### PR TITLE
Chat: fix lazy loading issue

### DIFF
--- a/skins/oasis/js/LazyRail.js
+++ b/skins/oasis/js/LazyRail.js
@@ -35,7 +35,7 @@ $(function() {
 					});
 				}
 
-				if ( window.ChatEntryPoint ) {
+				if ( window.ChatEntryPoint && typeof window.wgWikiaChatUsers !== 'undefined' ) {
 					window.ChatEntryPoint.init();
 				}
 


### PR DESCRIPTION
ChatEntryPoint is loaded on every wiki, but we want to initialize the module only when chat is enabled
