### PR TITLE
Use numeric unsupervised topics in ad serving

### DIFF
--- a/extensions/wikia/NLP/classes/Entities/Hooks.php
+++ b/extensions/wikia/NLP/classes/Entities/Hooks.php
@@ -18,7 +18,7 @@ class Hooks
 	 * @return boolean
 	 */
 	public static function onArticleViewHeader( &$article, &$outputDone, &$pcache ) {
-		return (new WikiEntitiesService)->registerEntitiesWithDFP();
+		return (new WikiEntitiesService)->registerLdaTopicsWithDFP();
 	}
 	
 }

--- a/extensions/wikia/NLP/classes/Entities/PageEntitiesService.php
+++ b/extensions/wikia/NLP/classes/Entities/PageEntitiesService.php
@@ -32,23 +32,6 @@ class PageEntitiesService
 	}
 	
 	/**
-	 * Responsible for storing page entities
-	 * @return bool
-	 */
-	public function registerEntitiesWithDFP() {
-		$mwService = $this->getMwService();
-		$entityList = $this->getEntitiesForPage( $mwService->getGlobal( 'ArticleId' ) );
-		if ( count( $entityList ) ) {
-			$keyValues = explode( ';', $mwService->getGlobalWithDefault( 'wgDartCustomKeyValues', '' ) );
-			foreach ( $entityList as &$val ) {
-				$val = sprintf( 'pageentities=%s', substr( $val, 0, 20 ) );
-			}
-			$mwService->setGlobal( 'wgDartCustomKeyValues', implode( ';', array_merge( $keyValues, $entityList ) ) );
-		}
-		return true;
-	}
-	
-	/**
 	 * Dependency lazy-loader.
 	 * @return \Wikia\Search\MediaWikiService
 	 */

--- a/extensions/wikia/NLP/classes/Test/Entities/WikiEntitiesServiceTest.php
+++ b/extensions/wikia/NLP/classes/Test/Entities/WikiEntitiesServiceTest.php
@@ -44,18 +44,41 @@ class WikiEntitiesServiceTest extends WikiaBaseTest
 		);
 	}
 	
+
+	/**
+	 * @covers Wikia\NLP\Entities\WikiEntitiesService::getLdaTopics
+	 */
+	public function testGetLdaTopics() {
+		$service = $this->getMock( self::CLASSNAME, [ 'getMwService' ] );
+		$mwService = $this->getMock( 'Wikia\Search\MediaWikiService', [ 'getGlobalWithDefault' ] );
+
+		$topics = [ 111, 235, 24 ];
+		
+		$service
+		    ->expects( $this->once() )
+		    ->method ( 'getMwService' )
+		    ->will   ( $this->returnValue( $mwService ) ) 
+		;
+		$mwService
+		    ->expects( $this->once() )
+		    ->method ( 'getGlobalWithDefault' )
+		    ->with   ( 'WikiLdaTopics', [] )
+		    ->will   ( $this->returnValue( $topics ) )
+		;
+		$this->assertEquals(
+				$topics,
+				$service->getLdaTopics()
+		);
+	}
+	
 	/**
 	 * @covers Wikia\NLP\Entities\WikiEntitiesService::registerEntitiesWithDFP
 	 */
-	public function testRegisterEntitiesWithDFP() {
-		$service = $this->getMock( self::CLASSNAME, [ 'getMwService', 'getEntityList' ] );
+	public function testLdaTopicsWithDFP() {
+		$service = $this->getMock( self::CLASSNAME, [ 'getMwService', 'getLdaTopics' ] );
 		$mwService = $this->getMock( 'Wikia\Search\MediaWikiService', [ 'getGlobalWithDefault', 'setGlobal' ] );
 
-		$entities = [ 'foo', 'bar', 'baz' ];
-		$entitiesTruncated = $entities;
-		$entities[] = str_pad('', 22, 'a' );
-		$entitiesTruncated[] = substr( end( $entities ), 0, 20 );
-
+		$topics = [111, 222, 333, 444, 555, 666];
 		$kvs = 'foo=bar;baz=qux';
 		
 		$service
@@ -65,8 +88,8 @@ class WikiEntitiesServiceTest extends WikiaBaseTest
 		;
 		$service
 		    ->expects( $this->once() )
-		    ->method ( 'getEntityList' )
-		    ->will   ( $this->returnValue( $entities ) )
+		    ->method ( 'getLdaTopics' )
+		    ->will   ( $this->returnValue( $topics ) )
 		;
 		$mwService
 		    ->expects( $this->once() )
@@ -77,9 +100,9 @@ class WikiEntitiesServiceTest extends WikiaBaseTest
 		$mwService
 		    ->expects( $this->once() )
 		    ->method ( 'setGlobal' )
-		    ->with   ( 'wgDartCustomKeyValues', $kvs . ';wikientities=foo;wikientities=bar;wikientities=baz;wikientities=' . end($entitiesTruncated) )
+		    ->with   ( 'wgDartCustomKeyValues', $kvs . ';wtpx=111;wtpx=222;wtpx=333;wtpx=444;wtpx=555' )
 		;
-		$this->assertTrue( $service->registerEntitiesWithDFP() );
+		$this->assertTrue( $service->registerLdaTopicsWithDFP() );
 	}
 	
 }


### PR DESCRIPTION
This is an update to last week's pull request for using entities. Since we want to be economical about the size of the data we're sending to DFP, we're scrapping the string value for entities for a compressed, vectorized approach.

For the top 5,000 WAM wikis, we're extracting the top 50 wiki entities and top 50 sentence-scoped syntactic heads (usually verbs) from each wiki. Those values are transformed into a vector for each wiki. The vector dimensionality is then reduced using latent Dirichlet allocation. This is an unsupervised learning algorithm that has been shown to work excellently against natural language data sets. We explicitly asked for 999 topics, because a high number of topics has been shown to [work well for ad targeting](http://www.academia.edu/1616507/Topic_Models_for_Retrieving_Relevant_Ads).

These topics, which range from 0 to 1 as a measure of "intensity", as it were, are injected  into a wikifactory variable as a serialized array. That array is basically pushed into the "wtpx" key.

The average number of topics each wiki has is 18 (out of 999), but since we're trying to be space-constrained, we're only transmitting the top 5.
