### PR TITLE
[MON] MON-286 create cache key with ALL country instead of ROW

### DIFF
--- a/extensions/wikia/MonetizationModule/MonetizationModuleHelper.class.php
+++ b/extensions/wikia/MonetizationModule/MonetizationModuleHelper.class.php
@@ -208,7 +208,7 @@ class MonetizationModuleHelper extends WikiaModel {
 	 * @return string
 	 */
 	public function getMemcKey( $params ) {
-		$geo = empty( $params['geo'] ) ? 'ROW' : $params['geo'];
+		$geo = empty( $params['geo'] ) ? 'ALL' : $params['geo'];
 		$memcKey = wfMemcKey( 'monetization_module', $params['cache'], $geo, $params['max'] );
 		return $memcKey;
 	}


### PR DESCRIPTION
We've change the monetization service to use 'ALL' as a catch-all country code instead of 'ROW'.  Update the cache key accordingly.

@saipetch, @jogura 
