### PR TITLE
BAC-1246: move wgJSMessagesCB to startup RL module

### DIFF
--- a/extensions/wikia/JSMessages/JSMessages.class.php
+++ b/extensions/wikia/JSMessages/JSMessages.class.php
@@ -250,9 +250,6 @@ class JSMessages {
 			$vars['wgMessages'] = self::getPackages($packages, false /* don't allow wildcards in INLINE mode (BugId:18482) */);
 		}
 
-		// messages cache buster used by JSMessages (BugId:6324)
-		$vars['wgJSMessagesCB'] = JSMessagesHelper::getMessagesCacheBuster();
-
 		self::log(__METHOD__, 'preparing list of external packages...');
 
 		$url = self::getExternalPackagesUrl();
@@ -263,6 +260,17 @@ class JSMessages {
 		}
 
 		wfProfileOut(__METHOD__);
+		return true;
+	}
+
+	/**
+	 * Add wgJSMessagesCB global variable to startup ResourceLoader module
+	 *
+	 * @param array $vars JS global variables
+	 * @return bool true
+	 */
+	static public function onResourceLoaderGetConfigVars(Array &$vars) {
+		$vars['wgJSMessagesCB'] = JSMessagesHelper::getMessagesCacheBuster();
 		return true;
 	}
 

--- a/extensions/wikia/JSMessages/JSMessages_setup.php
+++ b/extensions/wikia/JSMessages/JSMessages_setup.php
@@ -24,10 +24,9 @@ $wgAutoloadClasses['JSMessagesHelper'] =  $dir . '/JSMessagesHelper.class.php';
 $wgAutoloadClasses['JSMessagesController'] =  $dir . '/JSMessagesController.class.php';
 
 // hooks
-$wgHooks['WikiaSkinTopScripts'][] = 'JSMessages::onWikiaSkinTopScripts';
-$wgHooks['MessageCacheReplace'][] = 'JSMessagesHelper::onMessageCacheReplace';
-
-
+$wgHooks['WikiaSkinTopScripts']        [] = 'JSMessages::onWikiaSkinTopScripts';
+$wgHooks['ResourceLoaderGetConfigVars'][] = 'JSMessages::onResourceLoaderGetConfigVars';
+$wgHooks['MessageCacheReplace']        [] = 'JSMessagesHelper::onMessageCacheReplace';
 
 $wgExtensionFunctions[] = function () {
 	// This has to be wrapped in a function so it isn't run before we include GlobalSettings.php


### PR DESCRIPTION
No need to keep this variable in `<head>` section of the skin.

Load it via "startup" ResourceLoader module

@prein / @michalroszka
