### PR TITLE
MAIN-145: use CACHE_VERSION when building key for SASS caching

### DIFF
--- a/includes/wikia/services/sass/SassService.class.php
+++ b/includes/wikia/services/sass/SassService.class.php
@@ -25,7 +25,7 @@ use Wikia\Sass\Compiler\ExternalRubyCompiler;
  */
 class SassService extends WikiaObject {
 
-	const CACHE_VERSION = 1;
+	const CACHE_VERSION = 1; # SASS caching does not depend on $wgStyleVersion, use this constant to bust SASS cache
 
 	const FILTER_IMPORT_CSS = 1;
 	const FILTER_CDN_REWRITE = 2;
@@ -246,11 +246,12 @@ class SassService extends WikiaObject {
 	public function getCacheKey() {
 		return sprintf("%s%s",
 			$this->getCacheVariant() ? $this->getCacheVariant() . '-' : '',
-			md5(serialize(array(
+			md5(serialize([
 				$this->getHash(),
 				$this->getSassVariables(),
 				$this->getFilters(),
-			)))
+				self::CACHE_VERSION
+			]))
 		);
 	}
 


### PR DESCRIPTION
cb++ does not invalidate SASS cache. We need to clear SASS cache because of HTTP 403/404 being returned for images with cached old cache buster value.
