### PR TITLE
VID-2028 tracking rendered media in ranges

### DIFF
--- a/extensions/wikia/MediaGallery/scripts/views/gallery.js
+++ b/extensions/wikia/MediaGallery/scripts/views/gallery.js
@@ -98,12 +98,17 @@ define('mediaGallery.views.gallery', [
 	Gallery.prototype.render = function (count, $el) {
 		var self = this,
 			media,
-			mediaCount,
+			mediaRange,
 			deferredImages = [];
 
 		media = this.media.slice(this.visibleCount, this.visibleCount + count);
-		mediaCount = media.length;
-		this.bucky.timer.start('render.' + mediaCount);
+		if (!media.length) {
+			return this;
+		}
+
+		// track rendering of media in ranges of 20. "0" is 1-20, 1 is 21-40, etc.
+		mediaRange = Math.ceil(media.length / 20);
+		this.bucky.timer.start('render.' + mediaRange);
 
 		if ($el) {
 			$el.startThrobbing();
@@ -130,7 +135,7 @@ define('mediaGallery.views.gallery', [
 			$.each(media, function (idx, item) {
 				item.show();
 			});
-			self.bucky.timer.stop('render.' + mediaCount);
+			self.bucky.timer.stop('render.' + mediaRange);
 			self.$el.trigger('mediaLoaded');
 		});
 


### PR DESCRIPTION
After this change goes to production we'll see 5 lines in grafana (http://graph-s3.wikia-prod/grafana/#/dashboard/db/Liz%20Dash), each representing the time it takes to render a given range of media. Ranges are 0 => 1-20, 1 => 21-40, 2 => 41-60, 3 => 61-80, 4 => 81-100. 
