### PR TITLE
DAR-2295 Bring back clicktracking for related pages modules (P2 fix)

### DIFF
--- a/extensions/wikia/CategorySelect/css/CategorySelect.scss
+++ b/extensions/wikia/CategorySelect/css/CategorySelect.scss
@@ -6,7 +6,7 @@
 .CategorySelect.articlePage {
 	@include clear-linear-gradient();
 	line-height: normal;
-	margin: 10px 0 40px 0;
+	margin: 10px 0 10px 0;
 	padding: 0;
 	position: relative;
 

--- a/extensions/wikia/RelatedPages/js/RelatedPages.js
+++ b/extensions/wikia/RelatedPages/js/RelatedPages.js
@@ -12,7 +12,7 @@ require( [ 'sloth', 'wikia.window', 'jquery' ], function( sloth, w, $ ){
 			$placeholder = $( '#WikiaArticleFooter' );
 			break;
 		case 'monobook':
-			$placeholder = $( '#mw-data-after-content' )
+			$placeholder = $( '#mw-data-after-content' );
 			break;
 	}
 

--- a/extensions/wikia/RelatedPages/js/RelatedPages.js
+++ b/extensions/wikia/RelatedPages/js/RelatedPages.js
@@ -57,7 +57,7 @@ require( [ 'sloth', 'wikia.window', 'jquery' ], function( sloth, w, $ ){
 			on: element,
 			threshold: 200,
 			callback: function() {
-				require(['wikia.mustache', 'JSMessages', 'wikia.nirvana'], function(mustache, msg, nirvana){
+				require([ 'wikia.mustache', 'JSMessages', 'wikia.nirvana', 'wikia.tracker' ], function( mustache, msg, nirvana, tracker ) {
 					$.when(
 						nirvana.getJson(
 							'RelatedPagesApi',
@@ -92,6 +92,19 @@ require( [ 'sloth', 'wikia.window', 'jquery' ], function( sloth, w, $ ){
 							};
 
 							$placeholder.prepend( mustache.render( template, mustacheData ) );
+							$placeholder.on( 'mousedown', '.RelatedPagesModule a', function( event ) {
+								// Primary mouse button only
+								if( event.type === 'mousedown' && event.which !== 1 ) {
+									return;
+								}
+
+								tracker.track({
+									action: Wikia.Tracker.ACTIONS.CLICK,
+									trackingMethod: 'ga',
+									category: 'article',
+									label: 'related-pages'
+								});
+							})
 						}
 					});
 				});

--- a/skins/oasis/js/Tracking.js
+++ b/skins/oasis/js/Tracking.js
@@ -124,10 +124,7 @@ jQuery(function($){
 					label: label
 				});
 			}
-		}).on('mousedown', '.RelatedPagesModule a', {
-			category: category,
-			label: 'related-pages'
-		}, trackWithEventData).on('mousedown', '.editsection a', {
+		}).on('mousedown', '.editsection a', {
 			category: category,
 			label: 'section-edit'
 		}, trackWithEventData);


### PR DESCRIPTION
We implemented lazy loading of related pages but didn't think of clicktracking of it. In these changes we brought it back and did small changes to styling.

More information: [DAR-2295](https://wikia-inc.atlassian.net/browse/DAR-2295)
