### PR TITLE
Mob 241 - Fatal Error calling DataMartService::getTopWikisByPageviews()

### DIFF
--- a/extensions/wikia/RandomWiki/RandomWikiHelper.class.php
+++ b/extensions/wikia/RandomWiki/RandomWikiHelper.class.php
@@ -70,7 +70,8 @@ class RandomWikiHelper {
 			self::$mData[ 'hubs' ] = array();
 
 			if ( !empty( $wgStatsDBEnabled ) ) {
-				$wikis = DataMartService::getTopWikisByPageviews( DataMartService::PERIOD_ID_MONTHLY, 200, self::$mLanguage, null, 1 );
+				$langs = array(self::$mLanguage);
+				$wikis = DataMartService::getTopWikisByPageviews( DataMartService::PERIOD_ID_MONTHLY, 200, $langs, null, 1 );
 				$minPageViews = ( isset( self::$pageviewsLimits[ self::$mLanguage ] ) ) ? self::$pageviewsLimits[ self::$mLanguage ] : self::$pageviewsLimits[ 'default' ];
 
 				foreach ( $wikis as $wikiID => $pvCount ) {

--- a/includes/wikia/api/ArticlesApiController.class.php
+++ b/includes/wikia/api/ArticlesApiController.class.php
@@ -12,6 +12,7 @@ class ArticlesApiController extends WikiaApiController {
 	const MAX_ITEMS = 250;
 	const ITEMS_PER_BATCH = 25;
 	const TOP_WIKIS_FOR_HUB = 10;
+	const LANGUAGES_LIMIT = 10;
 
 	const PARAMETER_ARTICLES = 'ids';
 	const PARAMETER_TITLES = 'titles';
@@ -19,6 +20,7 @@ class ArticlesApiController extends WikiaApiController {
 	const PARAMETER_NAMESPACES = 'namespaces';
 	const PARAMETER_CATEGORY = 'category';
 	const PARAMETER_HUB = 'hub';
+	const PARAMETER_LANGUAGES = 'lang';
 
 	const CLIENT_CACHE_VALIDITY = 86400;//24h
 	const CATEGORY_CACHE_ID = 'category';
@@ -171,7 +173,7 @@ class ArticlesApiController extends WikiaApiController {
 
 		if ( $this->wg->DBname == 'wikiaglobal' ) {
 			$hub = trim( $this->request->getVal( self::PARAMETER_HUB, null ) );
-			$lang = trim( $this->request->getVal( 'lang', null ) );
+			$langs = $this->request->getArray( self::PARAMETER_LANGUAGES );
 			$namespaces = self::processNamespaces( $this->request->getArray( self::PARAMETER_NAMESPACES, null ), __METHOD__ );
 
 			if ( empty( $hub ) ) {
@@ -179,18 +181,28 @@ class ArticlesApiController extends WikiaApiController {
 				throw new MissingParameterApiException( self::PARAMETER_HUB );
 			}
 
+			if ( !empty( $langs ) &&  count($langs) > self::LANGUAGES_LIMIT) {
+				throw new LimitExceededApiException( self::PARAMETER_LANGUAGES, self::LANGUAGES_LIMIT );
+			}
+
 			//fetch the top 10 wikis on a weekly pageviews basis
 			//this has it's own cache
 			$wikis = DataMartService::getTopWikisByPageviews(
 				DataMartService::PERIOD_ID_WEEKLY,
 				self::TOP_WIKIS_FOR_HUB,
-				$lang,
+				$langs,
 				$hub,
 				1 /* only pubic */
 			);
 
+			$wikisCount = count( $wikis );
+
+			if ( $wikisCount < 1 ) {
+				throw new NotFoundApiException();
+			}
+
 			$found = 0;
-			$articlesPerWiki = ceil( self::MAX_ITEMS / count( $wikis ) );
+			$articlesPerWiki = ceil( self::MAX_ITEMS / $wikisCount );
 			$res = array();
 
 			//fetch $articlesPerWiki articles from each wiki


### PR DESCRIPTION
Fix for: https://wikia-inc.atlassian.net/browse/MOB-241

Added support for multiple languages to ArticlesApi->getTopByHub() and wrapped with array language string on RandomWikiHelper befor call to DataMartService::getTopWikisByPageviews.

I didn't found any other calls of DataMartService::getTopWikisByPageviews that use language parameter that was now changed to array.

@federico-lox @macbre 
