### PR TITLE
VID-2150 include db name in cache key for Related videos

### DIFF
--- a/extensions/wikia/VideosModule/Modules/VideosModuleBase.class.php
+++ b/extensions/wikia/VideosModule/Modules/VideosModuleBase.class.php
@@ -122,7 +122,6 @@ abstract class Base extends \WikiaModel {
 	protected function getCacheKey() {
 		$cacheKey = wfSharedMemcKey(
 			self::CACHE_VERSION,
-			__CLASS__,
 			$this->userRegion,
 			$this->source
 		);

--- a/extensions/wikia/VideosModule/Modules/VideosModuleRelated.class.php
+++ b/extensions/wikia/VideosModule/Modules/VideosModuleRelated.class.php
@@ -39,5 +39,11 @@ class Related extends Base {
 
 		return $this->videos;
 	}
+
+	public function getCacheKey() {
+		$cacheKey = parent::getCacheKey();
+
+		return $cacheKey . ':' . $this->wg->DBname;
+	}
 }
 


### PR DESCRIPTION
We're currently using wfSharedMemcKey to create the cache key for Related videos for the videos module. This is a problem because that means all wikis are sharing the same cache key. We need to make sure to include database information in the key to differentiate the keys. 

Ticket: https://wikia-inc.atlassian.net/browse/VID-2150
