### PR TITLE
AN-672 sending ga tracking calls to internal as well

### DIFF
--- a/resources/wikia/modules/tracker.js
+++ b/resources/wikia/modules/tracker.js
@@ -269,6 +269,12 @@
 			browserEvent = data.browserEvent || browserEvent;
 			eventName = data.eventName || eventName;
 			trackingMethod = data.trackingMethod || trackingMethod;
+
+			// AN-672: temporarily sending all data to internal warehouse
+			if (trackingMethod === 'ga') {
+				trackingMethod = 'both';
+			}
+
 			tracking[ trackingMethod ] = true;
 
 			if ( tracking.both ) {


### PR DESCRIPTION
This is adding temporary routing of all tracking code to the internal warehouse. We'll release to prod for a test then disable after a few hours. 
