### PR TITLE
MAIN-3073 add processData and contentType parameter to ajax request in nirvana.js

### DIFF
--- a/resources/wikia/modules/nirvana.js
+++ b/resources/wikia/modules/nirvana.js
@@ -79,14 +79,21 @@
 			}
 			url = getUrl( attr );
 
-			return $.ajax({
+			var settings = {
 				url: url,
 				dataType: format,
 				type: type,
 				data: data,
 				success: callback,
 				error: onErrorCallback
-			});
+			};
+			if ( typeof attr.contentType != 'undefined' ) {
+				settings.contentType = attr.contentType;
+			}
+			if ( typeof attr.processData != 'undefined' ) {
+				settings.processData = attr.processData;
+			}
+			return $.ajax(settings);
 		}
 
 		return {


### PR DESCRIPTION
In Modular Main Pages Modul (at this is moment its prototype called NJord) we want to use sendRequest from nirvana.js to upload images.
To do this we want to add processData and contentType to ajax request.
Please check is it valid solution.
