### PR TITLE
VID-219 fixing tables.js to work with tabs.js

### DIFF
--- a/skins/oasis/js/tables.js
+++ b/skins/oasis/js/tables.js
@@ -29,7 +29,7 @@ var WikiaWideTables = {
 				}
 
 				// Note that this table has been processed already
-				table.addClass('willPopOut')
+				table.addClass('willPopOut');
 
 				//Add wrapper for overflow
 				wrapper = table.wrap('<div class="WikiaWideTablesWrapper"><div class="table"></div></div>').parent().parent();

--- a/skins/oasis/js/tables.js
+++ b/skins/oasis/js/tables.js
@@ -23,6 +23,14 @@ var WikiaWideTables = {
 				var table = this,
 					wrapper;
 
+				// check if we've already handled this table
+				if ( table.hasClass('willPopOut') ) {
+					return;
+				}
+
+				// Note that this table has been processed already
+				table.addClass('willPopOut')
+
 				//Add wrapper for overflow
 				wrapper = table.wrap('<div class="WikiaWideTablesWrapper"><div class="table"></div></div>').parent().parent();
 
@@ -150,6 +158,9 @@ var WikiaWideTables = {
 
 $(function() {
 	WikiaWideTables.init();
+	$(window).on('wikiaTabClicked', function() {
+		WikiaWideTables.init.call(WikiaWideTables);
+	});
 });
 
 }(jQuery));

--- a/skins/oasis/js/tabs.js
+++ b/skins/oasis/js/tabs.js
@@ -27,7 +27,7 @@ jQuery(function($){
 			$('[data-tab-body="'+previousTabName+'"]').removeClass('selected');
 			$('[data-tab-body="'+newTabName+'"]').addClass('selected');
 
-			// Let extensions react to tab switch event.
+			// Let extensions react to tab switch event. Used in FilePage.js and tables.js
 			$(window).trigger('wikiaTabClicked', [newTabName]);
 
 		} else {


### PR DESCRIPTION
The problem this fixes is that tables that were hidden on page load (i.e. because they were behind a hidden tab) were not getting the popout styles applied.  With this change, every time a tab is clicked, a check will be made for tables in the tab content that haven't been processed yet, and will process those tables to add the popout styles. 
