### PR TITLE
MWEB-860 Limit map deletion capabilities

### DIFF
--- a/extensions/wikia/WikiaInteractiveMaps/WikiaInteractiveMaps.setup.php
+++ b/extensions/wikia/WikiaInteractiveMaps/WikiaInteractiveMaps.setup.php
@@ -78,7 +78,7 @@ JSMessages::registerPackage( 'WikiaInteractiveMapsEmbedMapCode', [
 $wgAvailableRights[] = 'canremovemap';
 
 // Permissions
-// canremove -- give it to users who can remove maps or maps' items (i.e. POIs, POIs categories)
+// canremove -- give it to users who can remove maps
 $wgGroupPermissions['*']['canremovemap'] = false;
 $wgGroupPermissions['sysop']['canremovemap'] = true;
 $wgGroupPermissions['staff']['canremovemap'] = true;

--- a/extensions/wikia/WikiaInteractiveMaps/WikiaInteractiveMaps.setup.php
+++ b/extensions/wikia/WikiaInteractiveMaps/WikiaInteractiveMaps.setup.php
@@ -74,6 +74,16 @@ JSMessages::registerPackage( 'WikiaInteractiveMapsEmbedMapCode', [
 	'wikia-interactive-maps-embed-map-code-*'
 ] );
 
+// Rights
+$wgAvailableRights[] = 'canremovemap';
+
+// Permissions
+// canremove -- give it to users who can remove maps or maps' items (i.e. POIs, POIs categories)
+$wgGroupPermissions['*']['canremovemap'] = false;
+$wgGroupPermissions['sysop']['canremovemap'] = true;
+$wgGroupPermissions['staff']['canremovemap'] = true;
+$wgGroupPermissions['helper']['canremovemap'] = true;
+
 // Logs
 $wgLogTypes[] = 'maps';
 $wgLogNames['maps'] = 'wikia-interactive-maps-log-name';

--- a/extensions/wikia/WikiaInteractiveMaps/controllers/WikiaInteractiveMapsBaseController.class.php
+++ b/extensions/wikia/WikiaInteractiveMaps/controllers/WikiaInteractiveMapsBaseController.class.php
@@ -191,17 +191,20 @@ class WikiaInteractiveMapsBaseController extends WikiaController {
 	 *
 	 * @return bool
 	 */
-	public function canDelete() {
+	public function canUserDelete() {
 		return $this->wg->User->isAllowed('canremovemap');
 	}
 
 	/**
 	 * Returns true if a user is map creator of a map
 	 *
+	 * @param Integer $mapId
+	 *
 	 * @return bool
 	 */
-	public function isMapCreator() {
-		return false;
+	public function isUserMapCreator( $mapId ) {
+		$mapData = $this->getModel()->getMapByIdFromApi($mapId);
+		return $this->wg->User->getName() === $mapData->created_by;
 	}
 
 }

--- a/extensions/wikia/WikiaInteractiveMaps/controllers/WikiaInteractiveMapsBaseController.class.php
+++ b/extensions/wikia/WikiaInteractiveMaps/controllers/WikiaInteractiveMapsBaseController.class.php
@@ -186,4 +186,22 @@ class WikiaInteractiveMapsBaseController extends WikiaController {
 		return $this->wg->User->isLoggedIn() && !$this->wg->User->isBlocked();
 	}
 
+	/**
+	 * Returns true if a user has right to remove a map or map's items
+	 *
+	 * @return bool
+	 */
+	public function canDelete() {
+		return $this->wg->User->isAllowed('canremovemap');
+	}
+
+	/**
+	 * Returns true if a user is map creator of a map
+	 *
+	 * @return bool
+	 */
+	public function isMapCreator() {
+		return false;
+	}
+
 }

--- a/extensions/wikia/WikiaInteractiveMaps/controllers/WikiaInteractiveMapsBaseController.class.php
+++ b/extensions/wikia/WikiaInteractiveMaps/controllers/WikiaInteractiveMapsBaseController.class.php
@@ -192,7 +192,7 @@ class WikiaInteractiveMapsBaseController extends WikiaController {
 	 * @return bool
 	 */
 	public function canUserDelete() {
-		return $this->wg->User->isAllowed('canremovemap');
+		return $this->wg->User->isAllowed( 'canremovemap' );
 	}
 
 	/**
@@ -203,7 +203,7 @@ class WikiaInteractiveMapsBaseController extends WikiaController {
 	 * @return bool
 	 */
 	public function isUserMapCreator( $mapId ) {
-		$mapData = $this->getModel()->getMapByIdFromApi($mapId);
+		$mapData = $this->getModel()->getMapByIdFromApi( $mapId );
 		return $this->wg->User->getName() === $mapData->created_by;
 	}
 

--- a/extensions/wikia/WikiaInteractiveMaps/controllers/WikiaInteractiveMapsMapController.class.php
+++ b/extensions/wikia/WikiaInteractiveMaps/controllers/WikiaInteractiveMapsMapController.class.php
@@ -179,7 +179,7 @@ class WikiaInteractiveMapsMapController extends WikiaInteractiveMapsBaseControll
 
 		$result = false;
 
-		if ( !$this->isUserAllowed() || !$this->canDelete() ) {
+		if ( !$this->isUserAllowed() || ( !$this->canUserDelete() && !$this->isUserMapCreator( $mapId ) ) ) {
 			throw new WikiaInteractiveMapsPermissionException();
 		}
 

--- a/extensions/wikia/WikiaInteractiveMaps/controllers/WikiaInteractiveMapsMapController.class.php
+++ b/extensions/wikia/WikiaInteractiveMaps/controllers/WikiaInteractiveMapsMapController.class.php
@@ -179,7 +179,7 @@ class WikiaInteractiveMapsMapController extends WikiaInteractiveMapsBaseControll
 
 		$result = false;
 
-		if ( !$this->isUserAllowed() ) {
+		if ( !$this->isUserAllowed() || !$this->canDelete() ) {
 			throw new WikiaInteractiveMapsPermissionException();
 		}
 

--- a/extensions/wikia/WikiaInteractiveMaps/css/WikiaInteractiveMaps.scss
+++ b/extensions/wikia/WikiaInteractiveMaps/css/WikiaInteractiveMaps.scss
@@ -1,7 +1,7 @@
-@import "skins/shared/mixins/background-opacity";
-@import "skins/shared/color";
-@import "skins/shared/mixins/gradient";
-@import "WikiaMapsShared";
+@import 'skins/shared/mixins/background-opacity';
+@import 'skins/shared/color';
+@import 'skins/shared/mixins/gradient';
+@import 'WikiaMapsShared';
 
 .maps-controls {
 	position: absolute;
@@ -23,14 +23,14 @@
 	}
 
 	li {
+		margin: 0 0 1px;
 		overflow-x: hidden;
 		position: relative;
-		margin: 0px 0px 1px;
 	}
 
 	.map-status {
 		@include background-opacity(#fff, 40);
-		padding: 0.6rem;
+		padding: .6rem;
 		position: absolute;
 		right: 0;
 	}
@@ -60,6 +60,10 @@
 
 .wikia-interactive-maps-page-header .wikia-menu-button {
 	padding-left: 8px;
+
+	.WikiaMenuElement {
+		list-style-type: none;
+	}
 }
 
 .wikia-interactive-map-wrapper {

--- a/extensions/wikia/WikiaInteractiveMaps/js/intMapUnDeleteMap.js
+++ b/extensions/wikia/WikiaInteractiveMaps/js/intMapUnDeleteMap.js
@@ -1,39 +1,49 @@
-define('wikia.intMaps.unDeleteMap', ['jquery', 'wikia.querystring', 'wikia.intMap.config'], function ($, qs, config) {
-	'use strict';
-	var mapId = $('iframe[name=wikia-interactive-map]').data('mapid');
+define(
+	'wikia.intMaps.unDeleteMap',
+	[
+		'jquery',
+		'wikia.window',
+		'wikia.querystring',
+		'wikia.intMap.config',
+		'wikia.intMap.utils'
+	],
+	function ($, w, qs, config, utils) {
+		'use strict';
+		var mapId = $('iframe[name=wikia-interactive-map]').data('mapid');
 
-	/**
-	 * @desc Show error message
-	 * @param {string} error - error message
-	 */
-	function showError(error) {
-		GlobalNotification.show(error, 'error');
-	}
+		/**
+		 * @desc Show error message
+		 * @param {string} error - error message
+		 */
+		function showError(error) {
+			w.GlobalNotification.show(error, 'error');
+		}
 
-	function init() {
-		$.nirvana.sendRequest({
-			controller: 'WikiaInteractiveMapsMap',
-			method: 'updateMapDeletionStatus',
-			type: 'POST',
-			data: {
-				mapId: mapId,
-				deleted: config.constants.mapNotDeleted
-			},
-			callback: function (response) {
-				var redirectUrl = response.redirectUrl;
-				if (redirectUrl) {
-					qs(redirectUrl).goTo();
-				} else {
-					showError(response);
+		function init() {
+			$.nirvana.sendRequest({
+				controller: 'WikiaInteractiveMapsMap',
+				method: 'updateMapDeletionStatus',
+				type: 'POST',
+				data: {
+					mapId: mapId,
+					deleted: config.constants.mapNotDeleted
+				},
+				callback: function (response) {
+					var redirectUrl = response.redirectUrl;
+					if (redirectUrl) {
+						qs(redirectUrl).goTo();
+					} else {
+						showError(response);
+					}
+				},
+				onErrorCallback: function (response) {
+					showError(utils.getNirvanaExceptionMessage(response));
 				}
-			},
-			onErrorCallback: function (response) {
-				showError(utils.getNirvanaExceptionMessage(response));
-			}
-		});
-	}
+			});
+		}
 
-	return {
-		init: init
-	};
-});
+		return {
+			init: init
+		};
+	}
+);

--- a/extensions/wikia/WikiaInteractiveMaps/tests/WikiaInteractiveMapsBaseControllerTest.php
+++ b/extensions/wikia/WikiaInteractiveMaps/tests/WikiaInteractiveMapsBaseControllerTest.php
@@ -26,23 +26,23 @@ class WikiaInteractiveMapsBaseControllerTest extends WikiaBaseTest {
 	 * @dataProvider isUserAllowedDataProvider
 	 */
 	public function testIsUserAllowed( $testCaseDesc, $isLoggedInMock, $isBlockedMock, $expected) {
-		$userMock = $this->getMockBuilder('User')
+		$userMock = $this->getMockBuilder( 'User' )
 			->disableOriginalConstructor()
 			->setMethods( ['isLoggedIn', 'isBlocked'] )
 			->getMock();
 
-		$userMock->expects($this->once())
-			->method('isLoggedIn')
-			->willReturn($isLoggedInMock);
+		$userMock->expects( $this->once() )
+			->method( 'isLoggedIn' )
+			->willReturn( $isLoggedInMock );
 
-		$userMock->expects($this->any())
-			->method('isBlocked')
-			->willReturn($isBlockedMock);
+		$userMock->expects( $this->any() )
+			->method( 'isBlocked' )
+			->willReturn( $isBlockedMock );
 
-		$this->mockGlobalVariable('wgUser', $userMock);
+		$this->mockGlobalVariable( 'wgUser', $userMock );
 
 		$controller = new WikiaInteractiveMapsBaseController();
-		$this->assertEquals($expected, $controller->isUserAllowed(), $testCaseDesc);
+		$this->assertEquals( $expected, $controller->isUserAllowed(), $testCaseDesc );
 	}
 
 	public function isUserAllowedDataProvider() {

--- a/extensions/wikia/WikiaInteractiveMaps/tests/WikiaInteractiveMapsBaseControllerTest.php
+++ b/extensions/wikia/WikiaInteractiveMaps/tests/WikiaInteractiveMapsBaseControllerTest.php
@@ -23,6 +23,52 @@ class WikiaInteractiveMapsBaseControllerTest extends WikiaBaseTest {
 	}
 
 	/**
+	 * @dataProvider isUserAllowedDataProvider
+	 */
+	public function testIsUserAllowed( $testCaseDesc, $isLoggedInMock, $isBlockedMock, $expected) {
+		$userMock = $this->getMockBuilder('User')
+			->disableOriginalConstructor()
+			->setMethods( ['isLoggedIn', 'isBlocked'] )
+			->getMock();
+
+		$userMock->expects($this->once())
+			->method('isLoggedIn')
+			->willReturn($isLoggedInMock);
+
+		$userMock->expects($this->any())
+			->method('isBlocked')
+			->willReturn($isBlockedMock);
+
+		$this->mockGlobalVariable('wgUser', $userMock);
+
+		$controller = new WikiaInteractiveMapsBaseController();
+		$this->assertEquals($expected, $controller->isUserAllowed(), $testCaseDesc);
+	}
+
+	public function isUserAllowedDataProvider() {
+		return [
+			[
+				'logged-in BUT not blocked user',
+				'isLoggedInMock' => true,
+				'isBlockedMock' => false,
+				'expected' => true,
+			],
+			[
+				'logged-in AND not blocked user',
+				'isLoggedInMock' => true,
+				'isBlockedMock' => true,
+				'expected' => false,
+			],
+			[
+				'not logged-in user',
+				'isLoggedInMock' => false,
+				'isBlockedMock' => false,
+				'expected' => false,
+			],
+		];
+	}
+
+	/**
 	 * Helper method returns different WikiaUploadStashFile mocks
 	 *
 	 * @param string $version

--- a/extensions/wikia/WikiaInteractiveMaps/tests/WikiaInteractiveMapsBaseControllerTest.php
+++ b/extensions/wikia/WikiaInteractiveMaps/tests/WikiaInteractiveMapsBaseControllerTest.php
@@ -69,6 +69,61 @@ class WikiaInteractiveMapsBaseControllerTest extends WikiaBaseTest {
 	}
 
 	/**
+	 * @dataProvider isUserMapCreatorDataProvider
+	 */
+	public function testIsUserMapCreator( $testDescription, $mapIdMock, $mapDataMock, $userNameMock, $expected ) {
+		$mapsModelMock = $this->getMockBuilder( 'WikiaMaps' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'getMapByIdFromApi' ] )
+			->getMock();
+
+		$mapsModelMock->expects( $this->once() )
+			->method( 'getMapByIdFromApi' )
+			->willReturn( $mapDataMock );
+
+		$userMock = $this->getMockBuilder( 'User' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'getName' ] )
+			->getMock();
+
+		$userMock->expects( $this->once() )
+			->method( 'getName' )
+			->willReturn( $userNameMock );
+
+		$mapsBaseControllerMock = $this->getMockBuilder('WikiaInteractiveMapsBaseController')
+			->disableOriginalConstructor()
+			->setMethods( [ 'getModel' ] )
+			->getMock();
+
+		$mapsBaseControllerMock->expects( $this->once() )
+			->method( 'getModel' )
+			->willReturn( $mapsModelMock );
+
+		$mapsBaseControllerMock->wg->User = $userMock;
+
+		$this->assertEquals( $mapsBaseControllerMock->isUserMapCreator( $mapIdMock ), $expected, $testDescription );
+	}
+
+	public function isUserMapCreatorDataProvider() {
+		return [
+			[
+				'a user IS map creator',
+				1,
+				(object) [ 'id' => 1, 'created_by' => 'Test User' ],
+				'Test User',
+				true
+			],
+			[
+				'a user IS NOT map creator',
+				1,
+				(object) [ 'id' => 1, 'created_by' => 'Test User' ],
+				'Different Test User',
+				false
+			]
+		];
+	}
+
+	/**
 	 * Helper method returns different WikiaUploadStashFile mocks
 	 *
 	 * @param string $version


### PR DESCRIPTION
Currently everyone can create and delete map. You can even delete map you haven't created. We wanted to limit deletion capabilities and therefore we added new user right `canremovemap`. We're checking if a user has the right and if she is an owner of the map. If none of the conditions is met we throw a permission exception.
