### PR TITLE
UC-84 Make sure maintenance/CLI scripts run properly w/ FacebookClientHooks

### DIFF
--- a/extensions/wikia/FacebookClient/FacebookClientHooks.class.php
+++ b/extensions/wikia/FacebookClient/FacebookClientHooks.class.php
@@ -19,7 +19,7 @@ class FacebookClientHooks {
 	public static function UserLoadFromSession( $user, &$result ) {
 		$wg = F::app()->wg;
 
-		if ( !$wg->Title instanceof Title ) {
+		if ( $wg->CommandLineMode ) {
 			return true;
 		}
 

--- a/extensions/wikia/FacebookClient/FacebookClientHooks.class.php
+++ b/extensions/wikia/FacebookClient/FacebookClientHooks.class.php
@@ -19,6 +19,10 @@ class FacebookClientHooks {
 	public static function UserLoadFromSession( $user, &$result ) {
 		$wg = F::app()->wg;
 
+		if ( !$wg->Title instanceof Title ) {
+			return true;
+		}
+
 		// If we're not trying to login, don't issue the redirect this handler creates
 		if ( !$wg->Title->isSpecial( 'Userlogin' ) ) {
 			return true;
@@ -163,7 +167,7 @@ class FacebookClientHooks {
 	public static function onOasisSkinAssetGroups( &$assetsArray ) {
 		$title = F::app()->wg->Title;
 
-		if ( !empty( $title ) && $title->isSpecial( 'Preferences' ) ) {
+		if ( $title instanceof Title && $title->isSpecial( 'Preferences' ) ) {
 			$assetsArray[] = 'facebook_client_preferences_js';
 		}
 

--- a/includes/wikia/AsyncCache.php
+++ b/includes/wikia/AsyncCache.php
@@ -98,10 +98,14 @@ class AsyncCache {
 	/** @var \Wikia\Cache\AsyncCacheTask - The task created to generate a new value */
 	private $task;
 
+	/** @var int - The current time.  Keeps us from calling time() over and over */
+	private $currTime;
+
 	/**
 	 * @param BagOStuff $cache - An alternate caching package
 	 */
 	public function __construct( $cache = null ) {
+		$this->currTime = time();
 		$this->ttl = self::DEFAULT_TTL;
 		$this->negativeResponseTTL = self::DEFAULT_NEGATIVE_RESPONSE_TTL;
 
@@ -221,7 +225,7 @@ class AsyncCache {
 		if ( $this->isCacheStale() ) {
 			return 0;
 		} else {
-			return $this->getCacheExpire() - time();
+			return $this->getCacheExpire() - $this->currTime;
 		}
 	}
 
@@ -231,7 +235,7 @@ class AsyncCache {
 	 * @return bool
 	 */
 	public function isCacheStale() {
-		return  time() > $this->getCacheExpire();
+		return  $this->currTime > $this->getCacheExpire();
 	}
 
 	/**
@@ -251,7 +255,7 @@ class AsyncCache {
 				return self::UNLIMITED_TIME_REMAINING;
 			}
 
-			return $this->getCacheExpire() + $this->staleOnMissTTL - time();
+			return $this->getCacheExpire() + $this->staleOnMissTTL - $this->currTime;
 		} else {
 			return 0;
 		}
@@ -347,7 +351,7 @@ class AsyncCache {
 			return true;
 		}
 
-		return time() - $this->getCacheExpire() < $this->staleOnMissTTL;
+		return $this->currTime - $this->getCacheExpire() < $this->staleOnMissTTL;
 	}
 
 	private function generateValueNow() {
@@ -373,7 +377,7 @@ class AsyncCache {
 	private function logInfo( $mesg ) {
 		WikiaLogger::instance()->info( $mesg, [
 			'key' => $this->key,
-			'time' => time(),
+			'time' => $this->currTime,
 			'expires' => $this->getCacheExpire(),
 			'ttlRemain' => $this->ttlRemain(),
 			'staleTTLRemain' => $this->staleTTLRemain(),

--- a/includes/wikia/AsyncCacheTask.php
+++ b/includes/wikia/AsyncCacheTask.php
@@ -21,7 +21,7 @@ class AsyncCacheTask extends BaseTask {
 	 *
 	 * @return \Status
 	 */
-	public static function generate( $key, callable $func, array $args, array $options ) {
+	public static function generate( $key, $func, array $args, array $options ) {
 
 		// Get TTLs to use for positive response and negative (empty) response
 		$ttl = empty( $options[ 'ttl' ] ) ? AsyncCache::DEFAULT_TTL : $options[ 'ttl' ];

--- a/maintenance/wikia/asyncCache.php
+++ b/maintenance/wikia/asyncCache.php
@@ -42,7 +42,7 @@ class AsyncCacheCLI extends Maintenance {
 
 		if ( $this->hasOption( 'purge' ) ) {
 			$cacheKey = $this->getOption( 'purge' );
-			( new AsyncCache() )->purge( $cacheKey );
+			( new Wikia\Cache\AsyncCache() )->purge( $cacheKey );
 			echo "Purged '$cacheKey'\n";
 			exit(0);
 		}
@@ -67,12 +67,12 @@ class AsyncCacheCLI extends Maintenance {
 		echo "\t- Time to regenerate: $regenTTL\n";
 		echo "\t- Value regeneration method: $method(".implode(', ', $args).")\n";
 
-		$cache = ( new AsyncCache() )
+		$cache = ( new Wikia\Cache\AsyncCache() )
 			->key( $cacheKey )
 			->ttl( $ttl )
 			->negativeResponseTTL( $negTTL )
 			->staleOnMiss( $regenTTL )
-			->callback( $method )->callbackParams( $args );
+			->callback( $method, [ $args ] );
 
 		if ( $block ) {
 			$cache->blockOnMiss();


### PR DESCRIPTION
Some of the new FacebookClientHooks seem to be called from maintenance scripts.  Make sure these scripts don't fail because of this.

Also added some logging for the AsyncCache code

https://wikia-inc.atlassian.net/browse/UC-84
