### PR TITLE
BAC-503: fix for Special:Log

### DIFF
--- a/includes/logging/LogFormatter.php
+++ b/includes/logging/LogFormatter.php
@@ -499,7 +499,10 @@ class LogFormatter {
 					$user->getName(),
 					true, // Red if no edits
 					0, // Flags
-					$user->getEditCount()
+					/* Wikia change begin - @author: Macbre (BAC-503) */
+					#$user->getEditCount()
+					$user->getEditCountLocal()
+					/* Wikia change end */
 				);
 			}
 		}


### PR DESCRIPTION
Special:Log&type=useravatar Showing RedLinks for Contribution Pages Long Created

Use real local edit count instead of shared one (`User::getEditCountLocal` vs `User::getEditCount`)

@kamilkoterba @lgarczewski - please review
