### PR TITLE
CONN-464: Added 60s caching on Notif::getUpdateCounts; Switched to GET;

### DIFF
--- a/extensions/wikia/Wall/js/WallNotifications.js
+++ b/extensions/wikia/Wall/js/WallNotifications.js
@@ -113,14 +113,11 @@ var WallNotifications = $.createClass(Object, {
 
 		if ( this.updateInProgress == false ) {
 			this.updateInProgress = true;
-
 			$.nirvana.sendRequest({
 				controller: 'WallNotificationsExternalController',
 				method: 'getUpdateCounts',
 				format: 'json',
-				data: {
-					username: wgTitle
-				},
+				type: 'GET',
 				callback: callback
 			});
 		}

--- a/extensions/wikia/Wall/notification/WallNotificationsExternalController.class.php
+++ b/extensions/wikia/Wall/notification/WallNotificationsExternalController.class.php
@@ -62,7 +62,6 @@ class WallNotificationsExternalController extends WikiaController {
 
 			$all = $wn->getCounts( $this->wg->User->getId() );
 
-
 			foreach($all as $k => $wiki) {
 				$sum += $wiki['unread'];
 				$wikiSitename = $wiki['sitename'];

--- a/extensions/wikia/Wall/notification/WallNotificationsExternalController.class.php
+++ b/extensions/wikia/Wall/notification/WallNotificationsExternalController.class.php
@@ -2,6 +2,7 @@
 
 class WallNotificationsExternalController extends WikiaController {
 	const WALL_WIKI_NAME_MAX_LEN = 32;
+	const CACHE_DURATION = 60;
 
 	var $helper;
 	public function __construct() {
@@ -54,27 +55,37 @@ class WallNotificationsExternalController extends WikiaController {
 		wfProfileIn(__METHOD__);
 
 		$app = F::app();
-		$all = $wn->getCounts( $this->wg->User->getId() );
-
 		$sum = 0;
-		foreach($all as $k => $wiki) {
-			$sum += $wiki['unread'];
-			$wikiSitename = $wiki['sitename'];
 
-			if( mb_strlen($wikiSitename) > self::WALL_WIKI_NAME_MAX_LEN ) {
-				$all[$k]['sitename'] = $app->wg->Lang->truncate($wikiSitename, (self::WALL_WIKI_NAME_MAX_LEN - 3) );
+		// CONN-464: Skip data collection if user is not logged in
+		if ( $this->wg->User->getId() ) {
+
+			$all = $wn->getCounts( $this->wg->User->getId() );
+
+
+			foreach($all as $k => $wiki) {
+				$sum += $wiki['unread'];
+				$wikiSitename = $wiki['sitename'];
+
+				if( mb_strlen($wikiSitename) > self::WALL_WIKI_NAME_MAX_LEN ) {
+					$all[$k]['sitename'] = $app->wg->Lang->truncate($wikiSitename, (self::WALL_WIKI_NAME_MAX_LEN - 3) );
+				}
 			}
+
+			//solution for problem with cross wiki notification and no wikia domain.
+			$notificationKey = uniqid();
+
+			$app->wg->Memc->set($notificationKey,  $this->wg->User->getId() );
 		}
-
-		//solution for problem with cross wiki notification and no wikia domain.
-		$notificationKey = uniqid();
-
-		$app->wg->Memc->set($notificationKey,  $this->wg->User->getId() );
 
 		$this->response->setVal('html', $this->app->renderView( 'WallNotifications', 'Update', array('notificationCounts' => $all, 'count' => $sum, 'notificationKey' => $notificationKey) ));
 		$this->response->setVal('count', $sum);
 		$this->response->setVal('reminder', wfMessage('wall-notifications-reminder', $sum)->text() );
 		$this->response->setVal('status', true);
+
+		// CONN-464: Add CACHE_DURATION seconds browser cache for the response
+		$this->response->setCachePolicy( WikiaResponse::CACHE_PRIVATE );
+		$this->response->setCacheValidity( self::CACHE_DURATION );
 
 		wfProfileOut(__METHOD__);
 	}

--- a/extensions/wikia/Wall/notification/WallNotificationsExternalController.class.php
+++ b/extensions/wikia/Wall/notification/WallNotificationsExternalController.class.php
@@ -2,7 +2,7 @@
 
 class WallNotificationsExternalController extends WikiaController {
 	const WALL_WIKI_NAME_MAX_LEN = 32;
-	const CACHE_DURATION = 60;
+	const CACHE_DURATION = 900;
 
 	var $helper;
 	public function __construct() {
@@ -58,7 +58,7 @@ class WallNotificationsExternalController extends WikiaController {
 		$sum = 0;
 
 		// CONN-464: Skip data collection if user is not logged in
-		if ( $this->wg->User->getId() ) {
+		if ( $this->wg->User->isLoggedIn() ) {
 
 			$all = $wn->getCounts( $this->wg->User->getId() );
 


### PR DESCRIPTION
This pull request deals with TopNav Notifications caching
- The **WallNotificationsExternal::getUpdateCounts** call gets cached for 60 seconds in the user browser;
- Removed the **username: wgTitle** param from the request as it is not used and also doesn't make much sense except as a cache-buster, which we're trying to prevent;
- Added conditional notification collection for logged users only to prevent potentially expensive and not required operation in case the user session has expired, but the user hasn't refreshed the page yet.

@macbre can you please take a look if the code is OK and if the caching interval is sufficient
