### PR TITLE
removed nolang_txt queryfield from all test profiles

### DIFF
--- a/extensions/wikia/Search/classes/TestProfile/Base.php
+++ b/extensions/wikia/Search/classes/TestProfile/Base.php
@@ -26,7 +26,6 @@ class Base
 			'html'              => 5,
 			'redirect_titles'   => 50,
 			'categories'        => 25,
-			'nolang_txt'        => 10,
 			'backlinks_txt'     => 25,
 			];
 	

--- a/extensions/wikia/Search/classes/TestProfile/Group106.php
+++ b/extensions/wikia/Search/classes/TestProfile/Group106.php
@@ -20,7 +20,6 @@ class Group106 extends Base
 			'html'              => 5,
 			'redirect_titles'   => 50,
 			'categories'        => 25,
-			'nolang_txt'        => 10,
 			'headings'          => 50
 			];
 }

--- a/extensions/wikia/Search/classes/TestProfile/Group107.php
+++ b/extensions/wikia/Search/classes/TestProfile/Group107.php
@@ -20,7 +20,6 @@ class Group107 extends Base
 			'html'              => 5,
 			'redirect_titles'   => 50,
 			'categories'        => 150,
-			'nolang_txt'        => 10,
 			'headings'          => 50
 			];
 }

--- a/extensions/wikia/Search/classes/TestProfile/GroupA.php
+++ b/extensions/wikia/Search/classes/TestProfile/GroupA.php
@@ -19,7 +19,6 @@ class GroupA extends Base
 			'title'             => 100,
 			'html'              => 80,
 			'redirect_titles'   => 50,
-			'nolang_txt'        => 10,
 			'backlinks_txt'     => 120,
 			];
 }

--- a/extensions/wikia/Search/classes/TestProfile/GroupB.php
+++ b/extensions/wikia/Search/classes/TestProfile/GroupB.php
@@ -20,7 +20,6 @@ class GroupB extends Base
 			'html'              => 5,
 			'redirect_titles'   => 50,
 			'categories'        => 25,
-			'nolang_txt'        => 10,
 			'headings'          => 50
 			];
 }


### PR DESCRIPTION
Temporarily disables the nolang_txt queryfield until reindexing unpollutes it.
