### PR TITLE
BugId:97097 - different Board namespace for DE

### DIFF
--- a/extensions/wikia/Forum/Forum.namespaces.php
+++ b/extensions/wikia/Forum/Forum.namespaces.php
@@ -13,7 +13,7 @@ $namespaces['en'] = array(
  * German
  */
 $namespaces['de'] = array(
-	NS_WIKIA_FORUM_BOARD	=> 'Forum',
+	NS_WIKIA_FORUM_BOARD	=> 'Diskussionsforum',
 	NS_WIKIA_FORUM_TOPIC_BOARD	=> 'Thema',
 	NS_WIKIA_FORUM_BOARD_THREAD	=> 'Forum-Diskussionsfaden',
 );


### PR DESCRIPTION
https://wikia.fogbugz.com/default.asp?97097 - The previously requested alias for the "Board" namespace in German - "Forum" - caused issues with viewing pages from the 'old' Forum namespace. As requested in the linked ticket, the alias has been changed to something that won't cause conflicts with existing namespaces.

Please review and merge (or dismiss), thanks in advance!
