### PR TITLE
GlobalTitle: use shared and cross-clusters memcache key

### DIFF
--- a/includes/wikia/GlobalTitle.php
+++ b/includes/wikia/GlobalTitle.php
@@ -821,9 +821,9 @@ class GlobalTitle extends Title {
 	 * @return string
 	 */
 	private function memcKey() {
-		global $wgSharedDB, $wgDevelEnvironmentName;
+		global $wgSharedKeyPrefix, $wgDevelEnvironmentName;
 
-		$parts = array( $wgSharedDB, "globaltitle", $this->mCityId );
+		$parts = array( $wgSharedKeyPrefix, "globaltitle", $this->mCityId );
 
 		if (!empty($wgDevelEnvironmentName)) {
 			$parts[] = $wgDevelEnvironmentName;


### PR DESCRIPTION
An easy fix found while working on PLATFORM-292

Use `wikicities:globaltitle:80433` key instead of `wikicities_c6:globaltitle:80433` (i.e. per cluster)

@wladekb / @michalroszka / @jcellary 
