### PR TITLE
VID-2110 Add history.js dependency to Lightbox.js

### DIFF
--- a/extensions/wikia/Lightbox/scripts/Lightbox.js
+++ b/extensions/wikia/Lightbox/scripts/Lightbox.js
@@ -811,13 +811,18 @@
 
 		// Handle history API
 		updateUrlState: function (clear) {
-			var qs = window.Wikia.Querystring();
+			var self = this;
+			require(['wikia.history'], function (history) {
+				var queryString = window.Wikia.Querystring();
 
-			if (clear) {
-				qs.removeVal('file').replaceState();
-			} else {
-				qs.setVal('file', this.current.key, true).replaceState();
-			}
+				if (clear) {
+					queryString.removeVal('file');
+					history.replaceState();
+				} else {
+					queryString.setVal('file', self.current.key, true);
+					history.replaceState();
+				}
+			});
 		},
 
 		getShareCodes: function (mediaParams, callback) {

--- a/extensions/wikia/Lightbox/scripts/spec/lightbox.spec.js
+++ b/extensions/wikia/Lightbox/scripts/spec/lightbox.spec.js
@@ -1,0 +1,15 @@
+describe('Lightbox', function () {
+	'use strict';
+
+	var windowMock = {},
+		historyApi = modules['wikia.history'](windowMock);
+
+	it('has access to the history.js, a module it depends on', function () {
+		expect(historyApi).toBeDefined();
+		expect(typeof historyApi).toBe('object');
+	});
+	it('history.js has replaceState defined, a function it depends on', function () {
+		expect(historyApi.replaceState).toBeDefined();
+		expect(typeof historyApi.replaceState).toBe('function');
+	});
+});

--- a/extensions/wikia/Lightbox/scripts/spec/lightbox.spec.js
+++ b/extensions/wikia/Lightbox/scripts/spec/lightbox.spec.js
@@ -4,11 +4,11 @@ describe('Lightbox', function () {
 	var windowMock = {},
 		historyApi = modules['wikia.history'](windowMock);
 
-	it('has access to the history.js, a module it depends on', function () {
+	it('has access to history.js, a module Lightbox depends on', function () {
 		expect(historyApi).toBeDefined();
 		expect(typeof historyApi).toBe('object');
 	});
-	it('history.js has replaceState defined, a function it depends on', function () {
+	it('history.js has replaceState defined, a function Lightbox depends on', function () {
 		expect(historyApi.replaceState).toBeDefined();
 		expect(typeof historyApi.replaceState).toBe('function');
 	});

--- a/tests/karma/js-unit.conf.js
+++ b/tests/karma/js-unit.conf.js
@@ -119,10 +119,6 @@ module.exports = function (config) {
 			'extensions/wikia/VideoPageTool/scripts/lib/backbone/backbone.js',
 			'extensions/wikia/VideoPageTool/scripts/shared/views/switcher.js',
 
-			/*
-			 * VideoPageTool: Admin Module
-			 */
-
 			// Collections
 			'extensions/wikia/VideoPageTool/scripts/admin/collections/category.js',
 			'extensions/wikia/VideoPageTool/scripts/admin/collections/categorydata.js',
@@ -182,7 +178,11 @@ module.exports = function (config) {
 			'extensions/wikia/MediaGallery/scripts/views/caption.js',
 			'extensions/wikia/MediaGallery/scripts/views/media.js',
 			'extensions/wikia/MediaGallery/scripts/views/gallery.js',
-			'extensions/wikia/MediaGallery/scripts/spec/**/*.spec.js'
+			'extensions/wikia/MediaGallery/scripts/spec/**/*.spec.js',
+
+			// Lightbox
+			'extensions/wikia/Lightbox/scripts/spec/lightbox.spec.js'
+
 		]
 	});
 };


### PR DESCRIPTION
Lightbox.js was using functionality that was originally found in querystring.js, but was recently refactored and moved into a separate module called history.js. This PR requires that new history.js module inside of Lightbox.js, fixing an error which was preventing the Lightbox header and closing button from showing.

@vforge, I grepped through the code and didn't see any other references to replaceState being called from window.Wikia.QueryString, but you may want to do a second check to make sure the refactor didn't have any other side effects.

Ticket: https://wikia-inc.atlassian.net/browse/VID-2110
