### PR TITLE
CE-1195 AutoFollow Staff Blogs in all officially supported languages

### DIFF
--- a/maintenance/wikia/cronjobs/AutoFollow.php
+++ b/maintenance/wikia/cronjobs/AutoFollow.php
@@ -61,6 +61,7 @@ while ( $row = $dbr->fetchRow( $res ) ) {
 		$titlesToWatch[] = Title::newFromText( $text );
 	}
 
+	$status = false;
 	foreach ( $titlesToWatch as $title ) {
 		$logParams = [
 			'user_id' => $row['user_id'],
@@ -70,6 +71,8 @@ while ( $row = $dbr->fetchRow( $res ) ) {
 		];
 		if ( $title instanceof Title ) {
 			WatchAction::doWatch( $title, $user );
+			$status = true;
+
 			\Wikia\Logger\WikiaLogger::instance()->info( "AutoFollow: User {$user->getName()} added to watchlist of {$title->getText()}.", $logParams );
 		} else {
 			// Log error to check for typos etc. Can be deleted when tested in production enviroment.
@@ -77,6 +80,8 @@ while ( $row = $dbr->fetchRow( $res ) ) {
 		}
 	}
 
-	$user->setOption( $alreadyWatchedKey, 1 );
-	$user->saveSettings();
+	if ( $status ) {
+		$user->setOption( $alreadyWatchedKey, 1 );
+		$user->saveSettings();
+	}
 }

--- a/maintenance/wikia/cronjobs/AutoFollow.php
+++ b/maintenance/wikia/cronjobs/AutoFollow.php
@@ -51,7 +51,7 @@ while ( $row = $dbr->fetchRow( $res ) ) {
 
 	$userLanguage = strtolower( $user->getOption( 'language' ) );
 	// Include dialects like pt-br
-	$userLanguageSplit = explode( "-", $userLanguage );
+	$userLanguageSplit = explode( '-', $userLanguage );
 	$userLanguage = $userLanguageSplit[0];
 	// Check for aliases
 	if ( isset( $languageAliases[$userLanguage] ) ) {

--- a/maintenance/wikia/cronjobs/AutoFollow.php
+++ b/maintenance/wikia/cronjobs/AutoFollow.php
@@ -13,18 +13,28 @@ $alreadyWatchedKey = 'autowatched-already';
 
 $titlesToWatch = [];
 $textsToWatch = [
+	'de' => ['Blog:Wikia_Deutschland_News'],
 	'en' => ['Blog:Wikia Staff Blog'],
-	'pl' => ['Blog:Wikia News'],
-	'zh' => ['博客:博客帖子'],
-	'ja' => ['ブログ:ウィキアスタッフブログ'],
-	'pt' => ['Blog_de_usuário:Macherie_ana'],
+	'es' => ['Blog:Comunidad'],
+	'fi' => ['Blogi:Wikia-uutiset'],
 	'fr' => ['Blog:Actualité_Wikia'],
 	'it' => ['Blog:Blog_ufficiale_di_Wikia_Italia'],
-	'ru' => ['Блог:Все_сообщения'],
+	'ja' => ['ブログ:ウィキアスタッフブログ'],
 	'nl' => ['Blog:Staff_blogs'],
-	'fi' => ['Blogi:Wikia-uutiset'],
-	'de' => ['Blog:Wikia_Deutschland_News'],
-	'es' => ['Blog:Comunidad'],
+	'pl' => ['Blog:Wikia News'],
+	'pt' => ['Blog:Notícias_da_Wikia'],
+	'ru' => ['Блог:Все_сообщения'],
+	'uk' => ['Блог:Все_сообщения'],
+	'zh' => ['博客:社区中心博客'],
+];
+
+/**
+ * This handles languages like uk which doesn't have its own
+ * community wikia to run the script at.
+ * @var Array
+ */
+$languageAliases = [
+	'uk' => 'ru',
 ];
 
 while ( $row = $dbr->fetchRow( $res ) ) {
@@ -39,8 +49,15 @@ while ( $row = $dbr->fetchRow( $res ) ) {
 		continue;
 	}
 
+	$userLanguage = strtolower( $user->getOption( 'language' ) );
 	// Include dialects like pt-br
-	$userLanguage = substr( $user->getOption( 'language' ), 0, 2 );
+	$userLanguageSplit = explode( "-", $userLanguage );
+	$userLanguage = $userLanguageSplit[0];
+	// Check for aliases
+	if ( isset( $languageAliases[$userLanguage] ) ) {
+		$userLanguage = $languageAliases[$userLanguage];
+	}
+
 	if ( $userLanguage != $contentLanguage ) {
 		continue;
 	}
@@ -67,13 +84,13 @@ while ( $row = $dbr->fetchRow( $res ) ) {
 			'user_id' => $row['user_id'],
 			'user_name' => $user->getName(),
 			'user_lang' => $userLanguage,
-			'title' => $title->getText(),
+			'title' => $title->getPrefixedText(),
 		];
 		if ( $title instanceof Title ) {
 			WatchAction::doWatch( $title, $user );
 			$status = true;
 
-			\Wikia\Logger\WikiaLogger::instance()->info( "AutoFollow: User {$user->getName()} added to watchlist of {$title->getText()}.", $logParams );
+			\Wikia\Logger\WikiaLogger::instance()->info( "AutoFollow: User {$user->getName()} added to watchlist of {$title->getPrefixedText()}.", $logParams );
 		} else {
 			// Log error to check for typos etc. Can be deleted when tested in production enviroment.
 			\Wikia\Logger\WikiaLogger::instance()->error( "AutoFollow: Invalid article name in {$userLanguage}", $logParams );

--- a/maintenance/wikia/cronjobs/AutoFollow.php
+++ b/maintenance/wikia/cronjobs/AutoFollow.php
@@ -3,18 +3,13 @@
 require_once( dirname(__FILE__) . '/../../commandLine.inc' );
 
 global $wgCityId;
-
 $contentLanguage = WikiFactory::getVarValueByName( 'wgLanguageCode', $wgCityId );
 
-echo "Starting procedure for a wikia in {$contentLanguage}...";
+$dbr = wfGetDB( DB_SLAVE, array(), $wgExternalSharedDB );
+$range = date( 'Ymd', strtotime( '-30 days' ) ) . '000000';
+$res = $dbr->select( '`user`', 'user_id', array( 'user_registration >= ' . $range ) );
 
 $alreadyWatchedKey = 'autowatched-already';
-
-$dbr = wfGetDB( DB_SLAVE, array(), $wgExternalSharedDB );
-
-$range = date( 'Ymd', strtotime( '-30 days' ) ) . '000000';
-
-$res = $dbr->select( '`user`', 'user_id', array( 'user_registration >= ' . $range ) );
 
 $titlesToWatch = [];
 $textsToWatch = [
@@ -32,44 +27,33 @@ $textsToWatch = [
 	'es' => ['Blog:Comunidad'],
 ];
 
-$reason = '';
-
 while ( $row = $dbr->fetchRow( $res ) ) {
-	if ( !empty( $reason ) ) {
-		echo "User not added to watchlist: {$reason}\n";
-	}
 
 	$user = User::newFromId( $row['user_id'] );
 
 	if ( !is_object( $user ) ) {
-		$reason = "Cannot create an object from ID {$row['user_id']}\n";
 		continue;
 	}
 
 	if ( $user->getOption( $alreadyWatchedKey ) == 1 ) {
-		$reason = "User {$row['user_id']} already on watchlist\n";
 		continue;
 	}
 
 	// Include dialects like pt-br
 	$userLanguage = substr( $user->getOption( 'language' ), 0, 2 );
 	if ( $userLanguage != $contentLanguage ) {
-		$reason = "There is no blog in {$userLanguage} for user {$row['user_id']}\n";
 		continue;
 	}
 
 	if ( $user->getOption( 'marketingallowed' ) != 1 ) {
-		$reason = "User {$row['user_id']} does not allow marketing\n";
 		continue;
 	}
 
 	if ( !$user->isEmailConfirmed() ) {
-		$reason = "User {$row['user_id']} hasn't confirmed his email\n";
 		continue;
 	}
 
 	if ( $user->getEditCount() == 0 ) {
-		$reason = "User {$row['user_id']} has 0 edits\n";
 		continue;
 	}
 
@@ -78,13 +62,20 @@ while ( $row = $dbr->fetchRow( $res ) ) {
 	}
 
 	foreach ( $titlesToWatch as $title ) {
+		$logParams = [
+			'user_id' => $row['user_id'],
+			'user_name' => $user->getName(),
+			'user_lang' => $userLanguage,
+			'title' => $title->getText(),
+		];
 		if ( $title instanceof Title ) {
-			echo "Watching {$title->getText()} in {$contentLanguage} as {$user->getName()}...\n";
 			WatchAction::doWatch( $title, $user );
+			\Wikia\Logger\WikiaLogger::instance()->info( "AutoFollow: User {$user->getName()} added to watchlist of {$title->getText()}.", $logParams );
+		} else {
+			// Log error to check for typos etc. Can be deleted when tested in production enviroment.
+			\Wikia\Logger\WikiaLogger::instance()->error( "AutoFollow: Invalid article name in {$userLanguage}", $logParams );
 		}
 	}
-
-	$reason = '';
 
 	$user->setOption( $alreadyWatchedKey, 1 );
 	$user->saveSettings();

--- a/maintenance/wikia/cronjobs/AutoFollow.php
+++ b/maintenance/wikia/cronjobs/AutoFollow.php
@@ -2,6 +2,12 @@
 
 require_once( dirname(__FILE__) . '/../../commandLine.inc' );
 
+global $wgCityId;
+
+$contentLanguage = WikiFactory::getVarValueByName( 'wgLanguageCode', $wgCityId );
+
+echo "Starting procedure for a wikia in {$contentLanguage}...";
+
 $alreadyWatchedKey = 'autowatched-already';
 
 $dbr = wfGetDB( DB_SLAVE, array(), $wgExternalSharedDB );
@@ -10,46 +16,75 @@ $range = date( 'Ymd', strtotime( '-30 days' ) ) . '000000';
 
 $res = $dbr->select( '`user`', 'user_id', array( 'user_registration >= ' . $range ) );
 
-$titlesToWatch = array();
-$textsToWatch = array(
-	'Blog:Wikia Staff Blog',
-);
+$titlesToWatch = [];
+$textsToWatch = [
+	'en' => ['Blog:Wikia Staff Blog'],
+	'pl' => ['Blog:Wikia News'],
+	'zh' => ['博客:博客帖子'],
+	'ja' => ['ブログ:ウィキアスタッフブログ'],
+	'pt' => ['Blog_de_usuário:Macherie_ana'],
+	'fr' => ['Blog:Actualité_Wikia'],
+	'it' => ['Blog:Blog_ufficiale_di_Wikia_Italia'],
+	'ru' => ['Блог:Все_сообщения'],
+	'nl' => ['Blog:Staff_blogs'],
+	'fi' => ['Blogi:Wikia-uutiset'],
+	'de' => ['Blog:Wikia_Deutschland_News'],
+	'es' => ['Blog:Comunidad'],
+];
 
-foreach ( $textsToWatch as $text ) {
-	$titlesToWatch[] = Title::newFromText( $text );
-}
+$reason = '';
 
 while ( $row = $dbr->fetchRow( $res ) ) {
+	if ( !empty( $reason ) ) {
+		echo "User not added to watchlist: {$reason}\n";
+	}
+
 	$user = User::newFromId( $row['user_id'] );
 
 	if ( !is_object( $user ) ) {
+		$reason = "Cannot create an object from ID {$row['user_id']}\n";
 		continue;
 	}
 
 	if ( $user->getOption( $alreadyWatchedKey ) == 1 ) {
+		$reason = "User {$row['user_id']} already on watchlist\n";
 		continue;
 	}
 
-	if ( $user->getOption( 'language' ) != 'en' ) {
+	// Include dialects like pt-br
+	$userLanguage = substr( $user->getOption( 'language' ), 0, 2 );
+	if ( $userLanguage != $contentLanguage ) {
+		$reason = "There is no blog in {$userLanguage} for user {$row['user_id']}\n";
 		continue;
 	}
 
 	if ( $user->getOption( 'marketingallowed' ) != 1 ) {
+		$reason = "User {$row['user_id']} does not allow marketing\n";
 		continue;
 	}
 
 	if ( !$user->isEmailConfirmed() ) {
+		$reason = "User {$row['user_id']} hasn't confirmed his email\n";
 		continue;
 	}
 
 	if ( $user->getEditCount() == 0 ) {
+		$reason = "User {$row['user_id']} has 0 edits\n";
 		continue;
 	}
 
-	foreach ( $titlesToWatch as $title ) {
-		echo "Watching {$title->getText()} as {$user->getName()}...\n";
-		WatchAction::doWatch( $title, $user );
+	foreach ( $textsToWatch[$contentLanguage] as $text ) {
+		$titlesToWatch[] = Title::newFromText( $text );
 	}
+
+	foreach ( $titlesToWatch as $title ) {
+		if ( $title instanceof Title ) {
+			echo "Watching {$title->getText()} in {$contentLanguage} as {$user->getName()}...\n";
+			WatchAction::doWatch( $title, $user );
+		}
+	}
+
+	$reason = '';
 
 	$user->setOption( $alreadyWatchedKey, 1 );
 	$user->saveSettings();


### PR DESCRIPTION
This PR's goal is to enable auto-following our Staff Blogs in all officially supported languages. It also adds WikiaLogger logging to check for possible failures.
