### PR TITLE
MAIN-1708 use Wikia\Search\IndexService\Abstract::getResponse instead of execute in Wikia\Search\Indexer

### DIFF
--- a/extensions/wikia/Search/classes/Indexer.php
+++ b/extensions/wikia/Search/classes/Indexer.php
@@ -89,7 +89,7 @@ class Indexer
 		foreach ( $this->serviceNames as $serviceName ) {
 			$serviceResult = $this->getIndexService( $serviceName )
 			                      ->setPageId( $pageId )
-			                      ->execute();
+			                      ->getResponse();
 			
 			if ( is_array( $serviceResult ) ) {
     			$result = array_merge( $result, $serviceResult );

--- a/extensions/wikia/Search/classes/Test/IndexerTest.php
+++ b/extensions/wikia/Search/classes/Test/IndexerTest.php
@@ -48,7 +48,7 @@ class IndexerTest extends BaseTest
 		$reflServiceNames = new ReflectionProperty( 'Wikia\Search\Indexer', 'serviceNames' );
 		$reflServiceNames->setAccessible( true );
 		$reflServiceNames->setValue( $indexer, array( 'DefaultContent' ) );
-		$mockIndexService = $this->getMock( 'Wikia\Search\IndexService\DefaultContent', array( 'setPageId', 'execute' ) );
+		$mockIndexService = $this->getMock( 'Wikia\Search\IndexService\DefaultContent', array( 'setPageId', 'getResponse' ) );
 		$mockMwService = $this->getMock( 'Wikia\Search\MediaWikiService', array( 'getWikiId', 'getCanonicalPageIdFromPageId' ) );
 		$indexer
 		    ->expects( $this->any() )
@@ -81,7 +81,7 @@ class IndexerTest extends BaseTest
 		;
 		$mockIndexService
 		    ->expects( $this->once() )
-		    ->method ( 'execute' )
+		    ->method ( 'getResponse' )
 		    ->will   ( $this->returnValue( $resultArray ) )
 		;
 		$this->assertEquals(


### PR DESCRIPTION
This fixes a defect which leaks nolang_txt field values from the creation of one Solr document to
another in the event that we are creating multiple Solr documents through the Wikia\Search\Indexer's functionality.
At this point, this only affects reindexing events run on the internal wiki.
