### PR TITLE
MWEB-1058 P2 fix: added new canremovemap right

### DIFF
--- a/extensions/wikia/WikiaMaps/WikiaMaps.setup.php
+++ b/extensions/wikia/WikiaMaps/WikiaMaps.setup.php
@@ -75,6 +75,16 @@ JSMessages::registerPackage( 'WikiaMapsEmbedMapCode', [
 	'wikia-interactive-maps-embed-map-code-*'
 ] );
 
+// Rights
+$wgAvailableRights[] = 'canremovemap';
+
+// Permissions
+// canremove -- give it to users who can remove maps
+$wgGroupPermissions['*']['canremovemap'] = false;
+$wgGroupPermissions['sysop']['canremovemap'] = true;
+$wgGroupPermissions['staff']['canremovemap'] = true;
+$wgGroupPermissions['helper']['canremovemap'] = true;
+
 // Logs
 $wgLogTypes[] = 'maps';
 $wgLogNames['maps'] = 'wikia-interactive-maps-log-name';


### PR DESCRIPTION
Somehow new rights in the setup file for WikiaMaps didn't get merged to `dev` branch nor to `release-247` and it made impossible for staff users removing maps.

This simple fix in `WikiaMaps.setup.php` fixes it.
