### PR TITLE
DAR-3222 | Fixed PHP Stricts to make Special:CreateNewWiki working

### DIFF
--- a/extensions/wikia/FounderEmails/events/FounderEmailsEditEvent.class.php
+++ b/extensions/wikia/FounderEmails/events/FounderEmailsEditEvent.class.php
@@ -236,9 +236,20 @@ class FounderEmailsEditEvent extends FounderEmailsEvent {
 		return $recentEditsCount;
 	}
 
+	/**
+	 * @param RecentChange|null $oRecentChange we allow it to be null because of compatibility with FounderEmailsEvent::register()
+	 *
+	 * @return bool
+	 *
+	 * @throws Exception
+	 */
 	public static function register( $oRecentChange = null ) {
 		global $wgUser, $wgCityId;
 		wfProfileIn( __METHOD__ );
+
+		if( is_null( $oRecentChange ) ) {
+			throw new \Exception( 'Invalid $oRecentChange value.' );
+		}
 
 		if ( FounderEmails::getInstance()->getLastEventType() == 'register' ) {
 			// special case: creating userpage after user registration, ignore event

--- a/extensions/wikia/FounderEmails/events/FounderEmailsEditEvent.class.php
+++ b/extensions/wikia/FounderEmails/events/FounderEmailsEditEvent.class.php
@@ -236,7 +236,7 @@ class FounderEmailsEditEvent extends FounderEmailsEvent {
 		return $recentEditsCount;
 	}
 
-	public static function register( $oRecentChange ) {
+	public static function register( $oRecentChange = null ) {
 		global $wgUser, $wgCityId;
 		wfProfileIn( __METHOD__ );
 

--- a/extensions/wikia/RTE/RTELinkerHooks.class.php
+++ b/extensions/wikia/RTE/RTELinkerHooks.class.php
@@ -108,9 +108,14 @@ class RTELinkerHooks extends Linker {
 	 * Returns placeholder for broken image link
 	 *
 	 * This one is called directly by RTEParser::makeImage()
+	 *
 	 */
-	public static function makeBrokenImageLinkObj(Title $title, $html = '', $query = '', $trail = '', $prefix = '', $time = false, $wikitextIdx = null) {
+	public static function makeBrokenImageLinkObj( $title, $html = '', $query = '', $trail = '', $prefix = '', $time = false, $wikitextIdx = null ) {
 		wfProfileIn(__METHOD__);
+
+		if( !$title instanceof Title ) {
+			throw new \Exception( '$title is not Title class instance' );
+		}
 
 		// try to resolve internal links in broken image caption (RT #90616)
 		$wikitext = RTEData::get('wikitext', $wikitextIdx);

--- a/includes/wikia/GlobalTitle.php
+++ b/includes/wikia/GlobalTitle.php
@@ -45,9 +45,22 @@ class GlobalTitle extends Title {
 	static protected $cachedObjects = array();
 
 	/**
-	 * static constructor, Create new Title from name of page
+	 * @desc Static constructor, Create new Title from name of page
+	 *
+	 * @param String $text
+	 * @param Integer $namespace (default NS_MAIN)
+	 * @param Integer|null $city_id a wiki id; we allow null because of compatibility with Title::newFromText()
+	 *
+	 * @throws Exception when $city_id parameter is null
+	 *
+	 * @return GlobalTitle
 	 */
 	public static function newFromText( $text, $namespace = NS_MAIN, $city_id = null ) {
+		if( $city_id <= 0 ) {
+		// we allow to pass null in the method definition because of Strict Compatibility with Title::newFromText()
+			throw new \Exception( 'Invalid $city_id.' );
+		}
+
 		$filteredText = Sanitizer::decodeCharReferences( $text );
 		$title = new GlobalTitle();
 
@@ -61,13 +74,21 @@ class GlobalTitle extends Title {
 		return $title;
 	}
 	
-    /**
-	 * Create a new Title for the Main Page
+	/**
+	 * @desc Create a new Title for the Main Page
 	 *
-	 * @param int city_id
-	 * @return Title the new object
+	 * @param Integer city_id a wiki id; we allow null because of compatibility with Title::newFromText()
+	 *
+	 * @throws Exception when $city_id parameter is null
+	 *
+	 * @return GlobalTitle
 	 */
 	public static function newMainPage( $city_id = null ) {
+		if( $city_id <= 0 ) {
+		// we allow to pass null in the method definition because of Strict Compatibility with Title::newFromText()
+			throw new \Exception( 'Invalid $city_id.' );
+		}
+
 		// sure hope this redirects for the most part
 		$title = self::newFromText( 'Main Page', NS_MAIN, $city_id );
 		return $title;

--- a/includes/wikia/GlobalTitle.php
+++ b/includes/wikia/GlobalTitle.php
@@ -77,7 +77,7 @@ class GlobalTitle extends Title {
 	/**
 	 * @desc Create a new Title for the Main Page
 	 *
-	 * @param Integer city_id a wiki id; we allow null because of compatibility with Title::newMainPage()
+	 * @param Integer $city_id a wiki id; we allow null because of compatibility with Title::newMainPage()
 	 *
 	 * @throws Exception when $city_id parameter is null
 	 *

--- a/includes/wikia/GlobalTitle.php
+++ b/includes/wikia/GlobalTitle.php
@@ -95,11 +95,24 @@ class GlobalTitle extends Title {
 	}
 
 	/**
-	 * static constructor, Create new Title from id of page
+	 * @desc static constructor, Create new Title from id of page
+	 *
+	 * @param Integer $id
+	 * @param Integer $city_id
+	 * @param String $dbname
+	 * 
+	 * @throws Exception
+	 *
+	 * @returns GlobalTitle|null
 	 */
 	public static function newFromId( $id, $city_id = 0, $dbname = "" ) {
 		global $wgMemc;
 		$title = null;
+
+		if( $city_id <= 0 ) {
+		// we allow to pass 0 in the method definition because of Strict Compatibility with Title::newFromText()
+			throw new \Exception( 'Invalid $city_id.' );
+		}
 
 		$memkey = sprintf( "GlobalTitle:%d:%d", $id, $city_id );
 		$res = $wgMemc->get( $memkey );

--- a/includes/wikia/GlobalTitle.php
+++ b/includes/wikia/GlobalTitle.php
@@ -47,8 +47,7 @@ class GlobalTitle extends Title {
 	/**
 	 * static constructor, Create new Title from name of page
 	 */
-	public static function newFromText( $text, $namespace, $city_id ) {
-
+	public static function newFromText( $text, $namespace = NS_MAIN, $city_id = null ) {
 		$filteredText = Sanitizer::decodeCharReferences( $text );
 		$title = new GlobalTitle();
 

--- a/includes/wikia/GlobalTitle.php
+++ b/includes/wikia/GlobalTitle.php
@@ -67,7 +67,7 @@ class GlobalTitle extends Title {
 	 * @param int city_id
 	 * @return Title the new object
 	 */
-	public static function newMainPage( $city_id ) {
+	public static function newMainPage( $city_id = null ) {
 		// sure hope this redirects for the most part
 		$title = self::newFromText( 'Main Page', NS_MAIN, $city_id );
 		return $title;

--- a/includes/wikia/GlobalTitle.php
+++ b/includes/wikia/GlobalTitle.php
@@ -56,7 +56,7 @@ class GlobalTitle extends Title {
 	 * @return GlobalTitle
 	 */
 	public static function newFromText( $text, $namespace = NS_MAIN, $city_id = null ) {
-		if( $city_id <= 0 ) {
+		if( $city_id === null ) {
 		// we allow to pass null in the method definition because of Strict Compatibility with Title::newFromText()
 			throw new \Exception( 'Invalid $city_id.' );
 		}
@@ -84,7 +84,7 @@ class GlobalTitle extends Title {
 	 * @return GlobalTitle
 	 */
 	public static function newMainPage( $city_id = null ) {
-		if( $city_id <= 0 ) {
+		if( $city_id === null ) {
 		// we allow to pass null in the method definition because of Strict Compatibility with Title::newFromText()
 			throw new \Exception( 'Invalid $city_id.' );
 		}
@@ -105,11 +105,11 @@ class GlobalTitle extends Title {
 	 *
 	 * @returns GlobalTitle|null
 	 */
-	public static function newFromId( $id, $city_id = 0, $dbname = "" ) {
+	public static function newFromId( $id, $city_id = null, $dbname = "" ) {
 		global $wgMemc;
 		$title = null;
 
-		if( $city_id <= 0 ) {
+		if( $city_id === null ) {
 		// we allow to pass 0 in the method definition because of Strict Compatibility with Title::newFromText()
 			throw new \Exception( 'Invalid $city_id.' );
 		}

--- a/includes/wikia/GlobalTitle.php
+++ b/includes/wikia/GlobalTitle.php
@@ -77,7 +77,7 @@ class GlobalTitle extends Title {
 	/**
 	 * @desc Create a new Title for the Main Page
 	 *
-	 * @param Integer city_id a wiki id; we allow null because of compatibility with Title::newFromText()
+	 * @param Integer city_id a wiki id; we allow null because of compatibility with Title::newMainPage()
 	 *
 	 * @throws Exception when $city_id parameter is null
 	 *
@@ -98,9 +98,9 @@ class GlobalTitle extends Title {
 	 * @desc static constructor, Create new Title from id of page
 	 *
 	 * @param Integer $id
-	 * @param Integer $city_id
+	 * @param Integer $city_id a wiki id; we allow null because of compatibility with Title::newFromId()
 	 * @param String $dbname
-	 * 
+	 *
 	 * @throws Exception
 	 *
 	 * @returns GlobalTitle|null

--- a/includes/wikia/GlobalTitle.php
+++ b/includes/wikia/GlobalTitle.php
@@ -76,7 +76,7 @@ class GlobalTitle extends Title {
 	/**
 	 * static constructor, Create new Title from id of page
 	 */
-	public static function newFromId( $id, $city_id, $dbname = "" ) {
+	public static function newFromId( $id, $city_id = 0, $dbname = "" ) {
 		global $wgMemc;
 		$title = null;
 


### PR DESCRIPTION
While working on [DAR-3222](https://wikia-inc.atlassian.net/browse/DAR-3222) we found out there were lots of PHP Stricts warnings. Here is a clean up for them.
