### PR TITLE
PLAT-345 ensure sender object is passed to doEdit for correct welcome message attribution

### DIFF
--- a/extensions/wikia/HAWelcome/HAWelcomeTask.php
+++ b/extensions/wikia/HAWelcome/HAWelcomeTask.php
@@ -3,6 +3,7 @@
 use Wikia\Tasks\Tasks\BaseTask;
 
 class HAWelcomeTask extends BaseTask {
+	use IncludeMessagesTrait;
 
 	/** @type String The default user to send welcome messages. */
 	const DEFAULT_WELCOMER = 'Wikia';
@@ -141,7 +142,7 @@ class HAWelcomeTask extends BaseTask {
 	}
 
 	protected function getMessageWallExtensionEnabled() {
-		if ( is_null($this->bMessageWallExt) ) {
+		if ( is_null( $this->bMessageWallExt ) ) {
 			/**
 			 * @global Boolean Indicated whether the Message Wall extension is enabled.
 			 */
@@ -173,7 +174,7 @@ class HAWelcomeTask extends BaseTask {
 	}
 
 	protected function getWelcomePageTemplateForRecipient() {
-		return wfMessage( 'welcome-user-page', $this->recipientName )->inContentLanguage()->plain();
+		return $this->getPlainVersionOfMessage( 'welcome-user-page', [$this->recipientName] );
 	}
 
 	/**
@@ -208,7 +209,7 @@ class HAWelcomeTask extends BaseTask {
 				$aUsers = array( 'bot' => array(), 'sysop' => array() );
 
 				// Classify the users as sysops or bots.
-				while( $oRow = $oDB->fetchObject( $oResult ) ) {
+				while ( $oRow = $oDB->fetchObject( $oResult ) ) {
 					array_push( $aUsers[$oRow->ug_group], $oRow->ug_user );
 				}
 
@@ -249,7 +250,7 @@ class HAWelcomeTask extends BaseTask {
 		}
 
 		// Terminate, if a valid user object has been created.
-		if( $senderObject instanceof User && $senderObject->getId() ) {
+		if ( $senderObject instanceof User && $senderObject->getId() ) {
 			$this->senderObject = $senderObject;
 			return;
 		}
@@ -265,7 +266,7 @@ class HAWelcomeTask extends BaseTask {
 		$senderObject = Wikia::staffForLang( $wgLanguageCode );
 
 		// Terminate, if a valid user object has been created.
-		if( $senderObject instanceof User && $senderObject->getId() ) {
+		if ( $senderObject instanceof User && $senderObject->getId() ) {
 			$this->senderObject = $senderObject;
 			return;
 		}
@@ -369,7 +370,7 @@ class HAWelcomeTask extends BaseTask {
 	public function setMessage() {
 		$welcomeMessageKey = 'welcome-message-';
 
-		//Determine the proper key
+		// Determine the proper key
 		//
 		// Is Message Wall enabled?
 		$welcomeMessageKey  .= $this->getMessageWallExtensionEnabled() ? 'wall-'  : '';
@@ -394,11 +395,10 @@ class HAWelcomeTask extends BaseTask {
 			? 'staffsig-text' : 'signature';
 
 		// Determine the full signature.
-		$sFullSignature = wfMessage(
+		$sFullSignature = $this->getTextVersionOfMessage(
 			$sSignatureKey,
-			$this->senderObject->getName(),
-			Parser::cleanSigInSig( $this->senderObject->getName() )
-		)->inContentLanguage()->text();
+			[$this->senderObject->getName(), Parser::cleanSigInSig( $this->senderObject->getName() )]
+		);
 
 		// Append the timestamp to the signature.
 		$sFullSignature .= ' ~~~~~';
@@ -413,12 +413,12 @@ class HAWelcomeTask extends BaseTask {
 		// * welcome-message-wall-user-staff
 		// * welcome-message-wall-anon
 		// * welcome-message-wall-anon-staff
-		$this->welcomeMessage = wfMessage( $welcomeMessageKey,
+		$this->welcomeMessage = $this->getPlainVersionOfMessage( $welcomeMessageKey, [
 			$sPrefixedText,
 			$this->senderObject->getUserPage()->getTalkPage()->getPrefixedText(),
 			$sFullSignature,
 			wfEscapeWikiText( $this->recipientName )
-		)->inContentLanguage()->plain();
+		] );
 	}
 
 	public function normalizeInstanceParameters( $params ) {

--- a/extensions/wikia/HAWelcome/HAWelcomeTaskHookDispatcher.php
+++ b/extensions/wikia/HAWelcome/HAWelcomeTaskHookDispatcher.php
@@ -9,6 +9,7 @@ use Wikia\Logger\Loggable;
 
 class HAWelcomeTaskHookDispatcher {
 	use Loggable;
+	use IncludeMessagesTrait;
 
 	/** @type \Revision */
 	private $revisionObject = null;
@@ -104,7 +105,7 @@ class HAWelcomeTaskHookDispatcher {
 	}
 
 	public function getWelcomeUserFromMessages() {
-		return trim( wfMessage( 'welcome-user' )->inContentLanguage()->text() );
+		return trim( $this->getTextVersionOfMessage( 'welcome-user' ) );
 	}
 
 	protected function markHAWelcomePosted() {
@@ -169,7 +170,7 @@ class HAWelcomeTaskHookDispatcher {
 	}
 
 	public function welcomeMessageDisabled() {
-		if ( in_array( trim( wfMessage( 'welcome-user' )->inContentLanguage()->text() ), array( '@disabled', '-' ) ) ) {
+		if ( in_array( trim( $this->getTextVersionOfMessage( 'welcome-user' ) ), array( '@disabled', '-' ) ) ) {
 			return true;
 		}
 	}

--- a/extensions/wikia/HAWelcome/HAWelcomeTaskHookDispatcher.php
+++ b/extensions/wikia/HAWelcome/HAWelcomeTaskHookDispatcher.php
@@ -38,7 +38,6 @@ class HAWelcomeTaskHookDispatcher {
 
 		if ( $this->hasContributorBeenWelcomedRecently() ) {
 			$this->info( "aborting the welcome hook: user has been welcomed recently" );
-			// abort if they have contributed recently
 			return true;
 		}
 

--- a/extensions/wikia/HAWelcome/HAWelcomeTaskHooks.php
+++ b/extensions/wikia/HAWelcome/HAWelcomeTaskHooks.php
@@ -43,6 +43,7 @@ class HAWelcomeTaskHooks {
 			return true;
 		}
 
+
 		$dispatcher = new HAWelcomeTaskHookDispatcher();
 		$dispatcher->setRevisionObject( $revisionObject )
 			->setCityId( $wgCityId )

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -381,10 +381,11 @@ $wgAutoloadClasses['Wikia\UI\DataException'] = $IP . '/includes/wikia/ui/excepti
 $wgAutoloadClasses['Wikia\UI\UIFactoryApiController'] = $IP . '/includes/wikia/ui/UIFactoryApiController.class.php';
 
 // Traits
-$wgAutoloadClasses[ 'PreventBlockedUsers' ] = $IP . '/includes/wikia/traits/PreventBlockedUsers.trait.php';
-$wgAutoloadClasses[ 'PreventBlockedUsersThrowsError' ] = $IP . '/includes/wikia/traits/PreventBlockedUsers.trait.php';
-$wgAutoloadClasses[ 'UserAllowedRequirement' ] = $IP . '/includes/wikia/traits/UserAllowedRequirement.trait.php';
-$wgAutoloadClasses[ 'UserAllowedRequirementThrowsError' ] = $IP . '/includes/wikia/traits/UserAllowedRequirement.trait.php';
+$wgAutoloadClasses['PreventBlockedUsers'] = $IP . '/includes/wikia/traits/PreventBlockedUsers.trait.php';
+$wgAutoloadClasses['PreventBlockedUsersThrowsError'] = $IP . '/includes/wikia/traits/PreventBlockedUsers.trait.php';
+$wgAutoloadClasses['UserAllowedRequirement'] = $IP . '/includes/wikia/traits/UserAllowedRequirement.trait.php';
+$wgAutoloadClasses['UserAllowedRequirementThrowsError'] = $IP . '/includes/wikia/traits/UserAllowedRequirement.trait.php';
+$wgAutoloadClasses['IncludeMessagesTrait'] = $IP . '/includes/wikia/traits/IncludeMessagesTrait.php';
 
 // Spotlights AB test
 $wgAutoloadClasses['SpotlightsABTestController'] = $IP.'/skins/oasis/modules/SpotlightsABTestController.class.php';

--- a/includes/wikia/tasks/Tasks/BaseTask.class.php
+++ b/includes/wikia/tasks/Tasks/BaseTask.class.php
@@ -392,16 +392,4 @@ abstract class BaseTask {
 		return AsyncTaskList::batch( $taskLists );
 	}
 
-	/**
-	 * Get the text version of inContentLanguage message. This is a wrapper so that we can
-	 * limit side effects in unit tests.
-	 *
-	 * @param string $message
-	 * @return string
-	 */
-	protected function getTextVersionOfMessage( $message ) {
-		return wfMessage( $message )->inContentLanguage()->text();
-	}
-
-
 }

--- a/includes/wikia/tasks/Tasks/BaseTask.class.php
+++ b/includes/wikia/tasks/Tasks/BaseTask.class.php
@@ -391,4 +391,17 @@ abstract class BaseTask {
 
 		return AsyncTaskList::batch( $taskLists );
 	}
+
+	/**
+	 * Get the text version of inContentLanguage message. This is a wrapper so that we can
+	 * limit side effects in unit tests.
+	 *
+	 * @param string $message
+	 * @return string
+	 */
+	protected function getTextVersionOfMessage( $message ) {
+		return wfMessage( $message )->inContentLanguage()->text();
+	}
+
+
 }

--- a/includes/wikia/traits/IncludeMessagesTrait.php
+++ b/includes/wikia/traits/IncludeMessagesTrait.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * This trait allows you to include accessor methods in your class that wrap the wfMessage functionality.
+ * The motivation for this is to provide a boundry between core MediaWiki functionality that relies upon
+ * globally acessible functions that have side effects or do IO and new functionality that needs to be tested.
+ *
+ * For example, you can't reliably test a function that has a call to wfMessage() without hitting the database.
+ * This means that you can't effectively unit test such a function.
+ *
+ * @author Damon Snyder (damon@wikia-inc.com)
+ */
+
+trait IncludeMessagesTrait {
+
+	/**
+	 * Get the text version of inContentLanguage message.
+	 *
+	 * Example:
+	 *	$this->getTextVersionOfMessage( 'a-message', $option1, $option2, ... )
+	 *
+	 * @param string $message
+	 * @param array parameters this is a flat array of parameters
+	 * @return string
+	 */
+	protected function getTextVersionOfMessage( $message, array $params = array() ) {
+		$message = new Message( $message, $params );
+		return $message->inContentLanguage()->text();
+	}
+
+	/**
+	 * Get the plain version of an inContentLanguage message.
+	 *
+	 * @param string $message
+	 * @param array parameters this is a flat array of parameters
+	 * @return string
+	 */
+	protected function getPlainVersionOfMessage( $message, array $params = array() ) {
+		$message = new Message( $message, $params );
+		return $message->inContentLanguage()->plain();
+	}
+
+}


### PR DESCRIPTION
It appears that the sender object has been missing from the parameter list to Article::doEdit which is responsible for the work of creating the welcome message. As a result, the `$wgUser` is being used as the default author in a batch context which appears to resolve to localhost or 127.0.0.1 in this context.

This pull request adds the sender to the `doEdit` calls and adds some testing to ensure that the user object is part of the parameter list. 

I've also attempted to make the testing more robust by stubbing some of the functionality that results in IO. I specifically wrapped a few of the calls to `wfMessage` to prevent database access in the unit tests.

/cc @Wikia/platform-team @michalroszka 
