### PR TITLE
VID-1997 removing css clearing for center-aligned elements

### DIFF
--- a/skins/oasis/css/core/article.scss
+++ b/skins/oasis/css/core/article.scss
@@ -136,8 +136,6 @@
 	}
 
 	.center {
-		@include clearfix;
-		clear: both;
 		text-align: center;
 		width: 100%;
 


### PR DESCRIPTION
This is a revert of https://wikia-inc.atlassian.net/browse/VID-1876. We'll find a better solution. 
