### PR TITLE
Removed ads from oasis skin

### DIFF
--- a/skins/oasis/modules/templates/Body_Index.php
+++ b/skins/oasis/modules/templates/Body_Index.php
@@ -84,17 +84,6 @@
 				<? if($displayAdminDashboardChromedArticle) { ?>
 					<?= (string)$app->sendRequest( 'AdminDashboardSpecialPage', 'chromedArticleHeader', array('headerText' => $wg->Title->getText() )) ?>
 				<? } ?>
-				<?php
-					global $wfMainPageTag_rcs_called, $wfMainPageTag_lcs_called;
-
-					if(empty($wfMainPageTag_rcs_called) && empty($wfMainPageTag_lcs_called)) {
-						?>
-							<div class="home-top-right-ads">
-								<?= $app->renderView('Ad', 'Index', array('slotname' => 'HOME_TOP_RIGHT_BOXAD')); ?>
-							</div>
-						<?php
-					}
-				?>
 
 				<?php
 				// for InfoBox-Testing


### PR DESCRIPTION
Removed ads from oasis skin.  Those variables are not set because they are set in parser hooks.  Proper fix will be upcoming
