### PR TITLE
UC-33 collect user's gender from FB on signup

### DIFF
--- a/extensions/wikia/UserLogin/UserLoginFacebookForm.class.php
+++ b/extensions/wikia/UserLogin/UserLoginFacebookForm.class.php
@@ -97,7 +97,7 @@ class UserLoginFacebookForm extends UserLoginForm {
 	 * following values for a user's gender: 'male', 'female', null.
 	 * @param User $user
 	 */
-	public function saveUserGender( User $user ) {
+	private function saveUserGender( User $user ) {
 		$fbUserInfo = FacebookClient::getInstance()->getUserInfo();
 		$gender = $fbUserInfo->getProperty( 'gender' );
 		if ( !is_null( $gender ) ) {

--- a/extensions/wikia/UserLogin/UserLoginFacebookForm.class.php
+++ b/extensions/wikia/UserLogin/UserLoginFacebookForm.class.php
@@ -61,7 +61,7 @@ class UserLoginFacebookForm extends UserLoginForm {
 		if ( $user instanceof User ) {
 
 			$this->connectWithFacebook( $user );
-			$user->saveSettings();
+			$this->saveUserGender( $user );
 
 			if ( $this->hasConfirmedEmail ) {
 				$this->confirmUser( $user );
@@ -73,6 +73,37 @@ class UserLoginFacebookForm extends UserLoginForm {
 		}
 
 		return $user;
+	}
+
+	/**
+	 * Connects given Wikia account with FB account and sets FB feed preferences
+	 * @param User $user Wikia account
+	 * @return bool true on success
+	 */
+	private function connectWithFacebook( User $user ) {
+		$fbId = FacebookClient::getInstance()->getUserId();
+
+		if ( F::app()->wg->EnableFacebookClientExt ) {
+			$mapping = \FacebookMapModel::createUserMapping( $user->getId(), $fbId );
+			return !empty( $mapping );
+		}
+
+		FBConnectDB::addFacebookID( $user, $fbId );
+		return true;
+	}
+
+	/**
+	 * Save a user's gender from facebook if one is available. Facebook will return the
+	 * following values for a user's gender: 'male', 'female', null.
+	 * @param User $user
+	 */
+	public function saveUserGender( User $user ) {
+		$fbUserInfo = FacebookClient::getInstance()->getUserInfo();
+		$gender = $fbUserInfo->getProperty( 'gender' );
+		if ( !is_null( $gender ) ) {
+			$user->setOption( 'gender', $gender );
+			$user->saveSettings();
+		}
 	}
 
 	/**
@@ -102,24 +133,6 @@ class UserLoginFacebookForm extends UserLoginForm {
 	private function sendConfirmationEmail() {
 		$userLoginHelper = new UserLoginHelper();
 		$userLoginHelper->sendConfirmationEmail( $this->mUsername );
-	}
-
-	/**
-	 * Connects given Wikia account with FB account and sets FB feed preferences
-	 *
-	 * @param User $user Wikia account
-	 * @return bool true on success
-	 */
-	private function connectWithFacebook( User $user ) {
-		$fbId = FacebookClient::getInstance()->getUserId();
-
-		if ( F::app()->wg->EnableFacebookClientExt ) {
-			$mapping = \FacebookMapModel::createUserMapping( $user->getId(), $fbId );
-			return !empty( $mapping );
-		}
-
-		FBConnectDB::addFacebookID( $user, $fbId );
-		return true;
 	}
 
 	/**


### PR DESCRIPTION
If a user signs up for a new Wikia account via Facebook, we want to make sure to collect their gender if it's available. During signup we now check with FB to see if they have a gender for the user and, if so, save it on our end.
