### PR TITLE
change proxyClass back to mockClass for now

### DIFF
--- a/extensions/wikia/Search/classes/Test/IndexService/CrossWikiCoreTest.php
+++ b/extensions/wikia/Search/classes/Test/IndexService/CrossWikiCoreTest.php
@@ -155,7 +155,7 @@ class CrossWikiCoreTest extends BaseTest
 				'hostname_s' => 'hostname', 'hostname_txt' => 'hostname', 'all_domains_mv_wd' => [ 'bar.wikia.com', 'baz.wikia.com', 'foo.wikia.com' ], 'domains_txt' => [ 'bar.wikia.com', 'baz.wikia.com', 'foo.wikia.com' ],
 				'wiki_pagetitle_txt' => 'Foo Wiki - Bar, Baz and More!',
 				];
-		$this->proxyClass( 'WikiFactory', $mockWiki, 'getWikiById' );
+		$this->mockClass( 'WikiFactory', $mockWiki, 'getWikiById' );
 		$this->mockGlobalFunction( 'WfMessage', $mockMessage );
 		$ref = new ReflectionMethod( $service, 'getWikiBasics' );
 		$ref->setAccessible( true );
@@ -192,7 +192,7 @@ class CrossWikiCoreTest extends BaseTest
 		    ->will   ( $this->returnValue( $response ) )
 		;
 		$expected = [ 'views_weekly_i' => 123, 'views_monthly_i' => '456' ];
-		$this->proxyClass( 'Wikia\Search\IndexService\WikiViews', $wv );
+		$this->mockClass( 'Wikia\Search\IndexService\WikiViews', $wv );
 		$get = new ReflectionMethod( $service, 'getWikiViews' );
 		$get->setAccessible( true );
 		$this->assertEquals(
@@ -223,7 +223,7 @@ class CrossWikiCoreTest extends BaseTest
 		    ->will   ( $this->returnValue( $response ) )
 		;
 		$expected = [ 'wam_i' => 100 ];
-		$this->proxyClass( 'Wikia\Search\IndexService\Wam', $wv );
+		$this->mockClass( 'Wikia\Search\IndexService\Wam', $wv );
 		$get = new ReflectionMethod( $service, 'getWam' );
 		$get->setAccessible( true );
 		$this->assertEquals(
@@ -268,7 +268,7 @@ class CrossWikiCoreTest extends BaseTest
 		    ->with   ( 123 )
 		    ->will   ( $this->returnValue( 50 ) )
 		;
-		$this->proxyClass( 'WikiService', $wikiService );
+		$this->mockClass( 'WikiService', $wikiService );
 
 		$get = new ReflectionMethod( $service, 'getWikiStats' );
 		$get->setAccessible( true );

--- a/extensions/wikia/Search/classes/Test/Match/MatchTest.php
+++ b/extensions/wikia/Search/classes/Test/Match/MatchTest.php
@@ -280,7 +280,7 @@ class MatchTest extends BaseTest {
 		    ->with   ( 'exactWikiMatch', true )
 		;
 
-		$this->proxyClass( 'SolrDocumentService', $mockService );
+		$this->mockClass( 'SolrDocumentService', $mockService );
 
 		$this->assertEquals(
 				$mockResult,

--- a/extensions/wikia/Search/classes/Test/MediaWikiServiceTest.php
+++ b/extensions/wikia/Search/classes/Test/MediaWikiServiceTest.php
@@ -467,7 +467,7 @@ class MediaWikiServiceTest extends BaseTest
 	 * @group Slow
 	 * @slowExecutionTime 0.12579 ms
 	 * Note: we actually expect an array here but since static method calls are tricky here
-	 * we're using proxyClass with translated version of a response array
+	 * we're using mockClass with translated version of a response array
 	 * @covers \Wikia\Search\MediaWikiService::getParseResponseFromPageId
 	 */
 	public function testGetParseResponseFromPageId() {
@@ -1372,7 +1372,7 @@ class MediaWikiServiceTest extends BaseTest
 			->will   ( $this->returnValue( 'wall message title' ) )
 		;
 
-		$this->proxyClass( '\WallMessage', $wm, 'newFromId' );
+		$this->mockClass( '\WallMessage', $wm, 'newFromId' );
 
 		$get = new ReflectionMethod( '\Wikia\Search\MediaWikiService', 'getTitleString' );
 		$get->setAccessible( true );
@@ -1464,7 +1464,7 @@ class MediaWikiServiceTest extends BaseTest
 //		    ->method ( 'getArticleID' )
 //		    ->will    ( $this->returnValue( $this->pageId ) )
 //		;
-//		$this->proxyClass( '\WallMessage', null, 'newFromId' );
+//		$this->mockClass( '\WallMessage', null, 'newFromId' );
 
 //		$get = new ReflectionMethod( '\Wikia\Search\MediaWikiService', 'getTitleString' );
 //		$get->setAccessible( true );
@@ -2116,7 +2116,7 @@ class MediaWikiServiceTest extends BaseTest
 		    ->with         ( 123 )
 		    ->will         ( $this->returnValue( $wiki ) )
 		;
-		$this->proxyClass( 'WikiFactory', $mockWf );
+		$this->mockClass( 'WikiFactory', $mockWf );
 		$refl = new ReflectionMethod( $mws, 'getWikiFromWikiId' );
 		$refl->setAccessible( true );
 		$this->assertEquals(

--- a/extensions/wikia/Search/classes/Test/QueryService/Select/AbstractSelectTest.php
+++ b/extensions/wikia/Search/classes/Test/QueryService/Select/AbstractSelectTest.php
@@ -804,7 +804,7 @@ class AbstractSelectTest extends Wikia\Search\Test\BaseTest {
 		    ->will   ( $this->returnValue( $mockConfig ) )
 		;
 
-		$this->proxyClass( 'Wikia\Search\ResultSet\Factory', $mockResultSetFactory );
+		$this->mockClass( 'Wikia\Search\ResultSet\Factory', $mockResultSetFactory );
 
 		$reflspell = new ReflectionMethod( $mockSelect, 'prepareResponse' );
 		$reflspell->setAccessible( true );

--- a/includes/wikia/services/tests/ArticleServiceTest.php
+++ b/includes/wikia/services/tests/ArticleServiceTest.php
@@ -145,7 +145,7 @@ class ArticleServiceTest extends WikiaBaseTest {
 		    ->will   ( $this->returnValue( 'foo' ) )
 		;
 
-		$this->proxyClass( 'SolrDocumentService', $mockDocumentService );
+		$this->mockClass( 'SolrDocumentService', $mockDocumentService );
 
 		$this->assertEquals(
 				'foo',

--- a/includes/wikia/services/tests/SolrDocumentServiceTest.php
+++ b/includes/wikia/services/tests/SolrDocumentServiceTest.php
@@ -11,7 +11,7 @@ class SolrDocumentServiceTest extends WikiaBaseTest
 		                  ->disableOriginalConstructor()
 		                  ->setMethods( [ 'offsetGet', 'offsetExists' ] )
 		                  ->getMock();
-		
+
 		$service
 		    ->expects( $this->once() )
 		    ->method ( 'getConfig' )
@@ -57,7 +57,7 @@ class SolrDocumentServiceTest extends WikiaBaseTest
 				SolrDocumentService::$documentCache
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.01169 ms
@@ -72,7 +72,7 @@ class SolrDocumentServiceTest extends WikiaBaseTest
 		                  ->setMethods( [ 'offsetGet', 'offsetExists' ] )
 		                  ->getMock();
 		$result = $this->getMock( 'Wikia\Search\Result' );
-		
+
 		$service
 		    ->expects( $this->once() )
 		    ->method ( 'getConfig' )
@@ -151,7 +151,7 @@ class SolrDocumentServiceTest extends WikiaBaseTest
 				$service->getResult()
 		);
 	}
-	
+
 	/**
 	 * @covers SolrDocumentService::setArticleId
 	 * @covers SolrDocumentService::getArticleId
@@ -176,7 +176,7 @@ class SolrDocumentServiceTest extends WikiaBaseTest
 				$ds->getArticleId()
 		);
 	}
-	
+
 	/**
 	 * @covers SolrDocumentService::setWikiId
 	 * @covers SolrDocumentService::getWikiId
@@ -211,7 +211,7 @@ class SolrDocumentServiceTest extends WikiaBaseTest
 				$ds->getWikiId()
 		);
 	}
-	
+
 	/**
 	 * @covers SolrDocumentService::getDocumentId
 	 */
@@ -230,7 +230,7 @@ class SolrDocumentServiceTest extends WikiaBaseTest
 		$ds
 		    ->expects( $this->once() )
 		    ->method ( 'getArticleId' )
-		    ->will   ( $this->returnValue( 234 ) ) 
+		    ->will   ( $this->returnValue( 234 ) )
 		;
 		$get = new ReflectionMethod( $ds, 'getDocumentId' );
 		$get->setAccessible( true );
@@ -239,7 +239,7 @@ class SolrDocumentServiceTest extends WikiaBaseTest
 				$get->invoke( $ds )
 		);
 	}
-	
+
 	/**
 	 * @covers SolrDocumentService::getDocumentId
 	 */
@@ -266,14 +266,14 @@ class SolrDocumentServiceTest extends WikiaBaseTest
 				$get->invoke( $ds )
 		);
 	}
-	
+
 	/**
 	 * @covers SolrDocumentService::getConfig
 	 */
 	public function testGetConfigCrossWiki() {
 		$ds = $this->getMock( 'SolrDocumentService', [ 'getCrossWiki' ] );
 		$config = $this->getMock( 'Wikia\Search\Config', [ 'setCrossWikiLuceneQuery', 'setDirectLuceneQuery', 'setLimit' ] );
-		
+
 		$ds
 		    ->expects( $this->once() )
 		    ->method ( 'getCrossWiki' )
@@ -289,7 +289,7 @@ class SolrDocumentServiceTest extends WikiaBaseTest
 		    ->method ( 'setCrossWikiLuceneQuery' )
 		    ->with   ( true )
 		;
-		$this->proxyClass( 'Wikia\Search\Config', $config );
+		$this->mockClass( 'Wikia\Search\Config', $config );
 		$get = new ReflectionMethod( $ds, 'getConfig' );
 		$get->setAccessible( true );
 		$this->assertEquals(
@@ -297,14 +297,14 @@ class SolrDocumentServiceTest extends WikiaBaseTest
 				$get->invoke( $ds )
 		);
 	}
-	
+
 	/**
 	 * @covers SolrDocumentService::getConfig
 	 */
 	public function testGetConfigMain() {
 		$ds = $this->getMock( 'SolrDocumentService', [ 'getCrossWiki' ] );
 		$config = $this->getMock( 'Wikia\Search\Config', [ 'setCrossWikiLuceneQuery', 'setDirectLuceneQuery', 'setLimit' ] );
-		
+
 		$ds
 		    ->expects( $this->once() )
 		    ->method ( 'getCrossWiki' )
@@ -320,7 +320,7 @@ class SolrDocumentServiceTest extends WikiaBaseTest
 		    ->method ( 'setDirectLuceneQuery' )
 		    ->with   ( true )
 		;
-		$this->proxyClass( 'Wikia\Search\Config', $config );
+		$this->mockClass( 'Wikia\Search\Config', $config );
 		$get = new ReflectionMethod( $ds, 'getConfig' );
 		$get->setAccessible( true );
 		$this->assertEquals(
@@ -328,7 +328,7 @@ class SolrDocumentServiceTest extends WikiaBaseTest
 				$get->invoke( $ds )
 		);
 	}
-	
+
 	/**
 	 * @covers SolrDocumentService::getFactory
 	 */
@@ -341,7 +341,7 @@ class SolrDocumentServiceTest extends WikiaBaseTest
 				$get->invoke( $ds )
 		);
 	}
-	
+
 	/**
 	 * @covers SolrDocumentService::getCrossWiki
 	 * @covers SolrDocumentService::setCrossWiki
@@ -369,5 +369,5 @@ class SolrDocumentServiceTest extends WikiaBaseTest
 				$ds->getCrossWiki()
 		);
 	}
-	
+
 }

--- a/includes/wikia/tests/core/WikiaBaseTest.class.php
+++ b/includes/wikia/tests/core/WikiaBaseTest.class.php
@@ -392,10 +392,6 @@ abstract class WikiaBaseTest extends PHPUnit_Framework_TestCase {
 		return WikiaMockProxyAction::currentInvocation();
 	}
 
-	protected function proxyClass() {
-		return call_user_func_array( array( $this, 'mockClass' ), func_get_args() );
-	}
-
 	private function unsetGlobals() {
 		/** @var $mock WikiaGlobalVariableMock */
 		foreach ($this->mockedGlobalVariables as $globalName => $mock) {


### PR DESCRIPTION
We were in the middle of refactoring mockClass into proxyClass but since proxyClass isn't really used much and the name doesn't matter much I'm just undoing the half-finished refactoring.

Basically this is so I can just close out an old ticket and update the docs.  We can always redo it later if we have the motivation.  
