### PR TITLE
BAC-551 Hide category namespace on Special:MovePage

### DIFF
--- a/includes/Html.php
+++ b/includes/Html.php
@@ -743,39 +743,43 @@ class Html {
 			$params['selected'] = '';
 		}
 
-		// Array holding the <option> elements
+		// Associative array between option-values and option-labels
 		$options = array();
 
 		if ( isset( $params['all'] ) ) {
-			// add an <option> that would let the user select all namespaces.
-			// Value is provided by user, the name shown is localized.
+			// add an option that would let the user select all namespaces.
+			// Value is provided by user, the name shown is localized for the user.
 			$options[$params['all']] = wfMsg( 'namespacesall' );
 		}
-		// Add defaults <option> according to content language
+		// Add all namespaces as options (in the content langauge)
 		$options += $wgContLang->getFormattedNamespaces();
 
-		// Convert $options to HTML
+		// Convert $options to HTML and filter out namespaces below 0
 		$optionsHtml = array();
 		foreach ( $options as $nsId => $nsName ) {
 			if ( $nsId < NS_MAIN ) {
 				continue;
 			}
 			if ( $nsId === 0 ) {
+				// For other namespaces use use the namespace prefix as label, but for
+				// main we don't use "" but the user message descripting it (e.g. "(Main)" or "(Article)")
 				$nsName = wfMsg( 'blanknamespace' );
 			}
 			$optionsHtml[] = Xml::option( $nsName, $nsId, $nsId === $params['selected'] );
 		}
 
-		// Forge a <select> element and returns it
 		$ret = '';
 		if ( isset( $params['label'] ) ) {
 			$ret .= Xml::label( $params['label'], $selectAttribs['id'] ) . '&#160;';
 		}
+
+		// Wrap options in a <select>
 		$ret .= Html::openElement( 'select', $selectAttribs )
 			. "\n"
 			. implode( "\n", $optionsHtml )
 			. "\n"
 			. Html::closeElement( 'select' );
+
 		return $ret;
 	}
 

--- a/includes/Html.php
+++ b/includes/Html.php
@@ -714,6 +714,8 @@ class Html {
 	 * - selected: [optional] Id of namespace which should be pre-selected
 	 * - all: [optional] Value of item for "all namespaces". If null or unset, no <option> is generated to select all namespaces
 	 * - label: text for label to add before the field
+	 * - exclude: [optional] Array of namespace ids to exclude
+	 * - disable: [optional] Array of namespace ids for which the option should be disabled in the selector
 	 * @param $selectAttribs array HTML attributes for the generated select element.
 	 * - id:   [optional], default: 'namespace'
 	 * - name: [optional], default: 'namespace'
@@ -743,6 +745,13 @@ class Html {
 			$params['selected'] = '';
 		}
 
+		if ( !isset( $params['exclude'] ) || !is_array( $params['exclude'] ) ) {
+			$params['exclude'] = array();
+		}
+		if ( !isset( $params['disable'] ) || !is_array( $params['disable'] ) ) {
+			$params['disable'] = array();
+		}
+
 		// Associative array between option-values and option-labels
 		$options = array();
 
@@ -757,7 +766,7 @@ class Html {
 		// Convert $options to HTML and filter out namespaces below 0
 		$optionsHtml = array();
 		foreach ( $options as $nsId => $nsName ) {
-			if ( $nsId < NS_MAIN ) {
+			if ( $nsId < NS_MAIN || in_array( $nsId, $params['exclude'] ) ) {
 				continue;
 			}
 			if ( $nsId === 0 ) {
@@ -765,7 +774,9 @@ class Html {
 				// main we don't use "" but the user message descripting it (e.g. "(Main)" or "(Article)")
 				$nsName = wfMsg( 'blanknamespace' );
 			}
-			$optionsHtml[] = Xml::option( $nsName, $nsId, $nsId === $params['selected'] );
+			$optionsHtml[] = Xml::option( $nsName, $nsId, $nsId === $params['selected'], array(
+				'disabled' => in_array( $nsId, $params['disable'] ),
+			) );
 		}
 
 		$ret = '';

--- a/includes/specials/SpecialMovepage.php
+++ b/includes/specials/SpecialMovepage.php
@@ -252,6 +252,14 @@ class MovePageForm extends UnlistedSpecialPage {
 		// Byte limit (not string length limit) for wpReason and wpNewTitleMain
 		// is enforced in the mediawiki.special.movePage module
 
+		$immovableNamespaces = array();
+
+		foreach ( array_keys( $this->getLanguage()->getNamespaces() ) as $nsId ) {
+			if ( !MWNamespace::isMovable( $nsId ) ) {
+				$immovableNamespaces[] = $nsId;
+			}
+		}
+
 		$out->addHTML(
 			 Xml::openElement( 'form', array( 'method' => 'post', 'action' => $this->getTitle()->getLocalURL( 'action=submit' ), 'id' => 'movepage' ) )
 		);
@@ -274,7 +282,10 @@ class MovePageForm extends UnlistedSpecialPage {
 				"</td>
 				<td class='mw-input'>" .
 					Html::namespaceSelector(
-						array( 'selected' => $newTitle->getNamespace() ),
+						array(
+							'selected' => $newTitle->getNamespace(),
+							'exclude' => $immovableNamespaces
+						),
 						array( 'name' => 'wpNewTitleNs', 'id' => 'wpNewTitleNs' )
 					) .
 					Xml::input( 'wpNewTitleMain', 60, $wgContLang->recodeForEdit( $newTitle->getText() ), array(

--- a/tests/phpunit/includes/HtmlTest.php
+++ b/tests/phpunit/includes/HtmlTest.php
@@ -212,6 +212,8 @@ class HtmlTest extends MediaWikiTestCase {
 	}
 
 	function testNamespaceSelector() {
+		global $wgContLang;
+
 		$this->assertEquals(
 			'<select id="namespace" name="namespace">' . "\n" .
 '<option value="0">(Main)</option>' . "\n" .
@@ -256,6 +258,35 @@ class HtmlTest extends MediaWikiTestCase {
 				array( 'name' => 'wpNamespace', 'id' => 'mw-test-namespace' )
 			),
 			'Basic namespace selector with custom values'
+		);
+		$immovable = array();
+		$namespaces = $wgContLang->getNamespaces();
+		foreach ( $namespaces as $nsId => $nsName ) {
+			if ( !MWNamespace::isMovable( intval( $nsId ) ) ) {
+				$immovable[] = $nsId;
+			}
+		}
+		$this->assertEquals(
+			'<select id="namespace" name="namespace">' . "\n" .
+'<option value="0">(Main)</option>' . "\n" .
+'<option value="1">Talk</option>' . "\n" .
+'<option value="2">User</option>' . "\n" .
+'<option value="3">User talk</option>' . "\n" .
+'<option value="4">MyWiki</option>' . "\n" .
+'<option value="5">MyWiki Talk</option>' . "\n" .
+'<option value="6">File</option>' . "\n" .
+'<option value="7">File talk</option>' . "\n" .
+'<option value="8">MediaWiki</option>' . "\n" .
+'<option value="9">MediaWiki talk</option>' . "\n" .
+'<option value="10">Template</option>' . "\n" .
+'<option value="11">Template talk</option>' . "\n" .
+'<option disabled="" value="14">Category</option>' . "\n" .
+'<option value="15">Category talk</option>' . "\n" .
+'</select>',
+			Html::namespaceSelector(
+				array( 'exclude' => array( 100, 101 ), 'disable' => $immovable )
+			),
+			'Namespace selector without the custom namespace and immovable namespaces disabled.'
 		);
 	}
 


### PR DESCRIPTION
**PLEASE DON'T MERGE WITHOUT APPROVAL FROM** @Wikia/platform-team

This is a backport of 3 commits from the latest MediaWiki release.

I used `git format-patch` and `git am --signoff` to apply the commits.

See [BAC-551](https://wikia-inc.atlassian.net/browse/BAC-551) for details.
