### PR TITLE
Fix Achievements to work correctly with split databases

### DIFF
--- a/extensions/wikia/AchievementsII/AchBadge.class.php
+++ b/extensions/wikia/AchievementsII/AchBadge.class.php
@@ -138,9 +138,11 @@ class AchBadge {
                 'badge_type_id' => $this->mBadgeTypeId,
                 'badge_lap' => $this->mBadgeLap
             );
+			$options = array();
             if(empty($wgEnableAchievementsStoreLocalData)) {
                 $dbr = wfGetDB(DB_SLAVE, array(), $wgExternalSharedDB);
                 $where[ 'wiki_id' ] = $wgCityId;
+				$options[ 'USE INDEX' ] = 'user_wiki_badge';
             } else {
                 $dbr = wfGetDB(DB_SLAVE);
             }
@@ -149,9 +151,7 @@ class AchBadge {
 				'count(distinct(user_id))',
                 $where,
 				__METHOD__,
-				array(
-					'USE INDEX' => 'user_wiki_badge'
-				)
+				$options
 			);
 			$wgMemc->set($memkey, $value, 60*30);
 		}

--- a/extensions/wikia/AchievementsII/services/AchNotificationService.class.php
+++ b/extensions/wikia/AchievementsII/services/AchNotificationService.class.php
@@ -71,7 +71,7 @@ class AchNotificationService {
 
 			$badge = $badges[$maxLevel][0];
 			if($markAsNotified && !wfReadOnly()){
-				$dbw->update('ach_user_badges', array('notified' => 1), array('wiki_id' => $wgCityId, 'user_id' => $userId, 'notified' => 0));
+				$dbw->update('ach_user_badges', array('notified' => 1), $where);
 			}
 		}
 


### PR DESCRIPTION
Need to update SQL queries to correctly work with new DB schema after splitting Achievements from one big database to per-wiki databases.
(Two such cases were missed)
