### PR TITLE
AssetManager group regex should be based on wgAssetsManagerQuery

### DIFF
--- a/resources/wikia/libraries/jquery/getResources/jquery.wikia.getResources.js
+++ b/resources/wikia/libraries/jquery/getResources/jquery.wikia.getResources.js
@@ -12,14 +12,14 @@
  */
 var getResources = (function() {
 	var rAssetManagerGroup = new RegExp( window.wgAssetsManagerQuery
-			// Replace the first parameter with 'groups' since that's all we care about
-			.replace( '%1$s', 'groups' )
 			// Escape any special regex characters in the URL
 			.replace( /[\-\[\]{}()*+?.,\\\^$|#\s]/g, '\\$&' )
+			// Escape forward slashes (required for string)
+			.replace( /\//g, '\\/' )
+			// Replace the first parameter to match group or groups
+			.replace( '%1\\$s', 'groups?' )
 			// Replace remaining parameters with wildcard matches
 			.replace( /%\d\\\$(?:s|d)/g, '(?:.*)' )
-			// Escape forward slashes
-			.replace( /\//g, '\\/' )
 		),
 		rAssetManagerGroupType = /(js|s?css)/,
 		rExtension = /\.(js|s?css)$/;

--- a/resources/wikia/libraries/jquery/getResources/jquery.wikia.getResources.js
+++ b/resources/wikia/libraries/jquery/getResources/jquery.wikia.getResources.js
@@ -1,4 +1,4 @@
-(function( $ ) {
+(function( window, $ ) {
 
 /**
  * Fetches a list of resources and fires a callback when they have all finished
@@ -11,7 +11,16 @@
  * @author kflorence
  */
 var getResources = (function() {
-	var rAssetManagerGroup = /__am\/\d+\/groups?\/.*\/(.*)$/,
+	var rAssetManagerGroup = new RegExp( window.wgAssetsManagerQuery
+			// Replace the first parameter with 'groups' since that's all we care about
+			.replace( '%1$s', 'groups' )
+			// Escape any special regex characters in the URL
+			.replace( /[\-\[\]{}()*+?.,\\\^$|#\s]/g, '\\$&' )
+			// Replace remaining parameters with wildcard matches
+			.replace( /%\d\\\$(?:s|d)/g, '(?:.*)' )
+			// Escape forward slashes
+			.replace( /\//g, '\\/' )
+		),
 		rAssetManagerGroupType = /(js|s?css)/,
 		rExtension = /\.(js|s?css)$/;
 
@@ -89,4 +98,4 @@ var getResources = (function() {
 // Exports
 $.getResources = $.getResource = getResources;
 
-})( jQuery );
+})( window, jQuery );


### PR DESCRIPTION
This is for https://wikia.fogbugz.com/default.asp?69073

Basically wgAssetsManagerQuery may differ across servers (in this particular case it differs for the internal wiki, which uses the old URL syntax). The regular expression match for checking if a URL is requesting an asset manager group should take this into account.
