### PR TITLE
DAR:153 - hovering over wall notifications - storing event target in clo...

### DIFF
--- a/skins/oasis/js/hoverMenu.js
+++ b/skins/oasis/js/hoverMenu.js
@@ -99,8 +99,9 @@ HoverMenu.prototype.handleShowNav = function(event) {
 	if ($(event.relatedTarget).closest(this.selector).length == 0) {
 
 		//Delay before showing subnav.
+		var currentTarget = event.currentTarget;
 		this.mouseoverTimer = setTimeout($.proxy(function() {
-			this.showNav(event.currentTarget);
+			this.showNav(currentTarget);
 		}, this), this.settings.mouseoverDelay);
 
 		this.mouseoverTimerRunning = true;


### PR DESCRIPTION
...sure so it won't be replaced till the moment callback is run.

Right now when the mouse hover event is generated with JS and by selenium web driver, then content of the event object is changed before the function is called by SetTimeout. This makes it impossible to expand wall notifications in automated tests without doing hack/workarounds.
