### PR TITLE
PLA-253 -- fix UTF-8 support in Solr nolang_txt field

### DIFF
--- a/extensions/wikia/Search/classes/IndexService/DefaultContent.php
+++ b/extensions/wikia/Search/classes/IndexService/DefaultContent.php
@@ -208,7 +208,7 @@ class DefaultContent extends AbstractService
 			$paragraphs = $this->getParagraphsFromDom( $dom );
 		}
 		$paragraphString = preg_replace( '/\s+/', ' ', implode( ' ', $paragraphs ) ); // can be empty
-		$words = str_word_count( $paragraphString?:$plaintext, 1 );
+		$words = preg_split( '/[[:space:]]+/', $paragraphString?: $plaintext);
 		$wordCount = count( $words );
 		$upTo100Words = implode( ' ', array_slice( $words, 0, min( array( $wordCount, 100 ) ) ) );
 		$this->pushNolangTxt( $upTo100Words );


### PR DESCRIPTION
Originally, we were using str_word_count, which apparently doesn't support UTF-8. Since the precise word count doesn't actually matter, we're now back to space-splitting words so that we can put up to 100 of them in the nolang_txt field.
