### PR TITLE
UC-138 Update the user_fbconnect table and code that accesses it

### DIFF
--- a/extensions/wikia/FacebookClient/FacebookClient.class.php
+++ b/extensions/wikia/FacebookClient/FacebookClient.class.php
@@ -322,14 +322,13 @@ class FacebookClient {
 	}
 
 	/**
-	 * Returns all known Facebook user IDs for the current Wikia user (could be many since Wikia has more
-	 * than one Facebook app
+	 * Returns the Facebook user ID for the current Wikia user
 	 *
 	 * @param User|int $user
 	 *
-	 * @return array|bool|mixed
+	 * @return int|null
 	 */
-	public function getFacebookUserIds( $user ) {
+	public function getFacebookUserId( $user ) {
 
 		// Determine if we got an ID or an object
 		if ( $user instanceof User && $user->getId() != 0 ) {
@@ -338,17 +337,16 @@ class FacebookClient {
 			$wikiaUserId = $user;
 		}
 
-		$fbid = [];
-		if ( $wikiaUserId ) {
-			$mappings = FacebookMapModel::lookupFromWikiaID( $wikiaUserId );
-
-			foreach ( $mappings as $map ) {
-				/** @var FacebookMapModel $map */
-				$fbid[] = $map->getFacebookUserId();
-			}
+		if ( empty( $wikiaUserId ) ) {
+			return null;
 		}
 
-		return $fbid;
+		$map = FacebookMapModel::lookupFromWikiaID( $wikiaUserId );
+		if ( empty( $map ) ) {
+			return null;
+		}
+
+		return $map->getFacebookUserId();
 	}
 
 	/**

--- a/extensions/wikia/FacebookClient/FacebookClientController.class.php
+++ b/extensions/wikia/FacebookClient/FacebookClientController.class.php
@@ -153,8 +153,8 @@ class FacebookClientController extends WikiaController {
 		}
 
 		// Create user mapping
-		$mappingCreated = \FacebookMapModel::createUserMapping( $wg->User->getId(), $fbUserId );
-		if ( !$mappingCreated ) {
+		$mapping = \FacebookMapModel::createUserMapping( $wg->User->getId(), $fbUserId );
+		if ( empty( $mapping ) ) {
 			$this->status = 'error';
 			return true;
 		}

--- a/extensions/wikia/FacebookClient/FacebookClientController.class.php
+++ b/extensions/wikia/FacebookClient/FacebookClientController.class.php
@@ -146,17 +146,17 @@ class FacebookClientController extends WikiaController {
 		$fb = FacebookClient::getInstance();
 		$fbUserId = $fb->getUserId();
 
-		// The user must be logged into Facebook and wikia
+		// The user must be logged into Facebook and Wikia
 		if ( !$fbUserId || !$wg->User->isLoggedIn() ) {
 			$this->status = 'error';
-			return true;
+			return;
 		}
 
 		// Create user mapping
 		$mapping = \FacebookMapModel::createUserMapping( $wg->User->getId(), $fbUserId );
 		if ( empty( $mapping ) ) {
 			$this->status = 'error';
-			return true;
+			return;
 		}
 
 		$this->status = 'ok';

--- a/extensions/wikia/FacebookClient/FacebookClientHooks.class.php
+++ b/extensions/wikia/FacebookClient/FacebookClientHooks.class.php
@@ -72,13 +72,13 @@ class FacebookClientHooks {
 	static function GetPreferences( $user, &$preferences ) {
 
 		// Determine if we're connected already or not
-		$ids = FacebookClient::getInstance()->getFacebookUserIds( $user );
-		if ( count( $ids ) > 0 ) {
+		$id = FacebookClient::getInstance()->getFacebookUserId( $user );
+		if ( empty( $id ) ) {
+			$isConnected = false;
+			$prefTab     = 'fbconnect-disconnect';
+		} else {
 			$isConnected = true;
 			$prefTab = 'fbconnect-connect';
-		} else {
-			$isConnected = false;
-			$prefTab = 'fbconnect-disconnect';
 		}
 
 		$html = F::app()->renderView( 'FacebookClientController', 'preferences', [ 'isConnected' => $isConnected ] );

--- a/extensions/wikia/FacebookClient/FacebookClientHooks.class.php
+++ b/extensions/wikia/FacebookClient/FacebookClientHooks.class.php
@@ -74,11 +74,11 @@ class FacebookClientHooks {
 		// Determine if we're connected already or not
 		$id = FacebookClient::getInstance()->getFacebookUserId( $user );
 		if ( $id ) {
-			$isConnected = false;
-			$prefTab     = 'fbconnect-disconnect';
-		} else {
 			$isConnected = true;
 			$prefTab = 'fbconnect-connect';
+		} else {
+			$isConnected = false;
+			$prefTab = 'fbconnect-disconnect';
 		}
 
 		$html = F::app()->renderView( 'FacebookClientController', 'preferences', [ 'isConnected' => $isConnected ] );

--- a/extensions/wikia/FacebookClient/FacebookClientHooks.class.php
+++ b/extensions/wikia/FacebookClient/FacebookClientHooks.class.php
@@ -73,7 +73,7 @@ class FacebookClientHooks {
 
 		// Determine if we're connected already or not
 		$id = FacebookClient::getInstance()->getFacebookUserId( $user );
-		if ( empty( $id ) ) {
+		if ( $id ) {
 			$isConnected = false;
 			$prefTab     = 'fbconnect-disconnect';
 		} else {

--- a/extensions/wikia/FacebookClient/FacebookMapModel.class.php
+++ b/extensions/wikia/FacebookClient/FacebookMapModel.class.php
@@ -195,6 +195,8 @@ class FacebookMapModel {
 			->FROM( 'user_fbconnect' )
 			->WHERE( $column )->EQUAL_TO( $id )
 			->AND_( 'user_fb_app_id' )->IN( $fbAppId, 0 )
+			->ORDER_BY( 'user_fb_app_id' )->DESC()
+			->LIMIT( 1 )
 			->runLoop( $dbr, function ( &$data, $row ) {
 				$data[] = [
 					self::paramWikiaUserId => $row->user_id,
@@ -206,16 +208,6 @@ class FacebookMapModel {
 			} );
 
 		if ( is_array( $data ) ) {
-			// If we get more than one result back, one of them has the right app ID and the other has zero.
-			// Return the version with the app ID.
-			if ( count( $data ) > 1 ) {
-				foreach ( $data as $mapping ) {
-					if ( $mapping[self::paramAppId] == $fbAppId ) {
-						return $mapping;
-					}
-				}
-			}
-
 			return $data[0];
 		} else {
 			return null;

--- a/extensions/wikia/FacebookClient/FacebookMapModel.class.php
+++ b/extensions/wikia/FacebookClient/FacebookMapModel.class.php
@@ -131,11 +131,6 @@ class FacebookMapModel {
 		try {
 			$map->save();
 		} catch ( FacebookMapModelException $e ) {
-			WikiaLogger::instance()->warning( 'Failed to create user mapping', [
-				'wikiaUserId' => $wikiaUserId,
-				'fbUserId' => $fbUserId,
-			] );
-
 			return null;
 		}
 
@@ -310,6 +305,14 @@ class FacebookMapModel {
 				->SET( self::columnFacebookAppId, $this->facebookAppId )
 				->run( $dbw );
 		} catch ( \Exception $e ) {
+			WikiaLogger::instance()->warning( 'Failed to create user mapping', [
+				'wikiaUserId' => $this->wikiaUserId,
+				'fbUserId' => $this->facebookUserId,
+				'fbAppId' => $this->facebookAppId,
+				'fbBizToken' => $this->facebookBizToken,
+				'errorMessage' => $e->getMessage(),
+			] );
+
 			throw new FacebookMapModelDbException( $e->getMessage() );
 		}
 	}

--- a/extensions/wikia/FacebookClient/FacebookMapModel.class.php
+++ b/extensions/wikia/FacebookClient/FacebookMapModel.class.php
@@ -105,7 +105,10 @@ class FacebookMapModel {
 	 * @throws FacebookMapModelInvalidParamException
 	 */
 	public static function createUserMapping( $wikiaUserId, $fbUserId ) {
-		// TODO: refactor callers to only call this for connection or FB sign up actions
+		// TODO: refactor callers to only call this for connection or FB sign up action.
+		// Additionally this check should be removed from createUserMapping; its a little
+		// deceptive to have something that says 'create' return an existing mapping.  That's
+		// probably an error, not a valid use case.
 		$map = self::lookupFromWikiaID( $wikiaUserId );
 		if ( !empty( $map ) ) {
 			return $map;

--- a/extensions/wikia/FacebookClient/FacebookMapModel.class.php
+++ b/extensions/wikia/FacebookClient/FacebookMapModel.class.php
@@ -207,11 +207,7 @@ class FacebookMapModel {
 				];
 			} );
 
-		if ( is_array( $data ) ) {
-			return $data[0];
-		} else {
-			return null;
-		}
+		return is_array( $data ) ? $data[0] : null;
 	}
 
 	private static function generateMemKey( array $params = [] ) {

--- a/extensions/wikia/FacebookClient/FacebookMapModel.class.php
+++ b/extensions/wikia/FacebookClient/FacebookMapModel.class.php
@@ -152,20 +152,35 @@ class FacebookMapModel {
 	 * Delete all mappings that have the given Wikia user ID
 	 *
 	 * @param int $wikiaId A Wikia User ID
+	 *
+	 * @return bool
 	 */
 	public static function deleteFromWikiaID( $wikiaId ) {
 		$map = self::lookupFromWikiaID( $wikiaId );
-		$map->delete();
+		if ( !empty( $map ) ) {
+			$map->delete();
+			return true;
+		} else {
+			return false;
+		}
+
 	}
 
 	/**
 	 * Delete all mappings that have the given Facebook user ID
 	 *
 	 * @param int $facebookId A Facebook user ID
+	 *
+	 * @return bool
 	 */
 	public static function deleteFromFacebookID( $facebookId ) {
 		$map = self::lookupFromFacebookID( $facebookId );
-		$map->delete();
+		if ( !empty( $map ) ) {
+			$map->delete();
+			return true;
+		} else {
+			return false;
+		}
 	}
 
 	private static function loadFromDB( array $params = [] ) {

--- a/extensions/wikia/FacebookClient/SpecialFacebookConnectController.class.php
+++ b/extensions/wikia/FacebookClient/SpecialFacebookConnectController.class.php
@@ -77,7 +77,8 @@ class SpecialFacebookConnectController extends WikiaSpecialPageController {
 			return true;
 		}
 
-		if ( !\FacebookMapModel::createUserMapping( $user->getId(), $fbUserId ) ) {
+		$mapping = \FacebookMapModel::createUserMapping( $user->getId(), $fbUserId );
+		if ( empty( $mapping ) ) {
 			// TODO/FIXME: show proper error message @see UC-116
 			F::app()->wg->Out->showErrorPage( 'fbconnect-error', 'fbconnect-errortext' );
 			$this->skipRendering();
@@ -117,7 +118,8 @@ class SpecialFacebookConnectController extends WikiaSpecialPageController {
 			return true;
 		}
 
-		if ( !\FacebookMapModel::createUserMapping( $wg->User->getId(), $fbUserId ) ) {
+		$mapping = \FacebookMapModel::createUserMapping( $wg->User->getId(), $fbUserId );
+		if ( empty( $mapping ) ) {
 			// TODO/FIXME: show proper error message @see UC-116
 			F::app()->wg->Out->showErrorPage( 'fbconnect-error', 'fbconnect-errortext' );
 			$this->skipRendering();

--- a/extensions/wikia/FacebookClient/sql/update_user_fbconnect.sql
+++ b/extensions/wikia/FacebookClient/sql/update_user_fbconnect.sql
@@ -1,6 +1,7 @@
 -- 1) Add columns, about 14s in dev (844966 rows each)
-ALTER TABLE user_fbconnect ADD COLUMN user_fb_app_id bigint(20) DEFAULT 0;
-ALTER TABLE user_fbconnect ADD COLUMN user_fb_biz_token varchar(255) DEFAULT '';
+ALTER TABLE user_fbconnect
+    ADD COLUMN user_fb_app_id bigint(20) DEFAULT 0,
+    ADD COLUMN user_fb_biz_token varchar(255) DEFAULT '';
 
 -- 2) Take care of dup wikia user IDs, about 3s (126 rows)
 UPDATE
@@ -12,8 +13,9 @@ WHERE orig.user_id = dup.user_id AND
       orig.time = dup.min_time;
 
 -- 3) Add constraints, about 7s
-ALTER TABLE user_fbconnect ADD UNIQUE KEY (user_id, user_fb_app_id);
-ALTER TABLE user_fbconnect ADD UNIQUE KEY (user_fbid, user_fb_app_id);
+ALTER TABLE user_fbconnect
+    ADD UNIQUE KEY (user_id, user_fb_app_id),
+    ADD UNIQUE KEY (user_fbid, user_fb_app_id);
 
 -- 4) Remove old constraint about 12s (844966 rows)
 ALTER TABLE user_fbconnect DROP PRIMARY KEY;

--- a/extensions/wikia/FacebookClient/sql/update_user_fbconnect.sql
+++ b/extensions/wikia/FacebookClient/sql/update_user_fbconnect.sql
@@ -1,0 +1,19 @@
+-- Add columns, about 14s in dev (844966 rows each)
+ALTER TABLE user_fbconnect ADD COLUMN user_fb_app_id bigint(20) DEFAULT 0;
+ALTER TABLE user_fbconnect ADD COLUMN user_fb_biz_token varchar(255) DEFAULT '';
+
+-- Take care of dup wikia user IDs, about 3s (126 rows)
+UPDATE
+        user_fbconnect AS orig,
+        (SELECT user_id, min(time) AS min_time, count(*)
+         FROM user_fbconnect GROUP BY user_id HAVING count(*) > 1) AS dup
+SET user_fb_app_id = 1
+WHERE orig.user_id = dup.user_id AND
+      orig.time = dup.min_time;
+
+-- Add constraints, about 7s
+ALTER TABLE user_fbconnect ADD UNIQUE KEY (user_id, user_fb_app_id);
+ALTER TABLE user_fbconnect ADD UNIQUE KEY (user_fbid, user_fb_app_id);
+
+-- Remove old constraint about 12s (844966 rows)
+ALTER TABLE user_fbconnect DROP PRIMARY KEY;

--- a/extensions/wikia/FacebookClient/sql/update_user_fbconnect.sql
+++ b/extensions/wikia/FacebookClient/sql/update_user_fbconnect.sql
@@ -1,8 +1,8 @@
--- Add columns, about 14s in dev (844966 rows each)
+-- 1) Add columns, about 14s in dev (844966 rows each)
 ALTER TABLE user_fbconnect ADD COLUMN user_fb_app_id bigint(20) DEFAULT 0;
 ALTER TABLE user_fbconnect ADD COLUMN user_fb_biz_token varchar(255) DEFAULT '';
 
--- Take care of dup wikia user IDs, about 3s (126 rows)
+-- 2) Take care of dup wikia user IDs, about 3s (126 rows)
 UPDATE
         user_fbconnect AS orig,
         (SELECT user_id, min(time) AS min_time, count(*)
@@ -11,9 +11,9 @@ SET user_fb_app_id = 1
 WHERE orig.user_id = dup.user_id AND
       orig.time = dup.min_time;
 
--- Add constraints, about 7s
+-- 3) Add constraints, about 7s
 ALTER TABLE user_fbconnect ADD UNIQUE KEY (user_id, user_fb_app_id);
 ALTER TABLE user_fbconnect ADD UNIQUE KEY (user_fbid, user_fb_app_id);
 
--- Remove old constraint about 12s (844966 rows)
+-- 4) Remove old constraint about 12s (844966 rows)
 ALTER TABLE user_fbconnect DROP PRIMARY KEY;

--- a/extensions/wikia/FacebookClient/tests/FacebookMapModelIntegrationTest.php
+++ b/extensions/wikia/FacebookClient/tests/FacebookMapModelIntegrationTest.php
@@ -1,0 +1,162 @@
+
+<?php
+
+/**
+ * FacebookMapModelIntegrationTest
+ *
+ * Database and Memcache integration tests
+ *
+ * @category Wikia
+ * @group UsingDB
+ */
+
+class FacebookMapModelIntegrationTest extends WikiaBaseTest {
+
+	/**
+	 * @dataProvider mappingIdProvider
+	 */
+	public function testMemcachedWikiaCRUD( $wikiaUserId, $facebookUserId ) {
+		/** @var PHPUnit_Framework_MockObject_MockObject|FacebookMapModel $mockMap */
+		$mockMap = $this->getMock( 'FacebookMapModel', [ 'saveToDatabase' ] );
+		$mockMap->expects( $this->once() )
+			->method( 'saveToDatabase' );
+
+		// CREATE
+		$mockMap->relate( $wikiaUserId, $facebookUserId );
+		$mockMap->save();
+
+		// READ
+		$this->assertTrue(
+			FacebookMapModel::hasUserMapping( $wikiaUserId, $facebookUserId ),
+			'Mapping does not exist'
+		);
+
+		$map = FacebookMapModel::lookupFromWikiaID( $wikiaUserId );
+		$this->assertNotEmpty( $map, 'Object not found in memcache' );
+		$this->assertEquals( $wikiaUserId, $map->getWikiaUserId(), 'Wikia user ID does not match' );
+		$this->assertEquals( $facebookUserId, $map->getFacebookUserId(), 'Facebook user ID does not match' );
+
+		// DELETE
+		FacebookMapModel::deleteFromWikiaID( $wikiaUserId );
+		$map = FacebookMapModel::lookupFromWikiaID( $wikiaUserId );
+		$this->assertEmpty( $map, 'Object still found in memcache after delete' );
+	}
+
+	/**
+	 * @dataProvider mappingIdProvider
+	 */
+	public function testMemcachedFacebookCRUD( $wikiaUserId, $facebookUserId ) {
+		/** @var PHPUnit_Framework_MockObject_MockObject|FacebookMapModel $mockMap */
+		$mockMap = $this->getMock( 'FacebookMapModel', [ 'saveToDatabase' ] );
+		$mockMap->expects( $this->once() )
+			->method( 'saveToDatabase' );
+
+		// CREATE
+		$mockMap->relate( $wikiaUserId, $facebookUserId );
+		$mockMap->save();
+
+		// READ
+		$this->assertTrue(
+			FacebookMapModel::hasUserMapping( $wikiaUserId, $facebookUserId ),
+			'Mapping does not exist'
+		);
+
+		$map = FacebookMapModel::lookupFromFacebookID( $facebookUserId );
+		$this->assertNotEmpty( $map, 'Object not found in memcache' );
+		$this->assertEquals( $wikiaUserId, $map->getWikiaUserId(), 'Wikia user ID does not match' );
+		$this->assertEquals( $facebookUserId, $map->getFacebookUserId(), 'Facebook user ID does not match' );
+
+		// DELETE
+		FacebookMapModel::deleteFromFacebookID( $facebookUserId );
+		$map = FacebookMapModel::lookupFromFacebookID( $facebookUserId );
+		$this->assertEmpty( $map, 'Object still found in memcache after delete' );
+	}
+
+	/**
+	 * @dataProvider mappingIdProvider
+	 */
+	public function testDBWikiaCRUD( $wikiaUserId, $facebookUserId ) {
+		self::setupMockCache();
+
+		/** @var PHPUnit_Framework_MockObject_MockObject|FacebookMapModel $mockMap */
+		$mockMap = $this->getMock( 'FacebookMapModel', [ 'saveToCache' ] );
+		$mockMap->expects( $this->once() )
+			->method( 'saveToCache' );
+
+		// CREATE
+		$mockMap->relate( $wikiaUserId, $facebookUserId );
+		$mockMap->save();
+
+		// READ
+		$this->assertTrue(
+			FacebookMapModel::hasUserMapping( $wikiaUserId, $facebookUserId ),
+			'Mapping does not exist'
+		);
+
+		$map = FacebookMapModel::lookupFromWikiaID( $wikiaUserId );
+		$this->assertNotEmpty( $map, 'Object not found in memcache' );
+		$this->assertEquals( $wikiaUserId, $map->getWikiaUserId(), 'Wikia user ID does not match' );
+		$this->assertEquals( $facebookUserId, $map->getFacebookUserId(), 'Facebook user ID does not match' );
+
+		// DELETE
+		FacebookMapModel::deleteFromWikiaID( $wikiaUserId );
+		$map = FacebookMapModel::lookupFromWikiaID( $wikiaUserId );
+		$this->assertEmpty( $map, 'Object still found in memcache after delete' );
+	}
+
+	/**
+	 * @dataProvider mappingIdProvider
+	 */
+	public function testDBFacebookCRUD( $wikiaUserId, $facebookUserId ) {
+		self::setupMockCache();
+
+		/** @var PHPUnit_Framework_MockObject_MockObject|FacebookMapModel $mockMap */
+		$mockMap = $this->getMock( 'FacebookMapModel', [ 'saveToCache' ] );
+		$mockMap->expects( $this->once() )
+			->method( 'saveToCache' );
+
+		// CREATE
+		$mockMap->relate( $wikiaUserId, $facebookUserId );
+		$mockMap->save();
+
+		// READ
+		$this->assertTrue(
+			FacebookMapModel::hasUserMapping( $wikiaUserId, $facebookUserId ),
+			'Mapping does not exist'
+		);
+
+		$map = FacebookMapModel::lookupFromFacebookID( $facebookUserId );
+		$this->assertNotEmpty( $map, 'Object not found in memcache' );
+		$this->assertEquals( $wikiaUserId, $map->getWikiaUserId(), 'Wikia user ID does not match' );
+		$this->assertEquals( $facebookUserId, $map->getFacebookUserId(), 'Facebook user ID does not match' );
+
+		// DELETE
+		FacebookMapModel::deleteFromFacebookID( $facebookUserId );
+		$map = FacebookMapModel::lookupFromFacebookID( $facebookUserId );
+		$this->assertEmpty( $map, 'Object still found in memcache after delete' );
+	}
+
+	protected function setupMockCache( ) {
+
+		// mock cache
+		$mockCache = $this->getMock( 'stdClass', [ 'get', 'set', 'delete' ] );
+		$mockCache->expects( $this->any() )
+			->method( 'get' )
+			->willReturn( null );
+		$mockCache->expects( $this->any() )
+			->method( 'set' );
+		$mockCache->expects( $this->any() )
+			->method( 'delete' );
+
+		$this->mockGlobalVariable( 'wgMemc', $mockCache );
+	}
+
+	public function mappingIdProvider() {
+		return [
+			[ 123, 987 ],
+			[ 23910423, 1506379856279184 ],
+		];
+	}
+
+
+}

--- a/extensions/wikia/FacebookClient/tests/FacebookMapModelIntegrationTest.php
+++ b/extensions/wikia/FacebookClient/tests/FacebookMapModelIntegrationTest.php
@@ -8,9 +8,20 @@
  *
  * @category Wikia
  * @group UsingDB
+ * @group Facebook
  */
 
 class FacebookMapModelIntegrationTest extends WikiaBaseTest {
+
+	public function setUp() {
+		// Don't get screwed if someone else doesn't clean up Memc
+		F::app()->wg->Memc = wfGetMainCache();
+	}
+
+	public function tearDown() {
+		// Don't screw anyone else
+		F::app()->wg->Memc = wfGetMainCache();
+	}
 
 	/**
 	 * @dataProvider mappingIdProvider

--- a/extensions/wikia/FacebookClient/tests/FacebookMapModelTest.php
+++ b/extensions/wikia/FacebookClient/tests/FacebookMapModelTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * FacebookMapModel test
+ *
+ * Testing the models non-static interface
+ *
+ * @category Wikia
+ */
+class FacebookMapModelTest extends WikiaBaseTest {
+
+	/**
+	 * @dataProvider mappingIdProvider
+	 */
+	public function testCreateValid( $wikiaUserId, $facebookUserId ) {
+		/** @var PHPUnit_Framework_MockObject_MockObject|FacebookMapModel $mockMap */
+		$mockMap = $this->getMock( 'FacebookMapModel', [ 'saveToDatabase' ] );
+		$mockMap->expects( $this->once() )
+			->method( 'saveToDatabase' );
+
+		$mockMap->relate( $wikiaUserId, $facebookUserId );
+
+		// Intercept the call to memcache's set and make sure its passed our object
+		self::setupMockWriteCache( $mockMap );
+
+		$mockMap->save();
+	}
+
+	public function mappingIdProvider() {
+		return [
+			[ 123, 987 ]
+		];
+	}
+
+	protected function setupMockWriteCache( $object ) {
+
+		// mock cache
+		$mockCache = $this->getMock( 'stdClass', [ 'get', 'set', 'delete' ] );
+		$mockCache->expects( $this->never() )
+			->method( 'get' );
+		$mockCache->expects( $this->exactly( 2 ) )
+			->method( 'set' )
+			->with( $this->anything(), $object );
+		$mockCache->expects( $this->never() )
+			->method( 'delete' );
+
+		$this->mockGlobalVariable( 'wgMemc', $mockCache );
+	}
+
+	/**
+	 * @dataProvider badIdProvider
+	 * @expectedException FacebookMapModelInvalidDataException
+	 */
+	public function testCreateBadID( $wikiaUserId, $facebookUserId ) {
+		self::setupMockUnusedCache();
+
+		/** @var PHPUnit_Framework_MockObject_MockObject|FacebookMapModel $mockMap */
+		$mockMap = $this->getMock( 'FacebookMapModel', [ 'saveToDatabase' ] );
+		$mockMap->expects( $this->never() )
+			->method( 'saveToDatabase' );
+		$mockMap->expects( $this->never() )
+			->method( 'saveToCache' );
+
+		$mockMap->relate( $wikiaUserId, $facebookUserId );
+		$mockMap->save();
+	}
+
+	public function badIdProvider() {
+		return [
+			[ null, 987 ],
+			[ 123, null ],
+			[ 123, 0 ],
+			[ 0, 0 ],
+			[ '', '' ],
+		];
+	}
+
+	protected function setupMockUnusedCache() {
+
+		// mock cache
+		$mockCache = $this->getMock( 'stdClass', [ 'get', 'set', 'delete' ] );
+		$mockCache->expects( $this->never() )
+			->method( 'get' );
+		$mockCache->expects( $this->never() )
+			->method( 'set' );
+		$mockCache->expects( $this->never() )
+			->method( 'delete' );
+
+		$this->mockGlobalVariable( 'wgMemc', $mockCache );
+	}
+}

--- a/extensions/wikia/FacebookClient/tests/FacebookMapModelTest.php
+++ b/extensions/wikia/FacebookClient/tests/FacebookMapModelTest.php
@@ -6,8 +6,19 @@
  * Testing the models non-static interface
  *
  * @category Wikia
+ * @group Facebook
  */
 class FacebookMapModelTest extends WikiaBaseTest {
+
+	public function setUp() {
+		// Don't get screwed if someone else doesn't clean up Memc
+		F::app()->wg->Memc = wfGetMainCache();
+	}
+
+	public function tearDown() {
+		// Don't screw anyone else
+		F::app()->wg->Memc = wfGetMainCache();
+	}
 
 	/**
 	 * @dataProvider mappingIdProvider

--- a/extensions/wikia/UserLogin/UserLoginFacebookForm.class.php
+++ b/extensions/wikia/UserLogin/UserLoginFacebookForm.class.php
@@ -70,9 +70,10 @@ class UserLoginFacebookForm extends UserLoginForm {
 	 * @param User $user Wikia account
 	 * @return bool true on success
 	 */
-	private function connectWithFacebook(User $user) {
+	private function connectWithFacebook( User $user ) {
 		if ( F::app()->wg->EnableFacebookClientExt ) {
-			return \FacebookMapModel::createUserMapping( $user->getId(), $this->fbUserId );
+			$mapping = \FacebookMapModel::createUserMapping( $user->getId(), $this->fbUserId );
+			return !empty( $mapping );
 		}
 
 		FBConnectDB::addFacebookID( $user, $this->fbUserId );


### PR DESCRIPTION
Changes to record all the data necessary to disambiguate Facebook users now that we don't get a universally unique ID.

https://wikia-inc.atlassian.net/browse/UC-138
