### PR TITLE
VID-2130 Fixing gallery loading race condition

### DIFF
--- a/resources/mediawiki.page/mediawiki.page.startup.js
+++ b/resources/mediawiki.page/mediawiki.page.startup.js
@@ -1,36 +1,37 @@
-( function ( $ ) {
+( function ( mw, $ ) {
 
 	mw.page = {};
 
 	// Client profile classes for <html>
 	// Allows for easy hiding/showing of JS or no-JS-specific UI elements
 	$( 'html' )
-		.addClass('client-js' )
+		.addClass( 'client-js' )
 		.removeClass( 'client-nojs' );
 
-	// Initialize utilities as soon as the document is ready (mw.util.$content,
-	// messageBoxNew, profile, tooltip access keys, Table of contents toggle, ..).
-	// Enqueued into domready from here instead of mediawiki.page.ready to ensure that it gets enqueued
-	// before other modules hook into document ready, so that mw.util.$content (defined by mw.util.init),
-	// is defined for them.
-	$( mw.util.init );
+	$( function () {
+		// Initialize utilities as soon as the document is ready (mw.util.$content).
+		// In the domready here instead of in mediawiki.page.ready to ensure that it gets enqueued
+		// before other modules hook into domready, so that mw.util.$content (defined by
+		// mw.util.init), is defined for them.
+		mw.util.init();
 
-	/**
-	 * Fired when wiki content is being added to the DOM
-	 *
-	 * It is encouraged to fire it before the main DOM is changed (when $content
-	 * is still detatched).  However, this order is not defined either way, so you
-	 * should only rely on $content itself.
-	 *
-	 * This includes the ready event on a page load (including post-edit loads)
-	 * and when content has been previewed with LivePreview.
-	 *
-	 * @event wikipage_content
-	 * @member mw.hook
-	 * @param {jQuery} $content The most appropriate element containing the content,
-	 *   such as #mw-content-text (regular content root) or #wikiPreview (live preview
-	 *   root)
-	 */
-	mw.hook( 'wikipage.content' ).fire( $( '#mw-content-text' ) );
+		/**
+		 * Fired when wiki content is being added to the DOM
+		 *
+		 * It is encouraged to fire it before the main DOM is changed (when $content
+		 * is still detatched).  However, this order is not defined either way, so you
+		 * should only rely on $content itself.
+		 *
+		 * This includes the ready event on a page load (including post-edit loads)
+		 * and when content has been previewed with LivePreview.
+		 *
+		 * @event wikipage_content
+		 * @member mw.hook
+		 * @param {jQuery} $content The most appropriate element containing the content,
+		 *   such as #mw-content-text (regular content root) or #wikiPreview (live preview
+		 *   root)
+		 */
+		mw.hook( 'wikipage.content' ).fire( $( '#mw-content-text' ) );
+	} );
 
-} )( jQuery );
+}( mediaWiki, jQuery ) );


### PR DESCRIPTION
Galleries weren't always loading b/c the `wikipage.content` event wasn't waiting for the DOM to be ready. I had only ported over one line from MW1.23.6 and had missed the part where it waited for the onload event. 
