### PR TITLE
Modal events changes

### DIFF
--- a/resources/wikia/ui_components/modal/js/modal.js
+++ b/resources/wikia/ui_components/modal/js/modal.js
@@ -178,8 +178,14 @@ define( 'wikia.ui.modal', [
 		/** ATTACHING EVENT HANDLERS TO MODAL */
 
 		// trigger custom buttons events based on button 'data-event' attribute
-		this.$element.on( 'click', 'button', $.proxy( function( event ) {
-			var modalEventName = $( event.target ).data( 'event' );
+		this.$element.on( 'click', 'button, a.modalEvent', $.proxy( function( event ) {
+			var $target = $( event.target),
+				modalEventName = $target.data( 'event' );
+
+			if ($target.is('a')) {
+				event.preventDefault();
+			}
+
 			if ( modalEventName ) {
 				this.trigger( modalEventName, event );
 			}

--- a/resources/wikia/ui_components/modal/js/modal.js
+++ b/resources/wikia/ui_components/modal/js/modal.js
@@ -283,6 +283,7 @@ define( 'wikia.ui.modal', [
 		( function iterate( param ) {
 			var result;
 
+			// if listener returns some value then push it to array of arguments that are passed to the next listener
 			if ( typeof param !== 'undefined' ) {
 				args.push( param );
 			}

--- a/resources/wikia/ui_components/modal/js/modal.js
+++ b/resources/wikia/ui_components/modal/js/modal.js
@@ -179,7 +179,7 @@ define( 'wikia.ui.modal', [
 
 		// trigger custom buttons events based on button 'data-event' attribute
 		this.$element.on( 'click', 'button, a.modalEvent', $.proxy( function( event ) {
-			var $target = $( event.target),
+			var $target = $( event.target ),
 				modalEventName = $target.data( 'event' );
 
 			if ($target.is('a')) {
@@ -280,8 +280,13 @@ define( 'wikia.ui.modal', [
 		// in future we may consider ignoring an event if the previous trigger call with the same
 		// eventName did not compete
 
-		( function iterate() {
+		( function iterate( param ) {
 			var result;
+
+			if ( typeof param !== 'undefined' ) {
+				args.push( param );
+			}
+
 			while( listeners && ( i < listeners.length ) ) {
 				result = listeners[ i++ ].apply( undefined, args );
 				if ( result && ( typeof result.then === 'function' ) ) {


### PR DESCRIPTION
Add support for special links in modal content to trigger modal events.
If event listener is a promise then add its result to arguments that are passed to consecutive listeners.
