### PR TITLE
CON-1983 make edit button one size

### DIFF
--- a/extensions/wikia/Venus/styles/article/article.scss
+++ b/extensions/wikia/Venus/styles/article/article.scss
@@ -29,9 +29,7 @@ $article-items-spacing: 40px;
 		}
 
 		h1 {
-			@include font-size-xxl;
 			bottom: 0;
-			font-weight: bold;
 			margin: 0;
 			padding: 0 $medium-grid-column-padding 30px $medium-content-padding + $medium-grid-column-padding - $content-border-width;
 			word-break: break-all;
@@ -70,29 +68,18 @@ $article-items-spacing: 40px;
 		@include font-size-xxs;
 		display: inline-block;
 		float: right;
-		line-height: 27px;
-		margin-left: 27px;
+		margin-left: $size-xl;
 		padding-left: 5px;
 		position: relative;
 		text-transform: uppercase;
 
 		a::before {
-			@include edit-button(27px);
+			@include edit-button($size-xl);
 		}
 	}
 
 	h1, h2, h3, h4, h5, h6 {
-		font-weight: bold;
 		overflow: hidden;
-	}
-
-	h1 .editsection {
-		line-height: 40px;
-		margin-left: 40px;
-
-		a::before {
-			@include resize-edit-button(40px);
-		}
 	}
 
 	h2 {
@@ -105,15 +92,6 @@ $article-items-spacing: 40px;
 
 		.mw-headline {
 			padding-left: $medium-grid-gutter;
-		}
-
-		.editsection {
-			line-height: 36px;
-			margin-left: 36px;
-
-			a::before {
-				@include resize-edit-button(36px);
-			}
 		}
 	}
 

--- a/extensions/wikia/Venus/styles/mixins.scss
+++ b/extensions/wikia/Venus/styles/mixins.scss
@@ -129,8 +129,10 @@
 	content: ' ';
 	display: inline-block;
 	height: $radius;
+	margin-top: -($radius / 2);
 	position: absolute;
 	right: 100%;
+	top: 50%;
 	width: $radius;
 }
 

--- a/extensions/wikia/Venus/styles/typographyMixins.scss
+++ b/extensions/wikia/Venus/styles/typographyMixins.scss
@@ -1,5 +1,4 @@
-//This variable is used for setting width and height of edit button
-$size-xl: 27px;
+@import "extensions/wikia/Venus/styles/variables";
 
 @mixin font-size-xxs {
 	font-size: 12px;

--- a/extensions/wikia/Venus/styles/typographyMixins.scss
+++ b/extensions/wikia/Venus/styles/typographyMixins.scss
@@ -1,3 +1,6 @@
+//This variable is used for setting width and height of edit button
+$size-xl: 27px;
+
 @mixin font-size-xxs {
 	font-size: 12px;
 }
@@ -19,7 +22,7 @@
 }
 
 @mixin font-size-xl {
-	font-size: 27px;
+	font-size: $size-xl;
 }
 
 @mixin font-size-xxl {

--- a/extensions/wikia/Venus/styles/variables.scss
+++ b/extensions/wikia/Venus/styles/variables.scss
@@ -63,3 +63,6 @@ $large-grid-column: 58px + 2 * $large-grid-column-padding;
 
 //Global Navigation
 $global-navigation-height: 56px;
+
+//Typography related variables
+$size-xl: 27px;


### PR DESCRIPTION
All edit buttons (next to headers) should have the same size.
Right now size is set to 27px which is the same size as H2 text.
