### PR TITLE
VE-1730: Remove default option from editor preference

### DIFF
--- a/extensions/wikia/EditorPreference/EditorPreference.class.php
+++ b/extensions/wikia/EditorPreference/EditorPreference.class.php
@@ -245,6 +245,22 @@ class EditorPreference {
 	}
 
 	/**
+	 * For users with default option, return their preference as VisualEditor
+	 *
+	 * @param array $options User options
+	 * @param string $name Option name
+	 * @param mixed $value Value of option
+	 * @return boolean
+	 */
+	public static function onUserGetOption($options, $name, &$value) {
+		if ($name === 'editor' && $value === self::OPTION_EDITOR_DEFAULT) {
+			$value = self::OPTION_EDITOR_VISUAL;
+		}
+
+		return true;
+	}
+
+	/**
 	 * Get the message key for a non-VisualEditor edit link in the actions dropdown.
 	 *
 	 * @return string

--- a/extensions/wikia/EditorPreference/EditorPreference.class.php
+++ b/extensions/wikia/EditorPreference/EditorPreference.class.php
@@ -26,7 +26,6 @@ class EditorPreference {
 			'label-message' => 'editor-preference',
 			'section' => 'editing/editing-experience',
 			'options' => array(
-				wfMessage( 'option-default-editor' )->text() => self::OPTION_EDITOR_DEFAULT,
 				wfMessage( 'option-visual-editor' )->text() => self::OPTION_EDITOR_VISUAL,
 				wfMessage( 'option-ck-editor' )->text() => self::OPTION_EDITOR_CK,
 				wfMessage( 'option-source-editor' )->text() => self::OPTION_EDITOR_SOURCE,

--- a/extensions/wikia/EditorPreference/EditorPreference.php
+++ b/extensions/wikia/EditorPreference/EditorPreference.php
@@ -24,6 +24,7 @@ $wgHooks['SkinTemplateNavigation'][] = 'EditorPreference::onSkinTemplateNavigati
 $wgHooks['MakeGlobalVariablesScript'][] = 'EditorPreference::onMakeGlobalVariablesScript';
 $wgHooks['AddNewAccount'][] = 'EditorPreference::onAddNewAccount';
 $wgHooks['UserProfilePageAfterGetActionButtonData'][] = 'EditorPreference::onUserProfilePageAfterGetActionButtonData';
+$wgHooks['UserGetOption'][] = 'EditorPreference::onUserGetOption';
 
 // Default preference
 $wgDefaultUserOptions[PREFERENCE_EDITOR] = 0;

--- a/includes/Preferences.php
+++ b/includes/Preferences.php
@@ -73,6 +73,11 @@ class Preferences {
 		## Prod in defaults from the user
 		foreach ( $defaultPreferences as $name => &$info ) {
 			$prefFromUser = self::getOptionFromUser( $name, $info, $user );
+			/* VE-1730: Temporarily treat all Default editor prefs as VE as first step of migration */
+			if ( $name === 'editor' && $prefFromUser === 0 ) {
+				$prefFromUser = 2;
+			}
+
 			$field = HTMLForm::loadInputFromParameters( $name, $info ); // For validation
 			$defaultOptions = User::getDefaultOptions();
 			$globalDefault = isset( $defaultOptions[$name] )

--- a/includes/Preferences.php
+++ b/includes/Preferences.php
@@ -73,11 +73,6 @@ class Preferences {
 		## Prod in defaults from the user
 		foreach ( $defaultPreferences as $name => &$info ) {
 			$prefFromUser = self::getOptionFromUser( $name, $info, $user );
-			/* VE-1730: Temporarily treat all Default editor prefs as VE as first step of migration */
-			if ( $name === 'editor' && $prefFromUser === 0 ) {
-				$prefFromUser = 2;
-			}
-
 			$field = HTMLForm::loadInputFromParameters( $name, $info ); // For validation
 			$defaultOptions = User::getDefaultOptions();
 			$globalDefault = isset( $defaultOptions[$name] )


### PR DESCRIPTION
This is the first phase of code for removing the "wiki default" option for editor preference. See https://wikia-inc.atlassian.net/browse/VE-1220 for a full description. 
