### PR TITLE
Fix video thumbs from video wiki

### DIFF
--- a/extensions/wikia/Thumbnails/ThumbnailVideo.class.php
+++ b/extensions/wikia/Thumbnails/ThumbnailVideo.class.php
@@ -32,11 +32,11 @@ class ThumbnailVideo extends ThumbnailImage {
 	// rewrite URLs to point to a proper video thumbnails storage during images migration
 	// @author macbre
 	function __construct( $file, $url, $width, $height, $path = false, $page = false ) {
-		global $wgWikiaVideoImageHost;
+		global $wgWikiaVideoImageHost, $wgEnableVignette;
 		parent::__construct( $file, $url, $width, $height, $path, $page );
 
 		// handle videos coming from shared repo (video.wikia.com)
-		if ( !empty( $wgWikiaVideoImageHost ) && ( $file instanceof WikiaForeignDBFile ) ) {
+		if ( !$wgEnableVignette && !empty( $wgWikiaVideoImageHost ) && ( $file instanceof WikiaForeignDBFile ) ) {
 			// replace with a proper video domain for production
 			$domain = parse_url( $this->url, PHP_URL_HOST );
 			$this->url = str_replace( "http://{$domain}/", $wgWikiaVideoImageHost, $this->url );

--- a/extensions/wikia/VideoHandlers/filerepo/WikiaForeignDBFile.class.php
+++ b/extensions/wikia/VideoHandlers/filerepo/WikiaForeignDBFile.class.php
@@ -74,6 +74,14 @@ class WikiaForeignDBFile extends ForeignDBFile {
 		return $this->oLocalFileLogic;
 	}
 
+	public function getBucket() {
+		$wikiDbName = $this->repo->getDBName();
+		$wikiId = WikiFactory::DBtoID( $wikiDbName );
+		$wikiUploadPath = WikiFactory::getVarValueByName( 'wgUploadPath', $wikiId );
+
+		return VignetteRequest::parseBucket( $wikiUploadPath );
+	}
+
 	function getPathPrefix() {
 		$wikiDbName = $this->repo->getDBName();
 		$wikiId = WikiFactory::DBtoID( $wikiDbName );

--- a/includes/filerepo/file/File.php
+++ b/includes/filerepo/file/File.php
@@ -242,6 +242,11 @@ abstract class File {
 		return $this->name;
 	}
 
+	public function getBucket() {
+		global $wgUploadPath;
+		return VignetteRequest::parseBucket($wgUploadPath);
+	}
+
 	public function getPathPrefix() {
 		global $wgUploadPath;
 		return VignetteRequest::parsePathPrefix( $wgUploadPath );

--- a/includes/wikia/VignetteRequest.php
+++ b/includes/wikia/VignetteRequest.php
@@ -14,6 +14,7 @@ class VignetteRequest {
 			'is-archive' => $file->isOld(),
 			'timestamp' => $timestamp,
 			'relative-path' => $file->getHashPath().rawurlencode($file->getName()),
+			'bucket' => $file->getBucket(),
 			'path-prefix' => $file->getPathPrefix(),
 		]);
 	}


### PR DESCRIPTION
@drsnyder @garthwebb 
get bucket from the file object, rather than assuming the file always lives in the same bucket as the rest of the current wiki. also, don't replace the thumb url's base domain in ThumbnailVideo, this was causing images with the new path scheme but being sent to the old thumbnailer.
