### PR TITLE
PLA-261 -- incorrect namespaces showing in file search

### DIFF
--- a/extensions/wikia/FilePage/FilePageController.class.php
+++ b/extensions/wikia/FilePage/FilePageController.class.php
@@ -180,7 +180,7 @@ class FilePageController extends WikiaController {
 		$relatedPages->setCategories($titleCats);
 
 		# Rendering the RelatedPages index with our alternate title and pre-seeded categories.
-		$this->text = F::app()->renderView( 'RelatedPages', 'Index', array( "altTitle" => $title ) );
+		$this->text = F::app()->renderView( 'RelatedPages', 'Index', array( "altTitle" => $title, "anyNS" => true ) );
 	}
 
 	/**

--- a/extensions/wikia/Forum/ForumHooksHelper.class.php
+++ b/extensions/wikia/Forum/ForumHooksHelper.class.php
@@ -381,8 +381,11 @@ class ForumHooksHelper {
 			if(!empty($thread)) {
 				$thread->purgeLastMessage();
 				$threadTitle = Title::newFromId( $threadId );
-				$threadTitle->purgeSquid();
-				$threadTitle->invalidateCache();
+				// the title can be empty if this is a create action
+				if ( !empty( $threadTitle ) ) {
+					$threadTitle->purgeSquid();
+					$threadTitle->invalidateCache();
+				}
 			}
 		}
 		return true;

--- a/extensions/wikia/RelatedPages/RelatedPagesController.class.php
+++ b/extensions/wikia/RelatedPages/RelatedPagesController.class.php
@@ -25,11 +25,18 @@ class RelatedPagesController extends WikiaController {
 			$relatedPages->setCategories( $categories );
 		}
 
+		// Determine if we need to care about the current namespace or not
+		if ( !empty($params["anyNS"]) ) {
+			$ignoreNS = false;
+		} else {
+			$ignoreNS = !empty( $wgTitle ) && !in_array( $wgTitle->getNamespace(), $wgContentNamespaces );
+		}
+
 		$this->skipRendering =
 			// check for mainpage
 			Wikia::isMainPage() ||
 			// check for content namespaces
-			(!empty( $wgTitle ) && !in_array( $wgTitle->getNamespace(), $wgContentNamespaces )) ||
+			$ignoreNS ||
 			// check if we have any categories
 			count( $relatedPages->getCategories( $title ) ) == 0 ||
 			// check action

--- a/extensions/wikia/Search/classes/Config.php
+++ b/extensions/wikia/Search/classes/Config.php
@@ -201,8 +201,8 @@ class Config
 	 * @var array
 	 */
 	protected $filterCodes = [
-			self::FILTER_VIDEO => 'is_video:true',
-			self::FILTER_IMAGE => 'is_image:true',
+			self::FILTER_VIDEO => '(is_video:true AND -is_image:true)',
+			self::FILTER_IMAGE => '(is_image:true AND -is_video:true)',
 			self::FILTER_HD    => 'video_hd_b:true',
 	];
 	

--- a/extensions/wikia/Search/classes/Config.php
+++ b/extensions/wikia/Search/classes/Config.php
@@ -817,7 +817,7 @@ class Config
 	 * @return int
 	 */
 	public function getWikiId() {
-		if ( empty( $this->wikId ) ) {
+		if ( empty( $this->wikiId ) ) {
 			$this->wikiId = $this->getService()->getWikiId();
 		}
 		return $this->wikiId;

--- a/extensions/wikia/Search/classes/QueryService/Select/AbstractSelect.php
+++ b/extensions/wikia/Search/classes/QueryService/Select/AbstractSelect.php
@@ -343,6 +343,10 @@ abstract class AbstractSelect
 	 */
 	protected function getFilterQueryString()
 	{
-		return Utilities::valueForField( 'wid', $this->config->getCityId() );
+		$namespaces = [];
+		foreach ( $this->config->getNamespaces() as $ns ) {
+			$namespaces[] = Utilities::valueForField( 'ns', $ns );
+		}
+		return implode( ' AND ', [ sprintf( '(%s)', implode( ' OR ', $namespaces ) ), Utilities::valueForField( 'wid', $this->config->getCityId() ) ] );
 	}
 }

--- a/extensions/wikia/Search/classes/QueryService/Select/AbstractSelect.php
+++ b/extensions/wikia/Search/classes/QueryService/Select/AbstractSelect.php
@@ -151,10 +151,12 @@ abstract class AbstractSelect
 	}
 	
 	/**
-	 * Introduced flexible in the actual query 
+	 * As an edismax query, gives the required query in the first clause of the conjunction, and then the parseable query stuff in the second clause.
 	 * @return string
 	 */
-	abstract protected function getFormulatedQuery();
+	protected function getFormulatedQuery() {
+		return sprintf( '+(%s) AND (%s)', $this->getQueryClausesString(), $this->config->getQuery()->getSolrQuery() );
+	}
 	
 	/**
 	 * Prepare boost queries based on the provided instance.

--- a/extensions/wikia/Search/classes/QueryService/Select/InterWiki.php
+++ b/extensions/wikia/Search/classes/QueryService/Select/InterWiki.php
@@ -177,14 +177,6 @@ class InterWiki extends AbstractSelect
 		}
 		return sprintf( '(%s)', implode( ' AND ', $queryClauses ) );
 	}
-	
-	/**
-	 * Returns a nested query, preceded by lucene queries used to filter out bad wikis, and non-content documents.
-	 * @see \Wikia\Search\QueryService\Select\AbstractSelect::getFormulatedQuery()
-	 */
-	protected function getFormulatedQuery() {
-		return sprintf( '%s AND (%s)', $this->getQueryClausesString(), $this->config->getQuery()->getSolrQuery() );
-	}
 
 	/**
 	 * Return a string of query fields based on configuration

--- a/extensions/wikia/Search/classes/QueryService/Select/OnWiki.php
+++ b/extensions/wikia/Search/classes/QueryService/Select/OnWiki.php
@@ -122,15 +122,6 @@ class OnWiki extends AbstractSelect
 	}
 	
 	/**
-	 * Returns a nested query, with query clauses used to pre-filter things like namespace and wiki ID.
-	 * @see \Wikia\Search\QueryService\Select\AbstractSelect::getFormulatedQuery()
-	 * @return string
-	 */
-	protected function getFormulatedQuery() {
-		return sprintf( '%s AND (%s)', $this->getQueryClausesString(), $this->config->getQuery()->getSolrQuery() );
-	}
-	
-	/**
 	 * Require the wiki ID we're on, and that everything is in the provided namespaces
 	 * @return string
 	 */

--- a/extensions/wikia/Search/classes/QueryService/Select/Video.php
+++ b/extensions/wikia/Search/classes/QueryService/Select/Video.php
@@ -39,19 +39,6 @@ class Video extends OnWiki
 		return $this;
 	}
 	
-	/**
-	 * Require the wiki ID we're on (or video wiki), and that everything is a video
-	 * @return string
-	 */
-	protected function getQueryClausesString() {
-		$queryClauses = array(
-				Utilities::valueForField( 'wid', $this->config->getCityId() ),
-				Utilities::valueForField( 'is_video', 'true' ),
-				Utilities::valueForField( 'ns', \NS_FILE )
-				);
-		return sprintf( '(%s)', implode( ' AND ', $queryClauses ) );
-	}
-	
 	protected function getBoostQueryString() {
 		return '';
 	}

--- a/extensions/wikia/Search/classes/QueryService/Select/VideoEmbedTool.php
+++ b/extensions/wikia/Search/classes/QueryService/Select/VideoEmbedTool.php
@@ -20,4 +20,18 @@ class VideoEmbedTool extends Video
 				preg_replace( '/\bwiki\b/i', '', $this->service->getGlobal( 'Sitename' ) )
 				);
 	}
+	
+	
+	/**
+	 * Require the wiki ID we're on (or video wiki), and that everything is a video
+	 * @return string
+	 */
+	protected function getQueryClausesString() {
+		$queryClauses = array(
+				Utilities::valueForField( 'wid', $this->config->getCityId() ),
+				Utilities::valueForField( 'is_video', 'true' ),
+				Utilities::valueForField( 'ns', \NS_FILE )
+				);
+		return sprintf( '(%s)', implode( ' AND ', $queryClauses ) );
+	}
 }

--- a/extensions/wikia/Search/classes/Test/ConfigTest.php
+++ b/extensions/wikia/Search/classes/Test/ConfigTest.php
@@ -836,4 +836,64 @@ class ConfigTest extends BaseTest {
 				$config->getQuery()
 		);
 	}
+	
+	/**
+	 * @covers Wikia\Search\Config::getWikiId
+	 */
+	public function testGetWikiIdDefault() {
+		$config = $this->getMockBuilder( 'Wikia\Search\Config' )
+		               ->disableOriginalConstructor()
+		               ->setMethods( [ 'getService' ] )
+		               ->getMock();
+		$service = $this->getMockBuilder( 'Wikia\Search\MediaWikiService' )
+		                ->setMethods( [ 'getWikiId' ] )
+		                ->getMock();
+		$this->assertAttributeEmpty(
+				'wikiId',
+				$config
+		);
+		$config
+		    ->expects( $this->once() )
+		    ->method ( 'getService' )
+		    ->will   ( $this->returnValue( $service ) )
+		;
+		$service
+		    ->expects( $this->once() )
+		    ->method ( 'getWikiId' )
+		    ->will   ( $this->returnValue( 123 ) )
+		;
+		$this->assertEquals(
+				123,
+				$config->getWikiId(),
+				'Wikia\Search\Config should default to ID of current wiki if the wiki ID has not been set'
+		);
+		$this->assertAttributeEquals(
+				123,
+				'wikiId',
+				$config,
+				'Calling Wikia\Search\Config::getWikiID on a config whose ID has not been set should store the current wiki in the wikiId attribute'
+		);
+	}
+	
+	/**
+	 * @covers Wikia\Search\Config::setWikiId
+	 * @covers Wikia\Search\Config::getWikiId
+	 */
+	public function testSetAndGetWikiId() {
+		$config = new Config;
+		$this->assertAttributeEmpty(
+				'wikiId',
+				$config
+		);
+		$config->setWikiId( 123 );
+		$this->assertAttributeEquals(
+				123,
+				'wikiId',
+				$config
+		);
+		$this->assertEquals(
+				123,
+				$config->getWikiId()
+		);
+	}
 }

--- a/extensions/wikia/Search/classes/Test/QueryService/Select/AbstractSelectTest.php
+++ b/extensions/wikia/Search/classes/Test/QueryService/Select/AbstractSelectTest.php
@@ -762,7 +762,7 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 	 * @covers Wikia\Search\QueryService\Select\AbstractSelect::getFilterQueryString
 	 */
 	public function testGetFilterQueryString() {
-		$mockConfig = $this->getMock( 'Wikia\Search\Config', array( 'getCityId' ) );
+		$mockConfig = $this->getMock( 'Wikia\Search\Config', array( 'getCityId', 'getNamespaces' ) );
 		$dc = new Wikia\Search\QueryService\DependencyContainer( array( 'config' => $mockConfig ) ); 
 		$mockSelect = $this->getMockBuilder( '\Wikia\Search\QueryService\Select\AbstractSelect' )
 		                   ->setConstructorArgs( array( $dc ) )
@@ -773,10 +773,15 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 		    ->method ( 'getCityId' )
 		    ->will   ( $this->returnValue( 123 ) )
 		;
+		$mockConfig
+		    ->expects( $this->once() )
+		    ->method ( 'getNamespaces' )
+		    ->will   ( $this->returnValue( [ 0, 14 ] ) )
+		;
 		$reflspell = new ReflectionMethod( 'Wikia\Search\QueryService\Select\AbstractSelect', 'getFilterQueryString' );
 		$reflspell->setAccessible( true );
 		$this->assertEquals(
-				Wikia\Search\Utilities::valueForField( 'wid', 123 ),
+				'((ns:0) OR (ns:14)) AND (wid:123)',
 				$reflspell->invoke( $mockSelect )
 		);
 	}

--- a/extensions/wikia/Search/classes/Test/QueryService/Select/AbstractSelectTest.php
+++ b/extensions/wikia/Search/classes/Test/QueryService/Select/AbstractSelectTest.php
@@ -939,4 +939,43 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 		);
 	}
 	
+	/**
+	 * @covers Wikia\Search\QueryService\Select\AbstractSelect::getFormulatedQuery
+	 */
+	public function testGetFormulatedQuery() {
+		$mockConfig = $this->getMock( 'Wikia\Search\Config', [ 'getQuery' ] );
+		
+		$dc = new \Wikia\Search\QueryService\DependencyContainer( array( 'config' => $mockConfig ) );
+		
+		$mockSelect = $this->getMockBuilder( 'Wikia\Search\QueryService\Select\OnWiki' )
+		                   ->setConstructorArgs( [ $dc ] )
+		                   ->setMethods( array( 'getQueryClausesString' ) )
+		                   ->getMock();
+		
+		$mockQuery = $this->getMock( 'Wikia\Search\Query\Select', [ 'getSolrQuery' ], [ 'foo' ] );
+		
+		$mockSelect
+		    ->expects( $this->once() )
+		    ->method ( 'getQueryClausesString' )
+		    ->will   ( $this->returnValue( 'foo' ) )
+		;
+		$mockConfig
+		    ->expects( $this->once() )
+		    ->method ( 'getQuery' )
+		    ->will   ( $this->returnValue( $mockQuery ) )
+		;
+		$mockQuery
+		    ->expects( $this->once() )
+		    ->method ( 'getSolrQuery' )
+		    ->will   ( $this->returnValue( 'bar' ) )
+		;
+		$method = new ReflectionMethod( 'Wikia\Search\QueryService\Select\OnWiki', 'getFormulatedQuery' );
+		$method->setAccessible( true );
+		$this->assertEquals(
+				'+(foo) AND (bar)',
+				$method->invoke( $mockSelect )
+		);
+	}
+	
+	
 }

--- a/extensions/wikia/Search/classes/Test/QueryService/Select/InterWikiTest.php
+++ b/extensions/wikia/Search/classes/Test/QueryService/Select/InterWikiTest.php
@@ -349,44 +349,6 @@ class InterWikiTest extends Wikia\Search\Test\BaseTest {
 	}
 	
 	/**
-	 * @covers Wikia\Search\QueryService\Select\InterWiki::getFormulatedQuery
-	 */
-	public function testGetFormulatedQuery() {
-		$mockConfig = $this->getMock( 'Wikia\Search\Config', [ 'getQuery' ] );
-		
-		$dc = new \Wikia\Search\QueryService\DependencyContainer( array( 'config' => $mockConfig ) );
-		
-		$mockSelect = $this->getMockBuilder( 'Wikia\Search\QueryService\Select\InterWiki' )
-		                   ->setConstructorArgs( [ $dc ] )
-		                   ->setMethods( [ 'getQueryClausesString' ] )
-		                   ->getMock();
-		
-		$mockQuery = $this->getMock( 'Wikia\Search\Query\Select', [ 'getSolrQuery' ], [ 'foo' ] );
-		
-		$mockSelect
-		    ->expects( $this->once() )
-		    ->method ( 'getQueryClausesString' )
-		    ->will   ( $this->returnValue( 'foo' ) )
-		;
-		$mockConfig
-		    ->expects( $this->once() )
-		    ->method ( 'getQuery' )
-		    ->will   ( $this->returnValue( $mockQuery ) )
-		;
-		$mockQuery
-		    ->expects( $this->once() )
-		    ->method ( 'getSolrQuery' )
-		    ->will   ( $this->returnValue( 'bar' ) )
-		;
-		$method = new ReflectionMethod( 'Wikia\Search\QueryService\Select\InterWiki', 'getFormulatedQuery' );
-		$method->setAccessible( true );
-		$this->assertEquals(
-				'foo AND (bar)',
-				$method->invoke( $mockSelect )
-		);
-	}
-	
-	/**
 	 * @covers Wikia\Search\QueryService\Select\InterWiki::getQueryFieldsString 
 	 */
 	public function testGetQueryFieldsString() {

--- a/extensions/wikia/Search/classes/Test/QueryService/Select/OnWikiTest.php
+++ b/extensions/wikia/Search/classes/Test/QueryService/Select/OnWikiTest.php
@@ -364,44 +364,6 @@ class OnWikiTest extends Wikia\Search\Test\BaseTest {
 	}
 	
 	/**
-	 * @covers Wikia\Search\QueryService\Select\OnWiki::getFormulatedQuery
-	 */
-	public function testGetFormulatedQuery() {
-		$mockConfig = $this->getMock( 'Wikia\Search\Config', [ 'getQuery' ] );
-		
-		$dc = new \Wikia\Search\QueryService\DependencyContainer( array( 'config' => $mockConfig ) );
-		
-		$mockSelect = $this->getMockBuilder( 'Wikia\Search\QueryService\Select\OnWiki' )
-		                   ->setConstructorArgs( [ $dc ] )
-		                   ->setMethods( array( 'getQueryClausesString' ) )
-		                   ->getMock();
-		
-		$mockQuery = $this->getMock( 'Wikia\Search\Query\Select', [ 'getSolrQuery' ], [ 'foo' ] );
-		
-		$mockSelect
-		    ->expects( $this->once() )
-		    ->method ( 'getQueryClausesString' )
-		    ->will   ( $this->returnValue( 'foo' ) )
-		;
-		$mockConfig
-		    ->expects( $this->once() )
-		    ->method ( 'getQuery' )
-		    ->will   ( $this->returnValue( $mockQuery ) )
-		;
-		$mockQuery
-		    ->expects( $this->once() )
-		    ->method ( 'getSolrQuery' )
-		    ->will   ( $this->returnValue( 'bar' ) )
-		;
-		$method = new ReflectionMethod( 'Wikia\Search\QueryService\Select\OnWiki', 'getFormulatedQuery' );
-		$method->setAccessible( true );
-		$this->assertEquals(
-				'foo AND (bar)',
-				$method->invoke( $mockSelect )
-		);
-	}
-	
-	/**
 	 * @covers Wikia\Search\QueryService\Select\OnWiki::getQueryClausesString
 	 */
 	public function testGetQueryClausesString() {

--- a/extensions/wikia/Search/classes/Test/QueryService/Select/VideoTest.php
+++ b/extensions/wikia/Search/classes/Test/QueryService/Select/VideoTest.php
@@ -54,29 +54,4 @@ class VideoTest extends Wikia\Search\Test\BaseTest {
 		);
 	}
 	
-	/**
-	 * @covers Wikia\Search\QueryService\Select\Video::getQueryClausesString
-	 */
-	public function testGetQueryClausesString() {
-		$mockConfig = $this->getMock( 'Wikia\Search\Config', array( 'getCityId', 'getNamespaces' ) );
-		$dc = new Wikia\Search\QueryService\DependencyContainer( array( 'config' => $mockConfig ) );
-		$mockSelect = $this->getMockBuilder( 'Wikia\Search\QueryService\Select\Video' )
-		                   ->setConstructorArgs( array( $dc ) )
-		                   ->setMethods( null )
-		                   ->getMock();
-		
-		$mockConfig
-		    ->expects( $this->once() )
-		    ->method ( 'getCityId' )
-		    ->will   ( $this->returnValue( 123 ) )
-		;
-		$method = new ReflectionMethod( 'Wikia\Search\QueryService\Select\Video', 'getQueryClausesString' );
-		$method->setAccessible( true );
-		$this->assertEquals(
-				'((wid:123) AND (is_video:true) AND (ns:6))',
-				$method->invoke( $mockSelect )
-		);
-	}
-	
-	
 }

--- a/extensions/wikia/Search/classes/Test/QueryService/Select/VideoTest.php
+++ b/extensions/wikia/Search/classes/Test/QueryService/Select/VideoTest.php
@@ -54,4 +54,29 @@ class VideoTest extends Wikia\Search\Test\BaseTest {
 		);
 	}
 	
+	/**
+	 * @covers Wikia\Search\QueryService\Select\VideoEmbedTool::getQueryClausesString
+	 */
+	public function testGetQueryClausesString() {
+		$mockConfig = $this->getMock( 'Wikia\Search\Config', array( 'getCityId', 'getNamespaces' ) );
+		$dc = new Wikia\Search\QueryService\DependencyContainer( array( 'config' => $mockConfig ) );
+		$mockSelect = $this->getMockBuilder( 'Wikia\Search\QueryService\Select\VideoEmbedTool' )
+		                   ->setConstructorArgs( array( $dc ) )
+		                   ->setMethods( null )
+		                   ->getMock();
+		
+		$mockConfig
+		    ->expects( $this->once() )
+		    ->method ( 'getCityId' )
+		    ->will   ( $this->returnValue( 123 ) )
+		;
+		$method = new ReflectionMethod( 'Wikia\Search\QueryService\Select\VideoEmbedTool', 'getQueryClausesString' );
+		$method->setAccessible( true );
+		$this->assertEquals(
+				'((wid:123) AND (is_video:true) AND (ns:6))',
+				$method->invoke( $mockSelect )
+		);
+	}
+	
+	
 }

--- a/extensions/wikia/SpecialMarketingToolbox/MarketingToolboxController.class.php
+++ b/extensions/wikia/SpecialMarketingToolbox/MarketingToolboxController.class.php
@@ -169,7 +169,7 @@ class MarketingToolboxController extends WikiaSpecialPageController {
 
 				// send request to add popular/featured videos
 				if ( $module->isVideoModule() ) {
-					$response = WikiaHubsServicesHelper::addVideoToHubsV2Wikis( $module, $selectedModuleData['values'] );
+					$response = WikiaHubsServicesHelper::addVideoToHubsV2Wikis( $module, $selectedModuleValues  );
 				}
 
 				$nextUrl = $this->getNextModuleUrl();

--- a/extensions/wikia/VideoEmbedTool/VideoEmbedTool_body.php
+++ b/extensions/wikia/VideoEmbedTool/VideoEmbedTool_body.php
@@ -82,6 +82,12 @@ class VideoEmbedTool {
 		global $wgRequest, $wgUser, $wgContLang;
 		wfProfileIn(__METHOD__);
 
+		if ( $wgUser->isBlocked() ) {
+			header('X-screen-type: error');
+			wfProfileOut( __METHOD__ );
+			return wfMessage( 'videos-error-blocked-user' );
+		}
+
 		$url = $wgRequest->getVal( 'url' );
 
 		$tempname = 'Temp_video_'.$wgUser->getID().'_'.rand(0, 1000);


### PR DESCRIPTION
QA found a defect where non-file namespaces were showing in file search. This was because NS:6 was one of the query clauses included in our gradient "must match" clause. We address this problem in two ways:

1) Add the "required" operator to the first-order clauses (e.g. wiki ID and namespace), and move this logic up to the abstract class, since it's shared across multiple query services. 
2) Add namespaces to filter queries, mostly for safety.
