### PR TITLE
VOLDEV-91: Special:Contact/bad-ad should not have the "Does this page answer your question?" footer

### DIFF
--- a/extensions/wikia/SpecialContact2/templates/bad-ad.tmpl.php
+++ b/extensions/wikia/SpecialContact2/templates/bad-ad.tmpl.php
@@ -87,5 +87,3 @@ if ( $isLoggedIn && $hasEmail ) {
 <input type="hidden" id="wpBrowser" name="wpBrowser" value="<?= htmlspecialchars( $_SERVER['HTTP_USER_AGENT'] ); ?>" />
 <input type="hidden" id="wpAbTesting" name="wpAbTesting" value="[unknown]" />
 </form>
-
-<p><?= wfMessage( 'specialcontact-noform-footer' )->parse() ?></p>


### PR DESCRIPTION
@Grunny 

Removes the footer with a link to S:C/general from S:C/bad-ad. `wfMessage` call was hardcoded in the template, so it was simply removed.
