### PR TITLE
adding height style to ooyala player div so the page doesn't move up and...

### DIFF
--- a/extensions/wikia/VideoHandlers/handlers/OoyalaVideoHandler.class.php
+++ b/extensions/wikia/VideoHandlers/handlers/OoyalaVideoHandler.class.php
@@ -13,7 +13,7 @@ class OoyalaVideoHandler extends VideoHandler {
 		$containerId = 'ooyalaplayer-'.$this->videoId.'-'.time();
 
 		$embed = <<<EOT
-<div id="{$containerId}" style="width:{$width}px;"></div>
+<div id="{$containerId}" style="width:{$width}px; height:{$height}px"></div>
 <script type="text/javascript" src="http://player.ooyala.com/player.js?embedCode={$this->videoId}&width={$width}&height={$height}&playerContainerId={$containerId}&autoplay={$autoPlayStr}&wmode=opaque"></script>
 EOT;
 


### PR DESCRIPTION
... down when player loads inline

This is a minor and temporary fix that will change once we merge our video handler refactor branch into dev. 
