### PR TITLE
Allow dots in bucket names

### DIFF
--- a/extensions/wikia/CreateNewWiki/CreateWiki.php
+++ b/extensions/wikia/CreateNewWiki/CreateWiki.php
@@ -720,10 +720,10 @@ class CreateWiki {
 	 * @return string Sanitized name
 	 */
 	private static function sanitizeS3BucketName( $name ) {
-		$RE_VALID = "/^[a-z0-9](?:[-_a-z0-9]{0,53}[a-z0-9])?\$/";
+		$RE_VALID = "/^[a-z0-9](?:[-_a-z0-9]{0,53}[a-z0-9])?(?:[a-z0-9](?:\\.[-_a-z0-9]{0,53}[a-z0-9])?)*\$/";
 		# check if it's already valid
 		$name = mb_strtolower($name);
-		if ( preg_match( $RE_VALID, $name ) ) {
+		if ( preg_match( $RE_VALID, $name ) && strlen($name) <= self::SANITIZED_BUCKET_NAME_MAXIMUM_LENGTH ) {
 			return $name;
 		}
 
@@ -732,7 +732,7 @@ class CreateWiki {
 		if ( in_array( substr($check_name,-1), [ '-', '_' ] ) ) {
 			$check_name .= '0';
 		}
-		if ( preg_match( $RE_VALID, $check_name ) ) {
+		if ( preg_match( $RE_VALID, $check_name ) && strlen($check_name) <= self::SANITIZED_BUCKET_NAME_MAXIMUM_LENGTH ) {
 			return $check_name;
 		}
 

--- a/extensions/wikia/CreateNewWiki/tests/CreateWikiTest.php
+++ b/extensions/wikia/CreateNewWiki/tests/CreateWikiTest.php
@@ -46,7 +46,7 @@ class CreateWikiTest extends WikiaBaseTest {
 			'0' => [ '0', '0' ],
 			'muppet' => [ 'muppet', 'muppet' ],
 			'with trailing underscores' => [ 'x__', 'x__0' ],
-			'with dots' => [ 'ru.google', 'ru_google' ],
+			'with dots' => [ 'ru.google', 'ru.google' ],
 			'with spaces' => [ 'save earth save life', 'save_earth_save_life' ],
 			'with parenthesis' => [ 'roman_empire_(the rebirth of rome)', 'roman_empire__the_rebirth_of_rome_0' ],
 			'long' => [ '012345678901234567890123456789012345678901234567890123456789', '0123456789012345678901234567890123456789012345678901234' ],


### PR DESCRIPTION
Allow dots in S3 bucket names as it complies with the standard and requirements.

https://wikia-inc.atlassian.net/browse/PLATFORM-535

/cc @macbre 
