### PR TITLE
Enable cache in LinkSuggest

### DIFF
--- a/extensions/wikia/LinkSuggest/LinkSuggest.class.php
+++ b/extensions/wikia/LinkSuggest/LinkSuggest.class.php
@@ -69,7 +69,7 @@ class LinkSuggest {
 		if (strlen($query) < 3) {
 			// enforce minimum character limit on server side
 			$out = self::getEmptyResponse($request->getText('format'));
-		} else if (false && $cached = $wgMemc->get($key)) {
+		} else if ($cached = $wgMemc->get($key)) {
 			$out = $cached;
 		}
 


### PR DESCRIPTION
We are storing LinkSuggest results in cache but not using it (D'oh!)

@idradm  @Szumo 
