### PR TITLE
PLA-243 -- more defensive title access w.r.t. WallMessage in MediaWikiService

### DIFF
--- a/extensions/wikia/Search/classes/MediaWikiService.php
+++ b/extensions/wikia/Search/classes/MediaWikiService.php
@@ -854,20 +854,23 @@ class MediaWikiService
 	 */
 	protected function getTitleString( \Title $title ) {
 		wfProfileIn( __METHOD__ );
+		$titleString = $title->getFullText();
 		if ( in_array( $title->getNamespace(), array( NS_WIKIA_FORUM_BOARD_THREAD, NS_USER_WALL_MESSAGE ) ) ){
 			$wm = \WallMessage::newFromId( $title->getArticleID() );
-			$wm->load();
-			
-			if ( !$wm->isMain() && ( $main = $wm->getTopParentObj() ) && !empty( $main ) ) {
-				$main->load();
-				$wm = $main;
+			if (! empty( $wm ) ) {
+				$wm->load();
+				if ( !$wm->isMain() ) {
+					$main = $wm->getTopParentObj();
+					if ( !empty( $main ) ) {
+						$main->load();
+						$wm = $main;
+					}
+				}
+				$titleString = $wm->getMetaTitle();
 			}
-			wfProfileOut( __METHOD__ );
-
-			return (string) $wm->getMetaTitle();
 		}
 		wfProfileOut(__METHOD__);
-		return $title->getFullText();
+		return $titleString;
 	}
 	
 	/**

--- a/extensions/wikia/Search/classes/Test/MediaWikiServiceTest.php
+++ b/extensions/wikia/Search/classes/Test/MediaWikiServiceTest.php
@@ -1232,13 +1232,13 @@ class MediaWikiServiceTest extends BaseTest
 		
 		$title
 		    ->expects( $this->at( 0 ) )
-		    ->method ( 'getNamespace' )
-		    ->will   ( $this->returnValue( NS_MAIN ) )
+		    ->method ( 'getFullText' )
+		    ->will   ( $this->returnValue( 'title' ) )
 		;
 		$title
 		    ->expects( $this->at( 1 ) )
-		    ->method ( 'getFullText' )
-		    ->will   ( $this->returnValue( 'title' ) )
+		    ->method ( 'getNamespace' )
+		    ->will   ( $this->returnValue( NS_MAIN ) )
 		;
 		$get = new ReflectionMethod( '\Wikia\Search\MediaWikiService', 'getTitleString' );
 		$get->setAccessible( true );
@@ -1248,7 +1248,7 @@ class MediaWikiServiceTest extends BaseTest
 		);
 	}
 	
-    /**
+	/**
 	 * @covers \Wikia\Search\MediaWikiService::getTitleString
 	 */
 	public function testGetTitleStringChildWallMessage() {
@@ -1256,7 +1256,7 @@ class MediaWikiServiceTest extends BaseTest
 		
 		$title = $this->getMockBuilder( '\Title' )
 		              ->disableOriginalConstructor()
-		              ->setMethods( array( 'getArticleID', 'getNamespace', '__toString' ) )
+		              ->setMethods( array( 'getArticleID', 'getNamespace', 'getFullText' ) )
 		              ->getMock();
 		
 		$wm = $this->getMockBuilder( '\WallMessage' )
@@ -1266,18 +1266,18 @@ class MediaWikiServiceTest extends BaseTest
 		
 		$title
 		    ->expects( $this->at( 0 ) )
+		    ->method ( 'getFullText' )
+		    ->will   ( $this->returnValue( 'not the wall message title' ) )
+		;
+		$title
+		    ->expects( $this->at( 1 ) )
 		    ->method ( 'getNamespace' )
 		    ->will   ( $this->returnValue( NS_WIKIA_FORUM_BOARD_THREAD ) )
 		;
 		$title
-		    ->expects( $this->at( 1 ) )
+		    ->expects( $this->at( 2 ) )
 		    ->method ( 'getArticleID' )
 		    ->will    ( $this->returnValue( $this->pageId ) )
-		;
-		$title
-		    ->expects( $this->at( 2 ) )
-		    ->method ( '__toString' )
-		    ->will   ( $this->returnValue( 'wall message title' ) )
 		;
 		$wm
 		    ->expects( $this->at( 0 ) )
@@ -1300,7 +1300,7 @@ class MediaWikiServiceTest extends BaseTest
 		$wm
 		    ->expects( $this->at( 4 ) )
 		    ->method ( 'getMetaTitle' )
-		    ->will   ( $this->returnValue( $title ) )
+		    ->will   ( $this->returnValue( 'wall message title' ) )
 		;
 		$this->proxyClass( '\WallMessage', $wm, 'newFromId' );
 		$this->mockApp();
@@ -1312,15 +1312,15 @@ class MediaWikiServiceTest extends BaseTest
 		);
 	}
 	
-    /**
+	/**
 	 * @covers \Wikia\Search\MediaWikiService::getTitleString
-	 **/
-	public function testGetTitleStringMainWallMessage() {
+	 */
+	public function testGetTitleStringEmptyChildWallMessage() {
 		$service = $this->service->getMock();
 		
 		$title = $this->getMockBuilder( '\Title' )
 		              ->disableOriginalConstructor()
-		              ->setMethods( array( 'getArticleID', 'getNamespace', '__toString' ) )
+		              ->setMethods( array( 'getArticleID', 'getNamespace', 'getFullText' ) )
 		              ->getMock();
 		
 		$wm = $this->getMockBuilder( '\WallMessage' )
@@ -1330,18 +1330,115 @@ class MediaWikiServiceTest extends BaseTest
 		
 		$title
 		    ->expects( $this->at( 0 ) )
+		    ->method ( 'getFullText' )
+		    ->will   ( $this->returnValue( 'not the wall message title' ) )
+		;
+		$title
+		    ->expects( $this->at( 1 ) )
 		    ->method ( 'getNamespace' )
 		    ->will   ( $this->returnValue( NS_WIKIA_FORUM_BOARD_THREAD ) )
 		;
 		$title
-		    ->expects( $this->at( 1 ) )
+		    ->expects( $this->at( 2 ) )
 		    ->method ( 'getArticleID' )
 		    ->will    ( $this->returnValue( $this->pageId ) )
 		;
+		$wm
+		    ->expects( $this->at( 0 ) )
+		    ->method ( 'load' )
+		;
+		$wm
+		    ->expects( $this->at( 1 ) )
+		    ->method ( 'isMain' )
+		    ->will   ( $this->returnValue( false ) )
+		;
+		$wm
+		    ->expects( $this->at( 2 ) )
+		    ->method ( 'getTopParentObj' )
+		    ->will   ( $this->returnValue( null ) )
+		;
+		$wm
+		    ->expects( $this->at( 3 ) )
+		    ->method ( 'getMetaTitle' )
+		    ->will   ( $this->returnValue( 'wall message title' ) )
+		;
+		$this->proxyClass( '\WallMessage', $wm, 'newFromId' );
+		$this->mockApp();
+		$get = new ReflectionMethod( '\Wikia\Search\MediaWikiService', 'getTitleString' );
+		$get->setAccessible( true );
+		$this->assertEquals(
+				'wall message title',
+				$get->invoke( $service, $title )
+		);
+	}
+	
+	/**
+	 * @covers \Wikia\Search\MediaWikiService::getTitleString
+	 */
+	public function testGetTitleStringEmptyWallMessage() {
+		$service = $this->service->getMock();
+		
+		$title = $this->getMockBuilder( '\Title' )
+		              ->disableOriginalConstructor()
+		              ->setMethods( array( 'getFullText', 'getNamespace' ) )
+		              ->getMock();
+		
+		$title
+		    ->expects( $this->at( 0 ) )
+		    ->method ( 'getFullText' )
+		    ->will   ( $this->returnValue( 'title' ) )
+		;
+		$title
+		    ->expects( $this->at( 1 ) )
+		    ->method ( 'getNamespace' )
+		    ->will   ( $this->returnValue( NS_WIKIA_FORUM_BOARD_THREAD ) )
+		;
 		$title
 		    ->expects( $this->at( 2 ) )
-		    ->method ( '__toString' )
-		    ->will   ( $this->returnValue( 'wall message title' ) )
+		    ->method ( 'getArticleID' )
+		    ->will    ( $this->returnValue( $this->pageId ) )
+		;
+		$this->proxyClass( '\WallMessage', null, 'newFromId' );
+		$this->mockApp();
+		$get = new ReflectionMethod( '\Wikia\Search\MediaWikiService', 'getTitleString' );
+		$get->setAccessible( true );
+		$this->assertEquals(
+				'title',
+				$get->invoke( $service, $title )
+		);
+	}
+	
+	
+	/**
+	 * @covers \Wikia\Search\MediaWikiService::getTitleString
+	 **/
+	public function testGetTitleStringMainWallMessage() {
+		$service = $this->service->getMock();
+		
+		$title = $this->getMockBuilder( '\Title' )
+		              ->disableOriginalConstructor()
+		              ->setMethods( array( 'getArticleID', 'getNamespace', 'getFullText' ) )
+		              ->getMock();
+		
+		$wm = $this->getMockBuilder( '\WallMessage' )
+		           ->disableOriginalConstructor()
+		           ->setMethods( array( 'load', 'isMain', 'getTopParentObj', 'getMetaTitle' ) )
+		           ->getMock();
+		
+		$title
+		    ->expects( $this->at( 0 ) )
+		    ->method ( 'getFullText' )
+		    ->will   ( $this->returnValue( 'not the wall message title' ) )
+		;
+		$title
+		    ->expects( $this->at( 1 ) )
+		    ->method ( 'getNamespace' )
+		    ->will   ( $this->returnValue( NS_WIKIA_FORUM_BOARD_THREAD ) )
+		;
+		$title
+		    ->expects( $this->at( 2 ) )
+		    ->method ( 'getArticleID' )
+		    ->will    ( $this->returnValue( $this->pageId ) )
 		;
 		$wm
 		    ->expects( $this->at( 0 ) )
@@ -1355,7 +1452,7 @@ class MediaWikiServiceTest extends BaseTest
 		$wm
 		    ->expects( $this->at( 2 ) )
 		    ->method ( 'getMetaTitle' )
-		    ->will   ( $this->returnValue( $title ) )
+		    ->will   ( $this->returnValue( 'wall message title' ) )
 		;
 		$this->proxyClass( '\WallMessage', $wm, 'newFromId' );
 		$this->mockApp();


### PR DESCRIPTION
This should fix fatals happening from calling "load" on a non-existent object.
