### PR TITLE
CON-1243 | Hacks to make staging more kosher

### DIFF
--- a/extensions/wikia/Staging/Staging.setup.php
+++ b/extensions/wikia/Staging/Staging.setup.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Code used to make staging environment more awesome!
+ *
+ * @author Damian Jóźwiak
+ */
+$dir = dirname(__FILE__) . '/';
+
+$wgExtensionCredits['other'][] = array(
+	'name' => 'StagingHooks',
+	'description' => '',
+	'authors' => array(
+		'Damian Jóźwiak',
+	),
+	'version' => 1.0
+);
+
+$wgAutoloadClasses['StagingHooks'] =  $dir . 'StagingHooks.class.php';
+
+$wgHooks['MakeGlobalVariablesScript'][] = 'StagingHooks::onMakeGlobalVariablesScript';

--- a/extensions/wikia/Staging/Staging.setup.php
+++ b/extensions/wikia/Staging/Staging.setup.php
@@ -18,3 +18,4 @@ $wgExtensionCredits['other'][] = array(
 $wgAutoloadClasses['StagingHooks'] =  $dir . 'StagingHooks.class.php';
 
 $wgHooks['MakeGlobalVariablesScript'][] = 'StagingHooks::onMakeGlobalVariablesScript';
+$wgHooks['BeforePageRedirect'][] = 'StagingHooks::onBeforePageRedirect';

--- a/extensions/wikia/Staging/StagingHooks.class.php
+++ b/extensions/wikia/Staging/StagingHooks.class.php
@@ -14,4 +14,23 @@ class StagingHooks {
 
 		return true;
 	}
+
+	/**
+	 * Rewrite redirects to preserve staging params
+	 *
+	 * @param $out
+	 * @param $redirect
+	 * @param $code
+	 * @return bool
+	 */
+	static public function onBeforePageRedirect( $out, &$redirect, &$code ) {
+		$stagingEnvName = explode( '.', $_SERVER['HTTP_HOST'])[0];
+		$stagingUrlPart = '://' . $stagingEnvName . '.';
+
+		if ( strpos( $redirect, 'wikia.com' ) !== false && strpos( $redirect, $stagingUrlPart ) === false ) {
+			$redirect = str_replace( '://', $stagingUrlPart, $redirect );
+		}
+
+		return true;
+	}
 }

--- a/extensions/wikia/Staging/StagingHooks.class.php
+++ b/extensions/wikia/Staging/StagingHooks.class.php
@@ -24,11 +24,13 @@ class StagingHooks {
 	 * @return bool
 	 */
 	static public function onBeforePageRedirect( $out, &$redirect, &$code ) {
-		$stagingEnvName = explode( '.', $_SERVER['HTTP_HOST'])[0];
-		$stagingUrlPart = '://' . $stagingEnvName . '.';
+		if ( !empty( $_SERVER['HTTP_X_STAGING'] ) ) {
+			$stagingEnvName = $_SERVER['HTTP_X_STAGING'];
+			$stagingUrlPart = '://' . $stagingEnvName . '.';
 
-		if ( strpos( $redirect, 'wikia.com' ) !== false && strpos( $redirect, $stagingUrlPart ) === false ) {
-			$redirect = str_replace( '://', $stagingUrlPart, $redirect );
+			if ( strpos( $redirect, 'wikia.com' ) !== false && strpos( $redirect, $stagingUrlPart ) === false ) {
+				$redirect = str_replace( '://', $stagingUrlPart, $redirect );
+			}
 		}
 
 		return true;

--- a/extensions/wikia/Staging/StagingHooks.class.php
+++ b/extensions/wikia/Staging/StagingHooks.class.php
@@ -1,0 +1,17 @@
+<?php
+
+class StagingHooks {
+	/**
+	* Register global JS variables bottom
+	*
+	* @param array $vars
+	*
+	* @return bool
+	*/
+	static public function onMakeGlobalVariablesScript( &$vars ) {
+		Wikia::addAssetsToOutput( 'extensions/wikia/Staging/js/Staging.js' );
+		$vars['wgStagingEnvironment'] = true;
+
+		return true;
+	}
+}

--- a/extensions/wikia/Staging/js/Staging.js
+++ b/extensions/wikia/Staging/js/Staging.js
@@ -1,17 +1,20 @@
 if ( window.wgStagingEnvironment ) {
-	(function(){
+	(function( document ){
 		'use strict';
 
 		var stagingEnvName = window.location.hostname.split( '.' )[0],
-			stagingURLPart = '://' + stagingEnvName + '.';
+			stagingURLPart = '://' + stagingEnvName + '.',
+			links = document.getElementsByTagName('a' ),
+			i = 0,
+			href;
 
-		$('a').each(function() {
-			var $this = $( this ),
-				href = $this.attr( 'href' );
+		for ( ; i < links.length; i++ ) {
+			href = links[i].getAttribute('href');
 
 			if ( href.indexOf( '://' ) > -1 && href.indexOf( 'wikia.com' ) > -1 && href.indexOf( stagingURLPart ) === -1 ) {
-				$this.attr( 'href', href.replace( '://', stagingURLPart ) );
+				links[i].setAttribute( 'href', href.replace( '://', stagingURLPart ) );
 			}
-		});
-	})();
+
+		}
+	})( document );
 }

--- a/extensions/wikia/Staging/js/Staging.js
+++ b/extensions/wikia/Staging/js/Staging.js
@@ -9,7 +9,7 @@ if ( window.wgStagingEnvironment ) {
 			var $this = $( this ),
 				href = $this.attr( 'href' );
 
-			if ( href.indexOf( '://' ) > -1 && href.indexOf( stagingURLPart ) === -1 ) {
+			if ( href.indexOf( '://' ) > -1 && href.indexOf( 'wikia.com' ) > -1 && href.indexOf( stagingURLPart ) === -1 ) {
 				$this.attr( 'href', href.replace( '://', stagingURLPart ) );
 			}
 		});

--- a/extensions/wikia/Staging/js/Staging.js
+++ b/extensions/wikia/Staging/js/Staging.js
@@ -2,14 +2,15 @@ if ( window.wgStagingEnvironment ) {
 	(function(){
 		'use strict';
 
-		var stagingEnvName = window.location.hostname.split( '.' )[0];
+		var stagingEnvName = window.location.hostname.split( '.' )[0],
+			stagingURLPart = '://' + stagingEnvName + '.';
 
 		$('a').each(function() {
 			var $this = $( this ),
 				href = $this.attr( 'href' );
 
-			if ( href.indexOf( '://' ) > -1 && href.indexOf( stagingEnvName ) === -1 ) {
-				$this.attr( 'href', href.replace( '://', '://' + stagingEnvName + '.' ) );
+			if ( href.indexOf( '://' ) > -1 && href.indexOf( stagingURLPart ) === -1 ) {
+				$this.attr( 'href', href.replace( '://', stagingURLPart ) );
 			}
 		});
 	})();

--- a/extensions/wikia/Staging/js/Staging.js
+++ b/extensions/wikia/Staging/js/Staging.js
@@ -1,0 +1,16 @@
+if ( window.wgStagingEnvironment ) {
+	(function(){
+		'use strict';
+
+		var stagingEnvName = window.location.hostname.split( '.' )[0];
+
+		$('a').each(function() {
+			var $this = $( this ),
+				href = $this.attr( 'href' );
+
+			if ( href.indexOf( '://' ) > -1 && href.indexOf( stagingEnvName ) === -1 ) {
+				$this.attr( 'href', href.replace( '://', '://' + stagingEnvName + '.' ) );
+			}
+		});
+	})();
+}


### PR DESCRIPTION
- Redirects points to staging env instead of production one
- all links are rewritten on DOMReady to use staging urls instead of production ones

Don't merge without https://github.com/Wikia/config/pull/546
