### PR TITLE
VID-2076 fixing issue with captions in new galleries on elderscrolls

### DIFF
--- a/extensions/wikia/MediaGallery/scripts/views/caption.js
+++ b/extensions/wikia/MediaGallery/scripts/views/caption.js
@@ -54,7 +54,7 @@ define('mediaGallery.views.caption', [], function () {
 		this.$el.addClass('hovered');
 
 		// calculate height of caption content plus padding of it's container
-		contentHeight = this.$el.find('.inner').outerHeight() + (2 * this.captionPadding);
+		contentHeight = this.$el.find('.inner').outerHeight(false) + (2 * this.captionPadding);
 
 		// get new negative top margin but limit it to 100% of it's container
 		// then adjust for container padding


### PR DESCRIPTION
This has to do with a jQuery bug that was fixed in v1.8 but older versions of jQuery UI still trigger the old functionality. Tickets with more info are here http://bugs.jquery.com/ticket/12491 and here http://bugs.jquery.com/ticket/10413. 

The bug was that `$.fn.outerWidth` returned a jQuery object instead of a string when: 
- no arguments are passed
- element has `box-sizing: border-box`
- parent is hidden (although I'm not 100% sure about this b/c I don't think the parent div is hidden). 

Fix: pass an argument!
