### PR TITLE
Fix for bugzid:99840 - Signup via Facebook broken

### DIFF
--- a/extensions/wikia/UserLogin/js/UserLoginFacebook.js
+++ b/extensions/wikia/UserLogin/js/UserLoginFacebook.js
@@ -115,7 +115,7 @@ var UserLoginFacebook = {
 
 		this.signupAjaxForm = new UserSignupAjaxForm(
 			this.wikiaForm,
-			['username', 'password'],
+			null,
 			this.form.el.find('input[type=submit]'));
 		this.wikiaForm.el
 			.find('input[name=username], input[name=password]')

--- a/extensions/wikia/UserLogin/js/UserSignupAjaxForm.js
+++ b/extensions/wikia/UserLogin/js/UserSignupAjaxForm.js
@@ -83,7 +83,7 @@ UserSignupAjaxForm.prototype.checkFieldsValid = function() {
 		}
 	}
 
-	if (this.checkFieldEmpty(this.wikiaForm.inputs[this.captchaField])) {
+	if (this.captchaField && this.checkFieldEmpty(this.wikiaForm.inputs[this.captchaField])) {
 		isValid = false;
 	}
 


### PR DESCRIPTION
The code was trying to validate fields that would appear only after
Facebook would invoke a callback breaking the JS; the way the validation
class is implemented doesn't seem to allow for attaching fields to
validate in a second moment (those need to be passed to the constructor)
and those fields (username
and password) are validated server-side so for the moment we're covered
despite detecting empty fields would be a better thing to do client-side
as it happens for the standard signup form.

There was also a small bug in the validator class which would still try
to verify a captcha field when none was passed to the constructor
(Facebook signup doesn't include captcha's, we trust Facebook).

@kvas-damian @sebastian-wikia : this will fix the problem for now but
I'd suggest to review the implementatio to fit in the Facebook case so
that we won't force a full roundtrip for checking empty fields.

Thanks.
