### PR TITLE
bugId::95533 fixing bad WMU refactoring by targeting the correct element

### DIFF
--- a/extensions/wikia/WikiaMiniUpload/js/WMU.js
+++ b/extensions/wikia/WikiaMiniUpload/js/WMU.js
@@ -325,7 +325,7 @@ function WMU_loadMainFromView() {
 				document.body.appendChild(element);
 			}
 
-			WMU_modal = $(document.body).makeModal({
+			WMU_modal = $(element).makeModal({
 				onAfterClose: function() {
 					WMU_switchScreen('Main');
 				},


### PR DESCRIPTION
The original line of code that was being refactored was:
<code>WMU_panel.render(document.body);</code>
I had a brainfart
