### PR TITLE
CON-2299: AssetsManager::checkIfGroupForSkin - fix a fatal

### DIFF
--- a/extensions/wikia/AssetsManager/AssetsManager.class.php
+++ b/extensions/wikia/AssetsManager/AssetsManager.class.php
@@ -684,10 +684,10 @@ class AssetsManager {
 	/**
 	 * Checks if given asset's group should be loaded for provided skin
 	 * @param string $group - Asset Manager group name
-	 * @param WikiaSkin $skin - Wikia Skin instance
+	 * @param Skin $skin - skin instance
 	 * @return bool whether group should be loaded for given skin
 	 */
-	public function checkIfGroupForSkin($group, WikiaSkin $skin) {
+	public function checkIfGroupForSkin($group, Skin $skin) {
 		$this->loadConfig();
 		$skinName = $skin->getSkinName();
 		$registeredSkin = $this->mAssetsConfig->getGroupSkin( $group );
@@ -696,7 +696,7 @@ class AssetsManager {
 			in_array( $skinName, $registeredSkin ) : $skinName === $registeredSkin;
 
 		//if not strict packages with no skin registered are positive
-		if ( $skin->isStrict() === false ) {
+		if ( ( $skin instanceof WikiaSkin ) && ( $skin->isStrict() === false ) ) {
 			$check = $check || empty( $registeredSkin );
 		}
 

--- a/extensions/wikia/SkinChooser/SkinChooser.class.php
+++ b/extensions/wikia/SkinChooser/SkinChooser.class.php
@@ -337,7 +337,13 @@ class SkinChooser {
 		return false;
 	}
 
-	private static function showVenusSkin( $title ) {
+	/**
+	 * Check if the current page should be rendered using Venus
+	 *
+	 * @param Title $title
+	 * @return bool
+	 */
+	private static function showVenusSkin( Title $title ) {
 		global $wgEnableVenusSkin, $wgEnableVenusSpecialSearch, $wgEnableVenusArticle, $wgRequest;
 
 		$action = $wgRequest->getVal('action');


### PR DESCRIPTION
`AssetsManager::checkIfGroupForSkin` can be called with an instance of `Skin` class (vector skin for instance). Make additional check for `WikiaSkin` class when calling `isStrict` method.
