### PR TITLE
PLAT-345 wrap $wgUser object when posting to wall

### DIFF
--- a/extensions/wikia/HAWelcome/HAWelcomeTask.php
+++ b/extensions/wikia/HAWelcome/HAWelcomeTask.php
@@ -334,15 +334,15 @@ class HAWelcomeTask extends BaseTask {
 		// some of the lower level methods used in buildNewMessageAndPost do not pass the
 		// $user object down the call stack and instead rely on the $wgUser which is
 		// not set in a Task environment
-		$wrapper = new GlobalStateWrapper(array(
+		$wrapper = new GlobalStateWrapper( array(
 			'wgUser' => $defaultWelcomeUser
-		));
+		) );
 
 		$this->info( "creating a welcome wall message" );
 		$welcomeMessage = $this->welcomeMessage;
 		$recipientName  = $this->recipientName;
 		$textMessage    = $this->getTextVersionOfMessage( 'welcome-message-log' );
-		$wrapper->wrap(function () use ($welcomeMessage, $recipientName, $defaultWelcomeUser) {
+		$wrapper->wrap( function () use ( $welcomeMessage, $recipientName, $defaultWelcomeUser ) {
 			$mWallMessage = WallMessage::buildNewMessageAndPost(
 				$welcomeMessage, $recipientName, $defaultWelcomeUser,
 				$textMessage, false, array(), false, false
@@ -354,7 +354,7 @@ class HAWelcomeTask extends BaseTask {
 				$mWallMessage->setPostedAsBot( $this->senderObject );
 				$mWallMessage->sendNotificationAboutLastRev();
 			}
-		});
+		} );
 
 	}
 

--- a/extensions/wikia/HAWelcome/HAWelcomeTask.php
+++ b/extensions/wikia/HAWelcome/HAWelcomeTask.php
@@ -45,17 +45,6 @@ class HAWelcomeTask extends BaseTask {
 	/** @type string */
 	private $welcomeMessage = null;
 
-	public function getRecipientId() {
-		return $this->recipientId;
-	}
-
-	public function getRecipientUserName() {
-		return $this->recipientName;
-	}
-
-	public function getTimestamp() {
-		return $this->timestamp;
-	}
 
 	protected function getLoggerContext() {
 		return ['task' => __CLASS__];
@@ -328,7 +317,7 @@ class HAWelcomeTask extends BaseTask {
 		}
 	}
 
-	protected function postWallMessageToRecipient() {
+	public function postWallMessageToRecipient() {
 		$defaultWelcomeUser = $this->getDefaultWelcomerUser();
 
 		// some of the lower level methods used in buildNewMessageAndPost do not pass the
@@ -342,20 +331,27 @@ class HAWelcomeTask extends BaseTask {
 		$welcomeMessage = $this->welcomeMessage;
 		$recipientName  = $this->recipientName;
 		$textMessage    = $this->getTextVersionOfMessage( 'welcome-message-log' );
-		$wrapper->wrap( function () use ( $welcomeMessage, $recipientName, $defaultWelcomeUser ) {
-			$mWallMessage = WallMessage::buildNewMessageAndPost(
-				$welcomeMessage, $recipientName, $defaultWelcomeUser,
-				$textMessage, false, array(), false, false
-			);
 
-			// Sets the sender of the message when the actual message
-			// was posted by the welcome bot
-			if ( $mWallMessage ) {
-				$mWallMessage->setPostedAsBot( $this->senderObject );
-				$mWallMessage->sendNotificationAboutLastRev();
-			}
+		$message = $wrapper->wrap( function () use ( $defaultWelcomeUser, $welcomeMessage, $recipientName, $textMessage ) {
+			return $this->executeBuildAndPostWallMessage( $defaultWelcomeUser, $welcomeMessage, $recipientName, $textMessage );
 		} );
 
+		return $message;
+	}
+
+	protected function executeBuildAndPostWallMessage( $defaultWelcomeUser, $welcomeMessage, $recipientName, $textMessage ) {
+		$wallMessage = WallMessage::buildNewMessageAndPost(
+			$welcomeMessage, $recipientName, $defaultWelcomeUser, $textMessage, false, array(), false, false
+		);
+
+		// Sets the sender of the message when the actual message
+		// was posted by the welcome bot
+		if ( $welcomeMessage ) {
+			$welcomeMessage->setPostedAsBot( $this->senderObject );
+			$welcomeMessage->sendNotificationAboutLastRev();
+		}
+
+		return $wallMessage;
 	}
 
 	public function postTalkPageMessageToRecipient() {
@@ -453,5 +449,26 @@ class HAWelcomeTask extends BaseTask {
 		$this->recipientObject = $recipient;
 		return $this;
 	}
+
+	public function getRecipientId() {
+		return $this->recipientId;
+	}
+
+	public function getRecipientUserName() {
+		return $this->recipientName;
+	}
+
+	public function setRecipientUserName( $name ) {
+		$this->recipientName = $name;
+	}
+
+	public function getTimestamp() {
+		return $this->timestamp;
+	}
+
+	public function setWelcomeMessage( $message ) {
+		$this->welcomeMessage = $message;
+	}
+
 
 }

--- a/extensions/wikia/HAWelcome/tests/HAWelcomeTaskTest.php
+++ b/extensions/wikia/HAWelcome/tests/HAWelcomeTaskTest.php
@@ -394,5 +394,34 @@ class HAWelcomeTaskTest extends WikiaBaseTest {
 		$task->sendWelcomeMessage( $params );
 	}
 
+	public function testExecuteAndPostMessage() {
+		$defaultUser = $this->getMock( '\User' );
+		$wallMessage = $this->getMock( '\WallMessage', [], [], '', false );
+		$task = $this->getMock( '\HAWelcomeTask', ['getDefaultWelcomerUser', 'getTextVersionOfMessage', 'executeBuildAndPostWallMessage'], [], '', false );
+
+		$welcomeMessage = "hello";
+		$recipientName  = "bob";
+		$textMessage    = "a text message";
+
+		$task->setWelcomeMessage( $welcomeMessage );
+		$task->setRecipientUserName( $recipientName );
+
+		$task->expects( $this->once() )
+			->method( 'getTextVersionOfMessage' )
+			->with( 'welcome-message-log' )
+			->will( $this->returnValue( $textMessage ) );
+
+		$task->expects( $this->once() )
+			->method( 'executeBuildAndPostWallMessage' )
+			->with( $defaultUser, $welcomeMessage, $recipientName, $textMessage )
+			->will( $this->returnValue( $wallMessage ) );
+
+		$task->expects( $this->once() )
+			->method( 'getDefaultWelcomerUser' )
+			->will( $this->returnValue( $defaultUser ) );
+
+		$message = $task->postWallMessageToRecipient();
+		$this->assertEquals( $wallMessage, $message );
+	}
 
 }

--- a/extensions/wikia/HAWelcome/tests/HAWelcomeTaskTest.php
+++ b/extensions/wikia/HAWelcome/tests/HAWelcomeTaskTest.php
@@ -104,6 +104,7 @@ class HAWelcomeTaskTest extends WikiaBaseTest {
 
 	public function testPostTalkPageToRecipientWhenNotExists() {
 		$sender = $this->getMock( '\User', ['getName'] );
+		$defaultWelcomer = $this->getMock( '\User' );
 		$recipient = $this->getMock( '\User', ['getName'] );
 
 		$talkPage = $this->getMock( '\Article', ['exists', 'getContent', 'doEdit'], [], '', false );
@@ -117,7 +118,7 @@ class HAWelcomeTaskTest extends WikiaBaseTest {
 			->method( 'getContent' )
 			->will( $this->returnValue( $talkPageContent ) );
 
-		$task = $this->getMock( '\HAWelcomeTask', ['getRecipientTalkPage', 'getTextVersionOfMessage'], [], '', false );
+		$task = $this->getMock( '\HAWelcomeTask', ['getRecipientTalkPage', 'getTextVersionOfMessage', 'getDefaultWelcomerUser'], [], '', false );
 
 		$task->expects( $this->exactly( 2 ) )
 			->method( 'getRecipientTalkPage' )
@@ -127,6 +128,10 @@ class HAWelcomeTaskTest extends WikiaBaseTest {
 		$task->expects( $this->once() )
 			->method( 'getTextVersionOfMessage' )
 			->will( $this->returnValue( $textMessage ) );
+
+		$task->expects( $this->once() )
+			->method( 'getDefaultWelcomerUser' )
+			->will( $this->returnValue( $defaultWelcomer ) );
 
 		$sender->expects( $this->once() )
 			->method( 'getName' )
@@ -138,7 +143,7 @@ class HAWelcomeTaskTest extends WikiaBaseTest {
 
 		$talkPage->expects( $this->once() )
 			->method( 'doEdit' )
-			->with( null, $textMessage, 0, false, $sender )
+			->with( null, $textMessage, 0, false, $defaultWelcomer )
 			->will( $this->returnValue( null ) );
 
 		$task->setSenderObject( $sender );


### PR DESCRIPTION
Followup replacement pull for https://github.com/Wikia/app/pull/4336.

The call stack used by buildNewMessageAndPost does not pass the `$user`
object all the way down the stack but instead falls back to `$wgUser`. We
have two choices-- we can alter core to pass `$user` down or we can wrap
the global. The former is preferred but risky. The latter is a compromise with the
`GlobalStateWrapper`. Going with the latter.

/cc @owend @michalroszka 
