### PR TITLE
VE-1343: Fix by specifying size of MapNode

### DIFF
--- a/extensions/VisualEditor/wikia/modules/ve/ce/ve.ce.WikiaMapNode.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ce/ve.ce.WikiaMapNode.js
@@ -17,7 +17,11 @@ ve.ce.WikiaMapNode = function VeCeWikiaMapNode( model, config ) {
 	ve.ce.WikiaMapNode.super.call( this, model, config );
 
 	// DOM changes
-	this.$element.addClass( 've-ce-wikiaMapNode' );
+	// Size provided as a fix for https://wikia-inc.atlassian.net/browse/VE-1343
+	this.$element
+		.addClass( 've-ce-wikiaMapNode' )
+		.height( 300 )
+		.width( 680 );
 };
 
 /* Inheritance */


### PR DESCRIPTION
Focus mode updates based on transact widget - but this is not robust enough for case of generated content nodes.
