### PR TITLE
UncategorizedPages: corrected case

### DIFF
--- a/includes/SpecialPageFactory.php
+++ b/includes/SpecialPageFactory.php
@@ -47,7 +47,7 @@ class SpecialPageFactory {
 		'Shortpages'                => 'ShortpagesPage',
 		'Uncategorizedcategories'   => 'UncategorizedcategoriesPage',
 		'Uncategorizedimages'       => 'UncategorizedimagesPage',
-		'Uncategorizedpages'        => 'UncategorizedpagesPage',
+		'Uncategorizedpages'        => 'UncategorizedPagesPage',
 		'Uncategorizedtemplates'    => 'UncategorizedtemplatesPage',
 		'Unusedcategories'          => 'UnusedcategoriesPage',
 		'Unusedimages'              => 'UnusedimagesPage',


### PR DESCRIPTION
In MW autoloader "case correcting" behavior was disabled as it costs performance when using more then one autoloader. One case was not properly addresed - special page UncategorizedPages. Correcting this now.
