### PR TITLE
CON-2029 fix for two line caption in slideshows

### DIFF
--- a/extensions/wikia/Venus/styles/article/media.scss
+++ b/extensions/wikia/Venus/styles/article/media.scss
@@ -1,6 +1,7 @@
 @import '/skins/wikia/shared.css';
 @import '../libs/foundation.custom/components/grid.mixins';
 @import 'extensions/wikia/MediaGallery/styles/MediaGallery';
+@import 'extensions/wikia/Venus/styles/typographyMixins';
 @import 'video';
 
 .wikia-gallery {
@@ -51,4 +52,8 @@
 		}
 	}
 
+	.wikia-slideshow-image-caption {
+		@include font-size-xs;
+		line-height: 22px;
+	}
 }


### PR DESCRIPTION
Fix for two line caption broken in slideshow on Venus.
Values set in scss files are ported from oasis styles.
