### PR TITLE
VID-2071 Adds hard upper limit to gallery size

### DIFF
--- a/extensions/wikia/MediaGallery/MediaGalleryModel.class.php
+++ b/extensions/wikia/MediaGallery/MediaGalleryModel.class.php
@@ -4,6 +4,12 @@ use Wikia\Logger\WikiaLogger;
 
 class MediaGalleryModel extends WikiaObject {
 	/**
+	 * Hard upper limit for the number of images per gallery
+	 * @see VID-2071
+	 */
+	const IMAGE_COUNT_LIMIT = 3000;
+
+	/**
 	 * @var array Basic data for MediaGalleries
 	 */
 	private $galleryData = [];
@@ -20,9 +26,16 @@ class MediaGalleryModel extends WikiaObject {
 
 	/**
 	 * Set basic data for galleries based on info passed in from WikiaPhotoGallery
+	 * Data exceeding the hard limit gets dropped.
+	 *
 	 * @param array $items Raw gallery data
 	 */
-	public function setGalleryData( $items ) {
+	protected function setGalleryData( array $items ) {
+		// Drop data exceeding the hard limit
+		if ( count( $items ) > self::IMAGE_COUNT_LIMIT ) {
+			$items = array_slice( $items, 0, self::IMAGE_COUNT_LIMIT, true );
+		}
+
 		$this->itemCount = count( $items );
 		$dimensionIndex = 0;
 


### PR DESCRIPTION
RFCR @garthwebb @lizlux 

Any more images than the 3K limit in the gallery are dropped on render.
This is to prevent performance problem with current gallery implementation, mainly concerning DOM size.

https://wikia-inc.atlassian.net/browse/VID-2071
