### PR TITLE
wgPFStringLengthLimit WikiFactory being overwritten

### DIFF
--- a/extensions/ParserFunctions/ParserFunctions.php
+++ b/extensions/ParserFunctions/ParserFunctions.php
@@ -14,7 +14,11 @@ if ( !defined( 'MEDIAWIKI' ) ) {
  * Defines the maximum length of a string that string functions are allowed to operate on
  * Prevention against denial of service by string function abuses.
  */
-$wgPFStringLengthLimit = 1000;
+// wikia change start (BAC-1119)
+if (empty($wgPFStringLengthLimit)) {
+	$wgPFStringLengthLimit = 1000;
+}
+// wikia change end
 
 /**
  * Enable string functions.


### PR DESCRIPTION
@Wikia/platform-team 
https://wikia-inc.atlassian.net/browse/BAC-1119

Quick fix for now, but we should probably talk about how to handle this in the general case, since it seems like WikiFactory is loaded before extensions are included, so extension defaults will always override WikiFactory settings.
