### PR TITLE
Consumer sprint34 bugid 99775

### DIFF
--- a/extensions/wikia/CategorySelect/CategorySelect.class.php
+++ b/extensions/wikia/CategorySelect/CategorySelect.class.php
@@ -45,20 +45,19 @@ class CategorySelect {
 
 					$str = "\n[[" . $category[ 'namespace' ] . ':' . $category[ 'name' ];
 
-					if ( !empty( $category[ 'sortKey' ] ) ) {
-						$str .= '|' . $category[ 'sortKey' ];
+					if ( !empty( $category[ 'sortkey' ] ) ) {
+						$str .= '|' . $category[ 'sortkey' ];
 					}
 
 					$str .= ']]';
 
-					if ( !empty( $category[ 'outerTag' ] ) ) {
-						$str = '<' . $category[ 'outerTag' ] . '>' . $str . '</' . $category[ 'outerTag' ] . '>';
+					if ( !empty( $category[ 'outertag' ] ) ) {
+						$str = '<' . $category[ 'outertag' ] . '>' . $str . '</' . $category[ 'outertag' ] . '>';
 					}
 
 					$changed .= $str;
 				}
 			}
-
 		} else if ( $to == 'array' ) {
 			$changed = $categories;
 
@@ -67,7 +66,6 @@ class CategorySelect {
 		}
 
 		wfProfileOut( __METHOD__ );
-
 		return $changed;
 	}
 
@@ -491,8 +489,8 @@ class CategorySelect {
 							$childOut['categories'][] = array(
 								'name' => $catName,
 								'namespace' => $catNamespace,
-								'outerTag' => $outerTag,
-								'sortKey' => $sortKey,
+								'outertag' => $outerTag,
+								'sortkey' => $sortKey,
 								'type' => self::getCategoryType( $catName ),
 							);
 						}
@@ -554,8 +552,8 @@ class CategorySelect {
 		self::$categories[] = array(
 			'name' => $catName,
 			'namespace' => $match[1],
-			'outerTag' => self::$outerTag,
-			'sortKey' => $sortKey,
+			'outertag' => self::$outerTag,
+			'sortkey' => $sortKey,
 			'type' => self::getCategoryType( $catName ),
 		);
 		return '';

--- a/extensions/wikia/CategorySelect/CategorySelectController.class.php
+++ b/extensions/wikia/CategorySelect/CategorySelectController.class.php
@@ -97,9 +97,9 @@ class CategorySelectController extends WikiaController {
 		$this->response->setVal( 'link', $this->request->getVal( 'link', '' ) );
 		$this->response->setVal( 'name', $this->request->getVal( 'name', '' ) );
 		$this->response->setVal( 'namespace', $this->request->getVal( 'namespace', '' ) );
-		$this->response->setVal( 'outerTag', $this->request->getVal( 'outerTag', '' ) );
+		$this->response->setVal( 'outertag', $this->request->getVal( 'outertag', '' ) );
 		$this->response->setVal( 'remove', $this->wf->Message( 'categoryselect-category-remove' )->text() );
-		$this->response->setVal( 'sortKey', $this->request->getVal( 'sortKey', '' ) );
+		$this->response->setVal( 'sortkey', $this->request->getVal( 'sortkey', '' ) );
 		$this->response->setVal( 'type', $this->request->getVal( 'type', 'normal' ) );
 
 		$this->response->setTemplateEngine( WikiaResponse::TEMPLATE_ENGINE_MUSTACHE );

--- a/extensions/wikia/CategorySelect/templates/CategorySelectController_category.mustache
+++ b/extensions/wikia/CategorySelect/templates/CategorySelectController_category.mustache
@@ -1,4 +1,4 @@
-<li class="category {{type}}" data-name="{{name}}" data-namespace="{{namespace}}" data-outertag="{{outerTag}}" data-sortkey="{{sortKey}}" data-type="{{type}}">
+<li class="category {{type}}" data-name="{{name}}" data-namespace="{{namespace}}" data-outertag="{{outertag}}" data-sortkey="{{sortkey}}" data-type="{{type}}">
 	<span class="name">{{#link}}{{{link}}}{{/link}}{{^link}}{{name}}{{/link}}</span>
 	<ul class="toolbar">
 		<li class="tool editCategory"><img src="{{blankImageUrl}}" class="sprite-small edit" title="{{messages.edit}}"></li>

--- a/extensions/wikia/CategorySelect/tests/CategorySelectTest.php
+++ b/extensions/wikia/CategorySelect/tests/CategorySelectTest.php
@@ -1,0 +1,33 @@
+<?php
+
+class CategorySelectTest extends WikiaBaseTest {
+	/**
+	 * (non-PHPdoc)
+	 * @see WikiaBaseTest::setUp()
+	 */
+	public function setUp() {
+		$this->setupFile = dirname(__FILE__) . '/../CategorySelect.setup.php';
+		parent::setUp();
+	}
+
+	public function testChangeFormatFromArrayToWikiText() {
+		$categories = [];
+		$categories[] = [
+			'namespace' => 'Category',
+			'name' => 'test category',
+			'sortkey' => 'test sort key'
+		];
+		$categories[] = [
+			'namespace' => 'Category',
+			'name' => '2nd test category',
+			'sortkey' => '2nd test sort key'
+		];
+
+		$expectedWikiText = "[[Category:test category|test sort key]]\n[[Category:2nd test category|2nd test sort key]]";
+
+		$wikiText = CategorySelect::changeFormat($categories, 'array', 'wikitext');
+
+		$this->assertEquals($expectedWikiText, trim($wikiText));
+	}
+
+}


### PR DESCRIPTION
Case: https://wikia.fogbugz.com/default.asp?99775

Problem: Category select is not saving sortkey for categories.

In javascript we are using lowercase for category attributes. In PHP we are using lowerCamelCase for categories attributes. Now all attributes are using lowercase as in js.

@kflorence : Can you look at those changes if this is correct way to fix it and all edge cases are fixed there.
