### PR TITLE
PLA-835 -- allow staff/internal reindex from maintenance script

### DIFF
--- a/extensions/wikia/Search/classes/Indexer.php
+++ b/extensions/wikia/Search/classes/Indexer.php
@@ -39,15 +39,7 @@ class Indexer
 	 * Used to determine which services to invoke during WikiaSearchIndexer::getPage()
 	 * @var array
 	 */
-	protected $serviceNames = array(
-			'DefaultContent',
-			'Metadata',
-			'MediaData',
-			'Redirects',
-			'Wam',
-			'WikiPromoData',
-			'WikiViews'
-	);
+	protected $serviceNames = array( 'All' );
 
 	/**
 	 * Used to generate indexing data for a number of page IDs on a given  wiki

--- a/extensions/wikia/Search/maintenance/staff-internal-reindex.php
+++ b/extensions/wikia/Search/maintenance/staff-internal-reindex.php
@@ -16,8 +16,7 @@ $wgTitle = Title::newMainPage();
 $c = RequestContext::getMain();
 $c->setUser($wgUser);
 $c->setTitle($wgTitle);
-
-$indexer = (new WikiaSearchIndexer);
+$indexer = (new Wikia\Search\Indexer);
 
 $dbr = wfGetDB( DB_MASTER );
 


### PR DESCRIPTION
We need to run a reindex on staff/internal in order to fix some of the index slowness. The maintenance script needed updating before we could do that.
