### PR TITLE
add simple Routing support to WikiaApp->registerController

### DIFF
--- a/extensions/wikia/WikiFeatures/WikiFeatures.setup.php
+++ b/extensions/wikia/WikiFeatures/WikiFeatures.setup.php
@@ -8,7 +8,12 @@
 $dir = dirname(__FILE__) . '/';
 $app = F::app();
 //classes
-$app->registerClass('WikiFeaturesSpecialController', $dir . 'WikiFeaturesSpecialController.class.php');
+$app->registerController(
+	'WikiFeaturesSpecialController',
+	$dir . 'WikiFeaturesSpecialController.class.php',
+	array( 'index' => array( "skin" => array( "monobook", "wikiamobile" ), "method" => "notOasis") )
+);
+
 $app->registerClass('WikiFeaturesHelper', $dir . 'WikiFeaturesHelper.class.php');
 $app->registerClass('WikiaLabsSpecialController', $dir . 'WikiaLabsSpecialController.class.php');
 

--- a/extensions/wikia/WikiFeatures/WikiFeaturesSpecialController.class.php
+++ b/extensions/wikia/WikiFeatures/WikiFeaturesSpecialController.class.php
@@ -23,13 +23,6 @@ class WikiFeaturesSpecialController extends WikiaSpecialPageController {
 			return false;  // skip rendering
 		}
 
-		$this->isOasis = F::app()->checkSkin( 'oasis' );
-
-		if ( !( $this->isOasis ) ) {
-			$this->forward('WikiFeaturesSpecial', 'notOasis');
-			return;
-		}
-
 		$this->response->addAsset('extensions/wikia/WikiFeatures/css/WikiFeatures.scss');
 		$this->response->addAsset('extensions/wikia/WikiFeatures/js/modernizr.transform.js');
 		$this->response->addAsset('extensions/wikia/WikiFeatures/js/WikiFeatures.js');

--- a/includes/wikia/nirvana/WikiaApp.class.php
+++ b/includes/wikia/nirvana/WikiaApp.class.php
@@ -446,18 +446,34 @@ class WikiaApp {
 
 	/**
 	 * register controller class
+	 * @param string $className Name of controller class
+	 * @param string $filePath Path to file containing class
+	 * @param array $options Array of routing options
+	 *
+	 * The dispatcher will check options for you before dispatching the request
+	 * Options contains an array of methods => conditions
+	 * This is used to invoke a different controller method depending on skin or global variable true/false
+	 * The dispatcher can also invoke a before/after method passing the same request/response object
+	 *
+	 * F::app()->registerController("FooController", "/path", array(
+	 * "performActionA" => array(
+	 *		"global" => "wgEnableNewFoo",
+	 *		"skin"=>"mobile"
+	 *	),
+	 *	"performActionB" => array(
+	 *		"skin" => "oasis",
+	 *		"before" => "calledBeforeActionB",
+	 *		"after" => "calledAfterActionB"
+	 *	),
+	 *	// default is "any skin"
+	 *
 	 */
 
 	public function registerController($className, $filePath, $options = null) {
 		// register the class with the autoloader
 		$this->registerClass($className, $filePath);
-
-		if ( is_array ($className)) {
-			foreach ( $className as $cls ) {
-				$this->wg->set('wgWikiaControllers', $className, $options);
-			}
-		} else {
-			$this->wg->set('wgWikiaControllers', $options);
+		if ( is_array( $options ) ) {
+			$this->dispatcher->addRouting($className, $options);
 		}
 	}
 

--- a/includes/wikia/nirvana/WikiaApp.class.php
+++ b/includes/wikia/nirvana/WikiaApp.class.php
@@ -473,7 +473,7 @@ class WikiaApp {
 		// register the class with the autoloader
 		$this->registerClass($className, $filePath);
 		if ( is_array( $options ) ) {
-			$this->dispatcher->addRouting($className, $options);
+			$this->getDispatcher()->addRouting($className, $options);
 		}
 	}
 

--- a/includes/wikia/nirvana/WikiaDispatchableObject.class.php
+++ b/includes/wikia/nirvana/WikiaDispatchableObject.class.php
@@ -30,7 +30,14 @@ abstract class WikiaDispatchableObject extends WikiaObject {
 	protected $response = null;
 
 	/**
-	 * wether the class accepts external requests
+	 * Describes object to dispatch to after this one is done
+	 * Used by "forward" function and "after" routing rule
+	 * @var $callNext array
+	 */
+	protected $callNext = array();
+
+	/**
+	 * Whether the class accepts external requests
 	 * @return boolean
 	 */
 	abstract public function allowsExternalRequests();
@@ -42,14 +49,25 @@ abstract class WikiaDispatchableObject extends WikiaObject {
 	 * @param string $methodName
 	 * @param bool $resetData
 	 */
-	protected function forward( $controllerName, $methodName, $resetData = true ) {
-		if( $resetData ) {
-			$this->response->resetData();
-		}
 
-		$this->request->setVal( 'controller', $controllerName );
-		$this->request->setVal( 'method', $methodName );
-		$this->request->setDispatched(false);
+	public function forward( $controllerName, $methodName, $resetData = true ) {
+		$this->callNext[] = array(
+			"controller" => $controllerName,
+			"method" => $methodName,
+			"reset" => $resetData
+		);
+	}
+
+	public function hasNext() {
+		return !empty($this->callNext);
+	}
+
+	public function getNext() {
+		if ($this->hasNext()) {
+			return array_pop($this->callNext);
+		} else {
+			return false;
+		}
 	}
 
 	/**

--- a/includes/wikia/nirvana/WikiaDispatcher.class.php
+++ b/includes/wikia/nirvana/WikiaDispatcher.class.php
@@ -13,13 +13,51 @@
 class WikiaDispatcher {
 
 	const DEFAULT_METHOD_NAME = 'index';
+	private $routes = array();
 
 	/**
-	 * @param WikiaRequest $request
-	 * @return mixed
+	 * @param WikiaApp $app
+	 * @param WikiaResponse $response
+	 * @param string $className Full class name (with Controller/Service suffix)
+	 * @param string $methodName Base method name from requeset
+	 * @return mixed $callStack if post-controller routing is involved, otherwise false
 	 */
-	protected function getMethodName( WikiaRequest $request ) {
-		return $request->getVal( 'method', self::DEFAULT_METHOD_NAME );
+	protected function applyRouting( WikiaApp $app, WikiaResponse $response, $className, $methodName ) {
+
+		// Starting with requested or default method name which is passed in by dispatch
+		$response->setControllerName( $className );
+		$response->setMethodName( $methodName );
+		$callNext = array();
+
+		// Check to see if we have a defined route for this controller to another controller
+		if ( isset( $this->routes[$className]["*"])) {
+			$route = $this->routes[$className]["*"];
+		}
+		// Check for method overrides
+		else if ( isset( $this->routes[$className][$methodName] ) ) {
+			$route = $this->routes[$className][$methodName];
+		} else {
+			return false;
+		}
+
+		// skin routing, also allows possibility to override template
+		if ( isset( $route['skin'] ) && $app->checkSkin( $route['skin']) ) {
+			if ( isset( $route['controller'] ) ) $response->setControllerName( $route['controller'] );
+			if ( isset( $route['method'] ) ) $response->setMethodName( $route['method'] );
+			if ( isset( $route['template'] ) ) $response->getView()->setTemplate( $className, $route['template'] );
+			if ( isset( $route['after'] ) ) $callNext = $route['after'];
+		}
+		// global var routing should probably only be for controllers and methods
+		if (isset( $route['global'] ) && isset( $app->wg->$route['global'] ) ) {
+			if ( isset( $route['controller'] ) ) $response->setControllerName( $route['controller'] );
+			if ( isset( $route['method'] ) ) $response->setMethodName( $route['method'] );
+			if ( isset( $route['after'] ) ) $callNext = $route['after'];
+		}
+		return $callNext;
+	}
+
+	public function addRouting( $className, array $routes ) {
+		$this->routes[$className] = $routes;
 	}
 
 	/**
@@ -36,20 +74,28 @@ class WikiaDispatcher {
 		}
 		$format = $request->getVal( 'format', WikiaResponse::FORMAT_HTML );
 		$response = F::build( 'WikiaResponse', array( 'format' => $format, 'request' => $request ) );
-		if ( $app->wg->EnableSkinTemplateOverride && $app->isSkinInitialized() ) {
-			$response->setSkinName( $app->wg->User->getSkin()->getSkinName() );
-		}
+		$controller = null;
 
 		// Main dispatch is a loop because Controllers can forward to each other
-		// Error condition is also handled via dispatching to the error controller
+		// Error condition is also handled via forwarding to the error controller
 		do {
-			$request->setDispatched(true);
+			// First time through the loop we skip this section
+			// If we got through the dispatch loop and have a nextCall, then call it.
+			// Request and Response are re-used, Response data can be optionally reset
+			if ( $controller && $controller->hasNext() ) {
+				$nextCall = $controller->getNext();
+				$request->setVal( 'controller', $nextCall['controller'] );
+				$request->setVal( 'method', $nextCall['method'] );
+				if ( $nextCall['reset'] ) $response->resetData();
+			}
 
 			try {
-				$method = $this->getMethodName( $request );
 
 				// Determine the "base" name for the controller, stripping off Controller/Service/Module
 				$controllerName = $app->getBaseName( $request->getVal( 'controller' ) );
+				if( empty( $controllerName ) ) {
+					throw new WikiaException( "Controller parameter missing or invalid: {$controllerName}" );
+				}
 
 				// Service classes must be dispatched by full name otherwise we look for a controller.
 				if ($app->isService($request->getVal('controller'))) {
@@ -58,32 +104,38 @@ class WikiaDispatcher {
 					$controllerClassName = $app->getControllerClassName( $controllerName );
 				}
 
-				$profilename = __METHOD__ . " ({$controllerName}_{$method})";
-
-				if( empty( $controllerName ) ) {
-					throw new WikiaException( "Invalid controller name: {$controllerName}" );
-				}
-
 				if ( empty( $autoloadClasses[$controllerClassName] ) ) {
-					throw new WikiaException( "Controller class does not exist: {$controllerClassName} method: {$method}" );
+					throw new WikiaException( "Controller class does not exist: {$controllerClassName}" );
 				}
 
+				// Determine the final name for the controller and method based on any routing rules
+				$callNext = $this->applyRouting( $app, $response, $controllerClassName, $request->getVal( 'method', self::DEFAULT_METHOD_NAME ) );
+				$controllerClassName = $response->getControllerName();		// might have been changed
+				$controllerName = $app->getBaseName($controllerClassName);  // chop off Service/Controller
+				$method = $response->getMethodName();						// might have been changed
+
+				$profilename = __METHOD__ . " ({$controllerClassName}_{$method})";
 				$app->wf->profileIn($profilename);
-				$response->setControllerName( $controllerClassName );
-				$response->setMethodName( $method );
 
 				$controller = F::build( $controllerClassName ); /* @var $controller WikiaController */
 
+				if ( $callNext ) {
+					list ($nextController, $nextMethod, $resetData) = explode("::", $callNext);
+					$controller->forward($nextController, $nextMethod, $resetData);
+				}
 				// map X to executeX method names for things that used to be modules
 				if (!method_exists($controller, $method)) {
 					$method = ucfirst( $method );
 					// This will throw an exception if the template is missing
 					// Refactor the offending class to not use executeXYZ methods or set format in request params
+					// Warning: this means you can't use the new Dispatcher routing to switch templates in modules
 					if ($format == WikiaResponse::FORMAT_HTML) {
 						$response->getView()->setTemplate( $controllerName, $method );
 					}
 					$method = "execute{$method}";
 					$params = $request->getParams();  // old modules expect params in a different place
+				} else {
+					$params = array();
 				}
 
 				if (
@@ -120,19 +172,13 @@ class WikiaDispatcher {
 				$controller->setApp( $app );
 				$controller->init();
 
-				// BugId:5125 - keep old hooks naming convention
-				$hookMethod = ucfirst( $this->getMethodName( $request ) );
-
-				$hookResult = $app->runHook( ( "{$controllerName}{$hookMethod}BeforeExecute" ), array( &$controller, &$params ) );
-
-				if ( $hookResult ) {
-					$result = $controller->$method( $params );
-
-					if($result === false) {
-						// skip template rendering when false returned
-						$controller->skipRendering();
-					}
+				// Actually call the controller::method!
+    			$result = $controller->$method( $params );
+				if($result === false) {
+				   // skip template rendering when false returned
+				   $controller->skipRendering();
 				}
+
 				// Preserve original request (this is for SpecialPageControllers)
 				if ($originalRequest != null) {
 					$controller->setRequest($originalRequest);
@@ -141,7 +187,8 @@ class WikiaDispatcher {
 					$controller->setResponse($originalResponse);
 				}
 
-				// we ignore the result of the AfterExecute hook
+				// keep the AfterExecute hooks for now, refactor later using "after" dispatching
+				$hookMethod = ucfirst( $method );
 				$app->runHook( ( "{$controllerName}{$hookMethod}AfterExecute" ), array( &$controller, &$params ) );
 
 				$app->wf->profileOut($profilename);
@@ -175,16 +222,15 @@ class WikiaDispatcher {
 				$response->setException($e);
 				Wikia::log(__METHOD__, $e->getMessage() );
 
-				// if we catch an exception, redirect to the WikiaError controller
-				if ( $controllerClassName != 'WikiaErrorController' && $method != 'error' ) {
-					$response->getView()->setTemplatePath( null );
-					$request->setVal( 'controller', 'WikiaError' );
-					$request->setVal( 'method', 'error' );
-					$request->setDispatched( false );
+				// if we catch an exception, forward to the WikiaError controller unless we are already dispatching Error
+				if ( empty($controllerClassName) || $controllerClassName != 'WikiaErrorController' ) {
+					$controller = F::build("WikiaErrorController");
+					$controller->forward('WikiaError', 'error', false);  // keep params for error controller
+					$response->getView()->setTemplatePath( null );  	// response is re-used so skip the original template
 				}
 			}
 
-		} while ( !$request->isDispatched() );
+		} while ( $controller && $controller->hasNext() );
 
 		if ( $request->isInternal() && $response->hasException() ) {
 			Wikia::logBacktrace(__METHOD__ . '::exception');

--- a/includes/wikia/nirvana/WikiaDispatcher.class.php
+++ b/includes/wikia/nirvana/WikiaDispatcher.class.php
@@ -73,7 +73,7 @@ class WikiaDispatcher {
 			throw new WikiaException( "wgAutoloadClasses is empty, cannot dispatch Request" );
 		}
 		$format = $request->getVal( 'format', WikiaResponse::FORMAT_HTML );
-		$response = F::build( 'WikiaResponse', array( 'format' => $format, 'request' => $request ) );
+		$response = new WikiaResponse( $format, $request );
 		$controller = null;
 
 		// Main dispatch is a loop because Controllers can forward to each other
@@ -117,6 +117,7 @@ class WikiaDispatcher {
 				$profilename = __METHOD__ . " ({$controllerClassName}_{$method})";
 				$app->wf->profileIn($profilename);
 
+				// TODO: remove F::build here after removing client calls to addClassConstructor
 				$controller = F::build( $controllerClassName ); /* @var $controller WikiaController */
 
 				if ( $callNext ) {
@@ -224,7 +225,7 @@ class WikiaDispatcher {
 
 				// if we catch an exception, forward to the WikiaError controller unless we are already dispatching Error
 				if ( empty($controllerClassName) || $controllerClassName != 'WikiaErrorController' ) {
-					$controller = F::build("WikiaErrorController");
+					$controller = new WikiaErrorController();
 					$controller->forward('WikiaError', 'error', false);  // keep params for error controller
 					$response->getView()->setTemplatePath( null );  	// response is re-used so skip the original template
 				}

--- a/includes/wikia/nirvana/WikiaRequest.class.php
+++ b/includes/wikia/nirvana/WikiaRequest.class.php
@@ -11,7 +11,6 @@
  */
 class WikiaRequest {
 
-	private $isDispatched = false;
 	private $isInternal = false;
 	protected $params = array();
 
@@ -57,22 +56,6 @@ class WikiaRequest {
 	public function setVal( $key, $value ) {
 		$this->params[$key] = $value;
 	}
-
-	/**
-	 * checks if request was already dispatched
-	 * @return bool
-	 */
-	// public function isDispatched() {
-	// 	return $this->isDispatched;
-	// }
-
-	/**
-	 * set "dispatched" flag
-	 * @param bool $value
-	 */
-	// public function setDispatched($value) {
-	// 	$this->isDispatched = (bool) $value;
-	// }
 
 	/**
 	 * checks if it's internal request

--- a/includes/wikia/nirvana/WikiaRequest.class.php
+++ b/includes/wikia/nirvana/WikiaRequest.class.php
@@ -62,17 +62,17 @@ class WikiaRequest {
 	 * checks if request was already dispatched
 	 * @return bool
 	 */
-	public function isDispatched() {
-		return $this->isDispatched;
-	}
+	// public function isDispatched() {
+	// 	return $this->isDispatched;
+	// }
 
 	/**
 	 * set "dispatched" flag
 	 * @param bool $value
 	 */
-	public function setDispatched($value) {
-		$this->isDispatched = (bool) $value;
-	}
+	// public function setDispatched($value) {
+	// 	$this->isDispatched = (bool) $value;
+	// }
 
 	/**
 	 * checks if it's internal request

--- a/includes/wikia/nirvana/WikiaView.class.php
+++ b/includes/wikia/nirvana/WikiaView.class.php
@@ -37,13 +37,6 @@ class WikiaView {
 		$response->setControllerName( $controllerName );
 		$response->setMethodName( $methodName );
 		$response->setData( $data );
-		$app = F::app();
-
-		if ( $app->wg->EnableSkinTemplateOverride ) {
-			if ( $app->isSkinInitialized() ) {
-				$response->setSkinName( $app->wg->User->getSkin()->getSkinName() );
-			}
-		}
 
 		return $response->getView();
 	}
@@ -123,30 +116,9 @@ class WikiaView {
 			// First we look for BaseName_MethodName
 			$dirName = dirname( $autoloadClasses[$controllerClass] );
 			$basePath = "{$dirName}/templates/{$controllerBaseName}_{$methodName}";
-			$templatePath = null;
-
-			/**
-			 * per-skin template override (experimental)
-			 * @see $wgEnableSkinTemplateOverride
-			 */
-			if ( !empty( $this->response ) ) {
-				$requestedSkinName = $this->response->getSkinName();
-
-				if ( !empty( $requestedSkinName ) ) {
-					$skinSpecificPath = "{$basePath}_{$requestedSkinName}.$extension";
-
-					if ( file_exists( $skinSpecificPath ) ) {
-						$templatePath = $skinSpecificPath;
-					}
-				}
-			}
-
-			if ( empty( $templatePath ) ) {
-				$templatePath = "{$basePath}.$extension";
-			}
-
-			// First we look for BaseName_MethodName
+			$templatePath = "{$basePath}.$extension";
 			$templateExists = file_exists( $templatePath );
+
 			// Fall back to ControllerClass_MethodName
 			if( !$templateExists ) {
 				$templatePath = "{$dirName}/templates/{$controllerClass}_{$methodName}.$extension";

--- a/includes/wikia/tests/WikiaControllerTest.php
+++ b/includes/wikia/tests/WikiaControllerTest.php
@@ -31,18 +31,18 @@ class WikiaControllerTest extends PHPUnit_Framework_TestCase {
 			array( false )
 		);
 	}
-	
+
 	/*
 	 * Test that the Controller response object is working properly for get/set/unset of a controller property
 	 */
 	public function testResponse() {
-		$controller = F::build('TestController');		
+		$controller = F::build('TestController');
 		$response = F::build('WikiaResponse', array('html'));
-		
+
 		// setResponse and getResponse
 		$controller->setResponse($response);
 		$this->assertEquals ($response, $controller->getResponse());
-		
+
 		// setVal and getVal
 		$controller->foo = 'foo';
 		$this->assertFalse (empty($controller->foo));
@@ -57,7 +57,7 @@ class WikiaControllerTest extends PHPUnit_Framework_TestCase {
 	 * @dataProvider redirectingDataProvider
 	 */
 	public function testRedirecting( $resetResponse ) {
-		$response = F::app()->sendRequest( 'Test', 'redirectTest', array( 'resetResponse' => $resetResponse ), false );
+		$response = F::app()->sendRequest( 'Test', 'forwardTest', array( 'resetResponse' => $resetResponse ), false );
 		$data = $response->getData();
 
 		$this->assertEquals( 'AnotherTestController', $data['controller'] );

--- a/includes/wikia/tests/_fixtures/TestController.php
+++ b/includes/wikia/tests/_fixtures/TestController.php
@@ -12,15 +12,22 @@ class TestController extends WikiaController {
 	public function jsonOnly() {
 	}
 
+	public function index() {
+		$this->getResponse()->setVal("wasCalled", "index");
+	}
+
 	public function sendTest() {
 		$this->sendRequest( 'nonExistentController', 'test' );
 	}
 
-	public function redirectTest() {
+	public function forwardTest() {
 		$resetResponse = (bool) $this->getRequest()->getVal( 'resetResponse', false );
 
 		$this->getResponse()->setVal( 'content', true );
 		$this->getResponse()->setVal( 'controller', __CLASS__ );
+
+		// set some data so we can check that resetData works
+		$this->getResponse()->setVal( 'forwardTest', true );
 
 		$this->forward( 'AnotherTest', 'hello', $resetResponse);
 	}
@@ -29,12 +36,30 @@ class TestController extends WikiaController {
 		$this->response->setVal( 'output', $this->request->getVal( 'input' ) );
 		$this->overrideTemplate( $this->request->getVal( 'template' ) );
 	}
+
+	// This is for testing dispatch by skin
+	public function skinRoutingTest() {
+		$this->getResponse()->setVal( 'wasCalled', "skinRouting");
+	}
+
+	// This is for testing dispatch by global var
+	public function globalRoutingTest() {
+		$this->getResponse()->setVal( 'wasCalled', "globalRouting");
+	}
 }
 
 class AnotherTestController extends WikiaController {
 
+	public function index() {
+		$this->skipRendering();
+		// this is for testing dispatch by * (total controller override)
+		$this->getResponse()->setVal( 'wasCalled', 'controllerRouting');
+	}
+
 	public function hello() {
 		$this->getResponse()->setVal( 'controller', __CLASS__ );
+		$this->getResponse()->setVal( 'wasCalled', "hello" );
 		$this->getResponse()->setVal( 'foo', true );
+
 	}
 }


### PR DESCRIPTION
Don't merge yet, just making this available for comments.  This uses the "options" parameter of registerController to set up a list of methods to override based on global var or skin name.  So, instead of calling Controller::foo it would call NewController::foo (if you want to override everything, you can use \* for the method name).  See code comments for more detail.

There is one feature mentioned in the comments which is not implemented yet because it may not be necessary.  There may not be any need to use "before" routing since the router currently calls the new method first anyway and if you still want to forward to the old method you can do that yourself in the new method.  Also on the TODO list is to refactor everything that uses the current dispatcher AfterExecute hooks to use this instead.    
