### PR TITLE
PLA-146 search push-to-top match with full title

### DIFF
--- a/extensions/wikia/Search/classes/MediaWikiService.php
+++ b/extensions/wikia/Search/classes/MediaWikiService.php
@@ -855,7 +855,7 @@ class MediaWikiService
 			return (string) $wm->getMetaTitle();
 		}
 		wfProfileOut(__METHOD__);
-		return $title->getBaseText();
+		return $title->getFullText();
 	}
 	
 	/**

--- a/extensions/wikia/Search/classes/Test/MediaWikiServiceTest.php
+++ b/extensions/wikia/Search/classes/Test/MediaWikiServiceTest.php
@@ -1200,7 +1200,7 @@ class MediaWikiServiceTest extends BaseTest
 		
 		$title = $this->getMockBuilder( '\Title' )
 		              ->disableOriginalConstructor()
-		              ->setMethods( array( 'getBaseText', 'getNamespace' ) )
+		              ->setMethods( array( 'getFullText', 'getNamespace' ) )
 		              ->getMock();
 		
 		$title
@@ -1210,7 +1210,7 @@ class MediaWikiServiceTest extends BaseTest
 		;
 		$title
 		    ->expects( $this->at( 1 ) )
-		    ->method ( 'getBaseText' )
+		    ->method ( 'getFullText' )
 		    ->will   ( $this->returnValue( 'title' ) )
 		;
 		$get = new ReflectionMethod( '\Wikia\Search\MediaWikiService', 'getTitleString' );


### PR DESCRIPTION
This updates MediaWikiService::getTitleString to use Title::getFullText instead of Title::getBaseText. This updates two parts of our code: the title string creation for push-to-top search results, and the title strings for the DefaultContent query service, which is responsible for populating the title field for search documents.
