### PR TITLE
Revert "use temporary migration queues"

### DIFF
--- a/includes/wikia/tasks/Queues/ParsoidPurgePriorityQueue.class.php
+++ b/includes/wikia/tasks/Queues/ParsoidPurgePriorityQueue.class.php
@@ -13,7 +13,7 @@ class ParsoidPurgePriorityQueue extends Queue {
 	const NAME = 'ParsoidPurgePriorityQueue';
 
 	public function __construct() {
-		$this->name = 'parsoid_purge_priority_tmp';
-		$this->routingKey = 'mediawiki.parsoid_purge_priority_tmp';
+		$this->name = 'parsoid_purge_priority';
+		$this->routingKey = 'mediawiki.parsoid_purge_priority';
 	}
 } 

--- a/includes/wikia/tasks/Queues/ParsoidPurgeQueue.class.php
+++ b/includes/wikia/tasks/Queues/ParsoidPurgeQueue.class.php
@@ -13,7 +13,7 @@ class ParsoidPurgeQueue extends Queue {
 	const NAME = 'ParsoidPurgeQueue';
 
 	public function __construct() {
-		$this->name = 'parsoid_purge_tmp';
-		$this->routingKey = 'mediawiki.parsoid_purge_tmp';
+		$this->name = 'parsoid_purge';
+		$this->routingKey = 'mediawiki.parsoid_purge';
 	}
 } 

--- a/includes/wikia/tasks/Queues/PriorityQueue.class.php
+++ b/includes/wikia/tasks/Queues/PriorityQueue.class.php
@@ -14,7 +14,7 @@ class PriorityQueue extends Queue {
 	const NAME = 'PriorityQueue';
 
 	public function __construct() {
-		$this->name = 'mediawiki_priority_tmp';
-		$this->routingKey = 'mediawiki.priority_tmp';
+		$this->name = 'mediawiki_priority';
+		$this->routingKey = 'mediawiki.priority';
 	}
 }

--- a/includes/wikia/tasks/Queues/Queue.class.php
+++ b/includes/wikia/tasks/Queues/Queue.class.php
@@ -17,8 +17,8 @@ class Queue {
 	protected $routingKey;
 
 	public function __construct() {
-		$this->name = 'mediawiki_tmp';
-		$this->routingKey = 'mediawiki_tmp';
+		$this->name = 'mediawiki';
+		$this->routingKey = 'mediawiki';
 	}
 
 	public function name() {


### PR DESCRIPTION
@owend 

This reverts commit b3506d7296bcff9d0f0d5f1787f3affbb3f05923.

Old queue is empty, the migration can continue now. This step tells mediawiki to queue to the original, non temporary queues that are now running the new worker.
