### PR TITLE
VOLDEV-19: Special:CSS logo misplaced on Special:AdminDashboard

### DIFF
--- a/extensions/wikia/AdminDashboard/css/AdminDashboard.scss
+++ b/extensions/wikia/AdminDashboard/css/AdminDashboard.scss
@@ -226,7 +226,7 @@ $color-highlight-column: rgba($color-page, 0);
 								background-position: -300px 0;
 							}
 							&.specialcsstool {
-								background-position: -900px 0;
+								background-position: -892px 0;
 							}
 
 							&.communitycorner {


### PR DESCRIPTION
@grunny @mroszka 
`background-position: -900px;` changed to `background-position: -892px;`.
