### PR TITLE
Parse wikitext warning message

### DIFF
--- a/extensions/VisualEditor/VisualEditorDataModule.php
+++ b/extensions/VisualEditor/VisualEditorDataModule.php
@@ -77,6 +77,7 @@ class VisualEditorDataModule extends ResourceLoaderModule {
 			'visualeditor-browserwarning' => array( 'visualeditor-browserwarning' ),
 			'visualeditor-report-notice' => array( 'visualeditor-report-notice' ),
 			'visualeditor-wikitext-warning' => array( 'visualeditor-wikitext-warning' ),
+			'wikia-visualeditor-wikitext-warning' => array( 'wikia-visualeditor-wikitext-warning' ),
 		);
 
 		// Override message value


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/VE-676

Messages that require parsing are handled differently than those that don't, so parsed messages require extra identification. A better fix would be to rework messaging so that no distinction is necessary, but this fixes the current P2. 
