### PR TITLE
PLATFORM-113: improvements to lock mechanism in WikiaDataAccess

### DIFF
--- a/includes/wikia/WikiaDataAccess.class.php
+++ b/includes/wikia/WikiaDataAccess.class.php
@@ -14,6 +14,8 @@ class WikiaDataAccess {
 	 **********************************/
 
 	const LOCK_TIMEOUT = 60; // lock for at most 60s
+	const LOCK_WAIT_INTERVAL_START = 10; // start with 10ms delay
+	const LOCK_WAIT_INTERVAL_MAX = 1000; // max. delay between lock checks = 1s
 	const CACHE_TIME_FACTOR_FOR_LOCK = 2; // How many times longer cache should be valid when using cacheWithLock
 
 	/**
@@ -199,11 +201,12 @@ class WikiaDataAccess {
 	static private function lock( $key, $waitForLock = true ) {
 		$app = F::app();
 		$wasLocked = false;
-		$timeout = $waitForLock ? self::LOCK_TIMEOUT : 1;
-		$gotLock = false;
-		for ( $i = 0; $i < $timeout && !($gotLock = $app->wg->Memc->add( $key, 1, self::LOCK_TIMEOUT )); $i++ ) {
+		$timeout = $waitForLock ? (microtime(true) + self::LOCK_TIMEOUT) : 0;
+		$interval = self::LOCK_WAIT_INTERVAL_START;
+		while ( !($gotLock = $app->wg->Memc->add( $key, 1, self::LOCK_TIMEOUT )) && microtime(true) < $timeout ) {
 			$wasLocked = true;
-			sleep( 1 );
+			usleep($interval * 1000); // convert ms to us
+			$interval = min( $interval * 2, self::LOCK_WAIT_INTERVAL_MAX );
 		}
 
 		return array($gotLock, $wasLocked);
@@ -217,6 +220,7 @@ class WikiaDataAccess {
 	 * Internal use by cacheWithLock code-path
 	 */
 	static private function getDataAndVerify( $app, $key ) {
+		$app->wg->Memc->clearLocalCache($key);
 		$result = $app->wg->Memc->get( $key );
 		if( !is_array($result) || $result === false || !isset($result['data']) || !isset($result['time'])) {
 			$result = null;

--- a/includes/wikia/WikiaDataAccess.class.php
+++ b/includes/wikia/WikiaDataAccess.class.php
@@ -136,7 +136,7 @@ class WikiaDataAccess {
 			if( $wasLocked && $gotLock ) {
 				self::unlock( $keyLock );
 				$gotLock = false;
-				$result = ($command == self::USE_CACHE) ? static::getDataAndVerify($app, $key) : null;
+				$result = ($command == self::USE_CACHE) ? static::getDataAndVerify($app, $key, true) : null;
 			}
 
 			if( is_null( $result ) ) {
@@ -216,11 +216,15 @@ class WikiaDataAccess {
 		F::app()->wg->Memc->delete( $key );
 	}
 
-	/*
+	/**
 	 * Internal use by cacheWithLock code-path
+	 *
+	 * @param bool $clearCache set it to true to force checking for updated value
 	 */
-	static private function getDataAndVerify( $app, $key ) {
-		$app->wg->Memc->clearLocalCache($key);
+	static private function getDataAndVerify( $app, $key, $clearLocalCache = false ) {
+		if ( $clearLocalCache ) {
+			$app->wg->Memc->clearLocalCache( $key );
+		}
 		$result = $app->wg->Memc->get( $key );
 		if( !is_array($result) || $result === false || !isset($result['data']) || !isset($result['time'])) {
 			$result = null;


### PR DESCRIPTION
**DO NOT MERGE**

This is an improvement idea for lock mechanism in WikiaDataAccess:
- clear the local in-request cache before repeating get() from memcached
- use increasing interval for lock probing

Still to be done:
- read data key while obtaining a lock
