### PR TITLE
PLA-119 -- fix grouping data population for wikis missing wgSitename

### DIFF
--- a/extensions/wikia/Search/classes/ResultSet/Grouping.php
+++ b/extensions/wikia/Search/classes/ResultSet/Grouping.php
@@ -74,11 +74,11 @@ class Grouping extends Base
 		$doc = end( $this->results ); // there's only one
 		$wikiId = $doc['wid'];
 		$wikiId = $wikiId ?: $this->service->getWikiIdByHost( $this->host );
+		$title = $this->service->getGlobalForWiki( 'wgSitename', $wikiId );
 		if (! empty( $doc ) ) {
 			$this->addHeaders( $doc->getFields() );
+			$title = $title ?: $doc[Utilities::field( 'wikititle' )]; // apparently wgSitename can be false for some wiki IDs
 		}
-		$title = $this->service->getGlobalForWiki( 'wgSitename', $wikiId );
-		$title = $title ?: $doc[Utilities::field( 'wikititle' )]; // apparently wgSitename can be false for some wiki IDs
 		$this->addHeaders( $this->service->getVisualizationInfoForWikiId( $wikiId ) )
 			 ->addHeaders( $this->service->getStatsInfoForWikiId( $wikiId ) )
 			 ->setHeader ( 'wikititle', $title )

--- a/extensions/wikia/Search/classes/ResultSet/Grouping.php
+++ b/extensions/wikia/Search/classes/ResultSet/Grouping.php
@@ -3,7 +3,7 @@
  * Class definition for Wikia\Search\ResultSet\Grouping
  */
 namespace Wikia\Search\ResultSet;
-use \Wikia\Search\MediaWikiService, \ArrayIterator, \Solarium_Result_Select, \Wikia\Search\Config;
+use \Wikia\Search\MediaWikiService, \ArrayIterator, \Solarium_Result_Select, \Wikia\Search\Config, Wikia\Search\Utilities;
 /**
  * This class handles sub-groupings of results for inter-wiki search.
  * @author relwell
@@ -78,6 +78,7 @@ class Grouping extends Base
 			$this->addHeaders( $doc->getFields() );
 		}
 		$title = $this->service->getGlobalForWiki( 'wgSitename', $wikiId );
+		$title = $title ?: $doc[Utilities::field( 'wikititle' )]; // apparently wgSitename can be false for some wiki IDs
 		$this->addHeaders( $this->service->getVisualizationInfoForWikiId( $wikiId ) )
 			 ->addHeaders( $this->service->getStatsInfoForWikiId( $wikiId ) )
 			 ->setHeader ( 'wikititle', $title )

--- a/extensions/wikia/Search/classes/Test/ResultSet/GroupingTest.php
+++ b/extensions/wikia/Search/classes/Test/ResultSet/GroupingTest.php
@@ -406,6 +406,117 @@ class GroupingTest extends Wikia\Search\Test\BaseTest
 		$this->resultSet
 		    ->expects( $this->at( 6 ) )
 		    ->method ( 'getDescription' )
+		    ->will   ( $this->returnValue( "we already got a descriptiopn" ) )
+		;
+		$this->service
+		    ->expects( $this->never() )
+		    ->method ( 'getSimpleMessage' )
+		;
+		$conf = new ReflectionMethod( 'Wikia\Search\ResultSet\Grouping', 'configureHeaders' );
+		$conf->setAccessible( true );
+		$this->assertEquals(
+				$this->resultSet,
+				$conf->invoke( $this->resultSet )
+		);
+	}
+	
+	/**
+	 * @covers Wikia\Search\ResultSet\Grouping::configureHeaders
+	 */
+	public function testConfigureHeadersWithDegenerateCases() {
+		$mockResult = $this->getMock( 'Wikia\Search\Result', array( 'offsetGet', 'getFields' ) );
+		$results = new \ArrayIterator( array( $mockResult ) );
+		$this->prepareMocks( array( 'addHeaders', 'setHeader', 'getHeader', 'getDescription' ), array(), array(), array( 'getSimpleMessage', 'getWikiIdByHost', 'getStatsInfoForWikiId', 'getVisualizationInfoForWikiId', 'getGlobalForWiki', 'getHubForWikiId' ) );
+		$fields = array( 'id' => 123 );
+		$vizInfo = array( 'description' => 'yup' );
+		$mockResult
+		    ->expects( $this->at( 0 ) )
+		    ->method ( 'offsetGet' )
+		    ->with   ( 'wid' )
+		    ->will   ( $this->returnValue( 123 ) )
+		;
+		$resultsRefl = new ReflectionProperty( 'Wikia\Search\ResultSet\Grouping', 'results' );
+		$resultsRefl->setAccessible( true );
+		$resultsRefl->setValue( $this->resultSet, $results );
+		$mockResult
+		    ->expects( $this->at( 1 ) )
+		    ->method ( 'getFields' )
+		    ->will   ( $this->returnValue( array( 'id' => 123 ) ) )
+		;
+		$this->service
+		    ->expects( $this->at( 1 ) )
+		    ->method ( 'getVisualizationInfoForWikiId' )
+		    ->with   ( 123 )
+		    ->will   ( $this->returnValue( $vizInfo ) )
+		;
+		$this->service
+		    ->expects( $this->at( 2 ) )
+		    ->method ( 'getStatsInfoForWikiId' )
+		    ->with   ( 123 )
+		    ->will   ( $this->returnValue( array( 'users_count' => 100 ) ) )
+		;
+		$mockResult
+		    ->expects( $this->once() )
+		    ->method ( 'getFields' )
+		    ->will   ( $this->returnValue( $fields ) )
+		;
+		$this->resultSet
+		    ->expects( $this->at( 0 ) )
+		    ->method ( 'addHeaders' )
+		    ->with   ( $fields )
+		    ->will   ( $this->returnValue( $this->resultSet ) )
+		;
+		$this->resultSet
+		    ->expects( $this->at( 1 ) )
+		    ->method ( 'addHeaders' )
+		    ->with   ( $vizInfo )
+		    ->will   ( $this->returnValue( $this->resultSet ) )
+		;
+		$this->resultSet
+		    ->expects( $this->at( 2 ) )
+		    ->method ( 'addHeaders' )
+		    ->with   ( array( 'users_count' => 100 ) )
+		    ->will   ( $this->returnValue( $this->resultSet ) )
+		;
+		$this->service
+		    ->expects( $this->any() )
+		    ->method ( 'getGlobalForWiki' )
+		    ->with   ( 'wgSitename', 123 )
+		    ->will   ( $this->returnValue( false ) )
+	    ;
+		$mockResult
+		    ->expects( $this->at( 2 ) )
+		    ->method ( 'offsetGet' )
+		    ->with   ( \Wikia\Search\Utilities::field( 'wikititle' ) )
+		    ->will   ( $this->returnValue( "my title" ) )
+		;
+		$this->resultSet
+		    ->expects( $this->at( 3 ) )
+		    ->method ( 'setHeader' )
+		    ->with   ( "wikititle", "my title" )
+		    ->will   ( $this->returnValue( $this->resultSet ) )
+		;
+		$this->service
+		    ->expects( $this->any() )
+		    ->method ( 'getHubForWikiId' )
+		    ->with   ( 123 )
+		    ->will   ( $this->returnValue( "Edutainment" ) )
+		;
+		$this->resultSet
+		    ->expects( $this->at( 4 ) )
+		    ->method ( 'setHeader' )
+		    ->with   ( "title", "my title" )
+		    ->will   ( $this->returnValue( $this->resultSet ) )
+		;
+		$this->resultSet
+		    ->expects( $this->at( 5 ) )
+		    ->method ( 'setHeader' )
+		    ->with   ( "hub", "Edutainment" )
+		    ->will   ( $this->returnValue( $this->resultSet ) )
+		;
+		$this->resultSet
+		    ->expects( $this->at( 6 ) )
+		    ->method ( 'getDescription' )
 		    ->will   ( $this->returnValue( "" ) )
 		;
 		$this->service


### PR DESCRIPTION
This fixes an issue where a search result missing the wgSitename value is also missing the wiki title value required to display the result.
