### PR TITLE
(CE-767) Make FBConnect user group implicit

### DIFF
--- a/extensions/FBConnect/FBConnect.php
+++ b/extensions/FBConnect/FBConnect.php
@@ -101,12 +101,14 @@ JSMessages::registerPackage('FBConnect', array('fbconnect-logout-confirm'));
 define( 'APCOND_FB_INGROUP',   'fb*g' );
 define( 'APCOND_FB_ISOFFICER', 'fb*o' );
 define( 'APCOND_FB_ISADMIN',   'fb*a' );
+define( 'APCOND_FB_USER',      'fb*u' ); // Wikia change - Make fb-user a properly implicit group (CE-767)
 
 // Create a new group for Facebook users
 //$wgGroupPermissions['fb-user'] = $wgGroupPermissions['user'];
 //rt#68127 (dont give basic permissions to other groups, opens security holes)
 $wgGroupPermissions['fb-user'] = array('facebook-user'=>true);
 $wgImplicitGroups[] = 'fb-user';
+$wgAutopromote['fb-user'] = APCOND_FB_USER; // Wikia change - Make fb-user a properly implicit group (CE-767)
 
 // If we are configured to pull group info from Facebook, then create the group permissions
 if ($fbUserRightsFromGroup) {

--- a/extensions/FBConnect/FBConnectHooks.php
+++ b/extensions/FBConnect/FBConnectHooks.php
@@ -66,6 +66,15 @@ class FBConnectHooks {
 	 */
 	static function AutopromoteCondition( $cond_type, $args, $user, &$result ) {
 		global $fbUserRightsFromGroup;
+
+		// Wikia change begin - Make fb-user a properly implicit group (CE-767)
+		if ( $cond_type === APCOND_FB_USER ) {
+			$fbIds = FBConnectDB::getFacebookIDs( $user );
+			$result = !empty( $fbIds );
+			return true;
+		}
+		// Wikia change end
+
 		// Probably a redundant check, but with PHP you can never be too sure...
 		if (!$fbUserRightsFromGroup) {
 			// No group to pull rights from, so the user can't be a member

--- a/extensions/FBConnect/SpecialConnect.php
+++ b/extensions/FBConnect/SpecialConnect.php
@@ -473,7 +473,7 @@ class SpecialConnect extends SpecialPage {
 			wfRunHooks( 'AddNewAccount', array( $user, false ) );
 
 			// Mark that the user is a Facebook user
-			$user->addGroup('fb-user');
+			// $user->addGroup('fb-user'); // Wikia change - Make fb-user a properly implicit group (CE-767)
 
 			// Store which fields should be auto-updated from Facebook when the user logs in.
 			$updateFormPrefix = "wpUpdateUserInfo";

--- a/extensions/wikia/Listusers/SpecialListusers_helper.php
+++ b/extensions/wikia/Listusers/SpecialListusers_helper.php
@@ -134,6 +134,7 @@ class ListusersData {
 					if ( !empty($group) ) {
 						if ( $group == Listusers::DEF_GROUP_NAME ) {
 							$whereGroup[] = " all_groups = '' ";
+							$whereGroup[] = " all_groups = 'fb-user' ";
 						} else {
 							$whereGroup[] = " all_groups " . $dbs->buildLike( $dbs->anyString(), $group );
 							$whereGroup[] = " all_groups " . $dbs->buildLike( $dbs->anyString(), sprintf("%s;", $group), $dbs->anyString() );
@@ -385,9 +386,9 @@ class ListusersData {
 						'user_is_closed' => 0
 					);
 					if ( $key != Listusers::DEF_GROUP_NAME ) {
-						$where[] = " all_groups " . $dbs->buildLike( $dbs->anyString(), $key ) . " OR all_groups " . $dbs->buildLike( $dbs->anyString(), sprintf("%s;", $key), $dbs->anyString() );						
+						$where[] = " all_groups " . $dbs->buildLike( $dbs->anyString(), $key ) . " OR all_groups " . $dbs->buildLike( $dbs->anyString(), sprintf("%s;", $key), $dbs->anyString() );
 					} else {
-						$where['cnt_groups'] = 0;
+						$where[] = " all_groups = '' OR all_groups = 'fb-user' ";
 					}
 
 					$unions[] = $dbs->selectSQLText(


### PR DESCRIPTION
Currently FBConnect adds the group 'fb-user' when a user connects an
account to Facebook, however, this group was intended to be implicit,
which means it shouldn't be actually added to the account. Also, when the
account is disconnected, the group isn't removed, and it's only added on
the wikia that they connected the account on, so won't show up on other
wikias anyway.

The group also caused an issue where these users wouldn't be included in
ListUsers on the wikias where they were added to the group by the extension
because ListUsers won't list groups in `$wgImplicitGroups`, and as it wasn't
actually implicit and was added to the events table they weren't included in
ListUsers.

This change makes the group properly implicit and will display the user as an
fb-user on any wikia if their account is currently connected, but won't after they
disconnect the account. It also ignores existing entries in the events table that
have just the fb-user group on ListUsers.
