### PR TITLE
(CE-41) Blocked users should be able to post on their own Wall

### DIFF
--- a/extensions/wikia/Wall/WallHooksHelper.class.php
+++ b/extensions/wikia/Wall/WallHooksHelper.class.php
@@ -15,8 +15,8 @@ class WallHooksHelper {
 	static public function onUserIsBlockedFrom($user, $title, &$blocked, &$allowUsertalk) {
 
 		if ( !$user->mHideName && $allowUsertalk && $title->getNamespace() == NS_USER_WALL_MESSAGE ) {
-			// wall owner is in it's name
-			if ( $title->getBaseText() === $user->getName() ) {
+			$parts = explode( '/', $title->getText() );
+			if ( $parts[0] === $user->getName() ) {
 				$blocked = false;
 				wfDebug( __METHOD__ . ": self-user wall page, ignoring any blocks\n" );
 			}


### PR DESCRIPTION
Fixes the previous fix. getBaseText was returning the whole title rather
than the first part of the title (the username) because the Thread
namespace does not have subpages enabled. Even it does, replies to
other comments will break anyway since it returns everything before the
last /. This forces it to always get the base page name which will be the
username.

@themech @RafLeszczynski Please review. :)
