### PR TITLE
Move BopFm widget above TOP_RIGHT_BOXAD as per LYR-113

### DIFF
--- a/extensions/3rdparty/LyricWiki/BopFm/BopFmRailController.class.php
+++ b/extensions/3rdparty/LyricWiki/BopFm/BopFmRailController.class.php
@@ -9,8 +9,8 @@ class BopFmRailController extends WikiaController {
 		global $wgUser;
 		wfProfileIn(__METHOD__);
 
-		// 1395 is a bit below the Wikia Game Helper (1400) in case there is a game, but above most other things.
-		$modules[1395] = array('BopFmRail', 'bop', null);
+		// Move BopFm module above the TOP_RIGHT_BOXAD (side effect: this module will not be lazy-loaded). - LYR-113
+		$modules[1495] = array('BopFmRail', 'bop', null);
 
 		wfProfileOut(__METHOD__);
 		return true;


### PR DESCRIPTION
Performance side-note:

The way it works is that the TOP_RIGHT_BOXAD is a rail module with priority 1490 (higher number shows higher on page).

Everything with below a priority of LAZY_LOADING_BEAKPOINT (1440) is Lazy-Loaded. So we can set the prio to 1495 to appear above the TOP_RIGHT_BOXAD, but this will have the side-effect of making the Bop module NOT be lazy-loaded.
