### PR TITLE
Entities to DFP

### DIFF
--- a/extensions/wikia/NLP/WikiaNLP.i18n.php
+++ b/extensions/wikia/NLP/WikiaNLP.i18n.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * NLP i18n messages, yo
+ */
+$messages = [];
+
+$messages['en'] = array(
+		'wikia-nlp-desc' => 'Extension for interacting with natural language data.'
+);
+
+$messages['qq'] = array(
+		'wikia-nlp-desc' => 'Extension description'
+);

--- a/extensions/wikia/NLP/WikiaNLP.i18n.php
+++ b/extensions/wikia/NLP/WikiaNLP.i18n.php
@@ -8,6 +8,6 @@ $messages['en'] = array(
 		'wikia-nlp-desc' => 'Extension for interacting with natural language data.'
 );
 
-$messages['qq'] = array(
+$messages['qqq'] = array(
 		'wikia-nlp-desc' => 'Extension description'
 );

--- a/extensions/wikia/NLP/WikiaNLP.setup.php
+++ b/extensions/wikia/NLP/WikiaNLP.setup.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Wikia NLP Extension
+ *
+ * @author Robert Elwell <robert(at)wikia-inc.com>
+ */
+
+
+$wgExtensionCredits['other'][] = array(
+		'name'              => 'Wikia NLP',
+		'version'           => '1.0',
+		'author'            => '[http://wikia.com/wiki/User:Relwell Robert Elwell]',
+		'descriptionmsg'    => 'wikia-nlp-desc',
+);
+
+$dir = dirname(__FILE__) . '/';
+
+// we still haven't done sensible cross-extension namespace autoloading, grr
+$wgAutoloadClasses['Wikia\NLP\Entities\PageEntitiesService'] =  $dir . 'classes/Entities/PageEntitiesService.php';
+$wgAutoloadClasses['Wikia\NLP\Entities\WikiEntitiesService'] =  $dir . 'classes/Entities/WikiEntitiesService.php';
+$wgAutoloadClasses['Wikia\NLP\Entities\Hooks'] =  $dir . 'classes/Entities/Hooks.php';
+
+// this would be for page_wikia_props -- should move to defines if we use it.
+define( 'PAGE_ENTITIES_KEY', 22 );
+
+if ( $wgEnableEntitiesForDFP ) {
+	$wgHooks['ArticleViewHeader'][] = 'Wikia\NLP\Entities\Hooks::onArticleViewHeader';
+}

--- a/extensions/wikia/NLP/WikiaNLP.setup.php
+++ b/extensions/wikia/NLP/WikiaNLP.setup.php
@@ -5,6 +5,7 @@
  * @author Robert Elwell <robert(at)wikia-inc.com>
  */
 
+global $wgEnableEntitiesForDFP, $wgExtensionCredits, $wgAutoloadClasses;
 
 $wgExtensionCredits['other'][] = array(
 		'name'              => 'Wikia NLP',

--- a/extensions/wikia/NLP/classes/Entities/Hooks.php
+++ b/extensions/wikia/NLP/classes/Entities/Hooks.php
@@ -18,8 +18,7 @@ class Hooks
 	 * @return boolean
 	 */
 	public static function onArticleViewHeader( &$article, &$outputDone, &$pcache ) {
-		(new WikiEntitiesService)->registerEntitiesWithDFP();
-		return true;
+		return (new WikiEntitiesService)->registerEntitiesWithDFP();
 	}
 	
 }

--- a/extensions/wikia/NLP/classes/Entities/Hooks.php
+++ b/extensions/wikia/NLP/classes/Entities/Hooks.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Class definition for Wikia\NLP\Entities\Hooks
+ */
+namespace Wikia\NLP\Entities;
+/**
+ * This class is for registering MediaWiki hooks against
+ * @author relwell
+ */
+class Hooks
+{
+
+	/**
+	 * Registers DFP key values for entities
+	 * @param Article $article
+	 * @param bool $outputDone
+	 * @param bool $pcache
+	 * @return boolean
+	 */
+	public static function onArticleViewHeader( &$article, &$outputDone, &$pcache ) {
+		(new WikiEntitiesService)->registerEntitiesWithDFP();
+		return true;
+	}
+	
+}

--- a/extensions/wikia/NLP/classes/Entities/PageEntitiesService.php
+++ b/extensions/wikia/NLP/classes/Entities/PageEntitiesService.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Class definition for Wikia\NLP\Entities\PageEntitiesService
+ */
+namespace Wikia\NLP\Entities;
+use Wikia\Search\MediaWikiService;
+/**
+ * Responsible for interacting with entities on the page level.
+ * @author relwell
+ */
+class PageEntitiesService
+{
+	/**
+	 * Accesses an array of page-scoped entities for a provided page ID
+	 * @todo this is probably better done using SolrDocumentService
+	 * @param int $pageId
+	 * @return array
+	 */
+	public function getEntitiesForPage( $pageId ) {
+		$unserialized = false;
+		$db = wfGetDB( DB_SLAVE );
+		$result = $db->select(
+				'page_wikia_props', 
+				[ 'props' ], 
+				array( 'page_id' => $pageId, 'propname' => PAGE_ENTITIES_KEY )
+		);
+		$row = $db->fetchRow( $result );
+		if ( ( $row != false ) && isset( $row['props'] ) ) {
+			$unserialized = unserialize( $row['props'] );
+		}
+		return $unserialized ?: [];
+	}
+	
+	/**
+	 * Responsible for storing page entities
+	 * @return bool
+	 */
+	public function registerEntitiesWithDFP() {
+		$mwService = $this->getMwService();
+		$entityList = $this->getEntitiesForPage( $mwService->getGlobal( 'ArticleId' ) );
+		if ( count( $entityList ) ) {
+			array_walk( $entityList, function( &$val ) { return substr( $val, 0, 20 ); } );
+			$keyValues = $mwService->getGlobalWithDefault( 'wgDartCustomKeyValues', '' )
+			           . http_build_query( [ 'pageentities' => $entityList ] );
+			$mwService->setGlobal( 'wgDartCustomKeyValues', $keyValues );
+		}
+		return true;
+	}
+	
+	/**
+	 * Dependency lazy-loader.
+	 * @return \Wikia\Search\MediaWikiService
+	 */
+	protected function getMwService() {
+		if ( $this->mwService === null ) {
+			$this->mwService = new MediaWikiService;
+		}
+		return $this->mwService;
+	}
+	
+}

--- a/extensions/wikia/NLP/classes/Entities/PageEntitiesService.php
+++ b/extensions/wikia/NLP/classes/Entities/PageEntitiesService.php
@@ -39,10 +39,11 @@ class PageEntitiesService
 		$mwService = $this->getMwService();
 		$entityList = $this->getEntitiesForPage( $mwService->getGlobal( 'ArticleId' ) );
 		if ( count( $entityList ) ) {
-			array_walk( $entityList, function( &$val ) { return substr( $val, 0, 20 ); } );
-			$keyValues = $mwService->getGlobalWithDefault( 'wgDartCustomKeyValues', '' )
-			           . http_build_query( [ 'pageentities' => $entityList ] );
-			$mwService->setGlobal( 'wgDartCustomKeyValues', $keyValues );
+			$keyValues = explode( ';', $mwService->getGlobalWithDefault( 'wgDartCustomKeyValues', '' ) );
+			foreach ( $entityList as &$val ) {
+				$val = sprintf( 'pageentities=%s', substr( $val, 0, 20 ) );
+			}
+			$mwService->setGlobal( 'wgDartCustomKeyValues', implode( ';', array_merge( $keyValues, $entityList ) ) );
 		}
 		return true;
 	}

--- a/extensions/wikia/NLP/classes/Entities/WikiEntitiesService.php
+++ b/extensions/wikia/NLP/classes/Entities/WikiEntitiesService.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Class definition for Wikia\NLP\Entities\WikiEntitiesService
+ */
+namespace Wikia\NLP\Entities;
+use Wikia\Search\MediaWikiService;
+/**
+ * Class responsible for interacting with wiki-scoped entities 
+ * @author relwell
+ */
+class WikiEntitiesService
+{
+	/**
+	 * Used to interact with MediaWiki components.
+	 * @var Wikia\Search\MediaWikiService
+	 */
+	protected $mwService;
+	
+	/**
+	 * Prepares entities for dart key-value pairs and stores it in the appropriate global variable 
+	 * @return bool
+	 */
+	public function registerEntitiesWithDFP() {
+		$mwService = $this->getMwService();
+		$entityList = $this->getEntityList();
+		if ( count( $entityList ) ) {
+			array_walk( $entityList, function( &$val ) { return substr( $val, 0, 20 ); } );
+			$keyValues = $mwService->getGlobalWithDefault( 'wgDartCustomKeyValues', '' )
+			           . http_build_query( [ 'wikientities' => $entityList ] );
+			$mwService->setGlobal( 'wgDartCustomKeyValues', $keyValues );
+		}
+		return true;
+	}
+	
+	
+	/**
+	 * Access entities from wikifactory, currently.
+	 * @todo store entities in xwiki Solr document and use SolrDocumentService to access data.
+	 * @return array
+	 */
+	public function getEntityList() {
+		return $this->getMwService()->getGlobalWithDefault( 'WikiEntities', [] );
+	}
+	
+	/**
+	 * Dependency lazy-loader.
+	 * @return \Wikia\Search\MediaWikiService
+	 */
+	protected function getMwService() {
+		if ( $this->mwService === null ) {
+			$this->mwService = new MediaWikiService;
+		}
+		return $this->mwService;
+	}
+	
+}

--- a/extensions/wikia/NLP/classes/Entities/WikiEntitiesService.php
+++ b/extensions/wikia/NLP/classes/Entities/WikiEntitiesService.php
@@ -24,8 +24,9 @@ class WikiEntitiesService
 		$mwService = $this->getMwService();
 		$entityList = $this->getEntityList();
 		if ( count( $entityList ) ) {
-			array_walk( $entityList, function( &$val ) { return substr( $val, 0, 20 ); } );
+			array_walk( $entityList, function( &$val ) { $val = substr( $val, 0, 20 ); } );
 			$keyValues = $mwService->getGlobalWithDefault( 'wgDartCustomKeyValues', '' )
+			           . '&'
 			           . http_build_query( [ 'wikientities' => $entityList ] );
 			$mwService->setGlobal( 'wgDartCustomKeyValues', $keyValues );
 		}

--- a/extensions/wikia/NLP/classes/Entities/WikiEntitiesService.php
+++ b/extensions/wikia/NLP/classes/Entities/WikiEntitiesService.php
@@ -24,7 +24,9 @@ class WikiEntitiesService
 		$mwService = $this->getMwService();
 		$entityList = $this->getEntityList();
 		if ( count( $entityList ) ) {
-			array_walk( $entityList, function( &$val ) { $val = substr( $val, 0, 20 ); } );
+			foreach ( $entityList as &$entity ) {
+				$entity = substr( $entity, 0, 20 );
+			}
 			$keyValues = $mwService->getGlobalWithDefault( 'wgDartCustomKeyValues', '' )
 			           . '&'
 			           . http_build_query( [ 'wikientities' => $entityList ] );

--- a/extensions/wikia/NLP/classes/Entities/WikiEntitiesService.php
+++ b/extensions/wikia/NLP/classes/Entities/WikiEntitiesService.php
@@ -24,13 +24,11 @@ class WikiEntitiesService
 		$mwService = $this->getMwService();
 		$entityList = $this->getEntityList();
 		if ( count( $entityList ) ) {
+			$keyValues = explode( ';', $mwService->getGlobalWithDefault( 'wgDartCustomKeyValues', '' ) );
 			foreach ( $entityList as &$entity ) {
-				$entity = substr( $entity, 0, 20 );
+				$entity = sprintf( 'wikientities=%s', substr( $entity, 0, 20 ) );
 			}
-			$keyValues = $mwService->getGlobalWithDefault( 'wgDartCustomKeyValues', '' )
-			           . '&'
-			           . http_build_query( [ 'wikientities' => $entityList ] );
-			$mwService->setGlobal( 'wgDartCustomKeyValues', $keyValues );
+			$mwService->setGlobal( 'wgDartCustomKeyValues', implode( ';', array_merge( $keyValues, $entityList ) ) );
 		}
 		return true;
 	}

--- a/extensions/wikia/NLP/classes/Test/Entities/WikiEntitiesServiceTest.php
+++ b/extensions/wikia/NLP/classes/Test/Entities/WikiEntitiesServiceTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Class definition for Wikia\NLP\Test\Entities\WikiEntitiesServiceTest
+ */
+namespace Wikia\NLP\Test\Entities;
+use WikiaBaseTest;
+/**
+ * Tests Wikia\NLP\Test\Entities\WikiEntitiesService
+ * @author relwell
+ */
+class WikiEntitiesServiceTest extends WikiaBaseTest
+{
+	
+	public function setUp() {
+		parent::setUp();
+		require_once( __DIR__ . '/../../../WikiaNLP.setup.php' );
+	}
+	
+	const CLASSNAME = 'Wikia\NLP\Entities\WikiEntitiesService';
+	
+	/**
+	 * @covers Wikia\NLP\Entities\WikiEntitiesService::getEntityList
+	 */
+	public function testGetEntityList() {
+		$service = $this->getMock( self::CLASSNAME, [ 'getMwService' ] );
+		$mwService = $this->getMock( 'Wikia\Search\MediaWikiService', [ 'getGlobalWithDefault' ] );
+
+		$entities = [ 'foo', 'bar', 'baz' ];
+		
+		$service
+		    ->expects( $this->once() )
+		    ->method ( 'getMwService' )
+		    ->will   ( $this->returnValue( $mwService ) ) 
+		;
+		$mwService
+		    ->expects( $this->once() )
+		    ->method ( 'getGlobalWithDefault' )
+		    ->with   ( 'WikiEntities', [] )
+		    ->will   ( $this->returnValue( $entities ) )
+		;
+		$this->assertEquals(
+				$entities,
+				$service->getEntityList()
+		);
+	}
+	
+	/**
+	 * @covers Wikia\NLP\Entities\WikiEntitiesService::registerEntitiesWithDFP
+	 */
+	public function testRegisterEntitiesWithDFP() {
+		$service = $this->getMock( self::CLASSNAME, [ 'getMwService', 'getEntityList' ] );
+		$mwService = $this->getMock( 'Wikia\Search\MediaWikiService', [ 'getGlobalWithDefault', 'setGlobal' ] );
+
+		$entities = [ 'foo', 'bar', 'baz' ];
+		$entitiesTruncated = $entities;
+		$entities[] = str_pad('', 22, 'a' );
+		$entitiesTruncated[] = substr( end( $entities ), 0, 20 );
+		
+		$kvs = 'foo=bar&baz=qux';
+		
+		$service
+		    ->expects( $this->once() )
+		    ->method ( 'getMwService' )
+		    ->will   ( $this->returnValue( $mwService ) ) 
+		;
+		$service
+		    ->expects( $this->once() )
+		    ->method ( 'getEntityList' )
+		    ->will   ( $this->returnValue( $entities ) )
+		;
+		$mwService
+		    ->expects( $this->once() )
+		    ->method ( 'getGlobalWithDefault' )
+		    ->with   ( 'wgDartCustomKeyValues', '' )
+		    ->will   ( $this->returnValue( $kvs ) )
+		;
+		$mwService
+		    ->expects( $this->once() )
+		    ->method ( 'setGlobal' )
+		    ->with   ( 'wgDartCustomKeyValues', $kvs . '&' . http_build_query( [ 'wikientities' => $entitiesTruncated ] ) )
+		;
+		$this->assertTrue( $service->registerEntitiesWithDFP() );
+	}
+	
+}

--- a/extensions/wikia/NLP/classes/Test/Entities/WikiEntitiesServiceTest.php
+++ b/extensions/wikia/NLP/classes/Test/Entities/WikiEntitiesServiceTest.php
@@ -55,8 +55,8 @@ class WikiEntitiesServiceTest extends WikiaBaseTest
 		$entitiesTruncated = $entities;
 		$entities[] = str_pad('', 22, 'a' );
 		$entitiesTruncated[] = substr( end( $entities ), 0, 20 );
-		
-		$kvs = 'foo=bar&baz=qux';
+
+		$kvs = 'foo=bar;baz=qux';
 		
 		$service
 		    ->expects( $this->once() )
@@ -77,7 +77,7 @@ class WikiEntitiesServiceTest extends WikiaBaseTest
 		$mwService
 		    ->expects( $this->once() )
 		    ->method ( 'setGlobal' )
-		    ->with   ( 'wgDartCustomKeyValues', $kvs . '&' . http_build_query( [ 'wikientities' => $entitiesTruncated ] ) )
+		    ->with   ( 'wgDartCustomKeyValues', $kvs . ';wikientities=foo;wikientities=bar;wikientities=baz;wikientities=' . end($entitiesTruncated) )
 		;
 		$this->assertTrue( $service->registerEntitiesWithDFP() );
 	}


### PR DESCRIPTION
This introduces an extension which pulls entities out of WikiFactory and registers them with our DART integration.

FYI, there is code in here for page-level entities, but I think we're only planning on supporting wiki-level entities at the present time.
