### PR TITLE
Rename existing traits to follow *Trait convention.

### DIFF
--- a/extensions/wikia/Tasks/TasksSpecialController.class.php
+++ b/extensions/wikia/Tasks/TasksSpecialController.class.php
@@ -8,8 +8,8 @@
  */
 
 class TasksSpecialController extends WikiaSpecialPageController {
-	use PreventBlockedUsersThrowsError;
-	use UserAllowedRequirementThrowsError;
+	use PreventBlockedUsersThrowsErrorTrait;
+	use UserAllowedRequirementThrowsErrorTrait;
 
 	/** @var TasksModel */
 	private $model;

--- a/extensions/wikia/WikiFeatures/WikiFeaturesSpecialController.class.php
+++ b/extensions/wikia/WikiFeatures/WikiFeaturesSpecialController.class.php
@@ -7,7 +7,7 @@
  * @author Saipetch
  */
 class WikiFeaturesSpecialController extends WikiaSpecialPageController {
-	use PreventBlockedUsersThrowsError;
+	use PreventBlockedUsersThrowsErrorTrait;
 
 	public function __construct() {
 		parent::__construct('WikiFeatures', 'wikifeaturesview');

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -382,10 +382,10 @@ $wgAutoloadClasses['Wikia\UI\DataException'] = $IP . '/includes/wikia/ui/excepti
 $wgAutoloadClasses['Wikia\UI\UIFactoryApiController'] = $IP . '/includes/wikia/ui/UIFactoryApiController.class.php';
 
 // Traits
-$wgAutoloadClasses['PreventBlockedUsers'] = $IP . '/includes/wikia/traits/PreventBlockedUsers.trait.php';
-$wgAutoloadClasses['PreventBlockedUsersThrowsError'] = $IP . '/includes/wikia/traits/PreventBlockedUsers.trait.php';
-$wgAutoloadClasses['UserAllowedRequirement'] = $IP . '/includes/wikia/traits/UserAllowedRequirement.trait.php';
-$wgAutoloadClasses['UserAllowedRequirementThrowsError'] = $IP . '/includes/wikia/traits/UserAllowedRequirement.trait.php';
+$wgAutoloadClasses['PreventBlockedUsersTrait'] = $IP . '/includes/wikia/traits/PreventBlockedUsersTrait.php';
+$wgAutoloadClasses['PreventBlockedUsersThrowsErrorTrait'] = $IP . '/includes/wikia/traits/PreventBlockedUsersTrait.php';
+$wgAutoloadClasses['UserAllowedRequirementTrait'] = $IP . '/includes/wikia/traits/UserAllowedRequirementTrait.php';
+$wgAutoloadClasses['UserAllowedRequirementThrowsErrorTrait'] = $IP . '/includes/wikia/traits/UserAllowedRequirementTrait.php';
 $wgAutoloadClasses['IncludeMessagesTrait'] = $IP . '/includes/wikia/traits/IncludeMessagesTrait.php';
 
 // Spotlights AB test

--- a/includes/wikia/traits/PreventBlockedUsersTrait.php
+++ b/includes/wikia/traits/PreventBlockedUsersTrait.php
@@ -6,7 +6,7 @@
  *
  * @author Nelson Monterroso <nelson@wikia-inc.com>
  */
-trait PreventBlockedUsers {
+trait PreventBlockedUsersTrait {
 	/**
 	 * list of actions that should be allowed even if a user is blocked
 	 * @return array string list of actions that should be allowed
@@ -41,11 +41,11 @@ trait PreventBlockedUsers {
 }
 
 /**
- * Trait PreventBlockedUsersThrowsError
+ * Trait PreventBlockedUsersThrowsErrorTrait
  * extends base trait to throw a UserBlockedError when a user is prevented from taking an action
  */
-trait PreventBlockedUsersThrowsError {
-	use PreventBlockedUsers;
+trait PreventBlockedUsersThrowsErrorTrait {
+	use PreventBlockedUsersTrait;
 
 	protected function onBlockedUsagePrevented( User $user ) {
 		throw new UserBlockedError( $user->mBlock );

--- a/includes/wikia/traits/UserAllowedRequirementTrait.php
+++ b/includes/wikia/traits/UserAllowedRequirementTrait.php
@@ -7,7 +7,7 @@
  * @author Nelson Monterroso <nelson@wikia-inc.com>
  */
 
-trait UserAllowedRequirement {
+trait UserAllowedRequirementTrait {
 	protected $userAccessDefaultRequirement;
 
 	/**
@@ -47,8 +47,8 @@ trait UserAllowedRequirement {
 	}
 }
 
-trait UserAllowedRequirementThrowsError {
-	use UserAllowedRequirement;
+trait UserAllowedRequirementThrowsErrorTrait {
+	use UserAllowedRequirementTrait;
 
 	protected function onUserAllowedRequirementFailed(User $user, $perms) {
 		throw new PermissionsError(implode(', ', $perms));


### PR DESCRIPTION
I renamed the existing traits in includes/wikia/traits to be named `*Trait` and to take the `.trait.` out of the pathname. This should make them compatible with PSR\* autoloaders as well.

/cc @nmonterroso
