### PR TITLE
BugID: 33724 - Page needs to reload after forced log-in

### DIFF
--- a/extensions/wikia/Chat2/ChatRailController.class.php
+++ b/extensions/wikia/Chat2/ChatRailController.class.php
@@ -4,7 +4,6 @@ class ChatRailController extends WikiaController {
 	const MAX_CHATTERS = 6;
 	const AVATAR_SIZE = 50;
 	const CHAT_WINDOW_FEATURES = 'width=600,height=600,menubar=no,status=no,location=no,toolbar=no,scrollbars=no,resizable=yes';
-	
 	const CACHE_DURATION = 5; // in seconds
 
 	/**
@@ -17,14 +16,12 @@ class ChatRailController extends WikiaController {
 		global $wgExtensionsPath;
 		wfProfileIn( __METHOD__ );
 
-		$this->buttonIconUrl = $wgExtensionsPath .'/wikia/Chat/images/chat_icon.png';
 		if ( !empty($this->totalInRoom) ) {
 			$this->buttonText = wfMsg('chat-join-the-chat');
 		} else {
 			$this->buttonText = wfMsg('chat-start-a-chat');
 		}
 		$this->linkToSpecialChat = SpecialPage::getTitleFor("Chat")->escapeLocalUrl();
-		$this->chatClickAction = "window.open('{$this->linkToSpecialChat}', 'wikiachat', '".self::CHAT_WINDOW_FEATURES."'); $('.modalWrapper').closeModal(); location.reload();";
 
 		wfProfileOut( __METHOD__ );
 	}

--- a/extensions/wikia/Chat2/css/ChatEntryPoint.scss
+++ b/extensions/wikia/Chat2/css/ChatEntryPoint.scss
@@ -14,6 +14,18 @@ body.skin-oasis .ChatMonobookEntryPoint {
 	display: none;
 }
 
+.chat-join {
+	button:before {
+		@include sprite-Chat-full('icon-chat_bubble');
+		content: "";
+		display: inline-block;
+		height: 15px;
+		margin-right: 5px;
+		vertical-align: middle;
+		width: 17px;
+	}
+}
+
 .ChatModule {
 	.chat-contents {
 		position: relative;
@@ -69,16 +81,6 @@ body.skin-oasis .ChatMonobookEntryPoint {
 		position: absolute;
 		top: 0;
 		right: 0;
-
-		button:before {
-			@include sprite-Chat-full('icon-chat_bubble');
-			content: "";
-			display: inline-block;
-			height: 15px;
-			margin-right: 5px;
-			vertical-align: middle;
-			width: 17px;
-		}
 	}
 
 	.chat-whos-here {

--- a/extensions/wikia/Chat2/js/ChatEntryPoint.js
+++ b/extensions/wikia/Chat2/js/ChatEntryPoint.js
@@ -110,13 +110,13 @@ var ChatEntryPoint = {
 		UserLoginModal.dialog.closeModal();
 		ChatEntryPoint.chatLaunchModal = $(html).makeModal({
 			width: 450,
-			onClose: ChatEntryPoint.onCloseJoinChatModal
+			onClose: ChatEntryPoint.reloadPage
 		});
 		ChatEntryPoint.chatLaunchModal.bind('click',ChatEntryPoint.launchChatWindow);
 
 	},
 
-	onCloseJoinChatModal: function() {
+	reloadPage: function() {
 		(new Wikia.Querystring()).addCb().goTo();
 	},
 
@@ -126,7 +126,7 @@ var ChatEntryPoint = {
 		if(ChatEntryPoint.chatLaunchModal) {
 			ChatEntryPoint.chatLaunchModal.closeModal();
 		}
-		(new Wikia.Querystring()).addCb().goTo();
+		ChatEntryPoint.reloadPage();
 	}
 };
 

--- a/extensions/wikia/Chat2/templates/ChatRail_AnonLoginSuccess.php
+++ b/extensions/wikia/Chat2/templates/ChatRail_AnonLoginSuccess.php
@@ -1,7 +1,6 @@
-<p>
+<p class='chat-join'>
 	<?= wfMsg('chat-great-youre-logged-in') ?>
-	<button onclick="<?= $chatClickAction ?>">
-		<img width="17" height="15" src="<?= $buttonIconUrl ?>">
+	<button id='modal-join-chat-button' data-chat-page="<?= $linkToSpecialChat ?>">
 		<?= $buttonText ?>
 	</button>
 </p>

--- a/extensions/wikia/Chat2/templates/ChatRail_AnonLoginSuccess.php
+++ b/extensions/wikia/Chat2/templates/ChatRail_AnonLoginSuccess.php
@@ -1,6 +1,6 @@
-<p class='chat-join'>
+<p class="chat-join">
 	<?= wfMsg('chat-great-youre-logged-in') ?>
-	<button id='modal-join-chat-button' data-chat-page="<?= $linkToSpecialChat ?>">
+	<button id="modal-join-chat-button" data-chat-page="<?= $linkToSpecialChat ?>">
 		<?= $buttonText ?>
 	</button>
 </p>


### PR DESCRIPTION
The fix addresses no reload on closing 'join the chat'
modal window after logging in from forced login modal.

There were also four changes done when fixing this:
1) inline JS removed from template
2) unnecessary and non-existent image removed from template
3) small refactoring of ChatEntryPoint.js to reduce nesting
   and increase readibility
4) introduced throbbing on forced log-in modal when waiting
   for server reply
