### PR TITLE
bugid-100111 | WikiaPhotoGallery - fixed lazy loading on preview

### DIFF
--- a/extensions/wikia/WikiaPhotoGallery/js/WikiaPhotoGallery.view.js
+++ b/extensions/wikia/WikiaPhotoGallery/js/WikiaPhotoGallery.view.js
@@ -230,7 +230,13 @@ var WikiaPhotoGalleryView = {
 		var self = this;
 
 		this.log('lazy loading images...');
-		$('.gallery-image-wrapper').find('img[data-src]:not(.lzyPlcHld)').each(
+		$('.gallery-image-wrapper').find('img[data-src]:not(.lzyPlcHld)')
+			.filter(function() {
+				var elem = $(this);
+				// make sure that those images weren't loaded already by ImgLzy
+				return elem.attr('src') != elem.attr('data-src');
+			})
+			.each(
 			function() {
 				var image = $(this);
 


### PR DESCRIPTION
Ticket
https://wikia.fogbugz.com/default.asp?100111

Tech info - we have two types of lazy loading in WikiaPhotoGalleryView and ImgLzy

On preview for photoGallery we need to make that we don't fire ImgLzy before gallery lazy loading. We cannot rely on filtering by className because ImgLzy removes class after image is loaded, thats why I added filter by src.

We cannot remove this code because there is a way to render gallery from RSS and there is no ImgLzy implemented. For example:

```
<gallery rssfeed="http://api.flickr.com/services/feeds/photos_public.gne?id=34001936@N05&lang=en-us&format=rss_200" captionalign="center" widths="95" orientation="landscape">
</gallery>
```

@macbre @Wyvek
