### PR TITLE
Improvements to log module

### DIFF
--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -585,6 +585,7 @@ $config['wikiaapp_js'] = array(
 $config['monobook_js'] = array(
 	'type' => AssetsManager::TYPE_JS,
 	'assets' => array(
+		'#group_oasis_wikia_js',
 		'#group_oasis_jquery',
 		'#group_articlecomments_js',
 
@@ -1186,5 +1187,5 @@ $config['history_polyfill_js'] = array(
 		'//resources/wikia/polyfills/history/history.adapter.jquery.js',
 		//'//resources/wikia/polyfills/history/history.html4.js', // add this back in when we're ready to support IE
 		'//resources/wikia/polyfills/history/history.js',
-	)	
+	)
 );

--- a/resources/wikia/jquery.wikia.js
+++ b/resources/wikia/jquery.wikia.js
@@ -56,15 +56,7 @@ $.getScript = function(url, callback, failureFn) {
 };
 
 $.fn.log = function (msg, group) {
-	if (typeof console != 'undefined') { /* JSlint ignore */
-		if (group) {
-			// nice formatting of objects with group prefix
-			console.log((typeof msg != 'object' ? '%s: %s' : '%s: %o'), group, msg);
-		}
-		else {
-			console.log(msg);
-		}
-	}
+	Wikia.log(msg, Wikia.log.levels.info, group);
 	return this;
 };
 

--- a/resources/wikia/modules/log.js
+++ b/resources/wikia/modules/log.js
@@ -11,6 +11,10 @@
  * //JS Namespace
  * Wikia.log(123, Wikia.log.levels.info, 'MyLogGroup');
  *
+ * //To allow the messages to be printed to the console add log_level=X to the
+ * //URL querystring, where X is one of the values in the levels hash (either the hash key or it's value)
+ * //e.g. http://glee.wikia.com/wiki/Rachel_Berry?log_level=info
+ *
  * @see  printMessage for a list of parameters and their description
  */
 (function (context) {

--- a/resources/wikia/modules/log.js
+++ b/resources/wikia/modules/log.js
@@ -1,31 +1,45 @@
-/*global console: true, opera: true */
 /**
  * Logging utility extracted from Liftium's library and further modified
  *
  * @author Przemek Piotrowski (Nef) <ppiotr(at)wikia-inc.com>
  * @author Federico "Lox" Lucignano <federico(at)wikia-inc.com>
+ *
+ * @example
+ * //AMD
+ * require(['log'], function (log) { log(123, log.levels.info, 'MyLogGroup'); });
+ *
+ * //JS Namespace
+ * Wikia.log(123, Wikia.log.levels.info, 'MyLogGroup');
+ *
+ * @see  printMessage for a list of parameters and their description
  */
 (function (context) {
 	'use strict';
 
+	var levels = {
+		user: 1,
+		feedback: 2,
+		info: 3,
+		system: 4,
+		warning: 5,
+		error: 6,
+		debug: 7,
+		trace: 8,
+		trace_l2: 9,
+		trace_l3: 10
+	};
+
 	function logger() {
-		var levels = {
-				user: 1,
-				feedback: 2,
-				info: 3,
-				system: 4,
-				warning: 5,
-				error: 6,
-				debug: 7,
-				trace: 8,
-				trace_l2: 9,
-				trace_l3: 10
-			},
+		var console = context.console,
+			//used for undefined checks
+			undef,
 			outputLevel = 0,
 			groups = {},
 			groupsString = '',
 			groupsCount = 0,
 			enabled = false,
+			//used to check for iOS devices
+			isIdevice,
 			levelsMap = [],
 			levelID,
 			p,
@@ -51,10 +65,26 @@
 		 * @param {String} group The log group
 		 */
 		function printMessage(msg, level, group) {
-			if (typeof console !== 'undefined') {
-				console.log((typeof msg !== 'object' ? '%s: %s' : '%s: %o'), group, msg);
-			} else if (typeof opera !== 'undefined') {
-				opera.postError(group + ': ' + msg);
+			if (console !== undef) {
+				if (group) {
+					//forcing space as IE doesn't
+					//add one between parameters
+					group += ': ';
+
+					if (isIdevice === undef) {
+						isIdevice = /i(pod|pad|phone)/i.test(context.navigator.userAgent);
+					}
+
+					if (isIdevice) {
+						//iOS doesn't print out more than one parameter
+						//and has no tree view for objects
+						console.log(group + msg.toString());
+					} else {
+						console.log(group, msg);
+					}
+				} else {
+					console.log(msg);
+				}
 			}
 		}
 
@@ -85,7 +115,7 @@
 			group = group || 'Unknown source';
 
 			if (!enabled ||
-					(typeof msg === "undefined") ||
+					(msg === undef) ||
 					(levelID > outputLevel) ||
 					(groupsCount > 0 && !(groups.hasOwnProperty(group)))) {
 				return false;
@@ -115,7 +145,7 @@
 			if (levels.hasOwnProperty(outputLevel)) {
 				outputLevel = levels[outputLevel];
 			} else {
-				outputLevel = parseInt( outputLevel, 10);
+				outputLevel = parseInt(outputLevel, 10);
 			}
 
 			selectedGroups = (qs.getVal('log_group') || cookies.get('log_group') || '').replace(' ', '').replace('|', ',').split(',');
@@ -151,7 +181,9 @@
 		context.Wikia = {};
 	}
 
-	context.Wikia.log = logger();//late binding
+	context.Wikia.log = logger();
+	//exposing levels to the outside world
+	context.Wikia.log.levels = levels;
 
 	if (context.define && context.define.amd) {
 		//AMD


### PR DESCRIPTION
So here's the deal:
- added core UMD modules to Monobook (they were missing)
- made $().log use Wikia.log removing the duplicated implementation
  - it defaults to the "info" log level (i.e. 3)
  - now to see the logs one needs to add the log_level querystring apram (I'll send an email to techteam once this is merged)
  - now by default a lot less stuff gets printed out which speeds up oasis/monobook at the beginning of the page load
- small changes to log.js
  - removed ancient code to support ancient versions of Opera (dated back to 2009!!!)
  - documentation header with examples, YAY!
  - if iOS is detected then print it out correctly, so now adEngs can quickly debug iPad + Oasis and mobile team the mobile skin + iPhone
  - exposed the levels hash to the outside world, so we can do Wikia.log('asd', Wikia.log.levels.info) and forget about magic numbers
  - minor optimizations
- tested on IE9, Firefox, Chrome and mobile Safari

@macbre @nefretete @hakubo, I'd appreciate if you guys could take a look :)
