### PR TITLE
wall: checking for non-existing titles inside checkTopic method

### DIFF
--- a/extensions/wikia/Wall/notification/WallNotificationsController.class.php
+++ b/extensions/wikia/Wall/notification/WallNotificationsController.class.php
@@ -278,7 +278,9 @@ class WallNotificationsController extends WikiaController {
 			/** @var $title title */
 			$title = Title::newFromText( $topic );
 
-			$result = (bool) $title->exists();
+			if ( $title instanceof Title ) {
+				$result = (bool) $title->exists();
+			}
 		}
 
 		$this->response->setVal( 'exists' , $result );


### PR DESCRIPTION
because currently we're not checking this, we generate fatals instead of returning false
