### PR TITLE
Bugid 52364: allow configurable search profiles

### DIFF
--- a/extensions/wikia/Search/WikiaSearch.setup.php
+++ b/extensions/wikia/Search/WikiaSearch.setup.php
@@ -17,21 +17,11 @@ Solarium_Autoloader::register();
 /**
  * constants we want for search profiles
  */
-if (! defined( 'SEARCH_PROFILE_DEFAULT' ) ) {
-		define( 'SEARCH_PROFILE_DEFAULT', 'default' );
-}
-if (! defined( 'SEARCH_PROFILE_IMAGES' ) ) {
-		define( 'SEARCH_PROFILE_IMAGES', 'images' );
-}
-if (! defined( 'SEARCH_PROFILE_USERS' ) ) {
-		define( 'SEARCH_PROFILE_USERS', 'users' );
-}
-if (! defined( 'SEARCH_PROFILE_ALL' ) ) {
-		define( 'SEARCH_PROFILE_ALL', 'all' );
-}
-if (! defined( 'SEARCH_PROFILE_ADVANCED' ) ) {
-		define( 'SEARCH_PROFILE_ADVANCED', 'advanced' );
-}
+define( 'SEARCH_PROFILE_DEFAULT',  'default' );
+define( 'SEARCH_PROFILE_IMAGES',   'images' );
+define( 'SEARCH_PROFILE_USERS',    'users' );
+define( 'SEARCH_PROFILE_ALL',      'all' );
+define( 'SEARCH_PROFILE_ADVANCED', 'advanced' );
 
 /**
  * classes

--- a/extensions/wikia/Search/WikiaSearch.setup.php
+++ b/extensions/wikia/Search/WikiaSearch.setup.php
@@ -17,14 +17,20 @@ Solarium_Autoloader::register();
 /**
  * constants we want for search profiles
  */
-
-$profiles = array( 'default', 'images', 'users', 'all', 'advanced' );
-
-foreach ( $profiles as $profile ) {
-	$profileConst = 'SEARCH_PROFILE_' . strtoupper( $profile ); 
-	if (! defined( $profileConst ) ) {
-		define( $profileConst, $profile );
-	}
+if (! defined( 'SEARCH_PROFILE_DEFAULT' ) ) {
+		define( 'SEARCH_PROFILE_DEFAULT', 'default' );
+}
+if (! defined( 'SEARCH_PROFILE_IMAGES' ) ) {
+		define( 'SEARCH_PROFILE_IMAGES', 'images' );
+}
+if (! defined( 'SEARCH_PROFILE_USERS' ) ) {
+		define( 'SEARCH_PROFILE_USERS', 'users' );
+}
+if (! defined( 'SEARCH_PROFILE_ALL' ) ) {
+		define( 'SEARCH_PROFILE_ALL', 'all' );
+}
+if (! defined( 'SEARCH_PROFILE_ADVANCED' ) ) {
+		define( 'SEARCH_PROFILE_ADVANCED', 'advanced' );
 }
 
 /**

--- a/extensions/wikia/Search/WikiaSearch.setup.php
+++ b/extensions/wikia/Search/WikiaSearch.setup.php
@@ -15,6 +15,19 @@ require( 'Solarium/Autoloader.php' );
 Solarium_Autoloader::register();
 
 /**
+ * constants we want for search profiles
+ */
+
+$profiles = array( 'default', 'images', 'users', 'all', 'advanced' );
+
+foreach ( $profiles as $profile ) {
+	$profileConst = 'SEARCH_PROFILE_' . strtoupper( $profile ); 
+	if (! defined( $profileConst ) ) {
+		define( $profileConst, $profile );
+	}
+}
+
+/**
  * classes
  */
 $app->registerClass('WikiaSearch', 					$dir . 'WikiaSearch.class.php');

--- a/extensions/wikia/Search/WikiaSearchConfig.class.php
+++ b/extensions/wikia/Search/WikiaSearchConfig.class.php
@@ -428,14 +428,14 @@ class WikiaSearchConfig extends WikiaObject implements ArrayAccess
 	public function getActiveTab() {
 		
 		if( $this->getAdvanced() ) {
-		    return 'advanced';
+		    return SEARCH_PROFILE_ADVANCED;
 		}
 		
 		$searchableNamespaces = array_keys( SearchEngine::searchableNamespaces() );
 		$nsVals = $this->getNamespaces();
 		
 		if ( empty( $nsVals ) ) {
-			return $this->wg->User->getOption('searchAllNamespaces') ? 'all' :  $this->wg->DefaultSearchProfile;
+			return $this->wg->User->getOption('searchAllNamespaces') ? SEARCH_PROFILE_ALL :  $this->wg->DefaultSearchProfile;
 		}
 		
 		foreach( $this->getSearchProfiles() as $name => $profile ) {
@@ -445,7 +445,7 @@ class WikiaSearchConfig extends WikiaObject implements ArrayAccess
 		    }
 		}
 		
-		return 'advanced';
+		return SEARCH_PROFILE_ADVANCED;
 	}
 	
 	/**

--- a/extensions/wikia/Search/WikiaSearchConfig.class.php
+++ b/extensions/wikia/Search/WikiaSearchConfig.class.php
@@ -380,38 +380,38 @@ class WikiaSearchConfig extends WikiaObject implements ArrayAccess
 	    // Builds list of Search Types (profiles)
 	    $searchEngine = F::build( 'SearchEngine' );
 	    $nsAllSet = array_keys( $searchEngine->searchableNamespaces() );
+	    $defaultNamespaces = $searchEngine->defaultNamespaces();
+
 	    $profiles = array(
-	            'default' => array(
+	            SEARCH_PROFILE_DEFAULT => array(
 	                    'message' => 'wikiasearch2-tabs-articles',
 	                    'tooltip' => 'searchprofile-articles-tooltip',
-	                    'namespaces' => SearchEngine::defaultNamespaces(),
-	                    'namespace-messages' => SearchEngine::namespacesAsText(
-	                            SearchEngine::defaultNamespaces()
-	                    ),
+	                    'namespaces' => $defaultNamespaces,
+	                    'namespace-messages' => $searchEngine->namespacesAsText( $defaultNamespaces ),
 	            ),
-	            'images' => array(
+	            SEARCH_PROFILE_IMAGES => array(
 	                    'message' => 'wikiasearch2-tabs-photos-and-videos',
 	                    'tooltip' => 'searchprofile-images-tooltip',
 	                    'namespaces' => array( NS_FILE ),
 	            ),
-	            'users' => array(
+	            SEARCH_PROFILE_USERS => array(
 	                    'message' => 'wikiasearch2-users',
 	                    'tooltip' => 'wikiasearch2-users-tooltip',
 	                    'namespaces' => array( NS_USER )
 	            ),
-	            'all' => array(
+	            SEARCH_PROFILE_ALL => array(
 	                    'message' => 'searchprofile-everything',
 	                    'tooltip' => 'searchprofile-everything-tooltip',
 	                    'namespaces' => $nsAllSet,
 	            ),
-	            'advanced' => array(
+	            SEARCH_PROFILE_ADVANCED => array(
 	                    'message' => 'searchprofile-advanced',
 	                    'tooltip' => 'searchprofile-advanced-tooltip',
 	                    'namespaces' => $this->getNamespaces(),
 	                    'parameters' => array( 'advanced' => 1 ),
 	            )
 	    );
-	
+	    
 	    wfRunHooks( 'SpecialSearchProfiles', array( &$profiles ) );
 	
 	    foreach( $profiles as $key => &$data ) {

--- a/extensions/wikia/Search/WikiaSearchConfig.class.php
+++ b/extensions/wikia/Search/WikiaSearchConfig.class.php
@@ -434,13 +434,14 @@ class WikiaSearchConfig extends WikiaObject implements ArrayAccess
 		$searchableNamespaces = array_keys( SearchEngine::searchableNamespaces() );
 		$nsVals = $this->getNamespaces();
 		
-		if(empty($nsVals)) {
-		    return $this->wg->User->getOption('searchAllNamespaces') ? 'all' :  'default';
+		if ( empty( $nsVals ) ) {
+			return $this->wg->User->getOption('searchAllNamespaces') ? 'all' :  $this->wg->DefaultSearchProfile;
 		}
 		
 		foreach( $this->getSearchProfiles() as $name => $profile ) {
-		    if ( !count( array_diff( $nsVals, $profile['namespaces'] ) ) && !count( array_diff($profile['namespaces'], $nsVals ) )) {
-		        return $name;
+		    if (   ( count( array_diff( $nsVals, $profile['namespaces'] ) ) == 0 ) 
+		    	&& ( count( array_diff($profile['namespaces'], $nsVals ) ) == 0 ) ) {
+	        	return $name;
 		    }
 		}
 		

--- a/extensions/wikia/Search/WikiaSearchController.class.php
+++ b/extensions/wikia/Search/WikiaSearchController.class.php
@@ -310,15 +310,20 @@ class WikiaSearchController extends WikiaSpecialPageController {
 		$searchEngine = F::build( 'SearchEngine' );
 		$searchableNamespaces = $searchEngine->searchableNamespaces();
 		$namespaces = array();
-		foreach($searchableNamespaces as $i => $name) {
-		    if ( $this->getVal('ns'.$i, false) ) {
+		foreach( $searchableNamespaces as $i => $name ) {
+		    if ( $this->getVal( 'ns'.$i, false ) ) {
 		        $namespaces[] = $i;
 		    }
 		}
-		if ( empty($namespaces) && $user->getOption('searchAllNamespaces')) {
-		    $namespaces = array_keys($searchableNamespaces);
+		if ( empty($namespaces) ) {
+		    if ( $user->getOption( 'searchAllNamespaces' ) ) {
+			    $namespaces = array_keys($searchableNamespaces);
+		    } else {
+		    	$profiles = $searchConfig->getSearchProfiles();
+		    	$namespaces = $profiles[$this->wg->DefaultSearchProfile]['namespaces'];
+		    }
+		    
 		}
-		
 		$searchConfig->setNamespaces( $namespaces );
 		
 		return true;


### PR DESCRIPTION
This change supports using the global variable $wgDefaultSearchProfile to set the filter view based on profile rather than namespace. So now we can support having an article search as the default search namespaces but a default video search view that uses the file namespace.

This also means we could make advanced search the default view for a wiki if we wanted to.
