### PR TITLE
Forum fix: check if title object exists before using it for purging

### DIFF
--- a/extensions/wikia/Forum/ForumHooksHelper.class.php
+++ b/extensions/wikia/Forum/ForumHooksHelper.class.php
@@ -381,8 +381,11 @@ class ForumHooksHelper {
 			if(!empty($thread)) {
 				$thread->purgeLastMessage();
 				$threadTitle = Title::newFromId( $threadId );
-				$threadTitle->purgeSquid();
-				$threadTitle->invalidateCache();
+				// the title can be empty if this is a create action
+				if ( !empty( $threadTitle ) ) {
+					$threadTitle->purgeSquid();
+					$threadTitle->invalidateCache();
+				}
 			}
 		}
 		return true;


### PR DESCRIPTION
During thread creation the title does not exist yet, so this caused fatals
