### PR TITLE
Make receiving client translate blocked PM message

### DIFF
--- a/extensions/wikia/Chat2/js/controllers/controllers.js
+++ b/extensions/wikia/Chat2/js/controllers/controllers.js
@@ -709,7 +709,7 @@ var NodeChatController = $.createClass(NodeRoomController,{
 					'hidden':  true
 				});
 
-				var newChatEntry = new models.InlineAlert({text: $.msg( 'chat-user-blocked', wgUserName, this.sanitizeHtml(userClear.get('name')) ) });
+				var newChatEntry = new models.InlineAlert({wfMsg: 'chat-user-blocked', msgParams: [wgUserName, this.sanitizeHtml(userClear.get('name')) ] });
 				this.chats.privates[ user.get('roomId') ].socket.send(newChatEntry.xport());
 
 				if(this.chats.privates[ user.get('roomId') ].active) {

--- a/extensions/wikia/Chat2/js/controllers/controllers.js
+++ b/extensions/wikia/Chat2/js/controllers/controllers.js
@@ -737,7 +737,7 @@ var NodeChatController = $.createClass(NodeRoomController,{
 					'hidden':  false
 				});
 
-				var newChatEntry = new models.InlineAlert({text: $.msg('chat-user-allow', wgUserName, this.sanitizeHtml(privateUser.get('name')) ) });
+				var newChatEntry = new models.InlineAlert({wfMsg: 'chat-user-allow', [wgUserName, this.sanitizeHtml(privateUser.get('name')) ] });
 				this.chats.privates[ user.get('roomId') ].socket.send(newChatEntry.xport());
 			}
 		}, this));

--- a/extensions/wikia/Chat2/js/controllers/controllers.js
+++ b/extensions/wikia/Chat2/js/controllers/controllers.js
@@ -737,7 +737,7 @@ var NodeChatController = $.createClass(NodeRoomController,{
 					'hidden':  false
 				});
 
-				var newChatEntry = new models.InlineAlert({wfMsg: 'chat-user-allow', [wgUserName, this.sanitizeHtml(privateUser.get('name')) ] });
+				var newChatEntry = new models.InlineAlert({wfMsg: 'chat-user-allow', msgParams: [wgUserName, this.sanitizeHtml(privateUser.get('name')) ] });
 				this.chats.privates[ user.get('roomId') ].socket.send(newChatEntry.xport());
 			}
 		}, this));


### PR DESCRIPTION
Currently when someone blocks someone else's PMs, the blocker's client translates the message and sends it to the blockee - so if a dutch user blocks a spanish user's PMs, the message will be in dutch for both of them. Fixed by sending the inline alert with `wfMsg`.
