### PR TITLE
(DAR-2344) Fix missing creation time on Forum Activity module

### DIFF
--- a/skins/oasis/js/LazyRail.js
+++ b/skins/oasis/js/LazyRail.js
@@ -39,6 +39,11 @@ $(function() {
 					window.ChatEntryPoint.init();
 				}
 
+				// Fix any rail modules that use jQuery timeago (DAR-2344)
+				if ( typeof $.fn.timeago !== 'undefined' ) {
+					rail.find( '.timeago' ).timeago();
+				}
+
 				if ( window.Wikia && window.Wikia.initRailTracking ) {
 					Wikia.initRailTracking();
 				}


### PR DESCRIPTION
This will also make any future uses of jQuery timeago in a rail module
work.

For a Darwin SLA ticket.

@themech @sebastian-wikia @kvas-damian 
