### PR TITLE
PLATFORM-275 Invoke UserRenameTask on default wikiCity only

### DIFF
--- a/extensions/wikia/UserRenameTool/RenameUserProcess.class.php
+++ b/extensions/wikia/UserRenameTool/RenameUserProcess.class.php
@@ -684,10 +684,9 @@ class RenameUserProcess {
 		);
 		if ( TaskRunner::isModern('UserRename') ) {
 			$task = ( new UserRenameTask() )
-				->wikiId( $wikiIDs )
 				->setPriority( \Wikia\Tasks\Queues\PriorityQueue::NAME );
 
-			$task->call( 'renameUser', $callParams );
+			$task->call( 'renameUser', $wikiIDs, $callParams );
 			$task->queue();
 		} else {
 			// create a new task for the Task Manager to handle all the global tables

--- a/extensions/wikia/UserRenameTool/UserRenameTask.class.php
+++ b/extensions/wikia/UserRenameTool/UserRenameTask.class.php
@@ -22,7 +22,7 @@ class UserRenameTask extends BaseTask {
 	 *		phalanx_block_id => Phalanx login block ID
 	 */
 	public function renameUser( array $wikiCityIds, array $params ) {
-		global $IP, $wgWikiaLocalSettingsPath, $wgWikiaAdminSettingsPath;
+		global $IP;
 
 		$renameIP = !empty($params['rename_ip']);
 

--- a/extensions/wikia/UserRenameTool/UserRenameTask.class.php
+++ b/extensions/wikia/UserRenameTool/UserRenameTask.class.php
@@ -21,8 +21,8 @@ class UserRenameTask extends BaseTask {
 	 *		rename_fake_user_id => Repeated rename process special case (TODO: Don't know what this is)
 	 *		phalanx_block_id => Phalanx login block ID
 	 */
-	public function renameUser( array $params ) {
-		global $wgCityId;
+	public function renameUser( array $wikiCityIds, array $params ) {
+		global $IP, $wgWikiaLocalSettingsPath, $wgWikiaAdminSettingsPath;
 
 		$renameIP = !empty($params['rename_ip']);
 
@@ -30,39 +30,64 @@ class UserRenameTask extends BaseTask {
 		$process->setLogDestination( \RenameUserProcess::LOG_BATCH_TASK, $this );
 		$process->setRequestorUser();
 
-		try {
-			// Rename user by IP address (for CoppaTool)
-			if ( $renameIP ) {
-				// validate IP rename
-				foreach ( [$params['rename_old_name'], $params['rename_new_name']] as $ip ) {
-					if ( !IP::isIPAddress($ip) ) {
-						$this->log("Invalid IP provided to rename IP address: {$ip}");
-						return false;
-					}
-				}
-				$process->updateLocalIP();
-			} else {
-				$process->updateLocal();
+		$noErrors = true;
+
+		foreach ($wikiCityIds as $cityId) {
+			/**
+			 * execute maintenance script
+			 */
+			$aconf = $wgWikiaAdminSettingsPath;
+
+			if ( defined('ENV_DEVBOX') && ENV_DEVBOX ) {
+				$aconf = preg_replace("/\\.\\.\\//","",$aconf);
 			}
-			$errors = $process->getErrors();
-		} catch (Exception $e) {
-			$errors = $process->getErrors();
-			$errors[] = sprintf("Exception in updateLocal(): %s in %s at line %d",
-				$e->getMessage(), $e->getFile(), $e->getLine());
+
+			$cmd = sprintf( "SERVER_ID=%s php {$IP}/maintenance/wikia/RenameUser_local.php", $cityId );
+			$opts = [
+				'rename-user-id' => $params['rename_user_id'],
+				'requestor-id' => $params['requestor_id'],
+				'reason' => $params['reason'],
+				'conf' => $wgWikiaLocalSettingsPath,
+				'aconf' => $aconf,
+			];
+
+			if ( $renameIP ) {
+				$opts['rename-old-name'] = $params['rename_old_name'];
+				$opts['rename-new-name'] = $params['rename_new_name'];
+			} else {
+				$opts['rename-old-name-enc'] = rawurlencode( $params['rename_old_name'] );
+				$opts['rename-new-name-enc'] = rawurlencode( $params['rename_new_name'] );
+				$opts['rename-fake-user-id'] = $params['rename_fake_user_id'];
+				$opts['phalanx-block-id'] = $params['phalanx_block_id'];
+			}
+
+			foreach ($opts as $opt => $val) {
+				$cmd .= sprintf( ' --%s %s', $opt, escapeshellarg($val) );
+			}
+			if ( $renameIP ) {
+				$cmd .= ' --rename-ip-address';
+			}
+
+			$exitCode = null;
+			$output = wfShellExec( $cmd, $exitCode );
+			$logMessage = sprintf( "Rename user %s to %s on city id %s",
+				$params['rename_old_name'], $params['rename_new_name'], $cityId);
+			$logContext = [
+				'command' => $cmd,
+				'exitStatus' => $exitCode,
+				'output' => $output,
+			];
+			if ( $exitCode > 0 ) {
+				\Wikia\Logger\WikiaLogger::instance()->error($logMessage, $logContext);
+				$noErrors = false;
+			} else {
+				\Wikia\Logger\WikiaLogger::instance()->info($logMessage, $logContext);
+			}
 		}
 
 		// clean up pre-process setup
 		$process->cleanup();
 
-		if ( !empty($errors) ) {
-			foreach ( $errors as $error ) {
-				$this->log($error);
-			}
-		}
-		// TODO - The original task sent a notification to the requestor and
-		// renamed user (if not by IP) *always*; should it do that even if there
-		// are errors?
-		// notify requestor and renamed user
 		$this->notifyUser(
 			\User::newFromId( $params['requestor_id'] ),
 			$params['rename_old_name'],
@@ -81,7 +106,7 @@ class UserRenameTask extends BaseTask {
 			}
 		}
 
-		return empty($errors);
+		return $noErrors;
 	}
 
 	/**
@@ -101,9 +126,16 @@ class UserRenameTask extends BaseTask {
 				'UserRenameProcessFinishedNotification',
 				wfMsgForContent('userrenametool-finished-email-body-html', $oldUsername, $newUsername)
 			);
-			$this->log("Notification sent to: {$user->getEmail()}");
+			\Wikia\Logger\WikiaLogger::instance()->info(
+				"Rename user {$oldUsername} to {$newUsername}: email notification",
+				[
+					'to' => $user->getEmail(),
+				]
+			);
 		} else {
-			$this->log("Cannot send email, no email set for user: {$user->getName()}");
+			\Wikia\Logger\WikiaLogger::instance()->warning(
+				"Rename user {$oldUsername} to {$newUsername}: no email address set for user"
+			);
 		}
 	}
 }

--- a/extensions/wikia/UserRenameTool/UserRenameTask.class.php
+++ b/extensions/wikia/UserRenameTool/UserRenameTask.class.php
@@ -36,19 +36,11 @@ class UserRenameTask extends BaseTask {
 			/**
 			 * execute maintenance script
 			 */
-			$aconf = $wgWikiaAdminSettingsPath;
-
-			if ( defined('ENV_DEVBOX') && ENV_DEVBOX ) {
-				$aconf = preg_replace("/\\.\\.\\//","",$aconf);
-			}
-
 			$cmd = sprintf( "SERVER_ID=%s php {$IP}/maintenance/wikia/RenameUser_local.php", $cityId );
 			$opts = [
 				'rename-user-id' => $params['rename_user_id'],
 				'requestor-id' => $params['requestor_id'],
 				'reason' => $params['reason'],
-				'conf' => $wgWikiaLocalSettingsPath,
-				'aconf' => $aconf,
 			];
 
 			if ( $renameIP ) {


### PR DESCRIPTION
Attempting to invoke the UserRenameTask on each wikiCity individually would
fail when the target wikiCity did not have the UserRenameTool extension
enabled, which should be all of them except "community". Instead, run
the task on the "community" main wiki and shell out to the pre-existing
maintenance script that bypasses the enabled check by force-requiring
the dependencies.

Also, better logging.

Also,
PLATFORM-75

@nmonterroso 
