### PR TITLE
MAIN-54 remove unsupported method call from Wikia\Search\Config in WikiaSearchAjaxController

### DIFF
--- a/extensions/wikia/Search/WikiaSearchAjaxController.class.php
+++ b/extensions/wikia/Search/WikiaSearchAjaxController.class.php
@@ -42,8 +42,7 @@ class WikiaSearchAjaxController extends WikiaController {
 		);
         $config = new Wikia\Search\Config( $params );
         $config->setInterWiki( $isInterWiki )
-               ->setQuery( $query )
-               ->setGroupResults( $isInterWiki );
+               ->setQuery( $query );
         $results = (new QueryService\Factory)->getFromConfig( $config )->search();
 
         $text = $this->app->getView('WikiaSearch', 'WikiaMobileResultList', array(


### PR DESCRIPTION
A call to the method "setGroupResults" (which is no longer used or supported) is causing fatals on preview, and breaking search result pagination in Wikia Mobile. This is the only place this controller is used.
