### PR TITLE
(bugid:100734) fixing undefined WikiaEditor error when openning VET outs...

### DIFF
--- a/extensions/wikia/VideoEmbedTool/js/VET.js
+++ b/extensions/wikia/VideoEmbedTool/js/VET.js
@@ -42,7 +42,7 @@
 				trackingMethod: 'both'
 			},
 			slice = [].slice,
-			track = ( WikiaEditor && WikiaEditor.track ) || Wikia.Tracker.track;
+			track = ( window.WikiaEditor && WikiaEditor.track ) || Wikia.Tracker.track;
 
 		return function() {
 			track.apply( track, [ config ].concat( slice.call( arguments ) ) );


### PR DESCRIPTION
...ide editor

Looks like it was already fixed in dev. 
