### PR TITLE
CON-2074: new media galleries on Venus

### DIFF
--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -1447,7 +1447,7 @@ $config['wikiasearch_scss_wikiamobile'] = array(
 
 /** Places **/
 $config['places_js'] = array(
-	'skin' => array( 'oasis', 'monobook', 'wikiamobile' ),
+	'skin' => array( 'oasis', 'monobook', 'wikiamobile', 'venus' ),
 	'type' => AssetsManager::TYPE_JS,
 	'assets' => array(
 			'//extensions/wikia/Places/js/Places.js'
@@ -1456,7 +1456,7 @@ $config['places_js'] = array(
 
 $config['places_css'] = array(
 	'type' => AssetsManager::TYPE_CSS,
-	'skin' => array( 'oasis', 'monobook', 'wikiamobile' ),
+	'skin' => array( 'oasis', 'monobook', 'wikiamobile', 'venus' ),
 	'assets' => array(
 			'//extensions/wikia/Places/css/Places.css',
 	)

--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -2072,7 +2072,7 @@ $config['global_header_js'] = [
 
 $config['media_gallery_js'] = [
 	'type' => AssetsManager::TYPE_JS,
-	'skin' => ['oasis'],
+	'skin' => ['oasis', 'venus'],
 	'assets' => [
 		'//extensions/wikia/MediaGallery/scripts/templates.mustache.js',
 		'//extensions/wikia/MediaGallery/scripts/views/caption.js',

--- a/extensions/wikia/MediaGallery/MediaGallery.setup.php
+++ b/extensions/wikia/MediaGallery/MediaGallery.setup.php
@@ -27,6 +27,7 @@ $wgAutoloadClasses['MediaGalleryModel'] =  $dir . 'MediaGalleryModel.class.php';
 $wgAutoloadClasses['MediaGalleryHooks'] =  $dir . 'MediaGalleryHooks.class.php';
 $wgHooks['OutputPageBeforeHTML'][] = 'MediaGalleryHooks::onOutputPageBeforeHTML';
 $wgHooks['OasisSkinAssetGroups'][] = 'MediaGalleryHooks::onOasisSkinAssetGroups';
+$wgHooks['VenusAssetsPackages'][] = 'MediaGalleryHooks::onVenusAssetsPackages';
 $wgHooks['MakeGlobalVariablesScript'][] = 'MediaGalleryHooks::onMakeGlobalVariablesScript';
 $wgHooks['WikiFeatures::afterToggleFeature'][] = 'MediaGalleryHooks::afterToggleFeature';
 

--- a/extensions/wikia/MediaGallery/MediaGalleryHooks.class.php
+++ b/extensions/wikia/MediaGallery/MediaGalleryHooks.class.php
@@ -30,6 +30,21 @@ class MediaGalleryHooks {
 	}
 
 	/**
+	 * Adds MediaGallery JS to main Venus asset group
+	 *
+	 * @param Array $jsHeadGroups
+	 * @param Array $jsBodyGroups
+	 * @param Array $cssGroups
+	 * @return bool
+	 */
+	public static function onVenusAssetsPackages( Array &$jsHeadGroups, Array &$jsBodyGroups, Array &$cssGroups ) {
+		if ( !empty( F::app()->wg->EnableMediaGalleryExt ) ) {
+			$jsBodyGroups[] = 'media_gallery_js';
+		}
+		return true;
+	}
+
+	/**
 	 * Add extension enabled flag to JS
 	 * @param array $vars
 	 * @return bool

--- a/includes/OutputPage.php
+++ b/includes/OutputPage.php
@@ -459,6 +459,21 @@ class OutputPage extends ContextSource {
 	 * @return Array of module names
 	 */
 	public function getModules( $filter = false, $position = null, $param = 'mModules' ) {
+		// Wikia change - begin - @author macbre
+		// Load all ResourceLoader modules at the bottom of the page
+		// when the skin has the flag set (e.g. Venus)
+		$skin = $this->getSkin();
+		if ( $skin instanceof WikiaSkin && !empty( $skin->pushRLModulesToBottom ) ) {
+			// when asked for top modules return nothing
+			if ( $position === 'top' ) {
+				return [];
+			}
+
+			// otherwise, return all modules - null means no filtering below
+			$position = null;
+		}
+		// Wikia change - end
+
 		$modules = array_values( array_unique( $this->$param ) );
 		return $filter
 			? $this->filterModules( $modules, $position )

--- a/includes/wikia/nirvana/WikiaSkin.class.php
+++ b/includes/wikia/nirvana/WikiaSkin.class.php
@@ -20,6 +20,10 @@ abstract class WikiaSkin extends SkinTemplate {
 	//@see AssetsManager::checkAssetUrlForSkin
 	protected $strictAssetUrlCheck = true;
 
+	//load all ResourceLoader modules at the bottom of the page
+	//@see OutputPage::getModules
+	public $pushRLModulesToBottom = false;
+
 	private $assetsManager;
 
 	/**

--- a/skins/Venus.php
+++ b/skins/Venus.php
@@ -6,8 +6,6 @@ if (!defined('MEDIAWIKI')) die();
  * @author Consumer Team
  */
 
-require_once('includes/SkinTemplate.php');
-
 class SkinVenus extends WikiaSkin {
 	function __construct() {
 		global $wgOut;
@@ -16,6 +14,7 @@ class SkinVenus extends WikiaSkin {
 		$wgOut->addModuleStyles( 'skins.venus' );
 
 		$this->strictAssetUrlCheck = true;
+		$this->pushRLModulesToBottom = true;
 	}
 
 	function setupSkinUserCss( OutputPage $out ) {}


### PR DESCRIPTION
- adding Media Gallery AM packages to Venus
- introduce `WikiaSkin::$pushRLModulesToBottom` flag to load all ResourceLoader modules at the bottom of the page and set it in Venus

Pinging @lizlux (please review gallery related changes) and @Wikia/platform-team (skin / core changes)
