### PR TITLE
PLA-547 serve small image in top articles if  only small is available.

### DIFF
--- a/extensions/wikia/Search/WikiaSearchController.class.php
+++ b/extensions/wikia/Search/WikiaSearchController.class.php
@@ -105,11 +105,15 @@ class WikiaSearchController extends WikiaSpecialPageController {
 				$detailResponse = $this->app->sendRequest( 'ArticlesApiController', 'getDetails', $params )->getData();
 				foreach ( $detailResponse['items'] as $id => $item ) {
 					if (! empty( $item['thumbnail'] ) ) {
+						$item['thumbnailSize'] = "small";
 						//get the first one image from imageServing as it needs other size
 						if ( empty( $pages ) ) {
 							$is = new ImageServing( [ $id ], 300, 150 );
 							$result = $is->getImages( 1 );
-							$item[ 'thumbnail' ] = $result[ $id ][ 0 ][ 'url' ];
+							if(! empty( $result[ $id ][ 0 ][ 'url' ] ) ) {
+								$item[ 'thumbnail' ] = $result[ $id ][ 0 ][ 'url' ];
+								$item['thumbnailSize'] = "large";
+							}
 						}
 						//render date
 						$item[ 'date' ] = $wgLang->date( $item[ 'revision' ][ 'timestamp' ] );

--- a/extensions/wikia/Search/templates/WikiaSearch_topWikiArticles.php
+++ b/extensions/wikia/Search/templates/WikiaSearch_topWikiArticles.php
@@ -3,7 +3,7 @@
 <div class="top-wiki-articles RailModule">
     <h1 class="top-wiki-main"><?= wfMessage( 'wikiasearch2-top-module-title' )->plain() ?></h1>
     <?php foreach ( $pages as $page ) : ?>
-    <?php if ( $counter == 0 ): ?>
+    <?php if ( !empty( $page["thumbnailSize"] ) && $page["thumbnailSize"] === "large" ): ?>
     <div class="top-wiki-article hot-article result">
         <div class="top-wiki-article-thumbnail" data-pos="<?= $counter ?>">
             <? if ( isset( $page['thumbnail'] ) ) : ?>


### PR DESCRIPTION
!! Just code review. No Q/A yet. !!

Hot results image sometimes wasn't displayed because there was image, just not big enought image. Solution is to display small image in such situation.

@idradm @relwell 
