### PR TITLE
VE-1710: Allow VisualEditor to retrieve Venus flavored Parser output after succesfull save

### DIFF
--- a/extensions/VisualEditor/ApiVisualEditor.php
+++ b/extensions/VisualEditor/ApiVisualEditor.php
@@ -165,12 +165,15 @@ class ApiVisualEditor extends ApiBase {
 		);
 	}
 
-	protected function parseWikitext( $title ) {
+	protected function parseWikitext( $title, $skin = null ) {
 		$apiParams = array(
 			'action' => 'parse',
 			'page' => $title->getPrefixedDBkey(),
-			'prop' => 'text|revid|categorieshtml',
+			'prop' => 'text|revid|categorieshtml'
 		);
+		if ( !empty( $skin ) ) {
+			$apiParams['useskin'] = $skin;
+		}
 		$api = new ApiMain(
 			new DerivativeRequest(
 				$this->getRequest(),

--- a/extensions/VisualEditor/ApiVisualEditorEdit.php
+++ b/extensions/VisualEditor/ApiVisualEditorEdit.php
@@ -112,7 +112,7 @@ class ApiVisualEditorEdit extends ApiVisualEditor {
 
 			// Return result of parseWikitext instead of saveWikitext so that the
 			// frontend can update the page rendering without a refresh.
-			$result = $this->parseWikitext( $page );
+			$result = $this->parseWikitext( $page, $params['useskin'] );
 			if ( $result === false ) {
 				$this->dieUsage( 'Error contacting the Parsoid server', 'parsoidserver' );
 			}

--- a/extensions/VisualEditor/modules/ve-mw/init/ve.init.mw.Target.js
+++ b/extensions/VisualEditor/modules/ve-mw/init/ve.init.mw.Target.js
@@ -1166,7 +1166,8 @@ ve.init.mw.Target.prototype.save = function ( doc, options ) {
 		'page': this.pageName,
 		'basetimestamp': this.baseTimeStamp,
 		'starttimestamp': this.startTimeStamp,
-		'token': this.editToken
+		'token': this.editToken,
+		'useskin': mw.config.get( 'skin' )
 	} );
 	if ( this.wikitext !== null ) {
 		data.oldwt = this.wikitext;


### PR DESCRIPTION
Venus changes to the Parser output are implemented as Parser hooks and enabled only for Venus skin (otherwise those hooks just return). Fortunetely MediaWiki, including API (api.php) allows to specify skin/context by passing its name as "useskin" GET/POST parameter.

https://wikia-inc.atlassian.net/browse/VE-1710
