### PR TITLE
Wikia tracker changes bugid 45483

### DIFF
--- a/extensions/3rdparty/tabber/tabber.js
+++ b/extensions/3rdparty/tabber/tabber.js
@@ -441,9 +441,9 @@ tabberObj.prototype.navClearActive = function(tabberIndex)
 };
 
 
-tabberObj.prototype.clickTrackingHandler = function(e) {
-	var node = $(e.target);
-	var button = e.button;
+tabberObj.prototype.clickTrackingHandler = function(event) {
+	var node = $(event.target);
+	var button = event.button;
 	var startTime = new Date();
 
 	if (node.closest('.tabbernav').length > 0) {
@@ -458,7 +458,8 @@ tabberObj.prototype.clickTrackingHandler = function(e) {
 				ga_label: 'tab',
 				ga_value: tabIndex
 			},
-			'internal'
+			'internal',
+			event
 		);
 	} else if (node.is('img') && node.hasParent('a')) {
 		var url = node.closest('a').attr('href');
@@ -468,10 +469,10 @@ tabberObj.prototype.clickTrackingHandler = function(e) {
 				ga_category: 'Tabber',
 				ga_action: WikiaTracker.ACTIONS.CLICK_LINK_IMAGE,
 				ga_label: 'image',
-				href:url,
-				button: button
+				href:url
 			},
-			'internal'
+			'internal',
+			event
 		);
 	} else if (node.is('a') || node.hasParent('a')) {
 		var url = node.closest('a').attr('href');
@@ -481,10 +482,10 @@ tabberObj.prototype.clickTrackingHandler = function(e) {
 				ga_category: 'Tabber',
 				ga_action: WikiaTracker.ACTIONS.CLICK_LINK_TEXT,
 				ga_label: 'content',
-				href:url,
-				button: button
+				href:url
 			},
-			'internal'
+			'internal',
+			event
 		);
 	}
 

--- a/extensions/wikia/ArticleComments/js/ArticleComments.wikiamobile.js
+++ b/extensions/wikia/ArticleComments/js/ArticleComments.wikiamobile.js
@@ -254,7 +254,8 @@ require(['loader', 'toast', 'modal', 'events', 'track', 'JSMessages'], function(
 			track.event('article-comments', track.IMAGE_LINK, {
 				label: 'avatar',
 				href: t.parentElement.href
-			});
+			},
+			ev);
 		}
 	});
 

--- a/extensions/wikia/ImageLightbox/ImageLightbox.js
+++ b/extensions/wikia/ImageLightbox/ImageLightbox.js
@@ -237,7 +237,8 @@ var ImageLightbox = {
 						'ga_value':eventValue,
 						'video_title':imageName
 					},
-					'both'
+					'both',
+					ev
 				);
 			}
 

--- a/extensions/wikia/Search/js/WikiaSearch.wikiamobile.js
+++ b/extensions/wikia/Search/js/WikiaSearch.wikiamobile.js
@@ -34,7 +34,8 @@ require(['loader', 'events', 'topbar', 'track'], function(loader, events, topbar
 			if (label) track.event('search', track.CLICK, {
 				label: label,
 				href: t.href
-			});
+			},
+			ev);
 		});
     }
 

--- a/extensions/wikia/SiteWideMessages/SpecialSiteWideMessages.js
+++ b/extensions/wikia/SiteWideMessages/SpecialSiteWideMessages.js
@@ -19,7 +19,7 @@ $(document).ready(function(){
 			impTrackObj,
 			'internal'
 		);
-		$( this ).find( 'p a' ).click( function () {
+		$( this ).find( 'p a' ).click( function (e) {
 			var trackObj = {
 				ga_category: 'sitewidemessages',
 				ga_action: WikiaTracker.ACTIONS.CLICK_LINK_TEXT,
@@ -30,7 +30,8 @@ $(document).ready(function(){
 			WikiaTracker.trackEvent(
 				'trackingevent',
 				trackObj,
-				'internal'
+				'internal',
+				e
 			);
 		} );
 	} );

--- a/extensions/wikia/SiteWideMessages/js/SiteWideMessages.tracking.js
+++ b/extensions/wikia/SiteWideMessages/js/SiteWideMessages.tracking.js
@@ -26,7 +26,7 @@ jQuery( document ).ready( function ( $ ) {
 	}
 	$notificationsArea.find( 'div[data-type="5"]' ).each( function () {
 		var msgId = parseInt( $( this ).attr( 'id' ).substr( 4 ) );
-		$( this ).find( 'p a' ).click( function () {
+		$( this ).find( 'p a' ).click( function (e) {
 			var trackObj = {
 				ga_category: 'sitewidemessages',
 				ga_action: WikiaTracker.ACTIONS.CLICK_LINK_TEXT,
@@ -37,7 +37,8 @@ jQuery( document ).ready( function ( $ ) {
 			WikiaTracker.trackEvent(
 				'trackingevent',
 				trackObj,
-				'internal'
+				'internal',
+				e
 			);
 		} );
 	} );

--- a/extensions/wikia/SpecialContact2/SpecialContact.js
+++ b/extensions/wikia/SpecialContact2/SpecialContact.js
@@ -11,25 +11,25 @@ var SpecialContact = {
 			SpecialContact.trackClick( trackLabel, trackUrl );
 		} );
 
-		$( '#SpecialContactFooterPicker a' ).click( function () {
+		$( '#SpecialContactFooterPicker a' ).click( function (e) {
 			var	trackLabel = 'footer-picker',
 				trackUrl = $( this ).attr( 'href' );
-			SpecialContact.trackClick( trackLabel, trackUrl );
+			SpecialContact.trackClick( trackLabel, trackUrl, e );
 		} );
-		$( '#SpecialContactFooterNoForm a' ).click( function () {
+		$( '#SpecialContactFooterNoForm a' ).click( function (e) {
 			var	trackLabel = 'footer-noform',
 				trackUrl = $( this ).attr( 'href' );
-			SpecialContact.trackClick( trackLabel, trackUrl );
+			SpecialContact.trackClick( trackLabel, trackUrl, e );
 		} );
-		$( '#SpecialContactIntroNoForm a' ).click( function () {
+		$( '#SpecialContactIntroNoForm a' ).click( function (e) {
 			var	trackLabel = 'intro-noform',
 				trackUrl = $( this ).attr( 'href' );
-			SpecialContact.trackClick( trackLabel, trackUrl );
+			SpecialContact.trackClick( trackLabel, trackUrl, e );
 		} );
-		$( '#SpecialContactIntroForm a' ).click( function () {
+		$( '#SpecialContactIntroForm a' ).click( function (e) {
 			var	trackLabel = 'intro-form',
 				trackUrl = $( this ).attr( 'href' );
-			SpecialContact.trackClick( trackLabel, trackUrl );
+			SpecialContact.trackClick( trackLabel, trackUrl, e );
 		} );
 
 		$('input[type=file]').change(function() {
@@ -37,7 +37,7 @@ var SpecialContact = {
 		});
 	},
 
-	trackClick: function ( trackLabel, trackUrl ) {
+	trackClick: function ( trackLabel, trackUrl, event ) {
 		var trackObj = {
 			ga_category: 'specialcontact',
 			ga_action: WikiaTracker.ACTIONS.CLICK_LINK_TEXT,
@@ -47,7 +47,8 @@ var SpecialContact = {
 		WikiaTracker.trackEvent(
 			'trackingevent',
 			trackObj,
-			'internal'
+			'internal',
+			event
 		);
 	}
 };

--- a/extensions/wikia/WikiaBar/js/WikiaBar.js
+++ b/extensions/wikia/WikiaBar/js/WikiaBar.js
@@ -381,7 +381,7 @@ var WikiaBar = {
 		return (this.wikiaBarHidden) ? 0 : wikiaBarHeight;
 	},
 	//todo: extract class
-	trackClick: function (category, action, label, value, params) {
+	trackClick: function (category, action, label, value, params, event) {
 		if (this.isSampledEvent()) {
 			var trackingObj = {
 				ga_category: category,
@@ -400,7 +400,8 @@ var WikiaBar = {
 			WikiaTracker.trackEvent(
 				'trackingevent',
 				trackingObj,
-				'ga'
+				'ga',
+				event
 			);
 		}
 	},
@@ -410,15 +411,15 @@ var WikiaBar = {
 			startTime = new Date();
 
 		if (node.hasClass('arrow')) {
-			this.trackClick('wikia-bar', WikiaTracker.ACTIONS.CLICK_LINK_BUTTON, 'arrow-hide', null, {});
+			this.trackClick('wikia-bar', WikiaTracker.ACTIONS.CLICK_LINK_BUTTON, 'arrow-hide', null, {}, e);
 		} else if (node.hasClass('wikia-bar-collapse')) {
-			this.trackClick('wikia-bar', WikiaTracker.ACTIONS.CLICK_LINK_BUTTON, 'arrow-show', null, {});
+			this.trackClick('wikia-bar', WikiaTracker.ACTIONS.CLICK_LINK_BUTTON, 'arrow-show', null, {}, e);
 		} else if (parent.hasClass('wikiabar-button')) {
 			var buttonIdx = parent.data('index');
-			this.trackClick('wikia-bar', WikiaTracker.ACTIONS.CLICK_LINK_BUTTON, 'wikiabar-button-' + buttonIdx, null, {});
+			this.trackClick('wikia-bar', WikiaTracker.ACTIONS.CLICK_LINK_BUTTON, 'wikiabar-button-' + buttonIdx, null, {}, e);
 		} else if (parent.hasClass('message')) {
 			var messageIdx = node.data('index');
-			this.trackClick('wikia-bar', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'message-' + messageIdx + '-clicked', null, {});
+			this.trackClick('wikia-bar', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'message-' + messageIdx + '-clicked', null, {}, e);
 		}
 
 		$().log('tracking took ' + (new Date() - startTime) + ' ms');

--- a/extensions/wikia/WikiaHomePage/js/CorporateFooterTracker.js
+++ b/extensions/wikia/WikiaHomePage/js/CorporateFooterTracker.js
@@ -4,7 +4,7 @@ var CorporateFooter = {
 			$.proxy(this.trackClick, this)
 		);
 	},
-	track: function(action, label, params) {
+	track: function(action, label, params, event) {
 		var trackObj = {
 			ga_category: 'corporateFooter',
 			ga_action: action,
@@ -16,22 +16,24 @@ var CorporateFooter = {
 		WikiaTracker.trackEvent(
 			'trackingevent',
 			trackObj,
-			'internal'
+			'internal',
+			event
 		);
 	},
 	trackClick: function(ev) {
 		var node = $(ev.target);
 		if (node.is('.button')) {
-			this.track(WikiaTracker.ACTIONS.CLICK_LINK_BUTTON, 'create-wiki');
+			this.track(WikiaTracker.ACTIONS.CLICK_LINK_BUTTON, 'create-wiki', {}, ev);
 		}
 		else if (node.is('.interlang')) {
-			this.track(WikiaTracker.ACTIONS.CLICK_LINK_IMAGE, 'hubs-link');
+			this.track(WikiaTracker.ACTIONS.CLICK_LINK_IMAGE, 'hubs-link', {}, ev);
 		}
 		else if (node.is('a')) {
 			this.track(
 				WikiaTracker.ACTIONS.CLICK_LINK_TEXT,
 				'hubs-link',
-				{href: node.attr('href'), anchor: node.text()}
+				{href: node.attr('href'), anchor: node.text()},
+				ev
 			);
 		}
 	}

--- a/extensions/wikia/WikiaHomePage/js/WikiaHomePage.js
+++ b/extensions/wikia/WikiaHomePage/js/WikiaHomePage.js
@@ -159,7 +159,7 @@ WikiaHomePageRemix.prototype = {
 		this.updateVisualisation();
 		$().log('WikiaHomePageRemix initialised');
 	},
-	track: function(action, label, params) {
+	track: function(action, label, params, event) {
 		var trackObj = {
 			ga_category: 'wikiaHomePage',
 			ga_action: action,
@@ -171,7 +171,8 @@ WikiaHomePageRemix.prototype = {
 		WikiaTracker.trackEvent(
 			'trackingevent',
 			trackObj,
-			'internal'
+			'internal',
+			event
 		);
 	},
 	trackClick: function(ev) {
@@ -187,53 +188,54 @@ WikiaHomePageRemix.prototype = {
 			$.storage.set('remixCounter', remixCounter);
 		}
 		else if (node.hasParent('.goPreview') || node.is('.goPreview')) {
-			this.track(WikiaTracker.ACTIONS.CLICK_LINK_BUTTON, 'preview');
+			this.track(WikiaTracker.ACTIONS.CLICK_LINK_BUTTON, 'preview', ev);
 		}
 		else if (node.hasParent('.goVisit') || node.is('.goVisit')) {
-			this.track(WikiaTracker.ACTIONS.CLICK_LINK_BUTTON, 'visit');
+			this.track(WikiaTracker.ACTIONS.CLICK_LINK_BUTTON, 'visit', ev);
 		}
 		else if (node.hasParent('.wikia-slot')) {
-			this.track(WikiaTracker.ACTIONS.CLICK_LINK_IMAGE, 'slot-image');
+			this.track(WikiaTracker.ACTIONS.CLICK_LINK_IMAGE, 'slot-image', ev);
 		}
 		else if (node.is('.create-wiki')) {
-			this.track(WikiaTracker.ACTIONS.CLICK_LINK_BUTTON, 'create-wiki');
+			this.track(WikiaTracker.ACTIONS.CLICK_LINK_BUTTON, 'create-wiki', ev);
 		}
 		else if (node.hasParent('.wikiahomepage-hubs-section')) {
 			if (node.hasParent('.videogames') && node.is('img')) {
-				this.track(WikiaTracker.ACTIONS.CLICK_LINK_IMAGE, 'hubs-image-videogames');
+				this.track(WikiaTracker.ACTIONS.CLICK_LINK_IMAGE, 'hubs-image-videogames', ev);
 			}
 			else if (node.hasParent('.entertainment') && node.is('img')) {
-				this.track(WikiaTracker.ACTIONS.CLICK_LINK_IMAGE, 'hubs-image-entertainment');
+				this.track(WikiaTracker.ACTIONS.CLICK_LINK_IMAGE, 'hubs-image-entertainment', ev);
 			}
 			else if (node.hasParent('.lifestyle') && node.is('img')) {
-				this.track(WikiaTracker.ACTIONS.CLICK_LINK_IMAGE, 'hubs-image-lifestyle');
+				this.track(WikiaTracker.ACTIONS.CLICK_LINK_IMAGE, 'hubs-image-lifestyle', ev);
 			}
 			else if (node.is('a')) {
 				this.track(
 					WikiaTracker.ACTIONS.CLICK_LINK_TEXT,
 					'hubs-link',
-					{href: node.attr('href'), anchor: node.text()}
+					{href: node.attr('href'), anchor: node.text()},
+					ev
 				);
 			}
 		}
 		else if (node.hasParent('.WikiPreviewInterstitial')) {
 			if (node.hasParent('.carousel')) {
-				this.track(WikiaTracker.ACTIONS.CLICK_LINK_IMAGE, 'interstitial-carousel');
+				this.track(WikiaTracker.ACTIONS.CLICK_LINK_IMAGE, 'interstitial-carousel', ev);
 			}
 			else if (node.is('.hero-image')) {
-				this.track(WikiaTracker.ACTIONS.CLICK_LINK_IMAGE, 'interstitial-hero-image');
+				this.track(WikiaTracker.ACTIONS.CLICK_LINK_IMAGE, 'interstitial-hero-image', ev);
 			}
 			else if (node.is('.close-button')) {
-				this.track(WikiaTracker.ACTIONS.CLICK_LINK_BUTTON, 'interstitial-close');
+				this.track(WikiaTracker.ACTIONS.CLICK_LINK_BUTTON, 'interstitial-close', ev);
 			}
 			else if (node.hasParent('.user-page')) {
-				this.track(WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'interstitial-user-page');
+				this.track(WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'interstitial-user-page', ev);
 			}
 			else if (node.hasParent('.user-contributions')) {
-				this.track(WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'interstitial-user-contributions');
+				this.track(WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'interstitial-user-contributions', ev);
 			}
 			else if (node.is('.visit') || node.hasParent('.visit')) {
-				this.track(WikiaTracker.ACTIONS.CLICK_LINK_BUTTON, 'interstitial-visit');
+				this.track(WikiaTracker.ACTIONS.CLICK_LINK_BUTTON, 'interstitial-visit', ev);
 			}
 		}
 	},

--- a/extensions/wikia/WikiaHubs/js/WikiaHubs.js
+++ b/extensions/wikia/WikiaHubs/js/WikiaHubs.js
@@ -32,7 +32,7 @@ var WikiaHubs = {
 		return false;
 	},
 
-	trackClick: function( event, category, action, label, value, params ) {
+	trackClick: function( category, action, label, value, params, event ) {
 		var trackingObj = {
 			ga_category: category,
 			ga_action: action,
@@ -67,58 +67,58 @@ var WikiaHubs = {
 			if (node.hasClass('thumbinner') || node.hasParent('.thumbinner')) {
 				url = node.closest('.thumbinner').find('a').attr('href');
 				var videoTitle = url.substr(url.indexOf(':') + 1);
-				WikiaHubs.trackClick(e, 'FeaturedVideo', WikiaTracker.ACTIONS.PLAY_VIDEO, 'play', null, {video_title: videoTitle, lang: lang});
+				WikiaHubs.trackClick('FeaturedVideo', WikiaTracker.ACTIONS.PLAY_VIDEO, 'play', null, {video_title: videoTitle, lang: lang}, e);
 			} else if (node.is('a')) {
 				url = node.closest('a').attr('href');
-				WikiaHubs.trackClick(e, 'FeaturedVideo', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'link', null, {href: url, lang: lang});
+				WikiaHubs.trackClick('FeaturedVideo', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'link', null, {href: url, lang: lang}, e);
 			}
 		} else if (node.closest('.wikiahubs-popular-videos').length > 0) {    // suggest video
 			if (node.is('#suggestVideo')) {
-				WikiaHubs.trackClick(e, 'SuggestVideo', WikiaTracker.ACTIONS.CLICK, 'suggest', null, {lang: lang});
+				WikiaHubs.trackClick('SuggestVideo', WikiaTracker.ACTIONS.CLICK, 'suggest', null, {lang: lang}, e);
 			}
 		} else if (node.closest('.wikiahubs-from-the-community').length > 0) {    // suggest article
 			if (node.is('img') && node.hasParent('a')) {
 				url = node.closest('a').attr('href');
-				WikiaHubs.trackClick(e, 'SuggestArticle', WikiaTracker.ACTIONS.CLICK_LINK_IMAGE, 'hero', null, {href: url, lang: lang});
+				WikiaHubs.trackClick('SuggestArticle', WikiaTracker.ACTIONS.CLICK_LINK_IMAGE, 'hero', null, {href: url, lang: lang}, e);
 			} else if (node.is('a')) {
 				url = node.closest('a').attr('href');
 				if (node.closest('.wikiahubs-ftc-title').length > 0) {
-					WikiaHubs.trackClick(e, 'SuggestArticle', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'title', null, {href: url, lang: lang});
+					WikiaHubs.trackClick('SuggestArticle', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'title', null, {href: url, lang: lang}, e);
 				} else if (node.closest('.wikiahubs-ftc-subtitle').length > 0) {
 					if (node.is('a:first-child')) {
-						WikiaHubs.trackClick(e, 'SuggestArticle', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'username', null, {href: url, lang: lang});
+						WikiaHubs.trackClick('SuggestArticle', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'username', null, {href: url, lang: lang}, e);
 					} else {
-						WikiaHubs.trackClick(e, 'SuggestArticle', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'wikiname', null, {href: url, lang: lang});
+						WikiaHubs.trackClick('SuggestArticle', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'wikiname', null, {href: url, lang: lang}, e);
 					}
 				}
 			} else if (node.is('#suggestArticle')) {
-				WikiaHubs.trackClick(e, 'SuggestArticle', WikiaTracker.ACTIONS.CLICK, 'suggest', null, {lang: lang});
+				WikiaHubs.trackClick('SuggestArticle', WikiaTracker.ACTIONS.CLICK, 'suggest', null, {lang: lang}, e);
 			}
 		} else if (node.closest('.wikiahubs-pulse').length > 0) {    // pulse
 			if (node.is('#facebook')) {
-				WikiaHubs.trackClick(e, 'Pulse', WikiaTracker.ACTIONS.CLICK_LINK_IMAGE, 'facebook', null, {lang: lang});
+				WikiaHubs.trackClick('Pulse', WikiaTracker.ACTIONS.CLICK_LINK_IMAGE, 'facebook', null, {lang: lang}, e);
 			} else if (node.is('#twitter')) {
-				WikiaHubs.trackClick(e, 'Pulse', WikiaTracker.ACTIONS.CLICK_LINK_IMAGE, 'twitter', null, {lang: lang});
+				WikiaHubs.trackClick('Pulse', WikiaTracker.ACTIONS.CLICK_LINK_IMAGE, 'twitter', null, {lang: lang}, e);
 			} else if (node.is('#google')) {
-				WikiaHubs.trackClick(e, 'Pulse', WikiaTracker.ACTIONS.CLICK_LINK_IMAGE, 'plus', null, {lang: lang});
+				WikiaHubs.trackClick('Pulse', WikiaTracker.ACTIONS.CLICK_LINK_IMAGE, 'plus', null, {lang: lang}, e);
 			} else if (node.is('#HubSearch')) {
-				WikiaHubs.trackClick(e, 'Pulse', WikiaTracker.ACTIONS.CLICK, 'search', null, {lang: lang});
+				WikiaHubs.trackClick('Pulse', WikiaTracker.ACTIONS.CLICK, 'search', null, {lang: lang}, e);
 			} else if (node.closest('.mw-headline').length > 0) {
 				if (node.is('a')) {
 					url = node.closest('a').attr('href');
-					WikiaHubs.trackClick(e, 'Pulse', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'wikiname', null, {href: url, lang: lang});
+					WikiaHubs.trackClick('Pulse', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'wikiname', null, {href: url, lang: lang}, e);
 				}
 			}
 		} else if (node.closest('.wikiahubs-explore').length > 0) {    // Explore
 			if (node.is('a')) {
 				url = node.closest('a').attr('href');
 				if (node.hasParent('.mw-headline')) {
-					WikiaHubs.trackClick(e, 'Explore', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'title', null, {href: url, lang: lang});
+					WikiaHubs.trackClick('Explore', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'title', null, {href: url, lang: lang}, e);
 				} else {
 					var aNode = node.closest('a'),
 						allANode = node.closest('.explore-content').find('a'),
 						itemIndex = allANode.index(aNode) + 1;
-					WikiaHubs.trackClick(e, 'Explore', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'item', itemIndex, {href: url, lang: lang});
+					WikiaHubs.trackClick('Explore', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'item', itemIndex, {href: url, lang: lang}, e);
 				}
 			}
 		} else if (node.closest('.wikiahubs-top-wikis').length > 0) {    // TopWikis
@@ -128,7 +128,7 @@ var WikiaHubs = {
 					nameIndex = allLiNode.index(liNode) + 1;
 
 				url = node.closest('a').attr('href');
-				WikiaHubs.trackClick(e, 'TopWikis', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'wikiname', nameIndex, {href: url, lang: lang});
+				WikiaHubs.trackClick('TopWikis', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'wikiname', nameIndex, {href: url, lang: lang}, e);
 			}
 		}
 
@@ -141,11 +141,11 @@ var WikiaHubs = {
 
 		if (node.closest('.VideoSuggestModal').length > 0) {
 			if (node.hasClass('submit')) {
-				WikiaHubs.trackClick(e, 'SuggestVideo', WikiaTracker.ACTIONS.SUBMIT, 'suggest', null, {lang: lang});
+				WikiaHubs.trackClick('SuggestVideo', WikiaTracker.ACTIONS.SUBMIT, 'suggest', null, {lang: lang}, e);
 			}
 		} else if (node.closest('.ArticleSuggestModal').length > 0) {
 			if (node.hasClass('submit')) {
-				WikiaHubs.trackClick(e, 'SuggestArticle', WikiaTracker.ACTIONS.SUBMIT, 'suggest', null, {lang: lang});
+				WikiaHubs.trackClick('SuggestArticle', WikiaTracker.ACTIONS.SUBMIT, 'suggest', null, {lang: lang}, e);
 			}
 		}
 	}

--- a/extensions/wikia/WikiaHubs/js/WikiaHubs.js
+++ b/extensions/wikia/WikiaHubs/js/WikiaHubs.js
@@ -32,7 +32,7 @@ var WikiaHubs = {
 		return false;
 	},
 
-	trackClick: function (category, action, label, value, params) {
+	trackClick: function( event, category, action, label, value, params ) {
 		var trackingObj = {
 			ga_category: category,
 			ga_action: action,
@@ -50,13 +50,13 @@ var WikiaHubs = {
 		WikiaTracker.trackEvent(
 			'trackingevent',
 			trackingObj,
-			'internal'
+			'internal',
+			event
 		);
 	},
 
 	clickTrackingHandler: function (e) {
 		var node = $(e.target),
-			mouseButton = e.button,
 			startTime = new Date(),
 			url,
 			lang;
@@ -67,58 +67,58 @@ var WikiaHubs = {
 			if (node.hasClass('thumbinner') || node.hasParent('.thumbinner')) {
 				url = node.closest('.thumbinner').find('a').attr('href');
 				var videoTitle = url.substr(url.indexOf(':') + 1);
-				WikiaHubs.trackClick('FeaturedVideo', WikiaTracker.ACTIONS.PLAY_VIDEO, 'play', null, {video_title: videoTitle, lang: lang});
+				WikiaHubs.trackClick(e, 'FeaturedVideo', WikiaTracker.ACTIONS.PLAY_VIDEO, 'play', null, {video_title: videoTitle, lang: lang});
 			} else if (node.is('a')) {
 				url = node.closest('a').attr('href');
-				WikiaHubs.trackClick('FeaturedVideo', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'link', null, {href: url, button: mouseButton, lang: lang});
+				WikiaHubs.trackClick(e, 'FeaturedVideo', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'link', null, {href: url, lang: lang});
 			}
 		} else if (node.closest('.wikiahubs-popular-videos').length > 0) {    // suggest video
 			if (node.is('#suggestVideo')) {
-				WikiaHubs.trackClick('SuggestVideo', WikiaTracker.ACTIONS.CLICK, 'suggest', null, {lang: lang});
+				WikiaHubs.trackClick(e, 'SuggestVideo', WikiaTracker.ACTIONS.CLICK, 'suggest', null, {lang: lang});
 			}
 		} else if (node.closest('.wikiahubs-from-the-community').length > 0) {    // suggest article
 			if (node.is('img') && node.hasParent('a')) {
 				url = node.closest('a').attr('href');
-				WikiaHubs.trackClick('SuggestArticle', WikiaTracker.ACTIONS.CLICK_LINK_IMAGE, 'hero', null, {href: url, button: mouseButton, lang: lang});
+				WikiaHubs.trackClick(e, 'SuggestArticle', WikiaTracker.ACTIONS.CLICK_LINK_IMAGE, 'hero', null, {href: url, lang: lang});
 			} else if (node.is('a')) {
 				url = node.closest('a').attr('href');
 				if (node.closest('.wikiahubs-ftc-title').length > 0) {
-					WikiaHubs.trackClick('SuggestArticle', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'title', null, {href: url, button: mouseButton, lang: lang});
+					WikiaHubs.trackClick(e, 'SuggestArticle', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'title', null, {href: url, lang: lang});
 				} else if (node.closest('.wikiahubs-ftc-subtitle').length > 0) {
 					if (node.is('a:first-child')) {
-						WikiaHubs.trackClick('SuggestArticle', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'username', null, {href: url, button: mouseButton, lang: lang});
+						WikiaHubs.trackClick(e, 'SuggestArticle', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'username', null, {href: url, lang: lang});
 					} else {
-						WikiaHubs.trackClick('SuggestArticle', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'wikiname', null, {href: url, button: mouseButton, lang: lang});
+						WikiaHubs.trackClick(e, 'SuggestArticle', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'wikiname', null, {href: url, lang: lang});
 					}
 				}
 			} else if (node.is('#suggestArticle')) {
-				WikiaHubs.trackClick('SuggestArticle', WikiaTracker.ACTIONS.CLICK, 'suggest', null, {lang: lang});
+				WikiaHubs.trackClick(e, 'SuggestArticle', WikiaTracker.ACTIONS.CLICK, 'suggest', null, {lang: lang});
 			}
 		} else if (node.closest('.wikiahubs-pulse').length > 0) {    // pulse
 			if (node.is('#facebook')) {
-				WikiaHubs.trackClick('Pulse', WikiaTracker.ACTIONS.CLICK_LINK_IMAGE, 'facebook', null, {lang: lang});
+				WikiaHubs.trackClick(e, 'Pulse', WikiaTracker.ACTIONS.CLICK_LINK_IMAGE, 'facebook', null, {lang: lang});
 			} else if (node.is('#twitter')) {
-				WikiaHubs.trackClick('Pulse', WikiaTracker.ACTIONS.CLICK_LINK_IMAGE, 'twitter', null, {lang: lang});
+				WikiaHubs.trackClick(e, 'Pulse', WikiaTracker.ACTIONS.CLICK_LINK_IMAGE, 'twitter', null, {lang: lang});
 			} else if (node.is('#google')) {
-				WikiaHubs.trackClick('Pulse', WikiaTracker.ACTIONS.CLICK_LINK_IMAGE, 'plus', null, {lang: lang});
+				WikiaHubs.trackClick(e, 'Pulse', WikiaTracker.ACTIONS.CLICK_LINK_IMAGE, 'plus', null, {lang: lang});
 			} else if (node.is('#HubSearch')) {
-				WikiaHubs.trackClick('Pulse', WikiaTracker.ACTIONS.CLICK, 'search', null, {lang: lang});
+				WikiaHubs.trackClick(e, 'Pulse', WikiaTracker.ACTIONS.CLICK, 'search', null, {lang: lang});
 			} else if (node.closest('.mw-headline').length > 0) {
 				if (node.is('a')) {
 					url = node.closest('a').attr('href');
-					WikiaHubs.trackClick('Pulse', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'wikiname', null, {href: url, button: mouseButton, lang: lang});
+					WikiaHubs.trackClick(e, 'Pulse', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'wikiname', null, {href: url, lang: lang});
 				}
 			}
 		} else if (node.closest('.wikiahubs-explore').length > 0) {    // Explore
 			if (node.is('a')) {
 				url = node.closest('a').attr('href');
 				if (node.hasParent('.mw-headline')) {
-					WikiaHubs.trackClick('Explore', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'title', null, {href: url, button: mouseButton, lang: lang});
+					WikiaHubs.trackClick(e, 'Explore', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'title', null, {href: url, lang: lang});
 				} else {
 					var aNode = node.closest('a'),
 						allANode = node.closest('.explore-content').find('a'),
 						itemIndex = allANode.index(aNode) + 1;
-					WikiaHubs.trackClick('Explore', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'item', itemIndex, {href: url, button: mouseButton, lang: lang});
+					WikiaHubs.trackClick(e, 'Explore', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'item', itemIndex, {href: url, lang: lang});
 				}
 			}
 		} else if (node.closest('.wikiahubs-top-wikis').length > 0) {    // TopWikis
@@ -128,7 +128,7 @@ var WikiaHubs = {
 					nameIndex = allLiNode.index(liNode) + 1;
 
 				url = node.closest('a').attr('href');
-				WikiaHubs.trackClick('TopWikis', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'wikiname', nameIndex, {href: url, button: mouseButton, lang: lang});
+				WikiaHubs.trackClick(e, 'TopWikis', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'wikiname', nameIndex, {href: url, lang: lang});
 			}
 		}
 
@@ -141,11 +141,11 @@ var WikiaHubs = {
 
 		if (node.closest('.VideoSuggestModal').length > 0) {
 			if (node.hasClass('submit')) {
-				WikiaHubs.trackClick('SuggestVideo', WikiaTracker.ACTIONS.SUBMIT, 'suggest', null, {lang: lang});
+				WikiaHubs.trackClick(e, 'SuggestVideo', WikiaTracker.ACTIONS.SUBMIT, 'suggest', null, {lang: lang});
 			}
 		} else if (node.closest('.ArticleSuggestModal').length > 0) {
 			if (node.hasClass('submit')) {
-				WikiaHubs.trackClick('SuggestArticle', WikiaTracker.ACTIONS.SUBMIT, 'suggest', null, {lang: lang});
+				WikiaHubs.trackClick(e, 'SuggestArticle', WikiaTracker.ACTIONS.SUBMIT, 'suggest', null, {lang: lang});
 			}
 		}
 	}

--- a/extensions/wikia/WikiaHubsV2/js/WikiaHubsV2.js
+++ b/extensions/wikia/WikiaHubsV2/js/WikiaHubsV2.js
@@ -31,7 +31,7 @@ var WikiaHubs = {
 		return false;
 	},
 
-	trackClick: function (category, action, label, value, params) {
+	trackClick: function (category, action, label, value, params, event) {
 		var trackingObj = {
 			ga_category: category,
 			ga_action: action,
@@ -49,7 +49,8 @@ var WikiaHubs = {
 		WikiaTracker.trackEvent(
 			'trackingevent',
 			trackingObj,
-			'internal'
+			'internal',
+			event
 		);
 	},
 
@@ -65,58 +66,58 @@ var WikiaHubs = {
 			if (node.hasClass('thumbinner') || node.hasParent('.thumbinner')) {
 				url = node.closest('.thumbinner').find('a').attr('href');
 				var videoTitle = url.substr(url.indexOf(':') + 1);
-				WikiaHubs.trackClick('FeaturedVideo', WikiaTracker.ACTIONS.PLAY_VIDEO, 'play', null, {video_title: videoTitle, lang: lang});
+				WikiaHubs.trackClick('FeaturedVideo', WikiaTracker.ACTIONS.PLAY_VIDEO, 'play', null, {video_title: videoTitle, lang: lang}, e);
 			} else if (node.is('a')) {
 				url = node.closest('a').attr('href');
-				WikiaHubs.trackClick('FeaturedVideo', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'link', null, {href: url, lang: lang});
+				WikiaHubs.trackClick('FeaturedVideo', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'link', null, {href: url, lang: lang}, e);
 			}
 		} else if (node.closest('.wikiahubs-popular-videos').length > 0) {    // suggest video
 			if (node.is('#suggestVideo')) {
-				WikiaHubs.trackClick('SuggestVideo', WikiaTracker.ACTIONS.CLICK, 'suggest', null, {lang: lang});
+				WikiaHubs.trackClick('SuggestVideo', WikiaTracker.ACTIONS.CLICK, 'suggest', null, {lang: lang}, e);
 			}
 		} else if (node.closest('.wikiahubs-from-the-community').length > 0) {    // suggest article
 			if (node.is('img') && node.hasParent('a')) {
 				url = node.closest('a').attr('href');
-				WikiaHubs.trackClick('SuggestArticle', WikiaTracker.ACTIONS.CLICK_LINK_IMAGE, 'hero', null, {href: url, lang: lang});
+				WikiaHubs.trackClick('SuggestArticle', WikiaTracker.ACTIONS.CLICK_LINK_IMAGE, 'hero', null, {href: url, lang: lang}, e);
 			} else if (node.is('a')) {
 				url = node.closest('a').attr('href');
 				if (node.closest('.wikiahubs-ftc-title').length > 0) {
-					WikiaHubs.trackClick('SuggestArticle', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'title', null, {href: url, lang: lang});
+					WikiaHubs.trackClick('SuggestArticle', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'title', null, {href: url, lang: lang}, e);
 				} else if (node.closest('.wikiahubs-ftc-subtitle').length > 0) {
 					if (node.is('a:first-child')) {
-						WikiaHubs.trackClick('SuggestArticle', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'username', null, {href: url, lang: lang});
+						WikiaHubs.trackClick('SuggestArticle', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'username', null, {href: url, lang: lang}, e);
 					} else {
-						WikiaHubs.trackClick('SuggestArticle', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'wikiname', null, {href: url, lang: lang});
+						WikiaHubs.trackClick('SuggestArticle', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'wikiname', null, {href: url, lang: lang}, e);
 					}
 				}
 			} else if (node.is('#suggestArticle')) {
-				WikiaHubs.trackClick('SuggestArticle', WikiaTracker.ACTIONS.CLICK, 'suggest', null, {lang: lang});
+				WikiaHubs.trackClick('SuggestArticle', WikiaTracker.ACTIONS.CLICK, 'suggest', null, {lang: lang}, e);
 			}
 		} else if (node.closest('.wikiahubs-pulse').length > 0) {    // pulse
 			if (node.is('#facebook')) {
-				WikiaHubs.trackClick('Pulse', WikiaTracker.ACTIONS.CLICK_LINK_IMAGE, 'facebook', null, {lang: lang});
+				WikiaHubs.trackClick('Pulse', WikiaTracker.ACTIONS.CLICK_LINK_IMAGE, 'facebook', null, {lang: lang}, e);
 			} else if (node.is('#twitter')) {
-				WikiaHubs.trackClick('Pulse', WikiaTracker.ACTIONS.CLICK_LINK_IMAGE, 'twitter', null, {lang: lang});
+				WikiaHubs.trackClick('Pulse', WikiaTracker.ACTIONS.CLICK_LINK_IMAGE, 'twitter', null, {lang: lang}, e);
 			} else if (node.is('#google')) {
-				WikiaHubs.trackClick('Pulse', WikiaTracker.ACTIONS.CLICK_LINK_IMAGE, 'plus', null, {lang: lang});
+				WikiaHubs.trackClick('Pulse', WikiaTracker.ACTIONS.CLICK_LINK_IMAGE, 'plus', null, {lang: lang}, e);
 			} else if (node.is('#HubSearch')) {
-				WikiaHubs.trackClick('Pulse', WikiaTracker.ACTIONS.CLICK, 'search', null, {lang: lang});
+				WikiaHubs.trackClick('Pulse', WikiaTracker.ACTIONS.CLICK, 'search', null, {lang: lang}, e);
 			} else if (node.closest('.mw-headline').length > 0) {
 				if (node.is('a')) {
 					url = node.closest('a').attr('href');
-					WikiaHubs.trackClick('Pulse', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'wikiname', null, {href: url, lang: lang});
+					WikiaHubs.trackClick('Pulse', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'wikiname', null, {href: url, lang: lang}, e);
 				}
 			}
 		} else if (node.closest('.wikiahubs-explore').length > 0) {    // Explore
 			if (node.is('a')) {
 				url = node.closest('a').attr('href');
 				if (node.hasParent('.mw-headline')) {
-					WikiaHubs.trackClick('Explore', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'title', null, {href: url, lang: lang});
+					WikiaHubs.trackClick('Explore', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'title', null, {href: url, lang: lang}, e);
 				} else {
 					var aNode = node.closest('a'),
 						allANode = node.closest('.explore-content').find('a'),
 						itemIndex = allANode.index(aNode) + 1;
-					WikiaHubs.trackClick('Explore', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'item', itemIndex, {href: url, lang: lang});
+					WikiaHubs.trackClick('Explore', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'item', itemIndex, {href: url, lang: lang}, e);
 				}
 			}
 		} else if (node.closest('.wikiahubs-top-wikis').length > 0) {    // TopWikis
@@ -126,7 +127,7 @@ var WikiaHubs = {
 					nameIndex = allLiNode.index(liNode) + 1;
 
 				url = node.closest('a').attr('href');
-				WikiaHubs.trackClick('TopWikis', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'wikiname', nameIndex, {href: url, lang: lang});
+				WikiaHubs.trackClick('TopWikis', WikiaTracker.ACTIONS.CLICK_LINK_TEXT, 'wikiname', nameIndex, {href: url, lang: lang}, e);
 			}
 		}
 
@@ -139,11 +140,11 @@ var WikiaHubs = {
 
 		if (node.closest('.VideoSuggestModal').length > 0) {
 			if (node.hasClass('submit')) {
-				WikiaHubs.trackClick('SuggestVideo', WikiaTracker.ACTIONS.SUBMIT, 'suggest', null, {lang: lang});
+				WikiaHubs.trackClick('SuggestVideo', WikiaTracker.ACTIONS.SUBMIT, 'suggest', null, {lang: lang}, e);
 			}
 		} else if (node.closest('.ArticleSuggestModal').length > 0) {
 			if (node.hasClass('submit')) {
-				WikiaHubs.trackClick('SuggestArticle', WikiaTracker.ACTIONS.SUBMIT, 'suggest', null, {lang: lang});
+				WikiaHubs.trackClick('SuggestArticle', WikiaTracker.ACTIONS.SUBMIT, 'suggest', null, {lang: lang}, e);
 			}
 		}
 	}

--- a/extensions/wikia/WikiaMobile/js/404.js
+++ b/extensions/wikia/WikiaMobile/js/404.js
@@ -3,11 +3,12 @@ window.addEventListener('DOMContentLoaded', function(){
 
 	if (link) {
 		require(['track'], function (track) {
-			link.addEventListener('click', function() {
+			link.addEventListener('click', function(ev) {
 				track.event('error-page', track.CLICK, {
 					label: 'random-image',
 					href: this.href
-				});
+				},
+				ev);
 			});
 		});
 	}

--- a/extensions/wikia/WikiaMobile/js/WikiaMobile.js
+++ b/extensions/wikia/WikiaMobile/js/WikiaMobile.js
@@ -44,7 +44,8 @@ window.addEventListener('DOMContentLoaded', function () {
 					if(t.tagName == 'A') {
 						track.event('read-more', track.IMAGE_LINK, {
 							href: t.href
-						});
+						},
+						ev);
 					} else {
 						if (relPage.children[0].className.indexOf('open') > -1) {
 							track.event('read-more', track.CLICK, {label: 'close'});
@@ -98,17 +99,19 @@ window.addEventListener('DOMContentLoaded', function () {
 						track.event('footer', track.TEXT_LINK, {
 							label: 'link',
 							href: t.href
-						});
+						},
+						ev);
 					}
 				});
 			}
 
 			if (topBar) {
 				if (wordmark = topBar.children[0]) {
-					wordmark.addEventListener(clickEvent, function () {
+					wordmark.addEventListener(clickEvent, function (ev) {
 						track.event('wordmark', track.CLICK, {
 							href: this.href
-						});
+						},
+						ev);
 					});
 				}
 			}
@@ -120,7 +123,8 @@ window.addEventListener('DOMContentLoaded', function () {
 						track.event('category', track.TEXT_LINK, {
 							label: 'article',
 							href: t.href
-						});
+						},
+						ev);
 					}
 				});
 			}

--- a/extensions/wikia/WikiaMobile/js/category_page.js
+++ b/extensions/wikia/WikiaMobile/js/category_page.js
@@ -46,7 +46,8 @@ require(['events', 'loader', 'track'], function (events, loader, track) {
 				track.event('category', track.IMAGE_LINK, {
 					label: 'exhibition',
 					href: t.href
-				});
+				},
+				ev);
 			}
 
 		});
@@ -61,7 +62,8 @@ require(['events', 'loader', 'track'], function (events, loader, track) {
 				track.event('category', track.TEXT_LINK, {
 					label: 'category',
 					href: t.href
-				});
+				},
+				ev);
 			} else if(t.className.indexOf('pag') > -1) {
 				onClick.call(t, ev);
 			}

--- a/extensions/wikia/WikiaMobile/js/track.js
+++ b/extensions/wikia/WikiaMobile/js/track.js
@@ -12,7 +12,7 @@ define('track', function () {
 	var ACTIONS = WikiaTracker.ACTIONS;
 
 	return {
-		event: function (category, action, options) {
+		event: function (category, action, options, ev) {
 			options = options || {};
 			var obj = {
 				ga_category: 'wikiamobile-' + category,
@@ -31,7 +31,7 @@ define('track', function () {
 				obj.href = options.href;
 			}
 
-			!window.wgGameGuides && WikiaTracker.trackEvent('trackingevent', obj, 'ga');
+			!window.wgGameGuides && WikiaTracker.trackEvent('trackingevent', obj, 'ga', ev);
 		},
 		//if anything happens to WikiaTracker it'll be much easier to fix it in one place
 		CLICK: ACTIONS.CLICK,

--- a/extensions/wikia/WikiaPhotoGallery/js/WikiaPhotoGallery.slider.mosaic.js
+++ b/extensions/wikia/WikiaPhotoGallery/js/WikiaPhotoGallery.slider.mosaic.js
@@ -10,7 +10,7 @@ var WikiaMosaicSliderMasterControl = {
 
 		sliders.click(WikiaMosaicSliderMasterControl.clickTrackingHandler);
 	},
-	trackClick: function(category, action, label, value, params) {
+	trackClick: function(category, action, label, value, params, event) {
 		var trackingObj = {
 			ga_category: category,
 			ga_action: action,
@@ -26,7 +26,8 @@ var WikiaMosaicSliderMasterControl = {
 		WikiaTracker.trackEvent(
 			'trackingevent',
 			trackingObj,
-			'internal'
+			'internal',
+			event
 		);
 	},
 
@@ -37,13 +38,13 @@ var WikiaMosaicSliderMasterControl = {
 
 		if (node.closest('.wikia-mosaic-slider-region').length > 0 && node.closest('a').length > 0) {
 			var url = node.closest('a').attr('href');
-			WikiaMosaicSliderMasterControl.trackClick('MosaicSlider', WikiaTracker.ACTIONS.CLICK_LINK_IMAGE, 'hero', null, {href:url, button: mouseButton});
+			WikiaMosaicSliderMasterControl.trackClick('MosaicSlider', WikiaTracker.ACTIONS.CLICK_LINK_IMAGE, 'hero', null, {href:url, button: mouseButton}, e);
 		} else if (node.closest('.wikia-mosaic-slide').length > 0) {
 			var liNode = node.closest('.wikia-mosaic-slide');
 			var allLiNode = node.closest('.wikia-mosaic-thumb-region').find('.wikia-mosaic-slide');
 			var imageIndex = allLiNode.index(liNode) + 1;
 			var url = node.closest('a').attr('href');
-			WikiaMosaicSliderMasterControl.trackClick('MosaicSlider', WikiaTracker.ACTIONS.CLICK_LINK_IMAGE, 'thumbnail', imageIndex, {href:url, button: mouseButton});
+			WikiaMosaicSliderMasterControl.trackClick('MosaicSlider', WikiaTracker.ACTIONS.CLICK_LINK_IMAGE, 'thumbnail', imageIndex, {href:url, button: mouseButton}, e);
 		}
 		$().log('tracking took ' + (new Date() - startTime) + ' ms');
 	}

--- a/extensions/wikia/WikiaQuiz/js/WikiaPlayQuiz.js
+++ b/extensions/wikia/WikiaQuiz/js/WikiaPlayQuiz.js
@@ -57,7 +57,7 @@ var WikiaQuiz = {
 
 		WikiaQuiz.ui.thanksScreen.add(WikiaQuiz.ui.emailScreen).find('.more-info').click(function(e) {
 			$().log('more info');
-			WikiaQuiz.trackEvent('click-link-text', 'moreinfo', -1, $(e.target).attr('href') );
+			WikiaQuiz.trackEvent('click-link-text', 'moreinfo', -1, $(e.target).attr('href'), e );
 		});
 
 
@@ -287,7 +287,7 @@ var WikiaQuiz = {
 	toggleSound: function() {
 		WikiaQuiz.isMuted = $(this).find('input').attr('checked');
 	},
-	trackEvent: function(action, label, value, href) {
+	trackEvent: function(action, label, value, href, event) {
 		var params = {
 			ga_category: 'wikia-quiz',
 			ga_action: action,
@@ -303,7 +303,8 @@ var WikiaQuiz = {
 		WikiaTracker.trackEvent(
 			'trackingevent',
 			params,
-			'both'
+			'both',
+			event
 		);
 	}
 };

--- a/extensions/wikia/WikiaTracker/js/WikiaTracker.js
+++ b/extensions/wikia/WikiaTracker/js/WikiaTracker.js
@@ -71,24 +71,27 @@ window.WikiaTracker = (function(){
 	 *		       href - (optional) if present, delay following outbound link of 100ms (to ensure tracking execution)
 	 *             [more custom parameters] - please ping the Tracking leads before adding a new ones
 	 * @param string trackingMethod Tracking method [both/ga/internal/none] (optional, default:none)
+	 * @param Object browserEvent (optional) browser event object in example an object created on click (basically all click-tracking should have this parameter passed otherwise it'll try to get it from window.event)
 	 *
 	 * @author Hyun Lim <hyun(at)wikia-inc.com>
 	 * @author Federico "Lox" Lucignano <federico(at)wikia-inc.com>
 	 */
-	function trackEvent(eventName, data, trackingMethod){
+	function trackEvent(eventName, data, trackingMethod, browserEvent) {
 		var logGroup = 'WikiaTracker',
 		eventName = eventName || mainEventName,
 		data = data || {},
 		trackingMethod = trackingMethod || 'none',
+		browserEvent = browserEvent || window.event,
 		isLink = (data && data.href),
-		isMiddleClick = (data.button && data.button === 1),
+		//we don't need to care here about the fact Microsoft has different value of button for middle clicks; only webkit fires click event on middle mouse button click
+		isMiddleClick = (browserEvent && browserEvent.button === 1),
 		gaqArgs = [];
 
 		// If clicking a link that will unload the page before tracking can happen,
 		// let's stop the default event and delay 100ms changing location (at the bottom)
-		// FIXME: this doesn't work in Firefox (there is no global event object there).
-		if( isLink && typeof event != 'undefined' && !isMiddleClick ) {
-			event.preventDefault();
+		// only if it's not mouse middle button click in a webkit browser
+		if( isLink && !isMiddleClick ) {
+			browserEvent.preventDefault();
 		}
 
 		var ga_category = data['ga_category'],

--- a/extensions/wikia/WikiaTracker/js/WikiaTracker.js
+++ b/extensions/wikia/WikiaTracker/js/WikiaTracker.js
@@ -84,15 +84,16 @@ window.WikiaTracker = (function(){
 		browserEvent = browserEvent || window.event,
 		mouseMiddleClick = isMiddleClick(browserEvent),
 		ctrlMouseLeftClick = isCtrlLeftClick(browserEvent),
-		isLink = (data && data.href);
+		isLink = (data && data.href),
+		isTrackableClick = (isLink && !mouseMiddleClick && !ctrlMouseLeftClick);
 		
-		if( isLink && !mouseMiddleClick && !ctrlMouseLeftClick && typeof(browserEvent) !== 'undefined' ) {
+		if( isTrackableClick && typeof(browserEvent) !== 'undefined' ) {
 			browserEvent.preventDefault();
 		}
-
+		
 		doTrack(logGroup, eventName, data, trackingMethod);
 		
-		if( isLink && !mouseMiddleClick && !ctrlMouseLeftClick ) {
+		if( isTrackableClick ) {
 		//delay at the end to make sure all of the above was at least invoked
 			setTimeout(function() {
 				document.location = data.href;

--- a/extensions/wikia/WikiaTracker/js/WikiaTracker.js
+++ b/extensions/wikia/WikiaTracker/js/WikiaTracker.js
@@ -90,7 +90,7 @@ window.WikiaTracker = (function(){
 		// If clicking a link that will unload the page before tracking can happen,
 		// let's stop the default event and delay 100ms changing location (at the bottom)
 		// only if it's not mouse middle button click in a webkit browser or ctrl + mouse left button click
-		if( isLink && !mouseMiddleClick && !ctrlMouseLeftClick ) {
+		if( isLink && !mouseMiddleClick && typeof(browserEvent) !== 'undefined' ) {
 			browserEvent.preventDefault();
 		}
 
@@ -138,6 +138,12 @@ window.WikiaTracker = (function(){
 			//WikiaTracker.track(null, 'main.sampled', gaqArgs);
 			if(window.gaTrackEvent) gaTrackEvent(ga_category, ga_action, ga_label, ga_value, true);
 		}
+		
+		if( isLink && ctrlMouseLeftClick && typeof(browserEvent) !== 'undefined' ) { //TODO: and it's not a mobile skin
+			$().log('==========');
+			$().log('TRIGGER THE EVENT!');
+			$().log('==========');
+		}
 
 		//delay at the end to make sure all of the above was at least invoked
 		if( isLink && !mouseMiddleClick && !ctrlMouseLeftClick ) {
@@ -158,7 +164,7 @@ window.WikiaTracker = (function(){
 	//bugId:45483
 		var result = false;
 		
-		if( browserEvent ) {
+		if( browserEvent && browserEvent.ctrlKey ) {
 			if( browserEvent.button === 1 ) {
 			//Microsoft left mouse button === 1
 				result = true;
@@ -166,6 +172,11 @@ window.WikiaTracker = (function(){
 				result = true;
 			}
 		}
+		
+		$().log('=========');
+		$().log('isCtrlLeftClick: ');
+		$().log(result);
+		$().log('=========');
 		
 		return result;
 	}

--- a/extensions/wikia/WikiaTracker/js/WikiaTracker.js
+++ b/extensions/wikia/WikiaTracker/js/WikiaTracker.js
@@ -83,15 +83,16 @@ window.WikiaTracker = (function(){
 		trackingMethod = trackingMethod || 'none',
 		browserEvent = browserEvent || window.event,
 		mouseMiddleClick = isMiddleClick(browserEvent),
+		isRetriggeredEvent = (typeof(browserEvent) !== 'undefined' && browserEvent.target && browserEvent.target.dataset && browserEvent.target.dataset.retriggered != 'false'),
 		isLink = (data && data.href);
 		
-		if( isLink && !mouseMiddleClick && typeof(browserEvent) !== 'undefined' && !browserEvent.target.dataset.retriggered ) {
+		if( isLink && !mouseMiddleClick && !isRetriggeredEvent ) {
 			browserEvent.preventDefault();
 		}
 
 		doTrack(logGroup, eventName, data, trackingMethod);
 		
-		if( isLink && !mouseMiddleClick && typeof(browserEvent) !== 'undefined' && !browserEvent.target.dataset.retriggered ) {
+		if( isLink && !mouseMiddleClick && !isRetriggeredEvent ) {
 			var newEvent = document.createEvent('MouseEvent');
 			newEvent.initMouseEvent(
 				browserEvent.type, browserEvent.bubbles, browserEvent.cancelable, browserEvent.view,

--- a/resources/wikia/oasis_tracking.js
+++ b/resources/wikia/oasis_tracking.js
@@ -2,7 +2,7 @@
 $(function(){
 
 	var tracker = window.WikiaTracker || {trackEvent:function(){/* null function */}},
-		track = function(category, action, label) {
+		track = function(category, action, label, event) {
 			WikiaTracker.trackEvent(
 				'trackingevent', 
 				{
@@ -10,7 +10,9 @@ $(function(){
 					ga_action: action,
 					ga_label: label
 				}, 
-				'ga');
+				'ga',
+				event
+			);
 		},
 		clickAction = WikiaTracker.ACTIONS.CLICK,
 		viewAction = WikiaTracker.ACTIONS.VIEW;
@@ -25,24 +27,24 @@ $(function(){
 		var category = 'top-nav';
 		
 		if(el.hasClass('logo')) {
-			track(category, clickAction, 'wikia-logo');
+			track(category, clickAction, 'wikia-logo', e);
 		} else if(el.parent().hasClass('start-a-wiki')) {
 			track(category, clickAction, 'start-a-wiki');
 		} else if(el.closest('.topNav').length > 0) {
-			track(category, clickAction, 'hub-item');
+			track(category, clickAction, 'hub-item', e);
 		} else if(el.data('id') == 'mytalk') {
 			if(el.hasClass('message-wall-item')) {
-				track(category, clickAction, 'user-menu-message-wall');
+				track(category, clickAction, 'user-menu-message-wall', e);
 			} else {
-				track(category, clickAction, 'user-menu-talk');
+				track(category, clickAction, 'user-menu-talk', e);
 			}
 		} else if(el.attr('accesskey') == '.') {
-			track(category, clickAction, 'user-menu-profile');
+			track(category, clickAction, 'user-menu-profile', e);
 		} else if(el.closest('.notifications-for-wiki').length > 0) {
 			if($(el.closest('.notifications-for-wiki')).data('wiki-id') == window.wgCityId) {
-				track(category, clickAction, 'notification-item-local');
+				track(category, clickAction, 'notification-item-local', e);
 			} else {
-				track(category, clickAction, 'notification-item-cross-wiki');
+				track(category, clickAction, 'notification-item-cross-wiki', e);
 			}
 		}
 	});
@@ -57,33 +59,33 @@ $(function(){
 		var category = 'wiki-nav';
 		
 		if(el.closest('.wordmark').length > 0) {
-			track(category, clickAction, 'wordmark');
+			track(category, clickAction, 'wordmark', e);
 		} else if(el.data('canonical')) {
 			var canonical = el.data('canonical');
 			switch(canonical) {
 				case 'wikiactivity':
-					track(category, clickAction, 'on-the-wiki-activity');
+					track(category, clickAction, 'on-the-wiki-activity', e);
 					break;
 				case 'random':
-					track(category, clickAction, 'on-the-wiki-random');
+					track(category, clickAction, 'on-the-wiki-random', e);
 					break;
 				case 'newfiles':
-					track(category, clickAction, 'on-the-wiki-new-photos');
+					track(category, clickAction, 'on-the-wiki-new-photos', e);
 					break;
 				case 'chat':
-					track(category, clickAction, 'on-the-wiki-chat');
+					track(category, clickAction, 'on-the-wiki-chat', e);
 					break;
 				case 'forum':
-					track(category, clickAction, 'on-the-wiki-forum');
+					track(category, clickAction, 'on-the-wiki-forum', e);
 					break;
 				case 'videos':
-					track(category, clickAction, 'on-the-wiki-videos');
+					track(category, clickAction, 'on-the-wiki-videos', e);
 					break;
 				default:
 					break;
 			}
 		} else if(el.closest('.WikiNav').length > 0) {
-			track(category, clickAction, 'custom');
+			track(category, clickAction, 'custom', e);
 		}
 	});
 	
@@ -97,12 +99,12 @@ $(function(){
 		var category = 'article';
 		
 		if((el.data('id') || el.parent().data('id')) == 'edit') {
-			track(category, clickAction, 'edit');
+			track(category, clickAction, 'edit', e);
 		} else if((el.data('id') || el.parent().data('id')) == 'comment') {
 			if(el.hasClass('talk') || el.parent().hasClass('talk')) {
-				track(category, clickAction, 'talk');
+				track(category, clickAction, 'talk', e);
 			} else {
-				track(category, clickAction, 'comment');
+				track(category, clickAction, 'comment', e);
 			}
 		}
 	});
@@ -117,7 +119,7 @@ $(function(){
 		var category = 'article';
 		
 		if(el.closest('.editsection').length > 0) {
-			track(category, clickAction, 'section-edit');
+			track(category, clickAction, 'section-edit', e);
 		}
 	});
 	
@@ -132,19 +134,19 @@ $(function(){
 		
 		if(el.parent().hasClass('image')) {
 			if(el.parent().hasClass('video')) {
-				track(category, clickAction, 'video');
+				track(category, clickAction, 'video', e);
 			} else {
-				track(category, clickAction, 'image');
+				track(category, clickAction, 'image', e);
 			}
 		} else if(el.closest('.RelatedPagesModule').length > 0) {
-			track(category, clickAction, 'related-pages');
+			track(category, clickAction, 'related-pages', e);
 		} else if(el.closest('.category-gallery').length > 0) {
-			track('category', clickAction, 'category-gallery');
+			track('category', clickAction, 'category-gallery', e);
 		}
 	});
 	
 	$('#WikiaArticleCategories').on('click', 'a', function(e) {
-		track('article', clickAction, 'category-name');
+		track('article', clickAction, 'category-name', e);
 	});
 	
 	$('#WikiaRail').on('click', '.WikiaActivityModule a, .LatestPhotosModule a, .ChatModule button', function(e) {
@@ -155,27 +157,27 @@ $(function(){
 		}
 		
 		if(el.closest('.edited-by').length > 0) {
-			track('recent-wiki-activity', clickAction, 'activity-username');
+			track('recent-wiki-activity', clickAction, 'activity-username', e);
 		} else if(el.closest('.WikiaActivityModule').length > 0) {
-			track('recent-wiki-activity', clickAction, 'activity-title');
+			track('recent-wiki-activity', clickAction, 'activity-title', e);
 		} else if(el.hasClass('thumbimage')) {
-			track('photos-module', clickAction, 'photos-module-thumbnail');
+			track('photos-module', clickAction, 'photos-module-thumbnail', e);
 		} else if(el.closest('.chat-join').length > 0) {
-			track('chat-module', clickAction, 'chat-join');
+			track('chat-module', clickAction, 'chat-join', e);
 		}
 	});
 	
 	$('#WikiaSearch').on('click', '.autocomplete', function(e) {
-		track('search', clickAction, 'search-suggest');
+		track('search', clickAction, 'search-suggest', e);
 	}).on('submit', '', function(e) {
-		track('search', clickAction, 'search-enter');
+		track('search', clickAction, 'search-enter', e);
 	});
 	
 	if($('body.editor').length > 0) {
 		// edit page view event
 		track('edit', viewAction, 'edit-page');
 		$('#wpSave').on('click', '', function(e) {
-			track('edit', clickAction, 'publish');
+			track('edit', clickAction, 'publish', e);
 		});
 	}
 
@@ -189,11 +191,11 @@ $(function(){
 		var category = 'thread-module';
 		
 		if(el.hasClass('forum-thread-title')) {
-			track(category, clickAction, 'title');
+			track(category, clickAction, 'title', e);
 		} else if(el.hasClass('forum-new-post')) {
-			track(category, clickAction, 'start-discussion');
+			track(category, clickAction, 'start-discussion', e);
 		} else if(el.closest('.forum-see-more').length > 0) {
-			track(category, clickAction, 'see-more');
+			track(category, clickAction, 'see-more', e);
 		}
 	});
 	

--- a/skins/oasis/js/WikiaNotifications.js
+++ b/skins/oasis/js/WikiaNotifications.js
@@ -49,7 +49,8 @@ var WikiaNotificationsApp = {
 					WikiaTracker.trackEvent(
 						'trackingevent',
 						trackObj,
-						'internal'
+						'internal',
+						ev
 					);
 
 					// remove <div>
@@ -67,7 +68,8 @@ var WikiaNotificationsApp = {
 						WikiaTracker.trackEvent(
 							'trackingevent',
 							impTrackObj,
-							'internal'
+							'internal',
+							ev
 						);
 					}
 					break;


### PR DESCRIPTION
More info can be find here: https://wikia.fogbugz.com/default.asp?45483

Basically, there were two issues:
1. Javascript error in the console in Firefox because we don't have global event object in Firefox
2. Ctrl + click on links which are being tracked didn't work as it should (it opened new page in the same tab instead of new tab and sending tracking data).

We still can think of better way of implementing our click tracking. But this one seems working correctly and I smoke tested it and didn't find any regression. If you're OK with this changes we can merge them and resolve ticket #45483.
