### PR TITLE
CON-NewArticle: Load wikia photo gallery assets...

### DIFF
--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -1479,6 +1479,72 @@ $config['wikiaphotogallery_slider_scss_wikiamobile'] = array(
 	)
 );
 
+$config['wikia_photo_gallery_js'] = [
+	'type' => AssetsManager::TYPE_JS,
+	'skin' => ['oasis', 'venus'],
+	'assets' => [
+		'//extensions/wikia/WikiaPhotoGallery/js/WikiaPhotoGallery.view.js',
+	]
+];
+
+$config['wikia_photo_gallery_scss'] = [
+	'type' => AssetsManager::TYPE_SCSS,
+	'skin' => ['oasis', 'venus'],
+	'assets' => [
+		'//extensions/wikia/WikiaPhotoGallery/css/gallery.scss',
+	]
+];
+
+$config['wikia_photo_gallery_slideshow_js'] = [
+	'type' => AssetsManager::TYPE_JS,
+	'skin' => ['oasis', 'venus'],
+	'assets' => [
+		'//resources/wikia/libraries/jquery/slideshow/jquery-slideshow-0.4.js',
+		'//extensions/wikia/WikiaPhotoGallery/js/WikiaPhotoGallery.slideshow.js',
+	]
+];
+
+$config['wikia_photo_gallery_slideshow_scss'] = [
+	'type' => AssetsManager::TYPE_SCSS,
+	'skin' => ['oasis', 'venus'],
+	'assets' => [
+		'//extensions/wikia/WikiaPhotoGallery/css/slideshow.scss',
+	]
+];
+
+$config['wikia_photo_gallery_slider_js'] = [
+	'type' => AssetsManager::TYPE_JS,
+	'skin' => ['oasis', 'venus'],
+	'assets' => [
+		'//extensions/wikia/WikiaPhotoGallery/js/WikiaPhotoGallery.slider.js',
+	]
+];
+
+$config['wikia_photo_gallery_slider_scss'] = [
+	'type' => AssetsManager::TYPE_SCSS,
+	'skin' => ['oasis', 'venus'],
+	'assets' => [
+		'//extensions/wikia/WikiaPhotoGallery/css/WikiaPhotoGallery.slidertag.scss',
+	]
+];
+
+$config['wikia_photo_gallery_mosaic_js'] = [
+	'type' => AssetsManager::TYPE_JS,
+	'skin' => ['oasis', 'venus'],
+	'assets' => [
+		'//resources/wikia/libraries/modernizr/modernizr-2.0.6.js',
+		'//extensions/wikia/WikiaPhotoGallery/js/WikiaPhotoGallery.slider.mosaic.js',
+	]
+];
+
+$config['wikia_photo_gallery_mosaic_scss'] = [
+	'type' => AssetsManager::TYPE_SCSS,
+	'skin' => ['oasis', 'venus'],
+	'assets' => [
+		'//extensions/wikia/WikiaPhotoGallery/css/WikiaPhotoGallery.slidertag.mosaic.scss',
+	]
+];
+
 // ImageDrop
 $config['imagedrop_js'] = array(
 	'skin' => array( 'monobook', 'oasis' ),

--- a/extensions/wikia/WikiaPhotoGallery/WikiaPhotoGallery.class.php
+++ b/extensions/wikia/WikiaPhotoGallery/WikiaPhotoGallery.class.php
@@ -568,7 +568,6 @@ class WikiaPhotoGallery extends ImageGallery {
 				$out = $this->renderSlider();
 				break;
 		}
-
 		if ( !$this->canRenderMediaGallery() ) {
 			$out .= $this->getBaseJSSnippets();
 		}
@@ -587,8 +586,8 @@ class WikiaPhotoGallery extends ImageGallery {
 	private function getBaseJSSnippets() {
 		$out = JSSnippets::addToStack(
 			array(
-				'/extensions/wikia/WikiaPhotoGallery/js/WikiaPhotoGallery.view.js',
-				'/extensions/wikia/WikiaPhotoGallery/css/gallery.scss',
+				'wikia_photo_gallery_js',
+				'wikia_photo_gallery_scss',
 			),
 			array(),
 			'WikiaPhotoGalleryView.init'
@@ -1353,9 +1352,8 @@ class WikiaPhotoGallery extends ImageGallery {
 
 			$slideshowHtml .= JSSnippets::addToStack(
 				array(
-					'/resources/wikia/libraries/jquery/slideshow/jquery-slideshow-0.4.js',
-					'/extensions/wikia/WikiaPhotoGallery/css/slideshow.scss',
-					'/extensions/wikia/WikiaPhotoGallery/js/WikiaPhotoGallery.slideshow.js'
+					'wikia_photo_gallery_slideshow_js',
+					'wikia_photo_gallery_slideshow_scss'
 				),
 				array(),
 				'WikiaPhotoGallerySlideshow.init',
@@ -1544,15 +1542,14 @@ class WikiaPhotoGallery extends ImageGallery {
 
 			if ( $orientation == 'mosaic' ) {
 				$sliderResources = array(
-					'/resources/wikia/libraries/modernizr/modernizr-2.0.6.js',
-					'/extensions/wikia/WikiaPhotoGallery/css/WikiaPhotoGallery.slidertag.mosaic.scss',
-					'/extensions/wikia/WikiaPhotoGallery/js/WikiaPhotoGallery.slider.mosaic.js'
+					'wikia_photo_gallery_mosaic_js',
+					'wikia_photo_gallery_mosaic_scss'
 				);
 				$javascriptInitializationFunction = 'WikiaMosaicSliderMasterControl.init';
 			} else {
 				$sliderResources = array(
-					'/extensions/wikia/WikiaPhotoGallery/css/WikiaPhotoGallery.slidertag.scss',
-					'/extensions/wikia/WikiaPhotoGallery/js/WikiaPhotoGallery.slider.js'
+					'wikia_photo_gallery_slider_js',
+					'wikia_photo_gallery_slider_scss'
 				);
 				$javascriptInitializationFunction = 'WikiaPhotoGallerySlider.init';
 			}


### PR DESCRIPTION
Load wikia photo gallery assets when strict skin assets url check is enabled.

In Venus we have `strictAssetUrlCheck = true;` to avoid loading unnecessary assets, so we need to add them via Assets Manager package name to be able to check the skin name.

@lizlux can you review this change?
