### PR TITLE
Http: log all requests

### DIFF
--- a/extensions/wikia/SharedHelp/SharedHelp.php
+++ b/extensions/wikia/SharedHelp/SharedHelp.php
@@ -43,6 +43,7 @@ class SharedHttp {
 		return self::request( "POST", $url, $timeout );
 	}
 
+	// TODO: use MediaWiki's HTTP class
 	static function request( $method, $url, $timeout = 'default' ) {
 		global $wgHTTPTimeout, $wgVersion, $wgTitle, $wgDevelEnvironment;
 		wfProfileIn(__METHOD__);
@@ -85,10 +86,24 @@ class SharedHttp {
 				curl_setopt( $c, CURLOPT_REFERER, $wgTitle->getFullURL() );
 			}
 
+			$requestTime = microtime( true );
+
 			ob_start();
 			curl_exec( $c );
 			$text = ob_get_contents();
 			ob_end_clean();
+
+			// log HTTP requests
+			$requestTime = (int)( ( microtime( true ) - $requestTime ) * 1000.0 );
+
+			$params = [
+				'statusCode' => curl_getinfo( $c, CURLINFO_HTTP_CODE ),
+				'reqMethod' => $method,
+				'reqUrl' => $url,
+				'caller' => __CLASS__,
+				'requestTimeMS' => $requestTime
+			];
+			\Wikia\Logger\WikiaLogger::instance()->debug( 'Http request' , $params );
 
 			# Don't return the text of error messages, return false on error
 			if ( ( curl_getinfo( $c, CURLINFO_HTTP_CODE ) != 200 ) && ( curl_getinfo( $c, CURLINFO_HTTP_CODE ) != 301 ) ) {

--- a/includes/HttpFunctions.php
+++ b/includes/HttpFunctions.php
@@ -70,10 +70,10 @@ class Http {
 		$status = $req->execute();
 
 		// Wikia change - @author: mech - begin
-		// log all the requests we make (except valid Phalanx calls, as we have a lot of them)
-		$caller =  wfGetCallerClassMethod( [ __CLASS__, 'Hooks', 'ApiService' ] );
+		// log all the requests we make
+		$caller =  wfGetCallerClassMethod( [ __CLASS__, 'Hooks', 'ApiService', 'Solarium_Client', 'Solarium_Client_Adapter_Curl' ] );
 		$isOk = $status->isOK();
-		if ( class_exists( 'Wikia\\Logger\\WikiaLogger' ) && ( !$isOk || false === strpos( $caller, 'Phalanx' ) ) ) {
+		if ( class_exists( 'Wikia\\Logger\\WikiaLogger' ) ) {
 
 			$requestTime = (int)( ( microtime( true ) - $requestTime ) * 1000.0 );
 			$backendTime = $req->getResponseHeader('x-backend-response-time') ?: 0;


### PR DESCRIPTION
@Wikia/platform-team 

http://graph-s3/grafana/#/dashboard/db/Services

Log all HTTP requests sent from MediaWiki. We're logging 500k+ requests each hour, should be much more after this change.
