### PR TITLE
(CE-224) Fix Chrome Spacing Error on History Pages

### DIFF
--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -27,7 +27,6 @@ $wgHooks['AllowNotifyOnPageChange']  [] = "Wikia::allowNotifyOnPageChange";
 $wgHooks['AfterInitialize']          [] = "Wikia::onAfterInitialize";
 $wgHooks['UserMailerSend']           [] = "Wikia::onUserMailerSend";
 $wgHooks['ArticleDeleteComplete']    [] = "Wikia::onArticleDeleteComplete";
-$wgHooks['PageHistoryLineEnding']    [] = "Wikia::onPageHistoryLineEnding";
 $wgHooks['ContributionsToolLinks']   [] = 'Wikia::onContributionsToolLinks';
 $wgHooks['AjaxAddScript'][] = 'Wikia::onAjaxAddScript';
 
@@ -1861,15 +1860,6 @@ class Wikia {
 		if ( $title instanceof Title ) {
 			$title->getArticleID( Title::GAID_FOR_UPDATE );
 		}
-		return true;
-	}
-
-	/**
-	 * Fix for bugid:38093
-	 * Chrome bug: No "Undo" links on Recent Changes
-	 */
-	public static function onPageHistoryLineEnding( $HistoryActionObj, $row , &$s, $classes ) {
-		$s = '<span dir="auto">'.$s.'</span>';
 		return true;
 	}
 

--- a/skins/oasis/css/core/article.scss
+++ b/skins/oasis/css/core/article.scss
@@ -340,10 +340,6 @@
 			background-color: $color-pagehistory;
 			border-style: dashed;
 		}
-		.mw-rollback-link, .mw-history-undo {
-			margin-left: 4px;
-		}
-
 	}
 	//diff page
 	td.diff-context {


### PR DESCRIPTION
This reverts two previous fixes, which fixes both the spacing issue
and the missing undo links in Chrome on history pages when the entry
goes onto the next line.

This fixes the issue fully as explained in https://github.com/Wikia/app/pull/1304
