### PR TITLE
ScribeClient: log pushes to the "queue"

### DIFF
--- a/extensions/wikia/Scribe/ScribeClient.php
+++ b/extensions/wikia/Scribe/ScribeClient.php
@@ -1,5 +1,7 @@
 <?php
 
+use \Wikia\Logger\WikiaLogger;
+
 $GLOBALS['THRIFT_ROOT'] = $IP . '/lib/vendor/scribe';
 
 include_once $GLOBALS['THRIFT_ROOT'] . '/scribe.php';
@@ -80,7 +82,7 @@ class WScribeClient {
     /**
      * Send a message to a destination
      *
-     * @param string $message
+     * @param string $message JSON encoded message
      * @return boolean
      */
     public function send ($message) {
@@ -118,6 +120,12 @@ class WScribeClient {
 				}
 
 				$this->transport->close();
+
+				WikiaLogger::instance()->info('Scribe', [
+					'cmd' => 'send',
+					'category' => $this->category,
+					'caller' => wfGetCallerClassMethod(__CLASS__)
+				]);
 			}
 			catch( TException $e ) {
 				// socket error


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-9

@Wikia/platform-team / @wladekb 

Adding logging of Scribe pushes, first step towards documenting the data flow in our system :)

``` json
{
  "@timestamp": "2014-09-24T15:49:19.360910+00:00",
  "@message": "Scribe",
  "@fields": {
    "db_name": "plpoznan",
    "city_id": "5915",
    "url": "/wiki/Gzik?action=purge",
    "ip": "10.14.30.102",
    "http_method": "POST",
    "server": "poznan.macbre.wikia-dev.com",
    "request_id": "mw5422e7fc7c60a8.41102147"
  },
  "@context": {
    "cmd": "send",
    "category": "varnish_purges",
    "caller": "ScribePurge:onRestInPeace"
  }
}
```
