### PR TITLE
VE-624 and MAIN-1208 - Render Text in Wiki Language

### DIFF
--- a/extensions/wikia/ImageTweaks/ImageTweaksHooks.class.php
+++ b/extensions/wikia/ImageTweaks/ImageTweaksHooks.class.php
@@ -373,7 +373,7 @@ class ImageTweaksHooks {
 
 			$html .= Xml::openElement( 'div', array( 'class' => 'picture-attribution' ) ) .
 				$avatar .
-				wfMessage('oasis-content-picture-added-by', $link, $attributeTo )->text() .
+				wfMessage('oasis-content-picture-added-by', $link, $attributeTo )->inContentLanguage()->text() .
 				Xml::closeElement( 'div' );
 
 			wfProfileOut( __METHOD__ . '::PictureAttribution' );

--- a/extensions/wikia/ImageTweaks/ImageTweaksService.class.php
+++ b/extensions/wikia/ImageTweaks/ImageTweaksService.class.php
@@ -36,7 +36,7 @@ class ImageTweaksService extends WikiaService {
 
 			$html .= Xml::openElement( 'div', array( 'class' => 'picture-attribution' ) ) .
 				$avatar .
-				wfMessage('oasis-content-picture-added-by', $link, $attributeTo )->text() .
+				wfMessage('oasis-content-picture-added-by', $link, $attributeTo )->inContentLanguage()->text() .
 				Xml::closeElement( 'div' );
 
 			wfProfileOut( __METHOD__ . '::PictureAttribution' );

--- a/extensions/wikia/TOC/TOCController.class.php
+++ b/extensions/wikia/TOC/TOCController.class.php
@@ -4,9 +4,9 @@ class TOCController extends WikiaController {
 
 	public function index() {
 
-		$this->tocHeader = wfMessage( 'toc' )->plain();
-		$this->show = wfMessage( 'showtoc' )->plain();
-		$this->hide = wfMessage( 'hidetoc' )->plain();
+		$this->tocHeader = wfMessage( 'toc' )->inContentLanguage()->text();
+		$this->show = wfMessage( 'showtoc' )->inContentLanguage()->text();
+		$this->hide = wfMessage( 'hidetoc' )->inContentLanguage()->text();
 		$this->response->setTemplateEngine(WikiaResponse::TEMPLATE_ENGINE_MUSTACHE);
 	}
 }

--- a/extensions/wikia/TOC/TOCController.class.php
+++ b/extensions/wikia/TOC/TOCController.class.php
@@ -4,9 +4,9 @@ class TOCController extends WikiaController {
 
 	public function index() {
 
-		$this->tocHeader = wfMessage( 'toc' )->inContentLanguage()->text();
-		$this->show = wfMessage( 'showtoc' )->inContentLanguage()->text();
-		$this->hide = wfMessage( 'hidetoc' )->inContentLanguage()->text();
+		$this->tocHeader = wfMessage( 'toc' )->inContentLanguage()->plain();
+		$this->show = wfMessage( 'showtoc' )->inContentLanguage()->plain();
+		$this->hide = wfMessage( 'hidetoc' )->inContentLanguage()->plain();
 		$this->response->setTemplateEngine(WikiaResponse::TEMPLATE_ENGINE_MUSTACHE);
 	}
 }


### PR DESCRIPTION
Changes text in the Table of Contents, as well as the attribution text for photos to be rendered in the language of the Wiki, not the language of the user.

https://wikia-inc.atlassian.net/browse/VE-624
https://wikia-inc.atlassian.net/browse/MAIN-1208
