### PR TITLE
Fix non-functional AB Test admin interface

### DIFF
--- a/extensions/wikia/AbTesting/AbTesting.i18n.php
+++ b/extensions/wikia/AbTesting/AbTesting.i18n.php
@@ -15,8 +15,8 @@ $messages['en'] = array(
 	'abtesting-heading-name' => 'Name',
 	'abtesting-heading-description' => 'Description',
 
-	'abtesting-heading-start-time' => 'Start Time',
-	'abtesting-heading-end-time' => 'End Time',
+	'abtesting-heading-start-time' => 'Start Time (UTC)',
+	'abtesting-heading-end-time' => 'End Time (UTC)',
 	'abtesting-heading-ga-slot' => 'GA Slot',
 	'abtesting-heading-group' => 'Group',
 	'abtesting-heading-control-group' => 'Control Group',
@@ -37,5 +37,26 @@ $messages['en'] = array(
  * qqq - Documentation for the messages.
  */
 $messages['qqq'] = array(
+	'abtesting' => 'Page title',
+	'abtesting-desc' => 'Description of the A/B Testing extension',
 
+	'abtesting-heading-id' => 'Label for the ID field',
+	'abtesting-heading-name' => 'Label for the Name field',
+	'abtesting-heading-description' => 'Label for the Description field',
+
+	'abtesting-heading-start-time' => 'Label for the experiment start time',
+	'abtesting-heading-end-time' => 'Label for the experiement end time',
+	'abtesting-heading-ga-slot' => 'Label for the GA Slot field',
+	'abtesting-heading-group' => 'Group',
+	'abtesting-heading-control-group' => 'Label for the control group pulldown',
+	'abtesting-heading-ranges' => 'Ranges (0-99)',
+	'abtesting-heading-treatment-groups' => 'Heading for the Treatment Groups section',
+
+	'abtesting-create-experiment' => 'Button for creating a new experiment',
+	'abtesting-add-experiment-title' => 'Add Experiment',
+	'abtesting-edit-experiment-title' => 'Edit Experiment',
+	'abtesting-add-treatment-group' => 'Button for adding a new treatment group',
+
+	'abtesting-edit-button' => 'Edit button',
+	'abtesting-save-button' => 'Save button',
 );

--- a/extensions/wikia/AbTesting/AbTestingData.class.php
+++ b/extensions/wikia/AbTesting/AbTestingData.class.php
@@ -148,7 +148,7 @@ class AbTestingData extends WikiaObject {
 		return $this->loadFromDb();
 	}
 
-	public function getById( $id, $use_master ) {
+	public function getById( $id, $use_master = false ) {
 		$list = $this->loadFromDb(array(
 			'e.id' => $id,
 		), $use_master);
@@ -237,7 +237,7 @@ class AbTestingData extends WikiaObject {
 		$this->deleteRow(self::TABLE_GROUPS,$grp,__METHOD__);
 	}
 
-	public function saveVersion( &$ver, $no_checks ) {
+	public function saveVersion( &$ver, $no_checks = false ) {
 		$this->saveRow(self::TABLE_VERSIONS,$ver,__METHOD__, $no_checks);
 	}
 

--- a/extensions/wikia/AbTesting/AbTestingData.class.php
+++ b/extensions/wikia/AbTesting/AbTestingData.class.php
@@ -103,9 +103,13 @@ class AbTestingData extends WikiaObject {
 		return $ret;
 	}
 
-	protected function loadFromDb( $where = array() ) {
+	protected function loadFromDb( $where = array(), $use_master = false ) {
+		// Some calls to this method want to load from the master so that they
+		// don't race with replication lag
+		$db_type = $use_master ? DB_MASTER : DB_SLAVE;
+
 		/** @var $dbr DatabaseMysql */
-		$dbr = $this->getDb();
+		$dbr = $this->getDb( $db_type );
 		$res = $dbr->select(
 			array( // tables
 				'e' => 'ab_experiments',
@@ -144,10 +148,11 @@ class AbTestingData extends WikiaObject {
 		return $this->loadFromDb();
 	}
 
-	public function getById( $id ) {
+	public function getById( $id, $use_master ) {
 		$list = $this->loadFromDb(array(
 			'e.id' => $id,
-		));
+		), $use_master);
+
 		return @$list[$id];
 	}
 
@@ -163,7 +168,7 @@ class AbTestingData extends WikiaObject {
 		return $row;
 	}
 
-	protected function saveRow( $table, &$row, $fname ) {
+	protected function saveRow( $table, &$row, $fname, $no_checks=false ) {
 		$dbw = $this->getDb(DB_MASTER);
 		$copy = $this->filterRow($table,$row);
 		if ( !empty($row['id']) ) {
@@ -173,9 +178,19 @@ class AbTestingData extends WikiaObject {
 			unset($copy['id']);
 			$dbw->update($table,$copy,$where,$fname);
 		} else {
+			// If this is set, relax foriegn key checks so that we can insert
+			// circular references
+			if ($no_checks) {
+				$dbw->query("SET foreign_key_checks = 0");
+			}
+
 			unset($row['id']);
 			$dbw->insert($table,$copy,$fname);
 			$row['id'] = $dbw->insertId();
+
+			if ($no_checks) {
+				$dbw->query("SET foreign_key_checks = 1");
+			}
 		}
 	}
 
@@ -222,8 +237,8 @@ class AbTestingData extends WikiaObject {
 		$this->deleteRow(self::TABLE_GROUPS,$grp,__METHOD__);
 	}
 
-	public function saveVersion( &$ver ) {
-		$this->saveRow(self::TABLE_VERSIONS,$ver,__METHOD__);
+	public function saveVersion( &$ver, $no_checks ) {
+		$this->saveRow(self::TABLE_VERSIONS,$ver,__METHOD__, $no_checks);
 	}
 
 	public function deleteVersion( &$ver ) {

--- a/resources/wikia/libraries/jquery/nirvana/jquery.wikia.nirvana.js
+++ b/resources/wikia/libraries/jquery/nirvana/jquery.wikia.nirvana.js
@@ -32,14 +32,22 @@ $.nirvana = {
 
 		(type == 'POST' ? getUrl : data).format = format;
 
-		var sortedKeys = [];
-		for(var key in data) {
-			sortedKeys[sortedKeys.length] = key;
-		}
-		sortedKeys.sort();
-		var sortedDict = {};
-		for(var i = 0; i < sortedKeys.length; i++) {
-			sortedDict[sortedKeys[i]] = data[sortedKeys[i]];
+		// If data is a string just pass it directly along as is.  Otherwise
+		// sort the structured data so that the URL is consistant (for cache
+		// busting purposes)
+		var sortedDict;
+		if (typeof data == 'string') {
+			sortedDict = data;
+		} else {
+			var sortedKeys = [];
+			for(var key in data) {
+				sortedKeys[sortedKeys.length] = key;
+			}
+			sortedKeys.sort();
+			sortedDict = {};
+			for(var i = 0; i < sortedKeys.length; i++) {
+				sortedDict[sortedKeys[i]] = data[sortedKeys[i]];
+			}
 		}
 
 		return $.ajax({


### PR DESCRIPTION
This commit addresses several issues:
- Sorting in the sendRequest method was causing the data sent to PHP to be mangled
- Inserting new experiments failed due to circular foriegn key constraints. Added option to disable key checks while inserting the version object
- ID was loaded from request parameters but is null when a new experiment is added.  It was never updated when a new experiment was created and saved.  Later this ID is used to retrieve this experiment which would fail.  The ID is now updated after a new experiment is created
- The $groups[$normalizedName] array is used inconsistantly.  A 'name' field is read from it for error reporting but never written.  Elsewhere a numeric array is written to it rather than named keys.  Updated to be consistent.
- New experiment is loaded after saving to get all fields, but experiences race condition with master/slave replication.  Fixed to load from master in this case
- Added some translation documentation.
