### PR TITLE
VE-1746: Get Karma to work properly with Chrome on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ install:
   - cd $TRAVIS_BUILD_DIR/extensions/VisualEditor/lib/ve/
   - npm install
 before_script: 
+  - export CHROME_BIN=chromium-browser
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
   - cd $TRAVIS_BUILD_DIR/extensions/VisualEditor/
   - grunt build
   - cd $TRAVIS_BUILD_DIR/extensions/VisualEditor/lib/ve/

--- a/extensions/VisualEditor/lib/ve/Gruntfile.js
+++ b/extensions/VisualEditor/lib/ve/Gruntfile.js
@@ -180,7 +180,13 @@ module.exports = function ( grunt ) {
 				autoWatch: false
 			},
 			main: {
-				browsers: [ 'Chrome' ],
+				browsers: [ 'ChromeTravisCi' ],
+				customLaunchers: {
+					ChromeTravisCi: {
+						base: 'Chrome',
+						flags: [ '--no-sandbox' ]
+					}
+				},
 				preprocessors: {
 					'src/**/*.js': [ 'coverage' ]
 				},


### PR DESCRIPTION
Travis CI is a headless environment - that's why special treatment for running Chrome is required (xvfb and --no-sandbox).

https://wikia-inc.atlassian.net/browse/VE-1746
