### PR TITLE
BugId 95198 - blog article sub-comments shown on wiki activity

### DIFF
--- a/extensions/wikia/MyHome/data/DataFeedProvider.php
+++ b/extensions/wikia/MyHome/data/DataFeedProvider.php
@@ -400,7 +400,7 @@ class DataFeedProvider {
 			$subpageTitle = Title::newFromText($title->getBaseText(), NS_BLOG_ARTICLE_TALK);
 			/*
 			* Unfortunately $subpageTitle->getSubpageText() don't grab the blog article title text for for subcomments.
-			* So considering blog structure is seems only reasonable way to get it, is to grab second title text part from full title text.
+			* So considering blog structure reasonable way to get it, is to grab second title text part from full title text.
 			*/
 			$articleText = explode("/", $title->getText());
 			$item['title'] = (count($articleText) > 2) ? $articleText[1] : $subpageTitle->getSubpageText();

--- a/extensions/wikia/MyHome/data/DataFeedProvider.php
+++ b/extensions/wikia/MyHome/data/DataFeedProvider.php
@@ -398,7 +398,7 @@ class DataFeedProvider {
 
 		} elseif (defined('NS_BLOG_ARTICLE_TALK') && $res['ns'] == NS_BLOG_ARTICLE_TALK && class_exists('ArticleComment')) {
 			$subpageTitle = Title::newFromText($title->getBaseText(), NS_BLOG_ARTICLE_TALK);
-			$articlwikieText = explode("/", $title->getText());
+			$articleText = explode("/", $title->getText());
 			(count($articleText) > 2) ? $articleTitleText = $articleText[1] : $articleTitleText = $subpageTitle->getSubpageText();
 			$item['title'] = $articleTitleText;
 			$item['url'] = $subpageTitle->getLocalUrl();;

--- a/extensions/wikia/MyHome/data/DataFeedProvider.php
+++ b/extensions/wikia/MyHome/data/DataFeedProvider.php
@@ -398,8 +398,10 @@ class DataFeedProvider {
 
 		} elseif (defined('NS_BLOG_ARTICLE_TALK') && $res['ns'] == NS_BLOG_ARTICLE_TALK && class_exists('ArticleComment')) {
 			$subpageTitle = Title::newFromText($title->getBaseText(), NS_BLOG_ARTICLE_TALK);
-			$item['title'] = $subpageTitle->getSubpageText();
-			$item['url'] = $subpageTitle->getLocalUrl();
+			$articleText = explode("/", $title->getText());
+			(count($articleText) > 2) ? $articleTitleText = $articleText[1] : $articleTitleText = $subpageTitle->getSubpageText();
+			$item['title'] = $articleTitleText;
+			$item['url'] = $subpageTitle->getLocalUrl();;
 
  		} elseif (defined('NS_BLOG_LISTING') && $res['ns'] == NS_BLOG_LISTING) {
 

--- a/extensions/wikia/MyHome/data/DataFeedProvider.php
+++ b/extensions/wikia/MyHome/data/DataFeedProvider.php
@@ -401,7 +401,7 @@ class DataFeedProvider {
 			$articleText = explode("/", $title->getText());
 			(count($articleText) > 2) ? $articleTitleText = $articleText[1] : $articleTitleText = $subpageTitle->getSubpageText();
 			$item['title'] = $articleTitleText;
-			$item['url'] = $subpageTitle->getLocalUrl();;
+			$item['url'] = $subpageTitle->getLocalUrl();
 
  		} elseif (defined('NS_BLOG_LISTING') && $res['ns'] == NS_BLOG_LISTING) {
 

--- a/extensions/wikia/MyHome/data/DataFeedProvider.php
+++ b/extensions/wikia/MyHome/data/DataFeedProvider.php
@@ -398,9 +398,12 @@ class DataFeedProvider {
 
 		} elseif (defined('NS_BLOG_ARTICLE_TALK') && $res['ns'] == NS_BLOG_ARTICLE_TALK && class_exists('ArticleComment')) {
 			$subpageTitle = Title::newFromText($title->getBaseText(), NS_BLOG_ARTICLE_TALK);
+			/*
+			* Unfortunately $subpageTitle->getSubpageText() don't grab the blog article title text for for subcomments.
+			* So considering blog structure is seems only reasonable way to get it, is to grab second title text part from full title text.
+			*/
 			$articleText = explode("/", $title->getText());
-			(count($articleText) > 2) ? $articleTitleText = $articleText[1] : $articleTitleText = $subpageTitle->getSubpageText();
-			$item['title'] = $articleTitleText;
+			$item['title'] = (count($articleText) > 2) ? $articleText[1] : $subpageTitle->getSubpageText();
 			$item['url'] = $subpageTitle->getLocalUrl();
 
  		} elseif (defined('NS_BLOG_LISTING') && $res['ns'] == NS_BLOG_LISTING) {

--- a/extensions/wikia/MyHome/data/DataFeedProvider.php
+++ b/extensions/wikia/MyHome/data/DataFeedProvider.php
@@ -398,7 +398,7 @@ class DataFeedProvider {
 
 		} elseif (defined('NS_BLOG_ARTICLE_TALK') && $res['ns'] == NS_BLOG_ARTICLE_TALK && class_exists('ArticleComment')) {
 			$subpageTitle = Title::newFromText($title->getBaseText(), NS_BLOG_ARTICLE_TALK);
-			$articleText = explode("/", $title->getText());
+			$articlwikieText = explode("/", $title->getText());
 			(count($articleText) > 2) ? $articleTitleText = $articleText[1] : $articleTitleText = $subpageTitle->getSubpageText();
 			$item['title'] = $articleTitleText;
 			$item['url'] = $subpageTitle->getLocalUrl();;


### PR DESCRIPTION
Unfortunately previous solution (https://github.com/Wikia/app/pull/312) didn't solve problem for getting blog article title text for subcomments. So considering blog structure is seems only reasonable way to get it, is to grab second title text part from full title text.
