### PR TITLE
(CE-1099) Fix additional calls of the ArticleDeleteComplete hook

### DIFF
--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -464,16 +464,11 @@ class ArticleComment {
 	public function doDeleteComment( $reason, $suppress = false ){
 		global $wgUser;
 		$error = '';
-		$wikiPage = new WikiPage($this->mTitle);
+		$wikiPage = new WikiPage( $this->mTitle );
 		$id = $wikiPage->getId();
 
-		//we need to run all the hook manual :/
-		if ( wfRunHooks( 'ArticleDelete', [&$wikiPage, &$wgUser, &$reason, &$error] ) ) {
-			if( $wikiPage->doDeleteArticle( $reason, $suppress ) ) {
-				$this->mTitle->getPrefixedText();
-				wfRunHooks( 'ArticleDeleteComplete', [&$wikiPage, &$wgUser, $reason, $id] );
-				return true;
-			}
+		if ( $wikiPage->doDeleteArticle( $reason, $suppress ) ) {
+			return true;
 		}
 
 		return false;

--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -462,10 +462,7 @@ class ArticleComment {
 	 * @access public
 	 */
 	public function doDeleteComment( $reason, $suppress = false ){
-		global $wgUser;
-		$error = '';
 		$wikiPage = new WikiPage( $this->mTitle );
-		$id = $wikiPage->getId();
 
 		if ( $wikiPage->doDeleteArticle( $reason, $suppress ) ) {
 			return true;

--- a/extensions/wikia/UserRollback/maintenance/rollbackEditsMulti.php
+++ b/extensions/wikia/UserRollback/maintenance/rollbackEditsMulti.php
@@ -189,7 +189,6 @@ class RollbackEditsMulti extends Maintenance {
 	}
 
 	private function deleteArticle( $article, $reason, $suppress = false, &$error = '' ) {
-		global $wgOut, $wgUser;
 		$id = $article->getTitle()->getArticleID( Title::GAID_FOR_UPDATE );
 
 		if ( $article->doDeleteArticle( $reason, $suppress, $id ) ) {

--- a/extensions/wikia/UserRollback/maintenance/rollbackEditsMulti.php
+++ b/extensions/wikia/UserRollback/maintenance/rollbackEditsMulti.php
@@ -24,9 +24,9 @@
 require_once( dirname(__FILE__) . '/../../../../maintenance/Maintenance.php' );
 
 class RollbackEditsMulti extends Maintenance {
-	
+
 	const USER_NAME = 'Maintenance script';
-	
+
 	public function __construct() {
 		parent::__construct();
 		$this->mDescription = "Rollback all edits by a given user or IP provided they're the most recent edit";
@@ -40,22 +40,22 @@ class RollbackEditsMulti extends Maintenance {
 
 	public function execute() {
 		global $wgUser, $wgSharedDB;
-		
+
 		if ( $this->getOption( 'onlyshared', false ) && empty($wgSharedDB) ) {
 			$this->output( "Skipping wiki due to non-shared users database\n" );
 			return;
 		}
-		
+
 		$wgUser = User::newFromName(self::USER_NAME);
 		$bot = true;
-		
+
 		$time = $this->getOption( 'time' );
 		$time = wfTimestamp( TS_UNIX, $time );
 		if ( !$time ) {
 			$this->error( 'Invalid time', true );
 		}
 		$time = wfTimestamp( TS_MW, $time );
-		
+
 		$users = explode('|', $this->getOption( 'users' ));
 		foreach ($users as $user) {
 			$username = User::isIP( $user ) ? $user : User::getCanonicalName( $user );
@@ -84,9 +84,9 @@ class RollbackEditsMulti extends Maintenance {
 			$this->output( "No suitable titles to be rolled back\n" );
 			return;
 		}
-		
+
 		$this->output( "Found " . count($titles) . " title(s) to process\n" );
-		
+
 		global $wgTitle;
 		foreach ( $titles as $t ) {
 			$wgTitle = $t;
@@ -111,8 +111,8 @@ class RollbackEditsMulti extends Maintenance {
 		$results = $dbr->select(
 			array( 'page', 'revision' ),
 			array( 'page_namespace', 'page_title' ),
-			array( 
-				'page_latest = rev_id', 
+			array(
+				'page_latest = rev_id',
 				'rev_user_text' => $users,
 				"rev_timestamp >= \"{$time}\"",
 			),
@@ -126,20 +126,20 @@ class RollbackEditsMulti extends Maintenance {
 		}
 		return $titles;
 	}
-	
+
 	private function rollbackTitle( $title, $users, $time, $summary, &$messages = '' ) {
 		global $wgUser;
-		
+
 		// build article object and find article id
 		$a = new Article($title);
 		$pageId = $a->getID();
-		
+
 		// check if article exists
 		if ( $pageId <= 0 ) {
 			$messages = 'page not found';
 			return false;
 		}
-		
+
 		// fetch revisions from this article
 		$dbw = wfGetDB( DB_MASTER );
 		$res = $dbw->select(
@@ -153,18 +153,18 @@ class RollbackEditsMulti extends Maintenance {
 				'ORDER BY' => 'rev_id DESC',
 			)
 		);
-		
+
 		// find the newest edit done by other user
 		$revertRevId = false;
 		while ( $row = $dbw->fetchObject($res) ) {
 			if ( !in_array( $row->rev_user_text, $users ) || $row->rev_timestamp < $time ) {
 				$revertRevId = $row->rev_id;
 				break;
-			} 
+			}
 		}
 		$dbw->freeResult($res);
-		
-		
+
+
 		if ($revertRevId) { // found an edit by other user - reverting
 			$rev = Revision::newFromId($revertRevId);
 			$text = $rev->getRawText();
@@ -187,17 +187,15 @@ class RollbackEditsMulti extends Maintenance {
 		}
 		return false;
 	}
-	
+
 	private function deleteArticle( $article, $reason, $suppress = false, &$error = '' ) {
 		global $wgOut, $wgUser;
 		$id = $article->getTitle()->getArticleID( Title::GAID_FOR_UPDATE );
 
-		if ( wfRunHooks( 'ArticleDelete', array( &$article, &$wgUser, &$reason, &$error ) ) ) {
-			if ( $article->doDeleteArticle( $reason, $suppress, $id ) ) {
-				wfRunHooks( 'ArticleDeleteComplete', array( &$article, &$wgUser, $reason, $id ) );
-				return true;
-			}
+		if ( $article->doDeleteArticle( $reason, $suppress, $id ) ) {
+			return true;
 		}
+
 		return false;
 	}
 }

--- a/maintenance/deleteBatch.php
+++ b/maintenance/deleteBatch.php
@@ -101,7 +101,6 @@ class DeleteBatch extends Maintenance {
 			$success = $page->doDeleteArticle( $reason, false, 0, false, $error, $user );
 			$dbw->commit();
 			if ( $success ) {
-				wfRunHooks('ArticleDeleteComplete', array(&$art, &$wgUser, $reason, $page_id));
 				$this->output( " Deleted!\n" );
 			} else {
 				$this->output( " FAILED to delete article\n" );

--- a/maintenance/wikia/deleteOn.php
+++ b/maintenance/wikia/deleteOn.php
@@ -88,9 +88,6 @@ if ( $removed == 0 ) {
 	$page_id = $page->getArticleID();
 	$art = new Article( $page );
 	$success = $art->doDeleteArticle( $reason, $suppress );
-	if ( $success ) {
-		wfRunHooks('ArticleDeleteComplete', array(&$art, &$wgUser, $reason, $page_id));
-	}
 }
 $dbw->commit();
 


### PR DESCRIPTION
The ArticleDeleteComplete hook was changed in MW 1.18 from using an
Article object as its first argument to using a WikiPage object. We
ran the hook in a few extra places, but did not update these hooks
when we upgraded from MW 1.16 to MW 1.19. When a correct type hint of
WikiPage was used recently in a method attached to this hook, it
started causing fatal errors.

This removes the custom 'ArticleDelete' and 'ArticleDeleteComplete'
hook calls as they are no longer needed. In MW 1.16, the hooks were
run from Article::doDelete not from Article::doDeleteArticle which
is what is used in these extensions. As such, the hooks were run
manually before and after calling Article::doDeleteArticle. However,
in MW 1.19, the hooks are run from WikiPage::doDeleteArticleReal
meaning that they are run anyway, and we've been running the hooks
twice per deletion in these extensions since the 1.19 upgrade.

Fixes the following fatal error:

PHP Catchable fatal error:  Argument 1 passed to
ApiHooks::onArticleDeleteComplete() must be an instance of WikiPage,
instance of Article given in includes/wikia/api/ApiHooks.class.php on
line 53.

/cc @macbre @Wikia/community-engineering @nandy-andy 
