### PR TITLE
Vid 2013 - Adding bucky profiling to some JS

### DIFF
--- a/extensions/wikia/Lightbox/js/LightboxLoader.js
+++ b/extensions/wikia/Lightbox/js/LightboxLoader.js
@@ -3,7 +3,7 @@
 (function (window, $) {
 	'use strict';
 
-	var LightboxLoader, LightboxTracker;
+	var LightboxLoader, LightboxTracker, bucky;
 
 	LightboxLoader = {
 		// cached thumbnail arrays and detailed info
@@ -64,12 +64,16 @@
 		videoThumbWidthThreshold: 400,
 		init: function () {
 			var self = this,
-				$article = $('#WikiaArticle'),
-				$photos = $('#LatestPhotosModule'),
-				$comments = $('#WikiaArticleComments'), // event handled with $footer
-				$footer = $('#WikiaArticleFooter'), // bottom videos module
-				$videosModule = $('.videos-module-rail'), // right rail videos module
-				$videoHomePage = $('#latest-videos-wrapper');
+				$article, $photos, $comments, $footer, $videosModule, $videoHomePage;
+
+			bucky.timer.start('init');
+
+			$article = $('#WikiaArticle');
+			$photos = $('#LatestPhotosModule');
+			$comments = $('#WikiaArticleComments'); // event handled with $footer
+			$footer = $('#WikiaArticleFooter'); // bottom videos module
+			$videosModule = $('.videos-module-rail'); // right rail videos module
+			$videoHomePage = $('#latest-videos-wrapper');
 
 			// Bind click event to initiate lightbox
 			$article.add($photos).add($footer).add($videosModule)
@@ -163,6 +167,7 @@
 						}
 					}
 				);
+			bucky.timer.stop('init');
 		},
 
 		/**
@@ -172,6 +177,9 @@
 		 */
 		loadLightbox: function (mediaTitle, trackingInfo) {
 			var openModal, lightboxParams, deferredList, resources, deferredTemplate;
+
+			bucky.timer.start('loadLightbox');
+
 			// restore inline videos to default state, because flash players overlaps with modal
 			LightboxLoader.removeInlineVideos();
 			LightboxLoader.lightboxLoading = true;
@@ -230,6 +238,7 @@
 				// LASTINDEX: index is last-index due to how deferred resolve works in mulitiple deferred objects
 				Lightbox.initialFileDetail = arguments[arguments.length - 1];
 				Lightbox.makeLightbox(lightboxParams);
+				bucky.timer.stop('loadLightbox');
 			});
 
 		},
@@ -293,6 +302,7 @@
 			if (!nocache && LightboxLoader.cache.details[title]) {
 				callback(LightboxLoader.cache.details[title]);
 			} else {
+				bucky.timer.start('getMediaDetail.request');
 				$.nirvana.sendRequest({
 					controller: 'Lightbox',
 					method: 'getMediaDetail',
@@ -300,6 +310,7 @@
 					format: 'json',
 					data: mediaParams,
 					callback: function (json) {
+						bucky.timer.stop('getMediaDetail.request');
 						// Don't cache videos played inline because width will be off for lightbox version bugid-42269
 						if (!nocache) {
 							LightboxLoader.cache.details[title] = json;
@@ -407,6 +418,9 @@
 
 	$(function () {
 		if (window.wgEnableLightboxExt) {
+			// performance profiling
+			bucky = window.Bucky('LightboxLoader');
+
 			LightboxLoader.init();
 			LightboxLoader.loadFromURL();
 		}

--- a/extensions/wikia/Lightbox/js/LightboxLoader.js
+++ b/extensions/wikia/Lightbox/js/LightboxLoader.js
@@ -430,4 +430,4 @@
 	window.LightboxLoader = LightboxLoader;
 	window.LightboxTracker = LightboxTracker;
 
-})(this, jQuery);
+})(window, jQuery);

--- a/extensions/wikia/MediaGallery/scripts/controllers/index.js
+++ b/extensions/wikia/MediaGallery/scripts/controllers/index.js
@@ -21,7 +21,8 @@ require(['mediaGallery.views.gallery'], function (Gallery) {
 				model: {
 					media: data[idx]
 				},
-				origVisibleCount: origVisibleCount
+				origVisibleCount: origVisibleCount,
+				index: idx
 			});
 			$this.append(gallery.render(origVisibleCount).$el);
 

--- a/extensions/wikia/MediaGallery/scripts/spec/views/gallery.spec.js
+++ b/extensions/wikia/MediaGallery/scripts/spec/views/gallery.spec.js
@@ -9,6 +9,7 @@ describe('MediaGalleries gallery', function () {
 		templates,
 		instance,
 		options,
+		bucky,
 		tracker = {
 			buildTrackingFunction: $.noop,
 			ACTIONS: {
@@ -43,10 +44,11 @@ describe('MediaGalleries gallery', function () {
 		};
 
 		spyOn(Mustache, 'render').andReturn('okay');
+		bucky = modules['bucky.mock'];
 		templates = modules['mediaGallery.templates.mustache'];
 		Caption = modules['mediaGallery.views.caption']();
 		Media = modules['mediaGallery.views.media'](Caption, templates);
-		Gallery = modules['mediaGallery.views.gallery'](Media, templates, tracker);
+		Gallery = modules['mediaGallery.views.gallery'](Media, templates, tracker, bucky);
 	});
 
 	it('should export a function', function () {

--- a/extensions/wikia/MediaGallery/scripts/views/gallery.js
+++ b/extensions/wikia/MediaGallery/scripts/views/gallery.js
@@ -1,7 +1,7 @@
 define('mediaGallery.views.gallery', [
-    'mediaGallery.views.media',
-    'mediaGallery.templates.mustache',
-    'wikia.tracker',
+	'mediaGallery.views.media',
+	'mediaGallery.templates.mustache',
+	'wikia.tracker',
 	'bucky'
 ], function (Media, templates, tracker, bucky) {
 	'use strict';

--- a/extensions/wikia/MediaGallery/scripts/views/gallery.js
+++ b/extensions/wikia/MediaGallery/scripts/views/gallery.js
@@ -1,12 +1,16 @@
 define('mediaGallery.views.gallery', [
     'mediaGallery.views.media',
     'mediaGallery.templates.mustache',
-    'wikia.tracker'
-], function (Media, templates, tracker) {
+    'wikia.tracker',
+	'bucky'
+], function (Media, templates, tracker, bucky) {
 	'use strict';
 
 	var Gallery,
 		togglerTemplateName = 'MediaGallery_showMore';
+
+	// performance profiling
+	bucky = bucky('mediaGallery.views.gallery');
 
 	Gallery = function (options) {
 		this.$el = options.$el.addClass('media-gallery-inner');
@@ -45,6 +49,8 @@ define('mediaGallery.views.gallery', [
 			return;
 		}
 
+		bucky.timer.start('createMedia');
+
 		$.each(throttled, function (idx, data) {
 			var media = new Media({
 				$el: $('<div></div>'),
@@ -53,6 +59,8 @@ define('mediaGallery.views.gallery', [
 			});
 			self.media.push(media);
 		});
+
+		bucky.timer.stop('createMedia');
 	};
 
 	Gallery.prototype.bindEvents = function () {
@@ -80,6 +88,7 @@ define('mediaGallery.views.gallery', [
 	/**
 	 * Render sets of media.
 	 * @param {int} count Number to be rendered
+	 * @param {jQuery} $el Element to apply loading graphic
 	 * @returns {Gallery}
 	 */
 	Gallery.prototype.render = function (count, $el) {
@@ -87,6 +96,7 @@ define('mediaGallery.views.gallery', [
 			media,
 			deferredImages = [];
 
+		bucky.timer.start('render');
 		if ($el) {
 			$el.startThrobbing();
 		}
@@ -113,6 +123,7 @@ define('mediaGallery.views.gallery', [
 			$.each(media, function (idx, item) {
 				item.show();
 			});
+			bucky.timer.stop('render');
 		});
 
 		return this;

--- a/extensions/wikia/MediaGallery/scripts/views/gallery.js
+++ b/extensions/wikia/MediaGallery/scripts/views/gallery.js
@@ -9,9 +9,6 @@ define('mediaGallery.views.gallery', [
 	var Gallery,
 		togglerTemplateName = 'MediaGallery_showMore';
 
-	// performance profiling
-	bucky = bucky('mediaGallery.views.gallery');
-
 	Gallery = function (options) {
 		this.$el = options.$el.addClass('media-gallery-inner');
 		this.$wrapper = options.$wrapper;
@@ -19,6 +16,8 @@ define('mediaGallery.views.gallery', [
 		this.origVisibleCount = options.origVisibleCount;
 		this.interval = options.interval || 12;
 		this.throttleVal = options.throttleVal || 200;
+		// performance profiling
+		this.bucky = bucky('mediaGallery.views.gallery.' + options.index);
 
 		this.rendered = false;
 		this.visibleCount = 0;
@@ -49,7 +48,7 @@ define('mediaGallery.views.gallery', [
 			return;
 		}
 
-		bucky.timer.start('createMedia');
+		this.bucky.timer.start('createMedia');
 
 		$.each(throttled, function (idx, data) {
 			var media = new Media({
@@ -60,7 +59,7 @@ define('mediaGallery.views.gallery', [
 			self.media.push(media);
 		});
 
-		bucky.timer.stop('createMedia');
+		this.bucky.timer.stop('createMedia');
 	};
 
 	Gallery.prototype.bindEvents = function () {
@@ -94,14 +93,17 @@ define('mediaGallery.views.gallery', [
 	Gallery.prototype.render = function (count, $el) {
 		var self = this,
 			media,
+			mediaCount,
 			deferredImages = [];
 
-		bucky.timer.start('render');
+		media = this.media.slice(this.visibleCount, this.visibleCount + count);
+		mediaCount = media.length;
+		this.bucky.timer.start('render.' + mediaCount);
+
 		if ($el) {
 			$el.startThrobbing();
 		}
 
-		media = this.media.slice(this.visibleCount, this.visibleCount + count);
 		$.each(media, function (idx, item) {
 			item.render();
 			self.$el.append(item.$el);
@@ -123,7 +125,7 @@ define('mediaGallery.views.gallery', [
 			$.each(media, function (idx, item) {
 				item.show();
 			});
-			bucky.timer.stop('render');
+			self.bucky.timer.stop('render.' + mediaCount);
 		});
 
 		return this;

--- a/extensions/wikia/VideosModule/scripts/controllers/index.js
+++ b/extensions/wikia/VideosModule/scripts/controllers/index.js
@@ -5,18 +5,28 @@
  */
 require([
 	'videosmodule.views.rail',
-	'videosmodule.models.videos'
-], function (RailModule, VideoData) {
+	'videosmodule.models.videos',
+	'bucky'
+], function (RailModule, VideoData, bucky) {
 	'use strict';
 
 	var $rail = $('#WikiaRail');
 
+	bucky = bucky('videosmodule.controller.index');
+
 	function init() {
+		var rail;
+
+		bucky.timer.start('execution');
 		// instantiate rail view
-		return new RailModule({
-			el: document.getElementById('videosModule'),
+		rail = new RailModule({
+			$el: $('#videosModule'),
 			model: new VideoData(),
 			isFluid: false
+		});
+
+		rail.$el.on('initialized.videosModule', function () {
+			bucky.timer.stop('execution');
 		});
 	}
 

--- a/extensions/wikia/VideosModule/scripts/views/rail.js
+++ b/extensions/wikia/VideosModule/scripts/views/rail.js
@@ -1,11 +1,14 @@
 define('videosmodule.views.rail', [
 	'videosmodule.views.titleThumbnail',
 	'wikia.tracker',
-	'wikia.log'
-], function (TitleThumbnailView, Tracker, log) {
+	'wikia.log',
+    'bucky'
+], function (TitleThumbnailView, Tracker, log, bucky) {
 	'use strict';
 
-	var track;
+	var VideosModule, track;
+
+	bucky = bucky('videosmodule.views.rail');
 
 	track = Tracker.buildTrackingFunction({
 		category: 'videos-module-rail',
@@ -14,7 +17,7 @@ define('videosmodule.views.rail', [
 		label: 'module-impression'
 	});
 
-	function VideoModule(options) {
+	VideosModule = function (options) {
 		// this.el is the container for the right rail videos module
 		this.el = options.el;
 		this.$el = $(options.el);
@@ -29,9 +32,9 @@ define('videosmodule.views.rail', [
 		if (this.articleId) {
 			this.init();
 		}
-	}
+	};
 
-	VideoModule.prototype.init = function () {
+	VideosModule.prototype.init = function () {
 		var self = this;
 
 		self.$thumbs.addClass('hidden');
@@ -46,7 +49,7 @@ define('videosmodule.views.rail', [
 			});
 	};
 
-	VideoModule.prototype.render = function () {
+	VideosModule.prototype.render = function () {
 		var i,
 			videos = this.model.data.videos,
 			staffPickVideos = this.model.data.staffVideos,
@@ -58,6 +61,8 @@ define('videosmodule.views.rail', [
 			StaffPicksIndex,
 			vidsNeeded;
 
+		bucky.timer.start('render');
+
 		// If we don't have enough videos to display the minimum amount, return
 		if (videos.length + staffPickVideos.length < this.minNumVids) {
 			this.$el.addClass('hidden');
@@ -67,6 +72,7 @@ define('videosmodule.views.rail', [
 				'VideosModule',
 				true
 			);
+			bucky.timer.stop('render');
 			return;
 		}
 
@@ -110,6 +116,7 @@ define('videosmodule.views.rail', [
 			.done(function () {
 				self.$thumbs.removeClass('hidden');
 				self.$el.stopThrobbing();
+				bucky.timer.stop('render');
 			});
 
 		// Remove tracking for Special Wikis Sampled at 100% -- VID-1800
@@ -123,7 +130,7 @@ define('videosmodule.views.rail', [
 	 * Using Fisher-Yates shuffle algorithm.
 	 * Slightly adapted from http://stackoverflow.com/questions/2450954/how-to-randomize-shuffle-a-javascript-array
 	 */
-	VideoModule.prototype.shuffle = function(array) {
+	VideosModule.prototype.shuffle = function (array) {
 		var i, j, temp;
 
 		for (i = array.length - 1; i > 0; i--) {
@@ -135,5 +142,5 @@ define('videosmodule.views.rail', [
 		return array;
 	};
 
-	return VideoModule;
+	return VideosModule;
 });

--- a/extensions/wikia/VideosModule/scripts/views/rail.js
+++ b/extensions/wikia/VideosModule/scripts/views/rail.js
@@ -19,8 +19,7 @@ define('videosmodule.views.rail', [
 
 	VideosModule = function (options) {
 		// this.el is the container for the right rail videos module
-		this.el = options.el;
-		this.$el = $(options.el);
+		this.$el = options.$el;
 		this.model = options.model;
 
 		this.$thumbs = this.$el.find('.thumbnails');
@@ -79,7 +78,8 @@ define('videosmodule.views.rail', [
 		$.when($imagesLoaded)
 			.done(function () {
 				self.$thumbs.removeClass('hidden');
-				self.$el.stopThrobbing();
+				self.$el.stopThrobbing()
+					.trigger('initialized.videosModule');
 				bucky.timer.stop('render');
 			});
 

--- a/extensions/wikia/VideosModule/scripts/views/rail.js
+++ b/extensions/wikia/VideosModule/scripts/views/rail.js
@@ -2,7 +2,7 @@ define('videosmodule.views.rail', [
 	'videosmodule.views.titleThumbnail',
 	'wikia.tracker',
 	'wikia.log',
-    'bucky'
+	'bucky'
 ], function (TitleThumbnailView, Tracker, log, bucky) {
 	'use strict';
 

--- a/extensions/wikia/VideosModule/scripts/views/rail.js
+++ b/extensions/wikia/VideosModule/scripts/views/rail.js
@@ -108,6 +108,37 @@ define('videosmodule.views.rail', [
 	};
 
 	/**
+	 * If there are less related videos than our default amount, this.NumVids, pull additional
+	 * videos from the staffPicks videos
+	 */
+	VideosModule.prototype.addBackfill = function () {
+		var vidsNeeded;
+
+		if (this.videos.length < this.numVids) {
+			vidsNeeded = this.numVids - this.videos.length;
+			this.videos = this.videos.concat(this.staffPickVideos.splice(0, vidsNeeded));
+			this.numVids = this.videos.length;
+		}
+	};
+
+	/**
+	 * Randomize array element order in-place.
+	 * Using Fisher-Yates shuffle algorithm.
+	 * Slightly adapted from http://stackoverflow.com/questions/2450954/how-to-randomize-shuffle-a-javascript-array
+	 */
+	VideosModule.prototype.shuffle = function (array) {
+		var i, j, temp;
+
+		for (i = array.length - 1; i > 0; i--) {
+			j = Math.floor(Math.random() * (i + 1));
+			temp = array[i];
+			array[i] = array[j];
+			array[j] = temp;
+		}
+		return array;
+	};
+
+	/**
 	 * If we have any staff pick videos, pick one randomly from that list and display it
 	 * in a random position in the Videos Module.
 	 */
@@ -119,20 +150,6 @@ define('videosmodule.views.rail', [
 			VideosIndex = Math.floor(Math.random() * this.numVids);
 			StaffPicksIndex = Math.floor(Math.random() * this.staffPickVideos.length);
 			this.videos[VideosIndex] = this.staffPickVideos[StaffPicksIndex];
-		}
-	};
-
-	/**
-	 * If there are less related videos than our default amount, this.NumVids, pull additional
-	 * videos from the staffPicks videos
-	 */
-	VideosModule.prototype.addBackfill = function () {
-		var vidsNeeded;
-
-		if (this.videos.length < this.numVids) {
-			vidsNeeded = this.numVids - this.videos.length;
-			this.videos = this.videos.concat(this.staffPickVideos.splice(0, vidsNeeded));
-			this.numVids = this.videos.length;
 		}
 	};
 
@@ -155,23 +172,6 @@ define('videosmodule.views.rail', [
 		}
 
 		return thumbHtml;
-	};
-
-	/**
-	 * Randomize array element order in-place.
-	 * Using Fisher-Yates shuffle algorithm.
-	 * Slightly adapted from http://stackoverflow.com/questions/2450954/how-to-randomize-shuffle-a-javascript-array
-	 */
-	VideosModule.prototype.shuffle = function (array) {
-		var i, j, temp;
-
-		for (i = array.length - 1; i > 0; i--) {
-			j = Math.floor(Math.random() * (i + 1));
-			temp = array[i];
-			array[i] = array[j];
-			array[j] = temp;
-		}
-		return array;
 	};
 
 	return VideosModule;


### PR DESCRIPTION
Added bucky profiling to: 
- media gallery 
- ligthbox loader
- videos module

Also did some code cleanup as I went. 

To do: 
- [x] Add overall time from init to render of videos module
- [x] Add mention of how many media items are being rendered in gallery.render()
