### PR TITLE
VE-1679: Show 3 columns when scrollbar is present

### DIFF
--- a/extensions/VisualEditor/wikia/modules/ve/ui/styles/ve.ui.WikiaSingleMediaInsertDialog.scss
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/styles/ve.ui.WikiaSingleMediaInsertDialog.scss
@@ -36,7 +36,7 @@ $width-results: 552px;
 		width: $width-results;
 
 		.oo-ui-selectWidget {
-			margin: 20px 24px;
+			margin: 20px 0 20px 24px;
 		}
 
 		.ve-ui-mwMediaResultWidget {


### PR DESCRIPTION
By omitting the right margin only 3 option widgets can still fit on each row, but space is also created for a scrollbar if necessary.
