### PR TITLE
Dar 1732 - wall notifications performance

### DIFF
--- a/extensions/wikia/Wall/notification/WallNotifications.class.php
+++ b/extensions/wikia/Wall/notification/WallNotifications.class.php
@@ -569,15 +569,16 @@ class WallNotifications {
 				$memcSync = $this->getCache($uId, $wikiId);
 
 				$this->lockAndSetData( $memcSync,
-				function() use( $memcSync, $uId, $wikiId, $uniqueId ) {
-					$data = $this->getData($memcSync, $uId, $wikiId);
-					$this->remNotificationFromData($data, $uniqueId);
-					return $data;
-				},
-				function() use( $memcSync ) {
-					// Delete the cache if we were unable to update to force a rebuild
-					$memcSync->delete();
-				});
+					function() use( $memcSync, $uId, $wikiId, $uniqueId ) {
+						$data = $this->getData($memcSync, $uId, $wikiId);
+						$this->remNotificationFromData($data, $uniqueId);
+						return $data;
+					},
+					function() use( $memcSync ) {
+						// Delete the cache if we were unable to update to force a rebuild
+						$memcSync->delete();
+					}
+				);
 
 			}
 

--- a/extensions/wikia/Wall/notification/WallNotifications.class.php
+++ b/extensions/wikia/Wall/notification/WallNotifications.class.php
@@ -593,7 +593,7 @@ class WallNotifications {
 				function() use( $memcSync, $uId, $wikiId, $uniqueId ) {
 					$data = $this->getData($memcSync, $uId, $wikiId);
 					$this->remNotificationFromData($data, $uniqueId);
-
+					return $data;
 				},
 				function() use( $memcSync ) {
 					// Delete the cache if we were unable to update to force a rebuild

--- a/extensions/wikia/Wall/notification/WallNotifications.class.php
+++ b/extensions/wikia/Wall/notification/WallNotifications.class.php
@@ -867,6 +867,11 @@ class WallNotifications {
 		return True;
 	}
 
+	/**
+	 * Used internally after acquiring cache entry lock
+	 * Tries to fetch the list of notifications from a memcache, and if it's not there,
+	 * it fetches it from the database
+	 */
 	protected function getData($cache, $userId, $wiki) {
 		$val = $cache->get();
 

--- a/extensions/wikia/Wall/notification/WallNotifications.class.php
+++ b/extensions/wikia/Wall/notification/WallNotifications.class.php
@@ -104,6 +104,7 @@ class WallNotifications {
 	}
 
 	public function getCounts($userId) {
+		wfProfileIn(__METHOD__);
 		$wikiList = $this->getWikiList($userId);
 
 		// prefetch data
@@ -125,7 +126,7 @@ class WallNotifications {
 			if( $wiki['unread'] > 0 || $wiki['id'] == $this->app->wg->CityId )
 				$output[] = $wiki;
 		}
-
+		wfProfileOut(__METHOD__);
 		return $output;
 	}
 

--- a/extensions/wikia/Wall/notification/WallNotifications.class.php
+++ b/extensions/wikia/Wall/notification/WallNotifications.class.php
@@ -159,7 +159,7 @@ class WallNotifications {
 		$key = $this->getKey($userId, 'LIST');
 		$val = $this->app->getGlobal('wgMemc')->get($key);
 
-		if(empty($val)) {
+		if( false === $val ) {
 			$val = $this->loadWikiListFromDB($userId);
 			$this->app->getGlobal('wgMemc')->set($key, $val);
 		}

--- a/extensions/wikia/Wall/notification/WallNotifications.class.php
+++ b/extensions/wikia/Wall/notification/WallNotifications.class.php
@@ -17,7 +17,7 @@ class WallNotifications {
 	private $removedEntities;
 	private $notUniqueUsers = array(); //used for sicen read email.
 	public function __construct() {
-		$this->app = F::App();
+		$this->app = F::app();
 		$this->removedEntities = array();
 	}
 

--- a/extensions/wikia/Wall/notification/WallNotifications.class.php
+++ b/extensions/wikia/Wall/notification/WallNotifications.class.php
@@ -172,11 +172,11 @@ class WallNotifications {
 		// $forceCurrentWiki = false - return only wikis that ever recived notifications
 
 		$key = $this->getKey($userId, 'LIST');
-		$val = $this->app->getGlobal('wgMemc')->get($key);
+		$val = $this->app->wg->memc->get($key);
 
 		if( false === $val ) {
 			$val = $this->loadWikiListFromDB($userId);
-			$this->app->getGlobal('wgMemc')->set($key, $val);
+			$this->app->wg->memc->set($key, $val);
 		}
 
 		// make sure that current Wiki is on the list, as first entry, sort the rest
@@ -227,7 +227,7 @@ class WallNotifications {
 
 	private function addWikiToList($userId, $wikiId, $wikiSitename) {
 		$key = $this->getKey($userId, 'LIST');
-		$val = $this->app->getGlobal('wgMemc')->get($key);
+		$val = $this->app->wg->memc->get($key);
 
 		if(empty($val)) {
 			$val = $this->loadWikiListFromDB($userId);
@@ -235,7 +235,7 @@ class WallNotifications {
 
 		$val[$wikiId] = $wikiSitename;
 
-		$this->app->getGlobal('wgMemc')->set($key, $val);
+		$this->app->wg->memc->set($key, $val);
 
 	}
 
@@ -247,7 +247,7 @@ class WallNotifications {
 		// that supports update-if-key-did-not-change
 
 		$key = $this->getKey($userId, 'LIST');
-		$val = $this->app->getGlobal('wgMemc')->get($key);
+		$val = $this->app->wg->memc->get($key);
 
 		if(empty($val)) {
 			// removing Wiki from list is just speed optimization
@@ -255,7 +255,7 @@ class WallNotifications {
 			// need to recreate it from DB
 		} else {
 			unset( $val[$wikiId] );
-			$this->app->getGlobal('wgMemc')->set($key, $val);
+			$this->app->wg->memc->set($key, $val);
 		}
 	}
 
@@ -795,7 +795,7 @@ class WallNotifications {
 
 	protected function isCachedData($userId, $wikiId) {
 		$key = $this->getKey($userId, $wikiId);
-		$val = F::App()->getGlobal('wgMemc')->get($key);
+		$val = $this->app->wg->memc->get($key);
 
 		if(empty($val) && !is_array($val)) {
 			return False;

--- a/extensions/wikia/Wall/notification/WallNotifications.setup.php
+++ b/extensions/wikia/Wall/notification/WallNotifications.setup.php
@@ -24,6 +24,5 @@ $wgAutoloadClasses['WallMessage'] =  $dir . '/WallMessage.class.php';
 
 //add script in monobook
 $wgHooks['SkinAfterBottomScripts'][] = 'WallNotificationsHooksHelper::onSkinAfterBottomScripts';
-$wgHooks['MakeGlobalVariablesScript'][] = 'WallNotificationsHooksHelper::onMakeGlobalVariablesScript';
 
 $wgHooks['PersonalUrls'][] = 'WallNotificationsHooksHelper::onPersonalUrls';

--- a/extensions/wikia/Wall/notification/WallNotificationsEveryone.class.php
+++ b/extensions/wikia/Wall/notification/WallNotificationsEveryone.class.php
@@ -4,7 +4,7 @@
 class WallNotificationsEveryone extends WallNotifications {
 	const queueTimeout = 30;
 	public function __construct() {
-		$this->app = F::App();
+		$this->app = F::app();
 		$this->cityId = $this->app->wg->CityId;
 	}
 
@@ -92,7 +92,7 @@ class WallNotificationsEveryone extends WallNotifications {
 		wfProfileIn(__METHOD__);
 		$cacheKey = $this->getGlobalCacheBusterKey();
 		$val = time();
-		$this->app->getGlobal('wgMemc')->set($cacheKey, $val);
+		$this->app->wg->memc->set($cacheKey, $val);
 		wfProfileOut(__METHOD__);
 		return $val;
 	}
@@ -100,7 +100,7 @@ class WallNotificationsEveryone extends WallNotifications {
 	public function getGlobalCacheBuster() {
 		wfProfileIn(__METHOD__);
 		$cacheKey = $this->getGlobalCacheBusterKey();
-		$val = $this->app->getGlobal('wgMemc')->get($cacheKey);
+		$val = $this->app->wg->memc->get($cacheKey);
 		if (empty($val)) {
 			wfProfileOut(__METHOD__);
 			return $this->setGlobalCacheBuster();
@@ -114,7 +114,7 @@ class WallNotificationsEveryone extends WallNotifications {
 		wfProfileIn(__METHOD__);
 
 		$cacheKey = $this->getEntityProcessedCacheKey($userId, $entityKey);
-		$this->app->getGlobal('wgMemc')->set($cacheKey, true);
+		$this->app->wg->memc->set($cacheKey, true);
 
 		$this->getDB(true)->insert('wall_notification_queue_processed', array(
 			'user_id' => $userId,
@@ -127,7 +127,7 @@ class WallNotificationsEveryone extends WallNotifications {
 	public function getEntityProcessed($userId, $entityKey) {
 		wfProfileIn(__METHOD__);
 		$cacheKey = $this->getEntityProcessedCacheKey($userId, $entityKey);
-		$val = $this->app->getGlobal('wgMemc')->get($cacheKey);
+		$val = $this->app->wg->memc->get($cacheKey);
 
 		if ($val == true) {
 			wfProfileOut(__METHOD__);
@@ -157,7 +157,7 @@ class WallNotificationsEveryone extends WallNotifications {
 		wfProfileIn(__METHOD__);
 
 		$cacheKey = $this->getQueueProcessedCacheKey($userId);
-		$this->app->getGlobal('wgMemc')->set($cacheKey, true);
+		$this->app->wg->memc->set($cacheKey, true);
 
 		wfProfileOut(__METHOD__);
 	}
@@ -166,7 +166,7 @@ class WallNotificationsEveryone extends WallNotifications {
 		wfProfileIn(__METHOD__);
 
 		$cacheKey = $this->getQueueProcessedCacheKey($userId);
-		$out = $this->app->getGlobal('wgMemc')->get($cacheKey);
+		$out = $this->app->wg->memc->get($cacheKey);
 
 		if ($out == true) {
 			wfProfileOut(__METHOD__);

--- a/extensions/wikia/Wall/notification/WallNotificationsExternalController.class.php
+++ b/extensions/wikia/Wall/notification/WallNotificationsExternalController.class.php
@@ -73,7 +73,7 @@ class WallNotificationsExternalController extends WikiaController {
 
 		$this->response->setVal('html', $this->app->renderView( 'WallNotifications', 'Update', array('notificationCounts' => $all, 'count' => $sum, 'notificationKey' => $notificationKey) ));
 		$this->response->setVal('count', $sum);
-		$this->response->setVal('reminder', wfMsgExt( 'wall-notifications-reminder', array('parsemag'), $sum ) );
+		$this->response->setVal('reminder', wfMessage('wall-notifications-reminder', $sum)->text() );
 		$this->response->setVal('status', true);
 
 		wfProfileOut(__METHOD__);

--- a/extensions/wikia/Wall/notification/WallNotificationsHooksHelper.class.php
+++ b/extensions/wikia/Wall/notification/WallNotificationsHooksHelper.class.php
@@ -19,21 +19,6 @@ class WallNotificationsHooksHelper {
 
 		return true;
 	}
-
-	/**
-	 * @brief pre render the notifications
-	 *
-	 **/
-
-	static public function onMakeGlobalVariablesScript( Array &$vars ){
-		$user =	F::app()->wg->User;
-		if( $user->isLoggedIn() ) {
-			$response = F::app()->sendRequest( 'WallNotificationsExternalController', 'getUpdateCounts', array() );
-			$vars['wgNotificationsCount'] = $response->getData();
-		}
-		return true;
-	}
-	
 	
 	/**
 	 * @brief Add notification dropdown to right corner for monobook


### PR DESCRIPTION
Major improvements:
- fetch the notifications in separate request, to reduce the main request server time
- fixed the bug with cache not being used in case the are no notifications
- when the memcache entry expired, it was not recreated - fixed

Additionally I've modified 4 methods to use a shared method for synchronizing memcache access
