### PR TITLE
PLA-460 use left join to filter broken links

### DIFF
--- a/extensions/wikia/LinkSuggest/LinkSuggest.class.php
+++ b/extensions/wikia/LinkSuggest/LinkSuggest.class.php
@@ -164,13 +164,24 @@ class LinkSuggest {
 
 		$pageNamespaceClause = isset($commaJoinedNamespaces) ?  'page_namespace IN (' . $commaJoinedNamespaces . ') AND ' : '';
 		if( count($results) < $wgLinkSuggestLimit ) {
-
+			$pageTitlePrefilter = "";
+			if( strlen($queryLower) >= 2 ) {
+				$pageTitlePrefilter = "(
+							(page_title " . $db->buildLike(strtolower($queryLower[0]) . strtolower($queryLower[1]) , $db->anyString() ) . ") OR
+							(page_title " . $db->buildLike(strtoupper($queryLower[0]) . strtolower($queryLower[1]) , $db->anyString() ) . ") OR
+							(page_title " . $db->buildLike(strtolower($queryLower[0]) . strtoupper($queryLower[1]) , $db->anyString() ) . ") OR
+							(page_title " . $db->buildLike(strtoupper($queryLower[0]) . strtoupper($queryLower[1]) , $db->anyString() ) . ") ) AND ";
+			} else if( strlen($queryLower) >= 1 ) {
+				$pageTitlePrefilter = "(
+							(page_title " . $db->buildLike(strtolower($queryLower[0]) , $db->anyString() ) . " ) OR
+							(page_title " . $db->buildLike(strtoupper($queryLower[0]) , $db->anyString() ) . " ) ) AND ";
+			}
 			// TODO: use $db->select helper method
 			$sql = "SELECT page_len, page_id, page_title, rd_title, page_namespace, page_is_redirect
-						FROM page IGNORE INDEX (`name_title`)
+						FROM page
 						LEFT JOIN redirect ON page_is_redirect = 1 AND page_id = rd_from
 						LEFT JOIN querycache ON qc_title = page_title AND qc_type = 'BrokenRedirects'
-						WHERE {$pageNamespaceClause} (LOWER(page_title) LIKE '{$queryLower}%')
+						WHERE  {$pageTitlePrefilter} {$pageNamespaceClause} (LOWER(page_title) LIKE '{$queryLower}%')
 							AND qc_type IS NULL
 						LIMIT ".($wgLinkSuggestLimit * 3);
 
@@ -291,9 +302,9 @@ class LinkSuggest {
 	 */
 
 	static private function replaceResultIfRedirected(&$results, &$redirects) {
-		foreach($results as &$val){
-			if (isset($redirects[$val])) {
-				$val = $redirects[$val];
+		for($i = 0; $i < count($results); $i++) {
+			if (isset($redirects[$results[$i]])) {
+				$results[$i] = $redirects[$results[$i]];
 			}
 		}
 	}

--- a/extensions/wikia/LinkSuggest/LinkSuggest.class.php
+++ b/extensions/wikia/LinkSuggest/LinkSuggest.class.php
@@ -164,17 +164,17 @@ class LinkSuggest {
 
 		$pageNamespaceClause = isset($commaJoinedNamespaces) ?  'page_namespace IN (' . $commaJoinedNamespaces . ') AND ' : '';
 		if( count($results) < $wgLinkSuggestLimit ) {
+			/**
+			 * @var string $pageTitlePrefilter this condition is able to use name_title index. It's added only for performance reasons.
+			 * It uses fact that page titles can't start with lowercase letter.
+			 */
 			$pageTitlePrefilter = "";
 			if( strlen($queryLower) >= 2 ) {
 				$pageTitlePrefilter = "(
-							(page_title " . $db->buildLike(strtolower($queryLower[0]) . strtolower($queryLower[1]) , $db->anyString() ) . ") OR
-							(page_title " . $db->buildLike(strtoupper($queryLower[0]) . strtolower($queryLower[1]) , $db->anyString() ) . ") OR
-							(page_title " . $db->buildLike(strtolower($queryLower[0]) . strtoupper($queryLower[1]) , $db->anyString() ) . ") OR
-							(page_title " . $db->buildLike(strtoupper($queryLower[0]) . strtoupper($queryLower[1]) , $db->anyString() ) . ") ) AND ";
+							( page_title " . $db->buildLike(strtoupper($queryLower[0]) . strtolower($queryLower[1]) , $db->anyString() ) . " ) OR
+							( page_title " . $db->buildLike(strtoupper($queryLower[0]) . strtoupper($queryLower[1]) , $db->anyString() ) . " ) ) AND ";
 			} else if( strlen($queryLower) >= 1 ) {
-				$pageTitlePrefilter = "(
-							(page_title " . $db->buildLike(strtolower($queryLower[0]) , $db->anyString() ) . " ) OR
-							(page_title " . $db->buildLike(strtoupper($queryLower[0]) , $db->anyString() ) . " ) ) AND ";
+				$pageTitlePrefilter = "( page_title " . $db->buildLike(strtoupper($queryLower[0]) , $db->anyString() ) . " ) AND ";
 			}
 			// TODO: use $db->select helper method
 			$sql = "SELECT page_len, page_id, page_title, rd_title, page_namespace, page_is_redirect

--- a/extensions/wikia/LinkSuggest/LinkSuggest.class.php
+++ b/extensions/wikia/LinkSuggest/LinkSuggest.class.php
@@ -184,7 +184,7 @@ class LinkSuggest {
 						WHERE  {$pageTitlePrefilter} {$pageNamespaceClause} (LOWER(page_title) LIKE '{$queryLower}%')
 							AND qc_type IS NULL
 						ORDER BY page_title
-						LIMIT ".($wgLinkSuggestLimit * 3);
+						LIMIT ".($wgLinkSuggestLimit * 3); // we fetch 3 times more results to leave out redirects to the same page
 
 			$res = $db->query($sql, __METHOD__);
 

--- a/extensions/wikia/LinkSuggest/LinkSuggest.class.php
+++ b/extensions/wikia/LinkSuggest/LinkSuggest.class.php
@@ -183,7 +183,6 @@ class LinkSuggest {
 						LEFT JOIN querycache ON qc_title = page_title AND qc_type = 'BrokenRedirects'
 						WHERE  {$pageTitlePrefilter} {$pageNamespaceClause} (LOWER(page_title) LIKE '{$queryLower}%')
 							AND qc_type IS NULL
-						ORDER BY page_title
 						LIMIT ".($wgLinkSuggestLimit * 3); // we fetch 3 times more results to leave out redirects to the same page
 
 			$res = $db->query($sql, __METHOD__);

--- a/extensions/wikia/LinkSuggest/LinkSuggest.class.php
+++ b/extensions/wikia/LinkSuggest/LinkSuggest.class.php
@@ -183,6 +183,7 @@ class LinkSuggest {
 						LEFT JOIN querycache ON qc_title = page_title AND qc_type = 'BrokenRedirects'
 						WHERE  {$pageTitlePrefilter} {$pageNamespaceClause} (LOWER(page_title) LIKE '{$queryLower}%')
 							AND qc_type IS NULL
+						ORDER BY page_title
 						LIMIT ".($wgLinkSuggestLimit * 3);
 
 			$res = $db->query($sql, __METHOD__);

--- a/extensions/wikia/LinkSuggest/LinkSuggest.class.php
+++ b/extensions/wikia/LinkSuggest/LinkSuggest.class.php
@@ -169,9 +169,9 @@ class LinkSuggest {
 			$sql = "SELECT page_len, page_id, page_title, rd_title, page_namespace, page_is_redirect
 						FROM page IGNORE INDEX (`name_title`)
 						LEFT JOIN redirect ON page_is_redirect = 1 AND page_id = rd_from
-						LEFT JOIN querycache ON qc_title = page_title
-						WHERE {$pageNamespaceClause} (page_title LIKE '{$query}%' or LOWER(page_title) LIKE '{$queryLower}%')
-							AND ( qc_type != 'BrokenRedirects' OR qc_type IS NULL )
+						LEFT JOIN querycache ON qc_title = page_title AND qc_type = 'BrokenRedirects'
+						WHERE {$pageNamespaceClause} (LOWER(page_title) LIKE '{$queryLower}%')
+							AND qc_type IS NULL
 						LIMIT ".($wgLinkSuggestLimit * 3);
 
 			$res = $db->query($sql, __METHOD__);

--- a/extensions/wikia/LinkSuggest/LinkSuggest.class.php
+++ b/extensions/wikia/LinkSuggest/LinkSuggest.class.php
@@ -302,9 +302,9 @@ class LinkSuggest {
 	 */
 
 	static private function replaceResultIfRedirected(&$results, &$redirects) {
-		for($i = 0; $i < count($results); $i++) {
-			if (isset($redirects[$results[$i]])) {
-				$results[$i] = $redirects[$results[$i]];
+		foreach($results as &$val){
+			if (isset($redirects[$val])) {
+				$val = $redirects[$val];
 			}
 		}
 	}

--- a/extensions/wikia/LinkSuggest/performance_tests/Performance.class.php
+++ b/extensions/wikia/LinkSuggest/performance_tests/Performance.class.php
@@ -1,0 +1,54 @@
+<?php
+
+require_once( dirname( __FILE__ ) . '/../../../../maintenance/Maintenance.php' );
+
+require_once( dirname( __FILE__ ) . '/Query_A.class.php' );
+require_once( dirname( __FILE__ ) . '/Query_B.class.php' );
+require_once( dirname( __FILE__ ) . '/Query_C.class.php' );
+
+$top100WikisBySize = [23556,43339,11557,83063,64030,10171,12716,11845,32379,547090,74842,95,40,2233,147,51687,103977,490,100562,2237,324,30696,4486,2311,2148,98707,119971,39089,2510,52285,1763,60540,110714,131376,3355,323,1657,24816,113,644,125,20,38322,989,4184,119902,280741,416886,615,2751,48406,831,203773,67345,94117,73,4099,1562,1544,31618,196577,304,49812,114,99007,97596,58191,283,129529,984,7708,410,916,93888,44810,374,1706,4630,179,425,3156,2777,101751,2400,174,100073,26,117144,108788,674351,94047,93612,521442,3591,3035,7107,10167,1865,115251,49688];
+
+class Performance extends Maintenance {
+
+	public function __construct() {
+		parent::__construct();
+		$this->addOption( "wikiIds", "The username to operate on", false, true );
+		$this->mDescription = "Change a user's password";
+	}
+
+	/**
+	 * @return Query_A[]
+	 */
+	protected function getVersionsToTest() {
+		return [ new Query_A(), new Query_B(), new Query_C() ];
+	}
+
+	protected function getQueriesToTest() {
+		return [ "fff", "ff", "lis", "john_pric", "mafasas_dfasdfasdf_dfasd"];
+	}
+
+	public function execute() {
+		global $top100WikisBySize;
+		$wikis = $this->getOption( "wikiIds", $top100WikisBySize );
+		if( is_string($wikis) ) {
+			$wikis = explode( ',', $wikis );
+		}
+
+		$linkSuggestVersions = $this->getVersionsToTest();
+
+		foreach( $wikis as $wikiId ) {
+			$db = WikiFactory::IDtoDB( $wikiId );
+			if ( empty( $db ) ) { continue; }
+			foreach( $this->getQueriesToTest() as $query ) {
+				foreach( $linkSuggestVersions as $linkSuggestVersion ) {
+					$time = $linkSuggestVersion->performQueryTest( $wikiId, $query );
+					echo implode( ";", [$db, $linkSuggestVersion->getKey(), $query, $time] ) . "\n";
+					usleep(300000);
+				}
+			}
+		}
+	}
+}
+
+$maintClass = "Performance";
+require_once( DO_MAINTENANCE );

--- a/extensions/wikia/LinkSuggest/performance_tests/Query_A.class.php
+++ b/extensions/wikia/LinkSuggest/performance_tests/Query_A.class.php
@@ -1,0 +1,54 @@
+<?php
+
+class Query_A {
+
+	public function getKey() {
+		return "order-by-ns-and-title";
+	}
+
+	/**
+	 * @param $wikiId
+	 * @param $query
+	 * @return float
+	 */
+	public function performQueryTest($wikiId, $query) {
+		$wgLinkSuggestLimit = 6;
+		$dbName = WikiFactory::IDtoDB( $wikiId );
+		$db = wfGetDB(DB_SLAVE, [], $dbName);
+		$namespaces = WikiFactory::getVarValueByName("wgContentNamespaces", $wikiId);
+		$namespaces = $namespaces ? $namespaces : [0];
+		$query = addslashes($query);
+
+		$queryLower = strtolower($query);
+
+		if (count($namespaces) > 0) {
+			$commaJoinedNamespaces = count($namespaces) > 1 ? array_shift($namespaces) . ', ' . implode(', ', $namespaces) : $namespaces[0];
+		}
+
+		$pageNamespaceClause = isset($commaJoinedNamespaces) ? 'page_namespace IN (' . $commaJoinedNamespaces . ') AND ' : '';
+
+		$pageTitlePrefilter = "";
+		if (strlen($queryLower) >= 2) {
+			$pageTitlePrefilter = "(
+							( page_title " . $db->buildLike(strtoupper($queryLower[0]) . strtolower($queryLower[1]), $db->anyString()) . " ) OR
+							( page_title " . $db->buildLike(strtoupper($queryLower[0]) . strtoupper($queryLower[1]), $db->anyString()) . " ) ) AND ";
+		} else if (strlen($queryLower) >= 1) {
+			$pageTitlePrefilter = "( page_title " . $db->buildLike(strtoupper($queryLower[0]), $db->anyString()) . " ) AND ";
+		}
+
+		$sql = "SELECT page_len, page_id, page_title, rd_title, page_namespace, page_is_redirect
+						FROM page
+						LEFT JOIN redirect ON page_is_redirect = 1 AND page_id = rd_from
+						LEFT JOIN querycache ON qc_title = page_title AND qc_type = 'BrokenRedirects'
+						WHERE  {$pageTitlePrefilter} {$pageNamespaceClause} (LOWER(page_title) LIKE '{$queryLower}%')
+							AND qc_type IS NULL
+						ORDER BY page_namespace,page_title
+						LIMIT " . ($wgLinkSuggestLimit * 3); // we fetch 3 times more results to leave out redirects to the same page
+
+		$start = microtime(true);
+		$res = $db->query($sql, __METHOD__);
+		while( $res->fetchRow() ) {}
+
+		return microtime(true) - $start;
+	}
+}

--- a/extensions/wikia/LinkSuggest/performance_tests/Query_B.class.php
+++ b/extensions/wikia/LinkSuggest/performance_tests/Query_B.class.php
@@ -1,0 +1,54 @@
+<?php
+
+class Query_B {
+
+	public function getKey() {
+		return "order-by-page_id";
+	}
+
+	/**
+	 * @param $wikiId
+	 * @param $query
+	 * @return float
+	 */
+	public function performQueryTest($wikiId, $query) {
+		$wgLinkSuggestLimit = 6;
+		$dbName = WikiFactory::IDtoDB( $wikiId );
+		$db = wfGetDB(DB_SLAVE, [], $dbName);
+		$namespaces = WikiFactory::getVarValueByName("wgContentNamespaces", $wikiId);
+		$namespaces = $namespaces ? $namespaces : [0];
+		$query = addslashes($query);
+
+		$queryLower = strtolower($query);
+
+		if (count($namespaces) > 0) {
+			$commaJoinedNamespaces = count($namespaces) > 1 ? array_shift($namespaces) . ', ' . implode(', ', $namespaces) : $namespaces[0];
+		}
+
+		$pageNamespaceClause = isset($commaJoinedNamespaces) ? 'page_namespace IN (' . $commaJoinedNamespaces . ') AND ' : '';
+
+		$pageTitlePrefilter = "";
+		if (strlen($queryLower) >= 2) {
+			$pageTitlePrefilter = "(
+							( page_title " . $db->buildLike(strtoupper($queryLower[0]) . strtolower($queryLower[1]), $db->anyString()) . " ) OR
+							( page_title " . $db->buildLike(strtoupper($queryLower[0]) . strtoupper($queryLower[1]), $db->anyString()) . " ) ) AND ";
+		} else if (strlen($queryLower) >= 1) {
+			$pageTitlePrefilter = "( page_title " . $db->buildLike(strtoupper($queryLower[0]), $db->anyString()) . " ) AND ";
+		}
+
+		$sql = "SELECT page_len, page_id, page_title, rd_title, page_namespace, page_is_redirect
+						FROM page
+						LEFT JOIN redirect ON page_is_redirect = 1 AND page_id = rd_from
+						LEFT JOIN querycache ON qc_title = page_title AND qc_type = 'BrokenRedirects'
+						WHERE  {$pageTitlePrefilter} {$pageNamespaceClause} (LOWER(page_title) LIKE '{$queryLower}%')
+							AND qc_type IS NULL
+						ORDER BY page_id
+						LIMIT " . ($wgLinkSuggestLimit * 3); // we fetch 3 times more results to leave out redirects to the same page
+
+		$start = microtime(true);
+		$res = $db->query($sql, __METHOD__);
+		while( $res->fetchRow() ) {}
+
+		return microtime(true) - $start;
+	}
+}

--- a/extensions/wikia/LinkSuggest/performance_tests/Query_C.class.php
+++ b/extensions/wikia/LinkSuggest/performance_tests/Query_C.class.php
@@ -1,0 +1,53 @@
+<?php
+
+class Query_C {
+
+	public function getKey() {
+		return "no-order-by";
+	}
+
+	/**
+	 * @param $wikiId
+	 * @param $query
+	 * @return float
+	 */
+	public function performQueryTest($wikiId, $query) {
+		$wgLinkSuggestLimit = 6;
+		$dbName = WikiFactory::IDtoDB( $wikiId );
+		$db = wfGetDB(DB_SLAVE, [], $dbName);
+		$namespaces = WikiFactory::getVarValueByName("wgContentNamespaces", $wikiId);
+		$namespaces = $namespaces ? $namespaces : [0];
+		$query = addslashes($query);
+
+		$queryLower = strtolower($query);
+
+		if (count($namespaces) > 0) {
+			$commaJoinedNamespaces = count($namespaces) > 1 ? array_shift($namespaces) . ', ' . implode(', ', $namespaces) : $namespaces[0];
+		}
+
+		$pageNamespaceClause = isset($commaJoinedNamespaces) ? 'page_namespace IN (' . $commaJoinedNamespaces . ') AND ' : '';
+
+		$pageTitlePrefilter = "";
+		if (strlen($queryLower) >= 2) {
+			$pageTitlePrefilter = "(
+							( page_title " . $db->buildLike(strtoupper($queryLower[0]) . strtolower($queryLower[1]), $db->anyString()) . " ) OR
+							( page_title " . $db->buildLike(strtoupper($queryLower[0]) . strtoupper($queryLower[1]), $db->anyString()) . " ) ) AND ";
+		} else if (strlen($queryLower) >= 1) {
+			$pageTitlePrefilter = "( page_title " . $db->buildLike(strtoupper($queryLower[0]), $db->anyString()) . " ) AND ";
+		}
+
+		$sql = "SELECT page_len, page_id, page_title, rd_title, page_namespace, page_is_redirect
+						FROM page
+						LEFT JOIN redirect ON page_is_redirect = 1 AND page_id = rd_from
+						LEFT JOIN querycache ON qc_title = page_title AND qc_type = 'BrokenRedirects'
+						WHERE  {$pageTitlePrefilter} {$pageNamespaceClause} (LOWER(page_title) LIKE '{$queryLower}%')
+							AND qc_type IS NULL
+						LIMIT " . ($wgLinkSuggestLimit * 3); // we fetch 3 times more results to leave out redirects to the same page
+
+		$start = microtime(true);
+		$res = $db->query($sql, __METHOD__);
+		while( $res->fetchRow() ) {}
+
+		return microtime(true) - $start;
+	}
+}


### PR DESCRIPTION
Don't merge. Just SQLReview.

@SQLReview 

mysql> explain SELECT page_len, page_id, page_title, rd_title, page_namespace, page_is_redirect FROM page IGNORE INDEX (`name_title`) LEFT JOIN redirect ON page_is_redirect = 1 AND page_id = rd_from LEFT JOIN querycache ON qc_title = page_title AND qc_type = 'BrokenRedirects' WHERE page_namespace IN (0) AND  (LOWER(page_title) LIKE 'john_pric%') AND ( qc_type IS NULL ) LIMIT 6;
+----+-------------+------------+--------+---------------+---------+---------+---------------------+--------+-------------------------+
| id | select_type | table      | type   | possible_keys | key     | key_len | ref                 | rows   | Extra                   |
+----+-------------+------------+--------+---------------+---------+---------+---------------------+--------+-------------------------+
|  1 | SIMPLE      | page       | ALL    | NULL          | NULL    | NULL    | NULL                | 149253 | Using where             |
|  1 | SIMPLE      | redirect   | eq_ref | PRIMARY       | PRIMARY | 4       | muppet.page.page_id |      1 |                         |
|  1 | SIMPLE      | querycache | ref    | qc_type       | qc_type | 32      | const               |      4 | Using where; Not exists |
+----+-------------+------------+--------+---------------+---------+---------+---------------------+--------+-------------------------+
3 rows in set (0.00 sec)
