### PR TITLE
Consumer QB1 bugid 20849

### DIFF
--- a/extensions/FBConnect/config.php
+++ b/extensions/FBConnect/config.php
@@ -205,7 +205,6 @@ if(!empty($fbEnablePushToFacebook)){
 		'FBPush_OnArticleComment',
 		'FBPush_OnBlogComment',
 		'FBPush_OnLargeEdit',
-		'FBPush_OnRateArticle',
 		'FBPush_OnWatchArticle',
 		'FBPush_OnAchBadge'
 	);

--- a/extensions/wikia/UserLogin/css/UserLoginFacebook.scss
+++ b/extensions/wikia/UserLogin/css/UserLoginFacebook.scss
@@ -90,6 +90,13 @@
 .FacebookSignupConfig {
 	display: none;
 	margin: 2px 0 -7px 0;
+	legend {
+		clear: both;
+		float: left;
+		font-weight: bold;
+		padding: 12px;
+		width: 620px;
+	}
 	> fieldset {
 		@include box-shadow(0, 0, 5px, mix($color-page, #000000, 90%), true, 1px);
 		@if $is-dark-wiki {
@@ -98,23 +105,14 @@
 			background-color: mix($color-page, #000000, 95%);
 		}
 		> .input-group {
+			clear: none;
+			float: left;
 			padding: 0 12px;
 			width: 300px;
-			p {
-				font-weight: bold;
-				padding: 17px 0;
-			}
 			input[type=checkbox] {
 				margin-right: 26px;
 				padding-left: 17px;
 			}
-		}
-		> div:nth-child(even) {
-			float: left;
-		}
-		> div:nth-child(odd) {
-			clear: right;
-			float: right;
 		}
 		.indented label {
 			padding-left: 42px;

--- a/extensions/wikia/UserLogin/css/UserLoginFacebook.scss
+++ b/extensions/wikia/UserLogin/css/UserLoginFacebook.scss
@@ -115,8 +115,11 @@
 				padding-left: 17px;
 			}
 		}
-		.indented input[type=checkbox] {
-			float: left;
+		.indented {
+			padding-top: 10px;
+			input[type=checkbox] {
+				float: left;
+			}
 		}
 	}
 }

--- a/extensions/wikia/UserLogin/css/UserLoginFacebook.scss
+++ b/extensions/wikia/UserLogin/css/UserLoginFacebook.scss
@@ -104,6 +104,7 @@
 		} @else {
 			background-color: mix($color-page, #000000, 95%);
 		}
+		padding: 0 0 12px 0;
 		> .input-group {
 			clear: none;
 			float: left;
@@ -114,9 +115,8 @@
 				padding-left: 17px;
 			}
 		}
-		.indented label {
-			padding-left: 42px;
-			text-indent: -42px;
+		.indented input[type=checkbox] {
+			float: left;
 		}
 	}
 }

--- a/extensions/wikia/UserLogin/templates/FacebookSignup_modal.php
+++ b/extensions/wikia/UserLogin/templates/FacebookSignup_modal.php
@@ -59,28 +59,23 @@
 
 <?php
 	// print out FB feed preferences
-	$newOptions[] = array(
-		'type' => 'custom',
-		'output' => '<p>'.wfMsg('fbconnect-prefs-post').'</p>',
-	);
-	$newOptions[] = array(
-		'type' => 'custom',
-		'output' => '',
-	);
 	foreach ($fbFeedOptions as $option) {
 		$optionElement = array(
 			'type' => 'checkbox',
 			'name' => $option['name'],
 			'label' => $option['shortText'],
-			'checked' => true
+			'attributes' => array(
+				'checked' => true
+			)
 		);
-		if ($optionElement['label'] == wfMsg('tog-fbconnect-push-allow-never')) {
-			$optionElement['checked'] = false;
+		if ($optionElement['name'] == 'fbconnect-push-allow-never') {
+			$optionElement['attributes'] = array();
 			$optionElement['class'] = 'indented';
 		}
 		$newOptions[] = $optionElement;
 	}
 	$formFb = array(
+		'legend' => wfMsg('fbconnect-prefs-post'),
 		'class' => 'FacebookSignupConfig',
 		'inputs' => $newOptions,
 		'method' => 'post',


### PR DESCRIPTION
FB feed preferences should be checked and "rate an article" removed from FB publish preferences in Connect Signup flow:
- Outdated pushEventClassName item was removed from  the list
- form items were realigned, positioning empty form item removed
- form items are now passed with 'checked' attribute defined in a way that WikiaStyleGuideForm supports
