### PR TITLE
VID-1332 adding languages to the i18n file for the VideosModule

### DIFF
--- a/extensions/wikia/VideosModule/VideosModule.i18n.php
+++ b/extensions/wikia/VideosModule/VideosModule.i18n.php
@@ -26,7 +26,7 @@ $messages['ja'] = array(
  * Chinese
  */
 $messages['zh'] = array(
-	'videosmodule-title-default' => ' 必看视频',
+	'videosmodule-title-default' => '必看视频',
 );
 
 /**

--- a/extensions/wikia/VideosModule/VideosModule.i18n.php
+++ b/extensions/wikia/VideosModule/VideosModule.i18n.php
@@ -15,3 +15,79 @@ $messages['qqq'] = array(
 	'videosmodule-title-trending' => 'Title for the videos suggestion module showing only trending content',
 );
 
+/**
+ * Japanese
+ */
+$messages['jp'] = array(
+	'videosmodule-title-default' => 'ビデオでチェック',
+);
+
+/**
+ * Chinese
+ */
+$messages['zh'] = array(
+	'videosmodule-title-default' => ' 必看视频',
+);
+
+/**
+ * Portugueses
+ */
+$messages['pt'] = array(
+	'videosmodule-title-default' => 'Vídeos para assistir',
+);
+
+/**
+ * Spanish
+ */
+$messages['es'] = array(
+	'videosmodule-title-default' => 'Videos que se deben ver',
+);
+
+/**
+ * German
+ */
+$messages['de'] = array(
+	'videosmodule-title-default' => 'Videos, die gesehen werden müssen',
+);
+
+/**
+ * Russian
+ */
+$messages['ru'] = array(
+	'videosmodule-title-default' => 'Обязаны посмотреть видео',
+);
+
+/**
+ * Dutch
+ */
+$messages['nl'] = array(
+	'videosmodule-title-default' => 'Video\'s die je moet zien',
+);
+
+/**
+ * Italian
+ */
+$messages['it'] = array(
+	'videosmodule-title-default' => 'Devi guardare i video',
+);
+
+/**
+ * Polish
+ */
+$messages['pl'] = array(
+	'videosmodule-title-default' => 'Filmy wideo, które musisz obejrzeć',
+);
+
+/**
+ * French
+ */
+$messages['fr'] = array(
+	'videosmodule-title-default' => 'Vidéos incontournables',
+);
+
+/**
+ * Norwegian
+ */
+$messages['nb'] = array(
+	'videosmodule-title-default' => 'Videoer man må se',
+);

--- a/extensions/wikia/VideosModule/VideosModule.i18n.php
+++ b/extensions/wikia/VideosModule/VideosModule.i18n.php
@@ -18,7 +18,7 @@ $messages['qqq'] = array(
 /**
  * Japanese
  */
-$messages['jp'] = array(
+$messages['ja'] = array(
 	'videosmodule-title-default' => 'ビデオでチェック',
 );
 


### PR DESCRIPTION
Just copied and pasted from the ticket.  

It's weird that when I try ?uselang=jp and ?uselang=xh the i18n messages still show up in english, but when I use 'de' and 'es' the messages are translated. Not sure what's going on there, but I don't think it has to do with this ticket. 
