### PR TITLE
BAC-1199: Add logging of catchable fatals

### DIFF
--- a/includes/Exception.php
+++ b/includes/Exception.php
@@ -193,6 +193,7 @@ class MWException extends Exception {
 			$wgOut->output();
 		} else {
 			header( 'HTTP/1.1 500 Internal Server Error' );
+			header( "X-MediaWiki-Exception: 1" ); // Wikia change - @author macbre (BAC-1199)
 			header( "Content-Type: text/html; charset=utf-8" );
 			$hookResult = $this->runHooks( get_class( $this ) . "Raw" );
 			if ( $hookResult ) {
@@ -213,6 +214,7 @@ class MWException extends Exception {
 
 		if ( $log ) {
 			wfDebugLog( 'exception', $log );
+			Wikia::log( 'exceptions-WIKIA', get_class($this), $log, true ); // Wikia change - @author macbre (BAC-1199)
 		}
 
 		if ( self::isCommandLine() ) {

--- a/includes/wikia/nirvana/WikiaException.php
+++ b/includes/wikia/nirvana/WikiaException.php
@@ -55,6 +55,7 @@ class WikiaException extends WikiaBaseException {
 		parent::__construct( $message, $code, $previous );
 
 		// log more details (macbre)
+		Wikia::log( 'exceptions-WIKIA', get_class($this), $message, true );
 		Wikia::logBacktrace( __METHOD__ );
 	}
 }


### PR DESCRIPTION
The following information will be logged to `datalog-s1:/var/log/private/exceptions.log`:

```
exceptions-WIKIA-WikiaDispatchedException: Internal Throw (Title::newFromText given an object)
exceptions-WIKIA-MWException: /wiki/Specjalna:Wersja   Exception from line 130 of /usr/wikia/source/app/includes/Title.php: Title::newFromText given an object
```

Additionally, `X-MediaWiki-Exception: 1` header will be added to the HTTP 500 response to ease debugging.

@Wikia/platform-team
