### PR TITLE
LYR-145 Remove parentheses from song name when there are no results

### DIFF
--- a/extensions/wikia/LyricsApi/LyricsApiController.class.php
+++ b/extensions/wikia/LyricsApi/LyricsApiController.class.php
@@ -87,7 +87,7 @@ class LyricsApiController extends WikiaController {
 				$details = 'Could not find artist which match the criteria';
 				break;
 			case 'searchSong':
-				$details = 'Could not find album which match the criteria';
+				$details = 'Could not find song which match the criteria';
 				break;
 			case 'searchLyrics':
 				$details = 'Could not find song which match the criteria';

--- a/extensions/wikia/LyricsApi/LyricsHandlers/SolrLyricsApiHandler.class.php
+++ b/extensions/wikia/LyricsApi/LyricsHandlers/SolrLyricsApiHandler.class.php
@@ -413,14 +413,17 @@ class SolrLyricsApiHandler {
 	 */
 	public function getSong( LyricsApiSearchParams $searchParams ) {
 		$query = $this->client->createSelect();
-		$queryHelper = $query->getHelper();
 		$lowerCaseSongName = $searchParams->getLowerCaseField( LyricsApiController::PARAM_SONG );
-		$queryText = 'type:"' . $queryHelper->escapeTerm( LyricsUtils::TYPE_SONG ) . '" AND ' .
-			'artist_name_lc:"' . $queryHelper->escapeTerm( $searchParams->getLowerCaseField( LyricsApiController::PARAM_ARTIST ) ) . '" AND ' .
-			'( song_name_lc:"' . $queryHelper->escapeTerm( $lowerCaseSongName ) . '" OR ' .
-			'song_name_lc:"' . $queryHelper->escapeTerm( LyricsUtils::removeBrackets( $lowerCaseSongName ) ) . '" )';
+		$queryText = 'type:%1% AND artist_name_lc:%P2% AND ( song_name_lc:%P3% OR song_name_lc:%P4% )';
 
-		$query->setQuery( $queryText );
+		$params = [
+			LyricsUtils::TYPE_SONG,
+			$searchParams->getLowerCaseField( LyricsApiController::PARAM_ARTIST ),
+			$lowerCaseSongName,
+			LyricsUtils::removeBrackets( $lowerCaseSongName ),
+		];
+
+		$query->setQuery( $queryText, $params );
 		$query->setFields( [
 			'artist_name',
 			'album_id',

--- a/extensions/wikia/LyricsApi/LyricsUtils.class.php
+++ b/extensions/wikia/LyricsApi/LyricsUtils.class.php
@@ -101,4 +101,8 @@ class LyricsUtils {
 		return false;
 	}
 
+	public static function removeBrackets( $string ) {
+		return trim( preg_replace( '#\((.*?)\)#s', '', $string ) );
+	}
+
 }

--- a/extensions/wikia/LyricsApi/LyricsUtils.class.php
+++ b/extensions/wikia/LyricsApi/LyricsUtils.class.php
@@ -102,7 +102,7 @@ class LyricsUtils {
 	}
 
 	public static function removeBrackets( $string ) {
-		return trim( preg_replace( '#\((.*?)\)#s', '', $string ) );
+		return trim( preg_replace( '#(\(|\[)(.*?)(\)|\])#s', '', $string ) );
 	}
 
 }

--- a/extensions/wikia/LyricsApi/tests/LyricsUtilsTest.php
+++ b/extensions/wikia/LyricsApi/tests/LyricsUtilsTest.php
@@ -118,4 +118,45 @@ class LyricsUtilsTest extends WikiaBaseTest {
 			]
 		];
 	}
+
+	/**
+	 * @param String $message
+	 * @param String $input
+	 * @param String $expected
+	 *
+	 * @dataProvider removeBracketsDataProvider
+	 */
+	public function testRemoveBrackets( $message, $input, $expected ) {
+		$this->assertEquals( $expected, LyricsUtils::removeBrackets( $input ), $message );
+	}
+
+	public function removeBracketsDataProvider() {
+		return [
+			[
+				'empty string',
+				'',
+				''
+			],
+			[
+				'empty parenthesis',
+				'()',
+				''
+			],
+			[
+				'parenthesis at the end',
+				'Happy (From "Despicable Me 2")',
+				'Happy'
+			],
+			[
+				'two parenthesis at the end',
+				'Happy (From "Despicable Me 2") (German version)',
+				'Happy'
+			],
+			[
+				'two parenthesis at the end',
+				'Happy (From "Despicable Me 2") (German version)',
+				'Happy'
+			],
+		];
+	}
 }

--- a/extensions/wikia/LyricsApi/tests/LyricsUtilsTest.php
+++ b/extensions/wikia/LyricsApi/tests/LyricsUtilsTest.php
@@ -164,8 +164,18 @@ class LyricsUtilsTest extends WikiaBaseTest {
 			],
 			[
 				'all kinds of brackets',
-				'Give Me Everything (Tonight) (Prod. By Afrojack) (Final) ( 2o11 ) [ www.MzHipHop.com ]',
+				'Give Me Everything (Tonight) (Prod. By Afrojack) (Final) ( 2o11 ) [ www.example.com ]',
 				'Give Me Everything'
+			],
+			[
+				'an opened parenthesis but not closed',
+				'Give Me Everything (Tonight',
+				'Give Me Everything (Tonight'
+			],
+			[
+				'an opened square bracket but not closed',
+				'Give Me Everything [Tonight',
+				'Give Me Everything [Tonight'
 			],
 		];
 	}

--- a/extensions/wikia/LyricsApi/tests/LyricsUtilsTest.php
+++ b/extensions/wikia/LyricsApi/tests/LyricsUtilsTest.php
@@ -157,6 +157,18 @@ class LyricsUtilsTest extends WikiaBaseTest {
 				'Happy (From "Despicable Me 2") (German version)',
 				'Happy'
 			],
+			[
+				'square brackets',
+				'Take My Hand [ Remix] [feat. Cassadee Pope]',
+				'Take My Hand'
+			],
+			/*
+			[
+				'all kinds of brackets',
+				'Give Me Everything (Tonight) (Prod. By Afrojack) (Final) ( 2o11 ) [ www.MzHipHop.com ]',
+				'Give Me Everything'
+			],
+			*/
 		];
 	}
 }

--- a/extensions/wikia/LyricsApi/tests/LyricsUtilsTest.php
+++ b/extensions/wikia/LyricsApi/tests/LyricsUtilsTest.php
@@ -162,13 +162,11 @@ class LyricsUtilsTest extends WikiaBaseTest {
 				'Take My Hand [ Remix] [feat. Cassadee Pope]',
 				'Take My Hand'
 			],
-			/*
 			[
 				'all kinds of brackets',
 				'Give Me Everything (Tonight) (Prod. By Afrojack) (Final) ( 2o11 ) [ www.MzHipHop.com ]',
 				'Give Me Everything'
 			],
-			*/
 		];
 	}
 }


### PR DESCRIPTION
- small fix of exception message,
- `getSong` query change,
- `LyricsUtils::removeBrackets()` method with unit tests.
