### PR TITLE
PLATFORM-204: update city_last_timestamp on edit

### DIFF
--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -30,6 +30,7 @@ if ( ! function_exists( "wfUnserializeHandler" ) ) {
  * define hooks for WikiFactory here
  */
 $wgHooks[ "ArticleSaveComplete" ][] = "WikiFactory::updateCityDescription";
+$wgHooks[ "ArticleSaveComplete" ][] = "WikiFactory::updateCityTimestamp";
 
 class WikiFactoryDuplicateWgServer extends Exception {
 	public $city_id, $city_url, $duplicate_city_id;
@@ -2847,6 +2848,20 @@ class WikiFactory {
 				__METHOD__
 			);
 		}
+
+		return true;
+	}
+
+	static public function updateCityTimestamp( &$article, &$user ) {
+		global $wgCityId;
+
+		$db = WikiFactory::db( DB_MASTER );
+			$db->update(
+				"city_list",
+				array( "city_last_timestamp" => wfTimestamp( TS_DB ) ),
+				array( "city_id" => $wgCityId ),
+				__METHOD__
+			);
 
 		return true;
 	}


### PR DESCRIPTION
city_last_timestamp is not being updated by the app on article edit, it probably should be.  

This definitely needs review because there are some back end processes that also update this field, and it may be that we want to do this offline.  

@lgarczewski  @macbre  @michalroszka 
