### PR TITLE
(BugId:98744) Fix allowing duplicate number categories.

### DIFF
--- a/extensions/wikia/CategorySelect/js/CategorySelect.js
+++ b/extensions/wikia/CategorySelect/js/CategorySelect.js
@@ -376,7 +376,7 @@
 			var data = [];
 
 			this.getCategories( filter ).each(function() {
-				data.push( CategorySelect.normalize( $(this).data() ) );
+				data.push( CategorySelect.normalize( $( this ).data() ) );
 			});
 
 			return data;
@@ -417,7 +417,7 @@
 			}
 
 			return filter !== undefined ?
-				( !isNaN( parseInt( filter, 10 ) ) ?
+				( typeof filter === 'number' ?
 					// By category index (relative to other categories)
 					categories.eq( filter ) :
 					// By category name, selector string, jQuery object or DOM Element


### PR DESCRIPTION
https://wikia.fogbugz.com/default.asp?98744

Category names were being parsed as integers to determine if they could be used as an index. This change makes it so only numbers passed in explicitly will be treated this way (otherwise, assume they should be string matched).
