### PR TITLE
preserve query params when getting a thumb or full image url

### DIFF
--- a/resources/wikia/modules/spec/thumbnailer.spec.js
+++ b/resources/wikia/modules/spec/thumbnailer.spec.js
@@ -16,25 +16,25 @@ describe('thumbnailer', function () {
 
 	it('returns proper nocrop thumbnail URL', function () {
 		expect(thumbnailer.getThumbURL(legacyThumbnailerUrl, 'nocrop', 660, 330)).toBe('http://images2.wikia.nocookie.net/__cb20111213221641/poznan/pl/images/thumb/0/06/Gzik.jpg/660x330-Gzik.png');
-		expect(thumbnailer.getThumbURL(thumbnailerUrl, 'nocrop', 90, 55)).toBe('http://vignette2.wikia.nocookie.net/arresteddevelopment/f/fb/1x08_My_Mother_the_Car_%2822%29.png/revision/latest/fixed-aspect-ratio/width/90/height/55');
+		expect(thumbnailer.getThumbURL(thumbnailerUrl, 'nocrop', 90, 55)).toBe('http://vignette2.wikia.nocookie.net/arresteddevelopment/f/fb/1x08_My_Mother_the_Car_%2822%29.png/revision/latest/fixed-aspect-ratio/width/90/height/55?cb=20120214071005');
 		expect(thumbnailer.getThumbURL(fullSizeImageUrl, 'nocrop', 90, 55)).toBe('http://img2.wikia.nocookie.net/__cb20140419225924/thelastofus/images/thumb/f/ff/Joel.png/90x55-Joel.png');
 	});
 
 	it('returns proper video thumbnail URL', function () {
 		expect(thumbnailer.getThumbURL(legacyThumbnailerUrl, 'video', 660, 330)).toBe('http://images2.wikia.nocookie.net/__cb20111213221641/poznan/pl/images/thumb/0/06/Gzik.jpg/660x330-Gzik.png');
-		expect(thumbnailer.getThumbURL(thumbnailerUrl, 'video', 90, 55)).toBe('http://vignette2.wikia.nocookie.net/arresteddevelopment/f/fb/1x08_My_Mother_the_Car_%2822%29.png/revision/latest/fixed-aspect-ratio/width/90/height/55');
+		expect(thumbnailer.getThumbURL(thumbnailerUrl, 'video', 90, 55)).toBe('http://vignette2.wikia.nocookie.net/arresteddevelopment/f/fb/1x08_My_Mother_the_Car_%2822%29.png/revision/latest/fixed-aspect-ratio/width/90/height/55?cb=20120214071005');
 		expect(thumbnailer.getThumbURL(fullSizeImageUrl, 'video', 90, 55)).toBe('http://img2.wikia.nocookie.net/__cb20140419225924/thelastofus/images/thumb/f/ff/Joel.png/90x55-Joel.png');
 	});
 
 	it('returns proper image thumbnail URL', function () {
 		expect(thumbnailer.getThumbURL(legacyThumbnailerUrl, 'image', 660, 330)).toBe('http://images2.wikia.nocookie.net/__cb20111213221641/poznan/pl/images/thumb/0/06/Gzik.jpg/660x330x2-Gzik.png');
-		expect(thumbnailer.getThumbURL(thumbnailerUrl, 'image', 90, 55)).toBe('http://vignette2.wikia.nocookie.net/arresteddevelopment/f/fb/1x08_My_Mother_the_Car_%2822%29.png/revision/latest/zoom-crop/width/90/height/55');
+		expect(thumbnailer.getThumbURL(thumbnailerUrl, 'image', 90, 55)).toBe('http://vignette2.wikia.nocookie.net/arresteddevelopment/f/fb/1x08_My_Mother_the_Car_%2822%29.png/revision/latest/zoom-crop/width/90/height/55?cb=20120214071005');
 		expect(thumbnailer.getThumbURL(fullSizeImageUrl, 'image', 90, 55)).toBe('http://img2.wikia.nocookie.net/__cb20140419225924/thelastofus/images/thumb/f/ff/Joel.png/90x55x2-Joel.png');
 	});
 
 	it('returns proper full image URL', function () {
 		expect(thumbnailer.getImageURL(legacyThumbnailerUrl)).toBe('http://images2.wikia.nocookie.net/__cb20111213221641/poznan/pl/images/0/06/Gzik.jpg');
-		expect(thumbnailer.getImageURL(thumbnailerUrl)).toBe('http://vignette2.wikia.nocookie.net/arresteddevelopment/f/fb/1x08_My_Mother_the_Car_%2822%29.png/revision/latest');
+		expect(thumbnailer.getImageURL(thumbnailerUrl)).toBe('http://vignette2.wikia.nocookie.net/arresteddevelopment/f/fb/1x08_My_Mother_the_Car_%2822%29.png/revision/latest?cb=20120214071005');
 		expect(thumbnailer.getImageURL(fullSizeImageUrl)).toBe(fullSizeImageUrl);
 	});
 });

--- a/resources/wikia/modules/thumbnailer.js
+++ b/resources/wikia/modules/thumbnailer.js
@@ -34,10 +34,10 @@
 			height = height || 0;
 			width = (width || 50) + (height ? '' : 'px');
 
-			if (isThumbUrl(url)) {
+			if (isLegacyThumbnailerUrl(url)) {
 				// URL points to a thumbnail, remove crop and size
 				url = clearThumbOptions(url);
-			} else {
+			} else if (!isThumbUrl(url)) {
 				// URL points to an image, convert to thumbnail URL
 				url = switchPathTo(url, 'thumb');
 			}
@@ -51,8 +51,14 @@
 		 * @param {String} url The URL to a thumbnail
 		 */
 		function getImageURL(url) {
-			if (isThumbUrl(url)) {
-				// URL points to a thumbnail
+			if (isThumbnailerUrl(url)) {
+				var query = getThumbQueryParams(url);
+				url = clearThumbOptions(url);
+
+				if (query) {
+					url += '?' + query;
+				}
+			} else if (isLegacyThumbnailerUrl(url)) {
 				url = clearThumbOptions(url);
 				url = switchPathTo(url, 'image');
 			}
@@ -108,6 +114,17 @@
 				clearedOptionsUrl = url.substring(0, url.lastIndexOf('/'));
 			}
 			return clearedOptionsUrl;
+		}
+
+		function getThumbQueryParams(url) {
+			var query = null,
+				queryStart = url.indexOf('?');
+
+			if (queryStart != -1) {
+				query = url.substring(url.indexOf('?') + 1);
+			}
+
+			return query;
 		}
 
 		/**
@@ -169,8 +186,17 @@
 		 * @returns {String}
 		 */
 		function addThumbnailerParameters(url, type, width, height) {
-			var thumbnailerRoute = (type === 'video' || type === 'nocrop') ? '/fixed-aspect-ratio' : '/zoom-crop';
-			return url + thumbnailerRoute + '/width/' + width + '/height/' + height;
+			var originalUrl = clearThumbOptions(url),
+				queryParams = getThumbQueryParams(url),
+				thumbnailerRoute = (type === 'video' || type === 'nocrop') ? '/fixed-aspect-ratio' : '/zoom-crop';
+
+			url = originalUrl + thumbnailerRoute + '/width/' + width + '/height/' + height;
+
+			if (queryParams) {
+				url += '?' + queryParams;
+			}
+
+			return url;
 		}
 
 		/**


### PR DESCRIPTION
@jsutterfield 
https://wikia-inc.atlassian.net/browse/VID-2122

Preserving query params when modifying a Vignette url guarantees the `path-prefix` and `cb` params are passed to Fastly/Vignette, which ensures the correct image is returned to the client.
