### PR TITLE
Bugid 52072

### DIFF
--- a/extensions/Cite/Cite.i18n.php
+++ b/extensions/Cite/Cite.i18n.php
@@ -52,6 +52,7 @@ no text was provided for refs named <code>$1</code>',
 	'cite_error_references_missing_key'              => '<code>&lt;ref&gt;</code> tag with name "$1" defined in <code>&lt;references&gt;</code> is not used in prior text.',
 	'cite_error_references_no_key'                   => '<code>&lt;ref&gt;</code> tag defined in <code>&lt;references&gt;</code> has no name attribute.',
 	'cite_error_empty_references_define'             => '<code>&lt;ref&gt;</code> tag defined in <code>&lt;references&gt;</code> with name "$1" has no content.',
+	'cite_error_malformed_dom'                       => '<code>&lt;references&gt;</code> was not closed properly. Please replace this with this tag with a self-closing <code>&lt;references&gt;/</code> tag, or close it with a <code>/&lt;references&gt;</code> tag.' ,
 
 	/*
 	   Output formatting
@@ -105,6 +106,7 @@ $messages['qqq'] = array(
 	'cite_error_references_no_backlink_label' => 'Cite extension. Error message shown in the references tag when the same name is used for too many ref tags. Too many in this case is more than there are backlink labels defined in [[MediaWiki:Cite references link many format backlink labels]].
 
 It is not possible to make a clickable link to this message. "nowiki" is mandatory around [[MediaWiki:Cite references link many format backlink labels]].',
+	'cite_error_malformed_dom' => 'Cite extension. Error message shown in the references tag when an unclosed references tag is provided',
 	'cite_error_no_link_label_group' => "*'''$1''' is the name of a reference group.
 *'''$2''' is <tt>cite_link_label_group-<i>groupname</i></tt>.",
 	'cite_error_references_no_text' => 'Cite extension. This error occurs when the tag <code>&lt;ref name="something" /&gt;</code> is used with the name-option specified and no other tag specifies a cite-text for this name.',

--- a/extensions/Cite/Cite_body.php
+++ b/extensions/Cite/Cite_body.php
@@ -537,6 +537,11 @@ class Cite {
 			$this->mInReferences = true;
 			$ret = $this->guardedReferences( $str, $argv, $parser );
 			$this->mInReferences = false;
+			
+			if ( trim( $str ) !== '' && !preg_match( '/<ref\b[^<]*?>/', $str ) ) {
+				return $this->error( 'cite_error_malformed_dom' );
+			}
+			
 			return $ret;
 		}
 	}

--- a/extensions/wikia/RTE/RTEParser.class.php
+++ b/extensions/wikia/RTE/RTEParser.class.php
@@ -98,18 +98,27 @@ class RTEParser extends Parser {
 	 */
 	public function checkForUnclosedParserHooks( $text ) {
 		foreach ( $this->mTagHooks as $tag => $callback ) {
-			$opens = array();
-			$closes = array();
-			preg_match_all( "/<{$tag}\b([^>\/])*>/si", $text, $opens );
-			preg_match_all( "/<\/[^>\w]*\b{$tag}>/si", $text, $closes );
+			$bothMatches = array();
+			$selfclosingMatches = array();
+			$closeMatches = array();
+			preg_match_all( "/<{$tag}\b[^>]*>/Usi", $text, $bothMatches );
+			preg_match_all( "/<{$tag}\b[^>]*\/>/Usi", $text, $selfclosingMatches );
+			preg_match_all( "/<\/[^>\w]*\b{$tag}>/si", $text, $closeMatches );
+			
+			$closes = count( $closeMatches ) ? count( $closeMatches[0] ) : 0;
+			$both = count ( $bothMatches ) ? count( $bothMatches[0] ) : 0;
+			$selfclosings = count( $selfclosingMatches ) ? count( $selfclosingMatches[0] ) : 0;
+			
+			// we do this because we can identify self-closing instances, but identifying non self-closing instances 
+			// is outside of the capabilities of a regular language (e.g. <foo src="bar/baz" /> -- the regex for that is no fun
+			$opens = $both - $selfclosings;
 			
 			// the number of opening tags should be identical to the number of closing tags
-			if ( count( $opens ) > 0 || count( $closes ) > 0 ) {
-				if ( ( count( $opens ) == 0 || count( $closes ) == 0 ) // no results from one
-				    || ( count( $opens[0] ) != count( $closes[0] ) ) // mismatched number
-			    ) {
+			if ( $opens != $closes ) {
+					Wikia::log(__METHOD__, 'tag', $tag );
+					Wikia::log(__METHOD__, 'opens', $opens );
+					Wikia::log(__METHOD__, 'closes', $closes );
 					RTE::$edgeCases[] = 'UNCLOSED_PARSER_HOOK_TAG';
-				}
 			}
 		}
 	}

--- a/extensions/wikia/RTE/RTEParser.class.php
+++ b/extensions/wikia/RTE/RTEParser.class.php
@@ -115,9 +115,6 @@ class RTEParser extends Parser {
 			
 			// the number of opening tags should be identical to the number of closing tags
 			if ( $opens != $closes ) {
-					Wikia::log(__METHOD__, 'tag', $tag );
-					Wikia::log(__METHOD__, 'opens', $opens );
-					Wikia::log(__METHOD__, 'closes', $closes );
 					RTE::$edgeCases[] = 'UNCLOSED_PARSER_HOOK_TAG';
 			}
 		}

--- a/extensions/wikia/RTE/RTEParser.class.php
+++ b/extensions/wikia/RTE/RTEParser.class.php
@@ -98,10 +98,18 @@ class RTEParser extends Parser {
 	 */
 	public function checkForUnclosedParserHooks( $text ) {
 		foreach ( $this->mTagHooks as $tag => $callback ) {
-			if ( preg_match( "/<{$tag}(\W[^>\/])*>/si", $text ) 
-				&& !preg_match( "/<\/[^>\w]*{$tag}>/si", $text )
-				) {
-				RTE::$edgeCases[] = 'UNCLOSED_PARSER_HOOK_TAG';
+			$opens = array();
+			$closes = array();
+			preg_match_all( "/<{$tag}\b([^>\/])*>/si", $text, $opens );
+			preg_match_all( "/<\/[^>\w]*\b{$tag}>/si", $text, $closes );
+			
+			// the number of opening tags should be identical to the number of closing tags
+			if ( count( $opens ) > 0 || count( $closes ) > 0 ) {
+				if ( ( count( $opens ) == 0 || count( $closes ) == 0 ) // no results from one
+				    || ( count( $opens[0] ) != count( $closes[0] ) ) // mismatched number
+			    ) {
+					RTE::$edgeCases[] = 'UNCLOSED_PARSER_HOOK_TAG';
+				}
 			}
 		}
 	}

--- a/extensions/wikia/RTE/RTEParser.class.php
+++ b/extensions/wikia/RTE/RTEParser.class.php
@@ -90,6 +90,21 @@ class RTEParser extends Parser {
 			}
 		}
 	}
+	
+	/**
+	 * Registers the wikitext as an edge case with RTE stack for cases where
+	 * parser hook tags are not either self-closing or an accompanying closing tag.
+	 * @param unknown_type $text
+	 */
+	public function checkForUnclosedParserHooks( $text ) {
+		foreach ( $this->mTagHooks as $tag => $callback ) {
+			if ( preg_match( "/<{$tag}(\W[^>\/])*>/si", $text ) 
+				&& !preg_match( "/<\/[^>\w]*{$tag}>/si", $text )
+				) {
+				RTE::$edgeCases[] = 'UNCLOSED_PARSER_HOOK_TAG';
+			}
+		}
+	}
 
 	/**
 	 * Reset empty lines counter and store current line as previous one for next step of foreach
@@ -489,6 +504,7 @@ class RTEParser extends Parser {
 
 		// parse to HTML
 		$output = parent::parse($text, $title, $options, $linestart, $clearState, $revid);
+		$this->checkForUnclosedParserHooks( $text );
 
 		$wgRTEParserEnabled = false;
 


### PR DESCRIPTION
This pull request addresses a defect where an unclosed references tag will hide any content following it under a puzzle piece icon in the visual editor.

This is a core defect as well, as it can be replicated on Wikipedia using the preview mode.

This is addressed in two ways:

1) Update the core Cite extension to register an error if the references tag is not closed (we will also submit this to gerrit.mediawiki.org as a pull request)
2) Register an edge case in the visual editor in cases where a parser hook tag is not closed, preventing visual mode in such scenarios

This will force the user to use the "preview" button to preview their changes, causing them to view the error message in the Cite extension, complaining that the tag was not closed. This will also prevent the loss of data, without forcing any guarantees around parsing buggy user-generated input.
