### PR TITLE
VE-1555: Do not "double fire" tracking for performance.system.activation/edit-page-ready

### DIFF
--- a/extensions/VisualEditor/modules/ve-mw/init/ve.init.mw.TargetEvents.js
+++ b/extensions/VisualEditor/modules/ve-mw/init/ve.init.mw.TargetEvents.js
@@ -169,7 +169,9 @@ ve.init.mw.TargetEvents.prototype.onSaveErrorUnknown = function () {
 };
 
 ve.init.mw.TargetEvents.prototype.onSurfaceReady = function () {
-	this.track( 'performance.system.activation', { 'duration': ve.now() - this.timings.activationStart } );
+	if ( this.target.wikitext === null ) {
+		this.track( 'performance.system.activation', { 'duration': ve.now() - this.timings.activationStart } );
+	}
 	this.target.surface.getModel().getDocument().connect( this, {
 		'transact': 'recordLastTransactionTime'
 	} );


### PR DESCRIPTION
Use "wikitext" property on target object as a flag to figure out if it's "initial" load of VE (then track event) or subsequent (then do not track event)

https://wikia-inc.atlassian.net/browse/VE-1555
