### PR TITLE
CON-1005 | Removed height for Search box from touchScreen.scss

### DIFF
--- a/skins/oasis/css/touchScreen.scss
+++ b/skins/oasis/css/touchScreen.scss
@@ -7,21 +7,31 @@
 }
 
 //make bigger inputs for finger
+//TODO: Check if it's actually used and if not remove it
 input {
 	font-size: 15pt;
 }
 
-.AccountNavigation .UserLoginDropdown .WikiaForm input[type=text],
-.AccountNavigation .UserLoginDropdown .WikiaForm input[type=password] {
+.AccountNavigation .UserLoginDropdown .WikiaForm,
+.UserLogin .WikiaForm,
+.WikiaSignup .form-container .WikiaForm {
+  input[type=text],
+  input[type=password],
+  input[type=submit] {
 	height: 30px;
+  }
+  input[type=text],
+  input[type=password] {
 	font-size: 14px;
+  }
 }
 
-.AccountNavigation .UserLoginDropdown .WikiaForm input[type=submit] {
-	height: 30px;
+.WikiaSignup .form-container .WikiaForm select {
+	height: 35px;
+	width: 32%; //TODO: Make it fill the whole container
 }
 
-//hide facbook description
+//hide facebook description
 #AjaxLoginConnectMarketing div {
 	h1:nth-of-type(2), ul {
 		display: none;
@@ -29,6 +39,8 @@ input {
 }
 
 //fixes for register form
+//TODO: Remove the hacks and do it properly
+//seems to be used in extensions/wikia/SpecialSignup/templates/Signup.php
 #wpName2, #wpEmail, #uselang, #wpBirthYear {
 	position: absolute !important;
 	left: 35px !important;

--- a/skins/oasis/css/touchScreen.scss
+++ b/skins/oasis/css/touchScreen.scss
@@ -7,28 +7,40 @@
 }
 
 //make bigger inputs for finger
-//TODO: Check if it's actually used and if not remove it
 input {
-	font-size: 15pt;
-}
-
-.AccountNavigation .UserLoginDropdown .WikiaForm,
-.UserLogin .WikiaForm,
-.WikiaSignup .form-container .WikiaForm {
-  input[type=text],
-  input[type=password],
-  input[type=submit] {
 	height: 30px;
-  }
-  input[type=text],
-  input[type=password] {
-	font-size: 14px;
-  }
 }
 
-.WikiaSignup .form-container .WikiaForm select {
+select {
 	height: 35px;
-	width: 32%; //TODO: Make it fill the whole container
+}
+
+.AccountNavigation .UserLoginDropdown .WikiaForm {
+	input[type=text],
+	input[type=password],
+	input[type=button],
+	input[type=submit] {
+		height: 30px;
+	}
+}
+
+.WikiaSignup select {
+	width: 103px;
+}
+
+//greater height of inputs makes the one-line-labels break
+.search-filter-sort,
+td.mw-input,
+.wikitable td {
+	input[type=checkbox],
+	input[type=radio] {
+		position: relative;
+		top: 9px;
+	}
+}
+
+td.mw-label {
+	vertical-align: middle;
 }
 
 //hide facebook description

--- a/skins/oasis/css/touchScreen.scss
+++ b/skins/oasis/css/touchScreen.scss
@@ -8,12 +8,7 @@
 
 //make bigger inputs for finger
 input {
-	height: 30px !important;
 	font-size: 15pt;
-}
-
-.WikiaSearch .wikia-button {
-	height: 40px !important;
 }
 
 .AccountNavigation .UserLoginDropdown .WikiaForm input[type=text],

--- a/skins/oasis/css/touchScreen.scss
+++ b/skins/oasis/css/touchScreen.scss
@@ -7,7 +7,11 @@
 }
 
 //make bigger inputs for finger
-input {
+input,
+input[type=button],
+input[type=submit],
+input[type=reset],
+button {
 	height: 30px;
 }
 
@@ -17,9 +21,7 @@ select {
 
 .AccountNavigation .UserLoginDropdown .WikiaForm {
 	input[type=text],
-	input[type=password],
-	input[type=button],
-	input[type=submit] {
+	input[type=password] {
 		height: 30px;
 	}
 }

--- a/skins/oasis/css/touchScreen.scss
+++ b/skins/oasis/css/touchScreen.scss
@@ -52,7 +52,6 @@ td.mw-label {
 
 //fixes for register form
 //TODO: Remove the hacks and do it properly
-//seems to be used in extensions/wikia/SpecialSignup/templates/Signup.php
 #wpName2, #wpEmail, #uselang, #wpBirthYear {
 	position: absolute !important;
 	left: 35px !important;

--- a/skins/oasis/css/touchScreen.scss
+++ b/skins/oasis/css/touchScreen.scss
@@ -13,7 +13,12 @@ input {
 
 .AccountNavigation .UserLoginDropdown .WikiaForm input[type=text],
 .AccountNavigation .UserLoginDropdown .WikiaForm input[type=password] {
+	height: 30px;
 	font-size: 14px;
+}
+
+.AccountNavigation .UserLoginDropdown .WikiaForm input[type=submit] {
+	height: 30px;
 }
 
 //hide facbook description


### PR DESCRIPTION
@qaga @kvas-damian @lukaszkonieczny @vforge I started some testing and this change even fixes the bug where the button becomes few pixels taller than the input field -- in the form on the Special:Search page (like http://fallout.wikia.com/wiki/Special:Search?search=geck&fulltext=Search).
