### PR TITLE
MOB-1853

### DIFF
--- a/extensions/wikia/WikiaInteractiveMaps/css/WikiaMaps.wikiamobile.scss
+++ b/extensions/wikia/WikiaInteractiveMaps/css/WikiaMaps.wikiamobile.scss
@@ -52,6 +52,6 @@
 	}
 }
 
-.error {
+.no-maps {
 	padding: 0 15px;
 }


### PR DESCRIPTION
Resigned from rules for `.error` instead used `.no-maps`.
