### PR TITLE
AjaxResponse::setCacheDuration - pass zero to disable CDN caching

### DIFF
--- a/includes/AjaxResponse.php
+++ b/includes/AjaxResponse.php
@@ -100,7 +100,7 @@ class AjaxResponse {
 			header ( "Last-Modified: " . gmdate( "D, d M Y H:i:s" ) . " GMT" );
 		}
 
-		if ( $this->mCacheDuration ) {
+		if ( is_numeric( $this->mCacheDuration ) ) { # Wikia change - make setCacheDuration(0) calls work (author @macbre)
 			# If squid caches are configured, tell them to cache the response,
 			# and tell the client to always check with the squid. Otherwise,
 			# tell the client to use a cached copy, without a way to purge it.


### PR DESCRIPTION
Before this change calls to `AjaxResponse::setCacheDuration` with value of zero passed did not work as expected - CDN caching was not disabled.

Emit the following HTTP response headers:

```
Cache-Control: s-maxage=0 must-revalidate, max-age=0
```

instead of

```
Expires: Mon, 26 Jul 1997 05:00:00 GMT
Cache-Control: no-cache, must-revalidate
Pragma: no-cache
```

@michalroszka / @prein / @adamkarminski / @Wikia/platform-team 
