### PR TITLE
Make AbuseFilter's examine table legible with a dark theme

### DIFF
--- a/extensions/AbuseFilter/modules/ext.abuseFilter.css
+++ b/extensions/AbuseFilter/modules/ext.abuseFilter.css
@@ -134,3 +134,14 @@ table.mw-abusefilter-diff th {
 .client-js #mw-abusefilter-export {
     display: none;
 }
+
+/* Wikia change - begin */
+/* Make the table legible in dark themes */
+.oasis-dark-theme table.mw-abuselog-details {
+	background: none repeat scroll 0 0 transparent;
+}
+
+.oasis-dark-theme table.mw-abuselog-details th {
+	background: none repeat scroll 0 0 #000000;
+}
+/* Wikia change - end */


### PR DESCRIPTION
Currently, the ext.abuseFilter.css module used by the extension enforces colorization from Wikipedia, which makes for hard-to-read examine tables if the wiki has a dark theme&mdash;see example at http://codfanfic.wikia.com/wiki/Special:AbuseFilter/examine/36819 . This change resets the styling if the Oasis theme is dark.
