### PR TITLE
VID-1986 Remove additional references to NS_VIDEO

### DIFF
--- a/extensions/wikia/CategorySelect/CategorySelectHelper.class.php
+++ b/extensions/wikia/CategorySelect/CategorySelectHelper.class.php
@@ -65,8 +65,8 @@ class CategorySelectHelper {
 
 			$isViewMode = in_array( $action, $viewModeActions );
 			$isEditMode = in_array( $action, $editModeActions );
-			$extraNamespacesOnView = array( NS_FILE, NS_CATEGORY, NS_VIDEO );
-			$extraNamespacesOnEdit = array( NS_FILE, NS_CATEGORY, NS_VIDEO, NS_USER, NS_SPECIAL );
+			$extraNamespacesOnView = array( NS_FILE, NS_CATEGORY );
+			$extraNamespacesOnEdit = array( NS_FILE, NS_CATEGORY, NS_USER, NS_SPECIAL );
 
 			$isEnabled = true;
 

--- a/extensions/wikia/Follow/FollowModel.class.php
+++ b/extensions/wikia/Follow/FollowModel.class.php
@@ -14,7 +14,6 @@ class FollowModel {
 		NS_MEDIAWIKI => 'wikiafollowedpages-special-heading-mediawiki',
 		NS_FORUM => 'wikiafollowedpages-special-heading-forum',
 		NS_FILE => 'wikiafollowedpages-special-heading-media',
-		NS_VIDEO => 'wikiafollowedpages-special-heading-media',
 		NS_USER_WALL => 'wikiafollowedpages-special-heading-wall',
 	];
 

--- a/extensions/wikia/GameGuides/GameGuidesSpecialSponsoredController.class.php
+++ b/extensions/wikia/GameGuides/GameGuidesSpecialSponsoredController.class.php
@@ -141,7 +141,7 @@ class GameGuidesSpecialSponsoredController extends WikiaSpecialPageController {
 					$video['wiki_name'] = $wiki->city_title;
 					$video['wiki_lang'] = $wiki->city_lang;
 
-					$title = Title::newFromText( $video['video_name'], NS_VIDEO );
+					$title = Title::newFromText( $video['video_name'], NS_FILE );
 
 					if ( !empty( $title ) && $title->exists() ) {
 						$vid = wfFindFile( $title );

--- a/extensions/wikia/MyHome/data/DataFeedProvider.php
+++ b/extensions/wikia/MyHome/data/DataFeedProvider.php
@@ -326,7 +326,6 @@ class DataFeedProvider {
 		|| ($res['ns'] == NS_TEMPLATE && $this->proxyType == self::WL)
 		|| ($res['ns'] == NS_MEDIAWIKI && $this->proxyType == self::WL)
 		|| ($res['ns'] == NS_IMAGE && $this->proxyType == self::WL)
-		|| ($res['ns'] == NS_VIDEO && $this->proxyType == self::WL)
 		|| (defined('NS_TOPLIST') && $res['ns'] == NS_TOPLIST)) {
 			$item['title'] = $res['title'];
 			$item['url'] = $title->getLocalUrl();

--- a/extensions/wikia/Oasis/tests/SharingToolbarControllerTest.php
+++ b/extensions/wikia/Oasis/tests/SharingToolbarControllerTest.php
@@ -44,9 +44,6 @@ class SharingToolbarControllerTest extends WikiaBaseTest
 			'NS_CATEGORY' => array(
 				'required' => true,
 			),
-			'NS_VIDEO' => array(
-				'required' => false,
-			),
 			'NS_BLOG_LISTING' => array(
 				'required' => false,
 			),

--- a/extensions/wikia/SharedHelp/SharedHelp.php
+++ b/extensions/wikia/SharedHelp/SharedHelp.php
@@ -272,16 +272,11 @@ function SharedHelpHook(&$out, &$text) {
 			$skipNamespaces[] = $wgContLang->getNsText(NS_CATEGORY);
 			$skipNamespaces[] = $wgContLang->getNsText(NS_IMAGE);
 			$skipNamespaces[] = $wgContLang->getNsText(NS_FILE);
-			if ( defined( 'NS_VIDEO' ) ) {
-				$skipNamespaces[] = $wgContLang->getNsText(NS_VIDEO);
-			};
+
 			$skipNamespaces[] = "Advice";
 			if ($wgLanguageCode != 'en') {
 				$skipNamespaces[] = MWNamespace::getCanonicalName(NS_CATEGORY);
 				$skipNamespaces[] = MWNamespace::getCanonicalName(NS_IMAGE);
-				if ( defined( 'NS_VIDEO' ) ) {
-					$skipNamespaces[] = MWNamespace::getCanonicalName(NS_VIDEO);
-				}
 			}
 			$skipNamespaces[] = 'Special:Search'; // Stop hard coded Search on Community Central being removed
 

--- a/extensions/wikia/VideoEmbedTool/VideoEmbedTool_setup.php
+++ b/extensions/wikia/VideoEmbedTool/VideoEmbedTool_setup.php
@@ -52,7 +52,7 @@ JSMessages::registerPackage('VideoEmbedTool', array(
  * @return bool
  */
 function VETArticleSave( $article, $user, &$text, $summary) {
-	if (NS_VIDEO == $article->mTitle->getNamespace()) {
+	if (NS_FILE == $article->mTitle->getNamespace()) {
 		$text = $article->dataline . $text;
 	}
 	return true;

--- a/extensions/wikia/VideoEmbedTool/WikiaVideoAdd_body.php
+++ b/extensions/wikia/VideoEmbedTool/WikiaVideoAdd_body.php
@@ -122,7 +122,7 @@ class WikiaVideoAddForm extends SpecialPage {
 			// sanitize all video titles
 			$this->mName = VideoFileUploader::sanitizeTitle( $this->mName );
 
-			$title = Title::makeTitleSafe( NS_VIDEO, $this->mName );
+			$title = Title::makeTitleSafe( NS_FILE, $this->mName );
 			if ( $title instanceof Title ) {
 				$permErrors = $title->getUserPermissionsErrors( 'edit', $this->getUser() );
 				$permErrorsUpload = $title->getUserPermissionsErrors( 'upload', $this->getUser() );

--- a/extensions/wikia/WikiaMobile/WikiaMobileHooks.class.php
+++ b/extensions/wikia/WikiaMobile/WikiaMobileHooks.class.php
@@ -371,7 +371,7 @@ class WikiaMobileHooks {
 
 			//get all the possible variations of the File namespace
 			//and the translation in the wiki's language
-			foreach ( array( NS_FILE, NS_IMAGE, NS_VIDEO ) as $ns ) {
+			foreach ( array( NS_FILE, NS_IMAGE ) as $ns ) {
 				$translatedNs[] = $wgContLang->getNsText( $ns );
 
 				foreach( $wgNamespaceAliases as $alias => $nsAlias ) {

--- a/includes/parser/Parser.php
+++ b/includes/parser/Parser.php
@@ -2000,7 +2000,7 @@ class Parser {
 
 			if ( $might_be_img ) { # if this is actually an invalid link
 				wfProfileIn( __METHOD__."-might_be_img" );
-				if ( ( $ns == NS_FILE || $ns == NS_VIDEO ) && $noforce ) { # but might be an image
+				if ( ( $ns == NS_FILE ) && $noforce ) { # but might be an image
 					$found = false;
 					while ( true ) {
 						# look at the next 'line' to see if we can close it there

--- a/skins/oasis/modules/BodyController.class.php
+++ b/skins/oasis/modules/BodyController.class.php
@@ -229,7 +229,7 @@ class BodyController extends WikiaController {
 
 		// Content, category and forum namespaces.  FB:1280 Added file,video,mw,template
 		if(	$wgTitle->isSubpage() && $wgTitle->getNamespace() == NS_USER ||
-			in_array($subjectNamespace, array (NS_CATEGORY, NS_CATEGORY_TALK, NS_FORUM, NS_PROJECT, NS_FILE, NS_VIDEO, NS_MEDIAWIKI, NS_TEMPLATE, NS_HELP)) ||
+			in_array($subjectNamespace, array (NS_CATEGORY, NS_CATEGORY_TALK, NS_FORUM, NS_PROJECT, NS_FILE, NS_MEDIAWIKI, NS_TEMPLATE, NS_HELP)) ||
 			in_array($subjectNamespace, $wgContentNamespaces) ||
 			array_key_exists( $subjectNamespace, $wgExtraNamespaces ) ) {
 			// add any content page related rail modules here

--- a/skins/oasis/modules/PageHeaderController.class.php
+++ b/skins/oasis/modules/PageHeaderController.class.php
@@ -242,9 +242,7 @@ class PageHeaderController extends WikiaController {
 
 		// remove namespaces prefix from title
 		$namespaces = array(NS_MEDIAWIKI, NS_TEMPLATE, NS_CATEGORY, NS_FILE);
-		if (defined('NS_VIDEO')) {
-			$namespaces[] = NS_VIDEO;
-		}
+
 		if ( in_array($ns, array_merge( $namespaces, $wgSuppressNamespacePrefix ) ) ) {
 			$this->title = $wgTitle->getText();
 			$this->displaytitle = false;
@@ -600,9 +598,7 @@ class PageHeaderController extends WikiaController {
 
 		// remove namespaces prefix from title
 		$namespaces = array(NS_MEDIAWIKI, NS_TEMPLATE, NS_CATEGORY, NS_FILE);
-		if (defined('NS_VIDEO')) {
-			$namespaces[] = NS_VIDEO;
-		}
+
 		if ( in_array($ns, array_merge( $namespaces, $wgSuppressNamespacePrefix ) ) ) {
 			$this->title = $wgTitle->getText();
 			$this->displaytitle = false;


### PR DESCRIPTION
In this PR I left all non-wikia code alone as those likely refer to the NS_VIDEO set to 400 that the Video extension defines.

I also left maintenance scripts alone as they are being cleaned up separately.
