### PR TITLE
Remove unused method

### DIFF
--- a/extensions/VisualEditor/lib/ve/modules/ve/ce/ve.ce.Node.js
+++ b/extensions/VisualEditor/lib/ve/modules/ve/ce/ve.ce.Node.js
@@ -260,36 +260,3 @@ ve.ce.Node.prototype.destroy = function () {
 ve.ce.Node.prototype.getModelHtmlDocument = function () {
 	return this.model.getDocument() && this.model.getDocument().getHtmlDocument();
 };
-
-/**
- * Gets the height of the contents of a node.
- *
- * If a node contains floated descendants, 'clearfix' will cause the node to expand to contain the floats.
- * However, if the element is beside a float, 'clearfix' will cause the node to expand to the height of the
- * floated node beside it.
- * To avoid this, the node will both 'clearfix' and clear floats.
- * If the node contains fluid content, clearing floats may widen and shorten the contents of the node. In this case,
- * it is preferred to use the original, taller height.
- *
- * @returns {number} Height of node contents
- */
-ve.ce.Node.prototype.getContentsHeight = function () {
-	var clearedHeight,
-		height = this.$element.height(),
-		clear = this.$element.css( 'clear' ),
-		clearfix = this.$element.hasClass( 'clearfix' );
-
-	if ( !clearfix ) {
-		this.$element.addClass( 'clearfix' );
-	}
-	this.$element.css( 'clear', 'both' );
-
-	clearedHeight = this.$element.height();
-
-	if ( !clearfix ) {
-		this.$element.removeClass( 'clearfix' );
-	}
-	this.$element.css( 'clear', clear );
-
-	return Math.max( height, clearedHeight );
-};

--- a/extensions/VisualEditor/lib/ve/modules/ve/ui/ve.ui.DesktopContext.js
+++ b/extensions/VisualEditor/lib/ve/modules/ve/ui/ve.ui.DesktopContext.js
@@ -24,7 +24,6 @@ ve.ui.DesktopContext = function VeUiDesktopContext( surface, config ) {
 	this.$window = this.$( this.getElementWindow() );
 	this.floatThreshold = 10;
 	this.floating = false;
-	this.focusedNodeContentsHeight = null;
 	this.visible = false;
 	this.showing = false;
 	this.hiding = false;
@@ -473,7 +472,6 @@ ve.ui.DesktopContext.prototype.show = function ( transition ) {
 
 		if ( focusedNode ) {
 			this.handleFloat();
-			this.focusedNodeContentsHeight = focusedNode.getContentsHeight();
 		}
 
 		this.visible = true;

--- a/extensions/VisualEditor/wikia/modules/ve/init/ve.init.mw.WikiaViewPageTarget.init.js
+++ b/extensions/VisualEditor/wikia/modules/ve/init/ve.init.mw.WikiaViewPageTarget.init.js
@@ -30,9 +30,7 @@
 		spinnerTimeoutId = null;
 
 	function getOptimizelyExperimentId( experimentName ) {
-		if ( experimentName === 'VE Focus Mode' ) {
-			return mw.config.get( 'wgDevelEnvironment' ) ? 1459280459 : 1673360028;
-		} else if ( experimentName === 'VE Source Entry Point Anon' ) {
+		if ( experimentName === 'VE Source Entry Point Anon' ) {
 			return mw.config.get( 'wgDevelEnvironment' ) ? 1673650053 : 1783530197;
 		} else if ( experimentName === 'VE Source Entry Point User' ) {
 			return mw.config.get( 'wgDevelEnvironment' ) ? 1673650053 : 1779071141;
@@ -72,11 +70,6 @@
 	function showSpinner() {
 		var $spinner = $( '.ve-spinner[data-type="loading"]' ),
 			$message = $spinner.find( 'p.message' );
-
-		/* Optimizely */
-		if ( window.veFocusMode === 'opaque' ) {
-			$spinner.addClass( 'optimizely-opaque' );
-		}
 
 		$message.hide();
 		$spinner.fadeIn( 400 );


### PR DESCRIPTION
This is some stuff that I created as part of the floating context menu work. It was replaced by ve.ce.FocusableNode:getDimensions() but this cleanup was never done.
