### PR TITLE
PER-85: Mustache partials

### DIFF
--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -278,6 +278,7 @@ $wgAutoloadClasses['VideoService'] = $IP . '/includes/wikia/services/VideoServic
 $wgAutoloadClasses['SassService']  =  $IP.'/includes/wikia/services/SassService.php';
 $wgAutoloadClasses['UserService']  =  $IP.'/includes/wikia/services/UserService.class.php';
 $wgAutoloadClasses['VideoUsageService'] = $IP . '/includes/wikia/services/VideoUsageService.php';
+$wgAutoloadClasses['MustacheService'] = $IP . '/includes/wikia/services/MustacheService.class.php';
 
 // data models
 $wgAutoloadClasses['WikisModel'] = "{$IP}/includes/wikia/models/WikisModel.class.php";

--- a/includes/wikia/nirvana/WikiaView.class.php
+++ b/includes/wikia/nirvana/WikiaView.class.php
@@ -182,7 +182,7 @@ class WikiaView {
 
 		switch($this->response->getTemplateEngine()) {
 			case WikiaResponse::TEMPLATE_ENGINE_MUSTACHE:
-				$m = new MustachePHP;
+				$m = MustacheService::getInstance();
 				$result = $m->render(file_get_contents( $this->getTemplatePath() ), $data);
 				wfProfileOut(__METHOD__);
 

--- a/includes/wikia/nirvana/WikiaView.class.php
+++ b/includes/wikia/nirvana/WikiaView.class.php
@@ -183,7 +183,7 @@ class WikiaView {
 		switch($this->response->getTemplateEngine()) {
 			case WikiaResponse::TEMPLATE_ENGINE_MUSTACHE:
 				$m = MustacheService::getInstance();
-				$result = $m->render(file_get_contents( $this->getTemplatePath() ), $data);
+				$result = $m->render( $this->getTemplatePath(), $data );
 				wfProfileOut(__METHOD__);
 
 				return $result;

--- a/includes/wikia/services/MustacheService.class.php
+++ b/includes/wikia/services/MustacheService.class.php
@@ -1,0 +1,79 @@
+<?php
+
+class MustacheService {
+
+	const REGEX_PARTIALS = '/{{>(.*?)}}/';
+
+	const INFO_TEMPLATE = 'template';
+	const INFO_DEPENDENCIES = 'dependencies';
+
+	protected $cache = array();
+
+	protected function __construct() {}
+
+	protected function getTemplateInfo( $fileName ) {
+		if ( !empty($this->cache[$fileName] ) ) {
+			return $this->cache[$fileName];
+		}
+
+		$dirName = dirname($fileName) . '/';
+		$dependencies = array();
+		$template = file_get_contents($fileName);
+		$template = preg_replace_callback(
+			self::REGEX_PARTIALS,
+			function($matches) use (&$dependencies,$dirName) {
+				$relName = $matches[1];
+				$depName = $dirName . $relName . '.mustache';
+				$depName = realpath($depName);
+				$dependencies[] = $depName;
+				return "{{>{$depName}}}";
+			},
+			$template);
+
+		$templateInfo = array(
+			self::INFO_TEMPLATE => $template,
+			self::INFO_DEPENDENCIES => $dependencies,
+		);
+		$this->cache[$fileName] = $templateInfo;
+
+		return $templateInfo;
+	}
+
+	protected function addDependencies( &$partials, $fileName ) {
+		if ( !empty($partials[$fileName])) {
+			return true;
+		}
+
+		$templateInfo = $this->getTemplateInfo($fileName);
+		if ( empty($templateInfo) ) {
+			return false;
+		}
+
+		$partials[$fileName] = $templateInfo[self::INFO_TEMPLATE];
+		foreach ($templateInfo[self::INFO_DEPENDENCIES] as $depFileName) {
+			$this->addDependencies($partials,$depFileName);
+		}
+		return true;
+	}
+
+	public function render( $fileName, $data ) {
+		$fileName = realpath($fileName);
+		$partials = array();
+		$this->addDependencies($partials,$fileName);
+		$template = $partials[$fileName];
+
+		var_dump($partials);
+
+		$mustache = new Mustache();
+		return $mustache->render($template,$data,$partials);
+	}
+
+	public static function getInstance() {
+		static $instance;
+		if ( empty( $instance ) ) {
+			$instance = new self;
+		}
+		return $instance;
+	}
+
+}

--- a/includes/wikia/services/MustacheService.class.php
+++ b/includes/wikia/services/MustacheService.class.php
@@ -1,16 +1,36 @@
 <?php
 
+/**
+ * MustacheService is a wrapper for actual Mustache implementation
+ * that automatically searches for all required partials and prefetches them
+ * in order to supply Mustache engine (either in PHP or JS) with all necessary
+ * dependencies.
+ *
+ * @author Władysław Bodzek <wladek@wikia-inc.com>
+ */
 class MustacheService {
 
-	const REGEX_PARTIALS = '/{{>(.*?)}}/';
+	const REGEX_PARTIALS = '/{{>([^{}]*?)}}/';
 
 	const INFO_TEMPLATE = 'template';
 	const INFO_DEPENDENCIES = 'dependencies';
 
 	protected $cache = array();
 
+	/**
+	 * Singleton - use MustacheService::getInstance() instead
+	 */
 	protected function __construct() {}
 
+	/**
+	 * Get a converted template contents and its dependency list
+	 *
+	 * @param $fileName string File path (absolute)
+	 * @return array Array containing requested data, keys are:
+	 * - MustacheService::INFO_TEMPLATE - contains template contents
+	 * - MustacheService::INFO_DEPENDENCIES - list of all partials that may be included
+	 * @throws Exception Thrown if any partial cannot be found
+	 */
 	protected function getTemplateInfo( $fileName ) {
 		if ( !empty($this->cache[$fileName] ) ) {
 			return $this->cache[$fileName];
@@ -21,10 +41,13 @@ class MustacheService {
 		$template = file_get_contents($fileName);
 		$template = preg_replace_callback(
 			self::REGEX_PARTIALS,
-			function($matches) use (&$dependencies,$dirName) {
+			function($matches) use (&$dependencies,$fileName,$dirName) {
 				$relName = $matches[1];
 				$depName = $dirName . $relName . '.mustache';
 				$depName = realpath($depName);
+				if ( empty( $depName ) ) { // partial doesn't exist
+					throw new Exception("Template \"{$fileName}\" references partial \"{$matches[1]}\" that was not found.");
+				}
 				$dependencies[] = $depName;
 				return "{{>{$depName}}}";
 			},
@@ -39,6 +62,15 @@ class MustacheService {
 		return $templateInfo;
 	}
 
+	/**
+	 * Recursively adds all partials that may be required to render the following
+	 * Mustache template
+	 *
+	 * @param $partials array Partials list (out reference)
+	 * @param $fileName string File path (absolute)
+	 * @return bool
+	 * @throws Exception Thrown if any partial cannot be found
+	 */
 	protected function addDependencies( &$partials, $fileName ) {
 		if ( !empty($partials[$fileName])) {
 			return true;
@@ -53,21 +85,82 @@ class MustacheService {
 		foreach ($templateInfo[self::INFO_DEPENDENCIES] as $depFileName) {
 			$this->addDependencies($partials,$depFileName);
 		}
+
 		return true;
 	}
 
-	public function render( $fileName, $data ) {
+	/**
+	 * Get a parsed data that is compatible with Mustache PHP extension
+	 * (it literally means resolving all objects and resources).
+	 *
+	 * All objects are converted to theirs string representatives except
+	 * instances of stdClass that get enumerated.
+	 *
+	 * All resources are converted to theirs string representatives.
+	 *
+	 * @param $data mixed Input data
+	 * @return mixed Parsed data that is safe to be submitted to Mustache PHP extension
+	 */
+	public function parseData( $data ) {
+		if ( is_array( $data )
+			|| is_object( $data ) && strtolower(get_class($data)) == 'stdclass'
+		) {
+			$res = array();
+			foreach ($data as $k => $v) {
+				$res[$k] = $this->parseData($v);
+			}
+		} else if ( is_bool($data) || is_int($data) || is_float($data) ) {
+			$res = $data;
+		} else {
+			$res = (string)$data;
+		}
+		return $res;
+	}
+
+	/**
+	 * Get a full list of partials that are required to correctly render given template
+	 *
+	 * @param $fileName string File path (absolute)
+	 * @return array List of partials
+	 * @throws Exception Thrown if any partial cannot be found
+	 */
+	public function getDependencies( $fileName ) {
 		$fileName = realpath($fileName);
 		$partials = array();
 		$this->addDependencies($partials,$fileName);
-		$template = $partials[$fileName];
 
-		var_dump($partials);
+		return $partials;
+	}
+
+	/**
+	 * Render given template using supplied data
+	 *
+	 * @param $fileName string Template file path (absolute)
+	 * @param $data array Data to be rendered
+	 * @return string Template output
+	 * @throws Exception Thrown if any partial cannot be found
+	 */
+	public function render( $fileName, $data ) {
+		$realFileName = realpath($fileName);
+		if ( empty( $realFileName ) ) {
+			throw new Exception("Template \"{$fileName}\" was not found.");
+		}
+		$partials = $this->getDependencies($realFileName);
+		$template = $partials[$realFileName];
+
+		// Note: php-mustache segfaults when objects are present in data
+		// so pre-process them before sending to renderer
+		$data = $this->parseData($data);
 
 		$mustache = new Mustache();
 		return $mustache->render($template,$data,$partials);
 	}
 
+	/**
+	 * Get a singleton instance of MustacheService
+	 *
+	 * @return MustacheService Singleton
+	 */
 	public static function getInstance() {
 		static $instance;
 		if ( empty( $instance ) ) {


### PR DESCRIPTION
This changeset enables us to use partials in Mustache templates in our codebase.
Partials are automatically scanned and prefetched before invoking Mustache renderer.
Partial names are resolved relative to currently processed file, so you can specify a relative path to partial (don't specify the .mustache extension as it's always appended), eg.:
- "item", "./item" - item.mustache in the same directory,
- "../item" - item.mustache in parent directory,
- "subdir/item", "./subdir/item" - item.mustache in subdirectory called "subdir".

In case of finding any unsatisfied dependency (partial file does not exist) it throws an exception.

@Wyvek @sebastian-wikia @owend @federico-lox You're welcome to review this code.
