### PR TITLE
DAR-1405 Avoiding count on master

### DIFF
--- a/extensions/wikia/FounderEmails/events/FounderEmailsEditEvent.class.php
+++ b/extensions/wikia/FounderEmails/events/FounderEmailsEditEvent.class.php
@@ -212,8 +212,7 @@ class FounderEmailsEditEvent extends FounderEmailsEvent {
 			$conditions,
 			__METHOD__,
 			[
-				'LIMIT' => self::FIRST_EDIT_REVISION_THRESHOLD,
-				'ORDER BY' => 'rev_timestamp DESC'
+				'LIMIT' => self::FIRST_EDIT_REVISION_THRESHOLD
 			],
 			[ 'page' => [
 					'left join',

--- a/extensions/wikia/FounderEmails/tests/FounderEmailsEditEventTest.php
+++ b/extensions/wikia/FounderEmails/tests/FounderEmailsEditEventTest.php
@@ -98,11 +98,11 @@ class FounderEmailsEditEventTest extends WikiaBaseTest {
 		$mockFounderEmailsEditEvent::staticExpects($this->any())
 			->method('getUserEditsStatus')
 			->will($this->returnValue(FounderEmailsEditEvent::NO_EDITS));
-		$mockFounderEmailsEditEvent->expects($this->any())->method('process')
-			->will($this->returnValue(null));
 		$mockFounderEmailsEditEvent::staticExpects($this->once())
 			->method('getEventData')
 			->with($this->anything(), $this->anything(), $this->anything(), false);
+		$mockFounderEmailsEditEvent->expects($this->any())->method('process')
+			->will($this->returnValue(null));
 		$this->mockClass('FounderEmailsEditEvent', $mockFounderEmailsEditEvent);
 
 		$mockRecentChange = $this->getMockRecentChange();
@@ -126,12 +126,9 @@ class FounderEmailsEditEventTest extends WikiaBaseTest {
 			'getEventData'
 		] );
 
-		$mockFounderEmailsEditEvent::staticExpects($this->any())
-			->method('getUserEditsStatus')
-			->will($this->returnValue(FounderEmailsEditEvent::NO_EDITS));
-		$mockFounderEmailsEditEvent->expects($this->any())->method('process')
-			->will($this->returnValue(null));
+		$mockFounderEmailsEditEvent::staticExpects($this->never())->method('getUserEditsStatus');
 		$mockFounderEmailsEditEvent::staticExpects($this->never())->method('getEventData');
+		$mockFounderEmailsEditEvent->expects($this->never())->method('process');
 		$this->mockClass('FounderEmailsEditEvent', $mockFounderEmailsEditEvent);
 
 		$mockRecentChange = $this->getMockRecentChange();

--- a/extensions/wikia/FounderEmails/tests/FounderEmailsEditEventTest.php
+++ b/extensions/wikia/FounderEmails/tests/FounderEmailsEditEventTest.php
@@ -20,38 +20,29 @@ class FounderEmailsEditEventTest extends WikiaBaseTest {
 	}
 
 	public function testRegisterForFirstEdit() {
+		// Test setup
 		global $wgUser;
-
 		$mockUser = $this->getMockUser();
 		$wgUser = $mockUser;
 
-		$mockRecentChange = $this->getMockRecentChange();
-
-		$mockFounderEmailsEditEvent = $this->getMock('FounderEmailsEditEvent', [
-			'__construct',
-			'getUserEditsStatus',
-			'process',
-			'getEventData'
-		] );
-
+		$mockFounderEmailsEditEvent = $this->getMockFounderEmailsEditEvent();
 		$mockFounderEmailsEditEvent::staticExpects($this->any())
 			->method('getUserEditsStatus')
 			->will($this->returnValue(FounderEmailsEditEvent::FIRST_EDIT));
-
 		$mockFounderEmailsEditEvent::staticExpects($this->once())
 			->method('getEventData')
 			->with($this->anything(), $this->anything(), $this->anything(), true);
-
-		$mockFounderEmailsEditEvent->expects($this->any())->method('process')
-			->will($this->returnValue(null));
 		$this->mockClass('FounderEmailsEditEvent', $mockFounderEmailsEditEvent);
 
+		$mockRecentChange = $this->getMockRecentChange();
+
+		// Test execution
 		$mockFounderEmailsEditEvent::register($mockRecentChange);
 	}
 
 	public function testRegisterForMultipleEdits() {
+		/* Test setup */
 		global $wgUser;
-
 		$mockUser = $this->getMockUser();
 		$mockUser->expects( $this->once() )->method( 'setOption' )->with(
 			$this->stringStartsWith(FounderEmailsEditEvent::FIRST_EDIT_NOTIFICATION_SENT_PROP_NAME),
@@ -59,59 +50,40 @@ class FounderEmailsEditEventTest extends WikiaBaseTest {
 		)->will( $this->returnValue( 0 ) );
 		$wgUser = $mockUser;
 
-		$mockRecentChange = $this->getMockRecentChange();
-
-		$mockFounderEmailsEditEvent = $this->getMock('FounderEmailsEditEvent', [
-			'__construct',
-			'getUserEditsStatus',
-			'process',
-			'getEventData'
-		] );
-
+		$mockFounderEmailsEditEvent = $this->getMockFounderEmailsEditEvent();
 		$mockFounderEmailsEditEvent::staticExpects($this->any())
 			->method('getUserEditsStatus')
 			->will($this->returnValue(FounderEmailsEditEvent::MULTIPLE_EDITS));
-
 		$mockFounderEmailsEditEvent::staticExpects($this->once())
 			->method('getEventData')
 			->with($this->anything(), $this->anything(), $this->anything(), false);
-
-		$mockFounderEmailsEditEvent->expects($this->any())->method('process')
-			->will($this->returnValue(null));
 		$this->mockClass('FounderEmailsEditEvent', $mockFounderEmailsEditEvent);
 
+		$mockRecentChange = $this->getMockRecentChange();
+
+		// Test execution
 		$mockFounderEmailsEditEvent::register($mockRecentChange);
 	}
 
 	public function testRegisterForNoEdits() {
+		// Test setup
 		global $wgUser;
-
 		$mockUser = $this->getMockUser();
 		$mockUser->expects( $this->never() )->method( 'setOption' );
 		$wgUser = $mockUser;
 
-		$mockRecentChange = $this->getMockRecentChange();
-
-		$mockFounderEmailsEditEvent = $this->getMock('FounderEmailsEditEvent', [
-			'__construct',
-			'getUserEditsStatus',
-			'process',
-			'getEventData'
-		] );
-
+		$mockFounderEmailsEditEvent = $this->getMockFounderEmailsEditEvent();
 		$mockFounderEmailsEditEvent::staticExpects($this->any())
 			->method('getUserEditsStatus')
 			->will($this->returnValue(FounderEmailsEditEvent::NO_EDITS));
-
-		$mockFounderEmailsEditEvent->expects($this->any())->method('process')
-			->will($this->returnValue(null));
-
 		$mockFounderEmailsEditEvent::staticExpects($this->once())
 			->method('getEventData')
 			->with($this->anything(), $this->anything(), $this->anything(), false);
-
 		$this->mockClass('FounderEmailsEditEvent', $mockFounderEmailsEditEvent);
 
+		$mockRecentChange = $this->getMockRecentChange();
+
+		// Test execution
 		$mockFounderEmailsEditEvent::register($mockRecentChange);
 	}
 
@@ -136,6 +108,18 @@ class FounderEmailsEditEventTest extends WikiaBaseTest {
 			->will( $this->returnCallback( [ $this, 'getAttributeCallback' ] )
 			);
 		return $mockRecentChange;
+	}
+
+	private function getMockFounderEmailsEditEvent() {
+		$mockFounderEmailsEditEvent = $this->getMock( 'FounderEmailsEditEvent', [
+			'__construct',
+			'getUserEditsStatus',
+			'process',
+			'getEventData'
+		] );
+		$mockFounderEmailsEditEvent->expects( $this->any() )->method( 'process' )->will( $this->returnValue( null ) );
+
+		return $mockFounderEmailsEditEvent;
 	}
 
 }

--- a/extensions/wikia/FounderEmails/tests/FounderEmailsEditEventTest.php
+++ b/extensions/wikia/FounderEmails/tests/FounderEmailsEditEventTest.php
@@ -1,0 +1,28 @@
+<?php
+
+class FounderEmailsEditEventTest extends WikiaBaseTest {
+
+	protected function setUp() {
+		parent::setUp();
+	}
+
+	public function testRegisterForFirstEdit() {
+		$this->markTestIncomplete('To be implemented');
+		$this->assertEquals(true,true,'On first edit value $isRegisteredUserFirstEdit should be set');
+		$this->assertEquals(true,true,'On first edit founderemails-first-edit-notification-sent user property should be set');
+	}
+
+	public function testRegisterForSecondEdit() {
+		$this->markTestIncomplete('To be implemented');
+		$this->assertEquals(true,true,'On first edit value $isRegisteredUserFirstEdit should NOT be set');
+		$this->assertEquals(true,true,'On first edit founderemails-first-edit-notification-sent user property should be set');
+
+	}
+
+	public function testRegisterForNoEdits() {
+		$this->markTestIncomplete('To be implemented');
+		$this->assertEquals(true,true,'On entry with no edits (i.e. after editing only profile page) $isRegisteredUserFirstEdit should NOT be set');
+		$this->assertEquals(true,true,'On first edit founderemails-first-edit-notification-sent user property should NOT be set');
+	}
+
+}

--- a/extensions/wikia/UserProfilePageV3/Masthead.class.php
+++ b/extensions/wikia/UserProfilePageV3/Masthead.class.php
@@ -701,62 +701,6 @@ class Masthead {
 		}
 	}
 
-	static public function getUserStatsData( $userName, $useMasterDb = false ) {
-		global $wgLang, $wgCityId, $wgExternalDatawareDB;
-		wfProfileIn( __METHOD__ );
-
-		$result = array( 'editCount' => 0, 'firstDate' => 0 );
-
-		$destionationUser = User::newFromName($userName);
-		$destionationUserId = $destionationUser ? $destionationUser->getId() : 0;
-		if($destionationUserId != 0) {
-			global $wgMemc, $wgEnableAnswers;
-
-			if(!empty($wgEnableAnswers) && class_exists('AttributionCache')) {
-				// use AttributionCache to get edit points and first edit date
-				$attrCache = AttributionCache::getInstance();
-
-				$editCount = $attrCache->getUserEditPoints($destionationUserId);
-				$firstDate = $wgLang->date(wfTimestamp(TS_MW, $attrCache->getUserFirstEditDateFromCache($destionationUserId)));
-			}
-			else {
-				$mastheadDataEditDateKey = wfMemcKey('mmastheadData-editDate-' . $destionationUserId);
-				$mastheadDataEditCountKey = wfMemcKey('mmastheadData-editCount-' . $destionationUserId);
-				$mastheadDataEditDate = $wgMemc->get($mastheadDataEditDateKey);
-				$mastheadDataEditCount = $wgMemc->get($mastheadDataEditCountKey);
-
-				if(empty($mastheadDataEditCount) || empty($mastheadDataEditDate)) {
-					$dbr = wfGetDB( $useMasterDb ? DB_MASTER : DB_SLAVE );
-
-					/* @TODO FIXME: respect your DB resources, never count on MASTER */
-					$dbResult = $dbr->select(
-						'revision',
-						array('min(rev_timestamp) AS date, count(*) AS edits'),
-						array('rev_user_text' => $destionationUser->getName()),
-						__METHOD__
-					);
-
-					if ($row = $dbr->FetchObject($dbResult)) {
-						$firstDate = $wgLang->date(wfTimestamp(TS_MW, $row->date));
-						$editCount = $row->edits;
-					}
-					if ($dbResult !== false) {
-						$dbr->FreeResult($dbResult);
-					}
-					$wgMemc->set($mastheadDataEditDateKey, $firstDate, 60 * 60);
-					$wgMemc->set($mastheadDataEditCountKey, $editCount, 60 * 60);
-				} else {
-					$firstDate = $mastheadDataEditDate;
-					$editCount = $mastheadDataEditCount;
-				}
-			}
-			$result['editCount'] = $editCount;
-			$result['firstDate'] = $firstDate;
-		}
-		wfProfileOut( __METHOD__ );
-		return $result;
-	}
-
 	/**
 	 * @param $article
 	 * @param User $user


### PR DESCRIPTION
- changed the query to only ask for recent revisions
- stored the information that the email was sent to avoid repeating those queries
- added tests for supported cases
- removed unused method from Masthead
