### PR TITLE
accept vignette urls as valid image urls

### DIFF
--- a/includes/parser/Parser.php
+++ b/includes/parser/Parser.php
@@ -1768,6 +1768,7 @@ class Parser {
 
 		$imagesfrom = $this->mOptions->getAllowExternalImagesFrom();
 		$imagesexception = !empty( $imagesfrom );
+		$isValidImageUrl = VignetteRequest::isVignetteUrl($url) || preg_match(self::EXT_IMAGE_REGEX, $url);
 		$text = false;
 		# $imagesfrom could be either a single string or an array of strings, parse out the latter
 		if ( $imagesexception && is_array( $imagesfrom ) ) {
@@ -1786,13 +1787,12 @@ class Parser {
 		if ( $this->mOptions->getAllowExternalImages()
 			 || ( !empty( $wgAllowExternalWhitelistImages ) && wfRunHooks( 'outputMakeExternalImage', array( &$url ) ) )
 			 || ( $imagesexception && $imagematch ) ) {
-			if ( preg_match( self::EXT_IMAGE_REGEX, $url ) ) {
+			if ( $isValidImageUrl ) {
 				# Image found
 				$text = Linker::makeExternalImage( $url );
 			}
 		}
-		if ( !$text && $this->mOptions->getEnableImageWhitelist()
-			 && preg_match( self::EXT_IMAGE_REGEX, $url ) ) {
+		if ( !$text && $this->mOptions->getEnableImageWhitelist() && $isValidImageUrl ) {
 			$whitelist = explode( "\n", wfMsgForContent( 'external_image_whitelist' ) );
 			foreach ( $whitelist as $entry ) {
 				# Sanitize the regex fragment, make it case-insensitive, ignore blank entries/comments


### PR DESCRIPTION
@Wikia/platform-team 
https://wikia-inc.atlassian.net/browse/PLATFORM-626

Since Vignette URLs don't end in an image extension, they need to be whitelisted when linking external images.
