### PR TITLE
UC-134 Send users directly to the special connect page

### DIFF
--- a/extensions/wikia/UserLogin/FacebookSignupController.class.php
+++ b/extensions/wikia/UserLogin/FacebookSignupController.class.php
@@ -91,7 +91,8 @@ class FacebookSignupController extends WikiaController {
 
 		$this->loginToken = UserLoginHelper::getSignupToken();
 
-		$this->specialUserLoginUrl = SpecialPage::getTitleFor( 'UserLogin' )->getLocalUrl();
+		$specialPage = $this->wg->EnableFacebookClientExt ? 'FacebookConnect' : 'Connect';
+		$this->specialUserLoginUrl = SpecialPage::getTitleFor( $specialPage )->getLocalUrl();
 	}
 
 	/**


### PR DESCRIPTION
Rather than bouncing them off the UserLogin page.  This fixes a side effect from the solution for the P2 last week, UC-135.  This is code that already exists in the current uconn-1 sprint branch but isn't slated to be released until next week.

https://wikia-inc.atlassian.net/browse/UC-134
