### PR TITLE
WikiaTargetEvents "directly" replaces TargetEvents (look at ve.ini.mw.Ta...

### DIFF
--- a/extensions/VisualEditor/VisualEditor.php
+++ b/extensions/VisualEditor/VisualEditor.php
@@ -249,6 +249,7 @@ $wgResourceModules += array(
 			'modules/ve-mw/init/ve.init.mw.Platform.js',
 			'modules/ve-mw/init/ve.init.mw.Target.js',
 			'modules/ve-mw/init/ve.init.mw.TargetEvents.js',
+			'wikia/modules/ve/init/ve.init.mw.WikiaTargetEvents.js',
 		),
 		'dependencies' => array(
 			'jquery.visibleText',

--- a/extensions/VisualEditor/wikia/VisualEditor.php
+++ b/extensions/VisualEditor/wikia/VisualEditor.php
@@ -50,8 +50,7 @@ $wgResourceModules += array(
 	),
 	'ext.visualEditor.wikiaViewPageTarget' => $wgVisualEditorWikiaResourceTemplate + array(
 		'scripts' => array(
-			've/init/ve.init.mw.WikiaViewPageTarget.js',
-			've/init/ve.init.mw.WikiaTargetEvents.js'
+			've/init/ve.init.mw.WikiaViewPageTarget.js'
 		),
 		'styles' => array(
 			've/init/styles/ve.init.mw.WikiaViewPageTarget.css'


### PR DESCRIPTION
...rget.js) - so should be available in all the same places that TargetEvents is
