### PR TITLE
Deleted $wgAbuseFilterBlockDuration definition.

### DIFF
--- a/extensions/AbuseFilter/AbuseFilter.php
+++ b/extensions/AbuseFilter/AbuseFilter.php
@@ -164,8 +164,5 @@ $wgAbuseFilterUDPPort = null;
 $wgAbuseFilterCentralDB = null;
 $wgAbuseFilterIsCentral = false;
 
-// Block duration
-$wgAbuseFilterBlockDuration = 'indefinite';
-
 // Callback functions for custom actions
 $wgAbuseFilterCustomActionsHandlers = array();


### PR DESCRIPTION
$wgAbuseFilterBlockDuration is now defined in CommonSettings.php and then overriden by WikiFactory.
