### PR TITLE
CON-2197 add notifications to Venus

### DIFF
--- a/extensions/wikia/Venus/Venus.setup.php
+++ b/extensions/wikia/Venus/Venus.setup.php
@@ -63,6 +63,7 @@ JSMessages::registerPackage('VenusArticle', [ 'venus-article-*' ]);
  */
 $wgHooks['ParserSectionCreate'][] = 'VenusHooks::onParserSectionCreate';
 $wgHooks['MakeHeadline'       ][] = 'VenusHooks::onMakeHeadline';
+$wgHooks['UserLogoutComplete' ][] = 'NotificationsController::addLogOutConfirmation';
 
 
 //404 Pages

--- a/extensions/wikia/Venus/VenusController.class.php
+++ b/extensions/wikia/Venus/VenusController.class.php
@@ -71,6 +71,7 @@ class VenusController extends WikiaController {
 		$this->localNavigation = $this->getLocalNavigation();
 		$this->globalFooter = $this->getGlobalFooter();
 		$this->corporateFooter = $this->getCorporateFooter();
+		$this->notifications = $this->app->renderView('Notifications', 'Confirmation');
 
 		if ($this->isUserLoggedIn) {
 			$this->recentWikiActivity = $this->getRecentWikiActivity();

--- a/extensions/wikia/Venus/styles/Venus.scss
+++ b/extensions/wikia/Venus/styles/Venus.scss
@@ -27,5 +27,9 @@
 @import 'grid';
 @import 'visibility';
 
+// import notifications styles
+@import 'skins/shared/styles/GlobalNotifications';
+@import 'extensions/wikia/Venus/styles/modules/GlobalNotifiacationsVenus';
+
 // hide 'Retrived from...' print footer
 .printfooter { display: none; }

--- a/extensions/wikia/Venus/styles/modules/GlobalNotifiacationsVenus.scss
+++ b/extensions/wikia/Venus/styles/modules/GlobalNotifiacationsVenus.scss
@@ -1,0 +1,14 @@
+.skin-venus .global-notification .wikia-chiclet-button {
+	background-image: none;
+	border: 0 none;
+	border-radius: 0;
+	display: inline-block;
+	line-height: 1px;
+	opacity: 0.3;
+	padding: 0;
+	position: relative;
+
+	&:hover {
+		opacity: 1;
+	}
+}

--- a/extensions/wikia/Venus/templates/VenusController_index.mustache
+++ b/extensions/wikia/Venus/templates/VenusController_index.mustache
@@ -14,6 +14,7 @@
 	<div id="ad-skin" class="wikia-ad noprint"></div>
 	{{{globalNavigation}}}
 	<div class="wikia-page-wrapper">
+		{{{notifications}}}
 		<div class="top-ads" id="WikiaTopAds">
 			<div class="ad">
 				{{{adTopLeaderboard}}}

--- a/skins/oasis/css/core/GlobalNotificationOasis.scss
+++ b/skins/oasis/css/core/GlobalNotificationOasis.scss
@@ -1,0 +1,68 @@
+@import 'layout';
+@import 'skins/shared/mixins/box-sizing-border-box';
+@import 'skins/shared/mixins/calc';
+@import 'skins/shared/styles/GlobalNotifications';
+
+/* temp transition code until grid is fully rolled out, remove and integrate after transition */
+.wikia-grid {
+	.global-notification {
+		width: 988px;
+
+		&.float {
+			margin-left: -505px;
+
+			// DAR-2719: Hidden global notification when window shrank
+			@media screen and (max-width: 1020px) {
+				@include calc(width, '100% - 20px');
+				left: 0;
+				margin: 0;
+			}
+		}
+	}
+}
+
+/* end temp transistion code */
+
+.modalWrapper > .global-notification {
+	@include box-shadow(0, 0, 0, #000);
+	margin: auto;
+	width: auto;
+
+	.close {
+		display: none;
+	}
+
+	&.float {
+		left: 0;
+		margin: 0;
+		padding: 0;
+		position: absolute;
+		width: 100%;
+	}
+
+	.msg {
+		padding: 8px 10px;
+	}
+}
+
+.modal > .global-notification {
+	width: 100%;
+
+	.close {
+		display: none;
+	}
+}
+
+// VisualEditor specific notification styling
+.ve-ui-window-body {
+	.global-notification {
+		@include box-sizing-border-box;
+		position: absolute;
+		width: 100%;
+
+		> .close {
+			position: absolute;
+			right: 15px;
+		}
+	}
+}

--- a/skins/oasis/css/oasis.scss
+++ b/skins/oasis/css/oasis.scss
@@ -46,7 +46,7 @@
 @import 'core/successerror';
 @import 'core/SpeechBubble';
 @import 'core/ArticleAfterComments';
-@import 'core/GlobalNotification';
+@import 'core/GlobalNotificationOasis';
 @import 'core/WikiaBar';
 @import 'core/jquery.ui.autocomplete'; // TODO: load on demand
 @import 'core/thumbnails';

--- a/skins/oasis/modules/NotificationsController.class.php
+++ b/skins/oasis/modules/NotificationsController.class.php
@@ -275,7 +275,8 @@ class NotificationsController extends WikiaController {
 		wfProfileIn(__METHOD__);
 		global $wgOut, $wgRequest;
 
-		if ( F::app()->checkSkin( 'oasis' ) ) {
+		if ( F::app()->checkSkin( 'oasis' ) || F::app()->checkSkin( 'venus' )) {
+
 			self::addConfirmation(wfMsg('oasis-confirmation-user-logout'));
 
 			// redirect the page user has been on when he clicked "log out" link

--- a/skins/shared/styles/GlobalNotifications.scss
+++ b/skins/shared/styles/GlobalNotifications.scss
@@ -1,6 +1,5 @@
-@import 'layout';
-@import 'skins/shared/mixins/box-sizing-border-box';
-@import 'skins/shared/mixins/calc';
+@import 'skins/shared/color';
+@import 'skins/shared/mixins/box-shadow';
 
 .global-notification {
 	@include box-shadow(0, 2px, 5px, darken($color-page, 12%));
@@ -95,70 +94,6 @@
 		img {
 			height: 11px;
 			width: 12px;
-		}
-	}
-}
-
-/* temp transition code until grid is fully rolled out, remove and integrate after transition */
-.wikia-grid {
-	.global-notification {
-		width: 988px;
-
-		&.float {
-			margin-left: -505px;
-
-			// DAR-2719: Hidden global notification when window shrank
-			@media screen and (max-width: 1020px) {
-				@include calc(width, '100% - 20px');
-				left: 0;
-				margin: 0;
-			}
-		}
-	}
-}
-
-/* end temp transistion code */
-
-.modalWrapper > .global-notification {
-	@include box-shadow(0, 0, 0, #000);
-	margin: auto;
-	width: auto;
-
-	.close {
-		display: none;
-	}
-
-	&.float {
-		left: 0;
-		margin: 0;
-		padding: 0;
-		position: absolute;
-		width: 100%;
-	}
-
-	.msg {
-		padding: 8px 10px;
-	}
-}
-
-.modal > .global-notification {
-	width: 100%;
-
-	.close {
-		display: none;
-	}
-}
-
-// VisualEditor specific notification styling
-.ve-ui-window-body {
-	.global-notification {
-		@include box-sizing-border-box;
-		position: absolute;
-		width: 100%;
-
-		> .close {
-			position: absolute;
-			right: 15px;
 		}
 	}
 }


### PR DESCRIPTION
Add Notifications (after user logout etc.) to Venus.
We added nasty check in NotificationsController to enable oasis logic on venus.

Since right now it is shared functionality we should move it to separate extension.
Ticket for that: https://wikia-inc.atlassian.net/browse/CON-2216
