### PR TITLE
PLAT-513 Use vignette in right rail photo module

### DIFF
--- a/extensions/wikia/ImageServing/imageServing.class.php
+++ b/extensions/wikia/ImageServing/imageServing.class.php
@@ -302,6 +302,7 @@ class ImageServing {
 			$this->tmpDeltaY = 0.5 - $H / $height / 2;
 		}
 
+		// FIXME: this should be replaced with a vignette thumbnail URL. See https://wikia-inc.atlassian.net/browse/PLATFORM-531.
 		$url = wfReplaceImageServer( $img->getThumbUrl( $sPrefix . $this->getCut( $width, $height ) . "-" . $img->getName().($issvg ? ".png":"") ) );
 
 		wfProfileOut( __METHOD__ );

--- a/includes/filerepo/file/File.php
+++ b/includes/filerepo/file/File.php
@@ -1790,7 +1790,7 @@ abstract class File implements FileInterface {
 	 * @return \UrlGenerator
 	 *
 	 */
-	protected function getUrlGenerator() {
+	public function getUrlGenerator() {
 			return new UrlGenerator( $this );
 	}
 

--- a/skins/oasis/modules/LatestPhotosController.class.php
+++ b/skins/oasis/modules/LatestPhotosController.class.php
@@ -83,17 +83,22 @@ class LatestPhotosController extends WikiaController {
 	}
 
 	private function getTemplateData($element) {
+		global $wgEnableVignette;
 
 		if (! isset($element['file'])) return array();
 
 		$file = $element['file'];
 		$fileTitle = $file->getTitle();
-		// crop the images correctly using extension:imageservice
-		$is = new ImageServing(array(), self::THUMB_SIZE);
-		$thumb_url = $is->getThumbnails(array($file));
-		$thumb_url = array_pop($thumb_url);
-		$thumb_url = $thumb_url['url'];
 		$userName = $file->user_text;
+		if ( $wgEnableVignette ) {
+			$thumb_url = $file->getUrlGenerator()->width( self::THUMB_SIZE )->zoomCrop();
+		} else {
+			// crop the images correctly using extension:imageservice
+			$is = new ImageServing(array(), self::THUMB_SIZE);
+			$thumb_url = $is->getThumbnails(array($file));
+			$thumb_url = array_pop($thumb_url);
+			$thumb_url = $thumb_url['url'];
+		}
 
 		$retval = array (
 			"file_url" => $element['url'],


### PR DESCRIPTION
Replace `ImageServing` thumbnail URL generation with Vignette URLs in `LatestPhotoController:: getTemplateData`. This change is surrounded in the $wgEnableVignette.

https://wikia-inc.atlassian.net/browse/PLATFORM-513

/cc @nmonterroso 
