### PR TITLE
VOLDEV-92 - Fix IE word-wrap bug

### DIFF
--- a/extensions/3rdparty/tabber/tabber.css
+++ b/extensions/3rdparty/tabber/tabber.css
@@ -28,6 +28,14 @@ ul.tabbernav
  padding: 3px 0;
  border-bottom: 1px solid #778;
  font: bold 12px Verdana, sans-serif;
+ /*
+  * begin wikia change
+  * VOLDEV-92
+  * @author Cqm
+  * Fixes weird word break issues in IE
+  */
+ word-wrap: normal;
+ /* end wikia change */
 }
 
 ul.tabbernav li


### PR DESCRIPTION
@Grunny Fixes odd word-wrap bug in IE11, possibly caused by inheriting a rule from `.WikiaArticle`. This does cause a slight `overflow:hidden` issue (see screenshot in ticket), but that seems limited to the right border on a tab intermittently disappearing.
