### PR TITLE
ImageServing: force ImageServing to return an empty list (PLATFORM-392)

### DIFF
--- a/extensions/wikia/ImageServing/imageServing.class.php
+++ b/extensions/wikia/ImageServing/imageServing.class.php
@@ -99,6 +99,15 @@ class ImageServing {
 		wfProfileIn( __METHOD__ );
 		$articles = $this->articles;
 		$out = array();
+
+		// force ImageServing to return an empty list
+		// see PLATFORM-392
+		global $wgImageServingForceNoResults;
+		if (!empty($wgImageServingForceNoResults)) {
+			wfProfileOut(__METHOD__);
+			return $out;
+		}
+
 		if( !empty( $articles ) ) {
 			if( $this->db == null ) {
 				$db = wfGetDB( DB_SLAVE, array() );


### PR DESCRIPTION
Introduce `wgImageServingForceNoResults` WF variable and set it to true on LyricsWiki.

@Wikia/platform-team 
