### PR TITLE
MAIN-128 replacing hardcoded message with message key

### DIFF
--- a/extensions/wikia/Oasis/Oasis.i18n.php
+++ b/extensions/wikia/Oasis/Oasis.i18n.php
@@ -163,6 +163,7 @@ $messages['en'] = array(
 	'oasis-upload-photos-fewer-options' => 'Fewer Options',
 	'oasis-upload-photos-force' => 'Upload anyway',
 	'oasis-upload-photos-caption' => 'Caption',
+	'oasis-upload-photos-overwrite-file' => 'Overwrite File',
 	
 	'oasis-corporatefooter-navigation-header' => 'Wikia Inc Navigation',
 	'oasis-corporatefooter-hub-Entertainment-link' => 'http://www.wikia.com/Entertainment',

--- a/skins/oasis/modules/templates/UploadPhotos_Index.php
+++ b/skins/oasis/modules/templates/UploadPhotos_Index.php
@@ -7,7 +7,7 @@
 			<input type="file" name="wpUploadFile">
 			<input type="submit" value="<?= wfMsg('Upload') ?>">
 			<img class="ajaxwait" src="<?= $wg->StylePath ?>/common/images/ajax.gif"><br>
-			<label class="override"><input type="checkbox" name="wpDestFileWarningAck">Overwrite File</label>
+			<label class="override"><input type="checkbox" name="wpDestFileWarningAck"><?= wfMessage( 'oasis-upload-photos-overwrite-file' )->text() ?></label>
 			<div class="status"></div>
 
 			<div class="options">


### PR DESCRIPTION
A fix for MAIN-128. Hardcoded text in the image upload modal has been replaced with a message key and a new message key has been defined. Please review and if the code is ok - merge with dev.
