### PR TITLE
fixing video thumbnail attributes so they have the correct number of quo...

### DIFF
--- a/extensions/wikia/Thumbnails/ThumbnailVideoController.class.php
+++ b/extensions/wikia/Thumbnails/ThumbnailVideoController.class.php
@@ -216,13 +216,19 @@ class ThumbnailVideoController extends WikiaController {
 
 	/**
 	 * Get attributes for mustache template
+	 * Note: wrap attributes in three curly braces to unescape html.
+	 * Ex: {{# attrs }}{{{ . }}} {{/ attrs }}
 	 * @param array $attrs [ array( key => value ) ]
-	 * @return array $attribs [ array( "key='value'" ) ]
+	 * @return array [ array( 'key="value"' ) ]
 	 */
 	protected function getAttribs( $attrs ) {
 		$attribs = [];
 		foreach ( $attrs as $key => $value ) {
-			$attribs[] = "$key='$value'";
+			$str = $key;
+			if ( $value ) {
+				$str .= "=" . '"' . $value . '"';
+			}
+			$attribs[] = $str;
 		}
 
 		return $attribs;

--- a/extensions/wikia/Thumbnails/ThumbnailVideoController.class.php
+++ b/extensions/wikia/Thumbnails/ThumbnailVideoController.class.php
@@ -43,9 +43,9 @@ class ThumbnailVideoController extends WikiaController {
 	 * @responseParam array imgAttrs
 	 *	Keys:
 	 *		alt - alt for image
-	 *		data-src - source of image for lazy loading
 	 *		style - style for image
 	 *		itemprop - for RDF metadata
+	 * @responseParam string dataSrc - data-src attribute for image lazy loading
 	 * @responseParam string duration (HH:MM:SS)
 	 * @responseParam array durationAttrs
 	 *	Keys:
@@ -123,11 +123,6 @@ class ThumbnailVideoController extends WikiaController {
 		// get alt for img tag
 		$imgAttribs['alt'] = empty( $options['alt'] ) ? '' : $options['alt'];
 
-		// lazy loading
-		if ( !empty( $options['usePreloading'] ) ) {
-			$imgAttribs['data-src'] = $imgSrc;
-		}
-
 		// set valign for img tag
 		$imgAttribs['style'] = '';
 		if ( !empty( $options['valign'] ) ) {
@@ -178,6 +173,11 @@ class ThumbnailVideoController extends WikiaController {
 			}
 		}
 
+		// data-src attribute in case of lazy loading
+		if ( !empty( $options['usePreloading'] ) ) {
+			$this->dataSrc = $imgSrc;
+		}
+
 		// check fluid
 		if ( empty( $options[ 'fluid' ] ) ) {
 			$this->imgWidth = $width;
@@ -216,7 +216,8 @@ class ThumbnailVideoController extends WikiaController {
 
 	/**
 	 * Get attributes for mustache template
-	 * Note: wrap attributes in three curly braces to unescape html.
+	 * Don't use this for values that need to be escaped.
+	 * Wrap attributes in three curly braces so quote markes don't get escaped.
 	 * Ex: {{# attrs }}{{{ . }}} {{/ attrs }}
 	 * @param array $attrs [ array( key => value ) ]
 	 * @return array [ array( 'key="value"' ) ]
@@ -225,7 +226,7 @@ class ThumbnailVideoController extends WikiaController {
 		$attribs = [];
 		foreach ( $attrs as $key => $value ) {
 			$str = $key;
-			if ( $value ) {
+			if ( !empty( $value ) ) {
 				$str .= "=" . '"' . $value . '"';
 			}
 			$attribs[] = $str;

--- a/extensions/wikia/Thumbnails/templates/mustache/thumbnailVideo.mustache
+++ b/extensions/wikia/Thumbnails/templates/mustache/thumbnailVideo.mustache
@@ -1,20 +1,21 @@
 <a
-	href="{{ linkHref }}"
-	class="video wikia-video-thumbnail {{ size }} {{# linkClasses }}{{ . }} {{/ linkClasses }}"
-	{{# linkAttrs }}{{{ . }}} {{/ linkAttrs }}>
+	href="{{linkHref}}"
+	class="video wikia-video-thumbnail {{size}} {{#linkClasses}}{{.}} {{/linkClasses}}"
+	{{#linkAttrs}}{{{.}}} {{/linkAttrs}}>
 
 	<span class="play-circle"></span>
 
 	<img
-		src="{{ imgSrc }}"
-		{{# imgClass }}class="{{ imgClass }}"{{/ imgClass }}
-		data-video-key="{{ videoKey }}"
-		data-video-name="{{ videoName }}"
-		{{# imgWidth }} width="{{ imgWidth }}" {{/ imgWidth}}
-		{{# imgHeight }} height="{{ imgHeight }}" {{/ imgHeight}}
-		{{# imgAttrs }}{{{ . }}} {{/ imgAttrs }}>
+		src="{{imgSrc}}"
+		{{#imgClass}}class="{{imgClass}}"{{/imgClass}}
+		data-video-key="{{videoKey}}"
+		data-video-name="{{videoName}}"
+		{{#dataSrc}}data-src="{{dataSrc}}" {{/dataSrc}}
+		{{#imgWidth}}width="{{imgWidth}}" {{/imgWidth}}
+		{{#imgHeight}}height="{{imgHeight}}" {{/imgHeight}}
+		{{#imgAttrs}}{{{.}}} {{/imgAttrs}}>
 
-	<span class="duration" {{# durationAttrs }}{{{ . }}} {{/ durationAttrs }}>{{ duration }}</span>
+	<span class="duration" {{#durationAttrs}}{{{.}}} {{/durationAttrs}}>{{duration}}</span>
 
-	{{# metaAttrs }}<meta itemprop="{{itemprop}}" content="{{content}}">{{/ metaAttrs }}
+	{{#metaAttrs}}<meta itemprop="{{itemprop}}" content="{{content}}">{{/metaAttrs}}
 </a>

--- a/extensions/wikia/Thumbnails/templates/mustache/thumbnailVideo.mustache
+++ b/extensions/wikia/Thumbnails/templates/mustache/thumbnailVideo.mustache
@@ -1,7 +1,7 @@
 <a
 	href="{{ linkHref }}"
 	class="video wikia-video-thumbnail {{ size }} {{# linkClasses }}{{ . }} {{/ linkClasses }}"
-	{{# linkAttrs }}{{ . }} {{/ linkAttrs }}>
+	{{# linkAttrs }}{{{ . }}} {{/ linkAttrs }}>
 
 	<span class="play-circle"></span>
 
@@ -12,9 +12,9 @@
 		data-video-name="{{ videoName }}"
 		{{# imgWidth }} width="{{ imgWidth }}" {{/ imgWidth}}
 		{{# imgHeight }} height="{{ imgHeight }}" {{/ imgHeight}}
-		{{# imgAttrs }}{{ . }} {{/ imgAttrs }}>
+		{{# imgAttrs }}{{{ . }}} {{/ imgAttrs }}>
 
-	<span class="duration" {{# durationAttrs }}{{ . }} {{/ durationAttrs }}>{{ duration }}</span>
+	<span class="duration" {{# durationAttrs }}{{{ . }}} {{/ durationAttrs }}>{{ duration }}</span>
 
 	{{# metaAttrs }}<meta itemprop="{{itemprop}}" content="{{content}}">{{/ metaAttrs }}
 </a>


### PR DESCRIPTION
...tes around them

See screenshot for malformed html - there's single quotes inside the double quotes for itemscope, itemtype, etc. 
![screen shot 2014-02-12 at 6 31 40 pm](https://f.cloud.github.com/assets/201367/2156277/02ba5748-9457-11e3-9a21-6765afb03424.png)

@kenkouot @saipetch 
