### PR TITLE
BAC-1051 - Removing global WF changelog link

### DIFF
--- a/extensions/wikia/WikiFactory/SpecialWikiFactory_body.php
+++ b/extensions/wikia/WikiFactory/SpecialWikiFactory_body.php
@@ -65,19 +65,7 @@ class WikiFactoryPage extends SpecialPage {
 		$wgOut->setRobotpolicy( 'noindex,nofollow' );
 		$wgOut->setArticleRelated( false );
 
-		#--- handle chagelog
-		if ( $subpage === "change.log" ) {
-			$oPager = new ChangeLogPager;
-
-			$oTmpl = new EasyTemplate( dirname( __FILE__ ) . "/templates/" );
-			$oTmpl->set_vars( array(
-				"limit"     => $oPager->getForm(),
-				"body"      => $oPager->getBody(),
-				"nav"       => $oPager->getNavigationBar()
-			));
-			$wgOut->addHTML( $oTmpl->render("changelog") );
-		}
-		elseif ( in_array( strtolower($subpage), array( "metrics", "metrics/main", "metrics/monthly", "metrics/daily" ) ) ) {
+		if ( in_array( strtolower($subpage), array( "metrics", "metrics/main", "metrics/monthly", "metrics/daily" ) ) ) {
 			$oAWCMetrics = new WikiMetrics();
 			$oAWCMetrics->show( $subpage );
 		}

--- a/extensions/wikia/WikiFactory/templates/selector.tmpl.php
+++ b/extensions/wikia/WikiFactory/templates/selector.tmpl.php
@@ -52,9 +52,6 @@ table.TablePager { border: 1px solid gray;}
 	<li>
 		You can use filters in the <a href="<?php echo $title->getFullUrl() ?>/metrics"><strong>metrics interface</strong></a>
 	</li>
-	<li>
-		<a href="<?php echo $title->getFullUrl() ?>/change.log"><strong>Changelog for variables (all wikis)</strong></a>
-	</li>
 </ul>
 <!-- e:short info -->
 <br />


### PR DESCRIPTION
The global Changelog WF query can seriously affect the performance of the DB on production, this will require further work but for now we'll just remove the functionality's entry-point.
