### PR TITLE
VID-217 Moved the commons message to the about tab.

### DIFF
--- a/extensions/wikia/FilePage/FilePageTabbed.php
+++ b/extensions/wikia/FilePage/FilePageTabbed.php
@@ -36,6 +36,10 @@ class FilePageTabbed extends WikiaFilePage {
 		return $isDiff;
 	}
 
+	/**
+	 * imageContent override
+	 * Content here will appear on the "About" tab
+	 */
 	protected function imageContent() {
 		wfProfileIn( __METHOD__ );
 
@@ -57,6 +61,8 @@ class FilePageTabbed extends WikiaFilePage {
 
 	/**
 	 * imageDetails override
+	 * Content here will appear on the "File History" tab
+	 *
 	 * Image page doesn't need the wrapper, but WikiaFilePage does
 	 * This is called after the wikitext is printed out
 	 */
@@ -86,6 +92,8 @@ class FilePageTabbed extends WikiaFilePage {
 
 	/**
 	 * imageMetadata override
+	 * Content here will appear on the "Metadata" tab
+	 *
 	 * Image page doesn't need the wrapper, but WikiaFilePage does
 	 */
 	protected function imageMetadata($formattedMetadata) {
@@ -106,7 +114,7 @@ class FilePageTabbed extends WikiaFilePage {
 		wfProfileOut( __METHOD__ );
 	}
 
-	/*
+	/**
 	 * Render related pages section at the bottom of a file page
 	 */
 	protected function imageFooter() {
@@ -182,5 +190,4 @@ class FilePageTabbed extends WikiaFilePage {
 
 		return $caption;
 	}
-
 }

--- a/includes/ImagePage.php
+++ b/includes/ImagePage.php
@@ -169,6 +169,7 @@ class ImagePage extends Article {
 
 	/**
 	 * Wikia - abstracted out part of view() function, so it can be wrapped by ImagePageTabbed
+	 * Content here will appear on the "About" tab in the tabbed version of the file page
 	 */
 	protected function imageContent() {
 		global $wgOut;
@@ -189,13 +190,6 @@ class ImagePage extends Article {
 			$wgOut->setPageTitle( $this->getTitle()->getPrefixedText() );
 			$this->mPage->doViewUpdates( $this->getContext()->getUser() );
 		}
-	}
-
-	/**
-	 * Wikia - abstracted out part of view() function, so it can be wrapped by ImagePageTabbed
-	 */
-	protected function imageDetails() {
-		global $wgOut;
 
 		# Show shared description, if needed
 		if ( $this->mExtraDescription ) {
@@ -205,6 +199,14 @@ class ImagePage extends Article {
 			}
 			$wgOut->addHTML( '<div id="shared-image-desc">' . $this->mExtraDescription . "</div>\n" );
 		}
+	}
+
+	/**
+	 * Wikia - abstracted out part of view() function, so it can be wrapped by FilePageTabbed
+	 * Content here will appear on the "File History" tab in the tabbed version of the file page
+	 */
+	protected function imageDetails() {
+		global $wgOut;
 
 		$this->closeShowImage();
 		$this->imageHistory();
@@ -224,6 +226,7 @@ class ImagePage extends Article {
 
 	/**
 	 * Wikia - abstracted out part of view() function, so it can be wrapped by ImagePageTabbed
+	 * Content here will appear on the "Metadata" tab in the tabbed version of the file page
 	 */
 	protected function imageMetadata($formattedMetadata) {
 		global $wgOut;


### PR DESCRIPTION
It will appear below the user description.

Note that this diff is weird.  I moved an IF block from imageDetails to imageContent, but the diff makes it look like I just deleted the function declaration and comments and moved them lower in the file.  I have no idea why it choose to represent it this way.
