### PR TITLE
Avoid reflection when determining the default controller template engine

### DIFF
--- a/includes/wikia/nirvana/WikiaDispatcher.class.php
+++ b/includes/wikia/nirvana/WikiaDispatcher.class.php
@@ -127,13 +127,7 @@ class WikiaDispatcher {
 				wfProfileIn($profilename);
 
 				$controller = new $controllerClassName; /* @var $controller WikiaController */
-				$controllerReflection = new ReflectionClass($controllerClassName);
-
-				if ($controllerReflection->hasConstant('DEFAULT_TEMPLATE_ENGINE')) {
-					$response->setTemplateEngine($controller::DEFAULT_TEMPLATE_ENGINE);
-				} else {
-					$response->setTemplateEngine(WikiaController::DEFAULT_TEMPLATE_ENGINE);
-				}
+				$response->setTemplateEngine($controllerClassName::DEFAULT_TEMPLATE_ENGINE);
 
 				if ( $callNext ) {
 					list ($nextController, $nextMethod, $resetData) = explode("::", $callNext);


### PR DESCRIPTION
@lizlux @owend (Not exactly sure why this didn't work the first time for me, but I suspect an ID10T or PEBKAC error)
