### PR TITLE
remove any report limit

### DIFF
--- a/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php
+++ b/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php
@@ -205,4 +205,21 @@ class ArticleAsJson extends WikiaService {
 
 		return true;
 	}
+
+	/**
+	 * Remove any limit report, we don't need that in json
+	 *
+	 * @param $parser Parser
+	 * @param $report
+	 * @return bool
+	 */
+	public static function reportLimits( $parser, &$report ) {
+		global $wgArticleAsJson;
+
+		if ( $wgArticleAsJson ) {
+			$report = '';
+		}
+
+		return false;
+	}
 }

--- a/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php
+++ b/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php
@@ -218,8 +218,10 @@ class ArticleAsJson extends WikiaService {
 
 		if ( $wgArticleAsJson ) {
 			$report = '';
+
+			return false;
 		}
 
-		return false;
+		return true;
 	}
 }

--- a/extensions/wikia/ArticleAsJson/ArticleAsJson.setup.php
+++ b/extensions/wikia/ArticleAsJson/ArticleAsJson.setup.php
@@ -17,3 +17,4 @@ $wgHooks['GalleryBeforeProduceHTML'][] = 'ArticleAsJson::onGalleryBeforeProduceH
 $wgHooks['PageRenderingHash'][] = 'ArticleAsJson::onPageRenderingHash';
 $wgHooks['ParserAfterTidy'][] = 'ArticleAsJson::onParserAfterTidy';
 $wgHooks['Parser::showEditLink'][] = 'ArticleAsJson::onShowEditLink';
+$wgHooks['ParserLimitReport'][] = 'ArticleAsJson::reportLimits';


### PR DESCRIPTION
Storing article in JSON in parser cache, is too fragile for a long run, 
This fixes the problem for now,
but we will have to think of a better way to handle this
