### PR TITLE
Implement Instant globals

### DIFF
--- a/extensions/wikia/AbTesting/AbTesting.class.php
+++ b/extensions/wikia/AbTesting/AbTesting.class.php
@@ -47,7 +47,6 @@ class AbTesting extends WikiaObject {
 
 	static public function onWikiaSkinTopScripts( &$vars, &$scripts, $skin ) {
 		$app = F::app();
-		$wg = $app->wg;
 
 		if ( $app->checkSkin( 'wikiamobile', $skin ) ) {
 			//Add this mock as wikia.ext.abtesting relies on it and on WikiaMobile there is no mw object
@@ -55,11 +54,15 @@ class AbTesting extends WikiaObject {
 			$scripts .= '<script>var mw = {loader: {state: function(){}}}</script>';
 		}
 
+		return true;
+	}
+
+	static public function onWikiaSkinTopShortTTLModules( Array &$modules, $skin) {
+		$app = F::app();
+
 		if ( $app->checkSkin( ['oasis', 'wikiamobile'], $skin ) ) {
-			$scripts .= ResourceLoader::makeCustomLink( $wg->out, array( 'wikia.ext.abtesting' ), 'scripts' ) . "\n";
+			$modules[] = 'wikia.ext.abtesting';
 		}
-
-
 
 		return true;
 	}

--- a/extensions/wikia/AbTesting/AbTesting.setup.php
+++ b/extensions/wikia/AbTesting/AbTesting.setup.php
@@ -50,6 +50,7 @@ $wgExtensionMessagesFiles['AbTesting'] = "{$dir}/AbTesting.i18n.php";
 
 // Embed the experiment/treatment config in the head scripts.
 $wgHooks['WikiaSkinTopScripts'][] =  'AbTesting::onWikiaSkinTopScripts';
+$wgHooks['WikiaSkinTopShortTTLModules'][] =  'AbTesting::onWikiaSkinTopShortTTLModules';
 $wgHooks['WikiaMobileAssetsPackages'][] = 'AbTesting::onWikiaMobileAssetsPackages';
 // Add js code in Oasis
 $wgHooks['OasisSkinAssetGroupsBlocking'][] = 'AbTesting::onOasisSkinAssetGroupsBlocking';

--- a/extensions/wikia/AdEngine/AdEngine2.setup.php
+++ b/extensions/wikia/AdEngine/AdEngine2.setup.php
@@ -18,6 +18,7 @@ $wgHooks['OasisSkinAssetGroupsBlocking'][] = 'AdEngine2Hooks::onOasisSkinAssetGr
 $wgHooks['WikiaSkinTopModules'][] = 'AdEngine2Hooks::onWikiaSkinTopModules';
 $wgHooks['WikiaMobileAssetsPackages'][] = 'AdEngine2Hooks::onWikiaMobileAssetsPackages';
 $wgHooks['OasisSkinAssetGroups'][] = 'AdEngine2Hooks::onOasisSkinAssetGroups';
+$wgHooks['InstantGlobalsGetVariables'][] = 'AdEngine2Hooks::onInstantGlobalsGetVariables';
 
 // Hooks for Exitstitial ads
 $wgHooks['LinkerMakeExternalLink'][] = 'AdEngine2ExitstitialHooks::onLinkerMakeExternalLink';

--- a/extensions/wikia/AdEngine/AdEngine2Hooks.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2Hooks.class.php
@@ -49,6 +49,21 @@ class AdEngine2Hooks {
 	}
 
 	/**
+	 * Register "instant" global JS
+	 *
+	 * @param array $vars
+	 *
+	 * @return bool
+	 */
+	static public function onInstantGlobalsGetVariables(array &$vars)
+	{
+		$vars[] = 'wgHighValueCountries';
+		$vars[] = 'wgAmazonDirectTargetedBuyCountries';
+
+		return true;
+	}
+
+	/**
 	 * Register ad-related vars on top
 	 *
 	 * @param array $vars

--- a/extensions/wikia/AdEngine/AdEngine2Hooks.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2Hooks.class.php
@@ -121,6 +121,7 @@ class AdEngine2Hooks {
 	 */
 	static public function onWikiaSkinTopModules(&$scriptModules, $skin) {
 		if (AdEngine2Service::areAdsInHead() || AnalyticsProviderAmazonDirectTargetedBuy::isEnabled()) {
+			$scriptModules[] = 'wikia.instantGlobals';
 			$scriptModules[] = 'wikia.cookies';
 			$scriptModules[] = 'wikia.geo';
 			$scriptModules[] = 'wikia.window';

--- a/extensions/wikia/AdEngine/AdEngine2Service.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2Service.class.php
@@ -195,7 +195,7 @@ class AdEngine2Service
 	private static function getJsVariables()
 	{
 		global $wgCityId, $wgEnableAdsInContent, $wgEnableOpenXSPC,
-			$wgHighValueCountriesDefault, $wgUser,
+			$wgUser,
 			$wgEnableAdMeldAPIClient, $wgEnableAdMeldAPIClientPixels,
 			$wgOutboundScreenRedirectDelay, $wgEnableOutboundScreenExt,
 			$wgAdDriverUseSevenOneMedia, $wgAdDriverUseEbay,
@@ -209,13 +209,6 @@ class AdEngine2Service
 
 		$vars = [];
 
-		$highValueCountries = WikiFactory::getVarValueByName(
-			'wgHighValueCountries',
-			[$wgCityId, Wikia::COMMUNITY_WIKI_ID],
-			false,
-			$wgHighValueCountriesDefault
-		);
-
 		$variablesToExpose = [
 			'wgEnableAdsInContent' => $wgEnableAdsInContent,
 			'wgEnableAdMeldAPIClient' => $wgEnableAdMeldAPIClient,
@@ -223,7 +216,6 @@ class AdEngine2Service
 			'wgEnableOpenXSPC' => $wgEnableOpenXSPC,
 
 			// Ad Driver
-			'wgHighValueCountries' => $highValueCountries,
 			'wgAdDriverUseCatParam' => array_search($wgLanguageCode, $wgAdPageLevelCategoryLangs),
 			'wgAdPageType' => $wgAdPageType,
 			'wgAdDriverUseEbay' => $wgAdDriverUseEbay,
@@ -320,7 +312,6 @@ class AdEngine2Service
 				'wgAdDriverUseCatParam',         // AdLogicPageParams.js
 				'wgDartCustomKeyValues',         // AdLogicPageParams.js
 				'wgEnableRHonDesktop',           // AdEngine2.run.js
-				'wgHighValueCountries',          // AdLogicHighValueCountry.js
 				'wgLoadAdsInHead',               // AdEngine2.run.js
 				'wgUsePostScribe',               // AdEngine2.run.js, scriptwriter.js
 				'wgWikiDirectedAtChildren',      // AdLogicPageParams.js

--- a/extensions/wikia/AdEngine/AdEngine2Service.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2Service.class.php
@@ -209,13 +209,6 @@ class AdEngine2Service
 
 		$vars = [];
 
-		$highValueCountries = WikiFactory::getVarValueByName(
-			'wgHighValueCountries',
-			[$wgCityId, Wikia::COMMUNITY_WIKI_ID],
-			false,
-			$wgHighValueCountriesDefault
-		);
-
 		$variablesToExpose = [
 			'wgEnableAdsInContent' => $wgEnableAdsInContent,
 			'wgEnableAdMeldAPIClient' => $wgEnableAdMeldAPIClient,
@@ -223,7 +216,7 @@ class AdEngine2Service
 			'wgEnableOpenXSPC' => $wgEnableOpenXSPC,
 
 			// Ad Driver
-			'wgHighValueCountries' => $highValueCountries,
+			'wgHighValueCountriesDefault' => $wgHighValueCountriesDefault,
 			'wgAdDriverUseCatParam' => array_search($wgLanguageCode, $wgAdPageLevelCategoryLangs),
 			'wgAdPageType' => $wgAdPageType,
 			'wgAdDriverUseEbay' => $wgAdDriverUseEbay,

--- a/extensions/wikia/AdEngine/AdEngine2Service.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2Service.class.php
@@ -195,7 +195,7 @@ class AdEngine2Service
 	private static function getJsVariables()
 	{
 		global $wgCityId, $wgEnableAdsInContent, $wgEnableOpenXSPC,
-			$wgUser,
+			$wgHighValueCountriesDefault, $wgUser,
 			$wgEnableAdMeldAPIClient, $wgEnableAdMeldAPIClientPixels,
 			$wgOutboundScreenRedirectDelay, $wgEnableOutboundScreenExt,
 			$wgAdDriverUseSevenOneMedia, $wgAdDriverUseEbay,
@@ -209,6 +209,13 @@ class AdEngine2Service
 
 		$vars = [];
 
+		$highValueCountries = WikiFactory::getVarValueByName(
+			'wgHighValueCountries',
+			[$wgCityId, Wikia::COMMUNITY_WIKI_ID],
+			false,
+			$wgHighValueCountriesDefault
+		);
+
 		$variablesToExpose = [
 			'wgEnableAdsInContent' => $wgEnableAdsInContent,
 			'wgEnableAdMeldAPIClient' => $wgEnableAdMeldAPIClient,
@@ -216,6 +223,7 @@ class AdEngine2Service
 			'wgEnableOpenXSPC' => $wgEnableOpenXSPC,
 
 			// Ad Driver
+			'wgHighValueCountries' => $highValueCountries,
 			'wgAdDriverUseCatParam' => array_search($wgLanguageCode, $wgAdPageLevelCategoryLangs),
 			'wgAdPageType' => $wgAdPageType,
 			'wgAdDriverUseEbay' => $wgAdDriverUseEbay,
@@ -312,6 +320,7 @@ class AdEngine2Service
 				'wgAdDriverUseCatParam',         // AdLogicPageParams.js
 				'wgDartCustomKeyValues',         // AdLogicPageParams.js
 				'wgEnableRHonDesktop',           // AdEngine2.run.js
+				'wgHighValueCountries',          // AdLogicHighValueCountry.js
 				'wgLoadAdsInHead',               // AdEngine2.run.js
 				'wgUsePostScribe',               // AdEngine2.run.js, scriptwriter.js
 				'wgWikiDirectedAtChildren',      // AdLogicPageParams.js

--- a/extensions/wikia/AdEngine/AdEngine2Service.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2Service.class.php
@@ -195,8 +195,7 @@ class AdEngine2Service
 	private static function getJsVariables()
 	{
 		global $wgCityId, $wgEnableAdsInContent, $wgEnableOpenXSPC,
-			$wgHighValueCountriesDefault, $wgUser,
-			$wgEnableAdMeldAPIClient, $wgEnableAdMeldAPIClientPixels,
+			$wgUser, $wgEnableAdMeldAPIClient, $wgEnableAdMeldAPIClientPixels,
 			$wgOutboundScreenRedirectDelay, $wgEnableOutboundScreenExt,
 			$wgAdDriverUseSevenOneMedia, $wgAdDriverUseEbay,
 			$wgAdPageLevelCategoryLangs, $wgLanguageCode, $wgAdDriverTrackState,
@@ -216,7 +215,6 @@ class AdEngine2Service
 			'wgEnableOpenXSPC' => $wgEnableOpenXSPC,
 
 			// Ad Driver
-			'wgHighValueCountriesDefault' => $wgHighValueCountriesDefault,
 			'wgAdDriverUseCatParam' => array_search($wgLanguageCode, $wgAdPageLevelCategoryLangs),
 			'wgAdPageType' => $wgAdPageType,
 			'wgAdDriverUseEbay' => $wgAdDriverUseEbay,

--- a/extensions/wikia/AdEngine/js/AdLogicHighValueCountry.js
+++ b/extensions/wikia/AdEngine/js/AdLogicHighValueCountry.js
@@ -24,7 +24,7 @@ define('ext.wikia.adEngine.adLogicHighValueCountry', ['wikia.window', 'wikia.ins
 		'US': 3
 	};
 
-	highValueCountries = globals && globals.wgHighValueCountries ?  globals.wgHighValueCountries : defaultHighValueCountries;
+	highValueCountries = globals.wgHighValueCountries ?  globals.wgHighValueCountries : defaultHighValueCountries;
 
 	isHighValueCountry = function (country) {
 		if (country && highValueCountries) {

--- a/extensions/wikia/AdEngine/js/AdLogicHighValueCountry.js
+++ b/extensions/wikia/AdEngine/js/AdLogicHighValueCountry.js
@@ -1,30 +1,12 @@
 /*global define*/
-define('ext.wikia.adEngine.adLogicHighValueCountry', ['wikia.window'], function (window) {
+define('ext.wikia.adEngine.adLogicHighValueCountry', ['wikia.window', 'wikia.instantGlobals'], function (window, globals) {
 	'use strict';
 
 	var highValueCountries,
-		defaultHighValueCountries,
 		isHighValueCountry,
 		getMaxCallsToDART;
 
-	// A copy of CommonSettings wgHighValueCountries
-	defaultHighValueCountries = {
-		'CA': 3,
-		'DE': 3,
-		'DK': 3,
-		'ES': 3,
-		'FI': 3,
-		'FR': 3,
-		'GB': 3,
-		'IT': 3,
-		'NL': 3,
-		'NO': 3,
-		'SE': 3,
-		'UK': 3,
-		'US': 3
-	};
-
-	highValueCountries = window.wgHighValueCountries || defaultHighValueCountries;
+	highValueCountries = globals && globals.wgHighValueCountries ?  globals.wgHighValueCountries : window.wgHighValueCountriesDefault;
 
 	isHighValueCountry = function (country) {
 		if (country && highValueCountries) {

--- a/extensions/wikia/AdEngine/js/AdLogicHighValueCountry.js
+++ b/extensions/wikia/AdEngine/js/AdLogicHighValueCountry.js
@@ -3,10 +3,28 @@ define('ext.wikia.adEngine.adLogicHighValueCountry', ['wikia.window', 'wikia.ins
 	'use strict';
 
 	var highValueCountries,
+		defaultHighValueCountries,
 		isHighValueCountry,
 		getMaxCallsToDART;
 
-	highValueCountries = globals && globals.wgHighValueCountries ?  globals.wgHighValueCountries : window.wgHighValueCountriesDefault;
+	// A copy of CommonSettings wgHighValueCountries
+	defaultHighValueCountries = {
+		'CA': 3,
+		'DE': 3,
+		'DK': 3,
+		'ES': 3,
+		'FI': 3,
+		'FR': 3,
+		'GB': 3,
+		'IT': 3,
+		'NL': 3,
+		'NO': 3,
+		'SE': 3,
+		'UK': 3,
+		'US': 3
+	};
+
+	highValueCountries = globals && globals.wgHighValueCountries ?  globals.wgHighValueCountries : defaultHighValueCountries;
 
 	isHighValueCountry = function (country) {
 		if (country && highValueCountries) {

--- a/extensions/wikia/AnalyticsEngine/AnalyticsProviderAmazonDirectTargetedBuy.php
+++ b/extensions/wikia/AnalyticsEngine/AnalyticsProviderAmazonDirectTargetedBuy.php
@@ -5,7 +5,7 @@ class AnalyticsProviderAmazonDirectTargetedBuy implements iAnalyticsProvider {
 	private static $code = <<< SCRIPT
 		<script>
 			require(['wikia.geo', 'wikia.instantGlobals'], function (geo, globals) {
-				if (globals && globals.wgAmazonDirectTargetedBuyCountries && globals.wgAmazonDirectTargetedBuyCountries.indexOf(geo.getCountryCode()) > -1) {
+				if (globals.wgAmazonDirectTargetedBuyCountries && globals.wgAmazonDirectTargetedBuyCountries.indexOf(geo.getCountryCode()) > -1) {
 					var aax_src='3006',
 						aax_url = encodeURIComponent(document.location),
 						s = document.createElement('script'),

--- a/extensions/wikia/AnalyticsEngine/AnalyticsProviderAmazonDirectTargetedBuy.php
+++ b/extensions/wikia/AnalyticsEngine/AnalyticsProviderAmazonDirectTargetedBuy.php
@@ -4,8 +4,8 @@ class AnalyticsProviderAmazonDirectTargetedBuy implements iAnalyticsProvider {
 
 	private static $code = <<< SCRIPT
 		<script>
-			require(['wikia.geo'], function (geo) {
-				if (geo.getCountryCode() in %%COUNTRIES%%) {
+			require(['wikia.geo', 'wikia.instantGlobals'], function (geo, globals) {
+				if (globals && globals.wgAmazonDirectTargetedBuyCountries && globals.wgAmazonDirectTargetedBuyCountries.indexOf(geo.getCountryCode()) > -1) {
 					var aax_src='3006',
 						aax_url = encodeURIComponent(document.location),
 						s = document.createElement('script'),
@@ -34,33 +34,11 @@ SCRIPT;
 	}
 
 	public function getSetupHtml($params = array()) {
-		global $wgAmazonDirectTargetedBuyCountriesDefault, $wgCityId;
-
 		static $called = false;
 		$code = '';
 
 		if (!$called && self::isEnabled()) {
-			$called = true;
-			$countriesJS = [];
-
-			$amazonCountries = WikiFactory::getVarValueByName(
-				'wgAmazonDirectTargetedBuyCountries',
-				[$wgCityId, Wikia::COMMUNITY_WIKI_ID],
-				false,
-				$wgAmazonDirectTargetedBuyCountriesDefault
-			);
-
-			if (is_array($amazonCountries)) {
-				foreach ($amazonCountries as $countryCode) {
-					if (is_string($countryCode)) {
-						$countriesJS[$countryCode] = true;
-					}
-				}
-			}
-
-			if ($countriesJS) {
-				$code = str_replace('%%COUNTRIES%%', json_encode($countriesJS), self::$code);
-			}
+			$code = self::$code;
 		}
 
 		return $code;

--- a/extensions/wikia/AnalyticsEngine/AnalyticsProviderAmazonDirectTargetedBuy.php
+++ b/extensions/wikia/AnalyticsEngine/AnalyticsProviderAmazonDirectTargetedBuy.php
@@ -5,7 +5,7 @@ class AnalyticsProviderAmazonDirectTargetedBuy implements iAnalyticsProvider {
 	private static $code = <<< SCRIPT
 		<script>
 			require(['wikia.geo'], function (geo) {
-				if (geo.getCountryCode() in %%COUNTRIES%%) {
+				if (window.wgAmazonDirectTargetedBuyCountries && wgAmazonDirectTargetedBuyCountries.indexOf(geo.getCountryCode()) > -1) {
 					var aax_src='3006',
 						aax_url = encodeURIComponent(document.location),
 						s = document.createElement('script'),
@@ -34,33 +34,11 @@ SCRIPT;
 	}
 
 	public function getSetupHtml($params = array()) {
-		global $wgAmazonDirectTargetedBuyCountriesDefault, $wgCityId;
-
 		static $called = false;
 		$code = '';
 
 		if (!$called && self::isEnabled()) {
-			$called = true;
-			$countriesJS = [];
-
-			$amazonCountries = WikiFactory::getVarValueByName(
-				'wgAmazonDirectTargetedBuyCountries',
-				[$wgCityId, Wikia::COMMUNITY_WIKI_ID],
-				false,
-				$wgAmazonDirectTargetedBuyCountriesDefault
-			);
-
-			if (is_array($amazonCountries)) {
-				foreach ($amazonCountries as $countryCode) {
-					if (is_string($countryCode)) {
-						$countriesJS[$countryCode] = true;
-					}
-				}
-			}
-
-			if ($countriesJS) {
-				$code = str_replace('%%COUNTRIES%%', json_encode($countriesJS), self::$code);
-			}
+			$code = self::$code;
 		}
 
 		return $code;

--- a/extensions/wikia/InstantGlobals/InstantGlobals.setup.php
+++ b/extensions/wikia/InstantGlobals/InstantGlobals.setup.php
@@ -6,6 +6,10 @@
  * Variables are exposed via ResourceLoader module with a short CDN caching time, allowing us to make critial config
  * changes with no need to wait 24h for CDN cache to invalidate.
  *
+ * - InstantGlobalsModule::$variables contains the list of WF variables to be emitted by the module
+ * - variables values are taken from Community Wiki
+ * - caching time on both server and client-side is 300 sec
+ *
  * @author macbre
  */
 

--- a/extensions/wikia/InstantGlobals/InstantGlobals.setup.php
+++ b/extensions/wikia/InstantGlobals/InstantGlobals.setup.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * This extension emits WikiFactory variables as JS globals.
+ *
+ * Variables are exposed via ResourceLoader module with a short CDN caching time, allowing us to make critial config
+ * changes with no need to wait 24h for CDN cache to invalidate.
+ *
+ * @author macbre
+ */
+
+/**
+ * info
+ */
+$wgExtensionCredits['other'][] = [
+	'name' => 'InstantGlobals',
+	'author' => 'Maciej Brencz',
+	'version' => '1.0'
+];
+
+/**
+ * classes
+ */
+$dir = __DIR__;
+
+$wgAutoloadClasses['InstantGlobalsHooks'] = "{$dir}/InstantGlobalsHooks.class.php";
+$wgAutoloadClasses['InstantGlobalsModule'] = "{$dir}/InstantGlobalsModule.class.php";
+
+/**
+ * hooks
+ */
+$wgHooks['WikiaSkinTopShortTTLModules'][] =  'InstantGlobalsHooks::onWikiaSkinTopShortTTLModules';
+
+/**
+ * register Resource Loader module
+ */
+$wgResourceModules['wikia.ext.instantglobals'] = [
+	'class' => 'InstantGlobalsModule',
+];

--- a/extensions/wikia/InstantGlobals/InstantGlobals.setup.php
+++ b/extensions/wikia/InstantGlobals/InstantGlobals.setup.php
@@ -40,6 +40,6 @@ $wgHooks['WikiaSkinTopShortTTLModules'][] =  'InstantGlobalsHooks::onWikiaSkinTo
 /**
  * register Resource Loader module
  */
-$wgResourceModules['wikia.ext.instantglobals'] = [
+$wgResourceModules['wikia.ext.instantGlobals'] = [
 	'class' => 'InstantGlobalsModule',
 ];

--- a/extensions/wikia/InstantGlobals/InstantGlobals.setup.php
+++ b/extensions/wikia/InstantGlobals/InstantGlobals.setup.php
@@ -10,6 +10,7 @@
  * - variables values are taken from Community Wiki
  * - caching time on both server and client-side is 300 sec
  * - RL module is only loaded in Oasis
+ * - values are available in Wikia.InstantGlobals object
  *
  * @author macbre
  */

--- a/extensions/wikia/InstantGlobals/InstantGlobals.setup.php
+++ b/extensions/wikia/InstantGlobals/InstantGlobals.setup.php
@@ -9,6 +9,7 @@
  * - InstantGlobalsModule::$variables contains the list of WF variables to be emitted by the module
  * - variables values are taken from Community Wiki
  * - caching time on both server and client-side is 300 sec
+ * - RL module is only loaded in Oasis
  *
  * @author macbre
  */

--- a/extensions/wikia/InstantGlobals/InstantGlobalsHooks.class.php
+++ b/extensions/wikia/InstantGlobals/InstantGlobalsHooks.class.php
@@ -2,7 +2,7 @@
 
 class InstantGlobalsHooks {
 
-	public static function onWikiaSkinTopShortTTLModules(Array &$modules, $skin) {
+	public static function onWikiaSkinTopShortTTLModules( Array &$modules, $skin ) {
 		if ( F::app()->checkSkin( 'oasis', $skin ) ) {
 			$modules[] = 'wikia.ext.instantGlobals';
 		}

--- a/extensions/wikia/InstantGlobals/InstantGlobalsHooks.class.php
+++ b/extensions/wikia/InstantGlobals/InstantGlobalsHooks.class.php
@@ -4,7 +4,7 @@ class InstantGlobalsHooks {
 
 	public static function onWikiaSkinTopShortTTLModules(Array &$modules, $skin) {
 		if ( F::app()->checkSkin( 'oasis', $skin ) ) {
-			$modules[] = 'wikia.ext.instantglobals';
+			$modules[] = 'wikia.ext.instantGlobals';
 		}
 		return true;
 	}

--- a/extensions/wikia/InstantGlobals/InstantGlobalsHooks.class.php
+++ b/extensions/wikia/InstantGlobals/InstantGlobalsHooks.class.php
@@ -3,7 +3,9 @@
 class InstantGlobalsHooks {
 
 	public static function onWikiaSkinTopShortTTLModules(Array &$modules, $skin) {
-		$modules[] = 'wikia.ext.instantglobals';
+		if ( F::app()->checkSkin( 'oasis', $skin ) ) {
+			$modules[] = 'wikia.ext.instantglobals';
+		}
 		return true;
 	}
 }

--- a/extensions/wikia/InstantGlobals/InstantGlobalsHooks.class.php
+++ b/extensions/wikia/InstantGlobals/InstantGlobalsHooks.class.php
@@ -1,0 +1,9 @@
+<?php
+
+class InstantGlobalsHooks {
+
+	public static function onWikiaSkinTopShortTTLModules(Array &$modules, $skin) {
+		$modules[] = 'wikia.ext.instantglobals';
+		return true;
+	}
+}

--- a/extensions/wikia/InstantGlobals/InstantGlobalsModule.class.php
+++ b/extensions/wikia/InstantGlobals/InstantGlobalsModule.class.php
@@ -16,7 +16,7 @@ class InstantGlobalsModule extends ResourceLoaderModule {
 	private function getVariablesValues() {
 		global $wgInstantGlobalsOverride;
 
-		if (!empty($wgInstantGlobalsOverride) && is_array($wgInstantGlobalsOverride)) {
+		if ( !empty( $wgInstantGlobalsOverride ) && is_array( $wgInstantGlobalsOverride ) ) {
 			$override = $wgInstantGlobalsOverride;
 		} else {
 			$override = [];
@@ -26,18 +26,18 @@ class InstantGlobalsModule extends ResourceLoaderModule {
 
 		$variables = [];
 
-		wfRunHooks('InstantGlobalsGetVariables', [&$variables]);
+		wfRunHooks( 'InstantGlobalsGetVariables', [&$variables] );
 
-		foreach($variables as $name) {
+		foreach ( $variables as $name ) {
 			// Use the value on community but override with the $wgInstantGlobalsOverride
-			if (array_key_exists($override, $name)) {
+			if ( array_key_exists( $name, $override ) ) {
 				$value = $override[$name];
 			} else {
-				$value = WikiFactory::getVarValueByName($name, Wikia::COMMUNITY_WIKI_ID);
+				$value = WikiFactory::getVarValueByName( $name, Wikia::COMMUNITY_WIKI_ID );
 			}
 
 			// don't emit "falsy" values
-			if (!empty($value)) {
+			if ( !empty( $value ) ) {
 				$ret[$name] = $value;
 			}
 		}
@@ -45,10 +45,10 @@ class InstantGlobalsModule extends ResourceLoaderModule {
 		return (object) $ret;
 	}
 
-	public function getScript(ResourceLoaderContext $context) {
+	public function getScript( ResourceLoaderContext $context ) {
 		$variables = $this->getVariablesValues();
 
-		return sprintf('Wikia.InstantGlobals = %s', json_encode($variables));
+		return sprintf( 'Wikia.InstantGlobals = %s', json_encode( $variables ) );
 	}
 
 	/**

--- a/extensions/wikia/InstantGlobals/InstantGlobalsModule.class.php
+++ b/extensions/wikia/InstantGlobals/InstantGlobalsModule.class.php
@@ -2,6 +2,8 @@
 /**
  * Implements InstantGlobals: fast changing WF variables in JavaScript
  *
+ * Emits Wikia.InstantGlobals key / value object.
+ *
  * @author macbre
  */
 class InstantGlobalsModule extends ResourceLoaderModule {
@@ -15,7 +17,7 @@ class InstantGlobalsModule extends ResourceLoaderModule {
 	/**
 	 * Get variables values
 	 *
-	 * @return array
+	 * @return object key / value list variables
 	 */
 	private function getVariablesValues() {
 		$ret = [];
@@ -29,18 +31,13 @@ class InstantGlobalsModule extends ResourceLoaderModule {
 			}
 		}
 
-		return $ret;
+		return (object) $ret;
 	}
 
 	public function getScript(ResourceLoaderContext $context) {
-		$items = [];
+		$variables = $this->getVariablesValues();
 
-		foreach($this->getVariablesValues() as $name => $value) {
-			$encValue = Xml::encodeJsVar( $value );
-			$items[] = "$name=$encValue";
-		}
-
-		return 'var ' . join(',', $items);
+		return sprintf('Wikia.InstantGlobals = %s', json_encode($variables));
 	}
 
 	/**

--- a/extensions/wikia/InstantGlobals/InstantGlobalsModule.class.php
+++ b/extensions/wikia/InstantGlobals/InstantGlobalsModule.class.php
@@ -9,10 +9,7 @@
 class InstantGlobalsModule extends ResourceLoaderModule {
 
 	// list of WikiFactory variables whose values should be taken from Community Wiki
-	private $variables = [
-		'wgHighValueCountries',
-		'wgAmazonDirectTargetedBuyCountries',
-	];
+	private $variables = [];
 
 	/**
 	 * Get variables values

--- a/extensions/wikia/InstantGlobals/InstantGlobalsModule.class.php
+++ b/extensions/wikia/InstantGlobals/InstantGlobalsModule.class.php
@@ -8,7 +8,7 @@
  */
 class InstantGlobalsModule extends ResourceLoaderModule {
 
-	// list of WikiFactory variables which values should be taken from Community Wiki
+	// list of WikiFactory variables whose values should be taken from Community Wiki
 	private $variables = [
 		'wgHighValueCountries',
 		'wgAmazonDirectTargetedBuyCountries',

--- a/extensions/wikia/InstantGlobals/InstantGlobalsModule.class.php
+++ b/extensions/wikia/InstantGlobals/InstantGlobalsModule.class.php
@@ -8,12 +8,6 @@
  */
 class InstantGlobalsModule extends ResourceLoaderModule {
 
-	// list of WikiFactory variables whose values should be taken from Community Wiki
-	private $variables = [
-		'wgHighValueCountries',
-		'wgAmazonDirectTargetedBuyCountries',
-	];
-
 	/**
 	 * Get variables values
 	 *
@@ -22,7 +16,11 @@ class InstantGlobalsModule extends ResourceLoaderModule {
 	private function getVariablesValues() {
 		$ret = [];
 
-		foreach($this->variables as $name) {
+		$variables = [];
+
+		wfRunHooks( 'InstantGlobalsGetVariables', [ &$variables ] );
+
+		foreach($variables as $name) {
 			$value = WikiFactory::getVarValueByName($name, Wikia::COMMUNITY_WIKI_ID);
 
 			// don't emit "falsy" values

--- a/extensions/wikia/InstantGlobals/InstantGlobalsModule.class.php
+++ b/extensions/wikia/InstantGlobals/InstantGlobalsModule.class.php
@@ -9,7 +9,10 @@
 class InstantGlobalsModule extends ResourceLoaderModule {
 
 	// list of WikiFactory variables whose values should be taken from Community Wiki
-	private $variables = [];
+	private $variables = [
+		'wgHighValueCountries',
+		'wgAmazonDirectTargetedBuyCountries',
+	];
 
 	/**
 	 * Get variables values

--- a/extensions/wikia/InstantGlobals/InstantGlobalsModule.class.php
+++ b/extensions/wikia/InstantGlobals/InstantGlobalsModule.class.php
@@ -14,14 +14,27 @@ class InstantGlobalsModule extends ResourceLoaderModule {
 	 * @return object key / value list variables
 	 */
 	private function getVariablesValues() {
+		global $wgInstantGlobalsOverride;
+
+		if (!empty($wgInstantGlobalsOverride) && is_array($wgInstantGlobalsOverride)) {
+			$override = $wgInstantGlobalsOverride;
+		} else {
+			$override = [];
+		}
+
 		$ret = [];
 
 		$variables = [];
 
-		wfRunHooks( 'InstantGlobalsGetVariables', [ &$variables ] );
+		wfRunHooks('InstantGlobalsGetVariables', [&$variables]);
 
 		foreach($variables as $name) {
-			$value = WikiFactory::getVarValueByName($name, Wikia::COMMUNITY_WIKI_ID);
+			// Use the value on community but override with the $wgInstantGlobalsOverride
+			if (array_key_exists($override, $name)) {
+				$value = $override[$name];
+			} else {
+				$value = WikiFactory::getVarValueByName($name, Wikia::COMMUNITY_WIKI_ID);
+			}
 
 			// don't emit "falsy" values
 			if (!empty($value)) {

--- a/extensions/wikia/InstantGlobals/InstantGlobalsModule.class.php
+++ b/extensions/wikia/InstantGlobals/InstantGlobalsModule.class.php
@@ -8,7 +8,8 @@ class InstantGlobalsModule extends ResourceLoaderModule {
 
 	// list of WikiFactory variables which values should be taken from Community Wiki
 	private $variables = [
-		'wgHighValueCountries'
+		'wgHighValueCountries',
+		'wgAmazonDirectTargetedBuyCountries',
 	];
 
 	/**

--- a/extensions/wikia/InstantGlobals/InstantGlobalsModule.class.php
+++ b/extensions/wikia/InstantGlobals/InstantGlobalsModule.class.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Implements InstantGlobals: fast changing WF variables in JavaScript
+ *
+ * @author macbre
+ */
+class InstantGlobalsModule extends ResourceLoaderModule {
+
+	// list of WikiFactory variables which values should be taken from Community Wiki
+	private $variables = [
+		'wgHighValueCountries'
+	];
+
+	/**
+	 * Get variables values
+	 *
+	 * @return array
+	 */
+	private function getVariablesValues() {
+		$ret = [];
+
+		foreach($this->variables as $name) {
+			$value = WikiFactory::getVarValueByName($name, Wikia::COMMUNITY_WIKI_ID);
+
+			// don't emit "falsy" values
+			if (!empty($value)) {
+				$ret[$name] = $value;
+			}
+		}
+
+		return $ret;
+	}
+
+	public function getScript(ResourceLoaderContext $context) {
+		$items = [];
+
+		foreach($this->getVariablesValues() as $name => $value) {
+			$encValue = Xml::encodeJsVar( $value );
+			$items[] = "$name=$encValue";
+		}
+
+		return 'var ' . join(',', $items);
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function supportsURLLoading() {
+		return false;
+	}
+
+	/**
+	 * Load this module from the shared domain
+	 *
+	 * @return String
+	 */
+	public function getSource() {
+		return 'common';
+	}
+}

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -537,6 +537,7 @@ include_once( "$IP/extensions/wikia/ArticleSummary/ArticleSummary.setup.php" );
 include_once( "$IP/extensions/wikia/FilePage/FilePage.setup.php" );
 include_once( "$IP/extensions/wikia/CityVisualization/CityVisualization.setup.php" );
 include_once( "$IP/extensions/wikia/Thumbnails/Thumbnails.setup.php" );
+include_once( "$IP/extensions/wikia/InstantGlobals/InstantGlobals.setup.php" );
 
 /**
  * @name $wgSkipSkins

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1163,15 +1163,6 @@ $wgWikiaHubsFileRepoDirectory = '/images/c/corp/images';
 $wgEnableAmazonDirectTargetedBuy = true;
 
 /**
- * @name $wgAmazonDirectTargetedBuyCountriesDefault
- * The default value for $wgAmazonDirectTargetedBuyCountriesDefault
- * Main steering var, change this one.
- * Value set for community central overrides this. Value for particular wiki overrides the community
- * US + EU (UK is GB...)
- */
-$wgAmazonDirectTargetedBuyCountriesDefault = ['US', 'AT', 'BE', 'DK', 'FI', 'FR', 'DE', 'IE', 'IT', 'LU', 'NL', 'NO', 'PL', 'PT', 'ES', 'SE', 'CH', 'GB'];
-
-/**
  * @name $wgAmazonDirectTargetedBuyCountries
  * Enables AmazonDirectTargetedBuy integration in theese countries (given AmazonDirectTargetedBuy is also true)
  * "Utility" var, don't change it here.
@@ -1240,13 +1231,6 @@ $wgAdDriverForceDirectGptAd = false;
  * Forces to use AdProviderLiftium for all slots managed by this provider
  */
 $wgAdDriverForceLiftiumAd = false;
-
-/**
- * @name $wgHighValueCountriesDefault
- * Default list of countries defined as high-value for revenue purposes
- * $wgHighValueCountries overrides this
- */
-$wgHighValueCountriesDefault = array('CA'=>3, 'DE'=>3, 'DK'=>3, 'ES'=>3, 'FI'=>3, 'FR'=>3, 'GB'=>3, 'IT'=>3, 'NL'=>3, 'NO'=>3, 'SE'=>3, 'UK'=>3, 'US'=>3);
 
 /**
  * @name $wgHighValueCountries

--- a/includes/wikia/nirvana/WikiaSkin.class.php
+++ b/includes/wikia/nirvana/WikiaSkin.class.php
@@ -189,6 +189,8 @@ abstract class WikiaSkin extends SkinTemplate {
 
 		wfrunHooks( 'WikiaSkinTopScripts', array( &$vars, &$scripts, $this ) );
 
+		$scripts .= $this->renderTopShortTTLModules();
+
 		$scriptModules = array( 'amd', 'wikia.tracker.stub' );
 		wfrunHooks( 'WikiaSkinTopModules', array( &$scriptModules, $this ) );
 		if ( !empty($scriptModules) ) {
@@ -203,6 +205,30 @@ abstract class WikiaSkin extends SkinTemplate {
 		}
 
 		return self::makeInlineVariablesScript($vars) . $scripts;
+	}
+
+	/**
+	 * Load ResourceLoader modules that have a short caching time
+	 *
+	 * Used by AbTesting and InstantGlobals
+	 *
+	 * @return string
+	 * @author macbre
+	 */
+	protected function renderTopShortTTLModules() {
+		$shortTtlScriptModules = [];
+
+		wfRunHooks( 'WikiaSkinTopShortTTLModules', [ &$shortTtlScriptModules, $this ] );
+
+		if ( !empty($shortTtlScriptModules) ) {
+			$scripts = ResourceLoader::makeCustomLink( $this->wg->out, $shortTtlScriptModules, 'scripts' ) . "\n";
+		}
+		else {
+			$scripts = '';
+		}
+
+		return $scripts;
+
 	}
 
 	// expose protected methods from Skin object

--- a/resources/wikia/Resources.php
+++ b/resources/wikia/Resources.php
@@ -13,6 +13,7 @@ return [
 	// shared AMD modules loaded on each page
 	'amd.shared' => [
 		'dependencies' => [
+			'wikia.instantGlobals',
 			'wikia.cache',
 			'wikia.cookies',
 			'wikia.document',
@@ -113,6 +114,13 @@ return [
 	],
 	'wikia.abTest' => [
 		'scripts' => 'resources/wikia/modules/abTest.js',
+		'dependencies' => [
+			'amd',
+			'wikia.window'
+		],
+	],
+	'wikia.instantGlobals' => [
+		'scripts' => 'resources/wikia/modules/instantGlobals.js',
 		'dependencies' => [
 			'amd',
 			'wikia.window'

--- a/resources/wikia/modules/instantGlobals.js
+++ b/resources/wikia/modules/instantGlobals.js
@@ -7,4 +7,6 @@ define('wikia.instantGlobals', ['wikia.window'], function(window) {
 	if (window.Wikia && window.Wikia.InstantGlobals) {
 		return window.Wikia.InstantGlobals;
 	}
+
+	return {};
 });

--- a/resources/wikia/modules/instantGlobals.js
+++ b/resources/wikia/modules/instantGlobals.js
@@ -1,0 +1,10 @@
+/**
+ * AMD module exporting Wikia.InstantGlobals object
+ */
+/*global define*/
+define('wikia.instantGlobals', ['wikia.window'], function(window) {
+	'use strict';
+	if (window.Wikia && window.Wikia.InstantGlobals) {
+		return window.Wikia.InstantGlobals;
+	}
+});

--- a/skins/WikiaMobile.php
+++ b/skins/WikiaMobile.php
@@ -29,6 +29,10 @@ class SkinWikiaMobile extends WikiaSkin {
 
 		//this is run to grab all global variables
 		wfRunHooks( 'WikiaSkinTopScripts', [ &$vars, &$scripts, $this ] );
+
+		// load ResourceLoader modules that have a short caching time
+		$scripts .= $this->renderTopShortTTLModules();
+
 		//send list of supported videos so we can treat not supported ones differently
 		$globalVariables['supportedVideos'] = $this->wg->WikiaMobileSupportedVideos;
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-236

This extension emits WikiFactory variables as JS globals. Variables are exposed via ResourceLoader module (loaded at the top of the page along with abtesting config) with a short CDN caching time, allowing us to make critical config changes with no need to wait 24h for CDN page cache to invalidate.
- `InstantGlobalsModule::$variables` contains the list of WF variables to be emitted by the module
- variables values are taken from Community Wiki
- caching time on both server and client-side is 300 sec
- RL module is only loaded in Oasis

@bognix / @gabrys / @prein / @michalroszka / @federico-lox 

**Do not merge** Waiting for QA from Ads team.
