### PR TITLE
(BugId:99348) - Attempt to fix category duplication in the editor.

### DIFF
--- a/extensions/wikia/CategorySelect/CategorySelectController.class.php
+++ b/extensions/wikia/CategorySelect/CategorySelectController.class.php
@@ -205,13 +205,10 @@ class CategorySelectController extends WikiaController {
 			$options = new ParserOptions();
 			$wikitext = ParserPool::preprocess( $wikitext, $title, $options );
 
+			// Extract categories from the article, merge them with those passed in, weed out
+			// duplicates and finally append them back to the article.
 			$data = CategorySelect::extractCategoriesFromWikitext( $wikitext, true );
-
-			// Merge categories stored in the article with any that were passed in and remove duplicates.
-			$categories = array_merge( $data[ 'categories' ], $categories );
-			$categories = CategorySelect::getUniqueCategories( $categories );
-
-			// Convert categories to wikitext and append them to the article's wikitext
+			$categories = CategorySelect::getUniqueCategories( $data[ 'categories' ], $categories );
 			$wikitext = $data[ 'wikitext' ] . CategorySelect::changeFormat( $categories, 'array', 'wikitext' );
 
 			$dbw = $this->wf->GetDB( DB_MASTER );

--- a/extensions/wikia/CategorySelect/CategorySelectHooksHelper.class.php
+++ b/extensions/wikia/CategorySelect/CategorySelectHooksHelper.class.php
@@ -57,11 +57,7 @@ class CategorySelectHooksHelper {
 
 		if ( $request->wasPosted() ) {
 			$categories = $editPage->safeUnicodeInput( $request, 'categories' );
-
-			// Prevents whitespace being added when no categories are present
-			if ( trim( $categories ) == '' ) {
-				$categories = '';
-			}
+			$categories = CategorySelect::changeFormat( $categories, 'json', 'array' );
 
 			// Concatenate categories to article wikitext (if there are any).
 			if ( !empty( $categories ) ) {
@@ -84,7 +80,6 @@ class CategorySelectHooksHelper {
 				// Extract categories from the article, merge them with those passed in, weed out
 				// duplicates and finally append them back to the article (BugId:99348).
 				$data = CategorySelect::extractCategoriesFromWikitext( $editPage->textbox1, true );
-				$categories = CategorySelect::changeFormat( $categories, 'json', 'array' );
 				$categories = CategorySelect::getUniqueCategories( $data[ 'categories' ], $categories );
 				$categories = CategorySelect::changeFormat( $categories, 'array', 'wikitext' );
 


### PR DESCRIPTION
https://wikia.fogbugz.com/default.asp?99348

**TL;DR**: Give saving editor content the same treatment as saving categories on article pages. 

Previously, only categories in the module were checked for duplicates. This changeset introduces extracting categories from the article wikitext as well, merging them with the categories from the module and then removing duplicates.

Along with this change, there is some small cleanup work to make things more consistent and more easily unit testable (such as removing converting to/from formats for getUniqueCategories).
