### PR TITLE
fixing jsmessages to allow some parsing; reducing the amount of VET mess...

### DIFF
--- a/extensions/wikia/JSMessages/JSMessages.class.php
+++ b/extensions/wikia/JSMessages/JSMessages.class.php
@@ -112,10 +112,9 @@ class JSMessages {
 				var_dump($msg);
 			}
 			if (substr($msg, 0, $patternLen) === $pattern) {
-				$ret[$msg] = wfmsgExt($msg, array('language' => $langCode));
+				$ret[$msg] = wfMessage($msg)->inLanguage($langCode)->parse();
 			}
 		}
-
 
 		wfProfileOut($fname);
 		return $ret;
@@ -192,11 +191,10 @@ class JSMessages {
 				}
 				// single message
 				else {
-					$msg = wfMsgGetKey($message, true /* $useDB */);
+					$msg = wfMessage($message)->exists();
 
-					// check for not existing message
-					if ($msg == htmlspecialchars("<{$message}>")) {
-						$msg = false;
+					if ( $msg ) {
+						$msg = wfMessage($message)->parse();
 					}
 
 					$ret[$message] = $msg;

--- a/extensions/wikia/JSMessages/JSMessages.class.php
+++ b/extensions/wikia/JSMessages/JSMessages.class.php
@@ -104,15 +104,15 @@ class JSMessages {
 		if($lang instanceof StubUserLang) {
 			$lang = $lang->_newObject();
 		}
-		$messageKeys = self::getAllMessageKeys($lang);
+		$messageKeys = self::getAllMessageKeys( $lang );
 
 		$ret = array();
-		foreach($messageKeys as $msg) {
+		foreach( $messageKeys as $msg ) {
 			if ( is_array( $msg ) ) {
-				var_dump($msg);
+				var_dump( $msg );
 			}
-			if (substr($msg, 0, $patternLen) === $pattern) {
-				$ret[$msg] = wfMessage($msg)->inLanguage($langCode)->parse();
+			if ( substr( $msg, 0, $patternLen ) === $pattern ) {
+				$ret[$msg] = wfMessage( $msg )->inLanguage( $langCode )->parse();
 			}
 		}
 
@@ -191,13 +191,13 @@ class JSMessages {
 				}
 				// single message
 				else {
-					$msg = wfMessage($message)->exists();
+					$msg = wfMessage( $message )->exists();
 
 					if ( $msg ) {
-						$msg = wfMessage($message)->parse();
+						$msg = wfMessage( $message )->parse();
 					}
 
-					$ret[$message] = $msg;
+					$ret[ $message ] = $msg;
 				}
 			}
 		}

--- a/extensions/wikia/VideoEmbedTool/VideoEmbedTool_setup.php
+++ b/extensions/wikia/VideoEmbedTool/VideoEmbedTool_setup.php
@@ -39,7 +39,11 @@ extAddSpecialPage( dirname(__FILE__) . '/WikiaVideoAdd_body.php', 'WikiaVideoAdd
 $wgExtensionMessagesFiles['VideoEmbedTool'] = $dir.'/VideoEmbedTool.i18n.php';
 $wgHooks['EditPage::showEditForm:initial2'][] = 'VETSetup';
 
-JSMessages::registerPackage('VideoEmbedTool', array('vet-*'));
+JSMessages::registerPackage('VideoEmbedTool', array(
+	'vet-warn2',
+	'vet-warn3',
+	'vet-insert-error',
+));
 JSMessages::enqueuePackage('VideoEmbedTool', JSMessages::EXTERNAL);
 
 


### PR DESCRIPTION
...ages sent to jsmessages

This adds wikitext to html parsing for all messages sent to JSMessage, so we'll now be able to have messages like this used in $.msg():

Some '''bold''' and ''italic'' text that's a [[link]]

Since it's impossible to know which messages will need parsing and which won't, I'm using parse() for all of them.  

I also noticed that there were 89 extra VET messages being loaded unnecessarily with JSMessages on every page.  Now we're only loading the necessary 3. 
