### PR TITLE
Configure cache TTL in a consistent, managable way

### DIFF
--- a/extensions/wikia/ArticleComments/modules/ArticleCommentsController.class.php
+++ b/extensions/wikia/ArticleComments/modules/ArticleCommentsController.class.php
@@ -105,7 +105,8 @@ class ArticleCommentsController extends WikiaController {
 
 		// When lazy loading this request it shouldn't be cached in the browser
 		if ( !empty( $this->wg->ArticleCommentsLoadOnDemand ) ) {
-			$this->response->setCacheValidity( WikiaResponse::CACHE_PRIVATE_DISABLED );
+			$this->response->setCachePolicy( WikiaResponse::CACHE_PRIVATE );
+			$this->response->setCacheValidity( WikiaResponse::CACHE_DISABLED );
 		}
 
 		wfProfileOut( __METHOD__ );

--- a/extensions/wikia/AssetsManager/AssetsManagerController.class.php
+++ b/extensions/wikia/AssetsManager/AssetsManagerController.class.php
@@ -140,7 +140,7 @@ class AssetsManagerController extends WikiaController {
 			wfProfileOut( $profileId );
 		}
 
-		$this->response->setCacheValidity( 7 * 86400 ); // a week
+		$this->response->setCacheValidity( WikiaResponse::CACHE_LONG );
 
 		$this->response->setFormat( 'json' );
 		wfProfileOut( __METHOD__ );

--- a/extensions/wikia/Lightbox/LightboxController.class.php
+++ b/extensions/wikia/Lightbox/LightboxController.class.php
@@ -24,7 +24,7 @@ class LightboxController extends WikiaController {
 		$this->showAdModalRectangle = $showAds && $this->wg->ShowAdModalRectangle;
 
 		// set cache control to 1 day
-		$this->response->setCacheValidity( 86400 );
+		$this->response->setCacheValidity( WikiaResponse::CACHE_STANDARD );
 	}
 
 	public function lightboxModalContentError() {
@@ -35,7 +35,7 @@ class LightboxController extends WikiaController {
 		}
 
 		// set cache control to 1 day
-		$this->response->setCacheValidity( 86400 );
+		$this->response->setCacheValidity( WikiaResponse::CACHE_STANDARD );
 	}
 
 	/**
@@ -299,7 +299,7 @@ class LightboxController extends WikiaController {
 		$this->imageUrl = $thumbUrl;
 
 		// set cache control to 1 day
-		$this->response->setCacheValidity( 86400 );
+		$this->response->setCacheValidity( WikiaResponse::CACHE_STANDARD );
 	}
 
 	/**

--- a/extensions/wikia/RelatedVideos/RelatedVideosController.class.php
+++ b/extensions/wikia/RelatedVideos/RelatedVideosController.class.php
@@ -204,7 +204,7 @@ class RelatedVideosController extends WikiaController {
 		}
 
 		// set cache control to 1 day
-		$this->response->setCacheValidity(86400);
+		$this->response->setCacheValidity(WikiaResponse::CACHE_STANDARD);
 
 		wfProfileOut(__METHOD__);
 	}

--- a/extensions/wikia/Search/SearchApiController.class.php
+++ b/extensions/wikia/Search/SearchApiController.class.php
@@ -166,7 +166,7 @@ class SearchApiController extends WikiaApiController {
 		$response = $this->getResponse();
 		$response->setValues( $responseValues );
 
-		$response->setCacheValidity(86400);
+		$response->setCacheValidity(WikiaResponse::CACHE_STANDARD);
 	}
 	
 	/**

--- a/extensions/wikia/SpecialStyleguide/SpecialStyleguideController.class.php
+++ b/extensions/wikia/SpecialStyleguide/SpecialStyleguideController.class.php
@@ -28,7 +28,7 @@ class SpecialStyleguideController extends WikiaSpecialPageController {
 
 		$wgAutoloadClasses['GlobalHeaderController'] = dirname( __FILE__ ) . '/helpers/SpecialStyleguideGlobalHeaderControllerOverride.php';
 
-		$this->response->setCacheValidity(86400);
+		$this->response->setCacheValidity(WikiaResponse::CACHE_STANDARD);
 
 		$subpage = mb_strtolower( $this->getFirstTextAfterSlash( $this->wg->Title->getSubpageText() ) );
 

--- a/extensions/wikia/templates/HelloWorld/HelloWorldController.class.php
+++ b/extensions/wikia/templates/HelloWorld/HelloWorldController.class.php
@@ -22,7 +22,7 @@ class HelloWorldController extends WikiaController {
 		$this->html5logo = $this->wg->ExtensionsPath . '/wikia/templates/HelloWorld/images/html5logo.png';
 
 		// use caching
-		$this->response->setCacheValidity(3600);
+		$this->response->setCacheValidity(WikiaResponse::CACHE_STANDARD);
 	}
 
 }

--- a/includes/wikia/api/SearchSuggestionsApiController.class.php
+++ b/includes/wikia/api/SearchSuggestionsApiController.class.php
@@ -45,7 +45,7 @@ class SearchSuggestionsApiController extends WikiaApiController {
 				throw new NotFoundApiException();
 			}
 
-			$this->response->setCacheValidity(86400);
+			$this->response->setCacheValidity(WikiaResponse::CACHE_STANDARD);
 		} else {
 			throw new NotFoundApiException( 'Link Suggest extension not available' );
 		}

--- a/includes/wikia/nirvana/WikiaResponse.class.php
+++ b/includes/wikia/nirvana/WikiaResponse.class.php
@@ -36,23 +36,30 @@ class WikiaResponse {
 	/**
 	 * template engine
 	 */
-
 	const TEMPLATE_ENGINE_PHP = 'php';
 	const TEMPLATE_ENGINE_MUSTACHE = 'mustache';
 
 	/**
-	 * Cache targets
+	 * Caching times
 	 */
-	const CACHE_PRIVATE_DISABLED = -1;
 	const CACHE_DISABLED = 0;
+
+	const CACHE_LONG = 2592000; // 30 days
+	const CACHE_STANDARD = 86400; // 24 hours
+	const CACHE_SHORT = 10800; // 3 hours
+
+	/**
+	 * Caching policy
+	 */
+	private $cachingPolicy = 'public';
+
+	const CACHE_PRIVATE = 'private';
+	const CACHE_PUBLIC = 'public';
 
 	/**
 	 * View object
 	 * @var WikiaView
 	 */
-
-	
-
 	private $view = null;
 	private $body = null;
 	private $code = null;
@@ -278,6 +285,17 @@ class WikiaResponse {
 	}
 
 	/**
+	 * Sets caching policy
+	 *
+	 * This method needs to be called before WikiaResponse::setCacheValidity
+	 *
+	 * @param string $policy caching policy (either private or public)
+	 */
+	public function setCachePolicy($policy) {
+		$this->cachingPolicy = $policy === self::CACHE_PRIVATE ? self::CACHE_PRIVATE : self::CACHE_PUBLIC;
+	}
+
+	/**
 	 * Sets correct cache headers for the client, Varnish or both
 	 *
 	 * Cache-Control / X-Pass-Cache-Control headers will be set
@@ -290,21 +308,30 @@ class WikiaResponse {
 	public function setCacheValidity( $varnishTTL, $browserTTL = false ) {
 		$this->isCaching = true;
 
-		if ($varnishTTL === self::CACHE_PRIVATE_DISABLED) {
-			$this->setHeader('Cache-Control', 'private, max-age=0, must-revalidate');
-		}
-		else {
-			$this->setHeader('Cache-Control', sprintf('s-maxage=%d', $varnishTTL));
-		}
-
 		// default to the TTL for Varnish
 		if ($browserTTL === false) {
 			$browserTTL = $varnishTTL;
 		}
 
+		switch($this->cachingPolicy) {
+			case self::CACHE_PUBLIC:
+				// Varnish caches for 5 seconds when Apache sends Cache-Control: public, s-maxage=0
+				// perform this logic here
+				if ( $varnishTTL === self::CACHE_DISABLED ) {
+					$varnishTTL = 5;
+				}
+
+				$this->setHeader('Cache-Control', sprintf('s-maxage=%d', $varnishTTL));
+				break;
+
+			case self::CACHE_PRIVATE:
+				$this->setHeader('Cache-Control', sprintf('private, s-maxage=%d', $varnishTTL));
+				break;
+		}
+
 		// cache on client side
 		if ($browserTTL > 0) {
-			$this->setHeader('X-Pass-Cache-Control', sprintf('public, max-age=%d', $browserTTL));
+			$this->setHeader('X-Pass-Cache-Control', sprintf('%s, max-age=%d', $this->cachingPolicy, $browserTTL));
 		}
 	}
 

--- a/skins/oasis/modules/GlobalHeaderController.class.php
+++ b/skins/oasis/modules/GlobalHeaderController.class.php
@@ -82,7 +82,7 @@ class GlobalHeaderController extends WikiaController {
 		$this->response->setData($menuItems);
 
 		// Cache for 1 day
-		$this->response->setCacheValidity(86400);
+		$this->response->setCacheValidity(WikiaResponse::CACHE_STANDARD);
 	}
 
 	protected function isGameStarLogoEnabled() {

--- a/skins/oasis/modules/RailController.class.php
+++ b/skins/oasis/modules/RailController.class.php
@@ -29,7 +29,7 @@ class RailController extends WikiaController {
 
 		$this->getLazyRail();
 
-		$this->response->setCacheValidity(86400);
+		$this->response->setCacheValidity(WikiaResponse::CACHE_STANDARD);
 
 		wfProfileOut(__METHOD__);
 	}


### PR DESCRIPTION
Introduce standard caching times:

```
    const CACHE_LONG = 2592000; // 30 days
    const CACHE_STANDARD = 86400; // 24 hours
    const CACHE_SHORT = 10800; // 3 hours
```

Introduce `WikiaResponse::setCachePolicy` for forcing private caching policy.

@michalroszka / @prein
