### PR TITLE
MOB-235: Hot fix for mobile advertisment

### DIFF
--- a/extensions/wikia/WikiaMobile/js/floatingAd.js
+++ b/extensions/wikia/WikiaMobile/js/floatingAd.js
@@ -77,7 +77,7 @@ window.addEventListener('load', function(){
 			}
 
 			ads.setupSlot({
-				name: 'MOBILE_FLOATING_FOOTER',
+				name: 'MOBILE_TOP_LEADERBOARD',
 				size: '320x50',
 				wrapper: wrapper,
 				init: function(){


### PR DESCRIPTION
This is fast fix for mobile main Ad slot. Most ads are targeted for MOBILE_TOP_LEADERBOARD not for MOBILE_FLOATING_FOOTER.

@hakubo @gabrys 
