### PR TITLE
(CE-565) Remove anon SiteWideMessages from page

### DIFF
--- a/extensions/wikia/SiteWideMessages/SiteWideMessagesController.class.php
+++ b/extensions/wikia/SiteWideMessages/SiteWideMessagesController.class.php
@@ -1,0 +1,36 @@
+<?php
+
+class SiteWideMessagesController extends WikiaController  {
+
+	public function getAnonMessages() {
+		if ( $this->wg->User->isLoggedIn() ) {
+			// Don't return anything if this happens
+			$this->skipRendering();
+			return;
+		}
+
+		$this->hasNotifications = $this->request->getBool( 'hasnotifications' );
+
+		$msgs = SiteWideMessages::getAllAnonMessages( $this->wg->User, false, false );
+
+		// Filter dismissed messages
+		foreach ( $msgs as $msgId => $msgData ) {
+			if ( isset( $_COOKIE[$this->wg->CookiePrefix . 'swm-' . $msgId] ) ) {
+				unset( $msgs[$msgId] );
+			}
+		}
+
+		$this->siteWideMessages = $msgs;
+		$this->notificationType = NotificationsController::NOTIFICATION_SITEWIDE;
+	}
+
+	public function dismissAnonMessage() {
+		if ( !$this->wg->User->isLoggedIn() ) {
+			$messageId = $this->request->getInt( 'messageid' );
+			if ( $messageId > 0 ) {
+				$this->wg->Request->response()->setcookie( 'swm-' . $messageId, 1, time() + 86400 /*24h*/ );
+			}
+		}
+	}
+
+}

--- a/extensions/wikia/SiteWideMessages/SpecialSiteWideMessages.php
+++ b/extensions/wikia/SiteWideMessages/SpecialSiteWideMessages.php
@@ -51,6 +51,14 @@ if (!function_exists('extAddSpecialPage')) {
 extAddSpecialPage(dirname(__FILE__) . '/SpecialSiteWideMessages_body.php', 'SiteWideMessages', 'SiteWideMessages');
 $wgSpecialPageGroups['SiteWideMessages'] = 'wikia';
 
+$wgAutoloadClasses['SiteWideMessagesController'] =  __DIR__ . '/SiteWideMessagesController.class.php';
+
+$wgResourceModules['ext.siteWideMessages.anon'] = array(
+	'localBasePath' => __DIR__ . '/js',
+	'remoteExtPath' => 'wikia/SiteWideMessages/js',
+	'scripts' => 'SiteWideMessages.anon.js',
+);
+
 /**
  * Initialize hooks
  *
@@ -135,11 +143,13 @@ function SiteWideMessagesAddNotifications(&$skim, &$tpl) {
 
 	if ( F::app()->checkSkin( 'oasis' ) ) {
 		// Add site wide notifications that haven't been dismissed
-		if ( $wgUser->isLoggedIn() ) {
-			$msgs = SiteWideMessages::getAllUserMessages( $wgUser, false, false );
-		} else {
-			$msgs = SiteWideMessages::getAllAnonMessages( $wgUser, false, false );
+		if ( !$wgUser->isLoggedIn() ) {
+			$wgOut->addModuleScripts( 'ext.siteWideMessages.anon' );
+			wfProfileOut( __METHOD__ );
+			return true;
 		}
+
+		$msgs = SiteWideMessages::getAllUserMessages( $wgUser, false, false );
 
 		if ( !empty( $msgs ) ) {
 			wfProfileIn( __METHOD__ . '::parse' );

--- a/extensions/wikia/SiteWideMessages/SpecialSiteWideMessages_body.php
+++ b/extensions/wikia/SiteWideMessages/SpecialSiteWideMessages_body.php
@@ -1246,69 +1246,55 @@ class SiteWideMessages extends SpecialPage {
 		return $result;
 	}
 
-	static function getAllAnonMessages( $user, $dismissLink = true, $formatted = true ) {
-		global $wgCookiePrefix, $wgCityId, $wgLanguageCode;
-		global $wgExternalSharedDB;
+	static function getAllAnonMessages( $user ) {
+		global $wgCityId, $wgExternalSharedDB, $wgMemc, $wgTitle;
 
-		wfProfileIn(__METHOD__);
+		wfProfileIn( __METHOD__ );
 
 		$localCityId = isset( $wgCityId ) ? $wgCityId : 0;
 
-		$dbr = wfGetDB( DB_SLAVE, array(), $wgExternalSharedDB );
+		$memcKey = "smw:anon:{$localCityId}";
 
-		$tmpMsg = array();
+		$result = $wgMemc->get( $memcKey );
 
-		$dbResult = $dbr->query(
-			'SELECT msg_wiki_id, msg_id AS id, msg_text AS text, msg_expire AS expire, msg_lang AS lang, msg_status AS status' .
-			' FROM ' . MSG_TEXT_DB .
-			' LEFT JOIN ' . MSG_STATUS_DB . ' USING (msg_id)' .
-			' WHERE msg_mode = ' . MSG_MODE_SELECTED .
-			' AND msg_recipient_id = 0' .
-			' AND msg_recipient_name = ' . $dbr->addQuotes( MSG_RECIPIENT_ANON ) .
-			' AND msg_status IN (' . MSG_STATUS_UNSEEN . ', ' . MSG_STATUS_SEEN . ')' .
-			' AND (msg_expire IS NULL OR msg_expire > ' . $dbr->addQuotes( date( 'Y-m-d H:i:s' ) ) . ')' .
-			' AND msg_removed = ' . MSG_REMOVED_NO .
-			" AND (msg_wiki_id = 0 OR msg_wiki_id = $localCityId )" .
-			';'
-			, __METHOD__
-		);
+		if ( !is_array( $result ) ) {
+			$dbr = wfGetDB( DB_SLAVE, array(), $wgExternalSharedDB );
 
-		while ( $oMsg = $dbr->fetchObject( $dbResult ) ) {
-			if ( !isset( $_COOKIE[$wgCookiePrefix . 'swm-' . $oMsg->id] ) && self::getLanguageConstraintsForUser( $user, $oMsg->lang ) ) {
-				$tmpMsg[$oMsg->id] = array( 'wiki_id' => $oMsg->msg_wiki_id, 'text' => $oMsg->text, 'expire' => $oMsg->expire, 'status' => $oMsg->status );
+			$result = array();
+
+			$dbResult = $dbr->query(
+				'SELECT msg_wiki_id, msg_id AS id, msg_text AS text, msg_expire AS expire, msg_lang AS lang, msg_status AS status' .
+				' FROM ' . MSG_TEXT_DB .
+				' LEFT JOIN ' . MSG_STATUS_DB . ' USING (msg_id)' .
+				' WHERE msg_mode = ' . MSG_MODE_SELECTED .
+				' AND msg_recipient_id = 0' .
+				' AND msg_recipient_name = ' . $dbr->addQuotes( MSG_RECIPIENT_ANON ) .
+				' AND msg_status IN (' . MSG_STATUS_UNSEEN . ', ' . MSG_STATUS_SEEN . ')' .
+				' AND (msg_expire IS NULL OR msg_expire > ' . $dbr->addQuotes( date( 'Y-m-d H:i:s' ) ) . ')' .
+				' AND msg_removed = ' . MSG_REMOVED_NO .
+				" AND (msg_wiki_id = 0 OR msg_wiki_id = $localCityId )" .
+				';'
+				, __METHOD__
+			);
+
+			while ( $oMsg = $dbr->fetchObject( $dbResult ) ) {
+				if ( self::getLanguageConstraintsForUser( $user, $oMsg->lang ) ) {
+					$messageText = ParserPool::parse( $oMsg->text, $wgTitle, new ParserOptions() )->getText();
+					$result[$oMsg->id] = array( 'wiki_id' => $oMsg->msg_wiki_id, 'text' => $messageText, 'expire' => $oMsg->expire, 'status' => $oMsg->status );
+				}
 			}
-		}
-		if ( $dbResult !== false ) {
-			$dbr->freeResult($dbResult);
-		}
-		//sort from newer to older
-		krsort( $tmpMsg );
+			if ( $dbResult !== false ) {
+				$dbr->freeResult( $dbResult );
+			}
 
-		$messages = array();
-		$language = Language::factory($wgLanguageCode);
-		foreach ( $tmpMsg as $tmpMsgId => $tmpMsgData ) {
-			$messages[] = $dismissLink ?
-				"<div class=\"SWM_message\" id=\"msg_$tmpMsgId\">\n".
-				"{$tmpMsgData['text']}\n" .
-				"<span class=\"SWM_dismiss\"><nowiki>[</nowiki><span class=\"plainlinks\">[{{fullurl:Special:SiteWideMessages|action=dismiss&mID=$tmpMsgId}} " . wfMsg('swm-link-dismiss') . "]</span><nowiki>]</nowiki></span>" .
-				(is_null($tmpMsgData['expire']) ? '' : "<span class=\"SWM_expire\">" . wfMsg('swm-expire-info', array($language->timeanddate(strtotime($tmpMsgData['expire']), true, $user->getDatePreference()))) . "</span>") .
-				"<div>&nbsp;</div></div>"
-				:
-				"<div class=\"SWM_message\">{$tmpMsgData['text']}</div>";
+			//sort from newer to older
+			krsort( $result );
+
+			// Cache resuult for 15 minutes
+			$wgMemc->set( $memcKey, $result, 900 /* 15 minutes */ );
 		}
 
-		//prevent double execution of all those queries
-		if ( count( $messages ) ) {
-			self::$hasMessages = true;
-		}
-
-		if ($formatted) {
-			$result = implode("\n", $messages);
-		} else {
-			$result = $tmpMsg;
-		}
-
-		wfProfileOut(__METHOD__);
+		wfProfileOut( __METHOD__ );
 		return $result;
 	}
 

--- a/extensions/wikia/SiteWideMessages/js/SiteWideMessages.anon.js
+++ b/extensions/wikia/SiteWideMessages/js/SiteWideMessages.anon.js
@@ -1,0 +1,112 @@
+( function ( $, mw, window ) {
+	'use strict';
+
+	var AnonSiteWideMessages = {
+		init: function () {
+			var $notificationArea = $( '#WikiaNotifications' ),
+				hasNotifications = $notificationArea.length ? 1 : 0,
+				self = this;
+
+			$.nirvana.sendRequest( {
+				controller: 'SiteWideMessagesController',
+				method: 'getAnonMessages',
+				format: 'html',
+				data: {
+					hasnotifications: hasNotifications
+				}
+			} ).done( function( data ) {
+				var	$body,
+					$siteWideMessages,
+					$firstSWM;
+
+				if ( hasNotifications ) {
+					$notificationArea.append( data );
+				} else {
+					$body = $( 'body' );
+					$body.addClass( 'notifications' );
+					$body.append( data );
+					$notificationArea = $( '#WikiaNotifications' );
+				}
+
+				$siteWideMessages = $notificationArea.find( 'div[data-type="5"]' );
+
+				if ( $siteWideMessages.length ) {
+					$firstSWM = $siteWideMessages.first();
+
+					// Track first notification impression
+					if ( $firstSWM.length ) {
+						self.track( {
+							action: window.Wikia.Tracker.ACTIONS.IMPRESSION,
+							label: 'swm-impression',
+							value: parseInt( $firstSWM.attr( 'id' ).substr( 4 ), 10 )
+						} );
+					}
+
+					// Handle dismissing notifications
+					$siteWideMessages.find( '.close-notification' )
+						.click( $.proxy( self.handleClose, self ) );
+
+					// Track clicks of links within messages
+					$siteWideMessages.each( function() {
+						var msgId = parseInt( $( this ).attr( 'id' ).substr( 4 ), 10 );
+						$( this ).find( 'p a' ).click( function( ev ) {
+							self.track( {
+								action: window.Wikia.Tracker.ACTIONS.CLICK_LINK_TEXT,
+								browserEvent: ev,
+								href: $( this ).attr( 'href' ),
+								label: 'swm-link',
+								value: msgId
+							} );
+						} );
+					} );
+				}
+			} );
+		},
+
+		handleClose: function ( ev ) {
+			var	notification = $( ev.currentTarget ).parent(),
+				messageId = parseInt( notification.attr( 'id' ).substr( 4 ), 10 ),
+				$nextNotification = notification.next(),
+				nextMessageId;
+
+			$.nirvana.sendRequest( {
+				controller: 'SiteWideMessagesController',
+				method: 'dismissAnonMessage',
+				data: {
+					messageid: messageId
+				}
+			} );
+
+			this.track( {
+				action: window.Wikia.Tracker.ACTIONS.CLICK_LINK_BUTTON,
+				browserEvent: ev,
+				label: 'swm-dismiss',
+				value: messageId
+			} );
+
+			notification.remove();
+			$nextNotification.show();
+
+			if ( $nextNotification.length ) {
+				nextMessageId = parseInt( $nextNotification.attr( 'id' ).substr( 4 ), 10 );
+
+				// Track next message impression
+				this.track( {
+					action: window.Wikia.Tracker.ACTIONS.IMPRESSION,
+					label: 'swm-impression',
+					value: nextMessageId
+				} );
+			}
+		},
+
+		track: window.Wikia.Tracker.buildTrackingFunction( {
+			category: 'sitewidemessages',
+			trackingMethod: 'internal'
+		} )
+	};
+
+	$( function() {
+		AnonSiteWideMessages.init();
+	} );
+
+}( jQuery, mediaWiki, this ) );

--- a/extensions/wikia/SiteWideMessages/templates/SiteWideMessages_getAnonMessages.php
+++ b/extensions/wikia/SiteWideMessages/templates/SiteWideMessages_getAnonMessages.php
@@ -1,0 +1,28 @@
+<?php
+if ( !empty( $siteWideMessages ) ) {
+	if ( !$hasNotifications ) {
+?>
+<ul id="WikiaNotifications" class="WikiaNotifications<?php if ( !empty( $wg->EnableWikiaBarExt ) ): echo ' hidden'; endif; ?>">
+<?php } ?>
+	<li>
+<?php
+$first = true;
+foreach ( $siteWideMessages as $msgId => $data ) {
+?>
+		<div data-type="<?= $notificationType ?>" id="msg_<?= $msgId ?>" style="display: <?= $first ? 'block' : 'none' ?>">
+			<a class="sprite close-notification"></a><?= $data['text'] ?>
+		</div>
+<?php
+	$first = false;
+}
+?>
+
+	</li>
+<?php
+	if ( !$hasNotifications ) {
+?>
+</ul>
+<?php
+	}
+}
+?>


### PR DESCRIPTION
Load Anon SiteWideMessages via AJAX instead, simplify things and add
some light caching. This should have the added benefit of slightly
better performance for anon page loads until we get to the new version
of SWM.

This is a quick temp solution for https://wikia-inc.atlassian.net/browse/CE-565.

@Wikia/community-engineering 
