### PR TITLE
Bugid 95455 wikia editor save category select state on login

### DIFF
--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -707,6 +707,7 @@ $config['mini_editor_js'] = array(
 		'//resources/mediawiki.action/mediawiki.action.edit.js',
 		// Edit Page Layout
 		'//extensions/wikia/EditPageLayout/js/editor/WikiaEditor.js',
+		'//extensions/wikia/EditPageLayout/js/editor/WikiaEditorStorage.js',
 		'//extensions/wikia/EditPageLayout/js/editor/Buttons.js',
 		'//extensions/wikia/EditPageLayout/js/editor/Modules.js',
 		'//extensions/wikia/EditPageLayout/js/plugins/MiniEditor.js',

--- a/extensions/wikia/CategorySelect/js/CategorySelect.js
+++ b/extensions/wikia/CategorySelect/js/CategorySelect.js
@@ -132,8 +132,6 @@
 					}
 				}));
 		}
-
-		element.trigger('ready', self);
 	};
 
 	/**

--- a/extensions/wikia/CategorySelect/js/CategorySelect.js
+++ b/extensions/wikia/CategorySelect/js/CategorySelect.js
@@ -132,6 +132,8 @@
 					}
 				}));
 		}
+
+		element.trigger('ready', self);
 	};
 
 	/**
@@ -604,7 +606,6 @@
 			new CategorySelect( this, options );
 		});
 	};
-
 	// Exports
 	Wikia.CategorySelect = CategorySelect;
 	window.Wikia = Wikia;

--- a/extensions/wikia/Development/Configs_DevBox/LocalSettings.php
+++ b/extensions/wikia/Development/Configs_DevBox/LocalSettings.php
@@ -11,7 +11,9 @@ error_reporting(E_ALL & ~ E_STRICT);
 ini_set('display_errors', '1');
 $wgShowExceptionDetails = true;
 
-$wgWikiaDatacenter = 'sjc';
+// include chef generated variables: $wgWikiaDatacenter
+require_once('/usr/wikia/devbox/DevBoxVariables.php');
+
 $IP = '/usr/wikia/source/wiki';
 $wgWikiaLocalSettingsPath  = __FILE__;
 $wgWikiaAdminSettingsPath = dirname( $wgWikiaLocalSettingsPath ) . "/../AdminSettings.php";
@@ -40,32 +42,45 @@ require_once( dirname( $wgWikiaLocalSettingsPath ) . '/../DB.sjc-dev.php' );
  * If you remove / comment / change order of the servers, the hash will miss
  * and that can result in bad performance for the cluster!
  */
-$wgMemCachedServers = array(
-	# ACTIVE LIST
-	# PLEASE MOVE SERVERS TO THE DOWN LIST RATHER THAN COMMENTING THEM OUT IN-PLACE
-	# If a server goes down, you must replace its slot with another server
-	# You can take a server for the spare list
+switch($wgWikiaDatacenter) {
+	case 'sjc':
+		$wgMemCachedServers = array(
+			# ACTIVE LIST
+			# PLEASE MOVE SERVERS TO THE DOWN LIST RATHER THAN COMMENTING THEM OUT IN-PLACE
+			# If a server goes down, you must replace its slot with another server
+			# You can take a server for the spare list
 
-	# SLOT	HOST
-	0 => "10.8.44.110:11000", # dev-memcached1
-	1 => "10.8.36.107:11000", # dev-memcached2
+			# SLOT	HOST
+			0 => "10.8.44.110:11000", # dev-memcached1
+			1 => "10.8.36.107:11000", # dev-memcached2
+		);
 
-/**** DOWN *****
+		$wgSessionMemCachedServers = array(
+			# SLOT	HOST
+			0 => "10.8.44.110:11000", # dev-memcached1
+			1 => "10.8.36.107:11000", # dev-memcached2
+		);
+		break;
 
-***** SPARE ****
-	X => "10.8.2.65:11000",		# memcached6
-	X => "10.8.2.61:11000",		# memcached4
-	X => "10.8.2.182:11000",	# memcached1
-	X => "10.8.2.44:11000",		# memcached2
-	X => "10.8.2.62:11000",		# memcached5
-****************/
-);
+	case 'poz':
+		$wgMemCachedServers = array(
+			# ACTIVE LIST
+			# PLEASE MOVE SERVERS TO THE DOWN LIST RATHER THAN COMMENTING THEM OUT IN-PLACE
+			# If a server goes down, you must replace its slot with another server
+			# You can take a server for the spare list
 
-$wgSessionMemCachedServers = array(
-	# SLOT	HOST
-	0 => "10.8.44.110:11000", # dev-memcached1
-	1 => "10.8.36.107:11000", # dev-memcached2
-);
+			# SLOT	HOST
+			0 => "10.14.30.143:11000", # dev-memcached-p1
+			1 => "10.14.30.143:11000", # dev-memcached-p2
+		);
+
+		$wgSessionMemCachedServers = array(
+			# SLOT	HOST
+			0 => "10.14.30.143:11000", # dev-memcached-p1
+			1 => "10.14.30.143:11000", # dev-memcached-p2
+		);
+		break;
+}
 
 # NOTE: THIS MUST BE DONE _BEFORE_ CALLING WikiFactory::execute IF WIKIFACTORY IS BEING USED.
 include("$IP/extensions/wikia/Development/SpecialDevBoxPanel/Special_DevBoxPanel.php");

--- a/extensions/wikia/EditPageLayout/EditPageLayoutHelper.class.php
+++ b/extensions/wikia/EditPageLayout/EditPageLayoutHelper.class.php
@@ -350,6 +350,7 @@ class EditPageLayoutHelper {
 			'extensions/wikia/EditPageLayout/js/loaders/EditPageEditorLoader.js',
 			// >> editor core
 			'extensions/wikia/EditPageLayout/js/editor/WikiaEditor.js',
+			'extensions/wikia/EditPageLayout/js/editor/WikiaEditorStorage.js',
 			'extensions/wikia/EditPageLayout/js/editor/Buttons.js',
 			'extensions/wikia/EditPageLayout/js/editor/Modules.js',
 			// >> Wikia specific editor plugins

--- a/extensions/wikia/EditPageLayout/js/editor/WikiaEditor.js
+++ b/extensions/wikia/EditPageLayout/js/editor/WikiaEditor.js
@@ -974,17 +974,15 @@
 		},
 
 		setContent: function(content, datamode) {
-			var ckeditor = this.editor.ck,
-				isWysiwyg = ckeditor.mode == 'wysiwyg',
-				dataKey = isWysiwyg ? 'wikitext' : 'html',
-				params = { title: wgPageName };
-
-			params[dataKey] = content;
+			var ckeditor = this.editor.ck;
 
 			// Needs conversion
 			if (datamode && ckeditor.mode != datamode) {
-				RTE.ajax(isWysiwyg ? 'html2wiki' : 'wiki2html', params, function(data) {
-					ckeditor.setData(data[dataKey]);
+				var params = { title: wgPageName };
+				params[isWysiwyg ? 'wikitext' : 'html'] = content;
+
+				RTE.ajax(isWysiwyg ? 'wiki2html' : 'html2wiki', params, function(data) {
+					ckeditor.setData(data[isWysiwyg ? 'html' : 'wikitext']);
 				});
 
 			} else {

--- a/extensions/wikia/EditPageLayout/js/editor/WikiaEditor.js
+++ b/extensions/wikia/EditPageLayout/js/editor/WikiaEditor.js
@@ -178,6 +178,14 @@
 		// set the state and submit the edit form
 		editorInstance.setState(editorInstance.states.RELOADING);
 
+		this.storeContent();
+
+		window.location.reload(true);
+	};
+
+	WE.storeContent = function(editorInstance) {
+		var editorInstance = WE.getInstance();
+
 		try {
 			// Save editor data before redirecting to prevent data loss (BugId:29754)
 			$.storage.set('WikiaEditorData', editorInstance.getContent());
@@ -186,9 +194,7 @@
 			$().log('Local Storage Exception:' + e.message);
 			$.storage.flush();
 		}
-
-		window.location.reload(true);
-	};
+	}
 
 	WE.Editor = $.createClass(Observable, {
 		states: {

--- a/extensions/wikia/EditPageLayout/js/editor/WikiaEditor.js
+++ b/extensions/wikia/EditPageLayout/js/editor/WikiaEditor.js
@@ -183,22 +183,8 @@
 		window.location.reload(true);
 	};
 
-	WE.storeContent = function(editorInstance) {
-		var editorInstance = WE.getInstance();
-
-		try {
-			// Save editor data before redirecting to prevent data loss (BugId:29754)
-
-			$.storage.set(WE.getStoreContentKey(), editorInstance.getContent());
-
-		} catch(e) {
-			$().log('Local Storage Exception:' + e.message);
-			$.storage.flush();
-		}
-	}
-
-	WE.getStoreContentKey = function() {
-		return 'WikiaEditorData/ArticleId-' + wgArticleId;
+	WE.storeContent = function() {
+		WikiaEditorStorage.store();
 	}
 
 	WE.Editor = $.createClass(Observable, {

--- a/extensions/wikia/EditPageLayout/js/editor/WikiaEditor.js
+++ b/extensions/wikia/EditPageLayout/js/editor/WikiaEditor.js
@@ -184,7 +184,7 @@
 	};
 
 	WE.storeContent = function() {
-		WikiaEditorStorage.store();
+		window.WikiaEditorStorage.store();
 	}
 
 	WE.Editor = $.createClass(Observable, {

--- a/extensions/wikia/EditPageLayout/js/editor/WikiaEditor.js
+++ b/extensions/wikia/EditPageLayout/js/editor/WikiaEditor.js
@@ -823,13 +823,26 @@
 
 			// Needs conversion
 			if (datamode == 'wysiwyg') {
-				RTE.ajax('html2wiki', { html: content, title: wgPageName }, function(data) {
+				this.html2wiki({ html: content, title: wgPageName }, function(data) {
 					editbox.val(data.wikitext);
 				});
 
 			} else {
 				editbox.val(content);
 			}
+		},
+
+		html2wiki: function(params, callback) {
+			if (typeof params != 'object') {
+				params = {};
+			}
+			params.method = 'html2wiki';
+
+			jQuery.post(window.wgScript + '?action=ajax&rs=RTEAjax', params, function(data) {
+				if (typeof callback == 'function') {
+					callback(data);
+				}
+			}, 'json');
 		},
 
 		editorFocused: function() {
@@ -979,6 +992,8 @@
 			// Needs conversion
 			if (datamode && ckeditor.mode != datamode) {
 				var params = { title: wgPageName };
+				var isWysiwyg = ckeditor.mode == 'wysiwyg';
+
 				params[isWysiwyg ? 'wikitext' : 'html'] = content;
 
 				RTE.ajax(isWysiwyg ? 'wiki2html' : 'html2wiki', params, function(data) {

--- a/extensions/wikia/EditPageLayout/js/editor/WikiaEditor.js
+++ b/extensions/wikia/EditPageLayout/js/editor/WikiaEditor.js
@@ -188,12 +188,17 @@
 
 		try {
 			// Save editor data before redirecting to prevent data loss (BugId:29754)
-			$.storage.set('WikiaEditorData', editorInstance.getContent());
+
+			$.storage.set(WE.getStoreContentKey(), editorInstance.getContent());
 
 		} catch(e) {
 			$().log('Local Storage Exception:' + e.message);
 			$.storage.flush();
 		}
+	}
+
+	WE.getStoreContentKey = function() {
+		return 'WikiaEditorData/ArticleId-' + wgArticleId;
 	}
 
 	WE.Editor = $.createClass(Observable, {

--- a/extensions/wikia/EditPageLayout/js/editor/WikiaEditorStorage.js
+++ b/extensions/wikia/EditPageLayout/js/editor/WikiaEditorStorage.js
@@ -9,9 +9,9 @@ WikiaEditorStorage.prototype = {
 	editorDirty: false,
 
 	store: function() {
-		if (typeof(wgArticleId) != undefined) {
+		if (typeof wgArticleId != 'undefined') {
 			var editorInstance = window.WikiaEditor.getInstance();
-			if (editorInstance.plugins.leaveconfirm == undefined || editorInstance.plugins.leaveconfirm.isDirty()) {
+			if (typeof editorInstance.plugins.leaveconfirm == 'undefined' || editorInstance.plugins.leaveconfirm.isDirty()) {
 				var summary = $('#wpSummary');
 				var categorySelect = $('#CategorySelect').data('categorySelect');
 
@@ -20,7 +20,7 @@ WikiaEditorStorage.prototype = {
 					content: editorInstance.getContent(),
 					editorMode: editorInstance.mode,
 					summary: summary.exists() ? summary.val() : undefined,
-					categories: categorySelect != undefined ? categorySelect.getData() : undefined
+					categories: typeof categorySelect != 'undefined' ? categorySelect.getData() : undefined
 				};
 
 				try {
@@ -66,21 +66,21 @@ WikiaEditorStorage.prototype = {
 		var content = this.getContent();
 		var editorMode = this.getEditorMode();
 
-		if (content != undefined && editorMode != undefined) {
+		if (typeof content != 'undefined' && typeof editorMode != 'undefined') {
 			editor.setContent(content, editorMode);
 		}
 	},
 
 	modifySummary: function() {
 		var summary = this.getSummary();
-		if (summary != undefined) {
+		if (typeof summary != 'undefined') {
 			$('#wpSummary').val(summary);
 		}
 	},
 
 	modifyCategories: function(categorySelect) {
 		var categories = this.getCategories();
-		if (categories != undefined) {
+		if (typeof categories != 'undefined') {
 			var actualCategories = categorySelect.getCategories();
 
 			var promises = [];

--- a/extensions/wikia/EditPageLayout/js/editor/WikiaEditorStorage.js
+++ b/extensions/wikia/EditPageLayout/js/editor/WikiaEditorStorage.js
@@ -4,6 +4,7 @@ WikiaEditorStorage.prototype = {
 	categories: undefined,
 	summary: undefined,
 	content: undefined,
+	editorMode: undefined,
 	articleId: undefined,
 
 	store: function() {
@@ -11,9 +12,10 @@ WikiaEditorStorage.prototype = {
 			var editorInstance = window.WikiaEditor.getInstance();
 			var summary = $('#wpSummary');
 
-			toStore = {
+			var toStore = {
 				articleId: wgArticleId,
 				content: editorInstance.getContent(),
+				editorMode: editorInstance.mode,
 				summary: summary.exists() ? summary.val() : undefined
 
 				// TODO
@@ -33,11 +35,12 @@ WikiaEditorStorage.prototype = {
 	init: function() {
 		this.fetchData();
 
-		$(window).bind('beforeWikiaEditorCreate', $.proxy(function(event, data){
-				this.modifyEditorContent(data);
-			},
-			this)
-		);
+		this.modifySummary();
+
+		editor = window.WikiaEditor.getInstance();
+		editor.on('ck-instanceReady', $.proxy(function(){
+			this.modifyEditorContent(editor);
+		}, this));
 	},
 
 	fetchData: function() {
@@ -48,14 +51,18 @@ WikiaEditorStorage.prototype = {
 			this.summary = storageData.summary;
 			this.articleId = storageData.articleId;
 			this.content = storageData.content;
+			this.editorMode = storageData.editorMode;
 		}
 		$.storage.del(storageKey);
 	},
 
-	modifyEditorContent: function(data) {
+	modifyEditorContent: function(editor) {
 		var content = this.getContent();
-		if (content != undefined) {
-			data.config.body.val(content);
+		var editorMode = this.getEditorMode();
+		if (content != undefined && editorMode != undefined) {
+			console.log(content);
+			console.log(editorMode);
+			editor.setContent(content, editorMode);
 		}
 	},
 
@@ -74,13 +81,16 @@ WikiaEditorStorage.prototype = {
 		return this.summary;
 	},
 
+	getEditorMode: function() {
+		return this.editorMode;
+	},
+
 	getStoreContentKey: function() {
 		return 'WikiaEditorData';
 	}
 };
 
 var WikiaEditorStorage = new WikiaEditorStorage();
-WikiaEditorStorage.init();
 $(function(){
-	WikiaEditorStorage.modifySummary();
+	WikiaEditorStorage.init();
 });

--- a/extensions/wikia/EditPageLayout/js/editor/WikiaEditorStorage.js
+++ b/extensions/wikia/EditPageLayout/js/editor/WikiaEditorStorage.js
@@ -9,9 +9,9 @@ WikiaEditorStorage.prototype = {
 	editorDirty: false,
 
 	store: function() {
-		if (typeof wgArticleId != 'undefined') {
+		if (typeof wgArticleId !== 'undefined') {
 			var editorInstance = window.WikiaEditor.getInstance();
-			if (typeof editorInstance.plugins.leaveconfirm == 'undefined' || editorInstance.plugins.leaveconfirm.isDirty()) {
+			if (typeof editorInstance.plugins.leaveconfirm === 'undefined' || editorInstance.plugins.leaveconfirm.isDirty()) {
 				var summary = $('#wpSummary');
 				var categorySelect = $('#CategorySelect').data('categorySelect');
 
@@ -20,7 +20,7 @@ WikiaEditorStorage.prototype = {
 					content: editorInstance.getContent(),
 					editorMode: editorInstance.mode,
 					summary: summary.exists() ? summary.val() : undefined,
-					categories: typeof categorySelect != 'undefined' ? categorySelect.getData() : undefined
+					categories: typeof categorySelect !== 'undefined' ? categorySelect.getData() : undefined
 				};
 
 				try {
@@ -66,21 +66,21 @@ WikiaEditorStorage.prototype = {
 		var content = this.getContent();
 		var editorMode = this.getEditorMode();
 
-		if (typeof content != 'undefined' && typeof editorMode != 'undefined') {
+		if (typeof content !== 'undefined' && typeof editorMode !== 'undefined') {
 			editor.setContent(content, editorMode);
 		}
 	},
 
 	modifySummary: function() {
 		var summary = this.getSummary();
-		if (typeof summary != 'undefined') {
+		if (typeof summary !== 'undefined') {
 			$('#wpSummary').val(summary);
 		}
 	},
 
 	modifyCategories: function(categorySelect) {
 		var categories = this.getCategories();
-		if (typeof categories != 'undefined') {
+		if (typeof categories !== 'undefined') {
 			var actualCategories = categorySelect.getCategories();
 
 			var promises = [];

--- a/extensions/wikia/EditPageLayout/js/editor/WikiaEditorStorage.js
+++ b/extensions/wikia/EditPageLayout/js/editor/WikiaEditorStorage.js
@@ -34,16 +34,10 @@ WikiaEditorStorage.prototype = {
 	init: function() {
 		this.fetchData();
 
-		$(function () {
-			$('#CategorySelect').on('ready', function(event, categorySelect) {
-				WikiaEditorStorage.modifyCategories(categorySelect);
-				})
-		});
-
-
 		GlobalTriggers.bind('WikiaEditorReady', $.proxy(function(editor){
 			this.modifySummary();
 			this.modifyEditorContent(editor);
+			this.modifyCategories($('#CategorySelect').data('categorySelect'));
 		}, this));
 	},
 
@@ -119,4 +113,6 @@ WikiaEditorStorage.prototype = {
 };
 
 var WikiaEditorStorage = new WikiaEditorStorage();
+window.WikiaEditorStorage = WikiaEditorStorage;
+
 WikiaEditorStorage.init();

--- a/extensions/wikia/EditPageLayout/js/editor/WikiaEditorStorage.js
+++ b/extensions/wikia/EditPageLayout/js/editor/WikiaEditorStorage.js
@@ -1,0 +1,86 @@
+var WikiaEditorStorage = function() {};
+
+WikiaEditorStorage.prototype = {
+	categories: undefined,
+	summary: undefined,
+	content: undefined,
+	articleId: undefined,
+
+	store: function() {
+		if (typeof(wgArticleId) != undefined) {
+			var editorInstance = window.WikiaEditor.getInstance();
+			var summary = $('#wpSummary');
+
+			toStore = {
+				articleId: wgArticleId,
+				content: editorInstance.getContent(),
+				summary: summary.exists() ? summary.val() : undefined
+
+				// TODO
+				//categories: categories
+			};
+
+			try {
+				$.storage.set(this.getStoreContentKey(), toStore);
+
+			} catch(e) {
+				$().log('Local Storage Exception:' + e.message);
+				$.storage.flush();
+			}
+		}
+	},
+
+	init: function() {
+		this.fetchData();
+
+		$(window).bind('beforeWikiaEditorCreate', $.proxy(function(event, data){
+				this.modifyEditorContent(data);
+			},
+			this)
+		);
+	},
+
+	fetchData: function() {
+		var storageKey = this.getStoreContentKey();
+		var storageData = $.storage.get(storageKey);
+
+		if (storageData != null && storageData.articleId == wgArticleId) {
+			this.summary = storageData.summary;
+			this.articleId = storageData.articleId;
+			this.content = storageData.content;
+		}
+		$.storage.del(storageKey);
+	},
+
+	modifyEditorContent: function(data) {
+		var content = this.getContent();
+		if (content != undefined) {
+			data.config.body.val(content);
+		}
+	},
+
+	modifySummary: function() {
+		var summary = this.getSummary();
+		if (summary != undefined) {
+			$('#wpSummary').val(summary);
+		}
+	},
+
+	getContent: function() {
+		return this.content;
+	},
+
+	getSummary: function() {
+		return this.summary;
+	},
+
+	getStoreContentKey: function() {
+		return 'WikiaEditorData';
+	}
+};
+
+var WikiaEditorStorage = new WikiaEditorStorage();
+WikiaEditorStorage.init();
+$(function(){
+	WikiaEditorStorage.modifySummary();
+});

--- a/extensions/wikia/EditPageLayout/js/editor/WikiaEditorStorage.js
+++ b/extensions/wikia/EditPageLayout/js/editor/WikiaEditorStorage.js
@@ -35,10 +35,8 @@ WikiaEditorStorage.prototype = {
 	init: function() {
 		this.fetchData();
 
-		this.modifySummary();
-
-		editor = window.WikiaEditor.getInstance();
-		editor.on('ck-instanceReady', $.proxy(function(){
+		GlobalTriggers.bind('WikiaEditorReady', $.proxy(function(editor){
+			this.modifySummary();
 			this.modifyEditorContent(editor);
 		}, this));
 	},
@@ -59,9 +57,8 @@ WikiaEditorStorage.prototype = {
 	modifyEditorContent: function(editor) {
 		var content = this.getContent();
 		var editorMode = this.getEditorMode();
+
 		if (content != undefined && editorMode != undefined) {
-			console.log(content);
-			console.log(editorMode);
 			editor.setContent(content, editorMode);
 		}
 	},
@@ -91,6 +88,4 @@ WikiaEditorStorage.prototype = {
 };
 
 var WikiaEditorStorage = new WikiaEditorStorage();
-$(function(){
-	WikiaEditorStorage.init();
-});
+WikiaEditorStorage.init();

--- a/extensions/wikia/EditPageLayout/js/loaders/EditPageEditorLoader.js
+++ b/extensions/wikia/EditPageLayout/js/loaders/EditPageEditorLoader.js
@@ -114,8 +114,6 @@
 		init: function() {
 			var data = this.getData();
 
-			$(window).trigger('beforeWikiaEditorCreate', [data]);
-
 			window.WikiaEditor.create(data.plugins, data.config);
 
 			$(window).bind('UserLoginSubmit', window.WikiaEditor.storeContent);

--- a/extensions/wikia/EditPageLayout/js/loaders/EditPageEditorLoader.js
+++ b/extensions/wikia/EditPageLayout/js/loaders/EditPageEditorLoader.js
@@ -9,15 +9,16 @@
 
 		constructor: function() {
 			var data;
+			var storageKey;
 
 			this.element = $('#EditPage');
 			this.body = $('#wpTextbox1');
 
 			// Use cached data. Generally stored before login redirect.
-			if ((data = $.storage.get('WikiaEditorData')) != null) {
-
+			storageKey = window.WikiaEditor.getStoreContentKey();
+			if ((data = $.storage.get(storageKey)) != null) {
 				this.body.val(data);
-				$.storage.del('WikiaEditorData');
+				$.storage.del(storageKey);
 			}
 		},
 

--- a/extensions/wikia/EditPageLayout/js/loaders/EditPageEditorLoader.js
+++ b/extensions/wikia/EditPageLayout/js/loaders/EditPageEditorLoader.js
@@ -8,18 +8,8 @@
 		element: false,
 
 		constructor: function() {
-			var data;
-			var storageKey;
-
 			this.element = $('#EditPage');
 			this.body = $('#wpTextbox1');
-
-			// Use cached data. Generally stored before login redirect.
-			storageKey = window.WikiaEditor.getStoreContentKey();
-			if ((data = $.storage.get(storageKey)) != null) {
-				this.body.val(data);
-				$.storage.del(storageKey);
-			}
 		},
 
 		getToolbarsConfig: function() {
@@ -123,6 +113,8 @@
 
 		init: function() {
 			var data = this.getData();
+
+			$(window).trigger('beforeWikiaEditorCreate', [data]);
 
 			window.WikiaEditor.create(data.plugins, data.config);
 

--- a/extensions/wikia/EditPageLayout/js/loaders/EditPageEditorLoader.js
+++ b/extensions/wikia/EditPageLayout/js/loaders/EditPageEditorLoader.js
@@ -15,6 +15,7 @@
 
 			// Use cached data. Generally stored before login redirect.
 			if ((data = $.storage.get('WikiaEditorData')) != null) {
+
 				this.body.val(data);
 				$.storage.del('WikiaEditorData');
 			}
@@ -123,6 +124,8 @@
 			var data = this.getData();
 
 			window.WikiaEditor.create(data.plugins, data.config);
+
+			$(window).bind('UserLoginSubmit', window.WikiaEditor.storeContent);
 		}
 	});
 

--- a/extensions/wikia/EditPageLayout/js/modules/Categories.js
+++ b/extensions/wikia/EditPageLayout/js/modules/Categories.js
@@ -18,7 +18,8 @@ WikiaEditor.modules.Categories = $.createClass( WikiaEditor.modules.base,{
 	afterAttach: function() {
 		var $categories = $( '#categories' ),
 			$categorySelect = $( '#CategorySelect' ),
-			namespace = 'categorySelect';
+			namespace = 'categorySelect',
+			editor = WikiaEditor.getInstance();
 
 		// Move to the right rail
 		this.el.replaceWith( $categorySelect );
@@ -49,7 +50,9 @@ WikiaEditor.modules.Categories = $.createClass( WikiaEditor.modules.base,{
 
 		}).on( 'update.' + namespace, function( event ) {
 			$categories.val( JSON.stringify(
-				$categorySelect.data( 'categorySelect' ).getData() ) );
+				$categorySelect.data( 'categorySelect' ).getData() )
+			);
+			editor.fire('markDirty');
 		});
 	}
 });

--- a/extensions/wikia/EditPageLayout/js/plugins/Leaveconfirm.js
+++ b/extensions/wikia/EditPageLayout/js/plugins/Leaveconfirm.js
@@ -13,10 +13,12 @@
 	 */
 	WE.plugins.leaveconfirm = $.createClass(WE.plugin,{
 
+		disableLeaveConfirm: false,
 		isDirtyFlag: false,
 		initialContent: false,
 		dialogShown: false,
 		leaveMessage: false,
+
 
 		init: function() {
 			this.leaveMessage = $.msg('wikia-editor-leaveconfirm-message');
@@ -30,6 +32,7 @@
 
 			$(window).bind('beforeunload.leaveconfirm', this.proxy(this.onBeforeUnload));
 			$(window).bind('unload.leaveconfirm', this.proxy(this.onUnload));
+			$(window).bind('UserLoginSubmit', this.proxy(this.onUserLoginSubmit))
 		},
 
 		onEditorReady: function() {
@@ -56,7 +59,7 @@
 
 		// @see https://developer.mozilla.org/en/DOM/window.onbeforeunload
 		onBeforeUnload: function(ev) {
-			if (this.isDirty()) {
+			if (this.shouldDisplayConfirm()) {
 				this.track('init');
 				this.dialogShown = true;
 
@@ -73,6 +76,10 @@
 			if (this.dialogShown) {
 				this.track('ok');
 			}
+		},
+
+		onUserLoginSubmit: function() {
+			this.disableLeaveConfirm = true;
 		},
 
 		track: function(ev) {
@@ -92,6 +99,10 @@
 		// was any change to the page made?
 		isDirty: function() {
 			return this.isDirtyFlag || this.isEditorDirty();
+		},
+
+		shouldDisplayConfirm: function() {
+			return (!this.disableLeaveConfirm && this.isDirty());
 		}
 	});
 })(this,jQuery);

--- a/extensions/wikia/EditPageLayout/js/plugins/Leaveconfirm.js
+++ b/extensions/wikia/EditPageLayout/js/plugins/Leaveconfirm.js
@@ -32,7 +32,9 @@
 
 			$(window).bind('beforeunload.leaveconfirm', this.proxy(this.onBeforeUnload));
 			$(window).bind('unload.leaveconfirm', this.proxy(this.onUnload));
-			$(window).bind('UserLoginSubmit', this.proxy(this.onUserLoginSubmit))
+			$(window).bind('UserLoginSubmit', this.proxy(this.onUserLoginSubmit));
+
+			$('#wpSummary').on('change', $.proxy(function() {this.editor.fire('markDirty')}, this));
 		},
 
 		onEditorReady: function() {

--- a/extensions/wikia/UserLogin/js/UserLoginAjaxForm.js
+++ b/extensions/wikia/UserLogin/js/UserLoginAjaxForm.js
@@ -35,6 +35,8 @@ UserLoginAjaxForm.prototype.init = function() {
 };
 
 UserLoginAjaxForm.prototype.submitLogin = function(e) {
+	$(window).trigger('UserLoginSubmit');
+
 	this.submitButton.attr('disabled', 'disabled');
 	if(this.options['ajaxLogin']) {
 		e.preventDefault();


### PR DESCRIPTION
This code is dependent on categoryselect-refactor code and should go live with this branch.

Preserving categories on user login in editor is done and tested.
