### PR TITLE
BAC-550: move "served by" info to header

### DIFF
--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -1692,7 +1692,6 @@ function wfReportTime() {
 	if ( !empty( $wgDisableReportTime ) ) {
 		return '';
 	}
-
 	// Wikia change - end
 
 	$elapsed = microtime( true ) - $wgRequestTime;

--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -1686,6 +1686,15 @@ function wfHostname() {
 function wfReportTime() {
 	global $wgRequestTime, $wgShowHostnames;
 
+	// Wikia change - begin
+	// @author macbre - BAC-550
+	global $wgDisableReportTime;
+	if ( !empty( $wgDisableReportTime ) ) {
+		return '';
+	}
+
+	// Wikia change - end
+
 	$elapsed = microtime( true ) - $wgRequestTime;
 
 	return $wgShowHostnames

--- a/includes/OutputPage.php
+++ b/includes/OutputPage.php
@@ -2025,6 +2025,8 @@ class OutputPage extends ContextSource {
 			wfProfileOut( 'Output-skin' );
 		}
 
+		wfRunHooks( 'BeforeSendCacheControl', array( &$this ) ); // Wikia change
+
 		$this->sendCacheControl();
 		ob_end_flush();
 		wfProfileOut( __METHOD__ );

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1252,3 +1252,9 @@ $wgOasisResponsive = null;
 
 /** @var $wgEnableCentralizedLogging bool whether or not logging to syslog is enabled */
 $wgEnableCentralizedLogging = true;
+
+/**
+ * @name $wgDisableReportTime
+ * Turns off <!-- Served by ... in ... ms --> HTML comment
+ */
+$wgDisableReportTime = true;

--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -59,6 +59,9 @@ $wgHooks['LocalFileExecuteUrls']        [] = 'Wikia::onLocalFilePurge';
 # send ETag response header - BAC-1227
 $wgHooks['ParserCacheGetETag']       [] = 'Wikia::onParserCacheGetETag';
 
+# Add X-Served-By and X-Backend-Response-Time response headers - BAC-550
+$wgHooks['BeforeSendCacheControl']   [] = 'Wikia::onBeforeSendCacheControl';
+
 /**
  * This class have only static methods so they can be used anywhere
  *
@@ -2235,6 +2238,28 @@ class Wikia {
 	static function onParserCacheGetETag(Article $article, ParserOptions $popts, &$eTag) {
 		global $wgStyleVersion;
 		$eTag = sprintf( '%s-%s', $article->getTouched(), $wgStyleVersion );
+		return true;
+	}
+
+	/**
+	 * Add X-Served-By and X-Backend-Response-Time response headers
+	 *
+	 * See BAC-550 for details
+	 *
+	 * @param OutputPage $out
+	 * @param Skin $sk
+	 * @return bool
+	 * @author macbre
+	 */
+	static function onBeforeSendCacheControl(OutputPage $out) {
+		global $wgRequestTime;
+
+		$response = $out->getRequest()->response();
+		$elapsed = microtime( true ) - $wgRequestTime;
+
+		$response->header( sprintf( 'X-Served-By:%s', wfHostname() ) );
+		$response->header( sprintf( 'X-Backend-Response-Time:%01.3f', $elapsed ) );
+
 		return true;
 	}
 }


### PR DESCRIPTION
- remove `<!-- Served by ... in ... sec -->` comment (introduce `$wgDisableReportTime` global variable)
- add `X-Backend-Response-Time` response header with response generation time in ms
- add `X-Served-By` header with hostname of apache machine that generated the response (will be appended with Varnish machines handling client response)

@michalroszka / @prein / @Wikia/platform-team 

```
$ curl -I "http://poznan.macbre.wikia-dev.com/wiki/Gzik" 
HTTP/1.1 200 OK
X-Backend-Response-Time: 0.852
X-Served-By: dev-macbre, cache-s24-SJC, cache-fra1227-FRA
```
