### PR TITLE
Varnish caching changes backported

### DIFF
--- a/extensions/wikia/Track/Track.php
+++ b/extensions/wikia/Track/Track.php
@@ -14,7 +14,7 @@ class Track {
 	const BASE_URL = 'http://a.wikia-beacon.com/__track';
 
 	public static function getURL ($type=null, $name=null, $param=null, $for_html=true) {
-		global $wgCityId, $wgContLanguageCode, $wgDBname, $wgDBcluster, $wgUser, $wgArticle, $wgTitle, $wgAdServerTest;
+		global $wgStyleVersion, $wgCityId, $wgContLanguageCode, $wgDBname, $wgDBcluster, $wgUser, $wgArticle, $wgTitle, $wgAdServerTest;
 
 		$sep = $for_html ? '&amp;' : '&';
 		$ip = F::app()->wg->Request->getIP();
@@ -23,6 +23,7 @@ class Track {
 			($type ? "/$type" : '').
 			($name ? "/$name" : '').
 			'?'.
+			'cb='.$wgStyleVersion.$sep.
 			'c='.$wgCityId.$sep.
 			'lc='.$wgContLanguageCode.$sep.
 			'lid='.WikiFactory::LangCodeToId($wgContLanguageCode).$sep.
@@ -71,7 +72,7 @@ class Track {
 	var utma = RegExp("__utma=([0-9\.]+)").exec(document.cookie);
 	var utmb = RegExp("__utmb=([0-9\.]+)").exec(document.cookie);
 
-	var trackUrl = "$url" + ((typeof document.referrer != "undefined") ? "&amp;r=" + escape(document.referrer) : "") + "&amp;cb=" + (new Date).valueOf() + (window.beacon_id ? "&amp;beacon=" + window.beacon_id : "") + (utma && utma[1] ? "&amp;utma=" + utma[1] : "") + (utmb && utmb[1] ? "&amp;utmb=" + utmb[1] : "");
+	var trackUrl = "$url" + ((typeof document.referrer != "undefined") ? "&amp;r=" + escape(document.referrer) : "") + "&amp;rand=" + (new Date).valueOf() + (window.beacon_id ? "&amp;beacon=" + window.beacon_id : "") + (utma && utma[1] ? "&amp;utma=" + utma[1] : "") + (utmb && utmb[1] ? "&amp;utmb=" + utmb[1] : "");
 	document.write('<'+'script type="text/javascript" src="' + trackUrl + '"><'+'/script>');
 })();
 </script>

--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -1686,6 +1686,14 @@ function wfHostname() {
 function wfReportTime() {
 	global $wgRequestTime, $wgShowHostnames;
 
+	// Wikia change - begin
+	// @author macbre - BAC-550
+	global $wgDisableReportTime;
+	if ( !empty( $wgDisableReportTime ) ) {
+		return '';
+	}
+	// Wikia change - end
+
 	$elapsed = microtime( true ) - $wgRequestTime;
 
 	return $wgShowHostnames

--- a/includes/OutputPage.php
+++ b/includes/OutputPage.php
@@ -2025,6 +2025,8 @@ class OutputPage extends ContextSource {
 			wfProfileOut( 'Output-skin' );
 		}
 
+		wfRunHooks( 'BeforeSendCacheControl', array( &$this ) ); // Wikia change
+
 		$this->sendCacheControl();
 		ob_end_flush();
 		wfProfileOut( __METHOD__ );

--- a/includes/parser/ParserCache.php
+++ b/includes/parser/ParserCache.php
@@ -79,6 +79,15 @@ class ParserCache {
 	 * @param $popts ParserOptions
 	 */
 	function getETag( $article, $popts ) {
+		// Wikia change - begin
+		// @author macbre - BAC-1227
+		$eTag = false;
+		wfRunHooks( 'ParserCacheGetETag', [ $article, $popts, &$eTag ] );
+		if ($eTag !== false) {
+			return $eTag;
+		}
+		// Wikia change - end
+
 		return 'W/"' . $this->getParserOutputKey( $article,
 			$popts->optionsHash( ParserOptions::legacyOptions(), $article->getTitle() ) ) .
 				"--" . $article->getTouched() . '"';

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1247,3 +1247,9 @@ $wgOasisResponsive = null;
 
 /** @var $wgEnableCentralizedLogging bool whether or not logging to syslog is enabled */
 $wgEnableCentralizedLogging = true;
+
+/**
+ * @name $wgDisableReportTime
+ * Turns off <!-- Served by ... in ... ms --> HTML comment
+ */
+$wgDisableReportTime = true;

--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -48,6 +48,9 @@ $wgHooks['UserLoadFromDatabase']     [] = "Wikia::onUserLoadFromDatabase";
 $wgHooks['AfterSetupLocalFileRepo']  [] = "Wikia::onAfterSetupLocalFileRepo";
 $wgHooks['BeforeRenderTimeline']     [] = "Wikia::onBeforeRenderTimeline";
 
+# send ETag response header - BAC-1227
+$wgHooks['ParserCacheGetETag']       [] = 'Wikia::onParserCacheGetETag';
+
 /**
  * This class have only static methods so they can be used anywhere
  *
@@ -2166,6 +2169,22 @@ class Wikia {
 		$cb = SassUtil::getCacheBuster();
 		$favicon = wfReplaceImageServer($favicon, $cb);
 
+		return true;
+	}
+
+	/**
+	 * Send ETag header with article's last modidication timestamp and cache buster
+	 *
+	 * See BAC-1227 for details
+	 *
+	 * @param WikiPage $article
+	 * @param ParserOptions $popts
+	 * @param $eTag
+	 * @author macbre
+	 */
+	static function onParserCacheGetETag(Article $article, ParserOptions $popts, &$eTag) {
+		global $wgStyleVersion;
+		$eTag = sprintf( '%s-%s', $article->getTouched(), $wgStyleVersion );
 		return true;
 	}
 }


### PR DESCRIPTION
Following PR backported to the current release:
- #2583 - Serve E-Tag along with Last-Modified header
- #2587 -  move "served by" info to header
- #2595 - send CB value with beacon requests

@prein / @michalroszka / @Wikia/platform-team 
