### PR TITLE
BAC-554: maintenance/wikia/imageReview.php

### DIFF
--- a/maintenance/wikia/imageReview.php
+++ b/maintenance/wikia/imageReview.php
@@ -27,7 +27,7 @@ $updated = 0;
 
 $sizeOfPack = 3;
 
-$lastRun = WikiFactory::getVarValueByName( 'wgImageReviewImportLastRun', $wgCityId );
+$lastRun = $wgImageReviewImportLastRun;
 
 if(!empty($lastRun)) {
 	$startFrom = $lastRun - 60*60;


### PR DESCRIPTION
WikiFactory::getVarValueByName being called in the context of a current wiki. Use wg global instead.

@lgarczewski - please review
