### PR TITLE
Vid 2069 Fixing order of showing, hiding, and loading indicator of gallery toggle buttons

### DIFF
--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -2039,6 +2039,7 @@ $config['media_gallery_js'] = [
 		'//extensions/wikia/MediaGallery/scripts/templates.mustache.js',
 		'//extensions/wikia/MediaGallery/scripts/views/caption.js',
 		'//extensions/wikia/MediaGallery/scripts/views/media.js',
+		'//extensions/wikia/MediaGallery/scripts/views/toggler.js',
 		'//extensions/wikia/MediaGallery/scripts/views/gallery.js',
 		'//extensions/wikia/MediaGallery/scripts/controllers/lightbox.js',
 		'//extensions/wikia/MediaGallery/scripts/controllers/galleries.js',

--- a/extensions/wikia/MediaGallery/scripts/spec/views/gallery.spec.js
+++ b/extensions/wikia/MediaGallery/scripts/spec/views/gallery.spec.js
@@ -5,6 +5,7 @@ describe('MediaGalleries gallery', function () {
 	var i,
 		Gallery,
 		Media,
+		Toggler,
 		Caption,
 		templates,
 		instance,
@@ -49,9 +50,10 @@ describe('MediaGalleries gallery', function () {
 		spyOn(Mustache, 'render').andReturn('okay');
 		bucky = modules['bucky.mock'];
 		templates = modules['mediaGallery.templates.mustache'];
+		Toggler = modules['mediaGallery.views.toggler'](templates);
 		Caption = modules['mediaGallery.views.caption']();
 		Media = modules['mediaGallery.views.media'](Caption, templates);
-		Gallery = modules['mediaGallery.views.gallery'](Media, templates, tracker, bucky);
+		Gallery = modules['mediaGallery.views.gallery'](Media, Toggler, tracker, bucky);
 
 		instance = new Gallery(options).init();
 	});
@@ -84,7 +86,7 @@ describe('MediaGalleries gallery', function () {
 		instance = new Gallery(options);
 		instance.init();
 
-		expect(instance.$toggler).toBeDefined();
+		expect(instance.toggler).toBeDefined();
 	});
 
 	it('should not init toggler', function () {
@@ -93,7 +95,7 @@ describe('MediaGalleries gallery', function () {
 		instance = new Gallery(options);
 		instance.init();
 
-		expect(instance.$toggler).not.toBeDefined();
+		expect(instance.toggler).not.toBeDefined();
 	});
 
 	it('should show more and show less', function () {

--- a/extensions/wikia/MediaGallery/scripts/templates.mustache.js
+++ b/extensions/wikia/MediaGallery/scripts/templates.mustache.js
@@ -1,6 +1,6 @@
 define( 'mediaGallery.templates.mustache', [], function() { 'use strict'; return {
-    "MediaGallery_gallery" : '<div class="media-gallery-wrapper count-{{count}}" data-visible-count="{{visibleCount}}"><script>window.Wikia = window.Wikia || {};Wikia.mediaGalleryData = Wikia.mediaGalleryData || [];Wikia.mediaGalleryData.push({{{json}}});</script><button class="add-image">{{addImageButton}}</button><noscript>{{#media}}<a href="{{linkHref}}"><img src="{{thumbUrl}}" alt="{{{caption}}}"></a>{{/media}}</noscript></div>',
+    "MediaGallery_gallery" : '<div class="media-gallery-wrapper count-{{count}}" data-visible-count="{{visibleCount}}" data-model="{{json}}" data-expanded="{{expanded}}"><button class="add-image">{{addImageButton}}</button><noscript>{{#media}}<a href="{{linkHref}}"><img src="{{thumbUrl}}" alt="{{{caption}}}"></a>{{/media}}</noscript></div>',
     "MediaGallery_media" : '{{{thumbHtml}}}{{#caption}}<div class="media-gallery-caption"><div class="inner">{{{caption}}}</div></div>{{/caption}}',
-    "MediaGallery_showMore" : '<div class="more"><button class="primary show">{{showMore}}</button><button class="secondary hide hidden">{{showLess}}</button></div>',
+    "MediaGallery_showMore" : '<button class="primary show">{{showMore}}</button><button class="secondary hide hidden">{{showLess}}</button>',
     "done": "true"
   }; });

--- a/extensions/wikia/MediaGallery/scripts/views/gallery.js
+++ b/extensions/wikia/MediaGallery/scripts/views/gallery.js
@@ -166,7 +166,7 @@ define('mediaGallery.views.gallery', [
 	Gallery.prototype.afterRender = function () {
 		// After rendering the gallery and all images are loaded,
 		// append the show more/less buttons (only happens once)
-		this.appendToggler();
+		this.initToggler();
 
 		// handle loading graphic
 		if (this.$loadingElement) {
@@ -180,7 +180,7 @@ define('mediaGallery.views.gallery', [
 	/**
 	 * Insert toggle buttons into DOM
 	 */
-	Gallery.prototype.appendToggler = function () {
+	Gallery.prototype.initToggler = function () {
 		// make sure we have items to load and we haven't added the toggle buttons already
 		if (this.toggler || this.model.media.length <= this.origVisibleCount) {
 			return;

--- a/extensions/wikia/MediaGallery/scripts/views/gallery.js
+++ b/extensions/wikia/MediaGallery/scripts/views/gallery.js
@@ -1,10 +1,9 @@
 define('mediaGallery.views.gallery', [
 	'mediaGallery.views.media',
 	'mediaGallery.views.toggler',
-	'mediaGallery.templates.mustache',
 	'wikia.tracker',
 	'bucky'
-], function (Media, Toggler, templates, tracker, bucky) {
+], function (Media, Toggler, tracker, bucky) {
 	'use strict';
 
 	var Gallery;

--- a/extensions/wikia/MediaGallery/scripts/views/toggler.js
+++ b/extensions/wikia/MediaGallery/scripts/views/toggler.js
@@ -1,0 +1,37 @@
+define('mediaGallery.views.toggler', [
+	'mediaGallery.templates.mustache'
+], function (templates) {
+	'use strict';
+
+	var Toggler = function () {
+		this.templateName = 'MediaGallery_showMore';
+		this.$el = $('<div></div>')
+			.addClass('toggler');
+
+		return this;
+	};
+
+
+	/**
+	 * Render the toggle buttons. Does not include DOM insertion.
+	 */
+	Toggler.prototype.render = function () {
+		var $html, data;
+
+		data = {
+			showMore: $.msg('mediagallery-show-more'),
+			showLess: $.msg('mediagallery-show-less')
+		};
+
+		// creates an array of button elements from mustache template
+		$html = $(Mustache.render(templates[this.templateName], data));
+		this.$more = $html.first();
+		this.$less = $html.last();
+
+		this.$el.html($html);
+
+		return this;
+	};
+
+	return Toggler;
+});

--- a/extensions/wikia/MediaGallery/styles/MediaGallery.scss
+++ b/extensions/wikia/MediaGallery/styles/MediaGallery.scss
@@ -75,7 +75,7 @@ $media-margin: 2.5px;
 		clear: both;
 	}
 
-	.more {
+	.toggler {
 		clear: both;
 		margin-left: $media-margin * -1;
 		padding: .5em;

--- a/extensions/wikia/MediaGallery/templates/MediaGallery_showMore.mustache
+++ b/extensions/wikia/MediaGallery/templates/MediaGallery_showMore.mustache
@@ -1,4 +1,2 @@
-<div class="more">
-	<button class="primary show">{{showMore}}</button>
-	<button class="secondary hide hidden">{{showLess}}</button>
-</div>
+<button class="primary show">{{showMore}}</button>
+<button class="secondary hide hidden">{{showLess}}</button>

--- a/tests/karma/js-unit.conf.js
+++ b/tests/karma/js-unit.conf.js
@@ -179,6 +179,7 @@ module.exports = function (config) {
 			'extensions/wikia/MediaGallery/scripts/templates.mustache.js',
 			'extensions/wikia/MediaGallery/scripts/views/caption.js',
 			'extensions/wikia/MediaGallery/scripts/views/media.js',
+			'extensions/wikia/MediaGallery/scripts/views/toggler.js',
 			'extensions/wikia/MediaGallery/scripts/views/gallery.js',
 			'extensions/wikia/MediaGallery/scripts/spec/**/*.spec.js'
 		]


### PR DESCRIPTION
I've moved the rendering of the toggler into it's own file in order to simplify gallery.js a bit. A lot of the functionality of the toggler is still in gallery.js, which isn't ideal, but I plan to leave it like this for now, and possibly revisit it later. 

This PR mainly updates the order in which toggler handlers are called to make sure you still see a loading graphic while the last group of images are loading. 
