### PR TITLE
Release 157 bugid 95249 comments index debug

### DIFF
--- a/extensions/wikia/ArticleComments/classes/CommentsIndex.class.php
+++ b/extensions/wikia/ArticleComments/classes/CommentsIndex.class.php
@@ -234,11 +234,11 @@ class CommentsIndex extends WikiaModel {
 			);
 			if ( false === $status ) {
 				Wikia::log(__FUNCTION__, __LINE__, "WALL_COMMENTS_INDEX_ERROR Failed to create comments_index entry, parent_page_id={$this->parentPageId}, comment_id={$this->commentId}, parent_comment_id={$this->parentCommentId}", true);
-			} else {
-				Wikia::log(__FUNCTION__, __LINE__, "WALL_COMMENTS_INDEX_ERROR Failed to create comments_index entry, db is readonly", true);
 			}
 
 			$db->commit();
+		} else {
+			Wikia::log(__FUNCTION__, __LINE__, "WALL_COMMENTS_INDEX_ERROR Failed to create comments_index entry, db is readonly", true);
 		}
 
 		$this->wf->ProfileOut( __METHOD__ );

--- a/extensions/wikia/ArticleComments/classes/CommentsIndex.class.php
+++ b/extensions/wikia/ArticleComments/classes/CommentsIndex.class.php
@@ -210,7 +210,7 @@ class CommentsIndex extends WikiaModel {
 			if ( empty($this->lastTouched) ) {
 				$this->lastTouched = $timestamp;
 			}
-			$db->replace(
+			$status = $db->replace(
 				'comments_index',
 				'',
 				array(
@@ -231,6 +231,10 @@ class CommentsIndex extends WikiaModel {
 				),
 				__METHOD__
 			);
+			if ( false === $status ) {
+				Wikia::log(__FUNCTION__, __LINE__, "WALL_COMMENTS_INDEX_ERROR Failed to create comments_index entry, parent_page_id={$this->parentPageId}, comment_id={$this->commentId}, parent_comment_id={$this->parentCommentId}", true);
+			}
+
 			$db->commit();
 		}
 

--- a/extensions/wikia/ArticleComments/classes/CommentsIndex.class.php
+++ b/extensions/wikia/ArticleComments/classes/CommentsIndex.class.php
@@ -196,6 +196,7 @@ class CommentsIndex extends WikiaModel {
 
 		//Just for transition time
 		if(empty($this->wg->EnableWallEngine) || !WallHelper::isWallNamespace($this->namespace) ) {
+			Wikia::log(__FUNCTION__, __LINE__, "WALL_COMMENTS_INDEX_ERROR no wall?", true);
 			$this->wf->ProfileOut( __METHOD__ );
 			return false;
 		}
@@ -233,6 +234,8 @@ class CommentsIndex extends WikiaModel {
 			);
 			if ( false === $status ) {
 				Wikia::log(__FUNCTION__, __LINE__, "WALL_COMMENTS_INDEX_ERROR Failed to create comments_index entry, parent_page_id={$this->parentPageId}, comment_id={$this->commentId}, parent_comment_id={$this->parentCommentId}", true);
+			} else {
+				Wikia::log(__FUNCTION__, __LINE__, "WALL_COMMENTS_INDEX_ERROR Failed to create comments_index entry, db is readonly", true);
 			}
 
 			$db->commit();


### PR DESCRIPTION
One of the scenarios for posting on Empty's wall is when creating an entry in comments_index fails. There is no check for this in the code, so I'm adding some logging to see if this happens on production.
