### PR TITLE
(CE-1051) Quick fix for caching in SharedHelp

### DIFF
--- a/extensions/wikia/SharedHelp/SharedHelp.php
+++ b/extensions/wikia/SharedHelp/SharedHelp.php
@@ -199,10 +199,10 @@ function SharedHelpHook(&$out, &$text) {
 			}
 		}
 		if(!empty($content)) {
-            # get rid of magic word editsection (non parsed piece causing double section headers)
-            $content = preg_replace("|<mw:editsection( .*)?>.*?</mw:editsection>|", "", $content);
-        } else {# If getting content from memcache failed (invalidate) then just download it via HTTP
-            $urlTemplate = $sharedServer . $sharedScript . "?title=Help:%s&action=render";
+			# get rid of magic word editsection (non parsed piece causing double section headers)
+			$content = preg_replace("|<mw:editsection( .*)?>.*?</mw:editsection>|", "", $content);
+		} else {# If getting content from memcache failed (invalidate) then just download it via HTTP
+			$urlTemplate = $sharedServer . $sharedScript . "?title=Help:%s&action=render";
 			$articleUrl = sprintf($urlTemplate, urlencode($wgTitle->getDBkey()));
 			list($content, $c) = SharedHttp::get($articleUrl);
 
@@ -252,8 +252,7 @@ function SharedHelpHook(&$out, &$text) {
 				$contentA = explode("\n", $content);
 				$tmp = isset($contentA[count($contentA)-2]) ? $contentA[count($contentA)-2] : '';
 				$idx1 = strpos($tmp, 'key');
-				$idx2 = strpos($tmp, 'end');
-				$key = trim(substr($tmp, $idx1+4, $idx2-$idx1));
+				$key = trim( substr( $tmp, $idx1+4, -4 ) );
 				$sharedArticle = array('cachekey' => $key, 'timestamp' => wfTimestamp());
 				$wgMemc->set($sharedArticleKey, $sharedArticle);
 				wfDebug("SharedHelp: using parser cache {$sharedArticle['cachekey']}\n");

--- a/extensions/wikia/SharedHelp/SharedHelp.php
+++ b/extensions/wikia/SharedHelp/SharedHelp.php
@@ -32,7 +32,7 @@ $wgHooks['SpecialSearchProfiles'][] = 'efSharedHelpSearchProfilesHook';
 $wgHooks['WantedPages::getQueryInfo'][] = 'SharedHelpWantedPagesSql';
 
 define( 'NOSHAREDHELP_MARKER', '<!--NOSHAREDHELP-->' );
-define( 'SHAREDHELP_CACHE_VERSION', '1' );
+define( 'SHAREDHELP_CACHE_VERSION', '2' );
 
 class SharedHttp {
 	static function get( $url, $timeout = 'default' ) {
@@ -177,24 +177,20 @@ function SharedHelpHook(&$out, &$text) {
 		$localArticlePathClean = str_replace('$1', '', $wgArticlePath);
 
 		# Try to get content from memcache
-		if ( !empty($sharedArticle['timestamp']) ) {
-			if( (wfTimestamp() - (int) ($sharedArticle['timestamp'])) < 600) {
-				if( isset($sharedArticle['exists']) && $sharedArticle['exists'] == 0 ) {
-					wfProfileOut(__METHOD__);
-					return true;
-				} else if (!empty($sharedArticle['cachekey'])) {
-					wfDebug("SharedHelp: trying parser cache {$sharedArticle['cachekey']}\n");
-					$key1 = str_replace('-1!', '-0!', $sharedArticle['cachekey']);
-					$key2 = str_replace('-0!', '-1!', $sharedArticle['cachekey']);
-					$parser = $wgMemc->get($key1);
-					if(!empty($parser) && is_object($parser)) {
-						$content = $parser->mText;
-					} else {
-						$parser = $wgMemc->get($key2);
-						if(!empty($parser) && is_object($parser)) {
-							$content = $parser->mText;
-						}
-					}
+		if ( isset( $sharedArticle['exists'] ) && $sharedArticle['exists'] == 0 ) {
+			wfProfileOut( __METHOD__ );
+			return true;
+		} elseif ( !empty( $sharedArticle['cachekey'] ) ) {
+			wfDebug( "SharedHelp: trying parser cache {$sharedArticle['cachekey']}\n" );
+			$key1 = str_replace( '-1!', '-0!', $sharedArticle['cachekey'] );
+			$key2 = str_replace( '-0!', '-1!', $sharedArticle['cachekey'] );
+			$parser = $wgMemc->get( $key1 );
+			if ( !empty( $parser ) && is_object( $parser ) ) {
+				$content = $parser->mText;
+			} else {
+				$parser = $wgMemc->get( $key2 );
+				if ( !empty( $parser ) && is_object( $parser ) ) {
+					$content = $parser->mText;
 				}
 			}
 		}
@@ -245,7 +241,7 @@ function SharedHelpHook(&$out, &$text) {
 			}
 			if(strpos($content, '"noarticletext"') > 0) {
 				$sharedArticle = array('exists' => 0, 'timestamp' => wfTimestamp());
-				$wgMemc->set($sharedArticleKey, $sharedArticle);
+				$wgMemc->set( $sharedArticleKey, $sharedArticle, 60 * 60 * 24 );
 				wfProfileOut(__METHOD__);
 				return true;
 			} else {
@@ -254,7 +250,7 @@ function SharedHelpHook(&$out, &$text) {
 				$idx1 = strpos($tmp, 'key');
 				$key = trim( substr( $tmp, $idx1+4, -4 ) );
 				$sharedArticle = array('cachekey' => $key, 'timestamp' => wfTimestamp());
-				$wgMemc->set($sharedArticleKey, $sharedArticle);
+				$wgMemc->set( $sharedArticleKey, $sharedArticle, 60 * 60 * 24 );
 				wfDebug("SharedHelp: using parser cache {$sharedArticle['cachekey']}\n");
 			}
 			curl_close( $c );


### PR DESCRIPTION
Quick fix for SharedHelp caching which we can improve later when
refactoring the extension.

SharedHelp tries to get the parser cache key from the text it gets
from the help wikia, and use that to save HTTP requests. The string
in the text it is parsing looks like:

<!-- Saved in parser cache with key wikia:pcache:idhash:16765-1!*!0!!en!*!* -->

Shared help was looking for the string 'end' to find the end of the
cache key. Because this string isn't in that comment, the resulting
parser cache key it would store would look something like
'wikia:pcache:idhash:16', which of course doesn't work. I'm not sure
this ever worked and probably should have been 'and' in the previous
version of the string before we removed the timestamp. This fixes that
parsing so the working parser cache key is stored.

This also removes the timestamp check which was only checking for 10 minutes
and sets the cache entry to 24 hours. We need to bump the cache version to
make sure old stuff uses the new way (mostly for checking if the article exists).

/cc @macbre 
