### PR TITLE
VOLDEV-17 replacing hardcoded link with message key

### DIFF
--- a/extensions/wikia/ThemeDesigner/ThemeDesigner.i18n.php
+++ b/extensions/wikia/ThemeDesigner/ThemeDesigner.i18n.php
@@ -60,6 +60,7 @@ $messages['en'] = array(
 	'themedesigner-wodmark-preview' => 'Preview',
 	'themedesigner-wordmark-preview-error' => 'Oops! The name of the wiki can\'t be blank,
 please enter the name of the wiki to save.',
+	'themedesigner-favicon-help-link' => 'http://community.wikia.com/wiki/Help:Favicon',
 );
 
 /** Message documentation (Message documentation)
@@ -97,6 +98,7 @@ $messages['qqq'] = array(
 * $2 is the author name',
 	'themedesigner-wodmark-preview' => '{{Identical|Preview}}',
 	'themedesigner-wordmark-preview-error' => 'Validation error on attempt to save empty text wordmark',
+	'themedesigner-favicon-help-link' => 'Link to a help page about favicons',
 );
 
 /** Afrikaans (Afrikaans)
@@ -1522,6 +1524,7 @@ $messages['pl'] = array(
 	'themedesigner-favicon-heading' => 'Favicon',
 	'themedesigner-wodmark-preview' => 'Podgląd',
 	'themedesigner-wordmark-preview-error' => 'Błąd - nazwa wiki nie może być usta, wprowadź nazwę wiki aby zapisać.',
+	'themedesigner-favicon-help-link' => 'http://spolecznosc.wikia.com/wiki/Pomoc:Favikona',
 );
 
 /** Piedmontese (Piemontèis)

--- a/extensions/wikia/ThemeDesigner/templates/ThemeDesigner_WordmarkTab.php
+++ b/extensions/wikia/ThemeDesigner/templates/ThemeDesigner_WordmarkTab.php
@@ -63,7 +63,7 @@
 		<h1><?= wfMsg('themedesigner-favicon-heading') ?></h1>
 		<h2>
 			<?= wfMsg('themedesigner-upload-a-graphic') ?>
-			<span class="form-questionmark" rel="tooltip" title="<?= wfMsg('themedesigner-rules-favicon') ?> &lt;a href='http://community.wikia.com/wiki/Help:Favicon' &gt; <?= wfMsg('themedesigner-rules-favicon-learn-more-link') ?>&lt;/a&gt;"></span>
+			<span class="form-questionmark" rel="tooltip" title="<?= wfMsg('themedesigner-rules-favicon') ?> &lt;a href='<?= wfMessage('themedesigner-favicon-help-link')->text(); ?>' &gt; <?= wfMsg('themedesigner-rules-favicon-learn-more-link') ?>&lt;/a&gt;"></span>
 		</h2>
 		<form id="FaviconUploadForm" action="<?= $wg->ScriptPath ?>/wikia.php?controller=ThemeDesigner&method=FaviconUpload&format=html" method="POST" enctype="multipart/form-data">
 			<input id="FaviconUploadFile" name="wpUploadFile" type="file" />


### PR DESCRIPTION
@Grunny  @mroszka

A fix for https://wikia-inc.atlassian.net/browse/VOLDEV-17 - a hardcoded link has been replaced by message key to allow localization
