### PR TITLE
Eliminate unecessary logic and replace deprecated function calls

### DIFF
--- a/extensions/wikia/CategoryExhibition/CategoryExhibitionSectionMedia.class.php
+++ b/extensions/wikia/CategoryExhibition/CategoryExhibitionSectionMedia.class.php
@@ -73,7 +73,7 @@ class CategoryExhibitionSectionMedia extends CategoryExhibitionSection {
 						'data-ref'		=> $itemTitle->getPrefixedURL(),
 						'targetUrl'		=> $linkFullUrl,
 						'targetText'		=> $linkText,
-						'useVideoOverlay'	=> ( WikiaFileHelper::isVideoStoredAsFile() && WikiaFileHelper::isTitleVideo( $itemTitle ) )
+						'useVideoOverlay'	=> WikiaFileHelper::isFileTypeVideo( $itemTitle )
 					);
 				};
 

--- a/extensions/wikia/FilePage/FilePageHooks.class.php
+++ b/extensions/wikia/FilePage/FilePageHooks.class.php
@@ -116,7 +116,7 @@ class FilePageHooks extends WikiaObject{
 			return true;
 		}
 
-		if ( WikiaFileHelper::isTitleVideo( $title ) ) {
+		if ( WikiaFileHelper::isFileTypeVideo( $title ) ) {
 			$file = wfFindFile( $title );
 			if( !$file->isLocal() ) {
 				// Prevent move tab being shown.

--- a/extensions/wikia/RelatedVideos/RelatedVideosEmbededData.class.php
+++ b/extensions/wikia/RelatedVideos/RelatedVideosEmbededData.class.php
@@ -85,7 +85,7 @@ class RelatedVideosEmbededData extends RelatedVideosNamespaceData {
 			while ( $row = $res->fetchObject( $res ) ) {
 				$sTitle = $row->il_to;
 				$oTitle = Title::newFromText( $sTitle, NS_VIDEO );
-				if ( is_object( $oTitle ) && WikiaFileHelper::isTitleVideo( $oTitle ) ){
+				if ( is_object( $oTitle ) && WikiaFileHelper::isFileTypeVideo( $oTitle ) ){
 					$lists[ self::WHITELIST_MARKER ][] = $this->createEntry( $sTitle );
 				}
 			}

--- a/extensions/wikia/Scribe/ScribeEventProducer.class.php
+++ b/extensions/wikia/Scribe/ScribeEventProducer.class.php
@@ -398,17 +398,15 @@ class ScribeEventProducer {
 			$images = $oPage->mPreparedEdit->output->getImages();
 			if ( !empty($images) ) {
 				foreach ($images as $iname => $dummy) {
-					if ( WikiaFileHelper::isVideoStoredAsFile() ) {
-						$file = wfFindFile($iname);
-						if ($file instanceof LocalFile) {
-							$mediaType = $file->getMediaType();
-							switch ($mediaType) {
-								case MEDIATYPE_VIDEO:
-									$links['video']++;
-									break;
-								default:
-									$links['image']++;
-							}
+					$file = wfFindFile($iname);
+					if ($file instanceof LocalFile) {
+						$mediaType = $file->getMediaType();
+						switch ($mediaType) {
+							case MEDIATYPE_VIDEO:
+								$links['video']++;
+								break;
+							default:
+								$links['image']++;
 						}
 					}
 					else {

--- a/extensions/wikia/VideoEmbedTool/WikiaVideoAdd_body.php
+++ b/extensions/wikia/VideoEmbedTool/WikiaVideoAdd_body.php
@@ -152,13 +152,6 @@ class WikiaVideoAddForm extends SpecialPage {
 						return;
 					}
 				}
-
-				if ( WikiaFileHelper::useWikiaVideoExtForEmbed() ) {
-					$video = new VideoPage( $title );
-					$video->parseUrl( $this->mUrl );
-					$video->setName( $this->mName );
-					$video->save();
-				}
 			} else {
 				//bad title returned
 				$errors['name'] = wfMessage( 'wva-failure' )->text();

--- a/includes/wikia/services/VideoService.class.php
+++ b/includes/wikia/services/VideoService.class.php
@@ -24,43 +24,39 @@ class VideoService extends WikiaModel {
 		}
 
 		try {
-			if ( WikiaFileHelper::isVideoStoredAsFile() ) {
-				// is it a WikiLink?
-				$title = Title::newFromText($url, NS_FILE);
-				if ( !$title || !WikiaFileHelper::isTitleVideo($title) ) {
-					$title = Title::newFromText( str_replace(array('[[',']]'),array('',''),$url), NS_FILE );
-				}
-				if ( !$title || !WikiaFileHelper::isTitleVideo($title) ) {
-					$transFileNS = wfMessage('nstab-image')->inContentLanguage()->text();
-
-					if ( ($pos = strpos($url, 'Video:')) !== false ) {
-						$title = Title::newFromText( substr($url,$pos), NS_FILE );
-					} elseif ( ($pos = strpos($url, 'File:')) !== false ) {
-						$title = Title::newFromText( substr($url,$pos), NS_FILE );
-					} elseif ( ($pos = strpos($url, $transFileNS.':')) !== false ) {
-						$title = Title::newFromText( substr($url,$pos), NS_FILE );
-					}
-				}
-				if ( $title && WikiaFileHelper::isTitleVideo($title) ) {
-					$videoTitle = $title;
-					$videoPageId = $title->getArticleId();
-					$videoProvider = '';
-					wfRunHooks( 'AddPremiumVideo', array( $title ) );
-				} else {
-					if ( empty( $this->wg->allowNonPremiumVideos ) ) {
-						wfProfileOut( __METHOD__ );
-						return wfMessage( 'videohandler-non-premium' )->parse();
-					}
-					list($videoTitle, $videoPageId, $videoProvider) = $this->addVideoVideoHandlers( $url );
-				}
-
-				// Add a default description if available and one doesn't already exist
-				$file = wfFindFile( $videoTitle );
-				$vHelper = new VideoHandlerHelper();
-				$vHelper->addDefaultVideoDescription( $file );
-			} else {
-				throw new Exception( wfMessage( 'videos-error-old-type-video' )->text() );
+			// is it a WikiLink?
+			$title = Title::newFromText($url, NS_FILE);
+			if ( !$title || !WikiaFileHelper::isFileTypeVideo($title) ) {
+				$title = Title::newFromText( str_replace(array('[[',']]'),array('',''),$url), NS_FILE );
 			}
+			if ( !$title || !WikiaFileHelper::isFileTypeVideo($title) ) {
+				$transFileNS = wfMessage('nstab-image')->inContentLanguage()->text();
+
+				if ( ($pos = strpos($url, 'Video:')) !== false ) {
+					$title = Title::newFromText( substr($url,$pos), NS_FILE );
+				} elseif ( ($pos = strpos($url, 'File:')) !== false ) {
+					$title = Title::newFromText( substr($url,$pos), NS_FILE );
+				} elseif ( ($pos = strpos($url, $transFileNS.':')) !== false ) {
+					$title = Title::newFromText( substr($url,$pos), NS_FILE );
+				}
+			}
+			if ( $title && WikiaFileHelper::isFileTypeVideo($title) ) {
+				$videoTitle = $title;
+				$videoPageId = $title->getArticleId();
+				$videoProvider = '';
+				wfRunHooks( 'AddPremiumVideo', array( $title ) );
+			} else {
+				if ( empty( $this->wg->allowNonPremiumVideos ) ) {
+					wfProfileOut( __METHOD__ );
+					return wfMessage( 'videohandler-non-premium' )->parse();
+				}
+				list($videoTitle, $videoPageId, $videoProvider) = $this->addVideoVideoHandlers( $url );
+			}
+
+			// Add a default description if available and one doesn't already exist
+			$file = wfFindFile( $videoTitle );
+			$vHelper = new VideoHandlerHelper();
+			$vHelper->addDefaultVideoDescription( $file );
 		} catch ( Exception $e ) {
 			wfProfileOut( __METHOD__ );
 			return $e->getMessage();

--- a/includes/wikia/services/WikiaFileHelper.class.php
+++ b/includes/wikia/services/WikiaFileHelper.class.php
@@ -7,28 +7,16 @@ class WikiaFileHelper extends Service {
 	const maxWideoWidth = 1200;
 
 	/**
-	 * Checks if videos on the wiki are converted to new format (File namespace)
-	 * @return boolean
-	 */
-	public static function isVideoStoredAsFile() {
-		// all videos are already converted and stored as a file
-		return true;
-	}
-
-	/**
 	 * Checks if given File is video
-	 * @param $file WikiaLocalFile object or Title object eventually
+	 * @param WikiaLocalFile|Title $file object or Title object eventually
 	 * @return boolean
 	 */
 	public static function isFileTypeVideo( $file ) {
-		if ( self::isVideoStoredAsFile() ) {
-			// File can be video only when new video logic is enabled for the wiki
-			if ( $file instanceof Title ) {
-				$file = wfFindFile( $file );
-			}
-			return self::isVideoFile( $file );
+		// File can be video only when new video logic is enabled for the wiki
+		if ( $file instanceof Title ) {
+			$file = wfFindFile( $file );
 		}
-		return false;
+		return self::isVideoFile( $file );
 	}
 
 	/**
@@ -54,21 +42,8 @@ class WikiaFileHelper extends Service {
 			return false;
 		}
 
-		if ( self::isVideoStoredAsFile() ) {
-
-			// video-as-file logic
-			if ( self::isFileTypeVideo( $title ) ) {
-
-				return true;
-			}
-			return false;
-
-		} elseif ( ( $title->getNamespace() == NS_VIDEO ) && $allowOld ) {
-
-			return true;
-		}
-
-		return false;
+		// video-as-file logic
+		return self::isFileTypeVideo( $title );
 	}
 
 
@@ -289,15 +264,7 @@ class WikiaFileHelper extends Service {
 	 * @return boolean
 	 */
 	public static function useVideoHandlersExtForIngestion() {
-		return static::isVideoStoredAsFile() || !empty( F::app()->wg->ingestVideosUseVideoHandlersExt );
-	}
-
-	/**
-	 * Can VideoHandlers extension be used to embed video
-	 * @return boolean
-	 */
-	public static function useWikiaVideoExtForEmbed() {
-		return !static::isVideoStoredAsFile() && !empty( F::app()->wg->embedVideosUseWikiaVideoExt );
+		return !empty( F::app()->wg->ingestVideosUseVideoHandlersExt );
 	}
 
 	/**
@@ -305,7 +272,7 @@ class WikiaFileHelper extends Service {
 	 * @return boolean
 	 */
 	public static function useVideoHandlersExtForEmbed() {
-		return static::isVideoStoredAsFile() || !empty( F::app()->wg->embedVideosUseVideoHandlersExt );
+		return !empty( F::app()->wg->embedVideosUseVideoHandlersExt );
 	}
 
 	/**


### PR DESCRIPTION
Eliminating constant value functions:
- WikiaFileHelper::isVideoStoredAsFile() - Always true
- WikiaFileHelper::useWikiaVideoExtForEmbed - Always false

Replacing deprecated method call:
- WikiaFileHelper::isTitleVideo replaced by WikiaFileHelper::isFileTypeVideo
