### PR TITLE
CON-1672 | Vertical expantion for 3rd parties

### DIFF
--- a/extensions/wikia/AnalyticsEngine/AnalyticsProviderQuantServe.php
+++ b/extensions/wikia/AnalyticsEngine/AnalyticsProviderQuantServe.php
@@ -11,7 +11,7 @@ class AnalyticsProviderQuantServe implements iAnalyticsProvider {
 		} else {
 			$called = true;
 		}
-		
+
 		$tag = <<<EOT
 <script type="text/javascript">
   var _qevents = _qevents || [];
@@ -23,7 +23,7 @@ class AnalyticsProviderQuantServe implements iAnalyticsProvider {
    elem.async = true;
    elem.type = "text/javascript";
    var scpt = document.getElementsByTagName('script')[0];
-   scpt.parentNode.insertBefore(elem, scpt);  
+   scpt.parentNode.insertBefore(elem, scpt);
   })();
 </script>
 
@@ -38,14 +38,14 @@ EOT;
 				$tag = <<<EOT
 <script type="text/javascript">
 var quantcastLabels = "";
-if (window.cityShort) {
-	quantcastLabels += cityShort;
+if (window.wgWikiVertical) {
+	quantcastLabels += wgWikiVertical;
 	if (window.wgDartCustomKeyValues) {
 		var keyValues = wgDartCustomKeyValues.split(';');
 		for (var i=0; i<keyValues.length; i++) {
 			var keyValue = keyValues[i].split('=');
 			if (keyValue.length >= 2) {
-				quantcastLabels += ',' + cityShort + '.' + keyValue[1];
+				quantcastLabels += ',' + wgWikiVertical + '.' + keyValue[1];
 			}
 		}
 	}

--- a/extensions/wikia/AnalyticsEngine/js/analytics_prod.js
+++ b/extensions/wikia/AnalyticsEngine/js/analytics_prod.js
@@ -146,7 +146,9 @@
 		['_setCustomVar', 9, 'CityId', window.wgCityId, 3],
 		['_setCustomVar', 14, 'HasAds', window.wgShowAds ? 'Yes' : 'No', 3],
 		['_setCustomVar', 15, 'IsCorporatePage', window.wikiaPageIsCorporate ? 'Yes' : 'No', 3],
-		['_setCustomVar', 16, 'Krux Segment', getKruxSegment(), 3]
+		['_setCustomVar', 16, 'Krux Segment', getKruxSegment(), 3],
+		['_setCustomVar', 17, 'Vertical', window.wgWikiVertical, 3],
+		['_setCustomVar', 18, 'Categories', window.wgWikiCategories.join(','), 3]
 	);
 
 	/**** Include A/B testing status ****/
@@ -219,7 +221,9 @@
 		['ads._setCustomVar', 9, 'CityId', window.wgCityId, 3],
 		['ads._setCustomVar', 14, 'HasAds', window.wgShowAds ? 'Yes' : 'No', 3],
 		['ads._setCustomVar', 15, 'IsCorporatePage', window.wikiaPageIsCorporate ? 'Yes' : 'No', 3],
-		['ads._setCustomVar', 16, 'Krux Segment', getKruxSegment(), 3]
+		['ads._setCustomVar', 16, 'Krux Segment', getKruxSegment(), 3],
+		['ads._setCustomVar', 17, 'Vertical', window.wgWikiVertical, 3],
+		['ads._setCustomVar', 18, 'Categories', window.wgWikiCategories.join(','), 3]
 	);
 
 	/**** Include A/B testing status ****/

--- a/extensions/wikia/WikiFactory/Hubs/WikiFactoryHub.php
+++ b/extensions/wikia/WikiFactory/Hubs/WikiFactoryHub.php
@@ -511,4 +511,22 @@ class WikiFactoryHub extends WikiaModel {
 
 		return '';
 	}
+
+
+	// TODO extract DocBlock
+	public static function onWikiaSkinTopScripts( &$vars, &$scripts, $skin ) {
+		global $wgCityId;
+		$wikiFactoryHub = self::getInstance();
+		$wikiCategories = [];
+
+		$categories = $wikiFactoryHub->getWikiCategories($wgCityId);
+		foreach($categories as $category) {
+			$wikiCategories[] = $category['cat_short'];
+		}
+
+		$vars['wgWikiVertical'] = $wikiFactoryHub->getWikiVertical($wgCityId)['short'];
+		$vars['wgWikiCategories'] = $wikiCategories;
+
+		return $vars;
+	}
 }

--- a/extensions/wikia/WikiFactory/Hubs/WikiFactoryHub.php
+++ b/extensions/wikia/WikiFactory/Hubs/WikiFactoryHub.php
@@ -511,22 +511,4 @@ class WikiFactoryHub extends WikiaModel {
 
 		return '';
 	}
-
-
-	// TODO extract DocBlock
-	public static function onWikiaSkinTopScripts( &$vars, &$scripts, $skin ) {
-		global $wgCityId;
-		$wikiFactoryHub = self::getInstance();
-		$wikiCategories = [];
-
-		$categories = $wikiFactoryHub->getWikiCategories($wgCityId);
-		foreach($categories as $category) {
-			$wikiCategories[] = $category['cat_short'];
-		}
-
-		$vars['wgWikiVertical'] = $wikiFactoryHub->getWikiVertical($wgCityId)['short'];
-		$vars['wgWikiCategories'] = $wikiCategories;
-
-		return $vars;
-	}
 }

--- a/extensions/wikia/WikiFactory/Hubs/WikiFactoryHubHooks.class.php
+++ b/extensions/wikia/WikiFactory/Hubs/WikiFactoryHubHooks.class.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * class WikiFactoryHubHooks
+ * Hooks connected to wiki hubs and verticals
+ *
+ * @author Damian Jozwiak <damian@wikia-inc.com>
+ */
+class WikiFactoryHubHooks extends WikiaModel {
+
+	/**
+	 * Hooks that export wiki vertical and categories on frontend
+	 *
+	 * @param Array $vars - (reference) js variables
+	 * @param Array $scripts - (reference) js scripts
+	 * @param Skin $skin - skins
+	 * @return Boolean True - to continue hooks execution
+	 */
+	public static function onWikiaSkinTopScripts( &$vars, &$scripts, $skin ) {
+		global $wgCityId;
+		$wikiFactoryHub = WikiFactoryHub::getInstance();
+		$wikiCategories = [];
+
+		$categories = $wikiFactoryHub->getWikiCategories( $wgCityId );
+		foreach( $categories as $category ) {
+			$wikiCategories[] = $category['cat_short'];
+		}
+
+		$vars['wgWikiVertical'] = $wikiFactoryHub->getWikiVertical( $wgCityId )['short'];
+		$vars['wgWikiCategories'] = $wikiCategories;
+
+		return true;
+	}
+}

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -217,6 +217,7 @@ $wgAutoloadClasses[ "GlobalTitle"                     ] = "$IP/includes/wikia/Gl
 $wgAutoloadClasses[ "GlobalFile"                      ] = "$IP/includes/wikia/GlobalFile.class.php";
 $wgAutoloadClasses[ "WikiFactory"                     ] = "$IP/extensions/wikia/WikiFactory/WikiFactory.php";
 $wgAutoloadClasses[ "WikiFactoryHub"                  ] = "$IP/extensions/wikia/WikiFactory/Hubs/WikiFactoryHub.php";
+$wgAutoloadClasses[ "WikiFactoryHubHooks"             ] = "$IP/extensions/wikia/WikiFactory/Hubs/WikiFactoryHubHooks.class.php";
 $wgAutoloadClasses[ 'SimplePie'                       ] = "$IP/lib/vendor/SimplePie/simplepie.inc";
 $wgAutoloadClasses[ 'MustachePHP'                     ] = "$IP/lib/vendor/mustache.php/Mustache.php";
 $wgAutoloadClasses[ 'Handlebars\\Autoloader'          ] = "$IP/lib/vendor/Handlebars/Autoloader.php";
@@ -407,7 +408,7 @@ $wgAutoloadClasses['ProfilerDataScribeSink'] = "{$IP}/includes/profiler/sinks/Pr
 
 // Skin loading scripts
 $wgHooks['WikiaSkinTopScripts'][] = 'SpotlightsABTestController::onWikiaSkinTopScripts';
-$wgHooks['WikiaSkinTopScripts'][] = 'WikiFactoryHub::onWikiaSkinTopScripts';
+$wgHooks['WikiaSkinTopScripts'][] = 'WikiFactoryHubHooks::onWikiaSkinTopScripts';
 $wgHooks['WikiaSkinTopScripts'][] = 'ReadMoreController::onWikiaSkinTopScripts';
 $wgHooks['WikiaSkinTopScripts'][] = 'Wikia\\Logger\\Hooks::onWikiaSkinTopScripts';
 

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -407,6 +407,7 @@ $wgAutoloadClasses['ProfilerDataScribeSink'] = "{$IP}/includes/profiler/sinks/Pr
 
 // Skin loading scripts
 $wgHooks['WikiaSkinTopScripts'][] = 'SpotlightsABTestController::onWikiaSkinTopScripts';
+$wgHooks['WikiaSkinTopScripts'][] = 'WikiFactoryHub::onWikiaSkinTopScripts';
 $wgHooks['WikiaSkinTopScripts'][] = 'ReadMoreController::onWikiaSkinTopScripts';
 $wgHooks['WikiaSkinTopScripts'][] = 'Wikia\\Logger\\Hooks::onWikiaSkinTopScripts';
 

--- a/resources/wikia/modules/tracker.js
+++ b/resources/wikia/modules/tracker.js
@@ -143,6 +143,7 @@
 				'n': window.wgNamespaceNumber,
 				'u': window.trackID || window.wgTrackID || 0,
 				's': window.skin,
+				'v': window.wgWikiVertical,
 				'beacon': window.beacon_id || '',
 				'cb': Math.floor( Math.random() * 99999 )
 			};

--- a/resources/wikia/modules/tracker.js
+++ b/resources/wikia/modules/tracker.js
@@ -144,6 +144,7 @@
 				'u': window.trackID || window.wgTrackID || 0,
 				's': window.skin,
 				'v': window.wgWikiVertical,
+				'ac': window.wgWikiCategories.join(','),
 				'beacon': window.beacon_id || '',
 				'cb': Math.floor( Math.random() * 99999 )
 			};


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CON-1672
## Changes
- GA
  - new vertical name - new variable - `17`
  - additional categories - new variable - `18`, names separated by `,`
- Internal tracking
  - new vertical name - new variable - `v`
  - additional categories - new variable - `ac`, names separated by `,`
- Quantcast - old category change to new vertical
## Remains unchanged
- Comscore - no changes - old categories aren't fully mapped to new verticals so it's not safe to take new vertical and map it into 3 cats.
- Ads - no changes - Ads targeting scheme is not ready for changing this now
- Krux - AdEng is working on Krux right now. They plan is to make Krux sites independent from categories so it's not required to update it.

@gabrys Please take a look if we won't break anything in Ads
