### PR TITLE
CON-280 - Fixed 404 on hubs and WAM

### DIFF
--- a/extensions/wikia/WAMPage/WAMPageArticle.class.php
+++ b/extensions/wikia/WAMPage/WAMPageArticle.class.php
@@ -18,9 +18,6 @@ class WAMPageArticle extends Article {
 	public function view() {
 		wfProfileIn(__METHOD__);
 
-		// let MW handle basic stuff
-		parent::view();
-
 		$app = F::app();
 		$app->wg->Out->clearHTML();
 		

--- a/extensions/wikia/WikiaHubsV2/models/WikiaHubsV2Article.class.php
+++ b/extensions/wikia/WikiaHubsV2/models/WikiaHubsV2Article.class.php
@@ -21,9 +21,6 @@ class WikiaHubsV2Article extends Article {
 	public function view() {
 		wfProfileIn(__METHOD__);
 
-		// let MW handle basic stuff
-		parent::view();
-
 		$params = array();
 		if (!empty($this->verticalId)) {
 			$params['verticalid'] = $this->verticalId;


### PR DESCRIPTION
As fix for https://wikia-inc.atlassian.net/browse/BAC-630 introduced check for not existing revisions on Articles Hubs and WAM started to throw 404s.
Call to `Article::view` is not required anymore for HUBS and WAM.
