### PR TITLE
Newrelic time measurements resolution

### DIFF
--- a/includes/wikia/measurements/Drivers.php
+++ b/includes/wikia/measurements/Drivers.php
@@ -30,7 +30,7 @@ interface Driver {
  * @see CustomMeasurements
  */
 class NewrelicDriver implements Driver {
-
+	const MILLISECONDS_IN_SECOND = 1000.0;
 	/**
 	 * @return bool
 	 */
@@ -41,12 +41,12 @@ class NewrelicDriver implements Driver {
 
 	/**
 	 * @param string $measurementName
-	 * @param float $time
+	 * @param float $time - in seconds
 	 */
 	public function measureTime( $measurementName, $time ) {
-		$fullMeasurementName = "Custom/{$measurementName}[seconds|call]";
+		$fullMeasurementName = "Custom/{$measurementName}[milliseconds|call]";
 		/** @noinspection PhpUndefinedFunctionInspection */
-		newrelic_custom_metric( $fullMeasurementName, $time );
+		newrelic_custom_metric( $fullMeasurementName, $time * self::MILLISECONDS_IN_SECOND );
 	}
 }
 

--- a/includes/wikia/measurements/Drivers.php
+++ b/includes/wikia/measurements/Drivers.php
@@ -44,7 +44,12 @@ class NewrelicDriver implements Driver {
 	 * @param float $time - in seconds
 	 */
 	public function measureTime( $measurementName, $time ) {
-		$fullMeasurementName = "Custom/{$measurementName}[milliseconds|call]";
+		$fullMeasurementName = "Custom/{$measurementName}[seconds|call]";
+		/*
+		 * We need to multiply time in seconds by 1000.
+		 * From newrelic documentation:
+		 * Adds a custom metric with the specified name and value, which is of type double. Values saved are assumed to be milliseconds, so "4" will be stored as ".004" in our system.
+		 */
 		/** @noinspection PhpUndefinedFunctionInspection */
 		newrelic_custom_metric( $fullMeasurementName, $time * self::MILLISECONDS_IN_SECOND );
 	}

--- a/includes/wikia/measurements/Drivers.php
+++ b/includes/wikia/measurements/Drivers.php
@@ -47,7 +47,7 @@ class NewrelicDriver implements Driver {
 		$fullMeasurementName = "Custom/{$measurementName}[seconds|call]";
 		/*
 		 * We need to multiply time in seconds by 1000.
-		 * From newrelic documentation:
+		 * From newrelic_custom_metric documentation:
 		 * Adds a custom metric with the specified name and value, which is of type double. Values saved are assumed to be milliseconds, so "4" will be stored as ".004" in our system.
 		 */
 		/** @noinspection PhpUndefinedFunctionInspection */

--- a/includes/wikia/measurements/tests/NewrelicDriverTest.php
+++ b/includes/wikia/measurements/tests/NewrelicDriverTest.php
@@ -16,7 +16,7 @@ class NewrelicDriverTest extends \WikiaBaseTest {
 		$this->getGlobalFunctionMock("newrelic_custom_metric")
 			->expects( $this->once() )
 			->method( 'newrelic_custom_metric' )
-			->with( "Custom/foo[seconds|call]", 0.1 );
+			->with( "Custom/foo[milliseconds|call]", 100.0 );
 
 		(new NewrelicDriver())->measureTime( "foo", 0.1 );
 	}

--- a/includes/wikia/measurements/tests/NewrelicDriverTest.php
+++ b/includes/wikia/measurements/tests/NewrelicDriverTest.php
@@ -16,7 +16,7 @@ class NewrelicDriverTest extends \WikiaBaseTest {
 		$this->getGlobalFunctionMock("newrelic_custom_metric")
 			->expects( $this->once() )
 			->method( 'newrelic_custom_metric' )
-			->with( "Custom/foo[milliseconds|call]", 100.0 );
+			->with( "Custom/foo[seconds|call]", 100.0 );
 
 		(new NewrelicDriver())->measureTime( "foo", 0.1 );
 	}


### PR DESCRIPTION
Fix newrelic time measurements.

newrelic_custom_metric function in multiplying value by 0.001 by itself. We need to multiply time by 1000 to account for that.

@nmonterroso - Take a look. It will affect your measurements. 
@Szumo 
