### PR TITLE
MAIN-2727 Fix call to setPostedAsBot() on non-object

### DIFF
--- a/extensions/wikia/HAWelcome/HAWelcomeTask.php
+++ b/extensions/wikia/HAWelcome/HAWelcomeTask.php
@@ -336,6 +336,8 @@ class HAWelcomeTask extends BaseTask {
 			return $this->executeBuildAndPostWallMessage( $defaultWelcomeUser, $welcomeMessage, $recipientName, $textMessage );
 		} );
 
+		$message = $this->setWallMessagePostedAsBot( $message );
+
 		return $message;
 	}
 
@@ -344,11 +346,15 @@ class HAWelcomeTask extends BaseTask {
 			$welcomeMessage, $recipientName, $defaultWelcomeUser, $textMessage, false, array(), false, false
 		);
 
+		return $wallMessage;
+	}
+
+	protected function setWallMessagePostedAsBot( $wallMessage ) {
 		// Sets the sender of the message when the actual message
 		// was posted by the welcome bot
-		if ( $welcomeMessage ) {
-			$welcomeMessage->setPostedAsBot( $this->senderObject );
-			$welcomeMessage->sendNotificationAboutLastRev();
+		if ( $wallMessage ) {
+			$wallMessage->setPostedAsBot( $this->senderObject );
+			$wallMessage->sendNotificationAboutLastRev();
 		}
 
 		return $wallMessage;

--- a/extensions/wikia/HAWelcome/tests/HAWelcomeTaskTest.php
+++ b/extensions/wikia/HAWelcome/tests/HAWelcomeTaskTest.php
@@ -396,7 +396,8 @@ class HAWelcomeTaskTest extends WikiaBaseTest {
 
 	public function testExecuteAndPostMessage() {
 		$defaultUser = $this->getMock( '\User' );
-		$wallMessage = $this->getMock( '\WallMessage', [], [], '', false );
+		$sender      = $this->getMock( '\User' );
+		$wallMessage = $this->getMock( '\WallMessage', ['setPostedAsBot', 'sendNotificationAboutLastRev'], [], '', false );
 		$task = $this->getMock( '\HAWelcomeTask', ['getDefaultWelcomerUser', 'getTextVersionOfMessage', 'executeBuildAndPostWallMessage'], [], '', false );
 
 		$welcomeMessage = "hello";
@@ -405,6 +406,7 @@ class HAWelcomeTaskTest extends WikiaBaseTest {
 
 		$task->setWelcomeMessage( $welcomeMessage );
 		$task->setRecipientUserName( $recipientName );
+		$task->setSenderObject( $sender );
 
 		$task->expects( $this->once() )
 			->method( 'getTextVersionOfMessage' )
@@ -415,6 +417,13 @@ class HAWelcomeTaskTest extends WikiaBaseTest {
 			->method( 'executeBuildAndPostWallMessage' )
 			->with( $defaultUser, $welcomeMessage, $recipientName, $textMessage )
 			->will( $this->returnValue( $wallMessage ) );
+
+		$wallMessage->expects( $this->once() )
+			->method( 'setPostedAsBot' )
+			->with( $sender );
+
+		$wallMessage->expects( $this->once() )
+			->method( 'sendNotificationAboutLastRev' );
 
 		$task->expects( $this->once() )
 			->method( 'getDefaultWelcomerUser' )


### PR DESCRIPTION
I introduced a refactoring error in a7ac26f2. This commit addresses that error and adds a test to make sure the correct object is passed through the call stack.

/cc @grunny @michalroszka 
