### PR TITLE
LDA Topic Fixes

### DIFF
--- a/extensions/wikia/NLP/WikiaNLP.setup.php
+++ b/extensions/wikia/NLP/WikiaNLP.setup.php
@@ -22,8 +22,8 @@ $wgAutoloadClasses['Wikia\NLP\Entities\WikiEntitiesService'] =  $dir . 'classes/
 $wgAutoloadClasses['Wikia\NLP\Entities\Hooks'] =  $dir . 'classes/Entities/Hooks.php';
 
 // this would be for page_wikia_props -- should move to defines if we use it.
-define( 'PAGE_ENTITIES_KEY', 22 );
+// define( 'PAGE_ENTITIES_KEY', 22 );
 
-if ( $wgEnableEntitiesForDFP ) {
-	$wgHooks['ArticleViewHeader'][] = 'Wikia\NLP\Entities\Hooks::onArticleViewHeader';
+if ( $wgEnableTopicsForDFP ) {
+	$wgHooks['ArticleViewHeader'][] = 'Wikia\\NLP\\Entities\\Hooks::onArticleViewHeader';
 }

--- a/extensions/wikia/Search/classes/MediaWikiService.php
+++ b/extensions/wikia/Search/classes/MediaWikiService.php
@@ -239,6 +239,7 @@ class MediaWikiService
 	 * @return \Wikia\Search\MediaWikiService
 	 */
 	public function setGlobal( $global, $value ) {
+		$global = substr_count( $global, 'wg', 0, 2 ) ? substr( $global, 2 ) : $global;
 		$this->app->wg->{$global} = $value;
 		return $this;
 	}


### PR DESCRIPTION
Uses the correct variable name for hook registration and fixes a bug in Wikia\Search\MediaWikiService that prevented global setting from working.
