### PR TITLE
(CE-1199) Fixing SharedHelp memcache key

### DIFF
--- a/extensions/wikia/SharedHelp/SharedHelp.php
+++ b/extensions/wikia/SharedHelp/SharedHelp.php
@@ -159,7 +159,7 @@ function SharedHelpHook(&$out, &$text) {
 		$sharedArticleKey = wfSharedMemcKey(
 			'sharedArticles',
 			$wgHelpWikiId,
-			md5(MWNamespace::getCanonicalName( $wgTitle->getNamespace() ), $wgTitle->getDBkey()),
+			md5(MWNamespace::getCanonicalName( $wgTitle->getNamespace() ) . ':' . $wgTitle->getDBkey()),
 			SHAREDHELP_CACHE_VERSION
 		);
 		$sharedArticle = $wgMemc->get($sharedArticleKey);
@@ -325,7 +325,7 @@ function SharedHelpHook(&$out, &$text) {
 			$sharedRedirectsArticlesKey = wfSharedMemcKey(
 				'sharedRedirectsArticles',
 				$wgHelpWikiId,
-				md5( MWNamespace::getCanonicalName( $wgTitle->getNamespace() ), $wgTitle->getDBkey() )
+				md5( MWNamespace::getCanonicalName( $wgTitle->getNamespace() ) . ':' . $wgTitle->getDBkey() )
 			);
 			$articleLink = $wgMemc->get($sharedRedirectsArticlesKey, null);
 


### PR DESCRIPTION
md5's second parameter is a boolean, so this caused the same memcache
key for all SharedHelp articles.

Follow up to https://github.com/Wikia/app/pull/5816

/cc @macbre 
