### PR TITLE
BAC-1231: change the way Cache-Control header is set

### DIFF
--- a/extensions/wikia/AbTesting/AbTestingController.class.php
+++ b/extensions/wikia/AbTesting/AbTestingController.class.php
@@ -45,8 +45,7 @@ class AbTestingController extends WikiaController {
 
 		// set appropriate cache TTL
 		$cacheTTL = $this->getCacheTTL();
-		$response->setCacheValidity(null,$cacheTTL['client'],array(WikiaResponse::CACHE_TARGET_BROWSER));
-		$response->setCacheValidity(null,$cacheTTL['server'],array(WikiaResponse::CACHE_TARGET_VARNISH));
+		$response->setCacheValidity($cacheTTL['server'], $cacheTTL['client']);
 	}
 
 	protected function getGroupData( $expName, $versionId, $groupId ) {

--- a/extensions/wikia/ArticleComments/modules/ArticleCommentsController.class.php
+++ b/extensions/wikia/ArticleComments/modules/ArticleCommentsController.class.php
@@ -105,7 +105,7 @@ class ArticleCommentsController extends WikiaController {
 
 		// When lazy loading this request it shouldn't be cached in the browser
 		if ( !empty( $this->wg->ArticleCommentsLoadOnDemand ) ) {
-			$this->response->setCacheValidity( 0, 0, array( WikiaResponse::CACHE_TARGET_BROWSER ) );
+			$this->response->setCacheValidity( WikiaResponse::CACHE_DISABLED );
 		}
 
 		wfProfileOut( __METHOD__ );

--- a/extensions/wikia/AssetsManager/AssetsManager.class.php
+++ b/extensions/wikia/AssetsManager/AssetsManager.class.php
@@ -728,14 +728,6 @@ class AssetsManager {
 			$request['ttl'] = $options['ttl'];
 		}
 
-		if ( !empty( $options['varnishTTL'] ) ) {
-			$request['varnishTTL'] = $options['varnishTTL'];
-		}
-
-		if ( !empty( $options['browserTTL'] ) ) {
-			$request['browserTTL'] = $options['browserTTL'];
-		}
-
 		$request['cb'] = $wgStyleVersion;
 
 		if ( !empty( $request ) ) {

--- a/extensions/wikia/AssetsManager/AssetsManagerController.class.php
+++ b/extensions/wikia/AssetsManager/AssetsManagerController.class.php
@@ -23,10 +23,6 @@ class AssetsManagerController extends WikiaController {
 	 * @requestParam string scripts - comma-separated list of AssetsManager groups
 	 * @requestParam string messages - comma-separated list of JSMessages packages
 	 * @requestParam integer ttl - cache period for varnish and browser (in seconds),
-	 * no caching will be used if not specified or 0, this value is overridden by varnishTTL
-	 * and browserTTL respectively for the Varnish part and the Browser part
-	 * @requestParam integer varnishTTL - cache period for varnish (in seconds)
-	 * @requestParam integer browserTTL - cache period for varnish (in seconds)
 	 *
 	 * @responseParam array templates - rendered templates (either HTML or JSON encoded string)
 	 * @responseParam array styles - minified styles

--- a/extensions/wikia/AssetsManager/AssetsManagerController.class.php
+++ b/extensions/wikia/AssetsManager/AssetsManagerController.class.php
@@ -46,8 +46,6 @@ class AssetsManagerController extends WikiaController {
 		$messages = $this->request->getVal( 'messages', null );
 		$mustache = $this->request->getVal( 'mustache', null );
 		$ttl = $this->request->getInt( 'ttl', 0 );
-		$varnishTTL = $this->request->getInt( 'varnishTTL', $ttl );
-		$browserTTL = $this->request->getInt( 'browserTTL', $ttl );
 
 		// handle templates via sendRequest
 		if ( !is_null( $templates ) ) {
@@ -148,12 +146,8 @@ class AssetsManagerController extends WikiaController {
 		}
 
 		// handle cache time
-		if ( $varnishTTL > 0 ) {
-			$this->response->setCacheValidity( $varnishTTL, $varnishTTL, array( WikiaResponse::CACHE_TARGET_VARNISH ) );
-		}
-
-		if ( $browserTTL > 0 ) {
-			$this->response->setCacheValidity( $browserTTL, $browserTTL, array( WikiaResponse::CACHE_TARGET_BROWSER ) );
+		if ( $ttl > 0 ) {
+			$this->response->setCacheValidity( $ttl );
 		}
 
 		$this->response->setFormat( 'json' );

--- a/extensions/wikia/AssetsManager/AssetsManagerServer.class.php
+++ b/extensions/wikia/AssetsManager/AssetsManagerServer.class.php
@@ -81,7 +81,6 @@ class AssetsManagerServer {
 		}
 
 		if($cacheDuration > 0) {
-			$headers['Expires'] = gmdate('D, d M Y H:i:s \G\M\T', strtotime($cacheDuration['server'] . ' seconds'));
 			$headers['Cache-Control'] = $builder->getCacheMode() . ', max-age=' . $cacheDuration['server'];
 			$headers['X-Pass-Cache-Control'] = $builder->getCacheMode() . ', max-age=' . $cacheDuration['client'];
 		}

--- a/extensions/wikia/AssetsManager/js/AssetsManager.js
+++ b/extensions/wikia/AssetsManager/js/AssetsManager.js
@@ -14,9 +14,7 @@ window.Wikia = window.Wikia || {};
  *		scripts - comma-separated list of AssetsManager groups
  *		messages - comma-separated list of JSMessages packages (messages are registered automagically)
  * 		mustache - comma-separated list of paths to Mustache-powered templates
- *		ttl - cache period for both Varnish and Browser (in seconds), is overridden by varnishTTL and BrowserTTL
- *		varnishTTL - cache period for varnish and browser (in seconds)
- *		browserTTL - cache period for browser (in seconds)
+ *		ttl - cache period for both Varnish and Browser (in seconds)
  *		params - an object with all the additional parameters for the request (e.g. useskin, forceprofile, etc.)
  *		callback - function to be called with fetched JSON object
  *
@@ -49,8 +47,6 @@ window.Wikia.getMultiTypePackage = function(options) {
 		callback = options.callback,
 		params = options.params,
 		ttl = options.ttl,
-		varnishTTL = options.varnishTTL,
-		browserTTL = options.browserTTL,
 		send = false;
 
 	if(typeof styles === 'string'){
@@ -85,12 +81,6 @@ window.Wikia.getMultiTypePackage = function(options) {
 
 	if(ttl)
 		request.ttl = ~~ttl;
-
-	if(varnishTTL)
-		request.varnishTTL = ~~varnishTTL;
-
-	if(browserTTL)
-		request.browserTTL = ~~browserTTL;
 
 	if(send){
 		// add a cache buster

--- a/extensions/wikia/Chat2/ChatRailController.class.php
+++ b/extensions/wikia/Chat2/ChatRailController.class.php
@@ -62,7 +62,7 @@ class ChatRailController extends WikiaController {
 		}
 
 		// Cache the entire call in varnish (and browser).
-		$this->response->setCacheValidity(self::CACHE_DURATION, self::CACHE_DURATION, array(WikiaResponse::CACHE_TARGET_BROWSER, WikiaResponse::CACHE_TARGET_VARNISH));
+		$this->response->setCacheValidity(self::CACHE_DURATION);
 
 		wfProfileOut( __METHOD__ );
 	}
@@ -71,7 +71,7 @@ class ChatRailController extends WikiaController {
 		wfProfileIn( __METHOD__ );
 		$this->users = ChatEntryPoint::getChatUsersInfo();
 		// Cache the entire call in varnish (and browser).
-		$this->response->setCacheValidity(self::CACHE_DURATION, self::CACHE_DURATION, array(WikiaResponse::CACHE_TARGET_BROWSER, WikiaResponse::CACHE_TARGET_VARNISH));
+		$this->response->setCacheValidity(self::CACHE_DURATION);
 		wfProfileOut( __METHOD__ );
 	}
 

--- a/extensions/wikia/Forum/ForumController.class.php
+++ b/extensions/wikia/Forum/ForumController.class.php
@@ -63,7 +63,7 @@ class ForumController extends WallBaseController {
 		$this->response->setVal( 'boardNamespace', NS_WIKIA_FORUM_BOARD );
 
 		//TODO: keep the varnish cache and do purging on post
-		$this->response->setCacheValidity( 0, 0 );
+		$this->response->setCacheValidity( WikiaResponse::CACHE_DISABLED );
 
 		$this->app->wg->SuppressPageHeader = true;
 	}

--- a/extensions/wikia/Forum/ForumSpecialController.class.php
+++ b/extensions/wikia/Forum/ForumSpecialController.class.php
@@ -73,7 +73,7 @@ class ForumSpecialController extends WikiaSpecialPageController {
 		}
 
 		//TODO: keep the varnish cache and do purging on post
-		$this->response->setCacheValidity( 0, 0 );
+		$this->response->setCacheValidity( WikiaResponse::CACHE_DISABLED );
 
 		wfProfileOut( __METHOD__ );
 	}

--- a/extensions/wikia/Forum/RelatedForumDiscussionController.class.php
+++ b/extensions/wikia/Forum/RelatedForumDiscussionController.class.php
@@ -76,8 +76,7 @@ class RelatedForumDiscussionController extends WikiaController {
 			$this->html = '';
 		}
 
-		$this->response->setCacheValidity( 0, 0, array(WikiaResponse::CACHE_TARGET_BROWSER) );
-		$this->response->setCacheValidity( 6*60*60, 6*60*60, array(WikiaResponse::CACHE_TARGET_VARNISH) );
+		$this->response->setCacheValidity( 6*60*60, WikiaResponse::CACHE_DISABLED /* no caching in browser */ );
 	}
 
 	public function purgeCache() {

--- a/extensions/wikia/GameGuides/GameGuidesController.class.php
+++ b/extensions/wikia/GameGuides/GameGuidesController.class.php
@@ -160,13 +160,7 @@ class GameGuidesController extends WikiaController {
 		if( isset( $period ) && isset( $factor ) ) {
 			$cacheValidityTime = $factor * $period;
 
-			$this->response->setCacheValidity(
-				$cacheValidityTime,
-				$cacheValidityTime,
-				[
-					WikiaResponse::CACHE_TARGET_VARNISH
-				]
-			);
+			$this->response->setCacheValidity($cacheValidityTime);
 		}
 	}
 

--- a/extensions/wikia/ImageReview/ImageReviewSpecialController.class.php
+++ b/extensions/wikia/ImageReview/ImageReviewSpecialController.class.php
@@ -53,7 +53,7 @@ class ImageReviewSpecialController extends WikiaSpecialPageController {
 			$this->forward( get_class( $this ), 'csvStats' );
 		}
 
-		$this->response->setCacheValidity(0, 0, array(WikiaResponse::CACHE_TARGET_BROWSER, WikiaResponse::CACHE_TARGET_VARNISH));
+		$this->response->setCacheValidity(WikiaResponse::CACHE_DISABLED);
 		$this->response->sendHeaders();
 
 		$this->response->addAsset('extensions/wikia/ImageReview/js/jquery.onImagesLoad.js');

--- a/extensions/wikia/ImageReview/ImageReviewSpecialController.class.php
+++ b/extensions/wikia/ImageReview/ImageReviewSpecialController.class.php
@@ -192,7 +192,6 @@ class ImageReviewSpecialController extends WikiaSpecialPageController {
 		$name = "ImageReviewStats-$startYear-$startMonth-$startDay-to-$endYear-$endMonth-$endDay";
 
 		header("Pragma: public");
-		header("Expires: 0");
 		header("Cache-Control: must-revalidate, post-check=0, pre-check=0");
 		header('Content-Type: text/force-download');
 

--- a/extensions/wikia/JSMessages/JSMessagesController.class.php
+++ b/extensions/wikia/JSMessages/JSMessagesController.class.php
@@ -26,10 +26,7 @@ class JSMessagesController extends WikiaController {
 
 		// cache it well :)
 		if ( !$this->request->isInternal() ) {
-			$this->response->setCacheValidity(self::CACHE_TIME, self::CACHE_TIME, array(
-				WikiaResponse::CACHE_TARGET_BROWSER,
-				WikiaResponse::CACHE_TARGET_VARNISH
-			));
+			$this->response->setCacheValidity(self::CACHE_TIME);
 
 			$this->response->setContentType('text/javascript; charset=utf-8');
 		}

--- a/extensions/wikia/Lightbox/LightboxController.class.php
+++ b/extensions/wikia/Lightbox/LightboxController.class.php
@@ -24,7 +24,7 @@ class LightboxController extends WikiaController {
 		$this->showAdModalRectangle = $showAds && $this->wg->ShowAdModalRectangle;
 
 		// set cache control to 1 day
-		$this->response->setCacheValidity(86400, 86400, array(WikiaResponse::CACHE_TARGET_BROWSER, WikiaResponse::CACHE_TARGET_VARNISH));
+		$this->response->setCacheValidity(86400);
 	}
 
 	public function lightboxModalContentError() {
@@ -35,7 +35,7 @@ class LightboxController extends WikiaController {
 		}
 
 		// set cache control to 1 day
-		$this->response->setCacheValidity(86400, 86400, array(WikiaResponse::CACHE_TARGET_BROWSER, WikiaResponse::CACHE_TARGET_VARNISH));
+		$this->response->setCacheValidity(86400);
 	}
 
 	/**
@@ -72,7 +72,7 @@ class LightboxController extends WikiaController {
 		$this->to = $minTimestamp;
 
 		// set cache control to 1 hour
-		$this->response->setCacheValidity(3600, 3600, array(WikiaResponse::CACHE_TARGET_BROWSER, WikiaResponse::CACHE_TARGET_VARNISH));
+		$this->response->setCacheValidity(3600);
 	}
 
 	/**
@@ -211,9 +211,6 @@ class LightboxController extends WikiaController {
 		$this->providerName = $data['providerName'];
 		$this->exists = $data['exists'];
 
-		// set cache control to 1 hour
-		// Note - we're probably not going to use this going forward.  Saipetch is investigating - Liz
-		//$this->response->setCacheValidity(3600, 3600, array(WikiaResponse::CACHE_TARGET_BROWSER, WikiaResponse::CACHE_TARGET_VARNISH));
 		// Make sure that a request with missing &format=json does not throw a "template not found" exception
 		$this->response->setFormat('json');
 	}
@@ -307,7 +304,7 @@ class LightboxController extends WikiaController {
 		$this->imageUrl = $thumbUrl;
 
 		// set cache control to 1 day
-		$this->response->setCacheValidity(86400, 86400, array(WikiaResponse::CACHE_TARGET_BROWSER, WikiaResponse::CACHE_TARGET_VARNISH));
+		$this->response->setCacheValidity(86400);
 	}
 
 	/**

--- a/extensions/wikia/PhotoPop/PhotoPopAppCacheController.class.php
+++ b/extensions/wikia/PhotoPop/PhotoPopAppCacheController.class.php
@@ -12,7 +12,7 @@ class PhotoPopAppCacheController extends WikiaController {
 	public function serveManifest(){
 		if ( $this->response->getFormat() == WikiaResponse::FORMAT_HTML ) {
 			$this->response->setContentType( self::CONTENT_TYPE );
-			$this->response->setCacheValidity( self::MANIFEST_VARNISH_CACHE_TIME, self::MANIFEST_VARNISH_CACHE_TIME, array( WikiaResponse::CACHE_TARGET_VARNISH ) );
+			$this->response->setCacheValidity( self::MANIFEST_VARNISH_CACHE_TIME, WikiaResponse::CACHE_DISABLED );
 		}
 		
 		$files = array();

--- a/extensions/wikia/Places/PlacesEditorController.class.php
+++ b/extensions/wikia/Places/PlacesEditorController.class.php
@@ -7,6 +7,6 @@
 class PlacesEditorController extends WikiaController {
 
 	public function getEditorModal() {
-		$this->response->setCacheValidity(3600, array(WikiaResponse::CACHE_TARGET_BROWSER, WikiaResponse::CACHE_TARGET_VARNISH));
+		$this->response->setCacheValidity(3600);
 	}
 }

--- a/extensions/wikia/RTE/RTEController.class.php
+++ b/extensions/wikia/RTE/RTEController.class.php
@@ -12,10 +12,7 @@ class RTEController extends WikiaController {
 		$requestedCb = $this->request->getVal('cb');
 		$key = $currentCb == $requestedCb ? 'versioned' : 'unversioned';
 
-		$this->response->setCacheValidity(null,$wgResourceLoaderMaxage[$key]['client'],
-			array(WikiaResponse::CACHE_TARGET_VARNISH));
-		$this->response->setCacheValidity(null,$wgResourceLoaderMaxage[$key]['server'],
-			array(WikiaResponse::CACHE_TARGET_BROWSER));
+		$this->response->setCacheValidity($wgResourceLoaderMaxage[$key]['server']. $wgResourceLoaderMaxage[$key]['client']);
 	}
 
 }

--- a/extensions/wikia/RelatedVideos/RelatedVideosController.class.php
+++ b/extensions/wikia/RelatedVideos/RelatedVideosController.class.php
@@ -204,7 +204,7 @@ class RelatedVideosController extends WikiaController {
 		}
 
 		// set cache control to 1 day
-		$this->response->setCacheValidity(86400, 86400, array(WikiaResponse::CACHE_TARGET_BROWSER, WikiaResponse::CACHE_TARGET_VARNISH));
+		$this->response->setCacheValidity(86400);
 
 		wfProfileOut(__METHOD__);
 	}

--- a/extensions/wikia/Search/SearchApiController.class.php
+++ b/extensions/wikia/Search/SearchApiController.class.php
@@ -100,14 +100,7 @@ class SearchApiController extends WikiaApiController {
 		$response = $this->getResponse();
 		$response->setValues( $responseValues );
 
-		$response->setCacheValidity(
-			86400 /* 24h */,
-			86400 /* 24h */,
-			array(
-				WikiaResponse::CACHE_TARGET_BROWSER,
-				WikiaResponse::CACHE_TARGET_VARNISH
-			)
-		);
+		$response->setCacheValidity(86400);
 	}
 	
 	/**

--- a/extensions/wikia/Search/classes/Test/Controller/SearchApiControllerTest.php
+++ b/extensions/wikia/Search/classes/Test/Controller/SearchApiControllerTest.php
@@ -374,7 +374,7 @@ class SearchApiControllerTest extends BaseTest
 		$mockResponse
 		    ->expects( $this->once() )
 		    ->method ( 'setCacheValidity' )
-		    ->with   ( 86400, 86400, [ \WikiaResponse::CACHE_TARGET_BROWSER, \WikiaResponse::CACHE_TARGET_VARNISH ] )
+		    ->with   ( 86400 )
 		;
 		
 		$this->mockClass( 'Wikia\Search\QueryService\Factory', $mockFactory );

--- a/extensions/wikia/SpecialStyleguide/SpecialStyleguideController.class.php
+++ b/extensions/wikia/SpecialStyleguide/SpecialStyleguideController.class.php
@@ -28,14 +28,7 @@ class SpecialStyleguideController extends WikiaSpecialPageController {
 
 		$wgAutoloadClasses['GlobalHeaderController'] = dirname( __FILE__ ) . '/helpers/SpecialStyleguideGlobalHeaderControllerOverride.php';
 
-		$this->response->setCacheValidity(
-			86400,
-			86400,
-			[
-				WikiaResponse::CACHE_TARGET_BROWSER,
-				WikiaResponse::CACHE_TARGET_VARNISH
-			]
-		);
+		$this->response->setCacheValidity(86400);
 
 		$subpage = mb_strtolower( $this->getFirstTextAfterSlash( $this->wg->Title->getSubpageText() ) );
 

--- a/extensions/wikia/SponsorshipDashboard/output/SDOutputCSV.class.php
+++ b/extensions/wikia/SponsorshipDashboard/output/SDOutputCSV.class.php
@@ -78,7 +78,6 @@ class SponsorshipDashboardOutputCSV extends SponsorshipDashboardOutputTable {
 	function beforePrint(){
 		header("HTTP/1.0 200 OK");
 		header("Pragma: public");
-		header("Expires: 0");
 		header("Cache-Control: must-revalidate, post-check=0, pre-check=0");
 		header("Content-Type: application/force-download");
 		header("Content-Type: application/octet-stream");

--- a/extensions/wikia/StructuredData/StructuredDataController.class.php
+++ b/extensions/wikia/StructuredData/StructuredDataController.class.php
@@ -329,7 +329,7 @@ class StructuredDataController extends WikiaSpecialPageController {
 
 	public function createReferencedObject() {
 		$this->getResponse()->setFormat( 'json' );
-		$this->getResponse()->setCacheValidity( 0, 0, array( WikiaResponse::CACHE_TARGET_BROWSER ) );
+		$this->getResponse()->setCacheValidity( WikiaResponse::CACHE_DISABLED );
 		if ( !$this->wg->User->isAllowed( 'sdsediting' ) ) {
 			$this->response->setVal( 'error', wfMsg( 'structureddata-no-rights-to-add-wikitext-object' ) );
 			return;

--- a/extensions/wikia/TranslationStatistics/SpecialTranslationStats.php
+++ b/extensions/wikia/TranslationStatistics/SpecialTranslationStats.php
@@ -115,7 +115,6 @@ class SpecialTranslationStats extends IncludableSpecialPage {
 				$wgOut->disable();
 				header( 'Content-Type: image/png' );
 				header( 'Cache-Control: private, max-age=3600' );
-				header( 'Expires: ' . wfTimestamp( TS_RFC2822, time() + 3600 ) );
 			}
 			$this->draw( $opts );
 

--- a/extensions/wikia/TranslationStatistics/phplot.php
+++ b/extensions/wikia/TranslationStatistics/phplot.php
@@ -119,7 +119,7 @@ class PHPlot
     public $label_format = array('x' => array(), 'xd' => array(), 'y' => array(), 'yd' => array());
     // data_units_text is retained for backward compatibility, because there was never a function
     // to set it. Use the 'suffix' argument to Set[XY]LabelType instead.
-    public $data_units_text = '';              // Units text for 'data' labels (i.e: '¤', '$', etc.)
+    public $data_units_text = '';              // Units text for 'data' labels (i.e: 'ï¿½', '$', etc.)
 
 // Legend
     public $legend = '';                       // An array with legend titles
@@ -1576,7 +1576,6 @@ class PHPlot
     {
         // Browser cache stuff submitted by Thiemo Nagel
         if ( (! $this->browser_cache) && (! $this->is_inline)) {
-            header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
             header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . 'GMT');
             header('Cache-Control: no-cache, must-revalidate');
             header('Pragma: no-cache');

--- a/extensions/wikia/WAM/controllers/api/WAMApiController.class.php
+++ b/extensions/wikia/WAM/controllers/api/WAMApiController.class.php
@@ -104,15 +104,7 @@ class WAMApiController extends WikiaApiController {
 		$this->response->setVal('wam_index', $wamIndex['wam_index']);
 		$this->response->setVal('wam_results_total', $wamIndex['wam_results_total']);
 		$this->response->setVal('wam_index_date', $wamIndex['wam_index_date']);
-		$this->response->setCacheValidity(
-			6 * 60 * 60 /* 6h */,
-			6 * 60 * 60 /* 6h */,
-			array(
-				WikiaResponse::CACHE_TARGET_BROWSER,
-				WikiaResponse::CACHE_TARGET_VARNISH
-			)
-		);
-
+		$this->response->setCacheValidity(6 * 60 * 60);
 	}
 
 	/**

--- a/extensions/wikia/Wall/WallBaseController.class.php
+++ b/extensions/wikia/Wall/WallBaseController.class.php
@@ -72,7 +72,7 @@ class WallBaseController extends WikiaController{
 		}
 
 		//TODO: keep the varnish cache and do purging on post
-		$this->response->setCacheValidity(0, 0);
+		$this->response->setCacheValidity(WikiaResponse::CACHE_DISABLED);
 
 		wfProfileOut( __METHOD__ );
 	}
@@ -120,7 +120,7 @@ class WallBaseController extends WikiaController{
 		$this->response->setVal('currentPage', $page );
 
 		//TODO: keep the varnish cache and do purging on post
-		$this->response->setCacheValidity(0, 0);
+		$this->response->setCacheValidity(WikiaResponse::CACHE_DISABLED);
 
 		wfProfileOut( __METHOD__ );
 	}

--- a/extensions/wikia/WikiStats/SpecialWikiStats_xls.php
+++ b/extensions/wikia/WikiStats/SpecialWikiStats_xls.php
@@ -103,7 +103,6 @@ class WikiStatsXLS {
 	public function setXLSHeader() {
 		header("HTTP/1.0 200 OK");
 		header("Pragma: public");
-		header("Expires: 0");
 		header("Cache-Control: must-revalidate, post-check=0, pre-check=0");
 		header("Content-Type: application/force-download");
 		header("Content-Type: application/octet-stream");

--- a/extensions/wikia/WikiaHomePage/WikiaHomePageController.class.php
+++ b/extensions/wikia/WikiaHomePage/WikiaHomePageController.class.php
@@ -77,7 +77,7 @@ class WikiaHomePageController extends WikiaController {
 
 	public function index() {
 		//cache response on varnish for 1h to enable rolling of stats
-		$this->response->setCacheValidity(3600, 3600, array(WikiaResponse::CACHE_TARGET_BROWSER, WikiaResponse::CACHE_TARGET_VARNISH));
+		$this->response->setCacheValidity(3600);
 
 		$this->response->addAsset('wikiahomepage_scss');
 		$this->response->addAsset('wikiahomepage_js');

--- a/extensions/wikia/WikiaHubsV2/WikiaHubsV2Controller.class.php
+++ b/extensions/wikia/WikiaHubsV2/WikiaHubsV2Controller.class.php
@@ -134,11 +134,7 @@ class WikiaHubsV2Controller extends WikiaController {
 	}
 
 	protected function initCacheValidityTimes() {
-		$this->response->setCacheValidity(
-			self::CACHE_VALIDITY_BROWSER,
-			self::CACHE_VALIDITY_VARNISH,
-			array(WikiaResponse::CACHE_TARGET_BROWSER, WikiaResponse::CACHE_TARGET_VARNISH)
-		);
+		$this->response->setCacheValidity(self::CACHE_VALIDITY_VARNISH, self::CACHE_VALIDITY_BROWSER);
 	}
 
 	/**

--- a/extensions/wikia/WikiaHubsV2/api/WikiaHubsApiController.class.php
+++ b/extensions/wikia/WikiaHubsV2/api/WikiaHubsApiController.class.php
@@ -66,14 +66,7 @@ class WikiaHubsApiController extends WikiaApiController {
 			throw new BadRequestApiException();
 		}
 		
-		$this->response->setCacheValidity(
-			self::CLIENT_CACHE_VALIDITY,
-			self::CLIENT_CACHE_VALIDITY,
-			array(
-				WikiaResponse::CACHE_TARGET_BROWSER,
-				WikiaResponse::CACHE_TARGET_VARNISH
-			)
-		);
+		$this->response->setCacheValidity(self::CLIENT_CACHE_VALIDITY);
 		
 		wfProfileOut( __METHOD__ );
 	}

--- a/extensions/wikia/WikiaMobile/WikiaMobileAppCacheController.class.php
+++ b/extensions/wikia/WikiaMobile/WikiaMobileAppCacheController.class.php
@@ -11,7 +11,7 @@ class WikiaMobileAppCacheController extends WikiaController {
 	public function serveManifest(){
 		if ( $this->response->getFormat() == WikiaResponse::FORMAT_HTML ) {
 			$this->response->setContentType( self::CONTENT_TYPE );
-			$this->response->setCacheValidity( self::MANIFEST_VARNISH_CACHE_TIME, self::MANIFEST_VARNISH_CACHE_TIME, array( WikiaResponse::CACHE_TARGET_VARNISH ) );
+			$this->response->setCacheValidity( self::MANIFEST_VARNISH_CACHE_TIME );
 		}
 		
 		$files = AssetsManager::getInstance()->getGroupCommonURL('wikiamobile_js');

--- a/extensions/wikia/WikiaMobile/WikiaMobileCategoryService.class.php
+++ b/extensions/wikia/WikiaMobile/WikiaMobileCategoryService.class.php
@@ -110,14 +110,7 @@ class WikiaMobileCategoryService extends WikiaService {
 
 				if ( !empty( $data['items'] ) ) {
 					//cache response for 3 hours in varnish and browser
-					$this->response->setCacheValidity(
-						WikiaMobileCategoryService::CACHE_TIME,
-						WikiaMobileCategoryService::CACHE_TIME,
-						[
-							WikiaResponse::CACHE_TARGET_BROWSER,
-							WikiaResponse::CACHE_TARGET_VARNISH
-						]
-					);
+					$this->response->setCacheValidity(WikiaMobileCategoryService::CACHE_TIME);
 					$this->response->setVal( 'itemsBatch', $data['items'] );
 				} else {
 					$err = "No Data for given index or batch";

--- a/extensions/wikia/WikiaMobile/WikiaMobileController.class.php
+++ b/extensions/wikia/WikiaMobile/WikiaMobileController.class.php
@@ -32,14 +32,7 @@ class WikiaMobileController extends WikiaController{
 		$wgLang = !empty( $lang ) ? Language::factory( $lang ) : $this->wg->Lang;
 
 		//Cache on Varnish for 15 minutes
-		$this->response->setCacheValidity(
-			900,
-			900,
-			[
-				WikiaResponse::CACHE_TARGET_BROWSER,
-				WikiaResponse::CACHE_TARGET_VARNISH
-			]
-		);
+		$this->response->setCacheValidity(900);
 
 		$this->forward( 'WikiaMobileNavigationService', 'navMenu' );
 	}

--- a/extensions/wikia/WikiaRSS/WikiaRssExternalController.class.php
+++ b/extensions/wikia/WikiaRSS/WikiaRssExternalController.class.php
@@ -8,7 +8,7 @@ class WikiaRssExternalController extends WikiaController {
 	public function getRssFeeds() {
 		$this->response->setVal('status', false);
 		$options = $this->request->getVal('options', false);
-		$this->response->setCacheValidity(3600, 3600, array(WikiaResponse::CACHE_TARGET_BROWSER, WikiaResponse::CACHE_TARGET_VARNISH)); //cache it on varnish for 1h
+		$this->response->setCacheValidity(3600); //cache it on varnish for 1h
 
 		//somehow empty arrays are lost
 		//we need to restore then its default values

--- a/extensions/wikia/hacks/AutoLinker/AutoLinkerController.class.php
+++ b/extensions/wikia/hacks/AutoLinker/AutoLinkerController.class.php
@@ -21,7 +21,7 @@ class AutoLinkerController extends WikiaController {
 		$this->setVal('regexp', $regexp);
 		$this->setVal('count', count($pages));
 
-		$this->getResponse()->setCacheValidity(self::CACHE_TTL, self::CACHE_TTL, array(WikiaResponse::CACHE_TARGET_BROWSER, WikiaResponse::CACHE_TARGET_VARNISH));
+		$this->getResponse()->setCacheValidity(self::CACHE_TTL);
 	}
 
 	private function getPagesFrom($source) {

--- a/extensions/wikia/templates/HelloWorld/HelloWorldController.class.php
+++ b/extensions/wikia/templates/HelloWorld/HelloWorldController.class.php
@@ -22,7 +22,7 @@ class HelloWorldController extends WikiaController {
 		$this->html5logo = $this->wg->ExtensionsPath . '/wikia/templates/HelloWorld/images/html5logo.png';
 
 		// use caching
-		$this->response->setCacheValidity(3600, 3600, array(WikiaResponse::CACHE_TARGET_BROWSER, WikiaResponse::CACHE_TARGET_VARNISH));
+		$this->response->setCacheValidity(3600);
 	}
 
 }

--- a/includes/wikia/api/ArticlesApiController.class.php
+++ b/includes/wikia/api/ArticlesApiController.class.php
@@ -177,14 +177,7 @@ class ArticlesApiController extends WikiaApiController {
 			throw new NotFoundApiException();
 		}
 
-		$this->response->setCacheValidity(
-			self::CLIENT_CACHE_VALIDITY,
-			self::CLIENT_CACHE_VALIDITY,
-			[
-				WikiaResponse::CACHE_TARGET_BROWSER,
-				WikiaResponse::CACHE_TARGET_VARNISH
-			]
-		);
+		$this->response->setCacheValidity(self::CLIENT_CACHE_VALIDITY);
 
 		//if no mainpages were found and deleted we want to always return collection of self::MAX_ITEMS items
 		if ( count( $collection ) > self::MAX_ITEMS ) {
@@ -363,14 +356,7 @@ class ArticlesApiController extends WikiaApiController {
 		$response = $this->getResponse();
 		$response->setValues( [ 'items' => array_slice( $results, 0, $limit ), 'basepath' => $this->wg->Server ] );
 
-		$response->setCacheValidity(
-			self::NEW_ARTICLES_VARNISH_CACHE_EXPIRATION /* 24h */,
-			self::NEW_ARTICLES_VARNISH_CACHE_EXPIRATION /* 24h */,
-			array(
-				WikiaResponse::CACHE_TARGET_BROWSER,
-				WikiaResponse::CACHE_TARGET_VARNISH
-			)
-		);
+		$response->setCacheValidity(self::NEW_ARTICLES_VARNISH_CACHE_EXPIRATION);
 
 		wfProfileOut( __METHOD__ );
 	}
@@ -531,14 +517,7 @@ class ArticlesApiController extends WikiaApiController {
 			throw new NotFoundApiException( 'No members' );
 		}
 
-		$this->response->setCacheValidity(
-			self::CLIENT_CACHE_VALIDITY,
-			self::CLIENT_CACHE_VALIDITY,
-			[
-				WikiaResponse::CACHE_TARGET_BROWSER,
-				WikiaResponse::CACHE_TARGET_VARNISH
-			]
-		);
+		$this->response->setCacheValidity(self::CLIENT_CACHE_VALIDITY);
 
 		wfProfileOut( __METHOD__ );
 	}	
@@ -885,9 +864,7 @@ class ArticlesApiController extends WikiaApiController {
 		$jsonSimple = $jsonFormatService->getSimpleFormatForArticle( $article );
 
 		$response = $this->getResponse();
-		$response->setCacheValidity(self::SIMPLE_JSON_VARNISH_CACHE_EXPIRATION, self::SIMPLE_JSON_VARNISH_CACHE_EXPIRATION,
-			[WikiaResponse::CACHE_TARGET_VARNISH,
-				WikiaResponse::CACHE_TARGET_BROWSER ]);
+		$response->setCacheValidity(self::SIMPLE_JSON_VARNISH_CACHE_EXPIRATION);
 
 		$response->setFormat("json");
 		$response->setData( $jsonSimple );

--- a/includes/wikia/api/NavigationApiController.class.php
+++ b/includes/wikia/api/NavigationApiController.class.php
@@ -20,14 +20,7 @@ class NavigationApiController extends WikiaApiController {
 		$model = new NavigationModel();
 		$nav = $model->getWiki();
 
-		$this->response->setCacheValidity(
-			NavigationModel::CACHE_TTL, //3 hours
-			NavigationModel::CACHE_TTL,
-			array(
-				WikiaResponse::CACHE_TARGET_BROWSER,
-				WikiaResponse::CACHE_TARGET_VARNISH
-			)
-		);
+		$this->response->setCacheValidity(NavigationModel::CACHE_TTL);
 
 		$ret = array();
 

--- a/includes/wikia/api/RelatedPagesApiController.class.php
+++ b/includes/wikia/api/RelatedPagesApiController.class.php
@@ -47,14 +47,7 @@ class RelatedPagesApiController extends WikiaApiController {
 			$this->response->setVal( 'items', $related );
 			$this->response->setVal( 'basepath', $this->wg->Server );
 
-			$this->response->setCacheValidity(
-				10800 /* 3 hours */,
-				10800 /* 3 hours */,
-				array(
-					WikiaResponse::CACHE_TARGET_BROWSER,
-					WikiaResponse::CACHE_TARGET_VARNISH
-				)
-			);
+			$this->response->setCacheValidity(10800);
 
 			wfProfileOut( __METHOD__ );
 		} else {

--- a/includes/wikia/api/SearchSuggestionsApiController.class.php
+++ b/includes/wikia/api/SearchSuggestionsApiController.class.php
@@ -45,14 +45,7 @@ class SearchSuggestionsApiController extends WikiaApiController {
 				throw new NotFoundApiException();
 			}
 
-			$this->response->setCacheValidity(
-				86400 /* 24h */,
-				86400 /* 24h */,
-				array(
-					WikiaResponse::CACHE_TARGET_BROWSER,
-					WikiaResponse::CACHE_TARGET_VARNISH
-				)
-			);
+			$this->response->setCacheValidity(86400);
 		} else {
 			throw new NotFoundApiException( 'Link Suggest extension not available' );
 		}

--- a/includes/wikia/api/StatsApiController.class.php
+++ b/includes/wikia/api/StatsApiController.class.php
@@ -25,14 +25,7 @@ class StatsApiController extends WikiaApiController {
 	 * @example
 	 */
 	function getData() {
-		$this->response->setCacheValidity(
-			self::CACHE_VALIDITY,
-			self::CACHE_VALIDITY,
-			array(
-				WikiaResponse::CACHE_TARGET_BROWSER,
-				WikiaResponse::CACHE_TARGET_VARNISH
-			)
-		);
+		$this->response->setCacheValidity(self::CACHE_VALIDITY);
 
 		$wikiService = new WikiService();
 

--- a/includes/wikia/api/TvApiController.class.php
+++ b/includes/wikia/api/TvApiController.class.php
@@ -52,14 +52,7 @@ class TvApiController extends WikiaApiController {
 		$response = $this->getResponse();
 		$response->setValues( $responseValues );
 
-		$response->setCacheValidity(
-			self::RESPONSE_CACHE_VALIDITY /* 24h */,
-			self::RESPONSE_CACHE_VALIDITY /* 24h */,
-			array(
-				WikiaResponse::CACHE_TARGET_BROWSER,
-				WikiaResponse::CACHE_TARGET_VARNISH
-			)
-		);
+		$response->setCacheValidity(self::RESPONSE_CACHE_VALIDITY);
 	}
 
 	/**

--- a/includes/wikia/api/WikisApiController.class.php
+++ b/includes/wikia/api/WikisApiController.class.php
@@ -68,14 +68,7 @@ class WikisApiController extends WikiaApiController {
 		foreach ( $batches as $name => $value ) {
 			$this->response->setVal( $name, $value );
 		}
-		$this->response->setCacheValidity(
-			static::CACHE_1_WEEK,
-			static::CACHE_1_WEEK,
-			array(
-				WikiaResponse::CACHE_TARGET_BROWSER,
-				WikiaResponse::CACHE_TARGET_VARNISH
-			)
-		);
+		$this->response->setCacheValidity(static::CACHE_1_WEEK);
 	}
 
 	/**
@@ -138,14 +131,7 @@ class WikisApiController extends WikiaApiController {
 		//store only for 24h to allow new wikis
 		//to appear in a reasonable amount of time in the search
 		//results
-		$this->response->setCacheValidity(
-			static::CACHE_1_DAY,
-			static::CACHE_1_DAY,
-			array(
-				WikiaResponse::CACHE_TARGET_BROWSER,
-				WikiaResponse::CACHE_TARGET_VARNISH
-			)
-		);
+		$this->response->setCacheValidity(static::CACHE_1_DAY);
 
 		wfProfileOut( __METHOD__ );
 	}
@@ -186,15 +172,7 @@ class WikisApiController extends WikiaApiController {
 		$this->response->setVal( 'items', $items );
 
 		//set varnish caching
-		$this->response->setCacheValidity(
-			static::CACHE_1_DAY,
-			static::CACHE_1_DAY,
-			array(
-				WikiaResponse::CACHE_TARGET_BROWSER,
-				WikiaResponse::CACHE_TARGET_VARNISH
-			)
-		);
-		//die();
+		$this->response->setCacheValidity(static::CACHE_1_DAY);
 		wfProfileOut( __METHOD__ );
 	}
 

--- a/includes/wikia/nirvana/WikiaResponse.class.php
+++ b/includes/wikia/nirvana/WikiaResponse.class.php
@@ -299,7 +299,7 @@ class WikiaResponse {
 		}
 
 		if ($varnishTTL > 0) {
-			$varnishCacheControl = sprintf('s-max-age=%d', $varnishTTL);
+			$varnishCacheControl = sprintf('s-maxage=%d', $varnishTTL);
 		}
 		else {
 			// disable Varnish cache

--- a/includes/wikia/nirvana/WikiaResponse.class.php
+++ b/includes/wikia/nirvana/WikiaResponse.class.php
@@ -43,8 +43,7 @@ class WikiaResponse {
 	/**
 	 * Cache targets
 	 */
-	const CACHE_TARGET_BROWSER = 0;
-	const CACHE_TARGET_VARNISH = 1;
+	const CACHE_DISABLED = 0;
 
 	/**
 	 * View object
@@ -278,6 +277,8 @@ class WikiaResponse {
 	 * Sets correct cache headers for the client, Varnish or both
 	 *
 	 * Cache-Control header will be set
+	 *
+	 * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html
 	 *
 	 * @param integer $varnishTTL expiry time for Varnish (and for the client if $browserTTL is not provided)
 	 * @param integer $browserTTL expiry time for the client

--- a/includes/wikia/nirvana/WikiaResponse.class.php
+++ b/includes/wikia/nirvana/WikiaResponse.class.php
@@ -279,7 +279,7 @@ class WikiaResponse {
 	 *
 	 * Cache-Control header will be set
 	 *
-	 * @param integer $varnishTTL expiry time for Varnish (and the client of $browserTTL is not provided)
+	 * @param integer $varnishTTL expiry time for Varnish (and for the client if $browserTTL is not provided)
 	 * @param integer $browserTTL expiry time for the client
 	 */
 	public function setCacheValidity( $varnishTTL, $browserTTL = false ){

--- a/includes/wikia/nirvana/WikiaResponse.class.php
+++ b/includes/wikia/nirvana/WikiaResponse.class.php
@@ -276,38 +276,27 @@ class WikiaResponse {
 	/**
 	 * Sets correct cache headers for the client, Varnish or both
 	 *
-	 * Cache-Control header will be set
+	 * Cache-Control / X-Pass-Cache-Control headers will be set
 	 *
 	 * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html
 	 *
 	 * @param integer $varnishTTL expiry time for Varnish (and for the client if $browserTTL is not provided)
 	 * @param integer $browserTTL expiry time for the client
 	 */
-	public function setCacheValidity( $varnishTTL, $browserTTL = false ){
+	public function setCacheValidity( $varnishTTL, $browserTTL = false ) {
 		$this->isCaching = true;
+
+		$this->setHeader('Cache-Control', sprintf('s-maxage=%d', $varnishTTL));
 
 		// default to the TTL for Varnish
 		if ($browserTTL === false) {
 			$browserTTL = $varnishTTL;
 		}
 
+		// cache on client sioe
 		if ($browserTTL > 0) {
-			$browserCacheControl = sprintf('public, max-age=%d', $browserTTL);
+			$this->setHeader('X-Pass-Cache-Control', sprintf('public, max-age=%d', $browserTTL));
 		}
-		else {
-			// disable client cache
-			$browserCacheControl = 'max-age=0, must-revalidate, no-cache';
-		}
-
-		if ($varnishTTL > 0) {
-			$varnishCacheControl = sprintf('s-maxage=%d', $varnishTTL);
-		}
-		else {
-			// disable Varnish cache
-			$varnishCacheControl = 'private, s-maxage=0, no-store';
-		}
-
-		$this->setHeader('Cache-Control', sprintf('%s, %s', $browserCacheControl, $varnishCacheControl));
 	}
 
 	/**

--- a/includes/wikia/tests/WikiaResponseTest.php
+++ b/includes/wikia/tests/WikiaResponseTest.php
@@ -164,4 +164,40 @@ class WikiaResponseTest extends PHPUnit_Framework_TestCase {
 		$this->assertStringStartsWith( '<pre>', $output );
 	}
 
+	/**
+	 * @dataProvider setCacheValidityProvider
+	 */
+	public function testSetCacheValidity($varnishTTL, $clientTTL, $expectedValue, $passExpectedValue) {
+		$this->object->setCacheValidity( $varnishTTL, $clientTTL );
+		$cacheControlValue = $this->object->getHeader( 'Cache-Control' )[0]['value'];
+		$passCacheControlValue = $this->object->getHeader( 'X-Pass-Cache-Control' )[0]['value'];
+
+		$this->assertEquals( $expectedValue, $cacheControlValue, 'Cache-Control header should match the expected value' );
+		$this->assertEquals( $passExpectedValue, $passCacheControlValue, 'X-Pass-Cache-Control header should match the expected value' );
+	}
+
+	public function setCacheValidityProvider() {
+		return [
+			// no caching
+			[
+				WikiaResponse::CACHE_DISABLED, false,
+				's-maxage=0', null
+			],
+			// cache on Varnish only
+			[
+				60, WikiaResponse::CACHE_DISABLED,
+				's-maxage=60', null
+			],
+			// cache on both
+			[
+				60, false,
+				's-maxage=60', 'public, max-age=60'
+			],
+			// cache on both (different TTLs)
+			[
+				86400, 60,
+				's-maxage=86400', 'public, max-age=60'
+			],
+		];
+	}
 }

--- a/includes/wikia/ui/UIFactoryApiController.class.php
+++ b/includes/wikia/ui/UIFactoryApiController.class.php
@@ -92,14 +92,7 @@ class UIFactoryApiController extends \WikiaApiController {
 		$this->setVal( 'dependencies', $result );
 
 		// set response caching
-		$this->response->setCacheValidity(
-			self::CLIENT_CACHE_VALIDITY,
-			self::CLIENT_CACHE_VALIDITY,
-			array(
-				\WikiaResponse::CACHE_TARGET_BROWSER,
-				\WikiaResponse::CACHE_TARGET_VARNISH
-			)
-		);
+		$this->response->setCacheValidity(self::CLIENT_CACHE_VALIDITY);
 
 		wfProfileOut( __METHOD__ );
 	}

--- a/resources/wikia/modules/loader.js
+++ b/resources/wikia/modules/loader.js
@@ -245,9 +245,7 @@ define('wikia.loader', ['wikia.window', require.optional('mw'), 'wikia.nirvana',
 		 *		scripts - comma-separated list of AssetsManager groups
 		 *		messages - comma-separated list of JSMessages packages (messages are registered automagically)
 		 * 		mustache - comma-separated list of paths to Mustache-powered templates
-		 *		ttl - cache period for both Varnish and Browser (in seconds), is overridden by varnishTTL and BrowserTTL
-		 *		varnishTTL - cache period for varnish and browser (in seconds)
-		 *		browserTTL - cache period for browser (in seconds)
+		 *		ttl - cache period for both Varnish and Browser (in seconds)
 		 *		params - an object with all the additional parameters for the request (e.g. useskin, forceprofile, etc.)
 		 *		callback - function to be called with fetched JSON object
 		 *

--- a/skins/oasis/modules/GlobalHeaderController.class.php
+++ b/skins/oasis/modules/GlobalHeaderController.class.php
@@ -81,10 +81,7 @@ class GlobalHeaderController extends WikiaController {
 		$this->response->setData($menuItems);
 
 		// Cache for 1 day
-		$this->response->setCacheValidity(3600, 3600, array(
-			WikiaResponse::CACHE_TARGET_BROWSER,
-			WikiaResponse::CACHE_TARGET_VARNISH
-		));
+		$this->response->setCacheValidity(3600);
 	}
 
 	protected function isGameStarLogoEnabled() {

--- a/skins/oasis/modules/LatestActivityController.class.php
+++ b/skins/oasis/modules/LatestActivityController.class.php
@@ -106,7 +106,7 @@ class LatestActivityController extends WikiaController {
 			$this->response->addAsset('skins/oasis/js/LatestActivity.js');
 		}
 		// Cache the latest activity call in varnish (and browser).
-		$this->response->setCacheValidity(self::CACHE_DURATION, self::CACHE_DURATION, array(WikiaResponse::CACHE_TARGET_BROWSER, WikiaResponse::CACHE_TARGET_VARNISH));
+		$this->response->setCacheValidity(self::CACHE_DURATION);
 		
 		wfProfileOut( __METHOD__ );
 	}

--- a/skins/oasis/modules/RailController.class.php
+++ b/skins/oasis/modules/RailController.class.php
@@ -29,13 +29,7 @@ class RailController extends WikiaController {
 
 		$this->getLazyRail();
 
-		$this->response->setCacheValidity(
-			86400 /* 24h */,
-			86400 /* 24h */,
-			array(
-				WikiaResponse::CACHE_TARGET_VARNISH
-			)
-		);
+		$this->response->setCacheValidity(86400);
 
 		wfProfileOut(__METHOD__);
 	}
@@ -48,7 +42,7 @@ class RailController extends WikiaController {
 
 		$this->getLazyRail();
 
-		$this->response->setCacheValidity(null, null, []);
+		//$this->response->setCacheValidity(null, null, []); // NOP
 
 		wfProfileOut(__METHOD__);
 	}


### PR DESCRIPTION
@Wikia/platform-team / @prein / @michalroszka 

This pull request introduces the following changes:
- `WikiaResponse::setCacheValidity` method has been simplified. It now requires just a single argument (cache TTL for both Varnish and the client). The second one is optional and is used when you want to have different TTL for Varnish (first argument) and the client (second argument).
- `Expires` response header is removed by Varnish. It's now removed from the code as well.
- `WikiaResponse::CACHE_TARGET_BROWSER` and `WikiaResponse::CACHE_TARGET_VARNISH` consts are removed
- introduced `WikiaResponse::CACHE_DISABLED` to clearly indicate "no caching, please"
