### PR TITLE
Changing multiple spaces to tabs for indentation

### DIFF
--- a/extensions/wikia/OversightCompanion/OversightCompanion.php
+++ b/extensions/wikia/OversightCompanion/OversightCompanion.php
@@ -13,16 +13,16 @@
 */
 
 if (!defined('MEDIAWIKI')){
-    echo ('THIS IS NOT VALID ENTRY POINT.'); exit (1);
+	echo ('THIS IS NOT VALID ENTRY POINT.'); exit (1);
 }
 
 $wgExtensionFunctions [] = 'efInitializeOversightCompanion';
 
 function efInitializeOversightCompanion(){
-        global $wgHooks;
+	global $wgHooks;
 
-        $wgHooks['Oversight::getRevisions'][] = 'efAddHiddenTable';
-        $wgHooks['Oversight::insertRevision'][] = 'efAddHiddenTable';
+	$wgHooks['Oversight::getRevisions'][] = 'efAddHiddenTable';
+	$wgHooks['Oversight::insertRevision'][] = 'efAddHiddenTable';
 }
 
 function efAddHiddenTable() {


### PR DESCRIPTION
As per MediaWiki's coding conventions (https://www.mediawiki.org/wiki/Manual:Coding_conventions), all indentation done in PHP files should be done using tabs as opposed to single or multiple spaces.

Whether or not this file/extension is used in Wikia anymore, it should still follow MediaWiki's coding conventions.

No functional changes in this commit.
