### PR TITLE
bug 44048 adding aliases for Special:Forum

### DIFF
--- a/extensions/wikia/Forum/Forum.alias.php
+++ b/extensions/wikia/Forum/Forum.alias.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Aliases for special pages
+ *
+ * @file
+ * @ingroup Extensions
+ */
+
+$specialPageAliases = array();
+
+/** English */
+$specialPageAliases['en'] = array(
+	'Forum' => array( 'Forum' ),
+);
+
+/** Spanish (Espanol) */
+$specialPageAliases['es'] = array(
+	'Forum' => array( 'Foro', 'Forum' ),
+);
+
+/** Russian (Русский) */
+$specialPageAliases['ru'] = array(
+	'Forum' => array( 'Форум', 'Forum' ),
+);

--- a/extensions/wikia/Forum/Forum.setup.php
+++ b/extensions/wikia/Forum/Forum.setup.php
@@ -28,6 +28,7 @@ $app->registerClass( 'RelatedForumDiscussionController', $dir . 'RelatedForumDis
 
 // i18n mapping
 $app->registerExtensionMessageFile( 'Forum', $dir . 'Forum.i18n.php' );
+$app->registerExtensionMessageFile( 'ForumAliases', $dir . 'Forum.alias.php');
 
 // special pages
 $app->registerSpecialPage( 'Forum', 'ForumSpecialController' );


### PR DESCRIPTION
As requested in https://wikia.fogbugz.com/default.asp?44048 - Forum.alias.php has been created and the setup file has been modified to load the aliases file. I hope that's all that's required to create localized aliases for other languages. If so - please merge with dev, if not - please close this request. Thanks in advance :)
