### PR TITLE
making the dart helper optional in ooyala js just in case it's adblocked

### DIFF
--- a/extensions/wikia/VideoHandlers/js/handlers/Ooyala.js
+++ b/extensions/wikia/VideoHandlers/js/handlers/Ooyala.js
@@ -1,12 +1,12 @@
 /*global define*/
-define('wikia.ooyala', ['wikia.window', 'ext.wikia.adengine.dartvideohelper'], function(window, dartVideoHelper) {
+define('wikia.ooyala', ['wikia.window', require.optional('ext.wikia.adengine.dartvideohelper')], function(window, dartVideoHelper) {
 	'use strict';
 
 	return function(params, vb) {
 		var containerId = vb.timeStampId( params.playerId ),
 			createParams = { width: params.width + 'px', height: params.height + 'px', autoplay: params.autoPlay, onCreate: onCreate };
 
-		if (window.wgAdVideoTargeting && window.wgShowAds) {
+		if (dartVideoHelper && window.wgAdVideoTargeting && window.wgShowAds) {
 			createParams['google-ima-ads-manager'] = {
 				adTagUrl: dartVideoHelper.getUrl(),
 				showInAdControlBar : true


### PR DESCRIPTION
Currently, if allinone=0 and ad block is enabled, ooyala videos won't play due to a js error: Uncaught Module ext.wikia.adengine.dartvideohelper is not defined. This issue only really effects devbox but it makes it super hard to work on video, so this change should fix that. 

@gabrys, does this look okay to you?
