### PR TITLE
fixing carousel css

### DIFF
--- a/extensions/wikia/VideoPageTool/css/carousel.scss
+++ b/extensions/wikia/VideoPageTool/css/carousel.scss
@@ -3,7 +3,7 @@
 @import 'skins/oasis/css/mixins/transform';
 @import './mixins/_sprite-VideoPageTool.scss';
 
-.carousel {
+.carousel-wrapper {
 	margin: 0 40px;
 	padding-bottom: 1em;
 

--- a/extensions/wikia/VideoPageTool/js/admin/views/categoryforms.js
+++ b/extensions/wikia/VideoPageTool/js/admin/views/categoryforms.js
@@ -16,7 +16,7 @@ define( 'videopageadmin.views.categoryforms', [
 							collection: this.categories
 					} );
 					this.previewView = new AdminCarouselView( {
-						el: this.$el.find( '.carousel' ),
+						el: this.$el.find( '.carousel-wrapper' ),
 						collection: this.categoryData
 					} );
 					_.bindAll( this,

--- a/extensions/wikia/VideoPageTool/js/shared/views/carousel.js
+++ b/extensions/wikia/VideoPageTool/js/shared/views/carousel.js
@@ -18,7 +18,7 @@ define( 'shared.views.carousel', [
 
 	var CarouselView = Backbone.View.extend( {
 		tagName: 'div',
-		className: 'carousel',
+		className: 'carousel-wrapper',
 		initialize: function() {
 			this.collection = new CategoryDataCollection( this.model.attributes.thumbnails );
 			this.render();

--- a/extensions/wikia/VideoPageTool/js/shared/views/owlcarousel.js
+++ b/extensions/wikia/VideoPageTool/js/shared/views/owlcarousel.js
@@ -3,7 +3,7 @@ define( 'shared.views.owlcarousel', [
 	'use strict';
 	var OwlCarouselView = Backbone.View.extend( {
 		tagName: 'div',
-		className: 'carousel',
+		className: 'carousel-wrapper',
 		$carousel: null,
 		events: {
 			'click .control[data-direction="left"]': 'slideLeft',

--- a/extensions/wikia/VideoPageTool/templates/VideoPageAdminSpecial_category.php
+++ b/extensions/wikia/VideoPageTool/templates/VideoPageAdminSpecial_category.php
@@ -40,7 +40,7 @@
 					<img class="chevron chevron-down" src="<?= $wg->BlankImgUrl ?>">
 				</button>
 			</div>
-			<div class="carousel">
+			<div class="carousel-wrapper">
 			</div>
 			<a class="preview" href="#"><span></span><?= wfMessage( 'videopagetool-category-preview' )->plain() ?><span></span></a>
 		</div>


### PR DESCRIPTION
There was a css conflict with the class .carousel because that class is being used inside the Lightbox as well.  See screenshot for issue.  

I fixed it by replacing .carousel with .carousel-wrapper but I'm open to suggestions for other solutions. 

![screen shot 2014-01-27 at 11 30 51 am](https://f.cloud.github.com/assets/201367/2012538/9901e3ea-8789-11e3-871a-d54ca293f2c6.png)
