### PR TITLE
Fix rendering of TextInputMenuWidget

### DIFF
--- a/extensions/VisualEditor/modules/ve-mw/ui/widgets/ve.ui.MWCategoryWidget.js
+++ b/extensions/VisualEditor/modules/ve-mw/ui/widgets/ve.ui.MWCategoryWidget.js
@@ -34,7 +34,7 @@ ve.ui.MWCategoryWidget = function VeUiMWCategoryWidget( config ) {
 		'$$': this.$$, 'align': 'right', '$overlay': config.$overlay
 	} );
 	this.input = new ve.ui.MWCategoryInputWidget( this, {
-		'$$': this.$$, '$overlay': config.$overlay, '$container': this.$
+		'$$': this.$$, '$overlay': config.$overlay
 	} );
 
 	// Events

--- a/extensions/VisualEditor/modules/ve/ui/ve.ui.Frame.js
+++ b/extensions/VisualEditor/modules/ve/ui/ve.ui.Frame.js
@@ -84,7 +84,7 @@ ve.ui.Frame.prototype.load = function () {
 	doc.open();
 	doc.write(
 		'<!doctype html>' +
-		'<html>' +
+		'<html class="ve-ui-frame-html">' +
 			'<body class="ve-ui-frame-body ve-' + this.dir + '" style="direction:' + this.dir + ';" dir="' + this.dir + '">' +
 				'<div class="ve-ui-frame-content"></div>' +
 			'</body>' +

--- a/extensions/VisualEditor/wikia/VisualEditor.scss
+++ b/extensions/VisualEditor/wikia/VisualEditor.scss
@@ -13,6 +13,7 @@
 @import "extensions/VisualEditor/wikia/modules/ve/ui/styles/ve.ui.Icons-vector";
 @import "extensions/VisualEditor/wikia/modules/ve/ui/styles/ve.ui.Surface";
 @import "extensions/VisualEditor/wikia/modules/ve/ui/styles/ve.ui.Dialog";
+@import "extensions/VisualEditor/wikia/modules/ve/ui/styles/ve.ui.Frame";
 @import "extensions/VisualEditor/wikia/modules/ve/ui/styles/ve.ui.Tool";
 @import "extensions/VisualEditor/wikia/modules/ve/ui/styles/ve.ui.ToolGroup";
 @import "extensions/VisualEditor/wikia/modules/ve/ui/styles/ve.ui.WikiaMediaInsertDialog";

--- a/extensions/VisualEditor/wikia/modules/ve/ui/styles/ve.ui.Frame.scss
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/styles/ve.ui.Frame.scss
@@ -1,0 +1,3 @@
+.ve-ui-frame-html, .ve-ui-frame-body {
+	height: 100%;
+}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/VE-441

The change to ve.ui.MWCategoryWidget.js is something that the Foundation has already done in their latest. This was passing the CategoryWidget as the location to anchor the menu to. Omitting a container specification in the config makes TextInputMenuWidget use its input as the anchor. 

The height wasn't being properly set because it relies on a calculation of the innerHeight of the dialog, which is 0 because the html and body tags weren't getting height set to 100%. The MW Vector skin sets this, so it was never noticed before.

@kflorence @kenkouot @inez @lizlux 
