### PR TITLE
added chack for null revision

### DIFF
--- a/extensions/wikia/HAWelcome/HAWelcome.php
+++ b/extensions/wikia/HAWelcome/HAWelcome.php
@@ -117,6 +117,13 @@ class HAWelcomeJob extends Job {
 	 */
 	public static function onArticleSaveComplete( &$oArticle, &$oUser, $sText, $sSummary, $iMinorEdit, $nWatchThis, $nSectionAnchor, &$iFlags, $oRevision, $oStatus, $iBaseRevId ) {
 		wfProfileIn( __METHOD__ );
+
+		if ( is_null( $oRevision ) ) {
+			// if oRevision is null, that means we're dealing with a null edit (no content change)
+			// and therefore we don't have to welcome anybody
+			return true;
+		}
+
 		/** @global Boolean Show PHP Notices. Set via WikiFactory. */
 		global $wgHAWelcomeNotices;
 		/** @type Interget Store the original error reporting level. */


### PR DESCRIPTION
this prevents a fatal when the edit is a null revision (no content changes)
