### PR TITLE
prevented FBConnect from loading user options during initialization

### DIFF
--- a/extensions/FBConnect/FBConnectPushEvent.php
+++ b/extensions/FBConnect/FBConnectPushEvent.php
@@ -181,12 +181,17 @@ class FBConnectPushEvent {
 					die($msg);
 				}
 
+				// @author: wladek
+				// options are lazy-checked inside each hook execution
+				/*
 				// The push event is valid, let it initialize itself if needed.
 				if( !$wgUser->getOption(self::$PREF_TO_DISABLE_ALL) ) {
 					if( $wgUser->getOption($prefName) ) {
 						$pushObj->init();
 					}
 				}
+				*/
+				$pushObj->init();
 			}
 		}
 
@@ -401,6 +406,17 @@ class FBConnectPushEvent {
 		$redirect = $wgStylePath.'/common/fbconnect/'.$wgRequest->getVal('img', '0');
 		header("Location: $redirect");
 		exit;
+	}
+
+	static public function checkUserOptions( $className ) {
+		global $wgUser;
+
+		$obj = new $className;
+		$prefName = $obj->getUserPreferenceName();
+
+		return
+			!$wgUser->getOption(self::$PREF_TO_DISABLE_ALL)
+			&& $wgUser->getOption($prefName);
 	}
 
 } // end FBConnectPushEvent class

--- a/extensions/FBConnect/pushEvents/FBPush_OnAchBadge.php
+++ b/extensions/FBConnect/pushEvents/FBPush_OnAchBadge.php
@@ -19,14 +19,18 @@ class FBPush_OnAchBadge extends FBConnectPushEvent {
 	}
 		
 	public static function onAchievementsBadgesGiven($user, $badg ){
-		global $wgContentNamespaces, $wgSitename, $wgUser, $wgServer;
+		global $wgSitename, $wgUser;
 		wfProfileIn(__METHOD__);
 
-                if( $badg->getTypeId() == BADGE_WELCOME ) {
-                    wfProfileOut(__METHOD__);
-                    return true;
-                }
+		if ( !self::checkUserOptions(__CLASS__) ) {
+			wfProfileOut(__METHOD__);
+			return true;
+		}
 
+		if( $badg->getTypeId() == BADGE_WELCOME ) {
+			wfProfileOut(__METHOD__);
+			return true;
+		}
 
 		$name = $badg->getName();
 		$img =  $badg->getPictureUrl();

--- a/extensions/FBConnect/pushEvents/FBPush_OnAddBlogPost.php
+++ b/extensions/FBConnect/pushEvents/FBPush_OnAddBlogPost.php
@@ -19,10 +19,14 @@ class FBPush_OnAddBlogPost extends FBConnectPushEvent {
 	}
 		
 	public static function articleEdit(&$article, &$user, $text, $summary,$flag, $fake1, $fake2, &$flags, $revision, &$status, $baseRevId){
-		global $wgContentNamespaces, $wgSitename;
-
+		global $wgSitename;
 		wfProfileIn(__METHOD__);
-		
+
+		if ( !self::checkUserOptions(__CLASS__) ) {
+			wfProfileOut(__METHOD__);
+			return true;
+		}
+
 		if( strlen($article->getId()) == 0 ) {
 			wfProfileOut(__METHOD__);
 			return true;

--- a/extensions/FBConnect/pushEvents/FBPush_OnAddImage.php
+++ b/extensions/FBConnect/pushEvents/FBPush_OnAddImage.php
@@ -14,23 +14,35 @@ class FBPush_OnAddImage extends FBConnectPushEvent {
 		wfProfileIn(__METHOD__);
 
 		$wgHooks['ArticleSaveComplete'][] = 'FBPush_OnAddImage::onArticleSaveComplete';
-		$wgHooks['UploadComplete'][] = 'FBPush_OnAddImage::onUploadComplet';
+		$wgHooks['UploadComplete'][] = 'FBPush_OnAddImage::onUploadComplete';
 		wfProfileOut(__METHOD__);
 	}
 
 	public static function onArticleSaveComplete(&$article, &$user, $text, $summary,$flag, $fake1, $fake2, &$flags, $revision, &$status, $baseRevId){
+		wfProfileIn(__METHOD__);
+		if ( !self::checkUserOptions(__CLASS__) ) {
+			wfProfileOut(__METHOD__);
+			return true;
+		}
+
 		if( $article->getTitle()->getNamespace() != NS_FILE ) {
+			wfProfileOut(__METHOD__);
 			return true;
 		}
 		$img = wfFindFile( $article->getTitle()->getText() );
 		if (!empty($img) && ($img->media_type == 'BITMAP') ) {
 			FBPush_OnAddImage::uploadNews( $img, $img->title->getText(), $img->title->getFullUrl("?ref=fbfeed&fbtype=addimage")) ;
 		}
+		wfProfileOut(__METHOD__);
 		return true;
 	}
 
-	public static function  onUploadComplet(&$image) {
-		global $wgServer, $wgSitename;
+	public static function  onUploadComplete(&$image) {
+		wfProfileIn(__METHOD__);
+		if ( !self::checkUserOptions(__CLASS__) ) {
+			wfProfileOut(__METHOD__);
+			return true;
+		}
 
 		/**
 		 * $image->mLocalFile is protected
@@ -39,6 +51,7 @@ class FBPush_OnAddImage extends FBConnectPushEvent {
 		if ($localFile->media_type == 'BITMAP' ) {
 			FBPush_OnAddImage::uploadNews( $localFile, $localFile->getTitle(), $localFile->getTitle()->getFullUrl( "?ref=fbfeed&fbtype=addimage" ) );
 		}
+		wfProfileOut(__METHOD__);
 		return true;
 	}
 

--- a/extensions/FBConnect/pushEvents/FBPush_OnAddVideo.php
+++ b/extensions/FBConnect/pushEvents/FBPush_OnAddVideo.php
@@ -21,6 +21,12 @@ class FBPush_OnAddVideo extends FBConnectPushEvent {
 	public static function articleCountVideoDiff(&$article,&$user,&$newText){
 		global $wgContentNamespaces, $wgSitename;
 		wfProfileIn(__METHOD__);
+
+		if ( !self::checkUserOptions(__CLASS__) ) {
+			wfProfileOut(__METHOD__);
+			return true;
+		}
+
 		if( !in_array($article->getTitle()->getNamespace(), $wgContentNamespaces) ) {
 			wfProfileOut(__METHOD__);
 			return true;

--- a/extensions/FBConnect/pushEvents/FBPush_OnArticleComment.php
+++ b/extensions/FBConnect/pushEvents/FBPush_OnArticleComment.php
@@ -21,8 +21,13 @@ class FBPush_OnArticleComment extends FBConnectPushEvent {
 	}
 	
 	public static function articleEdit(&$article, &$user, $text, $summary,$flag, $fake1, $fake2, &$flags, $revision, &$status, $baseRevId){
-		global $wgContentNamespaces, $wgServer, $wgEnableArticleCommentsExt, $wgSitename;
+		global $wgEnableArticleCommentsExt, $wgSitename;
 		wfProfileIn(__METHOD__);
+
+		if ( !self::checkUserOptions(__CLASS__) ) {
+			wfProfileOut(__METHOD__);
+			return true;
+		}
 
 		if (empty( $wgEnableArticleCommentsExt) ) {
 			wfProfileOut(__METHOD__);

--- a/extensions/FBConnect/pushEvents/FBPush_OnBlogComment.php
+++ b/extensions/FBConnect/pushEvents/FBPush_OnBlogComment.php
@@ -20,14 +20,19 @@ class FBPush_OnBlogComment extends FBConnectPushEvent {
 	
 	
 	public static function articleEdit(&$article, &$user, $text, $summary,$flag, $fake1, $fake2, &$flags, $revision, &$status, $baseRevId){
-		global $wgContentNamespaces, $wgSitename;
-		
-		if( !defined('NS_BLOG_ARTICLE_TALK') ) {
-			return true; 
+		global $wgSitename;
+		wfProfileIn(__METHOD__);
+
+		if ( !self::checkUserOptions(__CLASS__) ) {
+			wfProfileOut(__METHOD__);
+			return true;
 		}
 
-		wfProfileIn(__METHOD__);
-		
+		if( !defined('NS_BLOG_ARTICLE_TALK') ) {
+			wfProfileOut(__METHOD__);
+			return true;
+		}
+
 		if( $article->getTitle()->getNamespace() == NS_BLOG_ARTICLE_TALK ) {
 			$title_explode = explode("/", $article->getTitle()->getText());
 			$title = Title::newFromText($title_explode[0]."/".$title_explode[1], NS_BLOG_ARTICLE);

--- a/extensions/FBConnect/pushEvents/FBPush_OnLargeEdit.php
+++ b/extensions/FBConnect/pushEvents/FBPush_OnLargeEdit.php
@@ -33,7 +33,12 @@ class FBPush_OnLargeEdit extends FBConnectPushEvent {
 	public static function articleCountWordDiff(&$article,&$user,$newText, $summary,$flag, $fake1, $fake2, &$flags, $revision, &$status, $baseRevId){
 		global $wgContentNamespaces, $wgSitename;
 		wfProfileIn(__METHOD__);
-	
+
+		if ( !self::checkUserOptions(__CLASS__) ) {
+			wfProfileOut(__METHOD__);
+			return true;
+		}
+
 		if ( is_null( $revision ) ) {
 			// nothing's changed, quit early
 			wfProfileOut( __METHOD__ );

--- a/extensions/FBConnect/pushEvents/FBPush_OnRateArticle.php
+++ b/extensions/FBConnect/pushEvents/FBPush_OnRateArticle.php
@@ -21,9 +21,15 @@ class FBPush_OnRateArticle extends FBConnectPushEvent {
 	
 	public function onArticleAfterVote($user_id, &$page, $vote) {
 		global $wgSitename;
-		$article = Article::newFromID( $page );
 		wfProfileIn(__METHOD__);
-		
+
+		if ( !self::checkUserOptions(__CLASS__) ) {
+			wfProfileOut(__METHOD__);
+			return true;
+		}
+
+		$article = Article::newFromID( $page );
+
 		$params = array(
 			'$ARTICLENAME' => $article->getTitle()->getText(),
 			'$WIKINAME' => $wgSitename,

--- a/extensions/FBConnect/pushEvents/FBPush_OnWatchArticle.php
+++ b/extensions/FBConnect/pushEvents/FBPush_OnWatchArticle.php
@@ -20,8 +20,13 @@ class FBPush_OnWatchArticle extends FBConnectPushEvent {
 	
 	
 	public static function onWatchArticleComplete(&$user, &$article ){
-		global $wgContentNamespaces, $wgSitename, $wgRequest;
-		wfProfileIn(__METHOD__); 
+		global $wgSitename, $wgRequest;
+		wfProfileIn(__METHOD__);
+
+		if ( !self::checkUserOptions(__CLASS__) ) {
+			wfProfileOut(__METHOD__);
+			return true;
+		}
 
 		if ( $wgRequest->getVal('action','') == 'submit' ) {
 			wfProfileOut(__METHOD__);


### PR DESCRIPTION
This is an idea how to prevent FBConnect from loading user options during initialization.

I'm not experienced with testing Facebook Connect so if you are more experienced please do me a favor and test it.
