### PR TITLE
prevent renamed users from being locked out after a failed rename

### DIFF
--- a/extensions/wikia/UserRenameTool/UserRenameTask.class.php
+++ b/extensions/wikia/UserRenameTool/UserRenameTask.class.php
@@ -28,6 +28,7 @@ class UserRenameTask extends BaseTask {
 
 		$renameIP = !empty($params['rename_ip']);
 
+		$loadBalancerFactory = wfGetLBFactory();
 		$process = RenameUserProcess::newFromData( $params );
 		$process->setLogDestination( \RenameUserProcess::LOG_BATCH_TASK, $this );
 		$process->setRequestorUser();
@@ -46,61 +47,73 @@ class UserRenameTask extends BaseTask {
 				[ $this->getTaskId() ]
 			)
 		);
-		foreach ($wikiCityIds as $cityId) {
-			/**
-			 * execute maintenance script
-			 */
-			$cmd = sprintf( "SERVER_ID=%s php {$IP}/maintenance/wikia/RenameUser_local.php", $cityId );
-			$opts = [
-				'rename-user-id' => $params['rename_user_id'],
-				'requestor-id' => $params['requestor_id'],
-				'reason' => $params['reason'],
-			];
 
-			if ( $renameIP ) {
-				$opts['rename-old-name'] = $params['rename_old_name'];
-				$opts['rename-new-name'] = $params['rename_new_name'];
-			} else {
-				$opts['rename-old-name-enc'] = rawurlencode( $params['rename_old_name'] );
-				$opts['rename-new-name-enc'] = rawurlencode( $params['rename_new_name'] );
-				$opts['rename-fake-user-id'] = $params['rename_fake_user_id'];
-				$opts['phalanx-block-id'] = $params['phalanx_block_id'];
-			}
+		try{
+			foreach ($wikiCityIds as $cityId) {
+				/**
+				 * execute maintenance script
+				 */
+				$cmd = sprintf( "SERVER_ID=%s php {$IP}/maintenance/wikia/RenameUser_local.php", $cityId );
+				$opts = [
+					'rename-user-id' => $params['rename_user_id'],
+					'requestor-id' => $params['requestor_id'],
+					'reason' => $params['reason'],
+				];
 
-			foreach ($opts as $opt => $val) {
-				$cmd .= sprintf( ' --%s %s', $opt, escapeshellarg($val) );
-			}
-			if ( $renameIP ) {
-				$cmd .= ' --rename-ip-address';
-			}
+				if ( $renameIP ) {
+					$opts['rename-old-name'] = $params['rename_old_name'];
+					$opts['rename-new-name'] = $params['rename_new_name'];
+				} else {
+					$opts['rename-old-name-enc'] = rawurlencode( $params['rename_old_name'] );
+					$opts['rename-new-name-enc'] = rawurlencode( $params['rename_new_name'] );
+					$opts['rename-fake-user-id'] = $params['rename_fake_user_id'];
+					$opts['phalanx-block-id'] = $params['phalanx_block_id'];
+				}
 
-			$exitCode = null;
-			$output = wfShellExec( $cmd, $exitCode );
-			$logMessage = sprintf( "Rename user %s to %s on city id %s",
-				$params['rename_old_name'], $params['rename_new_name'], $cityId);
-			$logContext = [
-				'command' => $cmd,
-				'exitStatus' => $exitCode,
-				'output' => $output,
-			];
-			if ( $exitCode > 0 ) {
-				$this->error($logMessage, $logContext);
-				$noErrors = false;
-			} else {
-				$this->info($logMessage, $logContext);
+				foreach ($opts as $opt => $val) {
+					$cmd .= sprintf( ' --%s %s', $opt, escapeshellarg($val) );
+				}
+				if ( $renameIP ) {
+					$cmd .= ' --rename-ip-address';
+				}
+
+				$exitCode = null;
+				$output = wfShellExec( $cmd, $exitCode );
+				$logMessage = sprintf( "Rename user %s to %s on city id %s",
+					$params['rename_old_name'], $params['rename_new_name'], $cityId);
+				$logContext = [
+					'command' => $cmd,
+					'exitStatus' => $exitCode,
+					'output' => $output,
+				];
+				if ( $exitCode > 0 ) {
+					$this->error($logMessage, $logContext);
+					$noErrors = false;
+				} else {
+					$this->info($logMessage, $logContext);
+				}
+				$this->staffLog(
+					'log',
+					$params,
+					\RenameUserLogFormatter::wiki(
+						$params['requestor_name'],
+						$params['rename_old_name'],
+						$params['rename_new_name'],
+						$cityId,
+						$params['reason'],
+						$exitCode > 0
+					)
+				);
+
+				$loadBalancerFactory->forEachLBCallMethod('commitMasterChanges');
+				$loadBalancerFactory->forEachLBCallMethod('closeAll');
 			}
-			$this->staffLog(
-				'log',
-				$params,
-				\RenameUserLogFormatter::wiki(
-					$params['requestor_name'],
-					$params['rename_old_name'],
-					$params['rename_new_name'],
-					$cityId,
-					$params['reason'],
-					$exitCode > 0
-				)
-			);
+		} catch (Exception $e) {
+			$noErrors = false;
+			$this->error("error while renaming user", [
+				'message' => $e->getMessage(),
+				'stack' => $e->getTraceAsString(),
+			]);
 		}
 
 		// clean up pre-process setup


### PR DESCRIPTION
@owend @Wikia/platform-team 
https://wikia-inc.atlassian.net/browse/PLATFORM-420

Resetting database connections after the rename user maintenance script run, since that can take a long time and we're probably running into MySQL connection timeouts.
