### PR TITLE
UC-71 Addition of Return-URL support for FB Client ext

### DIFF
--- a/extensions/wikia/FacebookClient/FacebookClientHooks.class.php
+++ b/extensions/wikia/FacebookClient/FacebookClientHooks.class.php
@@ -43,16 +43,19 @@ class FacebookClientHooks {
 			$id = $mwUser ? $mwUser->getId() : 0;
 
 			// If the user doesn't exist, ask them to name their new account
-			if ( !$id && !empty( $wg->Title ) ) {
+			// Don't redirect if we're on certain special pages
+			if ( !$id && !empty( $wg->Title ) && FacebookClientHooks::isOkToRedirect() ) {
+				$skin = RequestContext::getMain()->getSkin();
 
-				// Don't redirect if we're on certain special pages
-				if ( FacebookClientHooks::isOkToRedirect() ) {
-					$skin = RequestContext::getMain()->getSkin();
-					$returnTo = 'returnto=' . $wg->Title->getPrefixedURL();
-
-					// Redirect to Special:Connect so the Facebook user can choose a nickname
-					$wg->Out->redirect( $skin->makeSpecialUrl( 'FacebookConnect', $returnTo ) );
+				$returnTo = $wg->request->getVal( 'returnto', $wg->Title->getPrefixedURL() );
+				$redirectUrl = 'returnto=' . htmlspecialchars( $returnTo );
+				$returnToQuery = $wg->request->getVal( 'returntoquery' );
+				if ( $returnToQuery ) {
+					$redirectUrl .= '&returntoquery=' . htmlspecialchars( $returnToQuery );
 				}
+
+				// Redirect to Special:Connect so the Facebook user can choose a nickname
+				$wg->Out->redirect( $skin->makeSpecialUrl( 'FacebookConnect', $redirectUrl ) );
 			}
 		}
 

--- a/extensions/wikia/FacebookClient/SpecialFacebookConnectController.class.php
+++ b/extensions/wikia/FacebookClient/SpecialFacebookConnectController.class.php
@@ -165,6 +165,9 @@ class SpecialFacebookConnectController extends WikiaSpecialPageController {
 		$this->userNameLabel = wfMessage( 'fbconnect-connect-username-label' )->plain();
 		$this->userName = $userName;
 		$this->passwordLabel = wfMessage( 'fbconnect-connect-password-label' )->plain();
+
+		$this->returnTo = htmlspecialchars( $wg->request->getVal( 'returnto' ) );
+		$this->returnToQuery = htmlspecialchars( $wg->request->getVal( 'returntoquery' ) );
 	}
 
 	/**
@@ -185,15 +188,16 @@ class SpecialFacebookConnectController extends WikiaSpecialPageController {
 		wfRunHooks( 'UserLoginComplete', [ &$user, &$inject_html ] );
 		$wg->User = $user;
 
-		$titleObj = Title::newFromText( $this->mReturnTo );
-		$queryStr = 'fbconnected=1&cb='.rand( 1, 10000 );
+		$returnTo = $wg->request->getVal( 'returnto' );
+		$returnToQuery = $wg->request->getVal( 'returntoquery' );
+		$titleObj = Title::newFromText( $returnTo );
 
 		if ( $this->isInvalidRedirectOnConnect( $titleObj ) ) {
 			// Don't redirect if the location is no good.  Go to the main page instead
 			$titleObj = Title::newMainPage();
-		} else {
+		} else if ( $returnToQuery ) {
 			// Include the return to query string if its ok to redirect
-			$queryStr = $this->mReturnToQuery . '&' . $queryStr;
+			$queryStr = $returnToQuery . '&fbconnected=1&cb=' . rand( 1, 10000 );
 		}
 
 		$wg->Out->redirect( $titleObj->getFullURL( $queryStr ) );

--- a/extensions/wikia/FacebookClient/SpecialFacebookConnectController.class.php
+++ b/extensions/wikia/FacebookClient/SpecialFacebookConnectController.class.php
@@ -197,7 +197,7 @@ class SpecialFacebookConnectController extends WikiaSpecialPageController {
 			$titleObj = Title::newMainPage();
 		} else if ( $returnToQuery ) {
 			// Include the return to query string if its ok to redirect
-			$queryStr = $returnToQuery . '&fbconnected=1&cb=' . rand( 1, 10000 );
+			$queryStr = urldecode( $returnToQuery ) . '&fbconnected=1&cb=' . rand( 1, 10000 );
 		}
 
 		$wg->Out->redirect( $titleObj->getFullURL( $queryStr ) );

--- a/extensions/wikia/FacebookClient/templates/SpecialFacebookConnect_connectUser.mustache
+++ b/extensions/wikia/FacebookClient/templates/SpecialFacebookConnect_connectUser.mustache
@@ -14,6 +14,8 @@
                     <input name="wpExistingName" size="16" value="{{userName}}" id="wpExistingName"/>
                     {{passwordLabel}}
                     <input name="wpExistingPassword" size="" value="" type="password"/>
+                    <input name="returnto" value="{{returnTo}}" type="hidden"/>
+                    <input name="returntoquery" value="{{returnToQuery}}" type="hidden"/>
                 </td>
             </tr>
             <tr>

--- a/extensions/wikia/UserLogin/FacebookSignupController.class.php
+++ b/extensions/wikia/UserLogin/FacebookSignupController.class.php
@@ -67,7 +67,7 @@ class FacebookSignupController extends WikiaController {
 		}
 
 		// The new FB SDK doesn't define contact_email
-		if ( F::app()->wg->EnableFacebookClientExt ) {
+		if ( $this->wg->EnableFacebookClientExt ) {
 			$this->fbEmail = $resp->getVal( 'email', false );
 		} else {
 			$this->fbEmail = $resp->getVal( 'contact_email', false );
@@ -78,6 +78,16 @@ class FacebookSignupController extends WikiaController {
 				$this->fbEmail = wfMessage( 'usersignup-facebook-proxy-email' )->escaped();
 			}
 		}
+
+		$returnTo = $this->getReturnTo();
+		$returnToParams = 'returnto=' . $returnTo;
+		$returnToQuery = htmlspecialchars( $this->wg->request->getVal( 'returntoquery' ) );
+		if ( $returnToQuery ) {
+			$returnToParams .= '&returntoquery=' . $returnToQuery;
+		}
+		$this->queryString = $returnToParams;
+		$this->returnTo = $returnTo;
+		$this->returnToQuery = $returnToQuery;
 
 		$this->loginToken = UserLoginHelper::getSignupToken();
 
@@ -106,6 +116,15 @@ class FacebookSignupController extends WikiaController {
 				$this->response->setData($signupResponse);
 				break;
 		}
+	}
+
+	protected function getReturnTo() {
+		$returnTo = $this->wg->request->getVal( 'returnto' );
+		if ( !$returnTo ) {
+			$returnTo = $this->wg->Title->getFullUrl();
+		}
+
+		return htmlspecialchars( $returnTo );
 	}
 
 	/**

--- a/extensions/wikia/UserLogin/UserLoginSpecialController.class.php
+++ b/extensions/wikia/UserLogin/UserLoginSpecialController.class.php
@@ -85,12 +85,17 @@ class UserLoginSpecialController extends WikiaSpecialPageController {
 	 * @responseParam string editToken - token for changing password
 	 */
 	public function index() {
+		$returnTo = urldecode( $this->request->getVal( 'returnto', '' ) );
+		$returnToQuery = urldecode( $this->request->getVal( 'returntoquery', '' ) );
 
 		// redirect if signup
 		$type = $this->request->getVal('type', '');
 		if ($type === 'signup' || $this->getPar() == 'signup') {
 			$title = SpecialPage::getTitleFor( 'UserSignup' );
-			$this->wg->Out->redirect( $title->getFullURL() );
+			$this->wg->Out->redirect( $title->getFullURL( [
+				['returnto' => $returnTo],
+				['returntoquery' => $returnToQuery],
+			] ) );
 			return false;
 		}
 
@@ -104,8 +109,8 @@ class UserLoginSpecialController extends WikiaSpecialPageController {
 		$this->password = $this->request->getVal( 'password', '' );
 		$this->keeploggedin = $this->request->getCheck( 'keeploggedin' );
 		$this->loginToken = UserLoginHelper::getLoginToken();
-		$this->returnto = htmlentities($this->request->getVal( 'returnto', '' ), ENT_QUOTES, "UTF-8");
-		$this->returntoquery = htmlentities($this->request->getVal( 'returntoquery', '' ), ENT_QUOTES, "UTF-8");
+		$this->returnto = $returnTo;
+		$this->returntoquery = $returnToQuery;
 
 		// process login
 		if ( $this->wg->request->wasPosted() ) {

--- a/extensions/wikia/UserLogin/js/UserLoginFacebook.js
+++ b/extensions/wikia/UserLogin/js/UserLoginFacebook.js
@@ -82,7 +82,10 @@
 					this.bucky.timer.start('loginCallbackAjax');
 
 					// now check FB account (is it connected with Wikia account?)
-					$.nirvana.postJson('FacebookSignupController', 'index',
+					$.nirvana.postJson('FacebookSignupController', 'index', {
+							returnto: encodeURIComponent(window.wgPageName),
+							returntoquery: encodeURIComponent(window.location.search.substring(1))
+						},
 						$.proxy(this.checkAccountCallback, this));
 					break;
 				case 'not_authorized':
@@ -192,7 +195,10 @@
 										action: self.actions.SUBMIT,
 										label: 'facebook-login-modal'
 									});
-									var location = res.location;
+									var location = res.returnto;
+									if (res.returntoquery) {
+										location += '?' + res.returntoquery;
+									}
 
 									// redirect to the user page
 									if (loginCallback && typeof loginCallback === 'function') {

--- a/extensions/wikia/UserLogin/js/UserLoginFacebookForm.js
+++ b/extensions/wikia/UserLogin/js/UserLoginFacebookForm.js
@@ -28,11 +28,14 @@ var UserLoginFacebookForm = $.createClass(UserLoginAjaxForm, {
 
 	// send a request to FB controller
 	ajaxLogin: function() {
+		'use strict';
 		$.nirvana.postJson('FacebookSignupController', 'signup', {
 			username: this.inputs.username.val(),
 			password: this.inputs.password.val(),
 			signupToken: this.inputs.logintoken.val(),
-			fbfeedoptions: this.getFeedOptions().join(',')
+			fbfeedoptions: this.getFeedOptions().join(','),
+			returnto: encodeURIComponent(window.wgPageName),
+			returntoquery: encodeURIComponent(window.location.search.substring(1))
 		},
 		$.proxy(this.submitFbSignupHandler, this));
 	},
@@ -51,6 +54,8 @@ var UserLoginFacebookForm = $.createClass(UserLoginAjaxForm, {
 				label: 'facebook-signup'
 			});
 		}
+		json.returnto = encodeURIComponent(window.wgPageName);
+		json.returntoquery = encodeURIComponent(window.location.search.substring(1));
 		this.submitLoginHandler(json);
 	}
 });

--- a/extensions/wikia/UserLogin/templates/FacebookSignup_modal.php
+++ b/extensions/wikia/UserLogin/templates/FacebookSignup_modal.php
@@ -36,6 +36,16 @@
 				'name' => 'loginToken',
 				'value' => Sanitizer::encodeAttribute( $loginToken ),
 			),
+			[
+				'type' => 'hidden',
+				'name' => 'returnto',
+				'value' => $returnTo, // already encoded
+			],
+			[
+				'type' => 'hidden',
+				'name' => 'returntoquery',
+				'value' => $returnToQuery, // already encoded
+			],
 			array(
 				'type' => 'nirvanaview',
 				'controller' => 'UserSignupSpecial',
@@ -54,7 +64,9 @@
 		<section class="UserLoginFacebookRight">
 			<h1><?= wfMessage('usersignup-facebook-have-an-account-heading')->escaped() ?></h1>
 			<p><?= wfMessage('usersignup-facebook-have-an-account')->escaped() ?></p>
-			<a class="wikia-button" href="<?= htmlspecialchars($specialUserLoginUrl) ?>"><?= wfMessage('login')->escaped() ?></a>
+			<a class="wikia-button" href="<?= htmlspecialchars( $specialUserLoginUrl )  . '?' . $queryString ?>">
+				<?= wfMessage('login')->escaped() ?>
+			</a>
 		</section>
 	</section>
 </div>


### PR DESCRIPTION
Implementation of returnto & returntoquery for new FB client code in order to direct user back to original page after logging in.

Ticket: https://wikia-inc.atlassian.net/browse/UC-71
