### PR TITLE
BugId:95082 - Existing user blog pages shown for non existing users.

### DIFF
--- a/extensions/wikia/Blogs/BlogTemplate.php
+++ b/extensions/wikia/Blogs/BlogTemplate.php
@@ -1080,7 +1080,7 @@ class BlogTemplateClass {
 								$relationArray[$sParamName] = $aParamValues;
 								$aTmpWhere = array();
 								foreach ( $aParamValues as $id => $sParamValue ) {
-									$sParamValue = str_replace(" ", "_", $sParamValue);
+									$sParamValue = str_replace(" ", "\\_", $sParamValue);
 									$aTmpWhere[] = "page_title like '".addslashes($sParamValue)."/%'";
 								}
 								if ( !empty($aTmpWhere) ) {


### PR DESCRIPTION
Mysql statement was grabbing blog pages of existing for non existing users in some cases.
Added escaping of underscore sign on username string which is used in mysql "like" statement as special sign, now is used literally. 
