### PR TITLE
BAC-114: Expose length of TaskManager's queue via API

### DIFF
--- a/extensions/wikia/TaskManager/SpecialTaskManager.php
+++ b/extensions/wikia/TaskManager/SpecialTaskManager.php
@@ -22,22 +22,24 @@ $wgExtensionCredits['specialpage'][] = array(
 	"author" => "Krzysztof Krzyżaniak (eloy)"
 );
 
+$dir = __DIR__;
+
 /**
  * add all task which should be visible here
  */
-require_once( dirname(__FILE__) . "/BatchTask.php" );
-extAddBatchTask( dirname(__FILE__)."/Tasks/CloseWikiTask.php", "closewiki", "CloseWikiTask" );
-extAddBatchTask( dirname(__FILE__)."/Tasks/MultiRestoreTask.php", "multirestore", "MultiRestoreTask" );
-extAddBatchTask( dirname(__FILE__)."/Tasks/ImageGrabberTask.php", "imagegrabber", "ImageGrabberTask" );
-extAddBatchTask( dirname(__FILE__)."/Tasks/ImageImporterTask.php", "imageimporter", "ImageImporterTask" );
-extAddBatchTask( dirname(__FILE__)."/Tasks/PageGrabberTask.php", "pagegrabber", "PageGrabberTask" );
-extAddBatchTask( dirname(__FILE__)."/Tasks/PageGrabberDumpTask.php", "pagegrabberdump", "PageGrabberDumpTask" );
-extAddBatchTask( dirname(__FILE__)."/Tasks/PageImporterTask.php", "pageimporter", "PageImporterTask" );
-extAddBatchTask( dirname(__FILE__)."/Tasks/SWMSendToGroupTask.php", "SWMSendToGroup", "SWMSendToGroupTask" );
-extAddBatchTask( dirname(__FILE__)."/Tasks/LocalMaintenanceTask.php", "local-maintenance", "LocalMaintenanceTask" );
-extAddBatchTask( dirname(__FILE__) ."/Tasks/RebuildLocalisationCacheTask.php", "rebuild_localisation_cache", "RebuildLocalisationCacheTask" );
-extAddBatchTask( dirname(__FILE__) ."/Tasks/UpdateSpecialPagesTask.php", "update_special_pages", "UpdateSpecialPagesTask" );
-extAddBatchTask( dirname(__FILE__)."/../AchievementsII/EnableAchievementsTask.php", "enableachievements", "EnableAchievementsTask" );
+require_once( $dir . "/BatchTask.php" );
+extAddBatchTask( $dir."/Tasks/CloseWikiTask.php", "closewiki", "CloseWikiTask" );
+extAddBatchTask( $dir."/Tasks/MultiRestoreTask.php", "multirestore", "MultiRestoreTask" );
+extAddBatchTask( $dir."/Tasks/ImageGrabberTask.php", "imagegrabber", "ImageGrabberTask" );
+extAddBatchTask( $dir."/Tasks/ImageImporterTask.php", "imageimporter", "ImageImporterTask" );
+extAddBatchTask( $dir."/Tasks/PageGrabberTask.php", "pagegrabber", "PageGrabberTask" );
+extAddBatchTask( $dir."/Tasks/PageGrabberDumpTask.php", "pagegrabberdump", "PageGrabberDumpTask" );
+extAddBatchTask( $dir."/Tasks/PageImporterTask.php", "pageimporter", "PageImporterTask" );
+extAddBatchTask( $dir."/Tasks/SWMSendToGroupTask.php", "SWMSendToGroup", "SWMSendToGroupTask" );
+extAddBatchTask( $dir."/Tasks/LocalMaintenanceTask.php", "local-maintenance", "LocalMaintenanceTask" );
+extAddBatchTask( $dir ."/Tasks/RebuildLocalisationCacheTask.php", "rebuild_localisation_cache", "RebuildLocalisationCacheTask" );
+extAddBatchTask( $dir ."/Tasks/UpdateSpecialPagesTask.php", "update_special_pages", "UpdateSpecialPagesTask" );
+extAddBatchTask( $dir."/../AchievementsII/EnableAchievementsTask.php", "enableachievements", "EnableAchievementsTask" );
 
 /**
  * permissions
@@ -54,12 +56,18 @@ $wgGroupPermissions['util']['taskmanager-action'] = true;
 /**
  * message file
  */
-$wgExtensionMessagesFiles[ $sSpecialPage ] = dirname(__FILE__) . "/Special{$sSpecialPage}.i18n.php";
+$wgExtensionMessagesFiles[ $sSpecialPage ] = $dir . "/Special{$sSpecialPage}.i18n.php";
 
 /**
  * aliases file
  */
-$wgExtensionMessagesFiles[ $sSpecialPage . 'Aliases' ] = __DIR__ . "/Special{$sSpecialPage}.aliases.php";
+$wgExtensionMessagesFiles[ $sSpecialPage . 'Aliases' ] = $dir . "/Special{$sSpecialPage}.aliases.php";
 
-extAddSpecialPage( dirname(__FILE__) . "/Special{$sSpecialPage}_body.php", $sSpecialPage, "{$sSpecialPage}Page" );
+extAddSpecialPage( $dir . "/Special{$sSpecialPage}_body.php", $sSpecialPage, "{$sSpecialPage}Page" );
 $wgSpecialPageGroups[$sSpecialPage] = 'wikia';
+
+/**
+ * hooks
+ */
+$wgAutoloadClasses['TaskManagerHooks'] = $dir . '/hooks/TaskManagerHooks.class.php';
+$wgHooks['APIQuerySiteInfoStatistics'][] = 'TaskManagerHooks::onAPIQuerySiteInfoStatistics';

--- a/extensions/wikia/TaskManager/hooks/TaskManagerHooks.class.php
+++ b/extensions/wikia/TaskManager/hooks/TaskManagerHooks.class.php
@@ -1,0 +1,37 @@
+<?php
+
+class TaskManagerHooks {
+
+	/**
+	 * Add an entry with number of items queued in TaskManager to APIQuerySiteInfo module
+	 *
+	 * @see http://www.wikia.com/api.php?action=query&meta=siteinfo&siprop=statistics
+	 *
+	 * @param ApiQuerySiteinfo $apiModule
+	 * @param array $stats
+	 * @return bool true
+	 */
+	public static function onAPIQuerySiteInfoStatistics(ApiQuerySiteinfo $apiModule, Array &$stats) {
+		$stats['tasks'] = self::getTasksCount();
+		return true;
+	}
+
+	/**
+	 * Get number of items queued in TaskManager
+	 *
+	 * @return int number of items in the queue
+	 */
+	private static function getTasksCount() {
+		global $wgMemc;
+
+		$key = __METHOD__;
+		$cnt = $wgMemc->get($key);
+
+		if (!is_numeric($cnt)) {
+			$dbr = WikiFactory::db( DB_SLAVE );
+			$cnt = $dbr->estimateRowCount('wikia_tasks');
+			$wgMemc->set($key, $cnt, 60 * 1);
+		}
+		return $cnt;
+	}
+}

--- a/includes/api/ApiQuerySiteinfo.php
+++ b/includes/api/ApiQuerySiteinfo.php
@@ -95,7 +95,7 @@ class ApiQuerySiteinfo extends ApiQueryBase {
 					break;
 				default:
 					wfRunHooks( 'UseExternalQuerySiteInfo', array(&$this) );
-					if ( !isset($this->noErrors) ) { 
+					if ( !isset($this->noErrors) ) {
 						ApiBase :: dieDebug( __METHOD__, "Unknown prop=$p" );
 					}
 			}
@@ -355,6 +355,12 @@ class ApiQuerySiteinfo extends ApiQueryBase {
 		$data['activeusers'] = intval( SiteStats::activeUsers() );
 		$data['admins'] = intval( SiteStats::numberingroup( 'sysop' ) );
 		$data['jobs'] = intval( SiteStats::jobs() );
+
+		// Wikia change begin
+		// @author macbre
+		wfRunHooks( 'APIQuerySiteInfoStatistics', array( $this, &$data ) );
+		// Wikia change end
+
 		return $this->getResult()->addValue( 'query', $property, $data );
 	}
 


### PR DESCRIPTION
- add `APIQuerySiteInfoStatistics` to alter data returned by siteinfo API module
- add `tasks` field with number of items queued in TaskManager
