### PR TITLE
remove js references to wgMedusaSlot

### DIFF
--- a/extensions/wikia/AnalyticsEngine/js/analytics_dev.js
+++ b/extensions/wikia/AnalyticsEngine/js/analytics_dev.js
@@ -125,7 +125,6 @@
     _gaqWikiaPush(['_setCustomVar', 8, 'PageType',
                       window.wikiaPageType, 3],
                   ['_setCustomVar', 9, 'CityId', window.wgCityId, 3],
-                  ['_setCustomVar', 12, 'MedusaSlot', window.wgMedusaSlot, 3],
                   ['_setCustomVar', 15, 'IsCorporatePage', window.wikiaPageIsCorporate ? 'Yes' : 'No', 3],
                   ['_setCustomVar', 16, 'Krux Segment', getKruxSegment(), 3]
     );
@@ -159,7 +158,6 @@
     window._gaq.push(['ads._setCustomVar', 8, 'PageType',
                   window.wikiaPageType, 3],
               ['ads._setCustomVar', 9, 'CityId', window.wgCityId, 3],
-              ['ads._setCustomVar', 12, 'MedusaSlot', window.wgMedusaSlot, 3],
               ['ads._setCustomVar', 15, 'IsCorporatePage', window.wikiaPageIsCorporate ? 'Yes' : 'No', 3],
               ['ads._setCustomVar', 16, 'Krux Segment', getKruxSegment(), 3]
     );
@@ -209,7 +207,7 @@
      * @param {number=0} opt_value Event Value. Have to be an integer.
      * @param {boolean=false} opt_noninteractive Event noInteractive.
      */
-    window.gaTrackEvent = function(category, action, opt_label, opt_value, 
+    window.gaTrackEvent = function(category, action, opt_label, opt_value,
                                    opt_noninteractive) {
         var args = Array.prototype.slice.call(arguments);
         args.unshift('_trackEvent');

--- a/extensions/wikia/AnalyticsEngine/js/analytics_prod.js
+++ b/extensions/wikia/AnalyticsEngine/js/analytics_prod.js
@@ -122,7 +122,6 @@
 	/**** Medium-Priority CVs ****/
 	_gaqWikiaPush( ['_setCustomVar', 8, 'PageType', window.wikiaPageType, 3],
 		['_setCustomVar', 9, 'CityId', window.wgCityId, 3],
-		['_setCustomVar', 12, 'MedusaSlot', window.wgMedusaSlot, 3],
 		['_setCustomVar', 14, 'HasAds', window.wgShowAds ? 'Yes' : 'No', 3],
 		['_setCustomVar', 15, 'IsCorporatePage', window.wikiaPageIsCorporate ? 'Yes' : 'No', 3],
 		['_setCustomVar', 16, 'Krux Segment', getKruxSegment(), 3]
@@ -196,7 +195,6 @@
 	/**** Medium-Priority CVs ****/
 	window._gaq.push( ['ads._setCustomVar', 8, 'PageType', window.wikiaPageType, 3],
 		['ads._setCustomVar', 9, 'CityId', window.wgCityId, 3],
-		['ads._setCustomVar', 12, 'MedusaSlot', window.wgMedusaSlot, 3],
 		['ads._setCustomVar', 14, 'HasAds', window.wgShowAds ? 'Yes' : 'No', 3],
 		['ads._setCustomVar', 15, 'IsCorporatePage', window.wikiaPageIsCorporate ? 'Yes' : 'No', 3],
 		['ads._setCustomVar', 16, 'Krux Segment', getKruxSegment(), 3]

--- a/extensions/wikia/JSVariables/JSVariables.php
+++ b/extensions/wikia/JSVariables/JSVariables.php
@@ -28,9 +28,6 @@ function wfJSVariablesTopScripts(Array &$vars, &$scripts) {
 	// analytics needs it (from here till the end of the function)
 	$vars['wgDBname'] = $wg->DBname;
 	$vars['wgCityId'] = $wg->CityId;
-	if (!empty($wg->MedusaSlot)) {
-		$vars['wgMedusaSlot'] = 'slot' . $wg->MedusaSlot;
-	}
 
 	// c&p from OutputPage::getJSVars with an old 1.16 name
 	$vars['wgContentLanguage'] = $title->getPageLanguage()->getCode();

--- a/extensions/wikia/WikiaMobile/WikiaMobile.setup.php
+++ b/extensions/wikia/WikiaMobile/WikiaMobile.setup.php
@@ -153,7 +153,6 @@ if ( empty( $wgWikiaMobileIncludeJSGlobals ) ) {
 			'wgCdnRootUrl',
 			'wgAssetsManagerQuery',
 			'wgContentLanguage',
-			'wgMedusaSlot',
 			'wgResourceBasePath',
 			'wgMainPageTitle',
 			'wgSitename',


### PR DESCRIPTION
The only references left to the wgMedusaSlot variable are javascript / analytics tracking, but the value never changes so it seems pointless to track it.  I am cleaning this up in preparation for adding "channel awareness" to the app as part of the config refactoring. 

@gabrys @wladekb 
