### PR TITLE
Commented hardcoded tabindex in ConfirmEdit for reCAPTCHA

### DIFF
--- a/extensions/ConfirmEdit/ReCaptcha.class.php
+++ b/extensions/ConfirmEdit/ReCaptcha.class.php
@@ -13,7 +13,7 @@ class ReCaptcha extends SimpleCaptcha {
 		global $wgReCaptchaPublicKey, $wgReCaptchaTheme;
 
 		$useHttps = ( isset( $_SERVER['HTTPS'] ) && $_SERVER['HTTPS'] == 'on' );
-		$js = 'var RecaptchaOptions = ' . Xml::encodeJsVar( array( 'theme' => $wgReCaptchaTheme, 'tabindex' => 1  ) );
+		$js = 'var RecaptchaOptions = ' . Xml::encodeJsVar( array( 'theme' => $wgReCaptchaTheme /*Wikia change */ /*, 'tabindex' => 1 */ /*Wikia change end*/) );
 
 		return Html::inlineScript( $js ) . recaptcha_get_html( $wgReCaptchaPublicKey, $this->recaptcha_error, $useHttps );
 	}


### PR DESCRIPTION
The tabindex option for reCAPTCHA is optional (https://developers.google.com/recaptcha/docs/customization). In ConfirmEdit it's hardcoded to 1, which breaks the tabindex flow in the browser. Removing the option allows the browser to decide and leads to the desired result.
