### PR TITLE
MWEB-1008 P2 fix for adding pins on a map in modal

### DIFF
--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -1833,7 +1833,7 @@ $config['int_map_ponto'] = [
 	'type' => AssetsManager::TYPE_JS,
 	'assets' => [
 		'//resources/wikia/libraries/Ponto/ponto.js',
-		'//extensions/wikia/WikiaInteractiveMaps/js/intMapPontoBridge.js'
+		'//extensions/wikia/WikiaInteractiveMaps/js/intMapPontoBridge.js',
 	]
 ];
 
@@ -1844,7 +1844,7 @@ $config['int_map_special_page_js'] = [
 		'//extensions/wikia/WikiaInteractiveMaps/js/intMapConfig.js',
 		'//extensions/wikia/WikiaInteractiveMaps/js/intMapUtils.js',
 		'#group_int_map_ponto',
-		'//extensions/wikia/WikiaInteractiveMaps/js/WikiaInteractiveMaps.js'
+		'//extensions/wikia/WikiaInteractiveMaps/js/WikiaInteractiveMaps.js',
 	]
 ];
 
@@ -1854,7 +1854,7 @@ $config['int_map_in_modal_display_js'] = [
 	'assets' => [
 		'#group_int_map_ponto',
 		'//extensions/wikia/WikiaInteractiveMaps/js/intMapConfig.js',
-		'//extensions/wikia/WikiaInteractiveMaps/js/intMapUtils.js'
+		'//extensions/wikia/WikiaInteractiveMaps/js/intMapUtils.js',
 	]
 ];
 
@@ -1893,7 +1893,7 @@ $config['int_map_edit_poi_js'] = [
 	'type' => AssetsManager::TYPE_JS,
 	'skin' => ['oasis'],
 	'assets' => [
-		'//extensions/wikia/WikiaInteractiveMaps/js/intMapEditPOI.js'
+		'//extensions/wikia/WikiaInteractiveMaps/js/intMapEditPOI.js',
 	]
 ];
 
@@ -1963,7 +1963,7 @@ $config['int_map_special_page_js_wikiamobile'] = [
 	'assets' => [
 		'//extensions/wikia/WikiaInteractiveMaps/js/intMapUtils.js',
 		'#group_int_map_ponto',
-		'//extensions/wikia/WikiaInteractiveMaps/js/WikiaInteractiveMaps.wikiamobile.js'
+		'//extensions/wikia/WikiaInteractiveMaps/js/WikiaInteractiveMaps.wikiamobile.js',
 	]
 ];
 
@@ -1971,7 +1971,7 @@ $config['int_map_parser_tag_js_wikiamobile'] = [
 	'type' => AssetsManager::TYPE_JS,
 	'skin' => ['wikiamobile'],
 	'assets' => [
-		'//extensions/wikia/WikiaInteractiveMaps/js/WikiaInteractiveMapsParserTag.wikiamobile.js'
+		'//extensions/wikia/WikiaInteractiveMaps/js/WikiaInteractiveMapsParserTag.wikiamobile.js',
 	]
 ];
 

--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -1853,6 +1853,7 @@ $config['int_map_in_modal_display_js'] = [
 	'skin' => ['oasis'],
 	'assets' => [
 		'#group_int_map_ponto',
+		'//extensions/wikia/WikiaInteractiveMaps/js/intMapConfig.js',
 		'//extensions/wikia/WikiaInteractiveMaps/js/intMapUtils.js'
 	]
 ];


### PR DESCRIPTION
Maps are accessible in few places:
- single map pages links which can be found on [Special:Maps](http://maps.wikia.com/wiki/Special:Maps),
- modals displayed after clicking [maps thumbnails in articles](http://mediawiki119.nandy.wikia-dev.com/wiki/EmbedMap).

While refactoring JavaScripts in MW client for maps we introduced new module placed in `intMapsConfig.js`. Unfortunately, we didn't add this file to the modals package which is fixing the described in this PR's title issue. The fix is [a one-liner](https://github.com/Wikia/app/pull/4822/files#diff-bede951fb0e48db15998e5e466d5b2ceR1856) but we'll re-think again the AM packages used by us for maps -- we should simplify them.
