### PR TITLE
Fixing Phalanx fatal error

### DIFF
--- a/extensions/wikia/Phalanx/PhalanxHelper.class.php
+++ b/extensions/wikia/Phalanx/PhalanxHelper.class.php
@@ -313,9 +313,9 @@ class PhalanxHelper {
 			$newDataShort = array(
 				$newData['id'],
 				$newData['text'],
-				  ($newData['exact'] ? self::FLAG_EXACT : 0)
-				+ ($newData['regex'] ? self::FLAG_REGEX : 0)
-				+ ($newData['case'] ? self::FLAG_CASE : 0)
+				  ($newData['exact'] ? Phalanx::FLAG_EXACT : 0)
+				+ ($newData['regex'] ? Phalanx::FLAG_REGEX : 0)
+				+ ($newData['case'] ? Phalanx::FLAG_CASE : 0)
 			);
 		}
 


### PR DESCRIPTION
Fixing PHP Fatal error:  Undefined class constant 'FLAG_EXACT'
