### PR TITLE
PLAT-345 pass $user param further down the stack

### DIFF
--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -740,7 +740,7 @@ class ArticleComment {
 
 		$bot = $user->isAllowed('bot');
 
-		return $editPage->internalAttemptSave( $result, $bot );
+		return $editPage->internalAttemptSave( $result, $bot, $user );
 	}
 
 	/**

--- a/extensions/wikia/HAWelcome/HAWelcomeTask.php
+++ b/extensions/wikia/HAWelcome/HAWelcomeTask.php
@@ -329,6 +329,7 @@ class HAWelcomeTask extends BaseTask {
 
 	protected function postWallMessageToRecipient() {
 		$this->info( "creating a welcome wall message" );
+		// always send these messages as the defaultWelcomeUser
 		$mWallMessage = WallMessage::buildNewMessageAndPost(
 			$this->welcomeMessage, $this->recipientName, $this->getDefaultWelcomerUser(),
 			$this->getTextVersionOfMessage( 'welcome-message-log' ), false, array(), false, false
@@ -352,12 +353,14 @@ class HAWelcomeTask extends BaseTask {
 
 		$this->info( sprintf( "posting talkpage message to %s from %s",
 			$this->recipientObject->getName(), $this->senderObject->getName() ) );
+
+		// always send these messages as the defaultWelcomeUser
 		$this->getRecipientTalkPage()->doEdit(
 			$welcomeMessage,
 			$this->getTextVersionOfMessage( 'welcome-message-log' ),
 			$this->integerFlags,
 			false,
-			$this->senderObject
+			$this->getDefaultWelcomerUser()
 		);
 	}
 


### PR DESCRIPTION
ArticleComment::doSaveAsArticle was not passing the $user object to
EditPage::internalAttemptSave which uses the $wgUser global by default.
As a result, the HAWelcome wall messages were being posted as the
"defualt" $wgUser when it's not set which is 127.0.0.1.

To fix this, I added a $user parameter to internalAttemptSave and pass
it down the call stack.

Additionally, instead of using the senderObject, we use the default welcome
user when posting to the talk page. The senderObject is still used to
create the message payload.

/cc @owend @michalroszka 
