### PR TITLE
DAR-2614: TOC: pages that start without an H2 have broken TOC levels

### DIFF
--- a/extensions/wikia/TOC/js/modules/spec/toc.spec.js
+++ b/extensions/wikia/TOC/js/modules/spec/toc.spec.js
@@ -230,5 +230,106 @@ describe('TOC', function() {
 		expect(JSON.stringify(data)).toBe(JSON.stringify(dataMock));
 	});
 
+	it('works for missed heading steps', function() {
 
+		htmlContent = '<h2>test2</h2><h3>test3</h3><h2>test2</h2><h4>test4</h4>';
+		dataMock = {
+			sections: [
+				{
+					title: 'test2',
+					sections: [
+						{
+							title: 'test3',
+							sections: []
+						}
+					]
+				},
+				{
+					title: 'test2',
+					sections: [
+						{
+							title: 'test4',
+							sections: []
+						}
+					]
+				}
+			]
+		};
+
+		html.innerHTML = htmlContent;
+		headers = getHeaders(html);
+		data = toc.getData(headers, createTOCSection);
+
+		expect(JSON.stringify(data)).toBe(JSON.stringify(dataMock));
+	});
+
+	it('works for http://kirkburn.wikia.com/wiki/Test5347a', function() {
+
+		htmlContent = '<h3>Heading 3</h3><h4>Heading 4</h4><h5>Heading 5 1</h5><h5>Heading 5 2</h5>';
+		dataMock = {
+			sections: [
+				{
+					title: 'Heading 3',
+					sections: [
+						{
+							title: 'Heading 4',
+							sections: [
+								{
+									title: 'Heading 5 1',
+									sections: []
+								},
+								{
+									title: 'Heading 5 2',
+									sections: []
+								}
+							]
+						}
+					]
+				}
+			]
+		};
+
+		html.innerHTML = htmlContent;
+		headers = getHeaders(html);
+		data = toc.getData(headers, createTOCSection);
+
+		expect(JSON.stringify(data)).toBe(JSON.stringify(dataMock));
+	});
+
+	it('works for http://kirkburn.wikia.com/wiki/Test5347b', function() {
+
+		htmlContent = '<h3>Heading 3</h3><h3>Heading 3</h3><h4>Heading 4</h4><h5>Heading 5 1</h5><h5>Heading 5 2</h5>';
+		dataMock = {
+			sections: [
+				{
+					title: 'Heading 3',
+					sections: []
+				},
+				{
+					title: 'Heading 3',
+					sections: [
+						{
+							title: 'Heading 4',
+							sections: [
+								{
+									title: 'Heading 5 1',
+									sections: []
+								},
+								{
+									title: 'Heading 5 2',
+									sections: []
+								}
+							]
+						}
+					]
+				}
+			]
+		};
+
+		html.innerHTML = htmlContent;
+		headers = getHeaders(html);
+		data = toc.getData(headers, createTOCSection);
+
+		expect(JSON.stringify(data)).toBe(JSON.stringify(dataMock));
+	});
 });

--- a/extensions/wikia/TOC/js/modules/spec/toc.spec.js
+++ b/extensions/wikia/TOC/js/modules/spec/toc.spec.js
@@ -8,7 +8,7 @@ describe('TOC', function() {
 			return {
 				title: header.textContent,
 				sections: []
-			}
+			};
 		},
 		// other vars
 		html = getBody(),
@@ -26,7 +26,7 @@ describe('TOC', function() {
 
 	it('works for one level deep TOC', function(){
 
-	    htmlContent = '<h2>test</h2><h2>test</h2><h2>test</h2>';
+		htmlContent = '<h2>test</h2><h2>test</h2><h2>test</h2>';
 		dataMock = {
 			sections: [
 				{
@@ -138,5 +138,97 @@ describe('TOC', function() {
 
 		expect(JSON.stringify(data)).toBe(JSON.stringify(dataMock));
 	});
+
+	it('works for flat TOC', function() {
+
+		htmlContent = '<h2>test</h2><h2>test</h2><h2>test</h2>';
+		dataMock = {
+			sections: [
+				{
+					title: 'test',
+					sections: []
+				},
+				{
+					title: 'test',
+					sections: []
+				},
+				{
+					title: 'test',
+					sections: []
+				}
+			]
+		};
+
+		html.innerHTML = htmlContent;
+		headers = getHeaders(html);
+		data = toc.getData(headers, createTOCSection);
+
+		expect(JSON.stringify(data)).toBe(JSON.stringify(dataMock));
+	});
+
+	it('works for broken TOC', function() {
+
+		htmlContent = '<h3>test3</h3><h4>test4</h4><h2>test2</h2><h5>test5</h5>';
+		dataMock = {
+			sections: [
+				{
+					title: 'test3',
+					sections: [
+						{
+							title: 'test4',
+							sections: []
+						}
+					]
+				},
+				{
+					title: 'test2',
+					sections: [
+						{
+							title: 'test5',
+							sections: []
+						}
+					]
+				}
+			]
+		};
+
+		html.innerHTML = htmlContent;
+		headers = getHeaders(html);
+		data = toc.getData(headers, createTOCSection);
+
+		expect(JSON.stringify(data)).toBe(JSON.stringify(dataMock));
+	});
+
+	it('works for reversed TOC', function() {
+
+		htmlContent = '<h5>test5</h5><h4>test4</h4><h3>test3</h3><h2>test2</h2>';
+		dataMock = {
+			sections: [
+				{
+					title: 'test5',
+					sections: []
+				},
+				{
+					title: 'test4',
+					sections: []
+				},
+				{
+					title: 'test3',
+					sections: []
+				},
+				{
+					title: 'test2',
+					sections: []
+				}
+			]
+		};
+
+		html.innerHTML = htmlContent;
+		headers = getHeaders(html);
+		data = toc.getData(headers, createTOCSection);
+
+		expect(JSON.stringify(data)).toBe(JSON.stringify(dataMock));
+	});
+
 
 });

--- a/extensions/wikia/TOC/js/modules/toc.js
+++ b/extensions/wikia/TOC/js/modules/toc.js
@@ -1,8 +1,6 @@
 define('wikia.toc', function() {
 	'use strict';
 
-	var MAXHEADER = 2; // <h2> is the highest article header
-
 	/**
 	 *  Create TOC data structure
 	 *
@@ -68,6 +66,6 @@ define('wikia.toc', function() {
 	/** PUBLIC API */
 	return {
 		getData: getData
-	}
+	};
 
 });

--- a/extensions/wikia/TOC/js/modules/toc.js
+++ b/extensions/wikia/TOC/js/modules/toc.js
@@ -26,9 +26,9 @@ define('wikia.toc', function() {
 		var toc = {
 				sections: []
 			}, // set base object for TOC data structure
-			levels = [toc.sections],
+			levels = [toc.sections], // level placeholders
 			headersLength = headers.length,
-			hToLevel = [],
+			hToLevel = [], // header to TOC level dictionary
 			level = -1,
 			lastHeader = -1,
 			headerLevel,
@@ -51,7 +51,7 @@ define('wikia.toc', function() {
 				level += 1;
 			} else if (headerLevel < lastHeader && level > 0) {
 				level = 0;
-				if (typeof hToLevel[headerLevel] !== 'undefined') {
+				if (typeof hToLevel[headerLevel] !== 'undefined') { // jump to the designated level if it is set
 					level = hToLevel[headerLevel];
 				}
 			}
@@ -60,6 +60,7 @@ define('wikia.toc', function() {
 			levels[level].push(obj);
 			levels[level+1] = obj.sections;
 		}
+
 		return toc;
 	}
 


### PR DESCRIPTION
Fixes issues with same level and broken (skipped levels) headings;
Added new test cases to the spec;
