### PR TITLE
BAC-1250: wgInvalidateCacheOnLocalSettingsChange - set to false

### DIFF
--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1258,3 +1258,9 @@ $wgEnableCentralizedLogging = true;
  * Turns off <!-- Served by ... in ... ms --> HTML comment
  */
 $wgDisableReportTime = true;
+
+/**
+ * @name $wgInvalidateCacheOnLocalSettingsChange
+ * Setting this to true will invalidate all cached pages whenever LocalSettings.php is changed.
+ */
+$wgInvalidateCacheOnLocalSettingsChange = false;


### PR DESCRIPTION
Do not include mtime of `$IP/LocalSettings.php` when calculating `Last-Modified` header value.

http://www.mediawiki.org/wiki/Manual:$wgInvalidateCacheOnLocalSettingsChange

@prein / @michalroszka 
