### PR TITLE
Adding WikiaArticle classname for proper styling

### DIFF
--- a/extensions/VisualEditor/modules/ve-mw/ui/dialogs/ve.ui.MWMediaEditDialog.js
+++ b/extensions/VisualEditor/modules/ve-mw/ui/dialogs/ve.ui.MWMediaEditDialog.js
@@ -113,6 +113,7 @@ ve.ui.MWMediaEditDialog.prototype.onOpen = function () {
 	);
 
 	// Initialization
+	this.captionSurface.$.addClass( 'WikiaArticle' );
 	this.captionFieldset.$.append( this.captionSurface.$ );
 	this.captionSurface.initialize();
 };


### PR DESCRIPTION
This is a quick fix and will be removed once we have our own media dialogs.
