### PR TITLE
fixing image and video placeholder regex issues

### DIFF
--- a/extensions/wikia/ImagePlaceholder/ImagePlaceholder_setup.php
+++ b/extensions/wikia/ImagePlaceholder/ImagePlaceholder_setup.php
@@ -279,7 +279,7 @@ function ImagePlaceholderMakePlaceholder( $file, $frameParams, $handlerParams ) 
 		'data-align' => $isalign,
 		'data-thumb' => $isthumb,
 		'data-caption' => htmlspecialchars($caption),
-		'data-width' => $isvideo ? '' : $width, // let VET slider determine width for video
+		'data-width' => $width,
 	);
 	
 	if( !$isvideo ) { // image placeholder
@@ -342,15 +342,19 @@ function ImagePlaceholderMakePlaceholder( $file, $frameParams, $handlerParams ) 
 	return $out;
 }
 
-// Match a placeholder image in the given $text.  The $box parameter determines
-// which placeholder is returned if there are more than one on the page.  If
-// the namespace is not NS_FILE it can be passed via the $ns parameter.  Finally
-// if there is anything additional to match within the placeholder tag, it can
-// be passed via parameter $constrain.
-function ImagePlaceholderMatch ( $text, $box = 0, $ns = NS_FILE, $constrain = null ) {
+/* Used by WMU and VET. Match a placeholder image in the given $text.  The $box parameter determines
+ * which placeholder is returned if there are more than one on the page.
+ * 
+ * @param string $text Article text to check agains placeholder wikitext
+ * @param int $box Index of placeholder to be replaced in case there's more than one on a page
+ * @param bool $isVideo Check placeholder for existence of "|video"  
+ */
+
+function MediaPlaceholderMatch ( $text, $box = 0, $isVideo = false ) {
 	global $wgContLang;
 
 	// Get the namesapace translations in the content language for files and videos
+	$ns = NS_FILE;
 	$ns_vid = $wgContLang->getFormattedNsText( $ns );
 	$ns_img = ImagePlaceholderTranslateNsImage();
 
@@ -372,16 +376,30 @@ function ImagePlaceholderMatch ( $text, $box = 0, $ns = NS_FILE, $constrain = nu
 			$en_ns_vid . ':' . $en_placeholder_msg,
 			$en_ns_img . ':' . $en_placeholder_msg)) . ')';
 
-	$placeholder .= $constrain ? $constrain : '';
-
 	preg_match_all( '/\[\[' . $placeholder . '[^\]]*\]\]/si', $text, $matches, PREG_OFFSET_CAPTURE );
 
 	// Make sure we have matches and that there exists a match at index $box
-	if (is_array($matches) && count($matches[0]) > $box ) {
-		return $matches[0][$box];
-	} else {
-		return null;
+	if ( is_array($matches) ) {
+		$matchArr = $matches[0];
+		
+		for( $x = 0; $x < count( $matchArr ); $x++ ) {
+			$match = $matchArr[$x];
+			if( $isVideo ) {
+				if ( !preg_match( '/\|video/', $match[0] ) ) {
+					array_splice($matchArr, $x, 1);
+				}	
+			} else {
+				if ( preg_match( '/video/', $match[0] ) ) {
+					array_splice($matchArr, $x, 1);
+				}		
+			}
+		}
+		if ( count($matchArr) > $box ) {
+			return $matchArr[$box];
+		}
 	}
+	
+	return null;
 }
 
 // check if this is or not a placeholder

--- a/extensions/wikia/WikiaMiniUpload/WikiaMiniUpload_body.php
+++ b/extensions/wikia/WikiaMiniUpload/WikiaMiniUpload_body.php
@@ -538,6 +538,8 @@ class WikiaMiniUpload {
 			return 'File was not found!';
 		}
 
+		$ns_img = $wgContLang->getFormattedNsText( NS_IMAGE );
+
 		if( ( -2 == $gallery ) && !$fck ) {
 			// this went in from the single placeholder...
 			$name = $title->getText();
@@ -555,9 +557,9 @@ class WikiaMiniUpload {
 
 			wfRunHooks( 'WikiaMiniUpload::fetchTextForImagePlaceholder', array( &$title_obj, &$text ) );
 
-			$box = '' != $wgRequest->getVal( 'box' ) ? $wgRequest->getVal( 'box' ) : '' ;
+			$box = $wgRequest->getVal( 'box', '' );
 
-			$placeholder = ImagePlaceholderMatch( $text, $box );
+			$placeholder = MediaPlaceholderMatch( $text, $box );
 
 			$success = false;
 			if ( $placeholder ) {
@@ -602,7 +604,8 @@ class WikiaMiniUpload {
 				header('X-screen-type: summary');
 			} else {
 				// failure signal opens js alert (BugId:4935)
-				// header('X-screen-type: error');
+				header('X-screen-type: error');
+				return;
 			}
 		} else {
 			header('X-screen-type: summary');
@@ -612,8 +615,6 @@ class WikiaMiniUpload {
 			$layout = $wgRequest->getVal('layout');
 			$caption = $wgRequest->getVal('caption');
 			$slider = $wgRequest->getVal('slider');
-
-			$ns_img = $wgContLang->getFormattedNsText( NS_IMAGE );
 
 			$tag = '[[' . $ns_img . ':'.$title->getDBkey();
 			if($size != 'full' && ($file->getMediaType() == 'BITMAP' || $file->getMediaType() == 'DRAWING')) {


### PR DESCRIPTION
For ticket https://wikia.fogbugz.com/default.asp?95916#610805.  Image placeholders were being inserted into the right place initially, but then on refresh, they had actually been inserted into the video placeholder. 
