### PR TITLE
PLATFORM-386 random wiki fatal error

### DIFF
--- a/extensions/wikia/RandomWiki/RandomWikiHelper.class.php
+++ b/extensions/wikia/RandomWiki/RandomWikiHelper.class.php
@@ -76,17 +76,18 @@ class RandomWikiHelper {
 
 				foreach ( $wikis as $wikiID => $pvCount ) {
 					if ( $pvCount >= $minPageViews ) {
-						$hub = WikiFactory::getCategoryId( $wikiID );
+						$hub = WikiFactoryHub::getInstance();
+						$cat_id = $hub->getCategoryId( $wikiID );
 
-						if ( !$hub ) {
+						if ( !$cat_id ) {
 							continue;
 						}
 
-						if ( !isset( self::$mData[ 'hubs' ][ $hub->cat_id ] ) ) {
-							self::$mData[ 'hubs' ][ $hub->cat_id ] = array( );
+						if ( !isset( self::$mData[ 'hubs' ][ $cat_id ] ) ) {
+							self::$mData[ 'hubs' ][ $cat_id ] = array( );
 						}
 
-						self::$mData[ 'hubs' ][ $hub->cat_id ][ ] = $wikiID;
+						self::$mData[ 'hubs' ][ $cat_id ][ ] = $wikiID;
 						$counter++;
 					}
 				}

--- a/extensions/wikia/RandomWiki/SpecialRandomWiki_body.php
+++ b/extensions/wikia/RandomWiki/SpecialRandomWiki_body.php
@@ -48,10 +48,12 @@ class RandomWiki extends SpecialPage {
 			$this->mCookie->history = array( );
 
 			if ( !empty( $wikiID ) ) {
-				$hub = WikiFactory::getCategoryId( $wikiID );
+				$hub = WikiFactoryHub::getInstance();
+				// FIXME: change this to verticalId
+				$cat_id = $hub->getCategoryId( $wikiID );
 
-				if ( is_object( $hub ) ) {
-					$this->mCookie->origHub = $hub->cat_id;
+				if ( $cat_id ) {
+					$this->mCookie->origHub = $cat_id;
 					$this->mCookie->langCode = WikiFactory::getWikiByID( $wikiID )->city_lang;
 					$this->mCookie->history[ ] = $wikiID;
 				}

--- a/extensions/wikia/WikiFactory/Hubs/WikiFactoryHub.php
+++ b/extensions/wikia/WikiFactory/Hubs/WikiFactoryHub.php
@@ -156,7 +156,7 @@ class WikiFactoryHub extends WikiaModel {
 				->FIELD( "vertical_url as url")
 				->FIELD( "vertical_short as short")
 			->FROM( "city_verticals" )
-			->cache ( $this->cache_ttl, wfSharedMemcKey("WFHub", __METHOD__) )
+			->cache ( $this->cache_ttl, wfSharedMemcKey(__METHOD__) )
 			->runLoop( $this->getSharedDB(), function ( &$result, $row)  {
 				$result[] = get_object_vars($row);
 			});
@@ -187,7 +187,7 @@ class WikiFactoryHub extends WikiaModel {
 			->JOIN ( "city_cat_mapping" )->USING( "cat_id" )
 			->WHERE( "city_id" )->EQUAL_TO( $city_id )
 			->AND_( "cat_deprecated" )->EQUAL_TO ( 1 )  // always return the "old" category
-			->cache( $this->cache_ttl, wfMemcKey( "WFHub", __METHOD__ ) )
+			->cache( $this->cache_ttl, wfSharedMemcKey( __METHOD__, $city_id ) )
 			->runLoop ( $this->getSharedDB(), function ( &$result, $row ) {
 				$result[]= $row->cat_id;
 			});
@@ -216,7 +216,7 @@ class WikiFactoryHub extends WikiaModel {
 			->SELECT( "city_vertical" )
 			->FROM( "city_list" )
 			->WHERE ("city_id")->EQUAL_TO( $city_id )
-			->cache( $this->$cache_ttl, wfMemcKey( "WFHub", __METHOD__ ) )
+			->cache( $this->$cache_ttl, wfSharedMemcKey( __METHOD__, $city_id ) )
 			->runLoop( $this->getSharedDB() );
 
 		return $id;
@@ -236,7 +236,7 @@ class WikiFactoryHub extends WikiaModel {
 
 	public function getCategoryIds( $city_id, $active = 1 ) {
 		global $wgExternalSharedDB;
-		if( !$wgExternalSharedDB ) {
+		if( !$wgExternalSharedDB || empty($city_id) ) {
 			return array();
 		}
 
@@ -246,7 +246,7 @@ class WikiFactoryHub extends WikiaModel {
 			->JOIN ( "city_cat_mapping" )->USING( "cat_id" )
 			->WHERE( "city_id" )->EQUAL_TO( $city_id )
 			->AND_( "cat_active" )->EQUAL_TO ( $active )
-			->cache( $this->cache_ttl, wfMemcKey( "WFHub", __METHOD__ ) )
+			->cache( $this->cache_ttl, wfSharedMemcKey( __METHOD__, $city_id ) )
 			->runLoop ( $this->getSharedDB(), function ( &$result, $row ) {
 				$result[]= $row->cat_id;
 			});
@@ -270,7 +270,7 @@ class WikiFactoryHub extends WikiaModel {
 			->JOIN ( "city_cat_mapping" )->USING( "cat_id" )
 			->WHERE( "city_id ")->EQUAL_TO( $city_id )
 			->AND_( "cat_active" )->EQUAL_TO ( $active )
-			->cache ( $this->cache_ttl, wfMemcKey( "WFHub", __METHOD__ ) )
+			->cache ( $this->cache_ttl, wfSharedMemcKey( __METHOD__, $city_id ) )
 			->runLoop( $this->getSharedDB(), function ( &$result, $row)  {
 				$result[] = get_object_vars($row);
 			});
@@ -281,7 +281,7 @@ class WikiFactoryHub extends WikiaModel {
 
 	/**
 	 * get single category name for a wiki
-	 * This is deprecated, use getCategoriesForWiki instead
+	 * This is deprecated, use getWikiCategories instead
 	 * @deprecated
 	 */
 	public function getCategoryName( $city_id ) {
@@ -294,7 +294,7 @@ class WikiFactoryHub extends WikiaModel {
 
 	/**
 	 * get single "short" category name for a wiki
-	 * This is deprecated, use getCategoriesForWiki instead
+	 * This is deprecated, use getWikiCategories instead
 	 * @param  [type] $city_id [description]
 	 * @return [type]          [description]
 	 * @deprecated
@@ -393,7 +393,7 @@ class WikiFactoryHub extends WikiaModel {
 				->FIELD( "cat_deprecated as deprecated")
 				->FIELD( "cat_active as active")
 			->FROM( "city_cats" )
-			->cache ( $this->cache_ttl, wfSharedMemcKey( "WFHub", __METHOD__ ))  // global cache
+			->cache ( $this->cache_ttl, wfSharedMemcKey( __METHOD__ ))  // global cache
 			->runLoop( $this->getSharedDB(), function (&$result, $row) {
 				$arr = get_object_vars($row);
 				//$result['all'][] = $arr;
@@ -469,7 +469,7 @@ class WikiFactoryHub extends WikiaModel {
 	public function addCategory ( $city_id, $category ) {
 
 		$current_categories = $this->getCategoryIds( $city_id );
-		$new_categories = array_merge( $current_categories, [$category] );
+		$new_categories = array_unique(array_merge( $current_categories, [$category] ));
 
 		$this->updateCategories( $city_id, $new_categories );
 
@@ -478,7 +478,7 @@ class WikiFactoryHub extends WikiaModel {
 	public function removeCategory ( $city_id, $category ) {
 
 		$current_categories = $this->getCategoryIds( $city_id );
-		$new_categories = array_diff( $current_categories, [$category] );
+		$new_categories = array_unique(array_diff( $current_categories, [$category] ));
 
 		$this->updateCategories( $city_id, $new_categories );
 	}
@@ -524,9 +524,10 @@ class WikiFactoryHub extends WikiaModel {
 	public function clearCache($city_id) {
 		global $wgMemc;
 
-		$keys = [ "getVerticalId", "getCategoryId", "getWikiCategories" ];
-		foreach ($keys as $key) {
-			$wgMemc->delete($city_id . "WFHub", $key);
+		// Extra : is added to make keys that look like __METHOD__ calls
+		$functionNames = [ "getVerticalId", "getCategoryId", "getCategoryIds", "getWikiCategories" ];
+		foreach ($functionNames as $name) {
+			$wgMemc->delete( wfSharedMemcKey("WikiFactoryHub:", $name, $city_id ) );
 		}
 	}
 


### PR DESCRIPTION
WikiFactory::getCategoryId was deleted, and I missed 2 calls for it, which need to change to use WikiFactoryHub.  During investigation of a separate bug I discovered that the memcache keys for the categories were pretty messed up, so I merged that fix as well.  
