### PR TITLE
MWEB-974 Fix for uploading images with FormData in Wikia Maps

### DIFF
--- a/extensions/wikia/WikiaInteractiveMaps/js/intMapCreateMapTileSet.js
+++ b/extensions/wikia/WikiaInteractiveMaps/js/intMapCreateMapTileSet.js
@@ -108,7 +108,7 @@ define(
 			// TODO: figure out where is better place to place it and move it there
 			modal.$element
 				.on('change', '#intMapUpload', function (event) {
-					uploadNewTileSetImage(event.target.parentNode);
+					uploadNewTileSetImage(event.target);
 				})
 				.on('keyup', '#intMapTileSetSearch', $.debounce(config.constants.debounceDelay, searchForTileSets));
 
@@ -348,22 +348,9 @@ define(
 
 		/**
 		 * @desc uploads tile set image to backend
-		 * @param {object} form - html form node element
 		 */
-		function uploadNewTileSetImage(form) {
-			var formData;
-
-			try {
-				formData = new FormData(form);
-			} catch (e) {
-				// MWEB-974 - fixed image preview on IE10, IE11
-				// IE10 and IE11 officially support FormData
-				// but if we try to use it in the same way as in other browsers
-				// it throws "SCRIPT5: Access is denied." error this is a workaround for it.
-
-				formData = new FormData();
-				formData.append('wpUploadFile', $uploadInput.get(0).files[0]);
-			}
+		function uploadNewTileSetImage(inputElement) {
+			var formData = utils.getFormDataInstance(inputElement);
 
 			utils.upload(modal, formData, 'map', function (data) {
 				data.type = 'custom';

--- a/extensions/wikia/WikiaInteractiveMaps/js/intMapCreateMapTileSet.js
+++ b/extensions/wikia/WikiaInteractiveMaps/js/intMapCreateMapTileSet.js
@@ -351,7 +351,19 @@ define(
 		 * @param {object} form - html form node element
 		 */
 		function uploadNewTileSetImage(form) {
-			var formData = new FormData(form);
+			var formData;
+
+			try {
+				formData = new FormData(form);
+			} catch (e) {
+				// MWEB-974 - fixed image preview on IE10, IE11
+				// IE10 and IE11 officially support FormData
+				// but if we try to use it in the same way as in other browsers
+				// it throws "SCRIPT5: Access is denied." error this is a workaround for it.
+
+				formData = new FormData();
+				formData.append('wpUploadFile', $uploadInput.get(0).files[0]);
+			}
 
 			utils.upload(modal, formData, 'map', function (data) {
 				data.type = 'custom';

--- a/extensions/wikia/WikiaInteractiveMaps/js/intMapCreateMapTileSet.js
+++ b/extensions/wikia/WikiaInteractiveMaps/js/intMapCreateMapTileSet.js
@@ -350,7 +350,7 @@ define(
 		 * @desc uploads tile set image to backend
 		 */
 		function uploadNewTileSetImage(inputElement) {
-			var formData = utils.getFormDataInstance(inputElement);
+			var formData = utils.getFormDataForFileUpload(inputElement);
 
 			utils.upload(modal, formData, 'map', function (data) {
 				data.type = 'custom';

--- a/extensions/wikia/WikiaInteractiveMaps/js/intMapPoiCategories.js
+++ b/extensions/wikia/WikiaInteractiveMaps/js/intMapPoiCategories.js
@@ -6,7 +6,7 @@ define('wikia.intMap.poiCategories',
 		'wikia.intMap.utils',
 		'wikia.intMap.poiCategories.model'
 	],
-	function($, qs, w, utils, poiCategoriesModel) {
+	function ($, qs, w, utils, poiCategoriesModel) {
 		'use strict';
 
 		// reference to modal component
@@ -293,7 +293,7 @@ define('wikia.intMap.poiCategories',
 
 		/**
 		 * @desc adds POI category id to hidden field
-		 * @param poiCategoryId
+		 * @param {Number} poiCategoryId
 		 */
 		function markPoiCategoryAsDeleted(poiCategoryId) {
 			// add POI category id to hidden field
@@ -305,12 +305,9 @@ define('wikia.intMap.poiCategories',
 		 * @param {Element} inputElement - file input element
 		 */
 		function uploadMarkerImage(inputElement) {
-			var file = inputElement.files[0],
-				formData = new FormData(),
+			var formData = utils.getFormDataInstance(inputElement),
 				$inputElement = $(inputElement),
 				$inputElementWrapper = $inputElement.closest('.poi-category-marker');
-
-			formData.append('wpUploadFile', file);
 
 			utils.upload(modal, formData, 'marker', function (data) {
 				modal.trigger('saveMarkerImage', data, $inputElementWrapper);
@@ -326,7 +323,7 @@ define('wikia.intMap.poiCategories',
 		function saveMarkerImage(data, $inputElementWrapper) {
 			$inputElementWrapper
 				.find('.poi-category-marker-image-url')
-				.val(data['fileThumbUrl']);
+				.val(data.fileThumbUrl);
 		}
 
 		/**
@@ -339,7 +336,7 @@ define('wikia.intMap.poiCategories',
 			$inputElement.val('');
 			$inputElementWrapper
 				.find('.poi-category-marker-image')
-				.attr('src', data['fileThumbUrl'])
+				.attr('src', data.fileThumbUrl)
 				.removeClass('hidden')
 				.siblings('span')
 				.addClass('hidden');

--- a/extensions/wikia/WikiaInteractiveMaps/js/intMapPoiCategories.js
+++ b/extensions/wikia/WikiaInteractiveMaps/js/intMapPoiCategories.js
@@ -305,7 +305,7 @@ define('wikia.intMap.poiCategories',
 		 * @param {Element} inputElement - file input element
 		 */
 		function uploadMarkerImage(inputElement) {
-			var formData = utils.getFormDataInstance(inputElement),
+			var formData = utils.getFormDataForFileUpload(inputElement),
 				$inputElement = $(inputElement),
 				$inputElementWrapper = $inputElement.closest('.poi-category-marker');
 

--- a/extensions/wikia/WikiaInteractiveMaps/js/intMapUtils.js
+++ b/extensions/wikia/WikiaInteractiveMaps/js/intMapUtils.js
@@ -197,6 +197,35 @@ define(
 		}
 
 		/**
+		 * @desc Creates an instance of FormData and appends to it file from passed <input type="file" /> element
+		 *
+		 * IE10 and IE11 officially support FormData but if we try to use it in the same way as in other browsers
+		 * (by passing the optional form parameter to FormData constructor) it throws "SCRIPT5: Access is denied."
+		 * error. The solution below works on IE and works in other browsers. We use it in two other places:
+		 * - intMapCreateTileSet.js,
+		 * - intMapPoiCategories.js.
+		 *
+		 * And we might use it somewhere else where an file upload with nice preview is required. That's why the method
+		 * is in intMapUtils.js file.
+		 *
+		 * @param {Object} inputElement <input type="file" /> element passed from an event
+		 * @param {String} inputFileName optional; by default it's going to be set to wpUploadFile
+		 * @returns {FormData}
+		 */
+		function getFormDataInstance(inputElement, inputFileName) {
+			inputFileName = (!inputFileName) ? 'wpUploadFile' : inputFileName;
+
+			if (!inputElement.files || !inputElement.files[0]) {
+				throw new Error('Could not find the file');
+			}
+
+			var formData = new FormData();
+			formData.append(inputFileName, inputElement.files[0]);
+
+			return formData;
+		}
+
+		/**
 		 * @desc
 		 * @param {object} modal - modal component
 		 * @param {FormData} formData - FormData object with file input named wpUploadFile
@@ -435,7 +464,8 @@ define(
 			trackerActions: tracker.ACTIONS,
 			triggerAction: triggerAction,
 			getActionConfig: getActionConfig,
-			inArray: inArray
+			inArray: inArray,
+			getFormDataInstance: getFormDataInstance
 		};
 	}
 );

--- a/extensions/wikia/WikiaInteractiveMaps/js/intMapUtils.js
+++ b/extensions/wikia/WikiaInteractiveMaps/js/intMapUtils.js
@@ -212,7 +212,7 @@ define(
 		 * @param {String} inputFileName optional; by default it's going to be set to wpUploadFile
 		 * @returns {FormData}
 		 */
-		function getFormDataInstance(inputElement, inputFileName) {
+		function getFormDataForFileUpload(inputElement, inputFileName) {
 			inputFileName = (!inputFileName) ? 'wpUploadFile' : inputFileName;
 
 			if (!inputElement.files || !inputElement.files[0]) {
@@ -465,7 +465,7 @@ define(
 			triggerAction: triggerAction,
 			getActionConfig: getActionConfig,
 			inArray: inArray,
-			getFormDataInstance: getFormDataInstance
+			getFormDataForFileUpload: getFormDataForFileUpload
 		};
 	}
 );

--- a/extensions/wikia/WikiaInteractiveMaps/spec/intMapUtils.spec.js
+++ b/extensions/wikia/WikiaInteractiveMaps/spec/intMapUtils.spec.js
@@ -3,13 +3,13 @@ describe('WikiaMaps.utils', function () {
 
 	var utilsModule = modules['wikia.intMap.utils'](jQuery, {}, {}, {}, {}, {}, {});
 
-	it('registers AMD module', function() {
+	it('registers AMD module', function () {
 		expect(typeof utilsModule).toBe('object');
 
 		expect(typeof utilsModule.inArray).toBe('function');
 	});
 
-	it('checks if a key is present in an array', function() {
+	it('checks if a key is present in an array', function () {
 		var testData = [
 			{
 				input: {
@@ -45,5 +45,32 @@ describe('WikiaMaps.utils', function () {
 
 			expect(output).toEqual(testCase.expectedOutput);
 		});
+	});
+
+	it('checks if there is no error if file is submitted', function () {
+		var inputElementStub = {
+			files: ['a-stub-file']
+		};
+		expect(function () {
+			utilsModule.getFormDataInstance(inputElementStub, 'just-for-test');
+		}).not.toThrow('Could not find the file');
+	});
+
+	it('checks if an error is thrown where there is no file', function () {
+		var inputElementStub = {
+			files: []
+		};
+		expect(function () {
+			utilsModule.getFormDataInstance(inputElementStub, 'just-for-test');
+		}).toThrow('Could not find the file');
+	});
+
+	it('checks if an error is thrown where there is no files array', function () {
+		var inputElementStub = {
+			files: []
+		};
+		expect(function () {
+			utilsModule.getFormDataInstance(inputElementStub, 'just-for-test');
+		}).toThrow('Could not find the file');
 	});
 });

--- a/extensions/wikia/WikiaInteractiveMaps/spec/intMapUtils.spec.js
+++ b/extensions/wikia/WikiaInteractiveMaps/spec/intMapUtils.spec.js
@@ -52,7 +52,7 @@ describe('WikiaMaps.utils', function () {
 			files: ['a-stub-file']
 		};
 		expect(function () {
-			utilsModule.getFormDataInstance(inputElementStub, 'just-for-test');
+			utilsModule.getFormDataForFileUpload(inputElementStub, 'just-for-test');
 		}).not.toThrow('Could not find the file');
 	});
 
@@ -61,7 +61,7 @@ describe('WikiaMaps.utils', function () {
 			files: []
 		};
 		expect(function () {
-			utilsModule.getFormDataInstance(inputElementStub, 'just-for-test');
+			utilsModule.getFormDataForFileUpload(inputElementStub, 'just-for-test');
 		}).toThrow('Could not find the file');
 	});
 
@@ -70,7 +70,7 @@ describe('WikiaMaps.utils', function () {
 			files: []
 		};
 		expect(function () {
-			utilsModule.getFormDataInstance(inputElementStub, 'just-for-test');
+			utilsModule.getFormDataForFileUpload(inputElementStub, 'just-for-test');
 		}).toThrow('Could not find the file');
 	});
 });


### PR DESCRIPTION
IE10 and IE11 have a weird way of supporting `FormData`. They throw an error if we're creating instance of `FormData` by passing form instance as a parameter. I found different sources describing solution for it:
- http://stackoverflow.com/questions/18389551/ie10-script5-access-is-denied-on-new-formdata
- https://github.com/styoe/croppic/issues/33
- http://jonhiggins.co.uk/words/formdata-ie10/

This pull request is nothing else as implementation of a workaround on our side for IE10 and IE11.
