### PR TITLE
Config refactoring

### DIFF
--- a/extensions/wikia/Development/SpecialDevBoxPanel/Special_DevBoxPanel.php
+++ b/extensions/wikia/Development/SpecialDevBoxPanel/Special_DevBoxPanel.php
@@ -53,6 +53,18 @@ $wgExtensionCredits['specialpage'][] = array(
 
 $wgSpecialPages['DevBoxPanel'] = 'DevBoxPanel';
 
+if (getenv('wgDevelEnvironmentName')) {
+        $wgDevelEnvironmentName = getenv('wgDevelEnvironmentName');
+} else {
+        $host = gethostname();
+        $host = explode("-", $host);
+        $wgDevelEnvironmentName = trim($host[1]);
+}
+
+// Asset manaager and ajax requests come in "too early" for the rest of config
+// So we need a fallback global domain.  This is kind of a hack, fixme.
+$wgDevboxDefaultWikiDomain = 'www.wikia.com';
+
 class DevBoxPanel extends SpecialPage {
 	public function __construct(){
 		// macbre: don't run code below when running in command line mode (memcache starts to act strange) - NOTE: This macbre code was in a different spot... this may be fixed implicitly now.

--- a/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
+++ b/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
@@ -629,6 +629,7 @@ class WikiFactoryLoader {
 						/**
 						 * skip this variable
 						 */
+						unset($this->mVariables[ $oRow->cv_name ]);
 						$this->debug( "{$oRow->cv_name} with value {$tUnserVal} skipped" );
 					}
 				}

--- a/maintenance/rebuildLocalisationCache.php
+++ b/maintenance/rebuildLocalisationCache.php
@@ -36,6 +36,9 @@ class RebuildLocalisationCache extends Maintenance {
 		$this->mDescription = "Rebuild the localisation cache";
 		$this->addOption( 'force', 'Rebuild all files, even ones not out of date' );
 		$this->addOption( 'threads', 'Fork more than one thread', false, true );
+		// Wikia change begin
+		$this->addOption( 'cache-dir', 'Override the value of $wgCacheDirectory', false, true );
+		// Wikia change end
 	}
 
 	public function memoryLimit() {
@@ -44,6 +47,11 @@ class RebuildLocalisationCache extends Maintenance {
 
 	public function execute() {
 		global $wgLocalisationCacheConf;
+
+		// Wikia change begin
+		global $wgCacheDirectory;
+		$wgCacheDirectory = $this->getOption( 'cache-dir', $wgCacheDirectory );
+		// Wikia change end
 
 		$force = $this->hasOption( 'force' );
 		$threads = $this->getOption( 'threads', 1 );


### PR DESCRIPTION
**_DO NOT MERGE**_

This is an experimental change to the application repo to support the new configuration layout.   This pull request is just to allow review by the deploytools/platform team.  

I moved a couple of settings into the DevBoxPanel setup because they have to load before CommonSettings in the load order.  The global Devbox config now loads after CommonSettings. 

We added a new parameter to the localization cache script so that the deploy tools can build messages as part of the build step.

And finally, a small bug fix for something I ran into during testing.  If the wgServer variable sneaks into the cached wikifactory settings then it will never be unset.  This would normally never happen unless you are hacking around on the configuration files. :) 
