### PR TITLE
Fix GlobalTitle caching issues with sandbox/prod

### DIFF
--- a/includes/wikia/GlobalTitle.php
+++ b/includes/wikia/GlobalTitle.php
@@ -823,11 +823,7 @@ class GlobalTitle extends Title {
 	private function memcKey() {
 		global $wgSharedKeyPrefix, $wgDevelEnvironmentName;
 
-		$parts = array( $wgSharedKeyPrefix, "globaltitle", $this->mCityId );
-
-		if (!empty($wgDevelEnvironmentName)) {
-			$parts[] = $wgDevelEnvironmentName;
-		}
+		$parts = array( $wgSharedKeyPrefix, "globaltitle", $this->mCityId, Wikia::getEnvironmentName() );
 
 		return implode(":", $parts);
 	}

--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -2305,4 +2305,19 @@ class Wikia {
 
 		return $countryNames;
 	}
+
+	/**
+	 * Get an environment name that should be enough to separate cache containing URLs
+	 *
+	 * @return string
+	 */
+	static public function getEnvironmentName() {
+		global $wgWikiaEnvironment;
+
+		if ( in_array( $wgWikiaEnvironment, [ WIKIA_ENV_PROD, WIKIA_ENV_PREVIEW, WIKIA_ENV_VERIFY ] ) ) {
+			return $wgWikiaEnvironment;
+		} else {
+			return wfHostname();
+		}
+	}
 }


### PR DESCRIPTION
GlobalTitle shares the cache between production and sandbox/preview verify environments. That would be fine if only it didn't cache URLs that are specific to the environment...

Wikia::getEnvironmentName() is the proposed to solve similar issues. Just add it to the memcached key and you should be safe. Please share any comments on that idea.

/cc @Wikia/platform-team @bognix @kvas-damian 
