### PR TITLE
ve-sprint-33

### DIFF
--- a/extensions/VisualEditor/wikia/modules/ve/ui/widgets/ve.ui.WikiaMediaPreviewWidget.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/widgets/ve.ui.WikiaMediaPreviewWidget.js
@@ -51,20 +51,6 @@ OO.inheritClass( ve.ui.WikiaMediaPreviewWidget, OO.ui.Widget );
 /* Methods */
 
 /**
- * Resize image after it's loaded if it's too tall for the screen
- * @method
- */
-ve.ui.WikiaMediaPreviewWidget.prototype.onImageLoad = function () {
-	// TODO: Add image aspect ratio to model (sorta the same comment from WikiaMediaPageWidget)
-	// thumbnailer.js only let's you restrict by width, not by height, so we'll do that here.
-	if ( this.$image.height() > this.maxImgHeight ) {
-		this.$image.height( this.maxImgHeight );
-	}
-
-	this.verticallyAlign( this.$image );
-};
-
-/**
  * @method
  */
 ve.ui.WikiaMediaPreviewWidget.prototype.verticallyAlign = function ( $element ) {
@@ -164,7 +150,7 @@ ve.ui.WikiaMediaPreviewWidget.prototype.openForImage = function ( title, url ) {
 	this.$image.attr( 'src', Vignette.getThumbURL( url, 'thumbnail-down', this.maxImgWidth, this.maxImgHeight ) );
 
 	this.$image
-		.load( ve.bind( this.onImageLoad, this ) )
+		.load( ve.bind( this.verticallyAlign, this, this.$image ) )
 		.appendTo( this.$element );
 };
 

--- a/extensions/wikia/EditorPreference/EditorPreference.class.php
+++ b/extensions/wikia/EditorPreference/EditorPreference.class.php
@@ -6,7 +6,6 @@
  */
 
 class EditorPreference {
-	const OPTION_EDITOR_DEFAULT = 0;
 	const OPTION_EDITOR_SOURCE = 1;
 	const OPTION_EDITOR_VISUAL = 2;
 	const OPTION_EDITOR_CK = 3;
@@ -26,7 +25,6 @@ class EditorPreference {
 			'label-message' => 'editor-preference',
 			'section' => 'editing/editing-experience',
 			'options' => array(
-				wfMessage( 'option-default-editor' )->text() => self::OPTION_EDITOR_DEFAULT,
 				wfMessage( 'option-visual-editor' )->text() => self::OPTION_EDITOR_VISUAL,
 				wfMessage( 'option-ck-editor' )->text() => self::OPTION_EDITOR_CK,
 				wfMessage( 'option-source-editor' )->text() => self::OPTION_EDITOR_SOURCE,
@@ -180,22 +178,6 @@ class EditorPreference {
 			$wgEnableVisualEditorExt &&
 			( is_array( $wgVisualEditorNamespaces ) ?
 				in_array( $wgTitle->getNamespace(), $wgVisualEditorNamespaces ) : false );
-	}
-
-	/**
-	 * Set the editor preference for newly-registered users.
-	 *
-	 * @param User $user The current user
-	 * @return boolean
-	 */
-	public static function onAddNewAccount( User $user ) {
-		// Force new users to set VisualEditor as preference
-		$user->setOption( PREFERENCE_EDITOR, self::OPTION_EDITOR_VISUAL );
-		$user->saveSettings();
-
-		// If the editor preference is not set here, the default preference
-		// is set in CommonSettings.
-		return true;
 	}
 
 	/**

--- a/extensions/wikia/EditorPreference/EditorPreference.php
+++ b/extensions/wikia/EditorPreference/EditorPreference.php
@@ -22,8 +22,4 @@ $wgExtensionMessagesFiles['EditorPreference'] = $dir . 'EditorPreference.i18n.ph
 $wgHooks['EditingPreferencesBefore'][] = 'EditorPreference::onEditingPreferencesBefore';
 $wgHooks['SkinTemplateNavigation'][] = 'EditorPreference::onSkinTemplateNavigation';
 $wgHooks['MakeGlobalVariablesScript'][] = 'EditorPreference::onMakeGlobalVariablesScript';
-$wgHooks['AddNewAccount'][] = 'EditorPreference::onAddNewAccount';
 $wgHooks['UserProfilePageAfterGetActionButtonData'][] = 'EditorPreference::onUserProfilePageAfterGetActionButtonData';
-
-// Default preference
-$wgDefaultUserOptions[PREFERENCE_EDITOR] = 0;


### PR DESCRIPTION
This pull request requires a simultaneous pull of config: https://github.com/Wikia/config/pull/814

Removes "wiki default" option from editor preferences.
Retires the need to resize images in the VE media tool on the client side (thanks vignette-js!)
