### PR TITLE
NewRelic + WikiaSearch reindexing

### DIFF
--- a/extensions/wikia/Search/WikiaSearchIndexerController.class.php
+++ b/extensions/wikia/Search/WikiaSearchIndexerController.class.php
@@ -27,6 +27,14 @@ class WikiaSearchIndexerController extends WikiaController
 		$this->service = new MediaWikiService;
 		$this->service->setGlobal( 'AllowMemcacheWrites', false )
 		                ->setGlobal( 'AppStripsHtml', true );
+
+		if ( function_exists( 'newrelic_disable_autorum') ) {
+			newrelic_disable_autorum();
+		}
+		if( function_exists( 'newrelic_background_job' ) ) {
+			newrelic_background_job(true);
+		}
+
 	}
 	
 	/**


### PR DESCRIPTION
Mark transactions as background jobs when executed on host which reports to newrelic.
Those calls are always executed "offline" (not from application layer) so they should be represented as such in NewRelic.
