### PR TITLE
Bugid 98307

### DIFF
--- a/extensions/wikia/WikiaPoll/SpecialCreateWikiaPoll.class.php
+++ b/extensions/wikia/WikiaPoll/SpecialCreateWikiaPoll.class.php
@@ -22,7 +22,8 @@ class SpecialCreateWikiaPoll extends SpecialPage {
 			return;
 		}
 
-		$wgOut->addScript('<script src="'.$wgResourceBasePath.'/resources/wikia/libraries/jquery-ui/jquery-ui-1.8.14.custom.js"></script>');
+		//$wgOut->addScript('<script src="'.$wgResourceBasePath.'/resources/wikia/libraries/jquery-ui/jquery-ui-1.8.14.custom.js"></script>');
+        $wgOut->addModules("wikia.jquery.ui");
 		$wgOut->addScript('<script src="'.$wgExtensionsPath.'/wikia/WikiaPoll/js/CreateWikiaPoll.js"></script>');
 
 		$wgOut->addStyle(AssetsManager::getInstance()->getSassCommonURL('/extensions/wikia/WikiaPoll/css/CreateWikiaPoll.scss'));

--- a/extensions/wikia/WikiaPoll/SpecialCreateWikiaPoll.class.php
+++ b/extensions/wikia/WikiaPoll/SpecialCreateWikiaPoll.class.php
@@ -22,8 +22,7 @@ class SpecialCreateWikiaPoll extends SpecialPage {
 			return;
 		}
 
-		//$wgOut->addScript('<script src="'.$wgResourceBasePath.'/resources/wikia/libraries/jquery-ui/jquery-ui-1.8.14.custom.js"></script>');
-        $wgOut->addModules("wikia.jquery.ui");
+		$wgOut->addModules("wikia.jquery.ui");
 		$wgOut->addScript('<script src="'.$wgExtensionsPath.'/wikia/WikiaPoll/js/CreateWikiaPoll.js"></script>');
 
 		$wgOut->addStyle(AssetsManager::getInstance()->getSassCommonURL('/extensions/wikia/WikiaPoll/css/CreateWikiaPoll.scss'));

--- a/extensions/wikia/WikiaPoll/js/CreateWikiaPoll.js
+++ b/extensions/wikia/WikiaPoll/js/CreateWikiaPoll.js
@@ -18,7 +18,7 @@ var CreateWikiaPoll = {
 			.on("mousedown", ".drag", function(event) {
 				event.preventDefault();
 			})
-            .on("click", ".trash", CreateWikiaPoll.remove)
+			.on("click", ".trash", CreateWikiaPoll.remove)
 			.find(".add-new a").click(CreateWikiaPoll.addNew).end()
 			.find(".create").click(CreateWikiaPoll.onSave);
 		if ($("#CreateWikiaPoll").closest(".modalWrapper")) {

--- a/extensions/wikia/WikiaPoll/js/CreateWikiaPoll.js
+++ b/extensions/wikia/WikiaPoll/js/CreateWikiaPoll.js
@@ -15,10 +15,10 @@ var CreateWikiaPoll = {
 				opacity: 0.8,
 				stop: CreateWikiaPoll.renumber
 			}).end()
-			.find(".drag").live("mousedown", function(event) {
+			.on("mousedown", ".drag", function(event) {
 				event.preventDefault();
-			}).end()
-			.find(".trash").live("click", CreateWikiaPoll.remove).end()
+			})
+            .on("click", ".trash", CreateWikiaPoll.remove)
 			.find(".add-new a").click(CreateWikiaPoll.addNew).end()
 			.find(".create").click(CreateWikiaPoll.onSave);
 		if ($("#CreateWikiaPoll").closest(".modalWrapper")) {


### PR DESCRIPTION
File: /extensions/wikia/WikiaPoll/js/CreateWikiaPoll.js

jQuery.live() is deprecated @ lines 18, 21

---

Reporting as P3 as it's blocking an upgrade to jQuery 1.9.x
