### PR TITLE
Refactored QuickStatsController::shortenNumberDecorator() and its test

### DIFF
--- a/extensions/wikia/AdminDashboard/QuickStatsController.class.php
+++ b/extensions/wikia/AdminDashboard/QuickStatsController.class.php
@@ -145,13 +145,15 @@ class QuickStatsController extends WikiaController {
 		$number = intval($number);
 
 		if ( $number >= 1000000000 ) {
-			return wfMsg('quickstats-number-shortening-billions', array(round( $number / 1000000000, 1)));
+			$result = wfMessage( 'quickstats-number-shortening-billions', round( $number / 1000000000, 1) )->plain();
 		} elseif ($number >= 1000000 ) {
-			return wfMsg('quickstats-number-shortening-millions', array(round( $number / 1000000, 1)));
+			$result = wfMessage( 'quickstats-number-shortening-millions', round( $number / 1000000, 1) )->plain();
 		} elseif ($number >= 10000 ) {
-			return wfMsg('quickstats-number-shortening', array(round( $number / 1000 , 1)));
+			$result = wfMessage( 'quickstats-number-shortening', round( $number / 1000 , 1) )->plain();
 		} else {
-			return F::app()->wg->Lang->formatNum( $number );
+			$result = F::app()->wg->Lang->formatNum( $number );
 		}
+
+		return $result;
 	}
 }

--- a/extensions/wikia/AdminDashboard/tests/AdminDashboardTest.php
+++ b/extensions/wikia/AdminDashboard/tests/AdminDashboardTest.php
@@ -221,21 +221,27 @@
 		/**
 		 * @dataProvider shortenNumberDecoratorDataProvider
 		 */
-		public function testShortenNumberDecorator($number,$expected) {
-			$result = QuickStatsController::shortenNumberDecorator($number);
-			$this->assertEquals($expected, $result);
+		public function testShortenNumberDecorator( $number, $expected ) {
+			$wfMessage = $this->getMock( 'stdclass', ['plain'] );
+			$wfMessage->expects( $this->any() )
+				->method( 'plain' )
+				->will( $this->returnValue( $expected ) );
+			$this->mockGlobalFunction( 'wfMessage', $wfMessage );
+
+			$result = QuickStatsController::shortenNumberDecorator( $number );
+			$this->assertEquals( $expected, $result );
 		}
 
 		public function shortenNumberDecoratorDataProvider() {
-				return array(
-					array(1234,'1,234'), // note: this only works for EN
-					array(56000,'56K'),
-					array(56710,'56.7K'),
-					array(56756,'56.8K'),
-					array(56900,'56.9K'),
-					array(56990,'57K'),
-					array(123456789,'123.5M')
-				);
+			return [
+				[ 1234, '1,234' ], // note: this only works for EN
+				[ 56000, '56K' ],
+				[ 56710, '56.7K' ],
+				[ 56756, '56.8K' ],
+				[ 56900, '56.9K' ],
+				[ 56990, '57K' ],
+				[ 123456789, '123.5M' ]
+			];
 		}
 
 		protected static function getFetchObjResult($key, $cnt, $date=null) {


### PR DESCRIPTION
For some reason this unit test failed when I ran all unit tests before merging our sprint changes to dev branch. I mocked `wfMessage()` global function here. @wladekb @themech tell me what you think about it, please.
