### PR TITLE
Adding basic Georgian (ქართული) internationalisation of some Chat2 messages

### DIFF
--- a/extensions/wikia/Chat2/Chat.i18n.php
+++ b/extensions/wikia/Chat2/Chat.i18n.php
@@ -1804,6 +1804,18 @@ $messages['ja'] = array(
 	'chat-status-away' => '退席中',
 );
 
+/** Georgian (ქართული)
+ * @author ToaMeiko
+ */
+ $messages['ka'] = array(
+ 	'chat' => 'სტატისტიკა',
+ 	'chat-desc' => '[[Special:Chat|სტატისტიკა]]',
+ 	'chat-ban-modal-button-cancel' => 'გაუქმება',
+ 	'chat-ban-undolink' => 'გაუქმება',
+ 	'chat-log-reason-undo' => 'გაუქმება',
+ 	'chat-you-are-banned' => 'ნებართვის შეცდომა.',
+ );
+
 /** Khowar (کھوار)
  * @author Rachitrali
  */


### PR DESCRIPTION
The listed commit adds a couple basic Georgian (ქართული) messages for the Wikia Chat2 extension.
