### PR TITLE
unset() exception backtrace func args

### DIFF
--- a/lib/Wikia/src/Logger/LogstashFormatter.php
+++ b/lib/Wikia/src/Logger/LogstashFormatter.php
@@ -8,6 +8,7 @@
  */
 
 namespace Wikia\Logger;
+use Exception;
 
 
 class LogstashFormatter extends \Monolog\Formatter\LogstashFormatter implements DevModeFormatterInterface {
@@ -49,5 +50,33 @@ class LogstashFormatter extends \Monolog\Formatter\LogstashFormatter implements 
 		}
 
 		return $message;
+	}
+
+	protected function normalizeException(Exception $e) {
+		$data = array(
+			'class' => get_class($e),
+			'message' => $e->getMessage(),
+			'file' => $e->getFile().':'.$e->getLine(),
+		);
+
+		$trace = $e->getTrace();
+		foreach ($trace as $frame) {
+			if (isset($frame['file'])) {
+				$data['trace'][] = $frame['file'].':'.$frame['line'];
+			} else {
+				// prevent huge json blobs from preventing message parsing (because of split message) and flooding file logs
+				if (isset($data['args'])) {
+					unset($data['args']);
+				}
+
+				$data['trace'][] = json_encode($frame);
+			}
+		}
+
+		if ($previous = $e->getPrevious()) {
+			$data['previous'] = $this->normalizeException($previous);
+		}
+
+		return $data;
 	}
 }


### PR DESCRIPTION
@frankfarmer 
prevent log spam resulting from function arguments in exception backtrace. This overrides the function declared in [NormalizerFormatter](https://github.com/Wikia/app/blob/dev/lib/composer/monolog/monolog/src/Monolog/Formatter/NormalizerFormatter.php#L95)
