### PR TITLE
MAIN-128 replacing hardcoded message with message key

### DIFF
--- a/extensions/wikia/Oasis/Oasis.i18n.php
+++ b/extensions/wikia/Oasis/Oasis.i18n.php
@@ -164,6 +164,7 @@ $messages['en'] = array(
 	'oasis-upload-photos-fewer-options' => 'Fewer Options',
 	'oasis-upload-photos-force' => 'Upload anyway',
 	'oasis-upload-photos-caption' => 'Caption',
+	'oasis-upload-photos-overwrite-file' => 'Overwrite File',
 
 	'oasis-corporatefooter-navigation-header' => 'Wikia Inc Navigation',
 	'oasis-corporatefooter-hub-Entertainment-link' => 'http://www.wikia.com/Entertainment',
@@ -298,6 +299,7 @@ Example output: deleted by Avatar 3 hours ago',
 	'oasis-corporatefooter-navigation-header' => 'Corporate Footer navigation header',
 	'oasis-global-page-header' => 'Global (corporate) header for whole HTML page - first <h1> in <body>',
 	'oasis-generic-error' => 'This is a generic error message that shows up when something unexpected went wrong in the code.',
+	'oasis-upload-photos-overwrite-file' => 'Label for the option in the image upload modal to overwrite a file, if a file by the same name already exists on the wiki',
 );
 
 /** Afrikaans (Afrikaans)

--- a/skins/oasis/modules/templates/UploadPhotos_Index.php
+++ b/skins/oasis/modules/templates/UploadPhotos_Index.php
@@ -7,7 +7,7 @@
 			<input type="file" name="wpUploadFile">
 			<input type="submit" value="<?= wfMsg('Upload') ?>">
 			<img class="ajaxwait" src="<?= $wg->StylePath ?>/common/images/ajax.gif"><br>
-			<label class="override"><input type="checkbox" name="wpDestFileWarningAck">Overwrite File</label>
+			<label class="override"><input type="checkbox" name="wpDestFileWarningAck"><?= wfMessage( 'oasis-upload-photos-overwrite-file' )->escape() ?></label>
 			<div class="status"></div>
 
 			<div class="options">

--- a/skins/oasis/modules/templates/UploadPhotos_Index.php
+++ b/skins/oasis/modules/templates/UploadPhotos_Index.php
@@ -7,7 +7,7 @@
 			<input type="file" name="wpUploadFile">
 			<input type="submit" value="<?= wfMsg('Upload') ?>">
 			<img class="ajaxwait" src="<?= $wg->StylePath ?>/common/images/ajax.gif"><br>
-			<label class="override"><input type="checkbox" name="wpDestFileWarningAck"><?= wfMessage( 'oasis-upload-photos-overwrite-file' )->escape() ?></label>
+			<label class="override"><input type="checkbox" name="wpDestFileWarningAck"><?= wfMessage( 'oasis-upload-photos-overwrite-file' )->escaped() ?></label>
 			<div class="status"></div>
 
 			<div class="options">


### PR DESCRIPTION
A fix for MAIN-128. Hardcoded text in the image upload modal has been replaced with a message key and a new message key has been defined. Please review and if the code is ok - merge with dev.
