### PR TITLE
Vid 898 hide fatured slider mobile

### DIFF
--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -1051,6 +1051,14 @@ $config['videohomepage_scss'] = array(
 	)
 );
 
+$config['videohomepage_scss_mobile'] = array(
+	'skin' => array( 'wikiamobile' ),
+	'type' => AssetsManager::TYPE_SCSS,
+	'assets' => array(
+		'//extensions/wikia/VideoPageTool/css/HomePage/mobile.scss',
+	)
+);
+
 /** UserLogin **/
 $config['userlogin_scss_wikiamobile'] = array(
 	'type' => AssetsManager::TYPE_SCSS,

--- a/extensions/wikia/VideoPageTool/VideoPageTool.setup.php
+++ b/extensions/wikia/VideoPageTool/VideoPageTool.setup.php
@@ -37,6 +37,7 @@ $wgSpecialPages['VideoPageAdmin'] = 'VideoPageAdminSpecialController';
 
 // hooks
 $wgHooks['ArticleFromTitle'][] = 'VideoPageToolHooks::onArticleFromTitle';
+$wgHooks['WikiaMobileAssetsPackages'][] = 'VideoPageToolHooks::onWikiaMobileAssetsPackages';
 
 // permissions
 $wgGroupPermissions['*']['videopagetool'] = false;

--- a/extensions/wikia/VideoPageTool/VideoPageToolHooks.class.php
+++ b/extensions/wikia/VideoPageTool/VideoPageToolHooks.class.php
@@ -19,4 +19,19 @@ class VideoPageToolHooks {
 		wfProfileOut(__METHOD__);
 		return true;
 	}
+	/**
+	 * Add assets to mobile video home page
+	 *
+	 * @param array $jsStaticPackages
+	 * @param array $jsExtensionPackages
+	 * @param array $scssPackages
+	 * @return bool
+	 */
+	static public function onWikiaMobileAssetsPackages( Array &$jsStaticPackages, Array &$jsExtensionPackages, Array &$scssPackages ){
+		if( F::app()->wg->Title->isMainPage() ) {
+			$scssPackages[] = 'videohomepage_scss_mobile';
+		}
+
+		return true;
+	}
 }

--- a/extensions/wikia/VideoPageTool/css/HomePage/mobile.scss
+++ b/extensions/wikia/VideoPageTool/css/HomePage/mobile.scss
@@ -1,0 +1,11 @@
+// hide featured video slider for now
+.featured-video {
+	display: none;
+}
+
+// hide oasis search form
+.main-header {
+	.search-container, .discover {
+		display: none;
+	}
+}

--- a/extensions/wikia/VideoPageTool/css/HomePage/mobile.scss
+++ b/extensions/wikia/VideoPageTool/css/HomePage/mobile.scss
@@ -3,7 +3,7 @@
 	display: none;
 }
 
-// hide oasis search form
+// hide oasis search form and discover dropdown
 .main-header {
 	.search-container, .discover {
 		display: none;


### PR DESCRIPTION
Temporary solution to the video home page on mobile.  Hiding main features for now and just showing wikitext and partner links. 
