### PR TITLE
VOLDEV-3: Followed Forum and Wall threads should be bold on RC

### DIFF
--- a/extensions/wikia/Wall/WallHooksHelper.class.php
+++ b/extensions/wikia/Wall/WallHooksHelper.class.php
@@ -893,8 +893,11 @@ class WallHooksHelper {
 				$class = '';
 
 				$articleLink = ' <a href="'.$link.'" class="'.$class.'" >'.$title.'</a> '.wfMsg(static::getMessagePrefix($rc->getAttribute('rc_namespace')) . '-new-message', array($wallUrl, $wallOwner));
+
 				# Bolden pages watched by this user
-				if( $watched ) {
+				# Users don't follow threads/boards but their specific comments
+				$user = $app->wg->User;
+				if ( $wm->isWatched( $user ) || $wm->isWallWatched( $user ) ) {
 					$articleLink = '<strong class="mw-watched">'.$articleLink.'</strong>';
 				}
 			}

--- a/extensions/wikia/Wall/WallHooksHelper.class.php
+++ b/extensions/wikia/Wall/WallHooksHelper.class.php
@@ -895,7 +895,7 @@ class WallHooksHelper {
 				$articleLink = ' <a href="'.$link.'" class="'.$class.'" >'.$title.'</a> '.wfMsg(static::getMessagePrefix($rc->getAttribute('rc_namespace')) . '-new-message', array($wallUrl, $wallOwner));
 
 				# Bolden pages watched by this user
-				# Users don't follow threads/boards but their specific comments
+				# Check if the user is following the thread or the board
 				$user = $app->wg->User;
 				if ( $wm->isWatched( $user ) || $wm->isWallWatched( $user ) ) {
 					$articleLink = '<strong class="mw-watched">'.$articleLink.'</strong>';


### PR DESCRIPTION
This is a fix for [VOLDEV-3](https://wikia-inc.atlassian.net/browse/VOLDEV-3) that bolds watched thread titles in RecentChanges with `<strong class="mw-watched">`.

@Grunny @mroszka &mdash; pinging you to review per usual process
