### PR TITLE
BAC-474: ImageServing

### DIFF
--- a/extensions/wikia/ImageServing/drivers/ImageServingDriverBase.class.php
+++ b/extensions/wikia/ImageServing/drivers/ImageServingDriverBase.class.php
@@ -14,13 +14,28 @@ abstract class ImageServingDriverBase {
 	 */
 	var $db;
 
+	protected $imagesList;
+	protected $articleCountList;
+	protected $filterdOut;
+
+	protected $minWidth;
+	protected $minHeight;
+
+	/**
+	 * @param $db
+	 * @param $imageServing ImageServing
+	 * @param $proportion
+	 */
 	function __construct($db, $imageServing, $proportion) {
 		$this->app = F::app();
 		$this->db = $db;
 		$this->proportion = $proportion;
 		//TODO: remove it
 		$this->imageServing = $imageServing;
-		$this->memc =  $this->app->getGlobal( 'wgMemc' );
+		$this->memc =  $this->app->wg->Memc;
+
+		$this->minHeight = $this->imageServing->getRequestedHeight();
+		$this->minWidth = $this->imageServing->getRequestedWidth();
 	}
 
 	abstract protected function getImagesFromDB($articles = array());
@@ -158,6 +173,6 @@ abstract class ImageServingDriverBase {
 	 * @author Federico "Lox" Lucignano
 	 */
 	protected function makeKey( $key  ) {
-		return wfMemcKey("imageserving-images-data", $key, $this->proportion);
+		return wfMemcKey("imageserving-images-data", $key, $this->minWidth, $this->minHeight);
 	}
 }

--- a/extensions/wikia/ImageServing/drivers/ImageServingDriverMainNS.class.php
+++ b/extensions/wikia/ImageServing/drivers/ImageServingDriverMainNS.class.php
@@ -2,7 +2,6 @@
 class ImageServingDriverMainNS extends ImageServingDriverBase {
 	protected $queryLimit = 50;
 	protected $maxCount = 10;
-	protected $minSize = 75;
 
 	function __construct($db, $imageServing, $proportion) {
 		parent::__construct( $db, $imageServing, $proportion );
@@ -123,10 +122,10 @@ class ImageServingDriverMainNS extends ImageServingDriverBase {
 					'img_name' => array_keys($imageRefs),
 				),
 				__METHOD__
-
 			);
+
 			foreach ($result as $row) {
-				if ( $row->img_height > $this->minSize && $row->img_width > $this->minSize ) {
+				if ( $row->img_height >= $this->minHeight && $row->img_width >= $this->minWidth ) {
 					if ( !in_array( $row->img_minor_mime, array( "svg+xml","svg") ) ) {
 						$imageData[$row->img_name] = $row;
 					}

--- a/extensions/wikia/ImageServing/imageServing.class.php
+++ b/extensions/wikia/ImageServing/imageServing.class.php
@@ -7,11 +7,9 @@
  * or specific dimensions.
  */
 class ImageServing {
-	//private $maxCount = 10;
-	//private $minSize = 75;
-	//private $queryLimit = 50;
 	private $articles = array();
 	private $width;
+	private $height;
 	private $proportion;
 	private $deltaY = null;
 	private $db;
@@ -44,9 +42,11 @@ class ImageServing {
 			$height = (int) $proportionOrHeight;
 			$this->proportion = array("w" => $width, "h" => $height);
 			$this->proportionString = $width.":".$height;
+			$this->height = $height;
 		} else {
 			$this->proportion = $proportionOrHeight;
 			$this->proportionString = implode(":", $proportionOrHeight);
+			$this->height = (int) round($width / $proportionOrHeight['w'] * $proportionOrHeight['h']);
 		}
 		$this->articles = array();
 
@@ -59,11 +59,26 @@ class ImageServing {
 
 		$this->app = F::app();
 		$this->width = $width;
-		$this->memc =  $this->app->getGlobal( 'wgMemc' );
+		$this->memc =  $this->app->wg->Memc;
 		$this->imageServingDrivers = $this->app->getGlobal( 'wgImageServingDrivers' );
 
 		$this->db = $db;
 	}
+
+	/**
+	 * @return int min width of requested images
+	 */
+	public function getRequestedWidth() {
+		return $this->width;
+	}
+
+	/**
+	 * @return int min height of requested images
+	 */
+	public function getRequestedHeight() {
+		return $this->height;
+	}
+
 	/**
 	 * getImages - get array with list of top images for all article passed into the constructor
 	 *
@@ -166,7 +181,7 @@ class ImageServing {
 	}
 
 	private function makeKey( $key ) {
-		return wfMemcKey("imageserving-article-details", $key, $this->width, $this->proportionString);
+		return wfMemcKey("imageserving-article-details", $key, $this->width, $this->height);
 	}
 
 	/**

--- a/extensions/wikia/ImageServing/tests/ImageServingUnitTest.php
+++ b/extensions/wikia/ImageServing/tests/ImageServingUnitTest.php
@@ -19,4 +19,16 @@ class ImageServingCroppingTest extends WikiaBaseTest {
 		$this->assertEquals( '200px-0,314,65,222', $is->getCut( 314, 654 ) );
 		$this->assertEquals( '200px-0,572,36,322', $is->getCut( 572, 355 ) );
 	}
+
+	function testWidthAndHeightGetters() {
+		$is = new ImageServing(null, 200, 100);
+
+		$this->assertEquals(200, $is->getRequestedWidth());
+		$this->assertEquals(100, $is->getRequestedHeight());
+
+		$is = new ImageServing(null, 300, ['w' => 2, 'h' => 1]);
+
+		$this->assertEquals(300, $is->getRequestedWidth());
+		$this->assertEquals(150, $is->getRequestedHeight());
+	}
 }


### PR DESCRIPTION
Small images render badly with ImageServing
- `ImageServing::getImages()` was not taking dimensions restriction into consideration
- Modify the structure of memcache keys
- Add unit tests
