### PR TITLE
(CE-1161) Applying MW 1.19.22 security patches

### DIFF
--- a/includes/DefaultSettings.php
+++ b/includes/DefaultSettings.php
@@ -2677,6 +2677,14 @@ $wgResourceLoaderValidateStaticJS = false;
  */
 $wgResourceLoaderExperimentalAsyncLoading = false;
 
+/**
+ * When OutputHandler is used, mangle any output that contains
+ * <cross-domain-policy>. Without this, an attacker can send their own
+ * cross-domain policy unless it is prevented by the crossdomain.xml file at
+ * the domain root.
+ */
+$wgMangleFlashPolicy = true;
+
 /** @} */ # End of resource loader settings }
 
 

--- a/includes/Html.php
+++ b/includes/Html.php
@@ -523,31 +523,10 @@ class Html {
 					$ret .= " $key=\"$key\"";
 				}
 			} else {
-				# Apparently we need to entity-encode \n, \r, \t, although the
-				# spec doesn't mention that.  Since we're doing strtr() anyway,
-				# and we don't need <> escaped here, we may as well not call
-				# htmlspecialchars().
-				# @todo FIXME: Verify that we actually need to
-				# escape \n\r\t here, and explain why, exactly.
-				#
-				# We could call Sanitizer::encodeAttribute() for this, but we
-				# don't because we're stubborn and like our marginal savings on
-				# byte size from not having to encode unnecessary quotes.
-				$map = array(
-					'&' => '&amp;',
-					'"' => '&quot;',
-					"\n" => '&#10;',
-					"\r" => '&#13;',
-					"\t" => '&#9;'
-				);
-				if ( $wgWellFormedXml ) {
-					# This is allowed per spec: <http://www.w3.org/TR/xml/#NT-AttValue>
-					# But reportedly it breaks some XML tools?
-					# @todo FIXME: Is this really true?
-					$map['<'] = '&lt;';
-				}
-				
-				$ret .= " $key=$quote" . strtr( $value, $map ) . $quote;
+				// Note: It's important to encode < and >, even if its not
+				// required in this context, due to how language converter
+				// works.
+				$ret .= " $key=$quote" . Sanitizer::encodeAttribute( $value ) . $quote;
 			}
 		}
 		return $ret;

--- a/includes/OutputHandler.php
+++ b/includes/OutputHandler.php
@@ -7,14 +7,16 @@
 
 /**
  * Standard output handler for use with ob_start
- * 
+ *
  * @param $s string
- * 
+ *
  * @return string
  */
 function wfOutputHandler( $s ) {
-	global $wgDisableOutputCompression, $wgValidateAllHtml;
-	$s = wfMangleFlashPolicy( $s );
+	global $wgDisableOutputCompression, $wgValidateAllHtml, $wgMangleFlashPolicy;
+	if ( $wgMangleFlashPolicy ) {
+		$s = wfMangleFlashPolicy( $s );
+	}
 	if ( $wgValidateAllHtml ) {
 		$headers = apache_response_headers();
 		$isHTML = true;
@@ -70,7 +72,7 @@ function wfRequestExtension() {
 /**
  * Handler that compresses data with gzip if allowed by the Accept header.
  * Unlike ob_gzhandler, it works for HEAD requests too.
- * 
+ *
  * @param $s string
  *
  * @return string

--- a/includes/api/ApiFormatJson.php
+++ b/includes/api/ApiFormatJson.php
@@ -67,9 +67,21 @@ class ApiFormatJson extends ApiFormatBase {
 			$prefix = ( "/**/$prefix" );
 			$suffix = ')';
 		}
+
+		$json = FormatJson::encode( $this->getResultData(), $this->getIsHtml() );
+
+		// Bug 66776: wfMangleFlashPolicy() is needed to avoid a nasty bug in
+		// Flash, but what it does isn't friendly for the API, so we need to
+		// work around it.
+		if ( preg_match( '/\<\s*cross-domain-policy\s*\>/i', $json ) ) {
+			$json = preg_replace(
+				'/\<(\s*cross-domain-policy\s*)\>/i', '\\u003C$1\\u003E', $json
+			);
+		}
+
 		$this->printText(
 			$prefix .
-			FormatJson::encode( $this->getResultData(), $this->getIsHtml() ) .
+			$json .
 			$suffix
 		);
 	}

--- a/includes/api/ApiFormatPhp.php
+++ b/includes/api/ApiFormatPhp.php
@@ -39,7 +39,24 @@ class ApiFormatPhp extends ApiFormatBase {
 	}
 
 	public function execute() {
-		$this->printText( serialize( $this->getResultData() ) );
+		global $wgMangleFlashPolicy;
+		$text = serialize( $this->getResultData() );
+
+		// Bug 66776: wfMangleFlashPolicy() is needed to avoid a nasty bug in
+		// Flash, but what it does isn't friendly for the API. There's nothing
+		// we can do here that isn't actively broken in some manner, so let's
+		// just be broken in a useful manner.
+		if ( $wgMangleFlashPolicy &&
+			in_array( 'wfOutputHandler', ob_list_handlers(), true ) &&
+			preg_match( '/\<\s*cross-domain-policy\s*\>/i', $text )
+		) {
+			$this->dieUsage(
+				'This response cannot be represented using format=php. See https://bugzilla.wikimedia.org/show_bug.cgi?id=66776',
+				'internalerror'
+			);
+		}
+
+		$this->printText( $text );
 	}
 
 	public function getDescription() {


### PR DESCRIPTION
Applying MW 1.19.22 security release patches without the release notes,
non-critical bug fixes and version number increase. The non-critical bug
fixes, version number and release notes will be updated later when also
applying the MW 1.19.21 maintenance release that just has a few bug fixes
(CE-1160).

/cc @owend 
