### PR TITLE
UC-216 Turn autoplay on for Maker Studios

### DIFF
--- a/extensions/wikia/VideoHandlers/handlers/MakerstudiosVideoHandler.class.php
+++ b/extensions/wikia/VideoHandlers/handlers/MakerstudiosVideoHandler.class.php
@@ -10,6 +10,10 @@ class MakerstudiosVideoHandler extends VideoHandler {
 		$height =  $this->getHeight( $width );
 		$sizeString = $this->getSizeString( $width, $height );
 		$url = $this->getEmbedUrl();
+		if ( !empty( $options['autoplay'] ) ) {
+			$url .= '?autoplay=true';
+		}
+
 		$html = <<< EOF
 <iframe class='videoplayer' src='$url' $sizeString style='border:0; overflow:hidden;' allowfullscreen seamless scrolling='no'></iframe>
 EOF;


### PR DESCRIPTION
When we first added support for Maker Studios we didn't configure the video handler to auto play videos. This fixes that so the videos autoplay when we want them to.

Ticket: https://wikia-inc.atlassian.net/browse/UC-216
