### PR TITLE
Backporting performance improvements (release-243)

### DIFF
--- a/extensions/wikia/ImageServing/imageServing.class.php
+++ b/extensions/wikia/ImageServing/imageServing.class.php
@@ -230,6 +230,7 @@ class ImageServing {
 		if( !empty( $fileNames ) ) {
 			/**
 			 * @var $fileName LocalFile
+			 * @var $title Title
 			 */
 			foreach ( $fileNames as $fileName ) {
 				if(!($fileName instanceof LocalFile)) {
@@ -240,8 +241,11 @@ class ImageServing {
 				}
 			}
 
-			$imagesIds[ $title->getArticleId() ] = $title->getDBkey();
-			$this->articles[ $title->getArticleId() ] = $title->getArticleId();
+			// do not query for page_id = 0
+			if ( $title->exists() ) {
+				$imagesIds[ $title->getArticleId() ] = $title->getDBkey();
+				$this->articles[ $title->getArticleId() ] = $title->getArticleId();
+			}
 		}
 
 		$out = $this->getImages(1);

--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -1949,6 +1949,8 @@ class WikiFactory {
 
 		$dbr = ( $master ) ? self::db( DB_MASTER ) : self::db( DB_SLAVE );
 
+		$caller = wfGetCallerClassMethod(__CLASS__);
+		$fname = __METHOD__ . " (from {$caller})";
 
 		if ( $master || !isset( self::$variablesCache[$cacheKey] ) ) {
 			$oRow = $dbr->selectRow(
@@ -1963,7 +1965,7 @@ class WikiFactory {
 					"cv_is_unique"
 				),
 				$condition,
-				__METHOD__
+				$fname
 			);
 			self::$variablesCache[$cacheKey] = $oRow;
 		}
@@ -1992,7 +1994,7 @@ class WikiFactory {
 					"cv_variable_id" => $oRow->cv_id,
 					"cv_city_id" => $city_id
 				),
-				__METHOD__
+				$fname
 			);
 			if ( isset( $oRow2->cv_variable_id ) ) {
 

--- a/includes/WatchedItem.php
+++ b/includes/WatchedItem.php
@@ -8,6 +8,7 @@
  * @ingroup Watchlist
  */
 class WatchedItem {
+	/* @var User $mUser */
 	var $mTitle, $mUser, $id, $ns, $ti;
 
 	/**
@@ -39,6 +40,11 @@ class WatchedItem {
 		# Pages and their talk pages are considered equivalent for watching;
 		# remember that talk namespaces are numbered as page namespace+1.
 
+		// Only loggedin user can have a watchlist
+		if ( $this->mUser->isAnon() ) {
+			return false;
+		}
+
 		$dbr = wfGetDB( DB_SLAVE );
 		$res = $dbr->select( 'watchlist', 1, array( 'wl_user' => $this->id, 'wl_namespace' => $this->ns,
 			'wl_title' => $this->ti ), __METHOD__ );
@@ -53,6 +59,13 @@ class WatchedItem {
 	 */
 	public function addWatch() {
 		wfProfileIn( __METHOD__ );
+
+		// Only loggedin user can have a watchlist
+		if ( wfReadOnly() || $this->mUser->isAnon() ) {
+			wfProfileOut( __METHOD__ );
+			return false;
+		}
+
 		$rows = array();
 
 		// Use INSERT IGNORE to avoid overwriting the notification timestamp
@@ -88,6 +101,12 @@ class WatchedItem {
 	 */
 	public function removeWatch() {
 		wfProfileIn( __METHOD__ );
+
+		// Only loggedin user can have a watchlist
+		if ( wfReadOnly() || $this->mUser->isAnon() ) {
+			wfProfileOut( __METHOD__ );
+			return false;
+		}
 
 		$success = false;
 		

--- a/includes/WatchedItem.php
+++ b/includes/WatchedItem.php
@@ -8,8 +8,10 @@
  * @ingroup Watchlist
  */
 class WatchedItem {
-	/* @var User $mUser */
-	var $mTitle, $mUser, $id, $ns, $ti;
+	/* @var Title $mTitle */
+	var $mTitle;
+	/* @var User $mUser  */
+	var $mUser, $id, $ns, $ti;
 
 	/**
 	 * Create a WatchedItem object with the given user and title
@@ -42,6 +44,11 @@ class WatchedItem {
 
 		// Only loggedin user can have a watchlist
 		if ( $this->mUser->isAnon() ) {
+			return false;
+		}
+
+		// some pages cannot be watched
+		if ( !$this->mTitle->isWatchable() ) {
 			return false;
 		}
 

--- a/includes/wikia/tests/GlobalTitleTest.php
+++ b/includes/wikia/tests/GlobalTitleTest.php
@@ -1,5 +1,6 @@
 <?php
-class GlobalTitleTest extends PHPUnit_Framework_TestCase {
+
+class GlobalTitleTest extends WikiaBaseTest {
 	private $wgDevelEnv;
 	private $wgDevelEnvName;
 	


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-431

@Wikia/platform-team 

Performance improvements:
- WatchedItem: avoid select/writes for anon user in WatchedItem #4770
- ImageServing: prevent queries by page_id = 0 #4774 
- PLATFORM-431 - Global title improve caching #4823

To be pushed live on Monday, September 22nd. We'd like to monitor this performance improvement without any other changes going live at the same time.

```
site> select key, count, time_p50, time_p95, total_time from Database_Queries_60m  where key =~ /WatchedItem::isWatched/  limit 5
┌──────────────────┬─────────────────┬───────┬───────────────────────────────┬─────────────────────┬────────────────────┬────────────────────┐
│       time       │ sequence_number │ count │ key                           │ time_p50            │ time_p95           │ total_time         │
├──────────────────┼─────────────────┼───────┼───────────────────────────────┼─────────────────────┼────────────────────┼────────────────────┤
│ 19/9/14 14:00:00 │ 518             │ 17597 │ select-WatchedItem::isWatched │ 0.3193241578561284  │ 2.264903025862611  │ 11610.924482345577 │
│ 19/9/14 13:00:00 │ 421             │ 19438 │ select-WatchedItem::isWatched │ 0.31848663979388303 │ 2.2772734288386673 │ 12766.570568084719 │
│ 19/9/14 12:00:00 │ 424             │ 17341 │ select-WatchedItem::isWatched │ 0.3128140334374397  │ 1.8310040881390166 │ 9867.2354221344    │
│ 19/9/14 11:00:00 │ 443             │ 17130 │ select-WatchedItem::isWatched │ 0.3194382204811954  │ 2.158705017270417  │ 11358.243703842165 │
│ 19/9/14 10:00:00 │ 517             │ 16717 │ select-WatchedItem::isWatched │ 0.32010003712102525 │ 2.2314249620138775 │ 11907.268047332767 │
└──────────────────┴─────────────────┴───────┴───────────────────────────────┴─────────────────────┴────────────────────┴────────────────────┘

site> select key, count, time_p50, time_p95, total_time from Database_Queries_60m  where key =~ /ImageServing/  limit 10
┌──────────────────┬─────────────────┬───────┬──────────────────────────────────────────────────────────────────┬─────────────────────┬─────────────────────┬────────────────────┐
│       time       │ sequence_number │ count │ key                                                              │ time_p50            │ time_p95            │ total_time         │
├──────────────────┼─────────────────┼───────┼──────────────────────────────────────────────────────────────────┼─────────────────────┼─────────────────────┼────────────────────┤
│ 19/9/14 14:00:00 │ 314             │ 4652  │ select-ImageServingDriverMainNS::getImagesPopularity::redirects  │ 0.6903247063204374  │ 2.997409853135574   │ 5174.968004226685  │
│ 19/9/14 14:00:00 │ 313             │ 4396  │ select-ImageServingDriverMainNS::getImagesPopularity::imagelinks │ 0.9256860484247633  │ 5.951139793632933   │ 8451.340436935423  │
│ 19/9/14 14:00:00 │ 312             │ 9324  │ select-ImageServingDriverMainNS::getArticleProbs                 │ 0.3456899614045116  │ 2.133199662873243   │ 6308.228254318236  │
│ 19/9/14 14:00:00 │ 311             │ 5311  │ select-ImageServingDriverMainNS::filterImages                    │ 0.40786085706768604 │ 2.4001330317872958  │ 4067.7585601806645 │
│ 19/9/14 14:00:00 │ 310             │ 1359  │ select-ImageServingDriverCategoryNS::getCategoryArticleList      │ 0.7376938767075923  │ 3.433263340679749   │ 1850.622177124022  │
│ 19/9/14 14:00:00 │ 309             │ 2847  │ select-ImageServing::getImages                                   │ 0.3365126925725313  │ 1.837714427026798   │ 1780.3039550781243 │
│ 19/9/14 14:00:00 │ 159             │ 20    │ replace-ImageServingHelper::buildIndex                           │ 0.8255441983540872  │ 0.8823891480763764  │ 17.541646957397482 │
│ 19/9/14 14:00:00 │ 30              │ 15    │ delete-ImageServingHelper::buildIndex                            │ 0.3414750099182142  │ 0.36917839731489205 │ 5.4256916046143    │
│ 19/9/14 13:00:00 │ 236             │ 4920  │ select-ImageServingDriverMainNS::getImagesPopularity::redirects  │ 0.7025080224487689  │ 2.983886040061528   │ 5501.692533493043  │
│ 19/9/14 13:00:00 │ 235             │ 5119  │ select-ImageServingDriverMainNS::getImagesPopularity::imagelinks │ 0.8946254940852065  │ 6.836544297224172   │ 9962.917804718028  │
└──────────────────┴─────────────────┴───────┴──────────────────────────────────────────────────────────────────┴─────────────────────┴─────────────────────┴────────────────────┘
Query took  433 ms
```
