### PR TITLE
PLA-589 fix for not correctly generated memc key, due to "0" edge case

### DIFF
--- a/includes/wikia/services/DataMartService.class.php
+++ b/includes/wikia/services/DataMartService.class.php
@@ -507,7 +507,7 @@ class DataMartService extends Service {
 			$cacheVersion,
 			$wikiId,
 			$limitUsed,
-			( !empty( $keyToken ) ) ? md5( $keyToken ) : null,
+			( $keyToken !== '' ) ? md5( $keyToken ) : null,
 			$excludeNamespaces
 		);
 


### PR DESCRIPTION
keyToken equals "0" when namespaces array contains only 0, which generates wrong memc key
