### PR TITLE
fixing anyclips player loading

### DIFF
--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -48,7 +48,6 @@ $config['adengine2_js'] = array(
 	'assets' => array(
 		// core
 		'//resources/wikia/modules/cache.js',
-		'//resources/wikia/modules/lazyqueue.js',
 
 		'//extensions/wikia/AdEngine/js/Krux.js',
 		'//extensions/wikia/AdEngine/js/SlotTweaker.js',
@@ -152,7 +151,8 @@ $config['oasis_blocking'] = array(
 	'type' => AssetsManager::TYPE_JS,
 	'assets' => array(
 		'//skins/wikia/js/WikiaScriptLoader.js',
-		'//skins/wikia/js/JqueryLoader.js'
+		'//skins/wikia/js/JqueryLoader.js',
+		'//resources/wikia/modules/lazyqueue.js',
 	)
 );
 
@@ -598,6 +598,7 @@ $config['monobook_js'] = array(
 //		'//resources/mediawiki/mediawiki.util.js', # instead of //skins/common/wikibits.js'
 //		'//skins/common/ajax.js',
 		'//skins/monobook/main.js',
+		'//resources/wikia/modules/lazyqueue.js',
 		'//extensions/wikia/JSMessages/js/JSMessages.js',
 		'//extensions/wikia/AjaxLogin/AjaxLoginBindings.js',
 		'//extensions/wikia/ImageLazyLoad/js/ImageLazyLoad.js',

--- a/extensions/wikia/VideoHandlers/handlers/AnyclipVideoHandler.class.php
+++ b/extensions/wikia/VideoHandlers/handlers/AnyclipVideoHandler.class.php
@@ -32,13 +32,25 @@ EOT;
 		 */
 		$html .= <<<EOT
 <script type="text/javascript">
-wgAfterContentAndJS.push(function(){
-	$.when(
-		$.getScript('{$jsFile}')
-	).done(function() {
-		AnyClipPlayer.load(["#AnyClipPlayer-{$this->videoId}-{$ajaxStr}", {clipID:"{$this->videoId}"{$autoPlayStr}}, {wmode: "opaque"}]);
-	});
-});
+
+(function(window) {
+
+	var loadAnyClips = function(){
+		$.when(
+			$.getScript('{$jsFile}')
+		).done(function() {
+			window.AnyClipPlayer.load(["#AnyClipPlayer-{$this->videoId}-{$ajaxStr}", {clipID:"{$this->videoId}"{$autoPlayStr}}, {wmode: "opaque"}]);
+		});
+	}
+	
+	if(window.wgAfterContentAndJSLoaded === true) {
+		loadAnyClips();
+	} else {
+		window.wgAfterContentAndJS.push(loadAnyClips);
+	}
+
+})(this);
+
 </script>
 EOT;
 

--- a/extensions/wikia/VideoHandlers/handlers/AnyclipVideoHandler.class.php
+++ b/extensions/wikia/VideoHandlers/handlers/AnyclipVideoHandler.class.php
@@ -39,7 +39,7 @@ EOT;
 		$.getScript('{$jsFile}').done(function() {
 			window.AnyClipPlayer.load(["#AnyClipPlayer-{$this->videoId}-{$ajaxStr}", {clipID:"{$this->videoId}"{$autoPlayStr}}, {wmode: "opaque"}]);
 		});
-	}
+	};
 
 	wgAfterContentAndJS.push(loadAnyClips);
 

--- a/extensions/wikia/VideoHandlers/handlers/AnyclipVideoHandler.class.php
+++ b/extensions/wikia/VideoHandlers/handlers/AnyclipVideoHandler.class.php
@@ -36,18 +36,12 @@ EOT;
 (function(window) {
 
 	var loadAnyClips = function(){
-		$.when(
-			$.getScript('{$jsFile}')
-		).done(function() {
+		$.getScript('{$jsFile}').done(function() {
 			window.AnyClipPlayer.load(["#AnyClipPlayer-{$this->videoId}-{$ajaxStr}", {clipID:"{$this->videoId}"{$autoPlayStr}}, {wmode: "opaque"}]);
 		});
 	}
-	
-	if(window.wgAfterContentAndJSLoaded === true) {
-		loadAnyClips();
-	} else {
-		window.wgAfterContentAndJS.push(loadAnyClips);
-	}
+
+	wgAfterContentAndJS.push(loadAnyClips);
 
 })(this);
 

--- a/resources/wikia/modules/lazyqueue.js
+++ b/resources/wikia/modules/lazyqueue.js
@@ -1,4 +1,3 @@
-alert('loaded');
 /**
  * LazyQueue module
  *

--- a/resources/wikia/modules/lazyqueue.js
+++ b/resources/wikia/modules/lazyqueue.js
@@ -1,3 +1,4 @@
+alert('loaded');
 /**
  * LazyQueue module
  *
@@ -31,7 +32,7 @@
  *
  * Then, you can start handling the items pushed you do:
  *
- * myQueue.run();
+ * myQueue.start();
  *
  * The callback you passed before would be called for all the elements pushed
  * to the queue so far (so you see 3 alerts, item1, item2, item3).

--- a/skins/LyricsMinimal.php
+++ b/skins/LyricsMinimal.php
@@ -868,7 +868,7 @@ if (43339 == $wgCityId) echo AnalyticsEngine::track("GA_Urchin", "lyrics");
 		$this->html('JSloader');
 		$this->html('headscripts');
 	}
-	echo '<script type="text/javascript">/*<![CDATA[*/for(var i=0;i<wgAfterContentAndJS.length;i++){wgAfterContentAndJS[i]();}/*]]>*/</script>' . "\n";
+	echo '<script type="text/javascript">/*<![CDATA[*/while(wgAfterContentAndJS.length>0){wgAfterContentAndJS.shift()();} wgAfterContentAndJSLoaded = true;/*]]>*/</script>' . "\n";
 
 if (array_key_exists("TOP_RIGHT_BOXAD", AdEngine::getInstance()->getPlaceholders())){
 	// Reset elements with a "clear:none" to "clear:right" when the box ad is displayed

--- a/skins/LyricsMinimal.php
+++ b/skins/LyricsMinimal.php
@@ -868,7 +868,7 @@ if (43339 == $wgCityId) echo AnalyticsEngine::track("GA_Urchin", "lyrics");
 		$this->html('JSloader');
 		$this->html('headscripts');
 	}
-	echo '<script type="text/javascript">/*<![CDATA[*/while(wgAfterContentAndJS.length>0){wgAfterContentAndJS.shift()();} wgAfterContentAndJSLoaded = true;/*]]>*/</script>' . "\n";
+	echo '<script type="text/javascript">/*<![CDATA[*/Wikia.LazyQueue.makeQueue(wgAfterContentAndJS, function(fn) {fn();}); wgAfterContentAndJS.start(); /*]]>*/</script>' . "\n";
 
 if (array_key_exists("TOP_RIGHT_BOXAD", AdEngine::getInstance()->getPlaceholders())){
 	// Reset elements with a "clear:none" to "clear:right" when the box ad is displayed

--- a/skins/Uncyclopedia.php
+++ b/skins/Uncyclopedia.php
@@ -134,6 +134,6 @@ class UncyclopediaTemplate extends MonoBookTemplate {
 	<div id="f-hosting"><i>Wikia</i>&reg; is a registered service mark of Wikia, Inc. All rights reserved.</div>
 
 	<!-- RT #79534 -->
-	<script type="text/javascript">/*<![CDATA[*/while(wgAfterContentAndJS.length>0){wgAfterContentAndJS.shift()();} wgAfterContentAndJSLoaded = true;/*]]>*/</script>
+	<script type="text/javascript">/*<![CDATA[*/Wikia.LazyQueue.makeQueue(wgAfterContentAndJS, function(fn) {fn();}); wgAfterContentAndJS.start();}/*]]>*/</script>
 <?php	}
 }

--- a/skins/Uncyclopedia.php
+++ b/skins/Uncyclopedia.php
@@ -134,6 +134,6 @@ class UncyclopediaTemplate extends MonoBookTemplate {
 	<div id="f-hosting"><i>Wikia</i>&reg; is a registered service mark of Wikia, Inc. All rights reserved.</div>
 
 	<!-- RT #79534 -->
-	<script type="text/javascript">/*<![CDATA[*/for(var i=0;i<wgAfterContentAndJS.length;i++){wgAfterContentAndJS[i]();}/*]]>*/</script>
+	<script type="text/javascript">/*<![CDATA[*/while(wgAfterContentAndJS.length>0){wgAfterContentAndJS.shift()();} wgAfterContentAndJSLoaded = true;/*]]>*/</script>
 <?php	}
 }

--- a/skins/campfire/modules/templates/Campfire_Index.php
+++ b/skins/campfire/modules/templates/Campfire_Index.php
@@ -61,7 +61,7 @@
 <?= $quantServe ?>
 
 <?php
-	print '<script type="text/javascript">/*<![CDATA[*/for(var i=0;i<wgAfterContentAndJS.length;i++){wgAfterContentAndJS[i]();}/*]]>*/</script>' . "\n";
+	print '<script type="text/javascript">/*<![CDATA[*/while(wgAfterContentAndJS.length>0){wgAfterContentAndJS.shift()();} wgAfterContentAndJSLoaded = true;/*]]>*/</script>' . "\n";
 
 	print "<!-- BottomScripts -->\n";
 	print $bottomscripts;

--- a/skins/campfire/modules/templates/Campfire_Index.php
+++ b/skins/campfire/modules/templates/Campfire_Index.php
@@ -61,7 +61,7 @@
 <?= $quantServe ?>
 
 <?php
-	print '<script type="text/javascript">/*<![CDATA[*/while(wgAfterContentAndJS.length>0){wgAfterContentAndJS.shift()();} wgAfterContentAndJSLoaded = true;/*]]>*/</script>' . "\n";
+	print '<script type="text/javascript">/*<![CDATA[*/for(var i=0;i<wgAfterContentAndJS.length;i++){wgAfterContentAndJS[i]();}/*]]>*/</script>' . "\n";
 
 	print "<!-- BottomScripts -->\n";
 	print $bottomscripts;

--- a/skins/common/wikibits.js
+++ b/skins/common/wikibits.js
@@ -689,7 +689,7 @@ function getLabelFor (obj_id) {
 if (skin != 'monaco' && skin != 'oasis') {
 	//see RT#46116
 	if ( !(skin == 'answers' && !window.wgOldAnswerSkin) ) {
-		addOnloadHook(function() { for(var i=0;i<wgAfterContentAndJS.length;i++){wgAfterContentAndJS[i]();} });
+		addOnloadHook(function() { while(wgAfterContentAndJS.length>0){wgAfterContentAndJS.shift()();} wgAfterContentAndJSLoaded = true; });
 	}
 }
 

--- a/skins/common/wikibits.js
+++ b/skins/common/wikibits.js
@@ -689,7 +689,7 @@ function getLabelFor (obj_id) {
 if (skin != 'monaco' && skin != 'oasis') {
 	//see RT#46116
 	if ( !(skin == 'answers' && !window.wgOldAnswerSkin) ) {
-		addOnloadHook(function() { while(wgAfterContentAndJS.length>0){wgAfterContentAndJS.shift()();} wgAfterContentAndJSLoaded = true; });
+		addOnloadHook(function() { Wikia.LazyQueue.makeQueue(wgAfterContentAndJS, function(fn) {fn();}); wgAfterContentAndJS.start();} );
 	}
 }
 

--- a/skins/oasis/modules/templates/Oasis_Index.php
+++ b/skins/oasis/modules/templates/Oasis_Index.php
@@ -92,7 +92,7 @@
 
 <?= AdEngine::getInstance()->getDelayedIframeLoadingCode() ?>
 
-<script type="text/javascript">/*<![CDATA[*/while(wgAfterContentAndJS.length>0){wgAfterContentAndJS.shift()();}/*]]>*/</script>
+<script type="text/javascript">/*<![CDATA[*/while(wgAfterContentAndJS.length>0){wgAfterContentAndJS.shift()();} wgAfterContentAndJSLoaded = true; /*]]>*/</script>
 
 <?= $bottomScripts ?>
 <?= $cssPrintLinks ?>

--- a/skins/oasis/modules/templates/Oasis_Index.php
+++ b/skins/oasis/modules/templates/Oasis_Index.php
@@ -92,7 +92,7 @@
 
 <?= AdEngine::getInstance()->getDelayedIframeLoadingCode() ?>
 
-<script type="text/javascript">/*<![CDATA[*/while(wgAfterContentAndJS.length>0){wgAfterContentAndJS.shift()();} wgAfterContentAndJSLoaded = true; /*]]>*/</script>
+<script type="text/javascript">/*<![CDATA[*/ Wikia.LazyQueue.makeQueue(wgAfterContentAndJS, function(fn) {fn();}); wgAfterContentAndJS.start(); /*]]>*/</script>
 
 <?= $bottomScripts ?>
 <?= $cssPrintLinks ?>


### PR DESCRIPTION
For this ticket: https://wikia.fogbugz.com/default.asp?95138.  There's been many different strategies for loading anyclips videos, which rely on jQuery being loaded first, and can be loaded on the file page or on demand (via lightbox and VET).  

This seems to me to be the best solution for all scenarios.  It involves adding a flag to indicate the gAfterContentAndJS stack has been executed so that JS can be run on demand after page load.  

Notifying @macbre, since this is a global front end change. 

Note: this fix was branched off of dev but actually needs to be cherry picked into the release branch for this week's release. 
