### PR TITLE
Fix paranthesis being in wrong place for Search/Backlinks functionality

### DIFF
--- a/extensions/wikia/Search/classes/IndexService/BacklinkText.php
+++ b/extensions/wikia/Search/classes/IndexService/BacklinkText.php
@@ -36,7 +36,7 @@ class BacklinkText extends AbstractService
 			foreach ( $resultSet as $result ) {
 				foreach ( $result['outbound_links_txt'] as $link ) {
 					if ( substr( $link, 0, strlen( $docIdSeparated ) ) == $docIdSeparated ) {
-						$backlinks[] = implode( ' | ', array_slice( explode( ' | ', $link ) ), 1 );
+						$backlinks[] = implode( ' | ', array_slice( explode( ' | ', $link ), 1 ) );
 					}
 				}
 			}


### PR DESCRIPTION
@relwell Please have a look. I think the intention for parenthesis was different (1 was supposed to apply to array_split not to implode)
