### PR TITLE
Fix php strict standard notice

### DIFF
--- a/includes/wikia/GlobalFunctions.php
+++ b/includes/wikia/GlobalFunctions.php
@@ -440,7 +440,8 @@ function parseItem($line) {
 			if($title) {
 				if ($title->getNamespace() == NS_SPECIAL) {
 					$dbkey = $title->getDBkey();
-					$specialCanonicalName = array_shift(SpecialPageFactory::resolveAlias($dbkey));
+					$pageData = SpecialPageFactory::resolveAlias( $dbkey );
+					$specialCanonicalName = array_shift( $pageData );
 					if (!$specialCanonicalName) $specialCanonicalName = $dbkey;
 				}
 				$title = $title->fixSpecialName();


### PR DESCRIPTION
This is a problem with PHP because it sees the output of the SpecialPageFactory::resolveAlias() as a value
and therefore complains when the value is directly passed to array_shift as a reference.
The intermediate variable fixes this.
