### PR TITLE
Check for cascading protection

### DIFF
--- a/skins/oasis/modules/PageHeaderController.class.php
+++ b/skins/oasis/modules/PageHeaderController.class.php
@@ -56,6 +56,13 @@ class PageHeaderController extends WikiaController {
 			unset($this->content_actions['viewsource']);
 		}
 
+		// If cascade protected, show viewsource button - BugId:VE-89
+		if ( isset( $this->content_actions['edit'] ) && $wgTitle->isCascadeProtected() ) {
+			$this->content_actions['viewsource'] = $this->content_actions['edit'];
+			$this->content_actions['viewsource']['text'] = wfMsg('viewsource');
+			unset( $this->content_actions['edit'] );
+		}
+
 		// PvX's rate (RT #76386)
 		if (isset($this->content_actions['rate'])) {
 			$this->action = $this->content_actions['rate'];

--- a/skins/oasis/modules/PageHeaderController.class.php
+++ b/skins/oasis/modules/PageHeaderController.class.php
@@ -52,14 +52,14 @@ class PageHeaderController extends WikiaController {
 			!$wgTitle->isNamespaceProtected($wgUser) ) {
 			// force login to edit page that is not protected
 			$this->content_actions['edit'] = $this->content_actions['viewsource'];
-			$this->content_actions['edit']['text'] = wfMsg('edit')->text();
+			$this->content_actions['edit']['text'] = wfMessage('edit')->text();
 			unset($this->content_actions['viewsource']);
 		}
 
 		// If cascade protected, show viewsource button - BugId:VE-89
 		if ( isset( $this->content_actions['edit'] ) && $wgTitle->isCascadeProtected() ) {
 			$this->content_actions['viewsource'] = $this->content_actions['edit'];
-			$this->content_actions['viewsource']['text'] = wfMsg('viewsource')->text();
+			$this->content_actions['viewsource']['text'] = wfMessage('viewsource')->text();
 			unset($this->content_actions['edit']);
 		}
 

--- a/skins/oasis/modules/PageHeaderController.class.php
+++ b/skins/oasis/modules/PageHeaderController.class.php
@@ -52,15 +52,15 @@ class PageHeaderController extends WikiaController {
 			!$wgTitle->isNamespaceProtected($wgUser) ) {
 			// force login to edit page that is not protected
 			$this->content_actions['edit'] = $this->content_actions['viewsource'];
-			$this->content_actions['edit']['text'] = wfMsg('edit');
+			$this->content_actions['edit']['text'] = wfMsg('edit')->text();
 			unset($this->content_actions['viewsource']);
 		}
 
 		// If cascade protected, show viewsource button - BugId:VE-89
 		if ( isset( $this->content_actions['edit'] ) && $wgTitle->isCascadeProtected() ) {
 			$this->content_actions['viewsource'] = $this->content_actions['edit'];
-			$this->content_actions['viewsource']['text'] = wfMsg('viewsource');
-			unset( $this->content_actions['edit'] );
+			$this->content_actions['viewsource']['text'] = wfMsg('viewsource')->text();
+			unset($this->content_actions['edit']);
 		}
 
 		// PvX's rate (RT #76386)


### PR DESCRIPTION
When protecting an article, you can choose: "Protect pages included in this page (cascading protection)". This will protect any transcluded articles (not sub-articles). When a Title isCascadeProtected(), the content actions contain 'edit' but not 'viewsource'. Using the same type of remapping as the fix for BugId:9494 (just a few lines higher in the file), 'edit' is removed and 'viewsource' is created. The result is the desired user experience.
