### PR TITLE
remove WikiaSuperFactory::$setters and helper functions

### DIFF
--- a/includes/wikia/nirvana/WikiaSuperFactory.class.php
+++ b/includes/wikia/nirvana/WikiaSuperFactory.class.php
@@ -8,7 +8,6 @@
  */
 abstract class WikiaSuperFactory {
 	protected static $constructors = array();
-	protected static $setters = array();
 	protected static $reflections = array();
 	const APP_OBJECT = 'App';
 
@@ -67,15 +66,6 @@ abstract class WikiaSuperFactory {
 	}
 
 	/**
-	 * set class setter methods to be called while building an object
-	 * @param string $className class name
-	 * @param array $setters array of setter methods ( setter name => value )
-	 */
-	public static function setClassSetters($className, Array $setters) {
-		self::$setters[$className] = $setters;
-	}
-
-	/**
 	 * build object
 	 * @param string $className class name
 	 * @param array $params array of parameters for constructor or factory method ( param name => value )
@@ -118,11 +108,6 @@ abstract class WikiaSuperFactory {
 			$object = call_user_func_array(array($className, $constructorMethod), $buildParams);
 		}
 
-		if(isset(self::$setters[$className])) {
-			foreach(self::$setters[$className] as $setterName => $value) {
-				call_user_func(array($object, $setterName), $value);
-			}
-		}
 		return $object;
 	}
 
@@ -133,12 +118,10 @@ abstract class WikiaSuperFactory {
 	public static function reset($className = null) {
 		if(!empty($className)) {
 			unset(self::$constructors[$className]);
-			unset(self::$setters[$className]);
 		}
 		else {
 			// @codeCoverageIgnoreStart
 			self::$constructors = array();
-			self::$setters = array();
 			// @codeCoverageIgnoreEnd
 		}
 	}
@@ -153,10 +136,9 @@ abstract class WikiaSuperFactory {
 }
 
 /**
- * WikiaFactory class aliases
+ * WikiaFactory class alias
  * @author ADi
  *
  */
-abstract class WF extends WikiaSuperFactory { }
 abstract class F extends WikiaSuperFactory { }
 

--- a/includes/wikia/tests/WikiaSuperFactoryTest.php
+++ b/includes/wikia/tests/WikiaSuperFactoryTest.php
@@ -65,24 +65,6 @@ class WikiaSuperFactoryTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(self::TEST_TYPE, $object->type);
 	}
 
-	public function testBuildWithClassSetters() {
-		WikiaSuperFactory::setClassSetters('WikiaSuperFactoryTestClass', array( 'setId' => self::TEST_ID, 'setBar' => self::TEST_BAR ));
-
-		$object = WikiaSuperFactory::build('WikiaSuperFactoryTestClass', array( self::TEST_TYPE ));
-
-		$this->assertInstanceOf('WikiaSuperFactoryTestClass', $object);
-		$this->assertEquals(self::TEST_ID, $object->id);
-		$this->assertEquals(self::TEST_TYPE, $object->type);
-		$this->assertEquals(self::TEST_BAR, $object->bar);
-
-		$object = 	WikiaSuperFactory::build('WikiaSuperFactoryTestClass', array( 'type' => self::TEST_TYPE, 'bar' => 'anotherBarToOverride'), 'newFromTypeAndBar');
-
-		$this->assertInstanceOf('WikiaSuperFactoryTestClass', $object);
-		$this->assertEquals(self::TEST_ID, $object->id);
-		$this->assertEquals(self::TEST_TYPE, $object->type);
-		$this->assertEquals(self::TEST_BAR, $object->bar);
-	}
-
 	public function testSettingInstance() {
 		$id = 12345;
 		$type = '01010101';


### PR DESCRIPTION
In a code review of WikiaApp and WikiaSuperFactory, @wyvek and I noticed that the $setters variable and setClassSetters function are not used at all.  Probably because nobody knows about it, but it doesn't seem to be a highly demanded feature. :)

It was a way of passing in an array of function names and variables which the Factory could use to call setX($var) or setY($var) "for" you.

I also removed the "WF" alias since there is not one single reference to it.  
