### PR TITLE
VE-467 fixing edit button on user blog pages

### DIFF
--- a/extensions/VisualEditor/wikia/modules/ve/init/ve.init.mw.WikiaViewPageTarget.init.js
+++ b/extensions/VisualEditor/wikia/modules/ve/init/ve.init.mw.WikiaViewPageTarget.init.js
@@ -20,7 +20,7 @@
  */
 ( function () {
 	var conf, tabMessages, uri, pageExists, viewUri, veEditUri, isViewPage,
-		init, support, getTargetDeferred, userPrefEnabled, $classicEditLink,
+		init, support, getTargetDeferred, userPrefEnabled, $edit,
 		plugins = [];
 
 	/**
@@ -57,19 +57,13 @@
 	}
 
 	conf = mw.config.get( 'wgVisualEditorConfig' );
-
 	tabMessages = conf.tabMessages;
-
 	uri = new mw.Uri( location.href );
-
 	// For special pages, no information about page existence is exposed to
 	// mw.config, so we assume it exists TODO: fix this in core.
 	pageExists = !!mw.config.get( 'wgArticleId' ) || mw.config.get( 'wgNamespaceNumber' ) < 0;
-
 	viewUri = new mw.Uri( mw.util.wikiGetlink( mw.config.get( 'wgRelevantPageName' ) ) );
-
 	veEditUri = viewUri.clone().extend( { 'veaction': 'edit' } );
-
 	isViewPage = (
 		mw.config.get( 'wgIsArticle' ) &&
 		!( 'diff' in uri.query )
@@ -269,10 +263,10 @@
 	mw.libs.ve = init;
 
 	if ( !init.isAvailable ) {
-		$classicEditLink = $( '#ca-edit' );
+		$edit = $( '#ca-edit' );
 		$( 'html' ).addClass( 've-not-available' );
-		$( '#ca-ve-edit' ).attr( 'href', $classicEditLink.attr( 'href' ) );
-		$classicEditLink.parent().remove();
+		$( '#ca-ve-edit' ).attr( 'href', $edit.attr( 'href' ) );
+		$edit.parent().remove();
 	} else {
 		$( 'html' ).addClass( 've-available' );
 	}

--- a/extensions/VisualEditor/wikia/modules/ve/init/ve.init.mw.WikiaViewPageTarget.init.js
+++ b/extensions/VisualEditor/wikia/modules/ve/init/ve.init.mw.WikiaViewPageTarget.init.js
@@ -20,7 +20,7 @@
  */
 ( function () {
 	var conf, tabMessages, uri, pageExists, viewUri, veEditUri, isViewPage,
-		init, support, getTargetDeferred, userPrefEnabled,
+		init, support, getTargetDeferred, userPrefEnabled, classicEditButton,
 		plugins = [];
 
 	/**
@@ -57,13 +57,19 @@
 	}
 
 	conf = mw.config.get( 'wgVisualEditorConfig' );
+
 	tabMessages = conf.tabMessages;
+
 	uri = new mw.Uri( location.href );
+
 	// For special pages, no information about page existence is exposed to
 	// mw.config, so we assume it exists TODO: fix this in core.
 	pageExists = !!mw.config.get( 'wgArticleId' ) || mw.config.get( 'wgNamespaceNumber' ) < 0;
+
 	viewUri = new mw.Uri( mw.util.wikiGetlink( mw.config.get( 'wgRelevantPageName' ) ) );
+
 	veEditUri = viewUri.clone().extend( { 'veaction': 'edit' } );
+
 	isViewPage = (
 		mw.config.get( 'wgIsArticle' ) &&
 		!( 'diff' in uri.query )
@@ -163,7 +169,7 @@
 		},
 
 		setupSectionLinks: function () {
-			$( '#mw-content-text .editsection a' ).click( init.onEditSectionLinkClick );
+			$( '#mw-content-text' ).find( '.editsection a' ).click( init.onEditSectionLinkClick );
 		},
 
 		onEditTabClick: function ( e ) {
@@ -263,9 +269,10 @@
 	mw.libs.ve = init;
 
 	if ( !init.isAvailable ) {
+		classicEditButton = $( '#ca-edit' );
 		$( 'html' ).addClass( 've-not-available' );
-		$( '#ca-ve-edit' ).attr( 'href', $( '#ca-edit' ).attr( 'href' ) );
-		$( '#ca-edit' ).parent().remove();
+		$( '#ca-ve-edit' ).attr( 'href', classicEditButton.attr( 'href' ) );
+		classicEditButton.parent().remove();
 	} else {
 		$( 'html' ).addClass( 've-available' );
 	}

--- a/extensions/VisualEditor/wikia/modules/ve/init/ve.init.mw.WikiaViewPageTarget.init.js
+++ b/extensions/VisualEditor/wikia/modules/ve/init/ve.init.mw.WikiaViewPageTarget.init.js
@@ -20,7 +20,7 @@
  */
 ( function () {
 	var conf, tabMessages, uri, pageExists, viewUri, veEditUri, isViewPage,
-		init, support, getTargetDeferred, userPrefEnabled, classicEditButton,
+		init, support, getTargetDeferred, userPrefEnabled, $classicEditLink,
 		plugins = [];
 
 	/**
@@ -269,10 +269,10 @@
 	mw.libs.ve = init;
 
 	if ( !init.isAvailable ) {
-		classicEditButton = $( '#ca-edit' );
+		$classicEditLink = $( '#ca-edit' );
 		$( 'html' ).addClass( 've-not-available' );
-		$( '#ca-ve-edit' ).attr( 'href', classicEditButton.attr( 'href' ) );
-		classicEditButton.parent().remove();
+		$( '#ca-ve-edit' ).attr( 'href', $classicEditLink.attr( 'href' ) );
+		$classicEditLink.parent().remove();
 	} else {
 		$( 'html' ).addClass( 've-available' );
 	}

--- a/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaMediaInsertDialog.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaMediaInsertDialog.js
@@ -47,13 +47,13 @@ ve.ui.WikiaMediaInsertDialog.prototype.initialize = function () {
 	this.removeButton = new ve.ui.ButtonWidget( {
 		'$$': this.frame.$$,
 		'label': 'Remove from the cart', //TODO: i18n
-		'flags': ['destructive']
+		'flags': [ 'destructive' ]
 	} );
 	this.removeButton.$.appendTo( this.$removePage );
 	this.insertButton = new ve.ui.ButtonWidget( {
 		'$$': this.$$,
 		'label': ve.msg( 'visualeditor-wikiamediainsertbuttontool-label' ),
-		'flags': ['primary']
+		'flags': [ 'primary' ]
 	} );
 	this.insertionDetails = {};
 
@@ -83,8 +83,8 @@ ve.ui.WikiaMediaInsertDialog.prototype.onSearchSelect = function ( item ) {
 	}
 	cartItems = ve.copy( this.cartModel.getItems() );
 	for ( i = 0; i < cartItems.length; i++ ) {
-		if ( cartItems[i].title === item.title ) {
-			this.cartModel.removeItems( [ cartItems[i] ] );
+		if ( cartItems[ i ].title === item.title ) {
+			this.cartModel.removeItems( [ cartItems[ i ] ] );
 		}
 	}
 	this.cartModel.addItems( [
@@ -138,7 +138,7 @@ ve.ui.WikiaMediaInsertDialog.prototype.insertMedia = function ( cartItems ) {
 
 	// Populates attributes, items.video and items.photo
 	for ( i = 0; i < cartItems.length; i++ ) {
-		cartItem = cartItems[i];
+		cartItem = cartItems[ i ];
 		attributes[ cartItem.title ] = {
 			'title': cartItem.title,
 			'type': cartItem.type
@@ -149,10 +149,10 @@ ve.ui.WikiaMediaInsertDialog.prototype.insertMedia = function ( cartItems ) {
 	function updateImageinfo( results ) {
 		var i, result;
 		for ( i = 0; i < results.length; i++ ) {
-			result = results[i];
-			attributes[result.title].height = result.height;
-			attributes[result.title].width = result.width;
-			attributes[result.title].url = result.url;
+			result = results[ i ];
+			attributes[ result.title ].height = result.height;
+			attributes[ result.title ].width = result.width;
+			attributes[ result.title ].url = result.url;
 		}
 	}
 
@@ -175,8 +175,8 @@ ve.ui.WikiaMediaInsertDialog.prototype.insertMedia = function ( cartItems ) {
 	}
 
 	function updateAvatar( result ) {
-		attributes[result.title].avatar = result.avatar;
-		attributes[result.title].username = result.username;
+		attributes[ result.title ].avatar = result.avatar;
+		attributes[ result.title ].username = result.username;
 	}
 
 	// Attribution request
@@ -203,7 +203,7 @@ ve.ui.WikiaMediaInsertDialog.prototype.insertMedia = function ( cartItems ) {
 ve.ui.WikiaMediaInsertDialog.prototype.insertMediaCallback = function ( attributes ) {
 	var title, type, item, items = [];
 	for ( title in attributes ) {
-		item = attributes[title];
+		item = attributes[ title ];
 		if ( item.type === 'photo' ) {
 			type = 'wikiaBlockImage';
 		} else if ( item.type === 'video' ) {
@@ -276,7 +276,7 @@ ve.ui.WikiaMediaInsertDialog.prototype.getImageInfo = function ( titles, width )
 			'iiurlwidth': width,
 			'iiprop': 'url',
 			'indexpageids': 'true',
-			'titles': titles.join('|')
+			'titles': titles.join( '|' )
 		},
 		'success': ve.bind( this.onGetImageInfoSuccess, this, deferred )
 	} );
@@ -293,12 +293,12 @@ ve.ui.WikiaMediaInsertDialog.prototype.getImageInfo = function ( titles, width )
 ve.ui.WikiaMediaInsertDialog.prototype.onGetImageInfoSuccess = function ( deferred, data ) {
 	var results = [], item, i;
 	for ( i = 0; i < data.query.pageids.length; i++ ) {
-		item = data.query.pages[ data.query.pageids[i] ];
+		item = data.query.pages[ data.query.pageids[ i ] ];
 		results.push( {
 			'title': item.title,
-			'height': item.imageinfo[0].thumbheight,
-			'width': item.imageinfo[0].thumbwidth,
-			'url': item.imageinfo[0].thumburl
+			'height': item.imageinfo[ 0 ].thumbheight,
+			'width': item.imageinfo[ 0 ].thumbwidth,
+			'url': item.imageinfo[ 0 ].thumburl
 		} );
 	}
 	deferred.resolve( results );

--- a/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaMediaInsertDialog.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaMediaInsertDialog.js
@@ -276,7 +276,7 @@ ve.ui.WikiaMediaInsertDialog.prototype.getImageInfo = function ( titles, width )
 			'iiurlwidth': width,
 			'iiprop': 'url',
 			'indexpageids': 'true',
-			'titles': titles.join('|')
+			'titles': titles.join( '|' )
 		},
 		'success': ve.bind( this.onGetImageInfoSuccess, this, deferred )
 	} );

--- a/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaMediaInsertDialog.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaMediaInsertDialog.js
@@ -47,13 +47,13 @@ ve.ui.WikiaMediaInsertDialog.prototype.initialize = function () {
 	this.removeButton = new ve.ui.ButtonWidget( {
 		'$$': this.frame.$$,
 		'label': 'Remove from the cart', //TODO: i18n
-		'flags': [ 'destructive' ]
+		'flags': ['destructive']
 	} );
 	this.removeButton.$.appendTo( this.$removePage );
 	this.insertButton = new ve.ui.ButtonWidget( {
 		'$$': this.$$,
 		'label': ve.msg( 'visualeditor-wikiamediainsertbuttontool-label' ),
-		'flags': [ 'primary' ]
+		'flags': ['primary']
 	} );
 	this.insertionDetails = {};
 
@@ -83,8 +83,8 @@ ve.ui.WikiaMediaInsertDialog.prototype.onSearchSelect = function ( item ) {
 	}
 	cartItems = ve.copy( this.cartModel.getItems() );
 	for ( i = 0; i < cartItems.length; i++ ) {
-		if ( cartItems[ i ].title === item.title ) {
-			this.cartModel.removeItems( [ cartItems[ i ] ] );
+		if ( cartItems[i].title === item.title ) {
+			this.cartModel.removeItems( [ cartItems[i] ] );
 		}
 	}
 	this.cartModel.addItems( [
@@ -138,7 +138,7 @@ ve.ui.WikiaMediaInsertDialog.prototype.insertMedia = function ( cartItems ) {
 
 	// Populates attributes, items.video and items.photo
 	for ( i = 0; i < cartItems.length; i++ ) {
-		cartItem = cartItems[ i ];
+		cartItem = cartItems[i];
 		attributes[ cartItem.title ] = {
 			'title': cartItem.title,
 			'type': cartItem.type
@@ -149,10 +149,10 @@ ve.ui.WikiaMediaInsertDialog.prototype.insertMedia = function ( cartItems ) {
 	function updateImageinfo( results ) {
 		var i, result;
 		for ( i = 0; i < results.length; i++ ) {
-			result = results[ i ];
-			attributes[ result.title ].height = result.height;
-			attributes[ result.title ].width = result.width;
-			attributes[ result.title ].url = result.url;
+			result = results[i];
+			attributes[result.title].height = result.height;
+			attributes[result.title].width = result.width;
+			attributes[result.title].url = result.url;
 		}
 	}
 
@@ -175,8 +175,8 @@ ve.ui.WikiaMediaInsertDialog.prototype.insertMedia = function ( cartItems ) {
 	}
 
 	function updateAvatar( result ) {
-		attributes[ result.title ].avatar = result.avatar;
-		attributes[ result.title ].username = result.username;
+		attributes[result.title].avatar = result.avatar;
+		attributes[result.title].username = result.username;
 	}
 
 	// Attribution request
@@ -203,7 +203,7 @@ ve.ui.WikiaMediaInsertDialog.prototype.insertMedia = function ( cartItems ) {
 ve.ui.WikiaMediaInsertDialog.prototype.insertMediaCallback = function ( attributes ) {
 	var title, type, item, items = [];
 	for ( title in attributes ) {
-		item = attributes[ title ];
+		item = attributes[title];
 		if ( item.type === 'photo' ) {
 			type = 'wikiaBlockImage';
 		} else if ( item.type === 'video' ) {
@@ -276,7 +276,7 @@ ve.ui.WikiaMediaInsertDialog.prototype.getImageInfo = function ( titles, width )
 			'iiurlwidth': width,
 			'iiprop': 'url',
 			'indexpageids': 'true',
-			'titles': titles.join( '|' )
+			'titles': titles.join('|')
 		},
 		'success': ve.bind( this.onGetImageInfoSuccess, this, deferred )
 	} );
@@ -293,12 +293,12 @@ ve.ui.WikiaMediaInsertDialog.prototype.getImageInfo = function ( titles, width )
 ve.ui.WikiaMediaInsertDialog.prototype.onGetImageInfoSuccess = function ( deferred, data ) {
 	var results = [], item, i;
 	for ( i = 0; i < data.query.pageids.length; i++ ) {
-		item = data.query.pages[ data.query.pageids[ i ] ];
+		item = data.query.pages[ data.query.pageids[i] ];
 		results.push( {
 			'title': item.title,
-			'height': item.imageinfo[ 0 ].thumbheight,
-			'width': item.imageinfo[ 0 ].thumbwidth,
-			'url': item.imageinfo[ 0 ].thumburl
+			'height': item.imageinfo[0].thumbheight,
+			'width': item.imageinfo[0].thumbwidth,
+			'url': item.imageinfo[0].thumburl
 		} );
 	}
 	deferred.resolve( results );

--- a/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaMediaInsertDialog.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaMediaInsertDialog.js
@@ -276,7 +276,7 @@ ve.ui.WikiaMediaInsertDialog.prototype.getImageInfo = function ( titles, width )
 			'iiurlwidth': width,
 			'iiprop': 'url',
 			'indexpageids': 'true',
-			'titles': titles.join('|'),
+			'titles': titles.join('|')
 		},
 		'success': ve.bind( this.onGetImageInfoSuccess, this, deferred )
 	} );

--- a/skins/oasis/modules/UserPagesHeaderController.class.php
+++ b/skins/oasis/modules/UserPagesHeaderController.class.php
@@ -472,7 +472,6 @@ class UserPagesHeaderController extends WikiaController {
 		}
 		else if (isset($this->content_actions['edit'])) {
 			$actionMenu['action'] = $this->content_actions['edit'];
-			//$actionMenu['action'] = $this->content_actions['ve-edit'];
 		}
 
 		foreach($dropdownActions as $action) {

--- a/skins/oasis/modules/UserPagesHeaderController.class.php
+++ b/skins/oasis/modules/UserPagesHeaderController.class.php
@@ -24,59 +24,59 @@ class UserPagesHeaderController extends WikiaController {
 	/**
 	 * Checks whether given user name is the current user
 	 */
-	public static function isItMe($userName) {
+	public static function isItMe( $userName ) {
 		global $wgUser;
-		return $wgUser->isLoggedIn() && ($userName == $wgUser->getName());
+		return $wgUser->isLoggedIn() && ( $userName == $wgUser->getName() );
 	}
 
 	/**
 	 * Get name of the user this page referrs to
 	 */
-	public static function getUserName(Title $title, $namespaces, $fallbackToGlobal = true) {
-		wfProfileIn(__METHOD__);
+	public static function getUserName( Title $title, $namespaces, $fallbackToGlobal = true ) {
+		wfProfileIn( __METHOD__ );
 		global $wgUser, $wgRequest;
 
 		$userName = null;
 
-		if (in_array($title->getNamespace(), $namespaces)) {
+		if ( in_array( $title->getNamespace(), $namespaces ) ) {
 			// get "owner" of this user / user talk / blog page
 			$parts = explode('/', $title->getText());
 		}
-		else if ($title->getNamespace() == NS_SPECIAL) {
-				if ($title->isSpecial( 'Following' ) || $title->isSpecial( 'Contributions' )) {
+		else if( $title->getNamespace() == NS_SPECIAL ) {
+				if( $title->isSpecial( 'Following' ) || $title->isSpecial( 'Contributions' )) {
 					$target = $wgRequest->getText('target');
-					if ($target != '') {
+					if( $target != '' ) {
 						// /wiki/Special:Contributions?target=FooBar (RT #68323)
-						$parts = array($target);
+						$parts = array( $target );
 					}
 					else {
 						// get user this special page referrs to
-						$parts = explode('/', $wgRequest->getText('title', false));
+						$parts = explode( '/', $wgRequest->getText( 'title', false ) );
 
 						// remove special page name
-						array_shift($parts);
+						array_shift( $parts );
 					}
 				}
 			}
 
-		if (isset($parts[0]) && $parts[0] != '') {
+		if ( isset( $parts[0] ) && $parts[0] != '' ) {
 			//this line was usign urldecode($parts[0]) before, see RT #107278, user profile pages with '+' symbols get 'non-existing' message
-			$userName = str_replace('_', ' ', $parts[0] );
+			$userName = str_replace( '_', ' ', $parts[0] );
 		}
 		elseif ( $fallbackToGlobal ) {
 			// fallback value
 			$userName = $wgUser->getName();
 		}
 
-		wfProfileOut(__METHOD__);
+		wfProfileOut( __METHOD__ );
 		return $userName;
 	}
 
 	/**
 	 * Get list of links for given username to be shown as tabs
 	 */
-	private function getTabs($userName) {
-		wfProfileIn(__METHOD__);
+	private function getTabs( $userName ) {
+		wfProfileIn( __METHOD__ );
 		global $wgTitle, $wgEnableWikiaFollowedPages;
 
 		$tabs = array();
@@ -84,123 +84,123 @@ class UserPagesHeaderController extends WikiaController {
 
 		// profile
 		$tabs[] = array(
-				'link' => Wikia::link(Title::newFromText($userName, NS_USER), wfMsg('profile')),
+				'link' => Wikia::link( Title::newFromText( $userName, NS_USER ), wfMsg( 'profile' ) ),
 				'selected' => ($namespace == NS_USER),
 				'data-id' => 'profile',
 				);
 
 		// talk
 		$tabs[] = array(
-				'link' => Wikia::link(Title::newFromText($userName, NS_USER_TALK), wfMsg('talkpage')),
-				'selected' => ($namespace == NS_USER_TALK),
+				'link' => Wikia::link( Title::newFromText( $userName, NS_USER_TALK ), wfMsg( 'talkpage' ) ),
+				'selected' => ( $namespace == NS_USER_TALK ),
 				'data-id' => 'talk',
 				);
 
 		// blog
-		if (defined('NS_BLOG_ARTICLE') && !User::isIP($this->userName)) {
+		if( defined( 'NS_BLOG_ARTICLE' ) && !User::isIP( $this->userName ) ) {
 			$tabs[] = array(
-					'link' => Wikia::link(Title::newFromText($userName, NS_BLOG_ARTICLE), wfMsg('blog-page'), array(), array(), 'known'),
-					'selected' => ($namespace == NS_BLOG_ARTICLE),
-					'data-id' => 'blog',
-					);
+				'link' => Wikia::link( Title::newFromText( $userName, NS_BLOG_ARTICLE ), wfMsg( 'blog-page' ), array(), array(), 'known' ),
+				'selected' => ( $namespace == NS_BLOG_ARTICLE ),
+				'data-id' => 'blog',
+			);
 		}
 
 		// contribs
 		$tabs[] = array(
-				'link' => Wikia::link(SpecialPage::getTitleFor("Contributions/{$userName}"), wfMsg('contris_s')),
-				'selected' => ($wgTitle->isSpecial( 'Contributions' )),
-				'data-id' => 'contribs',
-				);
+			'link' => Wikia::link( SpecialPage::getTitleFor( "Contributions/{$userName}" ), wfMsg( 'contris_s' ) ),
+			'selected' => ( $wgTitle->isSpecial( 'Contributions' ) ),
+			'data-id' => 'contribs',
+		);
 
-		if (self::isItMe($userName)) {
+		if ( self::isItMe( $userName ) ) {
 			// following (only render when user is viewing his own user pages)
-			if (!empty($wgEnableWikiaFollowedPages)) {
+			if ( !empty( $wgEnableWikiaFollowedPages ) ) {
 				$tabs[] = array(
-						'link' => Wikia::link(SpecialPage::getTitleFor('Following'), wfMsg('wikiafollowedpages-following')),
-						'selected' => ($wgTitle->isSpecial( 'Following' )),
-						'data-id' => 'following',
-						);
+					'link' => Wikia::link( SpecialPage::getTitleFor( 'Following' ), wfMsg( 'wikiafollowedpages-following' ) ),
+					'selected' => ( $wgTitle->isSpecial( 'Following' ) ),
+					'data-id' => 'following',
+				);
 			}
 
 			// avatar dropdown menu
 			$this->avatarMenu = array(
-					Wikia::link(SpecialPage::getTitleFor('Preferences'), wfMsg('oasis-user-page-change-avatar'))
-					);
+				Wikia::link( SpecialPage::getTitleFor( 'Preferences' ), wfMsg( 'oasis-user-page-change-avatar' ) )
+			);
 		}
 
-		wfRunHooks( 'UserPagesHeaderModuleAfterGetTabs', array(&$tabs, $namespace, $userName) );
+		wfRunHooks( 'UserPagesHeaderModuleAfterGetTabs', array( &$tabs, $namespace, $userName ) );
 
-		wfProfileOut(__METHOD__);
+		wfProfileOut( __METHOD__ );
 		return $tabs;
 	}
 
 	/**
 	 * Get and format stats for given user
 	 */
-	private function getStats($userName) {
-		wfProfileIn(__METHOD__);
+	private function getStats( $userName ) {
+		wfProfileIn( __METHOD__ );
 		global $wgLang;
 
-		$user = User::newFromName($userName);
+		$user = User::newFromName( $userName );
 		$stats = array();
 
-		if (!empty($user) && $user->isLoggedIn()) {
-			$userStatsService = new UserStatsService($user->getId());
+		if ( !empty( $user ) && $user->isLoggedIn() ) {
+			$userStatsService = new UserStatsService( $user->getId() );
 			$stats = $userStatsService->getStats();
 
-			if (!empty($stats)) {
+			if ( !empty( $stats ) ) {
 				// date and points formatting
 				if ( !empty( $stats['date'] ) ) {
-					$stats['date'] = $wgLang->date(wfTimestamp(TS_MW, $stats['date']));
+					$stats['date'] = $wgLang->date( wfTimestamp( TS_MW, $stats['date'] ) );
 				}
-				$stats['edits'] = $wgLang->formatNum($stats['edits']);
+				$stats['edits'] = $wgLang->formatNum( $stats['edits'] );
 			}
 		}
 
-		wfProfileOut(__METHOD__);
+		wfProfileOut( __METHOD__ );
 		return $stats;
 	}
 
 	public function executeIndex() {
-		wfProfileIn(__METHOD__);
+		wfProfileIn( __METHOD__ );
 
 		global $wgTitle, $wgRequest, $wgUser, $wgOut, $wgCityId, $wgIsPrivateWiki;
 
 		//fb#1090
-		$this->isInternalWiki = empty($wgCityId);
+		$this->isInternalWiki = empty( $wgCityId );
 		$this->isUserAnon = $wgUser->isAnon();
 		$this->isPrivateWiki = $wgIsPrivateWiki;
 
 		$namespace = $wgTitle->getNamespace();
 
 		// get user name to display in header
-		$this->userName = self::getUserName($wgTitle, BodyController::getUserPagesNamespaces());
+		$this->userName = self::getUserName( $wgTitle, BodyController::getUserPagesNamespaces() );
 
 		// render avatar (100x100)
-		$this->avatar = AvatarService::renderAvatar($this->userName, 100);
+		$this->avatar = AvatarService::renderAvatar( $this->userName, 100 );
 		$this->lastActionData = array();
 
 		// show "Unregistered contributor" + IP for anon accounts
-		if (User::isIP($this->userName)) {
+		if ( User::isIP( $this->userName ) ) {
 			$this->displaytitle = true;
-			$this->title = wfMsg('oasis-anon-header', $this->userName);
+			$this->title = wfMsg( 'oasis-anon-header', $this->userName );
 		}
 		// show full title of subpages in user (talk) namespace
-		else if (in_array($namespace, array(NS_USER, NS_USER_TALK))) {
-				$this->title = $wgTitle->getText();
-			}
-			else {
-				$this->title = $this->userName;
-			}
+		else if ( in_array( $namespace, array( NS_USER, NS_USER_TALK ) ) ) {
+			$this->title = $wgTitle->getText();
+		}
+		else {
+			$this->title = $this->userName;
+		}
 
 		// link to user page
-		$this->userPage = AvatarService::getUrl($this->userName);
+		$this->userPage = AvatarService::getUrl( $this->userName );
 
 		// render tabbed links
-		$this->tabs = $this->getTabs($this->userName);
+		$this->tabs = $this->getTabs( $this->userName );
 
 		// user stats (edit points, account creation date)
-		$this->stats = $this->getStats($this->userName);
+		$this->stats = $this->getStats( $this->userName );
 
 		// no "user" likes
 		$this->likes = false;
@@ -211,32 +211,32 @@ class UserPagesHeaderController extends WikiaController {
 				);
 
 		// page type specific stuff
-		if ($namespace == NS_USER) {
+		if ( $namespace == NS_USER ) {
 			// edit button
-			if (isset($this->content_actions['edit'])) {
+			if ( isset( $this->content_actions['edit'] ) ) {
 				$actionMenu['action'] = array(
-						'href' => $this->content_actions['edit']['href'],
-						'text' => wfMsg('oasis-page-header-edit-profile'),
-						);
+					'href' => $this->content_actions['edit']['href'],
+					'text' => wfMsg( 'oasis-page-header-edit-profile' ),
+				);
 
 				$this->actionImage = MenuButtonController::EDIT_ICON;
 				$this->actionName = 'editprofile';
 			}
 		}
-		else if ($namespace == NS_USER_TALK) {
+		else if ( $namespace == NS_USER_TALK ) {
 			// "Leave a message" button
-			if (isset($this->content_actions['addsection']['href'])) {
+			if ( isset( $this->content_actions['addsection']['href'] ) ) {
 				$actionMenu['action'] = array(
-						'href' => $this->content_actions['addsection']['href'],
-						'text' => wfMsg('add_comment'),
-						);
+					'href' => $this->content_actions['addsection']['href'],
+					'text' => wfMsg( 'add_comment' ),
+				);
 
 				$this->actionImage = MenuButtonController::MESSAGE_ICON;
 				$this->actionName = 'leavemessage';
 
 				// different handling for "My talk page"
-				if (self::isItMe($this->userName)) {
-					$actionMenu['action']['text'] = wfMsg('edit');
+				if ( self::isItMe($this->userName ) ) {
+					$actionMenu['action']['text'] = wfMsg( 'edit' );
 					$actionMenu['action']['href'] = $this->content_actions['edit']['href'];
 
 					$this->actionImage = MenuButtonController::EDIT_ICON;
@@ -244,12 +244,12 @@ class UserPagesHeaderController extends WikiaController {
 				}
 			}
 		}
-		else if ( defined( 'NS_BLOG_ARTICLE' ) && $namespace == NS_BLOG_ARTICLE ) {
+		else if( defined( 'NS_BLOG_ARTICLE' ) && $namespace == NS_BLOG_ARTICLE ) {
 			// "Create a blog post" button
-			if (self::isItMe($this->userName)) {
+			if ( self::isItMe( $this->userName ) ) {
 				$this->actionButton = array(
-					'href' => SpecialPage::getTitleFor('CreateBlogPage')->getLocalUrl(),
-					'text' => wfMsg('blog-create-post-label'),
+					'href' => SpecialPage::getTitleFor( 'CreateBlogPage' )->getLocalUrl(),
+					'text' => wfMsg( 'blog-create-post-label' ),
 				);
 
 				$this->actionImage = MenuButtonController::BLOG_ICON;
@@ -258,16 +258,16 @@ class UserPagesHeaderController extends WikiaController {
 		}
 
 		// dropdown actions for "Profile" and "Talk page" tabs
-		if (in_array($namespace, array(NS_USER, NS_USER_TALK))) {
-			$actions = array('move', 'protect', 'unprotect', 'delete', 'undelete', 'history');
+		if ( in_array( $namespace, array( NS_USER, NS_USER_TALK ) ) ) {
+			$actions = array( 'move', 'protect', 'unprotect', 'delete', 'undelete', 'history' );
 
 			// add "edit" item to "Leave a message" button
-			if ($this->actionName == 'leavemessage') {
-				array_unshift($actions, 'edit');
+			if ( $this->actionName == 'leavemessage' ) {
+				array_unshift( $actions, 'edit' );
 			}
 
-			foreach($actions as $action) {
-				if (isset($this->content_actions[$action])) {
+			foreach( $actions as $action ) {
+				if ( isset( $this->content_actions[$action] ) ) {
 					$actionMenu['dropdown'][$action] = $this->content_actions[$action];
 				}
 			}
@@ -275,11 +275,11 @@ class UserPagesHeaderController extends WikiaController {
 		$this->actionMenu = $actionMenu;
 
 		// don't show stats for user pages with too long titles (RT #68818)
-		if (mb_strlen($this->title) > 35) {
+		if ( mb_strlen( $this->title ) > 35) {
 			$this->stats = false;
 		}
 
-		wfProfileOut(__METHOD__);
+		wfProfileOut( __METHOD__ );
 	}
 
 
@@ -289,30 +289,30 @@ class UserPagesHeaderController extends WikiaController {
 	 *
 	 * @param bool $arg Users has granted access (true or false)*
 	 */
-	public function executeFacebookConnect($arg) {
+	public function executeFacebookConnect( $arg ) {
 		global $wgRequest, $wgFacebookSyncAppID, $wgFacebookSyncAppSecret, $IP, $wgTitle, $wgSitename;
-		wfProfileIn(__METHOD__);
+		wfProfileIn( __METHOD__ );
 
-		if ($arg['fbAccess'] == true) {
-			include($IP . '/extensions/FBConnect/facebook-sdk/facebook.php');
-			$facebook = new FacebookAPI(array('appId' =>$wgFacebookSyncAppID,'secret'=>$wgFacebookSyncAppSecret,	'cookie' =>true, ));
+		if ( $arg['fbAccess'] == true ) {
+			include( $IP . '/extensions/FBConnect/facebook-sdk/facebook.php' );
+			$facebook = new FacebookAPI( array( 'appId' =>$wgFacebookSyncAppID,'secret'=>$wgFacebookSyncAppSecret,	'cookie' =>true, ) );
 
 			// taken from http://trac.wikia-code.com/changeset/34764
 			$fbRedirectUrl = $wgTitle->getFullURL() .'?fbrequest=sent&action=purge';
 
 			$token_url = 'https://graph.facebook.com/oauth/access_token?client_id=' .$wgFacebookSyncAppID .'&redirect_uri=' . urlencode($fbRedirectUrl) .'&client_secret=' .$wgFacebookSyncAppSecret .'&code=' .$wgRequest->getVal( 'code' );
-			$access_token = Http::get($token_url);
+			$access_token = Http::get( $token_url );
 			$graph_url = "https://graph.facebook.com/me?" . $access_token;
-			$user = json_decode(Http::get($graph_url));
+			$user = json_decode( Http::get( $graph_url ) );
 
 			$likes_url = "https://graph.facebook.com/me/likes?" . $access_token;
-			$likes = json_decode(Http::get($likes_url));
+			$likes = json_decode( Http::get( $likes_url ) );
 
 			$interests_url = "https://graph.facebook.com/me/likes?" . $access_token;
-			$interests = json_decode(Http::get($interests_url));
+			$interests = json_decode( Http::get( $interests_url ) );
 
-			$this->fbSelectFormURL = $wgRequest->appendQueryValue('title', $this->getUserURL());
-			$this->fbSelectFormURL = $wgRequest->appendQueryValue('fbrequest', 'save');
+			$this->fbSelectFormURL = $wgRequest->appendQueryValue( 'title', $this->getUserURL() );
+			$this->fbSelectFormURL = $wgRequest->appendQueryValue( 'fbrequest', 'save' );
 
 			$this->fbUser = $user;
 			$this->fbUserLikes = $likes;
@@ -326,7 +326,7 @@ class UserPagesHeaderController extends WikiaController {
 			$this->fbAccess = false;
 		}
 
-		wfProfileOut(__METHOD__);
+		wfProfileOut( __METHOD__ );
 	}
 
 
@@ -338,12 +338,26 @@ class UserPagesHeaderController extends WikiaController {
 	public function executeFacebookConnectArticle() {
 		global $wgRequest;
 
-		$formElements = array('fb-name','fb-birthday', 'fb-relationshipstatus', 'fb-languages', 'fb-hometown','fb-location','fb-education','fb-gender', 'fb-work', 'fb-religion','fb-political','fb-website','fb-interests');
+		$formElements = array(
+			'fb-name',
+			'fb-birthday',
+			'fb-relationshipstatus',
+			'fb-languages',
+			'fb-hometown',
+			'fb-location',
+			'fb-education',
+			'fb-gender',
+			'fb-work',
+			'fb-religion',
+			'fb-political',
+			'fb-website',
+			'fb-interests'
+		);
 
 		$this->fbSaveData = array();
 
-		foreach ($formElements as $formElement) {
-			$this->fbSaveData[$formElement] = $wgRequest->getVal($formElement);
+		foreach ( $formElements as $formElement ) {
+			$this->fbSaveData[$formElement] = $wgRequest->getVal( $formElement );
 		}
 	}
 
@@ -355,8 +369,8 @@ class UserPagesHeaderController extends WikiaController {
 		global $wgUser;
 
 		$user_name = $wgUser->mName;
-		$userURL = explode('/', AvatarService::getUrl($user_name));
-		$userURL = $userURL[count($userURL) -1];
+		$userURL = explode( '/', AvatarService::getUrl( $user_name ) );
+		$userURL = $userURL[count( $userURL ) -1];
 		return $userURL;
 	}
 
@@ -371,40 +385,40 @@ class UserPagesHeaderController extends WikiaController {
 	 * @return bool need to return true
 	 *
 	 */
-	public static function saveFacebookConnectProfile($article, $outputDone, $userParserCache ) { //$fbContent
+	public static function saveFacebookConnectProfile( $article, $outputDone, $userParserCache ) { //$fbContent
 		global $wgArticle, $wgTitle, $wgOut, $wgRequest;
 
-		if ($wgRequest->getVal( 'fbrequest' ) != 'save') {
+		if ( $wgRequest->getVal( 'fbrequest' ) != 'save' ) {
 			return true;
 		}
 
-		$fbContent = F::app()->renderView('UserPagesHeader', 'FacebookConnectArticle');
+		$fbContent = F::app()->renderView( 'UserPagesHeader', 'FacebookConnectArticle' );
 
 		if ($fbContent) {
 			// getting users page url, not the clean way?
 			$userURL = self::getUserURL();
 
-			$articleTitle = Title::newFromText($userURL);
-			$wgArticle = new Article($articleTitle);
+			$articleTitle = Title::newFromText( $userURL );
+			$wgArticle = new Article( $articleTitle );
 			$userProfileContent = $wgArticle->getContent(); // reading content
 
 			// remove already existing sync
 			$regex = '#<table class="fbconnect-synced-profile[^>]+>[\w\W]*?</table>#i';
-			$userProfileContent = preg_replace($regex, '', $userProfileContent);
+			$userProfileContent = preg_replace( $regex, '', $userProfileContent );
 
 			$newUserProfileContent = $fbContent .$userProfileContent;
 
 			// save updated profile
 			$summary = "Synced profile with Facebook.";
-			NotificationsController::addConfirmation(wfMsg('fb-sync-success-message'));
+			NotificationsController::addConfirmation( wfMsg( 'fb-sync-success-message' ) );
 
-			$wgArticle->doEdit($newUserProfileContent, $summary,
+			$wgArticle->doEdit( $newUserProfileContent, $summary,
 					( 0 ) |
 					( 0 ) |
 					( 0 ) |
 					( 0 ) );
 
-			$wgOut->redirect($wgTitle->getFullUrl());
+			$wgOut->redirect( $wgTitle->getFullUrl() );
 		}
 
 		return true;
@@ -415,98 +429,98 @@ class UserPagesHeaderController extends WikiaController {
 	 * Render header for blog post
 	 */
 	public function executeBlogPost() {
-		wfProfileIn(__METHOD__);
+		wfProfileIn( __METHOD__ );
 		global $wgTitle, $wgLang, $wgOut;
 
 		// remove User_blog:xxx from title
-		$titleParts = explode('/', $wgTitle->getText());
-		array_shift($titleParts);
-		$this->title = implode('/', $titleParts);
+		$titleParts = explode( '/', $wgTitle->getText() );
+		array_shift( $titleParts );
+		$this->title = implode( '/', $titleParts );
 
 		// get user name to display in header
-		$this->userName = self::getUserName($wgTitle, BodyController::getUserPagesNamespaces());
+		$this->userName = self::getUserName( $wgTitle, BodyController::getUserPagesNamespaces() );
 
 		// render avatar (48x48)
-		$this->avatar = AvatarService::renderAvatar($this->userName, 48);
+		$this->avatar = AvatarService::renderAvatar( $this->userName, 48 );
 
 		// link to user page
-		$this->userPage = AvatarService::getUrl($this->userName);
+		$this->userPage = AvatarService::getUrl( $this->userName );
 
-		if ( $this->wg->EnableBlogArticles ) {
+		if( $this->wg->EnableBlogArticles ) {
 			// link to user blog page
 			$this->userBlogPage = AvatarService::getUrl( $this->userName, NS_BLOG_ARTICLE );
 
 			// user blog page message
 			$this->userBlogPageMessage = wfMessage( 'user-blog-url-link', $this->userName )->inContentLanguage()->parse();
 		}
-		if ( !empty( $this->wg->EnableGoogleAuthorInfo )
+		if( !empty( $this->wg->EnableGoogleAuthorInfo )
 			&& !empty( $this->wg->GoogleAuthorLinks )
 			&& array_key_exists( $this->userName, $this->wg->GoogleAuthorLinks )
 		) {
 			$this->googleAuthorLink = $this->wg->GoogleAuthorLinks[$this->userName] . '?rel=author';
 		}
-		if ($this->app->wg->Request->getVal('action') == 'history' || $this->app->wg->Request->getCheck( 'diff' ) ) {
-			$this->navLinks = Wikia::link($this->app->wg->title, wfMsg('oasis-page-header-back-to-article'), array(), array(), 'known');
+		if( $this->app->wg->Request->getVal( 'action' ) == 'history' || $this->app->wg->Request->getCheck( 'diff' ) ) {
+			$this->navLinks = Wikia::link( $this->app->wg->title, wfMsg( 'oasis-page-header-back-to-article' ), array(), array(), 'known' );
 		}
 		// user stats (edit points, account creation date)
-		$this->stats = $this->getStats($this->userName);
+		$this->stats = $this->getStats( $this->userName );
 
 		// commments / likes / date of first edit
-		if (!empty($wgTitle) && $wgTitle->exists()) {
-			$service = new PageStatsService($wgTitle->getArticleId());
+		if ( !empty( $wgTitle ) && $wgTitle->exists() ) {
+			$service = new PageStatsService( $wgTitle->getArticleId() );
 
-			$this->editTimestamp = $wgLang->date($service->getFirstRevisionTimestamp());
+			$this->editTimestamp = $wgLang->date( $service->getFirstRevisionTimestamp() );
 			$this->comments = $service->getCommentsCount();
 			$this->likes = true;
 		}
 
 		$actionMenu = array();
-		$dropdownActions = array('move', 'protect', 'unprotect', 'delete', 'undelete', 'history');
+		$dropdownActions = array( 'move', 'protect', 'unprotect', 'delete', 'undelete', 'history' );
 
 		// edit button / dropdown
-		if (isset($this->content_actions['ve-edit'])) {
+		if ( isset( $this->content_actions['ve-edit'] ) ) {
 			// new visual editor is enabled
 			$actionMenu['action'] = $this->content_actions['ve-edit'];
 			// add classic editor link to the possible dropdown options
 			array_unshift( $dropdownActions, 'edit' );
 		}
-		else if (isset($this->content_actions['edit'])) {
+		else if ( isset( $this->content_actions['edit'] ) ) {
 			$actionMenu['action'] = $this->content_actions['edit'];
 		}
 
-		foreach($dropdownActions as $action) {
-			if (isset($this->content_actions[$action])) {
+		foreach( $dropdownActions as $action ) {
+			if ( isset( $this->content_actions[$action] ) ) {
 				$actionMenu['dropdown'][$action] = $this->content_actions[$action];
 			}
 		}
 		$this->actionMenu = $actionMenu;
 
 		// load CSS for .WikiaUserPagesHeader (BugId:9212, 10246)
-		$wgOut->addStyle(AssetsManager::getInstance()->getSassCommonURL("skins/oasis/css/core/UserPagesHeader.scss"));
+		$wgOut->addStyle( AssetsManager::getInstance()->getSassCommonURL( "skins/oasis/css/core/UserPagesHeader.scss" ) );
 
-		wfProfileOut(__METHOD__);
+		wfProfileOut( __METHOD__ );
 	}
 
 	/**
 	 * Render header for blog listing
 	 */
 	public function executeBlogListing() {
-		wfProfileIn(__METHOD__);
+		wfProfileIn( __METHOD__ );
 
 		global $wgTitle, $wgOut;
 
 		// "Create blog post" button
 		$this->actionButton = array(
-				'href' => SpecialPage::getTitleFor('CreateBlogPage')->getLocalUrl(),
-				'text' => wfMsg('blog-create-post-label'),
+				'href' => SpecialPage::getTitleFor( 'CreateBlogPage' )->getLocalUrl(),
+				'text' => wfMsg( 'blog-create-post-label' ),
 				);
 		$this->title = $wgTitle->getText();
 		//subtitle is no longer rendered in this module. this probably needs to be moved to body module.
-		$this->subtitle = wfMsg('create-blog-post-category');
+		$this->subtitle = wfMsg( 'create-blog-post-category' );
 
 		// load CSS for .WikiaBlogListingHeader (BugId:9212, 10246)
-		$wgOut->addStyle(AssetsManager::getInstance()->getSassCommonURL("skins/oasis/css/core/UserPagesHeader.scss"));
+		$wgOut->addStyle( AssetsManager::getInstance()->getSassCommonURL( "skins/oasis/css/core/UserPagesHeader.scss" ) );
 
-		wfProfileOut(__METHOD__);
+		wfProfileOut( __METHOD__ );
 	}
 }

--- a/skins/oasis/modules/UserPagesHeaderController.class.php
+++ b/skins/oasis/modules/UserPagesHeaderController.class.php
@@ -244,18 +244,18 @@ class UserPagesHeaderController extends WikiaController {
 				}
 			}
 		}
-		else if (defined('NS_BLOG_ARTICLE') && $namespace == NS_BLOG_ARTICLE) {
-				// "Create a blog post" button
-				if (self::isItMe($this->userName)) {
-					$this->actionButton = array(
-							'href' => SpecialPage::getTitleFor('CreateBlogPage')->getLocalUrl(),
-							'text' => wfMsg('blog-create-post-label'),
-							);
+		else if ( defined( 'NS_BLOG_ARTICLE' ) && $namespace == NS_BLOG_ARTICLE ) {
+			// "Create a blog post" button
+			if (self::isItMe($this->userName)) {
+				$this->actionButton = array(
+					'href' => SpecialPage::getTitleFor('CreateBlogPage')->getLocalUrl(),
+					'text' => wfMsg('blog-create-post-label'),
+				);
 
-					$this->actionImage = MenuButtonController::BLOG_ICON;
-					$this->actionName = 'createblogpost';
-				}
+				$this->actionImage = MenuButtonController::BLOG_ICON;
+				$this->actionName = 'createblogpost';
 			}
+		}
 
 		// dropdown actions for "Profile" and "Talk page" tabs
 		if (in_array($namespace, array(NS_USER, NS_USER_TALK))) {
@@ -461,14 +461,21 @@ class UserPagesHeaderController extends WikiaController {
 		}
 
 		$actionMenu = array();
+		$dropdownActions = array('move', 'protect', 'unprotect', 'delete', 'undelete', 'history');
+
 		// edit button / dropdown
-		if (isset($this->content_actions['edit'])) {
+		if (isset($this->content_actions['ve-edit'])) {
+			// new visual editor is enabled
+			$actionMenu['action'] = $this->content_actions['ve-edit'];
+			// add classic editor link to the possible dropdown options
+			array_unshift( $dropdownActions, 'edit' );
+		}
+		else if (isset($this->content_actions['edit'])) {
 			$actionMenu['action'] = $this->content_actions['edit'];
+			//$actionMenu['action'] = $this->content_actions['ve-edit'];
 		}
 
-		// dropdown actions
-		$actions = array('move', 'protect', 'unprotect', 'delete', 'undelete', 'history');
-		foreach($actions as $action) {
+		foreach($dropdownActions as $action) {
 			if (isset($this->content_actions[$action])) {
 				$actionMenu['dropdown'][$action] = $this->content_actions[$action];
 			}


### PR DESCRIPTION
There is a little bit of code cleanup here so you can try ignoring white space to make it easier to see the changes. 
https://github.com/Wikia/app/pull/1892/files?w=1

The issue was that user blog pages handle the edit button and dropdown on their own, so the logic just had to be added to include both types of buttons so that one could be hidden if the ve was disabled. 
