### PR TITLE
BAC-982 Fixing SASS errors

### DIFF
--- a/skins/oasis/css/core/background.scss
+++ b/skins/oasis/css/core/background.scss
@@ -9,8 +9,17 @@
 // more performant. However, before we do that, we should come up with a
 // better way of passing parameters into Sass (like using a hash), otherwise
 // the URLs generated for Sass files will be even more ridiculously long.
-$background-height: get_command_line_param( "background-image-height", 0 ) * 1px; // convert int to pixel value
-$background-width: get_command_line_param( "background-image-width", 0 ) * 1px; // convert int to pixel value
+$background-height: get_command_line_param( "background-image-height", 0 );
+$background-width: get_command_line_param( "background-image-width", 0 );
+
+// convert unitless int values to pixels
+@if unitless($background-height) {
+  $background-height : $background-height * 1px;
+}
+@if unitless($background-width) {
+  $background-width : $background-width * 1px;
+}
+
 $background-width-half: $background-width / 2;
 $background-offset: ( $breakpoint-fluid - $background-width ) / 2;
 $background-align: if( $background-width > $width-outside, center, left );


### PR DESCRIPTION
Make sure that conversion to pixels happens only for unitless values

@macbre Please take a look
