### PR TITLE
PLA-523 -- fix cross-wiki PTT w.r.t language code and results found

### DIFF
--- a/extensions/wikia/Search/WikiaSearchController.class.php
+++ b/extensions/wikia/Search/WikiaSearchController.class.php
@@ -291,6 +291,7 @@ class WikiaSearchController extends WikiaSpecialPageController {
 				'wikiMatch',
 				$this->getApp()->getView( 'WikiaSearch', 'CrossWiki_result', [ 'result' => $matchResult, 'pos' => -1 ] ) 
 				);
+		$this->resultsFound++;
 	}
 	
 	/**

--- a/extensions/wikia/Search/classes/Config.php
+++ b/extensions/wikia/Search/classes/Config.php
@@ -481,7 +481,7 @@ class Config
 	 */
 	public function setWikiMatch( Match\Wiki $wikiMatch ) {
 		$wikiLang = $this->getService()->getGlobalForWiki( 'wgLanguageCode', $wikiMatch->getId() );
-		if ( (! $wikiLang ) || $this->getLanguageCode() === $wikiLang ) {
+		if ( ( !$wikiLang && $this->getLanguageCode() === MediaWikiService::WIKI_DEFAULT_LANG_CODE ) || $this->getLanguageCode() === $wikiLang ) {
 			$this->wikiMatch = $wikiMatch;
 		}
 		return $this;

--- a/extensions/wikia/Search/classes/Config.php
+++ b/extensions/wikia/Search/classes/Config.php
@@ -480,7 +480,8 @@ class Config
 	 * @return \Wikia\Search\Config provides fluent interface
 	 */
 	public function setWikiMatch( Match\Wiki $wikiMatch ) {
-		if ( $this->getLanguageCode() === $this->getService()->getGlobalForWiki( 'wgLanguageCode', $wikiMatch->getId() ) ) {
+		$wikiLang = $this->getService()->getGlobalForWiki( 'wgLanguageCode', $wikiMatch->getId() );
+		if ( (! $wikiLang ) || $this->getLanguageCode() === $wikiLang ) {
 			$this->wikiMatch = $wikiMatch;
 		}
 		return $this;

--- a/extensions/wikia/Search/classes/MediaWikiService.php
+++ b/extensions/wikia/Search/classes/MediaWikiService.php
@@ -492,7 +492,8 @@ class MediaWikiService
             }
             //exclude wikis which lang does not match current one
             $wikiLang = $this->getGlobalForWiki( 'wgLanguageCode', $wikiId );
-            if ( isset( $wikiId ) && ( (! $wikiLang ) || ( $langCode === $wikiLang ) ) ) {
+			//if wiki lang not set display only for default language
+            if ( isset( $wikiId ) && ( ( !$wikiLang && $langCode === static::WIKI_DEFAULT_LANG_CODE ) || ( $langCode === $wikiLang ) ) ) {
                 $match = new \Wikia\Search\Match\Wiki( $wikiId, $this );
             }
 		}

--- a/extensions/wikia/Search/classes/MediaWikiService.php
+++ b/extensions/wikia/Search/classes/MediaWikiService.php
@@ -491,7 +491,8 @@ class MediaWikiService
                 $wikiId = ( $interWikiComId = $this->getWikiIdByHost( "{$langCode}.{$domain}.wikia.com" ) ) !== null ? $interWikiComId : $this->getWikiIdByHost( "{$domain}.{$langCode}" );
             }
             //exclude wikis which lang does not match current one
-            if ( isset( $wikiId ) && $langCode === $this->getGlobalForWiki( 'wgLanguageCode', $wikiId ) ) {
+            $wikiLang = $this->getGlobalForWiki( 'wgLanguageCode', $wikiId );
+            if ( isset( $wikiId ) && ( (! $wikiLang ) || ( $langCode === $wikiLang ) ) ) {
                 $match = new \Wikia\Search\Match\Wiki( $wikiId, $this );
             }
 		}

--- a/extensions/wikia/Search/classes/MediaWikiService.php
+++ b/extensions/wikia/Search/classes/MediaWikiService.php
@@ -484,18 +484,18 @@ class MediaWikiService
 	public function getWikiMatchByHost( $domain ) {
 		$match = null;
 		if ( $domain !== '' ) {
-		$langCode = $this->getLanguageCode();
-            if ( $langCode === static::WIKI_DEFAULT_LANG_CODE ) {
-                $wikiId = $this->getWikiIdByHost( $domain . '.wikia.com' );
-            } else {
-                $wikiId = ( $interWikiComId = $this->getWikiIdByHost( "{$langCode}.{$domain}.wikia.com" ) ) !== null ? $interWikiComId : $this->getWikiIdByHost( "{$domain}.{$langCode}" );
-            }
-            //exclude wikis which lang does not match current one
-            $wikiLang = $this->getGlobalForWiki( 'wgLanguageCode', $wikiId );
+			$langCode = $this->getLanguageCode();
+			if ( $langCode === static::WIKI_DEFAULT_LANG_CODE ) {
+				$wikiId = $this->getWikiIdByHost( $domain . '.wikia.com' );
+			} else {
+				$wikiId = ( $interWikiComId = $this->getWikiIdByHost( "{$langCode}.{$domain}.wikia.com" ) ) !== null ? $interWikiComId : $this->getWikiIdByHost( "{$domain}.{$langCode}" );
+			}
+			//exclude wikis which lang does not match current one
+			$wikiLang = $this->getGlobalForWiki( 'wgLanguageCode', $wikiId );
 			//if wiki lang not set display only for default language
-            if ( isset( $wikiId ) && ( ( !$wikiLang && $langCode === static::WIKI_DEFAULT_LANG_CODE ) || ( $langCode === $wikiLang ) ) ) {
-                $match = new \Wikia\Search\Match\Wiki( $wikiId, $this );
-            }
+			if ( isset( $wikiId ) && ( ( !$wikiLang && $langCode === static::WIKI_DEFAULT_LANG_CODE ) || ( $langCode === $wikiLang ) ) ) {
+				$match = new \Wikia\Search\Match\Wiki( $wikiId, $this );
+			}
 		}
 		return $match;
 	}

--- a/extensions/wikia/Search/classes/Test/MediaWikiServiceTest.php
+++ b/extensions/wikia/Search/classes/Test/MediaWikiServiceTest.php
@@ -1810,6 +1810,26 @@ class MediaWikiServiceTest extends BaseTest
 		$service
 			->expects( $this->at( 0 ) )
 			->method ( 'getLanguageCode' )
+			->will   ( $this->returnValue( 'en' ) )
+		;
+		$service
+			->expects( $this->at( 1 ) )
+			->method ( 'getWikiIdByHost' )
+			->with   ( 'foo.wikia.com' )
+			->will   ( $this->returnValue( 123 ) )
+		;
+		$service
+			->expects( $this->at( 2 ) )
+			->method( 'getGlobalForWiki' )
+			->with( 'wgLanguageCode', 123 )
+			->will ( $this->returnValue( false ) )
+		;
+		$this->assertNotEmpty(
+			$service->getWikiMatchByHost( 'foo' )
+		);
+		$service
+			->expects( $this->at( 0 ) )
+			->method ( 'getLanguageCode' )
 			->will   ( $this->returnValue( 'pl' ) )
 		;
 		$service
@@ -1824,7 +1844,7 @@ class MediaWikiServiceTest extends BaseTest
 			->with( 'wgLanguageCode', 123 )
 			->will ( $this->returnValue( false ) )
 		;
-		$this->assertNotEmpty(
+		$this->assertEmpty(
 			$service->getWikiMatchByHost( 'foo' )
 		);
 		$service

--- a/extensions/wikia/Search/classes/Test/MediaWikiServiceTest.php
+++ b/extensions/wikia/Search/classes/Test/MediaWikiServiceTest.php
@@ -1782,29 +1782,51 @@ class MediaWikiServiceTest extends BaseTest
 			->with( 'wgLanguageCode', 123 )
 			->will ( $this->returnValue( 'en' ) )
 		;
-
 		$this->mockClass( 'Wikia\Search\Match\Wiki', $mockMatch );
 		$this->assertEquals(
 				$service->getWikiMatchByHost( 'foo' ),
 				$mockMatch
 		);
-
 		$service
 			->expects( $this->at( 0 ) )
 			->method ( 'getLanguageCode' )
 			->will   ( $this->returnValue( 'pl' ) )
 		;
-
 		$service
 			->expects( $this->at( 1 ) )
 			->method ( 'getWikiIdByHost' )
 			->with   ( 'pl.foo.wikia.com' )
 			->will   ( $this->returnValue( 123 ) )
 		;
+		$service
+			->expects( $this->at( 2 ) )
+			->method( 'getGlobalForWiki' )
+			->with( 'wgLanguageCode', 123 )
+			->will ( $this->returnValue( 'en' ) )
+		;
 		$this->assertEmpty(
 			$service->getWikiMatchByHost( 'foo' )
 		);
-
+		$service
+			->expects( $this->at( 0 ) )
+			->method ( 'getLanguageCode' )
+			->will   ( $this->returnValue( 'pl' ) )
+		;
+		$service
+			->expects( $this->at( 1 ) )
+			->method ( 'getWikiIdByHost' )
+			->with   ( 'pl.foo.wikia.com' )
+			->will   ( $this->returnValue( 123 ) )
+		;
+		$service
+			->expects( $this->at( 2 ) )
+			->method( 'getGlobalForWiki' )
+			->with( 'wgLanguageCode', 123 )
+			->will ( $this->returnValue( false ) )
+		;
+		$this->assertNotEmpty(
+			$service->getWikiMatchByHost( 'foo' )
+		);
 		$service
 			->expects( $this->at( 0 ) )
 			->method ( 'getLanguageCode' )

--- a/extensions/wikia/Search/classes/Test/QueryService/QueryServiceTest.php
+++ b/extensions/wikia/Search/classes/Test/QueryService/QueryServiceTest.php
@@ -67,10 +67,10 @@ class QueryServiceTest extends Search\Test\BaseTest {
 		$mockConfig
 		    ->expects( $this->once() )
 		    ->method ( 'getQueryService' )
-		    ->will   ( $this->returnValue( '\\Wikia\\Search\\QueryService\\Select\\OnWiki' ) )
+		    ->will   ( $this->returnValue( '\\Wikia\\Search\\QueryService\\Select\\Dismax\\OnWiki' ) )
 		;
 		$this->assertInstanceOf(
-				'Wikia\Search\QueryService\Select\OnWiki',
+				'Wikia\Search\QueryService\Select\Dismax\OnWiki',
 				$mockFactory->get( $dc )
 		);
 	}


### PR DESCRIPTION
This update handles two current problems with cross-wiki PTT:

1) If a wiki does not have the wgLanguageCode variable set, then the wiki is ignored. We're changing the language matching to only work if the wiki has a value for this variable. Otherwise, ignore the condition, and add it as a PTT match.

2) Cross-wiki PTT is not shown if there are no other results found. So in cases where the wiki is not mentioned at all in community, that wiki cannot currently be found, even if the language is set. To address this, we increment the number of results found when the cross-wiki match is registered with the view.

This change will also need to be merged to dev and release-182.
