### PR TITLE
Http::request - get callers for ApiService::foreignCall and report to Logstash

### DIFF
--- a/includes/HttpFunctions.php
+++ b/includes/HttpFunctions.php
@@ -66,7 +66,7 @@ class Http {
 
 		// Wikia change - @author: mech - begin
 		// log all the requests we make (except valid Phalanx calls, as we have a lot of them)
-		$caller =  wfGetCallerClassMethod( [ __CLASS__, 'Hooks' ] );
+		$caller =  wfGetCallerClassMethod( [ __CLASS__, 'Hooks', 'ApiService' ] );
 		$isOk = $status->isOK();
 		if ( class_exists( 'Wikia\\Logger\\WikiaLogger' ) && ( !$isOk || false === strpos( $caller, 'Phalanx' ) ) ) {
 


### PR DESCRIPTION
@wladekb / @jcellary 

`ApiService:: foreignCall` is being reported to Logstash. Adding it to the "blacklist" of `wfGetCallerClassMethod` function will report the "real" caller and make stats more meaningful.

HTTP requests stats from last hour:

``` json
 {
  "count": 5779, 
  "min": 10.0, 
  "sum_of_squares": 97660073.0, 
  "max": 858.0, 
  "sum": 608423.0, 
  "std_deviation": 76.25543745823305, 
  "key": "apiservice:foreigncall", 
  "variance": 5814.8917419464915, 
  "avg": 105.28170963834573
 }
```
