### PR TITLE
hide-cart-controls: Temporarily hide cart controls

### DIFF
--- a/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaSingleMediaDialog.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaSingleMediaDialog.js
@@ -98,7 +98,7 @@ ve.ui.WikiaSingleMediaDialog.prototype.initialize = function () {
 	this.cancelButton.connect( this, { 'click': 'onCancelButtonClick' } );
 
 	// Initialization
-	this.frame.$content.addClass( 've-ui-wikiaSingleMediaDialog' );
+	this.frame.$content.addClass( 've-ui-wikiaSingleMediaDialog ve-ui-wikiaSingleMediaDialog-hide-cart-controls' );
 	this.$main.append( this.search.$element, this.cart.$element );
 
 	this.$policy.append( this.$policyInner );

--- a/extensions/VisualEditor/wikia/modules/ve/ui/styles/ve.ui.WikiaSingleMediaInsertDialog.scss
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/styles/ve.ui.WikiaSingleMediaInsertDialog.scss
@@ -6,6 +6,17 @@
 $width-dialog: 712px;
 $width-results: 552px;
 
+// Temporary class for hiding the cart toggle
+.ve-ui-wikiaSingleMediaDialog-hide-cart-controls {
+	.ve-ui-wikiaSingleMediaDialog-cartControls {
+		display: none;
+	}
+	.ve-ui-wikiaSingleMediaCartSelectWidget {
+		padding-top: 15px;
+		top: 0;
+	}
+}
+
 .ve-ui-wikiaSingleMediaDialog {
 	.oo-ui-window-body {
 		padding: 0;


### PR DESCRIPTION
Because the tool is not yet complete, we are hiding the cart controls and adjusting the layout of the cart select widget for initial release.
