### PR TITLE
CON-1296 | ABTesting uses nocookie domain for external scripts

### DIFF
--- a/extensions/wikia/AbTesting/js/AbTest.js
+++ b/extensions/wikia/AbTesting/js/AbTest.js
@@ -298,7 +298,7 @@
 		}
 		if ( externalIds.length > 0 ) {
 			log('init', 'Loading external configuration');
-			var url = '/wikia.php?controller=AbTesting&method=externalData&callback=Wikia.AbTest.loadExternalData&ids=';
+			var url = window.wgCdnApiUrl + '/wikia.php?controller=AbTesting&method=externalData&callback=Wikia.AbTest.loadExternalData&ids=';
 			url += externalIds.join(',');
 			document.write('<scr'+'ipt src="'+encodeURI(url)+'"></script>');
 		}

--- a/extensions/wikia/JSVariables/JSVariables.php
+++ b/extensions/wikia/JSVariables/JSVariables.php
@@ -24,6 +24,7 @@ function wfJSVariablesTopScripts(Array &$vars, &$scripts) {
 		$vars['wgWikiFactoryTagNames'] = array_values( $wg->WikiFactoryTags );
 	}
 	$vars['wgCdnRootUrl'] = $wg->CdnRootUrl;
+	$vars['wgCdnApiUrl'] = $wg->CdnApiUrl;
 
 	// analytics needs it (from here till the end of the function)
 	$vars['wgDBname'] = $wg->DBname;

--- a/includes/wikia/nirvana/WikiaDispatchableObject.class.php
+++ b/includes/wikia/nirvana/WikiaDispatchableObject.class.php
@@ -11,6 +11,7 @@
  */
 abstract class WikiaDispatchableObject extends WikiaObject {
 	const DEFAULT_TEMPLATE_ENGINE = WikiaResponse::TEMPLATE_ENGINE_PHP;
+	const NIRVANA_API_PATH = '/wikia.php';
 
 	/**
 	 * Mediawiki RequestContext object
@@ -249,8 +250,6 @@ abstract class WikiaDispatchableObject extends WikiaObject {
 	 * @return string The absolute URL
 	 */
 	public static function getLocalUrl( $method, $params = null, $format = null ) {
-		$basePath = '/wikia.php';
-
 		$baseParams = array( 'controller' => preg_replace( "/Controller$/", '', get_called_class() ), 'method' => $method );
 
 		if ( !empty( $format ) ) {
@@ -264,7 +263,7 @@ abstract class WikiaDispatchableObject extends WikiaObject {
 			$baseParams = array_merge( $baseParams, $params );
 		}
 
-		return wfAppendQuery( $basePath, $baseParams );
+		return wfAppendQuery( self::NIRVANA_API_PATH, $baseParams );
 	}
 
 	/**
@@ -294,7 +293,7 @@ abstract class WikiaDispatchableObject extends WikiaObject {
 	 */
 	public static function getNoCookieUrl( $method, $params = null, $format = null ) {
 		$app = F::app();
-		return wfExpandUrl( F::app()->wg->CdnApiUrl . $app->wg->ScriptPath . self::getLocalUrl( $method, $params, $format ) );
+		return wfExpandUrl( $app->wg->CdnApiUrl . $app->wg->ScriptPath . self::getLocalUrl( $method, $params, $format ) );
 	}
 
 

--- a/includes/wikia/nirvana/WikiaDispatchableObject.class.php
+++ b/includes/wikia/nirvana/WikiaDispatchableObject.class.php
@@ -293,7 +293,8 @@ abstract class WikiaDispatchableObject extends WikiaObject {
 	 * @return string The absolute URL
 	 */
 	public static function getNoCookieUrl( $method, $params = null, $format = null ) {
-		return F::app()->wg->CdnApiUrl . self::getLocalUrl( $method, $params, $format );
+		$app = F::app();
+		return wfExpandUrl( F::app()->wg->CdnApiUrl . $app->wg->ScriptPath . self::getLocalUrl( $method, $params, $format ) );
 	}
 
 

--- a/includes/wikia/nirvana/WikiaDispatchableObject.class.php
+++ b/includes/wikia/nirvana/WikiaDispatchableObject.class.php
@@ -253,15 +253,15 @@ abstract class WikiaDispatchableObject extends WikiaObject {
 
 		$baseParams = array( 'controller' => preg_replace( "/Controller$/", '', get_called_class() ), 'method' => $method );
 
+		if ( !empty( $format ) ) {
+			$params['format'] = $format;
+		}
+
 		if ( ! empty( $params ) ) {
 			//WikiaAPI requests accept only sorted params
 			//to cut down caching variants
 			ksort( $params );
 			$baseParams = array_merge( $baseParams, $params );
-		}
-
-		if ( !empty( $format ) ) {
-			$baseParams['format'] = $format;
 		}
 
 		return wfAppendQuery( $basePath, $baseParams );

--- a/includes/wikia/nirvana/WikiaDispatchableObject.class.php
+++ b/includes/wikia/nirvana/WikiaDispatchableObject.class.php
@@ -223,32 +223,79 @@ abstract class WikiaDispatchableObject extends WikiaObject {
 	}
 
 	/**
-	 * Returns the URL that would be used for an Ajax or API call (Nirvana) to access this method
+	 * Alias: WikiaDispatchableObject::getFullUrl
+	 *
+	 * Returns the full URL that would be used for an Ajax or API call (Nirvana) to access this method
 	 *
 	 * @param string $method The method name
 	 * @param array $params An hash with the parameters for the request and their possible values,
 	 * schema ['paramName' => 'value', ...]
+	 * @param string $format Response format - Constants defined in WikiaResponse
 	 *
 	 * @return string The absolute URL
 	 */
-	public static function getUrl( $method, Array $params = null ) {
-		$app = F::app();
-		$basePath = wfExpandUrl( $app->wg->Server . $app->wg->ScriptPath . '/wikia.php' );
+	public static function getUrl( $method, array $params = null, $format = null ) {
+		return self::getFullUrl( $method, $params, $format );
+	}
 
-		$baseParams = array(
-			'controller' => preg_replace( "/Controller$/", '', get_called_class() ),
-			'method' => $method
-		);
+	/**
+	 * Returns the local URL that would be used for an Ajax or API call (Nirvana) to access this method
+	 *
+	 * @param string $method The method name
+	 * @param array $params An hash with the parameters for the request and their possible values,
+	 * schema ['paramName' => 'value', ...]
+	 * @param string $format Response format - Constants defined in WikiaResponse
+	 *
+	 * @return string The absolute URL
+	 */
+	public static function getLocalUrl( $method, $params = null, $format = null ) {
+		$basePath = '/wikia.php';
 
-		if ( !empty( $params ) ) {
+		$baseParams = array( 'controller' => preg_replace( "/Controller$/", '', get_called_class() ), 'method' => $method );
+
+		if ( ! empty( $params ) ) {
 			//WikiaAPI requests accept only sorted params
 			//to cut down caching variants
 			ksort( $params );
 			$baseParams = array_merge( $baseParams, $params );
 		}
 
+		if ( !empty( $format ) ) {
+			$baseParams['format'] = $format;
+		}
+
 		return wfAppendQuery( $basePath, $baseParams );
 	}
+
+	/**
+	 * Returns the full URL that would be used for an Ajax or API call (Nirvana) to access this method
+	 *
+	 * @param string $method The method name
+	 * @param array $params An hash with the parameters for the request and their possible values,
+	 * schema ['paramName' => 'value', ...]
+	 * @param string $format Response format - Constants defined in WikiaResponse
+	 *
+	 * @return string The absolute URL
+	 */
+	public static function getFullUrl( $method, $params = null, $format = null ) {
+		$app = F::app();
+		return wfExpandUrl( $app->wg->Server . $app->wg->ScriptPath . self::getLocalUrl( $method, $params, $format ) );
+	}
+
+	/**
+	 * Returns the nocookie URL that would be used for an API call (Nirvana) to access this method
+	 *
+	 * @param string $method The method name
+	 * @param array $params An hash with the parameters for the request and their possible values,
+	 * schema ['paramName' => 'value', ...]
+	 * @param string $format Response format - Constants defined in WikiaResponse
+	 *
+	 * @return string The absolute URL
+	 */
+	public static function getNoCookieUrl( $method, $params = null, $format = null ) {
+		return F::app()->wg->CdnApiUrl . self::getLocalUrl( $method, $params, $format );
+	}
+
 
 	/**
 	 * Purges URL's for multiple methods at once

--- a/includes/wikia/tests/WikiaDispatchableObjectTest.php
+++ b/includes/wikia/tests/WikiaDispatchableObjectTest.php
@@ -21,9 +21,9 @@ class WikiaDispatchableObjectTest extends WikiaBaseTest {
 			['test', null, null, null],
 			['testParamsOrdered', ['a' => 1, 'b' => 2], null, '&a=1&b=2'],
 			['testParamsUnordered', ['c' => 1, 'a' => 2, 'b' => 3], null, '&a=2&b=3&c=1'],
-			['testParamsUnordered', ['c' => 1, 'a' => 2, 'b' => 3], WikiaResponse::FORMAT_JSON, '&a=2&b=3&c=1'],
-			['testParamsUnordered', ['c' => 1, 'a' => 2, 'b' => 3], WikiaResponse::FORMAT_JSONP, '&a=2&b=3&c=1'],
-			['testParamsUnordered', ['c' => 1, 'a' => 2, 'b' => 3], WikiaResponse::FORMAT_RAW, '&a=2&b=3&c=1'],
+			['testParamsUnordered', ['c' => 1, 'a' => 2, 'b' => 3], WikiaResponse::FORMAT_JSON, '&a=2&b=3&c=1&format=json'],
+			['testParamsUnordered', ['c' => 1, 'a' => 2, 'b' => 3], WikiaResponse::FORMAT_JSONP, '&a=2&b=3&c=1&format=jsonp'],
+			['testParamsUnordered', ['c' => 1, 'a' => 2, 'b' => 3], WikiaResponse::FORMAT_RAW, '&a=2&b=3&c=1&format=raw'],
 		];
 	}
 
@@ -35,9 +35,6 @@ class WikiaDispatchableObjectTest extends WikiaBaseTest {
 		$serverName = "test-server";
 		$scriptPath = "/test-path";
 		$requestURI = "{$serverName}{$scriptPath}/wikia.php?controller={$className}&method={$methodName}{$encodedParams}";
-		if ( !empty( $format ) ) {
-			$requestURI .= '&format=' . $format;
-		}
 
 		$this->mockGlobalVariable( 'wgServer', $serverName );
 		$this->mockGlobalVariable( 'wgScriptPath', $scriptPath );
@@ -51,9 +48,6 @@ class WikiaDispatchableObjectTest extends WikiaBaseTest {
 	public function testGetLocalUrl( $methodName, $params, $format, $encodedParams ) {
 		$className = get_class( $this->dispatchableMock );
 		$requestURI = "/wikia.php?controller={$className}&method={$methodName}{$encodedParams}";
-		if ( !empty( $format ) ) {
-			$requestURI .= '&format=' . $format;
-		}
 
 		$this->assertEquals( $requestURI, $className::getLocalUrl( $methodName, $params, $format ) );
 	}
@@ -66,9 +60,6 @@ class WikiaDispatchableObjectTest extends WikiaBaseTest {
 		$mockCdnApiUrl = "api.nocookie.test-server";
 		$scriptPath = "/test-path";
 		$requestURI = "{$mockCdnApiUrl}{$scriptPath}/wikia.php?controller={$className}&method={$methodName}{$encodedParams}";
-		if ( !empty( $format ) ) {
-			$requestURI .= '&format=' . $format;
-		}
 
 		$this->mockGlobalVariable( 'wgCdnApiUrl', $mockCdnApiUrl );
 		$this->mockGlobalVariable( 'wgScriptPath', $scriptPath );

--- a/includes/wikia/tests/WikiaDispatchableObjectTest.php
+++ b/includes/wikia/tests/WikiaDispatchableObjectTest.php
@@ -17,26 +17,61 @@ class WikiaDispatchableObjectTest extends WikiaBaseTest {
 	//data provider for testGetUrl
 	public function getUrlProvider() {
 		return [
-			// methodName, params, encodedParams
-			['test', null, null],
-			['testParamsOrdered', ['a' => 1, 'b' => 2], '&a=1&b=2'],
-			['testParamsUnordered', ['c' => 1, 'a' => 2, 'b' => 3], '&a=2&b=3&c=1']
+			// methodName, params, format, encodedParams
+			['test', null, null, null],
+			['testParamsOrdered', ['a' => 1, 'b' => 2], null, '&a=1&b=2'],
+			['testParamsUnordered', ['c' => 1, 'a' => 2, 'b' => 3], null, '&a=2&b=3&c=1'],
+			['testParamsUnordered', ['c' => 1, 'a' => 2, 'b' => 3], WikiaResponse::FORMAT_JSON, '&a=2&b=3&c=1'],
+			['testParamsUnordered', ['c' => 1, 'a' => 2, 'b' => 3], WikiaResponse::FORMAT_JSONP, '&a=2&b=3&c=1'],
+			['testParamsUnordered', ['c' => 1, 'a' => 2, 'b' => 3], WikiaResponse::FORMAT_RAW, '&a=2&b=3&c=1'],
 		];
 	}
 
 	/**
 	 * @dataProvider getUrlProvider
 	 */
-	public function testGetUrl( $methodName, $params, $encodedParams ) {
+	public function testGetUrl( $methodName, $params, $format, $encodedParams ) {
 		$className = get_class( $this->dispatchableMock );
 		$serverName = "test-server";
 		$scriptPath = "/test-path";
 		$requestURI = "{$serverName}{$scriptPath}/wikia.php?controller={$className}&method={$methodName}{$encodedParams}";
+		if ( !empty( $format ) ) {
+			$requestURI .= '&format=' . $format;
+		}
 
 		$this->mockGlobalVariable( 'wgServer', $serverName );
 		$this->mockGlobalVariable( 'wgScriptPath', $scriptPath );
 
-		$this->assertEquals( $requestURI, $className::getUrl( $methodName, $params ) );
+		$this->assertEquals( $requestURI, $className::getUrl( $methodName, $params, $format ) );
+	}
+
+	/**
+	 * @dataProvider getUrlProvider
+	 */
+	public function testGetLocalUrl( $methodName, $params, $format, $encodedParams ) {
+		$className = get_class( $this->dispatchableMock );
+		$requestURI = "/wikia.php?controller={$className}&method={$methodName}{$encodedParams}";
+		if ( !empty( $format ) ) {
+			$requestURI .= '&format=' . $format;
+		}
+
+		$this->assertEquals( $requestURI, $className::getLocalUrl( $methodName, $params, $format ) );
+	}
+
+	/**
+	 * @dataProvider getUrlProvider
+	 */
+	public function testGetNoCookieUrl( $methodName, $params, $format, $encodedParams ) {
+		$className = get_class( $this->dispatchableMock );
+		$mockCdnApiUrl = "api.nocookie.test-server";
+		$requestURI = "{$mockCdnApiUrl}/wikia.php?controller={$className}&method={$methodName}{$encodedParams}";
+		if ( !empty( $format ) ) {
+			$requestURI .= '&format=' . $format;
+		}
+
+		$this->mockGlobalVariable( 'wgCdnApiUrl', $mockCdnApiUrl );
+
+		$this->assertEquals( $requestURI, $className::getNoCookieUrl( $methodName, $params, $format ) );
 	}
 
 	/**

--- a/includes/wikia/tests/WikiaDispatchableObjectTest.php
+++ b/includes/wikia/tests/WikiaDispatchableObjectTest.php
@@ -64,12 +64,14 @@ class WikiaDispatchableObjectTest extends WikiaBaseTest {
 	public function testGetNoCookieUrl( $methodName, $params, $format, $encodedParams ) {
 		$className = get_class( $this->dispatchableMock );
 		$mockCdnApiUrl = "api.nocookie.test-server";
-		$requestURI = "{$mockCdnApiUrl}/wikia.php?controller={$className}&method={$methodName}{$encodedParams}";
+		$scriptPath = "/test-path";
+		$requestURI = "{$mockCdnApiUrl}{$scriptPath}/wikia.php?controller={$className}&method={$methodName}{$encodedParams}";
 		if ( !empty( $format ) ) {
 			$requestURI .= '&format=' . $format;
 		}
 
 		$this->mockGlobalVariable( 'wgCdnApiUrl', $mockCdnApiUrl );
+		$this->mockGlobalVariable( 'wgScriptPath', $scriptPath );
 
 		$this->assertEquals( $requestURI, $className::getNoCookieUrl( $methodName, $params, $format ) );
 	}

--- a/resources/wikia/modules/nirvana.js
+++ b/resources/wikia/modules/nirvana.js
@@ -7,6 +7,18 @@
 	'use strict';
 
 	function nirvana($) {
+
+		/**
+		 * Get Nirvana API url
+		 * 
+		 * @param Object options
+		 *  controller - controller name
+		 *  method - method name
+		 *  format - (optional) responce format
+		 *  scriptPath - (optional) url protocol and location
+		 *  data - (optional) additional query string params
+		 * @returns {string}
+		 */
 		function getUrl( options ) {
 			var dataParams = options.data || {},
 				format = (options.format || 'json').toLowerCase(),

--- a/resources/wikia/modules/nirvana.js
+++ b/resources/wikia/modules/nirvana.js
@@ -7,10 +7,11 @@
 	'use strict';
 
 	function nirvana($) {
+		var allowedFormats = ['json', 'html', 'jsonp'];
 
 		/**
 		 * Get Nirvana API url
-		 * 
+		 *
 		 * @param Object options
 		 *  controller - controller name
 		 *  method - method name
@@ -68,7 +69,7 @@
 				url;
 
 
-			if( !(format === 'json' || format === 'html' || format === 'jsonp' ) ) {
+			if ( allowedFormats.indexOf( format ) === -1 ) {
 				throw 'Only Json,Jsonp and Html format are allowed';
 			}
 

--- a/resources/wikia/modules/nirvana.js
+++ b/resources/wikia/modules/nirvana.js
@@ -7,66 +7,70 @@
 	'use strict';
 
 	function nirvana($) {
+		function getUrl( options ) {
+			var dataParams = options.data || {},
+				format = (options.format || 'json').toLowerCase(),
+				i,
+				key,
+				sortedDict = {},
+				sortedKeys = [],
+				urlParams,
+				url = options.scriptPath || context.wgServer + context.wgScriptPath;
+
+			if ( ( typeof options.controller === 'undefined' ) || ( typeof options.method === 'undefined' ) ) {
+				throw 'controller and method are required';
+			}
+
+			urlParams = {
+				controller: options.controller.replace( /Controller$/, '' ),
+				method: options.method
+			};
+
+			if (typeof dataParams === 'string') {
+				dataParams += '&format=' + format;
+			} else {
+				dataParams.format = format;
+			}
+
+			// Sort params to avoid creating many urls on varnish
+			if ( typeof dataParams !== 'string' ) {
+				for( key in dataParams ) {
+					sortedKeys[sortedKeys.length] = key;
+				}
+				sortedKeys.sort();
+				for( i = 0; i < sortedKeys.length; i++ ) {
+					sortedDict[sortedKeys[i]] = dataParams[sortedKeys[i]];
+				}
+				dataParams = $.param( sortedDict );
+			}
+
+			return url + '/wikia.php?' + $.param( urlParams ) + '&' + dataParams;
+		}
 
 		function sendRequest(attr) {
 			var type = (attr.type || 'POST').toUpperCase(),
 				format = (attr.format || 'json').toLowerCase(),
-				data = attr.data || {},
+				data = {},
 				callback = attr.callback || function() {},
 				onErrorCallback = attr.onErrorCallback || function() {},
-				url,
-				getUrl;
+				url;
 
-			if((typeof attr.controller === 'undefined') || (typeof attr.method === 'undefined')) {
-				throw "controller and method are required";
-			}
 
 			if( !(format === 'json' || format === 'html' || format === 'jsonp' ) ) {
-				throw "Only Json,Jsonp and Html format are allowed";
+				throw 'Only Json,Jsonp and Html format are allowed';
 			}
 
-			url = attr.scriptPath || context.wgServer + context.wgScriptPath;
-
-			getUrl = {
-				//Iowa strips out POST parameters, Nirvana requires these to be set
-				//so we're passing them in the GET part of the request
-				controller: attr.controller.replace(/Controller$/, ''),
-				method: attr.method
-			};
-
-			if(type === 'POST') {
-				getUrl.format = format;
-			} else {
-				if(typeof data == 'string') {
-					data += '&format=' + format;
-				}else{
-					data.format = format;
-				}
+			if ( type === 'POST' && typeof attr.data !== 'undefined' ) {
+				data = attr.data;
+				delete attr.data;
 			}
-
-			// If data is a string just pass it directly along as is.  Otherwise
-			// sort the structured data so that the URL is consistant (for cache
-			// busting purposes)
-			var sortedDict;
-			if (typeof data == 'string') {
-				sortedDict = data;
-			} else {
-				var sortedKeys = [];
-				for(var key in data) {
-					sortedKeys[sortedKeys.length] = key;
-				}
-				sortedKeys.sort();
-				sortedDict = {};
-				for(var i = 0; i < sortedKeys.length; i++) {
-					sortedDict[sortedKeys[i]] = data[sortedKeys[i]];
-				}
-			}
+			url = getUrl( attr );
 
 			return $.ajax({
-				url: url + '/wikia.php?' + $.param(getUrl), /* JSlint ignore */
+				url: url,
 				dataType: format,
 				type: type,
-				data: sortedDict,
+				data: data,
 				success: callback,
 				error: onErrorCallback
 			});
@@ -74,8 +78,9 @@
 
 		return {
 			sendRequest: sendRequest,
+			getUrl: getUrl,
 			getJson: function(controller, method, data, callback, onErrorCallback) {
-				if(typeof data == 'function') {
+				if(typeof data === 'function') {
 					// callback is in data slot, shift parameters
 					onErrorCallback = callback;
 					callback = data;
@@ -91,7 +96,7 @@
 				});
 			},
 			postJson: function (controller, method, data, callback, onErrorCallback) {
-				if(typeof data == 'function') {
+				if(typeof data === 'function') {
 					// callback is in data slot, shift parameters
 					onErrorCallback = callback;
 					callback = data;

--- a/resources/wikia/modules/spec/nirvana.spec.js
+++ b/resources/wikia/modules/spec/nirvana.spec.js
@@ -15,7 +15,20 @@ describe("Nirvana", function () {
 		controllerName = 'foo',
 		methodName = 'bar',
 		origwgScriptPath,
-		origwgServer;
+		origwgServer,
+		jQueryParamMock = function(data){
+			var ret = '';
+
+			for(var key in data){
+				ret += key + '=' + data[key] + '&';
+			}
+
+			if (ret) {
+				ret = ret.slice(0, - 1);
+			}
+
+			return ret;
+		};
 
 	beforeEach(function(){
 		origwgScriptPath = window.wgScriptPath;
@@ -36,6 +49,7 @@ describe("Nirvana", function () {
 		expect(typeof nirvana.sendRequest).toBe('function');
 		expect(typeof nirvana.getJson).toBe('function');
 		expect(typeof nirvana.postJson).toBe('function');
+		expect(typeof nirvana.getUrl).toBe('function');
 	});
 
 	it('has jQuery API', function() {
@@ -43,6 +57,7 @@ describe("Nirvana", function () {
 		expect(typeof $.nirvana.sendRequest).toBe('function' ,'sendRequest');
 		expect(typeof $.nirvana.getJson).toBe('function', 'getJson');
 		expect(typeof $.nirvana.postJson).toBe('function', 'postJson');
+		expect(typeof $.nirvana.getUrl).toBe('function', 'getUrl');
 	});
 
 	it('controller name is required', function() {
@@ -72,7 +87,7 @@ describe("Nirvana", function () {
 	async.it('sendRequest uses POST and JSON by default', function(done) {
 		var jQuery = {
 				ajax: function(params) {
-					expect(params.url).toBe('/wikia.php?controller=foo&method=bar&format=json&');
+					expect(params.url).toBe('/wikia.php?controller=foo&method=bar&format=json');
 					expect(params.dataType).toBe('json'); // default format
 					expect(params.type).toBe('POST'); // default request method
 					expect(typeof params.data).toBe('object');
@@ -81,15 +96,7 @@ describe("Nirvana", function () {
 					// fire callback
 					params.success({res: true});
 				},
-				param: function(data){
-					var ret = '';
-
-					for(var key in data){
-						ret += key + '=' + data[key] + '&';
-					}
-
-					return ret;
-				}
+				param: jQueryParamMock
 			},
 			nirvana = modules['wikia.nirvana'](jQuery);
 
@@ -116,15 +123,7 @@ describe("Nirvana", function () {
 					// fire error callback
 					params.error();
 				},
-				param: function(data){
-					var ret = '';
-
-					for(var key in data){
-						ret += key + '=' + data[key] + '&';
-					}
-
-					return ret;
-				}
+				param: jQueryParamMock
 			},
 			nirvana = modules['wikia.nirvana'](jQuery);
 
@@ -140,24 +139,14 @@ describe("Nirvana", function () {
 	async.it('getJson uses GET and JSON', function(done) {
 		var jQuery = {
 				ajax: function(params) {
-					expect(params.url).toBe('/wikia.php?controller=foo&method=bar&');
+					expect(params.url).toBe('/wikia.php?controller=foo&method=bar&format=json&userName=Wikia');
 					expect(params.dataType).toBe('json');
 					expect(params.type).toBe('GET');
-					expect(typeof params.data).toBe('object');
-					expect(params.data.userName).toBe('Wikia');
 
 					// fire callback
 					params.success({res: true});
 				},
-				param: function(data){
-					var ret = '';
-
-					for(var key in data){
-						ret += key + '=' + data[key] + '&';
-					}
-
-					return ret;
-				}
+				param: jQueryParamMock
 			},
 			nirvana = modules['wikia.nirvana'](jQuery);
 
@@ -179,7 +168,7 @@ describe("Nirvana", function () {
 	async.it('postJson uses POST and JSON', function(done) {
 		var jQuery = {
 				ajax:  function(params) {
-					expect(params.url).toBe('/wikia.php?controller=foo&method=bar&format=json&');
+					expect(params.url).toBe('/wikia.php?controller=foo&method=bar&format=json');
 					expect(params.dataType).toBe('json');
 					expect(params.type).toBe('POST');
 					expect(typeof params.data).toBe('object');
@@ -188,15 +177,7 @@ describe("Nirvana", function () {
 					// fire callback
 					params.success({res: true});
 				},
-				param: function(data){
-					var ret = '';
-
-					for(var key in data){
-						ret += key + '=' + data[key] + '&';
-					}
-
-					return ret;
-				}
+				param: jQueryParamMock
 			},
 			nirvana = modules['wikia.nirvana'](jQuery);
 
@@ -219,20 +200,14 @@ describe("Nirvana", function () {
 		// mock the request
 		var jQuery = {
 				ajax: function(params) {
-					expect(JSON.stringify(params.data)).toBe('{"abc":"xyz","format":"json","userName":"Wikia","value":"1"}');
+					expect(params.url)
+						.toBe('/wikia.php?controller=foo&method=bar&abc=xyz&format=json&userName=Wikia&value=1');
+					expect(typeof params.data).toBe('object');
 
 					// fire callback
 					params.success();
 				},
-				param: function(data){
-					var ret = '';
-
-					for(var key in data){
-						ret += key + '=' + data[key] + '&';
-					}
-
-					return ret;
-				}
+				param: jQueryParamMock
 			},
 			nirvana = modules['wikia.nirvana'](jQuery);
 
@@ -255,20 +230,12 @@ describe("Nirvana", function () {
 		var urlParams = 'value=1&abc=xyz',
 			jQuery = {
 				ajax: function(params) {
-					expect(params.data).toBe(urlParams + '&format=json');
+					expect(params.url).toBe( '/wikia.php?controller=foo&method=bar&' + urlParams + '&format=json');
 
 					// fire callback
 					params.success();
 				},
-				param: function(data){
-					var ret = '';
-
-					for(var key in data){
-						ret += key + '=' + data[key] + '&';
-					}
-
-					return ret;
-				}
+				param: jQueryParamMock
 			},
 			nirvana = modules['wikia.nirvana'](jQuery);
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CON-1296

New variable was introduced on frontend and in PHP: 

```
window.wgCdnApiUrl and $wgCdnApiUrl
```

Api url on cookieless domain is stored there. For production current value is: 

```
http://api.wikia.nocookie.net/__cb{cacheBuste value}
```

In addition PHP methods for getting API urls were updated:
- `ControllerName::getUrl( $method, $params = null, $format = null )` stays without changes - this is alias for `ControllerName::getFullUrl( $method, $params = null, $format = null )`
- `ControllerName::getFullUrl( $method, $params = null, $format = null )` - returns full URL for API method on current wiki
- `ControllerName::getLocalUrl( $method, $params = null, $format = null )` - returns local URL for API method 
- `ControllerName::getNoCookieUrl( $method, $params = null, $format = null )` - returns URL for API method using cookieless domain

Similar work was done on frontend. From now `$.nirvana.sendRequest()` uses `$.nirvana.getUrl()` for URL calculation.

```
        /**
         * Get Nirvana API url
         *
         * @param Object options
         *  controller - controller name
         *  method - method name
         *  format - (optional) responce format
         *  scriptPath - (optional) url protocol and location
         *  data - (optional) additional query string params
         * @returns {string}
         */
        function getUrl( options )
```

**Don't merge without https://github.com/Wikia/config/pull/512.**
