### PR TITLE
CE-377 Decouple UserProfilePageV3 from Phalanx

### DIFF
--- a/extensions/wikia/PhalanxII/hooks/PhalanxHooks.class.php
+++ b/extensions/wikia/PhalanxII/hooks/PhalanxHooks.class.php
@@ -55,6 +55,10 @@ class PhalanxHooks extends WikiaObject {
 			return true;
 		}
 
+		if (!$typeId) {
+			$typeId = PhalanxModel::determineTypeId($text);
+		}
+
 		$model = PhalanxModel::newFromType($typeId, $text);
 
 		if (is_null($model)) {

--- a/extensions/wikia/PhalanxII/models/PhalanxModel.php
+++ b/extensions/wikia/PhalanxII/models/PhalanxModel.php
@@ -32,6 +32,30 @@ abstract class PhalanxModel extends WikiaObject {
 	}
 
 	/**
+	 * Determines the Phalanx block type from a piece of content that
+	 * was not passed in with a specified type.
+	 *
+	 * @param $content string|Title|User content to guess type for
+	 * @return int
+	 */
+	public static function determineTypeId($content) {
+		// Allow extensions to pass in unspecified content types to
+		// eliminate dependence on Phalanx from other extensions;
+		// Phalanx is not enabled on the internal wiki and causes
+		// extensions with a dependency on it to fail hard (500 errors)
+		// See CE-377
+		// default to TYPE_CONTENT
+		$typeId = Phalanx::TYPE_CONTENT;
+		if ($content instanceof Title) {
+			$typeId = Phalanx::TYPE_TITLE;
+		} else if ($content instanceof User) {
+			$typeId = Phalanx::TYPE_USER;
+		}
+
+		return $typeId;
+	}
+
+	/**
 	 * Returns instence of a proper PhalanxModel based on provided block type (Phalanx::TYPE_*)
 	 *
 	 * @param $typeId int type ID

--- a/extensions/wikia/UserProfilePageV3/tests/UserIdentityBoxTest.php
+++ b/extensions/wikia/UserProfilePageV3/tests/UserIdentityBoxTest.php
@@ -184,4 +184,119 @@ class UserIdentityBoxTest extends WikiaBaseTest {
 		$userIdentityBoxMock->getTopWikis();
 	}
 
+	/**
+	 * @dataProvider testSaveUserData_spamFilterProvider
+	 */
+	public function testSaveUserData_spamFilter($userData) {
+		$userMock =  $this->getMock( 'User', [ 'setOption' ] );
+		$userIdentityBoxMock = $this->getMock(
+			'UserIdentityBox',
+			[ 'doSpamCheck', 'hasUserEditedMastheadBefore' ],
+			[ $userMock ],
+			'',
+			false
+		);
+
+		$userIdentityBoxMock->expects( $this->any() )
+			->method( 'hasUserEditedMastheadBefore' )
+			->will( $this->returnValue(true) );
+
+		$userData = new StdClass();
+		foreach ($userData as $property => $config) {
+			$userData->$property = $config['value'];
+
+			if ($property == 'name') {
+				$userIdentityBoxMock->expects( $this->once() )
+					->method( 'doSpamCheck' )
+					// the `name` property uses a static method on `User` to
+					// inflate a user object to perform the spam check against;
+					// static methods on different classes cannot be mocked.
+					// FIXME Correctly mock this in a consistent way so that
+					// `name` can be tested specifically
+					->will( $this->returnValue(!$config['spam']) );
+
+				$userMock->expects( $this->once() )
+					->method( 'setRealName' )
+					->with($config['option']['value']);
+			} else {
+				$userIdentityBoxMock->expects( $this->once() )
+					->method( 'doSpamCheck' )
+					->with( $config['value'] )
+					->will( $this->returnValue(!$config['spam']) );
+
+				$userMock->expects( $this->once() )
+					->method( 'setOption' )
+					->with( $config['option']['property'], $config['option']['value'] );
+			}
+		}
+
+		$userIdentityBoxMock->saveUserData($userData);
+	}
+
+	public function testSaveUserData_spamFilterProvider() {
+		return array(
+			array(
+				array(
+					'name' => array(
+						'value' => 'short enough',
+						'spam' => false,
+						'option' => array(
+							'property' => 'name',
+							'value' => 'short enough',
+						),
+					),
+				),
+			),
+			array(
+				array(
+					'name' => array(
+						'value' => 'this is just way too long, and should be truncated to 40 characters',
+						'spam' => false,
+						'option' => array(
+							'property' => 'name',
+							'value' => '',
+						),
+					),
+				),
+			),
+			array(
+				array(
+					'name' => array(
+						'value' => 'spammy names should default to nothing',
+						'spam' => true,
+						'option' => array(
+							'property' => 'name',
+							'value' => '',
+						),
+					),
+				),
+			),
+			array(
+				// base case using a property with no additional filtering
+				array(
+					'twitter' => array(
+						'value' => 'twitterhandle',
+						'spam' => false,
+						'option' => array(
+							'property' => 'twitter',
+							'value' => 'twitterhandle',
+						),
+					),
+				),
+			),
+			array(
+				// base case using a property with no additional filtering
+				array(
+					'twitter' => array(
+						'value' => 'twitterhandle',
+						'spam' => true,
+						'option' => array(
+							'property' => 'twitter',
+							'value' => '',
+						),
+					),
+				),
+			),
+		);
+	}
 }

--- a/extensions/wikia/UserProfilePageV3/tests/UserIdentityBoxTest.php
+++ b/extensions/wikia/UserProfilePageV3/tests/UserIdentityBoxTest.php
@@ -206,13 +206,11 @@ class UserIdentityBoxTest extends WikiaBaseTest {
 			$userData->$property = $config['value'];
 
 			if ($property == 'name') {
+				$otherUser = $this->getMock( 'User', [] );
+				$this->mockClassStaticMethod('User', 'newFromName', $otherUser);
 				$userIdentityBoxMock->expects( $this->once() )
 					->method( 'doSpamCheck' )
-					// the `name` property uses a static method on `User` to
-					// inflate a user object to perform the spam check against;
-					// static methods on different classes cannot be mocked.
-					// FIXME Correctly mock this in a consistent way so that
-					// `name` can be tested specifically
+					->with( $otherUser )
 					->will( $this->returnValue(!$config['spam']) );
 
 				$userMock->expects( $this->once() )


### PR DESCRIPTION
UserProfilePageV3 had an implicit dependency on Phalanx, which prevented
it from working as expected on Wikia One (which has UserProfilePageV3
enabled and Phalanx disabled). Extract the determination of the content
type from UserProfilePageV3 into Phalanx, which now uses the class of
the given subject to determine the type if none is given.

RFCR @owend @macbre @nandy-andy 
