### PR TITLE
CE-1125 Merge ImageReview fixes from #release-252-image-review

### DIFF
--- a/extensions/wikia/ImageReview/ImageReview.hooks.php
+++ b/extensions/wikia/ImageReview/ImageReview.hooks.php
@@ -1,0 +1,51 @@
+<?php
+
+class ImageReviewHooks {
+
+	public static function setupHooks() {
+		$oImageReviewHooks = new self();
+		\Hooks::register( 'WikiFactoryPublicStatusChange', [ $oImageReviewHooks, 'onWikiFactoryPublicStatusChange' ] );
+	}
+
+	public function onWikiFactoryPublicStatusChange( $city_public, $city_id, $reason ) {
+		if ( $city_public == 0 || $city_public == -1 ) {
+			// the wiki was disabled, mark all unreviewed images as deleted
+
+			$newState = ImageReviewStatuses::STATE_WIKI_DISABLED;
+			$statesToUpdate = [
+				ImageReviewStatuses::STATE_UNREVIEWED,
+				ImageReviewStatuses::STATE_REJECTED,
+				ImageReviewStatuses::STATE_QUESTIONABLE,
+				ImageReviewStatuses::STATE_QUESTIONABLE_IN_REVIEW,
+				ImageReviewStatuses::STATE_REJECTED_IN_REVIEW,
+				ImageReviewStatuses::STATE_IN_REVIEW,
+			];
+		} elseif ( $city_public == 1 ) {
+			// the wiki was re-enabled, put all images back into the queue as unreviewed
+
+			$newState = ImageReviewStatuses::STATE_UNREVIEWED;
+			$statesToUpdate = [ ImageReviewStatuses::STATE_WIKI_DISABLED ];
+		} else {
+			// the state change doesn't affect images, we don't need to do anything here
+			return true;
+		}
+
+		/**
+		 * Update batch of images
+		 */
+		$aValues = [ 'state' => $newState ];
+		$aWhere = [
+			'wiki_id' => $city_id,
+			'state' => $statesToUpdate,
+		];
+
+		$oDB = $this->getDatabaseHelper();
+		$oDB->updateBatchImages( $aValues, $aWhere );
+
+		return true;
+	}
+
+	private function getDatabaseHelper() {
+		return new ImageReviewDatabaseHelper();
+	}
+}

--- a/extensions/wikia/ImageReview/ImageReview.setup.php
+++ b/extensions/wikia/ImageReview/ImageReview.setup.php
@@ -31,11 +31,13 @@ $wgAutoloadClasses['Wikia\\Tasks\\Tasks\\ImageReviewTask'] = "{$dir}ImageReviewT
 $wgAutoloadClasses['ImageReviewSpecialController'] =  $dir . 'ImageReviewSpecialController.class.php';
 $wgAutoloadClasses['ImageReviewHelperBase'] =  $dir . 'ImageReviewHelperBase.class.php';
 $wgAutoloadClasses['ImageReviewHelper'] =  $dir . 'ImageReviewHelper.class.php';
+$wgAutoloadClasses['ImageReviewDatabaseHelper'] =  $dir . 'ImageReviewDatabaseHelper.class.php';
+$wgAutoloadClasses['ImageReviewHooks'] =  $dir . 'ImageReview.hooks.php';
 
 $wgSpecialPages['ImageReview'] = 'ImageReviewSpecialController';
 
-// hooks
-$wgHooks['WikiFactoryPublicStatusChange'][] = 'ImageReviewHelper::onWikiFactoryPublicStatusChange' ;
+// hooks setup
+$wgExtensionFunctions[] = 'ImageReviewHooks::setupHooks';
 
 // rights
 $wgAvailableRights[] = 'imagereview';

--- a/extensions/wikia/ImageReview/ImageReviewDatabaseHelper.class.php
+++ b/extensions/wikia/ImageReview/ImageReviewDatabaseHelper.class.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * It is a class that will hold all of ImageReview queries
+ * for ease of finding and managing them.
+ *
+ * @package ImageReview
+ * @author  Adam Karmiński <adamk@wikia-inc.com>
+ */
+
+class ImageReviewDatabaseHelper {
+
+	/**
+	 * Query selecting images populating a list
+	 * @param  integer       $iState  A state to select
+	 * @param  string        $sOrder  Sorting order
+	 * @param  integer       $iLimit  SQL limit of queried images
+	 * @return ResultWrapper          Query's results
+	 */
+	public function selectImagesForList( $sOrder, $iLimit, $iState = ImageReviewStatuses::STATE_UNREVIEWED ) {
+		$oDB = $this->getDatawareDB( DB_SLAVE );
+
+		$oResults = $oDB->query('
+			SELECT pages.page_title_lower, image_review.wiki_id, image_review.page_id, image_review.state, image_review.flags, image_review.priority, image_review.last_edited
+			FROM (
+				SELECT image_review.wiki_id, image_review.page_id, image_review.state, image_review.flags, image_review.priority, image_review.last_edited
+				FROM `image_review`
+				WHERE state = ' . $iState . ' AND top_200 = false
+				ORDER BY ' . $sOrder . '
+				LIMIT ' . $iLimit . '
+			) as image_review
+			LEFT JOIN pages ON (image_review.wiki_id=pages.page_wikia_id) AND (image_review.page_id=pages.page_id) AND (pages.page_is_redirect=0)'
+		);
+
+		return $oResults;
+	}
+
+	/**
+	 * Query updating a state of a batch of images
+	 * @param  Array         $aValues  Values to set
+	 * @param  Array         $aWhere   SQL WHERE conditions
+	 * @return void
+	 */
+	public function updateBatchImages( Array $aValues, Array $aWhere ) {
+		$oDB = $this->getDatawareDB();
+
+		$oDB->update(
+			'image_review',
+			$aValues,
+			$aWhere,
+			__METHOD__
+		);
+
+		$oDB->commit();
+	}
+
+	/**
+	 * @param  int (const) $iDB  Database machine master/slave
+	 * @return DatabaseMysql     Dataware database object
+	 */
+	private function getDatawareDB( $iDB = DB_MASTER ) {
+		global $wgExternalDatawareDB;
+		return wfGetDB( $iDB, [], $wgExternalDatawareDB );
+	}
+}

--- a/extensions/wikia/ImageReview/ImageReviewDatabaseHelper.class.php
+++ b/extensions/wikia/ImageReview/ImageReviewDatabaseHelper.class.php
@@ -16,7 +16,10 @@ class ImageReviewDatabaseHelper {
 	 * @param  integer       $iLimit  SQL limit of queried images
 	 * @return ResultWrapper          Query's results
 	 */
-	public function selectImagesForList( $sOrder, $iLimit, $iState = ImageReviewStatuses::STATE_UNREVIEWED ) {
+	public function selectImagesForList( $sOrder,
+		$iLimit = ImageReviewHelper::LIMIT_IMAGES_FROM_DB,
+		$iState = ImageReviewStatuses::STATE_UNREVIEWED
+	) {
 		$oDB = $this->getDatawareDB( DB_SLAVE );
 
 		$oResults = $oDB->query('
@@ -24,11 +27,11 @@ class ImageReviewDatabaseHelper {
 			FROM (
 				SELECT image_review.wiki_id, image_review.page_id, image_review.state, image_review.flags, image_review.priority, image_review.last_edited
 				FROM `image_review`
-				WHERE state = ' . $iState . ' AND top_200 = false
+				WHERE state = ' . $iState . ' AND top_200 = 0
 				ORDER BY ' . $sOrder . '
 				LIMIT ' . $iLimit . '
 			) as image_review
-			LEFT JOIN pages ON (image_review.wiki_id=pages.page_wikia_id) AND (image_review.page_id=pages.page_id) AND (pages.page_is_redirect=0)'
+			LEFT JOIN pages ON (image_review.wiki_id=pages.page_wikia_id) AND (image_review.page_id=pages.page_id)'
 		);
 
 		return $oResults;

--- a/extensions/wikia/ImageReview/ImageReviewDatabaseHelper.class.php
+++ b/extensions/wikia/ImageReview/ImageReviewDatabaseHelper.class.php
@@ -56,12 +56,64 @@ class ImageReviewDatabaseHelper {
 		$oDB->commit();
 	}
 
+	public function countImagesByState() {
+		$aCounts = [];
+
+		$oDB = $this->getDatawareDB( DB_SLAVE );
+
+		$aWhere = [];
+		$aStatesToFetch = array(
+			ImageReviewStatuses::STATE_QUESTIONABLE,
+			ImageReviewStatuses::STATE_REJECTED,
+			ImageReviewStatuses::STATE_UNREVIEWED,
+			ImageReviewStatuses::STATE_INVALID_IMAGE,
+		);
+		$aWhere[] = 'state in (' . $oDB->makeList( $aStatesToFetch ) . ')';
+		$aWhere[] = 'top_200=0';
+
+		// select by reviewer, state and total count with rollup and then pick the data we want out
+		$oResults = $oDB->select(
+			array( 'image_review' ),
+			array( 'state', 'count(*) as total' ),
+			$aWhere,
+			__METHOD__,
+			array( 'GROUP BY' => 'state' )
+		);
+
+		while( $oRow = $oDB->fetchObject( $oResults ) ) {
+			$aCounts[ $oRow->state ] = $oRow->total;
+		}
+
+		return $aCounts;
+	}
+
+	public function updateResetAbandoned( $sFrom, $iStateSet, $iStateWhere ) {
+		$oDB = $this->getDatawareDB();
+
+		$oDB->update(
+			'image_review',
+			[
+				'reviewer_id' => null,
+				'state' => $iStateSet,
+				'review_start' => '0000-00-00 00:00:00',
+				'review_end' => '0000-00-00 00:00:00',
+			],
+			[
+				"review_start < '{$sFrom}'",
+				'state' => $iStateWhere,
+			],
+			__METHOD__
+		);
+
+		$oDB->commit();
+	}
+
 	/**
-	 * @param  int (const) $iDB  Database machine master/slave
+	 * @param  mixed $mDatabase  Database machine master/slave
 	 * @return DatabaseMysql     Dataware database object
 	 */
-	private function getDatawareDB( $iDB = DB_MASTER ) {
+	private function getDatawareDB( $mDatabase = DB_MASTER ) {
 		global $wgExternalDatawareDB;
-		return wfGetDB( $iDB, [], $wgExternalDatawareDB );
+		return wfGetDB( $mDatabase, [], $wgExternalDatawareDB );
 	}
 }

--- a/extensions/wikia/ImageReview/ImageReviewHelper.class.php
+++ b/extensions/wikia/ImageReview/ImageReviewHelper.class.php
@@ -11,16 +11,6 @@ class ImageReviewHelper extends ImageReviewHelperBase {
 
 	private $user_id = 0;
 
-	/**
-	 * Used in ImageReviewSpecial_index.php
-	 * @var array
-	 */
-	static $sortOptions = array(
-		'latest first' => 0,
-		'by priority and recency' => 1,
-		'oldest first' => 2,
-	);
-
 	function __construct() {
 		parent::__construct();
 		$this->user_id = $this->wg->user->getId();
@@ -110,6 +100,8 @@ class ImageReviewHelper extends ImageReviewHelperBase {
 				$this->wg->memc->delete( $key );
 		}
 
+		$this->createDeleteImagesTask( $deletionList );
+
 		wfProfileOut( __METHOD__ );
 	}
 
@@ -128,66 +120,16 @@ class ImageReviewHelper extends ImageReviewHelperBase {
 	}
 
 	/**
-	 * reset state in abandoned work
-	 * note: this is run via a cron script
+	 * Creates a task removing listed images from image_review queue
+	 * @param  array  $aDeletionList  An array of [ city_id, page_id ] arrays.
+	 * @return void
 	 */
-	public function resetAbandonedWork() {
-		wfProfileIn( __METHOD__ );
-
-		$db = $this->getDatawareDB( DB_MASTER );
-
-		$timeLimit = ( $this->wg->DevelEnvironment ) ? 1 : 3600; // 1 sec
-		$review_start = wfTimestamp(TS_DB, time() - $timeLimit );
-
-		// for STATE_UNREVIEWED
-		$db->update(
-			'image_review',
-			array(
-				'reviewer_id' => null,
-				'state' => ImageReviewStatuses::STATE_UNREVIEWED,
-				'review_start' => '0000-00-00 00:00:00',
-				'review_end' => '0000-00-00 00:00:00',
-			),
-			array(
-				"review_start < '{$review_start}'",
-				'state' => ImageReviewStatuses::STATE_IN_REVIEW,
-			),
-			__METHOD__
-		);
-
-		// for STATE_QUESTIONABLE
-		$db->update(
-			'image_review',
-			array(
-				'state' => ImageReviewStatuses::STATE_QUESTIONABLE,
-				'review_start' => '0000-00-00 00:00:00',
-				'review_end' => '0000-00-00 00:00:00',
-			),
-			array(
-				"review_start < '{$review_start}'",
-				'state' => ImageReviewStatuses::STATE_QUESTIONABLE_IN_REVIEW,
-			),
-			__METHOD__
-		);
-
-		// for STATE_REJECTED
-		$db->update(
-			'image_review',
-			array(
-				'state' => ImageReviewStatuses::STATE_REJECTED,
-				'review_start' => '0000-00-00 00:00:00',
-				'review_end' => '0000-00-00 00:00:00',
-			),
-			array(
-				"review_start < '{$review_start}'",
-				'state' => ImageReviewStatuses::STATE_REJECTED_IN_REVIEW,
-			),
-			__METHOD__
-		);
-
-		$db->commit();
-
-		wfProfileOut( __METHOD__ );
+	public function createDeleteFromQueueTask( $aDeletionList ) {
+		if ( !empty( $aDeletionList ) ) {
+			$task = new \Wikia\Tasks\Tasks\ImageReviewTask();
+			$task->call('deleteFromQueue', $aDeletionList);
+			$task->queue();
+		}
 	}
 
 	/**
@@ -242,9 +184,9 @@ class ImageReviewHelper extends ImageReviewHelperBase {
 		}
 		$db->freeResult( $result );
 
-		WikiaLogger::instance()->info( "ImageReview : refetched images based on timestamp", [
+		WikiaLogger::instance()->info( "ImageReviewLog", [
 			'method' => __METHOD__,
-			'count' => count( $imageList ),
+			'message' => "Refetched " . count( $imageList ) . " images based on timestamp",
 		] );
 
 		wfProfileOut( __METHOD__ );
@@ -307,7 +249,7 @@ class ImageReviewHelper extends ImageReviewHelperBase {
 		}
 		$oDB->commit();
 
-		$imageList = $unusedImages = $aDeletionList = [];
+		$imageList = $unusedImages = $aDeleteFromQueueList = [];
 
 		foreach ( $rows as $row ) {
 			$record = "(wiki_id = {$row->wiki_id} and page_id = {$row->page_id})";
@@ -350,21 +292,10 @@ class ImageReviewHelper extends ImageReviewHelperBase {
 						);
 					}
 				} else {
-					/**
-					 * CE-1068
-					 * Log page_id and wiki_id for images for which GlobalTitle::newFromId returns null.
-					 */
-					WikiaLogger::instance()->error( "ImageReview : Null GlobalTitle",
-						[
-							'method' => __METHOD__,
-							'pageId' => $row->page_id,
-							'wikiId' => $row->wiki_id,
-							'lastEdited' => $row->last_edited,
-							'exception' => new Exception()
-						]
-					);
-
-					$aDeletionList[] = [ $row->wiki_id, $row->page_id ];
+					$aDeleteFromQueueList[] = [
+						'wiki_id' => $row->wiki_id,
+						'page_id' => $row->page_id,
+					];
 
 					continue;
 				}
@@ -376,8 +307,8 @@ class ImageReviewHelper extends ImageReviewHelperBase {
 		/**
 		 * Invalid images
 		 */
-		if ( !empty( $aDeletionList ) ) {
-			$this->createDeleteImagesTask( $aDeletionList );
+		if ( !empty( $aDeleteFromQueueList ) ) {
+			$this->createDeleteFromQueueTask( $aDeleteFromQueueList );
 		}
 
 		/**
@@ -406,9 +337,9 @@ class ImageReviewHelper extends ImageReviewHelperBase {
 		/**
 		 * Return valid images list
 		 */
-		WikiaLogger::instance()->info( "ImageReviewImageList: fetched new images", [
+		WikiaLogger::instance()->info( "ImageReviewLog", [
 			'method' => __METHOD__,
-			'count' => count( $imageList ),
+			'message' => 'Fetched ' . count( $imageList ) . ' new images',
 		] );
 
 		wfProfileOut( __METHOD__ );
@@ -423,97 +354,35 @@ class ImageReviewHelper extends ImageReviewHelperBase {
 			$oDatabaseHelper->updateBatchImages( $aValues, $aWhere );
 		}
 
-		WikiaLogger::instance()->info( "ImageReviewImageList: updated {$sType} images.", [
+		WikiaLogger::instance()->info( "ImageReviewLog", [
 			'method' => __METHOD__,
-			'count' => $iCount,
+			'message' => "Updated {$iCount} images (type {$sType})",
 		] );
 	}
 
-	protected function getWhitelistedWikis() {
+	public function getImageCount( $sAction = false, $iImageListCount = false ) {
 		wfProfileIn( __METHOD__ );
 
-		$topWikis = $this->getTopWikis();
+		$key = wfMemcKey( 'ImageReviewSpecialController', 'v2', __METHOD__ );
+		$total = $this->wg->memc->get( $key, null );
 
-		$whitelistedWikis = $this->getWhitelistedWikisFromWF();
-
-		$out = array_keys( $whitelistedWikis + $topWikis );
-
-		wfProfileOut( __METHOD__ );
-
-		return $out;
-	}
-
-	protected function getWhitelistedWikisFromWF() {
-		wfProfileIn( __METHOD__ );
-		$key = wfMemcKey( 'ImageReviewSpecialController', __METHOD__ );
-
-		$data = $this->wg->memc->get($key, null);
-
-		if(!empty($data)) {
-			wfProfileOut( __METHOD__ );
-			return $data;
-		}
-
-		$oVariable = WikiFactory::getVarByName( 'wgImageReviewWhitelisted', 177 );
-		$fromWf = WikiFactory::getListOfWikisWithVar($oVariable->cv_variable_id, 'bool', '=' ,true);
-
-		$this->wg->memc->set($key, $fromWf, 60*10);
-		wfProfileOut( __METHOD__ );
-		return $fromWf;
-	}
-
-	protected function getTopWikis() {
-		wfProfileIn( __METHOD__ );
-		$key = wfMemcKey( 'ImageReviewSpecialController','v2', __METHOD__ );
-		$data = $this->wg->memc->get($key, null);
-		if( !empty($data) ) {
-			wfProfileOut( __METHOD__ );
-			return $data;
-		}
-
-		$ids = DataMartService::getTopWikisByPageviews( DataMartService::PERIOD_ID_MONTHLY, 200 );
-
-		$this->wg->memc->set( $key, $ids, 86400 /* 24h */ );
-		wfProfileOut( __METHOD__ );
-		return $ids;
-	}
-
-	public function getImageCount() {
-		wfProfileIn( __METHOD__ );
-
-		$key = wfMemcKey( 'ImageReviewSpecialController', 'v2', __METHOD__);
-		$total = $this->wg->memc->get($key, null);
-		if ( !empty($total) ) {
+		/**
+		 * Don't use cached results if:
+		 * 1. In Unreviewed queue
+		 * 2. SQL select returns 0 images
+		 * 3. Cached count of unreviewed > 0
+		 */
+		if ( !empty( $total )
+			&& ( $sAction != 'unreviewed'
+			|| $iImageListCount != 0
+			|| $total['unreviewed'] == 0 )
+		) {
 			wfProfileOut( __METHOD__ );
 			return $total;
 		}
 
-		$db = $this->getDatawareDB( DB_SLAVE );
-		$where = array();
-
-		$statesToFetch = array(
-			ImageReviewStatuses::STATE_QUESTIONABLE,
-			ImageReviewStatuses::STATE_REJECTED,
-			ImageReviewStatuses::STATE_UNREVIEWED,
-			ImageReviewStatuses::STATE_INVALID_IMAGE,
-		);
-		$where[] = 'state in (' . $db->makeList( $statesToFetch ) . ')';
-
-		$where[] = 'top_200 = 0';
-
-		$list = $this->getWhitelistedWikis();
-		if ( !empty($list) ) {
-			$where[] = 'wiki_id not in('.implode(',', $list).')';
-		}
-
-		// select by reviewer, state and total count with rollup and then pick the data we want out
-		$result = $db->select(
-			array( 'image_review' ),
-			array( 'state', 'count(*) as total' ),
-			$where,
-			__METHOD__,
-			array( 'GROUP BY' => 'state' )
-		);
+		$oDatabaseHelper = $this->getDatabaseHelper();
+		$aCounts = $oDatabaseHelper->countImagesByState();
 
 		$total = array(
 			'unreviewed' => 0,
@@ -521,21 +390,18 @@ class ImageReviewHelper extends ImageReviewHelperBase {
 			'rejected' => 0,
 			'invalid' => 0,
 		);
-		while( $row = $db->fetchObject($result) ) {
-			$total[$row->state] = $row->total;
-		}
 
-		if ( array_key_exists( ImageReviewStatuses::STATE_UNREVIEWED, $total ) ) {
-			$total['unreviewed'] = $this->wg->Lang->formatNum($total[ImageReviewStatuses::STATE_UNREVIEWED]);
+		if ( array_key_exists( ImageReviewStatuses::STATE_UNREVIEWED, $aCounts ) ) {
+			$total['unreviewed'] = $this->wg->Lang->formatNum( $aCounts[ ImageReviewStatuses::STATE_UNREVIEWED ] );
 		}
-		if ( array_key_exists( ImageReviewStatuses::STATE_QUESTIONABLE, $total ) ) {
-			$total['questionable'] = $this->wg->Lang->formatNum($total[ImageReviewStatuses::STATE_QUESTIONABLE]);
+		if ( array_key_exists( ImageReviewStatuses::STATE_QUESTIONABLE, $aCounts ) ) {
+			$total['questionable'] = $this->wg->Lang->formatNum( $aCounts[ ImageReviewStatuses::STATE_QUESTIONABLE ] );
 		}
-		if ( array_key_exists( ImageReviewStatuses::STATE_REJECTED, $total ) ) {
-			$total['rejected'] = $this->wg->Lang->formatNum( $total[ImageReviewStatuses::STATE_REJECTED]);
+		if ( array_key_exists( ImageReviewStatuses::STATE_REJECTED, $aCounts ) ) {
+			$total['rejected'] = $this->wg->Lang->formatNum( $aCounts[ ImageReviewStatuses::STATE_REJECTED ] );
 		}
-		if ( array_key_exists( ImageReviewStatuses::STATE_INVALID_IMAGE, $total ) ) {
-			$total['invalid'] = $this->wg->Lang->formatNum( $total[ImageReviewStatuses::STATE_INVALID_IMAGE]);
+		if ( array_key_exists( ImageReviewStatuses::STATE_INVALID_IMAGE, $aCounts ) ) {
+			$total['invalid'] = $this->wg->Lang->formatNum( $aCounts[ ImageReviewStatuses::STATE_INVALID_IMAGE ] );
 		}
 		$this->wg->memc->set( $key, $total, 3600 /* 1h */ );
 
@@ -631,6 +497,40 @@ class ImageReviewHelper extends ImageReviewHelperBase {
 
 	public function getUserTsKey() {
 		return wfMemcKey( 'ImageReviewSpecialController', 'userts', $this->wg->user->getId());
+	}
+
+	/**
+	 * reset state in abandoned work
+	 * note: this is run via a cron script
+	 */
+	public function resetAbandonedWork() {
+		wfProfileIn( __METHOD__ );
+
+		$oDatabaseHelper = $this->getDatabaseHelper();
+
+		$timeLimit = ( $this->wg->DevelEnvironment ) ? 1 : 3600; // 1 sec
+		$sFrom = wfTimestamp(TS_DB, time() - $timeLimit );
+
+		// for STATE_UNREVIEWED
+		$oDatabaseHelper->updateResetAbandoned( $sFrom,
+			ImageReviewStatuses::STATE_UNREVIEWED,
+			ImageReviewStatuses::STATE_IN_REVIEW
+		);
+
+		// for STATE_QUESTIONABLE
+		$oDatabaseHelper->updateResetAbandoned( $sFrom,
+			ImageReviewStatuses::STATE_QUESTIONABLE,
+			ImageReviewStatuses::STATE_QUESTIONABLE_IN_REVIEW
+		);
+
+		// for STATE_REJECTED
+		$oDatabaseHelper->updateResetAbandoned( $sFrom,
+			ImageReviewStatuses::STATE_REJECTED,
+			ImageReviewStatuses::STATE_REJECTED_IN_REVIEW
+		);
+
+		wfProfileOut( __METHOD__ );
+		return $sFrom;
 	}
 
 	private function getImageStatesForStats() {

--- a/extensions/wikia/ImageReview/ImageReviewHelper.class.php
+++ b/extensions/wikia/ImageReview/ImageReviewHelper.class.php
@@ -11,6 +11,16 @@ class ImageReviewHelper extends ImageReviewHelperBase {
 
 	private $user_id = 0;
 
+	/**
+	 * Used in ImageReviewSpecial_index.php
+	 * @var array
+	 */
+	static $sortOptions = array(
+		'latest first' => 0,
+		'by priority and recency' => 1,
+		'oldest first' => 2,
+	);
+
 	function __construct() {
 		parent::__construct();
 		$this->user_id = $this->wg->user->getId();
@@ -252,7 +262,7 @@ class ImageReviewHelper extends ImageReviewHelperBase {
 		$oDB = $this->getDatawareDB( DB_MASTER );
 		$oDatabaseHelper = $this->getDatabaseHelper();
 
-		$oResults = $oDatabaseHelper->selectImagesForList( $oDB, $state, $this->getOrder( $order ), self::LIMIT_IMAGES_FROM_DB );
+		$oResults = $oDatabaseHelper->selectImagesForList( $this->getOrder( $order ), self::LIMIT_IMAGES_FROM_DB, $state );
 
 		$rows = array();
 		$updateWhere = array();
@@ -366,26 +376,32 @@ class ImageReviewHelper extends ImageReviewHelperBase {
 		/**
 		 * Invalid images
 		 */
-		$this->createDeleteImagesTask( $aDeletionList );
+		if ( !empty( $aDeletionList ) ) {
+			$this->createDeleteImagesTask( $aDeletionList );
+		}
 
 		/**
 		 * Icons
 		 */
-		$aIconsValues = [
-			'state' => ImageReviewStatuses::STATE_ICO_IMAGE,
-		];
-		$aIconsWhere = [ implode( 'OR', $iconsWhere ) ];
-		$this->imageListAdditionalAction( 'icons', $oDB, $aIconsValues, $aIconsWhere );
+		if ( !empty( $iconsWhere ) ) {
+			$aIconsValues = [
+				'state' => ImageReviewStatuses::STATE_ICO_IMAGE,
+			];
+			$aIconsWhere = [ implode( 'OR', $iconsWhere ) ];
+			$this->imageListAdditionalAction( 'icons', $oDB, $aIconsValues, $aIconsWhere );
+		}
 
 		/**
 		 * Unused images
 		 */
-		$aUnusedValues = [
-			'reviewer_id = null',
-			'state' => $state,
-		];
-		$aUnusedWhere = [ implode( 'OR', $unusedImages ) ];
-		$this->imageListAdditionalAction( 'unused', $oDB, $aUnusedValues, $aUnusedWhere );
+		if ( !empty( $unusedImages ) ) {
+			$aUnusedValues = [
+				'reviewer_id = null',
+				'state' => $state,
+			];
+			$aUnusedWhere = [ implode( 'OR', $unusedImages ) ];
+			$this->imageListAdditionalAction( 'unused', $oDB, $aUnusedValues, $aUnusedWhere );
+		}
 
 		/**
 		 * Return valid images list
@@ -404,7 +420,7 @@ class ImageReviewHelper extends ImageReviewHelperBase {
 		$iCount = count( $aWhere );
 		if ( $iCount > 0 ) {
 			$oDatabaseHelper = $this->getDatabaseHelper();
-			$oDatabaseHelper->updateBatchImages( $oDB, $aValues, $aWhere );
+			$oDatabaseHelper->updateBatchImages( $aValues, $aWhere );
 		}
 
 		WikiaLogger::instance()->info( "ImageReviewImageList: updated {$sType} images.", [

--- a/extensions/wikia/ImageReview/ImageReviewHelper.class.php
+++ b/extensions/wikia/ImageReview/ImageReviewHelper.class.php
@@ -10,23 +10,6 @@ use \Wikia\Logger\WikiaLogger;
 class ImageReviewHelper extends ImageReviewHelperBase {
 
 	private $user_id = 0;
-	const LIMIT_IMAGES = 20;
-	/*
-	 * LIMIT_IMAGES_FROM_DB should be a little greater than LIMIT_IMAGES, so if
-	 * we fetch a few icons from DB, we can skip them
-	 */
-	const LIMIT_IMAGES_FROM_DB = 24;
-
-	/**
-	 * Define a size of a thumbnail
-	 */
-	const IMAGE_REVIEW_THUMBNAIL_SIZE = 250;
-
-	static $sortOptions = array(
-		'latest first' => 0,
-		'by priority and recency' => 1,
-		'oldest first' => 2,
-	);
 
 	function __construct() {
 		parent::__construct();
@@ -117,14 +100,21 @@ class ImageReviewHelper extends ImageReviewHelperBase {
 				$this->wg->memc->delete( $key );
 		}
 
-		if ( !empty( $deletionList ) ) {
+		wfProfileOut( __METHOD__ );
+	}
+
+	/**
+	 * Creates a task removing listed images
+	 * @param  array  $aDeletionList  An array of [ city_id, page_id ] arrays.
+	 * @return void
+	 */
+	public function createDeleteImagesTask( $aDeletionList ) {
+		if ( !empty( $aDeletionList ) ) {
 			$task = new \Wikia\Tasks\Tasks\ImageReviewTask();
-			$task->call('delete', $deletionList);
+			$task->call('delete', $aDeletionList);
 			$task->prioritize();
 			$task->queue();
 		}
-
-		wfProfileOut( __METHOD__ );
 	}
 
 	/**
@@ -242,7 +232,10 @@ class ImageReviewHelper extends ImageReviewHelperBase {
 		}
 		$db->freeResult( $result );
 
-		error_log("ImageReview : refetched " . count($imageList) . " images based on timestamp");
+		WikiaLogger::instance()->info( "ImageReview : refetched images based on timestamp", [
+			'method' => __METHOD__,
+			'count' => count( $imageList ),
+		] );
 
 		wfProfileOut( __METHOD__ );
 
@@ -256,28 +249,19 @@ class ImageReviewHelper extends ImageReviewHelperBase {
 	public function getImageList( $timestamp, $state = ImageReviewStatuses::STATE_UNREVIEWED, $order = self::ORDER_LATEST ) {
 		wfProfileIn( __METHOD__ );
 
-		// get images
-		$db = $this->getDatawareDB( DB_MASTER );
-		$result = $db->query('
-			SELECT pages.page_title_lower, image_review.wiki_id, image_review.page_id, image_review.state, image_review.flags, image_review.priority, image_review.last_edited
-			FROM (
-				SELECT image_review.wiki_id, image_review.page_id, image_review.state, image_review.flags, image_review.priority, image_review.last_edited
-				FROM `image_review`
-				WHERE state = ' . $state . ' AND top_200 = false
-				ORDER BY ' . $this->getOrder($order) . '
-				LIMIT ' . self::LIMIT_IMAGES_FROM_DB . '
-			) as image_review
-			LEFT JOIN pages ON (image_review.wiki_id=pages.page_wikia_id) AND (image_review.page_id=pages.page_id) AND (pages.page_is_redirect=0)'
-		);
+		$oDB = $this->getDatawareDB( DB_MASTER );
+		$oDatabaseHelper = $this->getDatabaseHelper();
+
+		$oResults = $oDatabaseHelper->selectImagesForList( $oDB, $state, $this->getOrder( $order ), self::LIMIT_IMAGES_FROM_DB );
 
 		$rows = array();
 		$updateWhere = array();
 		$iconsWhere = array();
-		while ( $row = $db->fetchObject($result) ) {
+		while ( $row = $oDB->fetchObject($oResults) ) {
 			$rows[] = $row;
 			$updateWhere[] = "(wiki_id = {$row->wiki_id} and page_id = {$row->page_id})";
 		}
-		$db->freeResult( $result );
+		$oDB->freeResult( $oResults );
 
 		# update records
 		if ( count($updateWhere) > 0) {
@@ -304,16 +288,17 @@ class ImageReviewHelper extends ImageReviewHelperBase {
 				$values[] = "review_end = '0000-00-00 00:00:00'";
 			}
 
-			$db->update(
+			$oDB->update(
 				'image_review',
 				$values,
 				array( implode(' OR ', $updateWhere) ),
 				__METHOD__
 			);
 		}
-		$db->commit();
+		$oDB->commit();
 
-		$imageList = $invalidImages = $unusedImages = array();
+		$imageList = $unusedImages = $aDeletionList = [];
+
 		foreach ( $rows as $row ) {
 			$record = "(wiki_id = {$row->wiki_id} and page_id = {$row->page_id})";
 
@@ -321,26 +306,24 @@ class ImageReviewHelper extends ImageReviewHelperBase {
 				$oImagePage = GlobalTitle::newFromId( $row->page_id, $row->wiki_id );
 				if ( $oImagePage instanceof GlobalTitle ) {
 					$oImageGlobalFile = new GlobalFile( $oImagePage );
-					$aImageInfo = array(
-						'src' => $oImageGlobalFile->getThumbUrl( self::IMAGE_REVIEW_THUMBNAIL_SIZE . 'px-' . $oImageGlobalFile->getName() ),
-						'page' => $oImagePage->getFullUrl(),
-						'extension' => pathinfo( strtolower( $aImageInfo['page'] ), PATHINFO_EXTENSION ), // this needs to use the page index since src for SVG ends in .svg.png :/
-					);
-					$bImageExists = $oImageGlobalFile->exists();
 
-					if ( !$bImageExists && $state != ImageReviewStatuses::STATE_INVALID_IMAGE ) {
-						$invalidImages[] = $record;
-						continue;
-					} elseif ( 'ico' == $aImageInfo['extension'] ) {
+					$sThumbUrl = $oImageGlobalFile->getUrlGenerator()
+						->width( self::IMAGE_REVIEW_THUMBNAIL_SIZE )
+						->height( self::IMAGE_REVIEW_THUMBNAIL_SIZE )
+						->thumbnailDown()
+						->url();
+
+					$aImageInfo = array(
+						'src' => $sThumbUrl,
+						'page' => $oImagePage->getFullUrl(),
+						'extension' => $oImageGlobalFile->getMimeType(),
+					);
+
+					if ( strpos( 'ico', $aImageInfo['extension'] ) ) {
 						$iconsWhere[] = $record;
 						continue;
 					} else {
-						$isThumb = true;
-
-						if  ( in_array( $aImageInfo['extension'], array( 'gif', 'svg' ) ) ) {
-							$aImageInfo = ImagesService::getImageOriginalUrl( $row->wiki_id, $row->page_id );
-							$isThumb = false;
-						}
+						$isThumb = true; // Vignette handles .gif and .svg files
 
 						$wikiRow = WikiFactory::getWikiByID( $row->wiki_id );
 
@@ -370,6 +353,9 @@ class ImageReviewHelper extends ImageReviewHelperBase {
 							'exception' => new Exception()
 						]
 					);
+
+					$aDeletionList[] = [ $row->wiki_id, $row->page_id ];
+
 					continue;
 				}
 			} else {
@@ -377,50 +363,54 @@ class ImageReviewHelper extends ImageReviewHelperBase {
 			}
 		}
 
-		$commit = false;
-		if ( count( $invalidImages ) > 0 ) {
-			$db->update(
-				'image_review',
-				array(
-					'state' => ImageReviewStatuses::STATE_INVALID_IMAGE
-				),
-				array( implode( ' OR ', $invalidImages ) ),
-				__METHOD__
-			);
-			$commit = true;
-		}
+		/**
+		 * Invalid images
+		 */
+		$this->createDeleteImagesTask( $aDeletionList );
 
-		if ( count( $iconsWhere ) > 0 ) {
-			$db->update(
-					'image_review',
-					array( 'state' => ImageReviewStatuses::STATE_ICO_IMAGE ),
-					array( implode( ' OR ', $iconsWhere ) ),
-					__METHOD__
-				   );
-			$commit = true;
-		}
+		/**
+		 * Icons
+		 */
+		$aIconsValues = [
+			'state' => ImageReviewStatuses::STATE_ICO_IMAGE,
+		];
+		$aIconsWhere = [ implode( 'OR', $iconsWhere ) ];
+		$this->imageListAdditionalAction( 'icons', $oDB, $aIconsValues, $aIconsWhere );
 
-		if ( count( $unusedImages ) > 0 ) {
-			$db->update(
-				'image_review',
-				array(
-					'reviewer_id = null',
-					'state' => $state
-				),
-				array( implode( ' OR ', $unusedImages ) ),
-				__METHOD__
-			);
-			$commit = true;
-			error_log( "ImageReview : returning " . count($unusedImages) . " back to the queue" );
-		}
+		/**
+		 * Unused images
+		 */
+		$aUnusedValues = [
+			'reviewer_id = null',
+			'state' => $state,
+		];
+		$aUnusedWhere = [ implode( 'OR', $unusedImages ) ];
+		$this->imageListAdditionalAction( 'unused', $oDB, $aUnusedValues, $aUnusedWhere );
 
-		if ( $commit ) $db->commit();
-
-		error_log( "ImageReview : fetched new " . count( $imageList ) . " images" );
+		/**
+		 * Return valid images list
+		 */
+		WikiaLogger::instance()->info( "ImageReviewImageList: fetched new images", [
+			'method' => __METHOD__,
+			'count' => count( $imageList ),
+		] );
 
 		wfProfileOut( __METHOD__ );
 
 		return $imageList;
+	}
+
+	private function imageListAdditionalAction( $sType, DatabaseMysql $oDB, Array $aValues, Array $aWhere ) {
+		$iCount = count( $aWhere );
+		if ( $iCount > 0 ) {
+			$oDatabaseHelper = $this->getDatabaseHelper();
+			$oDatabaseHelper->updateBatchImages( $oDB, $aValues, $aWhere );
+		}
+
+		WikiaLogger::instance()->info( "ImageReviewImageList: updated {$sType} images.", [
+			'method' => __METHOD__,
+			'count' => $iCount,
+		] );
 	}
 
 	protected function getWhitelistedWikis() {
@@ -682,48 +672,4 @@ class ImageReviewHelper extends ImageReviewHelperBase {
 		wfProfileOut( __METHOD__ );
 		return $reviewers;
 	}
-
-	public static function onWikiFactoryPublicStatusChange( $city_public, $city_id, $reason ) {
-		global $wgExternalDatawareDB;
-
-		if ( $city_public == 0 || $city_public == -1 ) {
-			// the wiki was disabled, mark all unreviewed images as deleted
-
-			$newState = ImageReviewStatuses::STATE_WIKI_DISABLED;
-			$statesToUpdate = array(
-				ImageReviewStatuses::STATE_UNREVIEWED,
-				ImageReviewStatuses::STATE_REJECTED,
-				ImageReviewStatuses::STATE_QUESTIONABLE,
-				ImageReviewStatuses::STATE_QUESTIONABLE_IN_REVIEW,
-				ImageReviewStatuses::STATE_REJECTED_IN_REVIEW,
-				ImageReviewStatuses::STATE_IN_REVIEW,
-			);
-		} elseif ( $city_public == 1 ) {
-			// the wiki was re-enabled, put all images back into the queue as unreviewed
-
-			$newState = ImageReviewStatuses::STATE_UNREVIEWED;
-			$statesToUpdate = array(
-				ImageReviewStatuses::STATE_WIKI_DISABLED,
-			);
-		} else {
-			// the state change doesn't affect images, we don't need to do anything here
-			return true;
-		}
-
-		$dbw = wfGetDB( DB_MASTER, array(), $wgExternalDatawareDB );
-
-		$dbw->update(
-			'image_review',
-			array(
-				'state' => $newState,
-			),
-			array(
-				'wiki_id' => $city_id,
-				'state' => $dbw->makeList( $statesToUpdate ),
-			)
-		);
-
-		return true;
-	}
 }
-

--- a/extensions/wikia/ImageReview/ImageReviewHelperBase.class.php
+++ b/extensions/wikia/ImageReview/ImageReviewHelperBase.class.php
@@ -9,6 +9,18 @@ abstract class ImageReviewHelperBase extends WikiaModel {
 	const ORDER_PRIORITY_LATEST = 1;
 	const ORDER_OLDEST = 2;
 
+	/*
+	 * LIMIT_IMAGES_FROM_DB should be a little greater than LIMIT_IMAGES, so if
+	 * we fetch a few icons from DB, we can skip them
+	 */
+	const LIMIT_IMAGES = 20;
+	const LIMIT_IMAGES_FROM_DB = 24;
+
+	/**
+	 * Define a size of a thumbnail
+	 */
+	const IMAGE_REVIEW_THUMBNAIL_SIZE = 250;
+
 	public abstract function updateImageState($images, $action = '');
 
 	public abstract function resetAbandonedWork();
@@ -26,6 +38,10 @@ abstract class ImageReviewHelperBase extends WikiaModel {
 	public abstract function getImageCount();
 
 	public abstract function getUserTsKey();
+
+	protected function getDatabaseHelper() {
+		return new ImageReviewDatabaseHelper();
+	}
 
 	protected function getOrder($order) {
 		switch ($order) {

--- a/extensions/wikia/ImageReview/ImageReviewHelperBase.class.php
+++ b/extensions/wikia/ImageReview/ImageReviewHelperBase.class.php
@@ -21,6 +21,16 @@ abstract class ImageReviewHelperBase extends WikiaModel {
 	 */
 	const IMAGE_REVIEW_THUMBNAIL_SIZE = 250;
 
+	/**
+	 * Used in ImageReviewSpecial_index.php
+	 * @var array
+	 */
+	static $sortOptions = array(
+		'latest first' => 0,
+		'by priority and recency' => 1,
+		'oldest first' => 2,
+	);
+
 	public abstract function updateImageState($images, $action = '');
 
 	public abstract function resetAbandonedWork();
@@ -28,12 +38,6 @@ abstract class ImageReviewHelperBase extends WikiaModel {
 	public abstract function refetchImageListByTimestamp($timestamp);
 
 	public abstract function getImageList($timestamp, $state = ImageReviewStatuses::STATE_UNREVIEWED, $order = self::ORDER_LATEST);
-
-	protected abstract function getWhitelistedWikis();
-
-	protected abstract function getWhitelistedWikisFromWF();
-
-	protected abstract function getTopWikis();
 
 	public abstract function getImageCount();
 

--- a/extensions/wikia/ImageReview/ImageReviewSpecialController.class.php
+++ b/extensions/wikia/ImageReview/ImageReviewSpecialController.class.php
@@ -4,8 +4,7 @@ use \Wikia\Logger\WikiaLogger;
 
 class ImageReviewSpecialController extends WikiaSpecialPageController {
 	const ACTION_QUESTIONABLE = 'questionable';
-	const ACTION_REJECTED = 'rejected';
-	const ACTION_INVALID = 'invalid';
+	const ACTION_REJECTED     = 'rejected';
 
 	var $statsHeaders = array( 'user', 'total reviewed', 'approved', 'deleted', 'qustionable', 'distance to avg.' );
 
@@ -45,9 +44,6 @@ class ImageReviewSpecialController extends WikiaSpecialPageController {
 			return false;
 		} elseif ( $action == self::ACTION_QUESTIONABLE && !$this->accessQuestionable ) {
 			$this->specialPage->displayRestrictionError( 'questionableimagereview' );
-			return false;
-		} elseif ( $action == self::ACTION_INVALID && !$this->accessQuestionable ) {
-			$this->specialPage->displayRestrictionError();
 			return false;
 		} elseif ( $action == self::ACTION_REJECTED && !$this->accessRejected ) {
 			$this->specialPage->displayRestrictionError( 'rejectedimagereview' );
@@ -115,17 +111,21 @@ class ImageReviewSpecialController extends WikiaSpecialPageController {
 			$this->imageList = $helper->refetchImageListByTimestamp( $ts );
 		}
 
-		if ( count($this->imageList) == 0 ) {
+		if ( count( $this->imageList ) == 0 ) {
 			$do = array( 
 				self::ACTION_QUESTIONABLE	=> ImageReviewStatuses::STATE_QUESTIONABLE,
 				self::ACTION_REJECTED		=> ImageReviewStatuses::STATE_REJECTED,
-				self::ACTION_INVALID		=> ImageReviewStatuses::STATE_INVALID_IMAGE,
-				'default'			=> ImageReviewStatuses::STATE_UNREVIEWED
+				'default'					=> ImageReviewStatuses::STATE_UNREVIEWED
 			);
-			$this->imageList = $helper->getImageList( $ts, isset( $do[ $action ] ) ? $do[ $action ] : $do['default'], $order );
-		}
 
-		if ( $this->accessQuestionable ) {
+			if ( isset( $do[ $action ] ) ) {
+				$this->imageList = $helper->getImageList( $ts, $do[ $action ], $order );
+				$this->imageCount = $helper->getImageCount();
+			} else {
+				$this->imageList = $helper->getImageList( $ts, $do[ 'default' ], $order );
+				$this->imageCount = $helper->getImageCount( 'unreviewed', count( $this->imageList ) );
+			}
+		} else {
 			$this->imageCount = $helper->getImageCount();
 		}
 	}

--- a/extensions/wikia/ImageReview/ImageReviewSpecialController.class.php
+++ b/extensions/wikia/ImageReview/ImageReviewSpecialController.class.php
@@ -1,5 +1,7 @@
 <?php
 
+use \Wikia\Logger\WikiaLogger;
+
 class ImageReviewSpecialController extends WikiaSpecialPageController {
 	const ACTION_QUESTIONABLE = 'questionable';
 	const ACTION_REJECTED = 'rejected';
@@ -104,7 +106,9 @@ class ImageReviewSpecialController extends WikiaSpecialPageController {
 		$newestTs = $this->wg->Memc->get( $user_key );
 
 		if ( $ts > $newestTs ) {
-			error_log("ImageReview: I've got the newest ts ($ts), I won't refetch the images");
+			WikiaLogger::instance()->info( "ImageReview: I've got the newest ts ($ts), I won't refetch the images", [
+				'method' => __METHOD__,
+			]);
 			$this->imageList = array();
 			$this->wg->memc->set( $user_key, $ts, 3600 /* 1h */ );
 		} else {

--- a/extensions/wikia/ImageReview/ImageReviewTask.class.php
+++ b/extensions/wikia/ImageReview/ImageReviewTask.class.php
@@ -7,6 +7,8 @@
 
 namespace Wikia\Tasks\Tasks;
 
+use \Wikia\Logger\WikiaLogger;
+
 class ImageReviewTask extends BaseTask {
 	public function delete( $pageList, $suppress = false ) {
 		global $IP;
@@ -80,14 +82,45 @@ class ImageReviewTask extends BaseTask {
 		return $success;
 	}
 
+	public function deleteFromQueue( Array $aDeletionList ) {
+		global $wgExternalDatawareDB;
+
+		$oDB = wfGetDB( DB_MASTER, [], $wgExternalDatawareDB );
+
+		foreach ( $aDeletionList as $aImageData ) {
+			$oDB->delete(
+				'image_review',
+				$aImageData,
+				__METHOD__
+			);
+
+			WikiaLogger::instance()->info( 'ImageReviewLog', [
+				'method' => __METHOD__,
+				'message' => 'Image removed from queue',
+				'params' => $aImageData,
+			] );
+		}
+	}
+
 	private function sendNotification() {
 		global $wgFlowerUrl;
 
 		$subject = "ImageReview deletion failed #{$this->taskId}";
 		$body = "{$wgFlowerUrl}/task/{$this->taskId}";
-		$recipients = [new \MailAddress( 'tor@wikia-inc.com' ), new \MailAddress( 'sannse@wikia-inc.com' )];
+		$recipients = [
+			new \MailAddress( 'tor@wikia-inc.com' ),
+			new \MailAddress( 'adamk@wikia-inc.com' ),
+			new \MailAddress( 'sannse@wikia-inc.com' ),
+		];
 		$from = $recipients[0];
 
 		\UserMailer::send( $recipients, $from, $subject, $body );
+
+		WikiaLogger::instance()->error( "ImageReviewLog", [
+			'method' => __METHOD__,
+			'message' => "Task #{$this->taskId} deleting images did not succeed. Please check.",
+			'taskId' => $this->taskId,
+			'taskUrl' => $body,
+		] );
 	}
-} 
+}

--- a/extensions/wikia/ImageReview/maintenance/ImageReviewResetAbandonedWork.php
+++ b/extensions/wikia/ImageReview/maintenance/ImageReviewResetAbandonedWork.php
@@ -1,6 +1,16 @@
 <?php
 
-require(  dirname(__FILE__ ) . '/../../../../maintenance/commandLine.inc'  );
+require_once( dirname(__FILE__ ) . '/../../../../maintenance/Maintenance.php' );
 
-$irh = new ImageReviewHelper();
-$irh->resetAbandonedWork();
+class ImageReviewResetAbandonedWork extends Maintenance {
+
+	public function execute() {
+		$oHelper = new ImageReviewHelper();
+		$sFrom = $oHelper->resetAbandonedWork();
+
+		$this->output( "\nReviews older than {$sFrom} reset.\n" );
+	}
+}
+
+$maintClass = "ImageReviewResetAbandonedWork";
+require_once( RUN_MAINTENANCE_IF_MAIN );

--- a/extensions/wikia/ImageReview/modules/PromoteImage/PromoteImageReviewHelper.class.php
+++ b/extensions/wikia/ImageReview/modules/PromoteImage/PromoteImageReviewHelper.class.php
@@ -1,5 +1,7 @@
 <?php
 
+use \Wikia\Logger\WikiaLogger;
+
 class PromoteImageReviewHelper extends ImageReviewHelperBase {
 
 	const LIMIT_IMAGES = 20;
@@ -318,14 +320,21 @@ class PromoteImageReviewHelper extends ImageReviewHelperBase {
 				__METHOD__
 			);
 			$commit = true;
-			error_log("PromoteImageReview : returning " . count($unusedImages) . " back to the queue");
+
+			WikiaLogger::instance()->info( "PromoteImageReview : returning unused images back to the queue", [
+				'method' => __METHOD__,
+				'count' => count( $unusedImages ),
+			] );
 		}
 
 		if ($commit) {
 			$db->commit();
 		}
 
-		error_log("PromoteImageReview : fetched new " . count($imageList) . " images");
+		WikiaLogger::instance()->info( "PromoteImageReview : fetched new images", [
+			'method' => __METHOD__,
+			'count' => count( $imageList ),
+		] );
 
 		wfProfileOut(__METHOD__);
 

--- a/extensions/wikia/ImageReview/templates/ImageReviewSpecial_index.php
+++ b/extensions/wikia/ImageReview/templates/ImageReviewSpecial_index.php
@@ -5,9 +5,6 @@
 			<a href="<?= $baseUrl ?>"><em><?= $imageCount['unreviewed'] ?></em> <span>unreviewed<br>images</span></a>
 		</div>
 		<div class="tally">
-			<a href="<?= $baseUrl ?>/invalid"><em><?= $imageCount['invalid']?></em> <span>invalid<br>images</span></a>
-		</div>
-		<div class="tally">
 			<a href="<?= $baseUrl ?>/questionable"><em><?= $imageCount['questionable']?></em> <span>questionable<br>images</span></a>
 		</div>
 <?php } ?>

--- a/extensions/wikia/Scribe/ScribeEventProducer.class.php
+++ b/extensions/wikia/Scribe/ScribeEventProducer.class.php
@@ -51,7 +51,7 @@ class ScribeEventProducer {
 		$this->setCategory();
 	}
 
-	public function buildEditPackage( $oPage, $oUser, $oRevision = null, $revision_id = null ) {
+	public function buildEditPackage( $oPage, $oUser, $oRevision = null, $revision_id = null, $oLocalFile = null ) {
 		wfProfileIn( __METHOD__ );
 
 		if ( !is_object( $oPage ) ) {
@@ -113,13 +113,13 @@ class ScribeEventProducer {
 		$this->setMediaLinks( $oPage );
 		$this->setTotalWords( str_word_count( $rev_text ) );
 
-		if ( in_array( $this->mParams['pageNamespace'], $this->mediaNS ) ) {
+		if ( $oLocalFile instanceof File ) {
 			$this->setMediaType( $oTitle );
-			$this->setIsLocalFile( $oTitle );
+			$this->setIsLocalFile( $oLocalFile );
 			$this->setIsTop200( $this->app->wg->CityId );
 			$this->setIsImageForReview();
-
-			WikiaLogger::instance()->info( 'ImageReviewParams', [ 'method' => __METHOD__, 'data' => $this->mParams ] );
+		} else {
+			$this->setIsImageForReview( false );
 		}
 
 		$t = microtime(true);
@@ -324,9 +324,8 @@ class ScribeEventProducer {
 		$this->mParams['eventTS'] = $ts;
 	}
 
-	public function setIsLocalFile ( Title $oTitle ) {
-		$oFile = wfFindFile( $oTitle );
-		if( $oFile instanceof LocalFile ) {
+	public function setIsLocalFile ( File $oLocalFile ) {
+		if( $oLocalFile instanceof File && $oLocalFile->exists() ) {
 			$bIsLocalFile = true;
 		} else {
 			$bIsLocalFile = false;
@@ -439,31 +438,35 @@ class ScribeEventProducer {
 		return false;
 	}
 
-	public function setIsImageForReview() {
-		$aAllowedTypes = [
-			1 => MEDIATYPE_BITMAP,
-			2 => MEDIATYPE_DRAWING,
-		];
+	public function setIsImageForReview( $bProvidedValue = null ) {
+		if ( $bProvidedValue === null ) {
+			$aAllowedTypes = [
+				1 => MEDIATYPE_BITMAP,
+				2 => MEDIATYPE_DRAWING,
+			];
 
-		if ( in_array( $this->mParams['pageNamespace'], $this->mediaNS )
-			&& isset( $aAllowedTypes[ $this->mParams['mediaType'] ] )
-		) {
-			if ( $this->mParams['isRedirect'] == 1 ) {
-				$sLogMessage = 'The page is a redirect';
-				$bIsImageForReview = false;
-			} elseif ( $this->mParams['isLocalFile'] == 0 ) {
-				$sLogMessage = 'The file is from an external repo';
-				$bIsImageForReview = false;
-			} elseif ( $this->mParams['isTop200'] == 1 ) {
-				$sLogMessage = 'The was uploaded to one of the Top200 wikias';
-				$bIsImageForReview = false;
-			} else {
-				$sLogMessage = 'The image was sent for a review';
-				$bIsImageForReview = true;
+			if ( in_array( $this->mParams['pageNamespace'], $this->mediaNS )
+				&& isset( $aAllowedTypes[ $this->mParams['mediaType'] ] )
+			) {
+				if ( $this->mParams['isRedirect'] == 1 ) {
+					$sLogMessage = 'The page is a redirect';
+					$bIsImageForReview = false;
+				} elseif ( $this->mParams['isLocalFile'] == 0 ) {
+					$sLogMessage = 'The file is from an external repo';
+					$bIsImageForReview = false;
+				} elseif ( $this->mParams['isTop200'] == 1 ) {
+					$sLogMessage = 'The image was uploaded to one of the Top200 wikias';
+					$bIsImageForReview = false;
+				} else {
+					$sLogMessage = 'The image was sent for a review';
+					$bIsImageForReview = true;
+				}
+
+				$this->mParams['isImageForReview'] = intval( $bIsImageForReview );
+				$this->sendImageReviewLog( $sLogMessage );
 			}
-
-			$this->sendImageReviewLog( $sLogMessage );
-			$this->mParams['isImageForReview'] = intval( $bIsImageForReview );
+		} else {
+			$this->mParams['isImageForReview'] = intval( $bProvidedValue );
 		}
 	}
 
@@ -475,7 +478,7 @@ class ScribeEventProducer {
 	private function sendImageReviewLog( $sLogMessage ) {
 		WikiaLogger::instance()->info( 'ImageReviewLog', [
 			'method' => __METHOD__,
-			'status' => $bIsImageForReview,
+			'status' => $this->mParams['isImageForReview'],
 			'message' => $sLogMessage,
 			'params' => $this->mParams,
 		] );

--- a/extensions/wikia/Scribe/ScribeEventProducer.class.php
+++ b/extensions/wikia/Scribe/ScribeEventProducer.class.php
@@ -1,5 +1,7 @@
 <?php
 
+use \Wikia\Logger\WikiaLogger;
+
 class ScribeEventProducer {
 	private $app = null;
 	private $mParams, $mKey, $mEventType;
@@ -110,8 +112,15 @@ class ScribeEventProducer {
 		$this->setMediaType( $oTitle );
 		$this->setMediaLinks( $oPage );
 		$this->setTotalWords( str_word_count( $rev_text ) );
-		$this->setIsTop200( $this->app->wg->CityId );
-		$this->setIsImageForReview();
+
+		if ( in_array( $this->mParams['pageNamespace'], $this->mediaNS ) ) {
+			$this->setMediaType( $oTitle );
+			$this->setIsLocalFile( $oTitle );
+			$this->setIsTop200( $this->app->wg->CityId );
+			$this->setIsImageForReview();
+
+			WikiaLogger::instance()->info( 'ImageReviewParams', [ 'method' => __METHOD__, 'data' => $this->mParams ] );
+		}
 
 		$t = microtime(true);
 		$micro = sprintf("%06d",($t - floor($t)) * 1000000);
@@ -436,18 +445,40 @@ class ScribeEventProducer {
 			2 => MEDIATYPE_DRAWING,
 		];
 
-		if ( $this->mParams['pageNamespace'] == 6
-			&& $this->mParams['isRedirect'] == 0
+		if ( in_array( $this->mParams['pageNamespace'], $this->mediaNS )
 			&& isset( $aAllowedTypes[ $this->mParams['mediaType'] ] )
-			&& $this->mParams['isLocalFile'] == 1
-			&& $this->mParams['isTop200'] == 0
 		) {
-			$bIsImageForReview = true;
-		} else {
-			$bIsImageForReview = false;
-		}
+			if ( $this->mParams['isRedirect'] == 1 ) {
+				$sLogMessage = 'The page is a redirect';
+				$bIsImageForReview = false;
+			} elseif ( $this->mParams['isLocalFile'] == 0 ) {
+				$sLogMessage = 'The file is from an external repo';
+				$bIsImageForReview = false;
+			} elseif ( $this->mParams['isTop200'] == 1 ) {
+				$sLogMessage = 'The was uploaded to one of the Top200 wikias';
+				$bIsImageForReview = false;
+			} else {
+				$sLogMessage = 'The image was sent for a review';
+				$bIsImageForReview = true;
+			}
 
-		$this->mParams['isImageForReview'] = intval( $bIsImageForReview );
+			$this->sendImageReviewLog( $sLogMessage );
+			$this->mParams['isImageForReview'] = intval( $bIsImageForReview );
+		}
+	}
+
+	/**
+	 * Sends a unified ImageReviewLog message
+	 * @param  string $sLogMessage  A log message
+	 * @return void
+	 */
+	private function sendImageReviewLog( $sLogMessage ) {
+		WikiaLogger::instance()->info( 'ImageReviewLog', [
+			'method' => __METHOD__,
+			'status' => $bIsImageForReview,
+			'message' => $sLogMessage,
+			'params' => $this->mParams,
+		] );
 	}
 
 	public function sendLog() {

--- a/extensions/wikia/Scribe/ScribeEventProducer.setup.php
+++ b/extensions/wikia/Scribe/ScribeEventProducer.setup.php
@@ -11,4 +11,4 @@ $wgHooks['NewRevisionFromEditComplete'][] = 'ScribeEventProducerController::onSa
 $wgHooks['ArticleDeleteComplete'][] = 'ScribeEventProducerController::onDeleteComplete';
 $wgHooks['ArticleUndelete'][] = 'ScribeEventProducerController::onArticleUndelete';
 $wgHooks['TitleMoveComplete'][] = 'ScribeEventProducerController::onMoveComplete'; 
-
+$wgHooks['UploadComplete'][] = 'ScribeEventProducerController::onUploadComplete';

--- a/extensions/wikia/Scribe/ScribeEventProducerController.class.php
+++ b/extensions/wikia/Scribe/ScribeEventProducerController.class.php
@@ -1,6 +1,36 @@
 <?php
 
 class ScribeEventProducerController {
+
+	/**
+	 * Ugly fix! TODO
+	 * The following static properties are declared to store
+	 * $oPage, $oUser and $oRevision objects passed from SaveComplete
+	 * and SaveRevisionComplete hooks. They are necessary to call
+	 * the buildEditPackage() method. For files, to check if they are local,
+	 * we need to wait till the UploadComplete hook is run.
+	 * This hook only passes an instance of UploadBase class so it is needed
+	 * to store the mentioned objects from the previously run hooks.
+	 * It is going to be fixed with the new version of the ImageReview tool.
+	 * @see    CE-1125 or any ImageReview related ticket
+	 * @blame  Adam Karminski <adamk@wikia-inc.com>
+	 */
+	private static $oPage, $oUser, $oRevision;
+
+	static public function onUploadComplete( UploadBase $oForm ) {
+		wfProfileIn( __METHOD__ );
+
+		$oLocalFile = $oForm->getLocalFile();
+
+		$oScribeProducer = new ScribeEventProducer( 'edit' );
+		if ( $oScribeProducer->buildEditPackage( self::$oPage, self::$oUser, self::$oRevision, null, $oLocalFile ) ) {
+			$oScribeProducer->sendLog();
+		}
+
+		wfProfileOut( __METHOD__ );
+		return true;
+	}
+
 	static public function onSaveComplete( &$oPage, &$oUser, $text, $summary, $minor, $undef1, $undef2, &$flags, $oRevision, &$status, $baseRevId ) {
 		wfProfileIn( __METHOD__ );
 
@@ -9,6 +39,17 @@ class ScribeEventProducerController {
 
  		$oScribeProducer = new ScribeEventProducer( $key, $is_archive );
 		if ( is_object( $oScribeProducer ) ) {
+			/**
+			 * Ugly fix! TODO
+			 * See the description above.
+			 */
+			$oTitle = $oPage->getTitle();
+			if ( $oTitle->getNamespace() == NS_FILE ) {
+				self::$oPage = $oPage;
+				self::$oUser = $oUser;
+				self::$oRevision = $oRevision;
+			}
+
 			if ( $oScribeProducer->buildEditPackage( $oPage, $oUser, $oRevision ) ) {
 				$oScribeProducer->sendLog();
 			}
@@ -25,6 +66,17 @@ class ScribeEventProducerController {
 		if ( $allow ) {
 			$oScribeProducer = new ScribeEventProducer( 'edit' );
 			if ( is_object( $oScribeProducer ) ) {
+				/**
+				 * Ugly fix! TODO
+				 * See the description above.
+				 */
+				$oTitle = $oPage->getTitle();
+				if ( $oTitle->getNamespace() == NS_FILE ) {
+					self::$oPage = $oPage;
+					self::$oUser = $oUser;
+					self::$oRevision = $oRevision;
+				}
+
 				if ( $oScribeProducer->buildEditPackage( $oPage, $oUser, $oRevision, $revision_id ) ) {
 					$oScribeProducer->sendLog();
 				}

--- a/includes/wikia/GlobalFile.class.php
+++ b/includes/wikia/GlobalFile.class.php
@@ -163,6 +163,27 @@ class GlobalFile extends WikiaObject {
 	}
 
 	/**
+	 * @return string  A path to file's bucket
+	 */
+	public function getBucket() {
+		return VignetteRequest::parseBucket( $this->getUploadDir() );
+	}
+
+	/**
+	 * @return string  A language prefix
+	 */
+	public function getPathPrefix() {
+		return VignetteRequest::parsePathPrefix( $this->getUploadDir() );
+	}
+
+	/**
+	 * @return UrlGenerator object
+	 */
+	public function getUrlGenerator() {
+		return VignetteRequest::fromGlobalFile( $this );
+	}
+
+	/**
 	 * Returns URL to cropped image
 	 *
 	 * Uses ImageServing cropping functionality

--- a/includes/wikia/VignetteRequest.php
+++ b/includes/wikia/VignetteRequest.php
@@ -20,6 +20,20 @@ class VignetteRequest {
 	}
 
 	/**
+	 * @param GlobalFile $globalFile
+	 * @return UrlGenerator
+	 */
+	public static function fromGlobalFile( GlobalFile $globalFile ) {
+		return self::fromConfigMap( [
+			'is-archive' => false, // GlobalFile doesn't serve archive files
+			'timestamp' => $globalFile->getTimestamp(),
+			'relative-path' => $globalFile->getUrlRel(),
+			'bucket' => $globalFile->getBucket(),
+			'path-prefix' => $globalFile->getPathPrefix(),
+		] );
+	}
+
+	/**
 	 * create a UrlGenerator from a config map. $config must have the following keys: relative-path.
 	 * optionally, it can also have timestamp, is-archive, path-prefix, bucket, base-url, and domain-shard-count.
 	 * if the optional values aren't in the map, they'll be generated from the current wiki environment


### PR DESCRIPTION
This massive PR includes important fixes for Special:ImageReview:
- Improved conditions for sending an image to review
- Self-cleaning mechanism for image_review queue
- Counters reset mechanism
- Removal of the Invalid queue
- Use of Vignette for thumbnails
- Improved logging (see [Kibana dashboard](https://kibana.wikia-inc.com/#/dashboard/elasticsearch/ImageReview%20Logs))
- Lots of refactoring and code separation
- Lots of documentation
