### PR TITLE
(CE-611) Stop using oldCrypt to hash passwords

### DIFF
--- a/includes/User.php
+++ b/includes/User.php
@@ -2121,9 +2121,7 @@ class User {
 			// Save an invalid hash...
 			$this->mPassword = '';
 		} else {
-			// Wikia uses the old hashing until we migrate all wikis to MW 1.13
-			//$this->mPassword = self::crypt( $str );
-			$this->mPassword = self::oldCrypt( $str, $this->mId );
+			$this->mPassword = self::crypt( $str );
 		}
 		$this->mNewpassword = '';
 		$this->mNewpassTime = null;
@@ -2176,9 +2174,7 @@ class User {
 	 */
 	public function setNewpassword( $str, $throttle = true ) {
 		$this->load();
-		// Wikia uses the old hashing until we migrate all wikis to MW 1.13
-		//$this->mNewpassword = self::crypt( $str );
-		$this->mNewpassword = self::oldCrypt( $str, $this->mId );
+		$this->mNewpassword = self::crypt( $str );
 		if ( $throttle ) {
 			$this->mNewpassTime = wfTimestampNow();
 		}


### PR DESCRIPTION
We have been using User::oldCrypt rather than switching to User::crypt
because of a temporary Wikia change from the time we upgraded to MW 1.13.
This temporary Wikia change has somehow persisted for all the upgrades since.

This only affects new user accounts and when users change their passwords.
The User::comparePasswords falls back to User::oldCrypt in the event the
hash doesn't match one of the formats provided by User::crypt.

@owend @federico-lox @lgarczewski 
