### PR TITLE
(BugId:100119) Fix improper diff for last section edits due to categories

### DIFF
--- a/extensions/wikia/EditPageLayout/SpecialCustomEditPage.class.php
+++ b/extensions/wikia/EditPageLayout/SpecialCustomEditPage.class.php
@@ -458,10 +458,8 @@ class SpecialCustomEditPage extends SpecialPage {
 				// Add categories to wikitext for preview and diff
 				if ( !empty( $this->app->wg->EnableCategorySelectExt ) ) {
 					$categories = $this->request->getVal( 'categories', '' );
-					$section = $this->request->getVal( 'section', '' );
 
-					// Only add if editing entire article (not section)
-					if ( empty( $section ) && !empty( $categories ) ) {
+					if ( !empty( $categories ) ) {
 						$wikitext .= CategorySelect::changeFormat( $categories, 'json', 'wikitext' );
 					}
 				}


### PR DESCRIPTION
https://wikia.fogbugz.com/default.asp?100119

Regardless of section, populate the diff with the provided categories (from JS). Sections without categories won't have any categories passed anyways and the last section of an article generally has categories in it.
