### PR TITLE
CON-2350 | Fix for sloth and inline elements

### DIFF
--- a/resources/wikia/libraries/sloth/sloth.js
+++ b/resources/wikia/libraries/sloth/sloth.js
@@ -77,7 +77,7 @@
 
 		Branch.prototype.isVisible = function () {
 			var elem = this.elem,
-				mayBeVisible = elem.scrollHeight || elem.scrollWidth,
+				mayBeVisible = elem.offsetHeight || elem.offsetWidth,
 				height,
 				threshold,
 				top,

--- a/resources/wikia/modules/nodeFinder.js
+++ b/resources/wikia/modules/nodeFinder.js
@@ -65,7 +65,7 @@ define('wikia.nodeFinder', function () {
 	 * @return {Bool}
 	 */
 	function isVisibleForSloth(element) {
-		return element.scrollWidth || element.scrollHeight;
+		return element.offsetWidth || element.offsetHeight;
 	}
 
 	return {


### PR DESCRIPTION
Because inline elements in chrome have `scrollHeight` and `scrollWidth` equals 0, changed them to `offsetHeight` and `offsetWidth`. This way we can hook sloth to inline elements in Chrome without problems.

ping @hakubo 
