### PR TITLE
DAR-1152: visual layout regressions for RTE

### DIFF
--- a/extensions/wikia/EditPageLayout/css/EditPageLayout.scss
+++ b/extensions/wikia/EditPageLayout/css/EditPageLayout.scss
@@ -398,14 +398,6 @@ body {
 	display: none;
 }
 
-.EditPageHeader h1 {
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    width: 300px;
-
-}
-
 .mw-toolbar-editbutton {
 	@include sprite-edit-mw-toolbar-deep-embed(23px,23px);
 }

--- a/extensions/wikia/EditPageLayout/css/core/header.scss
+++ b/extensions/wikia/EditPageLayout/css/core/header.scss
@@ -22,6 +22,7 @@
 			max-height: $height-epl-header;
 		}
 	}
+
 	> h2 {
 		color: $color-epl-header-text;
 		font-size: 14px;
@@ -30,13 +31,17 @@
 		margin: 0;
 		padding: 0;
 	}
+
 	> h1 {
 		display: inline-block;
 		float: left;
 		font-size: 19px;
 		line-height: 17px;
+		overflow: hidden;
 		padding: 0;
-		zoom: 1; // ie
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		width: 300px;
 		> a {
 			color: $color-epl-header-text;
 		}

--- a/extensions/wikia/EditPageLayout/css/core/toolbar.scss
+++ b/extensions/wikia/EditPageLayout/css/core/toolbar.scss
@@ -15,9 +15,11 @@
 			padding-top: 5px;
 		}
 	}
+
 	.editpage-toolbar .cke_buttons {
 		padding: 2px 0 1px;
 	}
+
 	.cke_toolbar_expand {
 		> a {
 			color: $color-text;
@@ -56,6 +58,10 @@
 		float: left;
 		margin-top: 23px;
 		margin-left: 10px;
+	}
+
+	.cke_toolbar_format {
+		margin-right: 30px;
 	}
 
 	.cke_toolbar_widescreen {

--- a/extensions/wikia/EditPageLayout/css/core/toolbar.scss
+++ b/extensions/wikia/EditPageLayout/css/core/toolbar.scss
@@ -62,6 +62,13 @@
 
 	.cke_toolbar_format {
 		margin-right: 30px;
+		padding-top: 0;
+
+		.cke_button a,
+		.cke_rcombo a,
+		.cke_separator {
+			margin-top: 5px;
+		}
 	}
 
 	.cke_toolbar_widescreen {
@@ -95,7 +102,7 @@
 		@include linear-gradient($color-epl-separator, top, $color-epl-separator-tips, 0%, $color-epl-separator, 10%, $color-epl-separator, 90%, $color-epl-separator-tips, 100%);
 		display: inline-block;
 		float: left;
-		height: 30px;
+		height: 29px;
 		margin: -1px 5px;
 		width: 1px;
 	}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/DAR-1152

Mostly cleaning up the visual mode toolbar so that it looks better on smaller screens. These changes will work regardless of whether or not responsive layout is enabled.
