### PR TITLE
Adding showPageContent function with correct selector for Oasis

### DIFF
--- a/extensions/VisualEditor/wikia/ve.init.mw.WikiaViewPageTarget.js
+++ b/extensions/VisualEditor/wikia/ve.init.mw.WikiaViewPageTarget.js
@@ -34,13 +34,13 @@ ve.init.mw.WikiaViewPageTarget.prototype.mutePageContent = function () {
 		.fadeTo( 'fast', 0.6 );
 };
 
-ve.init.mw.ViewPageTarget.prototype.hidePageContent = function () {
+ve.init.mw.WikiaViewPageTarget.prototype.hidePageContent = function () {
 	$( '#mw-content-text, .WikiaArticleCategories' )
 		.addClass( 've-init-mw-viewPageTarget-content' )
 		.hide();
 };
 
-ve.init.mw.ViewPageTarget.prototype.showPageContent = function () {
+ve.init.mw.WikiaViewPageTarget.prototype.showPageContent = function () {
 	$( '.ve-init-mw-viewPageTarget-content' )
 		.removeClass( 've-init-mw-viewPageTarget-content' )
 		.show()

--- a/extensions/VisualEditor/wikia/ve.init.mw.WikiaViewPageTarget.js
+++ b/extensions/VisualEditor/wikia/ve.init.mw.WikiaViewPageTarget.js
@@ -39,3 +39,10 @@ ve.init.mw.ViewPageTarget.prototype.hidePageContent = function () {
 		.addClass( 've-init-mw-viewPageTarget-content' )
 		.hide();
 };
+
+ve.init.mw.ViewPageTarget.prototype.showPageContent = function () {
+	$( '.ve-init-mw-viewPageTarget-content' )
+		.removeClass( 've-init-mw-viewPageTarget-content' )
+		.show()
+		.fadeTo( 0, 1 );
+};


### PR DESCRIPTION
The showPageContent function in ve.init.mw.ViewPageTarget is almost what we need, but the jQuery selector is slightly different for our Oasis integration. This change restores the view mode article when editing is cancelled.
