### PR TITLE
VE-1722: Remove bottom margin from paragraph in loading indicator

### DIFF
--- a/extensions/wikia/Venus/styles/visualeditor.scss
+++ b/extensions/wikia/Venus/styles/visualeditor.scss
@@ -12,3 +12,9 @@
 	transition: opacity .5s ease-in-out;
 	z-index: $zTop;
 }
+
+.ve-spinner {
+	.message {
+		margin: 0;
+	}
+}


### PR DESCRIPTION
Venus' CSS reset does not normalize paragraph margins. This selectively fixes the margin for the paragraph in the loading indicator.
