### PR TITLE
Vid 517 simplify ooyala ad tracking call

### DIFF
--- a/extensions/wikia/AdEngine/js/OoyalaTracking.js
+++ b/extensions/wikia/AdEngine/js/OoyalaTracking.js
@@ -9,16 +9,16 @@ require( ['wikia.window', 'wikia.tracker'], function( window, tracker ) {
 	 * Call like this from flite:
 	 * window.Wikia.fliteOoyalaTracker( 'video-identifier' );
 	 *
-	 * @param {String} video Identifier for video, either title or id
+	 * @param {String} id Identifier for video, either title or id
 	 */
 
-	wikia.fliteOoyalaTracker = function( video ) {
+	wikia.fliteOoyalaTracker = function( id ) {
 		tracker.track({
 			action: 'content-begin',
 			category: 'video-player-stats',
 			label: 'ooyala',
 			trackingMethod: 'internal',
-			title: video,
+			title: id,
 			clickSource: 'ad'
 		});
 	};

--- a/extensions/wikia/AdEngine/js/OoyalaTracking.js
+++ b/extensions/wikia/AdEngine/js/OoyalaTracking.js
@@ -18,7 +18,7 @@ require( ['wikia.window', 'wikia.tracker'], function( window, tracker ) {
 			category: 'video-player-stats',
 			label: 'ooyala',
 			trackingMethod: 'internal',
-			title: id || 'no id given',
+			title: id || '',
 			clickSource: 'ad'
 		});
 	};

--- a/extensions/wikia/AdEngine/js/OoyalaTracking.js
+++ b/extensions/wikia/AdEngine/js/OoyalaTracking.js
@@ -1,4 +1,3 @@
-alert('loaded');
 require( ['wikia.window', 'wikia.tracker'], function( window, tracker ) {
 	var wikia = window.Wikia = window.Wikia || {};
 

--- a/extensions/wikia/AdEngine/js/OoyalaTracking.js
+++ b/extensions/wikia/AdEngine/js/OoyalaTracking.js
@@ -1,0 +1,19 @@
+alert('loaded');
+require( ['wikia.window', 'wikia.tracker'], function( window, tracker ) {
+	var wikia = window.Wikia = window.Wikia || {};
+
+	/**
+	 * Add ability to tracking video views inside flite
+	 * @param {String} video Identifier for video, either title or id
+	 */
+	wikia.fliteOoyalaTracker = function( video ) {
+		tracker.track({
+			action: 'content-begin',
+			category: 'video-player-stats',
+			label: 'ooyala',
+			trackingMethod: 'internal',
+			title: video,
+			clickSource: 'ad'
+		});
+	};
+});

--- a/extensions/wikia/AdEngine/js/OoyalaTracking.js
+++ b/extensions/wikia/AdEngine/js/OoyalaTracking.js
@@ -18,7 +18,7 @@ require( ['wikia.window', 'wikia.tracker'], function( window, tracker ) {
 			category: 'video-player-stats',
 			label: 'ooyala',
 			trackingMethod: 'internal',
-			title: id,
+			title: id || 'no id given',
 			clickSource: 'ad'
 		});
 	};

--- a/extensions/wikia/AdEngine/js/OoyalaTracking.js
+++ b/extensions/wikia/AdEngine/js/OoyalaTracking.js
@@ -2,9 +2,16 @@ require( ['wikia.window', 'wikia.tracker'], function( window, tracker ) {
 	var wikia = window.Wikia = window.Wikia || {};
 
 	/**
-	 * Add ability to tracking video views inside flite
+	 * Hack to add ability to track video views inside flite.
+	 * Used specifically for the 'content-begin' event.
+	 * Jira ADEN-295 and VID-517
+	 *
+	 * Call like this from flite:
+	 * window.Wikia.fliteOoyalaTracker( 'video-identifier' );
+	 *
 	 * @param {String} video Identifier for video, either title or id
 	 */
+
 	wikia.fliteOoyalaTracker = function( video ) {
 		tracker.track({
 			action: 'content-begin',

--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -51,6 +51,7 @@ $config['adengine2_js'] = array(
 		'//extensions/wikia/AdEngine/js/AdEngine2.js',
 
 		// high prio
+		'//extensions/wikia/AdEngine/js/OoyalaTracking.js',
 		'//extensions/wikia/AdEngine/js/DartUrl.js',
 		'//extensions/wikia/AdEngine/js/WikiaDartHelper.js',
 		'//extensions/wikia/AdEngine/js/WikiaDartVideoHelper.js',


### PR DESCRIPTION
This code will be used by the ads team to allow video views to be tracked when ooyala videos are used in advertisements.  It will be copied and pasted into flite. 

@nefretete please have a look. 
