### PR TITLE
BAC-719 Trigger events on tabber tab change

### DIFF
--- a/extensions/3rdparty/tabber/tabber.js
+++ b/extensions/3rdparty/tabber/tabber.js
@@ -405,6 +405,14 @@ tabberObj.prototype.tabShow = function(tabberIndex)
 	/* Mark this tab navigation link as "active" */
 	this.navSetActive(tabberIndex);
 
+	/* Wikia change begin: @author Scott Rabin */
+	// Notify other listeners that the effective scroll position
+	// of some elements on the page may have changed as a result
+	// of switching tabs; e.g. lazy loaded images may now be visible
+	// and should load
+	$(window).trigger('scroll');
+	/* Wikia change end */
+
 	/* If the user specified an onTabDisplay function, call it now. */
 	if (typeof this.onTabDisplay == 'function') {
 		this.onTabDisplay({'tabber':this, 'index':tabberIndex});

--- a/extensions/wikia/ImageLazyLoad/js/ImgLzy.module.js
+++ b/extensions/wikia/ImageLazyLoad/js/ImgLzy.module.js
@@ -165,7 +165,7 @@ define('wikia.ImgLzy', ['jquery', 'wikia.log', 'wikia.window'], function ($, log
 				lastScrollTop,
 				scrollBottom,
 				idx,
-				visible,
+				inViewport,
 				cacheItem;
 
 			for (idx in this.cache) {
@@ -177,10 +177,10 @@ define('wikia.ImgLzy', ['jquery', 'wikia.log', 'wikia.window'], function ($, log
 				scrollTop = scrollTop - scrollSpeed;
 
 				cacheItem.parent.data('lastScrollTop', lastScrollTop);
-				visible = (scrollTop < cacheItem.top && scrollBottom > cacheItem.top) ||
+				inViewport = (scrollTop < cacheItem.top && scrollBottom > cacheItem.top) ||
 					(scrollTop < cacheItem.bottom && scrollBottom > cacheItem.bottom);
 
-				if (visible && this.parentVisible(cacheItem) && cacheItem.jq.is(':visible')) {
+				if (inViewport && this.parentVisible(cacheItem) && cacheItem.jq.is(':visible')) {
 					cacheItem.jq.addClass('lzyTrns');
 					cacheItem.el.onload = onload;
 					cacheItem.el.src = this.rewriteURLForWebP(cacheItem.jq.data('src'));

--- a/extensions/wikia/ImageLazyLoad/js/ImgLzy.module.js
+++ b/extensions/wikia/ImageLazyLoad/js/ImgLzy.module.js
@@ -180,7 +180,7 @@ define('wikia.ImgLzy', ['jquery', 'wikia.log', 'wikia.window'], function ($, log
 				visible = (scrollTop < cacheItem.top && scrollBottom > cacheItem.top) ||
 					(scrollTop < cacheItem.bottom && scrollBottom > cacheItem.bottom);
 
-				if (visible && this.parentVisible(cacheItem)) {
+				if (visible && this.parentVisible(cacheItem) && cacheItem.jq.is(':visible')) {
 					cacheItem.jq.addClass('lzyTrns');
 					cacheItem.el.onload = onload;
 					cacheItem.el.src = this.rewriteURLForWebP(cacheItem.jq.data('src'));


### PR DESCRIPTION
Tabber offers a not-very-helpful hook system to run code after switching
tabs, but there is no guarantee on the load order of this module to
either insert hooks manually on the prototype and no way to specify the
hook at creation time (because it's automatic). Trigger a `scroll` event
because most of the things that are waiting to see if their visibility
state has changed will listen for `scroll`.

Additionally, prevent ImgLzy from thinking that just because an
element's offset values are in the right range, that it's actually
visible. It needs to not be in a `display: none` element for that to be
true. This avoids the stuttering that occurs when scrolling the page for
the first time when many galleries are embedded in a tabber that is
entirely visible; previously, it would try to load ALL of the images
(since it was only offset based), and now it makes sure the elements
aren't still hidden by Tabber.

RFCR @lizlux @macbre 
