### PR TITLE
Fix broken imageinfo API

### DIFF
--- a/includes/api/ApiQueryImageInfo.php
+++ b/includes/api/ApiQueryImageInfo.php
@@ -167,7 +167,7 @@ class ApiQueryImageInfo extends ApiQueryBase {
 
 			$data = $this->getResultData();
 			foreach ( $data['query']['pages'] as $pageid => $arr ) {
-				if ( !isset( $arr['imagerepository'] ) ) {
+				if ( is_numeric($pageid) && !isset( $arr['imagerepository'] ) ) {
 					$result->addValue(
 						array( 'query', 'pages', $pageid ),
 						'imagerepository', ''


### PR DESCRIPTION
http://disney.wikia.com/api.php?action=query&titles=File:Finale-550x360.jpg&prop=imageinfo

```
<error code="internal_api_error_MWException" info="Exception Caught: Internal error in ApiResult::setElement: Bad parameter" xml:space="preserve" />
```
