### PR TITLE
VID-2103 Async caching for views to replace cron caching

### DIFF
--- a/includes/wikia/AsyncCache.php
+++ b/includes/wikia/AsyncCache.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Wikia\Cache;
+
 /**
  * Class AsyncCache
  *
@@ -105,7 +107,7 @@ class AsyncCache {
 
 		$this->callbackParams = [];
 
-		$this->cache = $cache ? $cache : F::app()->wg->Memc;
+		$this->cache = $cache ? $cache : \F::app()->wg->Memc;
 	}
 
 	/**
@@ -341,7 +343,7 @@ class AsyncCache {
 	}
 
 	private function generateValueNow() {
-		$task = new \Wikia\Cache\AsyncCacheTask();
+		$task = new AsyncCacheTask();
 		$value = $task->generate(
 			$this->key,
 			$this->callback,
@@ -352,7 +354,7 @@ class AsyncCache {
 	}
 
 	private function scheduleValueGeneration() {
-		$this->task = ( new \Wikia\Cache\AsyncCacheTask() )->wikiId( F::app()->wg->CityId );
+		$this->task = ( new AsyncCacheTask() )->wikiId( \F::app()->wg->CityId );
 		$this->task->dupCheck();
 		$this->task->call( 'generate',
 			$this->key, $this->callback, $this->callbackParams,

--- a/includes/wikia/AsyncCacheTask.php
+++ b/includes/wikia/AsyncCacheTask.php
@@ -24,9 +24,9 @@ class AsyncCacheTask extends BaseTask {
 	public static function generate( $key, callable $func, array $args, array $options ) {
 
 		// Get TTLs to use for positive response and negative (empty) response
-		$ttl = empty( $options[ 'ttl' ] ) ? \AsyncCache::DEFAULT_TTL : $options[ 'ttl' ];
+		$ttl = empty( $options[ 'ttl' ] ) ? AsyncCache::DEFAULT_TTL : $options[ 'ttl' ];
 		$negTTL = empty( $options[ 'negativeResponseTTL' ] )
-			? \AsyncCache::DEFAULT_NEGATIVE_RESPONSE_TTL
+			? AsyncCache::DEFAULT_NEGATIVE_RESPONSE_TTL
 			:  $options[ 'negativeResponseTTL' ];
 
 		// The function has the ability to determine what it considers to be a negative response since

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -693,6 +693,8 @@ include_once( "$IP/extensions/wikia/CreateNewWiki/CreateWikiLocalJob.php" );
  */
 require_once( "{$IP}/extensions/wikia/Tasks/Tasks.setup.php");
 require_once( "{$IP}/includes/wikia/tasks/autoload.php");
+require_once( "{$IP}/includes/wikia/AsyncCacheTask.php");
+require_once( "{$IP}/includes/wikia/AsyncCache.php");
 
 /*
  * @name wgWikiaStaffLanguages

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -272,6 +272,8 @@ $wgAutoloadClasses[ 'Wikia\\Blogs\\BlogTask'          ] = "$IP/extensions/wikia/
 $wgAutoloadClasses[ 'TemplatePageHelper'              ] = "$IP/includes/wikia/helpers/TemplatePageHelper.php";
 $wgAutoloadClasses[ 'CrossOriginResourceSharingHeaderHelper' ] = "$IP/includes/wikia/helpers/CrossOriginResourceSharingHeaderHelper.php";
 $wgAutoloadClasses[ 'VignetteRequest'                 ] = "{$IP}/includes/wikia/VignetteRequest.php";
+$wgAutoloadClasses[ 'Wikia\\Cache\\AsyncCacheTask'    ] = "$IP/includes/wikia/AsyncCacheTask.php";
+$wgAutoloadClasses[ 'Wikia\\Cache\\AsyncCache'        ] = "$IP/includes/wikia/AsyncCache.php";
 
 /**
  * Resource Loader enhancements
@@ -693,8 +695,6 @@ include_once( "$IP/extensions/wikia/CreateNewWiki/CreateWikiLocalJob.php" );
  */
 require_once( "{$IP}/extensions/wikia/Tasks/Tasks.setup.php");
 require_once( "{$IP}/includes/wikia/tasks/autoload.php");
-require_once( "{$IP}/includes/wikia/AsyncCacheTask.php");
-require_once( "{$IP}/includes/wikia/AsyncCache.php");
 
 /*
  * @name wgWikiaStaffLanguages

--- a/includes/wikia/services/MediaQueryService.class.php
+++ b/includes/wikia/services/MediaQueryService.class.php
@@ -624,13 +624,12 @@ class MediaQueryService extends WikiaService {
 		$asyncCacheEnabled = !empty( $app->wg->EnableAsyncVideoViewCache );
 
 		$hashTitle = md5( $title );
-		$memKeyBucket = substr( $hashTitle, 0, 2 );
 		$memKeyBase = self::getMemKeyTotalVideoViews( $asyncCacheEnabled );
-		$cacheKey = $memKeyBase . '-' . $memKeyBucket;
 
 		// @TODO: Remove EnableAsyncVideoViewCache and the else clause,
 		// after verifying the async caching solution works (@see VID-2103)
 		if ( $asyncCacheEnabled ) {
+			$cacheKey = $memKeyBase . '-' . $hashTitle;
 			$videoViews = ( new AsyncCache() )
 				->key( $cacheKey )
 				->ttl( $cacheTtl )
@@ -638,6 +637,7 @@ class MediaQueryService extends WikiaService {
 				->staleOnMiss( $staleCacheTtl )
 				->value();
 		} else {
+			$cacheKey = $memKeyBase . '-' . substr( $hashTitle, 0, 2 );
 			$videoList = $app->wg->Memc->get( $cacheKey );
 			if ( !isset( $videoList[ $hashTitle ] ) ) {
 				$viewCount = VideoInfoHelper::getTotalViewsFromTitle( $title );

--- a/maintenance/wikia/runOnCluster.php
+++ b/maintenance/wikia/runOnCluster.php
@@ -185,7 +185,7 @@ class RunOnCluster extends Maintenance {
 		foreach ( $clusterWikis as $cityId => $dbname ) {
 			// Catch connection errors and log them
 			try {
-				$result = $this->db->query( "use `$dbname`" );
+				$result = $this->db->selectDB( $dbname );
 			} catch ( Exception $e ) {
 				fwrite( STDERR, "ERROR: ".$e->getMessage()."\n" );
 			}


### PR DESCRIPTION
RFCR @garthwebb @owend 

This is the very first usage of the mighty [async caching](https://github.com/Wikia/app/pull/5045) for caching video view counts on demand rather than via running a cron job every 2 hours to retrieve and cache ALL video views on ALL clustered wikias. See [VID-2103](https://wikia-inc.atlassian.net/browse/VID-2103).

This is done via a new WikiFactory variable `wgEnableAsyncVideoViewCache`. This allows controlled rollout of this solution. Once this is solution proves effective, the variable will be removed.

This also:
- Uses selectDB() in runOnCluster()
- Loads Async cache files in defaultSettings 
