### PR TITLE
UC-205 guard against unauthorized facebook disconnects

### DIFF
--- a/extensions/wikia/FacebookClient/FacebookClientController.class.php
+++ b/extensions/wikia/FacebookClient/FacebookClientController.class.php
@@ -136,6 +136,7 @@ class FacebookClientController extends WikiaController {
 	public function disconnectFromFB() {
 
 		if ( $this->request->isInternal() ) {
+			// deauthorizeCallback which makes this internal request ensures 'user' is set
 			$userId = $this->getVal( 'user' );
 			$user = User::newFromId( $userId );
 		} elseif ( $this->isValidExternalRequest() ) {

--- a/extensions/wikia/FacebookClient/FacebookClientController.class.php
+++ b/extensions/wikia/FacebookClient/FacebookClientController.class.php
@@ -127,7 +127,7 @@ class FacebookClientController extends WikiaController {
 
 	/**
 	 * Disconnect the user from Facebook. This can occur in one of two ways, either when the user
-	 * deletes the Wikia App from facebook, of when they explicitly disconnect via Special:Preferences.
+	 * deletes the Wikia App from facebook, or when they explicitly disconnect via Special:Preferences.
 	 * If it comes from Facebook, the request is internal and is sent by FacebookClientController::deauthorizeCallback.
 	 * If it comes explicitly from the user, the request is external and is sent by preferences.js::disconnect.
 	 *
@@ -142,7 +142,7 @@ class FacebookClientController extends WikiaController {
 			$user = F::app()->wg->User;
 		} else {
 			$this->status = 'error';
-			$this->msg	= wfMessage( 'fbconnect-unknown-error' )->text();
+			$this->msg = wfMessage( 'fbconnect-unknown-error' )->escaped();
 			return;
 		}
 
@@ -171,10 +171,7 @@ class FacebookClientController extends WikiaController {
 	 * @return bool
 	 */
 	private function isValidExternalRequest() {
-		if ( $this->request->wasPosted() && $this->wg->User->matchEditToken( $this->getVal( 'token' ) ) ) {
-			return true;
-		}
-		return false;
+		return ( $this->request->wasPosted() && $this->wg->User->matchEditToken( $this->getVal( 'token' ) ) );
 	}
 
 	/**

--- a/extensions/wikia/FacebookClient/scripts/preferences.js
+++ b/extensions/wikia/FacebookClient/scripts/preferences.js
@@ -1,4 +1,5 @@
-(function () {
+/* global jQuery, mediaWiki */
+(function ($, mw) {
 	'use strict';
 
 	var fbPreferences = (function () {
@@ -91,6 +92,8 @@
 				controller: 'FacebookClient',
 				method: 'disconnectFromFB',
 				format: 'json',
+				data: {token: mw.user.tokens.get('editToken')},
+				type: 'POST',
 				callback: function (data) {
 					if (data.status === 'ok') {
 						window.GlobalNotification.show($.msg(disconnectMsg), 'confirm');
@@ -148,4 +151,4 @@
 
 	// instantiate singleton on DOM ready
 	$(fbPreferences.getInstance);
-})();
+})(jQuery, mediaWiki);


### PR DESCRIPTION
FacebookClientController::disconnectFromFB was vulnerable to unauthorized use, potentially disconnecting facebook accounts for many users. Make sure we're validating if the request is internal or external, and if it is external, make sure the the request was posted and has the proper CSRF token.

Ticket: https://wikia-inc.atlassian.net/browse/UC-205
