### PR TITLE
CE-19 add b/strong, em/italic tags to .wikitable td style.

### DIFF
--- a/skins/oasis/css/core/article.scss
+++ b/skins/oasis/css/core/article.scss
@@ -489,6 +489,14 @@ table.wikitable {
 		border: 1px darken($color-page, 35%) solid;
 		padding: 0.2em;
 	}
+	td {
+		b, strong {
+			font-weight: bold;
+		}
+		i, em {
+			font-style: italic;
+		}
+	}
 	> tr > th,  > * > tr > th {
 		background: darken($color-page, 5%);
 		text-align: center;


### PR DESCRIPTION
Fix for CE-19 - Popout tables didn't inherit WikiaArticle class. Added missing classes to CSS.
