### PR TITLE
OasisController: introduce addSkinAssetGroup method

### DIFF
--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -966,6 +966,13 @@ $config['wall_js'] = array(
 	)
 );
 
+$config['wall_notifications_js'] = array(
+	'type' => AssetsManager::TYPE_JS,
+	'assets' => array(
+		'//extensions/wikia/Wall/js/WallNotifications.js',
+	)
+);
+
 $config['wall_mini_editor_js'] = array(
 	'type' => AssetsManager::TYPE_JS,
 	'assets' => array(

--- a/extensions/wikia/RelatedPages/RelatedPages.class.php
+++ b/extensions/wikia/RelatedPages/RelatedPages.class.php
@@ -380,11 +380,7 @@ class RelatedPages {
 				!(Wikia::isMainPage() || !empty( $title ) && !in_array( $title->getNamespace(), $wg->ContentNamespaces )) &&
 				!$app->checkSkin( 'wikiamobile' )
 			) {
-				$scripts = AssetsManager::getInstance()->getURL( 'relatedpages_js' );
-
-				foreach( $scripts as $script ){
-					$wg->Out->addScript( "<script src='{$script}'></script>" );
-				}
+				OasisController::addSkinAssetGroup('relatedpages_js');
 			}
 		}
 

--- a/extensions/wikia/RelatedPages/RelatedPages.class.php
+++ b/extensions/wikia/RelatedPages/RelatedPages.class.php
@@ -380,10 +380,15 @@ class RelatedPages {
 				!(Wikia::isMainPage() || !empty( $title ) && !in_array( $title->getNamespace(), $wg->ContentNamespaces )) &&
 				!$app->checkSkin( 'wikiamobile' )
 			) {
-				$scripts = AssetsManager::getInstance()->getURL( 'relatedpages_js' );
+				if ( $app->checkSkin( 'oasis' ) ) {
+					OasisController::addSkinAssetGroup( 'relatedpages_js' );
+				}
+				else {
+					$scripts = AssetsManager::getInstance()->getURL( 'relatedpages_js' );
 
-				foreach( $scripts as $script ){
-					$wg->Out->addScript( "<script src='{$script}'></script>" );
+					foreach( $scripts as $script ){
+						$wg->Out->addScript( "<script src='{$script}'></script>" );
+					}
 				}
 			}
 		}

--- a/extensions/wikia/RelatedPages/RelatedPages.class.php
+++ b/extensions/wikia/RelatedPages/RelatedPages.class.php
@@ -380,7 +380,11 @@ class RelatedPages {
 				!(Wikia::isMainPage() || !empty( $title ) && !in_array( $title->getNamespace(), $wg->ContentNamespaces )) &&
 				!$app->checkSkin( 'wikiamobile' )
 			) {
-				OasisController::addSkinAssetGroup('relatedpages_js');
+				$scripts = AssetsManager::getInstance()->getURL( 'relatedpages_js' );
+
+				foreach( $scripts as $script ){
+					$wg->Out->addScript( "<script src='{$script}'></script>" );
+				}
 			}
 		}
 

--- a/extensions/wikia/Wall/notification/WallNotificationsController.class.php
+++ b/extensions/wikia/Wall/notification/WallNotificationsController.class.php
@@ -18,7 +18,7 @@ class WallNotificationsController extends WikiaController {
 		$suppressWallNotifications = $this->areNotificationsSuppressedByExtensions();
 
 		if( $loggedIn && !$suppressWallNotifications ) {
-			$this->response->addAsset( 'extensions/wikia/Wall/js/WallNotifications.js' );
+			OasisController::addSkinAssetGroup('wall_notifications_js');
 			$this->response->addAsset( 'extensions/wikia/Wall/css/WallNotifications.scss' );
 			$this->response->setVal( 'prehide', ( empty( $this->wg->EnableWallExt ) && empty( $this->wg->EnableForumExt ) ) );
 		}

--- a/extensions/wikia/Wall/tests/WallNotificationsControllerTest.php
+++ b/extensions/wikia/Wall/tests/WallNotificationsControllerTest.php
@@ -16,7 +16,7 @@ class WallNotificationsControllerTest extends WikiaBaseTest {
 	 *
 	 * @dataProvider indexDataProvider
 	 */
-	public function testIndex( $isUserLoggedIn, $isUserAllowed, $wgAtCreateNewWikiPageValue, $expectedInScriptString ) {
+	public function testIndex( $isUserLoggedIn, $isUserAllowed, $wgAtCreateNewWikiPageValue, $hasPrehide ) {
 		$userMock = $this->getMock( 'User', [ 'isLoggedIn', 'isAllowed' ], [], '', false );
 		$userMock->expects( $this->once() )
 			->method( 'isLoggedIn' )
@@ -28,13 +28,8 @@ class WallNotificationsControllerTest extends WikiaBaseTest {
 		$this->mockGlobalVariable( 'wgAtCreateNewWikiPage', $wgAtCreateNewWikiPageValue );
 		$this->mockGlobalVariable( 'wgUser', $userMock );
 
-		$this->app->sendRequest( 'WallNotificationsController', 'Index' );
-
-		if( !is_null( $expectedInScriptString ) ) {
-			$this->assertContains( $expectedInScriptString, $this->app->wg->Out->getScript() );
-		} else {
-			$this->assertNotContains( $expectedInScriptString, $this->app->wg->Out->getScript() );
-		}
+		$resp = $this->app->sendRequest( 'WallNotificationsController', 'Index' );
+		$this->assertEquals( $hasPrehide, is_bool($resp->getVal('prehide')) );
 	}
 
 	public function indexDataProvider() {
@@ -43,49 +38,49 @@ class WallNotificationsControllerTest extends WikiaBaseTest {
 				'isUserLoggedIn' => true,
 				'isUserAllowed' => true,
 				'wgAtCreateNewWikiPageValue' => null,
-				'expectedInScriptString' => 'WallNotifications.js',
+				'hasPrehide' => true,
 				'undefined $wgAtCreateNewWikiPage and user IS logged-in and IS allowed to read -- assets ARE added'
 			],
 			[
 				'isUserLoggedIn' => false,
 				'isUserAllowed' => true,
 				'wgAtCreateNewWikiPageValue' => null,
-				'expectedInScriptString' => null,
+				'hasPrehide' => false,
 				'undefined $wgAtCreateNewWikiPage and user IS NOT logged-in and IS allowed to read -- assets assets ARE NOT added'
 			],
 			[
 				'isUserLoggedIn' => false,
 				'isUserAllowed' => false,
 				'wgAtCreateNewWikiPageValue' => null,
-				'expectedInScriptString' => null,
+				'hasPrehide' => false,
 				'undefined $wgAtCreateNewWikiPage and user IS NOT logged-in and IS NOT allowed to read -- assets assets ARE NOT added'
 			],
 			[
 				'isUserLoggedIn' => false,
 				'isUserAllowed' => false,
 				'wgAtCreateNewWikiPageValue' => true,
-				'expectedInScriptString' => null,
+				'hasPrehide' => false,
 				'A create new wiki page and user IS NOT logged-in and IS NOT allowed to read -- assets assets ARE NOT added'
 			],
 			[
 				'isUserLoggedIn' => true,
 				'isUserAllowed' => true,
 				'wgAtCreateNewWikiPageValue' => true,
-				'expectedInScriptString' => null,
+				'hasPrehide' => false,
 				'A create new wiki page and user IS logged-in and IS allowed to read -- assets ARE NOT added'
 			],
 			[
 				'isUserLoggedIn' => false,
 				'isUserAllowed' => false,
 				'wgAtCreateNewWikiPageValue' => false,
-				'expectedInScriptString' => null,
+				'hasPrehide' => false,
 				'NOT a create new wiki page and user IS NOT logged-in and IS NOT allowed to read -- assets ARE NOT added'
 			],
 			[
 				'isUserLoggedIn' => true,
 				'isUserAllowed' => true,
 				'wgAtCreateNewWikiPageValue' => false,
-				'expectedInScriptString' => 'WallNotifications.js',
+				'hasPrehide' => true,
 				'NOT a create new wiki page and user IS logged-in and IS allowed to read -- assets ARE added'
 			],
 		];

--- a/skins/oasis/modules/OasisController.class.php
+++ b/skins/oasis/modules/OasisController.class.php
@@ -2,8 +2,9 @@
 
 class OasisController extends WikiaController {
 
-	private static $extraBodyClasses = array();
-	private static  $bodyParametersArray = array();
+	private static $extraBodyClasses = [];
+	private static $bodyParametersArray = [];
+	private static $skinAssetGroups = [];
 
 	/* @var AssetsManager */
 	private $assetsManager;
@@ -422,6 +423,10 @@ class OasisController extends WikiaController {
 			$jsAssetGroups[] = 'oasis_anon_js';
 		}
 		wfRunHooks('OasisSkinAssetGroups', array(&$jsAssetGroups));
+
+		// add groups queued via OasisController::addSkinAssetGroup
+		$jsAssetGroups = array_merge($jsAssetGroups, self::$skinAssetGroups);
+
 		$assets = array();
 
 		$assets['oasis_shared_js'] = $this->assetsManager->getURL($jsAssetGroups);
@@ -600,5 +605,14 @@ EOT;
 
 	public static function addBodyParameter($parameter) {
 		static::$bodyParametersArray[] = $parameter;
+	}
+
+	/**
+	 * Adds given AssetsManager group to Oasis main non-blocking JS request
+	 *
+	 * @param string $group group name
+	 */
+	public static function addSkinAssetGroup($group) {
+		self::$skinAssetGroups[] = $group;
 	}
 }


### PR DESCRIPTION
This change introduces `OasisController::addSkinAssetGroup` helper method for adding AssetsManager groups to the main Oasis JS request.

An example:

```
/__am/123456/groups/-/oasis_shared_core_js,adengine2_js,oasis_shared_js,oasis_user_js,liftium_ads_js,toc_js,qualtrics_zone_code_injector_js,qualaroo_js,relatedpages_js,wall_notifications_js
```

Calling this method is much simpler than binding to `OasisSkinAssetGroups` hook that usually requires copying the logic (see the WallNotifications and RelatedPages code that is ported to this helper method as an example).

Replacing `$this->response->addAsset` will remove one additional HTTP request by requesting all needed AssetsManager groups in one single request.

@Wikia/platform-team / @sebastian-wikia  / @nandy-andy / @RafLeszczynski
