### PR TITLE
BAC-266: Memory limit exceeded: /wikia.php?controller=Lightbox&method=getMediaDetail

### DIFF
--- a/includes/wikia/ArticlesUsingMediaQuery.class.php
+++ b/includes/wikia/ArticlesUsingMediaQuery.class.php
@@ -10,6 +10,8 @@ class ArticlesUsingMediaQuery {
 	private $app;
 	private $memc;
 
+	const IMAGELINKS_LIMIT = 500;
+
 	/*
 	 * @param Title $fileTitle
 	 */
@@ -42,7 +44,10 @@ class ArticlesUsingMediaQuery {
 			array( 'page_namespace', 'page_title' ),
 			array( 'il_to' => $this->fileTitle->getDBKey(), 'il_from = page_id' ),
 			__METHOD__,
-			array( 'ORDER BY' => 'page_namespace ASC' )
+			[
+				'LIMIT' => self::IMAGELINKS_LIMIT, # BAC-265
+				'ORDER BY' => 'page_namespace ASC'
+			]
 		);
 
 		$data = array() ;

--- a/includes/wikia/services/WikiaFileHelper.class.php
+++ b/includes/wikia/services/WikiaFileHelper.class.php
@@ -383,7 +383,7 @@ class WikiaFileHelper extends Service {
 				$user = F::build('User', array( $file->getUser('id') ), 'newFromId' );
 
 				// get article list
-				$mediaQuery =  F::build( 'ArticlesUsingMediaQuery' , array( $fileTitle ) );
+				$mediaQuery =  new ArticlesUsingMediaQuery($fileTitle);
 				$articleList = $mediaQuery->getArticleList();
 
 				$data['imageUrl'] = $thumb->getUrl();


### PR DESCRIPTION
`WikiaFileHelper::getMediaDetail` gets the list of articles that have given image embedded. This list is not limited. It will run out of memory for commonly used images on big wikis.

```
$ grep "Allowed memory size of " php.1 | grep getMediaDetail | wc -l
270
```

@themech @federico-lox 
