### PR TITLE
Vid 1106 css fix

### DIFF
--- a/extensions/wikia/SpecialVideos/css/SpecialVideos.scss
+++ b/extensions/wikia/SpecialVideos/css/SpecialVideos.scss
@@ -71,6 +71,10 @@ $placeholder-bg-color: darken($color-page, 10%);
 	.video {
 		margin-bottom: 8px;
 	}
+	// can be removed after article cache clears - 2/6/2014
+	.info-overlay-views {
+		display: inline;
+	}
 	.grid-2, .grid-2.alpha {
 		margin-bottom: 18px;
 	}

--- a/extensions/wikia/SpecialVideos/css/SpecialVideos.scss
+++ b/extensions/wikia/SpecialVideos/css/SpecialVideos.scss
@@ -71,7 +71,7 @@ $placeholder-bg-color: darken($color-page, 10%);
 	.video {
 		margin-bottom: 8px;
 	}
-	// can be removed after article cache clears - 2/6/2014
+	// can be removed after article cache clears on 2/6/2014
 	.info-overlay-views {
 		display: inline;
 	}

--- a/extensions/wikia/VideoHandlers/css/VideoHandlers.scss
+++ b/extensions/wikia/VideoHandlers/css/VideoHandlers.scss
@@ -93,7 +93,7 @@ a:hover .Wikia-video-play-button, .Wikia-video-play-button:hover {
 			font-weight: bold;
 		}
 	}
-	// can be removed after article cache clears - 2/6/2014
+	// can be removed after article cache clears on 2/6/2014
 	.info-overlay-views {
 		display: none;
 	}

--- a/extensions/wikia/VideoHandlers/css/VideoHandlers.scss
+++ b/extensions/wikia/VideoHandlers/css/VideoHandlers.scss
@@ -93,6 +93,10 @@ a:hover .Wikia-video-play-button, .Wikia-video-play-button:hover {
 			font-weight: bold;
 		}
 	}
+	// can be removed after article cache clears - 2/6/2014
+	.info-overlay-views {
+		display: none;
+	}
 	&:hover {
 		text-decoration: none;
 		.info-overlay {


### PR DESCRIPTION
this will hide the video views until the article cache clears on 2/6/2014 at which date this fix can be removed. 
