### PR TITLE
Pl q blitz bug id 93920

### DIFF
--- a/extensions/wikia/Chat2/js/controllers/controllers.js
+++ b/extensions/wikia/Chat2/js/controllers/controllers.js
@@ -127,7 +127,6 @@ var NodeRoomController = $.createClass(Observable,{
 	roomId: null,
 	mainController: null,
 	partTimeOuts: {},
-	logoutTimeOuts: {},
 	afterInitQueue: [],
 	banned: {},
 	userMain: null,

--- a/extensions/wikia/Chat2/js/controllers/controllers.js
+++ b/extensions/wikia/Chat2/js/controllers/controllers.js
@@ -387,7 +387,7 @@ var NodeRoomController = $.createClass(Observable,{
 	},
 
 	onLogout: function(message) {
-		/* we display the part message after the 15 seconds to avoid flooding the channel
+		/* we display the part message after 10 seconds to avoid flooding the channel
 		 with unnecessary part & join messages in case of refreshing chat window
 		 */
 		var logoutEvent = new models.LogoutEvent();

--- a/extensions/wikia/Chat2/js/controllers/controllers.js
+++ b/extensions/wikia/Chat2/js/controllers/controllers.js
@@ -127,6 +127,7 @@ var NodeRoomController = $.createClass(Observable,{
 	roomId: null,
 	mainController: null,
 	partTimeOuts: {},
+	logoutTimeOuts: {},
 	afterInitQueue: [],
 	banned: {},
 	userMain: null,
@@ -387,9 +388,17 @@ var NodeRoomController = $.createClass(Observable,{
 	},
 
 	onLogout: function(message) {
+		/* we display the part message after the 15 seconds to avoid flooding the channel
+		 with unnecessary part & join messages in case of refreshing chat window
+		 */
 		var logoutEvent = new models.LogoutEvent();
 		logoutEvent.mport(message.data);
-		this.onPartBase(logoutEvent.get('leavingUserName'), false);
+		if(this.partTimeOuts[logoutEvent.get('leavingUserName')]) {
+			return true;
+		}
+		this.partTimeOuts[logoutEvent.get('leavingUserName')] = setTimeout(this.proxy(function(){
+			this.onPartBase(logoutEvent.get('leavingUserName'), false);
+		}), 15000);
 	},
 
 	onKick: function(message) {

--- a/extensions/wikia/Chat2/js/controllers/controllers.js
+++ b/extensions/wikia/Chat2/js/controllers/controllers.js
@@ -397,7 +397,7 @@ var NodeRoomController = $.createClass(Observable,{
 		}
 		this.partTimeOuts[logoutEvent.get('leavingUserName')] = setTimeout(this.proxy(function(){
 			this.onPartBase(logoutEvent.get('leavingUserName'), false);
-		}), 15000);
+		}), 10000);
 	},
 
 	onKick: function(message) {


### PR DESCRIPTION
Postpone displaying logout message for 10 seconds to avoid flooding with login/logout messages when refreshing chat window
