### PR TITLE
CON-1064 | Krux Segment as custom Var in GA

### DIFF
--- a/extensions/wikia/AnalyticsEngine/js/analytics_dev.js
+++ b/extensions/wikia/AnalyticsEngine/js/analytics_dev.js
@@ -70,7 +70,7 @@
 	function getKruxSegment() {
 		var kruxSegment = 'not set',
 			uniqueKruxSegments = {
-				ocry7a4xg: 'Action Strategist 2014',
+				ocry7a4xg: 'Game Heroes 2014',
 				ocr1te1tc: 'Digital DNA 2014',
 				ocr6m2jd6: 'Inquisitive Minds 2014',
 				ocr05ve5z: 'Culture Caster 2014',

--- a/extensions/wikia/AnalyticsEngine/js/analytics_dev.js
+++ b/extensions/wikia/AnalyticsEngine/js/analytics_dev.js
@@ -86,7 +86,7 @@
 
 		if ( kruxSegments.length ) {
 			markedSegments = uniqueKruxSegmentsKeys.filter(function(n) {
-				return kruxSegments.indexOf(n) !== -1
+				return kruxSegments.indexOf(n) !== -1;
 			});
 			if (markedSegments.length) {
 				kruxSegment = uniqueKruxSegments[markedSegments[0]];

--- a/extensions/wikia/AnalyticsEngine/js/analytics_dev.js
+++ b/extensions/wikia/AnalyticsEngine/js/analytics_dev.js
@@ -67,6 +67,35 @@
       }
     }
 
+	function getKruxSegment() {
+		var kruxSegment = 'not set',
+			uniqueKruxSegments = {
+				ocry7a4xg: 'Action Strategist 2014',
+				ocr1te1tc: 'Digital DNA 2014',
+				ocr6m2jd6: 'Inquisitive Minds 2014',
+				ocr05ve5z: 'Culture Caster 2014',
+				ocr88oqh9: 'Social Entertainers 2014'
+			},
+			uniqueKruxSegmentsKeys= Object.keys(uniqueKruxSegments),
+			markedSegments = [],
+			kruxSegments = [];
+
+		if (window.localStorage) {
+			kruxSegments = ( window.localStorage.kxsegs || '' ).split( ',' );
+		}
+
+		if ( kruxSegments.length ) {
+			markedSegments = uniqueKruxSegmentsKeys.filter(function(n) {
+				return kruxSegments.indexOf(n) !== -1
+			});
+			if (markedSegments.length) {
+				kruxSegment = uniqueKruxSegments[markedSegments[0]];
+			}
+		}
+
+		return kruxSegment;
+	}
+
     // All domains that host content for wikia.
     possible_domains = ['wikia.com', 'ffxiclopedia.org', 'jedipedia.de',
      'marveldatabase.com', 'memory-alpha.org', 'uncyclopedia.org',
@@ -90,12 +119,15 @@
                   ['_setCustomVar', 5, 'LoginStatus',
                       !!window.wgUserName ? 'user' : 'anon', 3]);
 
+
+
     /**** Medium-Priority CVs ****/
     _gaqWikiaPush(['_setCustomVar', 8, 'PageType',
                       window.wikiaPageType, 3],
                   ['_setCustomVar', 9, 'CityId', window.wgCityId, 3],
                   ['_setCustomVar', 12, 'MedusaSlot', window.wgMedusaSlot, 3],
-                  ['_setCustomVar', 15, 'IsCorporatePage', window.wikiaPageIsCorporate ? 'Yes' : 'No', 3]
+                  ['_setCustomVar', 15, 'IsCorporatePage', window.wikiaPageIsCorporate ? 'Yes' : 'No', 3],
+                  ['_setCustomVar', 16, 'Krux Segment', getKruxSegment(), 3]
     );
 
     // Unleash
@@ -128,7 +160,8 @@
                   window.wikiaPageType, 3],
               ['ads._setCustomVar', 9, 'CityId', window.wgCityId, 3],
               ['ads._setCustomVar', 12, 'MedusaSlot', window.wgMedusaSlot, 3],
-              ['ads._setCustomVar', 15, 'IsCorporatePage', window.wikiaPageIsCorporate ? 'Yes' : 'No', 3]
+              ['ads._setCustomVar', 15, 'IsCorporatePage', window.wikiaPageIsCorporate ? 'Yes' : 'No', 3],
+              ['ads._setCustomVar', 16, 'Krux Segment', getKruxSegment(), 3]
     );
 
 

--- a/extensions/wikia/AnalyticsEngine/js/analytics_dev.js
+++ b/extensions/wikia/AnalyticsEngine/js/analytics_dev.js
@@ -76,7 +76,7 @@
 				ocr05ve5z: 'Culture Caster 2014',
 				ocr88oqh9: 'Social Entertainers 2014'
 			},
-			uniqueKruxSegmentsKeys= Object.keys(uniqueKruxSegments),
+			uniqueKruxSegmentsKeys = Object.keys(uniqueKruxSegments),
 			markedSegments = [],
 			kruxSegments = [];
 

--- a/extensions/wikia/AnalyticsEngine/js/analytics_prod.js
+++ b/extensions/wikia/AnalyticsEngine/js/analytics_prod.js
@@ -70,7 +70,7 @@
 	function getKruxSegment() {
 		var kruxSegment = 'not set',
 			uniqueKruxSegments = {
-				ocry7a4xg: 'Action Strategist 2014',
+				ocry7a4xg: 'Game Heroes 2014',
 				ocr1te1tc: 'Digital DNA 2014',
 				ocr6m2jd6: 'Inquisitive Minds 2014',
 				ocr05ve5z: 'Culture Caster 2014',

--- a/extensions/wikia/AnalyticsEngine/js/analytics_prod.js
+++ b/extensions/wikia/AnalyticsEngine/js/analytics_prod.js
@@ -86,7 +86,7 @@
 
 		if ( kruxSegments.length ) {
 			markedSegments = uniqueKruxSegmentsKeys.filter(function(n) {
-				return kruxSegments.indexOf(n) !== -1
+				return kruxSegments.indexOf(n) !== -1;
 			});
 			if (markedSegments.length) {
 				kruxSegment = uniqueKruxSegments[markedSegments[0]];

--- a/extensions/wikia/AnalyticsEngine/js/analytics_prod.js
+++ b/extensions/wikia/AnalyticsEngine/js/analytics_prod.js
@@ -67,6 +67,35 @@
 		}
 	}
 
+	function getKruxSegment() {
+		var kruxSegment = 'not set',
+			uniqueKruxSegments = {
+				ocry7a4xg: 'Action Strategist 2014',
+				ocr1te1tc: 'Digital DNA 2014',
+				ocr6m2jd6: 'Inquisitive Minds 2014',
+				ocr05ve5z: 'Culture Caster 2014',
+				ocr88oqh9: 'Social Entertainers 2014'
+			},
+			uniqueKruxSegmentsKeys= Object.keys(uniqueKruxSegments),
+			markedSegments = [],
+			kruxSegments = [];
+
+		if (window.localStorage) {
+			kruxSegments = ( window.localStorage.kxsegs || '' ).split( ',' );
+		}
+
+		if ( kruxSegments.length ) {
+			markedSegments = uniqueKruxSegmentsKeys.filter(function(n) {
+				return kruxSegments.indexOf(n) !== -1
+			});
+			if (markedSegments.length) {
+				kruxSegment = uniqueKruxSegments[markedSegments[0]];
+			}
+		}
+
+		return kruxSegment;
+	}
+
 	// All domains that host content for wikia.
 	possible_domains = ['wikia.com', 'ffxiclopedia.org', 'jedipedia.de',
 		'marveldatabase.com', 'memory-alpha.org', 'uncyclopedia.org',
@@ -95,7 +124,8 @@
 		['_setCustomVar', 9, 'CityId', window.wgCityId, 3],
 		['_setCustomVar', 12, 'MedusaSlot', window.wgMedusaSlot, 3],
 		['_setCustomVar', 14, 'HasAds', window.wgShowAds ? 'Yes' : 'No', 3],
-		['_setCustomVar', 15, 'IsCorporatePage', window.wikiaPageIsCorporate ? 'Yes' : 'No', 3]
+		['_setCustomVar', 15, 'IsCorporatePage', window.wikiaPageIsCorporate ? 'Yes' : 'No', 3],
+		['_setCustomVar', 16, 'Krux Segment', getKruxSegment(), 3]
 	);
 
 	/**** Include A/B testing status ****/
@@ -168,7 +198,8 @@
 		['ads._setCustomVar', 9, 'CityId', window.wgCityId, 3],
 		['ads._setCustomVar', 12, 'MedusaSlot', window.wgMedusaSlot, 3],
 		['ads._setCustomVar', 14, 'HasAds', window.wgShowAds ? 'Yes' : 'No', 3],
-		['ads._setCustomVar', 15, 'IsCorporatePage', window.wikiaPageIsCorporate ? 'Yes' : 'No', 3]
+		['ads._setCustomVar', 15, 'IsCorporatePage', window.wikiaPageIsCorporate ? 'Yes' : 'No', 3],
+		['ads._setCustomVar', 16, 'Krux Segment', getKruxSegment(), 3]
 	);
 
 	/**** Include A/B testing status ****/

--- a/extensions/wikia/AnalyticsEngine/js/analytics_prod.js
+++ b/extensions/wikia/AnalyticsEngine/js/analytics_prod.js
@@ -76,7 +76,7 @@
 				ocr05ve5z: 'Culture Caster 2014',
 				ocr88oqh9: 'Social Entertainers 2014'
 			},
-			uniqueKruxSegmentsKeys= Object.keys(uniqueKruxSegments),
+			uniqueKruxSegmentsKeys = Object.keys(uniqueKruxSegments),
 			markedSegments = [],
 			kruxSegments = [];
 


### PR DESCRIPTION
I don't like this hardcoded definition of Krux sugments, but exporting it from WikiFactory into HTML on every page is pretty inefficient. Rex confirmed that changes in segments are made rarely that's why we chose this way.

One more thing: We cannot use our Krux code because analytics code is loaded in the HEAD and cannot wait for bottom scripts.
