### PR TITLE
VID-2138 Update VideosModule::getWikiRelatedVideosTopics to use AsyncCache

### DIFF
--- a/extensions/wikia/VideosModule/VideosModule.class.php
+++ b/extensions/wikia/VideosModule/VideosModule.class.php
@@ -168,7 +168,7 @@ class VideosModule extends WikiaModel {
 	}
 
 	/**
-	 * Static function which is used as an entrypoint for AsyncCache. If AsyncCache can't find
+	 * Static method which is used as an entry point for AsyncCache. If AsyncCache can't find
 	 * the value it wants in cache, or if that value is stale, a job will be created which requires
 	 * a callback function. This static method serves as that callback function.
 	 * @param $userRegion
@@ -205,7 +205,6 @@ class VideosModule extends WikiaModel {
 			$this->addToList( $videos, $video, self::SOURCE_WIKI_TOPICS );
 		}
 
-		$videos = [];
 		if ( empty( $videos ) ) {
 			$msg = "No videos found for wiki {$this->wg->Sitename}";
 			$this->log->info( __METHOD__ . " " . $msg );

--- a/extensions/wikia/VideosModule/VideosModule.class.php
+++ b/extensions/wikia/VideosModule/VideosModule.class.php
@@ -149,15 +149,6 @@ class VideosModule extends WikiaModel {
 	 * @return array
 	 */
 	public function getVideosRelatedToWiki() {
-		$videos = $this->getVideosFromAsyncCache();
-		return $videos;
-	}
-
-	/**
-	 * Get videos related to wiki from AsyncCache.
-	 * @return array
-	 */
-	public function getVideosFromAsyncCache() {
 		$memcKey = wfMemcKey( 'videomodule', 'wiki_related_videos_topics', self::CACHE_VERSION, $this->userRegion );
 		$asynCache = ( new Wikia\Cache\AsyncCache() )
 			->key( $memcKey )

--- a/extensions/wikia/VideosModule/VideosModule.class.php
+++ b/extensions/wikia/VideosModule/VideosModule.class.php
@@ -147,7 +147,7 @@ class VideosModule extends WikiaModel {
 	 * @param integer $numRequired - number of videos required
 	 * @return array - Premium videos related to the local wiki.
 	 */
-	public function getWikiRelatedVideosTopics( $numRequired ) {
+	public function getVideosRelatedToWiki( $numRequired ) {
 		wfProfileIn( __METHOD__ );
 		$log = WikiaLogger::instance();
 

--- a/extensions/wikia/VideosModule/VideosModule.class.php
+++ b/extensions/wikia/VideosModule/VideosModule.class.php
@@ -104,7 +104,6 @@ class VideosModule extends WikiaModel {
 	 */
 	public function getLocalVideos( $numRequired, $sort ) {
 		wfProfileIn( __METHOD__ );
-		$this->log = WikiaLogger::instance();
 
 		$memcKey = wfMemcKey( 'videomodule', 'local_videos', self::CACHE_VERSION, $sort, $this->userRegion );
 		$videos = $this->wg->Memc->get( $memcKey );
@@ -154,7 +153,7 @@ class VideosModule extends WikiaModel {
 			->key( $memcKey )
 			->ttl( self::CACHE_TTL )
 			->negativeResponseTTL( self::NEGATIVE_CACHE_TTL )
-			->callback( 'VideosModule::getVideosRelatedToWikiStatically' )
+			->callback( 'VideosModule::getVideosRelatedToWikiCallback' )
 			->callbackParams( [ $this->userRegion ] );
 
 		if ( $asynCache->foundInCache() ) {
@@ -174,7 +173,7 @@ class VideosModule extends WikiaModel {
 	 * @param $userRegion
 	 * @return array
 	 */
-	public static function getVideosRelatedToWikiStatically( $userRegion ) {
+	public static function getVideosRelatedToWikiCallback( $userRegion ) {
 		$module = new self( $userRegion );
 		$videos = $module->getVideosRelatedToWikiFromSearch();
 		return $videos;
@@ -208,7 +207,7 @@ class VideosModule extends WikiaModel {
 		if ( empty( $videos ) ) {
 			$msg = "No videos found for wiki {$this->wg->Sitename}";
 			$this->log->info( __METHOD__ . " " . $msg );
-			// Caught by AsyncCache task which then using negative cache TTL
+			// Caught by AsyncCache task which then uses negative cache TTL
 			throw new Wikia\Cache\NegativeResponseException( $msg );
 		}
 

--- a/extensions/wikia/VideosModule/VideosModule.class.php
+++ b/extensions/wikia/VideosModule/VideosModule.class.php
@@ -142,11 +142,19 @@ class VideosModule extends WikiaModel {
 		return $videos;
 	}
 
+	/**
+	 * Get premium videos related to the local wiki.
+	 * @return array
+	 */
 	public function getVideosRelatedToWiki() {
 		$videos = $this->getVideosFromAsyncCache();
 		return $videos;
 	}
 
+	/**
+	 * Get videos related to wiki from AsyncCache.
+	 * @return array
+	 */
 	public function getVideosFromAsyncCache() {
 		$memcKey = wfMemcKey( 'videomodule', 'wiki_related_videos_topics', self::CACHE_VERSION, $this->userRegion );
 		$videos = ( new Wikia\Cache\AsyncCache() )
@@ -159,6 +167,13 @@ class VideosModule extends WikiaModel {
 		return $videos;
 	}
 
+	/**
+	 * Static function which is used as an entrypoint for AsyncCache. If AsyncCache can't find
+	 * the value it wants in cache, or if that value is stale, a job will be created which requires
+	 * a callback function. This static method serves as that callback function.
+	 * @param $userRegion
+	 * @return array
+	 */
 	public static function getVideosRelatedToWikiStatically( $userRegion ) {
 		$module = new self( $userRegion );
 		$videos = $module->getVideosRelatedToWikiFromSearch();

--- a/extensions/wikia/VideosModule/VideosModuleController.class.php
+++ b/extensions/wikia/VideosModule/VideosModuleController.class.php
@@ -26,7 +26,7 @@ class VideosModuleController extends WikiaController {
 		}
 
 		$this->response->setData( [
-			'title'	 => wfMessage( 'videosmodule-title-default' )->plain(),
+			'title'	 => wfMessage( 'videosmodule-title-default' )->escaped(),
 			'videos' => $videos,
 			'staffVideos' => $staffVideos
 		] );

--- a/extensions/wikia/VideosModule/VideosModuleController.class.php
+++ b/extensions/wikia/VideosModule/VideosModuleController.class.php
@@ -36,7 +36,7 @@ class VideosModuleController extends WikiaController {
 		} elseif ( !empty( $this->wg->VideosModuleCategories )  ) {
 			$videos = $module->getVideosByCategory();
 		} else {
-			$videos = $module->getWikiRelatedVideosTopics( $numRequired );
+			$videos = $module->getVideosRelatedToWiki( $numRequired );
 		}
 
 		$this->result = "ok";

--- a/extensions/wikia/VideosModule/VideosModuleController.class.php
+++ b/extensions/wikia/VideosModule/VideosModuleController.class.php
@@ -32,11 +32,11 @@ class VideosModuleController extends WikiaController {
 			$videos = $module->getVideosRelatedToWiki();
 		}
 
-		$this->title = wfMessage( 'videosmodule-title-default' )->plain();
-		$this->result = "ok";
-		$this->msg = '';
-		$this->videos = $videos;
-		$this->staffVideos = $staffVideos;
+		$this->response->setData( [
+			'title'	 => wfMessage( 'videosmodule-title-default' )->plain(),
+			'videos' => $videos,
+			'staffVideos' => $staffVideos
+		] );
 
 		// set cache
 		$this->response->setCacheValidity( VideosModule::CACHE_TTL );

--- a/extensions/wikia/VideosModule/VideosModuleController.class.php
+++ b/extensions/wikia/VideosModule/VideosModuleController.class.php
@@ -5,18 +5,11 @@ class VideosModuleController extends WikiaController {
 
 	/**
 	 * VideosModule
-	 * Returns videos to populate the Videos Module. First check if
-	 * local videos are being requested from the front-end (this is not
-	 * yet in use but will be used for A/B testing down the line). If not,
-	 * check if there are categories associated with this wiki for the
-	 * Videos Module and pull premium videos from those categories. Finally, if
-	 * neither of those first conditions are true, search for premium
-	 * videos related to the wiki.
-	 * @requestParam integer limit - number of videos shown in the module
-	 * @requestParam string local [true/false] - show local content
-	 * @requestParam string sort [recent/trend] - how to sort the results
-	 * @responseParam string $result [ok/error]
-	 * @responseParam string $msg - result message
+	 * Returns videos to populate the Videos Module. First check if there are
+	 * categories associated with this wiki for the Videos Module and pull
+	 * premium videos from those categories. Finally, if neither of those
+	 * first conditions are true, search for premium videos related to the wiki.
+	 * @responseParam string $title - i18nized title of the videos module
 	 * @responseParam array $videos - list of videos
 	 * @responseParam array $staffVideos - list of staff picked videos
 	 */

--- a/extensions/wikia/VideosModule/VideosModuleController.class.php
+++ b/extensions/wikia/VideosModule/VideosModuleController.class.php
@@ -23,22 +23,16 @@ class VideosModuleController extends WikiaController {
 	public function index() {
 		wfProfileIn( __METHOD__ );
 
-		$this->title = wfMessage( 'videosmodule-title-default' )->plain();
-		$numRequired = $this->request->getVal( 'limit', VideosModule::LIMIT_VIDEOS );
-		$localContent = ( $this->request->getVal( 'local' ) == 'true' );
-		$sort = $this->request->getVal( 'sort', 'trend' );
 		$userRegion = $this->request->getVal( 'userRegion', VideosModule::DEFAULT_REGION );
-
 		$module = new VideosModule( $userRegion );
 		$staffVideos = $module->getStaffPicks();
-		if ( $localContent ) {
-			$videos = $module->getLocalVideos( $numRequired, $sort );
-		} elseif ( !empty( $this->wg->VideosModuleCategories )  ) {
+		if ( !empty( $this->wg->VideosModuleCategories )  ) {
 			$videos = $module->getVideosByCategory();
 		} else {
-			$videos = $module->getVideosRelatedToWiki( $numRequired );
+			$videos = $module->getVideosRelatedToWiki();
 		}
 
+		$this->title = wfMessage( 'videosmodule-title-default' )->plain();
 		$this->result = "ok";
 		$this->msg = '';
 		$this->videos = $videos;


### PR DESCRIPTION
As part of our ongoing performance monitoring, we identified VideosModule::getWikiRelatedVideosTopics as a candidate for improving. After some initial investigation, we determined that implementing the caching for that method using the new AsynCache library would increase our cache hits and help bring down the average response time. This ticket is implementing that change.

Jira ticket: https://wikia-inc.atlassian.net/browse/VID-2138
