### PR TITLE
Vb tracking timeout

### DIFF
--- a/extensions/wikia/Lightbox/js/Lightbox.js
+++ b/extensions/wikia/Lightbox/js/Lightbox.js
@@ -402,7 +402,7 @@ var Lightbox = {
 				.css('line-height','normal');
 
 			require(['wikia.videoBootstrap'], function (VideoBootstrap) {
-				new VideoBootstrap(Lightbox.openModal.media[0], data.videoEmbedCode, Lightbox.openModal.vbClickSource);
+				LightboxLoader.videoInstance = new VideoBootstrap(Lightbox.openModal.media[0], data.videoEmbedCode, Lightbox.openModal.vbClickSource);
 				Lightbox.openModal.vbClickSource = LightboxTracker.clickSource.LB;
 			});
 		},
@@ -670,6 +670,11 @@ var Lightbox = {
 	},
 	updateMedia: function() {
 		Lightbox.openModal.media.html("").startThrobbing();
+
+		// If a video uses a timeout for tracking, clear it
+		if ( LightboxLoader.videoInstance ) {
+			LightboxLoader.videoInstance.clearTimeoutTrack();
+		}
 
 		var key = Lightbox.current.key;
 		var type = Lightbox.current.type;

--- a/extensions/wikia/Lightbox/js/LightboxLoader.js
+++ b/extensions/wikia/Lightbox/js/LightboxLoader.js
@@ -16,6 +16,7 @@ var LightboxLoader = {
 	inlineVideoLinks: $(),	// jquery array of inline video links
 	lightboxLoading: false,
 	inlineVideoLoading: [],
+	videoInstance: null,
 	pageAds: $('#TOP_RIGHT_BOXAD'), // if more ads start showing up over lightbox, add them here
 	defaults: {
 		// start with default modal options
@@ -47,6 +48,10 @@ var LightboxLoader = {
 			LightboxLoader.pageAds.css('visibility','visible');
 			// Reset tracking
 			Lightbox.clearTrackingTimeouts();
+			// If a video uses a timeout for tracking, clear it
+			if ( LightboxLoader.videoInstance ) {
+				LightboxLoader.videoInstance.clearTimeoutTrack();
+			}
 		}
 	},
 	videoThumbWidthThreshold: 400,
@@ -195,6 +200,8 @@ var LightboxLoader = {
 
 	},
 	displayInlineVideo: function(target, targetChildImg, mediaTitle, clickSource) {
+		var self = this;
+
 		if($.inArray(mediaTitle, LightboxLoader.inlineVideoLoading) > -1) {
 			return;
 		}
@@ -210,7 +217,7 @@ var LightboxLoader = {
 				inlineDiv = $('<div class="inline-video"></div>').insertAfter(target.hide());
 
 			require(['wikia.videoBootstrap'], function (VideoBootstrap) {
-				new VideoBootstrap(inlineDiv[0], embedCode, clickSource);
+				self.videoInstance = new VideoBootstrap(inlineDiv[0], embedCode, clickSource);
 			});
 
 			// save references for inline video removal later

--- a/extensions/wikia/VideoEmbedTool/js/VET.js
+++ b/extensions/wikia/VideoEmbedTool/js/VET.js
@@ -8,7 +8,8 @@
 /*
  * Variables
  */
-(function($, window) {
+require(['wikia.videoBootstrap', 'jquery', 'wikia.window'], function (VideoBootstrap, $, window) {
+
 	var VET_panel = null;
 	var VET_curSourceId = 0;
 	var VET_lastQuery = new Array();
@@ -319,9 +320,7 @@
 
 		var element = $('#VideoEmbedThumb .video-embed');
 
-		require(['wikia.videoBootstrap'], function (VideoBootstrap) {
-			VET_videoInstance = new VideoBootstrap(element[0], window.VETPlayerParams, 'vetDetails');
-		});
+		VET_videoInstance = new VideoBootstrap(element[0], window.VETPlayerParams, 'vetDetails');
 
 		VET_updateHeader();
 
@@ -916,9 +915,7 @@
 				videoWrapper = this.cachedSelectors.videoWrapper,
 				embedWrapper = $('<div class="Wikia-video-enabledEmbedCode">'+data.videoEmbedCode+'</div>').appendTo(videoWrapper.html(""));
 
-			require(['wikia.videoBootstrap'], function (VideoBootstrap) {
-				VET_videoInstance = new VideoBootstrap(embedWrapper[0], data.videoEmbedCode, 'vetPreview');
-			});
+			VET_videoInstance = new VideoBootstrap(embedWrapper[0], data.videoEmbedCode, 'vetPreview');
 
 			// expand preview is hidden
 			if (!previewWrapper.is(':visible')) {
@@ -1140,4 +1137,4 @@
 	window.VET_show = VET_show;
 	window.VET_close = VET_close;
 	window.VETExtended = VETExtended;
-})(jQuery, window);
+});

--- a/extensions/wikia/VideoEmbedTool/js/VET.js
+++ b/extensions/wikia/VideoEmbedTool/js/VET.js
@@ -34,6 +34,7 @@
 	var VET_MIN_WIDTH = 100;
 	var VET_DEFAULT_WIDTH = 335;
 	var VET_thumbSize = VET_DEFAULT_WIDTH;	// variable that can change later, defaulted to DEFAULT
+	var VET_videoInstance = null;
 
 	var VET_tracking = Wikia.Tracker.buildTrackingFunction( Wikia.trackEditorComponent, {
 		action: Wikia.Tracker.ACTIONS.CLICK,
@@ -314,14 +315,12 @@
 		VET_switchScreen('Details');
 		$('#VideoEmbedBack').css('display', 'inline');
 
-		// wlee: responseText could include <script>. Use jQuery to parse
-		// and execute this script
 		$('#VideoEmbedDetails').html(responseText);
 
-		var element = $('<div></div>').appendTo('#VideoEmbedThumb');
+		var element = $('#VideoEmbedThumb .video-embed');
 
 		require(['wikia.videoBootstrap'], function (VideoBootstrap) {
-			new VideoBootstrap(element[0], window.VETPlayerParams, 'vetDetails');
+			VET_videoInstance = new VideoBootstrap(element[0], window.VETPlayerParams, 'vetDetails');
 		});
 
 		VET_updateHeader();
@@ -494,6 +493,9 @@
 	}
 
 	function VET_switchScreen(to) {
+		if ( VET_videoInstance ) {
+			VET_videoInstance.clearTimeoutTrack();
+		}
 		VET_prevScreen = VET_curScreen;
 		VET_curScreen = to;
 		$('#VideoEmbedBody').find('.VET_screen').hide();
@@ -915,7 +917,7 @@
 				embedWrapper = $('<div class="Wikia-video-enabledEmbedCode">'+data.videoEmbedCode+'</div>').appendTo(videoWrapper.html(""));
 
 			require(['wikia.videoBootstrap'], function (VideoBootstrap) {
-				new VideoBootstrap(embedWrapper[0], data.videoEmbedCode, 'vetPreview');
+				VET_videoInstance = new VideoBootstrap(embedWrapper[0], data.videoEmbedCode, 'vetPreview');
 			});
 
 			// expand preview is hidden

--- a/extensions/wikia/VideoEmbedTool/templates/details.tmpl.php
+++ b/extensions/wikia/VideoEmbedTool/templates/details.tmpl.php
@@ -9,6 +9,7 @@ global $wgExtensionsPath;
 			window.VETPlayerParams = <?= $props['code'] ?>;
 		</script>
 		<p><?= wfMessage( 'vet-preview' ) ?></p>
+		<div class="video-embed"></div>
 	</div>
 	<div class="preview-options">
 		<div class="input-group" id="VideoEmbedNameRow">

--- a/extensions/wikia/VideoHandlers/js/VideoBootstrap.js
+++ b/extensions/wikia/VideoHandlers/js/VideoBootstrap.js
@@ -3,7 +3,7 @@
  * Important: If an init function is specified, it must handle it's own tracking
  */
 
-define('wikia.videoBootstrap', ['wikia.loader', 'wikia.nirvana'], function videoBootstrap(loader, nirvana) {
+define('wikia.videoBootstrap', ['wikia.loader', 'wikia.nirvana', 'wikia.log'], function videoBootstrap(loader, nirvana, log) {
 	var trackingTimeout = 0;
 
 	// vb stands for video bootstrap
@@ -69,6 +69,9 @@ define('wikia.videoBootstrap', ['wikia.loader', 'wikia.nirvana'], function video
 		 */
 		reload: function(title, width, autoplay, clickSource) {
 			var element = this.element;
+
+			this.clearTimeoutTrack();
+
 			nirvana.getJson(
 				'VideoHandler',
 				'getEmbedCode',
@@ -82,6 +85,7 @@ define('wikia.videoBootstrap', ['wikia.loader', 'wikia.nirvana'], function video
 			});
 		},
 		track: function(action) {
+			log('tracking ' + action, 3, 'VideoBootstrap');
 			Wikia.Tracker.track({
 				action: action,
 				category: 'video-player-stats',
@@ -98,10 +102,14 @@ define('wikia.videoBootstrap', ['wikia.loader', 'wikia.nirvana'], function video
 		 */
 		timeoutTrack: function() {
 			var self = this;
-			clearTimeout(trackingTimeout);
+			this.clearTimeoutTrack();
 			trackingTimeout = setTimeout(function() {
 				self.track('content-begin');
 			}, 3000);
+		},
+		clearTimeoutTrack: function() {
+			log('clearing tracking timeout', 3, 'VideoBootstrap');
+			clearTimeout(trackingTimeout);
 		},
 		/**
 		 * Some video providers require unique DOM id's in order to initialize

--- a/extensions/wikia/VideoHandlers/js/VideoBootstrap.js
+++ b/extensions/wikia/VideoHandlers/js/VideoBootstrap.js
@@ -46,6 +46,7 @@ define('wikia.videoBootstrap', ['wikia.loader', 'wikia.nirvana', 'wikia.log'], f
 				// execute the init function
 				if(init) {
 					require([init], function(init) {
+						self.clearTimeoutTrack();
 						init(jsParams, self);
 					});
 				}

--- a/extensions/wikia/WikiaMobile/js/media.js
+++ b/extensions/wikia/WikiaMobile/js/media.js
@@ -54,7 +54,8 @@ define('media', ['JSMessages', 'modal', 'throbber', 'wikia.querystring', require
 		inited,
 		supportedVideos = window.supportedVideos || [],
 		// Video view click source tracking. Possible values are "embed" and "lightbox" for consistancy with Oasis
-		clickSource;
+		clickSource,
+		videoInstance;
 
 	//Media object that holds all data needed to display it in modal/gallery
 	function Media(elem, data, length, i){
@@ -158,7 +159,7 @@ define('media', ['JSMessages', 'modal', 'throbber', 'wikia.querystring', require
 	}
 
 	function embedVideo(image, data) {
-		new VideoBootstrap(image, data, clickSource);
+		videoInstance = new VideoBootstrap(image, data, clickSource);
 		// Future video/image views will come from modal
 		clickSource = 'lightbox';
 	}
@@ -166,6 +167,11 @@ define('media', ['JSMessages', 'modal', 'throbber', 'wikia.querystring', require
 	function setupImage(){
 		var image = images[current],
 			video;
+
+		// If a video uses a timeout for tracking, clear it
+		if ( videoInstance ) {
+			videoInstance.clearTimeoutTrack();
+		}
 
 		throbber.remove(currentImage);
 

--- a/resources/wikia/modules/log.js
+++ b/resources/wikia/modules/log.js
@@ -14,6 +14,7 @@
  * //To allow the messages to be printed to the console add log_level=X to the
  * //URL querystring, where X is one of the values in the levels hash (either the hash key or it's value)
  * //e.g. http://glee.wikia.com/wiki/Rachel_Berry?log_level=info
+ * //e.g. http://glee.wikia.com/wiki/Rachel_Berry?log_level=info&log_group=MyLogGroup
  *
  * @see  printMessage for a list of parameters and their description
  */


### PR DESCRIPTION
The new video-player-stats version of video view tracking still uses a fallback of timeouts for videos that don't have JS API's for event tracking.  Those timeouts weren't being cleared properly, so this should fix that problem.  

Also wrapped VET in AMD. 
