### PR TITLE
WatchedItem: avoid select/writes for anon user in WatchedItem

### DIFF
--- a/includes/WatchedItem.php
+++ b/includes/WatchedItem.php
@@ -8,6 +8,7 @@
  * @ingroup Watchlist
  */
 class WatchedItem {
+	/* @var User $mUser */
 	var $mTitle, $mUser, $id, $ns, $ti;
 
 	/**
@@ -39,6 +40,11 @@ class WatchedItem {
 		# Pages and their talk pages are considered equivalent for watching;
 		# remember that talk namespaces are numbered as page namespace+1.
 
+		// Only loggedin user can have a watchlist
+		if ( $this->mUser->isAnon() ) {
+			return false;
+		}
+
 		$dbr = wfGetDB( DB_SLAVE );
 		$res = $dbr->select( 'watchlist', 1, array( 'wl_user' => $this->id, 'wl_namespace' => $this->ns,
 			'wl_title' => $this->ti ), __METHOD__ );
@@ -53,6 +59,13 @@ class WatchedItem {
 	 */
 	public function addWatch() {
 		wfProfileIn( __METHOD__ );
+
+		// Only loggedin user can have a watchlist
+		if ( wfReadOnly() || $this->mUser->isAnon() ) {
+			wfProfileOut( __METHOD__ );
+			return false;
+		}
+
 		$rows = array();
 
 		// Use INSERT IGNORE to avoid overwriting the notification timestamp
@@ -88,6 +101,12 @@ class WatchedItem {
 	 */
 	public function removeWatch() {
 		wfProfileIn( __METHOD__ );
+
+		// Only loggedin user can have a watchlist
+		if ( wfReadOnly() || $this->mUser->isAnon() ) {
+			wfProfileOut( __METHOD__ );
+			return false;
+		}
 
 		$success = false;
 		

--- a/includes/WatchedItem.php
+++ b/includes/WatchedItem.php
@@ -8,8 +8,10 @@
  * @ingroup Watchlist
  */
 class WatchedItem {
-	/* @var User $mUser */
-	var $mTitle, $mUser, $id, $ns, $ti;
+	/* @var Title $mTitle */
+	var $mTitle;
+	/* @var User $mUser  */
+	var $mUser, $id, $ns, $ti;
 
 	/**
 	 * Create a WatchedItem object with the given user and title
@@ -42,6 +44,11 @@ class WatchedItem {
 
 		// Only loggedin user can have a watchlist
 		if ( $this->mUser->isAnon() ) {
+			return false;
+		}
+
+		// some pages cannot be watched
+		if ( !$this->mTitle->isWatchable() ) {
 			return false;
 		}
 


### PR DESCRIPTION
@Wikia/platform-team 

https://wikia-inc.atlassian.net/browse/PLATFORM-460

This will save us several millions of queries a day

Backporting https://github.com/wikimedia/mediawiki-core/commit/21884f7537d6562a54241469f378229030b5bfa5#diff-64fe2609dd41ca7d16d8dff717036ed9R140

For a page view of a anon user the following select is executed:

``` sql
SELECT  wl_notificationtimestamp  FROM `watchlist`  WHERE wl_user = '0'
AND wl_namespace = '0' AND wl_title = 'Hauptseite'  LIMIT 1
```
