### PR TITLE
create UrlGenerator from Vignette URL string

### DIFF
--- a/includes/Linker.php
+++ b/includes/Linker.php
@@ -463,6 +463,10 @@ class Linker {
 	 * @return string
 	 */
 	private static function fnamePart( $url ) {
+		if (VignetteRequest::isVignetteUrl($url)) {
+			return VignetteRequest::getImageFilename($url);
+		}
+
 		$basename = strrchr( $url, '/' );
 		if ( false === $basename ) {
 			$basename = $url;

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -286,6 +286,7 @@ $wgAutoloadClasses[ 'TemplatePageHelper'              ] = "$IP/includes/wikia/he
 $wgAutoloadClasses[ 'CrossOriginResourceSharingHeaderHelper' ] = "$IP/includes/wikia/helpers/CrossOriginResourceSharingHeaderHelper.php";
 $wgAutoloadClasses[ 'VignetteRequest'                 ] = "{$IP}/includes/wikia/vignette/VignetteRequest.php";
 $wgAutoloadClasses[ 'UrlGeneratorInterface'           ] = "{$IP}/includes/wikia/vignette/UrlGeneratorInterface.php";
+$wgAutoloadClasses[ 'VignetteUrlToUrlGenerator'       ] = "{$IP}/includes/wikia/vignette/VignetteUrlToUrlGenerator.php";
 $wgAutoloadClasses[ 'Wikia\\Cache\\AsyncCacheTask'    ] = "$IP/includes/wikia/AsyncCacheTask.php";
 $wgAutoloadClasses[ 'Wikia\\Cache\\AsyncCache'        ] = "$IP/includes/wikia/AsyncCache.php";
 

--- a/includes/wikia/tests/VignetteRequestTest.php
+++ b/includes/wikia/tests/VignetteRequestTest.php
@@ -1,0 +1,46 @@
+<?php
+class VignetteRequestTest extends WikiaBaseTest {
+	private $vignetteUrl = 'http://vignette.wikia-dev.com';
+
+	public function testSetThumbnailFormat() {
+		$this->mockGlobalVariable('wgVignetteUrl', $this->vignetteUrl);
+		$this->assertEquals(
+			VignetteRequest::setThumbnailFormat("{$this->vignetteUrl}/tests/images/a/ab/SomeFile.jpg/revision/latest/scale-to-width/100?cb=12345", ImagesService::EXT_PNG),
+			"{$this->vignetteUrl}/tests/images/a/ab/SomeFile.jpg/revision/latest/scale-to-width/100?cb=12345&format=png"
+		);
+
+		$this->assertEquals(
+			VignetteRequest::setThumbnailFormat("{$this->vignetteUrl}/tests/images/a/ab/SomeFile.jpg/revision/latest/scale-to-width/100", ".png"),
+			"{$this->vignetteUrl}/tests/images/a/ab/SomeFile.jpg/revision/latest/scale-to-width/100?format=png"
+		);
+	}
+
+	public function testGetImageFilename() {
+		$this->mockGlobalVariable('wgVignetteUrl', $this->vignetteUrl);
+		$this->assertEquals(
+			VignetteRequest::getImageFilename("{$this->vignetteUrl}/tests/images/a/ab/SomeFile.jpg/revision/latest/scale-to-width/100?cb=12345"),
+			"SomeFile.jpg"
+		);
+
+		$this->assertEquals(
+			VignetteRequest::getImageFilename("{$this->vignetteUrl}/tests/images/a/ab/SomeFile.jpg/revision/latest?cb=12345"),
+			"SomeFile.jpg"
+		);
+	}
+
+	/**
+	 * @expectedException InvalidArgumentException
+	 */
+	public function testBadUrl() {
+		$this->mockGlobalVariable('wgVignetteUrl', $this->vignetteUrl);
+		VignetteRequest::fromUrl("http://google.com/search");
+	}
+
+	/**
+	 * @expectedException InvalidArgumentException
+	 */
+	public function testBadThumbnailDefinition() {
+		$this->mockGlobalVariable('wgVignetteUrl', $this->vignetteUrl);
+		VignetteRequest::fromUrl("{$this->vignetteUrl}/tests/images/a/ab/SomeFile.jpg/revision/latest/thumbnail/width/100/height");
+	}
+}

--- a/includes/wikia/vignette/VignetteRequest.php
+++ b/includes/wikia/vignette/VignetteRequest.php
@@ -76,7 +76,19 @@ class VignetteRequest {
 	}
 
 	/**
-	 * parse image bucket from a url. ex: http://images.wikia.com/muppet/images/a/ab/image.jpg will return "muppet"
+	 * create a UrlGenerator object from a Vignette url
+	 * @param $url
+	 * @param $asOriginal
+	 * @return null|UrlGenerator
+	 */
+	public static function fromUrl($url, $asOriginal=false) {
+		return (new VignetteUrlToUrlGenerator($url, $asOriginal))
+			->build();
+	}
+
+	/**
+	 * parse image bucket from a url. ex: http://images.wikia.com/muppet/images/a/ab/image.jpg will return "muppet".
+	 * It is safe to use this on a Vignette url.
 	 * @param $url
 	 * @return mixed
 	 */
@@ -91,7 +103,7 @@ class VignetteRequest {
 	}
 
 	/**
-	 * parse the path prefix from a url.
+	 * parse the path prefix from a legacy url. It is NOT safe to use this on a Vignette url.
 	 * http://images.wikia.com/walkingdead/ru/images -> "ru",
 	 * http://images.wikia.com/walkingdead/images -> null
 	 * http://images.wikia.com/p__/psychusa/zh/images -> psychusa/zh
@@ -109,8 +121,8 @@ class VignetteRequest {
 	}
 
 	/**
-	 * parse relative path from url. ex: http://images.wiukia.com/muppet/images/a/ab/image.jpg will
-	 * return "a/ab/image.jpg"
+	 * parse relative path from legacy url. ex: http://images.wikia.com/muppet/images/a/ab/image.jpg will
+	 * return "a/ab/image.jpg". It is NOT safe to use this ona Vignette url.
 	 * @param $url
 	 * @return mixed
 	 */
@@ -160,10 +172,13 @@ class VignetteRequest {
 			return $url;
 		}
 
-		$parts = parse_url($url);
-		parse_str($parts['query'], $query);
-		$query['format'] = $format;
-		$parts['query'] = http_build_query($query);
-		return http_build_url($url, $parts);
+		$generator = self::fromUrl($url);
+		return $generator->format($format)->url();
+	}
+
+	public static function getImageFilename($url) {
+		$generator = self::fromUrl($url);
+		$pathParts = explode('/', $generator->config()->relativePath());
+		return array_pop($pathParts);
 	}
 }

--- a/includes/wikia/vignette/VignetteUrlToUrlGenerator.php
+++ b/includes/wikia/vignette/VignetteUrlToUrlGenerator.php
@@ -29,7 +29,7 @@ class VignetteUrlToUrlGenerator {
 
 	public function build() {
 		if (!$this->parseUrl()) {
-			return null;
+			$this->reportError('unable to parse url');
 		}
 
 		$isArchive = $this->urlParts['revision'] != \Wikia\Vignette\UrlGenerator::REVISION_LATEST;

--- a/includes/wikia/vignette/VignetteUrlToUrlGenerator.php
+++ b/includes/wikia/vignette/VignetteUrlToUrlGenerator.php
@@ -9,7 +9,7 @@ use \Wikia\Logger\Loggable;
 class VignetteUrlToUrlGenerator {
 	use Loggable;
 
-	const URL_REGEX = '/^\/(?<bucket>[^\/]+)\/(images\/?)(?<relativePath>.*?)\/revision\/(?<revision>latest|\d+)(\/(?<thumbnailDefinition>.*))?/';
+	const URL_REGEX = '/^\/(?<bucket>[^\/]+)\/(images\/|avatars\/)?(?<relativePath>.*?)\/revision\/(?<revision>latest|\d+)(\/(?<thumbnailDefinition>.*))?/';
 
 	private $url;
 	private $asOriginal;

--- a/includes/wikia/vignette/VignetteUrlToUrlGenerator.php
+++ b/includes/wikia/vignette/VignetteUrlToUrlGenerator.php
@@ -1,0 +1,137 @@
+<?php
+use \Wikia\Vignette\UrlGenerator;
+use \Wikia\Logger\Loggable;
+
+/**
+ * Class VignetteUrlToUrlGenerator
+ * create a UrlGenerator object from a Vignette Url (string)
+ */
+class VignetteUrlToUrlGenerator {
+	use Loggable;
+
+	const URL_REGEX = '/^\/(?<bucket>[^\/]+)\/(images\/?)(?<relativePath>.*?)\/revision\/(?<revision>latest|\d+)(\/(?<thumbnailDefinition>.*))?/';
+
+	private $url;
+	private $asOriginal;
+	private $urlParts;
+	private $query;
+	private $timestamp;
+	private $pathPrefix;
+
+	public function __construct($url, $asOriginal=false) {
+		$this->url = $url;
+		$this->asOriginal = $asOriginal;
+
+		if (!VignetteRequest::isVignetteUrl($url)) {
+			$this->reportError('invalid url');
+		}
+	}
+
+	public function build() {
+		if (!$this->parseUrl()) {
+			return null;
+		}
+
+		$isArchive = $this->urlParts['revision'] != \Wikia\Vignette\UrlGenerator::REVISION_LATEST;
+		if ($isArchive) {
+			$this->timestamp = $this->urlParts['revision'];
+		}
+
+		$generator = VignetteRequest::fromConfigMap([
+			'bucket' => $this->urlParts['bucket'],
+			'relative-path' => $this->urlParts['relativePath'],
+			'timestamp' => $this->timestamp,
+			'path-prefix' => $this->pathPrefix,
+			'is-archive' => $isArchive,
+		]);
+
+		if (!$this->asOriginal && isset($this->urlParts['thumbnailDefinition'])) {
+			$this->addThumbDefinition($generator);
+		}
+
+		return $generator;
+	}
+
+	private function parseUrl() {
+		$parts = parse_url($this->url);
+
+		if (isset($parts['query'])) {
+			parse_str($parts['query'], $this->query);
+
+			if (isset($this->query['cb'])) {
+				$this->timestamp = $this->query['cb'];
+			}
+
+			if (isset($this->query['path-prefix'])) {
+				$this->pathPrefix = $this->query['path-prefix'];
+			}
+		}
+
+		return preg_match(self::URL_REGEX, $parts['path'], $this->urlParts);
+	}
+
+	private function addThumbDefinition(UrlGenerator $generator) {
+		if (isset($this->query['format'])) {
+			$generator->format($this->query['format']);
+		}
+
+		if (isset($this->query['fill'])) {
+			$generator->backgroundFill($this->query['fill']);
+		}
+
+		$parts = explode("/", $this->urlParts['thumbnailDefinition']);
+		$mode = array_shift($parts);
+		$generator->mode($mode);
+
+		if ($mode == UrlGenerator::MODE_SCALE_TO_WIDTH) {
+			$generator->width(array_shift($parts));
+			return;
+		}
+
+		foreach (array_chunk($parts, 2) as $chunk) {
+			if (count($chunk) != 2) {
+				$this->reportError('invalid chunk');
+			}
+
+			list($key, $val) = $chunk;
+			switch ($key) {
+				case 'width':
+					$generator->width($val);
+					break;
+				case 'height':
+					$generator->height($val);
+					break;
+				case 'x-offset':
+					$generator->xOffset($val);
+					break;
+				case 'y-offset':
+					$generator->yOffset($val);
+					break;
+				case 'window-width':
+					$generator->windowWidth($val);
+					break;
+				case 'window-height':
+					$generator->windowHeight($val);
+					break;
+				default:
+					$this->reportError('invalid key while building thumb mode', [
+						'key' => $key,
+						'val' => $val,
+					]);
+					break;
+			}
+		}
+	}
+
+	private function reportError($message, $context=[]) {
+		$exception = new InvalidArgumentException($message);
+		$this->error($message, $context);
+		throw $exception;
+	}
+
+	protected function getLoggerContext() {
+		return [
+			'url' => $this->url,
+		];
+	}
+}

--- a/lib/Wikia/src/Vignette/UrlGenerator.php
+++ b/lib/Wikia/src/Vignette/UrlGenerator.php
@@ -281,6 +281,10 @@ class UrlGenerator {
 		return $this->domainShard( $imagePath );
 	}
 
+	public function config() {
+		return $this->config;
+	}
+
 	/**
 	 * @return string
 	 */
@@ -332,7 +336,7 @@ class UrlGenerator {
 	 * @param string $mode one of the MODE_ constants defined above
 	 * @return $this
 	 */
-	private function mode($mode) {
+	public function mode($mode) {
 		$this->mode = $mode;
 		return $this;
 	}


### PR DESCRIPTION
@drsnyder 
https://wikia-inc.atlassian.net/browse/PLATFORM-648

Second time that we need the ability to get/modify a thumbnail request after the url string has been generated. This makes it easier, since now we can create a `UrlGenerator` object from the string URL, and do any manipulation/fetching on the object. This PR also udpates `VignetteReqest::setThumbnailFormat` to use this fanciness.
