### PR TITLE
CON-2280 fixing paddings and margins around article comments

### DIFF
--- a/extensions/wikia/Venus/styles/article/comments.scss
+++ b/extensions/wikia/Venus/styles/article/comments.scss
@@ -243,13 +243,17 @@
 		a {
 			display: inline-block;
 			font-weight: bold;
-			line-height: 50px;
+			line-height: 40px;
+			padding-left: 70px;
+			position: relative;
 		}
 	}
 
 	.avatar {
 		border-radius: 25px;
+		left: 0;
 		margin: 0 10px;
+		position: absolute;
 		vertical-align: middle;
 	}
 

--- a/extensions/wikia/Venus/styles/article/comments.scss
+++ b/extensions/wikia/Venus/styles/article/comments.scss
@@ -252,7 +252,6 @@
 	.avatar {
 		border-radius: 25px;
 		left: 0;
-		margin: 0 10px;
 		position: absolute;
 		vertical-align: middle;
 	}


### PR DESCRIPTION
small CSS changes to the article comments layout described in the article redesign spec.
