### PR TITLE
Fix needless painting caused by article comments loading indicator.

### DIFF
--- a/extensions/wikia/ArticleComments/js/ArticleComments.js
+++ b/extensions/wikia/ArticleComments/js/ArticleComments.js
@@ -612,6 +612,7 @@ if (ArticleComments.loadOnDemand) {
 		if (!permalink && belowTheFold()) {
 			$window.on('scrollstop.ArticleCommentsLoadOnDemand', function(event) {
 				if (!belowTheFold()) {
+					$comments.addClass('loading');
 					$window.off('scrollstop.ArticleCommentsLoadOnDemand');
 					loadAssets();
 				}

--- a/extensions/wikia/ArticleComments/modules/templates/ArticleComments_Index.php
+++ b/extensions/wikia/ArticleComments/modules/templates/ArticleComments_Index.php
@@ -1,7 +1,7 @@
 <? if ( $isMiniEditorEnabled ): ?>
 	<?= $app->renderView( 'MiniEditorController', 'Setup' ) ?>
 <? endif ?>
-<section id="WikiaArticleComments" class="WikiaArticleComments noprint<?= !empty( $isLoadingOnDemand ) ? ' loading' : '' ?>" data-page="<?= $page ?>">
+<section id="WikiaArticleComments" class="WikiaArticleComments noprint" data-page="<?= $page ?>">
 	<? if ( empty( $isLoadingOnDemand ) ): ?>
 		<?= $app->renderView( 'ArticleCommentsController', 'Content' ) ?>
 	<? endif ?>


### PR DESCRIPTION
I noticed a crap ton (one every 50ms) of repainting on all pages with Article Comments enabled when scrolled within about 500 pixels of the WikiaArticleComments element even when the loading indicator wasn't visible. This changeset makes the indicator visible only when the user can actually see it preventing all the needless repaints.
