### PR TITLE
opensearch: remove Expires and X-Pass-Expires response headers

### DIFF
--- a/opensearch_desc.php
+++ b/opensearch_desc.php
@@ -21,9 +21,7 @@ $response->header( "Content-type: $ctype" );
 // Set an Expires header so that squid can cache it for a short time
 // Short enough so that the sysadmin barely notices when $wgSitename is changed
 $expiryTime = 86400; // 1 day
-// Note: We changed varnish to pass through X-Pass-Expires and X-Pass-Cache-Control to the client
-$response->header( 'Expires: ' . gmdate( 'D, d M Y H:i:s', time() + $expiryTime ) . ' GMT' );
-$response->header( 'X-Pass-Expires: ' . gmdate( 'D, d M Y H:i:s', time() + $expiryTime ) . ' GMT' );
+// Note: We changed varnish to pass through X-Pass-Cache-Control to the client
 $response->header( "Cache-Control: max-age=$expiryTime" );
 $response->header( "X-Pass-Cache-Control: max-age=$expiryTime" );
 


### PR DESCRIPTION
@prein / @michalroszka 

Reverts 0e05254dd8eab1b5ac5efa29e9168081bcae806f
