### PR TITLE
VID-2047 add bucky profiling to wall notifications js

### DIFF
--- a/extensions/wikia/WallNotifications/scripts/WallNotifications.globalNavigation.js
+++ b/extensions/wikia/WallNotifications/scripts/WallNotifications.globalNavigation.js
@@ -133,9 +133,9 @@ require(
 						this.currentWikiId = firstWikiId;
 						this.wikiShown[ firstWikiId ] = true;
 						this.updateWiki( firstWikiId );
+						this.bucky.timer.stop('fetchForCurrentWiki');
 					}
 				}
-				this.bucky.timer.stop('fetchForCurrentWiki');
 			},
 
 			restoreFromCache: function() {

--- a/extensions/wikia/WallNotifications/scripts/WallNotifications.globalNavigation.js
+++ b/extensions/wikia/WallNotifications/scripts/WallNotifications.globalNavigation.js
@@ -183,13 +183,11 @@ require(
 			},
 
 			markAllAsRead: function(e) {
-				e.preventDefault();
 				this.markAllAsReadRequest( false );
 				return false;
 			},
 
 			markAllAsReadAllWikis: function(e) {
-				e.preventDefault();
 				this.markAllAsReadRequest( 'FORCE' );
 				return false;
 			},
@@ -224,7 +222,6 @@ require(
 			},
 
 			wikiClick: function(e) {
-				e.preventDefault();
 				var wikiEl = $(e.target).closest('.notifications-for-wiki'),
 					wikiId = parseInt(wikiEl.data('wiki-id'), 10);
 

--- a/extensions/wikia/WallNotifications/scripts/WallNotifications.globalNavigation.js
+++ b/extensions/wikia/WallNotifications/scripts/WallNotifications.globalNavigation.js
@@ -5,6 +5,7 @@ require(
 
 		var WallNotifications = {
 			init: function() {
+				this.bucky = window.Bucky('WallNotifications');
 				this.updateInProgress = false; // we only want 1 update simultaneously
 				this.notificationsCache = {}; // HTML for "trays" for different Wiki ids
 				this.wikiShown = {}; // all open "trays" (Wiki Notifications) - list of Wiki ids
@@ -72,6 +73,7 @@ require(
 			},
 
 			updateCounts: function() {
+				this.bucky.timer.start('updateCounts');
 				var data,
 					callback = this.proxy(function(data) {
 					if (data.status !== true || data.html === '') {
@@ -98,6 +100,8 @@ require(
 					setTimeout( this.proxy(function() {
 						this.updateInProgress = false;
 					}), 10000 );
+
+					this.bucky.timer.stop('updateCounts');
 				});
 
 
@@ -118,6 +122,7 @@ require(
 			},
 
 			fetchForCurrentWiki: function() {
+				this.bucky.timer.start('fetchForCurrentWiki');
 				if ( this.fetchedCurrent === false ) {
 					var wikiEl = this.$wallNotifications.find('.notifications-for-wiki').first(),
 						firstWikiId = parseInt(wikiEl.data('wiki-id'), 10);
@@ -130,6 +135,7 @@ require(
 						this.updateWiki( firstWikiId );
 					}
 				}
+				this.bucky.timer.stop('fetchForCurrentWiki');
 			},
 
 			restoreFromCache: function() {
@@ -142,6 +148,7 @@ require(
 			},
 
 			markAllAsReadRequest: function(forceAll) {
+				this.bucky.timer.start('markAllAsReadRequest');
 				nirvana.sendRequest({
 					controller: 'WallNotificationsExternalController',
 					method: 'markAllAsRead',
@@ -165,6 +172,8 @@ require(
 						//	= tray is hidden (because there are no other wikis with notifications)
 						//  = no ability to show notifications, no tray)
 						this.showFirst();
+
+						this.bucky.timer.stop('markAllAsReadRequest');
 					})
 				});
 			},

--- a/extensions/wikia/WallNotifications/scripts/WallNotifications.js
+++ b/extensions/wikia/WallNotifications/scripts/WallNotifications.js
@@ -1,6 +1,7 @@
 var $window = $(window);
 var WallNotifications = $.createClass(Object, {
 	constructor: function() {
+		this.bucky = window.Bucky('WallNotifications');
 		this.isMonobook = false;
 		this.updateInProgress = false; // we only want 1 update simultaneously
 		this.notificationsCache = {}; // HTML for "trays" for different Wiki ids
@@ -82,6 +83,7 @@ var WallNotifications = $.createClass(Object, {
 	},
 
 	updateCounts: function() {
+		this.bucky.timer.start('updateCounts');
 		var data,
 			callback = this.proxy(function(data) {
 
@@ -109,6 +111,8 @@ var WallNotifications = $.createClass(Object, {
 			setTimeout( this.proxy(function() {
 				this.updateInProgress = false;
 			}), 10000 );
+
+			this.bucky.timer.stop('updateCounts');
 		});
 
 		if ( this.updateInProgress == false ) {
@@ -127,6 +131,7 @@ var WallNotifications = $.createClass(Object, {
 	},
 
 	fetchForCurrentWiki: function() {
+		this.bucky.timer.start('fetchForCurrentWiki');
 		if ( this.fetchedCurrent == false ) {
 			var wikiEl = ( this.isMonobook ? $('#wall-notifications-inner') : this.$wallNotifications ).find('.notifications-for-wiki').first(),
 				firstWikiId = wikiEl.attr('data-wiki-id');
@@ -139,6 +144,7 @@ var WallNotifications = $.createClass(Object, {
 				this.updateWiki( firstWikiId );
 			}
 		}
+		this.bucky.timer.stop('fetchForCurrentWiki');
 	},
 
 	restoreFromCache: function() {
@@ -168,6 +174,7 @@ var WallNotifications = $.createClass(Object, {
 	},
 
 	markAllAsReadRequest: function(forceAll) {
+		this.bucky.timer.start('markAllAsReadRequest');
 		$.nirvana.sendRequest({
 			controller: 'WallNotificationsExternalController',
 			method: 'markAllAsRead',
@@ -191,6 +198,7 @@ var WallNotifications = $.createClass(Object, {
 				//	= tray is hidden (because there are no other wikis with notifications)
 				//  = no ability to show notifications, no tray)
 				this.showFirst();
+				this.bucky.timer.stop('markAllAsReadRequest');
 			})
 		});
 	},

--- a/extensions/wikia/WallNotifications/scripts/WallNotifications.js
+++ b/extensions/wikia/WallNotifications/scripts/WallNotifications.js
@@ -142,9 +142,9 @@ var WallNotifications = $.createClass(Object, {
 				this.currentWikiId = firstWikiId;
 				this.wikiShown[ firstWikiId ] = true;
 				this.updateWiki( firstWikiId );
+				this.bucky.timer.stop('fetchForCurrentWiki');
 			}
 		}
-		this.bucky.timer.stop('fetchForCurrentWiki');
 	},
 
 	restoreFromCache: function() {

--- a/extensions/wikia/WallNotifications/scripts/WallNotifications.js
+++ b/extensions/wikia/WallNotifications/scripts/WallNotifications.js
@@ -205,7 +205,6 @@ var WallNotifications = $.createClass(Object, {
 	},
 
 	markAllAsReadPrompt: function(e) {
-		e.preventDefault();
 		$('#wall-notifications-markasread-sub-opts').show();
 		$('#wall-notifications-dropdown').show();
 		var $markAsRead = $('#wall-notifications-markasread');
@@ -217,13 +216,11 @@ var WallNotifications = $.createClass(Object, {
 	},
 
 	markAllAsRead: function(e) {
-		e.preventDefault();
 		this.markAllAsReadRequest( false );
 		return false;
 	},
 
 	markAllAsReadAllWikis: function(e) {
-		e.preventDefault();
 		this.markAllAsReadRequest( 'FORCE' );
 		return false;
 	},
@@ -262,7 +259,6 @@ var WallNotifications = $.createClass(Object, {
 	},
 
 	wikiClick: function(e) {
-		e.preventDefault();
 		var wikiEl = $(e.target).closest('.notifications-for-wiki');
 		if(wikiEl.hasClass('show') ) {
 			wikiEl.removeClass('show');

--- a/extensions/wikia/WallNotifications/scripts/WallNotifications.js
+++ b/extensions/wikia/WallNotifications/scripts/WallNotifications.js
@@ -198,6 +198,7 @@ var WallNotifications = $.createClass(Object, {
 				//	= tray is hidden (because there are no other wikis with notifications)
 				//  = no ability to show notifications, no tray)
 				this.showFirst();
+
 				this.bucky.timer.stop('markAllAsReadRequest');
 			})
 		});


### PR DESCRIPTION
Add bucky profiling to the core javascript handlers used by wall notifications.
Ticket: https://wikia-inc.atlassian.net/browse/VID-2047
