### PR TITLE
(BugId:100980) - Fix losing categories inside of templates on save.

### DIFF
--- a/extensions/wikia/CategorySelect/CategorySelectController.class.php
+++ b/extensions/wikia/CategorySelect/CategorySelectController.class.php
@@ -202,7 +202,7 @@ class CategorySelectController extends WikiaController {
 			$wikitext = $article->fetchContent();
 
 			// Pull in categories from templates inside of the article (BugId:100980)
-			$options = new ParserOptions( $this->wg->User );
+			$options = new ParserOptions();
 			$wikitext = ParserPool::preprocess( $wikitext, $title, $options );
 
 			$data = CategorySelect::extractCategoriesFromWikitext( $wikitext, true );

--- a/extensions/wikia/CategorySelect/CategorySelectController.class.php
+++ b/extensions/wikia/CategorySelect/CategorySelectController.class.php
@@ -201,6 +201,10 @@ class CategorySelectController extends WikiaController {
 			$article = new Article( $title );
 			$wikitext = $article->fetchContent();
 
+			// Pull in categories from templates inside of the article (BugId:100980)
+			$options = new ParserOptions( $this->wg->User );
+			$wikitext = $this->wg->Parser->preprocess( $wikitext, $title, $options );
+
 			$data = CategorySelect::extractCategoriesFromWikitext( $wikitext, true );
 
 			// Merge categories stored in the article with any that were passed in and remove duplicates.

--- a/extensions/wikia/CategorySelect/CategorySelectController.class.php
+++ b/extensions/wikia/CategorySelect/CategorySelectController.class.php
@@ -203,7 +203,7 @@ class CategorySelectController extends WikiaController {
 
 			// Pull in categories from templates inside of the article (BugId:100980)
 			$options = new ParserOptions( $this->wg->User );
-			$wikitext = $this->wg->Parser->preprocess( $wikitext, $title, $options );
+			$wikitext = ParserPool::preprocess( $wikitext, $title, $options );
 
 			$data = CategorySelect::extractCategoriesFromWikitext( $wikitext, true );
 

--- a/includes/wikia/parser/ParserPool.class.php
+++ b/includes/wikia/parser/ParserPool.class.php
@@ -89,4 +89,20 @@ class ParserPool {
 		return $result;
 	}
 
+	/**
+	 * Expand templates and variables in the text, producing valid, static wikitext.
+	 * Also removes comments.
+	 *
+	 * @return string
+	 */
+	public static function preprocess( $text, Title $title, ParserOptions $options, $revid = null ) {
+		$args = func_get_args();
+
+		$parser = self::get();
+		$result = call_user_func_array( array( $parser, 'preprocess' ), $args );
+		self::release($parser);
+
+		return $result;
+	}
+
 }


### PR DESCRIPTION
https://wikia.fogbugz.com/default.asp?100980

Adds a parser preprocess call so that templates will be expanded inside of the article wikitext when new categories are added. I'm afraid this might be slow on huge articles, but it probably doesn't matter because it's an AJAX request. Nevertheless, open to better ways of scraping for all the categories on a page.
