### PR TITLE
(CE-1143) Load JSSnippets in Monobook

### DIFF
--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -848,6 +848,7 @@ $config['monobook_js'] = array(
 		'//resources/wikia/libraries/ghostwriter/gw.min.js',
 		'//extensions/wikia/GlobalNotification/GlobalNotification.js',
 		'//extensions/wikia/VideoHandlers/js/VideoBootstrap.js',
+		'//extensions/wikia/JSSnippets/js/JSSnippets.js',
 
 		'//resources/wikia/libraries/bootstrap/tooltip.js',
 		'//resources/wikia/libraries/bootstrap/popover.js',


### PR DESCRIPTION
In PR #5237, loading of JSSnippets was moved from a hook to the
AssetsManager config, but wasn't added to load in monobook_js as well.
This caused a number of JS issues in Monobook for extensions that made
use of JSSnippets, so we just need to add JSSnippets to monobook_js.

This fixes the following tickets:
- [CE-1143](https://wikia-inc.atlassian.net/browse/CE-1143): Tabber is broken in the Monobook skin
- [CE-1144](https://wikia-inc.atlassian.net/browse/CE-1144): RSS feeds still broken in Monobook
- [CE-1147](https://wikia-inc.atlassian.net/browse/CE-1147): Polls in Monobook are not working

/cc @lizlux @Wikia/community-engineering 
