### PR TITLE
PER-25: prevented msg_resource to be populated during a regular request

### DIFF
--- a/includes/OutputPage.php
+++ b/includes/OutputPage.php
@@ -2671,6 +2671,7 @@ $templates
 						$resourceLoader->makeModuleResponse( $context, $modules )
 					);
 				} else {
+					$context->setScriptsOnly(true);
 					$links .= Html::inlineScript(
 						ResourceLoader::makeLoaderConditionalScript(
 							$resourceLoader->makeModuleResponse( $context, $modules )

--- a/includes/OutputPage.php
+++ b/includes/OutputPage.php
@@ -2666,12 +2666,18 @@ $templates
 			// getHeadScripts() before the first loader call. Otherwise other modules can't
 			// properly use them as dependencies (bug 30914)
 			if ( $group === 'private' ) {
+				// Wikia change - begin - @author: wladek
+				// PER-25:Disabled processing messages in private modules.
+				// Currently private modules don't include any messages as they are more like configuration wrappers.
+				// However the underlying logic still needs to go through some checks which are likely
+				// to cause serious DB spikes when msg_resource table lacks the metadata for these modules.
+				$context->setSkipMessages(true);
+				// Wikia change - end
 				if ( $only == ResourceLoaderModule::TYPE_STYLES ) {
 					$links .= Html::inlineStyle(
 						$resourceLoader->makeModuleResponse( $context, $modules )
 					);
 				} else {
-					$context->setScriptsOnly(true);
 					$links .= Html::inlineScript(
 						ResourceLoader::makeLoaderConditionalScript(
 							$resourceLoader->makeModuleResponse( $context, $modules )

--- a/includes/resourceloader/ResourceLoaderContext.php
+++ b/includes/resourceloader/ResourceLoaderContext.php
@@ -40,9 +40,10 @@ class ResourceLoaderContext {
 	protected $version;
 	protected $hash;
 
-	/* Added by Wikia */
+	// Wikia change - begin
 	protected $sassParams;
-	protected $scriptsOnly;
+	protected $skipMessages;
+	// Wikia change - end
 
 	/* Methods */
 
@@ -222,11 +223,6 @@ class ResourceLoaderContext {
 	 * @return bool
 	 */
 	public function shouldIncludeStyles() {
-		// Wikia change - begin - @author: wladek
-		if ( !empty( $this->scriptsOnly ) ) {
-			return false;
-		}
-		// Wikia change - end
 		return is_null( $this->only ) || $this->only === 'styles';
 	}
 
@@ -235,7 +231,7 @@ class ResourceLoaderContext {
 	 */
 	public function shouldIncludeMessages() {
 		// Wikia change - begin - @author: wladek
-		if ( !empty( $this->scriptsOnly ) ) {
+		if ( !empty( $this->skipMessages ) ) {
 			return false;
 		}
 		// Wikia change - end
@@ -258,7 +254,16 @@ class ResourceLoaderContext {
 		return $this->hash;
 	}
 
-	public function setScriptsOnly( $scriptsOnly ) {
-		$this->scriptsOnly = $scriptsOnly;
+	/**
+	 * Allows to prevent including messages when generating modules response.
+	 * It's known to be costly when multiple instances are run in parallel
+	 * is some circumstances.
+	 *
+	 * @author Włądysłąw Bodzek
+	 * @see PER-25
+	 * @param $skipMessages bool If true prevents processing messages during response generation (default: false)
+	 */
+	public function setSkipMessages( $skipMessages ) {
+		$this->skipMessages = $skipMessages;
 	}
 }

--- a/includes/resourceloader/ResourceLoaderContext.php
+++ b/includes/resourceloader/ResourceLoaderContext.php
@@ -42,6 +42,7 @@ class ResourceLoaderContext {
 
 	/* Added by Wikia */
 	protected $sassParams;
+	protected $scriptsOnly;
 
 	/* Methods */
 
@@ -73,6 +74,7 @@ class ResourceLoaderContext {
 			}
 		}
 		ksort($this->sassParams);
+		$this->realOnly  = $this->only;
 		// Wikia - change end
 
 		$skinnames = Skin::getSkinNames();
@@ -221,6 +223,11 @@ class ResourceLoaderContext {
 	 * @return bool
 	 */
 	public function shouldIncludeStyles() {
+		// Wikia change - begin - @author: wladek
+		if ( !empty( $this->scriptsOnly ) ) {
+			return false;
+		}
+		// Wikia change - end
 		return is_null( $this->only ) || $this->only === 'styles';
 	}
 
@@ -228,6 +235,11 @@ class ResourceLoaderContext {
 	 * @return bool
 	 */
 	public function shouldIncludeMessages() {
+		// Wikia change - begin - @author: wladek
+		if ( !empty( $this->scriptsOnly ) ) {
+			return false;
+		}
+		// Wikia change - end
 		return is_null( $this->only ) || $this->only === 'messages';
 	}
 
@@ -245,5 +257,9 @@ class ResourceLoaderContext {
 			) );
 		}
 		return $this->hash;
+	}
+
+	public function setScriptsOnly( $scriptsOnly ) {
+		$this->scriptsOnly = $scriptsOnly;
 	}
 }

--- a/includes/resourceloader/ResourceLoaderContext.php
+++ b/includes/resourceloader/ResourceLoaderContext.php
@@ -74,7 +74,6 @@ class ResourceLoaderContext {
 			}
 		}
 		ksort($this->sassParams);
-		$this->realOnly  = $this->only;
 		// Wikia - change end
 
 		$skinnames = Skin::getSkinNames();


### PR DESCRIPTION
This is to prevent checking for messages of RL modules: user.options and user.tokens, which is completely unnecessary. Moreover it happens on every page render, which kills database when msg_resource gets truncated by any mean.

This is a little bit hacky solution, however I tried to optimize it for future core upgrades and to make them easier and more straight-forward. If you see any improvement please leave a comment.

If no objections are places here till tomorrow I'm going to merge it to release branch, push a production and test it by truncating msg_resource on production (it doesn't cause any data loss) and see how it helps in such case.

@owend @Wyvek @macbre I'd like you to take a look at this changeset.
