### PR TITLE
Chat: Normalize joinData -> data, leavingUserName -> name, part event cleanup

### DIFF
--- a/extensions/wikia/Chat2/js/controllers/controllers.js
+++ b/extensions/wikia/Chat2/js/controllers/controllers.js
@@ -376,13 +376,13 @@ var NodeRoomController = $.createClass(Observable,{
 	},
 
 	onPart: function(message) {
-		var partedUser = new models.User();
-		partedUser.mport(message.data);
-		if(this.partTimeOuts[partedUser.get('name')]) {
+		var partEvent = new models.PartEvent();
+		partEvent.mport(message.data);
+		if(this.partTimeOuts[partEvent.get('name')]) {
 			return true;
 		}
-		this.partTimeOuts[partedUser.get('name')] = setTimeout(this.proxy(function(){
-			this.onPartBase(partedUser);
+		this.partTimeOuts[partEvent.get('name')] = setTimeout(this.proxy(function(){
+			this.onPartBase(partEvent);
 		}), 45000);
 	},
 
@@ -392,11 +392,11 @@ var NodeRoomController = $.createClass(Observable,{
 		 */
 		var logoutEvent = new models.LogoutEvent();
 		logoutEvent.mport(message.data);
-		if(this.partTimeOuts[logoutEvent.get('leavingUserName')]) {
+		if(this.partTimeOuts[logoutEvent.get('name')]) {
 			return true;
 		}
-		this.partTimeOuts[logoutEvent.get('leavingUserName')] = setTimeout(this.proxy(function(){
-			this.onPartBase(logoutEvent.get('leavingUserName'), false);
+		this.partTimeOuts[logoutEvent.get('name')] = setTimeout(this.proxy(function(){
+			this.onPartBase(logoutEvent.get('name'), false);
 		}), 10000);
 	},
 

--- a/extensions/wikia/Chat2/js/controllers/controllers.js
+++ b/extensions/wikia/Chat2/js/controllers/controllers.js
@@ -340,7 +340,7 @@ var NodeRoomController = $.createClass(Observable,{
 
 	onJoin: function(message) {
 		var joinedUser = new models.User();
-		joinedUser.mport(message.joinData);
+		joinedUser.mport(message.data);
 
 		if(joinedUser.get('name') == wgUserName) {
 			this.userMain = joinedUser;

--- a/extensions/wikia/Chat2/js/models/models.js
+++ b/extensions/wikia/Chat2/js/models/models.js
@@ -111,12 +111,20 @@ var STATUS_STATE_AWAY = 'away';
 		}
 	});
 
+	models.PartEvent = Backbone.Model.extend({
+		initialize: function(options){
+			if(!options) return;
+			this.set({
+				name: options.name
+			});
+		}
+	});
+
 	models.LogoutEvent = Backbone.Model.extend({
 		initialize: function(options){
 			if(!options) return;
 			this.set({
-				command: 'logout',
-				leavingUserName: options.leavingUserName
+				name: options.name
 			});
 		}
 	});

--- a/extensions/wikia/Chat2/js/server.js
+++ b/extensions/wikia/Chat2/js/server.js
@@ -521,7 +521,7 @@ function broadcastDisconnectionInfo(client, socket){
 
 	broadcastUserListToMediaWiki(client, true);
 
-	var PartEvent = new models.PartEvent({
+	var partEvent = new models.PartEvent({
 		name: client.myUser.get('name')
 	});
 	broadcastToRoom(client, socket, {

--- a/extensions/wikia/Chat2/js/server.js
+++ b/extensions/wikia/Chat2/js/server.js
@@ -469,7 +469,7 @@ function formallyAddClient(client, socket, connectedUser){
 			logger.debug(new Date().getTime());
 			broadcastToRoom(client, socket, {
 				event: 'join',
-				joinData: connectedUser.xport()
+				data: connectedUser.xport()
 			});
 			broadcastUserListToMediaWiki(client, false);
 			//Conenction complted

--- a/extensions/wikia/Chat2/js/server.js
+++ b/extensions/wikia/Chat2/js/server.js
@@ -521,9 +521,12 @@ function broadcastDisconnectionInfo(client, socket){
 
 	broadcastUserListToMediaWiki(client, true);
 
+	var PartEvent = new models.PartEvent({
+		name: client.myUser.get('name')
+	});
 	broadcastToRoom(client, socket, {
         	event: 'part',
-        	data: client.myUser.xport()
+        	data: partEvent.xport()
 	});
 } // end broadcastDisconnectionInfo()
 
@@ -578,7 +581,7 @@ function chatMessage(client, socket, msg){
 
 function logout(client, socket, msg) {
 	var logoutEvent = new models.LogoutEvent({
-		leavingUserName: client.myUser.get('name')
+		name: client.myUser.get('name')
 	});
 	monitoring.incrEventCounter('logouts');
 	tracker.trackEvent(client, 'logout');


### PR DESCRIPTION
This normalizes the `joinData` property in join events to `data` like in all other events, normalizes the `leavingUserName` property in logout to `name` like in part events, and simplifies part events to save bandwidth.
To elaborate on part events, currently a part is an exported user model, which contains all of the information about the user, producing output similar to `{"event":"part","data":"{\"id\":null,\"cid\":\"c123456789\",\"attrs\":{\"name\":\"Example\",\"since\":\"\",\"statusMessage\":\"\",\"statusState\":\"here\",\"isModerator\":false,\"isStaff\":false,\"isCanGiveChatMod\":false,\"avatarSrc\":\"http://images3.wikia.nocookie.net/common/avatars/thumb/e/e6/example.png/28px-example.png\",\"editCount\":\"0\",\"isPrivate\":false,\"active\":false,\"privateRoomId\":false}}"}`. Because the user is leaving the room, this information is essentially useless, and should in fact be identical to the user's currently stored model (if it isn't, a function is not sending updateUser when it should). Since the full user model isn't used by any function (or any bot to my knowledge), I simplified this by creating a `PartEvent` model containing only the name property, producing output similar to `{"event":"part","data":"{\"id\":null,\"cid\":\"c123456789\",\"attrs\":{\"name\":\"Example\"}}"}`.
