### PR TITLE
VID-2077 Treat negative caching differently

### DIFF
--- a/extensions/wikia/VideoHandlers/VideoHandlerController.class.php
+++ b/extensions/wikia/VideoHandlers/VideoHandlerController.class.php
@@ -251,6 +251,9 @@ class VideoHandlerController extends WikiaController {
 		$fileTitleAsArray = wfReturnArray( $fileTitle );
 		$videoOptions = $this->getVideoOptionsWithDefaults( $this->getVal( 'videoOptions', [] ) );
 
+		// Key to cache the data under in memcache
+		$memcKey = wfMemcKey( __FUNCTION__, md5( serialize( [ $fileTitleAsArray, $videoOptions ] ) ) );
+
 		// How we'll get the data on a cache miss
 		$dataGenerator = function() use ( $fileTitleAsArray, $videoOptions ) {
 			$videos = $this->getDetailsForVideoTitles( $fileTitleAsArray, $videoOptions );
@@ -266,9 +269,6 @@ class VideoHandlerController extends WikiaController {
 
 			return $videos;
 		};
-
-		// Key to cache the data with
-		$memcKey= wfMemcKey( __FUNCTION__, md5( serialize( [ $fileTitleAsArray, $videoOptions ] ) ) );
 
 		// Call the generator, caching the result, or not caching if we get null from the $dataGenerator
 		$videos = WikiaDataAccess::cacheWithOptions( $memcKey, $dataGenerator, [

--- a/extensions/wikia/VideoHandlers/VideoHandlerController.class.php
+++ b/extensions/wikia/VideoHandlers/VideoHandlerController.class.php
@@ -274,7 +274,7 @@ class VideoHandlerController extends WikiaController {
 		$videos = WikiaDataAccess::cacheWithOptions( $memcKey, $dataGenerator, [
 			'cacheTTL' => WikiaResponse::CACHE_STANDARD,
 			'negativeCacheTTL' => 0,
-		]);
+		] );
 
 		// If file title was passed in as a string, return single associative array.
 		$this->detail = ( !empty( $videos ) && $returnSingleVideo ) ? array_pop( $videos ) : $videos;

--- a/extensions/wikia/VideoHandlers/VideoHandlerController.class.php
+++ b/extensions/wikia/VideoHandlers/VideoHandlerController.class.php
@@ -1,5 +1,7 @@
 <?php
 
+use \Wikia\Logger\WikiaLogger;
+
 /**
  * Class VideoHandlerController
  */
@@ -249,14 +251,30 @@ class VideoHandlerController extends WikiaController {
 		$fileTitleAsArray = wfReturnArray( $fileTitle );
 		$videoOptions = $this->getVideoOptionsWithDefaults( $this->getVal( 'videoOptions', [] ) );
 
-		$memcKey= wfMemcKey( __FUNCTION__, md5( serialize( [ $fileTitleAsArray, $videoOptions ] ) ) );
-		$videos = WikiaDataAccess::cache(
-			$memcKey,
-			WikiaResponse::CACHE_STANDARD,
-			function() use ( $fileTitleAsArray, $videoOptions ) {
-				return $this->getDetailsForVideoTitles( $fileTitleAsArray, $videoOptions );
+		// How we'll get the data on a cache miss
+		$dataGenerator = function() use ( $fileTitleAsArray, $videoOptions ) {
+			$videos = $this->getDetailsForVideoTitles( $fileTitleAsArray, $videoOptions );
+
+			// Take note when we are unable to get any details for a set of videos
+			if ( empty( $videos ) ) {
+				$log = WikiaLogger::instance();
+				$log->info( __METHOD__.' empty details', [
+					'titleCount' => count($fileTitleAsArray),
+					'titleString' => implode( '|', $fileTitleAsArray ),
+				] );
 			}
-		);
+
+			return $videos;
+		};
+
+		// Key to cache the data with
+		$memcKey= wfMemcKey( __FUNCTION__, md5( serialize( [ $fileTitleAsArray, $videoOptions ] ) ) );
+
+		// Call the generator, caching the result, or not caching if we get null from the $dataGenerator
+		$videos = WikiaDataAccess::cacheWithOptions( $memcKey, $dataGenerator, [
+			'cacheTTL' => WikiaResponse::CACHE_STANDARD,
+			'negativeCacheTTL' => 0,
+		]);
 
 		// If file title was passed in as a string, return single associative array.
 		$this->detail = ( !empty( $videos ) && $returnSingleVideo ) ? array_pop( $videos ) : $videos;

--- a/extensions/wikia/VideoHandlers/VideoHandlerController.class.php
+++ b/extensions/wikia/VideoHandlers/VideoHandlerController.class.php
@@ -262,7 +262,7 @@ class VideoHandlerController extends WikiaController {
 			if ( empty( $videos ) ) {
 				$log = WikiaLogger::instance();
 				$log->info( __METHOD__.' empty details', [
-					'titleCount' => count($fileTitleAsArray),
+					'titleCount' => count( $fileTitleAsArray ),
 					'titleString' => implode( '|', $fileTitleAsArray ),
 				] );
 			}

--- a/extensions/wikia/VideosModule/VideosModule.class.php
+++ b/extensions/wikia/VideosModule/VideosModule.class.php
@@ -13,6 +13,7 @@ class VideosModule extends WikiaModel {
 	const LIMIT_VIDEOS = 20;
 	const LIMIT_CATEGORY_VIDEOS = 40;
 	const CACHE_TTL = 43200; // 12 hours
+	const NEGATIVE_CACHE_TTL = 300; // 5 minutes
 	const CACHE_VERSION = 3;
 
 	const STAFF_PICK_PREFIX = 'Staff_Pick_';
@@ -127,7 +128,12 @@ class VideosModule extends WikiaModel {
 				$this->addToList( $videos, $video, self::SOURCE_LOCAL );
 			}
 
-			$this->wg->Memc->set( $memcKey, $videos, self::CACHE_TTL );
+			$ttl = self::CACHE_TTL;
+			if ( empty( $videos ) ) {
+				$ttl = self::NEGATIVE_CACHE_TTL;
+				$log->info( __METHOD__ . ' zero videos', $loggingParams );
+			}
+			$this->wg->Memc->set( $memcKey, $videos, $ttl );
 		} else {
 			$log->info( __METHOD__.' memc HIT', $loggingParams );
 		}
@@ -173,7 +179,12 @@ class VideosModule extends WikiaModel {
 				$this->addToList( $videos, $video, self::SOURCE_WIKI_TOPICS );
 			}
 
-			$this->wg->Memc->set( $memcKey, $videos, self::CACHE_TTL );
+			$ttl = self::CACHE_TTL;
+			if ( empty( $videos ) ) {
+				$ttl = self::NEGATIVE_CACHE_TTL;
+				$log->info( __METHOD__ . ' zero videos', $loggingParams );
+			}
+			$this->wg->Memc->set( $memcKey, $videos, $ttl );
 		} else {
 			$log->info( __METHOD__.' memc HIT', $loggingParams );
 		}
@@ -257,7 +268,12 @@ class VideosModule extends WikiaModel {
 				$this->addToList( $videos, $video, $source );
 			}
 
-			$this->wg->Memc->set( $memcKey, $videos, self::CACHE_TTL );
+			$ttl = self::CACHE_TTL;
+			if ( empty( $videos ) ) {
+				$ttl = self::NEGATIVE_CACHE_TTL;
+				$log->info( __METHOD__ . ' zero videos', $loggingParams );
+			}
+			$this->wg->Memc->set( $memcKey, $videos, $ttl );
 		} else {
 			$log->info( __METHOD__.' memc HIT', $loggingParams );
 		}

--- a/includes/wikia/WikiaDataAccess.class.php
+++ b/includes/wikia/WikiaDataAccess.class.php
@@ -41,7 +41,7 @@ class WikiaDataAccess {
 	 * Provider here for consistency
 	 * Should not be used - does not cache results
 	 *
-	 * @param callable $getData A function that returns the data the cache is backed by
+	 * @param callable $getData A function that returns data for cache MISSes
 	 *
 	 * @author Piotr Bablok <pbablok@wikia-inc.com>
 	 */

--- a/includes/wikia/WikiaDataAccess.class.php
+++ b/includes/wikia/WikiaDataAccess.class.php
@@ -35,21 +35,6 @@ class WikiaDataAccess {
 	 * Public Interface
 	 **********************************/
 
-
-	/**
-	 * Simple direct data getter
-	 * Provider here for consistency
-	 * Should not be used - does not cache results
-	 *
-	 * @param callable $getData A function that returns data for cache MISSes
-	 *
-	 * @author Piotr Bablok <pbablok@wikia-inc.com>
-	 */
-	static function simpleDirect( $getData ) {
-		return $getData();
-	}
-
-
 	/**
 	 * Returns cached data if possible (up to $cacheTTL old) otherwise gets the data and saves the result in cache
 	 * before returning it
@@ -94,7 +79,7 @@ class WikiaDataAccess {
 		$cacheTTL = empty( $options['cacheTTL'] ) ? self::DEFAULT_TTL : $options['cacheTTL'];
 
 		// Get the negative TTL, defaulting to the positive TTL.  Allow for a negative TTL of zero.
-		$negativeCacheTTL = array_key_exists( 'negativeCacheTTL', $options ) ? $options['negativeCacheTTL'] : $cacheTTL;
+		$negativeCacheTTL = isset( $options['negativeCacheTTL'] ) ? $options['negativeCacheTTL'] : $cacheTTL;
 
 		if ( $command == self::SKIP_CACHE ) {
 			Wikia::log( __METHOD__, 'debug', "Cache disabled for key:{$key}, if this is on production please contact the author of the code.", true);

--- a/includes/wikia/tests/WikiaDataAccessTest.php
+++ b/includes/wikia/tests/WikiaDataAccessTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+* @category Wikia
+*/
+class WikiaDataAccessTest extends WikiaBaseTest {
+
+	function testCacheMiss() {
+		$key = 'TESTKEY';
+		$value = 'TESTVALUE' . rand();
+		$ttl = 568;
+
+		// Mock our memcache class
+		$memc = $this->getMock( 'MemcachedPhpBagOStuff' );
+
+		// 'get' should be called and return null
+		$memc->expects( $this->once() )
+			->method( 'get' )
+			->willReturn( null );
+
+		// Our data should be accessed and passed to set
+		$memc->expects( $this->once() )
+			->method( 'set' )
+			->with( $this->equalTo( $key ), $this->equalTo( $value ), $this->equalTo( $ttl ) );
+
+		// Set the memc used to our mock object
+		F::app()->wg->Memc = $memc;
+
+		// Cache backed data access
+		$returnValue = WikiaDataAccess::cache( $key, $ttl, function () use ( $value ) { return $value; } );
+
+		// Make sure we get back what we expect
+		$this->assertEquals( $value, $returnValue, 'Cache HIT test' );
+	}
+
+	function testCacheHit() {
+		$key = 'TESTKEY';
+		$value = 'TESTVALUE' . rand();
+		$ttl = 568;
+
+		// Mock our memcache class
+		$memc = $this->getMock( 'MemcachedPhpBagOStuff' );
+
+		// 'get' should be called and return our value
+		$memc->expects( $this->once() )
+			->method( 'get' )
+			->willReturn( $value );
+
+		// 'set' should never be called
+		$memc->expects( $this->never() )
+			->method( 'set' );
+
+		// Set the memc used to our mock object
+		F::app()->wg->Memc = $memc;
+
+		// Cache backed data access
+		$returnValue = WikiaDataAccess::cache( $key, $ttl, function () use ( $value ) { return $value; } );
+
+		// Make sure we get back what we expect
+		$this->assertEquals( $value, $returnValue, 'Cache MISS test' );
+	}
+}


### PR DESCRIPTION
When there are no results, cache for a shorter TTL or zero TTL.

The rational for zero TTL on getDetails is that its called internally, and many places that call it also cache the results of the set.  On things that return data to an external client, the no result cache is minimal, currently 5min.

https://wikia-inc.atlassian.net/browse/VID-2077
