### PR TITLE
CategorySelect: fixes BugId:97334 and BugId:97512.

### DIFF
--- a/extensions/wikia/CategorySelect/CategorySelect.class.php
+++ b/extensions/wikia/CategorySelect/CategorySelect.class.php
@@ -12,7 +12,6 @@
 
 class CategorySelect {
 	private static $categories;
-	private static $categoryTypes;
 	private static $data;
 	private static $frame;
 	private static $isEditable;
@@ -134,10 +133,11 @@ class CategorySelect {
 		return self::$data;
 	}
 
-	public static function getCategoryTypes() {
-		return self::$categoryTypes;
-	}
-
+	/**
+	 * Extracts category tags from wikitext and returns a hash of the categories
+	 * and the wikitext with categories removed. If wikitext is not provided, it will
+	 * attempt to pull it from the current article.
+	 */
 	public static function getExtractedCategoryData( $wikitext = '', $force = false ) {
 		if ( !isset( self::$data ) ) {
 
@@ -308,14 +308,6 @@ class CategorySelect {
 		wfProfileOut( __METHOD__ );
 
 		return self::$isEnabled;
-	}
-
-	/**
-	 * Sets the type associated with categories (either "normal" or "hidden").
-	 * This function is called from a hook for view pages only.
-	 */
-	public static function setCategoryTypes( $categoryTypes ) {
-		self::$categoryTypes = $categoryTypes;
 	}
 
 	private static function parseNode(&$root, $outerTag = '') {

--- a/extensions/wikia/CategorySelect/CategorySelectController.class.php
+++ b/extensions/wikia/CategorySelect/CategorySelectController.class.php
@@ -29,12 +29,15 @@ class CategorySelectController extends WikiaController {
 		$categoryLinks = $this->wg->out->getCategoryLinks();
 		$userCanEdit = $this->request->getVal( 'userCanEdit', CategorySelect::isEditable() );
 
-		// Flatten categoryLinks into a single array. Keep hidden categories based on user preference.
-		if ( $this->wg->User->getBoolOption( 'showhiddencats' ) ) {
-			$categoryLinks = array_merge( $categoryLinks[ 'normal' ], $categoryLinks[ 'hidden' ] );
+		if ( !empty( $categoryLinks[ 'normal' ] ) ) {
 
-		} else {
-			$categoryLinks = $categoryLinks[ 'normal' ];
+			// Flatten categoryLinks array. Keep hidden categories based on user preference.
+			if ( !empty( $categoryLinks[ 'hidden' ] ) && $this->wg->User->getBoolOption( 'showhiddencats' ) ) {
+				$categoryLinks = array_merge( $categoryLinks[ 'normal' ], $categoryLinks[ 'hidden' ] );
+
+			} else {
+				$categoryLinks = $categoryLinks[ 'normal' ];
+			}
 		}
 
 		// There are no categories present and user can't edit, skip rendering

--- a/extensions/wikia/CategorySelect/CategorySelectController.class.php
+++ b/extensions/wikia/CategorySelect/CategorySelectController.class.php
@@ -29,15 +29,9 @@ class CategorySelectController extends WikiaController {
 		$categoryLinks = $this->wg->out->getCategoryLinks();
 		$userCanEdit = $this->request->getVal( 'userCanEdit', CategorySelect::isEditable() );
 
-		if ( !empty( $categoryLinks[ 'normal' ] ) ) {
-
-			// Flatten categoryLinks array. Keep hidden categories based on user preference.
-			if ( !empty( $categoryLinks[ 'hidden' ] ) && $this->wg->User->getBoolOption( 'showhiddencats' ) ) {
-				$categoryLinks = array_merge( $categoryLinks[ 'normal' ], $categoryLinks[ 'hidden' ] );
-
-			} else {
-				$categoryLinks = $categoryLinks[ 'normal' ];
-			}
+		// Remove hidden categories if user has chosen not to see them.
+		if ( !empty( $categoryLinks[ 'hidden' ] ) && !$this->wg->User->getBoolOption( 'showhiddencats' ) ) {
+			unset( $categoryLinks[ 'hidden' ] );
 		}
 
 		// There are no categories present and user can't edit, skip rendering
@@ -72,6 +66,7 @@ class CategorySelectController extends WikiaController {
 		$this->response->setVal( 'edit', $this->wf->Msg( 'categoryselect-category-edit' ) );
 		$this->response->setVal( 'name', $this->request->getVal( 'name', '' ) );
 		$this->response->setVal( 'remove', $this->wf->Msg( 'categoryselect-category-remove' ) );
+		$this->response->setVal( 'type', $this->request->getVal( 'type', 'normal' ) );
 
 		$this->response->setTemplateEngine( WikiaResponse::TEMPLATE_ENGINE_MUSTACHE );
 	}

--- a/extensions/wikia/CategorySelect/CategorySelectController.class.php
+++ b/extensions/wikia/CategorySelect/CategorySelectController.class.php
@@ -34,6 +34,9 @@ class CategorySelectController extends WikiaController {
 			unset( $categoryLinks[ 'hidden' ] );
 		}
 
+		// Make sure category types always show up in the same order (hidden last)
+		krsort( $categoryLinks );
+
 		// There are no categories present and user can't edit, skip rendering
 		if ( !$userCanEdit && !count( $categoryLinks ) ) {
 			$this->wf->ProfileOut( __METHOD__ );

--- a/extensions/wikia/CategorySelect/CategorySelectController.class.php
+++ b/extensions/wikia/CategorySelect/CategorySelectController.class.php
@@ -26,31 +26,19 @@ class CategorySelectController extends WikiaController {
 			return false;
 		}
 
-		// Categories are passed in for EditPage preview
-		$categories = $this->request->getVal( 'categories', array() );
+		$categoryLinks = $this->wg->out->getCategoryLinks();
 		$userCanEdit = $this->request->getVal( 'userCanEdit', CategorySelect::isEditable() );
 
-		// Build categories from categoryTypes array
-		if ( empty( $categories ) ) {
-			$categoryTypes = CategorySelect::getCategoryTypes();
+		// Flatten categoryLinks into a single array. Keep hidden categories based on user preference.
+		if ( $this->wg->User->getBoolOption( 'showhiddencats' ) ) {
+			$categoryLinks = array_merge( $categoryLinks[ 'normal' ], $categoryLinks[ 'hidden' ] );
 
-			if ( is_array( $categoryTypes ) ) {
-				foreach( $categoryTypes as $title => $type ) {
-					$title = Title::newFromText( $title, NS_CATEGORY );
-
-					if ( !is_null( $title ) ) {
-						$categories[] = array(
-							'link' => htmlspecialchars( $title->getLinkURL() ),
-							'name' => $this->wg->ContLang->convertHtml( $title->getText() ),
-							'type' => $type,
-						);
-					}
-				}
-			}
+		} else {
+			$categoryLinks = $categoryLinks[ 'normal' ];
 		}
 
 		// There are no categories present and user can't edit, skip rendering
-		if ( !$userCanEdit && empty( $categories ) ) {
+		if ( !$userCanEdit && !count( $categoryLinks ) ) {
 			$this->wf->ProfileOut( __METHOD__ );
 			return false;
 		}
@@ -66,9 +54,8 @@ class CategorySelectController extends WikiaController {
 
 		$categoriesLink = Linker::link( Title::newFromText( $categoriesLinkPage ), $categoriesLinkText, $categoriesLinkAttributes );
 
-		$this->response->setVal( 'categories', $categories );
+		$this->response->setVal( 'categoryLinks', $categoryLinks );
 		$this->response->setVal( 'categoriesLink', $categoriesLink );
-		$this->response->setVal( 'showHidden', $this->wg->User->getBoolOption( 'showhiddencats' ) );
 		$this->response->setVal( 'userCanEdit', $userCanEdit );
 
 		$this->wf->ProfileOut( __METHOD__ );
@@ -78,13 +65,9 @@ class CategorySelectController extends WikiaController {
 	 * The template for a category in the category list.
 	 */
 	public function category() {
-		$category = $this->request->getVal( 'category', array() );
-
 		$this->response->setVal( 'blankImageUrl', $this->wg->BlankImgUrl );
-		$this->response->setVal( 'category', $category );
-		$this->response->setVal( 'className', !empty( $category[ 'type' ] ) ? $category[ 'type' ] : 'normal' );
 		$this->response->setVal( 'edit', $this->wf->Msg( 'categoryselect-category-edit' ) );
-		$this->response->setVal( 'index', $this->request->getVal( 'index', 0 ) );
+		$this->response->setVal( 'name', $this->request->getVal( 'name', '' ) );
 		$this->response->setVal( 'remove', $this->wf->Msg( 'categoryselect-category-remove' ) );
 
 		$this->response->setTemplateEngine( WikiaResponse::TEMPLATE_ENGINE_MUSTACHE );
@@ -203,10 +186,11 @@ class CategorySelectController extends WikiaController {
 
 			$data = CategorySelect::extractCategoriesFromWikitext( $wikitext, true );
 
+			// Merge categories stored in the article with any that were passed in and remove duplicates.
 			$categories = array_merge( $data[ 'categories' ], $categories );
 			$categories = CategorySelect::getUniqueCategories( $categories );
 
-			$response[ 'categories' ] = $categories;
+			// Convert categories to wikitext and append them to the article's wikitext
 			$wikitext = $data[ 'wikitext' ] . CategorySelect::changeFormat( $categories, 'array', 'wikitext' );
 
 			$dbw = $this->wf->GetDB( DB_MASTER );
@@ -222,6 +206,18 @@ class CategorySelectController extends WikiaController {
 			$bot = $this->wg->User->isAllowed( 'bot' );
 			$status = $editPage->internalAttemptSave( $result, $bot )->value;
 
+			// Generate links for the new categories and add them to the response.
+			$categoryLinks = array();
+			foreach( $categories as $category ) {
+				$title = Title::makeTitleSafe( NS_CATEGORY, $category[ 'name' ] );
+				$text = $this->wg->ContLang->convertHtml( $title->getText() );
+
+				// We need to pass these through Linker so CategoryBlueLinks can handle them (BugId:97334)
+				$categoryLinks[] = Linker::link( $title, $text );
+			}
+
+			$response[ 'categories' ] = $categories;
+			$response[ 'categoryLinks' ] = $categoryLinks;
 			$response[ 'status' ] = $status;
 
 			switch( $status ) {

--- a/extensions/wikia/CategorySelect/CategorySelectHooksHelper.class.php
+++ b/extensions/wikia/CategorySelect/CategorySelectHooksHelper.class.php
@@ -164,12 +164,8 @@ class CategorySelectHooksHelper {
 
 			$app->registerHook( 'MakeGlobalVariablesScript', 'CategorySelectHooksHelper', 'onMakeGlobalVariablesScript' );
 
-			// Add hooks for view pages
-			if ( $action == 'view' || $action == 'purge' ) {
-				$app->registerHook( 'OutputPageMakeCategoryLinks', 'CategorySelectHooksHelper', 'onOutputPageMakeCategoryLinks' );
-
 			// Add hooks for edit pages
-			} else if ( $action == 'edit' || $action == 'submit' || $force ) {
+			if ( $action == 'edit' || $action == 'submit' || $force ) {
 				$app->registerHook( 'EditForm::MultiEdit:Form', 'CategorySelectHooksHelper', 'onEditFormMultiEditForm' );
 				$app->registerHook( 'EditPage::CategoryBox', 'CategorySelectHooksHelper', 'onEditPageCategoryBox' );
 				$app->registerHook( 'EditPage::getContent::end', 'CategorySelectHooksHelper', 'onEditPageGetContentEnd' );
@@ -179,17 +175,6 @@ class CategorySelectHooksHelper {
 		}
 
 		wfProfileOut( __METHOD__ );
-		return true;
-	}
-
-	/**
-	 * Set category types for view pages (either "normal" or "hidden").
-	 */
-	public static function onOutputPageMakeCategoryLinks( &$out, $categories, &$categoryLinks ) {
-		CategorySelect::setCategoryTypes( $categories );
-
-		// No need to add categories to skin
-		// ... except for WikiAnswers (BugId:97398)
 		return true;
 	}
 }

--- a/extensions/wikia/CategorySelect/css/CategorySelect.scss
+++ b/extensions/wikia/CategorySelect/css/CategorySelect.scss
@@ -26,10 +26,6 @@
 		}
 	}
 
-	&.showHidden .category.hidden {
-		display: block;
-	}
-
 	.add {
 		@include clear-linear-gradient();
 		background-color: $color-speech-bubble;
@@ -53,10 +49,6 @@
 		border-right: 1px solid $color-page-border;
 		margin-top: 3px;
 		padding-right: 6px;
-
-		&.hidden {
-			display: none;
-		}
 
 		&.new {
 			margin-top: 0;

--- a/extensions/wikia/CategorySelect/js/CategorySelect.js
+++ b/extensions/wikia/CategorySelect/js/CategorySelect.js
@@ -228,7 +228,7 @@
 					$.when( CategorySelect.getTemplate( 'category' ) ).done(function( template ) {
 						var element;
 
-						template.data.category = category;
+						template.data.name = category.name;
 
 						element = $( Mustache.render( template.content, template.data ) )
 							.addClass( 'new' )

--- a/extensions/wikia/CategorySelect/js/CategorySelect.view.js
+++ b/extensions/wikia/CategorySelect/js/CategorySelect.view.js
@@ -109,8 +109,8 @@
 					$categories.find( '.new' ).each(function() {
 						var $category = $( this ),
 							category = $category.data( 'category' ),
-							current = response.categories[ $category.index() ],
-							$link;
+							index = $category.index(),
+							current = response.categories[ index ];
 
 						// Category has been removed
 						if ( !current || current.name !== category.name ) {
@@ -118,15 +118,10 @@
 
 						// Linkify the category
 						} else {
-							$link = $( '<a>' )
-								.addClass( 'name' )
-								.attr( 'href', mw.util.wikiGetlink( categoryLinkPrefix + category.name ) )
-								.text( category.name );
-
 							$category
 								.removeClass( 'new' )
 								.find( '.name' )
-								.replaceWith( $link );
+								.html( response.categoryLinks[ index ] );
 						}
 					});
 				}

--- a/extensions/wikia/CategorySelect/templates/CategorySelectController_articlePage.php
+++ b/extensions/wikia/CategorySelect/templates/CategorySelectController_articlePage.php
@@ -2,14 +2,19 @@
 	<div class="container">
 		<div class="special-categories"><?= $categoriesLink ?>:</div>
 		<ul class="categories">
-			<? foreach( $categoryLinks as $link ): ?>
-				<?= $app->renderView( 'CategorySelectController', 'category', array(
-					'name' => $link
-				)) ?>
-			<? endforeach ?>
+			<? if ( !empty( $categoryLinks ) ): ?>
+				<? foreach( $categoryLinks as $type => $links ): ?>
+					<? foreach( $links as $link ): ?>
+						<?= $app->renderView( 'CategorySelectController', 'category', array(
+							'name' => $link,
+							'type' => $type
+						)) ?>
+					<? endforeach ?>
+				<? endforeach ?>
+			<? endif ?>
 			<? if ( $userCanEdit ): ?>
 				<li class="last">
-					<button class="wikia-button secondary add" id="CategorySelectAdd" type="button"><?= $wf->Message( 'categoryselect-button-add' ); ?></button>
+					<button class="wikia-button secondary add" id="CategorySelectAdd" type="button"><?= $wf->Message( 'categoryselect-button-add' ) ?></button>
 					<?= $app->getView( 'CategorySelect', 'input' ) ?>
 				</li>
 			<? endif ?>

--- a/extensions/wikia/CategorySelect/templates/CategorySelectController_articlePage.php
+++ b/extensions/wikia/CategorySelect/templates/CategorySelectController_articlePage.php
@@ -1,15 +1,12 @@
-<nav class="WikiaArticleCategories CategorySelect articlePage<?= $showHidden ? ' showHidden' : '' ?><?= $userCanEdit ? ' userCanEdit' : '' ?>" id="WikiaArticleCategories">
+<nav class="WikiaArticleCategories CategorySelect articlePage<?= $userCanEdit ? ' userCanEdit' : '' ?>" id="WikiaArticleCategories">
 	<div class="container">
 		<div class="special-categories"><?= $categoriesLink ?>:</div>
 		<ul class="categories">
-			<? if ( count( $categories ) ): ?>
-				<? foreach( $categories as $index => $category ): ?>
-					<?= $app->renderView( 'CategorySelectController', 'category', array(
-						'index' => $index,
-						'category' => $category
-					)) ?>
-				<? endforeach ?>
-			<? endif ?>
+			<? foreach( $categoryLinks as $link ): ?>
+				<?= $app->renderView( 'CategorySelectController', 'category', array(
+					'name' => $link
+				)) ?>
+			<? endforeach ?>
 			<? if ( $userCanEdit ): ?>
 				<li class="last">
 					<button class="wikia-button secondary add" id="CategorySelectAdd" type="button"><?= $wf->Message( 'categoryselect-button-add' ); ?></button>

--- a/extensions/wikia/CategorySelect/templates/CategorySelectController_category.mustache
+++ b/extensions/wikia/CategorySelect/templates/CategorySelectController_category.mustache
@@ -1,4 +1,4 @@
-<li class="category">
+<li class="category {{type}}">
 	<span class="name">{{{name}}}</span>
 	<ul class="toolbar">
 		<li class="tool editCategory"><img src="{{blankImageUrl}}" class="sprite-small edit" title="{{messages.edit}}"></li>

--- a/extensions/wikia/CategorySelect/templates/CategorySelectController_category.mustache
+++ b/extensions/wikia/CategorySelect/templates/CategorySelectController_category.mustache
@@ -1,10 +1,5 @@
-<li class="category {{className}}" data-name="{{category.name}}" data-namespace="{{category.namespace}}" data-sortKey="{{category.sortKey}}">
-	{{#category.link}}
-		<a class="name" href="{{category.link}}" title="{{category.name}}">{{category.name}}</a>
-	{{/category.link}}
-	{{^category.link}}
-		<span class="name">{{category.name}}</span>
-	{{/category.link}}
+<li class="category">
+	<span class="name">{{{name}}}</span>
 	<ul class="toolbar">
 		<li class="tool editCategory"><img src="{{blankImageUrl}}" class="sprite-small edit" title="{{messages.edit}}"></li>
 		<li class="tool removeCategory"><img src="{{blankImageUrl}}" class="sprite-small delete" title="{{messages.remove}}"></li>

--- a/extensions/wikia/CategorySelect/templates/CategorySelectController_editPage.php
+++ b/extensions/wikia/CategorySelect/templates/CategorySelectController_editPage.php
@@ -1,13 +1,10 @@
 <div class="CategorySelect editPage" id="CategorySelect">
 	<?= $app->getView( 'CategorySelect', 'input' ) ?>
 	<ul class="categories">
-		<? if ( count( $categories ) ): ?>
-			<? foreach( $categories as $index => $category ): ?>
-				<?= $app->renderView( 'CategorySelectController', 'category', array(
-					'index' => $index,
-					'category' => $category
-				)) ?>
-			<? endforeach ?>
-		<? endif ?>
+		<? foreach( $categories as $category ): ?>
+			<?= $app->renderView( 'CategorySelectController', 'category', array(
+				'name' => $category[ 'name' ]
+			)) ?>
+		<? endforeach ?>
 	</ul>
 </div>


### PR DESCRIPTION
Now that we are using core category link building again due to
BugId:97398, I was able to refactor and simplify the way CategorySelect builds
links on article pages and edit page previews.
