### PR TITLE
Bugid 100724

### DIFF
--- a/extensions/wikia/Search/WikiaSearchAjaxController.class.php
+++ b/extensions/wikia/Search/WikiaSearchAjaxController.class.php
@@ -20,7 +20,6 @@ class WikiaSearchAjaxController extends WikiaController {
         $this->response->setVal('status', true);
 
         $query = $this->request->getVal('query', $this->request->getVal('search'));
-        $query = htmlentities( Sanitizer::StripAllTags ( $query ), ENT_COMPAT, 'UTF-8' );
 
         $page = $this->request->getVal('page', 1);
         $rank = $this->request->getVal('rank', 'default');
@@ -40,10 +39,10 @@ class WikiaSearchAjaxController extends WikiaController {
 			'cityId'		=>	$cityId,
 			'rank'			=>	$rank,
 			'hub'			=>	$hub,
-			'query'			=>	$query,
 		);
         $config = new Wikia\Search\Config( $params );
         $config->setIsInterWiki( $isInterWiki )
+               ->setQuery( $query )
                ->setGroupResults( $isInterWiki );
         $results = (new QueryService\Factory)->getFromConfig( $config )->search();
 
@@ -53,7 +52,7 @@ class WikiaSearchAjaxController extends WikiaController {
                 'relevancyFunctionId' => 6,
                 'results' => $results,
                 'resultsPerPage' => $resultsPerPage,
-                'query' => $query)
+                'query' => $config->getQuery()->getQueryForHtml())
         )->render();
 
         $this->response->setVal('text', $text);

--- a/extensions/wikia/Search/classes/Config.php
+++ b/extensions/wikia/Search/classes/Config.php
@@ -285,6 +285,9 @@ class Config implements ArrayAccess
 		if (! isset( $this->params['query'] ) ) {
 			return false;
 		}
+		if ( is_string( $this->params['query'] ) ) {
+			$this->setQuery( $this->params['query'] );
+		}
 		return $this->params['query'];
 	}
 	

--- a/extensions/wikia/Search/classes/Test/ConfigTest.php
+++ b/extensions/wikia/Search/classes/Test/ConfigTest.php
@@ -979,5 +979,10 @@ class ConfigTest extends BaseTest {
 				'rawQuery',
 				$config->getQuery()
 		);
+		$config = new \Wikia\Search\Config( [ 'query' => 'foo' ] );
+		$this->assertInstanceOf(
+				'Wikia\Search\Query\Select',
+				$config->getQuery()
+		);
 	}
 }


### PR DESCRIPTION
WikiaSearchAjaxController, which is only used for the second page of mobile, sets the query in the config through the initial param array, but there wasn't any logic to handle turning this string into a Wikia\Search\Query\Select object. This was causing fatals, as we were trying to call methods on the string returned by getQuery.

I've updated the Config code to check if the value set is a string, and call the appropriate mutator to correctly store the appropriate object in advance of returning the value stored in $this->params['query'].

I've also updated the WikiaSearchAjaxController class to use the more standard setQuery approach on the config class.
