### PR TITLE
allow a Vignette url to change formats after the url has been generated

### DIFF
--- a/includes/wikia/services/ImagesService.class.php
+++ b/includes/wikia/services/ImagesService.class.php
@@ -126,7 +126,9 @@ class ImagesService extends Service {
 	 */
 	public static function overrideThumbnailFormat($thumbUrl, $newExtension) {
 
-		if ( !empty($thumbUrl)
+		if (VignetteRequest::isVignetteUrl($thumbUrl)) {
+			$thumbUrl = VignetteRequest::setThumbnailFormat($thumbUrl, $newExtension);
+		} elseif ( !empty($thumbUrl)
 				&& in_array($newExtension, self::$allowedExtensionsList) // only change extension if it's allowed
 				&& !self::imageUrlHasExtension($thumbUrl, $newExtension) // only change extension if it's different that current one
 				&& (substr($thumbUrl, 0, strlen(static::DATA_TAG)) != static::DATA_TAG)

--- a/includes/wikia/services/ImagesService.class.php
+++ b/includes/wikia/services/ImagesService.class.php
@@ -126,14 +126,14 @@ class ImagesService extends Service {
 	 */
 	public static function overrideThumbnailFormat($thumbUrl, $newExtension) {
 
-		if (VignetteRequest::isVignetteUrl($thumbUrl)) {
-			$thumbUrl = VignetteRequest::setThumbnailFormat($thumbUrl, $newExtension);
-		} elseif ( !empty($thumbUrl)
-				&& in_array($newExtension, self::$allowedExtensionsList) // only change extension if it's allowed
+		if (!empty($thumbUrl)) {
+			if (VignetteRequest::isVignetteUrl($thumbUrl)) {
+				$thumbUrl = VignetteRequest::setThumbnailFormat($thumbUrl, $newExtension);
+			} elseif (in_array($newExtension, self::$allowedExtensionsList) // only change extension if it's allowed
 				&& !self::imageUrlHasExtension($thumbUrl, $newExtension) // only change extension if it's different that current one
-				&& (substr($thumbUrl, 0, strlen(static::DATA_TAG)) != static::DATA_TAG)
-			) {
-			$thumbUrl .= $newExtension;
+				&& (substr($thumbUrl, 0, strlen(static::DATA_TAG)) != static::DATA_TAG)) {
+				$thumbUrl .= $newExtension;
+			}
 		}
 
 		return $thumbUrl;

--- a/includes/wikia/services/ImagesService.class.php
+++ b/includes/wikia/services/ImagesService.class.php
@@ -125,17 +125,25 @@ class ImagesService extends Service {
 	 * @return String new URL
 	 */
 	public static function overrideThumbnailFormat($thumbUrl, $newExtension) {
+		if (empty($thumbUrl) || !self::isValidThumbOverrideFormat($newExtension)) {
+			return $thumbUrl;
+		}
 
-		if (!empty($thumbUrl) && in_array($newExtension, self::$allowedExtensionsList)) {
-			if (VignetteRequest::isVignetteUrl($thumbUrl)) {
-				$thumbUrl = VignetteRequest::setThumbnailFormat($thumbUrl, $newExtension);
-			} elseif (!self::imageUrlHasExtension($thumbUrl, $newExtension) &&
-				substr($thumbUrl, 0, strlen(static::DATA_TAG)) != static::DATA_TAG) {
-				$thumbUrl .= $newExtension;
-			}
+		if (VignetteRequest::isVignetteUrl($thumbUrl)) {
+			$thumbUrl = VignetteRequest::setThumbnailFormat($thumbUrl, $newExtension);
+		} elseif (!self::imageUrlHasExtension($thumbUrl, $newExtension) && !self::isDataTagImage($thumbUrl)) {
+			$thumbUrl .= $newExtension;
 		}
 
 		return $thumbUrl;
+	}
+
+	private static function isValidThumbOverrideFormat($extension) {
+		return in_array($extension, self::$allowedExtensionsList);
+	}
+
+	private static function isDataTagImage($url) {
+		return substr($url, 0, strlen(static::DATA_TAG)) == static::DATA_TAG;
 	}
 
 	/**

--- a/includes/wikia/services/ImagesService.class.php
+++ b/includes/wikia/services/ImagesService.class.php
@@ -126,12 +126,11 @@ class ImagesService extends Service {
 	 */
 	public static function overrideThumbnailFormat($thumbUrl, $newExtension) {
 
-		if (!empty($thumbUrl)) {
+		if (!empty($thumbUrl) && in_array($newExtension, self::$allowedExtensionsList)) {
 			if (VignetteRequest::isVignetteUrl($thumbUrl)) {
 				$thumbUrl = VignetteRequest::setThumbnailFormat($thumbUrl, $newExtension);
-			} elseif (in_array($newExtension, self::$allowedExtensionsList) // only change extension if it's allowed
-				&& !self::imageUrlHasExtension($thumbUrl, $newExtension) // only change extension if it's different that current one
-				&& (substr($thumbUrl, 0, strlen(static::DATA_TAG)) != static::DATA_TAG)) {
+			} elseif (!self::imageUrlHasExtension($thumbUrl, $newExtension) &&
+				substr($thumbUrl, 0, strlen(static::DATA_TAG)) != static::DATA_TAG) {
 				$thumbUrl .= $newExtension;
 			}
 		}

--- a/includes/wikia/vignette/VignetteRequest.php
+++ b/includes/wikia/vignette/VignetteRequest.php
@@ -150,4 +150,20 @@ class VignetteRequest {
 
 		return $isVignetteUrl;
 	}
+
+	public static function setThumbnailFormat($url, $format) {
+		$format = preg_replace('/^\./', '', $format);
+
+		if ($url instanceof UrlGenerator) {
+			return $url->format($format);
+		} else if (!self::isVignetteUrl($url)) {
+			return $url;
+		}
+
+		$parts = parse_url($url);
+		parse_str($parts['query'], $query);
+		$query['format'] = $format;
+		$parts['query'] = http_build_query($query);
+		return http_build_url($url, $parts);
+	}
 }

--- a/includes/wikia/vignette/VignetteRequest.php
+++ b/includes/wikia/vignette/VignetteRequest.php
@@ -152,7 +152,7 @@ class VignetteRequest {
 	}
 
 	public static function setThumbnailFormat($url, $format) {
-		$format = preg_replace('/^\./', '', $format);
+		$format = ltrim($format, ".");
 
 		if ($url instanceof UrlGenerator) {
 			return $url->format($format);

--- a/lib/Wikia/src/Vignette/UrlGenerator.php
+++ b/lib/Wikia/src/Vignette/UrlGenerator.php
@@ -337,7 +337,7 @@ class UrlGenerator {
 		return $this;
 	}
 
-	private function format($format) {
+	public function format($format) {
 		$this->query['format'] = $format;
 		return $this;
 	}


### PR DESCRIPTION
@Wikia/platform-team @kvas-damian 
https://wikia-inc.atlassian.net/browse/PLATFORM-647

`ImagesService:: overrideThumbnailFormat()` is called after the url for an image has been generated, so we need a way to change the output format from a string :cry: 
