### PR TITLE
MOB-1704

### DIFF
--- a/includes/HttpFunctions.php
+++ b/includes/HttpFunctions.php
@@ -33,7 +33,7 @@ class Http {
 	 *                          MediaWiki/$wgVersion
 	 *    - headers             Additional headers for request
 	 *    - returnInstance      If set the method will return MWHttpRequest instance instead of string|boolean
-	 * @return Mixed: (bool)false on failure or a string on success
+	 * @return Mixed: (bool)false on failure or a string on success or MWHttpRequest instance if returnInstance option is set
 	 */
 	public static function request( $method, $url, $options = array() ) {
 		$fname = __METHOD__ . '::' . $method;
@@ -90,7 +90,7 @@ class Http {
 		// Introduced new returnInstance options to return MWHttpRequest instance instead of string-bool mix
 		if( !empty( $options['returnInstance'] ) ) {
 			$ret = $req;
-		} else if( $isOk && empty( $options['returnInstance'] ) ) {
+		} else if( $isOk ) {
 			$ret = $req->getContent();
 			// Wikia change - end
 		} else {

--- a/includes/HttpFunctions.php
+++ b/includes/HttpFunctions.php
@@ -32,6 +32,7 @@ class Http {
 	 *    - userAgent           A user agent, if you want to override the default
 	 *                          MediaWiki/$wgVersion
 	 *    - headers             Additional headers for request
+	 *    - returnInstance      If set the method will return MWHttpRequest instance instead of string|boolean
 	 * @return Mixed: (bool)false on failure or a string on success
 	 */
 	public static function request( $method, $url, $options = array() ) {
@@ -85,9 +86,13 @@ class Http {
 
 		}
 
-		if ( $isOk ) {
-		// Wikia change - end
+		// Wikia change - @author: nAndy - begin
+		// Introduced new returnInstance options to return MWHttpRequest instance instead of string-bool mix
+		if( !empty( $options['returnInstance'] ) ) {
+			$ret = $req;
+		} else if( $isOk && empty( $options['returnInstance'] ) ) {
 			$ret = $req->getContent();
+			// Wikia change - end
 		} else {
 			$ret = false;
 		}

--- a/tests/unit/HttpTest.php
+++ b/tests/unit/HttpTest.php
@@ -1,0 +1,57 @@
+<?php
+
+class HttpTest extends WikiaBaseTest {
+
+	const HTTP_CONTENT = 'HTTP Success Response';
+
+	/**
+	 * Tests request without any additional options with successful response
+	 */
+	public function testRequest_success() {
+		$requestMock = $this->getMock( 'PhpHttpRequest', [ 'execute', 'getContent' ] );
+		$requestMock->expects( $this->once() )
+			->method( 'execute' )
+			->will( $this->returnValue( $this->getStatusMock( self::HTTP_CONTENT ) ) );
+		$requestMock->expects( $this->once() )
+			->method( 'getContent' )
+			->will( $this->returnValue( 'HTTP Success Response' ) );
+
+		$this->mockMWHttpRequestFactory( $requestMock );
+
+		$this->assertEquals( 'HTTP Success Response', Http::request( 'GET', 'http://wikia.com' ) );
+	}
+
+	/**
+	 * Tests request without any additional options with error in response
+	 */
+	public function testRequest_error() {
+		$requestMock = $this->getMock( 'PhpHttpRequest', [ 'execute' ] );
+
+		$requestMock->expects( $this->once() )
+			->method( 'execute' )
+			->will( $this->returnValue( $this->getStatusMock( self::HTTP_CONTENT ) ) );
+
+		$this->mockMWHttpRequestFactory( $requestMock );
+
+		$this->assertEquals( false, Http::request( 'GET', 'http://wikia.com' ) );
+	}
+
+	private function getStatusMock( $returnValue ) {
+		$statusMock = $this->getMock( 'Status', [ 'isOK' ] );
+		$statusMock->expects( $this->once() )
+			->method( 'isOK' )
+			->will( $this->returnValue( $returnValue ) );
+
+		return $statusMock;
+	}
+
+	private function mockMWHttpRequestFactory( $requestMock ) {
+		$this->getStaticMethodMock(
+			'MWHttpRequest',
+			'factory'
+		)->expects( $this->once() )
+			->method( 'factory' )
+			->will( $this->returnValue( $requestMock ) );
+	}
+
+}

--- a/tests/unit/HttpTest.php
+++ b/tests/unit/HttpTest.php
@@ -3,6 +3,7 @@
 class HttpTest extends WikiaBaseTest {
 
 	const HTTP_CONTENT = 'HTTP Success Response';
+	const EXAMPLE_URL = 'http://www.wikia.com';
 
 	/**
 	 * Tests request without any additional options with successful response
@@ -18,7 +19,7 @@ class HttpTest extends WikiaBaseTest {
 
 		$this->mockMWHttpRequestFactory( $requestMock );
 
-		$this->assertEquals( 'HTTP Success Response', Http::request( 'GET', 'http://wikia.com' ) );
+		$this->assertEquals( 'HTTP Success Response', Http::request( 'GET', self::EXAMPLE_URL ) );
 	}
 
 	/**
@@ -33,7 +34,25 @@ class HttpTest extends WikiaBaseTest {
 
 		$this->mockMWHttpRequestFactory( $requestMock );
 
-		$this->assertEquals( false, Http::request( 'GET', 'http://wikia.com' ) );
+		$this->assertEquals( false, Http::request( 'GET', self::EXAMPLE_URL ) );
+	}
+
+	public function testRequest_return_response_instance() {
+		$requestMock = $this->getMock( 'PhpHttpRequest', [ 'execute' ] );
+
+		$requestMock->expects( $this->once() )
+			->method( 'execute' )
+			->will( $this->returnValue( $this->getStatusMock( self::HTTP_CONTENT ) ) );
+
+		$this->mockMWHttpRequestFactory( $requestMock );
+
+		$this->assertInstanceOf( 'MWHttpRequest', Http::request(
+			'GET',
+			self::EXAMPLE_URL,
+			[
+				'returnInstance' => true
+			]
+		) );
 	}
 
 	private function getStatusMock( $returnValue ) {

--- a/tests/unit/HttpTest.php
+++ b/tests/unit/HttpTest.php
@@ -19,7 +19,7 @@ class HttpTest extends WikiaBaseTest {
 
 		$this->mockMWHttpRequestFactory( $requestMock );
 
-		$this->assertEquals( 'HTTP Success Response', Http::request( 'GET', self::EXAMPLE_URL ) );
+		$this->assertEquals( self::HTTP_CONTENT, Http::request( 'GET', self::EXAMPLE_URL ) );
 	}
 
 	/**

--- a/tests/unit/HttpTest.php
+++ b/tests/unit/HttpTest.php
@@ -9,7 +9,14 @@ class HttpTest extends WikiaBaseTest {
 	 * Tests request without any additional options with successful response
 	 */
 	public function testRequest_success() {
-		$requestMock = $this->getMock( 'PhpHttpRequest', [ 'execute', 'getContent' ] );
+		$requestMock = $this->getMock(
+			'PhpHttpRequest',
+			[ 'execute', 'getContent' ],
+			[],
+			'',
+			false
+		);
+
 		$requestMock->expects( $this->once() )
 			->method( 'execute' )
 			->will( $this->returnValue( $this->getStatusMock( self::HTTP_CONTENT ) ) );
@@ -26,7 +33,13 @@ class HttpTest extends WikiaBaseTest {
 	 * Tests request without any additional options with error in response
 	 */
 	public function testRequest_error() {
-		$requestMock = $this->getMock( 'PhpHttpRequest', [ 'execute' ] );
+		$requestMock = $this->getMock(
+			'PhpHttpRequest',
+			[ 'execute', 'getContent' ],
+			[],
+			'',
+			false
+		);
 
 		$requestMock->expects( $this->once() )
 			->method( 'execute' )
@@ -38,7 +51,13 @@ class HttpTest extends WikiaBaseTest {
 	}
 
 	public function testRequest_return_response_instance() {
-		$requestMock = $this->getMock( 'PhpHttpRequest', [ 'execute' ] );
+		$requestMock = $this->getMock(
+			'PhpHttpRequest',
+			[ 'execute', 'getContent' ],
+			[],
+			'',
+			false
+		);
 
 		$requestMock->expects( $this->once() )
 			->method( 'execute' )
@@ -69,8 +88,8 @@ class HttpTest extends WikiaBaseTest {
 			'MWHttpRequest',
 			'factory'
 		)->expects( $this->once() )
-			->method( 'factory' )
-			->will( $this->returnValue( $requestMock ) );
+		->method( 'factory' )
+		->will( $this->returnValue( $requestMock ) );
 	}
 
 }


### PR DESCRIPTION
Added new option to MediaWiki `Http` class to return `MWHttpRequest` instance. It's necessary to receive HTTP errors from different HTTP APIs.

@federico-lox @SebastianMarzjan take a look, please. Once it's OK we can merge it to dev and re-use in Interactive Maps project and Data/API can use it in their projects ;)
