### PR TITLE
MWEB-1066 P2 fix: PHP fatal error on production

### DIFF
--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -468,10 +468,10 @@ class ArticleComment {
 		$id = $wikiPage->getId();
 
 		//we need to run all the hook manual :/
-		if ( wfRunHooks( 'ArticleDelete', array( &$wikiPage, &$wgUser, &$reason, &$error ) ) ) {
+		if ( wfRunHooks( 'ArticleDelete', [$wikiPage, $wgUser, $reason, $error] ) ) {
 			if( $wikiPage->doDeleteArticle( $reason, $suppress ) ) {
 				$this->mTitle->getPrefixedText();
-				wfRunHooks( 'ArticleDeleteComplete', array( &$wikiPage, &$wgUser, $reason, $id) );
+				wfRunHooks( 'ArticleDeleteComplete', [$wikiPage, $wgUser, $reason, $id] );
 				return true;
 			}
 		}

--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -463,16 +463,15 @@ class ArticleComment {
 	 */
 	public function doDeleteComment( $reason, $suppress = false ){
 		global $wgUser;
-		if(empty($this->mArticle)) {
-			$this->mArticle = new Article($this->mTitle, 0);
-		}
 		$error = '';
-		$id = $this->mArticle->getId();
+		$wikiPage = new WikiPage($this->mTitle);
+		$id = $wikiPage->getId();
+
 		//we need to run all the hook manual :/
-		if ( wfRunHooks( 'ArticleDelete', array( &$this->mArticle, &$wgUser, &$reason, &$error ) ) ) {
-			if( $this->mArticle->doDeleteArticle( $reason, $suppress ) ) {
+		if ( wfRunHooks( 'ArticleDelete', array( &$wikiPage, &$wgUser, &$reason, &$error ) ) ) {
+			if( $wikiPage->doDeleteArticle( $reason, $suppress ) ) {
 				$this->mTitle->getPrefixedText();
-				wfRunHooks( 'ArticleDeleteComplete', array( &$this->mArticle, &$wgUser, $reason, $id) );
+				wfRunHooks( 'ArticleDeleteComplete', array( &$wikiPage, &$wgUser, $reason, $id) );
 				return true;
 			}
 		}

--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -468,10 +468,10 @@ class ArticleComment {
 		$id = $wikiPage->getId();
 
 		//we need to run all the hook manual :/
-		if ( wfRunHooks( 'ArticleDelete', [$wikiPage, $wgUser, $reason, $error] ) ) {
+		if ( wfRunHooks( 'ArticleDelete', [&$wikiPage, &$wgUser, &$reason, &$error] ) ) {
 			if( $wikiPage->doDeleteArticle( $reason, $suppress ) ) {
 				$this->mTitle->getPrefixedText();
-				wfRunHooks( 'ArticleDeleteComplete', [$wikiPage, $wgUser, $reason, $id] );
+				wfRunHooks( 'ArticleDeleteComplete', [&$wikiPage, &$wgUser, $reason, $id] );
 				return true;
 			}
 		}

--- a/extensions/wikia/ArticleComments/classes/ArticleCommentList.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleCommentList.class.php
@@ -610,7 +610,7 @@ class ArticleCommentList {
 	 *
 	 * @return true -- because it's a hook
 	 */
-	static public function articleDelete( WikiPage $wikiPage, $user, $reason, $error ) {
+	static public function articleDelete( WikiPage &$wikiPage, &$user, &$reason, &$error ) {
 		wfProfileIn( __METHOD__ );
 
 		$title = $wikiPage->getTitle();
@@ -667,7 +667,7 @@ class ArticleCommentList {
 	 *
 	 * @return boolean -- because it's a hook
 	 */
-	static public function articleDeleteComplete( WikiPage $wikiPage, $user, $reason, $id ) {
+	static public function articleDeleteComplete( WikiPage &$wikiPage, &$user, $reason, $id ) {
 		global $wgOut, $wgRC2UDPEnabled, $wgMaxCommentsToDelete, $wgCityId, $wgUser, $wgEnableMultiDeleteExt;
 		wfProfileIn( __METHOD__ );
 

--- a/extensions/wikia/ArticleComments/classes/ArticleCommentList.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleCommentList.class.php
@@ -610,7 +610,7 @@ class ArticleCommentList {
 	 *
 	 * @return true -- because it's a hook
 	 */
-	static public function articleDelete( WikiPage &$wikiPage, &$user, &$reason, &$error ) {
+	static public function articleDelete( WikiPage $wikiPage, $user, $reason, $error ) {
 		wfProfileIn( __METHOD__ );
 
 		$title = $wikiPage->getTitle();
@@ -657,7 +657,7 @@ class ArticleCommentList {
 	/**
 	 * Hook
 	 *
-	 * @param WikiPage $wikiaPage -- instance of Article class
+	 * @param WikiPage $wikiPage -- instance of Article class
 	 * @param User    $user    -- current user
 	 * @param string  $reason  -- deleting reason
 	 * @param integer $id      -- article id
@@ -667,11 +667,11 @@ class ArticleCommentList {
 	 *
 	 * @return boolean -- because it's a hook
 	 */
-	static public function articleDeleteComplete( WikiPage &$wikiaPage, &$user, $reason, $id ) {
+	static public function articleDeleteComplete( WikiPage $wikiPage, $user, $reason, $id ) {
 		global $wgOut, $wgRC2UDPEnabled, $wgMaxCommentsToDelete, $wgCityId, $wgUser, $wgEnableMultiDeleteExt;
 		wfProfileIn( __METHOD__ );
 
-		$title = $wikiaPage->getTitle();
+		$title = $wikiPage->getTitle();
 
 		if (!MWNamespace::isTalk($title->getNamespace()) || !ArticleComment::isTitleComment($title)) {
 			if ( empty( self::$mArticlesToDelete ) ) {

--- a/extensions/wikia/ArticleComments/classes/ArticleCommentList.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleCommentList.class.php
@@ -600,7 +600,7 @@ class ArticleCommentList {
 	/**
 	 * Hook
 	 *
-	 * @param Article $article -- instance of Article class
+	 * @param WikiPage $wikiPage -- instance of WikiPage class
 	 * @param User    $user    -- current user
 	 * @param string  $reason  -- deleting reason
 	 * @param integer $error   -- error msg
@@ -610,10 +610,10 @@ class ArticleCommentList {
 	 *
 	 * @return true -- because it's a hook
 	 */
-	static public function articleDelete( &$article, &$user, &$reason, &$error ) {
+	static public function articleDelete( WikiPage &$wikiPage, &$user, &$reason, &$error ) {
 		wfProfileIn( __METHOD__ );
 
-		$title = $article->getTitle();
+		$title = $wikiPage->getTitle();
 
 		if ( empty( self::$mArticlesToDelete ) ) {
 			$listing = ArticleCommentList::newFromTitle($title);
@@ -657,7 +657,7 @@ class ArticleCommentList {
 	/**
 	 * Hook
 	 *
-	 * @param Article $article -- instance of Article class
+	 * @param WikiPage $wikiaPage -- instance of Article class
 	 * @param User    $user    -- current user
 	 * @param string  $reason  -- deleting reason
 	 * @param integer $id      -- article id
@@ -667,11 +667,11 @@ class ArticleCommentList {
 	 *
 	 * @return boolean -- because it's a hook
 	 */
-	static public function articleDeleteComplete( &$article, &$user, $reason, $id ) {
+	static public function articleDeleteComplete( WikiPage &$wikiaPage, &$user, $reason, $id ) {
 		global $wgOut, $wgRC2UDPEnabled, $wgMaxCommentsToDelete, $wgCityId, $wgUser, $wgEnableMultiDeleteExt;
 		wfProfileIn( __METHOD__ );
 
-		$title = $article->getTitle();
+		$title = $wikiaPage->getTitle();
 
 		if (!MWNamespace::isTalk($title->getNamespace()) || !ArticleComment::isTitleComment($title)) {
 			if ( empty( self::$mArticlesToDelete ) ) {


### PR DESCRIPTION
After [type hinting changes](https://github.com/Wikia/app/commit/3c90277780b70f14b2c190a1e8d8f8c57878b422#diff-8812c5dca1cb67ed8d0d9f3c9bfa3cbdR53) in `ApiHooks.class.php` users are not able to remove nested comments anymore. That's because a catchable fatal error occurs while trying to remove the comment with sub-comments.

The changes in this pull request fix it.

/cc @Grunny @macbre @idradm 
