### PR TITLE
Bugid 70020, 70081, 64316 - help page link tweaks for video tools

### DIFF
--- a/extensions/wikia/VideoEmbedTool/VideoEmbedTool.i18n.php
+++ b/extensions/wikia/VideoEmbedTool/VideoEmbedTool.i18n.php
@@ -63,7 +63,7 @@ $messages['en'] = array(
 	'vet-max-thumb' => 'maximum thumbnail size exceeded, reverting to original size',
 	'vet-notallowed' => 'You cannot insert videos on this wiki',
 	'vet-title' => 'Add a video to your article',
-	'vet-description' => 'Enter the full URL from any of the supported sites. See',
+	'vet-description' => 'Enter the full URL from any of the supported sites',
 	'vet-supported' => 'Supported video sites:',
 	'vet-preview' => '<i>This preview is not to scale</i>',
 	'vet-bad-url' => 'The supplied URL is invalid',
@@ -73,7 +73,7 @@ $messages['en'] = array(
 	'vet-add-button' => 'Add video',
 	'vet-added-from-gallery' => 'video added from video gallery',
 	'vet-added-from-placeholder' => 'Video added from video placeholder',
-	'vet-see-all' => 'all',
+	'vet-see-all' => 'See all',
 	'vet-bad-search' => 'Error loading search query.',
 	'vet-no-preview' => 'You cannot add video from article in preview mode.',
 	'vet-single-success' => 'Your video has been added to the article.',
@@ -94,7 +94,8 @@ $messages['en'] = array(
 	'vet-search-results-WVL' => 'We found $1 {{PLURAL:$1|result|results}} for "$2" on Wikia Video Library',
 	'vet-search-results-local' => 'We found $1 {{PLURAL:$1|result|results}} for "$2" on this Wiki',
 	'vet-search-filter-caption' => 'Search filter',
-	'vet-video-add-intro' => 'Looking for videos for your wiki? Try searching at [http://video.wikia.com Wikia Video Library] for high quality videos licensed by Wikia.'
+	'vet-video-add-intro' => 'Looking for videos for your wiki? Try searching at [http://video.wikia.com Wikia Video Library] for high quality videos licensed by Wikia.',
+	'vet-supported-sites-help-link' => 'http://community.wikia.com/wiki/Help:Videos#Supported_sites'
 );
 
 /** Message documentation (Message documentation)
@@ -1919,7 +1920,7 @@ Podaj nazwę tego filmu. Może to być np. opis jego zawartości.',
 	'vet-imagebutton' => 'Wstaw filmy',
 	'vet-license-cc' => 'Udostępniane na licencji Creative Commons Uznanie autorstwa – Na tych samych warunkach 3.0',
 	'vet-name-incorrect' => 'Nazwa filmu zawiera niedozwolone znaki, jak #',
-	'vet-description' => 'Wprowadź pełny adres URL jednej z obsługiwanych witryn. Zobacz',
+	'vet-description' => 'Wprowadź pełny adres URL jednej z obsługiwanych witryn.',
 	'vet-uploadtext' => "'''Ten formularz umożliwia szybkie przesyłanie i zamieszczanie plików w artykułach.'''
 
 ''Zobacz również [[Special:Log/upload|rejestr przesyłania]] oraz [[Special:ImageList|spis wszystkich przesłanych plików]].''",
@@ -1938,7 +1939,7 @@ Podaj nazwę tego filmu. Może to być np. opis jego zawartości.',
 	'vet-page-success' => 'Strona filmu została zaktualizowana. Być może trzeba będzie odświeżyć stronę, aby zobaczyć zmianę.',
 	'vet-add-button' => 'Dodaj film',
 	'vet-added-from-gallery' => 'dodano film z galerii',
-	'vet-see-all' => 'wszystko',
+	'vet-see-all' => 'Zobacz wszystkie',
 	'vet-bad-search' => 'Błąd podczas ładowania zapytania.',
 	'vet-no-preview' => 'Nie możesz w trybie podglądu dodać filmu z artykułu.',
 	'vet-single-success' => 'Film został pomyślnie dodany do artykułu.',
@@ -1948,6 +1949,7 @@ Podaj nazwę tego filmu. Może to być np. opis jego zawartości.',
 	'vet-right' => 'Prawo',
 	'vet-gallery' => 'Galeria',
 	'vet-protected' => 'Ten film jest zabezpieczony.',
+	'vet-supported-sites-help-link' => 'http://spolecznosc.wikia.com/wiki/Pomoc:Video_Embed_Tool#Serwisy'
 );
 
 /** Piedmontese (Piemontèis)

--- a/extensions/wikia/VideoEmbedTool/templates/main.tmpl.php
+++ b/extensions/wikia/VideoEmbedTool/templates/main.tmpl.php
@@ -24,7 +24,7 @@
 		<div class="input-group">
 			<label for="VideoEmbedUrl" class="with-info-p"><?= wfMsg('vet-url-label') ?></label>
 			<div>
-				<p><?= wfMsg( 'vet-description' ) ?> <a href="http://help.wikia.com/wiki/Help:Video_Embed_Tool" target="_blank"><?= wfMsg( 'vet-see-all' ) ?></a></p>
+				<p><?= wfMsg( 'vet-description' ) ?> <a href="<?= wfMsg('vet-supported-sites-help-link') ?>" target="_blank"><?= wfMsg( 'vet-see-all' ) ?></a></p>
 				<input id="VideoEmbedUrl" name="wpVideoEmbedUrl" type="text" onkeypress="VET_onVideoEmbedUrlKeypress(event);" />
 			</div>
 		</div>

--- a/extensions/wikia/VideoHandlers/VideoHandlers.i18n.php
+++ b/extensions/wikia/VideoHandlers/VideoHandlers.i18n.php
@@ -40,7 +40,8 @@ $messages['en'] = array(
 	'videos-error-unknown' => 'An unknown error occurred. Code: $1.',
 	'videos-error-old-type-video' => 'Old type of videos no longer supported (VideoPage)',
 	'videos-error-while-loading' => 'Error occurred while loading data. Please recheck your connection and refesh the page.',
-	'videos-initial-upload-edit-summary' => 'created video',
+	'videos-initial-upload-edit-summary' => 'created video'
+	'videos-supported-sites-help-link' => 'http://community.wikia.com/wiki/Help:Videos#Supported_sites',
 );
 
 /** Message documentation (Message documentation) */
@@ -480,9 +481,10 @@ $messages['pl'] = array(
 	'videohandler-category' => 'Filmy',
 	'videohandler-description' => 'Opis',
 	'videos-error-while-loading' => 'Wystąpił błąd podczas ładowania danych. Sprawdź ponownie połączenie i odśwież stronę.',
-	'videos-add-video-label-name' => 'Wpisz pełny adres URL, z jednej z obsługiwanych witryn.',
+	'videos-add-video-label-name' => 'Wprowadź pełny adres URL jednej z obsługiwanych witryn.',
 	'videos-add-video-ok' => 'Dodaj',
-	'videos-add-video-label-all' => 'Pokaż wszystko',
+	'videos-add-video-label-all' => 'Zobacz wszystkie'
+	'videos-supported-sites-help-link' => 'http://spolecznosc.wikia.com/wiki/Pomoc:Video_Embed_Tool#Serwisy',
 );
 
 /** Piedmontese (Piemontèis)

--- a/extensions/wikia/VideoHandlers/templates/Videos_addVideoModalText.php
+++ b/extensions/wikia/VideoHandlers/templates/Videos_addVideoModalText.php
@@ -3,10 +3,7 @@
 <div class="addRelatedVideos input-group required">
 	<label>
 		<?= wfMsg('videos-add-video-label-name') ?>
-		<a class="remove" href="<?
-			$oTitle = F::build( 'Title', array( 'Video_Embed_Tool', NS_HELP ), 'newFromText' );
-			echo $oTitle->getFullURL();
-		?>"><?= wfMsg('videos-add-video-label-all') ?></a>
+		<a class="remove" href="<?= wfMsg('videos-supported-sites-help-link') ?>"><?= wfMsg('videos-add-video-label-all') ?></a>
 		<br>
 		<input type="text" name="videoUrl" class="videoUrl" value="">
 		<button type="submit" class="button relatedVideosConfirm"><?= wfMsg('videos-add-video-ok') ?></button>


### PR DESCRIPTION
The attached commits address three tickets:

https://wikia.fogbugz.com/default.asp?70020 and https://wikia.fogbugz.com/default.asp?70081 - Both the VET and the AddVideo tools had more or less hardcoded links to  help pages listing supported sites from which a user can embed videos. I created new messages which contain the help page URLs and replaced the hardcoded links with references to proper messages. This solution is more i18n-friendly because it allows the i18n team to customize where the links go to, which also resolves https://wikia.fogbugz.com/default.asp?64316. If they are not translated, they will still default to English.

I'm not sure about the syntax and if the commits are compliant with any coding practices Wikia is using, that's why I'd like to ask an engineer to review the code and if everything is ok - merge with the main branch or close the request if it's not.Thanks in advance! :)
