### PR TITLE
ImageServing: prevent queries by page_id = 0

### DIFF
--- a/extensions/wikia/ImageServing/imageServing.class.php
+++ b/extensions/wikia/ImageServing/imageServing.class.php
@@ -230,6 +230,7 @@ class ImageServing {
 		if( !empty( $fileNames ) ) {
 			/**
 			 * @var $fileName LocalFile
+			 * @var $title Title
 			 */
 			foreach ( $fileNames as $fileName ) {
 				if(!($fileName instanceof LocalFile)) {
@@ -240,8 +241,11 @@ class ImageServing {
 				}
 			}
 
-			$imagesIds[ $title->getArticleId() ] = $title->getDBkey();
-			$this->articles[ $title->getArticleId() ] = $title->getArticleId();
+			// do not query for page_id = 0
+			if ( $title->exists() ) {
+				$imagesIds[ $title->getArticleId() ] = $title->getDBkey();
+				$this->articles[ $title->getArticleId() ] = $title->getArticleId();
+			}
 		}
 
 		$out = $this->getImages(1);


### PR DESCRIPTION
@Wikia/platform-team 

Avoid the following queries:

``` sql
SQL SELECT /* ImageServing::getImages Bloodsucker616 */  page_namespace as ns,page_title as title,page_id as id  FROM `page`  WHERE page_id = '0'
```
