### PR TITLE
VID-924 updating js code to be more easily changed by user js

### DIFF
--- a/skins/oasis/js/LatestPhotos.js
+++ b/skins/oasis/js/LatestPhotos.js
@@ -7,7 +7,7 @@ var UploadPhotos = {
 	libinit: false,
 	init: function() {
 		// Special:NewFiles and LatestPhotos module
-		$(".upphotos").click($.proxy(this.loginBeforeShowDialog, this));
+		$(".upphotos").on('click.uploadPhotos', $.proxy(this.loginBeforeShowDialog, this));
 		// LatestPhotos module only
 		$('#LatestPhotosModule').find('.upphotos, .upphotoslogin').tooltip({
 			delay: { show: 500, hide: 100 }


### PR DESCRIPTION
This change won't affect anything really other than it will make it easier for the harry potter admins to unbid a click event on the upload photos dialog.  They want to just have the browser follow the link to the image upload page. 

The JS they had in place broke after the right rail changes due to a race condition. 
