### PR TITLE
(CE-482) Comment out proxy for RSS feeds

### DIFF
--- a/extensions/3rdparty/RSS/magpierss/rss_fetch.inc
+++ b/extensions/3rdparty/RSS/magpierss/rss_fetch.inc
@@ -294,7 +294,7 @@ function _fetch_remote_file ($url, $headers = "" ) {
 \*=======================================================================*/
 function _response_to_rss ($resp) {
     $rss = new MagpieRSS( $resp->results, MAGPIE_OUTPUT_ENCODING, MAGPIE_INPUT_ENCODING, MAGPIE_DETECT_ENCODING );
-    
+
     // if RSS parsed successfully
     if ( $rss and !$rss->ERROR) {
 
@@ -401,7 +401,7 @@ function init () {
 
 	// Wikia change - begin
 	// BugId:985
-	global $wgHTTPProxy;
+	/*global $wgHTTPProxy;
 
 	if (!empty($wgHTTPProxy)) {
 		list($proxyHost, $proxyPort) = explode(':', $wgHTTPProxy);
@@ -412,7 +412,7 @@ function init () {
 		if ( !defined('MAGPIE_PROXY_PORT') ) {
 			define('MAGPIE_PROXY_PORT', $proxyPort);
 		}
-	}
+	}*/
 	// Wikia change - end
 
     if ( !defined('MAGPIE_PROXY_HOST') ) {


### PR DESCRIPTION
RSS feeds are currently always returning an error message. This is fixed
by removing the Wikia change that sets a proxy for it. Leaving it
commented rather than removing it as we may want to revert this once the
proxy issues are resolved.

Cherry picking from release-195.
