### PR TITLE
DAR-1133 Fixed issue with unable to delete a comment even if commentdelete user right is granted

### DIFF
--- a/extensions/wikia/ArticleComments/ArticleComments_setup.php
+++ b/extensions/wikia/ArticleComments/ArticleComments_setup.php
@@ -99,6 +99,8 @@ if (!empty($wgEnableWallEngine) || !empty($wgEnableArticleCommentsExt) || !empty
 	$wgHooks['FilePageImageUsageSingleLink'][] = 'ArticleCommentInit::onFilePageImageUsageSingleLink';
 }
 
+$wgHooks['BeforeDeletePermissionErrors'][] = 'ArticleComment::onBeforeDeletePermissionErrors';
+
 //JSMEssages setup
 JSMessages::registerPackage( 'ArticleCommentsCounter', array(
 	'oasis-comments-header',

--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -1459,32 +1459,6 @@ class ArticleComment {
 	}
 
 	/**
-	 * @param Article $article
-	 * @param Title $title
-	 * @param User $user
-	 * @param Array $permission_errors
-	 *
-	 * @return true because it's a hook
-	 */
-	static public function onBeforeDeletePermissionErrors( &$article, &$title, &$user, &$permission_errors ) {
-		$errors = [];
-		foreach( $permission_errors as $errorArr ) {
-			$errors[] = $errorArr[0];
-		}
-
-		if( self::isCommentingEnabled() &&
-			$user->isAllowed( 'commentdelete' ) &&
-			ArticleComment::isTitleComment( $title ) &&
-			self::isBadAccessError( $errors )
-		) {
-		// ok, somebody with commentdelete right is removing an article comment or a blog comment
-			$permission_errors = [];
-		}
-
-		return true;
-	}
-
-	/**
 	 * @desc Helper method returning true or false depending on fact if ArticleComments or Blogs are enabled
 	 *
 	 * @return bool
@@ -1493,6 +1467,31 @@ class ArticleComment {
 		global $wgEnableArticleCommentsExt, $wgEnableBlogArticles;
 
 		return !empty($wgEnableArticleCommentsExt) || !empty($wgEnableBlogArticles);
+	}
+
+	/**
+	 * @desc Enables article and blog comments deletion for users who have commentdelete right but don't have delete
+	 *
+	 * @param Article $article
+	 * @param Title $title
+	 * @param User $user
+	 * @param Array $permission_errors
+	 *
+	 * @return true because it's a hook
+	 */
+	static public function onBeforeDeletePermissionErrors( &$article, &$title, &$user, &$permission_errors ) {
+		if( self::isCommentingEnabled() &&
+			$user->isAllowed( 'commentdelete' ) &&
+			ArticleComment::isTitleComment( $title )
+		) {
+			foreach( $permission_errors as $key => $errorArr ) {
+				if( self::isBadAccessError( $errorArr ) ) {
+					unset( $permission_errors[$key] );
+				}
+			}
+		}
+
+		return true;
 	}
 
 	/**

--- a/includes/Article.php
+++ b/includes/Article.php
@@ -1344,6 +1344,11 @@ class Article extends Page {
 
 		# Check permissions
 		$permission_errors = $title->getUserPermissionsErrors( 'delete', $user );
+
+		# Wikia change @author nAndy (DAR-1133)
+		wfRunHooks( 'BeforeDeletePermissionErrors', [ &$this, &$title, &$user, &$permission_errors ] );
+		# End of Wikia change
+
 		if ( count( $permission_errors ) ) {
 			throw new PermissionsError( 'delete', $permission_errors );
 		}


### PR DESCRIPTION
- created new article hook {{BeforeDeletePermissionErrors}},
- implemented its handler in {{ArticleComment}} class,
- added there two helper methods: {{ArticleComment::isCommentingEnabled()}} and {{ArticleComment::isBadAccessError}}
