### PR TITLE
Fix textarea overflowing its container

### DIFF
--- a/extensions/wikia/SpecialContact2/SpecialContact.scss
+++ b/extensions/wikia/SpecialContact2/SpecialContact.scss
@@ -49,6 +49,9 @@ img.contactCaptch {
 
 	textarea {
 		display: block;
+		-moz-box-sizing: border-box; 
+		-webkit-box-sizing: border-box; 
+		box-sizing: border-box; 
 		width: 100%;
 		height: 15em;
 


### PR DESCRIPTION
The problem was not a 100% width of textarea but a border that was increasing the overall width. With box-sizing: border-box everything is fine.
