### PR TITLE
DAR-319: Added more information for chat logs

### DIFF
--- a/extensions/CheckUser/CheckUser.hooks.php
+++ b/extensions/CheckUser/CheckUser.hooks.php
@@ -13,7 +13,7 @@ class CheckUserHooks {
 		$ip = wfGetIP();
 		// Get XFF header
 		$xff = $wgRequest->getHeader( 'X-Forwarded-For' );
-		list( $xff_ip, $isSquidOnly ) = self::getClientIPfromXFF( $xff );
+		list( $xff_ip, $isSquidOnly ) = IP::getClientIPfromXFF( $xff );
 		// Get agent
 		$agent = $wgRequest->getHeader( 'User-Agent' );
 		// Store the log action text for log events
@@ -70,7 +70,7 @@ class CheckUserHooks {
 
 		// Get XFF header
 		$xff = $wgRequest->getHeader( 'X-Forwarded-For' );
-		list( $xff_ip, $isSquidOnly ) = self::getClientIPfromXFF( $xff );
+		list( $xff_ip, $isSquidOnly ) = IP::getClientIPfromXFF( $xff );
 		// Get agent
 		$agent = $wgRequest->getHeader( 'User-Agent' );
 		$dbw = wfGetDB( DB_MASTER );
@@ -115,7 +115,7 @@ class CheckUserHooks {
 		$ip = wfGetIP();
 		// Get XFF header
 		$xff = $wgRequest->getHeader( 'X-Forwarded-For' );
-		list( $xff_ip, $isSquidOnly ) = self::getClientIPfromXFF( $xff );
+		list( $xff_ip, $isSquidOnly ) = IP::getClientIPfromXFF( $xff );
 		// Get agent
 		$agent = $wgRequest->getHeader( 'User-Agent' );
 		$dbw = wfGetDB( DB_MASTER );
@@ -180,7 +180,7 @@ class CheckUserHooks {
 		$ip = wfGetIP();
 		// Get XFF header
 		$xff = $wgRequest->getHeader( 'X-Forwarded-For' );
-		list( $xff_ip, $isSquidOnly ) = self::getClientIPfromXFF( $xff );
+		list( $xff_ip, $isSquidOnly ) = IP::getClientIPfromXFF( $xff );
 		// Get agent
 		$agent = $wgRequest->getHeader( 'User-Agent' );
 		$dbw = wfGetDB( DB_MASTER );
@@ -225,7 +225,7 @@ class CheckUserHooks {
 		$ip = $request->getIP();
 		// Get XFF header
 		$xff = $request->getHeader( 'X-Forwarded-For' );
-		list( $xff_ip, $isSquidOnly ) = self::getClientIPfromXFF( $xff );
+		list( $xff_ip, $isSquidOnly ) = IP::getClientIPfromXFF( $xff );
 		// Get agent
 		$agent = $request->getHeader( 'User-Agent' );
 
@@ -270,45 +270,7 @@ class CheckUserHooks {
 		return true;
 	}
 
-	/**
-	 * Locates the client IP within a given XFF string
-	 * @param string $xff
-	 * @return array( string, bool )
-	 */
-	public static function getClientIPfromXFF( $xff ) {
-		global $wgSquidServers, $wgSquidServersNoPurge;
-
-		if ( !$xff ) {
-			return array( null, false );
-		}
-
-		// Avoid annoyingly long xff hacks
-		$xff = trim( substr( $xff, 0, 255 ) );
-		$client = null;
-		$isSquidOnly = true;
-		$trusted = true;
-		// Check each IP, assuming they are separated by commas
-		$ips = explode( ',', $xff );
-		foreach ( $ips as $ip ) {
-			$ip = trim( $ip );
-			// If it is a valid IP, not a hash or such
-			if ( IP::isIPAddress( $ip ) ) {
-				# The first IP should be the client.
-				# Start only from the first public IP.
-				if ( is_null( $client ) ) {
-					if ( IP::isPublic( $ip ) ) {
-						$client = $ip;
-					}
-				} elseif ( !wfIsTrustedProxy( $ip ) )
-				{
-					$isSquidOnly = false;
-					break;
-				}
-			}
-		}
-
-		return array( $client, $isSquidOnly );
-	}
+	/** Wikia change -- moved getClientIPfromXFF() method to IP class */
 
 	public static function checkUserSchemaUpdates( DatabaseUpdater $updater ) {
 		$base = dirname( __FILE__ );

--- a/extensions/CheckUser/CheckUser.hooks.php
+++ b/extensions/CheckUser/CheckUser.hooks.php
@@ -31,10 +31,6 @@ class CheckUserHooks {
 			$actionText = '';
 		}
 
-		/** Wikia change -- start */
-		wfRunHooks( 'BeforeInsertCheckUserData', [ &$actionText, &$ip, &$xff ] );
-		/** Wikia change -- end */
-
 		$dbw = wfGetDB( DB_MASTER );
 		$cuc_id = $dbw->nextSequenceValue( 'cu_changes_cu_id_seq' );
 		$rcRow = array(

--- a/extensions/CheckUser/CheckUser.hooks.php
+++ b/extensions/CheckUser/CheckUser.hooks.php
@@ -31,6 +31,10 @@ class CheckUserHooks {
 			$actionText = '';
 		}
 
+		/** Wikia change -- start */
+		wfRunHooks( 'BeforeInsertCheckUserData', [ &$actionText, &$ip, &$xff ] );
+		/** Wikia change -- end */
+
 		$dbw = wfGetDB( DB_MASTER );
 		$cuc_id = $dbw->nextSequenceValue( 'cu_changes_cu_id_seq' );
 		$rcRow = array(

--- a/extensions/CheckUser/CheckUser_body.php
+++ b/extensions/CheckUser/CheckUser_body.php
@@ -1013,7 +1013,7 @@ class CheckUser extends SpecialPage {
 					# XFF string, link to /xff search
 					if ( $set[1] ) {
 						# Flag our trusted proxies
-						list( $client, $trusted ) = CheckUserHooks::getClientIPfromXFF( $set[1], $set[0] );
+						list( $client, $trusted ) = IP::getClientIPfromXFF( $set[1], $set[0] );
 						$c = $trusted ? '#F0FFF0' : '#FFFFCC';
 						$s .= '&#160;&#160;&#160;<span style="background-color: ' . $c . '"><strong>XFF</strong>: ';
 						$s .= $this->sk->makeKnownLinkObj( $this->getTitle(),
@@ -1156,7 +1156,7 @@ class CheckUser extends SpecialPage {
 		# XFF
 		if ( $row->cuc_xff != null ) {
 			# Flag our trusted proxies
-			list( $client, $trusted ) = CheckUserHooks::getClientIPfromXFF( $row->cuc_xff, $row->cuc_ip );
+			list( $client, $trusted ) = IP::getClientIPfromXFF( $row->cuc_xff, $row->cuc_ip );
 			$c = $trusted ? '#F0FFF0' : '#FFFFCC';
 			$line .= '&#160;&#160;&#160;<span class="mw-checkuser-xff" style="background-color: ' . $c . '">' .
 				'<strong>XFF</strong>: ';

--- a/extensions/wikia/Chat2/Chat.class.php
+++ b/extensions/wikia/Chat2/Chat.class.php
@@ -472,11 +472,9 @@ class Chat {
 			$log->addEntry( 'chatconnect', SpecialPage::getTitleFor( 'Chat' ), '', array( $ip ), $wgUser );
 
 			$xff = $wgRequest->getHeader( self::HTTP_HEADER_XFF );
+			list( $xff_ip, $isSquidOnly ) = IP::getClientIPfromXFF( $xff );
+
 			$userAgent = $wgRequest->getHeader( self::HTTP_HEADER_USER_AGENT );
-
-			$xff = ( $xff === false ) ? '' : $xff;
-			$userAgent = ( $userAgent === false ) ? null : $userAgent;
-
 			$dbw = wfGetDB( DB_MASTER );
 			$cuc_id = $dbw->nextSequenceValue( 'cu_changes_cu_id_seq' );
 			$rcRow = [
@@ -494,9 +492,9 @@ class Chat {
 					'cuc_timestamp'  => $dbw->timestamp(),
 					'cuc_ip'         => IP::sanitizeIP( $ip ),
 					'cuc_ip_hex'     => $ip ? IP::toHex( $ip ) : null,
-					'cuc_xff'        => $xff,
-					'cuc_xff_hex'    => null,
-					'cuc_agent'      => $userAgent
+					'cuc_xff'        => !$isSquidOnly ? $xff : '',
+					'cuc_xff_hex'    => ( $xff_ip && !$isSquidOnly ) ? IP::toHex( $xff_ip ) : null,
+					'cuc_agent'      => ( $userAgent === false ) ? null : $userAgent,
 			];
 
 			$dbw->insert( 'cu_changes', $rcRow, __METHOD__ );

--- a/extensions/wikia/Chat2/Chat.class.php
+++ b/extensions/wikia/Chat2/Chat.class.php
@@ -8,6 +8,9 @@
  * @author Sean Colombo
  */
 class Chat {
+	const HTTP_HEADER_XFF = 'X-FORWARDED-FOR';
+	const HTTP_HEADER_USER_AGENT = 'USER-AGENT';
+
 	var $chatId;
 
 	public function __construct($chatId){
@@ -359,24 +362,24 @@ class Chat {
 	 * Add a rights log entry for an action.
 	 * Partially copied from SpecialUserrights.php
 	 *
-	 * @param object $user User object
-	 * @param boolean $addGroups adding or removing groups?
-	 * @param array $groups names of groups
-	 * @param object $doer - the chatmoderator that banned the user (this is subed into an i18n message).
+	 * @param User $user
+	 * @param User $doer
+	 * @param Array $attr An array with parameters passed to LogPage::addEntry() according to description there these are parameters passed later to wfMsg.* functions
+	 * @param String $type
+	 * @param String|null $reasone comment added to log
 	 */
 	public static function addLogEntry($user, $doer, $attr, $type = 'banadd', $reasone = null) {
-		global $wgRequest;
 		wfProfileIn(__METHOD__);
 
 		$doerName = $doer->getName();
 
 		if( $type === 'chatmoderator' ) {
-			$reason = empty($reasone) ? wfMsgForContent('chat-userrightslog-a-made-b-chatmod', $doerName, $user->getName()):$reasone;
+			$reason = empty($reasone) ? wfMsgForContent( 'chat-userrightslog-a-made-b-chatmod', $doerName, $user->getName() ) : $reasone;
 			$type = 'rights';
 			$subtype = $type;
-		} elseif(strpos($type, 'ban') === 0) {
-			$reason = empty($reasone) ? wfMsgForContent('chat-log-reason-'.$type, $doerName):$reasone;
-			$subtype = 'chat'.$type;
+		} else if(strpos($type, 'ban') === 0) {
+			$reason = empty($reasone) ? wfMsgForContent( 'chat-log-reason-'.$type, $doerName ) : $reasone;
+			$subtype = 'chat' . $type;
 			$type =  'chatban';
 		}
 
@@ -394,7 +397,7 @@ class Chat {
 	/**
 	 * Logs to chatlog table that a user opened chat room
 	 *
-	 * Using chatlog table is temporaly. It'll be last till event_type_description table will be done.
+	 * Using chatlog table is temporally. It'll be last till event_type_description table will be done.
 	 * Now we have:
 	 * mysql> select * from event_type_details ;
 	 * +------------------------+------------+
@@ -412,7 +415,7 @@ class Chat {
 	 * @author Andrzej 'nAndy' Łukaszewski
 	 */
 	public static function logChatWindowOpenedEvent() {
-		global $wgCityId, $wgUser, $wgCatId, $wgDevelEnvironment, $wgStatsDB;
+		global $wgCityId, $wgUser, $wgDevelEnvironment, $wgStatsDB;
 
 		wfProfileIn(__METHOD__);
 
@@ -448,28 +451,35 @@ class Chat {
 	}
 
 	/**
-	 * Add Chat log entry to "Special:log"
+	 * @desc Add Chat log entry to "Special:Log" and Special:CheckUser;
+	 * otherwise to giving a chat moderator or banning this method isn't called via AJAX,
+	 * therefore we have to insert all information manually into DB table
 	 */
-
 	public static function addConnectionLogEntry() {
-		global $wgMemc, $wgUser;
+		global $wgMemc, $wgUser, $wgRequest;
 		wfProfileIn(__METHOD__);
 
 		// record the IP of the connecting user.
-		// use memcache so we order only one (user, ip) pair 3 min to avoide flooding the log
-		$ip = F::app()->wg->request->getIP();
-
-		$memcKey = self::getUserIPMemcKey($wgUser->getID(), $ip );
+		// use memcache so we order only one (user, ip) pair 3 min to avoid flooding the log
+		$ip = $wgRequest->getIP();
+		$memcKey = self::getUserIPMemcKey( $wgUser->getID(), $ip );
 		$entry = $wgMemc->get( $memcKey, false );
 
 		if ( empty($entry) ) {
 			$wgMemc->set($memcKey, true, 60*3 /*3 min*/);
+
 			$log = new LogPage( 'chatconnect', false, false );
-			$log->addEntry( 'chatconnect', SpecialPage::getTitleFor('Chat'), '', array($ip), $wgUser);
+			$log->addEntry( 'chatconnect', SpecialPage::getTitleFor( 'Chat' ), '', array( $ip ), $wgUser );
+
+			$xff = $wgRequest->getHeader( self::HTTP_HEADER_XFF );
+			$userAgent = $wgRequest->getHeader( self::HTTP_HEADER_USER_AGENT );
+
+			$xff = ( $xff === false ) ? '' : $xff;
+			$userAgent = ( $userAgent === false ) ? null : $userAgent;
 
 			$dbw = wfGetDB( DB_MASTER );
 			$cuc_id = $dbw->nextSequenceValue( 'cu_changes_cu_id_seq' );
-			$rcRow = array(
+			$rcRow = [
 					'cuc_id'         => $cuc_id,
 					'cuc_namespace'  => NS_SPECIAL,
 					'cuc_title'      => 'Chat',
@@ -484,10 +494,11 @@ class Chat {
 					'cuc_timestamp'  => $dbw->timestamp(),
 					'cuc_ip'         => IP::sanitizeIP( $ip ),
 					'cuc_ip_hex'     => $ip ? IP::toHex( $ip ) : null,
-					'cuc_xff'        => '',
+					'cuc_xff'        => $xff,
 					'cuc_xff_hex'    => null,
-					'cuc_agent'      => null
-			);
+					'cuc_agent'      => $userAgent
+			];
+
 			$dbw->insert( 'cu_changes', $rcRow, __METHOD__ );
 			$dbw->commit();
 		}

--- a/extensions/wikia/Chat2/ChatAjax.class.php
+++ b/extensions/wikia/Chat2/ChatAjax.class.php
@@ -22,7 +22,7 @@ class ChatAjax {
 	 * If the user is not allowed to chat, an error message is returned (which can be shown to the user).
 	 */
 	static public function getUserInfo(){
-		global $wgMemc, $wgServer, $wgArticlePath, $wgRequest, $wgCityId, $wgContLang, $wgIP;
+		global $wgMemc, $wgServer, $wgArticlePath, $wgRequest, $wgCityId, $wgContLang;
 		wfProfileIn( __METHOD__ );
 
 		$data = $wgMemc->get( $wgRequest->getVal('key'), false );
@@ -212,7 +212,7 @@ class ChatAjax {
 	 * returns "error" => [error message].
 	 */
 	static public function giveChatMod() {
-		global $wgRequest, $wgUser, $wgMemc;
+		global $wgRequest, $wgUser;
 		wfProfileIn( __METHOD__ );
 
 		$promottingUser = $wgUser;
@@ -220,11 +220,11 @@ class ChatAjax {
 		$retVal = array();
 		$PARAM_NAME = "userToPromote";
 		$userToPromote = $wgRequest->getVal( $PARAM_NAME );
-		if(empty($userToPromote)){
+		if( empty( $userToPromote) ) {
 			$retVal["error"] = wfMsg('chat-missing-required-parameter', $PARAM_NAME);
 		} else {
-			$result = Chat::promoteChatModerator($userToPromote, $promottingUser);
-			if($result === true){
+			$result = Chat::promoteChatModerator( $userToPromote, $promottingUser );
+			if( $result === true ) {
 				$retVal["success"] = true;
 			} else {
 				$retVal["error"] = $result;

--- a/extensions/wikia/Chat2/ChatHelper.php
+++ b/extensions/wikia/Chat2/ChatHelper.php
@@ -4,7 +4,7 @@ class ChatHelper {
 	private static $serversBasket = "wgChatServersBasket";
 	private static $operationMode = "wgChatOperationMode";
 	private static $CentralCityId = 177;
-	private static $configFile = array();
+	private static $configFile = [];
 
 	// constants with config file sections
 	const CHAT_DEVBOX_ENV = 'dev';
@@ -302,4 +302,26 @@ class ChatHelper {
 
 		return wfMsg('chat-'.$action.'-log-entry', $link, $time, $endon );
 	}
+
+	/**
+	 * @desc Temporary solution not to display internal IPs on Special:CheckUser page
+	 *
+	 * @param String $actionText
+	 * @param String $xff
+	 *
+	 * @return bool true because it's a hook
+	 */
+	public static function onBeforeInsertCheckUserData( &$actionText, &$ip, &$xff ) {
+		global $wgEnableChat, $wgChatExcludeIPsInXFF;
+
+		if( !empty( $wgEnableChat ) && !empty( $wgChatExcludeIPsInXFF ) ) {
+			foreach( $wgChatExcludeIPsInXFF as $ip ) {
+				$xff = str_replace( $ip, '', $xff);
+			}
+			$xff = trim( $xff, ' , ');
+		}
+
+		return true;
+	}
+
 }

--- a/extensions/wikia/Chat2/ChatHelper.php
+++ b/extensions/wikia/Chat2/ChatHelper.php
@@ -4,7 +4,7 @@ class ChatHelper {
 	private static $serversBasket = "wgChatServersBasket";
 	private static $operationMode = "wgChatOperationMode";
 	private static $CentralCityId = 177;
-	private static $configFile = [];
+	private static $configFile = array();
 
 	// constants with config file sections
 	const CHAT_DEVBOX_ENV = 'dev';
@@ -302,26 +302,4 @@ class ChatHelper {
 
 		return wfMsg('chat-'.$action.'-log-entry', $link, $time, $endon );
 	}
-
-	/**
-	 * @desc Temporary solution not to display internal IPs on Special:CheckUser page
-	 *
-	 * @param String $actionText
-	 * @param String $xff
-	 *
-	 * @return bool true because it's a hook
-	 */
-	public static function onBeforeInsertCheckUserData( &$actionText, &$ip, &$xff ) {
-		global $wgEnableChat, $wgChatExcludeIPsInXFF;
-
-		if( !empty( $wgEnableChat ) && !empty( $wgChatExcludeIPsInXFF ) ) {
-			foreach( $wgChatExcludeIPsInXFF as $ip ) {
-				$xff = str_replace( $ip, '', $xff);
-			}
-			$xff = trim( $xff, ' , ');
-		}
-
-		return true;
-	}
-
 }

--- a/extensions/wikia/Chat2/Chat_setup.php
+++ b/extensions/wikia/Chat2/Chat_setup.php
@@ -111,7 +111,11 @@ $wgHooks[ 'ParserFirstCallInit' ][] = 'ChatEntryPoint::onParserFirstCallInit';
 $wgHooks[ 'LinkEnd' ][] = 'ChatHelper::onLinkEnd';
 $wgHooks[ 'BeforePageDisplay' ][] = 'ChatHelper::onBeforePageDisplay';
 $wgHooks[ 'ContributionsToolLinks' ][] = 'ChatHelper::onContributionsToolLinks';
+$wgHooks[ 'LogLine' ][] = 'ChatHelper::onLogLine';
+$wgHooks[ 'UserGetRights' ][] = 'chatAjaxonUserGetRights';
+$wgHooks[ 'GetIP' ][] = 'ChatAjax::onGetIP'; // used for calls from chat nodejs server
 
+// logs
 $wgLogTypes[] = 'chatban';
 $wgLogHeaders['chatban'] = 'chat-chatban-log';
 $wgLogNames['chatban'] = 'chat-chatban-log';
@@ -122,12 +126,9 @@ $wgLogNames['chatconnect'] = 'chat-chatconnect-log';
 $wgLogActions['chatconnect/chatconnect'] = 'chat-chatconnect-log-entry';
 $wgLogRestrictions["chatconnect"] = 'checkuser';
 
-$wgHooks[ 'LogLine' ][] = 'ChatHelper::onLogLine';
-
 $wgLogActionsHandlers['chatban/chatbanchange'] = "ChatHelper::formatLogEntry";
 $wgLogActionsHandlers['chatban/chatbanremove'] = "ChatHelper::formatLogEntry";
 $wgLogActionsHandlers['chatban/chatbanadd'] = "ChatHelper::formatLogEntry";
-
 
 // register messages package for JS
 JSMessages::registerPackage('Chat', array(
@@ -142,12 +143,8 @@ JSMessages::registerPackage('ChatBanModal', array(
 	'chat-ban-modal-button-change-ban',
 ));
 
-
 define( 'CHAT_TAG', 'chat' );
 define( 'CUC_TYPE_CHAT', 128);	// for CheckUser operation type
-
-
-$wgHooks['UserGetRights'][] = 'chatAjaxonUserGetRights';
 
 /**
  * Add read right to ChatAjax am reqest.
@@ -212,5 +209,3 @@ function ChatAjax() {
 		return $response;
 	}
 }
-
-$wgHooks['GetIP'][] = 'ChatAjax::onGetIP';        // used for calls from chat nodejs server

--- a/extensions/wikia/Chat2/Chat_setup.php
+++ b/extensions/wikia/Chat2/Chat_setup.php
@@ -192,17 +192,12 @@ function ChatAjax() {
 		/*
 		 ChatAjax requests come from chat nodejs server, and that's not the user ip
 		 so if the server passed the correct user ip, we try to make use of it and
-		 record it here so $wgRequest->getIP return this address.
-		 Similar thing is done with XFF - original value of this header (passed to nodejs server) is passed
-		 in X-Chat-Forwarded-For.
+		 record it here so $wgRequest->getIP return this address
 		 */
 		$userIP = $wgRequest->getVal('userIP');
 		if ( ( $userIP !== false ) && IP::isIPAddress( $userIP ) ){
 			ChatAjax::$chatUserIP = $userIP;
-		}
-		$chatXFF = $wgRequest->getHeader( 'X-Chat-Forwarded-For' );
-		if ( !empty( $chatXFF ) ) {
-			$wgRequest->setHeader( 'X-FORWARDED-FOR', $chatXFF );
+
 		}
 
 		$data = ChatAjax::$method();

--- a/extensions/wikia/Chat2/Chat_setup.php
+++ b/extensions/wikia/Chat2/Chat_setup.php
@@ -114,6 +114,7 @@ $wgHooks[ 'ContributionsToolLinks' ][] = 'ChatHelper::onContributionsToolLinks';
 $wgHooks[ 'LogLine' ][] = 'ChatHelper::onLogLine';
 $wgHooks[ 'UserGetRights' ][] = 'chatAjaxonUserGetRights';
 $wgHooks[ 'GetIP' ][] = 'ChatAjax::onGetIP'; // used for calls from chat nodejs server
+$wgHooks[ 'BeforeInsertCheckUserData' ][] = 'ChatHelper::onBeforeInsertCheckUserData';
 
 // logs
 $wgLogTypes[] = 'chatban';

--- a/extensions/wikia/Chat2/Chat_setup.php
+++ b/extensions/wikia/Chat2/Chat_setup.php
@@ -114,7 +114,6 @@ $wgHooks[ 'ContributionsToolLinks' ][] = 'ChatHelper::onContributionsToolLinks';
 $wgHooks[ 'LogLine' ][] = 'ChatHelper::onLogLine';
 $wgHooks[ 'UserGetRights' ][] = 'chatAjaxonUserGetRights';
 $wgHooks[ 'GetIP' ][] = 'ChatAjax::onGetIP'; // used for calls from chat nodejs server
-$wgHooks[ 'BeforeInsertCheckUserData' ][] = 'ChatHelper::onBeforeInsertCheckUserData';
 
 // logs
 $wgLogTypes[] = 'chatban';

--- a/extensions/wikia/Chat2/Chat_setup.php
+++ b/extensions/wikia/Chat2/Chat_setup.php
@@ -192,12 +192,17 @@ function ChatAjax() {
 		/*
 		 ChatAjax requests come from chat nodejs server, and that's not the user ip
 		 so if the server passed the correct user ip, we try to make use of it and
-		 record it here so $wgRequest->getIP return this address
+		 record it here so $wgRequest->getIP return this address.
+		 Similar thing is done with XFF - original value of this header (passed to nodejs server) is passed
+		 in X-Chat-Forwarded-For.
 		 */
 		$userIP = $wgRequest->getVal('userIP');
 		if ( ( $userIP !== false ) && IP::isIPAddress( $userIP ) ){
 			ChatAjax::$chatUserIP = $userIP;
-
+		}
+		$chatXFF = $wgRequest->getHeader( 'X-Chat-Forwarded-For' );
+		if ( !empty( $chatXFF ) ) {
+			$wgRequest->setHeader( 'X-FORWARDED-FOR', $chatXFF );
 		}
 
 		$data = ChatAjax::$method();

--- a/extensions/wikia/Chat2/js/WMBridge.js
+++ b/extensions/wikia/Chat2/js/WMBridge.js
@@ -144,7 +144,7 @@ var clearAuthenticateCache = function(roomId, name) {
 }
 
 WMBridge.prototype.authenticateUser = function(roomId, name, key, handshake, success, error) {
-        var cacheKey = name + "_" + roomId;  
+        var cacheKey = name + "_" + roomId;
         if(authenticateUserCache[cacheKey] && authenticateUserCache[cacheKey].key == key ) {
                 return success(authenticateUserCache[cacheKey].data);
         }
@@ -156,17 +156,17 @@ WMBridge.prototype.authenticateUser = function(roomId, name, key, handshake, suc
         });
         
         logger.debug(requestUrl);
-	var ts = Math.round((new Date()).getTime() / 1000);                                                                
-	monitoring.incrEventCounter('authenticateUserRequest');
-        requestMW('GET', roomId, {}, requestUrl, handshake, function(data){
-		authenticateUserCache[cacheKey] = {
-			data: data, 
-			key: key, 
-			ts: ts
-		};
-                success(data);
-        }, error);
-}       
+		var ts = Math.round((new Date()).getTime() / 1000);
+		monitoring.incrEventCounter('authenticateUserRequest');
+		requestMW( 'GET', roomId, {}, requestUrl, handshake, function(data) {
+			authenticateUserCache[cacheKey] = {
+				data: data,
+				key: key,
+				ts: ts
+			};
+			success(data);
+		}, error );
+}
 
 setInterval(function() {
 	var ts = Math.round((new Date()).getTime() / 1000);

--- a/extensions/wikia/Chat2/js/WMBridge.js
+++ b/extensions/wikia/Chat2/js/WMBridge.js
@@ -68,7 +68,7 @@ var requestMW = function(method, roomId, postdata, query, handshake, callback, e
 				}
 
 				if( typeof handshake.headers['x-forwarded-for'] !== 'undefined' ) {
-					headers['x-forwarded-for'] = handshake.headers['x-forwarded-for'];
+					headers['x-chat-forwarded-for'] = handshake.headers['x-forwarded-for'];
 				}
 			}
 

--- a/extensions/wikia/Chat2/js/WMBridge.js
+++ b/extensions/wikia/Chat2/js/WMBridge.js
@@ -38,7 +38,7 @@ var urlencode = function(str) {
     replace(/\)/g, '%29').replace(/\*/g, '%2A').replace(/%20/g, '+');
 };
 
-var requestMW = function(method, roomId, postdata, query, callback, errorcallback) {
+var requestMW = function(method, roomId, postdata, query, handshake, callback, errorcallback) {
 	if(!errorcallback){
 		errorcallback = function() {};
 	}
@@ -56,10 +56,26 @@ var requestMW = function(method, roomId, postdata, query, callback, errorcallbac
 			var wikiHostname = data.replace(/^https?:\/\//i, "");
 			var url = 'http://' + wikiHostname + '/index.php' + query + "&cb=" + Math.floor(Math.random()*99999); // varnish appears to be caching this (at least on dev boxes) when we don't want it to... so cachebust it.;
 			logger.debug("Making  request to host: " + url);
+
+			// settings HTTP headers' variable
+			var headers = {
+				'content-type': 'application/x-www-form-urlencoded'
+			};
+
+			if( handshake && handshake.headers ) {
+				if( typeof handshake.headers['user-agent'] !== 'undefined' ) {
+					headers['user-agent'] = handshake.headers['user-agent'];
+				}
+
+				if( typeof handshake.headers['x-forwarded-for'] !== 'undefined' ) {
+					headers['x-forwarded-for'] = handshake.headers['x-forwarded-for'];
+				}
+			}
+
 			request({
 			    	method: method,
 			    	//followRedirect: false,
-			    	headers: {'content-type' : 'application/x-www-form-urlencoded'},
+			    	headers: headers,
 			    	body: postdata,
 			    	json: false,
 			    	url: url,
@@ -68,7 +84,7 @@ var requestMW = function(method, roomId, postdata, query, callback, errorcallbac
 			    function (error, response, body) {
 			    	if(error) {
 			    		errorcallback();
-			    		logger.error(error);	
+			    		logger.error(error);
 			    		return ;
 			    	}
 			    	logger.debug(response.statusCode);
@@ -95,7 +111,7 @@ var requestMW = function(method, roomId, postdata, query, callback, errorcallbac
 			    		logger.debug(data);
 			    	}
 			    }
-			);			
+			);
 		}
 	},
 	errorcallback);
@@ -127,7 +143,7 @@ var clearAuthenticateCache = function(roomId, name) {
 	}
 }
 
-WMBridge.prototype.authenticateUser = function(roomId, name, key, address, success, error) {
+WMBridge.prototype.authenticateUser = function(roomId, name, key, handshake, success, error) {
         var cacheKey = name + "_" + roomId;  
         if(authenticateUserCache[cacheKey] && authenticateUserCache[cacheKey].key == key ) {
                 return success(authenticateUserCache[cacheKey].data);
@@ -136,14 +152,13 @@ WMBridge.prototype.authenticateUser = function(roomId, name, key, address, succe
         var requestUrl = getUrl( 'getUserInfo', {
                 roomId: roomId,
                 name: urlencode(name),
-                key: key,
-                address: urlencode(address)
+                key: key
         });
         
         logger.debug(requestUrl);
 	var ts = Math.round((new Date()).getTime() / 1000);                                                                
 	monitoring.incrEventCounter('authenticateUserRequest');
-        requestMW('GET', roomId, {}, requestUrl, function(data){ 
+        requestMW('GET', roomId, {}, requestUrl, handshake, function(data){
 		authenticateUserCache[cacheKey] = {
 			data: data, 
 			key: key, 
@@ -162,7 +177,7 @@ setInterval(function() {
 	}
 }, 5000);
 
-WMBridge.prototype.ban = function(roomId, name, userAddress ,time, reason, key, success, error) {
+WMBridge.prototype.ban = function(roomId, name, handshake ,time, reason, key, success, error) {
 	clearAuthenticateCache(roomId, name);
 	var requestUrl = getUrl('blockOrBanChat', {
 		roomId: roomId,
@@ -171,10 +186,10 @@ WMBridge.prototype.ban = function(roomId, name, userAddress ,time, reason, key, 
 		reason: urlencode(reason),
 		mode: 'global',
 		key: key,
-		userIP: (userAddress && userAddress.address) || ''
+		userIP: (handshake.address && handshake.address.address) || ''
 	});
 
-	requestMW('GET', roomId, {}, requestUrl, function(data){
+	requestMW('GET', roomId, {}, requestUrl, handshake, function(data){
 		// Process response from MediaWiki server and then kick the user from all clients.
 		if(data.error || data.errorWfMsg){
 			error(data);
@@ -185,16 +200,16 @@ WMBridge.prototype.ban = function(roomId, name, userAddress ,time, reason, key, 
 }
 
 
-WMBridge.prototype.giveChatMod = function(roomId, name, userAddress, key, success, error) {
+WMBridge.prototype.giveChatMod = function(roomId, name, handshake, key, success, error) {
 	clearAuthenticateCache(roomId, name);
 	var requestUrl = getUrl('giveChatMod', {
 		roomId: roomId,
 		userToPromote: urlencode(name),
 		key: key,
-		userIP: (userAddress && userAddress.address) || ''
+		userIP: (handshake.address && handshake.address.address) || ''
 	});
 
-	requestMW('GET', roomId, {}, requestUrl, function(data){
+	requestMW('GET', roomId, {}, requestUrl, handshake, function(data){
 		// Process response from MediaWiki server and then kick the user from all clients.
 		if(data.error || data.errorWfMsg){
 			error(data);
@@ -217,7 +232,7 @@ var setUsersList = function(roomId, users) {
                 userToSend.push(userName);
         }
 
-        requestMW('POST', roomId, {users: userToSend}, requestUrl, function(data){
+        requestMW('POST', roomId, {users: userToSend}, requestUrl, null, function(data){
 
         });
 }

--- a/extensions/wikia/Chat2/js/WMBridge.js
+++ b/extensions/wikia/Chat2/js/WMBridge.js
@@ -68,7 +68,7 @@ var requestMW = function(method, roomId, postdata, query, handshake, callback, e
 				}
 
 				if( typeof handshake.headers['x-forwarded-for'] !== 'undefined' ) {
-					headers['x-chat-forwarded-for'] = handshake.headers['x-forwarded-for'];
+					headers['x-forwarded-for'] = handshake.headers['x-forwarded-for'];
 				}
 			}
 

--- a/extensions/wikia/Chat2/js/server.js
+++ b/extensions/wikia/Chat2/js/server.js
@@ -323,7 +323,7 @@ function authConnection(handshakeData, authcallback){
 		}
 	};
 
-	mwBridge.authenticateUser(roomId, name, key, handshakeData.headers, callback, function(){
+	mwBridge.authenticateUser(roomId, name, key, handshakeData, callback, function(){
 		logger.error("User failed authentication: Wrong call to media wiki");
 		authcallback(null, false); // error first callback style
 	});

--- a/extensions/wikia/Chat2/js/server.js
+++ b/extensions/wikia/Chat2/js/server.js
@@ -323,14 +323,7 @@ function authConnection(handshakeData, authcallback){
 		}
 	};
 
-        var address = null;
-        if(!handshakeData.address || !handshakeData.address.address) {
-                address = "0.0.0.0";
-        } else {
-                address = handshakeData.address.address;
-        }
-
-	mwBridge.authenticateUser(roomId, name, key, address, callback, function(){
+	mwBridge.authenticateUser(roomId, name, key, handshakeData.headers, callback, function(){
 		logger.error("User failed authentication: Wrong call to media wiki");
 		authcallback(null, false); // error first callback style
 	});
@@ -652,7 +645,7 @@ function ban(client, socket, msg){
 	var time = banCommand.get('time');
 	var reason = banCommand.get('reason');
 
-	mwBridge.ban(client.roomId, userToBan, client.handshake.address, time, reason, client.userKey, function(data){
+	mwBridge.ban(client.roomId, userToBan, client.handshake, time, reason, client.userKey, function(data){
     	var kickEvent = new models.KickEvent({
     		kickedUserName: userToBan,
     		time: time,
@@ -683,10 +676,10 @@ function giveChatMod(client, socket, msg){
 
 	var userNameToPromote = giveChatModCommand.get('userToPromote');
 		
-	mwBridge.giveChatMod(client.roomId, userNameToPromote, client.handshake.address, client.userKey, function(data){
+	mwBridge.giveChatMod(client.roomId, userNameToPromote, client.handshake, client.userKey, function(data){
 		// Build a user that looks like the one that got banned... then kick them!
 			
-		storage.getRoomState(client.roomId, function(nodeChatModel) {	
+		storage.getRoomState(client.roomId, function(nodeChatModel) {
 			// Initial connection of the user (unless they're already connected).
 			var promotedUser = nodeChatModel.users.findByName(userNameToPromote);
 

--- a/includes/IP.php
+++ b/includes/IP.php
@@ -714,4 +714,48 @@ class IP {
 		}
 		return "$start/$bits";
 	}
+
+	/** Wikia change -- start */
+	/**
+	 * Wikia: took this method from CheckUser extension
+	 *
+	 * @desc Locates the client IP within a given XFF string
+	 * @param string $xff
+	 * @return array( string, bool )
+	 */
+	public static function getClientIPfromXFF( $xff ) {
+		global $wgSquidServers, $wgSquidServersNoPurge;
+
+		if ( !$xff ) {
+			return array( null, false );
+		}
+
+		// Avoid annoyingly long xff hacks
+		$xff = trim( substr( $xff, 0, 255 ) );
+		$client = null;
+		$isSquidOnly = true;
+		$trusted = true;
+		// Check each IP, assuming they are separated by commas
+		$ips = explode( ',', $xff );
+		foreach ( $ips as $ip ) {
+			$ip = trim( $ip );
+			// If it is a valid IP, not a hash or such
+			if ( IP::isIPAddress( $ip ) ) {
+				# The first IP should be the client.
+				# Start only from the first public IP.
+				if ( is_null( $client ) ) {
+					if ( IP::isPublic( $ip ) ) {
+						$client = $ip;
+					}
+				} elseif ( !wfIsTrustedProxy( $ip ) )
+				{
+					$isSquidOnly = false;
+					break;
+				}
+			}
+		}
+
+		return array( $client, $isSquidOnly );
+	}
+	/** Wikia change -- end */
 }


### PR DESCRIPTION
During investigation of the bug descriped in the [DAR-319](https://wikia-inc.atlassian.net/browse/DAR-319) we found out the bug doesn't exist there anymore but we can improve the log information passed from chat. I made changes in chat code so we display now XFF and user agent data in Special:Log and Special:CheckUser. I also did small clean-up in PHP code.
