### PR TITLE
Open graph meta performance

### DIFF
--- a/extensions/wikia/OpenGraphMetaCustomizations/OpenGraphMetaCustomizations.setup.php
+++ b/extensions/wikia/OpenGraphMetaCustomizations/OpenGraphMetaCustomizations.setup.php
@@ -33,7 +33,7 @@ function egOgmcParserAfterTidy( Parser $parser, &$text ) {
 
 /**
  * Now that the page is far enough along, use ArticleService to set
- * the escription on the OuptutPage.  This value will then
+ * the description on the OuptutPage.  This value will then
  * be used by the OpenGraphMeta extension.
  */
 $wgParserOutputHooks['applyOpenGraphMetaCustomizations'] = 'egOgmcParserOutputApplyValues';


### PR DESCRIPTION
@Wikia/platform-team / @jacekjursza 

While going through data from profilers I found that `egOgmcParserOutputApplyValues` function (from 2011) takes 5-6% of response generation time (on each hit to the backend!). It was:
- making incorrect calls to `ImageServing` (passing a single article ID instead of an array)
- taking archived version of wiki wordmark, instead of using a const from `ThemeSettings` class - which resulted in a DB query to Wikia's video shared repository (and to wikicities to get the shared video repo information).

Then it turned out that the result of `egOgmcParserOutputApplyValues` function is override by SeoTweaks hook added in 2013.

5% of request time well spent :)

This change:
- simplifies `egOgmcParserOutputApplyValues` to render just the `og:description` meta tag (now it takes just 0,7-0,8% of total request time)
- adds profiling around the function
