### PR TITLE
bugid-23457 | Added checking if editor is dirty and trigger dirty on change

### DIFF
--- a/extensions/wikia/EditPageLayout/js/plugins/Leaveconfirm.js
+++ b/extensions/wikia/EditPageLayout/js/plugins/Leaveconfirm.js
@@ -32,7 +32,9 @@
 
 			$(window).bind('beforeunload.leaveconfirm', this.proxy(this.onBeforeUnload));
 			$(window).bind('unload.leaveconfirm', this.proxy(this.onUnload));
-			$(window).bind('UserLoginSubmit', this.proxy(this.onUserLoginSubmit))
+			$(window).bind('UserLoginSubmit', this.proxy(this.onUserLoginSubmit));
+
+			$('#wpSummary').on('change', $.proxy(function() {this.editor.fire('markDirty')}, this));
 		},
 
 		onEditorReady: function() {


### PR DESCRIPTION
Fixed, that editor state is only saved when editor is marked as dirty.
Also changes in summary textarea marks editor as dirty.
WikiaEditorStorage marks editor as dirty when editor data is pulled from LocalStorage.
