### PR TITLE
PLA-310 -- ignore visualization info language value

### DIFF
--- a/extensions/wikia/Search/SearchApiController.class.php
+++ b/extensions/wikia/Search/SearchApiController.class.php
@@ -152,6 +152,7 @@ class SearchApiController extends WikiaApiController {
 			->setPage( $request->getVal( 'batch', 1 ) )
 			->setRank( $request->getVal( 'rank', 'default' ) )
 			->setInterWiki( true )
+			->setRequestedFields( array_merge( $searchConfig->getRequestedFields(), [ 'lang' ] ) ) 
 		;
 		return $searchConfig;
 	}

--- a/extensions/wikia/Search/classes/ResultSet/Grouping.php
+++ b/extensions/wikia/Search/classes/ResultSet/Grouping.php
@@ -122,11 +122,13 @@ class Grouping extends Base
 		$wikiId = $doc['wid'];
 		$wikiId = $wikiId ?: $this->service->getWikiIdByHost( $this->host );
 		$title = $this->service->getGlobalForWiki( 'wgSitename', $wikiId );
+		$visualizationInfo = $this->service->getVisualizationInfoForWikiId( $wikiId );
+		unset( $visualizationInfo['lang'] ); // untrustworthy
 		if (! empty( $doc ) ) {
 			$this->addHeaders( $doc->getFields() );
 			$title = $title ?: $doc[Utilities::field( 'wikititle' )]; // apparently wgSitename can be false for some wiki IDs
 		}
-		$this->addHeaders( $this->service->getVisualizationInfoForWikiId( $wikiId ) )
+		$this->addHeaders( $visualizationInfo )
 			 ->addHeaders( $this->service->getStatsInfoForWikiId( $wikiId ) )
 			 ->setHeader ( 'wikititle', $title )
 			 ->setHeader ( 'title', $title )

--- a/extensions/wikia/Search/classes/Test/ResultSet/GroupingTest.php
+++ b/extensions/wikia/Search/classes/Test/ResultSet/GroupingTest.php
@@ -361,7 +361,7 @@ class GroupingTest extends Wikia\Search\Test\BaseTest
 		$results = new \ArrayIterator( array( $mockResult ) );
 		$this->prepareMocks( array( 'addHeaders', 'setHeader', 'getHeader', 'getDescription' ), array(), array(), array( 'getSimpleMessage', 'getWikiIdByHost', 'getStatsInfoForWikiId', 'getVisualizationInfoForWikiId', 'getGlobalForWiki', 'getHubForWikiId' ) );
 		$fields = array( 'id' => 123 );
-		$vizInfo = array( 'description' => 'yup' );
+		$vizInfo = array( 'description' => 'yup', 'lang' => 'get rid of me' );
 		$mockResult
 		    ->expects( $this->at( 0 ) )
 		    ->method ( 'offsetGet' )
@@ -402,7 +402,7 @@ class GroupingTest extends Wikia\Search\Test\BaseTest
 		$this->resultSet
 		    ->expects( $this->at( 1 ) )
 		    ->method ( 'addHeaders' )
-		    ->with   ( $vizInfo )
+		    ->with   ( [ 'description' => 'yup' ] ) // note we dropped the lang
 		    ->will   ( $this->returnValue( $this->resultSet ) )
 		;
 		$this->resultSet


### PR DESCRIPTION
Sometimes WikisModell::getVisualization info provides a blank value for 'lang', which overwrites the more trustworthy value from the search result. This pull request updates logic in Wikia\Search\ResultSet\Grouping::setHeaders to avoid deleting the language value of a grouped search result.
