### PR TITLE
I18n video file page provider link

### DIFF
--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -316,7 +316,7 @@ class ArticleComment {
 
 		$comment = false;
 
-		$canDelete = $wgUser->isAllowed( 'delete' );
+		$canDelete = $wgUser->isAllowed( 'commentdelete' );
 
 		if ( self::isBlog() ) {
 			$canDelete = $canDelete || $wgUser->isAllowed( 'blog-comments-delete' );

--- a/extensions/wikia/FilePage/templates/FilePage_videoCaption.php
+++ b/extensions/wikia/FilePage/templates/FilePage_videoCaption.php
@@ -4,7 +4,7 @@
 ?>
 <div class="video-page-caption">
 	<p class="video-views"><?= wfMessage( 'video-page-views' )->numParams( $viewCount )->parse() ?></p>
-	<p><?= wfMessage( 'video-page-from-provider' )->params( $providerLink )->text() ?></p>
+	<p><?= wfMessage( 'video-page-from-provider' )->rawParams( $providerLink )->escaped() ?></p>
 	<? if( $expireDate ): ?>
 		<p class="video-provider"><?= $expireDate ?></p>
 	<? endif; ?>


### PR DESCRIPTION
This fixes an issue reported by @lizlux that was inadvertantly introduced by @siebrand with other fixes. Liz reverted the initial change of adding `escaped()` here. This re-applies that change with corrected handling of parameters via `rawParams()`
