### PR TITLE
PLA-263 -- fix regression in wiki ID setting due to updates to search config

### DIFF
--- a/extensions/wikia/Forum/ForumHooksHelper.class.php
+++ b/extensions/wikia/Forum/ForumHooksHelper.class.php
@@ -381,8 +381,11 @@ class ForumHooksHelper {
 			if(!empty($thread)) {
 				$thread->purgeLastMessage();
 				$threadTitle = Title::newFromId( $threadId );
-				$threadTitle->purgeSquid();
-				$threadTitle->invalidateCache();
+				// the title can be empty if this is a create action
+				if ( !empty( $threadTitle ) ) {
+					$threadTitle->purgeSquid();
+					$threadTitle->invalidateCache();
+				}
 			}
 		}
 		return true;

--- a/extensions/wikia/Search/classes/Config.php
+++ b/extensions/wikia/Search/classes/Config.php
@@ -201,8 +201,8 @@ class Config
 	 * @var array
 	 */
 	protected $filterCodes = [
-			self::FILTER_VIDEO => 'is_video:true',
-			self::FILTER_IMAGE => 'is_image:true',
+			self::FILTER_VIDEO => '(is_video:true AND -is_image:true)',
+			self::FILTER_IMAGE => '(is_image:true AND -is_video:true)',
 			self::FILTER_HD    => 'video_hd_b:true',
 	];
 	

--- a/extensions/wikia/Search/classes/Config.php
+++ b/extensions/wikia/Search/classes/Config.php
@@ -817,7 +817,7 @@ class Config
 	 * @return int
 	 */
 	public function getWikiId() {
-		if ( empty( $this->wikId ) ) {
+		if ( empty( $this->wikiId ) ) {
 			$this->wikiId = $this->getService()->getWikiId();
 		}
 		return $this->wikiId;

--- a/extensions/wikia/Search/classes/QueryService/Select/Video.php
+++ b/extensions/wikia/Search/classes/QueryService/Select/Video.php
@@ -39,19 +39,6 @@ class Video extends OnWiki
 		return $this;
 	}
 	
-	/**
-	 * Require the wiki ID we're on (or video wiki), and that everything is a video
-	 * @return string
-	 */
-	protected function getQueryClausesString() {
-		$queryClauses = array(
-				Utilities::valueForField( 'wid', $this->config->getCityId() ),
-				Utilities::valueForField( 'is_video', 'true' ),
-				Utilities::valueForField( 'ns', \NS_FILE )
-				);
-		return sprintf( '(%s)', implode( ' AND ', $queryClauses ) );
-	}
-	
 	protected function getBoostQueryString() {
 		return '';
 	}

--- a/extensions/wikia/Search/classes/QueryService/Select/VideoEmbedTool.php
+++ b/extensions/wikia/Search/classes/QueryService/Select/VideoEmbedTool.php
@@ -20,4 +20,18 @@ class VideoEmbedTool extends Video
 				preg_replace( '/\bwiki\b/i', '', $this->service->getGlobal( 'Sitename' ) )
 				);
 	}
+	
+	
+	/**
+	 * Require the wiki ID we're on (or video wiki), and that everything is a video
+	 * @return string
+	 */
+	protected function getQueryClausesString() {
+		$queryClauses = array(
+				Utilities::valueForField( 'wid', $this->config->getCityId() ),
+				Utilities::valueForField( 'is_video', 'true' ),
+				Utilities::valueForField( 'ns', \NS_FILE )
+				);
+		return sprintf( '(%s)', implode( ' AND ', $queryClauses ) );
+	}
 }

--- a/extensions/wikia/Search/classes/Test/ConfigTest.php
+++ b/extensions/wikia/Search/classes/Test/ConfigTest.php
@@ -836,4 +836,64 @@ class ConfigTest extends BaseTest {
 				$config->getQuery()
 		);
 	}
+	
+	/**
+	 * @covers Wikia\Search\Config::getWikiId
+	 */
+	public function testGetWikiIdDefault() {
+		$config = $this->getMockBuilder( 'Wikia\Search\Config' )
+		               ->disableOriginalConstructor()
+		               ->setMethods( [ 'getService' ] )
+		               ->getMock();
+		$service = $this->getMockBuilder( 'Wikia\Search\MediaWikiService' )
+		                ->setMethods( [ 'getWikiId' ] )
+		                ->getMock();
+		$this->assertAttributeEmpty(
+				'wikiId',
+				$config
+		);
+		$config
+		    ->expects( $this->once() )
+		    ->method ( 'getService' )
+		    ->will   ( $this->returnValue( $service ) )
+		;
+		$service
+		    ->expects( $this->once() )
+		    ->method ( 'getWikiId' )
+		    ->will   ( $this->returnValue( 123 ) )
+		;
+		$this->assertEquals(
+				123,
+				$config->getWikiId(),
+				'Wikia\Search\Config should default to ID of current wiki if the wiki ID has not been set'
+		);
+		$this->assertAttributeEquals(
+				123,
+				'wikiId',
+				$config,
+				'Calling Wikia\Search\Config::getWikiID on a config whose ID has not been set should store the current wiki in the wikiId attribute'
+		);
+	}
+	
+	/**
+	 * @covers Wikia\Search\Config::setWikiId
+	 * @covers Wikia\Search\Config::getWikiId
+	 */
+	public function testSetAndGetWikiId() {
+		$config = new Config;
+		$this->assertAttributeEmpty(
+				'wikiId',
+				$config
+		);
+		$config->setWikiId( 123 );
+		$this->assertAttributeEquals(
+				123,
+				'wikiId',
+				$config
+		);
+		$this->assertEquals(
+				123,
+				$config->getWikiId()
+		);
+	}
 }

--- a/extensions/wikia/Search/classes/Test/QueryService/Select/VideoTest.php
+++ b/extensions/wikia/Search/classes/Test/QueryService/Select/VideoTest.php
@@ -54,29 +54,4 @@ class VideoTest extends Wikia\Search\Test\BaseTest {
 		);
 	}
 	
-	/**
-	 * @covers Wikia\Search\QueryService\Select\Video::getQueryClausesString
-	 */
-	public function testGetQueryClausesString() {
-		$mockConfig = $this->getMock( 'Wikia\Search\Config', array( 'getCityId', 'getNamespaces' ) );
-		$dc = new Wikia\Search\QueryService\DependencyContainer( array( 'config' => $mockConfig ) );
-		$mockSelect = $this->getMockBuilder( 'Wikia\Search\QueryService\Select\Video' )
-		                   ->setConstructorArgs( array( $dc ) )
-		                   ->setMethods( null )
-		                   ->getMock();
-		
-		$mockConfig
-		    ->expects( $this->once() )
-		    ->method ( 'getCityId' )
-		    ->will   ( $this->returnValue( 123 ) )
-		;
-		$method = new ReflectionMethod( 'Wikia\Search\QueryService\Select\Video', 'getQueryClausesString' );
-		$method->setAccessible( true );
-		$this->assertEquals(
-				'((wid:123) AND (is_video:true) AND (ns:6))',
-				$method->invoke( $mockSelect )
-		);
-	}
-	
-	
 }

--- a/extensions/wikia/Search/classes/Test/QueryService/Select/VideoTest.php
+++ b/extensions/wikia/Search/classes/Test/QueryService/Select/VideoTest.php
@@ -54,4 +54,29 @@ class VideoTest extends Wikia\Search\Test\BaseTest {
 		);
 	}
 	
+	/**
+	 * @covers Wikia\Search\QueryService\Select\VideoEmbedTool::getQueryClausesString
+	 */
+	public function testGetQueryClausesString() {
+		$mockConfig = $this->getMock( 'Wikia\Search\Config', array( 'getCityId', 'getNamespaces' ) );
+		$dc = new Wikia\Search\QueryService\DependencyContainer( array( 'config' => $mockConfig ) );
+		$mockSelect = $this->getMockBuilder( 'Wikia\Search\QueryService\Select\VideoEmbedTool' )
+		                   ->setConstructorArgs( array( $dc ) )
+		                   ->setMethods( null )
+		                   ->getMock();
+		
+		$mockConfig
+		    ->expects( $this->once() )
+		    ->method ( 'getCityId' )
+		    ->will   ( $this->returnValue( 123 ) )
+		;
+		$method = new ReflectionMethod( 'Wikia\Search\QueryService\Select\VideoEmbedTool', 'getQueryClausesString' );
+		$method->setAccessible( true );
+		$this->assertEquals(
+				'((wid:123) AND (is_video:true) AND (ns:6))',
+				$method->invoke( $mockSelect )
+		);
+	}
+	
+	
 }

--- a/extensions/wikia/SpecialMarketingToolbox/MarketingToolboxController.class.php
+++ b/extensions/wikia/SpecialMarketingToolbox/MarketingToolboxController.class.php
@@ -169,7 +169,7 @@ class MarketingToolboxController extends WikiaSpecialPageController {
 
 				// send request to add popular/featured videos
 				if ( $module->isVideoModule() ) {
-					$response = WikiaHubsServicesHelper::addVideoToHubsV2Wikis( $module, $selectedModuleData['values'] );
+					$response = WikiaHubsServicesHelper::addVideoToHubsV2Wikis( $module, $selectedModuleValues  );
 				}
 
 				$nextUrl = $this->getNextModuleUrl();


### PR DESCRIPTION
A typo in Wikia\Search\Config has introduced a P2 that prevents users from searching for premium wikis on VET.

This fixes the problem and adds the requisite unit test.
