### PR TITLE
VID-1406 fixing i18n messages in Lightbox

### DIFF
--- a/extensions/wikia/Lightbox/Lightbox.i18n.php
+++ b/extensions/wikia/Lightbox/Lightbox.i18n.php
@@ -14,7 +14,7 @@ $messages['en'] = array(
 	'lightbox-more-info-caption-heading' => 'Caption:',
 	'lightbox-more-info-description-heading' => 'Description:',
 	'lightbox-more-info-filelinks-heading' => 'File Links:',
-	'lightbox-carousel-progress' => '<b>$1-$2</b> of <b>$3</b>',
+	'lightbox-carousel-progress' => "'''$1-$2''' of '''$3'''",
 	'lightbox-embed-url' => 'Embed URL',
 	'lightbox-file-page-url' => 'File Page URL',
 	'lightbox-email-label' => 'Email this to a friend',
@@ -28,7 +28,7 @@ $messages['en'] = array(
 	'lightbox-email-form-header' => 'Email',
 	'lightbox-pin-carousel-tooltip' => 'Pin top and bottom bars in place',
 	'lightbox-unpin-carousel-tooltip' => 'Unpin top and bottom bars',
-	'lightbox-carousel-more-items' => '<span>$1</span> {{PLURAL:$1|more item|more items}} on this wiki',
+	'lightbox-carousel-more-items' => "'''$1''' {{PLURAL:$1|more item|more items}} on this wiki",
 	'lightbox-video-views' => "'''$1''' {{PLURAL:$1|view|views}}",
 
 	/* /new stuff */
@@ -88,6 +88,7 @@ $messages['qqq'] = array(
 	/* new stuff for new lightbox */
 	'lightbox-header-more-info-button' => 'Click this button to view more information about an image or video, like where it\'s posted.',
 	'lightbox-header-share-button' => 'Click this button to go to a screen where you can email a video or image to a friend and get permalinks to the media.',
+	'lightbox-header-add-video-button' => 'Click this button to add the current video to an article page. It will take the user to the editor with the video in place.',
 	'lightbox-header-see-full-size-image' => 'Link text to go to the image page to see the image larger.',
 	'lightbox-header-added-by' => '$1 is the username of the person who added the image or video.',
 	'lightbox-header-posted-in' => '$1 is the article name where the image or video is posted.',

--- a/extensions/wikia/Lightbox/LightboxController.class.php
+++ b/extensions/wikia/Lightbox/LightboxController.class.php
@@ -403,7 +403,7 @@ class LightboxController extends WikiaController {
 		$totalWikiImages = $imageInfo['totalWikiImages'] + $extra;
 
 		$this->to = $imageInfo['timestamp'];
-		$this->msg = wfMessage( 'lightbox-carousel-more-items', $this->wg->Lang->formatNum( $totalWikiImages ) )->escaped();
+		$this->msg = wfMessage( 'lightbox-carousel-more-items', $this->wg->Lang->formatNum( $totalWikiImages ) )->parse();
 
 		wfProfileOut( __METHOD__ );
 	}

--- a/extensions/wikia/Lightbox/css/Lightbox.scss
+++ b/extensions/wikia/Lightbox/css/Lightbox.scss
@@ -362,7 +362,7 @@ $color-lightbox-border: mix($color-page-border, $color-page, 75%);
 							width: 0px;
 
 						}
-						span {
+						b {
 							font-size: 14px;
 							&:before {
 								content: "+";

--- a/extensions/wikia/Lightbox/templates/Lightbox_lightboxModalContent.php
+++ b/extensions/wikia/Lightbox/templates/Lightbox_lightboxModalContent.php
@@ -95,7 +95,7 @@
 	</script>
 
 	<script id="LightboxCarouselProgressTemplate" type="text/template">
-		<?= wfMsg('lightbox-carousel-progress', array("{{idx1}}", "{{idx2}}", "{{{total}}}")); ?>
+		<?= wfMessage( 'lightbox-carousel-progress' )->rawParams( '{{idx1}}', '{{idx2}}', '{{{total}}}' )->parse(); ?>
 	</script>
 
 	<script id="LightboxShareTemplate" type="text/template">


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/VID-1406

Escaped "<span>" tags are no longer showing up in the lightbox carousel. 
