### PR TITLE
Load abtesting module from the shared domain

### DIFF
--- a/extensions/wikia/AbTesting/ResourceLoaderAbTestingModule.class.php
+++ b/extensions/wikia/AbTesting/ResourceLoaderAbTestingModule.class.php
@@ -34,4 +34,13 @@ class ResourceLoaderAbTestingModule extends ResourceLoaderModule {
 		return $modifiedTime;
 	}
 
+	/**
+	 * Load abtesting module from the shared domain
+	 *
+	 * @return String
+	 */
+	public function getSource() {
+		return 'common';
+	}
+
 }


### PR DESCRIPTION
Serve ABTesting config from shared (aka nocookie) domain instead of a local one. Improve front-end performance a bit by not sending cookies with the request and improve cacheability on CDN.

@prein / @michalroszka / @SebastianMarzjan / @wladekb 
