### PR TITLE
PLAT-532 Replace File::createThumb thumbnail using vignette

### DIFF
--- a/includes/filerepo/file/File.php
+++ b/includes/filerepo/file/File.php
@@ -772,15 +772,28 @@ abstract class File {
 	 * @return string
 	 */
 	public function createThumb( $width, $height = -1 ) {
-		$params = array( 'width' => $width );
-		if ( $height != -1 ) {
-			$params['height'] = $height;
+		global $wgEnableVignette;
+		if ( $wgEnableVignette ) {
+			$generator = $this->getUrlGenerator()->width( $width );
+
+			if ( $height != -1 ) {
+				$generator->height( $height );
+			} else {
+				$generator->height( $width );
+			}
+
+			return ( string )$generator->thumbnailDown();
+		} else {
+			$params = array( 'width' => $width );
+			if ( $height != -1 ) {
+				$params['height'] = $height;
+			}
+			$thumb = $this->transform( $params );
+			if ( is_null( $thumb ) || $thumb->isError() ) {
+				return '';
+			}
+			return $thumb->getUrl();
 		}
-		$thumb = $this->transform( $params );
-		if ( is_null( $thumb ) || $thumb->isError() ) {
-			return '';
-		}
-		return $thumb->getUrl();
 	}
 
 	/**


### PR DESCRIPTION
This is a follow-on to https://github.com/Wikia/app/pull/5118 and https://wikia-inc.atlassian.net/browse/PLATFORM-513.

The right rail photo module links to `/Special:NewFiles`. This PR addresses the thumbnail generation there.

Replace File::createThumb thumbnail generation using vignette and surround the new thumbnail generation with a `wgEnableVignette` block so it will be toggled when vignette is enabled.

https://wikia-inc.atlassian.net/browse/PLATFORM-532

/cc @nmonterroso 
