### PR TITLE
(CE-1030) Add support for "stay logged in" to RestrictSessions

### DIFF
--- a/extensions/wikia/RestrictSessions/RestrictSessionsHooks.class.php
+++ b/extensions/wikia/RestrictSessions/RestrictSessionsHooks.class.php
@@ -55,23 +55,41 @@ class RestrictSessionsHooks extends \ContextSource {
 			return true;
 		}
 
-		$restrictSession = false;
+		$cookieUser = User::newFromId( $cookieUserId );
 
-		if ( $cookieUserId === $sessionUserId ) {
-			$restrictSession = User::newFromId( $cookieUserId )->isAllowed( 'restrictsession' );
-		} else {
-			// Check both cookie and session for the user because the user
-			// can be loaded from both
-			$cookieUser = User::newFromId( $cookieUserId );
-			$sessionUser = User::newFromId( $sessionUserId );
+		if ( $cookieUser->isAnon() ) {
+			// Don't load a staff session from just a session cookie.
+			if ( $sessionUserId !== null ) {
+				$sessionUser = User::newFromId( $sessionUserId );
+				if ( $sessionUser->isAllowed( 'restrictsession' ) ) {
+					$result = false;
+				}
+			}
 
-			$restrictSession = $cookieUser->isAllowed( 'restrictsession' )
-				|| $sessionUser->isAllowed( 'restrictsession' );
+			return true;
+		} elseif ( $sessionUserId !== null && $cookieUserId != $sessionUserId ) {
+			$result = false;
+			return true;
 		}
 
+		$restrictSession = $cookieUser->isAllowed( 'restrictsession' );
+
 		if ( $restrictSession ) {
-			$ipAddr = $request->getSessionData( self::IP_SESSION_KEY );
 			$reqIp = $request->getIP();
+			$cookieToken = $request->getCookie( 'Token' );
+
+			if ( $sessionUserId === null && $cookieToken !== null ) {
+				// If the user has opted to remember their login, check the token
+				// and update session data
+				$token = rtrim( $cookieUser->getToken( false ) );
+				if ( $restrictSession && strlen ( $token )
+					&& \hash_equals( $token, $cookieToken )
+				) {
+					$request->setSessionData( self::IP_SESSION_KEY, $reqIp );
+				}
+			}
+
+			$ipAddr = $request->getSessionData( self::IP_SESSION_KEY );
 
 			if ( $reqIp !== $ipAddr && !$this->isWhiteListedIP( $reqIp ) ) {
 				$result = false;

--- a/extensions/wikia/RestrictSessions/tests/RestrictSessionsTest.php
+++ b/extensions/wikia/RestrictSessions/tests/RestrictSessionsTest.php
@@ -12,7 +12,12 @@ class RestrictSessionsTest extends \WikiaBaseTest {
 	}
 
 	public function testUserSetCookiesIsStaff() {
-		$userMock = $this->getUserMock( true );
+		$userMock = $this->getMock( '\User', [ 'isAllowed' ] );
+
+		$userMock->expects( $this->once() )
+			->method( 'isAllowed' )
+			->with( 'restrictsession' )
+			->will( $this->returnValue( true ) );
 
 		$requestMock = $this->getMock( '\WebRequest', [ 'getIP' ] );
 
@@ -34,7 +39,12 @@ class RestrictSessionsTest extends \WikiaBaseTest {
 	}
 
 	public function testUserSetCookiesNotStaff() {
-		$userMock = $this->getUserMock( false );
+		$userMock = $this->getMock( '\User', [ 'isAllowed' ] );
+
+		$userMock->expects( $this->once() )
+			->method( 'isAllowed' )
+			->with( 'restrictsession' )
+			->will( $this->returnValue( false ) );
 
 		$requestMock = $this->getMock( '\WebRequest', [ 'getIP' ] );
 
@@ -52,7 +62,7 @@ class RestrictSessionsTest extends \WikiaBaseTest {
 	}
 
 	public function testUserLoadFromSessionIsStaffAndIPMatches() {
-		$userMock = $this->getUserMock( true );
+		$userMock = $this->getUserMock( true, false );
 
 		$requestMock = $this->getMock( '\WebRequest', [ 'getIP', 'getCookie', 'getSessionData' ] );
 
@@ -60,10 +70,14 @@ class RestrictSessionsTest extends \WikiaBaseTest {
 			->method( 'getIP' )
 			->will( $this->returnValue( '127.0.0.1' ) );
 
-		$requestMock->expects( $this->once() )
+		$requestMock->expects( $this->any() )
 			->method( 'getCookie' )
-			->with( 'UserID' )
-			->will( $this->returnValue( 1234 ) );
+			->will( $this->returnValueMap(
+				[
+					[ 'UserID', null, null, 1234 ],
+					[ 'Token', null, null, null ],
+				]
+			) );
 
 		$requestMock->expects( $this->any() )
 			->method( 'getSessionData' )
@@ -84,7 +98,7 @@ class RestrictSessionsTest extends \WikiaBaseTest {
 	}
 
 	public function testUserLoadFromSessionIsStaffAndIPDoesNotMatch() {
-		$userMock = $this->getUserMock( true );
+		$userMock = $this->getUserMock( true, false );
 
 		$requestMock = $this->getMock( '\WebRequest', [ 'getIP', 'getCookie', 'getSessionData' ] );
 
@@ -92,10 +106,14 @@ class RestrictSessionsTest extends \WikiaBaseTest {
 			->method( 'getIP' )
 			->will( $this->returnValue( '127.0.0.1' ) );
 
-		$requestMock->expects( $this->once() )
+		$requestMock->expects( $this->any() )
 			->method( 'getCookie' )
-			->with( 'UserID' )
-			->will( $this->returnValue( 1234 ) );
+			->will( $this->returnValueMap(
+				[
+					[ 'UserID', null, null, 1234 ],
+					[ 'Token', null, null, null ],
+				]
+			) );
 
 		$requestMock->expects( $this->any() )
 			->method( 'getSessionData' )
@@ -116,18 +134,23 @@ class RestrictSessionsTest extends \WikiaBaseTest {
 	}
 
 	public function testUserLoadFromSessionIsStaffAndIPNotInSession() {
-		$userMock = $this->getUserMock( true );
+		$userMock = $this->getUserMock( true, false );
 
-		$requestMock = $this->getMock( '\WebRequest', [ 'getIP', 'getCookie', 'getSessionData' ] );
+		$requestMock = $this->getMock( '\WebRequest', [ 'getIP', 'getCookie',
+			'getSessionData', 'setSessionData' ] );
 
 		$requestMock->expects( $this->once() )
 			->method( 'getIP' )
 			->will( $this->returnValue( '127.0.0.1' ) );
 
-		$requestMock->expects( $this->once() )
+		$requestMock->expects( $this->any() )
 			->method( 'getCookie' )
-			->with( 'UserID' )
-			->will( $this->returnValue( 1234 ) );
+			->will( $this->returnValueMap(
+				[
+					[ 'UserID', null, null, 1234 ],
+					[ 'Token', null, null, null ],
+				]
+			) );
 
 		$requestMock->expects( $this->any() )
 			->method( 'getSessionData' )
@@ -137,6 +160,105 @@ class RestrictSessionsTest extends \WikiaBaseTest {
 					[ RestrictSessionsHooks::IP_SESSION_KEY, null ]
 				]
 			) );
+
+		$requestMock->expects( $this->never() )
+			->method( 'setSessionData' );
+
+		$restrictSessionsMock = $this->getRestrictSessionsMock( $requestMock );
+
+		$result = null;
+
+		$restrictSessionsMock->onUserLoadFromSession( $userMock, $result );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test that if a staff member has checked "stay logged in" and has a valid
+	 * token cookie, that the session successfully loads and the IP session data
+	 * is set.
+	 */
+	public function testUserLoadFromSessionIsStaffAndLogInRemembered() {
+		$userMock = $this->getUserMock( true, false, 'sometokenstring' );
+
+		$requestMock = $this->getMock( '\WebRequest', [ 'getIP', 'getCookie',
+			'getSessionData', 'setSessionData' ] );
+
+		$requestMock->expects( $this->once() )
+			->method( 'getIP' )
+			->will( $this->returnValue( '127.0.0.1' ) );
+
+		$requestMock->expects( $this->any() )
+			->method( 'getCookie' )
+			->will( $this->returnValueMap(
+				[
+					[ 'UserID', null, null, 1234 ],
+					[ 'Token', null, null, 'sometokenstring' ],
+				]
+			) );
+
+		$sessionData = [];
+
+		$requestMock->expects( $this->any() )
+			->method( 'getSessionData' )
+			->will( $this->returnCallback( function ( $sessionKey ) use ( &$sessionData ) {
+				if ( $sessionKey === 'wsUserID' ) {
+					return null;
+				} elseif ( $sessionKey === RestrictSessionsHooks::IP_SESSION_KEY ) {
+					return $sessionData[RestrictSessionsHooks::IP_SESSION_KEY];
+				}
+			} ) );
+
+		$requestMock->expects( $this->once() )
+			->method( 'setSessionData' )
+			->with( RestrictSessionsHooks::IP_SESSION_KEY, '127.0.0.1' )
+			->will( $this->returnCallback( function ( $sessionKey, $sessionValue ) use ( &$sessionData ) {
+				$sessionData[$sessionKey] = $sessionValue;
+			} ) );
+
+		$restrictSessionsMock = $this->getRestrictSessionsMock( $requestMock );
+
+		$result = null;
+
+		$restrictSessionsMock->onUserLoadFromSession( $userMock, $result );
+
+		$this->assertTrue( $result === null );
+	}
+
+	/**
+	 * Test that if a staff member has checked "stay logged in" but has an invalid
+	 * token cookie, that the session fails to load.
+	 */
+	public function testUserLoadFromSessionIsStaffAndLogInRememberedInvalidToken() {
+		$userMock = $this->getUserMock( true, false, 'sometokenstring' );
+
+		$requestMock = $this->getMock( '\WebRequest', [ 'getIP', 'getCookie',
+			'getSessionData', 'setSessionData' ] );
+
+		$requestMock->expects( $this->once() )
+			->method( 'getIP' )
+			->will( $this->returnValue( '127.0.0.1' ) );
+
+		$requestMock->expects( $this->any() )
+			->method( 'getCookie' )
+			->will( $this->returnValueMap(
+				[
+					[ 'UserID', null, null, 1234 ],
+					[ 'Token', null, null, 'someothertokenstring' ],
+				]
+			) );
+
+		$requestMock->expects( $this->any() )
+			->method( 'getSessionData' )
+			->will( $this->returnValueMap(
+				[
+					[ 'wsUserID', null ],
+					[ RestrictSessionsHooks::IP_SESSION_KEY, null ]
+				]
+			) );
+
+		$requestMock->expects( $this->never() )
+			->method( 'setSessionData' );
 
 		$restrictSessionsMock = $this->getRestrictSessionsMock( $requestMock );
 
@@ -148,7 +270,7 @@ class RestrictSessionsTest extends \WikiaBaseTest {
 	}
 
 	public function testUserLoadFromSessionNotStaff() {
-		$userMock = $this->getUserMock( false );
+		$userMock = $this->getUserMock( false, false );
 
 		$requestMock = $this->getMock( '\WebRequest', [ 'getIP', 'getCookie', 'getSessionData' ] );
 
@@ -174,28 +296,23 @@ class RestrictSessionsTest extends \WikiaBaseTest {
 		$this->assertTrue( $result === null );
 	}
 
-	public function testUserLoadFromSessionCookieIsStaff() {
-		$userMock = $this->getUserMock( [ true, false ] );
+	public function testUserLoadFromSessionInvalidCookieSessionIsStaff() {
+		$userMock = $this->getUserMock( true, true );
 
 		$requestMock = $this->getMock( '\WebRequest', [ 'getIP', 'getCookie', 'getSessionData' ] );
 
-		$requestMock->expects( $this->once() )
-			->method( 'getIP' )
-			->will( $this->returnValue( '127.0.0.1' ) );
+		$requestMock->expects( $this->never() )
+			->method( 'getIP' );
 
 		$requestMock->expects( $this->once() )
 			->method( 'getCookie' )
 			->with( 'UserID' )
-			->will( $this->returnValue( 1234 ) );
+			->will( $this->returnValue( null ) );
 
-		$requestMock->expects( $this->any() )
+		$requestMock->expects( $this->once() )
 			->method( 'getSessionData' )
-			->will( $this->returnValueMap(
-				[
-					[ 'wsUserID', 2345 ],
-					[ RestrictSessionsHooks::IP_SESSION_KEY, '0.0.0.0' ]
-				]
-			) );
+			->with( 'wsUserID' )
+			->will( $this->returnValue( 1234 ) );
 
 		$restrictSessionsMock = $this->getRestrictSessionsMock( $requestMock );
 
@@ -206,28 +323,50 @@ class RestrictSessionsTest extends \WikiaBaseTest {
 		$this->assertFalse( $result );
 	}
 
-	public function testUserLoadFromSessionSessionIsStaff() {
-		$userMock = $this->getUserMock( [ false, true ] );
+	public function testUserLoadFromSessionInvalidCookieUserAndNullSession() {
+		$userMock = $this->getUserMock( false, true );
 
 		$requestMock = $this->getMock( '\WebRequest', [ 'getIP', 'getCookie', 'getSessionData' ] );
 
+		$requestMock->expects( $this->never() )
+			->method( 'getIP' );
+
 		$requestMock->expects( $this->once() )
-			->method( 'getIP' )
-			->will( $this->returnValue( '127.0.0.1' ) );
+			->method( 'getCookie' )
+			->with( 'UserID' )
+			->will( $this->returnValue( 0 ) );
+
+		$requestMock->expects( $this->once() )
+			->method( 'getSessionData' )
+			->with( 'wsUserID' )
+			->will( $this->returnValue( null ) );
+
+		$restrictSessionsMock = $this->getRestrictSessionsMock( $requestMock );
+
+		$result = null;
+
+		$restrictSessionsMock->onUserLoadFromSession( $userMock, $result );
+
+		$this->assertTrue( $result === null );
+	}
+
+	public function testUserLoadFromSessionIsStaffSessionMismatch() {
+		$userMock = $this->getUserMock( true, false );
+
+		$requestMock = $this->getMock( '\WebRequest', [ 'getIP', 'getCookie', 'getSessionData' ] );
+
+		$requestMock->expects( $this->never() )
+			->method( 'getIP' );
 
 		$requestMock->expects( $this->once() )
 			->method( 'getCookie' )
 			->with( 'UserID' )
 			->will( $this->returnValue( 1234 ) );
 
-		$requestMock->expects( $this->any() )
+		$requestMock->expects( $this->once() )
 			->method( 'getSessionData' )
-			->will( $this->returnValueMap(
-				[
-					[ 'wsUserID', 2345 ],
-					[ RestrictSessionsHooks::IP_SESSION_KEY, '0.0.0.0' ]
-				]
-			) );
+			->with( 'wsUserID' )
+			->will( $this->returnValue( 2345 ) );
 
 		$restrictSessionsMock = $this->getRestrictSessionsMock( $requestMock );
 
@@ -239,7 +378,7 @@ class RestrictSessionsTest extends \WikiaBaseTest {
 	}
 
 	public function testUserLoadFromSessionIsStaffAndIPWhitelisted() {
-		$userMock = $this->getUserMock( true );
+		$userMock = $this->getUserMock( true, false );
 
 		$requestMock = $this->getMock( '\WebRequest', [ 'getIP', 'getCookie', 'getSessionData' ] );
 
@@ -247,10 +386,14 @@ class RestrictSessionsTest extends \WikiaBaseTest {
 			->method( 'getIP' )
 			->will( $this->returnValue( '127.0.0.1' ) );
 
-		$requestMock->expects( $this->once() )
+		$requestMock->expects( $this->any() )
 			->method( 'getCookie' )
-			->with( 'UserID' )
-			->will( $this->returnValue( 1234 ) );
+			->will( $this->returnValueMap(
+				[
+					[ 'UserID', null, null, 1234 ],
+					[ 'Token', null, null, null ],
+				]
+			) );
 
 		$requestMock->expects( $this->any() )
 			->method( 'getSessionData' )
@@ -273,7 +416,7 @@ class RestrictSessionsTest extends \WikiaBaseTest {
 	}
 
 	public function testUserLoadFromSessionIsStaffAndIPNotWhitelisted() {
-		$userMock = $this->getUserMock( true );
+		$userMock = $this->getUserMock( true, false );
 
 		$requestMock = $this->getMock( '\WebRequest', [ 'getIP', 'getCookie', 'getSessionData' ] );
 
@@ -281,10 +424,14 @@ class RestrictSessionsTest extends \WikiaBaseTest {
 			->method( 'getIP' )
 			->will( $this->returnValue( '127.0.0.1' ) );
 
-		$requestMock->expects( $this->once() )
+		$requestMock->expects( $this->any() )
 			->method( 'getCookie' )
-			->with( 'UserID' )
-			->will( $this->returnValue( 1234 ) );
+			->will( $this->returnValueMap(
+				[
+					[ 'UserID', null, null, 1234 ],
+					[ 'Token', null, null, null ],
+				]
+			) );
 
 		$requestMock->expects( $this->any() )
 			->method( 'getSessionData' )
@@ -307,7 +454,12 @@ class RestrictSessionsTest extends \WikiaBaseTest {
 	}
 
 	public function testUserLogoutIsStaff() {
-		$userMock = $this->getUserMock( true );
+		$userMock = $this->getMock( '\User', [ 'isAllowed' ] );
+
+		$userMock->expects( $this->once() )
+			->method( 'isAllowed' )
+			->with( 'restrictsession' )
+			->will( $this->returnValue( true ) );
 
 		$requestMock = $this->getMock( '\WebRequest', [ 'setSessionData' ] );
 
@@ -321,7 +473,12 @@ class RestrictSessionsTest extends \WikiaBaseTest {
 	}
 
 	public function testUserLogoutIsNotStaff() {
-		$userMock = $this->getUserMock( false );
+		$userMock = $this->getMock( '\User', [ 'isAllowed' ] );
+
+		$userMock->expects( $this->once() )
+			->method( 'isAllowed' )
+			->with( 'restrictsession' )
+			->will( $this->returnValue( false ) );
 
 		$requestMock = $this->getMock( '\WebRequest', [ 'setSessionData' ] );
 
@@ -358,8 +515,12 @@ class RestrictSessionsTest extends \WikiaBaseTest {
 		];
 	}
 
-	private function getUserMock( $isAllowedResult ) {
-		$userMock = $this->getMock( '\User', [ 'isAllowed' ] );
+	private function getUserMock( $isAllowedResult, $isAnon, $token = false ) {
+		$userMock = $this->getMock( '\User', [ 'isAllowed', 'isAnon', 'getToken' ] );
+
+		$userMock->expects( $this->any() )
+			->method( 'isAnon' )
+			->will( $this->returnValue( $isAnon ) );
 
 		if ( is_array( $isAllowedResult ) ) {
 			$userMock->expects( $this->any() )
@@ -371,6 +532,15 @@ class RestrictSessionsTest extends \WikiaBaseTest {
 				->method( 'isAllowed' )
 				->with( 'restrictsession' )
 				->will( $this->returnValue( $isAllowedResult ) );
+		}
+
+		if ( $token === false ) {
+			$userMock->expects( $this->never() )
+				->method( 'getToken' );
+		} else {
+			$userMock->expects( $this->once() )
+				->method( 'getToken' )
+				->will( $this->returnValue( $token ) );
 		}
 
 		$this->mockClass( '\User', $userMock, 'newFromId' );

--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -76,6 +76,55 @@ if ( !function_exists( 'istainted' ) ) {
 	define( 'TC_PCRE', 1 );
 	define( 'TC_SELF', 1 );
 }
+
+/** Wikia change begin - backport hash_equals from MW 1.24 **/
+// hash_equals function only exists in PHP >= 5.6.0
+if ( !function_exists( 'hash_equals' ) ) {
+	/**
+	 * Check whether a user-provided string is equal to a fixed-length secret without
+	 * revealing bytes of the secret through timing differences.
+	 *
+	 * This timing guarantee -- that a partial match takes the same time as a complete
+	 * mismatch -- is why this function is used in some security-sensitive parts of the code.
+	 * For example, it shouldn't be possible to guess an HMAC signature one byte at a time.
+	 *
+	 * Longer explanation: http://www.emerose.com/timing-attacks-explained
+	 *
+	 * @codeCoverageIgnore
+	 * @param string $known_string Fixed-length secret to compare against
+	 * @param string $user_string User-provided string
+	 * @return bool True if the strings are the same, false otherwise
+	 */
+	function hash_equals( $known_string, $user_string ) {
+		// Strict type checking as in PHP's native implementation
+		if ( !is_string( $known_string ) ) {
+			trigger_error( 'hash_equals(): Expected known_string to be a string, ' .
+				gettype( $known_string ) . ' given', E_USER_WARNING );
+
+			return false;
+		}
+
+		if ( !is_string( $user_string ) ) {
+			trigger_error( 'hash_equals(): Expected user_string to be a string, ' .
+				gettype( $user_string ) . ' given', E_USER_WARNING );
+
+			return false;
+		}
+
+		// Note that we do one thing PHP doesn't: try to avoid leaking information about
+		// relative lengths of $known_string and $user_string, and of multiple $known_strings.
+		// However, lengths may still inevitably leak through, for example, CPU cache misses.
+		$known_string_len = strlen( $known_string );
+		$user_string_len = strlen( $user_string );
+		$result = $known_string_len ^ $user_string_len;
+		for ( $i = 0; $i < $user_string_len; $i++ ) {
+			$result |= ord( $known_string[$i % $known_string_len] ) ^ ord( $user_string[$i] );
+		}
+
+		return ( $result === 0 );
+	}
+}
+/** Wikia change -end **/
 /// @endcond
 
 /**


### PR DESCRIPTION
Adds support for the "stay logged in" login option to RestrictSessions.
This option sets a token cookie which is checked against the user's
current token to determine whether or not to restore the session data
from the cookie. This cookie is only set on the login request as part
of User::setCookies.

In this change, if the user is staff and this cookie is set and matches
the user token but the session isn't set, we set the current IP on the
session.

This change also prevents staff sessions from being restored from
just a session cookie. At present, the session can be restored from
just the session cookie, even if none of the user cookies set on
login are available.

In order to compare the cookie in a way that isn't vulnerable to timing
attacks, I backported the PHP 5.6 hash_equals function from the current
version of MediaWiki. This can also be used elsewhere if needed.

@michalroszka 
