### PR TITLE
(BugId:100844) Distorted tracking data for components used inside and outside of the editor

### DIFF
--- a/extensions/wikia/CategorySelect/js/CategorySelect.js
+++ b/extensions/wikia/CategorySelect/js/CategorySelect.js
@@ -716,18 +716,11 @@
 			}
 		},
 
-		track: (function() {
-			var config = {
-				action: Wikia.Tracker.ACTIONS.CLICK,
-				category: 'category-tool',
-				trackingMethod: 'both'
-			};
-
-			return function() {
-				var track = ( window.WikiaEditor && WikiaEditor.track ) || Wikia.Tracker.track;
-				track.apply( track, [ config ].concat( slice.call( arguments ) ) );
-			};
-		})()
+		track: Wikia.Tracker.buildTrackingFunction( Wikia.trackEditorComponent, {
+			action: Wikia.Tracker.ACTIONS.CLICK,
+			category: 'category-tool',
+			trackingMethod: 'both'
+		})
 	});
 
 	/**

--- a/extensions/wikia/VideoEmbedTool/js/VET.js
+++ b/extensions/wikia/VideoEmbedTool/js/VET.js
@@ -35,19 +35,11 @@
 	var VET_DEFAULT_WIDTH = 335;
 	var VET_thumbSize = VET_DEFAULT_WIDTH;	// variable that can change later, defaulted to DEFAULT
 
-	var VET_tracking = (function() {
-		var config = {
-				action: Wikia.Tracker.ACTIONS.CLICK,
-				category: 'vet',
-				trackingMethod: 'both'
-			},
-			slice = [].slice,
-			track = ( window.WikiaEditor && WikiaEditor.track ) || Wikia.Tracker.track;
-
-		return function() {
-			track.apply( track, [ config ].concat( slice.call( arguments ) ) );
-		};
-	})();
+	var VET_tracking = Wikia.Tracker.buildTrackingFunction( Wikia.trackEditorComponent, {
+		action: Wikia.Tracker.ACTIONS.CLICK,
+		category: 'vet',
+		trackingMethod: 'both'
+	});
 
 	// ajax call for 2nd screen (aka embed screen)
 	function VET_editVideo() {
@@ -238,14 +230,6 @@
 	}
 
 	function VET_show( options ) {
-		// Handle MiniEditor focus
-		// (BugId:18713)
-		if (window.WikiaEditor) {
-			var wikiaEditor = WikiaEditor.getInstance();
-			if(wikiaEditor.config.isMiniEditor) {
-				wikiaEditor.plugins.MiniEditor.hasFocus = true;
-			}
-		}
 
 		/* set options */
 		VET_options = options;
@@ -551,14 +535,8 @@
 
 		VET_loader.modal.closeModal();
 
-		// Handle MiniEditor focus
-		// (BugId:18713)
-		if (window.WikiaEditor) {
-			var wikiaEditor = WikiaEditor.getInstance();
-			if(wikiaEditor.config.isMiniEditor) {
-				wikiaEditor.editorFocus();
-				wikiaEditor.plugins.MiniEditor.hasFocus = false;
-			}
+		if ($.isFunction(VET_options.onClose)) {
+			VET_options.onClose();
 		}
 
 		UserLogin.refreshIfAfterForceLogin();

--- a/extensions/wikia/VideoEmbedTool/js/VET_WikiaEditor.js
+++ b/extensions/wikia/VideoEmbedTool/js/VET_WikiaEditor.js
@@ -5,35 +5,48 @@
 		var mode = 'create';
 		var embedPresets = {};
 		var exists = false;
-		
+
 		// Start on first or second screen of VET
 		var startPoint = 1;
-		
+
 		var element = false;
 		if (event && event.data && event.data.element) {
 			element = event.data.element;
 		}
-		
+
+		var onClose = null;
 		var triggeredFromRTE = event && event.type === 'rte';
 		if (triggeredFromRTE) {
+			var wikiaEditor = WikiaEditor.getInstance();
+
+			// Handle MiniEditor focus
+			if (wikiaEditor.config.isMiniEditor) {
+				wikiaEditor.plugins.MiniEditor.hasFocus = true;
+
+				onClose = function() {
+					wikiaEditor.editorFocus();
+					wikiaEditor.plugins.MiniEditor.hasFocus = false;
+				};
+			}
+
 			// get video from event data
 			if (element) {
 				// edit a video
 				mode = 'edit';
 				embedPresets = element.getData();
-				
+
 				if (!event.data.isPlaceholder) {
 					// "regular" video
 					$.extend(embedPresets, embedPresets.params);
 					delete embedPresets.params;
-					
+
 					startPoint = 2;
 				}
 			}
 		}
-		
+
 		var callback = null;
-		
+
 		if(mode === 'create') {
 			callback = function(embedData) {
 				var wikitag = $('#VideoEmbedTag').val();
@@ -62,26 +75,26 @@
 					if(element.hasClass('media-placeholder')) {
 						wikitext = embedData.wikitext;
 					} else {
-						
+
 						// generate wikitext
 						wikitext = '[[' + embedData.href;
-					
+
 						if (embedData.thumb) {
 							wikitext += '|thumb';
 						}
-					
+
 						if (embedData.align) {
 							wikitext += '|' + embedData.align;
 						}
-					
+
 						if (embedData.width) {
 							wikitext += '|' + embedData.width + 'px';
 						}
-					
+
 						if (embedData.caption) {
 							wikitext += '|' + embedData.caption;
 						}
-					
+
 						wikitext += ']]';
 					}
 					if (element) {
@@ -94,19 +107,19 @@
 						RTE.mediaEditor.addVideo(wikitext, embedData);
 					}
 				}
-				
 			};
 		}
-		
+
 		var options = {
-			embedPresets: embedPresets,
 			callbackAfterEmbed: callback,
+			embedPresets: embedPresets,
+			onClose: onClose,
 			startPoint: startPoint
 		};
-		
+
 		VET_loader.load(options);
 	}
-	
+
 	window.VET_WikiaEditor = VET_WikiaEditor;
 
 })(this, jQuery);

--- a/extensions/wikia/WikiaMiniUpload/js/WMU.js
+++ b/extensions/wikia/WikiaMiniUpload/js/WMU.js
@@ -1279,16 +1279,8 @@ var WMU_uploadCallback = {
 	}
 }
 
-var WMU_track = (function( Wikia, WikiaEditor ) {
-	var config = {
-			action: Wikia.Tracker.ACTIONS.CLICK,
-			category: 'photo-tool',
-			trackingMethod: 'both'
-		},
-		slice = [].slice,
-		track = ( WikiaEditor && WikiaEditor.track ) || Wikia.Tracker.track;
-
-	return function() {
-		track.apply( track, [ config ].concat( slice.call( arguments ) ) );
-	};
-})( window.Wikia, window.WikiaEditor );
+var WMU_track = Wikia.Tracker.buildTrackingFunction( Wikia.trackEditorComponent, {
+	action: Wikia.Tracker.ACTIONS.CLICK,
+	category: 'photo-tool',
+	trackingMethod: 'both'
+});

--- a/extensions/wikia/WikiaPhotoGallery/js/WikiaPhotoGallery.js
+++ b/extensions/wikia/WikiaPhotoGallery/js/WikiaPhotoGallery.js
@@ -2610,12 +2610,11 @@
 				slice = [].slice;
 
 			return function() {
-				var	track = ( window.WikiaEditor && WikiaEditor.track ) || Wikia.Tracker.track,
-					type = WikiaPhotoGallery.editor.gallery.type;
+				var	type = WikiaPhotoGallery.editor.gallery.type;
 
 				config.category = ( type == 3 ? 'slider' : type == 2 ? 'slideshow' : 'gallery' ) + '-tool';
 
-				track.apply( track, [ config ].concat( slice.call( arguments ) ) );
+				Wikia.trackEditorComponent.apply( null, [ config ].concat( slice.call( arguments ) ) );
 			};
 		})()
 	};

--- a/resources/wikia/modules/tracker.stub.js
+++ b/resources/wikia/modules/tracker.stub.js
@@ -78,8 +78,8 @@
 
 				return obj;
 			})(),
-			slice = [].slice,
-			spool = [];
+			spool = [],
+			slice = spool.slice;
 
 		/**
 		 * Stub method for queueing early tracking calls.
@@ -102,16 +102,24 @@
 		 *         label: 'myLabel'
 		 *     });
 		 *
-		 * @params {Object} defaults
-		 *         A key-value hash of parameters.
+		 * @param {Function} [trackingMethod]
+		 *        An optional tracking method to use instead of Wikia.Tracker.track.
+		 *
+		 * @param {Object} options
+		 *        A key-value hash of parameters.
+		 *
+		 * @param {...Object} [optionsN]
+		 *        Any number of additional hashes that will be merged into the first.
 		 *
 		 * @see The track method above for hash key information.
 		 */
-		function buildTrackingFunction() {
-			var args = slice.call( arguments );
+		function buildTrackingFunction( /* [ trackingMethod, ] options [ , ... optionsN ] */ ) {
+			var args = slice.call( arguments ),
+				trackingFunction = typeof args[ 0 ] === 'function' && args.shift();
 
 			return function() {
-				return Wikia.Tracker.track.apply( null, args.concat( slice.call( arguments ) ) );
+				var track = trackingFunction || Wikia.Tracker.track;
+				return track.apply( track, args.concat( slice.call( arguments ) ) );
 			};
 		}
 

--- a/skins/oasis/js/Tracking.js
+++ b/skins/oasis/js/Tracking.js
@@ -29,6 +29,26 @@ jQuery(function($){
 		}, e.data);
 	};
 
+	// For tracking components which are used inside and outside of the editor.
+	var trackEditorComponent = (function() {
+		var slice = Array.prototype.slice;
+
+		return function() {
+			var wikiaEditor = window.WikiaEditor && WikiaEditor.getInstance(),
+				track = Wikia.Tracker.track;
+
+			// Determine whether or not to track through the editor tracking method:
+			// - If an editor is present on the page and is not a MiniEditor, then it must be the main editor.
+			// - If an editor is present on the page and is a MiniEditor, make sure it currently has focus.
+			// - Otherwise, assume that we are not tracking through the editor.
+			if ( wikiaEditor && ( !wikiaEditor.config.isMiniEditor || wikiaEditor.plugins.MiniEditor.hasFocus ) ) {
+				track = WikiaEditor.track;
+			}
+
+			track.apply( track, slice.call( arguments ) );
+		};
+	})();
+
 	/** article **/
 
 	(function() {
@@ -616,4 +636,7 @@ jQuery(function($){
 			});
 		}
 	});
+
+	// Exports
+	Wikia.trackEditorComponent = trackEditorComponent;
 });


### PR DESCRIPTION
This pull request basically refines the logic used to determine whether a component should be tracked through the editor tracking method or the global, generic tracking method. In the process, the logic was also split out into it's own function (Wikia.trackEditorComponent) so that it won't have to be duplicated in several places. The basic logic is as follows:
- By default, use the global tracking function (Wikia.Tracker.track).
- If the editor object is present, check to see if it's a MiniEditor instance. If it's not, it must be the main editor, so track through wikiaEditor.track.
- If the editor object is present and it is a MiniEditor instance, make sure that the instance has focus. If it does, track it through wikiaEditor.track, otherwise use the global tracking function.

I'm not sure that's the best name or place for that function, if you have any suggestions let me know.
