### PR TITLE
Vid 696 history page undo ux

### DIFF
--- a/extensions/wikia/LicensedVideoSwap/js/lvsCommonAjax.js
+++ b/extensions/wikia/LicensedVideoSwap/js/lvsCommonAjax.js
@@ -51,6 +51,7 @@ define( 'lvs.commonajax', ['wikia.window', 'lvs.tracker'], function( window, tra
 	return {
 		init: init,
 		startLoadingGraphic: startLoadingGraphic,
+		stopLoadingGraphic: stopLoadingGraphic,
 		success: success,
 		failure: failure
 	}

--- a/extensions/wikia/LicensedVideoSwap/js/lvsHistoryPage.js
+++ b/extensions/wikia/LicensedVideoSwap/js/lvsHistoryPage.js
@@ -20,9 +20,7 @@ require([
 
 	LVSHistoryPage.prototype = {
 		init: function() {
-			this.bindListAnchors();
-		},
-		bindListAnchors: function() {
+			// bind click event on undo links
 			this.$el.on( 'click', '.undo-link', $.proxy( this.handleUndoClick, this ) );
 		},
 		undoSwap: function(url) {

--- a/extensions/wikia/LicensedVideoSwap/js/lvsHistoryPage.js
+++ b/extensions/wikia/LicensedVideoSwap/js/lvsHistoryPage.js
@@ -12,7 +12,6 @@ require([
 
 		// wait for DOM ready
 		$(function() {
-			that.location = window.location.href;
 			that.$el = $(opts.el);
 			that.init();
 		});
@@ -21,61 +20,44 @@ require([
 
 	LVSHistoryPage.prototype = {
 		init: function() {
-			this.redirectUrl = this.buildRedirectUrl();
-			this.bindUndoEvents();
 			this.bindListAnchors();
 		},
-		buildRedirectUrl: function() {
-			// redirect back to main LVS page
-			return this.location.replace('/History', '');
-		},
-		bindUndoEvents: function() {
-			var events,
-					that;
-
-			that = this;
-			events = [
-				'undo.clicked',
-				'undo.failed'
-			];
-
-			this.$el.on( events.join(' '), function(evt) {
-				// build function name from namespace and evoke
-				var state = evt.namespace;
-				if (state === 'clicked') {
-					return that.handleUndoClick();
-				} else {
-					return that.handleUndoFail();
-				}
-			});
-		},
 		bindListAnchors: function() {
-			var that = this;
-
-			this.$el.on('click', '.undo-link', function(evt) {
-				var url = evt.target.href;
-				evt.preventDefault();
-
-				that.$el.trigger('undo.clicked');
-
-				that.undoSwap(url)
-					.success(function() {
-						window.location = that.redirectUrl;
-					})
-					.error(function() {
-						that.$el.trigger('undo.failed');
-					});
-			});
+			this.$el.on( 'click', '.undo-link', $.proxy( this.handleUndoClick, this ) );
 		},
 		undoSwap: function(url) {
 			// returns the promise
 			return $.get(url);
 		},
-		handleUndoClick: function() {
+		handleUndoClick: function( evt ) {
+			evt.preventDefault();
+
+			var target = evt.target,
+				url = target.href,
+				that = this;
+
 			commonAjax.startLoadingGraphic();
+
+			this.undoSwap(url)
+				.success(function( data ) {
+					if ( data.result == "error" ) {
+						that.handleUndoFail( data.msg );
+					} else {
+						that.handleUndoSuccess( data.msg, target );
+					}
+				})
+				.error(function() {
+					that.handleUndoFail( $.msg( 'oasis-generic-error' ) );
+				});
 		},
-		handleUndoFail: function() {
+		handleUndoFail: function( msg ) {
 			commonAjax.stopLoadingGraphic();
+			GlobalNotification.show( msg, 'error' );
+		},
+		handleUndoSuccess: function( msg, target ) {
+			$( target ).closest( 'li' ).remove();
+			commonAjax.stopLoadingGraphic();
+			GlobalNotification.show( msg, 'confirm' );
 		},
 		// restore clobbered constructor
 		constructor: LVSHistoryPage

--- a/extensions/wikia/LicensedVideoSwap/js/lvsHistoryPage.js
+++ b/extensions/wikia/LicensedVideoSwap/js/lvsHistoryPage.js
@@ -38,7 +38,7 @@ require([
 
 			this.undoSwap(url)
 				.success(function( data ) {
-					if ( data.result == "error" ) {
+					if ( data.result === "error" ) {
 						that.handleUndoFail( data.msg );
 					} else {
 						that.handleUndoSuccess( data.msg, target );

--- a/extensions/wikia/LicensedVideoSwap/js/lvsHistoryPage.js
+++ b/extensions/wikia/LicensedVideoSwap/js/lvsHistoryPage.js
@@ -3,8 +3,8 @@
  * @author Kenneth Kouot <kenneth@wikia-inc.com>
  */
 require([
-		'jquery',
-		'lvs.commonajax'
+	'jquery',
+	'lvs.commonajax'
 ], function($, commonAjax) {
 
 	function LVSHistoryPage(opts) {


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/VID-696

Keeps the user on the LVS history page after undoing a swap/keep.  Displays global notifications when the request fails, when an error message is returned, and when a success message is returned.  
