### PR TITLE
bugid-101724 -- update SEOTweaks hook for mismatched URL to be less problematic

### DIFF
--- a/extensions/wikia/SEOTweaks/SEOTweaksHooksHelper.class.php
+++ b/extensions/wikia/SEOTweaks/SEOTweaksHooksHelper.class.php
@@ -113,11 +113,8 @@ class SEOTweaksHooksHelper extends WikiaModel {
 			&& ( isset( $_SERVER['HTTP_REFERER'] ) ) 
 			&& preg_match( self::SHARING_HOSTS_REGEX, parse_url( $_SERVER['HTTP_REFERER'], PHP_URL_HOST ) ) 
 		    ) {
-		    
 			$dbr = $this->wf->GetDB( DB_SLAVE );
-			$sql = sprintf( 'SELECT page_title FROM page WHERE page_title REGEXP "^%s[[:punct:]]+" ORDER BY CHAR_LENGTH( page_title ) LIMIT 1', $title->getDBKey() );
-			$result = $dbr->query( $sql );
-			
+			$result = $dbr->query( sprintf( 'SELECT page_title FROM page WHERE page_title %s LIMIT 1', $dbr->buildLike( $title->getDBKey(), $dbr->anyString() ) ), __METHOD__ );
 			if ( $row = $dbr->fetchObject( $result ) ) {
 				$title = Title::newFromText( $row->page_title );
 				$this->wg->Out->redirect( $title->getFullUrl() );

--- a/extensions/wikia/SEOTweaks/tests/SEOTweaksTest.php
+++ b/extensions/wikia/SEOTweaks/tests/SEOTweaksTest.php
@@ -663,7 +663,7 @@ class SEOTweaksTest extends WikiaBaseTest
 		
 		$mockDb = $this->getMockBuilder( "DatabaseMysql" )
 		               ->disableOriginalConstructor()
-		               ->setMethods( array( 'query', 'fetchObject' ) )
+		               ->setMethods( array( 'query', 'fetchObject', 'buildLike', 'anyString' ) )
 		               ->getMock();
 		
 		$mockResultWrapper = $this->getMockBuilder( 'ResultWrapper' )
@@ -698,12 +698,23 @@ class SEOTweaksTest extends WikiaBaseTest
 		;
 		$mockDb
 		    ->expects( $this->at( 0 ) )
-		    ->method ( 'query' )
-		    ->with   ( 'SELECT page_title FROM page WHERE page_title REGEXP "^' . $dbKey . '[[:punct:]]+" ORDER BY CHAR_LENGTH( page_title ) LIMIT 1' )
-		    ->will   ( $this->returnValue( $mockResultWrapper ) )
+		    ->method ( 'anyString' )
+		    ->will   ( $this->returnValue( '%' ) )
 		;
 		$mockDb
 		    ->expects( $this->at( 1 ) )
+		    ->method ( 'buildLike' )
+		    ->with   ( $dbKey, '%' )
+		    ->will   ( $this->returnValue( "LIKE '{$dbKey}%'" ) )
+		;
+		$mockDb
+		    ->expects( $this->at( 2 ) )
+		    ->method ( 'query' )
+		    ->with   ( "SELECT page_title FROM page WHERE page_title LIKE '{$dbKey}%' LIMIT 1" )
+		    ->will   ( $this->returnValue( $mockResultWrapper ) )
+		;
+		$mockDb
+		    ->expects( $this->at( 3 ) )
 		    ->method ( 'fetchObject' )
 		    ->will   ( $this->returnValue( null ) )
 		;
@@ -747,7 +758,7 @@ class SEOTweaksTest extends WikiaBaseTest
 		
 		$mockDb = $this->getMockBuilder( "DatabaseMysql" )
 		               ->disableOriginalConstructor()
-		               ->setMethods( array( 'query', 'fetchObject' ) )
+		               ->setMethods( array( 'query', 'fetchObject', 'buildLike', 'anyString' ) )
 		               ->getMock();
 		
 		$mockResultWrapper = $this->getMockBuilder( 'ResultWrapper' )
@@ -789,12 +800,23 @@ class SEOTweaksTest extends WikiaBaseTest
 		;
 		$mockDb
 		    ->expects( $this->at( 0 ) )
-		    ->method ( 'query' )
-		    ->with   ( 'SELECT page_title FROM page WHERE page_title REGEXP "^' . $dbKey . '[[:punct:]]+" ORDER BY CHAR_LENGTH( page_title ) LIMIT 1' )
-		    ->will   ( $this->returnValue( $mockResultWrapper ) )
+		    ->method ( 'anyString' )
+		    ->will   ( $this->returnValue( '%' ) )
 		;
 		$mockDb
 		    ->expects( $this->at( 1 ) )
+		    ->method ( 'buildLike' )
+		    ->with   ( $dbKey, '%' )
+		    ->will   ( $this->returnValue( "LIKE '{$dbKey}%'" ) )
+		;
+		$mockDb
+		    ->expects( $this->at( 2 ) )
+		    ->method ( 'query' )
+		    ->with   ( "SELECT page_title FROM page WHERE page_title LIKE '{$dbKey}%' LIMIT 1" )
+		    ->will   ( $this->returnValue( $mockResultWrapper ) )
+		;
+		$mockDb
+		    ->expects( $this->at( 3 ) )
 		    ->method ( 'fetchObject' )
 		    ->will   ( $this->returnValue( $resultObject ) )
 		;


### PR DESCRIPTION
This updates the query we use to find articles whose URLs were truncated by social sharing services.
