### PR TITLE
CONN-401 consistent thread count filtering

### DIFF
--- a/extensions/wikia/Forum/Forum.class.php
+++ b/extensions/wikia/Forum/Forum.class.php
@@ -89,6 +89,7 @@ class Forum extends Walls {
 
 			$sqlWhere = array(
 				'parent_comment_id' => 0,
+				'archived' => 0,
 				'deleted' => 0,
 				'removed' => 0,
 				'page_namespace' => NS_WIKIA_FORUM_BOARD_THREAD


### PR DESCRIPTION
The sub-forum thread filtering excludes `comments_index` rows where `archived != 0`. This results in inconsistent numbering between the per forum thread counts in [getBoardInfo](https://github.com/Wikia/app/blob/dev/extensions/wikia/Forum/ForumBoard.class.php#L36) and the total thread count displayed at the top of the page.

/cc @owend 
