### PR TITLE
Added limit for registerd accounts per email

### DIFF
--- a/extensions/wikia/UserLogin/UserLogin.setup.php
+++ b/extensions/wikia/UserLogin/UserLogin.setup.php
@@ -38,6 +38,7 @@ $wgHooks['PreferencesGetEmailAuthentication'][] = 'UserLoginHooksHelper::onGetEm
 $wgHooks['isValidEmailAddr'][] = 'UserLoginHooksHelper::isValidEmailAddr';
 $wgHooks['SavePreferences'][] = 'UserLoginHooksHelper::onSavePreferences';
 $wgHooks['AddNewAccount'][] = 'UserLoginHooksHelper::onAddNewAccount';
+$wgHooks['ConfirmEmailComplete'][] = 'UserLoginHooksHelper::onConfirmEmailComplete';
 // i18n mapping
 $wgExtensionMessagesFiles['UserLogin'] = $dir . 'UserLogin.i18n.php';
 $wgExtensionMessagesFiles['UserSignup'] = $dir . 'UserSignup.i18n.php';

--- a/extensions/wikia/UserLogin/UserLoginForm.class.php
+++ b/extensions/wikia/UserLogin/UserLoginForm.class.php
@@ -212,7 +212,7 @@ class UserLoginForm extends LoginForm {
 			$key = wfSharedMemcKey( "UserLogin", "AccountsPerEmail", $sEmail );
 			$count = $wgMemc->get($key);
 			if ( $count !== false
-				&& (int)$count > (int)$wgAccountsPerEmail
+				&& (int)$count >= (int)$wgAccountsPerEmail
 			) {
 				$this->mainLoginForm( wfMessage( 'userlogin-error-userlogin-unable-info' )->escaped(), 'error', 'email' );
 				return false;

--- a/extensions/wikia/UserLogin/UserLoginForm.class.php
+++ b/extensions/wikia/UserLogin/UserLoginForm.class.php
@@ -196,6 +196,31 @@ class UserLoginForm extends LoginForm {
 		return true;
 	}
 
+	/**
+	 * Validates email in terms of maximum registrations per email limit
+	 *
+	 * @return bool
+	 */
+	public function initValidationRegsPerEmail() {
+		global $wgAccountsPerEmail, $wgMemc;
+
+		$sEmail = $this->mEmail;
+		if ( isset( $wgAccountsPerEmail )
+			&& is_numeric( $wgAccountsPerEmail )
+			&& !UserLoginHooksHelper::isWikiaEmail( $sEmail )
+		) {
+			$key = wfSharedMemcKey( "UserLogin", "AccountsPerEmail", $sEmail );
+			$count = $wgMemc->get($key);
+			if ( $count !== false
+				&& (int)$count > (int)$wgAccountsPerEmail
+			) {
+				$this->mainLoginForm( wfMessage( 'userlogin-error-userlogin-unable-info' )->escaped(), 'error', 'email' );
+				return false;
+			}
+		}
+		return true;
+	}
+
 	public function addNewAccountInternal() {
 		if (!$this->initValidationUsername()) {
 			return false;

--- a/extensions/wikia/UserLogin/UserLoginHooksHelper.class.php
+++ b/extensions/wikia/UserLogin/UserLoginHooksHelper.class.php
@@ -2,6 +2,8 @@
 
 class UserLoginHooksHelper {
 
+	const WIKIA_EMAIL_DOMAIN = "@wikia-inc.com";
+
 	// set default user options and perform other actions after account creation
 	public static function onAddNewAccount( User $user, $byEmail ) {
 		$user->setOption( 'marketingallowed', 1 );
@@ -151,4 +153,64 @@ class UserLoginHooksHelper {
 		return true;
 	}
 
+	/**
+	 * Checks if Email belongs to the wikia domain;
+	 *
+	 * @param string $sEmail Email to check
+	 * @static
+	 * @return bool
+	 */
+	public static function isWikiaEmail( $sEmail ) {
+		return substr( $sEmail, strpos( $sEmail, '@' ) ) == self::WIKIA_EMAIL_DOMAIN;
+	}
+
+	/**
+	 * Returns number of activated accounts for specific email address
+	 *
+	 * @param mixed $sEmail
+	 * @static
+	 * @return integer
+	 */
+	public static function getUsersPerEmailFromDB( $sEmail ) {
+		wfProfileIn( __METHOD__ );
+		$dbw = wfGetDB( DB_SLAVE );
+		$iCount = $dbw->selectField( 'user',
+			'count(*)',
+			array(
+				'user_email' => $sEmail,
+				'user_email_authenticated IS NOT NULL',
+		    )
+		);
+		wfProfileOut( __METHOD__ );
+		return $iCount;
+	}
+
+	/**
+	 * Keeps count of registered accounts with same email
+	 *
+	 * @param User $user
+	 * @static
+	 * @return bool
+	 */
+	public static function onConfirmEmailComplete( User $user ) {
+		global $wgAccountsPerEmail, $wgMemc;
+		$sEmail = $user->getEmail();
+		if ( isset( $wgAccountsPerEmail )
+			&& is_numeric( $wgAccountsPerEmail )
+			&& !self::isWikiaEmail( $sEmail )
+		) {
+			$key = wfSharedMemcKey( "UserLogin", "AccountsPerEmail", $sEmail );
+			$iCount = $wgMemc->get( $key );
+			if ( $iCount === false ) {
+				$iCount = self::getUsersPerEmailFromDB( $sEmail );
+				if ( $iCount > 0 ) {
+					$wgMemc->set( $key, $iCount );
+				}
+			} else {
+				$wgMemc->incr( $key );
+			}
+		}
+        return true;
+	}
 }
+

--- a/extensions/wikia/UserLogin/UserSignupSpecialController.class.php
+++ b/extensions/wikia/UserLogin/UserSignupSpecialController.class.php
@@ -479,7 +479,8 @@ class UserSignupSpecialController extends WikiaSpecialPageController {
 				$response = $signupForm->initValidationPassword();
 				break;
 			case 'email' :
-				$response = $signupForm->initValidationEmail();
+				$response = $signupForm->initValidationEmail()
+					&& $signupForm->initValidationRegsPerEmail();
 				break;
 			case 'birthdate' :
 				$response = $signupForm->initValidationBirthdate();


### PR DESCRIPTION
Introduced new global variable $wgAccountsPerEmail which holds the number of accounts allowed per email for non-Wikia emails.
