### PR TITLE
BAC-209: Remove google indexing from LyricFind NS

### DIFF
--- a/extensions/3rdparty/LyricWiki/LyricFind/LyricFind.setup.php
+++ b/extensions/3rdparty/LyricWiki/LyricFind/LyricFind.setup.php
@@ -32,6 +32,9 @@ $app->registerHook('OasisSkinAssetGroups', 'LyricFindHooks', 'onOasisSkinAssetGr
 
 $wgLyricFindTrackingNamespaces = array(NS_LYRICFIND);
 
+// LyricFind indexing
+$app->registerHook('BeforePageDisplay', 'LyricFindHooks', 'onBeforePageDisplay');
+
 // edit permissions & view-source protection
 // @see http://www.mediawiki.org/wiki/Manual:$wgNamespaceProtection
 $wgGroupPermissions['*']['editlyricfind'] = false;

--- a/extensions/3rdparty/LyricWiki/LyricFind/tests/LyricFindIndexingTest.php
+++ b/extensions/3rdparty/LyricWiki/LyricFind/tests/LyricFindIndexingTest.php
@@ -1,0 +1,49 @@
+<?php
+
+class LyricFindIndexingTest extends WikiaBaseTest {
+
+	public function setUp() {
+		$this->setupFile = __DIR__ . '/../LyricFind.setup.php';
+		parent::setUp();
+	}
+
+	/**
+	 * @dataProvider indexPolicyProvider
+	 * @param $ns int namespace
+	 * @param $text string page title
+	 * @param $inMainNS bool is page in the main NS as well?
+	 * @param $expectedResult bool is page not permitted to be indexed?
+	 */
+	public function testIndexPolicy($ns, $inMainNS, $expectedResult) {
+		$title = $this->mockClassWithMethods('Title', [
+			'getNamespace' => $ns,
+			'getText' => 'Foo'
+		]);
+
+		$this->mockClassWithMethods('Title', [
+			'exists' => $inMainNS
+		], 'newFromText');
+
+		$this->assertEquals($expectedResult, LyricFindHooks::pageIsIndexable($title));
+	}
+
+	public function indexPolicyProvider() {
+		return [
+			[
+				'ns' => 222, // NS_LYRICFIND
+				'inMainNS' => true,
+				'expectedResult' => false
+			],
+			[
+				'ns' => 222, // NS_LYRICFIND
+				'inMainNS' => false,
+				'expectedResult' => true
+			],
+			[
+				'ns' => NS_MAIN,
+				'inMainNS' => true,
+				'expectedResult' => true
+			],
+		];
+	}
+}


### PR DESCRIPTION
`noindex,follow` robot policy will be set for LyricFind lyrics that have community-powered version in main namespace.
