### PR TITLE
bugid:101492 fixing gallery images with external links

### DIFF
--- a/extensions/wikia/Lightbox/js/LightboxLoader.js
+++ b/extensions/wikia/Lightbox/js/LightboxLoader.js
@@ -61,14 +61,18 @@ var LightboxLoader = {
 		article.add(photos).add(videos).add(comments)
 			.off('.lightbox')
 			.on('click.lightbox', '.lightbox, a.image', function(e) {
-				//LightboxLoader.handleClick(e, $(this));
-				e.preventDefault();
 
 				var $this = $(this),
 					$thumb = $this.children('img').first(),
 					fileKey = $thumb.attr('data-image-key') || $thumb.attr('data-video-key'),
 					parent,
 					isVideo;
+
+				if($this.hasClass('link-internal')) {
+					return;
+				}
+
+				e.preventDefault();
 
 				if($this.closest(article).length) {
 					parent = article;

--- a/extensions/wikia/WikiaPhotoGallery/WikiaPhotoGallery.class.php
+++ b/extensions/wikia/WikiaPhotoGallery/WikiaPhotoGallery.class.php
@@ -804,11 +804,15 @@ class WikiaPhotoGallery extends ImageGallery {
 				if (!is_object($fileObject) || ($imageTitle->getNamespace() != NS_FILE)) {
 					$image['linkTitle'] = $image['titleText'] = $imageTitle->getText();
 					$image['thumbnail'] = false;
+					$image['DBKey'] = false;
+					$image['fileTitle'] = false;
 					$image['link'] = Skin::makeSpecialUrl("Upload", array( 'wpDestFile' => $image['linkTitle'] ) );
 					$image['classes'] = 'image broken-image accent new';
 				} else {
 					$thumbParams = WikiaPhotoGalleryHelper::getThumbnailDimensions($fileObject, $thumbSize, $height, $crop);
 					$image['thumbnail'] = $fileObject->createThumb($thumbParams['width'], $thumbParams['height']);
+					$image['DBKey'] = $fileObject->getTitle()->getDBKey();
+					$image['fileTitle'] = $fileObject->getTitle()->getText();
 
 					$image['height'] = ($orientation == 'none') ? $heights[$index] : min($thumbParams['height'], $height);
 					$imgHeightCompensation = ($height - $image['height']) / 2;
@@ -885,7 +889,7 @@ class WikiaPhotoGallery extends ImageGallery {
 
 				if (!empty($image['thumbnail'])) {
 					$isVideo = WikiaFileHelper::isFileTypeVideo( $fileObject );
-					
+
 					if ( $isVideo ) {
 						$thumbHtml = WikiaFileHelper::videoPlayButtonOverlay( $image['width'], $image['height'] );
 						$videoOverlay = WikiaFileHelper::videoInfoOverlay( $image['width'], $image['linkTitle'] );
@@ -906,11 +910,11 @@ class WikiaPhotoGallery extends ImageGallery {
 					);
 
 					if ( $isVideo ) {
-						$imgAttribs['data-video-name'] = htmlspecialchars($image['linkTitle']);
-						$imgAttribs['data-video-key'] = urlencode(htmlspecialchars($image['linkTitle']));
+						$imgAttribs['data-video-name'] = htmlspecialchars($image['fileTitle']);
+						$imgAttribs['data-video-key'] = urlencode(htmlspecialchars($image['DBKey']));
 					} else {
-						$imgAttribs['data-image-name'] = htmlspecialchars($image['linkTitle']);	
-						$imgAttribs['data-image-key'] = urlencode(htmlspecialchars($image['linkTitle']));	
+						$imgAttribs['data-image-name'] = htmlspecialchars($image['fileTitle']);
+						$imgAttribs['data-image-key'] = urlencode(htmlspecialchars($image['DBKey']));
 					}
 
 					if ( !empty($image['data-caption']) ) {

--- a/extensions/wikia/WikiaPhotoGallery/WikiaPhotoGallery.class.php
+++ b/extensions/wikia/WikiaPhotoGallery/WikiaPhotoGallery.class.php
@@ -804,8 +804,6 @@ class WikiaPhotoGallery extends ImageGallery {
 				if (!is_object($fileObject) || ($imageTitle->getNamespace() != NS_FILE)) {
 					$image['linkTitle'] = $image['titleText'] = $imageTitle->getText();
 					$image['thumbnail'] = false;
-					$image['DBKey'] = false;
-					$image['fileTitle'] = false;
 					$image['link'] = Skin::makeSpecialUrl("Upload", array( 'wpDestFile' => $image['linkTitle'] ) );
 					$image['classes'] = 'image broken-image accent new';
 				} else {


### PR DESCRIPTION
https://wikia.fogbugz.com/default.asp?101492#646341

Couple things were happening that should now be fixed:

1) Clicking on gallery images with specified links opened the lightbox whereas it should have navigated the user to the linked page
2) When linked gallery images appeared in the Lightbox carousel, the link location was getting mixed up with the link location so the image was showing as not found. 
