### PR TITLE
CE-1125 ImageReview fixes continuation

### DIFF
--- a/extensions/wikia/ImageReview/ImageReviewDatabaseHelper.class.php
+++ b/extensions/wikia/ImageReview/ImageReviewDatabaseHelper.class.php
@@ -69,6 +69,7 @@ class ImageReviewDatabaseHelper {
 			ImageReviewStatuses::STATE_INVALID_IMAGE,
 		);
 		$aWhere[] = 'state in (' . $oDB->makeList( $aStatesToFetch ) . ')';
+		$aWhere[] = 'top_200=0';
 
 		// select by reviewer, state and total count with rollup and then pick the data we want out
 		$oResults = $oDB->select(
@@ -84,6 +85,27 @@ class ImageReviewDatabaseHelper {
 		}
 
 		return $aCounts;
+	}
+
+	public function updateResetAbandoned( $sFrom, $iStateSet, $iStateWhere ) {
+		$oDB = $this->getDatawareDB();
+
+		$oDB->update(
+			'image_review',
+			[
+				'reviewer_id' => null,
+				'state' => $iStateSet,
+				'review_start' => '0000-00-00 00:00:00',
+				'review_end' => '0000-00-00 00:00:00',
+			],
+			[
+				"review_start < '{$sFrom}'",
+				'state' => $iStateWhere,
+			],
+			__METHOD__
+		);
+
+		$oDB->commit();
 	}
 
 	/**

--- a/extensions/wikia/ImageReview/ImageReviewHelperBase.class.php
+++ b/extensions/wikia/ImageReview/ImageReviewHelperBase.class.php
@@ -21,6 +21,16 @@ abstract class ImageReviewHelperBase extends WikiaModel {
 	 */
 	const IMAGE_REVIEW_THUMBNAIL_SIZE = 250;
 
+	/**
+	 * Used in ImageReviewSpecial_index.php
+	 * @var array
+	 */
+	static $sortOptions = array(
+		'latest first' => 0,
+		'by priority and recency' => 1,
+		'oldest first' => 2,
+	);
+
 	public abstract function updateImageState($images, $action = '');
 
 	public abstract function resetAbandonedWork();
@@ -28,12 +38,6 @@ abstract class ImageReviewHelperBase extends WikiaModel {
 	public abstract function refetchImageListByTimestamp($timestamp);
 
 	public abstract function getImageList($timestamp, $state = ImageReviewStatuses::STATE_UNREVIEWED, $order = self::ORDER_LATEST);
-
-	protected abstract function getWhitelistedWikis();
-
-	protected abstract function getWhitelistedWikisFromWF();
-
-	protected abstract function getTopWikis();
 
 	public abstract function getImageCount();
 

--- a/extensions/wikia/ImageReview/ImageReviewSpecialController.class.php
+++ b/extensions/wikia/ImageReview/ImageReviewSpecialController.class.php
@@ -5,7 +5,6 @@ use \Wikia\Logger\WikiaLogger;
 class ImageReviewSpecialController extends WikiaSpecialPageController {
 	const ACTION_QUESTIONABLE = 'questionable';
 	const ACTION_REJECTED     = 'rejected';
-	const ACTION_INVALID      = 'invalid';
 
 	var $statsHeaders = array( 'user', 'total reviewed', 'approved', 'deleted', 'qustionable', 'distance to avg.' );
 
@@ -45,9 +44,6 @@ class ImageReviewSpecialController extends WikiaSpecialPageController {
 			return false;
 		} elseif ( $action == self::ACTION_QUESTIONABLE && !$this->accessQuestionable ) {
 			$this->specialPage->displayRestrictionError( 'questionableimagereview' );
-			return false;
-		} elseif ( $action == self::ACTION_INVALID && !$this->accessQuestionable ) {
-			$this->specialPage->displayRestrictionError();
 			return false;
 		} elseif ( $action == self::ACTION_REJECTED && !$this->accessRejected ) {
 			$this->specialPage->displayRestrictionError( 'rejectedimagereview' );
@@ -119,7 +115,6 @@ class ImageReviewSpecialController extends WikiaSpecialPageController {
 			$do = array( 
 				self::ACTION_QUESTIONABLE	=> ImageReviewStatuses::STATE_QUESTIONABLE,
 				self::ACTION_REJECTED		=> ImageReviewStatuses::STATE_REJECTED,
-				self::ACTION_INVALID		=> ImageReviewStatuses::STATE_INVALID_IMAGE,
 				'default'					=> ImageReviewStatuses::STATE_UNREVIEWED
 			);
 

--- a/extensions/wikia/ImageReview/ImageReviewSpecialController.class.php
+++ b/extensions/wikia/ImageReview/ImageReviewSpecialController.class.php
@@ -4,8 +4,8 @@ use \Wikia\Logger\WikiaLogger;
 
 class ImageReviewSpecialController extends WikiaSpecialPageController {
 	const ACTION_QUESTIONABLE = 'questionable';
-	const ACTION_REJECTED = 'rejected';
-	const ACTION_INVALID = 'invalid';
+	const ACTION_REJECTED     = 'rejected';
+	const ACTION_INVALID      = 'invalid';
 
 	var $statsHeaders = array( 'user', 'total reviewed', 'approved', 'deleted', 'qustionable', 'distance to avg.' );
 
@@ -115,17 +115,22 @@ class ImageReviewSpecialController extends WikiaSpecialPageController {
 			$this->imageList = $helper->refetchImageListByTimestamp( $ts );
 		}
 
-		if ( count($this->imageList) == 0 ) {
+		if ( count( $this->imageList ) == 0 ) {
 			$do = array( 
 				self::ACTION_QUESTIONABLE	=> ImageReviewStatuses::STATE_QUESTIONABLE,
 				self::ACTION_REJECTED		=> ImageReviewStatuses::STATE_REJECTED,
 				self::ACTION_INVALID		=> ImageReviewStatuses::STATE_INVALID_IMAGE,
-				'default'			=> ImageReviewStatuses::STATE_UNREVIEWED
+				'default'					=> ImageReviewStatuses::STATE_UNREVIEWED
 			);
-			$this->imageList = $helper->getImageList( $ts, isset( $do[ $action ] ) ? $do[ $action ] : $do['default'], $order );
-		}
 
-		if ( $this->accessQuestionable ) {
+			if ( isset( $do[ $action ] ) ) {
+				$this->imageList = $helper->getImageList( $ts, $do[ $action ], $order );
+				$this->imageCount = $helper->getImageCount();
+			} else {
+				$this->imageList = $helper->getImageList( $ts, $do[ 'default' ], $order );
+				$this->imageCount = $helper->getImageCount( 'unreviewed', count( $this->imageList ) );
+			}
+		} else {
 			$this->imageCount = $helper->getImageCount();
 		}
 	}

--- a/extensions/wikia/ImageReview/maintenance/ImageReviewResetAbandonedWork.php
+++ b/extensions/wikia/ImageReview/maintenance/ImageReviewResetAbandonedWork.php
@@ -1,6 +1,16 @@
 <?php
 
-require(  dirname(__FILE__ ) . '/../../../../maintenance/commandLine.inc'  );
+require_once( dirname(__FILE__ ) . '/../../../../maintenance/Maintenance.php' );
 
-$irh = new ImageReviewHelper();
-$irh->resetAbandonedWork();
+class ImageReviewResetAbandonedWork extends Maintenance {
+
+	public function execute() {
+		$oHelper = new ImageReviewHelper();
+		$sFrom = $oHelper->resetAbandonedWork();
+
+		$this->output( "\nReviews older than {$sFrom} reset.\n" );
+	}
+}
+
+$maintClass = "ImageReviewResetAbandonedWork";
+require_once( RUN_MAINTENANCE_IF_MAIN );

--- a/extensions/wikia/ImageReview/templates/ImageReviewSpecial_index.php
+++ b/extensions/wikia/ImageReview/templates/ImageReviewSpecial_index.php
@@ -5,9 +5,6 @@
 			<a href="<?= $baseUrl ?>"><em><?= $imageCount['unreviewed'] ?></em> <span>unreviewed<br>images</span></a>
 		</div>
 		<div class="tally">
-			<a href="<?= $baseUrl ?>/invalid"><em><?= $imageCount['invalid']?></em> <span>invalid<br>images</span></a>
-		</div>
-		<div class="tally">
 			<a href="<?= $baseUrl ?>/questionable"><em><?= $imageCount['questionable']?></em> <span>questionable<br>images</span></a>
 		</div>
 <?php } ?>

--- a/extensions/wikia/Scribe/ScribeEventProducer.class.php
+++ b/extensions/wikia/Scribe/ScribeEventProducer.class.php
@@ -323,6 +323,13 @@ class ScribeEventProducer {
 	}
 
 	public function setIsLocalFile ( File $oLocalFile ) {
+		WikiaLogger::instance()->info( 'ImageReviewLog', [
+			'method' => __METHOD__,
+			'status' => $this->mParams['isImageForReview'],
+			'message' => $sLogMessage,
+			'params' => $this->mParams,
+			'file' => $oLocalFile,
+		] );
 		if( $oLocalFile instanceof File && $oLocalFile->exists() ) {
 			$bIsLocalFile = true;
 		} else {

--- a/extensions/wikia/Scribe/ScribeEventProducer.class.php
+++ b/extensions/wikia/Scribe/ScribeEventProducer.class.php
@@ -51,7 +51,7 @@ class ScribeEventProducer {
 		$this->setCategory();
 	}
 
-	public function buildEditPackage( $oPage, $oUser, $oRevision = null, $revision_id = null ) {
+	public function buildEditPackage( $oPage, $oUser, $oRevision = null, $revision_id = null, $oLocalFile = null ) {
 		wfProfileIn( __METHOD__ );
 
 		if ( !is_object( $oPage ) ) {
@@ -111,13 +111,13 @@ class ScribeEventProducer {
 		$this->setMediaLinks( $oPage );
 		$this->setTotalWords( str_word_count( $rev_text ) );
 
-		if ( in_array( $this->mParams['pageNamespace'], $this->mediaNS ) ) {
+		if ( $oLocalFile instanceof File ) {
 			$this->setMediaType( $oTitle );
-			$this->setIsLocalFile( $oTitle );
+			$this->setIsLocalFile( $oLocalFile );
 			$this->setIsTop200( $this->app->wg->CityId );
 			$this->setIsImageForReview();
-
-			WikiaLogger::instance()->info( 'ImageReviewParams', [ 'method' => __METHOD__, 'data' => $this->mParams ] );
+		} else {
+			$this->setIsImageForReview( false );
 		}
 
 		$t = microtime(true);
@@ -322,14 +322,7 @@ class ScribeEventProducer {
 		$this->mParams['eventTS'] = $ts;
 	}
 
-	public function setIsLocalFile ( Title $oTitle ) {
-		// $oFile = wfFindFile( $oTitle );
-		$oLocalFile = RepoGroup::singleton()->getLocalRepo()->newFile( $oTitle );
-		wfDebug( "\n ImageReviewFixes " . json_encode($oLocalFile) . "\n" );
-		\Wikia\Logger\WikiaLogger::instance()->info( "ImageReviewFixes", [
-			'method' => __METHOD__,
-			'file' => $oLocalFile,
-		] );
+	public function setIsLocalFile ( File $oLocalFile ) {
 		if( $oLocalFile instanceof File && $oLocalFile->exists() ) {
 			$bIsLocalFile = true;
 		} else {
@@ -443,31 +436,35 @@ class ScribeEventProducer {
 		return false;
 	}
 
-	public function setIsImageForReview() {
-		$aAllowedTypes = [
-			1 => MEDIATYPE_BITMAP,
-			2 => MEDIATYPE_DRAWING,
-		];
+	public function setIsImageForReview( $bProvidedValue = null ) {
+		if ( $bProvidedValue === null ) {
+			$aAllowedTypes = [
+				1 => MEDIATYPE_BITMAP,
+				2 => MEDIATYPE_DRAWING,
+			];
 
-		if ( in_array( $this->mParams['pageNamespace'], $this->mediaNS )
-			&& isset( $aAllowedTypes[ $this->mParams['mediaType'] ] )
-		) {
-			if ( $this->mParams['isRedirect'] == 1 ) {
-				$sLogMessage = 'The page is a redirect';
-				$bIsImageForReview = false;
-			} elseif ( $this->mParams['isLocalFile'] == 0 ) {
-				$sLogMessage = 'The file is from an external repo';
-				$bIsImageForReview = false;
-			} elseif ( $this->mParams['isTop200'] == 1 ) {
-				$sLogMessage = 'The was uploaded to one of the Top200 wikias';
-				$bIsImageForReview = false;
-			} else {
-				$sLogMessage = 'The image was sent for a review';
-				$bIsImageForReview = true;
+			if ( in_array( $this->mParams['pageNamespace'], $this->mediaNS )
+				&& isset( $aAllowedTypes[ $this->mParams['mediaType'] ] )
+			) {
+				if ( $this->mParams['isRedirect'] == 1 ) {
+					$sLogMessage = 'The page is a redirect';
+					$bIsImageForReview = false;
+				} elseif ( $this->mParams['isLocalFile'] == 0 ) {
+					$sLogMessage = 'The file is from an external repo';
+					$bIsImageForReview = false;
+				} elseif ( $this->mParams['isTop200'] == 1 ) {
+					$sLogMessage = 'The image was uploaded to one of the Top200 wikias';
+					$bIsImageForReview = false;
+				} else {
+					$sLogMessage = 'The image was sent for a review';
+					$bIsImageForReview = true;
+				}
+
+				$this->sendImageReviewLog( $sLogMessage );
+				$this->mParams['isImageForReview'] = intval( $bIsImageForReview );
 			}
-
-			$this->sendImageReviewLog( $sLogMessage );
-			$this->mParams['isImageForReview'] = intval( $bIsImageForReview );
+		} else {
+			$this->mParams['isImageForReview'] = intval( $bProvidedValue );
 		}
 	}
 
@@ -479,7 +476,7 @@ class ScribeEventProducer {
 	private function sendImageReviewLog( $sLogMessage ) {
 		WikiaLogger::instance()->info( 'ImageReviewLog', [
 			'method' => __METHOD__,
-			'status' => $bIsImageForReview,
+			'status' => $this->mParams['isImageForReview'],
 			'message' => $sLogMessage,
 			'params' => $this->mParams,
 		] );

--- a/extensions/wikia/Scribe/ScribeEventProducer.class.php
+++ b/extensions/wikia/Scribe/ScribeEventProducer.class.php
@@ -460,8 +460,8 @@ class ScribeEventProducer {
 					$bIsImageForReview = true;
 				}
 
-				$this->sendImageReviewLog( $sLogMessage );
 				$this->mParams['isImageForReview'] = intval( $bIsImageForReview );
+				$this->sendImageReviewLog( $sLogMessage );
 			}
 		} else {
 			$this->mParams['isImageForReview'] = intval( $bProvidedValue );

--- a/extensions/wikia/Scribe/ScribeEventProducer.class.php
+++ b/extensions/wikia/Scribe/ScribeEventProducer.class.php
@@ -323,13 +323,6 @@ class ScribeEventProducer {
 	}
 
 	public function setIsLocalFile ( File $oLocalFile ) {
-		WikiaLogger::instance()->info( 'ImageReviewLog', [
-			'method' => __METHOD__,
-			'status' => $this->mParams['isImageForReview'],
-			'message' => $sLogMessage,
-			'params' => $this->mParams,
-			'file' => $oLocalFile,
-		] );
 		if( $oLocalFile instanceof File && $oLocalFile->exists() ) {
 			$bIsLocalFile = true;
 		} else {

--- a/extensions/wikia/Scribe/ScribeEventProducer.class.php
+++ b/extensions/wikia/Scribe/ScribeEventProducer.class.php
@@ -323,8 +323,10 @@ class ScribeEventProducer {
 	}
 
 	public function setIsLocalFile ( Title $oTitle ) {
-		$oFile = wfFindFile( $oTitle );
-		if( $oFile instanceof File && $oFile->exists() ) {
+		// $oFile = wfFindFile( $oTitle );
+		$oLocalFile = RepoGroup::singleton()->getLocalRepo()->newFile( $oTitle );
+		wfDebug( "\n ImageReviewFixes " . json_encode($oLocalFile) . "\n" );
+		if( $oLocalFile instanceof File && $oLocalFile->exists() ) {
 			$bIsLocalFile = true;
 		} else {
 			$bIsLocalFile = false;

--- a/extensions/wikia/Scribe/ScribeEventProducer.class.php
+++ b/extensions/wikia/Scribe/ScribeEventProducer.class.php
@@ -326,6 +326,10 @@ class ScribeEventProducer {
 		// $oFile = wfFindFile( $oTitle );
 		$oLocalFile = RepoGroup::singleton()->getLocalRepo()->newFile( $oTitle );
 		wfDebug( "\n ImageReviewFixes " . json_encode($oLocalFile) . "\n" );
+		\Wikia\Logger\WikiaLogger::instance()->info( "ImageReviewFixes", [
+			'method' => __METHOD__,
+			'file' => $oLocalFile,
+		] );
 		if( $oLocalFile instanceof File && $oLocalFile->exists() ) {
 			$bIsLocalFile = true;
 		} else {

--- a/extensions/wikia/Scribe/ScribeEventProducer.setup.php
+++ b/extensions/wikia/Scribe/ScribeEventProducer.setup.php
@@ -11,4 +11,4 @@ $wgHooks['NewRevisionFromEditComplete'][] = 'ScribeEventProducerController::onSa
 $wgHooks['ArticleDeleteComplete'][] = 'ScribeEventProducerController::onDeleteComplete';
 $wgHooks['ArticleUndelete'][] = 'ScribeEventProducerController::onArticleUndelete';
 $wgHooks['TitleMoveComplete'][] = 'ScribeEventProducerController::onMoveComplete'; 
-
+$wgHooks['UploadComplete'][] = 'ScribeEventProducerController::onUploadComplete';

--- a/extensions/wikia/Scribe/ScribeEventProducerController.class.php
+++ b/extensions/wikia/Scribe/ScribeEventProducerController.class.php
@@ -39,12 +39,11 @@ class ScribeEventProducerController {
 
  		$oScribeProducer = new ScribeEventProducer( $key, $is_archive );
 		if ( is_object( $oScribeProducer ) ) {
-			$oTitle = $oPage->getTitle();
-
 			/**
 			 * Ugly fix! TODO
 			 * See the description above.
 			 */
+			$oTitle = $oPage->getTitle();
 			if ( $oTitle->getNamespace() == NS_FILE ) {
 				self::$oPage = $oPage;
 				self::$oUser = $oUser;
@@ -67,6 +66,17 @@ class ScribeEventProducerController {
 		if ( $allow ) {
 			$oScribeProducer = new ScribeEventProducer( 'edit' );
 			if ( is_object( $oScribeProducer ) ) {
+				/**
+				 * Ugly fix! TODO
+				 * See the description above.
+				 */
+				$oTitle = $oPage->getTitle();
+				if ( $oTitle->getNamespace() == NS_FILE ) {
+					self::$oPage = $oPage;
+					self::$oUser = $oUser;
+					self::$oRevision = $oRevision;
+				}
+
 				if ( $oScribeProducer->buildEditPackage( $oPage, $oUser, $oRevision, $revision_id ) ) {
 					$oScribeProducer->sendLog();
 				}

--- a/extensions/wikia/Scribe/ScribeEventProducerController.class.php
+++ b/extensions/wikia/Scribe/ScribeEventProducerController.class.php
@@ -14,6 +14,8 @@ class ScribeEventProducerController {
 			}
 		}
 
+		wfDebug( "\n ImageReviewFixes " . __METHOD__ . "\n" );
+
 		wfProfileOut( __METHOD__ );
 		return true;
 	}
@@ -31,6 +33,8 @@ class ScribeEventProducerController {
 			}
 		}
 
+		wfDebug( "\n ImageReviewFixes " . __METHOD__ . "\n" );
+
 		wfProfileOut( __METHOD__ );
 		return true;
 	}
@@ -45,6 +49,8 @@ class ScribeEventProducerController {
 				$oScribeProducer->sendLog();
 			}
 		}
+
+		wfDebug( "\n ImageReviewFixes " . __METHOD__ . "\n" );
 
 		wfProfileOut( __METHOD__ );
 		return true;
@@ -70,6 +76,8 @@ class ScribeEventProducerController {
 			}
 		}
 
+		wfDebug( "\n ImageReviewFixes " . __METHOD__ . "\n" );
+
 		wfProfileOut( __METHOD__ );
 		return true;
 	}
@@ -83,6 +91,8 @@ class ScribeEventProducerController {
 				$oScribeProducer->sendLog();
 			}
 		}
+
+		wfDebug( "\n ImageReviewFixes " . __METHOD__ . "\n" );
 
 		wfProfileOut( __METHOD__ );
 		return true;
@@ -106,6 +116,8 @@ class ScribeEventProducerController {
 				}
 			}
 		}
+
+		wfDebug( "\n ImageReviewFixes " . __METHOD__ . "\n" );
 
 		wfProfileOut( __METHOD__ );
 		return true;
@@ -134,6 +146,8 @@ class ScribeEventProducerController {
 				$oScribeProducer->sendLog();
 			}
 		}
+
+		wfDebug( "\n ImageReviewFixes " . __METHOD__ . "\n" );
 
 		wfProfileOut( __METHOD__ );
 		return true;


### PR DESCRIPTION
This commit includes:
- Improved isLocalFile check
- Task clearing the queue from rows that it can't create a GlobalTitle object for
- Removal of Invalid queue
- Logging of every action (see [Kibana dashboard](https://kibana.wikia-inc.com/#/dashboard/elasticsearch/ImageReview%20Logs))
- More refactoring
- More documentation

Pinging @macbre @Grunny 
