### PR TITLE
BAC-318: add debugging logs to MW connection mgmt library

### DIFF
--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -961,6 +961,14 @@ function wfDebugLog( $logGroup, $text, $public = true ) {
 	} elseif ( $public === true ) {
 		wfDebug( $text, true );
 	}
+
+	# Wikia change - begin
+	# @author macbre
+	global $wgWikiaLogGroups;
+	if( isset( $wgWikiaLogGroups[$logGroup] ) ) {
+		Wikia::log(__METHOD__, $logGroup, $text, true);
+	}
+	# Wikia change - end
 }
 
 /**
@@ -976,6 +984,11 @@ function wfLogDBError( $text ) {
 		$text = date( 'D M j G:i:s T Y' ) . "\t$host\t$wiki\t$text";
 		wfErrorLog( $text, $wgDBerrorLog );
 	}
+
+	# Wikia change - begin
+	# @author macbre
+	Wikia::log(__METHOD__, false, $text, true);
+	# Wikia change - end
 }
 
 /**

--- a/includes/db/LoadBalancer.php
+++ b/includes/db/LoadBalancer.php
@@ -702,8 +702,19 @@ class LoadBalancer {
 
 		if ( $db->isOpen() ) {
 			wfDebug( "Connected to $host $dbname.\n" );
+
+			# Wikia change - begin
+			# @author macbre
+			Wikia::log(__METHOD__, 'connected', "$host [$dbname]", true);
+			Wikia::logBacktrace(__METHOD__);
+			# Wikia change - end
 		} else {
 			wfDebug( "Connection failed to $host $dbname.\n" );
+
+			# Wikia change - begin
+			# @author macbre
+			Wikia::log(__METHOD__, 'failed', "$host [$dbname]", true);
+			# Wikia change - end
 		}
 		$db->setLBInfo( $server );
 		if ( isset( $server['fakeSlaveLag'] ) ) {

--- a/includes/objectcache/MemcachedClient.php
+++ b/includes/objectcache/MemcachedClient.php
@@ -831,6 +831,12 @@ class MWMemcached {
 			return false;
 		}
 
+		# Wikia change - begin
+		# @author macbre
+		Wikia::log(__METHOD__, 'connected', $host, true);
+		Wikia::logBacktrace(__METHOD__);
+		# Wikia change - end
+
 		// Initialise timeout
 		stream_set_timeout( $sock, $this->_timeout_seconds, $this->_timeout_microseconds );
 

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1151,3 +1151,12 @@ $app->registerHook( 'IsTrustedProxy', 'TrustedProxyService', 'onIsTrustedProxy' 
  */
 //$wgChatDebugEnabled = true;
 
+
+/**
+ * Set to an array of log group that should be logged using Wikia::log.
+ * If set, wfDebugLog() output for that group will go to datalog-s1 machine
+ */
+$wgWikiaLogGroups = [
+	'connect' => true,
+	'replication' => true
+];


### PR DESCRIPTION
This change will add the following logs (wth PHP backtraces):

```
Jun  6 15:11:08 dev-macbre apache2[4227]: MWMemcached::_connect_sock-connected:my_wiki/:10.14.30.143:11000
LoadBalancer::reallyOpenConnection-connected: 10.14.30.145 [plpoznan]
LoadBalancer::reallyOpenConnection-connected: 10.14.30.142 [wikicities]
```

As it's going to be logged for every request, I'm still considering logging it only for small percentage of requests.

@federico-lox @owend @psychonaut @drozdo
