### PR TITLE
New cachebusting methodology

### DIFF
--- a/includes/wikia/wgCacheBuster.php
+++ b/includes/wikia/wgCacheBuster.php
@@ -4,4 +4,9 @@
  * various code-paths, some of which don't load the rest of the MediaWiki stack.
  */
 
-$wgCacheBuster = '61838';
+global $wgMedusaSlot;
+
+$slot_name = 'code' . ($wgMedusaSlot == 1 ? '' : $wgMedusaSlot);
+$cbFilePath = "/usr/wikia/deploy/$slot_name/src/wgCacheBuster.php";
+
+require_once($cbFilePath);


### PR DESCRIPTION
This is a new way to handle cache busting.  The Deploy Tools handle creating a file external to the release directory and so this file now includes it rather than defining the cachebuster itself.
