### PR TITLE
Bugid 102744

### DIFF
--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -645,7 +645,10 @@ class ArticleComment {
 		global $wgTitle;
 		wfProfileIn( __METHOD__ );
 
+		$mMetadata = $this->mMetadata;
+
 		$this->load(true);
+
 		if ( $force || ($this->canEdit() && !ArticleCommentInit::isFbConnectionNeeded()) ) {
 
 			if ( wfReadOnly() ) {
@@ -661,6 +664,10 @@ class ArticleComment {
 			if ( empty($this->mTitle) && !$commentId ) {
 				wfProfileOut( __METHOD__ );
 				return false;
+			}
+
+			if ( !empty($mMetadata) && $mMetadata != $this->mMetadata ) {
+				$this->mMetadata = $mMetadata;
 			}
 
 			$commentTitle = $this->mTitle ? $this->mTitle : Title::newFromId($commentId);

--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -684,7 +684,9 @@ class ArticleComment {
 			 */
 
 			$article = new Article( $commentTitle, intval( $this->mLastRevId ) );
-			if ($preserveMetadata) $this->mMetadata = $metadata;
+			if ( $preserveMetadata ) {
+				$this->mMetadata = $metadata;
+			}
 			$retval = self::doSaveAsArticle($text, $article, $user, $this->mMetadata, $summary );
 
 			if(!empty($title)) {

--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -638,12 +638,13 @@ class ArticleComment {
 	 * doSaveComment -- save comment
 	 *
 	 * @access public
-	 *
+	 * @param $preserveMetadata: hack to fix bug 102384 (prevent metadata override when trying to modify one of metadata keys)
 	 * @return Array or false on error. - TODO: Document what the array contains.
 	 */
-	public function doSaveComment( $text, $user, $title = null, $commentId = 0, $force = false, $summary = '' ) {
+	public function doSaveComment( $text, $user, $title = null, $commentId = 0, $force = false, $summary = '', $preserveMetadata = false ) {
 		global $wgTitle;
 		wfProfileIn( __METHOD__ );
+		$metadata = $this->mMetadata;
 
 		$mMetadata = $this->mMetadata;
 
@@ -683,6 +684,7 @@ class ArticleComment {
 			 */
 
 			$article = new Article( $commentTitle, intval( $this->mLastRevId ) );
+			if ($preserveMetadata) $this->mMetadata = $metadata;
 			$retval = self::doSaveAsArticle($text, $article, $user, $this->mMetadata, $summary );
 
 			if(!empty($title)) {

--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -646,8 +646,6 @@ class ArticleComment {
 		wfProfileIn( __METHOD__ );
 		$metadata = $this->mMetadata;
 
-		$mMetadata = $this->mMetadata;
-
 		$this->load(true);
 
 		if ( $force || ($this->canEdit() && !ArticleCommentInit::isFbConnectionNeeded()) ) {
@@ -665,10 +663,6 @@ class ArticleComment {
 			if ( empty($this->mTitle) && !$commentId ) {
 				wfProfileOut( __METHOD__ );
 				return false;
-			}
-
-			if ( !empty($mMetadata) && $mMetadata != $this->mMetadata ) {
-				$this->mMetadata = $mMetadata;
 			}
 
 			$commentTitle = $this->mTitle ? $this->mTitle : Title::newFromId($commentId);

--- a/extensions/wikia/Forum/Forum.i18n.php
+++ b/extensions/wikia/Forum/Forum.i18n.php
@@ -145,6 +145,7 @@ your email preferences here: http://community.wikia.com/Special:Preferences',
 	'forum-activity-module-heading' => 'Forum Activity',
 	'forum-related-module-heading' => 'Related Threads',
 	'forum-activity-module-posted' => '$1 posted a reply $2',
+	'forum-activity-module-edited' => '$1 edited a discussion $2',
 	'forum-activity-module-started' => '$1 started a discussion $2',
 
 	/* Forum Participation Module */
@@ -265,6 +266,7 @@ $messages['qqq'] = array(
 * $1 is the first user who replied (GENDER is supported in this message).",
 	'forum-activity-module-heading' => 'Forum Activity right rail module heading',
 	'forum-activity-module-posted' => '$1 is username, $2 is url to user page, $3 is a translated time statement such as "20 seconds ago" or "20 hours ago" or "20 days ago"',
+	'forum-activity-module-edited' => '$1 is username, $2 is url to user page, $3 is a translated time statement such as "20 seconds ago" or "20 hours ago" or "20 days ago"',
 	'forum-participation-module-heading' => 'Forum Participation right rail module heading.  Informal, and state "there are these people here"',
 	'forum-participation-module-kudos' => 'Gives state of kudos user activity by event and time.  $1 is a url link to the kudos event page.  $2 is a translated time statement such as "20 seconds ago" or "20 hours ago" or "20 days ago"',
 	'forum-participation-module-posted' => 'Gives state of posted user activity by event and time.  $1 is a url link to the posted event page.  $2 is a translated time statement such as "20 seconds ago" or "20 hours ago" or "20 days ago"',

--- a/extensions/wikia/Forum/templates/Forum_forumActivityModule.php
+++ b/extensions/wikia/Forum/templates/Forum_forumActivityModule.php
@@ -10,7 +10,7 @@
 			<div class="edited-by">
 				<?php $user = '<a href="'.$value['user']->getUserPage()->getFullUrl().'">'.$value['display_username'].'</a>'; ?>
 				<?php $time = '<span class="timeago abstimeago" title="'.$value['event_iso'].'" alt="'.$value['event_mw'].'">&nbsp;</span>' ?>
-				<?= wfMsg( $value['is_reply'] ? 'forum-activity-module-posted':'forum-activity-module-started', array($user, $time )); ?>			
+				<?= wfMsg( $value['is_reply'] ? 'forum-activity-module-posted': ($value['action'] ? 'forum-activity-module-started' : 'forum-activity-module-edited'), array($user, $time )); ?>
 			</div>
 		</li>
 		<?php endforeach; ?>

--- a/extensions/wikia/Wall/WallExternalController.class.php
+++ b/extensions/wikia/Wall/WallExternalController.class.php
@@ -511,7 +511,7 @@ class WallExternalController extends WikiaController {
 		$wallMessage->load();
 
 		$wallMessage->setMetaTitle($newtitle);
-		$text = $wallMessage->doSaveComment( $newbody, $this->wg->User );
+		$text = $wallMessage->doSaveComment( $newbody, $this->wg->User, '', false, true );
 
 		$this->response->setVal('isotime', wfTimestamp(TS_ISO_8601) );
 		$this->response->setVal('fulltime', $this->wg->Lang->timeanddate( wfTimestamp(TS_MW) ) );

--- a/extensions/wikia/Wall/WallExternalController.class.php
+++ b/extensions/wikia/Wall/WallExternalController.class.php
@@ -202,13 +202,13 @@ class WallExternalController extends WikiaController {
 			return true;
 		}
 
-		$ns = $this->request->getVal('pagenamespace');
+		$ns = $this->request->getVal( 'pagenamespace' );
 		$notifyEveryone = false;
-		if ($helper->isAllowedNotifyEveryone($ns, $this->wg->User)) {
-			$notifyEveryone = $this->request->getVal('notifyeveryone', false) == 1;
+		if ( $helper->isAllowedNotifyEveryone( $ns, $this->wg->User ) ) {
+			$notifyEveryone = $this->request->getVal( 'notifyeveryone', false ) == 1;
 		}
 
-		$title = F::build('Title', array($this->request->getVal('pagetitle'), $ns), 'newFromText');
+		$title = F::build( 'Title', array( $this->request->getVal ('pagetitle' ), $ns ), 'newFromText' );
 		$wallMessage = F::build('WallMessage', array($body, $title, $this->wg->User, $titleMeta, false, $relatedTopics, true, $notifyEveryone), 'buildNewMessageAndPost');
 
 		if( $wallMessage === false ) {

--- a/extensions/wikia/Wall/WallExternalController.class.php
+++ b/extensions/wikia/Wall/WallExternalController.class.php
@@ -202,12 +202,13 @@ class WallExternalController extends WikiaController {
 			return true;
 		}
 
+		$ns = $this->request->getVal('pagenamespace');
 		$notifyEveryone = false;
-		if ($helper->isAllowedNotifyEveryone($this->wg->Title->getNamespace(), $this->wg->User)) {
+		if ($helper->isAllowedNotifyEveryone($ns, $this->wg->User)) {
 			$notifyEveryone = $this->request->getVal('notifyeveryone', false) == 1;
 		}
 
-		$title = F::build('Title', array($this->request->getVal('pagetitle'), $this->request->getVal('pagenamespace')), 'newFromText');
+		$title = F::build('Title', array($this->request->getVal('pagetitle'), $ns), 'newFromText');
 		$wallMessage = F::build('WallMessage', array($body, $title, $this->wg->User, $titleMeta, false, $relatedTopics, true, $notifyEveryone), 'buildNewMessageAndPost');
 
 		if( $wallMessage === false ) {

--- a/extensions/wikia/Wall/WallHistory.class.php
+++ b/extensions/wikia/Wall/WallHistory.class.php
@@ -150,7 +150,6 @@ class WallHistory extends WikiaModel {
 
 	public function  getLastPosts($ns, $count = 5) {
 		$where = array(
-			'action' => WH_NEW,
 			'post_ns' => MWNamespace::getSubject( $ns ),
 			'deleted_or_removed' => 0
 		);
@@ -177,7 +176,7 @@ class WallHistory extends WikiaModel {
 				}
 			}
 		}
-		
+
 		return $out;
 	}
 	

--- a/extensions/wikia/Wall/WallMessage.class.php
+++ b/extensions/wikia/Wall/WallMessage.class.php
@@ -246,22 +246,24 @@ class WallMessage {
 		return $out;
 	}
 
-	public function doSaveComment($body, $user, $summary = '', $force = false) {
+	public function doSaveComment($body, $user, $summary = '', $force = false, $preserveMetadata = false) {
 		wfProfileIn( __METHOD__ );
 
 		if($this->canEdit($user) || $force){
-			$this->getArticleComment()->doSaveComment( $body, $user, null, 0, true, $summary );
+			$this->getArticleComment()->doSaveComment( $body, $user, null, 0, true, $summary, $preserveMetadata );
 		}
 		if( !$this->isMain() ) {
 			// after changing reply invalidate thread cache
 			$this->getThread()->invalidateCache();
 		}
-		/*
-		* mech: EditPage calls Article with watchThis set to false
-		*       which causes this article comment to be unsubscribed.
-		*       so we re-subscribe (it's not a hack, it's a workaround)
-		*/
-		$this->addWatch($user);
+		if ( !$preserveMetadata ) { // it's only a request to modify metadata, so we probably don't need to add watch
+			/**
+			 * mech: EditPage calls Article with watchThis set to false
+			 *      in Wall we assume that save on message subscribes you to it
+			 *      so we re-scubscribe it here
+			*/
+			$this->addWatch($user);
+		}
 		$out = $this->getArticleComment()->parseText($body);
 		wfProfileOut( __METHOD__ );
 		return $out;
@@ -269,8 +271,12 @@ class WallMessage {
 
 	public function doSaveMetadata($user, $summary = '', $force = false) {
 		wfProfileIn( __METHOD__ );
+		//@todo: as getRawText overwrites the metadata, we have to make a copy of it
+		//this is done only to quickly fix case 102384, this whole thing should be refactored
+		$m = $this->getArticleComment()->mMetadata;
 		$body = $this->getRawText(true);
-		$out = $this->doSaveComment($body, $user, $summary, $force);
+		$this->getArticleComment()->mMetadata = $m;
+		$out = $this->doSaveComment($body, $user, $summary, $force, true);
 		wfProfileOut( __METHOD__ );
 		return $out;
 	}
@@ -378,7 +384,7 @@ class WallMessage {
 			$this->load(true);
 			if($notifyeveryone) {
 				$this->getArticleComment()->setMetaData('notify_everyone', time());
-				$this->doSaveMetadata($app->wg->User, wfMsgForContent('wall-message-update-highlight-summary') );
+				$this->doSaveMetadata($app->wg->User, wfMsgForContent('wall-message-update-highlight-summary'), false, true );
 				$rev = $this->getArticleComment()->mLastRevision;
 				$notif = F::build('WallNotificationEntity', array($rev, $this->cityId), 'createFromRev');
 				$wne->addNotificationToQueue($notif);
@@ -386,7 +392,7 @@ class WallMessage {
 				$this->getArticleComment()->removeMetadata('notify_everyone');
 				$pageId = $this->getId();
 				$wne->removeNotificationFromQueue($pageId);
-				$this->doSaveMetadata($app->wg->User, wfMsgForContent('wall-message-update-removed-highlight-summary') );
+				$this->doSaveMetadata($app->wg->User, wfMsgForContent('wall-message-update-removed-highlight-summary'), false, true );
 			}
 		}
 	}

--- a/extensions/wikia/Wall/WallMessage.class.php
+++ b/extensions/wikia/Wall/WallMessage.class.php
@@ -262,7 +262,7 @@ class WallMessage {
 			 *      in Wall we assume that save on message subscribes you to it
 			 *      so we re-scubscribe it here
 			*/
-			$this->addWatch($user);
+			$this->addWatch( $user );
 		}
 		$out = $this->getArticleComment()->parseText($body);
 		wfProfileOut( __METHOD__ );
@@ -273,10 +273,10 @@ class WallMessage {
 		wfProfileIn( __METHOD__ );
 		//@todo: as getRawText overwrites the metadata, we have to make a copy of it
 		//this is done only to quickly fix case 102384, this whole thing should be refactored
-		$m = $this->getArticleComment()->mMetadata;
+		$metadataCopy = $this->getArticleComment()->mMetadata;
 		$body = $this->getRawText(true);
-		$this->getArticleComment()->mMetadata = $m;
-		$out = $this->doSaveComment($body, $user, $summary, $force, true);
+		$this->getArticleComment()->mMetadata = $metadataCopy;
+		$out = $this->doSaveComment( $body, $user, $summary, $force, true );
 		wfProfileOut( __METHOD__ );
 		return $out;
 	}
@@ -384,7 +384,7 @@ class WallMessage {
 			$this->load(true);
 			if($notifyeveryone) {
 				$this->getArticleComment()->setMetaData('notify_everyone', time());
-				$this->doSaveMetadata($app->wg->User, wfMsgForContent('wall-message-update-highlight-summary'), false, true );
+				$this->doSaveMetadata( $app->wg->User, wfMsgForContent( 'wall-message-update-highlight-summary' ), false, true );
 				$rev = $this->getArticleComment()->mLastRevision;
 				$notif = F::build('WallNotificationEntity', array($rev, $this->cityId), 'createFromRev');
 				$wne->addNotificationToQueue($notif);
@@ -392,7 +392,7 @@ class WallMessage {
 				$this->getArticleComment()->removeMetadata('notify_everyone');
 				$pageId = $this->getId();
 				$wne->removeNotificationFromQueue($pageId);
-				$this->doSaveMetadata($app->wg->User, wfMsgForContent('wall-message-update-removed-highlight-summary'), false, true );
+				$this->doSaveMetadata( $app->wg->User, wfMsgForContent( 'wall-message-update-removed-highlight-summary' ), false, true );
 			}
 		}
 	}


### PR DESCRIPTION
After bug fixed, I found another issue. Renamed Thread wasn't appear on Forum Activity, because there are shown only new posts and replies. I added also edited posts there, but I'm not sure should they be shown there.

It's also merged with https://github.com/Wikia/app/pull/777, because it has similar solutions
