### PR TITLE
Added cachebuster module with support to both AMD and globally bound methods

### DIFF
--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -212,6 +212,7 @@ $config['oasis_wikia_js'] = array(
 		'//resources/wikia/modules/log.js',
 		'//resources/wikia/modules/thumbnailer.js',
 		'//resources/wikia/modules/geo.js',
+		'//resources/wikia/modules/cachebuster.js',
 	)
 );
 

--- a/extensions/wikia/UserLogin/js/UserLoginAjaxForm.js
+++ b/extensions/wikia/UserLogin/js/UserLoginAjaxForm.js
@@ -69,7 +69,7 @@ UserLoginAjaxForm.prototype.submitLoginHandler = function(json) {
 			callback(json);
 		} else {
 			// reload page if no callback specified
-			this.reloadPage();
+			window.Wikia.CacheBuster.reloadPageWithCacheBuster();
 		}
 	} else if(result === 'resetpass') {
 		callback = this.options['resetpasscallback'] || '';
@@ -111,17 +111,6 @@ UserLoginAjaxForm.prototype.retrieveTemplateHandler = function(html) {
 		form.replaceWith(content);
 		content.slideDown(400);
 	});
-};
-
-/* TODO: Generalize this - hyun */
-/* It seems like we stuff all utility functions into jQuery namespace.  I'd rather wait until we come to a decision on placement of global utility functions than to further pollute jQuery - hyun */
-UserLoginAjaxForm.prototype.reloadPage = function() {
-	var location = window.location.href;
-	var delim = "?";
-	if(location.indexOf("?") > 0){
-		delim = "&";
-	}
-	window.location.href = location.split("#")[0] + delim + "cb=" + Math.floor(Math.random()*10000);
 };
 
 UserLoginAjaxForm.prototype.errorValidation = function(json) {

--- a/extensions/wikia/UserLogin/js/UserLoginModal.js
+++ b/extensions/wikia/UserLogin/js/UserLoginModal.js
@@ -28,7 +28,7 @@ var UserLoginModal = {
 							}
 							callback();
 						} else {
-							UserLoginModal.loginAjaxForm.reloadPage();
+							window.Wikia.CacheBuster.reloadPageWithCacheBuster();
 						}
 					},
 					resetpasscallback: function(res) {

--- a/extensions/wikia/Wall/js/Wall.js
+++ b/extensions/wikia/Wall/js/Wall.js
@@ -529,7 +529,7 @@ var Wall = $.createClass(Object, {
 				callback: this.proxy(function(json) {
 					if(json.status) {
 						if(UserLoginAjaxForm) {
-							UserLoginAjaxForm.prototype.reloadPage();	
+							window.Wikia.CacheBuster.reloadPageWithCacheBuster();
 						} else {
 							window.location.reload();
 						}

--- a/extensions/wikia/Wall/js/WallMessageForm.js
+++ b/extensions/wikia/Wall/js/WallMessageForm.js
@@ -77,7 +77,7 @@ Wall.MessageForm = $.createClass(Observable, {
 	},
 
 	reloadAfterLogin: function() {
-		UserLoginAjaxForm.prototype.reloadPage();
+		window.Wikia.CacheBuster.reloadPageWithCacheBuster();
 	},
 
 	getFormat: function() {

--- a/resources/wikia/modules/cachebuster.js
+++ b/resources/wikia/modules/cachebuster.js
@@ -1,0 +1,45 @@
+/**
+ * Global Wikia Utilities.
+ * Keep it short and reusable.
+ */
+(function(window) {
+	'use strict';
+	
+	function cachebuster() {
+		var cb = {};
+	
+		cb.setUrl = function(url) {
+			window.location.href = url;
+		};
+		
+		cb.getUrl = function() {
+			return window.location.href;
+		};
+		
+		cb.getRandomCb = function() {
+			return Math.floor(Math.random()*10000);
+		};
+
+		/**
+		 * Reloads current page with random cachebuster value
+		 */
+		cb.reloadPageWithCacheBuster = function() {
+			var location = cb.getUrl();
+			var delim = "?";
+			if(location.indexOf("?") > 0){
+				delim = "&";
+			}
+			cb.setUrl(location.split("#")[0] + delim + "cb=" + cb.getRandomCb());
+		};
+		
+		return cb;
+	}
+	
+	if (window.define && window.define.amd) {
+		window.define('cachebuster', cachebuster);
+	} else {
+		window.Wikia = window.Wikia || {};
+		window.Wikia.CacheBuster = cachebuster();
+	}
+	
+})(window);

--- a/resources/wikia/modules/tests/CacheBusterAMDTest.js
+++ b/resources/wikia/modules/tests/CacheBusterAMDTest.js
@@ -1,0 +1,50 @@
+/**
+ * @test-framework Jasmine
+ * @test-require-asset resources/wikia/libraries/modil/modil.js
+ * @test-require-asset resources/wikia/modules/cachebuster.js
+ */
+
+describe("CacheBuster module", function() {
+	var async = new AsyncSpec(this);
+
+	async.it("loads as expected", function(done) {
+		require(['cachebuster'], function(cb){
+			expect(cb).toBeDefined();
+			expect(typeof cb.reloadPageWithCacheBuster === 'function').toBe(true);
+			done();
+		});
+	});
+
+	async.it("reloads", function(done) {
+		require(['cachebuster'], function(cb) {
+			var url = 'http://www.wikia.com/Wikia';
+			
+			spyOn(cb, 'getUrl').andReturn(url);
+			spyOn(cb, 'getRandomCb').andReturn(1234);
+			spyOn(cb, 'setUrl');
+		
+			cb.reloadPageWithCacheBuster();
+			
+			expect(cb.setUrl).toHaveBeenCalledWith(url + '?cb=1234');
+			
+			done();
+		});
+	});
+	
+	async.it("reloads when having existing params", function(done) {
+		require(['cachebuster'], function(cb) {
+			var url = 'http://www.wikia.com/Wikia?awesomesauce=true';
+			
+			spyOn(cb, 'getUrl').andReturn(url);
+			spyOn(cb, 'getRandomCb').andReturn(1234);
+			spyOn(cb, 'setUrl');
+		
+			cb.reloadPageWithCacheBuster();
+			
+			expect(cb.setUrl).toHaveBeenCalledWith(url + '&cb=1234');
+			
+			done();
+		});
+	});
+
+});

--- a/resources/wikia/modules/tests/CacheBusterTest.js
+++ b/resources/wikia/modules/tests/CacheBusterTest.js
@@ -1,0 +1,39 @@
+/**
+ * @test-framework Jasmine
+ * @test-require-asset resources/wikia/modules/cachebuster.js
+ */
+
+describe("CacheBuster module", function() {
+	it("loads as expected", function() {
+		expect(Wikia).toBeDefined();
+		expect(Wikia.CacheBuster).toBeDefined();
+		expect(typeof Wikia.CacheBuster.reloadPageWithCacheBuster === 'function').toBe(true);
+	});
+	
+	it("reloads", function() {
+		var cb = Wikia.CacheBuster,
+			url = 'http://www.wikia.com/Wikia';
+		
+		spyOn(cb, 'getUrl').andReturn(url);
+		spyOn(cb, 'getRandomCb').andReturn(1234);
+		spyOn(cb, 'setUrl');
+	
+		cb.reloadPageWithCacheBuster();
+		
+		expect(cb.setUrl).toHaveBeenCalledWith(url + '?cb=1234');
+	});
+	
+	it("reloads with additional existing params", function() {
+		var cb = Wikia.CacheBuster,
+			url = 'http://www.wikia.com/Wikia?deliciouspie=true';
+		
+		spyOn(cb, 'getUrl').andReturn(url);
+		spyOn(cb, 'getRandomCb').andReturn(1234);
+		spyOn(cb, 'setUrl');
+	
+		cb.reloadPageWithCacheBuster();
+		
+		expect(cb.setUrl).toHaveBeenCalledWith(url + '&cb=1234');
+	});
+	
+});

--- a/skins/oasis/js/SharingToolbar.js
+++ b/skins/oasis/js/SharingToolbar.js
@@ -61,7 +61,7 @@ var SharingToolbar = {
 	},
 	showEmailModal: function(lightboxShareEmailLabel, lightboxSend, lightboxShareEmailLabelAddress, lightboxCancel) {
 		var refreshPage = function() {
-			UserLoginAjaxForm.prototype.reloadPage();
+			window.Wikia.CacheBuster.reloadPageWithCacheBuster();
 		};
 
 		$.showCustomModal(


### PR DESCRIPTION
Continuing from this pull request -> https://github.com/Wikia/app/pull/17

cachebuster.js is defined in /resources/wikia/modules as requested.  It should theoretically work with AMD, although I could not do more than unit test it.
