### PR TITLE
VE-1713: Allow toolbar menus to go outside article

### DIFF
--- a/extensions/wikia/Venus/styles/article/article.scss
+++ b/extensions/wikia/Venus/styles/article/article.scss
@@ -21,6 +21,11 @@ $header-without-cover-unit-spacing: 60px;
 	display: none !important;
 }
 
+// Allow VisualEditor toolbar menus to go outside of article area
+.ve .article {
+	overflow: visible;
+}
+
 .article {
 	overflow: hidden;
 


### PR DESCRIPTION
Setting overflow to visible on the .article element in Venus when in VE.
