### PR TITLE
VOLDEV-4: Fix Achievements rail module button behavior

### DIFF
--- a/skins/oasis/js/Achievements.js
+++ b/skins/oasis/js/Achievements.js
@@ -104,7 +104,7 @@
 					self.showBadgesDescription();
 					self.trackSponsoredBadges();
 
-					if ( Math.floor( self.page >= self.pageCount ) ) {
+					if ( self.page >= self.pageCount ) {
 						self.prev.show();
 						self.next.hide();
 					} else if ( self.page <= 0 ) {

--- a/skins/oasis/js/Achievements.js
+++ b/skins/oasis/js/Achievements.js
@@ -108,6 +108,7 @@
 						self.prev.show();
 						self.next.hide();
 					} else if ( self.page <= 0 ) {
+						self.next.show();
 						self.prev.hide();
 					} else {
 						self.next.show();

--- a/skins/oasis/js/Achievements.js
+++ b/skins/oasis/js/Achievements.js
@@ -105,6 +105,7 @@
 					self.trackSponsoredBadges();
 
 					if ( Math.floor( self.page >= self.pageCount ) ) {
+						self.prev.show();
 						self.next.hide();
 					} else if ( self.page <= 0 ) {
 						self.prev.hide();


### PR DESCRIPTION
This is a fix for VOLDEV-4, implementing the following changes:
- The "Previous" button now shows up on the last page when there are only two pages (10-17 badges)
- The "Next" button shows up when cycling back to the first page in the same scenario
- A redundant Math.floor() call was removed

@Grunny @mroszka &mdash; pinging per request process
