### PR TITLE
DAR-2047: Removing mysql statements from cleanupStarter

### DIFF
--- a/maintenance/cleanupStarter.sql
+++ b/maintenance/cleanupStarter.sql
@@ -1,9 +1,2 @@
-delete from page where page_id in (select cl_from from categorylinks where cl_to='Draft');
-delete from text where old_id in (select rev_text_id from revision, categorylinks where revision.rev_page=categorylinks.cl_from and cl_to='Draft');
-delete from revision where rev_page in (select cl_from from categorylinks where cl_to='Draft');
-
-delete from categorylinks where cl_to='Draft';
-delete from pagelinks where pl_namespace=14 and pl_title='Draft';
-
 delete from revision where rev_id not in (select page_latest from page);
 delete from text where old_id not in (select rev_text_id from revision);


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/DAR-2047

'Draft' category was removed in 2007 (http://starter.wikia.com/wiki/Special:Undelete?target=Category%3ADraft).
The idea of this category was to mark pages which shouldn't be copied to new wiki (http://starter.wikia.com/wiki/Special:Undelete?target=Category%3ADraft&timestamp=20061028171027&diff=prev&cb=7623) but it isn't used anymore.
