### PR TITLE
(CE-669) Add some client-side caching of anon SWM requests

### DIFF
--- a/extensions/wikia/SiteWideMessages/SiteWideMessagesController.class.php
+++ b/extensions/wikia/SiteWideMessages/SiteWideMessagesController.class.php
@@ -2,6 +2,9 @@
 
 class SiteWideMessagesController extends WikiaController  {
 
+	const CACHE_VALIDITY_VARNISH = 0;
+	const CACHE_VALIDITY_BROWSER = 900; // 15 minutes
+
 	public function getAnonMessages() {
 		if ( $this->wg->User->isLoggedIn() ) {
 			// Don't return anything if this happens
@@ -22,6 +25,8 @@ class SiteWideMessagesController extends WikiaController  {
 
 		$this->siteWideMessages = $msgs;
 		$this->notificationType = NotificationsController::NOTIFICATION_SITEWIDE;
+
+		$this->response->setCacheValidity( self::CACHE_VALIDITY_VARNISH, self::CACHE_VALIDITY_BROWSER );
 	}
 
 	public function dismissAnonMessage() {

--- a/extensions/wikia/SiteWideMessages/SiteWideMessagesController.class.php
+++ b/extensions/wikia/SiteWideMessages/SiteWideMessagesController.class.php
@@ -2,8 +2,8 @@
 
 class SiteWideMessagesController extends WikiaController  {
 
-	const CACHE_VALIDITY_VARNISH = 0;
-	const CACHE_VALIDITY_BROWSER = 900; // 15 minutes
+	const CACHE_VALIDITY_VARNISH = 10800; // 3 hours
+	const CACHE_VALIDITY_BROWSER = 3600; // 1 hour
 
 	public function getAnonMessages() {
 		if ( $this->wg->User->isLoggedIn() ) {

--- a/extensions/wikia/SiteWideMessages/js/SiteWideMessages.anon.js
+++ b/extensions/wikia/SiteWideMessages/js/SiteWideMessages.anon.js
@@ -13,7 +13,8 @@
 				format: 'html',
 				type: 'GET',
 				data: {
-					hasnotifications: hasNotifications
+					hasnotifications: hasNotifications,
+					lastdismissed: $.storage.get( 'swm-lastdismissed' )
 				}
 			} ).done( function( data ) {
 				var	$body,
@@ -77,6 +78,8 @@
 					messageid: messageId
 				}
 			} );
+
+			$.storage.set( 'swm-lastdismissed', messageId );
 
 			this.track( {
 				action: window.Wikia.Tracker.ACTIONS.CLICK_LINK_BUTTON,


### PR DESCRIPTION
Add 15 minute client-side caching of anon SWM checks and make use of
the last dismissed message ID to bust the cache when a message is
dismissed by the user.

@macbre 
