### PR TITLE
DAR-1170 Fixed theme designer pickers

### DIFF
--- a/extensions/wikia/ThemeDesigner/js/ThemeDesigner.js
+++ b/extensions/wikia/ThemeDesigner/js/ThemeDesigner.js
@@ -369,7 +369,7 @@ var ThemeDesigner = {
 			.addClass(type);
 
 		// clicking away will close picker
-		$("body").bind("click.picker", ThemeDesigner.hidePicker);
+		$("body").bind("click.picker", $.proxy(ThemeDesigner.hidePicker, this));
 		this.themeDesignerPicker.click(function(event) {
 			event.stopPropagation();
 		});


### PR DESCRIPTION
Theme designer color/image pickers didn't hide when clicking outside. This simple one-line change fixes it.
Jira ticket: https://wikia-inc.atlassian.net/browse/DAR-1170
