### PR TITLE
VID-516 Don't cache temporary file info

### DIFF
--- a/includes/filerepo/file/LocalFile.php
+++ b/includes/filerepo/file/LocalFile.php
@@ -227,6 +227,12 @@ class LocalFile extends File {
 			}
 		}
 
+		// If there's no timestamp with this file don't cache it, its a soon
+		// to be uploaded file that hasn't been fully saved yet.
+		if ( empty($cache['timestamp']) ) {
+			return;
+		}
+
 		$wgMemc->set( $key, $cache, 60 * 60 * 24 * 7 ); // A week
 	}
 

--- a/includes/filerepo/file/LocalFile.php
+++ b/includes/filerepo/file/LocalFile.php
@@ -227,11 +227,13 @@ class LocalFile extends File {
 			}
 		}
 
+		/* Wikia change begin */
 		// If there's no timestamp with this file don't cache it, its a soon
 		// to be uploaded file that hasn't been fully saved yet.
 		if ( empty($cache['timestamp']) ) {
 			return;
 		}
+		/* Wikia change end */
 
 		$wgMemc->set( $key, $cache, 60 * 60 * 24 * 7 ); // A week
 	}


### PR DESCRIPTION
New images are cached by name with no information in $cache.  This cache key is overwritten with real information when the file is uploaded, but if the process dies before overwriting this cache, this image can be marked as 'non-existent' even if its actually on disk and in the DB.
