### PR TITLE
MWEB-1059 Remove Wikia Maps branding from single map view

### DIFF
--- a/extensions/wikia/WikiaMaps/js/WikiaMapsCreateMapTileSet.js
+++ b/extensions/wikia/WikiaMaps/js/WikiaMapsCreateMapTileSet.js
@@ -135,7 +135,7 @@ define(
 		 */
 		function chooseTileSet() {
 			$.nirvana.getJson(
-				'WikiaMaps',
+				'WikiaMapsSpecial',
 				'getRealMapImageUrl',
 				function (data) {
 					templateData.mapType[0].image = data.url;

--- a/extensions/wikia/WikiaMaps/models/WikiaMaps.class.php
+++ b/extensions/wikia/WikiaMaps/models/WikiaMaps.class.php
@@ -230,7 +230,7 @@ class WikiaMaps extends WikiaObject {
 		$params = [];
 		$params[ 'uselang' ] = $this->wg->Lang->getCode();
 
-		if( $this->shouldHideAttribution( $mapCityId ) ) {
+		if ( $this->shouldHideAttribution( $mapCityId ) ) {
 			$params[ 'hideAttr' ] = '1';
 		}
 


### PR DESCRIPTION
After implementing `_escaped_fragment_` functionality we've introduced a bug with displaying Wikia Maps branding on wikia.com pages. The correct behaviour is to display them outside Wikia when somebody embeds maps on her page but not to display them on Wikia pages.

Changes below fixes it and also we're porting a fix from last week which was merged to release branch but not back ported to dev.
