### PR TITLE
Removing 'x' icon from field for IE

### DIFF
--- a/extensions/wikia/CategorySelect/css/CategorySelect.scss
+++ b/extensions/wikia/CategorySelect/css/CategorySelect.scss
@@ -19,6 +19,9 @@
 
 		.input {
 			display: inline-block;
+			&::-ms-clear {
+				display: none;
+			}
 		}
 
 		> .toolbar {


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/VE-145
Merge anytime. It's just a simple CSS change to hide the default "x" button for clearing the field in IE10.
