### PR TITLE
P2 quick fix bugid 96140

### DIFF
--- a/extensions/wikia/UserLogin/UserLoginSpecialController.class.php
+++ b/extensions/wikia/UserLogin/UserLoginSpecialController.class.php
@@ -67,6 +67,9 @@ class UserLoginSpecialController extends WikiaSpecialPageController {
 	 * @responseParam string editToken - token for changing password
 	 */
 	public function index() {
+		//new, probably temp asset as a fix for P2, bugId:96140
+		$this->response->addAsset( 'extensions/wikia/UserLogin/js/UserLoginSpecial.js' );
+		
 		// redirect if signup
 		$type = $this->request->getVal('type', '');
 		if($type === 'signup') {
@@ -559,7 +562,7 @@ class UserLoginSpecialController extends WikiaSpecialPageController {
 			'name' => 'username',
 			'isRequired' => true,
 			'label' => wfMsg('yourname'),
-			'isInvalid' => (!empty($errParam) && $errParam === 'username'),
+			'isInvalid' => (!empty($this->errParam) && $this->errParam === 'username'),
 			'value' => htmlspecialchars($this->username),
 			'tabindex' => ++$this->tabindex,
 		);
@@ -571,7 +574,7 @@ class UserLoginSpecialController extends WikiaSpecialPageController {
 			'name' => 'password',
 			'isRequired' => true,
 			'label' => wfMsg('yourpassword'),
-			'isInvalid' => (!empty($errParam) && $errParam === 'password'),
+			'isInvalid' => (!empty($this->errParam) && $this->errParam === 'password'),
 			'value' => htmlspecialchars($this->password),
 			'tabindex' => ++$this->tabindex,
 		);
@@ -580,7 +583,7 @@ class UserLoginSpecialController extends WikiaSpecialPageController {
 		$forgotPassword = array(
 			'type' => 'custom',
 			'class' => 'forgot-password',
-			'output' => '<a href="#" tabindex="0">'.wfMsg('userlogin-forgot-password').'</a>',
+			'output' => '<a href="#" tabindex="0" class="forgot-your-password-link">' . wfMsg('userlogin-forgot-password') . '</a>',
 		);
 
 		$rememberMeInput = array(
@@ -628,8 +631,8 @@ class UserLoginSpecialController extends WikiaSpecialPageController {
 			$form['inputs'][] = $createAccount;
 		}
 
-		$form['isInvalid'] = !empty($result) && empty($errParam) && !empty($msg);
-		$form['errorMsg'] = !empty($msg) ? $msg : '';
+		$form['isInvalid'] = !empty($this->result) && empty($this->errParam) && !empty($this->msg);
+		$form['errorMsg'] = !empty($this->msg) ? $this->msg : '';
 		
 		if( !empty($this->returnto) ) {
 			$form['inputs'][] = array(

--- a/extensions/wikia/UserLogin/UserLoginSpecialController.class.php
+++ b/extensions/wikia/UserLogin/UserLoginSpecialController.class.php
@@ -164,7 +164,6 @@ class UserLoginSpecialController extends WikiaSpecialPageController {
 		}
 		
 		$this->tabindex = self::SPECIAL_USERLOGIN_TABINDEX_START;
-		$this->makeInputFieldForForgotPassword = true;
 		$this->formData = $this->generateFormData();
 	}
 
@@ -194,6 +193,7 @@ class UserLoginSpecialController extends WikiaSpecialPageController {
 		$this->suppressCreateAccount = true;
 		$this->supressLogInBtnBig = true;
 		$this->returntoquery = $this->app->wf->ArrayToCGI( $query );
+
 		$this->formData = $this->generateFormData();
 	}
 
@@ -559,7 +559,7 @@ class UserLoginSpecialController extends WikiaSpecialPageController {
 			'name' => 'username',
 			'isRequired' => true,
 			'label' => wfMsg('yourname'),
-			'isInvalid' => (!empty($this->errParam) && $this->errParam === 'username'),
+			'isInvalid' => (!empty($errParam) && $errParam === 'username'),
 			'value' => htmlspecialchars($this->username),
 			'tabindex' => ++$this->tabindex,
 		);
@@ -571,27 +571,17 @@ class UserLoginSpecialController extends WikiaSpecialPageController {
 			'name' => 'password',
 			'isRequired' => true,
 			'label' => wfMsg('yourpassword'),
-			'isInvalid' => (!empty($this->errParam) && $this->errParam === 'password'),
+			'isInvalid' => (!empty($errParam) && $errParam === 'password'),
 			'value' => htmlspecialchars($this->password),
 			'tabindex' => ++$this->tabindex,
 		);
 		$passwordInput['errorMsg'] = $passwordInput['isInvalid'] ? $this->msg : '';
-		
-		if( !empty($this->makeInputFieldForForgotPassword) ) {
-			$forgotPassword = array(
-				'name' => 'action',
-				'type' => 'submit',
-				'class' => 'forgot-password link',
-				'value' => wfMsg('userlogin-forgot-password'),
-				'tabindex' => 0,
-			);
-		} else {
-			$forgotPassword = array(
-				'type' => 'custom',
-				'class' => 'forgot-password',
-				'output' => '<a href="#" tabindex="0">' . wfMsg('userlogin-forgot-password') . '</a>',
-			);
-		}
+
+		$forgotPassword = array(
+			'type' => 'custom',
+			'class' => 'forgot-password',
+			'output' => '<a href="#" tabindex="0">'.wfMsg('userlogin-forgot-password').'</a>',
+		);
 
 		$rememberMeInput = array(
 			'type' => 'checkbox',
@@ -637,10 +627,10 @@ class UserLoginSpecialController extends WikiaSpecialPageController {
 			);
 			$form['inputs'][] = $createAccount;
 		}
-		
-		$form['isInvalid'] = !empty($this->result) && empty($this->errParam) && !empty($this->msg);
-		$form['errorMsg'] = !empty($this->msg) ? $this->msg : '';
 
+		$form['isInvalid'] = !empty($result) && empty($errParam) && !empty($msg);
+		$form['errorMsg'] = !empty($msg) ? $msg : '';
+		
 		if( !empty($this->returnto) ) {
 			$form['inputs'][] = array(
 				'type' => 'hidden',

--- a/extensions/wikia/UserLogin/js/UserLoginSpecial.js
+++ b/extensions/wikia/UserLogin/js/UserLoginSpecial.js
@@ -1,0 +1,5 @@
+$(function() {
+	if( (typeof window.wgEnableUserLoginExt != 'undefined') && wgEnableUserLoginExt ) {
+		new UserLoginAjaxForm($('.UserLogin'));
+	}
+});

--- a/extensions/wikia/UserLogin/js/UserLoginSpecial.js
+++ b/extensions/wikia/UserLogin/js/UserLoginSpecial.js
@@ -1,5 +1,5 @@
 $(function() {
-	if( (typeof window.wgEnableUserLoginExt != 'undefined') && wgEnableUserLoginExt ) {
+	if( window.wgEnableUserLoginExt ) {
 		new UserLoginAjaxForm($('.UserLogin'));
 	}
 });


### PR DESCRIPTION
During work on [case 19518](https://wikia.fogbugz.com/default.asp?19518) we changed fields on Special:UserLogin form. But we removed input submit element and put regular anchor for "Frogot your password?" which introduced regression only on that one page [case 95971](https://wikia.fogbugz.com/default.asp?95971). We fixed the regression by restoring the submit input element but it caused another regression ([case 96140](https://wikia.fogbugz.com/default.asp?96140)) -- hitting Enter key submitted the form with the first submit input element which was "Forgot your password?" and not "Log in". The quick fix I've done is to have a regular anchor element for "Forgot your password?" and handling it the same way as we do in user login drop-down and user login force modal. 

However, it's a tech-debt because we aren't supporting now users without JavaScript enabled. I'm not sure if we wanted to support them and therefore we'll discuss it today during Daily Stand Up meeting and fix it if needed in coming sprints.
