### PR TITLE
(BugId:114024) - Remove template preprocessing from category select on view pages.

### DIFF
--- a/extensions/wikia/CategorySelect/CategorySelectController.class.php
+++ b/extensions/wikia/CategorySelect/CategorySelectController.class.php
@@ -201,10 +201,6 @@ class CategorySelectController extends WikiaController {
 			$article = new Article( $title );
 			$wikitext = $article->fetchContent();
 
-			// Pull in categories from templates inside of the article (BugId:100980)
-			$options = new ParserOptions();
-			$wikitext = ParserPool::preprocess( $wikitext, $title, $options );
-
 			// Extract categories from the article, merge them with those passed in, weed out
 			// duplicates and finally append them back to the article.
 			$data = CategorySelect::extractCategoriesFromWikitext( $wikitext, true );


### PR DESCRIPTION
Fixes: https://wikia.fogbugz.com/default.asp?114024

My fault: the preprocessed wikitext should not be used as the final wikitext to save, it should just be used to extract categories from.
