### PR TITLE
VE-1661: Option styling

### DIFF
--- a/extensions/VisualEditor/wikia/VisualEditor.i18n.php
+++ b/extensions/VisualEditor/wikia/VisualEditor.i18n.php
@@ -72,8 +72,10 @@ $messages['en'] = array(
 	'wikia-visualeditor-dialog-preference-link-preferences' => 'Manage your editor preferences',
 	'wikia-visualeditor-dialog-preference-start-button' => 'Got it!',
 	'wikia-visualeditor-dialogbutton-wikiasinglemedia-tooltip' => 'Gallery',
-	'visualeditor-dialog-wikiasinglemedia-title' => 'Insert Gallery',
-	'visualeditor-dialog-wikiasinglemedia-search' => 'Search for images',
+	'wikia-visualeditor-dialog-wikiasinglemedia-title' => 'Insert Gallery',
+	'wikia-visualeditor-dialog-wikiasinglemedia-search' => 'Search for images',
+	'wikia-visualeditor-wikiamediaoptionwidget-preview-photo' => 'View',
+	'wikia-visualeditor-wikiamediaoptionwidget-preview-video' => 'Watch',
 );
 
 /** Message documentation (Message documentation)
@@ -162,8 +164,10 @@ $messages['qqq'] = array(
 	'wikia-visualeditor-dialog-preference-link-preferences' => 'Link text to user preference page',
 	'wikia-visualeditor-dialog-preference-start-button' => 'Button copy that closes the dialog',
 	'wikia-visualeditor-dialogbutton-wikiasinglemedia-tooltip' => 'Tooltip of the single media dialog tool (currently posing as a Gallery-only tool',
-	'visualeditor-dialog-wikiasinglemedia-title' => 'Title of the single media dialog (currently posing as a Gallery-only tool',
-	'visualeditor-dialog-wikiasinglemedia-search' => 'Placeholder text of the single media dialog search field',
+	'wikia-visualeditor-dialog-wikiasinglemedia-title' => 'Title of the single media dialog (currently posing as a Gallery-only tool',
+	'wikia-visualeditor-dialog-wikiasinglemedia-search' => 'Placeholder text of the single media dialog search field',
+	'wikia-visualeditor-wikiamediaoptionwidget-preview-photo' => 'The text that prompts a user to preview a photo',
+	'wikia-visualeditor-wikiamediaoptionwidget-preview-video' => 'The text that prompts a user to preview a video',
 );
 
 /** Tunisian Spoken Arabic ( زَوُن)

--- a/extensions/VisualEditor/wikia/VisualEditor.php
+++ b/extensions/VisualEditor/wikia/VisualEditor.php
@@ -218,8 +218,10 @@ $wgResourceModules += array(
 			'wikia-visualeditor-dialog-preference-link-preferences',
 			'wikia-visualeditor-dialog-preference-start-button',
 			'wikia-visualeditor-dialogbutton-wikiasinglemedia-tooltip',
-			'visualeditor-dialog-wikiasinglemedia-title',
-			'visualeditor-dialog-wikiasinglemedia-search',
+			'wikia-visualeditor-dialog-wikiasinglemedia-title',
+			'wikia-visualeditor-dialog-wikiasinglemedia-search',
+			'wikia-visualeditor-wikiamediaoptionwidget-preview-photo',
+			'wikia-visualeditor-wikiamediaoptionwidget-preview-video',
 		),
 		'dependencies' => array(
 			'ext.visualEditor.core.desktop',

--- a/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaSingleMediaDialog.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaSingleMediaDialog.js
@@ -28,7 +28,7 @@ OO.inheritClass( ve.ui.WikiaSingleMediaDialog, ve.ui.Dialog );
 
 ve.ui.WikiaSingleMediaDialog.static.name = 'wikiaSingleMedia';
 
-ve.ui.WikiaSingleMediaDialog.static.title = OO.ui.deferMsg( 'visualeditor-dialog-wikiasinglemedia-title' );
+ve.ui.WikiaSingleMediaDialog.static.title = OO.ui.deferMsg( 'wikia-visualeditor-dialog-wikiasinglemedia-title' );
 
 ve.ui.WikiaSingleMediaDialog.static.icon = 'gallery';
 
@@ -45,7 +45,7 @@ ve.ui.WikiaSingleMediaDialog.prototype.initialize = function () {
 	};
 	this.query = new ve.ui.WikiaSingleMediaQueryWidget( {
 		'$': this.$,
-		'placeholder': ve.msg( 'visualeditor-dialog-wikiasinglemedia-search' )
+		'placeholder': ve.msg( 'wikia-visualeditor-dialog-wikiasinglemedia-search' )
 	} );
 	this.queryInput = this.query.getInput();
 	this.$main = this.$( '<div>' )

--- a/extensions/VisualEditor/wikia/modules/ve/ui/styles/images/icons/preview-photo-white.svg
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/styles/images/icons/preview-photo-white.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="14px" height="14px" viewBox="0 0 14 14" enable-background="new 0 0 14 14" xml:space="preserve">
+<g fill="#8096ac">
+	<path d="M12.8,11.6L9.2,8.1C9.7,7.3,10,6.4,10,5.5C10,3,8,1,5.5,1S1,3,1,5.5S3,10,5.5,10c0.9,0,1.8-0.3,2.6-0.8l3.6,3.6c0.3,0.3,0.8,0.2,1.1,0C13.1,12.3,13.1,11.9,12.8,11.6z M2.5,5.5c0-1.6,1.3-3,3-3s3,1.3,3,3s-1.3,3-3,3S2.5,7.1,2.5,5.5z"/>
+	<rect x="5" y="4" width="1" height="3"/>
+	<rect x="4" y="5" width="3" height="1"/>
+</g>
+</svg>

--- a/extensions/VisualEditor/wikia/modules/ve/ui/styles/images/icons/preview-photo.svg
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/styles/images/icons/preview-photo.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="14px" height="14px" viewBox="0 0 14 14" enable-background="new 0 0 14 14" xml:space="preserve">
+<g fill="#7f7f7f">
+	<path d="M12.8,11.6L9.2,8.1C9.7,7.3,10,6.4,10,5.5C10,3,8,1,5.5,1S1,3,1,5.5S3,10,5.5,10c0.9,0,1.8-0.3,2.6-0.8l3.6,3.6c0.3,0.3,0.8,0.2,1.1,0C13.1,12.3,13.1,11.9,12.8,11.6z M2.5,5.5c0-1.6,1.3-3,3-3s3,1.3,3,3s-1.3,3-3,3S2.5,7.1,2.5,5.5z"/>
+	<rect x="5" y="4" width="1" height="3"/>
+	<rect x="4" y="5" width="3" height="1"/>
+</g>
+</svg>

--- a/extensions/VisualEditor/wikia/modules/ve/ui/styles/ve.ui.Icons-vector.scss
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/styles/ve.ui.Icons-vector.scss
@@ -349,6 +349,9 @@
 .oo-ui-icon-cart-list {
 	@include ve-icon(cart-list, wikia);
 }
+.oo-ui-icon-preview-photo {
+	@include ve-icon(preview-photo, wikia);
+}
 
 /*
  * Specific overrides

--- a/extensions/VisualEditor/wikia/modules/ve/ui/styles/ve.ui.WikiaMediaInsertDialog.scss
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/styles/ve.ui.WikiaMediaInsertDialog.scss
@@ -74,6 +74,9 @@ $width-cart: 120px;
 			width: 0px;
 		}
 	}
+	.ve-ui-wikiaMediaOptionWidget-metaData {
+		display: none;
+	}
 }
 
 /* Cart */

--- a/extensions/VisualEditor/wikia/modules/ve/ui/styles/ve.ui.WikiaSingleMediaInsertDialog.scss
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/styles/ve.ui.WikiaSingleMediaInsertDialog.scss
@@ -1,5 +1,6 @@
 @import "skins/shared/mixins/transition";
 @import "skins/shared/color";
+@import "skins/shared/mixins/cursor";
 @import "mixins/ve-icon";
 
 $width-dialog: 712px;
@@ -28,7 +29,21 @@ $width-results: 552px;
 		}
 
 		.ve-ui-mwMediaResultWidget {
+			cursor: pointer;
 			margin: 0 5px 60px;
+
+			.ve-ui-wikiaMediaOptionWidget-metaData {
+				@include cursor( 'zoom-in' );
+				margin-top: 160px;
+				padding: 2px 0;
+				position: absolute;
+				width: 100%;
+			}
+			.oo-ui-labeledElement-label {
+				@include cursor( 'zoom-in' );
+				margin-top: 178px;
+				padding: 0;
+			}
 		}
 	}
 }
@@ -55,6 +70,7 @@ $width-results: 552px;
 	top: 70px;
 }
 
+/* Foot */
 .ve-ui-wikiaSingleMediaDialog-policy {
 	align-items: center;
 	color: $color-alternate-text;
@@ -71,6 +87,7 @@ $width-results: 552px;
 	}
 }
 
+/* Cart */
 .ve-ui-wikiaSingleMediaCartWidget {
 	background: $color-ve-page-secondary;
 	bottom: 0;
@@ -127,8 +144,19 @@ $width-results: 552px;
 	width: $width-dialog;
 
 	&.oo-ui-optionWidget-highlighted, &.oo-ui-optionWidget-selected {
+		box-shadow: none;
 		background: transparent;
 	}
+}
+
+.ve-ui-wikiaMediaOptionWidget-preview {
+	float: right;
+	text-transform: uppercase;
+}
+.ve-ui-wikiaMediaOptionWidget-preview-icon {
+	float: left;
+	height: 14px;
+	width: 14px;
 }
 
 .ve-ui-wikiaSingleMediaCartOptionImage {
@@ -145,4 +173,12 @@ $width-results: 552px;
 	height: 120px;
 	margin-left: 20px;
 	width: 530px;
+}
+
+.ve-ui-wikiaMediaOptionWidget-metaData {
+	color: $color-alternate-text;
+	font-size: .8em;
+	font-weight: bold;
+	margin-top: 162px;
+	position: absolute;
 }

--- a/extensions/VisualEditor/wikia/modules/ve/ui/widgets/ve.ui.WikiaMediaOptionWidget.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/widgets/ve.ui.WikiaMediaOptionWidget.js
@@ -28,6 +28,10 @@ ve.ui.WikiaMediaOptionWidget = function VeUiWikiaMediaOptionWidget( data, config
 	this.$back = this.$( '<div>' );
 	this.$front = this.$( '<div>' );
 	this.$thumb = this.$back.add( this.$front );
+	this.$metaData = this.$( '<div>' );
+	this.$preview = this.$( '<div>' );
+	this.$previewIcon = this.$( '<span>' );
+	this.$previewText = this.$( '<span>' );
 	// TODO: Presence of checkbox perhaps should depend on the configuration
 	this.check = new OO.ui.ButtonWidget( {
 		'$': this.$,
@@ -48,6 +52,15 @@ ve.ui.WikiaMediaOptionWidget = function VeUiWikiaMediaOptionWidget( data, config
 	this.setLabel( this.mwTitle );
 	this.$label.attr( 'title', this.mwTitle );
 	this.check.$element.addClass( 've-ui-wikiaMediaOptionWidget-check' );
+	this.$previewIcon.addClass( 've-ui-wikiaMediaOptionWidget-preview-icon' );
+	this.$previewText.addClass( 've-ui-wikiaMediaOptionWidget-preview-text' );
+	this.$preview
+		.addClass( 've-ui-wikiaMediaOptionWidget-preview' )
+		.append( this.$previewIcon, this.$previewText );
+	this.$metaData
+		.addClass( 've-ui-wikiaMediaOptionWidget-metaData' )
+		.append( this.$preview )
+		.insertBefore( this.$label );
 	this.$element
 		.addClass( 've-ui-mwMediaResultWidget ve-ui-texture-pending ' + this.data.type )
 		.css( { 'width': this.size, 'height': this.size } )

--- a/extensions/VisualEditor/wikia/modules/ve/ui/widgets/ve.ui.WikiaPhotoOptionWidget.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/widgets/ve.ui.WikiaPhotoOptionWidget.js
@@ -15,8 +15,20 @@
  * @cfg {number} [size] Media thumbnail size
  */
 ve.ui.WikiaPhotoOptionWidget = function VeUiWikiaPhotoOptionWidget( data, config ) {
+	var $dimensions;
+
 	// Parent constructor
 	ve.ui.WikiaPhotoOptionWidget.super.call( this, data, config );
+
+	// Initialization
+	$dimensions = this.$( '<div>' )
+		.addClass( 've-ui-wikiaPhotoOptionWidget-dimensions' )
+		.text( data.width + ' x ' + data.height );
+	this.$previewIcon.addClass( 'oo-ui-icon-preview-photo' );
+
+	// DOM changes
+	this.$metaData.append( $dimensions );
+	this.$previewText.text( ve.msg( 'wikia-visualeditor-wikiamediaoptionwidget-preview-photo' ) );
 };
 
 /* Inheritance */


### PR DESCRIPTION
This pull request styles the WikiaMediaOptionWidgets for the new single media dialog. The styling of the contents of the WikiaMediaInsertDialog is not altered.
- Changed naming on previously-committed messages
- WikiaMediaOptionWidget has common changes
- WikiaPhotoOptionWidget adds dimensions and sets correct preview icon and text
- Preview functionality will come in VE-1653.
