### PR TITLE
LBFactory: support custom ports in sectionLoads

### DIFF
--- a/includes/db/LBFactory_Multi.php
+++ b/includes/db/LBFactory_Multi.php
@@ -228,8 +228,13 @@ class LBFactory_Multi extends LBFactory {
 			if ( isset( $groupLoadsByServer[$serverName] ) ) {
 				$serverInfo['groupLoads'] = $groupLoadsByServer[$serverName];
 			}
-			if ( isset( $this->hostsByName[$serverName] ) ) {
-				$serverInfo['host'] = $this->hostsByName[$serverName];
+
+			// Wikia change - @author macbre
+			// sectionLoads entries may contain hostnames + port numbers (eg. lb-s1:1234)
+			list( $hostName, $port ) = explode( ':', $serverName );
+
+			if ( isset( $this->hostsByName[$hostName] ) ) {
+				$serverInfo['host'] = $this->hostsByName[$hostName] . ( $port ?  ':' . $port : '' );
 			} else {
 				$serverInfo['host'] = $serverName;
 			}


### PR DESCRIPTION
@Wikia/platform-team / @drozdo 

This will simplify the DB config as the hostname-to-IP conversion will happen based on hostname only (without a port).

Examples:

```
  'host' =>
  string(17) "10.14.30.142:3306"
  'hostName' =>
  string(22) "dev-db-central-p1:3306"

  'host' =>
  string(12) "10.14.30.142"
  'hostName' =>
  string(17) "dev-db-central-p1"
```

Required by https://github.com/Wikia/config/pull/654
