### PR TITLE
PLA-255 -- fix radio buttons for all files vs. video on video search

### DIFF
--- a/extensions/wikia/Search/WikiaSearchController.class.php
+++ b/extensions/wikia/Search/WikiaSearchController.class.php
@@ -228,7 +228,8 @@ class WikiaSearchController extends WikiaSpecialPageController {
 		}
 		$tabsArgs = array(
 				'config'		=> $searchConfig,
-				'by_category'	=> $this->getVal( 'by_category', false )
+				'by_category'	=> $this->getVal( 'by_category', false ),
+				'filters'       => $this->getVal( 'filters', array() ),
 				);
 		$this->setVal( 'results',               $searchConfig->getResults() );
 		$this->setVal( 'resultsFound',          $searchConfig->getResultsFound() );
@@ -432,7 +433,7 @@ class WikiaSearchController extends WikiaSpecialPageController {
 			);
 
 		// Set video wiki to display only videos by default
-		if( $is_video_wiki && $form['no_filter'] == 1 ) {
+		if( $is_video_wiki && $form['no_filter'] == 1 && !in_array( 'no_filter', $this->getVal( 'filters', array() ) ) ) {
 			$form['is_video'] = 1;
 			$form['no_filter'] = 0;
 		}

--- a/extensions/wikia/Search/classes/Test/Controller/SearchControllerTest.php
+++ b/extensions/wikia/Search/classes/Test/Controller/SearchControllerTest.php
@@ -1018,6 +1018,12 @@ class SearchControllerTest extends Wikia\Search\Test\BaseTest {
 			->will		( $this->returnValue( 'default' ) )
 		;
 		$mockController
+		    ->expects( $this->at( $incr++ ) )
+		    ->method ( 'getVal' )
+		    ->with   ( 'filters', array() )
+		    ->will   ( $this->returnValue( array() ) )
+		;
+		$mockController
 			->expects	( $this->at( $incr++ ) )
 			->method	( 'setVal' )
 			->with		( 'bareterm', 'foo' )
@@ -2478,7 +2484,7 @@ class SearchControllerTest extends Wikia\Search\Test\BaseTest {
 		$mockWg = (object) array( 'Title' => $mockTitle, 'User' => $mockUser );
 		
 		$controllerIncr = 0;
-		$tabsArgs = array( 'config' => $mockConfig, 'by_category' => false );
+		$tabsArgs = array( 'config' => $mockConfig, 'by_category' => false, 'filters' => array() );
 		
 		$mockController
 		    ->expects( $this->at( $controllerIncr++ ) )
@@ -2511,6 +2517,12 @@ class SearchControllerTest extends Wikia\Search\Test\BaseTest {
 		    ->method ( 'getVal' )
 		    ->with   ( 'by_category', false )
 		    ->will   ( $this->returnValue( false ) )
+		;
+		$mockController
+		    ->expects( $this->at( $controllerIncr++ ) )
+		    ->method ( 'getVal' )
+		    ->with   ( 'filters', array() )
+		    ->will   ( $this->returnValue( array() ) )
 		;
 		$mockConfig
 		    ->expects( $this->any() )


### PR DESCRIPTION
In order to differentiate between having no filter and having video as the default filter, we needed to pass the filters value of the request into the self request array for the tabs method of the wikia search controller.
