### PR TITLE
Removing deprecated right

### DIFF
--- a/extensions/wikia/CreateNewWiki/CreateNewWiki_setup.php
+++ b/extensions/wikia/CreateNewWiki/CreateNewWiki_setup.php
@@ -29,7 +29,6 @@ $wgAvailableRights[] = 'createnewwiki';
 $wgGroupPermissions['*']['createnewwiki'] = true;
 $wgGroupPermissions['staff']['createnewwiki'] = true;
 
-$wgAvailableRights[] = 'createwikimakefounder'; // user can give another's name as founder
 $wgAvailableRights[] = 'createwikilimitsexempt'; // user not bound by creation throttle
 $wgGroupPermissions['staff']['createwikilimitsexempt'] = true;
 


### PR DESCRIPTION
Ability to set founder was removed in a redesign a while ago. End-around is Staff can use Piggyback if truly needed.
