### PR TITLE
HG-385 P2 fix: added InvalidDataApiException to autloader and added fallback to navigation exception

### DIFF
--- a/extensions/wikia/MercuryApi/MercuryApiController.class.php
+++ b/extensions/wikia/MercuryApi/MercuryApiController.class.php
@@ -187,7 +187,9 @@ class MercuryApiController extends WikiaController {
 		try {
 			$wikiVariables[ 'navData' ] = $this->getNavigationData();
 		} catch (Exception $e) {
-			\Wikia\Logger\WikiaLogger::instance()->error( 'Fallback to empty navigation', (array) $e );
+			\Wikia\Logger\WikiaLogger::instance()->error( 'Fallback to empty navigation', [
+				'exception' => $e
+			] );
 			$wikiVariables[ 'navData' ] = [];
 		}
 

--- a/extensions/wikia/MercuryApi/MercuryApiController.class.php
+++ b/extensions/wikia/MercuryApi/MercuryApiController.class.php
@@ -183,7 +183,14 @@ class MercuryApiController extends WikiaController {
 	 */
 	public function getWikiVariables() {
 		$wikiVariables = $this->mercuryApi->getWikiVariables();
-		$wikiVariables[ 'navData' ] = $this->getNavigationData();
+
+		try {
+			$wikiVariables[ 'navData' ] = $this->getNavigationData();
+		} catch (Exception $e) {
+			\Wikia\Logger\WikiaLogger::instance()->error( 'Fallback to empty navigation', (array) $e );
+			$wikiVariables[ 'navData' ] = [];
+		}
+
 		$wikiVariables[ 'vertical' ] = WikiFactoryHub::getInstance()->getWikiVertical( $this->wg->CityId )['short'];
 		$wikiVariables[ 'basePath' ] = $this->wg->Server;
 
@@ -193,7 +200,6 @@ class MercuryApiController extends WikiaController {
 		}
 
 		$smartBannerConfig = $this->getSmartBannerConfig();
-
 		if ( !is_null( $smartBannerConfig ) ) {
 			$wikiVariables[ 'smartbanner' ] = $smartBannerConfig;
 		}

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -174,13 +174,13 @@ $wgWikiaApiControllers['MoviesApiController'] = "{$IP}/includes/wikia/api/Movies
 //Wikia Api exceptions classes
 $wgAutoloadClasses[ 'ApiAccessService' ] = "{$IP}/includes/wikia/api/services/ApiAccessService.php";
 $wgAutoloadClasses[ 'ApiOutboundingLinksService' ] = "{$IP}/includes/wikia/api/services/ApiOutboundingLinksService.php";
-$wgAutoloadClasses[ 'BadRequestApiException'] =  "{$IP}/includes/wikia/api/ApiExceptions.php" ;
-$wgAutoloadClasses[ 'OutOfRangeApiException'] =  "{$IP}/includes/wikia/api/ApiExceptions.php" ;
-$wgAutoloadClasses[ 'MissingParameterApiException'] =  "{$IP}/includes/wikia/api/ApiExceptions.php" ;
-$wgAutoloadClasses[ 'InvalidParameterApiException'] =  "{$IP}/includes/wikia/api/ApiExceptions.php" ;
-$wgAutoloadClasses[ 'InvalidDataApiException' ] = "{$IP}/includes/wikia/api/ApiExceptions.php" ;
-$wgAutoloadClasses[ 'LimitExceededApiException'] =  "{$IP}/includes/wikia/api/ApiExceptions.php" ;
-$wgAutoloadClasses[ 'NotFoundApiException'] =  "{$IP}/includes/wikia/api/ApiExceptions.php" ;
+$wgAutoloadClasses[ 'BadRequestApiException'] = "{$IP}/includes/wikia/api/ApiExceptions.php";
+$wgAutoloadClasses[ 'OutOfRangeApiException'] = "{$IP}/includes/wikia/api/ApiExceptions.php";
+$wgAutoloadClasses[ 'MissingParameterApiException'] = "{$IP}/includes/wikia/api/ApiExceptions.php";
+$wgAutoloadClasses[ 'InvalidParameterApiException'] = "{$IP}/includes/wikia/api/ApiExceptions.php";
+$wgAutoloadClasses[ 'InvalidDataApiException' ] = "{$IP}/includes/wikia/api/ApiExceptions.php";
+$wgAutoloadClasses[ 'LimitExceededApiException'] = "{$IP}/includes/wikia/api/ApiExceptions.php";
+$wgAutoloadClasses[ 'NotFoundApiException'] = "{$IP}/includes/wikia/api/ApiExceptions.php";
 
 /**
  * Wikia API end

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -178,6 +178,7 @@ $wgAutoloadClasses[ 'BadRequestApiException'] =  "{$IP}/includes/wikia/api/ApiEx
 $wgAutoloadClasses[ 'OutOfRangeApiException'] =  "{$IP}/includes/wikia/api/ApiExceptions.php" ;
 $wgAutoloadClasses[ 'MissingParameterApiException'] =  "{$IP}/includes/wikia/api/ApiExceptions.php" ;
 $wgAutoloadClasses[ 'InvalidParameterApiException'] =  "{$IP}/includes/wikia/api/ApiExceptions.php" ;
+$wgAutoloadClasses[ 'InvalidDataApiException' ] = "{$IP}/includes/wikia/api/ApiExceptions.php" ;
 $wgAutoloadClasses[ 'LimitExceededApiException'] =  "{$IP}/includes/wikia/api/ApiExceptions.php" ;
 $wgAutoloadClasses[ 'NotFoundApiException'] =  "{$IP}/includes/wikia/api/ApiExceptions.php" ;
 


### PR DESCRIPTION
There are some wikias with broken navigation data and not loaded `ApiExceptions.php` file which resulted with a white page for some users using Mercury. First step was to add missing exception to autoloader and then handle the navigation exception.
