### PR TITLE
LoadBalancer: support multiple masters

### DIFF
--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -3561,7 +3561,7 @@ function wfGetLB( $wiki = false ) {
 /**
  * Get the load balancer factory object
  *
- * @return LBFactory
+ * @return LBFactory_Wikia
  */
 function &wfGetLBFactory() {
 	return LBFactory::singleton();

--- a/includes/db/LoadBalancer.php
+++ b/includes/db/LoadBalancer.php
@@ -491,6 +491,11 @@ class LoadBalancer {
 		# Now we have an explicit index into the servers array
 		$conn = $this->openConnection( $i, $wiki );
 		if ( !$conn ) {
+			# master connection error handling
+			if ( $i == $this->getWriterIndex() ) {
+				wfGetLBFactory()->getMastersPoll()->markMasterAsBroken( $this->mServers[$i] );
+			}
+
 			$this->reportConnectionError( $this->mErrorConnection );
 		}
 

--- a/includes/db/LoadBalancer.php
+++ b/includes/db/LoadBalancer.php
@@ -488,13 +488,24 @@ class LoadBalancer {
 			}
 		}
 
+		// Wikia change - begin
+		// check the status of selected master
+		if ( $i == $this->getWriterIndex() ) {
+			if ( wfGetLBFactory()->getMastersPoll()->isMasterBroken( $this->mServers[0] ) ) {
+				// TODO: handle broken master
+			}
+		}
+		// Wikia change - end
+
 		# Now we have an explicit index into the servers array
 		$conn = $this->openConnection( $i, $wiki );
 		if ( !$conn ) {
+			// Wikia change - begin
 			# master connection error handling
 			if ( $i == $this->getWriterIndex() ) {
 				wfGetLBFactory()->getMastersPoll()->markMasterAsBroken( $this->mServers[$i] );
 			}
+			// Wikia change - end
 
 			$this->reportConnectionError( $this->mErrorConnection );
 		}

--- a/includes/db/LoadBalancer.php
+++ b/includes/db/LoadBalancer.php
@@ -492,7 +492,14 @@ class LoadBalancer {
 		// check the status of selected master
 		if ( $i == $this->getWriterIndex() ) {
 			if ( wfGetLBFactory()->getMastersPoll()->isMasterBroken( $this->mServers[0] ) ) {
-				// TODO: handle broken master
+				// handle broken master - connect to a different master
+				$clusterInfo = $this->parentInfo()['id'];
+				$newMaster = wfGetLBFactory()->getMastersPoll()->getNextMasterForSection( $clusterInfo );
+
+				// replace the master in LoadBalancer config
+				if ( !empty( $newMaster ) ) {
+					$this->mServers[$i] = $newMaster;
+				}
 			}
 		}
 		// Wikia change - end

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -724,6 +724,7 @@ $wgSharedKeyPrefix = "wikicities"; // default value for shared key prefix, @see 
 $wgWikiaMailerDB = 'wikia_mailer';
 
 $wgAutoloadClasses['LBFactory_Wikia'] = "$IP/includes/wikia/LBFactory_Wikia.php";
+$wgAutoloadClasses['Wikia\\MastersPoll'] = "$IP/includes/wikia/MastersPoll.php";
 
 /**
  * @name wgEnableBlogCommentEdit, wgEnabledGroupedBlogComments, wgEnableBlogWatchlist

--- a/includes/wikia/LBFactory_Wikia.php
+++ b/includes/wikia/LBFactory_Wikia.php
@@ -12,6 +12,33 @@
  */
 class LBFactory_Wikia extends LBFactory_Multi {
 
+	function __construct( $conf ) {
+		self::normalizeMultipleMasters($conf);
+
+		parent::__construct($conf);
+	}
+
+	/**
+	 * Normalize the list of multiple masters and slaves
+	 *
+	 * @param array $sectionLoads
+	 * @author macbre
+	 */
+	static function normalizeMultipleMasters(Array &$conf) {
+		foreach($conf['sectionLoads'] as $sectionName => &$sectionConf) {
+			# section config has both "masters" and "slaves" section
+			if (isset($sectionConf['masters']) && isset($sectionConf['slaves'])) {
+				# randomize masters server and normalize the section config
+				$master = array_rand($sectionConf['masters'], 1);
+
+				wfDebug(sprintf("%s: randomizing master for %s: picked %s\n", __METHOD__, $sectionName, $master) );
+
+				# make it flat
+				$sectionConf = array($master => $sectionConf['masters'][$master]) + $sectionConf['slaves'];
+			}
+		}
+	}
+
 	function getSectionForWiki( $wiki = false ) {
 		global $wgDBname, $wgDBcluster, $smwgUseExternalDB;
 

--- a/includes/wikia/LBFactory_Wikia.php
+++ b/includes/wikia/LBFactory_Wikia.php
@@ -13,9 +13,9 @@
 class LBFactory_Wikia extends LBFactory_Multi {
 
 	function __construct( $conf ) {
-		self::normalizeMultipleMasters($conf);
+		self::normalizeMultipleMasters( $conf );
 
-		parent::__construct($conf);
+		parent::__construct( $conf );
 	}
 
 	/**
@@ -23,18 +23,19 @@ class LBFactory_Wikia extends LBFactory_Multi {
 	 *
 	 * @param array $sectionLoads
 	 * @author macbre
+	 * @see PLATFORM-434
 	 */
-	static function normalizeMultipleMasters(Array &$conf) {
-		foreach($conf['sectionLoads'] as $sectionName => &$sectionConf) {
+	static function normalizeMultipleMasters( Array &$conf ) {
+		foreach ( $conf['sectionLoads'] as $sectionName => &$sectionConf ) {
 			# section config has both "masters" and "slaves" section
-			if (isset($sectionConf['masters']) && isset($sectionConf['slaves'])) {
+			if ( isset( $sectionConf['masters'] ) && isset( $sectionConf['slaves'] ) ) {
 				# randomize masters server and normalize the section config
-				$master = array_rand($sectionConf['masters'], 1);
+				$master = array_rand( $sectionConf['masters'], 1 );
 
-				wfDebug(sprintf("%s: randomizing master for %s: picked %s\n", __METHOD__, $sectionName, $master) );
+				wfDebug( sprintf( "%s: randomizing master for %s: picked %s\n", __METHOD__, $sectionName, $master ) );
 
 				# make it flat
-				$sectionConf = array($master => $sectionConf['masters'][$master]) + $sectionConf['slaves'];
+				$sectionConf = array( $master => $sectionConf['masters'][$master] ) + $sectionConf['slaves'];
 			}
 		}
 	}
@@ -56,11 +57,11 @@ class LBFactory_Wikia extends LBFactory_Multi {
 		$section = 'central';
 
 		$this->isSMWClusterActive = false;
-		if( $smwgUseExternalDB ) {
+		if ( $smwgUseExternalDB ) {
 			/**
 			 * set flag, strip database name
 			 */
-			if( substr($dbName, 0, 4 ) == "smw+" && isset( $this->sectionsByDB[ "smw+" ] ) ) {
+			if ( substr( $dbName, 0, 4 ) == "smw+" && isset( $this->sectionsByDB[ "smw+" ] ) ) {
 				$this->isSMWClusterActive = true;
 				$dbName = substr( $dbName, 4 );
 				wfDebugLog( "connect", __METHOD__ . ": smw+ cluster is active, dbname changed to $dbName\n", true );
@@ -71,7 +72,7 @@ class LBFactory_Wikia extends LBFactory_Multi {
 			// this is a db that has a cluster defined in the config file (DB.php)
 			$section = $this->sectionsByDB[$dbName];
 		}
-		elseif( $this->isSMWClusterActive ) {
+		elseif ( $this->isSMWClusterActive ) {
 			// use smw+ entry
 			$section = $this->sectionsByDB[ "smw+" ];
 			wfDebugLog( "connect", __METHOD__ . "-smw: section $section choosen for $wiki\n" );

--- a/includes/wikia/LBFactory_Wikia.php
+++ b/includes/wikia/LBFactory_Wikia.php
@@ -4,6 +4,8 @@
  * @ingroup Database
  */
 
+use Wikia\MastersPoll;
+
 /**
  * A multi-wiki, multi-master factory for Wikia and similar installations.
  * Ignores the old configuration globals
@@ -12,32 +14,15 @@
  */
 class LBFactory_Wikia extends LBFactory_Multi {
 
-	function __construct( $conf ) {
-		self::normalizeMultipleMasters( $conf );
+	private $mastersPoll;
 
-		parent::__construct( $conf );
+	function __construct( $conf ) {
+		$this->mastersPoll = new MastersPoll($conf);
+		parent::__construct( $this->mastersPoll->getConf() );
 	}
 
-	/**
-	 * Normalize the list of multiple masters and slaves
-	 *
-	 * @param array $sectionLoads
-	 * @author macbre
-	 * @see PLATFORM-434
-	 */
-	static function normalizeMultipleMasters( Array &$conf ) {
-		foreach ( $conf['sectionLoads'] as $sectionName => &$sectionConf ) {
-			# section config has both "masters" and "slaves" section
-			if ( isset( $sectionConf['masters'] ) && isset( $sectionConf['slaves'] ) ) {
-				# randomize masters server and normalize the section config
-				$master = array_rand( $sectionConf['masters'], 1 );
-
-				wfDebug( sprintf( "%s: randomizing master for %s: picked %s\n", __METHOD__, $sectionName, $master ) );
-
-				# make it flat
-				$sectionConf = array( $master => $sectionConf['masters'][$master] ) + $sectionConf['slaves'];
-			}
-		}
+	function getMastersPoll() {
+		return $this->mastersPoll;
 	}
 
 	function getSectionForWiki( $wiki = false ) {

--- a/includes/wikia/MastersPoll.php
+++ b/includes/wikia/MastersPoll.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Wikia;
+
+/**
+ * This class handles multiple masters in DB config
+ *
+ * @author macbre
+ * @see PLATFORM-434
+ */
+class MastersPoll {
+	# store server states in memcache (for 60 seconds)
+	const SERVER_BROKEN = true;
+	const SERVER_STATUS_TTL = 60;
+
+	private $conf;
+
+	function __construct( Array $conf ) {
+		$this->conf = $conf;
+		$this->normalizeMultipleMasters();
+	}
+
+	/**
+	 * @return array
+	 */
+	function getConf() {
+		return $this->conf;
+	}
+
+	/**
+	 * Normalize the list of multiple masters and slaves
+	 *
+	 * @param array $sectionLoads
+	 * @author macbre
+	 */
+	private function normalizeMultipleMasters() {
+		$this->conf['mastersPoolBySection'] = [];
+
+		foreach ( $this->conf['sectionLoads'] as $sectionName => &$sectionConf ) {
+			# section config has both "masters" and "slaves" section
+			if ( isset( $sectionConf['masters'] ) && isset( $sectionConf['slaves'] ) ) {
+				# randomize masters server and normalize the section config
+				$master = array_rand( $sectionConf['masters'], 1 );
+
+				wfDebug( sprintf( "%s: randomizing master for %s: picked %s\n", __CLASS__, $sectionName, $master ) );
+
+				# store the rest of master nodes
+				# we will try to use one of them if the one we picked is not responding
+				$mastersPoll = $sectionConf['masters'];
+				unset( $mastersPoll[$master] );
+
+				$this->conf['mastersPoolBySection'][$sectionName] = $mastersPoll;
+				wfDebug( sprintf( "%s: keeping masters pool for %s: %s\n", __CLASS__, $sectionName, join( ', ', array_keys( $mastersPoll ) ) ) );
+
+				# make it flat
+				$sectionConf = array( $master => $sectionConf['masters'][$master] ) + $sectionConf['slaves'];
+			}
+		}
+	}
+
+	/**
+	 * Mark given master node as broken
+	 *
+	 * This information will be stored in memcache for 60 seconds
+	 * Subsequent requests will skip this master node
+	 *
+	 * @param array $serverEntry
+	 */
+	static function markMasterAsBroken(Array $serverEntry) {
+		$hostName = $serverEntry['hostName'];
+		wfDebug( sprintf( "%s: marking '%s' as broken\n", __CLASS__, $hostName ) );
+
+		\F::app()->wg->Memc->set( self::getStatusKeyForServer( $hostName ), self::SERVER_BROKEN, self::SERVER_STATUS_TTL );
+	}
+
+	static function getStatusKeyForServer($hostName) {
+		return wfSharedMemcKey( __CLASS__, 'status', $hostName );
+	}
+}

--- a/includes/wikia/tests/LoadBalancerTest.php
+++ b/includes/wikia/tests/LoadBalancerTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Unit tests for LBFactory_Wikia::normalizeMultipleMasters
+ *
+ * @author macbre
+ */
+class LoadBalancerTest extends WikiaBaseTest {
+
+	public function testNormalizeMultipleMasters() {
+		$masters = [
+			'db-c1-a1' => 1,
+			'db-c1-a2' => 1,
+		];
+
+		$slaves = [
+			'db-c1-a3' => 1,
+			'db-c1-a4' => 1,
+		];
+
+		$central = array(
+			'db-c1' => 1,
+			'db-c2' => 1,
+		);
+
+		$conf = [
+			'class' => 'LBFactory_Wikia',
+			'sectionLoads' => array(
+				'central' => $central,
+				'c1' => array(
+					'masters' => $masters,
+					'slaves' => $slaves,
+				),
+				'c2' => array(
+					'db-c2-a1' => 1,
+					'db-c2-a2' => 1,
+				),
+			),
+		];
+
+		LBFactory_Wikia::normalizeMultipleMasters( $conf );
+		$servers = $conf['sectionLoads'];
+
+		$this->assertEquals( $slaves, array_slice( $servers['c1'], 1 ), 'List of slaves is maintained' );
+		$this->assertContains( array_keys( $servers['c1'] )[0], array_keys( $masters ), 'Master is randomized' );
+		$this->assertEquals( $central, $servers['central'], 'central cluster config is left unchanged' );
+	}
+}

--- a/includes/wikia/tests/MastersPollTest.php
+++ b/includes/wikia/tests/MastersPollTest.php
@@ -1,11 +1,13 @@
 <?php
 
+use Wikia\MastersPoll;
+
 /**
  * Unit tests for LBFactory_Wikia::normalizeMultipleMasters
  *
  * @author macbre
  */
-class LoadBalancerTest extends WikiaBaseTest {
+class MastersPollTest extends WikiaBaseTest {
 
 	public function testNormalizeMultipleMasters() {
 		$masters = [
@@ -38,11 +40,20 @@ class LoadBalancerTest extends WikiaBaseTest {
 			),
 		];
 
-		LBFactory_Wikia::normalizeMultipleMasters( $conf );
-		$servers = $conf['sectionLoads'];
+		$poll = new MastersPoll($conf);
 
+		$servers = $poll->getConf()['sectionLoads'];
+		$mastersPoll = $poll->getConf()['mastersPoolBySection'];
+
+		$selectedMaster = array_keys( $servers['c1'] )[0];
+
+		# master selection
 		$this->assertEquals( $slaves, array_slice( $servers['c1'], 1 ), 'List of slaves is maintained' );
-		$this->assertContains( array_keys( $servers['c1'] )[0], array_keys( $masters ), 'Master is randomized' );
+		$this->assertContains( $selectedMaster, array_keys( $masters ), 'Master is randomized' );
 		$this->assertEquals( $central, $servers['central'], 'central cluster config is left unchanged' );
+
+		# masters poll
+		$this->assertInternalType('array', $mastersPoll['c1'], 'Masters poll should be generated' );
+		$this->assertNotContains( $selectedMaster, $mastersPoll['c1'], 'Masters poll should not contain selected master' );
 	}
 }

--- a/includes/wikia/tests/MastersPollTest.php
+++ b/includes/wikia/tests/MastersPollTest.php
@@ -20,23 +20,22 @@ class MastersPollTest extends WikiaBaseTest {
 			'db-c1-a4' => 1,
 		];
 
-		$central = array(
+		$central = [
 			'db-c1' => 1,
 			'db-c2' => 1,
-		);
+		];
 
 		$conf = [
-			'class' => 'LBFactory_Wikia',
 			'sectionLoads' => array(
 				'central' => $central,
-				'c1' => array(
+				'c1' => [
 					'masters' => $masters,
 					'slaves' => $slaves,
-				),
-				'c2' => array(
+				],
+				'c2' => [
 					'db-c2-a1' => 1,
 					'db-c2-a2' => 1,
-				),
+				],
 			),
 		];
 
@@ -55,5 +54,9 @@ class MastersPollTest extends WikiaBaseTest {
 		# masters poll
 		$this->assertInternalType('array', $mastersPoll['c1'], 'Masters poll should be generated' );
 		$this->assertNotContains( $selectedMaster, $mastersPoll['c1'], 'Masters poll should not contain selected master' );
+
+		# next master for section
+		$this->assertEquals( false, $poll->getNextMasterForSection('central'), 'This cluster has no secondary master defined' );
+		$this->assertEquals( reset( array_keys( $mastersPoll['c1'] ) ), $poll->getNextMasterForSection('c1'), 'Secondary master is returned' );
 	}
 }

--- a/includes/wikia/tests/MastersPollTest.php
+++ b/includes/wikia/tests/MastersPollTest.php
@@ -3,11 +3,41 @@
 use Wikia\MastersPoll;
 
 /**
+ * A simple memcache mock
+ */
+class DummyMemcache {
+	private $storage = [];
+
+	function set( $key, $value ) {
+		$this->storage[$key] = $value;
+	}
+
+	function get( $key ) {
+		if ( isset( $this->storage[$key] ) ) {
+			return $this->storage[$key];
+		}
+		else {
+			return null;
+		}
+	}
+}
+
+/**
  * Unit tests for LBFactory_Wikia::normalizeMultipleMasters
  *
  * @author macbre
  */
 class MastersPollTest extends WikiaBaseTest {
+
+	/* @var DummyMemcache $memc */
+	private $memc;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->memc = new DummyMemcache();
+		$this->mockGlobalVariable( 'wgMemc', $this->memc );
+	}
 
 	public function testNormalizeMultipleMasters() {
 		$masters = [
@@ -39,7 +69,7 @@ class MastersPollTest extends WikiaBaseTest {
 			),
 		];
 
-		$poll = new MastersPoll($conf);
+		$poll = new MastersPoll( $conf );
 
 		$servers = $poll->getConf()['sectionLoads'];
 		$mastersPoll = $poll->getConf()['mastersPoolBySection'];
@@ -52,15 +82,42 @@ class MastersPollTest extends WikiaBaseTest {
 		$this->assertEquals( $central, $servers['central'], 'central cluster config is left unchanged' );
 
 		# masters poll
-		$this->assertInternalType('array', $mastersPoll['c1'], 'Masters poll should be generated' );
+		$this->assertInternalType( 'array', $mastersPoll['c1'], 'Masters poll should be generated' );
 		$this->assertNotContains( $selectedMaster, $mastersPoll['c1'], 'Masters poll should not contain selected master' );
 
 		# next master for section
-		$this->assertEquals( false, $poll->getNextMasterForSection('main-central'), 'This cluster has no secondary master defined' );
+		$this->assertEquals( false, $poll->getNextMasterForSection( 'main-central' ), 'This cluster has no secondary master defined' );
 
 		$nextMaster = $poll->getNextMasterForSection( 'main-c1' );
 		$mastersPollForC1 = array_keys( $mastersPoll['c1'] );
 
 		$this->assertEquals( reset( $mastersPollForC1 ), $nextMaster['hostName'], 'Secondary master is returned' );
+	}
+
+	public function testMarkAsBroken() {
+		$hostName = 'db-foo';
+		$serverEntry = [
+			'hostName' => $hostName
+		];
+
+		$poll = new MastersPoll( [] );
+		$key = MastersPoll::getStatusKeyForServer( $hostName );
+
+		$this->assertEquals( false, $poll->isMasterBroken( $serverEntry ) );
+
+		// mark the host as broken and check memcache entry
+		$poll->markMasterAsBroken( $serverEntry );
+
+		$this->assertEquals( 1, $this->memc->get( $key ) );
+		$this->assertEquals( false, $poll->isMasterBroken( $serverEntry ) );
+
+		// now add more broken connection until we reach the threshold
+		for ( $i = 1; $i < MastersPoll::SERVER_IS_BROKEN_THRESHOLD; $i++ ) {
+			$poll->markMasterAsBroken( $serverEntry );
+		}
+
+		// now the host should be marked as broken
+		$this->assertEquals( 5, $this->memc->get( $key ) );
+		$this->assertEquals( true, $poll->isMasterBroken( $serverEntry ) );
 	}
 }

--- a/includes/wikia/tests/MastersPollTest.php
+++ b/includes/wikia/tests/MastersPollTest.php
@@ -56,7 +56,11 @@ class MastersPollTest extends WikiaBaseTest {
 		$this->assertNotContains( $selectedMaster, $mastersPoll['c1'], 'Masters poll should not contain selected master' );
 
 		# next master for section
-		$this->assertEquals( false, $poll->getNextMasterForSection('central'), 'This cluster has no secondary master defined' );
-		$this->assertEquals( reset( array_keys( $mastersPoll['c1'] ) ), $poll->getNextMasterForSection('c1'), 'Secondary master is returned' );
+		$this->assertEquals( false, $poll->getNextMasterForSection('main-central'), 'This cluster has no secondary master defined' );
+
+		$nextMaster = $poll->getNextMasterForSection( 'main-c1' );
+		$mastersPollForC1 = array_keys( $mastersPoll['c1'] );
+
+		$this->assertEquals( reset( $mastersPollForC1 ), $nextMaster['hostName'], 'Secondary master is returned' );
 	}
 }


### PR DESCRIPTION
Add support for the following structure in DB config:

```
    'cluster-id' => array(
        'masters' => [
            'db-a1' => 1,
            'db-a2' => 1,
        ],
        'slaves' => [
            'db-a3' => 1,
            'db-a4' => 1,
        ]
    ),
```

@Wikia/platform-team / @drozdo 
