### PR TITLE
CON-548: Added city_id field and index to wikia_hub_modules table

### DIFF
--- a/extensions/wikia/WikiaHubsV2/sql/wikiahubsv2.sql
+++ b/extensions/wikia/WikiaHubsV2/sql/wikiahubsv2.sql
@@ -8,5 +8,6 @@ CREATE TABLE `wikia_hub_modules` (
   `module_status` tinyint NOT NULL DEFAULT 1, /* in sync with CT statuses: 1-saved, 2-published */
   `last_editor_id` int(11),
   `last_edit_timestamp` timestamp,
-  PRIMARY KEY ( `lang_code`, `vertical_id`, `hub_date`, `module_id`, `city_id` )
+  PRIMARY KEY ( `lang_code`, `vertical_id`, `hub_date`, `module_id`, `city_id` ),
+  KEY by_city_id ( `city_id`, `hub_date`, `module_id` )
 ) ENGINE=InnoDB;

--- a/extensions/wikia/WikiaHubsV2/sql/wikiahubsv2.sql
+++ b/extensions/wikia/WikiaHubsV2/sql/wikiahubsv2.sql
@@ -1,5 +1,5 @@
 CREATE TABLE `wikia_hub_modules` (
-  `city_id` int NOT NULL,
+  `city_id` int NOT NULL DEFAULT 0,
   `lang_code` varchar(8) NOT NULL,
   `vertical_id` tinyint NOT NULL, /* in sync with comscore id (2-gaming, 3-entertainment, 9-lifestyle) */
   `hub_date` date  NOT NULL,
@@ -8,6 +8,5 @@ CREATE TABLE `wikia_hub_modules` (
   `module_status` tinyint NOT NULL DEFAULT 1, /* in sync with CT statuses: 1-saved, 2-published */
   `last_editor_id` int(11),
   `last_edit_timestamp` timestamp,
-  PRIMARY KEY ( `lang_code`, `vertical_id`, `hub_date`, `module_id` )
+  PRIMARY KEY ( `lang_code`, `vertical_id`, `hub_date`, `city_id`, `module_id` )
 ) ENGINE=InnoDB;
-CREATE INDEX `wikia_hub_index` ON `wikia_hub_modules` (`city_id`, `hub_date`, `module_id`);

--- a/extensions/wikia/WikiaHubsV2/sql/wikiahubsv2.sql
+++ b/extensions/wikia/WikiaHubsV2/sql/wikiahubsv2.sql
@@ -1,4 +1,5 @@
 CREATE TABLE `wikia_hub_modules` (
+  `city_id` int NOT NULL,
   `lang_code` varchar(8) NOT NULL,
   `vertical_id` tinyint NOT NULL, /* in sync with comscore id (2-gaming, 3-entertainment, 9-lifestyle) */
   `hub_date` date  NOT NULL,
@@ -9,3 +10,4 @@ CREATE TABLE `wikia_hub_modules` (
   `last_edit_timestamp` timestamp,
   PRIMARY KEY ( `lang_code`, `vertical_id`, `hub_date`, `module_id` )
 ) ENGINE=InnoDB;
+CREATE INDEX `wikia_hub_index` ON `wikia_hub_modules` (`city_id`, `hub_date`, `module_id`);

--- a/extensions/wikia/WikiaHubsV2/sql/wikiahubsv2.sql
+++ b/extensions/wikia/WikiaHubsV2/sql/wikiahubsv2.sql
@@ -8,5 +8,5 @@ CREATE TABLE `wikia_hub_modules` (
   `module_status` tinyint NOT NULL DEFAULT 1, /* in sync with CT statuses: 1-saved, 2-published */
   `last_editor_id` int(11),
   `last_edit_timestamp` timestamp,
-  PRIMARY KEY ( `lang_code`, `vertical_id`, `hub_date`, `module_id` )
+  PRIMARY KEY ( `lang_code`, `vertical_id`, `hub_date`, `module_id`, `city_id` )
 ) ENGINE=InnoDB;

--- a/extensions/wikia/WikiaHubsV2/sql/wikiahubsv2.sql
+++ b/extensions/wikia/WikiaHubsV2/sql/wikiahubsv2.sql
@@ -8,5 +8,5 @@ CREATE TABLE `wikia_hub_modules` (
   `module_status` tinyint NOT NULL DEFAULT 1, /* in sync with CT statuses: 1-saved, 2-published */
   `last_editor_id` int(11),
   `last_edit_timestamp` timestamp,
-  PRIMARY KEY ( `lang_code`, `vertical_id`, `hub_date`, `city_id`, `module_id` )
+  PRIMARY KEY ( `lang_code`, `vertical_id`, `hub_date`, `module_id` )
 ) ENGINE=InnoDB;


### PR DESCRIPTION
Change DB schema for MTB

Example query:

SELECT  module_id,module_status,module_data,last_edit_timestamp,last_editor_id  FROM `wikia_hub_modules`  WHERE lang_code = 'en' AND vertical_id = '2' AND hub_date = '20131209000000' AND module_id = '1';

Explain:

+----+-------------+-------------------+-------+---------------+---------+---------+-------------------------+------+-------+
| id | select_type | table             | type  | possible_keys | key     | key_len | ref                     | rows | Extra |
+----+-------------+-------------------+-------+---------------+---------+---------+-------------------------+------+-------+
|  1 | SIMPLE      | wikia_hub_modules | const | PRIMARY       | PRIMARY | 15      | const,const,const,const |    1 |       |
+----+-------------+-------------------+-------+---------------+---------+---------+-------------------------+------+-------+
1 row in set (0.00 sec)
