### PR TITLE
VE-1287: Fix for context menu not being shown. There are not $shields an...

### DIFF
--- a/extensions/VisualEditor/lib/ve/modules/ve/ui/ve.ui.DesktopContext.js
+++ b/extensions/VisualEditor/lib/ve/modules/ve/ui/ve.ui.DesktopContext.js
@@ -515,12 +515,11 @@ ve.ui.DesktopContext.prototype.hide = function () {
  */
 ve.ui.DesktopContext.prototype.shouldBeEmbedded = function ( focusedNode ) {
 	var targetHeight = this.$menu.outerHeight() * 2,
-		targetWidth = this.$menu.outerWidth() * 2;
-
-	return (
-		targetHeight < Math.max( focusedNode.$focusable.outerHeight(), focusedNode.$shields.height() ) &&
-		targetWidth < Math.max( focusedNode.$focusable.outerWidth(),  focusedNode.$shields.width() )
-	);
+		targetWidth = this.$menu.outerWidth() * 2,
+		// Name of this method (getDimensions) is pretty unfortunate - it actually returns
+		// dimensions of highlights and not node itself.
+		dimensions = focusedNode.getDimensions();
+	return ( targetHeight < dimensions.height  && targetWidth < dimensions.width );
 };
 
 /**

--- a/extensions/VisualEditor/lib/ve/modules/ve/ui/ve.ui.DesktopContext.js
+++ b/extensions/VisualEditor/lib/ve/modules/ve/ui/ve.ui.DesktopContext.js
@@ -514,8 +514,9 @@ ve.ui.DesktopContext.prototype.hide = function () {
  * @return {boolean} Should the context menu be embedded
  */
 ve.ui.DesktopContext.prototype.shouldBeEmbedded = function ( focusedNode ) {
+	// FIXME: This calculation should be reconsidered.
 	var targetHeight = this.$menu.outerHeight() * 2,
-		targetWidth = this.$menu.outerWidth() * 2,
+		targetWidth = this.$menu.outerWidth() * 1.25,
 		// Name of this method (getDimensions) is pretty unfortunate - it actually returns
 		// dimensions of highlights and not node itself.
 		dimensions = focusedNode.getDimensions();


### PR DESCRIPTION
...ymore, there are $highlights, however they work different than $shields used to. Fortunatelly there is a method getDimensions which we can use here, instead of measuring with jQuery .width() and .height()
