### PR TITLE
RL modules should not be cached when timestamps from filesystem and URL do not match

### DIFF
--- a/extensions/wikia/AssetsManager/builders/AssetsManagerBaseBuilder.class.php
+++ b/extensions/wikia/AssetsManager/builders/AssetsManagerBaseBuilder.class.php
@@ -79,6 +79,7 @@ class AssetsManagerBaseBuilder {
 	public function getCacheDuration() {
 		global $wgStyleVersion;
 		if($this->mCb > $wgStyleVersion) {
+			Wikia::log(__METHOD__, false, "shorter TTL set for {$this->mOid}", true);
 			return 10 * 60; // 10 minutes
 		} else {
 			return 7 * 24 * 60 * 60; // 7 days

--- a/includes/resourceloader/ResourceLoader.php
+++ b/includes/resourceloader/ResourceLoader.php
@@ -581,6 +581,11 @@ class ResourceLoader {
 			$maxage  = $wgResourceLoaderMaxage['versioned']['client'];
 			$smaxage = $wgResourceLoaderMaxage['versioned']['server'];
 		}
+
+		// Wikia - change begin - @author: macbre
+		wfRunHooks('ResourceLoaderModifyMaxAge',array($context,$mtime,&$maxage,&$smaxage));
+		// Wikia - change end
+
 		if ( $context->getOnly() === 'styles' ) {
 			header( 'Content-Type: text/css; charset=utf-8' );
 		} else {

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -235,6 +235,7 @@ $wgHooks['ResourceLoaderUserModule::getPages'][]         = 'ResourceLoaderHooks:
 $wgHooks['ResourceLoaderCacheControlHeaders'][]          = "ResourceLoaderHooks::onResourceLoaderCacheControlHeaders";
 $wgHooks['AlternateResourceLoaderURL'][]                 = "ResourceLoaderHooks::onAlternateResourceLoaderURL";
 $wgHooks['ResourceLoaderMakeQuery'][]                    = "ResourceLoaderHooks::onResourceLoaderMakeQuery";
+$wgHooks['ResourceLoaderModifyMaxAge'][]                 = "ResourceLoaderHooks::onResourceLoaderModifyMaxAge";
 
 // core
 $wgAutoloadClasses['Module']  =  $IP.'/includes/wikia/Module.php';

--- a/includes/wikia/resourceloader/ResourceLoaderHooks.class.php
+++ b/includes/wikia/resourceloader/ResourceLoaderHooks.class.php
@@ -305,4 +305,26 @@ class ResourceLoaderHooks {
 		return true;
 	}
 
+	/**
+	 * @param ResourceLoaderContext $context
+	 * @param $mtime string timestamp from module(s) calculated from filesystem
+	 * @param $maxage int UNIX timestamp for maxage
+	 * @param $smaxage int UNIX timestamp for smaxage
+	 * @return bool it's a hook
+	 */
+	public static function onResourceLoaderModifyMaxAge(ResourceLoaderContext $context, $mtime, &$maxage, &$smaxage) {
+		global $wgResourceLoaderMaxage;
+		$timestampFromRequest = strtotime($context->getVersion()); // version parameter from URL
+
+		// request wants to get module(s) newer than on those on server - set shorter caching period
+		if ($timestampFromRequest > $mtime) {
+			$maxage  = $wgResourceLoaderMaxage['unversioned']['client'];
+			$smaxage = $wgResourceLoaderMaxage['unversioned']['server'];
+
+			$modules = implode(',', $context->getModules());
+			Wikia::log(__METHOD__, false, "shorter TTL set for {$modules}", true);
+		}
+
+		return true;
+	}
 }

--- a/includes/wikia/resourceloader/tests/ResourceLoaderTest.php
+++ b/includes/wikia/resourceloader/tests/ResourceLoaderTest.php
@@ -1,0 +1,84 @@
+<?php
+
+class TestResourceLoaderModule extends ResourceLoaderModule {
+
+	const TIMESTAMP = 1361547436;
+
+	public function getModifiedTime( ResourceLoaderContext $context ) {
+		return self::TIMESTAMP;
+	}
+}
+
+class ResourceLoaderTest extends WikiaBaseTest {
+
+	private static $ttl = false;
+	private $oldWgHooks;
+
+	public function setUp() {
+		global $wgHooks;
+		$this->oldWgHooks = $wgHooks;
+
+		parent::setUp();
+	}
+
+	public function tearDown() {
+		global $wgHooks;
+		$wgHooks = $this->oldWgHooks;
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @dataProvider resourceLoaderModifyMaxAgeDataProvider
+	 *
+	 * @param $timestamp int timestamp in URL
+	 * @param $ttl int expected caching period
+	 */
+	public function testResourceLoaderModifyMaxAge($timestamp, $ttl) {
+		global $wgHooks;
+
+		$resourceLoader = new ResourceLoader();
+		$resourceLoader->register('WikiaTestModule', array(
+			'class' => 'TestResourceLoaderModule'
+		));
+
+		$request = new WebRequest();
+		$request->setVal('modules', 'WikiaTestModule');
+		$request->setVal('version', wfTimestamp(TS_ISO_8601_BASIC, $timestamp));
+
+		// set up hooks
+		$wgHooks['ResourceLoaderCacheControlHeaders'][] = 'ResourceLoaderTest::onResourceLoaderCacheControlHeaders';
+
+		ob_start();
+		$resourceLoader->respond( new ResourceLoaderContext( $resourceLoader, $request ) );
+		ob_end_clean();
+
+		// hook ResourceLoaderHooks::onResourceLoaderModifyMaxAge was called
+		// check modified caching period with expected one
+		$this->assertEquals($ttl, self::$ttl, 'TTL should match expected value');
+	}
+
+	public function resourceLoaderModifyMaxAgeDataProvider() {
+		global $wgResourceLoaderMaxage;
+
+		return array(
+			array(
+				'timestamp' => TestResourceLoaderModule::TIMESTAMP - 1,
+				'ttl' => $wgResourceLoaderMaxage['versioned']['client']
+			),
+			array(
+				'timestamp' => TestResourceLoaderModule::TIMESTAMP,
+				'ttl' => $wgResourceLoaderMaxage['versioned']['client']
+			),
+			array(
+				'timestamp' => TestResourceLoaderModule::TIMESTAMP + 1,
+				'ttl' => $wgResourceLoaderMaxage['unversioned']['client']
+			)
+		);
+	}
+
+	public function onResourceLoaderCacheControlHeaders($context, $maxage, $smaxage, $exp) {
+		self::$ttl = $maxage;
+		return true;
+	}
+}

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -15,6 +15,9 @@
 	<testsuite name="Wikia Includes Test Suite">
 		<directory>../includes/wikia/</directory>
 	</testsuite>
+	<testsuite name="Wikia ResourceLoader Test Suite">
+		<directory>../includes/resourceloader/wikia/</directory>
+	</testsuite>
 	<testsuite name="Facebook Connect Extension">
 		<directory>../extensions/FBConnect/</directory>
 	</testsuite>


### PR DESCRIPTION
This fix will solve an issue we face every Wednesday shortly after the release when Apaches with old code get requests for new ResourceLoader-based assets. When timestamp from URL is greater than timestamp coming from filesystem caching time will be decreased from 30 days to 5 minutes.

[More details](https://wikia-inc.atlassian.net/secure/RapidBoard.jspa?rapidView=5&view=detail&selectedIssue=BLAC-61)
