### PR TITLE
Log URL when calling Wikia::logBacktrace

### DIFF
--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -406,6 +406,11 @@ class Wikia {
 		$backtrace = trim(strip_tags(wfBacktrace()));
 		$message = str_replace("\n", '/', $backtrace);
 
+		// add URL when logging from AJAX requests
+		if (($_SERVER['REQUEST_METHOD'] === 'GET') && ($_SERVER['SCRIPT_URL'] === '/wikia.php')) {
+			$message .= " URL: {$_SERVER['REQUEST_URI']}";
+		}
+
 		Wikia::log($method, false, $message, true /* $force */);
 	}
 


### PR DESCRIPTION
GET request parameters will be logged when used in wikia.php request

Example:

```
WikiaException::__construct: Wikia.php line 406 calls wfBacktrace()/WikiaException.php line 58 calls Wikia::logBacktrace()/WikiaDispatcher.class.php line 108 calls WikiaException->__construct()/WikiaApp.class.php line 590 calls WikiaDispatcher->dispatch()/wikia.php line 36 calls WikiaApp->sendRequest() URL: /wikia.php?controller=LyricFind&method=track&pageid=1964
```
