### PR TITLE
Switch to bzip2 compression to avoid invalid gzip files

### DIFF
--- a/extensions/wikia/WikiFactory/Dumps/runBackups.php
+++ b/extensions/wikia/WikiFactory/Dumps/runBackups.php
@@ -124,7 +124,7 @@ function runBackups( $from, $to, $full, $options ) {
 		$basedir = getDirectory( $row->city_dbname, $hide, $use_temp );
 
 		if( $full || $both ) {
-			$path = sprintf("%s/%s_pages_full.xml.gz", $basedir, $row->city_dbname );
+			$path = sprintf("%s/%s_pages_full.xml.bz2", $basedir, $row->city_dbname );
 			$time = wfTime();
 			Wikia::log( __METHOD__, "info", "{$row->city_id} {$row->city_dbname} {$path}", true, true );
 			$cmd = array(
@@ -137,7 +137,7 @@ function runBackups( $from, $to, $full, $options ) {
 				"--xml",
 				"--quiet",
 				"--server=$server",
-				"--output=gzip:{$path}"
+				"--output=bzip2:{$path}"
 			);
 			wfShellExec( implode( " ", $cmd ), $status );
 			$time = Wikia::timeDuration( wfTime() - $time );
@@ -148,7 +148,7 @@ function runBackups( $from, $to, $full, $options ) {
 
 		}
 		if( !$full || $both ) {
-			$path = sprintf("%s/%s_pages_current.xml.gz", $basedir, $row->city_dbname );
+			$path = sprintf("%s/%s_pages_current.xml.bz2", $basedir, $row->city_dbname );
 			$time = wfTime();
 			Wikia::log( __METHOD__, "info", "{$row->city_id} {$row->city_dbname} {$path}", true, true);
 			$cmd = array(
@@ -161,7 +161,7 @@ function runBackups( $from, $to, $full, $options ) {
 				"--xml",
 				"--quiet",
 				"--server=$server",
-				"--output=gzip:{$path}"
+				"--output=bzip2:{$path}"
 			);
 			wfShellExec( implode( " ", $cmd ), $status );
 			$time = Wikia::timeDuration( wfTime() - $time );


### PR DESCRIPTION
Currently, several dump gzip files are truncated to 419430400 bytes and are invalid:
d/dr/dragonball_pages_full.xml.gz
f/fa/fairytail_pages_full.xml.gz
h/ha/harrypotter_pages_full.xml.gz
h/hu/hurricanes_pages_full.xml.gz
n/na/naruto_pages_full.xml.gz
o/on/onepiece_pages_full.xml.gz
s/sm/smallville_pages_full.xml.gz
s/so/sonic_pages_full.xml.gz
s/st/starwars_pages_full.xml.gz

This should be fixed, but perhaps it's easier to compress the files below that limit.
Alternatives tested for compression of chillsonicfanon_pages_full.xml, 1.2 G:
- gzip -9 (current): 326 MB output, 1m28.592s user CPU
- 7z -mx=4: 8.4 MB, 0m37.062s
- 7z -mx=5 (default): 5 MB, 6m4.659s
- bzip2 (default): 70 MB, 4m51.169s
- bzip2 -1: 272 MB, 2m52.304s

We can't alter MediaWiki's 7z command (setup7zCommand() in Export.php) 
nor we have an environment variable to use:
https://sourceforge.net/p/sevenzip/discussion/45798/thread/70f81b1a/
So we could sacrifice some CPU to use bzip2 defaults and preserve disk.
