### PR TITLE
VE-1146: Removing anything releated to Favicon in CreateWiki

### DIFF
--- a/extensions/wikia/CreateNewWiki/CreateWiki.php
+++ b/extensions/wikia/CreateNewWiki/CreateWiki.php
@@ -41,7 +41,6 @@ class CreateWiki {
 	const IMGROOT              = "/images/";
 	const IMAGEURL             = "http://images.wikia.com/";
 	const CREATEWIKI_LOGO      = "http://images.wikia.com/central/images/2/22/Wiki_Logo_Template.png";
-	const CREATEWIKI_ICON      = "http://images.wikia.com/central/images/6/64/Favicon.ico";
 	const DEFAULT_STAFF        = "Angela";
 	const DEFAULT_USER         = 'Default';
 	const DEFAULT_DOMAIN       = "wikia.com";
@@ -50,7 +49,6 @@ class CreateWiki {
 	const DEFAULT_NAME         = "Wiki";
 	const DEFAULT_WIKI_TYPE    = "";
 	const DEFAULT_WIKI_LOGO    = '$wgUploadPath/b/bc/Wiki.png';
-	const DEFAULT_WIKI_FAVICON = '$wgUploadPath/6/64/Favicon.ico';
 
 
 	/**
@@ -324,7 +322,7 @@ class CreateWiki {
 		$this->mNewWiki->dbw->insert( "site_stats", array( "ss_row_id" => "1"), __METHOD__ );
 
 		/**
-		 * copy default logo & favicon
+		 * copy default logo
 		 */
 
 
@@ -333,13 +331,6 @@ class CreateWiki {
 			wfDebugLog( "createwiki", __METHOD__ . ": Default logo has been uploaded\n", true );
 		} else {
 			wfDebugLog( "createwiki", __METHOD__ . ": Default logo has not been uploaded - " . print_r($res['errors'], true) . "\n", true );
-		}
-
-		$res = ImagesService::uploadImageFromUrl( self::CREATEWIKI_ICON, (object) ['name' => 'Favicon.ico'], $uploader );
-		if (  $res['status'] == true  ) {
-			wfDebugLog( "createwiki", __METHOD__ . ": Default favicon has been uploaded\n", true );
-		} else {
-			wfDebugLog( "createwiki", __METHOD__ . ": Default favicon has not been uploaded - " . print_r($res['errors'], true) . "\n", true );
 		}
 
 		/**
@@ -918,7 +909,6 @@ class CreateWiki {
 		$this->mWFSettingVars['wgLocalInterwiki']         = $this->mNewWiki->sitename;
 		$this->mWFSettingVars['wgLanguageCode']           = $this->mNewWiki->language;
 		$this->mWFSettingVars['wgServer']                 = rtrim( $this->mNewWiki->url, "/" );
-		$this->mWFSettingVars['wgFavicon']                = self::DEFAULT_WIKI_FAVICON;
 		$this->mWFSettingVars['wgEnableSectionEdit']      = true;
 		$this->mWFSettingVars['wgEnableSwiftFileBackend'] = true;
 		$this->mWFSettingVars['wgOasisLoadCommonCSS']     = true;


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/VE-1146 @inez 

This script doesn't appear to actually create a Favicon - that work has traditionally been happening with the importStarter() method which imports the starter database and all of its files. starter.wikia.com does not have its own Favicon.ico file, so Favicon.ico files are not created on new wikis. The starter on devboxes does have a Favicon.ico (which threw me off for a while), and Favicons are being created on devboxes. There is no need to set $wgFavicon on new wikis (we have retired that functionality with VE-1145) and no need to try creating a Favicon.
