### PR TITLE
VE-1655: Preview functionality

### DIFF
--- a/extensions/VisualEditor/lib/ve/modules/ve/ui/ve.ui.Surface.js
+++ b/extensions/VisualEditor/lib/ve/modules/ve/ui/ve.ui.Surface.js
@@ -374,3 +374,11 @@ ve.ui.Surface.prototype.getTarget = function () {
 ve.ui.Surface.prototype.getFocusWidget = function () {
 	return this.focusWidget;
 };
+
+/**
+ * @method
+ * @returns {jQuery} this.$globalOverlay
+ */
+ve.ui.Surface.prototype.getGlobalOverlay = function () {
+	return this.$globalOverlay;
+};

--- a/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaMapInsertDialog.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaMapInsertDialog.js
@@ -93,7 +93,7 @@ ve.ui.WikiaMapInsertDialog.prototype.setupResultsPanel = function () {
 	headlineButton.on( 'click', ve.bind( this.onCreateClick, this ) );
 
 	this.resultsWidget = new ve.ui.WikiaMediaResultsWidget( { '$': this.$ } );
-	this.resultsWidget.on( 'preview', ve.bind( this.onMapSelect, this ) );
+	this.resultsWidget.on( 'select', ve.bind( this.onMapSelect, this ) );
 	this.selectWidget = this.resultsWidget.getResults();
 
 	this.panels.results.$element.append( $headline, this.resultsWidget.$element );

--- a/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaMediaInsertDialog.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaMediaInsertDialog.js
@@ -117,8 +117,6 @@ ve.ui.WikiaMediaInsertDialog.prototype.initialize = function () {
 	this.$policyReadMoreLink = this.$( '<a>' )
 		.html( ve.msg( 'wikia-visualeditor-dialog-wikiamediainsert-read-more' ) );
 	this.$policyReadMore.append( this.$policyReadMoreLink );
-	// Core VE used to pass VeUiSurface to this constructor. Getting it now with DOM traversal.
-	this.$globalOverlay = this.$frame.closest('.ve-ui-surface-overlay-global');
 
 	// Events
 	this.cartModel.connect( this, {
@@ -140,7 +138,7 @@ ve.ui.WikiaMediaInsertDialog.prototype.initialize = function () {
 	this.search.connect( this, {
 		'nearingEnd': 'onSearchNearingEnd',
 		'check': 'onSearchCheck',
-		'preview': 'onMediaPreview'
+		'select': 'onMediaPreview'
 	} );
 	this.upload.connect( this, uploadEvents );
 	this.queryUpload.connect( this, uploadEvents );
@@ -165,7 +163,7 @@ ve.ui.WikiaMediaInsertDialog.prototype.initialize = function () {
 	this.frame.$content.addClass( 've-ui-wikiaMediaInsertDialog' );
 	this.$foot.append( this.insertButton.$element );
 	this.$frame.prepend( this.dropTarget.$element );
-	this.$globalOverlay.append( this.mediaPreview.$element );
+	this.surface.getGlobalOverlay().append( this.mediaPreview.$element );
 };
 
 /**
@@ -269,20 +267,19 @@ ve.ui.WikiaMediaInsertDialog.prototype.onSearchNearingEnd = function () {
  * Handle check/uncheck of items in search results.
  *
  * @method
- * @param {Object} item The search result item data.
+ * @param {Object} item The search result item.
  */
 ve.ui.WikiaMediaInsertDialog.prototype.onSearchCheck = function ( item ) {
-	var cartItem;
-
-	cartItem = this.cart.getItemFromData( item.title );
+	var data = item.getData(),
+		cartItem = this.cart.getItemFromData( data.title );
 
 	if ( cartItem ) {
 		this.cartModel.removeItems( [ cartItem.getModel() ] );
 	} else {
-		if ( item.type === 'video' ) {
-			this.addCartItem( new ve.dm.WikiaCartItem( item.title, item.url, item.type, undefined, 'wikia' ) );
+		if ( data.type === 'video' ) {
+			this.addCartItem( new ve.dm.WikiaCartItem( data.title, data.url, data.type, undefined, 'wikia' ) );
 		} else {
-			this.addCartItem( new ve.dm.WikiaCartItem( item.title, item.url, item.type ) );
+			this.addCartItem( new ve.dm.WikiaCartItem( data.title, data.url, data.type ) );
 		}
 	}
 };

--- a/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaSingleMediaDialog.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaSingleMediaDialog.js
@@ -271,6 +271,8 @@ ve.ui.WikiaSingleMediaDialog.prototype.handleChoose = function ( item ) {
  * Handle showing the media preview
  *
  * @method
+ * @param {ve.ui.WikiaMediaOptionWidget} item Item to preview
+ * @param {jQuery.Event} event jQuery Event
  */
 ve.ui.WikiaSingleMediaDialog.prototype.handlePreview = function ( item, event ) {
 	var data = item.getData();

--- a/extensions/VisualEditor/wikia/modules/ve/ui/widgets/ve.ui.WikiaMediaOptionWidget.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/widgets/ve.ui.WikiaMediaOptionWidget.js
@@ -46,6 +46,12 @@ ve.ui.WikiaMediaOptionWidget = function VeUiWikiaMediaOptionWidget( data, config
 	this.check.on( 'click', ve.bind( function () {
 		this.emit( 'check', this );
 	}, this ) );
+	this.$metaData.on( 'mousedown', ve.bind( function ( event ) {
+		this.emit( 'metadata', this, event );
+	}, this ) );
+	this.$label.on( 'mousedown', ve.bind( function ( event ) {
+		this.emit( 'label', this, event );
+	}, this ) );
 
 	// Initialization
 	this.loadThumbnail();

--- a/extensions/VisualEditor/wikia/modules/ve/ui/widgets/ve.ui.WikiaMediaPreviewWidget.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/widgets/ve.ui.WikiaMediaPreviewWidget.js
@@ -2,7 +2,7 @@
  * VisualEditor UserInterface WikiaMediaPreviewWidget class.
  */
 
-/* global mw, require */
+/* global mw, require, Vignette */
 
 ve.ui.WikiaMediaPreviewWidget = function VeUiWikiaMediaPreviewWidget() {
 
@@ -161,9 +161,15 @@ ve.ui.WikiaMediaPreviewWidget.prototype.openForImage = function ( title, url ) {
 		.addClass( 've-ui-wikiaMediaPreviewWidget-image' )
 		.hide();
 
+	//debugger;
+	this.$image.attr( 'src', Vignette.getThumbURL( url, 'thumbnail-down', this.maxImgWidth, this.maxImgHeight ) );
+
+/*
 	require( ['wikia.thumbnailer'], ve.bind( function ( thumbnailer ) {
-		this.$image.attr( 'src', thumbnailer.getThumbURL( url, 'nocrop', this.maxImgWidth ) );
+		debugger;
+		this.$image.attr( 'src', thumbnailer.getThumbURL( url, 'nocrop', this.maxImgWidth, this.maxImgHeight ) );
 	}, this ) );
+*/
 
 	this.$image
 		.load( ve.bind( this.onImageLoad, this ) )

--- a/extensions/VisualEditor/wikia/modules/ve/ui/widgets/ve.ui.WikiaMediaResultsWidget.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/widgets/ve.ui.WikiaMediaResultsWidget.js
@@ -53,10 +53,24 @@ ve.ui.WikiaMediaResultsWidget.prototype.onResultsCheck = function ( item ) {
 	this.emit( 'check', item );
 };
 
+/**
+ * Handle metadata event
+ *
+ * @method
+ * @param {ve.ui.WikiaMediaOptionWidget} item Item that fired the event
+ * @param {jQuery.Event} event jQuery Event
+ */
 ve.ui.WikiaMediaResultsWidget.prototype.onResultsMetadata = function ( item, event ) {
 	this.emit( 'metadata', item, event );
 };
 
+/**
+ * Handle label event
+ *
+ * @method
+ * @param {ve.ui.WikiaMediaOptionWidget} item Item that fired the event
+ * @param {jQuery.Event} event jQuery Event
+ */
 ve.ui.WikiaMediaResultsWidget.prototype.onResultsLabel = function ( item, event ) {
 	this.emit( 'label', item, event );
 };

--- a/extensions/VisualEditor/wikia/modules/ve/ui/widgets/ve.ui.WikiaMediaResultsWidget.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/widgets/ve.ui.WikiaMediaResultsWidget.js
@@ -21,8 +21,7 @@ ve.ui.WikiaMediaResultsWidget = function VeUiWikiaMediaResultsWidget( config ) {
 	// Events
 	this.results.connect( this, {
 		'highlight': 'onResultsHighlight',
-		'select': 'onResultsSelect',
-		'check': 'onResultsCheck'
+		'select': 'onResultsSelect'
 	} );
 	this.$element.on( 'scroll', ve.bind( this.onResultsScroll, this ) );
 
@@ -51,7 +50,15 @@ OO.inheritClass( ve.ui.WikiaMediaResultsWidget, OO.ui.Widget );
  * @param {ve.ui.WikiaMediaOptionWidget} item Item whose state is changing
  */
 ve.ui.WikiaMediaResultsWidget.prototype.onResultsCheck = function ( item ) {
-	this.emit( 'check', item.getData() );
+	this.emit( 'check', item );
+};
+
+ve.ui.WikiaMediaResultsWidget.prototype.onResultsMetadata = function ( item, event ) {
+	this.emit( 'metadata', item, event );
+};
+
+ve.ui.WikiaMediaResultsWidget.prototype.onResultsLabel = function ( item, event ) {
+	this.emit( 'label', item, event );
 };
 
 /**
@@ -63,7 +70,7 @@ ve.ui.WikiaMediaResultsWidget.prototype.onResultsCheck = function ( item ) {
 ve.ui.WikiaMediaResultsWidget.prototype.onResultsSelect = function ( item ) {
 	if ( item ) {
 		this.results.selectItem( null );
-		this.emit( 'preview', item );
+		this.emit( 'select', item );
 	}
 };
 
@@ -78,7 +85,11 @@ ve.ui.WikiaMediaResultsWidget.prototype.addItems = function ( items ) {
 		results = [];
 	for ( i = 0; i < items.length; i++ ) {
 		optionWidget = ve.ui.WikiaMediaOptionWidget.newFromData( items[i], { '$': this.$, 'size': this.size } );
-		optionWidget.on( 'check', this.onResultsCheck, [ optionWidget ], this );
+		optionWidget.connect( this, {
+			'check': 'onResultsCheck',
+			'metadata': 'onResultsMetadata',
+			'label': 'onResultsLabel'
+		} );
 		results.push(
 			optionWidget
 		);


### PR DESCRIPTION
Adds preview functionality to the single media tool:

**ve.ui.Surface.js**
- Add a getter for the globalOverlay

**ve.ui.WikiaMapInsertDialog.js**
- Listen to new event

**ve.ui.WikiaMediaInsertDialog.js**
- Use globalOverlay getter instead of DOM traversal
- Listen to new events
- Adjust onSearchCheck to use passed item instead of itemData

**ve.ui.WikiaSingleMediaDialog.js**
- Integrate ve.ui.WikiaMediaPreviewWidget
- Handle events
- Correct UI for checked and unchecked results

**ve.ui.WikiaMediaOptionWidget.js**
- Added new events for mousedown on metadata and label. In the single media dialog, clicking these element should prevent the select widget from emitting 'select'. To do this, the DOM event is passed through EventEmitter up to the dialog, where the dialog can choose to stopPropagation. This is so a click on the label in the old media dialog does not prevent the 'select' event from firing.

**ve.ui.WikiaMediaResultsWidget.js**
- Event handling
