### PR TITLE
WikiaLogger: add more context when logging from maintenance scripts

### DIFF
--- a/lib/Wikia/src/Logger/Hooks.php
+++ b/lib/Wikia/src/Logger/Hooks.php
@@ -108,7 +108,7 @@ class Hooks {
 	 * @return bool true
 	 */
 	public static function onWikiFactoryExecuteComplete( \WikiFactoryLoader $wikiFactoryLoader ) {
-		global $wgRequest, $wgDBname, $wgCityId;
+		global $wgRequest, $wgDBname, $wgCityId, $maintClass;
 
 		$fields = [];
 
@@ -142,6 +142,17 @@ class Hooks {
 
 			if ( isset( $_SERVER['HTTP_REFERER'] ) ) {
 				$fields['referrer'] = $_SERVER['HTTP_REFERER'];
+			}
+		}
+
+		// add some context for maintenance scripts
+		if ( defined( 'RUN_MAINTENANCE_IF_MAIN' ) ) {
+			if ( isset( $_SERVER['SCRIPT_FILENAME'] ) ) {
+				$fields['maintenance_file'] = realpath( $_SERVER['SCRIPT_FILENAME'] );
+			}
+
+			if ( !empty( $maintClass ) ) {
+				$fields['maintenance_class'] = $maintClass;
 			}
 		}
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-431

@Wikia/platform-team 

Add more context for log entries from maintenance scripts

``` php
 '@fields' =>
  array(5) {
    'db_name' =>
    string(8) "plpoznan"
    'city_id' =>
    string(4) "5915"
    'maintenance_file' =>
    string(59) "/usr/wikia/source/app/maintenance/wikia/purgeWebPThumbs.php"
    'maintenance_class' =>
    string(15) "PurgeWebPThumbs"
    'request_id' =>
    string(25) "mw541850e3577f32.71699233"
  }

```
