### PR TITLE
VE-566 updating getWikiaFile to return an error message

### DIFF
--- a/extensions/VisualEditor/wikia/ApiTempUpload.php
+++ b/extensions/VisualEditor/wikia/ApiTempUpload.php
@@ -170,7 +170,7 @@ class ApiTempUpload extends ApiBase {
 		$this->checkPermissions( $this->mUser );
 
 		$url = $this->mParams['url'];
-		$wikiaFileStatus = WikiaFileHelper::getWikiaFile( $url );
+		$wikiaFileStatus = WikiaFileHelper::getWikiaFileFromUrl( $url );
 
 		if ( !$wikiaFileStatus->isGood() ) {
 			// It's a wikia file url but the file doesn't exist

--- a/extensions/VisualEditor/wikia/ApiTempUpload.php
+++ b/extensions/VisualEditor/wikia/ApiTempUpload.php
@@ -38,12 +38,12 @@ class ApiTempUpload extends ApiBase {
 	private function executePermanentVideo() {
 		$this->mParams['desiredName'] = wfStripIllegalFilenameChars( $this->mParams['desiredName'] );
 
-		if( empty( $this->mParams['provider'] ) ) {
+		if ( empty( $this->mParams['provider'] ) ) {
 			$this->dieUsageMsg( 'The provider parameter must be set' );
 		}
 
 		if ( $this->mParams['provider'] == 'wikia' ) {
-			if( empty( $this->mParams['title'] ) ) {
+			if ( empty( $this->mParams['title'] ) ) {
 				$this->dieUsageMsg( 'The title parameter must be set' );
 			}
 			// no need to upload, local reference
@@ -172,14 +172,14 @@ class ApiTempUpload extends ApiBase {
 		$url = $this->mParams['url'];
 		$wikiaFileStatus = WikiaFileHelper::getWikiaFile( $url );
 
-		if( !$wikiaFileStatus->isGood() ) {
+		if ( !$wikiaFileStatus->isGood() ) {
 			// It's a wikia file url but the file doesn't exist
 			$this->dieUsageMsg( $wikiaFileStatus->getWarningsArray() );
 		}
 
 		$file = $wikiaFileStatus->value;
 
-		if( !empty( $file ) ) {
+		if ( !empty( $file ) ) {
 			// Handle local and premium videos
 			$this->getResult()->addValue( null, $this->getModuleName(), array(
 				'title' => $file->getTitle()->getText(),

--- a/extensions/VisualEditor/wikia/ApiTempUpload.php
+++ b/extensions/VisualEditor/wikia/ApiTempUpload.php
@@ -170,7 +170,14 @@ class ApiTempUpload extends ApiBase {
 		$this->checkPermissions( $this->mUser );
 
 		$url = $this->mParams['url'];
-		$file = WikiaFileHelper::getWikiaFile( $url );
+		$wikiaFileStatus = WikiaFileHelper::getWikiaFile( $url );
+
+		if( !$wikiaFileStatus->isGood() ) {
+			// It's a wikia file url but the file doesn't exist
+			$this->dieUsageMsg( $wikiaFileStatus->getWarningsArray() );
+		}
+
+		$file = $wikiaFileStatus->value;
 
 		if( !empty( $file ) ) {
 			// Handle local and premium videos

--- a/includes/wikia/services/WikiaFileHelper.class.php
+++ b/includes/wikia/services/WikiaFileHelper.class.php
@@ -654,15 +654,8 @@ class WikiaFileHelper extends Service {
 		// added $nsFileTransladed to fix bugId:#48874
 		$pattern = '/(File:|'.$nsFileTranslated.':)(.+)$/';
 
-		if ( preg_match( $pattern, $url, $matches ) ) {
-			$hasMatch = true;
-			$file = wfFindFile( $matches[2] );
-			if ( !$file ) { // bugID: 26721
-				$file = wfFindFile( urldecode( $matches[2] ) );
-			}
-		// If the i18n'ed namespace has a special char it might need to be decoded
-		} else if ( preg_match( $pattern, urldecode( $url ), $matches ) ) {
-			$hasMatch = true;
+		$hasMatch = preg_match( $pattern, urldecode( $url ), $matches );
+		if ( $hasMatch ) {
 			$file = wfFindFile( $matches[2] );
 		}
 

--- a/includes/wikia/services/WikiaFileHelper.class.php
+++ b/includes/wikia/services/WikiaFileHelper.class.php
@@ -644,9 +644,8 @@ class WikiaFileHelper extends Service {
 	 * @param $url String The URL of a video
 	 * @return Status
 	 */
-	public static function getWikiaFile( $url ) {
+	public static function getWikiaFileFromUrl( $url ) {
 		$file = null;
-		$hasMatch = false;
 
 		// get the video name
 		$nsFileTranslated = F::app()->wg->ContLang->getNsText( NS_FILE );

--- a/includes/wikia/services/WikiaFileHelper.class.php
+++ b/includes/wikia/services/WikiaFileHelper.class.php
@@ -458,7 +458,7 @@ class WikiaFileHelper extends Service {
 	public static function truncateArticleList( $articles, $limit = 2 ) {
 		$isTruncated = 0;
 		$truncatedList = array();
-		if( !empty( $articles ) ) {
+		if ( !empty( $articles ) ) {
 			foreach ( $articles as $article ) {
 				// Create truncated list
 				if ( count( $truncatedList ) < $limit ) {
@@ -496,7 +496,7 @@ class WikiaFileHelper extends Service {
 				'duration' => true,
 				'linkAttribs' => array( 'class' => 'video-thumbnail' )
 			);
-			if( $force16x9Ratio ) {
+			if ( $force16x9Ratio ) {
 				$htmlParams['src'] = self::thumbUrl2thumbUrl( $thumb->getUrl(), 'video', $width, $height );
 				$thumb->width = $width;
 				$thumb->height = $height;
@@ -516,7 +516,7 @@ class WikiaFileHelper extends Service {
 	public static function  getVideoThumbnailHtml( Title $title, $width=150, $height=75, $force16x9Ratio=false ) {
 		$arr = [];
 		self::inflateArrayWithVideoData( $arr, $title, $width, $height, $force16x9Ratio );
-		if( !empty( $arr['thumbnail'] ) ) {
+		if ( !empty( $arr['thumbnail'] ) ) {
 			return $arr['thumbnail'];
 		} else {
 			return false;
@@ -577,7 +577,7 @@ class WikiaFileHelper extends Service {
 		if ( !empty( $hms ) ) {
 			$segments = explode( ':', $hms );
 			$ret = "PT";
-			if( count( $segments ) == 3 ) {
+			if ( count( $segments ) == 3 ) {
 				$ret .= array_shift( $segments ) . 'H';
 			}
 			$ret .= array_shift( $segments ) . 'M';
@@ -667,9 +667,9 @@ class WikiaFileHelper extends Service {
 		}
 
 		$status = Status::newGood();
-		if( !empty( $file ) ) {
+		if ( !empty( $file ) ) {
 			$status->setResult( true, $file );
-		} else if( $hasMatch ) {
+		} else if ( $hasMatch ) {
 			$status->warning( 'The supplied video does not exist' );
 		}
 


### PR DESCRIPTION
This updates WikiaFileHelper::getWikiaFile so that it sends back an error message if "File" is found in the URL but no actual file exists by the specified name.  
