### PR TITLE
Uc 107 Re-enabling notification to users upon successful facebook signup

### DIFF
--- a/extensions/FBConnect/FBConnect.php
+++ b/extensions/FBConnect/FBConnect.php
@@ -163,6 +163,7 @@ class FBConnect {
 		}
 
 		/* Wikia change begin */
+		$wgHooks['SkinTemplatePageBeforeUserMsg'][] = 'NotificationsController::addFacebookConnectConfirmation';
 		$wgHooks['OasisSkinAssetGroups'][] = 'FBConnectHooks::onSkinAssetGroups';
 		$wgHooks['MonobookSkinAssetGroups'][] = 'FBConnectHooks::onSkinAssetGroups';
 		/* Wikia change end */

--- a/extensions/FBConnect/FBConnectHooks.php
+++ b/extensions/FBConnect/FBConnectHooks.php
@@ -686,6 +686,7 @@ HTML;
 		return true;
 	}
 
+	// doesn't actually work. This is done in NotificationsController.class.php
 	public static function SkinTemplatePageBeforeUserMsg(&$msg) {
 		global $wgRequest, $wgUser, $wgServer;
 

--- a/extensions/wikia/FacebookClient/FacebookClient.class.php
+++ b/extensions/wikia/FacebookClient/FacebookClient.class.php
@@ -413,6 +413,16 @@ class FacebookClient {
 
 		return $titleObj->getFullURL( $queryStr );
 	}
+
+	/**
+	 * Get facebook mapping for current user
+	 * @return FacebookMapModel
+	 */
+	public function getMapping() {
+		$id = $this->getUserId();
+		$map = FacebookMapModel::lookupFromFacebookID( $id );
+		return $map;
+	}
 }
 
 /**

--- a/extensions/wikia/FacebookClient/FacebookClient.i18n.php
+++ b/extensions/wikia/FacebookClient/FacebookClient.i18n.php
@@ -60,6 +60,7 @@ The Wikia Community Team',
 	'fbconnect-canceltext' => 'The previous action was cancelled by the user.',
 	'fbconnect-preferences-connected' => 'Congratulations! Your Wikia and Facebook accounts are now connected.',
 	'fbconnect-preferences-connected-error' => "We're sorry, we couldn't complete your connection. Please make sure you are logged in to your Wikia account and have given Wikia permission to connect with Facebook.",
+	'fbconnect-connect-msg' => "Congratulations! Your Wikia and Facebook accounts are now connected.",
 ];
 
 /**
@@ -101,4 +102,5 @@ $messages['qqq'] = [
 	'fbconnect-logout-confirm' => 'Message shown if a user attempts to cancel process of connecting Wikia account with Facebook account. It informs the user that proceeding with this action will result in logout from Facebook and asks for confirmation.',
 	'fbconnect-preferences-connected' => 'Notifies user when they have successfully connected their facebook and wikia accounts via Special:Preferences',
 	'fbconnect-preferences-connected-error' => 'Notifies user if there was an error while trying to connect their facebook and wikia accounts via Special:Preferences',
+	'fbconnect-connect-msg' => 'Message users see when they have successfully signed up for facebook',
 ];

--- a/extensions/wikia/FacebookClient/FacebookClient.i18n.php
+++ b/extensions/wikia/FacebookClient/FacebookClient.i18n.php
@@ -60,7 +60,7 @@ The Wikia Community Team',
 	'fbconnect-canceltext' => 'The previous action was cancelled by the user.',
 	'fbconnect-preferences-connected' => 'Congratulations! Your Wikia and Facebook accounts are now connected.',
 	'fbconnect-preferences-connected-error' => "We're sorry, we couldn't complete your connection. Please make sure you are logged in to your Wikia account and have given Wikia permission to connect with Facebook.",
-	'fbconnect-connect-msg' => "Congratulations! Your Wikia and Facebook accounts are now connected.",
+	'fbconnect-connect-msg' => 'Congratulations! Your Wikia and Facebook accounts are now connected.',
 ];
 
 /**

--- a/extensions/wikia/FacebookClient/FacebookClient.setup.php
+++ b/extensions/wikia/FacebookClient/FacebookClient.setup.php
@@ -45,6 +45,7 @@ $wgHooks['GetPreferences'][] = 'FacebookClientHooks::GetPreferences';
 $wgHooks['OasisSkinAssetGroups'][] = 'FacebookClientHooks::onSkinAssetGroups';
 $wgHooks['MonobookSkinAssetGroups'][] = 'FacebookClientHooks::onSkinAssetGroups';
 $wgHooks['ParserFirstCallInit'][] = 'FacebookClientHooks::setupParserHook';
+$wgHooks['SkinTemplatePageBeforeUserMsg'][] = 'FacebookClientHooks::onSkinTemplatePageBeforeUserMsg';
 
 // special pages
 $wgSpecialPages[ 'FacebookConnect' ] =  'SpecialFacebookConnectController';

--- a/extensions/wikia/FacebookClient/FacebookClientHooks.class.php
+++ b/extensions/wikia/FacebookClient/FacebookClientHooks.class.php
@@ -122,4 +122,26 @@ class FacebookClientHooks {
 
 		return true;
 	}
+
+	/**
+	 * Handle confirmation message from Facebook Connect
+	 */
+	public static function onSkinTemplatePageBeforeUserMsg( &$html ) {
+		if ( F::app()->checkSkin( 'oasis' ) ) {
+			$fbStatus = F::app()->wg->Request->getVal( 'fbconnected' );
+
+			if ( $fbStatus  == '1' ) {
+				// note - sometimes returns user id even if user is logged out or disconnected from facebook (UC-144)
+				// doesn't matter so much for our purposes here though
+				$id = FacebookClient::getInstance()->getUserId();
+				if ( $id > 0 ) {
+					NotificationsController::addConfirmation( wfMessage( 'fbconnect-connect-msg' )->plain() );
+				}
+			}
+		}
+
+		return true;
+	}
+
+
 }

--- a/extensions/wikia/FacebookClient/FacebookClientHooks.class.php
+++ b/extensions/wikia/FacebookClient/FacebookClientHooks.class.php
@@ -128,13 +128,13 @@ class FacebookClientHooks {
 	 */
 	public static function onSkinTemplatePageBeforeUserMsg( &$html ) {
 		if ( F::app()->checkSkin( 'oasis' ) ) {
+			// check for querystring param
 			$fbStatus = F::app()->wg->Request->getVal( 'fbconnected' );
 
 			if ( $fbStatus  == '1' ) {
-				// note - sometimes returns user id even if user is logged out or disconnected from facebook (UC-144)
-				// doesn't matter so much for our purposes here though
-				$id = FacebookClient::getInstance()->getUserId();
-				if ( $id > 0 ) {
+				// check if current user is connected to facebook
+				$map = FacebookClient::getInstance()->getMapping();
+				if ( !empty( $map ) ) {
 					NotificationsController::addConfirmation( wfMessage( 'fbconnect-connect-msg' )->plain() );
 				}
 			}

--- a/extensions/wikia/GlobalNotification/GlobalNotification.js
+++ b/extensions/wikia/GlobalNotification/GlobalNotification.js
@@ -22,15 +22,13 @@ var GlobalNotification = {
 	 */
 	init: function () {
 		'use strict';
+
 		// If there's already a global notification on page load, set up JS
 		GlobalNotification.dom = $('.global-notification');
 		if (GlobalNotification.dom.length) {
 			this.setUpClose();
-
-			// temporary fix for CON-1856
-			// todo: must be removed together with global notification redesign
-			this.autoHide();
 		}
+
 		// Float notification (BugId:33365)
 		this.wikiaHeaderHeight = $('#WikiaHeader').height();
 	},

--- a/extensions/wikia/GlobalNotification/GlobalNotification.js
+++ b/extensions/wikia/GlobalNotification/GlobalNotification.js
@@ -34,15 +34,6 @@ var GlobalNotification = {
 	},
 
 	/**
-	 * @desc auto-hides global notification after 3 seconds
-	 * @todo: required for CON-1856 - temporary solution must be removed together with global notification redesign
-	 */
-	autoHide: function () {
-		'use strict';
-		window.setTimeout(this.hide, this.defaultTimeout);
-	},
-
-	/**
 	 * Build the notification DOM element and attach it to the DOM
 	 * @param {object} [element] Element to prepend the notification to
 	 * @param {boolean} [isModal] Whether or not a modal is present and visible on the page

--- a/extensions/wikia/Oasis/Oasis_setup.php
+++ b/extensions/wikia/Oasis/Oasis_setup.php
@@ -46,7 +46,6 @@ function wfOasisSetup() {
 	$wgHooks['ArticleDeleteComplete'][] = 'NotificationsController::addPageDeletedConfirmation';
 	$wgHooks['ArticleUndelete'][] = 'NotificationsController::addPageUndeletedConfirmation';
 	#$wgHooks['EditPageSuccessfulSave'][] = 'NotificationsController::addSaveConfirmation'; // BugId:10129
-	$wgHooks['SkinTemplatePageBeforeUserMsg'][] = 'NotificationsController::addFacebookConnectConfirmation';
 	$wgHooks['SpecialMovepageAfterMove'][] = 'NotificationsController::addPageMovedConfirmation';
 	$wgHooks['SpecialPreferencesOnRender'][] = 'NotificationsController::addPreferencesConfirmation';
 	$wgHooks['UserLogoutComplete'][] = 'NotificationsController::addLogOutConfirmation';

--- a/skins/oasis/modules/NotificationsController.class.php
+++ b/skins/oasis/modules/NotificationsController.class.php
@@ -122,6 +122,12 @@ class NotificationsController extends WikiaController {
 	public function executeConfirmation() {
 		wfProfileIn(__METHOD__);
 
+		// call hook to trigger user messages from extensions
+		#wfRunHooks('SkinTemplatePageBeforeUserMsg', array(&$ntl));
+
+		// add testing confirmation
+		# self::addConfirmation('test');
+
 		if (!empty($_SESSION[self::SESSION_KEY])) {
 			$entry = $_SESSION[self::SESSION_KEY];
 

--- a/skins/oasis/modules/NotificationsController.class.php
+++ b/skins/oasis/modules/NotificationsController.class.php
@@ -122,12 +122,6 @@ class NotificationsController extends WikiaController {
 	public function executeConfirmation() {
 		wfProfileIn(__METHOD__);
 
-		// call hook to trigger user messages from extensions
-		#wfRunHooks('SkinTemplatePageBeforeUserMsg', array(&$ntl));
-
-		// add testing confirmation
-		# self::addConfirmation('test');
-
 		if (!empty($_SESSION[self::SESSION_KEY])) {
 			$entry = $_SESSION[self::SESSION_KEY];
 
@@ -303,11 +297,11 @@ class NotificationsController extends WikiaController {
 
 	/**
 	 * Handle confirmations from Facebook Connect
+	 * @todo: Remove this function when we switch over to wgEnableFacebookClientExt
 	 */
 	public static function addFacebookConnectConfirmation(&$html) {
 		wfProfileIn(__METHOD__);
 		global $wgRequest, $wgUser;
-
 
 		// FBConnect messages
 		if ( F::app()->checkSkin( 'oasis' ) && class_exists('FBConnectHooks')) {

--- a/skins/oasis/modules/templates/Body_Index.php
+++ b/skins/oasis/modules/templates/Body_Index.php
@@ -15,7 +15,6 @@
 <? else: ?>
 	<?= $app->renderView('GlobalHeader', 'Index') ?>
 <? endif ?>
-<?= $app->renderView('Notifications', 'Confirmation') ?>
 <?= $app->renderView('Ad', 'Top') ?>
 
 <?= empty($wg->WikiaSeasonsPencilUnit) ? '' : $app->renderView('WikiaSeasons', 'pencilUnit', array()); ?>
@@ -23,6 +22,7 @@
 <section id="WikiaPage" class="WikiaPage<?= empty( $wg->OasisNavV2 ) ? '' : ' V2' ?><?= !empty($isGridLayoutEnabled) ? ' WikiaGrid' : '' ?>">
 	<div id="WikiaPageBackground" class="WikiaPageBackground"></div>
 	<div class="WikiaPageContentWrapper">
+		<?= $app->renderView('Notifications', 'Confirmation') ?>
 		<?php
 			if ( empty( $wg->SuppressWikiHeader )) {
 				if ( empty( $wg->EnableLocalNavExt ) ) {

--- a/skins/oasis/modules/templates/Body_Index.php
+++ b/skins/oasis/modules/templates/Body_Index.php
@@ -1,5 +1,5 @@
 <? if ( $displayHeader ): ?>
-<h1><?= wfMsg('oasis-global-page-header'); ?></h1>
+<h1><?= wfMsg( 'oasis-global-page-header' ); ?></h1>
 <? endif; ?>
 <div class="skiplinkcontainer">
 <a class="skiplink" rel="nofollow" href="#WikiaArticle"><?= wfMsg( 'oasis-skip-to-content' ); ?></a>
@@ -11,20 +11,20 @@
 <div id="ad-skin" class="wikia-ad noprint"></div>
 
 <? if ( !empty( $wg->EnableGlobalNavExt ) ): ?>
-	<?= $app->renderView('GlobalNavigation', 'index') ?>
+	<?= $app->renderView( 'GlobalNavigation', 'index' ) ?>
 <? else: ?>
-	<?= $app->renderView('GlobalHeader', 'Index') ?>
+	<?= $app->renderView( 'GlobalHeader', 'Index' ) ?>
 <? endif ?>
-<?= $app->renderView('Ad', 'Top') ?>
+<?= $app->renderView( 'Ad', 'Top' ) ?>
 
-<?= empty($wg->WikiaSeasonsPencilUnit) ? '' : $app->renderView('WikiaSeasons', 'pencilUnit', array()); ?>
+<?= empty( $wg->WikiaSeasonsPencilUnit ) ? '' : $app->renderView( 'WikiaSeasons', 'pencilUnit', array() ); ?>
 
-<section id="WikiaPage" class="WikiaPage<?= empty( $wg->OasisNavV2 ) ? '' : ' V2' ?><?= !empty($isGridLayoutEnabled) ? ' WikiaGrid' : '' ?>">
+<section id="WikiaPage" class="WikiaPage<?= empty( $wg->OasisNavV2 ) ? '' : ' V2' ?><?= !empty( $isGridLayoutEnabled ) ? ' WikiaGrid' : '' ?>">
 	<div id="WikiaPageBackground" class="WikiaPageBackground"></div>
 	<div class="WikiaPageContentWrapper">
-		<?= $app->renderView('Notifications', 'Confirmation') ?>
+		<?= $app->renderView( 'Notifications', 'Confirmation' ) ?>
 		<?php
-			if ( empty( $wg->SuppressWikiHeader )) {
+			if ( empty( $wg->SuppressWikiHeader ) ) {
 				if ( empty( $wg->EnableLocalNavExt ) ) {
 					echo $app->renderView( 'WikiHeader', 'Index' );
 				} else {
@@ -33,51 +33,51 @@
 			}
 		?>
 		<?php
-		if ( !empty( $wg->EnableNjordExt) && WikiaPageType::isMainPage() ) {
+		if ( !empty( $wg->EnableNjordExt ) && WikiaPageType::isMainPage() ) {
 			echo $app->renderView( 'Njord', 'Index' );
 		}
 		?>
 		<?php
-			if (!empty($wg->EnableWikiAnswers)) {
-				echo $app->renderView('WikiAnswers', 'QuestionBox');
+			if ( !empty( $wg->EnableWikiAnswers ) ) {
+				echo $app->renderView( 'WikiAnswers', 'QuestionBox' );
 			}
 		?>
 
 		<?php
-		if (!empty( $wg->InterlangOnTop ) ) {
-			echo $app->renderView('ArticleInterlang', 'Index');
+		if ( !empty( $wg->InterlangOnTop ) ) {
+			echo $app->renderView( 'ArticleInterlang', 'Index' );
 		}
 		?>
 
 		<?php
-		if ($headerModuleName == 'UserPagesHeader' && ($headerModuleAction != 'BlogPost' && $headerModuleAction != 'BlogListing') ) {
-			echo $app->renderView($headerModuleName, $headerModuleAction, $headerModuleParams);
+		if ( $headerModuleName == 'UserPagesHeader' && ( $headerModuleAction != 'BlogPost' && $headerModuleAction != 'BlogListing' ) ) {
+			echo $app->renderView( $headerModuleName, $headerModuleAction, $headerModuleParams );
 		}
 		?>
 
 		<?php
 			// Needs to be above page header so it can suppress page header
-			if ($displayAdminDashboard) {
-				echo $app->renderView('AdminDashboard', 'Chrome');
+			if ( $displayAdminDashboard ) {
+				echo $app->renderView( 'AdminDashboard', 'Chrome' );
 			}
 		?>
 
-		<article id="WikiaMainContent" class="WikiaMainContent<?= !empty($isGridLayoutEnabled) ? $railModulesExist ? ' grid-4' : ' grid-6' : '' ?>">
+		<article id="WikiaMainContent" class="WikiaMainContent<?= !empty( $isGridLayoutEnabled ) ? $railModulesExist ? ' grid-4' : ' grid-6' : '' ?>">
 			<?php
-			if ( !empty( $wg->EnableMomModulesExt) && WikiaPageType::isMainPage() ) {
+			if ( !empty( $wg->EnableMomModulesExt ) && WikiaPageType::isMainPage() ) {
 				echo $app->renderView( 'Njord', 'mom' );
 			}
 			?>
 			<div id="WikiaMainContentContainer" class="WikiaMainContentContainer">
 				<?php
-					if (!empty($wg->EnableForumExt) && ForumHelper::isForum()) {
+					if ( !empty( $wg->EnableForumExt ) && ForumHelper::isForum() ) {
 						echo $app->renderView( 'ForumController', 'header' );
 					}
 
 					// render UserPagesHeader or PageHeader or nothing...
-					if (empty($wg->SuppressPageHeader) && $headerModuleName) {
-						if ($headerModuleName == 'UserPagesHeader') {
-							if ($headerModuleAction == 'BlogPost' || $headerModuleAction == 'BlogListing') {
+					if ( empty( $wg->SuppressPageHeader ) && $headerModuleName ) {
+						if ( $headerModuleName == 'UserPagesHeader' ) {
+							if ( $headerModuleAction == 'BlogPost' || $headerModuleAction == 'BlogListing' ) {
 								// Show blog post header
 								echo $app->renderView( $headerModuleName, $headerModuleAction, $headerModuleParams );
 							} else {
@@ -85,33 +85,33 @@
 								echo $app->renderView( 'UserProfilePage', 'renderActionButton', array() );
 							}
 						} else {
-							echo $app->renderView($headerModuleName, $headerModuleAction, $headerModuleParams);
+							echo $app->renderView( $headerModuleName, $headerModuleAction, $headerModuleParams );
 						}
 					}
 				?>
 
 
-				<?php if ($subtitle != '' && $headerModuleName == 'UserPagesHeader' ) { ?>
+				<?php if ( $subtitle != '' && $headerModuleName == 'UserPagesHeader' ) { ?>
 					<div id="contentSub"><?= $subtitle ?></div>
 				<?php } ?>
 
-				<div id="WikiaArticle" class="WikiaArticle<?= $displayAdminDashboardChromedArticle ? ' AdminDashboardChromedArticle' : '' ?>"<?= $body_ondblclick ? ' ondblclick="' . htmlspecialchars($body_ondblclick) . '"' : '' ?>>
-					<? if($displayAdminDashboardChromedArticle) { ?>
-						<?= (string)$app->sendRequest( 'AdminDashboardSpecialPage', 'chromedArticleHeader', array('headerText' => $wg->Title->getText() )) ?>
+				<div id="WikiaArticle" class="WikiaArticle<?= $displayAdminDashboardChromedArticle ? ' AdminDashboardChromedArticle' : '' ?>"<?= $body_ondblclick ? ' ondblclick="' . htmlspecialchars( $body_ondblclick ) . '"' : '' ?>>
+					<? if( $displayAdminDashboardChromedArticle ) { ?>
+						<?= ( string )$app->sendRequest( 'AdminDashboardSpecialPage', 'chromedArticleHeader', array( 'headerText' => $wg->Title->getText() ) ) ?>
 					<? } ?>
 
 					<div class="home-top-right-ads">
 					<?php
 						if ( !WikiaPageType::isCorporatePage() && !$wg->EnableVideoPageToolExt && WikiaPageType::isMainPage() ) {
-							echo $app->renderView('Ad', 'Index', [
+							echo $app->renderView( 'Ad', 'Index', [
 								'slotName' => 'HOME_TOP_RIGHT_BOXAD',
-								'pageFairId' => isset($wg->AnalyticsProviderPageFairSlotIds['MEDREC']) ? $wg->AnalyticsProviderPageFairSlotIds['MEDREC'] : null,
+								'pageFairId' => isset( $wg->AnalyticsProviderPageFairSlotIds['MEDREC'] ) ? $wg->AnalyticsProviderPageFairSlotIds['MEDREC'] : null,
 								'pageTypes' => ['homepage_logged', 'corporate', 'all_ads']
-							]);
+							] );
 						}
 
-						if (!WikiaPageType::isCorporatePage() && !WikiaPageType::isMainPage() && $wg->AdDriverUseTopInContentBoxad) {
-							echo $app->renderView('Ad', 'Index', ['slotName' => 'TOP_INCONTENT_BOXAD']);
+						if ( !WikiaPageType::isCorporatePage() && !WikiaPageType::isMainPage() && $wg->AdDriverUseTopInContentBoxad ) {
+							echo $app->renderView( 'Ad', 'Index', ['slotName' => 'TOP_INCONTENT_BOXAD'] );
 						}
 
 					?>
@@ -119,8 +119,8 @@
 
 					<?php
 					// for InfoBox-Testing
-					if ($wg->EnableInfoBoxTest) {
-						echo $app->renderView('ArticleInfoBox', 'Index');
+					if ( $wg->EnableInfoBoxTest ) {
+						echo $app->renderView( 'ArticleInfoBox', 'Index' );
 					} ?>
 
 					<?= $bodytext ?>
@@ -136,8 +136,8 @@
 				<? endif ?>
 
 				<?php
-				if (empty( $wg->InterlangOnTop ) ) {
-					 echo $app->renderView('ArticleInterlang', 'Index');
+				if ( empty( $wg->InterlangOnTop ) ) {
+					 echo $app->renderView( 'ArticleInterlang', 'Index' );
 				}
 				?>
 
@@ -147,7 +147,7 @@
 					}
 				?>
 
-				<?php if (!empty($afterContentHookText)) { ?>
+				<?php if ( !empty( $afterContentHookText ) ) { ?>
 					<div id="WikiaArticleFooter" class="WikiaArticleFooter">
 						<?= $afterContentHookText ?>
 					</div>
@@ -161,28 +161,28 @@
 					}
 				?>
 				<div id="WikiaArticleBottomAd" class="noprint">
-					<?= $app->renderView('Ad', 'Index', ['slotName' => 'PREFOOTER_LEFT_BOXAD']) ?>
-					<?= $app->renderView('Ad', 'Index', ['slotName' => 'PREFOOTER_RIGHT_BOXAD']) ?>
+					<?= $app->renderView( 'Ad', 'Index', ['slotName' => 'PREFOOTER_LEFT_BOXAD'] ) ?>
+					<?= $app->renderView( 'Ad', 'Index', ['slotName' => 'PREFOOTER_RIGHT_BOXAD'] ) ?>
 				</div>
 			</div>
 		</article><!-- WikiaMainContent -->
 
 		<?php if( $railModulesExist ): ?>
-			<?= $app->renderView('Rail', 'Index', array('railModuleList' => $railModuleList)); ?>
+			<?= $app->renderView( 'Rail', 'Index', array( 'railModuleList' => $railModuleList ) ); ?>
 		<?php endif; ?>
 
 		<?php
-		if ($displayAdminDashboard) {
-			echo $app->renderView('AdminDashboard', 'Rail');
+		if ( $displayAdminDashboard ) {
+			echo $app->renderView( 'AdminDashboard', 'Rail' );
 		}
 		?>
 
-		<?= empty($wg->SuppressFooter) ? $app->renderView('Footer', 'Index') : '' ?>
-		<? if(!empty($wg->EnableCorporateFooterExt)) echo $app->renderView('CorporateFooter', 'index') ?>
-		<? if(!empty($wg->EnableGlobalFooterExt)) echo $app->renderView('GlobalFooter', 'index') ?>
+		<?= empty( $wg->SuppressFooter ) ? $app->renderView( 'Footer', 'Index' ) : '' ?>
+		<? if( !empty( $wg->EnableCorporateFooterExt ) ) echo $app->renderView( 'CorporateFooter', 'index' ) ?>
+		<? if( !empty( $wg->EnableGlobalFooterExt ) ) echo $app->renderView( 'GlobalFooter', 'index' ) ?>
 	</div>
 </section><!--WikiaPage-->
 
 <?php if( $wg->EnableWikiaBarExt ): ?>
-	<?= $app->renderView('WikiaBar', 'Index'); ?>
+	<?= $app->renderView( 'WikiaBar', 'Index' ); ?>
 <?php endif; ?>


### PR DESCRIPTION
The old FBConnect extension had a banner message (GlobalNotification) when the user signup up with facebook. It was triggered by a GET string of `fbconnected=1`. This PR adds this functionality into the FacebookClient extension. 

Note: I didn't carry over the error case b/c I'm assuming we're already handling it before any redirects. 

I also implemented a more permanent solution for https://wikia-inc.atlassian.net/browse/CON-1856. Turns out when the notifications are appended to `.WikiaPageContentWrapper`, as they are with JS, the z-index works fine. I just updated the Php version to work like the JS version and it's displaying correctly now, so I removed the `autoHide()` call from GlobalNotification.js. @rafalkalinski please let me know if this looks okay to you. 
