### PR TITLE
updating JSCS rules to match the new version

### DIFF
--- a/.jscs.json
+++ b/.jscs.json
@@ -2,6 +2,12 @@
 	"requireCurlyBraces": ["if", "else", "for", "while", "do"],
 	"requireSpaceAfterKeywords": ["if", "else", "for", "while", "do", "switch", "case", "catch", "return", "function"],
 	"requireParenthesesAroundIIFE": true,
+	"requireSpacesInConditionalExpression": {
+		"afterTest": true,
+		"beforeConsequent": true,
+		"afterConsequent": true,
+		"beforeAlternate": true
+	},
 	"requireSpacesInFunctionExpression": {
 		"beforeOpeningCurlyBrace": true
 	},
@@ -12,14 +18,12 @@
 	"disallowSpaceAfterObjectKeys": true,
 	"requireCommaBeforeLineBreak": true,
 	"requireOperatorBeforeLineBreak": ["?", "+", "-", "/", "*", "=", "==", "===", "!=", "!==", ">", ">=", "<", "<="],
-	"disallowLeftStickedOperators": ["?", "+", "/", "*", "-", "=", "==", "===", "!=", "!==", ">", ">=", "<", "<="],
-	"disallowRightStickedOperators": ["?", "/", "*", ":", "=", "==", "===", "!=", "!==", ">", ">=", "<", "<="],
-	"requireRightStickedOperators": ["!"],
-	"requireLeftStickedOperators": [","],
+	"disallowSpaceAfterBinaryOperators": ["!"],
+	"disallowSpaceBeforeBinaryOperators": [","],
 	"disallowSpaceAfterPrefixUnaryOperators": ["++", "--", "+", "-", "~"],
 	"disallowSpaceBeforePostfixUnaryOperators": ["++", "--"],
-	"requireSpaceBeforeBinaryOperators": ["+", "-", "/", "*", "=", "==", "===", "!=", "!=="],
-	"requireSpaceAfterBinaryOperators": ["+", "-", "/", "*", "=", "==", "===", "!=", "!=="],
+	"requireSpaceBeforeBinaryOperators": ["+", "-", "/", "*", "=", "==", "===", "!=", "!==", ">", ">=", "<", "<="],
+	"requireSpaceAfterBinaryOperators": ["+", "-", "/", "*", "=", "==", "===", "!=", "!==", ">", ">=", "<", "<="],
 	"disallowKeywords": [ "with" ],
 	"disallowMultipleLineStrings": true,
 	"disallowMultipleLineBreaks": true,


### PR DESCRIPTION
Per https://www.npmjs.org/package/jscs#removed-rules, rules have changed and our JSCS config was throwing errors with JSCS v1.5.8. 

To do: 
- [ ] make sure this is updated in the guidelines repo after merging. 

@kenkouot @hakubo @garthwebb 
