### PR TITLE
bug-68841 undoing alias which caused regression

### DIFF
--- a/extensions/wikia/AdminDashboard/AdminDashboard.alias.php
+++ b/extensions/wikia/AdminDashboard/AdminDashboard.alias.php
@@ -12,8 +12,3 @@ $specialPageAliases = array();
 $specialPageAliases['en'] = array(
 	'AdminDashboard' => array( 'AdminDashboard' ),
 );
-
-/** Polish (Polski) */
-$specialPageAliases['pl'] = array(
-	'AdminDashboard' => array( 'Panel_administratora', 'AdminDashboard' ),
-);

--- a/extensions/wikia/SpecialVideos/SpecialVideos.alias.php
+++ b/extensions/wikia/SpecialVideos/SpecialVideos.alias.php
@@ -18,11 +18,6 @@ $specialPageAliases['fr'] = array(
 	'Videos' => array( 'Vidéos', 'Videos' ),
 );
 
-/** Italian (Italiano) */
-$specialPageAliases['it'] = array(
-	'Videos' => array( 'Video', 'Videos' ),
-);
-
 /** Polish (Polski) */
 $specialPageAliases['pl'] = array(
 	'Videos' => array( 'Filmy', 'Videos' ),


### PR DESCRIPTION
Two of the special page aliases added recently through https://github.com/Wikia/app/pull/511 caused regressions:

http://preview.spolecznosc.wikia.com/wiki/Specjalna:Panel_administratora - quick stats module is missing
http://preview.it.community.wikia.com/wiki/Speciale:Video - has a redirect loop

The attached commits undo the creation of these two aliases, at least until the underlying cause for these problems is found. If everything is ok, please merge with dev.
