### PR TITLE
fixing an error with SpecialInterwikiEdit

### DIFF
--- a/extensions/wikia/SpecialInterwikiEdit/SpecialInterwikiEdit.php
+++ b/extensions/wikia/SpecialInterwikiEdit/SpecialInterwikiEdit.php
@@ -33,7 +33,7 @@ class InterwikiEdit extends SpecialPage {
 		parent::__construct('InterwikiEdit');
 	}
 
-	function execute(){
+	function execute( $par ){
 		global $wgOut, $wgUser, $wgRequest;
 
 		if( !$wgUser->isAllowed( 'InterwikiEdit' ) ) {


### PR DESCRIPTION
I was seeing this error on firefly wiki:  ( ! ) Strict standards: Declaration of InterwikiEdit::execute() should be compatible with SpecialPage::execute($par) in /usr/wikia/source/app/extensions/wikia/SpecialInterwikiEdit/SpecialInterwikiEdit.php on line 30

This changeset suppresses the warning, but I'm issuing this pull request in case someone wants to dig deeper into this before merging it to dev. 
