### PR TITLE
Consolidate on one error handler

### DIFF
--- a/extensions/AbuseFilter/AbuseFilter.parser.php
+++ b/extensions/AbuseFilter/AbuseFilter.parser.php
@@ -413,11 +413,11 @@ class AFPRegexErrorHandler {
 	}
 
 	function install() {
-		set_error_handler( array( $this, 'handleError' ) );
+		// no-op
 	}
 
 	function restore() {
-		restore_error_handler();
+		// no-op
 	}
 }
 

--- a/extensions/AbuseFilter/AbuseFilter.parser.php
+++ b/extensions/AbuseFilter/AbuseFilter.parser.php
@@ -216,15 +216,7 @@ class AFPData {
 			$pattern .= 'i';
 		}
 
-		$handler = new AFPRegexErrorHandler( $pattern, $pos );
-		try {
-			$handler->install();
-			$result = preg_match( $pattern, $str );
-			$handler->restore();
-		} catch ( Exception $e ) {
-			$handler->restore();
-			throw $e;
-		}
+		$result = preg_match( $pattern, $str );
 		return new AFPData( self::DBool, (bool)$result );
 	}
 
@@ -392,32 +384,6 @@ class AFPUserVisibleException extends AFPException {
 		$this->mExceptionID = $exception_id;
 		$this->mPosition = $position;
 		$this->mParams = $params;
-	}
-}
-
-class AFPRegexErrorHandler {
-	function __construct( $regex, $pos ) {
-		$this->regex = $regex;
-		$this->pos = $pos;
-	}
-
-	function handleError( $errno, $errstr, $errfile, $errline, $context ) {
-		if ( error_reporting() == 0 ) {
-			return true;
-		}
-		throw new AFPUserVisibleException(
-			'regexfailure',
-			$this->pos,
-			array( $errstr, $this->regex )
-		);
-	}
-
-	function install() {
-		// no-op
-	}
-
-	function restore() {
-		// no-op
 	}
 }
 
@@ -1508,15 +1474,7 @@ class AbuseFilterParser {
 
 			$matches = array();
 
-			$handler = new AFPRegexErrorHandler( $needle, $this->mCur->pos );
-			try {
-				$handler->install();
-				$count = preg_match_all( $needle, $haystack, $matches );
-				$handler->restore();
-			} catch ( Exception $e ) {
-				$handler->restore();
-				throw $e;
-			}
+			$count = preg_match_all( $needle, $haystack, $matches );
 		}
 
 		return new AFPData( AFPData::DInt, $count );

--- a/extensions/EmailPage/PHPMailer_v5.1/class.pop3.php
+++ b/extensions/EmailPage/PHPMailer_v5.1/class.pop3.php
@@ -200,13 +200,6 @@ class POP3 {
       return true;
     }
 
-    /*
-    On Windows this will raise a PHP Warning error if the hostname doesn't exist.
-    Rather than supress it with @fsockopen, let's capture it cleanly instead
-    */
-
-    set_error_handler(array(&$this, 'catchWarning'));
-
     //  Connect to the POP3 server
     $this->pop_conn = fsockopen($host,    //  POP3 Host
                   $port,    //  Port #
@@ -214,13 +207,7 @@ class POP3 {
                   $errstr,  //  Error Message
                   $tval);   //  Timeout (seconds)
 
-    //  Restore the error handler
-    restore_error_handler();
 
-    //  Does the Error Log now contain anything?
-    if ($this->error && $this->do_debug >= 1) {
-      $this->displayErrors();
-    }
 
     //  Did we connect?
     if ($this->pop_conn == false) {
@@ -384,22 +371,6 @@ class POP3 {
     }
 
     echo '</pre>';
-  }
-
-  /**
-   * Takes over from PHP for the socket warning handler
-   * @access private
-   * @param integer $errno
-   * @param string $errstr
-   * @param string $errfile
-   * @param integer $errline
-   */
-  private function catchWarning ($errno, $errstr, $errfile, $errline) {
-    $this->error[] = array(
-      'error' => "Connecting to the POP3 server raised a PHP warning: ",
-      'errno' => $errno,
-      'errstr' => $errstr
-    );
   }
 
   //  End of class

--- a/extensions/WebStore/404-handler.php
+++ b/extensions/WebStore/404-handler.php
@@ -254,18 +254,9 @@ EOT;
 		}
 	}
 
-	function setErrorHandler() {
-
-	}
-
-	function handleError( $errno, $errstr, $errfile, $errline ) {
-		$callback = $this->getErrorCleanupFunction();
-		$this->phpErrors[] = call_user_func( $callback, "$errstr in $errfile line $errline" );
-	}
 }
 
 $h = new WebStore404Handler;
-$h->setErrorHandler();
 $h->execute();
 
 

--- a/extensions/WebStore/404-handler.php
+++ b/extensions/WebStore/404-handler.php
@@ -188,7 +188,7 @@ $errors
 </body>
 </html>
 EOT;
-				restore_error_handler();
+
 				break;
 			}
 
@@ -255,7 +255,7 @@ EOT;
 	}
 
 	function setErrorHandler() {
-		set_error_handler( array( $this, 'handleError' ) );
+
 	}
 
 	function handleError( $errno, $errstr, $errfile, $errline ) {

--- a/extensions/WebStore/WebStoreCommon.php
+++ b/extensions/WebStore/WebStoreCommon.php
@@ -45,7 +45,6 @@ class WebStoreCommon {
 	}
 
 	function setErrorHandler() {
-		set_error_handler( array( $this, 'handleWarning' ), E_WARNING );
 		ini_set( 'html_errors', 0 );
 	}
 

--- a/extensions/WebStore/WebStoreCommon.php
+++ b/extensions/WebStore/WebStoreCommon.php
@@ -48,10 +48,6 @@ class WebStoreCommon {
 		ini_set( 'html_errors', 0 );
 	}
 
-	function handleWarning( $errno, $errstr, $errfile, $errline ) {
-		$this->errors[] = new WebStoreWarning( 'webstore_php_warning', $errstr );
-	}
-
 	function dtd() {
 		return <<<EOT
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">

--- a/extensions/wikia/CensusDataRetrieval/maintenance/listPagesInCensus.php
+++ b/extensions/wikia/CensusDataRetrieval/maintenance/listPagesInCensus.php
@@ -1,12 +1,4 @@
 <?php
-function my_error_handler( $errno, $errstr, $errfile = null, $errline = null, $errcontext = null ) {
-        printf( "Error: %d: %s\n", $errno, $errstr );
-}
-
-set_error_handler( 'my_error_handler', E_ALL | E_STRICT );
-error_reporting(E_ALL | E_STRICT );
-
-
 /**
  * Updates infoboxes of Pages with Census data enabled
  *
@@ -48,5 +40,5 @@ if( $res->numRows() > 0 ) {
 	echo "Total objects: ".$res->numRows()."\n";
 }
 
-				
+
 exit( 0 );

--- a/extensions/wikia/CensusDataRetrieval/maintenance/updateCensusPages.php
+++ b/extensions/wikia/CensusDataRetrieval/maintenance/updateCensusPages.php
@@ -1,12 +1,4 @@
 <?php
-function my_error_handler( $errno, $errstr, $errfile = null, $errline = null, $errcontext = null ) {
-        printf( "Error: %d: %s\n", $errno, $errstr );
-}
-
-set_error_handler( 'my_error_handler', E_ALL | E_STRICT );
-error_reporting(E_ALL | E_STRICT );
-
-
 /**
  * Updates infoboxes of Pages with Census data enabled
  *

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -209,7 +209,7 @@ class Hooks {
 			 * problem here.
 			 */
 			$retval = null;
-			set_error_handler( 'Hooks::hookErrorHandler' );
+
 			wfProfileOut(__METHOD__);
 			wfProfileIn( $func );
 			try {
@@ -219,7 +219,7 @@ class Hooks {
 			}
 			wfProfileOut( $func );
 			wfProfileIn(__METHOD__);
-			restore_error_handler();
+
 
 			/* String return is an error; false return means stop processing. */
 			if ( is_string( $retval ) ) {
@@ -261,17 +261,4 @@ class Hooks {
 		return true;
 	}
 
-	/**
-	 * This REALLY should be protected... but it's public for compatibility
-	 *
-	 * @param $errno Unused
-	 * @param $errstr String: error message
-	 * @return Boolean: false
-	 */
-	public static function hookErrorHandler( $errno, $errstr ) {
-		if ( strpos( $errstr, 'expected to be a reference, value given' ) !== false ) {
-			throw new MWHookException( $errstr );
-		}
-		return false;
-	}
 }

--- a/includes/UserMailer.php
+++ b/includes/UserMailer.php
@@ -344,7 +344,6 @@ class UserMailer {
 			self::$mErrorString = '';
 			$html_errors = ini_get( 'html_errors' );
 			ini_set( 'html_errors', '0' );
-			set_error_handler( 'UserMailer::errorHandler' );
 
 			$safeMode = wfIniGetBool( 'safe_mode' );
 			foreach ( $to as $recip ) {
@@ -360,7 +359,6 @@ class UserMailer {
 				}
 			}
 
-			restore_error_handler();
 			ini_set( 'html_errors', $html_errors );
 
 			if ( self::$mErrorString ) {
@@ -374,16 +372,6 @@ class UserMailer {
 				return Status::newGood();
 			}
 		}
-	}
-
-	/**
-	 * Set the mail error message in self::$mErrorString
-	 *
-	 * @param $code Integer: error number
-	 * @param $string String: error message
-	 */
-	static function errorHandler( $code, $string ) {
-		self::$mErrorString = preg_replace( '/^mail\(\)(\s*\[.*?\])?: /', '', $string );
 	}
 
 	/**

--- a/includes/wikia/GlobalFunctions.php
+++ b/includes/wikia/GlobalFunctions.php
@@ -1709,8 +1709,6 @@ function wfWikiaErrorHandler($errno, $errstr, $errfile, $errline) {
 	return false;
 }
 
-set_error_handler('wfWikiaErrorHandler');
-
 /**
  * get namespaces
  * @global $wgContLang


### PR DESCRIPTION
There were a lot of suspicious calls to set_error_handler and restore_error_handler. One of them was clobbering the `onWikiFactoryExecute` call to setup the `WikiaLogger::onError` handler.

This pull request attempts to clean up the calls to `[set|restore]_error_handler` for more consistent handling to ensure more events are passed through `WikiaLogger::onError`.

Related: see this [discussion](https://github.com/Wikia/app/commit/a1f0d54d91e8c476a434ceecb8d74664d3d48622#commitcomment-6492731).

/cc @Wikia/platform-team 
