### PR TITLE
VE-1649: Cart views

### DIFF
--- a/extensions/VisualEditor/wikia/VisualEditor.php
+++ b/extensions/VisualEditor/wikia/VisualEditor.php
@@ -143,6 +143,8 @@ $wgResourceModules += array(
 			've/ui/widgets/ve.ui.WikiaFocusWidget.js',
 			've/ui/widgets/ve.ui.WikiaCategoryInputWidget.js',
 			've/ui/widgets/ve.ui.WikiaSingleMediaCartWidget.js',
+			've/ui/widgets/ve.ui.WikiaSingleMediaCartSelectWidget.js',
+			've/ui/widgets/ve.ui.WikiaSingleMediaCartOptionWidget.js',
 			've/ui/widgets/ve.ui.WikiaSingleMediaQueryWidget.js',
 		),
 		'messages' => array(

--- a/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaMediaInsertDialog.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaMediaInsertDialog.js
@@ -275,7 +275,7 @@ ve.ui.WikiaMediaInsertDialog.prototype.onSearchCheck = function ( item ) {
 	var cartItem;
 
 	cartItem = this.cart.getItemFromData( item.title );
-debugger;
+
 	if ( cartItem ) {
 		this.cartModel.removeItems( [ cartItem.getModel() ] );
 	} else {

--- a/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaMediaInsertDialog.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaMediaInsertDialog.js
@@ -275,7 +275,7 @@ ve.ui.WikiaMediaInsertDialog.prototype.onSearchCheck = function ( item ) {
 	var cartItem;
 
 	cartItem = this.cart.getItemFromData( item.title );
-
+debugger;
 	if ( cartItem ) {
 		this.cartModel.removeItems( [ cartItem.getModel() ] );
 	} else {

--- a/extensions/VisualEditor/wikia/modules/ve/ui/styles/ve.ui.WikiaSingleMediaInsertDialog.scss
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/styles/ve.ui.WikiaSingleMediaInsertDialog.scss
@@ -46,15 +46,6 @@ $width-results: 552px;
 	width: $width-results;
 }
 
-.ve-ui-wikiaSingleMediaDialog-rightSide {
-	bottom: 0;
-	left: 0;
-	overflow-y: auto;
-	position: absolute;
-	right: 0;
-	top: 35px;
-}
-
 .ve-ui-wikiaSingleMediaDialog-policy {
 	align-items: center;
 	color: $color-alternate-text;
@@ -108,4 +99,34 @@ $width-results: 552px;
 }
 .ve-ui-wikiaSingleMediaDialog-cartListButton .oo-ui-buttonedElement-active .oo-ui-iconedElement-icon {
 	@include ve-icon(cart-list, wikia, $color-alternate-text);
+}
+
+.ve-ui-wikiaSingleMediaCartSelectWidget {
+	bottom: 0;
+	left: 0;
+	overflow-y: auto;
+	position: absolute;
+	right: 0;
+	top: 35px;
+}
+
+.ve-ui-wikiaSingleMediaCartOptionWidget {
+	box-sizing: border-box;
+	padding: 5px 20px;
+	width: $width-dialog;
+}
+
+.ve-ui-wikiaSingleMediaCartOptionImage {
+	border: 1px solid $color-page-border;
+	display: inline-block;
+}
+
+.ve-ui-wikiaSingleMediaCartOptionDetails {
+	background: $color-page;
+	border: 1px solid $color-page-border;
+	box-sizing: border-box;
+	display: inline-block;
+	height: 120px;
+	margin-left: 20px;
+	width: 530px;
 }

--- a/extensions/VisualEditor/wikia/modules/ve/ui/styles/ve.ui.WikiaSingleMediaInsertDialog.scss
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/styles/ve.ui.WikiaSingleMediaInsertDialog.scss
@@ -104,6 +104,7 @@ $width-results: 552px;
 .ve-ui-wikiaSingleMediaCartSelectWidget {
 	bottom: 0;
 	left: 0;
+	overflow-x: hidden;
 	overflow-y: auto;
 	position: absolute;
 	right: 0;
@@ -112,12 +113,14 @@ $width-results: 552px;
 
 .ve-ui-wikiaSingleMediaCartOptionWidget {
 	box-sizing: border-box;
+	line-height: 0;
 	padding: 5px 20px;
 	width: $width-dialog;
 }
 
 .ve-ui-wikiaSingleMediaCartOptionImage {
 	border: 1px solid $color-page-border;
+	box-sizing: border-box;
 	display: inline-block;
 }
 

--- a/extensions/VisualEditor/wikia/modules/ve/ui/widgets/ve.ui.WikiaSingleMediaCartOptionWidget.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/widgets/ve.ui.WikiaSingleMediaCartOptionWidget.js
@@ -1,0 +1,45 @@
+/*
+ * VisualEditor UserInterface WikiaSingleMediaCartOptionWidget class.
+ */
+
+/* global require */
+
+/**
+ * @class
+ * @extends OO.ui.OptionWidget
+ *
+ * @constructor
+ * @param {ve.dm.WikiaCartItem} model Cart item
+ */
+ve.ui.WikiaSingleMediaCartOptionWidget = function VeUiWikiaSingleMediaCartOptionWidget( model ) {
+	var size = 120, $image, $details;
+
+	ve.ui.WikiaSingleMediaCartOptionWidget.super.call( this, model.getId() );
+
+	this.model = model;
+	this.$element.addClass( 've-ui-texture-pending ve-ui-wikiaSingleMediaCartOptionWidget' );
+
+	$details = this.$( '<div>' ).addClass( 've-ui-wikiaSingleMediaCartOptionDetails' );
+
+	$image = this.$( '<img>' )
+		.attr( {
+			'height': size,
+			'width': size
+		} )
+		.addClass( 've-ui-wikiaSingleMediaCartOptionImage' )
+		.load( ve.bind( function () {
+			this.$element
+				.prepend( $image, $details )
+				.removeClass( 've-ui-texture-pending' );
+		}, this ) );
+
+	require( ['wikia.thumbnailer'], ve.bind( function ( thumbnailer ) {
+		$image.attr( 'src', thumbnailer.getThumbURL( this.model.url, 'image', size, size ) );
+	}, this ) );
+};
+
+OO.inheritClass( ve.ui.WikiaSingleMediaCartOptionWidget, OO.ui.OptionWidget );
+
+ve.ui.WikiaSingleMediaCartOptionWidget.prototype.getModel = function () {
+	return this.model;
+};

--- a/extensions/VisualEditor/wikia/modules/ve/ui/widgets/ve.ui.WikiaSingleMediaCartSelectWidget.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/widgets/ve.ui.WikiaSingleMediaCartSelectWidget.js
@@ -1,0 +1,38 @@
+/*!
+ * VisualEditor UserInterface WikiaSingleMediaCartSelectWidget class.
+ */
+
+/**
+ * @class
+ * @extends OO.ui.SelectWidget
+ *
+ * @constructor
+ * @param {ve.dm.WikiaCart} model Cart item
+ */
+ve.ui.WikiaSingleMediaCartSelectWidget = function VeUiWikiaSingleMediaCartSelectWidget( model ) {
+	ve.ui.WikiaSingleMediaCartSelectWidget.super.call( this );
+	this.model = model;
+	this.model.connect( this, { 'add': 'onAdd', 'remove': 'onRemove' } );
+	this.$element.addClass( 've-ui-wikiaSingleMediaCartSelectWidget' );
+};
+
+OO.inheritClass( ve.ui.WikiaSingleMediaCartSelectWidget, OO.ui.SelectWidget );
+
+ve.ui.WikiaSingleMediaCartSelectWidget.prototype.onAdd = function ( items, index ) {
+	var i, widgetItems = [];
+	for ( i = 0; i < items.length; i++ ) {
+		widgetItems.push( new ve.ui.WikiaSingleMediaCartOptionWidget( items[i] ) );
+	}
+	this.addItems( widgetItems, index );
+};
+
+ve.ui.WikiaSingleMediaCartSelectWidget.prototype.onRemove = function ( items ) {
+	var i, widgetItem, widgetItems = [];
+	for ( i = 0; i < items.length; i++ ) {
+		widgetItem = this.getItemFromData( items[i].getId() );
+		if ( widgetItem ) {
+			widgetItems.push( widgetItem );
+		}
+	}
+	this.removeItems( widgetItems );
+};

--- a/extensions/VisualEditor/wikia/modules/ve/ui/widgets/ve.ui.WikiaSingleMediaCartWidget.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/widgets/ve.ui.WikiaSingleMediaCartWidget.js
@@ -17,10 +17,6 @@ ve.ui.WikiaSingleMediaCartWidget = function VeUiWikiaSingleMediaCartWidget( conf
 	// Properties
 	this.dialog = config.dialog;
 
-	this.$rightSide = this.$( '<div>' )
-		.addClass( 've-ui-wikiaSingleMediaDialog-rightSide' )
-		.html('test<br>test<br>test<br>test<br>test<br>test<br>test<br>test<br>test<br>test<br>test<br>test<br>test<br>test<br>test<br>test<br>test<br>test<br>test<br>test<br>test<br>test<br>test<br>test');
-
 	this.$cartControls = this.$( '<div>' )
 		.addClass( 've-ui-wikiaSingleMediaDialog-cartControls' );
 	this.$cartViewButtons = this.$( '<div>' )
@@ -37,10 +33,9 @@ ve.ui.WikiaSingleMediaCartWidget = function VeUiWikiaSingleMediaCartWidget( conf
 		'icon': 'cart-list',
 		'classes': [ 've-ui-wikiaSingleMediaDialog-cartListButton' ]
 	} );
-	this.$cartControls.append( this.$cartViewButtons.append( [
-		this.cartGridButton.$element,
-		this.cartListButton.$element
-	] ) );
+
+	this.cartModel = new ve.dm.WikiaCart();
+	this.cartSelect = new ve.ui.WikiaSingleMediaCartSelectWidget( this.cartModel );
 
 	// Events
 	this.dialog.connect( this, { 'layout': 'onLayout' } );
@@ -48,9 +43,17 @@ ve.ui.WikiaSingleMediaCartWidget = function VeUiWikiaSingleMediaCartWidget( conf
 	this.cartListButton.connect( this, { 'click': [ this.emit, 'layout', 'list' ] } );
 
 	// Initialization
+	this.$cartControls.append( this.$cartViewButtons.append( [
+		this.cartGridButton.$element,
+		this.cartListButton.$element
+	] ) );
 	this.$element
 		.addClass( 've-ui-wikiaSingleMediaCartWidget' )
-		.append( this.$cartControls, this.$rightSide );
+		.append( this.$cartControls, this.cartSelect.$element );
+
+	// Temp stuff
+	this.tempItem = new ve.dm.WikiaCartItem( 'Janice elton floyd.jpg', 'http://vignette.wikia-dev.com/muppet/images/3/31/Janice_elton_floyd.jpg/revision/latest?cb=20110101181243', 'photo', undefined, 'wikia' );
+	this.cartModel.addItems( [ this.tempItem, this.tempItem, this.tempItem, this.tempItem, this.tempItem ] );
 };
 
 OO.inheritClass( ve.ui.WikiaSingleMediaCartWidget, OO.ui.Widget );


### PR DESCRIPTION
Creating the views for the cart. The prior WikiaMediaInsertDialog had a very simple cart and had views that extended Select and Option only. This new WikiaSingleMediaDialog has a more complex cart featuring view toggle controls, an upload widget (eventually) and a list of cart items. The new architecture uses a cart widget, cart select, and cart options. 

There is some temporary code in ve.ui.WikiaSingleMediaCartWidget.js to populate the view. It should be removed once the logic is in place to populate the cart from the search results.
