### PR TITLE
(BugId 34370) Do not attach UserLoginModel to 'view source' anymore. Thi...

### DIFF
--- a/extensions/wikia/UserLogin/js/UserLoginModal.js
+++ b/extensions/wikia/UserLogin/js/UserLoginModal.js
@@ -82,7 +82,7 @@ var UserLoginModal = {
 	},
 	init: function() {
 		// attach event handler
-		var editpromptable = $("#ca-viewsource, #te-editanon, .loginToEditProtectedPage, .upphotoslogin");
+		var editpromptable = $("#te-editanon, .loginToEditProtectedPage, .upphotoslogin");
 
 		// add .editsection on wikis with anon editing disabled
 		if ( window.wgDisableAnonymousEditing ) {


### PR DESCRIPTION
...s requirement comes from product team and is described in the ticket: "The option to 'view source' should work for all people of all accounts of all permissions. The edit window should open(...)"
