### PR TITLE
DAR-319: Chat promotes show Wikia's internal IP instead of the user

### DIFF
--- a/extensions/wikia/Chat2/js/WMBridge.js
+++ b/extensions/wikia/Chat2/js/WMBridge.js
@@ -185,12 +185,13 @@ WMBridge.prototype.ban = function(roomId, name, userAddress ,time, reason, key, 
 }
 
 
-WMBridge.prototype.giveChatMod = function(roomId, name, key, success, error) {
+WMBridge.prototype.giveChatMod = function(roomId, name, userAddress, key, success, error) {
 	clearAuthenticateCache(roomId, name);
 	var requestUrl = getUrl('giveChatMod', {
 		roomId: roomId,
 		userToPromote: urlencode(name),
-		key: key
+		key: key,
+		userIP: (userAddress && userAddress.address) || ''
 	});
 
 	requestMW('GET', roomId, {}, requestUrl, function(data){

--- a/extensions/wikia/Chat2/js/server.js
+++ b/extensions/wikia/Chat2/js/server.js
@@ -678,7 +678,7 @@ function giveChatMod(client, socket, msg){
 
 	var userNameToPromote = giveChatModCommand.get('userToPromote');
 		
-	mwBridge.giveChatMod(client.roomId, userNameToPromote, client.userKey, function(data){
+	mwBridge.giveChatMod(client.roomId, userNameToPromote, client.handshake.address, client.userKey, function(data){
 		// Build a user that looks like the one that got banned... then kick them!
 			
 		storage.getRoomState(client.roomId, function(nodeChatModel) {	


### PR DESCRIPTION
We're passing the user ip as a request paremeter, which later is used by ChatAjax::onGetIP to override user ip
