### PR TITLE
Check $wgEnableWikiaHomePageExt when trying to use WikiaHomePageHelper class

### DIFF
--- a/extensions/wikia/Search/classes/IndexService/WikiPromoData.php
+++ b/extensions/wikia/Search/classes/IndexService/WikiPromoData.php
@@ -16,7 +16,7 @@ class WikiPromoData extends AbstractWikiService
 	 * @var array
 	 */
 	protected $result;
-	
+
     /**
 	 * Access the promo text for a given wiki and set it in the document
 	 * @todo these need to be updated any time one of these values change for a wiki. could get dicey. will def need atomic update.
@@ -25,7 +25,7 @@ class WikiPromoData extends AbstractWikiService
 	 */
 	public function execute() {
 		wfProfileIn(__METHOD__);
-		if ( $this->result == null ) {
+		if ( $this->result == null && !empty(\F::app()->wg->EnableWikiaHomePageExt) ) {
 			$homepageHelper = new \WikiaHomePageHelper();
 			$detail = $homepageHelper->getWikiInfoForVisualization( $this->interface->getWikiId(), $this->interface->getLanguageCode() );
 			$this->result = array(


### PR DESCRIPTION
This code should only be run when WikiaHomePage extension is included.

Fixes the following fatal:

```
Jan 23 10:01:32 ap-s25 apache2[21096]: PHP Fatal error:  Class 'WikiaHomePageHelper' not found (URL: pt-br.crystalpedia.wikia.com/wikia.php?controller=WikiaSearch&method=getPages&ids=630&format=json) in /usr/wikia/slot1/code/extensions/wikia/Search/classes/IndexService/WikiPromoData.php on line 29
```
