### PR TITLE
PLA-411 implement a reinitialization scheme for batch reindex calls

### DIFF
--- a/extensions/wikia/Search/classes/IndexService/AbstractService.php
+++ b/extensions/wikia/Search/classes/IndexService/AbstractService.php
@@ -97,7 +97,7 @@ abstract class AbstractService
 				continue;
 			}
 			try {
-				$response = $this->execute();
+				$response = $this->getResponse();
 				$this->processedDocIds[] = $this->getCurrentDocumentId();
 				if (! empty( $response ) ) {
 				    $documents[] = $this->getJsonDocumentFromResponse( $response );
@@ -144,6 +144,30 @@ abstract class AbstractService
 			$this->service = new MediaWikiService;
 		}
 		return $this->service;
+	}
+	
+
+	/**
+	 * Hook for resetting any state specific to a single page
+	 * @return \Wikia\Search\IndexService\AbstractService
+	 */
+	protected function reinitialize() {
+		return $this;
+	}
+	
+	/**
+	 * Execute with hook to reinitialize
+	 * @return \Wikia\Search\IndexService\AbstractService
+	 */
+	protected function getResponse() {
+		try {
+			$response = $this->execute();
+		} catch ( \Exception $e ) {
+			$this->reinitialize();
+			throw $e;
+		}
+		$this->reinitialize();
+		return $response;
 	}
 	
 }

--- a/extensions/wikia/Search/classes/IndexService/All.php
+++ b/extensions/wikia/Search/classes/IndexService/All.php
@@ -44,7 +44,7 @@ class All extends AbstractService
 				$service = new $serviceName();
 				$this->services[$serviceName] = $service;
 			}
-			$subResult = $service->setPageId( $this->currentPageId )->execute();
+			$subResult = $service->setPageId( $this->currentPageId )->getResponse();
 			if ( is_array( $subResult ) ) {
     			$result = array_merge( $result, $subResult );
 			}

--- a/extensions/wikia/Search/classes/IndexService/DefaultContent.php
+++ b/extensions/wikia/Search/classes/IndexService/DefaultContent.php
@@ -90,6 +90,14 @@ class DefaultContent extends AbstractService
 	}
 	
 	/**
+	 * @return Wikia\Search\IndexService\DefaultContent
+	 */
+	protected function reinitialize() {
+		$this->nolang_txt = [];
+		return $this;
+	}
+	
+	/**
 	 * Provides an array of outbound links from the current document to other doc IDs.
 	 * Filters out self-links (e.g. Edit and the like)
 	 * @param int $wid

--- a/extensions/wikia/Search/classes/Test/IndexService/AbstractServiceTest.php
+++ b/extensions/wikia/Search/classes/Test/IndexService/AbstractServiceTest.php
@@ -98,8 +98,8 @@ class AbstractServiceTest extends BaseTest
 	public function testGetResponseForPageIdsSuccess() {
 		$service = $this->service
 		                ->disableOriginalConstructor()
-		                ->setMethods( array( 'getJsonDocumentFromResponse', 'execute', 'getCurrentDocumentId' ) )
-		                ->getMock();
+		                ->setMethods( array( 'getJsonDocumentFromResponse', 'getResponse', 'getCurrentDocumentId' ) )
+		                ->getMockForAbstractClass();
 		
 		$mwservice = $this->getMockBuilder( '\Wikia\Search\MediaWikiService' )
 		                  ->disableOriginalConstructor()
@@ -122,7 +122,7 @@ class AbstractServiceTest extends BaseTest
 		;
 		$service
 		    ->expects( $this->any() )
-		    ->method ( 'execute' )
+		    ->method ( 'getResponse' )
 		    ->will   ( $this->returnValue( $executeResponse ) )
 		;
 		$service
@@ -149,8 +149,8 @@ class AbstractServiceTest extends BaseTest
 	public function testGetResponseForPageIdsSkipRepeats() {
 		$service = $this->service
 		                ->disableOriginalConstructor()
-		                ->setMethods( array( 'getJsonDocumentFromResponse', 'execute', 'getCurrentDocumentId' ) )
-		                ->getMock();
+		                ->setMethods( array( 'getJsonDocumentFromResponse', 'getResponse', 'getCurrentDocumentId' ) )
+		                ->getMockForAbstractClass();
 		
 		$mwservice = $this->getMockBuilder( '\Wikia\Search\MediaWikiService' )
 		                  ->disableOriginalConstructor()
@@ -176,7 +176,7 @@ class AbstractServiceTest extends BaseTest
 		;
 		$service
 		    ->expects( $this->never() )
-		    ->method ( 'execute' )
+		    ->method ( 'getResponse' )
 		;
 
 		$reflIf = new ReflectionProperty( '\Wikia\Search\IndexService\AbstractService', 'service' );
@@ -197,8 +197,8 @@ class AbstractServiceTest extends BaseTest
 	public function testGetResponseForPageIdsError() {
 		$service = $this->service
 		                ->disableOriginalConstructor()
-		                ->setMethods( array( 'getJsonDocumentFromResponse', 'execute', 'getCurrentDocumentId' ) )
-		                ->getMock();
+		                ->setMethods( array( 'getJsonDocumentFromResponse', 'getResponse', 'getCurrentDocumentId' ) )
+		                ->getMockForAbstractClass();
 		
 		$mwservice = $this->getMockBuilder( '\Wikia\Search\MediaWikiService' )
 		                  ->disableOriginalConstructor()
@@ -219,7 +219,7 @@ class AbstractServiceTest extends BaseTest
 		;
 		$service
 		    ->expects( $this->any() )
-		    ->method ( 'execute' )
+		    ->method ( 'getResponse' )
 		    ->will   ( $this->throwException( $exception ) )
 		;
 		$reflIf = new ReflectionProperty( '\Wikia\Search\IndexService\AbstractService', 'service' );
@@ -239,8 +239,8 @@ class AbstractServiceTest extends BaseTest
 	public function testGetResponseForPageIdsNotExists() {
 		$service = $this->service
 		                ->disableOriginalConstructor()
-		                ->setMethods( array( 'getJsonDocumentFromResponse', 'execute', 'getCurrentDocumentId' ) )
-		                ->getMock();
+		                ->setMethods( array( 'getJsonDocumentFromResponse', 'getResponse', 'getCurrentDocumentId' ) )
+		                ->getMockForAbstractClass();
 		
 		$mwservice = $this->getMockBuilder( '\Wikia\Search\MediaWikiService' )
 		                  ->disableOriginalConstructor()
@@ -296,5 +296,64 @@ class AbstractServiceTest extends BaseTest
 				$service
 		);
 		
+	}
+	
+	/**
+	 * @covers Wikia\Search\IndexService\AbstractService::getResponse
+	 */
+	public function testGetResponseWorks() {
+		$service = $this->service
+		                ->disableOriginalConstructor()
+		                ->setMethods( array( 'execute', 'reinitialize' ) )
+		                ->getMockForAbstractClass();
+		$get = new \ReflectionMethod( $service, 'getResponse' );
+		$get->setAccessible( true );
+		$response = [ 1, 2, 3, 4, 5 ];
+		$service
+		    ->expects( $this->once() )
+		    ->method ( "execute" )
+		    ->will   ( $this->returnValue( $response ) )
+		;
+		$service
+		    ->expects( $this->once() )
+		    ->method ( 'reinitialize' )
+		;
+		$this->assertEquals(
+				$response,
+				$get->invoke( $service )
+		);
+	}
+	
+	/**
+	 * @covers Wikia\Search\IndexService\AbstractService::getResponse
+	 */
+	public function testGetResponseBreaks() {
+		$service = $this->service
+		                ->disableOriginalConstructor()
+		                ->setMethods( array( 'execute', 'reinitialize' ) )
+		                ->getMockForAbstractClass();
+		$exception = $this->getMockBuilder( 'Exception' )
+		                  ->disableOriginalConstructor()
+		                  ->getMock();
+		$get = new \ReflectionMethod( $service, 'getResponse' );
+		$get->setAccessible( true );
+		$response = [ 1, 2, 3, 4, 5 ];
+		$service
+		    ->expects( $this->once() )
+		    ->method ( "execute" )
+		    ->will   ( $this->throwException( $exception ) )
+		;
+		$service
+		    ->expects( $this->once() )
+		    ->method ( 'reinitialize' )
+		;
+		try {
+			$get->invoke( $service );
+		} catch ( \Exception $e ) { }
+		$this->assertInstanceOf(
+				'Exception',
+				$e,
+				'A failed call to execute should re-throw the exception after reinitializing'
+		);
 	}
 }

--- a/extensions/wikia/Search/classes/Test/IndexService/DefaultContentTest.php
+++ b/extensions/wikia/Search/classes/Test/IndexService/DefaultContentTest.php
@@ -693,4 +693,27 @@ ENDIT;
 				$get->invoke( $service )
 		);
 	}
+	
+	/**
+	 * @covers Wikia\Search\IndexService\DefaultContent::reinitialize
+	 */
+	public function testReinitialize() {
+		$service = $this->getMockBuilder( 'Wikia\Search\IndexService\DefaultContent' )
+		                ->disableOriginalConstructor()
+		                ->setMethods( null )
+		                ->getMock();
+		$nolang = new ReflectionProperty( $service, 'nolang_txt' );
+		$nolang->setAccessible( true );
+		$nolang->setValue( $service, [ 1, 2, 3, 4, 5 ] );
+		$reinitialize = new ReflectionMethod( $service, 'reinitialize' );
+		$reinitialize->setAccessible( true );
+		$this->assertEquals(
+				$service,
+				$reinitialize->invoke( $service )
+		);
+		$this->assertAttributeEmpty(
+				'nolang_txt',
+				$service
+		);
+	}
 }


### PR DESCRIPTION
Batch indexing is polluting the nolang_txt fields with values from previously parsed documents because of the stack approach we're using in Wikia\Search\IndexService\DefaultContent. Since we accidentally introduced leaky state between documents, we need a way to reinitialize state. So that's what this does.
