### PR TITLE
VID-1906 Add hook to separate parser cache on new gallery pages

### DIFF
--- a/extensions/wikia/WikiaPhotoGallery/WikiaPhotoGalleryHelper.class.php
+++ b/extensions/wikia/WikiaPhotoGallery/WikiaPhotoGalleryHelper.class.php
@@ -975,6 +975,27 @@ class WikiaPhotoGalleryHelper {
 	}
 
 	/**
+	 * Hook handler - Add a key for new gallery to parser cache
+	 * TODO: Remove this hook once media gallery is ready to be fully deployed
+	 *
+	 * @param $hash
+	 * @return bool
+	 */
+	public static function addMediaGalleryCacheKey( &$hash ) {
+		global $wgRequest, $wgEnableMediaGalleryExt;
+
+		if ( $wgRequest->getVal( 'gallery' ) == 'new' ) {
+
+			$wgEnableMediaGalleryExt = true;
+
+			// Add a key to parser cache key
+			$hash .= '!' . 'NewGallery';
+		}
+
+		return true;
+	}
+
+	/**
 	 * Check whether upload is allowed for current user and with current config
 	 * @author Macbre
 	 */

--- a/extensions/wikia/WikiaPhotoGallery/WikiaPhotoGalleryHelper.class.php
+++ b/extensions/wikia/WikiaPhotoGallery/WikiaPhotoGalleryHelper.class.php
@@ -55,18 +55,6 @@ class WikiaPhotoGalleryHelper {
 		// calculate "unique" hash of each gallery
 		$ig->calculateHash($params);
 
-
-		// This is temporary for the prototype stage of media gallery
-		// TODO: Remove this block once media gallery is ready to be fully deployed
-		if ( F::app()->wg->Request->getVal( 'gallery' ) == 'new' ) {
-			global $wgEnableParserCache, $wgEnableMediaGalleryExt;
-
-			$wgEnableMediaGalleryExt = true;
-
-			// Parser cache must be disabled if media gallery is requested via query parameter
-			$wgEnableParserCache = false;
-		}
-
 		wfProfileOut(__METHOD__);
 
 		return true;

--- a/extensions/wikia/WikiaPhotoGallery/WikiaPhotoGallery_setup.php
+++ b/extensions/wikia/WikiaPhotoGallery/WikiaPhotoGallery_setup.php
@@ -49,26 +49,7 @@ $wgHooks['EditPage::importFormData'][] = 'WikiaPhotoGalleryHelper::onImportFormD
 /* end temp transistion code */
 // This is temporary for the prototype stage of media gallery
 // TODO: Remove this hook once media gallery is ready to be fully deployed
-$wgHooks[ 'PageRenderingHash' ][] = 'wikiaPhotoGallery_mediaGalleryCache';
-
-/**
- * Hook callback - Add a key for new gallery to parser cache
- * @param $hash
- * @return bool
- */
-function wikiaPhotoGallery_mediaGalleryCache( &$hash ) {
-	global $wgRequest, $wgEnableMediaGalleryExt;
-
-	if ( $wgRequest->getVal( 'gallery' ) == 'new' ) {
-
-		$wgEnableMediaGalleryExt = true;
-
-		// Add a key to parser cache key
-		$hash .= '!' . 'NewGallery';
-	}
-
-	return true;
-}
+$wgHooks[ 'PageRenderingHash' ][] = 'WikiaPhotoGalleryHelper::addMediaGalleryCacheKey';
 
 // i18n
 $wgExtensionMessagesFiles['WikiaPhotoGallery'] = $dir.'/WikiaPhotoGallery.i18n.php';

--- a/extensions/wikia/WikiaPhotoGallery/WikiaPhotoGallery_setup.php
+++ b/extensions/wikia/WikiaPhotoGallery/WikiaPhotoGallery_setup.php
@@ -47,6 +47,28 @@ $wgHooks['Parser::FetchTemplateAndTitle'][] = 'WikiaPhotoGalleryHelper::fetchTem
 $wgHooks['MakeGlobalVariablesScript'][] = 'WikiaPhotoGalleryHelper::makeGlobalVariablesScriptForWikiaGrid';
 $wgHooks['EditPage::importFormData'][] = 'WikiaPhotoGalleryHelper::onImportFormData';
 /* end temp transistion code */
+// This is temporary for the prototype stage of media gallery
+// TODO: Remove this hook once media gallery is ready to be fully deployed
+$wgHooks[ 'PageRenderingHash' ][] = 'wikiaPhotoGallery_mediaGalleryCache';
+
+/**
+ * Hook callback - Add a key for new gallery to parser cache
+ * @param $hash
+ * @return bool
+ */
+function wikiaPhotoGallery_mediaGalleryCache( &$hash ) {
+	global $wgRequest, $wgEnableMediaGalleryExt;
+
+	if ( $wgRequest->getVal( 'gallery' ) == 'new' ) {
+
+		$wgEnableMediaGalleryExt = true;
+
+		// Add a key to parser cache key
+		$hash .= '!' . 'NewGallery';
+	}
+
+	return true;
+}
 
 // i18n
 $wgExtensionMessagesFiles['WikiaPhotoGallery'] = $dir.'/WikiaPhotoGallery.i18n.php';


### PR DESCRIPTION
Helper class is not the correct place for disabling/modifying parser cache because cache is already checked once it gets there. 
Also this change will cache new gallery pages with a modified cache key to avoid conflict with default pages, while still reaping the benefits of parser caching.
