### PR TITLE
Http::request - log the value of "X-Backend-Response-Time" header (release-241)

### DIFF
--- a/includes/HttpFunctions.php
+++ b/includes/HttpFunctions.php
@@ -71,13 +71,16 @@ class Http {
 		if ( class_exists( 'Wikia\\Logger\\WikiaLogger' ) && ( !$isOk || false === strpos( $caller, 'Phalanx' ) ) ) {
 
 			$requestTime = (int)( ( microtime( true ) - $requestTime ) * 1000.0 );
+			$backendTime = $req->getResponseHeader('x-backend-response-time') ?: 0;
+
 			$params = [
 				'statusCode' => $req->getStatus(),
 				'reqMethod' => $method,
 				'reqUrl' => $url,
 				'caller' => $caller,
 				'isOk' => $isOk,
-				'requestTimeMS' => $requestTime
+				'requestTimeMS' => $requestTime,
+				'backendTimeMS' => intval( 1000 * $backendTime),
 			];
 			if ( !$isOk ) {
 				$params[ 'statusMessage' ] = $status->getMessage();


### PR DESCRIPTION
@Wikia/platform-team 

See #4632
