### PR TITLE
Fix crosswiki relevance

### DIFF
--- a/extensions/wikia/Search/classes/QueryService/Select/InterWiki.php
+++ b/extensions/wikia/Search/classes/QueryService/Select/InterWiki.php
@@ -49,7 +49,7 @@ class InterWiki extends AbstractSelect
 	 * @var array
 	 */
 	protected $boostFunctions = array(
-		'log(wam)^5',
+		'log(wam)^10',
 	);
 	
 	/**
@@ -136,7 +136,8 @@ class InterWiki extends AbstractSelect
 	 * @return \Wikia\Search\QueryService\Select\InterWiki
 	 */
 	protected function configureQueryFields() {
-		$this->config->setQueryField( 'wikititle', 500 );
+		$this->config->setQueryField( 'wikititle', 200 )
+		             ->setQueryField( 'wiki_description_txt', 150 );
 		return $this;
 	}
 	
@@ -145,7 +146,7 @@ class InterWiki extends AbstractSelect
 	 * @return string
 	 */
 	protected function getFilterQueryString() {
-		$filterQueries = array( Utilities::valueForField( 'iscontent', 'true') );
+		$filterQueries = [ Utilities::valueForField( 'iscontent', 'true'), '-wikiarticles:[0 TO 50]' ];
 		$hub = $this->config->getHub();
 		if (! empty( $hub ) ) {
 			$filterQueries[] = Utilities::valueForField( 'hub', $hub );

--- a/extensions/wikia/Search/classes/QueryService/Select/InterWiki.php
+++ b/extensions/wikia/Search/classes/QueryService/Select/InterWiki.php
@@ -49,11 +49,7 @@ class InterWiki extends AbstractSelect
 	 * @var array
 	 */
 	protected $boostFunctions = array(
-		'log(wikipages)^4',
-		'log(activeusers)^4',
-		'log(revcount)^1',
-		'log(views)^8',
-		'log(words)^0.5',
+		'log(wam)^5',
 	);
 	
 	/**
@@ -140,7 +136,7 @@ class InterWiki extends AbstractSelect
 	 * @return \Wikia\Search\QueryService\Select\InterWiki
 	 */
 	protected function configureQueryFields() {
-		$this->config->setQueryField( 'wikititle', 7 );
+		$this->config->setQueryField( 'wikititle', 500 );
 		return $this;
 	}
 	
@@ -195,15 +191,7 @@ class InterWiki extends AbstractSelect
 	 */
 	protected function getBoostQueryString()
 	{
-		$queryNoQuotes = preg_replace( '/ wiki\b/i', '', $this->config->getQueryNoQuotes( true ) );
-		$boostQueries = array(
-				Utilities::valueForField( 'html', $queryNoQuotes, array( 'boost'=>5, 'valueQuote'=>'\"' ) ),
-				Utilities::valueForField( 'title', $queryNoQuotes, array( 'boost'=>10, 'valueQuote'=>'\"' ) ),
-				Utilities::valueForField( 'wikititle', $queryNoQuotes, array( 'boost' => 15, 'valueQuote' => '\"' ) ),
-				Utilities::valueForField( 'host', 'answers', array( 'boost' => 10, 'negate' => true ) ),
-				Utilities::valueForField( 'host', 'respuestas', array( 'boost' => 10, 'negate' => true ) )
-		);
-		return implode( ' ', $boostQueries );
+		return '';
 	}
 	
 	/**


### PR DESCRIPTION
the updates to search (e.g. removal of nested queries and improvement of default query field boosts) caused cross wiki relevance to degrade. these improvements aim to restore this relevance, and perhaps even improve it.

this includes an increased boost for wiki title, the addition of wiki description text as a query field, using solely WAM as a boosting function (instead of a mix of values that were intended to approximate WAM), and filtering out results for wikis with less than 50 pages.
