### PR TITLE
WikiaLogger: add backtrace for errors (PLATFORM-363)

### DIFF
--- a/includes/db/DatabaseError.php
+++ b/includes/db/DatabaseError.php
@@ -22,11 +22,11 @@ class DBError extends MWException {
 
 		// Wikia change - @author macbre - MAIN-2304
 		\Wikia\Logger\WikiaLogger::instance()->error('DBError', [
-			'msg' => $error,
 			'name' => $db->getDBname(),
 			'server' => $db->getServer(),
 			'errno' => $db->lastErrno(),
 			'err' => $db->lastError(),
+			'exception' => $this,
 		]);
 	}
 

--- a/includes/wikia/nirvana/WikiaException.php
+++ b/includes/wikia/nirvana/WikiaException.php
@@ -52,13 +52,15 @@ abstract class WikiaBaseException extends MWException {
  */
 class WikiaException extends WikiaBaseException {
 	public function __construct($message = '', $code = 0, Exception $previous = null) {
-		global $wgRunningUnitTests, $wgNoDBUnits;
+		global $wgRunningUnitTests;
 		parent::__construct( $message, $code, $previous );
 
-		if (!$wgRunningUnitTests && $wgNoDBUnits) {
-			// log more details (macbre)
-		Wikia::log( 'exceptions-WIKIA', get_class($this), $message, true );
-			Wikia::logBacktrace( __METHOD__ );
+		if (!$wgRunningUnitTests) {
+			\Wikia\Logger\WikiaLogger::instance()->error(__CLASS__, [
+				'err' => $message,
+				'errno' => $code,
+				'exception' => $this,
+			]);
 		}
 	}
 }

--- a/lib/Wikia/src/Logger/Hooks.php
+++ b/lib/Wikia/src/Logger/Hooks.php
@@ -17,15 +17,15 @@ class Hooks {
 	 * @return boolean
 	 *
 	 */
-	public static function onWikiaSkinTopScripts(&$vars, &$scripts) {
+	public static function onWikiaSkinTopScripts( &$vars, &$scripts ) {
 		global $wgDevelEnvironment, $wgIsGASpecialWiki, $wgEnableJavaScriptErrorLogging, $wgCacheBuster, $wgMemc;
 
-		if (!$wgDevelEnvironment) {
+		if ( !$wgDevelEnvironment ) {
 			$onError = $wgIsGASpecialWiki || $wgEnableJavaScriptErrorLogging;
 			$key = "wikialogger-top-script-$onError";
-			$loggingJs = $wgMemc->get($key);
+			$loggingJs = $wgMemc->get( $key );
 
-			if (!$loggingJs) {
+			if ( !$loggingJs ) {
 				$errorUrl = "//jserrorslog.wikia.com/";
 				$loggingJs = "
 					function syslogReport(priority, message, context) {
@@ -53,7 +53,7 @@ class Hooks {
 					}
 				";
 
-				if ($onError) {
+				if ( $onError ) {
 					$loggingJs .= "
 						window.onerror = function(m, u, l) {
 							if (Math.random() < 0.01) {
@@ -65,8 +65,8 @@ class Hooks {
 					";
 				}
 
-				$loggingJs = \AssetsManagerBaseBuilder::minifyJS($loggingJs);
-				$wgMemc->set($key, $loggingJs, 60*60*24);
+				$loggingJs = \AssetsManagerBaseBuilder::minifyJS( $loggingJs );
+				$wgMemc->set( $key, $loggingJs, 60 * 60 * 24 );
 			}
 
 			$scripts = "<script>$loggingJs</script>$scripts";
@@ -81,9 +81,9 @@ class Hooks {
 	 * @param \WikiFactoryLoader $wikiFactoryLoader
 	 * @return boolean true
 	 */
-	public static function onWikiFactoryExecute(\WikiFactoryLoader $wikiFactoryLoader) {
+	public static function onWikiFactoryExecute( \WikiFactoryLoader $wikiFactoryLoader ) {
 		global $wgDevelEnvironment;
-		if ($wgDevelEnvironment) {
+		if ( $wgDevelEnvironment ) {
 			// default to syslog in dev. you can override this in DevBoxSettings.php
 			WikiaLogger::instance()->setDevMode();
 		}
@@ -93,55 +93,61 @@ class Hooks {
 		 */
 		$logger = WikiaLogger::instance();
 
-		set_error_handler([$logger, 'onError'], error_reporting());
-		register_shutdown_function([$logger, 'onShutdown']);
+		set_error_handler( [$logger, 'onError'], error_reporting() );
+		register_shutdown_function( [$logger, 'onShutdown'] );
 
 		return true;
 	}
 
-	public static function onWikiFactoryExecuteComplete(\WikiFactoryLoader $wikiFactoryLoader) {
+	/**
+	 * A hook for setting additional fields that will be sent to Logstash
+	 *
+	 * @param \WikiFactoryLoader $wikiFactoryLoader
+	 * @return bool true
+	 */
+	public static function onWikiFactoryExecuteComplete( \WikiFactoryLoader $wikiFactoryLoader ) {
 		global $wgRequest, $wgDBname, $wgCityId;
 
 		$fields = [];
-		
-		if (!empty($wgDBname)) {
+
+		if ( !empty( $wgDBname ) ) {
 			$fields['db_name'] = $wgDBname;
 		}
 
-		if (!empty($wgCityId)) {
+		if ( !empty( $wgCityId ) ) {
 			$fields['city_id'] = $wgCityId;
 		}
 
-		if (isset($_SERVER['REQUEST_URI'])) {
+		if ( isset( $_SERVER['REQUEST_URI'] ) ) {
 			$fields['url'] = $_SERVER['REQUEST_URI'];
 
-			$ip = !empty($wgRequest) ? $wgRequest->getIP() : null;
-			if ($ip === null) {
-				$ip = isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : null;
+			$ip = !empty( $wgRequest ) ? $wgRequest->getIP() : null;
+			if ( $ip === null ) {
+				$ip = isset( $_SERVER['REMOTE_ADDR'] ) ? $_SERVER['REMOTE_ADDR'] : null;
 			}
 
-			if ($ip != null) {
+			if ( $ip != null ) {
 				$fields['ip'] = $ip;
 			}
 
-			if (isset($_SERVER['REQUEST_METHOD'])) {
+			if ( isset( $_SERVER['REQUEST_METHOD'] ) ) {
 				$fields['http_method'] = $_SERVER['REQUEST_METHOD'];
 			}
 
-			if (isset($_SERVER['SERVER_NAME'])) {
+			if ( isset( $_SERVER['SERVER_NAME'] ) ) {
 				$fields['server'] = $_SERVER['SERVER_NAME'];
 			}
 
-			if (isset($_SERVER['HTTP_REFERER'])) {
+			if ( isset( $_SERVER['HTTP_REFERER'] ) ) {
 				$fields['referrer'] = $_SERVER['HTTP_REFERER'];
 			}
 
-			if (isset($_SERVER['UNIQUE_ID'])) {
+			if ( isset( $_SERVER['UNIQUE_ID'] ) ) {
 				$fields['unique_id'] = $_SERVER['UNIQUE_ID'];
 			}
 		}
 
-		WikiaLogger::instance()->pushContext($fields, WebProcessor::RECORD_TYPE_FIELDS);
+		WikiaLogger::instance()->pushContext( $fields, WebProcessor::RECORD_TYPE_FIELDS );
 
 		return true;
 	}

--- a/lib/Wikia/src/Logger/LogstashFormatter.php
+++ b/lib/Wikia/src/Logger/LogstashFormatter.php
@@ -36,7 +36,6 @@ class LogstashFormatter extends \Monolog\Formatter\LogstashFormatter implements 
 		}
 
 		if (!empty($record['context'])) {
-			// macbre: log exception details
 			if (!empty($record['context']['exception'])) {
 				$message['@exception'] = $record['context']['exception'];
 				unset($record['context']['exception']);

--- a/lib/Wikia/src/Logger/LogstashFormatter.php
+++ b/lib/Wikia/src/Logger/LogstashFormatter.php
@@ -36,6 +36,12 @@ class LogstashFormatter extends \Monolog\Formatter\LogstashFormatter implements 
 		}
 
 		if (!empty($record['context'])) {
+			// macbre: log exception details
+			if (!empty($record['context']['exception'])) {
+				$message['@exception'] = $record['context']['exception'];
+				unset($record['context']['exception']);
+			}
+
 			$message['@context'] = $record['context'];
 		}
 


### PR DESCRIPTION
@Wikia/platform-team  / @nmonterroso 

This PR adds a support for `exception` field in context that can be used to pass `Exception` class instance. This field will then be renamed to `@exception` and contain message and error code from the exception and  backtrace array.

An example:

``` php
wfGetDB(DB_SLAVE)->query('select * from foo')
```

Data sent to Logstash:

``` json
{
  "@timestamp": "2014-07-31T11:56:30.308522+00:00",
  "@message": "DBError",
  "@fields": {
    "db_name": "muppet",
    "city_id": "831"
  },
  "@exception": {
    "class": "DBQueryError",
    "message": "A database error has occurred.  Did you forget to run maintenance/update.php after upgrading?  See: https://www.mediawiki.org/wiki/Manual:Upgrading#Run_the_update_script\nQuery: select * from foo\nFunction: \nError: 1146 Table 'muppet.foo' doesn't exist (10.14.30.141)\n",
    "file": "/usr/wikia/source/app/includes/db/Database.php:941",
    "trace": [
      "/usr/wikia/source/app/includes/db/Database.php:908",
      "/usr/wikia/source/app/maintenance/eval.php(72) : eval()'d code:1",
      "/usr/wikia/source/app/maintenance/eval.php:72"
    ]
  },
  "@context": {
    "name": "muppet",
    "server": "10.14.30.141",
    "errno": 1146,
    "err": "Table 'muppet.foo' doesn't exist (10.14.30.141)"
  }
}
```
