### PR TITLE
CON-1225 | Remove empty CSS selectors

### DIFF
--- a/skins/oasis/css/core/GlobalHeader.scss
+++ b/skins/oasis/css/core/GlobalHeader.scss
@@ -169,7 +169,7 @@
 		}
 	}
 
-	/* Global Header vertical-specific colors */
+	// Global Header vertical-specific colors
 	&.vertical-colors {
 		.video-games-vertical-color .subnav a {
 			color: $color-wikiahome-videogames;

--- a/skins/oasis/css/core/PageHeader.scss
+++ b/skins/oasis/css/core/PageHeader.scss
@@ -139,7 +139,7 @@
 				border-bottom: 0;
 			}
 		}
-		/* temp grid transition code - integrate into main, then remove after grid is fully rolled out */
+		// temp grid transition code - integrate into main, then remove after grid is fully rolled out
 		.WikiaGrid {
 			.WikiaPageHeader .tally {
 				right: 340px;
@@ -148,7 +148,7 @@
 				right: 0;
 			}
 		}
-		/* temp grid transition code */
+		// temp grid transition code
 	}
 }
 // WikiaNav - end


### PR DESCRIPTION
Key for this issue are multiline comments `/* ... */`. Oneline comments `// ...` work fine.

Operations order is root cause here:
1. removes one line comments
2. generate blocks
3. remove multiline comments if compressed mode enabled
After this step empty blocks are preserved.
