### PR TITLE
PLA-415 -- add varnish caching to search results pages

### DIFF
--- a/extensions/wikia/Search/WikiaSearchController.class.php
+++ b/extensions/wikia/Search/WikiaSearchController.class.php
@@ -31,8 +31,16 @@ class WikiaSearchController extends WikiaSpecialPageController {
 
 	/**
 	 * Default sufix for result template
+	 * @var string
 	 */
 	const WIKIA_DEFAULT_RESULT = 'result';
+
+	/**
+	 * Default varnish cache time for a search result
+	 * Currently 12 hours.
+	 * @var int
+	 */
+	const VARNISH_CACHE_TIME = 43200;
 	
 	/**
 	 * Responsible for instantiating query services based on config.
@@ -73,6 +81,7 @@ class WikiaSearchController extends WikiaSpecialPageController {
 		
 		$this->setPageTitle( $searchConfig );
 		$this->setResponseValuesFromConfig( $searchConfig );
+		$this->setVarnishCacheTime( self::VARNISH_CACHE_TIME );
 	}
 
 	/**

--- a/includes/wikia/nirvana/WikiaResponse.class.php
+++ b/includes/wikia/nirvana/WikiaResponse.class.php
@@ -66,6 +66,12 @@ class WikiaResponse {
 	protected $exception = null;
 
 	/**
+	 * Flag for whether we're caching
+	 * @var bool
+	 */
+	protected $isCaching = false;
+
+	/**
 	 * constructor
 	 * @param string $format
 	 */
@@ -276,6 +282,7 @@ class WikiaResponse {
 	 * WikiaResponse::CACHE_TARGET_BROWSER and WikiaResponse::CACHE_TARGET_VARNISH
 	 */
 	public function setCacheValidity( $expiryTime = null, $maxAge = null, Array $targets = array() ){
+		$this->isCaching = true;
 		$targetBrowser = ( in_array( self::CACHE_TARGET_BROWSER, $targets ) );
 		$targetVarnish = ( in_array( self::CACHE_TARGET_VARNISH, $targets ) );
 
@@ -304,6 +311,14 @@ class WikiaResponse {
 				$this->setHeader( 'Cache-Control', $cacheControl, true );
 			}
 		}
+	}
+
+	/**
+	 * Tells you if the request has cache validity set
+	 * @return bool
+	 */
+	public function isCaching() {
+		return $this->isCaching;
 	}
 
 	public function getHeader( $name ) {

--- a/includes/wikia/nirvana/WikiaSpecialPageController.class.php
+++ b/includes/wikia/nirvana/WikiaSpecialPageController.class.php
@@ -43,7 +43,7 @@ class WikiaSpecialPageController extends WikiaController {
 		if( $response->getFormat() == WikiaResponse::FORMAT_HTML ) {
 			try {
 				if ( $response->isCaching() ) {
-					Wikia::log( $this->specialPage->getName() . ' is an HTML-formatted special page with caching set through the response. Use WikiaSpecialPageController::setVarnishCacheTime instead.' );
+					Wikia::log( __METHOD__, false, $this->specialPage->getName() . ' is an HTML-formatted special page with caching set through the response. Use WikiaSpecialPageController::setVarnishCacheTime instead.' );
 				}
 				$this->wg->Out->addHTML( $response->toString() );
 			} catch( Exception $exception ) {

--- a/includes/wikia/nirvana/WikiaSpecialPageController.class.php
+++ b/includes/wikia/nirvana/WikiaSpecialPageController.class.php
@@ -61,6 +61,15 @@ class WikiaSpecialPageController extends WikiaController {
 	}
 
 	/**
+	 * This method is used to manually set varnish caching on special pages.
+	 * Special pages are sent through OutputPage, and headers set in the request are ignored.
+	 * @param int $seconds
+	 */
+	protected function setVarnishCacheTime( $seconds ) {
+		$this->wg->Out->mSquidMaxage = $seconds;
+	}
+
+	/**
 	 * Any functions that we do not implement, call directly on our specialPage object
 	 * @param String $method
 	 * @param String $args

--- a/includes/wikia/nirvana/WikiaSpecialPageController.class.php
+++ b/includes/wikia/nirvana/WikiaSpecialPageController.class.php
@@ -42,6 +42,9 @@ class WikiaSpecialPageController extends WikiaController {
 
 		if( $response->getFormat() == WikiaResponse::FORMAT_HTML ) {
 			try {
+				if ( $response->isCaching() ) {
+					Wikia::log( $this->specialPage->getName() . ' is an HTML-formatted special page with caching set through the response. Use WikiaSpecialPageController::setVarnishCacheTime instead.' )
+				}
 				$this->wg->Out->addHTML( $response->toString() );
 			} catch( Exception $exception ) {
 				// in case of exception thrown by WikiaView, just render standard error controller response

--- a/includes/wikia/nirvana/WikiaSpecialPageController.class.php
+++ b/includes/wikia/nirvana/WikiaSpecialPageController.class.php
@@ -43,7 +43,7 @@ class WikiaSpecialPageController extends WikiaController {
 		if( $response->getFormat() == WikiaResponse::FORMAT_HTML ) {
 			try {
 				if ( $response->isCaching() ) {
-					Wikia::log( $this->specialPage->getName() . ' is an HTML-formatted special page with caching set through the response. Use WikiaSpecialPageController::setVarnishCacheTime instead.' )
+					Wikia::log( $this->specialPage->getName() . ' is an HTML-formatted special page with caching set through the response. Use WikiaSpecialPageController::setVarnishCacheTime instead.' );
 				}
 				$this->wg->Out->addHTML( $response->toString() );
 			} catch( Exception $exception ) {


### PR DESCRIPTION
This changeset adds in varnish caching of 12 hours to anonymous searches. 

This also includes a new feature to allow special pages to set varnish caching, which was not previously possible according to our controller model for special pages, and how it interfaces with core MediaWiki.

This solution was worked on in cooperation with @owend and @Wyvek.
