### PR TITLE
VID-1905 Make sure wgVideosModuleBlackList has value before unserializin...

### DIFF
--- a/extensions/wikia/VideosModule/VideosModule.class.php
+++ b/extensions/wikia/VideosModule/VideosModule.class.php
@@ -41,9 +41,8 @@ class VideosModule extends WikiaModel {
 		$communityBlacklist = WikiFactory::getVarByName( "wgVideosModuleBlackList", WikiFactory::COMMUNITY_CENTRAL );
 
 		// Set the blacklist if there is data for it
-		if ( is_object( $communityBlacklist ) ) {
-			$serializedBlackList = $communityBlacklist->cv_value;
-			$this->blacklist = unserialize( $serializedBlackList );
+		if ( is_object( $communityBlacklist ) && !empty( $communityBlacklist->cv_value ) ) {
+			$this->blacklist = unserialize( $communityBlacklist->cv_value );
 		}
 
 		$this->userRegion = $userRegion;


### PR DESCRIPTION
...g it

The Videos Module has a global blacklist which we store inside of the wgVideosModuleBlackList variable on community.wikia.com. Currently that blacklist is saved as an array (as we expect it to be), but if someone ever deletes that array then the code below would assign False to $this->blacklist in the VideosModule. This would cause PHP Warnings as the code expects this value to be an array. Make sure wgVideosModuleBlackList has a value before unserializing it. If it does have a value, we can assume it's a serialized array because WikiFactory enforces that when saving the variable.

Ticket: https://wikia-inc.atlassian.net/browse/VID-1905
