### PR TITLE
BAC-1004:ThemeDesigner does not work with new Swift Storage (affects wikis with short bucket name)

### DIFF
--- a/extensions/wikia/SASS/SassUtil.php
+++ b/extensions/wikia/SASS/SassUtil.php
@@ -55,7 +55,7 @@ class SassUtil {
 	 *  - theme chosen using usetheme URL param
 	 */
 	public static function getOasisSettings() {
-		global $wgOasisThemes, $wgContLang;
+		global $wgContLang;
 		wfProfileIn(__METHOD__);
 
 		// Load the 5 deafult colors by theme here (eg: in case the wiki has an override but the user doesn't have overrides).
@@ -70,7 +70,7 @@ class SassUtil {
 			$oasisSettings["color-buttons"] = self::sanitizeColor($settings["color-buttons"]);
 			$oasisSettings["color-links"] = self::sanitizeColor($settings["color-links"]);
 			$oasisSettings["color-header"] = self::sanitizeColor($settings["color-header"]);
-			$oasisSettings["background-image"] = wfReplaceImageServer($settings['background-image'], self::getCacheBuster());
+			$oasisSettings["background-image"] = $themeSettings->getBackgroundUrl();
 
 			// sending width and height of background image to SASS
 			if ( !empty($settings["background-image-width"]) && !empty($settings["background-image-height"]) ) {
@@ -198,7 +198,7 @@ class SassUtil {
 	 *
 	 * @see http://blog.archive.jpsykes.com/211/rgb2hsl/index.html
 	 *
-	 * @param string RGB color in hex format (#474646)
+	 * @param string $rgbhex RGB color in hex format (#474646)
 	 * @return array HSL set
 	 */
 	private static function rgb2hsl($rgbhex){

--- a/extensions/wikia/ThemeDesigner/ThemeSettings.class.php
+++ b/extensions/wikia/ThemeDesigner/ThemeSettings.class.php
@@ -260,7 +260,7 @@ class ThemeSettings {
 	 * "background-image" entry (for custom backgrounds) and settings revision ID are ignored.
 	 *
 	 * @author macbre
-	 * @return string|bool wordmark URL or false if not found
+	 * @return string|bool background URL or false if not found
 	 */
 	public function getBackgroundUrl() {
 		$settings = $this->getSettings();

--- a/extensions/wikia/ThemeDesigner/ThemeSettings.class.php
+++ b/extensions/wikia/ThemeDesigner/ThemeSettings.class.php
@@ -252,4 +252,28 @@ class ThemeSettings {
 
 		return ($file instanceof File) ? $file->getUrl() : false;
 	}
+
+	/**
+	 * Get wiki background full, up-to-date URL
+	 *
+	 * This method returns URL based on "background-image-name" settings entry.
+	 * "background-image" entry (for custom backgrounds) and settings revision ID are ignored.
+	 *
+	 * @author macbre
+	 * @return string|bool wordmark URL or false if not found
+	 */
+	public function getBackgroundUrl() {
+		$settings = $this->getSettings();
+		$hasCustomBackground = $settings['background-image-name'] !== '';
+
+		// return standard, themed background - e.g. '/skins/oasis/images/themes/plated.jpg'
+		if (!$hasCustomBackground) {
+			return $settings['background-image'];
+		}
+
+		$title = Title::newFromText($this->getSettings()['background-image-name'] , NS_FILE);
+		$file = ($title instanceof Title) ? wfFindFile($title) : false;
+
+		return ($file instanceof File) ? $file->getUrl() : false;
+	}
 }

--- a/extensions/wikia/ThemeDesigner/ThemeSettings.class.php
+++ b/extensions/wikia/ThemeDesigner/ThemeSettings.class.php
@@ -234,9 +234,22 @@ class ThemeSettings {
 			}
 		}
 
-
 		WikiFactory::setVarByName(self::WikiFactoryHistory, $cityId, $history, $reason);
-
 	}
 
+	/**
+	 * Get wordmark full, up-to-date URL
+	 *
+	 * This method returns URL based on "wordmark-image-name" settings entry.
+	 * "wordmark-image-url" entry and settings revision ID are ignored.
+	 *
+	 * @author macbre
+	 * @return string|bool wordmark URL or false if not found
+	 */
+	public function getWordmarkUrl() {
+		$title = Title::newFromText($this->getSettings()['wordmark-image-name'] , NS_FILE);
+		$file = ($title instanceof Title) ? wfFindFile($title) : false;
+
+		return ($file instanceof File) ? $file->getUrl() : false;
+	}
 }

--- a/extensions/wikia/WikiaMobile/WikiaMobileNavigationService.class.php
+++ b/extensions/wikia/WikiaMobile/WikiaMobileNavigationService.class.php
@@ -24,7 +24,7 @@ class  WikiaMobileNavigationService extends WikiaService {
 		$this->response->setVal( 'wordmarkFont', $settings["wordmark-font"] );
 
 		if ( $settings["wordmark-type"] == "graphic" ) {
-			$this->response->setVal( 'wordmarkUrl', wfReplaceImageServer( $settings['wordmark-image-url'], SassUtil::getCacheBuster() ) );
+			$this->response->setVal( 'wordmarkUrl', $themeSettings->getWordmarkUrl() );
 		} else {
 			$this->response->setVal( 'wikiName', ( !empty( $settings['wordmark-text'] ) ) ? $settings['wordmark-text'] : $this->wg->SiteName );
 		}

--- a/skins/oasis/modules/WikiHeaderController.class.php
+++ b/skins/oasis/modules/WikiHeaderController.class.php
@@ -15,7 +15,7 @@ class WikiHeaderController extends WikiaController {
 
 		if ($this->wordmarkType == "graphic") {
 			wfProfileIn(__METHOD__ . 'graphicWordmarkV2');
-			$this->wordmarkUrl = wfReplaceImageServer($settings['wordmark-image-url'], SassUtil::getCacheBuster());
+			$this->wordmarkUrl = $themeSettings->getWordmarkUrl();
 			$imageTitle = Title::newFromText($themeSettings::WordmarkImageName, NS_IMAGE);
 			if ($imageTitle instanceof Title) {
 				$attributes = array();
@@ -50,7 +50,7 @@ class WikiHeaderController extends WikiaController {
 		$this->wordmarkUrl = '';
 		if ($this->wordmarkType == "graphic") {
 			wfProfileIn(__METHOD__ . 'graphicWordmark');
-			$this->wordmarkUrl = wfReplaceImageServer($settings['wordmark-image-url'], SassUtil::getCacheBuster());
+			$this->wordmarkUrl = $themeSettings->getWordmarkUrl();
 			$imageTitle = Title::newFromText($themeSettings::WordmarkImageName, NS_IMAGE);
 			if ($imageTitle instanceof Title) {
 				$attributes = array();


### PR DESCRIPTION
@Wikia/platform-team

https://wikia-inc.atlassian.net/browse/BAC-1004

Introduce two helper methods in `ThemeSettings` class that return up-to-date full URLs for wiki background and wordmark, instead of returning them from ThemeDesigner settings stored as JSON in WikiFactory (which can be outdated during images migration to Swift).

Please review:
- @themech - ThemeDesigner changes
- @federico-lox, @hakubo - Mobile code changes
- @sebastian-wikia - Oasis and SassUtil changes
