### PR TITLE
Flower Http request timeouts

### DIFF
--- a/includes/HttpFunctions.php
+++ b/includes/HttpFunctions.php
@@ -89,9 +89,8 @@ class Http {
 			];
 			if ( !$isOk ) {
 				$params[ 'statusMessage' ] = $status->getMessage();
+				\Wikia\Logger\WikiaLogger::instance()->debug( 'Http request' , $params );
 			}
-			\Wikia\Logger\WikiaLogger::instance()->debug( 'Http request' , $params );
-
 		}
 
 		// Wikia change - @author: nAndy - begin

--- a/includes/wikia/tasks/TaskRunner.class.php
+++ b/includes/wikia/tasks/TaskRunner.class.php
@@ -8,12 +8,16 @@
  */
 
 class TaskRunner {
+	const TASK_NOTIFY_TIMEOUT = 120; // number of seconds required before we notify flower of our job status
+
 	private $taskId;
 	private $taskList = [];
 	private $results = [];
 	private $callOrder;
 
 	private $exception;
+	private $startTime;
+	private $endTime;
 
 	function __construct( $taskId, $taskList, $callOrder, $createdBy ) {
 		$this->taskId = $taskId;
@@ -39,6 +43,7 @@ class TaskRunner {
 	}
 
 	function run() {
+		$this->startTime = $this->endTime = time();
 		if ( $this->exception ) {
 			$this->results [] = $this->exception;
 			return;
@@ -71,6 +76,12 @@ class TaskRunner {
 				break;
 			}
 		}
+
+		$this->endTime = time();
+	}
+
+	public function runTime() {
+		return $this->endTime - $this->startTime;
 	}
 
 	public function format() {

--- a/maintenance/wikia/task_runner.php
+++ b/maintenance/wikia/task_runner.php
@@ -25,18 +25,19 @@ ob_start();
 $runner->run();
 $result = $runner->format();
 
-// for long-running tasks that end up timing out, we need to notify flower that
-// the task actually did complete successfully
-Http::post( "{$wgFlowerUrl}/api/task/status/{$options['task_id']}", [
-	'noProxy' => true,
-	'postData' => json_encode( [
-		'kwargs' => [
-			'completed' => time(),
-			'state' => $result->status,
-			'result' => ( $result->status == 'success' ? $result->retval : $result->reason ),
-		],
-	] ),
-] );
+if ($runner->runTime() > TaskRunner::TASK_NOTIFY_TIMEOUT) {
+	Http::post( "{$wgFlowerUrl}/api/task/status/{$options['task_id']}", [
+		'noProxy' => true,
+		'postData' => json_encode( [
+			'kwargs' => [
+				'completed' => time(),
+				'state' => $result->status,
+				'result' => ( $result->status == 'success' ? $result->retval : $result->reason ),
+			],
+		] ),
+	] );
+}
+
 ob_end_clean();
 
 // if the runner completes in time, this will report back to celery immediately


### PR DESCRIPTION
@Wikia/platform-team 
https://wikia-inc.atlassian.net/browse/PLATFORM-454

This change makes it so we only send task status events to Flower when a timing thereshhold is reached. I think part of the problem is we're sending a lot of unnecessary API requests to Flower, which it can't handle (we can't cluster Flower), so this should alleviate that.

We're also logging on all Http requests. This also changes it so we're only logging when Http requests fail.
