### PR TITLE
VID-2134

### DIFF
--- a/includes/wikia/AsyncCache.php
+++ b/includes/wikia/AsyncCache.php
@@ -381,6 +381,7 @@ class AsyncCache {
 			'expires' => $this->getCacheExpire(),
 			'ttlRemain' => $this->ttlRemain(),
 			'staleTTLRemain' => $this->staleTTLRemain(),
+			'postTTL' => $this->currTime - $this->ttl,
 		] );
 	}
 }

--- a/includes/wikia/AsyncCache.php
+++ b/includes/wikia/AsyncCache.php
@@ -381,7 +381,7 @@ class AsyncCache {
 			'expires' => $this->getCacheExpire(),
 			'ttlRemain' => $this->ttlRemain(),
 			'staleTTLRemain' => $this->staleTTLRemain(),
-			'postTTL' => $this->currTime - $this->ttl,
+			'pastTTL' => $this->currTime - $this->ttl,
 		] );
 	}
 }

--- a/includes/wikia/services/MediaQueryService.class.php
+++ b/includes/wikia/services/MediaQueryService.class.php
@@ -620,7 +620,9 @@ class MediaQueryService extends WikiaService {
 		wfProfileIn( __METHOD__ );
 
 		$cacheTtl = 7200; // 2 hours for caching the result in memcache
-		$staleCacheTtl = 300; // 5m allowance for returning stale results until new cache is built
+		// 24hr allowance for returning stale results until new cache is built
+		// Adjusted to increase the caching benefit for infrequently views videos
+		$staleCacheTtl = 86400;
 		$asyncCacheEnabled = !empty( $app->wg->EnableAsyncVideoViewCache );
 
 		$hashTitle = md5( $title );

--- a/includes/wikia/services/MediaQueryService.class.php
+++ b/includes/wikia/services/MediaQueryService.class.php
@@ -621,7 +621,7 @@ class MediaQueryService extends WikiaService {
 
 		$cacheTtl = 7200; // 2 hours for caching the result in memcache
 		// 24hr allowance for returning stale results until new cache is built
-		// Adjusted to increase the caching benefit for infrequently views videos
+		// Adjusted to increase the caching benefit for infrequently viewed videos
 		$staleCacheTtl = 86400;
 		$asyncCacheEnabled = !empty( $app->wg->EnableAsyncVideoViewCache );
 


### PR DESCRIPTION
@garthwebb 

This is to increase the benefits of caching video views; the majority of video files are not visited very frequently, and therefore it does not make sense to schedule a cache task for them too frequently.

This change also logs another parameter for "time after TTL" (pastTTL) for async cache.
