### PR TITLE
single-media-policy: Finalize media policy for single media dialog

### DIFF
--- a/extensions/VisualEditor/wikia/VisualEditor.i18n.php
+++ b/extensions/VisualEditor/wikia/VisualEditor.i18n.php
@@ -76,6 +76,8 @@ $messages['en'] = array(
 	'wikia-visualeditor-dialog-wikiasinglemedia-search' => 'Search for images',
 	'wikia-visualeditor-wikiamediaoptionwidget-preview-photo' => 'View',
 	'wikia-visualeditor-wikiamediaoptionwidget-preview-video' => 'Watch',
+	'wikia-visualeditor-media-photo-policy' => 'Please adhere to this wikia\'s image policy when uploading new photos.',
+	'wikia-visualeditor-media-video-policy' => 'Please adhere to this wiki\'s video policy when adding new videos.',
 );
 
 /** Message documentation (Message documentation)

--- a/extensions/VisualEditor/wikia/VisualEditor.php
+++ b/extensions/VisualEditor/wikia/VisualEditor.php
@@ -223,6 +223,8 @@ $wgResourceModules += array(
 			'wikia-visualeditor-dialog-wikiasinglemedia-search',
 			'wikia-visualeditor-wikiamediaoptionwidget-preview-photo',
 			'wikia-visualeditor-wikiamediaoptionwidget-preview-video',
+			'wikia-visualeditor-media-photo-policy',
+			'wikia-visualeditor-media-video-policy',
 		),
 		'dependencies' => array(
 			'ext.visualEditor.core.desktop',

--- a/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaSingleMediaDialog.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaSingleMediaDialog.js
@@ -61,7 +61,7 @@ ve.ui.WikiaSingleMediaDialog.prototype.initialize = function () {
 		.addClass( 've-ui-wikiaSingleMediaDialog-policy' );
 	this.$policyInner = this.$( '<div>' )
 		.addClass( 've-ui-wikiaSingleMediaDialog-policyInner' )
-		.html('This is the image policy that has been decided on by this commmunity. Do not upload any photos of kitties or puppies because that is not what this wiki is about and it is played out anyway.');
+		.html( ve.msg( 'wikia-visualeditor-media-' + this.mode.type + '-policy' ) );
 	this.insertButton = new OO.ui.ButtonWidget( {
 		'$': this.$,
 		'label': ve.msg( 'wikia-visualeditor-dialog-done-button' ),


### PR DESCRIPTION
Removing placeholder text and replacing it with the appropriate policy message depending on dialog mode (always photo for now).
