### PR TITLE
VID-2081 Title not available in a task context

### DIFF
--- a/extensions/wikia/WikiaPhotoGallery/WikiaPhotoGallery.class.php
+++ b/extensions/wikia/WikiaPhotoGallery/WikiaPhotoGallery.class.php
@@ -601,7 +601,8 @@ class WikiaPhotoGallery extends ImageGallery {
 	 */
 	private function canRenderMediaGallery() {
 		// Do not render media gallery for special pages - It is only for UGC pages
-		if ( F::app()->wg->Title->getNamespace() === NS_SPECIAL ) {
+		$globalTitle = F::app()->wg->Title;
+		if ( !$globalTitle || $globalTitle->getNamespace() === NS_SPECIAL ) {
 			return false;
 		}
 


### PR DESCRIPTION
RFCR @garthwebb 

Purge task for gallery fails because global title does not exist in the context of tasks.

https://wikia-inc.atlassian.net/browse/VID-2081
