### PR TITLE
VID-695 fixing header width on lightbox

### DIFF
--- a/extensions/wikia/Lightbox/css/Lightbox.scss
+++ b/extensions/wikia/Lightbox/css/Lightbox.scss
@@ -459,10 +459,10 @@ $color-lightbox-border: mix($color-page-border, $color-page, 75%);
 
 	.LightboxHeader {
 		border-bottom: 1px solid $color-lightbox-border;
-		height: 50px;
+		box-sizing: border-box;
 		padding: 20px 20px 10px;
 		top: 0;
-		width: 960px;
+		width: 100%;
 		z-index: 2;
 		h1 {
 			float: left;

--- a/extensions/wikia/Lightbox/css/Lightbox.scss
+++ b/extensions/wikia/Lightbox/css/Lightbox.scss
@@ -460,6 +460,7 @@ $color-lightbox-border: mix($color-page-border, $color-page, 75%);
 	.LightboxHeader {
 		border-bottom: 1px solid $color-lightbox-border;
 		box-sizing: border-box;
+		height: 80px;
 		padding: 20px 20px 10px;
 		top: 0;
 		width: 100%;


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/VID-695

Looks like the padding on the modal has changed back and forth a few times so this commit sets the width of the header to the width of the modal regardless of padding. 
