### PR TITLE
VE-1605: Introduced new global variable: $wgVisualEditorNeverPrimary

### DIFF
--- a/extensions/wikia/EditorPreference/EditorPreference.i18n.php
+++ b/extensions/wikia/EditorPreference/EditorPreference.i18n.php
@@ -5,6 +5,7 @@ $messages = array();
 $messages['en'] = array(
 	'editorpreference-desc' => 'Allows users to set their preference of editor',
 	'editor-preference' => 'Preferred editor:',
+	'editor-preference-help' => 'On this wikia, the default editor is always the classic editor. [[Help:Editing|Learn more]].',
 	'option-default-editor' => 'Default',
 	'option-visual-editor' => 'Wikia\'s new VisualEditor',
 	'option-ck-editor' => 'Wikia\'s classic rich-text editor (where available)',


### PR DESCRIPTION
This new global variable disallow VisualEditor from ever appearing as a main/default/primary editor.
At the same time I'm removing old wgForceVisualEditor variable as not needed anymore.

https://wikia-inc.atlassian.net/browse/VE-1605
