### PR TITLE
wrap usage of $this->connection() in try/catch

### DIFF
--- a/includes/wikia/tasks/AsyncTaskList.class.php
+++ b/includes/wikia/tasks/AsyncTaskList.class.php
@@ -299,7 +299,7 @@ class AsyncTaskList {
 		] );
 
 		if ( $channel === null ) {
-			$exception = null;
+			$exception = $connection = null;
 			try {
 				$connection = $this->connection();
 				$channel = $connection->channel();
@@ -310,6 +310,14 @@ class AsyncTaskList {
 				$exception = $e;
 			} catch ( AMQPTimeoutException $e ) {
 				$exception = $e;
+			}
+
+			if ( $channel !== null ) {
+				$channel->close();
+			}
+
+			if ( $connection !== null ) {
+				$connection->close();
 			}
 
 			if ( $exception !== null ) {

--- a/includes/wikia/tasks/AsyncTaskList.class.php
+++ b/includes/wikia/tasks/AsyncTaskList.class.php
@@ -300,18 +300,17 @@ class AsyncTaskList {
 
 		if ( $channel === null ) {
 			$exception = null;
-			$connection = $this->connection();
-			$channel = $connection->channel();
 			try {
+				$connection = $this->connection();
+				$channel = $connection->channel();
 				$channel->basic_publish( $message, '', $this->getQueue()->name() );
+				$channel->close();
+				$connection->close();
 			} catch ( AMQPRuntimeException $e ) {
 				$exception = $e;
 			} catch ( AMQPTimeoutException $e ) {
 				$exception = $e;
 			}
-
-			$channel->close();
-			$connection->close();
 
 			if ( $exception !== null ) {
 				WikiaLogger::instance()->critical( "Failed to queue task", [ 'error' => $exception->getMessage() ] );
@@ -326,6 +325,8 @@ class AsyncTaskList {
 
 	/**
 	 * @return AMQPConnection connection to message broker
+	 * @throws AMQPRuntimeException
+	 * @throws AMQPTimeoutException
 	 */
 	protected function connection() {
 		global $wgTaskBroker;

--- a/includes/wikia/tasks/AsyncTaskList.class.php
+++ b/includes/wikia/tasks/AsyncTaskList.class.php
@@ -304,8 +304,6 @@ class AsyncTaskList {
 				$connection = $this->connection();
 				$channel = $connection->channel();
 				$channel->basic_publish( $message, '', $this->getQueue()->name() );
-				$channel->close();
-				$connection->close();
 			} catch ( AMQPRuntimeException $e ) {
 				$exception = $e;
 			} catch ( AMQPTimeoutException $e ) {


### PR DESCRIPTION
@SebastianMarzjan 
re: https://wikia-inc.atlassian.net/browse/DAT-2392

wrap `$this->connection()` in try/catch so task queueing while rabbit is down don't cause user errors.
