### PR TITLE
Fix hover state of Wikia Poll placeholder in RTE

### DIFF
--- a/extensions/wikia/RTE/RTE.class.php
+++ b/extensions/wikia/RTE/RTE.class.php
@@ -74,30 +74,6 @@ class RTE {
 		// this is placeholder
 		$data['placeholder'] = 1;
 
-		// Special case for WikiaPoll placeholder
-		// If we do more of these, refactor
-		if (defined ( "NS_WIKIA_POLL" )) {
-			global $wgContLang;
-			$pollNamespace = $wgContLang->getNsText( NS_WIKIA_POLL );
-			// Check for both canonical Poll and localized version of Poll
-			if (isset($data['title']) && ( (stripos($data['title'], 'Poll') === 0) || (stripos($data['title'], $pollNamespace) === 0) ) ) {
-				$data['type'] = 'poll';
-				$cssClass = "media-placeholder placeholder-poll";
-				$title = Title::newFromText($data['title'], NS_WIKIA_POLL);
-				if ($title->exists()) {
-					$data['pollId'] = $title->getArticleId();
-					$poll = WikiaPoll::newFromTitle($title);
-					$pollData = $poll->getData();
-					$data['question'] = $pollData['question'];
-					if (isset($pollData['answers'])) {
-						foreach ($pollData["answers"] as $answer ) {
-							$data['answers'][] = $answer['text'];
-						}
-					}
-				}
-			}
-		}
-
 		// store data
 		$dataIdx = RTEData::put('data', $data);
 

--- a/extensions/wikia/RTE/css/content.scss
+++ b/extensions/wikia/RTE/css/content.scss
@@ -183,8 +183,6 @@ img.image-slideshow {
 img.placeholder-poll {
 	background-image: url(/extensions/wikia/WikiaPoll/images/poll-placeholder.png);/* $wgCdnStylePath */
 	float: left;
-	height: 200px;
-	width: 300px;
 }
 
 /* redlinks (RT #87906) */

--- a/extensions/wikia/WikiaPoll/WikiaPoll.class.php
+++ b/extensions/wikia/WikiaPoll/WikiaPoll.class.php
@@ -300,7 +300,7 @@ class WikiaPoll {
 		wfProfileOut(__METHOD__);
 	}
 	
-	public function getRtePlaceholderSizes() {
+	public function getRtePlaceholderSize() {
 		$out = new stdClass();
 		$out->width = self::RTE_PLACEHOLDER_WIDTH;
 		$out->height = self::RTE_PLACEHOLDER_HEIGHT;

--- a/extensions/wikia/WikiaPoll/WikiaPoll.class.php
+++ b/extensions/wikia/WikiaPoll/WikiaPoll.class.php
@@ -13,6 +13,9 @@ class WikiaPoll {
 
 	const CACHE_TTL = 86400;
 	const CACHE_VER = 5;
+	
+	const RTE_PLACEHOLDER_WIDTH = 300;
+	const RTE_PLACEHOLDER_HEIGHT = 200;
 
 	public function __construct($pollId) {
 		$this->mData = null;
@@ -295,5 +298,13 @@ class WikiaPoll {
 		wfDebug(__METHOD__ . ": purged poll #{$this->mPollId}\n");
 
 		wfProfileOut(__METHOD__);
+	}
+	
+	public function getRtePlaceholderSizes() {
+		$out = new stdClass();
+		$out->width = self::RTE_PLACEHOLDER_WIDTH;
+		$out->height = self::RTE_PLACEHOLDER_HEIGHT;
+		
+		return $out;
 	}
 }

--- a/extensions/wikia/WikiaPoll/WikiaPoll.class.php
+++ b/extensions/wikia/WikiaPoll/WikiaPoll.class.php
@@ -300,11 +300,11 @@ class WikiaPoll {
 		wfProfileOut(__METHOD__);
 	}
 	
-	public function getRtePlaceholderSize() {
-		$out = new stdClass();
-		$out->width = self::RTE_PLACEHOLDER_WIDTH;
-		$out->height = self::RTE_PLACEHOLDER_HEIGHT;
-		
-		return $out;
+	public function getRtePlaceholderWidth() {
+		return self::RTE_PLACEHOLDER_WIDTH;
+	}
+
+	public function getRtePlaceholderHeight() {
+		return  self::RTE_PLACEHOLDER_HEIGHT;
 	}
 }

--- a/extensions/wikia/WikiaPoll/WikiaPollHooks.class.php
+++ b/extensions/wikia/WikiaPoll/WikiaPollHooks.class.php
@@ -150,7 +150,6 @@ class WikiaPollHooks {
 		}
 		// store data and mark HTML
 		$dataIdx = RTEData::put('data', $data);
-		$size = $poll->getRtePlaceholderSize();
 
 		// render poll placeholder
 		$tag = Xml::element('img', array(
@@ -158,8 +157,8 @@ class WikiaPollHooks {
 			'class' => "media-placeholder placeholder-poll",
 			'src' => $wgBlankImgUrl,
 			'type' => 'poll',
-			'width' => $size->width,
-			'height' => $size->height,
+			'width' => $poll->getRtePlaceholderWidth(),
+			'height' => $poll->getRtePlaceholderHeight(),
 		));
 		return RTEData::addIdxToTag($dataIdx, $tag);
 	}

--- a/extensions/wikia/WikiaPoll/WikiaPollHooks.class.php
+++ b/extensions/wikia/WikiaPoll/WikiaPollHooks.class.php
@@ -150,13 +150,16 @@ class WikiaPollHooks {
 		}
 		// store data and mark HTML
 		$dataIdx = RTEData::put('data', $data);
+		$sizes = $poll->getRtePlaceholderSizes();
 
 		// render poll placeholder
 		$tag = Xml::element('img', array(
 			'_rte_dataidx' => sprintf('%04d', $dataIdx),
 			'class' => "media-placeholder placeholder-poll",
 			'src' => $wgBlankImgUrl,
-			'type' => 'poll'
+			'type' => 'poll',
+			'width' => $sizes->width,
+			'height' => $sizes->height,
 		));
 		return RTEData::addIdxToTag($dataIdx, $tag);
 	}

--- a/extensions/wikia/WikiaPoll/WikiaPollHooks.class.php
+++ b/extensions/wikia/WikiaPoll/WikiaPollHooks.class.php
@@ -150,7 +150,7 @@ class WikiaPollHooks {
 		}
 		// store data and mark HTML
 		$dataIdx = RTEData::put('data', $data);
-		$sizes = $poll->getRtePlaceholderSizes();
+		$size = $poll->getRtePlaceholderSize();
 
 		// render poll placeholder
 		$tag = Xml::element('img', array(
@@ -158,8 +158,8 @@ class WikiaPollHooks {
 			'class' => "media-placeholder placeholder-poll",
 			'src' => $wgBlankImgUrl,
 			'type' => 'poll',
-			'width' => $sizes->width,
-			'height' => $sizes->height,
+			'width' => $size->width,
+			'height' => $size->height,
 		));
 		return RTEData::addIdxToTag($dataIdx, $tag);
 	}


### PR DESCRIPTION
Basically hovering on the placeholder was broken as described in [FB#101586](https://wikia.fogbugz.com/default.asp?101586). The cause of that was missing width attribute for img tag. It was used in RTE overlay plugin to calculate position of "modify remove" element (method getImageWidth() in /extensions/wikia/RTE/js/plugins/overlay/plugin.js). I removed the size from *.scss file and add the attributes (width and height) to the placeholder. Also, I found a piece of code in RTE.class.php which wasn't executed. @wladekb @macbre @owend you guys probably know RTE quite well -- can you take a look at this pull request and merge it if it's fine? :)
