### PR TITLE
BAC-1319: Make resource loader output X-Served-by header

### DIFF
--- a/includes/resourceloader/ResourceLoader.php
+++ b/includes/resourceloader/ResourceLoader.php
@@ -559,6 +559,7 @@ class ResourceLoader {
 			}
 		}
 
+		wfRunHooks( 'ResourceLoaderAfterRespond',[ $this,&$context ] ); // Wikia change - @author: macbre
 		wfProfileOut( __METHOD__ );
 	}
 


### PR DESCRIPTION
```
$ curl -I "http://poznan.macbre.wikia-dev.com/__load/-/cb%3D123456%26debug%3Dfalse%26lang%3Dpl%26only%3Dscripts%26skin%3Doasis/wikia.ext.abtesting" -s | grep -E "X-Served-By|X-Backend-Response-Time"
X-Backend-Response-Time: 0.149
X-Served-By: dev-macbre, cache-s24-SJC, cache-fra1227-FRA
```

ResourceLoader will respond with the same set of headers as added in #2587 

@prein / @michalroszka 
