### PR TITLE
Lazy load data fix

### DIFF
--- a/extensions/wikia/ImageLazyLoad/ImageLazyLoad.class.php
+++ b/extensions/wikia/ImageLazyLoad/ImageLazyLoad.class.php
@@ -26,8 +26,9 @@ class ImageLazyLoad extends WikiaObject {
 
 		if ( self::$enabled && empty( $wgRTEParserEnabled ) ) {
 
+			$isData = strrpos( $attribs[ 'src' ], "data:" );
 			// Don't lazy-load data elements
-			if ( startsWith( $attribs[ 'src' ], 'data:' ) ) {
+			if ( $isData !== false  ) {
 				return true;
 			}
 
@@ -74,9 +75,10 @@ class ImageLazyLoad extends WikiaObject {
 		global $wgRTEParserEnabled;
 
 		if ( self::$enabled && empty( $wgRTEParserEnabled ) ) {
-
+			
+			$isData = strrpos( $image[ 'thumbnail' ], "data:" );
 			// Don't lazy-load data elements
-			if ( startsWith( $image[ 'thumbnail' ], 'data:' ) ) {
+			if ( $isData !== false ) {
 				return true;
 			}
 

--- a/extensions/wikia/ImageLazyLoad/ImageLazyLoad.class.php
+++ b/extensions/wikia/ImageLazyLoad/ImageLazyLoad.class.php
@@ -28,7 +28,7 @@ class ImageLazyLoad extends WikiaObject {
 
 			$isData = strrpos( $attribs[ 'src' ], "data:" );
 			// Don't lazy-load data elements
-			if ( $isData !== false  ) {
+			if ( $isData !== false && $isData < 2 ) {
 				return true;
 			}
 
@@ -78,7 +78,7 @@ class ImageLazyLoad extends WikiaObject {
 			
 			$isData = strrpos( $image[ 'thumbnail' ], "data:" );
 			// Don't lazy-load data elements
-			if ( $isData !== false ) {
+			if ( $isData !== false && $isData < 2 ) {
 				return true;
 			}
 


### PR DESCRIPTION
Currently, images whose src attribute starts with "data:" are still lazy loaded despite the extension saying they should not. I'd like to change the checking method to use the native PHP function <a href="http://www.php.net/manual/en/function.strrpos.php">strrpos()</a>; if its output is non-boolean false or an int smaller than 2, it should prevent lazyloading.

Example of data images lazy loading: <a href="http://swfanon.wikia.com/wiki/Main_Page">this page</a>. Apologies if the issue is already being looked into or this is intended functionality.
