### PR TITLE
VID-142 Make sure admins can remove videos from the Videos right rail.

### DIFF
--- a/extensions/wikia/RelatedVideos/RelatedVideosController.class.php
+++ b/extensions/wikia/RelatedVideos/RelatedVideosController.class.php
@@ -184,7 +184,7 @@ class RelatedVideosController extends WikiaController {
 			$video['viewsMsg'] = wfMsg('related-videos-video-views', $this->wg->ContLang->formatNum($video['views']));
 
 			$userGroups = $this->wg->User->getEffectiveGroups();
-			$isAdmin = in_array('admin', $userGroups) || in_array('staff', $userGroups);
+			$isAdmin = in_array('sysop', $userGroups) || in_array('staff', $userGroups);
 
 			$this->removeTooltip = $this->wf->Message( 'related-videos-tooltip-remove' );
 			$this->videoThumb = $videoThumb;


### PR DESCRIPTION
Fixed userGroup.  Wiki administrator rights group is 'sysop' not 'admin'
