### PR TITLE
Add page title to track for all pages

### DIFF
--- a/extensions/wikia/Track/Track.php
+++ b/extensions/wikia/Track/Track.php
@@ -32,7 +32,7 @@ class Track {
 			'ip='.$ip.$sep.
 			'a='.(is_object($wgArticle) ? $wgArticle->getID() : null).$sep.
 			's='.RequestContext::getMain()->getSkin()->getSkinName().
-			($wgTitle && !is_object($wgArticle) ? $sep.'pg='.urlencode($wgTitle->getPrefixedDBkey()) : '').
+			(is_object($wgTitle) ? $sep.'pg='.urlencode($wgTitle->getPrefixedDBkey()) : '').
 			($wgTitle ? $sep.'n='.$wgTitle->getNamespace() : '').
 			(!empty($wgAdServerTest) ? $sep.'db_test=1' : '');
 
@@ -50,7 +50,7 @@ class Track {
 		global $wgDevelEnvironment, $wgJsMimeType;
 
 		// Fake beacon and varnishTime values for development environment
-		if ( !empty( $wgDevelEnvironment ) ) {
+		if ( empty( $wgDevelEnvironment ) ) {
 			$script = '<script>var beacon_id = "ThisIsFake", varnishTime = "' . date( "r" ) . '";</script>';
 
 		} else {

--- a/extensions/wikia/Track/Track.php
+++ b/extensions/wikia/Track/Track.php
@@ -50,7 +50,7 @@ class Track {
 		global $wgDevelEnvironment, $wgJsMimeType;
 
 		// Fake beacon and varnishTime values for development environment
-		if ( empty( $wgDevelEnvironment ) ) {
+		if ( !empty( $wgDevelEnvironment ) ) {
 			$script = '<script>var beacon_id = "ThisIsFake", varnishTime = "' . date( "r" ) . '";</script>';
 
 		} else {


### PR DESCRIPTION
@garthwebb @federico-lox 

Hey Guys

I am currently working on PathFinder project 
that takes scribe logs and give you possibility to create paths and graphs on how users are going from an article to an article

Piece I am missing is an article title - there is ID of it but I am doing it outside MW stack therefore I'd need to use API to get this titles what would slow down my project and also might be bit heavy for our servers needlessly

I have this 'fixing' implemented - that pings our servers and updates my DB with title
I'd love to uses titles provieded by scribe

Let me know if you need more info
I'd love to have it on prod next Wednsday to start collecting data.

Thanks
