### PR TITLE
PLA-261 -- incorrect namespaces showing in file search

### DIFF
--- a/extensions/wikia/Search/classes/QueryService/Select/AbstractSelect.php
+++ b/extensions/wikia/Search/classes/QueryService/Select/AbstractSelect.php
@@ -343,6 +343,10 @@ abstract class AbstractSelect
 	 */
 	protected function getFilterQueryString()
 	{
-		return Utilities::valueForField( 'wid', $this->config->getCityId() );
+		$namespaces = [];
+		foreach ( $this->config->getNamespaces() as $ns ) {
+			$namespaces[] = Utilities::valueForField( 'ns', $ns );
+		}
+		return implode( ' AND ', [ sprintf( '(%s)', implode( ' OR ', $namespaces ) ), Utilities::valueForField( 'wid', $this->config->getCityId() ) ] );
 	}
 }

--- a/extensions/wikia/Search/classes/QueryService/Select/AbstractSelect.php
+++ b/extensions/wikia/Search/classes/QueryService/Select/AbstractSelect.php
@@ -151,10 +151,12 @@ abstract class AbstractSelect
 	}
 	
 	/**
-	 * Introduced flexible in the actual query 
+	 * As an edismax query, gives the required query in the first clause of the conjunction, and then the parseable query stuff in the second clause.
 	 * @return string
 	 */
-	abstract protected function getFormulatedQuery();
+	protected function getFormulatedQuery() {
+		return sprintf( '+(%s) AND (%s)', $this->getQueryClausesString(), $this->config->getQuery()->getSolrQuery() );
+	}
 	
 	/**
 	 * Prepare boost queries based on the provided instance.

--- a/extensions/wikia/Search/classes/QueryService/Select/InterWiki.php
+++ b/extensions/wikia/Search/classes/QueryService/Select/InterWiki.php
@@ -177,14 +177,6 @@ class InterWiki extends AbstractSelect
 		}
 		return sprintf( '(%s)', implode( ' AND ', $queryClauses ) );
 	}
-	
-	/**
-	 * Returns a nested query, preceded by lucene queries used to filter out bad wikis, and non-content documents.
-	 * @see \Wikia\Search\QueryService\Select\AbstractSelect::getFormulatedQuery()
-	 */
-	protected function getFormulatedQuery() {
-		return sprintf( '%s AND (%s)', $this->getQueryClausesString(), $this->config->getQuery()->getSolrQuery() );
-	}
 
 	/**
 	 * Return a string of query fields based on configuration

--- a/extensions/wikia/Search/classes/QueryService/Select/OnWiki.php
+++ b/extensions/wikia/Search/classes/QueryService/Select/OnWiki.php
@@ -122,15 +122,6 @@ class OnWiki extends AbstractSelect
 	}
 	
 	/**
-	 * Returns a nested query, with query clauses used to pre-filter things like namespace and wiki ID.
-	 * @see \Wikia\Search\QueryService\Select\AbstractSelect::getFormulatedQuery()
-	 * @return string
-	 */
-	protected function getFormulatedQuery() {
-		return sprintf( '%s AND (%s)', $this->getQueryClausesString(), $this->config->getQuery()->getSolrQuery() );
-	}
-	
-	/**
 	 * Require the wiki ID we're on, and that everything is in the provided namespaces
 	 * @return string
 	 */

--- a/extensions/wikia/Search/classes/Test/QueryService/Select/AbstractSelectTest.php
+++ b/extensions/wikia/Search/classes/Test/QueryService/Select/AbstractSelectTest.php
@@ -762,7 +762,7 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 	 * @covers Wikia\Search\QueryService\Select\AbstractSelect::getFilterQueryString
 	 */
 	public function testGetFilterQueryString() {
-		$mockConfig = $this->getMock( 'Wikia\Search\Config', array( 'getCityId' ) );
+		$mockConfig = $this->getMock( 'Wikia\Search\Config', array( 'getCityId', 'getNamespaces' ) );
 		$dc = new Wikia\Search\QueryService\DependencyContainer( array( 'config' => $mockConfig ) ); 
 		$mockSelect = $this->getMockBuilder( '\Wikia\Search\QueryService\Select\AbstractSelect' )
 		                   ->setConstructorArgs( array( $dc ) )
@@ -773,10 +773,15 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 		    ->method ( 'getCityId' )
 		    ->will   ( $this->returnValue( 123 ) )
 		;
+		$mockConfig
+		    ->expects( $this->once() )
+		    ->method ( 'getNamespaces' )
+		    ->will   ( $this->returnValue( [ 0, 14 ] ) )
+		;
 		$reflspell = new ReflectionMethod( 'Wikia\Search\QueryService\Select\AbstractSelect', 'getFilterQueryString' );
 		$reflspell->setAccessible( true );
 		$this->assertEquals(
-				Wikia\Search\Utilities::valueForField( 'wid', 123 ),
+				'((ns:0) OR (ns:14)) AND (wid:123)',
 				$reflspell->invoke( $mockSelect )
 		);
 	}

--- a/extensions/wikia/Search/classes/Test/QueryService/Select/AbstractSelectTest.php
+++ b/extensions/wikia/Search/classes/Test/QueryService/Select/AbstractSelectTest.php
@@ -939,4 +939,43 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 		);
 	}
 	
+	/**
+	 * @covers Wikia\Search\QueryService\Select\AbstractSelect::getFormulatedQuery
+	 */
+	public function testGetFormulatedQuery() {
+		$mockConfig = $this->getMock( 'Wikia\Search\Config', [ 'getQuery' ] );
+		
+		$dc = new \Wikia\Search\QueryService\DependencyContainer( array( 'config' => $mockConfig ) );
+		
+		$mockSelect = $this->getMockBuilder( 'Wikia\Search\QueryService\Select\OnWiki' )
+		                   ->setConstructorArgs( [ $dc ] )
+		                   ->setMethods( array( 'getQueryClausesString' ) )
+		                   ->getMock();
+		
+		$mockQuery = $this->getMock( 'Wikia\Search\Query\Select', [ 'getSolrQuery' ], [ 'foo' ] );
+		
+		$mockSelect
+		    ->expects( $this->once() )
+		    ->method ( 'getQueryClausesString' )
+		    ->will   ( $this->returnValue( 'foo' ) )
+		;
+		$mockConfig
+		    ->expects( $this->once() )
+		    ->method ( 'getQuery' )
+		    ->will   ( $this->returnValue( $mockQuery ) )
+		;
+		$mockQuery
+		    ->expects( $this->once() )
+		    ->method ( 'getSolrQuery' )
+		    ->will   ( $this->returnValue( 'bar' ) )
+		;
+		$method = new ReflectionMethod( 'Wikia\Search\QueryService\Select\OnWiki', 'getFormulatedQuery' );
+		$method->setAccessible( true );
+		$this->assertEquals(
+				'+(foo) AND (bar)',
+				$method->invoke( $mockSelect )
+		);
+	}
+	
+	
 }

--- a/extensions/wikia/Search/classes/Test/QueryService/Select/InterWikiTest.php
+++ b/extensions/wikia/Search/classes/Test/QueryService/Select/InterWikiTest.php
@@ -349,44 +349,6 @@ class InterWikiTest extends Wikia\Search\Test\BaseTest {
 	}
 	
 	/**
-	 * @covers Wikia\Search\QueryService\Select\InterWiki::getFormulatedQuery
-	 */
-	public function testGetFormulatedQuery() {
-		$mockConfig = $this->getMock( 'Wikia\Search\Config', [ 'getQuery' ] );
-		
-		$dc = new \Wikia\Search\QueryService\DependencyContainer( array( 'config' => $mockConfig ) );
-		
-		$mockSelect = $this->getMockBuilder( 'Wikia\Search\QueryService\Select\InterWiki' )
-		                   ->setConstructorArgs( [ $dc ] )
-		                   ->setMethods( [ 'getQueryClausesString' ] )
-		                   ->getMock();
-		
-		$mockQuery = $this->getMock( 'Wikia\Search\Query\Select', [ 'getSolrQuery' ], [ 'foo' ] );
-		
-		$mockSelect
-		    ->expects( $this->once() )
-		    ->method ( 'getQueryClausesString' )
-		    ->will   ( $this->returnValue( 'foo' ) )
-		;
-		$mockConfig
-		    ->expects( $this->once() )
-		    ->method ( 'getQuery' )
-		    ->will   ( $this->returnValue( $mockQuery ) )
-		;
-		$mockQuery
-		    ->expects( $this->once() )
-		    ->method ( 'getSolrQuery' )
-		    ->will   ( $this->returnValue( 'bar' ) )
-		;
-		$method = new ReflectionMethod( 'Wikia\Search\QueryService\Select\InterWiki', 'getFormulatedQuery' );
-		$method->setAccessible( true );
-		$this->assertEquals(
-				'foo AND (bar)',
-				$method->invoke( $mockSelect )
-		);
-	}
-	
-	/**
 	 * @covers Wikia\Search\QueryService\Select\InterWiki::getQueryFieldsString 
 	 */
 	public function testGetQueryFieldsString() {

--- a/extensions/wikia/Search/classes/Test/QueryService/Select/OnWikiTest.php
+++ b/extensions/wikia/Search/classes/Test/QueryService/Select/OnWikiTest.php
@@ -364,44 +364,6 @@ class OnWikiTest extends Wikia\Search\Test\BaseTest {
 	}
 	
 	/**
-	 * @covers Wikia\Search\QueryService\Select\OnWiki::getFormulatedQuery
-	 */
-	public function testGetFormulatedQuery() {
-		$mockConfig = $this->getMock( 'Wikia\Search\Config', [ 'getQuery' ] );
-		
-		$dc = new \Wikia\Search\QueryService\DependencyContainer( array( 'config' => $mockConfig ) );
-		
-		$mockSelect = $this->getMockBuilder( 'Wikia\Search\QueryService\Select\OnWiki' )
-		                   ->setConstructorArgs( [ $dc ] )
-		                   ->setMethods( array( 'getQueryClausesString' ) )
-		                   ->getMock();
-		
-		$mockQuery = $this->getMock( 'Wikia\Search\Query\Select', [ 'getSolrQuery' ], [ 'foo' ] );
-		
-		$mockSelect
-		    ->expects( $this->once() )
-		    ->method ( 'getQueryClausesString' )
-		    ->will   ( $this->returnValue( 'foo' ) )
-		;
-		$mockConfig
-		    ->expects( $this->once() )
-		    ->method ( 'getQuery' )
-		    ->will   ( $this->returnValue( $mockQuery ) )
-		;
-		$mockQuery
-		    ->expects( $this->once() )
-		    ->method ( 'getSolrQuery' )
-		    ->will   ( $this->returnValue( 'bar' ) )
-		;
-		$method = new ReflectionMethod( 'Wikia\Search\QueryService\Select\OnWiki', 'getFormulatedQuery' );
-		$method->setAccessible( true );
-		$this->assertEquals(
-				'foo AND (bar)',
-				$method->invoke( $mockSelect )
-		);
-	}
-	
-	/**
 	 * @covers Wikia\Search\QueryService\Select\OnWiki::getQueryClausesString
 	 */
 	public function testGetQueryClausesString() {


### PR DESCRIPTION
QA found a defect where non-file namespaces were showing in file search. This was because NS:6 was one of the query clauses included in our gradient "must match" clause. We address this problem in two ways:

1) Add the "required" operator to the first-order clauses (e.g. wiki ID and namespace), and move this logic up to the abstract class, since it's shared across multiple query services. 
2) Add namespaces to filter queries, mostly for safety.
