### PR TITLE
Adding imports to MediaWiki:Chat.* and Special:MyPage/chat.*

### DIFF
--- a/extensions/wikia/Chat2/templates/Chat_Index.php
+++ b/extensions/wikia/Chat2/templates/Chat_Index.php
@@ -15,7 +15,7 @@
 
 
 	<!-- JS -->
-	<script type="text/javascript" src="/load.php?lang=en&mode=articles&articles=MediaWiki%3AChat.css%7CUser%3A<?php echo $wgUserName; ?>%2Fchat.css&only=styles"></script>
+	<script type="text/javascript" src="/load.php?lang=en&mode=articles&articles=MediaWiki%3AChat.js%7CUser%3A<?php echo $wgUserName; ?>%2Fchat.js&only=styles"></script>
 	<?php
 		$srcs = F::build('AssetsManager',array(),'getInstance')->getGroupCommonURL('oasis_blocking', array());
 	?>

--- a/extensions/wikia/Chat2/templates/Chat_Index.php
+++ b/extensions/wikia/Chat2/templates/Chat_Index.php
@@ -11,8 +11,11 @@
 
 	<!-- CSS -->
 	<link rel="stylesheet" href="<?= AssetsManager::getInstance()->getSassCommonURL('/extensions/wikia/Chat2/css/Chat.scss')?>">
+	<link rel="stylesheet" href="/load.php?lang=en&mode=articles&articles=MediaWiki%3AChat.css%7CUser%3A<?php echo $wgUserName; ?>%2Fchat.css&only=styles">
+
 
 	<!-- JS -->
+	<script type="text/javascript" src="/load.php?lang=en&mode=articles&articles=MediaWiki%3AChat.css%7CUser%3A<?php echo $wgUserName; ?>%2Fchat.css&only=styles"></script>
 	<?php
 		$srcs = F::build('AssetsManager',array(),'getInstance')->getGroupCommonURL('oasis_blocking', array());
 	?>

--- a/extensions/wikia/Chat2/templates/Chat_Index.php
+++ b/extensions/wikia/Chat2/templates/Chat_Index.php
@@ -13,9 +13,8 @@
 	<link rel="stylesheet" href="<?= AssetsManager::getInstance()->getSassCommonURL('/extensions/wikia/Chat2/css/Chat.scss')?>">
 	<link rel="stylesheet" href="/load.php?lang=en&mode=articles&articles=MediaWiki%3AChat.css%7CUser%3A<?php echo $wgUserName; ?>%2Fchat.css&only=styles">
 
-
 	<!-- JS -->
-	<script type="text/javascript" src="/load.php?lang=en&mode=articles&articles=MediaWiki%3AChat.js%7CUser%3A<?php echo $wgUserName; ?>%2Fchat.js&only=styles"></script>
+	<script type="text/javascript" src="/load.php?lang=en&mode=articles&articles=MediaWiki%3AChat.js%7CUser%3A<?php echo $wgUserName; ?>%2Fchat.js&only=scripts"></script>
 	<?php
 		$srcs = F::build('AssetsManager',array(),'getInstance')->getGroupCommonURL('oasis_blocking', array());
 	?>

--- a/extensions/wikia/Chat2/templates/Chat_Index.php
+++ b/extensions/wikia/Chat2/templates/Chat_Index.php
@@ -14,7 +14,6 @@
 	<link rel="stylesheet" href="/load.php?lang=en&mode=articles&articles=MediaWiki%3AChat.css%7CUser%3A<?php echo $wgUserName; ?>%2Fchat.css&only=styles">
 
 	<!-- JS -->
-	<script type="text/javascript" src="/load.php?lang=en&mode=articles&articles=MediaWiki%3AChat.js%7CUser%3A<?php echo $wgUserName; ?>%2Fchat.js&only=scripts"></script>
 	<?php
 		$srcs = F::build('AssetsManager',array(),'getInstance')->getGroupCommonURL('oasis_blocking', array());
 	?>
@@ -133,5 +132,6 @@
 		<script src="<?php echo $src ?>"></script>
 	<?php endforeach;?>
 	<script src="<?php echo $jsMessagePackagesUrl ?>"></script>
+	<script type="text/javascript" src="/load.php?lang=en&mode=articles&articles=MediaWiki%3AChat.js%7CUser%3A<?php echo $wgUserName; ?>%2Fchat.js&only=scripts"></script>
 </body>
 </html>


### PR DESCRIPTION
So far, importing these js and css pages had to be done with a kind of hack that loaded the pages indirectly, and after loading all other scripts. This will load the scripts to every wiki automatically without needing the hack to import it, and it will load the scripts from the start of the pageload, instead of after it.
