### PR TITLE
Remove Akamai-related code

### DIFF
--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -18,24 +18,6 @@ if( !defined( 'MEDIAWIKI' ) ) {
 }
 
 /**
- * @name wgAkamaiGlobalVersion
- *
- * this variable is used for purging all images on akamai. increasing this value
- * will expire (change all image links) on all wikis
- */
-$wgAkamaiGlobalVersion = 1;
-
-/**
- * @name wgAkamaiLocalVersion
- *
- * this variable is used for purging all images on akamai for one particular
- * wiki. Here is just initialization, if you want to change value of this variable
- * you should use WikiFactory interface. By default it is equal global version
- */
-$wgAkamaiLocalVersion = $wgAkamaiGlobalVersion;
-
-
-/**
  * @name $wgCityId
  *
  * contains wiki identifier from city_list table. If wiki is not from wiki.factory

--- a/includes/wikia/GlobalFunctions.php
+++ b/includes/wikia/GlobalFunctions.php
@@ -138,15 +138,6 @@ function wfReplaceImageServer( $url, $timestamp = false ) {
 					Wikia::log( __METHOD__, "", "BAD FOR CACHING!: There is a call to ".__METHOD__." without a timestamp and we could not parse a fallback cache-busting number out of wgCdnStylePath.  This means the '{$url}' image won't be cacheable!");
 					$timestamp = rand(0, 1000);
 				}
-			} else if(strtotime($timestamp) > strtotime("now -10 minute")){
-				// To prevent a race-condition, if the image is less than 10 minutes old, don't use cb-value.
-				// This will cause Akamai to only cache for 30 seconds.
-				$timestamp = "";
-			}
-
-			// Add Akamai versions, but only if there is some sort of caching number.
-			if($timestamp != ""){
-				$timestamp += $wg->AkamaiGlobalVersion + $wg->AkamaiLocalVersion;
 			}
 
 			// NOTE: This should be the only use of the cache-buster which does not use $wg->CdnStylePath.

--- a/includes/wikia/tests/ReplaceImageServerTest.php
+++ b/includes/wikia/tests/ReplaceImageServerTest.php
@@ -14,9 +14,6 @@ class ReplaceImageServerTest extends WikiaBaseTest {
 
 		$this->mockGlobalVariable('wgCdnStylePath', sprintf('http://slot1.images.wikia.nocookie.net/__cb%s/common', self::DEFAULT_CB));
 		$this->mockGlobalVariable('wgImagesDomainSharding', 'images%s.wikia.nocookie.net');
-
-		$this->mockGlobalVariable('wgAkamaiGlobalVersion', 0);
-		$this->mockGlobalVariable('wgAkamaiLocalVersion', 0);
 	}
 
 	/**


### PR DESCRIPTION
Revert 9b54b2ca20f6996bad76a4901715c6e0a881bd9b

This removes the logic that prevents adding cache buster value to the URL if the image is less than 10 minutes old. Images with URLs without cb value are cached only for 5 minutes.

Cleanup:
- remove `$wgAkamaiGlobalVersion`
- remove `$wgAkamaiLocalVersion`

@prein / @michalroszka / @ljagiello 
