### PR TITLE
BAC-282 Garbled link to block in "blocked" message on edit

### DIFF
--- a/extensions/wikia/PhalanxII/classes/PhalanxPager.class.php
+++ b/extensions/wikia/PhalanxII/classes/PhalanxPager.class.php
@@ -103,7 +103,7 @@ class PhalanxPager extends ReverseChronologicalPager {
 		$statsUrl = sprintf( "%s/%s", $this->phalanxStatsPage->getLocalUrl(), $row->p_id );
 
 		$html  = Html::openElement( 'li', array( 'id' => 'phalanx-block-' . $row->p_id ) );
-		$html .= Html::element( 'b', array('class' => 'blockContent'), htmlspecialchars( $row->p_text ) );
+		$html .= Html::element( 'b', array('class' => 'blockContent'), $row->p_text );
 		$html .= sprintf( " (%s%s%s) ",
 			( !empty($row->p_regex) ? 'regex' : 'plain' ),
 			( !empty($row->p_case)  ? ',case' : '' ),

--- a/extensions/wikia/PhalanxII/hooks/PhalanxContentBlock.class.php
+++ b/extensions/wikia/PhalanxII/hooks/PhalanxContentBlock.class.php
@@ -15,11 +15,20 @@ class PhalanxContentBlock extends WikiaObject {
 		F::setInstance( __CLASS__, $this );
 	}
 
+	/**
+	 * @param EditPage $editPage
+	 * @param $text
+	 * @param $section
+	 * @param $hookError
+	 * @param $summary
+	 * @return bool
+	 */
 	public function editFilter( $editPage, $text, $section, &$hookError, $summary ) {
 		wfProfileIn( __METHOD__ );
 
+		/* @var PhalanxContentModel $phalanxModel */
 		$phalanxModel = F::build('PhalanxContentModel', array( $this->wg->Title ) );
-		
+
 		$summary = $editPage->summary;
 		$textbox = $editPage->textbox1;
 		
@@ -41,7 +50,7 @@ class PhalanxContentBlock extends WikiaObject {
 		} else {
 			$error_msg = $phalanxModel->contentBlock();
 		}
-		
+
 		if ( $ret === false ) {
 			// we found block
 			$editPage->spamPageWithContent( $error_msg );

--- a/extensions/wikia/PhalanxII/models/PhalanxContentModel.php
+++ b/extensions/wikia/PhalanxII/models/PhalanxContentModel.php
@@ -66,7 +66,7 @@ class PhalanxContentModel extends PhalanxModel {
 	}
 	
 	public function contentBlock() {
-		$msg = $this->wf->msgExt( 'spamprotectionmatch', 'parseinline', "<nowiki>{$this->block->text} (Block #{$this->block->id})</nowiki>" ); 
+		$msg = wfMessage('spamprotectionmatch', "{$this->block->text} (Block #{$this->block->id})")->text();
 		$this->logBlock();
 		return $msg;
 	}

--- a/extensions/wikia/PhalanxII/models/PhalanxContentModel.php
+++ b/extensions/wikia/PhalanxII/models/PhalanxContentModel.php
@@ -1,6 +1,8 @@
 <?php
 
 class PhalanxContentModel extends PhalanxModel {
+
+	/* @var Title $title */
 	protected $title = null;
 	const SPAM_WHITELIST_TITLE = 'Spam-whitelist';
 	const SPAM_WHITELIST_NS_TITLE = 'Mediawiki:Spam-whitelist';
@@ -15,6 +17,10 @@ class PhalanxContentModel extends PhalanxModel {
 			!( $this->title instanceof Title ) || 
 			( $this->title->getPrefixedText() == self::SPAM_WHITELIST_NS_TITLE )  
 		);
+	}
+
+	public function getText() {
+		return !is_null( $this->text ) ? $this->text : $this->title->getFullText();
 	}
 
 	public function buildWhiteList() {

--- a/extensions/wikia/PhalanxII/models/PhalanxContentModel.php
+++ b/extensions/wikia/PhalanxII/models/PhalanxContentModel.php
@@ -17,10 +17,6 @@ class PhalanxContentModel extends PhalanxModel {
 		);
 	}
 
-	public function getText() {
-		return preg_replace( '/\s+/', ' ', preg_replace( '/[^\PP]+/', '', ( !is_null( $this->text ) ) ? $this->text : $this->title->getFullText() ) );
-	}
-
 	public function buildWhiteList() {
 		wfProfileIn( __METHOD__ );
 

--- a/extensions/wikia/PhalanxII/services/PhalanxService.class.php
+++ b/extensions/wikia/PhalanxII/services/PhalanxService.class.php
@@ -166,6 +166,7 @@ class PhalanxService extends Service {
 
 			$options["postData"] = implode( "&", $postData );
 			wfDebug( __METHOD__ . ": calling $url with POST data " . $options["postData"] ."\n" );
+			wfDebug( __METHOD__ . ": " . json_encode($parameters) ."\n" );
 			$response = Http::post( $url, $options);
 		}
 


### PR DESCRIPTION
Avoid double HTML encoding in block message and on the list of matching blocks on Phalanx special page
