### PR TITLE
VID-1769 debugging race conditions with videos module load

### DIFF
--- a/extensions/wikia/VideosModule/scripts/controllers/index.js
+++ b/extensions/wikia/VideosModule/scripts/controllers/index.js
@@ -22,10 +22,10 @@ require([
 	$(function () {
 		// instantiate rail view
 		if ($rail.hasClass('loaded')) {
+			// Debugging to see if there's a race condition. This fires if there's a bug. (VID-1769)
 			Wikia.syslog(Wikia.log.levels.debug, 'VideosModule', {railLoaded: true});
 			init();
 		} else {
-			Wikia.syslog(Wikia.log.levels.debug, 'VideosModule', {railLoaded: false});
 			$rail.on('afterLoad.rail', init);
 		}
 	});

--- a/extensions/wikia/VideosModule/scripts/controllers/index.js
+++ b/extensions/wikia/VideosModule/scripts/controllers/index.js
@@ -4,26 +4,29 @@
  * to leave this in there for now as we may at some point switch back to the bottom position.
  */
 require([
-	//'videosmodule.views.bottomModule',
 	'videosmodule.views.rail',
 	'videosmodule.models.videos'
-], function (/*BottomModule,*/ RailModule, VideoData) {
+], function (RailModule, VideoData) {
 	'use strict';
+
+	var $rail = $('#WikiaRail');
+
+	function init() {
+		return new RailModule({
+			el: document.getElementById('videosModule'),
+			model: new VideoData(),
+			isFluid: false
+		});
+	}
 
 	$(function () {
 		// instantiate rail view
-		$('#WikiaRail').on('afterLoad.rail', function() {
-			return new RailModule({
-				el: document.getElementById('videosModule'),
-				model: new VideoData(),
-				isFluid: false
-			});
-		});
-
-		/*
-		view = new BottomModule({
-			el: document.getElementById('RelatedPagesModuleWrapper'),
-			model: new VideoData()
-		});*/
+		if ($rail.hasClass('loaded')) {
+			Wikia.syslog(Wikia.log.levels.debug, 'Rail already loaded', {extension: 'VideosModule'});
+			init();
+		} else {
+			Wikia.syslog(Wikia.log.levels.debug, 'Rail not loaded yet', {extension: 'VideosModule'});
+			$rail.on('afterLoad.rail', init);
+		}
 	});
 });

--- a/extensions/wikia/VideosModule/scripts/controllers/index.js
+++ b/extensions/wikia/VideosModule/scripts/controllers/index.js
@@ -22,10 +22,10 @@ require([
 	$(function () {
 		// instantiate rail view
 		if ($rail.hasClass('loaded')) {
-			Wikia.syslog(Wikia.log.levels.debug, 'Rail already loaded', {extension: 'VideosModule'});
+			Wikia.syslog(Wikia.log.levels.debug, 'VideosModule', {railLoaded: true});
 			init();
 		} else {
-			Wikia.syslog(Wikia.log.levels.debug, 'Rail not loaded yet', {extension: 'VideosModule'});
+			Wikia.syslog(Wikia.log.levels.debug, 'VideosModule', {railLoaded: false});
 			$rail.on('afterLoad.rail', init);
 		}
 	});


### PR DESCRIPTION
It seems like there's a race condition causing a disconnect between the binding of the on rail load event and the triggering of it. This is a possible solution as well as some debug code to see if this is in fact what's causing the bug. 
