### PR TITLE
Fix for XSS vulnerability in CategoryGallery

### DIFF
--- a/extensions/wikia/CategoryGalleries/CategoryGallery.class.php
+++ b/extensions/wikia/CategoryGalleries/CategoryGallery.class.php
@@ -184,7 +184,7 @@
 		protected function getArticleSnippet( $articleId, $length = 150 ) {
 			wfProfileIn(__METHOD__);
 			$articleService = new ArticleService( $articleId );
-			$result = $articleService->getTextSnippet( $length );
+			$result = htmlspecialchars( $articleService->getTextSnippet( $length ) );
 			wfProfileOut(__METHOD__);
 			return $result;
 		}


### PR DESCRIPTION
Improper escaping in CategoryGallery::getArticleSnippet allows for arbitrary HTML insertion. I'm not sure if I should code this in the ArticleService class itself, as there appears to be escaping present.

Example: When the page http://swtor.wikia.com/wiki/Videos was displayed within http://swtor.wikia.com/wiki/Category:Candidates_for_deletion , the <object> tag therein was rendered.
