### PR TITLE
Fixing reference to WMU.css -> WMU.scss

### DIFF
--- a/extensions/wikia/MiniEditor/css/MiniEditor.scss
+++ b/extensions/wikia/MiniEditor/css/MiniEditor.scss
@@ -7,7 +7,7 @@
 // Required outside assets
 @import "../../RTE/css/RTE"; // RTE.scss
 @import "../../VideoEmbedTool/css/VET"; // VET.scss
-@import "/extensions/wikia/WikiaMiniUpload/css/WMU.css";
+@import "../../WikiaMiniUpload/css/WMU"; // WMU.scss
 @import "../../WikiaStyleGuide/css/Dropdown"; // Dropdown.scss
 
 @import "core/colors";


### PR DESCRIPTION
There are errors on production generated from WMU.css change to WMU.scss
One of the files (MiniEditor.scss) was not updated to reflect file name change.

This pull request aims to remedy that.
