### PR TITLE
VE-1648: Styling for results and other UI

### DIFF
--- a/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaSingleMediaDialog.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaSingleMediaDialog.js
@@ -39,20 +39,19 @@ ve.ui.WikiaSingleMediaDialog.prototype.initialize = function () {
 	ve.ui.WikiaSingleMediaDialog.super.prototype.initialize.call( this );
 
 	// Properties
+	this.mode = {
+		'action': 'insert',
+		'type': 'image'
+	};
 	this.query = new ve.ui.WikiaSingleMediaQueryWidget( {
 		'$': this.$,
 		'placeholder': ve.msg( 'visualeditor-dialog-wikiasinglemedia-search' )
 	} );
 	this.queryInput = this.query.getInput();
-	this.search = new ve.ui.WikiaMediaResultsWidget( { '$': this.$ } );
-	this.results = this.search.getResults();
-
-	// Main panels
 	this.$main = this.$( '<div>' )
 		.addClass( 've-ui-wikiaSingleMediaDialog-main' );
-	this.$leftSide = this.$( '<div>' )
-		.addClass( 've-ui-wikiaSingleMediaDialog-leftSide' )
-		.append( this.search.$element );
+	this.search = new ve.ui.WikiaMediaResultsWidget( { '$': this.$ } );
+	this.results = this.search.getResults();
 	this.cart = new ve.ui.WikiaSingleMediaCartWidget( { 'dialog': this } );
 
 	// Foot elements
@@ -84,10 +83,11 @@ ve.ui.WikiaSingleMediaDialog.prototype.initialize = function () {
 		'change': 'onQueryInputChange'
 	} );
 	this.queryInput.$input.on( 'keydown', ve.bind( this.onQueryInputKeydown, this ) );
+	this.cancelButton.connect( this, { 'click': 'onCloseButtonClick' } );
 
 	// Initialization
 	this.frame.$content.addClass( 've-ui-wikiaSingleMediaDialog' );
-	this.$main.append( this.$leftSide, this.cart.$element );
+	this.$main.append( this.search.$element, this.cart.$element );
 
 	this.$policy.append( this.$policyInner );
 	this.$body.append( this.query.$element, this.$main );
@@ -123,7 +123,15 @@ ve.ui.WikiaSingleMediaDialog.prototype.setLayout = function ( layout ) {
 	} else if ( layout === 'list' ) {
 		this.$main.css( 'left', -552 );
 	}
+	this.layout = layout;
 	this.emit( 'layout', layout );
+};
+
+/*
+ * Gets value of this.layout
+ */
+ve.ui.WikiaSingleMediaDialog.prototype.getLayout = function () {
+	return this.layout;
 };
 
 /**
@@ -154,6 +162,9 @@ ve.ui.WikiaSingleMediaDialog.prototype.onSearchNearingEnd = function () {
  */
 ve.ui.WikiaSingleMediaDialog.prototype.onQueryInputChange = function () {
 	this.results.clearItems();
+	if ( this.getLayout() === 'list' ) {
+		this.setLayout( 'grid' );
+	}
 };
 
 /* Registration */

--- a/extensions/VisualEditor/wikia/modules/ve/ui/styles/ve.ui.WikiaSingleMediaInsertDialog.scss
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/styles/ve.ui.WikiaSingleMediaInsertDialog.scss
@@ -15,6 +15,22 @@ $width-results: 552px;
 			float: right;
 		}
 	}
+
+	.ve-ui-wikiaMediaResultsWidget {
+		height: 100%;
+		left: 0;
+		overflow-y: auto;
+		position: absolute;
+		width: $width-results;
+
+		.oo-ui-selectWidget {
+			margin: 20px 24px;
+		}
+
+		.ve-ui-mwMediaResultWidget {
+			margin: 0 5px 60px;
+		}
+	}
 }
 
 .ve-ui-wikiaSingleMediaQueryWidget {
@@ -37,13 +53,6 @@ $width-results: 552px;
 	position: absolute;
 	right: 0;
 	top: 70px;
-}
-
-.ve-ui-wikiaSingleMediaDialog-leftSide {
-	height: 100%;
-	overflow-y: auto;
-	position: absolute;
-	width: $width-results;
 }
 
 .ve-ui-wikiaSingleMediaDialog-policy {
@@ -116,6 +125,10 @@ $width-results: 552px;
 	line-height: 0;
 	padding: 5px 20px;
 	width: $width-dialog;
+
+	&.oo-ui-optionWidget-highlighted, &.oo-ui-optionWidget-selected {
+		background: transparent;
+	}
 }
 
 .ve-ui-wikiaSingleMediaCartOptionImage {


### PR DESCRIPTION
Styling for the layout of the search results matches the design mockup. The design of the option widgets themselves will come in another pull request.

Small additions to this pull request:
- this.mode object to be used later when building UI for image/video and insert/edit flows. Does not need a setter method (the mode will be dictated by the entry point) but will likely need a getter later.
- Typing in the search field will transition from list to grid layout.
- Cancel button closes the dialog.
