### PR TITLE
CONN-27 Fixed pulling avatar in Special:Connect

### DIFF
--- a/extensions/FBConnect/wikia/fbconnect_customizations.php
+++ b/extensions/FBConnect/wikia/fbconnect_customizations.php
@@ -59,11 +59,11 @@ function wikia_fbconnect_considerProfilePic( &$specialConnect ){
 				$data->source = 'facebook';
 				$data->file = $tmpFile;
 
-				$userProfilePageV3->saveUsersAvatar($wgUser->getId(), $data);
+				$userProfilePageV3->saveUsersAvatar( $wgUser->getId(), $data );
 			}
 		}
 	}
 
-	wfProfileOut(__METHOD__);
+	wfProfileOut( __METHOD__ );
 	return true;
 } // end wikia_fbconnect_considerProfilePic()

--- a/extensions/FBConnect/wikia/fbconnect_customizations.php
+++ b/extensions/FBConnect/wikia/fbconnect_customizations.php
@@ -37,27 +37,25 @@ function wikia_fbconnect_considerProfilePic( &$specialConnect ){
 	if( count( $fb_ids ) > 0 ) {
 		$fb_id = array_shift( $fb_ids );
 
-		if ( class_exists( 'Masthead' ) ) {
-			// If the useralready has a masthead avatar, don't overwrite it, this function shouldn't alter anything in that case.
-			$masthead = Masthead::newFromUser( $wgUser );
+		// If the useralready has a masthead avatar, don't overwrite it, this function shouldn't alter anything in that case.
+		$masthead = Masthead::newFromUser( $wgUser );
 
-			if( !$masthead->hasAvatar() ) {
-				// Attempt to store the facebook profile pic as the Wikia avatar.
-				$picUrl = FBConnectProfilePic::getImgUrlById( $fb_id, FB_PIC_BIG );
+		if( !$masthead->hasAvatar() ) {
+			// Attempt to store the facebook profile pic as the Wikia avatar.
+			$picUrl = FBConnectProfilePic::getImgUrlById( $fb_id, FB_PIC_BIG );
 
-				if( $picUrl != '' ) {
-					$tmpFile = '';
-					$sUrl = $masthead->uploadByUrlToTempFile( $picUrl, $tmpFile );
+			if( $picUrl != '' ) {
+				$tmpFile = '';
+				$sUrl = $masthead->uploadByUrlToTempFile( $picUrl, $tmpFile );
 
-					$app = F::app();
+				$app = F::app();
 
-					// UPPv3 has been enabled in 2012 sitewide
-					// https://github.com/Wikia/config/blob/dev/CommonExtensions.php#L1714
-					$userProfilePageV3 = new UserProfilePageController( $app );
-					$data->source = 'facebook';
-					$data->file = $tmpFile;
-					$userProfilePageV3->saveUsersAvatar($wgUser->getId(), $data);
-				}
+				// UPPv3 has been enabled in 2012 sitewide
+				// https://github.com/Wikia/config/blob/dev/CommonExtensions.php#L1714
+				$userProfilePageV3 = new UserProfilePageController( $app );
+				$data->source = 'facebook';
+				$data->file = $tmpFile;
+				$userProfilePageV3->saveUsersAvatar($wgUser->getId(), $data);
 			}
 		}
 	}

--- a/extensions/FBConnect/wikia/fbconnect_customizations.php
+++ b/extensions/FBConnect/wikia/fbconnect_customizations.php
@@ -47,8 +47,6 @@ function wikia_fbconnect_considerProfilePic( &$specialConnect ){
 			$picUrl = FBConnectProfilePic::getImgUrlById( $fb_id, FB_PIC_BIG );
 
 			if( $picUrl != '' ) {
-				$tmpFile = '';
-
 				$app = F::app();
 
 				// UPPv3 has been enabled in 2012 sitewide
@@ -57,7 +55,7 @@ function wikia_fbconnect_considerProfilePic( &$specialConnect ){
 
 				$data = new stdClass();
 				$data->source = 'facebook';
-				$data->file = $tmpFile;
+				$data->file = $picUrl;
 
 				$userProfilePageV3->saveUsersAvatar( $wgUser->getId(), $data );
 			}

--- a/extensions/FBConnect/wikia/fbconnect_customizations.php
+++ b/extensions/FBConnect/wikia/fbconnect_customizations.php
@@ -26,18 +26,20 @@ function wikia_fbconnect_init(){
  * function will check to see if the user has a Wikia Avatar and if they don't, it will attempt to
  * use this Facebook-connected user's profile picture as their Wikia Avatar.
  *
- * FIXME: Is there a way to make this fail gracefully if we ever un-include the Masthead extension?
+ * This function is depended on Masthead and UserProfilePageController classes
  */
 function wikia_fbconnect_considerProfilePic( &$specialConnect ){
-	wfProfileIn(__METHOD__);
+	wfProfileIn( __METHOD__ );
 	global $wgUser;
 
 	// We need the facebook id to have any chance of getting a profile pic.
-	$fb_ids = FBConnectDB::getFacebookIDs($wgUser);
+	$fb_ids = FBConnectDB::getFacebookIDs( $wgUser );
+
 	if( count( $fb_ids ) > 0 ) {
 		$fb_id = array_shift( $fb_ids );
 
-		// If the useralready has a masthead avatar, don't overwrite it, this function shouldn't alter anything in that case.
+		// If the user already has a masthead avatar, don't overwrite it,
+		// this function shouldn't alter anything in that case.
 		$masthead = Masthead::newFromUser( $wgUser );
 
 		if( !$masthead->hasAvatar() ) {
@@ -46,15 +48,17 @@ function wikia_fbconnect_considerProfilePic( &$specialConnect ){
 
 			if( $picUrl != '' ) {
 				$tmpFile = '';
-				$sUrl = $masthead->uploadByUrlToTempFile( $picUrl, $tmpFile );
 
 				$app = F::app();
 
 				// UPPv3 has been enabled in 2012 sitewide
 				// https://github.com/Wikia/config/blob/dev/CommonExtensions.php#L1714
 				$userProfilePageV3 = new UserProfilePageController( $app );
+
+				$data = new stdClass();
 				$data->source = 'facebook';
 				$data->file = $tmpFile;
+
 				$userProfilePageV3->saveUsersAvatar($wgUser->getId(), $data);
 			}
 		}


### PR DESCRIPTION
- removed `class_exists( 'Masthead' );` call since Masthead is [enabled sitewide](https://github.com/Wikia/app/blob/dev/extensions/wikia/UserProfilePageV3/UserProfilePage.setup.php#L28),
- left upload to `UserProfilePageController` since it's also [enabled sitewide](https://github.com/Wikia/config/blob/dev/CommonExtensions.php#L1714)
