### PR TITLE
DAR-86: track dialog button close instead of dialog close.

### DIFF
--- a/extensions/wikia/EditPageLayout/js/plugins/Tracker.js
+++ b/extensions/wikia/EditPageLayout/js/plugins/Tracker.js
@@ -45,7 +45,7 @@
 		onCkInstanceCreated: function( ck ) {
 			ck.on( 'buttonClick', this.proxy( this.onCkButtonClick ) );
 			ck.on( 'dialogCancel', this.proxy( this.onCkDialogCancel ) );
-			ck.on( 'dialogHide', this.proxy( this.onCkDialogHide ) );
+			ck.on( 'dialogClose', this.proxy( this.onCkDialogClose ) );
 			ck.on( 'dialogOk', this.proxy( this.onCkDialogOk ) );
 			ck.on( 'dialogShow', this.proxy( this.onCkDialogShow ) );
 			ck.on( 'panelClick', this.proxy( this.onCkPanelClick ) );
@@ -62,13 +62,9 @@
 			this.track( 'dialog-' + label + '-button-cancel' );
 		},
 
-		onCkDialogHide: function( event ) {
+		onCkDialogClose: function( event ) {
 			var label = event.data._.name.toLowerCase();
-
-			this.track({
-				action:  Wikia.Tracker.ACTIONS.CLOSE,
-				label: 'dialog-' + label
-			});
+			this.track( 'dialog-' + label + '-button-close' );
 		},
 
 		onCkDialogOk: function( event ) {

--- a/extensions/wikia/RTE/ckeditor/_source/plugins/dialog/plugin.js
+++ b/extensions/wikia/RTE/ckeditor/_source/plugins/dialog/plugin.js
@@ -352,6 +352,7 @@ CKEDITOR.DIALOG_RESIZE_BOTH = 3;
 				{
 					// Wikia - start
 					this.fire('close', {close: true});
+					editor.fire( 'dialogClose', this );
 					// Wikia - end
 
 					if ( this.fire( 'cancel', { hide : true } ).hide !== false )


### PR DESCRIPTION
We used to track everytime a dialog closes, which is too ambiguous. We want to instead track whenever the close button (X) is clicked.
