### PR TITLE
DAR-1703 | Twitter share button fix when twitter api library was already loadd

### DIFF
--- a/extensions/wikia/ShareButtons/js/ShareButtonTwitter.js
+++ b/extensions/wikia/ShareButtons/js/ShareButtonTwitter.js
@@ -10,9 +10,15 @@ if ( ShareButtons ) {
 			var dfd = new $.Deferred();
 
 			// Resolve when contents have finished loading
-			$( '.twitter-share-button' ).load( dfd.resolve );
+			var button = $( '.twitter-share-button' );
+			button.load( dfd.resolve );
 
 			twttr.ready(function(twttr) {
+				if (button.not('iframe').exists()) {
+					// init share button one more time if Twitter api library was already loaded
+					twttr.widgets.load(button.parent().get(0));
+					dfd.resolve();
+				}
 				twttr.events.bind('click', function(event) {
 					ShareButtons.track({
 						label: 'twitter-' + event.region


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/DAR-1703

Twitter buttons are converted from links with correct class into iframe with twitter functionality on twitter lib load
On http://community.wikia.com/wiki/Community_Central there is twitter timeline in right rail, which loads twitter js. In that time this button doesn't exists in code because it lazy loaded.

This fix fires process of searching links when library was already loaded.
