### PR TITLE
CONN-587

### DIFF
--- a/extensions/CheckUser/CheckUser.hooks.php
+++ b/extensions/CheckUser/CheckUser.hooks.php
@@ -69,9 +69,7 @@ class CheckUserHooks {
 		global $wgRequest;
 
 		/** Wikia change - begin - CONN-587 */
-		$userId = $user->getId();
-		$userName = $user->getName();
-		if( !is_null( $userId ) ) {
+		try {
 		/** Wikia change - end */
 			// Get XFF header
 			$xff = $wgRequest->getHeader( 'X-Forwarded-For' );
@@ -85,8 +83,8 @@ class CheckUserHooks {
 				'cuc_namespace'  => NS_USER,
 				'cuc_title'      => '',
 				'cuc_minor'      => 0,
-				'cuc_user'       => $userId,
-				'cuc_user_text'  => $userName,
+				'cuc_user'       => $user->getId(),
+				'cuc_user_text'  => $user->getName(),
 				'cuc_actiontext' => wfMsgForContent( 'checkuser-reset-action', $account->getName() ),
 				'cuc_comment'    => '',
 				'cuc_this_oldid' => 0,
@@ -101,15 +99,16 @@ class CheckUserHooks {
 			);
 			$dbw->insert( 'cu_changes', $rcRow, __METHOD__ );
 		/** Wikia change - begin - CONN-587 */
-		} else {
+		} catch( Exception $e ) {
 			\Wikia\Logger\WikiaLogger::instance()->debug(
 				'CONN-587 - db error while changing user password',
 				[
-					'user_name' => $userName,
+					'exception' => $e->getMessage(),
+					'backtrace' => $e->getTraceAsString(),
+					'user_name' => $user->getName(),
 					'ip' => $ip,
-					'account_name' => ($account instanceof User) ? $account->getName() : null,
+					'account_name' => ( $account instanceof User ) ? $account->getName() : null,
 					'session_id' => session_id(),
-					'backtrace' => json_encode(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS)),
 				]
 			);
 		}

--- a/extensions/CheckUser/CheckUser.hooks.php
+++ b/extensions/CheckUser/CheckUser.hooks.php
@@ -103,8 +103,7 @@ class CheckUserHooks {
 			\Wikia\Logger\WikiaLogger::instance()->debug(
 				'CONN-587 - db error while changing user password',
 				[
-					'exception' => $e->getMessage(),
-					'backtrace' => $e->getTraceAsString(),
+					'exception' => $e,
 					'user_name' => $user->getName(),
 					'ip' => $ip,
 					'account_name' => ( $account instanceof User ) ? $account->getName() : null,

--- a/extensions/CheckUser/CheckUser.hooks.php
+++ b/extensions/CheckUser/CheckUser.hooks.php
@@ -68,33 +68,40 @@ class CheckUserHooks {
 	public static function updateCUPasswordResetData( User $user, $ip, $account ) {
 		global $wgRequest;
 
-		// Get XFF header
-		$xff = $wgRequest->getHeader( 'X-Forwarded-For' );
-		list( $xff_ip, $isSquidOnly ) = IP::getClientIPfromXFF( $xff );
-		// Get agent
-		$agent = $wgRequest->getHeader( 'User-Agent' );
-		$dbw = wfGetDB( DB_MASTER );
-		$cuc_id = $dbw->nextSequenceValue( 'cu_changes_cu_id_seq' );
-		$rcRow = array(
-			'cuc_id'         => $cuc_id,
-			'cuc_namespace'  => NS_USER,
-			'cuc_title'      => '',
-			'cuc_minor'      => 0,
-			'cuc_user'       => $user->getId(),
-			'cuc_user_text'  => $user->getName(),
-			'cuc_actiontext' => wfMsgForContent( 'checkuser-reset-action', $account->getName() ),
-			'cuc_comment'    => '',
-			'cuc_this_oldid' => 0,
-			'cuc_last_oldid' => 0,
-			'cuc_type'       => RC_LOG,
-			'cuc_timestamp'  => $dbw->timestamp( wfTimestampNow() ),
-			'cuc_ip'         => IP::sanitizeIP( $ip ),
-			'cuc_ip_hex'     => $ip ? IP::toHex( $ip ) : null,
-			'cuc_xff'        => !$isSquidOnly ? $xff : '',
-			'cuc_xff_hex'    => ( $xff_ip && !$isSquidOnly ) ? IP::toHex( $xff_ip ) : null,
-			'cuc_agent'      => $agent
-		);
-		$dbw->insert( 'cu_changes', $rcRow, __METHOD__ );
+		$userId = $user->getId();
+		$userName = $user->getName();
+		if( !is_null( $userId ) ) {
+			// Get XFF header
+			$xff = $wgRequest->getHeader( 'X-Forwarded-For' );
+			list( $xff_ip, $isSquidOnly ) = IP::getClientIPfromXFF( $xff );
+			// Get agent
+			$agent = $wgRequest->getHeader( 'User-Agent' );
+			$dbw = wfGetDB( DB_MASTER );
+			$cuc_id = $dbw->nextSequenceValue( 'cu_changes_cu_id_seq' );
+			$rcRow = array(
+				'cuc_id'         => $cuc_id,
+				'cuc_namespace'  => NS_USER,
+				'cuc_title'      => '',
+				'cuc_minor'      => 0,
+				'cuc_user'       => $userId,
+				'cuc_user_text'  => $userName,
+				'cuc_actiontext' => wfMsgForContent( 'checkuser-reset-action', $account->getName() ),
+				'cuc_comment'    => '',
+				'cuc_this_oldid' => 0,
+				'cuc_last_oldid' => 0,
+				'cuc_type'       => RC_LOG,
+				'cuc_timestamp'  => $dbw->timestamp( wfTimestampNow() ),
+				'cuc_ip'         => IP::sanitizeIP( $ip ),
+				'cuc_ip_hex'     => $ip ? IP::toHex( $ip ) : null,
+				'cuc_xff'        => !$isSquidOnly ? $xff : '',
+				'cuc_xff_hex'    => ( $xff_ip && !$isSquidOnly ) ? IP::toHex( $xff_ip ) : null,
+				'cuc_agent'      => $agent
+			);
+			$dbw->insert( 'cu_changes', $rcRow, __METHOD__ );
+		} else {
+			debug_print_backtrace();
+			var_dump($user);
+		}
 
 		return true;
 	}


### PR DESCRIPTION
Sometimes the AJAX request sent after clicking "Forgot your password?" fails because of DB error. We know it happens because `$userName` passed to DB in a hook is `null`. We don't know why it's `null` and it's hard to find out because the bug is occurring intermittently. To allow users reset their password I wrapped the hooks logic in `if-else` and I'm logging data which might help us tracking the cause of this strange issue. This way we'll know when the issue happened and the user will be still able to reset her password since the AJAX request won't fail.

pinging Platform Team: @michalroszka @macbre @jcellary @owend @jnrbsn @drsnyder @nmonterroso  @mklucsarits 
