### PR TITLE
BugId 95972

### DIFF
--- a/extensions/wikia/EditPageLayout/js/editor/WikiaEditor.js
+++ b/extensions/wikia/EditPageLayout/js/editor/WikiaEditor.js
@@ -782,7 +782,8 @@
 			this.textarea
 				.focus(this.proxy(this.editorFocused))
 				.blur(this.proxy(this.editorBlurred))
-				.click(this.proxy(this.editorClicked));
+				.click(this.proxy(this.editorClicked))
+				.keyup(this.proxy(this.editorKeyUp));
 
 			// Editor is ready now
 			this.editor.markAsReady();
@@ -855,6 +856,10 @@
 
 		editorClicked: function() {
 			this.editor.fire('editorClick', this.editor);
+		},
+
+		editorKeyUp: function() {
+			this.editor.fire('editorKeyUp', this.editor);
 		}
 	});
 
@@ -870,6 +875,7 @@
 			'blur',
 			'focus',
 			'instanceReady',
+			'keyUp',
 			'mode',
 			'modeSwitch',
 			'modeSwitchCancelled',
@@ -908,6 +914,7 @@
 			this.editor.on('ck-themeLoaded', this.proxy(this.themeLoaded));
 			this.editor.on('ck-focus', this.proxy(this.editorFocused));
 			this.editor.on('ck-blur', this.proxy(this.editorBlurred));
+			this.editor.on('ck-keyUp', this.proxy(this.editorKeyUp));
 
 			// This one can't be proxied because we need access to it before the proxies are set up
 			this.editor.on('ckInstanceCreated', this.proxy(this.ckInstanceCreated));
@@ -1032,6 +1039,10 @@
 
 		editorClicked: function() {
 			this.editor.fire('editorClick', this.editor);
+		},
+
+		editorKeyUp: function() {
+			this.editor.fire('editorKeyUp', this.editor);
 		}
 	});
 

--- a/extensions/wikia/EditPageLayout/js/plugins/MiniEditor.js
+++ b/extensions/wikia/EditPageLayout/js/plugins/MiniEditor.js
@@ -55,6 +55,7 @@
 			// insertion method we should have a universal 'content has changed' event.
 			this.editor.on( 'editorAddMedia', this.proxy( this.editorKeyUp ) );
 			this.editor.on( 'editorAddLink', this.proxy( this.editorKeyUp ) );
+			this.editor.on( 'editorInsertTags', this.proxy( this.editorKeyUp ) );
 		},
 
 		// CKE properties are now available

--- a/extensions/wikia/EditPageLayout/js/plugins/MiniEditor.js
+++ b/extensions/wikia/EditPageLayout/js/plugins/MiniEditor.js
@@ -99,7 +99,7 @@
 		editorKeyUp: function() {
 			this.editorToggleButtonsDisabled();
 
-			if ( this.editor.ck != 'undefined' ) {
+			if ( this.editor.ck != undefined ) {
 				this.editorResize();
 			}
 		},

--- a/extensions/wikia/EditPageLayout/js/plugins/MiniEditor.js
+++ b/extensions/wikia/EditPageLayout/js/plugins/MiniEditor.js
@@ -65,7 +65,7 @@
 			// Handle positioning of RTEOverlay (image overlay etc)
 			wikiaEditor.getEditboxWrapper().bind('mouseenter.MiniEditor', function() {
 				RTE.repositionRTEOverlay(ckeditor.name);
-				RTE.overlayNode.data('editor', wikiaEditor);
+				RTE.overlayNode.data('wikiaEditor', wikiaEditor);
 			});
 		},
 

--- a/extensions/wikia/EditPageLayout/js/plugins/MiniEditor.js
+++ b/extensions/wikia/EditPageLayout/js/plugins/MiniEditor.js
@@ -6,10 +6,19 @@
 		isReady: false,
 
 		proxyEvents: [
-			'ck-instanceReady', 'ck-wysiwygModeReady', 'editorActivated',
-			'editorAfterActivated', 'editorBeforeReady', 'editorBlur',
-			'editorClear', 'editorDeactivated', 'editorAfterDeactivated',
-			'editorFocus', 'editorReady', 'editorReset', 'editorResize'
+			'ck-instanceReady',
+			'editorActivated',
+			'editorAfterActivated',
+			'editorBeforeReady',
+			'editorBlur',
+			'editorClear',
+			'editorDeactivated',
+			'editorAfterDeactivated',
+			'editorFocus',
+			'editorReady',
+			'editorReset',
+			'editorResize',
+			'editorKeyUp'
 		],
 
 		beforeInit: function() {
@@ -41,6 +50,11 @@
 			if (this.buttonsWrapper.length) {
 				this.buttons = this.buttonsWrapper.find('button, input[submit]');
 			}
+
+			// TODO: instead of having separate events for every type of content
+			// insertion method we should have a universal 'content has changed' event.
+			this.editor.on( 'editorAddMedia', this.proxy( this.editorKeyUp ) );
+			this.editor.on( 'editorAddLink', this.proxy( this.editorKeyUp ) );
 		},
 
 		// CKE properties are now available
@@ -55,9 +69,8 @@
 			});
 		},
 
-		// Re-bind event listenners for elements inside wysiwyg iframe
 		'ck-wysiwygModeReady': function() {
-			this.editor.getEditbox().bind('keyup.MiniEditor', this.proxy(this.editorResize)).keyup();
+			this.editorResize();
 		},
 
 		editorActivated: function(event) {
@@ -83,8 +96,16 @@
 			this.editor.element.addClass('active');
 		},
 
-		editorButtonsActivate: function() {
-			this.buttons.removeAttr('disabled');
+		editorKeyUp: function() {
+			this.editorToggleButtonsDisabled();
+
+			if ( this.editor.ck != 'undefined' ) {
+				this.editorResize();
+			}
+		},
+
+		editorToggleButtonsDisabled: function() {
+			this.buttons.prop( 'disabled', !this.editor.getContent().length );
 		},
 
 		editorAfterActivated: function() {
@@ -96,17 +117,6 @@
 			if (!this.isReady) {
 				this.isReady = true;
 			}
-
-			this.editor.getEditbox().on(
-				'keyup',
-				$.proxy(this.editorButtonsActivate, this)
-			);
-			this.editor.on({
-				mode: $.proxy(this.editorButtonsActivate, this),
-				editorAddImage: $.proxy(this.editorButtonsActivate, this),
-				editorAddVideo: $.proxy(this.editorButtonsActivate, this),
-				editorAddLink: $.proxy(this.editorButtonsActivate, this)
-			});
 		},
 
 		editorBeforeReady: function() {
@@ -169,7 +179,6 @@
 			if(replacedElement.is('textarea') && typeof this.editor.ck != "undefined") {
 				replacedElement.val("");
 			}
-
 		},
 
 		editorReset: function() {

--- a/extensions/wikia/MiniEditor/js/Wall/Wall.ReplyMessageForm.js
+++ b/extensions/wikia/MiniEditor/js/Wall/Wall.ReplyMessageForm.js
@@ -5,7 +5,7 @@ MiniEditor.Wall.ReplyMessageForm = $.createClass(Wall.ReplyMessageForm, {
 	constructor: function(page, model) {
 		MiniEditor.Wall.ReplyMessageForm.superclass.constructor.apply(this,arguments);
 	},
-	
+
 	deferred: '',
 	initEvents: function() {
 		var self = this;
@@ -22,11 +22,11 @@ MiniEditor.Wall.ReplyMessageForm = $.createClass(Wall.ReplyMessageForm, {
 			}
 		});
 	},
-	
+
 	focus: function(e) {
 		this.initEditor({ target: e.target });
 	},
-	
+
 	setContent: function(replyWrapper, content) {
 		if(content) {
 			var wikiaEditor = this.editor.data('wikiaEditor');
@@ -34,7 +34,7 @@ MiniEditor.Wall.ReplyMessageForm = $.createClass(Wall.ReplyMessageForm, {
 			wikiaEditor.getEditbox().putCursorAtEndCE();
 		}
 	},
-	
+
 	activatedCallback: function(event, wikiaEditor) {
 		this.deferred.resolve(wikiaEditor);
 	},
@@ -42,7 +42,7 @@ MiniEditor.Wall.ReplyMessageForm = $.createClass(Wall.ReplyMessageForm, {
 	initEditor: function(e) {
 		var target = $(e.target);
 		this.deferred = $.Deferred();
-		
+
 		// check if editor exists before unbinding placeholder (BugId:23781)
 		if (!target.data('wikiaEditor')) {
 			// Unbind placeholder and clear textarea before initing mini editor (BugId:23221)
@@ -64,21 +64,21 @@ MiniEditor.Wall.ReplyMessageForm = $.createClass(Wall.ReplyMessageForm, {
 				editorActivated: $.proxy(this.activatedCallback, this)
 			}
 		});
-		
+
 		return this.deferred.promise();
 	},
 
 	getMessageBody: function(reply) {
 		var wikiaEditor = $('.wikiaEditor', reply).data('wikiaEditor');
 		return wikiaEditor.getContent();
-	}, 
-	
+	},
+
 	getFormat: function(reply) {
 		var wikiaEditor = $('.wikiaEditor', reply).data('wikiaEditor');
 		var format = wikiaEditor.mode == 'wysiwyg' ? 'wikitext' : '';
 		return format;
 	},
-	
+
 	resetEditor: function() {
 		var wikiaEditor = $('.wikiaEditor', reply).data('wikiaEditor');
 		reply.find(this.replyBody).val('').trigger('blur');

--- a/extensions/wikia/RTE/ckeditor/_source/plugins/keystrokes/plugin.js
+++ b/extensions/wikia/RTE/ckeditor/_source/plugins/keystrokes/plugin.js
@@ -119,6 +119,14 @@ CKEDITOR.keystrokeHandler = function( editor )
 		}
 	};
 
+	// Wikia change - begin
+	// @author kflorence
+	var onKeyUp = function( event )
+	{
+		this._.editor.fire( 'keyUp', { keyCode: event.data.getKeystroke() } );
+	};
+	// Wikia change - end
+
 	CKEDITOR.keystrokeHandler.prototype =
 	{
 		/**
@@ -130,6 +138,11 @@ CKEDITOR.keystrokeHandler = function( editor )
 		 */
 		attach : function( domObject )
 		{
+			// Wikia change - begin
+			// @author kflorence
+			domObject.on( 'keyup', onKeyUp, this );
+			// Wikia change - end
+
 			// For most browsers, it is enough to listen to the keydown event
 			// only.
 			domObject.on( 'keydown', onKeyDown, this );

--- a/extensions/wikia/RTE/js/plugins/media/plugin.js
+++ b/extensions/wikia/RTE/js/plugins/media/plugin.js
@@ -427,8 +427,6 @@ RTE.mediaEditor = {
 			wikitext: wikitext
 		};
 
-		RTE.getInstanceEditor().fire('editorAddImage');
-
 		this._add(wikitext, data);
 	},
 
@@ -442,8 +440,6 @@ RTE.mediaEditor = {
 			params: params,
 			wikitext: wikitext
 		};
-
-		RTE.getInstanceEditor().fire('editorAddVideo');
 
 		this._add(wikitext, data);
 	},
@@ -471,11 +467,10 @@ RTE.mediaEditor = {
 			// insert new media (don't reinitialize all placeholders)
 			RTE.tools.insertElement(newMedia, true);
 
-			// for MiniEditor, resize the editor after adding an image.
-			RTE.getInstanceEditor().fire('editorResize');
-
 			// setup added media
 			self.plugin.setupMedia(newMedia);
+
+			RTE.getInstanceEditor().fire('editorAddMedia');
 
 			editor.focus();
 		});

--- a/extensions/wikia/Wall/js/Wall.js
+++ b/extensions/wikia/Wall/js/Wall.js
@@ -6,7 +6,7 @@ var Wall = $.createClass(Object, {
 			return;
 		}
 		var self = this;
-		
+
 		Wall.initialized = true;
 		this.wall = $(element);
 		this.settings = $.extend(true, {}, Wall.settings, settings);
@@ -63,7 +63,7 @@ var Wall = $.createClass(Object, {
 
 		// Enable tooltips
 		this.setUpVoteTooltips();
-		
+
 		$('#ForumNewMessage .highlight').popover({
 			content: function() {
 				return self.WallTooltipMeta.find('.tooltip-highlight-thread').clone();
@@ -77,17 +77,17 @@ var Wall = $.createClass(Object, {
 		$(document).ready(this.initTextareas);
 		$(window).bind('hashchange', this.proxy(this.onHashChange)).trigger('hashchange');
 	},
-	
+
 	setUpVoteTooltips: function() {
 		// tooltips for votes
 		var self = this,
 			votingControls = $('.voting-controls');
-		
+
 		votingControls.find('.vote').popover({
 			content: function() {
 				var popoverText,
 					$this = $(this);
-					
+
 				if($this.hasClass('voted') || $this.hasClass('inprogress')) {
 					return self.WallTooltipMeta.find('.tooltip-votes-voted').clone();
 				}
@@ -97,12 +97,12 @@ var Wall = $.createClass(Object, {
 		});
 
 		var votesLink = votingControls.find('.votes');
-		
+
 		if(!votesLink.hasClass('notlink')) {
 			this.enableVotesLink(votesLink);
 		}
 	},
-	
+
 	enableVotesLink: function(votesLink) {
 		var self = this;
 
@@ -113,7 +113,7 @@ var Wall = $.createClass(Object, {
 			placement: 'top'
 		});
 	},
-	
+
 	disableVotesLink: function(votesLink) {
 		votesLink.popover('destroy');
 	},
@@ -188,18 +188,18 @@ var Wall = $.createClass(Object, {
 	},
 
 	scrollToQuoted: function(e) {
-		//check if we are on thread page 
+		//check if we are on thread page
 		//then we are just going to use link
 		if($('.Wall.Thread').length != 0) {
 			return true;
 		}
-		
+
 		e.preventDefault();
 		var postfix =  $(e.target).data('postfix');
 		var main = $(e.target).closest('.message-main');
-		
+
 		if(postfix > 1) {
-			var el = $('.message-' + postfix, main);	
+			var el = $('.message-' + postfix, main);
 		} else {
 			el = main;
 		}
@@ -212,7 +212,7 @@ var Wall = $.createClass(Object, {
 		var p = el.offset();
 		window.scrollTo(0, p.top);
 	},
-	
+
 	// TODO: this should be refactored so it can be used elsewhere
 	switchWatch: function(e) {
 		var element = $(e.target);
@@ -507,7 +507,7 @@ var Wall = $.createClass(Object, {
 			})
 		});
 	},
-	
+
 	doThreadChange: function(e) {
 		e.preventDefault();
 		var target = $(e.target);
@@ -530,7 +530,7 @@ var Wall = $.createClass(Object, {
 				callback: this.proxy(function(json) {
 					if(json.status) {
 						if(UserLoginAjaxForm) {
-							UserLoginAjaxForm.prototype.reloadPage();	
+							UserLoginAjaxForm.prototype.reloadPage();
 						} else {
 							window.location.reload();
 						}
@@ -562,25 +562,25 @@ var Wall = $.createClass(Object, {
 			window.location.reload();
 		});
 	},
-	
+
 	quote: function (e) {
 		e.preventDefault();
-		
+
 		var replyForm = this.replyMessageForm,
 			message = $(e.target).closest('.message'),
 			reply = message.find(replyForm.replyWrapper),
 			editorPromise = '',
 			quotedFrom = message.data('id');
-			
+
 		if(reply.length == 0) {
 			reply = message.parent().find(replyForm.replyWrapper);
 		}
-		
+
 		var formTarget = reply.find(replyForm.replyBody);
-		
+
 		//scroll
 		$('body').scrollTo(reply, {duration: 600});
-		
+
 		// start loading editor and get promise, or mock dummy promise
 		if(typeof replyForm.initEditor === 'function') {
 			editorPromise = replyForm.initEditor({target: formTarget});
@@ -590,7 +590,7 @@ var Wall = $.createClass(Object, {
 			editorPromise = editorDeferred.promise();
 			editorDeferred.resolve('');
 		}
-		
+
 		// get formatted quote
 		var deferredQuote = $.Deferred(),
 			quotePromise = deferredQuote.promise();
@@ -598,7 +598,7 @@ var Wall = $.createClass(Object, {
 			controller: 'WallExternalController',
 			method: 'getFormattedQuoteText',
 			format: 'json',
-			data: { 
+			data: {
 				messageId: message.data('id'),
 				convertToFormat: replyForm.editor && replyForm.editor.data('wikiaEditor') ? WikiaEditor.modeToFormat(replyForm.editor.data('wikiaEditor').mode) : 'wikitext'
 			},
@@ -606,7 +606,7 @@ var Wall = $.createClass(Object, {
 				deferredQuote.resolve(data);
 			}
 		});
-		
+
 		// merge two async operations here
 		$.when(editorPromise, quotePromise).done(function() {
 			var data = arguments[1];
@@ -614,10 +614,10 @@ var Wall = $.createClass(Object, {
 				replyForm.setContent(reply, data.markup);
 			}
 		});
-		
+
 		reply.data('quotedFrom', quotedFrom);
 	},
-	
+
 	handleEditTopics: function(e) {
 		e.preventDefault();
 		var rootMessageId = $(e.target).closest('.message').data('id');
@@ -631,23 +631,23 @@ var Wall = $.createClass(Object, {
 			this.editTopics(rootMessageId);
 		}
 	},
-	
+
 	editTopics: function(rootMessageId) {
 		var relatedTopics = $('.related-topics'),
 			messageTopicEditSection = $('.message-topic-edit'),
 			messageTopicSection = messageTopicEditSection.find('.message-topic'),
-			topics = [], 
+			topics = [],
 			model = this.model;
 
 		relatedTopics.hide();
 		messageTopicEditSection.show();
-		
+
 		relatedTopics.find('.related-topic').each(function() {
 			topics.push($(this).data('topic'));
 		});
-		
+
 		var messageTopic = messageTopicSection.data('messageTopic');
-		
+
 		if(messageTopic) {
 			messageTopic.resetSelections(topics);
 		} else {
@@ -670,11 +670,11 @@ var Wall = $.createClass(Object, {
 					messageTopicEditSection.hide();
 				});
 		}
-		
+
 		messageTopic.input.focus();
-		
+
 	},
-	
+
 	moveThread: function(e) {
 		var id = $(e.target).closest('.message').data('id');
 		$.nirvana.sendRequest({

--- a/resources/mediawiki.action/mediawiki.action.edit.js
+++ b/resources/mediawiki.action/mediawiki.action.edit.js
@@ -86,6 +86,16 @@
 						'post': tagClose
 					}
 				);
+
+				// Wikia change - begin
+				// @author kflorence
+				var wikiaEditor = currentFocused.data( 'wikiaEditor' );
+
+				// Let WikiaEditor know when things are inserted
+				if ( wikiaEditor ) {
+					wikiaEditor.fire( 'editorInsertTags' );
+				}
+				// Wikia change - end
 			}
 		},
 


### PR DESCRIPTION
https://wikia.fogbugz.com/default.asp?95972

Turns out the keyup event was bound in the wrong place which caused problems because of a race condition that would intermittently fail. The editor environment is very complex because there are about six different modes it can operate in, so the generally preferred way of handling events is by adding them into the WikiaEditor object which provides similar interfaces for both the CKEditor and the MediaWiki editor. I went ahead and added a keyUp event there that we can listen to.

Along the way I fixed a few other small issues:
- You could enter one character of text, then delete it, then submit, so I added a check to make sure the editor actually had content before the buttons would be enabled. After doing that I discovered that the events for adding media were being fired too early (before the content was actually inserted) and were a bit redundant (because we want to do the same thing for all media types) so I created a single event called 'editorAddMedia' and put it in a place where we can actually catch if content has been added or not.
- There was a mismatch in data keys used by the RTEOverlayNode ('editor' and 'wikiaEditor') that was causing "TypeError: Cannot call method 'setAsActiveInstance' of undefined"
