### PR TITLE
force master database connection during wiki creation process

### DIFF
--- a/extensions/wikia/CreateNewWiki/CreateWiki.php
+++ b/extensions/wikia/CreateNewWiki/CreateWiki.php
@@ -153,6 +153,11 @@ class CreateWiki {
 	public function create() {
 		global $wgWikiaLocalSettingsPath, $wgExternalSharedDB, $wgSharedDB, $wgUser;
 
+		// Set this flag to ensure that all select operations go against master
+		// Slave lag can cause random errors during wiki creation process
+		global $wgForceMasterDatabase;
+		$wgForceMasterDatabase = true;
+
 		wfProfileIn( __METHOD__ );
 
 		if ( wfReadOnly() ) {
@@ -292,13 +297,6 @@ class CreateWiki {
 			wfDebugLog( "createwiki", __METHOD__ . ": Creating tables not finished\n", true );
 			wfProfileOut( __METHOD__ );
 			return self::ERROR_SQL_FILE_BROKEN;
-		}
-
-		// Hack to slow down the devbox database creation because createTables() returns
-		// before the tables are created on the slave, and the uploadImage function hits the slave
-		global $wgDevelEnvironment;
-		if (isset($wgDevelEnvironment)) {
-			sleep(15);
 		}
 
 		/**

--- a/extensions/wikia/CreateNewWiki/CreateWikiLocalJob.php
+++ b/extensions/wikia/CreateNewWiki/CreateWikiLocalJob.php
@@ -64,6 +64,11 @@ class CreateWikiLocalJob extends Job {
 		global $wgUser, $wgErrorLog, $wgDebugLogFile,
 			$wgServer, $wgInternalServer;
 
+		// Set this flag to ensure that all select operations go against master
+		// Slave lag can cause random errors during wiki creation process
+		global $wgForceMasterDatabase;
+		$wgForceMasterDatabase = true;
+
 		wfProfileIn( __METHOD__ );
 
 		/**
@@ -131,12 +136,12 @@ class CreateWikiLocalJob extends Job {
 		$this->moveMainPage();
 		$this->changeStarterContributions();
 		$this->setWelcomeTalkPage();
-		if ( empty( $this->mParams->disableWelcome ) ) { 
+		if ( empty( $this->mParams->disableWelcome ) ) {
 			$this->sendWelcomeMail();
 		}
 		$this->populateCheckUserTables();
 		$this->protectKeyPages();
-		if ( empty( $this->mParams->disableReminder ) ) { 
+		if ( empty( $this->mParams->disableReminder ) ) {
 			$this->queueReminderMail();
 		}
 		$this->sendRevisionToScribe();
@@ -146,7 +151,7 @@ class CreateWikiLocalJob extends Job {
 			'url'	=> $this->mParams->url,
 			'city_id' => $this->mParams->city_id
 		);
-		
+
 		if ( empty( $this->mParams->disableCompleteHook ) ) {
 			wfRunHooks( 'CreateWikiLocalJob-complete', array( $params ) );
 		}

--- a/includes/db/LoadBalancer.php
+++ b/includes/db/LoadBalancer.php
@@ -444,6 +444,10 @@ class LoadBalancer {
 	public function &getConnection( $i, $groups = array(), $wiki = false ) {
 		wfProfileIn( __METHOD__ );
 
+		// Set this flag to ensure that all select operations go against master
+		// Slave lag can cause random errors during wiki creation process
+		global $wgForceMasterDatabase;
+
 		if ( $i == DB_LAST ) {
 			throw new MWException( 'Attempt to call ' . __METHOD__ . ' with deprecated server index DB_LAST' );
 		} elseif ( $i === null || $i === false ) {
@@ -455,7 +459,7 @@ class LoadBalancer {
 		}
 
 		# Query groups
-		if ( $i == DB_MASTER ) {
+		if ( $i == DB_MASTER || $wgForceMasterDatabase ) {
 			$i = $this->getWriterIndex();
 		} elseif ( !is_array( $groups ) ) {
 			$groupIndex = $this->getReaderIndex( $groups, $wiki );

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -738,6 +738,7 @@ $wgExternalWikiaStatsDB = 'wikiastats';
 $wgSpecialsDB = 'specials';
 $wgSharedKeyPrefix = "wikicities"; // default value for shared key prefix, @see wfSharedMemcKey
 $wgWikiaMailerDB = 'wikia_mailer';
+$wgForceMasterDatabase = false;  // true only during wiki creation process
 
 $wgAutoloadClasses['LBFactory_Wikia'] = "$IP/includes/wikia/LBFactory_Wikia.php";
 $wgAutoloadClasses['Wikia\\MastersPoll'] = "$IP/includes/wikia/MastersPoll.php";

--- a/includes/wikia/tasks/Tasks/CreateNewWikiTask.class.php
+++ b/includes/wikia/tasks/Tasks/CreateNewWikiTask.class.php
@@ -20,8 +20,11 @@ class CreateNewWikiTask extends BaseTask {
 	private $wikiLang;
 
 	public function init() {
-		global $IP;
+		global $IP, $wgForceMasterDatabase;
 
+		// Set this flag to ensure that all select operations go against master
+		// Slave lag can cause random errors during wiki creation process
+		$wgForceMasterDatabase = true;
 		parent::init();
 
 		$this->title = \Title::newFromText( NS_MAIN, "Main" );
@@ -446,4 +449,4 @@ class CreateNewWikiTask extends BaseTask {
 
 		$this->info('send starter revisions to scribe', ['num_rows' => $numRows]);
 	}
-} 
+}


### PR DESCRIPTION
This prevents random failures during the wiki creation process because of slave lag.  

@lgarczewski @michalroszka 
