### PR TITLE
PLA-256 -- fix display of photos in video search

### DIFF
--- a/extensions/wikia/Search/classes/Config.php
+++ b/extensions/wikia/Search/classes/Config.php
@@ -201,8 +201,8 @@ class Config
 	 * @var array
 	 */
 	protected $filterCodes = [
-			self::FILTER_VIDEO => 'is_video:true',
-			self::FILTER_IMAGE => 'is_image:true',
+			self::FILTER_VIDEO => '(is_video:true AND -is_image:true)',
+			self::FILTER_IMAGE => '(is_image:true AND -is_video:true)',
 			self::FILTER_HD    => 'video_hd_b:true',
 	];
 	

--- a/extensions/wikia/Search/classes/QueryService/Select/Video.php
+++ b/extensions/wikia/Search/classes/QueryService/Select/Video.php
@@ -39,19 +39,6 @@ class Video extends OnWiki
 		return $this;
 	}
 	
-	/**
-	 * Require the wiki ID we're on (or video wiki), and that everything is a video
-	 * @return string
-	 */
-	protected function getQueryClausesString() {
-		$queryClauses = array(
-				Utilities::valueForField( 'wid', $this->config->getCityId() ),
-				Utilities::valueForField( 'is_video', 'true' ),
-				Utilities::valueForField( 'ns', \NS_FILE )
-				);
-		return sprintf( '(%s)', implode( ' AND ', $queryClauses ) );
-	}
-	
 	protected function getBoostQueryString() {
 		return '';
 	}

--- a/extensions/wikia/Search/classes/QueryService/Select/VideoEmbedTool.php
+++ b/extensions/wikia/Search/classes/QueryService/Select/VideoEmbedTool.php
@@ -20,4 +20,18 @@ class VideoEmbedTool extends Video
 				preg_replace( '/\bwiki\b/i', '', $this->service->getGlobal( 'Sitename' ) )
 				);
 	}
+	
+	
+	/**
+	 * Require the wiki ID we're on (or video wiki), and that everything is a video
+	 * @return string
+	 */
+	protected function getQueryClausesString() {
+		$queryClauses = array(
+				Utilities::valueForField( 'wid', $this->config->getCityId() ),
+				Utilities::valueForField( 'is_video', 'true' ),
+				Utilities::valueForField( 'ns', \NS_FILE )
+				);
+		return sprintf( '(%s)', implode( ' AND ', $queryClauses ) );
+	}
 }

--- a/extensions/wikia/Search/classes/Test/QueryService/Select/VideoTest.php
+++ b/extensions/wikia/Search/classes/Test/QueryService/Select/VideoTest.php
@@ -54,29 +54,4 @@ class VideoTest extends Wikia\Search\Test\BaseTest {
 		);
 	}
 	
-	/**
-	 * @covers Wikia\Search\QueryService\Select\Video::getQueryClausesString
-	 */
-	public function testGetQueryClausesString() {
-		$mockConfig = $this->getMock( 'Wikia\Search\Config', array( 'getCityId', 'getNamespaces' ) );
-		$dc = new Wikia\Search\QueryService\DependencyContainer( array( 'config' => $mockConfig ) );
-		$mockSelect = $this->getMockBuilder( 'Wikia\Search\QueryService\Select\Video' )
-		                   ->setConstructorArgs( array( $dc ) )
-		                   ->setMethods( null )
-		                   ->getMock();
-		
-		$mockConfig
-		    ->expects( $this->once() )
-		    ->method ( 'getCityId' )
-		    ->will   ( $this->returnValue( 123 ) )
-		;
-		$method = new ReflectionMethod( 'Wikia\Search\QueryService\Select\Video', 'getQueryClausesString' );
-		$method->setAccessible( true );
-		$this->assertEquals(
-				'((wid:123) AND (is_video:true) AND (ns:6))',
-				$method->invoke( $mockSelect )
-		);
-	}
-	
-	
 }

--- a/extensions/wikia/Search/classes/Test/QueryService/Select/VideoTest.php
+++ b/extensions/wikia/Search/classes/Test/QueryService/Select/VideoTest.php
@@ -54,4 +54,29 @@ class VideoTest extends Wikia\Search\Test\BaseTest {
 		);
 	}
 	
+	/**
+	 * @covers Wikia\Search\QueryService\Select\VideoEmbedTool::getQueryClausesString
+	 */
+	public function testGetQueryClausesString() {
+		$mockConfig = $this->getMock( 'Wikia\Search\Config', array( 'getCityId', 'getNamespaces' ) );
+		$dc = new Wikia\Search\QueryService\DependencyContainer( array( 'config' => $mockConfig ) );
+		$mockSelect = $this->getMockBuilder( 'Wikia\Search\QueryService\Select\VideoEmbedTool' )
+		                   ->setConstructorArgs( array( $dc ) )
+		                   ->setMethods( null )
+		                   ->getMock();
+		
+		$mockConfig
+		    ->expects( $this->once() )
+		    ->method ( 'getCityId' )
+		    ->will   ( $this->returnValue( 123 ) )
+		;
+		$method = new ReflectionMethod( 'Wikia\Search\QueryService\Select\VideoEmbedTool', 'getQueryClausesString' );
+		$method->setAccessible( true );
+		$this->assertEquals(
+				'((wid:123) AND (is_video:true) AND (ns:6))',
+				$method->invoke( $mockSelect )
+		);
+	}
+	
+	
 }


### PR DESCRIPTION
Because the video query service is used in any contexts where we're on the video wiki. So I removed the query clause that requires just the file namespace (controller and config takes care of this), and fixed the filter queries we use to handle this. Finally, because we still needed the video-only feature for the VET stuff, I moved that logic to the VideoEmbedTool query service.
