### PR TITLE
(CE-1000) Assign user page creations to the default welcomer

### DIFF
--- a/extensions/wikia/HAWelcome/HAWelcomeTask.php
+++ b/extensions/wikia/HAWelcome/HAWelcomeTask.php
@@ -147,14 +147,14 @@ class HAWelcomeTask extends BaseTask {
 		$this->info( "attempting to create welcome user page" );
 		$recipientProfile = $this->getRecipientProfilePage();
 		if ( ! $recipientProfile->exists() ) {
-			$this->info( sprintf( "creating welcome user page for %s from %s",
-				$this->recipientObject->getName(), $this->senderObject->getName() ) );
+			$this->info( sprintf( "creating welcome user page for %s",
+				$this->recipientObject->getName() ) );
 			$recipientProfile->doEdit(
 				$this->getWelcomePageTemplateForRecipient(),
 				false,
 				$this->integerFlags,
 				false,
-				$this->senderObject
+				$this->getDefaultWelcomerUser()
 			);
 		}
 	}

--- a/extensions/wikia/HAWelcome/tests/HAWelcomeTaskTest.php
+++ b/extensions/wikia/HAWelcome/tests/HAWelcomeTaskTest.php
@@ -153,13 +153,14 @@ class HAWelcomeTaskTest extends WikiaBaseTest {
 	}
 
 	public function testCreateUserProfilePage() {
-		$sender = $this->getMock( '\User', ['getName'] );
+		$welcomer = $this->getMock( '\User' );
 		$recipient = $this->getMock( '\User', ['getName'] );
 
 		$profilePage = $this->getMock( '\Article', ['exists', 'doEdit'], [], '', false );
 		$task = $this->getMock( '\HAWelcomeTask', [
 			'getRecipientProfilePage',
 			'getWelcomePageTemplateForRecipient',
+			'getDefaultWelcomerUser',
 			] );
 
 		$profilePage->expects( $this->once() )
@@ -176,9 +177,9 @@ class HAWelcomeTaskTest extends WikiaBaseTest {
 			->method( 'getWelcomePageTemplateForRecipient' )
 			->will( $this->returnValue( $welcomePageTemplate ) );
 
-		$sender->expects( $this->once() )
-			->method( 'getName' )
-			->will( $this->returnValue( 'sender' ) );
+		$task->expects( $this->once() )
+			->method( 'getDefaultWelcomerUser' )
+			->will( $this->returnValue( $welcomer ) );
 
 		$recipient->expects( $this->once() )
 			->method( 'getName' )
@@ -186,10 +187,9 @@ class HAWelcomeTaskTest extends WikiaBaseTest {
 
 		$profilePage->expects( $this->once() )
 			->method( 'doEdit' )
-			->with( $welcomePageTemplate, false, 0, false, $sender )
+			->with( $welcomePageTemplate, false, 0, false, $welcomer )
 			->will( $this->returnValue( null ) );
 
-		$task->setSenderObject( $sender );
 		$task->setRecipientObject( $recipient );
 		$task->createUserProfilePage();
 	}


### PR DESCRIPTION
Prior to the rewrite, the user page creations were assigned to the
default welcome user (User:Wikia) due to the overwrite of $wgUser
global rather than passing it to the doEdit method. This restores the
expected functionality by passing the default welcome user to doEdit
rather than the sender object.

@drsnyder 
