### PR TITLE
Wall: re-enabling performance test

### DIFF
--- a/extensions/wikia/Wall/WallMessage.class.php
+++ b/extensions/wikia/Wall/WallMessage.class.php
@@ -430,7 +430,6 @@ class WallMessage {
 	public function getWallOwner( $master = false ) {
 		$parts = explode( '/', $this->getWallTitle( $master )->getText() );
 		$userName = $parts[0];
-		/*
 		// mech: I'm not sure we have to create wall title doing db queries on both, page and comments_index tables.
 		// as the user name is the first part on comment's title. But I'm not able to go through all wall/forum
 		// usecases. I'm going to check production logs for the next 2-3 sprints and make sure the result is
@@ -441,7 +440,6 @@ class WallMessage {
 			Wikia::log( __METHOD__, false, 'WALL_PERF article title owner does not match ci username (' . $userName .
 				' vs ' . $parts[0] . ') for ' . $this->getId() . ' (title is ' . $titleText. ')', true );
 		}
-		*/
 
 		$wall_owner = User::newFromName( $userName, false );
 


### PR DESCRIPTION
I want to re-enable WallMessage::getMessageOwner logging. The goal is to check if we still need to access comments_index table, or maybe a simple string operation is enough.
