### PR TITLE
bugid-64334: Lightbox - removing video player when closing modal

### DIFF
--- a/extensions/wikia/Lightbox/js/Lightbox.js
+++ b/extensions/wikia/Lightbox/js/Lightbox.js
@@ -203,6 +203,8 @@ var Lightbox = {
 			}
 
 			Lightbox.openModal.find('.carousel li').eq(Lightbox.current.index).trigger('click');
+		}).on('click.Lightbox', '.LightboxHeader .close', function() {
+				$('#LightboxModal .video-media').children().remove();
 		});
 	},
 	clearTrackingTimeouts: function() {


### PR DESCRIPTION
Right now after closing the Lightbox in IE8 the youtube player is still displayed, but it's not working and covers the whole screen with black color. I'm removing the elements from vide-media div before closing the lightbox and it seems to help.
