### PR TITLE
VID-2016 fixing issue with line breaks inside captions

### DIFF
--- a/extensions/wikia/MediaGallery/scripts/templates.mustache.js
+++ b/extensions/wikia/MediaGallery/scripts/templates.mustache.js
@@ -1,6 +1,6 @@
 define( 'mediaGallery.templates.mustache', [], function() { 'use strict'; return {
     "MediaGallery_gallery" : '<div class="media-gallery-wrapper count-{{count}}" data-visible-count="{{visibleCount}}"><script>window.Wikia = window.Wikia || {};Wikia.mediaGalleryData = Wikia.mediaGalleryData || [];Wikia.mediaGalleryData.push({{{json}}});</script><button class="add-image">{{addImageButton}}</button><noscript>{{#media}}<a href="{{linkHref}}"><img src="{{thumbUrl}}" alt="{{{caption}}}"></a>{{/media}}</noscript></div>',
-    "MediaGallery_media" : '{{{thumbHtml}}}{{#caption}}<div class="caption"><div class="inner">{{{caption}}}</div></div>{{/caption}}',
+    "MediaGallery_media" : '{{{thumbHtml}}}{{#caption}}<div class="media-gallery-caption"><div class="inner">{{{caption}}}</div></div>{{/caption}}',
     "MediaGallery_showMore" : '<div class="more"><button class="primary show">{{showMore}}</button><button class="secondary hide hidden">{{showLess}}</button></div>',
     "done": "true"
   }; });

--- a/extensions/wikia/MediaGallery/scripts/views/media.js
+++ b/extensions/wikia/MediaGallery/scripts/views/media.js
@@ -51,11 +51,11 @@ define('mediaGallery.views.media', [
 	 * Create caption instance
 	 */
 	Media.prototype.initCaption = function () {
-		var $caption = this.$el.find('.caption');
+		var $caption = this.$el.find('.media-gallery-caption');
 
 		if ($caption.length) {
 			this.caption = new Caption({
-				$el: this.$el.find('.caption'),
+				$el: $caption,
 				media: this
 			});
 		}

--- a/extensions/wikia/MediaGallery/styles/MediaGallery.scss
+++ b/extensions/wikia/MediaGallery/styles/MediaGallery.scss
@@ -103,12 +103,12 @@ $media-margin: 2.5px;
 	 *    - Expand caption content so it's height can be calculated by JS.
 	 */
 
-	$caption-line-height: 18px;
-	$caption-padding: 9px;
-	$caption-height: ($caption-padding * 2) + $caption-line-height;
+	$caption-line-height: 24px;
+	$caption-padding-y: 6px;
+	$caption-height: ($caption-padding-y * 2) + $caption-line-height;
 	$caption-top-offset: -1 * ($caption-height + $media-margin);
 
-	.caption {
+	.media-gallery-caption {
 		@include background-opacity(#000, 60);
 		bottom: $media-margin;
 		color: #fff;
@@ -117,7 +117,7 @@ $media-margin: 2.5px;
 		line-height: $caption-line-height;
 		margin-top: $caption-top-offset;
 		overflow: hidden;
-		padding: $caption-padding;
+		padding: $caption-padding-y 9px;
 		position: absolute;
 		right: $media-margin;
 		top: 100%;

--- a/extensions/wikia/MediaGallery/styles/MediaGallery.scss
+++ b/extensions/wikia/MediaGallery/styles/MediaGallery.scss
@@ -103,8 +103,8 @@ $media-margin: 2.5px;
 	 *    - Expand caption content so it's height can be calculated by JS.
 	 */
 
-	$caption-line-height: 24px;
-	$caption-padding-y: 6px;
+	$caption-line-height: 18px;
+	$caption-padding-y: 9px;
 	$caption-height: ($caption-padding-y * 2) + $caption-line-height;
 	$caption-top-offset: -1 * ($caption-height + $media-margin);
 
@@ -128,13 +128,16 @@ $media-margin: 2.5px;
 		}
 
 		.inner {
+			max-height: $caption-line-height;
 			overflow: hidden;
 			text-overflow: ellipsis;
 			white-space: nowrap;
 		}
 
 		&.hovered {
+
 			.inner {
+				max-height: none;
 				white-space: normal;
 			}
 		}

--- a/extensions/wikia/MediaGallery/styles/MediaGallery.scss
+++ b/extensions/wikia/MediaGallery/styles/MediaGallery.scss
@@ -117,7 +117,7 @@ $media-margin: 2.5px;
 		line-height: $caption-line-height;
 		margin-top: $caption-top-offset;
 		overflow: hidden;
-		padding: $caption-padding 9px;
+		padding: $caption-padding;
 		position: absolute;
 		right: $media-margin;
 		top: 100%;
@@ -135,7 +135,6 @@ $media-margin: 2.5px;
 		}
 
 		&.hovered {
-
 			.inner {
 				max-height: none;
 				white-space: normal;

--- a/extensions/wikia/MediaGallery/styles/MediaGallery.scss
+++ b/extensions/wikia/MediaGallery/styles/MediaGallery.scss
@@ -104,8 +104,8 @@ $media-margin: 2.5px;
 	 */
 
 	$caption-line-height: 18px;
-	$caption-padding-y: 9px;
-	$caption-height: ($caption-padding-y * 2) + $caption-line-height;
+	$caption-padding: 9px;
+	$caption-height: ($caption-padding * 2) + $caption-line-height;
 	$caption-top-offset: -1 * ($caption-height + $media-margin);
 
 	.media-gallery-caption {
@@ -117,7 +117,7 @@ $media-margin: 2.5px;
 		line-height: $caption-line-height;
 		margin-top: $caption-top-offset;
 		overflow: hidden;
-		padding: $caption-padding-y 9px;
+		padding: $caption-padding 9px;
 		position: absolute;
 		right: $media-margin;
 		top: 100%;

--- a/extensions/wikia/MediaGallery/templates/MediaGallery_media.mustache
+++ b/extensions/wikia/MediaGallery/templates/MediaGallery_media.mustache
@@ -1,6 +1,6 @@
 {{{thumbHtml}}}
 {{#caption}}
-	<div class="caption">
+	<div class="media-gallery-caption">
 		<div class="inner">
 			{{{caption}}}
 		</div>


### PR DESCRIPTION
Also renamed `.caption` to `.media-gallery-caption` to avoid conflicts with user css, like the disney wikia. 
