### PR TITLE
DAR-958 Removed class for grouped recent changes.

### DIFF
--- a/extensions/wikia/WikiaRecentChangesBlockHandler/templates/RecentChangesHeaderBlock.tmpl.php
+++ b/extensions/wikia/WikiaRecentChangesBlockHandler/templates/RecentChangesHeaderBlock.tmpl.php
@@ -1,7 +1,7 @@
 <table class="mw-collapsible mw-collapsed mw-enhanced-rc <?= Sanitizer::escapeClass( 'mw-changeslist-ns' . $title->getNamespace() . '-' . $title->getText() ) ?>">
 	<tr>
 		<td>
-			<span class="mw-collapsible-toggle mw-collapsible-toggle-collapsed">
+			<span class="mw-collapsible-toggle">
 				<span class="mw-rc-openarrow">
 					<a title="<?= htmlspecialchars( wfMsg( 'rc-enhanced-expand' ) )?>" href="#">
 						<img width="12" height="12" title="<?=htmlspecialchars( wfMsg( 'rc-enhanced-expand' ) )?>" alt="+" src="<?= $wgStylePath ?>/common/images/Arr_r.png">


### PR DESCRIPTION
These blocks are collapsed by JavaScript in this file: [/resources/jquery/jquery.makeCollapsible.js](https://github.com/Wikia/app/blob/dev/resources/jquery/jquery.makeCollapsible.js)

This change will make our custom stuff match how it is in core: [/includes/ChangesList.php](https://github.com/Wikia/app/blob/dev/includes/ChangesList.php)
