### PR TITLE
PLA-493 use $response[totalItemCount] to list total itels in vet

### DIFF
--- a/extensions/wikia/VideoEmbedTool/VideoEmbedToolController.class.php
+++ b/extensions/wikia/VideoEmbedTool/VideoEmbedToolController.class.php
@@ -40,7 +40,7 @@ class VideoEmbedToolController extends WikiaController {
 			$result = array(
 					'searchQuery' => $service->getSuggestionQuery(),
 					'caption' => wfMsg( 'vet-suggestions' ),
-					'totalItemCount' => 0,
+					'totalItemCount' => $response['totalItemCount'],
 					'nextStartFrom' => $response['nextStartFrom'],
 					'currentSetItemCount' => count($response['items']),
 					'items' => $response['items']


### PR DESCRIPTION
Fixes a defect in the number of results shown for a video search through VET
