### PR TITLE
Changed deprecated wfMsg method where possible.

### DIFF
--- a/extensions/wikia/StaffLog/StaffLog.events.php
+++ b/extensions/wikia/StaffLog/StaffLog.events.php
@@ -62,13 +62,13 @@ class StaffLogger {
 
 	static public function eventlogWFPublicStatusChange( $cityStatus, $cityId, $reason ) {
 		global $wgUser;
-		$comment = wfMsgForContent(
+		$comment = wfMessage(
 			'stafflog-wiki-status-change',
 			RenameUserLogFormatter::getCommunityUser( $wgUser->getName() ),
 			RenameUserLogFormatter::getCityLink( $cityId ),
 			$cityStatus,
 			$reason
-		);
+		)->inLanguage( 'en' )->text();
 		// sadly, $type and $action have 10-character limit, hence 'wikifactor' and 'pubstatus'.
 		self::log( 'wikifactor', 'pubstatus', $wgUser->getID(), $wgUser->getName(), '', '',  $comment );
 		return true;

--- a/extensions/wikia/StaffLog/StaffLog_body.php
+++ b/extensions/wikia/StaffLog/StaffLog_body.php
@@ -11,10 +11,10 @@ class StaffLog extends SpecialPage
 		parent::__construct( "stafflog","stafflog");
 		$this->aTypes = array(
 			'' => '',
-			'block' => wfMessage( 'stafflog-filter-type-block' )->inLanguage( $wgLang->getCode() )->text(),
-			'piggyback' => wfMessage( 'stafflog-filter-type-piggyback' )->inLanguage( $wgLang->getCode() )->text(),
-			'renameuser' => wfMessage( 'stafflog-filter-type-renameuser' )->inLanguage( $wgLang->getCode() )->text(),
-			'wikifactor' => wfMessage( 'stafflog-filter-type-wikifactory' )->inLanguage( $wgLang->getCode() )->text()
+			'block' => wfMessage( 'stafflog-filter-type-block' )->text(),
+			'piggyback' => wfMessage( 'stafflog-filter-type-piggyback' )->text(),
+			'renameuser' => wfMessage( 'stafflog-filter-type-renameuser' )->text(),
+			'wikifactor' => wfMessage( 'stafflog-filter-type-wikifactory' )->text()
 		);
 	}
 
@@ -162,14 +162,14 @@ class StaffLoggerPager extends ReverseChronologicalPager {
 						$linker->userLink($result->slog_user, $result->slog_user_name),
 						$linker->userLink($result->slog_userdst, $result->slog_user_namedst),
 						$siteurl,
-						strlen($result->slog_comment) > 0 ? $result->slog_comment:"-" ))->inLanguage( $wgLang->getCode() )->text();
+						strlen($result->slog_comment) > 0 ? $result->slog_comment:"-" ))->text();
 				break;
 			case  'piggyback':
 				$msg = $result->slog_action == "login" ? "stafflog-piggybackloginmsg" : "stafflog-piggybacklogoutmsg";
 				$out = wfMessage( $msg,
 					array($time,
 						$linker->userLink($result->slog_user, $result->slog_user_name),
-						$linker->userLink($result->slog_userdst, $result->slog_user_namedst)))->inLanguage( $wgLang->getCode() )->text();
+						$linker->userLink($result->slog_userdst, $result->slog_user_namedst)))->text();
 				break;
 			case 'wikifactor':
 				$out = $time . ' ' . $result->slog_comment;

--- a/extensions/wikia/StaffLog/StaffLog_body.php
+++ b/extensions/wikia/StaffLog/StaffLog_body.php
@@ -6,7 +6,7 @@ class StaffLog extends SpecialPage
 	private $aTypes = array( 'piggyback', 'wikifactor' );
 
 	function __construct(){
-		global $wgRequest, $wgLang;
+		global $wgRequest;
 		$this->request = &$wgRequest;
 		parent::__construct( "stafflog","stafflog");
 		$this->aTypes = array(

--- a/extensions/wikia/StaffLog/StaffLog_body.php
+++ b/extensions/wikia/StaffLog/StaffLog_body.php
@@ -6,15 +6,15 @@ class StaffLog extends SpecialPage
 	private $aTypes = array( 'piggyback', 'wikifactor' );
 
 	function __construct(){
-		global $wgRequest;
+		global $wgRequest, $wgLang;
 		$this->request = &$wgRequest;
 		parent::__construct( "stafflog","stafflog");
 		$this->aTypes = array(
 			'' => '',
-			'block' => wfMsg( 'stafflog-filter-type-block' ),
-			'piggyback' => wfMsg( 'stafflog-filter-type-piggyback' ),
-			'renameuser' => wfMsg( 'stafflog-filter-type-renameuser' ),
-			'wikifactor' => wfMsg( 'stafflog-filter-type-wikifactory' )
+			'block' => wfMessage( 'stafflog-filter-type-block' )->inLanguage( $wgLang->getCode() )->text(),
+			'piggyback' => wfMessage( 'stafflog-filter-type-piggyback' )->inLanguage( $wgLang->getCode() )->text(),
+			'renameuser' => wfMessage( 'stafflog-filter-type-renameuser' )->inLanguage( $wgLang->getCode() )->text(),
+			'wikifactor' => wfMessage( 'stafflog-filter-type-wikifactory' )->inLanguage( $wgLang->getCode() )->text()
 		);
 	}
 
@@ -157,19 +157,19 @@ class StaffLoggerPager extends ReverseChronologicalPager {
 				{
 					$siteurl =  Xml::tags('a', array("href" => "http://".$domains[0] ), $siteurl);
 				}
-				$out = wfMsg( 'stafflog-blockmsg' ,
+				$out = wfMessage( 'stafflog-blockmsg' ,
 					array($time,
 						$linker->userLink($result->slog_user, $result->slog_user_name),
 						$linker->userLink($result->slog_userdst, $result->slog_user_namedst),
 						$siteurl,
-						strlen($result->slog_comment) > 0 ? $result->slog_comment:"-" ));
+						strlen($result->slog_comment) > 0 ? $result->slog_comment:"-" ))->inLanguage( $wgLang->getCode() )->text();
 				break;
 			case  'piggyback':
 				$msg = $result->slog_action == "login" ? "stafflog-piggybackloginmsg" : "stafflog-piggybacklogoutmsg";
-				$out = wfMsg( $msg,
+				$out = wfMessage( $msg,
 					array($time,
 						$linker->userLink($result->slog_user, $result->slog_user_name),
-						$linker->userLink($result->slog_userdst, $result->slog_user_namedst)));
+						$linker->userLink($result->slog_userdst, $result->slog_user_namedst)))->inLanguage( $wgLang->getCode() )->text();
 				break;
 			case 'wikifactor':
 				$out = $time . ' ' . $result->slog_comment;


### PR DESCRIPTION
Most of log entries are now displayed using wfMessage method what fixed language issues when using StaffLog. Entries concerning user renaming or status changing are not translatable since they are inserted to a database as string into a comment field.
