### PR TITLE
BAC-131: User account API - reset password recovery flag

### DIFF
--- a/extensions/wikia/WikiaApi/WikiaApiResetPasswordTime.php
+++ b/extensions/wikia/WikiaApi/WikiaApiResetPasswordTime.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * WikiaApiResetPasswordTime
+ *
+ * This API function allows to reset the time of last password recovery
+ *
+ * @author macbre
+ */
+
+class WikiaApiResetPasswordTime extends ApiBase {
+
+	public function __construct( $main, $action ) {
+		parent :: __construct( $main, $action, '' /* prefix for parameters... so controller becomes $controller */ );
+	}
+
+	/**
+	 * See functions below for expected URL params
+	 */
+	public function execute() {
+		$app = F::app();
+		wfProfileIn(__METHOD__);
+
+		// validate token
+		if ($this->getParameter('token') !== $app->wg->TheSchwartzSecretToken) {
+			$this->dieUsage( 'Incorrect token provided', 'bad_token' );
+			wfProfileOut(__METHOD__);
+			return;
+		}
+
+		// validate the user
+		$user = User::newFromName($this->getParameter('user'));
+
+		if ( empty($user) || $user->getId() === 0 ) {
+			$this->dieUsage( 'Invalid user provided', 'bad_user' );
+			wfProfileOut(__METHOD__);
+			return;
+		}
+
+		$user->mNewpassTime = null;
+		$user->saveSettings();
+
+		$this->getResult()->addValue('resetpasswordtime', 'success', true);
+
+		wfProfileOut(__METHOD__);
+	}
+
+	public function mustBePosted() {
+		return true;
+	}
+
+	public function getAllowedParams() {
+		return array (
+			'user' => array(
+				ApiBase :: PARAM_TYPE => "string"
+			),
+			'token' => array(
+				ApiBase :: PARAM_TYPE => "string"
+			),
+		);
+	}
+
+	public function getVersion() {
+		return __CLASS__ . ': $Id: WikiaApiResetPasswordTime.php macbre';
+	}
+
+	public function getParamDescription() {
+		return array(
+			'user' => 'name of the user to reset the password time for',
+			'token' => 'token to validate the request',
+		);
+	}
+
+	public function getExamples() {
+		return array (
+			'api.php?action=resetpasswordtime&user=WikiaFooUser&token=xxx'
+		);
+	}
+
+	public function getDescription() {
+		return array(
+			'This module is used to reset the time when password recovery email was sent'
+		);
+	}
+}

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -380,6 +380,7 @@ $wgAutoloadClasses[ "WikiFactoryTags"               ] = "$IP/extensions/wikia/Wi
 $wgAutoloadClasses[ "WikiaApiQueryEventsData"       ] = "$IP/extensions/wikia/WikiaApi/WikiaApiQueryEventsData.php";
 $wgAutoloadClasses[ "WikiaApiQueryAllUsers"         ] = "$IP/extensions/wikia/WikiaApi/WikiaApiQueryAllUsers.php";
 $wgAutoloadClasses[ "WikiaApiQueryLastEditors"      ] = "$IP/extensions/wikia/WikiaApi/WikiaApiQueryLastEditors.php";
+$wgAutoloadClasses[ "WikiaApiResetPasswordTime"     ] = "$IP/extensions/wikia/WikiaApi/WikiaApiResetPasswordTime.php";
 $wgAutoloadClasses[ "ApiRunJob"                     ] = "$IP/extensions/wikia/WikiaApi/ApiRunJob.php";
 $wgAutoloadClasses[ "ApiFetchBlob"                  ] = "$IP/includes/api/wikia/ApiFetchBlob.php";
 
@@ -453,6 +454,7 @@ $wgAPIModules[ "ajaxlogin"         ] = "WikiaApiAjaxLogin";
 $wgAPIModules[ "awcreminder"       ] = "WikiaApiCreatorReminderEmail";
 $wgAPIModules[ "runjob"            ] = "ApiRunJob";
 $wgAPIModules[ "fetchblob"         ] = "ApiFetchBlob";
+$wgAPIModules[ "resetpasswordtime" ] = 'WikiaApiResetPasswordTime';
 
 $wgUseAjax                = true;
 $wgValidateUserName       = true;


### PR DESCRIPTION
This API method will be used by QA team in automated tests to reset the time when password recovery email was sent (currently it has a limit of one email in 24 hours).

Please **don't merge it** yet, waiting for QA...

@kkarolk 
