### PR TITLE
Make sure $this->facebookUserId is set before grabbing session

### DIFF
--- a/extensions/wikia/FacebookClient/FacebookClient.class.php
+++ b/extensions/wikia/FacebookClient/FacebookClient.class.php
@@ -200,7 +200,7 @@ class FacebookClient {
 					'/me'
 				) )->execute()->getGraphObject( Facebook\GraphUser::className() );
 
-				$this->userInfoCache[$userId] = $userProfile;
+				$this->userInfoCache[$this->facebookUserId] = $userProfile;
 			} catch( Exception $e ) {
 				$log->error( __CLASS__ . ': Failure in the api requesting "/me"', [
 					'method' => __METHOD__,
@@ -211,7 +211,7 @@ class FacebookClient {
 			}
 		}
 
-		return $this->userInfoCache[$userId];
+		return $this->userInfoCache[$this->facebookUserId];
 	}
 
 	/**

--- a/extensions/wikia/FacebookClient/FacebookClient.class.php
+++ b/extensions/wikia/FacebookClient/FacebookClient.class.php
@@ -163,24 +163,11 @@ class FacebookClient {
 			return $this->facebookUserId;
 		}
 
-		$errorMessage = null;
-
-		try {
-			$session = $this->getSession();
-			if ( $session ) {
-				$session->validate();
-				$this->facebookUserId = ( int ) $this->facebookAPI->getUserId();
-			}
-		} catch ( \Exception $e ) {
-			$errorMessage = $e->getMessage();
-		}
-
+		$this->facebookUserId = $this->facebookAPI->getUserId();
 		if ( empty( $this->facebookUserId ) ) {
 			$this->facebookUserId = 0;
-
 			WikiaLogger::instance()->warning( 'Null Facebook user id', [
 				'method' => __METHOD__,
-				'message' => $errorMessage,
 			] );
 		}
 
@@ -197,18 +184,15 @@ class FacebookClient {
 	public function getUserInfo( $userId = 0 ) {
 		$log = WikiaLogger::instance();
 
-		// Pull the user ID from the signed FB cookie if it wasn't passed in
-		if ( empty( $userId ) ) {
-			$userId = $this->getUserId();
-		}
+		$this->facebookUserId = empty( $userId ) ? $this->getUserId() : $userId;
 
 		// If we still couldn't get a user ID, return null
-		if ( empty( $userId ) ) {
+		if ( empty( $this->facebookUserId ) ) {
 			$log->warning( __CLASS__ . ': Could not get user ID from FB session', [ 'method' => __METHOD__ ]);
 			return null;
 		}
 
-		if ( empty( $this->userInfoCache[$userId] ) ) {
+		if ( empty( $this->userInfoCache[$this->facebookUserId] ) ) {
 			try {
 				$userProfile = ( new \Facebook\FacebookRequest(
 					$this->getSession(),

--- a/extensions/wikia/FacebookClient/FacebookClient.class.php
+++ b/extensions/wikia/FacebookClient/FacebookClient.class.php
@@ -164,7 +164,18 @@ class FacebookClient {
 		}
 
 		$this->facebookUserId = $this->facebookAPI->getUserId();
-		if ( empty( $this->facebookUserId ) ) {
+		if ( !empty( $this->facebookUserId ) ) {
+			try {
+				// Try and create a sesssion to see if facebookUserId is valid
+				$session = $this->getSession();
+			} catch ( \Exception $e ) {
+				$this->facebookUserId = 0;
+				WikiaLogger::instance()->warning( 'Unable to create valid session', [
+					'method' => __METHOD__,
+					'message' => $e->getMessage()
+				] );
+			}
+		} else {
 			$this->facebookUserId = 0;
 			WikiaLogger::instance()->warning( 'Null Facebook user id', [
 				'method' => __METHOD__,

--- a/extensions/wikia/FacebookClient/FacebookClient.class.php
+++ b/extensions/wikia/FacebookClient/FacebookClient.class.php
@@ -166,7 +166,7 @@ class FacebookClient {
 		$this->facebookUserId = $this->facebookAPI->getUserId();
 		if ( !empty( $this->facebookUserId ) ) {
 			try {
-				// Try and create a sesssion to see if facebookUserId is valid
+				// Try and create a session to see if facebookUserId is valid
 				$session = $this->getSession();
 			} catch ( \Exception $e ) {
 				$this->facebookUserId = 0;


### PR DESCRIPTION
There's a problem with the current implementation of caching a session in the FBClient. We create a cache key using $this->facebookUserId which hasn't been set by this point - meaning that all users are sharing the same cache key. This fix makes sure we set $this->facebookUserId before checking the cache for a session.
