### PR TITLE
Add back the default geo of 'ROW' in the cache key creation

### DIFF
--- a/extensions/wikia/MonetizationModule/MonetizationModuleHelper.class.php
+++ b/extensions/wikia/MonetizationModule/MonetizationModuleHelper.class.php
@@ -107,6 +107,13 @@ class MonetizationModuleHelper extends WikiaModel {
 			$cacheKey .= ':' . $params['s_id'];
 		}
 
+		if ( !empty( $params['geo'] ) ) {
+			$cacheKey .= ':' . $params['geo'];
+		} else {
+			// set the default to be rest of world ('ROW')
+			$cacheKey .= ':ROW';
+		}
+
 		return $cacheKey;
 	}
 


### PR DESCRIPTION
This will align with the service's cache key and avoid calling the service if there is a valid value in the cached.
