### PR TITLE
Removing location hash from URLs sent via bucky

### DIFF
--- a/extensions/wikia/Bucky/js/bucky_metrics.js
+++ b/extensions/wikia/Bucky/js/bucky_metrics.js
@@ -11,7 +11,8 @@ require([
 		var wgTransactionContext = window.wgTransactionContext || {};
 
 		wgTransactionContext.country = geo.getCountryCode();
-		wgTransactionContext.url = window.location.href;
+		// send URL without hash since we don't care about it and it breaks queries.
+		wgTransactionContext.url = window.location.href.split('#')[0];
 		wgTransactionContext.userAgent = window.navigator.userAgent;
 		wgTransactionContext.os = window.navigator.platform;
 		wgTransactionContext.bodySize = document.getElementsByTagName('body')[0].innerHTML.length;


### PR DESCRIPTION
I noticed that when there was a `#` in the url of the page I'm making bucky calls from, the request to speed.wikia.net was getting cut off at the location of the hash. One fix would be to escape the hash, but a possibly better fix is to just drop the hash altogether b/c we probably don't need that level of granularity in our analytics. 

@wladekb, please let me know what you think. It's possible this is only affecting chrome dev tools and the queries are going through successfully, but I'm not sure how to verify that. 

Example:
- wikia page: http://glee.liz.wikia-dev.com/wiki/Thread:1567598#2
- bucky request before fix: `http://speed.wikia.net/__rum/v2/send?p={%22context%22:{%22type%22:%22page/other%22,%22env%22:%22dev%22,%22wiki%22:%22glee%22,%22entry_point%22:%22page%22,%22namespace%22:1201,%22logged_in%22:true,%22action%22:%22view%22,%22skin%22:%22oasis%22,%22country%22:%22US%22,%22url%22:%22http://glee.liz.wikia-dev.com/wiki/Thread:1567598`
- bucky request after fix: `http://speed.wikia.net/__rum/v2/send?p={%22context%22:{%22type%22:%22page/other%22,%22env%22:%22dev%22,%22wiki%22:%22glee%22,%22entry_point%22:%22page%22,%22namespace%22:1201,%22logged_in%22:true,%22action%22:%22view%22,%22skin%22:%22oasis%22,%22country%22:%22US%22,%22url%22:%22http://glee.liz.wikia-dev.com/wiki/Thread:1567598%22,%22userAgent%22:%22Mozilla/5.0%20(Macintosh;%20Intel%20Mac%20OS%20X%2010_9_5)%20AppleWebKit/537.36%20(KHTML,%20like%20Gecko)%20Chrome/37.0.2062.124%20Safari/537.36%22,%22os%22:%22MacIntel%22,%22bodySize%22:56503},%22data%22:{%22metrics%22:{%22LightboxLoader.init%22:2.006},%22pageload%22:{%22loadEventEnd%22:6414,%22loadEventStart%22:6398,%22domComplete%22:6367,%22domContentLoadedEventEnd%22:5812,%22domContentLoadedEventStart%22:5701,%22domInteractive%22:5701,%22domLoading%22:708,%22responseEnd%22:694,%22responseStart%22:691,%22requestStart%22:6,%22connectEnd%22:0,%22connectStart%22:0,%22domainLookupEnd%22:0,%22domainLookupStart%22:0,%22fetchStart%22:0,%22unloadEventEnd%22:693,%22unloadEventStart%22:693,%22navigationStart%22:0}}}`
