### PR TITLE
DAR-1244 Move styleguide-specific code to SpecialStyleguide extension

### DIFF
--- a/extensions/wikia/SpecialStyleguide/SpecialStyleguide.setup.php
+++ b/extensions/wikia/SpecialStyleguide/SpecialStyleguide.setup.php
@@ -10,15 +10,16 @@
  */
 
 $dir = dirname( __FILE__ ) . '/';
-$baseDir =  $dir . '../../../';
 
 $wgExtensionCredits['specialpage'][] = [
 	'name' => 'Special:Styleguide',
 	'description' => 'Extension to present a library of reusable components with usage examples',
 	'descriptionmsg' => 'styleguide-descriptionmsg',
 	'authors' => [
-		'Rafał Leszczyński',
 		'Sebastian Marzjan',
+		'Rafał Leszczyński',
+		"Andrzej 'nAndy' Łukaszewski",
+		"Jacek 'mech' Woźniak",
 	],
 	'version' => 1.0
 ];
@@ -26,7 +27,7 @@ $wgExtensionCredits['specialpage'][] = [
 // classes
 $wgAutoloadClasses['SpecialStyleguideController'] = $dir . 'SpecialStyleguideController.class.php';
 $wgAutoloadClasses['SpecialStyleguideDataModel'] = $dir . 'models/SpecialStyleguideDataModel.class.php';
-$wgAutoloadClasses['UIStyleguideComponents'] = $baseDir . 'includes/wikia/ui/UIStyleguideComponents.class.php';
+$wgAutoloadClasses['UIStyleguideComponents'] = $dir . 'helpers/UIStyleguideComponents.class.php';
 
 // special page
 $wgSpecialPages['Styleguide'] = 'SpecialStyleguideController';

--- a/extensions/wikia/SpecialStyleguide/helpers/UIStyleguideComponents.class.php
+++ b/extensions/wikia/SpecialStyleguide/helpers/UIStyleguideComponents.class.php
@@ -22,9 +22,7 @@ class UIStyleguideComponents
 	 */
 	public function getAllComponents() {
 		$components = WikiaDataAccess::cache(
-			wfSharedMemcKey (
-				__CLASS__, 'all_components'
-			),
+			wfSharedMemcKey( __CLASS__, 'all_components' ),
 			UIFactory::MEMCACHE_EXPIRATION,
 			[ $this, 'getAllComponentsFromDirectories' ]
 		);

--- a/includes/wikia/ui/UIComponent.class.php
+++ b/includes/wikia/ui/UIComponent.class.php
@@ -106,7 +106,7 @@ class UIComponent {
 	 * @throws WikiaUITemplateException
 	 */
 	private function setTemplatePath( $template ) {
-		$template = UIFactory::sanitize( $template );
+		$template = Sanitizer::escapeId( $template, 'noninitial' );
 		$mustacheTplPath = $this->getBaseTemplatePath() . '_' . $template . '.' . self::MUSTACHE_FILE_EXTENSION;
 		if ( $this->fileExists( $mustacheTplPath ) ) {
 			$this->templatePath = $mustacheTplPath;

--- a/includes/wikia/ui/UIFactory.class.php
+++ b/includes/wikia/ui/UIFactory.class.php
@@ -178,7 +178,7 @@ class UIFactory {
 	 * @return array
 	 */
 	private function addComponentsId( $componentCfg ) {
-		$componentCfg[ 'id' ] = static::sanitize( $componentCfg[ 'name-msg-key' ] );
+		$componentCfg[ 'id' ] = Sanitizer::escapeId( $componentCfg[ 'name-msg-key' ], 'noninitial' );
 
 		return $componentCfg;
 	}
@@ -197,7 +197,7 @@ class UIFactory {
 	}
 
 	public function getComponentsBaseTemplatePath( $name ) {
-		$name = static::sanitize( $name );
+		$name = Sanitizer::escapeId( $name, 'noninitial' );
 		return $this->getComponentsDir() .
 			$name .
 			DIRECTORY_SEPARATOR .
@@ -264,10 +264,6 @@ class UIFactory {
 	
 	protected function getComponentInstance() {
 		return new UIComponent();
-	}
-	
-	public static function sanitize( $string ) {
-		return str_replace( ' ', '_', mb_strtolower( $string ) );
 	}
 
 	/**

--- a/includes/wikia/ui/tests/UIIntegration.php
+++ b/includes/wikia/ui/tests/UIIntegration.php
@@ -11,6 +11,7 @@ class UIIntegration extends WikiaBaseTest {
 	private $uiFactory;
 
 	protected function setUp() {
+		parent::setUp();
 		$this->path = dirname( __FILE__ ) . DIRECTORY_SEPARATOR . '_fixtures/components/';
 
 		$this->uiFactory = UIFactory::getInstance();


### PR DESCRIPTION
- moved the Special:Styleguide specific class to the extension's directory,
- additionally fixed integration tests,
- additionally re-used MW Sanitizer and got rid off UIFactory::sanitize()
