### PR TITLE
No ip whitelist for XFF client returned directly from first varnish

### DIFF
--- a/includes/WebRequest.php
+++ b/includes/WebRequest.php
@@ -1048,7 +1048,7 @@ HTML;
 
 		# short circuit XFF Check, and keep us from needing to know fastly IPS
 		if ( $wgClientIPHeader ) { 
-			$trustedHeaderIp = $this->getHeader( $wgClientIPHeader ) 
+			$trustedHeaderIp = $this->getHeader( $wgClientIPHeader ) ;
 			if ( $trustedHeaderIp !== false ) {
 				$ip = $trustedHeaderIp;	
 				$foundTrustedHeader = true;

--- a/includes/WebRequest.php
+++ b/includes/WebRequest.php
@@ -1033,6 +1033,10 @@ HTML;
 	 */
 	public function getIP() {
 		global $wgUsePrivateIPs;
+		# wikia change start
+		global $wgClientIPHeader;
+
+		$foundTrustedHeader = false;
 
 		# Return cached result
 		if ( $this->ip !== null ) {
@@ -1042,9 +1046,19 @@ HTML;
 		# collect the originating ips
 		$ip = $this->getRawIP();
 
+		# short circuit XFF Check, and keep us from needing to know fastly IPS
+		if ( $wgClientIPHeader ) { 
+			$trustedHeaderIp = $this->getHeader( $wgClientIPHeader ) 
+			if ( $trustedHeaderIp !== false ) {
+				$ip = $trustedHeaderIp;	
+				$foundTrustedHeader = true;
+			}
+		}
+
 		# Append XFF
 		$forwardedFor = $this->getHeader( 'X-Forwarded-For' );
-		if ( $forwardedFor !== false ) {
+		if ( $forwardedFor !== false && $foundTrustedHeader === false ) {
+		# wikia change end 
 			$ipchain = array_map( 'trim', explode( ',', $forwardedFor ) );
 			$ipchain = array_reverse( $ipchain );
 			if ( $ip ) {


### PR DESCRIPTION
I'm tired of managing Fastly's server ips, and I think it relies on too much information from them. This keeps happening, and this should be a quick solution to the issue.

Id like to add $wgClientIPHeader (currently set to X-Something in my LocalSettings). This will take the first fastly client ip and use this as the source IP. Matching VCL will not chain ips, so there is no need to walk the chain.

since we would set this with a config variable, I don't really see any security implications, and if for some reason there is a failure we'll fall back to X-forwarded-for.

Please comment.
