### PR TITLE
(CE-1003) Fix anonymous users not being welcomed

### DIFF
--- a/extensions/wikia/HAWelcome/HAWelcomeTaskHookDispatcher.php
+++ b/extensions/wikia/HAWelcome/HAWelcomeTaskHookDispatcher.php
@@ -56,12 +56,14 @@ class HAWelcomeTaskHookDispatcher {
 				return true;
 			}
 
-			$this->markHAWelcomePosted();
-			$this->queueWelcomeTask( $this->getTitleObjectFromRevision() );
-			$this->info( "queued welcome task" );
+			$this->info( "queueing welcome task for user" );
 		} else {
-			$this->info( "aborting the welcome hook for an anonymous user" );
+			$this->info( "queueing welcome task for an anonymous user" );
 		}
+
+		$this->markHAWelcomePosted();
+		$this->queueWelcomeTask( $this->getTitleObjectFromRevision() );
+		$this->info( "queued welcome task" );
 
 		return true;
 	}

--- a/extensions/wikia/HAWelcome/tests/HAWelcomeTaskHookDispatcherTest.php
+++ b/extensions/wikia/HAWelcome/tests/HAWelcomeTaskHookDispatcherTest.php
@@ -29,7 +29,13 @@ class HAWelcomeTaskHookDispatcherTest extends WikiaBaseTest {
 	}
 
 	public function testDispatchAnonymousUser() {
-		$dispatcher = $this->getMock( '\HAWelcomeTaskHookDispatcher', ['welcomeMessageDisabled', 'hasContributorBeenWelcomedRecently'] );
+		$dispatcher = $this->getMock( '\HAWelcomeTaskHookDispatcher', [
+			'welcomeMessageDisabled',
+			'hasContributorBeenWelcomedRecently',
+			'markHAWelcomePosted',
+			'getTitleObjectFromRevision',
+			'queueWelcomeTask',
+			] );
 
 		$dispatcher->expects( $this->once() )
 			->method( 'welcomeMessageDisabled' )
@@ -39,12 +45,26 @@ class HAWelcomeTaskHookDispatcherTest extends WikiaBaseTest {
 			->method( 'hasContributorBeenWelcomedRecently' )
 			->will( $this->returnValue( false ) );
 
+		$dispatcher->expects( $this->once() )
+			->method( 'markHAWelcomePosted' )
+			->will( $this->returnValue( null ) );
 
 		$revision = $this->getMock( '\Revision', ['getRawUser'], [], '', false );
 
 		$revision->expects( $this->once() )
 			->method( 'getRawUser' )
 			->will( $this->returnValue( 0 ) );
+
+		$title = $this->getMock( '\Title', [] );
+
+		$dispatcher->expects( $this->once() )
+			->method( 'getTitleObjectFromRevision' )
+			->will( $this->returnValue( $title ) );
+
+		$dispatcher->expects( $this->once() )
+			->method( 'queueWelcomeTask' )
+			->with( $title )
+			->will( $this->returnValue( null ) );
 
 		$dispatcher->setRevisionObject( $revision );
 		$this->assertTrue( $dispatcher->dispatch() );


### PR DESCRIPTION
Anonymous users weren't getting welcomed as no task was being queued.
If the user is anonymous, and they weren't welcomed recently, a task
should be created as was the previous functionality.

@drsnyder 
