### PR TITLE
BAC-91: fix PHP out of memory caused by recursive hook calls

### DIFF
--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -853,8 +853,8 @@ function wfMatchesDomainList( $url, $domains ) {
  * @param $logonly Bool: set true to avoid appearing in HTML when $wgDebugComments is set
  */
 function wfDebug( $text, $logonly = false ) {
-	global $wgOut, $wgDebugLogFile, $wgDebugComments, $wgProfileOnly, $wgDebugRawPage;
-	global $wgDebugLogPrefix, $wgShowDebug;
+	global $wgOut, $wgDebugComments, $wgDebugRawPage;
+	global $wgShowDebug;
 
 	static $cache = array(); // Cache of unoutputted messages
 	$text = wfDebugTimer() . $text;
@@ -872,7 +872,9 @@ function wfDebug( $text, $logonly = false ) {
 			$cache = array();
 		}
 	}
-	if ( wfRunHooks( 'Debug', array( $text, null /* no log group */ ) ) ) {
+	/**
+	global $wgDebugLogFile, $wgProfileOnly, $wgDebugLogPrefix;
+	if ( wfRunHooks( 'Debug', array( $text, null ) ) ) {
 		if ( $wgDebugLogFile != '' && !$wgProfileOnly ) {
 			# Strip unprintables; they can switch terminal modes when binary data
 			# gets dumped, which is pretty annoying.
@@ -881,6 +883,7 @@ function wfDebug( $text, $logonly = false ) {
 			wfErrorLog( $text, $wgDebugLogFile );
 		}
 	}
+	**/
 
 	MWDebug::debugMsg( $text );
 }

--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -853,8 +853,8 @@ function wfMatchesDomainList( $url, $domains ) {
  * @param $logonly Bool: set true to avoid appearing in HTML when $wgDebugComments is set
  */
 function wfDebug( $text, $logonly = false ) {
-	global $wgOut, $wgDebugComments, $wgDebugRawPage;
-	global $wgShowDebug;
+	global $wgOut, $wgDebugLogFile, $wgDebugComments, $wgProfileOnly, $wgDebugRawPage;
+	global $wgDebugLogPrefix, $wgShowDebug;
 
 	static $cache = array(); // Cache of unoutputted messages
 	$text = wfDebugTimer() . $text;
@@ -873,7 +873,7 @@ function wfDebug( $text, $logonly = false ) {
 		}
 	}
 	/**
-	global $wgDebugLogFile, $wgProfileOnly, $wgDebugLogPrefix;
+	# BAC-91
 	if ( wfRunHooks( 'Debug', array( $text, null ) ) ) {
 		if ( $wgDebugLogFile != '' && !$wgProfileOnly ) {
 			# Strip unprintables; they can switch terminal modes when binary data


### PR DESCRIPTION
Don't call `Debug` hook. It causes the following recursion:

```
7   0.0464  8737008 wfRunHooks( 'Debug', array (0 => 'wikifactory: wgDBserver for cluster c1 set to 10.14.30.141', 1 => NULL) ) ../GlobalFunctions.php:875
8   0.0464  8737008 Hooks::run( 'Debug', array (0 => 'wikifactory: wgDBserver for cluster c1 set to 10.14.30.141', 1 => NULL) ) ../GlobalFunctions.php:3879
9   0.0464  8737096 wfProfileIn( 'Hooks::run-hook-Debug' )  ../Hooks.php:96
10  0.0465  8737144 ProfilerSimple->profileIn( 'Hooks::run-hook-Debug' )    ../Profiler.php:17
11  0.0465  8737296 Profiler->debug( ' Entering Hooks::run-hook-Debug\n' )  ../ProfilerSimple.php:54
12  0.0465  8737336 wfDebug( ' Entering Hooks::run-hook-Debug\n', ??? ) ../Profiler.php:510
13  0.0465  8738008 wfRunHooks( 'Debug', array (0 => ' Entering Hooks::run-hook-Debug\n', 1 => NULL) )  ../GlobalFunctions.php:875
```

and so on :)

@wladekb
