### PR TITLE
PLATFORM-662: Fix Bucky on uncyclopedia

### DIFF
--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1604,6 +1604,7 @@ $wgBuckyEnabledSkins = [
 	'monobook',
 	'oasis',
 	'venus',
+	'uncyclopedia',
 ];
 
 /*


### PR DESCRIPTION
Fix Bucky on uncyclopedia which means make the code initialize the config on "uncyclopedia" skin.

https://wikia-inc.atlassian.net/browse/PLATFORM-662

/cc @kvas-damian @Wikia/platform-team 
