### PR TITLE
UploadBase: Images showing as 0 bytes

### DIFF
--- a/includes/upload/UploadBase.php
+++ b/includes/upload/UploadBase.php
@@ -134,6 +134,7 @@ abstract class UploadBase {
 			return null;
 		}
 
+		/* @var UploadFromFile $handler */
 		$handler = new $className;
 
 		$handler->initializeFromRequest( $request );
@@ -374,6 +375,14 @@ abstract class UploadBase {
 			wfProfileOut( __METHOD__ );
 			return $status;
 		}
+
+		// Wikia change - begin
+		// if filesize() returns 0, try to get the size from PHP upload info (BAC-773)
+		if ( empty( $this->mFileProps['size'] ) ) {
+			$this->mFileProps['size'] = $this->getFileSize();
+			Wikia::logBacktrace( __METHOD__ . '::sizeFallback::' . $this->getTitle()->getDBkey() );
+		}
+		// Wikia change - end
 
 		wfDebug( __METHOD__ . ": all clear; passing.\n" );
 		wfProfileOut( __METHOD__ );


### PR DESCRIPTION
`UploadBase` will try to fallback to PHP upload info data when `filesize()` returns 0.

https://wikia-inc.atlassian.net/browse/BAC-773

@Wikia/platform-team
