### PR TITLE
gw.config.js: fix IE8 issue

### DIFF
--- a/extensions/wikia/AdEngine/js/gw.config.js
+++ b/extensions/wikia/AdEngine/js/gw.config.js
@@ -91,7 +91,7 @@
 			return false;
 		}
 
-		if (tagName === 'div' && attrs.class === 'twtr-widget') {
+		if (tagName === 'div' && attrs['class'] === 'twtr-widget') {
 			if (logging) { window.console.log('gw.config.js: checkHandler: natively writing twitter div'); }
 			documentWriteTag('div', attrs);
 			if (logging) { window.console.log('gw.config.js: checkHandler: end of twitter div'); }


### PR DESCRIPTION
@gabrys, @nefretete: `class` is a keyword for IE8, hence the use of bracket syntax is needed here
