### PR TITLE
Vid 1288

### DIFF
--- a/extensions/wikia/VideoHandlers/VideoThumbnailController.class.php
+++ b/extensions/wikia/VideoHandlers/VideoThumbnailController.class.php
@@ -188,7 +188,7 @@ class VideoThumbnailController extends WikiaController {
 		$this->linkClasses = array_unique( $linkClasses );
 		$this->linkAttrs = $this->getAttribs( $linkAttribs );
 
-		if ( gettype( $options['forceSize'] ) == "string" ) {
+		if ( !empty( $options['forceSize'] ) ) {
 			$this->size = $options['forceSize'];
 		} else {
 			$this->size = $this->getThumbnailSize( $width );

--- a/extensions/wikia/VideoHandlers/VideoThumbnailController.class.php
+++ b/extensions/wikia/VideoHandlers/VideoThumbnailController.class.php
@@ -21,7 +21,8 @@ class VideoThumbnailController extends WikiaController {
 	 *		valign - valign for image
 	 *		imgExtraStyle - extra style for image
 	 *		disableRDF - disable RDF metadata
-	 *		responsive
+	 *		fluid - image will take the width of it's container
+	 *		forceSize - 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge'
 	 * @responseParam string width
 	 * @responseParam string height
 	 * @responseParam string linkHref
@@ -174,25 +175,24 @@ class VideoThumbnailController extends WikiaController {
 			}
 		}
 
-		// check responsive
-		if ( empty( $options[ 'responsive' ] ) ) {
-			$width = $width.'px';
-			$height = $height.'px';
+		// check fluid
+		if ( empty( $options[ 'fluid' ] ) ) {
+			$this->imgWidth = $width;
+			$this->imgHeight = $height;
 		} else {
-			$width = 0;
-			$height = 0;
-			$linkClasses[] = 'responsive';
+			$linkClasses[] = 'fluid';
 		}
-
-		// set width and height
-		$this->width = $width;
-		$this->height = $height;
 
 		// set link attributes
 		$this->linkHref = $linkHref;
 		$this->linkClasses = array_unique( $linkClasses );
 		$this->linkAttrs = $this->getAttribs( $linkAttribs );
-		$this->size = $this->getThumbnailSize( $width );
+
+		if ( gettype( $options['forceSize'] ) == "string" ) {
+			$this->size = $options['forceSize'];
+		} else {
+			$this->size = $this->getThumbnailSize( $width );
+		}
 
 		// set image attributes
 		$this->imgSrc = $imgSrc;

--- a/extensions/wikia/VideoPageTool/VideoPageToolHelper.class.php
+++ b/extensions/wikia/VideoPageTool/VideoPageToolHelper.class.php
@@ -226,6 +226,8 @@ class VideoPageToolHelper extends WikiaModel {
 		$db = wfGetDB( DB_SLAVE );
 
 		$thumbOptions['useTemplate'] = true;
+		$thumbOptions['fluid'] = true;
+		$thumbOptions['forceSize'] = 'small';
 
 		$videos = (new WikiaSQL())->cache( self::CACHE_TTL_CATEGORY_DATA, $memcKey )
 

--- a/extensions/wikia/VideoPageTool/VideoPageToolHelper.class.php
+++ b/extensions/wikia/VideoPageTool/VideoPageToolHelper.class.php
@@ -76,7 +76,6 @@ class VideoPageToolHelper extends WikiaModel {
 		foreach( $sections as $key => $value ) {
 			$query['section'] = $key;
 			$leftMenuItems[] = array(
-				'title' => $value,
 				'anchor' => $value,
 				'href' => $this->wg->title->getLocalURL( $query ),
 				'selected' => ($selected == $key),

--- a/extensions/wikia/VideoPageTool/css/HomePage/featured.scss
+++ b/extensions/wikia/VideoPageTool/css/HomePage/featured.scss
@@ -62,10 +62,6 @@ $play-button-overlay-fade-duration: 400ms;
 				.slide-image {
 					width: 100%;
 
-					> img {
-						width: 100%;
-					}
-
 					// darken the image with 10% opacity per design request
 					&:after {
 						@include opacity(10);

--- a/extensions/wikia/VideoPageTool/css/carousel.scss
+++ b/extensions/wikia/VideoPageTool/css/carousel.scss
@@ -104,10 +104,6 @@ $pagination-color-active: #a7a9ab;
 			margin-bottom: 11px;
 		}
 
-		img {
-			width: 100%;
-		}
-
 		a {
 			color: $color-text;
 		}

--- a/extensions/wikia/VideoPageTool/model/VideoPageToolAssetFeatured.class.php
+++ b/extensions/wikia/VideoPageTool/model/VideoPageToolAssetFeatured.class.php
@@ -13,6 +13,7 @@ class VideoPageToolAssetFeatured extends VideoPageToolAsset {
 	protected $defaultThumbOptions = [
 		'noLightbox' => true,
 		'useTemplate' => true,
+		'fluid' => true,
 		'hidePlayButton' => true,
 	];
 

--- a/extensions/wikia/VideoPageTool/templates/VideoHomePageController_featured.php
+++ b/extensions/wikia/VideoPageTool/templates/VideoHomePageController_featured.php
@@ -5,7 +5,7 @@
 			<? $index = 0; ?>
 			<? foreach ( $assets as $videoData ): ?>
 				<li>
-					<div class="slide-image video wikia-video-thumbnail xlarge hide-play" data-index="<?= $index ?>">
+					<div class="slide-image video wikia-video-thumbnail xlarge hide-play fluid" data-index="<?= $index ?>">
 						<span class="play-circle"></span>
 						<img src="<?= $videoData['largeThumbUrl'] ?>">
 						<div class="caption small-4 columns">

--- a/includes/Linker.php
+++ b/includes/Linker.php
@@ -664,7 +664,6 @@ class Linker {
 			 * Wikia change start
 			 * @author Federico
 			 */
-			$params['useTemplate'] = true;
 			$origHTML = $s = $thumb->toHtml( $params );
 			/**
 			 * Wikia change end
@@ -869,7 +868,6 @@ class Linker {
 			 * Wikia change start
 			 * @author Federico
 			 */
-			$params['useTemplate'] = true;
 			$origHTML = $thumb->toHtml( $params );
 			$s .= $origHTML;
 			/**

--- a/includes/Linker.php
+++ b/includes/Linker.php
@@ -664,6 +664,7 @@ class Linker {
 			 * Wikia change start
 			 * @author Federico
 			 */
+			$params['useTemplate'] = true;
 			$origHTML = $s = $thumb->toHtml( $params );
 			/**
 			 * Wikia change end
@@ -868,6 +869,7 @@ class Linker {
 			 * Wikia change start
 			 * @author Federico
 			 */
+			$params['useTemplate'] = true;
 			$origHTML = $thumb->toHtml( $params );
 			$s .= $origHTML;
 			/**

--- a/skins/oasis/css/core/video-thumbnail.scss
+++ b/skins/oasis/css/core/video-thumbnail.scss
@@ -8,8 +8,11 @@
 
 .wikia-video-thumbnail {
 	display: inline-block;
-	width: 100%;
 	position: relative;
+
+	&.fluid > img {
+		width: 100%;
+	}
 
 	// Background circle
 	.play-circle {

--- a/skins/oasis/css/modules/LeftMenu.scss
+++ b/skins/oasis/css/modules/LeftMenu.scss
@@ -33,6 +33,7 @@ $color-tabs-hover-background: mix($color-page, #000, 98%);
 	.selected a {
 		background-color: $color-tabs-background;
 		color: $color-text;
+		cursor: default;
 	}
 
 }


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/VID-1288

This forces a small size on the video thumbnails in the category carousels of the video home page.  It also addresses some issues with the new video thumbnail setup that hadn't been fully exposed before.  

Also some minor tweaks to the left menu items - hovering over the selected item will show a default cursor instead of an arrow, and the title attributes were removed because they were unnecessary and kinda annoying. 

@kenkouot @saipetch @garthwebb @jsutterfield 
