### PR TITLE
ThumbnailVideo: rewrite URLs

### DIFF
--- a/extensions/wikia/Development/Configs_DevBox/LocalSettings.php
+++ b/extensions/wikia/Development/Configs_DevBox/LocalSettings.php
@@ -169,6 +169,8 @@ if (!empty($wgEnableSwiftFileBackend)) {
 	$wgDevBoxImageServerOverride = 's3.dev-dfs-p1';
 }
 
+$wgWikiaVideoImageHost = false; // don't rewrite URLs for shared video thumbnails
+
 // macbre: generate proper paths for static assets on devboxes (BugId:6809)
 $wgCdnStylePath = "{$wgCdnRootUrl}/__cb{$wgStyleVersion}"; // paths for images requested from CSS/SASS
 $wgStylePath = "{$wgCdnStylePath}/skins";

--- a/extensions/wikia/VideoHandlers/ThumbnailVideo.class.php
+++ b/extensions/wikia/VideoHandlers/ThumbnailVideo.class.php
@@ -26,6 +26,24 @@ class ThumbnailVideo extends ThumbnailImage {
 //		$this->page = $page;
 //	}
 
+	// temporary hack - start
+	// rewrite URLs to point to a proper video thumbnails storage during images migration
+	// @author macbre
+	function __construct( $file, $url, $width, $height, $path = false, $page = false ) {
+		global $wgWikiaVideoImageHost;
+		parent::__construct( $file, $url, $width, $height, $path, $page );
+
+		// handle videos comming from shared repo (video.wikia.com)
+		if ( !empty( $wgWikiaVideoImageHost ) && ( $file instanceof WikiaForeignDBFile ) ) {
+			// replace with a proper video domain for production
+			$domain = parse_url($this->url, PHP_URL_HOST);
+			$this->url = str_replace("http://{$domain}/", $wgWikiaVideoImageHost, $this->url);
+		}
+
+		#var_dump(__METHOD__); var_dump($this->url);
+	}
+	// temporary hack - end
+
 	function getFile( ) {
 		return $this->file;
 	}

--- a/includes/filerepo/file/File.php
+++ b/includes/filerepo/file/File.php
@@ -287,6 +287,8 @@ abstract class File {
 			$this->url = $this->repo->getZoneUrl( 'public' ) . '/' . $this->getUrlRel();
 
 			# start wikia change
+			$this->originalUrl = $this->url;
+
 			global $wgDevelEnvironment;
 			if (!empty($wgDevelEnvironment)) {
 				$this->url = wfReplaceImageServer( $this->url, $this->getTimestamp() );
@@ -295,6 +297,18 @@ abstract class File {
 		}
 		return $this->url;
 	}
+
+	# start wikia change
+	protected $originalUrl;
+
+	public function getOriginalUrl() {
+		if ( !isset( $this->url ) ) {
+			$this->getUrl();
+		}
+
+		return $this->originalUrl;
+	}
+	# end wikia change
 
 	/**
 	 * Return a fully-qualified URL to the file.

--- a/includes/wikia/GlobalFunctions.php
+++ b/includes/wikia/GlobalFunctions.php
@@ -110,28 +110,28 @@ function print_pre($param, $return = 0)
  * @return String -- new url
  */
 function wfReplaceImageServer( $url, $timestamp = false ) {
-	global $wgImagesServers, $wgAkamaiLocalVersion,  $wgAkamaiGlobalVersion, $wgDevBoxImageServerOverride, $wgDBname;
+	$wg = F::app()->wg;
 
 	// Override image server location for Wikia development environment
 	// This setting should be images.developerName.wikia-dev.com or perhaps "localhost"
-	if (!empty($wgDevBoxImageServerOverride)) {
-		$url = preg_replace("/\/\/(.*?)wikia-dev\.com\/(.*)/", "//$wgDevBoxImageServerOverride/$2", $url);
+	if (!empty($wg->DevBoxImageServerOverride)) {
+		$url = preg_replace("/\/\/(.*?)wikia-dev\.com\/(.*)/", "//{$wg->DevBoxImageServerOverride}/$2", $url);
 	}
 
 	wfDebug( __METHOD__ . ": requested url $url\n" );
-	if(substr(strtolower($url), -4) != '.ogg' && isset($wgImagesServers) && is_int($wgImagesServers)) {
+	if(substr(strtolower($url), -4) != '.ogg' && isset($wg->ImagesServers) && is_int($wg->ImagesServers)) {
 		if(strlen($url) > 7 && substr($url,0,7) == 'http://') {
 			$hash = sha1($url);
 			$inthash = ord ($hash);
 
-			$serverNo = $inthash%($wgImagesServers-1);
+			$serverNo = $inthash%($wg->ImagesServers-1);
 			$serverNo++;
 
 			// If there is no timestamp, use the cache-busting number from wgCdnStylePath.
 			if($timestamp == ""){
-				global $wgCdnStylePath;
 				$matches = array();
-				if(0 < preg_match("/\/__cb([0-9]+)/i", $wgCdnStylePath, $matches)){
+				// @TODO: consider using wgStyleVersion
+				if(0 < preg_match("/\/__cb([0-9]+)/i", $wg->CdnStylePath, $matches)){
 					$timestamp = $matches[1];
 				} else {
 					// This results in no caching of the image.  Bad bad bad, but the best way to fail.
@@ -146,27 +146,29 @@ function wfReplaceImageServer( $url, $timestamp = false ) {
 
 			// Add Akamai versions, but only if there is some sort of caching number.
 			if($timestamp != ""){
-				$timestamp += $wgAkamaiGlobalVersion + $wgAkamaiLocalVersion;
+				$timestamp += $wg->AkamaiGlobalVersion + $wg->AkamaiLocalVersion;
 			}
 
-			// NOTE: This should be the only use of the cache-buster which does not use $wgCdnStylePath.
+			// NOTE: This should be the only use of the cache-buster which does not use $wg->CdnStylePath.
 			// RT#98969 if the url already has a cb value, don't add another one...
-			if ( !empty( $wgDevBoxImageServerOverride ) ) {
+			if ( !empty( $wg->DevBoxImageServerOverride ) ) {
 				$cb = '';
 			} else {
 				$cb = ($timestamp!='' && strpos($url, "__cb") === false) ? "__cb{$timestamp}/" : '';
 			}
 
-			if (!empty($wgDevBoxImageServerOverride)) {
+			// TODO: support __cb on devboxes
+			// TODO: support domain sharding on devboxes
+			if (!empty($wg->DevBoxImageServerOverride)) {
 				// Dev boxes
-				$url = str_replace('http://images.wikia.com/', sprintf("http://$wgDevBoxImageServerOverride/%s", $cb), $url);
+				$url = str_replace('http://images.wikia.com/', sprintf("http://{$wg->DevBoxImageServerOverride}/%s", $cb), $url);
 			} else {
 				// Production
 				$url = str_replace('http://images.wikia.com/', sprintf("http://images%s.wikia.nocookie.net/%s",$serverNo, $cb), $url);
 			}
 		}
-	} else if (!empty($wgDevBoxImageServerOverride)) {
-		$url = str_replace('http://images.wikia.com/', "http://$wgDevBoxImageServerOverride/", $url);
+	} else if (!empty($wg->DevBoxImageServerOverride)) {
+		$url = str_replace('http://images.wikia.com/', "http://{$wg->DevBoxImageServerOverride}/", $url);
 	}
 
 	return $url;

--- a/includes/wikia/tests/ReplaceImageServerTest.php
+++ b/includes/wikia/tests/ReplaceImageServerTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Set of unit tests for wfReplaceImageServer function
+ *
+ * @author macbre
+ */
+class ReplaceImageServerTest extends WikiaBaseTest {
+
+	const DEFAULT_CB = 123456789;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->mockGlobalVariable('wgCdnStylePath', sprintf('http://slot1.images.wikia.nocookie.net/__cb%s/common', self::DEFAULT_CB));
+		$this->mockGlobalVariable('wgAkamaiGlobalVersion', 0);
+		$this->mockGlobalVariable('wgAkamaiLocalVersion', 0);
+	}
+
+	/**
+	 * @dataProvider testForProductionDataProvider
+	 */
+	public function testForProduction($url, $timestamp, $expected) {
+		$this->mockGlobalVariable('wgDevBoxImageServerOverride', false);
+
+		$this->assertEquals( $expected, wfReplaceImageServer( $url, $timestamp ), 'URL returned by wfReplaceImageServer should match expected one' );
+	}
+
+	public function testForProductionDataProvider() {
+		return [
+			[
+				'url' => 'http://images.wikia.com/poznan/pl/images/0/06/Gzik.jpg',
+				'timestamp' => '20111213221641',
+				'expected' => 'http://images3.wikia.nocookie.net/__cb20111213221641/poznan/pl/images/0/06/Gzik.jpg',
+			],
+			[
+				'url' => 'http://images.wikia.com/poznan/pl/images/5/57/Ratusz_uj%C4%99cie_od_do%C5%82u.jpg',
+				'timestamp' => '20110917091718',
+				'expected' => 'http://images1.wikia.nocookie.net/__cb20110917091718/poznan/pl/images/5/57/Ratusz_uj%C4%99cie_od_do%C5%82u.jpg',
+			],
+			// no timestamp provided, use cache buster value from wgCdnStylePath (i.e. wgStyleVersion)
+			[
+				'url' => 'http://images.wikia.com/poznan/pl/images/5/57/Ratusz_uj%C4%99cie_od_do%C5%82u.jpg',
+				'timestamp' => false,
+				'expected' => 'http://images1.wikia.nocookie.net/__cb' . self::DEFAULT_CB . '/poznan/pl/images/5/57/Ratusz_uj%C4%99cie_od_do%C5%82u.jpg',
+			],
+			// ogg files should be served from images.wikia.com domain
+			[
+				'url' => 'http://images.wikia.com/poznan/pl/images/a/aa/File.ogg',
+				'timestamp' => '20110917091718',
+				'expected' => 'http://images.wikia.com/poznan/pl/images/a/aa/File.ogg',
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider devboxDataProvider
+	 */
+	public function testForDevbox($url, $timestamp, $expected) {
+		$this->mockGlobalVariable('wgDevBoxImageServerOverride', 'images.hakarl.wikia-dev.com');
+
+		$this->assertEquals( $expected, wfReplaceImageServer( $url, $timestamp ), 'URL returned by wfReplaceImageServer should match expected one' );
+	}
+
+	public function devboxDataProvider() {
+		return [
+			// cachebuster are not added on devboxes
+			[
+				'url' => 'http://images.wikia.com/poznan/pl/images/0/06/Gzik.jpg',
+				'timestamp' => '20111213221641',
+				'expected' => 'http://images.hakarl.wikia-dev.com/poznan/pl/images/0/06/Gzik.jpg',
+			],
+			[
+				'url' => 'http://images.wikia.com/poznan/pl/images/5/57/Ratusz_uj%C4%99cie_od_do%C5%82u.jpg',
+				'timestamp' => '20110917091718',
+				'expected' => 'http://images.hakarl.wikia-dev.com/poznan/pl/images/5/57/Ratusz_uj%C4%99cie_od_do%C5%82u.jpg',
+			],
+			// no timestamp provided, use cache buster value from wgCdnStylePath (i.e. wgStyleVersion)
+			[
+				'url' => 'http://images.wikia.com/poznan/pl/images/5/57/Ratusz_uj%C4%99cie_od_do%C5%82u.jpg',
+				'timestamp' => false,
+				'expected' => 'http://images.hakarl.wikia-dev.com/poznan/pl/images/5/57/Ratusz_uj%C4%99cie_od_do%C5%82u.jpg',
+			],
+			// ogg files should be served from devbox images domain
+			[
+				'url' => 'http://images.wikia.com/poznan/pl/images/a/aa/File.ogg',
+				'timestamp' => '20110917091718',
+				'expected' => 'http://images.hakarl.wikia-dev.com/poznan/pl/images/a/aa/File.ogg',
+			],
+		];
+	}
+}


### PR DESCRIPTION
We need to modify the way URLs for shared repository videos are generated. Currently `wfReplaceImageServer` is called which uses current aka local wiki setup - including image domains.

However, during migration to distributed file system we need to keep shared videos on old storage for a while, but "force" migrated wikis to use old images domain.

@garthwebb - please review
