### PR TITLE
CONN-130: Allow HTML5 elements in ArticleComment html

### DIFF
--- a/includes/wikia/GlobalFunctions.php
+++ b/includes/wikia/GlobalFunctions.php
@@ -1805,8 +1805,8 @@ function wfFixMalformedHTML( $html ) {
 	// what we're using it to fix) see: http://www.php.net/manual/en/domdocument.loadhtml.php#95463
 	libxml_use_internal_errors( true );
 
-	// Make sure loadHTML knows that text is utf-8 (it assumes  ISO-88591)
-	// CONN-130 - Added <!DOCTYPE html> to allow HTML5 tags in the article comment;
+	// Make sure loadHTML knows that text is utf-8 (it assumes ISO-88591)
+	// CONN-130 - Added <!DOCTYPE html> to allow HTML5 tags in the article comment
 	$htmlHeader = '<!DOCTYPE html><head><meta http-equiv="content-type" content="text/html; charset=utf-8"></head>';
 	$domDocument->loadHTML( $htmlHeader . $html );
 

--- a/includes/wikia/GlobalFunctions.php
+++ b/includes/wikia/GlobalFunctions.php
@@ -1805,14 +1805,14 @@ function wfFixMalformedHTML( $html ) {
 	// what we're using it to fix) see: http://www.php.net/manual/en/domdocument.loadhtml.php#95463
 	libxml_use_internal_errors( true );
 
-    // Make sure loadHTML knows that text is utf-8 (it assumes  ISO-88591)
+	// Make sure loadHTML knows that text is utf-8 (it assumes  ISO-88591)
 	// CONN-130 - Added <!DOCTYPE html> to allow HTML5 tags in the article comment;
 	$htmlHeader = '<!DOCTYPE html><head><meta http-equiv="content-type" content="text/html; charset=utf-8"></head>';
 	$domDocument->loadHTML( $htmlHeader . $html );
 
-    // Strip doctype declaration, <html>, <body> tags created by saveHTML, as well as <meta> tag added to
-    // to html above to declare the charset as UTF-8
-    $html = preg_replace(
+	// Strip doctype declaration, <html>, <body> tags created by saveHTML, as well as <meta> tag added to
+	// to html above to declare the charset as UTF-8
+	$html = preg_replace(
 		array(
 			'/^.*?<body>/si', '/^.*?charset=utf-8">/si',
 			'/<\/body><\/html>$/si',

--- a/includes/wikia/GlobalFunctions.php
+++ b/includes/wikia/GlobalFunctions.php
@@ -1799,17 +1799,28 @@ function wfGetNamespaces() {
  * @return string - repaired HTML
  */
 function wfFixMalformedHTML( $html ) {
-	$dom_document = new DOMDocument();
+	$domDocument = new DOMDocument();
 
 	// Silence errors when loading html into DOMDocument (it complains when receiving malformed html - which is
 	// what we're using it to fix) see: http://www.php.net/manual/en/domdocument.loadhtml.php#95463
 	libxml_use_internal_errors( true );
+
     // Make sure loadHTML knows that text is utf-8 (it assumes  ISO-88591)
-    $dom_document->loadHTML( '<meta http-equiv="content-type" content="text/html; charset=utf-8">' . $html );
+	// CONN-130 - Added <!DOCTYPE html> to allow HTML5 tags in the article comment;
+	$htmlHeader = '<!DOCTYPE html><head><meta http-equiv="content-type" content="text/html; charset=utf-8"></head>';
+	$domDocument->loadHTML( $htmlHeader . $html );
+
     // Strip doctype declaration, <html>, <body> tags created by saveHTML, as well as <meta> tag added to
     // to html above to declare the charset as UTF-8
-    $html = preg_replace( array( '/^.*?<body>/si', '/^.*?charset=utf-8">/si', 
-        '/<\/body><\/html>$/si', '/<\/head><\/html>$/si', ), '', $dom_document->saveHTML() );
+    $html = preg_replace(
+		array(
+			'/^.*?<body>/si', '/^.*?charset=utf-8">/si',
+			'/<\/body><\/html>$/si',
+			'/<\/head><\/html>$/si',
+		),
+		'',
+		$domDocument->saveHTML()
+	);
 
 	return $html;
 }

--- a/includes/wikia/tests/FixMalformedHTMLTest.php
+++ b/includes/wikia/tests/FixMalformedHTMLTest.php
@@ -69,6 +69,11 @@ class FixMalformedHTMLTest extends WikiaBaseTest {
 				'auto-closing nested tags',
 				'<table><tr><td><div>Test</td></tr></table>',
 				'<table><tr><td><div>Test</div></td></tr></table>'
+			],
+			[
+				'html5 fugure, figurecaption tags',
+				'<figure><img src="http://example.com/1.jpg"><figcaption>Added</figcaption></figure> asdasd',
+				'<figure><img src="http://example.com/1.jpg"><figcaption>Added</figcaption></figure> asdasd'
 			]
 		];
 	}


### PR DESCRIPTION
This function is called in ArticleComment and it's purpose is to normalize the HTML content from the parser. Thumbnails are embedded using the `<figure>` HTML5 element, which is invalidated if the DOCTYPE is not set in the HTML text.

The change adds the proper HTML5 `<!DOCTYPE html>` for the HTML string and further fixes some small code formatting issues.

Test case is also added to the Unit test, to validate the change.
