### PR TITLE
POC Wrap global state: Not because you want to, but because sometimes you have to

### DIFF
--- a/lib/Wikia/src/Util/GlobalStateWrapper.php
+++ b/lib/Wikia/src/Util/GlobalStateWrapper.php
@@ -1,0 +1,72 @@
+<?php
+/*
+ * Not because you want to, but because you have to.
+ *
+ * Example usage:
+ * $wrapper = new GlobalStateWrapper(array('wgUser' => $user));
+ * $wrapper->wrap(function () {
+ *		// ... do some stuff with core that expects $wgUser
+ * });
+ *
+ * if ($wrapper->getException()) {
+ *	  // oops, something went wrong, but I don't need to clean up $wgUser
+ *    // because that's been done for me
+ * }
+ */
+
+namespace Wikia\Util;
+
+class GlobalStateWrapper {
+
+	private $caughtException = null;
+
+	private $globalsToWrap = null;
+
+	private $capturedState = null;
+
+
+	/**
+	 * @param array $globalsToWrap key value pair of global name and overriding value
+	 */
+	function __construct(array $globalsToWrap) {
+		$this->globalsToWrap = $globalsToWrap;
+	}
+
+	public function wrap($function) {
+		$result = null;
+		$this->captureState();
+
+		try {
+			$result = $function();
+		} catch (\Exception $e) {
+			$this->caughtException = $e;
+		}
+
+		$this->restoreState();
+
+		return $result;
+	}
+
+	public function setCaughtException(Exception $e) {
+		$this->caughtException = $e;
+	}
+
+	public function getException() {
+		return $this->caughtException;
+	}
+
+	protected function captureState() {
+		$this->capturedState = array();
+		foreach($this->globalsToWrap as $globalKey => $globalValue) {
+			$this->capturedState[$globalKey] = $GLOBALS[$globalKey];
+			$GLOBALS[$globalKey] = $globalValue;
+		}
+	}
+
+	protected function restoreState() {
+		foreach($this->globalsToWrap as $globalKey => $globalValue) {
+			$GLOBALS[$globalKey] = $this->capturedState[$globalKey];
+		}
+	}
+
+}

--- a/lib/Wikia/src/Util/GlobalStateWrapper.php
+++ b/lib/Wikia/src/Util/GlobalStateWrapper.php
@@ -9,8 +9,8 @@
  * });
  *
  * if ($wrapper->getException()) {
- *	  // oops, something went wrong, but I don't need to clean up $wgUser
- *    // because that's been done for me
+ *	// oops, something went wrong, but I don't need to clean up $wgUser
+ *	// because that's been done for me
  * }
  */
 
@@ -28,17 +28,17 @@ class GlobalStateWrapper {
 	/**
 	 * @param array $globalsToWrap key value pair of global name and overriding value
 	 */
-	function __construct(array $globalsToWrap) {
+	function __construct( array $globalsToWrap ) {
 		$this->globalsToWrap = $globalsToWrap;
 	}
 
-	public function wrap($function) {
+	public function wrap( $function ) {
 		$result = null;
 		$this->captureState();
 
 		try {
 			$result = $function();
-		} catch (\Exception $e) {
+		} catch ( \Exception $e ) {
 			$this->caughtException = $e;
 		}
 
@@ -47,7 +47,7 @@ class GlobalStateWrapper {
 		return $result;
 	}
 
-	public function setCaughtException(Exception $e) {
+	public function setCaughtException( Exception $e ) {
 		$this->caughtException = $e;
 	}
 
@@ -57,14 +57,14 @@ class GlobalStateWrapper {
 
 	protected function captureState() {
 		$this->capturedState = array();
-		foreach($this->globalsToWrap as $globalKey => $globalValue) {
+		foreach ( $this->globalsToWrap as $globalKey => $globalValue ) {
 			$this->capturedState[$globalKey] = $GLOBALS[$globalKey];
 			$GLOBALS[$globalKey] = $globalValue;
 		}
 	}
 
 	protected function restoreState() {
-		foreach($this->globalsToWrap as $globalKey => $globalValue) {
+		foreach ( $this->globalsToWrap as $globalKey => $globalValue ) {
 			$GLOBALS[$globalKey] = $this->capturedState[$globalKey];
 		}
 	}

--- a/lib/Wikia/tests/Util/GlobalStateWrapperTest.php
+++ b/lib/Wikia/tests/Util/GlobalStateWrapperTest.php
@@ -40,17 +40,18 @@ class GlobalStateWrapperTest extends PHPUnit_Framework_TestCase {
 			'arrayGlobalState'  => $newArray
 		) );
 
-		$exceptionMessage = "an exception";
+		$exceptionWasThrown = false;
+		$result = null;
 		try {
-			$result = $wrapper->wrap( function () use ( $exceptionMessage ) {
-				throw new Exception( $exceptionMessage );
+			$result = $wrapper->wrap( function () {
+				throw new Exception( 'foo' );
 			} );
 		} catch ( Exception $e ) {
-			$this->fail( "caught outside" );
+			$exceptionWasThrown = true;
 		}
 
 		$this->assertNull( $result );
-		$this->assertEquals( $exceptionMessage, $wrapper->getException()->getMessage() );
+		$this->assertTrue( $exceptionWasThrown );
 
 		// make sure they are restored after the exception
 		$this->assertEquals( $this->scalarValue, $GLOBALS['scalarGlobalState'] );
@@ -79,9 +80,16 @@ class GlobalStateWrapperTest extends PHPUnit_Framework_TestCase {
 		} );
 
 		$this->assertEquals( array( 'a', 'b' ), $result );
-		$this->assertNull( $wrapper->getException() );
 		$this->assertEquals( $this->scalarValue, $scalarGlobalState );
 		$this->assertEquals( $this->arrayValue, $arrayGlobalState );
+	}
+
+	/**
+	 * @expectedException     InvalidArgumentException
+	 */
+	public function testWrapWithNotCallable() {
+		$wrapper = new GlobalStateWrapper( array() );
+		$wrapper->wrap( 'foo' );
 	}
 
 }

--- a/lib/Wikia/tests/Util/GlobalStateWrapperTest.php
+++ b/lib/Wikia/tests/Util/GlobalStateWrapperTest.php
@@ -5,7 +5,7 @@ use Wikia\Util\GlobalStateWrapper;
 class GlobalStateWrapperTest extends PHPUnit_Framework_TestCase {
 
 	private $scalarValue = "a-scalar-value";
-	private $arrayValue = array('foo' => 'bar');
+	private $arrayValue = array( 'foo' => 'bar' );
 
 
 	public function testWrapOveride() {
@@ -13,20 +13,20 @@ class GlobalStateWrapperTest extends PHPUnit_Framework_TestCase {
 		$GLOBALS['arrayGlobalState'] = $this->arrayValue;
 
 		$newScalar = 'new-scalar';
-		$newArray  = array('fizz' => 'buzz');
-		$wrapper = new GlobalStateWrapper(array(
+		$newArray  = array( 'fizz' => 'buzz' );
+		$wrapper = new GlobalStateWrapper( array(
 			'scalarGlobalState' => $newScalar,
 			'arrayGlobalState'  => $newArray
-		));
+		) );
 
-		$result = $wrapper->wrap(function() {
+		$result = $wrapper->wrap( function() {
 			global $scalarGlobalState, $arrayGlobalState;
-			return array($scalarGlobalState, $arrayGlobalState);
-		});
+			return array( $scalarGlobalState, $arrayGlobalState );
+		} );
 
-		$this->assertEquals(array($newScalar, $newArray), $result);
-		$this->assertEquals($this->scalarValue, $GLOBALS['scalarGlobalState']);
-		$this->assertEquals($this->arrayValue, $GLOBALS['arrayGlobalState']);
+		$this->assertEquals( array( $newScalar, $newArray ), $result );
+		$this->assertEquals( $this->scalarValue, $GLOBALS['scalarGlobalState'] );
+		$this->assertEquals( $this->arrayValue, $GLOBALS['arrayGlobalState'] );
 	}
 
 	public function testWrapException() {
@@ -34,27 +34,27 @@ class GlobalStateWrapperTest extends PHPUnit_Framework_TestCase {
 		$GLOBALS['arrayGlobalState'] = $this->arrayValue;
 
 		$newScalar = 'new-scalar';
-		$newArray  = array('fizz' => 'buzz');
-		$wrapper = new GlobalStateWrapper(array(
+		$newArray  = array( 'fizz' => 'buzz' );
+		$wrapper = new GlobalStateWrapper( array(
 			'scalarGlobalState' => $newScalar,
 			'arrayGlobalState'  => $newArray
-		));
+		) );
 
 		$exceptionMessage = "an exception";
 		try {
-			$result = $wrapper->wrap(function () use ($exceptionMessage) {
-				throw new Exception($exceptionMessage);
-			});
-		} catch (Exception $e) {
-			$this->fail("caught outside");
+			$result = $wrapper->wrap( function () use ( $exceptionMessage ) {
+				throw new Exception( $exceptionMessage );
+			} );
+		} catch ( Exception $e ) {
+			$this->fail( "caught outside" );
 		}
 
-		$this->assertNull($result);
-		$this->assertEquals($exceptionMessage, $wrapper->getException()->getMessage());
+		$this->assertNull( $result );
+		$this->assertEquals( $exceptionMessage, $wrapper->getException()->getMessage() );
 
 		// make sure they are restored after the exception
-		$this->assertEquals($this->scalarValue, $GLOBALS['scalarGlobalState']);
-		$this->assertEquals($this->arrayValue, $GLOBALS['arrayGlobalState']);
+		$this->assertEquals( $this->scalarValue, $GLOBALS['scalarGlobalState'] );
+		$this->assertEquals( $this->arrayValue, $GLOBALS['arrayGlobalState'] );
 	}
 
 	public function testWrapOverrideAndSet() {
@@ -63,25 +63,25 @@ class GlobalStateWrapperTest extends PHPUnit_Framework_TestCase {
 		$GLOBALS['arrayGlobalState'] = $this->arrayValue;
 
 		$newScalar = 'new-scalar';
-		$newArray  = array('fizz' => 'buzz');
-		$wrapper = new GlobalStateWrapper(array(
+		$newArray  = array( 'fizz' => 'buzz' );
+		$wrapper = new GlobalStateWrapper( array(
 			'scalarGlobalState' => $newScalar,
 			'arrayGlobalState'  => $newArray
-		));
+		) );
 
-		$result = $wrapper->wrap(function() use ($newScalar, $newArray) {
+		$result = $wrapper->wrap( function() use ( $newScalar, $newArray ) {
 			global $scalarGlobalState, $arrayGlobalState;
-			assert($scalarGlobalState == $newScalar);
-			assert($arrayGlobalState == $newArray);
+			assert( $scalarGlobalState == $newScalar );
+			assert( $arrayGlobalState == $newArray );
 			$scalarGlobalState = 'a';
 			$arrayGlobalState = 'b';
-			return array($scalarGlobalState, $arrayGlobalState);
-		});
+			return array( $scalarGlobalState, $arrayGlobalState );
+		} );
 
-		$this->assertEquals(array('a', 'b'), $result);
-		$this->assertNull($wrapper->getException());
-		$this->assertEquals($this->scalarValue, $scalarGlobalState);
-		$this->assertEquals($this->arrayValue, $arrayGlobalState);
+		$this->assertEquals( array( 'a', 'b' ), $result );
+		$this->assertNull( $wrapper->getException() );
+		$this->assertEquals( $this->scalarValue, $scalarGlobalState );
+		$this->assertEquals( $this->arrayValue, $arrayGlobalState );
 	}
 
 }

--- a/lib/Wikia/tests/Util/GlobalStateWrapperTest.php
+++ b/lib/Wikia/tests/Util/GlobalStateWrapperTest.php
@@ -1,0 +1,87 @@
+<?php
+
+use Wikia\Util\GlobalStateWrapper;
+
+class GlobalStateWrapperTest extends PHPUnit_Framework_TestCase {
+
+	private $scalarValue = "a-scalar-value";
+	private $arrayValue = array('foo' => 'bar');
+
+
+	public function testWrapOveride() {
+		$GLOBALS['scalarGlobalState'] = $this->scalarValue;
+		$GLOBALS['arrayGlobalState'] = $this->arrayValue;
+
+		$newScalar = 'new-scalar';
+		$newArray  = array('fizz' => 'buzz');
+		$wrapper = new GlobalStateWrapper(array(
+			'scalarGlobalState' => $newScalar,
+			'arrayGlobalState'  => $newArray
+		));
+
+		$result = $wrapper->wrap(function() {
+			global $scalarGlobalState, $arrayGlobalState;
+			return array($scalarGlobalState, $arrayGlobalState);
+		});
+
+		$this->assertEquals(array($newScalar, $newArray), $result);
+		$this->assertEquals($this->scalarValue, $GLOBALS['scalarGlobalState']);
+		$this->assertEquals($this->arrayValue, $GLOBALS['arrayGlobalState']);
+	}
+
+	public function testWrapException() {
+		$GLOBALS['scalarGlobalState'] = $this->scalarValue;
+		$GLOBALS['arrayGlobalState'] = $this->arrayValue;
+
+		$newScalar = 'new-scalar';
+		$newArray  = array('fizz' => 'buzz');
+		$wrapper = new GlobalStateWrapper(array(
+			'scalarGlobalState' => $newScalar,
+			'arrayGlobalState'  => $newArray
+		));
+
+		$exceptionMessage = "an exception";
+		try {
+			$result = $wrapper->wrap(function () use ($exceptionMessage) {
+				throw new Exception($exceptionMessage);
+			});
+		} catch (Exception $e) {
+			$this->fail("caught outside");
+		}
+
+		$this->assertNull($result);
+		$this->assertEquals($exceptionMessage, $wrapper->getException()->getMessage());
+
+		// make sure they are restored after the exception
+		$this->assertEquals($this->scalarValue, $GLOBALS['scalarGlobalState']);
+		$this->assertEquals($this->arrayValue, $GLOBALS['arrayGlobalState']);
+	}
+
+	public function testWrapOverrideAndSet() {
+		global $scalarGlobalState, $arrayGlobalState;
+		$GLOBALS['scalarGlobalState'] = $this->scalarValue;
+		$GLOBALS['arrayGlobalState'] = $this->arrayValue;
+
+		$newScalar = 'new-scalar';
+		$newArray  = array('fizz' => 'buzz');
+		$wrapper = new GlobalStateWrapper(array(
+			'scalarGlobalState' => $newScalar,
+			'arrayGlobalState'  => $newArray
+		));
+
+		$result = $wrapper->wrap(function() use ($newScalar, $newArray) {
+			global $scalarGlobalState, $arrayGlobalState;
+			assert($scalarGlobalState == $newScalar);
+			assert($arrayGlobalState == $newArray);
+			$scalarGlobalState = 'a';
+			$arrayGlobalState = 'b';
+			return array($scalarGlobalState, $arrayGlobalState);
+		});
+
+		$this->assertEquals(array('a', 'b'), $result);
+		$this->assertNull($wrapper->getException());
+		$this->assertEquals($this->scalarValue, $scalarGlobalState);
+		$this->assertEquals($this->arrayValue, $arrayGlobalState);
+	}
+
+}


### PR DESCRIPTION
There is a common pattern in the code that violates the [principle of least surprise](http://en.wikipedia.org/wiki/Principle_of_least_astonishment) and breaks encapsulation. It goes something like this:

``` PHP
global $wgUser;
$saveWgUser = $wgUser;
$wgUser = $theUserIWantItToBe.

// do something (sometimes lots of things), that has side effects using 
// $wgUser but doesn't take a $user parameter in MediaWiki core or pass
// it down the call stack

$wgUser = $saveWgUser;
```

Generally this is a terrible practice but has been accommodated in the MediaWiki code base for various reasons. Some of those reasons may be legitimate such as not wanting to modify or alter a heavily used core component that has little or no testing. We do this not because we want to, but because sometimes we have to.

This save/restore pattern also creates an additional plane of state that the code reader (and author) has to mentally track. The code base is large and complex enough that we don't need these distractions. 

This pull request attempts to address this by adding a global state wrapper. This may best be illustrated by an example. The example above using the wrapper would look like this:

``` PHP
$wrapper = new GlobalStateWrapper(array('wgUser' => $$theUserIWantItToBe));
$result = $wrapper->wrap(function () {
   // do something (hopefully one thing) that has side effects using $wgUser but doesn't take a $user
   // parameter in MediaWiki core
});
```

This has three benefits. First, it gives a very clear signal to the reader of the code what is happening which should free them to focus on more important details. Second, it handles all of the boilerplate of saving and restoring the `$wgUser` variable. And finally, if something goes wrong, you don't have to litter your code with `try/catch` statements that restore the state of `$wgUser` should something go wrong. 

The inspiration came from [here](https://github.com/Wikia/app/pull/4336) and [here](https://github.com/Wikia/app/pull/4319#discussion-diff-15655235R46). Feedback is welcome.

@Wikia/platform-team @garthwebb @inez
