### PR TITLE
DAR-266: optimize Oasis for screen sizes 1024px and under.

### DIFF
--- a/skins/oasis/css/core/responsive.scss
+++ b/skins/oasis/css/core/responsive.scss
@@ -3,6 +3,16 @@
 
 $width-padding: $width-gutter / 2;
 
+.AccountNavigation {
+	overflow: hidden;
+}
+
+.oasis-split-skin {
+	.WikiaHeader {
+		min-width: auto;
+	}
+}
+
 .WikiaActivityModule li em {
 	width: auto;
 }

--- a/skins/oasis/css/core/responsive.scss
+++ b/skins/oasis/css/core/responsive.scss
@@ -33,3 +33,19 @@ $width-padding: $width-gutter / 2;
 .WikiaRail {
 	padding: 0 10px 0 0;
 }
+
+// These styles apply to 1024px and smaller screens
+@media screen and (max-width: 1024px) {
+	body {
+		background: $color-page;
+	}
+
+	.oasis-split-skin .WikiaPage,
+	.WikiaPage {
+		border: 0;
+	}
+
+	.WikiaPageBackground {
+		display: none;
+	}
+}

--- a/skins/oasis/css/core/responsive.scss
+++ b/skins/oasis/css/core/responsive.scss
@@ -44,7 +44,6 @@ $width-padding: $width-gutter / 2;
 	padding: 0 10px 0 0;
 }
 
-// These styles apply to 1024px and smaller screens
 @media screen and (max-width: 1024px) {
 	body {
 		background: $color-page;
@@ -57,5 +56,26 @@ $width-padding: $width-gutter / 2;
 
 	.WikiaPageBackground {
 		display: none;
+	}
+}
+
+@media screen and (max-width: 1023px) {
+	.WikiaArticle {
+		min-height: auto;
+	}
+
+	.WikiaMainContent {
+		float: none;
+		margin-right: 0;
+	}
+
+	.WikiaMainContentContainer {
+		margin-right: 0;
+	}
+
+	.WikiaRail {
+		float: none;
+		padding: 0 10px;
+		width: auto;
 	}
 }


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/DAR-266

For screens that are 1024px and smaller:
- Remove ad skin and wiki background.
- Remove page borders

For screens that are 1023px and smaller:
- Right rail drops below content area and takes up full horizontal space
