### PR TITLE
BAC-630: handle articles with missing revision 

### DIFF
--- a/includes/Article.php
+++ b/includes/Article.php
@@ -555,6 +555,19 @@ class Article extends Page {
 					# This will set $this->mRevision if needed
 					$this->fetchContent();
 
+					// Wikia change - begin
+					// @author macbre
+					// return status different than HTTP 200 when revision is missing (BAC-630)
+					if ( !$this->mRevision instanceof Revision ) {
+						global $wgEnableParserCache;
+						wfDebug( __METHOD__ . ": no revision found - returning 404\n" );
+
+						$wgOut->setStatusCode( 404 );
+						$useParserCache = false;
+						$wgEnableParserCache = false;
+					}
+					// Wikia change - end
+
 					# Are we looking at an old revision
 					if ( $oldid && $this->mRevision ) {
 						$this->setOldSubtitle( $oldid );

--- a/includes/Article.php
+++ b/includes/Article.php
@@ -560,9 +560,10 @@ class Article extends Page {
 					// return status different than HTTP 200 when revision is missing (BAC-630)
 					if ( !$this->mRevision instanceof Revision ) {
 						global $wgEnableParserCache;
-						wfDebug( __METHOD__ . ": no revision found - returning 404\n" );
+						wfDebug( __METHOD__ . ": no revision found - disabling parser cache and returning 404\n" );
 
-						$wgOut->setStatusCode( 404 );
+						$wgOut->getRequest()->response()->header('X-Missing-Revision: 1', true, 404);
+
 						$useParserCache = false;
 						$wgEnableParserCache = false;
 					}


### PR DESCRIPTION
- return HTTP 404
- return `X-Missing-Revision` header
- disable parser cache

@Wikia/platform-team / @prein 
