### PR TITLE
VOLDEV-23: Special:Contributions links to Message Walls broken (individual Threads okay)

### DIFF
--- a/extensions/wikia/Wall/WallHelper.class.php
+++ b/extensions/wikia/Wall/WallHelper.class.php
@@ -633,7 +633,7 @@ class WallHelper {
 				'articleFullUrl' => $wm->getMessagePageUrl(),
 				'articleTitleVal' => $articleTitleTxt,
 				'articleTitleTxt' => empty( $articleTitleTxt ) ? wfMsg( 'wall-recentchanges-deleted-reply-title' ) : $articleTitleTxt,
-				'wallPageUrl' => $wm->getArticleTitle()->getPrefixedText(),
+				'wallPageUrl' => $wm->getArticleTitle()->getLocalURL(),
 				'wallPageFullUrl' => $wm->getArticleTitle()->getFullUrl(),
 				'wallPageName' => $wm->getArticleTitle()->getText(),
 				'actionUser' => $userText,


### PR DESCRIPTION
@grunny @mroszka 

Copy/paste error was outputting the title of the page (`Message Wall:Username`) instead of a url to the page as the `href` for the link. Browsers took this to mean that it should be appended to the end of the url with a `/`, thus creating links to `/wiki/Special:Contributions/Message Wall:Username`. It fixed itself when filtered by namespace because that would cause it to use the copy/paste source, which was correct.
