### PR TITLE
WikiaSearch: Spellcheck

### DIFF
--- a/extensions/wikia/Search/Solarium/Client/RequestBuilder/Select/Component/Spellcheck.php
+++ b/extensions/wikia/Search/Solarium/Client/RequestBuilder/Select/Component/Spellcheck.php
@@ -70,6 +70,11 @@ class Solarium_Client_RequestBuilder_Select_Component_Spellcheck
         $request->addParam('spellcheck.maxCollationEvaluations', $component->getMaxCollationEvaluations());
         $request->addParam('spellcheck.collateExtendedResults', $component->getCollateExtendedResults());
         $request->addParam('spellcheck.accuracy', $component->getAccuracy());
+        
+        foreach ( $component->getCollateParams() as $param => $value )
+        {
+        	$request->addParam('spellcheck.collateParam.'.$param, $value);
+        } 
 
         return $request;
     }

--- a/extensions/wikia/Search/Solarium/Query/Select/Component/Spellcheck.php
+++ b/extensions/wikia/Search/Solarium/Query/Select/Component/Spellcheck.php
@@ -46,6 +46,12 @@
  */
 class Solarium_Query_Select_Component_Spellcheck extends Solarium_Query_Select_Component
 {
+	/**
+	 * Used to further customize collation parameters
+	 * @var array
+	 */
+	protected $_collateParams = array();
+	
     /**
      * Component type
      *
@@ -338,4 +344,24 @@ class Solarium_Query_Select_Component_Spellcheck extends Solarium_Query_Select_C
         return $this->getOption('accuracy');
     }
 
+    /**
+     * Set a collation param
+     * @param string $param
+     * @param mixed $value
+     * @return Solarium_Query_Select_Component_Spellcheck Provides fluent interface 
+     */
+    public function setCollateParam($param, $value)
+    {
+    	$this->_collateParams[$param] = $value;
+    	return $this;
+    }
+    
+    /**
+     * Returns the array of collate params
+     * @return array
+     */
+    public function getCollateParams()
+    {
+    	return $this->_collateParams;
+    }
 }

--- a/extensions/wikia/Search/WikiaSearch.class.php
+++ b/extensions/wikia/Search/WikiaSearch.class.php
@@ -538,21 +538,21 @@ class WikiaSearch extends WikiaObject {
 	 */
 	protected function search( WikiaSearchConfig $searchConfig ) {
 		try {
-			$result = $this->client->select( $this->getSelectQuery( $searchConfig ) );
-			
+			return $this->client->select( $this->getSelectQuery( $searchConfig ) );
 		} catch ( Exception $e ) {
-			F::build('Wikia')->log(__METHOD__, 'Querying Solr First Time', $e);
-			$searchConfig	->setSkipBoostFunctions( true )
-							->setError( $e );
-			try {
-				$result = $this->client->select( $this->getSelectQuery( $searchConfig ) );
-			} catch ( Exception $e ) {
+			if ( $searchConfig->getError() !== false ) {
 				$searchConfig->setError( $e );
 				F::build('Wikia')->log(__METHOD__, 'Querying Solr With No Boost Functions', $e);
-				$result = F::build('Solarium_Result_Select_Empty');
+				return F::build('Solarium_Result_Select_Empty');
+			} else {
+				F::build('Wikia')->log(__METHOD__, 'Querying Solr First Time', $e);
+				
+				$searchConfig	->setSkipBoostFunctions( true )
+								->setError( $e );
+
+				return $this->search( $searchConfig );
 			}
 		}
-		return $result;
 	}
 	
 	/**

--- a/extensions/wikia/Search/WikiaSearch.class.php
+++ b/extensions/wikia/Search/WikiaSearch.class.php
@@ -581,20 +581,23 @@ class WikiaSearch extends WikiaObject {
 	 */
 	protected function postSearch( WikiaSearchConfig $searchConfig, Solarium_Result_Select $result ) {
 		
-		if ( $this->wg->WikiaSearchSpellcheckActivated && $result->getNumFound() == 0 ) {
+		if ( $this->wg->WikiaSearchSpellcheckActivated 
+				&& $result->getNumFound() == 0
+				&& !$searchConfig->hasArticleMatch() ) {
 			if ( $collation = $result->getSpellcheck()->getCollation() ) {
 				$searchConfig->setQuery( $collation->getQuery() );
-				$this->search( $searchConfig );
+				$result = $this->search( $searchConfig );
 			}
 		}
 		
 		$results = F::build('WikiaSearchResultSet', array($result, $searchConfig) );
+
+		$resultCount = $results->getResultsFound();
 		
 		$searchConfig->setResults		( $results )
-					 ->setResultsFound	( $results->getResultsFound() )
+					 ->setResultsFound	( $resultCount )
 		;
 		if( $searchConfig->getPage() == 1 ) {
-			$resultCount = $results->getResultsFound();
 			F::build( 'Track' )->event( ( !empty( $resultCount ) ? 'search_start' : 'search_start_nomatch' ), 
 										array(	'sterm'	=> $searchConfig->getQuery(), 
 												'rver'	=> self::RELEVANCY_FUNCTION_ID,

--- a/extensions/wikia/Search/WikiaSearch.class.php
+++ b/extensions/wikia/Search/WikiaSearch.class.php
@@ -524,6 +524,7 @@ class WikiaSearch extends WikiaObject {
 			$spellcheck->setMaxCollationTries( self::SPELLING_MAX_COLLATION_TRIES );
 			$spellcheck->setMaxCollations( 5 );
 			$spellcheck->setExtendedResults( true );
+			$spellcheck->setCollateParam( 'fq', 'is_content:true AND wid:'.$searchConfig->getCityId() );
 			$spellcheck->setOnlyMorePopular( true );
 			$spellcheck->setDictionary( in_array( $this->wg->LanguageCode, $this->wg->WikiaSearchSupportedLanguages ) ? $this->wg->LanguageCode : 'default'   );
 			$spellcheck->setCollateExtendedResults( true );
@@ -581,8 +582,10 @@ class WikiaSearch extends WikiaObject {
 	protected function postSearch( WikiaSearchConfig $searchConfig, Solarium_Result_Select $result ) {
 		
 		if ( $this->wg->WikiaSearchSpellcheckActivated && $result->getNumFound() == 0 ) {
-			$searchConfig->setQuery( $result->getSpellcheck()->getCollation()->getQuery() );
-			$this->search( $searchConfig );
+			if ( $collation = $result->getSpellcheck()->getCollation() ) {
+				$searchConfig->setQuery( $collation->getQuery() );
+				$this->search( $searchConfig );
+			}
 		}
 		
 		$results = F::build('WikiaSearchResultSet', array($result, $searchConfig) );

--- a/extensions/wikia/Search/WikiaSearch.class.php
+++ b/extensions/wikia/Search/WikiaSearch.class.php
@@ -67,13 +67,19 @@ class WikiaSearch extends WikiaObject {
 	 * Sets max collation tries when spellchecking
 	 * @var int
 	 */
-	const SPELLING_MAX_COLLATION_TRIES = 20;
+	const SPELLING_MAX_COLLATION_TRIES		= 20;
+	
+	/**
+	 * Sets max collations when spellchecking
+	 * @var int
+	 */
+	const SPELLING_MAX_COLLATIONS			= 5;
 	
 	/**
 	 * Sets the max number of results to return when spellchecking
 	 * @var int
 	 */
-	const SPELLING_RESULT_COUNT = 20;
+	const SPELLING_RESULT_COUNT				= 20;
 	
 	/**
 	 * These fields are actually dynamic language fields supported in 36 different languages
@@ -515,20 +521,28 @@ class WikiaSearch extends WikiaObject {
 		return $query;
 	}
 	
-	protected function handleSpellcheck( Solarium_Query $query, WikiaSearchConfig $searchConfig ) {
+	/**
+	 * Configures spellcheck per our desired settings
+	 * @param Solarium_Query_Select $query
+	 * @param WikiaSearchConfig $searchConfig
+	 * @return WikiaSearch
+	 */
+	protected function handleSpellcheck( Solarium_Query_Select $query, WikiaSearchConfig $searchConfig ) {
 		if ( $this->wg->WikiaSearchSpellcheckActivated ) {
-			$spellcheck = $query->getSpellcheck();
-			$spellcheck->setQuery( $searchConfig->getQueryNoQuotes( true ) );
-			$spellcheck->setCollate( true );
-			$spellcheck->setCount( self::SPELLING_RESULT_COUNT );
-			$spellcheck->setMaxCollationTries( self::SPELLING_MAX_COLLATION_TRIES );
-			$spellcheck->setMaxCollations( 5 );
-			$spellcheck->setExtendedResults( true );
-			$spellcheck->setCollateParam( 'fq', 'is_content:true AND wid:'.$searchConfig->getCityId() );
-			$spellcheck->setOnlyMorePopular( true );
-			$spellcheck->setDictionary( in_array( $this->wg->LanguageCode, $this->wg->WikiaSearchSupportedLanguages ) ? $this->wg->LanguageCode : 'default'   );
-			$spellcheck->setCollateExtendedResults( true );
+			$query	->getSpellcheck()
+					->setQuery( $searchConfig->getQueryNoQuotes( true ) )
+					->setCollate( true )
+					->setCount( self::SPELLING_RESULT_COUNT )
+					->setMaxCollationTries( self::SPELLING_MAX_COLLATION_TRIES )
+					->setMaxCollations( self::SPELLING_MAX_COLLATIONS )
+					->setExtendedResults( true )
+					->setCollateParam( 'fq', 'is_content:true AND wid:'.$searchConfig->getCityId() )
+					->setOnlyMorePopular( true )
+					->setDictionary( in_array( $this->wg->LanguageCode, $this->wg->WikiaSearchSupportedLanguages ) ? $this->wg->LanguageCode : 'default'   )
+					->setCollateExtendedResults( true )
+			;
 		}
+		return $this;
 	}
 	
 	/**

--- a/extensions/wikia/Search/tests/WikiaSearchTest.php
+++ b/extensions/wikia/Search/tests/WikiaSearchTest.php
@@ -2180,6 +2180,123 @@ class WikiaSearchTest extends WikiaSearchBaseTest {
 		);
 	}
 	
+	/**
+	 * @covers WikiaSearch::handleSpellcheck
+	 */
+	public function testHandleSpellcheck() {
+		$mockSearch = $this->getMockBuilder( 'WikiaSearch' )
+							->disableOriginalConstructor()
+							->getMock();
+		
+		$mockConfig = $this->getMockBuilder( 'WikiaSearchConfig' )
+							->disableOriginalConstructor()
+							->setMethods( array( 'getQueryNoQuotes', 'getCityId' ) )
+							->getMock();
+		
+		$mockQuery = $this->getMockBuilder( 'Solarium_Query_Select' )
+							->disableOriginalConstructor()
+							->setMethods( array( 'getSpellcheck' ) )
+							->getMock();
+		
+		$spellcheckMethods = array( 'setQuery', 'setCollate', 'setCount', 'setMaxCollationTries', 'setMaxCollations', 'setExtendedResults', 
+									'setCollateParam', 'setOnlyMorePopular', 'setDictionary', 'setCollateExtendedResults' );
+		
+		$mockSpellcheck = $this->getMockBuilder( 'Solarium_Query_Select_Component_Spellcheck' )
+								->disableOriginalConstructor()
+								->setMethods( $spellcheckMethods )
+								->getMock();
+		
+		$query = 'foo';
+		
+		$mockQuery
+			->expects	( $this->at( 0 ) )
+			->method	( 'getSpellcheck' )
+			->will		( $this->returnValue( $mockSpellcheck ) )
+		;
+		$mockConfig
+			->expects	( $this->at( 0 ) )
+			->method	( 'getQueryNoQuotes' )
+			->with		( true )
+			->will		( $this->returnValue( $query ) )			
+		;
+		$mockSpellcheck
+			->expects	( $this->at( 0 ) )
+			->method	( 'setQuery' )
+			->with		( $query )
+			->will		( $this->returnValue( $mockSpellcheck ) )
+		;
+		$mockSpellcheck
+			->expects	( $this->at( 1 ) )
+			->method	( 'setCollate' )
+			->with		( true )
+			->will		( $this->returnValue( $mockSpellcheck ) )
+		;
+		$mockSpellcheck
+			->expects	( $this->at( 2 ) )
+			->method	( 'setCount' )
+			->with		( WikiaSearch::SPELLING_RESULT_COUNT )
+			->will		( $this->returnValue( $mockSpellcheck ) )
+		;
+		$mockSpellcheck
+			->expects	( $this->at( 3 ) )
+			->method	( 'setMaxCollationTries' )
+			->with		( WikiaSearch::SPELLING_MAX_COLLATION_TRIES )
+			->will		( $this->returnValue( $mockSpellcheck ) )
+		;
+		$mockSpellcheck
+			->expects	( $this->at( 4 ) )
+			->method	( 'setMaxCollations' )
+			->with		( WikiaSearch::SPELLING_MAX_COLLATIONS )
+			->will		( $this->returnValue( $mockSpellcheck ) )
+		;
+		$mockSpellcheck
+			->expects	( $this->at( 5 ) )
+			->method	( 'setExtendedResults' )
+			->with		( true )
+			->will		( $this->returnValue( $mockSpellcheck ) )
+		;
+		$mockConfig
+			->expects	( $this->at( 1 ) )
+			->method	( 'getCityId' )
+			->will		( $this->returnValue( '123' ) )			
+		;
+		$mockSpellcheck
+			->expects	( $this->at( 6 ) )
+			->method	( 'setCollateParam' )
+			->with		( 'fq', 'is_content:true AND wid:123' )
+			->will		( $this->returnValue( $mockSpellcheck ) )
+		;
+		$mockSpellcheck
+			->expects	( $this->at( 7 ) )
+			->method	( 'setOnlyMorePopular' )
+			->with		( true )
+			->will		( $this->returnValue( $mockSpellcheck ) )
+		;
+		$mockSpellcheck
+			->expects	( $this->at( 8 ) )
+			->method	( 'setDictionary' )
+			->with		( 'en' )
+			->will		( $this->returnValue( $mockSpellcheck ) )
+		;
+		$mockSpellcheck
+			->expects	( $this->at( 9 ) )
+			->method	( 'setCollateExtendedResults' )
+			->with		( true )
+			->will		( $this->returnValue( $mockSpellcheck ) )
+		;
+		
+		$wg = new ReflectionProperty( 'WikiaSearch', 'wg' );
+		$wg->setAccessible( true );
+		$wg->setValue( $mockSearch, (object) array( 'WikiaSearchSpellcheckActivated' => true, 'LanguageCode' => 'en', 'WikiaSearchSupportedLanguages' => array( 'en' ) ) );
+		
+		$handle = new ReflectionMethod( 'WikiaSearch', 'handleSpellcheck' );
+		$handle->setAccessible( true );
+		$this->assertEquals(
+				$mockSearch,
+				$handle->invoke( $mockSearch, $mockQuery, $mockConfig )
+		);
+	}
+	
 
 	/**
 	 * @covers WikiaSearch::searchByLuceneQuery

--- a/extensions/wikia/Search/tests/WikiaSearchTest.php
+++ b/extensions/wikia/Search/tests/WikiaSearchTest.php
@@ -1970,6 +1970,216 @@ class WikiaSearchTest extends WikiaSearchBaseTest {
 		);
 	}
 
+	/**
+	 * @covers WikiaSearch::search
+	 */
+	public function testSearchWorksFirst() {
+		$mockSearch = $this->getMockBuilder( 'WikiaSearch' )
+							->disableOriginalConstructor()
+							->setMethods( array( 'getSelectQuery' ) )
+							->getMock();
+		
+		$mockClient = $this->getMockBuilder( 'Solarium_Client' )
+							->disableOriginalConstructor()
+							->setMethods( array( 'select' ) )
+							->getMock();
+		
+		$mockConfig = $this->getMockBuilder( 'WikiaSearchConfig' )
+							->disableOriginalConstructor()
+							->setMethods( array() )
+							->getMock();
+		
+		$mockResult = $this->getMockBuilder( 'Solarium_Result_Select' )
+							->disableOriginalConstructor()
+							->getMock();
+		
+		$mockQuery = $this->getMockBuilder( 'Solarium_Query_Select' )
+							->disableOriginalConstructor()
+							->getMock();
+		
+		$mockSearch
+			->expects	( $this->at( 0 ) )
+			->method	( 'getSelectQuery' )
+			->with		( $mockConfig )
+			->will		( $this->returnValue( $mockQuery ) )
+		;
+		$mockClient
+			->expects	( $this->at( 0 ) )
+			->method	( 'select' )
+			->with		( $mockQuery )
+			->will		( $this->returnValue( $mockResult ) )
+		;
+		
+		$reflClient = new ReflectionProperty( 'WikiaSearch', 'client' );
+		$reflClient->setAccessible( true );
+		$reflClient->setValue( $mockSearch, $mockClient );
+		
+		$reflSearch = new ReflectionMethod( 'WikiaSearch', 'search' );
+		$reflSearch->setAccessible( true );
+		$this->assertEquals(
+				$mockResult,
+				$reflSearch->invoke( $mockSearch, $mockConfig ),
+				'WikiaSearch::search should accept an instance of WikiaSearchConfig and return an instance of Solarium_Result_Select'
+		);
+	}
+	
+	/**
+	 * @covers WikiaSearch::search
+	 */
+	public function testSearchWithoutBoost() {
+		$mockSearch = $this->getMockBuilder( 'WikiaSearch' )
+							->disableOriginalConstructor()
+							->setMethods( array( 'getSelectQuery', 'search' ) )
+							->getMock();
+		
+		$mockClient = $this->getMockBuilder( 'Solarium_Client' )
+							->disableOriginalConstructor()
+							->setMethods( array( 'select' ) )
+							->getMock();
+		
+		$mockConfig = $this->getMockBuilder( 'WikiaSearchConfig' )
+							->disableOriginalConstructor()
+							->setMethods( array( 'getError', 'setError', 'setSkipBoostFunctions' ) )
+							->getMock();
+		
+		$mockResult = $this->getMockBuilder( 'Solarium_Result_Select' )
+							->disableOriginalConstructor()
+							->getMock();
+		
+		$mockQuery = $this->getMockBuilder( 'Solarium_Query_Select' )
+							->disableOriginalConstructor()
+							->getMock();
+		
+		$mockException = $this->getMockBuilder( 'Exception' )
+							->disableOriginalConstructor()
+							->getMock();
+		
+		$mockWikia = $this->getMock( 'Wikia', array( 'log' ) );
+		
+		$mockSearch
+			->expects	( $this->at( 0 ) )
+			->method	( 'getSelectQuery' )
+			->with		( $mockConfig )
+			->will		( $this->returnValue( $mockQuery ) )
+		;
+		$mockClient
+			->expects	( $this->at( 0 ) )
+			->method	( 'select' )
+			->with		( $mockQuery )
+			->will		( $this->throwException( $mockException ) )
+		;
+		$mockConfig
+			->expects	( $this->at( 0 ) )
+			->method	( 'getError' )
+			->will		( $this->returnValue( false ) )
+		;
+		$mockConfig
+			->expects	( $this->at( 1 ) )
+			->method	( 'setSkipBoostFunctions' )
+			->with		( true )
+			->will		( $this->returnValue( $mockConfig ) )
+		;
+		$mockConfig
+			->expects	( $this->at( 2 ) )
+			->method	( 'setError' )
+			->with		( $mockException )
+			->will		( $this->returnValue( $mockConfig ) )
+		;
+		$mockSearch
+			->expects	( $this->at( 1 ) )
+			->method	( 'search' )
+			->with		( $mockConfig )
+			->will		( $this->returnValue( $mockResult ) )
+		;
+		
+		$this->mockClass( 'Wikia', $mockWikia );
+		$this->mockApp();
+		
+		$reflClient = new ReflectionProperty( 'WikiaSearch', 'client' );
+		$reflClient->setAccessible( true );
+		$reflClient->setValue( $mockSearch, $mockClient );
+		
+		$reflSearch = new ReflectionMethod( 'WikiaSearch', 'search' );
+		$reflSearch->setAccessible( true );
+		$this->assertEquals(
+				$mockResult,
+				$reflSearch->invoke( $mockSearch, $mockConfig ),
+				'WikiaSearch::search should accept an instance of WikiaSearchConfig and return an instance of Solarium_Result_Select'
+		);
+	}
+	
+	/**
+	 * @covers WikiaSearch::search
+	 */
+	public function testSearchGivesUp() {
+		$mockSearch = $this->getMockBuilder( 'WikiaSearch' )
+							->disableOriginalConstructor()
+							->setMethods( array( 'getSelectQuery', 'search' ) )
+							->getMock();
+		
+		$mockClient = $this->getMockBuilder( 'Solarium_Client' )
+							->disableOriginalConstructor()
+							->setMethods( array( 'select' ) )
+							->getMock();
+		
+		$mockConfig = $this->getMockBuilder( 'WikiaSearchConfig' )
+							->disableOriginalConstructor()
+							->setMethods( array( 'getError', 'setError', 'setSkipBoostFunctions' ) )
+							->getMock();
+		
+		$mockResult = $this->getMockBuilder( 'Solarium_Result_Select' )
+							->disableOriginalConstructor()
+							->getMock();
+		
+		$mockQuery = $this->getMockBuilder( 'Solarium_Query_Select' )
+							->disableOriginalConstructor()
+							->getMock();
+		
+		$mockException = $this->getMockBuilder( 'Exception' )
+							->disableOriginalConstructor()
+							->getMock();
+		
+		$mockWikia = $this->getMock( 'Wikia', array( 'log' ) );
+		
+		$mockSearch
+			->expects	( $this->at( 0 ) )
+			->method	( 'getSelectQuery' )
+			->with		( $mockConfig )
+			->will		( $this->returnValue( $mockQuery ) )
+		;
+		$mockClient
+			->expects	( $this->at( 0 ) )
+			->method	( 'select' )
+			->with		( $mockQuery )
+			->will		( $this->throwException( $mockException ) )
+		;
+		$mockConfig
+			->expects	( $this->at( 0 ) )
+			->method	( 'getError' )
+			->will		( $this->returnValue( $mockException ) )
+		;
+		$mockConfig
+			->expects	( $this->at( 1 ) )
+			->method	( 'setError' )
+			->with		( $mockException )
+		;
+		
+		$this->mockClass( 'Wikia', $mockWikia );
+		$this->mockApp();
+		
+		$reflClient = new ReflectionProperty( 'WikiaSearch', 'client' );
+		$reflClient->setAccessible( true );
+		$reflClient->setValue( $mockSearch, $mockClient );
+		
+		$reflSearch = new ReflectionMethod( 'WikiaSearch', 'search' );
+		$reflSearch->setAccessible( true );
+		$this->assertInstanceOf(
+				'Solarium_Result_Select_Empty',
+				$reflSearch->invoke( $mockSearch, $mockConfig ),
+				'WikiaSearch::search should accept an instance of WikiaSearchConfig and return an instance of Solarium_Result_Select_Empty if a retry does not work'
+		);
+	}
+	
 
 	/**
 	 * @covers WikiaSearch::searchByLuceneQuery


### PR DESCRIPTION
This introduces spellcheck capabilities to WikiaSearch, hidden behind $wgWikiaSearchSpellcheckActivated, which is currently null.

We probably won't want to turn this on until we upgrade to 4.0, because spellchecking against an index comprising of multiple corpora is presently impossible. Every spellcheck we perform is done against a separate index that doesn't have any additional data -- meaning that we can't tell Solr not to suggest a term with more instances for the provided subquery that _isn't_ in the current wiki.

A basic overview of what has changed:
- The logic in WikiaSearch::doSearch has been broken up into three subroutines: WikiaSearch::preSearch, WikiaSearch::search, and WikiaSearch::postSearch
- WikiaSearch::preSearch primarily handles pagination and grouping
- WikiaSearch::search is a recursive function that guarantees the return of an instance of Solarium_Result_Select (empty or not)
- WikiaSearch::postSearch handles building the WikiaSearchResultSet instance and tracking
- WikiaSearch::handleSpellcheck has been introduced, but is currently inactive
- The Solarium library has been updated to handle Solr 4.0's spellcheck.collateParams.xx parameters (a pull request has been issued to the main project at https://github.com/basdenooijer/solarium/pull/138 )

These changes have been fully tested. The changes to Solarium have also been united tested, but as a "vendor library" those unit tests have not been ported over to the Search extension.
