### PR TITLE
DAR-347 | WAMApi - fixed boolean value

### DIFF
--- a/extensions/wikia/WAM/controllers/api/WAMApiController.class.php
+++ b/extensions/wikia/WAM/controllers/api/WAMApiController.class.php
@@ -151,11 +151,11 @@ class WAMApiController extends WikiaApiController {
 		$options['wikiLang'] = $this->request->getVal('wiki_lang', null);
 		$options['wikiId'] = $this->request->getInt('wiki_id', null);
 		$options['wikiWord'] = $this->request->getVal('wiki_word', null);
-		$options['excludeBlacklist'] = $this->request->getVal('exclude_blacklist', false);
+		$options['excludeBlacklist'] = $this->request->getFuzzyBool('exclude_blacklist', false);
 		$options['excludeNonCommercial'] = $this->hideNonCommercialContent();
-		$options['fetchAdmins'] = $this->request->getBool('fetch_admins', false);
+		$options['fetchAdmins'] = $this->request->getFuzzyBool('fetch_admins', false);
 		$options['avatarSize'] = $this->request->getInt('avatar_size', self::DEFAULT_AVATAR_SIZE);
-		$options['fetchWikiImages'] = $this->request->getBool('fetch_wiki_images', false);
+		$options['fetchWikiImages'] = $this->request->getFuzzyBool('fetch_wiki_images', false);
 		$options['wikiImageWidth'] = $this->request->getInt('wiki_image_width', self::DEFAULT_WIKI_IMAGE_WIDTH);
 		$options['wikiImageHeight'] = $this->request->getInt('wiki_image_height', WikiService::IMAGE_HEIGHT_KEEP_ASPECT_RATIO);
 		$options['sortColumn'] = $this->request->getVal('sort_column', 'wam_rank');

--- a/includes/wikia/nirvana/WikiaRequest.class.php
+++ b/includes/wikia/nirvana/WikiaRequest.class.php
@@ -106,6 +106,20 @@ class WikiaRequest {
 	}
 
 	/**
+	 * Fetch a boolean value from the input or return $default if not set.
+	 * Unlike getBool, the string "false" will result in boolean false, which is
+	 * useful when interpreting information sent from JavaScript.
+	 * @see WebRequest::getFuzzyBool
+	 *
+	 * @param $name String
+	 * @param $default Boolean
+	 * @return Boolean
+	 */
+	public function getFuzzyBool( $name, $default = false ) {
+		return $this->getBool( $name, $default ) && strcasecmp( $this->getVal( $name ), 'false' ) !== 0;
+	}
+
+	/**
 	 * Return true if the named value is set in the input, whatever that
 	 * value is (even "0"). Return false if the named value is not set.
 	 * Example use is checking for the presence of check boxes in forms.

--- a/includes/wikia/tests/WikiaRequestTest.php
+++ b/includes/wikia/tests/WikiaRequestTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * @ingroup mwabstract
+ */
+class WikiaRequestTest extends PHPUnit_Framework_TestCase {
+
+	/**
+	 * @dataProvider getBoolDataProvider
+	 */
+	public function testGetBool($testVal, $expected) {
+		$request = new WikiaRequest(['test' => $testVal]);
+		$result = $request->getBool('test');
+		$this->assertEquals($expected, $result);
+	}
+
+	public function getBoolDataProvider() {
+		return [
+			[true, true],
+			[false, false],
+			[0, false],
+			[1, true],
+			['true', true],
+			['false', true], // yep this is strange but it's from MW
+			['1', true],
+			['0', false],
+		];
+	}
+
+	/**
+	 * @dataProvider getFuzzyBoolDataProvider
+	 */
+	public function testGetFuzzyBool($testVal, $expected) {
+		$request = new WikiaRequest(['test' => $testVal]);
+		$result = $request->getFuzzyBool('test');
+		$this->assertEquals($expected, $result);
+	}
+
+	public function getFuzzyBoolDataProvider() {
+		return [
+			[true, true],
+			[false, false],
+			[0, false],
+			[1, true],
+			['true', true],
+			['false', false],
+			['1', true],
+			['0', false],
+		];
+	}
+}


### PR DESCRIPTION
As WikiaRequest::getBool returns `true` when passing `'false'` we need the same method as `WebRequest::getFuzzyBool` https://github.com/Wikia/app/blob/dev/includes/WebRequest.php#L470 there.
