### PR TITLE
CON-2328: DataMartService: add a fallback when replication does not work

### DIFF
--- a/includes/wikia/api/ArticlesApiController.class.php
+++ b/includes/wikia/api/ArticlesApiController.class.php
@@ -160,20 +160,6 @@ class ArticlesApiController extends WikiaApiController {
 			self::MAX_ITEMS + 1 //compensation for Main Page
 		);
 
-		if ( empty( $articles ) ) {
-			$fallbackDate = DataMartService::findLastRollupsDate( DataMartService::PERIOD_ID_WEEKLY );
-			if ( $fallbackDate ) {
-				$articles = DataMartService::getTopArticlesByPageview(
-					$this->wg->CityId,
-					$ids,
-					$namespaces,
-					false,
-					self::MAX_ITEMS + 1, //compensation for Main Page
-					$fallbackDate
-				);
-			}
-		}
-
 		$collection = [];
 
 		if ( !empty( $articles ) ) {

--- a/includes/wikia/api/Recommendations/Collector.class.php
+++ b/includes/wikia/api/Recommendations/Collector.class.php
@@ -4,7 +4,7 @@ namespace Wikia\Api\Recommendations;
 
 /**
  * Recommendations API data collector
- * @author Maciej Brench <macbre@wikia-inc.com>
+ * @author Maciej Brencz <macbre@wikia-inc.com>
  * @author Damian Jozwiak <damian@wikia-inc.com>
  * @author Łukasz Konieczny <lukaszk@wikia-inc.com>
  *
@@ -28,6 +28,7 @@ class Collector {
 				$currentLimit = $limit - count( $out );
 			}
 
+			wfDebug( sprintf("%s: calling %s to get %d items...\n", __METHOD__, get_class($dataProvider), $currentLimit ) );
 			$out = array_merge( $out, $dataProvider->get($articleId, $currentLimit ) );
 		}
 
@@ -39,7 +40,7 @@ class Collector {
 	/**
 	 * Get instances of all available data providers
 	 *
-	 * @return array
+	 * @return \Wikia\Api\Recommendations\DataProviders\IDataProvider[]
 	 */
 	protected function getDataProviders() {
 		return [

--- a/includes/wikia/api/Recommendations/DataProviders/Category.class.php
+++ b/includes/wikia/api/Recommendations/DataProviders/Category.class.php
@@ -3,7 +3,7 @@ namespace Wikia\Api\Recommendations\DataProviders;
 
 /**
  * Category based recommendations for RecommendationsApi
- * @author Maciej Brench <macbre@wikia-inc.com>
+ * @author Maciej Brencz <macbre@wikia-inc.com>
  * @author Damian Jozwiak <damian@wikia-inc.com>
  * @author Łukasz Konieczny <lukaszk@wikia-inc.com>
  *

--- a/includes/wikia/api/Recommendations/DataProviders/TopArticles.class.php
+++ b/includes/wikia/api/Recommendations/DataProviders/TopArticles.class.php
@@ -9,7 +9,7 @@ namespace Wikia\Api\Recommendations\DataProviders;
  *
  * Class TopArticles
  * @package Wikia\Api\Recommendations\DataProviders
- * @author Maciej Brench <macbre@wikia-inc.com>
+ * @author Maciej Brencz <macbre@wikia-inc.com>
  * @author Damian Jozwiak <damian@wikia-inc.com>
  * @author Łukasz Konieczny <lukaszk@wikia-inc.com>
  */
@@ -106,6 +106,8 @@ class TopArticles implements IDataProvider {
 				];
 			}
 		}
+
+		wfDebug( sprintf( "%s: returning %s items\n", __METHOD__, count($topArticles) ) );
 
 		wfProfileOut( __METHOD__ );
 		return $topArticles;

--- a/includes/wikia/api/Recommendations/DataProviders/Video.class.php
+++ b/includes/wikia/api/Recommendations/DataProviders/Video.class.php
@@ -3,7 +3,7 @@ namespace Wikia\Api\Recommendations\DataProviders;
 
 /**
  * Video recommendations for RecommendationsApi
- * @author Maciej Brench <macbre@wikia-inc.com>
+ * @author Maciej Brencz <macbre@wikia-inc.com>
  * @author Damian Jozwiak <damian@wikia-inc.com>
  * @author Łukasz Konieczny <lukaszk@wikia-inc.com>
  *
@@ -39,6 +39,9 @@ class Video implements IDataProvider {
 				$randomVideos = $this->getRandomRecommendations( $videos['videos'], $limit );
 				$recommendations = $this->prepareData( $randomVideos );
 			}
+		}
+		else {
+			wfDebug( __METHOD__ . ": \$wgEnableVideosModuleExt is set to false, no data returned!\n" );
 		}
 
 		return $recommendations;

--- a/includes/wikia/services/DataMartService.class.php
+++ b/includes/wikia/services/DataMartService.class.php
@@ -492,12 +492,13 @@ class DataMartService extends Service {
 	 *
 	 * @return Array The list, the key contains article ID's and each item as a "namespace_id" and "pageviews" key
 	 */
-	private static function doGetTopArticlesByPageview( $wikiId,
-	                                                 Array $articleIds = null,
-	                                                 Array $namespaces = null,
-	                                                 $excludeNamespaces = false,
-	                                                 $limit = 200,
-	                                                 $rollupDate = null
+	private static function doGetTopArticlesByPageview( 
+		$wikiId,
+                Array $articleIds = null,
+                Array $namespaces = null,
+                $excludeNamespaces = false,
+                $limit = 200,
+                $rollupDate = null
 	) {
 		$app = F::app();
 		wfProfileIn( __METHOD__ );
@@ -617,12 +618,13 @@ class DataMartService extends Service {
 	 *
 	 * @return Array The list, the key contains article ID's and each item as a "namespace_id" and "pageviews" key
 	 */
-	public static function getTopArticlesByPageview( $wikiId,
-													 Array $articleIds = null,
-													 Array $namespaces = null,
-													 $excludeNamespaces = false,
-													 $limit = 200,
-													 $rollupDate = null
+	public static function getTopArticlesByPageview( 
+		$wikiId,
+ 		Array $articleIds = null,
+		Array $namespaces = null,
+		$excludeNamespaces = false,
+		$limit = 200,
+		$rollupDate = null
 	) {
 		wfProfileIn( __METHOD__ );
 

--- a/includes/wikia/services/DataMartService.class.php
+++ b/includes/wikia/services/DataMartService.class.php
@@ -4,6 +4,7 @@
  */
 
 use FluentSql\StaticSQL as sql;
+use Wikia\Logger\WikiaLogger;
 
 class DataMartService extends Service {
 
@@ -487,10 +488,11 @@ class DataMartService extends Service {
 	 * @param Array $namespaces [OPTIONAL] A list of namespace ID's to restrict the list (inclusive)
 	 * @param boolean $excludeNamespaces [OPTIONAL] Sets $namespaces as an exclusive list, defaults to false
 	 * @param integer $limit [OPTIONAL] The maximum number of items in the list, defaults to 200
+	 * @param integer $rollupDate [OPTIONAL] Rollup ID to get (instead of the recent one)
 	 *
 	 * @return Array The list, the key contains article ID's and each item as a "namespace_id" and "pageviews" key
 	 */
-	public static function getTopArticlesByPageview( $wikiId,
+	private static function doGetTopArticlesByPageview( $wikiId,
 	                                                 Array $articleIds = null,
 	                                                 Array $namespaces = null,
 	                                                 $excludeNamespaces = false,
@@ -594,6 +596,67 @@ class DataMartService extends Service {
 		$topArticles = array_slice( $topArticles, 0, $limit, true );
 		wfProfileOut( __METHOD__ );
 		return $topArticles;
+	}
+
+	/**
+	 * Gets the list of top articles for a wiki on a weekly pageviews basis
+	 *
+	 * It internally calls doGetTopArticlesByPageview() method,
+	 * but applies a fallback to the last rollup when the current one is not replicated
+	 *
+	 * It's A Nasty And Ugly Hack (TM) before we have a proper rollups solution.
+	 *
+	 * @see https://wikia-inc.atlassian.net/browse/OPS-5465
+	 *
+	 * @param integer $wikiId A valid Wiki ID to fetch the list from
+	 * @param Array $articleIds [OPTIONAL] A list of article ID's to restrict the list
+	 * @param Array $namespaces [OPTIONAL] A list of namespace ID's to restrict the list (inclusive)
+	 * @param boolean $excludeNamespaces [OPTIONAL] Sets $namespaces as an exclusive list, defaults to false
+	 * @param integer $limit [OPTIONAL] The maximum number of items in the list, defaults to 200
+	 * @param integer $rollupDate [OPTIONAL] Rollup ID to get (instead of the recent one)
+	 *
+	 * @return Array The list, the key contains article ID's and each item as a "namespace_id" and "pageviews" key
+	 */
+	public static function getTopArticlesByPageview( $wikiId,
+													 Array $articleIds = null,
+													 Array $namespaces = null,
+													 $excludeNamespaces = false,
+													 $limit = 200,
+													 $rollupDate = null
+	) {
+		wfProfileIn( __METHOD__ );
+
+		$articles = self::doGetTopArticlesByPageview(
+			$wikiId,
+			$articleIds,
+			$namespaces,
+			$excludeNamespaces,
+			$limit,
+			$rollupDate
+		);
+
+		if ( empty( $articles ) ) {
+			// log when the fallback takes place
+			WikiaLogger::instance()->error( __METHOD__ . ' fallback', [
+				'wiki_id' => $wikiId,
+				'rollup_date' => $rollupDate
+			]);
+
+			$fallbackDate = self::findLastRollupsDate( self::PERIOD_ID_WEEKLY );
+			if ( $fallbackDate ) {
+				$articles = self::doGetTopArticlesByPageview(
+					$wikiId,
+					$articleIds,
+					$namespaces,
+					$excludeNamespaces,
+					$limit,
+					$fallbackDate
+				);
+			}
+		}
+
+		wfProfileOut( __METHOD__ );
+		return $articles;
 	}
 
 	/**


### PR DESCRIPTION
Hide `getTopArticlesByPageview` method behind a helper that performs a fallback to the last known rollup

A Nasty And Ugly Hack (TM) before we have a proper rollups solution.

@see https://wikia-inc.atlassian.net/browse/OPS-5465

@kvas-damian / @SebastianMarzjan / @drozdo 
