### PR TITLE
Add debug logging of Wikia API exceptions

### DIFF
--- a/includes/wikia/nirvana/WikiaException.php
+++ b/includes/wikia/nirvana/WikiaException.php
@@ -163,6 +163,7 @@ abstract class WikiaHttpException extends WikiaBaseException {
 
 	function __construct( $details = null, Exception $previous = null ) {
 		parent::__construct( $this->message, $this->code, $previous );
+		wfDebug(get_class($this). " raised from " . wfGetAllCallers(2) . "\n");
 		$this->details = $details;
 	}
 


### PR DESCRIPTION
An example of debug.log entry:

```
NotFoundApiException raised from ArticlesApiController::getTop/WikiaHttpException::__construct
```

@Wikia/platform-team @federico-lox 
