### PR TITLE
Use nocookie domain when serving assets from $.getAssetManagerGroupUrl

### DIFF
--- a/extensions/wikia/AssetsManager/AssetsManager.class.php
+++ b/extensions/wikia/AssetsManager/AssetsManager.class.php
@@ -53,14 +53,12 @@ class AssetsManager {
 	}
 
 	public static function onMakeGlobalVariablesScript(Array &$vars) {
-		global $wgCdnRootUrl, $wgAssetsManagerQuery;
+		global $wgAssetsManagerQuery;
 
 		$params = SassUtil::getSassSettings();
 
 		$vars['sassParams'] = $params;
 		$vars['wgAssetsManagerQuery'] = $wgAssetsManagerQuery;
-		$vars['wgCdnRootUrl'] = $wgCdnRootUrl; // TODO: wgCdnStylePath?
-
 		return true;
 	}
 

--- a/resources/wikia/jquery.wikia.js
+++ b/resources/wikia/jquery.wikia.js
@@ -28,12 +28,12 @@ $.getAssetManagerGroupUrl = function( groups, params ) {
 
 	params = params || {};
 
-	// Don't minify asset if we're on devbox
-	if ( window.wgDevelEnvironment ) {
+	// Don't minify the response when allinone=0
+	if ( window.debug === true ) {
 		params.minify = 0;
 	}
 
-	return wgAssetsManagerQuery .
+	return wgCdnRootUrl + wgAssetsManagerQuery .
 		replace( '%1$s', 'groups' ) .
 		replace( '%2$s', groups.join( ',' ) ) .
 		replace( '%3$s', $.isEmptyObject( params ) ? '-' : encodeURIComponent( $.param( params ) ) ) .


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-203

And cleanup of `wgCdnRootUrl` global (emit it only once from JSVariables)

@michalroszka / @prein / @lizlux 
