### PR TITLE
UC-73 Fix Facebook sign up

### DIFF
--- a/extensions/wikia/UserLogin/FacebookSignupController.class.php
+++ b/extensions/wikia/UserLogin/FacebookSignupController.class.php
@@ -66,11 +66,17 @@ class FacebookSignupController extends WikiaController {
 			return false;
 		}
 
-		$this->fbEmail = $resp->getVal( 'contact_email', false );
-		$email = $resp->getVal( 'email', false );
-		// check for proxy email
-		if ( $this->fbEmail != $email ) {
-			$this->fbEmail = wfMessage( 'usersignup-facebook-proxy-email' )->escaped();
+		// The new FB SDK doesn't define contact_email
+		if ( F::app()->wg->EnableFacebookClientExt ) {
+			$this->fbEmail = $resp->getVal( 'email', false );
+		} else {
+			$this->fbEmail = $resp->getVal( 'contact_email', false );
+			$email = $resp->getVal( 'email', false );
+
+			// check for proxy email
+			if ( $this->fbEmail != $email ) {
+				$this->fbEmail = wfMessage( 'usersignup-facebook-proxy-email' )->escaped();
+			}
 		}
 
 		$this->loginToken = UserLoginHelper::getSignupToken();

--- a/extensions/wikia/UserLogin/UserLoginFacebookForm.class.php
+++ b/extensions/wikia/UserLogin/UserLoginFacebookForm.class.php
@@ -66,6 +66,12 @@ class UserLoginFacebookForm extends UserLoginForm {
 	 * @param User $user Wikia account
 	 */
 	private function connectWithFacebook(User $user) {
-		FBConnectDB::addFacebookID($user, $this->fbUserId);
+		if ( F::app()->wg->EnableFacebookClientExt ) {
+			$map = new FacebookMapModel();
+			$map->relate( $user->getId(), $this->fbUserId);
+			$map->save();
+		} else {
+			FBConnectDB::addFacebookID( $user, $this->fbUserId );
+		}
 	}
 }


### PR DESCRIPTION
- Update how sessions are created, saving user access tokens in Memcache for a few hours
- Add some error checking
- Fixed some places that still used the old FBConnect code
- Eliminate use of contact_email which doesn't exist

https://wikia-inc.atlassian.net/browse/UC-73
