### PR TITLE
BAC-1301: Don't purge history page as they're not cached on Varnish

### DIFF
--- a/includes/Title.php
+++ b/includes/Title.php
@@ -3351,7 +3351,7 @@ class Title {
 
 		$urls = array(
 			$this->getInternalURL(),
-			$this->getInternalURL( 'action=history' )
+			#$this->getInternalURL( 'action=history' ) # Wikia change - BAC-1157 / history pages are not cached on Varnish
 		);
 
 		// purge variant urls as well


### PR DESCRIPTION
Purges of history page are more than 20% of all purge requests in our queue. Remove them as they're not cached on Varnish:

```
$ curl -I "http://poznan.wikia.com/wiki/W%C4%85tek:25212?action=history" -s | grep -i "Cache-Control"
X-Cacheable: NO:Cache-Control=private
Cache-Control: private, s-maxage=0, max-age=0, must-revalidate
```

@michalroszka / @prein 
