### PR TITLE
PLA-140 -- strip all tags from search result snippet text except for spans

### DIFF
--- a/extensions/wikia/Search/classes/Result.php
+++ b/extensions/wikia/Search/classes/Result.php
@@ -166,10 +166,11 @@ class Result extends ReadWrite {
 							preg_replace('/ ?\.{2,3}$/', '', 
 							preg_replace('/ ?&hellip;$/', '',
 							str_replace('�', '', $text)))))));
-		return strlen($text) > 0 && $addEllipses 
+		$text = strlen($text) > 0 && $addEllipses 
 				? preg_replace('/(<\/span)$/', '$1>', preg_replace('/[[:punct:]]+$/', '', $text)).'&hellip;' 
 				: $text;
-
+		$text = strip_tags( $text, '<span>' );
+		return $text;
 	}
 
 	/**

--- a/extensions/wikia/Search/classes/Test/ResultTest.php
+++ b/extensions/wikia/Search/classes/Test/ResultTest.php
@@ -291,6 +291,66 @@ class ResultTest extends BaseTest {
 				$method->invoke( $result, $text ),
 				'Wikia\Search\Result::fixSnippeting should strip all tags except spans.'
 		);
+		$text = '<style foo';
+		$this->assertNotContains('<',
+			$method->invoke( $result, $text ),
+			'Wikia\Search\Result::fixSnippeting should strip all characters that can break markup.'
+		);
+		$text = '</style foo';
+		$this->assertNotContains('<',
+			$method->invoke( $result, $text ),
+			'Wikia\Search\Result::fixSnippeting should strip all characters that can break markup.'
+		);
+		$text = 'style> foo';
+		$this->assertNotContains('>',
+			$method->invoke( $result, $text ),
+			'Wikia\Search\Result::fixSnippeting should strip all characters that can break markup.'
+		);
+		$text = '< &';
+		$this->assertNotContains('<',
+			$method->invoke( $result, $text ),
+			'Wikia\Search\Result::fixSnippeting should strip all characters that can break markup.'
+		);
+		$text = 'foo<style';
+		$this->assertEquals('foo',
+			$method->invoke( $result, $text ),
+			'Wikia\Search\Result::fixSnippeting should strip all characters that can break markup.'
+		);
+		$text = '<div> foo';
+		$this->assertEquals(' foo',
+			$method->invoke( $result, $text ),
+			'Wikia\Search\Result::fixSnippeting should strip all tags except spans.'
+		);
+		$text = '</div> bar';
+		$this->assertEquals(' bar',
+			$method->invoke( $result, $text ),
+			'Wikia\Search\Result::fixSnippeting should strip all tags except spans.'
+		);
+		$text = '<style> buz';
+		$this->assertEquals(' buz',
+			$method->invoke( $result, $text ),
+			'Wikia\Search\Result::fixSnippeting should strip all tags except spans.'
+		);
+		$text = '<style>';
+		$this->assertEquals('',
+			$method->invoke( $result, $text ),
+			'Wikia\Search\Result::fixSnippeting should strip all tags except spans.'
+		);
+		$text = '<br/>foo';
+		$this->assertEquals('foo',
+			$method->invoke( $result, $text ),
+			'Wikia\Search\Result::fixSnippeting should strip all tags except spans.'
+		);
+		$text = '<style></style>';
+		$this->assertEquals('',
+			$method->invoke( $result, $text ),
+			'Wikia\Search\Result::fixSnippeting should strip all tags except spans.'
+		);
+		$text = '</style>';
+		$this->assertEquals('',
+			$method->invoke( $result, $text ),
+			'Wikia\Search\Result::fixSnippeting should strip all tags except spans.'
+		);
 	}
 
 	/**

--- a/extensions/wikia/Search/classes/Test/ResultTest.php
+++ b/extensions/wikia/Search/classes/Test/ResultTest.php
@@ -285,6 +285,12 @@ class ResultTest extends BaseTest {
 		        $method->invoke( $result, $text, true ),
 		        'Wikia\Search\Result::fixSnippeting should append an ellipses to the end of a string if second parameter passed as true. Broken span tags should be repaired, as well.'
 		);
+		$text = '<span class="searchmatch">foo</span></div>';
+		$this->assertEquals(
+				'<span class="searchmatch">foo</span>',
+				$method->invoke( $result, $text ),
+				'Wikia\Search\Result::fixSnippeting should strip all tags except spans.'
+		);
 	}
 
 	/**

--- a/extensions/wikia/Search/classes/Test/ResultTest.php
+++ b/extensions/wikia/Search/classes/Test/ResultTest.php
@@ -291,66 +291,6 @@ class ResultTest extends BaseTest {
 				$method->invoke( $result, $text ),
 				'Wikia\Search\Result::fixSnippeting should strip all tags except spans.'
 		);
-		$text = '<style foo';
-		$this->assertNotContains('<',
-			$method->invoke( $result, $text ),
-			'Wikia\Search\Result::fixSnippeting should strip all characters that can break markup.'
-		);
-		$text = '</style foo';
-		$this->assertNotContains('<',
-			$method->invoke( $result, $text ),
-			'Wikia\Search\Result::fixSnippeting should strip all characters that can break markup.'
-		);
-		$text = 'style> foo';
-		$this->assertNotContains('>',
-			$method->invoke( $result, $text ),
-			'Wikia\Search\Result::fixSnippeting should strip all characters that can break markup.'
-		);
-		$text = '< &';
-		$this->assertNotContains('<',
-			$method->invoke( $result, $text ),
-			'Wikia\Search\Result::fixSnippeting should strip all characters that can break markup.'
-		);
-		$text = 'foo<style';
-		$this->assertEquals('foo',
-			$method->invoke( $result, $text ),
-			'Wikia\Search\Result::fixSnippeting should strip all characters that can break markup.'
-		);
-		$text = '<div> foo';
-		$this->assertEquals(' foo',
-			$method->invoke( $result, $text ),
-			'Wikia\Search\Result::fixSnippeting should strip all tags except spans.'
-		);
-		$text = '</div> bar';
-		$this->assertEquals(' bar',
-			$method->invoke( $result, $text ),
-			'Wikia\Search\Result::fixSnippeting should strip all tags except spans.'
-		);
-		$text = '<style> buz';
-		$this->assertEquals(' buz',
-			$method->invoke( $result, $text ),
-			'Wikia\Search\Result::fixSnippeting should strip all tags except spans.'
-		);
-		$text = '<style>';
-		$this->assertEquals('',
-			$method->invoke( $result, $text ),
-			'Wikia\Search\Result::fixSnippeting should strip all tags except spans.'
-		);
-		$text = '<br/>foo';
-		$this->assertEquals('foo',
-			$method->invoke( $result, $text ),
-			'Wikia\Search\Result::fixSnippeting should strip all tags except spans.'
-		);
-		$text = '<style></style>';
-		$this->assertEquals('',
-			$method->invoke( $result, $text ),
-			'Wikia\Search\Result::fixSnippeting should strip all tags except spans.'
-		);
-		$text = '</style>';
-		$this->assertEquals('',
-			$method->invoke( $result, $text ),
-			'Wikia\Search\Result::fixSnippeting should strip all tags except spans.'
-		);
 	}
 
 	/**


### PR DESCRIPTION
Prevents search result snippets with malformed markup from breaking result pages, without removing the match highlighting.
