### PR TITLE
Fix cb devbox maintenance

### DIFF
--- a/includes/OutputPage.php
+++ b/includes/OutputPage.php
@@ -3634,8 +3634,6 @@ $templates
 
 	/**
 	 * @author Wikia
-	 *
-	 * @param ParserOutput $parserOutput
 	 */
 	private function addKeywords( &$parserOutput ) {
 		global $wgTitle, $wgSitename, $wgDBname;

--- a/includes/OutputPage.php
+++ b/includes/OutputPage.php
@@ -3634,6 +3634,8 @@ $templates
 
 	/**
 	 * @author Wikia
+	 *
+	 * @param ParserOutput $parserOutput
 	 */
 	private function addKeywords( &$parserOutput ) {
 		global $wgTitle, $wgSitename, $wgDBname;

--- a/includes/wikia/wgCacheBuster.php
+++ b/includes/wikia/wgCacheBuster.php
@@ -13,5 +13,5 @@ if ($wgDevelEnvironment) {
 	global $wgCacheBuster;
 	$wgCacheBuster = 12345;
 } else {
-	require_once($cbFilePath);
+	include_once($cbFilePath);
 }


### PR DESCRIPTION
Trying to run any maintenance script on devboxes ends with:

```
Fatal error: require_once(): Failed opening required
'/usr/wikia/deploy/code/src/wgCacheBuster.php'
(include_path='.:/usr/share/php:/usr/share/pear') in
/usr/wikia/source/app/includes/wikia/wgCacheBuster.php on line 16
```

This commit replaces `require_once` (that throws a fatal in file cannot be found) with `include_once` (it throws "just" a warning).

Feel free to suggest a better approach, that's the worst one that came to my mind ;)
