### PR TITLE
ADEN-697 ensure single semi-colon per k-v pair, and final semicolon

### DIFF
--- a/extensions/wikia/AdEngine/js/AdLogicPageLevelParams.js
+++ b/extensions/wikia/AdEngine/js/AdLogicPageLevelParams.js
@@ -112,8 +112,10 @@ var AdLogicPageLevelParams = function (
 				kv = kvs[i].split('=');
 				key = kv[0];
 				value = kv[1];
-				params[key] = params[key] || [];
-				params[key].push(value);
+				if (key && value) {
+					params[key] = params[key] || [];
+					params[key].push(value);
+				}
 			}
 		}
 

--- a/extensions/wikia/NLP/classes/Entities/WikiEntitiesService.php
+++ b/extensions/wikia/NLP/classes/Entities/WikiEntitiesService.php
@@ -27,10 +27,13 @@ class WikiEntitiesService
 		$topics = $this->getLdaTopics();
 		if ( count( $topics ) ) {
 			$keyValues = explode( ';', $mwService->getGlobalWithDefault( 'wgDartCustomKeyValues', '' ) );
+			if ( end($keyValues) === '' ) {
+				$keyValues = array_slice( $keyValues, 0, -1 );
+			}
 			foreach ( $topics as &$topic ) {
 				$topic = 'wtpx='.$topic;
 			}
-			$mwService->setGlobal( 'wgDartCustomKeyValues', implode( ';', array_merge( $keyValues, array_slice( $topics, 0, 5 ) ) ) );
+			$mwService->setGlobal( 'wgDartCustomKeyValues', implode( ';', array_merge( $keyValues, array_slice( $topics, 0, 5 ) ) ) . ';' );
 		}
 		return true;
 	}

--- a/extensions/wikia/NLP/classes/Test/Entities/WikiEntitiesServiceTest.php
+++ b/extensions/wikia/NLP/classes/Test/Entities/WikiEntitiesServiceTest.php
@@ -79,6 +79,40 @@ class WikiEntitiesServiceTest extends WikiaBaseTest
 		$mwService = $this->getMock( 'Wikia\Search\MediaWikiService', [ 'getGlobalWithDefault', 'setGlobal' ] );
 
 		$topics = [111, 222, 333, 444, 555, 666];
+		$kvs = 'foo=bar;baz=qux;';
+		
+		$service
+		    ->expects( $this->once() )
+		    ->method ( 'getMwService' )
+		    ->will   ( $this->returnValue( $mwService ) ) 
+		;
+		$service
+		    ->expects( $this->once() )
+		    ->method ( 'getLdaTopics' )
+		    ->will   ( $this->returnValue( $topics ) )
+		;
+		$mwService
+		    ->expects( $this->once() )
+		    ->method ( 'getGlobalWithDefault' )
+		    ->with   ( 'wgDartCustomKeyValues', '' )
+		    ->will   ( $this->returnValue( $kvs ) )
+		;
+		$mwService
+		    ->expects( $this->once() )
+		    ->method ( 'setGlobal' )
+		    ->with   ( 'wgDartCustomKeyValues', $kvs . 'wtpx=111;wtpx=222;wtpx=333;wtpx=444;wtpx=555;' )
+		;
+		$this->assertTrue( $service->registerLdaTopicsWithDFP() );
+	}
+
+	/**
+	 * @covers Wikia\NLP\Entities\WikiEntitiesService::registerLdaTopicsWithDFP
+	 */
+	public function testLdaTopicsWithDFPNoEndingSemicolon() {
+		$service = $this->getMock( self::CLASSNAME, [ 'getMwService', 'getLdaTopics' ] );
+		$mwService = $this->getMock( 'Wikia\Search\MediaWikiService', [ 'getGlobalWithDefault', 'setGlobal' ] );
+
+		$topics = [111, 222, 333, 444, 555, 666];
 		$kvs = 'foo=bar;baz=qux';
 		
 		$service
@@ -100,9 +134,33 @@ class WikiEntitiesServiceTest extends WikiaBaseTest
 		$mwService
 		    ->expects( $this->once() )
 		    ->method ( 'setGlobal' )
-		    ->with   ( 'wgDartCustomKeyValues', $kvs . ';wtpx=111;wtpx=222;wtpx=333;wtpx=444;wtpx=555' )
+		    ->with   ( 'wgDartCustomKeyValues', $kvs . ';wtpx=111;wtpx=222;wtpx=333;wtpx=444;wtpx=555;' )
 		;
 		$this->assertTrue( $service->registerLdaTopicsWithDFP() );
 	}
+
+	/**
+	 * @covers Wikia\NLP\Entities\WikiEntitiesService::registerLdaTopicsWithDFP
+	 */
+	public function testLdaTopicsWithDFPNoTopics() {
+		$service = $this->getMock( self::CLASSNAME, [ 'getMwService', 'getLdaTopics' ] );
+		$mwService = $this->getMock( 'Wikia\Search\MediaWikiService', [ 'getGlobalWithDefault', 'setGlobal' ] );
+
+		$topics = null;
+		$kvs = 'foo=bar;baz=qux';
+		
+		$service
+		    ->expects( $this->once() )
+		    ->method ( 'getMwService' )
+		    ->will   ( $this->returnValue( $mwService ) ) 
+		;
+		$service
+		    ->expects( $this->once() )
+		    ->method ( 'getLdaTopics' )
+		    ->will   ( $this->returnValue( $topics ) )
+		;
+		$this->assertTrue( $service->registerLdaTopicsWithDFP() );
+	}
+
 	
 }

--- a/extensions/wikia/NLP/classes/Test/Entities/WikiEntitiesServiceTest.php
+++ b/extensions/wikia/NLP/classes/Test/Entities/WikiEntitiesServiceTest.php
@@ -108,6 +108,41 @@ class WikiEntitiesServiceTest extends WikiaBaseTest
 	/**
 	 * @covers Wikia\NLP\Entities\WikiEntitiesService::registerLdaTopicsWithDFP
 	 */
+	public function testLdaTopicsWithDFPNullKeyVals() {
+		$service = $this->getMock( self::CLASSNAME, [ 'getMwService', 'getLdaTopics' ] );
+		$mwService = $this->getMock( 'Wikia\Search\MediaWikiService', [ 'getGlobalWithDefault', 'setGlobal' ] );
+
+		$topics = [111, 222, 333, 444, 555, 666];
+		$kvs = null;
+		
+		$service
+		    ->expects( $this->once() )
+		    ->method ( 'getMwService' )
+		    ->will   ( $this->returnValue( $mwService ) ) 
+		;
+		$service
+		    ->expects( $this->once() )
+		    ->method ( 'getLdaTopics' )
+		    ->will   ( $this->returnValue( $topics ) )
+		;
+		$mwService
+		    ->expects( $this->once() )
+		    ->method ( 'getGlobalWithDefault' )
+		    ->with   ( 'wgDartCustomKeyValues', '' )
+		    ->will   ( $this->returnValue( $kvs ) )
+		;
+		$mwService
+		    ->expects( $this->once() )
+		    ->method ( 'setGlobal' )
+		    ->with   ( 'wgDartCustomKeyValues', 'wtpx=111;wtpx=222;wtpx=333;wtpx=444;wtpx=555;' )
+		;
+		$this->assertTrue( $service->registerLdaTopicsWithDFP() );
+	}
+
+
+	/**
+	 * @covers Wikia\NLP\Entities\WikiEntitiesService::registerLdaTopicsWithDFP
+	 */
 	public function testLdaTopicsWithDFPNoEndingSemicolon() {
 		$service = $this->getMock( self::CLASSNAME, [ 'getMwService', 'getLdaTopics' ] );
 		$mwService = $this->getMock( 'Wikia\Search\MediaWikiService', [ 'getGlobalWithDefault', 'setGlobal' ] );
@@ -159,7 +194,12 @@ class WikiEntitiesServiceTest extends WikiaBaseTest
 		    ->method ( 'getLdaTopics' )
 		    ->will   ( $this->returnValue( $topics ) )
 		;
+		$mwService
+			->expects( $this->never() )
+			->method ( 'setGlobal' )
+		;
 		$this->assertTrue( $service->registerLdaTopicsWithDFP() );
+	    
 	}
 
 	


### PR DESCRIPTION
We were running into some JavaScript errors because of how the NLP extension was handling deconstructing and reconstructing the DART key-value pair string. This fixes that problem and adds tests to account for those cases.
