### PR TITLE
Chat commands

### DIFF
--- a/extensions/wikia/Chat2/js/controllers/controllers.js
+++ b/extensions/wikia/Chat2/js/controllers/controllers.js
@@ -288,7 +288,7 @@ var NodeRoomController = $.createClass(Observable,{
 		} else {
 			this.socket.send(chatEntry.xport());
 		}
-	}
+	},
 
 	inputListener: function(event) {
 		if(this.active && event.which == 13 && !event.shiftKey) {

--- a/extensions/wikia/Chat2/js/models/models.js
+++ b/extensions/wikia/Chat2/js/models/models.js
@@ -149,14 +149,25 @@ var STATUS_STATE_AWAY = 'away';
 	/** ChatEntries (messages, alerts) **/
 	models.ChatEntry = Backbone.Model.extend({
 		defaults: {
-			'msgType': 'chat', // used by the server to determine how to handle one of these objects.
-			'roomId' : 0,
-			'name': '',
-			'text': '',
-			'avatarSrc': '',
-			'timeStamp': '',
-			'continued': false,
-			'temp': false //use for long time connection with private
+			msgType: 'chat', // used by the server to determine how to handle one of these objects.
+			roomId : 0,
+			name: '',
+			text: '',
+			avatarSrc: '',
+			timeStamp: '',
+			continued: false,
+			temp: false //use for long time connection with private
+		}
+	});
+	models.MeMessage = models.ChatEntry.extend({
+		initialize: function(options) {
+			if(!options) {return;}
+			this.set({
+				me: true,
+				text: options.text,
+				name: options.name,
+				roomId: options.roomId
+			});
 		}
 	});
 	/**

--- a/extensions/wikia/Chat2/js/views/views.js
+++ b/extensions/wikia/Chat2/js/views/views.js
@@ -135,19 +135,12 @@ var ChatView = Backbone.View.extend({
 			this.template = originalTemplate;
 		} else {
 			// "/me" command implementation
-			// note - in case of more commands executed on the message receiver side, there should
-			// be a loop here which goes through all commands and executes callbacks
-			if (msg.text.indexOf('/me ') == 0) {
-				msg.text = msg.text.substr(4);
+			if (this.model.get('me')) {
 				var originalTemplate = this.template;
 				this.template = this.meMessageTemplate;
 				$(this.el).html(this.template(msg));
 				this.template = originalTemplate;
 			} else {
-				if (msg.text.indexOf('//me ') == 0) {
-					msg.text = msg.text.substr(1);
-				}
-				// end of /me implementation
 				$(this.el).html(this.template(msg));
 			}
 		}
@@ -365,9 +358,9 @@ var NodeChatDiscussion = Backbone.View.extend({
 	},
 
 	triggerEvents: {
-		"keyup #Write [name='message']": "updateCharacterCount",
-		"keydown #Write [name='message']": "updateCharacterCount",
-		"keypress #Write [name='message']": "sendMessage"
+		"keyup #Write [name='message']": 'inputKeyup',
+		"keydown #Write [name='message']": 'inputKeydown',
+		"keypress #Write [name='message']": 'inputKeypress'
 	},
 
 	clear: function(chat) {


### PR DESCRIPTION
Following up on https://github.com/Wikia/app/pull/764 (`/me`):

Commands traditionally (a la IRC) are evaluated by the sending client, which accepts responsibility for giving the server a fully qualified request. The intent is to allow clients to implement any commands they want in any format, and to keep the server relatively simple.

For example, per https://github.com/Wikia/app/pull/764#issuecomment-17609122, the server already has a method for a client to request a kick or a ban - a `/kick` command could be implemented easily by the client, accepting the name of the user to kick, forming a `KickCommand` model and sending it on the main socket. The only change the server should make would be to ensure that the requested user is actually in the room, which arguably it should do anyway. 

Sender-side command execution has other benefits too - the sender would handle the problem of escapes (`//me` returning `/me` per https://github.com/Wikia/app/commit/7ae60466ba5b733c79c3489e163663af27581316), which simplifies the receiving end (particularly helpful to bots). It also addresses the problem of adding more commands (per https://github.com/Wikia/app/pull/724) and of being able to support more commands (per https://github.com/Wikia/app/commit/7ae60466ba5b733c79c3489e163663af27581316#L0R134) elegantly - the server can support a particular action, and the client can create an interface to that however it so chooses.

Toward that end, this pull request implements such a system as `NodeChatCommands`. It's a singleton (that can't be subclassed, because that would be silly), particularly to keep addition of new commands easy. Commands are added to `NodeChatCommands.commands`, and can be run with `NodeChatCommands.run`. Specifics are outlined in the comment above the definition (https://github.com/Monchoman45/app/commit/23f720036c3f1bea2319245ac28313616427ae1b#L0R954).

`NodeRoomController.sendMessage`'s functionality as a listener is now in `NodeRoomController.inputListener`, and `sendMessage` itself now accepts a string and directly sends it to the server. `inputListener` checks for commands and handles return values and escapes. `sendMessage` does not check for commands.

`/me` was an interesting first choice because it must be interpreted by the receiver (in IRC, `/me` is a [CTCP](http://enwp.org/Client-to-client_protocol) `ACTION`, but that's a different fish entirely). Since receiving `/me message` indicates something completely different now, I created a `MeMessage` model that subclasses `ChatMessage` and sets the property `me` to true. This is honored by `ChatView` and by `NodeChatCommands.commands.me`.

Also, if anyone is interested in doing more, `/away` is fairly popular and should be pretty straightforward to implement.
