### PR TITLE
CON-2349 | Fix onOverwriteTOC methods

### DIFF
--- a/extensions/wikia/ArticleNavigation/ArticleNavigationHelper.class.php
+++ b/extensions/wikia/ArticleNavigation/ArticleNavigationHelper.class.php
@@ -32,7 +32,7 @@ class ArticleNavigationHelper {
 		return $allowedInLanguage && array_key_exists( 'url', $service ) && array_key_exists( 'name', $service );
 	}
 
-	public function onOverwriteTOC( &$title, &$toc ) {
+	public static function onOverwriteTOC( &$title, &$toc ) {
 		if ( F::app()->checkSkin( 'venus' ) ) {
 			$toc = '';
 		}

--- a/extensions/wikia/TOC/TOCHooksHelper.class.php
+++ b/extensions/wikia/TOC/TOCHooksHelper.class.php
@@ -10,7 +10,7 @@ class TOCHooksHelper {
 	 * @return bool
 	 */
 
-	public function onOverwriteTOC( &$title, &$toc ) {
+	public static function onOverwriteTOC( &$title, &$toc ) {
 
         $app = F::app();
 		$isWikiaMobile = $app->checkSkin( 'wikiamobile' );


### PR DESCRIPTION
@macbre 

Fix for

```
Strict Standards: call_user_func_array() expects parameter 1 to be a valid callback,
non-static method TOCHooksHelper::onOverwriteTOC() should not be called
statically in /usr/wikia/source/app/includes/Hooks.php on line 216
```
