### PR TITLE
VE-1613: Support for MediaGallery paremeter - expand - in VE

### DIFF
--- a/extensions/VisualEditor/wikia/modules/ve/ce/ve.ce.WikiaGalleryNode.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ce/ve.ce.WikiaGalleryNode.js
@@ -101,7 +101,11 @@ ve.ce.WikiaGalleryNode.prototype.setupGallery = function ( galleryData ) {
 				$wrapper: this.$element,
 				model: { media: galleryData },
 				index: -1,
-				origVisibleCount: Math.min( galleryData.length, 8 )
+				// 100 and 8 are constant for MediaGallery extension. I could export them
+				// but I'm not going to because ultimetly "client" of Gallery should not have
+				// to know about it and just pass some boolean expand parameter to get desired
+				// effect.
+				origVisibleCount: this.model.getAttribute( 'expand' ) ? 100 : 8
 			},
 			gallery = new Gallery( galleryOptions ).init();
 

--- a/extensions/VisualEditor/wikia/modules/ve/dm/ve.dm.WikiaGalleryNode.js
+++ b/extensions/VisualEditor/wikia/modules/ve/dm/ve.dm.WikiaGalleryNode.js
@@ -43,14 +43,21 @@ ve.dm.WikiaGalleryNode.static.getMatchRdfaTypes = function () {
  */
 ve.dm.WikiaGalleryNode.static.toDataElement = function ( domElements ) {
 	var mwDataJSON = domElements[0].getAttribute( 'data-mw' ),
-		mwData = mwDataJSON ? JSON.parse( mwDataJSON ) : {};
+		mwData = mwDataJSON ? JSON.parse( mwDataJSON ) : {},
+		expandValue;
+
+	if ( 'expand' in mwData.attrs ) {
+		expandValue = mwData.attrs.expand === 'true';
+	} else {
+		expandValue = undefined;
+	}
 
 	return {
 		'type': this.name,
 		'attributes': {
 			'mw': mwData,
 			'originalMw': mwDataJSON,
-			'expand': mwData.attrs.expand === 'true' /* it is a string */
+			'expand': expandValue
 		}
 	};
 };
@@ -65,7 +72,9 @@ ve.dm.WikiaGalleryNode.static.toDomElements = function ( data, doc ) {
 		mwData = attribs.mw ? ve.copy( attribs.mw ) : {},
 		originalMw = attribs.originalMw;
 
-	ve.setProp( mwData, 'attrs', 'expand', (!!attribs.expand).toString() ); /* true/false must be a string */
+	if ( attribs.expand !== undefined ) {
+		ve.setProp( mwData, 'attrs', 'expand', (!!attribs.expand).toString() );
+	}
 
 	if ( originalMw && ve.compare( mwData, JSON.parse( originalMw ) ) ) {
 		el.setAttribute( 'data-mw', originalMw );

--- a/extensions/VisualEditor/wikia/modules/ve/dm/ve.dm.WikiaGalleryNode.js
+++ b/extensions/VisualEditor/wikia/modules/ve/dm/ve.dm.WikiaGalleryNode.js
@@ -57,7 +57,8 @@ ve.dm.WikiaGalleryNode.static.toDataElement = function ( domElements ) {
 		'attributes': {
 			'mw': mwData,
 			'originalMw': mwDataJSON,
-			'expand': expandValue
+			'expand': expandValue,
+			'originalExpand': expandValue
 		}
 	};
 };
@@ -72,8 +73,8 @@ ve.dm.WikiaGalleryNode.static.toDomElements = function ( data, doc ) {
 		mwData = attribs.mw ? ve.copy( attribs.mw ) : {},
 		originalMw = attribs.originalMw;
 
-	if ( attribs.expand !== undefined ) {
-		ve.setProp( mwData, 'attrs', 'expand', (!!attribs.expand).toString() );
+	if ( attribs.expand !== attribs.originalExpand ) {
+		ve.setProp( mwData, 'attrs', 'expand', attribs.expand ? "true" : undefined );
 	}
 
 	if ( originalMw && ve.compare( mwData, JSON.parse( originalMw ) ) ) {

--- a/extensions/VisualEditor/wikia/modules/ve/dm/ve.dm.WikiaGalleryNode.js
+++ b/extensions/VisualEditor/wikia/modules/ve/dm/ve.dm.WikiaGalleryNode.js
@@ -38,6 +38,44 @@ ve.dm.WikiaGalleryNode.static.getMatchRdfaTypes = function () {
 	}
 };
 
+/**
+ * @inheritdoc
+ */
+ve.dm.WikiaGalleryNode.static.toDataElement = function ( domElements ) {
+	var mwDataJSON = domElements[0].getAttribute( 'data-mw' ),
+		mwData = mwDataJSON ? JSON.parse( mwDataJSON ) : {};
+
+	return {
+		'type': this.name,
+		'attributes': {
+			'mw': mwData,
+			'originalMw': mwDataJSON,
+			'expand': mwData.attrs.expand === 'true' /* it is a string */
+		}
+	};
+};
+
+/**
+ * @inheritdoc
+ */
+ve.dm.WikiaGalleryNode.static.toDomElements = function ( data, doc ) {
+	// Inspired by ve.dm.MWReferenceListNode
+	var el = doc.createElement( 'div' ),
+		attribs = data.attributes;
+
+	mwData = attribs.mw ? ve.copy( attribs.mw ) : {};
+	ve.setProp( mwData, 'attrs', 'expand', (!!attribs.expand).toString() ); /* true/false must a string */
+
+	originalMw = attribs.originalMw;
+	if ( originalMw && ve.compare( mwData, JSON.parse( originalMw ) ) ) {
+		el.setAttribute( 'data-mw', originalMw );
+	} else {
+		el.setAttribute( 'data-mw', JSON.stringify( mwData ) );
+	}
+
+	return [ el ];
+};
+
 /* Methods */
 
 /* Registration */

--- a/extensions/VisualEditor/wikia/modules/ve/dm/ve.dm.WikiaGalleryNode.js
+++ b/extensions/VisualEditor/wikia/modules/ve/dm/ve.dm.WikiaGalleryNode.js
@@ -61,12 +61,12 @@ ve.dm.WikiaGalleryNode.static.toDataElement = function ( domElements ) {
 ve.dm.WikiaGalleryNode.static.toDomElements = function ( data, doc ) {
 	// Inspired by ve.dm.MWReferenceListNode
 	var el = doc.createElement( 'div' ),
-		attribs = data.attributes;
+		attribs = data.attributes,
+		mwData = attribs.mw ? ve.copy( attribs.mw ) : {},
+		originalMw = attribs.originalMw;
 
-	mwData = attribs.mw ? ve.copy( attribs.mw ) : {};
 	ve.setProp( mwData, 'attrs', 'expand', (!!attribs.expand).toString() ); /* true/false must a string */
 
-	originalMw = attribs.originalMw;
 	if ( originalMw && ve.compare( mwData, JSON.parse( originalMw ) ) ) {
 		el.setAttribute( 'data-mw', originalMw );
 	} else {

--- a/extensions/VisualEditor/wikia/modules/ve/dm/ve.dm.WikiaGalleryNode.js
+++ b/extensions/VisualEditor/wikia/modules/ve/dm/ve.dm.WikiaGalleryNode.js
@@ -74,7 +74,7 @@ ve.dm.WikiaGalleryNode.static.toDomElements = function ( data, doc ) {
 		originalMw = attribs.originalMw;
 
 	if ( attribs.expand !== attribs.originalExpand ) {
-		ve.setProp( mwData, 'attrs', 'expand', attribs.expand ? "true" : undefined );
+		ve.setProp( mwData, 'attrs', 'expand', attribs.expand ? 'true' : undefined );
 	}
 
 	if ( originalMw && ve.compare( mwData, JSON.parse( originalMw ) ) ) {

--- a/extensions/VisualEditor/wikia/modules/ve/dm/ve.dm.WikiaGalleryNode.js
+++ b/extensions/VisualEditor/wikia/modules/ve/dm/ve.dm.WikiaGalleryNode.js
@@ -65,7 +65,7 @@ ve.dm.WikiaGalleryNode.static.toDomElements = function ( data, doc ) {
 		mwData = attribs.mw ? ve.copy( attribs.mw ) : {},
 		originalMw = attribs.originalMw;
 
-	ve.setProp( mwData, 'attrs', 'expand', (!!attribs.expand).toString() ); /* true/false must a string */
+	ve.setProp( mwData, 'attrs', 'expand', (!!attribs.expand).toString() ); /* true/false must be a string */
 
 	if ( originalMw && ve.compare( mwData, JSON.parse( originalMw ) ) ) {
 		el.setAttribute( 'data-mw', originalMw );


### PR DESCRIPTION
Changes seem pretty significant and this is because it's not only support for displaying but also for changing value of expand. So if you process transaction similar to this: ve.dm.Transaction.newFromAttributeChanges(ve.instances[0].view.model.documentModel, 8, {expand:false} you will notice that diff looks correct.

https://wikia-inc.atlassian.net/browse/VE-1613
