### PR TITLE
Dar 1243 messages files

### DIFF
--- a/extensions/wikia/SpecialStyleguide/SpecialStyleguide.setup.php
+++ b/extensions/wikia/SpecialStyleguide/SpecialStyleguide.setup.php
@@ -36,11 +36,4 @@ $wgSpecialPageGroups['Styleguide'] = 'wikia';
 // message files
 $wgExtensionMessagesFiles['SpecialStyleguide'] = $dir . 'SpecialStyleguide.i18n.php';
 
-if( is_null(StyleguideComponents::$componentsNames) ) {
-	StyleguideComponents::$componentsNames = StyleguideComponents::loadComponentsFromFileSystem();
-}
-
-foreach( StyleguideComponents::$componentsNames as $componentName ) {
-	$componentMessageFile = StyleguideComponents::getComponentMessagesFileFullPath( $componentName );
-	$wgExtensionMessagesFiles['StyleguideComponents' . ucfirst($componentName) ] = $componentMessageFile;
-}
+$wgHooks['BeforeExtensionMessagesRecache'][] = 'StyleguideComponents::onBeforeExtensionMessagesRecache';

--- a/extensions/wikia/SpecialStyleguide/helpers/StyleguideComponents.class.php
+++ b/extensions/wikia/SpecialStyleguide/helpers/StyleguideComponents.class.php
@@ -184,15 +184,17 @@ class StyleguideComponents {
 
 	/**
 	 * Include components messages files when recompiling the language cache
-	 * @param $wgExtensionMessagesFiles - array with extensions' message files
+	 *
+	 * @param $$extensionMessagesFiles - array with extensions' messages files
+	 *
 	 * @return bool hook run status
 	 */
-	public static function onBeforeExtensionMessagesRecache( &$wgExtensionMessagesFiles ) {
+	public static function onBeforeExtensionMessagesRecache( &$extensionMessagesFiles ) {
 		// we don't want to use componentsNames from the cache when rebuilding the cache, as it won't speedup the process
 		// anyway and we risk some of the messages won't get cached
 		foreach( StyleguideComponents::loadComponentsFromFileSystem() as $componentName ) {
 			$componentMessageFile = self::getComponentMessagesFileFullPath( $componentName );
-			$wgExtensionMessagesFiles['StyleguideComponents' . ucfirst($componentName) ] = $componentMessageFile;
+			$extensionMessagesFiles['StyleguideComponents' . ucfirst($componentName) ] = $componentMessageFile;
 		}
 
 		return true;

--- a/extensions/wikia/SpecialStyleguide/helpers/StyleguideComponents.class.php
+++ b/extensions/wikia/SpecialStyleguide/helpers/StyleguideComponents.class.php
@@ -182,4 +182,20 @@ class StyleguideComponents {
 		self::MESSAGES_FILE_SUFFIX;
 	}
 
+	/**
+	 * Include components messages files when recompiling the language cache
+	 * @param $wgExtensionMessagesFiles - array with extensions' message files
+	 * @return bool hook run status
+	 */
+	public static function onBeforeExtensionMessagesRecache( &$wgExtensionMessagesFiles ) {
+		// we don't want to use componentsNames from the cache when rebuilding the cache, as it won't speedup the process
+		// anyway and we risk some of the messages won't get cached
+		foreach( StyleguideComponents::loadComponentsFromFileSystem() as $componentName ) {
+			$componentMessageFile = self::getComponentMessagesFileFullPath( $componentName );
+			$wgExtensionMessagesFiles['StyleguideComponents' . ucfirst($componentName) ] = $componentMessageFile;
+		}
+
+		return true;
+	}
+
 }

--- a/includes/LocalisationCache.php
+++ b/includes/LocalisationCache.php
@@ -653,9 +653,12 @@ class LocalisationCache {
 
 		$codeSequence = array_merge( array( $code ), $coreData['fallbackSequence'] );
 
-		// wikia changes begin
+		// wikia change begin
+		// author: mech
+		// allow extensions to use hook to add messages files
+		// this can be used in cases when enumerating message files is expensive so it shouldn't be done in setup file
 		wfRunHooks( 'BeforeExtensionMessagesRecache', array( &$wgExtensionMessagesFiles ) );
-		// wikia changes end
+		// wikia change end
 
 		# Load the extension localisations
 		# This is done after the core because we know the fallback sequence now.

--- a/includes/LocalisationCache.php
+++ b/includes/LocalisationCache.php
@@ -653,6 +653,10 @@ class LocalisationCache {
 
 		$codeSequence = array_merge( array( $code ), $coreData['fallbackSequence'] );
 
+		// wikia changes begin
+		wfRunHooks( 'BeforeExtensionMessagesRecache', array( &$wgExtensionMessagesFiles ) );
+		// wikia changes end
+
 		# Load the extension localisations
 		# This is done after the core because we know the fallback sequence now.
 		# But it has a higher precedence for merging so that we can support things


### PR DESCRIPTION
As enumerating all language files for components is heavy, we cannot do it on every request in setup file. So we moved it to a new hook, which is called when localisation cache is rebuilt
