### PR TITLE
DAR-1765 | Fixed global nav hover menu on IE10

### DIFF
--- a/skins/oasis/js/hoverMenu.js
+++ b/skins/oasis/js/hoverMenu.js
@@ -159,7 +159,8 @@ HoverMenu.prototype.showNav = function(parent) {
 	if (nav.exists()) {
 		nav.addClass("show");
 
-		event = new CustomEvent("hover-menu-shown", {"bubbles": true, "cancelable": true});
+		event = document.createEvent("HTMLEvents");
+		event.initEvent("hover-menu-shown", true, true);
 		nav.get(0).dispatchEvent(event);
 
 		// spotlights displaying
@@ -182,7 +183,8 @@ HoverMenu.prototype.hideNav = function() {
 	nav.removeClass("show");
 
 	if (nav.exists()) {
-		event = new CustomEvent("hover-menu-hidden", {"bubbles": true, "cancelable": true});
+		event = document.createEvent("HTMLEvents");
+		event.initEvent("hover-menu-hidden", true, true);
 		nav.get(0).dispatchEvent(event);
 	}
 };


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/DAR-1765
IE10 still does **not** support `CustomEvent` so we moved back to old way of triggering events.
