### PR TITLE
remove deprecated functions from WikiaBaseTest class

### DIFF
--- a/extensions/wikia/Search/classes/Test/IndexService/CrossWikiCoreTest.php
+++ b/extensions/wikia/Search/classes/Test/IndexService/CrossWikiCoreTest.php
@@ -80,7 +80,7 @@ class CrossWikiCoreTest extends BaseTest
 				$service->execute()
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.12268 ms
@@ -91,17 +91,17 @@ class CrossWikiCoreTest extends BaseTest
 		                ->disableOriginalConstructor()
 		                ->setMethods( [ 'getService' ] )
 		                ->getMock();
-		
+
 		$mwService = $this->getMock( 'Wikia\Search\MediaWikiService', [ 'getWikiId', 'getGlobal', 'getLanguageCode', 'getHubForWikiId', 'getHostName', 'getDomainsForWikiId' ] );
-		
+
 		$mockMessage = $this->getMockBuilder( 'WfMessage' )
 							->disableOriginalConstructor()
 							->setMethods( [ 'text' ] )
 							->getMock();
 
-		$mockWiki = (object) [ 
-				'city_created' => '11:11:11 2013-01-01', 
-				'city_last_timestamp' => '11:11:11 2013-01-01', 
+		$mockWiki = (object) [
+				'city_created' => '11:11:11 2013-01-01',
+				'city_last_timestamp' => '11:11:11 2013-01-01',
 				'city_url' => 'http://foo.wikia.com/',
 				'city_dbname' => 'foo'
 				];
@@ -149,8 +149,8 @@ class CrossWikiCoreTest extends BaseTest
 			->method ( 'text' )
 			->will   ( $this->returnValue( '$1 - Foo Wiki - Bar, Baz and More!' ) )
 		;
-		$expected = [ 
-				'id' => 123, 'sitename_txt' => 'foo wiki', 'lang_s' => 'en', 'hub_s' => 'Gaming', 
+		$expected = [
+				'id' => 123, 'sitename_txt' => 'foo wiki', 'lang_s' => 'en', 'hub_s' => 'Gaming',
 				'created_dt' => '11:11:11T2013-01-01Z', 'touched_dt' => '11:11:11T2013-01-01Z', 'url' => 'http://foo.wikia.com/', 'dbname_s' => 'foo',
 				'hostname_s' => 'hostname', 'hostname_txt' => 'hostname', 'all_domains_mv_wd' => [ 'bar.wikia.com', 'baz.wikia.com', 'foo.wikia.com' ], 'domains_txt' => [ 'bar.wikia.com', 'baz.wikia.com', 'foo.wikia.com' ],
 				'wiki_pagetitle_txt' => 'Foo Wiki - Bar, Baz and More!',
@@ -169,7 +169,7 @@ class CrossWikiCoreTest extends BaseTest
 				$service
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.08143 ms
@@ -183,8 +183,8 @@ class CrossWikiCoreTest extends BaseTest
 		$wv = $this->getMockBuilder( 'Wikia\Search\IndexService\WikiViews' )
 		           ->disableOriginalConstructor()
 		           ->setMethods( [ 'getStubbedWikiResponse' ] )
-		           ->getMock(); 
-		
+		           ->getMock();
+
 		$response = [ 'contents' => [ 'wikiviews_weekly' => [ 'set' => 123 ], 'wikiviews_monthly' => [ 'set' => 456 ] ] ];
 		$wv
 		    ->expects( $this->once() )
@@ -200,7 +200,7 @@ class CrossWikiCoreTest extends BaseTest
 				$get->invoke( $service )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.08105 ms
@@ -214,8 +214,8 @@ class CrossWikiCoreTest extends BaseTest
 		$wv = $this->getMockBuilder( 'Wikia\Search\IndexService\Wam' )
 		           ->disableOriginalConstructor()
 		           ->setMethods( [ 'getStubbedWikiResponse' ] )
-		           ->getMock(); 
-		
+		           ->getMock();
+
 		$response = [ 'contents' => [ 'wam' => [ 'set' => 100 ] ] ];
 		$wv
 		    ->expects( $this->once() )
@@ -231,7 +231,7 @@ class CrossWikiCoreTest extends BaseTest
 				$get->invoke( $service )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.08427 ms
@@ -242,11 +242,11 @@ class CrossWikiCoreTest extends BaseTest
 		                ->disableOriginalConstructor()
 		                ->setMethods( [ 'getService', 'getWikiId' ] )
 		                ->getMock();
-		
+
 		$mwService = $this->getMock( 'Wikia\Search\MediaWikiService', [ 'getApiStatsForWiki' ] );
-		
+
 		$wikiService = $this->getMock( 'WikiService', [ 'getTotalVideos' ] );
-		
+
 		$service
 		    ->expects( $this->once() )
 		    ->method ( 'getService' )
@@ -269,7 +269,7 @@ class CrossWikiCoreTest extends BaseTest
 		    ->will   ( $this->returnValue( 50 ) )
 		;
 		$this->proxyClass( 'WikiService', $wikiService );
-		$this->mockApp();
+
 		$get = new ReflectionMethod( $service, 'getWikiStats' );
 		$get->setAccessible( true );
 		$this->assertEquals(
@@ -277,7 +277,7 @@ class CrossWikiCoreTest extends BaseTest
 				$get->invoke( $service )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.08302 ms
@@ -288,7 +288,7 @@ class CrossWikiCoreTest extends BaseTest
 		                ->disableOriginalConstructor()
 		                ->setMethods( [ 'getService', 'getWikiId' ] )
 		                ->getMock();
-		
+
 		$mwService = $this->getMock( 'Wikia\Search\MediaWikiService', [ 'getVisualizationInfoForWikiId' ] );
 		$desc = 'this is my description';
 		$headline = 'this is my headline';
@@ -316,7 +316,7 @@ class CrossWikiCoreTest extends BaseTest
 				$get->invoke( $service )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.08589 ms
@@ -327,7 +327,7 @@ class CrossWikiCoreTest extends BaseTest
 		                ->disableOriginalConstructor()
 		                ->setMethods( [ 'getService', 'getWikiId' ] )
 		                ->getMock();
-		
+
 		$mwService = $this->getMock( 'Wikia\Search\MediaWikiService', [ 'getVisualizationInfoForWikiId', 'getSimpleMessage', 'getGlobal' ] );
 		$desc = 'this is my description';
 		$headline = 'this is my headline';

--- a/extensions/wikia/Search/classes/Test/Match/MatchTest.php
+++ b/extensions/wikia/Search/classes/Test/Match/MatchTest.php
@@ -20,15 +20,15 @@ class MatchTest extends BaseTest {
 		$mockMatch = $this->getMockBuilder( 'Wikia\Search\Match\AbstractMatch' )
 		                  ->setConstructorArgs( array( 123, $service ) )
 		                  ->getMockForAbstractClass();
-		
+
 		$this->assertAttributeEquals(
-				123, 
-				'id', 
+				123,
+				'id',
 				$mockMatch
 		);
 		$this->assertAttributeEquals(
-				$service, 
-				'service', 
+				$service,
+				'service',
 				$mockMatch
 		);
 		$this->assertEquals(
@@ -36,7 +36,7 @@ class MatchTest extends BaseTest {
 				$mockMatch->getId()
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.08443 ms
@@ -50,7 +50,7 @@ class MatchTest extends BaseTest {
 		$mockResult = $this->getMockBuilder( 'Wikia\Search\Result' )
 		                   ->disableOriginalConstructor()
 		                   ->getMock();
-		
+
 		$mockMatch
 		    ->expects( $this->once() )
 		    ->method ( 'createResult' )
@@ -61,7 +61,7 @@ class MatchTest extends BaseTest {
 				$mockMatch->getResult()
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.08511 ms
@@ -72,12 +72,12 @@ class MatchTest extends BaseTest {
 		                      ->disableOriginalConstructor()
 		                      ->setMethods( array( 'getCanonicalPageIdFromPageId' ) )
 		                      ->getMock();
-		
+
 		$mockResult = $this->getMockBuilder( 'Wikia\Search\Match\Article' )
 		                   ->setConstructorArgs( array( 123, $mockService ) )
 		                   ->setMethods( null )
 		                   ->getMock();
-		
+
 		$mockService
 		    ->expects( $this->at( 0 ) )
 		    ->method ( 'getCanonicalPageIdFromPageId' )
@@ -97,24 +97,24 @@ class MatchTest extends BaseTest {
 				$mockResult->hasRedirect()
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.10456 ms
 	 * @covers Wikia\Search\Match\Article::createResult
 	 */
 	public function testCreateResultArticle() {
-		$serviceMethods = array( 
+		$serviceMethods = array(
 				'getWikiId', 'getTitleStringFromPageId', 'getUrlFromPageid', 'getNamespaceFromPageId',
 				'getCanonicalPageIdFromPageId', 'getFirstRevisionTimestampForPageId','getLastRevisionTimestampForPageId',
 				'getSnippetForPageId', 'getNonCanonicalTitleStringFromPageId', 'getNonCanonicalUrlFromPageId'
 				);
-		
+
 		$mockService = $this->getMockBuilder( 'Wikia\Search\MediaWikiService' )
 		                      ->disableOriginalConstructor()
 		                      ->setMethods( $serviceMethods )
 		                      ->getMock();
-		
+
 		$pageId = 123;
 		$highlight = 'long span class';
 
@@ -122,8 +122,8 @@ class MatchTest extends BaseTest {
 		                   ->setConstructorArgs( array( $pageId, $mockService,$highlight ) )
 		                   ->setMethods( array( 'hasRedirect' ) )
 		                   ->getMock();
-		
-		
+
+
 		$wid = 321;
 		$canonicalPageId = 456;
 		$titleString = 'my title';
@@ -231,7 +231,7 @@ class MatchTest extends BaseTest {
 				$result->getVar( 'redirectUrl' )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.08899 ms
@@ -243,17 +243,17 @@ class MatchTest extends BaseTest {
 		                      ->disableOriginalConstructor()
 		                      ->setMethods( $serviceMethods )
 		                      ->getMock();
-		
+
 		$mockMatch = $this->getMockBuilder( 'Wikia\Search\Match\Wiki' )
 		                  ->disableOriginalConstructor()
 		                  ->setMethods( [ 'getId' ] )
 		                  ->getMock();
-		
+
 		$mockResult = $this->getMockBuilder( 'Wikia\Search\Result' )
 		                   ->disableOriginalConstructor()
 		                   ->setMethods( [ 'offsetSet' ] )
 		                   ->getMock();
-		
+
 		$mockService
 		    ->expects( $this->once() )
 		    ->method ( 'setCrossWiki' )
@@ -279,13 +279,13 @@ class MatchTest extends BaseTest {
 		    ->method ( 'offsetSet' )
 		    ->with   ( 'exactWikiMatch', true )
 		;
-		
+
 		$this->proxyClass( 'SolrDocumentService', $mockService );
-		$this->mockApp();
+
 		$this->assertEquals(
 				$mockResult,
 				$mockMatch->createResult()
 		);
-		
+
 	}
 }

--- a/extensions/wikia/Search/classes/Test/MediaWikiServiceTest.php
+++ b/extensions/wikia/Search/classes/Test/MediaWikiServiceTest.php
@@ -17,22 +17,22 @@ class MediaWikiServiceTest extends BaseTest
 	 * @var \Wikia\Search\MediaWikiService
 	 */
 	protected $service;
-	
+
 	/**
 	 * @var int
 	 */
 	protected $pageId;
-	
+
 	public function setUp() {
 		parent::setUp();
 		$this->pageId = 123;
 		$this->service = $this->getMockBuilder( '\Wikia\Search\MediaWikiService' )
                                 ->disableOriginalConstructor();
-		
+
 		// re-initialize static vars
-		$staticVars = array( 
+		$staticVars = array(
 				'pageIdsToArticles', 'pageIdsToTitles', 'redirectsToCanonicalIds',
-				'pageIdsToFiles', 'redirectArticles', 'wikiDataSources' 
+				'pageIdsToFiles', 'redirectArticles', 'wikiDataSources'
 		);
 		foreach ( $staticVars as $var ) {
 			$refl = new ReflectionProperty( 'Wikia\Search\MediaWikiService', $var );
@@ -40,7 +40,7 @@ class MediaWikiServiceTest extends BaseTest
 			$refl->setValue( array() );
 		}
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.08676 ms
@@ -48,13 +48,13 @@ class MediaWikiServiceTest extends BaseTest
 	 */
 	public function testGetTitleStringFromPageId() {
 		$service = $this->service->setMethods( array( 'getTitleString', 'getTitleFromPageId' ) )->getMock();
-		
+
 		$mockTitle = $this->getMockBuilder( 'Title' )
 		                  ->disableOriginalConstructor()
 		                  ->getMock();
-		
+
 		$mockTitleString = 'Mock Title';
-		
+
 		$service
 		    ->expects( $this->at( 0 ) )
 		    ->method ( 'getTitleFrompageId' )
@@ -73,7 +73,7 @@ class MediaWikiServiceTest extends BaseTest
 				'\Wikia\Search\MediaWikiService::getTitleStringFromPageId should return the string value of a title based on a page ID'
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.08731 ms
@@ -81,12 +81,12 @@ class MediaWikiServiceTest extends BaseTest
 	 */
 	public function testGetLocalUrlForPageId() {
 		$service = $this->service->setMethods( array( 'getTitleFromPageId' ) )->getMock();
-		
+
 		$mockTitle = $this->getMockBuilder( 'Title' )
 		                  ->disableOriginalConstructor()
 		                  ->setMethods( array( 'getLocalUrl' ) )
 		                  ->getMock();
-		
+
 		$service
 		    ->expects( $this->at( 0 ) )
 		    ->method ( 'getTitleFrompageId' )
@@ -105,7 +105,7 @@ class MediaWikiServiceTest extends BaseTest
 				'\Wikia\Search\MediaWikiService::getLocalUrlFromPageId should return the string value of local url based on a page ID'
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.08611 ms
@@ -113,16 +113,16 @@ class MediaWikiServiceTest extends BaseTest
 	 */
 	public function testGetTitleFromPageIdFreshPage() {
 		$service = $this->service->setMethods( array( 'getPageFromPageId' ) )->getMock();
-		
+
 		$mockPage = $this->getMockBuilder( 'Article' )
 		                 ->disableOriginalConstructor()
 		                 ->setMethods( array( 'getTitle' ) )
 		                 ->getMock();
-		
+
 		$mockTitle = $this->getMockBuilder( 'Title' )
 		                  ->disableOriginalConstructor()
 		                  ->getMock();
-		
+
 		$service
 		    ->expects( $this->at( 0 ) )
 		    ->method ( 'getPageFromPageId' )
@@ -134,17 +134,17 @@ class MediaWikiServiceTest extends BaseTest
 		    ->method ( 'getTitle' )
 		    ->will   ( $this->returnValue( $mockTitle ) )
 		;
-		
+
 		$getRefl = new ReflectionMethod( '\Wikia\Search\MediaWikiService', 'getTitleFromPageId' );
 		$getRefl->setAccessible( true );
 
 		$pageIdsToTitles = new ReflectionProperty( '\Wikia\Search\MediaWikiService', 'pageIdsToTitles' );
 		$pageIdsToTitles->setAccessible( true ) ;
-		
+
 		$this->assertEquals(
 				$mockTitle,
 				$getRefl->invoke( $service, $this->pageId ),
-				'\Wikia\Search\MediaWikiService::getTitleFromPageId should return an instance of Title corresponding to the provided page ID' 
+				'\Wikia\Search\MediaWikiService::getTitleFromPageId should return an instance of Title corresponding to the provided page ID'
 		);
 		$this->assertArrayHasKey(
 				$this->pageId,
@@ -152,7 +152,7 @@ class MediaWikiServiceTest extends BaseTest
 				'\Wikia\Search\MediaWikiService::getTitleFromPageId should store any titles it access for a page in the pageIdsToTitles array'
 		);
 	}
-	
+
     /**
 	 * @group Slow
 	 * @slowExecutionTime 0.08477 ms
@@ -160,16 +160,16 @@ class MediaWikiServiceTest extends BaseTest
 	 */
 	public function testGetTitleFromPageIdCachedPage() {
 		$service = $this->service->setMethods( array( 'getPageFromPageId' ) )->getMock();
-		
+
 		$mockPage = $this->getMockBuilder( 'Article' )
 		                 ->disableOriginalConstructor()
 		                 ->setMethods( array( 'getTitle' ) )
 		                 ->getMock();
-		
+
 		$mockTitle = $this->getMockBuilder( 'Title' )
 		                  ->disableOriginalConstructor()
 		                  ->getMock();
-		
+
 		$service
 		    ->expects( $this->never() )
 		    ->method ( 'getPageFromPageId' )
@@ -178,21 +178,21 @@ class MediaWikiServiceTest extends BaseTest
 		    ->expects( $this->never() )
 		    ->method ( 'getTitle' )
 		;
-		
+
 		$getRefl = new ReflectionMethod( '\Wikia\Search\MediaWikiService', 'getTitleFromPageId' );
 		$getRefl->setAccessible( true );
 
 		$pageIdsToTitles = new ReflectionProperty( '\Wikia\Search\MediaWikiService', 'pageIdsToTitles' );
 		$pageIdsToTitles->setAccessible( true );
 		$pageIdsToTitles->setValue( $service, array( $this->pageId => $mockTitle ) );
-		
+
 		$this->assertEquals(
 				$mockTitle,
 				$getRefl->invoke( $service, $this->pageId ),
-				'\Wikia\Search\MediaWikiService::getTitleFromPageId should return an instance of Title corresponding to the provided page ID' 
+				'\Wikia\Search\MediaWikiService::getTitleFromPageId should return an instance of Title corresponding to the provided page ID'
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.08548 ms
@@ -200,23 +200,23 @@ class MediaWikiServiceTest extends BaseTest
 	 */
 	public function testGetCanonicalPageIdFromPageIdIsCanonical() {
 		$service = $this->service->setMethods( array( 'getPageFromPageId' ) )->getMock();
-		
+
 		$service
 		    ->expects( $this->at( 0 ) )
 		    ->method ( 'getPageFromPageId' )
 		    ->with   ( $this->pageId )
 		;
-		
+
 		$getCanonicalPageIdFromPageId = new ReflectionMethod( '\Wikia\Search\MediaWikiService', 'getCanonicalPageIdFromPageId' );
 		$getCanonicalPageIdFromPageId->setAccessible( true );
-		
+
 		$this->assertEquals(
 				$this->pageId,
 				$getCanonicalPageIdFromPageId->invoke( $service, $this->pageId ),
 				'\Wikia\Search\MediaWikiService::getCanonicalPageIdFromPageId should return the value provided to it if a value is not stored in the redirect ID array'
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.08534 ms
@@ -233,17 +233,17 @@ class MediaWikiServiceTest extends BaseTest
 		    ->with   ( $this->pageId )
 		    ->will   ( $this->throwException( $ex ) )
 		;
-		
+
 		$getCanonicalPageIdFromPageId = new ReflectionMethod( '\Wikia\Search\MediaWikiService', 'getCanonicalPageIdFromPageId' );
 		$getCanonicalPageIdFromPageId->setAccessible( true );
-		
+
 		$this->assertEquals(
 				$this->pageId,
 				$getCanonicalPageIdFromPageId->invoke( $service, $this->pageId ),
 				'\Wikia\Search\MediaWikiService::getCanonicalPageIdFromPageId should return the value provided to it if an exception is thrown'
 		);
 	}
-	
+
     /**
 	 * @group Slow
 	 * @slowExecutionTime 0.08506 ms
@@ -251,29 +251,29 @@ class MediaWikiServiceTest extends BaseTest
 	 */
 	public function testGetCanonicalPageIdFromPageIdIsRedirect() {
 		$service = $this->service->setMethods( array( 'getPageFromPageId' ) )->getMock();
-		
+
 		$service
 		    ->expects( $this->at( 0 ) )
 		    ->method ( 'getPageFromPageId' )
 		    ->with   ( $this->pageId )
 		;
-		
+
 		$canonicalPageId = 54321;
-		
+
 		$redirectsToCanonicalIds = new ReflectionProperty( '\Wikia\Search\MediaWikiService', 'redirectsToCanonicalIds' );
 		$redirectsToCanonicalIds->setAccessible( true );
 		$redirectsToCanonicalIds->setValue( $service, array( $this->pageId => $canonicalPageId ) );
-		
+
 		$getCanonicalPageIdFromPageId = new ReflectionMethod( '\Wikia\Search\MediaWikiService', 'getCanonicalPageIdFromPageId' );
 		$getCanonicalPageIdFromPageId->setAccessible( true );
-		
+
 		$this->assertEquals(
 				$canonicalPageId,
 				$getCanonicalPageIdFromPageId->invoke( $service, $this->pageId ),
 				'\Wikia\Search\MediaWikiService::getCanonicalPageIdFromPageId should return the value provided to it if a value is not stored in the redirect ID array'
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.08618 ms
@@ -281,7 +281,7 @@ class MediaWikiServiceTest extends BaseTest
 	 */
 	public function testIsPageIdContentYes() {
 		$service = $this->service->setMethods( array( 'getNamespaceFromPageId', 'getGlobal' ) )->getMock();
-		
+
 		$service
 		    ->expects( $this->any() )
 		    ->method ( 'getNamespaceFromPageId' )
@@ -292,13 +292,13 @@ class MediaWikiServiceTest extends BaseTest
 		    ->expects( $this->any() )
 		    ->method ( 'getGlobal' )
 		    ->with   ( 'ContentNamespaces' )
-		    ->will   ( $this->returnValue( array( NS_MAIN, NS_CATEGORY ) ) ) 
+		    ->will   ( $this->returnValue( array( NS_MAIN, NS_CATEGORY ) ) )
 		;
 		$this->assertTrue(
 				$service->isPageIdContent( $this->pageId )
 		);
 	}
-	
+
     /**
 	 * @group Slow
 	 * @slowExecutionTime 0.08544 ms
@@ -306,7 +306,7 @@ class MediaWikiServiceTest extends BaseTest
 	 */
 	public function testIsPageIdContentNo() {
 		$service = $this->service->setMethods( array( 'getNamespaceFromPageId', 'getGlobal' ) )->getMock();
-		
+
 		$service
 		    ->expects( $this->any() )
 		    ->method ( 'getNamespaceFromPageId' )
@@ -317,13 +317,13 @@ class MediaWikiServiceTest extends BaseTest
 		    ->expects( $this->any() )
 		    ->method ( 'getGlobal' )
 		    ->with   ( 'ContentNamespaces' )
-		    ->will   ( $this->returnValue( array( NS_MAIN, NS_CATEGORY ) ) ) 
+		    ->will   ( $this->returnValue( array( NS_MAIN, NS_CATEGORY ) ) )
 		;
 		$this->assertFalse(
 				$service->isPageIdContent( $this->pageId )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.08566 ms
@@ -337,7 +337,7 @@ class MediaWikiServiceTest extends BaseTest
 				'\Wikia\Search\MediaWikiService::getLanguageCode should provide an interface to $wgContLang->getCode()'
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.08422 ms
@@ -345,14 +345,14 @@ class MediaWikiServiceTest extends BaseTest
 	 */
 	public function testGetUrlFromPageId() {
 		$service = $this->service->setMethods( array( 'getTitleFromPageId' ) )->getMock();
-		
+
 		$mockTitle = $this->getMockBuilder( 'Title' )
 		                  ->disableOriginalConstructor()
 		                  ->setMethods( array( 'getFullUrl' ) )
 		                  ->getMock();
-		
+
 		$url = 'http://foo.wikia.com/wiki/Bar';
-		
+
 		$service
 		    ->expects( $this->at( 0 ) )
 		    ->method ( 'getTitleFromPageId' )
@@ -370,7 +370,7 @@ class MediaWikiServiceTest extends BaseTest
 				'\Wikia\Search\MediaWikiService::getUrlFromPageId should return the full URL from the title instance associated with the provided page id'
 		);
 	}
-	
+
     /**
 	 * @group Slow
 	 * @slowExecutionTime 0.08527 ms
@@ -378,12 +378,12 @@ class MediaWikiServiceTest extends BaseTest
 	 */
 	public function testGetNamespaceFromPageId() {
 		$service = $this->service->setMethods( array( 'getTitleFromPageId' ) )->getMock();
-		
+
 		$mockTitle = $this->getMockBuilder( 'Title' )
 		                  ->disableOriginalConstructor()
 		                  ->setMethods( array( 'getNamespace' ) )
 		                  ->getMock();
-		
+
 		$service
 		    ->expects( $this->at( 0 ) )
 		    ->method ( 'getTitleFromPageId' )
@@ -401,7 +401,7 @@ class MediaWikiServiceTest extends BaseTest
 				'\Wikia\Search\MediaWikiService::getNamespaceFromPageId should return the namespace from the title instance associated with the provided page id'
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.08489 ms
@@ -413,7 +413,7 @@ class MediaWikiServiceTest extends BaseTest
 				(new MediaWikiService)->getMainPageArticleId()
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.08549 ms
@@ -424,7 +424,7 @@ class MediaWikiServiceTest extends BaseTest
 		                  ->disableOriginalConstructor()
 		                  ->setMethods( [ 'getArticleId' ] )
 		                  ->getMock();
-		
+
 		$mockService = $this->getMock( 'Wikia\Search\MediaWikiService', [ 'getMainPageTitleForWikiId' ] );
 		$mockService
 		    ->expects( $this->once() )
@@ -442,7 +442,7 @@ class MediaWikiServiceTest extends BaseTest
 				$mockService->getMainPageIdForWikiId( 123 )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.08591 ms
@@ -450,7 +450,7 @@ class MediaWikiServiceTest extends BaseTest
 	 */
 	public function testGetsimpleLanguageCode() {
 		$service = $this->service->setMethods( array( 'getLanguageCode' ) )->getMock();
-		
+
 		$service
 		    ->expects( $this->any() )
 		    ->method ( 'getLanguageCode' )
@@ -462,7 +462,7 @@ class MediaWikiServiceTest extends BaseTest
 				'\Wikia\Search\MediaWikiService::getSimpleLanguageCode should strip any extensions from the two-letter language code'
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.12579 ms
@@ -474,9 +474,9 @@ class MediaWikiServiceTest extends BaseTest
 		$mockApiService = $this->getMockBuilder( '\ApiService' )
 		                       ->setMethods( array( 'call' ) )
 		                       ->getMock();
-		
+
 		$mockResultArray = (object) array( 'foo' => 'bar' );
-		
+
 		// hack to make this work in our framework
 		$this->mockClass( '\ApiService', $mockResultArray, 'call' );
 
@@ -485,7 +485,7 @@ class MediaWikiServiceTest extends BaseTest
 				(new MediaWikiService)->getParseResponseFromPageId( $this->pageId )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.12603 ms
@@ -493,12 +493,12 @@ class MediaWikiServiceTest extends BaseTest
 	 */
 	public function testGetCacheKey() {
 		$service = $this->service->setMethods( array( 'getWikiId'  ) )->getMock();
-		
+
 		$mockSharedMemcKey = $this->getGlobalFunctionMock( 'wfSharedMemcKey' );
-		
+
 		$wid = 567;
 		$key = 'foo';
-		
+
 		$service
 		    ->expects( $this->any() )
 		    ->method ( 'getWikiId' )
@@ -515,16 +515,16 @@ class MediaWikiServiceTest extends BaseTest
 				$service->getCacheKey( $key )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.08632 ms
 	 * @covers \Wikia\Search\MediaWikiService::getCacheResult
 	 */
 	public function testGetCacheResult() {
-		
+
 		$service = $this->service->setMethods( array( 'getGlobal' ) )->getMock();
-		
+
 		$mockMc = $this->getMockBuilder( '\MemcachedClientForWiki' )
 		               ->disableOriginalConstructor()
 		               ->setMethods( array( 'get' ) )
@@ -532,7 +532,7 @@ class MediaWikiServiceTest extends BaseTest
 
 		$key = 'bar';
 		$result = 'foo';
-		
+
 		$app = (object) array( 'wg' => (object ) array( 'Memc' => $mockMc ) );
 		$reflApp = new ReflectionProperty( 'Wikia\Search\MediaWikiService', 'app' );
 		$reflApp->setAccessible( true );
@@ -550,7 +550,7 @@ class MediaWikiServiceTest extends BaseTest
 				'\WikiaSearch\MediaWikiService::getCacheResult should provide an interface to $wgMemc->get()'
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.08651 ms
@@ -558,10 +558,10 @@ class MediaWikiServiceTest extends BaseTest
 	 */
 	public function testGetCacheResultFromString() {
 		$service = $this->service->setMethods( array( 'getCacheResult', 'getCacheKey' ) )->getMock();
-		
+
 		$key = 'foo';
 		$val = 'bar';
-		
+
 		$service
 		    ->expects( $this->at( 0 ) )
 		    ->method ( 'getCacheKey' )
@@ -587,18 +587,18 @@ class MediaWikiServiceTest extends BaseTest
 	 * @covers \Wikia\Search\MediaWikiService::setCacheFromStringKey
 	 */
 	public function testSetCacheFromStringKey() {
-		
+
 		$service = $this->service->setMethods( array( 'getCacheKey', 'getWg' ) )->getMock();
-		
+
 		$mockMc = $this->getMockBuilder( '\MemcachedClientForWiki' )
 		               ->disableOriginalConstructor()
 		               ->setMethods( array( 'set' ) )
 		               ->getMock();
-		
+
 		$key = 'bar';
 		$value = 'foo';
 		$ttl = 3600;
-		
+
 		$service
 		    ->expects( $this->at( 0 ) )
 		    ->method ( 'getCacheKey' )
@@ -620,7 +620,7 @@ class MediaWikiServiceTest extends BaseTest
 				'\WikiaSearch\MediaWikiService::setCacheResultForStringKey should set a cache value in memcached provided a given plaintext key'
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @group Broken
@@ -630,13 +630,13 @@ class MediaWikiServiceTest extends BaseTest
 	 */
 	public function testGetBacklinksCountFromPageId() {
 		$service = $this->service->setMethods( array( 'getTitleStringFromPageId' ) )->getMock();
-		
+
 		$mockApiService = $this->getMock( '\ApiService', array( 'call' ) );
-		
+
 		$title = "Foo Bar";
-		
+
 		$data = array( 'query' => array( 'backlinks_count' => 0 ) );
-		
+
 		$service
 		    ->expects( $this->at( 0 ) )
 		    ->method ( 'getTitleStringFromPageId' )
@@ -658,7 +658,7 @@ class MediaWikiServiceTest extends BaseTest
 				$service->getBacklinksCountFromPageId( $this->pageId )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.08564 ms
@@ -668,14 +668,14 @@ class MediaWikiServiceTest extends BaseTest
 		$service = new MediaWikiService;
 		$app = \F::app();
 		$app->wg->Foo = 'bar';
-		
+
 		$this->assertEquals(
 				'bar',
 				$service->getGlobal( 'Foo' ),
 				'\WikiaSearch\MediaWikiService::getGlobal should provide an interface to MediaWiki wg-prefixed global variables'
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.09211 ms
@@ -685,14 +685,14 @@ class MediaWikiServiceTest extends BaseTest
 		$service = new MediaWikiService;
 		$app = \F::app();
 		$app->wg->Foo = null;
-		
+
 		$this->assertEquals(
 				'bar',
 				$service->getGlobalWithDefault( 'Foo', 'bar' ),
 				'\WikiaSearch\MediaWikiService::getGlobalWithDefault should return the default value if the global value is null.'
 		);
 	}
-	
+
     /**
 	 * @group Slow
 	 * @slowExecutionTime 0.08814 ms
@@ -701,7 +701,7 @@ class MediaWikiServiceTest extends BaseTest
 	public function testSetGlobal() {
 		$service = new MediaWikiService;
 		$app = \F::app();
-		
+
 		$this->assertEquals(
 				$service,
 				$service->setGlobal( 'Foo', 'bar' )
@@ -712,7 +712,7 @@ class MediaWikiServiceTest extends BaseTest
 				'\WikiaSearch\MediaWikiService::setGlobal should set the provided key as a global variable name with the provided value'
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.08829 ms
@@ -720,7 +720,7 @@ class MediaWikiServiceTest extends BaseTest
 	 */
 	public function testGetWikiId() {
 		$service = $this->service->setMethods( array( 'getGlobal' ) )->getMock();
-		
+
 		$service
 		    ->expects( $this->at( 0 ) )
 		    ->method ( 'getGlobal' )
@@ -754,7 +754,7 @@ class MediaWikiServiceTest extends BaseTest
 				$service->getWikiId()
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.09124 ms
@@ -762,12 +762,12 @@ class MediaWikiServiceTest extends BaseTest
 	 */
 	public function testGetMediaDataFromPageId() {
 		$service = $this->service->setMethods( array( 'pageIdHasFile', 'getFileForPageId' ) )->getMock();
-		
+
 		$mockFile = $this->getMockBuilder( 'File' )
 		                 ->disableOriginalConstructor()
 		                 ->setMethods( array( 'getMetadata' ) )
 		                 ->getMock();
-		
+
 		$service
 		    ->expects( $this->at( 0 ) )
 		    ->method ( 'pageIdHasFile' )
@@ -779,9 +779,9 @@ class MediaWikiServiceTest extends BaseTest
 				$service->getMediaDataFromPageId( $this->pageId ),
 				'\WikiaSearch\MediaWikiService::getMediaDataFromPageId should return an empty string if the page id is not a file'
 		);
-		
+
 		$serialized = serialize( array( 'foo' => 'bar' ) );
-		
+
 		$service
 		    ->expects( $this->at( 0 ) )
 		    ->method ( 'pageIdHasFile' )
@@ -810,14 +810,14 @@ class MediaWikiServiceTest extends BaseTest
 	 * @group Slow
 	 * @slowExecutionTime 0.09431 ms
      * @covers\Wikia\Search\MediaWikiService::pageIdHasFile
-     */	
+     */
 	public function testPageIdHasFile() {
 		$service = $this->service->setMethods( array( 'getFileForPageId' ) )->getMock();
-		
+
 		$mockFile = $this->getMockBuilder( 'File' )
 		                 ->disableOriginalConstructor()
 		                 ->getMock();
-		
+
 		$service
 		    ->expects( $this->at( 0 ) )
 		    ->method ( 'getFileForPageId' )
@@ -837,7 +837,7 @@ class MediaWikiServiceTest extends BaseTest
 				$service->pageIdHasFile( $this->pageId )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.20025 ms
@@ -856,7 +856,7 @@ class MediaWikiServiceTest extends BaseTest
 			    (new MediaWikiService)->getApiStatsForPageId( $this->pageId )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.14909 ms
@@ -875,7 +875,7 @@ class MediaWikiServiceTest extends BaseTest
 			    (new MediaWikiService)->getApiStatsForWiki( $wgCityId )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.08778 ms
@@ -887,9 +887,9 @@ class MediaWikiServiceTest extends BaseTest
 		             ->disableOriginalConstructor()
 		             ->setMethods( array( 'exists' ) )
 		             ->getMock();
-		
+
 		$mockException = $this->getMock( '\Exception' );
-		
+
 		$service
 		    ->expects( $this->at( 0 ) )
 		    ->method ( 'getPageFromPageId' )
@@ -931,7 +931,7 @@ class MediaWikiServiceTest extends BaseTest
 				'\WikiaSearch\MediaWikiService::pageExists should pass the return value of Article::exists'
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.1391 ms
@@ -939,18 +939,18 @@ class MediaWikiServiceTest extends BaseTest
 	 */
 	public function testGetRedirectTitlesForPageID() {
 		$service = $this->service->setMethods( array( 'getTitleFromPageId' ) )->getMock();
-		
+
 		$mockDbr = $this->getMockBuilder( '\DatabaseMysql' )
 		                ->disableOriginalConstructor()
 		                ->setMethods( array( 'select', 'fetchObject' ) )
 		                ->getMock();
-		
+
 		$mockGetDB = $this->getGlobalFunctionMock( 'wfGetDB' );
-		
+
 		$mockResult = $this->getMockBuilder( '\ResultWrapper' )
 		                   ->disableOriginalConstructor()
 		                   ->getMock();
-		
+
 		$mockRow = (object) array( 'page_title' => 'Bar_Foo' );
 		$titleKey = 'foo_page';
 		$titleNs = 13;
@@ -964,7 +964,7 @@ class MediaWikiServiceTest extends BaseTest
 		$group = array( 'GROUP' => 'rd_title' );
 		$join = array( 'page' => array( 'INNER JOIN', array( 'rd_title' => $titleKey, 'rd_namespace' => $titleNs, 'page_id = rd_from' ) ) );
 		$expectedResult = array( 'Bar Foo' );
-		
+
 		$mockGetDB
 		    ->expects( $this->once() )
 		    ->method ( 'wfGetDB' )
@@ -1011,7 +1011,7 @@ class MediaWikiServiceTest extends BaseTest
 				$service->getRedirectTitlesForPageId( $this->pageId )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @group Broken
@@ -1024,9 +1024,9 @@ class MediaWikiServiceTest extends BaseTest
 		$mockTitle = $this->getMockBuilder( 'Title' )
 		                  ->disableOriginalConstructor()
 		                  ->getMock();
-		
+
 		$detailArray = array( 'these my' => 'details' );
-		
+
 		$service
 		    ->expects( $this->at( 0 ) )
 		    ->method ( 'getTitleFromPageId' )
@@ -1044,7 +1044,7 @@ class MediaWikiServiceTest extends BaseTest
 				'\Wikia\Search\MediaWikiService::getMediaDetailFromPageId should return the array result of \WikiaFileHelper::getMediaDetail'
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.10581 ms
@@ -1052,12 +1052,12 @@ class MediaWikiServiceTest extends BaseTest
 	 */
 	public function testPageIdIsVideoFile() {
 		$service = $this->service->setMethods( array( 'getFileForPageId' ) )->getMock();
-		
+
 		$mockFile = $this->getMockBuilder( '\LocalFile' )
 		                 ->disableOriginalConstructor()
 		                 ->setMethods( array( 'getHandler' ) )
 		                 ->getMock();
-		
+
 		$mockVideoHandler = $this->getMockBuilder( '\VideoHandler' )->getMock();
 		// again, mocking stuff we don't really want to here because of static methods
 		$service
@@ -1075,7 +1075,7 @@ class MediaWikiServiceTest extends BaseTest
 				$service->pageIdIsVideoFile( $this->pageId )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.09202 ms
@@ -1107,7 +1107,7 @@ class MediaWikiServiceTest extends BaseTest
 				'\Wikia\Search\MediaWikiService::getTitleKeyFromPageId should return the db key for the canonical title associated with the provided page ID'
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.16046 ms
@@ -1118,13 +1118,13 @@ class MediaWikiServiceTest extends BaseTest
 		$mockFile = $this->getMockBuilder( '\File' )
 		                 ->disableOriginalConstructor()
 		                 ->getMock();
-		
+
 		$mockFindFile = $this->getGlobalFunctionMock( 'wfFindFile' );
-		
+
 		$mockTitle = $this->getMockBuilder( 'Title' )
 		                  ->disableOriginalConstructor()
 		                  ->getMock();
-		
+
 		$service
 		    ->expects( $this->at( 0 ) )
 		    ->method ( 'getTitleFromPageId' )
@@ -1161,7 +1161,7 @@ class MediaWikiServiceTest extends BaseTest
 				'\Wikia\Search\MediaWikiService::getFileForPageId should return a cached file for the provided page ID if already invoked'
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.14926 ms
@@ -1174,14 +1174,14 @@ class MediaWikiServiceTest extends BaseTest
 		try {
 			$get->invoke( (new MediaWikiService), $this->pageId );
 		} catch ( \Exception $e ) {}
-		
+
 		$this->assertInstanceOf(
 				'\Exception',
 				$e,
 				'\Wikia\Search\MediaWikiService::getPageFromPageId should throw an exception when provided a nonexistent page id'
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.16001 ms
@@ -1193,7 +1193,7 @@ class MediaWikiServiceTest extends BaseTest
 		                    ->disableOriginalConstructor()
 		                    ->setMethods( array( '__call' ) )
 		                    ->getMock();
-		
+
 		$mockArticle
 		    ->expects( $this->any() )
 		    ->method ( '__call' )
@@ -1222,7 +1222,7 @@ class MediaWikiServiceTest extends BaseTest
 				'\Wikia\Search\MediaWikiService::getPageFromPageId should return a cached instance of \Article for a provided page id upon consecutive invocations'
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.16608 ms
@@ -1287,7 +1287,7 @@ class MediaWikiServiceTest extends BaseTest
 				'\Wikia\Search\MediaWikiService::getPageFromPageId should return a cached instance of \Article for a provided canonical page id upon consecutive invocations, even if the redirect was accessed'
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.08691 ms
@@ -1295,12 +1295,12 @@ class MediaWikiServiceTest extends BaseTest
 	 */
 	public function testGetTitleStringDefault() {
 		$service = $this->service->getMock();
-		
+
 		$title = $this->getMockBuilder( '\Title' )
 		              ->disableOriginalConstructor()
 		              ->setMethods( array( 'getFullText', 'getNamespace' ) )
 		              ->getMock();
-		
+
 		$title
 		    ->expects( $this->once() )
 		    ->method ( 'getFullText' )
@@ -1318,7 +1318,7 @@ class MediaWikiServiceTest extends BaseTest
 				$get->invoke( $service, $title )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.1397 ms
@@ -1326,12 +1326,12 @@ class MediaWikiServiceTest extends BaseTest
 	 */
 	public function testGetTitleStringChildWallMessage() {
 		$service = $this->service->getMock();
-		
+
 		$title = $this->getMockBuilder( '\Title' )
 		              ->disableOriginalConstructor()
 		              ->setMethods( array( 'getArticleID', 'getNamespace', 'getFullText' ) )
 		              ->getMock();
-		
+
 		$wm = $this->getMockBuilder( '\WallMessage' )
 		           ->disableOriginalConstructor()
 		           ->setMethods( array( 'load', 'isMain', 'getTopParentObj', 'getMetaTitle' ) )
@@ -1373,7 +1373,7 @@ class MediaWikiServiceTest extends BaseTest
 		;
 
 		$this->proxyClass( '\WallMessage', $wm, 'newFromId' );
-		$this->mockApp();
+
 		$get = new ReflectionMethod( '\Wikia\Search\MediaWikiService', 'getTitleString' );
 		$get->setAccessible( true );
 		$this->assertEquals(
@@ -1381,7 +1381,7 @@ class MediaWikiServiceTest extends BaseTest
 				$get->invoke( $service, $title )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.13248 ms
@@ -1389,12 +1389,12 @@ class MediaWikiServiceTest extends BaseTest
 	 */
 	public function testGetTitleStringEmptyChildWallMessage() {
 		$service = $this->service->getMock();
-		
+
 		$title = $this->getMockBuilder( '\Title' )
 		              ->disableOriginalConstructor()
 		              ->setMethods( array( 'getArticleID', 'getNamespace', 'getFullText' ) )
 		              ->getMock();
-		
+
 		$wm = $this->getMockBuilder( '\WallMessage' )
 		           ->disableOriginalConstructor()
 		           ->setMethods( array( 'load', 'isMain', 'getTopParentObj', 'getMetaTitle' ) )
@@ -1437,7 +1437,7 @@ class MediaWikiServiceTest extends BaseTest
 				$get->invoke( $service, $title )
 		);
 	}
-	
+
 //	/**
 //	 * @covers \Wikia\Search\MediaWikiService::getTitleString
 //	 */
@@ -1465,7 +1465,7 @@ class MediaWikiServiceTest extends BaseTest
 //		    ->will    ( $this->returnValue( $this->pageId ) )
 //		;
 //		$this->proxyClass( '\WallMessage', null, 'newFromId' );
-//		$this->mockApp();
+
 //		$get = new ReflectionMethod( '\Wikia\Search\MediaWikiService', 'getTitleString' );
 //		$get->setAccessible( true );
 //		$this->assertEquals(
@@ -1473,8 +1473,8 @@ class MediaWikiServiceTest extends BaseTest
 //				$get->invoke( $service, $title )
 //		);
 //	}
-	
-	
+
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.13071 ms
@@ -1482,17 +1482,17 @@ class MediaWikiServiceTest extends BaseTest
 	 **/
 	public function testGetTitleStringMainWallMessage() {
 		$service = $this->service->getMock();
-		
+
 		$title = $this->getMockBuilder( '\Title' )
 		              ->disableOriginalConstructor()
 		              ->setMethods( array( 'getArticleID', 'getNamespace', 'getFullText' ) )
 		              ->getMock();
-		
+
 		$wm = $this->getMockBuilder( '\WallMessage' )
 		           ->disableOriginalConstructor()
 		           ->setMethods( array( 'load', 'isMain', 'getTopParentObj', 'getMetaTitle' ) )
 		           ->getMock();
-		
+
 		$title
 		    ->expects( $this->once() )
 		    ->method ( 'getNamespace' )
@@ -1525,7 +1525,7 @@ class MediaWikiServiceTest extends BaseTest
 				$get->invoke( $service, $title )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.08616 ms
@@ -1534,7 +1534,7 @@ class MediaWikiServiceTest extends BaseTest
 	public function testGetNamespaceIdForString() {
 		$this->assertEquals( NS_CATEGORY, (new MediaWikiService)->getNamespaceIdForString( 'Category' ) );
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @group Broken
@@ -1565,7 +1565,7 @@ class MediaWikiServiceTest extends BaseTest
 				(new MediaWikiService)->getGlobalForWiki( 'foo', 123 )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.10373 ms
@@ -1593,7 +1593,7 @@ class MediaWikiServiceTest extends BaseTest
 				$service->isSkinMobile()
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.08888 ms
@@ -1620,7 +1620,7 @@ class MediaWikiServiceTest extends BaseTest
 				$service->isOnDbCluster()
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.08666 ms
@@ -1632,7 +1632,7 @@ class MediaWikiServiceTest extends BaseTest
 				(new MediaWikiService)->getDefaultNamespacesFromSearchEngine()
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.09002 ms
@@ -1644,7 +1644,7 @@ class MediaWikiServiceTest extends BaseTest
 				(new MediaWikiService)->getSearchableNamespacesFromSearchEngine()
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.08619 ms
@@ -1656,7 +1656,7 @@ class MediaWikiServiceTest extends BaseTest
 				(new MediaWikiService)->getTextForNamespaces( array( 0, 14 ) )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.0894 ms
@@ -1700,7 +1700,7 @@ class MediaWikiServiceTest extends BaseTest
 				$service->getFirstRevisionTimestampForPageId( $this->pageId )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.09075 ms
@@ -1727,19 +1727,19 @@ class MediaWikiServiceTest extends BaseTest
 				$service->getSnippetForPageId( $this->pageId )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.09298 ms
 	 * @covers Wikia\Search\MediaWikiService::getNonCanonicalTitleStringFromPageId
 	 */
-	public function testGetNonCanonicalTitleStringFromPageId() { 
+	public function testGetNonCanonicalTitleStringFromPageId() {
 		$service = $this->service->setMethods( array( 'getTitleStringFromPageId', 'getTitleString' ) )->getMock();
 		$mockArticle = $this->getMockBuilder( 'Article' )
 		                    ->disableOriginalConstructor()
 		                    ->setMethods( array( 'getTitle' ) )
 		                    ->getMock();
-		
+
 		$mockTitle = $this->getMockBuilder( 'Title' )
 		                  ->disableOriginalConstructor()
 		                  ->getMock();
@@ -1773,19 +1773,19 @@ class MediaWikiServiceTest extends BaseTest
 				$service->getNonCanonicalTitleStringFromPageId( $this->pageId )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.09138 ms
 	 * @covers Wikia\Search\MediaWikiService::getNonCanonicalUrlFromPageId
 	 */
-	public function testGetNonCanonicalUrlFromPageId() { 
+	public function testGetNonCanonicalUrlFromPageId() {
 		$service = $this->service->setMethods( array( 'getUrlFromPageId' ) )->getMock();
 		$mockArticle = $this->getMockBuilder( 'Article' )
 		                    ->disableOriginalConstructor()
 		                    ->setMethods( array( 'getTitle' ) )
 		                    ->getMock();
-		
+
 		$mockTitle = $this->getMockBuilder( 'Title' )
 		                  ->disableOriginalConstructor()
 		                  ->setMethods( array( 'getFullUrl' ) )
@@ -1819,7 +1819,7 @@ class MediaWikiServiceTest extends BaseTest
 				$service->getNonCanonicalUrlFromPageId( $this->pageId )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @group Broken
@@ -1832,18 +1832,18 @@ class MediaWikiServiceTest extends BaseTest
 		                   ->disableOriginalConstructor()
 		                   ->setMethods( array( 'getNearMatch' ) )
 		                   ->getMock();
-		
+
 		$mockTitle = $this->getMockBuilder( 'Title' )
 		                  ->disableOriginalConstructor()
 		                  ->setMethods( array( 'getNamespace', 'getArticleId' ) )
 		                  ->getMock();
-		
+
 		$mockMatch = $this->getMockBuilder( 'Wikia\Search\Match\Article' )
 		                  ->disableOriginalConstructor()
 		                  ->getMock();
 		$term = 'Foo';
 		$namespaces = array( 0, 14 );
-		
+
 		$mockEngine
 		    ->staticExpects( $this->at( 0 ) )
 		    ->method       ( 'getNearMatch' )
@@ -1859,7 +1859,7 @@ class MediaWikiServiceTest extends BaseTest
 		    ->staticExpects( $this->at( 0 ) )
 		    ->method       ( 'getNearMatch' )
 		    ->with         ( $term )
-		    ->will         ( $this->returnValue( $mockTitle ) ) 
+		    ->will         ( $this->returnValue( $mockTitle ) )
 		;
 		$mockTitle
 		    ->expects( $this->once() )
@@ -1883,7 +1883,7 @@ class MediaWikiServiceTest extends BaseTest
 				$mockMatch
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.09007 ms
@@ -1895,12 +1895,12 @@ class MediaWikiServiceTest extends BaseTest
 		    ->expects( $this->never() )
 		    ->method ( 'getLanguageCode' )
 		;
-		$this->assertNull( 
+		$this->assertNull(
 				$mws->getWikiMatchByHost( '' ),
-				"Empty domain should return null" 
+				"Empty domain should return null"
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.09183 ms
@@ -1962,7 +1962,7 @@ class MediaWikiServiceTest extends BaseTest
 				'A host that corresponds to a public wiki matching the current language should return a match'
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.08665 ms
@@ -1995,7 +1995,7 @@ class MediaWikiServiceTest extends BaseTest
 				'A host that corresponds to a public wiki matching the current language should return a match'
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.08709 ms
@@ -2034,7 +2034,7 @@ class MediaWikiServiceTest extends BaseTest
 				'A host that corresponds to a public wiki matching the current language should return a match'
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.08804 ms
@@ -2066,7 +2066,7 @@ class MediaWikiServiceTest extends BaseTest
 				'We should not return a wiki match for a wiki that is closed'
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.08925 ms
@@ -2098,8 +2098,8 @@ class MediaWikiServiceTest extends BaseTest
 				'We should not return a wiki match for a non language-matching wiki'
 		);
 	}
-	
-	
+
+
 	/**
 	 * @group Slow
 	 * @group Broken
@@ -2153,7 +2153,7 @@ class MediaWikiServiceTest extends BaseTest
 				$service->getMainPageUrlForWikiId( 123 )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.08847 ms
@@ -2184,7 +2184,7 @@ class MediaWikiServiceTest extends BaseTest
 				$reflGet->invoke( $service, 123 )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.13295 ms
@@ -2229,7 +2229,7 @@ class MediaWikiServiceTest extends BaseTest
 				$service->getLastRevisionTimestampForPageId( $this->pageId )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.12891 ms
@@ -2258,7 +2258,7 @@ class MediaWikiServiceTest extends BaseTest
 		$lang
 		    ->expects( $this->once() )
 		    ->method ( 'date' )
-		    ->with   ( 'timestamp' ) 
+		    ->with   ( 'timestamp' )
 		    ->will   ( $this->returnValue( 'mw formatted timestamp' ) )
 		;
 		$this->assertEquals(
@@ -2266,7 +2266,7 @@ class MediaWikiServiceTest extends BaseTest
 				$service->getMediaWikiFormattedTimestamp( '11/11/11' )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.08929 ms
@@ -2534,7 +2534,7 @@ class MediaWikiServiceTest extends BaseTest
 			$service->getThumbnailHtmlFromFileTitle( 'x', array( 'width' => 12, 'height' => 13 ) )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @group Broken
@@ -2552,7 +2552,7 @@ class MediaWikiServiceTest extends BaseTest
 		            ->disableOriginalConstructor()
 		            ->setMethods( array( 'isFileTypeVideo' ) )
 		            ->getMock();
-		
+
 		$mqs = $this->getMockBuilder( 'MediaQueryService' )
 		            ->disableOriginalConstructor()
 		            ->setMethods( array( 'getTotalVideoViewsByTitle' ) )
@@ -2587,7 +2587,7 @@ class MediaWikiServiceTest extends BaseTest
 				$service->getVideoViewsForPageId( $this->pageId )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.13485 ms
@@ -2621,7 +2621,7 @@ class MediaWikiServiceTest extends BaseTest
 				$service->getFormattedVideoViewsForPageId( $this->pageId )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.09123 ms
@@ -2629,12 +2629,12 @@ class MediaWikiServiceTest extends BaseTest
 	 */
 	public function testFormatNumber() {
 		$service = $this->service->setMethods( null )->getMock();
-		
+
 		$lang = $this->getMockBuilder( "Language" )
 		             ->disableOriginalConstructor()
 		             ->setMethods( array( 'formatNum' ) )
 		             ->getMock();
-		
+
 		$lang
 		    ->expects( $this->once() )
 		    ->method ( 'formatNum' )
@@ -2650,7 +2650,7 @@ class MediaWikiServiceTest extends BaseTest
 				$service->formatNumber( 10000 )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.09122 ms
@@ -2688,7 +2688,7 @@ class MediaWikiServiceTest extends BaseTest
 	public function testGetStatsInfoForWikiId() {
 		$service = $this->service->setMethods( null )->getMock();
 		$wikisvc = $this->getMock( 'WikiService', array( 'getSiteStats', 'getTotalVideos' ) );
-		
+
 		$info = array( 'this' => 'yup' );
 		$wikisvc
 		    ->expects( $this->once() )
@@ -2710,7 +2710,7 @@ class MediaWikiServiceTest extends BaseTest
 				$service->getStatsInfoForWikiId( 123 )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.13199 ms
@@ -2734,7 +2734,7 @@ class MediaWikiServiceTest extends BaseTest
 				$meth->invoke( $service, $timestamp )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.09136 ms
@@ -2745,7 +2745,7 @@ class MediaWikiServiceTest extends BaseTest
 		$ds = $this->getMockBuilder( 'WikiDataSource' )
 		           ->disableOriginalConstructor()
 		           ->getMock();
-		
+
 		$this->mockClass( 'WikiDataSource', $ds );
 		$meth = $app = new ReflectionMethod( '\Wikia\Search\MediaWikiService' , 'getDataSourceForWikiId' );
 		$meth->setAccessible( true );
@@ -2760,7 +2760,7 @@ class MediaWikiServiceTest extends BaseTest
 				$service
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @group Broken
@@ -2774,7 +2774,7 @@ class MediaWikiServiceTest extends BaseTest
 		              ->disableOriginalConstructor()
 		              ->setMethods( [ 'isRedirect', 'getRedirectTarget' ] )
 		              ->getMock();
-		
+
 		$service
 		    ->expects( $this->once() )
 		    ->method ( 'getDbNameForWikiId' )
@@ -2815,7 +2815,7 @@ class MediaWikiServiceTest extends BaseTest
 				$title
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @group Broken
@@ -2825,8 +2825,8 @@ class MediaWikiServiceTest extends BaseTest
 	public function testGetDescriptionTextForWikiId() {
 		$service = $this->service->setMethods( [ 'getDbNameForWikiId', 'getGlobalForWiki' ] )->getMock();
 		$apiservice = $this->getMock( 'ApiService', [ 'foreignCall' ] );
-		
-		
+
+
 		$service
 		    ->expects( $this->at( 0 ) )
 		    ->method ( 'getDbNameForWikiId' )
@@ -2859,7 +2859,7 @@ class MediaWikiServiceTest extends BaseTest
 				$service->getDescriptionTextForWikiId( 123 )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @group Broken
@@ -2881,8 +2881,8 @@ class MediaWikiServiceTest extends BaseTest
 				$service->getHubForWikiId( 123 )
 		);
 	}
-	
-	
+
+
 	/**
 	 * @group Slow
 	 * @group Broken
@@ -2904,7 +2904,7 @@ class MediaWikiServiceTest extends BaseTest
 				$service->getSubHubForWikiId( 123 )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @group Broken
@@ -2918,7 +2918,7 @@ class MediaWikiServiceTest extends BaseTest
 		              ->disableOriginalConstructor()
 		              ->setMethods( [ 'getDbKey' ] )
 		              ->getMock();
-		
+
 		$params = [ 'controller' => 'ArticlesApiController', 'method' => 'getDetails', 'titles' => 'Foo_bar' ];
 		$title
 		    ->expects( $this->once() )
@@ -2950,7 +2950,7 @@ class MediaWikiServiceTest extends BaseTest
 				$service->getMainPageTextForWikiId( 123 )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.13325 ms
@@ -2969,7 +2969,7 @@ class MediaWikiServiceTest extends BaseTest
 				$service->invokeHook( 'onwhatever', [ 'foo', 123 ] )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.09113 ms
@@ -2983,7 +2983,7 @@ class MediaWikiServiceTest extends BaseTest
 				$service
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.09036 ms
@@ -2996,7 +2996,7 @@ class MediaWikiServiceTest extends BaseTest
 				$service->getHostName()
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.0917 ms
@@ -3053,7 +3053,7 @@ class MediaWikiServiceTest extends BaseTest
 			array(10000000000, 'message-id', 10000, 'message-id-M'),
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.13412 ms
@@ -3066,7 +3066,7 @@ class MediaWikiServiceTest extends BaseTest
 		                    ->disableOriginalConstructor()
 		                    ->setMethods( array( 'text' ) )
 		                    ->getMock();
-		
+
 		$service = $this->service->setMethods( null )->getMock();
 		$params = array( 'whatever' );
 		$mockWfMessage
@@ -3080,34 +3080,34 @@ class MediaWikiServiceTest extends BaseTest
 		    ->method ( 'text' )
 		    ->will   ( $this->returnValue( 'bar whatever' ) )
 		;
-		
+
 		$this->assertEquals(
 				'bar whatever',
 				$service->getSimpleMessage( 'foo', $params )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.13765 ms
 	 * @covers Wikia\Search\MediaWikiService::getDomainsForWikiId
 	 */
 	public function testGetDomainsForWikiId() {
-		$mws = $this->getMock( 'Wikia\Search\MediaWikiService', [ 'getGlobal', 'getWikiId' ] ); 
-		
+		$mws = $this->getMock( 'Wikia\Search\MediaWikiService', [ 'getGlobal', 'getWikiId' ] );
+
 		$mockDbr = $this->getMockBuilder( '\DatabaseMysql' )
 		                ->disableOriginalConstructor()
 		                ->setMethods( array( 'select', 'fetchObject' ) )
 		                ->getMock();
-		
+
 		$mockGetDB = $this->getGlobalFunctionMock( 'wfGetDB' );
-		
+
 		$mockResult = $this->getMockBuilder( '\ResultWrapper' )
 		                   ->disableOriginalConstructor()
 		                   ->getMock();
-		
+
 		$mockObject = (object) [ 'city_domain' => 'foo.wikia.com' ];
-		
+
 		$mws
 		    ->expects( $this->once() )
 		    ->method ( 'getGlobal' )

--- a/extensions/wikia/Search/classes/Test/QueryService/Select/AbstractSelectTest.php
+++ b/extensions/wikia/Search/classes/Test/QueryService/Select/AbstractSelectTest.php
@@ -25,7 +25,7 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 		$mockSelect = $this->getMockBuilder( 'Wikia\Search\QueryService\Select\AbstractSelect' )
 		                   ->setConstructorArgs( array( $dc ) )
 		                   ->getMockForAbstractClass();
-		
+
 		$this->assertAttributeInstanceOf(
 				'Wikia\Search\Config',
 				'config',
@@ -42,7 +42,7 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 				$mockSelect
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.09917 ms
@@ -52,20 +52,20 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 		$mockConfig = $this->getMockBuilder( 'Wikia\Search\Config' )
 		                   ->setMethods( array( 'getResults' ) )
 		                   ->getMock();
-		
+
 		$mockSelect = $this->getMockBuilder( 'Wikia\Search\QueryService\Select\AbstractSelect' )
 		                   ->disableOriginalConstructor()
 		                   ->setMethods( array( 'getMatch', 'prepareRequest', 'prepareResponse', 'sendSearchRequestToClient', 'getConfig' ) )
 		                   ->getMockForAbstractClass();
-		
+
 		$mockResponse = $this->getMockBuilder( 'Solarium_Result_Select' )
 		                     ->disableOriginalConstructor()
 		                     ->getMock();
-		
+
 		$mockResultSet = $this->getMockBuilder( 'Wikia\Search\ResultSet\Base' )
 		                      ->disableOriginalConstructor()
 		                      ->getMock();
-		
+
 		$mockSelect
 		    ->expects( $this->at( 0 ) )
 		    ->method ( 'getMatch' )
@@ -100,7 +100,7 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 				$mockSelect->search()
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.09584 ms
@@ -157,7 +157,7 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 				$mockSelect->getMatch()
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.09542 ms
@@ -186,7 +186,7 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 				$mockSelect->getMatch()
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.09908 ms
@@ -246,7 +246,7 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 				$getSelect->invoke( $mockSelect )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.10254 ms
@@ -267,7 +267,7 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 				$register->invoke( $mockSelect, $mockQuery )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.10082 ms
@@ -283,20 +283,20 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 		                   ->disableOriginalConstructor()
 		                   ->setMethods( array( 'getConfig', 'getRequestedFields' ) )
 		                   ->getMockForAbstractClass();
-		
+
 		$mockSelect
 		    ->expects( $this->any() )
 		    ->method ( 'getConfig' )
 		    ->will   ( $this->returnValue( $config ) )
 		;
-		
+
 		// we'll just use default values.
 		$sort = $config->getSort();
 		$start = $config->getStart();
 		$length = $config->getLength();
-		
+
 		$fields = [ 'foo', 'bar', 'baz' ];
-		
+
 		$mockSelect
 		    ->expects( $this->once() )
 		    ->method ( 'getRequestedFields' )
@@ -345,7 +345,7 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 				$register->invoke( $mockSelect, $mockQuery )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.09759 ms
@@ -363,7 +363,7 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 		                   ->disableOriginalConstructor()
 		                   ->setMethods( array( 'getFilterQueryString', 'registerFilterQueryForMatch', 'getConfig' ) )
 		                   ->getMockForAbstractClass();
-		
+
 		$mockSelect
 		    ->expects( $this->any() )
 		    ->method ( 'getConfig' )
@@ -400,7 +400,7 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 				$register->invoke( $mockSelect, $mockQuery )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.09187 ms
@@ -418,7 +418,7 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 				$get->invoke( $mockSelect )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.10014 ms
@@ -429,9 +429,9 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 		                  ->disableOriginalConstructor()
 		                  ->setMethods( array( 'getHighlighting' ) )
 		                  ->getMock();
-		
+
 		$hlMethods = array(
-				'addField', 'setSnippets', 'setRequireFieldMatch', 'setFragSize', 
+				'addField', 'setSnippets', 'setRequireFieldMatch', 'setFragSize',
 				'setSimplePrefix', 'setSimplePostfix', 'setAlternateField', 'setMaxAlternateFieldLength'
 				);
 		$mockHighlighting = $this->getMockBuilder( '\Solarium_Query_Select_Component_Highlighting' )
@@ -442,7 +442,7 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 		                   ->disableOriginalConstructor()
 		                   ->setMethods( array( 'getFilterQueryString', 'registerFilterQueryForMatch' ) )
 		                   ->getMockForAbstractClass();
-		
+
 		$mockQuery
 		    ->expects( $this->once() )
 		    ->method ( 'getHighlighting' )
@@ -496,7 +496,7 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 		    ->with   ( 100 )
 		    ->will   ( $this->returnValue( $mockHighlighting ) )
 		;
-		
+
 		$register = new ReflectionMethod( 'Wikia\Search\QueryService\Select\AbstractSelect', 'registerHighlighting' );
 		$register->setAccessible( true );
 		$this->assertEquals(
@@ -504,7 +504,7 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 				$register->invoke( $mockSelect, $mockQuery )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.10923 ms
@@ -527,7 +527,7 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 		                   ->setConstructorArgs( array( $dc ) )
 		                   ->setMethods( array( 'getSelectQuery', 'sendSearchRequestToClient' ) )
 		                   ->getMockForAbstractClass();
-		
+
 		$mockResult = $this->getMockBuilder( 'Solarium_Result_Select' )
 							->disableOriginalConstructor()
 							->getMock();
@@ -535,7 +535,7 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 		$mockQuery = $this->getMockBuilder( 'Solarium_Query_Select' )
 							->disableOriginalConstructor()
 							->getMock();
-		
+
 		$mockException = $this->getMockBuilder( '\Exception' )
 		                      ->disableOriginalConstructor()
 		                      ->getMock();
@@ -619,7 +619,7 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 				$reflSearch->invoke( $mockSelect )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.09672 ms
@@ -634,7 +634,7 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 		                   ->disableOriginalConstructor()
 		                   ->setMethods( array( 'getConfig' ) )
 		                   ->getMockForAbstractClass();
-		
+
 		$mockSelect
 		    ->expects( $this->any() )
 		    ->method ( 'getConfig' )
@@ -667,7 +667,7 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 				$reflPrep->invoke( $mockSelect )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.10116 ms
@@ -679,12 +679,12 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 		                      ->setMethods( array( 'getGlobal' ) )
 		                      ->getMock();
 		$mockConfig = $this->getMock( 'Wikia\Search\Config', array( 'hasMatch', 'setQuery' ) );
-		
+
 		$mockSelect = $this->getMockBuilder( '\Wikia\Search\QueryService\Select\AbstractSelect' )
 		                   ->disableOriginalConstructor()
 		                   ->setMethods( array( 'sendSearchRequestToClient', 'getConfig', 'getService' ) )
 		                   ->getMockForAbstractClass();
-		
+
 		$mockResult = $this->getMockBuilder( 'Solarium_Result_Select' )
 		                   ->disableOriginalConstructor()
 		                   ->setMethods( array( 'getNumFound', 'getSpellcheck' ) )
@@ -697,7 +697,7 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 		                      ->disableOriginalConstructor()
 		                      ->setMethods( array( 'getQuery' ) )
 		                      ->getMock();
-		
+
 		$mockSelect
 		    ->expects( $this->once() )
 		    ->method ( 'getConfig' )
@@ -756,7 +756,7 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 				$reflspell->invoke( $mockSelect, $mockResult )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.10668 ms
@@ -765,24 +765,24 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 	public function testPrepareResponse() {
 		$mockConfig = $this->getMock( 'Wikia\Search\Config', array( 'setResults', 'setResultsFound', 'getPage', 'getQuery' ) );
 		$mockQuery = $this->getMock( 'Wikia\Search\Query\Select', array( 'getSanitizedQuery' ), array( 'foo' ) );
-		
+
 		$mockResultSetFactory = $this->getMock( 'Wikia\Search\ResultSet\Factory', [ 'get' ] );
-		
+
 		$mockResult = $this->getMockBuilder( 'Solarium_Result_Select' )
 		                   ->disableOriginalConstructor()
 		                   ->setMethods( array( 'getNumFound', 'getSpellcheck' ) )
 		                   ->getMock();
-		
+
 		$mockResultSet = $this->getMockBuilder( 'Wikia\Search\ResultSet\Base' )
 		                      ->disableOriginalConstructor()
 		                      ->setMethods( array( 'getResultsFound' ) )
 		                      ->getMock();
-		
+
 		$mockSelect = $this->getMockBuilder( '\Wikia\Search\QueryService\Select\AbstractSelect' )
 		                   ->disableOriginalConstructor()
 		                   ->setMethods( array( 'spellcheckResult', 'getConfig' ) )
 		                   ->getMockForAbstractClass();
-		
+
 		$mockResultSetFactory
 		    ->expects( $this->once() )
 		    ->method ( 'get' )
@@ -803,10 +803,9 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 		    ->method ( 'setResults' )
 		    ->will   ( $this->returnValue( $mockConfig ) )
 		;
-		
+
 		$this->proxyClass( 'Wikia\Search\ResultSet\Factory', $mockResultSetFactory );
-		$this->mockApp();
-		
+
 		$reflspell = new ReflectionMethod( $mockSelect, 'prepareResponse' );
 		$reflspell->setAccessible( true );
 		$reflspell->invoke( $mockSelect, $mockResult ); // weirdness
@@ -932,7 +931,7 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 				$funcRefl->invoke( $mockSelect, $mockQuery )
 		);
 	}*/
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.09641 ms
@@ -943,14 +942,14 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 		                   ->disableOriginalConstructor()
 		                   ->setMethods( array( 'search' ) )
 		                   ->getMockForAbstractClass();
-		
+
 		$mockResultSet = $this->getMockBuilder( 'Wikia\Search\ResultSet\Base' )
 		                      ->disableOriginalConstructor()
 		                      ->setMethods( array( 'toArray' ) )
 		                      ->getMock();
-		
+
 		$results = array( array( 'id' => '123_234', 'title' => 'foo' ) );
-		
+
 		$mockSelect
 		    ->expects( $this->once() )
 		    ->method ( 'search' )
@@ -966,7 +965,7 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 				$mockSelect->searchAsApi()
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.10416 ms
@@ -977,21 +976,21 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 		                   ->disableOriginalConstructor()
 		                   ->setMethods( array( 'search', 'getConfig' ) )
 		                   ->getMockForAbstractClass();
-		
+
 		$mockResultSet = $this->getMockBuilder( 'Wikia\Search\ResultSet\Base' )
 		                      ->disableOriginalConstructor()
 		                      ->setMethods( array( 'toArray' ) )
 		                      ->getMock();
-		
+
 		$mockConfig = $this->getMockBuilder( 'Wikia\Search\Config' )
 		                   ->disableOriginalConstructor()
 		                   ->setMethods( [ 'getNumPages', 'getPage', 'getStart', 'getLimit', 'getResultsFound', 'mustAddMatchedRecords' ] )
 		                   ->getMock();
-		
+
 		$expectedFields = [ 'id', 'title' ];
-		
+
 		$results = array( array( 'id' => '123_234', 'title' => 'foo' ) );
-		
+
 		$mockSelect
 		    ->expects( $this->any() )
 		    ->method ( 'getConfig' )
@@ -1043,7 +1042,7 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 				$mockSelect->searchAsApi( $expectedFields, true )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.10116 ms
@@ -1054,21 +1053,21 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 		                   ->disableOriginalConstructor()
 		                   ->setMethods( array( 'search', 'getConfig' ) )
 		                   ->getMockForAbstractClass();
-		
+
 		$mockResultSet = $this->getMockBuilder( 'Wikia\Search\ResultSet\Base' )
 		                      ->disableOriginalConstructor()
 		                      ->setMethods( array( 'toArray' ) )
 		                      ->getMock();
-		
+
 		$mockConfig = $this->getMockBuilder( 'Wikia\Search\Config' )
 		                   ->disableOriginalConstructor()
 		                   ->setMethods( [ 'getNumPages', 'getPage', 'getStart', 'getLimit', 'getResultsFound' ] )
 		                   ->getMock();
-		
+
 		$expectedFields = [ 'id', 'title' ];
-		
+
 		$results = array();
-		
+
 		$mockSelect
 		    ->expects( $this->any() )
 		    ->method ( 'getConfig' )
@@ -1095,7 +1094,7 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 				$mockSelect->searchAsApi( $expectedFields, true )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.11422 ms
@@ -1106,23 +1105,23 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 		                    ->disableOriginalConstructor()
 		                    ->setMethods( [ 'getService', 'getConfig' ] )
 		                    ->getMockForAbstractClass();
-		
+
 		$mockConfig = $this->getMockBuilder( 'Wikia\Search\Config' )
 		                   ->disableOriginalConstructor()
 		                   ->setMethods( [ 'getQuery', 'setWikiMatch', 'getWikiMatch' ] )
 		                   ->getMock();
-		
+
 		$mockMatch = $this->getMockBuilder( 'Wikia\Search\Match\Wiki' )
 		                  ->setMethods( [ 'getId', 'getResult' ] )
 		                  ->disableOriginalConstructor()
 		                  ->getMock();
-		
+
 		$mockResult = $this->getMock( 'Wikia\Search\Result', [ 'offsetGet' ] );
-		
+
 		$mockMwService = $this->getMock( 'Wikia\Search\MediaWikiService', [ 'getWikiMatchByHost', 'getWikiId' ] );
-		
+
 		$mockQuery = $this->getMock( 'Wikia\Search\Query\Select', [ 'getSanitizedQuery' ], [ 'foo' ] );
-		
+
 		$mockService
 		    ->expects( $this->any() )
 		    ->method ( 'getConfig' )
@@ -1187,7 +1186,7 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 				$extract->invoke( $mockService )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.10737 ms
@@ -1198,23 +1197,23 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 		                    ->disableOriginalConstructor()
 		                    ->setMethods( [ 'getService', 'getConfig' ] )
 		                    ->getMockForAbstractClass();
-		
+
 		$mockConfig = $this->getMockBuilder( 'Wikia\Search\Config' )
 		                   ->disableOriginalConstructor()
 		                   ->setMethods( [ 'getQuery', 'setWikiMatch', 'getWikiMatch' ] )
 		                   ->getMock();
-		
+
 		$mockMatch = $this->getMockBuilder( 'Wikia\Search\Match\Wiki' )
 		                  ->setMethods( [ 'getId', 'getResult' ] )
 		                  ->disableOriginalConstructor()
 		                  ->getMock();
-		
+
 		$mockResult = $this->getMock( 'Wikia\Search\Result', [ 'offsetGet' ] );
-		
+
 		$mockMwService = $this->getMock( 'Wikia\Search\MediaWikiService', [ 'getWikiMatchByHost', 'getWikiId' ] );
-		
+
 		$mockQuery = $this->getMock( 'Wikia\Search\Query\Select', [ 'getSanitizedQuery' ], [ 'foo' ] );
-		
+
 		$mockService
 		    ->expects( $this->any() )
 		    ->method ( 'getConfig' )
@@ -1288,21 +1287,21 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 		                    ->disableOriginalConstructor()
 		                    ->setMethods( [ 'getService', 'getConfig' ] )
 		                    ->getMockForAbstractClass();
-		
+
 		$mockConfig = $this->getMockBuilder( 'Wikia\Search\Config' )
 		                   ->disableOriginalConstructor()
 		                   ->setMethods( [ 'getQuery', 'setWikiMatch', 'getWikiMatch' ] )
 		                   ->getMock();
-		
+
 		$mockMatch = $this->getMockBuilder( 'Wikia\Search\Match\Wiki' )
 		                  ->setMethods( [ 'getId' ] )
 		                  ->disableOriginalConstructor()
 		                  ->getMock();
-		
+
 		$mockMwService = $this->getMock( 'Wikia\Search\MediaWikiService', [ 'getWikiMatchByHost', 'getWikiId' ] );
-		
+
 		$mockQuery = $this->getMock( 'Wikia\Search\Query\Select', [ 'getSanitizedQuery' ], [ 'foo' ] );
-		
+
 		$mockService
 		    ->expects( $this->once() )
 		    ->method ( 'getConfig' )
@@ -1386,7 +1385,7 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 				$get->invoke( $mockService )
 		);
 	}
-	
+
 	/**
 	 * @covers Wikia\Search\QueryService\Select\AbstractSelect::getFilterQueryString
 	 */
@@ -1431,7 +1430,7 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 		);
 	}
 	 */
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.09538 ms
@@ -1453,7 +1452,7 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 				$get->invoke( $mockSelect )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.09431 ms
@@ -1475,7 +1474,7 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 				$get->invoke( $mockSelect )
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.09601 ms
@@ -1486,23 +1485,23 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 		                   ->disableOriginalConstructor()
 		                   ->setMethods( [ 'setCoreInClient' ] )
 		                   ->getMockForAbstractClass();
-		
+
 		$mockClient = $this->getMockBuilder( '\Solarium_Client' )
 		                   ->disableOriginalConstructor()
 		                   ->getMock();
-		
+
 		$mockSelect
 		    ->expects( $this->once() )
 		    ->method ( 'setCoreInClient' )
 		;
-		
+
 		$attr = new ReflectionProperty( $mockSelect, 'client' );
 		$attr->setAccessible( true );
 		$attr->setValue( $mockSelect, $mockClient );
-		
+
 		$get = new ReflectionMethod( $mockSelect, 'getClient' );
 		$get->setAccessible( true );
-		
+
 		$this->assertAttributeEmpty(
 				'coreSetInClient',
 				$mockSelect
@@ -1517,9 +1516,9 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 		$this->assertEquals(
 				$mockClient,
 				$get->invoke( $mockSelect )
-		); 
+		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.09929 ms
@@ -1530,15 +1529,15 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 		                   ->disableOriginalConstructor()
 		                   ->setMethods( [ null ] )
 		                   ->getMockForAbstractClass();
-		
+
 		$mockClient = $this->getMockBuilder( '\Solarium_Client' )
 		                   ->disableOriginalConstructor()
 		                   ->setMethods( [ 'getOptions', 'setOptions' ] )
 		                   ->getMock();
-		
+
 		$before = [ 'foo' => 'bar', 'adapteroptions' => [ 'path' => 'whatever', 'baz' => 'qux' ] ];
 		$after = [ 'foo' => 'bar', 'adapteroptions' => [ 'path' => '/solr/main', 'baz' => 'qux' ] ];
-		
+
 		$mockClient
 		    ->expects( $this->once() )
 		    ->method ( 'getOptions' )
@@ -1549,11 +1548,11 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 		    ->method ( 'setOptions' )
 		    ->with   ( $after, true )
 		;
-		
+
 		$client = new ReflectionProperty( $mockSelect, 'client' );
 		$client->setAccessible( true );
 		$client->setValue( $mockSelect, $mockClient );
-		
+
 		$set = new ReflectionMethod( $mockSelect, 'setCoreInClient' );
 		$set->setAccessible( true );
 		$this->assertEquals(
@@ -1566,5 +1565,5 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 				$mockSelect
 		);
 	}
-	
+
 }

--- a/includes/wikia/tests/core/WikiaBaseTest.class.php
+++ b/includes/wikia/tests/core/WikiaBaseTest.class.php
@@ -246,24 +246,14 @@ abstract class WikiaBaseTest extends PHPUnit_Framework_TestCase {
 	 * @param $inputParams array
 	 * @throws Exception
 	 */
-	protected function mockGlobalFunction( $functionName, $returnValue, $callsNum = null, $inputParams = null ) {
-		// sanity check to prevent deprecated way of using this function
-		if ( !function_exists($functionName) && function_exists('wf'.ucfirst($functionName)) ) {
-			throw new Exception("You have to specify full global function name including 'wf' prefix");
-		}
-
-		if ( func_num_args() > 2 ) {
-			throw new Exception("You are using deprecated version of mockGlobalFunction");
-		}
+	protected function mockGlobalFunction( $functionName, $returnValue ) {
 
 		list( $namespace, $baseName ) = WikiaMockProxy::parseGlobalFunctionName( $functionName );
 
 		$mock = $this->getGlobalFunctionMock( $functionName );
-		$expect = $mock->expects( $callsNum !== null ? $this->exactly( $callsNum ) : $this->any() )
-			->method( $baseName );
-		if ( $inputParams !== null ) {
-			$expect = call_user_func_array( array( $expect, 'with' ), $inputParams );
-		}
+		$expect = $mock->expects( $this->any() )
+						->method( $baseName );
+
 		$expect->will( $this->returnValue( $returnValue ) );
 
 		$this->getMockProxy()->getGlobalFunction($functionName)
@@ -400,13 +390,6 @@ abstract class WikiaBaseTest extends PHPUnit_Framework_TestCase {
 	 */
 	protected function getCurrentInvocation() {
 		return WikiaMockProxyAction::currentInvocation();
-	}
-
-	/**
-	 * @deprecated
-	 */
-	protected function mockApp() {
-		// noop
 	}
 
 	protected function proxyClass() {


### PR DESCRIPTION
PLATFORM-352: removing some deprecated functions from the base test class. 
