### PR TITLE
VE-338: Enable only on supported namespaces and skins

### DIFF
--- a/extensions/VisualEditor/VisualEditor.hooks.php
+++ b/extensions/VisualEditor/VisualEditor.hooks.php
@@ -93,8 +93,14 @@ class VisualEditorHooks {
 	 * @return boolean
 	 */
 	public static function onSkinTemplateNavigation( &$skin, &$links ) {
-		// Only do this if the user has VE enabled
+		global $wgTitle, $wgVisualEditorNamespaces;
+		// Should we enable VisualEditor?
 		if (
+			// Incorrect skin
+			!in_array( $skin->skinname, self::$supportedSkins ) ||
+			// Incorrect namespace
+			!in_array( $wgTitle->getNamespace(), $wgVisualEditorNamespaces ) ||
+			// Incorrect user setting
 			!$skin->getUser()->getOption( 'visualeditor-enable' ) ||
 			$skin->getUser()->getOption( 'visualeditor-betatempdisable' )
 		) {


### PR DESCRIPTION
This fixes the problem where Category pages (and others) could be edited with VE and also removes VE from Monobook.
