### PR TITLE
HG-97: JSSnippets return empty string on ArticleAsJson

### DIFF
--- a/extensions/wikia/JSSnippets/JSSnippets.class.php
+++ b/extensions/wikia/JSSnippets/JSSnippets.class.php
@@ -36,8 +36,15 @@ class JSSnippets {
 	 */
 
 	static public function addToStack( $dependencies, $loaders = array(), $callback = null, $options = null ) {
+		global $wgArticleAsJson;
+
 		wfProfileIn( __METHOD__ );
 		$js = "";
+
+		// HG-97: Don't include script tags when the article is requested as Json
+		if ( !empty( $wgArticleAsJson ) ) {
+			return $js;
+		}
 		$assetsManager = AssetsManager::getInstance();
 		$skin = RequestContext::getMain()->getSkin();
 		$isWikiaSkin = ( $skin instanceof WikiaSkin );

--- a/extensions/wikia/JSSnippets/JSSnippets.class.php
+++ b/extensions/wikia/JSSnippets/JSSnippets.class.php
@@ -37,14 +37,15 @@ class JSSnippets {
 
 	static public function addToStack( $dependencies, $loaders = array(), $callback = null, $options = null ) {
 		global $wgArticleAsJson;
-
-		wfProfileIn( __METHOD__ );
 		$js = "";
 
 		// HG-97: Don't include script tags when the article is requested as Json
 		if ( !empty( $wgArticleAsJson ) ) {
 			return $js;
 		}
+		
+		wfProfileIn( __METHOD__ );
+		
 		$assetsManager = AssetsManager::getInstance();
 		$skin = RequestContext::getMain()->getSkin();
 		$isWikiaSkin = ( $skin instanceof WikiaSkin );


### PR DESCRIPTION
Extensions frequently use `JSSnippet` to load resources on per-page basis. This is generally great approach instead of the case when we want to use the resulting page as a content in single page app. In this case having  `<script>` tags is highly undesirable.

The purpose of this PR is to suppress the `JSSnippet` tegerated `<script>` tags, when the Article is requested as JSON by the Mercury API. :postal_horn: 

/cc @macbre @hakubo 
