### PR TITLE
WikiaSQL comments

### DIFF
--- a/includes/wikia/WikiaSQL.class.php
+++ b/includes/wikia/WikiaSQL.class.php
@@ -12,6 +12,35 @@ use FluentSql as sql;
 class WikiaSQL extends FluentSql\SQL {
 	private $skipIfCondition = false;
 	private $useSharedMemKey = false;
+	private $cache;
+	private $callingMethod = [];
+	private $comments = [];
+
+	public function __construct() {
+		$stack = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
+
+		if (isset($stack[1])) { // 0=this, 1=whoever constructed this object
+			$caller = $stack[1];
+
+			if (isset($caller['class'])) {
+				$this->callingMethod['class'] = $caller['class'];
+			}
+
+			if (isset($caller['function'])) {
+				$this->callingMethod['function'] = $caller['function'];
+			}
+
+			$this->addComment(implode('::', $this->callingMethod));
+		}
+	}
+
+	/**
+	 * add a comment that's output along with this SQL statement
+	 * @param string $comment
+	 */
+	public function addComment($comment) {
+		$this->comments[] = $comment;
+	}
 
 	/**
 	 * @param $ttl
@@ -26,7 +55,7 @@ class WikiaSQL extends FluentSql\SQL {
 
 	protected function getCacheKey(sql\Breakdown $breakDown) {
 		$cache = $this->getCache();
-		return $cache->generateKey($breakDown, $this->useSharedMemKey);
+		return $cache->generateKey($breakDown);
 	}
 
 	protected function query($db, sql\Breakdown $breakDown, $autoIterate, callable $callback=null) {
@@ -38,16 +67,14 @@ class WikiaSQL extends FluentSql\SQL {
 	}
 
 	/**
-	 * @return sql\Cache|WikiaSQLCache
+	 * @return sql\Cache\Cache
 	 */
 	protected function getCache() {
-		static $cache = null;
-
-		if ($cache === null) {
-			$cache = new WikiaSQLCache();
+		if ($this->cache === null) {
+			$this->cache = new WikiaSQLCache($this->callingMethod, $this->useSharedMemKey);
 		}
 
-		return $cache;
+		return $this->cache;
 	}
 
 	/**
@@ -57,6 +84,19 @@ class WikiaSQL extends FluentSql\SQL {
 	 */
 	public function injectParams($db, sql\Breakdown $breakDown) {
 		return $db->fillPrepared($breakDown->getSql(), $breakDown->getParameters());
+	}
+
+	/** intercept build() and add comments */
+	public function build($bk=null, $tabs=0) {
+		if ($bk == null) {
+			$bk = new sql\Breakdown();
+		}
+
+		foreach ($this->comments as $comment) {
+			$bk->append("# $comment\n");
+		}
+
+		return parent::build($bk, $tabs);
 	}
 
 	/**

--- a/includes/wikia/WikiaSQLCache.class.php
+++ b/includes/wikia/WikiaSQLCache.class.php
@@ -8,31 +8,30 @@
  */
 
 class WikiaSQLCache extends FluentSql\Cache\Cache {
+	/** @var array */
+	private $keyArgs = ['sql-cache'];
+
+	/** @var bool */
+	private $useSharedKey = false;
+
+	/**
+	 * @param array $keyArgs starting state of memcache key
+	 * @param bool $useSharedKey whether or not this memkey is shared amongst wikis
+	 */
+	public function __construct($keyArgs=[], $useSharedKey=false) {
+		$this->keyArgs = array_merge($this->keyArgs, array_values($keyArgs));
+		$this->useSharedKey = $useSharedKey;
+	}
+
 	/**
 	 * @param \FluentSql\Breakdown $breakDown
-	 * @param bool $sharedKey whether or not this memkey is shared amongst wikis
 	 * @return string a memcache key to use
 	 */
-	public function generateKey(\FluentSql\Breakdown $breakDown, $sharedKey) {
-		$stack = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 4);
-		$keyArgs = ['sql-cache'];
+	public function generateKey(\FluentSql\Breakdown $breakDown) {
+		$this->keyArgs[] = parent::generateKey($breakDown);
+		$func = $this->useSharedKey ? 'wfSharedMemcKey' : 'wfMemcKey';
 
-		if (isset($stack[3])) { // 0=this, 1=WikiaSQL->getCacheKey, 2=SQL->run(), 3=whoever called "run"
-			$caller = $stack[3];
-
-			if (isset($caller['class'])) {
-				$keyArgs []= $caller['class'];
-			}
-
-			if (isset($caller['function'])) {
-				$keyArgs []= $caller['function'];
-			}
-		}
-
-		$keyArgs []= parent::generateKey($breakDown);
-		$func = $sharedKey ? 'wfSharedMemcKey' : 'wfMemcKey';
-
-		return call_user_func_array($func, $keyArgs);
+		return call_user_func_array($func, $this->keyArgs);
 	}
 
 	public function get($key) {


### PR DESCRIPTION
@Wikia/platform-team 
https://wikia-inc.atlassian.net/browse/PLATFORM-404
@macbre - a comment in the form `"# class::method\n` will now be added to every sql statement automatically, ex:

``` sql
# FooClass::barMethod
SELECT column1
FROM tbl
WHERE col1=5
```

Additionally, this introduces `WikiaSQL->addComment()`, which can be used to add arbitrary comments to the sql output.
