### PR TITLE
VE-317: Single preference

### DIFF
--- a/extensions/VisualEditor/VisualEditor.hooks.php
+++ b/extensions/VisualEditor/VisualEditor.hooks.php
@@ -17,8 +17,7 @@ class VisualEditorHooks {
 		if ( is_null( $isAvailable ) ) {
 			$isAvailable = (
 				in_array( $skin->getSkinName(), self::$supportedSkins ) &&
-				$skin->getUser()->getOption( 'visualeditor-enable' ) &&
-				!$skin->getUser()->getOption( 'visualeditor-betatempdisable' )
+				$skin->getUser()->getOption( 'enablerichtext' )
 			);
 		}
 		return $isAvailable;

--- a/extensions/VisualEditor/wikia/VisualEditor.hooks.php
+++ b/extensions/VisualEditor/wikia/VisualEditor.hooks.php
@@ -9,8 +9,13 @@
 class VisualEditorWikiaHooks {
 
 	public static function onGetPreferences( $user, &$preferences ) {
-		unset( $preferences['visualeditor-betatempdisable'] );
-		$preferences['visualeditor-enable']['label-message'] = 'visualeditor-wikiapreference-enable';
+		// Remove core VisualEditor preferences
+		unset(
+			$preferences['visualeditor-enable'],
+			$preferences['visualeditor-betatempdisable']
+		);
+
+		Wikia::log('enablerichtext: '.  !empty( $preferences['enablerichtext'] ) );
 
 		return true;
 	}

--- a/extensions/VisualEditor/wikia/VisualEditor.hooks.php
+++ b/extensions/VisualEditor/wikia/VisualEditor.hooks.php
@@ -15,8 +15,6 @@ class VisualEditorWikiaHooks {
 			$preferences['visualeditor-betatempdisable']
 		);
 
-		Wikia::log('enablerichtext: '.  !empty( $preferences['enablerichtext'] ) );
-
 		return true;
 	}
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/VE-371

This can be tested by setting wgEnableVisualEditorExt = false and then:
1. In preferences, check visual editor preference. Go to an article. There should only be an edit action (no classic) which takes you to _RTE_ editor.
2. In preferences, uncheck visual editor preference. Go to an article. There should only be an edit action (no classic) which takes you to _source_ editor.
Set wgEnableVisualEditorExt = true and then:
3. In preferences, check visual editor preference. Go to an article. There should be veaction=edit and classic editor and the edit button should take you to VE.
4. In preferences, uncheck visual editor preference. Go to an article. There should only be an edit action (no classic) which takes you to _source_ editor.
