### PR TITLE
Bugid 30866 blog post comments counter updates

### DIFF
--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -514,6 +514,16 @@ class ArticleComment {
 		}
 	}
 
+	public static function getBlogPostTitle($titleText, $oTitle = null){
+		$result = self::explode($titleText, $oTitle);
+
+		$tmpArr = explode('/', $result['title']);
+		array_shift($tmpArr);
+		$title = implode('/', $tmpArr);
+
+		return $title;
+	}
+
 	public static function explode($titleText, $oTitle = null) {
 		$count = 0;
 		$titleTextStripped = str_replace(ARTICLECOMMENT_PREFIX, '', $titleText, $count);
@@ -527,12 +537,6 @@ class ArticleComment {
 			//not a comment - fallback
 			$title = $titleText;
 			$partsOriginal = $partsStripped = array();
-		}
-
-		if( self::isBlog() ) {
-			$tmpArr = explode('/', $title);
-			array_shift($tmpArr);
-			$title = implode('/', $tmpArr);
 		}
 
 		$result = array(

--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -514,16 +514,6 @@ class ArticleComment {
 		}
 	}
 
-	public static function getBlogPostTitle($titleText, $oTitle = null){
-		$result = self::explode($titleText, $oTitle);
-
-		$tmpArr = explode('/', $result['title']);
-		array_shift($tmpArr);
-		$title = implode('/', $tmpArr);
-
-		return $title;
-	}
-
 	public static function explode($titleText, $oTitle = null) {
 		$count = 0;
 		$titleTextStripped = str_replace(ARTICLECOMMENT_PREFIX, '', $titleText, $count);

--- a/extensions/wikia/ArticleComments/js/ArticleComments.js
+++ b/extensions/wikia/ArticleComments/js/ArticleComments.js
@@ -366,7 +366,7 @@ var ArticleComments = {
 					$('#article-comments-counter-header').html($.msg('oasis-comments-header', json.counter));
 
 					if (window.skin == 'oasis') {
-						$('#WikiaPageHeader').find('.commentsbubble').html(json.counter);
+						$('#WikiaPageHeader, #WikiaUserPagesHeader').find('.commentsbubble').html(json.counter);
 
 						if (!parentId) {
 							if (!ArticleComments.mostRecentCount) {

--- a/extensions/wikia/MyHome/data/DataFeedProvider.php
+++ b/extensions/wikia/MyHome/data/DataFeedProvider.php
@@ -397,9 +397,9 @@ class DataFeedProvider {
 			$item['url'] = $title->getLocalUrl();
 
 		} elseif (defined('NS_BLOG_ARTICLE_TALK') && $res['ns'] == NS_BLOG_ARTICLE_TALK && class_exists('ArticleComment')) {
-
-			$item['title'] = ArticleComment::getBlogPostTitle($res['title'], $title );
-			$item['url'] = Title::newFromText($title->getBaseText(), NS_BLOG_ARTICLE_TALK)->getLocalUrl();
+			$subpageTitle = Title::newFromText($title->getBaseText(), NS_BLOG_ARTICLE_TALK);
+			$item['title'] = $subpageTitle->getSubpageText();
+			$item['url'] = $subpageTitle->getLocalUrl();
 
  		} elseif (defined('NS_BLOG_LISTING') && $res['ns'] == NS_BLOG_LISTING) {
 

--- a/extensions/wikia/MyHome/data/DataFeedProvider.php
+++ b/extensions/wikia/MyHome/data/DataFeedProvider.php
@@ -398,8 +398,7 @@ class DataFeedProvider {
 
 		} elseif (defined('NS_BLOG_ARTICLE_TALK') && $res['ns'] == NS_BLOG_ARTICLE_TALK && class_exists('ArticleComment')) {
 
-			$parts = ArticleComment::explode($res['title'], $title );
-			$item['title'] = $parts['title'];
+			$item['title'] = ArticleComment::getBlogPostTitle($res['title'], $title );
 			$item['url'] = Title::newFromText($title->getBaseText(), NS_BLOG_ARTICLE_TALK)->getLocalUrl();
 
  		} elseif (defined('NS_BLOG_LISTING') && $res['ns'] == NS_BLOG_LISTING) {


### PR DESCRIPTION
Solution for: https://wikia.fogbugz.com/default.asp?30866 . After adding or removing of comments on blog post, comments counters  ware not refreshed correctly because of wrong key in delete call to memcache.

This is also takes to consideration changes made to resolve this bug:
https://wikia.fogbugz.com/default.asp?1181
https://github.com/Wikia/app/commit/84bc6a64
