### PR TITLE
VE-1619: Resign from clearing HTML after rendering

### DIFF
--- a/extensions/VisualEditor/lib/ve/modules/ve/ce/ve.ce.BranchNode.js
+++ b/extensions/VisualEditor/lib/ve/modules/ve/ce/ve.ce.BranchNode.js
@@ -326,8 +326,10 @@ ve.ce.BranchNode.prototype.getSlugAtOffset = function ( offset ) {
  */
 ve.ce.BranchNode.prototype.setLive = function ( live ) {
 	ve.ce.Node.prototype.setLive.call( this, live );
-	for ( var i = 0; i < this.children.length; i++ ) {
-		this.children[i].setLive( live );
+	if ( !this.handlesOwnRendering() ) {
+		for ( var i = 0; i < this.children.length; i++ ) {
+			this.children[i].setLive( live );
+		}
 	}
 };
 

--- a/extensions/VisualEditor/lib/ve/modules/ve/ce/ve.ce.BranchNode.js
+++ b/extensions/VisualEditor/lib/ve/modules/ve/ce/ve.ce.BranchNode.js
@@ -199,9 +199,9 @@ ve.ce.BranchNode.prototype.onSplice = function ( index ) {
 						node.insertBefore( args[i].$element[j], firstChild );
 					}
 				}
-			}
-			if ( this.live !== args[i].isLive() ) {
-				args[i].setLive( this.live );
+				if ( this.live !== args[i].isLive() ) {
+					args[i].setLive( this.live );
+				}
 			}
 		}
 	}

--- a/extensions/VisualEditor/lib/ve/modules/ve/ce/ve.ce.BranchNode.js
+++ b/extensions/VisualEditor/lib/ve/modules/ve/ce/ve.ce.BranchNode.js
@@ -183,19 +183,21 @@ ve.ce.BranchNode.prototype.onSplice = function ( index ) {
 		}
 		for ( i = args.length - 1; i >= 2; i-- ) {
 			args[i].attach( this );
-			if ( index ) {
-				// DOM equivalent of $anchor.after( args[i].$element );
-				afterAnchor = $anchor[0].nextSibling;
-				parentNode = $anchor[0].parentNode;
-				for ( j = 0, length = args[i].$element.length; j < length; j++ ) {
-					parentNode.insertBefore( args[i].$element[j], afterAnchor );
-				}
-			} else {
-				// DOM equivalent of this.$element.prepend( args[j].$element );
-				node = this.$element[0];
-				firstChild = node.firstChild;
-				for ( j = args[i].$element.length - 1; j >= 0; j-- ) {
-					node.insertBefore( args[i].$element[j], firstChild );
+			if ( !this.handlesOwnRendering() ) {
+				if ( index ) {
+					// DOM equivalent of $anchor.after( args[i].$element );
+					afterAnchor = $anchor[0].nextSibling;
+					parentNode = $anchor[0].parentNode;
+					for ( j = 0, length = args[i].$element.length; j < length; j++ ) {
+						parentNode.insertBefore( args[i].$element[j], afterAnchor );
+					}
+				} else {
+					// DOM equivalent of this.$element.prepend( args[j].$element );
+					node = this.$element[0];
+					firstChild = node.firstChild;
+					for ( j = args[i].$element.length - 1; j >= 0; j-- ) {
+						node.insertBefore( args[i].$element[j], firstChild );
+					}
 				}
 			}
 			if ( this.live !== args[i].isLive() ) {
@@ -204,7 +206,9 @@ ve.ce.BranchNode.prototype.onSplice = function ( index ) {
 		}
 	}
 
-	this.setupSlugs();
+	if ( !this.handlesOwnRendering() ) {
+		this.setupSlugs();
+	}
 };
 
 /**

--- a/extensions/VisualEditor/lib/ve/modules/ve/ce/ve.ce.Node.js
+++ b/extensions/VisualEditor/lib/ve/modules/ve/ce/ve.ce.Node.js
@@ -70,6 +70,18 @@ ve.ce.Node.static.isFocusable = false;
  */
 ve.ce.Node.static.primaryCommandName = null;
 
+/**
+ * Whether this node handles its own rendering
+ *
+ * If false, ve.ce.Branchnode onSplice method will append this node's child elements to its element.
+ * If true, this node must handle rendering its children.
+ *
+ * @static
+ * @property {boolean}
+ * @inheritable
+ */
+ ve.ce.Node.static.handlesOwnRendering = false;
+
 /* Static Methods */
 
 /**
@@ -182,6 +194,15 @@ ve.ce.Node.prototype.handlesOwnChildren = function () {
  */
 ve.ce.Node.prototype.isFocusable = function () {
 	return this.constructor.static.isFocusable;
+};
+
+/**
+ * Check if the node renders its own children
+ *
+ * @returns {boolean} Node renders its own children
+ */
+ve.ce.Node.prototype.handlesOwnRendering = function () {
+	return this.constructor.static.handlesOwnRendering;
 };
 
 /**

--- a/extensions/VisualEditor/wikia/modules/ve/ce/ve.ce.WikiaGalleryNode.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ce/ve.ce.WikiaGalleryNode.js
@@ -45,6 +45,8 @@ OO.mixinClass( ve.ce.WikiaGalleryNode, ve.ce.FocusableNode );
 
 /* Static Properties */
 
+ve.ce.WikiaGalleryNode.static.handlesOwnRendering = true;
+
 ve.ce.WikiaGalleryNode.static.name = 'wikiaGallery';
 
 ve.ce.WikiaGalleryNode.static.tagName = 'div';
@@ -106,7 +108,6 @@ ve.ce.WikiaGalleryNode.prototype.setupGallery = function ( galleryData ) {
 			gallery = new Gallery( galleryOptions ).init();
 
 		this.$element
-			.html( '' )
 			.removeClass( function ( index, css ) {
 				return ( css.match ( /(^|\s)count-\S+/g ) || [] ).join( ' ' );
 			} )


### PR DESCRIPTION
Previously, GalleryItemNode and GalleryItemCaptionNode elements were attached to the GalleryNode and then removed. This was unnecessary and is fixed by this.
