### PR TITLE
Make "Disable all emails" work on Staff Blog.

### DIFF
--- a/extensions/CategoryWatch/CategoryWatch.php
+++ b/extensions/CategoryWatch/CategoryWatch.php
@@ -164,8 +164,8 @@ class CategoryWatch {
 			$watchingUser   = User::newFromId( $row[0] );
 			$timecorrection = $watchingUser->getOption( 'timecorrection' );
 			$editdate       = $wgLang->timeanddate( wfTimestampNow(), true, false, $timecorrection );
-
-			if ( $watchingUser->getOption( 'enotifwatchlistpages' ) && $watchingUser->isEmailConfirmed() ) {
+			
+			if ( $watchingUser->getOption( 'enotifwatchlistpages' ) && $watchingUser->isEmailConfirmed() && !$watchingUser->getBoolOption( 'unsubscribed' ) ) {
 				$to      = new MailAddress( $watchingUser );
 				$subject = wfMsg( 'categorywatch-emailsubject', $page );
 				$body    = wfMsgForContent( 'enotif_body' );

--- a/includes/UserMailer.php
+++ b/includes/UserMailer.php
@@ -652,8 +652,14 @@ class EmailNotification {
 					if ( $watchingUser->getOption( 'enotifwatchlistpages' ) &&
 						( !$minorEdit || $watchingUser->getOption( 'enotifminoredits' ) ) &&
 						$watchingUser->isEmailConfirmed() &&
-						$watchingUser->getID() != $userTalkId &&
-						!$watchingUser->getBoolOption( 'unsubscribed' ) )
+						$watchingUser->getID() != $userTalkId
+						/**
+						* WIKIA CHANGE begin - @author adam.karminski@wikia-inc.com
+						**/
+						&& !$watchingUser->getBoolOption( 'unsubscribed' ) )
+						/**
+						* WIKIA CHANGE end
+						**/
 					{
 						$this->compose( $watchingUser );
 					}

--- a/includes/UserMailer.php
+++ b/includes/UserMailer.php
@@ -652,7 +652,8 @@ class EmailNotification {
 					if ( $watchingUser->getOption( 'enotifwatchlistpages' ) &&
 						( !$minorEdit || $watchingUser->getOption( 'enotifminoredits' ) ) &&
 						$watchingUser->isEmailConfirmed() &&
-						$watchingUser->getID() != $userTalkId )
+						$watchingUser->getID() != $userTalkId &&
+						!$watchingUser->getBoolOption( 'unsubscribed' ) )
 					{
 						$this->compose( $watchingUser );
 					}


### PR DESCRIPTION
I've found two places where was no check for 'unsubscribed' option before sending email notification to a user. Further investigation is advised.
