### PR TITLE
PHP fast unit: mark tests that use DB and skip them

### DIFF
--- a/extensions/wikia/HAWelcome/tests/HAWelcomeTaskHookDispatcherTest.php
+++ b/extensions/wikia/HAWelcome/tests/HAWelcomeTaskHookDispatcherTest.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @group UsingDB
+ */
 class HAWelcomeTaskHookDispatcherTest extends WikiaBaseTest {
 
 	public function testDispatchWhenDisabled() {

--- a/extensions/wikia/HAWelcome/tests/HAWelcomeTaskTest.php
+++ b/extensions/wikia/HAWelcome/tests/HAWelcomeTaskTest.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @group UsingDB
+ */
 class HAWelcomeTaskTest extends WikiaBaseTest {
 
 	public function testNormalizeInstanceParameters() {

--- a/extensions/wikia/HubRssFeed/tests/models/BaseRssModelTest.php
+++ b/extensions/wikia/HubRssFeed/tests/models/BaseRssModelTest.php
@@ -82,6 +82,9 @@ class DummyNotMockedModel extends BaseRssModel {
 	}
 }
 
+/**
+ * @group UsingDB
+ */
 class BaseRssModelTest extends WikiaBaseTest
 {
 	protected static function getFn($obj, $name)

--- a/extensions/wikia/VideosModule/tests/VideosModuleTest.php
+++ b/extensions/wikia/VideosModule/tests/VideosModuleTest.php
@@ -4,6 +4,7 @@
 	 * Videos Module test
 	 *
 	 * @category Wikia
+	 * @group UsingDB
 	 */
 	class VideosModuleTest extends WikiaBaseTest {
 

--- a/extensions/wikia/WikiaInteractiveMaps/tests/WikiaInteractiveMapsParserTagControllerTest.php
+++ b/extensions/wikia/WikiaInteractiveMaps/tests/WikiaInteractiveMapsParserTagControllerTest.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @group UsingDB
+ */
 class WikiaInteractiveMapsParserTagControllerTest extends WikiaBaseTest {
 
 	public function setUp() {

--- a/extensions/wikia/WikiaInteractiveMaps/tests/WikiaInteractiveMapsUploadImageFromFileTest.php
+++ b/extensions/wikia/WikiaInteractiveMaps/tests/WikiaInteractiveMapsUploadImageFromFileTest.php
@@ -1,4 +1,8 @@
 <?php
+
+/**
+ * @group UsingDB
+ */
 class WikiaInteractiveMapsUploadImageFromFileTest extends WikiaBaseTest {
 
 	public function setUp() {

--- a/includes/wikia/tests/BatchRefreshLinksForTemplateTest.php
+++ b/includes/wikia/tests/BatchRefreshLinksForTemplateTest.php
@@ -56,7 +56,7 @@ class BatchRefreshLinksForTemplateTest extends PHPUnit_Framework_TestCase {
 
 		$task->expects( $this->exactly( $times ) )
 			->method( 'readyRefreshLinksForTitleTask' )
-			->with( $this->logicalOr( $titles[0], $titles[2], $titles[3] ) )
+			->with( $this->logicalOr( $titles[0], $titles[1], $titles[2] ) )
 			->will( $this->returnValue( $times ) );
 
 		$task->expects( $this->once() )


### PR DESCRIPTION
@Wikia/platform-team 
