### PR TITLE
WikiaTracker: define dependency on wikia.log

### DIFF
--- a/resources/wikia/Resources.php
+++ b/resources/wikia/Resources.php
@@ -98,6 +98,7 @@ return array(
 	// not yet AMD :-(
 	'wikia.tracker' => array(
 		'scripts' => 'extensions/wikia/WikiaTracker/js/WikiaTracker.js',
+		'dependencies' => 'wikia.log',
 	),
 
 	// AMD modules loaded on demand


### PR DESCRIPTION
Fixes an issue with `Wikia.log` not being defined when `WikiaTracker` is initialized
