### PR TITLE
BAC-536: Phalanx - make block ID more visible when blocked

### DIFF
--- a/extensions/wikia/PhalanxII/Phalanx_setup.php
+++ b/extensions/wikia/PhalanxII/Phalanx_setup.php
@@ -83,6 +83,7 @@ $phalanxhooks = array(
 			'SpamFilterCheck'                 => 'onSpamFilterCheck',
 			'EditPhalanxBlock'                => 'onEditPhalanxBlock',
 			'DeletePhalanxBlock'              => 'onDeletePhalanxBlock',
+			'AfterEditPermissionErrors'       => 'onAfterEditPermissionErrors',
 		)
 );
 

--- a/extensions/wikia/PhalanxII/Phalanx_setup.php
+++ b/extensions/wikia/PhalanxII/Phalanx_setup.php
@@ -83,7 +83,7 @@ $phalanxhooks = array(
 			'SpamFilterCheck'                 => 'onSpamFilterCheck',
 			'EditPhalanxBlock'                => 'onEditPhalanxBlock',
 			'DeletePhalanxBlock'              => 'onDeletePhalanxBlock',
-			'AfterEditPermissionErrors'       => 'onAfterEditPermissionErrors',
+			'AfterFormatPermissionsErrorMessage' => 'onAfterFormatPermissionsErrorMessage',
 		)
 );
 

--- a/extensions/wikia/PhalanxII/hooks/PhalanxHooks.class.php
+++ b/extensions/wikia/PhalanxII/hooks/PhalanxHooks.class.php
@@ -200,4 +200,22 @@ class PhalanxHooks extends WikiaObject {
 		wfProfileOut( __METHOD__ );
 		return $ret;
 	}
+
+	/**
+	 * Make block ID more visible in user block message
+	 *
+	 * @param array $permErrors
+	 * @param Title $title
+	 * @param bool $remove
+	 * @return bool true
+	 */
+	static public function onAfterEditPermissionErrors( Array &$permErrors, $title, $remove) {
+		foreach($permErrors as &$error) {
+			if (is_numeric($error[5])) {
+				$error[5] = "<big><strong>$error[5]</strong></big>";
+			}
+		}
+
+		return true;
+	}
 }

--- a/extensions/wikia/PhalanxII/hooks/PhalanxHooks.class.php
+++ b/extensions/wikia/PhalanxII/hooks/PhalanxHooks.class.php
@@ -202,16 +202,15 @@ class PhalanxHooks extends WikiaObject {
 	}
 
 	/**
-	 * Make block ID more visible in user block message
+	 * Make block ID more visible in user block message (BAC-536)
 	 *
 	 * @param array $permErrors
-	 * @param Title $title
-	 * @param bool $remove
+	 * @param string $action
 	 * @return bool true
 	 */
-	static public function onAfterEditPermissionErrors( Array &$permErrors, $title, $remove) {
+	static public function onAfterFormatPermissionsErrorMessage( Array &$permErrors, $action) {
 		foreach($permErrors as &$error) {
-			if (is_numeric($error[5])) {
+			if (isset($error[5]) && is_numeric($error[5])) {
 				$error[5] = "<big><strong>$error[5]</strong></big>";
 			}
 		}

--- a/extensions/wikia/PhalanxII/models/PhalanxContentModel.php
+++ b/extensions/wikia/PhalanxII/models/PhalanxContentModel.php
@@ -68,7 +68,7 @@ class PhalanxContentModel extends PhalanxModel {
 	}
 	
 	public function contentBlock() {
-		$msg = wfMessage('spamprotectionmatch', "{$this->block->text} (Block #{$this->block->id})")->text();
+		$msg = "{$this->block->text} (Block #{$this->block->id})";
 		$this->logBlock();
 		return $msg;
 	}

--- a/includes/OutputPage.php
+++ b/includes/OutputPage.php
@@ -2219,6 +2219,11 @@ class OutputPage extends ContextSource {
 			)->plain() . "\n\n";
 		}
 
+		# Wikia change - begin
+		# @author macbre
+		wfRunHooks( 'AfterFormatPermissionsErrorMessage', array( &$errors, $action ) );
+		# Wikia change - end
+
 		if ( count( $errors ) > 1 ) {
 			$text .= '<ul class="permissions-errors">' . "\n";
 


### PR DESCRIPTION
- `AfterFormatPermissionsErrorMessage` hook added in OutputPage class
- block ID is emphasized using big + strong HTML combo
