### PR TITLE
Fix JS errors log URL for mobile apps

### DIFF
--- a/extensions/wikia/GameGuides/GameGuidesController.class.php
+++ b/extensions/wikia/GameGuides/GameGuidesController.class.php
@@ -289,6 +289,8 @@ class GameGuidesController extends WikiaController {
 
 		$titleName = $this->request->getVal( 'page' );
 
+		$this->wg->WikiaForceSchemeInUrls = true;
+
 		$html = ApiService::call(
 			array(
 				'action' => 'parse',

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1548,6 +1548,14 @@ $wgDisableWAMOnHubs = false;
 
 /**
  * Force ImageServing to return an empty list
- * see PLATFORM-392
+ * @see PLATFORM-392
  */
 $wgImageServingForceNoResults = false;
+
+/**
+ * Controls whether producing URLs without scheme (http:/https:) is accepted in current request
+ * Primary use case is iOS apps that load articles from local disk cache and URLs starting with
+ * "//domain.com" produce errors.
+ * @see PLATFORM-486
+ */
+$wgWikiaForceSchemeInUrls = false;

--- a/lib/Wikia/src/Logger/Hooks.php
+++ b/lib/Wikia/src/Logger/Hooks.php
@@ -20,15 +20,21 @@ class Hooks {
 	 *
 	 */
 	public static function onWikiaSkinTopScripts( &$vars, &$scripts ) {
-		global $wgDevelEnvironment, $wgIsGASpecialWiki, $wgEnableJavaScriptErrorLogging, $wgCacheBuster, $wgMemc;
+		global $wgDevelEnvironment, $wgIsGASpecialWiki, $wgEnableJavaScriptErrorLogging, $wgMemc, $wgWikiaForceSchemeInUrls;
 
 		if ( !$wgDevelEnvironment ) {
 			$onError = $wgIsGASpecialWiki || $wgEnableJavaScriptErrorLogging;
-			$key = "wikialogger-top-script-$onError";
+			$key = sprintf("wikialogger-top-script-%d-%d",
+				intval($onError), intval($wgWikiaForceSchemeInUrls));
 			$loggingJs = $wgMemc->get( $key );
 
 			if ( !$loggingJs ) {
 				$errorUrl = "//jserrorslog.wikia.com/";
+				if ( !empty($wgWikiaForceSchemeInUrls) ) {
+					# we currently don't support https so it's safe to fall back to http
+					$errorUrl = "http:{$errorUrl}";
+				}
+
 				$loggingJs = "
 					function syslogReport(priority, message, context) {
 						context = context || null;


### PR DESCRIPTION
Fix JS errors log URL by prefixing it with scheme ("http:") in content returned to mobile apps. Lack thereof resulted in mobile apps breaking when JS error happened. Designed solution should be quite generic and allow adding other checks wherever necessary.

PLATFORM-486

@Wikia/platform-team pls review
