### PR TITLE
VE-1736: Code changes for new default editor

### DIFF
--- a/extensions/wikia/EditorPreference/EditorPreference.class.php
+++ b/extensions/wikia/EditorPreference/EditorPreference.class.php
@@ -6,7 +6,6 @@
  */
 
 class EditorPreference {
-	const OPTION_EDITOR_DEFAULT = 0;
 	const OPTION_EDITOR_SOURCE = 1;
 	const OPTION_EDITOR_VISUAL = 2;
 	const OPTION_EDITOR_CK = 3;
@@ -26,7 +25,6 @@ class EditorPreference {
 			'label-message' => 'editor-preference',
 			'section' => 'editing/editing-experience',
 			'options' => array(
-				wfMessage( 'option-default-editor' )->text() => self::OPTION_EDITOR_DEFAULT,
 				wfMessage( 'option-visual-editor' )->text() => self::OPTION_EDITOR_VISUAL,
 				wfMessage( 'option-ck-editor' )->text() => self::OPTION_EDITOR_CK,
 				wfMessage( 'option-source-editor' )->text() => self::OPTION_EDITOR_SOURCE,
@@ -180,22 +178,6 @@ class EditorPreference {
 			$wgEnableVisualEditorExt &&
 			( is_array( $wgVisualEditorNamespaces ) ?
 				in_array( $wgTitle->getNamespace(), $wgVisualEditorNamespaces ) : false );
-	}
-
-	/**
-	 * Set the editor preference for newly-registered users.
-	 *
-	 * @param User $user The current user
-	 * @return boolean
-	 */
-	public static function onAddNewAccount( User $user ) {
-		// Force new users to set VisualEditor as preference
-		$user->setOption( PREFERENCE_EDITOR, self::OPTION_EDITOR_VISUAL );
-		$user->saveSettings();
-
-		// If the editor preference is not set here, the default preference
-		// is set in CommonSettings.
-		return true;
 	}
 
 	/**

--- a/extensions/wikia/EditorPreference/EditorPreference.php
+++ b/extensions/wikia/EditorPreference/EditorPreference.php
@@ -22,8 +22,4 @@ $wgExtensionMessagesFiles['EditorPreference'] = $dir . 'EditorPreference.i18n.ph
 $wgHooks['EditingPreferencesBefore'][] = 'EditorPreference::onEditingPreferencesBefore';
 $wgHooks['SkinTemplateNavigation'][] = 'EditorPreference::onSkinTemplateNavigation';
 $wgHooks['MakeGlobalVariablesScript'][] = 'EditorPreference::onMakeGlobalVariablesScript';
-$wgHooks['AddNewAccount'][] = 'EditorPreference::onAddNewAccount';
 $wgHooks['UserProfilePageAfterGetActionButtonData'][] = 'EditorPreference::onUserProfilePageAfterGetActionButtonData';
-
-// Default preference
-$wgDefaultUserOptions[PREFERENCE_EDITOR] = 0;


### PR DESCRIPTION
This pull request reduces the number of editor options from 4 to 3 by removing "Wiki default". Previously, this was the default option. A corresponding config change is required (Wikia/config/VE-1737) to set the new default to 2 (VisualEditor). 
