### PR TITLE
CE-868 Add support for modules shared from dev.wikia.com

### DIFF
--- a/extensions/Scribunto/common/Base.php
+++ b/extensions/Scribunto/common/Base.php
@@ -136,6 +136,26 @@ abstract class ScribuntoEngineBase {
 		}
 		return $this->modules[$key];
 	}
+	/**
+	 * Wikia change by adamk@wikia-inc.com
+	 * Load shared a module from dev.wikia.com.
+	 * @param  GlobalTitle $title GlobalTitle instance of a shared module.
+	 * @return mixed              Returns a module if found and null otherwise.
+	 */
+	function fetchSharedModule( GlobalTitle $title ) {
+		$key = $title->getPrefixedText();
+
+		if( !array_key_exists( $key, $this->modules ) ) {
+			$text = $title->getContent();
+			if ( $text === false ) {
+				$this->modules[$key] = null;
+				return null;
+			}
+			$this->modules[$key] = $this->newModule( $text, $key );
+		}
+
+		return $this->modules[$key];
+	}
 
 	/**
 	 * Validates the script and returns a Status object containing the syntax

--- a/extensions/Scribunto/common/Base.php
+++ b/extensions/Scribunto/common/Base.php
@@ -138,7 +138,7 @@ abstract class ScribuntoEngineBase {
 	}
 	/**
 	 * Wikia change begin
-	 * Load shared a module from dev.wikia.com.
+	 * Load a shared module from dev.wikia.com.
 	 * @author Adam Karmiński <adamk@wikia-inc.com>
 	 * @param  GlobalTitle $title GlobalTitle instance of a shared module.
 	 * @return mixed              Returns a module if found and null otherwise.

--- a/extensions/Scribunto/common/Base.php
+++ b/extensions/Scribunto/common/Base.php
@@ -137,13 +137,14 @@ abstract class ScribuntoEngineBase {
 		return $this->modules[$key];
 	}
 	/**
-	 * Wikia change by adamk@wikia-inc.com
+	 * Wikia change begin
 	 * Load shared a module from dev.wikia.com.
+	 * @author Adam Karmiński <adamk@wikia-inc.com>
 	 * @param  GlobalTitle $title GlobalTitle instance of a shared module.
 	 * @return mixed              Returns a module if found and null otherwise.
 	 */
-	function fetchSharedModule( GlobalTitle $title ) {
-		$key = $title->getPrefixedText();
+	function fetchSharedModule( GlobalTitle $title, $prefix ) {
+		$key = $prefix . $title->getText();
 
 		if( !array_key_exists( $key, $this->modules ) ) {
 			$text = $title->getContent();
@@ -156,6 +157,9 @@ abstract class ScribuntoEngineBase {
 
 		return $this->modules[$key];
 	}
+	/**
+	 * Wikia change end
+	 */
 
 	/**
 	 * Validates the script and returns a Status object containing the syntax

--- a/extensions/Scribunto/common/Base.php
+++ b/extensions/Scribunto/common/Base.php
@@ -136,6 +136,7 @@ abstract class ScribuntoEngineBase {
 		}
 		return $this->modules[$key];
 	}
+
 	/**
 	 * Wikia change begin
 	 * Load a shared module from dev.wikia.com.
@@ -146,7 +147,7 @@ abstract class ScribuntoEngineBase {
 	function fetchSharedModule( GlobalTitle $title, $prefix ) {
 		$key = $prefix . $title->getText();
 
-		if( !array_key_exists( $key, $this->modules ) ) {
+		if ( !array_key_exists( $key, $this->modules ) ) {
 			$text = $title->getContent();
 			if ( $text === false ) {
 				$this->modules[$key] = null;

--- a/extensions/Scribunto/engines/LuaCommon/LuaCommon.php
+++ b/extensions/Scribunto/engines/LuaCommon/LuaCommon.php
@@ -342,7 +342,7 @@ abstract class Scribunto_LuaEngine extends ScribuntoEngineBase {
 			if ( !$title || $title->getNamespace() != NS_MODULE ) {
 				return array();
 			}
-			$module = $this->fetchModuleFromParser( $title );
+			$module = $this->fetchModuleFromParser( $title, SHARED_MODULES_PREFIX );
 		}
 		/**
 		 * Wikia change end

--- a/extensions/Scribunto/engines/LuaCommon/LuaCommon.php
+++ b/extensions/Scribunto/engines/LuaCommon/LuaCommon.php
@@ -314,12 +314,21 @@ abstract class Scribunto_LuaEngine extends ScribuntoEngineBase {
 			return array( $init );
 		}
 
-		$title = Title::newFromText( $name );
-		if ( !$title || $title->getNamespace() != NS_MODULE ) {
-			return array();
+		if ( preg_match( "/^Dev:/", $name ) ) {
+			$sDevName = preg_replace( "/^Dev:/", "", $name );
+			$title = GlobalTitle::newFromText( $sDevName, NS_MODULE, 7931 );
+			if ( !$title ) {
+				return array();
+			}
+			$module = $this->fetchSharedModule( $title );
+		}	else {
+			$title = Title::newFromText( $name );
+			if ( !$title || $title->getNamespace() != NS_MODULE ) {
+				return array();
+			}
+			$module = $this->fetchModuleFromParser( $title );
 		}
 
-		$module = $this->fetchModuleFromParser( $title );
 		if ( $module ) {
 			return array( $module->getInitChunk() );
 		} else {

--- a/extensions/Scribunto/engines/LuaCommon/LuaCommon.php
+++ b/extensions/Scribunto/engines/LuaCommon/LuaCommon.php
@@ -42,7 +42,7 @@ abstract class Scribunto_LuaEngine extends ScribuntoEngineBase {
 	 * Set constants for modules shared from dev.wikia.com
 	 * @author Adam Karmiński <adamk@wikia-inc.com>
 	 */
-	const SHARED_MODULES_PREFIX = "Dev:";
+	const SHARED_MODULES_PREFIX = 'Dev:';
 	const SHARED_MODULES_DEV_CITYID = 7931;
 	/**
 	 * Wikia change end
@@ -330,19 +330,19 @@ abstract class Scribunto_LuaEngine extends ScribuntoEngineBase {
 		 * Support modules shared from dev.wikia.com
 		 * @author Adam Karmiński <adamk@wikia-inc.com>
 		 */
-		if ( strpos( SHARED_MODULES_PREFIX, $name ) !== FALSE ) {
-			$sNameOnDev = substr( $name, strlen( SHARED_MODULES_PREFIX ) );
-			$title = GlobalTitle::newFromText( $sNameOnDev, NS_MODULE, SHARED_MODULES_DEV_CITYID );
+		if ( strpos( $name, self::SHARED_MODULES_PREFIX ) === 0 ) {
+			$sNameOnDev = substr( $name, strlen( self::SHARED_MODULES_PREFIX ) );
+			$title = GlobalTitle::newFromText( $sNameOnDev, NS_MODULE, self::SHARED_MODULES_DEV_CITYID );
 			if ( !$title ) {
 				return array();
 			}
-			$module = $this->fetchSharedModule( $title );
+			$module = $this->fetchSharedModule( $title, self::SHARED_MODULES_PREFIX );
 		} else {
 			$title = Title::newFromText( $name );
 			if ( !$title || $title->getNamespace() != NS_MODULE ) {
 				return array();
 			}
-			$module = $this->fetchModuleFromParser( $title, SHARED_MODULES_PREFIX );
+			$module = $this->fetchModuleFromParser( $title );
 		}
 		/**
 		 * Wikia change end

--- a/extensions/Scribunto/engines/LuaCommon/LuaCommon.php
+++ b/extensions/Scribunto/engines/LuaCommon/LuaCommon.php
@@ -38,6 +38,17 @@ abstract class Scribunto_LuaEngine extends ScribuntoEngineBase {
 	const MAX_EXPAND_CACHE_SIZE = 100;
 
 	/**
+	 * Wikia change begin
+	 * Set constants for modules shared from dev.wikia.com
+	 * @author Adam Karmiński <adamk@wikia-inc.com>
+	 */
+	const SHARED_MODULES_PREFIX = "Dev:";
+	const SHARED_MODULES_DEV_CITYID = 7931;
+	/**
+	 * Wikia change end
+	 */
+
+	/**
 	 * Create a new interpreter object
 	 * @return Scribunto_LuaInterpreter
 	 */
@@ -314,20 +325,28 @@ abstract class Scribunto_LuaEngine extends ScribuntoEngineBase {
 			return array( $init );
 		}
 
-		if ( preg_match( "/^Dev:/", $name ) ) {
-			$sDevName = preg_replace( "/^Dev:/", "", $name );
-			$title = GlobalTitle::newFromText( $sDevName, NS_MODULE, 7931 );
+		/**
+		 * Wikia change begin
+		 * Support modules shared from dev.wikia.com
+		 * @author Adam Karmiński <adamk@wikia-inc.com>
+		 */
+		if ( strpos( SHARED_MODULES_PREFIX, $name ) !== FALSE ) {
+			$sNameOnDev = substr( $name, strlen( SHARED_MODULES_PREFIX ) );
+			$title = GlobalTitle::newFromText( $sNameOnDev, NS_MODULE, SHARED_MODULES_DEV_CITYID );
 			if ( !$title ) {
 				return array();
 			}
 			$module = $this->fetchSharedModule( $title );
-		}	else {
+		} else {
 			$title = Title::newFromText( $name );
 			if ( !$title || $title->getNamespace() != NS_MODULE ) {
 				return array();
 			}
 			$module = $this->fetchModuleFromParser( $title );
 		}
+		/**
+		 * Wikia change end
+		 */
 
 		if ( $module ) {
 			return array( $module->getInitChunk() );


### PR DESCRIPTION
The solution bases on a "Dev:" prefix which works in require("Dev:ExampleModule"). The prefix is also used as a key for modules array that Lua loaders use. This prevents a name conflict since local modules are always in the NS_MODULE namespace and have "Module:" prefix.
