### PR TITLE
(CE-1067) Apply MW 1.19.19 security release

### DIFF
--- a/RELEASE-NOTES-1.19
+++ b/RELEASE-NOTES-1.19
@@ -3,6 +3,16 @@
 Security reminder: MediaWiki does not require PHP's register_globals
 setting since version 1.2.0. If you have it on, turn it '''off''' if you can.
 
+== MediaWiki 1.19.19 ==
+
+This is a security release of the MediaWiki 1.19 branch.
+
+=== Changes since 1.19.18 ===
+* (bug 69008) SECURITY: Enhance CSS filtering in SVG files. Filter <style>
+  elements; normalize style elements and attributes before filtering; add
+  checks for attributes that contain css; add unit tests for html5sec and
+  reported bugs.
+
 == MediaWiki 1.19.18 ==
 
 This is a security release of the MediaWiki 1.19 branch.

--- a/includes/DefaultSettings.php
+++ b/includes/DefaultSettings.php
@@ -33,7 +33,7 @@ $wgConf = new SiteConfiguration;
 /** @endcond */
 
 /** MediaWiki version number */
-$wgVersion = '1.19.18';
+$wgVersion = '1.19.19';
 
 /** Name of the site. It must be changed in LocalSettings.php */
 $wgSitename = 'MediaWiki';

--- a/includes/Sanitizer.php
+++ b/includes/Sanitizer.php
@@ -885,23 +885,16 @@ class Sanitizer {
 	}
 
 	/**
-	 * Pick apart some CSS and check it for forbidden or unsafe structures.
-	 * Returns a sanitized string. This sanitized string will have
-	 * character references and escape sequences decoded, and comments
-	 * stripped. If the input is just too evil, only a comment complaining
-	 * about evilness will be returned.
-	 *
-	 * Currently URL references, 'expression', 'tps' are forbidden.
-	 *
-	 * NOTE: Despite the fact that character references are decoded, the
-	 * returned string may contain character references given certain
-	 * clever input strings. These character references must
-	 * be escaped before the return value is embedded in HTML.
-	 *
-	 * @param $value String
-	 * @return String
+	 * Normalize CSS into a format we can easily search for hostile input
+	 *  - decode character references
+	 *  - decode escape sequences
+	 *  - convert characters that IE6 interprets into ascii
+	 *  - remove comments, unless the entire value is one single comment
+	 * @param string $value the css string
+	 * @return string normalized css
 	 */
-	static function checkCss( $value ) {
+	public static function normalizeCss( $value ) {
+
 		// Decode character references like &#123;
 		$value = Sanitizer::decodeCharReferences( $value );
 
@@ -975,6 +968,31 @@ class Sanitizer {
 			'ss',
 			$value
 		);
+
+		return $value;
+	}
+
+
+	/**
+	 * Pick apart some CSS and check it for forbidden or unsafe structures.
+	 * Returns a sanitized string. This sanitized string will have
+	 * character references and escape sequences decoded and comments
+	 * stripped (unless it is itself one valid comment, in which case the value
+	 * will be passed through). If the input is just too evil, only a comment
+	 * complaining about evilness will be returned.
+	 *
+	 * Currently URL references, 'expression', 'tps' are forbidden.
+	 *
+	 * NOTE: Despite the fact that character references are decoded, the
+	 * returned string may contain character references given certain
+	 * clever input strings. These character references must
+	 * be escaped before the return value is embedded in HTML.
+	 *
+	 * @param string $value
+	 * @return string
+	 */
+	static function checkCss( $value ) {
+		$value = self::normalizeCss( $value );
 
 		// Reject problematic keywords and control characters
 		if ( preg_match( '/[\000-\010\013\016-\037\177]/', $value ) ) {

--- a/includes/XmlTypeCheck.php
+++ b/includes/XmlTypeCheck.php
@@ -20,6 +20,23 @@ class XmlTypeCheck {
 	public $rootElement = '';
 
 	/**
+	 * A stack of strings containing the data of each xml element as it's processed. Append
+	 * data to the top string of the stack, then pop off the string and process it when the
+	 * element is closed.
+	 */
+	protected $elementData = array();
+
+	/**
+	 * A stack of element names and attributes, as we process them.
+	 */
+	protected $elementDataContext = array();
+
+	/**
+	 * Current depth of the data stack.
+	 */
+	protected $stackDepth = 0;
+
+	/**
 	 * Additional parsing options
 	 */
 	private $parserOptions = array(
@@ -31,7 +48,7 @@ class XmlTypeCheck {
 	 * @param $filterCallback callable (optional)
 	 *        Function to call to do additional custom validity checks from the
 	 *        SAX element handler event. This gives you access to the element
-	 *        namespace, name, and attributes, but not to text contents.
+	 *        namespace, name, attributes, and text contents.
 	 *        Filter should return 'true' to toggle on $this->filterMatch
 	 * @param array $options list of additional parsing options:
 	 *	processing_instruction_handler: Callback for xml_set_processing_instruction_handler
@@ -101,7 +118,12 @@ class XmlTypeCheck {
 		$this->rootElement = $name;
 
 		if( is_callable( $this->filterCallback ) ) {
-			xml_set_element_handler( $parser, array( $this, 'elementOpen' ), false );
+			xml_set_element_handler(
+				$parser,
+				array( $this, 'elementOpen' ),
+				array( $this, 'elementClose' )
+			);
+			xml_set_character_data_handler( $parser, array( $this, 'elementData' ) );
 			$this->elementOpen( $parser, $name, $attribs );
 		} else {
 			// We only need the first open element
@@ -115,10 +137,39 @@ class XmlTypeCheck {
 	 * @param $attribs
 	 */
 	private function elementOpen( $parser, $name, $attribs ) {
-		if( call_user_func( $this->filterCallback, $name, $attribs ) ) {
+		$this->elementDataContext[] = array( $name, $attribs );
+		$this->elementData[] = '';
+		$this->stackDepth++;
+	}
+
+	/**
+	 * @param $parser
+	 * @param $name
+	 */
+	private function elementClose( $parser, $name ) {
+		list( $name, $attribs ) = array_pop( $this->elementDataContext );
+		$data = array_pop( $this->elementData );
+		$this->stackDepth--;
+
+		if ( call_user_func(
+			$this->filterCallback,
+			$name,
+			$attribs,
+			$data
+		) ) {
 			// Filter hit!
 			$this->filterMatch = true;
 		}
+	}
+
+	/**
+	 * @param $parser
+	 * @param $data
+	 */
+	private function elementData( $parser, $data ) {
+		// xml_set_character_data_handler breaks the data on & characters, so
+		// we collect any data here, and we'll run the callback in elementClose
+		$this->elementData[ $this->stackDepth - 1 ] .= trim( $data );
 	}
 
 	/**

--- a/includes/upload/UploadBase.php
+++ b/includes/upload/UploadBase.php
@@ -1120,7 +1120,8 @@ abstract class UploadBase {
 	/**
 	 * @todo Replace this with a whitelist filter!
 	 */
-	public function checkSvgScriptCallback( $element, $attribs ) {
+	public function checkSvgScriptCallback( $element, $attribs, $data = null ) {
+
 		list( $namespace, $strippedElement ) = $this->splitXmlNamespace( $element );
 
 		static $validNamespaces = array(
@@ -1194,6 +1195,14 @@ abstract class UploadBase {
 		}
 
 
+		# Check <style> css
+		if ( $strippedElement == 'style'
+			&& self::checkCssFragment( Sanitizer::normalizeCss( $data ) )
+		) {
+			wfDebug( __METHOD__ . ": hostile css in style element.\n" );
+			return true;
+		}
+
 		foreach( $attribs as $attrib => $value ) {
 			$stripped = $this->stripXmlNamespace( $attrib );
 			$value = strtolower($value);
@@ -1230,6 +1239,18 @@ abstract class UploadBase {
 				return true;
 			}
 
+			# Change href with animate from (http://html5sec.org/#137). This doesn't seem
+			# possible without embedding the svg, but filter here in case.
+			if ( $stripped == 'from'
+				&& $strippedElement === 'animate'
+				&& !preg_match( '!^https?://!im', $value )
+			) {
+				wfDebug( __METHOD__ . ": Found animate that might be changing href using from "
+					. "\"<$strippedElement '$attrib'='$value'...\" in uploaded file.\n" );
+
+				return true;
+			}
+
 			# use set/animate to add event-handler attribute to parent
 			if( ( $strippedElement == 'set' || $strippedElement == 'animate' ) && $stripped == 'attributename' && substr( $value, 0, 2 ) == 'on' ) {
 				wfDebug( __METHOD__ . ": Found svg setting event-handler attribute with \"<$strippedElement $stripped='$value'...\" in uploaded file.\n" );
@@ -1256,14 +1277,23 @@ abstract class UploadBase {
 			}
 
 			# use CSS styles to bring in remote code
-			# catch url("http:..., url('http:..., url(http:..., but not url("#..., url('#..., url(#....
-			if( $stripped == 'style' && preg_match_all( '!((?:font|clip-path|fill|filter|marker|marker-end|marker-mid|marker-start|mask|stroke)\s*:\s*url\s*\(\s*["\']?\s*[^#]+.*?\))!sim', $value, $matches ) ) {
-				foreach ($matches[1] as $match) {
-					if (!preg_match( '!(?:font|clip-path|fill|filter|marker|marker-end|marker-mid|marker-start|mask|stroke)\s*:\s*url\s*\(\s*(#|\'#|"#)!sim', $match ) ) {
-						wfDebug( __METHOD__ . ": Found svg setting a style with remote url '$attrib'='$value' in uploaded file.\n" );
-						return true;
-					}
-				}
+			if ( $stripped == 'style'
+				&& self::checkCssFragment( Sanitizer::normalizeCss( $value ) )
+			) {
+				wfDebug( __METHOD__ . ": Found svg setting a style with "
+					. "remote url '$attrib'='$value' in uploaded file.\n" );
+				return true;
+			}
+
+			# Several attributes can include css, css character escaping isn't allowed
+			$cssAttrs = array( 'font', 'clip-path', 'fill', 'filter', 'marker',
+				'marker-end', 'marker-mid', 'marker-start', 'mask', 'stroke' );
+			if ( in_array( $stripped, $cssAttrs )
+				&& self::checkCssFragment( $value )
+			) {
+				wfDebug( __METHOD__ . ": Found svg setting a style with "
+					. "remote url '$attrib'='$value' in uploaded file.\n" );
+				return true;
 			}
 
 			# image filters can pull in url, which could be svg that executes scripts
@@ -1278,6 +1308,58 @@ abstract class UploadBase {
 	}
 
  	/**
+	 * Check a block of CSS or CSS fragment for anything that looks like
+	 * it is bringing in remote code.
+	 * @param string $value a string of CSS
+	 * @param bool $propOnly only check css properties (start regex with :)
+	 * @return bool true if the CSS contains an illegal string, false if otherwise
+	 */
+	private static function checkCssFragment( $value ) {
+
+		# Forbid external stylesheets, for both reliability and to protect viewer's privacy
+		if ( strpos( $value, '@import' ) !== false ) {
+			return true;
+		}
+
+		# We allow @font-face to embed fonts with data: urls, so we snip the string
+		# 'url' out so this case won't match when we check for urls below
+		$pattern = '!(@font-face\s*{[^}]*src:)url(\("data:;base64,)!im';
+		$value = preg_replace( $pattern, '$1$2', $value );
+
+		# Check for remote and executable CSS. Unlike in Sanitizer::checkCss, the CSS
+		# properties filter and accelerator don't seem to be useful for xss in SVG files.
+		# Expression and -o-link don't seem to work either, but filtering them here in case.
+		# Additionally, we catch remote urls like url("http:..., url('http:..., url(http:...,
+		# but not local ones such as url("#..., url('#..., url(#....
+		if ( preg_match( '!expression
+				| -o-link\s*:
+				| -o-link-source\s*:
+				| -o-replace\s*:!imx', $value ) ) {
+			return true;
+		}
+
+		if ( preg_match_all(
+				"!(\s*(url|image|image-set)\s*\(\s*[\"']?\s*[^#]+.*?\))!sim",
+				$value,
+				$matches
+			) !== 0
+		) {
+			# TODO: redo this in one regex. Until then, url("#whatever") matches the first
+			foreach ( $matches[1] as $match ) {
+				if ( !preg_match( "!\s*(url|image|image-set)\s*\(\s*(#|'#|\"#)!im", $match ) ) {
+					return true;
+				}
+			}
+		}
+
+		if ( preg_match( '/[\000-\010\013\016-\037\177]/', $value ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
 	 * Divide the element name passed by the xml parser to the callback into URI and prifix.
 	 * @param $name string
 	 * @return array containing the namespace URI and prefix

--- a/tests/phpunit/includes/upload/UploadTest.php
+++ b/tests/phpunit/includes/upload/UploadTest.php
@@ -123,6 +123,230 @@ class UploadTest extends MediaWikiTestCase {
 
 		$wgMaxUploadSize = $savedGlobal;  // restore global
 	}
+
+
+	/**
+	 * @dataProvider provideCheckSvgScriptCallback
+	 */
+	public function testCheckSvgScriptCallback( $svg, $wellFormed, $filterMatch, $message ) {
+		list( $formed, $match ) = $this->upload->checkSvgString( $svg );
+		$this->assertSame( $wellFormed, $formed, $message );
+		$this->assertSame( $filterMatch, $match, $message );
+	}
+
+	public static function provideCheckSvgScriptCallback() {
+		return array(
+			// html5sec SVG vectors
+			array(
+				'<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>',
+				true,
+				true,
+				'Script tag in svg (http://html5sec.org/#47)'
+			),
+			array(
+				'<svg xmlns="http://www.w3.org/2000/svg"><g onload="javascript:alert(1)"></g></svg>',
+				true,
+				true,
+				'SVG with onload property (http://html5sec.org/#11)'
+			),
+			array(
+				'<svg onload="javascript:alert(1)" xmlns="http://www.w3.org/2000/svg"></svg>',
+				true,
+				true,
+				'SVG with onload property (http://html5sec.org/#65)'
+			),
+			array(
+				'<svg xmlns="http://www.w3.org/2000/svg"> <a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="javascript:alert(1)"><rect width="1000" height="1000" fill="white"/></a> </svg>',
+				true,
+				true,
+				'SVG with javascript xlink (http://html5sec.org/#87)'
+			),
+			array(
+				'<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">  <animation xlink:href="javascript:alert(1)"/> </svg>',
+				true,
+				true,
+				'SVG with Opera animation xlink (http://html5sec.org/#88 - a)'
+			),
+			array(
+				'<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">  <animation xlink:href="data:text/xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' onload=\'alert(1)\'%3E%3C/svg%3E"/> </svg>',
+				true,
+				true,
+				'SVG with Opera animation xlink (http://html5sec.org/#88 - b)'
+			),
+			array(
+				'<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">  <image xlink:href="data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' onload=\'alert(1)\'%3E%3C/svg%3E"/> </svg>',
+				true,
+				true,
+				'SVG with Opera image xlink (http://html5sec.org/#88 - c)'
+			),
+			array(
+				'<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">  <foreignObject xlink:href="javascript:alert(1)"/> </svg>',
+				true,
+				true,
+				'SVG with Opera foreignObject xlink (http://html5sec.org/#88 - d)'
+			),
+			array(
+				'<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">  <foreignObject xlink:href="data:text/xml,%3Cscript xmlns=\'http://www.w3.org/1999/xhtml\'%3Ealert(1)%3C/script%3E"/> </svg>',
+				true,
+				true,
+				'SVG with Opera foreignObject xlink (http://html5sec.org/#88 - e)'
+			),
+			array(
+				'<svg xmlns="http://www.w3.org/2000/svg"> <set attributeName="onmouseover" to="alert(1)"/> </svg>',
+				true,
+				true,
+				'SVG with event handler set (http://html5sec.org/#89 - a)'
+			),
+			array(
+				'<svg xmlns="http://www.w3.org/2000/svg"> <animate attributeName="onunload" to="alert(1)"/> </svg>',
+				true,
+				true,
+				'SVG with event handler animate (http://html5sec.org/#89 - a)'
+			),
+			array(
+				'<svg xmlns="http://www.w3.org/2000/svg"> <handler xmlns:ev="http://www.w3.org/2001/xml-events" ev:event="load">alert(1)</handler> </svg>',
+				true,
+				true,
+				'SVG with element handler (http://html5sec.org/#94)'
+			),
+			array(
+				'<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"> <feImage> <set attributeName="xlink:href" to="data:image/svg+xml;charset=utf-8;base64, PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxzY3JpcHQ%2BYWxlcnQoMSk8L3NjcmlwdD48L3N2Zz4NCg%3D%3D"/> </feImage> </svg>',
+				true,
+				true,
+				'SVG with href to data: url (http://html5sec.org/#95)'
+			),
+			array(
+				'<svg xmlns="http://www.w3.org/2000/svg" id="foo"> <x xmlns="http://www.w3.org/2001/xml-events" event="load" observer="foo" handler="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%3Chandler%20xml%3Aid%3D%22bar%22%20type%3D%22application%2Fecmascript%22%3E alert(1) %3C%2Fhandler%3E%0A%3C%2Fsvg%3E%0A#bar"/> </svg>',
+				true,
+				true,
+				'SVG with Tiny handler (http://html5sec.org/#104)'
+			),
+			array(
+				'<svg xmlns="http://www.w3.org/2000/svg"> <a id="x"><rect fill="white" width="1000" height="1000"/></a> <rect fill="white" style="clip-path:url(test3.svg#a);fill:url(#b);filter:url(#c);marker:url(#d);mask:url(#e);stroke:url(#f);"/> </svg>',
+				true,
+				true,
+				'SVG with new CSS styles properties (http://html5sec.org/#109)'
+			),
+			array(
+				'<svg xmlns="http://www.w3.org/2000/svg"> <a id="x"><rect fill="white" width="1000" height="1000"/></a> <rect clip-path="url(test3.svg#a)" /> </svg>',
+				true,
+				true,
+				'SVG with new CSS styles properties as attributes'
+			),
+			array(
+				'<svg xmlns="http://www.w3.org/2000/svg"> <a id="x"> <rect fill="white" width="1000" height="1000"/> </a> <rect fill="url(http://html5sec.org/test3.svg#a)" /> </svg>',
+				true,
+				true,
+				'SVG with new CSS styles properties as attributes (2)'
+			),
+			array(
+				'<svg xmlns="http://www.w3.org/2000/svg"> <path d="M0,0" style="marker-start:url(test4.svg#a)"/> </svg>',
+				true,
+				true,
+				'SVG with path marker-start (http://html5sec.org/#110)'
+			),
+			array(
+				'<?xml version="1.0"?> <?xml-stylesheet type="text/xml" href="#stylesheet"?> <!DOCTYPE doc [ <!ATTLIST xsl:stylesheet id ID #REQUIRED>]> <svg xmlns="http://www.w3.org/2000/svg"> <xsl:stylesheet id="stylesheet" version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"> <xsl:template match="/"> <iframe xmlns="http://www.w3.org/1999/xhtml" src="javascript:alert(1)"></iframe> </xsl:template> </xsl:stylesheet> <circle fill="red" r="40"></circle> </svg>',
+				true,
+				true,
+				'SVG with embedded stylesheet (http://html5sec.org/#125)'
+			),
+			array(
+				'<svg xmlns="http://www.w3.org/2000/svg" id="x"> <listener event="load" handler="#y" xmlns="http://www.w3.org/2001/xml-events" observer="x"/> <handler id="y">alert(1)</handler> </svg>',
+				true,
+				true,
+				'SVG with handler attribute (http://html5sec.org/#127)'
+			),
+			array(
+				// Haven't found a browser that accepts this particular example, but we
+				// don't want to allow embeded svgs, ever
+				'<svg> <image style=\'filter:url("data:image/svg+xml;charset=utf-8;base64, PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxzY3JpcHQ/YWxlcnQoMSk8L3NjcmlwdD48L3N2Zz4NCg==")\' /> </svg>',
+				true,
+				true,
+				'SVG with image filter via style (http://html5sec.org/#129)'
+			),
+			array(
+				// This doesn't seem possible without embedding the svg, but just in case
+				'<svg> <a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="?"> <circle r="400"></circle> <animate attributeName="xlink:href" begin="0" from="javascript:alert(1)" to="" /> </a></svg>',
+				true,
+				true,
+				'SVG with animate from (http://html5sec.org/#137)'
+			),
+
+			// Other hostile SVG's
+			array(
+				'<?xml version="1.0" encoding="UTF-8" standalone="no"?> <svg xmlns:xlink="http://www.w3.org/1999/xlink"> <image xlink:href="https://upload.wikimedia.org/wikipedia/commons/3/34/Bahnstrecke_Zeitz-Camburg_1930.png" /> </svg>',
+				true,
+				true,
+				'SVG with non-local image href (bug 65839)'
+			),
+			array(
+				'<?xml version="1.0" ?> <?xml-stylesheet type="text/xsl" href="/w/index.php?title=User:Jeeves/test.xsl&amp;action=raw&amp;format=xml" ?> <svg> <height>50</height> <width>100</width> </svg>',
+				true,
+				true,
+				'SVG with remote stylesheet (bug 57550)'
+			),
+			array(
+				'<svg xmlns="http://www.w3.org/2000/svg" viewbox="-1 -1 15 15"> <rect y="0" height="13" width="12" stroke="#179" rx="1" fill="#2ac"/> <text x="1.5" y="11" font-family="courier" stroke="white" font-size="16"><![CDATA[B]]></text> <iframe xmlns="http://www.w3.org/1999/xhtml" srcdoc="&#x3C;&#x73;&#x63;&#x72;&#x69;&#x70;&#x74;&#x3E;&#x61;&#x6C;&#x65;&#x72;&#x74;&#x28;&#x27;&#x58;&#x53;&#x53;&#x45;&#x44;&#x20;&#x3D;&#x3E;&#x20;&#x44;&#x6F;&#x6D;&#x61;&#x69;&#x6E;&#x28;&#x27;&#x2B;&#x74;&#x6F;&#x70;&#x2E;&#x64;&#x6F;&#x63;&#x75;&#x6D;&#x65;&#x6E;&#x74;&#x2E;&#x64;&#x6F;&#x6D;&#x61;&#x69;&#x6E;&#x2B;&#x27;&#x29;&#x27;&#x29;&#x3B;&#x3C;&#x2F;&#x73;&#x63;&#x72;&#x69;&#x70;&#x74;&#x3E;"></iframe> </svg>',
+				true,
+				true,
+				'SVG with rembeded iframe (bug 60771)'
+			),
+			array(
+				'<svg xmlns="http://www.w3.org/2000/svg" viewBox="6 3 177 153" xmlns:xlink="http://www.w3.org/1999/xlink"> <style>@import url("https://fonts.googleapis.com/css?family=Bitter:700&amp;text=WebPlatform.org");</style> <g transform="translate(-.5,-.5)"> <text fill="#474747" x="95" y="150" text-anchor="middle" font-family="Bitter" font-size="20" font-weight="bold">WebPlatform.org</text> </g> </svg>',
+				true,
+				true,
+				'SVG with @import in style element (bug 69008)'
+			),
+			array(
+				'<svg xmlns="http://www.w3.org/2000/svg" viewBox="6 3 177 153" xmlns:xlink="http://www.w3.org/1999/xlink"> <style>@import url("https://fonts.googleapis.com/css?family=Bitter:700&amp;text=WebPlatform.org");<foo/></style> <g transform="translate(-.5,-.5)"> <text fill="#474747" x="95" y="150" text-anchor="middle" font-family="Bitter" font-size="20" font-weight="bold">WebPlatform.org</text> </g> </svg>',
+				true,
+				true,
+				'SVG with @import in style element and child element (bug 69008#c11)'
+			),
+			array(
+				'<svg xmlns="http://www.w3.org/2000/svg"> <rect width="100" height="100" style="background-image:url(https://www.google.com/images/srpr/logo11w.png)"/> </svg>',
+				true,
+				true,
+				'SVG with remote background image (bug 69008)'
+			),
+			array(
+				'<svg xmlns="http://www.w3.org/2000/svg"> <rect width="100" height="100" style="background-image:\55rl(https://www.google.com/images/srpr/logo11w.png)"/> </svg>',
+				true,
+				true,
+				'SVG with remote background image, encoded (bug 69008)'
+			),
+			array(
+				'<svg xmlns="http://www.w3.org/2000/svg"> <style> #a { background-image:\55rl(\'https://www.google.com/images/srpr/logo11w.png\'); } </style> <rect width="100" height="100" id="a"/> </svg>',
+				true,
+				true,
+				'SVG with remote background image, in style element (bug 69008)'
+			),
+			array(
+				// This currently doesn't seem to work in any browsers, but in case
+				// http://www.w3.org/TR/css3-images/ is implemented for SVG files
+				'<svg xmlns="http://www.w3.org/2000/svg"> <rect width="100" height="100" style="background-image:image(\'sprites.svg#xywh=40,0,20,20\')"/> </svg>',
+				true,
+				true,
+				'SVG with remote background image using image() (bug 69008)'
+			),
+
+			// Test good, but strange files that we want to allow
+			array(
+				'<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"> <g> <a xlink:href="http://en.wikipedia.org/wiki/Main_Page"> <path transform="translate(0,496)" id="path6706" d="m 112.09375,107.6875 -5.0625,3.625 -4.3125,5.03125 -0.46875,0.5 -4.09375,3.34375 -9.125,5.28125 -8.625,-3.375 z" style="fill:#cccccc;fill-opacity:1;stroke:#6e6e6e;stroke-width:0.69999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;display:inline" /> </a> </g> </svg>',
+				true,
+				false,
+				'SVG with <a> link to a remote site'
+			),
+			array(
+				'<svg> <defs> <filter id="filter6226" x="-0.93243687" width="2.8648737" y="-0.24250539" height="1.4850108"> <feGaussianBlur stdDeviation="3.2344681" id="feGaussianBlur6228" /> </filter> <clipPath id="clipPath2436"> <path d="M 0,0 L 0,0 L 0,0 L 0,0 z" id="path2438" /> </clipPath> </defs> <g clip-path="url(#clipPath2436)" id="g2460"> <text id="text2466"> <tspan>12345</tspan> </text> </g> <path style="fill:#346733;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:1, 1;stroke-dashoffset:0;filter:url(\'#filter6226\');fill-opacity:1;opacity:0.79807692" d="M 236.82371,332.63732 C 236.92217,332.63732 z" id="path5618" /> </svg>',
+				true,
+				false,
+				'SVG with local urls, including filter: in style'
+			),
+
+		);
+	}
 }
 
 class UploadTestHandler extends UploadBase {
@@ -134,6 +358,21 @@ class UploadTestHandler extends UploadBase {
 			$this->getTitle();
 			return $this->mTitleError;
 		}
+
+	/**
+	 * Almost the same as UploadBase::detectScriptInSvg, except it's
+	 * public, works on an xml string instead of filename, and returns
+	 * the result instead of interpreting them.
+	 */
+	public function checkSvgString( $svg ) {
+		$check = new XmlTypeCheck(
+			$svg,
+			array( $this, 'checkSvgScriptCallback' ),
+			false,
+			array( 'processing_instruction_handler' => 'UploadBase::checkSvgPICallback' )
+		);
+		return array( $check->wellFormed, $check->filterMatch );
+	}
 
 
 }


### PR DESCRIPTION
This applies the MW 1.19.19 security release which applies extra
CSS filtering to SVG files to prevent the inclusion of third-party
content.

/cc @owend 
