### PR TITLE
VID-2097 checking for true keyword instead of any value

### DIFF
--- a/extensions/wikia/MediaGallery/MediaGalleryController.class.php
+++ b/extensions/wikia/MediaGallery/MediaGalleryController.class.php
@@ -20,7 +20,8 @@ class MediaGalleryController extends WikiaController {
 		$this->model = new MediaGalleryModel( $items );
 
 		$galleryParams = $this->getVal( 'gallery_params', [] ); // gallery tag parameters
-		$visibleCount = empty( $galleryParams['expand'] ) ? self::MAX_ITEMS : self::MAX_EXPANDED_ITEMS;
+		$visibleCount = isset( $galleryParams['expand'] ) && $galleryParams['expand'] == 'true' ?
+			self::MAX_EXPANDED_ITEMS : self::MAX_ITEMS;
 
 		$data = $this->model->getGalleryData();
 


### PR DESCRIPTION
Turns out we don't have a great string to boolean converter when it comes to wikitext, so we actually have to check for the string `true` as opposed to just `!empty()` when parsing wikitext params. 

After this change, tags like `<gallery expand="foo">` and `<gallery expand="false">` will not result in an expanded gallery. 
