### PR TITLE
DAT-2176 remove checking of $wgStatsDBEnabled

### DIFF
--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -1149,11 +1149,7 @@ class Wikia {
 	 * hooked up to AddNewAccount
 	 */
 	static public function ignoreUser( $user, $byEmail = false ) {
-		global $wgStatsDBEnabled, $wgExternalDatawareDB;
-
-		if ( empty( $wgStatsDBEnabled ) ) {
-			return true;
-		}
+		global $wgExternalDatawareDB;
 
 		if ( ( $user instanceof User ) && ( 0 === strpos( $user->getName(), 'WikiaTestAccount' ) ) ) {
 			if( !wfReadOnly() ){ // Change to wgReadOnlyDbMode if we implement that


### PR DESCRIPTION
1)  wgExternalDatawareDB works on Reston
2)  wfReadOnly() returns true on Reston 

connected with: https://github.com/Wikia/config/pull/726
