### PR TITLE
DAR-112 Only store oldest notification for a specific thread/author.

### DIFF
--- a/extensions/wikia/Wall/notification/WallNotifications.class.php
+++ b/extensions/wikia/Wall/notification/WallNotifications.class.php
@@ -772,16 +772,16 @@ class WallNotifications {
 		}
 
 		// scan relation list, remove element that has the same author
+		// keep the old one, and remove the new one so that the notification link points to the oldest unread message
 		$found = false;
 
 		foreach( $data['relation'][ $uniqueId ]['list'] as $key=>$rel ) {
 			if( $rel['authorId'] == $authorId ) {
-				unset($data['relation'][ $uniqueId ]['list'][$key]);
 				$found = true;
 
 				// keep track of removed elements - we will remove them from db
 				// table after we are done updating in-memory structures
-				$this->removedEntities[] = array( 'user_id' => $userId, 'wiki_id' => $wikiId, 'unique_id'=>$uniqueId, 'entity_key' => $rel['entityKey'] );
+				$this->removedEntities[] = array( 'user_id' => $userId, 'wiki_id' => $wikiId, 'unique_id'=>$uniqueId, 'entity_key' => $entityKey );
 			}
 		}
 
@@ -795,11 +795,10 @@ class WallNotifications {
 			}
 		}
 
-		// add new element
-		$data['relation'][ $uniqueId ]['list'][] = array('entityKey' => $entityKey, 'authorId' => $authorId, 'isReply'=>$isReply);
-
 		// if this was new author increase author count
 		if($found == false){
+			// add new element
+			$data['relation'][ $uniqueId ]['list'][] = array('entityKey' => $entityKey, 'authorId' => $authorId, 'isReply'=>$isReply);
 			$data['relation'][ $uniqueId ]['count'] += 1;
 			$data['relation'][ $uniqueId ]['notifyeveryone'] = $notifyeveryone;
 		}


### PR DESCRIPTION
**PLEASE DO NOT MERGE WITHOUT APPROVAL FROM CONTRIBUTION TEAM.**

Notifications are grouped by thread so that there's only one notification per thread. If there's more than one reply on a single thread, the notification message will say something like "UserA, UserB, and UserC replied to..." Originally, the URL the notification would point to was for the _newest_ unread message. In https://github.com/Wikia/app/pull/737 I attempted to change it so that the URL would point to the _oldest_ unread message. That way, you continue reading where you left off. This worked for some cases but not all.

The problem is this that whenever a new notification is stored, it checks to see if there's an existing notification for the same author on the same thread. If there is, it deletes the old one and replaces it with the new one. So it always stores only the newest message. This was causing the URL for the notification to point to the _newest unread message by the author of the oldest unread message_.

This change will make it so that it will still check to see if there's an existing notification for the same author on the same thread, but it will keep the old one and throw out the new one. So it has the oldest message from that author instead of the newest.
