### PR TITLE
MWEB-1057: P3 fix for Wikia Maps - changing error message presented to a user

### DIFF
--- a/extensions/wikia/WikiaMaps/WikiaMaps.i18n.php
+++ b/extensions/wikia/WikiaMaps/WikiaMaps.i18n.php
@@ -136,9 +136,6 @@ $messages[ 'en' ] = [
 	'wikia-interactive-maps-poi-categories-default-character' => 'Character',
 	'wikia-interactive-maps-poi-categories-default-item' => 'Item',
 	'wikia-interactive-maps-poi-categories-default-event' => 'Event',
-
-	// errors & exceptions
-	'wikia-interactive-maps-permission-error' => 'Sorry, you do not have permission to edit on this wikia. If you think this was a mistake, please contact an administrator.',
 ];
 
 $messages[ 'pl' ] = [

--- a/extensions/wikia/WikiaMaps/exceptions/WikiaMapsPermissionException.class.php
+++ b/extensions/wikia/WikiaMaps/exceptions/WikiaMapsPermissionException.class.php
@@ -3,6 +3,6 @@ class WikiaMapsPermissionException extends ForbiddenException {
 	protected $message = "No Permissions";
 
 	public function __construct() {
-		$this->details = wfMessage( 'wikia-interactive-maps-permission-error' )->plain();
+		$this->details = wfMessage( 'badaccess-group0' )->plain();
 	}
 }


### PR DESCRIPTION
Changed error message which appears while deleting a map when user does not have proper rights.
