### PR TITLE
(BAC-1198) Fix use of explode in getData

### DIFF
--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -356,7 +356,7 @@ class ArticleComment {
 
 			$isStaff = (int)in_array('staff', $this->mUser->getEffectiveGroups() );
 
-			$parts = self::explode($title);
+			$parts = self::explode( $title->getDBkey() );
 
 			$buttons = array();
 			$replyButton = '';
@@ -364,7 +364,8 @@ class ArticleComment {
 			//this is for blogs we want to know if commenting on it is enabled
 			// we cannot check it using $title->getBaseText, as this returns main namespace title
 			// the subjectpage for $parts title is something like 'User blog comment:SomeUser/BlogTitle' which is fine
-			$commentingAllowed = ArticleComment::canComment( Title::newFromText( $parts['title'] )->getSubjectPage() );
+			$articleTitle = Title::makeTitle( MWNamespace::getSubject( $this->mNamespace ), $parts['title'] );
+			$commentingAllowed = ArticleComment::canComment( $articleTitle );
 
 			if ( ( count( $parts['partsStripped'] ) == 1 ) && $commentingAllowed && !ArticleCommentInit::isFbConnectionNeeded() ) {
 				$replyButton = '<button type="button" class="article-comm-reply wikia-button secondary actionButton">' . wfMsg('article-comments-reply') . '</button>';


### PR DESCRIPTION
The explode method which expects a string was being passed a Title
object. This worked for loading comments on Articles, Blogs, Walls,
and Forums because of Title's toString method (every other use of
explode correctly passes a string to it). This failed on some
WikiActivity pages however and instead of returning a string in
$parts['title'] it returned the title object.

We should be correctly passing a string of the title without a
namespace, rather than relying on toString, and then constructing
the subject page using the $parts['title'] and the subject namespace.

@themech @federico-lox 
