### PR TITLE
merge security release:

### DIFF
--- a/RELEASE-NOTES-1.19
+++ b/RELEASE-NOTES-1.19
@@ -3,6 +3,17 @@
 Security reminder: MediaWiki does not require PHP's register_globals
 setting since version 1.2.0. If you have it on, turn it '''off''' if you can.
 
+== MediaWiki 1.19.5 ==
+
+This is a security and maintenance release of the MediaWiki 1.19 branch
+
+=== Changes since 1.19.4 ===
+* (bug 47251) SECURITY: Disable external entities in Import
+* (bug 46859) SECURITY: Disable external entities in XMLReader
+* (bug 46084) SECURITY: Sanitize $limitReport before outputting
+* (bug 43594) Fix notices displayed on PHP 5.4
+* (bug 40585) Don't drop 'step="any"' in HTML input fields.
+
 == MediaWiki 1.19.4 ==
 
 This is a maintenance release of the MediaWiki 1.19 branch

--- a/includes/DefaultSettings.php
+++ b/includes/DefaultSettings.php
@@ -33,7 +33,7 @@ $wgConf = new SiteConfiguration;
 /** @endcond */
 
 /** MediaWiki version number */
-$wgVersion = '1.19.4';
+$wgVersion = '1.19.5';
 
 /** Name of the site. It must be changed in LocalSettings.php */
 $wgSitename = 'MediaWiki';

--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -2225,7 +2225,7 @@ function wfSuppressWarnings( $end = false ) {
 			if( !defined( 'E_DEPRECATED' ) ) {
 				define( 'E_DEPRECATED', 8192 );
 			}
-			$originalLevel = error_reporting( E_ALL & ~( E_WARNING | E_NOTICE | E_USER_WARNING | E_USER_NOTICE | E_DEPRECATED | E_STRICT ) );
+			$originalLevel = error_reporting( E_ALL & ~( E_WARNING | E_NOTICE | E_USER_WARNING | E_USER_NOTICE | E_DEPRECATED | E_USER_DEPRECATED | E_STRICT ) );
 		}
 		++$suppressCount;
 	}

--- a/includes/Html.php
+++ b/includes/Html.php
@@ -434,7 +434,13 @@ class Html {
 			# server-side validation.  Opera is the only other implementation at
 			# this time, and has ugly UI, so just kill the feature entirely until
 			# we have at least one good implementation.
-			if ( in_array( $key, array( 'max', 'min', 'pattern', 'required', 'step' ) ) ) {
+
+			# As the default value of "1" for "step" rejects decimal
+			# numbers to be entered in 'type="number"' fields, allow
+			# the special case 'step="any"'.
+
+			if ( in_array( $key, array( 'max', 'min', 'pattern', 'required' ) ) ||
+				 $key === 'step' && $value !== 'any' ) {
 				continue;
 			}
 

--- a/includes/Import.php
+++ b/includes/Import.php
@@ -396,9 +396,15 @@ class WikiImporter {
 	 * Primary entry point
 	 */
 	public function doImport() {
+
+		// Calls to reader->read need to be wrapped in calls to
+		// libxml_disable_entity_loader() to avoid local file
+		// inclusion attacks (bug 46932).
+		$oldDisable = libxml_disable_entity_loader( true );
 		$this->reader->read();
 
 		if ( $this->reader->name != 'mediawiki' ) {
+			libxml_disable_entity_loader( $oldDisable );
 			throw new MWException( "Expected <mediawiki> tag, got ".
 				$this->reader->name );
 		}
@@ -437,6 +443,7 @@ class WikiImporter {
 			}
 		}
 
+		libxml_disable_entity_loader( $oldDisable );
 		return true;
 	}
 

--- a/includes/cache/FileCacheBase.php
+++ b/includes/cache/FileCacheBase.php
@@ -116,9 +116,12 @@ abstract class FileCacheBase {
 	 * @return string
 	 */
 	public function fetchText() {
-		// gzopen can transparently read from gziped or plain text
-		$fh = gzopen( $this->cachePath(), 'rb' );
-		return stream_get_contents( $fh );
+		if( $this->useGzip() ) {
+			$fh = gzopen( $this->cachePath(), 'rb' );
+			return stream_get_contents( $fh );
+		} else {
+			return file_get_contents( $this->cachePath() );
+		}
 	}
 
 	/**

--- a/includes/media/SVGMetadataExtractor.php
+++ b/includes/media/SVGMetadataExtractor.php
@@ -71,7 +71,12 @@ class SVGReader {
 		// Expand entities, since Adobe Illustrator uses them for xmlns 
 		// attributes (bug 31719). Note that libxml2 has some protection 
 		// against large recursive entity expansions so this is not as 
-		// insecure as it might appear to be.
+		// insecure as it might appear to be. However, it is still extremely
+		// insecure. It's necessary to wrap any read() calls with
+		// libxml_disable_entity_loader() to avoid arbitrary local file
+		// inclusion, or even arbitrary code execution if the expect
+		// extension is installed (bug 46859).
+		$oldDisable = libxml_disable_entity_loader( true );
 		$this->reader->setParserProperty( XMLReader::SUBST_ENTITIES, true );
 
 		$this->metadata['width'] = self::DEFAULT_WIDTH;
@@ -85,9 +90,11 @@ class SVGReader {
 			$this->read();
 		} catch( Exception $e ) {
 			wfRestoreWarnings();
+			libxml_disable_entity_loader( $oldDisable );
 			throw $e;
 		}
 		wfRestoreWarnings();
+		libxml_disable_entity_loader( $oldDisable );
 	}
 
 	/**
@@ -100,7 +107,7 @@ class SVGReader {
 	/**
 	 * Read the SVG
 	 */
-	public function read() {
+	protected function read() {
 		$keepReading = $this->reader->read();
 
 		/* Skip until first element */

--- a/includes/parser/Parser.php
+++ b/includes/parser/Parser.php
@@ -467,6 +467,11 @@ class Parser {
 				"Template argument size: {$this->mIncludeSizes['arg']}/$max bytes\n".
 				$PFreport;
 			wfRunHooks( 'ParserLimitReport', array( $this, &$limitReport ) );
+
+			// Sanitize for comment. Note '‐' in the replacement is U+2010,
+			// which looks much like the problematic '-'.
+			$limitReport = str_replace( array( '-', '&' ), array( '‐', '&amp;' ), $limitReport );
+
 			$text .= "\n<!-- \n$limitReport-->\n";
 		}
 		$this->mOutput->setText( $text );

--- a/tests/phpunit/includes/HtmlTest.php
+++ b/tests/phpunit/includes/HtmlTest.php
@@ -330,4 +330,16 @@ class HtmlTest extends MediaWikiTestCase {
 		);
 	}
 
+	public function testFormValidationBlacklist() {
+		$this->assertEmpty(
+			Html::expandAttributes( array( 'min' => 1, 'max' => 100, 'pattern' => 'abc', 'required' => true, 'step' => 2 ) ),
+			'Blacklist form validation attributes.'
+		);
+		$this->assertEquals(
+			' step="any"',
+			Html::expandAttributes( array( 'min' => 1, 'max' => 100, 'pattern' => 'abc', 'required' => true, 'step' => 'any' ) ),
+			"Allow special case 'step=\"any\"'."
+		);
+	}
+
 }


### PR DESCRIPTION
- (bug 47251) SECURITY: Disable external entities in Import
- (bug 46859) SECURITY: Disable external entities in XMLReader
- (bug 46084) SECURITY: Sanitize $limitReport before outputting
- (bug 43594) Fix notices displayed on PHP 5.4
- (bug 40585) Don't drop 'step="any"' in HTML input fields.
