### PR TITLE
PLATFORM-664 vary memcache by environment

### DIFF
--- a/extensions/wikia/Staging/Staging.setup.php
+++ b/extensions/wikia/Staging/Staging.setup.php
@@ -19,3 +19,15 @@ $wgAutoloadClasses['StagingHooks'] =  $dir . 'StagingHooks.class.php';
 
 $wgHooks['MakeGlobalVariablesScript'][] = 'StagingHooks::onMakeGlobalVariablesScript';
 $wgHooks['BeforePageRedirect'][] = 'StagingHooks::onBeforePageRedirect';
+
+/**
+ * Vary memcache by environment
+ *
+ * We append wfWikiID() here as wfMemcKey() uses
+ * $wgCachePrefix or wfWikiID() if the first one is not set
+ *
+ * @author macbre
+ * @see PLATFORM-664
+ */
+$wgCachePrefix = gethostname() . '-' . wfWikiID(); // e.g. staging-s3-muppet / sandbox-qa02-glee / ...
+$wgSharedKeyPrefix = gethostname() . '-' . $wgSharedKeyPrefix; // e.g. staging-s3-wikicities

--- a/includes/wikia/GlobalTitle.php
+++ b/includes/wikia/GlobalTitle.php
@@ -288,7 +288,7 @@ class GlobalTitle extends Title {
 	 * Get a real URL referring to this title
 	 *
 	 * @param string $query an optional query string
-	 * @param string $variant language variant of url (for sr, zh..)
+	 * @param string|bool $variant language variant of url (for sr, zh..)
 	 *
 	 * @return string the URL
 	 */
@@ -320,7 +320,7 @@ class GlobalTitle extends Title {
 	 * getInternalUrl from Title is not working corretly with GlobalTitle so it is fixed by getting FullURL
 	 *
 	 * @param string $query an optional query string
-	 * @param string $query2 (deprecated) language variant of url (for sr, zh..)
+	 * @param string|bool $query2 (deprecated) language variant of url (for sr, zh..)
 	 *
 	 * @return string
 	 */
@@ -332,7 +332,7 @@ class GlobalTitle extends Title {
 	 * local url doesn't make sense in this context. we always return full URL
 	 *
 	 * @param string $query an optional query string
-	 * @param string $variant language variant of url (for sr, zh..)
+	 * @param string|bool $variant language variant of url (for sr, zh..)
 	 *
 	 * @return string
 	 */
@@ -604,11 +604,10 @@ class GlobalTitle extends Title {
 		return preg_replace( '!^' . $articlePath . '/!i', '', $path );
 	}
 
-
 	/**
 	 * check if page exists
 	 *
-	 * @return 0/1
+	 * @return int 0/1
 	 */
 	public function exists() {
 		$this->loadAll();
@@ -821,11 +820,7 @@ class GlobalTitle extends Title {
 	 * @return string
 	 */
 	private function memcKey() {
-		global $wgSharedKeyPrefix, $wgDevelEnvironmentName;
-
-		$parts = array( $wgSharedKeyPrefix, "globaltitle", $this->mCityId, Wikia::getEnvironmentName() );
-
-		return implode(":", $parts);
+		return wfSharedMemcKey( 'globaltitle', $this->mCityId );
 	}
 
 	/**

--- a/maintenance/wikia/imports/WikiaComWikisList.php
+++ b/maintenance/wikia/imports/WikiaComWikisList.php
@@ -393,7 +393,7 @@ class WikiaComWikisListImport {
 	}
 
 	protected function addToVisualizationTable($wikiData) {
-		global $wgSharedKeyPrefix;
+		global $wgSharedDB;
 		wfProfileIn(__METHOD__);
 
 		$wikiId = intval($wikiData['city_id']);
@@ -405,7 +405,7 @@ class WikiaComWikisListImport {
 			$this->wikisPerVertical[$wikiVertical->cat_name] = 1;
 		}
 
-		$db = wfGetDb(DB_MASTER, array(), $wgSharedKeyPrefix);
+		$db = wfGetDb(DB_MASTER, array(), $wgSharedDB);
 		$row = $db->selectRow('wikicities.city_visualization',
 			array('city_id'),
 			array('city_id' => $wikiId)


### PR DESCRIPTION
Use `gethostname()` as a prefix for both local and shared memcache keys in staging (preview / verify) and sandbox environments to **prevent production cache pollution**.

We can consider using the same approach for devboxes.

Replaces a quick fix from #5765

@Wikia/platform-team 
