### PR TITLE
Chat code sends purge request to the URL that returns 404

### DIFF
--- a/extensions/wikia/Chat2/ChatAjax.class.php
+++ b/extensions/wikia/Chat2/ChatAjax.class.php
@@ -123,8 +123,6 @@ class ChatAjax {
 
 		NodeApiClient::setChatters($wgRequest->getArray('users'));
 
-		ChatRailController::purgeMethod("content");
-
 		wfProfileOut( __METHOD__ );
 		return array('status' => $wgRequest->getArray('users') );
 	}


### PR DESCRIPTION
Chat code sends a lot of purge requests that return 404. This obviously makes no sense and just increases the amount of items in purge requests queue to Fastly.

``` json
{"url":"http:\/\/es.naruto.wikia.com\/wikia.php?controller=ChatRail&method=content","time":1394444796,"method":"ChatAjax:setUsersList"}
```

@prein / @michalroszka / @nandy-andy / @themech 
