### PR TITLE
Basic integration of VisualEditor and Oasis

### DIFF
--- a/extensions/VisualEditor/ApiVisualEditor.php
+++ b/extensions/VisualEditor/ApiVisualEditor.php
@@ -42,7 +42,8 @@ class ApiVisualEditor extends ApiBase {
 				),
 				array(
 					'method' => 'GET',
-					'timeout' => $wgVisualEditorParsoidTimeout
+					'timeout' => $wgVisualEditorParsoidTimeout,
+					'noProxy' => true
 				)
 			);
 			$status = $req->execute();
@@ -96,7 +97,8 @@ class ApiVisualEditor extends ApiBase {
 					'content' => $html,
 					'oldid' => $parserParams['oldid']
 				),
-				'timeout' => $wgVisualEditorParsoidTimeout
+				'timeout' => $wgVisualEditorParsoidTimeout,
+				'noProxy' => true
 			)
 		);
 	}
@@ -218,7 +220,11 @@ class ApiVisualEditor extends ApiBase {
 				// Dirty hack to provide the correct context for edit notices
 				global $wgTitle; // FIXME NOOOOOOOOES
 				$wgTitle = $page;
-				$notices = $page->getEditNotices();
+				// TODO: In MW 1.19.7 method getEditNotices does not exist so for now fallback to just an empty
+				// but in future figure out what's the proper backward compatibility solution.
+				// #back-compat
+				// $notices = $page->getEditNotices();
+				$notices = array();
 				if ( $user->isAnon() ) {
 					$wgVisualEditorEditNotices[] = 'anoneditwarning';
 				}

--- a/extensions/VisualEditor/VisualEditor.hooks.php
+++ b/extensions/VisualEditor/VisualEditor.hooks.php
@@ -10,7 +10,7 @@
 
 class VisualEditorHooks {
 	/** List of skins VisualEditor integration supports */
-	protected static $supportedSkins = array( 'vector', 'apex', 'monobook' );
+	protected static $supportedSkins = array( 'oasis' );
 
 	public static function onSetup() {
 		global $wgResourceModules, $wgVisualEditorResourceTemplate,
@@ -23,7 +23,7 @@ class VisualEditorHooks {
 		// parties who attempt to install VisualEditor onto non-alpha wikis, as
 		// this should have no impact on deploying to Wikimedia's wiki cluster.
 		// Is fine for release tarballs because 1.22wmf11 < 1.22alpha < 1.22.0.
-		wfUseMW( '1.22wmf11' );
+		//wfUseMW( '1.22wmf11' ); #back-compat
 
 		// Add tab messages to the init init module
 		foreach ( $wgVisualEditorTabMessages as $msg ) {
@@ -78,8 +78,8 @@ class VisualEditorHooks {
 	 * @param $skin Skin
 	 */
 	public static function onBeforePageDisplay( &$output, &$skin ) {
-		$output->addModules( array( 'ext.visualEditor.viewPageTarget.init' ) );
-		$output->addModuleStyles( array( 'ext.visualEditor.viewPageTarget.noscript' ) );
+		$output->addModules( array( 'ext.visualEditor.wikiaViewPageTarget.init' ) );
+		//$output->addModuleStyles( array( 'ext.visualEditor.viewPageTarget.noscript' ) );
 		return true;
 	}
 

--- a/extensions/VisualEditor/VisualEditor.i18n.php
+++ b/extensions/VisualEditor/VisualEditor.i18n.php
@@ -47,6 +47,7 @@ $messages['en'] = array(
 	'visualeditor-ca-ve-create' => 'VisualEditor',
 	'visualeditor-ca-ve-edit' => 'VisualEditor',
 	'visualeditor-ca-ve-edit-section' => 'VisualEditor',
+	'visualeditor-ca-classiceditor' => 'Classic editor',
 	'visualeditor-clearbutton-tooltip' => 'Clear formatting',
 	'visualeditor-desc' => 'Visual editor for MediaWiki',
 	'visualeditor-descriptionpagelink' => 'Project:VisualEditor',

--- a/extensions/VisualEditor/VisualEditor.php
+++ b/extensions/VisualEditor/VisualEditor.php
@@ -175,7 +175,7 @@ $wgResourceModules += array(
 			'mediawiki.api',
 			'mediawiki.feedback',
 			'mediawiki.jqueryMsg',
-			'mediawiki.notify',
+			//'mediawiki.notify', #back-compat
 			'mediawiki.Title',
 			'mediawiki.Uri',
 			'mediawiki.user',
@@ -806,14 +806,16 @@ $wgVisualEditorTabMessages = array(
 	'edit' => null,
 	// i18n message key to use for the old edit tab
 	// If null, the tab's caption will not be changed
-	'editsource' => 'visualeditor-ca-editsource',
+	//'editsource' => 'visualeditor-ca-editsource',
+	'editsource' => 'visualeditor-ca-classiceditor',
 	// i18n message key to use for the VisualEditor create tab
 	// If null, the default create tab caption will be used
 	// The 'visualeditor-ca-ve-create' message is available for this
 	'create' => null,
 	// i18n message key to use for the old create tab
 	// If null, the tab's caption will not be changed
-	'createsource' => 'visualeditor-ca-createsource',
+	//'createsource' => 'visualeditor-ca-createsource',
+	'createsource' => 'visualeditor-ca-classiceditor',
 	// i18n message key to use for the VisualEditor section edit link
 	// If null, the default edit section link caption will be used
 	'editsection' => null,

--- a/extensions/VisualEditor/modules/ve-mw/init/targets/ve.init.mw.ViewPageTarget.js
+++ b/extensions/VisualEditor/modules/ve-mw/init/targets/ve.init.mw.ViewPageTarget.js
@@ -17,11 +17,11 @@
  */
 ve.init.mw.ViewPageTarget = function VeInitMwViewPageTarget() {
 	var browserWhitelisted,
-		currentUri = new mw.Uri();
+		currentUri = new mw.Uri( location.href );
 
 	// Parent constructor
 	ve.init.mw.Target.call(
-		this, $( '#content' ),
+		this, $( '#WikiaArticle' ),
 		mw.config.get( 'wgRelevantPageName' ),
 		currentUri.query.oldid
 	);
@@ -175,7 +175,7 @@ ve.init.mw.ViewPageTarget.static.surfaceCommands = [
 ];
 
 // TODO: Accessibility tooltips and logical tab order for prevButton and closeButton.
-ve.init.mw.ViewPageTarget.saveDialogTemplate = '\
+ve.init.mw.ViewPageTarget.static.saveDialogTemplate = '\
 	<div class="ve-init-mw-viewPageTarget-saveDialog-head">\
 		<div class="ve-init-mw-viewPageTarget-saveDialog-prevButton"></div>\
 		<div class="ve-init-mw-viewPageTarget-saveDialog-closeButton"></div>\
@@ -321,7 +321,7 @@ ve.init.mw.ViewPageTarget.prototype.onLoad = function ( doc ) {
 			if ( mw.config.get( 'wgVisualEditorConfig' ).showBetaWelcome ) {
 				this.showBetaWelcome();
 			}
-			mw.hook( 've.activationComplete' ).fire();
+			//mw.hook( 've.activationComplete' ).fire();
 		}, this ) );
 	}
 };
@@ -1420,7 +1420,7 @@ ve.init.mw.ViewPageTarget.prototype.setupSaveDialog = function () {
 	viewPage.$saveDialog
 		// Must not use replaceWith because that can't be used on fragement roots,
 		// plus, we want to preserve the reference and class names of the wrapper.
-		.empty().append( this.constructor.saveDialogTemplate )
+		.empty().append( this.constructor.static.saveDialogTemplate )
 		// Attach buttons
 		.find( '.ve-init-mw-viewPageTarget-saveDialog-slide-save' )
 			.find( '.ve-init-mw-viewPageTarget-saveDialog-actions' )
@@ -1699,7 +1699,7 @@ ve.init.mw.ViewPageTarget.prototype.swapSaveDialog = function ( slide, options )
 	// Show the target slide
 	$slide.show();
 
-	mw.hook( 've.saveDialog.stateChanged' ).fire();
+	//mw.hook( 've.saveDialog.stateChanged' ).fire();
 
 	if ( slide === 'save' ) {
 		setTimeout( function () {
@@ -1855,7 +1855,8 @@ ve.init.mw.ViewPageTarget.prototype.setUpToolbar = function () {
 	}
 	this.toolbar.$
 		.addClass( 've-init-mw-viewPageTarget-toolbar' )
-		.insertBefore( '#firstHeading' );
+		//.insertBefore( '#firstHeading' );
+		.insertAfter( '#WikiaPageHeader' );
 	this.toolbar.$bar.slideDown( 'fast', ve.bind( function () {
 		// Check the surface wasn't torn down while the toolbar was animating
 		if ( this.surface ) {

--- a/extensions/VisualEditor/wikia/VisualEditor.php
+++ b/extensions/VisualEditor/wikia/VisualEditor.php
@@ -1,0 +1,34 @@
+<?php
+
+/* Setup */
+
+$wgExtensionCredits['other'][] = array(
+	'path' => __FILE__,
+	'name' => 'VisualEditor for Wikia'
+);
+
+// Register resource modules
+
+$wgResourceModules += array(
+	'ext.visualEditor.wikiaViewPageTarget.init' => array(
+		'scripts' => 've.init.mw.WikiaViewPageTarget.init.js',
+		'dependencies' => array(
+			'jquery.client',
+			'mediawiki.Title',
+			'mediawiki.Uri',
+			'mediawiki.util',
+			'user.options',
+		),
+		'position' => 'top',
+		'localBasePath' => dirname( __FILE__ ) . '/modules',
+		'remoteExtPath' => 'VisualEditor/wikia',
+	),
+	'ext.visualEditor.wikiaViewPageTarget' => array(
+		'scripts' => 've.init.mw.WikiaViewPageTarget.js',
+		'dependencies' => array(
+			'ext.visualEditor.viewPageTarget'
+		),
+		'localBasePath' => dirname( __FILE__ ) . '/modules',
+		'remoteExtPath' => 'VisualEditor/wikia',
+	),
+);

--- a/extensions/VisualEditor/wikia/ve.init.mw.WikiaViewPageTarget.init.js
+++ b/extensions/VisualEditor/wikia/ve.init.mw.WikiaViewPageTarget.init.js
@@ -1,0 +1,282 @@
+/*!
+ * VisualEditor MediaWiki ViewPageTarget init.
+ *
+ * This file must remain as widely compatible as the base compatibility
+ * for MediaWiki itself (see mediawiki/core:/resources/startup.js).
+ * Avoid use of: ES5, SVG, HTML5 DOM, ContentEditable etc.
+ *
+ * @copyright 2011-2013 VisualEditor Team and others; see AUTHORS.txt
+ * @license The MIT License (MIT); see LICENSE.txt
+ */
+
+/*global mw */
+
+/**
+ * Platform preparation for the MediaWiki view page. This loads (when user needs it) the
+ * actual MediaWiki integration and VisualEditor library.
+ *
+ * @class ve.init.mw.WikiaViewPageTarget.init
+ * @singleton
+ */
+( function () {
+	var conf, tabMessages, uri, pageExists, viewUri, veEditUri, isViewPage,
+		init, support, getTargetDeferred, userPrefEnabled,
+		plugins = [];
+
+	/**
+	 * Use deferreds to avoid loading and instantiating Target multiple times.
+	 * @returns {jQuery.Promise}
+	 */
+	function getTarget() {
+		var loadTargetDeferred;
+		if ( !getTargetDeferred ) {
+			getTargetDeferred = $.Deferred();
+			loadTargetDeferred = $.Deferred()
+				.done( function () {
+					//var target = new ve.init.mw.ViewPageTarget();
+					var target = new ve.init.mw.WikiaViewPageTarget();
+					ve.init.mw.targets.push( target );
+
+					// Transfer methods
+					//ve.init.mw.ViewPageTarget.prototype.setupSectionEditLinks = init.setupSectionLinks;
+					ve.init.mw.WikiaViewPageTarget.prototype.setupSectionEditLinks = init.setupSectionLinks;
+
+					// Add plugins
+					target.addPlugins( plugins );
+
+					getTargetDeferred.resolve( target );
+				} )
+				.fail( getTargetDeferred.reject );
+
+			mw.loader.using( 'ext.visualEditor.wikiaViewPageTarget', loadTargetDeferred.resolve, loadTargetDeferred.reject );
+		}
+		return getTargetDeferred.promise();
+	}
+
+	conf = mw.config.get( 'wgVisualEditorConfig' );
+	tabMessages = conf.tabMessages;
+	uri = new mw.Uri( location.href );
+	// For special pages, no information about page existence is exposed to
+	// mw.config, so we assume it exists TODO: fix this in core.
+	pageExists = !!mw.config.get( 'wgArticleId' ) || mw.config.get( 'wgNamespaceNumber' ) < 0;
+	viewUri = new mw.Uri( mw.util.wikiGetlink( mw.config.get( 'wgRelevantPageName' ) ) );
+	veEditUri = viewUri.clone().extend( { 'veaction': 'edit' } );
+	isViewPage = (
+		mw.config.get( 'wgIsArticle' ) &&
+		!( 'diff' in uri.query )
+	);
+
+	support = {
+		es5: !!(
+			// It would be much easier to do a quick inline function that asserts "use strict"
+			// works, but since IE9 doesn't support strict mode (and we don't use strict mode) we
+			// have to instead list all the ES5 features we do use.
+			Array.isArray &&
+			Array.prototype.filter &&
+			Array.prototype.indexOf &&
+			Array.prototype.map &&
+			Date.now &&
+			Date.prototype.toJSON &&
+			Function.prototype.bind &&
+			Object.create &&
+			Object.keys &&
+			String.prototype.trim &&
+			window.JSON &&
+			JSON.parse &&
+			JSON.stringify
+		),
+		contentEditable: 'contentEditable' in document.createElement( 'div' )
+	};
+
+	init = {
+
+		support: support,
+
+		blacklist: {
+			// IE <= 8 has various incompatibilities in layout and feature support
+			// IE9 and IE10 generally work but fail in ajax handling when making POST
+			// requests to the VisualEditor/Parsoid API which is causing silent failures
+			// when trying to save a page (bug 49187)
+			'msie': [['<=', 10]],
+			// Android 2.x and below "support" CE but don't trigger keyboard input
+			'android': [['<', 3]],
+			// Firefox issues in versions 12 and below (bug 50780)
+			// Wikilink [[./]] bug in Firefox 14 and below (bug 50720)
+			'firefox': [['<=', 14]],
+			// Opera < 12 was not tested and it's userbase is almost nonexistent anyway
+			'opera': [['<', 12]],
+			// Blacklist all versions:
+			'blackberry': null
+		},
+
+		/**
+		 * Add a plugin module or function.
+		 *
+		 * Plugins are run after VisualEditor is loaded, but before it is initialized. This allows
+		 * plugins to add classes and register them with the factories and registries.
+		 *
+		 * The parameter to this function can be a ResourceLoader module name or a function.
+		 *
+		 * If it's a module name, it will be loaded together with the VisualEditor core modules when
+		 * VE is loaded. No special care is taken to ensure that the module runs after the VE
+		 * classes are loaded, so if this is desired, the module should depend on
+		 * ext.visualEditor.core .
+		 *
+		 * If it's a function, it will be invoked once the VisualEditor core modules and any
+		 * plugin modules registered through this function have been loaded, but before the editor
+		 * is intialized. The function takes one parameter, which is the ve.init.mw.Target instance
+		 * that's initializing, and can optionally return a jQuery.Promise . VisualEditor will
+		 * only be initialized once all promises returned by plugin functions have been resolved.
+		 *
+		 *     @example
+		 *     // Register ResourceLoader module
+		 *     ve.libs.mw.addPlugin( 'ext.gadget.foobar' );
+		 *
+		 *     // Register a callback
+		 *     ve.libs.mw.addPlugin( function ( target ) {
+		 *         ve.dm.Foobar = .....
+		 *     } );
+		 *
+		 *     // Register a callback that loads another script
+		 *     ve.libs.mw.addPlugin( function () {
+		 *         return $.getScript( 'http://example.com/foobar.js' );
+		 *     } );
+		 *
+		 * @param {string|Function} plugin Module name or callback that optionally returns a promise
+		 */
+		addPlugin: function( plugin ) {
+			plugins.push( plugin );
+		},
+
+		setupSkin: function () {
+			if ( isViewPage ) {
+				init.setupTabs();
+				init.setupSectionLinks();
+			}
+		},
+
+		setupTabs: function () {
+			$( '#ca-ve-edit' ).click( init.onEditTabClick );
+		},
+
+		setupSectionLinks: function () {
+			$( '#mw-content-text .editsection a' ).click( init.onEditSectionLinkClick )
+		},
+
+		onEditTabClick: function ( e ) {
+			// Default mouse button is normalised by jQuery to key code 1.
+			// Only do our handling if no keys are pressed, mouse button is 1
+			// (e.g. not middle click or right click) and no modifier keys
+			// (e.g. cmd-click to open in new tab).
+			if ( ( e.which && e.which !== 1 ) || e.shiftKey || e.altKey || e.ctrlKey || e.metaKey ) {
+				return;
+			}
+
+			e.preventDefault();
+
+			getTarget().done( function ( target ) {
+				ve.track( 'Edit', { action: 'edit-link-click' } );
+				target.activate();
+			} );
+		},
+
+		onEditSectionLinkClick: function ( e ) {
+			if ( ( e.which && e.which !== 1 ) || e.shiftKey || e.altKey || e.ctrlKey || e.metaKey ) {
+				return;
+			}
+
+			e.preventDefault();
+
+			getTarget().done( function ( target ) {
+				ve.track( 'Edit', { action: 'section-edit-link-click' } );
+				target.saveEditSection( $( e.target ).closest( 'h1, h2, h3, h4, h5, h6' ).get( 0 ) );
+				target.activate();
+			} );
+		}
+	};
+
+	support.visualEditor = support.es5 &&
+		support.contentEditable &&
+		( ( 'vewhitelist' in uri.query ) || !$.client.test( init.blacklist, null, true ) );
+
+	userPrefEnabled = (
+		// Allow disabling for anonymous users separately from changing the
+		// default preference (bug 50000)
+		!( conf.disableForAnons && mw.config.get( 'wgUserName' ) === null ) &&
+
+		// User has 'visualeditor-enable' preference enabled (for alpha opt-in)
+		// User has 'visualeditor-betatempdisable' preference disabled
+		// Because user.options is embedded in the HTML and cached per-page for anons on wikis
+		// with static caching (e.g. wgUseFileCache or reverse-proxy) ignore user.options for
+		// anons as it is likely outdated.
+		(
+			mw.config.get( 'wgUserName' ) === null ?
+				( conf.defaultUserOptions.enable && !conf.defaultUserOptions.betatempdisable ) :
+				(
+					mw.user.options.get( 'visualeditor-enable', conf.defaultUserOptions.enable ) &&
+						!mw.user.options.get(
+							'visualeditor-betatempdisable',
+							conf.defaultUserOptions.betatempdisable
+						)
+				)
+		)
+	);
+
+	// Whether VisualEditor should be available for the current user, page, wiki, mediawiki skin,
+	// browser etc.
+	init.isAvailable = (
+		support.visualEditor &&
+
+		userPrefEnabled &&
+
+		// Disable on redirect pages until redirects are editable (bug 47328)
+		// Property wgIsRedirect is relatively new in core, many cached pages
+		// don't have it yet. We do a best-effort approach using the url query
+		// which will cover all working redirect (the only case where one can
+		// read a redirect page without ?redirect=no is in case of broken or
+		// double redirects).
+		!mw.config.get( 'wgIsRedirect', !!uri.query.redirect ) &&
+
+		// Only in supported skins
+		$.inArray( mw.config.get( 'skin' ), conf.skins ) !== -1 &&
+
+		// Only in enabled namespaces
+		$.inArray(
+			new mw.Title( mw.config.get( 'wgRelevantPageName' ) ).getNamespaceId(),
+			conf.namespaces
+		) !== -1
+	);
+
+	// Note: Though VisualEditor itself only needs this exposure for a very small reason
+	// (namely to access init.blacklist from the unit tests...) this has become one of the nicest
+	// ways to easily detect whether the VisualEditor initialisation code is present.
+	//
+	// The VE global was once available always, but now that platform integration initialisation
+	// is properly separated, it doesn't exist until the platform loads VisualEditor core.
+	//
+	// Most of mw.libs.ve is considered subject to change and private.  The exception is that
+	// mw.libs.ve.isAvailable is public, and indicates whether the VE editor itself can be loaded
+	// on this page. See above for why it may be false.
+	mw.libs.ve = init;
+
+	if ( !init.isAvailable ) {
+		$( 'html' ).addClass( 've-not-available' );
+	}
+
+	if ( !userPrefEnabled ) {
+		return;
+	}
+
+	$( 'html' ).addClass( 've-available' );
+
+	$( function () {
+		if ( init.isAvailable && isViewPage ) {
+			if ( uri.query.veaction === 'edit' ) {
+				getTarget().done( function ( target ) {
+					target.activate();
+				} );
+			}
+		}
+		init.setupSkin();
+	} );
+}() );

--- a/extensions/VisualEditor/wikia/ve.init.mw.WikiaViewPageTarget.js
+++ b/extensions/VisualEditor/wikia/ve.init.mw.WikiaViewPageTarget.js
@@ -1,0 +1,41 @@
+/*!
+ * VisualEditor MediaWiki Initialization WikiaViewPageTarget class.
+ *
+ * @copyright 2011-2013 VisualEditor Team and others; see AUTHORS.txt
+ * @license The MIT License (MIT); see LICENSE.txt
+ */
+
+/*global mw, confirm, alert */
+
+/**
+ * Initialization MediaWiki view page target.
+ *
+ * @class
+ * @extends ve.init.mw.ViewPageTarget
+ *
+ * @constructor
+ */
+ve.init.mw.WikiaViewPageTarget = function VeInitMwWikiaViewPageTarget() {
+	// Parent constructor
+	ve.init.mw.ViewPageTarget.call( this );
+};
+
+/* Inheritance */
+
+ve.inheritClass( ve.init.mw.WikiaViewPageTarget, ve.init.mw.ViewPageTarget );
+
+ve.init.mw.WikiaViewPageTarget.prototype.setupSkinTabs = function () {
+	// Intentionally left empty
+};
+
+ve.init.mw.WikiaViewPageTarget.prototype.mutePageContent = function () {
+	$( '#mw-content-text, .WikiaArticleCategories' )
+		.addClass( 've-init-mw-viewPageTarget-content' )
+		.fadeTo( 'fast', 0.6 );
+};
+
+ve.init.mw.ViewPageTarget.prototype.hidePageContent = function () {
+	$( '#mw-content-text, .WikiaArticleCategories' )
+		.addClass( 've-init-mw-viewPageTarget-content' )
+		.hide();
+};

--- a/resources/jquery/jquery.client.js
+++ b/resources/jquery/jquery.client.js
@@ -1,12 +1,12 @@
 /**
  * User-agent detection
  */
-( function( $ ) {
+( function ( $ ) {
 
 	/* Private Members */
 
 	/**
-	 * @var profileCache {Object} Keyed by userAgent string,
+	 * @var {Object} profileCache Keyed by userAgent string,
 	 * value is the parsed $.client.profile object for that user agent.
 	 */
 	var profileCache = {};
@@ -18,9 +18,9 @@
 		/**
 		 * Get an object containing information about the client.
 		 *
-		 * @param nav {Object} An object with atleast a 'userAgent' and 'platform' key.=
+		 * @param {Object} nav An object with atleast a 'userAgent' and 'platform' key.
 		 * Defaults to the global Navigator object.
-		 * @return {Object} The resulting client object will be in the following format:
+		 * @returns {Object} The resulting client object will be in the following format:
 		 *  {
 		 *   'name': 'firefox',
 		 *   'layout': 'gecko',
@@ -31,75 +31,83 @@
 		 *   'versionNumber': 3.5,
 		 *  }
 		 */
-		profile: function( nav ) {
+		profile: function ( nav ) {
+			/*jshint boss: true */
+
 			if ( nav === undefined ) {
 				nav = window.navigator;
 			}
 			// Use the cached version if possible
 			if ( profileCache[nav.userAgent] === undefined ) {
 
-				/* Configuration */
+				var
+					versionNumber,
 
-				// Name of browsers or layout engines we don't recognize
-				var uk = 'unknown';
-				// Generic version digit
-				var x = 'x';
-				// Strings found in user agent strings that need to be conformed
-				var wildUserAgents = ['Opera', 'Navigator', 'Minefield', 'KHTML', 'Chrome', 'PLAYSTATION 3'];
-				// Translations for conforming user agent strings
-				var userAgentTranslations = [
-					// Tons of browsers lie about being something they are not
-					[/(Firefox|MSIE|KHTML,\slike\sGecko|Konqueror)/, ''],
-					// Chrome lives in the shadow of Safari still
-					['Chrome Safari', 'Chrome'],
-					// KHTML is the layout engine not the browser - LIES!
-					['KHTML', 'Konqueror'],
-					// Firefox nightly builds
-					['Minefield', 'Firefox'],
-					// This helps keep differnt versions consistent
-					['Navigator', 'Netscape'],
-					// This prevents version extraction issues, otherwise translation would happen later
-					['PLAYSTATION 3', 'PS3']
-				];
-				// Strings which precede a version number in a user agent string - combined and used as match 1 in
-				// version detectection
-				var versionPrefixes = [
-					'camino', 'chrome', 'firefox', 'netscape', 'netscape6', 'opera', 'version', 'konqueror', 'lynx',
-					'msie', 'safari', 'ps3'
-				];
-				// Used as matches 2, 3 and 4 in version extraction - 3 is used as actual version number
-				var versionSuffix = '(\\/|\\;?\\s|)([a-z0-9\\.\\+]*?)(\\;|dev|rel|\\)|\\s|$)';
-				// Names of known browsers
-				var names = [
-					'camino', 'chrome', 'firefox', 'netscape', 'konqueror', 'lynx', 'msie', 'opera', 'safari', 'ipod',
-					'iphone', 'blackberry', 'ps3'
-				];
-				// Tanslations for conforming browser names
-				var nameTranslations = [];
-				// Names of known layout engines
-				var layouts = ['gecko', 'konqueror', 'msie', 'opera', 'webkit'];
-				// Translations for conforming layout names
-				var layoutTranslations = [['konqueror', 'khtml'], ['msie', 'trident'], ['opera', 'presto']];
-				// Names of supported layout engines for version number
-				var layoutVersions = ['applewebkit', 'gecko'];
-				// Names of known operating systems
-				var platforms = ['win', 'mac', 'linux', 'sunos', 'solaris', 'iphone'];
-				// Translations for conforming operating system names
-				var platformTranslations = [['sunos', 'solaris']];
+					/* Configuration */
 
-				/* Methods */
+					// Name of browsers or layout engines we don't recognize
+					uk = 'unknown',
+					// Generic version digit
+					x = 'x',
+					// Strings found in user agent strings that need to be conformed
+					wildUserAgents = ['Opera', 'Navigator', 'Minefield', 'KHTML', 'Chrome', 'PLAYSTATION 3', 'Iceweasel'],
+					// Translations for conforming user agent strings
+					userAgentTranslations = [
+						// Tons of browsers lie about being something they are not
+						[/(Firefox|MSIE|KHTML,?\slike\sGecko|Konqueror)/, ''],
+						// Chrome lives in the shadow of Safari still
+						['Chrome Safari', 'Chrome'],
+						// KHTML is the layout engine not the browser - LIES!
+						['KHTML', 'Konqueror'],
+						// Firefox nightly builds
+						['Minefield', 'Firefox'],
+						// This helps keep different versions consistent
+						['Navigator', 'Netscape'],
+						// This prevents version extraction issues, otherwise translation would happen later
+						['PLAYSTATION 3', 'PS3']
+					],
+					// Strings which precede a version number in a user agent string - combined and used as
+					// match 1 in version detection
+					versionPrefixes = [
+						'camino', 'chrome', 'firefox', 'iceweasel', 'netscape', 'netscape6', 'opera', 'version', 'konqueror',
+						'lynx', 'msie', 'safari', 'ps3', 'android'
+					],
+					// Used as matches 2, 3 and 4 in version extraction - 3 is used as actual version number
+					versionSuffix = '(\\/|\\;?\\s|)([a-z0-9\\.\\+]*?)(\\;|dev|rel|\\)|\\s|$)',
+					// Names of known browsers
+					names = [
+						'camino', 'chrome', 'firefox', 'iceweasel', 'netscape', 'konqueror', 'lynx', 'msie', 'opera',
+						'safari', 'ipod', 'iphone', 'blackberry', 'ps3', 'rekonq', 'android'
+					],
+					// Tanslations for conforming browser names
+					nameTranslations = [],
+					// Names of known layout engines
+					layouts = ['gecko', 'konqueror', 'msie', 'trident', 'opera', 'webkit'],
+					// Translations for conforming layout names
+					layoutTranslations = [ ['konqueror', 'khtml'], ['msie', 'trident'], ['opera', 'presto'] ],
+					// Names of supported layout engines for version number
+					layoutVersions = ['applewebkit', 'gecko', 'trident'],
+					// Names of known operating systems
+					platforms = ['win', 'wow64', 'mac', 'linux', 'sunos', 'solaris', 'iphone'],
+					// Translations for conforming operating system names
+					platformTranslations = [ ['sunos', 'solaris'], ['wow64', 'win'] ],
 
-				// Performs multiple replacements on a string
-				var translate = function( source, translations ) {
-					for ( var i = 0; i < translations.length; i++ ) {
-						source = source.replace( translations[i][0], translations[i][1] );
-					}
-					return source;
-				};
+					/* Methods */
 
-				/* Pre-processing */
+					/**
+					 * Performs multiple replacements on a string
+					 */
+					translate = function ( source, translations ) {
+						var i;
+						for ( i = 0; i < translations.length; i++ ) {
+							source = source.replace( translations[i][0], translations[i][1] );
+						}
+						return source;
+					},
 
-				var	ua = nav.userAgent,
+					/* Pre-processing */
+
+					ua = nav.userAgent,
 					match,
 					name = uk,
 					layout = uk,
@@ -135,82 +143,121 @@
 				/* Edge Cases -- did I mention about how user agent string lie? */
 
 				// Decode Safari's crazy 400+ version numbers
-				if ( name.match( /safari/ ) && version > 400 ) {
+				if ( name === 'safari' && version > 400 ) {
 					version = '2.0';
 				}
 				// Expose Opera 10's lies about being Opera 9.8
-				if ( name === 'opera' && version >= 9.8) {
-					version = ua.match( /version\/([0-9\.]*)/i )[1] || 10;
+				if ( name === 'opera' && version >= 9.8 ) {
+					match = ua.match( /\bversion\/([0-9\.]*)/ );
+					if ( match && match[1] ) {
+						version = match[1];
+					} else {
+						version = '10';
+					}
 				}
-				var versionNumber = parseFloat( version, 10 ) || 0.0;
+				// And Opera 15's lies about being Chrome
+				if ( name === 'chrome' && ( match = ua.match( /\bopr\/([0-9\.]*)/ ) ) ) {
+					if ( match[1] ) {
+						name = 'opera';
+						version = match[1];
+					}
+				}
+				// And IE 11's lies about being not being IE
+				if ( layout === 'trident' && layoutversion >= 7 && ( match = ua.match( /\brv[ :\/]([0-9\.]*)/ ) ) ) {
+					if ( match[1] ) {
+						name = 'msie';
+						version = match[1];
+					}
+				}
+
+				versionNumber = parseFloat( version, 10 ) || 0.0;
 
 				/* Caching */
 
 				profileCache[nav.userAgent] = {
-					'name': name,
-					'layout': layout,
-					'layoutVersion': layoutversion,
-					'platform': platform,
-					'version': version,
-					'versionBase': ( version !== x ? Math.floor( versionNumber ).toString() : x ),
-					'versionNumber': versionNumber
+					name: name,
+					layout: layout,
+					layoutVersion: layoutversion,
+					platform: platform,
+					version: version,
+					versionBase: ( version !== x ? Math.floor( versionNumber ).toString() : x ),
+					versionNumber: versionNumber
 				};
 			}
 			return profileCache[nav.userAgent];
 		},
 
 		/**
-		 * Checks the current browser against a support map object to determine if the browser has been black-listed or
-		 * not. If the browser was not configured specifically it is assumed to work. It is assumed that the body
-		 * element is classified as either "ltr" or "rtl". If neither is set, "ltr" is assumed.
+		 * Checks the current browser against a support map object.
 		 *
 		 * A browser map is in the following format:
 		 * {
+		 *   // Multiple rules with configurable operators
+		 *   'msie': [['>=', 7], ['!=', 9]],
+		 *    // Match no versions
+		 *   'iphone': false,
+		 *    // Match any version
+		 *   'android': null
+		 * }
+		 *
+		 * It can optionally be split into ltr/rtl sections:
+		 * {
 		 *   'ltr': {
-		 *     // Multiple rules with configurable operators
-		 *     'msie': [['>=', 7], ['!=', 9]],
-		 *      // Blocked entirely
+		 *     'android': null,
 		 *     'iphone': false
 		 *   },
 		 *   'rtl': {
-		 *     // Test against a string
-		 *     'msie': [['!==', '8.1.2.3']],
-		 *     // RTL rules do not fall through to LTR rules, you must explicity set each of them
+		 *     'android': false,
+		 *     // rules are not inherited from ltr
 		 *     'iphone': false
 		 *   }
 		 * }
 		 *
-		 * @param map {Object} Browser support map
-		 * @param profile {Object} (optional) a client-profile object.
+		 * @param {Object} map Browser support map
+		 * @param {Object} [profile] A client-profile object
+		 * @param {boolean} [exactMatchOnly=false] Only return true if the browser is matched, otherwise
+		 * returns true if the browser is not found.
 		 *
-		 * @return Boolean true if browser known or assumed to be supported, false if blacklisted
+		 * @returns {boolean} The current browser is in the support map
 		 */
-		test: function( map, profile ) {
-			profile = $.isPlainObject( profile ) ? profile : $.client.profile();
+		test: function ( map, profile, exactMatchOnly ) {
+			/*jshint evil: true */
 
-			var dir = $( 'body' ).is( '.rtl' ) ? 'rtl' : 'ltr';
+			var conditions, dir, i, op, val;
+			profile = $.isPlainObject( profile ) ? profile : $.client.profile();
+			if ( map.ltr && map.rtl ) {
+				dir = $( 'body' ).is( '.rtl' ) ? 'rtl' : 'ltr';
+				map = map[dir];
+			}
 			// Check over each browser condition to determine if we are running in a compatible client
-			if ( typeof map[dir] !== 'object' || typeof map[dir][profile.name] === 'undefined' ) {
-				// Unknown, so we assume it's working
+			if ( typeof map !== 'object' || map[profile.name] === undefined ) {
+				// Not found, return true if exactMatchOnly not set, false otherwise
+				return !exactMatchOnly;
+			}
+			conditions = map[profile.name];
+			if ( conditions === false ) {
+				// Match no versions
+				return false;
+			}
+			if ( conditions === null ) {
+				// Match all versions
 				return true;
 			}
-			var conditions = map[dir][profile.name];
-			for ( var i = 0; i < conditions.length; i++ ) {
-				var op = conditions[i][0];
-				var val = conditions[i][1];
-				if ( val === false ) {
-					return false;
-				} else if ( typeof val == 'string' ) {
+			for ( i = 0; i < conditions.length; i++ ) {
+				op = conditions[i][0];
+				val = conditions[i][1];
+				if ( typeof val === 'string' ) {
 					if ( !( eval( 'profile.version' + op + '"' + val + '"' ) ) ) {
 						return false;
 					}
-				} else if ( typeof val == 'number' ) {
+				} else if ( typeof val === 'number' ) {
 					if ( !( eval( 'profile.versionNumber' + op + val ) ) ) {
 						return false;
 					}
 				}
 			}
+
 			return true;
 		}
 	};
-} )( jQuery );
+}( jQuery ) );

--- a/skins/oasis/modules/PageHeaderController.class.php
+++ b/skins/oasis/modules/PageHeaderController.class.php
@@ -76,6 +76,12 @@ class PageHeaderController extends WikiaController {
 			$this->actionImage = MenuButtonController::EDIT_ICON;
 			$this->actionName = 'form-edit';
 		}
+		// ve-edit
+		else if (isset($this->content_actions['ve-edit'])) {
+			$this->action = $this->content_actions['ve-edit'];
+			$this->actionImage = MenuButtonController::EDIT_ICON;
+			$this->actionName = 've-edit';
+		}
 		// edit
 		else if (isset($this->content_actions['edit'])) {
 			$this->action = $this->content_actions['edit'];


### PR DESCRIPTION
extensions/VisualEditor/ApiVisualEditor.php
- do not use proxy when calling Parsoid (noProxy = true)
- backward compatibility fix for getEditNotices (#back-compat)

extensions/VisualEditor/VisualEditor.hooks.php
- enable VisualEditor only in oasis skin (and not in vector, apex and mono book)
- load Wikia specific ViewPageTarget.init instead of MW one

extensions/VisualEditor/VisualEditor.i18n.php
- added visualeditor-ca-classiceditor (Classic editor) message

extensions/VisualEditor/VisualEditor.php
- removed dependency on mediawiki.notify which does not exists in MW 1.19.7 (#back-compat)

extensions/VisualEditor/modules/ve-mw/init/targets/ve.init.mw.ViewPageTarget.js
- call mw.Uri the way as it is expected in MW 1.19.7 (#back-compat)
- modify particular CSS selectors to match Oasis instead of Vector
- make property saveDialogTemplate inheritable
- comment out calls to not existing API mw.hook (#back-compat)

resources/jquery/jquery.client.js
- port this library from current MediaWiki master

skins/oasis/modules/PageHeaderController.class.php
- if ve-action exists as a content action display it as the main one in the article navigation drop down
