### PR TITLE
AssetsManager: cache every multitype response for a week

### DIFF
--- a/extensions/wikia/AssetsManager/AssetsManagerController.class.php
+++ b/extensions/wikia/AssetsManager/AssetsManagerController.class.php
@@ -41,7 +41,6 @@ class AssetsManagerController extends WikiaController {
 		$scripts = $this->request->getVal( 'scripts', null );
 		$messages = $this->request->getVal( 'messages', null );
 		$mustache = $this->request->getVal( 'mustache', null );
-		$ttl = $this->request->getInt( 'ttl', 0 );
 
 		// handle templates via sendRequest
 		if ( !is_null( $templates ) ) {
@@ -141,10 +140,7 @@ class AssetsManagerController extends WikiaController {
 			wfProfileOut( $profileId );
 		}
 
-		// handle cache time
-		if ( $ttl > 0 ) {
-			$this->response->setCacheValidity( $ttl );
-		}
+		$this->response->setCacheValidity( 7 * 86400 ); // a week
 
 		$this->response->setFormat( 'json' );
 		wfProfileOut( __METHOD__ );

--- a/extensions/wikia/AssetsManager/js/AssetsManager.js
+++ b/extensions/wikia/AssetsManager/js/AssetsManager.js
@@ -14,7 +14,6 @@ window.Wikia = window.Wikia || {};
  *		scripts - comma-separated list of AssetsManager groups
  *		messages - comma-separated list of JSMessages packages (messages are registered automagically)
  * 		mustache - comma-separated list of paths to Mustache-powered templates
- *		ttl - cache period for both Varnish and Browser (in seconds)
  *		params - an object with all the additional parameters for the request (e.g. useskin, forceprofile, etc.)
  *		callback - function to be called with fetched JSON object
  *
@@ -46,7 +45,6 @@ window.Wikia.getMultiTypePackage = function(options) {
 		mustache = options.mustache,
 		callback = options.callback,
 		params = options.params,
-		ttl = options.ttl,
 		send = false;
 
 	if(typeof styles === 'string'){
@@ -78,9 +76,6 @@ window.Wikia.getMultiTypePackage = function(options) {
 	if(typeof params === 'object'){
 		request = $.extend(request, params);
 	}
-
-	if(ttl)
-		request.ttl = ~~ttl;
 
 	if(send){
 		// add a cache buster

--- a/extensions/wikia/RelatedPages/js/RelatedPages.js
+++ b/extensions/wikia/RelatedPages/js/RelatedPages.js
@@ -31,7 +31,6 @@ require(['sloth', 'wikia.window', 'jquery'], function (sloth, w, $) {
 				loader({
 					type: loader.MULTI,
 					resources: {
-						ttl: 604800, // 7 days
 						mustache: 'extensions/wikia/RelatedPages/templates/RelatedPages_section.mustache'
 					}
 				}).done(function (data) {

--- a/extensions/wikia/RelatedPages/js/relatedPages.wikiamobile.js
+++ b/extensions/wikia/RelatedPages/js/relatedPages.wikiamobile.js
@@ -35,7 +35,6 @@ function( window, nirvana, $, thumbnailer, lazyload, sloth, msg, mustache, secti
 				loader( {
 					type: loader.MULTI,
 					resources: {
-						ttl: 604800, // 7 days
 						mustache: 'extensions/wikia/RelatedPages/templates/RelatedPages_section.mustache'
 					}
 				} ).done( function ( data ) {

--- a/extensions/wikia/WikiaMobile/js/layout.js
+++ b/extensions/wikia/WikiaMobile/js/layout.js
@@ -42,8 +42,7 @@ function ( sections, media, cache, loader, lazyload, $, sloth, topbar ) {
 				type: loader.MULTI,
 				resources: {
 					scripts: 'wikiamobile_tables_js',
-					styles: '/extensions/wikia/WikiaMobile/css/tables.scss',
-					ttl: ttl
+					styles: '/extensions/wikia/WikiaMobile/css/tables.scss'
 				}
 			} ).done( process );
 		}

--- a/extensions/wikia/WikiaMobile/js/media.js
+++ b/extensions/wikia/WikiaMobile/js/media.js
@@ -644,8 +644,7 @@ function(
 						type: loader.MULTI,
 						resources: {
 							styles: '/extensions/wikia/WikiaMobile/css/mediagallery.scss',
-							scripts: 'wikiamobile_mediagallery_js',
-							ttl: ttl
+							scripts: 'wikiamobile_mediagallery_js'
 						}
 					} ).done( function ( res ) {
 						var script = res.scripts,

--- a/extensions/wikia/WikiaMobile/js/share.js
+++ b/extensions/wikia/WikiaMobile/js/share.js
@@ -54,8 +54,7 @@ define('share', ['wikia.cache', 'JSMessages', 'wikia.loader', 'wikia.window'], f
 							controller: 'WikiaMobileSharingService',
 							method: 'index'
 						}],
-						styles: '/extensions/wikia/WikiaMobile/css/sharing.scss',
-						ttl: 86400
+						styles: '/extensions/wikia/WikiaMobile/css/sharing.scss'
 					}
 				}).done(
 					function(res){

--- a/resources/wikia/modules/loader.js
+++ b/resources/wikia/modules/loader.js
@@ -245,7 +245,6 @@ define('wikia.loader', ['wikia.window', require.optional('mw'), 'wikia.nirvana',
 		 *		scripts - comma-separated list of AssetsManager groups
 		 *		messages - comma-separated list of JSMessages packages (messages are registered automagically)
 		 * 		mustache - comma-separated list of paths to Mustache-powered templates
-		 *		ttl - cache period for both Varnish and Browser (in seconds)
 		 *		params - an object with all the additional parameters for the request (e.g. useskin, forceprofile, etc.)
 		 *		callback - function to be called with fetched JSON object
 		 *


### PR DESCRIPTION
All multitype responses served by AssetsManager will now be cached for a week. AJAX URL still contains cb value, so it's pretty easy to invalidate these responses.
- code cleanup :)

@prein / @michalroszka / @hakubo 
