### PR TITLE
VOLDEV-93: InterwikiEdit 'back to menu' link is broken

### DIFF
--- a/extensions/wikia/SpecialInterwikiEdit/SpecialInterwikiEdit.php
+++ b/extensions/wikia/SpecialInterwikiEdit/SpecialInterwikiEdit.php
@@ -43,7 +43,7 @@ class InterwikiEdit extends SpecialPage {
 		$action = $wgRequest->getVal('action', 'choose');
 		//$lang_only = $wgRequest->getVal('lang_only', 1);
 
-		if ($action != 'choose') $ret = "<p class='subpages'>&lt; <a href=''>Back to menu</a></p>";
+		if ($action != 'choose') $ret = "<p class='subpages'>&lt; <a href='?'>Back to menu</a></p>";
 		else $ret = "";
 
 		switch ($action){


### PR DESCRIPTION
@Grunny 

Fixes "< Back to menu" on S:InterwikiEdit when a URL query is present (which is all links on http://c.wikia.com/wiki/Project:Interlanguage_link_requests). href was changed from an empty string to `?`.
