### PR TITLE
VID-890

### DIFF
--- a/extensions/wikia/Search/WikiaSearchController.class.php
+++ b/extensions/wikia/Search/WikiaSearchController.class.php
@@ -11,6 +11,8 @@
  */
 class WikiaSearchController extends WikiaSpecialPageController {
 
+	use Wikia\Search\Traits\NamespaceConfigurable;
+
 	/**
 	 * Default results per page for intra wiki search
 	 * @var int
@@ -575,38 +577,6 @@ class WikiaSearchController extends WikiaSpecialPageController {
 													array($this->wg->Sitename) )  );
 			}
 		}
-	}
-
-	/**
-	 * Called in index action. Sets the SearchConfigs namespaces based on MW-core NS request style.
-	 * @see    WikiSearchControllerTest::testSetNamespacesFromRequest
-	 * @param  Wikia\Search\Config $searchConfig
-	 * @param  User $user
-	 * @return boolean true
-	 */
-	protected function setNamespacesFromRequest( $searchConfig, User $user ) {
-		$searchEngine = (new SearchEngine);
-		$searchableNamespaces = $searchEngine->searchableNamespaces();
-		$namespaces = array();
-		foreach( $searchableNamespaces as $i => $name ) {
-		    if ( $this->getVal( 'ns'.$i, false ) ) {
-		        $namespaces[] = $i;
-		    }
-		}
-		if ( empty($namespaces) ) {
-		    if ( $user->getOption( 'searchAllNamespaces' ) ) {
-			    $namespaces = array_keys($searchableNamespaces);
-		    } else {
-		    	$profiles = $searchConfig->getSearchProfiles();
-		    	// this is mostly needed for unit testing
-		    	$defaultProfile = !empty( $this->wg->DefaultSearchProfile ) ? $this->wg->DefaultSearchProfile : 'default';
-		    	$namespaces = $profiles[$defaultProfile]['namespaces'];
-		    }
-
-		}
-		$searchConfig->setNamespaces( $namespaces );
-
-		return true;
 	}
 
 	/**

--- a/extensions/wikia/Search/classes/Traits/NamespaceConfigurable.php
+++ b/extensions/wikia/Search/classes/Traits/NamespaceConfigurable.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Wikia\Search\Traits;
+use SearchEngine, User;
+
+trait NamespaceConfigurable
+{
+	/**
+	 * Called in WikiaSearchController and Oasis SearchController index action. 
+	 * Sets the SearchConfigs namespaces based on MW-core NS request style.
+	 * @see    WikiSearchControllerTest::testSetNamespacesFromRequest
+	 * @param  Wikia\Search\Config $searchConfig
+	 * @param  User $user
+	 * @return boolean true
+	 */
+	protected function setNamespacesFromRequest( $searchConfig, User $user ) {
+		$searchEngine = (new SearchEngine);
+		$searchableNamespaces = $searchEngine->searchableNamespaces();
+		$namespaces = array();
+		foreach( $searchableNamespaces as $i => $name ) {
+		    if ( $this->getVal( 'ns'.$i, false ) ) {
+		        $namespaces[] = $i;
+		    }
+		}
+		if ( empty($namespaces) ) {
+		    if ( $user->getOption( 'searchAllNamespaces' ) ) {
+			    $namespaces = array_keys($searchableNamespaces);
+		    } else {
+		    	$profiles = $searchConfig->getSearchProfiles();
+		    	// this is mostly needed for unit testing
+		    	$defaultProfile = !empty( $this->wg->DefaultSearchProfile ) ? $this->wg->DefaultSearchProfile : 'default';
+		    	$namespaces = $profiles[$defaultProfile]['namespaces'];
+		    }
+
+		}
+		$searchConfig->setNamespaces( $namespaces );
+
+		return true;
+	}
+
+}

--- a/skins/oasis/modules/SearchController.class.php
+++ b/skins/oasis/modules/SearchController.class.php
@@ -21,7 +21,7 @@ class SearchController extends WikiaController {
 		}
 
 		$searchParams = [];
-		if (! $this->wg->request->getVal('nonamespaces', $this->request->getVal( 'nonamespaces' ), false ) ) { // why both?
+		if (! $this->request->getVal( 'nonamespaces', false ) ) {
 			$searchConfig = new Wikia\Search\Config();
 			$this->setNamespacesFromRequest($searchConfig, $this->wg->User);
 			foreach ( $searchConfig->getNamespaces() as $namespaceInt ) {

--- a/skins/oasis/modules/SearchController.class.php
+++ b/skins/oasis/modules/SearchController.class.php
@@ -6,6 +6,9 @@
  */
 
 class SearchController extends WikiaController {
+
+	use Wikia\Search\Traits\NamespaceConfigurable;
+
 	public function executeIndex() {
 		$this->setVal('specialSearchUrl', SpecialPage::getTitleFor( 'Search' )->getFullUrl());
 		$this->searchterm = $this->wg->request->getVal('search');
@@ -17,10 +20,18 @@ class SearchController extends WikiaController {
 			$this->noautocomplete = $this->request->getVal( 'noautocomplete' );
 		}
 
-		$this->nonamespaces = $this->wg->request->getVal('nonamespaces');
-		if ( !isset( $this->nonamespaces ) ) {
-			$this->nonamespaces = $this->request->getVal( 'nonamespaces' );
+		$searchParams = [];
+		if (! $this->wg->request->getVal('nonamespaces', $this->request->getVal( 'nonamespaces' ), false ) ) { // why both?
+			$searchConfig = new Wikia\Search\Config();
+			$this->setNamespacesFromRequest($searchConfig, $this->wg->User);
+			foreach ( $searchConfig->getNamespaces() as $namespaceInt ) {
+				$searchParams['ns'.$namespaceInt] = 1;
+			}
 		}
+		if ( $this->wg->CityId == Wikia\Search\QueryService\Select\Dismax\Video::VIDEO_WIKI_ID ) {
+			$searchParams['filters[]'] = 'is_video';
+		}
+		$this->searchParams = $searchParams;
 
 		$this->fulltext = $this->wg->User->getOption('enableGoSearch') ? 0 : 'Search';
 		$this->placeholder = wfMsg('Tooltip-search', $this->wg->Sitename);

--- a/skins/oasis/modules/SearchController.class.php
+++ b/skins/oasis/modules/SearchController.class.php
@@ -29,7 +29,8 @@ class SearchController extends WikiaController {
 			}
 		}
 		if ( $this->wg->CityId == Wikia\Search\QueryService\Select\Dismax\Video::VIDEO_WIKI_ID ) {
-			$searchParams['filters[]'] = 'is_video';
+			$searchParams['filters[]'] = 'is_video'; // this is required to hide images
+			$searchParams['rank'] = 'default'; // this is required to keep urls consistent between search and non-search pages
 		}
 		$this->searchParams = $searchParams;
 

--- a/skins/oasis/modules/templates/Search_Index.php
+++ b/skins/oasis/modules/templates/Search_Index.php
@@ -4,10 +4,9 @@
 <form id="<?= $searchFormId; ?>" class="WikiaSearch<?= empty($noautocomplete) ? '' : ' noautocomplete' ?>" action="<?= $specialSearchUrl; ?>" method="get">
 	<input type="text" name="search" placeholder="<?= $placeholder ?>" autocomplete="off" accesskey="f" value="<?= htmlspecialchars( $searchterm ) ?>">
 	<input type="hidden" name="fulltext" value="<?= $fulltext ?>">
-	<?php if( !$nonamespaces ) : ?>
-		<input type="hidden" name="<?= "ns".NS_MAIN; ?>" value="1">
-		<input type="hidden" name="<?= "ns".NS_CATEGORY; ?>" value="1">
-	<?php endif; ?>
+	<?php foreach( $searchParams as $name => $value ) : ?>
+		<input type="hidden" name="<?= $name ?>" value="<?= $value ?>">
+	<?php endforeach; ?>
 	<input type="submit">
 	<button class="wikia-button"><img src="<?= $wg->BlankImgUrl ?>" class="sprite search" height="17" width="21"></button>
 </form>


### PR DESCRIPTION
**TL;DR**
- Namespaces were hard-coded, even though the default content namespaces of a wiki are configurable
- This was breaking video search
- The video filter was also missing from video search, so this is also being fixed here
## Summary

This addresses the limitations on header search form namespace hidden field configuration per #1462 (PLA-670) by utilizing logic already available in the WikiaSearch extension. 

The required logic for populating the appropriate namespaces for a given wiki has been ported to a trait, Wikia\Search\Traits\NamespaceConfigurable. This allows the controller responsible for handling search pages as well as the controller responsible for populating the global search form to use the same logic for namespace filtering on either search form. 

Additionally, default video search requires a default behavior of filtering for videos. This seems to have been lost somewhere along the line. The updates included here allow us to provide this filter when on the Video wiki. So this also fixes a somewhat related existing regression.

This fix doesn't just repair the problems with the video wiki, but any wiki that has different default content namespaces.
