### PR TITLE
Special page contributions block log fix

### DIFF
--- a/extensions/wikia/PhalanxII/Phalanx.i18n.php
+++ b/extensions/wikia/PhalanxII/Phalanx.i18n.php
@@ -158,6 +158,8 @@ Please [[Special:Contact|contact Wikia]] about the problem.<br />The blocker als
 	'phalanx-section-type-account-creation' => 'Account creation',
 	'phalanx-section-type-wiki-creation' => 'Wiki creation',
 	'phalanx-section-type-questions' => 'Questions',
+
+	'phalanx-sp-contributions-blocked-globally' => 'This user is currently blocked across the Wikia network.',
 );
 
 /** Message documentation (Message documentation)

--- a/extensions/wikia/PhalanxII/Phalanx.i18n.php
+++ b/extensions/wikia/PhalanxII/Phalanx.i18n.php
@@ -158,7 +158,6 @@ Please [[Special:Contact|contact Wikia]] about the problem.<br />The blocker als
 	'phalanx-section-type-account-creation' => 'Account creation',
 	'phalanx-section-type-wiki-creation' => 'Wiki creation',
 	'phalanx-section-type-questions' => 'Questions',
-
 	'phalanx-sp-contributions-blocked-globally' => 'This user is currently blocked across the Wikia network.',
 );
 
@@ -182,7 +181,8 @@ $messages['qqq'] = array(
 	'phalanx-section-type-questions' => 'Legend for fieldset grouping blocks related to Answers wiki',
 	'phalanx-expire-custom' => 'Dropdown option for choosing custom expiry time',
 	'phalanx-expire-custom-tooltip' => 'Placeholder for custom expiry time input box with value examples',
-	'phalanx-filters-intro' => 'Intro text shown in block filtering section: $1 is a link to [[Special:Log]] with Phalanx entries'
+	'phalanx-filters-intro' => 'Intro text shown in block filtering section: $1 is a link to [[Special:Log]] with Phalanx entries',
+	'phalanx-sp-contributions-blocked-globally' => 'Information that user is blocked globally displayed instead of local log extract on special page contributions'
 );
 
 /** Arabic (العربية)

--- a/extensions/wikia/PhalanxII/Phalanx_setup.php
+++ b/extensions/wikia/PhalanxII/Phalanx_setup.php
@@ -87,6 +87,7 @@ $phalanxhooks = array(
 			'AfterFormatPermissionsErrorMessage' => 'onAfterFormatPermissionsErrorMessage',
 			// temp logging for PLATFORM-317
 			'GetBlockedStatus'                => 'onGetBlockedStatus',
+			'ContributionsLogEventsList'      => 'onContributionsLogEventsList',
 		)
 );
 

--- a/extensions/wikia/PhalanxII/hooks/PhalanxHooks.class.php
+++ b/extensions/wikia/PhalanxII/hooks/PhalanxHooks.class.php
@@ -252,4 +252,28 @@ class PhalanxHooks extends WikiaObject {
 
 		return true;
 	}
+
+	/**
+	 * Outputs information about users global block and prevents displaying extract from local log which does not contain
+	 * information about phalanx block.
+	 *
+	 * @see PLATFORM-470
+	 * @author jcellary
+	 *
+	 * @param OutputPage $out
+	 * @param User $user
+	 * @return bool false
+	 */
+	static public function onContributionsLogEventsList( OutputPage $out, User $user ) {
+
+		$blockedGlobally = $user->mBlockedGlobally;
+
+		if ($blockedGlobally) {
+			$message = wfMessage( 'phalanx-sp-contributions-blocked-globally' )->text();
+			$message = '<div class="'.LogEventsList::WARN_BOX_DIV_CLASS.'">'.$message.'</div>';
+			$out->addHTML($message);
+		}
+
+		return !$blockedGlobally; //If blocked globally disable listing local log
+	}
 }

--- a/includes/logging/LogEventsList.php
+++ b/includes/logging/LogEventsList.php
@@ -48,6 +48,8 @@ class LogEventsList {
 	 */
 	protected $mDefaultQuery;
 
+	const WARN_BOX_DIV_CLASS = 'mw-warning-with-logexcerpt';
+
 	public function __construct( $skin, $out, $flags = 0 ) {
 		$this->skin = $skin;
 		$this->out = $out;
@@ -670,7 +672,7 @@ class LogEventsList {
 		$s = '';
 		if( $logBody ) {
 			if ( $msgKey[0] ) {
-				$s = '<div class="mw-warning-with-logexcerpt">';
+				$s = '<div class="'.WARN_BOX_DIV_CLASS.'">';
 
 				if ( count( $msgKey ) == 1 ) {
 					$s .= wfMsgExt( $msgKey[0], array( 'parse' ) );

--- a/includes/logging/LogEventsList.php
+++ b/includes/logging/LogEventsList.php
@@ -672,7 +672,7 @@ class LogEventsList {
 		$s = '';
 		if( $logBody ) {
 			if ( $msgKey[0] ) {
-				$s = '<div class="'.WARN_BOX_DIV_CLASS.'">';
+				$s = '<div class="'.LogEventsList::WARN_BOX_DIV_CLASS.'">';
 
 				if ( count( $msgKey ) == 1 ) {
 					$s .= wfMsgExt( $msgKey[0], array( 'parse' ) );

--- a/includes/specials/SpecialContributions.php
+++ b/includes/specials/SpecialContributions.php
@@ -234,23 +234,26 @@ class SpecialContributions extends SpecialPage {
 			// Show a note if the user is blocked and display the last block log entry.
 			if ( $userObj->isBlocked() ) {
 				$out = $this->getOutput(); // showLogExtract() wants first parameter by reference
-				LogEventsList::showLogExtract(
-					$out,
-					'block',
-					$nt,
-					'',
-					array(
-						'lim' => 1,
-						'showIfEmpty' => false,
-						'msgKey' => array(
-							$userObj->isAnon() ?
-								'sp-contributions-blocked-notice-anon' :
-								'sp-contributions-blocked-notice',
-							$userObj->getName() # Support GENDER in 'sp-contributions-blocked-notice'
-						),
-						'offset' => '' # don't use WebRequest parameter offset
-					)
-				);
+				//If user is blocked globally we do not show local log extract as it doesn't contain information about this block
+				if ( wfRunHooks('ContributionsLogEventsList', array( $out, $userObj) ) ) {
+					LogEventsList::showLogExtract(
+						$out,
+						'block',
+						$nt,
+						'',
+						array(
+							'lim' => 1,
+							'showIfEmpty' => false,
+							'msgKey' => array(
+								$userObj->isAnon() ?
+									'sp-contributions-blocked-notice-anon' :
+									'sp-contributions-blocked-notice',
+								$userObj->getName() # Support GENDER in 'sp-contributions-blocked-notice'
+							),
+							'offset' => '' # don't use WebRequest parameter offset
+						)
+					);
+				}
 			}
 		}
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-470

Added a hook which overrides the default showing of a local log extract for blocked users in case a user is blocked globally using Phalanx. In that case the local log messages does not inform about the actual block and can be confusing, so instead a message that user is blocked globally is displayed.

I'm pretty new to changing MW, so let me know if something should be done differently :)

@michalroszka  @macbre  @wladekb 
