### PR TITLE
Vid 1996 reduce duplicate DOM selectors based on Yellow Lab data

### DIFF
--- a/extensions/wikia/ArticleComments/js/ArticleComments.js
+++ b/extensions/wikia/ArticleComments/js/ArticleComments.js
@@ -32,7 +32,7 @@
 				$fbCommentMessage = $('#fbCommentMessage'),
 				newComment;
 
-			// jQuery object could have been cashed before init method
+			// jQuery object could have been cached before init method
 			if (!ArticleComments.$wrapper) {
 				ArticleComments.$wrapper = $(ArticleComments.wrapperSelector);
 			}

--- a/extensions/wikia/ArticleComments/js/ArticleComments.js
+++ b/extensions/wikia/ArticleComments/js/ArticleComments.js
@@ -32,6 +32,7 @@
 				$fbCommentMessage = $('#fbCommentMessage'),
 				newComment;
 
+			// cache jQuery selector
 			this.$commentsList = $('#article-comments-ul');
 
 			if (ArticleComments.miniEditorEnabled) {
@@ -51,9 +52,9 @@
 			} else {
 				$articleComments.on('click', '.article-comm-edit', ArticleComments.actionProxy(ArticleComments.edit));
 				$articleComments.on('click', '.article-comm-reply', ArticleComments.actionProxy(ArticleComments.reply));
-				$('#article-comm-submit').bind('click', {
-						source: '#article-comm'
-					},
+				$('#article-comm-submit').on(
+					'click',
+					{ source: '#article-comm' },
 					ArticleComments.actionProxy(ArticleComments.postComment)
 				);
 			}

--- a/extensions/wikia/ArticleComments/js/ArticleComments.js
+++ b/extensions/wikia/ArticleComments/js/ArticleComments.js
@@ -21,6 +21,7 @@
 		miniEditorEnabled: typeof window.wgEnableMiniEditorExt !== 'undefined' && skin === 'oasis',
 		loadOnDemand: typeof window.wgArticleCommentsLoadOnDemand !== 'undefined',
 		initCompleted: false,
+		wrapperSelector: '#WikiaArticleComments',
 		bucky: window.Bucky('ArticleComments'),
 
 		init: function () {
@@ -31,9 +32,14 @@
 				$fbCommentMessage = $('#fbCommentMessage'),
 				newComment;
 
+			// jQuery object could have been cashed before init method
+			if (!ArticleComments.$wrapper) {
+				ArticleComments.$wrapper = $(ArticleComments.wrapperSelector);
+			}
+
 			// cache jQuery selector
-			this.$commentsList = $('#article-comments-ul');
-			this.$actionButtons = this.$wrapper.find('.actionButton');
+			ArticleComments.$commentsList = $('#article-comments-ul');
+			ArticleComments.$actionButtons = ArticleComments.$wrapper.find('.actionButton');
 
 			if (ArticleComments.miniEditorEnabled) {
 				newComment = $('#article-comm');
@@ -616,7 +622,7 @@
 			var content, hash, permalink, styleAssets, belowTheFold, loadAssets;
 
 			// Cache jQuery selector after DOM ready
-			ArticleComments.$wrapper = $('#WikiaArticleComments');
+			ArticleComments.$wrapper = $(ArticleComments.wrapperSelector);
 
 			// NO article comment on this page lets just skip
 			if (!ArticleComments.$wrapper.length) {

--- a/extensions/wikia/ArticleComments/js/ArticleComments.js
+++ b/extensions/wikia/ArticleComments/js/ArticleComments.js
@@ -1,681 +1,693 @@
-/* global wgAfterContentAndJS, wgArticleId, wgPageName, wgScript, wgUserName, MiniEditor, skin */
+/* global wgAfterContentAndJS, wgArticleId, wgPageName, wgScript, MiniEditor, skin */
 
 (function (window, $) {
 	'use strict';
 
-// This file is included on every page.
-// If we aren't on an article page, halt execution here.
-// TODO: revisit this at some point when we have dependency loading.
-if (!window.wgIsArticle) {
-	return;
-}
+	// This file is included on every page.
+	// If we aren't on an article page, halt execution here.
+	// TODO: revisit this at some point when we have dependency loading.
+	if (!window.wgIsArticle) {
+		return;
+	}
 
-var $window = $(window),
+	var $window = $(window),
+		ArticleComments;
+
 	ArticleComments = {
-	animations: {}, // Used by MiniEditor
-	processing: false,
-	mostRecentCount: 0,
-	messagesLoaded: false,
-	miniEditorEnabled: typeof window.wgEnableMiniEditorExt !== 'undefined' && skin === 'oasis',
-	loadOnDemand: typeof window.wgArticleCommentsLoadOnDemand !== 'undefined',
-	initCompleted: false,
-	actionButtons: $('#WikiaArticleComments').find('.actionButton'),
-	bucky: window.Bucky('ArticleComments'),
+		animations: {}, // Used by MiniEditor
+		processing: false,
+		mostRecentCount: 0,
+		messagesLoaded: false,
+		miniEditorEnabled: typeof window.wgEnableMiniEditorExt !== 'undefined' && skin === 'oasis',
+		loadOnDemand: typeof window.wgArticleCommentsLoadOnDemand !== 'undefined',
+		initCompleted: false,
+		actionButtons: $('#WikiaArticleComments').find('.actionButton'),
+		bucky: window.Bucky('ArticleComments'),
 
-	init: function () {
-		ArticleComments.bucky.timer.start('init');
+		init: function () {
+			ArticleComments.bucky.timer.start('init');
 
-		var $articleComments = $('#article-comments'),
-			$articleCommFbMonit = $('#article-comm-fbMonit'),
-			$fbCommentMessage = $('#fbCommentMessage'),
-			newComment;
+			var $articleComments = $('#article-comments'),
+				$articleCommFbMonit = $('#article-comm-fbMonit'),
+				$fbCommentMessage = $('#fbCommentMessage'),
+				newComment;
 
-		if (ArticleComments.miniEditorEnabled) {
-			newComment = $('#article-comm');
+			this.$commentsList = $('#article-comments-ul');
 
-			newComment.bind('focus', function () {
-				ArticleComments.editorInit(this);
+			if (ArticleComments.miniEditorEnabled) {
+				newComment = $('#article-comm');
+
+				newComment.bind('focus', function () {
+					ArticleComments.editorInit(this);
+				});
+
+				if (newComment.is(':focus')) {
+					ArticleComments.editorInit(newComment);
+				}
+			}
+
+			if (window.wgDisableAnonymousEditing && !window.wgUserName) {
+				$('.article-comm-reply').hide();
+			} else {
+				$articleComments.on('click', '.article-comm-edit', ArticleComments.actionProxy(ArticleComments.edit));
+				$articleComments.on('click', '.article-comm-reply', ArticleComments.actionProxy(ArticleComments.reply));
+				$('#article-comm-submit').bind('click', {
+						source: '#article-comm'
+					},
+					ArticleComments.actionProxy(ArticleComments.postComment)
+				);
+			}
+
+			$articleCommFbMonit.mouseenter(function () {
+				$fbCommentMessage.fadeIn('slow');
 			});
 
-			if (newComment.is(':focus')) {
-				ArticleComments.editorInit(newComment);
-			}
-		}
+			$articleCommFbMonit.mouseleave(function () {
+				$fbCommentMessage.fadeOut('slow');
+			});
 
-		if (window.wgDisableAnonymousEditing && !window.wgUserName){
-			$('.article-comm-reply').hide();
-		} else {
-			$articleComments.on('click', '.article-comm-edit', ArticleComments.actionProxy(ArticleComments.edit));
-			$articleComments.on('click', '.article-comm-reply', ArticleComments.actionProxy(ArticleComments.reply));
-			$('#article-comm-submit').bind('click',
-				{ source: '#article-comm' },
-				ArticleComments.actionProxy(ArticleComments.postComment)
-			);
-		}
+			ArticleComments.addHover();
+			ArticleComments.initCompleted = true;
 
-		$articleCommFbMonit.mouseenter(function () {
-			$fbCommentMessage.fadeIn('slow');
-		});
+			ArticleComments.bucky.timer.stop('init');
+		},
 
-		$articleCommFbMonit.mouseleave(function () {
-			$fbCommentMessage.fadeOut('slow');
-		});
+		actionProxy: function (callback) {
+			return function (e) {
+				e.preventDefault();
 
-		ArticleComments.addHover();
-		ArticleComments.showEditLink();
-		ArticleComments.initCompleted = true;
+				// Prevent the action if MiniEditor is enabled and loading
+				if (ArticleComments.miniEditorEnabled && MiniEditor.editorIsLoading) {
+					$().log('Event cancelled because editor is loading: ', e);
+					return true;
+				}
 
-		ArticleComments.bucky.timer.stop('init');
-	},
+				callback.apply(this, arguments);
+			};
+		},
 
-	actionProxy: function (callback) {
-		return function (e) {
+		edit: function (e) {
 			e.preventDefault();
 
-			// Prevent the action if MiniEditor is enabled and loading
-			if (ArticleComments.miniEditorEnabled && MiniEditor.editorIsLoading) {
-				$().log('Event cancelled because editor is loading: ', e);
-				return true;
+			if (ArticleComments.processing) {
+				return;
 			}
 
-			callback.apply(this, arguments);
-		};
-	},
+			// If MiniEditor is enabled, we need to determine the correct content format before making the request
+			if (ArticleComments.miniEditorEnabled && !MiniEditor.assetsLoaded) {
+				MiniEditor.loadAssets(makeRequest);
 
-	showEditLink: function () {
-		//hack to display 'edit' link when slave lag caused it to be hidden
-		if (wgUserName) {
-			$('#article-comments-ul details').find('a:contains("' + wgUserName + '")')
-				.closest('details').find('.edit-link').show();
-		}
-	},
+			} else {
+				makeRequest();
+			}
 
-	edit: function (e) {
-		e.preventDefault();
+			function makeRequest() {
+				ArticleComments.bucky.timer.start('edit.makeRequest');
+				var commentId = e.target.id.replace(/^comment/, ''),
+					$textfield = $('#article-comm-textfield-' + commentId);
 
-		if (ArticleComments.processing) {
-			return;
-		}
+				$.getJSON(wgScript, {
+					action: 'ajax',
+					article: wgArticleId,
+					convertToFormat: ArticleComments.getLoadConversionFormat($textfield),
+					id: commentId,
+					method: 'axEdit',
+					rs: 'ArticleCommentsAjax'
 
-		// If MiniEditor is enabled, we need to determine the correct content format before making the request
-		if (ArticleComments.miniEditorEnabled && !MiniEditor.assetsLoaded) {
-			MiniEditor.loadAssets(makeRequest);
+				}, function (json) {
+					if (!json.error) {
+						var $buttons = $(e.target).closest('.buttons'),
+							divFormSelector = '#article-comm-div-form-' + json.id,
+							textfieldSelector = '#article-comm-textfield-' + json.id,
+							$commentTextDiv = $('#comm-text-' + json.id).hide(),
+							$editDivForm = $(divFormSelector),
+							$blockquote = $commentTextDiv.parent(),
+							$editTemplate = $(json.text).hide(),
+							content = $editTemplate.find(textfieldSelector).val(),
+							$textfield;
 
-		} else {
-			makeRequest();
-		}
+						// editForm has to be added to the DOM the first time we call this function
+						if (!$editDivForm.length) {
+							$blockquote.append($editTemplate.attr('id', divFormSelector.substr(1)));
+							$editDivForm = $(divFormSelector);
+						}
 
-		function makeRequest() {
-			ArticleComments.bucky.timer.start('edit.makeRequest');
-			var commentId = e.target.id.replace(/^comment/, ''),
-				textfield = $('#article-comm-textfield-' + commentId);
+						$textfield = $(textfieldSelector);
+						if (ArticleComments.miniEditorEnabled) {
+							ArticleComments.editorInit($textfield, content, json.edgeCases);
+
+						} else {
+							$textfield.val(content);
+						}
+
+						$editDivForm.show();
+						$buttons.hide();
+
+						$('#article-comm-submit-' + json.id).bind('click', {
+							id: json.id,
+							emptyMsg: json.emptyMsg
+						}, ArticleComments.actionProxy(ArticleComments.saveEdit));
+
+						$('#article-comm-edit-cancel-' + json.id).bind('click', {
+							id: json.id,
+							target: e.target,
+							text: json.text
+						}, ArticleComments.actionProxy(ArticleComments.cancelEdit));
+					}
+
+					ArticleComments.processing = false;
+					ArticleComments.bucky.timer.stop('edit.makeRequest');
+				});
+			}
+
+			ArticleComments.processing = true;
+		},
+
+		cancelEdit: function (e) {
+			var commentId = e.data.id;
+
+			e.preventDefault();
+
+			if (ArticleComments.miniEditorEnabled) {
+				$('#article-comm-textfield-' + commentId).data('wikiaEditor').fire('editorDeactivated');
+			}
+
+			$('#article-comm-div-form-' + commentId).hide();
+			$(e.data.target).closest('.buttons').show();
+			$('#comm-text-' + commentId).show();
+		},
+
+		saveEdit: function (e) {
+			var commentId, commentFormDiv, $throbber, $submitButton, $textfield, content;
+
+			ArticleComments.bucky.timer.start('saveEdit');
+			e.preventDefault();
+
+			if (ArticleComments.processing) {
+				return;
+			}
+
+			commentId = e.data.id;
+			commentFormDiv = $('#article-comm-form-' + commentId);
+
+			if (commentFormDiv.length) {
+				$throbber = $(e.target).siblings('.throbber');
+				$submitButton = $('#article-comm-submit-' + commentId);
+				$textfield = $('#article-comm-textfield-' + commentId);
+				content = ArticleComments.getContent($textfield);
+
+				$submitButton.parent().find('.info').remove();
+
+				if ($.trim(content) === '') {
+					$submitButton.after($('<span>').addClass('info').html(e.data.emptyMsg));
+					return;
+				}
+
+				$('#article-comm-info').html('');
+				$throbber.css('visibility', 'visible');
+				$textfield.attr('readonly', 'readonly');
+
+				$.postJSON(wgScript, {
+					action: 'ajax',
+					article: wgArticleId,
+					convertToFormat: ArticleComments.getSaveConversionFormat($textfield),
+					id: commentId,
+					method: 'axSave',
+					rs: 'ArticleCommentsAjax',
+					title: wgPageName,
+					wpArticleComment: content
+
+				}, function (json) {
+					$throbber.css('visibility', 'hidden');
+
+					if (!json.error) {
+						if (json.commentId && json.commentId !== 0) {
+							var comment = $('#comm-' + json.commentId),
+								saveTemplate = $(json.text);
+
+							$('#article-comm-div-form-' + json.commentId).hide();
+
+							if (ArticleComments.miniEditorEnabled) {
+								$textfield.data('wikiaEditor').fire('editorReset');
+							}
+
+							// Update DOM with information from saveTemplate
+							comment.find('.article-comm-text')
+								.html(saveTemplate.find('.article-comm-text').html()).show();
+							comment.find('.edited-by').html(saveTemplate.find('.edited-by').html());
+						}
+					} else {
+						$('#article-comm-info').html(json.msg);
+					}
+
+					$textfield.removeAttr('readonly');
+
+					ArticleComments.processing = false;
+					ArticleComments.bucky.timer.stop('saveEdit');
+				});
+
+				ArticleComments.processing = true;
+			}
+		},
+
+		reply: function (e) {
+			ArticleComments.bucky.timer.start('reply');
+			e.preventDefault();
+
+			if (ArticleComments.processing) {
+				return;
+			}
 
 			$.getJSON(wgScript, {
 				action: 'ajax',
 				article: wgArticleId,
-				convertToFormat: ArticleComments.getLoadConversionFormat(textfield),
-				id: commentId,
-				method: 'axEdit',
-				rs: 'ArticleCommentsAjax'
+				id: $(this).closest('li').attr('id').replace(/^comm-/, ''),
+				method: 'axReply',
+				rs: 'ArticleCommentsAjax',
+				title: wgPageName
 
 			}, function (json) {
-				if (!json.error) {
-					var buttons = $(e.target).closest('.buttons'),
-						divFormSelector = '#article-comm-div-form-' + json.id,
-						textfieldSelector = '#article-comm-textfield-' + json.id,
-						commentTextDiv = $('#comm-text-' + json.id).hide(),
-						editDivForm = $(divFormSelector),
-						blockquote = commentTextDiv.parent(),
-						editTemplate = $(json.text).hide(),
-						content = editTemplate.find(textfieldSelector).val();
+				var $blockquote = $('#comm-text-' + json.id).parent(),
+					$editbox = $blockquote.find('.article-comm-edit-box'),
+					$buttons = $blockquote.find('.buttons').hide(),
+					$textfield;
 
-					// editForm has to be added to the DOM the first time we call this function
-					if (!editDivForm.length) {
-						blockquote.append(editTemplate.attr('id', divFormSelector.substr(1)));
-						editDivForm = $(divFormSelector);
-					}
+				$blockquote.find('.info').remove();
 
-					var textfield = $(textfieldSelector);
-					if (ArticleComments.miniEditorEnabled) {
-						ArticleComments.editorInit(textfield, content, json.edgeCases);
+				if ($editbox.length) {
+					$editbox.show();
 
-					} else {
-						textfield.val(content);
-					}
+				} else if (!json.error) {
+					$blockquote.append(json.html);
 
-					editDivForm.show();
-					buttons.hide();
+					$('#article-comm-reply-submit-' + json.id).bind('click', {
+						source: '#article-comm-reply-textfield-' + json.id,
+						parentId: json.id
+					}, ArticleComments.actionProxy(ArticleComments.postComment));
 
-					$('#article-comm-submit-' + json.id).bind('click', {
-						id: json.id,
-						emptyMsg: json.emptyMsg
-					}, ArticleComments.actionProxy(ArticleComments.saveEdit));
+					// Login required
+				} else if (json.error === 2) {
+					$blockquote.find('.tools').after($('<span>').addClass('info').html(json.msg));
 
-					$('#article-comm-edit-cancel-' + json.id).bind('click', {
-						id: json.id,
-						target: e.target,
-						text: json.text
-					}, ArticleComments.actionProxy(ArticleComments.cancelEdit));
+					// General error. TODO: add caption
+				} else {
+					require(['wikia.ui.factory'], function (uiFactory) {
+						uiFactory.init(['modal']).then(function (uiModal) {
+							var moduleConfig = {
+								vars: {
+									id: 'general_error',
+									size: 'small',
+									content: json.msg
+								}
+							};
+							uiModal.createComponent(moduleConfig, function (errorModal) {
+								errorModal.show();
+							});
+						});
+					});
+				}
+
+				$textfield = $('#article-comm-reply-textfield-' + json.id);
+				if (ArticleComments.miniEditorEnabled) {
+					ArticleComments.editorInit($textfield, {
+						editorActivated: function () {
+							$blockquote.find('.article-comm-edit-box').show();
+						},
+						editorDeactivated: function (event, wikiaEditor) {
+							if (!wikiaEditor.getContent()) {
+								$blockquote.find('.article-comm-edit-box').hide();
+								$buttons.show();
+							}
+						}
+					});
+
+				} else {
+					$textfield.focus();
 				}
 
 				ArticleComments.processing = false;
-				ArticleComments.bucky.timer.stop('edit.makeRequest');
+				ArticleComments.bucky.timer.stop('reply');
 			});
-		}
 
-		ArticleComments.processing = true;
-	},
+			ArticleComments.processing = true;
+		},
 
-	cancelEdit: function (e) {
-		var commentId = e.data.id;
+		postComment: function (e) {
+			var $source, $target, $throbber, content, showall, data;
+			e.preventDefault();
 
-		e.preventDefault();
-
-		if (ArticleComments.miniEditorEnabled) {
-			$('#article-comm-textfield-' + commentId).data('wikiaEditor').fire('editorDeactivated');
-		}
-
-		$('#article-comm-div-form-' + commentId).hide();
-		$(e.data.target).closest('.buttons').show();
-		$('#comm-text-' + commentId).show();
-	},
-
-	saveEdit: function (e) {
-		ArticleComments.bucky.timer.start('saveEdit');
-		e.preventDefault();
-
-		if (ArticleComments.processing) { return; }
-
-		var commentId = e.data.id,
-			commentFormDiv = $('#article-comm-form-' + commentId);
-
-		if (commentFormDiv.length) {
-			var throbber =  $(e.target).siblings('.throbber'),
-				submitButton = $('#article-comm-submit-' + commentId),
-				textfield = $('#article-comm-textfield-' + commentId),
-				content = ArticleComments.getContent(textfield);
-
-			submitButton.parent().find('.info').remove();
-
-			if ($.trim(content) === '') {
-				submitButton.after($('<span>').addClass('info').html(e.data.emptyMsg));
+			if (ArticleComments.processing) {
 				return;
 			}
 
-			$('#article-comm-info').html('');
-			throbber.css('visibility', 'visible');
-			textfield.attr('readonly', 'readonly');
+			$source = $(e.data.source);
+			content = ArticleComments.getContent($source);
 
-			$.postJSON(wgScript, {
+			if ($.trim(content) === '') {
+				return;
+			}
+
+			$target = $(e.target);
+			$throbber = $target.siblings('.throbber');
+			showall = $.getUrlVar('showall');
+			$throbber.css('visibility', 'visible');
+			$source.attr('readonly', 'readonly');
+			$target.attr('disabled', true);
+
+			data = {
 				action: 'ajax',
 				article: wgArticleId,
-				convertToFormat: ArticleComments.getSaveConversionFormat(textfield),
-				id: commentId,
-				method: 'axSave',
+				convertToFormat: ArticleComments.getSaveConversionFormat($source),
+				method: 'axPost',
 				rs: 'ArticleCommentsAjax',
 				title: wgPageName,
 				wpArticleComment: content
+			};
 
-			}, function (json) {
-				throbber.css('visibility', 'hidden');
+			if (e.data.parentId) {
+				data.parentId = e.data.parentId;
+				data.page = $('.article-comments-pagination-link-active').eq(0).attr('page');
+			}
+
+			if (showall) {
+				data.showall = 1;
+			}
+
+			function requestCallback(json) {
+				var $parent, $subcomments, parentId, nodes;
+
+				ArticleComments.bucky.timer.start('postComment.requestCallback');
+				$throbber.css('visibility', 'hidden');
+
+				if (ArticleComments.miniEditorEnabled) {
+					$source.data('wikiaEditor').fire('editorReset');
+				} else {
+					$source.val('');
+				}
 
 				if (!json.error) {
-					if (json.commentId && json.commentId !== 0) {
-						var comment = $('#comm-' + json.commentId),
-							saveTemplate = $(json.text);
+					parentId = json.parentId;
+					nodes = $(json.text);
 
-						$('#article-comm-div-form-' + json.commentId).hide();
+					if (parentId) {
+						//second level: reply
+						$parent = $('#comm-' + parentId);
+						$subcomments = $parent.next();
 
-						if (ArticleComments.miniEditorEnabled) {
-							textfield.data('wikiaEditor').fire('editorReset');
+						if (!$subcomments.hasClass('sub-comments')) {
+							$parent.after($subcomments = $('<ul class="sub-comments"></ul>'));
 						}
 
-						// Update DOM with information from saveTemplate
-						comment.find('.article-comm-text').html(saveTemplate.find('.article-comm-text').html()).show();
-						comment.find('.edited-by').html(saveTemplate.find('.edited-by').html());
+						$subcomments.append(nodes);
+
+						//remove input field and show buttons
+						$parent.find('.article-comm-edit-box').hide();
+						$parent.find('.buttons').show();
+					} else {
+						//first level: comment
+						nodes.prependTo(ArticleComments.$commentsList);
 					}
+
+					//update counter
+					$('#article-comments-counter-header').html($.msg('oasis-comments-header', json.counter));
+
+					if (window.skin === 'oasis') {
+						$('#WikiaPageHeader, #WikiaUserPagesHeader').find('.commentsbubble').html(json.counter);
+
+						if (!parentId) {
+							ArticleComments.mostRecentCount = ArticleComments.mostRecentCount ?
+								ArticleComments.mostRecentCount + 1 :
+								ArticleComments.$commentsList.children('li').length;
+
+							$('#article-comments-counter-recent').html(
+								$.msg('oasis-comments-showing-most-recent', ArticleComments.mostRecentCount)
+							);
+						}
+					}
+
+					//readd events
+					ArticleComments.addHover();
+					//clear error box
+					$('#article-comm-info').html('');
 				} else {
+					//fill error box
 					$('#article-comm-info').html(json.msg);
 				}
 
-				textfield.removeAttr('readonly');
+				$source.removeAttr('readonly');
+				$target.removeAttr('disabled');
 
 				ArticleComments.processing = false;
-				ArticleComments.bucky.timer.stop('saveEdit');
-			});
+				ArticleComments.bucky.timer.stop('postComment.requestCallback');
+			}
 
-			ArticleComments.processing = true;
-		}
-	},
+			function makeRequest() {
+				$.postJSON(wgScript, data, requestCallback);
 
-	reply: function (e) {
-		ArticleComments.bucky.timer.start('reply');
-		e.preventDefault();
+				ArticleComments.processing = true;
+			}
 
-		if (ArticleComments.processing) { return; }
-
-		$.getJSON(wgScript, {
-			action: 'ajax',
-			article: wgArticleId,
-			id: $(this).closest('li').attr('id').replace(/^comm-/, ''),
-			method: 'axReply',
-			rs: 'ArticleCommentsAjax',
-			title: wgPageName
-
-		}, function (json) {
-			var blockquote = $('#comm-text-' + json.id).parent(),
-				editbox = blockquote.find('.article-comm-edit-box'),
-				buttons = blockquote.find('.buttons').hide();
-
-			blockquote.find('.info').remove();
-
-			if (editbox.length) {
-				editbox.show();
-
-			} else if (!json.error) {
-				blockquote.append(json.html);
-
-				$('#article-comm-reply-submit-' + json.id).bind('click', {
-					source: '#article-comm-reply-textfield-' + json.id,
-					parentId: json.id
-				}, ArticleComments.actionProxy(ArticleComments.postComment));
-
-			// Login required
-			} else if (json.error === 2) {
-				blockquote.find('.tools').after($('<span>').addClass('info').html(json.msg));
-
-			// General error. TODO: add caption
-			} else {
-				require(['wikia.ui.factory'], function (uiFactory) {
-					uiFactory.init(['modal']).then(function (uiModal) {
-						var moduleConfig = {
-							vars: {
-								id: 'general_error',
-								size: 'small',
-								content: json.msg
-							}
-						};
-						uiModal.createComponent(moduleConfig, function (errorModal) {
-							errorModal.show();
-						});
-					});
+			if (!ArticleComments.messagesLoaded) {
+				$.getMessages('ArticleCommentsCounter', function () {
+					ArticleComments.messagesLoaded = true;
+					makeRequest();
 				});
-			}
-
-			var textfield = $('#article-comm-reply-textfield-' + json.id);
-			if (ArticleComments.miniEditorEnabled) {
-				ArticleComments.editorInit(textfield, {
-					editorActivated: function () {
-						blockquote.find('.article-comm-edit-box').show();
-					},
-					editorDeactivated: function (event, wikiaEditor) {
-						if (!wikiaEditor.getContent()) {
-							blockquote.find('.article-comm-edit-box').hide();
-							buttons.show();
-						}
-					}
-				});
-
 			} else {
-				textfield.focus();
-			}
-
-			ArticleComments.processing = false;
-			ArticleComments.bucky.timer.stop('reply');
-		});
-
-		ArticleComments.processing = true;
-	},
-
-	postComment: function (e) {
-		e.preventDefault();
-
-		if (ArticleComments.processing) { return; }
-
-		var source = $(e.data.source),
-			target = $(e.target),
-			throbber = target.siblings('.throbber'),
-			content = ArticleComments.getContent(source),
-			showall = $.getUrlVar('showall');
-
-		if ($.trim(content) === '') { return; }
-
-		throbber.css('visibility', 'visible');
-		source.attr('readonly', 'readonly');
-		target.attr('disabled', true);
-
-		var data = {
-			action: 'ajax',
-			article: wgArticleId,
-			convertToFormat: ArticleComments.getSaveConversionFormat(source),
-			method: 'axPost',
-			rs: 'ArticleCommentsAjax',
-			title: wgPageName,
-			wpArticleComment: content
-		};
-
-		if (e.data.parentId) {
-			data.parentId = e.data.parentId;
-			data.page = $('.article-comments-pagination-link-active').eq(0).attr('page');
-		}
-
-		if (showall) {
-			data.showall = 1;
-		}
-
-		function requestCallback(json) {
-			ArticleComments.bucky.timer.start('postComment.requestCallback');
-			throbber.css('visibility', 'hidden');
-
-			if (ArticleComments.miniEditorEnabled) {
-				source.data('wikiaEditor').fire('editorReset');
-			} else {
-				source.val('');
-			}
-
-			if (!json.error) {
-				var parent,
-					subcomments,
-					parentId = json.parentId,
-					nodes = $(json.text);
-
-				if (parentId) {
-					//second level: reply
-					parent = $('#comm-' + parentId);
-					subcomments = parent.next();
-
-					if (!subcomments.hasClass('sub-comments')){
-						parent.after(subcomments = $('<ul class="sub-comments"></ul>'));
-					}
-
-					subcomments.append(nodes);
-
-					//remove input field and show buttons
-					parent.find('.article-comm-edit-box').hide();
-					parent.find('.buttons').show();
-				} else {
-					//first level: comment
-					nodes.prependTo('#article-comments-ul');
-				}
-
-				//update counter
-				$('#article-comments-counter-header').html($.msg('oasis-comments-header', json.counter));
-
-				if (window.skin === 'oasis') {
-					$('#WikiaPageHeader, #WikiaUserPagesHeader').find('.commentsbubble').html(json.counter);
-
-					if (!parentId) {
-						ArticleComments.mostRecentCount = ArticleComments.mostRecentCount ?
-							ArticleComments.mostRecentCount + 1 :
-							$('#article-comments-ul > li').length;
-
-						$('#article-comments-counter-recent').html(
-							$.msg('oasis-comments-showing-most-recent', ArticleComments.mostRecentCount)
-						);
-					}
-				}
-
-				//readd events
-				ArticleComments.addHover();
-				//force to show 'edit' links for owners
-				ArticleComments.showEditLink();
-				//clear error box
-				$('#article-comm-info').html('');
-			} else {
-				//fill error box
-				$('#article-comm-info').html(json.msg);
-			}
-
-			source.removeAttr('readonly');
-			$(e.target).removeAttr('disabled');
-
-			ArticleComments.processing = false;
-			ArticleComments.bucky.timer.stop('postComment.requestCallback');
-		}
-
-		function makeRequest() {
-			$.postJSON(wgScript, data, requestCallback);
-
-			ArticleComments.processing = true;
-		}
-
-		if (!ArticleComments.messagesLoaded) {
-			$.getMessages('ArticleCommentsCounter', function () {
-				ArticleComments.messagesLoaded = true;
 				makeRequest();
-			});
-		} else {
-			makeRequest();
-		}
-	},
+			}
+		},
 
-	setPage: function (e) {
-		ArticleComments.bucky.timer.start('setPage');
-		e.preventDefault();
+		setPage: function (e) {
+			ArticleComments.bucky.timer.start('setPage');
 
-		var page = parseInt($(this).attr('page')),
-			$commentsList = $('#article-comments-ul').addClass('loading');
+			var page = parseInt($(this).attr('page'));
 
-		$.getJSON(wgScript + '?action=ajax&rs=ArticleCommentsAjax&method=axGetComments&article=' + wgArticleId, {
-			page: page,
-			order: $('#article-comm-order').attr('value')
+			e.preventDefault();
 
-		}, function (json) {
-			$commentsList.removeClass('loading');
+			ArticleComments.$commentsList.addClass('loading');
 
-			if (!json.error) {
-				$commentsList.html(json.text);
-				var $articleCommentsPagination = $('.article-comments-pagination');
-				if ($articleCommentsPagination.exists()) {
-					$articleCommentsPagination.html(json.pagination);
+			$.getJSON(wgScript + '?action=ajax&rs=ArticleCommentsAjax&method=axGetComments&article=' + wgArticleId, {
+				page: page,
+				order: $('#article-comm-order').attr('value')
+
+			}, function (json) {
+				ArticleComments.$commentsList.removeClass('loading');
+
+				if (!json.error) {
+					ArticleComments.$commentsList.html(json.text);
+					var $articleCommentsPagination = $('.article-comments-pagination');
+					if ($articleCommentsPagination.exists()) {
+						$articleCommentsPagination.html(json.pagination);
+					}
+
+					ArticleComments.addHover();
 				}
 
-				ArticleComments.addHover();
-			}
-
-			ArticleComments.processing = false;
-			ArticleComments.bucky.timer.stop('setPage');
-		});
-	},
-
-	addHover: function () {
-		var linkSelectors = [
-			'.article-comments-pagination-link-active',
-			'#article-comments-pagination-link-prev',
-			'#article-comments-pagination-link-next'
-		];
-
-		$('.article-comments-pagination-link')
-			.bind('click', ArticleComments.setPage)
-			.not(linkSelectors.join(', '))
-			.hover(function () {
-				$(this).addClass('accent');
-
-			}, function () {
-				$(this).removeClass('accent');
+				ArticleComments.processing = false;
+				ArticleComments.bucky.timer.stop('setPage');
 			});
-	},
+		},
 
-	// Used to initialize MiniEditor
-	editorInit: function (element, events, content, edgeCases) {
-		ArticleComments.bucky.timer.start('editorInit');
-		var $element = $(element),
-			wikiaEditor = $element.data('wikiaEditor');
+		addHover: function () {
+			var linkSelectors = [
+				'.article-comments-pagination-link-active',
+				'#article-comments-pagination-link-prev',
+				'#article-comments-pagination-link-next'
+			];
 
-		// Allow ommission of 'events' parameter
-		if (typeof events === 'string') {
-			edgeCases = content;
-			content = events;
-			events = {};
-		}
+			$('.article-comments-pagination-link')
+				.bind('click', ArticleComments.setPage)
+				.not(linkSelectors.join(', '))
+				.hover(function () {
+					$(this).addClass('accent');
 
-		// Check for edge cases
-		var hasEdgeCases = $.isArray(edgeCases) && edgeCases.length;
+				}, function () {
+					$(this).removeClass('accent');
+				});
+		},
 
-		function initEditor() {
-			events = events || {};
+		// Used to initialize MiniEditor
+		editorInit: function (element, events, content, edgeCases) {
+			ArticleComments.bucky.timer.start('editorInit');
+			var $element = $(element),
+				wikiaEditor = $element.data('wikiaEditor'),
+				editorActivated,
+				hasEdgeCases;
 
-			// Wrap editorActivated with our own function
-			var editorActivated = events.editorActivated;
-			events.editorActivated = function (/* event, wikiaEditor */) {
-				ArticleComments.actionButtons.removeClass('disabled').removeAttr('disabled');
-
-				if ($.isFunction(editorActivated)) {
-					editorActivated.apply(this, arguments);
-				}
-			};
-
-			// Initialize the editor
-			$element.miniEditor({
-				config: {
-					animations: MiniEditor.Wall.Animations,
-					mode: hasEdgeCases ? 'source' : MiniEditor.config.mode
-				},
-				events: events
-			});
-		}
-
-		// Already exists
-		if (wikiaEditor) {
-			wikiaEditor.fire('editorActivated');
-
-			if (content !== undefined) {
-
-				// Force source mode if edge cases are found.
-				if (hasEdgeCases) {
-					wikiaEditor.ck.setMode('source');
-				}
-
-				wikiaEditor.setContent(content);
+			// Allow ommission of 'events' parameter
+			if (typeof events === 'string') {
+				edgeCases = content;
+				content = events;
+				events = {};
 			}
 
-		// Needs initializing
-		} else {
-			ArticleComments.actionButtons.addClass('disabled').attr('disabled', true);
+			// Check for edge cases
+			hasEdgeCases = $.isArray(edgeCases) && edgeCases.length;
 
-			// Set content on element before initializing to keep focus in editbox (BugId:24188).
-			if (content !== undefined) {
-				$element.val(content);
+			function initEditor() {
+				events = events || {};
+
+				// Wrap editorActivated with our own function
+				editorActivated = events.editorActivated;
+				events.editorActivated = function ( /* event, wikiaEditor */ ) {
+					ArticleComments.actionButtons.removeClass('disabled').removeAttr('disabled');
+
+					if ($.isFunction(editorActivated)) {
+						editorActivated.apply(this, arguments);
+					}
+				};
+
+				// Initialize the editor
+				$element.miniEditor({
+					config: {
+						animations: MiniEditor.Wall.Animations,
+						mode: hasEdgeCases ? 'source' : MiniEditor.config.mode
+					},
+					events: events
+				});
 			}
 
-			// Load assets first so we have the proper config.mode (BugId:25182)
-			if (!MiniEditor.assetsLoaded) {
-				MiniEditor.loading($element);
-				MiniEditor.loadAssets(initEditor);
+			// Already exists
+			if (wikiaEditor) {
+				wikiaEditor.fire('editorActivated');
 
+				if (content !== undefined) {
+
+					// Force source mode if edge cases are found.
+					if (hasEdgeCases) {
+						wikiaEditor.ck.setMode('source');
+					}
+
+					wikiaEditor.setContent(content);
+				}
+
+				// Needs initializing
 			} else {
-				initEditor();
+				ArticleComments.actionButtons.addClass('disabled').attr('disabled', true);
+
+				// Set content on element before initializing to keep focus in editbox (BugId:24188).
+				if (content !== undefined) {
+					$element.val(content);
+				}
+
+				// Load assets first so we have the proper config.mode (BugId:25182)
+				if (!MiniEditor.assetsLoaded) {
+					MiniEditor.loading($element);
+					MiniEditor.loadAssets(initEditor);
+
+				} else {
+					initEditor();
+				}
+			}
+			ArticleComments.bucky.timer.stop('editorInit');
+		},
+
+		getContent: function (element) {
+			return ArticleComments.miniEditorEnabled ? element.data('wikiaEditor').getContent() : element.val();
+		},
+
+		getLoadConversionFormat: function (element) {
+			return ArticleComments.miniEditorEnabled ? MiniEditor.getLoadConversionFormat(element) : '';
+		},
+
+		getSaveConversionFormat: function (element) {
+			return ArticleComments.miniEditorEnabled ? MiniEditor.getSaveConversionFormat(element) : '';
+		},
+
+		scrollToElement: function (element) {
+			var $element = $(element),
+				docViewTop = $window.scrollTop(),
+				docViewBottom = docViewTop + $window.height(),
+				elementTop = $element.offset().top;
+
+			$element.find('blockquote').addClass('current');
+
+			if (elementTop < docViewTop || elementTop > docViewBottom) {
+				$('html, body').animate({
+					scrollTop: elementTop
+				}, 1);
 			}
 		}
-		ArticleComments.bucky.timer.stop('editorInit');
-	},
+	};
 
-	getContent: function (element) {
-		return ArticleComments.miniEditorEnabled ? element.data('wikiaEditor').getContent() : element.val();
-	},
+	if (ArticleComments.loadOnDemand) {
+		$(function () {
+			var content, hash, permalink, styleAssets, $comments, belowTheFold, loadAssets;
 
-	getLoadConversionFormat: function (element) {
-		return ArticleComments.miniEditorEnabled ? MiniEditor.getLoadConversionFormat(element) : '';
-	},
+			$comments = $('#WikiaArticleComments');
 
-	getSaveConversionFormat: function (element) {
-		return ArticleComments.miniEditorEnabled ? MiniEditor.getSaveConversionFormat(element) : '';
-	},
+			// NO article comment on this page lets just skip
+			if (!$comments.length) {
+				return;
+			}
 
-	scrollToElement: function (element) {
-		var $element = $(element),
-			docViewTop = $window.scrollTop(),
-			docViewBottom = docViewTop + $window.height(),
-			elementTop = $element.offset().top;
-
-		$element.find('blockquote').addClass('current');
-
-		if (elementTop < docViewTop || elementTop > docViewBottom) {
-			$('html, body').animate({
-				scrollTop: elementTop
-			}, 1);
-		}
-	}
-};
-
-if (ArticleComments.loadOnDemand) {
-	$(function () {
-
-		// NO article comment on this page lets just skip
-		if (!$('#WikiaArticleComments').length) {
-			return;
-		}
-
-		var content,
-			hash = window.location.hash,
-			permalink = /^#comm-/.test(hash),
+			hash = window.location.hash;
+			permalink = /^#comm-/.test(hash);
 			// TODO: we should be able to load it this way
 			//styleAssets.push($.getAssetManagerGroupUrl(
 			// 'articlecomments' + (ArticleComments.miniEditorEnabled ? '_mini_editor' : '') + '_scss'));
-			styleAssets = [$.getSassCommonURL('skins/oasis/css/core/ArticleComments.scss')],
-			$comments = $('#WikiaArticleComments'),
+			styleAssets = [$.getSassCommonURL('skins/oasis/css/core/ArticleComments.scss')];
 			belowTheFold = function () {
 				return $comments.offset().top >= ($window.scrollTop() + $window.height());
 			};
 
-		if (ArticleComments.miniEditorEnabled) {
-			styleAssets.push($.getSassCommonURL('extensions/wikia/MiniEditor/css/MiniEditor.scss'));
-			styleAssets.push($.getSassCommonURL(
-				'extensions/wikia/MiniEditor/css/ArticleComments/ArticleComments.scss')
-			);
-		}
+			if (ArticleComments.miniEditorEnabled) {
+				styleAssets.push($.getSassCommonURL('extensions/wikia/MiniEditor/css/MiniEditor.scss'));
+				styleAssets.push($.getSassCommonURL(
+					'extensions/wikia/MiniEditor/css/ArticleComments/ArticleComments.scss'));
+			}
 
-		var loadAssets = function () {
-			ArticleComments.bucky.timer.start('loadAssets');
-			$.when(
-				$.getResources(styleAssets),
-				$.nirvana.sendRequest({
-					controller: 'ArticleCommentsController',
-					method: 'Content',
-					format: 'html',
-					type: 'GET',
-					data: {
-						articleId: window.wgArticleId,
-						page: $comments.data('page'),
-						skin: true
-					},
-					callback: function (response) {
-						content = response;
+			loadAssets = function () {
+				ArticleComments.bucky.timer.start('loadAssets');
+				$.when(
+					$.getResources(styleAssets),
+					$.nirvana.sendRequest({
+						controller: 'ArticleCommentsController',
+						method: 'Content',
+						format: 'html',
+						type: 'GET',
+						data: {
+							articleId: window.wgArticleId,
+							page: $comments.data('page'),
+							skin: true
+						},
+						callback: function (response) {
+							content = response;
+						}
+					})
+				).then(function () {
+					$comments.removeClass('loading').html(content);
+
+					ArticleComments.init();
+
+					if (permalink) {
+						ArticleComments.scrollToElement(hash);
 					}
-				})
-			).then(function () {
-				$comments.removeClass('loading').html(content);
+					ArticleComments.bucky.timer.stop('loadAssets');
+				});
+			};
 
-				ArticleComments.init();
+			// Load comments as they become visible (unless we are requesting a permalink comment)
+			if (!permalink && belowTheFold()) {
+				$window.on('scrollstop.ArticleCommentsLoadOnDemand', function () {
+					if (!belowTheFold()) {
+						$comments.addClass('loading');
+						$window.off('scrollstop.ArticleCommentsLoadOnDemand');
+						loadAssets();
+					}
+				});
 
-				if (permalink) {
-					ArticleComments.scrollToElement(hash);
-				}
-				ArticleComments.bucky.timer.stop('loadAssets');
-			});
-		};
+				// Comments are already visible, load them now
+			} else {
+				loadAssets();
+			}
+		});
 
-		// Load comments as they become visible (unless we are requesting a permalink comment)
-		if (!permalink && belowTheFold()) {
-			$window.on('scrollstop.ArticleCommentsLoadOnDemand', function () {
-				if (!belowTheFold()) {
-					$comments.addClass('loading');
-					$window.off('scrollstop.ArticleCommentsLoadOnDemand');
-					loadAssets();
-				}
-			});
+	} else {
+		wgAfterContentAndJS.push(ArticleComments.init);
+	}
 
-		// Comments are already visible, load them now
-		} else {
-			loadAssets();
-		}
-	});
-
-} else {
-	wgAfterContentAndJS.push(ArticleComments.init);
-}
-
-// Exports
-window.ArticleComments = ArticleComments;
+	// Exports
+	window.ArticleComments = ArticleComments;
 
 })(this, jQuery);

--- a/extensions/wikia/ArticleComments/js/ArticleComments.js
+++ b/extensions/wikia/ArticleComments/js/ArticleComments.js
@@ -21,7 +21,6 @@
 		miniEditorEnabled: typeof window.wgEnableMiniEditorExt !== 'undefined' && skin === 'oasis',
 		loadOnDemand: typeof window.wgArticleCommentsLoadOnDemand !== 'undefined',
 		initCompleted: false,
-		actionButtons: $('#WikiaArticleComments').find('.actionButton'),
 		bucky: window.Bucky('ArticleComments'),
 
 		init: function () {
@@ -34,6 +33,7 @@
 
 			// cache jQuery selector
 			this.$commentsList = $('#article-comments-ul');
+			this.$actionButtons = this.$wrapper.find('.actionButton');
 
 			if (ArticleComments.miniEditorEnabled) {
 				newComment = $('#article-comm');
@@ -531,7 +531,7 @@
 				// Wrap editorActivated with our own function
 				editorActivated = events.editorActivated;
 				events.editorActivated = function ( /* event, wikiaEditor */ ) {
-					ArticleComments.actionButtons.removeClass('disabled').removeAttr('disabled');
+					ArticleComments.$actionButtons.removeClass('disabled').removeAttr('disabled');
 
 					if ($.isFunction(editorActivated)) {
 						editorActivated.apply(this, arguments);
@@ -564,7 +564,7 @@
 
 				// Needs initializing
 			} else {
-				ArticleComments.actionButtons.addClass('disabled').attr('disabled', true);
+				ArticleComments.$actionButtons.addClass('disabled').attr('disabled', true);
 
 				// Set content on element before initializing to keep focus in editbox (BugId:24188).
 				if (content !== undefined) {
@@ -613,12 +613,12 @@
 
 	if (ArticleComments.loadOnDemand) {
 		$(function () {
-			var content, hash, permalink, styleAssets, $comments, belowTheFold, loadAssets;
+			var content, hash, permalink, styleAssets, belowTheFold, loadAssets;
 
-			$comments = $('#WikiaArticleComments');
+			ArticleComments.$wrapper = $('#WikiaArticleComments');
 
 			// NO article comment on this page lets just skip
-			if (!$comments.length) {
+			if (!ArticleComments.$wrapper.length) {
 				return;
 			}
 
@@ -629,7 +629,7 @@
 			// 'articlecomments' + (ArticleComments.miniEditorEnabled ? '_mini_editor' : '') + '_scss'));
 			styleAssets = [$.getSassCommonURL('skins/oasis/css/core/ArticleComments.scss')];
 			belowTheFold = function () {
-				return $comments.offset().top >= ($window.scrollTop() + $window.height());
+				return ArticleComments.$wrapper.offset().top >= ($window.scrollTop() + $window.height());
 			};
 
 			if (ArticleComments.miniEditorEnabled) {
@@ -649,7 +649,7 @@
 						type: 'GET',
 						data: {
 							articleId: window.wgArticleId,
-							page: $comments.data('page'),
+							page: ArticleComments.$wrapper.data('page'),
 							skin: true
 						},
 						callback: function (response) {
@@ -657,7 +657,7 @@
 						}
 					})
 				).then(function () {
-					$comments.removeClass('loading').html(content);
+					ArticleComments.$wrapper.removeClass('loading').html(content);
 
 					ArticleComments.init();
 
@@ -672,7 +672,7 @@
 			if (!permalink && belowTheFold()) {
 				$window.on('scrollstop.ArticleCommentsLoadOnDemand', function () {
 					if (!belowTheFold()) {
-						$comments.addClass('loading');
+						ArticleComments.$wrapper.addClass('loading');
 						$window.off('scrollstop.ArticleCommentsLoadOnDemand');
 						loadAssets();
 					}

--- a/extensions/wikia/ArticleComments/js/ArticleComments.js
+++ b/extensions/wikia/ArticleComments/js/ArticleComments.js
@@ -615,6 +615,7 @@
 		$(function () {
 			var content, hash, permalink, styleAssets, belowTheFold, loadAssets;
 
+			// Cache jQuery selector after DOM ready
 			ArticleComments.$wrapper = $('#WikiaArticleComments');
 
 			// NO article comment on this page lets just skip


### PR DESCRIPTION
http://yellowlab.tools/ called out a number of duplicated DOM selectors on our site. I did a brief audit of this and ended up focusing on ArtcleComments, removing one query for "#WikiaArticleComments" and for 4 queries for "#article-comments-ul". I also did some general code cleanup while I was at it. 

Note: the way this JS is initialized is a little funky, so it wasn't as straight forward to make sure we cache jQuery DOM objects. 
