### PR TITLE
PLATFORM-559: move Bucky in Monobook up a bit

### DIFF
--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -821,8 +821,8 @@ $config['monobook_js'] = array(
 	'assets' => array(
 		'#group_oasis_shared_core_js',
 		'#group_oasis_jquery',
-		'#group_articlecomments_js',
 		'#group_bucky_js',
+		'#group_articlecomments_js',
 
 		// TODO: remove dependency on YUI (see BugId:3116)
 		'//resources/wikia/libraries/yui/utilities/utilities.js',


### PR DESCRIPTION
Define `window.bucky` before it's used by ArticleComments.

@Wikia/platform-team / @wladekb 
