### PR TITLE
UC-152 Avatars cannot be uploaded on some wikias

### DIFF
--- a/extensions/wikia/UserProfilePageV3/UserProfilePageController.class.php
+++ b/extensions/wikia/UserProfilePageV3/UserProfilePageController.class.php
@@ -542,33 +542,32 @@ class UserProfilePageController extends WikiaController {
 
 		$this->response->setContentType( 'application/json; charset=utf-8' );
 
-		$user = User::newFromId($this->getVal('userId'));
+		$user = User::newFromId( $this->getVal( 'userId' ) );
 
-		$errorMsg = wfMsg('userprofilepage-interview-save-internal-error');
-		$result = array('success' => false, 'error' => $errorMsg);
+		$errorMsg = wfMessage( 'userprofilepage-interview-save-internal-error' )->escaped();
+		$result = [ 'success' => false, 'error' => $errorMsg ];
 
-		if (!$user->isAnon() && $this->request->wasPosted()) {
+		if ( !$user->isAnon() && $this->request->wasPosted() ) {
 			$avatarUploadFiled = 'UPPLightboxAvatar';
-			$uploadError = $this->app->wg->Request->getUploadError($avatarUploadFiled);
+			$uploadError = $this->app->wg->Request->getUploadError( $avatarUploadFiled );
 
-			if ($uploadError != 0) {
+			if ( $uploadError != 0 ) {
 				$thumbnail = $uploadError;
 			} else {
-				$fileName = $this->app->wg->Request->getFileTempName($avatarUploadFiled);
+				$fileName = $this->app->wg->Request->getFileTempName( $avatarUploadFiled );
 
 				$fileuploader = new WikiaTempFilesUpload();
 
-				$thumbnail = $this->storeInTempImage($fileName, $fileuploader);
+				$thumbnail = $this->storeInTempImage( $fileName, $fileuploader );
 			}
 
 			if ( false === $thumbnail || is_int( $thumbnail ) ) {
-				$result = array('success' => false, 'error' => $this->validateUpload($thumbnail));
-				$this->setVal('result', $result);
-				wfProfileOut(__METHOD__);
+				$result = [ 'success' => false, 'error' => $this->validateUpload( $thumbnail ) ];
+				$this->setVal( 'result', $result ) ;
 				return;
 			}
 
-			$this->setVal('result', $result);
+			$this->setVal( 'result', $result );
 
 			$avatarUrl = $thumbnail->url;
 			// look for an occurrence of a ? to know if we should append the query string with a ? or a &
@@ -577,14 +576,11 @@ class UserProfilePageController extends WikiaController {
 			$result = [ 'success' => true, 'avatar' => $avatarUrl ];
 			$this->setVal('result', $result);
 
-			wfProfileOut(__METHOD__);
 			return;
 		}
 
-		$result = array('success' => false, 'error' => $errorMsg);
-		$this->setVal('result', $result);
-		wfProfileOut(__METHOD__);
-		return;
+		$result = [ 'success' => false, 'error' => $errorMsg ];
+		$this->setVal( 'result', $result );
 	}
 
 	/**

--- a/extensions/wikia/UserProfilePageV3/UserProfilePageController.class.php
+++ b/extensions/wikia/UserProfilePageV3/UserProfilePageController.class.php
@@ -538,7 +538,6 @@ class UserProfilePageController extends WikiaController {
 	 * @author Andrzej 'nAndy' Łukaszewski
 	 */
 	public function onSubmitUsersAvatar() {
-		wfProfileIn(__METHOD__);
 
 		$this->response->setContentType( 'application/json; charset=utf-8' );
 

--- a/extensions/wikia/UserProfilePageV3/UserProfilePageController.class.php
+++ b/extensions/wikia/UserProfilePageV3/UserProfilePageController.class.php
@@ -539,7 +539,7 @@ class UserProfilePageController extends WikiaController {
 	 */
 	public function onSubmitUsersAvatar() {
 
-		$this->response->setContentType( 'application/json; charset=utf-8' );
+		$this->response->setContentType( 'text/html; charset=utf-8' );
 
 		$user = User::newFromId( $this->getVal( 'userId' ) );
 
@@ -554,9 +554,7 @@ class UserProfilePageController extends WikiaController {
 				$thumbnail = $uploadError;
 			} else {
 				$fileName = $this->app->wg->Request->getFileTempName( $avatarUploadFiled );
-
 				$fileuploader = new WikiaTempFilesUpload();
-
 				$thumbnail = $this->storeInTempImage( $fileName, $fileuploader );
 			}
 

--- a/extensions/wikia/UserProfilePageV3/UserProfilePageController.class.php
+++ b/extensions/wikia/UserProfilePageV3/UserProfilePageController.class.php
@@ -540,7 +540,7 @@ class UserProfilePageController extends WikiaController {
 	public function onSubmitUsersAvatar() {
 		wfProfileIn(__METHOD__);
 
-		$this->response->setContentType('text/html; charset=utf-8');
+		$this->response->setContentType( 'application/json; charset=utf-8' );
 
 		$user = User::newFromId($this->getVal('userId'));
 

--- a/extensions/wikia/UserProfilePageV3/js/UserProfilePage.js
+++ b/extensions/wikia/UserProfilePageV3/js/UserProfilePage.js
@@ -286,6 +286,7 @@ var UserProfilePage = {
 			},
 			onComplete: function (response) {
 				try {
+					response = String(response).replace(/&amp;/g, '&');
 					response = JSON.parse(response);
 					var avatarImg = $modal.find('img.avatar');
 					if (response.result.success === true) {

--- a/extensions/wikia/UserProfilePageV3/js/UserProfilePage.js
+++ b/extensions/wikia/UserProfilePageV3/js/UserProfilePage.js
@@ -375,7 +375,7 @@ var UserProfilePage = {
 			type: 'POST',
 			url: this.ajaxEntryPoint + '&method=saveUserData',
 			dataType: 'json',
-			data: 'userId=' + UserProfilePage.userId + '&data=' + JSON.stringify(userData),
+			data: {'userId' : UserProfilePage.userId, 'data' : JSON.stringify(userData)},
 			success: function (data) {
 				if (data.status === 'error') {
 					UserProfilePage.error(data.errMsg);

--- a/extensions/wikia/UserProfilePageV3/js/UserProfilePage.js
+++ b/extensions/wikia/UserProfilePageV3/js/UserProfilePage.js
@@ -286,7 +286,6 @@ var UserProfilePage = {
 			},
 			onComplete: function (response) {
 				try {
-					response = String(response).replace(/&amp;/g, '&');
 					response = JSON.parse(response);
 					var avatarImg = $modal.find('img.avatar');
 					if (response.result.success === true) {

--- a/resources/wikia/modules/aim.js
+++ b/resources/wikia/modules/aim.js
@@ -31,7 +31,7 @@
 				if(typeof d.responseContent !== "undefined") {
 					response = d.responseContent;
 				} else {
-					response = d.body.innerHTML;
+					response = d.body.textContent;
 				}
 
 				i.onComplete(response);

--- a/resources/wikia/modules/aim.js
+++ b/resources/wikia/modules/aim.js
@@ -31,7 +31,7 @@
 				if(typeof d.responseContent !== "undefined") {
 					response = d.responseContent;
 				} else {
-					response = d.body.textContent;
+					response = d.body.innerHTML;
 				}
 
 				i.onComplete(response);


### PR DESCRIPTION
There were 2 problems here:

First, in aim.js, the code was interpreting a response from the server from UserProfilePage::onSubmitUsersAvatar as html, when it's actually json. This was HTML escaping ampersands into `&amp;`. Using textContent to get the raw value fixes that.

Second, The upload error presents itself on foreign language wikias which are using vignette. This is because vignette appends `path-prefix=<lang>` to the end of thumbnails on foreign language wikias and we were manually constructing a query string using that thumbnail to be sent to the server. Letting jquery construct that query string fixes that.
