### PR TITLE
HG-422: Add wgCdnApiUrl to the whitelisted variables

### DIFF
--- a/extensions/wikia/WikiaMobile/WikiaMobile.setup.php
+++ b/extensions/wikia/WikiaMobile/WikiaMobile.setup.php
@@ -204,6 +204,9 @@ if ( empty( $wgWikiaMobileIncludeJSGlobals ) ) {
 
 			//login
 			'fbAppId',
-			'wgLoginToken'
+			'wgLoginToken',
+
+			//AbTesting
+			'wgCdnApiUrl',
 		];
 }


### PR DESCRIPTION
The `ABTesting` script relies on `wgCdnApiUrl` to form the request urls.  This PR whitelists the `wgCdnApiUrl` variable so resulting URLs are valid.

/cc @hakubo 
