### PR TITLE
VE-1620: Skip highlighting captions of gallery items

### DIFF
--- a/extensions/VisualEditor/wikia/modules/ve/ce/ve.ce.WikiaGalleryItemCaptionNode.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ce/ve.ce.WikiaGalleryItemCaptionNode.js
@@ -15,6 +15,9 @@
 ve.ce.WikiaGalleryItemCaptionNode = function VeCeWikiaGalleryItemCaptionNode( model, config ) {
 	// Parent constructor
 	ve.ce.WikiaGalleryItemCaptionNode.super.call( this, model, config );
+
+	// DOM changes
+	this.$element.children().addClass( 've-ce-noHighlight' );
 };
 
 /* Inheritance */


### PR DESCRIPTION
There is no need to highlight captions of gallery items becuase they are contained within gallery (for sure) which already gets a highlight.

https://wikia-inc.atlassian.net/browse/VE-1620
