### PR TITLE
Add undefined messages to ext.quickTools

### DIFF
--- a/extensions/wikia/QuickTools/QuickTools.setup.php
+++ b/extensions/wikia/QuickTools/QuickTools.setup.php
@@ -47,7 +47,9 @@ $wgResourceModules['ext.quickTools'] = $qtResourceTemplate + array(
 	),
 	'messages' => array(
 		'quicktools-bot-reason',
-		'quicktools-botflag-remove'
+		'quicktools-botflag-remove',
+		'quicktools-adopt-success',
+		'quicktools-adopt-error'
 	)
 );
 $wgResourceModules['ext.createUserPage'] = $qtResourceTemplate + array(


### PR DESCRIPTION
Currently, ext.quickTools of extensions/wikia/QuickTools attempts to access the messages "quicktools-adopt-success" & "quicktools-adopt-error" when calling QuickTools.changeRights(); the messages are not rendered, as ResourceLoader is not instructed to load them. This commit adds the messages to $wgResourceModules['ext.quickTools'] as a fix.
