### PR TITLE
Open graph meta performance 

### DIFF
--- a/extensions/wikia/OpenGraphMetaCustomizations/OpenGraphMetaCustomizations.setup.php
+++ b/extensions/wikia/OpenGraphMetaCustomizations/OpenGraphMetaCustomizations.setup.php
@@ -33,7 +33,7 @@ function egOgmcParserAfterTidy( Parser $parser, &$text ) {
 
 /**
  * Now that the page is far enough along, use ArticleService to set
- * the escription on the OuptutPage.  This value will then
+ * the description on the OuptutPage.  This value will then
  * be used by the OpenGraphMeta extension.
  */
 $wgParserOutputHooks['applyOpenGraphMetaCustomizations'] = 'egOgmcParserOutputApplyValues';


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-431

@Wikia/platform-team 

Backporting #4738

To be pushed live on Monday, September 22nd. We'd like to monitor this performance improvement without any other changes going live at the same time.

```
site> select sum(count) as sum, median(real_pct50) as p50, median(real_pct95) as p95 from app_agg_xhprof_funcs where time > now() - 30m and func =~ /egOgmcParserOutputApplyValues/ group by time(5m)
┌──────────────────┬──────┬──────────┬──────────┐
│       time       │ sum  │ p50      │ p95      │
├──────────────────┼──────┼──────────┼──────────┤
│ 19/9/14 17:00:00 │ 1301 │ 0.007644 │ 0.037659 │
│ 19/9/14 16:55:00 │ 2507 │ 0.007516 │ 0.032782 │
│ 19/9/14 16:50:00 │ 2368 │ 0.007774 │ 0.036249 │
│ 19/9/14 16:45:00 │ 2304 │ 0.007668 │ 0.035816 │
│ 19/9/14 16:40:00 │ 2598 │ 0.008006 │ 0.041756 │
│ 19/9/14 16:35:00 │ 2599 │ 0.007593 │ 0.035114 │
│ 19/9/14 16:30:00 │ 1323 │ 0.008001 │ 0.039963 │
└──────────────────┴──────┴──────────┴──────────┘

site> select type, median(real_pct50) from app_agg_xhprof_reqs_by_type where time > now() - 20m and type =~ /page\/main\/view\/oasis\/parser/ group by time(10m), type limit 10
┌──────────────────┬──────────┬─────────────────────────────────────┐
│       time       │ median   │ type                                │
├──────────────────┼──────────┼─────────────────────────────────────┤
│ 19/9/14 17:20:00 │ 0.389558 │ page/main/view/oasis/parser         │
│ 19/9/14 17:20:00 │ 0.879072 │ page/main/view/oasis/parser/average │
│ 19/9/14 17:20:00 │ 3.102537 │ page/main/view/oasis/parser/complex │
│ 19/9/14 17:20:00 │ 0.45519  │ page/main/view/oasis/parser/simple  │
│ 19/9/14 17:10:00 │ 0.38647  │ page/main/view/oasis/parser         │
│ 19/9/14 17:10:00 │ 0.841713 │ page/main/view/oasis/parser/average │
│ 19/9/14 17:10:00 │ 2.434937 │ page/main/view/oasis/parser/complex │
│ 19/9/14 17:10:00 │ 0.566444 │ page/main/view/oasis/parser/simple  │
│ 19/9/14 17:00:00 │ 0.413272 │ page/main/view/oasis/parser         │
│ 19/9/14 17:00:00 │ 0.703958 │ page/main/view/oasis/parser/average │
└──────────────────┴──────────┴─────────────────────────────────────┘

site> select type, median(real_pct50) from app_agg_xhprof_reqs_by_type where time > now() - 1h and type =~ /page\/main\/view\/oasis\/no_parser$/ group by time(10m), type 
┌──────────────────┬──────────┬────────────────────────────────┐
│       time       │ median   │ type                           │
├──────────────────┼──────────┼────────────────────────────────┤
│ 19/9/14 17:10:00 │ 0.133531 │ page/main/view/oasis/no_parser │
│ 19/9/14 17:00:00 │ 0.706745 │ page/main/view/oasis/no_parser │
│ 19/9/14 16:30:00 │ 0.131322 │ page/main/view/oasis/no_parser │
│ 19/9/14 16:20:00 │ 0.14796  │ page/main/view/oasis/no_parser │
└──────────────────┴──────────┴────────────────────────────────┘
```
