### PR TITLE
Fix WAM Page

### DIFF
--- a/extensions/wikia/WAM/controllers/api/WAMApiController.class.php
+++ b/extensions/wikia/WAM/controllers/api/WAMApiController.class.php
@@ -175,7 +175,7 @@ class WAMApiController extends WikiaApiController {
 			$options['currentTimestamp'] = $wamDates['max_date'];
 			$options['previousTimestamp'] = $options['currentTimestamp'] - 60 * 60 * 24;
 		} else {
-			if($options['currentTimestamp'] > $wamDates['max_date'] || $options['currentTimestamp'] <= $wamDates['min_date']) {
+			if($options['currentTimestamp'] > $wamDates['max_date'] || $options['currentTimestamp'] < $wamDates['min_date']) {
 				throw new OutOfRangeApiException('currentTimestamp', $wamDates['min_date'], $wamDates['max_date']);
 			}
 
@@ -187,8 +187,8 @@ class WAMApiController extends WikiaApiController {
 				}
 			}
 
-			if($options['previousTimestamp'] >= $wamDates['max_date'] || $options['previousTimestamp'] < $wamDates['min_date']) {
-				throw new OutOfRangeApiException('previousTimestamp', $wamDates['min_date'], $wamDates['max_date']);
+			if($options['previousTimestamp'] > $wamDates['max_date']) {
+				throw new OutOfRangeApiException('previousTimestamp', 0, $wamDates['max_date']);
 			}
 		}
 

--- a/extensions/wikia/WAM/controllers/api/WAMApiController.class.php
+++ b/extensions/wikia/WAM/controllers/api/WAMApiController.class.php
@@ -176,10 +176,7 @@ class WAMApiController extends WikiaApiController {
 			$options['previousTimestamp'] = $options['currentTimestamp'] - 60 * 60 * 24;
 		} else {
 			if($options['currentTimestamp'] > $wamDates['max_date'] || $options['currentTimestamp'] <= $wamDates['min_date']) {
-				//throw new OutOfRangeApiException('currentTimestamp', $wamDates['min_date'], $wamDates['max_date']);
-				//fall back to previous day BugId: 101530
-				$options['currentTimestamp'] = $options['previousTimestamp'];
-				$options['previousTimestamp'] = $options['previousTimestamp'] - 60 * 60 * 24;
+				throw new OutOfRangeApiException('currentTimestamp', $wamDates['min_date'], $wamDates['max_date']);
 			}
 
 			if(empty($options['previousTimestamp'])) {

--- a/extensions/wikia/WAMPage/models/WAMPageModel.class.php
+++ b/extensions/wikia/WAMPage/models/WAMPageModel.class.php
@@ -118,6 +118,11 @@ class WAMPageModel extends WikiaModel {
 		$dates = $this->app->sendRequest('WAMApi', 'getMinMaxWamIndexDate')->getData();
 		if (isset($dates['min_max_dates'])) {
 			$dates = $dates['min_max_dates'];
+
+			// Set min date as next day, because we don't have previous data
+			if (!empty($dates['min_date'])) {
+				$dates['min_date'] += 60 * 60 * 24;
+			}
 		} else {
 			$dates = [
 				'min_date' => null,

--- a/extensions/wikia/WAMPage/models/WAMPageModel.class.php
+++ b/extensions/wikia/WAMPage/models/WAMPageModel.class.php
@@ -306,24 +306,15 @@ class WAMPageModel extends WikiaModel {
 	protected function getVisualizationParams($verticalId = null, $sortColumn = 'wam_index') {
 		$params = [
 			'vertical_id' => $verticalId,
-			'sort_column' => $sortColumn
-		];
-
-		return array_merge($params, $this->getDefaultParams());
-	}
-
-	protected function getDefaultParams() {
-		$lastDay = strtotime('00:00');
-
-		return [
-			'wam_day' => $lastDay,
-			'wam_previous_day' => strtotime('-1 day', $lastDay),
+			'sort_column' => $sortColumn,
 			'limit' => $this->getVisualizationItemsCount(),
 			'sort_direction' => 'DESC',
 			'wiki_image_height' => self::VISUALIZATION_ITEM_IMAGE_HEIGHT,
 			'wiki_image_width' => self::VISUALIZATION_ITEM_IMAGE_WIDTH,
 			'fetch_wiki_images' => true,
 		];
+
+		return $params;
 	}
 
 	/**


### PR DESCRIPTION
https://wikia.fogbugz.com/default.asp?101544
https://wikia.fogbugz.com/default.asp?101530
https://wikia.fogbugz.com/default.asp?101459

WamPage extension should not specify exact date that data should come from. We need most recent data and this fix changes it.
Also fixed problem with 2nd january 2012 where we don't have previous data and we are not able to compute wam change (up or down) so with PO we decided to not display data for this date.

@owend @sebastian-wikia @lukaszkonieczny 
