### PR TITLE
PLA-279 -- make images searchable without including file extension

### DIFF
--- a/extensions/wikia/Search/classes/Test/IndexService/DefaultContentTest.php
+++ b/extensions/wikia/Search/classes/Test/IndexService/DefaultContentTest.php
@@ -367,7 +367,7 @@ class DefaultContentTest extends BaseTest
 	 * @covers Wikia\Search\IndexService\DefaultContent::prepValuesFromHtml
 	 */
 	public function testPrepValuesFromHtml() {
-		$service = $this->getMock( 'Wikia\Search\IndexService\DefaultContent', array( 'field' ) );
+		$service = $this->getMock( 'Wikia\Search\IndexService\DefaultContent', array( 'field', 'pushNolangTxt' ) );
 		$prep = new ReflectionMethod( 'Wikia\Search\IndexService\DefaultContent', 'prepValuesFromHtml' );
 		$prep->setAccessible( true );
 		$service
@@ -375,6 +375,11 @@ class DefaultContentTest extends BaseTest
 		    ->method ( 'field' )
 		    ->with   ( 'html' )
 		    ->will   ( $this->returnValue( 'html_en' ) )
+		;
+		$service
+		    ->expects( $this->once() )
+		    ->method ( 'pushNoLangTxt' )
+		    ->withAnyParameters()
 		;
 		$html = <<<ENDIT
 This is a very long example so we can do some counts and stuff.
@@ -627,6 +632,39 @@ ENDIT;
 		$this->assertEquals(
 				[ 'infoboxes_txt' => [ 'here is my key | value' ] ],
 				$extract->invoke( $service, $dom, $result )
+		);
+	}
+	
+	/**
+	 * @covers Wikia\Search\IndexService\DefaultContent::pushNolangTxt
+	 * @covers Wikia\Search\IndexService\DefaultContent::getNolangTxt
+	 */
+	public function testPushAndGetNolangTxt() {
+		$service = $this->getMockBuilder( 'Wikia\Search\IndexService\DefaultContent' )
+		                ->disableOriginalConstructor()
+		                ->setMethods( null )
+		                ->getMock();
+		$push = new ReflectionMethod( 'Wikia\Search\IndexService\DefaultContent', 'pushNolangTxt' );
+		$push->setAccessible( true );
+		$get = new ReflectionMethod( 'Wikia\Search\IndexService\DefaultContent', 'getNolangTxt' );
+		$get->setAccessible( true );
+		$this->assertAttributeEquals(
+				[],
+				'nolang_txt',
+				$service
+		);
+		$this->assertEquals(
+				$service,
+				$push->invoke( $service, 'foo' )
+		);
+		$this->assertAttributeEquals(
+				['foo'],
+				'nolang_txt',
+				$service
+		);
+		$this->assertEquals(
+				[ 'nolang_txt' => [ 'foo' ] ],
+				$get->invoke( $service )
 		);
 	}
 }

--- a/extensions/wikia/Search/classes/Test/IndexService/DefaultContentTest.php
+++ b/extensions/wikia/Search/classes/Test/IndexService/DefaultContentTest.php
@@ -55,7 +55,7 @@ class DefaultContentTest extends BaseTest
 	 * @covers Wikia\Search\IndexService\DefaultContent::execute
 	 */
 	public function testExecute() {
-		$methods = [ 'getService', 'field', 'getPageContentFromParseResponse', 'getCategoriesFromParseResponse', 'getHeadingsFromParseResponse', 'getOutboundLinks' ];
+		$methods = [ 'getService', 'field', 'getPageContentFromParseResponse', 'getCategoriesFromParseResponse', 'getHeadingsFromParseResponse', 'getOutboundLinks', 'pushNolangTxt', 'getNolangTxt' ];
 		$service = $this->getMock( 'Wikia\Search\IndexService\DefaultContent', $methods, array() );
 		$mwMethods = [
 				'getParseResponseFrompageId', 'getTitleStringFromPageId', 'getUrlFromPageId',
@@ -151,12 +151,24 @@ class DefaultContentTest extends BaseTest
 		;
 		$service
 		    ->expects( $this->at( 1 ) )
+		    ->method ( 'pushNoLangTxt' )
+		    ->with   ( "my title" )
+		    ->will   ( $this->returnValue( $service ) )
+		;
+		$service
+		    ->expects( $this->at( 2 ) )
+		    ->method ( 'pushNoLangTxt' )
+		    ->with   ( "my title" )
+		    ->will   ( $this->returnValue( $service ) )
+		;
+		$service
+		    ->expects( $this->at( 3 ) )
 		    ->method ( 'field' )
 		    ->with   ( 'title' )
 		    ->will   ( $this->returnValue( 'title_en' ) )
 		;
 		$service
-		    ->expects( $this->at( 2 ) )
+		    ->expects( $this->at( 4 ) )
 		    ->method ( 'field' )
 		    ->with   ( 'wikititle' )
 		    ->will   ( $this->returnValue( 'wikititle_en' ) )
@@ -184,6 +196,11 @@ class DefaultContentTest extends BaseTest
 		    ->method ( 'getOutboundLinks' )
 		    ->will   ( $this->returnValue( [ 'outbound_links_txt' => [ '123_321|hey', '123_456|ho' ] ] ) )
 		;
+		$service
+		    ->expects( $this->once() )
+		    ->method ( 'getNolangTxt' )
+		    ->will   ( $this->returnValue( [ 'nolang_txt' => [ 'foo' ] ] ) )
+		;
 		$cpid = new \ReflectionProperty( 'Wikia\Search\IndexService\AbstractService', 'currentPageId' );
 		$cpid->setAccessible( true );
 		$cpid->setValue( $service, 123 );
@@ -204,7 +221,8 @@ class DefaultContentTest extends BaseTest
 				'page_images' => 2,
 				'iscontent' => 'true',
 				'is_main_page' => 'false',
-				'outbound_links_txt' => [ '123_321|hey', '123_456|ho' ]
+				'outbound_links_txt' => [ '123_321|hey', '123_456|ho' ],
+				'nolang_txt' => [ 'foo' ]
 				];
 		$this->assertEquals(
 				$expectedResult,


### PR DESCRIPTION
This adds a version of the title string to nolang_txt, which will help expose content treated as a single filename to the search engine. We will need to reindex the site to get this to work for all pages. For more information about this defect, please take a look at PLA-279.
