### PR TITLE
VE-1537: Fix problem with focusedNode

### DIFF
--- a/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaTemplateInsertDialog.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaTemplateInsertDialog.js
@@ -131,9 +131,11 @@ ve.ui.WikiaTemplateInsertDialog.prototype.insertTemplate = function () {
  * We can ask the commandRegistry for the command for the node and execute it.
  */
 ve.ui.WikiaTemplateInsertDialog.prototype.onTransact = function () {
-	ve.ui.commandRegistry.getCommandForNode(
-		this.surface.getView().getFocusedNode()
-	).execute( this.surface );
+	setTimeout( ve.bind( function() {
+		ve.ui.commandRegistry.getCommandForNode(
+			this.surface.getView().getFocusedNode()
+		).execute( this.surface );
+	}, this ), 0 );
 };
 
 /**

--- a/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaTemplateInsertDialog.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaTemplateInsertDialog.js
@@ -131,7 +131,7 @@ ve.ui.WikiaTemplateInsertDialog.prototype.insertTemplate = function () {
  * We can ask the commandRegistry for the command for the node and execute it.
  */
 ve.ui.WikiaTemplateInsertDialog.prototype.onTransact = function () {
-	setTimeout( ve.bind( function() {
+	setTimeout( ve.bind( function () {
 		ve.ui.commandRegistry.getCommandForNode(
 			this.surface.getView().getFocusedNode()
 		).execute( this.surface );


### PR DESCRIPTION
Templates are inserted "asynchronously" so focusedNode sometimes might be not yet defined when onTransact is called. Delaying it by setTimeout 0 solves the problem.
