### PR TITLE
CON-2113: load Wikia.css in Venus

### DIFF
--- a/extensions/wikia/AssetsManager/AssetsManager.class.php
+++ b/extensions/wikia/AssetsManager/AssetsManager.class.php
@@ -645,10 +645,15 @@ class AssetsManager {
 	public function checkAssetUrlForSkin( $url, WikiaSkin $skin ) {
 		wfProfileIn( __METHOD__ );
 
+		// ResourceLoader has its own skin filtering mechanism, skip the check for /__load/ URLs - CON-2113
+		if ( strpos( $url, '/__load/' ) !== false ) {
+			wfProfileOut( __METHOD__ );
+			return true;
+		}
+
 		//lazy loading of AssetsConfig
 		$this->loadConfig();
 		$group = null;
-		$skinName = $skin->getSkinName();
 		$strict = $skin->isStrict();
 
 		if ( is_string( $url ) && array_key_exists($url, $this->mGeneratedUrls) ) {

--- a/extensions/wikia/AssetsManager/tests/AssetsManagerTest.php
+++ b/extensions/wikia/AssetsManager/tests/AssetsManagerTest.php
@@ -122,6 +122,48 @@ class AssetsManagerTest extends WikiaBaseTest {
 		$this->assertEquals( $assetsManagerMock->checkIfGroupForSkin( 'foo', $wikiaSkinMock ), $expectedValue );
 	}
 
+	/**
+	 * @dataProvider checkAssetUrlForSkinDataProvider
+	 */
+	public function testCheckAssetUrlForSkin( $url, $isSkinStrict, $expectedValue ) {
+		$skinMock = $this->mockClassWithMethods('WikiaSkin', [
+			'isStrict' => $isSkinStrict,
+			'checkIfGroupForSkin' => false, // "block" all assets when in strict mode
+			'loadConfig' => null,
+		]);
+
+		$assetsManagerMock = $this->getMock( 'AssetsManager', null, [], '', false );
+
+		$this->assertEquals( $expectedValue, $assetsManagerMock->checkAssetUrlForSkin($url, $skinMock) );
+	}
+
+	public function checkAssetUrlForSkinDataProvider() {
+		return [
+			// always accept ResourceLoader URLs
+			[
+				'url' => 'http://foo.net/__load/123',
+				'isSkinStrict' => true,
+				'expectedValue' => true,
+			],
+			[
+				'url' => 'http://foo.net/__load/123',
+				'isSkinStrict' => false,
+				'expectedValue' => true,
+			],
+			// AssetsManager URLs - depends on whether the skin is strict
+			[
+				'url' => 'http://i2.macbre.wikia-dev.com/__am/123456/group/-/local_navigation_js',
+				'isSkinStrict' => true,
+				'expectedValue' => false,
+			],
+			[
+				'url' => 'http://i2.macbre.wikia-dev.com/__am/123456/group/-/local_navigation_js',
+				'isSkinStrict' => false,
+				'expectedValue' => true,
+			],
+		];
+	}
+
 	public function duplicateAssetsDataProvider() {
 		$dataSets = array();
 

--- a/extensions/wikia/Venus/VenusController.class.php
+++ b/extensions/wikia/Venus/VenusController.class.php
@@ -84,7 +84,12 @@ class VenusController extends WikiaController {
 
 	private function setBodyClasses() {
 		// generate list of CSS classes for <body> tag
-		$bodyClasses = [$this->skinNameClass, $this->dir, $this->pageClass];
+		$bodyClasses = [
+			'mediawiki',
+			$this->skinNameClass,
+			$this->dir,
+			$this->pageClass
+		];
 
 		// add skin theme name
 		if(!empty($this->skin->themename)) {

--- a/extensions/wikia/Venus/scripts/modules/spec/integration/nodeFinder.spec.js
+++ b/extensions/wikia/Venus/scripts/modules/spec/integration/nodeFinder.spec.js
@@ -1,7 +1,7 @@
 describe( 'moduleInsertion', function(){
 	'use strict';
 
-	var moduleInsertion,
+	var nodeFinder,
 		articleMock = document.createElement('div'),
 		extenderMock = document.createElement('div'),
 		h2Mock = document.createElement('h2'),
@@ -22,16 +22,16 @@ describe( 'moduleInsertion', function(){
 
 	document.body.appendChild(articleMock);
 
-	moduleInsertion = modules['venus.moduleInsertion'](document);
+	nodeFinder = modules['venus.nodeFinder'](document);
 
 	it('header should returned', function(){
-		var header = moduleInsertion.findElementByOffsetTop(articleMock, 'h2', 100);
+		var header = nodeFinder.findNodeByOffsetTop(articleMock, 'h2', 100);
 		expect(header.id).toBe('h2-0');
 
-		header = moduleInsertion.findElementByOffsetTop(articleMock, 'h2', 300);
+		header = nodeFinder.findNodeByOffsetTop(articleMock, 'h2', 300);
 		expect(header.id).toBe('h2-1');
 
-		header = moduleInsertion.findElementByOffsetTop(articleMock, 'h2', 1000);
+		header = nodeFinder.findNodeByOffsetTop(articleMock, 'h2', 1000);
 		expect(header.id).toBe('h2-4');
 	});
 });

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1103,9 +1103,10 @@ $wgPasswordSenderName = 'Wikia';
  *
  * @var array
  */
-$wgResourceLoaderAssetsSkinMapping = array(
+$wgResourceLoaderAssetsSkinMapping = [
 	'oasis' => 'wikia', // in Oasis we use Wikia.js (and Wikia.css) instead of Oasis.js (Oasis.css)
-);
+	'venus' => 'wikia', // in Venus we use Wikia.js (and Wikia.css) instead of Venus.js (Venus.css) - CON-2113
+];
 
 /**
  * @see https://wikia.fogbugz.com/default.asp?36946


### PR DESCRIPTION
- add `.mediawiki` class to `<body>`
- always allow ResourceLoader assets to be loaded (even in strict mode)
- use `Wikia.css/js` in Venus
