### PR TITLE
Refactor Solr2rss extension; fix fatals on production

### DIFF
--- a/extensions/wikia/Search/WikiaSearch.class.php
+++ b/extensions/wikia/Search/WikiaSearch.class.php
@@ -197,6 +197,52 @@ class WikiaSearch extends WikiaObject {
 	}
 	
 	/**
+	 * Searches using strict lucene query syntax -- no dismax here. 
+	 * What you set in the query value of the searchconfig is what we search for.
+	 * Please note the risk of not getting results 
+	 * @param  WikiaSearchConfig $searchConfig
+	 * @return WikiaSearchResultSet
+	 */
+	public function searchByLuceneQuery( WikiaSearchConfig $searchConfig ) {
+		$this->wf->ProfileIn( __METHOD__ );
+		
+		$query = $this->client->createSelect();
+		$query->setDocumentClass( 'WikiaSearchResult' );
+		
+		$sort = $searchConfig->getSort();
+		
+		$query	->addFields		( $searchConfig->getRequestedFields() )
+				->removeField	('*')
+			  	->setStart		( $searchConfig->getStart() )
+				->setRows		( $searchConfig->getLength() )
+				->addSort		( $sort[0], $sort[1] )
+				->addParam		( 'timeAllowed', 5000 )
+				->setQuery		( $searchConfig->getQuery( WikiaSearchConfig::QUERY_RAW ) )
+		;
+		
+		try {
+			
+			$result = $this->client->select( $query );
+			
+		} catch ( Exception $e ) {
+			F::build('Wikia')->log(__METHOD__, 'Querying Solr First Time', $e);
+			$searchConfig->setError( $e );
+			$result = F::build('Solarium_Result_Select_Empty');
+		}
+		
+		$results = F::build('WikiaSearchResultSet', array($result, $searchConfig) );
+		
+		$searchConfig->setResults		( $results )
+					 ->setResultsFound	( $results->getResultsFound() )
+		;		
+		
+		$this->wf->ProfileOut( __METHOD__ );
+		
+		return $results;
+	}
+	
+	
+	/**
 	 * Retrives interesting terms from a MoreLikeThis search
 	 * @param  WikiaSearchConfig $searchConfig
 	 * @return array of interesting terms

--- a/extensions/wikia/Search/WikiaSearch.class.php
+++ b/extensions/wikia/Search/WikiaSearch.class.php
@@ -165,10 +165,12 @@ class WikiaSearch extends WikiaObject {
 			
 		} catch ( Exception $e ) {
 			F::build('Wikia')->log(__METHOD__, 'Querying Solr First Time', $e);
-			$searchConfig->setSkipBoostFunctions( true );
+			$searchConfig	->setSkipBoostFunctions( true )
+							->setError( $e );
 			try {
 				$result = $this->client->select( $this->getSelectQuery( $searchConfig ) );
 			} catch ( Exception $e ) {
+				$searchConfig->setError( $e );
 				F::build('Wikia')->log(__METHOD__, 'Querying Solr With No Boost Functions', $e);
 				$result = F::build('Solarium_Result_Select_Empty');
 			}

--- a/extensions/wikia/Search/WikiaSearchConfig.class.php
+++ b/extensions/wikia/Search/WikiaSearchConfig.class.php
@@ -354,8 +354,8 @@ class WikiaSearchConfig extends WikiaObject implements ArrayAccess
 	public function getRequestedFields()
 	{
 		$fieldsPrepped = array();
-		foreach ($this['requestedFields'] as $field) {
-			$fieldsPrepped[] = WikiaSearch::field( $field, $this->getLang() );
+		foreach ( $this['requestedFields'] as $field ) {
+			$fieldsPrepped[] = WikiaSearch::field( $field );
 		}
 		
 		return $fieldsPrepped;
@@ -598,18 +598,6 @@ class WikiaSearchConfig extends WikiaObject implements ArrayAccess
 			$this->setFilterQueryByCode( $code );
 		}
 		return $this;
-	}
-	
-	/**
-	 * Allows us to set the language WikiaSearchConfig is operating under.
-	 * Defaults to wgContlang
-	 * @return string
-	 */
-	public function getLang() {
-		if (! isset( $this->params['lang'] ) ) {
-			$this->params['lang'] = $this->wg->ContLang->mCode;
-		}
-		return $this->params['lang'];
 	}
 
 }

--- a/extensions/wikia/Search/WikiaSearchConfig.class.php
+++ b/extensions/wikia/Search/WikiaSearchConfig.class.php
@@ -287,6 +287,11 @@ class WikiaSearchConfig extends WikiaObject implements ArrayAccess
 	 * @return array where index 0 is the field name and index 1 is the constant used for ASC or DESC in solarium
 	 */
 	public function getSort() {
+		// Allows you to override our default keyword-based ranking functionality. Don't abuse this.
+		// I have aggressively validated this value to protect your query.
+		if ( isset( $this->params['sort'] ) && is_array( $this->params['sort'] ) && count( $this->params['sort'] ) == 2 ) {
+			return $this->params['sort'];
+		}
 		$rank = $this->getRank();
 		return isset($this->rankOptions[$rank]) ? $this->rankOptions[$rank] : $this->rankOptions['default']; 
 	}

--- a/extensions/wikia/Search/WikiaSearchConfig.class.php
+++ b/extensions/wikia/Search/WikiaSearchConfig.class.php
@@ -355,7 +355,7 @@ class WikiaSearchConfig extends WikiaObject implements ArrayAccess
 	{
 		$fieldsPrepped = array();
 		foreach ($this['requestedFields'] as $field) {
-			$fieldsPrepped[] = WikiaSearch::field($field);
+			$fieldsPrepped[] = WikiaSearch::field( $field, $this->getLang() );
 		}
 		
 		return $fieldsPrepped;
@@ -598,6 +598,18 @@ class WikiaSearchConfig extends WikiaObject implements ArrayAccess
 			$this->setFilterQueryByCode( $code );
 		}
 		return $this;
+	}
+	
+	/**
+	 * Allows us to set the language WikiaSearchConfig is operating under.
+	 * Defaults to wgContlang
+	 * @return string
+	 */
+	public function getLang() {
+		if (! isset( $this->params['lang'] ) ) {
+			$this->params['lang'] = $this->wg->ContLang->mCode;
+		}
+		return $this->params['lang'];
 	}
 
 }

--- a/extensions/wikia/Search/WikiaSearchConfig.class.php
+++ b/extensions/wikia/Search/WikiaSearchConfig.class.php
@@ -358,6 +358,10 @@ class WikiaSearchConfig extends WikiaObject implements ArrayAccess
 			$fieldsPrepped[] = WikiaSearch::field( $field );
 		}
 		
+		if (! ( in_array( 'id', $fieldsPrepped ) || in_array( '*', $fieldsPrepped ) ) ) {
+			$fieldsPrepped[] = 'id';
+		} 
+		
 		return $fieldsPrepped;
 	}
 	

--- a/extensions/wikia/Search/WikiaSearchResultSet.class.php
+++ b/extensions/wikia/Search/WikiaSearchResultSet.class.php
@@ -542,11 +542,11 @@ class WikiaSearchResultSet extends WikiaObject implements Iterator,ArrayAccess {
 	 * 
 	 * @return array
 	 */
-	public function toNestedArray() {
+	public function toNestedArray( array $expectedFields = array( 'title', 'url' ) ) {
 		$tempResults = array();
-		foreach( $this as $result ){
-		    if($result instanceof WikiaSearchResult){
-		        $tempResults[] = $result->toArray(array('title', 'url'));
+		foreach( $this->results as $result ){
+		    if( $result instanceof WikiaSearchResult ){
+		        $tempResults[] = $result->toArray( $expectedFields );
 		    }
 		}
 		return $tempResults;

--- a/extensions/wikia/Search/tests/WikiaSearchConfigTest.php
+++ b/extensions/wikia/Search/tests/WikiaSearchConfigTest.php
@@ -396,6 +396,14 @@ class WikiaSearchConfigTest extends WikiaSearchBaseTest {
 				$config->getSort(),
 				'A well-formed rank key should return the appropriate sort array.'
 		);
+		
+		$config->setSort( array( 'created', 'asc' ) );
+		
+		$this->assertEquals(
+				array( 'created', 'asc' ),
+				$config->getSort(),
+				'WikiaSearchConfig::getSort should return a value set by setSort if it has been invoked'
+		);
 	}
 	
 	/**
@@ -792,6 +800,28 @@ class WikiaSearchConfigTest extends WikiaSearchBaseTest {
 		// needs resetting to get the testing environment back in shape
 		WikiaSearchConfig::$filterQueryIncrement = 0;
 	} 
+	
+	/**
+	 * @covers WikiaSearchConfig::getRequestedFields
+	 */
+	public function testGetRequestedFields() {
+		$config = F::build( 'WikiaSearchConfig' );
+		
+		$config->setRequestedFields( array( 'html' ) );
+		
+		$fields = $config->getRequestedFields();
+		
+		$this->assertContains(
+				WikiaSearch::field( 'html' ),
+				$fields,
+				'WikiaSearchConfig::getRequestedFields() should perform language field transformation'
+		);
+		$this->assertContains(
+				'id',
+				$fields,
+				'WikiaSearchConfig::getRequestedFields() should always include an id'
+		);
+	}
 	
 	
 }

--- a/extensions/wikia/Search/tests/WikiaSearchTest.php
+++ b/extensions/wikia/Search/tests/WikiaSearchTest.php
@@ -1838,6 +1838,328 @@ class WikiaSearchTest extends WikiaSearchBaseTest {
 				$mockSearch->doSearch( $mockConfig ),
 				'WikiaSearch::doSearch should always return an instance of WikiaSearchResultSet'
 		);
+	}
+	
+	/**
+	 * @covers WikiaSearch::searchByLuceneQuery
+	 */
+	public function testSearchByLuceneQueryWorks() {
+		$searchConfigMethods = array(
+				'getGroupResults', 'setLength', 'setIsInterWiki', 'getPage', 'setResults', 'getRequestedFields',
+				'setResultsFound', 'getQuery', 'getIsInterWiki', 'getLength', 'setStart', 'getSort', 'getStart'
+				);
+		$mockConfig		=	$this->getMock( 'WikiaSearchConfig', $searchConfigMethods );
+		$mockClient		=	$this->getMockBuilder( 'Solarium_Client' )
+								->disableOriginalConstructor()
+								->setMethods( array( 'select', 'setAdapter', 'createSelect' ) )
+								->getMock();
 		
+		$mockResultSet	=	$this->getMockBuilder( 'WikiaSearchResultSet' )
+								->disableOriginalConstructor()
+								->setMethods( array( 'getResultsFound' ) )
+								->getMock();
+		
+		$mockSolResult	=	$this->getMockBuilder( 'Solarium_Result' )
+								->disableOriginalConstructor()
+								->getMock();
+		
+		$queryMethods	=	array( 'setDocumentClass', 'addFields', 'removeField', 'setStart', 'setRows', 'addSort', 'addParam', 'setQuery' );
+		
+		$mockQuery		=	$this->getMockBuilder( 'Solarium_Query_Select' )
+								->disableOriginalConstructor()
+								->setMethods( $queryMethods )
+								->getMock();
+		
+		$mockWikia = $this->getMock( 'Wikia', array( 'log' ) );
+		
+		$mockClient
+			->expects	( $this->once() )
+			->method	( 'setAdapter' )
+			->with		( 'Solarium_Client_Adapter_Curl' )
+		;
+		$mockClient
+			->expects	( $this->once() )
+			->method	( 'createSelect' )
+			->will		( $this->returnValue( $mockQuery ) )
+		;
+		$mockQuery
+			->expects	( $this->once() )
+			->method	( 'setDocumentClass' )
+			->with		( 'WikiaSearchResult' )
+		;
+		$mockConfig
+			->expects	( $this->once() )
+			->method	( 'getSort' )
+			->will		( $this->returnValue( array( 'created', 'desc' ) ) )
+		;
+		$mockConfig
+			->expects	( $this->once() )
+			->method	( 'getRequestedFields' )
+			->will		( $this->returnValue( array( 'title_en', 'url', 'id' ) ) )
+		;
+		$mockQuery
+			->expects	( $this->once() )
+			->method	( 'addFields' )
+			->with		( array( 'title_en', 'url', 'id' ) )
+			->will		( $this->returnValue( $mockQuery ) )
+		;
+		$mockQuery
+			->expects	( $this->once() )
+			->method	( 'removeField' )
+			->with		( '*' )
+			->will		( $this->returnValue( $mockQuery ) )
+		;
+		$mockConfig
+			->expects	( $this->once() )
+			->method	( 'getStart' )
+			->will		( $this->returnValue( 0 ) )
+		;
+		$mockQuery
+			->expects	( $this->once() )
+			->method	( 'setStart' )
+			->with		( 0 )
+			->will		( $this->returnValue( $mockQuery ) )
+		;
+		$mockConfig
+			->expects	( $this->once() )
+			->method	( 'getLength' )
+			->will		( $this->returnValue( 20 ) )
+		;
+		$mockQuery
+			->expects	( $this->once() )
+			->method	( 'setRows' )
+			->with		( 20 )
+			->will		( $this->returnValue( $mockQuery ) )
+		;
+		$mockQuery
+			->expects	( $this->once() )
+			->method	( 'addSort' )
+			->with		( 'created', 'desc' )
+			->will		( $this->returnValue( $mockQuery ) )
+		;
+		$mockQuery
+			->expects	( $this->once() )
+			->method	( 'addParam' )
+			->with		( 'timeAllowed', 5000 )
+			->will		( $this->returnValue( $mockQuery ) )
+		;
+		$mockConfig
+			->expects	( $this->once() )
+			->method	( 'getQuery' )
+			->with		( WikiaSearchConfig::QUERY_RAW )
+			->will		( $this->returnValue( 'hub:Entertainment' ) )
+		;
+		$mockQuery
+			->expects	( $this->once() )
+			->method	( 'setQuery' )
+			->with		( 'hub:Entertainment' )
+		;
+		$mockClient
+			->expects	( $this->once() )
+			->method	( 'select' )
+			->will		( $this->returnValue( $mockSolResult ) )
+		;
+		$mockConfig
+			->expects	( $this->once() )
+			->method	( 'setResults' )
+			->with		( $mockResultSet )
+			->will		( $this->returnValue( $mockConfig ) )
+		;
+		$mockResultSet
+			->expects	( $this->once() )
+			->method	( 'getResultsFound' )
+			->will		( $this->returnValue( 200 ) )
+		;
+		$mockConfig
+			->expects	( $this->once() )
+			->method	( 'setResultsFound' )
+			->with		( 200 )
+		;
+		
+		$this->mockClass( 'WikiaSearchResultSet', $mockResultSet );
+		$this->mockClass( 'Wikia', $mockWikia );
+		$this->mockClass( 'Solarium_Client', $mockClient );
+		$this->mockApp();
+		
+		$search = $this->getMockBuilder( 'WikiaSearch' )
+						->setConstructorArgs( array( $mockClient ) )
+						->setMethods( array() )
+						->getMock();
+		$search = F::build( 'WikiaSearch', array( $mockClient ) );
+		
+		$reflectionProperty = new ReflectionProperty( 'WikiaSearch', 'client' );
+		$reflectionProperty->setAccessible( true );
+		$reflectionProperty->setValue( $search, $mockClient );
+		
+		$results = $search->searchByLuceneQuery( $mockConfig );
+		
+		$this->assertEquals(
+				$mockResultSet,
+				$results,
+				'WikiaSearchConfig::searchByLuceneQuery should return an instance of WikiaSearchResultSet, no matter what'
+		);
+	}
+	
+
+	/**
+	 * @covers WikiaSearch::searchByLuceneQuery
+	 */
+	public function testSearchByLuceneQueryBreaksGracefully() {
+		$searchConfigMethods = array(
+				'getGroupResults', 'setLength', 'setIsInterWiki', 'getPage', 'setResults', 'getRequestedFields',
+				'setResultsFound', 'getQuery', 'getIsInterWiki', 'getLength', 'setStart', 'getSort', 'getStart'
+				);
+		$mockConfig		=	$this->getMock( 'WikiaSearchConfig', $searchConfigMethods );
+		$mockClient		=	$this->getMockBuilder( 'Solarium_Client' )
+								->disableOriginalConstructor()
+								->setMethods( array( 'select', 'setAdapter', 'createSelect' ) )
+								->getMock();
+		
+		$mockResultSet	=	$this->getMockBuilder( 'WikiaSearchResultSet' )
+								->disableOriginalConstructor()
+								->setMethods( array( 'getResultsFound' ) )
+								->getMock();
+		
+		$mockSolResult	=	$this->getMockBuilder( 'Solarium_Result' )
+								->disableOriginalConstructor()
+								->getMock();
+		
+		$mockException	=	$this->getMock( 'Exception' );
+		
+		$queryMethods	=	array( 'setDocumentClass', 'addFields', 'removeField', 'setStart', 'setRows', 'addSort', 'addParam', 'setQuery' );
+		
+		$mockQuery		=	$this->getMockBuilder( 'Solarium_Query_Select' )
+								->disableOriginalConstructor()
+								->setMethods( $queryMethods )
+								->getMock();
+		
+		$mockWikia = $this->getMock( 'Wikia', array( 'log' ) );
+		
+		$mockClient
+			->expects	( $this->once() )
+			->method	( 'setAdapter' )
+			->with		( 'Solarium_Client_Adapter_Curl' )
+		;
+		$mockClient
+			->expects	( $this->once() )
+			->method	( 'createSelect' )
+			->will		( $this->returnValue( $mockQuery ) )
+		;
+		$mockQuery
+			->expects	( $this->once() )
+			->method	( 'setDocumentClass' )
+			->with		( 'WikiaSearchResult' )
+		;
+		$mockConfig
+			->expects	( $this->once() )
+			->method	( 'getSort' )
+			->will		( $this->returnValue( array( 'created', 'desc' ) ) )
+		;
+		$mockConfig
+			->expects	( $this->once() )
+			->method	( 'getRequestedFields' )
+			->will		( $this->returnValue( array( 'title_en', 'url', 'id' ) ) )
+		;
+		$mockQuery
+			->expects	( $this->once() )
+			->method	( 'addFields' )
+			->with		( array( 'title_en', 'url', 'id' ) )
+			->will		( $this->returnValue( $mockQuery ) )
+		;
+		$mockQuery
+			->expects	( $this->once() )
+			->method	( 'removeField' )
+			->with		( '*' )
+			->will		( $this->returnValue( $mockQuery ) )
+		;
+		$mockConfig
+			->expects	( $this->once() )
+			->method	( 'getStart' )
+			->will		( $this->returnValue( 0 ) )
+		;
+		$mockQuery
+			->expects	( $this->once() )
+			->method	( 'setStart' )
+			->with		( 0 )
+			->will		( $this->returnValue( $mockQuery ) )
+		;
+		$mockConfig
+			->expects	( $this->once() )
+			->method	( 'getLength' )
+			->will		( $this->returnValue( 20 ) )
+		;
+		$mockQuery
+			->expects	( $this->once() )
+			->method	( 'setRows' )
+			->with		( 20 )
+			->will		( $this->returnValue( $mockQuery ) )
+		;
+		$mockQuery
+			->expects	( $this->once() )
+			->method	( 'addSort' )
+			->with		( 'created', 'desc' )
+			->will		( $this->returnValue( $mockQuery ) )
+		;
+		$mockQuery
+			->expects	( $this->once() )
+			->method	( 'addParam' )
+			->with		( 'timeAllowed', 5000 )
+			->will		( $this->returnValue( $mockQuery ) )
+		;
+		$mockConfig
+			->expects	( $this->once() )
+			->method	( 'getQuery' )
+			->with		( WikiaSearchConfig::QUERY_RAW )
+			->will		( $this->returnValue( 'hub:Entertainment' ) )
+		;
+		$mockQuery
+			->expects	( $this->once() )
+			->method	( 'setQuery' )
+			->with		( 'hub:Entertainment' )
+		;
+		$mockClient
+			->expects	( $this->once() )
+			->method	( 'select' )
+			->will		( $this->throwException( $mockException ) )
+		;
+		$mockConfig
+			->expects	( $this->once() )
+			->method	( 'setResults' )
+			->with		( $mockResultSet )
+			->will		( $this->returnValue( $mockConfig ) )
+		;
+		$mockResultSet
+			->expects	( $this->once() )
+			->method	( 'getResultsFound' )
+			->will		( $this->returnValue( 200 ) )
+		;
+		$mockConfig
+			->expects	( $this->once() )
+			->method	( 'setResultsFound' )
+			->with		( 200 )
+		;
+		
+		$this->mockClass( 'WikiaSearchResultSet', $mockResultSet );
+		$this->mockClass( 'Wikia', $mockWikia );
+		$this->mockClass( 'Solarium_Client', $mockClient );
+		$this->mockApp();
+		
+		$search = $this->getMockBuilder( 'WikiaSearch' )
+						->setConstructorArgs( array( $mockClient ) )
+						->setMethods( array() )
+						->getMock();
+		$search = F::build( 'WikiaSearch', array( $mockClient ) );
+		
+		$reflectionProperty = new ReflectionProperty( 'WikiaSearch', 'client' );
+		$reflectionProperty->setAccessible( true );
+		$reflectionProperty->setValue( $search, $mockClient );
+		
+		$results = $search->searchByLuceneQuery( $mockConfig );
+		
+		$this->assertEquals(
+				$mockResultSet,
+				$results,
+				'WikiaSearchConfig::searchByLuceneQuery should return an instance of WikiaSearchResultSet, no matter what'
+		);
 	}
 }

--- a/extensions/wikia/solr2rss/templates/results.tmpl.php
+++ b/extensions/wikia/solr2rss/templates/results.tmpl.php
@@ -9,11 +9,11 @@
   <generator><?php echo htmlspecialchars($url); ?></generator>
   <?php foreach ($docs as $doc): ?>
    <item>
-    <title><?php echo htmlspecialchars($doc->title); ?></title>
-    <link><?php echo htmlspecialchars($doc->url); ?></link>
-    <description><?php echo htmlspecialchars($doc->html); ?></description>
-    <pubDate><?php echo date($dateFormat, strtotime($doc->created)); ?></pubDate>
-    <guid isPermaLink="true"><?php echo htmlspecialchars($doc->url); ?></guid>
+    <title><?php echo htmlspecialchars($doc[WikiaSearch::field( 'title', $lang )]); ?></title>
+    <link><?php echo htmlspecialchars($doc['url']); ?></link>
+    <description><?php echo htmlspecialchars($doc[WikiaSearch::field( 'html', $lang )]); ?></description>
+    <pubDate><?php echo date($dateFormat, strtotime($doc['created'])); ?></pubDate>
+    <guid isPermaLink="true"><?php echo htmlspecialchars($doc['url']); ?></guid>
    </item>
   <?php endforeach; ?>
  </channel>


### PR DESCRIPTION
This addresses an intermittent error on production. I'm worried we should maybe just turn this extension off, since this change would actually give a bit too much power to anonymous users. I think at its present capabilities, there is some chance for overloading the search servers.  Doing this in a pull request so we can have a good dialogue about the best course of action here. We could always introduce the search class updates, and just remove solr2rss. However, since it's an unlisted special page, we might still be able to get away with these updates now.
