### PR TITLE
HG-238: Return empty array if no contributors are found for article

### DIFF
--- a/extensions/wikia/MercuryApi/MercuryApiController.class.php
+++ b/extensions/wikia/MercuryApi/MercuryApiController.class.php
@@ -74,6 +74,9 @@ class MercuryApiController extends WikiaController {
 	 * @return mixed
 	 */
 	private function getTopContributorsDetails( Array $ids ) {
+		if ( empty( $ids ) ) {
+			return [];
+		}
 		try {
 			return $this->sendRequest( 'UserApi', 'getDetails', [ 'ids' => implode( ',', $ids ) ] )
 				->getData()[ 'items' ];
@@ -82,7 +85,6 @@ class MercuryApiController extends WikiaController {
 			// and we want the article even if we don't have the contributors
 			return [];
 		}
-
 	}
 
 	/**


### PR DESCRIPTION
In case there are no contributors for article, `getTopContributorsDetails` should not call `getDetails` to get user details.
