### PR TITLE
Editor wasn't loading or was loaded with bug described in FB#100020

### DIFF
--- a/extensions/wikia/RTE/ckeditor/ckeditor.wikia.pack
+++ b/extensions/wikia/RTE/ckeditor/ckeditor.wikia.pack
@@ -219,7 +219,6 @@ packages :
 					'../js/plugins/temporary-save/plugin.js',
 					'../js/plugins/toolbar/plugin.js',
 					'../js/plugins/tools/plugin.js',
-					'../js/plugins/track/plugin.js',
 
 						// Wikia skin
 					'_source/themes/wikia/theme.js',

--- a/extensions/wikia/RTE/js/plugins/media/plugin.js
+++ b/extensions/wikia/RTE/js/plugins/media/plugin.js
@@ -89,11 +89,11 @@ CKEDITOR.plugins.add('rte-media',
 				label: msgs['delete'],
 				'class': 'RTEMediaOverlayDelete',
 				callback: function(node) {
-					var type = self.getTrackingType(node);
+					var msgMediaType = self.getMediaTypeForMsg(node);
 
 					// show modal version of confirm()
-					var title = RTE.getInstance().lang[type].confirmDeleteTitle;
-					var msg = RTE.getInstance().lang[type].confirmDelete;
+					var title = RTE.getInstance().lang[msgMediaType].confirmDeleteTitle;
+					var msg = RTE.getInstance().lang[msgMediaType].confirmDelete;
 
 					RTE.tools.confirm(title, msg, function() {
 						RTE.tools.removeElement(node);
@@ -334,8 +334,8 @@ CKEDITOR.plugins.add('rte-media',
 		}
 	},
 
-	// get type name for tracking code
-	getTrackingType: function(media) {
+	// maps media type to messages' group name
+	getMediaTypeForMsg: function(media) {
 		var type;
 
 		switch($(media).attr('type')) {

--- a/extensions/wikia/RTE/js/plugins/media/plugin.js
+++ b/extensions/wikia/RTE/js/plugins/media/plugin.js
@@ -89,6 +89,7 @@ CKEDITOR.plugins.add('rte-media',
 				label: msgs['delete'],
 				'class': 'RTEMediaOverlayDelete',
 				callback: function(node) {
+					var type = self.getTrackingType(node);
 
 					// show modal version of confirm()
 					var title = RTE.getInstance().lang[type].confirmDeleteTitle;
@@ -331,6 +332,39 @@ CKEDITOR.plugins.add('rte-media',
 		if (RTE.config.disableDragDrop) {
 			RTE.tools.disableDragDrop(placeholder);
 		}
+	},
+
+	// get type name for tracking code
+	getTrackingType: function(media) {
+		var type;
+
+		switch($(media).attr('type')) {
+			case 'image':
+				type = 'image';
+				break;
+
+			case 'video':
+				type = 'video';
+				break;
+
+			case 'image-placeholder':
+				type = 'imagePlaceholder';
+				break;
+
+			case 'video-placeholder':
+				type = 'videoPlaceholder';
+				break;
+
+			case 'image-gallery':
+				type = 'photoGallery';
+				break;
+
+			case 'poll':
+				type = 'poll';
+				break;
+		}
+
+		return type;
 	}
 });
 
@@ -358,7 +392,7 @@ RTE.mediaEditor = {
 
 		this._add(wikitext, data);
 	},
-
+	
 	// add a video (wikitext will parser to HTML, params stored in metadata)
 	addVideo: function(wikitext, params) {
 		RTE.log('adding a video');


### PR DESCRIPTION
Basically, there were two issues in the editor and unfortunately both caused by tracking clean up: (https://github.com/Wikia/app/commit/7317d4760a1261422470212eaa5c322fd1de6c88).

First one was just one line which wasn't deleted after deletion of a file:
https://github.com/Wikia/app/pull/new/Wikia:release-155...p2-fix-for-editor-bugid-100020#L0L222

And the second one which is described in [FB#100020](https://wikia.fogbugz.com/default.asp?100020) was caused by strange logic -- getting messages for modal depended on tracking type.

If everything is OK with my changes, please merge it and I'll be able to resolve the ticket.
