### PR TITLE
MOB-1704

### DIFF
--- a/extensions/wikia/WikiaInteractiveMaps/WikiaInteractiveMaps.i18n.php
+++ b/extensions/wikia/WikiaInteractiveMaps/WikiaInteractiveMaps.i18n.php
@@ -27,7 +27,7 @@ $messages[ 'en' ] = [
 	'wikia-interactive-maps-parser-tag-error-no-map-found' => 'Wikia Interactive Maps error occurred: Map not found.',
 
 	'wikia-interactive-maps-map-placeholder-error' => 'Unexpected error has occurred. Please contact us if it happens again.',
-	'wikia-interactive-maps-api-error-message' => 'Unexpected error has occurred.',
+	'wikia-interactive-maps-service-error' => 'Oops, we have issues with our maps service. If it repeats [[Special:Contact|contact us]], please.',
 
 	'wikia-interactive-maps-map-status-done' => 'Ready to use',
 	'wikia-interactive-maps-map-status-processing' => 'Processing...',
@@ -47,7 +47,6 @@ $messages[ 'en' ] = [
 	'wikia-interactive-maps-create-map-title-placeholder' => 'Title',
 
 	'wikia-interactive-maps-create-map-bad-request-error' => 'Neither of required parameters was provided',
-	'wikia-interactive-maps-create-map-service-error' => 'Oops, we have issues with our maps service. If it repeats [[Special:Contact|contact us]], please.',
 
 	'wikia-interactive-maps-image-uploads-disabled' => 'File uploads are currently disabled on your wiki. Please try again later.',
 	'wikia-interactive-maps-image-uploads-error' => 'There was an error while uploading the image. If it repeats [[Special:Contact|contact us]], please.',
@@ -78,7 +77,6 @@ $messages[ 'qqq' ] = [
 	'wikia-interactive-maps-parser-tag-error-no-map-found' => 'Interactive maps error when map of given id doesn\'t exist',
 
 	'wikia-interactive-maps-map-placeholder-error' => 'Interactive maps unexpected error which could happen during some rare situations such as file system dead',
-	'wikia-interactive-maps-api-error-message' => 'Backend connection error.',
 
 	'wikia-interactive-maps-sort-newest-to-oldest' => 'Ordering option shown in drop-down menu above map lists; when chosen orders map list from newest map to oldest',
 	'wikia-interactive-maps-sort-alphabetical' => 'Ordering option shown in drop-down menu above map lists; when chosen orders map list in alphabetical order',

--- a/extensions/wikia/WikiaInteractiveMaps/WikiaInteractiveMaps.i18n.php
+++ b/extensions/wikia/WikiaInteractiveMaps/WikiaInteractiveMaps.i18n.php
@@ -7,30 +7,30 @@ $messages[ 'en' ] = [
 	'wikia-interactive-maps-create-a-map' => 'Create a Map',
 	'wikia-interactive-maps-no-maps' => 'No maps found. Create new map now.',
 
+	'wikia-interactive-maps-map-status-done' => 'Ready to use',
+	'wikia-interactive-maps-map-status-processing' => 'Processing...',
+
 	'wikia-interactive-maps-parser-tag-error-no-require-parameters' => 'Wikia Interactive Maps error occurred: no parameters passed to the tag. The only required parameter is map-id parameter. Make sure it\'s set, please.',
 	'wikia-interactive-maps-parser-tag-error-invalid-map-id' => 'Wikia Interactive Maps error occurred: invalid map id. Please make sure your map-id parameter is an integer number.',
+	'wikia-interactive-maps-parser-tag-error-invalid-longitude' => 'Wikia Interactive Maps error occurred: invalid lon. Please make sure your longitude parameter is a number or remove it to set it to default value.',
 	'wikia-interactive-maps-parser-tag-error-invalid-latitude' => 'Wikia Interactive Maps error occurred: invalid lat. Please make sure your latitude parameter is a number or remove it to set it to default value.',
+	'wikia-interactive-maps-parser-tag-error-invalid-zoom' => 'Wikia Interactive Maps error occurred: invalid zoom. Please make sure your zoom parameter is an integer number or remove it to set it to default value.',
+	'wikia-interactive-maps-parser-tag-error-invalid-width' => 'Wikia Interactive Maps error occurred: invalid width. Please make sure your width parameter is an integer number or remove it to set it to default value.',
+	'wikia-interactive-maps-parser-tag-error-invalid-height' => 'Wikia Interactive Maps error occurred: invalid height. Please make sure your height parameter is an integer number or remove it to set it to default value.',
 	'wikia-interactive-maps-parser-tag-error-min-latitude' => 'Wikia Interactive Maps error occurred: invalid lat. Please make sure your latitude is higher then $min.',
 	'wikia-interactive-maps-parser-tag-error-max-latitude' => 'Wikia Interactive Maps error occurred: invalid lat. Please make sure your latitude is lower then $max.',
-	'wikia-interactive-maps-parser-tag-error-invalid-longitude' => 'Wikia Interactive Maps error occurred: invalid lon. Please make sure your longitude parameter is a number or remove it to set it to default value.',
 	'wikia-interactive-maps-parser-tag-error-min-longitude' => 'Wikia Interactive Maps error occurred: invalid lon. Please make sure your longitude is higher then $min.',
 	'wikia-interactive-maps-parser-tag-error-max-longitude' => 'Wikia Interactive Maps error occurred: invalid lon. Please make sure your longitude is lower then $max.',
-	'wikia-interactive-maps-parser-tag-error-invalid-zoom' => 'Wikia Interactive Maps error occurred: invalid zoom. Please make sure your zoom parameter is an integer number or remove it to set it to default value.',
 	'wikia-interactive-maps-parser-tag-error-min-zoom' => 'Wikia Interactive Maps error occurred: invalid zoom. Please make sure your zoom parameter is set to $min or higher.',
 	'wikia-interactive-maps-parser-tag-error-max-zoom' => 'Wikia Interactive Maps error occurred: invalid zoom. Please make sure your zoom parameter is to $max or lower.',
-	'wikia-interactive-maps-parser-tag-error-invalid-width' => 'Wikia Interactive Maps error occurred: invalid width. Please make sure your width parameter is an integer number or remove it to set it to default value.',
 	'wikia-interactive-maps-parser-tag-error-min-width' => 'Wikia Interactive Maps error occurred: invalid width. Minimum supported with is $min.',
 	'wikia-interactive-maps-parser-tag-error-max-width' => 'Wikia Interactive Maps error occurred: invalid width. Maximum supported with is $max.',
-	'wikia-interactive-maps-parser-tag-error-invalid-height' => 'Wikia Interactive Maps error occurred: invalid height. Please make sure your height parameter is an integer number or remove it to set it to default value.',
 	'wikia-interactive-maps-parser-tag-error-min-height' => 'Wikia Interactive Maps error occurred: invalid height. Minimum supported height is $min.',
 	'wikia-interactive-maps-parser-tag-error-max-height' => 'Wikia Interactive Maps error occurred: invalid height. Maximum supported height is $max.',
 	'wikia-interactive-maps-parser-tag-error-no-map-found' => 'Wikia Interactive Maps error occurred: Map not found.',
 
 	'wikia-interactive-maps-map-placeholder-error' => 'Unexpected error has occurred. Please contact us if it happens again.',
 	'wikia-interactive-maps-service-error' => 'Oops, we have issues with our maps service. If it repeats [[Special:Contact|contact us]], please.',
-
-	'wikia-interactive-maps-map-status-done' => 'Ready to use',
-	'wikia-interactive-maps-map-status-processing' => 'Processing...',
 
 	'wikia-interactive-maps-sort-newest-to-oldest' => 'Newest to Oldest',
 	'wikia-interactive-maps-sort-alphabetical' => 'Alphabetical',
@@ -41,7 +41,6 @@ $messages[ 'en' ] = [
 	'wikia-interactive-maps-create-map-header' => 'Create a Map',
 	'wikia-interactive-maps-create-map-next-btn' => 'Next',
 	'wikia-interactive-maps-create-map-back-btn' => 'Back',
-
 	'wikia-interactive-maps-create-map-choose-type-geo' => 'Real Map',
 	'wikia-interactive-maps-create-map-choose-type-custom' => 'Custom Map',
 	'wikia-interactive-maps-create-map-title-placeholder' => 'Title',
@@ -63,20 +62,30 @@ $messages[ 'qqq' ] = [
 	'wikia-interactive-maps-create-a-map' => 'Label for create new map button',
 	'wikia-interactive-maps-no-maps' => 'Shown when there are no maps created for this wiki',
 
+	'wikia-interactive-maps-map-status-done' => 'Message which informs about map tiles processing status; not visible for a user',
+	'wikia-interactive-maps-map-status-processing' => 'Message which informs about map tiles processing status; not visible for a user',
+
 	'wikia-interactive-maps-parser-tag-error-no-require-parameters' => 'Interactive maps error after try of parsing wikitext tag; one of the required parameters is not set',
 	'wikia-interactive-maps-parser-tag-error-invalid-map-id' => 'Interactive maps error after try of parsing wikitext tag; the map-id is not passed or is not a valid number',
 	'wikia-interactive-maps-parser-tag-error-invalid-latitude' => 'Interactive maps error after try of parsing wikitext tag; an invalid latitude value has been passed',
 	'wikia-interactive-maps-parser-tag-error-invalid-longitude' => 'Interactive maps error after try of parsing wikitext tag; an invalid longitude has been passed',
 	'wikia-interactive-maps-parser-tag-error-invalid-zoom' => 'Interactive maps error after try of parsing wikitext tag; an invalid zoom has been passed',
 	'wikia-interactive-maps-parser-tag-error-invalid-width' => 'Interactive maps error after try of parsing wikitext tag; an invalid width has been passed',
+	'wikia-interactive-maps-parser-tag-error-invalid-height' => 'Interactive maps error after try of parsing wikitext tag; an invalid height has been passed',
+	'wikia-interactive-maps-parser-tag-error-min-latitude' => 'Interactive maps error after try of parsing wikitext tag; an invalid latitude has been passed',
+	'wikia-interactive-maps-parser-tag-error-max-latitude' => 'Interactive maps error after try of parsing wikitext tag; an invalid latitude has been passed',
+	'wikia-interactive-maps-parser-tag-error-min-longitude' => 'Interactive maps error after try of parsing wikitext tag; an invalid longitude has been passed',
+	'wikia-interactive-maps-parser-tag-error-max-longitude' => 'Interactive maps error after try of parsing wikitext tag; an invalid longitude has been passed',
+	'wikia-interactive-maps-parser-tag-error-min-zoom' => 'Interactive maps error after try of parsing wikitext tag; an invalid zoom level has been passed',
+	'wikia-interactive-maps-parser-tag-error-max-zoom' => 'Interactive maps error after try of parsing wikitext tag; an invalid zoom level has been passed',
 	'wikia-interactive-maps-parser-tag-error-min-width' => 'Interactive maps error after try of parsing wikitext tag; value below minimum width has been passed',
 	'wikia-interactive-maps-parser-tag-error-max-width' => 'Interactive maps error after try of parsing wikitext tag; value above maximum width has been passed',
-	'wikia-interactive-maps-parser-tag-error-invalid-height' => 'Interactive maps error after try of parsing wikitext tag; an invalid height has been passed',
 	'wikia-interactive-maps-parser-tag-error-min-height' => 'Interactive maps error after try of parsing wikitext tag; value below minimum height has been passed',
 	'wikia-interactive-maps-parser-tag-error-max-height' => 'Interactive maps error after try of parsing wikitext tag; value above maximum height has been passed',
 	'wikia-interactive-maps-parser-tag-error-no-map-found' => 'Interactive maps error when map of given id doesn\'t exist',
 
 	'wikia-interactive-maps-map-placeholder-error' => 'Interactive maps unexpected error which could happen during some rare situations such as file system dead',
+	'wikia-interactive-maps-service-error' => 'An error message which appears in the creation map modal when our map service fails to create a map',
 
 	'wikia-interactive-maps-sort-newest-to-oldest' => 'Ordering option shown in drop-down menu above map lists; when chosen orders map list from newest map to oldest',
 	'wikia-interactive-maps-sort-alphabetical' => 'Ordering option shown in drop-down menu above map lists; when chosen orders map list in alphabetical order',
@@ -92,7 +101,6 @@ $messages[ 'qqq' ] = [
 	'wikia-interactive-maps-create-map-title-placeholder' => 'Input placeholder for map title',
 
 	'wikia-interactive-maps-create-map-bad-request-error' => 'An API error message not visible for the user',
-	'wikia-interactive-maps-create-map-service-error' => 'An error message which appears in the creation map modal when our map service fails to create a map',
 
 	'wikia-interactive-maps-image-uploads-disabled' => 'An error displayed to a user when files upload is disabled on a wikia',
 	'wikia-interactive-maps-image-uploads-error' => 'An error displayed to a user when a file upload fails because of backend errors',
@@ -103,4 +111,3 @@ $messages[ 'qqq' ] = [
 
 	'wikia-interactive-maps-create-map-error-invalid-map-title' => 'An error message displayed above map title form field when the map title is invalid.',
 ];
-

--- a/extensions/wikia/WikiaInteractiveMaps/WikiaInteractiveMapsController.class.php
+++ b/extensions/wikia/WikiaInteractiveMaps/WikiaInteractiveMapsController.class.php
@@ -337,7 +337,7 @@ class WikiaInteractiveMapsController extends WikiaSpecialPageController {
 		] );
 
 		if( !$response ) {
-			$results['error'] = wfMessage( 'wikia-interactive-maps-create-map-service-error' )->parse();
+			$results['error'] = wfMessage( 'wikia-interactive-maps-service-error' )->parse();
 		} else {
 			$result = json_decode( $response );
 			$results['success'] = true;
@@ -364,7 +364,7 @@ class WikiaInteractiveMapsController extends WikiaSpecialPageController {
 		] );
 
 		if( !$response ) {
-			$results['error'] = wfMessage( 'wikia-interactive-maps-create-map-service-error' )->parse();
+			$results['error'] = wfMessage( 'wikia-interactive-maps-service-error' )->parse();
 		} else {
 			$response = json_decode( $response );
 			$mapId = $response->id;
@@ -421,7 +421,7 @@ class WikiaInteractiveMapsController extends WikiaSpecialPageController {
 	 */
 	public function error() {
 		$this->setVal( 'messages', [
-			'wikia-interactive-maps-api-error-message' => wfMessage( 'wikia-interactive-maps-api-error-message' )
+			'wikia-interactive-maps-api-error-message' => wfMessage( 'wikia-interactive-maps-service-error' )->parse()
 		] );
 		$this->response->setTemplateEngine( WikiaResponse::TEMPLATE_ENGINE_MUSTACHE );
 	}

--- a/extensions/wikia/WikiaInteractiveMaps/WikiaInteractiveMapsController.class.php
+++ b/extensions/wikia/WikiaInteractiveMaps/WikiaInteractiveMapsController.class.php
@@ -276,7 +276,7 @@ class WikiaInteractiveMapsController extends WikiaSpecialPageController {
 			$results = $this->createTileset();
 
 			if( true === $results['success'] ) {
-				$this->setCreationData( 'tileSetId', $results['id'] );
+				$this->setCreationData( 'tileSetId', $results['content']->id );
 				$results = $this->createMapFromTilesetId();
 			}
 		}
@@ -336,15 +336,12 @@ class WikiaInteractiveMapsController extends WikiaSpecialPageController {
 			'created_by' => $this->getCreationData( 'creatorName' ),
 		] );
 
-		if( !$response ) {
-			$results['error'] = wfMessage( 'wikia-interactive-maps-service-error' )->parse();
-		} else {
-			$result = json_decode( $response );
-			$results['success'] = true;
-			$results['id'] = $result->id;
+		if( !$response['success'] && is_null( $response['content'] ) ) {
+			$response['content'] = new stdClass();
+			$response['content']->message = wfMessage( 'wikia-interactive-maps-service-error' )->parse();
 		}
 
-		return $results;
+		return $response;
 	}
 
 	/**
@@ -361,8 +358,9 @@ class WikiaInteractiveMapsController extends WikiaSpecialPageController {
 			'created_by' => $this->getCreationData( 'creatorName' ),
 		] );
 
-		if( !$response['success'] ) {
-			$response['message'] = wfMessage( 'wikia-interactive-maps-service-error' )->parse();
+		if( !$response['success'] && is_null( $response['content'] ) ) {
+			$response['content'] = new stdClass();
+			$response['content']->message = wfMessage( 'wikia-interactive-maps-service-error' )->parse();
 		} else {
 			$response['content']->mapUrl = Title::newFromText(
 				self::PAGE_NAME . '/' . $response['content']->id,

--- a/extensions/wikia/WikiaInteractiveMaps/WikiaInteractiveMapsController.class.php
+++ b/extensions/wikia/WikiaInteractiveMaps/WikiaInteractiveMapsController.class.php
@@ -354,8 +354,6 @@ class WikiaInteractiveMapsController extends WikiaSpecialPageController {
 	 * @return Array
 	 */
 	private function createMapFromTilesetId() {
-		$results['success'] = false;
-
 		$response = $this->mapsModel->saveMap( [
 			'title' => $this->getCreationData( 'title' ),
 			'tile_set_id' => $this->getCreationData( 'tileSetId' ),
@@ -363,19 +361,16 @@ class WikiaInteractiveMapsController extends WikiaSpecialPageController {
 			'created_by' => $this->getCreationData( 'creatorName' ),
 		] );
 
-		if( !$response ) {
-			$results['error'] = wfMessage( 'wikia-interactive-maps-service-error' )->parse();
+		if( !$response['success'] ) {
+			$response['message'] = wfMessage( 'wikia-interactive-maps-service-error' )->parse();
 		} else {
-			$response = json_decode( $response );
-			$mapId = $response->id;
-
-			$results['success'] = true;
-			$results['mapId'] = $mapId;
-			$results['mapUrl'] = Title::newFromText( self::PAGE_NAME . '/' . $mapId, NS_SPECIAL )->getFullUrl();
-			$results['message'] = $response->message;
+			$response['content']->mapUrl = Title::newFromText(
+				self::PAGE_NAME . '/' . $response['content']->id,
+				NS_SPECIAL
+			)->getFullUrl();
 		}
 
-		return $results;
+		return $response;
 	}
 
 	/**

--- a/extensions/wikia/WikiaInteractiveMaps/WikiaInteractiveMapsController.class.php
+++ b/extensions/wikia/WikiaInteractiveMaps/WikiaInteractiveMapsController.class.php
@@ -414,7 +414,7 @@ class WikiaInteractiveMapsController extends WikiaSpecialPageController {
 	 */
 	public function error() {
 		$this->setVal( 'messages', [
-			'wikia-interactive-maps-api-error-message' => wfMessage( 'wikia-interactive-maps-service-error' )->parse()
+			'wikia-interactive-maps-service-error' => wfMessage( 'wikia-interactive-maps-service-error' )->parse()
 		] );
 		$this->response->setTemplateEngine( WikiaResponse::TEMPLATE_ENGINE_MUSTACHE );
 	}

--- a/extensions/wikia/WikiaInteractiveMaps/WikiaInteractiveMapsController.class.php
+++ b/extensions/wikia/WikiaInteractiveMaps/WikiaInteractiveMapsController.class.php
@@ -449,8 +449,8 @@ class WikiaInteractiveMapsController extends WikiaSpecialPageController {
 
 		$this->setVal( 'results', $this->getPinTypesCreationResults(
 			count( $this->getCreationData( 'pinTypeNames' ) ),
-			$createdPinTypes )
-		);
+			$createdPinTypes
+		) );
 	}
 
 	/**
@@ -494,15 +494,13 @@ class WikiaInteractiveMapsController extends WikiaSpecialPageController {
 
 		$createdPinTypes = 0;
 		foreach( $pinTypesNames as $name ) {
-			$response = json_decode(
-				$this->mapsModel->savePinType( [
-					'map_id' => $mapId,
-					'name' => $name,
-					'created_by' => $this->getCreationData( 'createdBy' ),
-				] )
-			);
+			$response = $this->mapsModel->savePinType( [
+				'map_id' => $mapId,
+				'name' => $name,
+				'created_by' => $this->getCreationData( 'createdBy' ),
+			] );
 
-			if( isset( $response->id ) ) {
+			if( $response['success'] === true ) {
 				$createdPinTypes++;
 			}
 		}
@@ -519,18 +517,19 @@ class WikiaInteractiveMapsController extends WikiaSpecialPageController {
 	 * @return Array
 	 */
 	private function getPinTypesCreationResults( $requestedCreations, $createdPinTypes ) {
-		$results['success'] = true;
+		$response['success'] = true;
 
 		if( $createdPinTypes !== $requestedCreations ) {
-			$results['success'] = false;
-			$results['error'] = wfMessage(
+			$response['success'] = false;
+			$response['content'] = new stdClass();
+			$response['message'] = wfMessage(
 				'wikia-interactive-maps-create-pin-types-error',
 				$createdPinTypes,
 				$requestedCreations
 			)->plain();
 		}
 
-		return $results;
+		return $response;
 	}
 
 	/**

--- a/extensions/wikia/WikiaInteractiveMaps/js/intMapCreateMapModal.js
+++ b/extensions/wikia/WikiaInteractiveMaps/js/intMapCreateMapModal.js
@@ -126,7 +126,7 @@ define(
 
 		//TODO: to be changed when pin types step will be added
 		function showCreatedMap(data) {
-			qs(data.mapUrl).goTo();
+			qs(data.content.mapUrl).goTo();
 		}
 
 		return {

--- a/extensions/wikia/WikiaInteractiveMaps/js/intMapCreateMapPinTypes.js
+++ b/extensions/wikia/WikiaInteractiveMaps/js/intMapCreateMapPinTypes.js
@@ -115,7 +115,7 @@ define('wikia.intMap.createMap.pinTypes',
 			// if no pin types display blank pin type input
 			var pinTypes = templateData.pinTypes ? templateData.pinTypes : [{}];
 
-			pinTypesTemplateData.mapId = templateData.mapId;
+			pinTypesTemplateData.mapId = templateData.id;
 			pinTypesTemplateData.pinTypes = extendPinTypesData(pinTypes);
 		}
 
@@ -210,7 +210,7 @@ define('wikia.intMap.createMap.pinTypes',
 
 					if (data && data.success) {
 						modal.trigger('cleanUpError');
-						modal.trigger('pinTypesCreated', data);
+						modal.trigger('pinTypesCreated', data.content);
 					} else {
 						modal.trigger('error', data.error);
 					}

--- a/extensions/wikia/WikiaInteractiveMaps/js/intMapCreateMapPreview.js
+++ b/extensions/wikia/WikiaInteractiveMaps/js/intMapCreateMapPreview.js
@@ -114,11 +114,11 @@ define(
 					if (data && data.success) {
 						modal.trigger('mapCreated', data);
 					} else {
-						modal.trigger('error', data.message);
+						modal.trigger('error', data.content.message);
 					}
 				},
 				onErrorCallback: function(response) {
-					modal.trigger('error', response.results.message);
+					modal.trigger('error', response.results.content.message);
 				}
 			});
 		}

--- a/extensions/wikia/WikiaInteractiveMaps/js/intMapCreateMapPreview.js
+++ b/extensions/wikia/WikiaInteractiveMaps/js/intMapCreateMapPreview.js
@@ -114,11 +114,11 @@ define(
 					if (data && data.success) {
 						modal.trigger('mapCreated', data);
 					} else {
-						modal.trigger('error', data.error);
+						modal.trigger('error', data.message);
 					}
 				},
 				onErrorCallback: function(response) {
-					modal.trigger('error', response.results.error);
+					modal.trigger('error', response.results.message);
 				}
 			});
 		}

--- a/extensions/wikia/WikiaInteractiveMaps/js/intMapCreateMapPreview.js
+++ b/extensions/wikia/WikiaInteractiveMaps/js/intMapCreateMapPreview.js
@@ -112,7 +112,7 @@ define(
 
 					if (data && data.success) {
 						modal.trigger('cleanUpError');
-						modal.trigger('mapCreated', data);
+						modal.trigger('mapCreated', data.content);
 					} else {
 						modal.trigger('error', data.content.message);
 					}

--- a/extensions/wikia/WikiaInteractiveMaps/models/WikiaMaps.class.php
+++ b/extensions/wikia/WikiaInteractiveMaps/models/WikiaMaps.class.php
@@ -85,6 +85,7 @@ class WikiaMaps {
 			'headers' => [
 				'Authorization' => $this->config['token']
 			],
+			'returnInstance' => true,
 			//TODO: this is temporary workaround, remove it before production!
 			'noProxy' => true
 		] );
@@ -100,10 +101,11 @@ class WikiaMaps {
 	private function getMapsFromApi( Array $params ) {
 		$mapsData = new stdClass();
 		$url = $this->buildUrl( [ self::ENTRY_POINT_MAP ], $params );
-		$response = Http::get( $url, 'default', array(
+		$response = Http::get( $url, 'default', [
+			'returnInstance' => true,
 			//TODO: this is temporary workaround, remove it before production!
 			'noProxy' => true
-		) );
+		] );
 
 		if ( $response !== false ) {
 			$mapsData = json_decode( $response );
@@ -140,17 +142,19 @@ class WikiaMaps {
 	private function getMapByIdFromApi( Array $params ) {
 		$mapId = array_shift( $params );
 		$url = $this->buildUrl( [ self::ENTRY_POINT_MAP, $mapId ], $params );
-		$response = Http::get( $url, 'default', array(
+		$response = Http::get( $url, 'default', [
+				'returnInstance' => true,
 			//TODO: this is temporary workaround, remove it before production!
 			'noProxy' => true
-		) );
+		] );
 
 		$map = json_decode( $response );
 		if( !empty( $map->tile_set_url ) ) {
-			$response = Http::get( $map->tile_set_url, 'default', array(
+			$response = Http::get( $map->tile_set_url, 'default', [
+				'returnInstance' => true,
 				//TODO: this is temporary workaround, remove it before production!
 				'noProxy' => true
-			) );
+			] );
 			$tilesData = json_decode( $response );
 
 			if( !is_null( $tilesData ) ) {

--- a/extensions/wikia/WikiaInteractiveMaps/models/WikiaMaps.class.php
+++ b/extensions/wikia/WikiaInteractiveMaps/models/WikiaMaps.class.php
@@ -105,14 +105,16 @@ class WikiaMaps {
 	private function getMapsFromApi( Array $params ) {
 		$mapsData = new stdClass();
 		$url = $this->buildUrl( [ self::ENTRY_POINT_MAP ], $params );
-		$response = Http::get( $url, 'default', [
-			'returnInstance' => true,
-			//TODO: this is temporary workaround, remove it before production!
-			'noProxy' => true
-		] );
+		$response = $this->processServiceResponse(
+			Http::get( $url, 'default', [
+				'returnInstance' => true,
+				//TODO: this is temporary workaround, remove it before production!
+				'noProxy' => true
+			] )
+		);
 
-		if ( $response !== false ) {
-			$mapsData = json_decode( $response );
+		if( !$response['success'] ) {
+			$mapsData = $response['content'];
 
 			// Add map size to maps and human status messages
 			array_walk( $mapsData->items, function( &$map ) {

--- a/extensions/wikia/WikiaInteractiveMaps/models/WikiaMaps.class.php
+++ b/extensions/wikia/WikiaInteractiveMaps/models/WikiaMaps.class.php
@@ -18,7 +18,7 @@ class WikiaMaps {
 	const MAP_TYPE_GEO = 'geo';
 
 	const HTTP_CREATED_CODE = 201;
-	const HTTP_SUCCESS_CODE = 200;
+	const HTTP_SUCCESS_OK = 200;
 
 	/**
 	 * @var array API connection config
@@ -299,10 +299,12 @@ class WikiaMaps {
 	 */
 	private function processServiceResponse( MWHttpRequest $response ) {
 		$results['success'] = false;
-		$results['content'] = json_decode( $response->getContent() );
 		$status = $response->getStatus();
+		$content = json_decode( $response->getContent() );
+		$results['content'] = $content;
 
-		if( in_array( $status, [ self::HTTP_CREATED_CODE, self::HTTP_SUCCESS_CODE ] ) ) {
+		// MW Http::request() can return 200 HTTP code if service is offline, that's why we check content here
+		if( in_array( $status, [ self::HTTP_CREATED_CODE, self::HTTP_SUCCESS_OK ] ) && !is_null( $content ) ) {
 			$results['success'] = true;
 		}
 

--- a/extensions/wikia/WikiaInteractiveMaps/models/WikiaMaps.class.php
+++ b/extensions/wikia/WikiaInteractiveMaps/models/WikiaMaps.class.php
@@ -85,8 +85,8 @@ class WikiaMaps {
 			'headers' => [
 				'Authorization' => $this->config['token']
 			],
-            //TODO this is temporary workaround, remove it before production!
-            'noProxy' => true
+			//TODO: this is temporary workaround, remove it before production!
+			'noProxy' => true
 		] );
 	}
 
@@ -101,8 +101,9 @@ class WikiaMaps {
 		$mapsData = new stdClass();
 		$url = $this->buildUrl( [ self::ENTRY_POINT_MAP ], $params );
 		$response = Http::get( $url, 'default', array(
-            'noProxy' => true
-        ) );
+			//TODO: this is temporary workaround, remove it before production!
+			'noProxy' => true
+		) );
 
 		if ( $response !== false ) {
 			$mapsData = json_decode( $response );
@@ -140,16 +141,16 @@ class WikiaMaps {
 		$mapId = array_shift( $params );
 		$url = $this->buildUrl( [ self::ENTRY_POINT_MAP, $mapId ], $params );
 		$response = Http::get( $url, 'default', array(
-            //TODO this is temporary workaround, remove it before production!
-            'noProxy' => true
-        ) );
+			//TODO: this is temporary workaround, remove it before production!
+			'noProxy' => true
+		) );
 
 		$map = json_decode( $response );
 		if( !empty( $map->tile_set_url ) ) {
 			$response = Http::get( $map->tile_set_url, 'default', array(
-                //TODO this is temporary workaround, remove it before production!
-                'noProxy' => true
-            ) );
+				//TODO: this is temporary workaround, remove it before production!
+				'noProxy' => true
+			) );
 			$tilesData = json_decode( $response );
 
 			if( !is_null( $tilesData ) ) {

--- a/extensions/wikia/WikiaInteractiveMaps/models/WikiaMaps.class.php
+++ b/extensions/wikia/WikiaInteractiveMaps/models/WikiaMaps.class.php
@@ -17,6 +17,8 @@ class WikiaMaps {
 	const MAP_TYPE_CUSTOM = 'uploaded';
 	const MAP_TYPE_GEO = 'geo';
 
+	const HTTP_CREATED_CODE = 201;
+
 	/**
 	 * @var array API connection config
 	 */
@@ -80,15 +82,17 @@ class WikiaMaps {
 	 * @return string|bool
 	 */
 	private function postRequest( $url, $data ) {
-		return Http::post( $url, [
-			'postData' => json_encode( $data ),
-			'headers' => [
-				'Authorization' => $this->config['token']
-			],
-			'returnInstance' => true,
-			//TODO: this is temporary workaround, remove it before production!
-			'noProxy' => true
-		] );
+		return $this->processServiceResponse(
+			Http::post( $url, [
+				'postData' => json_encode( $data ),
+				'headers' => [
+					'Authorization' => $this->config['token']
+				],
+				'returnInstance' => true,
+				//TODO: this is temporary workaround, remove it before production!
+				'noProxy' => true
+			] )
+		);
 	}
 
 	/**
@@ -277,6 +281,24 @@ class WikiaMaps {
 		}
 
 		return 0;
+	}
+
+	/**
+	 * Returns results array with success and content elements
+	 *
+	 * @param MWHttpRequest $response
+	 * @todo: how about extracting results to an object?
+	 */
+	private function processServiceResponse( MWHttpRequest $response ) {
+		$results['success'] = false;
+		$results['content'] = json_decode( $response->getContent() );
+		$status = $response->getStatus();
+
+		if( $status === self::HTTP_CREATED_CODE ) {
+			$results['success'] = true;
+		}
+
+		return $results;
 	}
 
 }

--- a/extensions/wikia/WikiaInteractiveMaps/models/WikiaMaps.class.php
+++ b/extensions/wikia/WikiaInteractiveMaps/models/WikiaMaps.class.php
@@ -151,7 +151,7 @@ class WikiaMaps {
 		$url = $this->buildUrl( [ self::ENTRY_POINT_MAP, $mapId ], $params );
 		$response = $this->processServiceResponse(
 			Http::get( $url, 'default', [
-					'returnInstance' => true,
+				'returnInstance' => true,
 				//TODO: this is temporary workaround, remove it before production!
 				'noProxy' => true
 			] )

--- a/extensions/wikia/WikiaInteractiveMaps/models/WikiaMaps.class.php
+++ b/extensions/wikia/WikiaInteractiveMaps/models/WikiaMaps.class.php
@@ -242,10 +242,12 @@ class WikiaMaps {
 		$url = $this->buildUrl( [ self::ENTRY_POINT_TILE_SET ], $params );
 
 		//TODO: consider caching the response
-		$response = Http::get( $url, 'default', [
-			//TODO this is temporary workaround, remove it before production!
-			'noProxy' => true
-		] );
+		$response = $this->processServiceResponse(
+			Http::get( $url, 'default', [
+				//TODO this is temporary workaround, remove it before production!
+				'noProxy' => true
+			] )
+		);
 
 		return json_decode( $response );
 	}

--- a/extensions/wikia/WikiaInteractiveMaps/templates/WikiaInteractiveMapsController_error.mustache
+++ b/extensions/wikia/WikiaInteractiveMaps/templates/WikiaInteractiveMapsController_error.mustache
@@ -1,2 +1,2 @@
-<p>{{messages.wikia-interactive-maps-api-error-message}}</p>
+<p>{{{messages.wikia-interactive-maps-api-error-message}}}</p>
 

--- a/extensions/wikia/WikiaInteractiveMaps/templates/WikiaInteractiveMapsController_error.mustache
+++ b/extensions/wikia/WikiaInteractiveMaps/templates/WikiaInteractiveMapsController_error.mustache
@@ -1,2 +1,2 @@
-<p>{{{messages.wikia-interactive-maps-api-error-message}}}</p>
+<p>{{{messages.wikia-interactive-maps-service-error}}}</p>
 

--- a/includes/HttpFunctions.php
+++ b/includes/HttpFunctions.php
@@ -108,7 +108,7 @@ class Http {
 	 * @param $url
 	 * @param $timeout string
 	 * @param $options array
-	 * @return string
+	 * @return string|bool|MWHttpRequest
 	 */
 	public static function get( $url, $timeout = 'default', $options = array() ) {
 		$options['timeout'] = $timeout;
@@ -121,7 +121,7 @@ class Http {
 	 *
 	 * @param $url
 	 * @param $options array
-	 * @return string
+	 * @return string|bool|MWHttpRequest
 	 */
 	public static function post( $url, $options = array() ) {
 		return Http::request( 'POST', $url, $options );


### PR DESCRIPTION
We can handle service errors when we have `returnInstance` option now in MW `Http` class. I changed our model so it always requires the instance of `MWHttpRequest`, therefore we can serve service errors such as "Name needs to be unique" for creating tilesets.
