### PR TITLE
VID-1011 and DAR-985 - Unable to start video player on message wall if thumb parameter is missing

### DIFF
--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -250,6 +250,24 @@ class ArticleComment {
 		$head = $parser->parse( $rawtext, $this->mTitle, ParserOptions::newFromContext( RequestContext::getMain() ) );
 
 		$this->mText = $head->getText();
+
+		// Repair malformed HTML without making semantic changes (ie, changing tags to more closely follow the HTML spec.
+		// Refs DAR-985 and VID-1011)
+		$dom_document = new DOMDocument();
+		// Silence errors when loading html into DOMDocument (it complains when receiving malformed html - which is
+		// what we're using it to fix) see: http://www.php.net/manual/en/domdocument.loadhtml.php#95463
+		libxml_use_internal_errors(true);
+		$dom_document->loadHTML($this->mText);
+		// Isolate and return the <body> element, otherwise saveHTML would return an HTML doc which includes the
+		// html declaration, <html> tags, and <head> tags. saveHTML is what closes malformed tags.
+		$body_element = $dom_document->getElementsByTagName("body")->item(0);
+		$this->mText = $dom_document->saveHTML($body_element);
+		// Sanity check to make sure <body> is the outermost tag which we'll be stripping off (it should always be)
+		if (preg_match("/^<body>(.*)<\/body>$/s", $this->mText, $matches)) {
+			// Assign $mtext to everything inside of <body></body>
+			$this->mText = $matches[1];
+		}
+
 		$this->mHeadItems = $head->getHeadItems();
 
 		if( isset( $parser->ac_metadata ) ) {

--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -247,11 +247,6 @@ class ArticleComment {
 
 		$parser->ac_metadata = [];
 
-		// Always tidy Article Comment markup to avoid breakage of surrounding markup
-		global $wgAlwaysUseTidy;
-		$oldWgAlwaysUseTidy = $wgAlwaysUseTidy;
-		$wgAlwaysUseTidy = true;
-
 		$head = $parser->parse( $rawtext, $this->mTitle, ParserOptions::newFromContext( RequestContext::getMain() ) );
 
 		$this->mText = $head->getText();
@@ -264,9 +259,6 @@ class ArticleComment {
 		}
 
 		ParserPool::release( $parser );
-
-		// Restore old value of $wgAlwaysUseTidy
-		$wgAlwaysUseTidy = $oldWgAlwaysUseTidy;
 
 		return $this->mText;
 	}


### PR DESCRIPTION
Fixes VID-1011 (Unable to start video player on message wall if thumb parameter is missing) by reverting and altering code which was added to fix DAR-985 (Forum posts break due to unclosed tags). Ran full suite of WallMessage Selenium tests to ensure no regression.
