### PR TITLE
BAC-979: sync avatars with NFS

### DIFF
--- a/extensions/wikia/UserProfilePageV3/Masthead.class.php
+++ b/extensions/wikia/UserProfilePageV3/Masthead.class.php
@@ -725,7 +725,10 @@ class Masthead {
 				}
 
 				// sync with NFS
-				copy($sFilePath, $this->getFullPath());
+				global $wgEnableSwithSyncToLocalFS;
+				if (!empty($wgEnableSwithSyncToLocalFS)) {
+					copy($sFilePath, $this->getFullPath());
+				}
 			}
 
 			$sUserText =  $this->mUser->getName();

--- a/extensions/wikia/UserProfilePageV3/Masthead.class.php
+++ b/extensions/wikia/UserProfilePageV3/Masthead.class.php
@@ -679,7 +679,7 @@ class Masthead {
 		/**
 		 * generate new image to png format
 		 */
-		$sFilePath = empty( $wgAvatarsUseSwiftStorage ) ? $this->getFullPath() : $this->getTempFile();
+		$sFilePath = empty( $wgAvatarsUseSwiftStorage ) ? $this->getFullPath() : $this->getTempFile(); // either NFS or temp file
 
 		$ioh = new ImageOperationsHelper();
 		$oImg = $ioh->postProcess(  $oImgOrig, $aOrigSize );
@@ -700,7 +700,7 @@ class Masthead {
 		else {
 			$errorNo = UPLOAD_ERR_OK;
 
-			/* remove tmp file */
+			/* remove tmp image */
 			imagedestroy($oImg);
 
 			// store the avatar on Swift
@@ -723,6 +723,9 @@ class Masthead {
 						'dst' => $mwStorePath
 					] )->add();
 				}
+
+				// sync with NFS
+				copy($sFilePath, $this->getFullPath());
 			}
 
 			$sUserText =  $this->mUser->getName();


### PR DESCRIPTION
Avatars stored on Swift should be synced with an old, NFS-based storage.

@moliwikia / @Wikia/platform-team 
