### PR TITLE
 BAC-574: fix PHP warning in PhalanxService

### DIFF
--- a/extensions/wikia/PhalanxII/hooks/PhalanxAnswersBlock.class.php
+++ b/extensions/wikia/PhalanxII/hooks/PhalanxAnswersBlock.class.php
@@ -10,10 +10,7 @@
  */
 
 class PhalanxAnswersBlock extends WikiaObject {
-	function __construct() {
-		parent::__construct();
-	}
-	
+
 	/**
 	 * Hook handler for CreateDefaultQuestionPageFilter hook
 	 * @see extensions/wikia/Answers/PrefilledDefaultQuestion.php#L15
@@ -30,9 +27,9 @@ class PhalanxAnswersBlock extends WikiaObject {
 
 		$language = RequestContext::getMain()->getLanguage();
 
-		$phalanxModel = new PhalanxContentModel( $title, $language );
+		$phalanxModel = new PhalanxContentModel( $title, $language->getCode() );
 		$ret = $phalanxModel->match_question_title();
-		
+
 		wfProfileOut( __METHOD__ );
 		return $ret;
 	}

--- a/extensions/wikia/PhalanxII/hooks/PhalanxTitleBlock.class.php
+++ b/extensions/wikia/PhalanxII/hooks/PhalanxTitleBlock.class.php
@@ -12,18 +12,15 @@
  */
 
 class PhalanxTitleBlock extends WikiaObject {
-	function __construct() {
-		parent::__construct();
-	}
 
 	/**
 	 * handler for beforeMove hook
 	 *
 	 * @static
 	 *
-	 * @param SpecialPage $move -- Special::Move class instance
+	 * @param MovePageForm $move -- Special::Move class instance
 	 *
-	 * @return true -- pass hook further
+	 * @return bool true -- pass hook further
 	 */
 	static public function beforeMove( &$move ) {
 		wfProfileIn( __METHOD__ );
@@ -41,6 +38,7 @@ class PhalanxTitleBlock extends WikiaObject {
 	/**
 	 * handler for editFilter hook
 	 *
+	 * @param EditPage $editPage -- edit page instance
 	 * @static
 	 */
 	static public function editFilter( $editPage, $text, $section, &$hookError, $summary ) {
@@ -73,7 +71,7 @@ class PhalanxTitleBlock extends WikiaObject {
 	 * @param Title $title -- title instance
 	 * @param Bool $displayBlock -- shoould block be displayed or not
 	 *
-	 * @return true -- pass hook further
+	 * @return bool true -- pass hook further
 	 */
 	static public function checkTitle( $title, $displayBlock = true ) {
 		wfProfileIn( __METHOD__ );
@@ -97,7 +95,7 @@ class PhalanxTitleBlock extends WikiaObject {
 	 * @param Title $title -- title for checking
 	 * @param String $error_msg -- returned message, by reference
 	 *
-	 * @return true -- pass hook further
+	 * @return bool true -- pass hook further
 	 */
 	static public function pageTitleFilter( $title, &$error_msg ) {
 		wfProfileIn( __METHOD__ );

--- a/extensions/wikia/PhalanxII/models/PhalanxContentModel.php
+++ b/extensions/wikia/PhalanxII/models/PhalanxContentModel.php
@@ -7,10 +7,15 @@ class PhalanxContentModel extends PhalanxModel {
 	const SPAM_WHITELIST_TITLE = 'Spam-whitelist';
 	const SPAM_WHITELIST_NS_TITLE = 'Mediawiki:Spam-whitelist';
 
+	/**
+	 * @param Title $title
+	 * @param string $lang
+	 * @param int $id
+	 */
 	public function __construct( $title, $lang = null, $id = 0 ) {
 		parent::__construct( __CLASS__, array( 'title' => $title, 'lang' => $lang, 'id' => $id ) );
 	}
-	
+
 	public function isOk() { 
 		return ( 
 			$this->wg->User->isAllowed( 'phalanxexempt' ) || 

--- a/extensions/wikia/PhalanxII/models/PhalanxModel.php
+++ b/extensions/wikia/PhalanxII/models/PhalanxModel.php
@@ -3,6 +3,7 @@
 /**
  * @method setBlock
  * @method getBlock
+ * @method setText
  * @method getText
  * @method getLang
  */


### PR DESCRIPTION
Don't pass whole Language object, language code is enough + code hinting

```
PHP Warning: urlencode() expects parameter 1 to be string, object given in /usr/wikia/slot1/code/extensions/wikia/PhalanxII/services/PhalanxService.php
```
