### PR TITLE
Generate and pass request ID to internal HTTP requests	

### DIFF
--- a/includes/HttpFunctions.php
+++ b/includes/HttpFunctions.php
@@ -53,6 +53,11 @@ class Http {
 				$req->setHeader( $name, $value );
 			}
 		}
+
+		// @author macbre
+		// pass Request ID to internal requests
+		$req->setHeader( Wikia\Util\RequestId::REQUEST_HEADER_NAME, Wikia\Util\RequestId::instance()->getRequestId() );
+
 		// Wikia change - end
 		if( isset( $options['userAgent'] ) ) {
 			$req->setUserAgent( $options['userAgent'] );

--- a/lib/Wikia/src/Logger/Hooks.php
+++ b/lib/Wikia/src/Logger/Hooks.php
@@ -145,7 +145,7 @@ class Hooks {
 			}
 		}
 
-		$fields['unique_id'] = RequestId::instance()->getRequestId();
+		$fields['request_id'] = RequestId::instance()->getRequestId();
 
 		WikiaLogger::instance()->pushContext( $fields, WebProcessor::RECORD_TYPE_FIELDS );
 

--- a/lib/Wikia/src/Logger/Hooks.php
+++ b/lib/Wikia/src/Logger/Hooks.php
@@ -7,6 +7,8 @@
 
 namespace Wikia\Logger;
 
+use Wikia\Util\RequestId;
+
 class Hooks {
 
 	/**
@@ -141,11 +143,9 @@ class Hooks {
 			if ( isset( $_SERVER['HTTP_REFERER'] ) ) {
 				$fields['referrer'] = $_SERVER['HTTP_REFERER'];
 			}
-
-			if ( isset( $_SERVER['UNIQUE_ID'] ) ) {
-				$fields['unique_id'] = $_SERVER['UNIQUE_ID'];
-			}
 		}
+
+		$fields['unique_id'] = RequestId::instance()->getRequestId();
 
 		WikiaLogger::instance()->pushContext( $fields, WebProcessor::RECORD_TYPE_FIELDS );
 

--- a/lib/Wikia/src/Util/RequestId.php
+++ b/lib/Wikia/src/Util/RequestId.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * Generate unique request ID or use the value when passed as HTTP request header
+ *
+ * Usage:
+ *
+ * Wikia\Util\RequestId::instance()->getRequestId()
+ *
+ * @see PLATFORM-362
+ */
+
+namespace Wikia\Util;
+
+class RequestId {
+
+	const REQUEST_HEADER_NAME = 'X-Request-Id';
+	private $requestId = false;
+
+	/**
+	 * @return self
+	 */
+	public static function instance() {
+		static $instance = null;
+
+		if (!isset($instance)) {
+			$instance = new self();
+		}
+
+		return $instance;
+	}
+
+	/*
+	 * Return unique request ID. Either:
+	 *
+	 * - get it from HTTP request header
+	 * - generate a new one
+	 *
+	 * @return string unique ID
+	 */
+	function getRequestId() {
+		// request ID is already generated
+		if ($this->requestId !== false) {
+			return $this->requestId;
+		}
+
+		// try to get the value from request header
+		$req = \F::app()->wg->Request;
+		$headerValue = !empty($req) ? $req->getHeader(self::REQUEST_HEADER_NAME) : false;
+
+		if (self::isValidId($headerValue)) {
+			$this->requestId = $headerValue;
+			wfDebug( __METHOD__ . ": from HTTP request\n" );
+		}
+		else {
+			// return 23 characters long unique ID + mw prefix
+			// e.g. mw5405bb3d129e76.46189257
+			$this->requestId = uniqid('mw', true);
+			wfDebug( __METHOD__ . ": generated a new one\n" );
+		}
+
+		wfDebug( __METHOD__ . ": {$this->requestId}\n" );
+		return $this->requestId;
+	}
+
+	/**
+	 * Validate provided request ID
+	 *
+	 * @param $id
+	 * @return bool
+	 */
+	public static function isValidId($id) {
+		return is_string($id) &&
+			strlen($id) === 25 &&
+			startsWith($id, 'mw');
+	}
+}

--- a/lib/Wikia/src/Util/RequestId.php
+++ b/lib/Wikia/src/Util/RequestId.php
@@ -23,7 +23,7 @@ class RequestId {
 	public static function instance() {
 		static $instance = null;
 
-		if (!isset($instance)) {
+		if ( !isset( $instance ) ) {
 			$instance = new self();
 		}
 
@@ -40,22 +40,23 @@ class RequestId {
 	 */
 	function getRequestId() {
 		// request ID is already generated
-		if ($this->requestId !== false) {
+		if ( $this->requestId !== false ) {
 			return $this->requestId;
 		}
 
 		// try to get the value from request header
-		$req = \F::app()->wg->Request;
-		$headerValue = !empty($req) ? $req->getHeader(self::REQUEST_HEADER_NAME) : false;
+		// we can't simply use $wgRequest as it's not yet set at this point
+		// this method is called on WikiFactoryExecuteComplete hook
+		$headerValue = !empty( $_SERVER['HTTP_X_REQUEST_ID'] ) ? $_SERVER['HTTP_X_REQUEST_ID'] : false;
 
-		if (self::isValidId($headerValue)) {
+		if ( self::isValidId( $headerValue ) ) {
 			$this->requestId = $headerValue;
 			wfDebug( __METHOD__ . ": from HTTP request\n" );
 		}
 		else {
 			// return 23 characters long unique ID + mw prefix
 			// e.g. mw5405bb3d129e76.46189257
-			$this->requestId = uniqid('mw', true);
+			$this->requestId = uniqid( 'mw', true );
 			wfDebug( __METHOD__ . ": generated a new one\n" );
 		}
 
@@ -69,9 +70,9 @@ class RequestId {
 	 * @param $id
 	 * @return bool
 	 */
-	public static function isValidId($id) {
-		return is_string($id) &&
-			strlen($id) === 25 &&
-			startsWith($id, 'mw');
+	public static function isValidId( $id ) {
+		return is_string( $id ) &&
+			strlen( $id ) === 25 &&
+			startsWith( $id, 'mw' );
 	}
 }

--- a/lib/Wikia/tests/Util/RequestIdTest.php
+++ b/lib/Wikia/tests/Util/RequestIdTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use Wikia\Util\RequestId;
+
+/**
+ * Tests RequestId class
+ */
+class RequestIdTest extends WikiaBaseTest {
+
+	/**
+	 * @dataProvider isValidIdData
+	 */
+	function testIsValidId($id, $isValid) {
+		$this->assertEquals( $isValid, RequestId::isValidId($id) );
+	}
+
+	function isValidIdData() {
+		return [
+			[
+				'id' => 123,
+				'valid' => false,
+			],
+			[
+				'id' => '123',
+				'valid' => false,
+			],
+			[
+				'id' => 'mw5405bb3c76f364.47661604',
+				'valid' => true,
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider getRequestIdFromHeaderData
+	 */
+	function testGetRequestIdFromHeader($headerValue, $isUsed) {
+		$req = new FauxRequest();
+		$req->setHeader(RequestId::REQUEST_HEADER_NAME, $headerValue);
+		$this->mockGlobalVariable('wgRequest', $req);
+
+		$requestId = (new RequestId())->getRequestId();
+
+		if ($isUsed) {
+			$this->assertEquals($headerValue, $requestId);
+		}
+		else {
+			$this->assertNotEquals('foo', $requestId);
+		}
+	}
+
+	function getRequestIdFromHeaderData() {
+		return [
+			[
+				'headerValue' => false,
+				'isUsed' => false,
+			],
+			[
+				'headerValue' => 'foo',
+				'isUsed' => false,
+			],
+			[
+				'headerValue' => 'mw5405bb3d129e76.46189257',
+				'isUsed' => true,
+			],
+		];
+	}
+
+	function testSingleton() {
+		$instance = RequestId::instance();
+		$this->assertEquals($instance->getRequestId(), $instance->getRequestId(), 'ID should be the same for the same instance');
+
+		$this->assertNotEquals((new RequestId())->getRequestId(), (new RequestId())->getRequestId(), 'ID should be different for different instances');
+	}
+
+}

--- a/lib/Wikia/tests/Util/RequestIdTest.php
+++ b/lib/Wikia/tests/Util/RequestIdTest.php
@@ -7,11 +7,23 @@ use Wikia\Util\RequestId;
  */
 class RequestIdTest extends WikiaBaseTest {
 
+	private $serverOriginal;
+
+	function setUp() {
+		parent::setUp();
+		$this->serverOriginal = $_SERVER;
+	}
+
+	function tearDown() {
+		parent::tearDown();
+		$_SERVER = $this->serverOriginal;
+	}
+
 	/**
 	 * @dataProvider isValidIdData
 	 */
-	function testIsValidId($id, $isValid) {
-		$this->assertEquals( $isValid, RequestId::isValidId($id) );
+	function testIsValidId( $id, $isValid ) {
+		$this->assertEquals( $isValid, RequestId::isValidId( $id ) );
 	}
 
 	function isValidIdData() {
@@ -34,18 +46,18 @@ class RequestIdTest extends WikiaBaseTest {
 	/**
 	 * @dataProvider getRequestIdFromHeaderData
 	 */
-	function testGetRequestIdFromHeader($headerValue, $isUsed) {
-		$req = new FauxRequest();
-		$req->setHeader(RequestId::REQUEST_HEADER_NAME, $headerValue);
-		$this->mockGlobalVariable('wgRequest', $req);
+	function testGetRequestIdFromHeader( $headerValue, $isUsed ) {
+		if ( !empty( $headerValue ) ) {
+			$_SERVER['HTTP_X_REQUEST_ID'] = $headerValue;
+		}
 
-		$requestId = (new RequestId())->getRequestId();
+		$requestId = ( new RequestId() )->getRequestId();
 
-		if ($isUsed) {
-			$this->assertEquals($headerValue, $requestId);
+		if ( $isUsed ) {
+			$this->assertEquals( $headerValue, $requestId );
 		}
 		else {
-			$this->assertNotEquals('foo', $requestId);
+			$this->assertNotEquals( 'foo', $requestId );
 		}
 	}
 
@@ -68,9 +80,9 @@ class RequestIdTest extends WikiaBaseTest {
 
 	function testSingleton() {
 		$instance = RequestId::instance();
-		$this->assertEquals($instance->getRequestId(), $instance->getRequestId(), 'ID should be the same for the same instance');
+		$this->assertEquals( $instance->getRequestId(), $instance->getRequestId(), 'ID should be the same for the same instance' );
 
-		$this->assertNotEquals((new RequestId())->getRequestId(), (new RequestId())->getRequestId(), 'ID should be different for different instances');
+		$this->assertNotEquals( ( new RequestId() )->getRequestId(), ( new RequestId() )->getRequestId(), 'ID should be different for different instances' );
 	}
 
 }


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-362
- generate unique id for each MW request
- report it to Logstash as `@context.request_id` field
- pass it to internal HTTP requests via `X-Request-Id` request header

@Wikia/platform-team 
