### PR TITLE
Made it so that users cannot CREATE pages if those pages are blocked by ...

### DIFF
--- a/extensions/3rdparty/LyricWiki/LyricFind/LyricFind.i18n.php
+++ b/extensions/3rdparty/LyricWiki/LyricFind/LyricFind.i18n.php
@@ -9,10 +9,14 @@ $messages = [
 		'lyricfind-send-ringtone' => 'Send "$1" Ringtone to your Cell',
 		'lyricfind-song-by' => 'This song is by [[$1]] ([[LyricFind:$1|uneditable LyricFind version]]).',
 		'lyricfind-copyright' => 'Lyrics Provided by LyricFind ([[LyricFind:EULA|Lyrics Terms of Use]])',
-		'lyricfind-edit-blocked' => 'Sorry, but the source can not be viewed on LyricFind pages due to licensing requirements.'
+		'lyricfind-edit-blocked' => 'Sorry, but the source can not be viewed on LyricFind pages due to licensing requirements.',
+		'lyricfind-editpage-blocked' => 'Sorry, but the source can not be viewed on this page due to licensing requirements.',
+		'lyricfind-creation-blocked' => 'Sorry, but this specific page can not be created due to licensing requirements.  Please continue to create other pages! Only a few (by specific artists, etc.) are prohibited.'
 	],
 	'qqq' => [
 		'lyricfind-header' => 'Copyright message shown above the lyric and link to community-editable version: $1 - artist, $2 - song',
-		'lyricfind-edit-blocked' => 'Message shown on edit page (which is disabled for LyricFind namespace)'
+		'lyricfind-edit-blocked' => 'Message shown on edit page in LyricFind namespace (editing is disabled for LyricFind namespace and view-source is replaced with this message)',
+		'lyricfind-editpage-blocked' => 'Message shown on edit pages if LyricFind does not have the license to sublicense the lyrics to this song. Sorry for any confusion compared to lyricfind-edit-blocked which actually blocks view-source on the legacy LyricFind namespace.',
+		'lyricfind-creation-blocked' => 'Message shown on edit page when trying to create a new page that LyricFind is not licensed to display.'
 	]
 ];

--- a/extensions/3rdparty/LyricWiki/LyricFind/LyricFind.setup.php
+++ b/extensions/3rdparty/LyricWiki/LyricFind/LyricFind.setup.php
@@ -49,6 +49,7 @@ $wgHooks['ParserBeforeStrip'][] = 'LyricFindHooks::onParserBeforeStrip';
 // @see http://www.mediawiki.org/wiki/Manual:$wgNamespaceProtection
 $wgGroupPermissions['*']['editlyricfind'] = false;
 $wgGroupPermissions['staff']['editlyricfind'] = true;
+$wgGroupPermissions['sysop']['editlyricfind'] = true;
 
 $wgHooks['AlternateEdit'][] = 'LyricFindHooks::onAlternateEdit';
 

--- a/extensions/3rdparty/LyricWiki/LyricFind/LyricFindHooks.class.php
+++ b/extensions/3rdparty/LyricWiki/LyricFind/LyricFindHooks.class.php
@@ -56,20 +56,38 @@ class LyricFindHooks {
 	}
 
 	/**
-	 * Blocks view page source page
+	 * Blocks view source page & make it so that users cannot create/edit
+	 * pages that are on the takedown list.
 	 *
 	 * @param EditPage $editPage edit page instance
 	 * @return bool show edit page form?
 	 */
 	static public function onAlternateEdit(EditPage $editPage) {
 		$wg = F::app()->wg;
+		$wf = F::app()->wf;
 		$title = $editPage->getTitle();
+
+		// Block view-source on the LyricFind namespace.
 		$isLyricFind = $title->getNamespace() === NS_LYRICFIND;
 		$isNotAllowedToEdit = $title->isNamespaceProtected($wg->User);
-
 		$blockEdit = ($isLyricFind && $isNotAllowedToEdit);
 		if ($blockEdit) {
 			$wg->Out->addHTML(Wikia::errorbox(wfMessage('lyricfind-edit-blocked')));
+		} else if($title->exists()){
+			// Look at the page-props to see if this page is blocked.
+			if(!$wg->user->isAllowed( 'editlyricfind' )){ // some users (staff/admin) will be allowed to edit these to prevent vandalism/spam issues.
+				$removedProp = $wf->GetWikiaPageProp(WPP_LYRICFIND_MARKED_FOR_REMOVAL, $title->getArticleID());
+				if(!empty($removedProp)){
+					$wg->Out->addHTML(Wikia::errorbox(wfMessage('lyricfind-editpage-blocked')));
+					$blockEdit = true;
+				}
+			}
+		} else {
+			// Page is being created. Prevent this if page is prohibited by LyricFind.
+			$blockEdit = LyricFindTrackingService::isPageBlockedViaApi($amgId="", $gracenoteId="", $title->getText());
+			if($blockEdit){
+				$wg->Out->addHTML(Wikia::errorbox(wfMessage('lyricfind-creation-blocked')));
+			}
 		}
 
 		return !$blockEdit;

--- a/extensions/3rdparty/LyricWiki/LyricFind/LyricFindTrackingService.class.php
+++ b/extensions/3rdparty/LyricWiki/LyricFind/LyricFindTrackingService.class.php
@@ -64,7 +64,7 @@ class LyricFindTrackingService extends WikiaService {
 	 *
 	 * @param $data array containing amgid, gnlyricid and title of the lyric
 	 */
-	private function formatTrackId($data) {
+	public function formatTrackId($data) {
 		$parts = [];
 
 		if (!empty($data['amg'])) {
@@ -154,6 +154,74 @@ class LyricFindTrackingService extends WikiaService {
 
 		wfProfileOut(__METHOD__);
 		return $status;
+	}
+	
+	/**
+	 * WARNING: This function makes an API request and is therefore slow.
+	 *
+	 * This function is intended only for use to test if not-yet-created pages are blocked
+	 * (so that we can prevent their creation). If calling-code just needs to check if an
+	 * already-existing page is blocked, check the page properties using
+	 * GetWikiaPageProp(WPP_LYRICFIND_MARKED_FOR_REMOVAL) instead.
+	 */
+	public static function isPageBlockedViaApi($amgId="", $gracenoteId="", $pageTitleText=""){
+		wfProfileIn(__METHOD__);
+		
+		$isBlocked = false;
+		
+		$app = F::app();
+		$service = new LyricFindTrackingService();
+
+		// format trackid parameter
+		$trackId = $service->formatTrackId([
+			'amg' => $amgId,
+			'gracenote' => $gracenoteId,
+			'title' => $pageTitleText
+		]);
+
+		$url = $app->wg->LyricFindApiUrl . '/lyric.do';
+		$data = [
+			'apikey' => $app->wg->LyricFindApiKeys['display'],
+			'reqtype' => 'offlineviews',
+			'count' => 1, // This is overcounting since we know it's not a view (page doesn't exist yet), but their API won't accept "0"
+			'trackid' => $trackId,
+			'output' => 'json',
+			'useragent' => isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : self::DEFAULT_USER_AGENT
+		];
+
+		wfDebug(__METHOD__ . ': ' . json_encode($data) . "\n");
+
+		$resp = Http::post($url, ['postData' => $data]);
+
+		if ($resp !== false) {
+			wfDebug(__METHOD__ . ": API response - {$resp}\n");
+		}
+
+		// get the code from API response
+		if ($resp !== false) {
+			$json = json_decode($resp, true);
+
+			$code = !empty($json['response']['code']) ? intval($json['response']['code']) : false;
+
+			switch ($code) {
+				case self::CODE_LYRIC_IS_BLOCKED:
+					$isBlocked = true;
+					break;
+
+				case self::CODE_LRC_IS_AVAILABLE:
+				case self::CODE_LYRIC_IS_INSTRUMENTAL:
+				case self::CODE_LYRIC_IS_AVAILABLE:
+					break;
+
+				default:
+					self::log(__METHOD__, "got #{$code} response code from API (track amg#{$amgId} / gn#{$gracenoteId} / '{$pageTitleText}')");
+			}
+		} else {
+			self::log(__METHOD__, "LyricFind API request failed in isPageBlockedViaApi()!");
+		}
+
+		wfProfileOut(__METHOD__);
+		return $isBlocked;
 	}
 
 	/**


### PR DESCRIPTION
...LyricFind. Additionally, users will not be allowed to see the edit-page if the song is blocked.  For maintenance reasons (preventing spam/vandalism and fixing existing categorizations, etc.) both staff and sysops will be able to see the edit page (but still they can NOT create a page).
