### PR TITLE
Short circuit swipe event handling for Special:Videos on mobile

### DIFF
--- a/extensions/wikia/SpecialVideos/scripts/mobile/views/index.js
+++ b/extensions/wikia/SpecialVideos/scripts/mobile/views/index.js
@@ -20,6 +20,7 @@ define('specialVideos.mobile.views.index', [
 		this.collection = config.collection;
 		this.filterActiveClass = config.filterActiveClass;
 
+		WikiaMobileMediaControls.disableSwipe();
 		this.initialize();
 	}
 

--- a/extensions/wikia/WikiaMobile/js/media.js
+++ b/extensions/wikia/WikiaMobile/js/media.js
@@ -53,6 +53,7 @@ function(
 		currentMedia,
 		currentWrapper,
 		currentWrapperStyle,
+		disableSwipe,
 		wkMdlImages,
 		qs = querystring(),
 		shrImg = encodeURIComponent( qs.getVal( 'file', '' ) ) || null,
@@ -709,7 +710,8 @@ function(
 						refresh();
 					}
 				},
-				circle: true
+				circle: true,
+				disableSwipe: disableSwipe
 			} );
 
 			function tap ( ev ) {
@@ -798,6 +800,9 @@ function(
 			inited = false;
 			init(document.getElementsByClassName('media'));
 			setup();
+		},
+		disableSwipe: function () {
+			disableSwipe = true;
 		},
 		skip: function () {
 			if ( currentNum - lastNum > 0 ) {

--- a/extensions/wikia/WikiaMobile/js/pager.js
+++ b/extensions/wikia/WikiaMobile/js/pager.js
@@ -219,6 +219,9 @@ define('pager', ['wikia.window'], function (window) {
 
 			},
 			onTouchMove = function(ev){
+				if (options.disableSwipe) {
+					return false;
+				}
 				if ( ev.touches.length === 1 ) {
 					if( isFunction ? !checkCancel() : true ) {
 						ev.preventDefault();


### PR DESCRIPTION
@hakubo Video wants to disable swiping in the modal for the new Special:Videos page. It seems there's no elegant way to simply turn off paging. If I skip loading of the paging module, it will also fail to load content and because of the ad hoc nature of the events, it seems that there isn't a simple opportunity to 'unbind' the events on the main pager elements. Here is my solution to this request, although, I don't particularly like adding more conditions & complexity to an already pretty complex flow. Do you have any better suggestions?

@lizlux @saipetch 
