### PR TITLE
Revert 'DAR-985 Always tidy Article Comment markup when parsing'. This r...

### DIFF
--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -247,11 +247,6 @@ class ArticleComment {
 
 		$parser->ac_metadata = [];
 
-		// Always tidy Article Comment markup to avoid breakage of surrounding markup
-		global $wgAlwaysUseTidy;
-		$oldWgAlwaysUseTidy = $wgAlwaysUseTidy;
-		$wgAlwaysUseTidy = true;
-
 		$head = $parser->parse( $rawtext, $this->mTitle, ParserOptions::newFromContext( RequestContext::getMain() ) );
 
 		$this->mText = $head->getText();
@@ -264,9 +259,6 @@ class ArticleComment {
 		}
 
 		ParserPool::release( $parser );
-
-		// Restore old value of $wgAlwaysUseTidy
-		$wgAlwaysUseTidy = $oldWgAlwaysUseTidy;
 
 		return $this->mText;
 	}


### PR DESCRIPTION
...everts commit

df248d208d7e14cfedb683c791b94ff65df6043f. Tidy no longer needed. Closes VID-1011
