### PR TITLE
Fix JS error caused by interaction between ToneFuze ad and Wikia's edit-...

### DIFF
--- a/extensions/3rdparty/LyricWiki/Tag_Lyric.php
+++ b/extensions/3rdparty/LyricWiki/Tag_Lyric.php
@@ -207,7 +207,7 @@ function getToneFuzeLink($isAboveLyrics=true, $artist, $songTitle=""){
 	$ringtoneLink .= "adunit_id: {$AD_ID_STRING},";
 	$ringtoneLink .= "div_id: \"cf_async_\" + Math.floor((Math.random() * 999999999))";
 	$ringtoneLink .= "};";
-	$ringtoneLink .= "document.write('<div id=\"'+opts.div_id+'\"></div>');var c=function(){cf.showAsyncAd(opts)};if(window.cf)c();else{cf_async=!0;var r=document.createElement(\"script\"),s=document.getElementsByTagName(\"script\")[0];r.async=!0;r.src=\"//srv.tonefuse.com/showads/showad.js\";r.readyState?r.onreadystatechange=function(){if(\"loaded\"==r.readyState||\"complete\"==r.readyState)r.onreadystatechange=null,c()}:r.onload=c;s.parentNode.insertBefore(r,s)};";
+	$ringtoneLink .= "document.write('<div id=\"'+opts.div_id+'\"></div>');var c=function(){cf.showAsyncAd(opts)};if(window.cf)c();else{cf_async=!0;var r=document.createElement(\"script\"),s=document.getElementsByTagName(\"script\")[0];r.async=!0;r.src=\"//srv.tonefuse.com/showads/showad.js\";r.readyState?r.onreadystatechange=function(){if(\"loaded\"==r.readyState||\"complete\"==r.readyState)r.onreadystatechange=null,c()}:r.onload=c;if(s){s.parentNode.insertBefore(r,s)}};";
 	$ringtoneLink .= "})();";
 	$ringtoneLink .= "</script>";
 	


### PR DESCRIPTION
...page Preview functionality.

Fixes LYR-210.
Bug was: hitting "preview" on any page that contained a <lyrics> tag caused the page to redirect instead of show a preview... this discarded the editors edits (it was pretty infuriating to a few people ;) will be nice to have it cleaned up).

The root problem is that the ToneFuze JS code is expecting a normal page instead of the little div that the preview is inside of, and it doesn't find a script-tag that it is looking for... when finding script tags fails, this code-change will make the code just gracefully do nothing (which is fine for the Preview functionality... don't need to attempt to render functioning ads there).
