### PR TITLE
Do not enable Swift on new wikis by default (release-206)

### DIFF
--- a/extensions/wikia/CreateNewWiki/CreateWiki.php
+++ b/extensions/wikia/CreateNewWiki/CreateWiki.php
@@ -890,10 +890,8 @@ class CreateWiki {
 		$this->mWFSettingVars['wgLanguageCode']	            = $this->mNewWiki->language;
 		$this->mWFSettingVars['wgServer']                	= rtrim( $this->mNewWiki->url, "/" );
 		$this->mWFSettingVars['wgFavicon']               	= self::DEFAULT_WIKI_FAVICON;
-
-		$this->mWFSettingVars['wgEnableEditEnhancements']   = true;
+		$this->mWFSettingVars['wgEnableEditEnhancements'] 	= true;
 		$this->mWFSettingVars['wgEnableSectionEdit']	    = true;
-		$this->mWFSettingVars['wgEnableSwiftFileBackend']   = true;
 
 		// rt#60223: colon allowed in sitename, breaks project namespace
 		if( mb_strpos( $this->mWFSettingVars['wgSitename'], ':' ) !== false ) {


### PR DESCRIPTION
This commit removes enabling Swift storage by default for new wikis. This is required to be live before the migration starts next week.

Reverts #2062 / #2532 backported

@Wikia/platform-team
