### PR TITLE
[MON-151] Handle "rendering_in_process" state

### DIFF
--- a/extensions/wikia/MonetizationModule/MonetizationModuleController.class.php
+++ b/extensions/wikia/MonetizationModule/MonetizationModuleController.class.php
@@ -24,6 +24,13 @@ class MonetizationModuleController extends WikiaController {
 			's_id' => $this->wg->CityId,
 			'max' => MonetizationModuleHelper::calculateNumberOfAds( $this->wg->Title->mLength ),
 		];
+
+		$mcachePurge = $this->wg->request->getVal( 'mcache', false );
+
+		if ( $mcachePurge ) {
+			$params['mcache'] = $mcachePurge;
+		}
+
 		$this->data = MonetizationModuleHelper::getMonetizationUnits( $params );
 
 		// set cache control to 1 hour

--- a/extensions/wikia/MonetizationModule/MonetizationModuleHelper.class.php
+++ b/extensions/wikia/MonetizationModule/MonetizationModuleHelper.class.php
@@ -18,6 +18,7 @@ class MonetizationModuleHelper extends WikiaModel {
 	// TODO: encapsulate in Monetization Client
 	// do not change unless monetization service changes
 	const MONETIZATION_SERVICE_CACHE_PREFIX = 'monetization';
+	const RENDERING_IN_PROCESS = 1;
 
 	/**
 	 * Show the Module only on File pages, Article pages, and Main pages
@@ -64,7 +65,10 @@ class MonetizationModuleHelper extends WikiaModel {
 		$log->debug( "Monetization: " . __METHOD__ . " - lookup with cache key: $cacheKey" );
 		$json_results = $wgMemc->get( $cacheKey );
 
-		if ( !empty( $json_results ) ) {
+		if ( $json_results == RENDERING_IN_PROCESS ) {
+			// TODO: potentially block until rendering finishes, until then return nothing
+			return false;
+		} else if ( !empty( $json_results ) ) {
 			return json_decode( $json_results, true );
 		}
 


### PR DESCRIPTION
If the service is already handling a request for the cachekey
return for now. That page request will not get any ads.
Otherwise, either return the value from the cache or issue the
call to the service.

Pass on the 'mcache' variable to the service.
