### PR TITLE
Drop unused function param and variables

### DIFF
--- a/extensions/wikia/Forum/ForumHooksHelper.class.php
+++ b/extensions/wikia/Forum/ForumHooksHelper.class.php
@@ -113,7 +113,7 @@ class ForumHooksHelper {
 
 		if ( $element->page_namespace == NS_WIKIA_FORUM_BOARD_THREAD ) {
 
-			$titleData = WallHelper::getWallTitleData(null, $element, true);
+			$titleData = WallHelper::getWallTitleData(null, $element );
 
 			$boardText = wfMsg( 'forum-wiki-activity-msg', '<a href="' .$titleData['wallPageFullUrl'] . '">' . wfMsg( 'forum-wiki-activity-msg-name', $titleData['wallPageName'] ) . '</a>' );
 			$link = '<a href="'.$titleData['articleFullUrl'].'">'.$titleData['articleTitleTxt'].'</a> ' . $boardText;

--- a/extensions/wikia/VideoHandlers/handlers/VideoHandler.class.php
+++ b/extensions/wikia/VideoHandlers/handlers/VideoHandler.class.php
@@ -54,7 +54,7 @@ abstract class VideoHandler extends BitmapHandler {
 	}
 
 	function normaliseParams( $image, &$params ) {
-		global $wgMaxImageArea, $wgMaxThumbnailArea;
+		global $wgMaxThumbnailArea;
 		wfProfileIn( __METHOD__ );
 		if ( !ImageHandler::normaliseParams( $image, $params ) ) {
 			wfProfileOut( __METHOD__ );

--- a/extensions/wikia/Wall/WallHelper.class.php
+++ b/extensions/wikia/Wall/WallHelper.class.php
@@ -221,7 +221,6 @@ class WallHelper {
 	 * @author Andrzej 'nAndy' Lukaszewski
 	 */
 	public function getWallComments($parentId = null) {
-		$app = F::app();
 		wfProfileIn(__METHOD__);
 
 		$comments = array();
@@ -293,7 +292,6 @@ class WallHelper {
 	 * @author Andrzej 'nAndy' Åukaszewski
 	 */
 	private function getCommentsData($comments) {
-		$app = F::app();
 		wfProfileIn(__METHOD__);
 
 		$timeNow = time();

--- a/extensions/wikia/Wall/WallHelper.class.php
+++ b/extensions/wikia/Wall/WallHelper.class.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @property mixed title
+ */
 class WallHelper {
 	//WA = wiki activity
 	const WA_WALL_COMMENTS_MAX_LEN = 150;
@@ -60,6 +63,7 @@ class WallHelper {
 	 * It sends request to UserProfilePage controller which should return user object generated
 	 * from passed title.
 	 *
+	 * @param bool $title
 	 * @return User
 	 *
 	 * @author Andrzej 'nAndy' Åukaszewski
@@ -115,7 +119,6 @@ class WallHelper {
 	 * @author Andrzej 'nAndy' Åukaszewski
 	 */
 	public function wikiActivityFilterMessageWall($title, &$res) {
-		$app = F::app();
 		wfProfileIn(__METHOD__);
 
 		$item = array();
@@ -286,6 +289,7 @@ class WallHelper {
 	 *
 	 * @param array $comments an array with WallMessage instances
 	 *
+	 * @return array
 	 * @author Andrzej 'nAndy' Åukaszewski
 	 */
 	private function getCommentsData($comments) {
@@ -388,7 +392,6 @@ class WallHelper {
 	public function getParsedText($rawtext, $title) {
 		global $wgParser, $wgOut;
 		global $wgEnableParserCache;
-		global $wgUser;
 		$wgEnableParserCache = false;
 
 		return $wgParser->parse( $rawtext, $title, $wgOut->parserOptions())->getText();
@@ -436,6 +439,7 @@ class WallHelper {
 	 *
 	 * @param integer $textId article's text id in text table
 	 *
+	 * @return string
 	 * @author Andrzej 'nAndy' Åukaszewski
 	 */
 	public function getDeletedArticleTitleTxt($textId) {
@@ -467,6 +471,7 @@ class WallHelper {
 	 *
 	 * TODO: remove it we don't need to operate on delete wall messages anymore
 	 *
+	 * @return string
 	 * @author Andrzej 'nAndy' Åukaszewski
 	 */
 	public function getTitleTxtFromMetadata($text) {

--- a/extensions/wikia/Wall/WallHelper.class.php
+++ b/extensions/wikia/Wall/WallHelper.class.php
@@ -560,10 +560,9 @@ class WallHelper {
 	/**
 	 * @param null $rc
 	 * @param array $row [ page_title, page_namespace, rev_user_text?, page_is_new?, rev_parent_id? ]
-	 * @param bool $fullUrls
 	 * @return array|bool
 	 */
-	public static function getWallTitleData( $rc = null, $row = null, $fullUrls = false ) {
+	public static function getWallTitleData( $rc = null, $row = null ) {
 
 		wfProfileIn(__METHOD__);
 
@@ -608,9 +607,6 @@ class WallHelper {
 			}
 			$wmw->load();
 		}
-
-		$articleId = $wm->getId();
-		$wallOwnerName = $wm->getArticleTitle()->getText();
 
 		if(!empty($wmw)) {
 			$articleTitleTxt =  $wmw->getMetaTitle();
@@ -659,5 +655,4 @@ class WallHelper {
 
 		return $out;
 	}
-	
 }

--- a/extensions/wikia/Wall/WallHooksHelper.class.php
+++ b/extensions/wikia/Wall/WallHooksHelper.class.php
@@ -1536,7 +1536,7 @@ class WallHooksHelper {
 		$page->resetArticleId($row->rev_page);
 		$skin = $app->wg->User->getSkin();
 
-		$wfMsgOptsBase = $this->getMessageOptions(null, $row, true);
+		$wfMsgOptsBase = $this->getMessageOptions(null, $row);
 
 
 		$isThread = $wfMsgOptsBase['isThread'];
@@ -1627,12 +1627,13 @@ class WallHooksHelper {
 	 *
 	 * @param RecentChanges $rc
 	 * @param Object $row
-	 * @param Title $objTitle
+	 * @param bool $fullUrls
+	 * @internal param \Title $objTitle
 	 *
 	 * @return Array
 	 */
-	public  function getMessageOptions($rc = null, $row = null, $fullUrls = false) {
-		return WallHelper::getWallTitleData( $rc, $row, $fullUrls);
+	public  function getMessageOptions($rc = null, $row = null) {
+		return WallHelper::getWallTitleData( $rc, $row );
 	}
 
 
@@ -1640,7 +1641,7 @@ class WallHooksHelper {
 
 		if ( $element->page_namespace == NS_USER_WALL_MESSAGE ) {
 
-			$titleData = WallHelper::getWallTitleData(null, $element, true);
+			$titleData = WallHelper::getWallTitleData(null, $element );
 			$a = '<a href="'.$titleData['articleFullUrl'].'">'.$titleData['articleTitleTxt'].'</a> ';
 			$link = wfMsg( 'wall-recentchanges-thread-group', array( $a, $titleData['wallPageFullUrl'], $titleData['wallPageName'] ) );
 		}
@@ -1661,11 +1662,10 @@ class WallHooksHelper {
 
 		if( isset($row->page_namespace) && in_array( intval($row->page_namespace), array( NS_USER_WALL_MESSAGE, NS_WIKIA_FORUM_BOARD_THREAD )) ) {
 			$defaultRendering = false;
-			$title = F::build('Title', array($row->page_title, $row->page_namespace), 'newFromText');
 
 			$app = F::app();
 			$wlhTitle = SpecialPage::getTitleFor( 'Whatlinkshere' );
-			$wfMsgOptsBase = $this->getMessageOptions(null, $row, true);
+			$wfMsgOptsBase = $this->getMessageOptions(null, $row);
 
 			$wfMsgOpts = array(
 				$wfMsgOptsBase['articleFullUrl'],

--- a/extensions/wikia/Wall/WallHooksHelper.class.php
+++ b/extensions/wikia/Wall/WallHooksHelper.class.php
@@ -162,6 +162,10 @@ class WallHooksHelper {
 	/**
 	 * @brief Hook to change tabs on user wall page
 	 *
+	 * @param $template
+	 * @param $contentActions
+	 * @return bool
+	 *
 	 * @author Andrzej 'nAndy' Łukaszewski
 	 */
 	public function onSkinTemplateTabs($template, &$contentActions) {
@@ -261,6 +265,7 @@ class WallHooksHelper {
 	/**
 	 * @brief Redirects any attempts of editing anything in NS_USER_WALL namespace
 	 *
+	 * @param $editPage
 	 * @return true
 	 *
 	 * @author Andrzej 'nAndy' Łukaszewski
@@ -274,6 +279,7 @@ class WallHooksHelper {
 	/**
 	 * @brief Redirects any attempts of viewing history of any page in NS_USER_WALL namespace
 	 *
+	 * @param $article
 	 * @return true
 	 *
 	 * @author Andrzej 'nAndy' Łukaszewski
@@ -305,6 +311,7 @@ class WallHooksHelper {
 	/**
 	 * @brief Overrides descrpiton of history page
 	 *
+	 * @param $description
 	 * @return true
 	 *
 	 * @author Jakub Olek
@@ -322,8 +329,12 @@ class WallHooksHelper {
 
 	/**
 	 * @brief add history to wall toolbar
-	 **/
-	function onBeforeToolbarMenu(&$items) {
+	 *
+	 * @param $items
+	 *
+	 * @return bool
+	 */
+	function onBeforeToolbarMenu( &$items ) {
 		$app = F::app();
 		if( empty( $app->wg->EnableWallExt ) ){
 			return true;
@@ -376,11 +387,10 @@ class WallHooksHelper {
 		return true;
 	}
 
-
-
 	/**
 	 * @brief Redirects any attempts of protecting any page in NS_USER_WALL namespace
 	 *
+	 * @param $article
 	 * @return true
 	 *
 	 * @author Andrzej 'nAndy' Łukaszewski
@@ -394,6 +404,7 @@ class WallHooksHelper {
 	/**
 	 * @brief Redirects any attempts of unprotecting any page in NS_USER_WALL namespace
 	 *
+	 * @param $article
 	 * @return true
 	 *
 	 * @author Andrzej 'nAndy' Łukaszewski
@@ -407,6 +418,7 @@ class WallHooksHelper {
 	/**
 	 * @brief Redirects any attempts of deleting any page in NS_USER_WALL namespace
 	 *
+	 * @param $article
 	 * @return true
 	 *
 	 * @author Andrzej 'nAndy' Łukaszewski
@@ -420,6 +432,8 @@ class WallHooksHelper {
 	/**
 	 * @brief Changes "My talk" to "Message wall" in the user links.
 	 *
+	 * @param $personalUrls
+	 * @param $title
 	 * @return true
 	 *
 	 * @author Andrzej 'nAndy' Łukaszewski
@@ -453,6 +467,9 @@ class WallHooksHelper {
 	/**
 	 * @brief Changes "My talk" to "Message wall" in Oasis (in the tabs on the User page).
 	 *
+	 * @param $tabs
+	 * @param $namespace
+	 * @param $userName
 	 * @return true
 	 *
 	 * @author Andrzej 'nAndy' Łukaszewski
@@ -484,6 +501,11 @@ class WallHooksHelper {
 	/**
 	 * @brief Remove Message Wall:: from back link
 	 *
+	 * @param $title
+	 * @param $ptext
+	 * @param $cssClass
+	 * @return bool
+	 *
 	 * @author Andrzej 'nAndy' Łukaszewski
 	 */
 	public function onSkinSubPageSubtitleAfterTitle($title, &$ptext, &$cssClass) {
@@ -497,6 +519,11 @@ class WallHooksHelper {
 
 	/**
 	 * @brief Adds an action button on user talk archive page
+	 *
+	 * @param $response
+	 * @param $ns
+	 * @param $skin
+	 * @return bool
 	 *
 	 * @author Andrzej 'nAndy' Łukaszewski
 	 */
@@ -612,6 +639,8 @@ class WallHooksHelper {
 	 *
 	 * @author Andrzej 'nAndy' Łukaszewski
 	 *
+	 * @param null $subpage
+	 * @param null $user
 	 * @return Title | null
 	 */
 	protected function getWallTitle($subpage = null, $user = null) {
@@ -622,10 +651,13 @@ class WallHooksHelper {
 	}
 
 	/**
-	 *  clean history after delete
-	 *
-	 **/
-
+	 * clean history after delete
+	 * @param $self
+	 * @param $user
+	 * @param $reason
+	 * @param $id
+	 * @return bool
+	 */
 	public function onArticleDeleteComplete( &$self, &$user, $reason, $id) {
 		$title = $self->getTitle();
 		$app = F::app();
@@ -708,6 +740,9 @@ class WallHooksHelper {
 	 *
 	 * @author Andrzej 'nAndy' Łukaszewski
 	 *
+	 * @param $permErrors
+	 * @param $title
+	 * @param $removeArray
 	 * @return boolean true -- because it's a hook
 	 */
 	public function onAfterEditPermissionErrors(&$permErrors, $title, $removeArray) {
@@ -781,7 +816,6 @@ class WallHooksHelper {
 	public function onChangesListInsertFlags($list, &$flags, $rc) {
 		if( $rc->getAttribute('rc_type') == RC_NEW && $rc->getAttribute('rc_namespace') == NS_USER_WALL_MESSAGE ) {
 			//we don't need flags if this is a reply on a message wall
-			$app = F::app();
 
 			$rcTitle = $rc->getTitle();
 
@@ -883,11 +917,13 @@ class WallHooksHelper {
 	 * @desc This method doesn't let display diff history links
 	 *
 	 * @param ChangesList $list
-	 * @param string $articleLink
+	 * @param $diffLink
+	 * @param $historyLink
 	 * @param string $s
 	 * @param RecentChange $rc
 	 * @param boolean $unpatrolled
 	 *
+	 * @internal param string $articleLink
 	 * @return true because this is a hook
 	 *
 	 * @author Andrzej 'nAndy' Lukaszewski
@@ -986,10 +1022,9 @@ class WallHooksHelper {
 	 * @desc This method creates comment to a recent change line
 	 *
 	 * @param ChangesList $list
-	 * @param string $comment
-	 * @param string $s
 	 * @param RecentChange $rc
-	 *
+	 * @param string $comment
+	 * @internal param string $s
 	 * @return true because this is a hook
 	 *
 	 * @author Andrzej 'nAndy' Lukaszewski
@@ -1096,10 +1131,11 @@ class WallHooksHelper {
 	 *
 	 * @desc This method clears or leaves as it was the text which is being send as a content of <li /> elements in RC page
 	 *
-	 * @param ChangesList $list
+	 * @param $changelist
 	 * @param string $s
 	 * @param RecentChange $rc
 	 *
+	 * @internal param \ChangesList $list
 	 * @return true because this is a hook
 	 *
 	 * @author Andrzej 'nAndy' Lukaszewski
@@ -1107,7 +1143,6 @@ class WallHooksHelper {
 	public function onOldChangesListRecentChangesLine($changelist, &$s, $rc) {
 		if( $rc->getAttribute('rc_namespace') == NS_USER_WALL_MESSAGE ) {
 			wfProfileIn( __METHOD__ );
-			$app = F::app();
 			$rcTitle = $rc->getTitle();
 
 			if( !($rcTitle instanceof Title) ) {
@@ -1199,7 +1234,6 @@ class WallHooksHelper {
 	 */
 	public function onPageArchiveUndeleteBeforeLogEntry(&$pageArchive, &$logPage, &$title, $reason, &$hookAddedLogEntry) {
 		if( $title instanceof Title && $title->getNamespace() == NS_USER_WALL_MESSAGE ) {
-			$app = F::app();
 			$wm = F::build('WallMessage', array($title));
 			$parentObj = $wm->getTopParentObj();
 			$reason = ''; //we don't want any comment
@@ -1246,8 +1280,10 @@ class WallHooksHelper {
 	 * @param string $r
 	 * @param array $oRCCacheEntryArray an array of RCCacheEntry instances
 	 * @param boolean $changeRecentChangesHeader a flag saying Wikia's hook if we want to change header or not
+	 * @param $oTitle
 	 * @param string $headerTitle string which will be put as a header for RecentChanges block
 	 *
+	 * @return bool
 	 * @author Andrzej 'nAndy' Łukaszewski
 	 */
 	public function onWikiaRecentChangesBlockHandlerChangeHeaderBlockGroup($oChangeList, $r, $oRCCacheEntryArray, &$changeRecentChangesHeader, $oTitle, &$headerTitle) {
@@ -1282,10 +1318,9 @@ class WallHooksHelper {
 	/**
 	 * @brief get prefixed message name for recent changes, helpful for using wall on others namesapces
 	 *
-	 *
 	 * @param int $namespace
-	 * @param string $message
-	 *
+	 * @return string
+	 * @internal param string $message
 	 */
 
 	protected function getMessagePrefix($namespace) {
@@ -1308,6 +1343,7 @@ class WallHooksHelper {
 	 * @param string $secureName
 	 * @param RecentChange $rc
 	 *
+	 * @return bool
 	 * @author Andrzej 'nAndy' Łukaszewski
 	 */
 	public function onChangesListMakeSecureName($changesList, &$secureName, $rc) {
@@ -1334,8 +1370,15 @@ class WallHooksHelper {
 	/**
 	 * @brief Changing all links to Message Wall to blue links
 	 *
-	 * @param Title $title
-	 * @param boolean $result
+	 * @param $skin
+	 * @param $target
+	 * @param $text
+	 * @param $customAttribs
+	 * @param $query
+	 * @param $options
+	 * @param $ret
+	 * @internal param \Title $title
+	 * @internal param bool $result
 	 *
 	 * @return true -- because it's a hook
 	 *
@@ -1366,6 +1409,12 @@ class WallHooksHelper {
 	/**
 	 * getUserPermissionsErrors -  control access to articles in the namespace NS_USER_WALL_MESSAGE_GREETING
 	 *
+	 * @param $title
+	 * @param $user
+	 * @param $action
+	 * @param $result
+	 * @return bool
+	 *
 	 * @author Tomek Odrobny
 	 *
 	 * @access public
@@ -1389,7 +1438,6 @@ class WallHooksHelper {
 		$result = null;
 		return true;
 	}
-
 
 	public function onComposeCommonBodyMail($title, &$keys, &$body, $editor) {
 		return true;
@@ -1507,7 +1555,6 @@ class WallHooksHelper {
 		return true;
 	}
 
-
 	/**
 	 * @brief Adjusting Special:Contributions
 	 *
@@ -1537,7 +1584,6 @@ class WallHooksHelper {
 		$skin = $app->wg->User->getSkin();
 
 		$wfMsgOptsBase = $this->getMessageOptions(null, $row);
-
 
 		$isThread = $wfMsgOptsBase['isThread'];
 		$isNew = $wfMsgOptsBase['isNew'];
@@ -1613,8 +1659,6 @@ class WallHooksHelper {
 			$ret .= ' ' . Xml::openElement('span', array('class' => 'comment')) . $msg . Xml::closeElement('span');
 		}
 
-
-
 		wfProfileOut(__METHOD__);
 
 		return true;
@@ -1627,8 +1671,6 @@ class WallHooksHelper {
 	 *
 	 * @param RecentChanges $rc
 	 * @param Object $row
-	 * @param bool $fullUrls
-	 * @internal param \Title $objTitle
 	 *
 	 * @return Array
 	 */
@@ -1641,7 +1683,7 @@ class WallHooksHelper {
 
 		if ( $element->page_namespace == NS_USER_WALL_MESSAGE ) {
 
-			$titleData = WallHelper::getWallTitleData(null, $element );
+			$titleData = WallHelper::getWallTitleData( null, $element );
 			$a = '<a href="'.$titleData['articleFullUrl'].'">'.$titleData['articleTitleTxt'].'</a> ';
 			$link = wfMsg( 'wall-recentchanges-thread-group', array( $a, $titleData['wallPageFullUrl'], $titleData['wallPageName'] ) );
 		}
@@ -1975,7 +2017,6 @@ class WallHooksHelper {
 	/**
 	 * create needed tables
 	 */
-
 	public static function onAfterToggleFeature($name, $val) {
 		global $IP;
 		if($name == 'wgEnableWallExt' || $name == 'wgEnableForumExt') {
@@ -2028,9 +2069,10 @@ class WallHooksHelper {
 	/**
 	 * HAWelcome
 	 *
-	 * @param String $$prefixedText
+	 * @param $prefixedText
 	 * @param Title $title
 	 *
+	 * @internal param $String $$prefixedText
 	 * @access public
 	 * @author Tomek
 	 *


### PR DESCRIPTION
- Updated method documentation
- Removed unused variables
- Removed an unused function parameter in WallHelper::getWallTitleData
