### PR TITLE
CON-2265 fix broken ad skin size by other styles

### DIFF
--- a/extensions/wikia/Venus/styles/background.scss
+++ b/extensions/wikia/Venus/styles/background.scss
@@ -8,7 +8,10 @@ $width-limit: 1000px;
 $background-align: if( $background-width > $width-limit, center, left );
 
 body:not(.venus-preview) {
-	background: $color-body url($background-image) top $background-align repeat; /* $wgCdnStylePath */
+	background-color: $color-body;
+	background-image: url($background-image); /* $wgCdnStylePath */
+	background-repeat: repeat;
+	background-position: top $background-align;
 }
 
 body.background-not-tiled {


### PR DESCRIPTION
Ad skin was badly sized on large breakpoint.
It was caused by some styles which were overriding background-size from ads.scss
