### PR TITLE
MWEB-965 Changes in HTTP codes returned by maps service

### DIFF
--- a/extensions/wikia/WikiaInteractiveMaps/models/WikiaMaps.class.php
+++ b/extensions/wikia/WikiaInteractiveMaps/models/WikiaMaps.class.php
@@ -19,10 +19,9 @@ class WikiaMaps extends WikiaObject {
 	const MAP_TYPE_CUSTOM = 'custom';
 	const MAP_TYPE_GEO = 'geo';
 
-	const HTTP_CREATED_CODE = 201;
+	const HTTP_ACCEPTED_CODE = 202;
 	const HTTP_SUCCESS_OK = 200;
 	const HTTP_UPDATED = 303;
-	const HTTP_NO_CONTENT = 204;
 
 	const MAP_THUMB_PREFIX = '/thumb/';
 	const DEFAULT_REAL_MAP_URL = 'http://img.wikia.nocookie.net/intmap_Geo_Map/default-geo.jpg';
@@ -165,7 +164,7 @@ class WikiaMaps extends WikiaObject {
 	/**
 	 * Sends requests to IntMap service to get data about a map and tiles it's connected with
 	 *
-	 * @param $mapId Map id
+	 * @param integer $mapId Map id
 	 * @param array $params additional parameters
 	 *
 	 * @return mixed
@@ -519,9 +518,8 @@ class WikiaMaps extends WikiaObject {
 	 */
 	private function isSuccess( $status, $content ) {
 		$isStatusOK = in_array( $status, [
-			self::HTTP_CREATED_CODE,
-			self::HTTP_UPDATED,
-			self::HTTP_NO_CONTENT,
+			self::HTTP_ACCEPTED_CODE,
+			self::HTTP_UPDATED
 		] );
 
 		// MW Http::request() can return 200 HTTP code if service is offline


### PR DESCRIPTION
The changes are connected to recent work on refactoring `interactive-maps` service code. We changed the HTTP status codes while refactoring CRUD files:
- https://github.com/Wikia/interactive-maps/commit/26ab7515ea683caee322935e554c73339b3b0d33,
- https://github.com/Wikia/interactive-maps/commit/cfae0f9573450c59b61077d80029a0ee3b5341c3,
- https://github.com/Wikia/interactive-maps/commit/883d1ae7f7f9c73c43de0dc822fb4cb80634c3a4,
- https://github.com/Wikia/interactive-maps/commit/bade108fd1053e5482492035ca3439fc5bb9d8ee,
- https://github.com/Wikia/interactive-maps/commit/3d525926cef591ff054746b43bd49194be73b5f1.

The change of HTTP code statuses will fix our automation Python changes for maps' API.

These small PHP changes are connected to ones mentioned above. After tests all connected pull requests will get merged:
- https://github.com/Wikia/interactive-maps/pull/214
