### PR TITLE
PLAT-541 Add support for replace query param via global and URL param

### DIFF
--- a/includes/wikia/VignetteRequest.php
+++ b/includes/wikia/VignetteRequest.php
@@ -36,6 +36,15 @@ class VignetteRequest {
 		$pathPrefix = isset($config['path-prefix']) ? $config['path-prefix'] : null;
 		$timestamp = isset($config['timestamp']) ? $config['timestamp'] : 0;
 
+		if (isset($config['replace'])) {
+			$replaceThumbnail = $config['replace'];
+		} else {
+			global $wgVignetteReplaceThumbnails;
+			if ($wgVignetteReplaceThumbnails || (!empty($_GET['replace']) && (bool)$_GET['replace'])) {
+				$replaceThumbnail = true;
+			}
+		}
+
 		if (!isset($config['base-url'])) {
 			global $wgVignetteUrl;
 			$config['base-url'] = $wgVignetteUrl;
@@ -64,6 +73,7 @@ class VignetteRequest {
 
 		$config = ( new UrlConfig() )
 			->setIsArchive( $isArchive )
+			->setReplaceThumbnail( $replaceThumbnail )
 			->setTimestamp( $timestamp )
 			->setRelativePath( $config['relative-path'] )
 			->setPathPrefix( $pathPrefix )

--- a/includes/wikia/VignetteRequest.php
+++ b/includes/wikia/VignetteRequest.php
@@ -28,6 +28,8 @@ class VignetteRequest {
 	 * @throws InvalidArgumentException
 	 */
 	public static function fromConfigMap($config) {
+		$replaceThumbnail = false;
+
 		$requiredKeys = [
 			'relative-path',
 		];

--- a/lib/Wikia/src/Vignette/UrlConfig.php
+++ b/lib/Wikia/src/Vignette/UrlConfig.php
@@ -12,6 +12,7 @@ namespace Wikia\Vignette;
 
 class UrlConfig {
 	protected $isArchive = false;
+	protected $replaceThumbnail = false;
 	protected $timestamp;
 	protected $relativePath;
 	protected $pathPrefix;
@@ -21,6 +22,11 @@ class UrlConfig {
 
 	public function setIsArchive($isArchive) {
 		$this->isArchive = $isArchive;
+		return $this;
+	}
+
+	public function setReplaceThumbnail($replace) {
+		$this->replaceThumbnail = $replace;
 		return $this;
 	}
 
@@ -56,6 +62,10 @@ class UrlConfig {
 
 	public function isArchive() {
 		return $this->isArchive;
+	}
+
+	public function replaceThumbnail() {
+		return $this->replaceThumbnail;
 	}
 
 	public function timestamp() {

--- a/lib/Wikia/src/Vignette/UrlGenerator.php
+++ b/lib/Wikia/src/Vignette/UrlGenerator.php
@@ -226,6 +226,16 @@ class UrlGenerator {
 	}
 
 	/**
+	 * Force the thumbnail request to replace the cached thumbnail.
+	 *
+	 * @return $this
+	 */
+	public function replaceThumbnail() {
+		$this->query['replace'] = "true";
+		return $this;
+	}
+
+	/**
 	 * request an image in webp format
 	 * @return $this
 	 */
@@ -251,6 +261,10 @@ class UrlGenerator {
 
 		if (!isset($this->query['path-prefix'])) {
 			$this->pathPrefix($this->config->pathPrefix());
+		}
+
+		if (!isset($this->query['replace']) && $this->config->replaceThumbnail()) {
+			$this->replaceThumbnail();
 		}
 
 		$imagePath .= $this->modePath();


### PR DESCRIPTION
Add support for ?replace=true query param and `$wgVignetteReplaceThumbnails` global. These settings, when set to something truthy, will force the thumbnailer to replace the cached (disk) version of the thumbnails that are generated.

The vignette side is https://github.com/Wikia/vignette/pull/33. The corresponding ticket is here https://wikia-inc.atlassian.net/browse/PLATFORM-541.

/cc @nmonterroso @garthwebb 
