### PR TITLE
VID-2124 don't decode data-image-key

### DIFF
--- a/extensions/wikia/Lightbox/scripts/LightboxLoader.js
+++ b/extensions/wikia/Lightbox/scripts/LightboxLoader.js
@@ -135,8 +135,6 @@
 						return;
 					}
 
-					fileKey = decodeURI(fileKey);
-
 					// Display video inline, don't open lightbox
 					isVideo = $this.children('.play-circle').length;
 					if (


### PR DESCRIPTION
The currently selected image in the lightbox is having it's image-data-key url decoded when it's being set. The problem is that all the images in the carousel do not have their image-data-key url decoded, which is leading to inconsistency and wonky behavior.  Remove the line which url decodes the current image's image-data-key.
