### PR TITLE
Backporting mw.hook for VisualEditor

### DIFF
--- a/extensions/VisualEditor/modules/ve-mw/init/targets/ve.init.mw.ViewPageTarget.js
+++ b/extensions/VisualEditor/modules/ve-mw/init/targets/ve.init.mw.ViewPageTarget.js
@@ -321,7 +321,7 @@ ve.init.mw.ViewPageTarget.prototype.onLoad = function ( doc ) {
 			if ( mw.config.get( 'wgVisualEditorConfig' ).showBetaWelcome ) {
 				this.showBetaWelcome();
 			}
-			//mw.hook( 've.activationComplete' ).fire();
+			mw.hook( 've.activationComplete' ).fire();
 		}, this ) );
 	}
 };
@@ -1699,7 +1699,7 @@ ve.init.mw.ViewPageTarget.prototype.swapSaveDialog = function ( slide, options )
 	// Show the target slide
 	$slide.show();
 
-	//mw.hook( 've.saveDialog.stateChanged' ).fire();
+	mw.hook( 've.saveDialog.stateChanged' ).fire();
 
 	if ( slide === 'save' ) {
 		setTimeout( function () {

--- a/resources/mediawiki/mediawiki.js
+++ b/resources/mediawiki/mediawiki.js
@@ -7,7 +7,9 @@ var mw = ( function ( $, undefined ) {
 
 	/* Private Members */
 
-	var hasOwn = Object.prototype.hasOwnProperty;
+	var hasOwn = Object.prototype.hasOwnProperty,
+		slice = Array.prototype.slice;
+	
 	/* Object constructors */
 
 	/**
@@ -1494,7 +1496,84 @@ var mw = ( function ( $, undefined ) {
 		user: {
 			options: new Map(),
 			tokens: new Map()
-		}
+		},
+
+		/**
+		 * Registry and firing of events.
+		 *
+		 * MediaWiki has various interface components that are extended, enhanced
+		 * or manipulated in some other way by extensions, gadgets and even
+		 * in core itself.
+		 *
+		 * This framework helps streamlining the timing of when these other
+		 * code paths fire their plugins (instead of using document-ready,
+		 * which can and should be limited to firing only once).
+		 *
+		 * Features like navigating to other wiki pages, previewing an edit
+		 * and editing itself – without a refresh – can then retrigger these
+		 * hooks accordingly to ensure everything still works as expected.
+		 *
+		 * Example usage:
+		 *
+		 *     mw.hook( 'wikipage.content' ).add( fn ).remove( fn );
+		 *     mw.hook( 'wikipage.content' ).fire( $content );
+		 *
+		 * Handlers can be added and fired for arbitrary event names at any time. The same
+		 * event can be fired multiple times. The last run of an event is memorized
+		 * (similar to `$(document).ready` and `$.Deferred().done`).
+		 * This means if an event is fired, and a handler added afterwards, the added
+		 * function will be fired right away with the last given event data.
+		 *
+		 * Like Deferreds and Promises, the mw.hook object is both detachable and chainable.
+		 * Thus allowing flexible use and optimal maintainability and authority control.
+		 * You can pass around the `add` and/or `fire` method to another piece of code
+		 * without it having to know the event name (or `mw.hook` for that matter).
+		 *
+		 *     var h = mw.hook( 'bar.ready' );
+		 *     new mw.Foo( .. ).fetch( { callback: h.fire } );
+		 *
+		 * @class mw.hook
+		 */
+		hook: ( function () {
+			var lists = {};
+
+			/**
+			 * @method hook
+			 * @member mw
+			 * @param {string} name Name of hook.
+			 * @return {mw.hook}
+			 */
+			return function ( name ) {
+				var list = lists[name] || ( lists[name] = $.Callbacks( 'memory' ) );
+
+				return {
+					/**
+					 * Register a hook handler
+					 * @param {Function...} handler Function to bind.
+					 * @chainable
+					 */
+					add: list.add,
+
+					/**
+					 * Unregister a hook handler
+					 * @param {Function...} handler Function to unbind.
+					 * @chainable
+					 */
+					remove: list.remove,
+
+					/**
+					 * Run a hook.
+					 * @param {Mixed...} data
+					 * @chainable
+					 */
+					fire: function () {
+						return list.fireWith( null, slice.call( arguments ) );
+					}
+				};
+			};
+		}() )
+
+
 	};
 	
 })( jQuery );


### PR DESCRIPTION
The 'Cancel' button in the toolbar relies on mw.hook.
