### PR TITLE
HG-347: Check if linkhref is set in the array

### DIFF
--- a/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php
+++ b/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php
@@ -90,8 +90,8 @@ class ArticleAsJson extends WikiaService {
 				if ( !empty( $caption ) ) {
 					$caption = $parser->parse( $caption, $title, $parserOptions, false )->getText();
 				}
-
-				$media[] = self::createMediaObj( $details, $image['name'], $caption, $image['linkhref'] );
+				$linkHref = isset( $image['linkhref'] ) ? $image['linkhref'] : null;
+				$media[] = self::createMediaObj( $details, $image['name'], $caption, $linkHref );
 
 				self::addUserObj($details);
 			}


### PR DESCRIPTION
`$image['linkhref']` is rarely set, which causes a lot of notices in the logs. This PR adds a check and default value for `linkhref` :art: 
