### PR TITLE
WikiFactory: do not cache axWFactoryGetVariable responses

### DIFF
--- a/extensions/wikia/WikiFactory/SpecialWikiFactory_ajax.php
+++ b/extensions/wikia/WikiFactory/SpecialWikiFactory_ajax.php
@@ -112,10 +112,14 @@ function axWFactoryGetVariable() {
 		'wikiFactoryUrl' => Title::makeTitle( NS_SPECIAL, 'WikiFactory' )->getFullUrl()
 	));
 
-	return json_encode( array(
+	$response = new AjaxResponse(json_encode( array(
 		"div-body" => $oTmpl->render( "variable" ),
 		"div-name" => "wk-variable-form"
-	));
+	)));
+
+	$response->setCacheDuration(0);
+	$response->setContentType('application/json; charset=utf-8');
+	return $response;
 }
 
 /**


### PR DESCRIPTION
`axWFactoryGetVariable` responses were using the default `action=ajax` requests caching policy. Make these requests not cacheable and always get the latest variable value.

```
< Cache-Control: no-cache, must-revalidate
```

is currently returned.

@Wikia/platform-team / @prein / @michalroszka 
