### PR TITLE
Dar 120 - wall empty bug fix

### DIFF
--- a/extensions/wikia/ArticleComments/ArticleComments_setup.php
+++ b/extensions/wikia/ArticleComments/ArticleComments_setup.php
@@ -93,6 +93,9 @@ if (!empty($wgEnableWallEngine) || !empty($wgEnableArticleCommentsExt) || !empty
 	$wgHooks['BeforePageDisplay'][] = 'ArticleCommentsController::onBeforePageDisplay';
 	$wgHooks['SkinAfterContent'][] = 'ArticleCommentsController::onSkinAfterContent';
 
+	// adding comment_index rows for articles
+	$wgHooks['ArticleDoEdit'][] = 'CommentsIndex::onArticleDoEdit';
+
 	// comments_index table
 	$wgHooks['LoadExtensionSchemaUpdates'][] = 'CommentsIndex::onLoadExtensionSchemaUpdates';
 

--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -738,16 +738,9 @@ class ArticleComment {
 		}
 
 		$bot = $user->isAllowed('bot');
-			//this function calls Article::onArticleCreate which clears cache for article and it's talk page - TODO: is this comment still valid? Does it refer to the line above or to something that got deleted?
-		$retval = $editPage->internalAttemptSave( $result, $bot );
 
-		if( $retval->value == EditPage::AS_SUCCESS_UPDATE ) {
-			$commentsIndex = CommentsIndex::newFromId( $article->getID() );
-			if ( $commentsIndex instanceof CommentsIndex ) {
-				$commentsIndex->updateLastRevId( $article->getTitle()->getLatestRevID(Title::GAID_FOR_UPDATE) );
-			}
-		}
-		return $retval;
+		return $editPage->internalAttemptSave( $result, $bot );
+
 	}
 
 	/**
@@ -843,46 +836,10 @@ class ArticleComment {
 		 */
 
 		$article  = new Article( $commentTitle, 0 );
+
+		CommentsIndex::addCommentInfo($commentTitleText, $title, $parentId);
+
 		$retval = self::doSaveAsArticle($text, $article, $user, $metadata);
-
-		// add comment to database
-		if ( $retval->value == EditPage::AS_SUCCESS_NEW_ARTICLE ) {
-			if ( !empty($parentId) ) {
-				Wikia::log( __METHOD__, false, "ArticleComment::doPost (reply to " . $parentId . ") - saved an article " .
-					$commentTitleText . ', commentId is ' . $article->getID(), true );
-			}
-			$revId = $article->getRevIdFetched();
-			$data = array(
-				'namespace' => $title->getNamespace(),
-				'parentPageId' => $title->getArticleID(),
-				'commentId' => $article->getID(),
-				'parentCommentId' => intval($parentId),
-				'firstRevId' => $revId,
-				'lastRevId' => $revId,
-			);
-
-			$commentsIndex = new CommentsIndex( $data );
-			$commentsIndex->addToDatabase();
-			if ( !empty($parentId) ) {
-				Wikia::log( __METHOD__, false, "ArticleComment::doPost (reply to " . $parentId . ") - added comments index to DB for " .
-					$commentTitleText . ', commentId is ' . $article->getID(), true );
-			}
-
-			// set last child comment id
-			$commentsIndex->updateParentLastCommentId( $data['commentId'] );
-
-			if ( !empty($parentId) ) {
-				Wikia::log( __METHOD__, false, "ArticleComment::doPost (reply to " . $parentId . ") - updated parent for " .
-					$commentTitleText . ', commentId is ' . $article->getID(), true );
-			}
-
-			wfRunHooks( 'EditCommentsIndex', array($article->getTitle(), $commentsIndex) );
-		} else {
-			if ( !empty($parentId) ) {
-				Wikia::log( __METHOD__, false, "ArticleComment::doPost (reply to " . $parentId .
-					") - failed to save reply article with title " . $commentTitleText, true );
-			}
-		}
 
 		$res = ArticleComment::doAfterPost( $retval, $article, $parentId );
 

--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -740,7 +740,6 @@ class ArticleComment {
 		$bot = $user->isAllowed('bot');
 
 		return $editPage->internalAttemptSave( $result, $bot );
-
 	}
 
 	/**
@@ -840,6 +839,11 @@ class ArticleComment {
 		CommentsIndex::addCommentInfo($commentTitleText, $title, $parentId);
 
 		$retval = self::doSaveAsArticle($text, $article, $user, $metadata);
+
+		if ( $retval->value == EditPage::AS_SUCCESS_NEW_ARTICLE ) {
+			$commentsIndex = CommentsIndex::newFromId( $article->getID() );
+			wfRunHooks( 'EditCommentsIndex', [ $article->getTitle(), $commentsIndex ] );
+		}
 
 		$res = ArticleComment::doAfterPost( $retval, $article, $parentId );
 

--- a/extensions/wikia/ArticleComments/classes/CommentsIndex.class.php
+++ b/extensions/wikia/ArticleComments/classes/CommentsIndex.class.php
@@ -184,7 +184,9 @@ class CommentsIndex extends WikiaModel {
 				array( 'comment_id' => $this->commentId ),
 				__METHOD__
 			);
-			if ( is_null($this->dbw ) ) {
+
+			// if $dbw was passed, this is a part of some outside transaction, so we don't commit anything yet
+			if ( is_null( $this->dbw ) ) {
 				$db->commit();
 			}
 		}
@@ -235,6 +237,7 @@ class CommentsIndex extends WikiaModel {
 			Wikia::log(__FUNCTION__, __LINE__, "WALL_COMMENTS_INDEX_ERROR Failed to create comments_index entry, parent_page_id={$this->parentPageId}, comment_id={$this->commentId}, parent_comment_id={$this->parentCommentId}", true);
 		}
 
+		// if $dbw was passed, this is a part of some outside transaction, so we don't commit anything yet
 		if ( is_null( $this->dbw ) ) {
 			$db->commit();
 		}

--- a/extensions/wikia/ArticleComments/classes/CommentsIndex.class.php
+++ b/extensions/wikia/ArticleComments/classes/CommentsIndex.class.php
@@ -527,8 +527,15 @@ class CommentsIndex extends WikiaModel {
 
 	}
 
+	/*
+	 * We need some data in order to create CommentIndex objects inside the MW transaction creating the article
+	 */
 	private static $commentInfoData = [];
 
+	/**
+	 * Store the information about new comment, so it can be used for creating CommentsIndex instances inside
+	 * MW transaction (ArticleDoEdit hook)
+	 */
 	static public function addCommentInfo($commentTitleText, $userPageTitle, $parentId) {
 		$entry = new stdClass();
 		$entry->userPageTitle = $userPageTitle;
@@ -537,6 +544,13 @@ class CommentsIndex extends WikiaModel {
 		self::$commentInfoData[ $commentTitleText ] = $entry;
 	}
 
+	/**
+	 * Hook into MW transaction that creates new article comments and execute queries that create comments_index entries
+	 * @param $dbw database connetion
+	 * @param Title $title newly created article
+	 * @param Revision $revision revision containig the lastest version of article comment
+	 * @param $flags Integer bitfield, the same as in WikiPage::doEdit method
+	 */
 	static public function onArticleDoEdit( $dbw,  Title $title, Revision $revision, $flags) {
 		global $wgEnableWallEngine;
 

--- a/extensions/wikia/ArticleComments/classes/CommentsIndex.class.php
+++ b/extensions/wikia/ArticleComments/classes/CommentsIndex.class.php
@@ -23,11 +23,11 @@ class CommentsIndex extends WikiaModel {
 	protected $lastTouched = 0;
 	protected $namespace = 0;
 	protected $data = array();
-
+	private $dbw = null;
 
 	public function __construct( $data = array(), $dbw = null ) {
 		$this->data = $data;
-		$this->$dbw = $dbw;
+		$this->dbw = $dbw;
 		foreach ( $data as $key => $value ) {
 			$this->$key = $value;
 		}

--- a/extensions/wikia/ArticleComments/classes/CommentsIndex.class.php
+++ b/extensions/wikia/ArticleComments/classes/CommentsIndex.class.php
@@ -551,7 +551,7 @@ class CommentsIndex extends WikiaModel {
 	 * @param Revision $revision revision containig the lastest version of article comment
 	 * @param $flags Integer bitfield, the same as in WikiPage::doEdit method
 	 */
-	static public function onArticleDoEdit( $dbw,  Title $title, Revision $revision, $flags) {
+	static public function onArticleDoEdit( $dbw, Title $title, Revision $revision, $flags) {
 		global $wgEnableWallEngine;
 
 		if ( !empty( $wgEnableWallEngine ) && WallHelper::isWallNamespace( $title->getNamespace() ) ) {

--- a/extensions/wikia/ArticleComments/tests/CommentsIndexTest.php
+++ b/extensions/wikia/ArticleComments/tests/CommentsIndexTest.php
@@ -1,0 +1,84 @@
+<?php
+
+class CommentsIndexTest extends WikiaBaseTest {
+
+	/*
+	 * Create a fake object emulating the comments_index row fetched from db
+	 */
+	private function getFakeCommentsIndexRow( $v ) {
+		$rowMock = new stdClass();
+		$rowMock->parent_page_id = $v;
+		$rowMock->comment_id = $v;
+		$rowMock->parent_comment_id = $v;
+		$rowMock->last_child_comment_id = $v;
+		$rowMock->archived = $v;
+		$rowMock->deleted = $v;
+		$rowMock->removed = $v;
+		$rowMock->locked = $v;
+		$rowMock->protected = $v;
+		$rowMock->sticky = $v;
+		$rowMock->first_rev_id = $v;
+		$rowMock->created_at = $v;
+		$rowMock->last_rev_id = $v;
+		$rowMock->last_touched = $v;
+		return $rowMock;
+	}
+
+	/*
+	 * Make sure the cache is not used when the CommentsIndex objects are just fetched from the database.
+	 */
+	public function testCommentsIndexCacheNotUsedForDB() {
+
+		$rowMock = $this->getFakeCommentsIndexRow(1);
+
+		$dbMock = $this->getMock('stdClass', [ 'selectRow' ] );
+		$dbMock->expects($this->exactly(2))
+			->method( 'selectRow' )
+			->will( $this->returnValue( $rowMock ) );
+
+		CommentsIndex::newFromId(1, 0, $dbMock);
+		CommentsIndex::newFromId(1, 0, $dbMock);
+	}
+
+	/*
+	 * The purpose of CommentsIndex cache is avoid database queries for CommentsIndex instances that were created
+	 * during the request. So here we simulate inserting the CommentsIndex to the table and then ask for that id and
+	 * make sure it's not fetched from the database
+	 */
+	public function testCommentsIndexCacheIsUsedForNewObjects() {
+
+		$rowMock = $this->getFakeCommentsIndexRow(2);
+
+		$dbMock = $this->getMock('stdClass', [ 'selectRow', 'replace', 'tableExists', 'timestamp' ] );
+
+		$dbMock->expects($this->exactly(0))
+			->method( 'selectRow' )
+			->will( $this->returnValue( $rowMock ) );
+
+		$dbMock->expects($this->any())
+			->method( 'replace' )
+			->will( $this->returnValue( true ) );
+
+		$dbMock->expects($this->any())
+			->method( 'timestamp' )
+			->will( $this->returnValue( '20130102030405' ) );
+
+		$dbMock->expects($this->any())
+			->method( 'tableExists' )
+			->will( $this->returnValue( true ) );
+
+		$ci = new CommentsIndex( [ 'commentId' => 2, 'parentPageId' => 3, 'parentCommentId' => 4 ], $dbMock );
+		$ci->addToDatabase();
+
+		//we pass the same $db connection so it's easier to compare objects
+		$ci2 = CommentsIndex::newFromId(2, 0, $dbMock);
+
+		// make sure the cached object has the same properties
+		$this->assertEquals($ci, $ci2);
+
+		//make sure we don't inherit the database connection form the original object
+		$ci2 = CommentsIndex::newFromId(3);
+		$this->assertNotEquals($ci, $ci2);
+	}
+
+}

--- a/extensions/wikia/Wall/WallExternalController.class.php
+++ b/extensions/wikia/Wall/WallExternalController.class.php
@@ -171,9 +171,27 @@ class WallExternalController extends WikiaController {
 		}
 	}
 
+	public function testWelcomeMessage() {
+		global $wgUser;
+		error_log("MECH ======================== testWelcomeMessage ======================================");
+		$sRecipientName = $this->request->getVal('username', "1.2.3.4");
+		$wgUser = User::newFromName("Wikia");
+		$mWallMessage = WallMessage::buildNewMessageAndPost(
+			"test message", $sRecipientName, $wgUser,
+			"message content", false, array(), false, false
+		);
+
+		if ( $mWallMessage ) {
+			$x = User::newFromName("Wikia");
+			$mWallMessage->setPostedAsBot( $x );
+			$mWallMessage->sendNotificationAboutLastRev();
+		}
+
+	}
+
 	public function postNewMessage() {
 		wfProfileIn(__METHOD__);
-
+		error_log("MECH ======================== postNewMessage ======================================");
 		$relatedTopics = $this->request->getVal('relatedTopics', array());
 
 		$this->response->setVal('status', true);
@@ -540,6 +558,8 @@ class WallExternalController extends WikiaController {
 
 	public function replyToMessage() {
 		$this->response->setVal('status', true);
+
+		error_log("MECH ======================== replyToMessage ======================================");
 
 		$parentId = $this->request->getVal('parent');
 		$parentTitle = Title::newFromId( $parentId );

--- a/extensions/wikia/Wall/WallExternalController.class.php
+++ b/extensions/wikia/Wall/WallExternalController.class.php
@@ -171,27 +171,8 @@ class WallExternalController extends WikiaController {
 		}
 	}
 
-	public function testWelcomeMessage() {
-		global $wgUser;
-		error_log("MECH ======================== testWelcomeMessage ======================================");
-		$sRecipientName = $this->request->getVal('username', "1.2.3.4");
-		$wgUser = User::newFromName("Wikia");
-		$mWallMessage = WallMessage::buildNewMessageAndPost(
-			"test message", $sRecipientName, $wgUser,
-			"message content", false, array(), false, false
-		);
-
-		if ( $mWallMessage ) {
-			$x = User::newFromName("Wikia");
-			$mWallMessage->setPostedAsBot( $x );
-			$mWallMessage->sendNotificationAboutLastRev();
-		}
-
-	}
-
 	public function postNewMessage() {
 		wfProfileIn(__METHOD__);
-		error_log("MECH ======================== postNewMessage ======================================");
 		$relatedTopics = $this->request->getVal('relatedTopics', array());
 
 		$this->response->setVal('status', true);

--- a/extensions/wikia/Wall/WallExternalController.class.php
+++ b/extensions/wikia/Wall/WallExternalController.class.php
@@ -540,8 +540,6 @@ class WallExternalController extends WikiaController {
 	public function replyToMessage() {
 		$this->response->setVal('status', true);
 
-		error_log("MECH ======================== replyToMessage ======================================");
-
 		$parentId = $this->request->getVal('parent');
 		$parentTitle = Title::newFromId( $parentId );
 		$debugParentDB = 'from slave';   // tracing bug 95249

--- a/includes/WikiPage.php
+++ b/includes/WikiPage.php
@@ -1349,9 +1349,9 @@ class WikiPage extends Page {
 				# creates a window where concurrent edits can cause an ignored edit conflict.
 				$ok = $this->updateRevisionOn( $dbw, $revision, $oldid, $oldIsRedirect );
 
-				// <Wikia>
+				// wikia changes begin
 				wfRunHooks( 'ArticleDoEdit', array( $dbw, $this->mTitle, $revision, $flags ) );
-				// </Wikia>
+				// wikia changes end
 
 				if ( !$ok ) {
 					/* Belated edit conflict! Run away!! */
@@ -1446,9 +1446,9 @@ class WikiPage extends Page {
 			# Update the page record with revision data
 			$this->updateRevisionOn( $dbw, $revision, 0 );
 
-			// <Wikia>
+			// wikia changes begin
 			wfRunHooks( 'ArticleDoEdit', array( &$dbw, $this->mTitle, $revision, $flags ) );
-			// </Wikia>
+			// wikia changes end
 
 			wfRunHooks( 'NewRevisionFromEditComplete', array( $this, $revision, false, $user ) );
 

--- a/includes/WikiPage.php
+++ b/includes/WikiPage.php
@@ -1349,6 +1349,10 @@ class WikiPage extends Page {
 				# creates a window where concurrent edits can cause an ignored edit conflict.
 				$ok = $this->updateRevisionOn( $dbw, $revision, $oldid, $oldIsRedirect );
 
+				// <Wikia>
+				wfRunHooks( 'ArticleDoEdit', array( $dbw, $this->mTitle, $revision, $flags ) );
+				// </Wikia>
+
 				if ( !$ok ) {
 					/* Belated edit conflict! Run away!! */
 					$status->fatal( 'edit-conflict' );
@@ -1441,6 +1445,10 @@ class WikiPage extends Page {
 
 			# Update the page record with revision data
 			$this->updateRevisionOn( $dbw, $revision, 0 );
+
+			// <Wikia>
+			wfRunHooks( 'ArticleDoEdit', array( &$dbw, $this->mTitle, $revision, $flags ) );
+			// </Wikia>
 
 			wfRunHooks( 'NewRevisionFromEditComplete', array( $this, $revision, false, $user ) );
 

--- a/includes/WikiPage.php
+++ b/includes/WikiPage.php
@@ -1447,7 +1447,7 @@ class WikiPage extends Page {
 			$this->updateRevisionOn( $dbw, $revision, 0 );
 
 			// wikia changes begin
-			wfRunHooks( 'ArticleDoEdit', array( &$dbw, $this->mTitle, $revision, $flags ) );
+			wfRunHooks( 'ArticleDoEdit', array( $dbw, $this->mTitle, $revision, $flags ) );
 			// wikia changes end
 
 			wfRunHooks( 'NewRevisionFromEditComplete', array( $this, $revision, false, $user ) );


### PR DESCRIPTION
Currently the data for Wall/Forum is inconsistent, as the entries in comments_index table are created in a separate db transaction, and when this second transaction fails, we end up having posts attached to 'Empty'. In this pull requests I've added a hook triggered when an article is saved. In case it's a Wall or Forum post, the comments_index row is added within the transaction that is used to create the post.
