### PR TITLE
BAC-1183: log reasons for multiple url purge requests

### DIFF
--- a/includes/cache/HTMLCacheUpdate.php
+++ b/includes/cache/HTMLCacheUpdate.php
@@ -58,6 +58,13 @@ class HTMLCacheUpdate implements DeferrableUpdate {
 
 		# Get an estimate of the number of rows from the BacklinkCache
 		$numRows = $this->mCache->getNumLinks( $this->mTable );
+
+		// Wikia change - begin
+		// @author macbre - BAC-1183
+		Wikia::log('purge-requests-WIKIA', false,
+			sprintf('an edit of "%s" triggered %d purge requests', $this->mTitle->getPrefixedText(), $numRows), true);
+		// Wikia change - end
+
 		if ( $numRows > $this->mRowsPerJob * 2 ) {
 			# Do fast cached partition
 			$this->insertJobs();


### PR DESCRIPTION
The following entries will be added to `datalog-s1:/var/log/private/purge-requests.log`:

```
an edit of "Szablon:Pętla infobox" triggered 23 purge requests
```

@prein / @Wikia/platform-team 
