### PR TITLE
MWEB-1056: Cherry picked fix for restoring map

### DIFF
--- a/extensions/wikia/WikiaMaps/js/WikiaMapsUndeleteMap.js
+++ b/extensions/wikia/WikiaMaps/js/WikiaMapsUndeleteMap.js
@@ -4,8 +4,8 @@ define(
 		'jquery',
 		'wikia.window',
 		'wikia.querystring',
-		'wikia.intMap.config',
-		'wikia.intMap.utils'
+		'wikia.maps.config',
+		'wikia.maps.utils'
 	],
 	function ($, w, qs, config, utils) {
 		'use strict';


### PR DESCRIPTION
While cleaning file names for Wikia Maps in our Wikia extension we introduced a regression which is causing restore map functionality to be broken.

The changes below: renaming the file and changing names of JS modules to be loaded fix it.
