### PR TITLE
VOLDEV-6: ThemeDesigner restriction error

### DIFF
--- a/extensions/wikia/ThemeDesigner/ThemeDesigner.i18n.php
+++ b/extensions/wikia/ThemeDesigner/ThemeDesigner.i18n.php
@@ -3,6 +3,7 @@
 $messages = array();
 
 $messages['en'] = array(
+	'action-themedesigner' => 'access Theme Designer',
 	'themedesigner-or' => 'or',
 	'themedesigner-desc' => 'Allows wiki administrators to design a theme for a wiki',
 	'themedesigner-title' => 'Wikia Theme Designer',
@@ -69,6 +70,7 @@ please enter the name of the wiki to save.',
  * @author The Evil IP address
  */
 $messages['qqq'] = array(
+	'action-themedesigner' => 'Text displayed mid-sentence in the permission error when ThemeDesigner is accessed without proper permissions.',
 	'themedesigner-or' => '"or", as in, either Text Wordmark *or* Graphic Wordmark.
 {{Identical|Or}}',
 	'themedesigner-desc' => '{{desc}}',
@@ -868,6 +870,7 @@ $messages['gl'] = array(
  * @author TK-999
  */
 $messages['hu'] = array(
+	'action-themedesigner' => 'a Stílustervező használata',
 	'themedesigner-or' => 'vagy',
 	'themedesigner-desc' => 'Lehetővé teszi a wiki stílusának megtervezését a wiki adminisztrátorainak',
 	'themedesigner-title' => 'Wikia Stílustervező',

--- a/extensions/wikia/ThemeDesigner/ThemeDesigner.i18n.php
+++ b/extensions/wikia/ThemeDesigner/ThemeDesigner.i18n.php
@@ -70,7 +70,7 @@ please enter the name of the wiki to save.',
  * @author The Evil IP address
  */
 $messages['qqq'] = array(
-	'action-themedesigner' => 'Text displayed mid-sentence in the permission error when ThemeDesigner is accessed without proper permissions.',
+	'action-themedesigner' => '{{doc-action|themedesigner}}',
 	'themedesigner-or' => '"or", as in, either Text Wordmark *or* Graphic Wordmark.
 {{Identical|Or}}',
 	'themedesigner-desc' => '{{desc}}',


### PR DESCRIPTION
This patch fixes the problem of the `<action-themedesigner>` message key showing up when ThemeDesigner was accessed without the proper permissions.

@Grunny @mroszka &mdash; pinging per protocol.
