### PR TITLE
VOLDEV-7: Special:Promote and Special:WikiaVideoAdd should have the General tab highlighted when open

### DIFF
--- a/extensions/wikia/AdminDashboard/AdminDashboardLogic.class.php
+++ b/extensions/wikia/AdminDashboard/AdminDashboardLogic.class.php
@@ -16,6 +16,7 @@ class AdminDashboardLogic {
 			'ListUsers' => true,
 			'MultipleUpload' => true,
 			'PageLayoutBuilder' => true,
+			'Promote' => true,
 			'Recentchanges' => true,
 			'RecentChanges' => true,
 			'ThemeDesigner' => true,
@@ -23,6 +24,7 @@ class AdminDashboardLogic {
 			'UserRights' => true,
 			'Userrights' => true,
 			'WikiFeatures' => true,
+			'WikiaVideoAdd' => true,
 		);
 		return !empty($generalApps[$appName]);
 	}


### PR DESCRIPTION
@Grunny @mroszka
