### PR TITLE
Basic support for inline video

### DIFF
--- a/extensions/VisualEditor/wikia/VisualEditor.php
+++ b/extensions/VisualEditor/wikia/VisualEditor.php
@@ -32,8 +32,21 @@ $wgResourceModules += array(
 		),
 		'localBasePath' => dirname( __FILE__ ),
 		'remoteExtPath' => 'VisualEditor/wikia'
+	),
+	'ext.visualEditor.wikiaCore' => array(
+		'scripts' => array(
+			've.dm.WikiaInlineVideoNode.js',
+			've.ce.WikiaInlineVideoNode.js'
+		),
+		'dependencies' => array(
+			'ext.visualEditor.core'
+		),
+		'localBasePath' => dirname( __FILE__ ) . '/modules',
+		'remoteExtPath' => 'VisualEditor/wikia',
 	)
 );
+
+$wgVisualEditorPluginModules[] = 'ext.visualEditor.wikiaCore';
 
 // Register hooks
 $wgHooks['ResourceLoaderTestModules'][] = 'Wikia_onResourceLoaderTestModules';

--- a/extensions/VisualEditor/wikia/ve.ce.WikiaInlineVideoNode.js
+++ b/extensions/VisualEditor/wikia/ve.ce.WikiaInlineVideoNode.js
@@ -3,7 +3,7 @@
  */
 
 /**
- * ContentEditable Wikai video node.
+ * ContentEditable Wikia video node.
  *
  * @class
  * @extends ve.ce.MWInlineImageNode

--- a/extensions/VisualEditor/wikia/ve.ce.WikiaInlineVideoNode.js
+++ b/extensions/VisualEditor/wikia/ve.ce.WikiaInlineVideoNode.js
@@ -1,0 +1,33 @@
+/*!
+ * VisualEditor ContentEditable WikiaInlineVideoNode class.
+ */
+
+/**
+ * ContentEditable Wikai video node.
+ *
+ * @class
+ * @extends ve.ce.MWInlineImageNode
+ * @mixins ve.ce.ProtectedNode
+ * @mixins ve.ce.FocusableNode
+ * @mixins ve.ce.RelocatableNode
+ *
+ * @constructor
+ * @param {ve.dm.WikiaInlineVideoNode} model Model to observe
+ * @param {Object} [config] Config options
+ */
+ve.ce.WikiaInlineVideoNode = function VeCeWikiaInlineVideoNode( model, config ) {
+	// Parent constructor
+	ve.ce.MWInlineImageNode.call( this, model, config );
+};
+
+/* Inheritance */
+
+ve.inheritClass( ve.ce.WikiaInlineVideoNode, ve.ce.MWInlineImageNode );
+
+/* Static Properties */
+
+ve.ce.WikiaInlineVideoNode.static.name = 'wikiaInlineVideo';
+
+/* Registration */
+
+ve.ce.nodeFactory.register( ve.ce.WikiaInlineVideoNode );

--- a/extensions/VisualEditor/wikia/ve.dm.WikiaInlineVideoNode.js
+++ b/extensions/VisualEditor/wikia/ve.dm.WikiaInlineVideoNode.js
@@ -1,0 +1,33 @@
+/*!
+ * VisualEditor DataModel WikiaInlineVideo class.
+ */
+
+/**
+ * DataModel Wikia video node.
+ *
+ * @class
+ * @extends ve.dm.MWInlineImageNode
+ * @constructor
+ * @param {number} [length] Length of content data in document
+ * @param {Object} [element] Reference to element in linear model
+ */
+ve.dm.WikiaInlineVideoNode = function VeDmWikiaInlineVideoNode( length, element ) {
+	ve.dm.MWInlineImageNode.call( this, 0, element );
+};
+
+/* Inheritance */
+
+ve.inheritClass( ve.dm.WikiaInlineVideoNode, ve.dm.MWInlineImageNode );
+
+/* Static Properties */
+
+ve.dm.WikiaInlineVideoNode.static.rdfaToType = {
+	'mw:Video': 'inline',
+	'mw:Video/Frameless': 'frameless'
+};
+
+ve.dm.WikiaInlineVideoNode.static.name = 'wikiaInlineVideo';
+
+/* Registration */
+
+ve.dm.modelRegistry.register( ve.dm.WikiaInlineVideoNode );

--- a/extensions/VisualEditor/wikia/ve.dm.WikiaInlineVideoNode.js
+++ b/extensions/VisualEditor/wikia/ve.dm.WikiaInlineVideoNode.js
@@ -12,7 +12,7 @@
  * @param {Object} [element] Reference to element in linear model
  */
 ve.dm.WikiaInlineVideoNode = function VeDmWikiaInlineVideoNode( length, element ) {
-	ve.dm.MWInlineImageNode.call( this, 0, element );
+	ve.dm.MWInlineImageNode.call( this, length, element );
 };
 
 /* Inheritance */


### PR DESCRIPTION
- ported https://gerrit.wikimedia.org/r/#/c/83503/ from upstream ve.dm.MWInlineImageNode can be easly extended
- tests for this change are easly implementable but depend on wikia-block-media-node to be merged first
