### PR TITLE
fix-tests: Specify correct paths to i18n files

### DIFF
--- a/extensions/VisualEditor/lib/ve/modules/ve/init/sa/ve.init.sa.Platform.js
+++ b/extensions/VisualEditor/lib/ve/modules/ve/init/sa/ve.init.sa.Platform.js
@@ -19,7 +19,7 @@ ve.init.sa.Platform = function VeInitSaPlatform() {
 
 	// Properties
 	this.externalLinkUrlProtocolsRegExp = /^https?\:\/\//;
-	this.modulesUrl = 'extensions/VisualEditor/modules';
+	this.modulesUrl = '/extensions/VisualEditor/modules';
 	this.parsedMessages = {};
 	this.userLanguages = ['en'];
 };
@@ -167,12 +167,12 @@ ve.init.sa.Platform.prototype.initialize = function () {
 		filename = languages[i].toLowerCase() + '.json';
 
 		deferred = $.Deferred();
-		$.i18n().load( path + '/ve/i18n/' + filename, languages[i] )
+		$.i18n().load( path + '/ve-wmf/i18n/' + filename, languages[i] )
 			.always( deferred.resolve );
 		promises.push( deferred.promise() );
 
 		deferred = $.Deferred();
-		$.i18n().load( path + '/../lib/oojs-ui/i18n/' + filename, languages[i] )
+		$.i18n().load( path + '/../lib/ve/lib/oojs-ui/i18n/' + filename, languages[i] )
 			.always( deferred.resolve );
 		promises.push( deferred.promise() );
 	}


### PR DESCRIPTION
There is no ticket for this. Our unit tests are failing because the path to i18n files is incorrect. 
