### PR TITLE
DAR-1783 Final tweaks to EditPreview

### DIFF
--- a/extensions/wikia/EditPageLayout/css/EditPageLayout.scss
+++ b/extensions/wikia/EditPageLayout/css/EditPageLayout.scss
@@ -315,7 +315,8 @@ body {
 		}
 		& .tooltip-icon {
 			@include tooltip-icon;
-			top: 4px;
+			top: 6px;
+			right: -17px;
 		}
 		.modalContent {
 			border-color: transparent;

--- a/extensions/wikia/EditPreview/EditPreview.i18n.php
+++ b/extensions/wikia/EditPreview/EditPreview.i18n.php
@@ -1,14 +1,14 @@
 <?php
 $messages['en'] = [
-	'wikia-editor-preview-current-width' => 'current width',
-	'wikia-editor-preview-min-width' => 'minimum width',
-	'wikia-editor-preview-max-width' => 'maximum width',
-	'wikia-editor-preview-type-tooltip' => "To make sure your edits look good on all computers, we've introduced the ability to change browser width in preview!",
+	'wikia-editor-preview-current-width' => 'Current width',
+	'wikia-editor-preview-min-width' => 'Minimum width',
+	'wikia-editor-preview-max-width' => 'Maximum width',
+	'wikia-editor-preview-type-tooltip' => "See how your edits will look on any computer.  Changing this option will show you what this article will look like when it's displayed in a browser at minimum width, maximum width, or on your current display.",
 ];
 
 $messages['qqq'] = [
-	'wikia-editor-preview-current-width' => 'select option - current width',
-	'wikia-editor-preview-min-width' => 'select option - minimum width',
-	'wikia-editor-preview-max-width' => 'select option - maximum width',
-	'wikia-editor-preview-type-tooltip' => 'Tooltip explaining what preview type select does',
+	'wikia-editor-preview-current-width' => 'select option; after choosing it a user see preview of the article in his/her current screen width',
+	'wikia-editor-preview-min-width' => 'select option; after choosing it a user see preview of the article in minimum supported width (1024px)',
+	'wikia-editor-preview-max-width' => 'select option; after choosing it a user see preview of the article in maximum supported width (1600px)',
+	'wikia-editor-preview-type-tooltip' => 'content of a comics bubble displayed after hovering over small icon with a question mark; it explains what preview type select does',
 ];

--- a/extensions/wikia/EditPreview/EditPreview.i18n.php
+++ b/extensions/wikia/EditPreview/EditPreview.i18n.php
@@ -3,7 +3,7 @@ $messages['en'] = [
 	'wikia-editor-preview-current-width' => 'Current width',
 	'wikia-editor-preview-min-width' => 'Minimum width',
 	'wikia-editor-preview-max-width' => 'Maximum width',
-	'wikia-editor-preview-type-tooltip' => "See how your edits will look on any computer.  Changing this option will show you what this article will look like when it's displayed in a browser at minimum width, maximum width, or on your current display.",
+	'wikia-editor-preview-type-tooltip' => "See how your edits will look with fluid width on any computer. Changing this option will show you what this article will look like when it's displayed in a browser on small screens, large screens, or on your current display.",
 ];
 
 $messages['qqq'] = [

--- a/extensions/wikia/EditPreview/js/preview.js
+++ b/extensions/wikia/EditPreview/js/preview.js
@@ -148,12 +148,10 @@ define( 'wikia.preview', [ 'wikia.window', 'wikia.nirvana', 'wikia.deferred', 'j
 							});
 
 							var tooltipParams = { placement: 'right' };
-							var editPageDialog = document.getElementById( 'EditPageDialog' );
-
-							if( editPageDialog && editPageDialog.style.zIndex ) {
+							if( $dialog[0] && $dialog[0].style && $dialog[0].style.zIndex ) {
 								// on Chrome when using $.css('z-index') / $.css('zIndex') it gave me 2e+9
 								// this vanilla solution works better
-								tooltipParams['z-index'] = parseInt( editPageDialog.style.zIndex, 10 );
+								tooltipParams['z-index'] = parseInt( $dialog[0].style.zIndex, 10 );
 							}
 
 							jquery('.tooltip-icon').tooltip( tooltipParams );

--- a/extensions/wikia/EditPreview/js/preview.js
+++ b/extensions/wikia/EditPreview/js/preview.js
@@ -132,7 +132,7 @@ define( 'wikia.preview', [ 'wikia.window', 'wikia.nirvana', 'wikia.deferred', 'j
 								},
 								html = mustache.render(template, params);
 
-							jquery(html).insertAfter( jquery( $dialog.find('h1:first') ) );
+							jquery(html).insertAfter( $dialog.find('h1:first') );
 
 							// fire an event once preview is rendered
 							jquery(window).trigger('EditPageAfterRenderPreview', [contentNode]);

--- a/extensions/wikia/EditPreview/js/preview.js
+++ b/extensions/wikia/EditPreview/js/preview.js
@@ -111,6 +111,7 @@ define( 'wikia.preview', [ 'wikia.window', 'wikia.nirvana', 'wikia.deferred', 'j
 					loader({type: loader.MULTI, resources: {
 						mustache: 'extensions/wikia/EditPreview/templates/preview_type_dropdown.mustache'
 					}}).done(function(response) {
+							var $dialog = jquery('#EditPageDialog');
 							var template = response.mustache[0],
 								params = {
 									options: [
@@ -131,13 +132,14 @@ define( 'wikia.preview', [ 'wikia.window', 'wikia.nirvana', 'wikia.deferred', 'j
 								},
 								html = mustache.render(template, params);
 
-							jquery(html).insertAfter('#EditPageDialog >h1');
+							jquery(html).insertAfter( jquery( $dialog.find('h1:first') ) );
 
 							// fire an event once preview is rendered
 							jquery(window).trigger('EditPageAfterRenderPreview', [contentNode]);
 
 							// cache article wrapper selector and its initial width
-							$articleWrapper = jquery('#EditPageDialog .ArticlePreviewInner');
+							$articleWrapper = jquery( $dialog.find('.ArticlePreviewInner') );
+
 							previewTypes.current.value = $articleWrapper.width();
 
 							// attach events to type dropdown

--- a/extensions/wikia/EditPreview/js/preview.js
+++ b/extensions/wikia/EditPreview/js/preview.js
@@ -147,7 +147,16 @@ define( 'wikia.preview', [ 'wikia.window', 'wikia.nirvana', 'wikia.deferred', 'j
 								switchPreview(jquery(event.target).val());
 							});
 
-							jquery('.tooltip-icon').tooltip( { placement: 'right' } );
+							var tooltipParams = { placement: 'right' };
+							var editPageDialog = document.getElementById( 'EditPageDialog' );
+
+							if( editPageDialog && editPageDialog.style.zIndex ) {
+								// on Chrome when using $.css('z-index') / $.css('zIndex') it gave me 2e+9
+								// this vanilla solution works better
+								tooltipParams['z-index'] = parseInt( editPageDialog.style.zIndex, 10 );
+							}
+
+							jquery('.tooltip-icon').tooltip( tooltipParams );
 						}
 					);
 				} else {

--- a/resources/wikia/libraries/bootstrap/tooltip.js
+++ b/resources/wikia/libraries/bootstrap/tooltip.js
@@ -121,6 +121,12 @@
           .css({ top: 0, left: 0, display: 'block' })
           .appendTo(inside ? this.$element : document.body)
 
+		/* wikia change starts (nAndy) */
+		if( this.options && this.options['z-index'] ) {
+			$tip.css( 'z-index', this.options['z-index'] );
+		}
+		/* wikia change ends) */
+
         pos = this.getPosition(inside)
 
         actualWidth = $tip[0].offsetWidth


### PR DESCRIPTION
Changes:
- copy changes,
- more descriptive qqq in messages' file,
- fixed positioning of tooltip icon in preview modal,
- added caching of one DOM element in preview.js,
- added logic updating z-index property of tooltip used in a modal.
