### PR TITLE
PLAT-75 Jobqueue migration for RefreshLinksJob and RefreshLinksJob2

### DIFF
--- a/includes/LinksUpdate.php
+++ b/includes/LinksUpdate.php
@@ -293,12 +293,12 @@ class LinksUpdate {
 					'start' => $start,
 					'end' => $end,
 				);
-				$jobs[] = new RefreshLinksJob2( $this->mTitle, $params );
+				$legacyJobs[] = new RefreshLinksJob2( $this->mTitle, $params );
 			}
 		}
 
 		if ( !empty( $legacyJobs ) ) {
-			Job::batchInsert( $jobs );
+			Job::batchInsert( $legacyJobs );
 		}
 
 	}

--- a/includes/LinksUpdate.php
+++ b/includes/LinksUpdate.php
@@ -283,10 +283,10 @@ class LinksUpdate {
 			list( $start, $end ) = $batch;
 			if ( TaskRunner::isModern( 'RefreshLinksJob' ) ) {
 				global $wgCityId;
-				$task = new BatchRefreshLinksForTemplate( $start, $end );
+				$task = new BatchRefreshLinksForTemplate();
 				$task->title( $this->mTitle );
 				$task->wikiId( $wgCityId );
-				$task->call( 'refreshTemplateLinks' );
+				$task->call( 'refreshTemplateLinks', $start, $end );
 				$task->queue();
 			} else {
 				$params = array(

--- a/includes/LinksUpdate.php
+++ b/includes/LinksUpdate.php
@@ -19,6 +19,9 @@
  *
  * @todo document (e.g. one-sentence top-level class description).
  */
+
+use Wikia\Tasks\Tasks\BatchRefreshLinksForTemplate;
+
 class LinksUpdate {
 
 	/**@{{

--- a/includes/LinksUpdate.php
+++ b/includes/LinksUpdate.php
@@ -282,8 +282,10 @@ class LinksUpdate {
 		foreach ( $batches as $batch ) {
 			list( $start, $end ) = $batch;
 			if ( TaskRunner::isModern( 'RefreshLinksJob' ) ) {
+				global $wgCityId;
 				$task = new BatchRefreshLinksForTemplate( $start, $end );
 				$task->title( $this->mTitle );
+				$task->wikiId( $wgCityId );
 				$task->call( 'refreshTemplateLinks' );
 				$task->queue();
 			} else {

--- a/includes/Title.php
+++ b/includes/Title.php
@@ -4624,6 +4624,21 @@ class Title {
 	}
 
 	/**
+	 * Get the backlinks for a given table. Cached in process memory only.
+	 *
+	 * This is a local wrapper around the local BacklinkCache instance to prevent
+	 * reaching from other objects, through the title, to the BacklinkCache.
+	 *
+	 * @param $table String
+	 * @param $startId Integer or false
+	 * @param $endId Integer or false
+	 * @return TitleArrayFromResult
+	 */
+	public function getLinksFromBacklinkCache( $table, $start, $end ) {
+		return $this->getBacklinkCache()->getLinks( $table, $start, $end );
+	}
+
+	/**
 	 * Whether the magic words __INDEX__ and __NOINDEX__ function for  this page.
 	 *
 	 * @return Boolean

--- a/includes/wikia/tasks/TaskRunner.class.php
+++ b/includes/wikia/tasks/TaskRunner.class.php
@@ -99,6 +99,7 @@ class TaskRunner {
 			'CreatePdfThumbnailsJob',
 //		'CreateWikiLocalJob',
 			'HAWelcomeJob',
+			'RefreshLinksJob',
 			'HTMLCacheUpdate',
 			'ImageReviewTask',
 			'MultiDeleteTask',

--- a/includes/wikia/tasks/Tasks/BaseTask.class.php
+++ b/includes/wikia/tasks/Tasks/BaseTask.class.php
@@ -242,6 +242,17 @@ abstract class BaseTask {
 	}
 
 	/**
+	 * Explicitly set the \Title object on this task. This should not be used pre-enqueue and is primarily
+	 * for testing task objects.
+	 *
+	 * @param \Title $title
+	 */
+	public function setTitle(\Title $title) {
+		$this->title = $title;
+		return $this;
+	}
+
+	/**
 	 * @param $taskId
 	 * @return $this
 	 */

--- a/includes/wikia/tasks/Tasks/BaseTask.class.php
+++ b/includes/wikia/tasks/Tasks/BaseTask.class.php
@@ -284,6 +284,13 @@ abstract class BaseTask {
 	}
 
 	/**
+	 * @return int
+	 */
+	public function getWikiId() {
+		return $this->wikiId;
+	}
+
+	/**
 	 * get a list of all task methods this class can execute via Special:Tasks
 	 *
 	 * @return array

--- a/includes/wikia/tasks/Tasks/BatchRefreshLinksForTemplate.class.php
+++ b/includes/wikia/tasks/Tasks/BatchRefreshLinksForTemplate.class.php
@@ -48,11 +48,6 @@ class BatchRefreshLinksForTemplate extends BaseTask {
 	 * @return bool true on success, false on failure
 	 */
 	public function isValidTask() {
-		if ( is_null( $this->title ) ) {
-			$this->error( "invalid task; undefined title" );
-			return false;
-		}
-
 		if ( !isset( $this->start ) || !isset( $this->end ) ) {
 			$this->error( "invalid task; start or end is undefined" );
 			return false;

--- a/includes/wikia/tasks/Tasks/BatchRefreshLinksForTemplate.class.php
+++ b/includes/wikia/tasks/Tasks/BatchRefreshLinksForTemplate.class.php
@@ -9,27 +9,15 @@ class BatchRefreshLinksForTemplate extends BaseTask {
 
 	const BACKLINK_CACHE_TABLE = 'templatelinks';
 
-	// Note: these instance variables need to remain protected to ensure that they
-	// will be serialized when the job is queued. @nmonterroso is planning on changing
-	// this behavior.
-
 	/** @var integer $start */
-	protected $start = null;
+	private $start = null;
 
 	/** @var integer $end */
-	protected $end   = null;
+	private $end   = null;
 
-	function __construct( $start=null, $end=null ) {
-		if (isset($start)) {
-			$this->start = $start;
-		}
+	public function refreshTemplateLinks( $start, $end ) {
+		$this->setStartAndEndBoundaries( $start, $end );
 
-		if (isset($end)) {
-			$this->end = $end;
-		}
-	}
-
-	public function refreshTemplateLinks() {
 		if ( !$this->isValidTask() ) {
 			return false;
 		}
@@ -40,6 +28,17 @@ class BatchRefreshLinksForTemplate extends BaseTask {
 		$this->enqueueRefreshLinksTasksForTitles( $titles );
 
 		return true;
+	}
+
+	/**
+	 * Set the start and end boundaries for the batch processing.
+	 *
+	 * @param int $start
+	 * @param int $end
+	 */
+	public function setStartAndEndBoundaries( $start, $end ) {
+		$this->start = $start;
+		$this->end   = $end;
 	}
 
 	/**
@@ -70,9 +69,9 @@ class BatchRefreshLinksForTemplate extends BaseTask {
 	}
 
 	public function enqueueRefreshLinksTasksForTitles( $titles ) {
-		$this->info( sprintf( "queueing %d RefreshLinksForTitleTasks", count($titles) ) );
+		$this->info( sprintf( "queueing %d RefreshLinksForTitleTasks", count( $titles ) ) );
 		foreach ( $titles as $title ) {
-			if ( is_null( $title) ) {
+			if ( is_null( $title ) ) {
 				$this->error( "empty BackLink title" );
 				continue;
 			}

--- a/includes/wikia/tasks/Tasks/BatchRefreshLinksForTemplate.class.php
+++ b/includes/wikia/tasks/Tasks/BatchRefreshLinksForTemplate.class.php
@@ -72,6 +72,11 @@ class BatchRefreshLinksForTemplate extends BaseTask {
 	public function enqueueRefreshLinksTasksForTitles( $titles ) {
 		$this->info( sprintf( "queueing %d RefreshLinksForTitleTasks", count($titles) ) );
 		foreach ( $titles as $title ) {
+			if ( is_null( $title) ) {
+				$this->error( "empty BackLink title" );
+				continue;
+			}
+
 			$this->enqueueRefreshLinksForTitleTask( $title );
 		}
 	}
@@ -80,9 +85,10 @@ class BatchRefreshLinksForTemplate extends BaseTask {
 		$task = new RefreshLinksForTitleTask();
 		$task->title( $title );
 		$task->call( 'refresh' );
-		$task->queue();
+		$task->wikiId( $this->getWikiId() );
+		$taskId = $task->queue();
+		$this->info( sprintf( "queued taskid %s for title '%s'", $taskId, $title->getText() ) );
 	}
-
 
 	public function getStart() {
 		return $this->start;

--- a/includes/wikia/tasks/Tasks/BatchRefreshLinksForTemplate.class.php
+++ b/includes/wikia/tasks/Tasks/BatchRefreshLinksForTemplate.class.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Replacement task for the core RefreshLinksJob.
+ */
+
+namespace Wikia\Tasks\Tasks;
+
+class BatchRefreshLinksForTemplate extends BaseTask {
+
+	const BACKLINK_CACHE_TABLE = 'templatelinks';
+
+	// Note: these instance variables need to remain protected to ensure that they
+	// will be serialized when the job is queued. @nmonterroso is planning on changing
+	// this behavior.
+
+	/** @var integer $start */
+	protected $start = null;
+
+	/** @var integer $end */
+	protected $end   = null;
+
+	function __construct( $start, $end ) {
+		$this->start = $start;
+		$this->end   = $end;
+	}
+
+	public function refreshTemplateLinks() {
+		if ( !$this->isValidTask() ) {
+			return false;
+		}
+
+		$this->clearLinkCache();
+
+		$titles = $this->getTitlesWithBackLinks( $start, $end );
+		$this->enqueueRefreshLinksTasksForTitles( $titles );
+
+		return true;
+	}
+
+	/**
+	 * Is the task valid?
+	 *
+	 * @return bool true on success, false on failure
+	 */
+	public function isValidTask() {
+		if ( is_null( $this->title ) ) {
+			$this->error( "invalid task; undefined title" );
+			return false;
+		}
+
+		if ( !isset( $this->start ) || !isset( $this->end ) ) {
+			$this->error( "invalid task; start or end is undefined" );
+			return false;
+		}
+
+		return true;
+	}
+
+	protected function clearLinkCache() {
+		LinkCache::singleton()->clear();
+	}
+
+	public function getTitlesWithBackLinks() {
+		return $this->title->getLinksFromBacklinkCache( self::BACKLINK_CACHE_TABLE, $this->start, $this->end );
+	}
+
+	public function enqueueRefreshLinksTasksForTitles( array $titles ) {
+		foreach ( $titles as $title ) {
+			$this->enqueueRefreshLinksForTitleTask( $title );
+		}
+	}
+
+	public function enqueueRefreshLinksForTitleTask( \Title $title ) {
+			$task = new RefreshLinksForTitleTask();
+			$task->title( $title );
+			$task->call( 'refresh' );
+			$task->queue();
+	}
+
+
+	public function getStart() {
+		return $this->start;
+	}
+
+	public function getEnd() {
+		return $this->end;
+	}
+
+}

--- a/includes/wikia/tasks/Tasks/RefreshLinksForTitleTask.class.php
+++ b/includes/wikia/tasks/Tasks/RefreshLinksForTitleTask.class.php
@@ -28,11 +28,6 @@ class RefreshLinksForTitleTask extends BaseTask {
 		return \Revision::newFromTitle( $this->title );
 	}
 
-	public function setTitle( \Title $title ) {
-		$this->title = $title;
-		return $this;
-	}
-
 	public function parseRevisionAndUpdateLinks( \Revision $revision ) {
 		$this->info( sprintf( "parsing revision and updating links for revision %d", $revision->getId() ) );
 		$parserOutput = $this->parseRevisionText( $revision );

--- a/includes/wikia/tasks/Tasks/RefreshLinksForTitleTask.class.php
+++ b/includes/wikia/tasks/Tasks/RefreshLinksForTitleTask.class.php
@@ -7,7 +7,7 @@ namespace Wikia\Tasks\Tasks;
 
 class RefreshLinksForTitleTask extends BaseTask {
 
-	public function refresh( ) {
+	public function refresh() {
 		if ( is_null( $this->title ) ) {
 			return false;
 		}
@@ -21,11 +21,9 @@ class RefreshLinksForTitleTask extends BaseTask {
 		return true;
 	}
 
-
 	protected function getRevisionFromTitle() {
 		return Revision::newFromTitle( $this->title );
 	}
-
 
 	public function setTitle( \Title $title ) {
 		$this->title = $title;

--- a/includes/wikia/tasks/Tasks/RefreshLinksForTitleTask.class.php
+++ b/includes/wikia/tasks/Tasks/RefreshLinksForTitleTask.class.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Replacement task for the core RefreshLinksJob.
+ */
+
+namespace Wikia\Tasks\Tasks;
+
+class RefreshLinksForTitleTask extends BaseTask {
+
+	public function refresh( ) {
+		if ( is_null( $this->title ) ) {
+			return false;
+		}
+
+		$revision = $this->getRevisionFromTitle();
+		if ( !$revision ) {
+			return false;
+		}
+
+		$this->parseRevisionAndUpdateLinks( $revision );
+		return true;
+	}
+
+
+	protected function getRevisionFromTitle() {
+		return Revision::newFromTitle( $this->title );
+	}
+
+
+	public function setTitle(\Title $title) {
+		$this->title = $title;
+		return $this;
+	}
+
+	public function parseRevisionAndUpdateLinks( \Revision $revision ) {
+		$parserOutput = $this->parseRevisionText( $revision );
+		$this->updateLinks( $parserOutput );
+	}
+
+	public function updateLinks( $parserOutput ) {
+		$update = new \LinksUpdate( $this->title, $parserOutput, false );
+		$update->doUpdate();
+	}
+
+	protected function parseRevisionText( \Revision $revision ) {
+		$options = $this->getParserOptions();
+		return $this->getParser()->parse( $revision->getText(), $this->title, $options, true, true, $revision->getId() );
+	}
+
+	protected function getParserOptions() {
+		return ParserOptions::newFromUserAndLang( new \User, $this->getLanguage() );
+	}
+
+	protected function getParser() {
+		global $wgParser;
+		return $wgParser;
+	}
+
+	protected function getLanguage() {
+		global $wgContLang;
+		return $wgContLang;
+	}
+}

--- a/includes/wikia/tasks/Tasks/RefreshLinksForTitleTask.class.php
+++ b/includes/wikia/tasks/Tasks/RefreshLinksForTitleTask.class.php
@@ -27,7 +27,7 @@ class RefreshLinksForTitleTask extends BaseTask {
 	}
 
 
-	public function setTitle(\Title $title) {
+	public function setTitle( \Title $title ) {
 		$this->title = $title;
 		return $this;
 	}

--- a/includes/wikia/tasks/Tasks/RefreshLinksForTitleTask.class.php
+++ b/includes/wikia/tasks/Tasks/RefreshLinksForTitleTask.class.php
@@ -31,6 +31,7 @@ class RefreshLinksForTitleTask extends BaseTask {
 	}
 
 	public function parseRevisionAndUpdateLinks( \Revision $revision ) {
+		$this->info( sprintf( "parsing revision and updating links for revision %d", $revision->getId() ) );
 		$parserOutput = $this->parseRevisionText( $revision );
 		$this->updateLinks( $parserOutput );
 	}
@@ -57,5 +58,9 @@ class RefreshLinksForTitleTask extends BaseTask {
 	protected function getLanguage() {
 		global $wgContLang;
 		return $wgContLang;
+	}
+
+	protected function getLoggerContext() {
+		return ['task' => __CLASS__];
 	}
 }

--- a/includes/wikia/tasks/Tasks/RefreshLinksForTitleTask.class.php
+++ b/includes/wikia/tasks/Tasks/RefreshLinksForTitleTask.class.php
@@ -9,10 +9,6 @@ class RefreshLinksForTitleTask extends BaseTask {
 
 	public function refresh() {
 		$this->info( "refreshing links" );
-		if ( is_null( $this->title ) ) {
-			$this->error( "invalid RefreshLinksJob; no title" );
-			return false;
-		}
 
 		$revision = $this->getRevisionFromTitle();
 		if ( !$revision ) {

--- a/includes/wikia/tasks/Tasks/RefreshLinksForTitleTask.class.php
+++ b/includes/wikia/tasks/Tasks/RefreshLinksForTitleTask.class.php
@@ -16,7 +16,7 @@ class RefreshLinksForTitleTask extends BaseTask {
 
 		$revision = $this->getRevisionFromTitle();
 		if ( !$revision ) {
-			$this->error( "invalid RefreshLinksJob; no revision" );
+			$this->error( "invalid RefreshLinksJob; no article/revision" );
 			return false;
 		}
 

--- a/includes/wikia/tasks/Tasks/RefreshLinksForTitleTask.class.php
+++ b/includes/wikia/tasks/Tasks/RefreshLinksForTitleTask.class.php
@@ -8,12 +8,15 @@ namespace Wikia\Tasks\Tasks;
 class RefreshLinksForTitleTask extends BaseTask {
 
 	public function refresh() {
+		$this->info( "refreshing links" );
 		if ( is_null( $this->title ) ) {
+			$this->error( "invalid RefreshLinksJob; no title" );
 			return false;
 		}
 
 		$revision = $this->getRevisionFromTitle();
 		if ( !$revision ) {
+			$this->error( "invalid RefreshLinksJob; no revision" );
 			return false;
 		}
 
@@ -22,7 +25,7 @@ class RefreshLinksForTitleTask extends BaseTask {
 	}
 
 	protected function getRevisionFromTitle() {
-		return Revision::newFromTitle( $this->title );
+		return \Revision::newFromTitle( $this->title );
 	}
 
 	public function setTitle( \Title $title ) {
@@ -47,7 +50,7 @@ class RefreshLinksForTitleTask extends BaseTask {
 	}
 
 	protected function getParserOptions() {
-		return ParserOptions::newFromUserAndLang( new \User, $this->getLanguage() );
+		return \ParserOptions::newFromUserAndLang( new \User, $this->getLanguage() );
 	}
 
 	protected function getParser() {

--- a/includes/wikia/tests/BatchRefreshLinksForTemplateTest.php
+++ b/includes/wikia/tests/BatchRefreshLinksForTemplateTest.php
@@ -67,4 +67,35 @@ class BatchRefreshLinksForTemplateTest extends PHPUnit_Framework_TestCase {
 		$task->enqueueRefreshLinksTasksForTitles( $titles );
 	}
 
+	public function testRefreshTemplateLinks() {
+		$start = 1;
+		$end   = 2;
+		$titles = [$this->getMock( '\Title' )];
+		$task = $this->getMock( 'Wikia\Tasks\Tasks\BatchRefreshLinksForTemplate', [
+			'isValidTask',
+			'clearLinkCache',
+			'getTitlesWithBackLinks',
+			'enqueueRefreshLinksTasksForTitles'
+			], [$start, $end], '', true );
+
+		$task->expects($this->once())
+			->method('isValidTask')
+			->will($this->returnValue(true));
+
+		$task->expects($this->once())
+			->method('clearLinkCache')
+			->will($this->returnValue(true));
+
+		$task->expects($this->once())
+			->method('getTitlesWithBackLinks')
+			->will($this->returnValue($titles));
+
+		$task->expects($this->once())
+			->method('enqueueRefreshLinksTasksForTitles')
+			->with($titles)
+			->will($this->returnValue(true));
+
+		$task->refreshTemplateLinks();
+
+	}
 }

--- a/includes/wikia/tests/BatchRefreshLinksForTemplateTest.php
+++ b/includes/wikia/tests/BatchRefreshLinksForTemplateTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use Wikia\Tasks\Tasks\BatchRefreshLinksForTemplate;
+
+class BatchRefreshLinksForTemplateTest extends PHPUnit_Framework_TestCase {
+
+	public function testBatchRefreshLinksForTemplateSerialize() {
+		$start = 1;
+		$end   = 10;
+
+		$task = new BatchRefreshLinksForTemplate( $start, $end );
+		$serializedTask = serialize( $task );
+
+		$unserializedTask = unserialize( $serializedTask );
+		$this->assertEquals( $start, $unserializedTask->getStart() );
+		$this->assertEquals( $end, $unserializedTask->getEnd() );
+	}
+
+	public function testIsValidTask() {
+		$title = $this->getMock( '\Title' );
+		$start = 1;
+		$end   = 2;
+
+		$task = new BatchRefreshLinksForTemplate( null, null );
+		$this->assertFalse( $task->isValidTask() );
+
+		$task = new BatchRefreshLinksForTemplate( $start, $end );
+		$this->assertFalse( $task->isValidTask() );
+
+		$task = new BatchRefreshLinksForTemplate( $start, $end );
+		$task->setTitle( $title );
+		$this->assertTrue( $task->isValidTask() );
+	}
+
+	public function testGetTitlesWithBackLinks() {
+		$start = 1;
+		$end   = 10;
+		$result = array( 'foo' );
+
+		$task = new BatchRefreshLinksForTemplate( $start, $end );
+
+		$title = $this->getMock( '\Title', ['getLinksFromBacklinkCache'] );
+		$title->expects( $this->once() )
+			->method( 'getLinksFromBacklinkCache' )
+			->with( BatchRefreshLinksForTemplate::BACKLINK_CACHE_TABLE, $start, $end )
+			->will( $this->returnValue( $result ) );
+
+		$task->setTitle( $title );
+
+		$this->assertEquals( $result, $task->getTitlesWithBackLinks() );
+	}
+
+	public function testEnqueueRefreshLinksForTitles() {
+		$start = 1;
+		$end   = 2;
+		$task = $this->getMock( 'Wikia\Tasks\Tasks\BatchRefreshLinksForTemplate', ['enqueueRefreshLinksForTitleTask'], [$start, $end], '', true );
+		$times = 3;
+		$titles = array();
+		for ( $i = 0; $i < 3; $i++ ) {
+			$titles[] = $this->getMock( '\Title' );
+		}
+
+		$task->expects( $this->exactly( $times ) )
+			->method( 'enqueueRefreshLinksForTitleTask' )
+			->with( $this->logicalOr( $titles[0], $titles[2], $titles[3] ) );
+
+		$task->enqueueRefreshLinksTasksForTitles( $titles );
+	}
+
+}

--- a/includes/wikia/tests/BatchRefreshLinksForTemplateTest.php
+++ b/includes/wikia/tests/BatchRefreshLinksForTemplateTest.php
@@ -68,25 +68,24 @@ class BatchRefreshLinksForTemplateTest extends PHPUnit_Framework_TestCase {
 		$titles = [$title];
 		$task = $this->getMock( 'Wikia\Tasks\Tasks\BatchRefreshLinksForTemplate', [
 			'clearLinkCache',
-			//'getTitlesWithBackLinks',
 			'enqueueRefreshLinksTasksForTitles'
 			], [], '', false );
 
-		$title->expects($this->once())
-			->method('getLinksFromBacklinkCache')
-			->with(BatchRefreshLinksForTemplate::BACKLINK_CACHE_TABLE, $start, $end)
-			->will($this->returnValue($titles));
+		$title->expects( $this->once() )
+			->method( 'getLinksFromBacklinkCache' )
+			->with( BatchRefreshLinksForTemplate::BACKLINK_CACHE_TABLE, $start, $end )
+			->will( $this->returnValue( $titles ) );
 
-		$task->expects($this->once())
-			->method('clearLinkCache')
-			->will($this->returnValue(true));
+		$task->expects( $this->once() )
+			->method( 'clearLinkCache' )
+			->will( $this->returnValue( true ) );
 
-		$task->expects($this->once())
-			->method('enqueueRefreshLinksTasksForTitles')
-			->with($titles)
-			->will($this->returnValue(true));
+		$task->expects( $this->once() )
+			->method( 'enqueueRefreshLinksTasksForTitles' )
+			->with( $titles )
+			->will( $this->returnValue( true ) );
 
-		$task->setTitle($title);
+		$task->setTitle( $title );
 
 		$this->assertTrue( $task->refreshTemplateLinks( $start, $end ) );
 

--- a/includes/wikia/tests/BatchRefreshLinksForTemplateTest.php
+++ b/includes/wikia/tests/BatchRefreshLinksForTemplateTest.php
@@ -5,7 +5,6 @@ use Wikia\Tasks\Tasks\BatchRefreshLinksForTemplate;
 class BatchRefreshLinksForTemplateTest extends PHPUnit_Framework_TestCase {
 
 	public function testIsValidTask() {
-		$title = $this->getMock( '\Title' );
 		$start = 1;
 		$end   = 2;
 
@@ -15,11 +14,6 @@ class BatchRefreshLinksForTemplateTest extends PHPUnit_Framework_TestCase {
 
 		$task = new BatchRefreshLinksForTemplate();
 		$task->setStartAndEndBoundaries( $start, $start );
-		$this->assertFalse( $task->isValidTask() );
-
-		$task = new BatchRefreshLinksForTemplate();
-		$task->setStartAndEndBoundaries( $start, $start );
-		$task->setTitle( $title );
 		$this->assertTrue( $task->isValidTask() );
 	}
 

--- a/includes/wikia/tests/RefreshLinksForTitleTaskTest.php
+++ b/includes/wikia/tests/RefreshLinksForTitleTaskTest.php
@@ -1,0 +1,84 @@
+<?php
+
+use Wikia\Tasks\Tasks\RefreshLinksForTitleTask;
+
+class RefreshLinksForTitleTaskTest extends PHPUnit_Framework_TestCase {
+
+	public function testRefreshNoTitle() {
+		$task = new RefreshLinksForTitleTask();
+		$this->assertFalse( $task->refresh() );
+	}
+
+	public function testRefreshGetRevisionFromTitle() {
+		$task = $this->getMock( 'Wikia\Tasks\Tasks\RefreshLinksForTitleTask', ['getRevisionFromTitle'], [], '', false );
+		$title = $this->getMock( '\Title' );
+
+		$task->setTitle( $title );
+
+		$task->expects( $this->once() )
+			->method( 'getRevisionFromTitle' )
+			->will( $this->returnValue( null ) );
+
+		$this->assertFalse( $task->refresh() );
+	}
+
+	public function testRefreshCallsMocked() {
+		$task = $this->getMock( 'Wikia\Tasks\Tasks\RefreshLinksForTitleTask', ['getRevisionFromTitle', 'parseRevisionAndUpdateLinks'], [], '', false );
+		$title = $this->getMock( '\Title' );
+		$revision = $this->getMock( '\Revision', [], [], '', false );
+
+		$task->setTitle( $title );
+
+		$task->expects( $this->once() )
+			->method( 'getRevisionFromTitle' )
+			->will( $this->returnValue( $revision ) );
+
+		$task->expects( $this->once() )
+			->method( 'parseRevisionAndUpdateLinks' )
+			->with( $revision )
+			->will( $this->returnValue( true ) );
+
+		$this->assertTrue( $task->refresh() );
+	}
+
+	public function testParseRevisionAndUpdateLinks() {
+		$task = $this->getMock( 'Wikia\Tasks\Tasks\RefreshLinksForTitleTask', ['getParserOptions', 'getParser', 'updateLinks'], [], '', false );
+		$title = $this->getMock( '\Title' );
+		$parser = $this->getMock( '\Parser' );
+		$parserOptions = $this->getMock( '\ParserOptions', [], [], '', false );
+		$revision = $this->getMock( '\Revision', [], [], '', false );
+
+		$revisionText = 'foobar-in';
+		$revisionId = 1;
+		$revision->expects( $this->once() )
+			->method( 'getText' )
+			->will( $this->returnValue( $revisionText ) );
+		$revision->expects($this->once())
+			->method('getId')
+			->will($this->returnValue($revisionId));
+
+		$parserOutput = 'foobar';
+		$parser->expects( $this->once() )
+			->method( 'parse' )
+			->with( $revisionText, $title, $parserOptions, true, true, $revisionId )
+			->will( $this->returnValue( $parserOutput ) );
+
+		$task->expects( $this->once() )
+			->method( 'getParser' )
+			->will( $this->returnValue( $parser ) );
+
+		$task->expects($this->once())
+			->method('getParserOptions')
+			->will($this->returnValue($parserOptions));
+
+		$task->expects($this->once())
+			->method('updateLinks')
+			->with($parserOutput);
+
+		$task->setTitle( $title );
+
+		$task->parseRevisionAndUpdateLinks( $revision );
+	}
+
+
+}

--- a/includes/wikia/tests/RefreshLinksForTitleTaskTest.php
+++ b/includes/wikia/tests/RefreshLinksForTitleTaskTest.php
@@ -53,9 +53,9 @@ class RefreshLinksForTitleTaskTest extends PHPUnit_Framework_TestCase {
 		$revision->expects( $this->once() )
 			->method( 'getText' )
 			->will( $this->returnValue( $revisionText ) );
-		$revision->expects($this->once())
-			->method('getId')
-			->will($this->returnValue($revisionId));
+		$revision->expects( $this->once() )
+			->method( 'getId' )
+			->will( $this->returnValue( $revisionId ) );
 
 		$parserOutput = 'foobar';
 		$parser->expects( $this->once() )
@@ -67,13 +67,13 @@ class RefreshLinksForTitleTaskTest extends PHPUnit_Framework_TestCase {
 			->method( 'getParser' )
 			->will( $this->returnValue( $parser ) );
 
-		$task->expects($this->once())
-			->method('getParserOptions')
-			->will($this->returnValue($parserOptions));
+		$task->expects( $this->once() )
+			->method( 'getParserOptions' )
+			->will( $this->returnValue( $parserOptions ) );
 
-		$task->expects($this->once())
-			->method('updateLinks')
-			->with($parserOutput);
+		$task->expects( $this->once() )
+			->method( 'updateLinks' )
+			->with( $parserOutput );
 
 		$task->setTitle( $title );
 

--- a/includes/wikia/tests/RefreshLinksForTitleTaskTest.php
+++ b/includes/wikia/tests/RefreshLinksForTitleTaskTest.php
@@ -53,7 +53,7 @@ class RefreshLinksForTitleTaskTest extends PHPUnit_Framework_TestCase {
 		$revision->expects( $this->once() )
 			->method( 'getText' )
 			->will( $this->returnValue( $revisionText ) );
-		$revision->expects( $this->once() )
+		$revision->expects( $this->exactly( 2 ) )
 			->method( 'getId' )
 			->will( $this->returnValue( $revisionId ) );
 

--- a/includes/wikia/tests/RefreshLinksForTitleTaskTest.php
+++ b/includes/wikia/tests/RefreshLinksForTitleTaskTest.php
@@ -4,11 +4,6 @@ use Wikia\Tasks\Tasks\RefreshLinksForTitleTask;
 
 class RefreshLinksForTitleTaskTest extends PHPUnit_Framework_TestCase {
 
-	public function testRefreshNoTitle() {
-		$task = new RefreshLinksForTitleTask();
-		$this->assertFalse( $task->refresh() );
-	}
-
 	public function testRefreshGetRevisionFromTitle() {
 		$task = $this->getMock( 'Wikia\Tasks\Tasks\RefreshLinksForTitleTask', ['getRevisionFromTitle'], [], '', false );
 		$title = $this->getMock( '\Title' );


### PR DESCRIPTION
This job migration was two in one. The original `RefreshLinksJob2` was created which then launched one `RefreshLinkJob` for every back link to the template retrieved in `LinksUpdate`.

This pull request migrates `RefreshLinksJob` to a task with the name `RefreshLinksForTitleTask` and migrates `RefreshLinksJob2` to `BatchRefreshLinksForTemplate`. The new naming I think better reflects what is happening with the tasks.

The new tasks also have some basic testing in place. The structure of the code was also cleaned up to be less verbose.

/cc @nmonterroso @Wikia/platform-team 
