### PR TITLE
purge site/user css/js on edit

### DIFF
--- a/includes/OutputPage.php
+++ b/includes/OutputPage.php
@@ -2585,8 +2585,9 @@ $templates
 	 * @param $extraQuery Array with extra query parameters to add to each request. array( param => value )
 	 * @param $loadCall boolean If true, output an (asynchronous) mw.loader.load() call rather than a <script src="..."> tag
 	 * @return string html <script> and <style> tags
+	 * // Wikia change -- made this public so we could use it to build asset purge links BAC-895
 	 */
-	protected function makeResourceLoaderLink( $modules, $only, $useESI = false, array $extraQuery = array(), $loadCall = false ) {
+	public function makeResourceLoaderLink( $modules, $only, $useESI = false, array $extraQuery = array(), $loadCall = false ) {
 		global $wgResourceLoaderUseESI;
 
 		if ( !count( $modules ) ) {

--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -1553,7 +1553,9 @@ class Wikia {
 		if ($link != null) {
 			// extract the url from the link src
 			preg_match("/\"(.*)\"/", $link, $matches);
-			$urls[]= $matches[1];
+			if ( isset($matches[1]) ) {
+				$urls[]= $matches[1];
+			}
 		}
 
 		wfProfileOut(__METHOD__);

--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -28,7 +28,8 @@ $wgHooks['AfterInitialize']          [] = "Wikia::onAfterInitialize";
 $wgHooks['UserMailerSend']           [] = "Wikia::onUserMailerSend";
 $wgHooks['ArticleDeleteComplete']    [] = "Wikia::onArticleDeleteComplete";
 $wgHooks['ContributionsToolLinks']   [] = 'Wikia::onContributionsToolLinks';
-$wgHooks['AjaxAddScript'][] = 'Wikia::onAjaxAddScript';
+$wgHooks['AjaxAddScript']            [] = 'Wikia::onAjaxAddScript';
+$wgHooks['TitleGetSquidURLs']        [] = 'Wikia::onTitleGetSquidURLs';
 
 # changes in recentchanges (MultiLookup)
 $wgHooks['RecentChange_save']        [] = "Wikia::recentChangesSave";
@@ -484,7 +485,7 @@ class Wikia {
 		$msg = "***** END *****";
 		Wikia::log($method, false, $msg, true /* $force */);
 	}
-	
+
 	/**
 	 * get staff person responsible for language
 	 *
@@ -1520,59 +1521,40 @@ class Wikia {
 	}
 
 	/**
-	 * Get list of all URLs to be purged for a given Title
+	 * Purge Common and Wikia and User css/js when those files are edited
+	 * Uses $wgOut->makeResourceLoaderLink which was protected, but has lots of logic we don't want to duplicate
+	 * This was rewritten from scratch as part of BAC-895
 	 *
 	 * @param Title $title page to be purged
 	 * @param Array $urls list of URLs to be purged
 	 * @return mixed true - it's a hook
 	 */
 	static public function onTitleGetSquidURLs(Title $title, Array $urls) {
-		// if this is a site css or js purge it as well
 		global $wgUseSiteCss, $wgAllowUserJs;
-		global $wgSquidMaxage, $wgJsMimeType;
-
+		global $wgOut;
 		wfProfileIn(__METHOD__);
 
+		$link = null;
 		if( $wgUseSiteCss && $title->getNamespace() == NS_MEDIAWIKI ) {
-			global $wgServer;
-			$urls[] = $wgServer.'/__am/';
-			$urls[] = $wgServer.'/__wikia_combined/';
-			$query = array(
-				'usemsgcache' => 'yes',
-				'ctype' => 'text/css',
-				'smaxage' => $wgSquidMaxage,
-				'action' => 'raw',
-				'maxage' => $wgSquidMaxage,
-			);
-
-			if( $title->getText() == 'Common.css' || $title->getText() == 'Wikia.css' ) {
-				// BugId:20929 - tell (or trick) varnish to store the latest revisions of Wikia.css and Common.css.
-				$oTitleCommonCss	= Title::newFromText( 'Common.css', NS_MEDIAWIKI );
-				$oTitleWikiaCss		= Title::newFromText( 'Wikia.css',  NS_MEDIAWIKI );
-				$query['maxrev'] = max( (int) $oTitleWikiaCss->getLatestRevID(), (int) $oTitleCommonCss->getLatestRevID() );
-				unset( $oTitleWikiaCss, $oTitleCommonCss );
-				$urls[] = $title->getInternalURL( $query );
-			} else {
-				foreach( Skin::getSkinNames() as $skinkey => $skinname ) {
-					if( $title->getText() == ucfirst($skinkey).'.css' ) {
-						$urls[] = str_replace('text%2Fcss', 'text/css', $title->getInternalURL( $query )); // For Artur
-						$urls[] = $title->getInternalURL( $query ); // For Artur
-						break;
-					} elseif ( $title->getText() == 'Common.js' ) {
-						$urls[] = Skin::makeUrl('-', "action=raw&smaxage=86400&gen=js&useskin=" .urlencode( $skinkey ) );
-					}
-				}
+			$text = $title->getText();
+			if( $text == 'Common.js' || $text == 'Wikia.js') {
+				$link = $wgOut->makeResourceLoaderLink( 'site', ResourceLoaderModule::TYPE_SCRIPTS);
 			}
-		} elseif( $wgAllowUserJs && $title->isCssJsSubpage() ) {
-			if( $title->isJsSubpage() ) {
-				$urls[] = $title->getInternalURL( 'action=raw&ctype='.$wgJsMimeType );
-			} elseif( $title->isCssSubpage() ) {
-				$urls[] = $title->getInternalURL( 'action=raw&ctype=text/css' );
+			else if( $text == 'Common.css' || $text == 'Wikia.css' ) {
+				$link = $wgOut->makeResourceLoaderLink( 'site', ResourceLoaderModule::TYPE_STYLES);
 			}
 		}
-
-		// purge Special:RecentChanges too
-		$urls[] = SpecialPage::getTitleFor('RecentChanges')->getInternalURL();
+		if( $wgAllowUserJs && $title->isJsSubpage() ) {
+			$link = $wgOut->makeResourceLoaderLink( 'user', ResourceLoaderModule::TYPE_SCRIPTS);
+		}
+		else if( $wgAllowUserJs && $title->isCssSubpage() ) {
+			$link = $wgOut->makeResourceLoaderLink( 'user', ResourceLoaderModule::TYPE_STYLES);
+		}
+		if ($link != null) {
+			// extract the url from the link src
+			preg_match("/\"(.*)\"/", $link, $matches);
+			$urls[]= $matches[1];
+		}
 
 		wfProfileOut(__METHOD__);
 		return true;


### PR DESCRIPTION
This is a bit of a "hack" because it involves calling a protected function in OutputPage.  However, that function has about 200 lines of code and re-implemeting it involves copying about 50 lines to a helper... :/  

I think it's cleaner in this case to just to make it public and re-use the logic.   However, if there are strong objections to this approach I am willing to refactor.

@Wikia/platform-team  
