### PR TITLE
insert-surface-fix: Change where the surface is inserted

### DIFF
--- a/extensions/VisualEditor/modules/ve-mw/init/ve.init.mw.Target.js
+++ b/extensions/VisualEditor/modules/ve-mw/init/ve.init.mw.Target.js
@@ -1345,7 +1345,7 @@ ve.init.mw.Target.prototype.setupSurface = function ( doc, callback ) {
 				// Wikia change
 				// Was previously prepended:
 				// https://github.com/Wikia/app/commit/45982569ef4381319e238ef973c49f57f96caf72
-				target.$element.append( target.surface.$element );
+				target.surface.$element.insertBefore( '#mw-content-text' );
 				target.setupToolbar();
 				if ( ve.debug ) {
 					target.setupDebugBar();


### PR DESCRIPTION
Insert the surface just before the read-only content. This fixes the problem of article comments in Venus appearing above the surface, while still keeping the page title above it.
