### PR TITLE
PLA-597 -- fix wiki result match image on community

### DIFF
--- a/extensions/wikia/Search/templates/WikiaSearch_CrossWiki_result.php
+++ b/extensions/wikia/Search/templates/WikiaSearch_CrossWiki_result.php
@@ -8,8 +8,7 @@
 	}
 	if ( empty( $imageURL ) ) {
 		// display placeholder image if no thumbnail
-		global $wgExtensionsPath;
-		$imageURL = $wgExtensionsPath . '/wikia/Search/images/wiki_image_placeholder.png';
+		$imageURL = $wg->ExtensionsPath . '/wikia/Search/images/wiki_image_placeholder.png';
 		$thumbTracking = 'class="wiki-thumb-tracking" data-pos="' . $pos . '" data-event="search_click_wiki-no-thumb"';
 	}
 

--- a/extensions/wikia/Search/templates/WikiaSearch_CrossWiki_result.php
+++ b/extensions/wikia/Search/templates/WikiaSearch_CrossWiki_result.php
@@ -8,6 +8,7 @@
 	}
 	if ( empty( $imageURL ) ) {
 		// display placeholder image if no thumbnail
+		global $wgExtensionsPath;
 		$imageURL = $wgExtensionsPath . '/wikia/Search/images/wiki_image_placeholder.png';
 		$thumbTracking = 'class="wiki-thumb-tracking" data-pos="' . $pos . '" data-event="search_click_wiki-no-thumb"';
 	}


### PR DESCRIPTION
So on regular cross-wiki search, the wgExtensionsPath variable works fine without a global declaration, but when using this template for a cross-wiki match on on-wiki search, the wgExtensionsPath needs to be explicitly declared as global. Seems weird, but it's a simple fix that addresses the functional issue.
