### PR TITLE
HG-133: Generate ETag for the current article and pass it to Mercury

### DIFF
--- a/extensions/wikia/MercuryApi/MercuryApiController.class.php
+++ b/extensions/wikia/MercuryApi/MercuryApiController.class.php
@@ -9,6 +9,8 @@ class MercuryApiController extends WikiaController {
 	const NUMBER_CONTRIBUTORS = 6;
 	const DEFAULT_PAGE = 1;
 
+	const HEADERS_ETAG = 'X-Mercury-ETag';
+
 	private $mercuryApi = null;
 
 	public function __construct() {
@@ -196,7 +198,7 @@ class MercuryApiController extends WikiaController {
 		if ( $this->wg->UseETag ) {
 			$eTag = $this->mercuryApi->getArticleETag( $articleId );
 			if ( $eTag ) {
-				$data['eTag'] = $eTag;
+				$this->response->setHeader( self::HEADERS_ETAG, $eTag );
 			}
 		}
 

--- a/extensions/wikia/MercuryApi/MercuryApiController.class.php
+++ b/extensions/wikia/MercuryApi/MercuryApiController.class.php
@@ -193,6 +193,13 @@ class MercuryApiController extends WikiaController {
 			'basePath' => $this->wg->Server
 		];
 
+		if ( $this->wg->UseETag ) {
+			$eTag = $this->mercuryApi->getArticleETag( $articleId );
+			if ( $eTag ) {
+				$data['eTag'] = $eTag;
+			}
+		}
+
 		$relatedPages = $this->getRelatedPages( $articleId );
 		if ( !empty( $relatedPages ) ) {
 			$data['relatedPages'] = $relatedPages;

--- a/extensions/wikia/MercuryApi/models/MercuryApi.class.php
+++ b/extensions/wikia/MercuryApi/models/MercuryApi.class.php
@@ -309,4 +309,17 @@ class MercuryApi {
 			];
 		});
 	}
+
+	/**
+	 * Returns ETag for the article with given ID
+	 *
+	 * @param $articleId Article ID
+	 * @return bool|string
+	 */
+	public function getArticleETag( $articleId ) {
+		$article = Article::newFromID( $articleId );
+		$context =  RequestContext::newExtraneousContext( $article->getTitle() );
+		$parserOptions = ParserOptions::newFromContext( $context );
+		return ParserCache::singleton()->getETag( $article, $parserOptions );
+	}
 }

--- a/extensions/wikia/MercuryApi/models/MercuryApi.class.php
+++ b/extensions/wikia/MercuryApi/models/MercuryApi.class.php
@@ -313,7 +313,7 @@ class MercuryApi {
 	/**
 	 * Returns ETag for the article with given ID
 	 *
-	 * @param $articleId Article ID
+	 * @param integer $articleId Article ID
 	 * @return bool|string
 	 */
 	public function getArticleETag( $articleId ) {


### PR DESCRIPTION
Generate ETag from MediaWiki and pass it to Mercury as X-Mercury-ETag header.

The goal is to use the same caching strategy on Mercury as in MediaWiki.

/cc @macbre @michalroszka 
