### PR TITLE
JSMessages: add support for messages containing plural forms

### DIFF
--- a/extensions/wikia/JSMessages/js/JSMessages.js
+++ b/extensions/wikia/JSMessages/js/JSMessages.js
@@ -42,6 +42,10 @@
 			if (window.wgMessages) {
 				ret = window.wgMessages[key] || ret;
 
+				// the is a small design flaw in JSMessages - it can fetch messages for both, user language and content
+				// language (although nobody uses the later method right now). But all of them are stored in the same
+				// window.wgMessages so there is no way to determine message language. We assume the user language here,
+				// but we might want to improve it in the future.
 				ret = Plurals.process(ret, arguments, window.wgUserLanguage);
 
 				// replace $1, $2, $3, ...  with parameters provided

--- a/extensions/wikia/JSMessages/js/JSMessages.js
+++ b/extensions/wikia/JSMessages/js/JSMessages.js
@@ -175,6 +175,7 @@
 		 */
 		getPlural: function(forms, ruleFunction, n) {
 			var plural = ruleFunction(n);
+			// prevent from running out of the forms array bounds
 			if (plural < 0) {
 				plural = 0;
 			} else if (plural >= forms.length) {

--- a/extensions/wikia/JSMessages/js/JSMessages.js
+++ b/extensions/wikia/JSMessages/js/JSMessages.js
@@ -201,7 +201,7 @@
 		 * @returns {string} Message with a plurals being replaced with a proper forms
 		 */
 		process: function(msg, msgArguments, language) {
-			msg = msg.replace(/\{\{PLURAL:\$(\d+)\|([^\{\}]+)\}\}/g, function(wholeMsg, variable, forms) {
+			msg = msg.replace(/\{\{PLURAL:\$(\d+)\|([^\{\}]+)\}\}/gi, function(wholeMsg, variable, forms) {
 				if ((variable < 1) || (variable > msgArguments.length)) { // no argument was passed
 					return wholeMsg;
 				}

--- a/extensions/wikia/JSMessages/js/JSMessages.js
+++ b/extensions/wikia/JSMessages/js/JSMessages.js
@@ -174,7 +174,7 @@
 						break;
 					}
 				}
-				Plurals.pluralRules[lang] = ruleFunction;   // cache it for we won't search for it again
+				Plurals.pluralRules[lang] = ruleFunction;   // cache it so we won't search for it again
 			}
 			return Plurals.pluralRules[lang];
 		},

--- a/extensions/wikia/JSMessages/js/JSMessages.js
+++ b/extensions/wikia/JSMessages/js/JSMessages.js
@@ -42,6 +42,8 @@
 			if (window.wgMessages) {
 				ret = window.wgMessages[key] || ret;
 
+				ret = Plurals.process(ret, arguments, window.wgUserLanguage);
+
 				// replace $1, $2, $3, ...  with parameters provided
 				if (ret !== key && arguments.length) {
 					for(var i = 0, l = arguments.length; i < l; i++){
@@ -111,6 +113,101 @@
 
 		return JSMessages;
 	}
+
+	// private module for plural support
+	var Plurals = {
+		defaultPluralRule: function(n) {
+			return (n != 1) ? 1 : 0;
+		},
+		pluralRules: {
+			'ay bo cgg dz fa id ja jbo ka kk km ko ky lo ms su th tr tt ug uz vi wo zh zh-hans zh-hant zh-tw': function() {return 0;},
+			'ach ak am arn br fil fr gun ln mfe mg mi nso oc pt-br ti wa': function(n) {return (n > 1) ? 1 : 0;},
+			'cs sk': function(n) { return (n == 1) ? 0 : ( (n >= 2 && n <= 4) ? 1 : 2 );},
+			'be bs ru sr uk': function(n) {return (n%10 == 1 && n%100 != 11) ? 0 : ( (n%10 >= 2 && n%10 <= 4 && (n%100 < 10 || n%100 >= 20)) ? 1 : 2 );},
+			'jv': function(n) {return (n != 0) ? 1 : 0;},
+			'mk': function(n) {return (n == 1 || n%10 == 1) ? 0 : 1;},
+			'mnk': function(n) {return (n == 0) ? 0 : n == 1 ? 1 : 2;},
+			'lv': function(n) {return (n%10 == 1 && n%100 != 11) ? 0 : ( (n != 0) ? 1 : 2 );},
+			'kw': function(n) {return (n == 1) ? 0 : ( (n == 2) ? 1 : ( (n == 3) ? 2 : 3 ) );},
+			'ro': function(n) {return (n == 1) ? 0 : ( (n == 0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2 );},
+			'ga': function(n) {return (n == 1) ? 0 : ( (n == 2) ? 1 : ( (n < 7) ? 2 : ( (n < 11) ? 3 : 4 ) ) );},
+			'gd': function(n) {return (n == 1 || n == 11) ? 0 : (n == 2 || n == 12) ? 1 : (n > 2 && n < 20) ? 2 : 3;},
+			'sl': function(n) {return (n%100 == 1) ? 0 : ( (n%100 == 2) ? 1 : ( (n%100 == 3 || n%100 == 4) ? 2 : 3 ) );},
+			'pl': function(n) {return (n == 1) ? 0 : ( (n%10 >= 2 && n%10 <= 4 && (n%100 < 10 || n%100 >= 20)) ? 1 : 2 );},
+			'csb': function(n) {return (n == 1) ? 0 : ( (n%10 >= 2 && n%10 <= 4 && (n%100 < 10 || n%100 >= 20)) ? 1 : 2 );},
+			'lt': function(n) {return (n%10 == 1 && n%100 != 11) ? 0 : ( (n%10 >= 2 && (n%100 < 10 || n%100 >= 20)) ? 1 : 2 );},
+			'cy': function(n) {return (n == 0) ? 0 : ( (n == 1) ? 1 : ( (n == 2) ? 2 : ( (n == 3) ? 3 : ( (n == 6) ? 4 : 5 ) ) ) );},
+			'hr': function(n) {return (n%10 == 1 && n%100 != 11) ? 0 : ( (n%10 >= 2 && n%10 <= 4 && (n%100 < 10 || n%100 >= 20)) ? 1 : 2 );},
+			'mt': function(n) {return (n == 1) ? 0 : ( (n == 0 || (n%100 > 1 && n%100 < 11)) ? 1 : ( (n%100 > 10 && n%100 < 20) ? 2 : 3 ) );},
+			'ar': function(n) {return (n == 0) ? 0 : ( (n == 1) ? 1 : ( (n == 2) ? 2 : ( (n%100 >= 3 && n%100 <= 10) ? 3 : ( (n%100 >= 11 && n%100 <= 99) ? 4 : 5 ) ) ) );}
+		},
+		/**
+		 * Return a function, which based on cardinality, returns the position of the plural form
+		 * @param lang string - language code
+		 * @return function - function which takes an integer parameter and returns a plural definition number
+		 */
+		getPluralRuleFunction: function(lang) {
+			if (typeof Plurals.pluralRules[lang] === "undefined") { //search for language plural rule function
+				var ruleFunction = Plurals.defaultPluralRule;       // default function
+				var langRegexp = new RegExp('(?:^| )'+lang+'(?: |$)');
+				for (var langKey in Plurals.pluralRules) {
+					if (Plurals.pluralRules.hasOwnProperty(langKey)){
+						if (langRegexp.test(langKey)) {
+							ruleFunction = Plurals.pluralRules[langKey];
+							break;
+						}
+					}
+				}
+				Plurals.pluralRules[lang] = ruleFunction;   // cache it for we won't search for it again
+			}
+			return Plurals.pluralRules[lang];
+		},
+		/**
+		 * Return a plural form based on the cardinality
+		 *
+		 * @param forms array of plural forms
+		 * @param ruleFunction function which based on the cardinality, returns a plural form number
+		 * @param n integer cardinality
+		 * @returns string proper plural form
+		 */
+		getPlural: function(forms, ruleFunction, n) {
+			var plural = ruleFunction(n);
+			if (plural < 0) {
+				plural = 0;
+			} else if (plural >= forms.length) {
+				plural = forms.length - 1;
+			}
+			return forms[plural];
+		},
+		/**
+		 * Process plural forms within a message
+		 *
+		 * For example if the message is 'User $1 has {{PLURAL:$2|one edit|$2 edits}}' the result is
+		 * * for arguments ['Joe', 1] -> 'User $1 has one edit'
+		 * * for arguments ['John', 100] -> 'User $1 has $2 edits'
+		 *
+		 * @param msg string message containing plural pattern {{PLURAL:$<number>|<plural forms>}}
+		 * @param msgArguments array message arguments
+		 * @param language string language code
+		 * @returns string message with a plurals being replaced with a proper forms
+		 */
+		process: function(msg, msgArguments, language) {
+			msg = msg.replace(/\{\{PLURAL:\$(\d+)\|([^\{\}]+)\}\}/g, function(wholeMsg, variable, forms) {
+				if ((variable < 1) || (variable > msgArguments.length)) { // no argument was passed
+					return wholeMsg;
+				}
+				var cardinality = msgArguments[variable - 1];
+				if (typeof cardinality !== "number") { // try converting it to a number
+					cardinality = parseInt(cardinality);
+					if (isNaN(cardinality)) {
+						return wholeMsg;
+					}
+				}
+				return Plurals.getPlural(forms.split('|'), Plurals.getPluralRuleFunction(language), cardinality);
+			});
+			return msg;
+		}
+	};
 
 	//UMD inclusive
 	if(jQuery){

--- a/extensions/wikia/JSMessages/js/JSMessages.js
+++ b/extensions/wikia/JSMessages/js/JSMessages.js
@@ -160,7 +160,7 @@
 				if (mainLanguage.length > 1) {
 					langs.push(mainLanguage[0]);
 				}
-				for (i = 0; i < langs.length; i++) {
+				for (i = 0; (i < langs.length) && (ruleFunction === Plurals.defaultPluralRule); i++) {
 					var langRegexp = new RegExp('(?:^| )'+langs[i]+'(?: |$)');
 					for (var langKey in Plurals.pluralRules) {
 						if (Plurals.pluralRules.hasOwnProperty(langKey)){
@@ -169,9 +169,6 @@
 								break;
 							}
 						}
-					}
-					if (ruleFunction != Plurals.defaultPluralRule) {
-						break;
 					}
 				}
 				Plurals.pluralRules[lang] = ruleFunction;   // cache it so we won't search for it again

--- a/extensions/wikia/JSMessages/js/JSMessages.js
+++ b/extensions/wikia/JSMessages/js/JSMessages.js
@@ -17,7 +17,7 @@
 	 *		msg.getForContent('foo');
 	 *  })
 	 *
-	 * or as a compatability support
+	 * or as a compatibility support
 	 *
 	 * $.msg();
 	 * $.getMessages();
@@ -143,8 +143,9 @@
 		},
 		/**
 		 * Return a function, which based on cardinality, returns the position of the plural form
-		 * @param lang string - language code
-		 * @return function - function which takes an integer parameter and returns a plural definition number
+		 *
+		 * @param {string} lang Language code
+		 * @return {function(number): number} Function for determining plural form number
 		 */
 		getPluralRuleFunction: function(lang) {
 			if (typeof Plurals.pluralRules[lang] === "undefined") { //search for language plural rule function
@@ -165,10 +166,10 @@
 		/**
 		 * Return a plural form based on the cardinality
 		 *
-		 * @param forms array of plural forms
-		 * @param ruleFunction function which based on the cardinality, returns a plural form number
-		 * @param n integer cardinality
-		 * @returns string proper plural form
+		 * @param {Array.<string>} forms Plural forms
+		 * @param {function(number): number} ruleFunction Function which based on the cardinality, returns a plural form number
+		 * @param {number} n Cardinality passed to ruleFunction
+		 * @returns {string} Proper plural form
 		 */
 		getPlural: function(forms, ruleFunction, n) {
 			var plural = ruleFunction(n);
@@ -180,16 +181,17 @@
 			return forms[plural];
 		},
 		/**
-		 * Process plural forms within a message
+		 * Process plural forms within a message. In case there is a problem with the parameters or the message
+		 * itself, the {{PLURAL}} tag is not replaced.
 		 *
 		 * For example if the message is 'User $1 has {{PLURAL:$2|one edit|$2 edits}}' the result is
 		 * * for arguments ['Joe', 1] -> 'User $1 has one edit'
 		 * * for arguments ['John', 100] -> 'User $1 has $2 edits'
 		 *
-		 * @param msg string message containing plural pattern {{PLURAL:$<number>|<plural forms>}}
-		 * @param msgArguments array message arguments
-		 * @param language string language code
-		 * @returns string message with a plurals being replaced with a proper forms
+		 * @param {string} msg Message containing plural pattern {{PLURAL:$<number>|<plural forms>}}
+		 * @param {Array.<string|number>} msgArguments Message arguments
+		 * @param {string} language Language code
+		 * @returns {string} Message with a plurals being replaced with a proper forms
 		 */
 		process: function(msg, msgArguments, language) {
 			msg = msg.replace(/\{\{PLURAL:\$(\d+)\|([^\{\}]+)\}\}/g, function(wholeMsg, variable, forms) {

--- a/extensions/wikia/JSMessages/js/JSMessages.js
+++ b/extensions/wikia/JSMessages/js/JSMessages.js
@@ -155,14 +155,23 @@
 		 */
 		getPluralRuleFunction: function(lang) {
 			if (typeof Plurals.pluralRules[lang] === "undefined") { //search for language plural rule function
-				var ruleFunction = Plurals.defaultPluralRule;       // default function
-				var langRegexp = new RegExp('(?:^| )'+lang+'(?: |$)');
-				for (var langKey in Plurals.pluralRules) {
-					if (Plurals.pluralRules.hasOwnProperty(langKey)){
-						if (langRegexp.test(langKey)) {
-							ruleFunction = Plurals.pluralRules[langKey];
-							break;
+				var ruleFunction = Plurals.defaultPluralRule,       // default function
+					langs = [lang], mainLanguage = lang.split('-'), i;
+				if (mainLanguage.length > 1) {
+					langs.push(mainLanguage[0]);
+				}
+				for (i = 0; i < langs.length; i++) {
+					var langRegexp = new RegExp('(?:^| )'+langs[i]+'(?: |$)');
+					for (var langKey in Plurals.pluralRules) {
+						if (Plurals.pluralRules.hasOwnProperty(langKey)){
+							if (langRegexp.test(langKey)) {
+								ruleFunction = Plurals.pluralRules[langKey];
+								break;
+							}
 						}
+					}
+					if (ruleFunction != Plurals.defaultPluralRule) {
+						break;
 					}
 				}
 				Plurals.pluralRules[lang] = ruleFunction;   // cache it for we won't search for it again

--- a/extensions/wikia/JSMessages/js/JSMessages.js
+++ b/extensions/wikia/JSMessages/js/JSMessages.js
@@ -116,9 +116,11 @@
 
 	// private module for plural support
 	var Plurals = {
+		// Default function used as a fallback for languages not listed in pluralRules
 		defaultPluralRule: function(n) {
 			return (n != 1) ? 1 : 0;
 		},
+		// Language-specific functions. One method can be common for several languages specified in the key
 		pluralRules: {
 			'ay bo cgg dz fa id ja jbo ka kk km ko ky lo ms su th tr tt ug uz vi wo zh zh-hans zh-hant zh-tw': function() {return 0;},
 			'ach ak am arn br fil fr gun ln mfe mg mi nso oc pt-br ti wa': function(n) {return (n > 1) ? 1 : 0;},

--- a/extensions/wikia/JSMessages/js/spec/JSMessages.spec.js
+++ b/extensions/wikia/JSMessages/js/spec/JSMessages.spec.js
@@ -81,6 +81,16 @@ describe("JSMessages", function () {
 		expect(msg('caseInsensitivePlural', 2)).toBe('two');
 	});
 
+	it('PLURAL without parameter uses the last form', function() {
+		window.wgUserLanguage = 'en';
+		expect(msg('defaultPlural')).toBe('$1 multiple');
+	});
+
+	it('PLURAL with non numerical parameter uses the last form', function() {
+		window.wgUserLanguage = 'en';
+		expect(msg('defaultPlural', 'foo')).toBe('foo multiple');
+	});
+
 	it('default value is returned for unknown message', function() {
 		window.wgUserLanguage = defaultLang;
 		expect(msg('unknown')).toBe('unknown');

--- a/extensions/wikia/JSMessages/js/spec/JSMessages.spec.js
+++ b/extensions/wikia/JSMessages/js/spec/JSMessages.spec.js
@@ -91,9 +91,11 @@ describe("JSMessages", function () {
 		expect(msg('defaultPlural', 'foo')).toBe('foo multiple');
 	});
 
-	it('default value is returned for unknown message', function() {
-		window.wgUserLanguage = defaultLang;
-		expect(msg('unknown')).toBe('unknown');
+	it('if there is no rule for language sub-code, use the general language rule', function() {
+		window.wgUserLanguage = 'pl-PL';
+		expect(msg('plural', 1)).toBe('Na imprezie jest 1 slon');
+		expect(msg('plural', 2)).toBe('Na imprezie sa 2 slonie');
+		expect(msg('plural', 8)).toBe('Na imprezie jest 8 sloni');
 	});
 
 	async.it('package with messages is properly loaded and applied', function(done) {

--- a/extensions/wikia/JSMessages/js/spec/JSMessages.spec.js
+++ b/extensions/wikia/JSMessages/js/spec/JSMessages.spec.js
@@ -1,4 +1,4 @@
-ddescribe("JSMessages", function () {
+describe("JSMessages", function () {
 	'use strict';
 
 	var async = new AsyncSpec(this),

--- a/extensions/wikia/JSMessages/js/spec/JSMessages.spec.js
+++ b/extensions/wikia/JSMessages/js/spec/JSMessages.spec.js
@@ -1,4 +1,4 @@
-describe("JSMessages", function () {
+ddescribe("JSMessages", function () {
 	'use strict';
 
 	var async = new AsyncSpec(this),
@@ -6,11 +6,16 @@ describe("JSMessages", function () {
 		window = {
 			wgMessages: {
 				foo: 'bar',
-				complex: '$1 is $2'
+				complex: '$1 is $2',
+				plural: 'Na imprezie {{PLURAL:$1|jest $1 slon|sa $1 slonie|jest $1 sloni}}',
+				pluralComplex: '{{PLURAL:$1|$1 arbuz|$1 arbuzy|$1 arbuzow}} i {{PLURAL:$2|$2 melon|$2 melony|$2 melonow}}',
+				defaultPlural: '{{PLURAL:$1|$1 single|$1 multiple}}',
+				sharedPlural: '{{PLURAL:$1|one|two|five}}'
 			},
 			wgUserLanguage: 'foo',
 			wgJSMessagesCB: 123
 		},
+		defaultLang = window.wgUserLanguage,
 		msg = modules.JSMessages(nirvanaMock, $, window);
 
 	it('registers AMD module', function() {
@@ -26,22 +31,60 @@ describe("JSMessages", function () {
 	});
 
 	it('message is returned', function() {
+		window.wgUserLanguage = defaultLang;
 		expect(msg('foo')).toBe('bar');
 	});
 
 	it('message with parameters is parsed', function() {
+		window.wgUserLanguage = defaultLang;
 		expect(msg('complex', '123', '456')).toBe('123 is 456');
 	});
 
+	it('message with plural is working', function() {
+		window.wgUserLanguage = 'pl';
+		expect(msg('plural', 1)).toBe('Na imprezie jest 1 slon');
+		expect(msg('plural', 2)).toBe('Na imprezie sa 2 slonie');
+		expect(msg('plural', 8)).toBe('Na imprezie jest 8 sloni');
+	});
+
+	it('message with several plurals is working', function() {
+		window.wgUserLanguage = 'pl';
+		expect(msg('pluralComplex', 2, 5)).toBe('2 arbuzy i 5 melonow');
+		expect(msg('pluralComplex', 1, 2)).toBe('1 arbuz i 2 melony');
+		expect(msg('pluralComplex', 5, 1)).toBe('5 arbuzow i 1 melon');
+	});
+
+	it('shared plural rule definiton is working', function() {
+		window.wgUserLanguage = 'sk';
+		expect(msg('sharedPlural', 1)).toBe('one');
+		expect(msg('sharedPlural', 2)).toBe('two');
+		expect(msg('sharedPlural', 5)).toBe('five');
+	});
+
+	it('default plural rule is working', function() {
+		window.wgUserLanguage = 'klingon';
+		expect(msg('defaultPlural', 1)).toBe('1 single');
+		expect(msg('defaultPlural', 2)).toBe('2 multiple');
+		expect(msg('defaultPlural', 10)).toBe('10 multiple');
+	});
+
+	it('passing string as a plural argument is working', function() {
+		window.wgUserLanguage = 'klingon';
+		expect(msg('defaultPlural', "1")).toBe('1 single');
+		expect(msg('defaultPlural', "2")).toBe('2 multiple');
+	});
+
 	it('default value is returned for unknown message', function() {
+		window.wgUserLanguage = defaultLang;
 		expect(msg('unknown')).toBe('unknown');
 	});
 
 	async.it('package with messages is properly loaded and applied', function(done) {
+		window.wgUserLanguage = defaultLang;
 		var packageName = ['foo', 'bar'],
 			nirvanaMock = {
 				sendRequest: function(attr) {
-					expect(attr.data.uselang).toBe('foo');
+					expect(attr.data.uselang).toBe(defaultLang);
 					expect(attr.data.packages).toBe(packageName.join(','));
 					expect(attr.data.cb).toBe(123);
 

--- a/extensions/wikia/JSMessages/js/spec/JSMessages.spec.js
+++ b/extensions/wikia/JSMessages/js/spec/JSMessages.spec.js
@@ -70,8 +70,8 @@ describe("JSMessages", function () {
 
 	it('passing string as a plural argument is working', function() {
 		window.wgUserLanguage = 'klingon';
-		expect(msg('defaultPlural', "1")).toBe('1 single');
-		expect(msg('defaultPlural', "2")).toBe('2 multiple');
+		expect(msg('defaultPlural', '1')).toBe('1 single');
+		expect(msg('defaultPlural', '2')).toBe('2 multiple');
 	});
 
 	it('default value is returned for unknown message', function() {

--- a/extensions/wikia/JSMessages/js/spec/JSMessages.spec.js
+++ b/extensions/wikia/JSMessages/js/spec/JSMessages.spec.js
@@ -10,7 +10,8 @@ describe("JSMessages", function () {
 				plural: 'Na imprezie {{PLURAL:$1|jest $1 slon|sa $1 slonie|jest $1 sloni}}',
 				pluralComplex: '{{PLURAL:$1|$1 arbuz|$1 arbuzy|$1 arbuzow}} i {{PLURAL:$2|$2 melon|$2 melony|$2 melonow}}',
 				defaultPlural: '{{PLURAL:$1|$1 single|$1 multiple}}',
-				sharedPlural: '{{PLURAL:$1|one|two|five}}'
+				sharedPlural: '{{PLURAL:$1|one|two|five}}',
+				caseInsensitivePlural: '{{pLuRaL:$1|one|two}}'
 			},
 			wgUserLanguage: 'foo',
 			wgJSMessagesCB: 123
@@ -72,6 +73,12 @@ describe("JSMessages", function () {
 		window.wgUserLanguage = 'klingon';
 		expect(msg('defaultPlural', '1')).toBe('1 single');
 		expect(msg('defaultPlural', '2')).toBe('2 multiple');
+	});
+
+	it('PLURAL keyword in a message in case insensitive', function() {
+		window.wgUserLanguage = 'en';
+		expect(msg('caseInsensitivePlural', 1)).toBe('one');
+		expect(msg('caseInsensitivePlural', 2)).toBe('two');
 	});
 
 	it('default value is returned for unknown message', function() {


### PR DESCRIPTION
This adds support for messages containing {{PLURAL:}} keyword. The module right now contains a set of rule for several supported languages. The existing plural support in MW language classes couldn't be used, as those are regural PHP functions. As there are only 20 different rules for plurals, I've decided to embed all of the in the JS file.
