### PR TITLE
bugid-50999 | added subtitles for all special pages in admin dashboard

### DIFF
--- a/extensions/wikia/AdminDashboard/AdminDashboardSpecialPageController.class.php
+++ b/extensions/wikia/AdminDashboard/AdminDashboardSpecialPageController.class.php
@@ -8,12 +8,6 @@
  */
 class AdminDashboardSpecialPageController extends WikiaSpecialPageController {
 
-	private $pagesWithSubtitle = array ( 
-            'Watchlist', 
-            'EditWatchlist', 
-            'EditWatchlist/raw' 
-        );
-
 	public function __construct() {
 		parent::__construct('AdminDashboard', '', false);
 	}
@@ -123,10 +117,8 @@ class AdminDashboardSpecialPageController extends WikiaSpecialPageController {
                 }
 		$headerText = SpecialPage::getLocalNameFor($page);
 		$this->headerText = $headerText;
-                if( in_array($page, $this->pagesWithSubtitle) ) {
-                    $this->tagline = $this->msg('tagline');
-                    $this->subtitle = $this->wg->Out->getSubtitle();
-                }
+		$this->tagline = $this->msg('tagline');
+		$this->subtitle = $this->wg->Out->getSubtitle();
 	}
 
 	/**


### PR DESCRIPTION
Small bugfix, but I'm not sure if all Special Pages work fine with AdminDashbord now. 
