### PR TITLE
BAC-86: Add a hook to check if uploaded image file is corrupted

### DIFF
--- a/includes/wikia/tests/UploadVerifyFileTest.php
+++ b/includes/wikia/tests/UploadVerifyFileTest.php
@@ -24,11 +24,7 @@ class UploadVerifyFile extends WikiaBaseTest {
 			file_put_contents($this->tmpPath, $uploadContent);
 		}
 
-		$titleMock = $this->mockClassWithMethods('Title', array(
-			'getText' => 'Foo'
-		));
 		$uploadMock = $this->mockClassWithMethods('TestUploadClass', array(
-			'getTitle' => $titleMock,
 			'getTempPath' => $this->tmpPath
 		));
 


### PR DESCRIPTION
Use ImageMagick's `identify` binary to validate uploaded images (works way better than GD).
