### PR TITLE
DAR-2367 | Lazy rail - changed title param because of problems in API

### DIFF
--- a/skins/oasis/js/LazyRail.js
+++ b/skins/oasis/js/LazyRail.js
@@ -8,7 +8,7 @@ $(function() {
 			controller: 'RailController',
 			method: (window.wgUserName) ? 'lazy' : 'lazyForAnons',
 			data: {
-				'title': window.wgTitle,
+				'articleTitle': window.wgTitle,
 				'namespace': window.wgNamespaceNumber,
 				'cb': window.wgStyleVersion
 			},

--- a/skins/oasis/modules/RailController.class.php
+++ b/skins/oasis/modules/RailController.class.php
@@ -58,34 +58,37 @@ class RailController extends WikiaController {
 	 */
 	protected function getLazyRail() {
 		wfProfileIn(__METHOD__);
-		global $wgUseSiteJs, $wgAllowUserJs;
+		global $wgUseSiteJs, $wgAllowUserJs, $wgTitle;
+		$title = Title::newFromText($this->request->getVal('articleTitle', null), $this->request->getInt('namespace', null));
 
-		$railModules = $this->filterModules((new BodyController)->getRailModuleList(), self::FILTER_LAZY_MODULES);
-		$this->railLazyContent = '';
-		krsort($railModules);
-		foreach ($railModules as $railModule) {
-			$this->railLazyContent .= $this->app->renderView(
-				$railModule[0], /* Controller */
-				$railModule[1], /* Method */
-				$railModule[2] /* array of params */
-			);
+		if ($title instanceof Title) {
+			$wgTitle = $title;
+			$railModules = $this->filterModules((new BodyController)->getRailModuleList(), self::FILTER_LAZY_MODULES);
+			$this->railLazyContent = '';
+			krsort($railModules);
+			foreach ($railModules as $railModule) {
+				$this->railLazyContent .= $this->app->renderView(
+					$railModule[0], /* Controller */
+					$railModule[1], /* Method */
+					$railModule[2] /* array of params */
+				);
+			}
+
+			$this->railLazyContent .= Html::element('div', ['id' => 'WikiaAdInContentPlaceHolder']);
+
+			$this->css = array_keys($this->app->wg->Out->styles);
+
+			// Do not load user and site jses as they are already loaded and can break page
+			$oldWgUseSiteJs = $wgUseSiteJs;
+			$oldWgAllowUserJs = $wgAllowUserJs;
+			$wgUseSiteJs = false;
+			$wgAllowUserJs = false;
+
+			$this->js = $this->app->wg->Out->getBottomScripts();
+
+			$wgUseSiteJs = $oldWgUseSiteJs;
+			$wgAllowUserJs = $oldWgAllowUserJs;
 		}
-
-		$this->railLazyContent .= Html::element('div', ['id' => 'WikiaAdInContentPlaceHolder']);
-
-		$this->css = array_keys($this->app->wg->Out->styles);
-
-		// Do not load user and site jses as they are already loaded and can break page
-		$oldWgUseSiteJs = $wgUseSiteJs;
-		$oldWgAllowUserJs = $wgAllowUserJs;
-		$wgUseSiteJs = false;
-		$wgAllowUserJs = false;
-
-		$this->js = $this->app->wg->Out->getBottomScripts();
-
-		$wgUseSiteJs = $oldWgUseSiteJs;
-		$wgAllowUserJs = $oldWgAllowUserJs;
-
 
 		wfProfileOut(__METHOD__);
 	}

--- a/skins/oasis/modules/RailController.class.php
+++ b/skins/oasis/modules/RailController.class.php
@@ -62,6 +62,7 @@ class RailController extends WikiaController {
 		$title = Title::newFromText($this->request->getVal('articleTitle', null), $this->request->getInt('namespace', null));
 
 		if ($title instanceof Title) {
+			$oldWgTitle = $wgTitle;
 			$wgTitle = $title;
 			$railModules = $this->filterModules((new BodyController)->getRailModuleList(), self::FILTER_LAZY_MODULES);
 			$this->railLazyContent = '';
@@ -88,6 +89,7 @@ class RailController extends WikiaController {
 
 			$wgUseSiteJs = $oldWgUseSiteJs;
 			$wgAllowUserJs = $oldWgAllowUserJs;
+			$wgTitle = $oldWgTitle;
 		}
 
 		wfProfileOut(__METHOD__);

--- a/skins/oasis/modules/RailController.class.php
+++ b/skins/oasis/modules/RailController.class.php
@@ -54,7 +54,7 @@ class RailController extends WikiaController {
 	}
 
 	/**
-	 *
+	 * Get lazy right rail modules
 	 */
 	protected function getLazyRail() {
 		wfProfileIn(__METHOD__);
@@ -62,6 +62,9 @@ class RailController extends WikiaController {
 		$title = Title::newFromText($this->request->getVal('articleTitle', null), $this->request->getInt('namespace', null));
 
 		if ($title instanceof Title) {
+			// override original wgTitle from title given in parameters
+			// we cannot use wgTitle that is created on by API because it's broken on wikis without '/wiki' in URL
+			// https://wikia-inc.atlassian.net/browse/BAC-906
 			$oldWgTitle = $wgTitle;
 			$wgTitle = $title;
 			$railModules = $this->filterModules((new BodyController)->getRailModuleList(), self::FILTER_LAZY_MODULES);


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/DAR-2367
Fix for p2

Additional info:
Mediawiki stack is changing `$_GET['title']` into `"wikia.php"` on API calls when `wgArticlePath` is set to `'/$1'`. Jira ticket for this bug: https://wikia-inc.atlassian.net/browse/MAIN-1036
