### PR TITLE
DAR-452 | Verify correct appearance and functionality of /extensions/wikia/LookupUser within fluid layout

### DIFF
--- a/extensions/wikia/LookupContribs/templates/main-form.tmpl.php
+++ b/extensions/wikia/LookupContribs/templates/main-form.tmpl.php
@@ -23,6 +23,7 @@ $(document).ready(function() {
 	}
 
 	var oTable = $('#lc-table').dataTable( {
+		bAutoWidth: false,
 		"oLanguage": {
 			"sLengthMenu": "<?=wfMsg('table_pager_limit', '_MENU_');?>",
 			"sZeroRecords": "<?=wfMsg('table_pager_empty');?>",

--- a/extensions/wikia/LookupContribs/templates/mode-form.tmpl.php
+++ b/extensions/wikia/LookupContribs/templates/mode-form.tmpl.php
@@ -14,6 +14,7 @@ $(document).ready(function() {
 	}
 
 	var oTable = $('#lc-table').dataTable( {
+		bAutoWidth: false,
 		"oLanguage": {
 			"sLengthMenu": "<?=wfMsg('table_pager_limit', '_MENU_');?>",
 			"sZeroRecords": "<?=wfMsg('table_pager_empty');?>",

--- a/extensions/wikia/LookupUser/templates/contribution.table.tmpl.php
+++ b/extensions/wikia/LookupUser/templates/contribution.table.tmpl.php
@@ -10,6 +10,7 @@ $(document).ready(function() {
 	var ajaxRequests = [];
 
 	var oTable = $('#lookupuser-table').dataTable( {
+		bAutoWidth: false,
 		oLanguage: {
 			sLengthMenu: "<?=wfMsg('table_pager_limit', '_MENU_');?>",
 			sZeroRecords: "<?=wfMsg('table_pager_empty');?>",

--- a/extensions/wikia/WikiFactory/Metrics/templates/metrics-daily-form.tmpl.php
+++ b/extensions/wikia/WikiFactory/Metrics/templates/metrics-daily-form.tmpl.php
@@ -22,6 +22,7 @@ $(document).ready(function() {
 	var baseurl = wgScript + "?action=ajax&rs=axAWCMetricsCategory";
 	var cnt = 0;
 	var oTable = $('#wfm-table').dataTable( {
+		bAutoWidth: false,
 		"oLanguage": {
 			"sLengthMenu": "<?=wfMsg('table_pager_limit', '_MENU_');?>",
 			"sZeroRecords": "<?=wfMsg('table_pager_empty');?>",

--- a/extensions/wikia/WikiFactory/Metrics/templates/metrics-main-form.tmpl.php
+++ b/extensions/wikia/WikiFactory/Metrics/templates/metrics-main-form.tmpl.php
@@ -34,6 +34,7 @@ $(document).ready(function() {
 	var baseurl = wgScript + "?action=ajax&rs=axAWCMetrics";
 				
 	var oTable = $('#wfm-table').dataTable( {
+		bAutoWidth: false,
 		"oLanguage": {
 			"sLengthMenu": "<?=wfMsg('table_pager_limit', '_MENU_');?>",
 			"sZeroRecords": "<?=wfMsg('table_pager_empty');?>",

--- a/extensions/wikia/WikiFactory/Metrics/templates/metrics-monthly-form.tmpl.php
+++ b/extensions/wikia/WikiFactory/Metrics/templates/metrics-monthly-form.tmpl.php
@@ -22,6 +22,7 @@ $(document).ready(function() {
 	var baseurl = wgScript + "?action=ajax&rs=axAWCMetricsCategory";
 	var cnt = 0;
 	var oTable = $('#wfm-table').dataTable( {
+		bAutoWidth: false,
 		"oLanguage": {
 			"sLengthMenu": "<?=wfMsg('table_pager_limit', '_MENU_');?>",
 			"sZeroRecords": "<?=wfMsg('table_pager_empty');?>",


### PR DESCRIPTION
Adding parameter "bAutoWidth: false" to "$(...).dataTable( {" skips adding initial table width to "table" element. Therefore it stays at 100% and it's scaled properly.
