### PR TITLE
PLA-262 -- do not use empty domains to drive a wiki match

### DIFF
--- a/extensions/wikia/Search/classes/MediaWikiService.php
+++ b/extensions/wikia/Search/classes/MediaWikiService.php
@@ -470,7 +470,7 @@ class MediaWikiService
 	 */
 	public function getWikiMatchByHost( $domain ) {
 		$match = null;
-		if ( $wikiId = $this->getWikiIdByHost( $domain . '.wikia.com' ) ) {
+		if ( ( $domain !== '' ) && ( $wikiId = $this->getWikiIdByHost( $domain . '.wikia.com' ) ) ) {
 			$match = new \Wikia\Search\Match\Wiki( $wikiId, $this );
 		}
 		return $match;

--- a/extensions/wikia/Search/classes/QueryService/Select/AbstractSelect.php
+++ b/extensions/wikia/Search/classes/QueryService/Select/AbstractSelect.php
@@ -381,4 +381,23 @@ abstract class AbstractSelect
 	protected function getService() {
 		return $this->service;
 	}
+	
+	/**
+	 * Reusable logic for storing matches on a wiki basis. Used in InterWiki and OnWiki Query Services.
+	 * @return Wikia\Search\Match\Wiki|null
+	 */
+	protected function extractWikiMatch() {
+		$config = $this->getConfig();
+		$query = $config->getQuery()->getSanitizedQuery();
+		$domain = preg_replace(
+			'/[^a-zA-Z0-9]/',
+			'',
+			strtolower( $query ) 
+		);
+		$wikiMatch = $this->getService()->getWikiMatchByHost( $domain );
+		if (! empty( $wikiMatch ) ) {
+			$config->setWikiMatch( $wikiMatch );
+		}
+		return $config->getWikiMatch();
+	}
 }

--- a/extensions/wikia/Search/classes/QueryService/Select/InterWiki.php
+++ b/extensions/wikia/Search/classes/QueryService/Select/InterWiki.php
@@ -59,21 +59,12 @@ class InterWiki extends AbstractSelect
 	protected $timeAllowed = 7500;
 	
 	/**
-	 * Identifies a match by domain via mw service. Registers with config and returns if found.
+	 * Reuses AbstractSelect's extractWikiMatch as the primary match method
 	 * @see \Wikia\Search\QueryService\Select\AbstractSelect::extractMatch()
 	 * @return Wikia\Search\Match\Wiki
 	 */
 	public function extractMatch() {
-		$domain = preg_replace(
-				'/[^a-zA-Z]/',
-				'',
-				strtolower( $this->config->getQuery()->getSanitizedQuery() ) 
-				);
-		$match =  $this->service->getWikiMatchByHost( $domain );
-		if (! empty( $match ) ) {
-			$this->config->setWikiMatch( $match );
-		}
-		return $match;
+		return $this->extractWikiMatch();
 	}
 	
 	/**

--- a/extensions/wikia/Search/classes/QueryService/Select/OnWiki.php
+++ b/extensions/wikia/Search/classes/QueryService/Select/OnWiki.php
@@ -38,15 +38,7 @@ class OnWiki extends AbstractSelect
 			$this->config->setArticleMatch( $match );
 		}
 		if ( $this->service->getGlobal( 'OnWikiSearchIncludesWikiMatch' ) ) {
-			$domain = preg_replace(
-				'/[^a-zA-Z]/',
-				'',
-				strtolower( $query ) 
-				);
-			$wikiMatch = $this->service->getWikiMatchByHost( $domain );
-			if (! empty( $wikiMatch ) ) {
-				$this->config->setWikiMatch( $wikiMatch );
-			}
+			$this->extractWikiMatch();
 		}
 		return $this->config->getMatch();
 	}

--- a/extensions/wikia/Search/classes/Test/MediaWikiServiceTest.php
+++ b/extensions/wikia/Search/classes/Test/MediaWikiServiceTest.php
@@ -1729,6 +1729,24 @@ class MediaWikiServiceTest extends BaseTest
 	}
 	
 	/**
+	 * @covers Wikia\Search\MediaWikiService::getWikiMatchByHost
+	 */
+	public function testGetWikiMatchByHostWithNoDomain() {
+		$service = $this->service->setMethods( array( 'getWikiIdByHost' ) )->getMock();
+		$mockMatch = $this->getMockBuilder( 'Wikia\Search\Match\Wiki' )
+		                  ->disableOriginalConstructor()
+		                  ->getMock();
+		
+		$service
+		    ->expects( $this->never() )
+		    ->method ( 'getWikiIdByHost' )
+		;
+		$this->assertNull(
+				$service->getWikiMatchByHost( '' )
+		);
+	}
+	
+	/**
 	 * @covers Wikia\Search\MediaWikiService::getMainPageUrlForWikiId
 	 */
 	public function testGetMainPageUrlForWikiId() {

--- a/extensions/wikia/Search/classes/Test/QueryService/Select/AbstractSelectTest.php
+++ b/extensions/wikia/Search/classes/Test/QueryService/Select/AbstractSelectTest.php
@@ -1097,5 +1097,70 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 		);
 	}
 	
+	/**
+	 * @covers Wikia\Search\QueryService\Select\AbstractSelect::extractWikiMatch
+	 */
+	public function testExtractWikiMatchWithMatch() {
+		$mockService = $this->getMockBuilder( 'Wikia\Search\QueryService\Select\AbstractSelect' )
+		                    ->disableOriginalConstructor()
+		                    ->setMethods( [ 'getService', 'getConfig' ] )
+		                    ->getMockForAbstractClass();
+		
+		$mockConfig = $this->getMockBuilder( 'Wikia\Search\Config' )
+		                   ->disableOriginalConstructor()
+		                   ->setMethods( [ 'getQuery', 'setWikiMatch', 'getWikiMatch' ] )
+		                   ->getMock();
+		
+		$mockMatch = $this->getMockBuilder( 'Wikia\Search\Match\Wiki' )
+		                  ->disableOriginalConstructor()
+		                  ->getMock();
+		
+		$mockMwService = $this->getMock( 'Wikia\Search\MediaWikiService', [ 'getWikiMatchByHost' ] );
+		
+		$mockQuery = $this->getMock( 'Wikia\Search\Query\Select', [ 'getSanitizedQuery' ], [ 'foo' ] );
+		
+		$mockService
+		    ->expects( $this->once() )
+		    ->method ( 'getConfig' )
+		    ->will   ( $this->returnValue( $mockConfig ) )
+		;
+		$mockService
+		    ->expects( $this->once() )
+		    ->method ( 'getService' )
+		    ->will   ( $this->returnValue( $mockMwService ) )
+		;
+		$mockConfig
+		    ->expects( $this->once() )
+		    ->method ( 'getQuery' )
+		    ->will   ( $this->returnValue( $mockQuery ) )
+		;
+		$mockQuery
+		    ->expects( $this->once() )
+		    ->method ( 'getSanitizedQuery' )
+		    ->will   ( $this->returnValue( 'foo bar 123' ) )
+		;
+		$mockMwService
+		    ->expects( $this->once() )
+		    ->method ( 'getWikiMatchByHost' )
+		    ->with   ( 'foobar123' )
+		    ->will   ( $this->returnValue( $mockMatch ) )
+		;
+		$mockConfig
+		    ->expects( $this->once() )
+		    ->method ( 'setWikiMatch' )
+		    ->with   ( $mockMatch )
+		;
+		$mockConfig
+		    ->expects( $this->once() )
+		    ->method ( 'getWikiMatch' )
+		    ->will   ( $this->returnValue( $mockMatch ) )
+		;
+		$extract = new ReflectionMethod( $mockService, 'extractWikiMatch' );
+		$extract->setAccessible( true );
+		$this->assertEquals(
+				$mockMatch,
+				$extract->invoke( $mockService )
+		);
+	}
 	
 }

--- a/extensions/wikia/Search/classes/Test/QueryService/Select/InterWikiTest.php
+++ b/extensions/wikia/Search/classes/Test/QueryService/Select/InterWikiTest.php
@@ -13,48 +13,22 @@ class InterWikiTest extends Wikia\Search\Test\BaseTest {
 	 * @covers Wikia\Search\QueryService\Select\InterWiki::extractMatch
 	 */
 	public function testExtractMatch() {
-		$mockConfig = $this->getMock( 'Wikia\Search\Config', array( 'getQuery', 'setWikiMatch', 'getWikiMatch' ) );
-		$mockQuery = $this->getMock( 'Wikia\Search\Query\Select', array( 'getSanitizedQuery' ), array( 'foo' ) );
-		$mockService = $this->getMockBuilder( 'Wikia\Search\MediaWikiService' )
-		                      ->disableOriginalConstructor()
-		                      ->setMethods( array( 'getWikiMatchByHost' ) )
-		                      ->getMock();
-
-		$dc = new Wikia\Search\QueryService\DependencyContainer( array( 'config' => $mockConfig, 'service' => $mockService ) );
 		$mockSelect = $this->getMockBuilder( 'Wikia\Search\QueryService\Select\InterWiki' )
-		                   ->setConstructorArgs( array( $dc ) )
-		                   ->setMethods( null )
+		                   ->disableOriginalConstructor()
+		                   ->setMethods( array( 'extractWikiMatch' ) )
 		                   ->getMock();
 		$mockMatch = $this->getMockBuilder( 'Wikia\Search\Match\Wiki' )
 		                  ->disableOriginalConstructor()
 		                  ->getMock();
-		
-		$mockConfig
+		$mockSelect
 		    ->expects( $this->once() )
-		    ->method ( 'getQuery' )
-		    ->will   ( $this->returnValue( $mockQuery ) )
-	    ;
-		$mockQuery
-		    ->expects( $this->once() )
-		    ->method ( 'getSanitizedQuery' )
-		    ->will   ( $this->returnValue( 'star wars' ) )
-		;
-		$mockService
-		    ->expects( $this->once() )
-		    ->method ( 'getWikiMatchByHost' )
-		    ->with   ( 'starwars' )
+		    ->method ( 'extractWikiMatch' )
 		    ->will   ( $this->returnValue( $mockMatch ) )
 		;
-		$mockConfig
-		    ->expects( $this->once() )
-		    ->method ( 'setWikiMatch' )
-		    ->with   ( $mockMatch )
-		;
-		$method = new ReflectionMethod( 'Wikia\Search\QueryService\Select\InterWiki', 'extractMatch' );
-		$method->setAccessible( true );
+		$extract = new ReflectionMethod( $mockSelect, 'extractMatch' );
 		$this->assertEquals(
 				$mockMatch,
-				$method->invoke( $mockSelect )
+				$extract->invoke( $mockSelect )
 		);
 	}
 	

--- a/extensions/wikia/Search/classes/Test/QueryService/Select/OnWikiTest.php
+++ b/extensions/wikia/Search/classes/Test/QueryService/Select/OnWikiTest.php
@@ -28,7 +28,7 @@ class OnWikiTest extends Wikia\Search\Test\BaseTest {
 		$dc = new Wikia\Search\QueryService\DependencyContainer( array( 'service' => $mockService, 'config' => $mockConfig ) );
 		$mockSelect = $this->getMockBuilder( 'Wikia\Search\QueryService\Select\OnWiki' )
 		                   ->setConstructorArgs( array( $dc ) )
-		                   ->setMethods(  [ 'matchPassesFilters' ] )
+		                   ->setMethods(  [ 'extractWikiMatch' ] )
 		                   ->getMock();
 		
 		$mockMatch = $this->getMockBuilder( 'Wikia\Search\Match\Article' )
@@ -71,16 +71,10 @@ class OnWikiTest extends Wikia\Search\Test\BaseTest {
 		    ->with   ( 'OnWikiSearchIncludesWikiMatch' )
 		    ->will   ( $this->returnValue( true ) )
 		;
-		$mockService
+		$mockSelect
 		    ->expects( $this->once() )
-		    ->method ( 'getWikiMatchByHost' )
-		    ->with   ( 'starwars' )
+		    ->method ( 'extractWikiMatch' )
 		    ->will   ( $this->returnValue( $mockWikiMatch ) )
-		;
-		$mockConfig
-		    ->expects( $this->once() )
-		    ->method ( 'setWikiMatch' )
-		    ->with   ( $mockWikiMatch )
 		;
 		$mockConfig
 		    ->expects( $this->once() )


### PR DESCRIPTION
This code change prevents a wiki match with an empty domain from being treated like a legitimate wiki match.
