### PR TITLE
Fix for same XSS issue in CategoryExhibition

### DIFF
--- a/extensions/wikia/CategoryExhibition/CategoryExhibitionSectionSubcategories.class.php
+++ b/extensions/wikia/CategoryExhibition/CategoryExhibitionSectionSubcategories.class.php
@@ -146,7 +146,7 @@ class CategoryExhibitionSectionSubcategories extends CategoryExhibitionSection {
 				}
 				if ( empty($snippetText) ){
 					$snippetService = new ArticleService ( $item['page_id'] );
-					$snippetText = $snippetService->getTextSnippet();;
+					$snippetText = htmlspecialchars( $snippetService->getTextSnippet() );
 				}
 				$counter++;
 			}


### PR DESCRIPTION
The ArticleService::getTextSnippet XSS vulnerability also affects CategoryGallery. I'm not sure if a similar fix in the extension itself is OK or the problem should be rectified in getTextSnippet itself&mdash;strip_tags is applied there.
