### PR TITLE
BAC-265: do not remove limits when dealing with big wikis

### DIFF
--- a/extensions/wikia/WikiaMobile/models/WikiaMobileCategoryModel.class.php
+++ b/extensions/wikia/WikiaMobile/models/WikiaMobileCategoryModel.class.php
@@ -96,11 +96,12 @@ class WikiaMobileCategoryViewer extends CategoryViewer{
 	private $items;
 	private $count;
 
+	const LIMIT = 5000;
+
 	function __construct( Category $category ){
 		parent::__construct( $category->getTitle(), RequestContext::getMain() );
 
-		//get all the members in the category
-		$this->limit = null;
+		$this->limit = self::LIMIT; # BAC-265
 
 		$this->items = [];
 		$this->count = 0;


### PR DESCRIPTION
WikiaMobileCategoryModel had no limit on number of pages that are shown on category page. This caused out of memory errors on big wikis (around 200 daily) when viewing category pages on mobile skin.

@federico-lox
