### PR TITLE
VID-1844 Remove the file=XXX part of the query string on close

### DIFF
--- a/extensions/wikia/Lightbox/js/Lightbox.js
+++ b/extensions/wikia/Lightbox/js/Lightbox.js
@@ -206,7 +206,7 @@
 				Lightbox.openModal.removeClass('share-mode').removeClass('more-info-mode');
 				Lightbox.openModal.share.html('');
 				Lightbox.openModal.moreInfo.html('');
-			}).on('click.Lightbox', Lightbox.openModal.pin, function (evt) {
+			}).on('click.Lightbox', Lightbox.openModal.pin.selector, function (evt) {
 				// Pin the toolbar on icon click
 				var target = $(evt.target),
 					overlayActive = Lightbox.openModal.data('overlayactive'),

--- a/extensions/wikia/Lightbox/js/LightboxLoader.js
+++ b/extensions/wikia/Lightbox/js/LightboxLoader.js
@@ -59,8 +59,6 @@
 				if (LightboxLoader.reloadOnClose) {
 					window.location.reload();
 				}
-				// Make sure to remove the file=XXX part of the query string VID-1844
-				Lightbox.updateUrlState(true);
 			}
 		},
 		videoThumbWidthThreshold: 400,

--- a/extensions/wikia/Lightbox/js/LightboxLoader.js
+++ b/extensions/wikia/Lightbox/js/LightboxLoader.js
@@ -59,6 +59,8 @@
 				if (LightboxLoader.reloadOnClose) {
 					window.location.reload();
 				}
+				// Make sure to remove the file=XXX part of the query string VID-1844
+				Lightbox.updateUrlState(true);
 			}
 		},
 		videoThumbWidthThreshold: 400,


### PR DESCRIPTION
This way if the user clicks to another page and then uses the back button they don't incorrectly get the lightbox
