### PR TITLE
VE-699: Fixing slider buttons for i18n

### DIFF
--- a/extensions/wikia/WikiFeatures/css/WikiFeatures.scss
+++ b/extensions/wikia/WikiFeatures/css/WikiFeatures.scss
@@ -96,26 +96,19 @@
 					display: block;
 					float: left;
 					height: 26px;
+					min-width: 107px;
 					position: relative;
-					width: 107px;
 					.texton {
-						color: #FFFFFF;
+						color: #FFF;
 						display: none;
 						font-weight: bold;
-						margin-left: 5px;
-						position: absolute;
-						text-align: center;
-						top: 2px;
-						width: 70px;
+						margin: 2px 35px 0 10px;
 					}
 					.textoff {
 						color: #000;
+						display: block;
 						font-weight: bold;
-						margin-left: 32px;
-						position: absolute;
-						text-align: center;
-						top: 2px;
-						width: 70px;
+						margin: 2px 10px 0 35px;
 					}
 					.button {
 						@include border-radius(14px);
@@ -140,7 +133,8 @@
 							display: none;
 						}
 						.button {
-							left: 80px;
+							left: 100%;
+							margin-left: -27px;
 						}
 					}
 				}


### PR DESCRIPTION
Slider buttons are now flexible instead of static width, allowing for better i18n support.
