### PR TITLE
BugId:98734 - Prepare adsinhead test

### DIFF
--- a/extensions/wikia/AdEngine/AdEngine2Controller.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2Controller.class.php
@@ -43,15 +43,38 @@ class AdEngine2Controller extends WikiaController {
 		return $runAds;
 	}
 
-	public static function areAdsInHead() {
-		static $cached = null;
+	public static function getAdsInHeadGroup() {
+		static $group = null;
 
-		if ($cached === null) {
-			$wg = F::app()->wg;
-			$cached = $wg->Request->getBool('adsinhead', (bool) $wg->LoadAdsInHead);
+		if ($group === null) {
+			// Get into a random 1% group:
+			$bucket = mt_rand(0, 99);
+
+			if ($bucket === 0 || $bucket === 1 || $bucket === 2) {
+				// 3% gets group #1
+				$group = 1;
+			} elseif ($bucket === 3 || $bucket === 4 || $bucket === 5) {
+				// 3% gets group #2
+				$group = 2;
+			} else {
+				// 94% gets group #0
+				$group = 0;
+			}
+
+			// Override from URL
+			$group = F::app()->wg->Request->getInt('adsinhead', $group);
+
+			// Only accept 0, 1 and 2
+			if ($group > 2 || $group < 0) {
+				$group = 0;
+			}
 		}
 
-		return $cached;
+		return $group;
+	}
+
+	public static function areAdsInHead() {
+		return self::getAdsInHeadGroup() === 1;
 	}
 
 	/**
@@ -70,6 +93,7 @@ class AdEngine2Controller extends WikiaController {
 		// AdEngine2.js
 		$vars['adslots2'] = array();
 		$vars['wgLoadAdsInHead'] = self::areAdsInHead();
+		$vars['wgAdsInHeadGroup'] = self::getAdsInHeadGroup();
 		$vars['wgAdsShowableOnPage'] = self::areAdsShowableOnPage();
 		$vars['wgShowAds'] = $this->wg->ShowAds;
 

--- a/extensions/wikia/AnalyticsEngine/js/analytics_prod.js
+++ b/extensions/wikia/AnalyticsEngine/js/analytics_prod.js
@@ -134,6 +134,12 @@
 				window.addEventListener("load", abOnLoadHandler, false);
 			}
 		}
+
+		/**** Back-end A/B test for order of loading test ****/
+		if (window.wgAdsInHeadGroup !== 0) {
+			_gaqWikiaPush(['_setCustomVar', 39, 'ADSINHEAD', 'ADSINHEAD_' + window.wgAdsInHeadGroup, 3]);
+			abCustomVarsForAds.push(['ads._setCustomVar', 39, 'ADSINHEAD', 'ADSINHEAD_' + window.wgAdsInHeadGroup, 3]);
+		}
     }
 
     // Unleash


### PR DESCRIPTION
- For about 3% of requests the backend will generate a page emulating wgLoadAdsInHead=1 and add reporting variable to GA (slot 39, value 1).
- For another 3% of requests the backend will generate a regular page and add reporting variable to GA (slot 39, value 2), so we can compare groups of the same size.
- For the rest of the traffic a regular page is generated.

This pull request also adds URL configuration variable liftiumonload which delays Liftium.init to onload event. It also removes possibility to set adsinhead by cookie, because it's not reliable.
