### PR TITLE
CON-47: fix params to select and fix SQL by using subquery

### DIFF
--- a/includes/wikia/services/WikiService.class.php
+++ b/includes/wikia/services/WikiService.class.php
@@ -43,15 +43,15 @@ class WikiService extends WikiaModel {
 							$conditions = array("ug_group in ('sysop','bureaucrat')");
 
 							if ($excludeBots) {
-								$conditions[] = "ug_group not in (" .
+								$conditions[] = "ug_user not in (select distinct ug_user from user_groups where ug_group in (" .
 									$db->makeList(self::$botGroups) .
-									")";
+									"))";
 							}
 
 							$result = $db->select(
 								'user_groups',
 								'distinct ug_user',
-								array ("ug_group in ('sysop','bureaucrat')"),
+								$conditions,
 								__METHOD__,
 								(!empty($limit))?(array('LIMIT' => $limit)):array()
 							);


### PR DESCRIPTION
Please @sqlreview this SQL:

select distinct ug_user from user_groups where ug_group in ('sysop', 'bureaucrat') and ug_user not in (select distinct ug_user from user_groups where ug_group in ('bot', 'bot-global'))

Can it be written without subquery? Or optimized somehow?
