### PR TITLE
Special new part deux: Change File object thumb to scaleToWidth to fix Special:

### DIFF
--- a/includes/filerepo/file/File.php
+++ b/includes/filerepo/file/File.php
@@ -1792,9 +1792,7 @@ abstract class File {
 	 */
 	protected function getVignetteThumbUrl( $params ) {
 		$thumbUrl = $this->getUrlGenerator()
-			->width( $params['width'] )
-			->height( $params['height'] )
-			->thumbnail();
+			->scaleToWidth( $params['width'] );
 
 		return ( string )$thumbUrl;
 	}


### PR DESCRIPTION
By default we scale to width in the old thumbnailer by omitting the height parameter. To preserve this
behavior change the default for thumbnails when using vignette to also scale to width in the `File` object. This should generate the same or similar thumbnails in most cases.

https://wikia-inc.atlassian.net/browse/PLATFORM-532

/cc @nmonterroso 

![part-deux](https://cloud.githubusercontent.com/assets/21621/4799722/e31b7a6a-5e1e-11e4-8890-5cf4b2be61d1.jpg)
