### PR TITLE
Conn 430 - clean up of varnish purge requests list

### DIFF
--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -877,21 +877,7 @@ class ArticleComment {
 
 		// Purge squid proxy URLs for ajax loaded content if we are lazy loading
 		if ( !empty( $wgArticleCommentsLoadOnDemand ) ) {
-			$urls = array();
-			$articleId = $title->getArticleId();
-
-			// Only page 1 is cached in varnish when lazy loading is on
-			// Other pages load with action=ajax&rs=ArticleCommentsAjax&method=axGetComments
-			$urls[] = ArticleCommentsController::getUrl(
-				'Content',
-				array(
-					'format' => 'html',
-					'articleId' => $articleId,
-					'page' => 1,
-					'skin' => 'true'
-				)
-			);
-
+			$urls = self::getSquidURLs( $title );
 			$squidUpdate = new SquidUpdate( $urls );
 			$squidUpdate->doUpdate();
 
@@ -909,6 +895,30 @@ class ArticleComment {
 		}
 
 		wfProfileOut( __METHOD__ );
+	}
+
+	/**
+	 * @param Title $title
+	 */
+	public static function getSquidURLs( $title ) {
+		$urls = [];
+		$articleId = $title->getArticleId();
+
+		// Only page 1 is cached in varnish when lazy loading is on
+		// Other pages load with action=ajax&rs=ArticleCommentsAjax&method=axGetComments
+		$urls[] = ArticleCommentsController::getUrl(
+			'Content',
+			array(
+				'format' => 'html',
+				'articleId' => $articleId,
+				'page' => 1,
+				'skin' => 'true'
+			)
+		);
+
+		wfRunHooks( 'ArticleCommentGetSquidURLs', array( $title, &$urls ) );
+
+		return $urls;
 	}
 
 	/**

--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -900,7 +900,7 @@ class ArticleComment {
 	/**
 	 * @param Title $title
 	 */
-	public static function getSquidURLs( $title ) {
+	public static function getSquidURLs( Title $title ) {
 		$urls = [];
 		$articleId = $title->getArticleId();
 

--- a/extensions/wikia/Forum/Forum.setup.php
+++ b/extensions/wikia/Forum/Forum.setup.php
@@ -81,6 +81,7 @@ $wgHooks['LinkBegin'][] = 'ForumHooksHelper::onLinkBegin';
 
 // Fix URLs of thread pages when purging them.
 $wgHooks['TitleGetSquidURLs'][] = 'ForumHooksHelper::onTitleGetSquidURLs';
+$wgHooks['ArticleCommentGetSquidURLs'][] = 'ForumHooksHelper::onArticleCommentGetSquidURLs';
 
 include ($dir . '/Forum.namespace.setup.php');
 

--- a/extensions/wikia/Forum/Forum.setup.php
+++ b/extensions/wikia/Forum/Forum.setup.php
@@ -45,7 +45,6 @@ $wgHooks['WallHistoryHeader'][] = 'ForumHooksHelper::onWallHistoryHeader';
 
 $wgHooks['WallHeader'][] = 'ForumHooksHelper::onWallHeader';
 $wgHooks['WallNewMessage'][] = 'ForumHooksHelper::onWallNewMessage';
-$wgHooks['EditCommentsIndex'][] = 'ForumHooksHelper::onEditCommentsIndex';
 $wgHooks['ArticleInsertComplete'][] = 'ForumHooksHelper::onArticleInsertComplete';
 $wgHooks['WallBeforeRenderThread'][] = 'ForumHooksHelper::onWallBeforeRenderThread';
 $wgHooks['AfterBuildNewMessageAndPost'][] = 'ForumHooksHelper::onAfterBuildNewMessageAndPost';

--- a/extensions/wikia/Forum/ForumExternalController.class.php
+++ b/extensions/wikia/Forum/ForumExternalController.class.php
@@ -172,6 +172,10 @@ class ForumExternalController extends WallExternalController {
 			return true;
 		}
 
+		/**
+		 * @var ForumBoard $board
+		 * @var ForumBoard $destinationBoard
+		 */
 		$board = ForumBoard::newFromId( $boardId );
 		$destinationBoard = ForumBoard::newFromId( $destinationBoardId );
 

--- a/extensions/wikia/Forum/ForumHooksHelper.class.php
+++ b/extensions/wikia/Forum/ForumHooksHelper.class.php
@@ -378,12 +378,14 @@ class ForumHooksHelper {
 
 		if ( $title->inNamespaces( NS_WIKIA_FORUM_BOARD_THREAD, NS_WIKIA_FORUM_TOPIC_BOARD ) ) {
 			$wallMessage = WallMessage::newFromTitle( $title );
+			$wallMessage->load( true );
 
 			// CONN-426: Purge cache only for main thread page
 			if ( $wallMessage->isMain() ) {
 				$urls[] = $wallMessage->getMessagePageUrl( true );
 			} else {
 				$wallMessage = $wallMessage->getTopParentObj();
+				$wallMessage->load( true );
 				$urls[] = $wallMessage->getMessagePageUrl( true );
 			}
 

--- a/extensions/wikia/Forum/ForumHooksHelper.class.php
+++ b/extensions/wikia/Forum/ForumHooksHelper.class.php
@@ -378,7 +378,6 @@ class ForumHooksHelper {
 
 		if ( $title->inNamespaces( NS_WIKIA_FORUM_BOARD_THREAD, NS_WIKIA_FORUM_TOPIC_BOARD ) ) {
 			$wallMessage = WallMessage::newFromTitle( $title );
-			$wallMessage->load( true );
 			$urls = array_merge( $urls, $wallMessage->getSquidURLs( NS_WIKIA_FORUM_BOARD ) );
 		}
 

--- a/extensions/wikia/Forum/ForumHooksHelper.class.php
+++ b/extensions/wikia/Forum/ForumHooksHelper.class.php
@@ -202,27 +202,6 @@ class ForumHooksHelper {
 		return true;
 	}
 
-	// Hook: clear cache when editing comment
-	static public function onEditCommentsIndex($title, $commentsIndex) {
-		if ( $title->getNamespace() == NS_WIKIA_FORUM_BOARD_THREAD ) {
-			$parentPageId = $commentsIndex->getParentPageId();
-
-			$board = ForumBoard::newFromId( $parentPageId );
-			if ( $board instanceof ForumBoard ) {
-				$board->clearCacheBoardInfo();
-			} else {
-				Wikia::log(
-					__METHOD__,
-					'',
-					'Board doesn\'t exist: PageId: ' . $parentPageId .
-					' Title: ' . $title->getText()
-				);
-			}
-		}
-
-		return true;
-	}
-
 	/**
 	 * Hook: add comments_index table when adding board
 	 */
@@ -374,17 +353,9 @@ class ForumHooksHelper {
 				return true;
 			}
 
-			$board->clearCacheBoardInfo();
-
 			$thread = WallThread::newFromId( $threadId );
-			if(!empty($thread)) {
+			if( !empty($thread) ) {
 				$thread->purgeLastMessage();
-				$threadTitle = Title::newFromId( $threadId );
-				// the title can be empty if this is a create action
-				if ( !empty( $threadTitle ) ) {
-					$threadTitle->purgeSquid();
-					$threadTitle->invalidateCache();
-				}
 			}
 		}
 		return true;
@@ -398,15 +369,32 @@ class ForumHooksHelper {
 	 * @return bool
 	 */
 	public static function onTitleGetSquidURLs( $title, &$urls ) {
-		if ( $title->inNamespace( NS_WIKIA_FORUM_BOARD_THREAD ) ) {
+		wfProfileIn( __METHOD__ );
+
+		if( $title->inNamespaces( NS_WIKIA_FORUM_BOARD, NS_WIKIA_FORUM_BOARD_THREAD, NS_WIKIA_FORUM_TOPIC_BOARD ) ) {
+			// CONN-430: Resign from default ArticleComment purges
+			$urls = [];
+		}
+
+		if ( $title->inNamespaces( NS_WIKIA_FORUM_BOARD_THREAD, NS_WIKIA_FORUM_TOPIC_BOARD ) ) {
 			$wallMessage = WallMessage::newFromTitle( $title );
-			$urls = array();
-			// CONN-426: Purge cache only for main thread page. When a reply is added, the main page is also updated so
-			// we should prevent replies from being added for purging
+
+			// CONN-426: Purge cache only for main thread page
 			if ( $wallMessage->isMain() ) {
 				$urls[] = $wallMessage->getMessagePageUrl( true );
+			} else {
+				$wallMessage = $wallMessage->getTopParentObj();
+				$urls[] = $wallMessage->getMessagePageUrl( true );
+			}
+
+			// CONN-430: Purge board page
+			$boardTitle = Title::newFromText( $wallMessage->getMainPageText(), NS_WIKIA_FORUM_BOARD );
+			if( !empty( $boardTitle ) ) {
+				$urls[] = $boardTitle->getFullURL();
 			}
 		}
+
+		wfProfileOut( __METHOD__ );
 		return true;
 	}
 
@@ -419,11 +407,14 @@ class ForumHooksHelper {
 	 * @return bool
 	 */
 	public static function onArticleCommentGetSquidURLs( $title, &$urls ) {
+		wfProfileIn( __METHOD__ );
+
 		if( $title->inNamespaces( NS_WIKIA_FORUM_BOARD, NS_WIKIA_FORUM_BOARD_THREAD, NS_WIKIA_FORUM_TOPIC_BOARD ) ) {
 			// CONN-430: Resign from default ArticleComment purges
 			$urls = [];
 		}
 
+		wfProfileOut( __METHOD__ );
 		return true;
 	}
 

--- a/extensions/wikia/Forum/ForumHooksHelper.class.php
+++ b/extensions/wikia/Forum/ForumHooksHelper.class.php
@@ -411,6 +411,23 @@ class ForumHooksHelper {
 	}
 
 	/**
+	 * @desc Makes sure we don't send unnecessary ArticleComments links to purge
+	 *
+	 * @param Title $title
+	 * @param String[] $urls
+	 *
+	 * @return bool
+	 */
+	public static function onArticleCommentGetSquidURLs( $title, &$urls ) {
+		if( $title->inNamespaces( NS_WIKIA_FORUM_BOARD, NS_WIKIA_FORUM_BOARD_THREAD, NS_WIKIA_FORUM_TOPIC_BOARD ) ) {
+			// CONN-430: Resign from default ArticleComment purges
+			$urls = [];
+		}
+
+		return true;
+	}
+
+	/**
 	 * just proxy to onWallStoreRelatedTopicsInDB
 	 */
 	static public function onWallStoreRelatedTopicsInDB($parent, $id, $namespace) {

--- a/extensions/wikia/Forum/ForumHooksHelper.class.php
+++ b/extensions/wikia/Forum/ForumHooksHelper.class.php
@@ -379,21 +379,7 @@ class ForumHooksHelper {
 		if ( $title->inNamespaces( NS_WIKIA_FORUM_BOARD_THREAD, NS_WIKIA_FORUM_TOPIC_BOARD ) ) {
 			$wallMessage = WallMessage::newFromTitle( $title );
 			$wallMessage->load( true );
-
-			// CONN-426: Purge cache only for main thread page
-			if ( $wallMessage->isMain() ) {
-				$urls[] = $wallMessage->getMessagePageUrl( true );
-			} else {
-				$wallMessage = $wallMessage->getTopParentObj();
-				$wallMessage->load( true );
-				$urls[] = $wallMessage->getMessagePageUrl( true );
-			}
-
-			// CONN-430: Purge board page
-			$boardTitle = Title::newFromText( $wallMessage->getMainPageText(), NS_WIKIA_FORUM_BOARD );
-			if( !empty( $boardTitle ) ) {
-				$urls[] = $boardTitle->getFullURL();
-			}
+			$urls = array_merge( $urls, $wallMessage->getSquidURLs( NS_WIKIA_FORUM_BOARD ) );
 		}
 
 		wfProfileOut( __METHOD__ );

--- a/extensions/wikia/GameGuides/GameGuidesController.class.php
+++ b/extensions/wikia/GameGuides/GameGuidesController.class.php
@@ -27,7 +27,7 @@ class GameGuidesController extends WikiaController {
 	private $mModel = null;
 	private $mPlatform = null;
 	//Make sure this is updated as in GameGuides.js
-	private static $disabledNamespaces = [-2, -1, 1, 2, 3, 4, 5, 6, 7, 10, 11, 12, 13, 15, 110, 111, 500, 501, 700, 701, 1200, 1201, 1202];
+	private static $disabledNamespaces = [ -2, -1, 1, 2, 3, 4, 5, 6, 7, 10, 11, 12, 13, 15, 110, 111, 500, 501, 700, 701, 1200, 1201, 1202, 2000, 2001, 2002 ];
 
 	function init() {
 		$requestedVersion = $this->request->getInt( 'ver', self::API_VERSION );

--- a/extensions/wikia/GameGuides/GameGuidesController.class.php
+++ b/extensions/wikia/GameGuides/GameGuidesController.class.php
@@ -27,7 +27,40 @@ class GameGuidesController extends WikiaController {
 	private $mModel = null;
 	private $mPlatform = null;
 	//Make sure this is updated as in GameGuides.js
-	private static $disabledNamespaces = [ -2, -1, 1, 2, 3, 4, 5, 6, 7, 10, 11, 12, 13, 15, 110, 111, 500, 501, 700, 701, 1200, 1201, 1202, 2000, 2001, 2002 ];
+	private static $disabledNamespaces = [
+		// Core MediaWiki
+		-2,
+		-1,
+		1,
+		2,
+		3,
+		4,
+		5,
+		6,
+		7,
+		10,
+		11,
+		12,
+		13,
+		15,
+		// Forum
+		110,
+		111,
+		// Blog
+		500,
+		501,
+		// Top List
+		700,
+		701,
+		// Wall
+		1200,
+		1201,
+		1202,
+		// Wikia Forum
+		2000,
+		2001,
+		2002,
+	];
 
 	function init() {
 		$requestedVersion = $this->request->getInt( 'ver', self::API_VERSION );

--- a/extensions/wikia/Wall/Wall.setup.php
+++ b/extensions/wikia/Wall/Wall.setup.php
@@ -157,6 +157,9 @@ $wgHooks['SkinTemplateToolboxEnd'][] = 'WallHooksHelper::onBuildMonobookToolbox'
 // Hook for code that wants a beautified title and URL given the not very readable Wall/Forum title
 $wgHooks['FormatForumLinks'][] = 'WallHooksHelper::onFormatForumLinks';
 
+// Fix URLs when purging after adding a thread/post
+$wgHooks['TitleGetSquidURLs'][] = 'WallHooksHelper::onTitleGetSquidURLs';
+
 JSMessages::registerPackage('Wall', array(
 	'wall-notifications',
 	'wall-notifications-reminder',

--- a/extensions/wikia/Wall/Wall.setup.php
+++ b/extensions/wikia/Wall/Wall.setup.php
@@ -159,6 +159,7 @@ $wgHooks['FormatForumLinks'][] = 'WallHooksHelper::onFormatForumLinks';
 
 // Fix URLs when purging after adding a thread/post
 $wgHooks['TitleGetSquidURLs'][] = 'WallHooksHelper::onTitleGetSquidURLs';
+$wgHooks['ArticleCommentGetSquidURLs'][] = 'WallHooksHelper::onArticleCommentGetSquidURLs';
 
 JSMessages::registerPackage('Wall', array(
 	'wall-notifications',

--- a/extensions/wikia/Wall/WallExternalController.class.php
+++ b/extensions/wikia/Wall/WallExternalController.class.php
@@ -293,6 +293,7 @@ class WallExternalController extends WikiaController {
 		if($isDeleteOrRemove) {
 			$this->response->setVal('html', $this->app->renderView( 'WallController', 'messageRemoved', array('showundo' => true , 'comment' => $mw)));
 			$mw->getLastActionReason();
+			$mw->purgeSquid();
 			$this->response->setVal('deleteInfoBox', 'INFO BOX');
 		}
 
@@ -320,11 +321,13 @@ class WallExternalController extends WikiaController {
 			case 'close':
 				if($mw->canArchive($this->wg->User)) {
 					$result = $mw->archive($this->wg->User, $reason);
+					$mw->purgeSquid();
 				}
 				break;
 			case 'open':
 				if($mw->canReopen($this->wg->User)) {
 					$result = $mw->reopen($this->wg->User);
+					$mw->purgeSquid();
 				}
 				break;
 			default:
@@ -375,6 +378,7 @@ class WallExternalController extends WikiaController {
 
 		){
 			$mw->restore($this->wg->User);
+			$mw->purgeSquid();
 			$this->response->setVal('status', true);
 			return true;
 		}
@@ -401,6 +405,7 @@ class WallExternalController extends WikiaController {
 			}
 
 			$mw->restore($this->wg->User, $reason);
+			$mw->purgeSquid();
 
 			$this->response->setVal('buttons', $this->app->renderView( 'WallController', 'messageButtons', array('comment' => $mw)));
 			$this->response->setVal('status', true);

--- a/extensions/wikia/Wall/WallHooksHelper.class.php
+++ b/extensions/wikia/Wall/WallHooksHelper.class.php
@@ -2209,6 +2209,7 @@ class WallHooksHelper {
 				$urls[] = $wallMessage->getMessagePageUrl( true );
 			} else {
 				$wallMessage = $wallMessage->getTopParentObj();
+				$wallMessage->load( true );
 				$urls[] = $wallMessage->getMessagePageUrl( true );
 			}
 

--- a/extensions/wikia/Wall/WallHooksHelper.class.php
+++ b/extensions/wikia/Wall/WallHooksHelper.class.php
@@ -2204,16 +2204,7 @@ class WallHooksHelper {
 			// while running AfterBuildNewMessageAndPost hook
 			$wallMessage = WallMessage::newFromTitle( $title );
 			$wallMessage->load( true );
-
-			if( $wallMessage->isMain() ) {
-				$urls[] = $wallMessage->getMessagePageUrl( true );
-			} else {
-				$wallMessage = $wallMessage->getTopParentObj();
-				$wallMessage->load( true );
-				$urls[] = $wallMessage->getMessagePageUrl( true );
-			}
-
-			$urls[] = $wallMessage->getUserWallUrl();
+			$urls = array_merge( $urls, $wallMessage->getSquidURLs( NS_USER_WALL ) );
 		}
 
 		wfProfileOut( __METHOD__ );

--- a/extensions/wikia/Wall/WallHooksHelper.class.php
+++ b/extensions/wikia/Wall/WallHooksHelper.class.php
@@ -2178,4 +2178,36 @@ class WallHooksHelper {
 
 		return true;
 	}
+
+	/**
+	 * Makes sure the correct URLs for thread pages get purged.
+	 *
+	 * @param $title Title
+	 * @param $urls String[]
+	 * @return bool
+	 */
+	public static function onTitleGetSquidURLs( $title, &$urls ) {
+		if( $title->inNamespace( NS_USER_WALL ) ||
+			$title->inNamespace( NS_USER_WALL_MESSAGE ) ||
+			$title->inNamespace( NS_USER_WALL_MESSAGE_GREETING )
+		) {
+		// CONN-430: Resign from default ArticleComment purges
+			$urls = [];
+		}
+
+		if ( $title->inNamespace( NS_USER_WALL_MESSAGE ) ||
+			$title->inNamespace( NS_USER_WALL_MESSAGE_GREETING )
+		) {
+		// CONN-430: purge cache only for main thread page and owner's wall page
+		// while running AfterBuildNewMessageAndPost hook
+			$wallMessage = WallMessage::newFromTitle( $title );
+			$wallMessage->load( true );
+
+			$urls[] = $wallMessage->getUserWallUrl();
+			$urls[] = $wallMessage->getMessagePageUrl( true );
+		}
+
+		return true;
+	}
+
 }

--- a/extensions/wikia/Wall/WallHooksHelper.class.php
+++ b/extensions/wikia/Wall/WallHooksHelper.class.php
@@ -2205,4 +2205,21 @@ class WallHooksHelper {
 		return true;
 	}
 
+	/**
+	 * @desc Makes sure we don't send unnecessary ArticleComments links to purge
+	 *
+	 * @param Title $title
+	 * @param String[] $urls
+	 *
+	 * @return bool
+	 */
+	public static function onArticleCommentGetSquidURLs( $title, &$urls ) {
+		if( $title->inNamespaces( NS_USER_WALL, NS_USER_WALL_MESSAGE, NS_USER_WALL_MESSAGE_GREETING ) ) {
+			// CONN-430: Resign from default ArticleComment purges
+			$urls = [];
+		}
+
+		return true;
+	}
+
 }

--- a/extensions/wikia/Wall/WallHooksHelper.class.php
+++ b/extensions/wikia/Wall/WallHooksHelper.class.php
@@ -2180,24 +2180,19 @@ class WallHooksHelper {
 	}
 
 	/**
-	 * Makes sure the correct URLs for thread pages get purged.
+	 * Makes sure the correct URLs for thread pages and message wall page get purged.
 	 *
 	 * @param $title Title
 	 * @param $urls String[]
 	 * @return bool
 	 */
 	public static function onTitleGetSquidURLs( $title, &$urls ) {
-		if( $title->inNamespace( NS_USER_WALL ) ||
-			$title->inNamespace( NS_USER_WALL_MESSAGE ) ||
-			$title->inNamespace( NS_USER_WALL_MESSAGE_GREETING )
-		) {
+		if( $title->inNamespaces( NS_USER_WALL, NS_USER_WALL_MESSAGE, NS_USER_WALL_MESSAGE_GREETING ) ) {
 		// CONN-430: Resign from default ArticleComment purges
 			$urls = [];
 		}
 
-		if ( $title->inNamespace( NS_USER_WALL_MESSAGE ) ||
-			$title->inNamespace( NS_USER_WALL_MESSAGE_GREETING )
-		) {
+		if ( $title->inNamespaces( NS_USER_WALL_MESSAGE, NS_USER_WALL_MESSAGE_GREETING ) ) {
 		// CONN-430: purge cache only for main thread page and owner's wall page
 		// while running AfterBuildNewMessageAndPost hook
 			$wallMessage = WallMessage::newFromTitle( $title );

--- a/extensions/wikia/Wall/WallHooksHelper.class.php
+++ b/extensions/wikia/Wall/WallHooksHelper.class.php
@@ -2020,7 +2020,12 @@ class WallHooksHelper {
 	}
 
 	/**
-	 * create needed tables
+	 * @desc Adds necessary tables if Wall or Forum has just been enabled in Special:WikiFeatures
+	 *
+	 * @param String $name
+	 * @param String $val
+	 *
+	 * @return bool
 	 */
 	public static function onAfterToggleFeature($name, $val) {
 		global $IP;
@@ -2187,6 +2192,8 @@ class WallHooksHelper {
 	 * @return bool
 	 */
 	public static function onTitleGetSquidURLs( $title, &$urls ) {
+		wfProfileIn( __METHOD__ );
+
 		if( $title->inNamespaces( NS_USER_WALL, NS_USER_WALL_MESSAGE, NS_USER_WALL_MESSAGE_GREETING ) ) {
 		// CONN-430: Resign from default ArticleComment purges
 			$urls = [];
@@ -2202,6 +2209,7 @@ class WallHooksHelper {
 			$urls[] = $wallMessage->getMessagePageUrl( true );
 		}
 
+		wfProfileOut( __METHOD__ );
 		return true;
 	}
 

--- a/extensions/wikia/Wall/WallHooksHelper.class.php
+++ b/extensions/wikia/Wall/WallHooksHelper.class.php
@@ -2195,18 +2195,24 @@ class WallHooksHelper {
 		wfProfileIn( __METHOD__ );
 
 		if( $title->inNamespaces( NS_USER_WALL, NS_USER_WALL_MESSAGE, NS_USER_WALL_MESSAGE_GREETING ) ) {
-		// CONN-430: Resign from default ArticleComment purges
+			// CONN-430: Resign from default ArticleComment purges
 			$urls = [];
 		}
 
 		if ( $title->inNamespaces( NS_USER_WALL_MESSAGE, NS_USER_WALL_MESSAGE_GREETING ) ) {
-		// CONN-430: purge cache only for main thread page and owner's wall page
-		// while running AfterBuildNewMessageAndPost hook
+			// CONN-430: purge cache only for main thread page and owner's wall page
+			// while running AfterBuildNewMessageAndPost hook
 			$wallMessage = WallMessage::newFromTitle( $title );
 			$wallMessage->load( true );
 
+			if( $wallMessage->isMain() ) {
+				$urls[] = $wallMessage->getMessagePageUrl( true );
+			} else {
+				$wallMessage = $wallMessage->getTopParentObj();
+				$urls[] = $wallMessage->getMessagePageUrl( true );
+			}
+
 			$urls[] = $wallMessage->getUserWallUrl();
-			$urls[] = $wallMessage->getMessagePageUrl( true );
 		}
 
 		wfProfileOut( __METHOD__ );

--- a/extensions/wikia/Wall/WallHooksHelper.class.php
+++ b/extensions/wikia/Wall/WallHooksHelper.class.php
@@ -2203,7 +2203,6 @@ class WallHooksHelper {
 			// CONN-430: purge cache only for main thread page and owner's wall page
 			// while running AfterBuildNewMessageAndPost hook
 			$wallMessage = WallMessage::newFromTitle( $title );
-			$wallMessage->load( true );
 			$urls = array_merge( $urls, $wallMessage->getSquidURLs( NS_USER_WALL ) );
 		}
 

--- a/extensions/wikia/Wall/WallMessage.class.php
+++ b/extensions/wikia/Wall/WallMessage.class.php
@@ -1444,10 +1444,41 @@ class WallMessage {
 		return ( $this->isMain() && !$this->isRemove() && $this->can($user, 'wallmessagemove') && in_array(MWNamespace::getSubject($this->title->getNamespace()), F::App()->wg->WallTopicsNS) );
 	}
 
+	/**
+	 * @desc Creates wall message title (a board, a thread, a message) instance and calls purgeSquid() on it
+	 * The flow then goes to TitleGetSquidURLs hook which cleans the list of URLs in Wall and Forum
+	 */
 	public function purgeSquid() {
 		$title = Title::newFromID( $this->getId() );
 		if ( $title instanceof Title ) {
 			$title->purgeSquid();
 		}
 	}
+
+	/**
+	 * @param Integer $namespace Message_Wall or Board namespace
+	 *
+	 * @return array
+	 */
+	public function getSquidURLs( $namespace ) {
+		$urls = [];
+
+		if( $this->isMain() ) {
+			$urls[] = $this->getMessagePageUrl( true );
+		} else {
+			/** @var WallMessage $parent */
+			$parent = $this->getTopParentObj();
+			$parent->load( true );
+			$urls[] = $parent->getMessagePageUrl( true );
+		}
+
+		// CONN-430: Purge wall page / forum board
+		$title = Title::newFromText( $this->getMainPageText(), $namespace );
+		if( !empty( $title ) ) {
+			$urls[] = $title->getFullURL();
+		}
+
+		return $urls;
+	}
+
 }

--- a/extensions/wikia/Wall/WallMessage.class.php
+++ b/extensions/wikia/Wall/WallMessage.class.php
@@ -1467,9 +1467,7 @@ class WallMessage {
 		// While creating a new forum board the message id === 0
 		// Therefore we're getting at this place invalid URLs to be purge
 		// To quick fix it we use $idDB variable...
-		$inDb = ( $this->getMessagePageId() > 0 );
-
-		if( $inDb ) {
+		if( $this->getMessagePageId() > 0 ) {
 			if( $this->isMain() ) {
 				$urls[] = $this->getMessagePageUrl( true );
 			} else {

--- a/extensions/wikia/Wall/WallMessage.class.php
+++ b/extensions/wikia/Wall/WallMessage.class.php
@@ -1443,4 +1443,11 @@ class WallMessage {
 	public function canMove(User $user) {
 		return ( $this->isMain() && !$this->isRemove() && $this->can($user, 'wallmessagemove') && in_array(MWNamespace::getSubject($this->title->getNamespace()), F::App()->wg->WallTopicsNS) );
 	}
+
+	public function purgeSquid() {
+		$title = Title::newFromID( $this->getId() );
+		if ( $title instanceof Title ) {
+			$title->purgeSquid();
+		}
+	}
 }

--- a/extensions/wikia/Wall/WallMessage.class.php
+++ b/extensions/wikia/Wall/WallMessage.class.php
@@ -551,8 +551,8 @@ class WallMessage {
 	}
 
 	public function getMessagePageUrl($withoutAnchor = false) {
-
 		wfProfileIn(__METHOD__);
+
 		//local cache consider cache this in memc
 		if(!empty($this->messagePageUrl)) {
 			wfProfileOut(__METHOD__);
@@ -560,7 +560,7 @@ class WallMessage {
 		}
 
 		$id = $this->getMessagePageId();
-
+		
 		$postFix = $this->getPageUrlPostFix();
 		$postFix = empty($postFix) ? "":('#'.$postFix);
 		$title = Title::newFromText($id, NS_USER_WALL_MESSAGE);
@@ -1462,20 +1462,28 @@ class WallMessage {
 	 */
 	public function getSquidURLs( $namespace ) {
 		$urls = [];
+		$this->load( true );
 
-		if( $this->isMain() ) {
-			$urls[] = $this->getMessagePageUrl( true );
-		} else {
-			/** @var WallMessage $parent */
-			$parent = $this->getTopParentObj();
-			$parent->load( true );
-			$urls[] = $parent->getMessagePageUrl( true );
-		}
+		// While creating a new forum board the message id === 0
+		// Therefore we're getting at this place invalid URLs to be purge
+		// To quick fix it we use $idDB variable...
+		$inDb = ( $this->getMessagePageId() > 0 );
 
-		// CONN-430: Purge wall page / forum board
-		$title = Title::newFromText( $this->getMainPageText(), $namespace );
-		if( !empty( $title ) ) {
-			$urls[] = $title->getFullURL();
+		if( $inDb ) {
+			if( $this->isMain() ) {
+				$urls[] = $this->getMessagePageUrl( true );
+			} else {
+				/** @var WallMessage $parent */
+				$parent = $this->getTopParentObj();
+				$parent->load( true );
+				$urls[] = $parent->getMessagePageUrl( true );
+			}
+
+			// CONN-430: Purge wall page / forum board
+			$title = Title::newFromText( $this->getMainPageText(), $namespace );
+			if( !empty( $title ) ) {
+				$urls[] = $title->getFullURL();
+			}
 		}
 
 		return $urls;


### PR DESCRIPTION
**DO NOT MERGE - work in progress**
- new method `ArticleComment::getSquidURLs()`,
- new hook in `ArticleCommentGetSquidURLs`,
- removed logic in Forum which sends the same URLs to the purging list (ArticleComments handles that),
- added Forum namespaces to `GameGuidesController::$disabledNamespaces` array,
- new methods: `WallMessage::purgeSquid()`, `WallMessage::getSquidURLs()`

@macbre @themech @hakubo feel free to comment. I'm going to check tomorrow different actions on Wall/Forum (if they send purge request when they have to) and after that I'll be able to push it to production if you don't find anything nasty in the code ;)
