### PR TITLE
PLATFORM-292: WikiaNewtalk - improve memcache key structure

### DIFF
--- a/extensions/wikia/WikiaNewtalk/wikia_newtalk.php
+++ b/extensions/wikia/WikiaNewtalk/wikia_newtalk.php
@@ -3,6 +3,18 @@
 $wgWikiaNewtalkExpiry = 300;
 
 /**
+ * Generate a memcache key for given user's shared message cache
+ *
+ * Either user's ID (logged-in) or his IP (anon) will be used
+ *
+ * @param User $user
+ * @return string
+ */
+function wfWikiaNewTalkMemcKey( User $user ) {
+	return wfSharedMemcKey( 'WikiaSharedNewTalk', $user->isLoggedIn() ? $user->getId() : $user->getName() );
+}
+
+/**
  * wfSetWikiaNewtalk
  *
  * Hook, set new wikia shared message
@@ -16,7 +28,7 @@ $wgWikiaNewtalkExpiry = 300;
  * @return false: don't go to next hook
  */
 function wfSetWikiaNewtalk( &$article ) {
-	global $wgMemc, $wgWikiaNewtalkExpiry, $wgExternalSharedDB;
+	global $wgMemc, $wgExternalSharedDB;
 	$name = $article->mTitle->getDBkey();
 	$other = User::newFromName( $name );
 
@@ -58,8 +70,7 @@ function wfSetWikiaNewtalk( &$article ) {
             __METHOD__
         );
         $dbw->commit();
-		$key = 'wikia:shared_newtalk:'.$other->getID().':'.str_replace( ' ', '_', $other->getName() );
-		$wgMemc->delete( $key );
+		$wgMemc->delete( wfWikiaNewTalkMemcKey( $other ) );
 	}
 	return false;
 }
@@ -69,7 +80,7 @@ function wfSetWikiaNewtalk( &$article ) {
  * @param $talks
  * @return bool
  */
-function wfGetWikiaNewtalk( &$user, &$talks ) {
+function wfGetWikiaNewtalk( User $user, &$talks ) {
 	global $wgMemc, $wgWikiaNewtalkExpiry, $wgExternalSharedDB;
 
 	# hack: don't check it for our varnish ip addresses
@@ -81,7 +92,7 @@ function wfGetWikiaNewtalk( &$user, &$talks ) {
 		return true;
 	}
 	wfProfileIn( __METHOD__ );
-	$key = 'wikia:shared_newtalk:'.$user->getID().':'.str_replace( ' ', '_', $user->getName() );
+	$key = wfWikiaNewTalkMemcKey( $user );
 	$wikia_talks = $wgMemc->get( $key );
 	if( !is_array( $wikia_talks ) ) {
 		$wikia_talks = array();
@@ -150,7 +161,7 @@ function wfGetWikiaNewtalk( &$user, &$talks ) {
  *
  * @return true: don't stop hook's processing
  */
-function wfClearWikiaNewtalk( &$user ) {
+function wfClearWikiaNewtalk( User $user ) {
 	global $wgMemc, $wgExternalSharedDB;
 
 	$dbw = wfGetDB( DB_MASTER, array(), $wgExternalSharedDB );
@@ -163,8 +174,7 @@ function wfClearWikiaNewtalk( &$user ) {
         ),
         __METHOD__
     );
-	$key = 'wikia:shared_newtalk:'.$user->getID().':'.str_replace( ' ', '_', $user->getName() );
-	$wgMemc->delete( $key );
+	$wgMemc->delete( wfWikiaNewTalkMemcKey( $user ) );
 	return true;
 }
 
@@ -208,8 +218,7 @@ function wfDismissWikiaNewtalks() {
 		$dbw = wfGetDB(DB_MASTER);
 		$dbw->commit();
 
-		$key = 'wikia:shared_newtalk:'.$wgUser->getID().':'.str_replace( ' ', '_', $wgUser->getName() );
-		$wgMemc->delete( $key );
+		$wgMemc->delete( wfWikiaNewTalkMemcKey( $wgUser ) );
 
 		$result = true;
 	}


### PR DESCRIPTION
Improve the structure of the memcache key

Instead of `wikia:shared_newtalk:<user ID>:My_Long_UserName` use the following:

```
wikicities:WikiaSharedNewTalk:<anon's IP>
wikicities:WikiaSharedNewTalk:<logged-in user ID>
```
- code cleanup
- removal of c&p code that generated memcache keys

@wladekb / @michalroszka / @jcellary 
