### PR TITLE
Wall: fixing WikiaBot's posts on Empty's message wall

### DIFF
--- a/extensions/wikia/Wall/Wall.class.php
+++ b/extensions/wikia/Wall/Wall.class.php
@@ -228,7 +228,7 @@ class Wall extends WikiaModel {
 
 
 			while ( $row = $db->fetchObject( $res ) ) {
-				$out[] = WallThread::newFromId($row->comment_id);
+				$out[] = WallThread::newFromId( $row->comment_id );
 			}
 		}
 

--- a/extensions/wikia/Wall/Wall.class.php
+++ b/extensions/wikia/Wall/Wall.class.php
@@ -104,6 +104,10 @@ class Wall extends WikiaModel {
 		$this->cacheable = false;
 	}
 
+	/**
+	 * This can return false instead of where condition in case the where would
+	 * ask for parent_page_id equal 0
+	 */
 	protected function getWhere() {
 		wfProfileIn(__METHOD__);
 
@@ -134,7 +138,7 @@ class Wall extends WikiaModel {
 		$out = array();
 		$where = $this->getWhere();
 
-		if ( !empty( $where ) ) {
+		if ( $where ) {
 			$db = wfGetDB( $master ? DB_MASTER : DB_SLAVE );
 
 			$time = date ("Y-m-d H:i:s", time() - 24*7*60*60 ) ;

--- a/extensions/wikia/Wall/Wall.class.php
+++ b/extensions/wikia/Wall/Wall.class.php
@@ -110,6 +110,8 @@ class Wall extends WikiaModel {
 		if ( empty( $this->mRelatedPageId ) ) {
 			$pageId = $this->mTitle->getArticleID();
 			if ( empty( $pageId ) ) {
+				// bugid:95249 - $pageId means an empty Wall, so we shouldn't query for anything
+				// otherwise we will get some strange results like WikiaBot's posts on Empty's wall
 				$where = false;
 			} else {
 				$where = "parent_page_id = $pageId  and deleted = 0 and removed = 0";

--- a/extensions/wikia/Wall/Wall.class.php
+++ b/extensions/wikia/Wall/Wall.class.php
@@ -106,11 +106,15 @@ class Wall extends WikiaModel {
 
 	protected function getWhere() {
 		wfProfileIn(__METHOD__);
-		$pageId = $this->mTitle->getArticleID();
 
-		$where = "parent_page_id = $pageId  and deleted = 0 and removed = 0";
-
-		if( !empty($this->mRelatedPageId) ) {
+		if ( empty( $this->mRelatedPageId ) ) {
+			$pageId = $this->mTitle->getArticleID();
+			if ( empty( $pageId ) ) {
+				$where = false;
+			} else {
+				$where = "parent_page_id = $pageId  and deleted = 0 and removed = 0";
+			}
+		} else {
 			$where = "comment_id in (select comment_id from wall_related_pages where page_id = {$this->mRelatedPageId})";
 		}
 
@@ -125,34 +129,35 @@ class Wall extends WikiaModel {
 	protected function getLast7daysOrder( $master = false ) {
 		wfProfileIn(__METHOD__);
 
-		$db = wfGetDB( $master ? DB_MASTER : DB_SLAVE );
-
-		$time = date ("Y-m-d H:i:s", time() - 24*7*60*60 ) ;
-
-		$pageId = (int) $this->mTitle->getArticleID();
-
-		$res = $db->select(
-			array( 'comments_index' ),
-			array( 'parent_comment_id, count(*) as cnt' ),
-			array(
-				$this->getWhere(),
-				'parent_comment_id != 0',
-				"last_touched BETWEEN '$time' AND NOW()",
-			),
-			__METHOD__,
-			array(
-				'ORDER BY' => 'cnt desc',
-				'LIMIT' => 100,
-				'GROUP BY' => 'parent_comment_id'
-			)
-		);
-
 		$out = array();
+		$where = $this->getWhere();
 
-		while ( $row = $db->fetchObject( $res ) ) {
-			$out[] = $row->parent_comment_id;
+		if ( !empty( $where ) ) {
+			$db = wfGetDB( $master ? DB_MASTER : DB_SLAVE );
+
+			$time = date ("Y-m-d H:i:s", time() - 24*7*60*60 ) ;
+
+			$res = $db->select(
+				array( 'comments_index' ),
+				array( 'parent_comment_id, count(*) as cnt' ),
+				array(
+					$where,
+					'parent_comment_id != 0',
+					"last_touched BETWEEN '$time' AND NOW()",
+				),
+				__METHOD__,
+				array(
+					'ORDER BY' => 'cnt desc',
+					'LIMIT' => 100,
+					'GROUP BY' => 'parent_comment_id'
+				)
+			);
+
+			while ( $row = $db->fetchObject( $res ) ) {
+				$out[] = $row->parent_comment_id;
+			}
 		}
-		$ids = implode(',', $out);
+
 
 		if(!empty($out)) {
 			/* look a lit bit complicated but it is fast, tested on 150000 rows, we are expecing less then that. */
@@ -197,25 +202,28 @@ class Wall extends WikiaModel {
 
 		$offset = ($page - 1)*$this->mMaxPerPage;
 
+		$out = array();
 		$where = $this->getWhere();
 
-		$where .= ' and parent_comment_id = 0 ';
+		if ( $where ) {
+			$where .= ' and parent_comment_id = 0 ';
 
-		$orderBy = $this->getOrderBy();
+			$orderBy = $this->getOrderBy();
 
-		$query = "
+			$query = "
 			SELECT comment_id FROM comments_index
 				WHERE $where
 				ORDER BY $orderBy
 				LIMIT $offset, {$this->mMaxPerPage}
 			";
 
-		$res = $db->query( $query );
+			$res = $db->query( $query );
 
-		$out = array();
 
-		while ( $row = $db->fetchObject( $res ) ) {
-			$out[] = WallThread::newFromId($row->comment_id);
+
+			while ( $row = $db->fetchObject( $res ) ) {
+				$out[] = WallThread::newFromId($row->comment_id);
+			}
 		}
 
 		wfProfileOut(__METHOD__);
@@ -224,18 +232,22 @@ class Wall extends WikiaModel {
 
 	public function getThreadCount( $master = false ) {
 		wfProfileIn(__METHOD__);
+		$where = $this->getWhere();
+		if ( !$where ) {
+			$count = 0;
+		} else {
+			$db = wfGetDB( $master ? DB_MASTER : DB_SLAVE );
 
-		$db = wfGetDB( $master ? DB_MASTER : DB_SLAVE );
-
-		$count = $db->selectField(
-			array( 'comments_index' ),
-			array( 'count(distinct comment_id) cnt' ),
-			array(
-				'parent_comment_id' => 0,
-				$this->getWhere()
-			),
-			__METHOD__
-		);
+			$count = $db->selectField(
+				array( 'comments_index' ),
+				array( 'count(distinct comment_id) cnt' ),
+				array(
+					'parent_comment_id' => 0,
+					$where
+				),
+				__METHOD__
+			);
+		}
 
 		wfProfileOut(__METHOD__);
 		return $count;

--- a/extensions/wikia/Wall/Wall.class.php
+++ b/extensions/wikia/Wall/Wall.class.php
@@ -114,7 +114,7 @@ class Wall extends WikiaModel {
 		if ( empty( $this->mRelatedPageId ) ) {
 			$pageId = $this->mTitle->getArticleID();
 			if ( empty( $pageId ) ) {
-				// bugid:95249 - $pageId means an empty Wall, so we shouldn't query for anything
+				// bugid:95249 - empty($pageId) means the Wall does not exist yet, so we shouldn't query for anything
 				// otherwise we will get some strange results like WikiaBot's posts on Empty's wall
 				$where = false;
 			} else {

--- a/extensions/wikia/Wall/Wall.i18n.php
+++ b/extensions/wikia/Wall/Wall.i18n.php
@@ -197,6 +197,7 @@ The original post and your summary will still appear in the wiki's history.",
 	'wall-recentchanges-reopened-thread' => 'reopened thread "[[$1|$2]] on [[$3|$4\'s wall]]"',
 
 	'wall-recentchanges-deleted-reply-title' => 'A reply on message wall',
+	'wall-recentchanges-wall-created-title' => 'Created a message wall',
 	'wall-recentchanges-namespace-selector-message-wall' => 'Message Wall',
 	'wall-recentchanges-thread-group' => '$1 on <a href="$2">$3\'s wall</a>',
 	'wall-recentchanges-history-link' => 'wall history',
@@ -639,6 +640,7 @@ This message follows after http://messaging.wikia.com/wiki/MediaWiki:Prefs-email
 * $4 is wall owner
 * $5 is optional username and you can use it with GENDER parameter',
 	'wall-recentchanges-deleted-reply-title' => 'fallback reply title for deleted replies  are not accessible in archive',
+	'wall-recentchanges-wall-created-title' => 'fallback title for wall creation action',
 	'wall-recentchanges-namespace-selector-message-wall' => 'Recent changes, item in namespace dropdown',
 	'wall-recentchanges-thread-group' => 'Grouped recent changes item. Parameters:
 * $1 is thread title

--- a/extensions/wikia/Wall/WallHelper.class.php
+++ b/extensions/wikia/Wall/WallHelper.class.php
@@ -619,20 +619,40 @@ class WallHelper {
 			$articleId = $wm->getId();
 		}
 
-		$title = Title::newFromText($articleId, NS_USER_WALL_MESSAGE);
+		$ci = $wm->getCommentsIndex();
+		if ( empty($ci) && ($row->page_namespace == NS_USER_WALL) ) {
+			// change in NS_USER_WALL namespace mean that wall page was created (bugid:95249)
+			$title = F::build( 'title', array( $row->page_title, NS_USER_WALL ), 'newFromText' );
 
-		$out = array(
-			'articleUrl' => $title->getPrefixedText(),
-			'articleFullUrl' => $wm->getMessagePageUrl(),
-			'articleTitleVal' => $articleTitleTxt,
-			'articleTitleTxt' => empty($articleTitleTxt) ? wfMsg('wall-recentchanges-deleted-reply-title'):$articleTitleTxt,
-			'wallPageUrl' => $wm->getArticleTitle()->getPrefixedText(),
-			'wallPageFullUrl' => $wm->getArticleTitle()->getFullUrl(),
-			'wallPageName' => $wm->getArticleTitle()->getText(),
-			'actionUser' => $userText,
-			'isThread' => $wm->isMain(),
-			'isNew' => $isNew,
-		);
+			$out = array(
+				'articleUrl' => $title->getPrefixedText(),
+				'articleFullUrl' => $title->getFullUrl(),
+				'articleTitleVal' => '',
+				'articleTitleTxt' => wfMsg('wall-recentchanges-wall-created-title'),
+				'wallPageUrl' => $title->getLocalURL(),
+				'wallPageFullUrl' =>  $title->getFullUrl(),
+				'wallPageName' => $row->page_title,
+				'actionUser' => $userText,
+				'isThread' => $wm->isMain(),
+				'isNew' => $isNew
+			);
+
+		} else {
+			$title = Title::newFromText($articleId, NS_USER_WALL_MESSAGE);
+
+			$out = array(
+				'articleUrl' => $title->getPrefixedText(),
+				'articleFullUrl' => $wm->getMessagePageUrl(),
+				'articleTitleVal' => $articleTitleTxt,
+				'articleTitleTxt' => empty($articleTitleTxt) ? wfMsg('wall-recentchanges-deleted-reply-title'):$articleTitleTxt,
+				'wallPageUrl' => $wm->getArticleTitle()->getPrefixedText(),
+				'wallPageFullUrl' => $wm->getArticleTitle()->getFullUrl(),
+				'wallPageName' => $wm->getArticleTitle()->getText(),
+				'actionUser' => $userText,
+				'isThread' => $wm->isMain(),
+				'isNew' => $isNew
+			);
+		}
 
 		wfProfileOut(__METHOD__);
 

--- a/extensions/wikia/Wall/WallHelper.class.php
+++ b/extensions/wikia/Wall/WallHelper.class.php
@@ -620,7 +620,7 @@ class WallHelper {
 		}
 
 		$ci = $wm->getCommentsIndex();
-		if ( empty($ci) && ($row->page_namespace == NS_USER_WALL) ) {
+		if ( empty( $ci ) && ( $row->page_namespace == NS_USER_WALL ) ) {
 			// change in NS_USER_WALL namespace mean that wall page was created (bugid:95249)
 			$title = F::build( 'title', array( $row->page_title, NS_USER_WALL ), 'newFromText' );
 
@@ -628,7 +628,7 @@ class WallHelper {
 				'articleUrl' => $title->getPrefixedText(),
 				'articleFullUrl' => $title->getFullUrl(),
 				'articleTitleVal' => '',
-				'articleTitleTxt' => wfMsg('wall-recentchanges-wall-created-title'),
+				'articleTitleTxt' => wfMsg( 'wall-recentchanges-wall-created-title' ),
 				'wallPageUrl' => $title->getLocalURL(),
 				'wallPageFullUrl' =>  $title->getFullUrl(),
 				'wallPageName' => $row->page_title,
@@ -638,13 +638,13 @@ class WallHelper {
 			);
 
 		} else {
-			$title = Title::newFromText($articleId, NS_USER_WALL_MESSAGE);
+			$title = Title::newFromText( $articleId, NS_USER_WALL_MESSAGE );
 
 			$out = array(
 				'articleUrl' => $title->getPrefixedText(),
 				'articleFullUrl' => $wm->getMessagePageUrl(),
 				'articleTitleVal' => $articleTitleTxt,
-				'articleTitleTxt' => empty($articleTitleTxt) ? wfMsg('wall-recentchanges-deleted-reply-title'):$articleTitleTxt,
+				'articleTitleTxt' => empty( $articleTitleTxt ) ? wfMsg( 'wall-recentchanges-deleted-reply-title' ) : $articleTitleTxt,
 				'wallPageUrl' => $wm->getArticleTitle()->getPrefixedText(),
 				'wallPageFullUrl' => $wm->getArticleTitle()->getFullUrl(),
 				'wallPageName' => $wm->getArticleTitle()->getText(),


### PR DESCRIPTION
There are two fixes here, both related to WikiaBot's posts mentioned in bug 95249. The first issue was happening on walls without any messages - in this case the getWhere() method was returning an SQL condition asking for messages with parent_page_id set to 0, which resulted in showing broken messages on those walls.
The second fix addresses the problem with Special:Contributions for WikiaBot, which was showing a ton of posts on Empty's wall. In fact those entries are related to the fact that WikiaBot is creating message wall pages in namespace 1200 when the first item is posted. So after this fix those contributions will be propertly showed as wall creations.
