### PR TITLE
DAR-341 | Admin dashboard disbaled on Special:UserLogin

### DIFF
--- a/extensions/wikia/AdminDashboard/AdminDashboardLogic.class.php
+++ b/extensions/wikia/AdminDashboard/AdminDashboardLogic.class.php
@@ -40,6 +40,7 @@ class AdminDashboardLogic {
 			$bits = explode( '/', $title->getDBkey(), 2 );
 			$alias = array_shift(SpecialPageFactory::resolveAlias($bits[0]));
 
+
 			// NOTE: keep this list in alphabetical order
 			static $exclusionList = array(
 				"AbTesting",
@@ -95,7 +96,7 @@ class AdminDashboardLogic {
 				"ThemeDesigner",
 				"ThemeDesignerPreview",
 				"UnusedVideos",
-				"UserLogin",
+				"Userlogin",
 				"UserManagement",
 				"UserPathPrediction",
 				"UserSignup",

--- a/extensions/wikia/UserLogin/js/UserLoginFacebook.js
+++ b/extensions/wikia/UserLogin/js/UserLoginFacebook.js
@@ -64,8 +64,15 @@ var UserLoginFacebook = {
 			if (loginCallback && typeof loginCallback === 'function') {
 				loginCallback();
 			} else {
-				var form = new UserLoginFacebookForm();
-				form.reloadPage();
+				require(['wikia.querystring'], function(qs){
+					var qString = new qs(),
+						returnto = (wgCanonicalSpecialPageName && (wgCanonicalSpecialPageName.match(/Userlogin|Userlogout/))) ? wgMainPageTitle : null;
+
+					if(returnto) {
+						qString.setPath(wgArticlePath.replace('$1', returnto));
+					}
+					qString.addCb().goTo();
+				});
 			}
 		}
 		else {


### PR DESCRIPTION
Fixed misspell that was enabling AdminDashboard on Special:UserLogin page.

Do not merge this pull request until it's tested by QA.
