### PR TITLE
DAR-1409 | AM removed / from path when using resources

### DIFF
--- a/extensions/wikia/SpecialCss/SpecialCssController.class.php
+++ b/extensions/wikia/SpecialCss/SpecialCssController.class.php
@@ -98,7 +98,7 @@ class SpecialCssController extends WikiaSpecialPageController {
 		$this->response->addAsset('/extensions/wikia/SpecialCss/css/SpecialCss.scss');
 		$this->response->addAsset('special_css_js');
 		// This shouldn't be moved to asset manager package because of Ace internal autoloader
-		$this->response->addAsset('/resources/Ace/ace.js');
+		$this->response->addAsset('resources/Ace/ace.js');
 
 		$aceUrl = AssetsManager::getInstance()->getOneCommonURL('/resources/Ace');
 		$aceUrlParts = parse_url($aceUrl);

--- a/extensions/wikia/SpecialMarketingToolbox/MarketingToolboxController.class.php
+++ b/extensions/wikia/SpecialMarketingToolbox/MarketingToolboxController.class.php
@@ -133,7 +133,7 @@ class MarketingToolboxController extends WikiaSpecialPageController {
 
 		$this->response->addAsset('/extensions/wikia/SpecialMarketingToolbox/js/EditHub.js');
 		$this->response->addAsset('/extensions/wikia/SpecialMarketingToolbox/js/EditHubNavigation.js');
-		$this->response->addAsset('/resources/jquery/jquery.validate.js');
+		$this->response->addAsset('resources/jquery/jquery.validate.js');
 		$this->response->addAsset('/extensions/wikia/SpecialMarketingToolbox/js/jquery.MetaData.js');
 
 		$selectedModuleValues = $modulesData['moduleList'][$this->selectedModuleId]['data'];

--- a/extensions/wikia/UserProfilePageV3/UserProfilePageController.class.php
+++ b/extensions/wikia/UserProfilePageV3/UserProfilePageController.class.php
@@ -139,7 +139,7 @@ class UserProfilePageController extends WikiaController {
 			$this->setVal('reloadUrl', '');
 		}
 
-		$this->response->addAsset('/resources/wikia/modules/aim.js');
+		$this->response->addAsset('resources/wikia/modules/aim.js');
 
 		if ( $this->app->checkSkin( 'wikiamobile' ) ) {
 			$this->overrideTemplate( 'WikiaMobileRenderUserIdentityBox' );


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/DAR-1409
When using AssetManager and adding asset from resources there should be no '/' because it breaks URL while using ?allinone=0 or wgAllInOne set to false
