### PR TITLE
DAR-1730 Performance changes connected to Follow extension

### DIFF
--- a/extensions/wikia/Follow/FollowModel.class.php
+++ b/extensions/wikia/Follow/FollowModel.class.php
@@ -70,12 +70,19 @@ class FollowModel {
 		$namespaces_keys = array_keys($namespaces);
 
 		$queryArray = array();
+		$user_id = (int) $user_id;
+		$from = (int) $from;
+		$limit = (int) $limit;
+
 		foreach ($namespaces_keys as $value) {
-			$queryArray[] = "(select wl_namespace, wl_title from watchlist where wl_user = ".intval($user_id)." and wl_namespace = ".intval($value)
-					.( intval($value) == NS_USER_WALL ? " and not wl_title like '%/%'  ":"")
+			$value = (int) $value;
+			$isWall = $value == NS_USER_WALL;
+
+			$queryArray[] = "(select wl_namespace, wl_title from watchlist where wl_user = " . $user_id . " and wl_namespace = " . $value
+					. ( $isWall ? " and not wl_title like '%/%' " : '' )
 					//THIS hack will be removed after runing script with will clear all notification copy
-					.( intval($value) == NS_USER_WALL ? " and wl_wikia_addedtimestamp > '2012-01-31'  ":"")
-					." ORDER BY wl_wikia_addedtimestamp desc limit ".intval($from).",".intval($limit).")";
+					. ( $value == NS_USER_WALL ? " and wl_wikia_addedtimestamp > '2012-01-31'  " : '' )
+					." ORDER BY wl_wikia_addedtimestamp desc limit " . $from . "," . $limit . ")";
 		}
 
 		$res = $db->query( implode(" union ",$queryArray) );
@@ -129,7 +136,7 @@ class FollowModel {
 		 * so we will skip NS_USER_WALL with are subpage to filter out this.
 		 */
 
-		$con = " wl_user = ".intval($user_id)." and wl_namespace in (".implode(',', $namespaces_keys).")";
+		$con = " wl_user = " . $user_id . " and wl_namespace in (" . implode( ',', $namespaces_keys ) . ")";
 		//special case for Wall to avoid subpages
 		//THIS hack will be removed after runing script with will clear all notification copy
 		$con .= (" and ( not wl_namespace = ".NS_USER_WALL."  or (wl_namespace = ".NS_USER_WALL."  and not wl_title like '%/%' and wl_wikia_addedtimestamp > '2012-01-31' ))");

--- a/extensions/wikia/Follow/FollowModel.class.php
+++ b/extensions/wikia/Follow/FollowModel.class.php
@@ -128,10 +128,9 @@ class FollowModel {
 			$isWall = $value == NS_USER_WALL;
 
 			$queryArray[] = "(select wl_namespace, wl_title from watchlist where wl_user = " . $user_id . " and wl_namespace = " . $value
+				// special case for Wall to avoid sub-pages
 				. ( $isWall ? " and not wl_title like '%/%' " : '' )
-				//THIS hack will be removed after runing script with will clear all notification copy
-				. ( $value == NS_USER_WALL ? " and wl_wikia_addedtimestamp > '2012-01-31'  " : '' )
-				." ORDER BY wl_wikia_addedtimestamp desc limit " . $from . "," . $limit . ")";
+				. " ORDER BY wl_wikia_addedtimestamp desc limit " . $from . "," . $limit . ")";
 		}
 
 		$res = $db->query( implode(" union ",$queryArray) );
@@ -202,9 +201,8 @@ class FollowModel {
 		 * so we will skip NS_USER_WALL with are subpage to filter out this.
 		 */
 		$con = " wl_user = " . $user_id . " and wl_namespace in (" . implode( ',', $namespaces_keys ) . ")";
-		//special case for Wall to avoid subpages
-		//THIS hack will be removed after runing script with will clear all notification copy
-		$con .= (" and ( not wl_namespace = ".NS_USER_WALL."  or (wl_namespace = ".NS_USER_WALL."  and not wl_title like '%/%' and wl_wikia_addedtimestamp > '2012-01-31' ))");
+		// special case for Wall to avoid sub-pages
+		$con .= ( " and ( not wl_namespace = ".NS_USER_WALL."  or ( wl_namespace = ".NS_USER_WALL."  and not wl_title like '%/%' ) )" );
 
 
 		$res = $db->select(

--- a/extensions/wikia/Follow/FollowModel.class.php
+++ b/extensions/wikia/Follow/FollowModel.class.php
@@ -20,7 +20,7 @@ class FollowModel {
 	];
 
 	/**
-	 * getWatchList -- get data for followed pages include see all
+	 * getWatchList -- get data for followed pages
 	 *
 	 * @static
 	 * @access public
@@ -74,6 +74,11 @@ class FollowModel {
 		return $order;
 	}
 
+	/**
+	 * @desc Prepares list of namespaces which should be taken into consideration in selecting the list from DB
+	 *
+	 * @param String $namespace_head
+	 */
 	private function prepareNamespaces( $namespace_head ) {
 		global $wgContentNamespaces, $wgEnableBlogArticles, $wgEnableForumExt;
 		wfProfileIn( __METHOD__ );
@@ -101,6 +106,16 @@ class FollowModel {
 		wfProfileOut( __METHOD__ );
 	}
 
+	/**
+	 * @desc Gets pages from watchlist depending on given parameters; The result list is grouped by static::$namespaces
+	 *
+	 * @param Integer $user_id
+	 * @param Integer $from
+	 * @param Integer $limit
+	 * @param Boolean $show_deleted_pages
+	 *
+	 * @return Array
+	 */
 	private function getWatchListArray( $user_id, $from, $limit, $show_deleted_pages ) {
 		global $wgServer, $wgScript, $wgContentNamespaces;
 		wfProfileIn( __METHOD__ );
@@ -167,6 +182,15 @@ class FollowModel {
 		return $out_data;
 	}
 
+	/**
+	 * @desc Gets amount of watchlist elements grouped by static::$namespaces
+	 *
+	 * @param Integer $user_id
+	 * @param Integer $limit
+	 * @param Array $out_data result array from static::getWatchListArray()
+	 *
+	 * @return array
+	 */
 	private function getWatchListCount( $user_id, $limit, $out_data ) {
 		wfProfileIn( __METHOD__ );
 		$db = wfGetDB( DB_SLAVE );
@@ -216,19 +240,19 @@ class FollowModel {
 	}
 
 	/**
-	 * getUserPageWatchList -- getdata for box on user page
+	 * @desc getUserPageWatchList -- getdata for box on user page
+	 *
+	 * @param Integer $user_id
 	 *
 	 * @static
 	 * @access public
 	 *
-	 *
-	 * @return bool
+	 * @return Array
 	 */
 	static function getUserPageWatchList($user_id) {
 		global $wgContentNamespaces, $wgEnableBlogArticles;
 
 		$NS = array();
-
 		if ( !empty($wgEnableBlogArticles) ) {
 			$NS[] = NS_BLOG_ARTICLE;
 		}
@@ -251,7 +275,6 @@ class FollowModel {
 		);
 
 		$watchlist = array();
-
 		while ($row = $db->fetchRow( $res ) ) {
 			$title = Title::makeTitle( $row['wl_namespace'], $row['wl_title'] );
 			$row['url'] = $title->getFullURL();
@@ -267,6 +290,7 @@ class FollowModel {
 			}
 			$watchlist[] = $row;
 		}
+
 		wfProfileOut( __METHOD__ );
 		return $watchlist;
 	}

--- a/extensions/wikia/Follow/FollowModel.class.php
+++ b/extensions/wikia/Follow/FollowModel.class.php
@@ -15,7 +15,7 @@ class FollowModel {
 	 *
 	 * @return array
 	 */
-	static function getWatchList( $user_id, $from = 0, $limit = 15, $namespace_head = null, $show_deleted_pages = true ) {
+	static function getWatchList($user_id, $from = 0, $limit = 15, $namespace_head = null, $show_deleted_pages = true) {
 		global $wgServer, $wgScript, $wgContentNamespaces, $wgEnableBlogArticles, $wgEnableForumExt;
 		wfProfileIn( __METHOD__ );
 		$db = wfGetDB( DB_SLAVE );
@@ -68,17 +68,14 @@ class FollowModel {
 			}
 		}
 		$namespaces_keys = array_keys($namespaces);
-		$user_id = (int) $user_id;
-		$from = (int) $from;
-		$limit = (int) $limit;
 
 		$queryArray = array();
 		foreach ($namespaces_keys as $value) {
-			$value = (int) $value;
-
-			$queryArray[] = "(select wl_namespace, wl_title from watchlist where wl_user = " . $user_id . " and wl_namespace = " . $value
-					. ( $value == NS_USER_WALL ? " and not wl_title like '%/%'  " : "" )
-					. " ORDER BY wl_wikia_addedtimestamp desc limit " . $from . "," . $limit . ")";
+			$queryArray[] = "(select wl_namespace, wl_title from watchlist where wl_user = ".intval($user_id)." and wl_namespace = ".intval($value)
+					.( intval($value) == NS_USER_WALL ? " and not wl_title like '%/%'  ":"")
+					//THIS hack will be removed after runing script with will clear all notification copy
+					.( intval($value) == NS_USER_WALL ? " and wl_wikia_addedtimestamp > '2012-01-31'  ":"")
+					." ORDER BY wl_wikia_addedtimestamp desc limit ".intval($from).",".intval($limit).")";
 		}
 
 		$res = $db->query( implode(" union ",$queryArray) );
@@ -88,7 +85,6 @@ class FollowModel {
 			$row['url'] = $title->getFullURL();
 			$row['hideurl'] = $wgServer.$wgScript."?action=ajax&rs=wfAjaxWatch&rsargs[]=".$title->getPrefixedURL()."&rsargs[]=u";
 			$row['wl_title'] = str_replace("_"," ",$row['wl_title'] );
-
 			if (defined('NS_BLOG_ARTICLE') && $row['wl_namespace'] == NS_BLOG_ARTICLE) {
 				$explode = explode("/", $row['wl_title']);
 				if ( count($explode) > 1) {
@@ -96,7 +92,6 @@ class FollowModel {
 					$row['by_user'] =  $explode[0];
 				}
 			}
-
 			if ( defined( 'NS_WIKIA_FORUM_BOARD_THREAD' ) && $row['wl_namespace'] == NS_WIKIA_FORUM_BOARD_THREAD ) {
 				$wallMessage = WallMessage::newFromTitle( $title );
 				$wallMessage->load();
@@ -124,6 +119,7 @@ class FollowModel {
 					$out_data[$namespaces[ $row['wl_namespace'] ]][] = $row;
 				}
 			}
+
 		}
 
 		/**
@@ -132,7 +128,12 @@ class FollowModel {
 		 * When you fallow tread the fallowing is marked in NS_USER_WALL_MESSAGE, NS_USER_WALL
 		 * so we will skip NS_USER_WALL with are subpage to filter out this.
 		 */
-		$con = " wl_user = " . $user_id . " and wl_namespace in (" . implode( ',', $namespaces_keys ) . ")";
+
+		$con = " wl_user = ".intval($user_id)." and wl_namespace in (".implode(',', $namespaces_keys).")";
+		//special case for Wall to avoid subpages
+		//THIS hack will be removed after runing script with will clear all notification copy
+		$con .= (" and ( not wl_namespace = ".NS_USER_WALL."  or (wl_namespace = ".NS_USER_WALL."  and not wl_title like '%/%' and wl_wikia_addedtimestamp > '2012-01-31' ))");
+
 
 		$res = $db->select(
 			array( 'watchlist' ),

--- a/extensions/wikia/Follow/FollowModel.class.php
+++ b/extensions/wikia/Follow/FollowModel.class.php
@@ -4,11 +4,11 @@
  * Data model
  */
 class FollowModel {
-        static public $ajaxListLimit = 600;
-        static public $specialPageListLimit = 15;
+	static public $ajaxListLimit = 600;
+	static public $specialPageListLimit = 15;
 	static $cache;
 
-    /**
+	/**
 	 * getWatchList -- get data for followed pages include see all
 	 *
 	 * @static
@@ -32,7 +32,6 @@ class FollowModel {
 			NS_VIDEO => 'wikiafollowedpages-special-heading-media',
 			NS_USER_WALL => 'wikiafollowedpages-special-heading-wall',
 		);
-
 
 		if ( !empty($wgEnableBlogArticles) ) {
 			$namespaces[NS_BLOG_ARTICLE] = 'wikiafollowedpages-special-heading-blogs';

--- a/extensions/wikia/Follow/FollowModel.class.php
+++ b/extensions/wikia/Follow/FollowModel.class.php
@@ -7,6 +7,17 @@ class FollowModel {
 	static public $ajaxListLimit = 600;
 	static public $specialPageListLimit = 15;
 	static $cache;
+	static $namespaces = [
+		NS_CATEGORY => 'wikiafollowedpages-special-heading-category',
+		NS_PROJECT => 'wikiafollowedpages-special-heading-project' ,
+		NS_TEMPLATE => 'wikiafollowedpages-special-heading-templates',
+		NS_USER => 'wikiafollowedpages-special-heading-user',
+		NS_MEDIAWIKI => 'wikiafollowedpages-special-heading-mediawiki',
+		NS_FORUM => 'wikiafollowedpages-special-heading-forum',
+		NS_FILE => 'wikiafollowedpages-special-heading-media',
+		NS_VIDEO => 'wikiafollowedpages-special-heading-media',
+		NS_USER_WALL => 'wikiafollowedpages-special-heading-wall',
+	];
 
 	/**
 	 * getWatchList -- get data for followed pages include see all
@@ -17,31 +28,12 @@ class FollowModel {
 	 * @return array
 	 */
 	static function getWatchList($user_id, $from = 0, $limit = 15, $namespace_head = null, $show_deleted_pages = true) {
-		global $wgServer, $wgScript, $wgContentNamespaces, $wgEnableBlogArticles, $wgEnableForumExt;
 		wfProfileIn( __METHOD__ );
-		$db = wfGetDB( DB_SLAVE );
 
-		$namespaces = array(
-			NS_CATEGORY => 'wikiafollowedpages-special-heading-category',
-			NS_PROJECT => 'wikiafollowedpages-special-heading-project' ,
-			NS_TEMPLATE => 'wikiafollowedpages-special-heading-templates',
-			NS_USER => 'wikiafollowedpages-special-heading-user',
-			NS_MEDIAWIKI => 'wikiafollowedpages-special-heading-mediawiki',
-			NS_FORUM => 'wikiafollowedpages-special-heading-forum',
-			NS_FILE => 'wikiafollowedpages-special-heading-media',
-			NS_VIDEO => 'wikiafollowedpages-special-heading-media',
-			NS_USER_WALL => 'wikiafollowedpages-special-heading-wall',
-		);
-
-		if ( !empty($wgEnableBlogArticles) ) {
-			$namespaces[NS_BLOG_ARTICLE] = 'wikiafollowedpages-special-heading-blogs';
-			$namespaces[NS_BLOG_LISTING] = 'wikiafollowedpages-special-heading-blogs';
-		}
-
-		if ( !empty( $wgEnableForumExt ) ) {
-			$namespaces[NS_WIKIA_FORUM_BOARD_THREAD] = 'wikiafollowedpages-special-heading-board';
-		}
-
+		static::prepareNamespaces( $namespace_head );
+		$user_id = (int) $user_id;
+		$from = (int) $from;
+		$limit = (int) $limit;
 		$order = array(
 			'wikiafollowedpages-special-heading-category',
 			'wikiafollowedpages-special-heading-article',
@@ -56,123 +48,15 @@ class FollowModel {
 			'wikiafollowedpages-special-heading-board'
 		);
 
-		foreach ($wgContentNamespaces as $value) {
-			$namespaces[$value] = 'wikiafollowedpages-special-heading-article';
-		}
-
-		if ($namespace_head != null) {
-			foreach ($namespaces as $key => $value) {
-				if ( $value != $namespace_head ) {
-					unset($namespaces[$key]);
-				}
-			}
-		}
-		$namespaces_keys = array_keys($namespaces);
-
-		$queryArray = array();
-		$user_id = (int) $user_id;
-		$from = (int) $from;
-		$limit = (int) $limit;
-
-		foreach ($namespaces_keys as $value) {
-			$value = (int) $value;
-			$isWall = $value == NS_USER_WALL;
-
-			$queryArray[] = "(select wl_namespace, wl_title from watchlist where wl_user = " . $user_id . " and wl_namespace = " . $value
-					. ( $isWall ? " and not wl_title like '%/%' " : '' )
-					//THIS hack will be removed after runing script with will clear all notification copy
-					. ( $value == NS_USER_WALL ? " and wl_wikia_addedtimestamp > '2012-01-31'  " : '' )
-					." ORDER BY wl_wikia_addedtimestamp desc limit " . $from . "," . $limit . ")";
-		}
-
-		$res = $db->query( implode(" union ",$queryArray) );
-		$out_data = array();
 		if( empty( static::$cache['out_data'] ) ) {
-			while ($row =  $db->fetchRow( $res ) ) {
-				$title = Title::makeTitle( $row['wl_namespace'], $row['wl_title'] );
-				$row['url'] = $title->getFullURL();
-				$row['hideurl'] = $wgServer.$wgScript."?action=ajax&rs=wfAjaxWatch&rsargs[]=".$title->getPrefixedURL()."&rsargs[]=u";
-				$row['wl_title'] = str_replace("_"," ",$row['wl_title'] );
-				if (defined('NS_BLOG_ARTICLE') && $row['wl_namespace'] == NS_BLOG_ARTICLE) {
-					$explode = explode("/", $row['wl_title']);
-					if ( count($explode) > 1) {
-						$row['wl_title'] = $explode[1];
-						$row['by_user'] =  $explode[0];
-					}
-				}
-				if ( defined( 'NS_WIKIA_FORUM_BOARD_THREAD' ) && $row['wl_namespace'] == NS_WIKIA_FORUM_BOARD_THREAD ) {
-					$wallMessage = WallMessage::newFromTitle( $title );
-					$wallMessage->load();
-					$row['wl_title'] = $wallMessage->getMetaTitle();
-					$row['wl_title_obj'] = Title::newFromText( $wallMessage->getID(), NS_USER_WALL_MESSAGE );
-					$row['on_board'] = Xml::tags(
-						'a',
-						array(
-							'href' => $wallMessage->getWallUrl(),
-							'title' => $wallMessage->getArticleTitle()->getText()
-						),
-						$wallMessage->getArticleTitle()->getText()
-					);
-				}
-
-				if ( in_array($row['wl_namespace'], $wgContentNamespaces) && (NS_MAIN != $row['wl_namespace']) ) {
-					$ttile = Title::makeTitle($row['wl_namespace'], "none");
-					$row['other_namespace'] = $ttile->getNsText();
-				}
-
-				if( $show_deleted_pages ) {
-					$out_data[$namespaces[ $row['wl_namespace'] ]][] = $row;
-				} else {
-					if( $title->isKnown() ||  $title->getNamespace() == NS_USER_WALL) {
-						$out_data[$namespaces[ $row['wl_namespace'] ]][] = $row;
-					}
-				}
-			}
-
+			$out_data = static::getWatchListArray( $user_id, $from, $limit, $show_deleted_pages );
 			static::$cache['out_data'] = $out_data;
 		} else {
 			$out_data = static::$cache['out_data'];
 		}
 
 		if( empty( static::$cache['out'] ) ) {
-			/**
-			 * Wall Logic
-			 *
-			 * When you fallow tread the fallowing is marked in NS_USER_WALL_MESSAGE, NS_USER_WALL
-			 * so we will skip NS_USER_WALL with are subpage to filter out this.
-			 */
-			$con = " wl_user = " . $user_id . " and wl_namespace in (" . implode( ',', $namespaces_keys ) . ")";
-			//special case for Wall to avoid subpages
-			//THIS hack will be removed after runing script with will clear all notification copy
-			$con .= (" and ( not wl_namespace = ".NS_USER_WALL."  or (wl_namespace = ".NS_USER_WALL."  and not wl_title like '%/%' and wl_wikia_addedtimestamp > '2012-01-31' ))");
-
-
-			$res = $db->select(
-				array( 'watchlist' ),
-				array( 'wl_namespace',
-					   'count(wl_title) as cnt' ),
-				$con,
-				__METHOD__,
-				array(
-					'ORDER BY' 	=> 'wl_wikia_addedtimestamp desc,wl_title',
-					'GROUP BY' => 'wl_namespace'
-				)
-			);
-
-			while ($row =  $db->fetchRow( $res ) ) {
-				$ns = $namespaces[$row['wl_namespace']];
-				if ( !empty($out[$ns]) ) {
-					$out[$ns]['count'] += $row['cnt'];
-				} else {
-					$out[$ns] = array('ns' => $ns,'count' => $row['cnt'], 'data' => (empty($out_data[$ns]) ? array() : $out_data[$ns]));
-				}
-
-				$out[$ns]['show_more'] = 0;
-				if ( $out[$ns]['count']  > $limit ) {
-					$out[$ns]['show_more'] = 1;
-				}
-			}
-
+			$out = static::getWatchListCount( $user_id, $limit, $out_data );
 			static::$cache['out'] = $out;
 		} else {
 			$out = static::$cache['out'];
@@ -190,6 +74,147 @@ class FollowModel {
 		return $order;
 	}
 
+	private function prepareNamespaces( $namespace_head ) {
+		global $wgContentNamespaces, $wgEnableBlogArticles, $wgEnableForumExt;
+		wfProfileIn( __METHOD__ );
+
+		if ( !empty( $wgEnableBlogArticles ) ) {
+			static::$namespaces[NS_BLOG_ARTICLE] = 'wikiafollowedpages-special-heading-blogs';
+			static::$namespaces[NS_BLOG_LISTING] = 'wikiafollowedpages-special-heading-blogs';
+		}
+
+		if ( !empty( $wgEnableForumExt ) ) {
+			static::$namespaces[NS_WIKIA_FORUM_BOARD_THREAD] = 'wikiafollowedpages-special-heading-board';
+		}
+
+		foreach( $wgContentNamespaces as $value ) {
+			static::$namespaces[$value] = 'wikiafollowedpages-special-heading-article';
+		}
+
+		if( $namespace_head != null ) {
+			foreach( static::$namespaces as $key => $value ) {
+				if ( $value != $namespace_head ) {
+					unset( static::$namespaces[$key] );
+				}
+			}
+		}
+		wfProfileOut( __METHOD__ );
+	}
+
+	private function getWatchListArray( $user_id, $from, $limit, $show_deleted_pages ) {
+		global $wgServer, $wgScript, $wgContentNamespaces;
+		wfProfileIn( __METHOD__ );
+
+		$db = wfGetDB( DB_SLAVE );
+		$namespaces_keys = array_keys( static::$namespaces );
+		$queryArray = [];
+		$out_data = [];
+
+		foreach ($namespaces_keys as $value) {
+			$value = (int) $value;
+			$isWall = $value == NS_USER_WALL;
+
+			$queryArray[] = "(select wl_namespace, wl_title from watchlist where wl_user = " . $user_id . " and wl_namespace = " . $value
+				. ( $isWall ? " and not wl_title like '%/%' " : '' )
+				//THIS hack will be removed after runing script with will clear all notification copy
+				. ( $value == NS_USER_WALL ? " and wl_wikia_addedtimestamp > '2012-01-31'  " : '' )
+				." ORDER BY wl_wikia_addedtimestamp desc limit " . $from . "," . $limit . ")";
+		}
+
+		$res = $db->query( implode(" union ",$queryArray) );
+		while ($row =  $db->fetchRow( $res ) ) {
+			$title = Title::makeTitle( $row['wl_namespace'], $row['wl_title'] );
+			$row['url'] = $title->getFullURL();
+			$row['hideurl'] = $wgServer . $wgScript . "?action=ajax&rs=wfAjaxWatch&rsargs[]=".$title->getPrefixedURL()."&rsargs[]=u";
+			$row['wl_title'] = str_replace("_"," ",$row['wl_title'] );
+			if (defined('NS_BLOG_ARTICLE') && $row['wl_namespace'] == NS_BLOG_ARTICLE) {
+				$explode = explode("/", $row['wl_title']);
+				if ( count($explode) > 1) {
+					$row['wl_title'] = $explode[1];
+					$row['by_user'] =  $explode[0];
+				}
+			}
+			if ( defined( 'NS_WIKIA_FORUM_BOARD_THREAD' ) && $row['wl_namespace'] == NS_WIKIA_FORUM_BOARD_THREAD ) {
+				$wallMessage = WallMessage::newFromTitle( $title );
+				$wallMessage->load();
+				$row['wl_title'] = $wallMessage->getMetaTitle();
+				$row['wl_title_obj'] = Title::newFromText( $wallMessage->getID(), NS_USER_WALL_MESSAGE );
+				$row['on_board'] = Xml::tags(
+					'a',
+					array(
+						'href' => $wallMessage->getWallUrl(),
+						'title' => $wallMessage->getArticleTitle()->getText()
+					),
+					$wallMessage->getArticleTitle()->getText()
+				);
+			}
+
+			if ( in_array($row['wl_namespace'], $wgContentNamespaces) && (NS_MAIN != $row['wl_namespace']) ) {
+				$title = Title::makeTitle($row['wl_namespace'], "none");
+				$row['other_namespace'] = $title->getNsText();
+			}
+
+			if( $show_deleted_pages ) {
+				$out_data[ static::$namespaces[ $row['wl_namespace'] ]][] = $row;
+			} else {
+				if( $title->isKnown() ||  $title->getNamespace() == NS_USER_WALL) {
+					$out_data[ static::$namespaces[ $row['wl_namespace'] ]][] = $row;
+				}
+			}
+		}
+
+		wfProfileOut( __METHOD__ );
+		return $out_data;
+	}
+
+	private function getWatchListCount( $user_id, $limit, $out_data ) {
+		wfProfileIn( __METHOD__ );
+		$db = wfGetDB( DB_SLAVE );
+		$namespaces_keys = array_keys( static::$namespaces );
+
+		/**
+		 * Wall Logic
+		 *
+		 * When you fallow tread the fallowing is marked in NS_USER_WALL_MESSAGE, NS_USER_WALL
+		 * so we will skip NS_USER_WALL with are subpage to filter out this.
+		 */
+		$con = " wl_user = " . $user_id . " and wl_namespace in (" . implode( ',', $namespaces_keys ) . ")";
+		//special case for Wall to avoid subpages
+		//THIS hack will be removed after runing script with will clear all notification copy
+		$con .= (" and ( not wl_namespace = ".NS_USER_WALL."  or (wl_namespace = ".NS_USER_WALL."  and not wl_title like '%/%' and wl_wikia_addedtimestamp > '2012-01-31' ))");
+
+
+		$res = $db->select(
+			array( 'watchlist' ),
+			array( 'wl_namespace',
+				'count(wl_title) as cnt' ),
+			$con,
+			__METHOD__,
+			array(
+				'ORDER BY' 	=> 'wl_wikia_addedtimestamp desc,wl_title',
+				'GROUP BY' => 'wl_namespace'
+			)
+		);
+
+		$out = [];
+		while ($row =  $db->fetchRow( $res ) ) {
+			$ns = static::$namespaces[ $row['wl_namespace'] ];
+			if ( !empty($out[$ns]) ) {
+				$out[$ns]['count'] += $row['cnt'];
+			} else {
+				$out[$ns] = array('ns' => $ns,'count' => $row['cnt'], 'data' => (empty($out_data[$ns]) ? array() : $out_data[$ns]));
+			}
+
+			$out[$ns]['show_more'] = 0;
+			if ( $out[$ns]['count']  > $limit ) {
+				$out[$ns]['show_more'] = 1;
+			}
+		}
+
+		wfProfileOut( __METHOD__ );
+		return $out;
+	}
+
 	/**
 	 * getUserPageWatchList -- getdata for box on user page
 	 *
@@ -199,7 +224,6 @@ class FollowModel {
 	 *
 	 * @return bool
 	 */
-
 	static function getUserPageWatchList($user_id) {
 		global $wgContentNamespaces, $wgEnableBlogArticles;
 

--- a/extensions/wikia/Follow/FollowedPagesSpecial.php
+++ b/extensions/wikia/Follow/FollowedPagesSpecial.php
@@ -64,7 +64,7 @@ class FollowedPages extends SpecialPage {
 		$template = new EasyTemplate( dirname( __FILE__ ) . '/templates/' );
 		$template->set_vars(
 			array (
-				"data" 	=> FollowModel::getWatchList( $user->getId() ),
+				"data" 	=> $data,
 				"owner" => $wgUser->getId() == $user->getId(),
 				"user_id" =>  $user->getId(),
 				"is_hide" => $is_hide,


### PR DESCRIPTION
What has been done here:
- re-used `$data` variable when passing it to `EasyTemplate` -- one less call to `FollowModel::getWatchList`,
- re-factored `FollowModel`: changed `intval()` calls into typecasting and extracted (what could be extracted) from inside the loop, moved namespaces array to static field, split `FollowModel::getWatchList` into three methods,
- updated PHPDoc.
