### PR TITLE
VE-1443: Added temporary, extra logging to investigate a bug

### DIFF
--- a/includes/wikia/tasks/Tasks/ParsoidCacheUpdateTask.class.php
+++ b/includes/wikia/tasks/Tasks/ParsoidCacheUpdateTask.class.php
@@ -137,13 +137,13 @@ class ParsoidCacheUpdateTask extends BaseTask {
 
 	private function wikiaLog( $data ) {
 		global $wgEnableVisualEditorUI;
-		if ( empty ( $data ) ) {
+		if ( !is_array ( $data ) ) {
 			$data = array();
 		}
-		if ( !isset( $wgEnableVisualEditorUI ) ) {
-			$data['wgEnableVisualEditorUI'] = 'notset';
-		} else {
+		if ( isset( $wgEnableVisualEditorUI ) ) {
 			$data['wgEnableVisualEditorUI'] = $wgEnableVisualEditorUI;
+		} else {
+			$data['wgEnableVisualEditorUI'] = 'notset';
 		}
 		WikiaLogger::instance()->debug( "ParsoidCacheUpdateTask", $data );
 	}

--- a/includes/wikia/tasks/Tasks/ParsoidCacheUpdateTask.class.php
+++ b/includes/wikia/tasks/Tasks/ParsoidCacheUpdateTask.class.php
@@ -136,6 +136,15 @@ class ParsoidCacheUpdateTask extends BaseTask {
 	}
 
 	private function wikiaLog( $data ) {
+		global $wgEnableVisualEditorUI;
+		if ( empty ( $data ) ) {
+			$data = array();
+		}
+		if ( !isset( $wgEnableVisualEditorUI ) ) {
+			$data['wgEnableVisualEditorUI'] = 'notset';
+		} else {
+			$data['wgEnableVisualEditorUI'] = $wgEnableVisualEditorUI;
+		}
 		WikiaLogger::instance()->debug( "ParsoidCacheUpdateTask", $data );
 	}
 }


### PR DESCRIPTION
I have a suspicion that sometimes there is an attempt to execute ParsoidCacheUpdateTask task while $wgEnableVisualEditorUI is not set to true. That shouldn't be the case - this change will help to confirm if it is.
