### PR TITLE
CONN-86: wall owner fix - broken comments_index row with id equal 0 can ...

### DIFF
--- a/extensions/wikia/ArticleComments/classes/CommentsIndex.class.php
+++ b/extensions/wikia/ArticleComments/classes/CommentsIndex.class.php
@@ -326,6 +326,10 @@ class CommentsIndex extends WikiaModel {
 
 		wfProfileIn( __METHOD__ );
 
+		if ( !$commentId ) {
+			wfProfileOut( __METHOD__ );
+			return null;
+		}
 		$sqlWhere = array( 'comment_id' => $commentId );
 		if ( !empty($parentPageId) ) {
 			$sqlWhere['parent_page_id'] = $parentPageId;


### PR DESCRIPTION
...cause wrong wall owner detecion
