### PR TITLE
PLAT-373 short circuit addition article lookups

### DIFF
--- a/extensions/3rdparty/LyricWiki/ImageServing_LyricWiki.php
+++ b/extensions/3rdparty/LyricWiki/ImageServing_LyricWiki.php
@@ -95,9 +95,13 @@ function lw_ImageServingFallback(ImageServing $imageServing, $n, &$out){
 		}
 
 		// Some of the titles were real pages, use ImageServing to get the results and store them (by reference) in '$out'.
-		if(count($articleIds) > 0){
-			$imageServing = new ImageServing( $articleIds );
-			$out = $imageServing->getImages( $n );
+		if ( count( $articleIds ) > 0 ) {
+			// the ImageServing::fallbackOnNoResults hook is triggered in ImageServing::getImages.
+			// we don't want to cycle through here repeatedly on the same article ids
+			if ( !$imageServing->hasArticleIds( $articleIds ) ) {
+				$imageServing = new ImageServing( $articleIds );
+				$out = $imageServing->getImages( $n );
+			}
 		}
 	}
 

--- a/extensions/wikia/ImageServing/imageServing.class.php
+++ b/extensions/wikia/ImageServing/imageServing.class.php
@@ -54,12 +54,7 @@ class ImageServing {
 		}
 		$this->articles = array();
 
-		if( is_array( $articles ) ) {
-			foreach( $articles as $article ){
-				$articleId = ( int ) $article;
-				$this->articles[ $articleId ] = $articleId;
-			}
-		}
+		$this->setArticleIds( $articles );
 
 		$this->app = F::app();
 		$this->width = $width;
@@ -165,7 +160,7 @@ class ImageServing {
 				$out = $out + $driver->execute();
 			}
 
-			if(empty($out)){
+			if( empty( $out ) ) {
 				// Hook for finding fallback images if there were no matches. - NOTE: should this fallback any time (count($out) < $limit)? Seems like overkill.
 				wfRunHooks( 'ImageServing::fallbackOnNoResults', array( &$this, $limit, &$out ) );
 			}
@@ -379,5 +374,19 @@ class ImageServing {
 
 	public function setDeltaY( $iCenterPosition = 0 ){
 		$this->deltaY = $iCenterPosition;
+	}
+
+	public function setArticleIds( $articleIds ) {
+		if( is_array( $articleIds ) ) {
+			foreach ( $articleIds as $article ) {
+				$articleId = ( int ) $article;
+				$this->articles[ $articleId ] = $articleId;
+			}
+		}
+	}
+
+	public function hasArticleIds( $articleIds ) {
+		$containsArticleIds = array_diff( $articleIds, array_keys( $this->articles ) );
+		return empty( $containsArticleIds );
 	}
 }

--- a/extensions/wikia/ImageServing/tests/ImageServingUnitTest.php
+++ b/extensions/wikia/ImageServing/tests/ImageServingUnitTest.php
@@ -31,4 +31,23 @@ class ImageServingUnitTest extends WikiaBaseTest {
 		$this->assertEquals(300, $is->getRequestedWidth());
 		$this->assertEquals(150, $is->getRequestedHeight());
 	}
+
+	function testHasArticleIds() {
+		$is = new ImageServing(null, 200, 100);
+		$articles = array( 1234 );
+		$is->setArticleIds( $articles );
+		$this->assertTrue( $is->hasArticleIds( $articles ) );
+	}
+
+	function testHasArticleIdsDiff() {
+		$is = new ImageServing(null, 200, 100);
+		$is->setArticleIds( array( 1234 ) );
+		$this->assertFalse( $is->hasArticleIds( array( 1111 ) ) );
+	}
+
+	function testHasArticleIdsEmpty() {
+		$is = new ImageServing(null, 200, 100);
+		$articles = array( 1234 );
+		$this->assertFalse( $is->hasArticleIds( $articles ) );
+	}
 }


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-373

Only traverse an article for images once to prevent an infinite cycle between getImages and the fallbackOnNoResults hook.

/cc @macbre @SeanColombo 
