### PR TITLE
fixing image placeholders in articles and code cleanup

### DIFF
--- a/extensions/wikia/ImagePlaceholder/js/MediaPlaceholder.js
+++ b/extensions/wikia/ImagePlaceholder/js/MediaPlaceholder.js
@@ -9,6 +9,7 @@
 
 'use strict';
 
+// Make global so JSSnippets can pick it up
 window.MediaPlaceholder = {
 
 	init: function() {
@@ -56,13 +57,17 @@ window.MediaPlaceholder = {
 					).done( function() {
 						self.imageLoaded = true;
 						$this.stopThrobbing();
-						window.WMU_show( window.event, -2, props.placeholderIndex, props.align, props.thumb,
-							props.width, props.caption, props.link );
+						window.WMU_show( // jshint ignore:line
+							window.event, -2, props.placeholderIndex, props.align, props.thumb,
+							props.width, props.caption, props.link
+						);
 					} );
 			} else {
 				$this.stopThrobbing();
-				window.WMU_show( window.event, -2, props.placeholderIndex, props.align, props.thumb, props.width,
-					props.caption, props.link );
+				window.WMU_show( // jshint ignore:line
+					window.event, -2, props.placeholderIndex, props.align, props.thumb, props.width,
+					props.caption, props.link
+				);
 			}
 		} );
 	},

--- a/extensions/wikia/ImagePlaceholder/js/MediaPlaceholder.js
+++ b/extensions/wikia/ImagePlaceholder/js/MediaPlaceholder.js
@@ -118,14 +118,14 @@
 		},
 
 		// Get data for WMU / VET from placeholder element
-		getProps: function( elem ) {
+		getProps: function( $elem ) {
 			return {
-				placeholderIndex: elem.attr( 'data-id' ),
-				align: elem.attr( 'data-align' ),
-				width: elem.attr( 'data-width' ),
-				thumb: elem.attr( 'data-thumb' ),
-				link: elem.attr( 'data-link' ),
-				caption: elem.attr( 'data-caption' )
+				placeholderIndex: $elem.attr( 'data-id' ),
+				align: $elem.attr( 'data-align' ),
+				width: $elem.attr( 'data-width' ),
+				thumb: $elem.attr( 'data-thumb' ),
+				link: $elem.attr( 'data-link' ),
+				caption: $elem.attr( 'data-caption' )
 			};
 		}
 	};

--- a/extensions/wikia/ImagePlaceholder/js/MediaPlaceholder.js
+++ b/extensions/wikia/ImagePlaceholder/js/MediaPlaceholder.js
@@ -7,127 +7,126 @@
 
 (function( $, window ) {
 
-'use strict';
+	'use strict';
 
-// Make global so JSSnippets can pick it up
-window.MediaPlaceholder = {
+	// Make global so JSSnippets can pick it up
+	window.MediaPlaceholder = {
 
-	init: function() {
+		init: function() {
 
-		// Don't run more than once
-		if ( this.loaded ) {
-			return;
-		}
+			// Don't run more than once
+			if ( this.loaded ) {
+				return;
+			}
 
-		this.loaded = true;
-		this.imageLoaded = false;
-		this.WikiaArticle = $( '#WikiaArticle' );
+			this.loaded = true;
+			this.imageLoaded = false;
+			this.WikiaArticle = $( '#WikiaArticle' );
 
-		// Don't allow editing on history or diff pages
-		if ( $.getUrlVar( 'diff' ) || $.getUrlVar( 'oldid' ) ) {
-			return;
-		}
+			// Don't allow editing on history or diff pages
+			if ( $.getUrlVar( 'diff' ) || $.getUrlVar( 'oldid' ) ) {
+				return;
+			}
 
-		this.setupVideoPlaceholders();
-		this.setupImagePlaceholders();
-	},
+			this.setupVideoPlaceholders();
+			this.setupImagePlaceholders();
+		},
 
-	setupImagePlaceholders: function() {
-		var self = this;
+		setupImagePlaceholders: function() {
+			var self = this;
 
-		// Handle clicks on image placeholders (video placeholders are handled differently)
-		this.WikiaArticle.on( 'click', '.wikiaImagePlaceholder a', function( e ) {
-			var $this = $( this ),
-				props = self.getProps( $this );
+			// Handle clicks on image placeholders (video placeholders are handled differently)
+			this.WikiaArticle.on( 'click', '.wikiaImagePlaceholder a', function( e ) {
+				var $this = $( this ),
+					props = self.getProps( $this );
 
-			e.preventDefault();
+				e.preventDefault();
 
-			// Provide immediate feedback once button is clicked
-			$this.startThrobbing();
+				// Provide immediate feedback once button is clicked
+				$this.startThrobbing();
 
-			if ( !self.imageLoaded ) {
-				// open WMU
-				$.when(
-					$.getResources( [
-						$.loadYUI,
-						$.loadJQueryAIM,
-						$.getSassCommonURL( 'extensions/wikia/WikiaMiniUpload/css/WMU.scss' ),
-						window.wgResourceBasePath + '/extensions/wikia/WikiaMiniUpload/js/WMU.js'
-					] )
-				).done( function() {
-					self.imageLoaded = true;
+				if ( !self.imageLoaded ) {
+					// open WMU
+					$.when(
+						$.getResources( [
+							$.loadYUI,
+							$.loadJQueryAIM,
+							$.getSassCommonURL( 'extensions/wikia/WikiaMiniUpload/css/WMU.scss' ),
+							window.wgResourceBasePath + '/extensions/wikia/WikiaMiniUpload/js/WMU.js'
+						] )
+					).done( function() {
+						self.imageLoaded = true;
+						$this.stopThrobbing();
+						window.WMU_show( // jshint ignore:line
+							window.event, -2, props.placeholderIndex, props.align, props.thumb,
+							props.width, props.caption, props.link
+						);
+					} );
+				} else {
 					$this.stopThrobbing();
 					window.WMU_show( // jshint ignore:line
-						window.event, -2, props.placeholderIndex, props.align, props.thumb,
-						props.width, props.caption, props.link
+						window.event, -2, props.placeholderIndex, props.align, props.thumb, props.width,
+						props.caption, props.link
 					);
-				} );
-			} else {
-				$this.stopThrobbing();
-				window.WMU_show( // jshint ignore:line
-					window.event, -2, props.placeholderIndex, props.align, props.thumb, props.width,
-					props.caption, props.link
-				);
-			}
-		} );
-	},
-	setupVideoPlaceholders: function() {
-		var self = this;
-
-		self.WikiaArticle.find( '.wikiaVideoPlaceholder a' ).each( function() {
-			var $this = $( this ),
-				props = self.getProps( $this );
-
-			$this.addVideoButton( {
-				embedPresets: props,
-				insertFinalVideoParams: [
-					'placeholder=1',
-					'box=' + props.placeholderIndex,
-					'article=' + encodeURIComponent( window.wgTitle ),
-					'ns=' + window.wgNamespaceNumber
-				],
-				callbackAfterEmbed: $.proxy( self.videoEmbedCallback, self )
+				}
 			} );
-		} );
-	},
+		},
+		setupVideoPlaceholders: function() {
+			var self = this;
 
-	videoEmbedCallback: function( embedData ) {
-		var placeholders = this.WikiaArticle.find( '.wikiaVideoPlaceholder a' ),
-			// get placeholder to turn into a video thumbnail
-			toUpdate = placeholders.filter( '[data-id=' + embedData.placeholderIndex + ']' ),
-			// get thumbnail code from hidden div in success modal
-			html = $( '#VideoEmbedCode' ).html();
+			self.WikiaArticle.find( '.wikiaVideoPlaceholder a' ).each( function() {
+				var $this = $( this ),
+					props = self.getProps( $this );
 
-		toUpdate.closest( '.wikiaVideoPlaceholder' ).replaceWith( html );
+				$this.addVideoButton( {
+					embedPresets: props,
+					insertFinalVideoParams: [
+						'placeholder=1',
+						'box=' + props.placeholderIndex,
+						'article=' + encodeURIComponent( window.wgTitle ),
+						'ns=' + window.wgNamespaceNumber
+					],
+					callbackAfterEmbed: $.proxy( self.videoEmbedCallback, self )
+				} );
+			} );
+		},
 
-		// update data id so we can match DOM placeholders to parsed wikitext placeholders
-		placeholders.each( function() {
-			var $this = $( this ),
-				id = $this.attr( 'data-id' );
+		videoEmbedCallback: function( embedData ) {
+			var placeholders = this.WikiaArticle.find( '.wikiaVideoPlaceholder a' ),
+				// get placeholder to turn into a video thumbnail
+				toUpdate = placeholders.filter( '[data-id=' + embedData.placeholderIndex + ']' ),
+				// get thumbnail code from hidden div in success modal
+				html = $( '#VideoEmbedCode' ).html();
 
-			if ( id > embedData.placeholderIndex ) {
-				$this.attr( 'data-id', id - 1 );
-			}
-		} );
+			toUpdate.closest( '.wikiaVideoPlaceholder' ).replaceWith( html );
 
-		// purge cache of article so video will show up on reload
-		$.post( window.wgScript, {title: window.wgPageName, action: 'purge'} );
+			// update data id so we can match DOM placeholders to parsed wikitext placeholders
+			placeholders.each( function() {
+				var $this = $( this ),
+					id = $this.attr( 'data-id' );
 
-		// re-bind events
-		this.setupVideoPlaceholders();
-	},
+				if ( id > embedData.placeholderIndex ) {
+					$this.attr( 'data-id', id - 1 );
+				}
+			} );
 
-	// Get data for WMU / VET from placeholder element
-	getProps: function( elem ) {
-		return {
-			placeholderIndex: elem.attr( 'data-id' ),
-			align: elem.attr( 'data-align' ),
-			width: elem.attr( 'data-width' ),
-			thumb: elem.attr( 'data-thumb' ),
-			link: elem.attr( 'data-link' ),
-			caption: elem.attr( 'data-caption' )
-		};
-	}
-};
+			// purge cache of article so video will show up on reload
+			$.post( window.wgScript, {title: window.wgPageName, action: 'purge'} );
 
+			// re-bind events
+			this.setupVideoPlaceholders();
+		},
+
+		// Get data for WMU / VET from placeholder element
+		getProps: function( elem ) {
+			return {
+				placeholderIndex: elem.attr( 'data-id' ),
+				align: elem.attr( 'data-align' ),
+				width: elem.attr( 'data-width' ),
+				thumb: elem.attr( 'data-thumb' ),
+				link: elem.attr( 'data-link' ),
+				caption: elem.attr( 'data-caption' )
+			};
+		}
+	};
 })( jQuery, window );

--- a/extensions/wikia/ImagePlaceholder/js/MediaPlaceholder.js
+++ b/extensions/wikia/ImagePlaceholder/js/MediaPlaceholder.js
@@ -5,160 +5,121 @@
  *
  */
 
-(function($, window) {
-var MediaPlaceholder = {
+(function( $, window ) {
+
+'use strict';
+
+window.MediaPlaceholder = {
 
 	init: function() {
 
 		// Don't run more than once
-		if(this.loaded) {
+		if ( this.loaded ) {
 			return;
 		}
 
 		this.loaded = true;
 		this.imageLoaded = false;
-		this.WikiaArticle = $('#WikiaArticle');
+		this.WikiaArticle = $( '#WikiaArticle' );
 
 		// Don't allow editing on history or diff pages
-		if( $.getUrlVar('diff') || $.getUrlVar('oldid') ){
-			return false;
+		if ( $.getUrlVar( 'diff' ) || $.getUrlVar( 'oldid' ) ) {
+			return;
 		}
 
-		var self = this;
-
 		this.setupVideoPlaceholders();
-
-		// TODO: use .wikiaImagePlaceholder instead of .wikiaPlaceholder after
-		// all articles have purged (after 14 days)
-		// Then we can remove wikiaVideoPlaceholder check below
-		$('#WikiaArticle').on('click', '.wikiaPlaceholder a', function(e) {
-			var $this = $(this);
-
-			// video placeholders handled differently
-			if($this.parent().parent().hasClass('wikiaVideoPlaceholder')) {
-				return;
-			}
-
-			e.preventDefault();
-
-			// Provide immediate feedback once button is clicked
-			var oText = $this.text();
-			$this.startThrobbing();
-
-			var props = self.getProps($this);
-
-			if(!self.imageLoaded) {
-				// open WMU
-				$.when(
-					$.getResources([
-						$.loadYUI,
-						$.loadJQueryAIM,
-						$.getSassCommonURL( 'extensions/wikia/WikiaMiniUpload/css/WMU.scss'),
-						wgResourceBasePath + '/extensions/wikia/WikiaMiniUpload/js/WMU.js'
-					])
-				).done(function() {
-					self.imageLoaded = true;
-
-					$this.text(oText);
-					window.WMU_show( self.getEvent(), -2, props.placeholderIndex, props.align, props.thumb, props.width, props.caption, props.link);
-				});
-			} else {
-				$this.text(oText);
-				window.WMU_show( self.getEvent(), -2, props.placeholderIndex, props.align, props.thumb, props.width, props.caption, props.link);
-			}
-		});
+		this.setupImagePlaceholders();
 	},
 
+	setupImagePlaceholders: function() {
+		var self = this;
+
+		// Handle clicks on image placeholders (video placeholders are handled differently)
+		this.WikiaArticle.on( 'click', '.wikiaImagePlaceholder a', function( e ) {
+			e.preventDefault();
+
+			var $this = $( this ),
+				props = self.getProps( $this );
+
+			// Provide immediate feedback once button is clicked
+			$this.startThrobbing();
+
+			if ( !self.imageLoaded ) {
+				// open WMU
+				$.when(
+						$.getResources( [
+							$.loadYUI,
+							$.loadJQueryAIM,
+							$.getSassCommonURL( 'extensions/wikia/WikiaMiniUpload/css/WMU.scss' ),
+							window.wgResourceBasePath + '/extensions/wikia/WikiaMiniUpload/js/WMU.js'
+						] )
+					).done( function() {
+						self.imageLoaded = true;
+						$this.stopThrobbing();
+						window.WMU_show( window.event, -2, props.placeholderIndex, props.align, props.thumb,
+							props.width, props.caption, props.link );
+					} );
+			} else {
+				$this.stopThrobbing();
+				window.WMU_show( window.event, -2, props.placeholderIndex, props.align, props.thumb, props.width,
+					props.caption, props.link );
+			}
+		} );
+	},
 	setupVideoPlaceholders: function() {
 		var self = this;
 
-		self.WikiaArticle.find('.wikiaVideoPlaceholder a').each(function() {
+		self.WikiaArticle.find( '.wikiaVideoPlaceholder a' ).each( function() {
 
-			var $this = $(this),
-				props = self.getProps($this);
+			var $this = $( this ),
+				props = self.getProps( $this );
 
-			$this.addVideoButton({
+			$this.addVideoButton( {
 				embedPresets: props,
-				insertFinalVideoParams: ['placeholder=1', 'box=' + props.placeholderIndex, 'article='+encodeURIComponent( wgTitle ), 'ns='+wgNamespaceNumber],
-				callbackAfterEmbed: self.videoEmbedCallback
-			});
-		});
+				insertFinalVideoParams: ['placeholder=1', 'box=' + props.placeholderIndex, 'article=' +
+					encodeURIComponent( window.wgTitle ), 'ns=' + window.wgNamespaceNumber],
+				callbackAfterEmbed: $.proxy( self.videoEmbedCallback, self )
+			} );
+		} );
 	},
 
-	videoEmbedCallback: function(embedData) {
-		var placeholders = MediaPlaceholder.WikiaArticle.find('.wikiaVideoPlaceholder a'),
-			// get placeholder to turn into a video thumbnail
-			to_update = placeholders.filter('[data-id='+embedData.placeholderIndex+']'),
-			// get thumbnail code from hidden div in success modal
-			html = $('#VideoEmbedCode').html();
+	videoEmbedCallback: function( embedData ) {
+		var placeholders = this.WikiaArticle.find( '.wikiaVideoPlaceholder a' ),
+		// get placeholder to turn into a video thumbnail
+			toUpdate = placeholders.filter( '[data-id=' + embedData.placeholderIndex + ']' ),
+		// get thumbnail code from hidden div in success modal
+			html = $( '#VideoEmbedCode' ).html();
 
-		to_update.parent().parent().replaceWith(html);
+		toUpdate.closest( '.wikiaVideoPlaceholder' ).replaceWith( html );
 
 		// update data id so we can match DOM placeholders to parsed wikitext placeholders
-		placeholders.each(function() {
-			var $this = $(this),
-				id = $this.attr('data-id');
+		placeholders.each( function() {
+			var $this = $( this ),
+				id = $this.attr( 'data-id' );
 
-			if(id > embedData.placeholderIndex) {
-				$this.attr('data-id', id-1);
+			if ( id > embedData.placeholderIndex ) {
+				$this.attr( 'data-id', id - 1 );
 			}
-		});
+		} );
 
 		// purge cache of article so video will show up on reload
-		$.post(wgScript, {title: wgPageName, action: 'purge'});
+		$.post( window.wgScript, {title: window.wgPageName, action: 'purge'} );
 
 		// re-bind events
-		MediaPlaceholder.setupVideoPlaceholders();
-
-
+		this.setupVideoPlaceholders();
 	},
-
 
 	// Get data for WMU / VET from placeholder element
-	getProps: function(elem) {
+	getProps: function( elem ) {
 		return {
-			placeholderIndex: elem.attr('data-id'),
-			align: elem.attr('data-align'),
-			width: elem.attr('data-width'),
-			thumb: elem.attr('data-thumb'),
-			link: elem.attr('data-link'),
-			caption: elem.attr('data-caption')
-		}
-	},
-
-	/**
-	 * Finds the event in the window object, the caller's arguments, or
-	 * in the arguments of another method in the callstack.  This is
-	 * executed automatically for events registered through the event
-	 * manager, so the implementer should not normally need to execute
-	 * this function at all.
-	 * @method getEvent
-	 * @param {Event} e the event parameter from the handler
-	 * @param {HTMLElement} boundEl the element the listener is attached to
-	 * @return {Event} the event
-	 * @static
-	 *
-	 * @deprecated - used by WMU and VET only
-	 */
-	getEvent: function(e, boundEl) {
-		var ev = e || window.event;
-
-		if (!ev) {
-			var c = this.getEvent.caller;
-			while (c) {
-				ev = c.arguments[0]; /* JSlint ignore */
-				if (ev && Event == ev.constructor) { /* JSlint ignore */
-					break;
-				}
-				c = c.caller;
-			}
-		}
-
-		return ev;
+			placeholderIndex: elem.attr( 'data-id' ),
+			align: elem.attr( 'data-align' ),
+			width: elem.attr( 'data-width' ),
+			thumb: elem.attr( 'data-thumb' ),
+			link: elem.attr( 'data-link' ),
+			caption: elem.attr( 'data-caption' )
+		};
 	}
-
 };
 
-window.MediaPlaceholder = MediaPlaceholder;
-
-})(jQuery, this);
+})( jQuery, window );

--- a/extensions/wikia/ImagePlaceholder/js/MediaPlaceholder.js
+++ b/extensions/wikia/ImagePlaceholder/js/MediaPlaceholder.js
@@ -37,10 +37,10 @@ window.MediaPlaceholder = {
 
 		// Handle clicks on image placeholders (video placeholders are handled differently)
 		this.WikiaArticle.on( 'click', '.wikiaImagePlaceholder a', function( e ) {
-			e.preventDefault();
-
 			var $this = $( this ),
 				props = self.getProps( $this );
+
+			e.preventDefault();
 
 			// Provide immediate feedback once button is clicked
 			$this.startThrobbing();
@@ -48,20 +48,20 @@ window.MediaPlaceholder = {
 			if ( !self.imageLoaded ) {
 				// open WMU
 				$.when(
-						$.getResources( [
-							$.loadYUI,
-							$.loadJQueryAIM,
-							$.getSassCommonURL( 'extensions/wikia/WikiaMiniUpload/css/WMU.scss' ),
-							window.wgResourceBasePath + '/extensions/wikia/WikiaMiniUpload/js/WMU.js'
-						] )
-					).done( function() {
-						self.imageLoaded = true;
-						$this.stopThrobbing();
-						window.WMU_show( // jshint ignore:line
-							window.event, -2, props.placeholderIndex, props.align, props.thumb,
-							props.width, props.caption, props.link
-						);
-					} );
+					$.getResources( [
+						$.loadYUI,
+						$.loadJQueryAIM,
+						$.getSassCommonURL( 'extensions/wikia/WikiaMiniUpload/css/WMU.scss' ),
+						window.wgResourceBasePath + '/extensions/wikia/WikiaMiniUpload/js/WMU.js'
+					] )
+				).done( function() {
+					self.imageLoaded = true;
+					$this.stopThrobbing();
+					window.WMU_show( // jshint ignore:line
+						window.event, -2, props.placeholderIndex, props.align, props.thumb,
+						props.width, props.caption, props.link
+					);
+				} );
 			} else {
 				$this.stopThrobbing();
 				window.WMU_show( // jshint ignore:line
@@ -75,14 +75,17 @@ window.MediaPlaceholder = {
 		var self = this;
 
 		self.WikiaArticle.find( '.wikiaVideoPlaceholder a' ).each( function() {
-
 			var $this = $( this ),
 				props = self.getProps( $this );
 
 			$this.addVideoButton( {
 				embedPresets: props,
-				insertFinalVideoParams: ['placeholder=1', 'box=' + props.placeholderIndex, 'article=' +
-					encodeURIComponent( window.wgTitle ), 'ns=' + window.wgNamespaceNumber],
+				insertFinalVideoParams: [
+					'placeholder=1',
+					'box=' + props.placeholderIndex,
+					'article=' + encodeURIComponent( window.wgTitle ),
+					'ns=' + window.wgNamespaceNumber
+				],
 				callbackAfterEmbed: $.proxy( self.videoEmbedCallback, self )
 			} );
 		} );

--- a/extensions/wikia/ImagePlaceholder/js/MediaPlaceholder.js
+++ b/extensions/wikia/ImagePlaceholder/js/MediaPlaceholder.js
@@ -111,7 +111,7 @@
 			} );
 
 			// purge cache of article so video will show up on reload
-			$.post( window.wgScript, {title: window.wgPageName, action: 'purge'} );
+			$.post( window.wgScript, { title: window.wgPageName, action: 'purge' } );
 
 			// re-bind events
 			this.setupVideoPlaceholders();

--- a/extensions/wikia/ImagePlaceholder/js/MediaPlaceholder.js
+++ b/extensions/wikia/ImagePlaceholder/js/MediaPlaceholder.js
@@ -93,9 +93,9 @@ window.MediaPlaceholder = {
 
 	videoEmbedCallback: function( embedData ) {
 		var placeholders = this.WikiaArticle.find( '.wikiaVideoPlaceholder a' ),
-		// get placeholder to turn into a video thumbnail
+			// get placeholder to turn into a video thumbnail
 			toUpdate = placeholders.filter( '[data-id=' + embedData.placeholderIndex + ']' ),
-		// get thumbnail code from hidden div in success modal
+			// get thumbnail code from hidden div in success modal
 			html = $( '#VideoEmbedCode' ).html();
 
 		toUpdate.closest( '.wikiaVideoPlaceholder' ).replaceWith( html );

--- a/extensions/wikia/ImageTweaks/ImageTweaks.setup.php
+++ b/extensions/wikia/ImageTweaks/ImageTweaks.setup.php
@@ -50,7 +50,7 @@ $wgHooks['ImageAfterProduceHTML'][] = 'ImageTweaksHooks::onImageAfterProduceHTML
 //hook into Linker::MakeThumbLink2
 $wgHooks['ThumbnailAfterProduceHTML'][] = 'ImageTweaksHooks::onThumbnailAfterProduceHTML';
 
-//hook into ImageThumbnail::toHTML
+//hook into ThumbnailImage::toHTML
 $wgHooks['ThumbnailImageHTML'][] = 'ImageTweaksHooks::onThumbnailImageHTML';
 
 //hook into ThumbnailVideo::toHTML

--- a/extensions/wikia/WikiaMiniUpload/WikiaMiniUpload_body.php
+++ b/extensions/wikia/WikiaMiniUpload/WikiaMiniUpload_body.php
@@ -435,7 +435,7 @@ class WikiaMiniUpload {
 
 		$gallery = $wgRequest->getVal( 'gallery', '' );
 		$title_main = urldecode( $wgRequest->getVal( 'article', '' ) );
-		$fck = $wgRequest->getCheck( 'ns', false );
+
 		$ns = $wgRequest->getVal( 'ns', '' );
 		$link = urldecode( $wgRequest->getVal( 'link', '' ) );
 
@@ -606,7 +606,7 @@ class WikiaMiniUpload {
 
 		$ns_img = $wgContLang->getFormattedNsText( NS_IMAGE );
 
-		if ( ( -2 == $gallery ) && !$fck ) {
+		if ( ( -2 == $gallery ) ) {
 			// this went in from the single placeholder...
 			$name = $title->getText();
 			$size = $wgRequest->getVal('size');

--- a/extensions/wikia/WikiaMiniUpload/WikiaMiniUpload_body.php
+++ b/extensions/wikia/WikiaMiniUpload/WikiaMiniUpload_body.php
@@ -435,10 +435,11 @@ class WikiaMiniUpload {
 
 		$gallery = $wgRequest->getVal( 'gallery', '' );
 		$title_main = urldecode( $wgRequest->getVal( 'article', '' ) );
-
 		$ns = $wgRequest->getVal( 'ns', '' );
-		$ck = $wgRequest->getVal( 'ck' );
 		$link = urldecode( $wgRequest->getVal( 'link', '' ) );
+
+		// Are we in the ck editor?
+		$ck = $wgRequest->getVal( 'ck' );
 
 		$extraId = $wgRequest->getVal('extraId');
 		$newFile =  true;

--- a/extensions/wikia/WikiaMiniUpload/WikiaMiniUpload_body.php
+++ b/extensions/wikia/WikiaMiniUpload/WikiaMiniUpload_body.php
@@ -437,6 +437,7 @@ class WikiaMiniUpload {
 		$title_main = urldecode( $wgRequest->getVal( 'article', '' ) );
 
 		$ns = $wgRequest->getVal( 'ns', '' );
+		$ck = $wgRequest->getVal( 'ck' );
 		$link = urldecode( $wgRequest->getVal( 'link', '' ) );
 
 		$extraId = $wgRequest->getVal('extraId');
@@ -606,7 +607,7 @@ class WikiaMiniUpload {
 
 		$ns_img = $wgContLang->getFormattedNsText( NS_IMAGE );
 
-		if ( ( -2 == $gallery ) ) {
+		if ( ( -2 == $gallery ) && !$ck ) {
 			// this went in from the single placeholder...
 			$name = $title->getText();
 			$size = $wgRequest->getVal('size');

--- a/extensions/wikia/WikiaMiniUpload/js/WMU.js
+++ b/extensions/wikia/WikiaMiniUpload/js/WMU.js
@@ -1013,7 +1013,8 @@ function WMU_insertImage(type) {
 		params.push( 'article='+encodeURIComponent( wgTitle ) );
 		params.push( 'ns='+wgNamespaceNumber );
 		if( WMU_refid != null ) {
-			params.push( 'fck=true' );
+			// was fck, updated to ck to be more accurate
+			params.push( 'ck=true' );
 		}
 	}
 

--- a/extensions/wikia/WikiaMiniUpload/js/WMU.js
+++ b/extensions/wikia/WikiaMiniUpload/js/WMU.js
@@ -921,8 +921,6 @@ function WMU_insertPlaceholder( box ) {
 	WMU_box_filled.push(box);
 	var to_update = $( '#WikiaImagePlaceholder' + box );
 	to_update.html($( '#ImageUploadCode' ).html());
-	//the class would need to be different if we had here the full-size...
-	to_update.className = '';
 	$.post(wgServer + wgScript + '?title=' + wgPageName  +'&action=purge');
 }
 

--- a/extensions/wikia/WikiaMiniUpload/js/WMU.js
+++ b/extensions/wikia/WikiaMiniUpload/js/WMU.js
@@ -1014,7 +1014,6 @@ function WMU_insertImage(type) {
 		params.push( 'article='+encodeURIComponent( wgTitle ) );
 		params.push( 'ns='+wgNamespaceNumber );
 		if( WMU_refid != null ) {
-			// was fck, updated to ck to be more accurate
 			params.push( 'ck=true' );
 		}
 	}

--- a/extensions/wikia/WikiaMiniUpload/js/WMU.js
+++ b/extensions/wikia/WikiaMiniUpload/js/WMU.js
@@ -1,6 +1,6 @@
 /*
  * Author: Inez Korczynski, Bartek Lapinski
- * Converted from YUI to jQuery by Hyun
+ * Converted from YUI to jQuery by Hyun (except for the slider)
  */
 
 /**
@@ -840,6 +840,7 @@ function WMU_displayDetails(responseText) {
 		}
 		var thumbSize = [image.width(), image.height()];
 		WMU_orgThumbSize = null;
+		// TODO: switch to jQuery slider, remove YUI!
 		WMU_slider = YAHOO.widget.Slider.getHorizSlider('ImageUploadSlider', 'ImageUploadSliderThumb', 0, 200);
 		WMU_slider.initialRound = true;
 		WMU_slider.getRealValue = function() {


### PR DESCRIPTION
This PR fixes image placeholders in articles so that they actually add and save an image. 

I also fixed white space in MediaPlaceholder.js and cleaned up a few other items as they came up. 
