### PR TITLE
additional logging for wall/forum bug 95249

### DIFF
--- a/extensions/wikia/Wall/WallExternalController.class.php
+++ b/extensions/wikia/Wall/WallExternalController.class.php
@@ -529,18 +529,23 @@ class WallExternalController extends WikiaController {
 		
 	public function replyToMessage() {
 		$this->response->setVal('status', true);
-		
-		$parentTitle = F::build('Title', array( $this->request->getVal('parent') ), 'newFromId');
+
+		$parentId = $this->request->getVal('parent');
+		$parentTitle = F::build('Title', array( $parentId ), 'newFromId');
+		$debugParentDB = 'from slave';   // tracing bug 95249
 
 		if(empty($parentTitle)) {
 			// try again from master
-			$parentTitle = F::build('Title', array( $this->request->getVal('parent'), Title::GAID_FOR_UPDATE ), 'newFromId');
+			$parentTitle = F::build('Title', array( $parentId, Title::GAID_FOR_UPDATE ), 'newFromId');
+			$debugParentDB = 'from master';
 		}
-		
+
 		if(empty($parentTitle)) {
 			$this->response->setVal('status', false);
 			return true;
 		}
+
+		Wikia::log( 'Wall::replyToMessage for parent ' . $parentTitle->getFullUrl() . ' (parentId: ' . $parentId . ') ' . $debugParentDB );
 
 		/**
 		 * @var $wallMessage WallMessage
@@ -568,7 +573,7 @@ class WallExternalController extends WikiaController {
 		 * @var $wn WallNotifications
 		 */
 		$wn = F::build('WallNotifications', array());
-		$wn->markRead( $this->wg->User->getId(), $this->wg->CityId, $this->request->getVal('parent'));		
+		$wn->markRead( $this->wg->User->getId(), $this->wg->CityId, $this->request->getVal('parent'));
 		
 	}
 	


### PR DESCRIPTION
Added full tracing of wall/forum reply requests. Right now the articles for comments are created, but entries in comments_index are missing. I will parse the logs next week and try to see what's happening there.
