### PR TITLE
VE-1728: Not necessary to resize image client-side

### DIFF
--- a/extensions/VisualEditor/wikia/modules/ve/ui/widgets/ve.ui.WikiaMediaPreviewWidget.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/widgets/ve.ui.WikiaMediaPreviewWidget.js
@@ -51,20 +51,6 @@ OO.inheritClass( ve.ui.WikiaMediaPreviewWidget, OO.ui.Widget );
 /* Methods */
 
 /**
- * Resize image after it's loaded if it's too tall for the screen
- * @method
- */
-ve.ui.WikiaMediaPreviewWidget.prototype.onImageLoad = function () {
-	// TODO: Add image aspect ratio to model (sorta the same comment from WikiaMediaPageWidget)
-	// thumbnailer.js only let's you restrict by width, not by height, so we'll do that here.
-	if ( this.$image.height() > this.maxImgHeight ) {
-		this.$image.height( this.maxImgHeight );
-	}
-
-	this.verticallyAlign( this.$image );
-};
-
-/**
  * @method
  */
 ve.ui.WikiaMediaPreviewWidget.prototype.verticallyAlign = function ( $element ) {
@@ -164,7 +150,7 @@ ve.ui.WikiaMediaPreviewWidget.prototype.openForImage = function ( title, url ) {
 	this.$image.attr( 'src', Vignette.getThumbURL( url, 'thumbnail-down', this.maxImgWidth, this.maxImgHeight ) );
 
 	this.$image
-		.load( ve.bind( this.onImageLoad, this ) )
+		.load( ve.bind( this.verticallyAlign, this, this.$image ) )
 		.appendTo( this.$element );
 };
 


### PR DESCRIPTION
Originally this ticket was to import the latest version of Vignette-js and remove this now-unnecessary code. However, @kvas-damian recently updated Vignette-js and it includes the change we need. This pull request now only removes the unnecessary code.

Changes were not made to WikiaMediaPageWidget as it is still using the old thumbnailer and will soon be removed with the new media tool.
