### PR TITLE
Make LinkCache memcache keys not exceed protocol limits

### DIFF
--- a/includes/cache/LinkCache.php
+++ b/includes/cache/LinkCache.php
@@ -48,7 +48,7 @@ class LinkCache {
 		}
 		// start wikia change
 		elseif( $wgEnableFastLinkCache ) {
-			return (int) $wgMemc->get($this->getMemcKey($title, 'good'));
+			return (int) $wgMemc->get(self::getMemcKey($title, 'good'));
 		}
 		// end wikia change
 		else {
@@ -72,7 +72,7 @@ class LinkCache {
 		}
 		// start wikia change
 		elseif( $wgEnableFastLinkCache ) {
-			$fields = $wgMemc->get($this->getMemcKey($dbkey, 'fields'));
+			$fields = $wgMemc->get(self::getMemcKey($dbkey, 'fields'));
 			return isset($fields[$field]) ? $fields[$field] : null;
 		}
 		// end wikia change
@@ -109,8 +109,8 @@ class LinkCache {
 		// start wikia change
 		global $wgMemc, $wgEnableFastLinkCache;
 		if ( $wgEnableFastLinkCache ) {
-			$wgMemc->set($this->getMemcKey($dbkey, 'good'), intval( $id ), 3600);
-			$wgMemc->set($this->getMemcKey($dbkey, 'fields'), $this->mGoodLinkFields[$dbkey], 3600);
+			$wgMemc->set(self::getMemcKey($dbkey, 'good'), intval( $id ), 3600);
+			$wgMemc->set(self::getMemcKey($dbkey, 'fields'), $this->mGoodLinkFields[$dbkey], 3600);
 		}
 		// end wikia change
 	}
@@ -134,8 +134,8 @@ class LinkCache {
 		// start wikia change
 		global $wgMemc, $wgEnableFastLinkCache;
 		if ( $wgEnableFastLinkCache ) {
-			$wgMemc->set($this->getMemcKey($dbkey, 'good'), intval( $row->page_id ), 3600);
-			$wgMemc->set($this->getMemcKey($dbkey, 'fields'), $this->mGoodLinkFields[$dbkey], 3600);
+			$wgMemc->set(self::getMemcKey($dbkey, 'good'), intval( $row->page_id ), 3600);
+			$wgMemc->set(self::getMemcKey($dbkey, 'fields'), $this->mGoodLinkFields[$dbkey], 3600);
 		}
 		// end wikia change
 	}
@@ -166,8 +166,8 @@ class LinkCache {
 		// start wikia change
 		global $wgMemc, $wgEnableFastLinkCache;
 		if( $wgEnableFastLinkCache ) {
-			$wgMemc->delete($this->getMemcKey($dbkey, 'good'));
-			$wgMemc->delete($this->getMemcKey($dbkey, 'fields'));
+			$wgMemc->delete(self::getMemcKey($dbkey, 'good'));
+			$wgMemc->delete(self::getMemcKey($dbkey, 'fields'));
 		}
 		// end wikia change
 	}
@@ -264,7 +264,7 @@ class LinkCache {
 	 *
 	 * @aauthor macbre
 	 */
-	private function getMemcKey($dbkey, $type) {
+	static public function getMemcKey($dbkey, $type) {
 		// Mediawiki's title can be up to 255 characters long, memcache key can have a maximum of 250 characters
 		$hash = md5($dbkey);
 		return wfMemcKey("linkcache:{$type}:{$hash}");

--- a/includes/cache/LinkCache.php
+++ b/includes/cache/LinkCache.php
@@ -70,10 +70,12 @@ class LinkCache {
 		if ( array_key_exists( $dbkey, $this->mGoodLinkFields ) ) {
 			return $this->mGoodLinkFields[$dbkey][$field];
 		}
+		// start wikia change
 		elseif( $wgEnableFastLinkCache ) {
 			$fields = $wgMemc->get($this->getMemcKey($dbkey, 'fields'));
 			return isset($fields[$field]) ? $fields[$field] : null;
 		}
+		// end wikia change
 		else {
 			return null;
 		}
@@ -97,8 +99,6 @@ class LinkCache {
 	 * @param $revision Integer: latest revision's ID
 	 */
 	public function addGoodLinkObj( $id, $title, $len = -1, $redir = null, $revision = false ) {
-		global $wgMemc, $wgEnableFastLinkCache; // wikia change
-
 		$dbkey = $title->getPrefixedDbKey();
 		$this->mGoodLinks[$dbkey] = intval( $id );
 		$this->mGoodLinkFields[$dbkey] = array(
@@ -107,6 +107,7 @@ class LinkCache {
 			'revision' => intval( $revision ) );
 
 		// start wikia change
+		global $wgMemc, $wgEnableFastLinkCache;
 		if ( $wgEnableFastLinkCache ) {
 			$wgMemc->set($this->getMemcKey($dbkey, 'good'), intval( $id ), 3600);
 			$wgMemc->set($this->getMemcKey($dbkey, 'fields'), $this->mGoodLinkFields[$dbkey], 3600);
@@ -122,8 +123,6 @@ class LinkCache {
 	 *  page_latest
 	 */
 	public function addGoodLinkObjFromRow( $title, $row ) {
-		global $wgMemc, $wgEnableFastLinkCache; // wikia change
-
 		$dbkey = $title->getPrefixedDbKey();
 		$this->mGoodLinks[$dbkey] = intval( $row->page_id );
 		$this->mGoodLinkFields[$dbkey] = array(
@@ -131,7 +130,9 @@ class LinkCache {
 			'redirect' => intval( $row->page_is_redirect ),
 			'revision' => intval( $row->page_latest ),
 		);
+
 		// start wikia change
+		global $wgMemc, $wgEnableFastLinkCache;
 		if ( $wgEnableFastLinkCache ) {
 			$wgMemc->set($this->getMemcKey($dbkey, 'good'), intval( $row->page_id ), 3600);
 			$wgMemc->set($this->getMemcKey($dbkey, 'fields'), $this->mGoodLinkFields[$dbkey], 3600);

--- a/includes/parser/LinkHolderArray.php
+++ b/includes/parser/LinkHolderArray.php
@@ -283,8 +283,8 @@ class LinkHolderArray {
 						continue;
 					}
 					if ( $entry['pdbk'] !== '' ) {
-						$memcKeys[] = wfMemcKey("linkcache:good:{$entry['pdbk']}");
-						$memcKeys[] = wfMemcKey("linkcache:fields:{$entry['pdbk']}");
+						$memcKeys[] = LinkCache::getMemcKey($entry['pdbk'], 'good');
+						$memcKeys[] = LinkCache::getMemcKey($entry['pdbk'], 'fields');
 					}
 				}
 			}


### PR DESCRIPTION
LinkCache causes memcache parsing errors,  because of the way it creates keys:

``` php
return (int) $wgMemc->get(wfMemcKey("linkcache:good:$title"));
```

`Title` class "limits the size of titles to 255 bytes". 

From memcache's protocol.txt:

> Currently the length limit of a key is set at 250 characters (of course, normally clients wouldn't need to  use such long keys); the key must not include control characters or whitespace.

This pull request changes the way keys are built - DB key's md5 hash is used (instead of full DB key).
