### PR TITLE
Vignette fix unit tests

### DIFF
--- a/includes/wikia/services/tests/AvatarServiceTest.php
+++ b/includes/wikia/services/tests/AvatarServiceTest.php
@@ -1,6 +1,11 @@
 <?php
 class AvatarServiceTest extends WikiaBaseTest {
 
+	public function setUp() {
+		parent::setUp();
+		$this->mockGlobalVariable( 'wgEnableVignette', true );
+	}
+
 	/**
 	 * @dataProvider getDefaultAvatarDataProvider
 	 * @group UsingDB

--- a/includes/wikia/services/tests/AvatarServiceTest.php
+++ b/includes/wikia/services/tests/AvatarServiceTest.php
@@ -69,14 +69,14 @@ class AvatarServiceTest extends WikiaBaseTest {
 		return [
 			// anon
 			[
-				'url' => '/images/thumb/1/19/Avatar.jpg/20px-Avatar.jpg',
+				'url' => '/images/1/19/Avatar.jpg/revision/latest/scale-to-width/20',
 				'userName' => '80.2.3.4',
 				'userId' => 0,
 				'avatarSize' => 20,
 			],
 			// logged-in
 			[
-				'url' => '/images/thumb/e/e1/123456/20px-123456',
+				'url' => '/images/e/e1/123456/revision/latest/scale-to-width/20',
 				'userName' => 'TestUser123',
 				'userId' => 123456,
 				'avatarSize' => 20,

--- a/tests/unit/ServiceTest.php
+++ b/tests/unit/ServiceTest.php
@@ -18,20 +18,20 @@ class ServiceTest extends WikiaBaseTest {
 		$anonName = '10.10.10.10';
 		$userName = 'WikiaBot';
 
-		$this->mockGlobalVariable('wgDevBoxImageServerOverride', 'images.foo.wikia-dev.com');
+		$this->mockGlobalVariable('wgVignetteUrl', 'http://images.foo.wikia-dev.com');
+		$this->mockGlobalVariable('wgEnableVignette', true);
 
 		// users
-		$this->assertRegExp('/width="32"/', AvatarService::render($userName, 32));
-		$this->assertRegExp('/\/20px-/', AvatarService::render($userName, 16));
-		$this->assertRegExp('/User:WikiaBot/', AvatarService::renderLink($userName));
+		$this->assertContains('width="32"', AvatarService::render($userName, 32));
+		$this->assertContains('/scale-to-width/20"', AvatarService::render($userName, 16));
+		$this->assertContains('User:WikiaBot', AvatarService::renderLink($userName));
 		$this->assertRegExp('/^<img src="http:\/\/images/', AvatarService::renderAvatar($userName));
-		$this->assertRegExp('/^http:\/\/images/', AvatarService::getAvatarUrl($userName));
 
 		// anons
-		$this->assertRegExp('/Special:Contributions\//', AvatarService::getUrl($anonName));
+		$this->assertContains('Special:Contributions/', AvatarService::getUrl($anonName));
 		$this->assertRegExp('/^<img src="/', AvatarService::renderAvatar($anonName));
-		$this->assertRegExp('/\/20px-/', AvatarService::renderAvatar($anonName, 20));
-		$this->assertRegExp('/Special:Contributions/', AvatarService::renderLink($anonName));
+		$this->assertContains('/20px-', AvatarService::renderAvatar($anonName, 20));
+		$this->assertContains('Special:Contributions', AvatarService::renderLink($anonName));
 	}
 
 	/**


### PR DESCRIPTION
The Last Set Of Fixes, now we should be fine :)

@Wikia/platform-team / @lizlux 

```
1) ServiceTest::testAvatarService
Failed asserting that '<img src="http://vignette.wikia-dev.com/messaging/images/1/19/Avatar.jpg/revision/latest/scale-to-width/20" width="16" height="16" class="avatar" alt="WikiaBot" /> <a href="/wiki/User:WikiaBot">WikiaBot</a>' matches PCRE pattern "/\/20px-/".

/var/lib/jenkins/workspace/phpUnit_trunkUnit/tests/unit/ServiceTest.php:25

2) AvatarServiceTest::testGetAvatarUrl with data set #0 ('/images/thumb/1/19/Avatar.jpg/20px-Avatar.jpg', '80.2.3.4', 0, 20)
Failed asserting that 'http://vignette.wikia-dev.com/messaging/images/1/19/Avatar.jpg/revision/latest/scale-to-width/20' ends with "/images/thumb/1/19/Avatar.jpg/20px-Avatar.jpg".

/var/lib/jenkins/workspace/phpUnit_trunkUnit/includes/wikia/services/tests/AvatarServiceTest.php:65

3) AvatarServiceTest::testGetAvatarUrl with data set #1 ('/images/thumb/e/e1/123456/20px-123456', 'TestUser123', 123456, 20)
Failed asserting that 'http://vignette.wikia-dev.com/messaging/images/e/e1/123456/revision/latest/scale-to-width/20' ends with "/images/thumb/e/e1/123456/20px-123456".

/var/lib/jenkins/workspace/phpUnit_trunkUnit/includes/wikia/services/tests/AvatarServiceTest.php:65
```
