### PR TITLE
VOLDEV-51: Fix broken section edit links in Community-corner

### DIFF
--- a/includes/cache/MessageCache.php
+++ b/includes/cache/MessageCache.php
@@ -115,6 +115,10 @@ class MessageCache {
 	function getParserOptions() {
 		if ( !$this->mParserOptions ) {
 			$this->mParserOptions = new ParserOptions;
+			// Wikia change - begin - @author: TK-999
+			// Backporting upstream fix https://git.wikimedia.org/commit/mediawiki%2Fcore.git/ac97386173bde921e4c53c343bc7b40fcfb4d2b9
+			$this->mParserOptions->setEditSection( false );
+			// Wikia change - end
 		}
 		return $this->mParserOptions;
 	}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/VOLDEV-51

This commit backports the core MediaWiki fix to bug 36975 (https://bugzilla.wikimedia.org/show_bug.cgi?id=36975) by disabling section edit links in parsed messages.
@Grunny @michalroszka 
