### PR TITLE
Added the MinimalMainPage extension which removes a large portion of the...

### DIFF
--- a/extensions/wikia/MinimalMainPage/MinimalMainPage.i18n.php
+++ b/extensions/wikia/MinimalMainPage/MinimalMainPage.i18n.php
@@ -1,0 +1,16 @@
+<?php
+/**
+* Internationalisation file for MinimalMainPage extension.
+*
+* @addtogroup Languages
+*/
+
+$messages = array();
+
+$messages['en'] = array(
+	'minimalmainpage-desc' => 'The Minimal Main Page extension removes much of the default Wikia skin found on a Main Page. This can be used to allow more room for special-purpose wikis to have a very-custom promotional homepage.',
+);
+
+$messages['qqq'] = array(
+	'minimalmainpage-desc' => 'Description of the extension for Special:Version.',
+);

--- a/extensions/wikia/MinimalMainPage/MinimalMainPage.setup.php
+++ b/extensions/wikia/MinimalMainPage/MinimalMainPage.setup.php
@@ -7,7 +7,7 @@
  */
 
 $wgExtensionCredits['other'][] = array(
-	'name'   => 'Minimal Main Page',
+	'name' => 'Minimal Main Page',
 	'author' => array( '[http://www.seancolombo.com/ Sean Colombo]' ),
 	'descriptionmsg' => 'minimalmainpage-desc',
 	'version' => '1.0'
@@ -16,7 +16,7 @@ $wgExtensionCredits['other'][] = array(
 $dir = dirname(__FILE__) . '/';
 
 // MinimalMainPage shared classes
-$wgAutoloadClasses['MinimalMainPageHooks']         =  $dir . 'MinimalMainPageHooks.class.php';
+$wgAutoloadClasses['MinimalMainPageHooks'] =  $dir . 'MinimalMainPageHooks.class.php';
 
 // i18n mapping
 $wgExtensionMessagesFiles['MinimalMainPage'] = $dir.'MinimalMainPage.i18n.php';

--- a/extensions/wikia/MinimalMainPage/MinimalMainPage.setup.php
+++ b/extensions/wikia/MinimalMainPage/MinimalMainPage.setup.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * MinimalMainPage
+ * @author Sean Colombo - derived from VideoPageTool by:
+ * @author Garth Webb, Kenneth Kouot, Liz Lee, Saipetch Kongkatong
+ */
+
+$wgExtensionCredits['other'][] = array(
+	'name'   => 'Minimal Main Page',
+	'author' => array( '[http://www.seancolombo.com/ Sean Colombo]' ),
+	'descriptionmsg' => 'minimalmainpage-desc',
+	'version' => '1.0'
+);
+
+$dir = dirname(__FILE__) . '/';
+
+// MinimalMainPage shared classes
+$wgAutoloadClasses['MinimalMainPageHooks']         =  $dir . 'MinimalMainPageHooks.class.php';
+
+// i18n mapping
+$wgExtensionMessagesFiles['MinimalMainPage'] = $dir.'MinimalMainPage.i18n.php';
+
+// hooks
+$wgHooks['ArticleFromTitle'][] = 'MinimalMainPageHooks::onArticleFromTitle';

--- a/extensions/wikia/MinimalMainPage/MinimalMainPageHooks.class.php
+++ b/extensions/wikia/MinimalMainPage/MinimalMainPageHooks.class.php
@@ -8,7 +8,7 @@ class MinimalMainPageHooks {
 	 * @return boolean
 	 */
 	public static function onArticleFromTitle( &$title, &$article ) {
-		wfProfileIn(__METHOD__);
+		wfProfileIn( __METHOD__ );
 		$app = F::app();
 
 		if ( $title->isMainPage() && $app->checkSkin( 'oasis' ) ) {
@@ -19,13 +19,13 @@ class MinimalMainPageHooks {
 			$app->wg->SuppressArticleCategories = true;
 			
 			// If configured, also hide the ads.
-			if(!empty($app->wg->MinimalMain_hideAds)){
+			if( !empty( $app->wg->MinimalMainPageHideAds ) ){
 				$app->wg->SuppressAds = true;
 				$app->wg->ShowAds = false;
 			}
 		}
 
-		wfProfileOut(__METHOD__);
+		wfProfileOut( __METHOD__ );
 		return true;
 	}
 }

--- a/extensions/wikia/MinimalMainPage/MinimalMainPageHooks.class.php
+++ b/extensions/wikia/MinimalMainPage/MinimalMainPageHooks.class.php
@@ -21,6 +21,7 @@ class MinimalMainPageHooks {
 			// If configured, also hide the ads.
 			if(!empty($app->wg->MinimalMain_hideAds)){
 				$app->wg->SuppressAds = true;
+				$app->wg->ShowAds = false;
 			}
 		}
 

--- a/extensions/wikia/MinimalMainPage/MinimalMainPageHooks.class.php
+++ b/extensions/wikia/MinimalMainPage/MinimalMainPageHooks.class.php
@@ -1,0 +1,30 @@
+<?php
+
+class MinimalMainPageHooks {
+
+	/**
+	 * @param Title $title
+	 * @param Article $article
+	 * @return boolean
+	 */
+	public static function onArticleFromTitle( &$title, &$article ) {
+		wfProfileIn(__METHOD__);
+		$app = F::app();
+
+		if ( $title->isMainPage() && $app->checkSkin( 'oasis' ) ) {
+			$app->wg->SuppressPageHeader = true;
+			$app->wg->SuppressWikiHeader = true;
+			$app->wg->SuppressRail = true;
+			$app->wg->SuppressFooter = true;
+			$app->wg->SuppressArticleCategories = true;
+			
+			// If configured, also hide the ads.
+			if(!empty($app->wg->MinimalMain_hideAds)){
+				$app->wg->SuppressAds = true;
+			}
+		}
+
+		wfProfileOut(__METHOD__);
+		return true;
+	}
+}


### PR DESCRIPTION
... main page chrome in order to allow more space on promotional wikis. This is designed for use mainly by wikis that Wikia creates to promote Wikia functionality. It will soon be toggleable by the wgEnableMinimalMainExt Wikifactory variable. Ads can be suppressed on the MinimalMainPage by setting wgMinimalMain_hideAds to true in Wikifactory.
