### PR TITLE
VID-2074 Allow expanded galleries to show more images

### DIFF
--- a/extensions/wikia/MediaGallery/MediaGalleryController.class.php
+++ b/extensions/wikia/MediaGallery/MediaGalleryController.class.php
@@ -29,6 +29,7 @@ class MediaGalleryController extends WikiaController {
 		$this->json = json_encode( $data );
 		$this->count = $this->model->getMediaCount();
 		$this->visibleCount = $visibleCount;
+		$this->expanded = !empty( $galleryParams['expand'] );
 		$this->addImageButton = wfMessage('mediagallery-add-image-button')->plain();
 	}
 }

--- a/extensions/wikia/MediaGallery/MediaGalleryController.class.php
+++ b/extensions/wikia/MediaGallery/MediaGalleryController.class.php
@@ -25,11 +25,11 @@ class MediaGalleryController extends WikiaController {
 		$data = $this->model->getGalleryData();
 
 		// noscript tag does not need more than 100 images
-		$this->media = array_slice( $data, 0, 100 );
+		$this->media = array_slice( $data, 0, self::MAX_EXPANDED_ITEMS );
 		$this->json = json_encode( $data );
 		$this->count = $this->model->getMediaCount();
 		$this->visibleCount = $visibleCount;
-		$this->expanded = !empty( $galleryParams['expand'] );
+		$this->expanded = empty( $galleryParams['expand'] ) ? 0 : self::MAX_EXPANDED_ITEMS;
 		$this->addImageButton = wfMessage('mediagallery-add-image-button')->plain();
 	}
 }

--- a/extensions/wikia/MediaGallery/scripts/controllers/index.js
+++ b/extensions/wikia/MediaGallery/scripts/controllers/index.js
@@ -32,10 +32,9 @@ require([
 				index: idx
 			};
 
-		if ($elem.data('expanded')) {
-			// If expanded is set, it will be the number of images to show per interval
-			galleryOptions.interval = $elem.data('expanded');
-		}
+		// If expanded is set, it will be the number of images to show per interval.  If it's not set (zero) the gallery
+		// model will use its default
+		galleryOptions.interval = $elem.data('expanded');
 
 		// Instantiate gallery view
 		gallery = new Gallery(galleryOptions);

--- a/extensions/wikia/MediaGallery/scripts/controllers/index.js
+++ b/extensions/wikia/MediaGallery/scripts/controllers/index.js
@@ -21,18 +21,23 @@ require([
 	 */
 	GalleryController.prototype.createGallery = function ($elem, idx, data) {
 		var origVisibleCount = $elem.data('visible-count') || 8,
-			gallery;
+			gallery,
+			galleryOptions = {
+				$el: $('<div></div>'),
+				$wrapper: $elem,
+				model: {
+					media: data
+				},
+				origVisibleCount: origVisibleCount,
+				index: idx
+			};
+
+		if ($elem.data('expanded')) {
+			galleryOptions.interval = 100;
+		}
 
 		// Instantiate gallery view
-		gallery = new Gallery({
-			$el: $('<div></div>'),
-			$wrapper: $elem,
-			model: {
-				media: data
-			},
-			origVisibleCount: origVisibleCount,
-			index: idx
-		});
+		gallery = new Gallery(galleryOptions);
 
 		// Append gallery HTML to DOM
 		$elem.append(gallery.render(origVisibleCount).$el);

--- a/extensions/wikia/MediaGallery/scripts/controllers/index.js
+++ b/extensions/wikia/MediaGallery/scripts/controllers/index.js
@@ -33,7 +33,8 @@ require([
 			};
 
 		if ($elem.data('expanded')) {
-			galleryOptions.interval = 100;
+			// If expanded is set, it will be the number of images to show per interval
+			galleryOptions.interval = $elem.data('expanded');
 		}
 
 		// Instantiate gallery view

--- a/extensions/wikia/MediaGallery/templates/MediaGallery_gallery.mustache
+++ b/extensions/wikia/MediaGallery/templates/MediaGallery_gallery.mustache
@@ -1,4 +1,4 @@
-<div class="media-gallery-wrapper count-{{count}}" data-visible-count="{{visibleCount}}" data-model="{{json}}">
+<div class="media-gallery-wrapper count-{{count}}" data-visible-count="{{visibleCount}}" data-model="{{json}}" data-expanded="{{expanded}}">
 	<button class="add-image">{{addImageButton}}</button>
 	<noscript>
 		{{#media}}


### PR DESCRIPTION
Galleries that have the expand="true" parameter set and have more than 100 images (enough to have the "show more" button show up) will now show 100 images at at time when clicking "show more" rather than 12 images at a time.

https://wikia-inc.atlassian.net/browse/VID-2074
