### PR TITLE
BAC-299: fix Phalanx shadowing + extra check in PhalanxService::__call

### DIFF
--- a/extensions/wikia/Phalanx/services/PhalanxService.class.php
+++ b/extensions/wikia/Phalanx/services/PhalanxService.class.php
@@ -28,6 +28,8 @@ class PhalanxService extends Service {
 				$this->$key = $args[0];
 				$result = $this;
 				break;
+			default:
+				throw new WikiaException('PhalanxService::_call supports getters and setters only');
 		}
 		return $result;
 	}
@@ -59,6 +61,17 @@ class PhalanxService extends Service {
 	 */
 	public function match( $type, $content, $lang = "" ) {
 		return $this->sendToPhalanxDaemon( "match", array( "type" => $type, "content" => $content, "lang" => $lang ) );
+	}
+
+	/**
+	 * Send expected results for comparison
+	 */
+	public function matchShadow($type, $content, $expected_id, $lang = "" ) {
+		wfProfileIn( __METHOD__  );
+		$result =  $this->sendToPhalanxDaemon( "match", array( "type" => $type, "content" => $content,
+			"expected" => $expected_id, "lang" => $lang ) );
+		wfProfileOut( __METHOD__  );
+		return $result;
 	}
 
 	/**

--- a/extensions/wikia/PhalanxII/services/PhalanxService.class.php
+++ b/extensions/wikia/PhalanxII/services/PhalanxService.class.php
@@ -34,6 +34,8 @@ class PhalanxService extends Service {
 				$this->$key = $args[0];
 				$result = $this;
 				break;
+			default:
+				throw new WikiaException('PhalanxService::_call supports getters and setters only');
 		}
 		return $result;
 	}
@@ -69,14 +71,6 @@ class PhalanxService extends Service {
 	public function match( $type, $content, $lang = "" ) {
 		wfProfileIn( __METHOD__  );
 		$result =  $this->sendToPhalanxDaemon( "match", array( "type" => $type, "content" => $content, "lang" => $lang ) );
-		wfProfileOut( __METHOD__  );
-		return $result;
-	}
-	
-	public function matchShadow($type, $content, $expected_id, $lang = "" ) {
-		wfProfileIn( __METHOD__  );
-		$result =  $this->sendToPhalanxDaemon( "match", array( "type" => $type, "content" => $content,
-				"expected" => $expected_id, "lang" => $lang ) );
 		wfProfileOut( __METHOD__  );
 		return $result;
 	}


### PR DESCRIPTION
- `matchShadow` method moved to PhalanxService in old Phalanx directory
- check added in `_call` method (only setters and getters are supported)
