### PR TITLE
tighten up external sass compiler invokation and error checking

### DIFF
--- a/includes/wikia/services/sass/SassService.class.php
+++ b/includes/wikia/services/sass/SassService.class.php
@@ -226,7 +226,12 @@ class SassService extends WikiaObject {
 			foreach ($filters as $filter) {
 				$styles = $filter->process($styles);
 			}
+			$styles = trim($styles);
 			$end = microtime(true);
+
+			if (empty($styles)) {
+				throw new \Wikia\Sass\Exception('Empty style');
+			}
 
 			$ok = true;
 


### PR DESCRIPTION
@Wikia/platform-team 
https://wikia-inc.atlassian.net/browse/PLATFORM-102

From the urls that have been posted on this problem, it looks like sass compilation completes, but the resulting file is empty. This tightens it up to make it impossible for that result to get cached in memcache.
