### PR TITLE
LocalFile: ignore oldimage entries with empty oi_archive_name

### DIFF
--- a/includes/filerepo/file/LocalFile.php
+++ b/includes/filerepo/file/LocalFile.php
@@ -2348,6 +2348,28 @@ class LocalFileMoveBatch {
 			return $status;
 		}
 
+		// Wikia change - begin
+		// @author macbre (PLATFORM-238)
+		$rowsWithEmptyArchiveName = $dbw->selectField(
+			'oldimage',
+			'count(*)',
+			array(
+				'oi_name' => $this->oldName,
+				'oi_archive_name = ""',
+			),
+			__METHOD__
+		);
+
+		if ( $rowsWithEmptyArchiveName > 0 ) {
+			\Wikia\Logger\WikiaLogger::instance()->debug( 'Empty oi_archive_name' , [
+				'oi_name' => $this->oldName,
+				'new_name' => $this->newName,
+				'count' => $rowsWithEmptyArchiveName
+			] );
+		}
+
+		// Wikia change - end
+
 		// Update old images
 		$dbw->update(
 			'oldimage',
@@ -2355,12 +2377,15 @@ class LocalFileMoveBatch {
 				'oi_name' => $this->newName,
 				'oi_archive_name = ' . $dbw->strreplace( 'oi_archive_name', $dbw->addQuotes( $this->oldName ), $dbw->addQuotes( $this->newName ) ),
 			),
-			array( 'oi_name' => $this->oldName ),
+			array(
+				'oi_name' => $this->oldName,
+				'oi_archive_name <> ""', // Wikia change - @author macbre (PLATFORM-238)
+			),
 			__METHOD__
 		);
 
-		$affected = $dbw->affectedRows();
-		$total = $this->oldCount;
+		$affected = $dbw->affectedRows() + $rowsWithEmptyArchiveName; // Wikia change - @author macbre (PLATFORM-238)
+		$total = $this->oldCount + $rowsWithEmptyArchiveName; // Wikia change - @author macbre (PLATFORM-238)
 		$status->successCount += $affected;
 		$status->failCount += $total - $affected;
 		if ( $status->failCount ) {


### PR DESCRIPTION
This change will simply ignore `oldimage` rows with empty `oi_archive_name` value and allow affected files to be moved.

https://wikia-inc.atlassian.net/browse/PLATFORM-238

@Wikia/platform-team 
