### PR TITLE
[MON-153] Clean up country codes in the MON module extension

### DIFF
--- a/extensions/wikia/MonetizationModule/MonetizationModuleController.class.php
+++ b/extensions/wikia/MonetizationModule/MonetizationModuleController.class.php
@@ -6,7 +6,6 @@ class MonetizationModuleController extends WikiaController {
 
 	/**
 	 * Monetization Module
-	 * @requestParam string geo
 	 * @responseParam array data - list of modules
 	 */
 	public function index() {
@@ -23,7 +22,6 @@ class MonetizationModuleController extends WikiaController {
 
 		$params = [
 			's_id' => $this->wg->CityId,
-			'geo' => MonetizationModuleHelper::getCountryCode( $this->request ),
 			'max' => MonetizationModuleHelper::calculateNumberOfAds( $this->wg->Title->mLength ),
 		];
 		$this->data = MonetizationModuleHelper::getMonetizationUnits( $params );

--- a/extensions/wikia/MonetizationModule/MonetizationModuleHelper.class.php
+++ b/extensions/wikia/MonetizationModule/MonetizationModuleHelper.class.php
@@ -19,9 +19,6 @@ class MonetizationModuleHelper extends WikiaModel {
 	// do not change unless monetization service changes
 	const MONETIZATION_SERVICE_CACHE_PREFIX = 'monetization';
 
-	static $SUPPORTED_COUNTRY_CODES = [ 'AU', 'CA', 'DE', 'HK', 'MX', 'RU', 'TW', 'UK', 'US' ];
-	const REST_OF_WORLD = 'ROW';
-
 	/**
 	 * Show the Module only on File pages, Article pages, and Main pages
 	 * @return boolean
@@ -61,7 +58,8 @@ class MonetizationModuleHelper extends WikiaModel {
 		global $wgMonetizationServiceUrl, $wgMemc;
 
 		// this cache key must match the one set by the MonetizationService
-		// and should not use the wgCachePrefix()
+		// and should not use the wgCachePrefix(), wfSharedMemcKey() or
+		// wfMemcKey() methods
 		$cacheKey = self::createCacheKey( $params );
 		$log->debug( "Monetization: " . __METHOD__ . " - lookup with cache key: $cacheKey" );
 		$json_results = $wgMemc->get( $cacheKey );
@@ -93,26 +91,6 @@ class MonetizationModuleHelper extends WikiaModel {
 	}
 
 	/**
-	 * Get country code
-	 * @param Request $request
-	 * @return string $countryCode
-	 */
-	public static function getCountryCode( $request ) {
-		wfProfileIn( __METHOD__ );
-
-		$countryCode = '';
-		$geo = $request->getCookie( 'Geo' );
-		if ( !empty( $geo ) ) {
-			$geo = json_decode( $geo, true );
-			$countryCode = $geo['country'];
-		}
-
-		wfProfileOut( __METHOD__ );
-
-		return $countryCode;
-	}
-
-	/**
 	 * Creates the cache key for the given parameters.
 	 *
 	 * @param array $params
@@ -125,29 +103,7 @@ class MonetizationModuleHelper extends WikiaModel {
 			$cacheKey .= ':' . $params['s_id'];
 		}
 
-		if ( !empty( $params['geo'] ) ) {
-			$cacheKey .= ':' . self::convertCountryCode( $params['geo'] );
-		} else {
-			$cacheKey .= ':' . self::REST_OF_WORLD;
-		}
-
 		return $cacheKey;
-	}
-
-	/**
-	 * Converts the country code to 'ROW' if the country code passed in
-	 * is not one of the 9 countries that are supported. Otherwise,
-	 * just returns the country code (all uppercase).
-	 *
-	 * @param $countryCode
-	 * @return string
-	 */
-	public static function convertCountryCode( $countryCode ) {
-		if ( in_array( $countryCode, MonetizationModuleHelper::$SUPPORTED_COUNTRY_CODES ) ) {
-			return strtoupper( $countryCode );
-		}
-
-		return MonetizationModuleHelper::REST_OF_WORLD;
 	}
 
 	/**


### PR DESCRIPTION
Country codes cannot be handled in the extension due to caching.
Country codes must be handled in the browser. Therefore, removing
references to country codes.
