### PR TITLE
PLA-1735 Remove reference to hostname from app code

### DIFF
--- a/extensions/wikia/Search/classes/Indexer.php
+++ b/extensions/wikia/Search/classes/Indexer.php
@@ -242,7 +242,7 @@ class Indexer
 	protected function getClient() {
 		if ( $this->client === null ) {
 			$mwService = $this->getMwService();
-			$master = $mwService->isOnDbCluster() ? $mwService->getGlobal( 'SolrMaster' ) : 'staff-search-s2';
+			$master = $mwService->getGlobal( 'SolrMaster' );
 			$params = array(
 					'adapter' => 'Solarium_Client_Adapter_Curl',
 					'adapteroptions' => array(

--- a/extensions/wikia/Search/classes/QueryService/Factory.php
+++ b/extensions/wikia/Search/classes/QueryService/Factory.php
@@ -38,7 +38,7 @@ class Factory
 
 	public function getSolariumClientConfig() {
 		$service = (new \Wikia\Search\ProfiledClassFactory)->get( 'Wikia\Search\MediaWikiService' );
-		$host = $service->isOnDbCluster() ? $service->getGlobalWithDefault( 'SolrHost', 'localhost' ) : 'staff-search-s2';
+		$host = $service->getGlobalWithDefault( 'SolrHost', 'localhost' );
 		$host = (! empty( $_GET['newsolrhost'] ) ) ? $service->getGlobal( 'AlternateSolrHost' ) : $host;
 
 		$solariumConfig = [];


### PR DESCRIPTION
$wgSolrMaster and $wgSolrHost are set in CommonSettings for One, making this piece of code redundant and unnecessary
