### PR TITLE
Refactor SearchApiController and add tests

### DIFF
--- a/extensions/wikia/Search/SearchApiController.class.php
+++ b/extensions/wikia/Search/SearchApiController.class.php
@@ -52,17 +52,11 @@ class SearchApiController extends WikiaApiController {
 		$next = 0;
 
 		$searchConfig->setQuery( $query )
-			->setCityId( $this->wg->CityId )
-			->setLimit( $limit )
-			->setPage( $batch )
-			->setRank( $rank )
-			->setDebug( false )
-			->setSkipCache( false )
-			->setAdvanced( false )
-			->setHub( false )
-			->setRedirs( false )
-			->setVideoSearch( $type == 'videos' )
-			->setGroupResults( false );
+		             ->setLimit( $limit )
+		             ->setPage( $batch )
+		             ->setRank( $rank )
+		             ->setVideoSearch( $type == 'videos' )
+		;
 
 		if ( !empty( $namespaces ) ) {
 			foreach ( $namespaces as &$n ) {
@@ -77,21 +71,14 @@ class SearchApiController extends WikiaApiController {
 		}
 
 		if ( $searchConfig->getQuery()->hasTerms() ) {
-			$container = new DependencyContainer( array( 'config' => $searchConfig ) );
-			$wikiaSearch = (new Factory)->get( $container );
+			$wikiaSearch = (new Factory)->getFromConfig( $searchConfig );
 
 			$resultSet = $wikiaSearch->search( $searchConfig );
 			$total = $searchConfig->getResultsFound();
 
 			if ( $total ) {
-				foreach ( $resultSet as $result ) {
-					$results[] = [
-						'id' => $result['pageid'],
-						'title' => $result->getTitle(),
-						'url' => $result->getUrl(),
-						'ns' => $result['ns']
-					];
-				}
+				$results = $resultSet->toArray( ['pageid' => 'id', 'title', 'url', 'ns' ] );
+				unset( $results['pageid'] );
 
 				$batches = $searchConfig->getNumPages();
 				$currentBatch = $searchConfig->getPage();

--- a/extensions/wikia/Search/classes/QueryService/Select/AbstractSelect.php
+++ b/extensions/wikia/Search/classes/QueryService/Select/AbstractSelect.php
@@ -114,10 +114,11 @@ abstract class AbstractSelect
 	
 	/**
 	 * Allows us to get an array from search results rather than search result objects.
+	 * @param array $fields allows us to apply a mapping
 	 * @return array
 	 */
-	public function searchAsApi() {
-		return $this->search()->toArray();
+	public function searchAsApi( $fields = [] ) {
+		return $this->search()->toArray( $fields );
 	}
 	
 	/**

--- a/extensions/wikia/Search/classes/Result.php
+++ b/extensions/wikia/Search/classes/Result.php
@@ -202,13 +202,14 @@ class Result extends ReadWrite {
 
 	/**
 	 * Helper method for turning results into nested arrays for JSON encoding
-	 * @param array $keys list of fields you want in your json output
+	 * @param array $keys list of fields you want in your json output. You can use associative arrays to map from key to mapped value.
 	 * @return array
 	 */
 	public function toArray( $keys ) {
 		$array = array();
-		foreach ( $keys as $key ) {
-			$array[$key] = $this[$key];
+		foreach ( $keys as $key => $mapped  ) {
+			$key = is_int( $key ) ? $mapped : $key;
+			$array[$mapped] = $this[$key];
 		}
 		return $array;
 	}

--- a/extensions/wikia/Search/classes/Test/Controller/SearchApiControllerTest.php
+++ b/extensions/wikia/Search/classes/Test/Controller/SearchApiControllerTest.php
@@ -1,0 +1,415 @@
+<?php
+/**
+ * Class definition for Wikia\Search\Test\Controller\SearchApiControllerTest
+ */
+namespace Wikia\Search\Test\Controller;
+use Wikia\Search\Test\BaseTest;
+/**
+ * Tests SearchApiController functionality
+ */
+class SearchApiControllerTest extends BaseTest
+{
+	/**
+	 * @covers SearchApiController::getList
+	 */
+	public function testGetListWithTerms() {
+		$mockConfig = $this->getMockBuilder( 'Wikia\Search\Config' )
+		                   ->disableOriginalConstructor()
+		                   ->setMethods( [ 'getQuery' ] )
+		                   ->getMock();
+		
+		$mockController = $this->getMockBuilder( 'SearchApiController' )
+		                       ->disableOriginalConstructor()
+		                       ->setMethods( [ 'setResponseFromConfig', 'getConfigFromRequest' ] )
+		                       ->getMock();
+		
+		$mockController
+		    ->expects( $this->once() )
+		    ->method ( 'getConfigFromRequest' )
+		    ->will   ( $this->returnValue( $mockConfig ) )
+		;
+		$mockController
+		    ->expects( $this->once() )
+		    ->method ( 'setResponseFromConfig' )
+		    ->with   ( $mockConfig )
+		;
+		$mockController->getList();
+	}
+	
+	/**
+	 * @covers SearchApiController::getConfigFromRequest
+	 */
+	public function testGetConfigFromRequest() {
+		$mockRequest = $this->getMockBuilder( 'WikiaRequest' )
+		                    ->disableOriginalConstructor()
+		                    ->setMethods( [ 'getVal', 'getInt' ] )
+		                    ->getMock();
+		
+		$mockConfig = $this->getMockBuilder( 'Wikia\Search\Config' )
+		                   ->disableOriginalConstructor()
+		                   ->setMethods( [ 'setQuery', 'setLimit', 'setPage', 'setRank', 'setVideoSearch' ] )
+		                   ->getMock();
+		
+		$mockController = $this->getMockBuilder( 'SearchApiController' )
+		                       ->disableOriginalConstructor()
+		                       ->setMethods( [ 'getRequest', 'validateNamespacesForConfig' ] )
+		                       ->getMock();
+		
+		$this->proxyClass( 'Wikia\Search\Config', $mockConfig );
+		$this->mockApp();
+		
+		$requestIncr = 0;
+		$configIncr = 0;
+		
+		$mockController
+		    ->expects( $this->once() )
+		    ->method ( 'getRequest' )
+		    ->will   ( $this->returnValue( $mockRequest ) )
+		;
+		$mockRequest
+		    ->expects( $this->at( $requestIncr++ ) )
+		    ->method ( 'getVal' )
+		    ->with   ( 'query', null )
+		    ->will   ( $this->returnValue( 'foo' ) )
+		;
+		$mockConfig
+		    ->expects( $this->at( $configIncr++ ) )
+		    ->method ( 'setQuery' )
+		    ->with   ( 'foo' )
+		    ->will   ( $this->returnValue( $mockConfig ) )
+		;
+		$mockRequest
+		    ->expects( $this->at( $requestIncr++ ) )
+		    ->method ( 'getInt' )
+		    ->with   ( 'limit', \SearchApiController::ITEMS_PER_BATCH )
+		    ->will   ( $this->returnValue( 20 ) )
+		;
+		$mockConfig
+		    ->expects( $this->at( $configIncr++ ) )
+		    ->method ( 'setLimit' )
+		    ->with   ( 20 )
+		    ->will   ( $this->returnValue( $mockConfig ) )
+		;
+		$mockRequest
+		    ->expects( $this->at( $requestIncr++ ) )
+		    ->method ( 'getVal' )
+		    ->with   ( 'batch', 1 )
+		    ->will   ( $this->returnValue( 1 ) )
+		;
+		$mockConfig
+		    ->expects( $this->at( $configIncr++ ) )
+		    ->method ( 'setPage' )
+		    ->with   ( 1 )
+		    ->will   ( $this->returnValue( $mockConfig ) )
+		;
+		$mockRequest
+		    ->expects( $this->at( $requestIncr++ ) )
+		    ->method ( 'getVal' )
+		    ->with   ( 'rank', 'default' )
+		    ->will   ( $this->returnValue( 'default' ) )
+		;
+		$mockConfig
+		    ->expects( $this->at( $configIncr++ ) )
+		    ->method ( 'setRank' )
+		    ->with   ( 'default' )
+		    ->will   ( $this->returnValue( $mockConfig ) )
+		;
+		$mockRequest
+		    ->expects( $this->at( $requestIncr++ ) )
+		    ->method ( 'getVal' )
+		    ->with   ( 'type', 'articles' )
+		    ->will   ( $this->returnValue( 'articles' ) )
+		;
+		$mockConfig
+		    ->expects( $this->at( $configIncr++ ) )
+		    ->method ( 'setVideoSearch' )
+		    ->with   ( false )
+		    ->will   ( $this->returnValue( $mockConfig ) )
+		;
+		$mockController
+		    ->expects( $this->once() )
+		    ->method ( 'validateNamespacesForConfig' )
+		    //->with   ( $mockConfig )
+		    ->will   ( $this->returnValue( $mockConfig ) )
+		;
+		$get = new \ReflectionMethod( 'SearchApiController', 'getConfigFromRequest' );
+		$get->setAccessible( true );
+		$this->assertEquals(
+				$mockConfig,
+				$get->invoke( $mockController )
+		);
+	}
+	
+	/**
+	 * @covers SearchApiController::validateNamespacesForConfig
+	 */
+	public function testValidateNamespacesForConfigNoNamespaces() {
+		$mockConfig = $this->getMockBuilder( 'Wikia\Search\Config' )
+		                   ->disableOriginalConstructor()
+		                   ->setMethods( [ 'setNamespaces' ] )
+		                   ->getMock();
+		
+		$mockRequest = $this->getMockBuilder( 'WikiaRequest' )
+		                    ->disableOriginalConstructor()
+		                    ->setMethods( [ 'getArray' ] )
+		                    ->getMock();
+		
+		$mockController = $this->getMockBuilder( 'SearchApiController' )
+		                       ->disableOriginalConstructor()
+		                       ->setMethods( [ 'getRequest' ] )
+		                       ->getMock();
+		
+		$mockController
+		    ->expects( $this->any() )
+		    ->method ( 'getRequest' )
+		    ->will   ( $this->returnValue( $mockRequest ) )
+		;
+		$mockRequest
+		    ->expects( $this->once() )
+		    ->method ( 'getArray' )
+		    ->with   ( 'namespaces', [] )
+		    ->will   ( $this->returnValue( [] ) )
+		;
+		$mockConfig
+		    ->expects( $this->never() )
+		    ->method ( 'setNamespaces' )
+		;
+		$validate = new \ReflectionMethod( 'SearchApiController', 'validateNamespacesForConfig' );
+		$validate->setAccessible( true );
+		$this->assertEquals(
+				$mockConfig,
+				$validate->invoke( $mockController, $mockConfig )
+		);
+	}
+	
+	/**
+	 * @covers SearchApiController::validateNamespacesForConfig
+	 */
+	public function testValidateNamespacesForConfigWithNamespaces() {
+		$mockConfig = $this->getMockBuilder( 'Wikia\Search\Config' )
+		                   ->disableOriginalConstructor()
+		                   ->setMethods( [ 'setNamespaces' ] )
+		                   ->getMock();
+		
+		$mockRequest = $this->getMockBuilder( 'WikiaRequest' )
+		                    ->disableOriginalConstructor()
+		                    ->setMethods( [ 'getArray' ] )
+		                    ->getMock();
+		
+		$mockController = $this->getMockBuilder( 'SearchApiController' )
+		                       ->disableOriginalConstructor()
+		                       ->setMethods( [ 'getRequest' ] )
+		                       ->getMock();
+		
+		$mockController
+		    ->expects( $this->any() )
+		    ->method ( 'getRequest' )
+		    ->will   ( $this->returnValue( $mockRequest ) )
+		;
+		$mockRequest
+		    ->expects( $this->once() )
+		    ->method ( 'getArray' )
+		    ->with   ( 'namespaces', [] )
+		    ->will   ( $this->returnValue( [ NS_MAIN ] ) )
+		;
+		$mockConfig
+		    ->expects( $this->once() )
+		    ->method ( 'setNamespaces' )
+		    ->with   ( [ NS_MAIN ] )
+		;
+		$validate = new \ReflectionMethod( 'SearchApiController', 'validateNamespacesForConfig' );
+		$validate->setAccessible( true );
+		$this->assertEquals(
+				$mockConfig,
+				$validate->invoke( $mockController, $mockConfig )
+		);
+	}
+	
+	/**
+	 * @covers SearchApiController::validateNamespacesForConfig
+	 */
+	public function testValidateNamespacesForConfigBadNamespaces() {
+		$mockConfig = $this->getMockBuilder( 'Wikia\Search\Config' )
+		                   ->disableOriginalConstructor()
+		                   ->setMethods( [ 'setNamespaces' ] )
+		                   ->getMock();
+		
+		$mockRequest = $this->getMockBuilder( 'WikiaRequest' )
+		                    ->disableOriginalConstructor()
+		                    ->setMethods( [ 'getArray' ] )
+		                    ->getMock();
+		
+		$mockController = $this->getMockBuilder( 'SearchApiController' )
+		                       ->disableOriginalConstructor()
+		                       ->setMethods( [ 'getRequest' ] )
+		                       ->getMock();
+		
+		$mockController
+		    ->expects( $this->any() )
+		    ->method ( 'getRequest' )
+		    ->will   ( $this->returnValue( $mockRequest ) )
+		;
+		$mockRequest
+		    ->expects( $this->once() )
+		    ->method ( 'getArray' )
+		    ->with   ( 'namespaces', [] )
+		    ->will   ( $this->returnValue( [ NS_MAIN, 'crap' ] ) )
+		;
+		
+		$validate = new \ReflectionMethod( 'SearchApiController', 'validateNamespacesForConfig' );
+		$validate->setAccessible( true );
+		try {
+			$validate->invoke( $mockController, $mockConfig );
+		} catch ( \InvalidParameterApiException $e ) { }
+		$this->assertInstanceOf(
+				'InvalidParameterApiException',
+				$e
+		);
+	}
+	
+	/**
+	 * @covers SearchApiController::setResponseFromConfig
+	 */
+	public function testSetResponseFromConfigNoTerms() {
+		$mockQuery = $this->getMock( 'Wikia\Search\Query\Select', [ 'hasTerms' ], [ 'foo' ] );
+		
+		$mockController = $this->getMockBuilder( 'SearchApiController' )
+		                       ->disableOriginalConstructor()
+		                       ->setMethods( [ 'getRequest' ] )
+		                       ->getMock();
+		
+		$mockConfig = $this->getMockBuilder( 'Wikia\Search\Config' )
+		                   ->disableOriginalConstructor()
+		                   ->setMethods( [ 'getQuery' ] )
+		                   ->getMock();
+		
+		$mockConfig
+		    ->expects( $this->once() )
+		    ->method ( 'getQuery' )
+		    ->will   ( $this->returnValue( $mockQuery ) )
+		;
+		$mockQuery
+		    ->expects( $this->once() )
+		    ->method ( 'hasTerms' )
+		    ->will   ( $this->returnValue( false ) )
+		;
+		
+		$set = new \ReflectionMethod( 'SearchApiController', 'setResponseFromConfig' );
+		$set->setAccessible( true );
+		try {
+			$set->invoke( $mockController, $mockConfig );
+		} catch ( \NotFoundApiException $e ) { }
+		
+		$this->assertInstanceOf(
+				'NotFoundApiException',
+				$e
+		);
+	}
+	
+	/**
+	 * @covers SearchApiController::setResponseFromConfig
+	 */
+	public function testSetResponseFromConfigWithTerms() {
+		$mockQuery = $this->getMock( 'Wikia\Search\Query\Select', [ 'hasTerms' ], [ 'foo' ] );
+		
+		$mockController = $this->getMockBuilder( 'SearchApiController' )
+		                       ->disableOriginalConstructor()
+		                       ->setMethods( [ 'getRequest', 'getResponse' ] )
+		                       ->getMock();
+		
+		$mockConfig = $this->getMockBuilder( 'Wikia\Search\Config' )
+		                   ->disableOriginalConstructor()
+		                   ->setMethods( [ 'getQuery', 'getLimit', 'getResultsFound', 'getNumPages', 'getPage' ] )
+		                   ->getMock();
+		
+		$mockFactory = $this->getMock( 'Wikia\Search\QueryService\Factory', [ 'getFromConfig' ] );
+		
+		$mockService = $this->getMockBuilder( 'Wikia\Search\QueryService\Select\OnWiki' )
+		                    ->disableOriginalConstructor()
+		                    ->setMethods( [ 'search' ] )
+		                    ->getMock();
+		
+		$mockResponse = $this->getMockBuilder( 'WikiaResponse' )
+		                     ->disableOriginalConstructor()
+		                     ->setMethods( [ 'setValues', 'setCacheValidity' ] )
+		                     ->getMock();
+		
+		$mockResultSet = $this->getMockBuilder( 'Wikia\Search\ResultSet\Base' )
+		                      ->disableOriginalConstructor()
+		                      ->setMethods( [ 'toArray' ] )
+		                      ->getMock();
+		
+		$resultArray = [ [ 'id' => 123, 'title' => 'foo', 'url' => 'http://www.wikia.com/wiki/Foo', 'ns' => 0 ] ];
+		
+		$mockConfig
+		    ->expects( $this->once() )
+		    ->method ( 'getQuery' )
+		    ->will   ( $this->returnValue( $mockQuery ) )
+		;
+		$mockQuery
+		    ->expects( $this->once() )
+		    ->method ( 'hasTerms' )
+		    ->will   ( $this->returnValue( true ) )
+		;
+		$mockConfig
+		    ->expects( $this->once() )
+		    ->method ( 'getLimit' )
+		    ->will   ( $this->returnValue( 20 ) )
+		;
+		$mockFactory
+		    ->expects( $this->once() )
+		    ->method ( 'getFromConfig' )
+		    ->with   ( $mockConfig )
+		    ->will   ( $this->returnValue( $mockService ) )
+		;
+		$mockService
+		    ->expects( $this->once() )
+		    ->method ( 'search' )
+		    ->will   ( $this->returnValue( $mockResultSet ) )
+		;
+		$mockConfig
+		    ->expects( $this->once() )
+		    ->method ( 'getResultsFound' )
+		    ->will   ( $this->returnValue( 100 ) )
+		;
+		$mockResultSet
+		    ->expects( $this->once() )
+		    ->method ( 'toArray' )
+		    ->with   ( ['pageid' => 'id', 'title', 'url', 'ns' ] )
+		    ->will   ( $this->returnValue( $resultArray ) )
+		;
+		$mockConfig
+		    ->expects( $this->once() )
+		    ->method ( 'getNumPages' )
+		    ->will   ( $this->returnValue( 5 ) )
+		;
+		$mockConfig
+		    ->expects( $this->once() )
+		    ->method ( 'getPage' )
+		    ->will   ( $this->returnValue( 1 ) )
+		;
+		$mockController
+		    ->expects( $this->once() )
+		    ->method ( 'getResponse' )
+		    ->will   ( $this->returnValue( $mockResponse ) )
+		;
+		$mockResponse
+		    ->expects( $this->once() )
+		    ->method ( 'setValues' )
+		    ->with   ( [ 'items' => $resultArray, 'next' => 20, 'total' => 100, 'batches' => 5, 'currentBatch' => 1 ] )
+		;
+		$mockResponse
+		    ->expects( $this->once() )
+		    ->method ( 'setCacheValidity' )
+		    ->with   ( 86400, 86400, [ \WikiaResponse::CACHE_TARGET_BROWSER, \WikiaResponse::CACHE_TARGET_VARNISH ] )
+		;
+		
+		$this->proxyClass( 'Wikia\Search\QueryService\Factory', $mockFactory );
+		$this->mockApp();
+		
+		$set = new \ReflectionMethod( 'SearchApiController', 'setResponseFromConfig' );
+		$set->setAccessible( true );
+		$set->invoke( $mockController, $mockConfig );
+		
+	}
+}

--- a/extensions/wikia/Search/classes/Test/ResultTest.php
+++ b/extensions/wikia/Search/classes/Test/ResultTest.php
@@ -297,8 +297,10 @@ class ResultTest extends BaseTest {
 	 * @covers Wikia\Search\Result::toArray
 	 */
 	public function testToArray() {
-		$result = new Result( $this->defaultFields );
-		$array  = $result->toArray( array( 'wid' ) );
+		$fields = $this->defaultFields;
+		$fields['foo'] = 'bar';
+		$result = new Result( $fields );
+		$array  = $result->toArray( array( 'wid', 'foo' => 'roseanne' ) );
 		$this->assertArrayHasKey(
 				'wid',
 				$array
@@ -306,6 +308,10 @@ class ResultTest extends BaseTest {
 		$this->assertEquals(
 				123,
 				$array['wid']
+		);
+		$this->assertEquals(
+				'bar',
+				$array['roseanne']
 		);
 	}
 


### PR DESCRIPTION
Adding in tests to the search API controller so future changes to the Wikia search library get caught won't result in P2 bugs, but unit test failures on dev instead.
