### PR TITLE
CE-248 Fix for displying double sorting arrows in tables

### DIFF
--- a/resources/jquery/jquery.tablesorter.js
+++ b/resources/jquery/jquery.tablesorter.js
@@ -280,18 +280,22 @@
 			this.order = 0;
 			this.count = 0;
 
-			if ( $( this ).is( '.unsortable' ) ) {
+			var thisCached = $( this );
+
+			if ( thisCached.is( '.unsortable' ) ) {
 				this.sortDisabled = true;
 			}
 
 			if ( !this.sortDisabled ) {
 
-				var $th = $( this ).addClass( table.config.cssHeader ).attr( 'title', msg[1])
+				var $th = thisCached.addClass( table.config.cssHeader ).attr( 'title', msg[1] )
+					/* Wikia change */
 					.each( function() {
-						if( !$( this ).find( "div span.chevron" ).length ) {
-							$( this ).append( '<div><span class="chevron"></span><span class="chevron"></span></div>' );
+						if( !thisCached.find( "div .chevron" ).length ) {
+							thisCached.append( '<div><span class="chevron"></span><span class="chevron"></span></div>' );
 						}
 					} );
+					/* Wikia change end */
 
 			}
 

--- a/resources/jquery/jquery.tablesorter.js
+++ b/resources/jquery/jquery.tablesorter.js
@@ -285,7 +285,14 @@
 			}
 
 			if ( !this.sortDisabled ) {
-				var $th = $( this ).addClass( table.config.cssHeader ).attr( 'title', msg[1]).append('<div><span class="chevron"></span><span class="chevron"></span></div>');
+
+				var $th = $( this ).addClass( table.config.cssHeader ).attr( 'title', msg[1])
+					.each( function() {
+						if( !$( this ).find( "div span.chevron" ).length ) {
+							$( this ).append( '<div><span class="chevron"></span><span class="chevron"></span></div>' );
+						}
+					} );
+
 			}
 
 			// add cell to headerList

--- a/resources/jquery/jquery.tablesorter.js
+++ b/resources/jquery/jquery.tablesorter.js
@@ -289,7 +289,7 @@
 			if ( !this.sortDisabled ) {
 
 				var $th = thisCached.addClass( table.config.cssHeader ).attr( 'title', msg[1] )
-					/* Wikia change */
+					/* Wikia change - check whether arrows already exists before appending */
 					.each( function() {
 						if( !thisCached.find( "div .chevron" ).length ) {
 							thisCached.append( '<div><span class="chevron"></span><span class="chevron"></span></div>' );

--- a/skins/oasis/js/tables.js
+++ b/skins/oasis/js/tables.js
@@ -128,9 +128,9 @@ var WikiaWideTables = {
 			height: $(window).height() - 150
 		});
 		$sortableTable = $( '#ModalTable' ).find( 'table.sortable' );
-		//remove all sorting arrows as tablesorter() inserts them again
-		$sortableTable.find( '.headerSort div').remove();
 		if ( $sortableTable.length ) {
+			//remove all sorting arrows as tablesorter() inserts them again
+			$sortableTable.find( '.headerSort div' ).remove();
 			$sortableTable.tablesorter();
 		}
 	},

--- a/skins/oasis/js/tables.js
+++ b/skins/oasis/js/tables.js
@@ -128,6 +128,8 @@ var WikiaWideTables = {
 			height: $(window).height() - 150
 		});
 		$sortableTable = $( '#ModalTable' ).find( 'table.sortable' );
+		//remove all sorting arrows as tablesorter() inserts them again
+		$sortableTable.find( '.headerSort div').remove();
 		if ( $sortableTable.length ) {
 			$sortableTable.tablesorter();
 		}

--- a/skins/oasis/js/tables.js
+++ b/skins/oasis/js/tables.js
@@ -129,8 +129,6 @@ var WikiaWideTables = {
 		});
 		$sortableTable = $( '#ModalTable' ).find( 'table.sortable' );
 		if ( $sortableTable.length ) {
-			//remove all sorting arrows as tablesorter() inserts them again
-			$sortableTable.find( '.headerSort div' ).remove();
 			$sortableTable.tablesorter();
 		}
 	},


### PR DESCRIPTION
I was trying to find out whether it's possible to copy the table together with sorting, but .clone(true, true) doesn't work and table loses ability to sort. 

Removing arrows before re-init makes the thing.
