### PR TITLE
Platform 337

### DIFF
--- a/extensions/wikia/SwiftSync/SwiftSync.setup.php
+++ b/extensions/wikia/SwiftSync/SwiftSync.setup.php
@@ -6,11 +6,11 @@
  * @author Maciej Brencz (macbre@wikia-inc.com)
  * @author Piotr Molski (moli@wikia-inc.com)
  */
- 
+
 $app = F::app();
 $dir = dirname(__FILE__) . '/';
 
-# load 
+# load
 $wgAutoloadClasses[ 'Wikia\\SwiftSync\\Hooks'         ] = $dir . "classes/Hooks.php";
 $wgAutoloadClasses[ 'Wikia\\SwiftSync\\Queue'         ] = $dir . "classes/Queue.class.php";
 $wgAutoloadClasses[ 'Wikia\\SwiftSync\\ImageSync'     ] = $dir . "classes/ImageSync.class.php";
@@ -19,3 +19,4 @@ $wgAutoloadClasses[ 'Wikia\\SwiftSync\\ImageSync'     ] = $dir . "classes/ImageS
 $wgHooks[ 'SwiftFileBackend::doStoreInternal'     ][] = 'Wikia\SwiftSync\Hooks::doStoreInternal';
 $wgHooks[ 'SwiftFileBackend::doCopyInternal'      ][] = 'Wikia\SwiftSync\Hooks::doCopyInternal';
 $wgHooks[ 'SwiftFileBackend::doDeleteInternal'    ][] = 'Wikia\SwiftSync\Hooks::doDeleteInternal';
+$wgHooks[ 'Masthead::AvatarSavedToSwift'          ][] = 'Wikia\SwiftSync\Hooks::SyncFiletoDC';

--- a/extensions/wikia/SwiftSync/classes/Hooks.php
+++ b/extensions/wikia/SwiftSync/classes/Hooks.php
@@ -6,7 +6,7 @@ namespace Wikia\SwiftSync;
 
 /**
  * SwiftFileBackend helper class to sync stored/removed/renamed file with local FS
- * 
+ *
  * @author moli
  * @package SwiftSync
  */
@@ -21,10 +21,10 @@ class Hooks {
 	 */
 	static private function initLocalFS( ) {
 		global $wgUploadDirectory, $wgUploadDirectoryNFS;
-		
+
 		$repoName = self::$repoName;
 		$directory = ( !empty( $wgUploadDirectoryNFS ) ) ? $wgUploadDirectoryNFS : $wgUploadDirectory;
-		
+
 		$config = array (
 			'name'           => "{$repoName}-backend",
 			'class'          => 'FSFileBackend',
@@ -42,29 +42,29 @@ class Hooks {
 		return new $class( $config );
 	}
 
-	/* replace swith-backend with local-backend */
+	/* replace swift-backend with local-backend */
 	private static function replaceBackend( $path ) {
-		$path = preg_replace( 
-			'/\/swift-backend\/(.*)\/images/', 
-			sprintf( "/%s-backend/%s-public", self::$repoName, self::$repoName ), 
+		$path = preg_replace(
+			'/\/swift-backend\/(.*)\/images/',
+			sprintf( "/%s-backend/%s-public", self::$repoName, self::$repoName ),
 			$path
 		);
-		
+
 		return $path;
 	}
-	
+
 	/* save image into local repo */
 	public static function doStoreInternal( $params, \Status $status ) {
-		global $wgEnableSwithSyncToLocalFS, $wgDevelEnvironment;
-		
+		global $wgEnableSwiftSyncToLocalFS, $wgDevelEnvironment;
+
 		wfProfileIn( __METHOD__ );
 		$fsParams = $params;
 
-		if ( !empty( $wgEnableSwithSyncToLocalFS ) ) {
+		if ( !empty( $wgEnableSwiftSyncToLocalFS ) ) {
 			if ( !empty( $params['dst'] ) && !empty( $params['src'] ) ) {
-				# replace swift-backend storage URL with local-backend ... 
+				# replace swift-backend storage URL with local-backend ...
 				$params['dst'] = self::replaceBackend( $params['dst'] );
-				
+
 				# ... and set correct destination path
 				$params['dst'] = str_replace( "swift-backend", sprintf("%s-backend", self::$repoName), $params['dst'] );
 
@@ -74,18 +74,18 @@ class Hooks {
 					wfProfileOut( __METHOD__ );
 					return true;
 				}
-			
+
 				# init FSFileBackend object
 				$fsBackend = self::initLocalFS();
-				
+
 				# prepare dir for uploaded file ...
 				$status = $fsBackend->prepare( [ 'dir' => dirname( $params['dst'] ) ] );
-				
+
 				# ... and if created save image in destination path
 				if ( $status->isOK() ) {
 					$status = $fsBackend->storeInternal( $params );
-				} 
-				
+				}
+
 				if ( !$status->isOK() ) {
 					\Wikia\SwiftStorage::log( __METHOD__, 'Cannot save image on local storage: ' . json_encode( $status ) );
 				}
@@ -94,110 +94,110 @@ class Hooks {
 				$status->fatal( 'backend-fail-store', $params['dst'] );
 			}
 		}
-		
-		if ( empty( $wgDevelEnvironment ) ) { 
+
+		if ( empty( $wgDevelEnvironment ) ) {
 			Queue::newFromParams( $fsParams )->add();
 		}
-		
+
 		wfProfileOut( __METHOD__ );
-		
+
 		return true;
 	}
-	
+
 	public static function doCopyInternal( $params, \Status $status ) {
-		global $wgEnableSwithSyncToLocalFS, $wgDevelEnvironment;
-		
+		global $wgEnableSwiftSyncToLocalFS, $wgDevelEnvironment;
+
 		wfProfileIn( __METHOD__ );
 		$fsParams = $params;
-		
-		if ( !empty( $wgEnableSwithSyncToLocalFS ) ) {
+
+		if ( !empty( $wgEnableSwiftSyncToLocalFS ) ) {
 			if ( !empty( $params['dst'] ) && !empty( $params['src'] ) ) {
-				# replace swift-backend storage URL with local-backend ... 
+				# replace swift-backend storage URL with local-backend ...
 				$params['dst'] = self::replaceBackend( $params['dst'] );
 				$params['src'] = self::replaceBackend( $params['src'] );
-		
+
 				# init FSFileBackend object
 				$fsBackend = self::initLocalFS();
-				
+
 				# prepare dir for copied file ...
 				if ( strpos( $params['dst'], '/deleted/' ) !== false ) {
-					$prepare_params = [ 
+					$prepare_params = [
 						'dir'       => dirname( $params['dst'] ),
 						'noAccess'  => 1,
-						'noListing' => 1 
-					];	
+						'noListing' => 1
+					];
 				} else {
-					$prepare_params = [ 
-						'dir'       => dirname( $params['dst'] ) 
+					$prepare_params = [
+						'dir'       => dirname( $params['dst'] )
 					];
 				}
 				$status = $fsBackend->prepare( $prepare_params );
-				
+
 				# ... and if created save image in destination path
 				if ( $status->isOK() ) {
-					$status = $fsBackend->copyInternal( $params );		
+					$status = $fsBackend->copyInternal( $params );
 				} else {
 					\Wikia\SwiftStorage::log( __METHOD__, 'Cannot create directory for copied file' );
 				}
-				
-				if ( !$status->isOK() ) {	
+
+				if ( !$status->isOK() ) {
 					\Wikia\SwiftStorage::log( __METHOD__, 'Cannot copy image to ' .$params['dst'] );
-				}		
+				}
 			} else {
 				$status->fatal( 'backend-fail-store', ( empty( $params['dst'] ) ) ? $params['dst'] : $params['src'] );
 			}
 		}
-		
-		if ( empty( $wgDevelEnvironment ) ) { 
+
+		if ( empty( $wgDevelEnvironment ) ) {
 			Queue::newFromParams( $fsParams )->add();
 		}
-		
+
 		wfProfileOut( __METHOD__ );
-		
+
 		return true;
 	}
-	
+
 	public static function doDeleteInternal( $params, \Status $status ) {
-		global $wgEnableSwithSyncToLocalFS, $wgDevelEnvironment;
-		
+		global $wgEnableSwiftSyncToLocalFS, $wgDevelEnvironment;
+
 		wfProfileIn( __METHOD__ );
-		
+
 		if ( !empty( $params['src'] ) && ( strpos( $params['src'], '/images/thumb' ) !== false ) ) {
 			wfProfileOut( __METHOD__ );
 			return true;
 		}
-		
+
 		if ( empty( $params['op']  ) ) {
 			$params['op'] = 'delete';
 		}
 		$fsParams = $params;
-				
-		if ( !empty( $wgEnableSwithSyncToLocalFS ) ) {
+
+		if ( !empty( $wgEnableSwiftSyncToLocalFS ) ) {
 			if ( !empty( $params['src'] ) ) {
-				# replace swift-backend storage URL with local-backend ... 
+				# replace swift-backend storage URL with local-backend ...
 				$params['src'] = self::replaceBackend( $params['src'] );
-		
+
 				# init FSFileBackend object
 				$fsBackend = self::initLocalFS();
-				
+
 				# ... and delete source image
-				$status = $fsBackend->deleteInternal( $params );	
-				
-				if ( !$status->isOK() ) {	
+				$status = $fsBackend->deleteInternal( $params );
+
+				if ( !$status->isOK() ) {
 					\Wikia\SwiftStorage::log( __METHOD__, 'Cannot remove image ' .$params['src'] );
-				}	
+				}
 			} else {
 				$status->fatal( 'backend-fail-delete', $params['src'] );
 				\Wikia\SwiftStorage::log( __METHOD__, 'Invalid source path' );
 			}
 		}
-		
-		if ( empty( $wgDevelEnvironment ) ) { 
+
+		if ( empty( $wgDevelEnvironment ) ) {
 			Queue::newFromParams( $fsParams )->add();
 		}
-		
+
 		wfProfileOut( __METHOD__ );
-		
+
 		return true;
 	}
 }

--- a/extensions/wikia/UserProfilePageV3/Masthead.class.php
+++ b/extensions/wikia/UserProfilePageV3/Masthead.class.php
@@ -524,7 +524,7 @@ class Masthead {
 	}
 
 	private function getThumbPath( $dir ) {
-		return str_replace( "/avatars/", "/avatars/thumb/", $dir );		
+		return str_replace( "/avatars/", "/avatars/thumb/", $dir );
 	}
 
 	/**
@@ -717,22 +717,21 @@ class Masthead {
 
 				// errors handling
 				$errorNo = $res->isOK() ? UPLOAD_ERR_OK : UPLOAD_ERR_CANT_WRITE;
-				
+
 				// synchronize between DC
 				if ($res->isOK()) {
-					$mwStorePath = sprintf( 'mwstore://swift-backend/%s%s%s', 
+					$mwStorePath = sprintf( 'mwstore://swift-backend/%s%s%s',
 						$wgBlogAvatarSwiftContainer, $wgBlogAvatarSwiftPathPrefix, $this->getLocalPath() );
-					Wikia\SwiftSync\Queue::newFromParams( [
+e					Wikia\SwiftSync\Queue::newFromParams( [
 						'city_id' => 0,
 						'op' => 'store',
 						'src' => $sFilePath,
 						'dst' => $mwStorePath
 					] )->add();
 				}
-
 				// sync with NFS
-				global $wgEnableSwithSyncToLocalFS;
-				if (!empty($wgEnableSwithSyncToLocalFS)) {
+				global $wgEnableSwiftSyncToLocalFS;
+				if (!empty($wgEnableSwiftSyncToLocalFS)) {
 					copy($sFilePath, $this->getFullPath());
 				}
 			}

--- a/extensions/wikia/UserProfilePageV3/Masthead.class.php
+++ b/extensions/wikia/UserProfilePageV3/Masthead.class.php
@@ -722,17 +722,8 @@ class Masthead {
 				if ($res->isOK()) {
 					$mwStorePath = sprintf( 'mwstore://swift-backend/%s%s%s',
 						$wgBlogAvatarSwiftContainer, $wgBlogAvatarSwiftPathPrefix, $this->getLocalPath() );
-e					Wikia\SwiftSync\Queue::newFromParams( [
-						'city_id' => 0,
-						'op' => 'store',
-						'src' => $sFilePath,
-						'dst' => $mwStorePath
-					] )->add();
-				}
-				// sync with NFS
-				global $wgEnableSwiftSyncToLocalFS;
-				if (!empty($wgEnableSwiftSyncToLocalFS)) {
-					copy($sFilePath, $this->getFullPath());
+
+					wfRunHooks("Masthead::AvatarSavedToSwift", array ( $sFilePath, $mwStorePath) );
 				}
 			}
 


### PR DESCRIPTION
Remove SyncToLocalFS variable and related code. 

Add a hook for Masthead::AvatarSavedToSwift instead of calling Queue class directly so that we can disable SwiftSync safely from config.  
