### PR TITLE
Wikia.InstantGlobals doesn't supply the proper Last-Modified header

### DIFF
--- a/extensions/wikia/InstantGlobals/InstantGlobalsModule.class.php
+++ b/extensions/wikia/InstantGlobals/InstantGlobalsModule.class.php
@@ -52,6 +52,15 @@ class InstantGlobalsModule extends ResourceLoaderModule {
 	}
 
 	/**
+	 * InstantGlobals module needs to be revalidated every time the CDN cache expires
+	 *
+	 * @return int
+	 */
+	public function getModifiedTime() {
+		return time();
+	}
+
+	/**
 	 * @return bool
 	 */
 	public function supportsURLLoading() {


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-298

Emit `Last-Modified` response header with the current timestamp. It will cause CDN to update the cache entry on every miss.

@gabrys / @Wikia/platform-team 
