### PR TITLE
Clean-up after removing part of CorporatePage extension and occurrences of $wgEnableCorporatePageExt

### DIFF
--- a/extensions/wikia/RelatedVideos/RelatedVideos.hooks.php
+++ b/extensions/wikia/RelatedVideos/RelatedVideos.hooks.php
@@ -144,9 +144,7 @@ class RelatedVideosHookHandler {
 	
 	private function isRailModuleWanted($title, $namespace) {
 		$app = F::App();
-		wfProfileIn(__METHOD__);
-
-		wfProfileOut(__METHOD__);
+		
 		return !HubService::isCorporatePage()
 			&& $title->exists()
 			&& $app->wg->request->getVal( 'diff' ) === null

--- a/extensions/wikia/RelatedVideos/RelatedVideos.hooks.php
+++ b/extensions/wikia/RelatedVideos/RelatedVideos.hooks.php
@@ -133,15 +133,28 @@ class RelatedVideosHookHandler {
 		$title = $app->wg->Title;
 		$namespace = $title->getNamespace();
 
-		if( $title->exists() && $app->wg->request->getVal( 'diff' ) === null
-			&& ( $namespace == NS_MAIN || $namespace == NS_FILE || $namespace == NS_CATEGORY
-				|| ( (!empty($app->wg->ContentNamespace)) && in_array($namespace, $app->wg->ContentNamespace) ) ) ) {
+		if( $this->isRailModuleWanted($title, $namespace) ) {
 			$pos = $app->wg->User->isAnon() ? 1301 : 1281;
 			$modules[$pos] = array('RelatedVideosRail', 'index', null);
 		}
 
 		wfProfileOut(__METHOD__);
 		return true;
+	}
+	
+	private function isRailModuleWanted($title, $namespace) {
+		$app = F::App();
+		wfProfileIn(__METHOD__);
+
+		wfProfileOut(__METHOD__);
+		return !HubService::isCorporatePage()
+			&& $title->exists()
+			&& $app->wg->request->getVal( 'diff' ) === null
+			&& ( $namespace == NS_MAIN 
+				|| $namespace == NS_FILE 
+				|| $namespace == NS_CATEGORY
+				|| ( (!empty($app->wg->ContentNamespace)) && in_array($namespace, $app->wg->ContentNamespace) ) 
+			);
 	}
 
 	/**

--- a/extensions/wikia/WikiaHomePage/WikiaHomePage.setup.php
+++ b/extensions/wikia/WikiaHomePage/WikiaHomePage.setup.php
@@ -52,3 +52,4 @@ $app->registerHook('OutputPageBeforeHTML', 'WikiaHomePageController', 'onOutputP
 $app->registerHook('WikiaMobileAssetsPackages', 'WikiaHomePageController', 'onWikiaMobileAssetsPackages');
 $app->registerHook('ArticleCommentCheck', 'WikiaHomePageController', 'onArticleCommentCheck');
 $app->registerHook('AfterGlobalHeader', 'WikiaHomePageController', 'onAfterGlobalHeader');
+$app->registerHook('GetRailModuleList', 'WikiaHomePageController', 'onGetRailModuleList');

--- a/extensions/wikia/WikiaHomePage/WikiaHomePageController.class.php
+++ b/extensions/wikia/WikiaHomePage/WikiaHomePageController.class.php
@@ -730,6 +730,14 @@ class WikiaHomePageController extends WikiaController {
 		return true;
 	}
 
+	public static function onGetRailModuleList(&$railModuleList) {
+		$railModuleList = [
+			1500 => ['Search', 'Index', null],
+		];
+		
+		return true;
+	}
+
 	public function getWikiBatchesForVisualization() {
 		$numberOfBatches = $this->request->getVal('numberOfBatches', self::WIKI_BATCH_SIZE);
 		$wikiId = $this->wg->cityId;

--- a/skins/oasis/modules/BodyController.class.php
+++ b/skins/oasis/modules/BodyController.class.php
@@ -348,6 +348,7 @@ class BodyController extends WikiaController {
 		// show corporate header on this page?
 		} else if( !empty($wgEnableWikiaHomePageExt) ) {
 			$this->headerModuleName = 'PageHeader';
+			
 			if( self::isEditPage() ) {
 				$this->headerModuleAction = 'EditPage';
 			} else {

--- a/skins/oasis/modules/BodyController.class.php
+++ b/skins/oasis/modules/BodyController.class.php
@@ -345,19 +345,27 @@ class BodyController extends WikiaController {
 			else if (self::isBlogListing()) {
 				$this->headerModuleAction = 'BlogListing';
 			}
-		} else {
+		// show corporate header on this page?
+		} else if( !empty($wgEnableWikiaHomePageExt) ) {
 			$this->headerModuleName = 'PageHeader';
-			if (self::isEditPage()) {
+			if( self::isEditPage() ) {
 				$this->headerModuleAction = 'EditPage';
+			} else {
+				$this->headerModuleAction = 'Corporate';
 			}
 
 			// FIXME: move to separate module
-			if ( $wgEnableWikiaHomePageExt && WikiaPageType::isMainPage() ) {
+			if( WikiaPageType::isMainPage() ) {
 				$this->wg->SuppressFooter = true;
 				$this->wg->SuppressArticleCategories = true;
 				$this->wg->SuppressPageHeader = true;
 				$this->wg->SuppressWikiHeader = true;
 				$this->wg->SuppressSlider = true;
+			}
+		} else {
+			$this->headerModuleName = 'PageHeader';
+			if( self::isEditPage() ) {
+				$this->headerModuleAction = 'EditPage';
 			}
 		}
 

--- a/skins/oasis/modules/BodyController.class.php
+++ b/skins/oasis/modules/BodyController.class.php
@@ -346,7 +346,7 @@ class BodyController extends WikiaController {
 				$this->headerModuleAction = 'BlogListing';
 			}
 		// show corporate header on this page?
-		} else if( !empty($wgEnableWikiaHomePageExt) ) {
+		} else if( HubService::isCorporatePage() ) {
 			$this->headerModuleName = 'PageHeader';
 			
 			if( self::isEditPage() ) {


### PR DESCRIPTION
Since we [partly removed CorporatePage](https://github.com/Wikia/app/commit/fb564947f573e39c80052389f127a5bce610a86c) and occurrences of [$wgEnableCorporatePageExt](https://github.com/Wikia/app/pull/765) we checked how it affected [wikia.com](http://www.wikia.com). I found inconsistencies between production and dev versions (except out-dated content of articles). First one was a regular page header and I brought it back by adding another "else if" block in our Oasis BodyController.

After that most of the pages looked as on production except Mobile page and its sub-pages -- there is a search form visible next to page title in header. But the content is out-dated and on production I saw the form is hidden by CSS rule in article's content.

I'm more worried about the sub-page example:
http://www.wikiaglobal.nandy.wikia-dev.com/wiki/Press (this isn't valid anymore -- code changes were done which fixed it)

At the beginning after removal of CorporatePage the right rail has the same modules within as on regural wiki. When [on production](http://www.wikia.com/Press) you can notice there is only the search. I wanted to accomplish that by creating hook in WikiaHomePage extension. It almost worked, except "Related Video" module. @saipetch @lizlux @garthwebb can I modify your code and add to the [onGetRailModuleList hook method](https://github.com/Wikia/app/blob/dev/extensions/wikia/RelatedVideos/RelatedVideos.hooks.php#L136) condition which hides the module on corporate pages?

@moliwikia @macbre @gabrys @owend @federico-lox an eye on the changes are most welcome :)
