### PR TITLE
VID-370 - Keep Wall code contained

### DIFF
--- a/extensions/wikia/FilePage/FilePageController.class.php
+++ b/extensions/wikia/FilePage/FilePageController.class.php
@@ -436,8 +436,6 @@ class FilePageController extends WikiaController {
 				// Eliminate the superfluous 'summary' key
 				$extraData = $extraData['summary'];
 
-				$whHelper = new WallHooksHelper;
-
 				// Loop with indexes so we can change $data in place
 				for ($i = 0; $i < count($articles); $i++) {
 					$info = $articles[$i];

--- a/extensions/wikia/FilePage/FilePageController.class.php
+++ b/extensions/wikia/FilePage/FilePageController.class.php
@@ -443,24 +443,13 @@ class FilePageController extends WikiaController {
 					$info = $articles[$i];
 					$extraInfo = $extraData[$info['id']];
 
-					$ns = $info['namespace_id'];
+					// Let the wall code clean up any links to the user wall or forums
+					wfRunHooks( 'FormatForumLinks', array( &$extraInfo, $info['title'], $info['namespace_id']) );
 
-					// Handle message wall and forum board links
-					if ( isset($ns) && in_array($ns, array(NS_USER_WALL_MESSAGE, NS_WIKIA_FORUM_BOARD_THREAD)) ) {
-						$row['page_namespace'] = $info['namespace_id'];
-						$row['page_title'] = $info['title'];
-						$opts = $whHelper->getMessageOptions( null, (object)$row );
-
-						// Beautify the title
-						$extraInfo['titleText'] = $opts['articleTitleTxt'];
-						$extraInfo['url'] = $opts['articleFullUrl'];
-					}
 					// Clean up any type of comment on any article page
-					else {
-						$cleanedText = preg_replace('/\/@comment-.+-[0-9]+$/', '', $extraInfo['titleText']);
-						if ( !empty($cleanedText) ) {
-							$extraInfo['titleText'] = $cleanedText;
-						}
+					$cleanedText = preg_replace('/\/@comment-.+-[0-9]+$/', '', $extraInfo['titleText']);
+					if ( !empty($cleanedText) ) {
+						$extraInfo['titleText'] = $cleanedText;
 					}
 
 					$articles[$i] = array_merge($info, $extraInfo);

--- a/extensions/wikia/Wall/Wall.setup.php
+++ b/extensions/wikia/Wall/Wall.setup.php
@@ -157,7 +157,7 @@ $app->registerHook( 'HAWelcomeGetPrefixText', 'WallHooksHelper', 'onHAWelcomeGet
 $app->registerHook( 'SkinTemplateToolboxEnd', 'WallHooksHelper', 'onBuildMonobookToolbox');
 
 // Hook for code that wants a beautified title and URL given the not very readable Wall/Forum title
-$app->registerHook( 'FormatForumLinks', 'WallHooksHelper', 'onFormatForumLinks');
+$wgHooks['FormatForumLinks'][] = 'WallHooksHelper::onFormatForumLinks';
 
 F::build('JSMessages')->registerPackage('Wall', array(
 	'wall-notifications',

--- a/extensions/wikia/Wall/Wall.setup.php
+++ b/extensions/wikia/Wall/Wall.setup.php
@@ -156,6 +156,9 @@ $app->registerHook( 'HAWelcomeGetPrefixText', 'WallHooksHelper', 'onHAWelcomeGet
 // Monobook toolbar links
 $app->registerHook( 'SkinTemplateToolboxEnd', 'WallHooksHelper', 'onBuildMonobookToolbox');
 
+// Hook for code that wants a beautified title and URL given the not very readable Wall/Forum title
+$app->registerHook( 'FormatForumLinks', 'WallHooksHelper', 'onFormatForumLinks');
+
 F::build('JSMessages')->registerPackage('Wall', array(
 	'wall-notifications',
 	'wall-notifications-reminder',

--- a/extensions/wikia/Wall/WallHooksHelper.class.php
+++ b/extensions/wikia/Wall/WallHooksHelper.class.php
@@ -2148,6 +2148,15 @@ class WallHooksHelper {
 		return true;
 	}
 
+	/**
+	 * Fills the $info parameter with a human readable article title and a URL that links directly to
+	 * a wall or forum post
+	 *
+	 * @param $info - Associative array to hold the result
+	 * @param $title - The article title of the wall/forum post
+	 * @param $ns - The namespace of the wall/forum post
+	 * @return bool - The status of the hook
+	 */
 	public static function onFormatForumLinks( &$info, $title, $ns ) {
 
 		// Handle message wall and forum board links

--- a/extensions/wikia/Wall/WallHooksHelper.class.php
+++ b/extensions/wikia/Wall/WallHooksHelper.class.php
@@ -2147,4 +2147,21 @@ class WallHooksHelper {
 		echo '<li id="t-log">' . Linker::link(SpecialPage::getTitleFor('Log'), wfMsgHtml('log'), array(), array('user' => $user->getName())) . '</li>';
 		return true;
 	}
+
+	public static function onFormatForumLinks( &$info, $title, $ns ) {
+
+		// Handle message wall and forum board links
+		if ( isset($ns) && in_array($ns, array(NS_USER_WALL_MESSAGE, NS_WIKIA_FORUM_BOARD_THREAD)) ) {
+			// The method expects a DB result row. Set the data and then pass it as an object
+			$row['page_namespace'] = $ns;
+			$row['page_title'] = $title;
+			$opts = WallHelper::getWallTitleData( null, (object)$row );
+
+			// Set the human readable title and a link
+			$info['titleText'] = $opts['articleTitleTxt'];
+			$info['url'] = $opts['articleFullUrl'];
+		}
+
+		return true;
+	}
 }


### PR DESCRIPTION
Use a hook to call out to wall code.  When Wall/Forum isn't loaded, the hook doesn't fire and nothing is converted
