### PR TITLE
Removing old beacon_id code

### DIFF
--- a/resources/wikia/jquery.wikia.js
+++ b/resources/wikia/jquery.wikia.js
@@ -581,11 +581,6 @@ $(function() {
 		$().log('DOM ready after ' + loadTime + ' ms', window.skin);
 	}
 
-	//beacon_id cookie
-	if ( window.beacon_id ) {
-		$.cookies.set( 'wikia_beacon_id', window.beacon_id, { path: wgCookiePath, domain: wgCookieDomain });
-	}
-
 	// For selenium tests
 	window.wgWikiaDOMReady = true;
 


### PR DESCRIPTION
Beacon_id comes in cookie and wikia.beack_id is set (in track.php) to the cookie value.
 There should be no need for reverse operation (setting cookie back based on the value of js variable)
