### PR TITLE
DAR-1744: Fix internal tracking when trackingMethod is set to both

### DIFF
--- a/resources/wikia/modules/tracker.js
+++ b/resources/wikia/modules/tracker.js
@@ -303,12 +303,13 @@
 
 			if ( tracking.ad && gaTrackAdEvent ) {
 				gaTrackAdEvent.apply( null, gaqArgs );
-
-			} else if ( tracking.ga && gaTrackEvent ) {
-				gaTrackEvent.apply( null, gaqArgs );
-
-			} else if ( tracking.internal ) {
-				internalTrack( eventName, data );
+			} else {
+				if ( tracking.ga && gaTrackEvent ) {
+					gaTrackEvent.apply( null, gaqArgs );
+				}
+				if ( tracking.internal ) {
+					internalTrack( eventName, data );
+				}
 			}
 
 			// Handle links which navigate away from the current page

--- a/resources/wikia/modules/tracker.js
+++ b/resources/wikia/modules/tracker.js
@@ -307,6 +307,7 @@
 				if ( tracking.ga && gaTrackEvent ) {
 					gaTrackEvent.apply( null, gaqArgs );
 				}
+				
 				if ( tracking.internal ) {
 					internalTrack( eventName, data );
 				}


### PR DESCRIPTION
After investigation why internal tracking doesn't work on hubs, we have found a bug for every internal tracking where trackingMethod is set to 'both'.

https://github.com/Wikia/app/commit/e202c9e1640ea7beed2a9e5ed0fb5ab6d0e77b6a#L1R212

@kflorence @jmarch 
