### PR TITLE
removing maxparams from jshint

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -13,7 +13,6 @@
 	"latedef": true,
 	"maxdepth": 3,
 	"maxlen": 120,
-	"maxparams": 4,
 	"newcap": true,
 	"noarg": true,
 	"noempty": true,


### PR DESCRIPTION
Per conversations with Rychu and JSSG team, we'd like to remove the maxparams rule from JSHint and add it to the style guide.  The reason for this is that, the way we have it set up, we often need more than four dependencies in AMD modules.
