### PR TITLE
DAR-1701 Whitelist Special:WikiaConfirmEmail from AdminDashboard Chrome

### DIFF
--- a/extensions/wikia/AdminDashboard/AdminDashboardLogic.class.php
+++ b/extensions/wikia/AdminDashboard/AdminDashboardLogic.class.php
@@ -109,6 +109,7 @@ class AdminDashboardLogic {
 				"WDACReview",
 				"WhereIsExtension",
 				"WikiActivity",
+				"WikiaConfirmEmail",
 				"WikiaHubsV2",
 				"WikiaSearch",
 				"WikiaStyleGuide",


### PR DESCRIPTION
See https://wikia-inc.atlassian.net/browse/DAR-1701

The issue is not reproducible anymore, so it's only the whitelist change.
