### PR TITLE
SwiftFileBackend: improve mime type detection

### DIFF
--- a/includes/filerepo/backend/SwiftFileBackend.php
+++ b/includes/filerepo/backend/SwiftFileBackend.php
@@ -251,7 +251,7 @@ class SwiftFileBackend extends FileBackendStore {
 			// The MD5 here will be checked within Swift against its own MD5.
 			$obj->set_etag( md5_file( $params['src'] ) );
 			// Use the same content type as StreamFile for security
-			$obj->content_type = StreamFile::contentTypeFromPath( $params['dst'] );
+			$obj->content_type = $this->getFileProps($params)['mime']; // Wikia cnange: use the same logic as for DB row (BAC-1199)
 			// Actually write the object in Swift
 			$obj->load_from_filename( $params['src'], True ); // calls $obj->write()
 		} catch ( BadContentTypeException $e ) {

--- a/includes/wikia/services/tests/ImagesServiceUploadTest.php
+++ b/includes/wikia/services/tests/ImagesServiceUploadTest.php
@@ -51,10 +51,12 @@ class ImagesServiceUploadTest extends WikiaBaseTest {
 		);
 
 		// verify that it's accessible via HTTP
-		$res = Http::get( $url, 'default', ['noProxy' => true] );
+		$req = MWHttpRequest::factory( $url, ['noProxy' => true] );
+		$req->execute();
 
-		$this->assertTrue( $res !== false, 'Uploaded image should return HTTP 200 - ' . $url );
-		$this->assertEquals( $fileHash, md5( $res ), 'Uploaded image hash should match - ' . $url );
+		$this->assertEquals( 200, $req->getStatus(), 'Uploaded image should return HTTP 200 - ' . $url );
+		$this->assertEquals( $fileHash, md5( $req->getContent() ), 'Uploaded image hash should match - ' . $url );
+		$this->assertEquals( 'image/jpeg', $req->getResponseHeader( 'Content-Type' ), 'Uploaded image should be JPEG' );
 	}
 
 	// check the path - /firefly/images/thumb/5/53/Test-1378979336.jpg/120px-0%2C451%2C0%2C294-Test-1378979336.jpg


### PR DESCRIPTION
Use the same logic that is used when storing image data in database (BAC-1109)

@moliwikia / @Wikia/platform-team 
