### PR TITLE
Uc 165 fixing unit tests

### DIFF
--- a/extensions/wikia/UserLogin/UserSignupSpecialController.class.php
+++ b/extensions/wikia/UserLogin/UserSignupSpecialController.class.php
@@ -465,6 +465,7 @@ class UserSignupSpecialController extends WikiaSpecialPageController {
 					$abortError,
 					'email'
 				);
+				// FIXME: unreachable
 				$phalanxValid = false;
 			}
 			return $phalanxValid;

--- a/extensions/wikia/UserLogin/tests/UserSignupTest.php
+++ b/extensions/wikia/UserLogin/tests/UserSignupTest.php
@@ -69,16 +69,16 @@
 			$objectName = 'ExternalUser_Wikia';
 			$mockObject = true;
 
-			$mockExternalUser = $this->getMock($objectName, ['initFromName', 'getLocalUser', 'getId'], [], '', false);;
+			$mockExternalUser = $this->getMock( $objectName, ['initFromName', 'getLocalUser', 'getId'], [], '', false );
 
 			$mockExternalUser->expects( $this->any() )->method( 'initFromName' )
-				->willReturn($mockObject);
+				->willReturn( $mockObject );
 			$mockExternalUser->expects( $this->any() )->method( 'getLocalUser' )
-				->willReturn($mockObject);
+				->willReturn( $mockObject );
 			$mockExternalUser->expects( $this->any() )->method( 'getId' )
-				->willReturn((isset($objectParams['params']['mId']) ? $objectParams['params']['mId'] : 0));
+				->willReturn( ( isset($objectParams['params']['mId'] ) ? $objectParams['params']['mId'] : 0 ) );
 
-			if ( !is_null($mockUserLoginFormParams) ) {
+			if ( !is_null( $mockUserLoginFormParams ) ) {
 				$this->setUpMockObject( 'UserLoginForm', $mockUserLoginFormParams, true, null, array(), false );
 			}
 

--- a/extensions/wikia/UserLogin/tests/UserSignupTest.php
+++ b/extensions/wikia/UserLogin/tests/UserSignupTest.php
@@ -28,7 +28,8 @@
 
 			$this->setUpMockObject( 'stdClass', $memcParams, false, 'wgMemc' );
 
-			$this->mockGlobalVariable('wgCityId', self::TEST_CITY_ID);
+			$this->mockGlobalVariable( 'wgCityId', self::TEST_CITY_ID );
+			$this->mockGlobalVariable( 'wgAntiSpoofAccounts', false );
 
 			// "mock" IP
 			$this->originalServer = $_SERVER;


### PR DESCRIPTION
Now that antispoof is enabled on dev, it's calling out a conflict with and existing user `W1K1AU5ER`. Since Antispoof should have it's own unit tests, and this isn't an integration test, I'm disabling these checks for the sake of this unit test. 
