### PR TITLE
Bugid 68713

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 /mysql-connector-java-5.1.18-bin.jar
 /mysql-connector-license.txt
 .DS_Store
+.buildpath

--- a/extensions/wikia/SEOTweaks/SEOTweaks.setup.php
+++ b/extensions/wikia/SEOTweaks/SEOTweaks.setup.php
@@ -18,7 +18,7 @@ $app->registerHook('BeforePageDisplay', 'SEOTweaksHooksHelper', 'onBeforePageDis
 $app->registerHook('ArticleFromTitle', 'SEOTweaksHooksHelper', 'onArticleFromTitle');
 $app->registerHook('ImagePageAfterImageLinks', 'SEOTweaksHooksHelper', 'onImagePageAfterImageLinks');
 $app->registerHook('BeforeParserMakeImageLinkObjOptions', 'SEOTweaksHooksHelper', 'onBeforeParserMakeImageLinkObjOptions');
-
+$app->registerHook('ArticleViewHeader', 'SEOTweaksHooksHelper', 'onArticleViewHeader');
 
 // messages
 $app->registerExtensionMessageFile('SEOTweaks', $dir . 'SEOTweaks.i18n.php');

--- a/extensions/wikia/SEOTweaks/SEOTweaksHooksHelper.class.php
+++ b/extensions/wikia/SEOTweaks/SEOTweaksHooksHelper.class.php
@@ -105,18 +105,14 @@ class SEOTweaksHooksHelper extends WikiaModel {
 		$title = $article->getTitle();
 		if (! $title->exists() ) {
 		    
-			$dbr = $this->wf->GetDB(DB_SLAVE);
+			$dbr = $this->wf->GetDB( DB_SLAVE );
 			$sql = sprintf( 'SELECT page_title FROM page WHERE page_title REGEXP "^%s[[:punct:]]+" ORDER BY CHAR_LENGTH( page_title ) LIMIT 1', $title->getDBKey() );
 			$result = $dbr->query( $sql );
 			
 			if ( $row = $dbr->fetchObject( $result ) ) {
 				$title = Title::newFromText( $row->page_title );
-				if ( $title ) {
-					$url = $title->getFullUrl();
-					
-					$this->wg->Out->redirect( $url );
-				    $outputDone = true;
-				}
+				$this->wg->Out->redirect( $title->getFullUrl() );
+			    $outputDone = true;
 			}
 		}
 		return true;

--- a/extensions/wikia/SEOTweaks/SEOTweaksHooksHelper.class.php
+++ b/extensions/wikia/SEOTweaks/SEOTweaksHooksHelper.class.php
@@ -9,6 +9,12 @@
 
 class SEOTweaksHooksHelper extends WikiaModel {
 	const DELETED_PAGES_STATUS_CODE = 410;
+	
+	/**
+	 * List of hosts associated with external sharing services
+	 * @var unknown_type
+	 */
+	const SHARING_HOSTS_REGEX = '/\.(facebook)|(twitter)|(google)\./is';
 
 	/**
 	 * @author mech
@@ -103,7 +109,10 @@ class SEOTweaksHooksHelper extends WikiaModel {
 	public function onArticleViewHeader( &$article, &$outputDone, &$pcache )
 	{
 		$title = $article->getTitle();
-		if (! $title->exists() ) {
+		if ( ( ! $title->exists() ) 
+			&& ( isset( $_SERVER['HTTP_REFERER'] ) ) 
+			&& preg_match( self::SHARING_HOSTS_REGEX, parse_url( $_SERVER['HTTP_REFERER'], PHP_URL_HOST ) ) 
+		    ) {
 		    
 			$dbr = $this->wf->GetDB( DB_SLAVE );
 			$sql = sprintf( 'SELECT page_title FROM page WHERE page_title REGEXP "^%s[[:punct:]]+" ORDER BY CHAR_LENGTH( page_title ) LIMIT 1', $title->getDBKey() );

--- a/extensions/wikia/SEOTweaks/tests/SEOTweaksTest.php
+++ b/extensions/wikia/SEOTweaks/tests/SEOTweaksTest.php
@@ -528,6 +528,9 @@ class SEOTweaksTest extends WikiaBaseTest
 		);
 	}
 	
+	/**
+	 * @covers SEOTweaksHooksHelper::onArticleViewHeader
+	 */
 	public function testOnArticleViewHeaderTitleExists()
 	{
 		$mockHelper = $this->helperMocker->setMethods( array( 'foo' ) ) // fake method required to run real methods
@@ -576,10 +579,13 @@ class SEOTweaksTest extends WikiaBaseTest
 		);
 		$this->assertFalse(
 				$outputDone,
-				'$outputDone should not be set to false by SEOTweaksHooksHelper::onArticleViewHeader unless we redirect' 
+				'$outputDone should not be set to true by SEOTweaksHooksHelper::onArticleViewHeader unless we redirect' 
 		);
 	}
 	
+	/**
+	 * @covers SEOTweaksHooksHelper::onArticleViewHeader
+	 */
     public function testOnArticleViewHeaderTitleNotExistsNoResults()
 	{
 		$mockHelper = $this->helperMocker->setMethods( array( 'foo' ) ) // fake method required to run real methods
@@ -656,7 +662,114 @@ class SEOTweaksTest extends WikiaBaseTest
 		);
 		$this->assertFalse(
 				$outputDone,
-				'$outputDone should not be set to false by SEOTweaksHooksHelper::onArticleViewHeader unless we redirect' 
+				'$outputDone should not be set to true by SEOTweaksHooksHelper::onArticleViewHeader unless we redirect' 
+		);
+	}
+	
+	/**
+	 * @covers SEOTweaksHooksHelper::onArticleViewHeader
+	 */
+    public function testOnArticleViewHeaderTitleNotExistsWithResults()
+	{
+		$mockHelper = $this->helperMocker->setMethods( array( 'foo' ) ) // fake method required to run real methods
+		                                 ->getMock();
+		
+		$mockArticle = $this->getMockBuilder( 'Article' )
+		                    ->disableOriginalConstructor()
+		                    ->setMethods( array( 'getTitle' ) )
+		                    ->getMock();
+		
+		$mockTitle = $this->getMockBuilder( 'Title' )
+		                  ->disableOriginalConstructor()
+		                  ->setMethods( array( 'exists', 'getDBKey', 'getFullUrl' ) )
+		                  ->getMock();
+		
+		$mockWrapper = $this->getMockBuilder( 'WikiaFunctionWrapper' )
+		                    ->disableOriginalConstructor()
+		                    ->setMethods( array( 'GetDB' ) )
+		                    ->getMock();
+		
+		$mockDb = $this->getMockBuilder( "DatabaseMysql" )
+		               ->disableOriginalConstructor()
+		               ->setMethods( array( 'query', 'fetchObject' ) )
+		               ->getMock();
+		
+		$mockResultWrapper = $this->getMockBuilder( 'ResultWrapper' )
+		                          ->disableOriginalConstructor()
+		                          ->getMock();
+		
+		$mockOut = $this->getMockBuilder( 'OutputPage' )
+		                ->disableOriginalConstructor()
+		                ->setMethods( array( 'redirect' ) )
+		                ->getMock();
+		
+		$outputDone = false;
+		$pcache = false;
+		
+		$dbKey = "Wanted";
+		$resultObject = (object) array( 'page_title' => "Wanted!" );
+		$fullUrl = 'http://foo.wikia.com/wiki/Wanted!';
+		
+		$mockArticle
+		    ->expects( $this->at( 0 ) )
+		    ->method ( 'getTitle' )
+		    ->will   ( $this->returnValue( $mockTitle ) )
+		;
+		$mockTitle
+		    ->expects( $this->at( 0 ) )
+		    ->method ( 'exists' )
+		    ->will   ( $this->returnValue( false ) )
+		;
+		$mockWrapper
+		    ->expects( $this->at( 0 ) )
+		    ->method ( 'getDB' )
+		    ->will   ( $this->returnValue( $mockDb ) )
+		;
+		$mockTitle
+		    ->expects( $this->at( 1 ) )
+		    ->method ( 'getDBKey' )
+		    ->will   ( $this->returnValue( $dbKey ) )
+		;
+		$mockDb
+		    ->expects( $this->at( 0 ) )
+		    ->method ( 'query' )
+		    ->with   ( 'SELECT page_title FROM page WHERE page_title REGEXP "^' . $dbKey . '[[:punct:]]+" ORDER BY CHAR_LENGTH( page_title ) LIMIT 1' )
+		    ->will   ( $this->returnValue( $mockResultWrapper ) )
+		;
+		$mockDb
+		    ->expects( $this->at( 1 ) )
+		    ->method ( 'fetchObject' )
+		    ->will   ( $this->returnValue( $resultObject ) )
+		;
+		$mockTitle
+		    ->expects( $this->at( 2 ) )
+		    ->method ( 'getFullUrl' )
+		    ->will   ( $this->returnValue( $fullUrl ) )
+		;
+		$mockOut
+		    ->expects( $this->at( 0 ) )
+		    ->method ( 'redirect' )
+		    ->with   ( $fullUrl )
+		;
+		
+		$reflWf = new ReflectionProperty( 'WikiaObject', 'wf' );
+		$reflWf->setAccessible( true );
+		$reflWf->setValue( $mockHelper, $mockWrapper );
+		
+		$reflWg = new ReflectionProperty( 'WikiaObject', 'wg' );
+		$reflWg->setAccessible( true );
+		$reflWg->setValue( $mockHelper, (object) array( 'Out' => $mockOut ) );
+		
+		$this->mockClass( 'Title', $mockTitle );
+		$this->proxyClass( 'Title', $mockTitle, 'newFromText' );
+		
+		$this->assertTrue(
+				$mockHelper->onArticleViewHeader( $mockArticle, $outputDone, $pcache),
+				'SEOTweaksHooksHelper::onArticleViewHeader should always return true'
+		);
+		$this->assertTrue(
+				$outputDone,
+				'$outputDone should be set to true by SEOTweaksHooksHelper::onArticleViewHeader if we redirect' 
 		);
 	}
 	

--- a/extensions/wikia/SEOTweaks/tests/SEOTweaksTest.php
+++ b/extensions/wikia/SEOTweaks/tests/SEOTweaksTest.php
@@ -528,4 +528,56 @@ class SEOTweaksTest extends WikiaBaseTest
 		);
 	}
 	
+	public function testOnArticleViewHeaderTitleExists()
+	{
+		$mockHelper = $this->helperMocker->setMethods( array( 'foo' ) ) // fake method required to run real methods
+		                                 ->getMock();
+		
+		$mockArticle = $this->getMockBuilder( 'Article' )
+		                    ->disableOriginalConstructor()
+		                    ->setMethods( array( 'getTitle' ) )
+		                    ->getMock();
+		
+		$mockTitle = $this->getMockBuilder( 'Title' )
+		                  ->disableOriginalConstructor()
+		                  ->setMethods( array( 'exists' ) )
+		                  ->getMock();
+		
+		$mockWrapper = $this->getMockBuilder( 'WikiaFunctionWrapper' )
+		                    ->disableOriginalConstructor()
+		                    ->setMethods( array( 'GetDB' ) )
+		                    ->getMock();
+		
+		$outputDone = false;
+		$pcache = false;
+		
+		$mockArticle
+		    ->expects( $this->at( 0 ) )
+		    ->method ( 'getTitle' )
+		    ->will   ( $this->returnValue( $mockTitle ) )
+		;
+		$mockTitle
+		    ->expects( $this->at( 0 ) )
+		    ->method ( 'exists' )
+		    ->will   ( $this->returnValue( true ) )
+		;
+		$mockWrapper
+		    ->expects( $this->never() )
+		    ->method ( 'getDB' )
+		;
+		
+		$reflWf = new ReflectionProperty( 'WikiaObject', 'wf' );
+		$reflWf->setAccessible( true );
+		$reflWf->setValue( $mockHelper, $mockWrapper );
+		
+		$this->assertTrue(
+				$mockHelper->onArticleViewHeader( $mockArticle, $outputDone, $pcache),
+				'SEOTweaksHooksHelper::onArticleViewHeader should always return true'
+		);
+		$this->assertFalse(
+				$outputDone,
+				'$outputDone should not be set to false by SEOTweaksHooksHelper::onArticleViewHeader unless we redirect' 
+		);
+	}
+	
 }

--- a/extensions/wikia/SEOTweaks/tests/SEOTweaksTest.php
+++ b/extensions/wikia/SEOTweaks/tests/SEOTweaksTest.php
@@ -583,6 +583,61 @@ class SEOTweaksTest extends WikiaBaseTest
 		);
 	}
 	
+    /**
+	 * @covers SEOTweaksHooksHelper::onArticleViewHeader
+	 */
+	public function testOnArticleViewHeaderTitleExistsNonShareReferrer()
+	{
+		$mockHelper = $this->helperMocker->setMethods( array( 'foo' ) ) // fake method required to run real methods
+		                                 ->getMock();
+		
+		$mockArticle = $this->getMockBuilder( 'Article' )
+		                    ->disableOriginalConstructor()
+		                    ->setMethods( array( 'getTitle' ) )
+		                    ->getMock();
+		
+		$mockTitle = $this->getMockBuilder( 'Title' )
+		                  ->disableOriginalConstructor()
+		                  ->setMethods( array( 'exists' ) )
+		                  ->getMock();
+		
+		$mockWrapper = $this->getMockBuilder( 'WikiaFunctionWrapper' )
+		                    ->disableOriginalConstructor()
+		                    ->setMethods( array( 'GetDB' ) )
+		                    ->getMock();
+		
+		$outputDone = false;
+		$pcache = false;
+		
+		$mockArticle
+		    ->expects( $this->at( 0 ) )
+		    ->method ( 'getTitle' )
+		    ->will   ( $this->returnValue( $mockTitle ) )
+		;
+		$mockTitle
+		    ->expects( $this->at( 0 ) )
+		    ->method ( 'exists' )
+		    ->will   ( $this->returnValue( false ) )
+		;
+		$mockWrapper
+		    ->expects( $this->never() )
+		    ->method ( 'getDB' )
+		;
+		
+		$reflWf = new ReflectionProperty( 'WikiaObject', 'wf' );
+		$reflWf->setAccessible( true );
+		$reflWf->setValue( $mockHelper, $mockWrapper );
+		
+		$this->assertTrue(
+				$mockHelper->onArticleViewHeader( $mockArticle, $outputDone, $pcache),
+				'SEOTweaksHooksHelper::onArticleViewHeader should always return true'
+		);
+		$this->assertFalse(
+				$outputDone,
+				'$outputDone should not be set to true by SEOTweaksHooksHelper::onArticleViewHeader unless we redirect' 
+		);
+	}
+	
 	/**
 	 * @covers SEOTweaksHooksHelper::onArticleViewHeader
 	 */
@@ -619,6 +674,7 @@ class SEOTweaksTest extends WikiaBaseTest
 		$pcache = false;
 		
 		$dbKey = "Wanted";
+		$_SERVER['HTTP_REFERER'] = 'http://www.facebook.com'; 
 		
 		$mockArticle
 		    ->expects( $this->at( 0 ) )
@@ -707,6 +763,7 @@ class SEOTweaksTest extends WikiaBaseTest
 		$pcache = false;
 		
 		$dbKey = "Wanted";
+		$_SERVER['HTTP_REFERER'] = 'http://www.facebook.com';
 		$resultObject = (object) array( 'page_title' => "Wanted!" );
 		$fullUrl = 'http://foo.wikia.com/wiki/Wanted!';
 		

--- a/extensions/wikia/ShareButtons/ShareButton.class.php
+++ b/extensions/wikia/ShareButtons/ShareButton.class.php
@@ -48,11 +48,16 @@ abstract class ShareButton {
 
 	/**
 	 * Return absolute URL to a page to be shared (uses wgTitle)
-	 *
+	 * The path component of the URL is urlencoded to prevent confusion between sharing services
 	 * @return string URL to be shared
 	 */
 	protected function getURL() {
-		return $this->title->getFullUrl();
+		$path = $this->title->getLocalUrl();
+		$paths = explode( '/', $path );
+		foreach ( $paths as $index => $section ) {
+			$paths[$index] = urlencode( $section );
+		}
+		return str_replace( $path, implode( '/', $paths ), $this->title->getFullUrl() );
 	}
 
 	/**

--- a/extensions/wikia/ShareButtons/ShareButton.class.php
+++ b/extensions/wikia/ShareButtons/ShareButton.class.php
@@ -4,37 +4,32 @@
  * Abstract class for various social networks providing share buttons
  */
 
-abstract class ShareButton {
-
-	protected $app;
+abstract class ShareButton extends WikiaObject {
+	/**
+	 * The title object whose URL we will be using to share. Defaults to wgTitle.
+	 * @var Title
+	 */
 	protected $title;
 
 	/**
 	 * Return instance of share button for given social network
 	 *
-	 * @param WikiaApp $app application instance
 	 * @param string $name social networks name
+	 * @param Title|null $title the title whose URL we will share 
 	 * @return ShareButton object instance
 	 */
-	static public function factory(WikiaApp $app, $name) {
+	static public function factory( $name, $title = null ) {
 		$className = 'ShareButton' . $name;
-		$instance = null;
-
-		if (class_exists($className)) {
-			$instance = F::build($className, array('app' => $app));
+		if ( class_exists( $className ) ) {
+			return new $className( $title instanceof Title ? $title : F::app()->wg->Title );
 		}
-
-		return $instance;
 	}
 
 	/**
 	 * Use ShareButton::factory instead
 	 */
-	public function __construct(WikiaApp $app) {
-		$this->app = $app;
-
-		// use the current title
-		$this->title = $this->app->wg->Title;
+	public function __construct( Title $title ) {
+		$this->title = $title;
 	}
 
 	/**

--- a/extensions/wikia/ShareButtons/providers/ShareButtonFacebook.class.php
+++ b/extensions/wikia/ShareButtons/providers/ShareButtonFacebook.class.php
@@ -2,10 +2,6 @@
 
 class ShareButtonFacebook extends ShareButton {
 
-	public function __construct(WikiaApp $app) {
-		parent::__construct($app);
-	}
-
 	// AssetsManager compliant path to assets
 	public function getAssets() {
 		return array( '//extensions/wikia/ShareButtons/js/ShareButtonFacebook.js' );

--- a/extensions/wikia/ShareButtons/providers/ShareButtonGooglePlus.class.php
+++ b/extensions/wikia/ShareButtons/providers/ShareButtonGooglePlus.class.php
@@ -2,10 +2,6 @@
 
 class ShareButtonGooglePlus extends ShareButton {
 
-	public function __construct(WikiaApp $app) {
-		parent::__construct($app);
-	}
-
 	// AssetsManager compliant path to assets
 	public function getAssets() {
 		return array( '//extensions/wikia/ShareButtons/js/ShareButtonGooglePlus.js' );

--- a/extensions/wikia/ShareButtons/providers/ShareButtonMail.class.php
+++ b/extensions/wikia/ShareButtons/providers/ShareButtonMail.class.php
@@ -2,10 +2,6 @@
 
 class ShareButtonMail extends ShareButton {
 
-	public function __construct(WikiaApp $app) {
-		parent::__construct($app);
-	}
-
 	// AssetsManager compliant path to assets
 	public function getAssets() {
 		return array();

--- a/extensions/wikia/ShareButtons/providers/ShareButtonTwitter.class.php
+++ b/extensions/wikia/ShareButtons/providers/ShareButtonTwitter.class.php
@@ -2,10 +2,6 @@
 
 class ShareButtonTwitter extends ShareButton {
 
-	public function __construct(WikiaApp $app) {
-		parent::__construct($app);
-	}
-
 	// AssetsManager compliant path to assets
 	public function getAssets() {
 		return array( '//extensions/wikia/ShareButtons/js/ShareButtonTwitter.js' );

--- a/extensions/wikia/ShareButtons/tests/ShareButtonsTest.php
+++ b/extensions/wikia/ShareButtons/tests/ShareButtonsTest.php
@@ -48,5 +48,40 @@ class ShareButtonsTest extends WikiaBaseTest {
 		$this->assertContains('data-size="tall"', $box);
 		$this->assertContains('data-href="' . htmlspecialchars($url) . '"', $box);
 	}
+	
+	public function testUrlSpecialCharsAreEncoded() {
+		$mockTitle = $this->getMockBuilder( 'Title' )
+		                  ->disableOriginalConstructor()
+		                  ->getMock();
+		
+		$titleUrlString = '/wiki/ParŽnt_Page?/This_is_a_tŽst!';
+		
+		$mockTitle
+		    ->expects    ( $this->any() )
+		    ->method     ( 'getLocalUrl' )
+		    ->will       ( $this->returnValue( $titleUrlString ) )
+		;
+		$mockTitle
+		    ->expects    ( $this->any() )
+		    ->method     ( 'getFullUrl' )
+		    ->will       ( $this->returnValue( 'http://foo.wikia.com' . $titleUrlString ) )
+		;
+		
+		$this->mockGlobalVariable('wgServer', 'http://foo.wikia.com' );
+	    $this->mockGlobalVariable('wgTitle', $mockTitle);
+	    $this->mockApp();
+	    $twitter = F::build('ShareButton', array('app' => $this->app, 'id' => 'Twitter'), 'factory');
+	    
+        $getUrl = new ReflectionMethod( 'ShareButton', 'getUrl' );
+        $getUrl->setAccessible( true );
+        $getUrlString = $getUrl->invoke( $twitter );
+        
+	    $this->assertContains(
+	    		"/wiki/Par%8Ent_Page%3F/This_is_a_t%8Est%21",
+	    		$getUrlString,
+	    		'An instance of ShareButton should URL-encode path names.'
+		);
+	    
+	}
 
 }

--- a/extensions/wikia/ShareButtons/tests/ShareButtonsTest.php
+++ b/extensions/wikia/ShareButtons/tests/ShareButtonsTest.php
@@ -11,13 +11,43 @@ class ShareButtonsTest extends WikiaBaseTest {
 		$this->mockApp();
 	}
 
-	public function testFactory() {
-		$facebook = F::build('ShareButton', array('app' => $this->app, 'id' => 'Facebook'), 'factory');
+	public function testFactoryWithDefaults() {
+		$facebook = ShareButton::factory( 'Facebook' );
 		$this->assertInstanceOf('ShareButtonFacebook', $facebook);
+		
+		$titleRefl = new ReflectionProperty( 'ShareButton', 'title' );
+		$titleRefl->setAccessible( true );
+		
+		$this->assertEquals(
+				Title::newMainPage(),
+				$titleRefl->getValue( $facebook )
+		);
+	}
+	
+	public function testFactoryWithTitle() {
+		$mockTitle = $this->getMockBuilder( 'Title' )
+		                  ->disableOriginalConstructor()
+		                  ->getMock();
+		
+		$twitter = ShareButton::factory( 'Twitter', $mockTitle );
+		$this->assertInstanceOf('ShareButtonTwitter', $twitter);
+		
+		$titleRefl = new ReflectionProperty( 'ShareButton', 'title' );
+		$titleRefl->setAccessible( true );
+		$titleResult = $titleRefl->getValue( $twitter );
+		
+		$this->assertEquals(
+				$mockTitle,
+				$titleResult
+		);
+		$this->assertNotEquals(
+				Title::newMainPage(),
+				$titleResult
+		);
 	}
 
 	public function testFacebookShareBox() {
-		$facebook = F::build('ShareButton', array('app' => $this->app, 'id' => 'Facebook'), 'factory');
+		$facebook = ShareButton::factory( 'Facebook' );
 
 		$box = $facebook->getShareBox();
 		$url = $this->app->wg->Title->getFullUrl();
@@ -28,7 +58,7 @@ class ShareButtonsTest extends WikiaBaseTest {
 	}
 
 	public function testTwitterShareBox() {
-		$twitter = F::build('ShareButton', array('app' => $this->app, 'id' => 'Twitter'), 'factory');
+		$twitter = ShareButton::factory( 'Twitter' );
 
 		$box = $twitter->getShareBox();
 		$url = $this->app->wg->Title->getFullUrl();
@@ -39,7 +69,7 @@ class ShareButtonsTest extends WikiaBaseTest {
 	}
 
 	public function testGooglePlusShareBox() {
-		$googleplus = F::build('ShareButton', array('app' => $this->app, 'id' => 'GooglePlus'), 'factory');
+		$googleplus = ShareButton::factory( 'GooglePlus' );
 
 		$box = $googleplus->getShareBox();
 		$url = $this->app->wg->Title->getFullUrl();
@@ -70,7 +100,7 @@ class ShareButtonsTest extends WikiaBaseTest {
 		$this->mockGlobalVariable('wgServer', 'http://foo.wikia.com' );
 	    $this->mockGlobalVariable('wgTitle', $mockTitle);
 	    $this->mockApp();
-	    $twitter = F::build('ShareButton', array('app' => $this->app, 'id' => 'Twitter'), 'factory');
+	    $twitter = ShareButton::factory( 'Twitter' );
 	    
         $getUrl = new ReflectionMethod( 'ShareButton', 'getUrl' );
         $getUrl->setAccessible( true );

--- a/skins/oasis/js/SharingToolbar/SharingToolbarLoader.js
+++ b/skins/oasis/js/SharingToolbar/SharingToolbarLoader.js
@@ -12,7 +12,8 @@ jQuery(function( $ ) {
 				scripts: 'sharingtoolbar_js',
 				templates: [{
 					controllerName: 'SharingToolbarController',
-					methodName: 'Index'
+					methodName: 'Index',
+					params: {pagename: window.mw.config.get('wgPageName')}
 				}]
 			}),
 			// Can't load this with Wikia.getMultiTypePackage because it needs params :(

--- a/skins/oasis/modules/SharingToolbarController.class.php
+++ b/skins/oasis/modules/SharingToolbarController.class.php
@@ -86,6 +86,14 @@ class SharingToolbarController extends WikiaController {
 	}
 
 	public function index() {
+		$app = F::app();
+		$titleString = $this->getVal( 'pagename' );
+		Wikia::Log( __METHOD__, '', $titleString );
+		$newTitle = Title::newFromText( $titleString );
+		if ( $newTitle !== null ) {
+			$app->wg->Title = $newTitle;
+		}
+
 		$this->response->setVal( 'shareButtons', self::getShareButtons() );
 	}
 

--- a/skins/oasis/modules/SharingToolbarController.class.php
+++ b/skins/oasis/modules/SharingToolbarController.class.php
@@ -52,13 +52,12 @@ class SharingToolbarController extends WikiaController {
 		return $ret;
 	}
 
-	public function getShareButtons() {
+	public function getShareButtons( Title $title ) {
 		if ( !self::$shareButtons ) {
-			$app = F::app();
 			$shareButtons = array();
 
 			foreach( self::$shareNetworks as $network ) {
-				$shareButton = F::build( 'ShareButton', array( $app, $network ), 'factory' );
+				$shareButton = ShareButton::factory( $network, $title );
 
 				if ( $shareButton instanceof ShareButton ) {
 					$shareButtons[] = $shareButton;
@@ -86,15 +85,9 @@ class SharingToolbarController extends WikiaController {
 	}
 
 	public function index() {
-		$app = F::app();
 		$titleString = $this->getVal( 'pagename' );
-		Wikia::Log( __METHOD__, '', $titleString );
-		$newTitle = Title::newFromText( $titleString );
-		if ( $newTitle !== null ) {
-			$app->wg->Title = $newTitle;
-		}
-
-		$this->response->setVal( 'shareButtons', self::getShareButtons() );
+		$title = $titleString !== null ? Title::newFromText( $titleString ) : $this->wg->Title;
+		$this->response->setVal( 'shareButtons', self::getShareButtons( $title ) );
 	}
 
 	// Returning false will prevent the button from being shown


### PR DESCRIPTION
This issue addresses a problem with external services, where our URLs do not follow the guidelines of percent-encoding RFC 3986 reserved characters.

For example, if you attempt to use a share button on a page where the URL is something like, "Wanted!", Twitter will not recognize the exclamation point when creating the URL.

The first step of fixing this problem is to update share buttons to URL-encode those reserved characters. This is a change to the ShareButton abstract class.

The second step of fixing this problem is to register a hook in the SEOTweaksHelper that, for a title that does not exist, checks the page table for regular expression matches that include any punctuation after the provided title. _I have tested this on LyricWiki on dev, and it seems to work pretty well._ However, I'd like some review and signoff from @owend, @moliwikia, or @psychonaut to make sure this kind of feature wouldn't know over the site. Some of my thoughts for mitigating this include checking the referrer, or simply disabling this feature on sufficiently large wikis.

This pull request also addresses a defect where we were not providing the appropriate URL for share buttons. All share buttons were linking to the main page of a wiki instead of the article for the page you were on. So if this pull request is reject, there are still a few commits we'll have to cherry-pick over :)
