### PR TITLE
Return HTTP 503 when DB can not be found on a devbox

### DIFF
--- a/extensions/wikia/Development/SpecialDevBoxPanel/Special_DevBoxPanel.php
+++ b/extensions/wikia/Development/SpecialDevBoxPanel/Special_DevBoxPanel.php
@@ -190,8 +190,8 @@ function wfDevBoxForceWiki(WikiFactoryLoader $wikiFactoryLoader){
 
 			$devbox_dbs = array_merge(getDevBoxOverrideDatabases($db1), getDevBoxOverrideDatabases($db2));
 			if (array_search($dbname, $devbox_dbs) === false) {
-				echo "<pre>Fatal Error: No local copy of database [$dbname] was found.</pre>";
-				exit(); // fatal error
+				header('HTTP/1.1 503');
+				die("<pre>Fatal Error: No local copy of database [$dbname] was found.</pre>");
 			}
 		}
 


### PR DESCRIPTION
Set HTTP 503 response code when a database cannot be found on a devbox

No ticket, HTTP 200 was simply not kosher for me :)

@Wikia/platform-team 
