### PR TITLE
PLATFORM-644: Fix DPL fatal error in tasks

### DIFF
--- a/extensions/DynamicPageList/DPLMain.php
+++ b/extensions/DynamicPageList/DPLMain.php
@@ -2651,10 +2651,10 @@ class DPLMain {
             if (!$bIncludeSubpages && (!(strpos($pageTitle,'/')===false))) continue;
 
             $title = Title::makeTitle($pageNamespace, $pageTitle);
+            $thisTitle = $parser->getTitle();
 
             // block recursion: avoid to show the page which contains the DPL statement as part of the result
-            if ($bSkipThisPage && ($title->getNamespace() == $wgTitle->getNamespace() &&
-                $title->getText() == $wgTitle->getText())) {
+            if ($bSkipThisPage && $title->equals($thisTitle)) {
                 // $output.= 'BLOCKED '.$wgTitle->getText().' DUE TO RECURSION'."\n";
                 continue;
             }


### PR DESCRIPTION
This solves a reference to $wgTitle in DPL which is not a Title object in tasks. The parsed article's title should be used instead.

https://wikia-inc.atlassian.net/browse/PLATFORM-644

/cc @Wikia/platform-team 
