### PR TITLE
lightbox will ignore shared-help images

### DIFF
--- a/extensions/wikia/Lightbox/js/LightboxLoader.js
+++ b/extensions/wikia/Lightbox/js/LightboxLoader.js
@@ -73,7 +73,7 @@ var LightboxLoader = {
 					parent,
 					isVideo;
 
-				if($this.hasClass('link-internal') || $this.hasClass('link-external')) {
+				if( $this.hasClass('link-internal') || $this.hasClass('link-external') || $thumb.attr('data-shared-help') ) {
 					return;
 				}
 


### PR DESCRIPTION
For this ticket https://wikia-inc.atlassian.net/browse/VID-251

This is returning the shared help functionality to what it was before the regression, i.e. it opens the image in a new tab rather than in the lightbox.  If we want it to open in the lightbox there's more infrastructure that needs to be built out. 
