### PR TITLE
(CE-937) Use staff welcome message for non-admin Helpers

### DIFF
--- a/extensions/wikia/HAWelcome/HAWelcomeTask.php
+++ b/extensions/wikia/HAWelcome/HAWelcomeTask.php
@@ -401,8 +401,11 @@ class HAWelcomeTask extends BaseTask {
 		// Is sender a staff member and not a local admin?
 		$senderGroups = $this->senderObject->getEffectiveGroups();
 
-		$welcomeMessageKey .= ( in_array( 'staff', $senderGroups ) && !in_array( 'sysop', $senderGroups ) )
-			? '-staff' : '';
+		if ( ( in_array( 'staff', $senderGroups ) || in_array( 'helper', $senderGroups ) )
+			&& !in_array( 'sysop', $senderGroups )
+		) {
+			$welcomeMessageKey .= '-staff';
+		}
 
 		$sPrefixedText = $this->title->getPrefixedText();
 


### PR DESCRIPTION
Make helpers who are not local admins use the staff welcome message
when welcoming users. Some helpers are listed as the staff member for a
language which is used as a fallback to determine the welcomer when
there was no recently active admin. In those cases, they should use
the staff welcome message so they are not confused for a local admin.

/cc @Wikia/community-engineering 
