### PR TITLE
BAC-854: use $wgImagesDomainSharding in wfReplaceImageServer

### DIFF
--- a/includes/wikia/GlobalFunctions.php
+++ b/includes/wikia/GlobalFunctions.php
@@ -153,13 +153,13 @@ function wfReplaceImageServer( $url, $timestamp = false ) {
 			// RT#98969 if the url already has a cb value, don't add another one...
 			$cb = ($timestamp!='' && strpos($url, "__cb") === false) ? "__cb{$timestamp}/" : '';
 
-			// TODO: support domain sharding on devboxes
 			if (!empty($wg->DevBoxImageServerOverride)) {
 				// Dev boxes
+				// TODO: support domains sharding on devboxes
 				$url = str_replace('http://images.wikia.com/', sprintf("http://{$wg->DevBoxImageServerOverride}/%s", $cb), $url);
 			} else {
 				// Production
-				$url = str_replace('http://images.wikia.com/', sprintf("http://images%s.wikia.nocookie.net/%s",$serverNo, $cb), $url);
+				$url = str_replace('http://images.wikia.com/', sprintf("http://{$wg->ImagesDomainSharding}/%s",$serverNo, $cb), $url);
 			}
 		}
 	} else if (!empty($wg->DevBoxImageServerOverride)) {


### PR DESCRIPTION
We need to a way to change a pattern used for sharding images domain for wikis with Swift storage enabled and disabled.

@Wikia/platform-team @moliwikia 

Merge together with https://github.com/Wikia/config/pull/225 (sets `$wgImagesDomainSharding`)
