### PR TITLE
Use globals instead of WikiFactory::getVarValueByName

### DIFF
--- a/extensions/wikia/SpecialSpamWikis/maintenance/SpecialSpamWikisCache.php
+++ b/extensions/wikia/SpecialSpamWikis/maintenance/SpecialSpamWikisCache.php
@@ -150,10 +150,11 @@ class SpecialSpamWikiCache {
                 __METHOD__
             );
         }
-        
+
         unset( $tmpDbObj );
 
-	$lu = WikiFactory::getVarValueByName( 'wgSpecialSpamWikisLastUpdate', F::app()->wg->cityId );
+		global $wgSpecialSpamWikisLastUpdate;
+		$lu = $wgSpecialSpamWikisLastUpdate;
 
 	$res = $this->dbObj->select(
                 'wikicities.city_list',

--- a/extensions/wikia/UserLogin/maintenance.php
+++ b/extensions/wikia/UserLogin/maintenance.php
@@ -168,9 +168,6 @@
 			getScope( $fromUserId, $toUserId, $condition );
 		}
 
-		// update url
-		$wgServer = WikiFactory::getVarValueByName( 'wgServer', $wgCityId );
-
 		$cnt = 0;
 		do {
 			$to = ( $toUserId - $fromUserId > $range ) ? $fromUserId + $range : $toUserId ;

--- a/skins/oasis/modules/UserPagesHeaderController.class.php
+++ b/skins/oasis/modules/UserPagesHeaderController.class.php
@@ -287,7 +287,7 @@ class UserPagesHeaderController extends WikiaController {
 	 * @param bool $arg Users has granted access (true or false)*
 	 */
 	public function executeFacebookConnect($arg) {
-		global $wgRequest, $wgCityId, $wgFacebookSyncAppID, $wgFacebookSyncAppSecret, $IP, $wgTitle;
+		global $wgRequest, $wgSitename, $wgFacebookSyncAppID, $wgFacebookSyncAppSecret, $IP, $wgTitle;
 		wfProfileIn(__METHOD__);
 
 		if ($arg['fbAccess'] == true) {
@@ -316,7 +316,7 @@ class UserPagesHeaderController extends WikiaController {
 			$this->fbUserInterests = $interests;
 			$this->fbAccess = true;
 
-			$wikiName = WikiFactory::getVarValueByName( 'wgSitename', $wgCityId );
+			$wikiName = $wgSitename;
 			$this->fbUserNameWiki = $this->getUserURL() . "|Wiki:'" .$wikiName ."'";
 
 		}


### PR DESCRIPTION
When getting value from a "local" wiki, it's much simpler to get it from global variable then calling WikiFactory method.
