### PR TITLE
VE-1627: Fix for problem with Wikia One

### DIFF
--- a/includes/wikia/resourceloader/ResourceLoaderHooks.class.php
+++ b/includes/wikia/resourceloader/ResourceLoaderHooks.class.php
@@ -51,7 +51,7 @@ class ResourceLoaderHooks {
 		$sources = $resourceLoader->getSources();
 
 		// staff and internal special case
-		if ( $wgCityId === null ) {
+		if ( $wgCityId === null || $wgCityId === 11 ) {
 			$resourceLoader->addSource('common',$sources['local']);
 			return true;
 		}


### PR DESCRIPTION
No Wikia One have an ID (which previously it didn't) which makes certain conditions evaluate incorrectly.

https://wikia-inc.atlassian.net/browse/VE-1627
