### PR TITLE
VOLDEV-108: Make RecentChanges js object public

### DIFF
--- a/extensions/wikia/RecentChanges/js/RecentChanges.js
+++ b/extensions/wikia/RecentChanges/js/RecentChanges.js
@@ -1,4 +1,5 @@
 jQuery(function($) {
+	//Used by AjaxRC
 	window.Wikia = window.Wikia || {};
 	
 	var RecentChanges = {
@@ -43,5 +44,5 @@ jQuery(function($) {
 	};
 
 	RecentChanges.init();
-	Wikia.RecentChanges = RecentChanges;
+	Wikia.RecentChanges = RecentChanges; //needed for AjaxRC
 });

--- a/extensions/wikia/RecentChanges/js/RecentChanges.js
+++ b/extensions/wikia/RecentChanges/js/RecentChanges.js
@@ -44,5 +44,5 @@ jQuery(function($) {
 	};
 
 	RecentChanges.init();
-	Wikia.RecentChanges = RecentChanges; //needed for AjaxRC
+	window.Wikia.RecentChanges = RecentChanges; //needed for AjaxRC
 });

--- a/extensions/wikia/RecentChanges/js/RecentChanges.js
+++ b/extensions/wikia/RecentChanges/js/RecentChanges.js
@@ -1,4 +1,6 @@
 jQuery(function($) {
+	window.Wikia = window.Wikia || {};
+	
 	var RecentChanges = {
 		init: function() {
 			this.$table = $('.mw-recentchanges-table');
@@ -41,4 +43,5 @@ jQuery(function($) {
 	};
 
 	RecentChanges.init();
+	Wikia.RecentChanges = RecentChanges;
 });


### PR DESCRIPTION
@Grunny @timmyquivy 

This is a voldev ticket but I'm not actually voldev so apologies if this is not the way to do a PR. I made the RecentChanges class public because for the past year or so AjaxRC has been using a duplicate version of this class that's in the script itself to make sure that the Dropdown is reinitialized every time that the refresh is run. This means though that the code on the script could go out of date at any time and that it's running an exact duplicate of the code that Wikia made, which is never really efficient or a good thing.

I added RecentChanges to the Wikia global in this patch- it can be found under Wikia.RecentChanges. It's not camel case because the original private object wasn't and anyways theres a precedent of noncamel case stuff under the Wikia global (LazyQueue).

Sorry for the huge explanation for a two line change.
