### PR TITLE
VE-1588: Tests for ve.dm.WikiaTemplateModel

### DIFF
--- a/extensions/VisualEditor/wikia/VisualEditor.hooks.php
+++ b/extensions/VisualEditor/wikia/VisualEditor.hooks.php
@@ -35,6 +35,7 @@ class VisualEditorWikiaHooks {
 				've/test/dm/ve.dm.wikiaExample.js',
 				've/test/dm/ve.dm.WikiaConverter.test.js',
 				've/test/dm/ve.dm.WikiaCart.test.js',
+				've/test/dm/ve.dm.WikiaTemplateModel.test.js',
 
 				// ce
 				've/test/ce/ve.ce.wikiaExample.js',

--- a/extensions/VisualEditor/wikia/modules/ve/test/dm/ve.dm.WikiaTemplateModel.test.js
+++ b/extensions/VisualEditor/wikia/modules/ve/test/dm/ve.dm.WikiaTemplateModel.test.js
@@ -1,0 +1,33 @@
+/*!
+ * VisualEditor DataModel WikiaTemplateModel tests.
+ */
+
+QUnit.module( 've.dm.WikiaTemplateModel' );
+
+/* Tests */
+
+QUnit.test( 'WikiaTemplateModel', function ( assert ) {
+	var templateModel, serialize, wikitext, originalData = {
+		'target': { 'wt': 'foo' },
+		'params': {
+			'name': { 'wt': 'Christian' }
+		}
+	};
+
+	// Create template model with originalData
+	// MWTemplateModel.newFromData method actually creates instance of WikiaTemplateModel.
+	templateModel = ve.dm.MWTemplateModel.newFromData(
+		new ve.dm.WikiaTransclusionModel(),
+		originalData
+	);
+	// Add a parameter
+	templateModel.addParameter( new ve.dm.MWParameterModel( templateModel, 'ignoreme' ) );
+
+	serialize = templateModel.serialize();
+	wikitext = templateModel.getWikitext();
+
+	QUnit.expect( 2 );
+
+	assert.deepEqual( serialize.template.params, originalData.params, 'serialize' );
+	assert.equal( wikitext, '{{foo|name=Christian}}', 'wikitext' );
+} );

--- a/extensions/VisualEditor/wikia/modules/ve/test/dm/ve.dm.WikiaTemplateModel.test.js
+++ b/extensions/VisualEditor/wikia/modules/ve/test/dm/ve.dm.WikiaTemplateModel.test.js
@@ -7,7 +7,8 @@ QUnit.module( 've.dm.WikiaTemplateModel' );
 /* Tests */
 
 QUnit.test( 'WikiaTemplateModel', function ( assert ) {
-	var templateModel, serialize, wikitext, originalData = {
+	var templateModel,
+	originalData = {
 		'target': { 'wt': 'foo' },
 		'params': {
 			'name': { 'wt': 'Christian' }
@@ -23,11 +24,16 @@ QUnit.test( 'WikiaTemplateModel', function ( assert ) {
 	// Add a parameter
 	templateModel.addParameter( new ve.dm.MWParameterModel( templateModel, 'ignoreme' ) );
 
-	serialize = templateModel.serialize();
-	wikitext = templateModel.getWikitext();
-
 	QUnit.expect( 2 );
 
-	assert.deepEqual( serialize.template.params, originalData.params, 'serialize' );
-	assert.equal( wikitext, '{{foo|name=Christian}}', 'wikitext' );
+	assert.deepEqual(
+		templateModel.serialize().template.params,
+		originalData.params,
+		'Auto-suggested and unused parameter is not present in serialize() output'
+	);
+	assert.equal(
+		templateModel.getWikitext(),
+		'{{foo|name=Christian}}',
+		'Auto-suggested and unused parameter is not present in getWikitext() output'
+	);
 } );


### PR DESCRIPTION
Because we make an API request to get all available parameters for a given template, we need to ensure that we don't add all of the empty parameters in the serialize() and getWikiText() methods. This test tests for this scenario.

https://wikia-inc.atlassian.net/browse/VE-1588
