### PR TITLE
PLA-1145 disabling cache purge for article API (backporting to release)

### DIFF
--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -123,8 +123,6 @@ $wgWikiaAPIControllers = array();
 include_once( "$IP/lib/vendor/ApiGate/config.php" );
 
 //Wikia API Hooks
-$wgHooks['ArticleUpdateCategoryCounts'][] = 'ArticlesApiController::onArticleUpdateCategoryCounts';
-
 $wgAutoloadClasses[ 'ApiHooks'] =  "{$IP}/includes/wikia/api/ApiHooks.class.php" ;
 
 $wgHooks['WikiFactoryChanged'][] = 'ApiHooks::onWikiFactoryChanged';

--- a/includes/wikia/api/ArticlesApiController.class.php
+++ b/includes/wikia/api/ArticlesApiController.class.php
@@ -765,23 +765,6 @@ class ArticlesApiController extends WikiaApiController {
 	}
 
 	/**
-	 * @private
-	 */
-	static function onArticleUpdateCategoryCounts( $this, $added, $deleted ) {
-		foreach ( $added + $deleted as $cat) {
-			WikiaDataAccess::cachePurge( self::getCacheKey( $cat, self::CATEGORY_CACHE_ID ) );
-
-			$param = array(
-				'category' => $cat
-			);
-
-			self::purgeMethods( [['getTop', $param], ['getList', $param]] );
-		}
-
-		return true;
-	}
-
-	/**
 	 * @param $category
 	 * @return array|null|string
 	 */


### PR DESCRIPTION
WikiaDataAccess::cachePurge( self::getCacheKey( $cat, self::CATEGORY_CACHE_ID ) ); is purging wrong keys anyways. If we need better consistency sematntics of getTop and getList endpoints we need to do significant work and we would consider this a feature request.

Backporting #2802 

@ArturD / @prein / @michalroszka 
