### PR TITLE
Major Search Querying Update

### DIFF
--- a/extensions/wikia/Search/classes/Config.php
+++ b/extensions/wikia/Search/classes/Config.php
@@ -97,7 +97,7 @@ class Config implements ArrayAccess
 			'redirect_titles'   => 50,
 			'categories'        => 25,
 			'nolang_txt'        => 10,
-			'backlinks_txt'     => 50,
+			'backlinks_txt'     => 25,
 			);
 	
 

--- a/extensions/wikia/Search/classes/Config.php
+++ b/extensions/wikia/Search/classes/Config.php
@@ -59,7 +59,7 @@ class Config implements ArrayAccess
 			'cityId'		=>	0,
 			'rank'			=>	'default',
 			'start'			=>	0,
-			'minimumMatch'	=> '66%',
+			'minimumMatch'	=> '80%',
 			);
 	
 	/**
@@ -92,12 +92,12 @@ class Config implements ArrayAccess
 	 * @var array
 	 */
 	private $queryFieldsToBoosts = array(
-			'title'             => 5,
-			'html'              => 1.5,
-			'redirect_titles'   => 4,
-			'categories'        => 1,
-			'nolang_txt'        => 7,
-			'backlinks_txt'     => 15,
+			'title'             => 100,
+			'html'              => 5,
+			'redirect_titles'   => 50,
+			'categories'        => 25,
+			'nolang_txt'        => 10,
+			'backlinks_txt'     => 50,
 			);
 	
 

--- a/extensions/wikia/Search/classes/Config.php
+++ b/extensions/wikia/Search/classes/Config.php
@@ -96,7 +96,8 @@ class Config implements ArrayAccess
 			'html'              => 1.5,
 			'redirect_titles'   => 4,
 			'categories'        => 1,
-			'nolang_txt'        => 7
+			'nolang_txt'        => 7,
+			'backlinks_txt'     => 15,
 			);
 	
 

--- a/extensions/wikia/Search/classes/QueryService/Select/AbstractSelect.php
+++ b/extensions/wikia/Search/classes/QueryService/Select/AbstractSelect.php
@@ -314,16 +314,14 @@ abstract class AbstractSelect
 	
 	/**
 	 * Creates a nested query using extended dismax.
-	 * @return Solarium_Query_Select
+	 * @return AbstractSelect
 	 */
-	protected function getNestedQuery() {
-		$nestedQuery = $this->client->createSelect();
-		$nestedQuery->setQuery( $this->config->getQuery()->getSolrQuery() );
+	protected function registerDismax( Solarium_Query_Select $select ) {
 		
 		$queryFieldsString = $this->getQueryFieldsString();
-		$dismax = $nestedQuery->getDismax()
-		                      ->setQueryFields( $queryFieldsString )
-		                      ->setQueryParser( 'edismax' )
+		$dismax = $select->getDismax()
+		                 ->setQueryFields( $queryFieldsString )
+		                 ->setQueryParser( 'edismax' )
 		;
 		
 		if ( $this->service->isOnDbCluster() ) {
@@ -338,7 +336,7 @@ abstract class AbstractSelect
 			    $dismax->setBoostFunctions( implode(' ', $this->boostFunctions ) );
 			}
 		}
-		return $nestedQuery;
+		return $this;
 	}
 	
 	/**

--- a/extensions/wikia/Search/classes/QueryService/Select/InterWiki.php
+++ b/extensions/wikia/Search/classes/QueryService/Select/InterWiki.php
@@ -91,6 +91,7 @@ class InterWiki extends AbstractSelect
 		            ->registerQueryParams   ( $query )
 		            ->registerFilterQueries ( $query )
 		            ->registerGrouping      ( $query )
+		            ->registerDismax        ( $query )
 		;
 	}
 	
@@ -185,7 +186,7 @@ class InterWiki extends AbstractSelect
 	 * @see \Wikia\Search\QueryService\Select\AbstractSelect::getFormulatedQuery()
 	 */
 	protected function getFormulatedQuery() {
-		return sprintf( '%s AND (%s)', $this->getQueryClausesString(), $this->getNestedQuery() );
+		return sprintf( '%s AND (%s)', $this->getQueryClausesString(), $this->config->getQuery()->getSolrQuery() );
 	}
 	
 	/**

--- a/extensions/wikia/Search/classes/QueryService/Select/OnWiki.php
+++ b/extensions/wikia/Search/classes/QueryService/Select/OnWiki.php
@@ -24,7 +24,6 @@ class OnWiki extends AbstractSelect
 	 * @var array
 	 */
 	protected $boostFunctions = array(
-		'log(views)^0.66', 
 		'log(backlinks)'
 	);
 	
@@ -131,19 +130,5 @@ class OnWiki extends AbstractSelect
 		}
 		$queryClauses[] = "({$nsQuery})";
 		return sprintf( '(%s)', implode( ' AND ', $queryClauses ) );
-	}
-	
-	/**
-	 * Returns the string used to build out a boost query with Solarium
-	 * @return string
-	 */
-	protected function getBoostQueryString()
-	{
-		$queryNoQuotes = str_replace( '\"', '', $this->config->getQuery()->getSolrQuery() );
-		$boostQueries = array(
-				Utilities::valueForField( 'html', $queryNoQuotes, array( 'boost'=>5, 'valueQuote'=>'\"' ) ),
-		        Utilities::valueForField( 'title', $queryNoQuotes, array( 'boost'=>10, 'valueQuote'=>'\"' ) ),
-		);
-		return implode( ' ', $boostQueries );
 	}
 }

--- a/extensions/wikia/Search/classes/QueryService/Select/OnWiki.php
+++ b/extensions/wikia/Search/classes/QueryService/Select/OnWiki.php
@@ -51,6 +51,7 @@ class OnWiki extends AbstractSelect
 		            ->registerHighlighting  ( $query )
 		            ->registerFilterQueries ( $query )
 		            ->registerSpellcheck    ( $query )
+		            ->registerDismax        ( $query )
 		;
 	}
 	
@@ -115,7 +116,7 @@ class OnWiki extends AbstractSelect
 	 * @return string
 	 */
 	protected function getFormulatedQuery() {
-		return sprintf( '%s AND (%s)', $this->getQueryClausesString(), $this->getNestedQuery() );
+		return sprintf( '%s AND (%s)', $this->getQueryClausesString(), $this->config->getQuery()->getSolrQuery() );
 	}
 	
 	/**

--- a/extensions/wikia/Search/classes/Test/QueryService/Select/AbstractSelectTest.php
+++ b/extensions/wikia/Search/classes/Test/QueryService/Select/AbstractSelectTest.php
@@ -789,7 +789,7 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 	/**
 	 * @covers Wikia\Search\QueryService\Select\AbstractSelect::registerDismax
 	 */
-	public function testGetNestedQuery() {
+	public function testRegisterDismax() {
 		$mockQuery = $this->getMockBuilder( 'Solarium_Query_Select' )
 		                  ->disableOriginalConstructor()
 		                  ->setMethods( array( 'getDismax' ) )

--- a/extensions/wikia/Search/classes/Test/QueryService/Select/AbstractSelectTest.php
+++ b/extensions/wikia/Search/classes/Test/QueryService/Select/AbstractSelectTest.php
@@ -787,17 +787,12 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 	}
 	
 	/**
-	 * @covers Wikia\Search\QueryService\Select\AbstractSelect::getNestedQuery
+	 * @covers Wikia\Search\QueryService\Select\AbstractSelect::registerDismax
 	 */
 	public function testGetNestedQuery() {
-		$mockClient = $this->getMockBuilder( 'Solarium_Client' )
-		                   ->disableOriginalConstructor()
-		                   ->setMethods( array( 'createSelect' ) )
-		                   ->getMock();
-		
 		$mockQuery = $this->getMockBuilder( 'Solarium_Query_Select' )
 		                  ->disableOriginalConstructor()
-		                  ->setMethods( array( 'setQuery', 'getDismax' ) )
+		                  ->setMethods( array( 'getDismax' ) )
 		                  ->getMock();
 		
 		$dismaxMethods = array( 
@@ -817,35 +812,13 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 		                   ->setMethods( array( 'getMinimumMatch', 'getSkipBoostFunctions', 'getQuery' ) )
 		                   ->getMock();
 		
-		$mockQueryWrapper = $this->getMock( 'Wikia\Search\Query\Select', array( 'getSolrQuery' ), array( 'foo' ) );
-		
-		$deps = array( 'config' => $mockConfig, 'client' => $mockClient, 'service' => $mockService  );
+		$deps = array( 'config' => $mockConfig, 'service' => $mockService  );
 		$dc = new Wikia\Search\QueryService\DependencyContainer( $deps );
 		$mockSelect = $this->getMockBuilder( 'Wikia\Search\QueryService\Select\AbstractSelect' )
 		                   ->setConstructorArgs( array( $dc ) )
 		                   ->setMethods( array( 'getQueryFieldsString', 'getBoostQueryString' ) )
 		                   ->getMockForAbstractClass();
 		
-		$mockClient
-		    ->expects( $this->once() )
-		    ->method ( 'createSelect' )
-		    ->will   ( $this->returnValue( $mockQuery ) )
-		;
-		$mockConfig
-		    ->expects( $this->once() )
-		    ->method ( 'getQuery' )
-		    ->will   ( $this->returnValue( $mockQueryWrapper ) )
-	    ;
-		$mockQueryWrapper
-		    ->expects( $this->once() )
-		    ->method ( 'getSolrQuery' )
-		    ->will   ( $this->returnValue( 'foo' ) )
-		;
-		$mockQuery
-		    ->expects( $this->once() )
-		    ->method ( 'setQuery' )
-		    ->with   ( 'foo' )
-		;
 		$mockSelect
 		    ->expects( $this->once() )
 		    ->method ( 'getQueryFieldsString' )
@@ -893,12 +866,12 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 		$mockConfig
 		    ->expects( $this->once() )
 		    ->method ( 'getMinimumMatch' )
-		    ->will   ( $this->returnValue( '66%' ) )
+		    ->will   ( $this->returnValue( '80%' ) )
 		;
 		$mockDismax
 		    ->expects( $this->once() )
 		    ->method ( 'setMinimumMatch' )
-		    ->with   ( '66%' )
+		    ->with   ( '80%' )
 		    ->will   ( $this->returnValue( $mockDismax ) )
 		;
 		$mockDismax
@@ -926,11 +899,11 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 		    ->method ( 'setBoostFunctions' )
 		    ->with   ( 'foo bar' )
 		;
-		$funcRefl = new ReflectionMethod( 'Wikia\Search\QueryService\Select\AbstractSelect', 'getNestedQuery' );
+		$funcRefl = new ReflectionMethod( 'Wikia\Search\QueryService\Select\AbstractSelect', 'registerDismax' );
 		$funcRefl->setAccessible( true );
 		$this->assertEquals(
-				$mockQuery,
-				$funcRefl->invoke( $mockSelect )
+				$mockSelect,
+				$funcRefl->invoke( $mockSelect, $mockQuery )
 		);
 	}
 	

--- a/extensions/wikia/Search/classes/Test/QueryService/Select/InterWikiTest.php
+++ b/extensions/wikia/Search/classes/Test/QueryService/Select/InterWikiTest.php
@@ -345,19 +345,30 @@ class InterWikiTest extends Wikia\Search\Test\BaseTest {
 	 * @covers Wikia\Search\QueryService\Select\InterWiki::getFormulatedQuery
 	 */
 	public function testGetFormulatedQuery() {
+		$mockConfig = $this->getMock( 'Wikia\Search\Config', [ 'getQuery' ] );
+		
+		$dc = new \Wikia\Search\QueryService\DependencyContainer( array( 'config' => $mockConfig ) );
+		
 		$mockSelect = $this->getMockBuilder( 'Wikia\Search\QueryService\Select\InterWiki' )
-		                   ->disableOriginalConstructor()
-		                   ->setMethods( array( 'getQueryClausesString', 'getNestedQuery' ) )
+		                   ->setConstructorArgs( [ $dc ] )
+		                   ->setMethods( [ 'getQueryClausesString' ] )
 		                   ->getMock();
+		
+		$mockQuery = $this->getMock( 'Wikia\Search\Query\Select', [ 'getSolrQuery' ], [ 'foo' ] );
 		
 		$mockSelect
 		    ->expects( $this->once() )
 		    ->method ( 'getQueryClausesString' )
 		    ->will   ( $this->returnValue( 'foo' ) )
 		;
-		$mockSelect
+		$mockConfig
 		    ->expects( $this->once() )
-		    ->method ( 'getNestedQuery' )
+		    ->method ( 'getQuery' )
+		    ->will   ( $this->returnValue( $mockQuery ) )
+		;
+		$mockQuery
+		    ->expects( $this->once() )
+		    ->method ( 'getSolrQuery' )
 		    ->will   ( $this->returnValue( 'bar' ) )
 		;
 		$method = new ReflectionMethod( 'Wikia\Search\QueryService\Select\InterWiki', 'getFormulatedQuery' );

--- a/extensions/wikia/Search/classes/Test/QueryService/Select/OnWikiTest.php
+++ b/extensions/wikia/Search/classes/Test/QueryService/Select/OnWikiTest.php
@@ -7,7 +7,7 @@ use Wikia, ReflectionProperty, ReflectionMethod;
 /**
  * Tests on-wiki search functionality
  */
-class OnWikiTest extends Wikia\Search\Test\BaseTest {
+class OnWikiTest extends Wikia\Search\Test\BaseTest { 
 	
 	/**
 	 * @covers Wikia\Search\QueryService\Select\OnWiki::extractMatch
@@ -82,7 +82,7 @@ class OnWikiTest extends Wikia\Search\Test\BaseTest {
 		
 		$selectMethods = array( 
 				'registerQueryParams', 'registerHighlighting', 'registerFilterQueries', 
-				'registerSpellcheck', 'configureQueryFields' 
+				'registerSpellcheck', 'configureQueryFields', 'registerDismax'
 				);
 		$mockSelect = $this->getMockBuilder( 'Wikia\Search\QueryService\Select\OnWiki' )
 		                   ->disableOriginalConstructor()
@@ -115,6 +115,12 @@ class OnWikiTest extends Wikia\Search\Test\BaseTest {
 		$mockSelect
 		    ->expects( $this->once() )
 		    ->method ( 'registerSpellcheck' )
+		    ->with   ( $mockQuery )
+		    ->will   ( $this->returnValue( $mockSelect ) )
+		;
+		$mockSelect
+		    ->expects( $this->once() )
+		    ->method ( 'registerDismax' )
 		    ->with   ( $mockQuery )
 		    ->will   ( $this->returnValue( $mockSelect ) )
 		;
@@ -340,19 +346,30 @@ class OnWikiTest extends Wikia\Search\Test\BaseTest {
 	 * @covers Wikia\Search\QueryService\Select\OnWiki::getFormulatedQuery
 	 */
 	public function testGetFormulatedQuery() {
+		$mockConfig = $this->getMock( 'Wikia\Search\Config', [ 'getQuery' ] );
+		
+		$dc = new \Wikia\Search\QueryService\DependencyContainer( array( 'config' => $mockConfig ) );
+		
 		$mockSelect = $this->getMockBuilder( 'Wikia\Search\QueryService\Select\OnWiki' )
-		                   ->disableOriginalConstructor()
-		                   ->setMethods( array( 'getQueryClausesString', 'getNestedQuery' ) )
+		                   ->setConstructorArgs( [ $dc ] )
+		                   ->setMethods( array( 'getQueryClausesString' ) )
 		                   ->getMock();
+		
+		$mockQuery = $this->getMock( 'Wikia\Search\Query\Select', [ 'getSolrQuery' ], [ 'foo' ] );
 		
 		$mockSelect
 		    ->expects( $this->once() )
 		    ->method ( 'getQueryClausesString' )
 		    ->will   ( $this->returnValue( 'foo' ) )
 		;
-		$mockSelect
+		$mockConfig
 		    ->expects( $this->once() )
-		    ->method ( 'getNestedQuery' )
+		    ->method ( 'getQuery' )
+		    ->will   ( $this->returnValue( $mockQuery ) )
+		;
+		$mockQuery
+		    ->expects( $this->once() )
+		    ->method ( 'getSolrQuery' )
 		    ->will   ( $this->returnValue( 'bar' ) )
 		;
 		$method = new ReflectionMethod( 'Wikia\Search\QueryService\Select\OnWiki', 'getFormulatedQuery' );
@@ -388,41 +405,6 @@ class OnWikiTest extends Wikia\Search\Test\BaseTest {
 		$method->setAccessible( true );
 		$this->assertEquals(
 				'((wid:123) AND ((ns:0) OR (ns:14)))',
-				$method->invoke( $mockSelect )
-		);
-	}
-	
-	/**
-	 * @covers Wikia\Search\QueryService\Select\OnWiki::getBoostQueryString
-	 */
-	public function testGetBoostQueryString() {
-		$mockConfig = $this->getMock( 'Wikia\Search\Config', array( 'getQuery' ) );
-		$mockQuery = $this->getMock( 'Wikia\Search\Query\Select', array( 'getSolrQuery' ), array( 'foo' ) );
-		$dc = new Wikia\Search\QueryService\DependencyContainer( array( 'config' => $mockConfig ) );
-		$mockSelect = $this->getMockBuilder( 'Wikia\Search\QueryService\Select\OnWiki' )
-		                   ->setConstructorArgs( array( $dc ) )
-		                   ->setMethods( null )
-		                   ->getMock();
-		$queryNoQuotes = 'foo';
-		$queryWithQuotes = '\"foo\"';
-		$mockConfig
-		    ->expects( $this->once() )
-		    ->method ( 'getQuery' )
-		    ->will   ( $this->returnValue( $mockQuery ) )
-	    ;
-		$mockQuery
-		    ->expects( $this->once() )
-		    ->method ( 'getSolrQuery' )
-		    ->will   ( $this->returnValue( $queryWithQuotes ) )
-		;
-		$method = new ReflectionMethod( 'Wikia\Search\QueryService\Select\OnWiki', 'getBoostQueryString' );
-		$method->setAccessible( true );
-		$boostQueries = array(
-				Wikia\Search\Utilities::valueForField( 'html', $queryNoQuotes, array( 'boost'=>5, 'valueQuote'=>'\"' ) ),
-				Wikia\Search\Utilities::valueForField( 'title', $queryNoQuotes, array( 'boost'=>10, 'valueQuote'=>'\"' ) ),
-		);
-		$this->assertEquals(
-				implode( ' ', $boostQueries ),
 				$method->invoke( $mockSelect )
 		);
 	}


### PR DESCRIPTION
This update includes several important changes that result in a major increase in search relevance.

This is accomplished in part by the following changes:
- Removal of Nested Queries
- Inclusion of Backlinks as a Query Field
- Removal of Boost Queries from On-Wiki Search
- Re-Tweaking of Query Field Boosts
- Removal of Views as a Boost Function
- Minimum Match Increase
## Removal of Nested Queries

Our original approach for searching with Solr as of 2/1/2012 was a DisMax query that scored all documents matching the phrase and then filtered out documents that did not match the provided wiki ID. In order to address our needs for robust matching as well as wiki filtering, we had to move to using Lucene query syntax for a number of statements required to minimize scope, and then conjoin with a DisMax nested query to operate against a minimum of candidate documents. This introduced complexity and weakened performance. 

The ExtendedDisMax parser, introduced in Solr 3.1, lets us provide robust matching for user input while allowing for full Lucene query syntax. This makes our queries much easier to read, and puts many of the parameters passed to the subquery as variables in the GET request, where they belong. In the future, we will also be able to experiment with bigram and trigram matching for improved relevance, which is something that this parser supports off the shelf.
## Inclusion of Backlinks as a Query Field

Backlinks have now been introduced as a field against which we are querying using the ExtendedDisMax parser. Backlinks are populated by storing outbound link text and the outbound link's document id for a given document, and then "inverting the graph", using a backend process, storing the inbound link text for a given document in a separate field. This has been tested as working correctly against about 30 wikis, generally among our "use case" wikis. That is to say, the majority of our wikis do not yet have this feature, but those that do have it show a clear improvement upon querying such a field. Backlinks are likely to be introduced to more wikis upon a future full site reindex.
## Removal of Boost Queries from On-Wiki Search

One of the side effects of using nested queries for our dismax capabilities was the need to add boost queries to place a higher preference on proximity matches. Removing this feature actually gives us better results, based on our tests.
## Re-Tweaking of Query Field Boosts

With backlinks included as a query field, we used this opportunity to experimentally improve our search relevance based on 122 different use cases populated by the community. The arrived-upon values were found to provide the best score among a number of different configurations.
## Removal of Views as a Boost Function

This data was experimentally shown to reduce relevance. It also gets stale rather quickly. We have removed it as a factor in search relevance for now.
## Minimum Match Increase

DisMax-style query parsers include a component for declaring the minimum percentage of matches against the Lucene syntax clauses the Dismax Query Parser generates. We have increased this from 66% to 80% for stricter matching, which has shown to experimentally provide better results.
