### PR TITLE
add /me command to chat

### DIFF
--- a/extensions/wikia/Chat2/js/views/views.js
+++ b/extensions/wikia/Chat2/js/views/views.js
@@ -1,4 +1,3 @@
-
 //
 //Views
 //
@@ -34,6 +33,10 @@ var ChatView = Backbone.View.extend({
 		var localWikiLinkReg = '^' + wgServer + wgArticlePath;
 		localWikiLinkReg = localWikiLinkReg.replace(/\$1/, "(\\S+[^.\\s\\?\\,])");
 		localWikiLinkReg = new RegExp(localWikiLinkReg, "i");
+		
+		if (text.substring(0,4) === "/me ") {
+			text = text.replace("/me ", "*" + wgUserName + " ");
+		}
 
 
 		if (!allowHtml) {


### PR DESCRIPTION
In a perfect world, I'd know where to call a code page that would allow for slash commands to be easily created by users- eg 

``` javascript
WikiaChatCommands.create("/foo", function () {});
```

But I don't know how to do that so I have to do with adding a small if to processText that adds a /me command.

Thanks.
