### PR TITLE
Assets caching tweaks

### DIFF
--- a/extensions/wikia/AssetsManager/AssetsManagerServer.class.php
+++ b/extensions/wikia/AssetsManager/AssetsManagerServer.class.php
@@ -60,9 +60,9 @@ class AssetsManagerServer {
 
 		$cacheDuration = $builder->getCacheDuration();
 		if($cacheDuration > 0) {
-			$headers['Expires'] = gmdate('D, d M Y H:i:s \G\M\T', strtotime($cacheDuration . ' seconds'));
-			$headers['X-Pass-Cache-Control'] = $builder->getCacheMode() . ', max-age=' . $cacheDuration;
-			$headers['Cache-Control'] = $builder->getCacheMode() . ', max-age=' . $cacheDuration;
+			$headers['Expires'] = gmdate('D, d M Y H:i:s \G\M\T', strtotime($cacheDuration['server'] . ' seconds'));
+			$headers['Cache-Control'] = $builder->getCacheMode() . ', max-age=' . $cacheDuration['server'];
+			$headers['X-Pass-Cache-Control'] = $builder->getCacheMode() . ', max-age=' . $cacheDuration['client'];
 		}
 
 		$headers['Last-Modified'] = gmdate('D, d M Y H:i:s \G\M\T');

--- a/extensions/wikia/AssetsManager/builders/AssetsManagerBaseBuilder.class.php
+++ b/extensions/wikia/AssetsManager/builders/AssetsManagerBaseBuilder.class.php
@@ -77,12 +77,12 @@ class AssetsManagerBaseBuilder {
 	}
 
 	public function getCacheDuration() {
-		global $wgStyleVersion;
+		global $wgResourceLoaderMaxage, $wgStyleVersion;
 		if($this->mCb > $wgStyleVersion) {
 			Wikia::log(__METHOD__, false, "shorter TTL set for {$this->mOid}", true);
-			return 10 * 60; // 10 minutes
+			return $wgResourceLoaderMaxage['unversioned'];
 		} else {
-			return 7 * 24 * 60 * 60; // 7 days
+			return $wgResourceLoaderMaxage['versioned'];
 		}
 	}
 

--- a/extensions/wikia/JSVariables/JSVariables.php
+++ b/extensions/wikia/JSVariables/JSVariables.php
@@ -56,6 +56,9 @@ function wfJSVariablesTopScripts(Array &$vars, &$scripts) {
 	$vars['_gaq'] = array();
 	$vars['wgIsGASpecialWiki'] = $wg->IsGASpecialWiki;
 
+	// PER-58: moved wgStyleVersion to <head>
+	$vars['wgStyleVersion'] = (string)($wg->StyleVersion);
+
 	$scripts .= Html::inlineScript("var wgNow = new Date();") .	"\n";
 
 	return true;
@@ -69,7 +72,7 @@ function wfJSVariablesTopScripts(Array &$vars, &$scripts) {
 function wfMakeGlobalVariablesScript(Array &$vars, OutputPage $out) {
 	wfProfileIn(__METHOD__);
 	global $wgMemc, $wgEnableAjaxLogin, $wgPrivateTracker, $wgExtensionsPath,
-		$wgArticle, $wgStyleVersion, $wgSitename, $wgDisableAnonymousEditing,
+		$wgArticle, $wgSitename, $wgDisableAnonymousEditing,
 		$wgGroupPermissions, $wgBlankImgUrl, $wgCookieDomain, $wgCookiePath, $wgResourceBasePath;
 
 	$skin = $out->getSkin();
@@ -111,8 +114,6 @@ function wfMakeGlobalVariablesScript(Array &$vars, OutputPage $out) {
 	if (Wikia::isContentNamespace()) {
 		$vars['wgIsContentNamespace'] = true;
 	}
-
-	$vars['wgStyleVersion'] = isset($wgStyleVersion) ? $wgStyleVersion : '' ;
 
 	// TODO: is this one really needed?
 	if(isset($skin->themename)) {

--- a/includes/wikia/resourceloader/ResourceLoaderHooks.class.php
+++ b/includes/wikia/resourceloader/ResourceLoaderHooks.class.php
@@ -323,6 +323,17 @@ class ResourceLoaderHooks {
 	public static function onResourceLoaderModifyMaxAge(ResourceLoaderContext $context, $mtime, &$maxage, &$smaxage) {
 		global $wgStyleVersion, $wgResourceLoaderMaxage;
 
+		// need to cache RL manifest for longer
+		$modules = $context->getModules();
+		if ( count($modules) == 1 && $modules[0] == 'startup' ) {
+			$maxage  = $wgResourceLoaderMaxage['versioned']['client'];
+			$smaxage = $wgResourceLoaderMaxage['versioned']['server'];
+
+			$modules = implode(',', $context->getModules());
+			Wikia::log(__METHOD__, false, "longer TTL set for {$modules}", true);
+			return true;
+		}
+
 		$forceShortTTL = false;
 
 		$version = explode('-',(string)($context->getVersion()),2);

--- a/includes/wikia/resourceloader/ResourceLoaderHooks.class.php
+++ b/includes/wikia/resourceloader/ResourceLoaderHooks.class.php
@@ -221,7 +221,7 @@ class ResourceLoaderHooks {
 	}
 
 	public static function onResourceLoaderCacheControlHeaders( $context, $maxage, $smaxage, $exp ) {
-		header( "X-Pass-Cache-Control: public, max-age=$maxage, s-maxage=$smaxage" );
+		header( "X-Pass-Cache-Control: public, max-age=$maxage, s-maxage=$maxage" );
 		header( 'X-Pass-Expires: ' . wfTimestamp( TS_RFC2822, $exp + time() ) );
 
 		return true;
@@ -281,6 +281,14 @@ class ResourceLoaderHooks {
 	}
 
 	public static function onResourceLoaderMakeQuery( $modules, &$query ) {
+		// PER-58: append CB value to RL query
+		global $wgStyleVersion;
+		if ( !empty( $query['version'] ) ) {
+			$query['version'] = $wgStyleVersion . "-" . $query['version'];
+		} else {
+			$query['cb'] = $wgStyleVersion;
+		}
+
 		$only = isset($query['only']) ? $query['only'] : null;
 
 		if ( empty( $only ) || $only == 'styles' ) {
@@ -313,11 +321,24 @@ class ResourceLoaderHooks {
 	 * @return bool it's a hook
 	 */
 	public static function onResourceLoaderModifyMaxAge(ResourceLoaderContext $context, $mtime, &$maxage, &$smaxage) {
-		global $wgResourceLoaderMaxage;
-		$timestampFromRequest = strtotime($context->getVersion()); // version parameter from URL
+		global $wgStyleVersion, $wgResourceLoaderMaxage;
+
+		$forceShortTTL = false;
+
+		$version = explode('-',(string)($context->getVersion()),2);
+		if ( !is_array($version) || count($version) != 2 ) { // if version format different than "CB-TS"
+			$forceShortTTL = true;
+		}
+
+		if ( !$forceShortTTL ) {
+			list( $styleVersionFromRequest, $timestampFromRequest ) = $version;
+			$timestampFromRequest = strtotime($timestampFromRequest); // parse timestamp from request
+			$forceShortTTL = $styleVersionFromRequest > $wgStyleVersion
+				|| $timestampFromRequest > $mtime;
+		}
 
 		// request wants to get module(s) newer than on those on server - set shorter caching period
-		if ($timestampFromRequest > $mtime) {
+		if ( $forceShortTTL ) {
 			$maxage  = $wgResourceLoaderMaxage['unversioned']['client'];
 			$smaxage = $wgResourceLoaderMaxage['unversioned']['server'];
 

--- a/includes/wikia/resourceloader/ResourceLoaderHooks.class.php
+++ b/includes/wikia/resourceloader/ResourceLoaderHooks.class.php
@@ -221,7 +221,7 @@ class ResourceLoaderHooks {
 	}
 
 	public static function onResourceLoaderCacheControlHeaders( $context, $maxage, $smaxage, $exp ) {
-		header( "X-Pass-Cache-Control: public, max-age=$maxage, s-maxage=$maxage" );
+		header( "X-Pass-Cache-Control: public, max-age=$maxage, s-maxage=$smaxage" );
 		header( 'X-Pass-Expires: ' . wfTimestamp( TS_RFC2822, $exp + time() ) );
 
 		return true;

--- a/resources/mediawiki/mediawiki.js
+++ b/resources/mediawiki/mediawiki.js
@@ -972,6 +972,12 @@ var mw = ( function ( $, undefined ) {
 							}
 		
 							currReqBase = $.extend( { 'version': formatVersionNumber( maxVersion ) }, reqBase );
+							// Wikia change - begin - @author: wladek
+							// PER-58: add style version
+							currReqBase.version = (window.wgStyleVersion ? window.wgStyleVersion + '-' : '')
+								+ currReqBase.version;
+							// Wikia change - end
+
 							currReqBaseLength = $.param( currReqBase ).length;
 							async = true;
 							// We may need to split up the request to honor the query string length limit,


### PR DESCRIPTION
Primary purpose of this changeset is to add CB value to all Resource Loader requests. This allows us to have consistent JS code on the edge between Assets Manager and Resource Loader. This hit us a bit during past few releases.

Second small tweak is to unify cache TTL of all assets that we serve through apaches, now Assets Manager uses Resource Loader's configuration. This means we're slightly changing caching TTLs in AM in the following way:
- AM requests coming with newer CB value than one present in the code - will be cached for 5 minutes instead of 10 minutes,
- AM requests with CB value equal or lower than one present in the code - will be cached for 1 month instead of 1 week.

This is also a preparation part for tweaking assets caching TTL. Since RL cache configuration has two separate values for client and server, this will allow us to significantly decrease caching time at client side at the application level if we decide so.

@Wyvek @macbre @owend your comments are welcome, I hope to get it reviewed and merged today so it goes out with next week's release
