### PR TITLE
DAR-1350 Fixed fatal error caused by date collisions in wall_history.

### DIFF
--- a/extensions/wikia/Wall/WallHistory.class.php
+++ b/extensions/wikia/Wall/WallHistory.class.php
@@ -219,8 +219,8 @@ class WallHistory extends WikiaModel {
 					FROM `wall_history` AS `last_title`
 					WHERE
 						`parent_comment_id` = `wall_history`.`parent_comment_id`
-						AND `event_date` = (
-							SELECT MAX(`event_date`)
+						AND (`event_date`, `revision_id`) = (
+							SELECT MAX(`event_date`), MAX(`revision_id`)
 							FROM `wall_history`
 							WHERE
 								`action` IN (' . WH_EDIT . ', ' . WH_NEW . ')
@@ -234,7 +234,8 @@ class WallHistory extends WikiaModel {
 				(
 					SELECT
 						`parent_comment_id`,
-						MAX(`event_date`) AS `event_date`
+						MAX(`event_date`) AS `event_date`,
+						MAX(`revision_id`) AS `revision_id`
 					FROM `wall_history`
 					RIGHT JOIN
 						(
@@ -255,7 +256,7 @@ class WallHistory extends WikiaModel {
 					ORDER BY `event_date` DESC
 					LIMIT ' . $count . '
 				) AS `last_new_post_date`
-				USING (`parent_comment_id`, `event_date`)',
+				USING (`parent_comment_id`, `event_date`, `revision_id`)',
 			__METHOD__
 		);
 


### PR DESCRIPTION
P2: https://wikia-inc.atlassian.net/browse/DAR-1350

This was a fatal error caused by date collisions in the `wall_history` table. It was causing the first sub-query to return more than 1 row. The date collisions were also causing the query to return multiple rows for a single thread. This change fixes both of those issues.
