### PR TITLE
use $image->getUrlGenerator()

### DIFF
--- a/extensions/wikia/ImageServing/imageServing.class.php
+++ b/extensions/wikia/ImageServing/imageServing.class.php
@@ -304,7 +304,7 @@ class ImageServing {
 	}
 
 	/**
-	 * @param File $image
+	 * @param File|GlobalFile $image
 	 * @param $width
 	 * @param $height
 	 * @return string
@@ -312,7 +312,7 @@ class ImageServing {
 	private function getVignetteUrl($image, $width, $height) {
 		list($top, $right, $bottom, $left) = $this->getCutParams($width, $height);
 
-		return VignetteRequest::fromFile($image)
+		return $image->getUrlGenerator()
 			->windowCrop()
 			->width($this->width)
 			->xOffset($left)

--- a/includes/wikia/GlobalFile.class.php
+++ b/includes/wikia/GlobalFile.class.php
@@ -177,7 +177,7 @@ class GlobalFile extends WikiaObject {
 	}
 
 	/**
-	 * @return UrlGenerator object
+	 * @return \Wikia\Vignette\UrlGenerator object
 	 */
 	public function getUrlGenerator() {
 		return VignetteRequest::fromGlobalFile( $this );


### PR DESCRIPTION
@Wikia/platform-team 
https://wikia-inc.atlassian.net/browse/PLATFORM-634

Both `File` and  `GlobalFile` have a `getUrlGenerator` function, so let's use that to patch this fatal.
