### PR TITLE
Database::query - add profiling info to queries like BEGIN or COMMIT

### DIFF
--- a/includes/db/Database.php
+++ b/includes/db/Database.php
@@ -839,6 +839,14 @@ abstract class DatabaseBase implements DatabaseType {
 		}
 		$commentedSql = preg_replace( '/\s/', " /* $fname $userName */ ", $sql, 1 );
 
+		# Wikia change - begin
+		# @author macbre
+		# Add profiling data to queries like BEGIN or COMMIT (preg_replace above will not handle them)
+		if (strpos($sql, ' ') === false) {
+			$commentedSql = "{$sql} /* {$fname} {$userName} */";
+		}
+		# Wikia change - end
+
 		# If DBO_TRX is set, start a transaction
 		if ( ( $this->mFlags & DBO_TRX ) && !$this->trxLevel() &&
 			$sql != 'BEGIN' && $sql != 'COMMIT' && $sql != 'ROLLBACK' ) {


### PR DESCRIPTION
An example:

```
Query plpoznan (99) (master): COMMIT /* SiteStatsUpdate::doUpdate Macbre */
```

This change should make it easier to debug issues like the following one:

```
May 31 10:08:02 cron-s3 apache2[7988]: SQL (yugioh): 2006: MySQL server has gone away (10.8.52.49)
May 31 10:08:02 cron-s3 apache2[7988]: SQL: invalid query: COMMIT
```

@federico-lox @owend @psychonaut @Wyvek
