### PR TITLE
BAC-1153: round ResourceLoader timestamps

### DIFF
--- a/includes/resourceloader/ResourceLoaderFileModule.php
+++ b/includes/resourceloader/ResourceLoaderFileModule.php
@@ -433,6 +433,7 @@ class ResourceLoaderFileModule extends ResourceLoaderModule {
 
 		wfProfileIn( __METHOD__.'-filemtime' );
 		$filesMtime = max( array_map( array( __CLASS__, 'safeFilemtime' ), $files ) );
+		$filesMtime = ResourceLoaderHooks::normalizeTimestamp($filesMtime); // Wikia change - @macbre
 		wfProfileOut( __METHOD__.'-filemtime' );
 		$this->modifiedTime[$context->getHash()] = max(
 			$filesMtime,

--- a/includes/resourceloader/ResourceLoaderStartUpModule.php
+++ b/includes/resourceloader/ResourceLoaderStartUpModule.php
@@ -144,6 +144,7 @@ class ResourceLoaderStartUpModule extends ResourceLoaderModule {
 				// seem to do that, and custom implementations might forget. Coerce it to TS_UNIX
 				$moduleMtime = wfTimestamp( TS_UNIX, $module->getModifiedTime( $context ) );
 				$mtime = max( $moduleMtime, wfTimestamp( TS_UNIX, $wgCacheEpoch ) );
+				$mtime = ResourceLoaderHooks::normalizeTimestamp($mtime); // Wikia change - @macbre
 				// Wikia - change begin - @author: wladek
 				$flags = $module->getFlag( $module->getFlagNames() );
 				if ( !empty( $flags ) ) {
@@ -293,6 +294,7 @@ ENDSCRIPT;
 		// infinite recursion - think carefully before making changes to this
 		// code!
 		$time = wfTimestamp( TS_UNIX, $wgCacheEpoch );
+		$time = ResourceLoaderHooks::normalizeTimestamp($time); // Wikia change - @macbre
 		foreach ( $loader->getModuleNames() as $name ) {
 			$module = $loader->getModule( $name );
 			$time = max( $time, $module->getModifiedTime( $context ) );

--- a/includes/wikia/resourceloader/ResourceLoaderHooks.class.php
+++ b/includes/wikia/resourceloader/ResourceLoaderHooks.class.php
@@ -8,6 +8,8 @@
  */
 class ResourceLoaderHooks {
 
+	const TIMESTAMP_PRECISION = 900; // 15 minutes
+
 	static protected $resourceLoaderInstance;
 	static protected $assetsManagerGroups = array(
 //		'skins.oasis.blocking' => 'oasis_blocking',
@@ -365,5 +367,18 @@ class ResourceLoaderHooks {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Round timestamps to 15 minutes to make Varnish entries consistent across nodes
+	 *
+	 * @param $timestamp int timestamp to normalize
+	 * @return int normalized timestamp
+	 *
+	 * @author macbre
+	 * @see BAC-1153
+	 */
+	public static function normalizeTimestamp($timestamp) {
+		return intval( floor( $timestamp / self::TIMESTAMP_PRECISION ) * self::TIMESTAMP_PRECISION );
 	}
 }


### PR DESCRIPTION
remove (or shorten) timestamp from mw.loader.register

@wladekb / @prein / @michalroszka / @Wikia/platform-team 
