### PR TITLE
DAR-87: fix photo tool checkbox alignment events.

### DIFF
--- a/extensions/wikia/WikiaMiniUpload/js/WMU.js
+++ b/extensions/wikia/WikiaMiniUpload/js/WMU.js
@@ -117,18 +117,6 @@ function WMU_loadDetails() {
 
 		$('#ImageUploadBack').hide();
 
-		$('#ImageUploadLayoutLeft').on('click', function() {
-			WMU_track({
-				label: 'checkbox-alignment-left'
-			});
-		});
-
-		$('#ImageUploadLayoutRight').on('click', function() {
-			WMU_track({
-				label: 'checkbox-alignment-right'
-			});
-		});
-
 		setTimeout(function() {
 			// FIXME: FCK is mocked here so this code would still work even though we're not using FCK anymore
 			if(!FCK.wysiwygData[WMU_refid].thumb) {
@@ -778,6 +766,18 @@ function WMU_displayDetails(responseText) {
 	$('#ImageUpload' + WMU_curScreen).html(responseText);
 
 	$('#ImageUploadLicense').bind('change', WMU_licenseSelectorCheck);
+
+	$('#ImageUploadLayoutLeft').on('click', function() {
+		WMU_track({
+			label: 'checkbox-alignment-left'
+		});
+	});
+
+	$('#ImageUploadLayoutRight').on('click', function() {
+		WMU_track({
+			label: 'checkbox-alignment-right'
+		});
+	});
 
 	// If Details view and showhide link exists, adjust the height of the right sidebar
 	$('#WMU_showhide').click(function(event) {


### PR DESCRIPTION
These events were not working, now they are.
