### PR TITLE
VOLDEV-73: Allow normal users to view message wall greetings

### DIFF
--- a/extensions/wikia/Wall/WallHooksHelper.class.php
+++ b/extensions/wikia/Wall/WallHooksHelper.class.php
@@ -1426,7 +1426,7 @@ class WallHooksHelper {
 
 			$wm = new WallMessage( $title );
 
-			if( $user->isAllowed('walledit') || $wm->isWallOwner( $user ) ) {
+			if( $user->isAllowed('walledit') || $wm->isWallOwner( $user ) || $action === 'read' || $action === 'history' ) {
 				$result = null;
 				return true;
 			} else {


### PR DESCRIPTION
Previously, it was impossible to view another user's Message Wall
Greeting unless you had the 'walledit' permission - this is obviously
not in the spirit of a wiki, as all pages should at least be viewable by
everyone. This change lets you do everything but edit another user's MWG
without 'walledit' :)

ping @Grunny 
