### PR TITLE
VE-1620: Apply ve-ce-noHighlight not only to the paragraph (which is a wrapper) but also to all element children.

### DIFF
--- a/extensions/VisualEditor/wikia/modules/ve/ce/ve.ce.WikiaGalleryItemCaptionNode.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ce/ve.ce.WikiaGalleryItemCaptionNode.js
@@ -17,7 +17,7 @@ ve.ce.WikiaGalleryItemCaptionNode = function VeCeWikiaGalleryItemCaptionNode( mo
 	ve.ce.WikiaGalleryItemCaptionNode.super.call( this, model, config );
 
 	// DOM changes
-	this.$element.children().addClass( 've-ce-noHighlight' );
+	this.$element.find( '*' ).addClass( 've-ce-noHighlight' );
 };
 
 /* Inheritance */


### PR DESCRIPTION
This is to solve a problem when some HTML elements are using in the caption - for instance bold or italic.

https://wikia-inc.atlassian.net/browse/VE-1620
