### PR TITLE
Fatal: Class ParsoidCacheUpdateTask not found

### DIFF
--- a/extensions/wikia/Parsoid/Parsoid.hooks.php
+++ b/extensions/wikia/Parsoid/Parsoid.hooks.php
@@ -2,6 +2,7 @@
 
 use Wikia\Tasks\Queues\ParsoidPurgeQueue;
 use Wikia\Tasks\Queues\ParsoidPurgePriorityQueue;
+use Wikia\Tasks\Tasks\ParsoidCacheUpdateTask;
 
 /**
  * Hooks for events that should trigger Parsoid cache updates.

--- a/extensions/wikia/Parsoid/Parsoid.php
+++ b/extensions/wikia/Parsoid/Parsoid.php
@@ -15,10 +15,6 @@ class ParsoidSetup {
 		$dir = __DIR__;
 
 		$wgAutoloadClasses['ParsoidHooks'] = "$dir/Parsoid.hooks.php";
-		$wgAutoloadClasses['CurlMultiClient'] = "$dir/CurlMultiClient.php";
-
-		// modern task
-		$wgAutoloadClasses['ParsoidCacheUpdateTask'] = "$dir/ParsoidCacheUpdateTask.class.php";
 
 		self::registerHooks();
 

--- a/includes/wikia/CurlMultiClient.php
+++ b/includes/wikia/CurlMultiClient.php
@@ -2,7 +2,6 @@
 
 /**
  * A simple parallel CURL client helper class
- * @TODO: name this ParsoidCurlMultiClient or move to core
  */
 class CurlMultiClient {
 

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -241,6 +241,7 @@ $wgAutoloadClasses[ 'TitleBatch'                      ] = "$IP/includes/wikia/ca
 $wgAutoloadClasses[ 'WikiaUserPropertiesHandlerBase'  ] = "$IP/includes/wikia/models/WikiaUserPropertiesHandlerBase.class.php";
 $wgAutoloadClasses[ 'ParserPool'                      ] = "$IP/includes/wikia/parser/ParserPool.class.php";
 $wgAutoloadClasses[ 'WikiDataSource'                  ] = "$IP/includes/wikia/WikiDataSource.php";
+$wgAutoloadClasses[ 'CurlMultiClient'                 ] = "$IP/includes/wikia/CurlMultiClient.php";
 $wgAutoloadClasses[ 'DateFormatHelper'                ] = "$IP/includes/wikia/DateFormatHelper.php";
 $wgAutoloadClasses[ 'CategoryHelper'                  ] = "$IP/includes/wikia/helpers/CategoryHelper.class.php";
 $wgAutoloadClasses[ 'Wikia\\Measurements\\Driver'     ] = "$IP/includes/wikia/measurements/Drivers.php";

--- a/includes/wikia/tasks/Tasks/ParsoidCacheUpdateTask.class.php
+++ b/includes/wikia/tasks/Tasks/ParsoidCacheUpdateTask.class.php
@@ -1,7 +1,8 @@
 <?php
 
+namespace Wikia\Tasks\Tasks;
+
 use Wikia\Logger\WikiaLogger;
-use Wikia\Tasks\Tasks\BaseTask;
 use Wikia\Tasks\AsyncTaskList;
 use Wikia\Tasks\Queues\ParsoidPurgePriorityQueue;
 
@@ -45,7 +46,7 @@ class ParsoidCacheUpdateTask extends BaseTask {
 		return $this->invalidateTitle( $this->title );
 	}
 
-	protected function getParsoidURL( Title $title, $prev = false ) {
+	protected function getParsoidURL( \Title $title, $prev = false ) {
 		global $wgVisualEditorParsoidURL;
 
 		$oldid = $prev ? $title->getPreviousRevisionID( $title->getLatestRevID() ) : $title->getLatestRevID();
@@ -57,7 +58,7 @@ class ParsoidCacheUpdateTask extends BaseTask {
 	protected function checkCurlResults( $results ) {
 		foreach ( $results as $k => $result ) {
 			if ( $results[ $k ][ 'error' ] != null ) {
-				throw new Exception( $results[ $k ][ 'error' ] );
+				throw new \Exception( $results[ $k ][ 'error' ] );
 			}
 		}
 
@@ -74,7 +75,7 @@ class ParsoidCacheUpdateTask extends BaseTask {
 		$requests = array();
 		foreach ( $wgParsoidCacheServers as $server ) {
 			foreach ( $titles as $key => $title ) {
-				/** @var Title $title */
+				/** @var \Title $title */
 				if ( !in_array( $title->getNamespace(), $wgContentNamespaces ) ) {
 					continue;
 				}
@@ -93,10 +94,10 @@ class ParsoidCacheUpdateTask extends BaseTask {
 			}
 		}
 
-		return $this->checkCurlResults( CurlMultiClient::request( $requests ) );
+		return $this->checkCurlResults( \CurlMultiClient::request( $requests ) );
 	}
 
-	protected function invalidateTitle( Title $title ) {
+	protected function invalidateTitle( \Title $title ) {
 		global $wgParsoidCacheServers, $wgContentNamespaces;
 
 		if ( !in_array( $title->getNamespace(), $wgContentNamespaces ) ) {
@@ -116,7 +117,7 @@ class ParsoidCacheUpdateTask extends BaseTask {
 				'Cache-control: no-cache' ) );
 			$this->wikiaLog( array( "action" => "invalidateTitle", "get_url" => $singleUrl ) );
 		}
-		$this->checkCurlResults( CurlMultiClient::request( $requests ) );
+		$this->checkCurlResults( \CurlMultiClient::request( $requests ) );
 
 		# And now purge the previous revision so that we make efficient use of
 		# the Varnish cache space without relying on LRU. Since the URL
@@ -128,10 +129,10 @@ class ParsoidCacheUpdateTask extends BaseTask {
 			$requests[ ] = array( 'url' => $singleUrl );
 			$this->wikiaLog( array( "action" => "invalidateTitle", "purge_url" => $singleUrl ) );
 		}
-		$options = CurlMultiClient::getDefaultOptions();
+		$options = \CurlMultiClient::getDefaultOptions();
 		$options[ CURLOPT_CUSTOMREQUEST ] = "PURGE";
 
-		return $this->checkCurlResults( CurlMultiClient::request( $requests, $options ) );
+		return $this->checkCurlResults( \CurlMultiClient::request( $requests, $options ) );
 	}
 
 	private function wikiaLog( $data ) {


### PR DESCRIPTION
@Wikia/platform-team @inez 
https://wikia-inc.atlassian.net/browse/PLATFORM-354

Looks like there's a code path somewhere that's causing this task to be queued for a wiki that has $wgEnableVisualEditorUI = false. @inez - can someone on the contribution team investigate? For now, this will stop the fatals.

I thought it might have to do with a user who has VE enabled via preferences on a wiki that has it disabled globally, but I could not repro this way.
