### PR TITLE
Fixed indexer test after indroducing wgSolrDefaultPort global

### DIFF
--- a/extensions/wikia/Search/classes/Test/IndexerTest.php
+++ b/extensions/wikia/Search/classes/Test/IndexerTest.php
@@ -597,10 +597,10 @@ class IndexerTest extends BaseTest
 		    ->will   ( $this->returnValue( true ) )
 		;
 		$mwService
-		    ->expects( $this->any() )
-		    ->method ( 'getGlobal' )
-		    ->with   ( 'SolrMaster' )
-		    ->will   ( $this->returnValue( 'search' ) )
+			->expects( $this->any() )
+			->method ( 'getGlobal' )
+			// first called with 'SolrMaster' then with 'SolrDefaultPort'
+			->will   ( $this->onConsecutiveCalls( 'search', 1234 ) )
 		;
 		$this->assertAttributeEmpty(
 				'client',


### PR DESCRIPTION
We discussed creating a new PHP global variable in the https://github.com/Wikia/app/pull/3336#discussion_r11442427 Unfortunately, it broke unit tests. Here is the fix for it. @relwell take a look, please :)
