### PR TITLE
Fix the way LinkSuggest time measurement keys are generated

### DIFF
--- a/extensions/wikia/LinkSuggest/LinkSuggest.class.php
+++ b/extensions/wikia/LinkSuggest/LinkSuggest.class.php
@@ -143,7 +143,7 @@ class LinkSuggest {
 		$exactMatchRow = null;
 
 		$queryLower = strtolower($query);
-		$sql1Measurement = T::start(__FUNCTION__ . "\\sql-1");
+		$sql1Measurement = T::start([ __FUNCTION__ , "sql-1" ]);
 		$res = $db->select(
 			array( 'querycache', 'page' ),
 			array( 'page_namespace', 'page_title', 'page_is_redirect' ),
@@ -188,7 +188,7 @@ class LinkSuggest {
 							AND qc_type IS NULL
 						LIMIT ".($wgLinkSuggestLimit * 3); // we fetch 3 times more results to leave out redirects to the same page
 
-			$sql2Measurement = T::start(__FUNCTION__ . "\\sql-2");
+			$sql2Measurement = T::start([ __FUNCTION__, "sql-2" ]);
 			$res = $db->query($sql, __METHOD__);
 
 			self::formatResults($db, $res, $query, $redirects, $results, $exactMatchRow);

--- a/includes/wikia/measurements/Drivers.php
+++ b/includes/wikia/measurements/Drivers.php
@@ -44,7 +44,8 @@ class NewrelicDriver implements Driver {
 	 * @param float $time
 	 */
 	public function measureTime( $measurementName, $time ) {
-		$fullMeasurementName = "Custom/{$measurementName}/[seconds|call]";
+		$fullMeasurementName = "Custom/{$measurementName}[seconds|call]";
+		/** @noinspection PhpUndefinedFunctionInspection */
 		newrelic_custom_metric( $fullMeasurementName, $time );
 	}
 }

--- a/includes/wikia/measurements/Time.class.php
+++ b/includes/wikia/measurements/Time.class.php
@@ -22,10 +22,13 @@ class Time {
 	private $startTime;
 
 	/**
-	 * @param $measurementName
+	 * @param string|string[] $measurementName
 	 * @return Time
 	 */
 	public static function start( $measurementName ) {
+		if ( is_array( $measurementName ) ) {
+			$measurementName = implode( '/', $measurementName );
+		}
 		return new Time( $measurementName, Drivers::get() );
 	}
 

--- a/includes/wikia/measurements/tests/NewrelicDriverTest.php
+++ b/includes/wikia/measurements/tests/NewrelicDriverTest.php
@@ -13,7 +13,10 @@ class NewrelicDriverTest extends \WikiaBaseTest {
 	}
 
 	public function testMeasureTime() {
-		$this->mockGlobalFunction("newrelic_custom_metric", null);
+		$this->getGlobalFunctionMock("newrelic_custom_metric")
+			->expects( $this->once() )
+			->method( 'newrelic_custom_metric' )
+			->with( "Custom/foo[seconds|call]", 0.1 );
 
 		(new NewrelicDriver())->measureTime( "foo", 0.1 );
 	}

--- a/includes/wikia/measurements/tests/TimeTest.php
+++ b/includes/wikia/measurements/tests/TimeTest.php
@@ -7,7 +7,8 @@ class TimeTest extends \WikiaBaseTest {
 	public function testStop() {
 		$driver = $this->buildMock();
 		$driver->expects( $this->once() )
-			->method( 'measureTime' );
+			->method( 'measureTime' )
+			->with( "foo" );
 
 		$measurements = new Time( "foo", $driver );
 		$measurements->stop();
@@ -16,7 +17,8 @@ class TimeTest extends \WikiaBaseTest {
 	public function testAutoDestroy() {
 		$driver = $this->buildMock();
 		$driver->expects( $this->once() )
-			->method( 'measureTime' );
+			->method( 'measureTime' )
+			->with( 'foo' );
 
 		$measurements = new Time( "foo", $driver );
 	}
@@ -32,10 +34,21 @@ class TimeTest extends \WikiaBaseTest {
 	public function testStart() {
 		$driver = $this->buildMock();
 		$driver->expects( $this->once() )
-			->method( 'measureTime' );
+			->method( 'measureTime' )
+			->with( 'bar' );
 		Drivers::set( $driver );
 
 		Time::start("bar");
+	}
+
+	public function testStartWithArray() {
+		$driver = $this->buildMock();
+		$driver->expects( $this->once() )
+			->method( 'measureTime' )
+			->with( 'foo/bar' );
+		Drivers::set( $driver );
+
+		Time::start( ["foo", "bar"] );
 	}
 
 	protected  function buildMock() {


### PR DESCRIPTION
Changing newrelic measurment key for link suggest:
Custom/getLinkSuggest\sql-1/[seconds|call] - > Custom/getLinkSuggest/sql-1[seconds|call]

To avoid this kind of confusion in future I've added possibility of passing key as array of parts instead of full imploded key
i.e. you can pass ['x','y', 'z'] instead of 'x/y/z'.

@jacekjursza @federico-lox 
