### PR TITLE
(CE-615) Cleanup i18n in WikiaNewFiles

### DIFF
--- a/extensions/wikia/WikiaNewFiles/SpecialNewFiles.i18n.php
+++ b/extensions/wikia/WikiaNewFiles/SpecialNewFiles.i18n.php
@@ -8,15 +8,19 @@
 $messages = array();
 
 $messages['en'] = array(
+	'wikianewfiles-title' => 'New photos on this wiki',
 	'wikianewfiles-desc' => 'Extends a [[Special:NewFiles|special page]] to override some of the header formatting',
-	'wikianewfiles-uploadby' => 'by $1',
+	'wikianewfiles-uploadby' => 'by {{GENDER:$2|$1}}',
 	'wikianewfiles-postedin' => 'Posted in',
 	'wikianewfiles-more' => 'more...',
 );
 
 $messages['qqq'] = array(
-	'wikianewfiles-desc' => 'This is the description of the extension',
-	'wikianewfiles-uploadby' => 'Text displayed below a file to indicate which user uploaded the file',
+	'wikianewfiles-title' => 'Title of the special page.',
+	'wikianewfiles-desc' => '{{desc}}',
+	'wikianewfiles-uploadby' => 'Text displayed below a file to indicate which user uploaded the file.
+* $1 is a link to the user page of the user who uploaded the file.
+* $2 is the user name for GENDER support.',
 	'wikianewfiles-postedin' => 'Text displayed below a file to indicate which articles the file is posted in.',
 	'wikianewfiles-more' => 'Text displayed when there are more articles the file is posted in.',
 );

--- a/extensions/wikia/WikiaNewFiles/SpecialNewFiles.php
+++ b/extensions/wikia/WikiaNewFiles/SpecialNewFiles.php
@@ -160,17 +160,17 @@ function wfSpecialWikiaNewFiles ( $par, $specialPage ) {
 			$moreFiles = false;
 		}
 
-		$caption = wfMessage( 'wikianewfiles-uploadby' )->rawParams( $ul )->escaped() . "<br />\n" .
+		$caption = wfMessage( 'wikianewfiles-uploadby' )->rawParams( $ul )->params( $ut )->escaped() . "<br />\n" .
 				  "<i>$timeago</i><br />\n";
 
 		if ( count( $links ) ) {
-			$caption .= wfMessage( 'wikianewfiles-postedin' )->plain() . "&nbsp;" . $links[0];
+			$caption .= wfMessage( 'wikianewfiles-postedin' )->escaped() . "&nbsp;" . $links[0];
 		}
 
 		if ( $moreFiles ) {
 			$caption .= ", " . '<a href="' . $nt->getLocalUrl() .
 			'#filelinks" class="wikia-gallery-item-more">' .
-			wfMessage( 'wikianewfiles-more' )->plain() . '</a>';
+			wfMessage( 'wikianewfiles-more' )->escaped() . '</a>';
 		}
 
 		$gallery->add( $nt, $caption );
@@ -190,11 +190,11 @@ function wfSpecialWikiaNewFiles ( $par, $specialPage ) {
 		$wgOut->addHTML(
 			Xml::openElement( 'form', array( 'action' => $action, 'method' => 'post', 'id' => 'imagesearch' ) ) .
 			Xml::fieldset( wfMessage( 'newimages-legend' )->plain() ) .
-			Xml::inputLabel( wfMessage( 'newimages-label' )->escaped(), 'wpIlMatch', 'wpIlMatch', 20, $wpIlMatch ) . ' ' .
+			Xml::inputLabel( wfMessage( 'newimages-label' )->plain(), 'wpIlMatch', 'wpIlMatch', 20, $wpIlMatch ) . ' ' .
 			Xml::submitButton( wfMessage( 'ilsubmit' )->plain(), array( 'name' => 'wpIlSubmit' ) ) .
 			Xml::closeElement( 'fieldset' ) .
 			Xml::closeElement( 'form' )
-		 );
+		);
 	}
 
 	/**
@@ -217,13 +217,11 @@ function wfSpecialWikiaNewFiles ( $par, $specialPage ) {
 		'from=' . $now . $botpar . $searchpar );
 
 	$botLink = Linker::link( $titleObj,
-						 wfMessage( 'showhidebots' )->rawParams( $hidebots ? wfMessage( 'show' )->plain() : wfMessage( 'hide' )->plain() )->escaped(),
+						 wfMessage( 'showhidebots', $hidebots ? wfMessage( 'show' )->plain() : wfMessage( 'hide' )->plain() )->escaped(),
 						 array( 'class' => 'navigation-' . ( $hidebots ? 'showbots' : 'hidebots' ) ),
 						 'hidebots=' . ( $hidebots ? '0' : '1' ) . $searchpar );
 
-
-	$opts = array( 'parsemag', 'escapenoentities' );
-	$prevLink = wfMessage( 'pager-newer-n', $opts, $wgLang->formatNum( $limit ) )->text();
+	$prevLink = wfMessage( 'pager-newer-n', $wgLang->formatNum( $limit ) )->escaped();
 	if ( $firstTimestamp && $firstTimestamp != $latestTimestamp ) {
 		$wmu['prev'] = $firstTimestamp;
 		$prevLink = Linker::link( $titleObj, $prevLink,
@@ -231,7 +229,7 @@ function wfSpecialWikiaNewFiles ( $par, $specialPage ) {
 							   'from=' . $firstTimestamp . $botpar . $searchpar );
 	}
 
-	$nextLink = wfMessage( 'pager-older-n', $opts, $wgLang->formatNum( $limit ) )->text();
+	$nextLink = wfMessage( 'pager-older-n', $wgLang->formatNum( $limit ) )->escaped();
 	if ( $shownImages > $limit && $lastTimestamp ) {
 		$wmu['next'] = $lastTimestamp;
 		$nextLink = Linker::link( $titleObj, $nextLink,

--- a/extensions/wikia/WikiaNewFiles/WikiaNewFiles.class.php
+++ b/extensions/wikia/WikiaNewFiles/WikiaNewFiles.class.php
@@ -18,6 +18,6 @@ class WikiaNewFiles extends SpecialNewFiles {
 	 * @see SpecialPage::getDescription
 	 */
 	public function getDescription() {
-		return wfMessage( 'wikianewfiles-title' )->text();
+		return $this->msg( 'wikianewfiles-title' )->text();
 	}
 }

--- a/languages/messages/wikia/MessagesEn.php
+++ b/languages/messages/wikia/MessagesEn.php
@@ -895,8 +895,6 @@ Text should be placed on this page if you wish to explain usage, style and polic
 # Button labels
 'button-createpage' => 'Add a Page',
 
-'wikianewfiles-title' => 'New photos on this wiki',
-
 # Hub names
 'hub-Entertainment' => 'Entertainment',
 'hub-Gaming' => 'Video Games',


### PR DESCRIPTION
Cleanup i18n in WikiaNewFiles in preparation for review by TWN.
- Add wikianewfiles-title to i18n file, which is used in the
  WikiaNewFiles.class.php but was defined in our main messages file
  for some reason.
- Corrected escaping of messages being outputted as HTML, and remove
  instance of double escaping.
- Fix message that was still using old wfMsg options as a second
  parameter which resulted in "older parsemag" and "newer parsemag"
  as the output rather than the correct number
- Add GENDER support to wikianewfiles-uploadby

@garthwebb @saipetch 
