### PR TITLE
WikiaDataAccess cache time bugfix

### DIFF
--- a/extensions/wikia/WikiaHubsServices/models/MarketingToolboxModel.class.php
+++ b/extensions/wikia/WikiaHubsServices/models/MarketingToolboxModel.class.php
@@ -598,7 +598,7 @@ class MarketingToolboxModel extends WikiaModel {
 
 		if ($timestamp == strtotime('00:00')) {
 			$lastPublishedTimestamp = WikiaDataAccess::cache(
-				$this->getMKeyForLastPublishedTimestamp($langCode, $sectionId, $verticalId),
+				$this->getMKeyForLastPublishedTimestamp($langCode, $sectionId, $verticalId, $timestamp),
 				6 * 60 * 60,
 				function () use ($langCode, $sectionId, $verticalId, $timestamp, $useMaster) {
 					return $this->getLastPublishedTimestampFromDB($langCode, $sectionId, $verticalId, $timestamp, $useMaster);
@@ -612,7 +612,7 @@ class MarketingToolboxModel extends WikiaModel {
 	}
 
 	protected function purgeLastPublishedTimestampCache($langCode, $sectionId, $verticalId) {
-		$this->wg->Memc->delete($this->getMKeyForLastPublishedTimestamp($langCode, $sectionId, $verticalId));
+		$this->wg->Memc->delete($this->getMKeyForLastPublishedTimestamp($langCode, $sectionId, $verticalId, strtotime('00:00')));
 	}
 
 	public function getLastPublishedTimestampFromDB($langCode, $sectionId, $verticalId, $timestamp, $useMaster = false) {
@@ -702,12 +702,13 @@ class MarketingToolboxModel extends WikiaModel {
 		return $table;
 	}
 
-	protected function getMKeyForLastPublishedTimestamp($langCode, $sectionId, $verticalId) {
+	protected function getMKeyForLastPublishedTimestamp($langCode, $sectionId, $verticalId, $timestamp) {
 		return wfSharedMemcKey(
 			self::CACHE_KEY,
 			$langCode,
 			$sectionId,
 			$verticalId,
+			$timestamp,
 			self::CACHE_KEY_LAST_PUBLISHED_TIMESTAMP
 		);
 	}

--- a/includes/wikia/WikiaDataAccess.class.php
+++ b/includes/wikia/WikiaDataAccess.class.php
@@ -14,6 +14,7 @@ class WikiaDataAccess {
 	 **********************************/
 
 	const LOCK_TIMEOUT = 60; // lock for at most 60s
+	const CACHE_TIME_FACTOR_FOR_LOCK = 2; // How many times longer cache should be valid when using cacheWithLock
 
 	/**
 	 * WikiaDataAccess::USE_CACHE - does not have to be passed to cache or cacheWithLock [default]
@@ -93,7 +94,7 @@ class WikiaDataAccess {
 	 */
 	static private function setCache( $key, $result, $cacheTime, $command = self::USE_CACHE ) {
 		if ( $command == self::USE_CACHE || $command == self::REFRESH_CACHE ) {
-			F::app()->wg->Memc->set( $key, $result, $cacheTime * 2 );
+			F::app()->wg->Memc->set( $key, $result, $cacheTime );
 		}
 
 		if ( $command == self::REFRESH_CACHE ) {
@@ -141,7 +142,7 @@ class WikiaDataAccess {
 					'data' => $getData(),
 					'time' => wfTimestamp( TS_UNIX )
 				);
-				self::setCache( $key, $result, $cacheTime * 2, $command );
+				self::setCache( $key, $result, $cacheTime * self::CACHE_TIME_FACTOR_FOR_LOCK, $command );
 			}
 
 			if( $gotLock ) self::unlock( $keyLock );
@@ -162,7 +163,7 @@ class WikiaDataAccess {
 						'data' => $getData(),
 						'time' => wfTimestamp( TS_UNIX )
 					);
-					self::setCache( $key, $result, $cacheTime * 2, $command );
+					self::setCache( $key, $result, $cacheTime * self::CACHE_TIME_FACTOR_FOR_LOCK, $command );
 				} else {
 					// what we already have in $result is good enough
 					// and another thread is generating that data anyway for future requests


### PR DESCRIPTION
WikiaDataAccess::cache had small bug, so data was cached for longer time that it was supposed to be (2 times longer)

WikiaDataAccess::cacheWithLock was cached for even longer time but it's wasn't affected by this bug because of complex logic checking when cache is invalid

This pull request fixes problem mentioned above.

@Wyvek @hakubo @wladekb please take a look and correct me if something is wrong.
