### PR TITLE
PLA-172 rewrite video title search using edismax

### DIFF
--- a/extensions/wikia/Search/WikiaSearchController.class.php
+++ b/extensions/wikia/Search/WikiaSearchController.class.php
@@ -134,6 +134,7 @@ class WikiaSearchController extends WikiaSpecialPageController {
 			throw new Exception( "Please include a value for 'title'." );
 		}
 		$searchConfig
+		    ->setMinimumMatch( $this->getVal( 'mm', '75%' ) )
 		    ->setVideoTitleSearch( true )
 		    ->setQuery( $title );
 		$this->getResponse()->setFormat( 'json' );

--- a/extensions/wikia/Search/classes/QueryService/Select/VideoTitle.php
+++ b/extensions/wikia/Search/classes/QueryService/Select/VideoTitle.php
@@ -3,21 +3,47 @@
  * Class definition for Wikia\Search\QueryService\Select\VideoTitle
  */
 namespace Wikia\Search\QueryService\Select;
+use Solarium_Query_Select;
 /**
  * This class is designed to provide search results based on the title of a video.
  * @see WikiaSearchController::searchVideosByTitle for example usage.
  * @author relwell
  */
-class VideoTitle extends Lucene
+class VideoTitle extends AbstractSelect
 {
 	/**
-	 * Given a search query (which is the title of a video), the video wiki for videos 
-	 * (non-PHPdoc)
-	 * @see \Wikia\Search\QueryService\Select\AbstractSelect::getQueryClausesString()
-	 * @return string
+	 * Totally short-circuits how we do select queries
+	 * @return \Solarium_Query_Select
 	 */
-	protected function getFormulatedQuery() {
-		$query = $this->config->getQuery();
-		return sprintf( 'wid:%s AND ns:6 AND ( title_en:(%s) OR nolang_txt:(%s) )', Video::VIDEO_WIKI_ID, $query, $query );
+	protected function getSelectQuery() {
+		$query = $this->client->createSelect();
+		$query->setDocumentClass( '\Wikia\Search\Result' );
+		
+		$dismax = $query->getDisMax();
+		$dismax->setQueryParser( 'edismax' )
+		       ->setQueryFields( $this->getQueryFieldsString() )
+		       ->setMinimumMatch( $this->config->getMinimumMatch() )
+		;
+		$query->setQuery( "(wid:%1% AND ns:6 AND categories_mv_en:%2%) AND (%3%)", 
+				[
+						Video::VIDEO_WIKI_ID,
+						$this->service->getHubForWikiId( $this->service->getWikiId() ),
+						$this->config->getQuery()->getSanitizedQuery()
+				] );
+		
+		return $query;
+	}
+	
+	/**
+	 * To heck with it, we need to get rid of this anyway.
+	 * (non-PHPdoc)
+	 * @see \Wikia\Search\QueryService\Select\AbstractSelect::getFormulatedQuery()
+	 */
+	public function getFormulatedQuery() {
+		return '';
+	}
+	
+	protected function getQueryFieldsString() {
+		return 'title_en^5 nolang_txt';
 	}
 }

--- a/extensions/wikia/Search/classes/Test/Controller/SearchControllerTest.php
+++ b/extensions/wikia/Search/classes/Test/Controller/SearchControllerTest.php
@@ -1608,7 +1608,7 @@ class SearchControllerTest extends Wikia\Search\Test\BaseTest {
 	 * @covers WikiaSearchController::searchVideosByTitle
 	 */
 	public function testSearchVideosByTitle() {
-		$mockConfig		=	$this->getMock( 'Wikia\Search\Config', array( 'setVideoTitleSearch', 'setQuery' ) );
+		$mockConfig		=	$this->getMock( 'Wikia\Search\Config', array( 'setVideoTitleSearch', 'setQuery', 'setMinimumMatch' ) );
 		$mockController	=	$this->searchController->setMethods( array( 'getResponse', 'getVal' ) )->getMock();
 		$mockSearch		=	$this->getMockBuilder( 'Wikia\Search\QueryService\Select\VideoTitle' )
 								->setMethods( array( 'searchAsApi' ) )
@@ -1650,14 +1650,26 @@ class SearchControllerTest extends Wikia\Search\Test\BaseTest {
 			->with		( 'title' )
 			->will		( $this->returnValue( 'title' ) )
 		;
+		$mockController
+			->expects	( $this->at( 1 ) )
+			->method	( 'getVal' )
+			->with		( 'mm', '75%' )
+			->will		( $this->returnValue( '80%' ) )
+		;
 		$mockConfig
 			->expects	( $this->at( 0 ) )
+			->method	( 'setMinimumMatch' )
+			->with		( '80%' )
+			->will		( $this->returnValue( $mockConfig ) )
+		;
+		$mockConfig
+			->expects	( $this->at( 1 ) )
 			->method	( 'setVideoTitleSearch' )
 			->with		( true )
 			->will		( $this->returnValue( $mockConfig ) )
 		;
 		$mockConfig
-			->expects	( $this->at( 1 ) )
+			->expects	( $this->at( 2 ) )
 			->method	( 'setQuery' )
 			->with		( 'title' )
 			->will		( $this->returnValue( $mockConfig ) )

--- a/extensions/wikia/Search/classes/Test/QueryService/Select/VideoTitleTest.php
+++ b/extensions/wikia/Search/classes/Test/QueryService/Select/VideoTitleTest.php
@@ -11,28 +11,112 @@ use Wikia\Search\Test\BaseTest, ReflectionMethod, Wikia\Search\QueryService\Depe
 class VideoTitleTest extends BaseTest
 {
 	/**
-	 * @covers Wikia\Search\QueryService\Select\VideoTitle::getFormulatedQuery
+	 * @covers Wikia\Search\QueryService\VideoTitle
 	 */
-	public function testGetFormulatedQuery() {
-		$mockConfig = $this->getMock( 'Wikia\Search\Config', array( 'getQuery' ) );
-		$dc = new DependencyContainer( array( 'config' => $mockConfig ) );
-		$mockSelect = $this->getMockBuilder( 'Wikia\Search\QueryService\Select\VideoTitle' )
-		                   ->setConstructorArgs( array( $dc ) )
-		                   ->setMethods( null )
+	public function testGetSelectQuery() {
+		$mockClient = $this->getMockBuilder( 'Solarium_Client' )
+		                   ->disableOriginalConstructor()
+		                   ->setMethods( [ 'createSelect' ] )
 		                   ->getMock();
 		
-		$videoTitle ='my video title';
+		$mockSolariumQuery = $this->getMockBuilder( 'Solarium_Query_Select' )
+		                          ->disableOriginalConstructor()
+		                          ->setMethods( [ 'setDocumentClass', 'getDismax', 'setQuery' ] )
+		                          ->getMock();
 		
+		$mockDismax = $this->getMockBuilder( 'Solarium_Query_Select_Component_Dismax' )
+		                   ->disableOriginalConstructor()
+		                   ->setMethods( [ 'setQueryParser', 'setQueryFields', 'setMinimumMatch' ] )
+		                   ->getMock();
+		
+		$mockService = $this->getMock( 'Wikia\Search\MediaWikiService', [ 'getHubForWikiId', 'getWikiId' ] );
+		
+		$mockConfig = $this->getMock( 'Wikia\Search\Config', [ 'getMinimumMatch', 'getQuery' ] );
+
+		$dc = new \Wikia\Search\QueryService\DependencyContainer( [ 'client' => $mockClient, 'service' => $mockService, 'config' => $mockConfig ] );
+		
+		$mockSelect = $this->getMockBuilder( 'Wikia\Search\QueryService\Select\VideoTitle' )
+		                   ->setConstructorArgs( [ $dc ] )
+		                   ->setMethods( [ 'getQueryFieldsString' ] )
+		                   ->getMock();
+		
+		$mockQuery = $this->getMock( 'Wikia\Search\Query\Select', [ 'getSanitizedQuery' ], [ 'foo' ] );
+		
+		$mockClient
+		    ->expects( $this->once() )
+		    ->method ( 'createSelect' )
+		    ->will   ( $this->returnValue( $mockSolariumQuery ) )
+		;
+		$mockSolariumQuery
+		    ->expects( $this->once() )
+		    ->method ( 'setDocumentClass' )
+		    ->with   ( '\Wikia\Search\Result' )
+		;
+		$mockSolariumQuery
+		    ->expects( $this->once() )
+		    ->method ( 'getDismax' )
+		    ->will   ( $this->returnValue( $mockDismax ) )
+		;
+		$mockDismax
+		    ->expects( $this->once() )
+		    ->method ( 'setQueryParser' )
+		    ->with   ( 'edismax' )
+		    ->will   ( $this->returnValue( $mockDismax ) )
+		;
+		$mockSelect
+		    ->expects( $this->once() )
+		    ->method ( 'getQueryFieldsString' )
+		    ->will   ( $this->returnValue( 'title_en^5 nolang_txt' ) )
+		;
+		$mockDismax
+		    ->expects( $this->once() )
+		    ->method ( 'setQueryFields' )
+		    ->with   ( 'title_en^5 nolang_txt' )
+		    ->will   ( $this->returnValue( $mockDismax ) )
+		;
+		$mockConfig
+		    ->expects( $this->once() )
+		    ->method ( 'getMinimumMatch' )
+		    ->will   ( $this->returnValue( '80%' ) )
+		;
+		$mockDismax
+		    ->expects( $this->once() )
+		    ->method ( 'setMinimumMatch' )
+		    ->with   ( '80%' )
+		;
+		$mockService
+		    ->expects( $this->once() )
+		    ->method ( 'getWikiId' )
+		    ->will   ( $this->returnValue( 123 ) )
+		;
+		$mockService
+		    ->expects( $this->once() )
+		    ->method ( 'getHubForWikiId' )
+		    ->with   ( 123 )
+		    ->will   ( $this->returnValue( 'Entertainment' ) ) 
+		;
 		$mockConfig
 		    ->expects( $this->once() )
 		    ->method ( 'getQuery' )
-		    ->will   ( $this->returnValue( $videoTitle ) )
+		    ->will   ( $this->returnValue( $mockQuery ) )
 		;
-		$method = new ReflectionMethod( 'Wikia\Search\QueryService\Select\VideoTitle', 'getFormulatedQuery' );
-		$method->setAccessible( true );
+		$mockQuery
+		    ->expects( $this->once() )
+		    ->method ( 'getSanitizedQuery' )
+		    ->will  ( $this->returnValue( 'foo' ) )
+		;
+		$params = [ \Wikia\Search\QueryService\Select\Video::VIDEO_WIKI_ID, 'Entertainment', 'foo' ];
+		$mockSolariumQuery
+		    ->expects( $this->once() )
+		    ->method ( 'setQuery' )
+		    ->with   ( "(wid:%1% AND ns:6 AND categories_mv_en:%2%) AND (%3%)", $params )
+		;
+		$getSelect = new ReflectionMethod( 'Wikia\Search\QueryService\Select\VideoTitle', 'getSelectQuery' );
+		$getSelect->setAccessible( true );
 		$this->assertEquals(
-				sprintf( 'wid:%s AND ns:6 AND ( title_en:(%s) OR nolang_txt:(%s) )', Video::VIDEO_WIKI_ID, $videoTitle, $videoTitle ),
-				$method->invoke( $mockSelect )
+				$mockSolariumQuery,
+				$getSelect->invoke( $mockSelect )
 		);
 	}
+	
 }

--- a/maintenance/wikia/VideoHandlers/singleTitleSearch.php
+++ b/maintenance/wikia/VideoHandlers/singleTitleSearch.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Try to find matches in our video library for a title or youtube URLs
+ *
+ * @author garth@wikia-inc.com
+ * @ingroup Maintenance
+ */
+
+ini_set('display_errors', 'stderr');
+
+require_once( dirname( __FILE__ ) . '/../../Maintenance.php' );
+
+class EditCLI extends Maintenance {
+	public function __construct() {
+		parent::__construct();
+		$this->mDescription = "Try to match youtube tags in the wiki with premium video";
+		$this->addOption( 'title', 'Title', false, true, 't' );
+		$this->addOption( 'url', 'URL', false, true, 't' );
+		$this->addOption( 'verbose', 'Verbose', false, false, 'v' );
+	}
+
+	public function execute() {
+
+		// See if we have a one off title search
+		$youtube_title = $this->getOption( 'title' );
+		$url = $this->getOption( 'url' );
+
+                if (empty($url) && empty($youtube_title)) {
+                        die("Either --url or --title required\n");
+                }
+
+		// If we have a one off title, don't search this wiki for them
+		if ($url) {
+			$youtube_title = $this->pullTitle($url);
+		}
+
+		$premium_title = $this->closestMatch($youtube_title);
+		$premium_title = preg_replace('/^file:/i', '', $premium_title);
+
+		echo("# YouTube: $youtube_title\n" .
+		     "# Premium: $premium_title\n");
+	}
+
+	function pullTitle ( $url ) {
+		$url = trim($url);
+
+		try {
+			$youtube = YoutubeApiWrapper::newFromUrl($url);
+		}
+		catch( VideoIsPrivateException $e ) {
+			echo ("# [ERROR] video is private: $url\n");
+			continue;
+		}
+		catch( VideoNotFoundException $e ) {
+			echo ("# [ERROR] video not found: $url\n");
+			continue;
+		}
+		catch (Exception $e) {
+			echo '# [ERROR] Caught exception: ',  $e->getMessage(), ": $url\n";
+		}
+
+		$t = $youtube->getTitle();
+
+		return $t;
+	}
+
+	function closestMatch ( $titleText ) {
+		$app = F::App();
+		$data = $app->sendRequest('WikiaSearchController', 'searchVideosByTitle',
+								  array('title' => $titleText))->getData();
+
+		if ( empty( $data[0]['title'] ) ) {
+			return '';
+		} else {
+			return $data[0]['title'];
+		}
+	}
+}
+
+$maintClass = "EditCLI";
+require_once( RUN_MAINTENANCE_IF_MAIN );
+


### PR DESCRIPTION
This accommodates some of the requirements set forth by PLA-172, including the ability to pass a "minimum match" parameter to the search controller and configure that threshold through client requests.
