### PR TITLE
BugId:98734 - Prepare adsinhead test

### DIFF
--- a/extensions/wikia/AdEngine/AdEngine.php
+++ b/extensions/wikia/AdEngine/AdEngine.php
@@ -13,7 +13,7 @@ $wgExtensionFunctions[] = 'wfAdEngineInit';
 
 function wfAdEngineInit() {
 	global $wgRequest, $wgUser;
-	global $wgNoExternals, $wgShowAds, $wgEnableAdsInContent, $wgEnableAdMeldAPIClient, $wgEnableKruxTargeting, $wgLoadAdsInHead;
+	global $wgNoExternals, $wgShowAds, $wgEnableAdsInContent, $wgEnableAdMeldAPIClient, $wgEnableKruxTargeting;
 
 	// No ads when noexternals or noads is passed in URL
 	if ($wgRequest->getBool('noexternals', $wgNoExternals) || $wgRequest->getBool('noads', false)) {
@@ -36,15 +36,6 @@ function wfAdEngineInit() {
 		$wgEnableAdMeldAPIClient = false;
 		$wgEnableKruxTargeting = false;
 	}
-
-	// Canonical value for wgLoadAdsInHead
-	$wgLoadAdsInHead = !empty($wgLoadAdsInHead);
-
-	// Override wgLoadAdsInHead by cookie adsinhead
-	$wgLoadAdsInHead = (bool) $wgRequest->getCookie('adsinhead', '', $wgLoadAdsInHead);
-
-	// Override wgLoadAdsInHead by URL param adsinhead (?adsinhead=0 or ?adsinhead=1)
-	$wgLoadAdsInHead = $wgRequest->getBool('adsinhead', $wgLoadAdsInHead);
 }
 
 //$wgHooks["WikiaSkinTopScripts"][] = "wfAdEngineSetupJSVars";

--- a/extensions/wikia/AdEngine/AdEngine2Controller.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2Controller.class.php
@@ -43,6 +43,17 @@ class AdEngine2Controller extends WikiaController {
 		return $runAds;
 	}
 
+	public static function areAdsInHead() {
+		static $cached = null;
+
+		if ($cached === null) {
+			$wg = F::app()->wg;
+			$cached = $wg->Request->getBool('adsinhead', (bool) $wg->LoadAdsInHead);
+		}
+
+		return $cached;
+	}
+
 	/**
 	 * Register ad-related vars on top
 	 *
@@ -58,12 +69,12 @@ class AdEngine2Controller extends WikiaController {
 
 		// AdEngine2.js
 		$vars['adslots2'] = array();
-		$vars['wgLoadAdsInHead'] = !empty($this->wg->LoadAdsInHead);
+		$vars['wgLoadAdsInHead'] = self::areAdsInHead();
 		$vars['wgAdsShowableOnPage'] = self::areAdsShowableOnPage();
 		$vars['wgShowAds'] = $this->wg->ShowAds;
 
-		$useGpt = $req->getBool('usegpt', (bool) $this->wg->AdDriverUseGpt);
-		$vars['wgAdDriverUseGpt'] = $useGpt;
+		$vars['wgAdDriverUseGpt'] = $req->getBool('usegpt', (bool) $this->wg->AdDriverUseGpt);
+		$vars['wgAdDriverStartLiftiumOnLoad'] = $req->getBool('liftiumonload', (bool) $this->wg->LiftiumOnLoad);
 
 		// Used to hop by DART ads
 		$vars['adDriverLastDARTCallNoAds'] = array();
@@ -74,10 +85,6 @@ class AdEngine2Controller extends WikiaController {
 		}
 		$cat = AdEngine::getCachedCategory();
 		$vars['cityShort'] = $cat['short'];
-
-		if (!empty($this->wg->DFPid)) {
-			$vars['wgDFPid'] = $this->wg->DFPid;
-		}
 
 		wfProfileOut(__METHOD__);
 
@@ -98,7 +105,7 @@ class AdEngine2Controller extends WikiaController {
 			return true;
 		}
 
-		if (!$this->wg->LoadAdsInHead) {
+		if (!self::areAdsInHead()) {
 			// Add ad asset to JavaScripts loaded on bottom (with regular JavaScripts)
 			array_splice($jsAssets, $coreGroupIndex + 1, 0, self::ASSET_GROUP_ADENGINE);
 		}
@@ -113,7 +120,7 @@ class AdEngine2Controller extends WikiaController {
 	 * @return bool
 	 */
 	public function onOasisSkinAssetGroupsBlocking(&$jsAssets) {
-		if ($this->wg->LoadAdsInHead) {
+		if (self::areAdsInHead()) {
 			// Add ad asset to JavaScripts loaded on top (in <head>)
 			$jsAssets[] = self::ASSET_GROUP_ADENGINE;
 		}
@@ -121,13 +128,14 @@ class AdEngine2Controller extends WikiaController {
 	}
 
 	public function onWikiaSkinTopModules(&$scriptModules, $skin) {
-		if ($this->wg->LoadAdsInHead) {
+		if (self::areAdsInHead()) {
 			$scriptModules[] = 'wikia.cookies';
 			$scriptModules[] = 'wikia.geo';
 			$scriptModules[] = 'wikia.location';
 			$scriptModules[] = 'wikia.log';
 			$scriptModules[] = 'wikia.querystring';
 			$scriptModules[] = 'wikia.tracker';
+			$scriptModules[] = 'wikia.window';
 		}
 		return true;
 	}

--- a/extensions/wikia/AdEngine/AdEngine2Controller.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2Controller.class.php
@@ -43,15 +43,27 @@ class AdEngine2Controller extends WikiaController {
 		return $runAds;
 	}
 
-	public static function areAdsInHead() {
-		static $cached = null;
+	public static function getAdsInHeadGroup() {
+		static $group = null;
 
-		if ($cached === null) {
-			$wg = F::app()->wg;
-			$cached = $wg->Request->getBool('adsinhead', (bool) $wg->LoadAdsInHead);
+		if ($group === null) {
+			// Get into a random 3% group:
+			$group = mt_rand(0, 33);
+
+			// Override from URL
+			$group = F::app()->wg->Request->getInt('adsinhead', $group);
+
+			// Put all but #1 and #2 group into #0
+			if ($group > 2) {
+				$group = 0;
+			}
 		}
 
-		return $cached;
+		return $group;
+	}
+
+	public static function areAdsInHead() {
+		return self::getAdsInHeadGroup() === 1;
 	}
 
 	/**
@@ -70,6 +82,7 @@ class AdEngine2Controller extends WikiaController {
 		// AdEngine2.js
 		$vars['adslots2'] = array();
 		$vars['wgLoadAdsInHead'] = self::areAdsInHead();
+		$vars['wgAdsInHeadGroup'] = self::getAdsInHeadGroup();
 		$vars['wgAdsShowableOnPage'] = self::areAdsShowableOnPage();
 		$vars['wgShowAds'] = $this->wg->ShowAds;
 

--- a/extensions/wikia/AdEngine/js/AdEngine2.run.js
+++ b/extensions/wikia/AdEngine/js/AdEngine2.run.js
@@ -80,16 +80,18 @@
 		adProviderNull
 	);
 
-	log('work on window.adslots2 according to AdConfig2', 1, module);
-	tracker.track({
-		eventName: 'liftium.init',
-		ga_category: 'init2/init',
-		ga_action: 'init',
-		ga_label: 'adengine2',
-		trackingMethod: 'ad'
+	window.wgAfterContentAndJS.push(function() {
+		log('work on window.adslots2 according to AdConfig2', 1, module);
+		tracker.track({
+			eventName: 'liftium.init',
+			ga_category: 'init2/init',
+			ga_action: 'init',
+			ga_label: 'adengine2',
+			trackingMethod: 'ad'
+		});
+		window.adslots2 = window.adslots2 || [];
+		adEngine.run(adConfig, window.adslots2);
 	});
-	window.adslots2 = window.adslots2 || [];
-	adEngine.run(adConfig, window.adslots2);
 
 	// DART API for Liftium
 	window.LiftiumDART = {

--- a/extensions/wikia/AdEngine/liftium/Liftium.js
+++ b/extensions/wikia/AdEngine/liftium/Liftium.js
@@ -2764,8 +2764,13 @@ if (LiftiumOptions.error_beacon !== false ){
 
 
 // Gentlemen, Start your optimization!
-if (Liftium.empty(LiftiumOptions.offline)){
-	Liftium.init();
+
+if (window.wgAdDriverStartLiftiumOnLoad) {
+	Liftium.addEventListener(window, 'load', Liftium.init);
+} else {
+	if (Liftium.empty(LiftiumOptions.offline)){
+		Liftium.init();
+	}
 }
 
 Liftium.addEventListener(window, 'load', Liftium.onLoadHandler);

--- a/extensions/wikia/AnalyticsEngine/js/analytics_prod.js
+++ b/extensions/wikia/AnalyticsEngine/js/analytics_prod.js
@@ -134,6 +134,12 @@
 				window.addEventListener("load", abOnLoadHandler, false);
 			}
 		}
+
+		/**** Back-end A/B test for order of loading test ****/
+		if (window.wgAdsInHeadGroup !== 0) {
+			_gaqWikiaPush(['_setCustomVar', 39, 'adsinhead', 'adsinhead=' + window.wgAdsInHeadGroup, 3]);
+			abCustomVarsForAds.push(['ads._setCustomVar', 39, 'adsinhead', 'adsinhead=' + window.wgAdsInHeadGroup, 3]);
+		}
     }
 
     // Unleash


### PR DESCRIPTION
- For about 3% of requests the backend will generate a page emulating wgLoadAdsInHead=1 and add reporting variable to GA (slot 39, value 1).
- For another 3% of requests the backend will generate a regular page and add reporting variable to GA (slot 39, value 2), so we can compare groups of the same size.
- For the rest of the traffic a regular page is generated.

This pull request also adds URL configuration variable liftiumonload which delays Liftium.init to onload event. It also removes possibility to set adsinhead by cookie, because it's not reliable.
