### PR TITLE
change include to include_once to avoid re-declaring classes

### DIFF
--- a/extensions/wikia/Search/maintenance/handle-closed-wikis.php
+++ b/extensions/wikia/Search/maintenance/handle-closed-wikis.php
@@ -11,7 +11,7 @@
 ini_set( "include_path", dirname(__FILE__)."/../../../../maintenance/" );
 require_once( "commandLine.inc" );
 
-include("$IP/extensions/wikia/Search/WikiaSearch.setup.php");
+include_once("$IP/extensions/wikia/Search/WikiaSearch.setup.php");
 
 $indexer = F::build( 'WikiaSearchIndexer' );
 


### PR DESCRIPTION
When running handle-closed-wikis.php, getting the following error:

Dec  5 20:17:20 cron-s1 php: PHP Fatal error:  Cannot redeclare class Solarium_A
utoloader (URL: (null)(null)) in /usr/wikia/slot1/code/extensions/wikia/Search/S
olarium/Autoloader.php on line 48

This is likely because of the following line: https://github.com/Wikia/app/blob/dev/extensions/wikia/Search/maintenance/handle-closed-wikis.php#L14

So we want to change that line.
