### PR TITLE
fixing js error in JSSnippets on mobile where mw is defined but not mw.c...

### DIFF
--- a/extensions/wikia/JSSnippets/js/JSSnippets.js
+++ b/extensions/wikia/JSSnippets/js/JSSnippets.js
@@ -63,7 +63,7 @@ var JSSnippets = (function(){
 			var dependencies = [],
 				callbacks = {},
 				options = {},
-				debugMode = window.mw ? mw.config.get('debug') : window.debug,
+				debugMode = window.mw && mw.config ? mw.config.get('debug') : window.debug,
 				entry,
 				dependency,
 				ext,


### PR DESCRIPTION
...onfig

This was introduced when mobile A/B testing went out. mw is mocked, but only mw.loader, not mw.config. 
