### PR TITLE
AbTest: add a check for flags field (BugId:96148)

### DIFF
--- a/extensions/wikia/AnalyticsEngine/js/analytics_prod.js
+++ b/extensions/wikia/AnalyticsEngine/js/analytics_prod.js
@@ -102,6 +102,9 @@
 			abForceTrackOnLoad = false;
         for ( abIndex = 0; abIndex < abList.length; abIndex++ ) {
             abExp = abList[abIndex];
+			if ( !abExp || !abExp.flags) {
+				continue;
+			}
 			if ( !abExp.flags.ga_tracking ) {
 				continue;
 			}
@@ -207,7 +210,7 @@
      * @param {number=0} opt_value Event Value. Have to be an integer.
      * @param {boolean=false} opt_noninteractive Event noInteractive.
      */
-    window.gaTrackEvent = function(category, action, opt_label, opt_value, 
+    window.gaTrackEvent = function(category, action, opt_label, opt_value,
                                    opt_noninteractive) {
         var args = Array.prototype.slice.call(arguments);
         args.unshift('_trackEvent');


### PR DESCRIPTION
JS code is failing because AbTest assumes that `flags` field is always set, which apparently isn't true.

```
> JSON.stringify(window.Wikia.AbTest.getExperiments( /* includeAll */ true )) 
 "[{"id":2,"name":"PERFORMANCE_V_PREFOOTERS"}]"
```
