### PR TITLE
CON-1160: NavigationModel - vary memcache key by user lang and content lang

### DIFF
--- a/includes/wikia/models/NavigationModel.class.php
+++ b/includes/wikia/models/NavigationModel.class.php
@@ -320,6 +320,10 @@ class NavigationModel extends WikiaModel {
 		$this->forContent = $forContent;
 
 		$cacheKey = $this->getMemcKey( $source );
+		if ( $forContent === false) {
+			$cacheKey .= ':forUserLang';
+		}
+
 		$nodes = $this->wg->Memc->get( $cacheKey );
 
 		if ( empty( $nodes ) ) {


### PR DESCRIPTION
Memcache key used to be shared between calls to `NavigationModel::parse` with `$forContent` being set and not.
