### PR TITLE
Improvements to importing and /me command

### DIFF
--- a/extensions/wikia/Chat2/js/views/views.js
+++ b/extensions/wikia/Chat2/js/views/views.js
@@ -1,4 +1,3 @@
-
 //
 //Views
 //
@@ -137,7 +136,7 @@ var ChatView = Backbone.View.extend({
 				msg.text = msg.text.substr(4);
 				var originalTemplate = this.template;
 				this.template = this.meMessageTemplate;
-				$(this.el).html(this.template(msg));
+				$(this.el).html(this.template(msg)).addClass('me-message-line');
 				this.template = originalTemplate;
 			} else {
 				if (msg.text.indexOf('//me ') == 0) {

--- a/extensions/wikia/Chat2/templates/Chat_Index.php
+++ b/extensions/wikia/Chat2/templates/Chat_Index.php
@@ -11,7 +11,7 @@
 
 	<!-- CSS -->
 	<link rel="stylesheet" href="<?= AssetsManager::getInstance()->getSassCommonURL('/extensions/wikia/Chat2/css/Chat.scss')?>">
-	<link rel="stylesheet" href="/load.php?lang=en&mode=articles&articles=MediaWiki%3AChat.css%7CUser%3A<?php echo $wgUserName; ?>%2Fchat.css&only=styles">
+	<link rel="stylesheet" href="/load.php?lang=en&mode=articles&articles=MediaWiki%3AChat.css%7CUser%3A<?php echo $wg->User->getName(); ?>%2Fchat.css&only=styles">
 
 	<!-- JS -->
 	<?php
@@ -132,6 +132,6 @@
 		<script src="<?php echo $src ?>"></script>
 	<?php endforeach;?>
 	<script src="<?php echo $jsMessagePackagesUrl ?>"></script>
-	<script type="text/javascript" src="/load.php?lang=en&mode=articles&articles=MediaWiki%3AChat.js%7CUser%3A<?php echo $wgUserName; ?>%2Fchat.js&only=scripts"></script>
+	<script type="text/javascript" src="/load.php?lang=en&mode=articles&articles=MediaWiki%3AChat.js%7CUser%3A<?php echo $wg->User->getName(); ?>%2Fchat.js&only=scripts"></script>
 </body>
 </html>

--- a/extensions/wikia/Chat2/templates/Chat_Index.php
+++ b/extensions/wikia/Chat2/templates/Chat_Index.php
@@ -82,7 +82,7 @@
 		<img width="<?= ChatAjax::CHAT_AVATAR_DIMENSION ?>" height="<?= ChatAjax::CHAT_AVATAR_DIMENSION ?>" class="avatar" src="<%= avatarSrc %>"/>
 		<span class="time"><%= timeStamp %></span>
 		<span class="username"><%= name %></span>
-		<span class="message me-message">* <%= name %> <%= text %></span>
+		<span class="message me-message"><span class="me-username">* <span><%= name %></span></span> <%= text %></span>
 	</script>
 	<script type='text/template' id='inline-alert-template'>
 		<%= text %>

--- a/extensions/wikia/Chat2/templates/Chat_Index.php
+++ b/extensions/wikia/Chat2/templates/Chat_Index.php
@@ -15,7 +15,7 @@
 
 
 	<!-- JS -->
-	<script type="text/javascript" src="/load.php?lang=en&mode=articles&articles=MediaWiki%3AChat.css%7CUser%3A<?php echo $wgUserName; ?>%2Fchat.css&only=styles"></script>
+	<script type="text/javascript" src="/load.php?lang=en&mode=articles&articles=MediaWiki%3AChat.js%7CUser%3A<?php echo $wgUserName; ?>%2Fchat.js&only=styles"></script>
 	<?php
 		$srcs = F::build('AssetsManager',array(),'getInstance')->getGroupCommonURL('oasis_blocking', array());
 	?>

--- a/extensions/wikia/Chat2/templates/Chat_Index.php
+++ b/extensions/wikia/Chat2/templates/Chat_Index.php
@@ -11,8 +11,11 @@
 
 	<!-- CSS -->
 	<link rel="stylesheet" href="<?= AssetsManager::getInstance()->getSassCommonURL('/extensions/wikia/Chat2/css/Chat.scss')?>">
+	<link rel="stylesheet" href="/load.php?lang=en&mode=articles&articles=MediaWiki%3AChat.css%7CUser%3A<?php echo $wgUserName; ?>%2Fchat.css&only=styles">
+
 
 	<!-- JS -->
+	<script type="text/javascript" src="/load.php?lang=en&mode=articles&articles=MediaWiki%3AChat.css%7CUser%3A<?php echo $wgUserName; ?>%2Fchat.css&only=styles"></script>
 	<?php
 		$srcs = F::build('AssetsManager',array(),'getInstance')->getGroupCommonURL('oasis_blocking', array());
 	?>

--- a/extensions/wikia/Chat2/templates/Chat_Index.php
+++ b/extensions/wikia/Chat2/templates/Chat_Index.php
@@ -13,9 +13,8 @@
 	<link rel="stylesheet" href="<?= AssetsManager::getInstance()->getSassCommonURL('/extensions/wikia/Chat2/css/Chat.scss')?>">
 	<link rel="stylesheet" href="/load.php?lang=en&mode=articles&articles=MediaWiki%3AChat.css%7CUser%3A<?php echo $wgUserName; ?>%2Fchat.css&only=styles">
 
-
 	<!-- JS -->
-	<script type="text/javascript" src="/load.php?lang=en&mode=articles&articles=MediaWiki%3AChat.js%7CUser%3A<?php echo $wgUserName; ?>%2Fchat.js&only=styles"></script>
+	<script type="text/javascript" src="/load.php?lang=en&mode=articles&articles=MediaWiki%3AChat.js%7CUser%3A<?php echo $wgUserName; ?>%2Fchat.js&only=scripts"></script>
 	<?php
 		$srcs = F::build('AssetsManager',array(),'getInstance')->getGroupCommonURL('oasis_blocking', array());
 	?>

--- a/extensions/wikia/Chat2/templates/Chat_Index.php
+++ b/extensions/wikia/Chat2/templates/Chat_Index.php
@@ -14,7 +14,6 @@
 	<link rel="stylesheet" href="/load.php?lang=en&mode=articles&articles=MediaWiki%3AChat.css%7CUser%3A<?php echo $wgUserName; ?>%2Fchat.css&only=styles">
 
 	<!-- JS -->
-	<script type="text/javascript" src="/load.php?lang=en&mode=articles&articles=MediaWiki%3AChat.js%7CUser%3A<?php echo $wgUserName; ?>%2Fchat.js&only=scripts"></script>
 	<?php
 		$srcs = F::build('AssetsManager',array(),'getInstance')->getGroupCommonURL('oasis_blocking', array());
 	?>
@@ -133,5 +132,6 @@
 		<script src="<?php echo $src ?>"></script>
 	<?php endforeach;?>
 	<script src="<?php echo $jsMessagePackagesUrl ?>"></script>
+	<script type="text/javascript" src="/load.php?lang=en&mode=articles&articles=MediaWiki%3AChat.js%7CUser%3A<?php echo $wgUserName; ?>%2Fchat.js&only=scripts"></script>
 </body>
 </html>


### PR DESCRIPTION
In these commits I've added an import to Chat.js and Chat.css files so that it is way easier to make changes to the chat interface any way the user wants. Having this built in the code by default is much easier than having to use the workaround to add the imports. This would make it a lot easier to help other wikis install things to their chat too, since they won't have to follow the steps to install the workaround to give them access to the scripts.

This also includes a small change to the /me command, adding a span tag around the username so that it is possible to change the css there. This would be useful to have when you want to style the usernames a certain way.
