### PR TITLE
Converting wfMsg to wfMessage

### DIFF
--- a/extensions/wikia/AdminDashboard/QuickStatsController.class.php
+++ b/extensions/wikia/AdminDashboard/QuickStatsController.class.php
@@ -142,14 +142,20 @@ class QuickStatsController extends WikiaController {
 	}
 
 	public static function shortenNumberDecorator($number) {
-		$number = intval($number);
+		$number = intval( $number );
 
 		if ( $number >= 1000000000 ) {
-			return wfMsg('quickstats-number-shortening-billions', array(round( $number / 1000000000, 1)));
-		} elseif ($number >= 1000000 ) {
-			return wfMsg('quickstats-number-shortening-millions', array(round( $number / 1000000, 1)));
-		} elseif ($number >= 10000 ) {
-			return wfMsg('quickstats-number-shortening', array(round( $number / 1000 , 1)));
+			return wfMessage( 'quickstats-number-shortening-billions' )
+				->params( round( $number / 1000000000, 1 ) )
+				->parse();
+		} elseif ( $number >= 1000000 ) {
+			return wfMessage( 'quickstats-number-shortening-millions' )
+				->params( round( $number / 1000000, 1 ) )
+				->parse();
+		} elseif ( $number >= 10000 ) {
+			return wfMessage( 'quickstats-number-shortening' )
+				->params( round( $number / 1000 , 1 ) )
+				->parse();
 		} else {
 			return F::app()->wg->Lang->formatNum( $number );
 		}


### PR DESCRIPTION
There were some admin dashboard tests that were failing due to message translation issues. It turns out the code in this PR wasn't the fix for the tests, the fix was to run rebuild messages on my devbox, but while I was in this code I converted `wfMsg` to `wfMessage`, so I figured I'd commit that code. 
