### PR TITLE
BAC-1241: RL caching policy updated

### DIFF
--- a/includes/resourceloader/ResourceLoader.php
+++ b/includes/resourceloader/ResourceLoader.php
@@ -584,7 +584,7 @@ class ResourceLoader {
 		}
 
 		// Wikia - change begin - @author: macbre
-		wfRunHooks('ResourceLoaderModifyMaxAge',array($context,$mtime,&$maxage,&$smaxage));
+		wfRunHooks( 'ResourceLoaderModifyMaxAge',[ $this, $context, $mtime, &$maxage, &$smaxage ] );
 		// Wikia - change end
 
 		if ( $context->getOnly() === 'styles' ) {

--- a/includes/wikia/resourceloader/ResourceLoaderHooks.class.php
+++ b/includes/wikia/resourceloader/ResourceLoaderHooks.class.php
@@ -361,11 +361,11 @@ class ResourceLoaderHooks {
 
 		if ($hasDynamicModule) {
 			// use long TTL when version value matches $mtime passed to the hook
-			$useLongTTL = ($ts >= $mtime);
+			$useLongTTL = !empty($ts) && ($ts <= $mtime);
 		}
 		else {
 			// use long TTL when cache buster value from URL matches $wgStyleVersion
-			$useLongTTL = ($cb == $wgStyleVersion);
+			$useLongTTL = !empty($cb) && ($cb <= $wgStyleVersion);
 		}
 
 		// cache "startup" module for longer

--- a/includes/wikia/resourceloader/ResourceLoaderHooks.class.php
+++ b/includes/wikia/resourceloader/ResourceLoaderHooks.class.php
@@ -6,6 +6,8 @@
  * @author macbre
  * @author Wladyslaw Bodzek
  */
+use Wikia\Logger\WikiaLogger;
+
 class ResourceLoaderHooks {
 
 	const TIMESTAMP_PRECISION = 900; // 15 minutes
@@ -314,55 +316,75 @@ class ResourceLoaderHooks {
 	}
 
 	/**
+	 * Customize caching policy for RL modules
+	 *
+	 * * cache "static" modules for 30 days when cb param in the URL matches $wgStyleVersion
+	 * * cache "dynamic" modules for 30 days when version param is present in the URL and matches $mtime timestamp
+	 * * otherwise fallback to caching for 5 minutes
+	 *
+	 * @see BAC-1241
+	 *
+	 * @param ResourceLoader $rl
 	 * @param ResourceLoaderContext $context
-	 * @param $mtime string timestamp from module(s) calculated from filesystem
+	 * @param $mtime int UNIX timestamp from module(s) calculated from filesystem
 	 * @param $maxage int UNIX timestamp for maxage
 	 * @param $smaxage int UNIX timestamp for smaxage
 	 * @return bool it's a hook
 	 */
-	public static function onResourceLoaderModifyMaxAge(ResourceLoaderContext $context, $mtime, &$maxage, &$smaxage) {
+	public static function onResourceLoaderModifyMaxAge(ResourceLoader $rl, ResourceLoaderContext $context, $mtime, &$maxage, &$smaxage) {
 		global $wgStyleVersion, $wgResourceLoaderMaxage;
 
-		// need to cache RL manifest for longer
+		// parse cb and version provided as URL parameters
+		// version%3D123456-20140220T090000Z
+		// cb%3D123456%26
+		$version = explode('-', (string) $context->getVersion(), 2);
+
+		if (count($version) === 2) {
+			list($cb, $ts) = $version;
+			$ts = strtotime($ts); // convert MW to UNIX timestamp
+		}
+		else {
+			$cb = $context->getRequest()->getVal('cb', false);
+			$ts = false;
+		}
+
+		// check if at least one of required modules serves dynamic content
+		$hasDynamicModule = false;
 		$modules = $context->getModules();
-		if ( count($modules) == 1 && $modules[0] == 'startup' ) {
-			$maxage  = $wgResourceLoaderMaxage['versioned']['client'];
-			$smaxage = $wgResourceLoaderMaxage['versioned']['server'];
 
-			$modules = implode(',', $context->getModules());
-			Wikia::log(__METHOD__, false, "longer TTL set for {$modules}", true);
-			return true;
+		foreach($modules as $moduleName) {
+			if (!($rl->getModule($moduleName) instanceof ResourceLoaderFileModule) ) {
+				$hasDynamicModule = true;
+				break;
+			}
 		}
 
-		// if we have already short TTL set, there's no need to do further checks
-		if ( $maxage == $wgResourceLoaderMaxage['unversioned']['client']
-			&& $smaxage == $wgResourceLoaderMaxage['unversioned']['server']
-		) {
-			return true;
+		if ($hasDynamicModule) {
+			// use long TTL when version value matches $mtime passed to the hook
+			$useLongTTL = ($ts >= $mtime);
+		}
+		else {
+			// use long TTL when cache buster value from URL matches $wgStyleVersion
+			$useLongTTL = ($cb == $wgStyleVersion);
 		}
 
-		$forceShortTTL = false;
-
-		$version = explode('-',(string)($context->getVersion()),2);
-		if ( !is_array($version) || count($version) != 2 ) { // if version format different than "CB-TS"
-			$forceShortTTL = true;
+		// cache "startup" module for longer
+		if (count($modules) === 1 && $modules[0] === 'startup') {
+			$useLongTTL = true;
 		}
 
-		if ( !$forceShortTTL ) {
-			list( $styleVersionFromRequest, $timestampFromRequest ) = $version;
-			$timestampFromRequest = strtotime($timestampFromRequest); // parse timestamp from request
-			$forceShortTTL = $styleVersionFromRequest > $wgStyleVersion
-				|| $timestampFromRequest > $mtime;
+		// modify caching times
+		if (!$useLongTTL) {
+			WikiaLogger::instance()->info( 'rl.shortTTL', [
+				'modules' => join(',', $modules),
+				'cb' => $cb,
+				'ts' => $ts,
+			]);
 		}
 
-		// request wants to get module(s) newer than on those on server - set shorter caching period
-		if ( $forceShortTTL ) {
-			$maxage  = $wgResourceLoaderMaxage['unversioned']['client'];
-			$smaxage = $wgResourceLoaderMaxage['unversioned']['server'];
-
-			$modules = implode(',', $context->getModules());
-			Wikia::log(__METHOD__, false, "shorter TTL set for {$modules}", true);
-		}
+		$cachingTimes = $wgResourceLoaderMaxage[$useLongTTL ? 'versioned' : 'unversioned'];
+		$maxage  = $cachingTimes['client'];
+		$smaxage = $cachingTimes['server'];
 
 		return true;
 	}

--- a/includes/wikia/resourceloader/tests/ResourceLoaderTest.php
+++ b/includes/wikia/resourceloader/tests/ResourceLoaderTest.php
@@ -18,8 +18,6 @@ class ResourceLoaderTest extends WikiaBaseTest {
 		global $wgHooks;
 		$this->oldWgHooks = $wgHooks;
 
-		$this->mockGlobalVariable('wgCacheEpoch',TestResourceLoaderModule::TIMESTAMP - 1000);
-
 		parent::setUp();
 	}
 
@@ -72,7 +70,7 @@ class ResourceLoaderTest extends WikiaBaseTest {
 		return array(
 			'timestamp - 1' => array(
 				'version' => [$wgStyleVersion, $pastTimestamp],
-				'ttl' => $wgResourceLoaderMaxage['versioned']['client']
+				'ttl' => $wgResourceLoaderMaxage['unversioned']['client']
 			),
 			'timestamp' => array(
 				'version' => [$wgStyleVersion, $currTimestamp],
@@ -80,11 +78,7 @@ class ResourceLoaderTest extends WikiaBaseTest {
 			),
 			'timestamp + 1' => array(
 				'version' => [$wgStyleVersion, $futureTimestamp],
-				'ttl' => $wgResourceLoaderMaxage['unversioned']['client']
-			),
-			'no style version' => array(
-				'version' => [$currTimestamp],
-				'ttl' => $wgResourceLoaderMaxage['unversioned']['client']
+				'ttl' => $wgResourceLoaderMaxage['versioned']['client']
 			)
 		);
 	}

--- a/includes/wikia/resourceloader/tests/ResourceLoaderTest.php
+++ b/includes/wikia/resourceloader/tests/ResourceLoaderTest.php
@@ -70,7 +70,7 @@ class ResourceLoaderTest extends WikiaBaseTest {
 		return array(
 			'timestamp - 1' => array(
 				'version' => [$wgStyleVersion, $pastTimestamp],
-				'ttl' => $wgResourceLoaderMaxage['unversioned']['client']
+				'ttl' => $wgResourceLoaderMaxage['versioned']['client']
 			),
 			'timestamp' => array(
 				'version' => [$wgStyleVersion, $currTimestamp],
@@ -78,7 +78,7 @@ class ResourceLoaderTest extends WikiaBaseTest {
 			),
 			'timestamp + 1' => array(
 				'version' => [$wgStyleVersion, $futureTimestamp],
-				'ttl' => $wgResourceLoaderMaxage['versioned']['client']
+				'ttl' => $wgResourceLoaderMaxage['unversioned']['client']
 			)
 		);
 	}


### PR DESCRIPTION
- cache "static" modules for 30 days (when cb in URL matches `$wgStyleVersion`)
- cache "dynamic" modules for 30 days (when version param is present and matches module's $mtime)
- force 30 days caching for "startup" module

@michalroszka / @prein / @wladekb 
