### PR TITLE
(CE-1185) Fix fatal error on close account

### DIFF
--- a/extensions/wikia/EditAccount/SpecialEditAccount_body.php
+++ b/extensions/wikia/EditAccount/SpecialEditAccount_body.php
@@ -427,9 +427,14 @@ class EditAccount extends SpecialPage {
 	 * @return void
 	 */
 	public static function disconnectFBConnect( User $user ) {
-		$fbIds = FBConnectDB::getFacebookIDs( $user );
-		if ( !empty( $fbIds ) ) {
-			FBConnectDB::removeFacebookID( $user );
+		global $wgEnableFacebookClientExt;
+		if ( !empty( $wgEnableFacebookClientExt ) ) {
+			FacebookMapModel::deleteFromWikiaID( $user->getId() );
+		} else {
+			$fbIds = FBConnectDB::getFacebookIDs( $user );
+			if ( !empty( $fbIds ) ) {
+				FBConnectDB::removeFacebookID( $user );
+			}
 		}
 	}
 


### PR DESCRIPTION
When the new FacebookClient is enabled, the old FBConnect isn't available
and so removing the account from FBConnect fails. Add a check for the new
version and use its method of disconnecting accounts from Facebook.

This has stopped account closures from being logged since the start of the month, and potentially allows people with FB Connected accounts to still login after their account is closed.

Cherry-picked from dev (https://github.com/Wikia/app/pull/5830).

For approval by UConn before releasing. /cc @garthwebb @lizlux 
