### PR TITLE
bugid-86845: For some reason, removing this animation allows the event f...

### DIFF
--- a/extensions/wikia/MiniEditor/js/Wall/Wall.Animations.js
+++ b/extensions/wikia/MiniEditor/js/Wall/Wall.Animations.js
@@ -56,7 +56,9 @@ MiniEditor.Wall.Animations = {
 				}
 
 			} else {
-				wikiaEditor.fire('editorAfterActivated');
+				element.animate(animation, function() {
+					wikiaEditor.fire('editorAfterActivated');
+				});
 			}
 		}
 	},

--- a/extensions/wikia/MiniEditor/js/Wall/Wall.Animations.js
+++ b/extensions/wikia/MiniEditor/js/Wall/Wall.Animations.js
@@ -56,9 +56,7 @@ MiniEditor.Wall.Animations = {
 				}
 
 			} else {
-				element.animate(animation, function() {
-					wikiaEditor.fire('editorAfterActivated');
-				});
+				wikiaEditor.fire('editorAfterActivated');
 			}
 		}
 	},

--- a/extensions/wikia/MiniEditor/js/Wall/Wall.NewMessageForm.js
+++ b/extensions/wikia/MiniEditor/js/Wall/Wall.NewMessageForm.js
@@ -37,9 +37,6 @@ MiniEditor.Wall.NewMessageForm = $.createClass(Wall.settings.classBindings.newMe
 						wikiaEditor.getEditbox()
 							.placeholder()
 							.triggerHandler('focus.placeholder');
-						self.messageBody.autoResize({
-							min: 200
-						});
 					}
 					if ($.browser.msie) {
 						self.messageTitle.keydown(function(e) {
@@ -48,7 +45,14 @@ MiniEditor.Wall.NewMessageForm = $.createClass(Wall.settings.classBindings.newMe
 								wikiaEditor.editorFocus();
 							}
 						});
-					}			
+					}
+				},
+				editorAfterActivated: function( event, wikiaEditor ) {
+					if (!MiniEditor.ckeditorEnabled) {
+						self.messageBody.autoResize({
+							min: 200
+						});
+					}
 				}
 			}
 		}, event);


### PR DESCRIPTION
...ire to happen

https://wikia.fogbugz.com/default.asp?86845
You must disable visual editing to trigger this bug.

I don't understand why, but the textarea still animates its height when this animation is removed. The code in the animation callback wasn't being run, so the "editorAfterActivated" event wasn't firing and the buttons weren't becoming enabled. 

Hoping for a review from Kyle Florence as he probably knows more about this code than I do.
