### PR TITLE
CON-861 Load two lazyrail-related assets in existing groups

### DIFF
--- a/extensions/wikia/AdminDashboard/AdminDashboardSpecialPageController.class.php
+++ b/extensions/wikia/AdminDashboard/AdminDashboardSpecialPageController.class.php
@@ -74,7 +74,6 @@ class AdminDashboardSpecialPageController extends WikiaSpecialPageController {
 
 		// add messages package
 		JSMessages::enqueuePackage('AdminDashboard', JSMessages::INLINE);
-		$this->response->addAsset('skins/oasis/js/LatestPhotos.js');
 	}
 
 	/**

--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -312,6 +312,7 @@ $config['oasis_anon_js'] = array(
 		'//extensions/wikia/UserLogin/js/UserLoginFacebook.js',
 		'//extensions/wikia/UserLogin/js/UserLoginFacebookForm.js',
 		'//extensions/wikia/UserLogin/js/UserLoginDropdown.js',
+		'//skins/oasis/js/LatestActivity.js',
 	)
 );
 
@@ -1728,6 +1729,7 @@ $config['lazy_rail_js'] = [
 	'type' => AssetsManager::TYPE_JS,
 	'skin' => ['oasis'],
 	'assets' => [
-		'//skins/oasis/js/LazyRail.js'
+		'//skins/oasis/js/LazyRail.js',
+		'//skins/oasis/js/LatestPhotos.js',
 	]
 ];

--- a/extensions/wikia/WikiaNewFiles/WikiaNewFiles.class.php
+++ b/extensions/wikia/WikiaNewFiles/WikiaNewFiles.class.php
@@ -9,7 +9,6 @@ class WikiaNewFiles extends SpecialNewFiles {
 	function execute( $par ) {
 		$this->mName  = 'WikiaNewFiles';
 		$this->setHeaders();
-		Wikia::addAssetsToOutput( '/skins/oasis/js/LatestPhotos.js' );
 
 		wfSpecialWikiaNewFiles( $par, $this );
 	}

--- a/skins/oasis/js/LatestActivity.js
+++ b/skins/oasis/js/LatestActivity.js
@@ -26,5 +26,8 @@ var LatestActivity = {
 };
 
 $(window).load(function() {
-	LatestActivity.init();
+	$('.WikiaRail').on('afterLoad.rail', function() {
+		LatestActivity.init();
+	});
 });
+

--- a/skins/oasis/js/LatestPhotos.js
+++ b/skins/oasis/js/LatestPhotos.js
@@ -210,15 +210,15 @@ var UploadPhotos = {
 };
 
 var LatestPhotos = {
-    init: function () {
-        this.carousel = $('.LatestPhotosModule').find('.carousel-container');
-        this.carousel.carousel({attachBlindImages: true})
-    }
+	init: function () {
+		this.carousel = $('.LatestPhotosModule').find('.carousel-container');
+		this.carousel.carousel({attachBlindImages: true})
+	}
 };
 
 $(function () {
-    $(".WikiaRail").on('afterLoad.rail', function () {
-        LatestPhotos.init();
-    });
-    UploadPhotos.init();
+	$(".WikiaRail").on('afterLoad.rail', function () {
+		LatestPhotos.init();
+	});
+	UploadPhotos.init();
 });

--- a/skins/oasis/js/LatestPhotos.js
+++ b/skins/oasis/js/LatestPhotos.js
@@ -210,13 +210,15 @@ var UploadPhotos = {
 };
 
 var LatestPhotos = {
-	init: function() {
-		this.carousel = $('.LatestPhotosModule').find('.carousel-container');
-		this.carousel.carousel({attachBlindImages: true});
-	}
+    init: function () {
+        this.carousel = $('.LatestPhotosModule').find('.carousel-container');
+        this.carousel.carousel({attachBlindImages: true})
+    }
 };
 
-$(function() {
-    LatestPhotos.init();
+$(function () {
+    $(".WikiaRail").on('afterLoad.rail', function () {
+        LatestPhotos.init();
+    });
     UploadPhotos.init();
 });

--- a/skins/oasis/js/LatestPhotos.js
+++ b/skins/oasis/js/LatestPhotos.js
@@ -6,11 +6,14 @@ var UploadPhotos = {
 	status: false,
 	libinit: false,
 	init: function() {
-		// Special:NewFiles and LatestPhotos module
-		$(".upphotos").on('click.uploadPhotos', $.proxy(this.loginBeforeShowDialog, this));
+		// LatestPhotos module and Special:NewFiles
+		$(".WikiaRail,.mw-special-Newimages").on('click', '.upphotos', $.proxy(this.loginBeforeShowDialog, this));
+
 		// LatestPhotos module only
-		$('#LatestPhotosModule').find('.upphotos, .upphotoslogin').tooltip({
-			delay: { show: 500, hide: 100 }
+		$(".WikiaRail").on('afterLoad.rail', function() {
+			$('#LatestPhotosModule').find('.upphotos, .upphotoslogin').tooltip({
+				delay: { show: 500, hide: 100 }
+			});
 		});
 	},
 	loginBeforeShowDialog: function(evt) {

--- a/skins/oasis/modules/LatestActivityController.class.php
+++ b/skins/oasis/modules/LatestActivityController.class.php
@@ -92,9 +92,6 @@ class LatestActivityController extends WikiaController {
 			}
 		}
 
-		if ($wgUser->isAnon()) {
-			$this->response->addAsset('skins/oasis/js/LatestActivity.js');
-		}
 		// Cache the response in CDN and browser
 		$this->response->setCacheValidity(600);
 		

--- a/skins/oasis/modules/LatestPhotosController.class.php
+++ b/skins/oasis/modules/LatestPhotosController.class.php
@@ -21,8 +21,6 @@ class LatestPhotosController extends WikiaController {
 	public function executeIndex() {
 		global $wgUser, $wgMemc;
 
-		$this->response->addAsset('skins/oasis/js/LatestPhotos.js');
-
 		$this->isUserLoggedIn = $wgUser->isLoggedIn();
 
 		// get the count of images on this wiki


### PR DESCRIPTION
It doesn't seem to be worth it to load it separately for other page types
based on page type ratios and gzipped size of those files
@lizlux Can you also take a look, as click.uploadPhotos was removed? (it was introduced for one specific reason - custom JS on harrypotter wikia - that seems to be gone now)
