### PR TITLE
Remove globals from SpecialChat.class.php & linkify chat-no-login

### DIFF
--- a/extensions/wikia/Chat2/Chat.i18n.php
+++ b/extensions/wikia/Chat2/Chat.i18n.php
@@ -5,8 +5,8 @@ $messages = array();
 $messages['en'] = array(
     'chat' => 'Chat',
     'chat-desc' => '[[Special:Chat|Live chat]]',
-    'chat-no-login' => 'You must be logged in to chat.',
-    'chat-no-login-text' => 'Please login to chat.',
+    'chat-no-login' => 'You must be <a href="/wiki/Special:Userlogin">logged in</a> to chat.',
+    'chat-no-login-text' => 'Please <a href="/wiki/Special:Userlogin">log in</a> to chat.',
     'chat-default-topic' => 'Welcome to the $1 chat',
     'chat-welcome-message' => 'Welcome to the $1 chat',
     'chat-user-joined' => '$1 has joined the chat.',

--- a/extensions/wikia/Chat2/Chat.i18n.php
+++ b/extensions/wikia/Chat2/Chat.i18n.php
@@ -5,8 +5,8 @@ $messages = array();
 $messages['en'] = array(
     'chat' => 'Chat',
     'chat-desc' => '[[Special:Chat|Live chat]]',
-    'chat-no-login' => 'You must be <a href="/wiki/Special:Userlogin">logged in</a> to chat.',
-    'chat-no-login-text' => 'Please <a href="/wiki/Special:Userlogin">log in</a> to chat.',
+    'chat-no-login' => 'You must be [[Special:Userlogin|logged in]] to chat.',
+    'chat-no-login-text' => 'Please [[Special:Userlogin|log in]] to chat.',
     'chat-default-topic' => 'Welcome to the $1 chat',
     'chat-welcome-message' => 'Welcome to the $1 chat',
     'chat-user-joined' => '$1 has joined the chat.',

--- a/extensions/wikia/Chat2/SpecialChat.class.php
+++ b/extensions/wikia/Chat2/SpecialChat.class.php
@@ -21,9 +21,7 @@ class SpecialChat extends UnlistedSpecialPage {
 				$output->showErrorPage( 'chat-you-are-banned', 'chat-you-are-banned-text' );
 			}
 		} else {
-			// TODO: FIXME: Make a link on this page which lets the user login.
-			// TODO: FIXME: Make a link on this page which lets the user login.
-			
+
 			// $wgOut->permissionRequired( 'chat' ); // this is a really useless message, don't use it.
 			$output->showErrorPage( 'chat-no-login', 'chat-no-login-text' );
 

--- a/extensions/wikia/Chat2/SpecialChat.class.php
+++ b/extensions/wikia/Chat2/SpecialChat.class.php
@@ -8,22 +8,24 @@ class SpecialChat extends UnlistedSpecialPage {
 
 	public function execute() {
 		wfProfileIn( __METHOD__ );
-		global $wgUser, $wgOut, $wgCityId;
+		global $wgCityId;
+		$output = $this->getOutput();
+		$user = $this->getUser();
 
 		// check if logged in
-		if($wgUser->isLoggedIn()){
-			if( Chat::canChat($wgUser) ){
+		if ( $user->isLoggedIn() ) {
+			if ( Chat::canChat( $user ) ){
 				Wikia::setVar( 'OasisEntryControllerName', 'Chat' );
 				Chat::logChatWindowOpenedEvent();
 			} else {
-				$wgOut->showErrorPage( 'chat-you-are-banned', 'chat-you-are-banned-text' );
+				$output->showErrorPage( 'chat-you-are-banned', 'chat-you-are-banned-text' );
 			}
 		} else {
 			// TODO: FIXME: Make a link on this page which lets the user login.
 			// TODO: FIXME: Make a link on this page which lets the user login.
 			
 			// $wgOut->permissionRequired( 'chat' ); // this is a really useless message, don't use it.
-			$wgOut->showErrorPage( 'chat-no-login', 'chat-no-login-text' );
+			$output->showErrorPage( 'chat-no-login', 'chat-no-login-text' );
 
 		}
 


### PR DESCRIPTION
The attached commits replace $wgOut and $wgUser in SpecialChat.class.php with the respective SpecialPage methods that return the same object, and fix the TODO present there, i.e. add a link to Special:Userlogin in MediaWiki:Chat-no-join and MediaWiki:Chat-no-join-text.
