### PR TITLE
gallery-clearing: Move clearing from inner to wrapper

### DIFF
--- a/extensions/wikia/MediaGallery/styles/MediaGallery.scss
+++ b/extensions/wikia/MediaGallery/styles/MediaGallery.scss
@@ -9,6 +9,7 @@ $media-margin: 2.5px;
 
 .media-gallery-wrapper {
 	@include grid-row();
+	clear: both;
 	margin: 0 $media-margin * -1;
 	padding: 1px; // leave room for the image outlines
 	width: auto;
@@ -73,10 +74,6 @@ $media-margin: 2.5px;
 
 	&[class*="count-"] .media:nth-child(n) {
 		padding: $media-margin;
-	}
-
-	.media-gallery-inner {
-		clear: both;
 	}
 
 	.more {


### PR DESCRIPTION
VisualEditor measures the bounding box of an element for drawing focus highlights. When a gallery is beside floated content (infoboxes, thumbs), the contents of the media-gallery-inner clears the float, but the outer media-gallery-wrapper does not. This causes a very large highlight to be drawn. 
