### PR TITLE
VID-1485 Change getThumbImages request from POST to GET

### DIFF
--- a/extensions/wikia/Lightbox/js/Lightbox.js
+++ b/extensions/wikia/Lightbox/js/Lightbox.js
@@ -1337,7 +1337,7 @@
 				$.nirvana.sendRequest({
 					controller: 'Lightbox',
 					method: 'getThumbImages',
-					type: 'POST',
+					type: 'GET',
 					format: 'json',
 					data: {
 						to: Lightbox.to,


### PR DESCRIPTION
After making this change, the Chrome dev tools verify that these requests are now being cached.
