### PR TITLE
(CE-1172) Fix Korean Wall namespace translation

### DIFF
--- a/extensions/wikia/Wall/Wall.namespaces.php
+++ b/extensions/wikia/Wall/Wall.namespaces.php
@@ -81,9 +81,9 @@ $namespaces['ja'] = array(
  * Korean (한국어)
  */
 $namespaces['ko'] = array(
-	NS_USER_WALL			=> '메시지 담벼락',
+	NS_USER_WALL			=> '메시지_담벼락',
 	NS_USER_WALL_MESSAGE		=> '게시글',
-	NS_USER_WALL_MESSAGE_GREETING	=> '메시지 담벼락 환영',
+	NS_USER_WALL_MESSAGE_GREETING	=> '메시지_담벼락_환영',
 );
 
 /**


### PR DESCRIPTION
Fix Korean Wall namespace translation. Namespace aliases need to have
underscores instead of spaces.
