### PR TITLE
UC-122 fixing Global Notification when scrolled down the page

### DIFF
--- a/extensions/wikia/GlobalNotification/GlobalNotification.js
+++ b/extensions/wikia/GlobalNotification/GlobalNotification.js
@@ -29,8 +29,10 @@ var GlobalNotification = {
 			this.setUpClose();
 		}
 
-		// Float notification (BugId:33365)
-		this.wikiaHeaderHeight = $('#WikiaHeader').height();
+		this.pageContainer = $('.WikiaPageContentWrapper');
+		this.pageContainerElem = this.pageContainer[0];
+		this.wikiaHeader = $('#globalNavigation');
+		this.headerHeight = this.wikiaHeader.height();
 	},
 
 	/**
@@ -40,6 +42,7 @@ var GlobalNotification = {
 	 */
 	createDom: function (element, isModal) {
 		'use strict';
+
 		// create and store dom
 		if (!GlobalNotification.dom.length) {
 			GlobalNotification.dom = $('<div class="global-notification">' +
@@ -54,17 +57,13 @@ var GlobalNotification = {
 		if (element instanceof jQuery) {
 			element.prepend(GlobalNotification.dom).show();
 
-		// handle standard modal implementation
+		// handle modal implementations
 		} else if (isModal) {
 			GlobalNotification.modal.prepend(GlobalNotification.dom);
 
 		// handle non-modal implementation
 		} else {
-			if ($('.oasis-split-skin').length) {
-				$('.WikiaHeader').after(GlobalNotification.dom);
-			} else {
-				$('.WikiaPageContentWrapper').prepend(GlobalNotification.dom);
-			}
+			this.pageContainer.prepend(GlobalNotification.dom);
 		}
 
 		GlobalNotification.msg = GlobalNotification.dom.find('.msg');
@@ -165,19 +164,25 @@ var GlobalNotification = {
 	},
 
 	/**
-	 * Hack to share the scroll event with WikiaFooter.js
-	 * @param {number} scrollTop
+	 * Pin the notification to the top of the screen when scrolled down the page.
+	 * Shares the scroll event with WikiaFooter.js
 	 */
-	onScroll: function (scrollTop) {
+	onScroll: function () {
 		'use strict';
-		if (GlobalNotification.dom && GlobalNotification.dom.length) {
-			var minTop = GlobalNotification.wikiaHeaderHeight;
-			if (scrollTop > minTop) {
-				GlobalNotification.dom.addClass('float');
-			} else {
-				GlobalNotification.dom.removeClass('float');
-			}
 
+		var containerTop;
+
+		if (!GlobalNotification.dom || !GlobalNotification.dom.length) {
+			return;
+		}
+
+		// get the position of the wrapper element relative to the top of the viewport
+		containerTop = GlobalNotification.pageContainerElem.getBoundingClientRect().top;
+
+		if (containerTop < GlobalNotification.headerHeight) {
+			GlobalNotification.dom.addClass('float');
+		} else {
+			GlobalNotification.dom.removeClass('float');
 		}
 	}
 };
@@ -186,11 +191,3 @@ $(function () {
 	'use strict';
 	GlobalNotification.init();
 });
-
-// ajax failure notification event registration
-if (typeof wgAjaxFailureMsg !== 'undefined') {
-	$(document).ajaxError(function () {
-		'use strict';
-		GlobalNotification.show(window.wgAjaxFailureMsg, 'error');
-	});
-}

--- a/extensions/wikia/GlobalNotification/GlobalNotification.setup.php
+++ b/extensions/wikia/GlobalNotification/GlobalNotification.setup.php
@@ -1,9 +1,10 @@
 <?php
 
-/*
- *  GlobalNotifications controller lives here: /skins/oasis/modules/NotificationsController.class.php
- *  Css lives here: /skins/oasis/css/core/GlobalNotification.scss
- *  Docs are on internal in UI Style Guide
+/**
+ * Note: This file isn't actually included anywhere
+ * GlobalNotifications controller lives here: /skins/oasis/modules/NotificationsController.class.php
+ * Css lives here: /skins/oasis/css/core/GlobalNotification.scss
+ * Docs are on internal in UI Style Guide
  */
 
 $wgExtensionCredits['globalnotification'][] = array(
@@ -15,13 +16,3 @@ $wgExtensionCredits['globalnotification'][] = array(
 $dir = dirname(__FILE__) . '/';
 
 $wgExtensionMessagesFiles['GlobalNotification'] = $dir . 'GlobalNotification.i18n.php';
-
-// TODO: make this use JSMessages later instead of JSVar hook
-//JSMessages::registerPackage('GlobalNotification', array('globalnotification-*'));
-
-$wgHooks["MakeGlobalVariablesScript"][] = "wfGlobalNotificationJSVars";
-
-function wfGlobalNotificationJSVars(Array &$vars) {
-	$vars['wgAjaxFailureMsg'] = wfMsg('globalnotification-general-ajax-failure');
-	return true;
-}

--- a/skins/shared/styles/GlobalNotifications.scss
+++ b/skins/shared/styles/GlobalNotifications.scss
@@ -1,5 +1,7 @@
 @import 'skins/shared/color';
 @import 'skins/shared/mixins/box-shadow';
+@import 'extensions/wikia/Venus/styles/variables';
+
 
 .global-notification {
 	@include box-shadow(0, 2px, 5px, darken($color-page, 12%));
@@ -73,7 +75,7 @@
 		left: 50%;
 		margin-left: -489px;
 		position: fixed;
-		top: 0;
+		top: $global-navigation-height;
 	}
 
 	.msg {


### PR DESCRIPTION
After the release of the new Global Nav, the global notifications stopped scrolling along with the page. This fixes  that. 
