### PR TITLE
Fixed global title unit tests

### DIFF
--- a/includes/wikia/tests/GlobalTitleTest.php
+++ b/includes/wikia/tests/GlobalTitleTest.php
@@ -7,15 +7,7 @@ class GlobalTitleTest extends WikiaBaseTest {
 	function setUp() {
 		parent::setUp();
 
-		$wgMemcMock = $this->getMockBuilder( 'MWMemcached' )
-			->disableOriginalConstructor()
-			->setMethods( [ 'get' ] )
-			->getMock();
-		$wgMemcMock->expects( $this->any() )
-			->method( 'get' )
-			->willReturn( null );
-		$this->mockGlobalVariable( 'wgMemc', $wgMemcMock );
-
+		$this->disableMemCache();
 		$this->getStaticMethodMock( 'WikiFactory', 'getVarValueByName' )
 			->expects( $this->any() )
 			->method( 'getVarValueByName' )

--- a/includes/wikia/tests/GlobalTitleTest.php
+++ b/includes/wikia/tests/GlobalTitleTest.php
@@ -71,8 +71,7 @@ class GlobalTitleTest extends WikiaBaseTest {
 	 */
 	function testUrlsSpacebars() {
 		$title = GlobalTitle::newFromText( "Test Ze Spacjami", NS_TALK, 177 );
-		$url = "http://community.wikia.com/wiki/Talk:Test_Ze_Spacjami";
-		$this->assertTrue( $title->getFullURL() === $url, sprintf("%s = %s, NOT MATCH", $title->getFullURL(), $url ) );
+		$this->assertStringEndsWith( "Talk:Test_Ze_Spacjami", $title->getFullURL(), "verify if whitespaces changed to underscores" );
 	}
 
 	/**

--- a/includes/wikia/tests/GlobalTitleTest.php
+++ b/includes/wikia/tests/GlobalTitleTest.php
@@ -76,20 +76,34 @@ class GlobalTitleTest extends WikiaBaseTest {
 		$this->assertStringEndsWith( "Talk:Test_Ze_Spacjami", $title->getFullURL(), "verify if whitespaces changed to underscores" );
 	}
 
+	function testUrlsSpecialNS() {
+		$title = GlobalTitle::newFromText( "WikiFactory", NS_SPECIAL, 1686 ); # pl.wikia.com
+		$this->assertStringEndsWith(
+			"Special:WikiFactory",
+			$title->getFullURL(),
+			"verify if special pages namespace was used"
+		);
+	}
+
+	function testUrlsWithQueryParams() {
+		$title = GlobalTitle::newFromText( "WikiFactory", NS_SPECIAL, 1686 ); # pl.wikia.com
+		$this->assertStringEndsWith(
+			"?diff=0&oldid=500",
+			$title->getFullURL( wfArrayToCGI( [ "diff" => 0, "oldid" => 500 ] ) ),
+			"verify if special pages namespace was used"
+		);
+	}
+
 	/**
 	 * @group UsingDB
 	 */
-	function testUrlsPolishWiki() {
-		$title = GlobalTitle::newFromText( "WikiFactory", NS_SPECIAL, 1686 ); # pl.wikia.com
-		$url = "http://spolecznosc.wikia.com/wiki/Special:WikiFactory";
-		$this->assertTrue( $title->getFullURL() === $url, sprintf("%s = %s, NOT MATCH", $title->getFullURL(), $url ) );
-
-		$url = "http://spolecznosc.wikia.com/wiki/Special:WikiFactory?diff=0&oldid=500";
-		$this->assertTrue( $title->getFullURL( wfArrayToCGI(array( "diff" => 0, "oldid" => 500 ) ) ) === $url, sprintf("%s = %s, NOT MATCH", $title->getFullURL(), $url ) );
-
+	function testUrlsWithUtf8() {
 		$title = GlobalTitle::newFromText( "Strona główna", false, 1686 ); # pl.wikia.com
-		$url = "http://spolecznosc.wikia.com/wiki/Strona_g%C5%82%C3%B3wna?diff=0&oldid=500";
-		$this->assertTrue( $title->getFullURL( wfArrayToCGI(array( "diff" => 0, "oldid" => 500 ) ) ) === $url, "NOT MATCH" );
+		$this->assertStringEndsWith(
+			"Strona_g%C5%82%C3%B3wna?diff=0&oldid=500",
+			$title->getFullURL( wfArrayToCGI( [ "diff" => 0, "oldid" => 500 ] ) ),
+			"verify if special pages namespace was used"
+		);
 	}
 
 	/**

--- a/includes/wikia/tests/GlobalTitleTest.php
+++ b/includes/wikia/tests/GlobalTitleTest.php
@@ -26,7 +26,7 @@ class GlobalTitleTest extends WikiaBaseTest {
 				[ 'wgServer', 490, 'http://www.wowwiki.com' ],
 				[ 'wgServer', 1686, 'http://spolecznosc.wikia.com' ],
 				/** @see testUrlsMainNSonWoW **/
-				[ 'wgArticlePath', 490, '/wiki/$1' ],
+				[ 'wgArticlePath', 490, '/$1' ],
 				[ 'wgExtraNamespacesLocal', 490, [ 116 => 'Portal' ] ],
 			] );
 
@@ -73,7 +73,7 @@ class GlobalTitleTest extends WikiaBaseTest {
 
 	function testUrlsMainNSonWoW() {
 		$title = GlobalTitle::newFromText( "Main", 116, 490); # wowwiki
-		$url = "http://www.wowwiki.com/wiki/Portal:Main";
+		$url = "http://www.wowwiki.com/Portal:Main";
 		$this->assertTrue( $title->getFullURL() === $url, sprintf("%s = %s, NOT MATCH", $title->getFullURL(), $url ) );
 	}
 

--- a/includes/wikia/tests/GlobalTitleTest.php
+++ b/includes/wikia/tests/GlobalTitleTest.php
@@ -53,8 +53,11 @@ class GlobalTitleTest extends WikiaBaseTest {
 	 */
 	function testUrlsMainNS() {
 		$title = GlobalTitle::newFromText( "Timeline", NS_MAIN, 113 ); # memory-alpha
-		$url = "http://en.memory-alpha.org/wiki/Timeline";
-		$this->assertTrue( $title->getFullURL() === $url, sprintf("%s = %s, NOT MATCH", $title->getFullURL(), $url ) );
+		$this->assertStringEndsWith(
+			"/Timeline",
+			$title->getFullURL(),
+			"verify if there is no namespace if regular main namespace is being used"
+		);
 	}
 
 	/**

--- a/includes/wikia/tests/GlobalTitleTest.php
+++ b/includes/wikia/tests/GlobalTitleTest.php
@@ -44,7 +44,7 @@ class GlobalTitleTest extends WikiaBaseTest {
 		$this->assertTrue( $title->getText() === "Test" );
 
 		$title = GlobalTitle::newFromText( "Test_Ze_Spacjami", NS_MAIN, 177 );
-		$this->assertTrue( $title->getText() === "Test Ze Spacjami", "Underscores, spaces expected" );
+		$this->assertEquals( "Test Ze Spacjami", $title->getText(), "Underscores, spaces expected" );
 	}
 
 	function testNewFromText2() {
@@ -54,31 +54,31 @@ class GlobalTitleTest extends WikiaBaseTest {
 		$this->assertTrue( $title->getText() === "Test" );
 
 		$title = GlobalTitle::newFromText( "Test_Ze_Spacjami", NS_TALK, 177 );
-		$this->assertTrue( $title->getText() === "Test Ze Spacjami", "Underscores, spaces expected" );
+		$this->assertEquals( "Test Ze Spacjami", $title->getText(), "Underscores, spaces expected" );
 	}
 
 	function testUrlsMainNS() {
 		$title = GlobalTitle::newFromText( "Timeline", NS_MAIN, 113 ); # memory-alpha
-		$url = "http://en.memory-alpha.org/wiki/Timeline";
-		$this->assertTrue( $title->getFullURL() === $url, sprintf("%s = %s, NOT MATCH", $title->getFullURL(), $url ) );
+		$expectedUrl = "http://en.memory-alpha.org/wiki/Timeline";
+		$this->assertEquals( $expectedUrl, $title->getFullURL() );
 	}
 
 	function testUrlsMainNSonWoW() {
 		$title = GlobalTitle::newFromText( "Main", 116, 490); # wowwiki
-		$url = "http://www.wowwiki.com/Portal:Main";
-		$this->assertTrue( $title->getFullURL() === $url, sprintf("%s = %s, NOT MATCH", $title->getFullURL(), $url ) );
+		$expectedUrl = "http://www.wowwiki.com/Portal:Main";
+		$this->assertEquals( $expectedUrl, $title->getFullURL() );
 	}
 
 	function testUrlsSpacebars() {
 		$title = GlobalTitle::newFromText( "Test Ze Spacjami", NS_TALK, 177 );
-		$url = "http://community.wikia.com/wiki/Talk:Test_Ze_Spacjami";
-		$this->assertTrue( $title->getFullURL() === $url, sprintf("%s = %s, NOT MATCH", $title->getFullURL(), $url ) );
+		$expectedUrl = "http://community.wikia.com/wiki/Talk:Test_Ze_Spacjami";
+		$this->assertEquals( $expectedUrl, $title->getFullURL() );
 	}
 
 	function testUrlsSpecialNS() {
 		$title = GlobalTitle::newFromText( "WikiFactory", NS_SPECIAL, 1686 ); # pl.wikia.com
-		$url = "http://spolecznosc.wikia.com/wiki/Special:WikiFactory";
-		$this->assertTrue( $title->getFullURL() === $url, sprintf("%s = %s, NOT MATCH", $title->getFullURL(), $url ) );
+		$expectedUrl = "http://spolecznosc.wikia.com/wiki/Special:WikiFactory";
+		$this->assertEquals( $expectedUrl, $title->getFullURL() );
 	}
 
 	function testUrlsWithQueryParams() {

--- a/includes/wikia/tests/GlobalTitleTest.php
+++ b/includes/wikia/tests/GlobalTitleTest.php
@@ -3,13 +3,7 @@
 class GlobalTitleTest extends WikiaBaseTest {
 	private $wgDevelEnv;
 	private $wgDevelEnvName;
-	private $wikiUrlsMock = [
-		177 => 'http://community.wikia.com',
-		113 => 'http://en.memory-alpha.org',
-		490 => 'http://www.wowwiki.com',
-		1686 => 'http://spolecznosc.wikia.com',
-	];
-	
+
 	function setUp() {
 		parent::setUp();
 
@@ -22,19 +16,20 @@ class GlobalTitleTest extends WikiaBaseTest {
 			->willReturn( null );
 		$this->mockGlobalVariable( 'wgMemc', $wgMemcMock );
 
-		$this->mockStaticMethodWithCallback( 'WikiFactory', 'getVarValueByName', function( $cvName, $cityId ) {
-			$mockedReturnValue = null;
-
-			if ( $cvName === 'wgExtraNamespacesLocal' ) {
+		$this->getStaticMethodMock( 'WikiFactory', 'getVarValueByName' )
+			->expects( $this->any() )
+			->method( 'getVarValueByName' )
+			->willReturnMap( [
+				// basically all tests where GlobalTitle::load() is executed
+				[ 'wgServer', 177, 'http://community.wikia.com' ],
+				[ 'wgServer', 113, 'http://en.memory-alpha.org' ],
+				[ 'wgServer', 490, 'http://www.wowwiki.com' ],
+				[ 'wgServer', 1686, 'http://spolecznosc.wikia.com' ],
 				/** @see testUrlsMainNSonWoW **/
-				$mockedReturnValue = [ 116 => 'Portal' ];
-			} else if ( $cvName === 'wgServer' ) {
-				$mockedReturnValue = $this->wikiUrlsMock[$cityId];
-			}
+				[ 'wgArticlePath', 490, '/wiki/$1' ],
+				[ 'wgExtraNamespacesLocal', 490, [ 116 => 'Portal' ] ],
+			] );
 
-			return $mockedReturnValue;
-		} );
-		
 		global $wgDevelEnvironment,$wgDevelEnvironmentName;
 		$this->wgDevelEnv = $wgDevelEnvironment;
 		$this->wgDevelEnvName = $wgDevelEnvironmentName;

--- a/includes/wikia/tests/GlobalTitleTest.php
+++ b/includes/wikia/tests/GlobalTitleTest.php
@@ -6,6 +6,15 @@ class GlobalTitleTest extends WikiaBaseTest {
 	
 	function setUp() {
 		parent::setUp();
+
+		$wgMemcMock = $this->getMockBuilder( 'MWMemcached' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'get' ] )
+			->getMock();
+		$wgMemcMock->expects( $this->any() )
+			->method( 'get' )
+			->willReturn( null );
+		$this->mockGlobalVariable( 'wgMemc', $wgMemcMock );
 		
 		global $wgDevelEnvironment,$wgDevelEnvironmentName;
 		$this->wgDevelEnv = $wgDevelEnvironment;

--- a/includes/wikia/tests/GlobalTitleTest.php
+++ b/includes/wikia/tests/GlobalTitleTest.php
@@ -62,8 +62,7 @@ class GlobalTitleTest extends WikiaBaseTest {
 	 */
 	function testUrlsMainNSonWoW() {
 		$title = GlobalTitle::newFromText( "Main", 116, 490); # wowwiki
-		$url = "http://www.wowwiki.com/Portal:Main";
-		$this->assertTrue( $title->getFullURL() === $url, sprintf("%s = %s, NOT MATCH", $title->getFullURL(), $url ) );
+		$this->assertStringEndsWith( "Portal:Main", $title->getFullURL(), "verify if WOW Wikia namespace was used" );
 	}
 
 	/**

--- a/includes/wikia/tests/core/WikiaBaseTest.class.php
+++ b/includes/wikia/tests/core/WikiaBaseTest.class.php
@@ -457,7 +457,7 @@ abstract class WikiaBaseTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * Mocks global $wgMemc->get() so it always returns null
 	 */
-	public function disableMemCache() {
+	protected function disableMemCache() {
 		$wgMemcMock = $this->getMockBuilder( 'MWMemcached' )
 			->disableOriginalConstructor()
 			->setMethods( [ 'get' ] )

--- a/includes/wikia/tests/core/WikiaBaseTest.class.php
+++ b/includes/wikia/tests/core/WikiaBaseTest.class.php
@@ -453,4 +453,18 @@ abstract class WikiaBaseTest extends PHPUnit_Framework_TestCase {
 			return [ ltrim( substr( $functionName, 0, $last + 1 ), '\\' ), substr( $functionName, $last + 1 ) ];
 		}
 	}
+
+	/**
+	 * Mocks global $wgMemc->get() so it always returns null
+	 */
+	public function disableMemCache() {
+		$wgMemcMock = $this->getMockBuilder( 'MWMemcached' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'get' ] )
+			->getMock();
+		$wgMemcMock->expects( $this->any() )
+			->method( 'get' )
+			->willReturn( null );
+		$this->mockGlobalVariable( 'wgMemc', $wgMemcMock );
+	}
 }

--- a/includes/wikia/tests/core/WikiaBaseTest.class.php
+++ b/includes/wikia/tests/core/WikiaBaseTest.class.php
@@ -215,8 +215,32 @@ abstract class WikiaBaseTest extends PHPUnit_Framework_TestCase {
 	 * @param $retVal mixed result to be returned by mocked method
 	 */
 	protected function mockStaticMethod($className, $methodName, $retVal) {
-		$this->getMockProxy()->getStaticMethod($className,$methodName)
+		$this->getMockProxy()
+			->getStaticMethod($className, $methodName)
 			->willReturn($retVal);
+	}
+
+	/**
+	 * Mock a static method using callback
+	 *
+	 * Examples:
+	 *
+	 * $this->mockStaticMethod('Http', 'post', function() {
+	 *     return json_encode(['foo' => 'bar']);
+	 * });
+	 *
+	 * $this->mockStaticMethod('Http', 'post', function( $value ) {
+	 *     return json_encode(['foo' => $value]);
+	 * });
+	 *
+	 * @param $className string class name
+	 * @param $methodName string method name
+	 * @param $callback callable which imitate original method
+	 */
+	protected function mockStaticMethodWithCallback($className, $methodName, $callback) {
+		$this->getMockProxy()
+			->getStaticMethod($className, $methodName)
+			->willCall($callback);
 	}
 
 	/**

--- a/includes/wikia/tests/core/WikiaBaseTest.class.php
+++ b/includes/wikia/tests/core/WikiaBaseTest.class.php
@@ -221,29 +221,6 @@ abstract class WikiaBaseTest extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * Mock a static method using callback
-	 *
-	 * Examples:
-	 *
-	 * $this->mockStaticMethod('Http', 'post', function() {
-	 *     return json_encode(['foo' => 'bar']);
-	 * });
-	 *
-	 * $this->mockStaticMethod('Http', 'post', function( $value ) {
-	 *     return json_encode(['foo' => $value]);
-	 * });
-	 *
-	 * @param $className string class name
-	 * @param $methodName string method name
-	 * @param $callback callable which imitate original method
-	 */
-	protected function mockStaticMethodWithCallback($className, $methodName, $callback) {
-		$this->getMockProxy()
-			->getStaticMethod($className, $methodName)
-			->willCall($callback);
-	}
-
-	/**
 	 * Mock global ($wg...) variable.
 	 *
 	 * @param $globalName string name of global variable (e.g. wgCity - WITH wg prefix)


### PR DESCRIPTION
`GlobalTitle` unit tests depended on a wiki domain which was broken every time when memcached data was invalidated and tests were run on a devbox.

Changes below remove dependency on a wiki domain from the tests.
