### PR TITLE
use vignette for generating avatar urls

### DIFF
--- a/extensions/wikia/VideoHandlers/filerepo/WikiaForeignDBFile.class.php
+++ b/extensions/wikia/VideoHandlers/filerepo/WikiaForeignDBFile.class.php
@@ -74,12 +74,12 @@ class WikiaForeignDBFile extends ForeignDBFile {
 		return $this->oLocalFileLogic;
 	}
 
-	function getLanguageCode() {
+	function getPathPrefix() {
 		$wikiDbName = $this->repo->getDBName();
 		$wikiId = WikiFactory::DBtoID($wikiDbName);
 		$wikiUploadPath = WikiFactory::getVarValueByName('wgUploadPath', $wikiId);
 
-		return VignetteRequest::parseLanguageCode( $wikiUploadPath );
+		return VignetteRequest::parsePathPrefix( $wikiUploadPath );
 	}
 
 	// Not everything can be transparent, because __call skips already defined methods.

--- a/extensions/wikia/VideoHandlers/filerepo/WikiaForeignDBFile.class.php
+++ b/extensions/wikia/VideoHandlers/filerepo/WikiaForeignDBFile.class.php
@@ -76,8 +76,8 @@ class WikiaForeignDBFile extends ForeignDBFile {
 
 	function getPathPrefix() {
 		$wikiDbName = $this->repo->getDBName();
-		$wikiId = WikiFactory::DBtoID($wikiDbName);
-		$wikiUploadPath = WikiFactory::getVarValueByName('wgUploadPath', $wikiId);
+		$wikiId = WikiFactory::DBtoID( $wikiDbName );
+		$wikiUploadPath = WikiFactory::getVarValueByName( 'wgUploadPath', $wikiId );
 
 		return VignetteRequest::parsePathPrefix( $wikiUploadPath );
 	}

--- a/extensions/wikia/VideoHandlers/filerepo/WikiaForeignDBFile.class.php
+++ b/extensions/wikia/VideoHandlers/filerepo/WikiaForeignDBFile.class.php
@@ -77,14 +77,9 @@ class WikiaForeignDBFile extends ForeignDBFile {
 	function getLanguageCode() {
 		$wikiDbName = $this->repo->getDBName();
 		$wikiId = WikiFactory::DBtoID($wikiDbName);
-		$wikiContLang = WikiFactory::getVarValueByName('wgContLang', $wikiId);
+		$wikiUploadPath = WikiFactory::getVarValueByName('wgUploadPath', $wikiId);
 
-		$code = null;
-		if ( $wikiContLang ) {
-			$code = $wikiContLang->getCode();
-		}
-
-		return $code;
+		return VignetteRequest::parseLanguageCode( $wikiUploadPath );
 	}
 
 	// Not everything can be transparent, because __call skips already defined methods.

--- a/includes/filerepo/file/File.php
+++ b/includes/filerepo/file/File.php
@@ -242,9 +242,9 @@ abstract class File {
 		return $this->name;
 	}
 
-	public function getLanguageCode() {
+	public function getPathPrefix() {
 		global $wgUploadPath;
-		return VignetteRequest::parseLanguageCode( $wgUploadPath );
+		return VignetteRequest::parsePathPrefix( $wgUploadPath );
 	}
 
 	/**

--- a/includes/filerepo/file/File.php
+++ b/includes/filerepo/file/File.php
@@ -243,14 +243,8 @@ abstract class File {
 	}
 
 	public function getLanguageCode() {
-		global $wgContLang;
-
-		$code = null;
-		if ( isset( $wgContLang ) ) {
-			$code = $wgContLang->getCode();
-		}
-
-		return $code;
+		global $wgUploadPath;
+		return VignetteRequest::parseLanguageCode( $wgUploadPath );
 	}
 
 	/**

--- a/includes/wikia/VignetteRequest.php
+++ b/includes/wikia/VignetteRequest.php
@@ -14,13 +14,13 @@ class VignetteRequest {
 			'is-archive' => $file->isOld(),
 			'timestamp' => $timestamp,
 			'relative-path' => $file->getHashPath().rawurlencode($file->getName()),
-			'language-code' => $file->getLanguageCode(),
+			'path-prefix' => $file->getPathPrefix(),
 		]);
 	}
 
 	/**
 	 * create a UrlGenerator from a config map. $config must have the following keys: relative-path.
-	 * optionally, it can also have timestamp, is-archive, language-code, bucket, base-url, and domain-shard-count.
+	 * optionally, it can also have timestamp, is-archive, path-prefix, bucket, base-url, and domain-shard-count.
 	 * if the optional values aren't in the map, they'll be generated from the current wiki environment
 	 *
 	 * @param $config
@@ -33,7 +33,7 @@ class VignetteRequest {
 		];
 
 		$isArchive = isset($config['is-archive']) ? $config['is-archive'] : false;
-		$languageCode = isset($config['language-code']) ? $config['language-code'] : null;
+		$pathPrefix = isset($config['path-prefix']) ? $config['path-prefix'] : null;
 		$timestamp = isset($config['timestamp']) ? $config['timestamp'] : 0;
 
 		if (!isset($config['base-url'])) {
@@ -66,7 +66,7 @@ class VignetteRequest {
 			->setIsArchive( $isArchive )
 			->setTimestamp( $timestamp )
 			->setRelativePath( $config['relative-path'] )
-			->setLanguageCode( $languageCode )
+			->setPathPrefix( $pathPrefix )
 			->setBucket( $config['bucket'] )
 			->setBaseUrl( $config['base-url'] )
 			->setDomainShardCount( $config['domain-shard-count'] );
@@ -90,19 +90,21 @@ class VignetteRequest {
 	}
 
 	/**
-	 * parse the language code from a url. http://images.wikia.com/walkingdead/ru/images -> "ru",
+	 * parse the path prefix from a url.
+	 * http://images.wikia.com/walkingdead/ru/images -> "ru",
 	 * http://images.wikia.com/walkingdead/images -> null
+	 * http://images.wikia.com/p__/psychusa/zh/images -> psychusa/zh
 	 * @param $url
 	 * @return null
 	 */
-	public static function parseLanguageCode( $url ) {
-		$languageCode = null;
+	public static function parsePathPrefix( $url ) {
+		$pathPrefix = null;
 
 		if ( preg_match( '/http(s)?:\/\/(.*?)\/(.*?)\/(.*?\/)?images$/', $url, $matches ) && isset( $matches[4] ) ) {
-			$languageCode = rtrim($matches[4], '/');
+			$pathPrefix = rtrim($matches[4], '/');
 		}
 
-		return $languageCode;
+		return $pathPrefix;
 	}
 
 	/**

--- a/includes/wikia/VignetteRequest.php
+++ b/includes/wikia/VignetteRequest.php
@@ -79,7 +79,7 @@ class VignetteRequest {
 	 * @param $url
 	 * @return mixed
 	 */
-	public static function parseBucket($url) {
+	public static function parseBucket( $url ) {
 		$bucket = null;
 
 		if ( preg_match( '/http(s?):\/\/(.*?)\/(.*?)\/(.*)$/', $url, $matches ) ) {
@@ -90,12 +90,28 @@ class VignetteRequest {
 	}
 
 	/**
+	 * parse the language code from a url. http://images.wikia.com/walkingdead/ru/images -> "ru",
+	 * http://images.wikia.com/walkingdead/images -> null
+	 * @param $url
+	 * @return null
+	 */
+	public static function parseLanguageCode( $url ) {
+		$languageCode = null;
+
+		if ( preg_match( '/http(s)?:\/\/(.*?)\/(.*?)\/(.*?\/)?images$/', $url, $matches ) && isset( $matches[4] ) ) {
+			$languageCode = rtrim($matches[4], '/');
+		}
+
+		return $languageCode;
+	}
+
+	/**
 	 * parse relative path from url. ex: http://images.wiukia.com/muppet/images/a/ab/image.jpg will
 	 * return "a/ab/image.jpg"
 	 * @param $url
 	 * @return mixed
 	 */
-	public static function parseRelativePath($url) {
+	public static function parseRelativePath( $url ) {
 		$relativePath = null;
 
 		if ( preg_match( '/\w\/\w\w\/(.*)$/', $url, $matches ) ) {

--- a/includes/wikia/services/AvatarService.class.php
+++ b/includes/wikia/services/AvatarService.class.php
@@ -14,39 +14,39 @@ class AvatarService extends Service {
 	/**
 	 * Internal method for getting user object with caching
 	 */
-	static private function getUser($userName) {
-		wfProfileIn(__METHOD__);
+	static private function getUser( $userName ) {
+		wfProfileIn( __METHOD__ );
 
 		static $usersCache;
 
-		if( isset($usersCache[$userName]) ) {
+		if ( isset( $usersCache[$userName] ) ) {
 			$user = $usersCache[$userName];
 		} else {
-			$user = User::newFromName($userName);
+			$user = User::newFromName( $userName );
 
 			$usersCache[$userName] = $user;
 		}
 
-		wfProfileOut(__METHOD__);
+		wfProfileOut( __METHOD__ );
 		return $user;
 	}
 
 	/**
 	 * Get URL to default avatar
 	 */
-	static public function getDefaultAvatar($avatarSize) {
-		wfProfileIn(__METHOD__);
+	static public function getDefaultAvatar( $avatarSize ) {
+		wfProfileIn( __METHOD__ );
 		global $wgStylePath;
 
-		if (class_exists('Masthead')) {
-			$avatarUrl = Masthead::newFromUserId(0)->getThumbnail($avatarSize);
+		if ( class_exists( 'Masthead' ) ) {
+			$avatarUrl = Masthead::newFromUserId( 0 )->getThumbnail( $avatarSize );
 		}
 		else {
-			$randomInt = rand(1, 3);
+			$randomInt = rand( 1, 3 );
 			$avatarUrl = "{$wgStylePath}/oasis/images/generic_avatar{$randomInt}.png";
 		}
 
-		wfProfileOut(__METHOD__);
+		wfProfileOut( __METHOD__ );
 		return $avatarUrl;
 	}
 
@@ -57,25 +57,25 @@ class AvatarService extends Service {
 	 * @param  int    $ns
 	 * @return string $url
 	 */
-	static function getUrl($userName, $ns = NS_USER) {
-		wfProfileIn(__METHOD__);
+	static function getUrl( $userName, $ns = NS_USER ) {
+		wfProfileIn( __METHOD__ );
 
 		static $linksCache;
 
 		$url = '';
-		
+
 		$cacheSignature = "{$userName}_{$ns}";
 
-		if( isset($linksCache[$cacheSignature]) ) {
+		if ( isset( $linksCache[$cacheSignature] ) ) {
 			$url = $linksCache[$cacheSignature];
 		} else {
-			if (User::isIP($userName)) {
+			if ( User::isIP( $userName ) ) {
 				// anon: point to Special:Contributions
-				$url = Skin::makeSpecialUrl('Contributions').'/'.$userName;
+				$url = Skin::makeSpecialUrl( 'Contributions' ) . '/' . $userName;
 			}
 			else {
 				// user: point to user page
-				$userPage = Title::newFromText($userName, $ns);
+				$userPage = Title::newFromText( $userName, $ns );
 				if ( !is_null( $userPage ) ) {
 					$url = $userPage->getLocalUrl();
 				}
@@ -84,7 +84,7 @@ class AvatarService extends Service {
 			$linksCache[$cacheSignature] = $url;
 		}
 
-		wfProfileOut(__METHOD__);
+		wfProfileOut( __METHOD__ );
 		return $url;
 	}
 
@@ -95,132 +95,132 @@ class AvatarService extends Service {
 	 * @param int $avatarSize
 	 * @return String avatar's URL
 	 */
-	static function getAvatarUrl($user, $avatarSize = 20) {
+	static function getAvatarUrl( $user, $avatarSize = 20 ) {
 		global $wgEnableVignette;
 
-		wfProfileIn(__METHOD__);
+		wfProfileIn( __METHOD__ );
 
 		static $avatarsCache;
-		if( $user instanceof User ) {
+		if ( $user instanceof User ) {
 			$key = "{$user->getName()}::{$avatarSize}";
 		} else {
-			//assumes $user is a string with user name
+			// assumes $user is a string with user name
 			$key = "{$user}::{$avatarSize}";
 		}
 
-		if( isset($avatarsCache[$key]) ) {
+		if ( isset( $avatarsCache[$key] ) ) {
 			$avatarUrl = $avatarsCache[$key];
 		} else {
-			if( !($user instanceof User) ) {
-				$user = self::getUser($user);
+			if ( !( $user instanceof User ) ) {
+				$user = self::getUser( $user );
 			}
 
 			// handle anon users - return default avatar
-			if( empty($user) || !class_exists('Masthead') ) {
-				$avatarUrl = self::getDefaultAvatar($avatarSize);
+			if ( empty( $user ) || !class_exists( 'Masthead' ) ) {
+				$avatarUrl = self::getDefaultAvatar( $avatarSize );
 
-				wfProfileOut(__METHOD__);
+				wfProfileOut( __METHOD__ );
 				return $avatarUrl;
 			}
 
-			$masthead = Masthead::newFromUser($user);
+			$masthead = Masthead::newFromUser( $user );
 			// use per-user cachebuster when custom avatar is used
-			$cb = !$masthead->isDefault() ? intval($user->getOption('avatar_rev')) : 0;
+			$cb = !$masthead->isDefault() ? intval( $user->getOption( 'avatar_rev' ) ) : 0;
 
-			if ($wgEnableVignette) {
-				$avatarUrl = self::getVignetteUrl($masthead, $avatarSize, $cb);
+			if ( $wgEnableVignette ) {
+				$avatarUrl = self::getVignetteUrl( $masthead, $avatarSize, $cb );
 			} else {
-				$avatarUrl = $masthead->getThumbnailPurgeUrl($avatarSize);
+				$avatarUrl = $masthead->getThumbnailPurgeUrl( $avatarSize );
 
 				// Make URLs consistent and using no-cookie domain.  We need to pass a
 				// stringified zero rather than an actual zero because this function
 				// treats them differently o_O  Setting this to string zero matches
 				// the anonymous user behavior (BugId:22190)
-				$avatarUrl = wfReplaceImageServer($avatarUrl,  ($cb > 0) ? $cb : "0");
+				$avatarUrl = wfReplaceImageServer( $avatarUrl,  ( $cb > 0 ) ? $cb : "0" );
 
 				// make avatars as JPG intead of PNGs / GIF but only when it will be a gain (most likely)
-				if (intval($avatarSize) > self::PERFORMANCE_JPEG_THRESHOLD) {
-					$avatarUrl = ImagesService::overrideThumbnailFormat($avatarUrl, ImagesService::EXT_JPG);
+				if ( intval( $avatarSize ) > self::PERFORMANCE_JPEG_THRESHOLD ) {
+					$avatarUrl = ImagesService::overrideThumbnailFormat( $avatarUrl, ImagesService::EXT_JPG );
 				}
 			}
 
 			$avatarsCache[$key] = $avatarUrl;
 		}
 
-		wfProfileOut(__METHOD__);
+		wfProfileOut( __METHOD__ );
 		return $avatarUrl;
 	}
 
 	/**
 	 * Render avatar
 	 */
-	static function renderAvatar($userName, $avatarSize = 20) {
-		wfProfileIn(__METHOD__);
+	static function renderAvatar( $userName, $avatarSize = 20 ) {
+		wfProfileIn( __METHOD__ );
 
 		// For performance reasons, we only generate avatars that are of specific sizes.
 		// We allow HTML tag to resize to any size.
-		if ($avatarSize <= self::AVATAR_SIZE_SMALL) {
+		if ( $avatarSize <= self::AVATAR_SIZE_SMALL ) {
 			$allowedSize = self::AVATAR_SIZE_SMALL;
-		} else if ($avatarSize <= self::AVATAR_SIZE_SMALL_PLUS) {
+		} else if ( $avatarSize <= self::AVATAR_SIZE_SMALL_PLUS ) {
 			$allowedSize = self::AVATAR_SIZE_SMALL_PLUS;
-		} else if ($avatarSize <= self::AVATAR_SIZE_MEDIUM) {
+		} else if ( $avatarSize <= self::AVATAR_SIZE_MEDIUM ) {
 			$allowedSize = self::AVATAR_SIZE_MEDIUM;
 		} else {
 			$allowedSize = self::AVATAR_SIZE_LARGE;
 		}
 
-		$avatarUrl = self::getAvatarUrl($userName, $allowedSize);
+		$avatarUrl = self::getAvatarUrl( $userName, $allowedSize );
 
-		$ret = Xml::element('img', array(
+		$ret = Xml::element( 'img', array(
 			'src' => $avatarUrl,
 			'width' => $avatarSize,
 			'height' => $avatarSize,
 			'class' => 'avatar',
 			'alt' => $userName,
-		));
+		) );
 
-		wfProfileOut(__METHOD__);
+		wfProfileOut( __METHOD__ );
 		return $ret;
 	}
 
 	/**
 	 * Render link to user page / Special:Contributions
 	 */
-	static function renderLink($userName) {
-		wfProfileIn(__METHOD__);
+	static function renderLink( $userName ) {
+		wfProfileIn( __METHOD__ );
 
 		// for anons show "A Wikia user" instead of IP address
-		if (User::isIP($userName)) {
-			$label = wfMsg('oasis-anon-user');
+		if ( User::isIP( $userName ) ) {
+			$label = wfMsg( 'oasis-anon-user' );
 		}
 		else {
 			$label = $userName;
 		}
 
-		$link = Xml::element('a',
-			array('href' => self::getUrl($userName)),
-			$label);
+		$link = Xml::element( 'a',
+			array( 'href' => self::getUrl( $userName ) ),
+			$label );
 
-		wfProfileOut(__METHOD__);
+		wfProfileOut( __METHOD__ );
 		return $link;
 	}
 
 	/**
 	 * Render avatar and link to user page
 	 */
-	static function render($userName, $avatarSize = 20) {
-		wfProfileIn(__METHOD__);
+	static function render( $userName, $avatarSize = 20 ) {
+		wfProfileIn( __METHOD__ );
 
 		// render avatar
-		$ret = self::renderAvatar($userName, $avatarSize);
+		$ret = self::renderAvatar( $userName, $avatarSize );
 
 		// add small spacing
 		$ret .= ' ';
 
 		// render link to user page / Special:Contributions
-		$ret .= self::renderLink($userName);
+		$ret .= self::renderLink( $userName );
 
-		wfProfileOut(__METHOD__);
+		wfProfileOut( __METHOD__ );
 		return $ret;
 	}
 
@@ -232,17 +232,17 @@ class AvatarService extends Service {
 		global $wgStylePath;
 
 		if ( class_exists( 'Masthead' ) ) {
-			$avatarUrl = Masthead::newFromUserName($userName)->mUser->getOption( AVATAR_USER_OPTION_NAME );
+			$avatarUrl = Masthead::newFromUserName( $userName )->mUser->getOption( AVATAR_USER_OPTION_NAME );
 			$images = getMessageForContentAsArray( 'blog-avatar-defaults' );
 			$firstDefaultImage = $images[ 0 ];
-			if( empty( $avatarUrl ) || substr( $avatarUrl, -strlen( $firstDefaultImage ) ) === $firstDefaultImage ) {
+			if ( empty( $avatarUrl ) || substr( $avatarUrl, -strlen( $firstDefaultImage ) ) === $firstDefaultImage ) {
 				wfProfileOut( __METHOD__ );
 				return true;
 			}
 		} else {
 			$avatarUrl = self::getAvatarUrl( $userName );
 			$avatarDefaultUrlStart = "{$wgStylePath}/oasis/images/generic_avatar";
-			if( $avatarUrl === '' || strpos( $avatarUrl, $avatarDefaultUrlStart ) === 0 ) {
+			if ( $avatarUrl === '' || strpos( $avatarUrl, $avatarDefaultUrlStart ) === 0 ) {
 				wfProfileOut( __METHOD__ );
 				return true;
 			}
@@ -258,55 +258,55 @@ class AvatarService extends Service {
 	 * @param $timestamp
 	 * @return \Wikia\Vignette\UrlGenerator
 	 */
-	private static function getVignetteUrl(Masthead $masthead, $width, $timestamp) {
-		$relativePath = $masthead->mUser->getOption(AVATAR_USER_OPTION_NAME);
+	private static function getVignetteUrl( Masthead $masthead, $width, $timestamp ) {
+		$relativePath = $masthead->mUser->getOption( AVATAR_USER_OPTION_NAME );
 
-		if ($relativePath) {
-			if (strpos($relativePath, '/') !== false) { // custom avatar
-				$url = self::vignetteCustomUrl($width, $relativePath, $timestamp);
+		if ( $relativePath ) {
+			if ( strpos( $relativePath, '/' ) !== false ) { // custom avatar
+				$url = self::vignetteCustomUrl( $width, $relativePath, $timestamp );
 			} else { // wikia-provided avatars
 				$hash = FileRepo::getHashPathForLevel( $relativePath, 2 );
-				$bucket = VignetteRequest::parseBucket($masthead->mDefaultPath);
-				$relativePath = $hash.$relativePath;
-				$url = self::buildVignetteUrl($width, $bucket, $relativePath, $timestamp, false);
+				$bucket = VignetteRequest::parseBucket( $masthead->mDefaultPath );
+				$relativePath = $hash . $relativePath;
+				$url = self::buildVignetteUrl( $width, $bucket, $relativePath, $timestamp, false );
 			}
 		} else { // default avatar
 			$legacyDefaultUrl = array_shift( $masthead->getDefaultAvatars( 'thumb/' ) );
-			$bucket = VignetteRequest::parseBucket($legacyDefaultUrl);
-			$relativePath = VignetteRequest::parseRelativePath($legacyDefaultUrl);
-			$url = self::buildVignetteUrl($width, $bucket, $relativePath, $timestamp, false);
+			$bucket = VignetteRequest::parseBucket( $legacyDefaultUrl );
+			$relativePath = VignetteRequest::parseRelativePath( $legacyDefaultUrl );
+			$url = self::buildVignetteUrl( $width, $bucket, $relativePath, $timestamp, false );
 		}
 
 		return $url;
 	}
 
-	private static function vignetteCustomUrl($width, $relativePath, $timestamp) {
+	private static function vignetteCustomUrl( $width, $relativePath, $timestamp ) {
 		global $wgBlogAvatarPath;
 
 		$url = $relativePath;
-		if (strpos($relativePath, 'http://') === false) {
-			$bucket = VignetteRequest::parseBucket($wgBlogAvatarPath);
-			$relativePath = ltrim($relativePath, '/');
-			$url = self::buildVignetteUrl($width, $bucket, $relativePath, $timestamp);
+		if ( strpos( $relativePath, 'http://' ) === false ) {
+			$bucket = VignetteRequest::parseBucket( $wgBlogAvatarPath );
+			$relativePath = ltrim( $relativePath, '/' );
+			$url = self::buildVignetteUrl( $width, $bucket, $relativePath, $timestamp );
 		}
 
 		return $url;
 	}
 
-	private static function buildVignetteUrl($width, $bucket, $relativePath, $timestamp, $avatarImageType=true) {
+	private static function buildVignetteUrl( $width, $bucket, $relativePath, $timestamp, $avatarImageType = true ) {
 		$config = [
 			'bucket' => $bucket,
 			'timestamp' => $timestamp,
 			'relative-path' => $relativePath,
 		];
 
-		$avatar = VignetteRequest::fromConfigMap($config)->scaleToWidth($width);
+		$avatar = VignetteRequest::fromConfigMap( $config )->scaleToWidth( $width );
 
-		if (intval($width) > self::PERFORMANCE_JPEG_THRESHOLD) {
+		if ( intval( $width ) > self::PERFORMANCE_JPEG_THRESHOLD ) {
 			$avatar->jpg();
 		}
 
-		if ($avatarImageType) {
+		if ( $avatarImageType ) {
 			$avatar->avatar();
 		}
 

--- a/includes/wikia/services/AvatarService.class.php
+++ b/includes/wikia/services/AvatarService.class.php
@@ -258,7 +258,7 @@ class AvatarService extends Service {
 	 * @param $timestamp
 	 * @return \Wikia\Vignette\UrlGenerator
 	 */
-	private static function getVignetteUrl( Masthead $masthead, $width, $timestamp ) {
+	public static function getVignetteUrl( Masthead $masthead, $width, $timestamp ) {
 		$relativePath = $masthead->mUser->getOption( AVATAR_USER_OPTION_NAME );
 
 		if ( $relativePath ) {

--- a/includes/wikia/services/tests/AvatarServiceTest.php
+++ b/includes/wikia/services/tests/AvatarServiceTest.php
@@ -1,12 +1,11 @@
 <?php
 class AvatarServiceTest extends WikiaBaseTest {
-
 	/**
 	 * @dataProvider getDefaultAvatarDataProvider
 	 * @group UsingDB
 	 */
-	public function testGetDefaultAvatar($url, $width) {
-			$this->assertStringEndsWith($url, AvatarService::getDefaultAvatar($width));
+	public function testGetDefaultAvatar( $url, $width ) {
+			$this->assertStringEndsWith( $url, AvatarService::getDefaultAvatar( $width ) );
 	}
 
 	public function getDefaultAvatarDataProvider() {
@@ -30,8 +29,8 @@ class AvatarServiceTest extends WikiaBaseTest {
 	 * @dataProvider getUrlDataProvider
 	 * @group UsingDB
 	 */
-	public function testGetUrl($url, $userName) {
-		$this->assertStringEndsWith($url, AvatarService::getUrl($userName));
+	public function testGetUrl( $url, $userName ) {
+		$this->assertStringEndsWith( $url, AvatarService::getUrl( $userName ) );
 	}
 
 	public function getUrlDataProvider() {
@@ -53,16 +52,16 @@ class AvatarServiceTest extends WikiaBaseTest {
 	 * @group UsingDB
 	 * @dataProvider getAvatarUrlDataProvider
 	 */
-	public function testGetAvatarUrl($url, $userName, $userId, $avatarSize) {
+	public function testGetAvatarUrl( $url, $userName, $userId, $avatarSize ) {
 		$user = new User();
-		$user->setId($userId);
-		$user->setName($userName);
+		$user->setId( $userId );
+		$user->setName( $userName );
 
-		if ($userId > 0) {
-			$user->setOption(AVATAR_USER_OPTION_NAME, $userId);
+		if ( $userId > 0 ) {
+			$user->setOption( AVATAR_USER_OPTION_NAME, $userId );
 		}
 
-		$this->assertStringEndsWith($url, AvatarService::getAvatarUrl($user, $avatarSize));
+		$this->assertStringEndsWith( $url, AvatarService::getAvatarUrl( $user, $avatarSize ) );
 	}
 
 	public function getAvatarUrlDataProvider() {
@@ -82,5 +81,69 @@ class AvatarServiceTest extends WikiaBaseTest {
 				'avatarSize' => 20,
 			],
 		];
+	}
+
+	function testCustomUploadedAvatar() {
+		$user = $this->getMock( 'User' );
+		$user
+			->expects( $this->any() )
+			->method( 'getOption' )
+			->will( $this->returnValue( '/a/ab/12345.png' ) );
+
+		$masthead = $this->getMock( 'Masthead', [], [$user] );
+
+		$this->assertEquals(
+			'http://vignette.wikia-dev.com/common/avatars/a/ab/12345.png/revision/latest/scale-to-width/150?cb=789&format=jpg',
+			AvatarService::getVignetteUrl( $masthead, 150, 789 )
+		);
+	}
+
+	function testCustomExternalAvatar() {
+		$user = $this->getMock( 'User' );
+		$user
+			->expects( $this->any() )
+			->method( 'getOption' )
+			->will( $this->returnValue( 'http://images.domain.com/user/nelson.jpg' ) );
+
+		$masthead = $this->getMock( 'Masthead', [], [$user] );
+
+		$this->assertEquals(
+			'http://images.domain.com/user/nelson.jpg',
+			AvatarService::getVignetteUrl( $masthead, 150, 789 )
+		);
+	}
+
+	function testWikiaAvatar() {
+		$user = $this->getMock( 'User' );
+		$user
+			->expects( $this->any() )
+			->method( 'getOption' )
+			->will( $this->returnValue( 'Fish.jpg' ) );
+
+		$masthead = $this->getMock( 'Masthead', [], [$user] );
+
+		$this->assertEquals(
+			'http://vignette.wikia-dev.com/messaging/images/f/fe/Fish.jpg/revision/latest/scale-to-width/150?cb=789&format=jpg',
+			AvatarService::getVignetteUrl( $masthead, 150, 789 )
+		);
+	}
+
+	function testDefaultAvatar() {
+		$user = $this->getMock( 'User' );
+		$user
+			->expects( $this->any() )
+			->method( 'getOption' )
+			->will( $this->returnValue( null ) );
+
+		$masthead = $this->getMock( 'Masthead', [], [$user] );
+		$masthead
+			->expects( $this->any() )
+			->method( 'getDefaultAvatars' )
+			->will( $this->returnValue( ['http://images.wikia.com/messaging/images/1/19/Avatar.jpg'] ) );
+
+		$this->assertEquals(
+			'http://vignette.wikia-dev.com/messaging/images/1/19/Avatar.jpg/revision/latest/scale-to-width/150?cb=789&format=jpg',
+			AvatarService::getVignetteUrl( $masthead, 150, 789 )
+		);
 	}
 }

--- a/lib/Wikia/src/Vignette/UrlConfig.php
+++ b/lib/Wikia/src/Vignette/UrlConfig.php
@@ -14,7 +14,7 @@ class UrlConfig {
 	protected $isArchive = false;
 	protected $timestamp;
 	protected $relativePath;
-	protected $languageCode;
+	protected $pathPrefix;
 	protected $bucket;
 	protected $baseUrl;
 	protected $domainShardCount;
@@ -34,8 +34,8 @@ class UrlConfig {
 		return $this;
 	}
 
-	public function setLanguageCode($languageCode) {
-		$this->languageCode = $languageCode;
+	public function setPathPrefix($languageCode) {
+		$this->pathPrefix = $languageCode;
 		return $this;
 	}
 
@@ -66,8 +66,8 @@ class UrlConfig {
 		return $this->relativePath;
 	}
 
-	public function languageCode() {
-		return $this->languageCode;
+	public function pathPrefix() {
+		return $this->pathPrefix;
 	}
 
 	public function bucket() {

--- a/lib/Wikia/src/Vignette/UrlGenerator.php
+++ b/lib/Wikia/src/Vignette/UrlGenerator.php
@@ -101,7 +101,7 @@ class UrlGenerator {
 	 */
 	public function pathPrefix($pathPrefix) {
 		if (!empty($pathPrefix)) {
-			$this->query['pathPrefix'] = $pathPrefix;
+			$this->query['path-prefix'] = $pathPrefix;
 		}
 
 		return $this;
@@ -249,7 +249,7 @@ class UrlGenerator {
 	public function url() {
 		$imagePath = "{$this->config->bucket()}/{$this->imageType}/{$this->config->relativePath()}/revision/{$this->getRevision()}";
 
-		if (!isset($this->query['pathPrefix'])) {
+		if (!isset($this->query['path-prefix'])) {
 			$this->pathPrefix($this->config->pathPrefix());
 		}
 

--- a/lib/Wikia/src/Vignette/UrlGenerator.php
+++ b/lib/Wikia/src/Vignette/UrlGenerator.php
@@ -95,13 +95,13 @@ class UrlGenerator {
 	}
 
 	/**
-	 * set an image's language
-	 * @param string $lang
+	 * set an image's path prefix
+	 * @param string $pathPrefix
 	 * @return $this
 	 */
-	public function lang($lang) {
-		if (!empty($lang)) {
-			$this->query['lang'] = $lang;
+	public function pathPrefix($pathPrefix) {
+		if (!empty($pathPrefix)) {
+			$this->query['pathPrefix'] = $pathPrefix;
 		}
 
 		return $this;
@@ -249,8 +249,8 @@ class UrlGenerator {
 	public function url() {
 		$imagePath = "{$this->config->bucket()}/{$this->imageType}/{$this->config->relativePath()}/revision/{$this->getRevision()}";
 
-		if (!isset($this->query['lang'])) {
-			$this->lang($this->config->languageCode());
+		if (!isset($this->query['pathPrefix'])) {
+			$this->pathPrefix($this->config->pathPrefix());
 		}
 
 		$imagePath .= $this->modePath();

--- a/lib/Wikia/src/Vignette/UrlGenerator.php
+++ b/lib/Wikia/src/Vignette/UrlGenerator.php
@@ -100,7 +100,7 @@ class UrlGenerator {
 	 * @return $this
 	 */
 	public function lang($lang) {
-		if (!empty($lang) && $lang != 'en') {
+		if (!empty($lang)) {
 			$this->query['lang'] = $lang;
 		}
 


### PR DESCRIPTION
@drsnyder 
Use `VignetteRequest::fromConfigMap` to generate vignette urls for user avatars. We can't use `fromFile` because avatars aren't stored as file objects, they're strings built from the user's id.

Also piggybacking - use `$wgUploadPath` for determining a file's "prefix path" instead of `$wgContLang`. This is needed because some english wikis have their images in `<bucket>/en/images` instead of `<bucket>/images`, and also some wikis have their bucket stored under another, higher level bucket (ex: `p__/psychusa`), so we need to parse that to determine what `parse-prefix` to set for the vignette url.
