### PR TITLE
bugid: 94988 -- refactor ShareButton class to fix fatal on preview

### DIFF
--- a/extensions/wikia/ShareButtons/ShareButton.class.php
+++ b/extensions/wikia/ShareButtons/ShareButton.class.php
@@ -10,6 +10,12 @@ abstract class ShareButton extends WikiaObject {
 	 * @var Title
 	 */
 	protected $title;
+	
+	/**
+	 * Stores assets for a given button type
+	 * @var array
+	 */
+	protected static $assets = array();
 
 	/**
 	 * Return instance of share button for given social network
@@ -24,9 +30,24 @@ abstract class ShareButton extends WikiaObject {
 			return new $className( $title instanceof Title ? $title : F::app()->wg->Title );
 		}
 	}
+	
+	/**
+	 * Returns an array containing assets for a provided network
+	 * Will return an empty array if the class name is incorrect
+	 * @param string $name The name of the network
+	 * @return array
+	 */
+	static public function getAssetsForNetwork( $name ) {
+	    $className = 'ShareButton' . $name;
+		if ( class_exists( $className ) ) {
+			return $className::getAssets();
+		}
+		return array();
+	}
 
 	/**
 	 * Use ShareButton::factory instead
+	 * @param Title $title
 	 */
 	public function __construct( Title $title ) {
 		$this->title = $title;
@@ -34,7 +55,6 @@ abstract class ShareButton extends WikiaObject {
 
 	/**
 	 * Return color scheme name to be used based on SASS color calculation
-	 *
 	 * @return string color scheme to be used ("light" or "dark")
 	 */
 	protected function getColorScheme() {
@@ -54,19 +74,37 @@ abstract class ShareButton extends WikiaObject {
 		}
 		return str_replace( $path, implode( '/', $paths ), $this->title->getFullUrl() );
 	}
+	
+	/**
+	 * Return protected static assets from inherited class. By default this is an empty array.
+	 * Child classes can specify their own value for this property.
+	 * @return array
+	 */
+	public static function getAssets() {
+		return static::$assets;
+	}
 
 	/**
 	 * Return HTML rendering share box (with votes count)
+	 * @return string
 	 */
-	abstract public function getShareBox();
+	public function getShareBox() {
+		return '';
+	}
 
 	/**
 	 * Return HTML rendering share button
+	 * @return string
 	 */
-	abstract public function getShareButton();
+	public function getShareButton() {
+		return '';
+	}
 
 	/**
 	 * Return HTML rendering share link
+	 * @return string
 	 */
-	abstract public function getShareLink();
+	public function getShareLink() {
+		return '';
+	}
 }

--- a/extensions/wikia/ShareButtons/providers/ShareButtonFacebook.class.php
+++ b/extensions/wikia/ShareButtons/providers/ShareButtonFacebook.class.php
@@ -2,15 +2,17 @@
 
 class ShareButtonFacebook extends ShareButton {
 
-	// AssetsManager compliant path to assets
-	public function getAssets() {
-		return array( '//extensions/wikia/ShareButtons/js/ShareButtonFacebook.js' );
-	}
+    /**
+	 * AssetsManager compliant path to assets
+	 * @var array
+	 */
+	protected static $assets =  array( '//extensions/wikia/ShareButtons/js/ShareButtonFacebook.js' );
 
 	/**
 	 * Return HTML rendering share box (with votes count)
 	 *
 	 * @see https://developers.facebook.com/docs/reference/plugins/like/
+	 * @return string
 	 */
 	public function getShareBox() {
 		global $wgNoExternals;
@@ -28,19 +30,5 @@ class ShareButtonFacebook extends ShareButton {
 		), ' ');
 
 		return $html;
-	}
-
-	/**
-	 * Return HTML rendering share button
-	 */
-	public function getShareButton() {
-
-	}
-
-	/**
-	 * Return HTML rendering share link
-	 */
-	public function getShareLink() {
-
 	}
 }

--- a/extensions/wikia/ShareButtons/providers/ShareButtonGooglePlus.class.php
+++ b/extensions/wikia/ShareButtons/providers/ShareButtonGooglePlus.class.php
@@ -2,15 +2,17 @@
 
 class ShareButtonGooglePlus extends ShareButton {
 
-	// AssetsManager compliant path to assets
-	public function getAssets() {
-		return array( '//extensions/wikia/ShareButtons/js/ShareButtonGooglePlus.js' );
-	}
+	/**
+	 * AssetsManager compliant path to assets
+	 * @var array
+	 */
+	protected static $assets = array( '//extensions/wikia/ShareButtons/js/ShareButtonGooglePlus.js' );
 
 	/**
 	 * Return HTML rendering share box (with votes count)
 	 *
 	 * @see http://www.google.com/intl/en/webmasters/+1/button/index.html
+	 * @return string
 	 */
 	public function getShareBox() {
 		$html = Xml::element('div', array(
@@ -20,19 +22,5 @@ class ShareButtonGooglePlus extends ShareButton {
 		), ' ');
 
 		return $html;
-	}
-
-	/**
-	 * Return HTML rendering share button
-	 */
-	public function getShareButton() {
-
-	}
-
-	/**
-	 * Return HTML rendering share link
-	 */
-	public function getShareLink() {
-
 	}
 }

--- a/extensions/wikia/ShareButtons/providers/ShareButtonMail.class.php
+++ b/extensions/wikia/ShareButtons/providers/ShareButtonMail.class.php
@@ -1,30 +1,11 @@
 <?php
 
 class ShareButtonMail extends ShareButton {
-
-	// AssetsManager compliant path to assets
-	public function getAssets() {
-		return array();
-	}
-
 	/**
 	 * Return HTML rendering share box (with votes count)
+	 * @return string
 	 */
 	public function getShareBox() {
 		return F::app()->renderView( 'ShareButtonMail', 'Button' );
-	}
-
-	/**
-	 * Return HTML rendering share button
-	 */
-	public function getShareButton() {
-
-	}
-
-	/**
-	 * Return HTML rendering share link
-	 */
-	public function getShareLink() {
-
 	}
 }

--- a/extensions/wikia/ShareButtons/providers/ShareButtonTwitter.class.php
+++ b/extensions/wikia/ShareButtons/providers/ShareButtonTwitter.class.php
@@ -2,15 +2,17 @@
 
 class ShareButtonTwitter extends ShareButton {
 
-	// AssetsManager compliant path to assets
-	public function getAssets() {
-		return array( '//extensions/wikia/ShareButtons/js/ShareButtonTwitter.js' );
-	}
+	/**
+	 * AssetsManager compliant path to assets
+	 * @var array
+	 */
+	protected static $assets = array( '//extensions/wikia/ShareButtons/js/ShareButtonTwitter.js' );
 
 	/**
 	 * Return HTML rendering share box (with votes count)
 	 *
 	 * @see http://twitter.com/goodies/tweetbutton
+	 * @return string
 	 */
 	public function getShareBox() {
 		global $wgNoExternals;
@@ -28,17 +30,4 @@ class ShareButtonTwitter extends ShareButton {
 		return $html;
 	}
 
-	/**
-	 * Return HTML rendering share button
-	 */
-	public function getShareButton() {
-
-	}
-
-	/**
-	 * Return HTML rendering share link
-	 */
-	public function getShareLink() {
-
-	}
 }

--- a/skins/oasis/modules/SharingToolbarController.class.php
+++ b/skins/oasis/modules/SharingToolbarController.class.php
@@ -74,8 +74,8 @@ class SharingToolbarController extends WikiaController {
 		if ( !self::$assets ) {
 			$assets = array();
 
-			foreach( self::getShareButtons() as $shareButton ) {
-				$assets = array_merge( $assets, (array) $shareButton->getAssets() );
+            foreach ( self::$shareNetworks as $network ) {
+				$assets = array_merge( $assets, ShareButton::getAssetsForNetwork( $network ) );
 			}
 
 			self::$assets = array_unique( $assets );


### PR DESCRIPTION
SharingToolbarController was constructing ShareButton instances to access what could have been a static property on each child. Because we want instantiated logic to be dependent upon a Title instance, and since the getAssets call should be relatively stateless, I have refactored the class hierarchy a little bit. At the same time, I've removed the assumption that a couple of generally unused rendering functions must be implemented by their children, since this doesn't make a great deal of OO sense. 

This fix addresses a P2 defect on preview.
