### PR TITLE
CONN-512 Fixing dangling comments_index records left from Special:Nuke (dev)

### DIFF
--- a/extensions/wikia/Forum/Forum.setup.php
+++ b/extensions/wikia/Forum/Forum.setup.php
@@ -62,8 +62,10 @@ $wgHooks['getUserPermissionsErrors'][] = 'ForumHooksHelper::onGetUserPermissions
 $wgHooks['PageHeaderIndexAfterActionButtonPrepared'][] = 'ForumHooksHelper::onPageHeaderIndexAfterActionButtonPrepared';
 $wgHooks['ArticleViewHeader'][] = 'ForumHooksHelper::onArticleViewHeader';
 
-// make sure that when an article is deleted, that if it has a comments_index
-// that record is properly marked as deleted
+// make sure that when an article is deleted, if it has a comments_index,
+// that record is properly marked as deleted. this needs to happen within
+// the transaction in  WikiPage::doDeleteArticleReal which is why it's being hooked
+// here and not in ArticleDeleteComplete
 $wgHooks['ArticleDoDeleteArticleBeforeLogEntry'][] = 'ForumHooksHelper::onArticleDoDeleteArticleBeforeLogEntry';
 
 

--- a/extensions/wikia/Forum/Forum.setup.php
+++ b/extensions/wikia/Forum/Forum.setup.php
@@ -64,7 +64,7 @@ $wgHooks['ArticleViewHeader'][] = 'ForumHooksHelper::onArticleViewHeader';
 
 // make sure that when an article is deleted, that if it has a comments_index
 // that record is properly marked as deleted
-$wgHooks['ArticleDeleteComplete'][] = 'ForumHooksHelper::onArticleDeleteComplete';
+$wgHooks['ArticleDoDeleteArticleBeforeLogEntry'][] = 'ForumHooksHelper::onArticleDoDeleteArticleBeforeLogEntry';
 
 
 // forum discussion on article

--- a/extensions/wikia/Forum/Forum.setup.php
+++ b/extensions/wikia/Forum/Forum.setup.php
@@ -62,6 +62,11 @@ $wgHooks['getUserPermissionsErrors'][] = 'ForumHooksHelper::onGetUserPermissions
 $wgHooks['PageHeaderIndexAfterActionButtonPrepared'][] = 'ForumHooksHelper::onPageHeaderIndexAfterActionButtonPrepared';
 $wgHooks['ArticleViewHeader'][] = 'ForumHooksHelper::onArticleViewHeader';
 
+// make sure that when an article is deleted, that if it has a comments_index
+// that record is properly marked as deleted
+$wgHooks['ArticleDeleteComplete'][] = 'ForumHooksHelper::onArticleDeleteComplete';
+
+
 // forum discussion on article
 //It need to be first one !!!
 array_splice( $wgHooks['OutputPageBeforeHTML'], 0, 0, 'ForumHooksHelper::onOutputPageBeforeHTML' );

--- a/extensions/wikia/Forum/ForumHooksHelper.class.php
+++ b/extensions/wikia/Forum/ForumHooksHelper.class.php
@@ -493,4 +493,18 @@ class ForumHooksHelper {
 
 		return true;
 	}
+
+	// FIXME: how do we test this? see extensions/wikia/Search/classes/Test/HooksTest.php
+	static public function onArticleDeleteComplete( &$page, &$user, $reason, $id) {
+		$title = $page->getTitle();
+		var_dump(get_class($title), $title->getNamespace());
+		if($title instanceof Title) {
+			$wallMessage = WallMessage::newFromTitle($title);
+			// FIXME: check to see if it isn't already removed, deleted, or archived?
+			$wallMessage->setInCommentsIndex(WPP_WALL_ADMINDELETE, 1);
+		}
+
+		return true;
+	}
+
 }

--- a/extensions/wikia/Forum/ForumHooksHelper.class.php
+++ b/extensions/wikia/Forum/ForumHooksHelper.class.php
@@ -507,9 +507,9 @@ class ForumHooksHelper {
 	 * @return bool true
 	 *
 	 */
-	static public function onArticleDoDeleteArticleBeforeLogEntry( &$page, &$user, $reason, $id) {
+	static public function onArticleDoDeleteArticleBeforeLogEntry( &$page, &$user, $reason, $id ) {
 		$title = $page->getTitle();
-		if($title instanceof Title) {
+		if ( $title instanceof Title ) {
 			$wallMessage = WallMessage::newFromTitle($title);
 			$wallMessage->setInCommentsIndex(WPP_WALL_ADMINDELETE, 1);
 		}

--- a/extensions/wikia/Forum/ForumHooksHelper.class.php
+++ b/extensions/wikia/Forum/ForumHooksHelper.class.php
@@ -495,9 +495,8 @@ class ForumHooksHelper {
 	}
 
 	// FIXME: how do we test this? see extensions/wikia/Search/classes/Test/HooksTest.php
-	static public function onArticleDeleteComplete( &$page, &$user, $reason, $id) {
+	static public function onArticleDoDeleteArticleBeforeLogEntry( &$page, &$user, $reason, $id) {
 		$title = $page->getTitle();
-		var_dump(get_class($title), $title->getNamespace());
 		if($title instanceof Title) {
 			$wallMessage = WallMessage::newFromTitle($title);
 			// FIXME: check to see if it isn't already removed, deleted, or archived?

--- a/extensions/wikia/Forum/ForumHooksHelper.class.php
+++ b/extensions/wikia/Forum/ForumHooksHelper.class.php
@@ -494,12 +494,23 @@ class ForumHooksHelper {
 		return true;
 	}
 
-	// FIXME: how do we test this? see extensions/wikia/Search/classes/Test/HooksTest.php
+	/**
+	 * Ensure that the comments_index record (if it exists) for an article is marked as deleted
+	 * when an article is deleted. This event must be run inside the transaction in WikiPage::doDeleteArticleReal
+	 * otherwise the Article referenced will no longer exist and the lookup for it's associated
+	 * comments_index row will fail.
+	 *
+	 * @param WikiPage
+	 * @param [not used]
+	 * @param [not used]
+	 * @param [not used]
+	 * @return bool true
+	 *
+	 */
 	static public function onArticleDoDeleteArticleBeforeLogEntry( &$page, &$user, $reason, $id) {
 		$title = $page->getTitle();
 		if($title instanceof Title) {
 			$wallMessage = WallMessage::newFromTitle($title);
-			// FIXME: check to see if it isn't already removed, deleted, or archived?
 			$wallMessage->setInCommentsIndex(WPP_WALL_ADMINDELETE, 1);
 		}
 

--- a/extensions/wikia/Wall/WallMessage.class.php
+++ b/extensions/wikia/Wall/WallMessage.class.php
@@ -1284,7 +1284,7 @@ class WallMessage {
 		return false;
 	}
 
-	protected function setInCommentsIndex( $prop, $value, $useMaster = false ) {
+	public function setInCommentsIndex( $prop, $value, $useMaster = false ) {
 		$commentId = $this->getId();
 		if ( !empty($commentId) ) {
 			$commentsIndex = $this->getCommentsIndex();

--- a/includes/WikiPage.php
+++ b/includes/WikiPage.php
@@ -2044,8 +2044,6 @@ class WikiPage extends Page {
 			return WikiPage::DELETE_NO_REVISIONS;
 		}
 
-		$this->doDeleteUpdates( $id );
-
 		# Log the deletion, if the page was suppressed, log it at Oversight instead
 		$logtype = $suppress ? 'suppress' : 'delete';
 
@@ -2065,6 +2063,11 @@ class WikiPage extends Page {
 			$logEntry->publish( $logid );
 		}
 		# Wikia change end
+
+		// Wikia change: doDeleteUpdates has side effects that reset the title. This prevents hooks from acting on the
+		// page if they rely on the title or related associations.
+		$this->doDeleteUpdates( $id );
+		// Wikia change end
 
 		if ( $commit ) {
 			$dbw->commit();

--- a/maintenance/wikia/Forum/cleanupCommentsIndex.php
+++ b/maintenance/wikia/Forum/cleanupCommentsIndex.php
@@ -62,26 +62,26 @@ SQL;
 		printf("%s: fixing bad comments_index rows...\n", $dbname);
 
 		$sql = <<<SQL
-CREATE TEMPORARY TABLE temporary_bad_comments_index_records AS (
-		SELECT parent_page_id, first_rev_id, removed, deleted, archived
-		FROM comments_index
-		LEFT JOIN revision ON (
-						revision.rev_id = comments_index.first_rev_id
-		)
-		WHERE comments_index.removed = 0 AND
-					comments_index.deleted = 0 AND
-					comments_index.archived = 0 AND
-					revision.rev_id IS NULL
-);
+		CREATE TEMPORARY TABLE temporary_bad_comments_index_records AS (
+			SELECT parent_page_id, first_rev_id, removed, deleted, archived
+			FROM comments_index
+			LEFT JOIN revision ON (
+							revision.rev_id = comments_index.first_rev_id
+			)
+			WHERE comments_index.removed = 0 AND
+						comments_index.deleted = 0 AND
+						comments_index.archived = 0 AND
+						revision.rev_id IS NULL
+		);
 SQL;
 		$db->query($sql);
 		$row = $db->fetchObject( $ret );
 
 		$sql = <<<SQL
-UPDATE comments_index, temporary_bad_comments_index_records
-				SET comments_index.deleted = 1
-				WHERE comments_index.parent_page_id = temporary_bad_comments_index_records.parent_page_id AND
-							comments_index.first_rev_id = temporary_bad_comments_index_records.first_rev_id;
+		UPDATE comments_index, temporary_bad_comments_index_records
+			SET comments_index.deleted = 1
+			WHERE comments_index.parent_page_id = temporary_bad_comments_index_records.parent_page_id AND
+				comments_index.first_rev_id = temporary_bad_comments_index_records.first_rev_id;
 SQL;
 		$db->query($sql);
 		$row = $db->fetchObject( $ret );

--- a/maintenance/wikia/Forum/cleanupCommentsIndex.php
+++ b/maintenance/wikia/Forum/cleanupCommentsIndex.php
@@ -43,9 +43,9 @@ class CleanupCommentsIndex {
 		 revision.rev_id = comments_index.first_rev_id
 		)
 		WHERE comments_index.removed = 0 AND
-					comments_index.deleted = 0 AND
-					comments_index.archived = 0 AND
-					revision.rev_id IS NULL
+			comments_index.deleted = 0 AND
+			comments_index.archived = 0 AND
+			revision.rev_id IS NULL
 SQL;
 		$ret = $db->query( $sql );
 		$row = $db->fetchObject( $ret );
@@ -66,12 +66,12 @@ SQL;
 			SELECT parent_page_id, first_rev_id, removed, deleted, archived
 			FROM comments_index
 			LEFT JOIN revision ON (
-							revision.rev_id = comments_index.first_rev_id
+				revision.rev_id = comments_index.first_rev_id
 			)
 			WHERE comments_index.removed = 0 AND
-						comments_index.deleted = 0 AND
-						comments_index.archived = 0 AND
-						revision.rev_id IS NULL
+				comments_index.deleted = 0 AND
+				comments_index.archived = 0 AND
+				revision.rev_id IS NULL
 		);
 SQL;
 		$db->query($sql);

--- a/maintenance/wikia/Forum/cleanupCommentsIndex.php
+++ b/maintenance/wikia/Forum/cleanupCommentsIndex.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Cleanup the dangling references in comments_index.
+ * https://wikia-inc.atlassian.net/browse/CONN-506
+ */
+
+class CleanupCommentsIndex {
+
+	/**
+	 * Runner. See maintenance/wikia/runOnCluster.php
+	 *
+	 * If --test is given checks to see if there are any bad comments_index rows. OTW, runs the fix
+	 * which marks those rows with deleted = 1.
+	 *
+	 */
+	public static function run( DatabaseMysql $db, $test = false, $verbose = false, $params ) {
+		$dbname = $params['dbname'];
+
+		if ( !self::commentsIndexExists( $db) ) {
+			return;
+		}
+
+		if ( $test ) {
+			self::checkCommentsIndex( $db, $dbname );
+		} else {
+			self::fixCommentsIndex( $db, $dbname );
+		}
+
+	}
+
+	/**
+	 * Check the comments_index table for bad records. Emits a line to STDOUT
+	 * indicating the how many were found.
+	 *
+	 * @param DatabaseMysql
+	 * @param string the database name
+	 */
+	public static function checkCommentsIndex( DatabaseMysql $db, $dbname ) {
+		$sql = <<<SQL
+		SELECT COUNT(*) AS count
+		FROM comments_index
+		LEFT JOIN revision ON (
+		 revision.rev_id = comments_index.first_rev_id
+		)
+		WHERE comments_index.removed = 0 AND
+					comments_index.deleted = 0 AND
+					comments_index.archived = 0 AND
+					revision.rev_id IS NULL
+SQL;
+		$ret = $db->query( $sql );
+		$row = $db->fetchObject( $ret );
+		printf("%s: Found %d bad comments_index rows.\n", $dbname, $row->count);
+	}
+
+	/**
+	 * Fixes the bad rows in the comments_index table by marking them with deleted=1.
+	 *
+	 * @param DatabaseMysql
+	 * @param string the database name
+	 */
+	public function fixCommentsIndex( DatabaseMysql $db, $dbname ) {
+		printf("%s: fixing bad comments_index rows...\n", $dbname);
+
+		$sql = <<<SQL
+CREATE TEMPORARY TABLE temporary_bad_comments_index_records AS (
+		SELECT parent_page_id, first_rev_id, removed, deleted, archived
+		FROM comments_index
+		LEFT JOIN revision ON (
+						revision.rev_id = comments_index.first_rev_id
+		)
+		WHERE comments_index.removed = 0 AND
+					comments_index.deleted = 0 AND
+					comments_index.archived = 0 AND
+					revision.rev_id IS NULL
+);
+SQL;
+		$db->query($sql);
+		$row = $db->fetchObject( $ret );
+
+		$sql = <<<SQL
+UPDATE comments_index, temporary_bad_comments_index_records
+				SET comments_index.deleted = 1
+				WHERE comments_index.parent_page_id = temporary_bad_comments_index_records.parent_page_id AND
+							comments_index.first_rev_id = temporary_bad_comments_index_records.first_rev_id;
+SQL;
+		$db->query($sql);
+		$row = $db->fetchObject( $ret );
+	}
+
+	/**
+	 * Check to see if the comments_index table exists.
+	 *
+	 * @param DatabaseMysql
+	 */
+	public static function commentsIndexExists( DatabaseMysql $db ) {
+		return $db->query("SHOW TABLES LIKE 'comments_index'")->numRows() > 0;
+	}
+}


### PR DESCRIPTION
This is the dev branch version of https://github.com/Wikia/app/pull/3574.

This pull request fixes the root cause of the dangling comments_index records by adding a hook to `ArticleDoDeleteArticleBeforeLogEntry` to mark the comments_index associated with an article as deleted and adds a maintenance script that will mark all of the dangling comments_index records as deleted.

https://wikia-inc.atlassian.net/browse/CONN-512
https://wikia-inc.atlassian.net/browse/CONN-506

/cc @owend
