### PR TITLE
Dar 1532: changing wiki name is breaking chat module

### DIFF
--- a/extensions/wikia/Chat2/js/WMBridge.js
+++ b/extensions/wikia/Chat2/js/WMBridge.js
@@ -100,6 +100,7 @@ var requestMW = function(method, roomId, postdata, query, handshake, callback, e
 			 */
 			function updateMWaddress() {
 				if (redirectInfo.newServer && (server != redirectInfo.newServer)) {
+					logger.critical('Old wiki address found: ' + server + ', updating to ' + redirectInfo.newServer);
 					storage.setRoomData(roomId, 'wgServer', redirectInfo.newServer);
 				}
 			}

--- a/extensions/wikia/Chat2/js/WMBridge.js
+++ b/extensions/wikia/Chat2/js/WMBridge.js
@@ -4,6 +4,7 @@ var qs = require('qs');
 var storage = require('./storage').redisFactory();
 var request = require('request');
 var logger = require('./logger').logger;
+var url = require('url');
 
 var urlencode = function(str) {
     // http://kevin.vanzonneveld.net
@@ -51,16 +52,18 @@ var requestMW = function(method, roomId, postdata, query, handshake, callback, e
 		postdata = "";
 	}
 
-	storage.getRoomData(roomId, 'wgServer', function(data) {
-		if (data) {
-			var wikiHostname = data.replace(/^https?:\/\//i, "");
-			var url = 'http://' + wikiHostname + '/index.php' + query + "&cb=" + Math.floor(Math.random()*99999); // varnish appears to be caching this (at least on dev boxes) when we don't want it to... so cachebust it.;
-			logger.debug("Making  request to host: " + url);
-
-			// settings HTTP headers' variable
-			var headers = {
-				'content-type': 'application/x-www-form-urlencoded'
-			};
+	storage.getRoomData(roomId, 'wgServer', function(server) {
+		if (server) {
+			var wikiHostname = server.replace(/^https?:\/\//i, ''),
+				redirectInfo = {
+					redirects: 0,   // number of redirects followed so far
+					MAX_REDIRECTS: 3,   // maximum number of redirects
+					newServer: null   // last redirect host (http(s)://something)
+				},
+				// settings HTTP headers' variable
+				headers = {
+					'content-type': 'application/x-www-form-urlencoded'
+				};
 
 			if( handshake && handshake.headers ) {
 				if( typeof handshake.headers['user-agent'] !== 'undefined' ) {
@@ -72,46 +75,82 @@ var requestMW = function(method, roomId, postdata, query, handshake, callback, e
 				}
 			}
 
-			request({
-			    	method: method,
-			    	//followRedirect: false,
-			    	headers: headers,
-			    	body: postdata,
-			    	json: false,
-			    	url: url,
-			    	proxy: 'http://' + config.WIKIA_PROXY
-			    }, 
-			    function (error, response, body) {
-			    	if(error) {
-			    		errorcallback();
-			    		logger.error(error);
-			    		return ;
-			    	}
-			    	logger.debug(response.statusCode);
-			    	if(response.statusCode ==  200) {
-						try{
-							if((typeof body) == 'string'){
-								data = JSON.parse(body);
-								logger.debug("parsing");
-							} else {
-								logger.debug("parsed by request");
-								data = body;
+			/**
+			 * check the response and if this is a redirect, follow it
+			 * returns true in case the method handled the redirect response
+			 */
+			function handleRedirect(response) {
+				if (response && (response.statusCode ==  301) && response.headers && response.headers.location) {
+					// extract server
+					var parts = url.parse(response.headers.location);
+					if (parts.hostname != wikiHostname) {
+						redirectInfo.redirects++;
+						if (redirectInfo.redirects < redirectInfo.MAX_REDIRECTS) {
+							redirectInfo.newServer = parts.protocol + '//' + parts.hostname;
+							makeRequest(parts.hostname);
+							return true;
+						}
+					}
+				}
+				return false;
+			}
+
+			function updateMWaddress() {
+				if (redirectInfo.newServer && (server != redirectInfo.newServer)) {
+					storage.setRoomData(roomId, 'wgServer', redirectInfo.newServer);
+				}
+			}
+
+			function makeRequest(host) {
+				var requestUrl = 'http://' + host + '/index.php' + query + "&cb=" + Math.floor(Math.random()*99999), // varnish appears to be caching this (at least on dev boxes) when we don't want it to... so cachebust it.;
+					data;
+				logger.debug("Making request to host: " + requestUrl);
+				request({
+						method: method,
+						//followRedirect: false,
+						headers: headers,
+						body: postdata,
+						json: false,
+						url: requestUrl,
+						proxy: 'http://' + config.WIKIA_PROXY
+					},
+					function (error, response, body) {
+						if (handleRedirect(response)) { // 301 handling
+							return;
+						}
+						if(error) {
+							errorcallback();
+							logger.error(error);
+							return ;
+						}
+						logger.debug(response.statusCode);
+						if(response.statusCode ==  200) {
+							try{
+								if((typeof body) == 'string'){
+									data = JSON.parse(body);
+									logger.debug("parsing");
+								} else {
+									logger.debug("parsed by request");
+									data = body;
+								}
+								logger.debug(data);
+								updateMWaddress();
+								callback(data);
+							} catch(e) {
+								logger.error("Error: while parsing result from:" + requestUrl + '\nError was' + e.message + "\nResponse that didn't parse was:" );
+								logger.error(body);
+								data = {
+									error: '',
+									errorWfMsg: 'chat-err-communicating-with-mediawiki',
+									errorMsgParams: []
+								};
 							}
 							logger.debug(data);
-							callback(data);
-						} catch(e) {
-							logger.error("Error: while parsing result from:" + url + '\nError was' + e.message + "\nResponse that didn't parse was:" );
-							logger.error(body);
-							data = {
-								error: '',
-								errorWfMsg: 'chat-err-communicating-with-mediawiki',
-								errorMsgParams: []
-							};
 						}
-			    		logger.debug(data);
-			    	}
-			    }
-			);
+				});
+			}
+
+			makeRequest(wikiHostname);
 		}
 	},
 	errorcallback);

--- a/extensions/wikia/Chat2/js/server_api.js
+++ b/extensions/wikia/Chat2/js/server_api.js
@@ -83,7 +83,7 @@ function api_getDefaultRoomId(cityId, extraDataString, type, serializedUsers, su
 	// See if there are any rooms for this wiki and if there are, get the first one.
 	var roomId = "";
 
-	users = [];
+	var users = [];
 	if ( typeof(serializedUsers) != 'undefined' ) {
 		try {
 			users = JSON.parse( serializedUsers ) || [];

--- a/extensions/wikia/Chat2/js/server_config.js
+++ b/extensions/wikia/Chat2/js/server_config.js
@@ -110,7 +110,7 @@ exports.getKey_userInRoom = function(userName, roomId){
 exports.getKeyPrefix_usersInRoom = function(){ return "users_in_room"; }
 exports.getKey_usersInRoom = function(roomId){ return exports.getKeyPrefix_usersInRoom() +":" + roomId; } // key for set of all usernames in the given room
 
-exports.getKeyPrefix_usersAllowedInPrivRoom = function( roomId ){ return "users_allowed_in_priv_room"; }
+exports.getKeyPrefix_usersAllowedInPrivRoom = function(){ return "users_allowed_in_priv_room"; }
 exports.getKey_usersAllowedInPrivRoom = function( roomId ){ return exports.getKeyPrefix_usersAllowedInPrivRoom() + ":" + roomId; }
 
 exports.getKey_chatEntriesInRoom = function(roomId){ return "chatentries:" + roomId; }

--- a/extensions/wikia/Chat2/js/server_config.js
+++ b/extensions/wikia/Chat2/js/server_config.js
@@ -82,11 +82,11 @@ exports.logLevel = (typeof arvg.loglevel != 'undefined') ? arvg.loglevel : "CRIT
 //TODO move this to other file
 /** KEY BUILDING / ACCESSING FUNCTIONS **/
 exports.getKey_listOfRooms = function( cityId, type, users ){
-	users = users || [];
-	users = users.sort();
 	if(type == "open") {
 		return "rooms_on_wiki:" + cityId;
 	} else {
+		users = users || [];
+		users = users.sort();
 		return "rooms_on_wiki:" + cityId + ':' + md5( type + users.join( ',' ) );
 	}
 }

--- a/extensions/wikia/Chat2/js/storage.js
+++ b/extensions/wikia/Chat2/js/storage.js
@@ -60,8 +60,17 @@ RedisStorage.prototype = {
 						extraData = {};
 					}
 				}
-				// Store the room in redis.
-				self._hmset(roomKey, {
+				var hmsetdata = {
+					'room_id': roomId,
+					'wgCityId': cityId,
+					'wgServer': extraData.wgServer,
+					'wgArticlePath': extraData.wgArticlePath
+				};
+
+				logger.critical("Calling _hmset for key " + roomKey + ' and data '+ JSON.stringify(hmsetdata));
+				self._hmset(roomKey, hmsetdata);
+
+				self.setRoomData(roomId, null, {
 					'room_id': roomId,
 					'wgCityId': cityId,
 					'wgServer': extraData.wgServer,
@@ -109,6 +118,35 @@ RedisStorage.prototype = {
 					'Error: while getting ' + key +' of room: "'+ roomId + '": %error%', 
 					errback);
 		}
+	},
+
+	/**
+	 * Set the room data
+	 * @param roomId room identifier
+	 * @param key key to set, if null then value can containg multiple entries
+	 * @param value single value if key is specified or multipl ewhen key is null
+	 */
+	setRoomData: function(roomId, key, value, callback, errback) {
+		var roomKey = this.config.getKey_room(roomId);
+		if ( key === null )  {
+			logger.critical("Wanted to call _hmset for key " + roomKey + ' and data '+ JSON.stringify(value));
+			/*
+			this._hmset(roomKey, value, callback,
+				"Warning: couldn't set hash data for room w/key '"+ roomKey + "': %error%",
+				function(errorMsg){
+					logger.warning(errorMsg);
+					errback();
+				});
+				*/
+		} else {
+			logger.critical('Want to store new host address for room ' + roomId + ': ' + key + ' - ' + value);
+			/*
+			this._hset(roomKey, key, value, callback,
+				'Error: while setting ' + key +' of room: "'+ roomId + '": %error%',
+				errback);
+			*/
+		}
+
 	},
 	
 	getRuntimeStats: function(callback, errback, both) {

--- a/extensions/wikia/Chat2/js/storage.js
+++ b/extensions/wikia/Chat2/js/storage.js
@@ -67,6 +67,10 @@ RedisStorage.prototype = {
 					'wgArticlePath': extraData.wgArticlePath
 				});
 
+				// mech: sanity check, I saw that breaking sometimes, want to see the details
+				if (users && (typeof users.sort !== 'function')) {
+					logger.critical('Malformed users list for roomId ' + roomId, users);
+				}
 				// Add the room to the list of rooms on this wiki.
 				self._rpush(self.config.getKey_listOfRooms(cityId, type, users), roomId);
 				var result = {

--- a/extensions/wikia/Chat2/js/storage.js
+++ b/extensions/wikia/Chat2/js/storage.js
@@ -50,7 +50,6 @@ RedisStorage.prototype = {
 		self._incr(
 			self.config.getKey_nextRoomId(), function(roomId) {
 				// Create the room.
-				var roomKey = self.config.getKey_room( roomId );
 				var extraData = {};
 				if(extraDataString){
 					try{
@@ -60,15 +59,6 @@ RedisStorage.prototype = {
 						extraData = {};
 					}
 				}
-				var hmsetdata = {
-					'room_id': roomId,
-					'wgCityId': cityId,
-					'wgServer': extraData.wgServer,
-					'wgArticlePath': extraData.wgArticlePath
-				};
-
-				logger.critical("Calling _hmset for key " + roomKey + ' and data '+ JSON.stringify(hmsetdata));
-				self._hmset(roomKey, hmsetdata);
 
 				self.setRoomData(roomId, null, {
 					'room_id': roomId,
@@ -129,22 +119,16 @@ RedisStorage.prototype = {
 	setRoomData: function(roomId, key, value, callback, errback) {
 		var roomKey = this.config.getKey_room(roomId);
 		if ( key === null )  {
-			logger.critical("Wanted to call _hmset for key " + roomKey + ' and data '+ JSON.stringify(value));
-			/*
 			this._hmset(roomKey, value, callback,
 				"Warning: couldn't set hash data for room w/key '"+ roomKey + "': %error%",
 				function(errorMsg){
 					logger.warning(errorMsg);
 					errback();
 				});
-				*/
 		} else {
-			logger.critical('Want to store new host address for room ' + roomId + ': ' + key + ' - ' + value);
-			/*
 			this._hset(roomKey, key, value, callback,
 				'Error: while setting ' + key +' of room: "'+ roomId + '": %error%',
 				errback);
-			*/
 		}
 
 	},


### PR DESCRIPTION
The problem is that request module does not handle redirects for POST requests - which are used to send info for chat module. So in case of redirect I'm updating the wiki hostname in redis and re-posting the data.
