### PR TITLE
respect $order when formatting results in ImageServingDriverBase

### DIFF
--- a/extensions/wikia/ImageServing/drivers/ImageServingDriverBase.class.php
+++ b/extensions/wikia/ImageServing/drivers/ImageServingDriverBase.class.php
@@ -141,21 +141,29 @@ abstract class ImageServingDriverBase {
 		wfProfileIn( __METHOD__ );
 
 		$out = array();
-		foreach( $imageList as $key => $value  ) {
-			if( isset($dbOut[ $key ]) ) {
-				foreach($value as $key2 => $value2) {
-					if (empty($out[$key2]) || count($out[$key2]) < $limit) {
-						$img = $this->getImageFile( $key );
-						$out[$key2][] = array(
-							"name" => $key,
-							"original_dimensions" => array(
-								"width"	=> !empty( $img ) ? $img->getWidth() : 0,
-								"height"=> !empty( $img ) ? $img->getHeight() : 0
-							),
-							"url" => !empty( $img ) ? $this->imageServing->getUrl($img, $dbOut[$key]['img_width'], $dbOut[$key]['img_height']) : ''
-						);
-					}
+		$pageOrderedImages = [ ];
+		foreach ( $imageList as $imageName => $pageData ) {
+			if ( isset( $dbOut[ $imageName ] ) ) {
+				foreach ( $pageData as $pageId => $pageImageOrder ) {
+					// insert into an array so we can ensure the $order is respected
+					$pageOrderedImages[ $pageId ][ $pageImageOrder ] = $imageName;
 				}
+			}
+		}
+
+		foreach ( $pageOrderedImages as $pageId => $pageImageList ) {
+			ksort( $pageImageList );
+			$useImages = array_slice( $pageImageList, 0, $limit );
+			foreach ( $useImages as $imageName ) {
+				$img = $this->getImageFile( $imageName );
+				$out[ $pageId ][ ] = [
+					"name" => $imageName,
+					"original_dimensions" => [
+						"width" => !empty( $img ) ? $img->getWidth() : 0,
+						"height" => !empty( $img ) ? $img->getHeight() : 0
+					],
+					"url" => !empty( $img ) ? $this->imageServing->getUrl( $img, $dbOut[ $imageName ][ 'img_width' ], $dbOut[ $imageName ][ 'img_height' ] ) : ''
+				];
 			}
 		}
 

--- a/extensions/wikia/ImageServing/drivers/ImageServingDriverBase.class.php
+++ b/extensions/wikia/ImageServing/drivers/ImageServingDriverBase.class.php
@@ -140,7 +140,7 @@ abstract class ImageServingDriverBase {
 	protected function formatResult($imageList ,$dbOut, $limit) {
 		wfProfileIn( __METHOD__ );
 
-		$out = array();
+		$out = [ ];
 		$pageOrderedImages = [ ];
 		foreach ( $imageList as $imageName => $pageData ) {
 			if ( isset( $dbOut[ $imageName ] ) ) {


### PR DESCRIPTION
@Wikia/platform-team 
https://wikia-inc.atlassian.net/browse/BAC-734

Issue here is that we were fetching/storing the order for images on a page (so main image is always first), but we were ignoring that order when we were building the final list. This has the potential to lead to non-main images on top lists (see https://wikia-inc.atlassian.net/browse/BAC-734) when images appeared in more than one article.

This change changes the default behavior for all ImageServingDriverBase classes (ImageServingDriverMainNS, ImageServingDriverUserNS, ImageServingDriverFileNS, ImageServingDriverCategoryNS) but seems safe from a functionality standpoint (though I'd like someone more familiar with this to verify). It has a small perf impact sine we're now paying the price for a ksort and looping over images again, but since this data is cached it's probably ok.
