### PR TITLE
MAIN-2922: Unlist the Specail:Mercury page

### DIFF
--- a/extensions/wikia/MercuryApi/MercurySpecialPageController.class.php
+++ b/extensions/wikia/MercuryApi/MercurySpecialPageController.class.php
@@ -7,7 +7,6 @@
 class MercurySpecialPageController extends WikiaSpecialPageController {
 
 	const PAGE_NAME = 'Mercury';
-
 	const COOKIE_NAME = 'wk_mercury';
 	const OPT_IN = 1;
 	const COOKIE_EXPIRE_DAYS = 7;

--- a/extensions/wikia/MercuryApi/MercurySpecialPageController.class.php
+++ b/extensions/wikia/MercuryApi/MercurySpecialPageController.class.php
@@ -7,15 +7,23 @@
 class MercurySpecialPageController extends WikiaSpecialPageController {
 
 	const PAGE_NAME = 'Mercury';
+	const PAGE_RESTRICTION = 'lookupuser';
 	const COOKIE_NAME = 'wk_mercury';
 	const OPT_IN = 1;
 	const COOKIE_EXPIRE_DAYS = 7;
 
 	public function __construct() {
-		parent::__construct( self::PAGE_NAME );
+		parent::__construct( self::PAGE_NAME, self::PAGE_RESTRICTION, false );
 	}
 
 	public function index() {
+		global $wgUser;
+
+		if( !$wgUser->isAllowed( self::PAGE_RESTRICTION ) ) {
+			$this->displayRestrictionError();
+			return;
+		}
+
 		$opt = $this->request->getVal( 'opt' );
 		if ( !empty( $opt ) ) {
 			if ( $opt === 'in' ) {

--- a/extensions/wikia/MercuryApi/MercurySpecialPageController.class.php
+++ b/extensions/wikia/MercuryApi/MercurySpecialPageController.class.php
@@ -8,22 +8,15 @@ class MercurySpecialPageController extends WikiaSpecialPageController {
 
 	const PAGE_NAME = 'Mercury';
 
-	// This is an action used in both Staff and Utils groups
-	const PAGE_RESTRICTION = 'lookupuser';
 	const COOKIE_NAME = 'wk_mercury';
 	const OPT_IN = 1;
 	const COOKIE_EXPIRE_DAYS = 7;
 
 	public function __construct() {
-		parent::__construct( self::PAGE_NAME, self::PAGE_RESTRICTION, false );
+		parent::__construct( self::PAGE_NAME, '', false );
 	}
 
 	public function index() {
-		if( !$this->wg->User->isAllowed( self::PAGE_RESTRICTION ) ) {
-			$this->displayRestrictionError();
-			return;
-		}
-
 		$opt = $this->request->getVal( 'opt' );
 		if ( !empty( $opt ) ) {
 			if ( $opt === 'in' ) {

--- a/extensions/wikia/MercuryApi/MercurySpecialPageController.class.php
+++ b/extensions/wikia/MercuryApi/MercurySpecialPageController.class.php
@@ -7,6 +7,8 @@
 class MercurySpecialPageController extends WikiaSpecialPageController {
 
 	const PAGE_NAME = 'Mercury';
+
+	// This is an action used in both Staff and Utils groups
 	const PAGE_RESTRICTION = 'lookupuser';
 	const COOKIE_NAME = 'wk_mercury';
 	const OPT_IN = 1;
@@ -17,9 +19,7 @@ class MercurySpecialPageController extends WikiaSpecialPageController {
 	}
 
 	public function index() {
-		global $wgUser;
-
-		if( !$wgUser->isAllowed( self::PAGE_RESTRICTION ) ) {
+		if( !$this->wg->User->isAllowed( self::PAGE_RESTRICTION ) ) {
 			$this->displayRestrictionError();
 			return;
 		}


### PR DESCRIPTION
Restricts acces to users having `lookupuser` access Utils and Staff only and de-lists the Special page from Special:SpecialPages.
