### PR TITLE
VE-1312: Blur contentEditable node while destroying surface.

### DIFF
--- a/extensions/VisualEditor/lib/ve/modules/ve/ce/ve.ce.Surface.js
+++ b/extensions/VisualEditor/lib/ve/modules/ve/ce/ve.ce.Surface.js
@@ -239,12 +239,17 @@ ve.ce.Surface.static.getClipboardHash = function ( $elements ) {
  * @method
  */
 ve.ce.Surface.prototype.destroy = function () {
+	var documentNode = this.documentView.getDocumentNode();
+
 	// Detach observer and event sequencer
 	this.surfaceObserver.detach();
 	this.eventSequencer.detach();
 
 	// Make document node not live
-	this.documentView.getDocumentNode().setLive( false );
+	documentNode.setLive( false );
+
+	// Blur to make selection/cursor disappear
+	documentNode.$element.blur();
 
 	// Disconnect events
 	this.surfaceObserver.disconnect( this );

--- a/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaMediaInsertDialog.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaMediaInsertDialog.js
@@ -436,7 +436,6 @@ ve.ui.WikiaMediaInsertDialog.prototype.onPageSet = function () {
  * @method
  * @param {string} action Which action is being performed on close.
  */
-<<<<<<< HEAD
 ve.ui.WikiaMediaInsertDialog.prototype.getTeardownProcess = function ( data ) {
 	return ve.ui.WikiaMediaInsertDialog.super.prototype.getTeardownProcess.call( this, data )
 		.first( function () {
@@ -447,18 +446,6 @@ ve.ui.WikiaMediaInsertDialog.prototype.getTeardownProcess = function ( data ) {
 			this.queryInput.setValue( '' );
 			this.dropTarget.teardown();
 		}, this );
-=======
-ve.ui.WikiaMediaInsertDialog.prototype.teardown = function ( action ) {
-	if ( action === 'insert' ) {
-		this.insertMedia( ve.copy( this.cartModel.getItems() ), this.fragment );
-	}
-	this.cartModel.clearItems();
-	this.queryInput.setValue( '' );
-	this.dropTarget.teardown();
-
-	// Parent method
-	ve.ui.WikiaMediaInsertDialog.super.prototype.teardown.call( this, action );
->>>>>>> VE-1261 Using super
 };
 
 /**


### PR DESCRIPTION
https://gerrit.wikimedia.org/r/#/c/144089/

This solves problem in FF - cursor remains being visible
after canceling edit and switching back to view mode.

Also a fix for accidently comited conflict.
