### PR TITLE
VID-905 Fixing missing video messaging

### DIFF
--- a/extensions/wikia/VideoPageTool/VideoPageTool.i18n.php
+++ b/extensions/wikia/VideoPageTool/VideoPageTool.i18n.php
@@ -62,6 +62,7 @@ $messages['en'] = array(
 	'videopagetool-category-instructions' => 'Note: A minimum of three modules must be programmed in order to save or publish this page.',
 
 	'videopagetool-hint-required-dimensions' => 'Image dimensions must be 1024 x 461',
+	'videopagetool-formerror-videokey' => 'Please add a video',
 	'videopagetool-formerror-altthumb' => 'Please add an image',
 	'videopagetool-formerror-category-name' => 'At least 3 categories must be chosen',
 	'videopagetool-date-header' => 'Editing for date: $1',

--- a/extensions/wikia/VideoPageTool/VideoPageTool.i18n.php
+++ b/extensions/wikia/VideoPageTool/VideoPageTool.i18n.php
@@ -140,6 +140,7 @@ $messages['qqq'] = array(
 
 	'videopagetool-success-publish' => 'This text appears if your changes have been published successfully',
 	'videopagetool-hint-required-dimensions' => 'Message describing exact dimensions required for custom image upload (1024 x 461)',
+	'videopagetool-formerror-videokey' => 'Error message for required video to be added',
 	'videopagetool-formerror-altthumb' => 'Error message for required custom image to be added',
 	'videopagetool-date-header' => 'Shows the date that you\'re programming for at the top of the form.',
 

--- a/extensions/wikia/VideoPageTool/VideoPageTool.setup.php
+++ b/extensions/wikia/VideoPageTool/VideoPageTool.setup.php
@@ -57,6 +57,7 @@ JSMessages::registerPackage('VideoPageTool', array(
 	'videopagetool-description-maxlength-error',
 	'videopagetool-video-title-default-text',
 	'videopagetool-image-title-default-text',
+	'videopagetool-formerror-videokey',
 	'videopagetool-formerror-altthumb',
 	'videopagetool-formerror-category-name',
 ));

--- a/extensions/wikia/VideoPageTool/js/admin/views/featured.js
+++ b/extensions/wikia/VideoPageTool/js/admin/views/featured.js
@@ -31,10 +31,11 @@ define('videopageadmin.views.featured', [
 					required: true,
 					messages: {
 						required: function (len, elem) {
-							var msg;
-							if ($(elem).hasClass('video-key')) {
+							var msg,
+								$elem = $(elem);
+							if ($elem.hasClass('video-key')) {
 								msg = $.msg('videopagetool-formerror-videokey');
-							} else if ($(elem).hasClass('alt-thumb')) {
+							} else if ($elem.hasClass('alt-thumb')) {
 								msg = $.msg('videopagetool-formerror-altthumb');
 							} else {
 								msg = $.msg('htmlform-required');

--- a/extensions/wikia/VideoPageTool/js/admin/views/featured.js
+++ b/extensions/wikia/VideoPageTool/js/admin/views/featured.js
@@ -32,7 +32,9 @@ define('videopageadmin.views.featured', [
 					messages: {
 						required: function (len, elem) {
 							var msg;
-							if ($(elem).hasClass('alt-thumb')) {
+							if ($(elem).hasClass('video-key')) {
+								msg = $.msg('videopagetool-formerror-videokey');
+							} else if ($(elem).hasClass('alt-thumb')) {
 								msg = $.msg('videopagetool-formerror-altthumb');
 							} else {
 								msg = $.msg('htmlform-required');


### PR DESCRIPTION
Added JSMessages keys for the missing video field in the VideoPageTool.

https://wikia-inc.atlassian.net/browse/VID-905

/cc @jnrbsn @lizlux 
