### PR TITLE
VE-518: Insert content properly when saving

### DIFF
--- a/extensions/VisualEditor/wikia/modules/ve/init/ve.init.mw.WikiaViewPageTarget.js
+++ b/extensions/VisualEditor/wikia/modules/ve/init/ve.init.mw.WikiaViewPageTarget.js
@@ -229,7 +229,7 @@ ve.init.mw.WikiaViewPageTarget.prototype.maybeShowDialogs = function () {
  * @inheritdoc
  */
 ve.init.mw.ViewPageTarget.prototype.replacePageContent = function ( html, categoriesHtml ) {
-	var $articleContent, $insertTarget,
+	var $insertTarget,
 		$mwContentText = $( '#mw-content-text' ),
 		$content = $( $.parseHTML( html ) );
 
@@ -251,11 +251,10 @@ ve.init.mw.ViewPageTarget.prototype.replacePageContent = function ( html, catego
 
 		$insertTarget = window.CategoryExhibition ? '#mw-pages' : '.category-gallery';
 		$content.insertBefore( $insertTarget );
-		$articleContent = $mwContentText;
 	} else {
-		$articleContent = $mwContentText.empty().append( $content );
+		$mwContentText.empty().append( $content );
 	}
 
-	mw.hook( 'wikipage.content' ).fire( $articleContent );
+	mw.hook( 'wikipage.content' ).fire( $mwContentText );
 	$( '#catlinks' ).replaceWith( categoriesHtml );
 };

--- a/extensions/VisualEditor/wikia/modules/ve/init/ve.init.mw.WikiaViewPageTarget.js
+++ b/extensions/VisualEditor/wikia/modules/ve/init/ve.init.mw.WikiaViewPageTarget.js
@@ -224,3 +224,38 @@ ve.init.mw.WikiaViewPageTarget.prototype.maybeShowDialogs = function () {
 		}
 	}
 };
+
+/**
+ * @inheritdoc
+ */
+ve.init.mw.ViewPageTarget.prototype.replacePageContent = function ( html, categoriesHtml ) {
+	var $articleContent, $insertTarget,
+		$mwContentText = $( '#mw-content-text' );
+		$content = $( $.parseHTML( html ) );
+
+	if ( mw.config.get( 'wgNamespaceNumber' ) === 14 ) {
+		//Category
+		$mwContentText.children().filter( function( index ) {
+			var $this = $( this );
+			return !(
+				// Category form
+				$this.hasClass( 'category-gallery-form' ) ||
+				// Category thumbs
+				$this.hasClass( 'category-gallery' ) ||
+				// Category exhibition
+				$this.is( '#mw-pages' ) ||
+				// Category list
+				$this.children( '#mw-pages' ).length
+			);
+		} ).remove();
+
+		$insertTarget = window.CategoryExhibition ? '#mw-pages' : '.category-gallery';
+		$content.insertBefore( $insertTarget );
+		$articleContent = $mwContentText;
+	} else {
+		$articleContent = $mwContentText.empty().append( $content );
+	}
+
+	mw.hook( 'wikipage.content' ).fire( $articleContent );
+	$( '#catlinks' ).replaceWith( categoriesHtml );
+};

--- a/extensions/VisualEditor/wikia/modules/ve/init/ve.init.mw.WikiaViewPageTarget.js
+++ b/extensions/VisualEditor/wikia/modules/ve/init/ve.init.mw.WikiaViewPageTarget.js
@@ -229,7 +229,7 @@ ve.init.mw.WikiaViewPageTarget.prototype.maybeShowDialogs = function () {
  * @inheritdoc
  */
 ve.init.mw.ViewPageTarget.prototype.replacePageContent = function ( html, categoriesHtml ) {
-	var $insertTarget,
+	var insertTarget,
 		$mwContentText = $( '#mw-content-text' ),
 		$content = $( $.parseHTML( html ) );
 
@@ -249,8 +249,8 @@ ve.init.mw.ViewPageTarget.prototype.replacePageContent = function ( html, catego
 			);
 		} ).remove();
 
-		$insertTarget = window.CategoryExhibition ? '#mw-pages' : '.category-gallery';
-		$content.insertBefore( $insertTarget );
+		insertTarget = window.CategoryExhibition ? '#mw-pages' : '.category-gallery';
+		$content.insertBefore( insertTarget );
 	} else {
 		$mwContentText.empty().append( $content );
 	}

--- a/extensions/VisualEditor/wikia/modules/ve/init/ve.init.mw.WikiaViewPageTarget.js
+++ b/extensions/VisualEditor/wikia/modules/ve/init/ve.init.mw.WikiaViewPageTarget.js
@@ -230,7 +230,7 @@ ve.init.mw.WikiaViewPageTarget.prototype.maybeShowDialogs = function () {
  */
 ve.init.mw.ViewPageTarget.prototype.replacePageContent = function ( html, categoriesHtml ) {
 	var $articleContent, $insertTarget,
-		$mwContentText = $( '#mw-content-text' );
+		$mwContentText = $( '#mw-content-text' ),
 		$content = $( $.parseHTML( html ) );
 
 	if ( mw.config.get( 'wgNamespaceNumber' ) === 14 ) {


### PR DESCRIPTION
As reported by Rochan. When canceling an edit, the hidden elements in the content area are simply redisplayed (category thumbs, category list, etc), but when saving, the entire content area is emptied and replaced. 

I've written our own version of replacePageContent that takes this into consideration and inserts the new content into the correct place. 
@inez 
