### PR TITLE
BAC-345: TagsReport doesn't show all found Pages

### DIFF
--- a/extensions/wikia/TagsReport/SpecialTagsReport.i18n.php
+++ b/extensions/wikia/TagsReport/SpecialTagsReport.i18n.php
@@ -13,6 +13,7 @@ $messages['en'] = array(
 	'tagsreportpages' => '(<strong>$1</strong> {{PLURAL:$1|page|pages}})',
 	'tagsreportpagesfound' => 'Found <strong>$1</strong> {{PLURAL:$1|page|pages}}, which contain special tag (DPL, YouTube, etc.)',
 	'tagsreportgenerated' => 'Generated on $1 at $2',
+	'tagsreportpageremoved' => 'Page #$1 has been removed'
 );
 
 /** Message documentation (Message documentation)
@@ -27,6 +28,9 @@ $messages['qqq'] = array(
 	'tagsreportgenerated' => 'Parameters:
 * $1 is a date.
 * $2 is a time.',
+	'tagsreportpageremoved' => 'Shown when page can not be listed because it has been removed.
+* $1 is page id
+'
 );
 
 /** Afrikaans (Afrikaans)

--- a/extensions/wikia/TagsReport/SpecialTagsReport_body.php
+++ b/extensions/wikia/TagsReport/SpecialTagsReport_body.php
@@ -11,6 +11,7 @@ if ( !defined( 'MEDIAWIKI' ) ) {
 }
 
 class TagsReportPage extends SpecialPage {
+	/* @var Title $mTitle */
 	private $mTitle;
 	private $mTag;
 	/**
@@ -118,7 +119,7 @@ class TagsReportPage extends SpecialPage {
 			$dbs = wfGetDB(DB_SLAVE, array(), $wgStatsDB);
 			if (!is_null($dbs)) {
 				$query = "select ct_kind, count(*) as cnt from city_used_tags where ct_kind is not null and ct_wikia_id = {$wgCityId} group by ct_kind order by ct_kind";
-				$res = $dbs->query ($query);
+				$res = $dbs->query ($query, __METHOD__);
 				while ($row = $dbs->fetchObject($res)) {
 					$tagsList[$row->ct_kind] = $row->cnt;
 				}
@@ -142,7 +143,7 @@ class TagsReportPage extends SpecialPage {
 			$dbs = wfGetDB(DB_SLAVE, array(), $wgStatsDB);
 			if (!is_null($dbs)) {
 				$query = "select ct_namespace, ct_page_id from city_used_tags where ct_kind = " .$dbs->addQuotes( $this->mTag ). " and ct_wikia_id = {$wgCityId} order by ct_namespace";
-				$res = $dbs->query ($query);
+				$res = $dbs->query ($query, __METHOD__);
 				while ($row = $dbs->fetchObject($res)) {
 					$tagsArticles[$row->ct_namespace][] = $row->ct_page_id;
 				}
@@ -158,9 +159,8 @@ class TagsReportPage extends SpecialPage {
 
 	private function getGenDate() {
 		global $wgLang, $wgStatsDB, $wgCityId, $wgStatsDBEnabled;
-		$tagsArticles = array();
 
-		if ( !empty( $wgStatsDBEnabled ) ) {
+		if ( empty( $wgStatsDBEnabled ) ) {
 			return array();
 		}
 

--- a/extensions/wikia/TagsReport/templates/main-form.tmpl.php
+++ b/extensions/wikia/TagsReport/templates/main-form.tmpl.php
@@ -6,9 +6,11 @@
 <? if (!empty($tagList)) { ?>
 <? foreach ($tagList as $tag => $cnt) { ?>
 <div style="margin:4px 10px">
-<span style="vertical-align: middle;"><input type="radio" name="target" value="<?=$tag?>" "<?=($tag == $mTag)?"checked":""?>"></span>
-<span style="vertical-align: middle; font-family: monospace;" class="tagname"><?=$tag ?></span> 
-<span style="vertical-align: middle;" class="tagcount"><?=wfMsg('tagsreportpages', $cnt); ?></span>
+<label>
+	<span style="vertical-align: middle;"><?= Xml::radio('target', $tag, ($tag == $mTag)); ?></span>
+	<span style="vertical-align: middle; font-family: monospace;" class="tagname"><?=$tag ?></span>
+	<span style="vertical-align: middle;" class="tagcount"><?=wfMsg('tagsreportpages', $cnt); ?></span>
+</label>
 </div>
 <? } ?>
 <? } ?>

--- a/extensions/wikia/TagsReport/templates/tag-activity.tmpl.php
+++ b/extensions/wikia/TagsReport/templates/tag-activity.tmpl.php
@@ -11,7 +11,9 @@
 			<? foreach ($aRows as $id => $pageId) { ?>
 				<? $oTitle = Title::newFromID($pageId); ?>
 				<? if ($oTitle instanceof Title) { ?>
-<li><?=$skin->makeLinkObj($oTitle);?></li>			
+<li><?=$skin->makeLinkObj($oTitle);?></li>
+				<? } else { ?>
+<li><?= wfMsg('tagsreportpageremoved', $pageId) ?></li>
 				<? } ?>
 			<? } ?>
 		<? } ?>
@@ -19,4 +21,3 @@
 	<? } ?>
 <? } ?>
 <!-- e:<?= __FILE__ ?> -->
-	


### PR DESCRIPTION
Show removed articles as well

Minor fixes:
- wrap checkboxes using <label> tag
- show the information when the report was generated
- DB queries profiling

`tagsreportpageremoved` i18n message added
