### PR TITLE
(CE-1141) Fix fatal error in backup datacenter

### DIFF
--- a/extensions/Scribunto/common/Hooks.php
+++ b/extensions/Scribunto/common/Hooks.php
@@ -265,7 +265,10 @@ class ScribuntoHooks {
 	 */
 	public static function onAfterDisplayingTextbox( EditPage $editPage, &$hidden ) {
 		$app = F::app();
-		if ( !$app->checkSkin( 'oasis' ) || $editPage->getTitle()->getNamespace() !== NS_MODULE ) {
+		if ( !$app->checkSkin( 'oasis' )
+			|| !( $editPage instanceof EditPageLayout )
+			|| $editPage->getTitle()->getNamespace() !== NS_MODULE
+		) {
 			return true;
 		}
 


### PR DESCRIPTION
When the we're in our backup datacenter and the site is read only, the
editor in Oasis does not load, and so the EditForm:AfterDisplayingTextbox
hook is not called in the context of our edit page. This means that the
addCustomCheckbox method is not available, so the following fatal error
occurs:
Call to undefined method EditPage::addCustomCheckbox() in Scribunto/common/Hooks.php

This hook is only meant to be run in Oasis when using our custom edit
page, so this just checks the edit page is an instance of our custom
EditPageLayout class before attempting to add the checkbox and console,
as these will already have been added when the default edit page is used
anyway.

/cc @Wikia/community-engineering 
