### PR TITLE
Solr atomic updates

### DIFF
--- a/extensions/wikia/Search/Solarium/Client/RequestBuilder/Update.php
+++ b/extensions/wikia/Search/Solarium/Client/RequestBuilder/Update.php
@@ -119,7 +119,7 @@ class Solarium_Client_RequestBuilder_Update extends Solarium_Client_RequestBuild
 
             foreach ($doc->getFields() AS $name => $value) {
                 $boost = $doc->getFieldBoost($name);
-                $modifier = $doc instanceof Solarium_Document_AtomicUpdate ? $doc->getFieldModifier() : null;
+                $modifier = $doc instanceof Solarium_Document_AtomicUpdate ? $doc->getFieldModifier($name) : null;
                 if (is_array($value)) {
                     foreach ($value AS $multival) {
                         $xml .= $this->_buildFieldXml($name, $boost, $multival, $modifier);
@@ -145,15 +145,14 @@ class Solarium_Client_RequestBuilder_Update extends Solarium_Client_RequestBuild
      * @param string $name
      * @param float $boost
      * @param mixed $value
+     * @param string $modifier
      * @return string
      */
     protected function _buildFieldXml($name, $boost, $value, $modifier = null)
     {
         $xml = '<field name="' . $name . '"';
         $xml .= $this->attrib('boost', $boost);
-        if ( $modifier !== null ) {
-            $xml .= $this->attrib('update', $modifier);
-        }
+        $xml .= $this->attrib('update', $modifier);
         $xml .= '>' . htmlspecialchars($value, ENT_NOQUOTES, 'UTF-8');
         $xml .= '</field>';
 

--- a/extensions/wikia/Search/Solarium/Client/RequestBuilder/Update.php
+++ b/extensions/wikia/Search/Solarium/Client/RequestBuilder/Update.php
@@ -119,12 +119,13 @@ class Solarium_Client_RequestBuilder_Update extends Solarium_Client_RequestBuild
 
             foreach ($doc->getFields() AS $name => $value) {
                 $boost = $doc->getFieldBoost($name);
+                $modifier = $doc instanceof Solarium_Document_AtomicUpdate ? $doc->getFieldModifier() : null;
                 if (is_array($value)) {
                     foreach ($value AS $multival) {
-                        $xml .= $this->_buildFieldXml($name, $boost, $multival);
+                        $xml .= $this->_buildFieldXml($name, $boost, $multival, $modifier);
                     }
                 } else {
-                    $xml .= $this->_buildFieldXml($name, $boost, $value);
+                    $xml .= $this->_buildFieldXml($name, $boost, $value, $modifier);
                 }
             }
 
@@ -146,10 +147,13 @@ class Solarium_Client_RequestBuilder_Update extends Solarium_Client_RequestBuild
      * @param mixed $value
      * @return string
      */
-    protected function _buildFieldXml($name, $boost, $value)
+    protected function _buildFieldXml($name, $boost, $value, $modifier = null)
     {
         $xml = '<field name="' . $name . '"';
         $xml .= $this->attrib('boost', $boost);
+        if ( $modifier !== null ) {
+            $xml .= $this->attrib('update', $modifier);
+        }
         $xml .= '>' . htmlspecialchars($value, ENT_NOQUOTES, 'UTF-8');
         $xml .= '</field>';
 

--- a/extensions/wikia/Search/Solarium/Document/AtomicUpdate.php
+++ b/extensions/wikia/Search/Solarium/Document/AtomicUpdate.php
@@ -1,0 +1,86 @@
+<?php
+
+class Solarium_Document_AtomicUpdate extends Solarium_Document_ReadWrite
+{
+    /**
+     * Allows us to determine what kind of atomic update we want to set
+     * @var unknown_type
+     */
+    protected $_modifiers = array();
+    
+    /**
+     * Directive to set a value using atomic updates
+     * @var string
+     */
+    const MODIFIER_SET = 'set';
+    
+    /**
+     * Directive to increment an integer value using atomic updates
+     * @var string
+     */
+    const MODIFIER_INC = 'inc';
+    
+    /**
+     * Directive to append a value (e.g. multivalued fields) using atomic updates
+     * @var string
+     */
+    const MODIFIER_ADD = 'add';
+    
+    /**
+     * Constructor 
+     * 
+     * @param array $fields
+     * @param array $boosts
+     * @param array $modifiers
+     */
+    public function __construct($fields = array(), $boosts = array(), $modifiers = array()) 
+    {
+        parent::__construct($fields, $boosts);
+        $this->_modifiers = $modifiers;
+    }
+    
+    /**
+     * (non-PHPdoc)
+     * @see Solarium_Document_ReadWrite::addField()
+     */
+    public function addField($key, $value, $boost = null, $modifier = self::MODIFIER_SET)
+    {
+        return parent::__addField($key, $value, $boost)->setModifierForField($key, $modifier);
+    }
+    
+    /**
+     * (non-PHPdoc)
+     * @see Solarium_Document_ReadWrite::clear()
+     */
+    public function clear()
+    {
+        $this->_modifiers = array();
+        return parent::clear();
+    }
+    
+    /**
+     * Sets the modifier type for the provided field
+     * @param string $key
+     * @param string $modifier
+     * @throws Exception
+     * @return Solarium_Document_AtomicUpdate
+     */
+    public function setModifierForField($key, $modifier = self::MODIFIER_SET)
+    {
+        if (! in_array($modifier, array(self::MODIFIER_ADD, self::MODIFIER_INC, self::MODIFIER_SET)) ) {
+            throw new Exception('Attempt to set an atomic update modifier that is not supported');
+        } 
+        $this->_modifiers[$key] = $modifier;
+        return $this;
+    }
+    
+    /**
+     * Returns the appropriate modifier for atomic updates. 
+     * @param string $key
+     * @return Ambigous <NULL, unknown_type>
+     */
+    public function getModifierForField($key)
+    {
+        return isset($this->_modifiers[$key]) ? $this->_modifiers[$key] : null; 
+    }
+}

--- a/extensions/wikia/Search/Solarium/Document/AtomicUpdate.php
+++ b/extensions/wikia/Search/Solarium/Document/AtomicUpdate.php
@@ -9,6 +9,11 @@ class Solarium_Document_AtomicUpdate extends Solarium_Document_ReadWrite
     protected $_modifiers = array();
     
     /**
+     * This field needs to be explicitly set to observe the rules of atomic updates
+     */
+    protected $key;
+    
+    /**
      * Directive to set a value using atomic updates
      * @var string
      */
@@ -40,12 +45,22 @@ class Solarium_Document_AtomicUpdate extends Solarium_Document_ReadWrite
     }
     
     /**
+     * Sets the uniquely identifying key for use in atomic updating
+     * @param string $key
+     */
+    public function setKey($key, $value)
+    {
+    	$this->key = $key;
+    	return parent::addField($key, $value);
+    }
+    
+    /**
      * (non-PHPdoc)
      * @see Solarium_Document_ReadWrite::addField()
      */
     public function addField($key, $value, $boost = null, $modifier = self::MODIFIER_SET)
     {
-        return parent::__addField($key, $value, $boost)->setModifierForField($key, $modifier);
+        return parent::addField($key, $value, $boost)->setModifierForField($key, $modifier);
     }
     
     /**
@@ -82,5 +97,17 @@ class Solarium_Document_AtomicUpdate extends Solarium_Document_ReadWrite
     public function getModifierForField($key)
     {
         return isset($this->_modifiers[$key]) ? $this->_modifiers[$key] : null; 
+    }
+    
+    /**
+     * (non-PHPdoc)
+     * @see Solarium_Document_ReadOnly::getFields()
+     */
+    public function getFields()
+    {
+    	if ($this->key == null || !isset($this->_fields[$this->key])) {
+    		throw new Exception('Solarium_Document_ReadOnly must have a unique-ID\'d key registered before it can be used to build update commands');
+    	}
+    	return parent::getFields();
     }
 }

--- a/extensions/wikia/Search/WikiaSearch.class.php
+++ b/extensions/wikia/Search/WikiaSearch.class.php
@@ -84,7 +84,7 @@ class WikiaSearch extends WikiaObject {
 	 * @see WikiaSearch::field
 	 * @staticvar array
 	 */
-	private static $dynamicUnstoredFields = array('headings', 'first500', 'beginningText');
+	private static $dynamicUnstoredFields = array();
 	
 	/**
 	 * Used for dynamically composing multivalued language fields

--- a/extensions/wikia/Search/tests/SolariumModificationTest.php
+++ b/extensions/wikia/Search/tests/SolariumModificationTest.php
@@ -1,0 +1,357 @@
+<?php
+
+class SolariumModificationTest extends WikiaSearchBaseTest
+{
+	
+	//@todo write tests to handle the nested query capability we added
+	/**
+	 * @covers Solarium_Document_AtomicUpdate::addField
+	 * @covers Solarium_Document_AtomicUpdate::getModifierForField
+	 * @covers Solarium_Document_AtomicUpdate::setModifierForField
+	 */
+	public function testAtomicUpdateStoresModifier() {
+		
+		$doc = new Solarium_Document_AtomicUpdate();
+		$doc->addField( 'foo', 'bar' );
+		
+		$modifiers = new ReflectionProperty( 'Solarium_Document_AtomicUpdate', '_modifiers' );
+		$modifiers->setAccessible( true );
+		$modifierArray = $modifiers->getValue( $doc );
+		
+		$this->assertEquals(
+				Solarium_Document_AtomicUpdate::MODIFIER_SET,
+				$modifierArray['foo'],
+				'Solarium_Document_AtomicUpdate should set any added field to modify as a setter by default'
+		);
+		
+		$this->assertNull(
+				$doc->getModifierForField( 'baz' ),
+				'Solarium_Document_AtomicUpdate::getModifierForField should return the modifier string for the field provided, if not set'
+		);
+		
+		try {
+			$doc->addField('test', 'breaks', null, 'not a real modifier');
+		} catch ( Exception $e ) { }
+		
+		$this->assertInstanceOf(
+				'Exception',
+				$e,
+				'Solarium_Document_AtomicUpdate::setModifierForField should throw an exception if not passed a legal modifier'
+		);
+		
+		$doc->addField( 'baz', 'qux', null, Solarium_Document_AtomicUpdate::MODIFIER_ADD );
+
+		$this->assertEquals(
+				Solarium_Document_AtomicUpdate::MODIFIER_ADD,
+				$doc->getModifierForField( 'baz' ),
+				'Solarium_Document_AtomicUpdate::getModifierForField should return the modifier string for the field provided, if set'
+		);
+	}
+	
+	/**
+	 * @covers Solarium_Document_AtomicUpdate::setKey
+	 * @covers Solarium_Document_AtomicUpdate::getFields
+	 */
+	public function testAtomicUpdateStoresKey() {
+		
+		$doc = new Solarium_Document_AtomicUpdate();
+		
+		try {
+			$doc->getFields();
+		} catch ( Exception $e1 ) { }
+		
+		$this->assertInstanceOf(
+				'Exception',
+				$e1,
+				'Solarium_Document_AtomicUpdate should throw an exception if getFields() is called before a key is set to prevent malformed requests'
+		);
+		
+		$doc->setKey('id', '123_456');
+		
+		$e2 = null;
+		try {
+			$doc->getFields();
+		} catch ( Exception $e2 ) { }
+		
+		$this->assertNull(
+				$e2,
+				'Solarium_Document_AtomicUpdate should not throw an exception if getFields() is called after a key is set'
+		);
+		
+		$modifiers = new ReflectionProperty( 'Solarium_Document_AtomicUpdate', '_modifiers' );
+		$modifiers->setAccessible( true );
+		$modifierArray = $modifiers->getValue( $doc );
+		
+		$this->assertEmpty(
+				$modifierArray,
+				'Solarium_Document_AtomicUpdate::setKey should not store a modifier for the unique key'
+		);
+		
+		$keyRefl = new ReflectionProperty( 'Solarium_Document_AtomicUpdate', 'key' );
+		$keyRefl->setAccessible( true );
+		
+		$this->assertEquals(
+				'id',
+				$keyRefl->getValue( $doc ),
+				'Solarium_Document_AtomicUpdate::setKey should set the "key" member variable to the name of the field'
+		);
+	}
+	
+	/**
+	 * @covers Solarium_Client_RequestBuilder_Update::buildAddXml
+	 */
+	public function testUpdateRequestBuilderAccommodatesAtomicUpdatesSingleValue() {
+		
+		$mockUpdate = $this->getMockBuilder( 'Solarium_Client_RequestBuilder_Update' )
+							->disableOriginalConstructor()
+							->setMethods( array( 'attrib', '_buildFieldXml', 'boolAttrib' ) )
+							->getMock();
+		
+		$mockDocument = $this->getMock( 'Solarium_Document_AtomicUpdate', array( 'getBoost', 'getFieldBoost', 'getFields', 'getFieldModifier' ) );
+		
+		$mockCommand = $this->getMockBuilder( 'Solarium_Query_Update_Command_Add' )
+							->disableOriginalConstructor()
+							->setMethods( array( 'getOverwrite', 'getCommitWithin', 'getDocuments' ) )
+							->getMock();
+		
+		$mockCommand
+			->expects	( $this->at( 0 ) )
+			->method	( 'getOverwrite' )
+			->will		( $this->returnValue( true ) )
+		;
+		$mockUpdate
+			->expects	( $this->at( 0 ) )
+			->method	( 'boolAttrib' )
+			->with		( 'overwrite', true )
+			->will		( $this->returnValue( ' overwrite="true"' ) )
+		;
+		$mockCommand
+			->expects	( $this->at( 1 ) )
+			->method	( 'getCommitWithin' )
+			->will		( $this->returnValue( 100) )
+		;
+		$mockUpdate
+			->expects	( $this->at( 1 ) )
+			->method	( 'attrib' )
+			->with		( 'commitWithin', 100 )
+			->will		( $this->returnValue( ' commitWithin="100"' ) )
+		;
+		$mockCommand
+			->expects	( $this->at( 2 ) )
+			->method	( 'getDocuments' )
+			->will		( $this->returnValue( array( $mockDocument ) ) )
+		;
+		$mockDocument
+			->expects	( $this->at( 0 ) )
+			->method	( 'getBoost' )
+			->will		( $this->returnValue( null ) )
+		;
+		$mockUpdate
+			->expects	( $this->at( 2 ) )
+			->method	( 'attrib' )
+			->with		( 'boost', null )
+			->will		( $this->returnValue( '' ) )
+		;
+		$mockDocument
+			->expects	( $this->at( 1 ) )
+			->method	( 'getFields' )
+			->will		( $this->returnValue( array( 'id' => '123_456', 'views' => 100 ) ) )
+		;
+		$mockDocument
+			->expects	( $this->at( 2 ) )
+			->method	( 'getFieldBoost' )
+			->with		( 'id' )
+			->will		( $this->returnValue( null ) )
+		;
+		$mockDocument
+			->expects	( $this->at( 3 ) )
+			->method	( 'getFieldModifier' )
+			->with		( 'id' )
+			->will		( $this->returnValue( null ) )
+		;
+		$mockUpdate
+			->expects	( $this->at( 3 ) )
+			->method	( '_buildFieldXml' )
+			->with		( 'id', null, '123_456', null )
+			->will		( $this->returnValue( '<field name="id">123_456</field>' ) )
+		;
+		$mockDocument
+			->expects	( $this->at( 4 ) )
+			->method	( 'getFieldBoost' )
+			->with		( 'views' )
+			->will		( $this->returnValue( null ) )
+		;
+		$mockDocument
+			->expects	( $this->at( 5 ) )
+			->method	( 'getFieldModifier' )
+			->with		( 'views' )
+			->will		( $this->returnValue( Solarium_Document_AtomicUpdate::MODIFIER_SET ) )
+		;
+		$mockUpdate
+			->expects	( $this->at( 4 ) )
+			->method	( '_buildFieldXml' )
+			->with		( 'views', null, '100', 'set' )
+			->will		( $this->returnValue( '<field name="views" update="set">100</field>' ) )
+		;
+		
+		$expected = <<<END
+<add overwrite="true" commitWithin="100"><doc><field name="id">123_456</field><field name="views" update="set">100</field></doc></add>
+END;
+		
+		$this->assertEquals(
+				$expected,
+				$mockUpdate->buildAddXml( $mockCommand ),
+				'Solarium_Client_RequestBuilder_Update::buildAddXml should pass the appropriate values to _buildFieldXml to accommodate atomic updates'
+		);
+	}
+	
+	/**
+	 * @covers Solarium_Client_RequestBuilder_Update::buildAddXml
+	 */
+	public function testUpdateRequestBuilderAccommodatesAtomicUpdatesMultiValue() {
+		
+		$mockUpdate = $this->getMockBuilder( 'Solarium_Client_RequestBuilder_Update' )
+							->disableOriginalConstructor()
+							->setMethods( array( 'attrib', '_buildFieldXml', 'boolAttrib' ) )
+							->getMock();
+		
+		$mockDocument = $this->getMock( 'Solarium_Document_AtomicUpdate', array( 'getBoost', 'getFieldBoost', 'getFields', 'getFieldModifier' ) );
+		
+		$mockCommand = $this->getMockBuilder( 'Solarium_Query_Update_Command_Add' )
+							->disableOriginalConstructor()
+							->setMethods( array( 'getOverwrite', 'getCommitWithin', 'getDocuments' ) )
+							->getMock();
+		
+		$mockCommand
+			->expects	( $this->at( 0 ) )
+			->method	( 'getOverwrite' )
+			->will		( $this->returnValue( true ) )
+		;
+		$mockUpdate
+			->expects	( $this->at( 0 ) )
+			->method	( 'boolAttrib' )
+			->with		( 'overwrite', true )
+			->will		( $this->returnValue( ' overwrite="true"' ) )
+		;
+		$mockCommand
+			->expects	( $this->at( 1 ) )
+			->method	( 'getCommitWithin' )
+			->will		( $this->returnValue( 100) )
+		;
+		$mockUpdate
+			->expects	( $this->at( 1 ) )
+			->method	( 'attrib' )
+			->with		( 'commitWithin', 100 )
+			->will		( $this->returnValue( ' commitWithin="100"' ) )
+		;
+		$mockCommand
+			->expects	( $this->at( 2 ) )
+			->method	( 'getDocuments' )
+			->will		( $this->returnValue( array( $mockDocument ) ) )
+		;
+		$mockDocument
+			->expects	( $this->at( 0 ) )
+			->method	( 'getBoost' )
+			->will		( $this->returnValue( null ) )
+		;
+		$mockUpdate
+			->expects	( $this->at( 2 ) )
+			->method	( 'attrib' )
+			->with		( 'boost', null )
+			->will		( $this->returnValue( '' ) )
+		;
+		$mockDocument
+			->expects	( $this->at( 1 ) )
+			->method	( 'getFields' )
+			->will		( $this->returnValue( array( 'id' => '123_456', 'redirect_titles' => array( 'stuff', 'things' ) ) ) )
+		;
+		$mockDocument
+			->expects	( $this->at( 2 ) )
+			->method	( 'getFieldBoost' )
+			->with		( 'id' )
+			->will		( $this->returnValue( null ) )
+		;
+		$mockDocument
+			->expects	( $this->at( 3 ) )
+			->method	( 'getFieldModifier' )
+			->with		( 'id' )
+			->will		( $this->returnValue( null ) )
+		;
+		$mockUpdate
+			->expects	( $this->at( 3 ) )
+			->method	( '_buildFieldXml' )
+			->with		( 'id', null, '123_456', null )
+			->will		( $this->returnValue( '<field name="id">123_456</field>' ) )
+		;
+		$mockDocument
+			->expects	( $this->at( 4 ) )
+			->method	( 'getFieldBoost' )
+			->with		( 'redirect_titles' )
+			->will		( $this->returnValue( null ) )
+		;
+		$mockDocument
+			->expects	( $this->at( 5 ) )
+			->method	( 'getFieldModifier' )
+			->with		( 'redirect_titles' )
+			->will		( $this->returnValue( Solarium_Document_AtomicUpdate::MODIFIER_ADD ) )
+		;
+		$mockUpdate
+			->expects	( $this->at( 4 ) )
+			->method	( '_buildFieldXml' )
+			->with		( 'redirect_titles', null, 'stuff', 'add' )
+			->will		( $this->returnValue( '<field name="redirect_titles" update="add">stuff</field>' ) )
+		;
+		$mockUpdate
+			->expects	( $this->at( 5 ) )
+			->method	( '_buildFieldXml' )
+			->with		( 'redirect_titles', null, 'things', 'add' )
+			->will		( $this->returnValue( '<field name="redirect_titles" update="add">things</field>' ) )
+		;
+		
+		$expected = <<<END
+<add overwrite="true" commitWithin="100"><doc><field name="id">123_456</field><field name="redirect_titles" update="add">stuff</field><field name="redirect_titles" update="add">things</field></doc></add>
+END;
+		
+		$this->assertEquals(
+				$expected,
+				$mockUpdate->buildAddXml( $mockCommand ),
+				'Solarium_Client_RequestBuilder_Update::buildAddXml should pass the appropriate values to _buildFieldXml to accommodate atomic updates'
+		);
+	}
+	
+	/**
+	 * @covers Solarium_Client_RequestBuilder_Update::_buildFieldXml
+	 */
+	public function testBuildFieldXmlWithModifier() {
+		$mockUpdate = $this->getMockBuilder( 'Solarium_Client_RequestBuilder_Update' )
+							->disableOriginalConstructor()
+							->setMethods( array( 'attrib' ) )
+							->getMock();
+		
+		$mockUpdate
+			->expects	( $this->at( 0 ) )
+			->method	( 'attrib' )
+			->with		( 'boost', null )
+			->will		( $this->returnValue( '' ) )
+		;
+		$mockUpdate
+			->expects	( $this->at( 1 ) )
+			->method	( 'attrib' )
+			->with		( 'update', 'set' )
+			->will		( $this->returnValue( ' update="set"' ) )
+		;
+		
+		$buildFieldXml = new ReflectionMethod( 'Solarium_Client_RequestBuilder_Update', '_buildFieldXml' );
+		$buildFieldXml->setAccessible( true );
+		
+		$expected = <<<END
+<field name="foo" update="set">bar</field>
+END;
+		
+		$this->assertEquals(
+				$expected,
+				$buildFieldXml->invoke( $mockUpdate, 'foo', null, 'bar', 'set' )
+		);
+	}
+	
+}

--- a/extensions/wikia/Search/tests/WikiaSearchTest.php
+++ b/extensions/wikia/Search/tests/WikiaSearchTest.php
@@ -58,13 +58,6 @@ class WikiaSearchTest extends WikiaSearchBaseTest {
 		$this->assertEquals( $dynamicOutput, $expectedDynamicOutput,
 		        'An unsupported language field parameter should result in the default field name during WikiaSearch::field()' );
 
-		// A field that is dynamic unstored should have '_us' and the language code appended
-		$dynamicUnstoredField			= 'first500';
-		$dynamicUnstoredOutput			= WikiaSearch::field( $dynamicUnstoredField );
-		$expectedDynamicUnstoredOutput	= 'first500_us_en';
-		$this->assertEquals( $dynamicUnstoredOutput, $expectedDynamicUnstoredOutput,
-							'An unstored dynamic field did not have the appropriate suffixes appended during WikiaSearch::field()' );
-
 		// A field that is dynamic and multivalued should have '_mv' and the language code appended
 		$dynamicMultiValuedField			= 'categories';
 		$dynamicMultiValuedOutput			= WikiaSearch::field( $dynamicMultiValuedField );


### PR DESCRIPTION
This changeset includes an update to allow us to write atomic updates through Solarium, our Solr query-building library. This change was already accepted in the core project (https://github.com/basdenooijer/solarium/pull/136), and is fully tested. 

This also includes the effective removal of support for unstored fields from our library, as using atomic updates requires that all fields be stored and recoverable. 
