### PR TITLE
VE-1639: Integrate ve.ui.WikiaMediaResultsWidget into ve.ui.WikiaSingleMediaDialog

### DIFF
--- a/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaSingleMediaDialog.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaSingleMediaDialog.js
@@ -80,6 +80,9 @@ ve.ui.WikiaSingleMediaDialog.prototype.initialize = function () {
 	this.search.connect( this, {
 		'nearingEnd': 'onSearchNearingEnd'
 	} );
+	this.queryInput.connect( this, {
+		'change': 'onQueryInputChange'
+	} );
 
 	// Initialization
 	this.frame.$content.addClass( 've-ui-wikiaSingleMediaDialog' );
@@ -125,6 +128,16 @@ ve.ui.WikiaSingleMediaDialog.prototype.onSearchNearingEnd = function () {
 	if ( !this.queryInput.isPending() ) {
 		this.query.requestMedia();
 	}
+};
+
+/**
+ * Handle query input changes.
+ *
+ * @method
+ * @param {string} value The query input value
+ */
+ve.ui.WikiaSingleMediaDialog.prototype.onQueryInputChange = function ( value ) {
+	this.results.clearItems();
 };
 
 /* Registration */

--- a/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaSingleMediaDialog.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaSingleMediaDialog.js
@@ -38,18 +38,21 @@ ve.ui.WikiaSingleMediaDialog.prototype.initialize = function () {
 	// Parent method
 	ve.ui.WikiaSingleMediaDialog.super.prototype.initialize.call( this );
 
-	// Search
+	// Properties
 	this.query = new ve.ui.WikiaSingleMediaQueryWidget( {
 		'$': this.$,
 		'placeholder': ve.msg( 'visualeditor-dialog-wikiasinglemedia-search' )
 	} );
+	this.queryInput = this.query.getInput();
+	this.search = new ve.ui.WikiaMediaResultsWidget( { '$': this.$ } );
+	this.results = this.search.getResults();
 
 	// Main panels
 	this.$main = this.$( '<div>' )
 		.addClass( 've-ui-wikiaSingleMediaDialog-main' );
 	this.$leftSide = this.$( '<div>' )
 		.addClass( 've-ui-wikiaSingleMediaDialog-leftSide' )
-		.html('test<br>test<br>test<br>test<br>test<br>test<br>test<br>test<br>test<br>test<br>test<br>test<br>test<br>test<br>test<br>test<br>test<br>test<br>test<br>test<br>test<br>test<br>test<br>test');
+		.append( this.search.$element );
 	this.cart = new ve.ui.WikiaSingleMediaCartWidget( { 'dialog': this } );
 
 	// Foot elements
@@ -71,6 +74,12 @@ ve.ui.WikiaSingleMediaDialog.prototype.initialize = function () {
 
 	// Events
 	this.cart.connect( this, { 'layout': 'setLayout' } );
+	this.query.connect( this, {
+		'requestMediaDone': 'onQueryRequestMediaDone'
+	} );
+	this.search.connect( this, {
+		'nearingEnd': 'onSearchNearingEnd',
+	} );
 
 	// Initialization
 	this.frame.$content.addClass( 've-ui-wikiaSingleMediaDialog' );
@@ -95,6 +104,27 @@ ve.ui.WikiaSingleMediaDialog.prototype.setLayout = function ( layout ) {
 		this.$main.css( 'left', -552 );
 	}
 	this.emit( 'layout', layout );
+};
+
+/**
+ * Handle the resulting data from a query media request.
+ *
+ * @method
+ * @param {Object} items An object containing items to add to the search results
+ */
+ve.ui.WikiaSingleMediaDialog.prototype.onQueryRequestMediaDone = function ( items ) {
+	this.search.addItems( items );
+};
+
+/**
+ * Handle nearing the end of search results.
+ *
+ * @method
+ */
+ve.ui.WikiaSingleMediaDialog.prototype.onSearchNearingEnd = function () {
+	if ( !this.queryInput.isPending() ) {
+		this.query.requestMedia();
+	}
 };
 
 /* Registration */

--- a/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaSingleMediaDialog.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaSingleMediaDialog.js
@@ -95,6 +95,19 @@ ve.ui.WikiaSingleMediaDialog.prototype.initialize = function () {
 	this.setLayout( 'grid' );
 };
 
+/**
+ * Handle closing the dialog.
+ *
+ * @method
+ * @param {string} action Which action is being performed on close.
+ */
+ve.ui.WikiaSingleMediaDialog.prototype.getTeardownProcess = function ( data ) {
+	return ve.ui.WikiaSingleMediaDialog.super.prototype.getTeardownProcess.call( this, data )
+		.first( function () {
+			this.queryInput.setValue( '' );
+		}, this );
+};
+
 /*
  * Sets layout between list and grid.
  *

--- a/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaSingleMediaDialog.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaSingleMediaDialog.js
@@ -147,9 +147,8 @@ ve.ui.WikiaSingleMediaDialog.prototype.onSearchNearingEnd = function () {
  * Handle query input changes.
  *
  * @method
- * @param {string} value The query input value
  */
-ve.ui.WikiaSingleMediaDialog.prototype.onQueryInputChange = function ( value ) {
+ve.ui.WikiaSingleMediaDialog.prototype.onQueryInputChange = function () {
 	this.results.clearItems();
 };
 

--- a/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaSingleMediaDialog.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaSingleMediaDialog.js
@@ -78,7 +78,7 @@ ve.ui.WikiaSingleMediaDialog.prototype.initialize = function () {
 		'requestMediaDone': 'onQueryRequestMediaDone'
 	} );
 	this.search.connect( this, {
-		'nearingEnd': 'onSearchNearingEnd',
+		'nearingEnd': 'onSearchNearingEnd'
 	} );
 
 	// Initialization

--- a/extensions/VisualEditor/wikia/modules/ve/ui/widgets/ve.ui.WikiaSingleMediaQueryWidget.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/widgets/ve.ui.WikiaSingleMediaQueryWidget.js
@@ -2,6 +2,8 @@
  * VisualEditor UserInterface WikiaSingleMediaQueryWidget class.
  */
 
+/*global mw */
+
 /**
  * @class
  * @extends OO.ui.Widget

--- a/extensions/VisualEditor/wikia/modules/ve/ui/widgets/ve.ui.WikiaSingleMediaQueryWidget.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/widgets/ve.ui.WikiaSingleMediaQueryWidget.js
@@ -25,8 +25,14 @@ ve.ui.WikiaSingleMediaQueryWidget = function VeUiWikiaSingleMediaQueryWidget( co
 		'placeholder': config.placeholder,
 		'value': config.value
 	} );
+	this.requestMediaCallback = ve.bind( this.requestMedia, this );
+	this.request = null;
+	this.value = null;
+	this.timeout = null;
+	this.batch = null;
 
 	// Events
+	this.input.connect( this, { 'change': 'onInputChange' } );
 
 	// Initialization
 	this.$element
@@ -51,3 +57,78 @@ OO.inheritClass( ve.ui.WikiaSingleMediaQueryWidget, OO.ui.Widget );
  */
 
 /* Methods */
+
+/**
+ * Handle query input changes.
+ *
+ * @method
+ */
+ve.ui.WikiaSingleMediaQueryWidget.prototype.onInputChange = function () {
+	if ( this.request ) {
+		this.request.abort();
+	}
+	clearTimeout( this.timeout );
+	this.batch = 1;
+	this.value = this.input.getValue();
+	if ( this.value.trim().length !== 0 ) {
+		this.timeout = setTimeout( this.requestMediaCallback, 100 );
+	}
+};
+
+/**
+ * @method
+ */
+ve.ui.WikiaSingleMediaQueryWidget.prototype.requestMedia = function () {
+	this.input.pushPending();
+	this.request = $.ajax( {
+		'url': mw.util.wikiScript( 'api' ),
+		'data': {
+			'format': 'json',
+			'action': 'apimediasearch',
+			'query': this.value,
+			'type': 'photo',
+			'mixed': false,
+			'batch': this.batch,
+			'limit': 16
+		}
+	} )
+		.always( ve.bind( this.onRequestMediaAlways, this ) )
+		.done( ve.bind( this.onRequestMediaDone, this ) );
+};
+
+/**
+ * Handle media request promise.always
+ *
+ * @method
+ */
+ve.ui.WikiaSingleMediaQueryWidget.prototype.onRequestMediaAlways = function () {
+	this.request = null;
+	this.input.popPending();
+};
+
+/**
+ * Handle media request promise.done
+ *
+ * @method
+ * @param {Object} data The response Object from the server.
+ * @fires requestMediaDone
+ */
+ve.ui.WikiaSingleMediaQueryWidget.prototype.onRequestMediaDone = function ( data ) {
+	var items;
+	if ( !data.response || !data.response.results ) {
+		return;
+	}
+	items = data.response.results.photo.items;
+	this.batch++;
+	this.emit( 'requestMediaDone', items );
+};
+
+/**
+ * Get the query input.
+ *
+ * @method
+ * @returns {OO.ui.TextInputWidget} Query input
+ */
+ve.ui.WikiaSingleMediaQueryWidget.prototype.getInput = function () {
+	return this.input;
+};


### PR DESCRIPTION
It is reusing ve.ui.WikiaMediaResultsWidget and (ve.ui.WikiaMediaOptionWidget) that is currently used in current media dialog and in maps.
Known issues: more styling work to do, add data about dimensions of the image.

https://wikia-inc.atlassian.net/browse/VE-1639
