### PR TITLE
Varnish caching backports to release-208

### DIFF
--- a/extensions/wikia/GameGuides/GameGuidesController.class.php
+++ b/extensions/wikia/GameGuides/GameGuidesController.class.php
@@ -26,6 +26,8 @@ class GameGuidesController extends WikiaController {
 	 */
 	private $mModel = null;
 	private $mPlatform = null;
+	//Make sure this is updated as in GameGuides.js
+	private static $disabledNamespaces = [-2, -1, 1, 2, 3, 4, 5, 6, 7, 10, 11, 12, 13, 15, 110, 111, 500, 501, 700, 701, 1200, 1201, 1202];
 
 	function init() {
 		$requestedVersion = $this->request->getInt( 'ver', self::API_VERSION );
@@ -234,9 +236,12 @@ class GameGuidesController extends WikiaController {
 	 * @return bool
 	 */
 	static function onTitleGetSquidURLs( $title, &$urls ){
-		$urls[] = GameGuidesController::getUrl( 'getPage', array(
-			'page' => $title->getPartialURL()
-		));
+
+		if ( !in_array( $title->getNamespace(), self::$disabledNamespaces ) ) {
+			$urls[] = self::getUrl( 'getPage', array(
+				'page' => $title->getPrefixedText()
+			) );
+		}
 
 		return true;
 	}

--- a/extensions/wikia/GameGuides/js/GameGuides.js
+++ b/extensions/wikia/GameGuides/js/GameGuides.js
@@ -9,6 +9,7 @@
 		regExpNamespace = new RegExp(window.wgArticlePath.replace('$1', '([^:]*)')),
 		//not all namespaces in GG should be clickable
 		//there are custom namespaces on wikis therefore black list will be better suited here
+		//Make sure this is updated as in GameGuidesController.class.php
 		disabledNs = [-2,-1,1,2,3,4,5,6,7,10,11,12,13,15,110,111,500,501,700,701,1200,1201,1202],
 		link,
 		path,

--- a/extensions/wikia/MyHome/ActivityFeedHelper.php
+++ b/extensions/wikia/MyHome/ActivityFeedHelper.php
@@ -173,13 +173,12 @@ class ActivityFeedHelper {
 	/**
 	 * @author Maciej Błaszkowski <marooned at wikia-inc.com>
 	 */
-	static function purgeCommunityWidgetInVarnish($title) {
-		global $wgScript, $wgContentNamespaces, $wgContLang, $wgMemc;
+	static function purgeCommunityWidgetInVarnish(Title $title) {
+		global $wgContentNamespaces, $wgContLang, $wgMemc;
 		if (in_array($title->getNamespace(), $wgContentNamespaces)) {
 			$lang = $wgContLang->getCode();
 			$key = wfMemcKey('community_widget_v1', $lang);
 			$wgMemc->delete($key);
-			SquidUpdate::purge(array($wgScript . "?action=ajax&rs=CommunityWidgetAjax&uselang=$lang"));
 		}
 		return true;
 	}

--- a/includes/cache/SquidUpdate.php
+++ b/includes/cache/SquidUpdate.php
@@ -240,7 +240,7 @@ class SquidUpdate {
 	 * @static
 	 */
 	static function ScribePurge( $urlArr ) {
-		global $wgEnableScribeReport;
+		global $wgEnableScribeReport, $wgCityId;
 		wfProfileIn( __METHOD__ );
 		$key = 'varnish_purges';
 
@@ -255,15 +255,24 @@ class SquidUpdate {
 					throw new MWException( 'Bad purge URL' );
 				}
 				$url = SquidUpdate::expand( $url );
+				$method = self::getPurgeCaller();
 
 				wfDebug( "Purging URL $url via Scribe\n" );
 				$data = json_encode(
 					array(
 						'url' => $url,
 						'time' => time(),
+						'method' => $method,
 					)
 				);
 				WScribeClient::singleton($key)->send($data);
+
+				// log purges using SFlow (BAC-1258)
+				Wikia\SFlow::operation('varnish.purge', [
+					'city' => $wgCityId,
+					'url' => $url,
+					'method' => $method,
+				]);
 			}
 		}
 		catch( TException $e ) {
@@ -271,6 +280,29 @@ class SquidUpdate {
 		}
 
 		wfProfileOut( __METHOD__ );
+	}
+
+	/**
+	 * Return the name of the method (outside of internal code) that triggered purge request
+	 *
+	 * @return bool|string method name
+	 */
+	private static function getPurgeCaller() {
+		// analyze the backtrace to log the source of purge requests
+		$backtrace = wfDebugBacktrace();
+		$method = '';
+
+		while($entry = array_shift($backtrace)) {
+			// ignore "internal" classes
+			if (empty($entry['class']) || in_array($entry['class'], [__CLASS__, 'WikiPage', 'Article', 'Title'])) {
+				continue;
+			}
+
+			$method = $entry['class'] . ':' . $entry['function'];
+			break;
+		}
+
+		return $method;
 	}
 
 	/**

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1266,3 +1266,12 @@ $wgDisableReportTime = true;
  * Setting this to true will invalidate all cached pages whenever LocalSettings.php is changed.
  */
 $wgInvalidateCacheOnLocalSettingsChange = false;
+
+/**
+ * SFlow client and config
+ */
+$wgSFlowHost = 'localhost';
+$wgSFlowPort = 36343;
+$wgSFlowSampling = 1;
+
+$wgAutoloadClasses[ 'Wikia\\SFlow'] = "$IP/lib/vendor/SFlow.class.php";

--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -2259,6 +2259,9 @@ class Wikia {
 		$response->header( sprintf( 'X-Served-By:%s', wfHostname() ) );
 		$response->header( sprintf( 'X-Backend-Response-Time:%01.3f', $elapsed ) );
 
+		$response->header( 'X-Cache: ORIGIN' );
+		$response->header( 'X-Cache-Hits: ORIGIN' );
+
 		return true;
 	}
 }

--- a/lib/vendor/SFlow.class.php
+++ b/lib/vendor/SFlow.class.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * PHP client for sending JSON reports to sflow deamon
+ *
+ * @author macbre
+ * @see http://blog.sflow.com/2012_05_01_archive.html
+ */
+namespace Wikia;
+
+class SFlow {
+
+	const APPLICATION = 'mw';
+
+	/**
+	 * Report given operation
+	 *
+	 * @param string $op_name operation name
+	 * @param array $data optional params to be sent
+	 */
+	public static function operation( $op_name, Array $data = array() ) {
+		self::app_operation( self::APPLICATION, $op_name, wfArrayToCGI( $data ) );
+	}
+
+	/**
+	 * Send a packet to SFlow daemon
+	 *
+	 * @param $app_name
+	 * @param $op_name
+	 * @param string $attributes
+	 * @param int $status
+	 * @param string $status_descr
+	 * @param int $req_bytes
+	 * @param int $resp_bytes
+	 * @param int $uS
+	 */
+	private static function app_operation( $app_name, $op_name, $attributes = "", $status = 0, $status_descr = "", $req_bytes = 0, $resp_bytes = 0, $uS = 0 ) {
+		global $wgSFlowHost, $wgSFlowPort, $wgSFlowSampling;
+
+		// sampling handling
+		$sampling_rate = $wgSFlowSampling;
+
+		if ( $sampling_rate > 1 ) {
+			if ( mt_rand( 1, $sampling_rate ) != 1 ) {
+				return;
+			}
+		}
+
+		wfProfileIn( __METHOD__ );
+
+		try {
+			$sock = fsockopen( "udp://" . $wgSFlowHost, $wgSFlowPort, $errno, $errstr );
+			if ( !$sock ) {
+				return;
+			}
+
+			$data = [
+				"flow_sample" => [
+					"app_name" => $app_name,
+					"sampling_rate" => $sampling_rate,
+					"app_operation" => [
+						"operation" => $op_name,
+						"attributes" => $attributes,
+						"status_descr" => $status_descr,
+						"status" => $status,
+						"req_bytes" => $req_bytes,
+						"resp_bytes" => $resp_bytes,
+						"uS" => $uS
+					]
+				]
+			];
+
+			$payload = json_encode( $data );
+			wfDebug( sprintf( "%s: sending '%s'\n", __METHOD__ , $payload ) );
+
+			fwrite( $sock, $payload );
+			fclose( $sock );
+		} catch ( \Exception $e ) {
+			\Wikia::log( __METHOD__, 'send', $e->getMessage(), true );
+			\Wikia::logBacktrace( __METHOD__ );
+		}
+
+		wfProfileOut( __METHOD__ );
+	}
+}


### PR DESCRIPTION
- BAC-1252: remove ActivityFeed purge request on edit
- BAC-1262: Purge only enabled namespaces and purge them with correct prefix
- BAC-1254: fix X-Cache header
- BAC-1258:  Add sFlow monitoring for purges from MW

@prein / @michalroszka / @hakubo 
