### PR TITLE
PLATFORM-624: Patch how we retrieve user from database after updating it in the same request

### DIFF
--- a/includes/wikia/ExternalUser_Wikia.php
+++ b/includes/wikia/ExternalUser_Wikia.php
@@ -31,7 +31,7 @@ class ExternalUser_Wikia extends ExternalUser {
 
 		wfDebug( __METHOD__ . ": init User from cond: " . wfArrayToString( $cond ) . " \n" );
 
-		# PLATFORM-624: do not user slave if we just updated this user
+		# PLATFORM-624: do not use slave if we just updated this user
 		if ( array_key_exists('user_id',$cond) && isset(self::$recentlyUpdated[$cond['user_id']]) ) {
 			$row = null;
 		} else {

--- a/includes/wikia/ExternalUser_Wikia.php
+++ b/includes/wikia/ExternalUser_Wikia.php
@@ -1,6 +1,7 @@
 <?php
 
 class ExternalUser_Wikia extends ExternalUser {
+	static private $recentlyUpdated = array();
 	private $mRow, $mDb, $mUser;
 
 	protected function initFromName( $name ) {
@@ -30,13 +31,25 @@ class ExternalUser_Wikia extends ExternalUser {
 
 		wfDebug( __METHOD__ . ": init User from cond: " . wfArrayToString( $cond ) . " \n" );
 
-		$this->mDb = wfGetDB( DB_SLAVE, array(), $wgExternalSharedDB );
-		$row = $this->mDb->selectRow(
-			'`user`',
-			array( '*' ),
-			$cond,
-			__METHOD__
-		);
+		# PLATFORM-624: do not user slave if we just updated this user
+		if ( array_key_exists('user_id',$cond) && isset(self::$recentlyUpdated[$cond['user_id']]) ) {
+			$row = null;
+		} else {
+			$this->mDb = wfGetDB( DB_SLAVE, array(), $wgExternalSharedDB );
+			$row = $this->mDb->selectRow(
+				'`user`',
+				array( '*' ),
+				$cond,
+				__METHOD__
+			);
+		}
+
+		# PLATFORM-624: force read from master for users updated recently
+		# note: if we had a condition for name we could still have fetched a user that
+		# was recently updated
+		if ( $row && isset(self::$recentlyUpdated[$row->user_id]) ) {
+			$row = null;
+		}
 
 		if( !$row ) {
 			$this->mDb = wfGetDB( DB_MASTER, array(), $wgExternalSharedDB );
@@ -396,6 +409,10 @@ class ExternalUser_Wikia extends ExternalUser {
 				__METHOD__
 			);
 			$dbw->commit( __METHOD__ );
+
+			if ( $this->mUser->mId ) { // sanity check
+				self::$recentlyUpdated[$this->mUser->mId] = true;
+			}
 		}
 		wfProfileOut( __METHOD__ );
 	}


### PR DESCRIPTION
It's a simple patch to force reading users from master if we updated them earlier in the same request. It is supposed to fix random login failures after changing password which breaks our automated tests.

https://wikia-inc.atlassian.net/browse/PLATFORM-624

/cc @Wikia/platform-team 
