### PR TITLE
Change 'replace' to 'vignetteReplaceThumbnails'

### DIFF
--- a/includes/wikia/VignetteRequest.php
+++ b/includes/wikia/VignetteRequest.php
@@ -43,7 +43,7 @@ class VignetteRequest {
 			$replaceThumbnail = $config['replace'];
 		} else {
 			global $wgVignetteReplaceThumbnails;
-			if ($wgVignetteReplaceThumbnails || (!empty($_GET['replace']) && (bool)$_GET['replace'])) {
+			if ($wgVignetteReplaceThumbnails || (!empty($_GET['vignetteReplaceThumbnails']) && (bool)$_GET['vignetteReplaceThumbnails'])) {
 				$replaceThumbnail = true;
 			}
 		}


### PR DESCRIPTION
The word `replace` is too generic in the context of MW. Change it to `vignetteReplaceThumbnails`.

This fixes the original naming introduced in https://github.com/Wikia/app/pull/5157.

/cc @nmonterroso 
