### PR TITLE
DAR-264: As Wikia we want to define a new minimum article body area and right rail

### DIFF
--- a/extensions/wikia/SASS/SassUtil.php
+++ b/extensions/wikia/SASS/SassUtil.php
@@ -4,7 +4,7 @@
  */
 
 class SassUtil {
-	
+
 	const DEFAULT_OASIS_THEME = 'oasis';
 
 	/**
@@ -20,7 +20,7 @@ class SassUtil {
 
 		return $params;
 	}
-	
+
 	/**
 	 * Returns a set of sass parameters set by the webapp that should not be saved to wiki themesettings
 	 * For example, skin width is an webapp, application, setting.  It is not user controllable.
@@ -29,22 +29,22 @@ class SassUtil {
 	 *            Non-settable settings should be driven programmatically.
 	 */
 	public static function getApplicationThemeSettings() {
-		global $wgOasisHD, $wgOasisFluid, $wgOasisGrid;
-		
+		global $wgOasisGrid, $wgOasisHD, $wgOasisResponsive;
+
 		$params = array();
 
 		if ( $wgOasisHD ) {
 			$params['widthType'] = 1;
 		}
 
-		if ( $wgOasisFluid ) {
+		if ( $wgOasisResponsive ) {
 			$params['widthType'] = 2;
 		}
-		
+
 		if ( $wgOasisGrid ) {
 			$params['widthType'] = 3;
 		}
-		
+
 		return $params;
 	}
 
@@ -59,11 +59,11 @@ class SassUtil {
 
 		// Load the 5 deafult colors by theme here (eg: in case the wiki has an override but the user doesn't have overrides).
 		static $oasisSettings = array();
-		
+
 		if (empty($oasisSettings)) {
 			$themeSettings = new ThemeSettings();
 			$settings = $themeSettings->getSettings();
-	
+
 			$oasisSettings["color-body"] = self::sanitizeColor($settings["color-body"]);
 			$oasisSettings["color-page"] = self::sanitizeColor($settings["color-page"]);
 			$oasisSettings["color-buttons"] = self::sanitizeColor($settings["color-buttons"]);
@@ -77,7 +77,7 @@ class SassUtil {
 			if (isset($settings["wordmark-font"]) && $settings["wordmark-font"] != "default") {
 				$oasisSettings["wordmark-font"] = $settings["wordmark-font"];
 			}
-	
+
 			// RTL
 			if($wgContLang && $wgContLang->isRTL()){
 				$oasisSettings['rtl'] = 'true';
@@ -94,7 +94,7 @@ class SassUtil {
 		wfDebug(__METHOD__ . ': ' . json_encode($oasisSettings) . "\n");
 
 		wfProfileOut(__METHOD__);
-		
+
 		return $oasisSettings;
 	}
 
@@ -161,7 +161,7 @@ class SassUtil {
 				$oasisSettings = self::getDefaultOasisSettings();
 			}
 		}
-		
+
 		$backgroundColor = $oasisSettings['color-page'];
 
 		// convert RGB to HSL
@@ -174,7 +174,7 @@ class SassUtil {
 		wfProfileOut(__METHOD__);
 		return $isDark;
 	}
-	
+
 	/**
 	 * Convert RGB colors array into HSL array
 	 *

--- a/extensions/wikia/SASS/SassUtil.php
+++ b/extensions/wikia/SASS/SassUtil.php
@@ -37,7 +37,7 @@ class SassUtil {
 			$params['widthType'] = 1;
 		}
 
-		if ( $wgOasisResponsive ) {
+		if ( class_exists( 'OasisController' ) && OasisController::isResponsiveLayoutEnabled() ) {
 			$params['widthType'] = 2;
 		}
 

--- a/extensions/wikia/SASS/SassUtil.php
+++ b/extensions/wikia/SASS/SassUtil.php
@@ -37,7 +37,7 @@ class SassUtil {
 			$params['widthType'] = 1;
 		}
 
-		if ( class_exists( 'OasisController' ) && OasisController::isResponsiveLayoutEnabled() ) {
+		if ( class_exists( 'BodyController' ) && BodyController::isResponsiveLayoutEnabled() ) {
 			$params['widthType'] = 2;
 		}
 

--- a/skins/oasis/css/core/layout.scss
+++ b/skins/oasis/css/core/layout.scss
@@ -1,35 +1,33 @@
-// Highest z-index //
+// Highest z-index
 $zTop: 20000000;
 
-// Dimension Variables //
+// Dimension Variables
 $oasisWidthType: get_command_line_param("widthType", 0);
 
+// We often use this amount of padding or margin to separate elements in our layout.
+$width-gutter: 10px;
 $width-outside: 1000px;
+$width-rail: 300px;
+
 $wikia-search-base-width: 200px;
 
-/* $wgOasisHD */
+// $wgOasisHD
 @if $oasisWidthType == 1 {
 	$width-outside: 1200px;
 }
 
-/* $wgOasisFluid */
+// $wgOasisResponsive
 @if $oasisWidthType == 2 {
-	$width-outside: auto;
+	$width-gutter: 20px;
+	// Hardcoded for now, but will go away when the breakpoints are in place
+	$width-outside: 1020px;
 }
 
-/* $wgOasisGrid */
+// $wgOasisGrid
 @if $oasisWidthType == 3 {
 	$width-outside: 1030px;
 	$wikia-search-base-width: 230px;
 }
 
-$width-rail: 300px;
-
-/* We often use this amount of padding or margin to separate elements in our layout.
- * For example, .WikiaRail has this much padding on the left and right to not touch the edge of the page or the article content.
- * .WikiaArticle does the same.
- */
-$width-gutter: 10px;
-
-/* wikiaheader-width for the globalheader and gamestarlogo */
+// wikiaheader-width for the globalheader and gamestarlogo
 $wikiaheader-width: $width-outside + 14px;

--- a/skins/oasis/css/core/responsive.scss
+++ b/skins/oasis/css/core/responsive.scss
@@ -1,3 +1,4 @@
+@import "color";
 @import "layout";
 
 .WikiaMainContent {
@@ -6,7 +7,13 @@
 }
 
 .WikiaMainContentContainer {
+	background-color: $color-page;
 	margin-right: $width-rail + $width-gutter;
+}
+
+.WikiaPage,
+.oasis-split-skin .WikiaPage {
+	border: 0;
 }
 
 .WikiaRail {

--- a/skins/oasis/css/core/responsive.scss
+++ b/skins/oasis/css/core/responsive.scss
@@ -1,0 +1,14 @@
+@import "layout";
+
+.WikiaMainContent {
+	margin-right: -#{ $width-rail + $width-gutter };
+	width: 100%;
+}
+
+.WikiaMainContentContainer {
+	margin-right: $width-rail + $width-gutter;
+}
+
+.WikiaRail {
+	padding: 0;
+}

--- a/skins/oasis/css/core/responsive.scss
+++ b/skins/oasis/css/core/responsive.scss
@@ -24,6 +24,10 @@ $width-padding: $width-gutter / 2;
 	border: 0;
 }
 
+.WikiaPageBackground {
+	display: none;
+}
+
 .WikiaPageHeader,
 .wikinav2 .WikiaPageHeader {
 	margin: 0 0 $width-padding 0;

--- a/skins/oasis/css/core/responsive.scss
+++ b/skins/oasis/css/core/responsive.scss
@@ -1,6 +1,13 @@
 @import "color";
 @import "layout";
 
+$width-padding: $width-gutter / 2;
+
+.WikiaArticle,
+.WikiaArticleFooter {
+	padding: 0;
+}
+
 .WikiaMainContent {
 	margin-right: -#{ $width-rail + $width-gutter };
 	width: 100%;
@@ -9,11 +16,18 @@
 .WikiaMainContentContainer {
 	background-color: $color-page;
 	margin-right: $width-rail + $width-gutter;
+	padding: $width-padding;
 }
 
 .WikiaPage,
 .oasis-split-skin .WikiaPage {
 	border: 0;
+}
+
+.WikiaPageHeader,
+.wikinav2 .WikiaPageHeader {
+	margin: 0 0 $width-padding 0;
+	padding-bottom: $width-padding / 2;
 }
 
 .WikiaRail {

--- a/skins/oasis/modules/BodyController.class.php
+++ b/skins/oasis/modules/BodyController.class.php
@@ -52,7 +52,7 @@ class BodyController extends WikiaController {
 		$ns = $app->wg->Title->getNamespace();
 
 		// Don't enable for article pages when responsive layout is enabled
-		if ( !empty( $app->wg->EnableResponsiveLayout ) && $ns == NS_MAIN ) {
+		if ( !empty( $app->wg->OasisResponsive ) && $ns == NS_MAIN ) {
 			return false;
 		}
 

--- a/skins/oasis/modules/BodyController.class.php
+++ b/skins/oasis/modules/BodyController.class.php
@@ -51,7 +51,7 @@ class BodyController extends WikiaController {
 		$app = F::app();
 
 		// Don't enable when responsive layout is enabled
-		if ( OasisController::isResponsiveLayoutEnabled() ) {
+		if ( self::isResponsiveLayoutEnabled() ) {
 			return false;
 		}
 
@@ -70,6 +70,17 @@ class BodyController extends WikiaController {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Pretty self explanitory.
+	 * @return Boolean
+	 */
+	public static function isResponsiveLayoutEnabled() {
+		return !empty( F::app()->wg->OasisResponsive ) &&
+				WikiaPageType::isContentPage() &&
+				!WikiaPageType::isMainPage() &&
+				!WikiaPageType::isWikiaHub();
 	}
 
 	/**

--- a/skins/oasis/modules/BodyController.class.php
+++ b/skins/oasis/modules/BodyController.class.php
@@ -51,8 +51,8 @@ class BodyController extends WikiaController {
 		$app = F::app();
 		$ns = $app->wg->Title->getNamespace();
 
-		// Don't enable for article pages when responsive layout is enabled
-		if ( !empty( $app->wg->OasisResponsive ) && $ns == NS_MAIN ) {
+		// Don't enable when responsive layout is enabled
+		if ( OasisController::isResponsiveLayoutEnabled() ) {
 			return false;
 		}
 

--- a/skins/oasis/modules/BodyController.class.php
+++ b/skins/oasis/modules/BodyController.class.php
@@ -49,12 +49,16 @@ class BodyController extends WikiaController {
 	 */
 	public static function isGridLayoutEnabled() {
 		$app = F::app();
+		$ns = $app->wg->Title->getNamespace();
+
+		// Don't enable for article pages when responsive layout is enabled
+		if ( !empty( $app->wg->EnableResponsiveLayout ) && $ns == NS_MAIN ) {
+			return false;
+		}
 
 		if( !empty($app->wg->OasisGrid) ) {
 			return true;
 		}
-
-		$ns = $app->wg->Title->getNamespace();
 
 		if( in_array( MWNamespace::getSubject($ns), $app->wg->WallNS) ) {
 			return true;
@@ -348,7 +352,7 @@ class BodyController extends WikiaController {
 		// show corporate header on this page?
 		} else if( HubService::isCorporatePage() ) {
 			$this->headerModuleName = 'PageHeader';
-			
+
 			if( self::isEditPage() ) {
 				$this->headerModuleAction = 'EditPage';
 			} else {

--- a/skins/oasis/modules/BodyController.class.php
+++ b/skins/oasis/modules/BodyController.class.php
@@ -49,7 +49,6 @@ class BodyController extends WikiaController {
 	 */
 	public static function isGridLayoutEnabled() {
 		$app = F::app();
-		$ns = $app->wg->Title->getNamespace();
 
 		// Don't enable when responsive layout is enabled
 		if ( OasisController::isResponsiveLayoutEnabled() ) {
@@ -59,6 +58,8 @@ class BodyController extends WikiaController {
 		if( !empty($app->wg->OasisGrid) ) {
 			return true;
 		}
+
+		$ns = $app->wg->Title->getNamespace();
 
 		if( in_array( MWNamespace::getSubject($ns), $app->wg->WallNS) ) {
 			return true;

--- a/skins/oasis/modules/OasisController.class.php
+++ b/skins/oasis/modules/OasisController.class.php
@@ -127,6 +127,10 @@ class OasisController extends WikiaController {
 			$wgOut->addScript( '<script src="' . $this->wg->ExtensionsPath . '/wikia/CreateNewWiki/js/WikiWelcome.js"></script>' );
 		}
 
+		if ( !empty( $this->wg->EnableResponsiveLayout ) ) {
+			$wgOut->addStyle( $this->assetsManager->getSassCommonURL( 'skins/oasis/css/core/responsive.scss' ) );
+		}
+
 		$renderContentOnly = false;
 		if (!empty($this->wg->EnableRenderContentOnlyExt)) {
 			if(renderContentOnly::isRenderContentOnlyEnabled()) {

--- a/skins/oasis/modules/OasisController.class.php
+++ b/skins/oasis/modules/OasisController.class.php
@@ -127,7 +127,7 @@ class OasisController extends WikiaController {
 			$wgOut->addScript( '<script src="' . $this->wg->ExtensionsPath . '/wikia/CreateNewWiki/js/WikiWelcome.js"></script>' );
 		}
 
-		if ( !empty( $this->wg->EnableResponsiveLayout ) ) {
+		if ( !empty( $this->wg->OasisResponsive ) ) {
 			$wgOut->addStyle( $this->assetsManager->getSassCommonURL( 'skins/oasis/css/core/responsive.scss' ) );
 		}
 

--- a/skins/oasis/modules/OasisController.class.php
+++ b/skins/oasis/modules/OasisController.class.php
@@ -47,13 +47,6 @@ class OasisController extends WikiaController {
 		wfProfileOut(__METHOD__);
 	}
 
-	public static function isResponsiveLayoutEnabled() {
-		return !empty( F::app()->wg->OasisResponsive ) &&
-				WikiaPageType::isContentPage() &&
-				!WikiaPageType::isMainPage() &&
-				!WikiaPageType::isWikiaHub();
-	}
-
 	/**
 	 * Add global JS variables with wgJsAtBottom
 	 *
@@ -134,7 +127,7 @@ class OasisController extends WikiaController {
 			$wgOut->addScript( '<script src="' . $this->wg->ExtensionsPath . '/wikia/CreateNewWiki/js/WikiWelcome.js"></script>' );
 		}
 
-		if ( self::isResponsiveLayoutEnabled() ) {
+		if ( BodyController::isResponsiveLayoutEnabled() ) {
 			$wgOut->addStyle( $this->assetsManager->getSassCommonURL( 'skins/oasis/css/core/responsive.scss' ) );
 		}
 

--- a/skins/oasis/modules/OasisController.class.php
+++ b/skins/oasis/modules/OasisController.class.php
@@ -47,6 +47,13 @@ class OasisController extends WikiaController {
 		wfProfileOut(__METHOD__);
 	}
 
+	public static function isResponsiveLayoutEnabled() {
+		return !empty( F::app()->wg->OasisResponsive ) &&
+				WikiaPageType::isContentPage() &&
+				!WikiaPageType::isMainPage() &&
+				!WikiaPageType::isWikiaHub();
+	}
+
 	/**
 	 * Add global JS variables with wgJsAtBottom
 	 *
@@ -127,7 +134,7 @@ class OasisController extends WikiaController {
 			$wgOut->addScript( '<script src="' . $this->wg->ExtensionsPath . '/wikia/CreateNewWiki/js/WikiWelcome.js"></script>' );
 		}
 
-		if ( !empty( $this->wg->OasisResponsive ) ) {
+		if ( self::isResponsiveLayoutEnabled() ) {
 			$wgOut->addStyle( $this->assetsManager->getSassCommonURL( 'skins/oasis/css/core/responsive.scss' ) );
 		}
 

--- a/skins/oasis/modules/templates/Body_Index.php
+++ b/skins/oasis/modules/templates/Body_Index.php
@@ -18,7 +18,7 @@
 <?= empty($wg->WikiaSeasonsPencilUnit) ? '' : $app->renderView('WikiaSeasons', 'pencilUnit', array()); ?>
 
 <section id="WikiaPage" class="WikiaPage<?= empty( $wg->OasisNavV2 ) ? '' : ' V2' ?><?= !empty($isGridLayoutEnabled) ? ' WikiaGrid' : '' ?>">
-	<? if ( empty( $wg->EnableResponsiveLayout ) ): ?>
+	<? if ( empty( $wg->OasisResponsive ) ): ?>
 		<div id="WikiaPageBackground" class="WikiaPageBackground"></div>
 	<? endif ?>
 	<div class="WikiaPageContentWrapper">

--- a/skins/oasis/modules/templates/Body_Index.php
+++ b/skins/oasis/modules/templates/Body_Index.php
@@ -18,7 +18,9 @@
 <?= empty($wg->WikiaSeasonsPencilUnit) ? '' : $app->renderView('WikiaSeasons', 'pencilUnit', array()); ?>
 
 <section id="WikiaPage" class="WikiaPage<?= empty( $wg->OasisNavV2 ) ? '' : ' V2' ?><?= !empty($isGridLayoutEnabled) ? ' WikiaGrid' : '' ?>">
-	<div id="WikiaPageBackground" class="WikiaPageBackground"></div>
+	<? if ( empty( $wg->EnableResponsiveLayout ) ): ?>
+		<div id="WikiaPageBackground" class="WikiaPageBackground"></div>
+	<? endif ?>
 	<div class="WikiaPageContentWrapper">
 		<?= empty($wg->GlobalHeaderFullWidth) ? $app->renderView('Notifications', 'Confirmation') : '' ?>
 

--- a/skins/oasis/modules/templates/Body_Index.php
+++ b/skins/oasis/modules/templates/Body_Index.php
@@ -56,80 +56,81 @@
 		?>
 
 		<article id="WikiaMainContent" class="WikiaMainContent<?= !empty($isGridLayoutEnabled) ? $railModulesExist ? ' grid-4' : ' grid-6' : '' ?>">
-			<?php
-				if (!empty($wg->EnableForumExt) && !empty($wg->IsForum)) {
-					echo $app->renderView( 'ForumController', 'header' );
-				}
-
-				// render UserPagesHeader or PageHeader or nothing...
-				if (empty($wg->SuppressPageHeader) && $headerModuleName) {
-					if ($headerModuleName == 'UserPagesHeader') {
-						if ($headerModuleAction == 'BlogPost' || $headerModuleAction == 'BlogListing') {
-							// Show blog post header
-							echo $app->renderView( $headerModuleName, $headerModuleAction, $headerModuleParams );
-						} else {
-							// Show just the edit button
-							echo $app->renderView( 'UserProfilePage', 'renderActionButton', array() );
-						}
-					} else {
-						echo $app->renderView($headerModuleName, $headerModuleAction, $headerModuleParams);
-					}
-				}
-			?>
-
-
-			<?php if ($subtitle != '' && $headerModuleName == 'UserPagesHeader' ) { ?>
-				<div id="contentSub"><?= $subtitle ?></div>
-			<?php } ?>
-
-			<div id="WikiaArticle" class="WikiaArticle<?= $displayAdminDashboardChromedArticle ? ' AdminDashboardChromedArticle' : '' ?>"<?= $body_ondblclick ? ' ondblclick="' . htmlspecialchars($body_ondblclick) . '"' : '' ?>>
-				<? if($displayAdminDashboardChromedArticle) { ?>
-					<?= (string)$app->sendRequest( 'AdminDashboardSpecialPage', 'chromedArticleHeader', array('headerText' => $wg->Title->getText() )) ?>
-				<? } ?>
-				
-				<div class="home-top-right-ads">
+			<div id="WikiaMainContentContainer" class="WikiaMainContentContainer">
 				<?php
-					if (!$wg->EnableWikiaHomePageExt && WikiaPageType::isMainPage()) {
-						echo $app->renderView('Ad', 'Index', array('slotname' => 'HOME_TOP_RIGHT_BOXAD'));
+					if (!empty($wg->EnableForumExt) && !empty($wg->IsForum)) {
+						echo $app->renderView( 'ForumController', 'header' );
+					}
+
+					// render UserPagesHeader or PageHeader or nothing...
+					if (empty($wg->SuppressPageHeader) && $headerModuleName) {
+						if ($headerModuleName == 'UserPagesHeader') {
+							if ($headerModuleAction == 'BlogPost' || $headerModuleAction == 'BlogListing') {
+								// Show blog post header
+								echo $app->renderView( $headerModuleName, $headerModuleAction, $headerModuleParams );
+							} else {
+								// Show just the edit button
+								echo $app->renderView( 'UserProfilePage', 'renderActionButton', array() );
+							}
+						} else {
+							echo $app->renderView($headerModuleName, $headerModuleAction, $headerModuleParams);
+						}
 					}
 				?>
+
+
+				<?php if ($subtitle != '' && $headerModuleName == 'UserPagesHeader' ) { ?>
+					<div id="contentSub"><?= $subtitle ?></div>
+				<?php } ?>
+
+				<div id="WikiaArticle" class="WikiaArticle<?= $displayAdminDashboardChromedArticle ? ' AdminDashboardChromedArticle' : '' ?>"<?= $body_ondblclick ? ' ondblclick="' . htmlspecialchars($body_ondblclick) . '"' : '' ?>>
+					<? if($displayAdminDashboardChromedArticle) { ?>
+						<?= (string)$app->sendRequest( 'AdminDashboardSpecialPage', 'chromedArticleHeader', array('headerText' => $wg->Title->getText() )) ?>
+					<? } ?>
+
+					<div class="home-top-right-ads">
+					<?php
+						if (!$wg->EnableWikiaHomePageExt && WikiaPageType::isMainPage()) {
+							echo $app->renderView('Ad', 'Index', array('slotname' => 'HOME_TOP_RIGHT_BOXAD'));
+						}
+					?>
+					</div>
+
+					<?php
+					// for InfoBox-Testing
+					if ($wg->EnableInfoBoxTest) {
+						echo $app->renderView('ArticleInfoBox', 'Index');
+					} ?>
+
+					<?= $bodytext ?>
+
 				</div>
+
+				<? if ( empty( $wg->SuppressArticleCategories ) ): ?>
+					<? if ( !empty( $wg->EnableCategorySelectExt ) && CategorySelect::isEnabled() ): ?>
+						<?= $app->renderView( 'CategorySelect', 'articlePage' ) ?>
+					<? else: ?>
+						<?= $app->renderView( 'ArticleCategories', 'Index' ) ?>
+					<? endif ?>
+				<? endif ?>
 
 				<?php
-				// for InfoBox-Testing
-				if ($wg->EnableInfoBoxTest) {
-					echo $app->renderView('ArticleInfoBox', 'Index');
-				} ?>
+				if (empty( $wg->InterlangOnTop ) ) {
+					 echo $app->renderView('ArticleInterlang', 'Index');
+				}
+				?>
 
-				<?= $bodytext ?>
+				<?php if (!empty($afterContentHookText)) { ?>
+					<div id="WikiaArticleFooter" class="WikiaArticleFooter">
+						<?= $afterContentHookText ?>
+					</div>
+				<?php } ?>
 
-			</div>
-
-			<? if ( empty( $wg->SuppressArticleCategories ) ): ?>
-				<? if ( !empty( $wg->EnableCategorySelectExt ) && CategorySelect::isEnabled() ): ?>
-					<?= $app->renderView( 'CategorySelect', 'articlePage' ) ?>
-				<? else: ?>
-					<?= $app->renderView( 'ArticleCategories', 'Index' ) ?>
-				<? endif ?>
-			<? endif ?>
-
-			<?php
-			if (empty( $wg->InterlangOnTop ) ) {
-				 echo $app->renderView('ArticleInterlang', 'Index');
-			}
-			?>
-
-			<?php if (!empty($afterContentHookText)) { ?>
-				<div id="WikiaArticleFooter" class="WikiaArticleFooter">
-					<?= $afterContentHookText ?>
+				<div id="WikiaArticleBottomAd" class="noprint">
+					<?= $app->renderView('Ad', 'Index', array('slotname' => 'PREFOOTER_LEFT_BOXAD')) ?>
+					<?= $app->renderView('Ad', 'Index', array('slotname' => 'PREFOOTER_RIGHT_BOXAD')) ?>
 				</div>
-			<?php } ?>
-
-			<div id="WikiaArticleBottomAd" class="noprint">
-				<?= $app->renderView('Ad', 'Index', array('slotname' => 'PREFOOTER_LEFT_BOXAD')) ?>
-				<?= $app->renderView('Ad', 'Index', array('slotname' => 'PREFOOTER_RIGHT_BOXAD')) ?>
 			</div>
-
 		</article><!-- WikiaMainContent -->
 
 		<?php if( $railModulesExist ): ?>

--- a/skins/oasis/modules/templates/Body_Index.php
+++ b/skins/oasis/modules/templates/Body_Index.php
@@ -18,9 +18,7 @@
 <?= empty($wg->WikiaSeasonsPencilUnit) ? '' : $app->renderView('WikiaSeasons', 'pencilUnit', array()); ?>
 
 <section id="WikiaPage" class="WikiaPage<?= empty( $wg->OasisNavV2 ) ? '' : ' V2' ?><?= !empty($isGridLayoutEnabled) ? ' WikiaGrid' : '' ?>">
-	<? if ( empty( $wg->OasisResponsive ) ): ?>
-		<div id="WikiaPageBackground" class="WikiaPageBackground"></div>
-	<? endif ?>
+	<div id="WikiaPageBackground" class="WikiaPageBackground"></div>
 	<div class="WikiaPageContentWrapper">
 		<?= empty($wg->GlobalHeaderFullWidth) ? $app->renderView('Notifications', 'Confirmation') : '' ?>
 


### PR DESCRIPTION
NEEDS THUMBS UP FROM CONTRIBUTION TEAM MEMBERS BEFORE MERGE

https://wikia-inc.atlassian.net/browse/DAR-264

Creates a flag for responsive layout style and injects a new responsive.scss file into head if the responsive layout is enabled. For now, only content pages that aren't main pages and hub pages will get these new styles.

Changed the width of the right rail from 320px to 300px and re-styled the main content area so that the article content can be fluid width.

See also: https://github.com/Wikia/config/pull/130
