### PR TITLE
WikiaHomePageHelper: fixing image serving params

### DIFF
--- a/extensions/wikia/CityVisualization/helpers/WikiaHomePageHelper.class.php
+++ b/extensions/wikia/CityVisualization/helpers/WikiaHomePageHelper.class.php
@@ -604,8 +604,7 @@ class WikiaHomePageHelper extends WikiaModel {
 			}
 
 			if (!empty($originalHeight) && !empty($originalWidth)) {
-				$imageServingParams = $this->getImageServingParamsForResize($requestedWidth, $requestedHeight, $originalWidth, $originalHeight);
-				$imageServing = $this->getImageServingWithParams($imageServingParams);
+				$imageServing = $this->getImageServingForResize($requestedWidth, $requestedHeight, $originalWidth, $originalHeight);
 				$imageUrl = $imageServing->getUrl($file, $originalWidth, $originalHeight);
 			} else {
 				$imageUrl = $this->wg->blankImgUrl;
@@ -647,7 +646,8 @@ class WikiaHomePageHelper extends WikiaModel {
 		return $imageId;
 	}
 
-	public function getImageServingWithParams($params) {
+	public function getImageServingForResize($requestedWidth, $requestedHeight, $originalWidth, $originalHeight) {
+		$params = $this->getImageServingParamsForResize($requestedWidth, $requestedHeight, $originalWidth, $originalHeight);
 		return new ImageServing($params[0], $params[1], $params[2]);
 	}
 

--- a/extensions/wikia/CityVisualization/helpers/WikiaHomePageHelper.class.php
+++ b/extensions/wikia/CityVisualization/helpers/WikiaHomePageHelper.class.php
@@ -605,7 +605,7 @@ class WikiaHomePageHelper extends WikiaModel {
 
 			if (!empty($originalHeight) && !empty($originalWidth)) {
 				$imageServingParams = $this->getImageServingParamsForResize($requestedWidth, $requestedHeight, $originalWidth, $originalHeight);
-				$imageServing = new ImageServing($imageServingParams);
+				$imageServing = $this->getImageServingWithParams($imageServingParams);
 				$imageUrl = $imageServing->getUrl($file, $originalWidth, $originalHeight);
 			} else {
 				$imageUrl = $this->wg->blankImgUrl;
@@ -645,6 +645,10 @@ class WikiaHomePageHelper extends WikiaModel {
 
 		wfProfileOut(__METHOD__);
 		return $imageId;
+	}
+
+	public function getImageServingWithParams($params) {
+		return new ImageServing($params[0], $params[1], $params[2]);
 	}
 
 	public function getImageServingParamsForResize($requestedWidth, $requestedHeight, $originalWidth, $originalHeight) {


### PR DESCRIPTION
back-to-roots branch introduced bug in WikiaHomePageHelper when initializing ImageServing. Fixing.
