### PR TITLE
BugId:98734 - Server-side test for adsinhead 

### DIFF
--- a/extensions/wikia/AdEngine/AdEngine2Controller.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2Controller.class.php
@@ -43,15 +43,31 @@ class AdEngine2Controller extends WikiaController {
 		return $runAds;
 	}
 
-	public static function areAdsInHead() {
+	public static function getAdsInHeadGroup() {
 		static $cached = null;
 
 		if ($cached === null) {
-			$wg = F::app()->wg;
-			$cached = $wg->Request->getBool('adsinhead', (bool) $wg->LoadAdsInHead);
+			if (F::app()->wg->LoadAdsInHead) {
+				// Get into a random 50/50 group:
+				$cached = mt_rand(1, 2);
+			} else {
+				$cached = 0;
+			}
+
+			// Override from URL
+			$cached = F::app()->wg->Request->getInt('adsinhead', $cached);
+
+			// Only accept 0, 1 and 2
+			if ($cached > 2 || $cached < 0) {
+				$cached = 0;
+			}
 		}
 
 		return $cached;
+	}
+
+	public static function areAdsInHead() {
+		return self::getAdsInHeadGroup() === 1;
 	}
 
 	/**
@@ -70,6 +86,7 @@ class AdEngine2Controller extends WikiaController {
 		// AdEngine2.js
 		$vars['adslots2'] = array();
 		$vars['wgLoadAdsInHead'] = self::areAdsInHead();
+		$vars['wgAdsInHeadGroup'] = self::getAdsInHeadGroup();
 		$vars['wgAdsShowableOnPage'] = self::areAdsShowableOnPage();
 		$vars['wgShowAds'] = $this->wg->ShowAds;
 

--- a/extensions/wikia/AnalyticsEngine/js/analytics_prod.js
+++ b/extensions/wikia/AnalyticsEngine/js/analytics_prod.js
@@ -134,6 +134,12 @@
 				window.addEventListener("load", abOnLoadHandler, false);
 			}
 		}
+
+		/**** Back-end A/B test for order of loading test ****/
+		if (window.wgAdsInHeadGroup !== 0) {
+			_gaqWikiaPush(['_setCustomVar', 39, 'ADSINHEAD', 'ADSINHEAD_' + window.wgAdsInHeadGroup, 3]);
+			abCustomVarsForAds.push(['ads._setCustomVar', 39, 'ADSINHEAD', 'ADSINHEAD_' + window.wgAdsInHeadGroup, 3]);
+		}
     }
 
     // Unleash


### PR DESCRIPTION
When $wgLoadAdsInHead is set, pageviews get into either adsinhead=1 (50%) or adsinhead=2 (50%) group, which get logged to GA (custom variable 39) and if adsinhead=1 JavaScript ad code is pushed up to HTML <head>. This allows us to test the performance hit for pushing ad code up in HTML.
