### PR TITLE
DAR-2135 P2 fix after implementing lazy loaded RelatedPages

### DIFF
--- a/extensions/wikia/FilePage/FilePageController.class.php
+++ b/extensions/wikia/FilePage/FilePageController.class.php
@@ -184,7 +184,7 @@ class FilePageController extends WikiaController {
 		$relatedPages->setCategories($titleCats);
 
 		# Rendering the RelatedPages index with our alternate title and pre-seeded categories.
-		$this->text = F::app()->renderView( 'RelatedPages', 'Index', array( "altTitle" => $title, "anyNS" => true ) );
+		$this->text = F::app()->renderView( 'RelatedPages', 'section', [ "altTitle" => $title, "anyNS" => true ] );
 	}
 
 	/**

--- a/extensions/wikia/RelatedPages/RelatedPages.php
+++ b/extensions/wikia/RelatedPages/RelatedPages.php
@@ -27,6 +27,7 @@ $wgHooks['SkinAfterContent'][] = 'RelatedPages::onSkinAfterContent';
 
 // classes
 $wgAutoloadClasses['RelatedPages'] = $dir . 'RelatedPages.class.php';
+$wgAutoloadClasses['RelatedPagesController'] = $dir . 'RelatedPagesController.class.php';
 
 // messages
 $wgExtensionMessagesFiles['RelatedPages'] = $dir . 'RelatedPages.i18n.php';

--- a/extensions/wikia/RelatedPages/RelatedPagesController.class.php
+++ b/extensions/wikia/RelatedPages/RelatedPagesController.class.php
@@ -12,15 +12,10 @@ class RelatedPagesController extends WikiaController {
 		// request params
 		$altTitle = $this->request->getVal( 'altTitle', null );
 		$relatedPages = RelatedPages::getInstance();
-		$categories = $this->request->getVal( 'categories' );
 		$anyNs = $this->request->getVal( 'anyNS', false );
 
 		$title = empty( $altTitle ) ? $wgTitle : $altTitle;
 		$articleid = $title->getArticleId();
-
-		if ( !is_null( $categories ) ) {
-			$relatedPages->setCategories( $categories );
-		}
 
 		if( !$anyNs ) {
 			$ignoreNS = !empty( $wgTitle ) && in_array( $wgTitle->getNamespace(), $wgContentNamespaces );

--- a/extensions/wikia/RelatedPages/RelatedPagesController.class.php
+++ b/extensions/wikia/RelatedPages/RelatedPagesController.class.php
@@ -56,6 +56,13 @@ class RelatedPagesController extends WikiaController {
 		$this->response->setTemplateEngine( WikiaResponse::TEMPLATE_ENGINE_MUSTACHE );
 	}
 
+	/**
+	 * @desc Converts array results from RelatedPages::get() method to array for mustache template
+	 *
+	 * @param Array $relatedPages array with results of RelatedPages::get() method
+	 *
+	 * @return array of stdObjects for mustache
+	 */
 	private function prepareTemplateVars( $relatedPages ) {
 		wfProfileIn( __METHOD__ );
 

--- a/extensions/wikia/RelatedPages/RelatedPagesController.class.php
+++ b/extensions/wikia/RelatedPages/RelatedPagesController.class.php
@@ -1,0 +1,85 @@
+<?php
+class RelatedPagesController extends WikiaController {
+	const MEMC_KEY_VER = '1.003';
+
+	/**
+	 * @desc Related pages are lazy-loaded on article pages for mobile, oasis and monobook. However, there are extensions
+	 * dependent on this method where related pages module isn't lazy-loaded such as: FilePage (FilePageController.class.php)
+	 */
+	public function section() {
+		global $wgTitle, $wgContentNamespaces, $wgRequest, $wgMemc;
+
+		// request params
+		$altTitle = $this->request->getVal( 'altTitle', null );
+		$relatedPages = RelatedPages::getInstance();
+		$categories = $this->request->getVal( 'categories' );
+		$anyNs = $this->request->getVal( 'anyNS', false );
+
+		$title = empty( $altTitle ) ? $wgTitle : $altTitle;
+		$articleid = $title->getArticleId();
+
+		if ( !is_null( $categories ) ) {
+			$relatedPages->setCategories( $categories );
+		}
+
+		if( !$anyNs ) {
+			$ignoreNS = !empty( $wgTitle ) && in_array( $wgTitle->getNamespace(), $wgContentNamespaces );
+		} else {
+			$ignoreNS = false;
+		}
+
+		$this->skipRendering =
+			// check for mainpage
+			Wikia::isMainPage() ||
+			// check for content namespaces
+			$ignoreNS ||
+			// check if we have any categories
+			count( $relatedPages->getCategories( $articleid ) ) == 0 ||
+			// check action
+			$wgRequest->getVal('action', 'view') != 'view' ||
+			// skip, if module was already rendered
+			$relatedPages->isRendered();
+
+		if ( !$this->skipRendering ) {
+			$mKey = wfMemcKey( 'mOasisRelatedPages', $articleid, self::MEMC_KEY_VER );
+			$this->pages = $wgMemc->get( $mKey );
+			$this->srcAttrName = $this->app->checkSkin( 'monobook' ) ? 'src' : 'data-src';
+
+			if ( empty($this->pages) ) {
+				$this->pages = $this->prepareTemplateVars( $relatedPages->get( $articleid ) );
+
+				if ( count( $this->pages ) > 0) {
+					$wgMemc->set( $mKey, $this->pages, 3 * 3600 );
+				} else {
+					$this->skipRendering = true;
+				}
+			}
+		}
+
+		$this->mobileSkin = false;
+		$this->relatedPagesHeading = wfMessage( 'wikiarelatedpages-heading' )->plain();
+		$this->response->setTemplateEngine( WikiaResponse::TEMPLATE_ENGINE_MUSTACHE );
+	}
+
+	private function prepareTemplateVars( $relatedPages ) {
+		wfProfileIn( __METHOD__ );
+
+		$templateVars = [];
+		foreach( $relatedPages as $page ) {
+			$tplVar = new stdClass();
+			$tplVar->pageUrl = $page[ 'url' ];
+			$tplVar->pageTitle = $page[ 'title' ];
+			$tplVar->artSnippet = $page[ 'text' ];
+
+			if( !empty( $page[ 'imgUrl' ] ) ) {
+				$this->imgUrl = $page[ 'imgUrl' ];
+			}
+
+			$templateVars[] = $tplVar;
+		}
+
+		wfProfileOut( __METHOD__ );
+		return $templateVars;
+	}
+
+}


### PR DESCRIPTION
During implementation of lazy loaded RelatedPages module we missed that `FilePageController` calls one method directly.

To make it working again we:
- created new controller which is called in `FilePageController` (the new controller's `section()` method was a slightly changed copy of [previous `RelatedPages::executeIndex()` method](https://github.com/Wikia/app/blob/dc7db17c5dce4da0d934d8fccfc9c34127820fe5/extensions/wikia/RelatedPages/RelatedPagesController.class.php#L11)),
- changed `renderView()` params in `FilePageController` so it calls `section` method instead of `index` (so we re-used same for all skins mustache template).

Lazy loading this module on file page is more complex task due to the different `article id` than the `wgArticleId` on which related pages are pulled from database.

@hakubo @RafLeszczynski feel free to take a look, please :)
