### PR TITLE
removing varnish cache for video handlers refactor release

### DIFF
--- a/extensions/wikia/Lightbox/LightboxController.class.php
+++ b/extensions/wikia/Lightbox/LightboxController.class.php
@@ -197,7 +197,7 @@ class LightboxController extends WikiaController {
 		$this->exists = $data['exists'];
 
 		// set cache control to 1 hour
-		$this->response->setCacheValidity(3600, 3600, array(WikiaResponse::CACHE_TARGET_BROWSER));
+		//$this->response->setCacheValidity(3600, 3600, array(WikiaResponse::CACHE_TARGET_BROWSER, WikiaResponse::CACHE_TARGET_VARNISH));
 		// Make sure that a request with missing &format=json does not throw a "template not found" exception
 		$this->response->setFormat('json');
 	}

--- a/extensions/wikia/Lightbox/LightboxController.class.php
+++ b/extensions/wikia/Lightbox/LightboxController.class.php
@@ -197,7 +197,7 @@ class LightboxController extends WikiaController {
 		$this->exists = $data['exists'];
 
 		// set cache control to 1 hour
-		$this->response->setCacheValidity(3600, 3600, array(WikiaResponse::CACHE_TARGET_BROWSER, WikiaResponse::CACHE_TARGET_VARNISH));
+		$this->response->setCacheValidity(3600, 3600, array(WikiaResponse::CACHE_TARGET_BROWSER));
 		// Make sure that a request with missing &format=json does not throw a "template not found" exception
 		$this->response->setFormat('json');
 	}


### PR DESCRIPTION
There's a large change to both php and js going out tomorrow, so if we kept this varnish and browser caching all videos across the site would be broken for an hour.  This should prevent that. 
