### PR TITLE
don't re-build image list for image serving

### DIFF
--- a/extensions/wikia/ImageServing/imageServingHelper.class.php
+++ b/extensions/wikia/ImageServing/imageServingHelper.class.php
@@ -15,18 +15,11 @@ class ImageServingHelper {
 	 */
 	public static function onLinksUpdateComplete( $linksUpdate ) {
 		wfProfileIn(__METHOD__);
-		$images = $linksUpdate->getImages();
+
 		$articleId = $linksUpdate->getTitle()->getArticleID();
+		$images = array_keys($linksUpdate->getImages());
+		self::buildIndex( $articleId, $images);
 
-		if(count($images) === 1) {
-			$images = array_keys($images);
-			self::buildIndex( $articleId, $images);
-			wfProfileOut(__METHOD__);
-			return true;
-		}
-
-		$article = new Article($linksUpdate->getTitle());
-		self::buildAndGetIndex( $article );
 		wfProfileOut(__METHOD__);
 		return true;
 	}


### PR DESCRIPTION
@Wikia/platform-team 
https://wikia-inc.atlassian.net/browse/BAC-708

ImageServing builds up the same list of images in the same order as what LinksUpdate builds, so we should use that list instead of building it up again. Only difference is that ImageServing can have an image listed multiple times if it shows up on a page multiple times, but it seems like the consumer of ImageServing could see that as a mistake, but please correct me if I'm wrong on that and I'll update to account for that.
