### PR TITLE
CE-993 Main page title area on some wikias sometimes gets messed up

### DIFF
--- a/extensions/wikia/Forum/ForumController.class.php
+++ b/extensions/wikia/Forum/ForumController.class.php
@@ -9,7 +9,21 @@ class ForumController extends WallBaseController {
 	}
 
 	public function init() {
-		$this->response->addAsset( 'extensions/wikia/Forum/css/Forum.scss' );
+		/**
+		 * Include Forum.scss only if the method is called
+		 * from a page in one of the Forum namespaces.
+		 */
+		$iNS = $this->wg->Title->getNamespace();
+		$aForumNamespaces = array(
+				NS_WIKIA_FORUM_BOARD,
+				NS_WIKIA_FORUM_TOPIC_BOARD,
+				NS_WIKIA_FORUM_BOARD_THREAD,
+				NS_FORUM,
+				NS_FORUM_TALK,
+		);
+		if ( in_array( $iNS, $aForumNamespaces ) ) {
+			$this->response->addAsset( 'extensions/wikia/Forum/css/Forum.scss' );
+		}
 	}
 
 	public function board() {

--- a/extensions/wikia/Forum/ForumController.class.php
+++ b/extensions/wikia/Forum/ForumController.class.php
@@ -10,18 +10,10 @@ class ForumController extends WallBaseController {
 
 	public function init() {
 		/**
-		 * Include Forum.scss only if the method is called
-		 * from a page in one of the Forum namespaces.
+		 * Include Forum.scss only if
+		 * the method is called in a Forum context
 		 */
-		$iNS = $this->wg->Title->getNamespace();
-		$aForumNamespaces = array(
-				NS_WIKIA_FORUM_BOARD,
-				NS_WIKIA_FORUM_TOPIC_BOARD,
-				NS_WIKIA_FORUM_BOARD_THREAD,
-				NS_FORUM,
-				NS_FORUM_TALK,
-		);
-		if ( in_array( $iNS, $aForumNamespaces ) ) {
+		if ( ForumHelper::isForum() ) {
 			$this->response->addAsset( 'extensions/wikia/Forum/css/Forum.scss' );
 		}
 	}


### PR DESCRIPTION
The issue was happening when the "Latest Forum Activity" widget was used and it caused invalid inclusion of Forum.scss. Now it is only used when the init method is called from a Forum context.
