### PR TITLE
CONN-435: make cacheable GET requests for RelatedForumDiscussion

### DIFF
--- a/extensions/wikia/Forum/RelatedForumDiscussionController.class.php
+++ b/extensions/wikia/Forum/RelatedForumDiscussionController.class.php
@@ -76,6 +76,7 @@ class RelatedForumDiscussionController extends WikiaController {
 			$this->html = '';
 		}
 
+		$this->response->setFormat(WikiaResponse::FORMAT_JSON);
 		$this->response->setCacheValidity( 6*60*60, WikiaResponse::CACHE_DISABLED /* no caching in browser */ );
 	}
 

--- a/extensions/wikia/Forum/js/RelatedForumDiscussion.js
+++ b/extensions/wikia/Forum/js/RelatedForumDiscussion.js
@@ -22,7 +22,7 @@
 				$.nirvana.sendRequest({
 					controller: 'RelatedForumDiscussionController',
 					method: 'checkData',
-					format: 'json',
+					type: 'GET',
 					data: {
 						articleId: window.wgArticleId ? window.wgArticleId:0 
 					},


### PR DESCRIPTION
Make cacheable GET requests to RelatedForumDiscussionController instead of POST.
- force JSON format on the backend side, to have consistent URLs (in AJAX requests and those pushed to purger queue)
- cache on backend for 6 hours, no caching on client-side

This change will remove a huge part of 10mm requests backend receives daily.

@nandy-andy / @RafLeszczynski / @themech / @prein / @michalroszka 
