### PR TITLE
PLATFORM-679 - fix ReplaceImageServerTest failing

### DIFF
--- a/includes/wikia/tests/ReplaceImageServerTest.php
+++ b/includes/wikia/tests/ReplaceImageServerTest.php
@@ -59,9 +59,12 @@ class ReplaceImageServerTest extends WikiaBaseTest {
 		$devImageServer = 'images.hakarl.wikia-dev.com';
 		$this->mockGlobalVariable( 'wgDevBoxImageServerOverride', $devImageServer );
 
+		// test logic for the old thumbnailer
+		$this->mockGlobalVariable('wgEnableVignette', false);
 		$testURL = wfReplaceImageServer( $url, $timestamp );
 		$this->assertEquals( $expected, $testURL, 'URL returned by wfReplaceImageServer should match expected one' );
 
+		// test logic for the Vignette
 		$this->mockGlobalVariable('wgEnableVignette', true);
 		$testURL = wfReplaceImageServer( $url, $timestamp );
 		$this->assertEquals( 0, preg_match( '/images\.hakarl\.wikia-dev\.com/', $testURL ), 'URL returned by wfReplaceImageServer be the original with wgEnableVignette = true' );


### PR DESCRIPTION
Mock `wgEnableVignette` correctly

@Wikia/platform-team 
