### PR TITLE
MAIN-3096: Pass correct path-prefix when making a request to Vignette

### DIFF
--- a/extensions/VisualEditor/wikia/VisualEditor.hooks.php
+++ b/extensions/VisualEditor/wikia/VisualEditor.hooks.php
@@ -55,7 +55,7 @@ class VisualEditorWikiaHooks {
 	 * Adds extra variables to the page config.
 	 */
 	public static function onMakeGlobalVariablesScript( array &$vars, OutputPage $out ) {
-		global $wgMaxUploadSize, $wgEnableVisualEditorUI, $wgEnableWikiaInteractiveMaps, $wgIntMapConfig, $wgUser;
+		global $wgMaxUploadSize, $wgEnableVisualEditorUI, $wgEnableWikiaInteractiveMaps, $wgIntMapConfig, $wgUser, $wgUploadPath;
 		$vars[ 'wgMaxUploadSize' ] = $wgMaxUploadSize;
 		$vars[ 'wgEnableVisualEditorUI' ] = !empty( $wgEnableVisualEditorUI );
 		$vars[ 'wgEnableWikiaInteractiveMaps' ] = !empty( $wgEnableWikiaInteractiveMaps );
@@ -71,8 +71,9 @@ class VisualEditorWikiaHooks {
 		}
 		// Note: even if set as integer, option value is retrieved as string
 		if ( $wgUser->getOption( 'showVisualEditorTransitionDialog' ) === '1' ) {
-			$vars['showVisualEditorTransitionDialog'] = 1;
+			$vars[ 'showVisualEditorTransitionDialog' ] = 1;
 		}
+		$vars[ 'VignettePathPrefix' ] = VignetteRequest::parsePathPrefix( $wgUploadPath );
 		return true;
 	}
 

--- a/extensions/VisualEditor/wikia/modules/ve/ce/ve.ce.WikiaGalleryNode.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ce/ve.ce.WikiaGalleryNode.js
@@ -124,7 +124,7 @@ ve.ce.WikiaGalleryNode.prototype.setupGallery = function ( galleryData ) {
 };
 
 ve.ce.WikiaGalleryNode.static.getThumbUrl = function ( url ) {
-	var vignettePathPrefix = mw.config.get('VignettePathPrefix'),
+	var vignettePathPrefix = mw.config.get( 'VignettePathPrefix' ),
 		height = 480,
 		width = 480,
 		parts = [

--- a/extensions/VisualEditor/wikia/modules/ve/ce/ve.ce.WikiaGalleryNode.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ce/ve.ce.WikiaGalleryNode.js
@@ -124,14 +124,19 @@ ve.ce.WikiaGalleryNode.prototype.setupGallery = function ( galleryData ) {
 };
 
 ve.ce.WikiaGalleryNode.static.getThumbUrl = function ( url ) {
-	var height = 480,
-		width = 480;
-	return [
-		url.substr( 0, url.indexOf( '/revision/' ) ),
-		'/revision/latest/zoom-crop',
-		'/width/' + width + '/height/' + height,
-		'?' + url.match( /cb=\d*/gm ) + '&fill=transparent'
-	].join( '' );
+	var vignettePathPrefix = mw.config.get('VignettePathPrefix'),
+		height = 480,
+		width = 480,
+		parts = [
+			url.substr( 0, url.indexOf( '/revision/' ) ),
+			'/revision/latest/zoom-crop',
+			'/width/' + width + '/height/' + height,
+			'?' + url.match( /cb=\d*/gm ) + '&fill=transparent'
+		];
+	if ( vignettePathPrefix ) {
+		parts.push( '&path-prefix=' + vignettePathPrefix );
+	}
+	return parts.join( '' );
 };
 
 ve.ce.WikiaGalleryNode.static.getThumbHtml = function ( linkUrl, imageUrl, name ) {


### PR DESCRIPTION
Vignette requires to pass correct path-prefix to it when sending a request. For unknown new galleries in VE were not tested in different languages than EN and this problem didn't pop out (path-prefix for English is null).

This whole approach is sort of temporary and will be "re-done" when we get a proper Vignette library on the client side.

https://wikia-inc.atlassian.net/browse/MAIN-3096
