### PR TITLE
CON-1954: remove no longer needed -moz prefixes

### DIFF
--- a/extensions/wikia/AchievementsII/css/notification.css
+++ b/extensions/wikia/AchievementsII/css/notification.css
@@ -1,6 +1,4 @@
 .AchievementsNotification {
-	-moz-border-radius-bottomleft: 12px;
-	-moz-border-radius-bottomright: 12px;
 	-webkit-border-bottom-left-radius: 12px;
 	-webkit-border-bottom-right-radius: 12px;
 	border-bottom-left-radius: 12px;

--- a/extensions/wikia/AchievementsII/css/platinum.css
+++ b/extensions/wikia/AchievementsII/css/platinum.css
@@ -102,7 +102,6 @@
 	margin-bottom: 10px;
 	padding: 5px;
 	width: 90px;
-	-moz-border-radius: 5px;
 }
 
 .customize-platinum-badge .commands {

--- a/extensions/wikia/Answers/templates/AnswersCSS.tmpl.php
+++ b/extensions/wikia/Answers/templates/AnswersCSS.tmpl.php
@@ -59,7 +59,7 @@ body { background: url(http://images2.wikia.nocookie.net/test1223/images/c/c5/An
 <?/* Article */?>
 #wikia_page { border: 0 ; margin: 0 311px 0 0; padding: 0; top: 0; }
 #article { padding: 15px 30px; }
-h1.firstHeading { background: #e9f0ff; border: 1px solid #36C; padding: 25px; line-height: normal; -moz-border-radius: 20px; -webkit-border-radius: 20px; }
+h1.firstHeading { background: #e9f0ff; border: 1px solid #36C; padding: 25px; line-height: normal; -webkit-border-radius: 20px; }
 h1.firstHeading:after { content: '?'; }
 
 <?/* Sidebar */?>

--- a/extensions/wikia/ApiDocs/css/ApiDocs.scss
+++ b/extensions/wikia/ApiDocs/css/ApiDocs.scss
@@ -20,7 +20,6 @@ $darkGray-c5: #333333;
 }
 
 @mixin buttons {
-	-moz-border-radius: 2px;
 	background-color: $blue-c1;
 	border: solid 1px $blue-c1;
 	border-radius: 2px;
@@ -30,7 +29,6 @@ $darkGray-c5: #333333;
 }
 
 @mixin inputs {
-	-moz-border-radius: 2px;
 	border: solid 1px $midGray-c3;
 	border-radius: 2px;
 	color: $darkGray-c5;

--- a/extensions/wikia/CreatePage/css/CreatePage.css
+++ b/extensions/wikia/CreatePage/css/CreatePage.css
@@ -50,7 +50,6 @@
 
 #CreatePageDialogChoices .accent {
 	border-radius: 10px;
-	-moz-border-radius: 10px;
 	-webkit-border-radius: 10px;
 }
 

--- a/extensions/wikia/RTE/ckeditor/_source/skins/wikia/tabs.css
+++ b/extensions/wikia/RTE/ckeditor/_source/skins/wikia/tabs.css
@@ -15,7 +15,6 @@
 }
 
 .cke_skin_wikia .cke_tabs .cke_button a {
-	-moz-box-shadow: none;
 	box-shadow: none;
 	border: none;
 	height: 15px;

--- a/extensions/wikia/RegexBlock/RegexBlock.css
+++ b/extensions/wikia/RegexBlock/RegexBlock.css
@@ -23,6 +23,5 @@ color:#DC143C;
 	background-image: -webkit-gradient(linear, 0% 20%, 0% 70%, from(#c00), to(#670000));
 	border-color: #ff0000;
 	color: #FFF;
-	-moz-box-shadow: 0 0 0 1px #800000;
 	-webkit-box-shadow: 0 1px 0 #800000, 0 -1px 0 #800000, 1px 0 0 #800000, -1px 0 0 #800000;
 }

--- a/extensions/wikia/SpecialMultipleLookup/css/table.css
+++ b/extensions/wikia/SpecialMultipleLookup/css/table.css
@@ -14,7 +14,7 @@ table.TablePager{ clear:both; margin:5px auto; width:100%; }
 .dataTables_paginate { width: 44px; float: right; text-align: right; }
 .paginate_disabled_previous, .paginate_enabled_previous, .paginate_disabled_next, .paginate_enabled_next { height: 19px; width: 19px; margin-left: 3px; float: left;}
 .paging_full_numbers span.paginate_button,
-.paging_full_numbers span.paginate_active { border: 1px solid #aaa; -webkit-border-radius: 5px; -moz-border-radius: 5px; padding: 2px 5px; margin: 0 3px; cursor: pointer; *cursor: hand; }
+.paging_full_numbers span.paginate_active { border: 1px solid #aaa; -webkit-border-radius: 5px; padding: 2px 5px; margin: 0 3px; cursor: pointer; *cursor: hand; }
 .paging_full_numbers span.paginate_button { background-color: #ddd; }
 .paging_full_numbers span.paginate_button:hover { background-color: #ccc; }
 .paging_full_numbers span.paginate_active { background-color: #99B3FF; }

--- a/extensions/wikia/WallNotifications/styles/monobook/WallNotificationsMonobook.scss
+++ b/extensions/wikia/WallNotifications/styles/monobook/WallNotificationsMonobook.scss
@@ -61,7 +61,6 @@
 
 		.notifications-wiki-count-container .notifications-wiki-count {
 			border-radius: 15px;
-			-moz-border-radius: 15px;
 			-webkit-border-radius: 15px;
 			background: #FF0000;
 			font-size: 12px;

--- a/extensions/wikia/WikiAnswers/WikiAnswers.css
+++ b/extensions/wikia/WikiAnswers/WikiAnswers.css
@@ -13,7 +13,6 @@
 #answers_ask input.header_field,
 #tabAsk input.header_field,
 #tab input.header_field {
-	-moz-border-radius:10px 10px 10px 10px;
 	-webkit-border-radius:10px 10px 10px 10px;
 	border:3px solid #E0EAF8;
 	font-family:"Helvetica Neue",Helvetica,Arial,default;
@@ -87,7 +86,6 @@
 }
 
 #question_box {
-	-moz-border-radius: 10px 10px 0px 0px;
 	-webkit-border-radius: 10px 10px 0px 0px;
 	border-left: 2px solid #E0EAF8;
 	border-right: 2px solid #E0EAF8;
@@ -100,7 +98,6 @@
 }
 
 #answer_box {
-	-moz-border-radius: 10px;
 	-webkit-border-radius: 10px;
 	margin-bottom: 20px;
 	padding-bottom: 35px; /* overcome float:right" in save button */
@@ -112,7 +109,6 @@
 }
 
 #article_save_button {
-	-moz-box-shadow:none;
 	background: #2966B8;
 	border: 1px solid;
 	color: #fff;
@@ -177,7 +173,6 @@
 
 
 .qa_box {
-	-moz-border-radius: 8px;
 	-webkit-border-radius: 8px;
 	border-style: solid;
 	border-width: 1px;
@@ -194,7 +189,6 @@
 }
 
 #qa_toolbox_button {
-	-moz-border-radius: 8px;
 	-webkit-border-radius: 8px;
 	background-color: #fff;
 	border: 1px solid #A9C5EB;
@@ -322,7 +316,6 @@
 #answers_article .ui-corner-bottom,
 #answers_article .ui-corner-all,
 #answers_article .ui-corner-top {
-	-moz-border-radius: 0px;
 	-webkit-border-radius: 0px;
 }
 
@@ -364,7 +357,6 @@
 
 /* Related questions */
 #related_questions {
-	-moz-border-radius: 10px 10px 10px 10px;
 	-webkit-border-radius:10px 10px 10px 10px;
 	padding: 10px;
 }
@@ -415,7 +407,6 @@ div.article-comm-input-text textarea {
 #search_box {
 	background-image: none;
 	padding: 0px;
-	-moz-border-radius: 5px; 
 	-webkit-border-radius: 5px;
 }
 
@@ -639,7 +630,6 @@ div.userInfoNoAvatar .userPoints {
 }
 
 .action-right a:link, .action-right a:visited {
-	-moz-border-radius: 3px 3px 3px 3px;
 	-webkit-border-radius: 3px 3px 3px 3px;
 	background: #6094DB;
 	color: #FFF;

--- a/extensions/wikia/WikiFactory/Metrics/css/table.css
+++ b/extensions/wikia/WikiFactory/Metrics/css/table.css
@@ -14,7 +14,7 @@ table.TablePager{ clear:both; margin:5px auto; width:100%; }
 .dataTables_paginate { width: 44px; float: right; text-align: right; }
 .paginate_disabled_previous, .paginate_enabled_previous, .paginate_disabled_next, .paginate_enabled_next { height: 19px; width: 19px; margin-left: 3px; float: left;}
 .paging_full_numbers span.paginate_button,
-.paging_full_numbers span.paginate_active { border: 1px solid #aaa; -webkit-border-radius: 5px; -moz-border-radius: 5px; padding: 2px 5px; margin: 0 3px; cursor: pointer; *cursor: hand; }
+.paging_full_numbers span.paginate_active { border: 1px solid #aaa; -webkit-border-radius: 5px; padding: 2px 5px; margin: 0 3px; cursor: pointer; *cursor: hand; }
 .paging_full_numbers span.paginate_button { background-color: #ddd; }
 .paging_full_numbers span.paginate_button:hover { background-color: #ccc; }
 .paging_full_numbers span.paginate_active { background-color: #99B3FF; }

--- a/extensions/wikia/WikiStats/css/wikistats.css
+++ b/extensions/wikia/WikiStats/css/wikistats.css
@@ -203,7 +203,7 @@ table.TablePager{ clear:both; margin:5px auto; width:100%; }
 .dataTables_paginate { width: 44px; float: right; text-align: right; }
 .paginate_disabled_previous, .paginate_enabled_previous, .paginate_disabled_next, .paginate_enabled_next { height: 19px; width: 19px; margin-left: 3px; float: left;}
 .paging_full_numbers span.paginate_button,
-.paging_full_numbers span.paginate_active { border: 1px solid #aaa; -webkit-border-radius: 5px; -moz-border-radius: 5px; padding: 2px 5px; margin: 0 3px; cursor: pointer; *cursor: hand; }
+.paging_full_numbers span.paginate_active { border: 1px solid #aaa; -webkit-border-radius: 5px; padding: 2px 5px; margin: 0 3px; cursor: pointer; *cursor: hand; }
 .paging_full_numbers span.paginate_button { background-color: #ddd; }
 .paging_full_numbers span.paginate_button:hover { background-color: #ccc; }
 .paging_full_numbers span.paginate_active { background-color: #99B3FF; }

--- a/extensions/wikia/WikiaPhotoGallery/css/WikiaPhotoGallery.editor.css
+++ b/extensions/wikia/WikiaPhotoGallery/css/WikiaPhotoGallery.editor.css
@@ -41,7 +41,6 @@ img.WikiaPhotoGalleryProgress {
 
 /* slider from jQuery UI */
 #WikiaPhotoGalleryEditor .ui-slider {
-	-moz-border-radius: 4px;
 	border: solid 1px #aaa;
 	cursor: pointer;
 	display: inline-block;
@@ -330,7 +329,6 @@ img.WikiaPhotoGalleryProgress {
 .WikiaPhotoGalleryEditorPage .WikiaPhotoGalleryColorPickerPopUp {
 	background-color: #fff;
 	border: solid 1px #cacaca;
-	-moz-box-shadow: 0 0 10px 1px #aaa;
 	-webkit-box-shadow: 0 0 10px 1px #aaa;
 	display: none;
 	position: absolute;


### PR DESCRIPTION
Remove `-moz-border-radius` and `-moz-box-shadow` (not required since Firefox 4)

Pinging @lizlux and @kvas-damian 

Follow-up of #5066
