### PR TITLE
VID-638 Make sure we get raw text and check for errors

### DIFF
--- a/extensions/wikia/RelatedVideos/RelatedVideosNamespaceData.class.php
+++ b/extensions/wikia/RelatedVideos/RelatedVideosNamespaceData.class.php
@@ -132,8 +132,27 @@ class RelatedVideosNamespaceData {
 				return;
 			}
 
-			// parse wikitext with RelatedVideos NS data (stored as wikitext list)
-			$content = $article->getContent();
+			// Get the content of the article, bypassing any user permission checks (we're using this
+			// page as a datastore so the same checks do not apply)
+			$page = $article->getPage();
+			if ( empty($page) ) {
+				wfDebug(__METHOD__ . ": RelatedVideos NS page doesn't exist\n");
+				wfProfileOut(__METHOD__);
+				return;
+			}
+			$rev = $page->getRevision();
+			if ( empty($rev) ) {
+				wfDebug(__METHOD__ . ": RelatedVideos NS revision doesn't exist\n");
+				wfProfileOut(__METHOD__);
+				return;
+			}
+			$content = $rev->getText( Revision::RAW );
+			if ( $content === false ) {
+				wfDebug(__METHOD__ . ": Problem retrieving RelatedVideos NS revision text\n");
+				wfProfileOut(__METHOD__);
+				return;
+			}
+
 			$lines = explode( "\n", $content );
 			$lists = array();
 			$lists[ self::BLACKLIST_MARKER ] = array();


### PR DESCRIPTION
Prev version checked user permission before getting content of the blacklist page.  This page is used as a datastore so we don't want to check the current user's permissions against it.  Also look for this returning false which is the error condition.  Don't cache anything if this is false!
