### PR TITLE
DAR-1355: fix scrollbars not appearing for body min-width when dynamic backgrounds are applied.

### DIFF
--- a/skins/oasis/css/core/responsive.scss
+++ b/skins/oasis/css/core/responsive.scss
@@ -147,7 +147,6 @@ body {
 
 	@if ( $background-is-dynamic ) {
 		background: $color-body;
-		overflow-x: hidden;
 
 		&:after,
 		&:before {
@@ -155,6 +154,7 @@ body {
 			background-repeat: no-repeat;
 			content: "";
 			height: $background-height;
+			overflow-x: hidden;
 			position: $background-position;
 			top: 0;
 			width: $background-width-half;


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/DAR-1355

Moved overflow-x hidden to body psuedo elements instead of body itself.
