### PR TITLE
Indexing new field -- wiki-scoped title tag data

### DIFF
--- a/extensions/wikia/Search/classes/IndexService/CrossWikiCore.php
+++ b/extensions/wikia/Search/classes/IndexService/CrossWikiCore.php
@@ -25,7 +25,6 @@ class CrossWikiCore extends AbstractWikiService
 	 * @see \Wikia\Search\IndexService\AbstractService::execute()
 	 */
 	public function execute() {
-		
 		return array_merge(
 				$this->getWikiBasics(),
 				$this->getWikiStats(),
@@ -61,6 +60,7 @@ class CrossWikiCore extends AbstractWikiService
 		$response['hostname_s'] = $service->getHostName();
 		$response['hostname_txt'] = $response['hostname_s'];
 		$response['domains_txt'] = $service->getDomainsForWikiId( $this->wikiId );
+		$response['wiki_pagetitle_txt'] = str_replace( '$1 - ', '', ( \wfMessage( 'Pagetitle' )->text() ) );
 		return $response;
 	}
 	

--- a/extensions/wikia/Search/classes/Test/IndexService/CrossWikiCoreTest.php
+++ b/extensions/wikia/Search/classes/Test/IndexService/CrossWikiCoreTest.php
@@ -94,13 +94,18 @@ class CrossWikiCoreTest extends BaseTest
 		
 		$mwService = $this->getMock( 'Wikia\Search\MediaWikiService', [ 'getWikiId', 'getGlobal', 'getLanguageCode', 'getHubForWikiId', 'getHostName', 'getDomainsForWikiId' ] );
 		
+		$mockMessage = $this->getMockBuilder( 'WfMessage' )
+							->disableOriginalConstructor()
+							->setMethods( [ 'text' ] )
+							->getMock();
+
 		$mockWiki = (object) [ 
 				'city_created' => '11:11:11 2013-01-01', 
 				'city_last_timestamp' => '11:11:11 2013-01-01', 
 				'city_url' => 'http://foo.wikia.com/',
 				'city_dbname' => 'foo'
 				];
-		
+
 		$service
 		    ->expects( $this->once() )
 		    ->method ( 'getService' )
@@ -139,12 +144,19 @@ class CrossWikiCoreTest extends BaseTest
 		    ->with   ( 123 )
 		    ->will   ( $this->returnValue( [ 'bar.wikia.com', 'baz.wikia.com', 'foo.wikia.com' ] ) )
 		;
+		$mockMessage
+			->expects( $this->once() )
+			->method ( 'text' )
+			->will   ( $this->returnValue( '$1 - Foo Wiki - Bar, Baz and More!' ) )
+		;
 		$expected = [ 
 				'id' => 123, 'sitename_txt' => 'foo wiki', 'lang_s' => 'en', 'hub_s' => 'Gaming', 
 				'created_dt' => '11:11:11T2013-01-01Z', 'touched_dt' => '11:11:11T2013-01-01Z', 'url' => 'http://foo.wikia.com/', 'dbname_s' => 'foo',
 				'hostname_s' => 'hostname', 'hostname_txt' => 'hostname', 'domains_txt' => [ 'bar.wikia.com', 'baz.wikia.com', 'foo.wikia.com' ],
+				'wiki_pagetitle_txt' => 'Foo Wiki - Bar, Baz and More!',
 				];
 		$this->proxyClass( 'WikiFactory', $mockWiki, 'getWikiById' );
+		$this->mockGlobalFunction( 'WfMessage', $mockMessage );
 		$ref = new ReflectionMethod( $service, 'getWikiBasics' );
 		$ref->setAccessible( true );
 		$this->assertEquals(


### PR DESCRIPTION
This adds the user-configurable "pagetitle" message to the cross-wiki document.

After testing on dev-indexer-s4, the impact on the cross-wiki core's index appears to be negligible (i.e. within .1 GB difference).

This update will not have an effect on search relevance unless the cross-wiki query service is updated.

We want to store this value in Solr for some experiments the NLP group is working on, since it's currently serving as a canonical source of denormalized data about the wiki. We also think that this could be useful for improved search relevance in the future.
