### PR TITLE
TransactionClassifier: report when parser cache is disabled

### DIFF
--- a/includes/parser/Parser.php
+++ b/includes/parser/Parser.php
@@ -5609,7 +5609,7 @@ class Parser {
 			'exception' => new Exception()
 		]);
 
-		Transaction::setAttribute( Transaction::PARAM_PARSER_CACHE_USED, Transaction::PARSER_CACHE_DISABLED );
+		Transaction::setAttribute( Transaction::PARAM_PARSER_CACHE_DISABLED, true );
 		// Wikia change - end
 	}
 

--- a/includes/parser/Parser.php
+++ b/includes/parser/Parser.php
@@ -5608,6 +5608,8 @@ class Parser {
 		Wikia\Logger\WikiaLogger::instance()->info(__METHOD__, [
 			'exception' => new Exception()
 		]);
+
+		Transaction::setAttribute( Transaction::PARAM_PARSER_CACHE_USED, Transaction::PARSER_CACHE_DISABLED );
 		// Wikia change - end
 	}
 

--- a/includes/wikia/transaction/Transaction.php
+++ b/includes/wikia/transaction/Transaction.php
@@ -40,6 +40,8 @@ class Transaction {
 
 	const EVENT_ARTICLE_PARSE = 'article_parse';
 
+	const PARSER_CACHE_DISABLED = 'parser_cache_disabled';
+
 	/**
 	 * Returns TransactionTrace singleton instance
 	 *

--- a/includes/wikia/transaction/Transaction.php
+++ b/includes/wikia/transaction/Transaction.php
@@ -18,6 +18,7 @@ class Transaction {
 	const PARAM_ENTRY_POINT = 'entry_point';
 	const PARAM_LOGGED_IN = 'logged_in';
 	const PARAM_PARSER_CACHE_USED = 'parser_cache_used';
+	const PARAM_PARSER_CACHE_DISABLED = 'parser_cache_disabled';
 	const PARAM_SIZE_CATEGORY = 'size_category';
 	const PARAM_NAMESPACE = 'namespace';
 	const PARAM_ACTION = 'action';
@@ -39,8 +40,6 @@ class Transaction {
 	const SIZE_CATEGORY_COMPLEX = 'complex';
 
 	const EVENT_ARTICLE_PARSE = 'article_parse';
-
-	const PARSER_CACHE_DISABLED = 'parser_cache_disabled';
 
 	/**
 	 * Returns TransactionTrace singleton instance

--- a/includes/wikia/transaction/TransactionClassifier.php
+++ b/includes/wikia/transaction/TransactionClassifier.php
@@ -72,7 +72,10 @@ class TransactionClassifier {
 	protected static $MAP_PARSER_CACHED_USED = array(
 		false => 'parser',
 		true => 'no_parser',
-		Transaction::PARSER_CACHE_DISABLED => 'parser_disabled',
+	);
+
+	protected static $MAP_PARSER_CACHE_DISABLED = array(
+		true => 'parser_cache_disabled',
 	);
 
 
@@ -156,8 +159,12 @@ class TransactionClassifier {
 		if ( $this->add( Transaction::PARAM_SKIN ) === null ) {
 			return;
 		}
+		// add parser_cache_disabled indicator
+		if ( $this->addByMap( Transaction::PARAM_PARSER_CACHE_DISABLED, self::$MAP_PARSER_CACHE_DISABLED, null ) === true ) {
+
+		}
 		// add parser_cached_used indicator
-		if ( $this->addByMap( Transaction::PARAM_PARSER_CACHE_USED, self::$MAP_PARSER_CACHED_USED ) === null ) {
+		else if ( $this->addByMap( Transaction::PARAM_PARSER_CACHE_USED, self::$MAP_PARSER_CACHED_USED ) === null ) {
 			return;
 		}
 		// add size category
@@ -183,7 +190,9 @@ class TransactionClassifier {
 		}
 		$value = $this->attributes[$key];
 		$nameValue = $valueTransform ? $valueTransform( $value ) : $value;
-		$this->nameParts[] = $nameValue;
+		if ( !is_null( $nameValue ) ) {
+			$this->nameParts[] = $nameValue;
+		};
 		return $value;
 	}
 
@@ -214,14 +223,15 @@ class TransactionClassifier {
 	 *
 	 * @param string $key Attribute key
 	 * @param array $map Map of raw values and tokens to be included in transaction name. Non-existent items are replaced by "other"
+	 * @param string $defaulty The value to use if the key is not set
 	 * @return mixed
 	 */
-	protected function addByMap( $key, $map ) {
-		return $this->add( $key, function ( $value ) use ( $map ) {
+	protected function addByMap( $key, $map, $default = self::OTHER ) {
+		return $this->add( $key, function ( $value ) use ( $map, $default ) {
 			if ( isset( $map[$value] ) ) {
 				return $map[$value];
 			} else {
-				return self::OTHER;
+				return $default;
 			}
 		} );
 	}

--- a/includes/wikia/transaction/TransactionClassifier.php
+++ b/includes/wikia/transaction/TransactionClassifier.php
@@ -72,6 +72,7 @@ class TransactionClassifier {
 	protected static $MAP_PARSER_CACHED_USED = array(
 		false => 'parser',
 		true => 'no_parser',
+		Transaction::PARSER_CACHE_DISABLED => 'parser_disabled',
 	);
 
 

--- a/includes/wikia/transaction/tests/TransactionClassifierTest.php
+++ b/includes/wikia/transaction/tests/TransactionClassifierTest.php
@@ -1,0 +1,32 @@
+<?php
+
+class TransactionIsCacheableTest extends WikiaBaseTest {
+
+	/**
+	 * @dataProvider isCacheableDataProvider
+	 */
+	public function testIsCacheable( $header, $expected ) {
+		$this->assertEquals( $expected, Transaction::isCacheable( ['Cache-Control' => $header] ) );
+	}
+
+	public function isCacheableDataProvider() {
+		return [
+			[
+				'header' => false,
+				'isCacheable' => null
+			],
+			[
+				'header' => 's-maxage=86400, must-revalidate, max-age=0',
+				'isCacheable' => true
+			],
+			[
+				'header' => 'public, max-age=2592000',
+				'isCacheable' => true
+			],
+			[
+				'header' => 'private, must-revalidate, max-age=0',
+				'isCacheable' => false
+			],
+		];
+	}
+}

--- a/includes/wikia/transaction/tests/TransactionClassifierTest.php
+++ b/includes/wikia/transaction/tests/TransactionClassifierTest.php
@@ -1,31 +1,73 @@
 <?php
 
-class TransactionIsCacheableTest extends WikiaBaseTest {
+/**
+ * Unit tests for TransactionClassifier
+ *
+ * @author macbre
+ */
+class TransactionClassifierTest extends WikiaBaseTest {
 
 	/**
-	 * @dataProvider isCacheableDataProvider
+	 * @dataProvider buildDataProvider
 	 */
-	public function testIsCacheable( $header, $expected ) {
-		$this->assertEquals( $expected, Transaction::isCacheable( ['Cache-Control' => $header] ) );
+	public function testBuild( Array $attributes, $expectedName ) {
+		$classifier = new TransactionClassifier();
+
+		foreach($attributes as $key => $value) {
+			$classifier->update($key, $value);
+		}
+
+		$this->assertEquals($expectedName, $classifier->getName(), 'The transaction name should match');
 	}
 
-	public function isCacheableDataProvider() {
+	// TODO: Władek to update the test cases (2014-09-18)
+	public function buildDataProvider() {
 		return [
 			[
-				'header' => false,
-				'isCacheable' => null
+				'attributes' => [
+					Transaction::PARAM_ENTRY_POINT => Transaction::ENTRY_POINT_PAGE,
+					Transaction::PARAM_NAMESPACE => NS_MAIN,
+					Transaction::PARAM_ACTION => TransactionClassifier::ACTION_VIEW,
+					Transaction::PARAM_SKIN => 'foo-skin',
+					Transaction::PARAM_PARSER_CACHE_USED => false,
+					Transaction::PARAM_SIZE_CATEGORY => 'big-page'
+				],
+				'expectedName' => 'page/main/view/foo-skin/parser/big-page'
 			],
 			[
-				'header' => 's-maxage=86400, must-revalidate, max-age=0',
-				'isCacheable' => true
+				'attributes' => [
+					Transaction::PARAM_ENTRY_POINT => Transaction::ENTRY_POINT_PAGE,
+					Transaction::PARAM_NAMESPACE => NS_MAIN,
+					Transaction::PARAM_ACTION => TransactionClassifier::ACTION_VIEW,
+					Transaction::PARAM_SKIN => 'foo-skin',
+					Transaction::PARAM_PARSER_CACHE_USED => false,
+					Transaction::PARAM_SIZE_CATEGORY => 'small-page'
+				],
+				'expectedName' => 'page/main/view/foo-skin/parser/small-page'
 			],
 			[
-				'header' => 'public, max-age=2592000',
-				'isCacheable' => true
+				'attributes' => [
+					Transaction::PARAM_ENTRY_POINT => Transaction::ENTRY_POINT_PAGE,
+					Transaction::PARAM_NAMESPACE => NS_MAIN,
+					Transaction::PARAM_ACTION => TransactionClassifier::ACTION_VIEW,
+					Transaction::PARAM_SKIN => 'foo-skin',
+					Transaction::PARAM_PARSER_CACHE_USED => true,
+					Transaction::PARAM_PARSER_CACHE_DISABLED => true,
+					Transaction::PARAM_SIZE_CATEGORY => 'medium-page'
+				],
+				'expectedName' => 'page/main/view/foo-skin/parser_cache_disabled/medium-page'
 			],
 			[
-				'header' => 'private, must-revalidate, max-age=0',
-				'isCacheable' => false
+				'attributes' => [
+					Transaction::PARAM_ENTRY_POINT => Transaction::ENTRY_POINT_PAGE,
+					Transaction::PARAM_NAMESPACE => NS_MAIN,
+					Transaction::PARAM_ACTION => TransactionClassifier::ACTION_VIEW,
+					Transaction::PARAM_SKIN => 'foo-skin',
+					Transaction::PARAM_PARSER_CACHE_USED => true,
+					Transaction::PARAM_PARSER_CACHE_DISABLED => false,
+					Transaction::PARAM_SIZE_CATEGORY => 'medium-page'
+				],
+				'expectedName' => 'page/main/view/foo-skin/no_parser/medium-page'
 			],
 		];
 	}


### PR DESCRIPTION
@wladekb, please review

```
TransactionTrace: notification: ["onAttributeChange","parser_cache_used","parser_cache_disabled"]
TransactionTrace: notification: ["onTypeChange","page\/main\/view\/oasis\/parser_disabled"]

TransactionTrace: notification: ["onAttributeChange","parser_cache_used",false]
TransactionTrace: notification: ["onTypeChange","page\/main\/view\/oasis\/parser"]

TransactionTrace: notification: ["onTypeChange","page\/main\/view\/oasis"]
```
