### PR TITLE
PLA-352 -- update infobox parsing in indexing to accommodate multiple infoboxes

### DIFF
--- a/extensions/wikia/Search/classes/IndexService/DefaultContent.php
+++ b/extensions/wikia/Search/classes/IndexService/DefaultContent.php
@@ -230,21 +230,22 @@ class DefaultContent extends AbstractService
 		$result = array();
 		$infoboxes = $dom->find( 'table.infobox' );
 		if ( count( $infoboxes ) > 0 ) {
-			$infobox = $infoboxes[0];
-			$infobox = new simple_html_dom( $infobox->outertext() );
-			$this->removeGarbageFromDom( $infobox );
-			$infobox->load( $infobox->save() );
-			$infoboxRows = $infobox->find( 'tr' );
-			
-			if ( $infoboxRows ) {
-				$result['infoboxes_txt'] = [];
-				foreach ( $infoboxRows as $row ) {
-					$infoboxCells = $row->find( 'td' );
-					// we only care about key-value pairs in infoboxes
-					if ( count( $infoboxCells ) == 2 ) {
-						$result['infoboxes_txt'][] = preg_replace( '/\s+/', ' ', $infoboxCells[0]->plaintext . ' | ' . $infoboxCells[1]->plaintext  );
+			$result['infoboxes_txt'] = [];
+			$counter = 1;
+			foreach ( $infoboxes as $infobox ) {
+				$infobox = new simple_html_dom( $infobox->outertext() );
+				$this->removeGarbageFromDom( $infobox );
+				$infobox->load( $infobox->save() );
+				$infoboxRows = $infobox->find( 'tr' );
+				if ( $infoboxRows ) {
+					foreach ( $infoboxRows as $row ) {
+						$infoboxCells = $row->find( 'td' );
+						if ( count( $infoboxCells ) == 2 ) {
+							$result['infoboxes_txt'][] = "infobox_{$counter} | " . preg_replace( '/\s+/', ' ', $infoboxCells[0]->plaintext . ' | ' . $infoboxCells[1]->plaintext  );
+						}
 					}
 				}
+				$counter++;
 			}
 		}
 		return $result;

--- a/extensions/wikia/Search/classes/Test/IndexService/DefaultContentTest.php
+++ b/extensions/wikia/Search/classes/Test/IndexService/DefaultContentTest.php
@@ -656,7 +656,7 @@ ENDIT;
 		$this->proxyClass( 'simple_html_dom', $dom2 );
 		$this->mockApp();
 		$this->assertEquals(
-				[ 'infoboxes_txt' => [ 'here is my key | value' ] ],
+				[ 'infoboxes_txt' => [ 'infobox_1 | here is my key | value' ] ],
 				$extract->invoke( $service, $dom, $result )
 		);
 	}

--- a/includes/wikia/services/InfoboxesService.class.php
+++ b/includes/wikia/services/InfoboxesService.class.php
@@ -87,12 +87,16 @@ class InfoboxesService
 			if ( isset( $item['infoboxes_txt'] ) ) {
 				foreach ( $item['infoboxes_txt'] as $row ) {
 					$cells = explode( ' | ', $row );
+					$table = array_shift( $cells );
 					$key = array_shift( $cells );
-					$infoboxes[$key] = implode( ' | ', $cells );
+					if (! isset( $infoboxes[$table] ) ) {
+						$infoboxes[$table] = [];
+					}
+					$infoboxes[$table][] = implode( ' | ', $cells );
 				}
 			}
 			foreach ( $mappedIds[$item['pageid']] as $expectedId ) {
-				$items[$expectedId] = $infoboxes;
+				$items[$expectedId] = array_values( $infoboxes ); // don't want infobox_1, infobox_2, etc.
 			}
 		}
 		// integrity check

--- a/includes/wikia/services/tests/InfoboxesServiceTest.php
+++ b/includes/wikia/services/tests/InfoboxesServiceTest.php
@@ -159,8 +159,9 @@ class InfoboxesServiceTest extends WikiaBaseTest
 		
 		$service = $this->getMock( 'InfoboxesService', [ 'getMappedIds' ] );
 		$mapped = [ 123 => [ 123 ], 234 => [ 456, 789 ], 987 => [ 889 ] ];
-		$boxes = [ 'foo | bar' ];
-		$result = [ 123 => [ 'foo' => 'bar' ], 456 => [ 'foo' => 'bar' ], 789 => [ 'foo' => 'bar' ], 889 => [] ];
+		$boxes = [ 'infobox_1 | foo | bar', 'infobox_2 | baz | qux' ];
+		$ib = [ [ 'foo' => 'bar' ], [ 'baz' => 'qux' ] ];
+		$result = [ 123 => $ib, 456 => $ib, 789 => $ib, 889 => [] ];
 		$service
 		    ->expects( $this->once() )
 		    ->method ( 'getMappedIds' )


### PR DESCRIPTION
This change enables the provision of multiple infoboxes for a given document. This is a requirement for using Solr as the data store for infobox data.
