### PR TITLE
Front-end part of JS error logging.

### DIFF
--- a/extensions/wikia/AdEngine/liftium/Liftium.js
+++ b/extensions/wikia/AdEngine/liftium/Liftium.js
@@ -2757,7 +2757,13 @@ Liftium.maxHopTime = Liftium.getRequestVal('liftium_timeout', 0) || Liftium.cook
 
 LiftiumOptions.error_beacon = !Liftium.debugLevel && !Liftium.getRequestVal('liftium_onerror', 0) && !Liftium.cookie("liftium_onerror");
 if (LiftiumOptions.error_beacon !== false ){
-	window.onerror = Liftium.catchError;
+	(function () {
+		var originalOnError = window.onerror;
+		window.onerror = function(m, l, e) {
+			originalOnError && originalOnError(m, l, e);
+			Liftium.catchError(m, l, e);
+		}
+	}());
 }
 
 } // \if (typeof Liftium == "undefined" )

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1099,6 +1099,12 @@ $wgWikiaHubsFileRepoDirectory = '/images/c/central/';
 $wgEnableAmazonDirectTargetedBuy = true;
 
 /**
+ * @name $wgEnableJavaScriptErrorLogging
+ * Enables JavaScript error logging mechanism
+ */
+$wgEnableJavaScriptErrorLogging = false;
+
+/**
  * trusted proxy service registry
  */
 $app->registerClass( 'TrustedProxyService', "$IP/includes/wikia/services/TrustedProxyService.class.php" );

--- a/skins/oasis/modules/templates/Oasis_Index.php
+++ b/skins/oasis/modules/templates/Oasis_Index.php
@@ -32,6 +32,20 @@
 	<style type="text/css"><?= $pageCss ?></style>
 <? endif ?>
 
+<? // 1% of JavaScript errors are logged for $wgEnableJSerrorLogging=true non-devbox wikis ?>
+<? if ( $wg->EnableJavaScriptErrorLogging && !$wg->DevelEnvironment ): ?>
+<script>
+window.onerror=function(m,u,l){
+var q='//jserrorslog.wikia.com/',i=new Image();
+if(Math.random()<0.01){
+	try{var d=[m,u,l];
+		try{d.push(document.cookie.match(/server.([A-Z]*).cache/)[1])}catch(e){}
+		i.src=q+'l?'+JSON.stringify(d)
+	}catch(e){i.src=q+'e?'+e}
+}return!1}
+</script>
+<? endif ?>
+
 <?= $topScripts ?>
 <?= $wikiaScriptLoader; /*needed for jsLoader and for the async loading of CSS files.*/ ?>
 


### PR DESCRIPTION
~200 bytes are added to gzipped HTML response if the error collecting is enabled  via wg varliable. It binds to onerror event and sends 1% of errors encoded as JSON to the URL configured: http://jserrorslog.wikia.com/l?[errorMsg, fileUrl, lineNumber, varnishServer].

The change is experimental and will only be present on Oasis (we should extend to other skins later).
