### PR TITLE
Improve performance of Wall code

### DIFF
--- a/extensions/wikia/Wall/WallHooksHelper.class.php
+++ b/extensions/wikia/Wall/WallHooksHelper.class.php
@@ -1979,15 +1979,24 @@ class WallHooksHelper {
 		return true;
 	}
 
+	/**
+	 * @param $title Title
+	 * @param $unused
+	 * @param $output
+	 * @param $user
+	 * @param $request
+	 * @param $mediawiki
+	 * @return bool
+	 */
 	static public function onBeforeInitialize( $title, $unused, $output, $user, $request, $mediawiki ) {
 		global $wgHooks;
 		if( !empty($title) && $title->isSpecial('Allpages') ) {
-			$wgHooks['AfterLanguageGetNamespaces'][] = 'WallHooksHelper::onAfterLanguageGetNamespaces';
+			$wgHooks['LanguageGetNamespaces'][] = 'WallHooksHelper::onLanguageGetNamespaces';
 		}
 		return true;
 	}
 
-	static public function onAfterLanguageGetNamespaces( &$namespaces ) {
+	static public function onLanguageGetNamespaces( &$namespaces ) {
 		wfProfileIn(__METHOD__);
 		$app = F::App();
 		$title = $app->wg->Title;

--- a/languages/Language.php
+++ b/languages/Language.php
@@ -366,11 +366,8 @@ class Language {
 
 			wfRunHooks( 'LanguageGetNamespaces', array( &$this->namespaceNames ) );
 		}
-		
-		$namespaceNames =  $this->namespaceNames;
-		wfRunHooks( 'AfterLanguageGetNamespaces', array( &$namespaceNames ) );
-		
-		return $namespaceNames;
+
+		return $this->namespaceNames;
 	}
 
 	/**


### PR DESCRIPTION
This change reduces calls to WallHooksHelper::onLanguageGetNamespaces to just one. Used to be 200+ on pages with looooots of links.
- partially revert e5458fbb088cb
- remove AfterLanguageGetNamespaces custom hook
- use LanguageGetNamespaces hook which is called only once and then the result is cached

@themech - please review and merge
