### PR TITLE
MAIN-3084 Spotlights have disappeared globally

### DIFF
--- a/extensions/wikia/AdEngine/AdEngine2Hooks.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2Hooks.class.php
@@ -90,6 +90,10 @@ class AdEngine2Hooks {
 		$vars['adDriverLastDARTCallNoAds'] = []; // Used to hop by DART ads
 		$vars['adDriver2ForcedStatus'] = [];     // 3rd party code (eg. dart collapse slot template) can force AdDriver2 to respect unusual slot status
 
+		if ($wg->EnableOpenXSPC) {
+			$vars['wgEnableOpenXSPC'] = $wg->EnableOpenXSPC;
+		}
+
 		return true;
 	}
 


### PR DESCRIPTION
Bringing back the spotlights by exporting the wgEnableOpenXSPC variable to the client side.

This bug was introduced while working on ADEN-1318: #5090 
