### PR TITLE
Apply a very simple length check to determine how many ads to display

### DIFF
--- a/extensions/wikia/MonetizationModule/MonetizationModuleController.class.php
+++ b/extensions/wikia/MonetizationModule/MonetizationModuleController.class.php
@@ -24,6 +24,7 @@ class MonetizationModuleController extends WikiaController {
 		$params = [
 			's_id' => $this->wg->CityId,
 			'geo' => MonetizationModuleHelper::getCountryCode( $this->request ),
+			'max' => MonetizationModuleHelper::calculateNumberOfAds( $this->wg->Title->mLength ),
 		];
 		$this->data = MonetizationModuleHelper::getMonetizationUnits( $params );
 

--- a/extensions/wikia/MonetizationModule/MonetizationModuleHelper.class.php
+++ b/extensions/wikia/MonetizationModule/MonetizationModuleHelper.class.php
@@ -150,4 +150,25 @@ class MonetizationModuleHelper extends WikiaModel {
 		return MonetizationModuleHelper::REST_OF_WORLD;
 	}
 
+	/**
+	 * Very rudimentary way to determine the number of ads to display.
+	 * If the page length (text chars count only) is greater than 5K
+	 * then it is considered a "long" article, in between 1.5-5K it is
+	 * considered "medium" and anything less than 1.5K is considered
+	 * "short"
+	 *
+	 * @param $pageLength
+	 * @return int
+	 */
+	public static function calculateNumberOfAds( $pageLength ) {
+		if ( $pageLength > 5000 ) {
+			// long length article
+			return 3;
+		} else if ( $pageLength > 1500 ) {
+			// medium length article
+			return 2;
+		}
+		// short articles
+		return 1;
+	}
 }


### PR DESCRIPTION
To avoid being penalized by AdSense by having a high ad to low text
ration calculate the general size of the article (not counting text
from templates) to determine how many ads to display.
