### PR TITLE
VID-2147 Fix null cache key

### DIFF
--- a/extensions/wikia/VideosModule/Modules/VideosModuleCategory.class.php
+++ b/extensions/wikia/VideosModule/Modules/VideosModuleCategory.class.php
@@ -64,7 +64,7 @@ class Category extends Base {
 		sort( $category );
 		$hashCategory = md5( json_encode( $category ) );
 
-		return implode( ':', $cacheKey, $hashCategory, $this->sort );
+		return implode( ':', [$cacheKey, $hashCategory, $this->sort] );
 	}
 
 	/**

--- a/extensions/wikia/VideosModule/Modules/VideosModuleCategory.class.php
+++ b/extensions/wikia/VideosModule/Modules/VideosModuleCategory.class.php
@@ -64,7 +64,7 @@ class Category extends Base {
 		sort( $category );
 		$hashCategory = md5( json_encode( $category ) );
 
-		return implode( ':', [$cacheKey, $hashCategory, $this->sort] );
+		return implode( ':', [ $cacheKey, $hashCategory, $this->sort ] );
 	}
 
 	/**

--- a/extensions/wikia/VideosModule/Modules/VideosModuleLocal.class.php
+++ b/extensions/wikia/VideosModule/Modules/VideosModuleLocal.class.php
@@ -20,7 +20,7 @@ class Local extends Base {
 	public function getCacheKey() {
 		$cacheKey = parent::getCacheKey();
 
-		return implode( ':', $cacheKey, $this->sort );
+		return implode( ':', [$cacheKey, $this->sort] );
 	}
 
 	protected function getLogParams() {

--- a/extensions/wikia/VideosModule/Modules/VideosModuleLocal.class.php
+++ b/extensions/wikia/VideosModule/Modules/VideosModuleLocal.class.php
@@ -20,7 +20,7 @@ class Local extends Base {
 	public function getCacheKey() {
 		$cacheKey = parent::getCacheKey();
 
-		return implode( ':', [$cacheKey, $this->sort] );
+		return implode( ':', [ $cacheKey, $this->sort ] );
 	}
 
 	protected function getLogParams() {

--- a/extensions/wikia/VideosModule/Modules/VideosModuleStaff.class.php
+++ b/extensions/wikia/VideosModule/Modules/VideosModuleStaff.class.php
@@ -38,7 +38,7 @@ class Staff extends Base {
 		sort( $category );
 		$hashCategory = md5( json_encode( $category ) );
 
-		return implode( ':', [$cacheKey, $hashCategory, $this->sort] );
+		return implode( ':', [ $cacheKey, $hashCategory, $this->sort ] );
 	}
 
 	/**

--- a/extensions/wikia/VideosModule/Modules/VideosModuleStaff.class.php
+++ b/extensions/wikia/VideosModule/Modules/VideosModuleStaff.class.php
@@ -38,7 +38,7 @@ class Staff extends Base {
 		sort( $category );
 		$hashCategory = md5( json_encode( $category ) );
 
-		return implode( ':', $cacheKey, $hashCategory, $this->sort );
+		return implode( ':', [$cacheKey, $hashCategory, $this->sort] );
 	}
 
 	/**

--- a/extensions/wikia/VideosModule/Modules/VideosModuleVertical.class.php
+++ b/extensions/wikia/VideosModule/Modules/VideosModuleVertical.class.php
@@ -55,7 +55,7 @@ class Vertical extends Base {
 		sort( $category );
 		$hashCategory = md5( json_encode( $category ) );
 
-		return implode( ':', $cacheKey, $hashCategory, $this->sort );
+		return implode( ':', [$cacheKey, $hashCategory, $this->sort] );
 	}
 
 	/**

--- a/extensions/wikia/VideosModule/Modules/VideosModuleVertical.class.php
+++ b/extensions/wikia/VideosModule/Modules/VideosModuleVertical.class.php
@@ -55,7 +55,7 @@ class Vertical extends Base {
 		sort( $category );
 		$hashCategory = md5( json_encode( $category ) );
 
-		return implode( ':', [$cacheKey, $hashCategory, $this->sort] );
+		return implode( ':', [ $cacheKey, $hashCategory, $this->sort ] );
 	}
 
 	/**


### PR DESCRIPTION
Passing more than 2 parameters to `implode` results in null and being the cache key, cache always returns as empty.

https://wikia-inc.atlassian.net/browse/VID-2147
