### PR TITLE
BAC-629: add a backtrace reporting to modil

### DIFF
--- a/resources/wikia/libraries/modil/modil.js
+++ b/resources/wikia/libraries/modil/modil.js
@@ -135,7 +135,7 @@
 	 */
 	define = function (id, dependencies, definition, defMock) {
 		if (typeof id !== strType) {
-			throw "Module id missing or not a string.";
+			throw "Module id missing or not a string. " + (new Error().stack||'').replace(/\n/g, ' / ');
 		}
 
 		//no dependencies array, it's actually the definition


### PR DESCRIPTION
We need more information to fix BAC-629. The following entries will be added to jserror.log:

```
 /l?["uncaught exception: Module id missing or not a string. define@http://macbre.wikia-dev.com/__load/-/cb%3D1375976812&debug%3Dfalse&lang%3Dpl&only%3Dscripts&skin%3Doasis/amd|wikia.tracker.stub|wikia.cookies,geo,window:2 / @http://macbre.wikia-dev.com/__am/1375976812/groups/-/oasis_shared_core_js,adengine2_js,oasis_shared_js,oasis_anon_js:2476 / ","",0,"LON"] "client": "10.8.68.51", "X-Forwarded-For": 212.91.26.151, "referrer": "http://poznan.macbre.wikia-dev.com/wiki/Gzik" "user-agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:23.0) Gecko/20100101 Firefox/23.0"
```

@gabrys / @federico-lox - please review
