### PR TITLE
Fix floating context menu near static toolbar

### DIFF
--- a/extensions/VisualEditor/lib/ve/modules/ve/ui/ve.ui.DesktopContext.js
+++ b/extensions/VisualEditor/lib/ve/modules/ve/ui/ve.ui.DesktopContext.js
@@ -108,8 +108,8 @@ ve.ui.DesktopContext.prototype.onWindowResize = function () {
 ve.ui.DesktopContext.prototype.onWindowScroll = function () {
 	var toolbar = this.surface.getTarget().getToolbar();
 
-	// Context menu is visible and embedded and the toolbar is floating
-	if ( this.visible && this.embedded && toolbar.isFloating() ) {
+	// Context menu is visible and embedded
+	if ( this.visible && this.embedded ) {
 		this.handleFloat();
 	}
 };

--- a/extensions/VisualEditor/lib/ve/modules/ve/ui/ve.ui.DesktopContext.js
+++ b/extensions/VisualEditor/lib/ve/modules/ve/ui/ve.ui.DesktopContext.js
@@ -106,8 +106,6 @@ ve.ui.DesktopContext.prototype.onWindowResize = function () {
  * Handle window scroll events.
  */
 ve.ui.DesktopContext.prototype.onWindowScroll = function () {
-	var toolbar = this.surface.getTarget().getToolbar();
-
 	// Context menu is visible and embedded
 	if ( this.visible && this.embedded ) {
 		this.handleFloat();


### PR DESCRIPTION
With the removal of the slugs, the toolbar and the first possible embedded context menu are closer to each other than they are when floating. Previously, we were checking to see if the toolbar was floating before handling any context menu floating. Now we need to handle floating of the context menu even when the toolbar isn't floating (but only just quickly in the time that you begin or end floating a context menu embedded in an element very near the static toolbar).
