### PR TITLE
VE-545: Purge ResourceLoader startup file when wgEnableVisualEditorExt is toggled

### DIFF
--- a/extensions/wikia/WikiFactoryChangedHooks/WikiFactoryChangedHooks.class.php
+++ b/extensions/wikia/WikiFactoryChangedHooks/WikiFactoryChangedHooks.class.php
@@ -198,4 +198,33 @@ Class WikiFactoryChangedHooks {
 		}
 		return true;
 	}
+
+	static public function VisualEditor($cv_name, $wiki_id, $value) {
+		global $wgOut;
+		if ($cv_name == 'wgEnableVisualEditorExt') {
+			Wikia::log(__METHOD__, $wiki_id, "{$cv_name} = {$value}");
+
+			// get resource loader url
+			$link = $wgOut->makeResourceLoaderLink('startup', ResourceLoaderModule::TYPE_SCRIPTS);
+			if ($link != null) {
+			// extract the url from the link src
+				preg_match("/\"(.*)\"/", $link, $matches);
+				if ( isset($matches[1]) ) {
+					$urls[]= $matches[1];
+				}
+			}
+
+			// parsed resource loader URL
+			$resourceLoaderURL = parse_url( $urls[0] );
+			// parsed wiki URL
+			$wikiURL = parse_url( GlobalTitle::newFromText( 'Version', NS_SPECIAL, $wiki_id )->getFullURL() );
+			// URL to purge (constructed from $resourceLoaderURL and $wikiURL)
+			$purgeURL = $wikiURL['scheme'] . '://' . $wikiURL['host'] . $resourceLoaderURL['path'];
+
+			// purge
+			$u = new SquidUpdate( [$purgeURL] );
+			$u->doUpdate();
+		}
+		return true;
+	}
 }

--- a/extensions/wikia/WikiFactoryChangedHooks/WikiFactoryChangedHooks.class.php
+++ b/extensions/wikia/WikiFactoryChangedHooks/WikiFactoryChangedHooks.class.php
@@ -208,14 +208,13 @@ Class WikiFactoryChangedHooks {
 			$link = $wgOut->makeResourceLoaderLink('startup', ResourceLoaderModule::TYPE_SCRIPTS);
 			if ($link != null) {
 			// extract the url from the link src
-				preg_match("/\"(.*)\"/", $link, $matches);
-				if ( isset($matches[1]) ) {
-					$urls[]= $matches[1];
+				if ( preg_match("/\"(.*)\"/", $link, $matches) ) {
+					$url= $matches[1];
 				}
 			}
 
 			// parsed resource loader URL
-			$resourceLoaderURL = parse_url( $urls[0] );
+			$resourceLoaderURL = parse_url( $url );
 			// parsed wiki URL
 			$wikiURL = parse_url( GlobalTitle::newFromText( 'Version', NS_SPECIAL, $wiki_id )->getFullURL() );
 			// URL to purge (constructed from $resourceLoaderURL and $wikiURL)

--- a/extensions/wikia/WikiFactoryChangedHooks/WikiFactoryChangedHooks.class.php
+++ b/extensions/wikia/WikiFactoryChangedHooks/WikiFactoryChangedHooks.class.php
@@ -208,20 +208,20 @@ Class WikiFactoryChangedHooks {
 			$link = $wgOut->makeResourceLoaderLink('startup', ResourceLoaderModule::TYPE_SCRIPTS);
 			if ($link != null) {
 			// extract the url from the link src
-				if ( preg_match("/\"(.*)\"/", $link, $matches) ) {
+				if (preg_match("/\"(.*)\"/", $link, $matches)) {
 					$url= $matches[1];
 				}
 			}
 
 			// parsed resource loader URL
-			$resourceLoaderURL = parse_url( $url );
+			$resourceLoaderURL = parse_url($url);
 			// parsed wiki URL
-			$wikiURL = parse_url( GlobalTitle::newFromText( 'Version', NS_SPECIAL, $wiki_id )->getFullURL() );
+			$wikiURL = parse_url(GlobalTitle::newFromText('Version', NS_SPECIAL, $wiki_id )->getFullURL());
 			// URL to purge (constructed from $resourceLoaderURL and $wikiURL)
 			$purgeURL = $wikiURL['scheme'] . '://' . $wikiURL['host'] . $resourceLoaderURL['path'];
 
 			// purge
-			$u = new SquidUpdate( [$purgeURL] );
+			$u = new SquidUpdate([$purgeURL]);
 			$u->doUpdate();
 		}
 		return true;

--- a/extensions/wikia/WikiFactoryChangedHooks/WikiFactoryChangedHooks.class.php
+++ b/extensions/wikia/WikiFactoryChangedHooks/WikiFactoryChangedHooks.class.php
@@ -206,23 +206,20 @@ Class WikiFactoryChangedHooks {
 
 			// get resource loader url
 			$link = $wgOut->makeResourceLoaderLink('startup', ResourceLoaderModule::TYPE_SCRIPTS);
-			if ($link != null) {
-			// extract the url from the link src
-				if (preg_match("/\"(.*)\"/", $link, $matches)) {
-					$url= $matches[1];
-				}
+			if ($link != null && preg_match("/\"(.*)\"/", $link, $matches)) {
+				// parsed resource loader URL
+				$resourceLoaderURL = parse_url($matches[1]);
+				// parsed wiki URL
+				$wikiURL = parse_url(GlobalTitle::newFromText('Version', NS_SPECIAL, $wiki_id )->getFullURL());
+				// URL to purge (constructed from $resourceLoaderURL and $wikiURL)
+				$purgeURL = $wikiURL['scheme'] . '://' . $wikiURL['host'] . $resourceLoaderURL['path'];
+
+				// purge
+				$update = new SquidUpdate([$purgeURL]);
+				$update->doUpdate();
+			} else {
+				Wikia::log( __METHOD__, false, "Error retreiving script tag for ResourceLoader startup js file");
 			}
-
-			// parsed resource loader URL
-			$resourceLoaderURL = parse_url($url);
-			// parsed wiki URL
-			$wikiURL = parse_url(GlobalTitle::newFromText('Version', NS_SPECIAL, $wiki_id )->getFullURL());
-			// URL to purge (constructed from $resourceLoaderURL and $wikiURL)
-			$purgeURL = $wikiURL['scheme'] . '://' . $wikiURL['host'] . $resourceLoaderURL['path'];
-
-			// purge
-			$u = new SquidUpdate([$purgeURL]);
-			$u->doUpdate();
 		}
 		return true;
 	}

--- a/extensions/wikia/WikiFactoryChangedHooks/WikiFactoryChangedHooks.php
+++ b/extensions/wikia/WikiFactoryChangedHooks/WikiFactoryChangedHooks.php
@@ -14,4 +14,4 @@ $wgHooks['WikiFactoryChanged'][] = 'WikiFactoryChangedHooks::BlogArticle';
 $wgHooks['WikiFactoryChanged'][] = 'WikiFactoryChangedHooks::FounderProgressBar';
 $wgHooks['WikiFactoryChanged'][] = 'WikiFactoryChangedHooks::recipesTweaks';
 $wgHooks['WikiFactoryChanged'][] = 'WikiFactoryChangedHooks::onAbuseFilterEnabled';
-
+$wgHooks['WikiFactoryChanged'][] = 'WikiFactoryChangedHooks::VisualEditor';


### PR DESCRIPTION
This will add the Resource Loader startup JS asset to the scribe queue to be purged. This is required to toggle VisualEditor in WikiFactory.
