### PR TITLE
BAC-483: Special:BrokenRedirects

### DIFF
--- a/includes/specials/SpecialBrokenRedirects.php
+++ b/includes/specials/SpecialBrokenRedirects.php
@@ -42,26 +42,38 @@ class BrokenRedirectsPage extends PageQueryPage {
 	}
 
 	function getQueryInfo() {
+		$dbr = wfGetDB( DB_SLAVE );
+
 		return array(
-			'tables' => array( 'redirect', 'p1' => 'page',
-					'p2' => 'page' ),
-			'fields' => array( 'p1.page_namespace AS namespace',
+			'tables' => array(
+				'redirect',
+				'p1' => 'page',
+				'p2' => 'page',
+			),
+			'fields' => array(
+					'p1.page_namespace AS namespace',
 					'p1.page_title AS title',
 					'p1.page_title AS value',
 					'rd_namespace',
 					'rd_title'
 			),
-			'conds' => array( 'rd_namespace >= 0',
-					'p2.page_namespace IS NULL'
+			'conds' => array(
+				// Exclude pages that don't exist locally as wiki pages,
+				// but aren't "broken" either.
+				// Special pages and interwiki links
+				'rd_namespace >= 0',
+				'rd_interwiki IS NULL OR rd_interwiki = ' . $dbr->addQuotes( '' ),
+				'p2.page_namespace IS NULL',
 			),
-			'join_conds' => array( 'p1' => array( 'JOIN', array(
-						'rd_from=p1.page_id',
-					) ),
-					'p2' => array( 'LEFT JOIN', array(
-						'rd_namespace=p2.page_namespace',
-						'rd_title=p2.page_title'
-					) )
-			)
+			'join_conds' => array(
+				'p1' => array( 'JOIN', array(
+					'rd_from=p1.page_id',
+				) ),
+				'p2' => array( 'LEFT JOIN', array(
+					'rd_namespace=p2.page_namespace',
+					'rd_title=p2.page_title'
+				) ),
+			),
 		);
 	}
 


### PR DESCRIPTION
Always lists interwiki redirects, regardless of validity

Backported a commit from MW 1.21.0 - https://github.com/wikimedia/mediawiki-core/commit/4c21cf53d87697bfbfb521d99b825a3fd287c77e

``` mysql
mysql> EXPLAIN SELECT   p1.page_namespace AS namespace,p1.page_title AS title,p1.page_title   AS value,rd_namespace,rd_title  FROM `redirect` JOIN `page` `p1` ON ((rd_from=p1.page_id)) LEFT JOIN `page` `p2` ON ((rd_namespace=p2.page_namespace) AND (rd_title=p2.page_title))  WHERE (rd_namespace >= 0) AND (rd_interwiki IS NULL OR rd_interwiki = '') AND (p2.page_namespace IS NULL)  ORDER BY rd_namespace, rd_title, rd_from LIMIT 50;
+----+-------------+----------+--------+---------------------+-------------+---------+-----------------------------------------------------------+------+--------------------------------------+
| id | select_type | table    | type   | possible_keys       | key         | key_len | ref                                                       | rows | Extra                                |
+----+-------------+----------+--------+---------------------+-------------+---------+-----------------------------------------------------------+------+--------------------------------------+
|  1 | SIMPLE      | redirect | range  | PRIMARY,rd_ns_title | rd_ns_title | 4       | NULL                                                      | 2519 | Using where                          |
|  1 | SIMPLE      | p1       | eq_ref | PRIMARY             | PRIMARY     | 4       | plpoznan.redirect.rd_from                                 |    1 |                                      |
|  1 | SIMPLE      | p2       | eq_ref | name_title          | name_title  | 261     | plpoznan.redirect.rd_namespace,plpoznan.redirect.rd_title |    1 | Using where; Using index; Not exists |
+----+-------------+----------+--------+---------------------+-------------+---------+-----------------------------------------------------------+------+--------------------------------------+
3 rows in set (0.01 sec)
```
