### PR TITLE
CE-1103 Enable WikiaInYourLang extension on all wikias

### DIFF
--- a/extensions/wikia/WikiaInYourLang/WikiaInYourLangController.class.php
+++ b/extensions/wikia/WikiaInYourLang/WikiaInYourLangController.class.php
@@ -69,12 +69,28 @@ class WikiaInYourLangController extends WikiaController {
 
 	/**
 	 * Retrieves a domain (host) from a full URL
+	 * Using preg_match to handle all languages
+	 * e.g. get pad.wikia.com from zh.pad.wikia.com
 	 * @param  string $sCurrentUrl A full URL to parse
 	 * @return string              The retrieved domain
 	 */
 	private function getWikiDomain( $sCurrentUrl ) {
 		$aParsed = parse_url( $sCurrentUrl );
-		return $aParsed['host'];
+		$sHost = $aParsed['host'];
+		$regExp = "/([a-z]{2}\.)?(.*)/i";
+		/**
+		 * preg_match returns this array:
+		 * [
+		 * 	0 => zh.example.wikia.com,
+		 * 	1 => (zh. | empty),
+		 * 	2 => example.wikia.com
+		 * ]
+		 * [2] is a domain without the language prefix
+		 * @var Array
+		 */
+		$aPreged = preg_match( $regExp, $sHost );
+		$sWikiDomain = $aPreged[2];
+		return $sWikiDomain;
 	}
 
 	/**

--- a/extensions/wikia/WikiaInYourLang/WikiaInYourLangController.class.php
+++ b/extensions/wikia/WikiaInYourLang/WikiaInYourLangController.class.php
@@ -77,19 +77,20 @@ class WikiaInYourLangController extends WikiaController {
 	private function getWikiDomain( $sCurrentUrl ) {
 		$aParsed = parse_url( $sCurrentUrl );
 		$sHost = $aParsed['host'];
-		$regExp = "/([a-z]{2}\.)?(.*)/i";
+		$regExp = "/(([a-z]{2,3}|[a-z]{2}\-[a-z]{2})\.)?([^\.]+\.[a-z]+\.[a-z]+)/i";
 		/**
-		 * preg_match returns this array:
+		 * preg_match returns similar array:
 		 * [
 		 * 	0 => zh.example.wikia.com,
 		 * 	1 => (zh. | empty),
-		 * 	2 => example.wikia.com
+		 * 	2 => (zh | empty),
+		 * 	3 => example.wikia.com
 		 * ]
-		 * [2] is a domain without the language prefix
+		 * [3] is a domain without the language prefix
 		 * @var Array
 		 */
 		$aPreged = preg_match( $regExp, $sHost );
-		$sWikiDomain = $aPreged[2];
+		$sWikiDomain = $aPreged[3];
 		return $sWikiDomain;
 	}
 

--- a/extensions/wikia/WikiaInYourLang/WikiaInYourLangController.class.php
+++ b/extensions/wikia/WikiaInYourLang/WikiaInYourLangController.class.php
@@ -82,32 +82,35 @@ class WikiaInYourLangController extends WikiaController {
 	 * @param  string $sCurrentUrl A full URL to parse
 	 * @return string              The retrieved domain
 	 */
-	private function getWikiDomain( $sCurrentUrl ) {
+	public function getWikiDomain( $sCurrentUrl ) {
 		$aParsed = parse_url( $sCurrentUrl );
-		$sHost = $aParsed['host'];
-		$regExp = "/(([a-z]{2,3}|[a-z]{2}\-[a-z]{2})\.)?([^\.]+\.)(.*)/i";
-		/**
-		 * preg_match returns similar array as a third parameter:
-		 * [
-		 * 	0 => zh.example.wikia.com,
-		 * 	1 => (zh. | empty),
-		 * 	2 => (zh | empty),
-		 * 	3 => example.
-		 * 	4 => ( wikia.com | adamk.wikia-dev.com )
-		 * ]
-		 * [3] is a domain without the language prefix
-		 * @var Array
-		 */
-		$aMatches = [];
-		$iMatchesCount = preg_match( $regExp, $sHost, $aMatches );
-		/**
-		 * Domains are stored only with an original domain - wikia.com
-		 * This allows the extension to work on devboxes
-		 */
-		if ( $iMatchesCount == 1 ) {
-			$sWikiDomain = $aMatches[3] . self::WIKIAINYOURLANG_WIKIA_DOMAIN;
-		} else {
-			$sWikiDomain = false;
+		// Assume false
+		$sWikiDomain = false;
+
+		if ( isset( $aParsed['host'] ) ) {
+			$sHost = $aParsed['host'];
+			$regExp = "/(([a-z]{2,3}|[a-z]{2}\-[a-z]{2})\.)?([^\.]+\.)(.*)/i";
+			/**
+			 * preg_match returns similar array as a third parameter:
+			 * [
+			 * 	0 => zh.example.wikia.com,
+			 * 	1 => (zh. | empty),
+			 * 	2 => (zh | empty),
+			 * 	3 => example.
+			 * 	4 => ( wikia.com | adamk.wikia-dev.com )
+			 * ]
+			 * [3] is a domain without the language prefix
+			 * @var Array
+			 */
+			$aMatches = [];
+			$iMatchesCount = preg_match( $regExp, $sHost, $aMatches );
+			/**
+			 * Domains are stored only with an original domain - wikia.com
+			 * This allows the extension to work on devboxes
+			 */
+			if ( $iMatchesCount == 1 ) {
+				$sWikiDomain = $aMatches[3] . self::WIKIAINYOURLANG_WIKIA_DOMAIN;
+			}
 		}
 
 		return $sWikiDomain;

--- a/extensions/wikia/WikiaInYourLang/WikiaInYourLangController.class.php
+++ b/extensions/wikia/WikiaInYourLang/WikiaInYourLangController.class.php
@@ -6,6 +6,8 @@
 
 class WikiaInYourLangController extends WikiaController {
 
+	const WIKIAINYOURLANG_WIKIA_DOMAIN = "wikia.com";
+
 	/**
 	 * Searches the city_list table for the given wikia in the target language.
 	 * Takes the currentUrl and targetLanguage parameters from the Request object.
@@ -59,6 +61,8 @@ class WikiaInYourLangController extends WikiaController {
 			$this->response->setVal( 'success', false );
 		}
 
+		$this->response->setVal( 'query', $sWikiDomain );
+
 		/**
 		 * Cache the response aggresively
 		 */
@@ -77,20 +81,27 @@ class WikiaInYourLangController extends WikiaController {
 	private function getWikiDomain( $sCurrentUrl ) {
 		$aParsed = parse_url( $sCurrentUrl );
 		$sHost = $aParsed['host'];
-		$regExp = "/(([a-z]{2,3}|[a-z]{2}\-[a-z]{2})\.)?([^\.]+\.[a-z]+\.[a-z]+)/i";
+		$regExp = "/(([a-z]{2,3}|[a-z]{2}\-[a-z]{2})\.)?([^\.]+\.)(.*)/i";
 		/**
-		 * preg_match returns similar array:
+		 * preg_match returns similar array as a third parameter:
 		 * [
 		 * 	0 => zh.example.wikia.com,
 		 * 	1 => (zh. | empty),
 		 * 	2 => (zh | empty),
-		 * 	3 => example.wikia.com
+		 * 	3 => example.
+		 * 	4 => ( wikia.com | adamk.wikia-dev.com )
 		 * ]
 		 * [3] is a domain without the language prefix
 		 * @var Array
 		 */
-		$aPreged = preg_match( $regExp, $sHost );
-		$sWikiDomain = $aPreged[3];
+		$aMatches = [];
+		$aPreged = preg_match( $regExp, $sHost, $aMatches );
+		/**
+		 * Domains are stored only with an original domain - wikia.com
+		 * This allows the extension to work on devboxes
+		 */
+		$sWikiDomain = $aMatches[3] . self::WIKIAINYOURLANG_WIKIA_DOMAIN;
+
 		return $sWikiDomain;
 	}
 

--- a/extensions/wikia/WikiaInYourLang/modules/ext.wikiaInYourLang.js
+++ b/extensions/wikia/WikiaInYourLang/modules/ext.wikiaInYourLang.js
@@ -119,11 +119,21 @@ require(
 		}
 
 		function onNotificationClosed() {
+			// Track closing of a notification
+			var trackingParams = {
+				trackingMethod: 'ga',
+				category: 'wikia-in-your-lang',
+				action: tracker.ACTIONS.CLOSE,
+				label: targetLanguage + '-notification-close',
+			};
+			tracker.track(trackingParams);
+
 			cache.set(targetLanguage + 'WikiaInYourLangMessage', null);
 			cache.set('wikiaInYourLangNotificationShown', true);
 		}
 
 		function onLinkClick() {
+			// Track a click on a notification link
 			var trackingParams = {
 				trackingMethod: 'ga',
 				category: 'wikia-in-your-lang',

--- a/extensions/wikia/WikiaInYourLang/modules/ext.wikiaInYourLang.js
+++ b/extensions/wikia/WikiaInYourLang/modules/ext.wikiaInYourLang.js
@@ -27,7 +27,7 @@ require(
 			targetLanguage = getTargetLanguage();
 
 		function init() {
-			if (targetLanguage !== false) {
+			if (targetLanguage !== false && targetLanguage != w.wgContentLanguage) {
 				// Check local browser cache to see if a request has been sent
 				// in the last month and if the notification has been shown to him.
 				// Both have to be !== true to continue.

--- a/extensions/wikia/WikiaInYourLang/tests/WikiaInYourLangControllerTest.php
+++ b/extensions/wikia/WikiaInYourLang/tests/WikiaInYourLangControllerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+class WikiaInYourLangControllerTest extends WikiaBaseTest {
+
+	public function setUp() {
+		include_once __DIR__ . DIRECTORY_SEPARATOR
+			. '..' . DIRECTORY_SEPARATOR
+			. 'WikiaInYourLangController.class.php';
+		parent::setUp();
+	}
+
+	/**
+	 * @dataProvider getDomainsList
+	 */
+	public function testGetWikiDomain( $sDomainToParse, $sParsedDomain ) {
+		$oController = new WikiaInYourLangController();
+		$this->assertTrue( $sParsedDomain === $oController->getWikiDomain( $sDomainToParse ) );
+	}
+
+	public function getDomainsList() {
+		return [
+			['http://naruto.wikia.com', 'naruto.wikia.com'],
+			['http://zh.naruto.wikia.com', 'naruto.wikia.com'],
+			['http://pt-br.naruto.wikia.com', 'naruto.wikia.com'],
+			['http://zh.zh-pad.wikia.com', 'zh-pad.wikia.com'],
+			['http://de.engelpedia.wikia.com', 'engelpedia.wikia.com'],
+			['Just a random string', false],
+		];
+	}
+}

--- a/extensions/wikia/WikiaInYourLang/tests/WikiaInYourLangControllerTest.php
+++ b/extensions/wikia/WikiaInYourLang/tests/WikiaInYourLangControllerTest.php
@@ -3,9 +3,7 @@
 class WikiaInYourLangControllerTest extends WikiaBaseTest {
 
 	public function setUp() {
-		include_once __DIR__ . DIRECTORY_SEPARATOR
-			. '..' . DIRECTORY_SEPARATOR
-			. 'WikiaInYourLang.setup.php';
+		$this->setupFile = __DIR__ . '/../WikiaInYourLang.setup.php';
 		parent::setUp();
 	}
 

--- a/extensions/wikia/WikiaInYourLang/tests/WikiaInYourLangControllerTest.php
+++ b/extensions/wikia/WikiaInYourLang/tests/WikiaInYourLangControllerTest.php
@@ -5,7 +5,7 @@ class WikiaInYourLangControllerTest extends WikiaBaseTest {
 	public function setUp() {
 		include_once __DIR__ . DIRECTORY_SEPARATOR
 			. '..' . DIRECTORY_SEPARATOR
-			. 'WikiaInYourLangController.class.php';
+			. 'WikiaInYourLang.setup.php';
 		parent::setUp();
 	}
 
@@ -14,7 +14,7 @@ class WikiaInYourLangControllerTest extends WikiaBaseTest {
 	 */
 	public function testGetWikiDomain( $sDomainToParse, $sParsedDomain ) {
 		$oController = new WikiaInYourLangController();
-		$this->assertTrue( $sParsedDomain === $oController->getWikiDomain( $sDomainToParse ) );
+		$this->assertEquals( $sParsedDomain, $oController->getWikiDomain( $sDomainToParse ) );
 	}
 
 	public function getDomainsList() {


### PR DESCRIPTION
Per Yoko request the WikiaInYourLang extension is going site-wide. That requires a tweak that retrieves "vanilla" domain of a wikia without its language prefix (e.g. retrieves pad.wikia.com from zh.pad.wikia.com).

Corresponding config PR: https://github.com/Wikia/config/pull/756
