### PR TITLE
VID-1527 fixing VET for multiple loads

### DIFF
--- a/extensions/wikia/VideoEmbedTool/js/VET_Loader.js
+++ b/extensions/wikia/VideoEmbedTool/js/VET_Loader.js
@@ -33,6 +33,10 @@
 		vetLoader = {},
 		template = '';
 
+	/**
+	 * Load template, js, scss, and messages. Only called the first time VET is opened.
+	 * @returns {Array}
+	 */
 	function loadResources() {
 		var deferredList = [];
 
@@ -79,6 +83,7 @@
 			$elem.stopThrobbing();
 			return;
 		} else if (window.wgUserName === null) {
+			// handle login on article page
 			window.UserLoginModal.show({
 				origin: 'vet',
 				callback: function () {
@@ -87,7 +92,6 @@
 				}
 			});
 			$elem.stopThrobbing();
-			// handle login on article page
 			return;
 		}
 
@@ -105,6 +109,7 @@
 		}
 
 		$.when.apply($, resourceList).done(function (templateResp) {
+			// If this is the first time resources are loaded, cache the template string
 			if (!resourcesLoaded) {
 				template = templateResp[0];
 			}
@@ -127,6 +132,7 @@
 
 				vet.show(options);
 
+				// resources are now officially loaded
 				resourcesLoaded = true;
 			});
 		});

--- a/extensions/wikia/VideoEmbedTool/js/VET_Loader.js
+++ b/extensions/wikia/VideoEmbedTool/js/VET_Loader.js
@@ -31,7 +31,7 @@
 	var resourcesLoaded = false,
 		modalOnScreen = false,
 		vetLoader = {},
-		UserLoginModal = window.UserLoginModal;
+		template = '';
 
 	function loadResources() {
 		var deferredList = [];
@@ -79,7 +79,7 @@
 			$elem.stopThrobbing();
 			return;
 		} else if (window.wgUserName === null) {
-			UserLoginModal.show({
+			window.UserLoginModal.show({
 				origin: 'vet',
 				callback: function () {
 					window.UserLogin.forceLoggedIn = true;
@@ -105,12 +105,16 @@
 		}
 
 		$.when.apply($, resourceList).done(function (templateResp) {
+			if (!resourcesLoaded) {
+				template = templateResp[0];
+			}
+
 			$elem.stopThrobbing();
 
 			// now that VET is loaded, require it.
 			require(['wikia.vet'], function (vet) {
 
-				vetLoader.modal = $(templateResp[0]).makeModal({
+				vetLoader.modal = $(template).makeModal({
 					width: 939,
 					onClose: function () {
 						vet.close();


### PR DESCRIPTION
Fixing bug after VET refactor. Subsequent loads were missing the template string. 
