### PR TITLE
(CE-755) Disallow login via FBConnect for disabled accounts

### DIFF
--- a/extensions/wikia/EditAccount/SpecialEditAccount_body.php
+++ b/extensions/wikia/EditAccount/SpecialEditAccount_body.php
@@ -372,6 +372,7 @@ class EditAccount extends SpecialPage {
 
 		# close account and invalidate cache + cluster data
 		Wikia::invalidateUser( $user, true, true );
+		self::disconnectFBConnect( $user );
 
 		if ( $user->getEmail() == ''  ) {
 			$title = Title::newFromText( 'EditAccount', NS_SPECIAL );
@@ -387,6 +388,22 @@ class EditAccount extends SpecialPage {
 			// There were errors...inform the user about those
 			$mStatusMsg = wfMessage( 'editaccount-error-close', $user->mName )->plain();
 			return false;
+		}
+	}
+
+	/**
+	 * Disconnect Facebook account from Wikia account
+	 *
+	 * @param  User   $user The user account to disconnect
+	 * @return void
+	 */
+	public static function disconnectFBConnect( User $user ) {
+		global $wgEnableFacebookConnectExt;
+		if ( !empty( $wgEnableFacebookConnectExt ) ) {
+			$fbIds = FBConnectDB::getFacebookIDs( $user );
+			if ( !empty( $fbIds ) ) {
+				FBConnectDB::removeFacebookID( $user );
+			}
 		}
 	}
 

--- a/extensions/wikia/EditAccount/SpecialEditAccount_body.php
+++ b/extensions/wikia/EditAccount/SpecialEditAccount_body.php
@@ -344,6 +344,7 @@ class EditAccount extends SpecialPage {
 	 * @return Boolean: true on success, false on failure
 	 */
 	public static function closeAccount( $user = '', $changeReason = '', &$mStatusMsg = '', &$mStatusMsg2 = '' ) {
+		global $wgEnableFacebookConnectExt;
 		if ( empty( $user ) ) {
 			throw new Exception( 'User object is invalid.' );
 		}
@@ -372,7 +373,9 @@ class EditAccount extends SpecialPage {
 
 		# close account and invalidate cache + cluster data
 		Wikia::invalidateUser( $user, true, true );
-		self::disconnectFBConnect( $user );
+		if ( !empty( $wgEnableFacebookConnectExt ) ) {
+			self::disconnectFBConnect( $user );
+		}
 
 		if ( $user->getEmail() == ''  ) {
 			$title = Title::newFromText( 'EditAccount', NS_SPECIAL );
@@ -398,12 +401,9 @@ class EditAccount extends SpecialPage {
 	 * @return void
 	 */
 	public static function disconnectFBConnect( User $user ) {
-		global $wgEnableFacebookConnectExt;
-		if ( !empty( $wgEnableFacebookConnectExt ) ) {
-			$fbIds = FBConnectDB::getFacebookIDs( $user );
-			if ( !empty( $fbIds ) ) {
-				FBConnectDB::removeFacebookID( $user );
-			}
+		$fbIds = FBConnectDB::getFacebookIDs( $user );
+		if ( !empty( $fbIds ) ) {
+			FBConnectDB::removeFacebookID( $user );
 		}
 	}
 

--- a/extensions/wikia/UserLogin/FacebookSignupController.class.php
+++ b/extensions/wikia/UserLogin/FacebookSignupController.class.php
@@ -22,11 +22,8 @@ class FacebookSignupController extends WikiaController {
 
 		if ( ( $user instanceof User ) && ( $fbUserId !== 0 ) ) {
 			$this->errorMsg = '';
-			$userAccountDisabled = $user->getOption( 'disabled' );
 
-			if( !empty( $userAccountDisabled ) ||
-				( defined( 'CLOSED_ACCOUNT_FLAG' ) && $user->getRealName() == CLOSED_ACCOUNT_FLAG )
-			) {
+			if ( $this->isAccountDisabled( $user ) ) {
 				// User account was disabled, abort the login
 				$this->loginAborted = true;
 				$this->errorMsg = wfMessage( 'userlogin-error-edit-account-closed-flag' )->escaped();
@@ -171,5 +168,19 @@ class FacebookSignupController extends WikiaController {
 	private function getFacebookUserId() {
 		$fbApi = new FBConnectAPI();
 		return $fbApi->user();
+	}
+
+	/**
+	 * Check if account is disabled
+	 *
+	 * @param  User    $user User account
+	 * @return boolean       true if the account is disabled,
+	 *                       false otherwise
+	 */
+	private function isAccountDisabled( User $user ) {
+		return $user->getBoolOption( 'disabled' ) || (
+			defined( 'CLOSED_ACCOUNT_FLAG' ) &&
+			$user->getRealName() == CLOSED_ACCOUNT_FLAG
+		);
 	}
 }

--- a/extensions/wikia/UserLogin/js/UserLoginFacebook.js
+++ b/extensions/wikia/UserLogin/js/UserLoginFacebook.js
@@ -13,26 +13,26 @@ var UserLoginFacebook = {
 
 
 
-	log: function( msg ) {
+	log: function (msg) {
 		'use strict';
 
-		$().log( msg, 'UserLoginFacebook' );
+		$().log(msg, 'UserLoginFacebook');
 	},
 
-	init: function( origin ) {
+	init: function (origin) {
 		'use strict';
 
 		var self = this;
 
-		if( !this.initialized ) {
-			require( ['wikia.tracker'], function( tracker ) {
+		if (!this.initialized) {
+			require(['wikia.tracker'], function (tracker) {
 				self.actions = tracker.ACTIONS;
-				self.track = tracker.buildTrackingFunction( {
+				self.track = tracker.buildTrackingFunction({
 					category: 'user-sign-up',
 					value: origin || 0,
 					trackingMethod: 'both'
-				} );
-			} );
+				});
+			});
 
 			this.initialized = true;
 			this.loginSetup();
@@ -40,118 +40,113 @@ var UserLoginFacebook = {
 			// load when the login dropdown is shown - see BugId:68955
 			$.loadFacebookAPI();
 
-			this.log( 'init' );
+			this.log('init');
 		}
 	},
 
-	loginSetup: function() {
+	loginSetup: function () {
 		'use strict';
 
 		var self = this;
 
-		$( 'body' )
-			.off( 'fb' )
-			.on( 'click.fb', '.sso-login-facebook', function( ev ) {
+		$('body')
+			.off('fb')
+			.on('click.fb', '.sso-login-facebook', function (ev) {
 				ev.preventDefault();
 
 				// @see http://developers.facebook.com/docs/reference/javascript/FB.login/
-				window.FB.login( $.proxy( self.loginCallback, self ), {
-					scope:'publish_stream,email'
-				} );
-		} );
+				window.FB.login($.proxy(self.loginCallback, self), {
+					scope: 'publish_stream,email'
+				});
+			});
 	},
 
 	// callback for FB.login
-	loginCallback: function( response ) {
+	loginCallback: function (response) {
 		'use strict';
 
-		if ( typeof response === 'object' && response.status ) {
-			this.log( response );
-			switch ( response.status ) {
+		if (typeof response === 'object' && response.status) {
+			this.log(response);
+			switch (response.status) {
 				case 'connected':
-					this.log( 'FB.login successful' );
+					this.log('FB.login successful');
 
 					// now check FB account (is it connected with Wikia account?)
-					$.nirvana.postJson( 'FacebookSignupController', 'index', $.proxy(
-						this.checkAccountCallback, this )
-					);
+					$.nirvana.postJson('FacebookSignupController', 'index',
+						$.proxy(this.checkAccountCallback, this));
 					break;
 
 				default:
 					// Track FB Connect Error
-					this.track( {
+					this.track({
 						action: this.actions.ERROR,
 						label: 'facebook-login'
-					} );
+					});
 			}
 		}
 	},
 
 	// check FB account (is it connected with Wikia account?)
-	checkAccountCallback: function( resp ) {
+	checkAccountCallback: function (resp) {
 		'use strict';
 
 		var self = this,
 			loginCallback = this.callbacks['login-success'] || '';
 
-		if ( resp.loggedIn ) {
+		if (resp.loggedIn) {
 			// logged in using FB account, reload the page or callback
 
 			// Track FB Connect Login
-			this.track( {
+			this.track({
 				action: this.actions.SUCCESS,
 				label: 'facebook-login'
-			} );
+			});
 
-			if ( loginCallback && typeof loginCallback === 'function' ) {
+			if (loginCallback && typeof loginCallback === 'function') {
 				loginCallback();
 			} else {
-				require( ['wikia.querystring'], function( Qs ) {
+				require(['wikia.querystring'], function (Qs) {
 					var w = window,
 						wgCanonicalSpecialPageName = w.wgCanonicalSpecialPageName,
 						qString = new Qs(),
-						returnTo = ( wgCanonicalSpecialPageName &&
-							( wgCanonicalSpecialPageName.match( /Userlogin|Userlogout/ ) ) ) ? w.wgMainPageTitle : null;
+						returnTo = (wgCanonicalSpecialPageName &&
+							(wgCanonicalSpecialPageName.match(/Userlogin|Userlogout/))) ? w.wgMainPageTitle : null;
 
-					if( returnTo ) {
-						qString.setPath( w.wgArticlePath.replace( '$1', returnTo ) );
+					if (returnTo) {
+						qString.setPath(w.wgArticlePath.replace('$1', returnTo));
 					}
 					qString.addCb().goTo();
-				} );
+				});
 			}
-		} else if ( resp.loginAborted ) {
-			window.GlobalNotification.show( resp.errorMsg, 'error' );
+		} else if (resp.loginAborted) {
+			window.GlobalNotification.show(resp.errorMsg, 'error');
 		} else {
-			require( ['wikia.ui.factory'], function( uiFactory ) {
+			require(['wikia.ui.factory'], function (uiFactory) {
 				$.when(
-					uiFactory.init( 'modal' ),
+					uiFactory.init('modal'),
 					$.getResources(
-						[$.getSassCommonURL( 'extensions/wikia/UserLogin/css/UserLoginFacebook.scss' )]
+						[$.getSassCommonURL('extensions/wikia/UserLogin/css/UserLoginFacebook.scss')]
 					)
-				).then( function( uiModal ) {
+				).then(function (uiModal) {
 					var modalConfig = {
 						vars: {
 							id: 'FacebookSignUp',
 							size: 'medium',
 							content: resp.modal,
 							title: resp.title,
-							buttons: [
-								{
-									vars: {
-										value: resp.cancelMsg,
-										data: [
-											{
-												key: 'event',
-												value: 'close'
-											}
-										]
-									}
+							buttons: [{
+								vars: {
+									value: resp.cancelMsg,
+									data: [{
+										key: 'event',
+										value: 'close'
+									}]
 								}
-							]
+							}]
 						}
 					};
 
-					uiModal.createComponent( modalConfig, function( facebookSignupModal ) {
+					uiModal.createComponent(modalConfig, function (facebookSignupModal) {
 						var form,
 							wikiaForm,
 							signupAjaxForm,
@@ -160,32 +155,32 @@ var UserLoginFacebook = {
 						self.modal = facebookSignupModal; // set reference to modal object
 
 						// Track Facebook Connect Modal Close
-						facebookSignupModal.bind( 'beforeClose', function () {
+						facebookSignupModal.bind('beforeClose', function () {
 							// Track FB Connect Modal Close
-							self.track( {
+							self.track({
 								action: self.actions.CLOSE,
 								label: 'facebook-login-modal'
-							} );
-						} );
+							});
+						});
 
-						self.form = new UserLoginFacebookForm( $modal, {
+						self.form = new UserLoginFacebookForm($modal, {
 							ajaxLogin: true,
-							callback: function( res ) {
+							callback: function (res) {
 								// Track FB Connect Sign Up
-								self.track( {
+								self.track({
 									action: self.actions.SUBMIT,
 									label: 'facebook-login-modal'
-								} );
+								});
 								var location = res.location;
 
 								// redirect to the user page
-								if ( loginCallback && typeof loginCallback === 'function' ) {
+								if (loginCallback && typeof loginCallback === 'function') {
 									loginCallback();
-								} else if ( location ) {
+								} else if (location) {
 									window.location.href = location;
 								}
 							}
-						} );
+						});
 						form = self.form; // cache in local variables
 
 						self.wikiaForm = form.wikiaForm; // re-reference for convinience
@@ -194,51 +189,51 @@ var UserLoginFacebook = {
 						self.signupAjaxForm = new UserSignupAjaxForm(
 							wikiaForm,
 							null,
-							form.el.find( 'input[type=submit]' )
+							form.el.find('input[type=submit]')
 						);
 						signupAjaxForm = self.signupAjaxForm; // cache in local variables
 
 						// attach handlers to modal content
 						$modal
-							.on( 'click', '.FacebookSignupConfigHeader', function( event ) {
+							.on('click', '.FacebookSignupConfigHeader', function (event) {
 								event.preventDefault();
-								$( this ).toggleClass( 'on' ).next( 'form' ).toggle();
-							} )
-							.on( 'blur', 'input[name=username], input[name=password]',
-								$.proxy( signupAjaxForm.validateInput, signupAjaxForm )
+								$(this).toggleClass('on').next('form').toggle();
+							})
+							.on('blur', 'input[name=username], input[name=password]',
+								$.proxy(signupAjaxForm.validateInput, signupAjaxForm)
 							)
-							.on( 'click', '.submit-pane .extiw', function( event ) {
-								require( ['wikia.tracker'], function( tracker ) {
-									tracker.track( {
+							.on('click', '.submit-pane .extiw', function (event) {
+								require(['wikia.tracker'], function (tracker) {
+									tracker.track({
 										action: tracker.ACTIONS.CLICK_LINK_TEXT,
 										browserEvent: event,
 										category: 'user-sign-up',
-										href: $( event.target ).attr( 'href' ),
+										href: $(event.target).attr('href'),
 										label: 'wikia-terms-of-use',
 										trackingMethod: 'both'
-									} );
-								} );
-							} );
+									});
+								});
+							});
 
 						// Track FB Connect Modal Open
-						self.track( {
+						self.track({
 							action: self.actions.OPEN,
 							label: 'facebook-login-modal'
-						} );
+						});
 						facebookSignupModal.show();
-					} );
-				} );
-			} );
+					});
+				});
+			});
 		}
 	},
 
-	closeSignupModal: function() {
+	closeSignupModal: function () {
 		'use strict';
 
 		var modal = this.modal;
 
-		if( modal ) {
-			modal.trigger( 'close' );
+		if (modal) {
+			modal.trigger('close');
 		}
 	}
 };

--- a/extensions/wikia/UserLogin/js/UserLoginFacebook.js
+++ b/extensions/wikia/UserLogin/js/UserLoginFacebook.js
@@ -119,6 +119,8 @@ var UserLoginFacebook = {
 					qString.addCb().goTo();
 				} );
 			}
+		} else if ( resp.loginAborted ) {
+			window.GlobalNotification.show( resp.errorMsg, 'error' );
 		} else {
 			require( ['wikia.ui.factory'], function( uiFactory ) {
 				$.when(


### PR DESCRIPTION
[CE-755](https://wikia-inc.atlassian.net/browse/CE-755)

This stops users from logging in to disabled accounts if they had
connected them to Facebook. Additionally, future account closures
will disconnect the account from Facebook.

This also provides a hook that will allow extensions to prevent a login
via FBConnect and display an error message. This is needed for CloseMyAccount.

@nandy-andy  
