### PR TITLE
New files implementing an asynchronous cache.

### DIFF
--- a/includes/wikia/AsyncCache.php
+++ b/includes/wikia/AsyncCache.php
@@ -95,7 +95,7 @@ class AsyncCache {
 	private $task;
 
 	/**
-	 * @param Object $cache - An alternate caching package
+	 * @param BagOStuff $cache - An alternate caching package
 	 */
 	public function __construct( $cache = null ) {
 		$this->ttl = self::DEFAULT_TTL;

--- a/includes/wikia/AsyncCache.php
+++ b/includes/wikia/AsyncCache.php
@@ -1,0 +1,360 @@
+<?php
+
+/**
+ * Class AsyncCache
+ *
+ * A class implementing an asynchronous cache.  That is, if a cache value was found in the cache, but it is expired,
+ * this stale value will be returned and an asynchronous task will be started to regenerate the cache value.  This
+ * eliminates the cache MISS time penalty for most cases.
+ *
+ * Example usage:
+ *
+ * $value = ( new AsyncCache() )
+ *     ->key( 'video_views' )
+ *     ->ttl( 300 )
+ *     ->callback( 'SomeClass::someMethod' )->callbackParams( [ 1, 'cat', true ] )
+ *     ->value();
+ *
+ * This will try to fetch the 'video_views' key from the cache.  If the key is not found in the cache, the callback
+ * function will be executed as:
+ *
+ *   SomeClass::someMethod(1, 'cat', true);
+ *
+ * This will run immediately and will block the call to 'value()' from returning until a new value is generated.  This
+ * value will then be stored in cache with a TTL of 300 seconds (5 minutes).
+ *
+ * If 'video_views' key is found in the cache and it is fresh (the TTL hasn't expired) the value will be returned.
+ *
+ * If 'video_views' key is found in the cache but it is stale (the TTL has expired), a task to generate the new value
+ * will be created and the existing stale value will be immediately returned.
+ *
+ * If 'video_views' key is found in the cache but it is stale (the TTL has expired), AND the stale TTL has
+ * expired (the default is 60 seconds to return stale values), the callback function will be executed and will block
+ * the call to 'value()' until a new value is generated
+ *
+ */
+class AsyncCache {
+
+	// Some default TTLs
+
+	// Default time for cache value to live
+	const DEFAULT_TTL = 300;
+
+	// Default time for negative cache responses (e.g. zero, null, etc) to live
+	const DEFAULT_NEGATIVE_RESPONSE_TTL = 0;
+
+	// Default time for a stale cache value to live (returned while async job is running)
+	const DEFAULT_STALE_TTL = 60;
+
+	/** @var MemcachedPhpBagOStuff - The caching client */
+	private $cache;
+
+	/** @var string - Key to store value under */
+	private $key;
+
+	/** @var int - The cache value time to live */
+	private $ttl;
+
+	/** @var int - The cached negative response value time to live */
+	private $negativeResponseTTL = 0;
+
+	/** @var  bool - Whether to generate new values synchronously */
+	private $blockOnMiss = false;
+
+	/** @var  bool - Whether to return stale values while new values are being generated asynchronously */
+	private $staleOnMiss = true;
+
+	/** @var int - How long to return stale values while waiting for new values to be generated.  Zero
+	 			   means serve stale data as long as it takes to generate new data
+	 */
+	private $staleOnMissTTL = 0;
+
+	/** @var callable|string - A function to run to generate new values */
+	private $callback;
+	/** @var array - Arguments to pass to the $callback function */
+	private $callbackParams;
+
+	/** @var bool - Whether the cache has been fetched yet */
+	private $cacheFetched = false;
+
+	/** @var bool - Whether the cache fetch returned a value */
+	private $foundInCache = false;
+
+	/** @var int - Whether the cache value is expired */
+	private $cacheExpire;
+
+	/** @var mixed - The value returned by the task */
+	private $cacheValue;
+
+	/** @var \Wikia\Cache\AsyncCacheTask - The task created to generate a new value */
+	private $task;
+
+	/**
+	 * @param Object $cache - An alternate caching package
+	 */
+	public function __construct( $cache = null ) {
+		$this->ttl = self::DEFAULT_TTL;
+		$this->negativeResponseTTL = self::DEFAULT_NEGATIVE_RESPONSE_TTL;
+
+		$this->staleOnMissTTL = self::DEFAULT_STALE_TTL;
+
+		$this->callbackParams = [];
+
+		$this->cache = $cache ? $cache : F::app()->wg->Memc;
+	}
+
+	/**
+	 * Set the key to fetch
+	 *
+	 * @param string $cacheKey
+	 *
+	 * @return AsyncCache $this
+	 */
+	public function key( $cacheKey ) {
+		$this->key = $cacheKey;
+		return $this;
+	}
+
+	/**
+	 * Set the TTL for the cache if a new cache value is generated
+	 *
+	 * @param int $secs
+	 *
+	 * @return AsyncCache $this
+	 */
+	public function ttl( $secs ) {
+		$this->ttl = $secs;
+		return $this;
+	}
+
+	/**
+	 * Set the TTL for negative responses.  This is typically zero, or null, or some type of empty due to some type
+	 * of error getting the data.  Typically a negative response should not be cached.  An exception might be if
+	 * the negative response comes from a timeout (e.g. network problems) where caching an empty result would keep
+	 * the timeout from backing up the rest of the calling code.
+	 *
+	 * @param int $secs
+	 *
+	 * @return AsyncCache $this
+	 */
+	public function negativeResponseTTL( $secs ) {
+		$this->negativeResponseTTL = $secs;
+		return $this;
+	}
+
+	/**
+	 * Set the cache request to generate a value immediately on a miss, blocking execution until it finishes
+	 *
+	 * @return AsyncCache $this
+	 */
+	public function blockOnMiss() {
+		$this->blockOnMiss = true;
+		$this->staleOnMiss = false;
+		return $this;
+	}
+
+	/**
+	 * Set the cache to return stale data on a miss.  The single optional argument gives the time in seconds the
+	 * data is allowed to be stale
+	 *
+	 * @param int $secs
+	 *
+	 * @return AsyncCache $this
+	 */
+	public function staleOnMiss( $secs = self::DEFAULT_STALE_TTL ) {
+		$this->staleOnMiss = true;
+		$this->blockOnMiss = false;
+		$this->staleOnMissTTL = $secs;
+		return $this;
+	}
+
+	/**
+	 * A function to call that can regenerate the cache value
+	 *
+	 * @param callable|string $callback
+	 *
+	 * @return AsyncCache $this
+	 */
+	public function callback( $callback ) {
+		$this->callback = $callback;
+		return $this;
+	}
+
+	/**
+	 * Parameters to pass to the callback function
+	 *
+	 * @param array $params
+	 *
+	 * @return AsyncCache $this
+	 */
+	public function callbackParams( array $params ) {
+		$this->callbackParams = $params;
+		return $this;
+	}
+
+	/**
+	 * Whether the value was found in cache or not.  Note that calling this method will trigger a fetch from cache.
+	 *
+	 * @return bool
+	 */
+	public function foundInCache() {
+		$this->fetchFromCache();
+		return $this->foundInCache;
+	}
+
+	/**
+	 * How many seconds are left in the TTL.  Note that calling this method will trigger a fetch from cache.
+	 *
+	 * @return int
+	 */
+	public function ttlRemain() {
+		if ( $this->isCacheStale() ) {
+			return 0;
+		} else {
+			return $this->getCacheExpire() - time();
+		}
+	}
+
+	/**
+	 * Whether the cache value is stale.  Note that calling this method will trigger a fetch from cache.
+	 *
+	 * @return bool
+	 */
+	public function isCacheStale() {
+		return  time() > $this->getCacheExpire();
+	}
+
+	/**
+	 * How many seconds a stale cache value can still be returned.  If our staleOnMissTTL is zero, this method will
+	 * return '-1' meaning 'forever'.  Note that calling this method will trigger a fetch from cache.
+	 *
+	 * @return int - Seconds remaining
+	 */
+	public function staleTTLRemain() {
+		if ( !$this->isCacheStale() ) {
+			return -1;
+		}
+
+		if ( $this->canReturnStale() ) {
+			// If we can return stale forever, return a special remaining time
+			if ( $this->staleOnMissTTL == 0 ) {
+				return -1;
+			}
+
+			return $this->getCacheExpire() + $this->staleOnMissTTL - time();
+		} else {
+			return 0;
+		}
+	}
+
+	/**
+	 * Returns whether a task has been scheduled
+	 *
+	 * @return bool
+	 */
+	public function isTaskScheduled() {
+		return !empty( $this->task );
+	}
+
+	/**
+	 * Purge the give cache key from the cache
+	 *
+	 * @param string $key
+	 */
+	public function purge( $key ) {
+		\F::app()->wg->memc->delete( $key );
+	}
+
+	/**
+	 * Fetches the value from cache implementing all stale and asynchronous generation logic.
+	 *
+	 * @return mixed
+	 */
+	public function value() {
+
+		// If we have a cache value and its fresh or there's still time to return a stale cache value while we
+		// regenerate, then use the value we found.
+		if ( $this->foundInCache() && ( !$this->isCacheStale() || $this->canReturnStale() ) ) {
+			$value = $this->getCacheValue();
+
+			// If we're stale but can wait on the fresh value, schedule a job
+			if ( $this->isCacheStale() ) {
+				$this->scheduleValueGeneration();
+			}
+		} else {
+			// If we're missing or stale and can't wait for a value, generate immediately
+			$value = $this->generateValueNow();
+		}
+
+		return $value;
+	}
+
+	private function fetchFromCache() {
+		if ( $this->cacheFetched ) {
+			return;
+		}
+
+		$cacheData = $this->cache->get( $this->key );
+
+		if ( $cacheData ) {
+			list( $expire, $value ) = $cacheData;
+			$this->cacheExpire = $expire;
+			$this->cacheValue = $value;
+			$this->foundInCache = true;
+		} else {
+			$this->foundInCache = false;
+		}
+
+		$this->cacheFetched = true;
+	}
+
+	private function getCacheExpire() {
+		$this->fetchFromCache();
+
+		return $this->cacheExpire;
+	}
+
+	private function getCacheValue() {
+		$this->fetchFromCache();
+
+		return $this->cacheValue;
+	}
+
+	private function canReturnStale() {
+		// If we're always blocking on a miss, always return false
+		if ( $this->blockOnMiss ) {
+			return false;
+		}
+
+		// If we've got a zero stale on miss TTL, we gan return stale forever
+		if ( $this->staleOnMissTTL == 0 ) {
+			return true;
+		}
+
+		return time() - $this->getCacheExpire() < $this->staleOnMissTTL;
+	}
+
+	private function generateValueNow() {
+		$task = new \Wikia\Cache\AsyncCacheTask();
+		$status = $task->generate(
+			$this->key,
+			$this->callback,
+			$this->callbackParams,
+			[ 'ttl' => $this->ttl, 'negativeResponseTTL' => $this->negativeResponseTTL ] );
+
+		if ( $status->isGood() ) {
+			return $status->value;
+		} else {
+			return null;
+		}
+	}
+
+	private function scheduleValueGeneration() {
+		$this->task = ( new \Wikia\Cache\AsyncCacheTask() )->wikiId( F::app()->wg->CityId );
+		$this->task->dupCheck();
+		$this->task->call( 'generate',
+			$this->key, $this->callback, $this->callbackParams,
+			[ 'ttl' => $this->ttl, 'negativeResponseTTL' => $this->negativeResponseTTL ] );
+		$this->task->queue();
+	}
+}

--- a/includes/wikia/AsyncCache.php
+++ b/includes/wikia/AsyncCache.php
@@ -74,7 +74,7 @@ class AsyncCache {
 	 */
 	private $staleOnMissTTL = 0;
 
-	/** @var callable|string - A function to run to generate new values */
+	/** @var callable - A function to run to generate new values */
 	private $callback;
 	/** @var array - Arguments to pass to the $callback function */
 	private $callbackParams;
@@ -174,7 +174,7 @@ class AsyncCache {
 	/**
 	 * A function to call that can regenerate the cache value
 	 *
-	 * @param callable|string $callback
+	 * @param callable $callback
 	 * @param array|null $params
 	 *
 	 * @return AsyncCache $this

--- a/includes/wikia/AsyncCache.php
+++ b/includes/wikia/AsyncCache.php
@@ -179,12 +179,9 @@ class AsyncCache {
 	 *
 	 * @return AsyncCache $this
 	 */
-	public function callback( $callback, array $params = null ) {
+	public function callback( callable $callback, array $params = null ) {
 		$this->callback = $callback;
-
-		if ( is_array( $params ) ) {
-			$this->callbackParams = $params;
-		}
+		$this->callbackParams = $params;
 
 		return $this;
 	}

--- a/includes/wikia/AsyncCacheTask.php
+++ b/includes/wikia/AsyncCacheTask.php
@@ -12,8 +12,10 @@ use Wikia\Tasks\Tasks\BaseTask;
 class AsyncCacheTask extends BaseTask {
 
 	/**
+	 * This method calls code ($func) that will generate a new value to cache and then caches it.
+	 *
 	 * @param string $key - The key to cache the result under
-	 * @param string|array|callable $func - Any value that call_user_func_array recognizes as a callable method
+	 * @param callable $func - Function to generate new value
 	 * @param array $args - The args for $func
 	 * @param $options - Any additional options send back from the caching object
 	 *

--- a/includes/wikia/AsyncCacheTask.php
+++ b/includes/wikia/AsyncCacheTask.php
@@ -17,11 +17,11 @@ class AsyncCacheTask extends BaseTask {
 	 * @param string $key - The key to cache the result under
 	 * @param callable $func - Function to generate new value
 	 * @param array $args - The args for $func
-	 * @param $options - Any additional options send back from the caching object
+	 * @param array $options - Any additional options send back from the caching object
 	 *
 	 * @return \Status
 	 */
-	public static function generate( $key, $func, $args, $options ) {
+	public static function generate( $key, callable $func, array $args, array $options ) {
 
 		// Get TTLs to use for positive response and negative (empty) response
 		$ttl = empty( $options[ 'ttl' ] ) ? \AsyncCache::DEFAULT_TTL : $options[ 'ttl' ];

--- a/includes/wikia/AsyncCacheTask.php
+++ b/includes/wikia/AsyncCacheTask.php
@@ -45,7 +45,7 @@ class AsyncCacheTask extends BaseTask {
 			\F::app()->wg->memc->set( $key, $payload );
 		}
 
-		return \Status::newGood( $value );
+		return $value;
 	}
 }
 

--- a/includes/wikia/AsyncCacheTask.php
+++ b/includes/wikia/AsyncCacheTask.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Wikia\Cache;
+
+use Wikia\Tasks\Tasks\BaseTask;
+
+/**
+ * Class AsyncCacheTask
+ *
+ * @package Wikia\Cache
+ */
+class AsyncCacheTask extends BaseTask {
+
+	/**
+	 * @param string $key - The key to cache the result under
+	 * @param string|array|callable $func - Any value that call_user_func_array recognizes as a callable method
+	 * @param array $args - The args for $func
+	 * @param $options - Any additional options send back from the caching object
+	 *
+	 * @return \Status
+	 */
+	public static function generate( $key, $func, $args, $options ) {
+
+		// Get TTLs to use for positive response and negative (empty) response
+		$ttl = empty( $options[ 'ttl' ] ) ? \AsyncCache::DEFAULT_TTL : $options[ 'ttl' ];
+		$negTTL = empty( $options[ 'negativeResponseTTL' ] )
+			? \AsyncCache::DEFAULT_NEGATIVE_RESPONSE_TTL
+			:  $options[ 'negativeResponseTTL' ];
+
+		// The function has the ability to determine what it considers to be a negative response since
+		// sometimes zero or null are valid responses (e.g., count of videos on a wiki can be zero) where as other times
+		// a non-zero, non-null response can be invalid (e.g. an error response)
+		$value = null;
+		try {
+			$value = call_user_func_array( $func, $args );
+		} catch ( NegativeResponseException $e ) {
+			$ttl = $negTTL;
+		}
+
+		// Include the time
+		$payload = [ time() + $ttl, $value ];
+
+		// If our TTL isn't zero (e.g. don't cache) then cache the result
+		if ( $ttl != 0 ) {
+			\F::app()->wg->memc->set( $key, $payload );
+		}
+
+		return \Status::newGood( $value );
+	}
+}
+
+/**
+ * Class AsyncCacheTestGenerator
+ *
+ * A simple generator to test the AsyncCacheTask class
+ *
+ * @package Wikia\Cache
+ */
+class AsyncCacheTestGenerator {
+	public static function getValue( $value = 'test-value', $sleep = 0, $negResponse = false ) {
+		if ( $sleep ) {
+			sleep( $sleep );
+		}
+
+		if ( $negResponse ) {
+			throw new NegativeResponseException();
+		} else {
+			return $value;
+		}
+	}
+}
+
+/**
+ * Class NegativeResultException
+ *
+ * @package Wikia\Cache
+ */
+class NegativeResponseException extends \Exception { }

--- a/maintenance/wikia/asyncCache.php
+++ b/maintenance/wikia/asyncCache.php
@@ -34,10 +34,10 @@ class AsyncCacheCLI extends Maintenance {
 		$this->addOption( 'neg-ttl', 'TTL for negative responses', false, true, 'n' );
 		$this->addOption( 'regen-ttl', 'TTL for serving stale values', false, true, 'e' );
 
-		$this->addOption( 'generate-method', 'TTL for serving stale values', false, true, 'm' );
-		$this->addOption( 'generate-args', 'TTL for serving stale values', false, true, 'a' );
+		$this->addOption( 'generate-method', 'Method to regenerate value', false, true, 'm' );
+		$this->addOption( 'generate-args', 'Comma separated args for --generate-method', false, true, 'a' );
 
-		$this->addOption( 'block', 'TTL for serving stale values', false, false, 'b' );
+		$this->addOption( 'block', 'Block on value regeneratoin when cache is stale', false, false, 'b' );
 	}
 
 	public function execute() {

--- a/maintenance/wikia/asyncCache.php
+++ b/maintenance/wikia/asyncCache.php
@@ -26,7 +26,7 @@ class AsyncCacheCLI extends Maintenance {
 		$this->mDescription = "A CLI interface to the AsyncCache class";
 
 		$this->addOption( 'get', 'Get the value of a memc key', false, true, 'g' );
-		$this->addOption( 'purge', 'Get the value of a memc key', false, true, 'p' );
+		$this->addOption( 'purge', 'Purge the value of a memc key', false, true, 'p' );
 
 		$this->addOption( 'ttl', 'TTL for the cached value', false, true, 'l' );
 		$this->addOption( 'neg-ttl', 'TTL for negative responses', false, true, 'n' );

--- a/maintenance/wikia/asyncCache.php
+++ b/maintenance/wikia/asyncCache.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * asyncCache
+ *
+ * This script is a CLI interface to the AsyncCache class
+ *
+ */
+
+putenv( 'SERVER_ID=177' );
+
+ini_set('display_errors', 'stderr');
+ini_set('error_reporting', E_NOTICE);
+
+require_once( dirname( __FILE__ ) . '/../Maintenance.php' );
+
+/**
+ * Class AsyncCacheCLI
+ */
+class AsyncCacheCLI extends Maintenance {
+
+	protected $verbose = false;
+	protected $test    = false;
+
+	public function __construct() {
+		parent::__construct();
+		$this->mDescription = "A CLI interface to the AsyncCache class";
+		$this->addOption( 'test', 'Test mode; make no changes', false, false, 't' );
+		$this->addOption( 'verbose', 'Show extra debugging output', false, false, 'v' );
+
+		$this->addOption( 'get', 'Get the value of a memc key', false, true, 'g' );
+		$this->addOption( 'purge', 'Get the value of a memc key', false, true, 'p' );
+
+		$this->addOption( 'ttl', 'TTL for the cached value', false, true, 'l' );
+		$this->addOption( 'neg-ttl', 'TTL for negative responses', false, true, 'n' );
+		$this->addOption( 'regen-ttl', 'TTL for serving stale values', false, true, 'e' );
+
+		$this->addOption( 'generate-method', 'TTL for serving stale values', false, true, 'm' );
+		$this->addOption( 'generate-args', 'TTL for serving stale values', false, true, 'a' );
+
+		$this->addOption( 'block', 'TTL for serving stale values', false, false, 'b' );
+	}
+
+	public function execute() {
+		$this->test    = $this->hasOption( 'test' );
+		$this->verbose = $this->hasOption( 'verbose' );
+
+		if ( $this->hasOption( 'purge' ) ) {
+			$cacheKey = $this->getOption( 'purge' );
+			( new AsyncCache() )->purge( $cacheKey );
+			echo "Purged '$cacheKey'\n";
+			exit(0);
+		}
+
+		$cacheKey   = $this->getOption( 'get' );
+
+		$ttl      = $this->getOption( 'ttl', 300 );
+		$negTTL   = $this->getOption( 'neg-ttl', 0 );
+		$regenTTL = $this->getOption( 'regen-ttl', 60 );
+
+		$block    = $this->hasOption( 'block' );
+
+		$method = $this->getOption( 'generate-method', 'Wikia\Cache\AsyncCacheTestGenerator::getValue' );
+		$args   = explode( ',', $this->getOption( 'generate-args', '' ) );
+
+		$start = time();
+
+		echo "\n";
+		echo "Retrieving key '$cacheKey'\n";
+		echo "\t- TTL: $ttl\n";
+		echo "\t- Negative Response TTL: $negTTL\n";
+		echo "\t- Time to regenerate: $regenTTL\n";
+		echo "\t- Value regeneration method: $method(".implode(', ', $args).")\n";
+
+		$cache = ( new AsyncCache() )
+			->key( $cacheKey )
+			->ttl( $ttl )
+			->negativeResponseTTL( $negTTL )
+			->staleOnMiss( $regenTTL )
+			->callback( $method )->callbackParams( $args );
+
+		if ( $block ) {
+			$cache->blockOnMiss();
+		}
+
+		$value = $cache->value();
+
+		echo "\n";
+
+		if ( $cache->foundInCache() ) {
+			echo "## Key found in cache\n";
+			echo "-- TTL Remaining: " . $cache->ttlRemain() . "\n";
+		}
+
+		if ( $cache->isCacheStale() ) {
+			echo "## Cache is stale\n";
+			echo "-- Stale TTL Remaining: " . $cache->staleTTLRemain() . "\n";
+		}
+
+		if ( $cache->isTaskScheduled() ) {
+			echo "## Regenerate task scheduled\n";
+		}
+
+		echo "VALUE: $value\n";
+
+		echo "\nFinished in ".( time() - $start )." secs\n";
+	}
+
+	/**
+	 * Print the message if verbose is enabled
+	 * @param $msg - The message text to echo to STDOUT
+	 */
+	private function debug( $msg ) {
+		if ( $this->verbose ) {
+			echo $msg;
+		}
+	}
+}
+
+$maintClass = "AsyncCacheCLI";
+require_once( RUN_MAINTENANCE_IF_MAIN );
+

--- a/maintenance/wikia/asyncCache.php
+++ b/maintenance/wikia/asyncCache.php
@@ -24,8 +24,6 @@ class AsyncCacheCLI extends Maintenance {
 	public function __construct() {
 		parent::__construct();
 		$this->mDescription = "A CLI interface to the AsyncCache class";
-		$this->addOption( 'test', 'Test mode; make no changes', false, false, 't' );
-		$this->addOption( 'verbose', 'Show extra debugging output', false, false, 'v' );
 
 		$this->addOption( 'get', 'Get the value of a memc key', false, true, 'g' );
 		$this->addOption( 'purge', 'Get the value of a memc key', false, true, 'p' );
@@ -37,12 +35,10 @@ class AsyncCacheCLI extends Maintenance {
 		$this->addOption( 'generate-method', 'Method to regenerate value', false, true, 'm' );
 		$this->addOption( 'generate-args', 'Comma separated args for --generate-method', false, true, 'a' );
 
-		$this->addOption( 'block', 'Block on value regeneratoin when cache is stale', false, false, 'b' );
+		$this->addOption( 'block', 'Block on value regeneration when cache is stale', false, false, 'b' );
 	}
 
 	public function execute() {
-		$this->test    = $this->hasOption( 'test' );
-		$this->verbose = $this->hasOption( 'verbose' );
 
 		if ( $this->hasOption( 'purge' ) ) {
 			$cacheKey = $this->getOption( 'purge' );
@@ -103,16 +99,6 @@ class AsyncCacheCLI extends Maintenance {
 		echo "VALUE: $value\n";
 
 		echo "\nFinished in ".( time() - $start )." secs\n";
-	}
-
-	/**
-	 * Print the message if verbose is enabled
-	 * @param $msg - The message text to echo to STDOUT
-	 */
-	private function debug( $msg ) {
-		if ( $this->verbose ) {
-			echo $msg;
-		}
 	}
 }
 


### PR DESCRIPTION
A class implementing an asynchronous cache.  That is, if a cache value was found in the cache, but it is expired, this stale value will be returned and an asynchronous task will be started to regenerate the cache value.  This eliminates the cache MISS time penalty for most cases.

Also included is a test script for this class.  Example usage:

``` shell
  php ./asyncCache.php --get animal --ttl 20 --regen-ttl 10 --generate-args cat,5
```

This will fetch the key 'animal' setting a TTL of 20 seconds if it has to be regenerated and cached.  It will serve stale data for 10 seconds (--regen-ttl) if the cache is found but stale and the asynchronous job has not completed.  It will call the default test function 'AsyncCacheTestGenerator::getValue' with arguments 'cat' and 5.  Here 'cat' is the value to store and 5 is the number of seconds the job should sleep to simulate an expensive request.

If this is run several times the output will show in what state the cache is in.  Changing 'cat' to 'dog' will help show when stale values are being served while the 5 second regeneration job runs.

Additional parameters are available to test the other functionality of AsyncCache and are described via:

``` shell
  php ./asyncCache.php --help
```
