### PR TITLE
Pla 1736 2

### DIFF
--- a/includes/wikia/api/ArticlesApiController.class.php
+++ b/includes/wikia/api/ArticlesApiController.class.php
@@ -648,6 +648,7 @@ class ArticlesApiController extends WikiaApiController {
 	 */
 	public function getDetails() {
 		wfProfileIn( __METHOD__ );
+		$this->setOutputFieldType( "items", self::OUTPUT_FIELD_TYPE_OBJECT );
 
 		//get optional params for details
 		$params = $this->getDetailsParams();

--- a/includes/wikia/api/WikisApiController.class.php
+++ b/includes/wikia/api/WikisApiController.class.php
@@ -159,6 +159,7 @@ class WikisApiController extends WikiaApiController {
 
 	public function getDetails() {
 		wfProfileIn( __METHOD__ );
+		$this->setOutputFieldType( "items", self::OUTPUT_FIELD_TYPE_OBJECT );
 		$ids = $this->request->getVal( self::PARAMETER_WIKI_IDS, null );
 		if ( !empty( $ids ) ) {
 			$ids = explode( ',', $ids );


### PR DESCRIPTION
QA note: We need to cover new use case in api tests: when there is no results in response the "item" object cannot be empty array. It must be an object "{ }"
