### PR TITLE
DAR-2396 Temporary logging for SassUtil

### DIFF
--- a/extensions/wikia/SASS/SassUtil.php
+++ b/extensions/wikia/SASS/SassUtil.php
@@ -76,7 +76,8 @@ class SassUtil {
 							__LINE__,
 							'$settings',
 							str_replace( "\n", '\n', var_export( $settings, true ) )
-						)
+						),
+						true
 					);
 				}
 			}
@@ -109,7 +110,8 @@ class SassUtil {
 								__LINE__,
 								'$settings',
 								str_replace( "\n", '\n', var_export( $settings, true ) )
-							)
+							),
+							true
 						);
 					}
 

--- a/extensions/wikia/SASS/SassUtil.php
+++ b/extensions/wikia/SASS/SassUtil.php
@@ -56,6 +56,7 @@ class SassUtil {
 	 */
 	public static function getOasisSettings() {
 		global $wgOasisThemes, $wgContLang;
+		global $wgEnableSassUtilLogging;
 		wfProfileIn(__METHOD__);
 
 		// Load the 5 deafult colors by theme here (eg: in case the wiki has an override but the user doesn't have overrides).
@@ -64,6 +65,21 @@ class SassUtil {
 		if (empty($oasisSettings)) {
 			$themeSettings = new ThemeSettings();
 			$settings = $themeSettings->getSettings();
+
+			if ( !empty( $wgEnableSassUtilLogging ) ) {
+				if ( empty( $settings["background-image-width"] ) || empty( $settings["background-image-height"] ) ) {
+					Wikia::log(
+						__METHOD__,
+						false,
+						sprintf( "In %s@%s, %s has value %s",
+							__CLASS__,
+							__LINE__,
+							'$settings',
+							str_replace( "\n", '\n', var_export( $settings, true ) )
+						)
+					);
+				}
+			}
 
 			$oasisSettings["color-body"] = self::sanitizeColor($settings["color-body"]);
 			$oasisSettings["color-page"] = self::sanitizeColor($settings["color-page"]);
@@ -83,6 +99,19 @@ class SassUtil {
 				if ( !empty($bgImage) ) {
 					$settings["background-image-width"] = $oasisSettings["background-image-width"] = $bgImage->getWidth();
 					$settings["background-image-height"] = $oasisSettings["background-image-height"] = $bgImage->getHeight();
+
+					if ( !empty( $wgEnableSassUtilLogging ) ) {
+						Wikia::log(
+							__METHOD__,
+							false,
+							sprintf( "In %s@%s (to be set), %s has value %s",
+								__CLASS__,
+								__LINE__,
+								'$settings',
+								str_replace( "\n", '\n', var_export( $settings, true ) )
+							)
+						);
+					}
 
 					$themeSettings->saveSettings($settings);
 				}


### PR DESCRIPTION
The code block gated by
!empty($settings["background-image-width"]) && !empty($settings["background-image-height"])
should never execute.
However, it gets executed, so we need to find out why.

The logging can be turned on and off with a variable.

This will be removed right after defect is fixed.
