### PR TITLE
set legacy category based on new vertical id in createwiki

### DIFF
--- a/extensions/wikia/CityVisualization/helpers/WikiaHomePageHelper.class.php
+++ b/extensions/wikia/CityVisualization/helpers/WikiaHomePageHelper.class.php
@@ -175,6 +175,7 @@ class WikiaHomePageHelper extends WikiaModel {
 	 */
 	public function updateHubSlotsToV2($hubSlots) {
 		$hubSlotsV2 = [];
+		if (empty($hubSlots)) return $hubSlotsV2;
 		foreach( $hubSlots as $slot ) {
 			$hubSlotsV2['hub_slot'][] = $slot['hub_slot'];
 		}

--- a/extensions/wikia/CreateNewWiki/CreateNewWikiController.class.php
+++ b/extensions/wikia/CreateNewWiki/CreateNewWikiController.class.php
@@ -266,7 +266,10 @@ class CreateNewWikiController extends WikiaController {
 				return;
 			}
 
-			$createWiki = new CreateWiki($params['wName'], $params['wDomain'], $params['wLanguage'], $params['wVertical'], $params['wCategories']);
+			$categories = isset($params['wCategories']) ? $params['wCategories'] : array();
+
+			$createWiki = new CreateWiki($params['wName'], $params['wDomain'], $params['wLanguage'], $params['wVertical'], $categories);
+
 			$error_code = $createWiki->create();
 			$cityId = $createWiki->getWikiInfo('city_id');
 			if(empty($cityId)) {

--- a/extensions/wikia/CreateNewWiki/CreateWiki.php
+++ b/extensions/wikia/CreateNewWiki/CreateWiki.php
@@ -581,6 +581,16 @@ class CreateWiki {
 		$this->mNewWiki->domain = strtolower( trim( $this->mDomain ) );
 
 		$this->mNewWiki->vertical = $this->mVertical;
+
+		// Map new verticals to old categories while in transition so that "hub" code still works
+		// If a user selects a vertical we will also add the old category that matches best with it
+		// This code can be removed after we are fully using the new verticals (PLATFORM-403)
+
+		// uses array_unshift to make sure hub category is first, because we take the first cat from SQL
+		if ( $this->mVertical == 1 ) array_unshift($this->mCategories, 2);	// Video games
+		if ( in_array( $this->mVertical, [2,3,4,5,6] ) ) array_unshift($this->mCategories, 3); // Entertainment
+		if ( $this->mVertical == 7 ) array_unshift($this->mCategories, 9);	// Lifestyle
+
 		$this->mNewWiki->categories = $this->mCategories;
 
 		// name


### PR DESCRIPTION
Use vertical_id to set the "legacy" category of a wiki while we are in transition to new vertical/category split.  
Also fixed a couple of warnings because category is optional, vertical is required

@inez 
