### PR TITLE
VE-1685: VisualEditor entry points in Venus

### DIFF
--- a/extensions/VisualEditor/VisualEditor.php
+++ b/extensions/VisualEditor/VisualEditor.php
@@ -55,7 +55,7 @@ $wgAPIModules['visualeditoredit'] = 'ApiVisualEditorEdit';
 
 // Register Hooks
 $wgHooks['BeforePageDisplay'][] = 'VisualEditorHooks::onBeforePageDisplay';
-$wgHooks['DoEditSectionLink'][] = 'VisualEditorHooks::onDoEditSectionLink';
+//$wgHooks['DoEditSectionLink'][] = 'VisualEditorHooks::onDoEditSectionLink';
 $wgHooks['GetBetaFeaturePreferences'][] = 'VisualEditorHooks::onGetBetaPreferences';
 $wgHooks['GetPreferences'][] = 'VisualEditorHooks::onGetPreferences';
 $wgHooks['ListDefinedTags'][] = 'VisualEditorHooks::onListDefinedTags';

--- a/extensions/VisualEditor/VisualEditor.php
+++ b/extensions/VisualEditor/VisualEditor.php
@@ -1262,9 +1262,6 @@ $wgVisualEditorNamespaces = array_merge( $wgContentNamespaces, array( NS_USER ) 
 // Whether to enable the (experimental for now) TOC widget
 $wgVisualEditorEnableTocWidget = false;
 
-// List of skins VisualEditor integration supports
-$wgVisualEditorSupportedSkins = array( 'oasis', 'venus' );
-
 // List of browsers VisualEditor is incompatibe with
 // See jQuery.client for specification
 $wgVisualEditorBrowserBlacklist = array(

--- a/extensions/wikia/ArticleNavigation/ArticleNavigationController.class.php
+++ b/extensions/wikia/ArticleNavigation/ArticleNavigationController.class.php
@@ -83,7 +83,8 @@ class ArticleNavigationController extends WikiaController {
 				$data = [
 					'href' => $contentAction['href'],
 					'title' => $contentAction['text'],
-					'trackingId' => $contentAction['id']
+					'id' => $contentAction['id'],
+					'accesskey' => $contentAction['accesskey']
 				];
 
 				if ( $wgUser->isAnon() &&

--- a/extensions/wikia/EditorPreference/EditorPreference.class.php
+++ b/extensions/wikia/EditorPreference/EditorPreference.class.php
@@ -173,8 +173,8 @@ class EditorPreference {
 	 * @return boolean
 	 */
 	public static function shouldShowVisualEditorLink( $skin ) {
-		global $wgTitle, $wgEnableVisualEditorExt, $wgVisualEditorNamespaces, $wgUser;
-		return $skin->getSkinName() === 'oasis' &&
+		global $wgTitle, $wgEnableVisualEditorExt, $wgVisualEditorNamespaces, $wgVisualEditorSupportedSkins, $wgUser;
+		return in_array( $skin->getSkinName(), $wgVisualEditorSupportedSkins ) &&
 			!$wgUser->isBlockedFrom( $wgTitle ) &&
 			!$wgTitle->isRedirect() &&
 			$wgEnableVisualEditorExt &&

--- a/resources/wikia/ui_components/dropdown_navigation/templates/dropdownItem.mustache
+++ b/resources/wikia/ui_components/dropdown_navigation/templates/dropdownItem.mustache
@@ -1,6 +1,8 @@
 <li {{#referenceId}}data-id="{{referenceId}}" {{/referenceId}} class="wikia-dropdown-nav-item">
 	<a href="{{href}}" title="{{#tooltip}}{{tooltip}}{{/tooltip}}{{^tooltip}}{{title}}{{/tooltip}}"
-		{{#trackingId}}data-tracking-id="{{trackingId}}" {{/trackingId}}
+		{{#accesskey}}accesskey="{{accesskey}}" {{/accesskey}}
+		{{#id}}id="{{id}}" {{/id}}
+		{{#id}}data-tracking-id="{{id}}" {{/id}}
 		rel="{{#rel}}{{rel}}{{/rel}}{{^rel}}nofollow{{/rel}}"
 		{{#dataAttr}}
 			data-{{key}}="{{value}}"


### PR DESCRIPTION
Do not mess up Venus edit section links by removing subscrption to DoEditSectionLink MediaWiki hook. It might look like it would hurt Oasis but it wouldn't - cause Oasis was overwriting output of that hook anyways in skins/oasis/modules/ContentDisplayController.class.php. The "bonus" of this change is that now we won't be doing that not necessary processing for Oasis.

https://wikia-inc.atlassian.net/browse/VE-1685
