### PR TITLE
(CE-580) Fix missing reply button on some comments

### DIFF
--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -362,6 +362,8 @@ class ArticleComment {
 			$replyButton = '';
 
 			//this is for blogs we want to know if commenting on it is enabled
+			// we cannot check it using $title->getBaseText, as this returns main namespace title
+			// the subjectpage for $parts title is something like 'User blog comment:SomeUser/BlogTitle' which is fine
 			$commentingAllowed = ArticleComment::canComment( Title::newFromText( $parts['title'] )->getSubjectPage() );
 
 			if ( ( count( $parts['partsStripped'] ) == 1 ) && $commentingAllowed && !ArticleCommentInit::isFbConnectionNeeded() ) {

--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -362,7 +362,7 @@ class ArticleComment {
 			$replyButton = '';
 
 			//this is for blogs we want to know if commenting on it is enabled
-			$commentingAllowed = ArticleComment::canComment( Title::newFromText( $title->getBaseText() ) );
+			$commentingAllowed = ArticleComment::canComment( Title::newFromText( $parts['title'] )->getSubjectPage() );
 
 			if ( ( count( $parts['partsStripped'] ) == 1 ) && $commentingAllowed && !ArticleCommentInit::isFbConnectionNeeded() ) {
 				$replyButton = '<button type="button" class="article-comm-reply wikia-button secondary actionButton">' . wfMsg('article-comments-reply') . '</button>';
@@ -565,7 +565,7 @@ class ArticleComment {
 
 		$canComment = true;
 		$title = is_null( $title ) ? $wgTitle : $title;
-		
+
 		if ( !in_array( $title->getNamespace(), $wgArticleCommentsNamespaces ) ) {
 			$canComment = false;
 		}


### PR DESCRIPTION
When article comments are disabled but blog comments are still enabled,
or if article comments are enabled on other namespaces but disabled on
the main namespace, the check for whether the user can reply to a comment
fails because it is checking if the user can comment against the comment
title's getBaseText(). This always returns a main namespace title, which
means we were always just checking if the user could comment on the main
namespace. This only worked before because prior to d8232fd canComment
would always return true for any namespace, so through the API a user
could have commented on any namespace.

This fixes it by getting a title from the parts array and getting its
subject page. For blog comments, the title in parts is
User blog comment:SomeUser/BlogTitle or
User blog comment:SomeUser/BlogTitle/@comment-SomeOtherUser-20140107140257
and the subject page of it is User blog:SomeUser/BlogTitle so we are now
checking the right title. For article comments (on main namespace pages in
this example), the title in parts is Talk:Test Page and the subject page
of it is just Test Page.

This method isn't relied on by Wall or Forum, and only affects article
comments and blogs.

@themech 
