### PR TITLE
quick fix (add missing methods after search refactoring)

### DIFF
--- a/extensions/wikia/Search/classes/Config.php
+++ b/extensions/wikia/Search/classes/Config.php
@@ -320,7 +320,27 @@ class Config
 			? $this->limit - 1 
 			: $this->limit;
 	}
-	
+
+	/** @DEPRECATED */
+	public function setLength( $limit ) {
+		return $this->setLimit( $limit );
+	}
+	/** @DEPRECATED */
+	public function setDebug( $param ) {
+		return $this;
+	}
+	/** @DEPRECATED */
+	public function setSkipCache( $param ) {
+		return $this;
+	}
+	/** @DEPRECATED */
+	public function setRedirs( $param ) {
+		return $this;
+	}
+	/** @DEPRECATED */
+	public function setGroupResults( $param ) {
+		return $this;
+	}
 
 	/**
 	 * Allows us to set the number of documents returned.


### PR DESCRIPTION
Just add missing methods:
    /*\* @DEPRECATED _/
    public function setLength( $limit ) {
        return $this->setLimit( $limit );
    }
    /_\* @DEPRECATED _/
    public function setDebug( $param ) {
        return $this;
    }
    /_\* @DEPRECATED _/
    public function setSkipCache( $param ) {
        return $this;
    }
    /_\* @DEPRECATED _/
    public function setRedirs( $param ) {
        return $this;
    }
    /_\* @DEPRECATED */
    public function setGroupResults( $param ) {
        return $this;
    }
