### PR TITLE
fixed HTML sanitization in slider BugzId:69169

### DIFF
--- a/extensions/wikia/WikiaPhotoGallery/WikiaPhotoGallery.class.php
+++ b/extensions/wikia/WikiaPhotoGallery/WikiaPhotoGallery.class.php
@@ -412,7 +412,7 @@ class WikiaPhotoGallery extends ImageGallery {
 				'link' => $link,
 				'linktext' => $linktext,
 				'shorttext' => $shorttext,
-				'data-caption' => htmlspecialchars( $caption ),
+				'data-caption' => Sanitizer::removeHTMLtags( $caption ),
 			);
 
 			// store list of images from inner content of tag (to be used by front-end)
@@ -1137,7 +1137,7 @@ class WikiaPhotoGallery extends ImageGallery {
 
 				// add link overlay
 				$linkOverlay = Xml::openElement('span', array('class' => 'wikia-slideshow-link-overlay'))
-					. wfMsg('wikiaPhotoGallery-slideshow-view-link-overlay', htmlspecialchars($linkText))
+					. wfMsg('wikiaPhotoGallery-slideshow-view-link-overlay', Sanitizer::removeHTMLtags( $linkText ))
 					. Xml::closeElement('span');
 			}
 
@@ -1380,10 +1380,10 @@ class WikiaPhotoGallery extends ImageGallery {
 
 				$data = array(
 					'imageUrl' => $imageUrl,
-					'imageTitle' => htmlspecialchars($text),
-					'imageShortTitle' => htmlspecialchars($shortText),
+					'imageTitle' => Sanitizer::removeHTMLtags($text),
+					'imageShortTitle' => Sanitizer::removeHTMLtags($shortText),
 					'imageLink' => !empty($link) ? $linkAttribs['href'] : '',
-					'imageDescription' => htmlspecialchars($linkText),
+					'imageDescription' => Sanitizer::removeHTMLtags($linkText),
 					'imageThumbnail' => $thumbUrl,
 				);
 

--- a/extensions/wikia/WikiaPhotoGallery/templates/sliderPreview.tmpl.php
+++ b/extensions/wikia/WikiaPhotoGallery/templates/sliderPreview.tmpl.php
@@ -43,22 +43,22 @@
 			}
 		// image caption
 			if ($image['caption'] != '') {
-				$caption = $image['caption'];
+				$caption = Sanitizer::removeHTMLtags( $image['caption'] );
 			} else {
 				$caption = wfMsg('wikiaPhotoGallery-preview-add-caption');
 			}
 
 		// image description
 			if ($image['linktext'] != '') {
-				$linktext = $image['linktext'];
+				$linktext = Sanitizer::removeHTMLtags( $image['linktext'] );
 			} else {
 				$linktext = wfMsg('wikiaPhotoGallery-preview-add-description');
 			}
 ?>
 		<span class="WikiaPhotoGalleryPreviewSliderCaptionWrapper">
-			<p class="WikiaPhotoGalleryPreviewSliderCaption WikiaPhotoGalleryPreviewItemCaption SliderTitle"><?= htmlspecialchars($caption) ?></p>
-			<p class="WikiaPhotoGalleryPreviewSliderCaption WikiaPhotoGalleryPreviewItemCaption SliderDescription"><?= htmlspecialchars($linktext) ?></p>
-			<p class="WikiaPhotoGalleryPreviewSliderCaption WikiaPhotoGalleryPreviewItemCaption SliderLink"><?= htmlspecialchars($linkMsg) ?></p>
+			<p class="WikiaPhotoGalleryPreviewSliderCaption WikiaPhotoGalleryPreviewItemCaption SliderTitle"><?= $caption ?></p>
+			<p class="WikiaPhotoGalleryPreviewSliderCaption WikiaPhotoGalleryPreviewItemCaption SliderDescription"><?= $linktext ?></p>
+			<p class="WikiaPhotoGalleryPreviewSliderCaption WikiaPhotoGalleryPreviewItemCaption SliderLink"><?= $linkMsg ?></p>
 		</span>
 	</span>
 <?php


### PR DESCRIPTION
This fixes a bug which causes legit HTML to be escaped. This approach uses Sanitizer to allow for safe markup while still preventing XSS attacks, whcih the initial fix was for.
