### PR TITLE
PLA-415 Solr query word limit

### DIFF
--- a/extensions/wikia/Search/classes/Query/Select.php
+++ b/extensions/wikia/Search/classes/Query/Select.php
@@ -77,9 +77,14 @@ class Select
 	
 	/**
 	 * Returns the value we use when querying Solr, with the appropriate special characters escaped.
+	 * Word limit allows us to optionally set a maximum number of words in a query
+	 * @TODO applying word limit here is clumsy at best and suggests it's about time we implement some class abstraction
+	 * and hierarchy around what kinds of queries we're using where. this would be good for an actual edismax query, not so 
+	 * great for video suggest or direct solr queries, for instance.
+	 * @param null|int $wordLimit
 	 * @return string
 	 */
-	public function getSolrQuery() {
+	public function getSolrQuery( $wordLimit = null ) {
 		$query = $this->getSanitizedQuery();
 		if (! $this->namespaceChecked ) {
 			$this->initializeNamespaceData();
@@ -93,7 +98,16 @@ class Select
 		$query = preg_replace( '/(\d+)([a-zA-Z]+)/i', '$1 $2', $query );
 	
 		// escape all lucene special characters: + - && || ! ( ) { } [ ] ^ " ~ * ? : \ (RT #25482)
-		return (new Solarium_Query_Helper)->escapeTerm( $query,  ENT_COMPAT, 'UTF-8' );
+		$query = (new Solarium_Query_Helper)->escapeTerm( $query,  ENT_COMPAT, 'UTF-8' );
+		
+		if (! empty( $wordLimit ) ) {
+			// this is actually a micro-optimization. 
+			// i could just as easily apply no preg_split limit and impose the limit on array_slice.
+			$split = preg_split( '/\s+/', $query, $wordLimit + 1 );
+			$query = implode( ' ', array_slice( $split, 0, -1 ) );
+		} 
+		
+		return $query;
 	}
 	
 	/**

--- a/extensions/wikia/Search/classes/QueryService/Select/AbstractSelect.php
+++ b/extensions/wikia/Search/classes/QueryService/Select/AbstractSelect.php
@@ -173,7 +173,7 @@ abstract class AbstractSelect
 	 * @return string
 	 */
 	protected function getFormulatedQuery() {
-		return sprintf( '+(%s) AND (%s)', $this->getQueryClausesString(), $this->config->getQuery()->getSolrQuery() );
+		return sprintf( '+(%s) AND (%s)', $this->getQueryClausesString(), $this->config->getQuery()->getSolrQuery( 10 ) );
 	}
 	
 	/**

--- a/extensions/wikia/Search/classes/Test/Query/SelectTest.php
+++ b/extensions/wikia/Search/classes/Test/Query/SelectTest.php
@@ -153,4 +153,17 @@ class SelectTest extends BaseTest
 				$query->getSolrQuery()
 		);
 	}
+	
+	public function testGetSolrQueryWithWordLimit() {
+		$query = <<<YEEZY
+Uh:my mind move like a Tron bike
+Uh, pop a wheelie on the Zeitgeist
+Uh, I'm finna start a new movement
+YEEZY;
+		$q = new Query( $query );
+		$this->assertEquals(
+				'Uh\:my mind move like a Tron bike Uh, pop a',
+				$q->getSolrQuery( 10 )
+		);
+	}
 }

--- a/extensions/wikia/Search/classes/Test/QueryService/Select/AbstractSelectTest.php
+++ b/extensions/wikia/Search/classes/Test/QueryService/Select/AbstractSelectTest.php
@@ -1087,6 +1087,7 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 		$mockQuery
 		    ->expects( $this->once() )
 		    ->method ( 'getSolrQuery' )
+		    ->with   ( 10 )
 		    ->will   ( $this->returnValue( 'bar' ) )
 		;
 		$method = new ReflectionMethod( 'Wikia\Search\QueryService\Select\OnWiki', 'getFormulatedQuery' );


### PR DESCRIPTION
Applies a ten-word limit to solr queries to mitigate edge-case queries that negatively affect performance
