### PR TITLE
PLATFORM-615: Use WikiaDataAccess when getting list of hidden categories in DataFeedProvider

### DIFF
--- a/extensions/wikia/MyHome/data/DataFeedProvider.php
+++ b/extensions/wikia/MyHome/data/DataFeedProvider.php
@@ -280,11 +280,12 @@ class DataFeedProvider {
 	 */
 	private function getHiddenCategories() {
 		wfProfileIn(__METHOD__);
+		$fname = __METHOD__;
 		if (!is_array(self::$hiddenCategories)) {
-			self::$hiddenCategories = WikiaDataAccess::cacheWithLock('hidden-categories-v2',60*60,
-				function(){
+			self::$hiddenCategories = WikiaDataAccess::cacheWithLock(wfMemcKey('hidden-categories-v2'),60*60,
+				function() use ($fname) {
 					$dbr = wfGetDB(DB_SLAVE);
-					$res = $dbr->query("SELECT sql_no_cache page_title FROM page JOIN page_props ON page_id=pp_page AND pp_propname='hiddencat';");
+					$res = $dbr->query("SELECT page_title FROM page JOIN page_props ON page_id=pp_page AND pp_propname='hiddencat';",$fname);
 					$hiddenCategories = array();
 					while($row = $dbr->fetchObject($res)) {
 						$hiddenCategories[] = $row->page_title;

--- a/extensions/wikia/MyHome/data/DataFeedProvider.php
+++ b/extensions/wikia/MyHome/data/DataFeedProvider.php
@@ -269,12 +269,12 @@ class DataFeedProvider {
 	}
 
 	/**
-	 * Get a full list of hidden categories cached using WikiaDataAccess. This method returns stalled data while
-	 * the first one is generating a fresh version of the list so there should be no delay if the outdated
-	 * version is still in cache. On the other hand if the data is not present in memcached only one process
-	 * is generating the data.
+	 * Get list of hidden categories (cached in memcached using WikiaDataAccess).
 	 *
-	 * WikiaDataAccess has this advantage over WikiaSQL that it returns stalled data and odes not introduce a delay.
+	 * Using WikiaDataAccess to limit number of processes regenerating cache and prevent delay when other
+	 * process is already regenerating data. The stalled data is returned in the latter case.
+	 *
+	 * @see https://wikia-inc.atlassian.net/browse/PLATFORM-615
 	 *
 	 * @return array
 	 */


### PR DESCRIPTION
Use WikiaDataAccess to limit number of concurrent processes generating the hidden categories list. WikiaDataAccess returns stalled data for up to another cache TTL if some other process is generating 
the fresh version of data

https://wikia-inc.atlassian.net/browse/PLATFORM-615

/cc @macbre @owend 
