### PR TITLE
(CE-815) Fix Scribunto fatal error when parser is cloned

### DIFF
--- a/includes/parser/Parser.php
+++ b/includes/parser/Parser.php
@@ -220,6 +220,15 @@ class Parser {
 	}
 
 	/**
+	 * Allow extensions to clean up when the parser is cloned
+	 *
+	 * Wikia change - backported from MW 1.21 (CE-815)
+	 */
+	function __clone() {
+		wfRunHooks( 'ParserCloned', array( $this ) );
+	}
+
+	/**
 	 * Do various kinds of initialisation on the first call of the parser
 	 */
 	function firstCallInit() {


### PR DESCRIPTION
Fixes a fatal error in Scribunto when the parser is cloned, such as
when DPL is used on the same page as a Lua module. This allows us to
give the new Parser instance a new ScribuntoEngine, as otherwise the
engine for the other parser will be unexpectedly destroyed. Scribunto
already makes use of this hook to handle this, so we just need to
backport the ParserCloned hook call.
