### PR TITLE
Fix broken reference to AIM

### DIFF
--- a/extensions/wikia/SpecialPromote/SpecialPromoteController.class.php
+++ b/extensions/wikia/SpecialPromote/SpecialPromoteController.class.php
@@ -43,7 +43,6 @@ class SpecialPromoteController extends WikiaSpecialPageController {
 			return true;
 		}
 
-		$this->response->addAsset('resources/wikia/libraries/aim/jquery.aim.js');
 		$this->response->addAsset('extensions/wikia/SpecialPromote/js/SpecialPromote.js');
 
 		F::build('JSMessages')->enqueuePackage('SpecialPromote', JSMessages::EXTERNAL);

--- a/extensions/wikia/SpecialPromote/js/SpecialPromote.js
+++ b/extensions/wikia/SpecialPromote/js/SpecialPromote.js
@@ -432,7 +432,11 @@ SpecialPromote.prototype = {
 	}
 };
 
-var SpecialPromoteInstance = new SpecialPromote();
 $(function () {
-	SpecialPromoteInstance.init();
+	$.when(
+		$.loadJQueryAIM()
+	).done(function() {
+		var SpecialPromoteInstance = new SpecialPromote();
+		SpecialPromoteInstance.init();
+	});
 });


### PR DESCRIPTION
This pull request is to fix broken reference to resource ( jquery.aim.js ) that has been re-written and moved.
Missing reference is breaking existing functionality on preview (Special:Promote)
