### PR TITLE
UC-40 Fixing modal overlapping problem

### DIFF
--- a/extensions/wikia/UserLogin/js/UserLoginFacebook.js
+++ b/extensions/wikia/UserLogin/js/UserLoginFacebook.js
@@ -1,3 +1,4 @@
+/* global UserLoginModal */
 (function () {
 	'use strict';
 
@@ -58,6 +59,7 @@
 					window.FB.login($.proxy(self.loginCallback, self), {
 						scope: 'publish_stream,email'
 					});
+					UserLoginModal.$modal.trigger('close');
 				});
 		},
 


### PR DESCRIPTION
The force login modal was still present after a user clicked to sign up with facebook, and it was actually overlapping the facebook login modal. This PR fixes this by closing the force login modal as soon as a user clicks the facebook connect button. 
