### PR TITLE
DAR-86: fix hanging hyphen when there is no label.

### DIFF
--- a/extensions/wikia/EditPageLayout/js/plugins/Tracker.js
+++ b/extensions/wikia/EditPageLayout/js/plugins/Tracker.js
@@ -129,7 +129,10 @@
 			delete data.category;
 
 			// Update label
-			labelParts.push( data.label );
+			if ( data.label != undefined && data.label != '' ) {
+				labelParts.push( data.label );
+			}
+
 			data.label = labelParts.join( '-' );
 
 			Wikia.Tracker.track( this.config, data );


### PR DESCRIPTION
Fixes cases where events would be tracked like: 'editor-mini-ck/photo-tool-/' (now it will track correctly as 'editor-mini-ck/photo-tool/').
