### PR TITLE
PLA-268 -- impose a 200 result limit on Wikia\Search\Config::setLimit

### DIFF
--- a/extensions/wikia/Search/classes/Config.php
+++ b/extensions/wikia/Search/classes/Config.php
@@ -348,6 +348,7 @@ class Config
 	 * @return Wikia\Search\Config provides fluent interface
 	 */
 	public function setLimit( $limit ) {
+		$limit = $limit < 200 ? $limit : 200;
 		$this->limit = $limit;
 		return $this;
 	}

--- a/extensions/wikia/Search/classes/Test/ConfigTest.php
+++ b/extensions/wikia/Search/classes/Test/ConfigTest.php
@@ -896,4 +896,40 @@ class ConfigTest extends BaseTest {
 				$config->getWikiId()
 		);
 	}
+	
+	/**
+	 * @covers Wikia\Search\Config::setLimit
+	 * @covers Wikia\Search\Config::getLimit
+	 */
+	public function testSetGetLimit() {
+		$config = new Config;
+		$this->assertAttributeEquals(
+				\Wikia\Search\Config::RESULTS_PER_PAGE,
+				'limit',
+				$config
+		);
+		$this->assertEquals(
+				$config,
+				$config->setLimit( 123 )
+		);
+		$this->assertAttributeEquals(
+				123,
+				'limit',
+				$config
+		);
+		$this->assertEquals(
+				$config,
+				$config->setLimit( 500 )
+		);
+		$this->assertAttributeEquals(
+				200,
+				'limit',
+				$config,
+				'We restrict the number of results in a search to 200'
+		);
+		$this->assertEquals(
+				200,
+				$config->getLimit()
+		);
+	}
 }


### PR DESCRIPTION
This prevents users from causing searches to whitescreen by requesting too many results. We set a limit of 200 in the config for any limits requested higher than that.
