### PR TITLE
VE-247: Prevent window from scrolling for Internet Explorer

### DIFF
--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -191,6 +191,7 @@ $config['oasis_jquery'] = array(
 		'//resources/wikia/libraries/jquery/carousel/jquery.wikia.carousel.js',
 		'//resources/wikia/libraries/jquery/modal/jquery.wikia.modal.js',
 		'//resources/wikia/libraries/jquery/expirystorage/jquery.expirystorage.js',
+		'//resources/wikia/libraries/jquery/focusNoScroll/jquery.focusNoScroll.js',
 
 		// libraries loaders
 		'//resources/wikia/libraries/jquery/getResources/jquery.wikia.getResources.js',

--- a/extensions/wikia/MiniEditor/js/Wall/Wall.Animations.js
+++ b/extensions/wikia/MiniEditor/js/Wall/Wall.Animations.js
@@ -25,7 +25,7 @@ MiniEditor.Wall.Animations = {
 
 			} else {
 				wrapper.animate(animation, function() {
-					wikiaEditor.getEditbox().focus();
+					wikiaEditor.getEditbox().focusNoScroll();
 					wikiaEditor.fire('editorAfterActivated');
 				});
 			}

--- a/extensions/wikia/VideoEmbedTool/js/VET.js
+++ b/extensions/wikia/VideoEmbedTool/js/VET.js
@@ -257,7 +257,7 @@ define('wikia.vet', ['wikia.videoBootstrap', 'jquery', 'wikia.window'], function
 	function VET_loadMain(searchOrder) {
 		var callback = function(data) {
 			$('#VideoEmbedMain').html(data.responseText);
-			$('#VideoEmbedUrl').focus();
+			$('#VideoEmbedUrl').focusNoScroll();
 			VET_updateHeader();
 
 			// macbre: RT #19150

--- a/extensions/wikia/WikiaMiniUpload/js/WMU.js
+++ b/extensions/wikia/WikiaMiniUpload/js/WMU.js
@@ -339,7 +339,7 @@ function WMU_loadMainFromView() {
 
 			WMU_indicator(1, false);
 			if($('#ImageQuery').length) {
-				$('#ImageQuery').focus();
+				$('#ImageQuery').focusNoScroll();
 			}
 			var cookieMsg = document.cookie.indexOf("wmumainmesg=");
 			if (cookieMsg > -1 && document.cookie.charAt(cookieMsg + 12) == 0) {
@@ -476,7 +476,9 @@ function WMU_show( e, gallery, box, align, thumb, size, caption, link ) {
 		if(WMU_refid != null && WMU_wysiwygStart == 2) {
 			WMU_loadDetails();
 		} else {
-			if($('#ImageQuery').length) $('#ImageQuery').focus();
+			if( $('#ImageQuery').length) {
+				$('#ImageQuery').focusNoScroll();
+			}
 		}
 		return;
 	}
@@ -521,7 +523,9 @@ function WMU_loadMain() {
 	var callback = function(html) {
 		$('#ImageUploadMain').html(html);
 		WMU_indicator(1, false);
-		if($('#ImageQuery').length) $('#ImageQuery').focus();
+		if( $('#ImageQuery').length && $('#ImageQuery').is(':visible') ) {
+			$('#ImageQuery').focusNoScroll();
+		} 
 		var cookieMsg = document.cookie.indexOf("wmumainmesg=");
 		if (cookieMsg > -1 && document.cookie.charAt(cookieMsg + 12) == 0) {
 			$('#ImageUploadTextCont').hide();
@@ -593,7 +597,9 @@ function WMU_changeSource(e) {
 			$('#WMU_results_' + WMU_curSourceId).hide();
 			$('#WMU_results_' + sourceId).show();
 
-			if($('#ImageQuery').length) $('#ImageQuery').focus();
+			if($('#ImageQuery').length) {
+				$('#ImageQuery').focusNoScroll();
+			}
 
 			WMU_track({
 				label: sourceId == 0 ? 'find-this-wiki' : 'find-flickr'

--- a/resources/wikia/libraries/jquery/focusNoScroll/jquery.focusNoScroll.js
+++ b/resources/wikia/libraries/jquery/focusNoScroll/jquery.focusNoScroll.js
@@ -1,0 +1,13 @@
+/**
+ * Yo Internet Explorer, stop scrolling all over the place on focus!
+ *
+ * @author Christian Williams christian@wikia-inc.com
+ */
+(function( $ ) {
+	$.fn.focusNoScroll = function() {
+		var x = $(window).scrollLeft(), y = $(window).scrollTop();
+		$(this).focus();
+		$(window).scrollLeft(x).scrollTop(y);
+		return this;
+	};
+})( jQuery );


### PR DESCRIPTION
Setting focus on input elements causes Internet Explorer to scroll unexpectedly. 

jquery.focusNoScroll.js
This jQuery plugin captures the window scroll position, calls focus(), then sets the window scroll position. This is chainable and is a direct drop-in replacement for focus().
