### PR TITLE
Remove Ooyala ingestion for weekend

### DIFF
--- a/extensions/wikia/VideoHandlers/feedingesters/VideoFeedIngester.class.php
+++ b/extensions/wikia/VideoHandlers/feedingesters/VideoFeedIngester.class.php
@@ -27,7 +27,6 @@ abstract class VideoFeedIngester {
 	// Providers from which we ingest daily video data
 	protected static $ACTIVE_PROVIDERS = [
 		self::PROVIDER_IGN,
-		self::PROVIDER_OOYALA,
 		self::PROVIDER_IVA,
 		self::PROVIDER_SCREENPLAY,
 	];


### PR DESCRIPTION
Video is going to remove Ooyala ingestion over the weekend due to a bug which is causing duplicate and broken videos to be ingested. We'll re-add Ooyala and put in the fix on Monday.
