### PR TITLE
MAIN-939: fix chopped off dropdowns on wall/forum pages.

### DIFF
--- a/skins/oasis/css/core/article.scss
+++ b/skins/oasis/css/core/article.scss
@@ -8,7 +8,7 @@
 .WikiaArticle {
 	@include bodytext;
 	// Prevent content from escaping the article area
-	overflow-x: hidden;
+	overflow: hidden;
 	padding: 0 $width-gutter;
 	position: relative;
 	min-height: 250px;
@@ -413,6 +413,17 @@
 	}
 }
 
+// Exceptions to the rule (MAIN-939)
+// Wall and Forum have dropdowns that escape the article area. This prevents
+// them from getting chopped off with the downside that large tables won't be
+// controlled properly until the JavaScript loads.
+.ns-1200,
+.ns-1201,
+.ns-2000 {
+	.WikiaArticle {
+		overflow: visible;
+	}
+}
 
 /**
  * FB#24380 - Make wikia-infobox styling work in RTE popup previews (out of .WikiaArticle)


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/MAIN-939

This is a good quick fix for the problem mentioned in the ticket, however, it's not very elegant and has caveats (see code comments). I'm hesitant to remove the overflow on the article area because, IMO, content within it should be controlled properly (aside from handling wide tables, it also controls huge images and long unbreaking lines of text properly).

There may be some other solutions to this in the long term if we find other cases of elements getting chopped off which should be explored if this becomes a bigger issue.
