### PR TITLE
CON-1487: generic support for concatenation of SASS files

### DIFF
--- a/extensions/wikia/Venus/VenusController.class.php
+++ b/extensions/wikia/Venus/VenusController.class.php
@@ -113,7 +113,6 @@ class VenusController extends WikiaController {
 		$cssGroups = ['venus_css'];
 		$cssLinks = '';
 
-		$styles = $this->skin->getStyles();
 		$scripts = $this->skin->getScripts();
 
 		//let extensions manipulate the asset packages (e.g. ArticleComments,
@@ -127,36 +126,17 @@ class VenusController extends WikiaController {
 			]
 		);
 
-		// try to fetch all SASS files using a single request (CON-1487)
-		$sassFiles = [];
-
 		// SASS files requested via VenusAssetsPackages hook
+		$sassFiles = [];
 		foreach ( $this->assetsManager->getURL( $cssGroups ) as $src ) {
 			if ( $this->assetsManager->checkAssetUrlForSkin( $src, $this->skin ) ) {
 				$sassFiles[] = $src;
 			}
 		}
 
-		// SASS files requested via Wikia::addAssetsToOutput
-		if ( is_array( $styles ) ) {
-			foreach ( $styles as $s ) {
-				if ($this->assetsManager->isSassUrl($s['url'])) {
-					$sassFiles[] = $s['url'];
-				} else {
-					$cssLinks .= $s['tag'];
-				}
-			}
-		}
-
-		// turn an url (http://something.wikia.com/__am/sass/options/path/to/file.scss) to a local filepath
-		$sassFiles = $this->assetsManager->getSassFilePath($sassFiles);
-
-		// get a single URL to fetch all the required SASS files
-		$sassFilesUrl = $this->assetsManager->getSassesUrl($sassFiles);
-
-		$cssLinks = Html::linkedStyle($sassFilesUrl) . $cssLinks;
-
-		#print_r($cssLinks); die;
+		// try to fetch all SASS files using a single request (CON-1487)
+		// "WikiaSkin::getStylesWithCombinedSASS: combined 9 SASS files"
+		$cssLinks .= $this->skin->getStylesWithCombinedSASS($sassFiles);
 
 		foreach ( $this->assetsManager->getURL( $jsHeadGroups ) as $src ) {
 			if ( $this->assetsManager->checkAssetUrlForSkin( $src, $this->skin ) ) {

--- a/extensions/wikia/WikiaMobile/WikiaMobileService.class.php
+++ b/extensions/wikia/WikiaMobile/WikiaMobileService.class.php
@@ -67,7 +67,6 @@ class WikiaMobileService extends WikiaService {
 		$cssLinks = '';
 		$jsBodyFiles = '';
 		$jsExtensionFiles = '';
-		$styles = $this->skin->getStyles();
 		$scripts = $this->skin->getScripts();
 
 		if ( $type == 'preview' ) {
@@ -91,23 +90,16 @@ class WikiaMobileService extends WikiaService {
 			]
 		);
 
-		if ( is_array( $this->scssPackages ) ) {
-			//force main SCSS as first to make overriding it possible
-			foreach ( $this->assetsManager->getURL( $this->scssPackages ) as $s ) {
-				//packages/assets are enqueued via an hook, let's make sure we should actually let them through
-				if ( $this->assetsManager->checkAssetUrlForSkin( $s, $this->skin ) ) {
-					//W3C standard says type attribute and quotes (for single non-URI values) not needed, let's save on output size
-					$cssLinks .= "<link rel=stylesheet href='{$s}'/>";
-				}
+		// SASS files requested via WikiaMobileAssetsPackages hook
+		$sassFiles = [];
+		foreach ( $this->assetsManager->getURL( $this->scssPackages ) as $src ) {
+			if ( $this->assetsManager->checkAssetUrlForSkin( $src, $this->skin ) ) {
+				$sassFiles[] = $src;
 			}
 		}
 
-		if ( is_array( $styles ) ) {
-			foreach ( $styles as $s ) {
-				//safe URL's as getStyles performs all the required checks
-				$cssLinks .= "<link rel=stylesheet href='{$s['url']}'/>";//this is a strict skin, getStyles returns only elements with a set URL
-			}
-		}
+		// try to fetch all SASS files using a single request (CON-1487)
+		$cssLinks .= $this->skin->getStylesWithCombinedSASS($sassFiles);
 
 		if ( is_array( $this->jsExtensionPackages ) ) {
 			//core JS in the head section, definitely safe

--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -2039,6 +2039,8 @@ class Wikia {
 
 		$sources = AssetsManager::getInstance()->getURL( $assetName, $type, $local );
 
+		#print_r([$assetName, $type, wfGetCallerClassMethod(__CLASS__)]);
+
 		foreach($sources as $src){
 			switch ( $type ) {
 				case AssetsManager::TYPE_CSS:

--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -2039,8 +2039,6 @@ class Wikia {
 
 		$sources = AssetsManager::getInstance()->getURL( $assetName, $type, $local );
 
-		#print_r([$assetName, $type, wfGetCallerClassMethod(__CLASS__)]);
-
 		foreach($sources as $src){
 			switch ( $type ) {
 				case AssetsManager::TYPE_CSS:

--- a/includes/wikia/nirvana/WikiaSkin.class.php
+++ b/includes/wikia/nirvana/WikiaSkin.class.php
@@ -183,10 +183,13 @@ abstract class WikiaSkin extends SkinTemplate {
 	 *
 	 * Additionaly, all SASS files from $sassFiles array will be loaded as well.
 	 *
+	 * Once this function ends its run $sassFiles will be updated (via a reference)
+	 * with all SASS files extracted from getStyles().
+	 *
 	 * @param array $sassFiles additional list of SASS files to load
 	 * @return string CSS links with extracted SASS files and the rest
 	 */
-	public function getStylesWithCombinedSASS(Array $sassFiles) {
+	public function getStylesWithCombinedSASS(Array &$sassFiles) {
 		wfProfileIn(__METHOD__);
 
 		global $wgAllInOne;

--- a/includes/wikia/nirvana/WikiaSkin.class.php
+++ b/includes/wikia/nirvana/WikiaSkin.class.php
@@ -20,6 +20,8 @@ abstract class WikiaSkin extends SkinTemplate {
 	//@see AssetsManager::checkAssetUrlForSkin
 	protected $strictAssetUrlCheck = true;
 
+	private $assetsManager;
+
 	/**
 	 * WikiaSkin constructor
 	 *
@@ -32,6 +34,8 @@ abstract class WikiaSkin extends SkinTemplate {
 		$this->app = F::app();
 		$this->wg = $this->app->wg;
 		$this->wf = $this->app->wf;
+
+		$this->assetsManager = AssetsManager::getInstance();
 
 		/**
 		 * old skins initialize template, skinname, stylename and themename statically in the class declaration,
@@ -92,7 +96,6 @@ abstract class WikiaSkin extends SkinTemplate {
 		wfProfileIn( __METHOD__ );
 
 		$scriptTags = $this->wg->out->getScriptsOnly() . $this->wg->out->getHeadItems();
-		$am = AssetsManager::getInstance();
 		$matches = array();
 		$res = array();
 
@@ -106,7 +109,7 @@ abstract class WikiaSkin extends SkinTemplate {
 				//find the src if set
 				preg_match( '/<script[^>]+src=["\'\s]?([^"\'>\s]+)["\'\s]?[^>]*>/im', $m, $srcMatch );
 
-				if ( !empty( $srcMatch[1] ) && $am->checkAssetUrlForSkin( $srcMatch[1], $this ) ) {
+				if ( !empty( $srcMatch[1] ) && $this->assetsManager->checkAssetUrlForSkin( $srcMatch[1], $this ) ) {
 					//fix HTML::inlineScript's expansion of ampersands in the src attribute
 					$url = str_replace( '&amp;', '&', $srcMatch[1] );
 					// apply domain sharding
@@ -134,7 +137,6 @@ abstract class WikiaSkin extends SkinTemplate {
 
 		//there are a number of extension that use addScript to append link tags for stylesheets, need to include those too
 		$stylesTags = $this->wg->out->buildCssLinks(). $this->wg->out->getHeadItems() . $this->wg->out->getScriptsOnly();
-		$am = AssetsManager::getInstance();
 		$matches = array();
 		$res = array();
 
@@ -148,7 +150,7 @@ abstract class WikiaSkin extends SkinTemplate {
 				//find the src if set
 				preg_match( '/<link[^>]+href=["\'\s]?([^"\'>\s]+)["\'\s]?[^>]*>/im', $m, $hrefMatch );
 
-				if ( !empty( $hrefMatch[1] ) && $am->checkAssetUrlForSkin( $hrefMatch[1], $this ) ) {
+				if ( !empty( $hrefMatch[1] ) && $this->assetsManager->checkAssetUrlForSkin( $hrefMatch[1], $this ) ) {
 					//fix HTML::element's expansion of ampersands in the src attribute
 					// todo: do we really need this trick? I notice URLs that are not properly encoded in the head element
 					$url = str_replace( '&amp;', '&', $hrefMatch[1] );
@@ -193,13 +195,11 @@ abstract class WikiaSkin extends SkinTemplate {
 		wfProfileIn(__METHOD__);
 
 		global $wgAllInOne;
-		$am = AssetsManager::getInstance();
-
 		$cssLinks = [];
 
 		foreach ( $this->getStyles() as $s ) {
 			if ( !empty($s['url']) ) {
-				if ($wgAllInOne && $am->isSassUrl($s['url'])) {
+				if ($wgAllInOne && $this->assetsManager->isSassUrl($s['url'])) {
 					$sassFiles[] = $s['url'];
 				} else {
 					$cssLinks[] = $s['tag'];
@@ -210,10 +210,10 @@ abstract class WikiaSkin extends SkinTemplate {
 		}
 
 		// turn an url (http://something.wikia.com/__am/sass/options/path/to/file.scss) to a local filepath
-		$sassFiles = $am->getSassFilePath($sassFiles);
+		$sassFiles = $this->assetsManager->getSassFilePath($sassFiles);
 
 		// get a single URL to fetch all the required SASS files
-		$sassFilesUrl = $am->getSassesUrl($sassFiles);
+		$sassFilesUrl = $this->assetsManager->getSassesUrl($sassFiles);
 
 		wfDebug( sprintf( "%s: combined %d SASS files\n", __METHOD__, count($sassFiles) ) );
 
@@ -230,7 +230,7 @@ abstract class WikiaSkin extends SkinTemplate {
 		$scripts = '';
 		$vars = array(
 			'Wikia' => new stdClass(),
-			'wgJqueryUrl' => AssetsManager::getInstance()->getURL( 'jquery' ),
+			'wgJqueryUrl' => $this->assetsManager->getURL( 'jquery' ),
 		);
 
 		wfrunHooks( 'WikiaSkinTopScripts', array( &$vars, &$scripts, $this ) );

--- a/includes/wikia/nirvana/WikiaSkin.class.php
+++ b/includes/wikia/nirvana/WikiaSkin.class.php
@@ -192,19 +192,17 @@ abstract class WikiaSkin extends SkinTemplate {
 		global $wgAllInOne;
 		$am = AssetsManager::getInstance();
 
-		$cssLinks = '';
-		$combinedCnt = 0;
+		$cssLinks = [];
 
 		foreach ( $this->getStyles() as $s ) {
 			if ( !empty($s['url']) ) {
 				if ($wgAllInOne && $am->isSassUrl($s['url'])) {
 					$sassFiles[] = $s['url'];
-					$combinedCnt++;
 				} else {
-					$cssLinks .= $s['tag'];
+					$cssLinks[] = $s['tag'];
 				}
 			} else {
-				$cssLinks .= $s['tag'];
+				$cssLinks[] = $s['tag'];
 			}
 		}
 
@@ -214,10 +212,10 @@ abstract class WikiaSkin extends SkinTemplate {
 		// get a single URL to fetch all the required SASS files
 		$sassFilesUrl = $am->getSassesUrl($sassFiles);
 
-		wfDebug( sprintf( "%s: combined %d SASS files\n", __METHOD__, $combinedCnt ) );
+		wfDebug( sprintf( "%s: combined %d SASS files\n", __METHOD__, count($sassFiles) ) );
 
 		wfProfileOut(__METHOD__);
-		return Html::linkedStyle($sassFilesUrl ) . $cssLinks;
+		return Html::linkedStyle($sassFilesUrl ) . implode('', $cssLinks);
 	}
 
 	/*

--- a/includes/wikia/tests/WikiaSkinTest.php
+++ b/includes/wikia/tests/WikiaSkinTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Wikia\Tests\WikiaSkin;
+
+class DummySkin extends \WikiaSkin {
+
+	protected $strictAssetUrlCheck = false;
+
+}
+
+/**
+ * A set of unit tests for WikiaSkin class
+ *
+ * @author macbre
+ */
+class WikiaSkinTest extends \WikiaBaseTest {
+
+	public function setUp() {
+		parent::setUp();
+		$this->mockGlobalVariable('wgStyleVersion', 123);
+	}
+
+	private function mockOutputPage(Array $styles) {
+		$links = '';
+		foreach ($styles as $style) {
+			$links .= \Html::linkedStyle($style);
+		}
+
+		$this->mockGlobalVariable('wgOut', $this->mockClassWithMethods('OutputPage', [
+			'buildCssLinks' => $links
+		]));
+	}
+
+	/**
+	 * Test for WikiaSkin::getStylesWithCombinedSASS
+	 *
+	 */
+	public function testGetStylesWithCombinedSASS() {
+		$cssFiles = [
+			'/ext/123/style.css',
+			'/ext/456/style.scss', # this one should be combined with files from $sassFiles
+			'/ext/789/style.css',
+		];
+		$sassFiles = [
+			'foo/bar/style.scss',
+			'foo/awesome/style.scss',
+		];
+
+		$this->mockOutputPage($cssFiles);
+
+		$skin = new DummySkin();
+		$combinaedStyles = $skin->getStylesWithCombinedSASS($sassFiles);
+
+		$this->assertEquals(3, substr_count($combinaedStyles, '<link rel="stylesheet"'), 'There should be three CSS/SASS requests made');
+		$this->assertEquals(1, substr_count($combinaedStyles, '/__am/123/sasses/'), 'Concatenated SASS files should be requested with a single request');
+		$this->assertEquals(2, substr_count($combinaedStyles, '<link rel="stylesheet" href="/ext/'), 'CSS files should still be loaded separately');
+
+		foreach(array_merge($cssFiles, $sassFiles) as $style) {
+			$this->assertContains($style, $combinaedStyles, 'Each CSS/SASS should be requested');
+		}
+	}
+
+}

--- a/includes/wikia/tests/WikiaSkinTest.php
+++ b/includes/wikia/tests/WikiaSkinTest.php
@@ -15,11 +15,6 @@ class DummySkin extends \WikiaSkin {
  */
 class WikiaSkinTest extends \WikiaBaseTest {
 
-	public function setUp() {
-		parent::setUp();
-		$this->mockGlobalVariable('wgStyleVersion', 123);
-	}
-
 	private function mockOutputPage(Array $styles) {
 		$links = '';
 		foreach ($styles as $style) {
@@ -49,14 +44,14 @@ class WikiaSkinTest extends \WikiaBaseTest {
 		$this->mockOutputPage($cssFiles);
 
 		$skin = new DummySkin();
-		$combinaedStyles = $skin->getStylesWithCombinedSASS($sassFiles);
+		$combinedStyles = $skin->getStylesWithCombinedSASS($sassFiles);
 
-		$this->assertEquals(3, substr_count($combinaedStyles, '<link rel="stylesheet"'), 'There should be three CSS/SASS requests made');
-		$this->assertEquals(1, substr_count($combinaedStyles, '/__am/123/sasses/'), 'Concatenated SASS files should be requested with a single request');
-		$this->assertEquals(2, substr_count($combinaedStyles, '<link rel="stylesheet" href="/ext/'), 'CSS files should still be loaded separately');
+		$this->assertEquals(3, substr_count($combinedStyles, '<link rel="stylesheet"'), 'There should be three CSS/SASS requests made - ' . $combinedStyles);
+		$this->assertEquals(1, substr_count($combinedStyles, '/sasses/'), 'Concatenated SASS files should be requested with a single request - ' . $combinedStyles);
+		$this->assertEquals(2, substr_count($combinedStyles, '<link rel="stylesheet" href="/ext/'), 'CSS files should still be loaded separately - ' . $combinedStyles);
 
 		foreach(array_merge($cssFiles, $sassFiles) as $style) {
-			$this->assertContains($style, $combinaedStyles, 'Each CSS/SASS should be requested');
+			$this->assertContains($style, $combinedStyles, 'Each CSS/SASS should be requested - ' . $combinedStyles);
 		}
 	}
 

--- a/skins/oasis/modules/OasisController.class.php
+++ b/skins/oasis/modules/OasisController.class.php
@@ -197,7 +197,6 @@ class OasisController extends WikiaController {
 
     	// Reset (this ensures no duplication in CSS links)
 		$this->cssLinks = '';
-		$this->cssPrintLinks = '';
 
 		$sassFiles = [];
 		foreach ( $skin->getStyles() as $s ) {
@@ -210,10 +209,7 @@ class OasisController extends WikiaController {
 					}
 				}
 
-				// Print styles will be loaded separately at the bottom of the page
-				if ( stripos($tag, 'media="print"') !== false ) {
-					$this->cssPrintLinks .= $tag;
-				} elseif ($wgAllInOne && $this->assetsManager->isSassUrl($s['url'])) {
+				if ($wgAllInOne && $this->assetsManager->isSassUrl($s['url'])) {
 					$sassFiles[] = $s['url'];
 				} else {
 					$this->cssLinks .= $tag;

--- a/skins/oasis/modules/OasisController.class.php
+++ b/skins/oasis/modules/OasisController.class.php
@@ -196,40 +196,12 @@ class OasisController extends WikiaController {
 		}
 
     	// Reset (this ensures no duplication in CSS links)
-		$this->cssLinks = '';
+		$sassFiles = ['skins/oasis/css/oasis.scss'];
 
-		$sassFiles = [];
-		foreach ( $skin->getStyles() as $s ) {
-			if ( !empty($s['url']) ) {
-				$tag = $s['tag'];
-				if ( !empty( $wgAllInOne ) ) {
-					$url = $this->minifySingleAsset($s['url']);
-					if ($url !== $s['url']) {
-						$tag = str_replace($s['url'],$url,$tag);
-					}
-				}
+		$this->cssLinks = $skin->getStylesWithCombinedSASS($sassFiles);
 
-				if ($wgAllInOne && $this->assetsManager->isSassUrl($s['url'])) {
-					$sassFiles[] = $s['url'];
-				} else {
-					$this->cssLinks .= $tag;
-				}
-			} else {
-				$this->cssLinks .= $s['tag'];
-			}
-		}
-
-		$mainSassFile = 'skins/oasis/css/oasis.scss';
-		if (!empty($sassFiles)) {
-			array_unshift($sassFiles, $mainSassFile);
-			$sassFiles = $this->assetsManager->getSassFilePath($sassFiles);
-			$sassFilesUrl = $this->assetsManager->getSassesUrl($sassFiles);
-
-			$this->cssLinks = Html::linkedStyle($sassFilesUrl) . $this->cssLinks;
-			$this->bottomScripts .= Html::inlineScript("var wgSassLoadedScss = ".json_encode($sassFiles).";");
-		} else {
-			$this->cssLinks = Html::linkedStyle($this->assetsManager->getSassCommonURL($mainSassFile)) . $this->cssLinks;
-		}
+		// $sassFiles will be updated by getStylesWithCombinedSASS method will all extracted and concatenated SASS files
+		$this->bottomScripts .= Html::inlineScript("var wgSassLoadedScss = ".json_encode($sassFiles).";");
 
 		$this->headLinks = $wgOut->getHeadLinks();
 		$this->headItems = $skin->getHeadItems();

--- a/skins/oasis/modules/templates/Oasis_Index.php
+++ b/skins/oasis/modules/templates/Oasis_Index.php
@@ -105,7 +105,6 @@
 <script type="text/javascript">/*<![CDATA[*/ if (typeof AdEngine_trackPageInteractive === 'function') {wgAfterContentAndJS.push(AdEngine_trackPageInteractive);} /*]]>*/</script>
 <?php } ?>
 <?= $bottomScripts ?>
-<?= $cssPrintLinks ?>
 
 </body>
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CON-1487

@kvas-damian / @wladekb / @Wikia/platform-team 

This PR brings a generic handling of SASS files concatenation for all skins. Currently only Oasis has this front-end performance related feature.
- in Venus this change saves ~10 requests to SASS files
- in WikiaMobile only a single request is made (instead of four) - pinging @hakubo 

Each call to `Wikia::addAssetsToOutput` with SASS group passed adds a new `<link>` tag to `$wgOut`. This change ports Oasis-specific filtering and concatenating of SASS requests into a generic code that can be used in all skins.

@wladekb: unit tests were added :)
