### PR TITLE
MWEB-1028 P3 fix for a bug in the process of creating maps

### DIFF
--- a/extensions/wikia/WikiaMaps/js/WikiaMapsCreateMapModal.js
+++ b/extensions/wikia/WikiaMaps/js/WikiaMapsCreateMapModal.js
@@ -6,7 +6,7 @@ define(
 		'wikia.maps.createMap.tileSet',
 		'wikia.maps.createMap.preview'
 	],
-	function($, w, utils, tileSet, preview) {
+	function ($, w, utils, tileSet, preview) {
 		'use strict';
 
 		// placeholder for holding reference to modal instance
@@ -61,6 +61,10 @@ define(
 				modal.$buttons = modal.$element.find('.buttons').children();
 				modal.$innerContent = modal.$content.children('#intMapInnerContent');
 				modal.$errorContainer = $('.map-modal-error');
+				$(modal.$element).on('submit', '.create-map-form', function (event) {
+					event.preventDefault();
+					modal.trigger('createMap');
+				});
 
 				utils.bindEvents(modal, events);
 
@@ -79,4 +83,3 @@ define(
 		};
 	}
 );
-

--- a/extensions/wikia/WikiaMaps/js/WikiaMapsCreateMapModal.js
+++ b/extensions/wikia/WikiaMaps/js/WikiaMapsCreateMapModal.js
@@ -61,7 +61,7 @@ define(
 				modal.$buttons = modal.$element.find('.buttons').children();
 				modal.$innerContent = modal.$content.children('#intMapInnerContent');
 				modal.$errorContainer = $('.map-modal-error');
-				$(modal.$element).on('submit', '.create-map-form', function (event) {
+				modal.$element.on('submit', '.create-map-form', function (event) {
 					event.preventDefault();
 					modal.trigger('createMap');
 				});

--- a/extensions/wikia/WikiaMaps/js/WikiaMapsPoiCategories.js
+++ b/extensions/wikia/WikiaMaps/js/WikiaMapsPoiCategories.js
@@ -164,6 +164,10 @@ define('wikia.maps.poiCategories',
 					modal.trigger('uploadMarkerImage', event.target);
 				});
 
+				modal.$element.on('submit', '.intMapPoiCategoriesForm', function (event) {
+					event.preventDefault();
+				});
+
 				modal.show();
 			});
 		}


### PR DESCRIPTION
While creating a map user have two forms when is asked about maps name and then about POI categories for the map. In both forms when she focused mouse on any input filed and hit enter key or "Go" button from iPad keyboard the page was redirected and the map creation process was interrupted without possibility to get back to it.

Changes below fix it in two ways:
- in the first step of modal when there is only one input field after hitting enter user is moved to second step,
- in the second step when she can create many POI categories we just don't allow submitting the form in any other way than clicking "Next" button in the modal.
