### PR TITLE
(BugID: 51784) Improving Phalanx IP check performance

### DIFF
--- a/extensions/wikia/Phalanx/PhalanxHelper.class.php
+++ b/extensions/wikia/Phalanx/PhalanxHelper.class.php
@@ -27,6 +27,10 @@ class PhalanxHelper {
 		$result = false;
 		wfProfileIn( __METHOD__ );
 
+		if ( ( $data['type'] & Phalanx::TYPE_USER ) && User::isIP( $data['text'] ) ) {
+			$data['ip_hex'] = IP::toHex( $data['text'] );
+		}
+
 		//get data before update - we need it for cache update
 		$oldData = Phalanx::getFromId($data['id']);
 
@@ -62,6 +66,10 @@ class PhalanxHelper {
 		global $wgExternalSharedDB, $wgMemc;
 		$result = false;
 		wfProfileIn( __METHOD__ );
+
+		if ( ( $data['type'] & Phalanx::TYPE_USER ) && User::isIP( $data['text'] ) ) {
+			$data['ip_hex'] = IP::toHex( $data['text'] );
+		}
 
 		$dbw = wfGetDB( DB_MASTER, array(), $wgExternalSharedDB );
 		$dbw->insert(

--- a/extensions/wikia/Phalanx/Phalanx_setup.php
+++ b/extensions/wikia/Phalanx/Phalanx_setup.php
@@ -9,6 +9,7 @@ $wgExtensionCredits['other'][] = array(
 		'[http://community.wikia.com/wiki/User:Macbre Maciej Brencz]',
 		'[http://community.wikia.com/wiki/User:TOR Lucas \'TOR\' Garczewski]',
 		'Bartek Łapiński',
+		'[http://community.wikia.com/wiki/User:Grunny Daniel Grunwell (Grunny)]',
 	)
 );
 

--- a/extensions/wikia/Phalanx/blocks/UserBlock.class.php
+++ b/extensions/wikia/Phalanx/blocks/UserBlock.class.php
@@ -40,13 +40,13 @@ class UserBlock {
 		$blocksData = Phalanx::getFromFilter( self::TYPE );
 		if ( !empty($blocksData) && !empty($text) ) {
 			if ( $user->isAnon() ) {
-				$ret =  self::blockCheckInternal( $user, $blocksData, $text, true, $isCurrentUser );
+				$ret =  self::blockCheckIP( $user, $text, $isCurrentUser );
 			} else {
-				$ret = self::blockCheckInternal( $user, $blocksData, $text, false, $isCurrentUser );
+				$ret = self::blockCheckInternal( $user, $blocksData, $text, $isCurrentUser );
 				//do not check IP for current user when checking block status of different user
 				if ( $ret && $isCurrentUser ) {
 					// if the user name was not blocked, check for an IP block
-					$ret = self::blockCheckInternal( $user, $blocksData, $wgRequest->getIP(), true, $isCurrentUser );
+					$ret = self::blockCheckIP( $user, $wgRequest->getIP(), $isCurrentUser );
 				}
 			}
 		}
@@ -65,20 +65,16 @@ class UserBlock {
 		return $ret;
 	}
 
-	protected static function blockCheckInternal( User $user, $blocksData, $text, $isBlockIP = false, $writeStats = true ) {
+	protected static function blockCheckInternal( User $user, $blocksData, $text, $writeStats = true ) {
 		global $wgMemc;
 		wfProfileIn( __METHOD__ );
 
 		foreach ($blocksData as $blockData) {
-			if ( $isBlockIP && !$user->isIP($blockData['text'])) {
-				continue;
-			}
-
 			$result = Phalanx::isBlocked( $text, $blockData, $writeStats );
 
 			if ( $result['blocked'] ) {
 				Wikia::log(__METHOD__, __LINE__, "Block '{$result['msg']}' blocked '$text'.");
-				self::setUserData( $user, $blockData, $text, $isBlockIP );
+				self::setUserData( $user, $blockData, $text, false );
 
 				$cachedState = array(
 					'timestamp' => wfTimestampNow(),
@@ -90,6 +86,66 @@ class UserBlock {
 				wfProfileOut( __METHOD__ );
 				return false;
 			}
+		}
+
+		wfProfileOut( __METHOD__ );
+		return true;
+	}
+
+	/**
+	 * Directly check for IP block which is quicker than looping through all filters as we don't support
+	 * anything other than exact for IP blocks, and this significantly improves performance
+	 *
+	 * @author grunny
+	 */
+	protected static function blockCheckIP( User $user, $text, $writeStats = true ) {
+		global $wgMemc, $wgExternalSharedDB;
+		wfProfileIn( __METHOD__ );
+		$dbr = wfGetDB( DB_SLAVE, array(), $wgExternalSharedDB );
+		$moduleId = Phalanx::TYPE_USER;
+		$timestampNow = wfTimestampNow();
+		$ipAddr = IP::toHex( $text );
+		$row = $dbr->selectRow(
+			'phalanx',
+			'*',
+			array(
+				"p_type & $moduleId = $moduleId",
+				"p_lang IS NULL",
+				'p_ip_hex' => $ipAddr,
+				"p_expire IS NULL OR p_expire > {$dbr->addQuotes( $timestampNow )}"
+			),
+			__METHOD__
+		);
+		if ( $row !== false ) {
+			$blockData = array(
+				'id' => $row->p_id,
+				'author_id' => $row->p_author_id,
+				'text' => $row->p_text,
+				'type' => $row->p_type,
+				'timestamp' => $row->p_timestamp,
+				'expire' => $row->p_expire,
+				'exact' => $row->p_exact,
+				'regex' => $row->p_regex,
+				'case' => $row->p_case,
+				'reason' => $row->p_reason,
+				'lang' => $row->p_lang
+			);
+			Wikia::log(__METHOD__, __LINE__, "Block '{$blockData['text']}' blocked '$text'.");
+			if ( $writeStats ) {
+				Phalanx::addStats($blockData['id'], $blockData['type']);
+			}
+
+			self::setUserData( $user, $blockData, $text, true );
+
+			$cachedState = array(
+				'timestamp' => wfTimestampNow(),
+				'block' => $blockData,
+				'return' => false,
+			);
+			$wgMemc->set( self::getCacheKey( $user ), $cachedState );
+
+			wfProfileOut( __METHOD__ );
+			return false;
 		}
 
 		wfProfileOut( __METHOD__ );

--- a/extensions/wikia/Phalanx/blocks/UserCookieBlock.class.php
+++ b/extensions/wikia/Phalanx/blocks/UserCookieBlock.class.php
@@ -54,7 +54,7 @@ class UserCookieBlock extends UserBlock {
 
 		if ( !empty( $blocksData ) && !empty( $hashes ) ) {
 			foreach ( $hashes as $hash ) {
-				$ret = self::blockCheckInternal( $user, $blocksData, $hash, false, $isCurrentUser );
+				$ret = self::blockCheckInternal( $user, $blocksData, $hash, $isCurrentUser );
 				if ( !$ret ) {
 					// only check until we get first blocking match
 					break;

--- a/extensions/wikia/Phalanx/maintenance/populatePhalanxIPColumn.php
+++ b/extensions/wikia/Phalanx/maintenance/populatePhalanxIPColumn.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * One-off script to populate the new IP column in the Phalanx table
+ *
+ * @author grunny
+ */
+require(  __DIR__ . '/../../../../maintenance/commandLine.inc'  );
+
+$dbr = wfGetDB( DB_SLAVE, array(), $wgExternalSharedDB );
+
+$dbResult = $dbr->select(
+	array( 'phalanx' ),
+	array( '*' ),
+	array(
+		'p_type & 8 = 8',
+		'p_lang IS NULL'
+	),
+	__METHOD__
+);
+
+$toUpdate = array();
+
+while ( $row = $dbr->fetchObject( $dbResult ) ) {
+	if ( User::isIP( $row->p_text ) ) {
+		$toUpdate[$row->p_id] = IP::toHex( $row->p_text );
+	}
+}
+$dbr->freeResult( $dbResult );
+$dbr->close();
+
+$dbw = wfGetDB( DB_MASTER, array(), $wgExternalSharedDB );
+
+$failedFilters = array();
+
+foreach ( $toUpdate as $phalId => $ipHex ) {
+	$res = (boolean)$dbw->update(
+		'phalanx',
+		array(
+			'p_ip_hex' => $ipHex
+		),
+		array(
+			'p_id' => $phalId
+		)
+	);
+	if ( !$res ) {
+		$failedFilters[] = $phalId;
+	}
+}
+$dbw->close();
+
+echo "Done\n";
+echo count( $failedFilters ) . " failed to be updated!\n";
+
+exit( 0 );

--- a/extensions/wikia/Phalanx/schema.sql
+++ b/extensions/wikia/Phalanx/schema.sql
@@ -6,7 +6,7 @@ CREATE TABLE IF NOT EXISTS `phalanx` (
 -- block content (plain text or regex)
   `p_text` blob NOT NULL,
 -- Hexadecimal representation of IP blocks
-  `p_ip_hex` VARCHAR(255) default NULL,
+  `p_ip_hex` VARCHAR(35) default NULL,
 -- block type (mask of 16 bits determining which module will use that block)
   `p_type` smallint(1) unsigned NOT NULL,
 -- date of creation or last edit of this block

--- a/extensions/wikia/Phalanx/schema.sql
+++ b/extensions/wikia/Phalanx/schema.sql
@@ -5,6 +5,8 @@ CREATE TABLE IF NOT EXISTS `phalanx` (
   `p_author_id` int(6) NOT NULL,
 -- block content (plain text or regex)
   `p_text` blob NOT NULL,
+-- Hexadecimal representation of IP blocks
+  `p_ip_hex` VARCHAR(255) default NULL,
 -- block type (mask of 16 bits determining which module will use that block)
   `p_type` smallint(1) unsigned NOT NULL,
 -- date of creation or last edit of this block
@@ -21,7 +23,8 @@ CREATE TABLE IF NOT EXISTS `phalanx` (
   `p_reason` tinyblob NOT NULL,
 -- language to which the block applies - just for Answers for legacy reasons
   `p_lang` varchar(10),
-  PRIMARY KEY (`p_id`)
+  PRIMARY KEY (`p_id`),
+  KEY (`p_ip_hex`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `phalanx_stats` (


### PR DESCRIPTION
This significantly improves the execution time of the UserBlock::blockCheck method (the slowest by far for Phalanx) for IP addresses (by about 84% for logged-out users and 42% for logged in users from data collected during testing on devboxes), and replaces ~3,000 calls per blockCheck on an IP to Phalanx::isBlocked with one call to blockCheckIP.

Will require running a script to update the Phalanx table to populate the new column, which I have ready as well.
