### PR TITLE
Remove class check for WikiaLogger in Wikia::log

### DIFF
--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -413,13 +413,10 @@ class Wikia {
 
 		$method = $sub ? $method . "-" . $sub : $method;
 		if( $wgDevelEnvironment || $wgErrorLog || $always ) {
-			if (class_exists('Wikia\\Logger\\WikiaLogger')) {
-				$method = preg_match('/-WIKIA$/', $method) ? str_replace('-WIKIA', '', $method) : $method;
-				\Wikia\Logger\WikiaLogger::instance()->debug($message, ['method' => $method]);
-			} else {
-				error_log( $method . ":{$wgDBname}/{$wgCityId}:" . $message );
-			}
+			$method = preg_match('/-WIKIA$/', $method) ? str_replace('-WIKIA', '', $method) : $method;
+			\Wikia\Logger\WikiaLogger::instance()->debug($message, ['method' => $method]);
 		}
+
 		/**
 		 * commandline = echo
 		 */


### PR DESCRIPTION
Removes the class existing check in Wikia::log. The WikiaLogger
class is now in the Wikia\ namespace and will be available everywhere.

/cc @nmonterroso
