### PR TITLE
VID-492 Ignore known premium video in the WantedFiles page

### DIFF
--- a/extensions/wikia/WikiaWantedQueryPage/WantedFilesPageWikia.class.php
+++ b/extensions/wikia/WikiaWantedQueryPage/WantedFilesPageWikia.class.php
@@ -13,6 +13,17 @@ class WantedFilesPageWikia extends WantedFilesPage {
 			$queryInfo['conds'][] = "il_to not in (" . $dbr->makeList($wgExcludedWantedFiles) . ") ";
 		}
 
+		// Make sure the video_info table exists before adding this additional condition
+		$infoHelper = new VideoInfoHelper();
+		if ( $infoHelper->videoInfoExists() ) {
+			// Ignore any missing images that are actually premium video.  Premium video comes from the
+			// video.wikia.com wiki and will not have local image table entries
+			$queryInfo['tables'][] = 'video_info';
+			$queryInfo['join_conds']['video_info'] = array( 'LEFT JOIN',
+															array("il_to = video_title", "premium = 1"));
+			$queryInfo['conds'][] = 'video_title IS NULL';
+		}
+
 		return $queryInfo;
 	}
 }


### PR DESCRIPTION
@SQLReview 

The code adds to an existing SQL query. The resulting query is:

``` sql
SELECT
    '6' AS namespace,
    il_to AS title,
   COUNT(*) AS value
FROM `imagelinks`
    LEFT JOIN `image`
        ON il_to = img_name
    LEFT JOIN `video_info`
        ON il_to = video_title AND premium = 1
WHERE
    img_name IS NULL AND
    il_to not in ('Placeholder','Welcome-user-page') AND
    video_title IS NULL
GROUP BY il_to
ORDER BY value DESC
LIMIT 1000
```

The parts added by this ticket are:

``` sql
    LEFT JOIN `video_info`
        ON il_to = video_title AND premium = 1
    # ...
    video_title IS NULL
```

The explain for this query is:

```
| id | select_type | table      | type   | possible_keys   | key     | key_len | ref                    | rows | Extra                                                     |
|  1 | SIMPLE      | imagelinks | index  | il_to           | il_to   | 261     | NULL                   |  178 | Using where; Using index; Using temporary; Using filesort |
|  1 | SIMPLE      | image      | eq_ref | PRIMARY         | PRIMARY | 257     | garth.imagelinks.il_to |    1 | Using where; Using index; Not exists                      |
|  1 | SIMPLE      | video_info | eq_ref | PRIMARY,premium | PRIMARY | 257     | garth.imagelinks.il_to |    1 | Using where; Not exists                                   |
```
