### PR TITLE
nocaptchatest passed on when first used on Special:CreateNewWiki

### DIFF
--- a/extensions/wikia/CreateNewWiki/CreateNewWikiController.class.php
+++ b/extensions/wikia/CreateNewWiki/CreateNewWikiController.class.php
@@ -76,7 +76,11 @@ class CreateNewWikiController extends WikiaController {
 		$this->signupUrl = '';
 		if(!empty($this->wg->EnableUserLoginExt)) {
 			$signupTitle = Title::newFromText('UserSignup', NS_SPECIAL);
-			$this->signupUrl = $signupTitle->getFullURL();
+			if ( $wgRequest->getInt( 'nocaptchatest' ) ) {
+				$this->signupUrl = $signupTitle->getFullURL('nocaptchatest=1');
+			} else {
+				$this->signupUrl = $signupTitle->getFullURL();
+			}
 		}
 
 		// Make various parsed messages and status available in JS


### PR DESCRIPTION
Passing nocaptcha parameter to fix "Create new wiki with signup" testcase
