### PR TITLE
CON-1987: share default CSS for infoboxes between Oasis and Venus

### DIFF
--- a/extensions/wikia/Venus/styles/article/article.scss
+++ b/extensions/wikia/Venus/styles/article/article.scss
@@ -6,6 +6,7 @@
 @import 'extensions/wikia/Venus/styles/typographyMixins';
 @import 'extensions/wikia/Venus/styles/variables';
 @import 'skins/shared/color';
+@import 'skins/shared/styles/infoboxes';
 
 $placeholder-background-color: $color-left-article-nav; // only for prototype version
 $article-items-spacing: 40px;

--- a/skins/oasis/css/core/article.scss
+++ b/skins/oasis/css/core/article.scss
@@ -5,6 +5,8 @@
 @import 'skins/shared/mixins/gradient';
 @import 'skins/shared/mixins/infobox';
 
+@import 'skins/shared/styles/infoboxes';
+
 .WikiaArticle {
 	@extend %bodytext;
 	// Prevent content from escaping the article area
@@ -359,22 +361,6 @@
 
 		legend {
 			padding: 7px;
-		}
-	}
-
-	.infobox {
-		background-color: mix($color-page, #000, 95%);
-		border: 1px solid $color-page-border;
-		clear: right;
-		color: $color-text;
-		float: right;
-		margin-bottom: .5em;
-		margin-left: 1em;
-		padding: .2em;
-
-		&[width='100%'] {	/* fb:8918 - 100% width support */
-			float: none;
-			margin-left: 0;
 		}
 	}
 

--- a/skins/shared/styles/infoboxes.scss
+++ b/skins/shared/styles/infoboxes.scss
@@ -1,0 +1,17 @@
+@import "skins/shared/color";
+
+.infobox {
+	background-color: mix($color-page, #000, 95%);
+	border: 1px solid $color-page-border;
+	clear: right;
+	color: $color-text;
+	float: right;
+	margin-bottom: .5em;
+	margin-left: 1em;
+	padding: .2em;
+
+	&[width='100%'] {	/* fb:8918 - 100% width support */
+		float: none;
+		margin-left: 0;
+	}
+}


### PR DESCRIPTION
- avoid c&p and move infoboxes CSS to `/skins/shared/styles`
- make CSS selector less specific
