### PR TITLE
Wall: remove wikia::log call that's no longer needed

### DIFF
--- a/extensions/wikia/ArticleComments/classes/CommentsIndex.class.php
+++ b/extensions/wikia/ArticleComments/classes/CommentsIndex.class.php
@@ -196,7 +196,6 @@ class CommentsIndex extends WikiaModel {
 
 		//Just for transition time
 		if(empty($this->wg->EnableWallEngine) || !WallHelper::isWallNamespace($this->namespace) ) {
-			Wikia::log(__FUNCTION__, __LINE__, "WALL_COMMENTS_INDEX_ERROR no wall?", true);
 			wfProfileOut( __METHOD__ );
 			return false;
 		}


### PR DESCRIPTION
Remove log call that's executed very often but is no longer needed for wall debugging.
