### PR TITLE
VE-160 don't allow wikia videos to be renamed

### DIFF
--- a/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaMediaInsertDialog.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaMediaInsertDialog.js
@@ -240,7 +240,10 @@ ve.ui.WikiaMediaInsertDialog.prototype.onCartModelAdd = function ( items ) {
 	for ( i = 0; i < items.length; i++ ) {
 		item = items[i];
 		isTemporary = item.isTemporary();
-		config = { '$$': this.frame.$$, 'editable': isTemporary };
+		config = {
+			'$$': this.frame.$$,
+			'editable': ( isTemporary && item.provider !== 'wikia' )
+		};
 		if ( isTemporary ) {
 			config.$license = this.$$( this.license.html );
 		}


### PR DESCRIPTION
This makes the renaming input non-editable if the video is from a wiki. 
