### PR TITLE
CONN-642: Global block overwrites local allowence

### DIFF
--- a/extensions/wikia/Wall/WallBaseController.class.php
+++ b/extensions/wikia/Wall/WallBaseController.class.php
@@ -614,8 +614,10 @@ class WallBaseController extends WikiaController {
 	protected function checkAndSetUserBlockedStatus( $wallOwner = null ) {
 		$user = $this->app->wg->User;
 
-		if ( $user->isBlocked() || $user->isBlockedGlobally() ) {
-			if (	!empty( $wallOwner ) &&
+		if ( $user->isBlockedGlobally() ) {
+			$this->response->setVal('userBlocked', true);
+		} else if ( $user->isBlocked() ) {
+			if( !empty($wallOwner) &&
 				$wallOwner->getName() == $this->wg->User->getName() &&
 				!( empty( $user->mAllowUsertalk ) ) ) {
 				// user is blocked, but this is his wall and he was not blocked
@@ -627,7 +629,6 @@ class WallBaseController extends WikiaController {
 		} else {
 			$this->response->setVal( 'userBlocked', false );
 		}
-
 	}
 
 	public function getThread( $filterid ) {

--- a/extensions/wikia/Wall/WallController.class.php
+++ b/extensions/wikia/Wall/WallController.class.php
@@ -141,26 +141,6 @@ class WallController extends WallBaseController {
 		return $this->parserText( $text );
 	}
 
-	protected function checkAndSetUserBlockedStatus( $wallOwner = null ) {
-		$user = $this->app->wg->User;
-
-		if ( $user->isBlocked() || $user->isBlockedGlobally() ) {
-			if (	!empty( $wallOwner ) &&
-				$wallOwner->getName() == $this->wg->User->getName() &&
-				!( empty( $user->mAllowUsertalk ) ) ) {
-
-				// user is blocked, but this is his wall and he was not blocked
-				// from user talk page
-				$this->response->setVal( 'userBlocked', false );
-			} else {
-				$this->response->setVal( 'userBlocked', true );
-			}
-		} else {
-			$this->response->setVal( 'userBlocked', false );
-		}
-
-	}
-
 	protected function getSortingOptions() {
 		$title = $this->request->getVal( 'title', $this->app->wg->Title );
 


### PR DESCRIPTION
Global edit block must prevail over local allowance. Also removed `WallController::checkAndSetUserBlockedStatus` as it is the same as `WallBaseController::checkAndSetUserBlockedStatus` and `WallController` inherits `WallBaseController`.

/cc @nandy-andy care to take a look :oncoming_automobile: 
