### PR TITLE
BugId:98435 Fix for ImageServing not indexing images for articles thumbn...

### DIFF
--- a/extensions/wikia/ImageServing/imageServingHelper.class.php
+++ b/extensions/wikia/ImageServing/imageServingHelper.class.php
@@ -86,7 +86,7 @@ class ImageServingHelper{
 		$ig->parse();
 		$data = $ig->getData();
 
-		$ig = new fakeIGimageServing( $ig->mImages );
+		$ig = new fakeIGimageServing( $data['images'] );
 		wfProfileOut(__METHOD__);
 		return false;
 	}
@@ -189,7 +189,7 @@ class fakeIGimageServing extends ImageGallery {
 	function toHTML() {
 		$res = "";
 		foreach ( $this->in as $key => $imageData ) {
-			$file =  $this->getImage($imageData[0]);
+			$file =  $this->getImage($imageData['name']);
 
 			if($file) {
 				$res .= " <image mw='".$file->getTitle()->getDBkey()."' /> ";


### PR DESCRIPTION
...ails

Maintenance script for indexing images from articles wasn't catching images from galleries.

mImages field seems to be always empty and actually images are returned by method WikiaPhotoGallery::getData.

I changed this part of ImageServingHelper to use images returned by getData method.

I also made two test runs on muppet. One using mImages field one getData method. All what was found by first run was also found in the second run.
