### PR TITLE
VID-1737 Escape title of video on edit

### DIFF
--- a/extensions/wikia/VideoEmbedTool/templates/quickform.tmpl.php
+++ b/extensions/wikia/VideoEmbedTool/templates/quickform.tmpl.php
@@ -33,7 +33,7 @@ $formSubmits = array(
 $nameInput = array(
 	'type' => 'hidden',
 	'name' => 'name',
-	'value' => $name,
+	'value' => htmlentities( $name, ENT_COMPAT ), // Escape at least double-quotes. see VID-1737
 );
 
 $form = array(


### PR DESCRIPTION
RFCR @saipetch @garthwebb 

Escapes double quotes so the html value field does not get truncated.
