### PR TITLE
wfMessage('Description') as meta tag description for main pages

### DIFF
--- a/includes/wikia/api/ArticlesApiController.class.php
+++ b/includes/wikia/api/ArticlesApiController.class.php
@@ -1350,17 +1350,11 @@ class ArticlesApiController extends WikiaApiController {
 	 * @return string
 	 * @throws WikiaException
 	 */
-	protected function getArticleDescription( $article, $descLength = 100 ) {
+	protected function getArticleDescription( Article $article, $descLength = 100 ) {
 		$title = $article->getTitle();
 		$sMessage = null;
-		$sMainPage = wfMessage( 'Mainpage' )->inContentLanguage()->text();
-		if ( strpos( $sMainPage, ':' ) !== false ) {
-			$sTitle = $title->getFullText();
-		} else {
-			$sTitle = $title->getText();
-		}
 
-		if ( strcmp( $sTitle, $sMainPage ) == 0 ) {
+		if ( $title->isMainPage() ) {
 			// we're on Main Page, check MediaWiki:Description message
 			$sMessage = wfMessage( 'Description' )->text();
 		}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/HG-488

Added support for `wfMessage('Description')` as a value for the main page's meta tag description.
This is currently being done by the `ArticleMediaDescription` extension but not when the `ArticlesApi` is used.
