### PR TITLE
bugId: 95249 - try to avoid using a fake "empty" title

### DIFF
--- a/extensions/wikia/Wall/WallHooksHelper.class.php
+++ b/extensions/wikia/Wall/WallHooksHelper.class.php
@@ -57,8 +57,8 @@ class WallHooksHelper {
 			}
 
 			if(empty($dbkey) || !$helper->isDbkeyFromWall($dbkey) ) {
-				// no dbkey or not from wall, redirect to wall
-				$app->wg->Out->redirect($this->getWallTitle()->getFullUrl(), 301);
+				// On Wall NS but no dbkey found or dbkey not from wall, fall back to User wall instead of "empty"
+				$app->wg->Out->redirect($this->getWallTitle(null, $app->wg->User)->getFullUrl(), 301);
 
 				wfProfileOut(__METHOD__);
 				return true;
@@ -616,8 +616,6 @@ class WallHooksHelper {
 	 */
 	protected function getWallTitle($subpage = null, $user = null) {
 		$helper = F::build('WallHelper', array());
-		$app = F::app();
-
 		return $helper->getTitle(NS_USER_WALL, $subpage, $user);
 	}
 


### PR DESCRIPTION
This will go out with the release tomorrow and I will check the MultiWikiFinder to see if the problem is still happening.  There may be other locations where the same problem happens.  I can't think of a better solution for the root problem right now.  There is no case I can think of where passing around a fake title object called "empty" is the right thing to do, but if I try anything else, it causes a fatal error.  
