### PR TITLE
BugIds: 97734, 97942, 97932, 97541

### DIFF
--- a/extensions/wikia/CategorySelect/CategorySelect.class.php
+++ b/extensions/wikia/CategorySelect/CategorySelect.class.php
@@ -180,6 +180,8 @@ class CategorySelect {
 	public static function getUniqueCategories( $categories, $format = 'array', $toFormat = 'array' ) {
 		wfProfileIn( __METHOD__ );
 
+		$app = F::app();
+
 		$categoryNames = array();
 		$uniqueCategories = array();
 
@@ -190,14 +192,14 @@ class CategorySelect {
 		if ( !empty( $categories ) ) {
 			foreach( $categories as $category ) {
 				if ( !empty( $category ) ) {
-					$title = Title::newFromText( $category[ 'name' ], NS_CATEGORY );
+					$name = $category[ 'name' ];
+					$title = Title::makeTitleSafe( NS_CATEGORY, $name );
 
-					// Can return false or null if invalid
 					if ( !empty( $title ) ) {
-						$category[ 'name' ] = $title->getText();
+						$app->wg->ContLang->findVariantLink( $name, $title, true );
 
-						if ( !in_array( $category[ 'name' ], $categoryNames ) ) {
-							$categoryNames[] = $category[ 'name' ];
+						if ( !in_array( $name, $categoryNames ) ) {
+							$categoryNames[] = $name;
 							$uniqueCategories[] = $category;
 						}
 					}
@@ -430,11 +432,11 @@ class CategorySelect {
 
 							$childOut['text'] = $newNode;
 							$childOut['categories'][] = array(
-								'hidden' => self::$categoriesService->isCategoryHidden( $catName ),
 								'name' => $catName,
 								'namespace' => $catNamespace,
 								'outerTag' => $outerTag,
 								'sortKey' => $sortKey,
+								'type' => self::$categoriesService->isCategoryHidden( $catName ) ? 'hidden' : 'normal',
 							);
 						}
 						if (count($childOut['categories'])) {
@@ -493,11 +495,11 @@ class CategorySelect {
 			$sortKey = '';
 		}
 		self::$categories[] = array(
-			'hidden' => self::$categoriesService->isCategoryHidden( $catName ),
 			'name' => $catName,
 			'namespace' => $match[1],
 			'outerTag' => self::$outerTag,
-			'sortKey' => $sortKey
+			'sortKey' => $sortKey,
+			'type' => self::$categoriesService->isCategoryHidden( $catName ) ? 'hidden' : 'normal',
 		);
 		return '';
 	}

--- a/extensions/wikia/CategorySelect/CategorySelect.class.php
+++ b/extensions/wikia/CategorySelect/CategorySelect.class.php
@@ -192,14 +192,13 @@ class CategorySelect {
 		if ( !empty( $categories ) ) {
 			foreach( $categories as $category ) {
 				if ( !empty( $category ) ) {
-					$name = $category[ 'name' ];
-					$title = Title::makeTitleSafe( NS_CATEGORY, $name );
+					$title = Title::makeTitleSafe( NS_CATEGORY, $category[ 'name' ] );
 
 					if ( !empty( $title ) ) {
-						$app->wg->ContLang->findVariantLink( $name, $title, true );
+						$text = $title->getText();
 
-						if ( !in_array( $name, $categoryNames ) ) {
-							$categoryNames[] = $name;
+						if ( !in_array( $text, $categoryNames ) ) {
+							$categoryNames[] = $text;
 							$uniqueCategories[] = $category;
 						}
 					}

--- a/extensions/wikia/CategorySelect/CategorySelect.class.php
+++ b/extensions/wikia/CategorySelect/CategorySelect.class.php
@@ -115,7 +115,6 @@ class CategorySelect {
 		$root = $dom->getElementsByTagName( 'root' )->item( 0 );
 
 		self::$frame = $app->wg->Parser->getPreprocessor()->newFrame();
-		self::$categoriesService = new CategoriesService();
 
 		$categories = self::parseNode( $root );
 
@@ -135,6 +134,64 @@ class CategorySelect {
 		return self::$data;
 	}
 
+	/**
+	 * Gets an array of links for the given categories.
+	 */
+	public static function getCategoryLinks( $categories ) {
+		wfProfileIn( __METHOD__ );
+
+		$app = F::app();
+		$categoryLinks = array();
+
+		if ( !empty( $categories ) ) {
+			foreach( $categories as $category ) {
+				// Support array of category names or array of category data objects
+				$name = is_array( $category ) ? $category[ 'name' ] : $category;
+
+				if ( !empty( $name ) ) {
+					$title = Title::makeTitleSafe( NS_CATEGORY, $name );
+
+					if ( !empty( $title ) ) {
+						$text = $app->wg->ContLang->convertHtml( $title->getText() );
+						$categoryLinks[] = Linker::link( $title, $text );
+					}
+				}
+			}
+		}
+
+		wfProfileOut( __METHOD__ );
+
+		return $categoryLinks;
+	}
+
+	/**
+	 * Gets the type of a category (either "hidden" or "normal").
+	 */
+	public static function getCategoryType( $category ) {
+		if ( !isset( self::$categoriesService ) ) {
+			self::$categoriesService = new CategoriesService();
+		}
+
+		// Support category name or category data object
+		$name = is_array( $category ) ? $category[ 'name' ] : $category;
+		$type = 'normal';
+
+		$title = Title::makeTitleSafe( NS_CATEGORY, $name );
+
+		if ( !empty( $title ) ) {
+			$text = $title->getDBKey();
+
+			if ( self::$categoriesService->isCategoryHidden( $text ) ) {
+				$type = 'hidden';
+			}
+		}
+
+		return $type;
+	}
+
+	/**
+	 * Gets the default namespaces for a wiki and content language.
+	 */
 	public static function getDefaultNamespaces() {
 		if ( !isset( self::$namespaces ) ) {
 			$namespaces = F::app()->wg->ContLang->getNsText( NS_CATEGORY );
@@ -435,7 +492,7 @@ class CategorySelect {
 								'namespace' => $catNamespace,
 								'outerTag' => $outerTag,
 								'sortKey' => $sortKey,
-								'type' => self::$categoriesService->isCategoryHidden( $catName ) ? 'hidden' : 'normal',
+								'type' => self::getCategoryType( $catName ),
 							);
 						}
 						if (count($childOut['categories'])) {
@@ -498,7 +555,7 @@ class CategorySelect {
 			'namespace' => $match[1],
 			'outerTag' => self::$outerTag,
 			'sortKey' => $sortKey,
-			'type' => self::$categoriesService->isCategoryHidden( $catName ) ? 'hidden' : 'normal',
+			'type' => self::getCategoryType( $catName ),
 		);
 		return '';
 	}

--- a/extensions/wikia/CategorySelect/CategorySelect.class.php
+++ b/extensions/wikia/CategorySelect/CategorySelect.class.php
@@ -237,8 +237,6 @@ class CategorySelect {
 	public static function getUniqueCategories( $categories, $format = 'array', $toFormat = 'array' ) {
 		wfProfileIn( __METHOD__ );
 
-		$app = F::app();
-
 		$categoryNames = array();
 		$uniqueCategories = array();
 

--- a/extensions/wikia/CategorySelect/CategorySelectController.class.php
+++ b/extensions/wikia/CategorySelect/CategorySelectController.class.php
@@ -138,32 +138,6 @@ class CategorySelectController extends WikiaController {
 	}
 
 	/**
-	 * Rerturns all of the categories for the given article.
-	 * FIXME: this doesn't actually get all of the categories that may be displayed
-	 * on the article, for example, those that are added outside of the article itself.
-	 */
-	public function getArticleCategories() {
-		$this->wf->ProfileIn( __METHOD__ );
-
-		$articleId = $this->request->getVal( 'articleId', 0 );
-		$categories = array();
-
-		$title = Title::newFromID( $articleId );
-
-		if ( !empty( $title ) ) {
-			$article = new Article( $title );
-			$wikitext = $article->fetchContent();
-
-			$data = CategorySelect::extractCategoriesFromWikitext( $wikitext, true );
-			$categories = $data[ 'categories' ];
-		}
-
-		$this->response->setVal( 'categories', $categories );
-
-		$this->wf->ProfileOut( __METHOD__ );
-	}
-
-	/**
 	 * Returns all of the categories on the current wiki.
 	 */
 	public function getWikiCategories() {

--- a/extensions/wikia/CategorySelect/CategorySelectHooksHelper.class.php
+++ b/extensions/wikia/CategorySelect/CategorySelectHooksHelper.class.php
@@ -130,17 +130,8 @@ class CategorySelectHooksHelper {
 	 */
 	public static function onMakeGlobalVariablesScript( Array &$vars ) {
 		$app = F::app();
-		$action = $app->wg->Request->getVal( 'action', 'view' );
-		$categories = array();
-
-		// Load categories data for edit page
-		if ( $action == 'edit' || $action == 'submit' ) {
-			$data = CategorySelect::getExtractedCategoryData();
-			$categories = $data[ 'categories' ];
-		}
 
 		$vars[ 'wgCategorySelect' ] = array(
-			'categories' => $categories,
 			'defaultNamespace' => $app->wg->ContLang->getNsText( NS_CATEGORY ),
 			'defaultNamespaces' => CategorySelect::getDefaultNamespaces(),
 			'defaultSeparator' => trim( $app->wf->Message( 'colon-separator' )->escaped() ),

--- a/extensions/wikia/CategorySelect/css/CategorySelect.edit.scss
+++ b/extensions/wikia/CategorySelect/css/CategorySelect.edit.scss
@@ -93,3 +93,8 @@ $categoryselect-color-placeholder: darken( $color-epl-input, 2% );
 #EditPageMain .CategorySelect {
 	display: none;
 }
+
+// Unhide for widescreen mode
+.editpage-visualwidemode #EditPageMain .CategorySelect {
+	display: block;
+}

--- a/extensions/wikia/CategorySelect/css/CategorySelect.scss
+++ b/extensions/wikia/CategorySelect/css/CategorySelect.scss
@@ -35,6 +35,12 @@
 		margin: 0;
 		overflow: hidden;
 		padding: 0;
+
+		&.showHidden {
+			.category.hidden {
+				display: block;
+			}
+		}
 	}
 
 	.category,
@@ -49,6 +55,10 @@
 		border-right: 1px solid $color-page-border;
 		margin-top: 3px;
 		padding-right: 6px;
+
+		&.hidden {
+			display: none;
+		}
 
 		&.new {
 			margin-top: 0;

--- a/extensions/wikia/CategorySelect/css/CategorySelect.scss
+++ b/extensions/wikia/CategorySelect/css/CategorySelect.scss
@@ -6,7 +6,7 @@
 .CategorySelect.articlePage {
 	@include clear-linear-gradient();
 	line-height: normal;
-	margin: 0 0 40px 0;
+	margin: 10px 0 40px 0;
 	padding: 0;
 	position: relative;
 

--- a/extensions/wikia/CategorySelect/js/CategorySelect.js
+++ b/extensions/wikia/CategorySelect/js/CategorySelect.js
@@ -4,6 +4,7 @@
 
 	var cached = {},
 		namespace = 'categorySelect',
+		properties = [ 'name', 'namespace', 'outerTag', 'sortKey', 'type' ],
 		slice = Array.prototype.slice,
 		wgCategorySelect = window.wgCategorySelect,
 		Wikia = window.Wikia || {};
@@ -36,6 +37,14 @@
 			}
 		}
 	};
+
+	// Safely decode HTML entities.
+	// TODO: move this somewhere else?
+	function decodeHtmlEntities( str ) {
+		var textarea = document.createElement( 'textarea' );
+		textarea.innerHTML = str;
+		return textarea.value;
+	}
 
 	/**
 	 * CategorySelect Class
@@ -112,14 +121,7 @@
 			});
 
 		elements.list = element.find( options.selectors.categories );
-
-		// Store category data in categories
-		elements.categories = elements.list
-			.find( options.selectors.category )
-			.each(function( i ) {
-				$( this ).data( 'category',
-					CategorySelect.normalize( options.categories[ i ] ) );
-			});
+		elements.categories = elements.list.find( options.selectors.category );
 
 		if ( typeof options.autocomplete === 'object' ) {
 			limit = self.options.autocomplete.limit;
@@ -198,7 +200,7 @@
 		 *          invalid.
 		 */
 		addCategory: function( category ) {
-			var data,
+			var existing,
 				self = this,
 				input = self.elements.input,
 				options = self.options;
@@ -206,17 +208,15 @@
 			category = CategorySelect.normalize( category );
 
 			if ( category ) {
-				data = self.getData( category.name );
+				existing = self.getDatum( category.name );
 
 				// Category already exists
-				if ( data.length ) {
-					category = data[ 0 ];
-
-					input.val( category.name );
+				if ( existing !== undefined ) {
+					input.val( existing.name );
 
 					if ( options.popover ) {
 						$.extend( self.popover.options, {
-							content: $.msg( 'categoryselect-error-duplicate-category-name', category.name ),
+							content: $.msg( 'categoryselect-error-duplicate-category-name', existing.name ),
 							placement: 'right',
 							type: 'error'
 						});
@@ -226,13 +226,12 @@
 
 				} else {
 					$.when( CategorySelect.getTemplate( 'category' ) ).done(function( template ) {
-						var element;
+						var data = $.extend( {}, template.data, category ),
+							element = $( Mustache.render( template.content, data ) );
 
-						template.data.name = category.name;
-
-						element = $( Mustache.render( template.content, template.data ) )
+						element
 							.addClass( 'new' )
-							.data( 'category', category );
+							.data( category );
 
 						self.dirty = true;
 
@@ -260,7 +259,7 @@
 		},
 
 		/**
-		 * Edits a category.
+		 * Edit an existing category.
 		 *
 		 * @param { Element | jQuery | Number | String } category
 		 *        The index of a category relative to the list of categories, the
@@ -269,16 +268,18 @@
 		editCategory: function( category ) {
 			var modal,
 				self = this,
-				element = self.getCategory( category );
+				element = self.getCategory( category ),
+				category = element && self.getDatum( element );
 
-			if ( element.length ) {
-				category = element.data( 'category' );
-
+			if ( category !== undefined ) {
 				$.when( CategorySelect.getTemplate( 'categoryEdit' ) ).done(function( template ) {
-					template.data.category = category;
-					template.data.messages.sortKey = $.msg( 'categoryselect-modal-category-sortkey', category.name );
+					var data = $.extend( true, {}, template.data, category, {
+						messages: {
+							sortKey: $.msg( 'categoryselect-modal-category-sortkey', category.name )
+						}
+					});
 
-					modal = $.showCustomModal( cached.messages.categoryEdit, Mustache.render( template.content, template.data ), {
+					modal = $.showCustomModal( cached.messages.categoryEdit, Mustache.render( template.content, data ), {
 						buttons: [
 							{
 								id: 'CategorySelectEditModalSave',
@@ -292,7 +293,7 @@
 									if ( name === '' ) {
 										error = cached.messages.errorEmptyCategoryName;
 
-									} else if ( name !== category.name && self.getData( name )[ 0 ] ) {
+									} else if ( name !== category.name && self.getDatum( name ) ) {
 										error = $.msg( 'categoryselect-error-duplicate-category-name', name );
 									}
 
@@ -309,7 +310,7 @@
 											});
 
 											element
-												.data( 'category', category )
+												.data( category )
 												.find( '.name' )
 												.text( name );
 
@@ -337,32 +338,47 @@
 		 * Gets the data associated with categories.
 		 *
 		 * @param { Element | jQuery | Number | String } filter
-		 *        The index of a category relative to the list of categories, a
-		 *        selector string or the jQuery object or DOM Element for a category.
+		 *        The index of a category relative to the list of categories, the
+		 *        name of a category, a selector string or the jQuery object or
+		 *        DOM Element for a category.
 		 *
-		 * @returns	{ Object }
-		 *			The data associated with the category, an array of category data
-		 *          for all categories, or undefined if not found.
+		 * @returns	{ Array }
+		 *          An array of data associated with the categories.
 		 */
 		getData: function( filter ) {
 			var data = [];
 
 			this.getCategories( filter ).each(function() {
-				data.push( $( this ).data( 'category' ) );
+				data.push( CategorySelect.normalize( $.data( this ) ) );
 			});
 
 			return data;
 		},
 
 		/**
-		 * Gets categories from the list of categories.
+		 * Gets the data associated with a single category.
 		 *
 		 * @param { Element | jQuery | Number | String } filter
 		 *        The index of a category relative to the list of categories, a
 		 *        selector string or the jQuery object or DOM Element for a category.
 		 *
+		 * @returns	{ Object }
+		 *          The data associated with the category or undefined if not found.
+		 */
+		getDatum: function( filter ) {
+			return this.getData( filter )[ 0 ];
+		},
+
+		/**
+		 * Gets categories from the list of categories.
+		 *
+		 * @param { Element | jQuery | Number | String } filter
+		 *        The index of a category relative to the list of categories, the
+		 *        name of a category, a selector string or the jQuery object or
+		 *        DOM Element for a category.
+		 *
 		 * @returns	{ jQuery }
-		 *			The categories, or an empty jQuery object if not found.
+		 *          The categories, or an empty jQuery object if not found.
 		 */
 		getCategories: function( filter ) {
 			var categories = this.elements.categories;
@@ -380,8 +396,8 @@
 					// By category name, selector string, jQuery object or DOM Element
 					categories.filter(function() {
 						var $category = $( this ),
-							data = $category.data( 'category' ),
-							match = data && data.name === filter;
+							category = CategorySelect.normalize( $category.data() ),
+							match = category.name === decodeHtmlEntities( filter );
 
 						// Try to match a selector string, jQuery object or DOM Element
 						if ( !match ) {
@@ -406,7 +422,7 @@
 		 *        selector string or the jQuery object or DOM Element for a category.
 		 *
 		 * @returns	{ jQuery }
-		 *			The categories, or an empty jQuery object if not found.
+		 *          The categories, or an empty jQuery object if not found.
 		 */
 		getCategory: function( filter ) {
 			return this.getCategories( filter ).eq( 0 );
@@ -459,6 +475,20 @@
 		},
 
 		/**
+		 * Associates category data with DOM elements.
+		 *
+		 * @param { Element | jQuery | Number | String } filter
+		 *        The index of a category relative to the list of categories, the
+		 *        name of a category or the jQuery or DOM Element for a category.
+		 *
+		 * @param { Object } data
+		 *        The data associated with a category.
+		 */
+		setData: function( filter, data ) {
+			return this.getCategories( filter ).data( data );
+		},
+
+		/**
 		 * Triggers an event on the wrapper element. The CategorySelect class is
 		 * always passed as the second argument to handlers, further arguments are
 		 * optional.
@@ -471,7 +501,7 @@
 		 */
 		trigger: function( eventType ) {
 			var args = [ this ].concat( slice.call( arguments, 1 ) );
-			return this.element.triggerHandler( eventType + '.' + namespace, args );
+			return this.element.triggerHandler( eventType, args );
 		}
 	});
 
@@ -551,15 +581,14 @@
 		 *          invalid.
 		 */
 		normalize: (function() {
-			var properties = [ 'name', 'namespace', 'outerTag', 'sortKey', 'type' ],
-				rCategory = new RegExp( '\\[\\[' +
-					// Category namespace
-					'(' + wgCategorySelect.defaultNamespaces + '):' +
-					// Category name
-					'([^\\]|]+)' +
-					// Category sortKey (optional)
-					'\\|?([^\\]]+)?' +
-				']]', 'i' );
+			var rCategory = new RegExp( '\\[\\[' +
+				// Category namespace
+				'(' + wgCategorySelect.defaultNamespaces + '):' +
+				// Category name
+				'([^\\]|]+)' +
+				// Category sortKey (optional)
+				'\\|?([^\\]]+)?' +
+			']]', 'i' );
 
 			return function( category ) {
 				var pieces, prop,
@@ -600,6 +629,9 @@
 						}
 					}
 
+					// Decode HTML entities
+					category.name = decodeHtmlEntities( category.name );
+
 					// Uppercase the first letter in name to match MediaWiki article titles
 					category.name = category.name[ 0 ].toUpperCase() + category.name.slice( 1 );
 				}
@@ -628,7 +660,6 @@
 				// Non-standard
 				limit: 6
 			},
-			categories: [],
 
 			// Based on Title max length
 			maxLength: 255,

--- a/extensions/wikia/CategorySelect/js/CategorySelect.js
+++ b/extensions/wikia/CategorySelect/js/CategorySelect.js
@@ -551,7 +551,7 @@
 		 *          invalid.
 		 */
 		normalize: (function() {
-			var properties = [ 'name', 'namespace', 'sortKey' ],
+			var properties = [ 'name', 'namespace', 'outerTag', 'sortKey', 'type' ],
 				rCategory = new RegExp( '\\[\\[' +
 					// Category namespace
 					'(' + wgCategorySelect.defaultNamespaces + '):' +

--- a/extensions/wikia/CategorySelect/js/CategorySelect.js
+++ b/extensions/wikia/CategorySelect/js/CategorySelect.js
@@ -4,7 +4,7 @@
 
 	var cached = {},
 		namespace = 'categorySelect',
-		properties = [ 'name', 'namespace', 'outerTag', 'sortKey', 'type' ],
+		properties = [ 'name', 'namespace', 'outertag', 'sortkey', 'type' ],
 		slice = Array.prototype.slice,
 		wgCategorySelect = window.wgCategorySelect,
 		Wikia = window.Wikia || {};
@@ -303,10 +303,10 @@
 											.find( '.error-msg' ).text( error );
 
 									} else {
-										if ( name !== category.name || sortKey !== category.sortKey ) {
+										if ( name !== category.name || sortKey !== category.sortkey ) {
 											$.extend( category, {
 												name: name,
-												sortKey: sortKey
+												sortkey: sortKey
 											});
 
 											element
@@ -609,7 +609,7 @@
 					category = undefined;
 
 				} else {
-					category.name = $.trim( category.name );
+					category.name = $.trim( decodeHtmlEntities( category.name ) );
 
 					// Get rid of unecessary properties
 					for ( prop in category ) {
@@ -625,12 +625,9 @@
 
 						// SortKey is optional
 						if ( pieces[ 3 ] !== undefined ) {
-							category.sortKey = pieces[ 3 ];
+							category.sortkey = pieces[ 3 ];
 						}
 					}
-
-					// Decode HTML entities
-					category.name = decodeHtmlEntities( category.name );
 
 					// Uppercase the first letter in name to match MediaWiki article titles
 					category.name = category.name[ 0 ].toUpperCase() + category.name.slice( 1 );

--- a/extensions/wikia/CategorySelect/templates/CategorySelectController_articlePage.php
+++ b/extensions/wikia/CategorySelect/templates/CategorySelectController_articlePage.php
@@ -1,13 +1,10 @@
-<nav class="WikiaArticleCategories CategorySelect articlePage<?= $showHidden ? ' showHidden' : '' ?><?= $userCanEdit ? ' userCanEdit' : '' ?>" id="WikiaArticleCategories">
+<nav class="WikiaArticleCategories CategorySelect articlePage<?= $userCanEdit ? ' userCanEdit' : '' ?>" id="WikiaArticleCategories">
 	<div class="container">
 		<div class="special-categories"><?= $categoriesLink ?>:</div>
-		<ul class="categories">
-			<? foreach( $categories as $category ): ?>
-				<?= $app->renderView( 'CategorySelectController', 'category', array(
-					'name' => $category[ 'link' ],
-					'type' => $category[ 'type' ],
-				)) ?>
-			<? endforeach ?>
+		<ul class="categories<?= $showHidden ? ' showHidden' : '' ?>">
+			<?= $app->renderView( 'CategorySelectController', 'categories', array(
+				'categories' => $categories
+			)) ?>
 			<? if ( $userCanEdit ): ?>
 				<li class="last">
 					<button class="wikia-button secondary add" id="CategorySelectAdd" type="button"><?= $wf->Message( 'categoryselect-button-add' ) ?></button>
@@ -16,8 +13,10 @@
 			<? endif ?>
 		</ul>
 	</div>
-	<div class="toolbar">
-		<button class="wikia-button secondary cancel" id="CategorySelectCancel" type="button"><?= $wf->Message( 'categoryselect-button-cancel' ) ?></button>
-		<button class="wikia-button save" id="CategorySelectSave" type="button" disabled="disabled"><?= $wf->Message( 'categoryselect-button-save' ) ?></button>
-	</div>
+	<? if ( $userCanEdit ): ?>
+		<div class="toolbar">
+			<button class="wikia-button secondary cancel" id="CategorySelectCancel" type="button"><?= $wf->Message( 'categoryselect-button-cancel' ) ?></button>
+			<button class="wikia-button save" id="CategorySelectSave" type="button" disabled="disabled"><?= $wf->Message( 'categoryselect-button-save' ) ?></button>
+		</div>
+	<? endif ?>
 </nav>

--- a/extensions/wikia/CategorySelect/templates/CategorySelectController_articlePage.php
+++ b/extensions/wikia/CategorySelect/templates/CategorySelectController_articlePage.php
@@ -1,17 +1,13 @@
-<nav class="WikiaArticleCategories CategorySelect articlePage<?= $userCanEdit ? ' userCanEdit' : '' ?>" id="WikiaArticleCategories">
+<nav class="WikiaArticleCategories CategorySelect articlePage<?= $showHidden ? ' showHidden' : '' ?><?= $userCanEdit ? ' userCanEdit' : '' ?>" id="WikiaArticleCategories">
 	<div class="container">
 		<div class="special-categories"><?= $categoriesLink ?>:</div>
 		<ul class="categories">
-			<? if ( !empty( $categoryLinks ) ): ?>
-				<? foreach( $categoryLinks as $type => $links ): ?>
-					<? foreach( $links as $link ): ?>
-						<?= $app->renderView( 'CategorySelectController', 'category', array(
-							'name' => $link,
-							'type' => $type
-						)) ?>
-					<? endforeach ?>
-				<? endforeach ?>
-			<? endif ?>
+			<? foreach( $categories as $category ): ?>
+				<?= $app->renderView( 'CategorySelectController', 'category', array(
+					'name' => $category[ 'link' ],
+					'type' => $category[ 'type' ],
+				)) ?>
+			<? endforeach ?>
 			<? if ( $userCanEdit ): ?>
 				<li class="last">
 					<button class="wikia-button secondary add" id="CategorySelectAdd" type="button"><?= $wf->Message( 'categoryselect-button-add' ) ?></button>

--- a/extensions/wikia/CategorySelect/templates/CategorySelectController_categories.php
+++ b/extensions/wikia/CategorySelect/templates/CategorySelectController_categories.php
@@ -1,0 +1,3 @@
+<? foreach( $categories as $category ): ?>
+	<?= $app->renderView( 'CategorySelectController', 'category', $category ) ?>
+<? endforeach ?>

--- a/extensions/wikia/CategorySelect/templates/CategorySelectController_category.mustache
+++ b/extensions/wikia/CategorySelect/templates/CategorySelectController_category.mustache
@@ -1,4 +1,4 @@
-<li class="category {{type}}" data-name="{{name}}" data-namespace="{{namespace}}" data-outerTag="{{outerTag}}" data-sortKey="{{sortKey}}" data-type="{{type}}">
+<li class="category {{type}}" data-name="{{name}}" data-namespace="{{namespace}}" data-outertag="{{outerTag}}" data-sortkey="{{sortKey}}" data-type="{{type}}">
 	<span class="name">{{#link}}{{{link}}}{{/link}}{{^link}}{{name}}{{/link}}</span>
 	<ul class="toolbar">
 		<li class="tool editCategory"><img src="{{blankImageUrl}}" class="sprite-small edit" title="{{messages.edit}}"></li>

--- a/extensions/wikia/CategorySelect/templates/CategorySelectController_category.mustache
+++ b/extensions/wikia/CategorySelect/templates/CategorySelectController_category.mustache
@@ -1,5 +1,5 @@
-<li class="category {{type}}">
-	<span class="name">{{{name}}}</span>
+<li class="category {{type}}" data-name="{{name}}" data-namespace="{{namespace}}" data-outerTag="{{outerTag}}" data-sortKey="{{sortKey}}" data-type="{{type}}">
+	<span class="name">{{#link}}{{{link}}}{{/link}}{{^link}}{{name}}{{/link}}</span>
 	<ul class="toolbar">
 		<li class="tool editCategory"><img src="{{blankImageUrl}}" class="sprite-small edit" title="{{messages.edit}}"></li>
 		<li class="tool removeCategory"><img src="{{blankImageUrl}}" class="sprite-small delete" title="{{messages.remove}}"></li>

--- a/extensions/wikia/CategorySelect/templates/CategorySelectController_categoryEdit.mustache
+++ b/extensions/wikia/CategorySelect/templates/CategorySelectController_categoryEdit.mustache
@@ -6,6 +6,6 @@
 	</div>
 	<div class="input-group categorySortKey">
 		<label>{{messages.sortKey}}</label>
-		<input type="text" name="categorySortKey" value="{{sortKey}}">
+		<input type="text" name="categorySortKey" value="{{sortkey}}">
 	</div>
 </div>

--- a/extensions/wikia/CategorySelect/templates/CategorySelectController_categoryEdit.mustache
+++ b/extensions/wikia/CategorySelect/templates/CategorySelectController_categoryEdit.mustache
@@ -1,11 +1,11 @@
 <div class="WikiaForm">
 	<div class="input-group categoryName">
 		<label>{{messages.name}}</label>
-		<input type="text" name="categoryName" value="{{category.name}}">
+		<input type="text" name="categoryName" value="{{name}}">
 		<div class="error-msg"></div>
 	</div>
 	<div class="input-group categorySortKey">
 		<label>{{messages.sortKey}}</label>
-		<input type="text" name="categorySortKey" value="{{category.sortKey}}">
+		<input type="text" name="categorySortKey" value="{{sortKey}}">
 	</div>
 </div>

--- a/extensions/wikia/CategorySelect/templates/CategorySelectController_editPage.php
+++ b/extensions/wikia/CategorySelect/templates/CategorySelectController_editPage.php
@@ -3,7 +3,8 @@
 	<ul class="categories">
 		<? foreach( $categories as $category ): ?>
 			<?= $app->renderView( 'CategorySelectController', 'category', array(
-				'name' => $category[ 'name' ]
+				'name' => $category[ 'name' ],
+				'type' => $category[ 'type' ]
 			)) ?>
 		<? endforeach ?>
 	</ul>

--- a/extensions/wikia/CategorySelect/templates/CategorySelectController_editPage.php
+++ b/extensions/wikia/CategorySelect/templates/CategorySelectController_editPage.php
@@ -2,10 +2,7 @@
 	<?= $app->getView( 'CategorySelect', 'input' ) ?>
 	<ul class="categories">
 		<? foreach( $categories as $category ): ?>
-			<?= $app->renderView( 'CategorySelectController', 'category', array(
-				'name' => $category[ 'name' ],
-				'type' => $category[ 'type' ]
-			)) ?>
+			<?= $app->renderView( 'CategorySelectController', 'category', $category ) ?>
 		<? endforeach ?>
 	</ul>
 </div>

--- a/extensions/wikia/EditPageLayout/js/modules/Categories.js
+++ b/extensions/wikia/EditPageLayout/js/modules/Categories.js
@@ -40,7 +40,6 @@ WikiaEditor.modules.Categories = $.createClass( WikiaEditor.modules.base,{
 					}
 				}
 			},
-			categories: wgCategorySelect.categories,
 			popover: {
 				placement: 'top'
 			}


### PR DESCRIPTION
Fixes numerous minor issues with CategorySelect:
- Properly maintain the order of categories across view/edit pages. This was causing issues with trying to map category data to category elements.
- Truly associate category data to the DOM. Data will now be built from "data-" attributes on category DOM Element's themselves instead of loading this data separately and applying it to DOM Elements. This also addresses problems with mapping category data to their elements.
- After save, generate HTML for the categories list the same way it was generated on article view. This prevents issues with view inconsistencies after saving categories.
- Hidden categories: 'hidden' class + showing/hiding based on user preference. This will allow users the ability to style hidden categories if they choose to see them.
- Add some padding to the top of CategorySelect to prevent it from bumping into stuff above it.
- Fix some prefixed category tags being stripped improperly.
- Fix CategorySelect not appearing on widescreen mode.
