### PR TITLE
MWEB-1086 Fixed PHP fatal error

### DIFF
--- a/extensions/wikia/WikiaMaps/controllers/WikiaMapsPoiController.class.php
+++ b/extensions/wikia/WikiaMaps/controllers/WikiaMapsPoiController.class.php
@@ -219,10 +219,11 @@ class WikiaMapsPoiController extends WikiaMapsBaseController {
 	 * @return bool
 	 */
 	public function isValidArticleTitle() {
-		$articleTitle = $this->getData( 'articleTitleOrExternalUrl' );
+		$articleTitleText = $this->getData( 'articleTitleOrExternalUrl' );
+		$articleTitle = Title::newFromText( $articleTitleText );
 		$valid = false;
 
-		if ( ( !empty( $articleTitle ) && Title::newFromText( $articleTitle )->exists() ) || empty( $articleTitle ) ) {
+		if ( ( !empty( $articleTitle ) && $articleTitle->exists() ) || empty( $articleTitleText ) ) {
 			$valid = true;
 		}
 

--- a/extensions/wikia/WikiaMaps/tests/WikiaMapsPoiControllerTest.php
+++ b/extensions/wikia/WikiaMaps/tests/WikiaMapsPoiControllerTest.php
@@ -113,6 +113,20 @@ class WikiaMapsPoiControllerTest extends WikiaBaseTest {
 				'expected' => true,
 			],
 			[
+				'not empty, valid URL - HTML5 URL encoded',
+				'urlMock' => 'http://www.wikia.com/%D0%A1%D0%BB%D1%83%D0%B6%D0%B5%D0%B1%D0%BD%D0%B0%D1%8F',
+				'isValidCalledTimes' => 'once',
+				'isValidMock' => true,
+				'expected' => true,
+			],
+			[
+				'not empty, valid URL with UTF8 characters',
+				'urlMock' => 'http://www.wikia.com/Служебная',
+				'isValidCalledTimes' => 'once',
+				'isValidMock' => true,
+				'expected' => true,
+			],
+			[
 				'not empty and invalid URL',
 				'urlMock' => 'This is not an URL',
 				'isValidCalledTimes' => 'once',


### PR DESCRIPTION
When passing HTML encoded URL like `http://www.wikia.com/%D0%A1%D0%BB%D1%83%D0%B6%D0%B5%D0%B1%D0%BD%D0%B0%D1%8F` to `isValidArticleTitle`, a `Title` istance isn't being created which casued PHP fatal error in `WikiaMapsPoiController` and makes our users refresh the page since it's freezed with loading throbber.

Changes below fixes it. I also added two more test cases for similar functionality.
