### PR TITLE
VID-2143 Make sure we have a ThumbnailImage object with a File when crea...

### DIFF
--- a/extensions/wikia/MediaGallery/MediaGalleryModel.class.php
+++ b/extensions/wikia/MediaGallery/MediaGalleryModel.class.php
@@ -80,6 +80,16 @@ class MediaGalleryModel extends WikiaObject {
 			'height' => $dimension,
 		];
 		$thumb = $file->transform( $dimensions );
+
+		// Error check and logging for VID-2143
+		if ( !$thumb instanceof ThumbnailImage || !$thumb->file instanceof File ) {
+			WikiaLogger::instance()->error(
+				'MediaGalleryModel',
+				'ThumbnailImage from title: ' . $item['title'] . 'couldn\'t be created or is missing associated File'
+			);
+			return null;
+		}
+
 		$thumb->setUrl( $thumbUrl );
 
 		$thumbnail = $this->app->renderView(

--- a/extensions/wikia/MediaGallery/MediaGalleryModel.class.php
+++ b/extensions/wikia/MediaGallery/MediaGalleryModel.class.php
@@ -66,8 +66,8 @@ class MediaGalleryModel extends WikiaObject {
 
 		if ( !$file instanceof File ) {
 			WikiaLogger::instance()->error(
-				'MediaGalleryModel',
-				'File with title: ' . $item['title'] . 'doesn\'t exist'
+				'File with title: ' . $item['title'] . 'doesn\'t exist',
+				[ 'class' => __CLASS__ ]
 			);
 			return null;
 		}
@@ -81,11 +81,10 @@ class MediaGalleryModel extends WikiaObject {
 		];
 		$thumb = $file->transform( $dimensions );
 
-		// Error check and logging for VID-2143
-		if ( !$thumb instanceof ThumbnailImage || !$thumb->file instanceof File ) {
+		if ( !$thumb instanceof ThumbnailImage ) {
 			WikiaLogger::instance()->error(
-				'MediaGalleryModel',
-				'ThumbnailImage from title: ' . $item['title'] . 'couldn\'t be created or is missing associated File'
+				'ThumbnailImage from title: ' . $item['title'] . ' couldn\'t be created.',
+				[ 'thumbClass' => get_class( $thumb ) ]
 			);
 			return null;
 		}

--- a/extensions/wikia/Thumbnails/ThumbnailController.class.php
+++ b/extensions/wikia/Thumbnails/ThumbnailController.class.php
@@ -84,7 +84,9 @@ class ThumbnailController extends WikiaController {
 	}
 
 	/**
-	 * Render image tags for the MediaGallery
+	 * Render image tags for the MediaGallery. Please note it is the caller's responsibility
+	 * to ensure thumb is of the proper type. No error checking takes place here and there's
+	 * the opportunity to throw a fatal if the wrong data is passed in.
 	 * @requestParam MediaTransformOutput thumb
 	 * @requestParam array options This is here for consistency, it's not used yet
 	 */

--- a/extensions/wikia/Thumbnails/ThumbnailController.class.php
+++ b/extensions/wikia/Thumbnails/ThumbnailController.class.php
@@ -86,7 +86,7 @@ class ThumbnailController extends WikiaController {
 	/**
 	 * Render image tags for the MediaGallery
 	 * @requestParam MediaTransformOutput thumb
-	 * @requestParam array options This is here for consistancy, it's not used yet
+	 * @requestParam array options This is here for consistency, it's not used yet
 	 */
 	public function gallery() {
 		$this->mediaType = 'image';


### PR DESCRIPTION
...ting gallery image

There have been instances of the following fatal being thrown: PHP Fatal error:  Call to a member function getTitle() on a non-object in /usr/wikia/slot1/2618/src/extensions/wikia/Thumbnails/ThumbnailController.class.php on line 99

Make sure the $thumb object being passed to this controller is a ThumbnailImage and that it has a corresponding $File object. If not, log the error so we can investigate down the line.

Ticket: https://wikia-inc.atlassian.net/browse/VID-2143
