### PR TITLE
PLATFORM-317: Phalanx should ignore Wikia's border-http-s4/5 IPs

### DIFF
--- a/extensions/wikia/PhalanxII/Phalanx_setup.php
+++ b/extensions/wikia/PhalanxII/Phalanx_setup.php
@@ -85,6 +85,8 @@ $phalanxhooks = array(
 			'EditPhalanxBlock'                => 'onEditPhalanxBlock',
 			'DeletePhalanxBlock'              => 'onDeletePhalanxBlock',
 			'AfterFormatPermissionsErrorMessage' => 'onAfterFormatPermissionsErrorMessage',
+			// temp logging for PLATFORM-317
+			'GetBlockedStatus'                => 'onGetBlockedStatus',
 		)
 );
 


### PR DESCRIPTION
@michalroszka / @Wikia/platform-team 

Log cases when we're missing Fastly request header with "original" client IP.

```
curl "http://poznan.macbre.wikia-dev.com/wiki/Gzik"
```

vs

```
curl "http://poznan.macbre.wikia-dev.com/wiki/Gzik" -x dev-macbre:80
```

which will log the following:

``` php
Array
(
    [@timestamp] => 2014-10-20T14:13:41.421860+00:00
    [@message] => Phalanx user IP incorrect
    [@fields] => Array
        (
            [db_name] => plpoznan
            [city_id] => 5915
            [url] => http://poznan.macbre.wikia-dev.com/wiki/Gzik
            [ip] => 10.14.30.110
            [http_method] => GET
            [server] => poznan.macbre.wikia-dev.com
            [request_id] => mw544518951ed443.44344121
        )

    [@context] => Array
        (
            [ip_from_fastly] => false
            [ip_from_user] => 10.14.30.110
            [ip_from_request] => 10.14.30.110
        )
)
```
