### PR TITLE
DAR-1350 "Fix" for DAR-1350

### DIFF
--- a/extensions/wikia/MiniEditor/js/Forum/Forum.NewMessageForm.js
+++ b/extensions/wikia/MiniEditor/js/Forum/Forum.NewMessageForm.js
@@ -2,6 +2,7 @@
 
 MiniEditor.Forum.NewMessageForm = $.createClass(Wall.settings.classBindings.newMessageForm, {
 	disableNewMessage: function() {
+		this.message.find('.submit').attr('disabled', 'disabled');
 		this.message.addClass('loading');
 	},
 	enableNewMessage: function() {

--- a/extensions/wikia/Wall/WallHistory.class.php
+++ b/extensions/wikia/Wall/WallHistory.class.php
@@ -226,6 +226,7 @@ class WallHistory extends WikiaModel {
 								`action` IN (' . WH_EDIT . ', ' . WH_NEW . ')
 								AND `parent_comment_id` = `last_title`.`parent_comment_id`
 						)
+					LIMIT 1
 				) AS `metatitle`,
 				`reason`,
 				`revision_id`


### PR DESCRIPTION
After few hours of trying to reproduce the bug (duplicate records in `wall_history` table) [DAR-1350](https://wikia-inc.atlassian.net/browse/DAR-1350) we decided to implement a fix which is a work-around. It'll fix the forum related pages but will not remove root cause which is unknown for now. We found several worrisome issues with `wall_history`. We'll investigate it more [DAR-2123](https://wikia-inc.atlassian.net/browse/DAR-2123)

@SQLReview 
The changed query was reviewed [here](https://github.com/Wikia/app/commit/50f1c4b1467742e01074764c57fdaa55ba25c00a). We just added a limit in the sub-query.

**Changed query:**

``` sql
SELECT `parent_page_id`,
   `post_user_id`,
   `post_user_ip`,
   `is_reply`,
   `parent_comment_id`,
   `comment_id`,
   `action`,
   `event_date`,
   (
      SELECT `metatitle`
      FROM `wall_history` AS `last_title`
      WHERE
         `parent_comment_id` = `wall_history`.`parent_comment_id`
         AND (`event_date`, `revision_id`) = (
            SELECT MAX(`event_date`), MAX(`revision_id`)
            FROM `wall_history`
            WHERE
               `action` IN (0, 1)
            AND `parent_comment_id` = `last_title`.`parent_comment_id`
         )
      LIMIT 1
   ) AS `metatitle`,
   `reason`,
   `revision_id`
FROM `wall_history`
RIGHT JOIN (
   SELECT
      `parent_comment_id`,
      MAX(`event_date`) AS `event_date`,
      MAX(`revision_id`) AS `revision_id`
   FROM `wall_history`
   RIGHT JOIN
   (
      SELECT `parent_comment_id`
      FROM `wall_history`
      WHERE
         `action` = 1
      AND `deleted_or_removed` = 0
      AND `post_ns` = 2000
      AND `is_reply` = 0
   ) AS `not_removed_parents`
   USING (`parent_comment_id`)
   WHERE
      `action` = 1
      AND `deleted_or_removed` = 0
      AND `post_ns` = 2000
   GROUP BY `parent_comment_id`
   ORDER BY `event_date` DESC
   LIMIT 5
) AS `last_new_post_date`
USING (`parent_comment_id`, `event_date`, `revision_id`)
```

**EXPLAIN on changed query:**

```
+----+--------------------+--------------+------+---------------------------------+--------------------+---------+--------------------------------------------------------------------+------+---------------------------------+
| id | select_type        | table        | type | possible_keys                   | key                | key_len | ref                                                                | rows | Extra                           |
+----+--------------------+--------------+------+---------------------------------+--------------------+---------+--------------------------------------------------------------------+------+---------------------------------+
|  1 | PRIMARY            | <derived4>   | ALL  | NULL                            | NULL               | NULL    | NULL                                                               |    5 |                                 |
|  1 | PRIMARY            | wall_history | ref  | getByParentComment              | getByParentComment | 9       | last_new_post_date.parent_comment_id,last_new_post_date.event_date |    1 |                                 |
|  4 | DERIVED            | <derived5>   | ALL  | NULL                            | NULL               | NULL    | NULL                                                               |  225 | Using temporary; Using filesort |
|  4 | DERIVED            | wall_history | ref  | getLastUsers,getByParentComment | getByParentComment | 5       | not_removed_parents.parent_comment_id                              |    1 | Using where                     |
|  5 | DERIVED            | wall_history | ref  | getLastUsers                    | getLastUsers       | 15      |                                                                    |  916 | Using where                     |
|  2 | DEPENDENT SUBQUERY | last_title   | ref  | getByParentComment              | getByParentComment | 5       | muppet.wall_history.parent_comment_id                              |    1 | Using where                     |
|  3 | DEPENDENT SUBQUERY | wall_history | ref  | getLastUsers,getByParentComment | getByParentComment | 5       | muppet.last_title.parent_comment_id                                |    1 | Using where                     |
+----+--------------------+--------------+------+---------------------------------+--------------------+---------+--------------------------------------------------------------------+------+---------------------------------+
```
