### PR TITLE
BAC-948: Fix for too short Swift bucket names

### DIFF
--- a/extensions/wikia/SwiftSync/classes/Hooks.php
+++ b/extensions/wikia/SwiftSync/classes/Hooks.php
@@ -18,18 +18,20 @@ class Hooks {
 	 * init config for FSFileBackend class
 	 */
 	static private function initLocalFS( ) {
-		global $wgUploadDirectory, $wgDeletedDirectory;
+		global $wgUploadDirectory, $wgUploadDirectoryNFS, $wgDeletedDirectory;
 		
 		$repoName = self::$repoName;
+		$directory = ( !empty( $wgUploadDirectoryNFS ) ) ? $wgUploadDirectoryNFS : $wgUploadDirectory;
+		
 		$config = array (
 			'name'           => "{$repoName}-backend",
 			'class'          => 'FSFileBackend',
 			'lockManager'    => 'fsLockManager',
 			'containerPaths' => array(
-				"{$repoName}-public"  => "{$wgUploadDirectory}",
-				"{$repoName}-thumb"   => "{$wgUploadDirectory}/thumb",
-				"{$repoName}-deleted" => "{$wgDeletedDirectory}",
-				"{$repoName}-temp"    => "{$wgUploadDirectory}/temp"
+				"{$repoName}-public"  => "{$directory}",
+				"{$repoName}-thumb"   => "{$directory}/thumb",
+				"{$repoName}-deleted" => "{$directory}",
+				"{$repoName}-temp"    => "{$directory}/temp"
 			),
 			'fileMode'       => 0644,
 		);
@@ -55,7 +57,7 @@ class Hooks {
 		
 		wfProfileIn( __METHOD__ );
 		$fsParams = $params;
-		
+
 		if ( !empty( $wgEnableSwithSyncToLocalFS ) ) {
 			if ( !empty( $params['dst'] ) && !empty( $params['src'] ) ) {
 				# replace swift-backend storage URL with local-backend ... 

--- a/maintenance/wikia/migrateImagesToSwift.php
+++ b/maintenance/wikia/migrateImagesToSwift.php
@@ -21,12 +21,16 @@ class MigrateImagesToSwift extends Maintenance {
 	const FILES_PER_SEC = 10;
 	const KB_PER_SEC = 800;
 
+	const SWIFT_BUCKET_NAME_MIN_LENGTH = 3;
+
 	// log groups
 	const LOG_MIGRATION_PROGRESS = 'swift-migration-progress';
 	const LOG_MIGRATION_ERRORS = 'swift-migration-errors';
 
 	/* @var \Wikia\SwiftStorage $swift */
 	private $swift;
+
+	private $shortBucketNameFixed = false;
 
 	// stats
 	private $imagesCnt = 0;
@@ -52,10 +56,49 @@ class MigrateImagesToSwift extends Maintenance {
 	 */
 	private function init() {
 		global $wgUploadDirectory, $wgDBname, $wgCityId;
+		$this->shortBucketNameFixed = $this->fixShortBucketName();
+
 		$this->swift = \Wikia\SwiftStorage::newFromWiki( $wgCityId );
 		$remotePath = $this->swift->getUrl( '' );
 
 		$this->output( "Migrating images on {$wgDBname} - <{$wgUploadDirectory}> -> <{$remotePath}>...\n" );
+	}
+
+	/**
+	 * Try to "fix" wikis with too short (less than 3 characters) bucket names
+	 *
+	 * $wgUploadDirectory = '/images/x/x/images'
+	 * wgUploadPath = 'http://images.wikia.com/x/x/images'
+	 *
+	 * This method sets $wgUploadDirectoryNFS WF variable.
+	 * It is used when synchronizing Swift operations back to NFS storage.
+	 *
+	 * @return boolean true if the "fix" was applied
+	 */
+	private function fixShortBucketName() {
+		global $wgUploadDirectory, $wgUploadPath, $wgUploadDirectoryNFS;
+
+		$parts = explode('/', trim($wgUploadDirectory, '/')); // images, <bucket name>, ...
+		$bucketName = $parts[1];
+
+		// bucket name is fine, leave now
+		if (strlen($bucketName) >= self::SWIFT_BUCKET_NAME_MIN_LENGTH) {
+			return false;
+		}
+
+		// keep the old path
+		$wgUploadDirectoryNFS = $wgUploadDirectory;
+
+		// fill with underscores
+		$bucketName = str_pad($bucketName, self::SWIFT_BUCKET_NAME_MIN_LENGTH, '_', STR_PAD_RIGHT);
+
+		// update $wgUploadDirectory and wgUploadPath accordingly
+		$parts[1] = $bucketName;
+		$wgUploadDirectory = '/' . join('/', $parts);
+		$wgUploadPath = 'http://images.wikia.com/' . join('/', array_slice($parts, 1));
+
+		self::log( __CLASS__, "short bucket name fix applied - '{$bucketName}', <{$wgUploadPath}>, <{$wgUploadDirectory}>" , self::LOG_MIGRATION_PROGRESS );
+		return true;
 	}
 
 	/**
@@ -134,9 +177,11 @@ class MigrateImagesToSwift extends Maintenance {
 	 * @param $path array image info
 	 */
 	private function copyFile( $path, Array $row ) {
-		global $wgUploadDirectory, $wgCityId, $wgDBname;
+		global $wgUploadDirectory, $wgUploadDirectoryNFS, $wgCityId, $wgDBname;
 
 		if ( $path === false ) return;
+
+		$uploadDir = !empty($wgUploadDirectoryNFS) ? $wgUploadDirectoryNFS : $wgUploadDirectory;
 
 		// set metadata
 		$metadata = [];
@@ -146,7 +191,7 @@ class MigrateImagesToSwift extends Maintenance {
 			$metadata['Sha1Base36'] = $row['hash'];
 		}
 
-		$res = $this->swift->store( $wgUploadDirectory . '/' . $path, $path, $metadata, $mime );
+		$res = $this->swift->store( $uploadDir . '/' . $path, $path, $metadata, $mime );
 
 		if ( !$res->isOK() ) {
 			self::log( __METHOD__, "error storing <{$path}>", self::LOG_MIGRATION_ERRORS );
@@ -154,14 +199,14 @@ class MigrateImagesToSwift extends Maintenance {
 		}
 		else {
 			$mwStorePath = sprintf( 'mwstore://swift-backend/%s/images/%s', $wgDBname, $path );
-						
+
 			Wikia\SwiftSync\Queue::newFromParams( [
 				'city_id' => $wgCityId,
 				'op' => 'store',
-				'src' => $wgUploadDirectory . '/' . $path,
+				'src' => $uploadDir . '/' . $path,
 				'dst' => $mwStorePath
 			] )->add();
-					
+
 			$this->migratedImagesSize += $row['size'];
 			$this->migratedImagesCnt++;
 		}
@@ -347,6 +392,16 @@ class MigrateImagesToSwift extends Maintenance {
 		WikiFactory::setVarByName( 'wgEnableSwiftFileBackend', $wgCityId, true, self::REASON );
 
 		$this->output( "\nNew storage enabled\n" );
+
+		// too short bucket name fix
+		if ($this->shortBucketNameFixed) {
+			global $wgUploadPath, $wgUploadDirectory, $wgUploadDirectoryNFS;
+			WikiFactory::setVarByName( 'wgUploadPath',         $wgCityId, $wgUploadPath,         self::REASON );
+			WikiFactory::setVarByName( 'wgUploadDirectory',    $wgCityId, $wgUploadDirectory,    self::REASON );
+			WikiFactory::setVarByName( 'wgUploadDirectoryNFS', $wgCityId, $wgUploadDirectoryNFS, self::REASON );
+
+			$this->output( "\nNew upload directory set up\n" );
+		}
 
 		// enable uploads via WikiFactory
 		// wgEnableUploads = true / wgUploadMaintenance = false (remove values from WF to give them the default value)


### PR DESCRIPTION
Update $wgUploadDirectory when migrating wikis with bucket name shorter than 3 characters

@Wikia/platform-team / @moliwikia 

https://wikia-inc.atlassian.net/browse/BAC-948
