### PR TITLE
ImageServing: Thumbnail image not appearing in latest news articles

### DIFF
--- a/extensions/wikia/ImageServing/drivers/ImageServingDriverMainNS.class.php
+++ b/extensions/wikia/ImageServing/drivers/ImageServingDriverMainNS.class.php
@@ -43,6 +43,7 @@ class ImageServingDriverMainNS extends ImageServingDriverBase {
 
 		$this->mimeTypesBlacklist = array_unique($this->mimeTypesBlacklist);
 
+		wfDebug( sprintf( "%s: minor MIME types blacklist - %s\n", __CLASS__, join( ', ', $this->mimeTypesBlacklist ) ) );
 		wfProfileOut(__METHOD__);
 	}
 
@@ -130,20 +131,20 @@ class ImageServingDriverMainNS extends ImageServingDriverBase {
 
 			// get image usage
 			$sql = [];
+			$batchResponse = [];
+
 			foreach ( $imageRedirectsMap as $fromImg => $toImg ) {
+				// prepare the results array )see PLATFORM-358)
+				$batchResponse[$fromImg] = 0;
+
 				$sql[] = "(SELECT {$this->db->addQuotes($toImg)} AS il_to FROM {$imageLinksTable} JOIN {$pageTable} on page.page_id = il_from WHERE il_to = {$this->db->addQuotes($fromImg)} AND page_namespace IN ({$contentNamespaces}) LIMIT {$sqlCount} )";
 			}
 			$sql = implode(' UNION ALL ',$sql);
 			$batchResult = $this->db->query($sql, __METHOD__. '::imagelinks');
 
 			// do a "group by" on PHP side
-			$batchResponse = [];
 			foreach ($batchResult as $row) {
-				if ( !isset($batchResponse[$row->il_to]) ) {
-					$batchResponse[$row->il_to] = 1;
-				} else {
-					$batchResponse[$row->il_to]++;
-				}
+				$batchResponse[$row->il_to]++;
 			}
 			$batchResult->free();
 
@@ -196,6 +197,9 @@ class ImageServingDriverMainNS extends ImageServingDriverBase {
 				if ( $row->img_height >= $this->minHeight && $row->img_width >= $this->minWidth ) {
 					if ( !in_array( $row->img_minor_mime, $this->mimeTypesBlacklist ) ) {
 						$imageData[$row->img_name] = $row;
+					}
+					else {
+						wfDebug(__METHOD__ . ": {$row->img_name} - filtered out because of {$row->img_minor_mime} minor MIME type\n");
 					}
 				}
 			}

--- a/extensions/wikia/ImageServing/drivers/ImageServingDriverMainNS.class.php
+++ b/extensions/wikia/ImageServing/drivers/ImageServingDriverMainNS.class.php
@@ -135,7 +135,7 @@ class ImageServingDriverMainNS extends ImageServingDriverBase {
 
 			foreach ( $imageRedirectsMap as $fromImg => $toImg ) {
 				// prepare the results array )see PLATFORM-358)
-				$batchResponse[$fromImg] = 0;
+				$batchResponse[$toImg] = 0;
 
 				$sql[] = "(SELECT {$this->db->addQuotes($toImg)} AS il_to FROM {$imageLinksTable} JOIN {$pageTable} on page.page_id = il_from WHERE il_to = {$this->db->addQuotes($fromImg)} AND page_namespace IN ({$contentNamespaces}) LIMIT {$sqlCount} )";
 			}

--- a/maintenance/wikia/imageServing.php
+++ b/maintenance/wikia/imageServing.php
@@ -43,10 +43,13 @@ class ImageServingScript extends Maintenance {
 		$this->output(implode("\n", $images) . "\n");
 
 		// get filtered list of images
-		$im = new ImageServing( array( $title->getArticleID() ) );
+		global $wgAllowMemcacheReads;
+		$wgAllowMemcacheReads = false;
+
+		$im = new ImageServing( array( $title->getArticleID() ), 32, 32 );
 		$images = reset($im->getImages(20));
 
-		$this->output("\nImages list with filters applied:\n");
+		$this->output("\nImages list as returned by ImageServing (min size: 32x32 px):\n");
 
 		foreach($images as $image) {
 			$this->output("* {$image['name']}\n");


### PR DESCRIPTION
@Wikia/platform-team

This regression was caused by PLATFORM-285. Video (or any other image) that was used only on a single blog post (i.e. outside content namespace) was not added to the list of images with popularity score (calculated only for images used on content namespaces) and as a result not added to the list of images suggested for a given article.

PLATFORM-358
