### PR TITLE
Mob 226 - WikisApi: support for multiple languages

### DIFF
--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -176,6 +176,7 @@ $wgAutoloadClasses[ 'BadRequestApiException'] =  "{$IP}/includes/wikia/api/ApiEx
 $wgAutoloadClasses[ 'OutOfRangeApiException'] =  "{$IP}/includes/wikia/api/ApiExceptions.php" ;
 $wgAutoloadClasses[ 'MissingParameterApiException'] =  "{$IP}/includes/wikia/api/ApiExceptions.php" ;
 $wgAutoloadClasses[ 'InvalidParameterApiException'] =  "{$IP}/includes/wikia/api/ApiExceptions.php" ;
+$wgAutoloadClasses[ 'LimitExceededApiException'] =  "{$IP}/includes/wikia/api/ApiExceptions.php" ;
 $wgAutoloadClasses[ 'NotFoundApiException'] =  "{$IP}/includes/wikia/api/ApiExceptions.php" ;
 
 /**

--- a/includes/wikia/api/ApiExceptions.php
+++ b/includes/wikia/api/ApiExceptions.php
@@ -25,7 +25,7 @@ class InvalidParameterApiException extends BadRequestException {
 }
 
 class LimitExceededApiException extends BadRequestException {
-	function __construct( $paramNamem, $limit ) {
+	function __construct( $paramName, $limit ) {
 		parent::__construct( "Parameter '{$paramName}' exceeds limit of {$limit}" );
 	}
 }

--- a/includes/wikia/api/ApiExceptions.php
+++ b/includes/wikia/api/ApiExceptions.php
@@ -24,6 +24,12 @@ class InvalidParameterApiException extends BadRequestException {
 	}
 }
 
+class LimitExceededApiException extends BadRequestException {
+	function __construct( $paramNamem, $limit ) {
+		parent::__construct( "Parameter '{$paramName}' exceeds limit of {$limit}" );
+	}
+}
+
 class NotFoundApiException extends NotFoundException {}
 
 class InvalidDataApiException extends InvalidDataException {}

--- a/includes/wikia/api/WikisApiController.class.php
+++ b/includes/wikia/api/WikisApiController.class.php
@@ -34,7 +34,7 @@ class WikisApiController extends WikiaApiController {
 	 * Get the top wikis by pageviews optionally filtering by vertical (hub) and/or language
 	 *
 	 * @requestParam string $hub [OPTIONAL] The name of the vertical (e.g. Gaming, Entertainment, Lifestyle, etc.) to use as a filter
-	 * @requestParam string $lang [OPTIONAL] The language code (e.g. en, de, fr, es, it, etc.) to use as a filter
+	 * @requestParam string $lang [OPTIONAL] The comma-separated list of language codes (e.g. en,de,fr,es,it, etc.) to use as a filter
 	 * @requestParam integer $limit [OPTIONAL] The maximum number of results to fetch, defaults to 25
 	 * @requestParam integer $batch [OPTIONAL] The batch/page index to retrieve, defaults to 1
 	 *

--- a/includes/wikia/api/WikisApiController.class.php
+++ b/includes/wikia/api/WikisApiController.class.php
@@ -59,8 +59,8 @@ class WikisApiController extends WikiaApiController {
 		}
 
 		$this->response->setCacheValidity(
-			1 /* 604800 1 week */,
-			1 /* 604800 1 week */,
+			604800 /* 604800 1 week */,
+			604800 /* 604800 1 week */,
 			array(
 				WikiaResponse::CACHE_TARGET_BROWSER,
 				WikiaResponse::CACHE_TARGET_VARNISH

--- a/includes/wikia/api/WikisApiController.class.php
+++ b/includes/wikia/api/WikisApiController.class.php
@@ -10,6 +10,7 @@
 class WikisApiController extends WikiaApiController {
 	const ITEMS_PER_BATCH = 25;
 	const PARAMETER_KEYWORD = 'string';
+	const PARAMETER_LANGUAGES = 'lang';
 	const PARAMETER_WIKI_IDS = 'ids';
 	const CACHE_VALIDITY = 86400;//1 day
 	const MEMC_NAME = 'SharedWikiApiData:';
@@ -46,7 +47,7 @@ class WikisApiController extends WikiaApiController {
 	 */
 	public function getList() {
 		$hub = trim( $this->request->getVal( 'hub', null ) );
-		$lang = trim( $this->getVal( 'lang', null ) );
+		$lang = trim( $this->getVal( self::PARAMETER_LANGUAGES, null ) );
 		$limit = $this->request->getInt( 'limit', self::ITEMS_PER_BATCH );
 		$batch = $this->request->getInt( 'batch', 1 );
 		$results = self::$model->getTop( $lang, $hub );
@@ -91,7 +92,7 @@ class WikisApiController extends WikiaApiController {
 
 		$keyword = trim( $this->request->getVal( self::PARAMETER_KEYWORD, null ) );
 		$hub = trim( $this->request->getVal( 'hub', null ) );
-		$langs = $this->request->getArray( 'lang' );
+		$langs = $this->request->getArray( self::PARAMETER_LANGUAGES );
 		$limit = $this->request->getInt( 'limit', self::ITEMS_PER_BATCH );
 		$batch = $this->request->getInt( 'batch', 1 );
 		$includeDomain = $this->request->getBool( 'includeDomain', false );
@@ -101,7 +102,7 @@ class WikisApiController extends WikiaApiController {
 		}
 
 		if ( !empty( $langs ) &&  count($langs) > self::LANGUAGES_LIMIT) {
-			throw new LimitExceededApiException( self::PARAMETER_KEYWORD, self::LANGUAGES_LIMIT );
+			throw new LimitExceededApiException( self::PARAMETER_LANGUAGES, self::LANGUAGES_LIMIT );
 		}
 
 		$results = self::$model->getByString($keyword, $langs, $hub, $includeDomain );

--- a/includes/wikia/api/WikisApiController.class.php
+++ b/includes/wikia/api/WikisApiController.class.php
@@ -51,6 +51,11 @@ class WikisApiController extends WikiaApiController {
 		$langs = $this->request->getArray( self::PARAMETER_LANGUAGES );
 		$limit = $this->request->getInt( 'limit', self::ITEMS_PER_BATCH );
 		$batch = $this->request->getInt( 'batch', 1 );
+
+		if ( !empty( $langs ) &&  count($langs) > self::LANGUAGES_LIMIT) {
+			throw new LimitExceededApiException( self::PARAMETER_LANGUAGES, self::LANGUAGES_LIMIT );
+		}
+
 		$results = self::$model->getTop( $langs, $hub );
 		$batches = wfPaginateArray( $results, $limit, $batch );
 

--- a/includes/wikia/api/WikisApiController.class.php
+++ b/includes/wikia/api/WikisApiController.class.php
@@ -13,6 +13,7 @@ class WikisApiController extends WikiaApiController {
 	const PARAMETER_WIKI_IDS = 'ids';
 	const CACHE_VALIDITY = 86400;//1 day
 	const MEMC_NAME = 'SharedWikiApiData:';
+	const LANGUAGES_LIMIT = 10;
 	const DEFAULT_TOP_EDITORS_NUMBER = 10;
 	const DEFAULT_WIDTH = 250;
 	const DEFAULT_HEIGHT = null;
@@ -97,6 +98,10 @@ class WikisApiController extends WikiaApiController {
 
 		if ( empty( $keyword ) ) {
 			throw new MissingParameterApiException( self::PARAMETER_KEYWORD );
+		}
+
+		if ( !empty( $langs ) &&  count($langs) > self::LANGUAGES_LIMIT) {
+			throw new LimitExceededApiException( self::PARAMETER_KEYWORD, self::LANGUAGES_LIMIT );
 		}
 
 		$results = self::$model->getByString($keyword, $langs, $hub, $includeDomain );

--- a/includes/wikia/api/WikisApiController.class.php
+++ b/includes/wikia/api/WikisApiController.class.php
@@ -71,7 +71,7 @@ class WikisApiController extends WikiaApiController {
 	 *
 	 * @requestParam string $keyword search term
 	 * @requestParam string $hub [OPTIONAL] The name of the vertical (e.g. Gaming, Entertainment, Lifestyle, etc.) to use as a filter
-	 * @requestParam string $lang [OPTIONAL] The language code (e.g. en, de, fr, es, it, etc.) to use as a filter
+	 * @requestParam string $lang [OPTIONAL] The comma-separated list of language codes (e.g. en,de,fr,es,it, etc.) to use as a filter
 	 * @requestParam integer $limit [OPTIONAL] The number of items per each batch/page, defaults to 25
 	 * @requestParam integer $batch [OPTIONAL] The batch/page index to retrieve, defaults to 1
 	 * @requestParam bool $includeDomain [OPTIONAL] Wheter to include wikis' domains as search targets or not,
@@ -90,7 +90,7 @@ class WikisApiController extends WikiaApiController {
 
 		$keyword = trim( $this->request->getVal( self::PARAMETER_KEYWORD, null ) );
 		$hub = trim( $this->request->getVal( 'hub', null ) );
-		$lang = trim( $this->getVal( 'lang', null ) );
+		$langs = $this->request->getArray( 'lang' );
 		$limit = $this->request->getInt( 'limit', self::ITEMS_PER_BATCH );
 		$batch = $this->request->getInt( 'batch', 1 );
 		$includeDomain = $this->request->getBool( 'includeDomain', false );
@@ -99,7 +99,7 @@ class WikisApiController extends WikiaApiController {
 			throw new MissingParameterApiException( self::PARAMETER_KEYWORD );
 		}
 
-		$results = self::$model->getByString($keyword, $lang, $hub, $includeDomain );
+		$results = self::$model->getByString($keyword, $langs, $hub, $includeDomain );
 
 		if( is_array( $results ) ) {
 			$batches = wfPaginateArray( $results, $limit, $batch );

--- a/includes/wikia/api/WikisApiController.class.php
+++ b/includes/wikia/api/WikisApiController.class.php
@@ -5,6 +5,7 @@
  * Available only on the www.wikia.com main domain.
  *
  * @author Federico "Lox" Lucignano <federico@wikia-inc.com>
+ * @author Artur Klajnerok <arturk@wikia-inc.com>
  */
 
 class WikisApiController extends WikiaApiController {
@@ -47,10 +48,10 @@ class WikisApiController extends WikiaApiController {
 	 */
 	public function getList() {
 		$hub = trim( $this->request->getVal( 'hub', null ) );
-		$lang = trim( $this->getVal( self::PARAMETER_LANGUAGES, null ) );
+		$langs = $this->request->getArray( self::PARAMETER_LANGUAGES );
 		$limit = $this->request->getInt( 'limit', self::ITEMS_PER_BATCH );
 		$batch = $this->request->getInt( 'batch', 1 );
-		$results = self::$model->getTop( $lang, $hub );
+		$results = self::$model->getTop( $langs, $hub );
 		$batches = wfPaginateArray( $results, $limit, $batch );
 
 		foreach ( $batches as $name => $value ) {
@@ -58,8 +59,8 @@ class WikisApiController extends WikiaApiController {
 		}
 
 		$this->response->setCacheValidity(
-			604800 /* 1 week */,
-			604800 /* 1 week */,
+			1 /* 604800 1 week */,
+			1 /* 604800 1 week */,
 			array(
 				WikiaResponse::CACHE_TARGET_BROWSER,
 				WikiaResponse::CACHE_TARGET_VARNISH

--- a/includes/wikia/api/WikisApiController.class.php
+++ b/includes/wikia/api/WikisApiController.class.php
@@ -64,8 +64,8 @@ class WikisApiController extends WikiaApiController {
 		}
 
 		$this->response->setCacheValidity(
-			604800 /* 604800 1 week */,
-			604800 /* 604800 1 week */,
+			604800 /* 1 week */,
+			604800 /* 1 week */,
 			array(
 				WikiaResponse::CACHE_TARGET_BROWSER,
 				WikiaResponse::CACHE_TARGET_VARNISH

--- a/includes/wikia/models/WikisModel.class.php
+++ b/includes/wikia/models/WikisModel.class.php
@@ -63,15 +63,15 @@ class WikisModel extends WikiaModel {
 	 *
 	 * @return array A collection of results with id, name, hub, language, topic and domain
 	 */
-	public function getTop( $lang = null, $hub = null ) {
+	public function getTop( Array $langs = null, $hub = null ) {
 		wfProfileIn( __METHOD__ );
 
-		$cacheKey = wfSharedMemcKey( __METHOD__, self::CACHE_VERSION, $lang, $hub );
+		$cacheKey = wfSharedMemcKey( __METHOD__, self::CACHE_VERSION, implode( ',', $langs ), $hub );
 		$results = $this->wg->Memc->get( $cacheKey );
 
 		if ( !is_array( $results ) ) {
 			$results = array();
-			$wikis = DataMartService::getTopWikisByPageviews( DataMartService::PERIOD_ID_WEEKLY, self::MAX_RESULTS, $lang, $hub, 1 /* only pubic */ );
+			$wikis = DataMartService::getTopWikisByPageviews( DataMartService::PERIOD_ID_WEEKLY, self::MAX_RESULTS, $langs, $hub, 1 /* only pubic */ );
 
 			foreach ( $wikis as $wikiId => $wiki ) {
 				//fetching data from WikiFactory

--- a/includes/wikia/models/WikisModel.class.php
+++ b/includes/wikia/models/WikisModel.class.php
@@ -170,10 +170,8 @@ class WikisModel extends WikiaModel {
 					);
 
 					if ( !empty( $langs ) ) {
-						foreach ( $langs as $index => $lang ) {
-							$langs[$index] = $db->addQuotes( "{$lang}" );
-						}
-						$where[] = 'city_list.city_lang IN (' . implode( ',', $langs ) . ')';
+						$langs = $db->makeList($langs);
+						$where[] = 'city_list.city_lang IN (' . $langs . ')';
 					}
 
 					if ( is_integer( $hubId ) ) {

--- a/includes/wikia/services/DataMartService.class.php
+++ b/includes/wikia/services/DataMartService.class.php
@@ -230,7 +230,7 @@ class DataMartService extends Service {
 	 *
 	 * @return array $topWikis [ array( wikiId => pageviews ) ]
 	 */
-	public static function getTopWikisByPageviews ($periodId, $limit = 200, $lang = null, $hub = null, $public = null) {
+	public static function getTopWikisByPageviews ($periodId, $limit = 200, Array $langs = null, $hub = null, $public = null) {
 		$app = F::app();
 		wfProfileIn(__METHOD__);
 
@@ -251,8 +251,8 @@ class DataMartService extends Service {
 				break;
 		}
 
-		$memKey = wfSharedMemcKey('datamart', 'topwikis', $cacheVersion, $field, $limitUsed, $lang, $hub, $public);
-		$getData = function () use ($app, $limitUsed, $lang, $hub, $public, $field) {
+		$memKey = wfSharedMemcKey('datamart', 'topwikis', $cacheVersion, $field, $limitUsed, implode( ',', $langs ), $hub, $public);
+		$getData = function () use ($app, $limitUsed, $langs, $hub, $public, $field) {
 			wfProfileIn(__CLASS__ . '::TopWikisQuery');
 			$topWikis = array();
 
@@ -262,9 +262,11 @@ class DataMartService extends Service {
 				$tables = array('report_wiki_recent_pageviews as r');
 				$where = array();
 
-				if (!empty($lang)) {
-					$lang = $db->addQuotes($lang);
-					$where[] = "r.lang = {$lang}";
+				if (!empty($langs)) {
+					foreach ( $langs as $index => $lang ) {
+						$langs[$index] = $db->addQuotes( "{$lang}" );
+					}
+					$where[] = 'r.lang IN (' . implode( ',', $langs ) . ')';
 				}
 
 				if (!empty($hub)) {

--- a/includes/wikia/services/DataMartService.class.php
+++ b/includes/wikia/services/DataMartService.class.php
@@ -263,10 +263,8 @@ class DataMartService extends Service {
 				$where = array();
 
 				if (!empty($langs)) {
-					foreach ( $langs as $index => $lang ) {
-						$langs[$index] = $db->addQuotes( "{$lang}" );
-					}
-					$where[] = 'r.lang IN (' . implode( ',', $langs ) . ')';
+					$langs = $db->makeList($langs);
+					$where[] = 'r.lang IN (' . $langs . ')';
 				}
 
 				if (!empty($hub)) {


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/MOB-226

Extending WikisApi to allow multiple languages support. Number of languages in one request is limited to 10. 

Sample query from getList method (Using DataMart):

```
SELECT  r.wiki_id AS id,pageviews_7day AS pageviews
FROM report_wiki_recent_pageviews as r,dimension_wikis AS d
WHERE (r.lang IN ('en','es','pl')) AND (r.hub_name = 'Gaming') AND (r.wiki_id = d.wiki_id) AND (d.public = 1)
ORDER BY pageviews desc LIMIT 250
```

Sample query from getByString method:

```
SELECT  city_list.city_id,city_list.city_lang,city_list.city_title,city_variables.cv_value
FROM `city_list`
LEFT JOIN `city_variables` ON ((city_list.city_id = city_variables.cv_city_id AND city_variables.cv_variable_id = 1048)) 
LEFT JOIN `city_cat_mapping` ON ((city_list.city_id = city_cat_mapping.city_id))
WHERE city_list.city_public = '1' AND ((city_list.city_title LIKE '%elders%' OR city_list.city_url LIKE '%elders%' OR city_variables.cv_value LIKE '%elders%')) AND (city_list.city_lang IN ('es','pl','de')) AND city_cat_mapping.cat_id = '2' 
LIMIT 250
```

Please review:
@federico-lox @owend @hakubo @themech  @jacekjursza @idradm @jmarch @moliwikia 
