### PR TITLE
DAR-2753: Remove quote button on closed threads

### DIFF
--- a/extensions/wikia/Wall/templates/Wall_messageButtons.php
+++ b/extensions/wikia/Wall/templates/Wall_messageButtons.php
@@ -1,7 +1,7 @@
 <div class="buttons">
 
-	<? if($canFastAdminDelete): ?>
-		<button  class="secondary fast-admin-delete-message" data-mode="fastadmin"><?= wfMsg('wall-message-fast-admin-delete-message') ?></button>
+	<? if ( $canFastAdminDelete ): ?>
+		<button  class="secondary fast-admin-delete-message" data-mode="fastadmin"><?= wfMessage( 'wall-message-fast-admin-delete-message' )->escaped() ?></button>
 	<? endif; ?>
 
 	<? if ( !$isClosed ): ?>
@@ -11,103 +11,103 @@
 	<?php
 		$dropdown = array();
 
-		if($canEdit) {
+		if ( $canEdit ) {
 			$dropdown[] = array(
 				'class' => 'edit-message',
 				'href' => '#',
-				'text' => wfMsg('wall-message-edit'),
+				'text' => wfMessage( 'wall-message-edit' )->escaped(),
 			);
 		}
 
 		$dropdown[] = array(
 			'class' => 'thread-history',
 			'href' => $threadHistoryLink,
-			'text' => wfMsg('history_short')
+			'text' => wfMessage( 'history_short' )->escaped(),
 		);
 
-		if($canAdminDelete) {
+		if ( $canAdminDelete ) {
 			$dropdown[] = array(
 				'attr' => 'data-mode="admin"',
 				'class' => 'admin-delete-message',
 				'href' => '#',
-				'text' => wfMsg('wall-message-delete'),
+				'text' => wfMessage( 'wall-message-delete' )->escaped(),
 			);
 		}
 
-		if($showViewSource) {
+		if ( $showViewSource ) {
 			$dropdown[] = array(
 				'class' => 'source-message',
 				'href' => '#',
-				'text' => wfMsg('user-action-menu-view-source'),
+				'text' => wfMessage( 'user-action-menu-view-source' )->escaped(),
 			);
 		}
 
-		if($canRemove) {
+		if ( $canRemove ) {
 			$dropdown[] = array(
 				'attr' => 'data-mode="remove"',
 				'class' => 'remove-message',
 				'href' => '#',
-				'text' => wfMsg('wall-message-remove'),
+				'text' => wfMessage( 'wall-message-remove' )->escaped(),
 			);
 		}
 
-		if($canDelete) {
+		if ( $canDelete ) {
 			$dropdown[] = array(
 				'attr' => 'data-mode="rev"',
 				'class' => 'delete-message',
 				'href' => '#',
-				'text' => wfMsg('wall-message-rev-delete'),
+				'text' => wfMessage( 'wall-message-rev-delete' )->escaped(),
 			);
 		}
 
-		if($canNotifyeveryone) {
+		if ( $canNotifyeveryone ) {
 			$dropdown[] = array(
 				'attr' => 'data-dir="1"',
 				'class' => 'edit-notifyeveryone',
 				'href' => '#',
-				'text' => wfMsg('wall-message-notifyeveryone'),
+				'text' => wfMessage( 'wall-message-notifyeveryone' )->escaped(),
 			);
 		}
 
-		if($canUnnotifyeveryone) {
+		if ( $canUnnotifyeveryone ) {
 			$dropdown[] = array(
 				'attr' => 'data-mode="0"',
 				'class' => 'edit-notifyeveryone',
 				'href' => '#',
-				'text' => wfMsg('wall-message-unnotifyeveryone'),
+				'text' => wfMessage( 'wall-message-unnotifyeveryone' )->escaped(),
 			);
 		}
 
-		if($canClose) {
+		if ( $canClose ) {
 			$dropdown[] = array(
 				'attr' => 'data-mode="close"',
 				'class' => 'close-thread',
 				'href' => '#',
-				'text' => wfMsg('wall-message-close-thread'),
+				'text' => wfMessage( 'wall-message-close-thread' )->escaped(),
 			);
 		}
 
-		if($canReopen) {
+		if ( $canReopen ) {
 			$dropdown[] = array(
 				'class' => 'reopen-thread',
 				'href' => '#',
-				'text' => wfMsg('wall-message-reopen-thread'),
+				'text' => wfMessage( 'wall-message-reopen-thread' )->escaped(),
 			);
 		}
 
-		if($canMove) {
+		if ( $canMove ) {
 			$dropdown[] = array(
 				'class' => 'move-thread',
 				'href' => '#',
-				'text' => wfMsg('wall-message-move-thread'),
+				'text' => wfMessage( 'wall-message-move-thread' )->escaped(),
 			);
 		}
 	?>
-	<?php if(!empty($dropdown)): ?>
-		<?= F::app()->renderView('MenuButton',
+	<?php if ( !empty( $dropdown ) ): ?>
+		<?= F::app()->renderView( 'MenuButton',
 			'Index',
 			array(
-				'action' => array("text" => wfMsg('wall-message-more'), "id" => ""),
+				'action' => array( 'text' => wfMessage( 'wall-message-more' )->escaped(), 'id' => '' ),
 				'class' => 'secondary',
 				'dropdown' => $dropdown
 			)
@@ -118,53 +118,53 @@
 <div class="buttons-monobook">
 	<!-- only show this if it's user's own message -->
 	<span class="tools">
-		<? if($canFastAdminDelete): ?>
-			<a href="#"  class="fast-admin-delete-message" data-mode="fastadmin"><?= wfMsg('wall-message-fast-admin-delete-message') ?></a>
+		<? if( $canFastAdminDelete ): ?>
+			<a href="#"  class="fast-admin-delete-message" data-mode="fastadmin"><?= wfMessage( 'wall-message-fast-admin-delete-message' )->escaped() ?></a>
 		<? endif; ?>
 
 		<? if ( !$isClosed ): ?>
 			<a href="#" class="quote-button"><?= wfMessage( 'wall-message-quote-button' )->escaped() ?></a>
 		<? endif; ?>
 
-		<? if( $canClose ): ?>
-		 	<a href="#" class="close-thread" data-mode="close"> <?= wfMsg('wall-message-close-thread'); ?> </a>
-		 <? endif; ?>
-
-		<? if( $canReopen): ?>
-		 	<a href="#" class="reopen-thread"> <?= wfMsg('wall-message-reopen-thread'); ?> </a>
+		<? if ( $canClose ): ?>
+			<a href="#" class="close-thread" data-mode="close"> <?= wfMessage( 'wall-message-close-thread' )->escaped(); ?> </a>
 		<? endif; ?>
 
-		<? if( $showViewSource ): ?>
-			<a href="#" class="source-message"> <?= wfMsg('user-action-menu-view-source'); ?> </a>
+		<? if ( $canReopen): ?>
+			<a href="#" class="reopen-thread"> <?= wfMessage( 'wall-message-reopen-thread' )->escaped(); ?> </a>
 		<? endif; ?>
 
-                <a href="<?= $threadHistoryLink ?>" class="thread-history"> <?= wfMsg('history_short'); ?> </a>
+		<? if ( $showViewSource ): ?>
+			<a href="#" class="source-message"> <?= wfMessage( 'user-action-menu-view-source' )->escaped(); ?> </a>
+		<? endif; ?>
 
-		<?php if( $canEdit ): ?>
-			<img src="<?= $wgBlankImgUrl ?>" class="sprite edit-pencil"><a href="#" class="edit-message"><?= wfMsg('wall-message-edit'); ?></a>
+		<a href="<?= $threadHistoryLink ?>" class="thread-history"> <?= wfMessage( 'history_short' )->escaped(); ?> </a>
+
+		<?php if ( $canEdit ): ?>
+			<img src="<?= $wgBlankImgUrl ?>" class="sprite edit-pencil"><a href="#" class="edit-message"><?= wfMessage( 'wall-message-edit' )->escaped(); ?></a>
 		<?php endif; ?>
 
-		<? if( $canRemove ): ?>
-			<img src="<?= $wgBlankImgUrl ?>" class="sprite-small delete"><a href="#" class="remove-message" data-mode="remove"><?= wfMsg('wall-message-remove'); ?> </a>
+		<? if ( $canRemove ): ?>
+			<img src="<?= $wgBlankImgUrl ?>" class="sprite-small delete"><a href="#" class="remove-message" data-mode="remove"><?= wfMessage( 'wall-message-remove' )->escaped(); ?> </a>
 		<? endif; ?>
 
-		<? if( $canAdminDelete ): ?>
-			<img src="<?= $wgBlankImgUrl ?>" class="sprite-small delete"><a href="#" class="admin-delete-message" data-mode="admin"><?= wfMsg('wall-message-delete'); ?> </a>
+		<? if ( $canAdminDelete ): ?>
+			<img src="<?= $wgBlankImgUrl ?>" class="sprite-small delete"><a href="#" class="admin-delete-message" data-mode="admin"><?= wfMessage( 'wall-message-delete' )->escaped(); ?> </a>
 		<?php endif;?>
 
-		<?php if( $canDelete ): ?>
-			<img src="<?= $wgBlankImgUrl ?>" class="sprite-small delete"><a href="#" class="delete-message"><?= wfMsg('wall-message-delete'); ?></a>
+		<?php if ( $canDelete ): ?>
+			<img src="<?= $wgBlankImgUrl ?>" class="sprite-small delete"><a href="#" class="delete-message"><?= wfMessage( 'wall-message-rev-delete' )->escaped(); ?></a>
 		<?php endif; ?>
 
-		 <? if( $canNotifyeveryone ): ?>
-		 	<a href="#" class="edit-notifyeveryone" data-dir="1"> <?= wfMsg('wall-message-notifyeveryone'); ?> </a>
-		 <? endif; ?>
-		 <? if( $canUnnotifyeveryone ): ?>
-		 	<a href="#" class="edit-notifyeveryone" data-mode="0"> <?= wfMsg('wall-message-unnotifyeveryone'); ?> </a>
-		 <? endif; ?>
-		 <? if( $canMove ): ?>
-		 	<a href="#" class="move-thread"> <?= wfMsg('wall-message-move-thread'); ?> </a>
-		 <? endif; ?>
+		<? if ( $canNotifyeveryone ): ?>
+			<a href="#" class="edit-notifyeveryone" data-dir="1"> <?= wfMessage( 'wall-message-notifyeveryone' )->escaped(); ?> </a>
+		<? endif; ?>
+		<? if ( $canUnnotifyeveryone ): ?>
+			<a href="#" class="edit-notifyeveryone" data-mode="0"> <?= wfMessage( 'wall-message-unnotifyeveryone' )->escaped(); ?> </a>
+		<? endif; ?>
+		<? if ( $canMove ): ?>
+			<a href="#" class="move-thread"> <?= wfMessage( 'wall-message-move-thread' )->escaped(); ?> </a>
+		<? endif; ?>
 
 	</span>
 </div>

--- a/extensions/wikia/Wall/templates/Wall_messageButtons.php
+++ b/extensions/wikia/Wall/templates/Wall_messageButtons.php
@@ -1,11 +1,13 @@
 <div class="buttons">
-	
+
 	<? if($canFastAdminDelete): ?>
 		<button  class="secondary fast-admin-delete-message" data-mode="fastadmin"><?= wfMsg('wall-message-fast-admin-delete-message') ?></button>
 	<? endif; ?>
 
-	<button class="quote-button secondary"><?= wfMsg('wall-message-quote-button') ?></button>
-	
+	<? if ( !$isClosed ): ?>
+		<button class="quote-button secondary"><?= wfMessage( 'wall-message-quote-button' )->escaped() ?></button>
+	<? endif; ?>
+
 	<?php
 		$dropdown = array();
 
@@ -92,7 +94,7 @@
 				'text' => wfMsg('wall-message-reopen-thread'),
 			);
 		}
-		
+
 		if($canMove) {
 			$dropdown[] = array(
 				'class' => 'move-thread',
@@ -119,17 +121,19 @@
 		<? if($canFastAdminDelete): ?>
 			<a href="#"  class="fast-admin-delete-message" data-mode="fastadmin"><?= wfMsg('wall-message-fast-admin-delete-message') ?></a>
 		<? endif; ?>
-		
-		<a href="#" class="quote-button"><?= wfMsg('wall-message-quote-button') ?></a>
-		
+
+		<? if ( !$isClosed ): ?>
+			<a href="#" class="quote-button"><?= wfMessage( 'wall-message-quote-button' )->escaped() ?></a>
+		<? endif; ?>
+
 		<? if( $canClose ): ?>
 		 	<a href="#" class="close-thread" data-mode="close"> <?= wfMsg('wall-message-close-thread'); ?> </a>
 		 <? endif; ?>
-		 
+
 		<? if( $canReopen): ?>
 		 	<a href="#" class="reopen-thread"> <?= wfMsg('wall-message-reopen-thread'); ?> </a>
 		<? endif; ?>
-		
+
 		<? if( $showViewSource ): ?>
 			<a href="#" class="source-message"> <?= wfMsg('user-action-menu-view-source'); ?> </a>
 		<? endif; ?>


### PR DESCRIPTION
Remove quote button on closed threads as the user can't reply anyway and it causes a JS error when clicked.

Plus, wfMsg -> wfMessage cleanup in touched file.

For a Darwin SLA ticket.

@themech 
