### PR TITLE
Fix for https://wikia-inc.atlassian.net/browse/MAIN-152.

### DIFF
--- a/extensions/wikia/EditPageLayout/EditPageService.class.php
+++ b/extensions/wikia/EditPageLayout/EditPageService.class.php
@@ -93,7 +93,9 @@ class EditPageService extends Service {
 		// create "fake" EditPage
 		$editPage = new EditPage($article);
 
-		$editPage->textbox1 = $wikitext;
+		// rtrim is a fix for https://wikia-inc.atlassian.net/browse/MAIN-152
+		// To understand better look at "$this->textbox1 = $this->safeUnicodeInput( $request, 'wpTextbox1' );" in EditPage.php
+		$editPage->textbox1 = rtrim( $wikitext );
 		$editPage->edittime = null;
 		$editPage->section = $section > 0 ? $section : '';
 

--- a/extensions/wikia/YouTube/YouTube.php
+++ b/extensions/wikia/YouTube/YouTube.php
@@ -61,9 +61,7 @@ function wfParserFunction_magic(&$magicWords, $langCode){
 }
 
 function upgradeYouTubeTag( $editpage, $request ) {
-	$text = $request->getText( 'wpTextbox1' );
-	$text = $request->getBool( 'safemode' ) ? $editpage->unmakesafe( $text ) : $text;
-
+	$text = $editpage->textbox1;
 	$text = preg_replace_callback(
 		'/<youtube([^>]*)>([^<]+)<\/youtube>/i',
 		function ($matches) {
@@ -87,9 +85,7 @@ function upgradeYouTubeTag( $editpage, $request ) {
 		},
 		$text
 	);
-
 	$editpage->textbox1 = $text;
-
 	return true;
 }
 


### PR DESCRIPTION
The way how hook handlers was implemented was wrong - it was reading data directly from request, modyfing it with regex, and assigning to already assigned (so overwriting) property called textbox1. This way it was skipping all the hard work done in importFormData in EditPage.php.
