### PR TITLE
VE-1721: Load sequence

### DIFF
--- a/extensions/VisualEditor/modules/ve-mw/init/ve.init.mw.Target.js
+++ b/extensions/VisualEditor/modules/ve-mw/init/ve.init.mw.Target.js
@@ -1345,7 +1345,7 @@ ve.init.mw.Target.prototype.setupSurface = function ( doc, callback ) {
 				// Wikia change
 				// Was previously prepended:
 				// https://github.com/Wikia/app/commit/45982569ef4381319e238ef973c49f57f96caf72
-				target.surface.$element.insertBefore( '#mw-content-text' );
+				target.surface.$element.insertAfter( '#mw-content-text' );
 				target.setupToolbar();
 				if ( ve.debug ) {
 					target.setupDebugBar();


### PR DESCRIPTION
For a split second, both the surface and the read-only content is visible on the screen. A change to insert the surface just before the read-only content was done recently to prevent article comments from rendering above the surface (surface was previously appended to the article wrapper). 

This change moves the surface to just after the read-only content so that it still appears between the page title and article comments but won't have a negative effect on the animation sequence.
