### PR TITLE
PLATFORM-142 - Database: log server IP, cluster name and DB name

### DIFF
--- a/includes/db/Database.php
+++ b/includes/db/Database.php
@@ -3524,13 +3524,17 @@ abstract class DatabaseBase implements DatabaseType {
 	 * @return void
 	 */
 	protected function logSql( $sql, $fname, $elapsedTime, $isMaster ) {
+		global $wgDBcluster;
+
 		if ($this->getSampler()->shouldSample()) {
 			$this->getWikiaLogger()->info( "SQL $sql", [
 				'method'      => $fname,
 				'elapsed'     => $elapsedTime,
-				'server_role' => $isMaster ? 'master' : 'slave'
-				]
-			);
+				'cluster'     => $wgDBcluster,
+				'server'      => $this->mServer,
+				'server_role' => $isMaster ? 'master' : 'slave',
+				'db_name'     => $this->mDBname,
+			]);
 		}
 	}
 


### PR DESCRIPTION
@Wikia/platform-team 

More logging for https://github.com/Wikia/cheetah/pull/25

An example:

``` php
Array
(
    [@timestamp] => 2014-09-16T08:55:02.317822+00:00
    [@message] => SQL SELECT /* DataMartService:getSumPageviewsMonthly  */ SUM( pageviews ) AS cnt, time_id
     FROM rollup_wiki_pageviews
     WHERE period_id = '3'
     AND time_id = '12354566789121111232112112'
    [@fields] => Array
        (
            [db_name] => plpoznan
            [city_id] => 5915
            [request_id] => mw5417fae0aa6410.92866046
        )

    [@context] => Array
        (
            [method] => DataMartService:getSumPageviewsMonthly
            [elapsed] => 0.0015420913696289
            [cluster] => c1
            [server] => 10.xx.xx.xx
            [server_role] => master
            [db_name] => statsdb_mart
        )
)
```
