### PR TITLE
DAR-2325 P2 fix for flood in JS console

### DIFF
--- a/resources/wikia/modules/loader.js
+++ b/resources/wikia/modules/loader.js
@@ -97,47 +97,9 @@ define('wikia.loader', ['wikia.window', require.optional('mw'), 'wikia.nirvana',
 					};
 				}
 				// If onload is available, use it
-				// don't use it when loading CSS in WebKit
-				else if(element.onload === null && (element.all /* exclude WebKit */ || type !== loader.CSS)) {
+				else if( element.onload === null ) {
 					element.onload = success;
 					element.onerror = function(){failure(this.src || this.href)};
-				}
-				// use polling when loading CSS in Webkit :(
-				else if (type === loader.CSS) {
-					timer = window.setInterval((function (url) {
-						return function() {
-							var stylesheet,
-								stylesheets = doc.styleSheets,
-								i = stylesheets.length;
-							while (i--) {
-								stylesheet = stylesheets[i];
-								if (url === stylesheet.href) {
-									try {
-										// We store so that minifiers don't remove the code
-										var cssRules = stylesheet.cssRules;
-										// Webkit:
-										// Webkit browsers don't create the stylesheet object
-										// before the link has been loaded.
-										// When requesting rules for crossDomain links
-										// they simply return nothing (no exception thrown)
-										// Gecko:
-										// NS_ERROR_DOM_INVALID_ACCESS_ERR thrown if the stylesheet is not loaded
-										// If the stylesheet is loaded:
-										//  * no error thrown for same-domain
-										//  * NS_ERROR_DOM_SECURITY_ERR thrown for cross-domain
-										throw 'SECURITY';
-									} catch(err) {
-										// Gecko: catch NS_ERROR_DOM_SECURITY_ERR
-										// Webkit: catch SECURITY
-										if (/SECURITY/.test(err) || /SECURITY/i.test(err.name)) {
-											timer = window.clearInterval(timer);
-											success();
-										}
-									}
-								}
-							}
-						};
-					})(url), 50);
 				}
 
 				log('[' + type + '] ' + url, log.levels.info, 'loader');


### PR DESCRIPTION
I removed nasty code causing the flood and @justnpT QA'ed loading styles with lazy loaded right rail in Chrome and Safari ([DAR-2325](https://wikia-inc.atlassian.net/browse/DAR-2325)). I smoke tested it on Chrome and Firefox in Ubuntu.

I talked to @macbre and he doesn't have anything against removing this code if it doesn't break functionality in supported browsers. The nasty piece of code is 3 years old.

@macbre @hakubo @kflorence take once again a look on it, please. If we find something dangerous we can always revert my change and modify the `while` loop, I think.
