### PR TITLE
Tonefuze update

### DIFF
--- a/extensions/3rdparty/LyricWiki/Tag_Lyric.php
+++ b/extensions/3rdparty/LyricWiki/Tag_Lyric.php
@@ -46,38 +46,6 @@ $wgExtensionCredits["parserhook"][]=array(
 }
 
 ################################################################################
-# Inject ToneFuze ads onto Artist pages
-#
-# The Lyrics tag adds ToneFuze to the lyrics pages, this will cram the tags into
-# artist pages also.
-
-// Note: in normal MediaWiki, the SkinTemplateOutputPageBeforeExec is probably the right place
-// to change this, but in Wikia code, that isn't applied late enough, and skin 'title' is overridden
-// by wgOut->getPageTitle() after that hook is called.
-$wgHooks['OuptutPageBeforeHTML'][] = 'toneFuzeOnArtistPages_onBeforePageDisplay';
-
-function toneFuzeOnArtistPages_onBeforePageDisplay( OutputPage &$out, &$text ) {
-	global $wgTitle;
-
-	// lyrics pages will only be in the main namespace after the merge
-	if($wgTitle->getNamespace() == NS_MAIN){
-		$origTitle = $out->getPageTitle();
-		if(0 == preg_match("/.+:+/", $origTitle)){ // only do this on Artist pages.
-		
-			// TODO: Inject tonefuze below the Contents box.
-//print "BODY TEXT: ".$out->mBodyText;
-			// TODO: Inject tonefuze below the Contents box.
-		
-			//$out->setPageTitle( $origTitle. wfMsg('H1-lyricssuffix')); // added as a message so that it can be translated
-		}
-	}
-
-	//return true;
-	return $out; // need to return this for OutputPageBeforeHTML
-} // end toneFuzeOnArtistPages_onBeforePageDisplay()
-
-
-################################################################################
 # Lyric Render Section
 #
 # This section has no configuration, and can be ignored.
@@ -160,25 +128,10 @@ function renderLyricTag($input, $argv, $parser)
 		$artist = $parser->mTitle->getDBkey();
 		$colonIndex = strpos("$artist", ":");
 		$songTitle = $parser->mTitle->getText();
-//		$artistLink = $artist;
-//		$songLink = $songTitle;
 		if($colonIndex !== false){
 			$artist = substr($artist, 0, $colonIndex);
 			$songTitle = substr($songTitle, $colonIndex+1);
-
-//			$artistLink = str_replace(" ", "+", $artist);
-//			$songLink = str_replace(" ", "+", $songTitle);
 		}
-		//$artistLink = str_replace("_", "+", $artistLink);
-		//$songLink = str_replace("_", "+", $songLink);
-		//$href = "<a href='http://www.ringtonematcher.com/co/ringtonematcher/02/noc.asp?sid=WILWros&amp;artist=".urlencode($artistLink)."&amp;song=".urlencode($songLink)."' rel='nofollow' target='_blank'>";
-		//$ringtoneLink = "";
-		//$ringtoneLink = "<div class='rtMatcher'>";
-		//$ringtoneLink.= "$href<img src='" . $imgPath . "/phone_left.gif' alt='phone' width='16' height='17'/> ";
-		//$ringtoneLink.= "Send \"$songTitle\" Ringtone to your Cell";
-		//$ringtoneLink.= " <img src='" . $imgPath . "/phone_right.gif' alt='phone' width='16' height='17'/></a>";
-		//$ringtoneLink.= "<span class='adNotice'>Ad</span>";
-		//$ringtoneLink.= "</div>";
 
 		// The links have different adunit_ids above/below lyrics now. This will differentiate them for tracking.
 		$aboveLink = getToneFuzeLink($isAboveLyrics=true, $artist, $songTitle);

--- a/extensions/3rdparty/LyricWiki/Tag_Lyric.php
+++ b/extensions/3rdparty/LyricWiki/Tag_Lyric.php
@@ -46,6 +46,37 @@ $wgExtensionCredits["parserhook"][]=array(
 }
 
 ################################################################################
+# Inject ToneFuze ads onto Artist pages
+#
+# The Lyrics tag adds ToneFuze to the lyrics pages, this will cram the tags into
+# artist pages also.
+
+// Note: in normal MediaWiki, the SkinTemplateOutputPageBeforeExec is probably the right place
+// to change this, but in Wikia code, that isn't applied late enough, and skin 'title' is overridden
+// by wgOut->getPageTitle() after that hook is called.
+$wgHooks['BeforePageDisplay'][] = 'toneFuzeOnArtistPages_onBeforePageDisplay';
+
+function toneFuzeOnArtistPages_onBeforePageDisplay( OutputPage &$out, Skin &$skin ) {
+	global $wgTitle;
+
+	// lyrics pages will only be in the main namespace after the merge
+	if($wgTitle->getNamespace() == NS_MAIN){
+		$origTitle = $out->getPageTitle();
+		if(0 == preg_match("/.+:+/", $origTitle)){ // only do this on Artist pages.
+		
+			// TODO: Inject tonefuze below the Contents box.
+//print "BODY TEXT: ".$out->mBodyText;
+			// TODO: Inject tonefuze below the Contents box.
+		
+			//$out->setPageTitle( $origTitle. wfMsg('H1-lyricssuffix')); // added as a message so that it can be translated
+		}
+	}
+
+	return true;
+} // end toneFuzeOnArtistPages_onBeforePageDisplay()
+
+
+################################################################################
 # Lyric Render Section
 #
 # This section has no configuration, and can be ignored.

--- a/extensions/3rdparty/LyricWiki/Tag_Lyric.php
+++ b/extensions/3rdparty/LyricWiki/Tag_Lyric.php
@@ -127,7 +127,7 @@ function renderLyricTag($input, $argv, $parser)
 		$imgPath = "$wgExtensionsPath/3rdparty/LyricWiki";
 		$artist = $parser->mTitle->getDBkey();
 		$colonIndex = strpos("$artist", ":");
-		$songTitle = $parser->mTitle->getText();
+		$songTitle = "";
 		if($colonIndex !== false){
 			$artist = substr($artist, 0, $colonIndex);
 			$songTitle = substr($songTitle, $colonIndex+1);
@@ -177,7 +177,7 @@ function renderToneFuzeTag($input, $argv, $parser){
 	// Parse out artist and/or song-title from the page title.
 	$artist = $parser->mTitle->getDBkey();
 	$colonIndex = strpos("$artist", ":");
-	$songTitle = $parser->mTitle->getText();
+	$songTitle = "";
 	if($colonIndex !== false){
 		$artist = substr($artist, 0, $colonIndex);
 		$songTitle = substr($songTitle, $colonIndex+1);

--- a/extensions/3rdparty/LyricWiki/Tag_Lyric.php
+++ b/extensions/3rdparty/LyricWiki/Tag_Lyric.php
@@ -151,7 +151,7 @@ function renderLyricTag($input, $argv, $parser)
 		$ID_BELOW_LYRICS = 39382077;
 		$AD_ID_STRING = "AD_ID_STRING";
 		$ringtoneLink = "";
-		$ringtoneLink = "<script>\n"
+		$ringtoneLink = "<script>\n";
 		$ringtoneLink .= "(function() {\n";
 		$ringtoneLink .= "var opts = {\n";
 		$ringtoneLink .= "artist: \"{$artist}\",\n";

--- a/extensions/3rdparty/LyricWiki/Tag_Lyric.php
+++ b/extensions/3rdparty/LyricWiki/Tag_Lyric.php
@@ -151,7 +151,7 @@ function renderLyricTag($input, $argv, $parser)
 		$ID_BELOW_LYRICS = 39382077;
 		$AD_ID_STRING = "AD_ID_STRING";
 		$ringtoneLink = "";
-		$ringtoneLink = "<script>\n";
+		$ringtoneLink = "<script>";
 		$ringtoneLink .= "(function() {\n";
 		$ringtoneLink .= "var opts = {\n";
 		$ringtoneLink .= "artist: \"{$artist}\",\n";

--- a/extensions/3rdparty/LyricWiki/Tag_Lyric.php
+++ b/extensions/3rdparty/LyricWiki/Tag_Lyric.php
@@ -138,14 +138,35 @@ function renderLyricTag($input, $argv, $parser)
 		}
 		$artistLink = str_replace("_", "+", $artistLink);
 		$songLink = str_replace("_", "+", $songLink);
-		$href = "<a href='http://www.ringtonematcher.com/co/ringtonematcher/02/noc.asp?sid=WILWros&amp;artist=".urlencode($artistLink)."&amp;song=".urlencode($songLink)."' rel='nofollow' target='_blank'>";
+		//$href = "<a href='http://www.ringtonematcher.com/co/ringtonematcher/02/noc.asp?sid=WILWros&amp;artist=".urlencode($artistLink)."&amp;song=".urlencode($songLink)."' rel='nofollow' target='_blank'>";
+		//$ringtoneLink = "";
+		//$ringtoneLink = "<div class='rtMatcher'>";
+		//$ringtoneLink.= "$href<img src='" . $imgPath . "/phone_left.gif' alt='phone' width='16' height='17'/> ";
+		//$ringtoneLink.= "Send \"$songTitle\" Ringtone to your Cell";
+		//$ringtoneLink.= " <img src='" . $imgPath . "/phone_right.gif' alt='phone' width='16' height='17'/></a>";
+		//$ringtoneLink.= "<span class='adNotice'>Ad</span>";
+		//$ringtoneLink.= "</div>";
+
+		$ID_ABOVE_LYRICS = 39382076;
+		$ID_BELOW_LYRICS = 39382077;
+		$AD_ID_STRING = "AD_ID_STRING";
 		$ringtoneLink = "";
-		$ringtoneLink = "<div class='rtMatcher'>";
-		$ringtoneLink.= "$href<img src='" . $imgPath . "/phone_left.gif' alt='phone' width='16' height='17'/> ";
-		$ringtoneLink.= "Send \"$songTitle\" Ringtone to your Cell";
-		$ringtoneLink.= " <img src='" . $imgPath . "/phone_right.gif' alt='phone' width='16' height='17'/></a>";
-		$ringtoneLink.= "<span class='adNotice'>Ad</span>";
-		$ringtoneLink.= "</div>";
+		$ringtoneLink = "<script>\n"
+		$ringtoneLink .= "(function() {\n";
+		$ringtoneLink .= "var opts = {\n";
+		$ringtoneLink .= "artist: \"{$artist}\",\n";
+		$ringtoneLink .= "song: \"{$songTitle}\",\n";
+		$ringtoneLink .= "adunit_id: {$AD_ID_STRING},\n";
+		$ringtoneLink .= "div_id: \"cf_async_\" + Math.floor((Math.random() * 999999999)),\n";
+		$ringtoneLink .= "};\n";
+		$ringtoneLink .= "document.write('<div id=\"'+opts.div_id+'\"></div>');var c=function(){cf.showAsyncAd(opts)};if(window.cf)c();else{cf_async=!0;var r=document.createElement(\"script\"),s=document.getElementsByTagName(\"script\")[0];r.async=!0;r.src=\"//srv.tonefuse.com/showads/showad.js\";r.readyState?r.onreadystatechange=function(){if(\"loaded\"==r.readyState||\"complete\"==r.readyState)r.onreadystatechange=null,c()}:r.onload=c;s.parentNode.insertBefore(r,s)};\n";
+		$ringtoneLink .= "})();\n";
+		$ringtoneLink .= "</script>";
+
+		// The links have different adunit_ids above/below lyrics now. This will differentiate them for tracking.
+		$aboveLink = str_replace($AD_ID_STRING, $ID_ABOVE_LYRICS, $ringtoneLink);
+		$belowLink = str_replace($AD_ID_STRING, $ID_BELOW_LYRICS, $ringtoneLink);
+
 		$wgFirstLyricTag = false;
 	}
 
@@ -159,9 +180,9 @@ function renderLyricTag($input, $argv, $parser)
 
 	$retVal.= gracenote_getNoscriptTag();
 	$retVal.= "<div class='lyricbox'>";
-	$retVal.= ($isInstrumental?"":$ringtoneLink); // if this is an instrumental, just a ringtone link on the bottom is plenty.
+	$retVal.= ($isInstrumental?"":$aboveLink); // if this is an instrumental, just a ringtone link on the bottom is plenty.
 	$retVal.= gracenote_obfuscateText($transform);
-	$retVal.= $ringtoneLink;
+	$retVal.= $belowLink;
 	$retVal.= "<div class='lyricsbreak'></div>\n"; // so that we can have stuff in the box (like videos & awards) even if the lyrics are short.
 	$retVal.= "</div>";
 

--- a/extensions/3rdparty/LyricWiki/Tag_Lyric.php
+++ b/extensions/3rdparty/LyricWiki/Tag_Lyric.php
@@ -130,6 +130,7 @@ function renderLyricTag($input, $argv, $parser)
 		$songTitle = "";
 		if($colonIndex !== false){
 			$artist = substr($artist, 0, $colonIndex);
+			$songTitle = $parser->mTitle->getText();
 			$songTitle = substr($songTitle, $colonIndex+1);
 		}
 
@@ -180,6 +181,7 @@ function renderToneFuzeTag($input, $argv, $parser){
 	$songTitle = "";
 	if($colonIndex !== false){
 		$artist = substr($artist, 0, $colonIndex);
+		$songTitle = $parser->mTitle->getText();
 		$songTitle = substr($songTitle, $colonIndex+1);
 	}
 	$retVal = getToneFuzeLink($isAbove, $artist, $songTitle);	

--- a/extensions/3rdparty/LyricWiki/Tag_Lyric.php
+++ b/extensions/3rdparty/LyricWiki/Tag_Lyric.php
@@ -152,11 +152,11 @@ function renderLyricTag($input, $argv, $parser)
 		$AD_ID_STRING = "AD_ID_STRING";
 		$ringtoneLink = "";
 		$ringtoneLink = "<script>";
-		$ringtoneLink .= "(function() {\n";
-		$ringtoneLink .= "var opts = {\n";
-		$ringtoneLink .= "artist: \"{$artist}\",\n";
-		$ringtoneLink .= "song: \"{$songTitle}\",\n";
-		$ringtoneLink .= "adunit_id: {$AD_ID_STRING},\n";
+		$ringtoneLink .= "(function() {";
+		$ringtoneLink .= "var opts = {";
+		$ringtoneLink .= "artist: \"{$artist}\",";
+		$ringtoneLink .= "song: \"{$songTitle}\",";
+		$ringtoneLink .= "adunit_id: {$AD_ID_STRING},";
 		$ringtoneLink .= "div_id: \"cf_async_\" + Math.floor((Math.random() * 999999999))";
 		$ringtoneLink .= "};";
 		$ringtoneLink .= "document.write('<div id=\"'+opts.div_id+'\"></div>');var c=function(){cf.showAsyncAd(opts)};if(window.cf)c();else{cf_async=!0;var r=document.createElement(\"script\"),s=document.getElementsByTagName(\"script\")[0];r.async=!0;r.src=\"//srv.tonefuse.com/showads/showad.js\";r.readyState?r.onreadystatechange=function(){if(\"loaded\"==r.readyState||\"complete\"==r.readyState)r.onreadystatechange=null,c()}:r.onload=c;s.parentNode.insertBefore(r,s)};";

--- a/extensions/3rdparty/LyricWiki/Tag_Lyric.php
+++ b/extensions/3rdparty/LyricWiki/Tag_Lyric.php
@@ -158,9 +158,9 @@ function renderLyricTag($input, $argv, $parser)
 		$ringtoneLink .= "song: \"{$songTitle}\",\n";
 		$ringtoneLink .= "adunit_id: {$AD_ID_STRING},\n";
 		$ringtoneLink .= "div_id: \"cf_async_\" + Math.floor((Math.random() * 999999999)),\n";
-		$ringtoneLink .= "};\n";
-		$ringtoneLink .= "document.write('<div id=\"'+opts.div_id+'\"></div>');var c=function(){cf.showAsyncAd(opts)};if(window.cf)c();else{cf_async=!0;var r=document.createElement(\"script\"),s=document.getElementsByTagName(\"script\")[0];r.async=!0;r.src=\"//srv.tonefuse.com/showads/showad.js\";r.readyState?r.onreadystatechange=function(){if(\"loaded\"==r.readyState||\"complete\"==r.readyState)r.onreadystatechange=null,c()}:r.onload=c;s.parentNode.insertBefore(r,s)};\n";
-		$ringtoneLink .= "})();\n";
+		$ringtoneLink .= "};";
+		$ringtoneLink .= "document.write('<div id=\"'+opts.div_id+'\"></div>');var c=function(){cf.showAsyncAd(opts)};if(window.cf)c();else{cf_async=!0;var r=document.createElement(\"script\"),s=document.getElementsByTagName(\"script\")[0];r.async=!0;r.src=\"//srv.tonefuse.com/showads/showad.js\";r.readyState?r.onreadystatechange=function(){if(\"loaded\"==r.readyState||\"complete\"==r.readyState)r.onreadystatechange=null,c()}:r.onload=c;s.parentNode.insertBefore(r,s)};";
+		$ringtoneLink .= "})();";
 		$ringtoneLink .= "</script>";
 
 		// The links have different adunit_ids above/below lyrics now. This will differentiate them for tracking.

--- a/extensions/3rdparty/LyricWiki/Tag_Lyric.php
+++ b/extensions/3rdparty/LyricWiki/Tag_Lyric.php
@@ -157,7 +157,7 @@ function renderLyricTag($input, $argv, $parser)
 		$ringtoneLink .= "artist: \"{$artist}\",\n";
 		$ringtoneLink .= "song: \"{$songTitle}\",\n";
 		$ringtoneLink .= "adunit_id: {$AD_ID_STRING},\n";
-		$ringtoneLink .= "div_id: \"cf_async_\" + Math.floor((Math.random() * 999999999)),\n";
+		$ringtoneLink .= "div_id: \"cf_async_\" + Math.floor((Math.random() * 999999999))";
 		$ringtoneLink .= "};";
 		$ringtoneLink .= "document.write('<div id=\"'+opts.div_id+'\"></div>');var c=function(){cf.showAsyncAd(opts)};if(window.cf)c();else{cf_async=!0;var r=document.createElement(\"script\"),s=document.getElementsByTagName(\"script\")[0];r.async=!0;r.src=\"//srv.tonefuse.com/showads/showad.js\";r.readyState?r.onreadystatechange=function(){if(\"loaded\"==r.readyState||\"complete\"==r.readyState)r.onreadystatechange=null,c()}:r.onload=c;s.parentNode.insertBefore(r,s)};";
 		$ringtoneLink .= "})();";


### PR DESCRIPTION
ToneFuze has new tags, they're different for top of page & bottom of page, and they needed to be added to Artist pages also.

This update fixes all of these issues.  The code is still old-school... but this whole extension is very 3rdparty style (rather than new Wikia style) because it's very old.

The ToneFuze ads are still injected into lyrics pages by putting them at the top and bottom of the first <lyrics> tag on the page automatically (nothing new there except that the tag is different).  For artist pages, there is now a <tonefuze> tag, which was the easiest way to get it exactly where we want it (ie: on the left, below the TOC, and on the very bottom right near the artist footer, on artist pages).

Once this code is live, there will be two small edits required in order to get the ad live on Artist pages also. This is to edit http://lyrics.wikia.com/Template:ArtistHeader to change '&#95;&#95;TOC&#95;&#95;&lt;/td>' to '&#95;&#95;TOC&#95;&#95;&lt;tonefuze location="above"/>&lt;/td>' and to edit http://lyrics.wikia.com/Template:ArtistFooter to put "&lt;tonefuze/>" immediately after the first "&lt;includeonly>".

Artist page:
http://lyrics.sean.wikia-dev.com/Cake
Song page:
http://lyrics.sean.wikia-dev.com/Cake:Guitar
