### PR TITLE
fix-category-sort-menu: Remove href data for main action

### DIFF
--- a/extensions/wikia/CategoryExhibition/templates/form.tmpl.php
+++ b/extensions/wikia/CategoryExhibition/templates/form.tmpl.php
@@ -17,7 +17,7 @@
 	<?= F::app()->renderView('MenuButton',
 			'Index',
 			array(
-				'action' => array( "href" => $path, "text" => wfMsg('category-exhibition-'.$current), "id" => "category-exhibition-form-current" ),
+				'action' => array( "text" => wfMsg('category-exhibition-'.$current), "id" => "category-exhibition-form-current" ),
 				'class' => 'secondary',
 				'dropdown' => $dropdown,
 				'name' => 'sortType'


### PR DESCRIPTION
While code reviewing VE-1551, I noticed that the sort menu was the standard menu button type which has a main action and a dropdown of secondary actions. On the Category Exhibition page, the button is being used as stylized select menu, more similar to the Contribute button in the wiki header for which there is no primary action. I've removed the href data for the main action to cause the MenuButtonController to handle this as a menu button without a primary action.
