### PR TITLE
MAIN-111 replacing hardcoded messages with message keys

### DIFF
--- a/extensions/wikia/ImageReview/ImageReview.i18n.php
+++ b/extensions/wikia/ImageReview/ImageReview.i18n.php
@@ -18,6 +18,9 @@ $messages['en'] = array(
 
 	'imagereview-imagepage-header' => 'Image Review history',
 	'imagereview-imagepage-not-in-queue' => 'Warning: this image has not been added to the review queue.',
+	'imagereview-imagepage-table-header-reviewer' => 'Reviewer',
+	'imagereview-imagepage-table-header-state' => 'State',
+	'imagereview-imagepage-table-header-time' => 'Time',
 );
 
 $messages['pl'] = array(

--- a/extensions/wikia/ImageReview/ImageReviewImageStatus.php
+++ b/extensions/wikia/ImageReview/ImageReviewImageStatus.php
@@ -18,7 +18,11 @@ function efImageReviewDisplayStatus( $imagePage, &$html ) {
 	$html .= Xml::element( 'h2', array(), wfMsg( 'imagereview-imagepage-header' ) );
 
 	$reviews = array();
-	$headers = array( 'Reviewer', 'State', 'Time' );
+	$headers = array(
+		wfMessage('imagereview-imagepage-table-header-reviewer')->text(),
+		wfMessage('imagereview-imagepage-table-header-state')->text(),
+		wfMessage('imagereview-imagepage-table-header-time')->text(),
+	);
 	$where = array(
 			'wiki_id' => $wgCityId,
 			'page_id' => $imagePage->getId(),


### PR DESCRIPTION
A fix for MAIN-111. Hardcoded table headers have been replaced with message keys and new message keys have been defined. Please review and if the code is ok - merge with dev.
