### PR TITLE
MWEB-966 P2 fix

### DIFF
--- a/extensions/wikia/WikiaInteractiveMaps/controllers/WikiaInteractiveMapsController.class.php
+++ b/extensions/wikia/WikiaInteractiveMaps/controllers/WikiaInteractiveMapsController.class.php
@@ -27,7 +27,7 @@ class WikiaInteractiveMapsController extends WikiaSpecialPageController {
 	private $mapsModel;
 
 	/**
-	 * @desc Special page constructor
+	 * Special page constructor
 	 *
 	 * @param null $name
 	 * @param string $restriction
@@ -158,6 +158,11 @@ class WikiaInteractiveMapsController extends WikiaSpecialPageController {
 		$this->response->setTemplateEngine( WikiaResponse::TEMPLATE_ENGINE_MUSTACHE );
 	}
 
+	/**
+	 * Redirects to a single map page on right wikia if the current wikia id isn't the same as the map's city_id
+	 * @param Integer $cityId
+	 * @param Integer $mapId
+	 */
 	public function redirectIfForeignWiki( $cityId, $mapId ) {
 		if ( (int) $this->wg->CityId !== $cityId ) {
 			$targetUrl = $this->getWikiPageUrl( self::PAGE_NAME, NS_SPECIAL, $cityId );
@@ -165,6 +170,13 @@ class WikiaInteractiveMapsController extends WikiaSpecialPageController {
 		}
 	}
 
+	/**
+	 * Returns full URL for a wiki with given $cityId
+	 * @param String $text
+	 * @param Integer $namespace
+	 * @param Integer|null $cityId
+	 * @return string
+	 */
 	protected function getWikiPageUrl( $text, $namespace = NS_MAIN, $cityId = null ) {
 		return GlobalTitle::newFromText( $text, $namespace, $cityId )->getFullURL();
 	}
@@ -187,7 +199,8 @@ class WikiaInteractiveMapsController extends WikiaSpecialPageController {
 	}
 
 	/**
-	 * @desc Renders the menu markup for the map page from mustache
+	 * Renders the menu markup for the map page from mustache
+	 * @param Integer $deleted flag which tells if a map was deleted
 	 * @return string
 	 */
 	function getMenuMarkup( $deleted ) {
@@ -209,11 +222,11 @@ class WikiaInteractiveMapsController extends WikiaSpecialPageController {
 			];
 		}
 
-		return F::app()->renderView( 'MenuButton', 'index', $actionButtonArray );
+		return $this->app->renderView( 'MenuButton', 'index', $actionButtonArray );
 	}
 
 	/**
-	 * @desc Obtains a url to a special page with a given path
+	 * Obtains a url to a special page with a given path
 	 * @param string $name - name of the special page
 	 * @return string
 	 */
@@ -222,7 +235,7 @@ class WikiaInteractiveMapsController extends WikiaSpecialPageController {
 	}
 
 	/**
-	 * @desc Ajax method for un/deleting a map from IntMaps API
+	 * Ajax method for un/deleting a map from IntMaps API
 	 */
 	public function updateMapDeletionStatus() {
 		$mapId = $this->request->getVal( 'mapId', 0 );
@@ -274,10 +287,8 @@ class WikiaInteractiveMapsController extends WikiaSpecialPageController {
 
 	/**
 	 * Generates offset value based on current page and items per page
-	 *
 	 * @param int $currentPage
 	 * @param int $itemsPerPage
-	 *
 	 * @return int mixed
 	 */
 	private function getPaginationOffset( $currentPage, $itemsPerPage ) {
@@ -296,7 +307,6 @@ class WikiaInteractiveMapsController extends WikiaSpecialPageController {
 
 	/**
 	 * Iterates through $items and changes image URL to thumbnail
-	 *
 	 * @param Array $items
 	 * @param Integer $width
 	 * @param Integer $height
@@ -309,7 +319,6 @@ class WikiaInteractiveMapsController extends WikiaSpecialPageController {
 
 	/**
 	 * Sets template variables depending on skin
-	 *
 	 * @param Array $mapsResponse an array taken from API response
 	 * @param String $selectedSort a sorting option passed in $_GET
 	 */
@@ -353,7 +362,6 @@ class WikiaInteractiveMapsController extends WikiaSpecialPageController {
 
 	/**
 	 * Renders pagination and adds it to template variables for Oasis skin
-	 *
 	 * @param Integer $totalMaps
 	 * @param Integer $currentPage
 	 * @param Array $urlParams

--- a/extensions/wikia/WikiaInteractiveMaps/tests/WikiaInteractiveMapsControllerTest.php
+++ b/extensions/wikia/WikiaInteractiveMaps/tests/WikiaInteractiveMapsControllerTest.php
@@ -12,7 +12,7 @@ class WikiaInteractiveMapsControllerTest extends WikiaBaseTest {
 	}
 
 	public function testRedirectIfForeignWiki_not_foreign() {
-		$wikiaInteractiveMapsControllerMock = $this->getWikiaInteractiveMapsControllerMock();
+		$wikiaInteractiveMapsControllerMock = $this->getControllerMock( 'testRedirectIfForeignWiki' );
 
 		$wikiaInteractiveMapsControllerMock->wg->CityId = self::WIKI_CITY_ID;
 
@@ -25,7 +25,7 @@ class WikiaInteractiveMapsControllerTest extends WikiaBaseTest {
 	}
 
 	public function testRedirectIfForeignWiki_foreign() {
-		$wikiaInteractiveMapsControllerMock = $this->getWikiaInteractiveMapsControllerMock( true );
+		$wikiaInteractiveMapsControllerMock = $this->getControllerMock( 'testRedirectIfForeignWiki' );
 
 		$wikiaInteractiveMapsControllerMock->wg->CityId = self::WIKI_CITY_ID;
 
@@ -37,66 +37,76 @@ class WikiaInteractiveMapsControllerTest extends WikiaBaseTest {
 		$wikiaInteractiveMapsControllerMock->redirectIfForeignWiki( self::WIKI_FOREIGN_CITY_ID, 1 );
 	}
 
-	/**
-	 * @return PHPUnit_Framework_MockObject_MockObject|WikiaInteractiveMapsController
-	 */
-	private function getWikiaInteractiveMapsControllerMock() {
-		$mock = $this->getMock( 'WikiaInteractiveMapsController', [ 'getWikiPageUrl' ], [], '', false );
-
-		$mock->expects( $this->any() )
-			->method( 'getWikiPageUrl' )
-			->will( $this->returnValue( self::WIKI_URL ) );
-
-		return $mock;
-	}
-
 	public function testMap_mapNotFound() {
 		$exceptionObject = new stdClass();
 		$exceptionObject->message = 'Map not found';
 		$exceptionObject->details = 'Map with given id (1) was not found.';
-
-		$appMock = $this->getMock( 'WikiaApp', [ 'checkSkin' ], [], '', false );
-		$appMock->expects( $this->once() )
-			->method( 'checkSkin' )
-			->will( $this->returnValue(false) );
-
-		$requestMock = $this->getMock( 'WikiaRequest', [ 'getInt' ], [], '', false );
-		$requestMock->expects( $this->any() )
-			->method( 'getInt' )
-			->will( $this->returnValue(1) );
-
-		$responseMock = $this->getMock( 'WikiaResponse', [ 'addAsset', 'setTemplateEngine' ], [], '', false );
-		$responseMock->expects( $this->once() )
-			->method( 'addAsset' );
-		$responseMock->expects( $this->once() )
-			->method( 'setTemplateEngine' );
 
 		$mapsModelMock = $this->getMock( 'WikiaMaps', [ 'getMapByIdFromApi' ], [], '', false );
 		$mapsModelMock->expects( $this->once() )
 			->method( 'getMapByIdFromApi' )
 			->will( $this->returnValue( $exceptionObject ) );
 
-		$mapsControllerMock = $this->getMock( 'WikiaInteractiveMapsController', [
-			'getModel',
-			'redirectIfForeignWiki',
-			'setVal',
-			'addAsset',
-			'setTemplateEngine'
-		], [], '', false );
-
+		$mapsControllerMock = $this->getControllerMock( 'testMap' );
 		$mapsControllerMock->expects( $this->once() )
 			->method( 'getModel' )
 			->will( $this->returnValue( $mapsModelMock ) );
-		$mapsControllerMock->expects( $this->never() )
-			->method( 'redirectIfForeignWiki' );
-		$mapsControllerMock->expects( $this->any() )
-			->method( 'setVal' );
-
-		$mapsControllerMock->app = $appMock;
-		$mapsControllerMock->request = $requestMock;
-		$mapsControllerMock->response = $responseMock;
 
 		$mapsControllerMock->map();
+	}
+
+	/**
+	 * @param String $test Name of test/test group basic on which proper mock object will be returned
+	 * @return PHPUnit_Framework_MockObject_MockObject|WikiaInteractiveMapsController
+	 */
+	private function getControllerMock( $test ) {
+		$mapsControllerMock = null;
+
+		switch( $test ) {
+			case 'testRedirectIfForeignWiki':
+				$mapsControllerMock = $this->getMock( 'WikiaInteractiveMapsController', [ 'getWikiPageUrl' ], [], '', false );
+
+				$mapsControllerMock->expects( $this->any() )
+					->method( 'getWikiPageUrl' )
+					->will( $this->returnValue( self::WIKI_URL ) );
+				break;
+			case 'testMap':
+				$appMock = $this->getMock( 'WikiaApp', [ 'checkSkin' ], [], '', false );
+				$appMock->expects( $this->once() )
+					->method( 'checkSkin' )
+					->will( $this->returnValue(false) );
+
+				$requestMock = $this->getMock( 'WikiaRequest', [ 'getInt' ], [], '', false );
+				$requestMock->expects( $this->any() )
+					->method( 'getInt' )
+					->will( $this->returnValue(1) );
+
+				$responseMock = $this->getMock( 'WikiaResponse', [ 'addAsset', 'setTemplateEngine' ], [], '', false );
+				$responseMock->expects( $this->once() )
+					->method( 'addAsset' );
+				$responseMock->expects( $this->once() )
+					->method( 'setTemplateEngine' );
+
+				$mapsControllerMock = $this->getMock( 'WikiaInteractiveMapsController', [
+					'getModel',
+					'redirectIfForeignWiki',
+					'setVal',
+					'addAsset',
+					'setTemplateEngine'
+				], [], '', false );
+
+				$mapsControllerMock->expects( $this->never() )
+					->method( 'redirectIfForeignWiki' );
+				$mapsControllerMock->expects( $this->any() )
+					->method( 'setVal' );
+
+				$mapsControllerMock->app = $appMock;
+				$mapsControllerMock->request = $requestMock;
+				$mapsControllerMock->response = $responseMock;
+				break;
+		}
+
+		return $mapsControllerMock;
 	}
 
 }

--- a/extensions/wikia/WikiaInteractiveMaps/tests/WikiaInteractiveMapsControllerTest.php
+++ b/extensions/wikia/WikiaInteractiveMaps/tests/WikiaInteractiveMapsControllerTest.php
@@ -49,4 +49,54 @@ class WikiaInteractiveMapsControllerTest extends WikiaBaseTest {
 
 		return $mock;
 	}
+
+	public function testMap_mapNotFound() {
+		$exceptionObject = new stdClass();
+		$exceptionObject->message = 'Map not found';
+		$exceptionObject->details = 'Map with given id (1) was not found.';
+
+		$appMock = $this->getMock( 'WikiaApp', [ 'checkSkin' ], [], '', false );
+		$appMock->expects( $this->once() )
+			->method( 'checkSkin' )
+			->will( $this->returnValue(false) );
+
+		$requestMock = $this->getMock( 'WikiaRequest', [ 'getInt' ], [], '', false );
+		$requestMock->expects( $this->any() )
+			->method( 'getInt' )
+			->will( $this->returnValue(1) );
+
+		$responseMock = $this->getMock( 'WikiaResponse', [ 'addAsset', 'setTemplateEngine' ], [], '', false );
+		$responseMock->expects( $this->once() )
+			->method( 'addAsset' );
+		$responseMock->expects( $this->once() )
+			->method( 'setTemplateEngine' );
+
+		$mapsModelMock = $this->getMock( 'WikiaMaps', [ 'getMapByIdFromApi' ], [], '', false );
+		$mapsModelMock->expects( $this->once() )
+			->method( 'getMapByIdFromApi' )
+			->will( $this->returnValue( $exceptionObject ) );
+
+		$mapsControllerMock = $this->getMock( 'WikiaInteractiveMapsController', [
+			'getModel',
+			'redirectIfForeignWiki',
+			'setVal',
+			'addAsset',
+			'setTemplateEngine'
+		], [], '', false );
+
+		$mapsControllerMock->expects( $this->once() )
+			->method( 'getModel' )
+			->will( $this->returnValue( $mapsModelMock ) );
+		$mapsControllerMock->expects( $this->never() )
+			->method( 'redirectIfForeignWiki' );
+		$mapsControllerMock->expects( $this->any() )
+			->method( 'setVal' );
+
+		$mapsControllerMock->app = $appMock;
+		$mapsControllerMock->request = $requestMock;
+		$mapsControllerMock->response = $responseMock;
+
+		$mapsControllerMock->map();
+	}
+
 }


### PR DESCRIPTION
This week we introduce a redirection if a map's `city_id` isn't the same as a wikia's `city_id`. Unfortunately, there is a bug in the code which causes a blank page when trying to open a single map page of map which doesn't exist. 

This code changes gives us a unit test which checks the issue of not existing map and a fix for blank page.
