### PR TITLE
VE-1747: Fix PHP errors, introduce config classes

### DIFF
--- a/extensions/VisualEditor/VisualEditor.hooks.php
+++ b/extensions/VisualEditor/VisualEditor.hooks.php
@@ -17,7 +17,9 @@ class VisualEditorHooks {
 		// parties who attempt to install VisualEditor onto non-alpha wikis, as
 		// this should have no impact on deploying to Wikimedia's wiki cluster;
 		// is fine for release tarballs because 1.22wmf11 < 1.22alpha < 1.22.0.
-		wfUseMW( '1.25wmf13' );
+
+		// Wikia change: skip version check
+		// wfUseMW( '1.25wmf13' );
 	}
 
 	/**
@@ -378,14 +380,16 @@ class VisualEditorHooks {
 	 * Adds extra variables to the page config.
 	 */
 	public static function onMakeGlobalVariablesScript( array &$vars, OutputPage $out ) {
+		global $wgSVGMaxSize, $wgNamespacesWithSubpages;
+
 		$pageLanguage = $out->getTitle()->getPageLanguage();
 
 		$vars['wgVisualEditor'] = array(
 			'isPageWatched' => $out->getUser()->isWatched( $out->getTitle() ),
 			'pageLanguageCode' => $pageLanguage->getHtmlCode(),
 			'pageLanguageDir' => $pageLanguage->getDir(),
-			'svgMaxSize' => $out->getConfig()->get( 'SVGMaxSize' ),
-			'namespacesWithSubpages' => $out->getConfig()->get( 'NamespacesWithSubpages' )
+			'svgMaxSize' => $wgSVGMaxSize,
+			'namespacesWithSubpages' => $wgNamespacesWithSubpages
 		);
 
 		return true;
@@ -434,7 +438,8 @@ class VisualEditorHooks {
 	 * @return boolean true
 	 */
 	public static function onResourceLoaderRegisterModules( ResourceLoader &$resourceLoader ) {
-		$resourceModules = $resourceLoader->getConfig()->get( 'ResourceModules' );
+		global $wgResourceModules;
+
 		$veResourceTemplate = ConfigFactory::getDefaultInstance()
 			->makeConfig( 'visualeditor')->get( 'VisualEditorResourceTemplate' );
 		$libModules = array(

--- a/includes/config/Config.php
+++ b/includes/config/Config.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Copyright 2014
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * http://www.gnu.org/copyleft/gpl.html
+ *
+ * @file
+ */
+
+/**
+ * Interface for configuration instances
+ *
+ * @since 1.23
+ */
+interface Config {
+
+	/**
+	 * Get a configuration variable such as "Sitename" or "UploadMaintenance."
+	 *
+	 * @param string $name Name of configuration option
+	 * @return mixed Value configured
+	 * @throws ConfigException
+	 */
+	public function get( $name );
+
+	/**
+	 * Check whether a configuration option is set for the given name
+	 *
+	 * @param string $name Name of configuration option
+	 * @return bool
+	 * @since 1.24
+	 */
+	public function has( $name );
+}

--- a/includes/config/ConfigFactory.php
+++ b/includes/config/ConfigFactory.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * Copyright 2014
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * http://www.gnu.org/copyleft/gpl.html
+ *
+ * @file
+ */
+
+/**
+ * Factory class to create Config objects
+ *
+ * @since 1.23
+ */
+class ConfigFactory {
+
+	/**
+	 * Map of config name => callback
+	 * @var array
+	 */
+	protected $factoryFunctions = array();
+
+	/**
+	 * Config objects that have already been created
+	 * name => Config object
+	 * @var array
+	 */
+	protected $configs = array();
+
+	/**
+	 * @var ConfigFactory
+	 */
+	private static $self;
+
+	public static function getDefaultInstance() {
+		if ( !self::$self ) {
+			self::$self = new self;
+			global $wgConfigRegistry;
+			foreach ( $wgConfigRegistry as $name => $callback ) {
+				self::$self->register( $name, $callback );
+			}
+		}
+		return self::$self;
+	}
+
+	/**
+	 * Destroy the default instance
+	 * Should only be called inside unit tests
+	 * @throws MWException
+	 * @codeCoverageIgnore
+	 */
+	public static function destroyDefaultInstance() {
+		if ( !defined( 'MW_PHPUNIT_TEST' ) ) {
+			throw new MWException( __METHOD__ . ' was called outside of unit tests' );
+		}
+
+		self::$self = null;
+	}
+
+	/**
+	 * Register a new config factory function
+	 * Will override if it's already registered
+	 * @param string $name
+	 * @param callable $callback That takes this ConfigFactory as an argument
+	 * @throws InvalidArgumentException If an invalid callback is provided
+	 */
+	public function register( $name, $callback ) {
+		if ( !is_callable( $callback ) ) {
+			throw new InvalidArgumentException( 'Invalid callback provided' );
+		}
+		$this->factoryFunctions[$name] = $callback;
+	}
+
+	/**
+	 * Create a given Config using the registered callback for $name.
+	 * If an object was already created, the same Config object is returned.
+	 * @param string $name Name of the extension/component you want a Config object for
+	 *                     'main' is used for core
+	 * @throws ConfigException If a factory function isn't registered for $name
+	 * @throws UnexpectedValueException If the factory function returns a non-Config object
+	 * @return Config
+	 */
+	public function makeConfig( $name ) {
+		if ( !isset( $this->configs[$name] ) ) {
+			if ( !isset( $this->factoryFunctions[$name] ) ) {
+				throw new ConfigException( "No registered builder available for $name." );
+			}
+			$conf = call_user_func( $this->factoryFunctions[$name], $this );
+			if ( $conf instanceof Config ) {
+				$this->configs[$name] = $conf;
+			} else {
+				throw new UnexpectedValueException( "The builder for $name returned a non-Config object." );
+			}
+		}
+
+		return $this->configs[$name];
+	}
+}

--- a/includes/config/GlobalVarConfig.php
+++ b/includes/config/GlobalVarConfig.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Copyright 2014
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * http://www.gnu.org/copyleft/gpl.html
+ *
+ * @file
+ */
+
+/**
+ * Accesses configuration settings from $GLOBALS
+ *
+ * @since 1.23
+ */
+class GlobalVarConfig implements Config {
+
+	/**
+	 * Prefix to use for configuration variables
+	 * @var string
+	 */
+	private $prefix;
+
+	/**
+	 * Default builder function
+	 * @return GlobalVarConfig
+	 */
+	public static function newInstance() {
+		return new GlobalVarConfig();
+	}
+
+	public function __construct( $prefix = 'wg' ) {
+		$this->prefix = $prefix;
+	}
+
+	/**
+	 * @see Config::get
+	 */
+	public function get( $name ) {
+		if ( !$this->has( $name ) ) {
+			throw new ConfigException( __METHOD__ . ": undefined option: '$name'" );
+		}
+		return $this->getWithPrefix( $this->prefix, $name );
+	}
+
+	/**
+	 * @see Config::has
+	 */
+	public function has( $name ) {
+		return $this->hasWithPrefix( $this->prefix, $name );
+	}
+
+	/**
+	 * Get a variable with a given prefix, if not the defaults.
+	 *
+	 * @param string $prefix Prefix to use on the variable, if one.
+	 * @param string $name Variable name without prefix
+	 * @return mixed
+	 */
+	protected function getWithPrefix( $prefix, $name ) {
+		return $GLOBALS[$prefix . $name];
+	}
+
+	/**
+	 * Check if a variable with a given prefix is set
+	 *
+	 * @param string $prefix Prefix to use on the variable
+	 * @param string $name Variable name without prefix
+	 * @return bool
+	 */
+	protected function hasWithPrefix( $prefix, $name ) {
+		$var = $prefix . $name;
+		return array_key_exists( $var, $GLOBALS );
+	}
+}

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -66,7 +66,6 @@ if($wgDBname != 'uncyclo') {
  */
 global $wgAutoloadClasses;
 
-
 /**
  * Nirvana framework classes
  */
@@ -526,6 +525,13 @@ $wgAutoloadClasses[ "WikiaValidatorDependent"       ] = "$IP/includes/wikia/vali
 $wgAutoloadClasses[ 'WikiaValidatorRestrictiveUrl'  ] = "$IP/includes/wikia/validators/WikiaValidatorRestrictiveUrl.class.php";
 $wgAutoloadClasses[ 'WikiaValidatorUsersUrl'        ] = "$IP/includes/wikia/validators/WikiaValidatorUsersUrl.class.php";
 include_once("$IP/includes/wikia/validators/WikiaValidatorsExceptions.php");
+
+/**
+ * MediaWiki Config
+ */
+$wgAutoloadClasses['Config'] = $IP . '/includes/config/Config.php';
+$wgAutoloadClasses['ConfigFactory'] = $IP . '/includes/config/ConfigFactory.php';
+$wgAutoloadClasses['GlobalVarConfig'] = $IP . '/includes/config/GlobalVarConfig.php';
 
 /**
  * registered API methods


### PR DESCRIPTION
PHP globals are used for OutputPage and ResourceLoader to avoid rewriting them to use ConfigFactory. ConfigFactory and related files are ported to support the multiple uses within VisualEditor.hooks.php.

Changes:
Ported ConfigFactory and related classes
No longer checking MW version
