### PR TITLE
check if related videos are enabled

### DIFF
--- a/extensions/wikia/VideoHandlers/videoInfo/VideoInfoHooksHelper.class.php
+++ b/extensions/wikia/VideoHandlers/videoInfo/VideoInfoHooksHelper.class.php
@@ -86,6 +86,12 @@ class VideoInfoHooksHelper {
 			return true;
 		}
 
+		// makes no sense to continue, if we're not running RelatedVideos on the wiki
+		$app = F::app();
+		if ( !$app->wg->EnableRelatedVideosExt ) {
+			return true;
+		}
+
 		$images = array();
 		$insertedImages = Wikia::getVar( 'imageInserts' );
 		foreach( $insertedImages as $img ) {


### PR DESCRIPTION
if wgEnableRelatedVideosExt is set to false, we get a fatal on save. This fixes the problem.

But this whole coupling of VideoHandlers (video info sub-module) is weird. Shouldn't this hook be in RelatedVideos instead?
