### PR TITLE
Bugid 100565 -- Introduce new user-elicited query abstraction layer to Search

### DIFF
--- a/extensions/wikia/Search/SearchApiController.class.php
+++ b/extensions/wikia/Search/SearchApiController.class.php
@@ -77,7 +77,7 @@ class SearchApiController extends WikiaApiController {
 			$searchConfig->setNamespaces( $namespaces );
 		}
 
-		if ( $searchConfig->getQueryNoQuotes( true ) ) {
+		if ( $searchConfig->getQuery()->hasTerms() ) {
 			$container = new DependencyContainer( array( 'config' => $searchConfig ) );
 			$wikiaSearch = (new Factory)->get( $container );
 

--- a/extensions/wikia/Search/classes/Config.php
+++ b/extensions/wikia/Search/classes/Config.php
@@ -3,7 +3,9 @@
  * Class definition for Wikia\Search\Config
  */
 namespace Wikia\Search;
-use Wikia\Search\MediaWikiService, \Sanitizer, \Solarium_Query_Select, \Wikia\Search\Match, \ArrayAccess;
+use Wikia\Search\MediaWikiService, Wikia\Search\Match;
+use Wikia\Search\Query\Select as Query;
+use ArrayAccess, Solarium_Query_Select;
 /**
  * A config class intended to handle variable flags for search
  * Intended to be a dependency-injected receptacle for different search requirements
@@ -253,61 +255,37 @@ class Config implements ArrayAccess
 	}
 	
 	/**
-	 * Used to store the query from the request as passed by the controller.
-	 * We remove any namespaces prefixes, but store the original query under the originalQuery param.
+	 * Receives a possibly dirty user input string and stores it in an
+	 * instance of Wikia\Search\Query\Select.
+	 * Uses the methods within that class to determine if we need to 
+	 * record a specific namespace associated with that query.
+	 * 
 	 * @param  string $query
 	 * @return Wikia\Search\Config provides fluent interface
 	 */
 	public function setQuery( $query ) {
 		
-		$query = html_entity_decode( Sanitizer::StripAllTags ( $query ), ENT_COMPAT, 'UTF-8');
+		$this->params['query'] = new Query( $query );
 		
-		$this->params['originalQuery'] = $query;
-		
-		if ( strpos( $query, ':' ) !== false ) {
-			$queryNsExploded = explode( ':', $query );
-			$queryNamespaceStr = array_shift( $queryNsExploded );
-			$queryNamespace	= $this->service->getNamespaceIdForString( $queryNamespaceStr );
-			if ( $queryNamespace ) {
-				$namespaces = $this->getNamespaces();
-			    if ( empty( $namespaces ) || (! in_array( $queryNamespace, $namespaces ) ) ) {
-			        $this->params['queryNamespace'] = $queryNamespace;
-			    } 
-			    $query = implode( ':', $queryNsExploded );
+		$namespace = $this->params['query']->getNamespaceId();
+		if ( $namespace !== null ) {
+			$namespaces = $this->getNamespaces();
+			if ( empty( $namespaces ) || (! in_array( $namespace, $namespaces ) ) ) {
+				$this->params['queryNamespace'] = $namespace;
 			}
 		}
-		
-		$this->params['query'] = $query;
-		
 		return $this;
 	}
 	
 	/**
-	 * Most of the time, we want the query escaped for XSS and Lucene syntax well-formedness
-	 * @param  int $strategy one of the self::QUERY_ constants
-	 * @return string
+	 * Returns the query we've stored.
+	 * @return Wikia\Search\Query\Select
 	 */
-	public function getQuery( $strategy = self::QUERY_DEFAULT ) {
+	public function getQuery() {
 		if (! isset( $this->params['query'] ) ) {
 			return false;
 		}
-		$query = $strategy !== self::QUERY_DEFAULT ? $this->params['query'] : Utilities::sanitizeQuery( $this->params['query'] );
-		$query = $strategy === self::QUERY_ENCODED ? htmlentities( $query, ENT_COMPAT, 'UTF-8' ) : $query;
-		
-		if ( $this->isInterWiki() ) {
-			$query = preg_replace( '/ wiki\b/i', '', $query);
-		}
-		return $query;
-	}
-	
-	/**
-	 * Strips out quotes, and sanitizes the query for Lucene query syntax (can be deactivated by passing true)
-	 * @param  boolean $raw
-	 * @return string
-	 */
-	public function getQueryNoQuotes( $raw = false ) {
-		$query = preg_replace( "/['\"]/", '', preg_replace( "/(\\w)['\"](\\w)/", '$1 $2',  $this->getQuery( self::QUERY_RAW ) ) );
-		return $raw ? $query : Utilities::sanitizeQuery( $query );
+		return $this->params['query'];
 	}
 	
 	/**

--- a/extensions/wikia/Search/classes/Query/Select.php
+++ b/extensions/wikia/Search/classes/Query/Select.php
@@ -124,14 +124,22 @@ class Select
 	}
 	
 	/**
+	 * Says whether we have an actionable value for searching
+	 * @return boolean
+	 */
+	public function hasTerms() {
+		return strlen( preg_replace( '[^a-zA-Z0-9]', '', $this->getSanitizedQuery() ) ) > 0;
+	} 
+	
+	/**
 	 * This is factored out of getNamespaceId and getNamespacePrefix so we can just lazy load them for either.
 	 * @return bool
 	 */
 	protected function initializeNamespaceData() {
-		$query = $this->getSanitizedQueryString();
+		$query = $this->getSanitizedQuery();
 		if ( (! $this->namespaceChecked ) && ( $this->namespacePrefix === null ) && strpos( $query, ':' ) !== false ) {
 			$colonSploded = explode( ':', $query );
-			$queryNamespace = $this->service->getNamespaceIdForString( $colonSploded[0] );
+			$queryNamespace = $this->getService()->getNamespaceIdForString( $colonSploded[0] );
 			if ( is_int( $queryNamespace ) && $queryNamespace > 0 ) {
 				$this->namespaceId = $queryNamespace;
 				$this->namespacePrefix = $colonSploded[0];

--- a/extensions/wikia/Search/classes/Query/Select.php
+++ b/extensions/wikia/Search/classes/Query/Select.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Class definition for Wikia\Search\Query\Select
+ */
+namespace Wikia\Search\Query;
+use Wikia\Search\MediaWikiService, Wikia\Search\Utilities, Sanitizer, Solarium_Query_Helper;
+/**
+ * This class is responsible for abstracting the different ways we express queries.
+ * @author relwell
+ */
+class Select
+{
+	/**
+	 * The pristine value passed during construct with no alterations
+	 * @var string
+	 */
+	protected $rawQuery;
+	
+	/**
+	 * Any possible namespace prefix -- has to be an actual prefix, though.
+	 * @var string
+	 */
+	protected $namespacePrefix;
+	
+	/**
+	 * Keeps us from checking for namespace more than once.
+	 * @var boolean
+	 */
+	protected $namespaceChecked = false;
+	
+	/**
+	 * If we have a namespace query, then an int. Otherwise null.
+	 * @var int
+	 */
+	protected $namespaceId;
+	
+	/**
+	 * This is the query string *without* any namespace prefix.
+	 * We use this for passing to Solr queries.
+	 * @var string
+	 */
+	protected $strippedQuery;
+	
+	/**
+	 * This is our original query with any XSS vulns and tags removed.
+	 * @var unknown_type
+	 */
+	protected $sanitizedQuery;
+	
+	/**
+	 * MediaWikiService, encapsulates MediaWiki logic
+	 * @var Wikia\Search\MediaWikiService
+	 */
+	protected $service;
+	
+	/**
+	 * Constructor method. Requires the original query string.
+	 * Sets this value as protected attribute rawQuery.
+	 * This is raw user input, so you should use a public accessor to get the right kind of query.
+	 * @param string $queryString
+	 */
+	public function __construct( $queryString )
+	{
+		$this->rawQuery = $queryString;
+	}
+	
+	/**
+	 * Lazy-loads a sanitized version of the user input.
+	 * @return string
+	 */
+	public function getSanitizedQuery() {
+		if ( $this->sanitizedQuery == null ) {
+			$this->sanitizedQuery = html_entity_decode( (new Sanitizer)->StripAllTags( $this->rawQuery ), \ENT_COMPAT, 'UTF-8');
+		}
+		return $this->sanitizedQuery;
+	}
+	
+	/**
+	 * Returns the value we use when querying Solr, with the appropriate special characters escaped.
+	 * @return string
+	 */
+	public function getSolrQuery() {
+		$query = $this->getSanitizedQuery();
+		// we don't want the namespace prefix
+		if ( $this->namespacePrefix !== null ) {
+			$query = substr( $query, strlen( $this->namespacePrefix ) + 1 ); // prefix plus colon
+		}
+		
+		// non-indexed number-string phrases issue workaround (RT #24790)
+		$query = preg_replace( '/(\d+)([a-zA-Z]+)/i', '$1 $2', $query );
+	
+		// escape all lucene special characters: + - && || ! ( ) { } [ ] ^ " ~ * ? : \ (RT #25482)
+		return (new Solarium_Query_Helper)->escapeTerm( $query,  ENT_COMPAT, 'UTF-8' );
+	}
+	
+	/**
+	 * Returns the query prepped to be shown in HTML
+	 * @return string
+	 */
+	public function getQueryForHtml() {
+		return htmlentities( $this->getSanitizedQuery(), ENT_COMPAT, 'UTF-8' );
+	}
+	
+	/**
+	 * Returns the namespace prefix string, if a legit prefix string.
+	 * @return string
+	 */
+	public function getNamespacePrefix() {
+		if (! $this->namespaceChecked ) {
+			$this->initializeNamespaceData();
+		}
+		return $this->namespacePrefix;
+	}
+	
+	/**
+	 * Returns the integer value of a namespace constant correlating to the prefix string of a search query.
+	 * @return int
+	 */
+	public function getNamespaceId() {
+		if (! $this->namespaceChecked ) {
+			$this->initializeNamespaceData();
+		}
+		return $this->namespaceId;
+	}
+	
+	/**
+	 * This is factored out of getNamespaceId and getNamespacePrefix so we can just lazy load them for either.
+	 * @return bool
+	 */
+	protected function initializeNamespaceData() {
+		$query = $this->getSanitizedQueryString();
+		if ( (! $this->namespaceChecked ) && ( $this->namespacePrefix === null ) && strpos( $query, ':' ) !== false ) {
+			$colonSploded = explode( ':', $query );
+			$queryNamespace = $this->service->getNamespaceIdForString( $colonSploded[0] );
+			if ( is_int( $queryNamespace ) && $queryNamespace > 0 ) {
+				$this->namespaceId = $queryNamespace;
+				$this->namespacePrefix = $colonSploded[0];
+			}
+		}
+		$this->namespaceChecked = true;
+		return true;
+	}
+	
+	/**
+	 * Accessor method, handles lazy-loaded DI
+	 * @return MediaWikiService
+	 */
+	protected function getService() {
+		if ( $this->service === null ) {
+			$this->service = new MediaWikiService;
+		}
+	}
+	
+}

--- a/extensions/wikia/Search/classes/Query/Select.php
+++ b/extensions/wikia/Search/classes/Query/Select.php
@@ -81,6 +81,9 @@ class Select
 	 */
 	public function getSolrQuery() {
 		$query = $this->getSanitizedQuery();
+		if (! $this->namespaceChecked ) {
+			$this->initializeNamespaceData();
+		}
 		// we don't want the namespace prefix
 		if ( $this->namespacePrefix !== null ) {
 			$query = substr( $query, strlen( $this->namespacePrefix ) + 1 ); // prefix plus colon
@@ -128,7 +131,7 @@ class Select
 	 * @return boolean
 	 */
 	public function hasTerms() {
-		return strlen( preg_replace( '[^a-zA-Z0-9]', '', $this->getSanitizedQuery() ) ) > 0;
+		return strlen( preg_replace( '/[^a-zA-Z0-9]/', '', $this->getSanitizedQuery() ) ) > 0;
 	} 
 	
 	/**

--- a/extensions/wikia/Search/classes/Query/Select.php
+++ b/extensions/wikia/Search/classes/Query/Select.php
@@ -157,6 +157,7 @@ class Select
 		if ( $this->service === null ) {
 			$this->service = new MediaWikiService;
 		}
+		return $this->service;
 	}
 	
 }

--- a/extensions/wikia/Search/classes/QueryService/Factory.php
+++ b/extensions/wikia/Search/classes/QueryService/Factory.php
@@ -23,7 +23,6 @@ class Factory
 		$config = $container->getConfig();
 		$this->validateClient( $container );
 		
-		$terminal = 'OnWiki';
 		if ( $config->isInterWiki() ) {
 			return new Select\InterWiki( $container );
 		}

--- a/extensions/wikia/Search/classes/QueryService/Select/AbstractSelect.php
+++ b/extensions/wikia/Search/classes/QueryService/Select/AbstractSelect.php
@@ -299,7 +299,7 @@ abstract class AbstractSelect
 			\Track::event(
 					( !empty( $resultCount ) ? 'search_start' : 'search_start_nomatch' ),
 					array(
-							'sterm'	=> $this->config->getQuery(), 
+							'sterm'	=> $this->config->getQuery()->getSanitizedQuery(), 
 							'stype'	=> $this->searchType 
 							)
 					);
@@ -318,7 +318,7 @@ abstract class AbstractSelect
 	 */
 	protected function getNestedQuery() {
 		$nestedQuery = $this->client->createSelect();
-		$nestedQuery->setQuery( $this->config->getQuery() );
+		$nestedQuery->setQuery( $this->config->getQuery()->getSolrQuery() );
 		
 		$queryFieldsString = $this->getQueryFieldsString();
 		$dismax = $nestedQuery->getDismax()

--- a/extensions/wikia/Search/classes/QueryService/Select/InterWiki.php
+++ b/extensions/wikia/Search/classes/QueryService/Select/InterWiki.php
@@ -71,7 +71,7 @@ class InterWiki extends AbstractSelect
 		$domain = preg_replace(
 				'/[^a-zA-Z]/',
 				'',
-				strtolower( $this->config->getQuery( \Wikia\Search\Config::QUERY_RAW ) ) 
+				strtolower( $this->config->getQuery()->getSanitizedQuery() ) 
 				);
 		$match =  $this->service->getWikiMatchByHost( $domain );
 		if (! empty( $match ) ) {

--- a/extensions/wikia/Search/classes/QueryService/Select/Lucene.php
+++ b/extensions/wikia/Search/classes/QueryService/Select/Lucene.php
@@ -17,7 +17,7 @@ class Lucene extends AbstractSelect
 	 * @see \Wikia\Search\QueryService\Select\AbstractSelect::getQueryClausesString()
 	 */
 	protected function getFormulatedQuery() {
-		return $this->config->getQuery( \Wikia\Search\Config::QUERY_RAW );
+		return $this->config->getQuery()->getSanitizedQuery();
 	}
 	
 	/**

--- a/extensions/wikia/Search/classes/QueryService/Select/OnWiki.php
+++ b/extensions/wikia/Search/classes/QueryService/Select/OnWiki.php
@@ -33,7 +33,7 @@ class OnWiki extends AbstractSelect
 	 * @return Wikia\Search\Match\Article|null
 	 */
 	public function extractMatch() {
-		$match = $this->service->getArticleMatchForTermAndNamespaces( $this->config->getOriginalQuery(), $this->config->getNamespaces() );
+		$match = $this->service->getArticleMatchForTermAndNamespaces( $this->config->getQuery()->getSanitizedQuery(), $this->config->getNamespaces() );
 		if (! empty( $match ) ) {
 			$this->config->setArticleMatch( $match );
 		}

--- a/extensions/wikia/Search/classes/QueryService/Select/OnWiki.php
+++ b/extensions/wikia/Search/classes/QueryService/Select/OnWiki.php
@@ -75,7 +75,7 @@ class OnWiki extends AbstractSelect
 	protected function registerSpellcheck( Select $query ) {
 		if ( $this->service->getGlobal( 'WikiaSearchSpellcheckActivated' ) ) {
 			$query->getSpellcheck()
-			      ->setQuery( $this->config->getQueryNoQuotes( true ) )
+			      ->setQuery( $this->config->getQuery()->getSanitizedQuery() )
 			      ->setCollate( true )
 			      ->setCount( self::SPELLING_RESULT_COUNT )
 			      ->setMaxCollationTries( self::SPELLING_MAX_COLLATION_TRIES )
@@ -138,7 +138,7 @@ class OnWiki extends AbstractSelect
 	 */
 	protected function getBoostQueryString()
 	{
-		$queryNoQuotes = $this->config->getQueryNoQuotes( true );
+		$queryNoQuotes = str_replace( '\"', '', $this->config->getQuery()->getSolrQuery() );
 		$boostQueries = array(
 				Utilities::valueForField( 'html', $queryNoQuotes, array( 'boost'=>5, 'valueQuote'=>'\"' ) ),
 		        Utilities::valueForField( 'title', $queryNoQuotes, array( 'boost'=>10, 'valueQuote'=>'\"' ) ),

--- a/extensions/wikia/Search/classes/ResultSet/AbstractResultSet.php
+++ b/extensions/wikia/Search/classes/ResultSet/AbstractResultSet.php
@@ -149,7 +149,7 @@ abstract class AbstractResultSet implements Iterator, ArrayAccess
 	 * @return string
 	 */
 	public function getQuery() {
-		return $this->searchConfig->getQuery( Config::QUERY_ENCODED );
+		return $this->searchConfig->getQuery()->getQueryForHtml();
 	}
 	
 	/**

--- a/extensions/wikia/Search/classes/Test/ConfigTest.php
+++ b/extensions/wikia/Search/classes/Test/ConfigTest.php
@@ -187,197 +187,8 @@ class ConfigTest extends BaseTest {
 				'Setting a limit should set the same key used by size and length methods.'
 		);
 	}
-
-	/**
-	 * @covers \Wikia\Search\Config::setQuery
-	 * @covers \Wikia\Search\Config::getQuery
-	 * @covers \Wikia\Search\Config::getNamespaces
-	 * @covers \Wikia\Search\Config::getQueryNoQuotes
-	 * @todo
-	public function testQueryAndNamespaceMethods() {
-
-		$config = new \Wikia\Search\Config();
-		$noNsQuery = 'foo';
-		$nsQuery = 'File:foo';
-		$phantomNsQuery = 'file';
-
-		$searchEngineMock	= $this->getMock( 'SearchEngine', array( 'DefaultNamespaces' ), array() );
-
-		$expectedDefaultNamespaces = array( NS_MAIN );
-
-		$searchEngineMock
-			->staticExpects	( $this->at( 0 ) )
-			->method		( 'DefaultNamespaces' )
-			->will			( $this->returnValue( null ) )
-		;
-		$searchEngineMock
-			->staticExpects	( $this->at( 1 ) )
-			->method		( 'DefaultNamespaces' )
-			->will			( $this->returnValue( $expectedDefaultNamespaces ) )
-		;
-
-		$this->mockClass( 'SearchEngine',	$searchEngineMock );
-		$this->mockApp();
-		F::setInstance( 'SearchEngine', $searchEngineMock );
-
-		$emptyNamespaces = $config->getNamespaces();
-
-		$this->assertEmpty( $emptyNamespaces );
-
-		$originalNamespaces = $config->getNamespaces();
-		$this->assertEquals(
-				$expectedDefaultNamespaces,
-				$originalNamespaces,
-				'\Wikia\Search\Config::getNamespaces should return SearchEngine::DefaultNamespaces if namespaces are not initialized.'
-		);
-		$this->assertFalse( $config->getQuery(), '\Wikia\Search\Config::getQuery should return false if the query has not been set.');
-		$this->assertEquals(
-				$config,
-				$config->setQuery( $noNsQuery ),
-				'\Wikia\Search\Config::setQuery should provide a fluent interface'
-		);
-		$this->assertEquals(
-				$noNsQuery,
-				$config->getQuery(),
-				'Calling setQuery for a basic query should store the query value, accessible using getQuery.'
-		);
-		$this->assertEquals(
-				$config->getQuery(),
-				$config->getOriginalQuery(),
-				'The original query and the actual query should match for non-namespaced queries.'
-		);
-		$this->assertEquals(
-				$originalNamespaces,
-				$config->getNamespaces(),
-				'A query without a valid namespace prefix should not mutate the namespaces stored in the search config.'
-		);
-		$this->assertEquals(
-				$config,
-				$config->setQuery( $nsQuery ),
-				'\Wikia\Search\Config::setQuery should provide a fluent interface'
-		);
-		$this->assertEquals(
-		        $nsQuery,
-		        $config->getOriginalQuery(),
-		        'The original query should be stored under the "originalQuery" key regardless of prefix.'
-		);
-		$this->assertEquals(
-				$noNsQuery,
-				$config->getQuery(),
-				'The namespace prefix for a query should be stripped from the main query value.'
-		);
-		$this->assertNotEquals(
-		        $config->getQuery(),
-		        $config->getOriginalQuery(),
-		        'The actual query and the original query should not be equivalent when passed a valid namespace prefix query.'
-		);
-		$this->assertEquals(
-		        array_merge( $originalNamespaces, array( NS_FILE ) ),
-		        $config->getNamespaces(),
-		        'Setting a namespace-prefixed query should result in the appropriate namespace being appended.'
-		);
-		$tildeQuery = 'foo~';
-		$this->assertEquals(
-				'foo\~',
-				$config->setQuery( $tildeQuery )->getQuery(),
-				'A query with a tilde should be escaped in getQuery.'
-		);
-		$quoteQuery = '"foo bar"';
-		$this->assertEquals(
-				'\"foo bar\"',
-				$config->setQuery( $quoteQuery )->getQuery(),
-				'A query with quotes should have the quotes escaped by default in getQuery.'
-		);
-		$this->assertEquals(
-		        '"foo bar"',
-		        $config->setQuery( $quoteQuery )->getQuery( true ),
-		        'A query with quotes should have its quotes left alone if the first parameter of getQuery is passed as true.'
-		);
-		$this->assertEquals(
-				'foo bar',
-				$config->setQuery( $quoteQuery )->getQueryNoQuotes(),
-				'A query with double quotes should have its quotes stripped in the default versoin of getQueryNoQuotes.'
-		);
-		$this->assertEquals(
-		        'foo bar\~',
-		        $config->setQuery( $quoteQuery.'~' )->getQueryNoQuotes(),
-		        'Tildes should be escaped in the default versoin of getQueryNoQuotes.'
-		);
-		$this->assertEquals(
-		        'foo bar~',
-		        $config->setQuery( $quoteQuery.'~' )->getQueryNoQuotes( true ),
-		        'Tildes should not be escaped in the raw versoin of getQueryNoQuotes.'
-		);
-
-		$xssQuery = "foo'<script type='javascript'>alert('xss');</script>";
-		$this->assertEquals(
-				"foo'alert\\('xss'\\);",
-				$config->setQuery( $xssQuery )->getQuery(),
-				'Setting a query should result in the sanitization and html entity decoding of that query.'
-		);
-		$this->assertEquals(
-				"foo alert\\(xss\\);",
-				$config->getQueryNoQuotes(),
-				"Queries with quotes or apostrophes between two letters should be replaced with spaces with getQueryNoQuotes."
-		);
-
-		$htmlEntityQuery = "'foo & bar &amp; baz' &quot;";
-		$this->assertEquals(
-				"'foo & bar & baz' \\\"",
-				$config->setQuery( $htmlEntityQuery )->getQuery(),
-				"HTML entities in queries should be decoded when being set."
-		);
-		$this->assertEquals(
-		        $config->setQuery( $htmlEntityQuery )->getQuery( \Wikia\Search\Config::QUERY_DEFAULT ),
-		        $config->setQuery( $htmlEntityQuery )->getQuery(),
-		        "The default behavior of the getQuery method should be identical to passing the Wikia\\Search\\Config::QUERY_DEFAULT constant."
-		);
-
-		$this->assertEquals(
-		        "'foo & bar & baz' \"",
-		        $config->setQuery( $htmlEntityQuery )->getQuery( \Wikia\Search\Config::QUERY_RAW ),
-		        "HTML entities in queries should be decoded when being set. Raw-strategy queries shouldn't escape anything."
-		);
-		$this->assertEquals(
-		        "'foo &amp; bar &amp; baz' &quot;",
-		        $config->setQuery( $htmlEntityQuery )->getQuery( \Wikia\Search\Config::QUERY_ENCODED ),
-		        "HTML entities in queries should be decoded when being set. HTML-decoded queries should properly HTML-encode all entities on access if using encoded strategy."
-		);
-
-		$utf8Query = '"аВатаР"';
-		$this->assertEquals(
-				'\"аВатаР\"',
-				$config->setQuery( $utf8Query )->getQuery( \Wikia\Search\Config::QUERY_DEFAULT ),
-				'\Wikia\Search\Config::setQuery should not unnecessarily mutate UTF-8 characters. Retrieving them should return those characters, properly encoded.'
-		);
-		$this->assertEquals(
-				'"аВатаР"',
-				$config->setQuery( $utf8Query )->getQuery( \Wikia\Search\Config::QUERY_RAW ),
-				'\Wikia\Search\Config::getQuery() should not unnecessarily mutate UTF-8 characters, and should not escape quotes when asking for raw query.'
-		);
-		$this->assertEquals(
-		        htmlentities( '"аВатаР"', ENT_COMPAT, 'UTF-8' ),
-		        $config->setQuery( $utf8Query )->getQuery( \Wikia\Search\Config::QUERY_ENCODED ),
-		        '\Wikia\Search\Config::getQuery() should properly HTML-encode UTF-8 characters when using the encoded query strategy.'
-		);
-
-		$config->setQuery( 'foo bar wiki' );
-		$config->setIsInterWiki( true );
-
-		$this->assertEquals(
-				'foo bar',
-				$config->getQuery(),
-				'\Wikia\Search\Config::getQuery() should strip the term "wiki" from the set query if the search is interwiki'
-		);
-
-		$config->setQuery( $phantomNsQuery );
-		$this->assertEquals(
-				$phantomNsQuery,
-				$config->getQuery(),
-				'A query that initially matches a namespaces but does not end with a colon should not strip namespaces'
-		);
-
-	}*/
+	
+	
 
 	/**
 	 * @covers \Wikia\Search\Config::getSort
@@ -1084,40 +895,50 @@ class ConfigTest extends BaseTest {
 	
 	/**
 	 * @covers \Wikia\Search\Config::setQuery
+	 * @covers \Wikia\Search\Config::getQuery
 	 */
-	public function testSetQuery() {
-		$service = $this->service->setMethods( array( 'getNamespaceIdForString' ) )->getMock();
-		$config = $this->config->setMethods( array( 'getNamespaces' ) )->getMock();
-		$this->setService( $config, $service );
+	public function testQueryMethods() {
+		$mockQuery = $this->getMock( 'Wikia\Search\Query\Select', [ 'getNamespaceId' ], [ 'foo' ] );
+		$mockConfig = $this->getMock( 'Wikia\Search\Config', [ 'getNamespaces' ] );
 		
-		$query = 'Category:Foo';
+		$this->proxyClass( 'Wikia\Search\Query\Select', $mockQuery );
+		$this->mockApp();
 		
-		$service
-		    ->expects( $this->once() )
-		    ->method ( 'getNamespaceIdForString' )
-		    ->with   ( 'Category' )
-		    ->will   ( $this->returnValue( 14 ) )
+		$this->assertFalse(
+				$mockConfig->getQuery()
+		);
+		$mockQuery
+		    ->expects( $this->at( 0 ) )
+		    ->method ( 'getNamespaceId' )
+		    ->will   ( $this->returnValue( null ) )
 		;
-		$config
+		$this->assertEquals(
+				$mockConfig,
+				$mockConfig->setQuery( 'foo' )
+		);
+		$this->assertInstanceOf(
+				$mockConfig->getQuery()->_mockClassName, // mockproxy hack
+				$mockQuery
+		);
+		$mockQuery
+		    ->expects( $this->at( 0 ) )
+		    ->method ( 'getNamespaceId' )
+		    ->will   ( $this->returnValue( NS_CATEGORY ) )
+		;
+		$mockConfig
 		    ->expects( $this->once() )
 		    ->method ( 'getNamespaces' )
-		    ->will   ( $this->returnValue( array( 0 ) ) )
+		    ->will   ( $this->returnValue( [ NS_MAIN ] ) )
 		;
 		$this->assertEquals(
-				$config,
-				$config->setQuery( $query )
-		);
-		$paramsRefl = new ReflectionProperty( '\Wikia\Search\Config', 'params' );
-		$paramsRefl->setAccessible( true );
-		$params = $paramsRefl->getValue( $config );
-		$this->assertEquals(
-				$query,
-				$params['originalQuery']
+				$mockConfig,
+				$mockConfig->setQuery( 'foo' )
 		);
 		$this->assertEquals(
-				'Foo',
-				$params['query']
+				NS_CATEGORY,
+				$mockConfig->getQueryNamespace()
 		);
+		
 	}
 	
 	/**
@@ -1140,23 +961,6 @@ class ConfigTest extends BaseTest {
 	}
 	
 	/**
-	 * @covers \Wikia\Search\Config::getQueryNoQuotes
-	 */
-	public function testGetQueryNoQuotes() {
-		$query = '"foo" and: \'bar\'';
-		$config = new \Wikia\Search\Config;
-		$this->assertEquals(
-				"foo and\\: bar",
-				$config->setQuery( $query )->getQueryNoQuotes()
-		);
-		$query = '"foo" and:\'bar\'';
-		$this->assertEquals(
-				"foo and:bar",
-				$config->setQuery( $query )->getQueryNoQuotes( true )
-		);
-	}
-	
-	/**
 	 * @covers \Wikia\Search\Config::getQuery
 	 */
 	public function testGetQuery() {
@@ -1166,21 +970,13 @@ class ConfigTest extends BaseTest {
 		);
 		$query = "foo and: bar & baz";
 		$config->setQuery( $query );
-		$this->assertEquals(
-				"foo and\\: bar & baz",
+		$this->assertInstanceOf(
+				'Wikia\Search\Query\Select',
 				$config->getQuery()
 		);
-		$this->assertEquals(
-				"foo and: bar &amp; baz",
-				$config->getQuery( \Wikia\Search\Config::QUERY_ENCODED )
-		);
-		$this->assertEquals(
+		$this->assertAttributeContains(
 				$query,
-				$config->getQuery( \Wikia\Search\Config::QUERY_RAW )
-		);
-		$config->setQuery( 'foo wiki' )->setIsInterWiki( true );
-		$this->assertEquals(
-				'foo',
+				'rawQuery',
 				$config->getQuery()
 		);
 	}

--- a/extensions/wikia/Search/classes/Test/Controller/SearchControllerTest.php
+++ b/extensions/wikia/Search/classes/Test/Controller/SearchControllerTest.php
@@ -29,7 +29,8 @@ class SearchControllerTest extends Wikia\Search\Test\BaseTest {
 				'handleArticleMatchTracking', 'setPageTitle', 'setResponseValuesFromConfig' );
 		$mockController = $this->searchController->setMethods( $methods )->getMock();
 		
-		$mockConfig = $this->getMock( 'Wikia\Search\Config', array( 'getQueryNoQuotes' ) );
+		$mockConfig = $this->getMock( 'Wikia\Search\Config', array( 'getQuery' ) );
+		$mockQuery = $this->getMock( 'Wikia\Search\Query\Select', array( 'hasTerms' ), array( 'foo' ) );
 		
 		$mockSearch = $this->getMockBuilder( 'Wikia\Search\QueryService\Select\OnWiki' )
 		                   ->setMethods( array( 'search', 'getMatch' ) )
@@ -52,9 +53,13 @@ class SearchControllerTest extends Wikia\Search\Test\BaseTest {
 		;
 		$mockConfig
 		    ->expects( $this->once() )
-		    ->method ( 'getQueryNoQuotes' )
-		    ->with   ( true )
-		    ->will   ( $this->returnValue( "query" ) )
+		    ->method ( 'getQuery' )
+		    ->will   ( $this->returnValue( $mockQuery ) )
+		;
+		$mockQuery
+		    ->expects( $this->once() )
+		    ->method ( 'hasTerms' )
+		    ->will   ( $this->returnValue( true ) )
 		;
 		$mockFactory
 		    ->expects( $this->once() )
@@ -113,7 +118,8 @@ class SearchControllerTest extends Wikia\Search\Test\BaseTest {
 	 */
 	public function testArticleMatchTrackingWithMatch() {
 		$mockController = $this->searchController->setMethods( array( 'getVal' ) )->getMock();
-		$searchConfig = $this->getMock( 'Wikia\Search\Config', array( 'getOriginalQuery', 'getPage', 'hasArticleMatch', 'getArticleMatch' ) );
+		$searchConfig = $this->getMock( 'Wikia\Search\Config', array( 'getQuery', 'getPage', 'hasArticleMatch', 'getArticleMatch' ) );
+		$mockQuery = $this->getMock( 'Wikia\Search\Query', array( 'getSanitizedQuery' ) );
 		$mockTitle = $this->getMockBuilder( 'Title' )
 		                  ->disableOriginalConstructor()
 		                  ->setMethods( array( 'getFullUrl' ) )
@@ -143,7 +149,12 @@ class SearchControllerTest extends Wikia\Search\Test\BaseTest {
 		;
 		$searchConfig
 		    ->expects( $this->any() )
-		    ->method ( 'getOriginalQuery' )
+		    ->method ( 'getQuery' )
+		    ->will   ( $this->returnValue( $mockQuery ) )
+	    ;
+		$mockQuery
+		    ->expects( $this->once() )
+		    ->method ( 'getSanitizedQuery' )
 		    ->will   ( $this->returnValue( 'foo' ) )
 		;
 		$searchConfig
@@ -223,7 +234,8 @@ class SearchControllerTest extends Wikia\Search\Test\BaseTest {
 	public function testArticleMatchTrackingWithoutMatch() {
 
 		$mockController = $this->searchController->setMethods( array( 'getVal' ) )->getMock();
-		$searchConfig = $this->getMock( 'Wikia\Search\Config', array( 'getOriginalQuery', 'getPage', 'hasArticleMatch' ) );
+		$searchConfig = $this->getMock( 'Wikia\Search\Config', array( 'getQuery', 'getPage', 'hasArticleMatch' ) );
+		$mockQuery = $this->getMock( 'Wikia\Search\Query', array( 'getSanitizedQuery' ) );
 		$mockTitle = $this->getMockBuilder( 'Title' )
 		                  ->disableOriginalConstructor()
 		                  ->setMethods( array( 'getFullUrl' ) )
@@ -244,7 +256,12 @@ class SearchControllerTest extends Wikia\Search\Test\BaseTest {
 		;
 		$searchConfig
 		    ->expects( $this->any() )
-		    ->method ( 'getOriginalQuery' )
+		    ->method ( 'getQuery' )
+		    ->will   ( $this->returnValue( $mockQuery ) )
+		;
+		$mockQuery
+		    ->expects( $this->once() )
+		    ->method ( 'getSanitizedQuery' )
 		    ->will   ( $this->returnValue( $originalQuery ) )
 		;
 		$searchConfig
@@ -285,7 +302,8 @@ class SearchControllerTest extends Wikia\Search\Test\BaseTest {
 	 */
 	public function testHandleArticleMatchTrackingWithoutGoSearch() {
 		$mockController = $this->searchController->setMethods( array( 'getVal' ) )->getMock();
-		$searchConfig = $this->getMock( 'Wikia\Search\Config', array( 'getOriginalQuery', 'getPage', 'hasArticleMatch', 'getArticleMatch' ) );
+		$searchConfig = $this->getMock( 'Wikia\Search\Config', array( 'getQuery', 'getPage', 'hasArticleMatch', 'getArticleMatch' ) );
+		$mockQuery = $this->getMock( 'Wikia\Search\Query', array( 'getSanitizedQuery' ) );
 		$mockTitle = $this->getMockBuilder( 'Title' )
 		                  ->disableOriginalConstructor()
 		                  ->setMethods( array( 'getFullUrl' ) )
@@ -330,7 +348,12 @@ class SearchControllerTest extends Wikia\Search\Test\BaseTest {
 		;
 		$searchConfig
 		    ->expects( $this->any() )
-		    ->method ( 'getOriginalQuery' )
+		    ->method ( 'getQuery' )
+		    ->will   ( $this->returnValue( $mockQuery ) )
+		;
+		$mockQuery
+		    ->expects( $this->once() )
+		    ->method ( 'getSanitizedQuery' )
 		    ->will   ( $this->returnValue( $originalQuery ) )
 		;
 		$searchConfig
@@ -531,6 +554,7 @@ class SearchControllerTest extends Wikia\Search\Test\BaseTest {
 										'getSkipCache', 'getDebug', 'getNamespaces', 'getAdvanced', 'getIncludeRedirects',
 										'getLimit', 'getPublicFilterKeys', 'getRank' );
 		$mockConfig			=	$this->getMock( 'Wikia\Search\Config', $configMethods );
+		$mockQuery = $this->getMock( 'Wikia\Search\Query\Select', array( 'getSanitizedQuery' ), array( 'foo' ) );
 
 		$mockWgRefl = new ReflectionProperty( 'WikiaSearchController', 'wg' );
 		$mockWgRefl->setAccessible( true );
@@ -561,8 +585,12 @@ class SearchControllerTest extends Wikia\Search\Test\BaseTest {
 		$mockConfig
 			->expects	( $this->at( $incr++ ) )
 			->method	( 'getQuery' )
-			->with		( Wikia\Search\Config::QUERY_RAW )
-			->will		( $this->returnValue( 'foo' ) )
+			->will		( $this->returnValue( $mockQuery ) )
+		;
+		$mockQuery
+		    ->expects( $this->once() )
+		    ->method ( 'getSanitizedQuery' )
+		    ->will   ( $this->returnValue( 'foo' ) )
 		;
 		$mockConfig
 			->expects	( $this->at( $incr++ ) )
@@ -779,6 +807,9 @@ class SearchControllerTest extends Wikia\Search\Test\BaseTest {
 									->disableOriginalConstructor()
 									->setMethods( array( 'getNamespaces', 'getQuery', 'getSearchProfiles', 'getIncludeRedirects', 'getActiveTab', 'getFilterQueries', 'getRank' ) )
 									->getMock();
+		
+		$mockQuery = $this->getMock( 'Wikia\Search\Query\Select', array( 'getSanitizedQuery' ), array( 'foo' ) );
+		
 
 		$this->mockGlobalVariable( 'wgDefaultSearchProfile', SEARCH_PROFILE_DEFAULT );
 
@@ -858,8 +889,12 @@ class SearchControllerTest extends Wikia\Search\Test\BaseTest {
 		$mockSearchConfig
 			->expects	( $this->once() )
 			->method	( 'getQuery' )
-			->with		( Wikia\Search\Config::QUERY_RAW )
-			->will		( $this->returnValue( 'foo' ) )
+			->will		( $this->returnValue( $mockQuery ) )
+		;
+		$mockQuery
+		    ->expects   ( $this->once() )
+		    ->method    ( 'getSanitizedQuery' )
+		    ->will      ( $this->returnValue( 'foo' ) )
 		;
 		$mockSearchConfig
 			->expects	( $this->once() )
@@ -926,6 +961,8 @@ class SearchControllerTest extends Wikia\Search\Test\BaseTest {
 									->setMethods( array( 'getNamespaces', 'getQuery', 'getSearchProfiles', 'getIncludeRedirects', 'getActiveTab', 'getFilterQueries', 'getRank' ) )
 									->getMock();
 
+		$mockQuery = $this->getMock( 'Wikia\Search\Query\Select', array( 'getSanitizedQuery' ),  array( 'foo' ) );
+		
 		$this->mockGlobalVariable( 'wgDefaultSearchProfile', SEARCH_PROFILE_DEFAULT );
 
 		$defaultNamespaces = array( NS_MAIN, NS_CATEGORY );
@@ -1003,8 +1040,12 @@ class SearchControllerTest extends Wikia\Search\Test\BaseTest {
 		$mockSearchConfig
 			->expects	( $this->once() )
 			->method	( 'getQuery' )
-			->with		( Wikia\Search\Config::QUERY_RAW )
-			->will		( $this->returnValue( 'foo' ) )
+			->will		( $this->returnValue( $mockQuery ) )
+		;
+		$mockQuery
+		    ->expects   ( $this->once() )
+		    ->method    ( 'getSanitizedQuery' )
+		    ->will      ( $this->returnValue( 'foo' ) )
 		;
 		$mockSearchConfig
 			->expects	( $this->once() )
@@ -2270,6 +2311,8 @@ class SearchControllerTest extends Wikia\Search\Test\BaseTest {
 		               ->setMethods( array( 'msg' ) )
 		               ->getMock();
 		
+		$mockQuery = $this->getMock( 'Wikia\Search\Query\Select', array( 'hasTerms', 'getSanitizedQuery' ), array( 'foo' ) );
+		
 		$mockOut = $this->getMockBuilder( 'OutputPage' )
 		                ->disableOriginalConstructor()
 		                ->setMethods( array( 'setPageTitle' ) )
@@ -2277,7 +2320,7 @@ class SearchControllerTest extends Wikia\Search\Test\BaseTest {
 		
 		$mockConfig = $this->getMockBuilder( 'Wikia\Search\Config' )
 		                   ->disableOriginalConstructor()
-		                   ->setMethods( array( 'getQueryNoQuotes', 'getQuery', 'getIsInterWiki' ) )
+		                   ->setMethods( array( 'getQuery', 'getIsInterWiki' ) )
 		                   ->getMock();
 		
 		$sitename = "Foo Wiki";
@@ -2298,14 +2341,22 @@ class SearchControllerTest extends Wikia\Search\Test\BaseTest {
 		
 		$mockConfig
 		    ->expects( $this->at( 0 ) )
-		    ->method ( 'getQueryNoQuotes' )
-		    ->with   ( true )
-		    ->will   ( $this->returnValue( $query ) )
+		    ->method ( 'getQuery' )
+		    ->will   ( $this->returnValue( $mockQuery ) )
+		;
+		$mockQuery
+		    ->expects( $this->at( 0 ) )
+		    ->method ( 'hasTerms' )
+		    ->will   ( $this->returnValue( true ) )
 		;
 		$mockConfig
 		    ->expects( $this->at( 1 ) )
 		    ->method ( 'getQuery' )
-		    ->with   ( Wikia\Search\Config::QUERY_RAW )
+		    ->will   ( $this->returnValue( $mockQuery ) )
+		;
+		$mockQuery
+		    ->expects( $this->at( 1 ) )
+		    ->method ( 'getSanitizedQuery' )
 		    ->will   ( $this->returnValue( $query ) )
 		;
 		$mockWf
@@ -2324,9 +2375,13 @@ class SearchControllerTest extends Wikia\Search\Test\BaseTest {
 		
 		$mockConfig
 		    ->expects( $this->at( 0 ) )
-		    ->method ( 'getQueryNoQuotes' )
-		    ->with   ( true )
-		    ->will   ( $this->returnValue( null ) )
+		    ->method ( 'getQuery' )
+		    ->will   ( $this->returnValue( $mockQuery ) )
+		;
+		$mockQuery
+		    ->expects( $this->at( 0 ) )
+		    ->method ( 'hasTerms' )
+		    ->will   ( $this->returnValue( false ) )
 		;
 		$mockConfig
 		    ->expects( $this->at( 1 ) )
@@ -2349,9 +2404,13 @@ class SearchControllerTest extends Wikia\Search\Test\BaseTest {
 		
 		$mockConfig
 		    ->expects( $this->at( 0 ) )
-		    ->method ( 'getQueryNoQuotes' )
-		    ->with   ( true )
-		    ->will   ( $this->returnValue( null ) )
+		    ->method ( 'getQuery' )
+		    ->will   ( $this->returnValue( $mockQuery ) )
+		;
+		$mockQuery
+		    ->expects( $this->at( 0 ) )
+		    ->method ( 'hasTerms' )
+		    ->will   ( $this->returnValue( false ) )
 		;
 		$mockConfig
 		    ->expects( $this->at( 1 ) )
@@ -2382,6 +2441,8 @@ class SearchControllerTest extends Wikia\Search\Test\BaseTest {
 		                       ->disableOriginalConstructor()
 		                       ->setMethods( array( 'getResponse', 'getVal' ) )
 		                       ->getMock();
+		
+		$mockQuery = $this->getMock( 'Wikia\Search\Query\Select', array( 'getQueryForHtml' ), array( 'foo' ) );
 		
 		$mockResponse = $this->getMockBuilder( 'WikiaResponse' )
 		                     ->disableOriginalConstructor()
@@ -2452,6 +2513,8 @@ class SearchControllerTest extends Wikia\Search\Test\BaseTest {
 		                     ->disableOriginalConstructor()
 		                     ->setMethods( array( 'getFormat', 'setData' ) )
 		                     ->getMock();
+		
+		$mockQuery = $this->getMock( 'Wikia\Search\Query\Select', array( 'getQueryForHtml' ), array( 'foo' ) );
 		
 		$configMethods = array( 
 				'getResults', 'getResultsFound', 'getQuery', 
@@ -2596,7 +2659,11 @@ class SearchControllerTest extends Wikia\Search\Test\BaseTest {
 		$mockConfig
 		    ->expects( $this->any() )
 		    ->method ( 'getQuery' )
-		    ->with   ( Wikia\Search\Config::QUERY_ENCODED )
+		    ->will   ( $this->returnValue( $mockQuery ) )
+		;
+		$mockQuery
+		    ->expects( $this->once() )
+		    ->method ( 'getQueryForHtml' )
 		    ->will   ( $this->returnValue( 'foo' ) )
 		;
 		$mockController

--- a/extensions/wikia/Search/classes/Test/Query/SelectTest.php
+++ b/extensions/wikia/Search/classes/Test/Query/SelectTest.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * Class definition for Wikia\Search\Test\Query\Select
+ */
+namespace Wikia\Search\Test\Query;
+use Wikia\Search\Query\Select as Query, Wikia\Search\MediaWikiService, Wikia\Search\Test\BaseTest, ReflectionMethod;
+
+class SelectTest extends BaseTest
+{
+	/**
+	 * @covers Wikia\Search\Query\Select::__construct
+	 */
+	public function testConstruct()
+	{
+		$query = new Query( 'foo' );
+		$this->assertAttributeEquals(
+				'foo',
+				'rawQuery',
+				$query
+		);
+	}
+	
+	/**
+	 * @covers Wikia\Search\Query\Select::getSanitizedQuery
+	 */
+	public function testGetSanitizedQuery()
+	{
+		$sanitizer = $this->getMock( 'Sanitizer', array( 'StripAllTags' ) );
+		$this->proxyClass( 'Sanitizer', $sanitizer );
+		$this->mockApp();
+		$rawQuery = "crime &amp; <b>punishment</b>";
+		$expected = "crime & punishment";
+		$query = new Query( $rawQuery );
+		$this->assertAttributeEmpty(
+				'sanitizedQuery',
+				$query
+		);
+		$sanitizer
+		    ->staticExpects( $this->once() )
+		    ->method       ( 'StripAllTags' )
+		    ->with         ( $rawQuery )
+		    ->will         ( $this->returnValue( "crime &amp; punishment" ) )
+		;
+		$this->assertEquals(
+				$expected,
+				$query->getSanitizedQuery()
+		);
+		$this->assertAttributeEquals(
+				$expected,
+				'sanitizedQuery',
+				$query
+		);
+	}
+	
+	/**
+	 * @covers Wikia\Search\Query\Select::getQueryForHtml
+	 */
+	public function testGetQueryForHtml() {
+		$mockQuery = $this->getMock( 'Wikia\Search\Query\Select', [ 'getSanitizedQuery' ], [ 'foo' ] );
+		$mockQuery
+		    ->expects( $this->once() )
+		    ->method ( 'getSanitizedQuery' )
+		    ->will   ( $this->returnValue( "crime & punishment" ) )
+		;
+		$this->assertEquals(
+				"crime &amp; punishment",
+				$mockQuery->getQueryForHtml()
+		);
+	}
+	
+	/**
+	 * @covers Wikia\Search\Query\Select::hasTerms
+	 */
+	public function testHasTerms() {
+		$mockQuery = $this->getMock( 'Wikia\Search\Query\Select', [ 'getSanitizedQuery' ], [ 'foo' ] );
+		$mockQuery
+		    ->expects( $this->at( 0 ) )
+		    ->method ( 'getSanitizedQuery' )
+		    ->will   ( $this->returnValue( '#*%&!*!' ) )
+		;
+		$this->assertFalse(
+				$mockQuery->hasTerms()
+		);
+		$mockQuery
+		    ->expects( $this->at( 0 ) )
+		    ->method ( 'getSanitizedQuery' )
+		    ->will   ( $this->returnValue( 'drive slow, homie' ) )
+		;
+		$this->assertTrue(
+				$mockQuery->hasTerms()
+		);
+	}
+	
+	/**
+	 * @covers Wikia\Search\Query\Select::getService
+	 */
+	public function testGetService() {
+		$query = new Query( 'foo' );
+		$method = new ReflectionMethod( 'Wikia\Search\Query\Select', 'getService' );
+		$method->setAccessible( true );
+		$this->assertInstanceOf(
+				'Wikia\Search\MediaWikiService',
+				$method->invoke( $query )
+		);
+		$this->assertAttributeInstanceOf(
+				'Wikia\Search\MediaWikiService',
+				'service',
+				$query
+		);
+	}
+	
+	/**
+	 * @covers Wikia\Search\Query\Select::initializeNamespaceData
+	 * @covers Wikia\Search\Query\Select::getNamespacePrefix
+	 * @covers Wikia\Search\Query\Select::getNamespaceId
+	 */
+	public function testNamespaceLogic() {
+		$query = new Query( 'ThisIsNotANamespace:Bar' );
+		$this->assertNull(
+				$query->getNamespaceId()
+		);
+		$this->assertNull(
+				$query->getNamespacePrefix()
+		);
+		$query = new Query( 'Category:Things That Are Namespaces' );
+		$this->assertEquals(
+				NS_CATEGORY,
+				$query->getNamespaceId()
+		);
+		$this->assertEquals(
+				'Category',
+				$query->getNamespacePrefix()
+		);
+	}
+	
+	/**
+	 * @covers Wikia\Search\Query\Select::getSolrQuery
+	 */
+	public function testGetSolrQuery() {
+		$query = new Query( "Category:Shortcuts" );
+		$this->assertEquals(
+				"Shortcuts",
+				$query->getSolrQuery()
+		);
+		$query = new Query( "123foo" );
+		$this->assertEquals(
+				"123 foo",
+				$query->getSolrQuery()
+		);
+		$query = new Query( '"foo:bar&&baz"' );
+		$this->assertEquals(
+				'\"foo\:bar\&&baz\"',
+				$query->getSolrQuery()
+		);
+	}
+}

--- a/extensions/wikia/Search/classes/Test/QueryService/Select/AbstractSelectTest.php
+++ b/extensions/wikia/Search/classes/Test/QueryService/Select/AbstractSelectTest.php
@@ -700,6 +700,7 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 		                    ->setMethods( array( 'get' ) )
 		                    ->getMock();
 		$mockConfig = $this->getMock( 'Wikia\Search\Config', array( 'setResults', 'setResultsFound', 'getPage', 'getQuery' ) );
+		$mockQuery = $this->getMock( 'Wikia\Search\Query\Select', array( 'getSanitizedQuery' ), array( 'foo' ) );
 		
 		$mockResult = $this->getMockBuilder( 'Solarium_Result_Select' )
 		                   ->disableOriginalConstructor()
@@ -750,6 +751,11 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 		$mockConfig
 		    ->expects( $this->once() )
 		    ->method ( 'getQuery' )
+	        ->will   ( $this->returnValue( $mockQuery ) )
+        ;
+		$mockQuery
+		    ->expects( $this->once() )
+		    ->method ( 'getSanitizedQuery' )
 		    ->will   ( $this->returnValue( 'foo' ) )
 		;
 		$reflspell = new ReflectionMethod( 'Wikia\Search\QueryService\Select\AbstractSelect', 'prepareResponse' );
@@ -811,6 +817,8 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 		                   ->setMethods( array( 'getMinimumMatch', 'getSkipBoostFunctions', 'getQuery' ) )
 		                   ->getMock();
 		
+		$mockQueryWrapper = $this->getMock( 'Wikia\Search\Query\Select', array( 'getSolrQuery' ), array( 'foo' ) );
+		
 		$deps = array( 'config' => $mockConfig, 'client' => $mockClient, 'service' => $mockService  );
 		$dc = new Wikia\Search\QueryService\DependencyContainer( $deps );
 		$mockSelect = $this->getMockBuilder( 'Wikia\Search\QueryService\Select\AbstractSelect' )
@@ -826,6 +834,11 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 		$mockConfig
 		    ->expects( $this->once() )
 		    ->method ( 'getQuery' )
+		    ->will   ( $this->returnValue( $mockQueryWrapper ) )
+	    ;
+		$mockQueryWrapper
+		    ->expects( $this->once() )
+		    ->method ( 'getSolrQuery' )
 		    ->will   ( $this->returnValue( 'foo' ) )
 		;
 		$mockQuery

--- a/extensions/wikia/Search/classes/Test/QueryService/Select/InterWikiTest.php
+++ b/extensions/wikia/Search/classes/Test/QueryService/Select/InterWikiTest.php
@@ -14,6 +14,7 @@ class InterWikiTest extends Wikia\Search\Test\BaseTest {
 	 */
 	public function testExtractMatch() {
 		$mockConfig = $this->getMock( 'Wikia\Search\Config', array( 'getQuery', 'setWikiMatch', 'getWikiMatch' ) );
+		$mockQuery = $this->getMock( 'Wikia\Search\Query\Select', array( 'getSanitizedQuery' ), array( 'foo' ) );
 		$mockService = $this->getMockBuilder( 'Wikia\Search\MediaWikiService' )
 		                      ->disableOriginalConstructor()
 		                      ->setMethods( array( 'getWikiMatchByHost' ) )
@@ -31,7 +32,11 @@ class InterWikiTest extends Wikia\Search\Test\BaseTest {
 		$mockConfig
 		    ->expects( $this->once() )
 		    ->method ( 'getQuery' )
-		    ->with   ( Wikia\Search\Config::QUERY_RAW )
+		    ->will   ( $this->returnValue( $mockQuery ) )
+	    ;
+		$mockQuery
+		    ->expects( $this->once() )
+		    ->method ( 'getSanitizedQuery' )
 		    ->will   ( $this->returnValue( 'star wars' ) )
 		;
 		$mockService

--- a/extensions/wikia/Search/classes/Test/QueryService/Select/LuceneTest.php
+++ b/extensions/wikia/Search/classes/Test/QueryService/Select/LuceneTest.php
@@ -14,6 +14,7 @@ class LuceneTest extends Wikia\Search\Test\BaseTest {
 	 */
 	public function testGetFormulatedQuery() {
 		$mockConfig = $this->getMock( 'Wikia\Search\Config', array( 'getQuery' ) );
+		$mockQuery = $this->getMock( 'Wikia\Search\Query\Select', array( 'getSanitizedQuery' ), array( 'foo' ) );
 		$dc = new Wikia\Search\QueryService\DependencyContainer( array( 'config' => $mockConfig ) );
 		$mockSelect = $this->getMockBuilder( 'Wikia\Search\QueryService\Select\Lucene' )
 		                   ->setConstructorArgs( array( $dc ) )
@@ -23,7 +24,11 @@ class LuceneTest extends Wikia\Search\Test\BaseTest {
 		$mockConfig
 		    ->expects( $this->once() )
 		    ->method ( 'getQuery' )
-		    ->with   ( Wikia\Search\Config::QUERY_RAW )
+		    ->will   ( $this->returnValue( $mockQuery ) )
+	    ;
+		$mockQuery
+		    ->expects( $this->once() )
+		    ->method ( 'getSanitizedQuery' )
 		    ->will   ( $this->returnValue( 'foo:bar' ) )
 		;
 		$method = new ReflectionMethod( 'Wikia\Search\QueryService\Select\Lucene', 'getFormulatedQuery' );

--- a/extensions/wikia/Search/classes/Test/QueryService/Select/OnWikiTest.php
+++ b/extensions/wikia/Search/classes/Test/QueryService/Select/OnWikiTest.php
@@ -20,8 +20,10 @@ class OnWikiTest extends Wikia\Search\Test\BaseTest {
 		                      ->getMock();
 		
 		$mockConfig = $this->getMockBuilder( 'Wikia\Search\Config' )
-		                   ->setMethods( array( 'getOriginalQuery', 'getNamespaces', 'setArticleMatch', 'getMatch' ) )
+		                   ->setMethods( array( 'getQuery', 'getNamespaces', 'setArticleMatch', 'getMatch' ) )
 		                   ->getMock();
+		
+		$mockQuery = $this->getMock( 'Wikia\Search\Query\Select', array( 'getSanitizedQuery' ), array( 'foo' ) );
 		
 		$dc = new Wikia\Search\QueryService\DependencyContainer( array( 'service' => $mockService, 'config' => $mockConfig ) );
 		$mockSelect = $this->getMockBuilder( 'Wikia\Search\QueryService\Select\OnWiki' )
@@ -35,7 +37,12 @@ class OnWikiTest extends Wikia\Search\Test\BaseTest {
 		
 		$mockConfig
 		    ->expects( $this->once() )
-		    ->method ( 'getOriginalQuery' )
+		    ->method ( 'getQuery' )
+		    ->will   ( $this->returnValue( $mockQuery ) )
+	    ;
+		$mockQuery
+		    ->expects( $this->once() )
+		    ->method ( 'getSanitizedQuery' )
 		    ->will   ( $this->returnValue( 'term' ) )
 		;
 		$mockConfig
@@ -192,7 +199,8 @@ class OnWikiTest extends Wikia\Search\Test\BaseTest {
 		                      ->disableOriginalConstructor()
 		                      ->setMethods( array( 'getGlobal' ) )
 		                      ->getMock();
-		$mockConfig = $this->getMock( 'Wikia\Search\Config', array( 'getQueryNoQuotes', 'getCityId'  ) );
+		$mockConfig = $this->getMock( 'Wikia\Search\Config', array( 'getQuery', 'getCityId'  ) );
+		$mockQueryWrapper = $this->getMock( 'Wikia\Search\Query\Select', array( 'getSanitizedQuery' ), array( 'foo' ) );
 		
 		$dc = new Wikia\Search\QueryService\DependencyContainer( array( 'service' => $mockService, 'config' => $mockConfig ) );
 		$mockSelect = $this->getMockBuilder( 'Wikia\Search\QueryService\Select\OnWiki' )
@@ -213,8 +221,12 @@ class OnWikiTest extends Wikia\Search\Test\BaseTest {
 	    ;
 		$mockConfig
 		    ->expects( $this->once() )
-		    ->method ( 'getQueryNoQuotes' )
-		    ->with   ( true )
+		    ->method ( 'getQuery' )
+		    ->will   ( $this->returnValue( $mockQueryWrapper ) )
+	    ;
+		$mockQueryWrapper
+		    ->expects( $this->once() )
+		    ->method ( 'getSanitizedQuery' )
 		    ->will   ( $this->returnValue( 'foo' ) )
 		;
 		$mockSpellcheck
@@ -384,18 +396,24 @@ class OnWikiTest extends Wikia\Search\Test\BaseTest {
 	 * @covers Wikia\Search\QueryService\Select\OnWiki::getBoostQueryString
 	 */
 	public function testGetBoostQueryString() {
-		$mockConfig = $this->getMock( 'Wikia\Search\Config', array( 'getQueryNoQuotes' ) );
+		$mockConfig = $this->getMock( 'Wikia\Search\Config', array( 'getQuery' ) );
+		$mockQuery = $this->getMock( 'Wikia\Search\Query\Select', array( 'getSolrQuery' ), array( 'foo' ) );
 		$dc = new Wikia\Search\QueryService\DependencyContainer( array( 'config' => $mockConfig ) );
 		$mockSelect = $this->getMockBuilder( 'Wikia\Search\QueryService\Select\OnWiki' )
 		                   ->setConstructorArgs( array( $dc ) )
 		                   ->setMethods( null )
 		                   ->getMock();
 		$queryNoQuotes = 'foo';
+		$queryWithQuotes = '\"foo\"';
 		$mockConfig
 		    ->expects( $this->once() )
-		    ->method ( 'getQueryNoQuotes' )
-		    ->with   ( true )
-		    ->will   ( $this->returnValue( $queryNoQuotes ) )
+		    ->method ( 'getQuery' )
+		    ->will   ( $this->returnValue( $mockQuery ) )
+	    ;
+		$mockQuery
+		    ->expects( $this->once() )
+		    ->method ( 'getSolrQuery' )
+		    ->will   ( $this->returnValue( $queryWithQuotes ) )
 		;
 		$method = new ReflectionMethod( 'Wikia\Search\QueryService\Select\OnWiki', 'getBoostQueryString' );
 		$method->setAccessible( true );

--- a/extensions/wikia/Search/classes/Test/ResultSet/AbstractResultSetTest.php
+++ b/extensions/wikia/Search/classes/Test/ResultSet/AbstractResultSetTest.php
@@ -177,6 +177,7 @@ class AbstractResultSetTest extends Wikia\Search\Test\BaseTest {
 		                  ->getMockForAbstractClass();
 		
 		$mockConfig = $this->getMock( 'Wikia\Search\Config', array( 'getQuery' ) );
+		$mockQuery = $this->getMock( 'Wikia\Search\Query\Select', array( 'getQueryForHtml' ), array( 'foo' ) );
 		$configRefl = new ReflectionProperty( 'Wikia\Search\ResultSet\AbstractResultSet', 'searchConfig' );
 		$configRefl->setAccessible( true );
 		$configRefl->setValue( $resultSet, $mockConfig );
@@ -184,7 +185,11 @@ class AbstractResultSetTest extends Wikia\Search\Test\BaseTest {
 		$mockConfig
 		    ->expects( $this->once() )
 		    ->method ( 'getQuery' )
-		    ->with   ( Wikia\Search\Config::QUERY_ENCODED )
+		    ->will   ( $this->returnValue( $mockQuery ) )
+	    ;
+		$mockQuery
+		    ->expects( $this->once() )
+		    ->method ( 'getQueryForHtml' )
 		    ->will   ( $this->returnValue( 'foo' ) )
 		;
 		$this->assertEquals(

--- a/extensions/wikia/Search/classes/Test/UtilitiesTest.php
+++ b/extensions/wikia/Search/classes/Test/UtilitiesTest.php
@@ -29,26 +29,4 @@ class UtilitiesTest extends BaseTest
 				(string) (new \Wikia\Search\Field\Field( 'html', 'fr' ))
 		);
 	}
-	
-	/**
-	 * @covers Wikia\Search\Utilities::sanitizeQuery
-	 */
-	public function testSanitizeQuery() {
-		$qh = $this->getMock( 'Solarium_Query_Helper', array( 'escapeTerm' ) );
-		$qhRefl = new \ReflectionProperty( 'Wikia\Search\Utilities', 'queryHelper' );
-		$qhRefl->setAccessible( true );
-		$qhRefl->setValue( null );
-		$qh
-		    ->expects( $this->once() )
-		    ->method ( 'escapeTerm' )
-		    ->with   ( '123 foo?' )
-		    ->will   ( $this->returnValue( '123 foo\?' ) ) 
-		;
-		$this->proxyClass( 'Solarium_Query_Helper', $qh );
-		$this->mockApp();
-		$this->assertEquals(
-				'123 foo\?',
-				Utils::sanitizeQuery( '123foo?' )
-		);
-	}
 }

--- a/extensions/wikia/Search/classes/Utilities.php
+++ b/extensions/wikia/Search/classes/Utilities.php
@@ -42,24 +42,4 @@ class Utilities
 		$field = new Field\Field( $field, $lang );
 		return $field->__toString();
 	}
-	
-	/**
-	 * Prevents XSS and escapes characters used in Lucene query syntax.
-	 * Any query string transformations before sending to backend should be placed here.
-	 * @see    WikiaSearchTest::testSanitizeQuery
-	 * @param  string $query
-	 * @return string
-	 */
-	public static function sanitizeQuery( $query )
-	{
-		if ( self::$queryHelper === null ) {
-			self::$queryHelper = new Solarium_Query_Helper();
-		}
-		// non-indexed number-string phrases issue workaround (RT #24790)
-		$query = preg_replace('/(\d+)([a-zA-Z]+)/i', '$1 $2', $query);
-	
-		// escape all lucene special characters: + - && || ! ( ) { } [ ] ^ " ~ * ? : \ (RT #25482)
-		// added html entity decoding now that we're doing extra work to prevent xss
-		return self::$queryHelper->escapeTerm( html_entity_decode( $query,  ENT_COMPAT, 'UTF-8' ) );
-	}
 }


### PR DESCRIPTION
This adds the class Wikia\Search\Query\Select, which handles mutating the input according to needs for security, HTML compatibility, and Lucene Query Syntax compatibility.

This is namespaced into Wikia\Search\Query because I imagine we're going to want to swap out Wikia\Search\QueryService\Select\Lucene to use a more direct version of the query that tolerates raw input better, since it will only be accessible internally. Since there isn't a high need for it now, that part is not yet introduced.

This teases out some of the thornier query-associated logic with Wikia\Search\Config, and addresses a bug that stripped out the namespace prefix from a user's query when displaying in the search result box.
