### PR TITLE
HG-483: Add wikiCategories to WikiVariables response

### DIFF
--- a/extensions/wikia/MercuryApi/models/MercuryApi.class.php
+++ b/extensions/wikia/MercuryApi/models/MercuryApi.class.php
@@ -119,7 +119,7 @@ class MercuryApi {
 			'siteName' => $wg->Sitename,
 			'mainPageTitle' => Title::newMainPage()->getPrefixedDBkey(),
 			'theme' => SassUtil::getOasisSettings(),
-			'wikiCategories' => WikiFactoryHubHooks::getWikiCategories( $wg->CityId ),
+			'wikiCategories' => WikiFactoryHub::getInstance()->getWikiCategoryNames( $wg->CityId ),
 		];
 	}
 

--- a/extensions/wikia/MercuryApi/models/MercuryApi.class.php
+++ b/extensions/wikia/MercuryApi/models/MercuryApi.class.php
@@ -118,7 +118,8 @@ class MercuryApi {
 			'namespaces' => MWNamespace::getCanonicalNamespaces(),
 			'siteName' => $wg->Sitename,
 			'mainPageTitle' => Title::newMainPage()->getPrefixedDBkey(),
-			'theme' => SassUtil::getOasisSettings()
+			'theme' => SassUtil::getOasisSettings(),
+			'wikiCategories' => WikiFactoryHubHooks::getWikiCategories( $wg->CityId ),
 		];
 	}
 

--- a/extensions/wikia/WikiFactory/Hubs/WikiFactoryHub.php
+++ b/extensions/wikia/WikiFactory/Hubs/WikiFactoryHub.php
@@ -271,6 +271,23 @@ class WikiFactoryHub extends WikiaModel {
 	}
 
 	/**
+	 * Gets list of wiki category names
+	 *
+	 * @param Int $cityId CityId
+	 * @param Int $active Active status of categories to return
+	 * @return array Array of wiki category names
+	 */
+	public function getWikiCategoryNames( $cityId, $active = 1 ) {
+		$wikiCategoryNames = [];
+		$categories = $this->getWikiCategories( $cityId, $active );
+		foreach( $categories as $category ) {
+			$wikiCategoryNames[] = $category['cat_short'];
+		}
+		return $wikiCategoryNames;
+	}
+
+
+	/**
 	 * get single category name for a wiki
 	 * This is deprecated, use getWikiCategories instead
 	 * @deprecated

--- a/extensions/wikia/WikiFactory/Hubs/WikiFactoryHubHooks.class.php
+++ b/extensions/wikia/WikiFactory/Hubs/WikiFactoryHubHooks.class.php
@@ -9,6 +9,23 @@
 class WikiFactoryHubHooks extends WikiaModel {
 
 	/**
+	 * Gets list of wiki categories
+	 *
+	 * @param int $cityId CityId
+	 * @return array - list of wiki categories
+	 */
+	public static function getWikiCategories( $cityId ) {
+		$wikiCategories = [];
+		$wikiFactoryHub = WikiFactoryHub::getInstance();
+
+		$categories = $wikiFactoryHub->getWikiCategories( $cityId );
+		foreach( $categories as $category ) {
+			$wikiCategories[] = $category['cat_short'];
+		}
+		return $wikiCategories;
+	}
+
+	/**
 	 * Hooks that export wiki vertical and categories on frontend
 	 *
 	 * @param Array $vars - (reference) js variables
@@ -19,15 +36,9 @@ class WikiFactoryHubHooks extends WikiaModel {
 	public static function onWikiaSkinTopScripts( &$vars, &$scripts, $skin ) {
 		global $wgCityId;
 		$wikiFactoryHub = WikiFactoryHub::getInstance();
-		$wikiCategories = [];
-
-		$categories = $wikiFactoryHub->getWikiCategories( $wgCityId );
-		foreach( $categories as $category ) {
-			$wikiCategories[] = $category['cat_short'];
-		}
 
 		$vars['wgWikiVertical'] = $wikiFactoryHub->getWikiVertical( $wgCityId )['short'];
-		$vars['wgWikiCategories'] = $wikiCategories;
+		$vars['wgWikiCategories'] = self::getWikiCategories( $wgCityId );
 
 		return true;
 	}

--- a/extensions/wikia/WikiFactory/Hubs/WikiFactoryHubHooks.class.php
+++ b/extensions/wikia/WikiFactory/Hubs/WikiFactoryHubHooks.class.php
@@ -11,8 +11,8 @@ class WikiFactoryHubHooks extends WikiaModel {
 	/**
 	 * Gets list of wiki categories
 	 *
-	 * @param int $cityId CityId
-	 * @return array - list of wiki categories
+	 * @param Int $cityId CityId
+	 * @return Array - list of wiki categories
 	 */
 	public static function getWikiCategories( $cityId ) {
 		$wikiCategories = [];

--- a/extensions/wikia/WikiFactory/Hubs/WikiFactoryHubHooks.class.php
+++ b/extensions/wikia/WikiFactory/Hubs/WikiFactoryHubHooks.class.php
@@ -9,23 +9,6 @@
 class WikiFactoryHubHooks extends WikiaModel {
 
 	/**
-	 * Gets list of wiki categories
-	 *
-	 * @param Int $cityId CityId
-	 * @return Array - list of wiki categories
-	 */
-	public static function getWikiCategories( $cityId ) {
-		$wikiCategories = [];
-		$wikiFactoryHub = WikiFactoryHub::getInstance();
-
-		$categories = $wikiFactoryHub->getWikiCategories( $cityId );
-		foreach( $categories as $category ) {
-			$wikiCategories[] = $category['cat_short'];
-		}
-		return $wikiCategories;
-	}
-
-	/**
 	 * Hooks that export wiki vertical and categories on frontend
 	 *
 	 * @param Array $vars - (reference) js variables
@@ -38,7 +21,7 @@ class WikiFactoryHubHooks extends WikiaModel {
 		$wikiFactoryHub = WikiFactoryHub::getInstance();
 
 		$vars['wgWikiVertical'] = $wikiFactoryHub->getWikiVertical( $wgCityId )['short'];
-		$vars['wgWikiCategories'] = self::getWikiCategories( $wgCityId );
+		$vars['wgWikiCategories'] = $wikiFactoryHub->getWikiCategoryNames( $wgCityId );
 
 		return true;
 	}


### PR DESCRIPTION
As a part of the effort to unify tracking between MW and Mercury, we need to pass the value of `wgWikiCategories` to Mercury. I wanted to keep this DRY, and that's why the `WikiFactoryHubHooks::getWikiCategories` logic was extracted from `WikiFactoryHubHooks::onWikiaSkinTopScripts` :oden: 

Related to: https://github.com/Wikia/mercury/pull/464
/cc @kvas-damian @hakubo 
