### PR TITLE
Fixing user stats unit tests

### DIFF
--- a/includes/wikia/services/UserStatsService.class.php
+++ b/includes/wikia/services/UserStatsService.class.php
@@ -93,17 +93,15 @@ class UserStatsService extends WikiaModel {
 		wfProfileIn( __METHOD__ );
 
 		$wikiId = ( $wikiId == 0 ) ? $this->wg->CityId : $wikiId ;
-
 		$editCount = $this->getOptionWiki( 'editcount', $wikiId, $skipCache );
 
-		if( $editCount === null or $editCount === false ) { // editcount has not been initialized. do so.
-
+		if( $editCount === null or $editCount === false ) {
+		// editcount has not been initialized. do so.
 			$editCount = $this->resetEditCountWiki( $wikiId );
-
 		}
 
 		wfProfileOut( __METHOD__ );
-		return $editCount;
+		return (int) $editCount;
 	}
 
 

--- a/tests/unit/ServiceTest.php
+++ b/tests/unit/ServiceTest.php
@@ -85,6 +85,11 @@ class ServiceTest extends WikiaBaseTest {
 	}
 
 	function testUserStatsService() {
+		// make sure we don't use memcache during the call
+		$wgMemcMock = $this->getMock( 'stdclass', ['get', 'set'] );
+		$wgMemcMock->expects( $this->any() )->method( 'get' )->will( $this->returnValue( null ) );
+		$this->mockGlobalVariable('wgMemc', $wgMemcMock);
+
 		$user = User::newFromName('QATestsBot');
 
 		$service = new UserStatsService($user->getId());

--- a/tests/unit/ServiceTest.php
+++ b/tests/unit/ServiceTest.php
@@ -90,9 +90,9 @@ class ServiceTest extends WikiaBaseTest {
 		$service = new UserStatsService($user->getId());
 		$stats = $service->getStats();
 
-		$this->assertInternalType('int', $stats['edits']);
-		$this->assertInternalType('int', $stats['likes']);
-		$this->assertInternalType('string', $stats['date']);
+		$this->assertInternalType('int', $stats['edits'], 'Checking if edits number is an integer');
+		$this->assertInternalType('int', $stats['likes'], 'Checking if likes number is an integer');
+		$this->assertInternalType('string', $stats['date'], 'Checking if date is a string');
 
 		// edits increase - perform fake edit
 		$edits = $stats['edits'];
@@ -100,7 +100,7 @@ class ServiceTest extends WikiaBaseTest {
 		$service->increaseEditsCount();
 
 		$stats = $service->getStats();
-		$this->assertEquals($edits+1, $stats['edits']);
+		$this->assertEquals($edits+1, $stats['edits'], 'Checking if UserStatsService::increaseEditsCount works correctly');
 	}
 
 	function testCategoriesService() {


### PR DESCRIPTION
For some reason this unit test failed when I ran all unit tests before merging our sprint changes to dev. I mocked memcached and force one method to return an integer. @wladekb @themech @kamilkoterba tell me what you think about it, please. Maybe we should exclude this test from our unit tests group instead of fixing it like that...
