### PR TITLE
VE-1745: Get VE to save article

### DIFF
--- a/extensions/VisualEditor/ApiVisualEditor.php
+++ b/extensions/VisualEditor/ApiVisualEditor.php
@@ -243,7 +243,8 @@ class ApiVisualEditor extends ApiBase {
 			'action' => 'query',
 			'prop' => 'revisions',
 			'titles' => $title->getPrefixedDBkey(),
-			'rvdifftotext' => $this->pstWikitext( $title, $wikitext )
+			//'rvdifftotext' => $this->pstWikitext( $title, $wikitext )
+			'rvdifftotext' => $wikitext
 		);
 		$api = new ApiMain(
 			new DerivativeRequest(

--- a/extensions/VisualEditor/ApiVisualEditorEdit.php
+++ b/extensions/VisualEditor/ApiVisualEditorEdit.php
@@ -10,7 +10,7 @@
 
 class ApiVisualEditorEdit extends ApiVisualEditor {
 
-	public function __construct( ApiMain $main, $name, Config $config ) {
+	public function __construct( ApiMain $main, $name /*, Config $config */ ) {
 		parent::__construct( $main, $name, $config );
 	}
 


### PR DESCRIPTION
Removed pre save transformation because it depends on content handlers which are not supported in our version of MediaWiki.
Removed expectation to receive Config in the constructor - also not supported in our version of MediaWiki.

https://wikia-inc.atlassian.net/browse/VE-1745
