### PR TITLE
Wikia media caption node

### DIFF
--- a/extensions/VisualEditor/modules/ve-mw/dm/nodes/ve.dm.MWBlockImageNode.js
+++ b/extensions/VisualEditor/modules/ve-mw/dm/nodes/ve.dm.MWBlockImageNode.js
@@ -41,6 +41,8 @@ ve.dm.MWBlockImageNode.static.handlesOwnChildren = true;
 
 ve.dm.MWBlockImageNode.static.childNodeTypes = [ 'mwImageCaption' ];
 
+ve.dm.MWBlockImageNode.static.captionNodeType = 'mwImageCaption';
+
 ve.dm.MWBlockImageNode.static.matchTagNames = [ 'figure' ];
 
 ve.dm.MWBlockImageNode.static.getMatchRdfaTypes = function () {

--- a/extensions/VisualEditor/modules/ve-mw/dm/nodes/ve.dm.MWBlockImageNode.js
+++ b/extensions/VisualEditor/modules/ve-mw/dm/nodes/ve.dm.MWBlockImageNode.js
@@ -98,13 +98,13 @@ ve.dm.MWBlockImageNode.static.toDataElement = function ( domElements, converter 
 	if ( $caption.length === 0 ) {
 		return [
 			{ 'type': this.name, 'attributes': attributes },
-			{ 'type': 'mwImageCaption' },
-			{ 'type': '/mwImageCaption' },
+			{ 'type': this.childNodeTypes[0] },
+			{ 'type': '/' + this.childNodeTypes[0] },
 			{ 'type': '/' + this.name }
 		];
 	} else {
 		return [ { 'type': this.name, 'attributes': attributes } ].
-			concat( converter.getDataFromDomRecursionClean( $caption[0], { 'type': 'mwImageCaption' } ) ).
+			concat( converter.getDataFromDomRecursionClean( $caption[0], { 'type': this.childNodeTypes[0] } ) ).
 			concat( [ { 'type': '/' + this.name } ] );
 	}
 };

--- a/extensions/VisualEditor/modules/ve-mw/dm/nodes/ve.dm.MWBlockImageNode.js
+++ b/extensions/VisualEditor/modules/ve-mw/dm/nodes/ve.dm.MWBlockImageNode.js
@@ -100,13 +100,13 @@ ve.dm.MWBlockImageNode.static.toDataElement = function ( domElements, converter 
 	if ( $caption.length === 0 ) {
 		return [
 			{ 'type': this.name, 'attributes': attributes },
-			{ 'type': this.childNodeTypes[0] },
-			{ 'type': '/' + this.childNodeTypes[0] },
+			{ 'type': this.captionNodeType },
+			{ 'type': '/' + this.captionNodeType },
 			{ 'type': '/' + this.name }
 		];
 	} else {
 		return [ { 'type': this.name, 'attributes': attributes } ].
-			concat( converter.getDataFromDomRecursionClean( $caption[0], { 'type': this.childNodeTypes[0] } ) ).
+			concat( converter.getDataFromDomRecursionClean( $caption[0], { 'type': this.captionNodeType } ) ).
 			concat( [ { 'type': '/' + this.name } ] );
 	}
 };

--- a/extensions/VisualEditor/modules/ve-mw/dm/nodes/ve.dm.MWImageCaptionNode.js
+++ b/extensions/VisualEditor/modules/ve-mw/dm/nodes/ve.dm.MWImageCaptionNode.js
@@ -29,7 +29,7 @@ ve.dm.MWImageCaptionNode.static.parentNodeTypes = [ 'mwBlockImage' ];
 
 ve.dm.MWImageCaptionNode.static.toDataElement = function () {
 	// Probably not needed
-	return { 'type': 'mwImageCaption' };
+	return { 'type': this.name };
 };
 
 ve.dm.MWImageCaptionNode.static.toDomElements = function ( dataElement, doc ) {

--- a/extensions/VisualEditor/wikia/VisualEditor.php
+++ b/extensions/VisualEditor/wikia/VisualEditor.php
@@ -38,6 +38,7 @@ $wgResourceModules += array(
 	),
 	'ext.visualEditor.wikiaCore' => array(
 		'scripts' => array(
+			'dm/ve.dm.WikiaMediaCaptionNode.js',
 			'dm/ve.dm.WikiaBlockMediaNode.js',
 			'dm/ve.dm.WikiaBlockImageNode.js',
 			'dm/ve.dm.WikiaBlockVideoNode.js',

--- a/extensions/VisualEditor/wikia/ce/ve.ce.WikiaMediaCaptionNode.js
+++ b/extensions/VisualEditor/wikia/ce/ve.ce.WikiaMediaCaptionNode.js
@@ -33,7 +33,7 @@ ve.inheritClass( ve.ce.WikiaMediaCaptionNode, ve.ce.BranchNode );
 
 /* Static Properties */
 
-ve.ce.WikiaMediaCaptionNode.static.name = 'mwImageCaption';
+ve.ce.WikiaMediaCaptionNode.static.name = 'wikiaMediaCaption';
 
 ve.ce.WikiaMediaCaptionNode.static.tagName = 'figcaption';
 

--- a/extensions/VisualEditor/wikia/dm/ve.dm.WikiaBlockMediaNode.js
+++ b/extensions/VisualEditor/wikia/dm/ve.dm.WikiaBlockMediaNode.js
@@ -27,7 +27,6 @@ ve.dm.WikiaBlockMediaNode.static.childNodeTypes = [ 'wikiaMediaCaption' ];
 
 ve.dm.WikiaBlockMediaNode.static.captionNodeType = 'wikiaMediaCaption';
 
-// TODO: need to use wikiaMediaCaption inside toDataElement also
 ve.dm.WikiaBlockMediaNode.static.toDataElement = function ( domElements, converter ) {
 	var dataElement = ve.dm.MWBlockImageNode.static.toDataElement.call(
 			this, domElements, converter

--- a/extensions/VisualEditor/wikia/dm/ve.dm.WikiaBlockMediaNode.js
+++ b/extensions/VisualEditor/wikia/dm/ve.dm.WikiaBlockMediaNode.js
@@ -23,6 +23,9 @@ ve.inheritClass( ve.dm.WikiaBlockMediaNode, ve.dm.MWBlockImageNode );
 
 /* Static Properties */
 
+ve.dm.WikiaBlockMediaNode.static.childNodeTypes = [ 'wikiaMediaCaption' ];
+
+// TODO: need to use wikiaMediaCaption inside toDataElement also
 ve.dm.WikiaBlockMediaNode.static.toDataElement = function ( domElements, converter ) {
 	var dataElement = ve.dm.MWBlockImageNode.static.toDataElement.call(
 			this, domElements, converter

--- a/extensions/VisualEditor/wikia/dm/ve.dm.WikiaBlockMediaNode.js
+++ b/extensions/VisualEditor/wikia/dm/ve.dm.WikiaBlockMediaNode.js
@@ -25,6 +25,8 @@ ve.inheritClass( ve.dm.WikiaBlockMediaNode, ve.dm.MWBlockImageNode );
 
 ve.dm.WikiaBlockMediaNode.static.childNodeTypes = [ 'wikiaMediaCaption' ];
 
+ve.dm.WikiaBlockMediaNode.static.captionNodeType = 'wikiaMediaCaption';
+
 // TODO: need to use wikiaMediaCaption inside toDataElement also
 ve.dm.WikiaBlockMediaNode.static.toDataElement = function ( domElements, converter ) {
 	var dataElement = ve.dm.MWBlockImageNode.static.toDataElement.call(

--- a/extensions/VisualEditor/wikia/dm/ve.dm.WikiaMediaCaptionNode.js
+++ b/extensions/VisualEditor/wikia/dm/ve.dm.WikiaMediaCaptionNode.js
@@ -11,23 +11,23 @@
  * @param {number} [length] Length of content data in document
  * @param {Object} [element] Reference to element in linear model
  */
-ve.dm.VeWikiaMediaCaptionNode = function VeDmWikiaMediaCaptionNode( length, element ) {
+ve.dm.WikiaMediaCaptionNode = function VeDmWikiaMediaCaptionNode( length, element ) {
 	ve.dm.MWImageCaptionNode.call( this, length, element );
 };
 
 /* Inheritance */
 
-ve.inheritClass( ve.dm.VeWikiaMediaCaptionNode, ve.dm.MWImageCaptionNode );
+ve.inheritClass( ve.dm.WikiaMediaCaptionNode, ve.dm.MWImageCaptionNode );
 
 /* Static Properties */
 
-ve.dm.VeWikiaMediaCaptionNode.static.name = 'wikiaMediaCaption';
+ve.dm.WikiaMediaCaptionNode.static.name = 'wikiaMediaCaption';
 
-ve.dm.VeWikiaMediaCaptionNode.static.parentNodeTypes = [
+ve.dm.WikiaMediaCaptionNode.static.parentNodeTypes = [
 	'wikiaBlockImage',
 	'wikiaBlockVideo'
 ];
 
 /* Registration */
 
-ve.dm.modelRegistry.register( ve.dm.VeWikiaMediaCaptionNode );
+ve.dm.modelRegistry.register( ve.dm.WikiaMediaCaptionNode );

--- a/extensions/VisualEditor/wikia/dm/ve.dm.WikiaMediaCaptionNode.js
+++ b/extensions/VisualEditor/wikia/dm/ve.dm.WikiaMediaCaptionNode.js
@@ -1,0 +1,32 @@
+/*!
+ * VisualEditor DataModel WikiaMediaCaptionNode class.
+ */
+
+/**
+ * DataModel Wikia media caption node.
+ *
+ * @class
+ * @extends ve.dm.MWImageCaptionNode
+ * @constructor
+ * @param {number} [length] Length of content data in document
+ * @param {Object} [element] Reference to element in linear model
+ */
+ve.dm.VeDmWikiaMediaCaptionNode = function VeDmWikiaMediaCaptionNode( length, element ) {
+	ve.dm.MWImageCaptionNode.call( this, length, element );
+};
+
+/* Inheritance */
+
+ve.inheritClass( ve.dm.VeDmWikiaMediaCaptionNode, ve.dm.MWImageCaptionNode );
+
+/* Static Properties */
+
+ve.dm.VeDmWikiaMediaCaptionNode.static.name = 'wikiaMediaCaption';
+ve.dm.VeDmWikiaMediaCaptionNode.static.parentNodeTypes = [
+	'wikiaBlockImage',
+	'wikiaBlockVideo'
+];
+
+/* Registration */
+
+ve.dm.modelRegistry.register( ve.dm.VeDmWikiaMediaCaptionNode );

--- a/extensions/VisualEditor/wikia/dm/ve.dm.WikiaMediaCaptionNode.js
+++ b/extensions/VisualEditor/wikia/dm/ve.dm.WikiaMediaCaptionNode.js
@@ -22,6 +22,7 @@ ve.inheritClass( ve.dm.VeDmWikiaMediaCaptionNode, ve.dm.MWImageCaptionNode );
 /* Static Properties */
 
 ve.dm.VeDmWikiaMediaCaptionNode.static.name = 'wikiaMediaCaption';
+
 ve.dm.VeDmWikiaMediaCaptionNode.static.parentNodeTypes = [
 	'wikiaBlockImage',
 	'wikiaBlockVideo'

--- a/extensions/VisualEditor/wikia/dm/ve.dm.WikiaMediaCaptionNode.js
+++ b/extensions/VisualEditor/wikia/dm/ve.dm.WikiaMediaCaptionNode.js
@@ -11,23 +11,23 @@
  * @param {number} [length] Length of content data in document
  * @param {Object} [element] Reference to element in linear model
  */
-ve.dm.VeDmWikiaMediaCaptionNode = function VeDmWikiaMediaCaptionNode( length, element ) {
+ve.dm.VeWikiaMediaCaptionNode = function VeDmWikiaMediaCaptionNode( length, element ) {
 	ve.dm.MWImageCaptionNode.call( this, length, element );
 };
 
 /* Inheritance */
 
-ve.inheritClass( ve.dm.VeDmWikiaMediaCaptionNode, ve.dm.MWImageCaptionNode );
+ve.inheritClass( ve.dm.VeWikiaMediaCaptionNode, ve.dm.MWImageCaptionNode );
 
 /* Static Properties */
 
-ve.dm.VeDmWikiaMediaCaptionNode.static.name = 'wikiaMediaCaption';
+ve.dm.VeWikiaMediaCaptionNode.static.name = 'wikiaMediaCaption';
 
-ve.dm.VeDmWikiaMediaCaptionNode.static.parentNodeTypes = [
+ve.dm.VeWikiaMediaCaptionNode.static.parentNodeTypes = [
 	'wikiaBlockImage',
 	'wikiaBlockVideo'
 ];
 
 /* Registration */
 
-ve.dm.modelRegistry.register( ve.dm.VeDmWikiaMediaCaptionNode );
+ve.dm.modelRegistry.register( ve.dm.VeWikiaMediaCaptionNode );


### PR DESCRIPTION
Without creating our own WikiaMediaCaptionNode, the model tree contained:

wikiaBlockImage
mwImageCaption
/mwImageCaption
/wikiaBlockImage

The childNodeTypes and parentNodeTypes were mismatched and created problems with drag&drop (and probably copy&paste). The only changes to core VE remove hardcoded type references and instead refer to the class's static properties (which can be changed via inheritance). 
