### PR TITLE
Bugid 102384 forum highlighting

### DIFF
--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -677,7 +677,9 @@ class ArticleComment {
 			 */
 
 			$article = new Article( $commentTitle, intval( $this->mLastRevId ) );
-			if ($preserveMetadata) $this->mMetadata = $metadata;
+			if ( $preserveMetadata ) {
+				$this->mMetadata = $metadata;
+			}
 			$retval = self::doSaveAsArticle($text, $article, $user, $this->mMetadata, $summary );
 
 			if(!empty($title)) {

--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -638,12 +638,13 @@ class ArticleComment {
 	 * doSaveComment -- save comment
 	 *
 	 * @access public
-	 *
+	 * @param $preserveMetadata: hack to fix bug 102384 (prevent metadata override when trying to modify one of metadata keys)
 	 * @return Array or false on error. - TODO: Document what the array contains.
 	 */
-	public function doSaveComment( $text, $user, $title = null, $commentId = 0, $force = false, $summary = '' ) {
+	public function doSaveComment( $text, $user, $title = null, $commentId = 0, $force = false, $summary = '', $preserveMetadata = false ) {
 		global $wgTitle;
 		wfProfileIn( __METHOD__ );
+		$metadata = $this->mMetadata;
 
 		$this->load(true);
 		if ( $force || ($this->canEdit() && !ArticleCommentInit::isFbConnectionNeeded()) ) {
@@ -676,6 +677,7 @@ class ArticleComment {
 			 */
 
 			$article = new Article( $commentTitle, intval( $this->mLastRevId ) );
+			if ($preserveMetadata) $this->mMetadata = $metadata;
 			$retval = self::doSaveAsArticle($text, $article, $user, $this->mMetadata, $summary );
 
 			if(!empty($title)) {

--- a/extensions/wikia/Wall/WallExternalController.class.php
+++ b/extensions/wikia/Wall/WallExternalController.class.php
@@ -202,13 +202,13 @@ class WallExternalController extends WikiaController {
 			return true;
 		}
 
-		$ns = $this->request->getVal('pagenamespace');
+		$ns = $this->request->getVal( 'pagenamespace' );
 		$notifyEveryone = false;
-		if ($helper->isAllowedNotifyEveryone($ns, $this->wg->User)) {
-			$notifyEveryone = $this->request->getVal('notifyeveryone', false) == 1;
+		if ( $helper->isAllowedNotifyEveryone( $ns, $this->wg->User ) ) {
+			$notifyEveryone = $this->request->getVal( 'notifyeveryone', false ) == 1;
 		}
 
-		$title = F::build('Title', array($this->request->getVal('pagetitle'), $ns), 'newFromText');
+		$title = F::build( 'Title', array( $this->request->getVal ('pagetitle' ), $ns ), 'newFromText' );
 		$wallMessage = F::build('WallMessage', array($body, $title, $this->wg->User, $titleMeta, false, $relatedTopics, true, $notifyEveryone), 'buildNewMessageAndPost');
 
 		if( $wallMessage === false ) {

--- a/extensions/wikia/Wall/WallExternalController.class.php
+++ b/extensions/wikia/Wall/WallExternalController.class.php
@@ -202,12 +202,13 @@ class WallExternalController extends WikiaController {
 			return true;
 		}
 
+		$ns = $this->request->getVal('pagenamespace');
 		$notifyEveryone = false;
-		if ($helper->isAllowedNotifyEveryone($this->wg->Title->getNamespace(), $this->wg->User)) {
+		if ($helper->isAllowedNotifyEveryone($ns, $this->wg->User)) {
 			$notifyEveryone = $this->request->getVal('notifyeveryone', false) == 1;
 		}
 
-		$title = F::build('Title', array($this->request->getVal('pagetitle'), $this->request->getVal('pagenamespace')), 'newFromText');
+		$title = F::build('Title', array($this->request->getVal('pagetitle'), $ns), 'newFromText');
 		$wallMessage = F::build('WallMessage', array($body, $title, $this->wg->User, $titleMeta, false, $relatedTopics, true, $notifyEveryone), 'buildNewMessageAndPost');
 
 		if( $wallMessage === false ) {

--- a/extensions/wikia/Wall/WallMessage.class.php
+++ b/extensions/wikia/Wall/WallMessage.class.php
@@ -246,22 +246,24 @@ class WallMessage {
 		return $out;
 	}
 
-	public function doSaveComment($body, $user, $summary = '', $force = false) {
+	public function doSaveComment($body, $user, $summary = '', $force = false, $preserveMetadata = false) {
 		wfProfileIn( __METHOD__ );
 
 		if($this->canEdit($user) || $force){
-			$this->getArticleComment()->doSaveComment( $body, $user, null, 0, true, $summary );
+			$this->getArticleComment()->doSaveComment( $body, $user, null, 0, true, $summary, $preserveMetadata );
 		}
 		if( !$this->isMain() ) {
 			// after changing reply invalidate thread cache
 			$this->getThread()->invalidateCache();
 		}
-		/*
-		* mech: EditPage calls Article with watchThis set to false
-		*       which causes this article comment to be unsubscribed.
-		*       so we re-subscribe (it's not a hack, it's a workaround)
-		*/
-		$this->addWatch($user);
+		if ( !$preserveMetadata ) { // it's only a request to modify metadata, so we probably don't need to add watch
+			/**
+			 * mech: EditPage calls Article with watchThis set to false
+			 *      in Wall we assume that save on message subscribes you to it
+			 *      so we re-scubscribe it here
+			*/
+			$this->addWatch($user);
+		}
 		$out = $this->getArticleComment()->parseText($body);
 		wfProfileOut( __METHOD__ );
 		return $out;
@@ -269,8 +271,12 @@ class WallMessage {
 
 	public function doSaveMetadata($user, $summary = '', $force = false) {
 		wfProfileIn( __METHOD__ );
+		//@todo: as getRawText overwrites the metadata, we have to make a copy of it
+		//this is done only to quickly fix case 102384, this whole thing should be refactored
+		$m = $this->getArticleComment()->mMetadata;
 		$body = $this->getRawText(true);
-		$out = $this->doSaveComment($body, $user, $summary, $force);
+		$this->getArticleComment()->mMetadata = $m;
+		$out = $this->doSaveComment($body, $user, $summary, $force, true);
 		wfProfileOut( __METHOD__ );
 		return $out;
 	}
@@ -378,7 +384,7 @@ class WallMessage {
 			$this->load(true);
 			if($notifyeveryone) {
 				$this->getArticleComment()->setMetaData('notify_everyone', time());
-				$this->doSaveMetadata($app->wg->User, wfMsgForContent('wall-message-update-highlight-summary') );
+				$this->doSaveMetadata($app->wg->User, wfMsgForContent('wall-message-update-highlight-summary'), false, true );
 				$rev = $this->getArticleComment()->mLastRevision;
 				$notif = F::build('WallNotificationEntity', array($rev, $this->cityId), 'createFromRev');
 				$wne->addNotificationToQueue($notif);
@@ -386,7 +392,7 @@ class WallMessage {
 				$this->getArticleComment()->removeMetadata('notify_everyone');
 				$pageId = $this->getId();
 				$wne->removeNotificationFromQueue($pageId);
-				$this->doSaveMetadata($app->wg->User, wfMsgForContent('wall-message-update-removed-highlight-summary') );
+				$this->doSaveMetadata($app->wg->User, wfMsgForContent('wall-message-update-removed-highlight-summary'), false, true );
 			}
 		}
 	}

--- a/extensions/wikia/Wall/WallMessage.class.php
+++ b/extensions/wikia/Wall/WallMessage.class.php
@@ -262,7 +262,7 @@ class WallMessage {
 			 *      in Wall we assume that save on message subscribes you to it
 			 *      so we re-scubscribe it here
 			*/
-			$this->addWatch($user);
+			$this->addWatch( $user );
 		}
 		$out = $this->getArticleComment()->parseText($body);
 		wfProfileOut( __METHOD__ );
@@ -273,10 +273,10 @@ class WallMessage {
 		wfProfileIn( __METHOD__ );
 		//@todo: as getRawText overwrites the metadata, we have to make a copy of it
 		//this is done only to quickly fix case 102384, this whole thing should be refactored
-		$m = $this->getArticleComment()->mMetadata;
+		$metadataCopy = $this->getArticleComment()->mMetadata;
 		$body = $this->getRawText(true);
-		$this->getArticleComment()->mMetadata = $m;
-		$out = $this->doSaveComment($body, $user, $summary, $force, true);
+		$this->getArticleComment()->mMetadata = $metadataCopy;
+		$out = $this->doSaveComment( $body, $user, $summary, $force, true );
 		wfProfileOut( __METHOD__ );
 		return $out;
 	}
@@ -384,7 +384,7 @@ class WallMessage {
 			$this->load(true);
 			if($notifyeveryone) {
 				$this->getArticleComment()->setMetaData('notify_everyone', time());
-				$this->doSaveMetadata($app->wg->User, wfMsgForContent('wall-message-update-highlight-summary'), false, true );
+				$this->doSaveMetadata( $app->wg->User, wfMsgForContent( 'wall-message-update-highlight-summary' ), false, true );
 				$rev = $this->getArticleComment()->mLastRevision;
 				$notif = F::build('WallNotificationEntity', array($rev, $this->cityId), 'createFromRev');
 				$wne->addNotificationToQueue($notif);
@@ -392,7 +392,7 @@ class WallMessage {
 				$this->getArticleComment()->removeMetadata('notify_everyone');
 				$pageId = $this->getId();
 				$wne->removeNotificationFromQueue($pageId);
-				$this->doSaveMetadata($app->wg->User, wfMsgForContent('wall-message-update-removed-highlight-summary'), false, true );
+				$this->doSaveMetadata( $app->wg->User, wfMsgForContent( 'wall-message-update-removed-highlight-summary' ), false, true );
 			}
 		}
 	}


### PR DESCRIPTION
Fix the permission check in WallExternalController to use the namespace of the actual message (wgTitle in ajax request is not the thing we want to use here)
Add some workarounds to be able to modify article comment metadata - as saving article comments was preceded with loading metadata from database.
