### PR TITLE
VE-1478: Set width, height and position template dialog in the correct p...

### DIFF
--- a/extensions/VisualEditor/lib/ve/modules/ve/ui/ve.ui.Dialog.js
+++ b/extensions/VisualEditor/lib/ve/modules/ve/ui/ve.ui.Dialog.js
@@ -147,23 +147,6 @@ ve.ui.Dialog.prototype.getSetupProcess = function ( data ) {
 };
 
 /**
- * Aligns the edge of the dialog with the edge of the surface
- */
-ve.ui.Dialog.prototype.alignToSurface = function () {
-	var padding = 10,
-		$surface = this.surface.getView().$element,
-		surfaceOffset = $surface.offset();
-
-	if ( this.surface.getView().getFocusedNode().getHorizontalBias() === 'right' ) {
-		this.frame.$element.parent()
-			.css( 'left', surfaceOffset.left - padding );
-	} else {
-		this.frame.$element.parent()
-			.css( 'left', surfaceOffset.left + $surface.width() - this.frame.$element.parent().outerWidth() + padding );
-	}
-};
-
-/**
  * Get the surface fragment the dialog is for
  *
  * @returns {ve.dm.SurfaceFragment|null} Surface fragment the dialog is for, null if the dialog is closed

--- a/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaTransclusionDialog.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaTransclusionDialog.js
@@ -172,7 +172,7 @@ ve.ui.WikiaTransclusionDialog.prototype.getTeardownProcess = function ( data ) {
  */
 ve.ui.WikiaTransclusionDialog.prototype.position = function () {
 	var viewportHeight = $( window ).height(),
-		dialogHeight = Math.min( 600 /* max height */, viewportHeight * 0.7 ),
+		dialogHeight = Math.min( 600, viewportHeight * 0.7 ),
 		padding = 10,
 		$surface = this.surface.getView().$element,
 		surfaceOffset = $surface.offset();

--- a/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaTransclusionDialog.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaTransclusionDialog.js
@@ -181,8 +181,7 @@ ve.ui.WikiaTransclusionDialog.prototype.position = function () {
 		'width': 400,
 		'height': dialogHeight,
 		'top': ( viewportHeight - dialogHeight ) / 2,
-		'max-height': 'none',
-		'left': left
+		'max-height': 'none'
 	} );
 
 	if ( this.surface.getView().getFocusedNode().getHorizontalBias() === 'right' ) {

--- a/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaTransclusionDialog.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaTransclusionDialog.js
@@ -177,6 +177,14 @@ ve.ui.WikiaTransclusionDialog.prototype.position = function () {
 		$surface = this.surface.getView().$element,
 		surfaceOffset = $surface.offset();
 
+	this.frame.$element.parent().css( {
+		'width': 400,
+		'height': dialogHeight,
+		'top': ( viewportHeight - dialogHeight ) / 2,
+		'max-height': 'none',
+		'left': left
+	} );
+
 	if ( this.surface.getView().getFocusedNode().getHorizontalBias() === 'right' ) {
 		this.frame.$element.parent()
 			.css( 'left', surfaceOffset.left - padding );
@@ -184,12 +192,6 @@ ve.ui.WikiaTransclusionDialog.prototype.position = function () {
 		this.frame.$element.parent()
 			.css( 'left', surfaceOffset.left + $surface.width() - this.frame.$element.parent().outerWidth() + padding );
 	}
-	this.frame.$element.parent().css( {
-		'width': 400,
-		'height': dialogHeight,
-		'top': ( viewportHeight - dialogHeight ) / 2,
-		'max-height': 'none'
-	} );
 };
 
 /* Registration */

--- a/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaTransclusionDialog.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaTransclusionDialog.js
@@ -160,7 +160,11 @@ ve.ui.WikiaTransclusionDialog.prototype.getTeardownProcess = function ( data ) {
 			if ( this.allowScroll ) {
 				this.unsetAllowScroll();
 			}
-			this.frame.$element.parent().css( 'width', '' );
+			this.frame.$element.parent().css( {
+				'width': '',
+				'height': '',
+				'max-height': ''
+			} );
 		}, this );
 };
 

--- a/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaTransclusionDialog.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaTransclusionDialog.js
@@ -125,8 +125,7 @@ ve.ui.WikiaTransclusionDialog.prototype.getSetupProcess = function ( data ) {
 
 			if ( single ) {
 				// Appearance
-				this.frame.$element.parent().css( 'width', 400 );
-				this.alignToSurface();
+				this.position();
 				// Drag
 				this.setDraggable();
 				// Overlay
@@ -139,6 +138,9 @@ ve.ui.WikiaTransclusionDialog.prototype.getSetupProcess = function ( data ) {
 		}, this );
 };
 
+/**
+ * @inheritdoc
+ */
 ve.ui.WikiaTransclusionDialog.prototype.getTeardownProcess = function ( data ) {
 	return ve.ui.WikiaTransclusionDialog.super.prototype.getTeardownProcess.call( this, data )
 		.first( function () {
@@ -160,6 +162,34 @@ ve.ui.WikiaTransclusionDialog.prototype.getTeardownProcess = function ( data ) {
 			}
 			this.frame.$element.parent().css( 'width', '' );
 		}, this );
+};
+
+/**
+ * Position dialog. Vertically in the middle of the viewport
+ * and horizontally with the edge (left or right) of the surface
+ *
+ * @method
+ */
+ve.ui.WikiaTransclusionDialog.prototype.position = function () {
+	var viewportHeight = $( window ).height(),
+		dialogHeight = Math.min( 600 /* max height */, viewportHeight * 0.7 ),
+		padding = 10,
+		$surface = this.surface.getView().$element,
+		surfaceOffset = $surface.offset();
+
+	if ( this.surface.getView().getFocusedNode().getHorizontalBias() === 'right' ) {
+		this.frame.$element.parent()
+			.css( 'left', surfaceOffset.left - padding );
+	} else {
+		this.frame.$element.parent()
+			.css( 'left', surfaceOffset.left + $surface.width() - this.frame.$element.parent().outerWidth() + padding );
+	}
+	this.frame.$element.parent().css( {
+		'width': 400,
+		'height': dialogHeight,
+		'top': ( viewportHeight - dialogHeight ) / 2,
+		'max-height': 'none'
+	} );
 };
 
 /* Registration */

--- a/extensions/VisualEditor/wikia/modules/ve/ui/pages/ve.ui.WikiaParameterPage.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/pages/ve.ui.WikiaParameterPage.js
@@ -28,7 +28,7 @@ ve.ui.WikiaParameterPage = function VeUiWikiaParameterPage( parameter, name, con
 			'$': this.$,
 			'frameless': true,
 			'icon': 'arrow-circled',
-			'label': ve.msg( 'wikia-visualeditor-dialog-transclusion-get-info', this.template.getTarget().wt ),
+			'label': ve.msg( 'wikia-visualeditor-dialog-transclusion-get-info', this.template.getSpec().getLabel() ),
 			'tabIndex': -1,
 			'classes': [ 've-ui-mwParameterPage-templateInfoButton' ]
 		} )

--- a/extensions/VisualEditor/wikia/modules/ve/ui/styles/ve.ui.Dialog.scss
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/styles/ve.ui.Dialog.scss
@@ -85,7 +85,6 @@
 .oo-ui-dialog-draggable {
 	> .oo-ui-window-frame {
 		bottom: auto;
-		height: 300px;
 		right: auto;
 	}
 }


### PR DESCRIPTION
...lace

Moved and renamed method ve.ui.Dialog.prototype.alignToSurface to ve.ui.WikiaTransclusionDialog.prototype.position because it is not a generic dialog method. For instance, to work properly, it depends on dialog being opened for a focusable node. Also, what it does, it's pretty specific (at least at this moment) to this particlar dialog.

Minor fix to accessing template name for displaying purpose - use actually template spec instead of private variables.

Removed the default height for draggable dialog.

https://wikia-inc.atlassian.net/browse/VE-1478
