### PR TITLE
Bac 91 debug hook

### DIFF
--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -875,6 +875,7 @@ function wfDebug( $text, $logonly = false ) {
 	/**
 	# BAC-91
 	if ( wfRunHooks( 'Debug', array( $text, null ) ) ) {
+	 **/
 		if ( $wgDebugLogFile != '' && !$wgProfileOnly ) {
 			# Strip unprintables; they can switch terminal modes when binary data
 			# gets dumped, which is pretty annoying.
@@ -882,6 +883,7 @@ function wfDebug( $text, $logonly = false ) {
 			$text = $wgDebugLogPrefix . $text;
 			wfErrorLog( $text, $wgDebugLogFile );
 		}
+	/**
 	}
 	**/
 

--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -872,10 +872,7 @@ function wfDebug( $text, $logonly = false ) {
 			$cache = array();
 		}
 	}
-	/**
-	# BAC-91
-	if ( wfRunHooks( 'Debug', array( $text, null ) ) ) {
-	 **/
+	# if ( wfRunHooks( 'Debug', array( $text, null ) ) ) { // Wikia change - BAC-91
 		if ( $wgDebugLogFile != '' && !$wgProfileOnly ) {
 			# Strip unprintables; they can switch terminal modes when binary data
 			# gets dumped, which is pretty annoying.
@@ -883,9 +880,7 @@ function wfDebug( $text, $logonly = false ) {
 			$text = $wgDebugLogPrefix . $text;
 			wfErrorLog( $text, $wgDebugLogFile );
 		}
-	/**
-	}
-	**/
+	#} // Wikia change - BAC-91
 
 	MWDebug::debugMsg( $text );
 }


### PR DESCRIPTION
Fixes an issue that I introduced in #488. Hook should not be called, but logging to the file should still happen.
