### PR TITLE
Switching slider placeholder to inline

### DIFF
--- a/extensions/wikia/RTE/css/content.scss
+++ b/extensions/wikia/RTE/css/content.scss
@@ -165,7 +165,7 @@ img.image-gallery {
 
 img.image-gallery-slider {
 	background-image: url(/extensions/wikia/WikiaPhotoGallery/images/slider-placeholder.png);/* $wgCdnStylePath */
-	display: block;
+	display: inline;
 }
 
 img.image-slideshow {


### PR DESCRIPTION
When a gallery type="slider" is the first element in RTE, IE is unable to place the cursor before. This is because in contenteditable, we have a p with a placeholder img to represent the slider and the img is set to display:block. By setting the image to display:inline, IE will naturally allow placement of the cursor before and after the image, within the paragraph. Unfortunately, this is not true WYSIWYG because the slider actually renders as display:block. I ran this option by Trevor Bolliger and compared it to the current handling of gallery (which also deviates from WYSIWYG) and he approved this fix. I can't wait for VisualEditor which will solve these types of problems with block slugs. @kflorence or @inez, please review.
