### PR TITLE
VE-1551: Removed "Recently edited" sort functionality from Category Exhibition

### DIFF
--- a/extensions/wikia/CategoryExhibition/CategoryExhibitionSection.class.php
+++ b/extensions/wikia/CategoryExhibition/CategoryExhibitionSection.class.php
@@ -12,7 +12,7 @@ class CategoryExhibitionSection {
 	protected $displayOption = false;	// current state of display option
 	protected $sortOption = false;		// current state of sort option
 
-	protected $allowedSortOptions = array( 'mostvisited', 'alphabetical', 'recentedits' );
+	protected $allowedSortOptions = array( 'mostvisited', 'alphabetical' );
 	protected $allowedDisplayOptions = array( 'exhibition', 'page' );
 
 	protected $verifyChecker = '';
@@ -75,7 +75,6 @@ class CategoryExhibitionSection {
 				//FB#26239 - fall back to alphabetical order if most visited data is empty
 				return ( !empty( $res ) ) ? $res : CategoryDataService::getAlphabetical( $sCategoryDBKey, $ns, $negative );
 			case 'alphabetical': return CategoryDataService::getAlphabetical( $sCategoryDBKey, $ns, $negative );
-			case 'recentedits': return CategoryDataService::getRecentlyEdited( $sCategoryDBKey, $ns, $negative );
 		}
 		return array();
 	}

--- a/extensions/wikia/CategoryExhibition/services/CategoryDataService.class.php
+++ b/extensions/wikia/CategoryExhibition/services/CategoryDataService.class.php
@@ -88,36 +88,6 @@ class CategoryDataService extends Service {
 	}
 
 	/**
-	 * Return a list of articles in a particular category, ordered by their last edit date
-	 *
-	 * @param string $sCategoryDBKey
-	 * @param string $mNamespace
-	 * @param bool $negative
-	 * @return array
-	 */
-	public static function getRecentlyEdited( $sCategoryDBKey, $mNamespace, $negative = false  ) {
-		wfProfileIn( __METHOD__ );
-
-		$dbr = wfGetDB( DB_SLAVE );
-		$res = $dbr->select(
-			array( 'page', 'revision', 'categorylinks' ),
-			array( 'page_id', 'page_title' ),
-			array(
-				'cl_to' => $sCategoryDBKey,
-				'page_namespace ' . ($negative ? 'NOT ' : '') . 'IN(' . $mNamespace . ')'
-			),
-			__METHOD__,
-			array(	'ORDER BY' => 'rev_timestamp DESC, page_title' ),
-			array(	'revision'  => array( 'LEFT JOIN', 'rev_page = page_id' ),
-				'categorylinks'  => array( 'INNER JOIN', 'cl_from = page_id' ))
-		);
-
-		wfProfileOut( __METHOD__ );
-
-		return self::tableFromResult( $res );
-	}
-
-	/**
 	 * @param string $sCategoryDBKey
 	 * @param array $mNamespace
 	 * @param bool $limit


### PR DESCRIPTION
Along with removing the option from the UI method (getRecentlyEdited) used for getting data from database was removed as well.
Reason for removing is that query is not performant (temporary table and filesort is being used) but also functionality is not popular/important enough to fix it.

https://wikia-inc.atlassian.net/browse/VE-1551
