### PR TITLE
Uc-206 Fail state will trigger while loading fb

### DIFF
--- a/extensions/wikia/CreateNewWiki/js/CreateNewWiki.js
+++ b/extensions/wikia/CreateNewWiki/js/CreateNewWiki.js
@@ -95,6 +95,9 @@
 					$.loadFacebookAPI()
 						.done(function () {
 							$('.fb-loaded').removeClass('hidden');
+						})
+						.fail(function () {
+							// you can do something here if you want
 						});
 				}
 			});

--- a/resources/wikia/libraries/jquery/getResources/jquery.wikia.getResources.js
+++ b/resources/wikia/libraries/jquery/getResources/jquery.wikia.getResources.js
@@ -5,6 +5,9 @@
 	 * Fetches a list of resources and fires a callback when they have all finished
 	 * loading. Supports CSS, JavaScript, Sass and AssetManager groups.
 	 *
+	 * This is not recommended for cross-domain JS script loading, as the failure function will not be called.
+	 * @see http://bugs.jquery.com/ticket/13735
+	 *
 	 * TODO: Right now, asset group file type is determined by searching for a
 	 * file type extension in the URI. Is there a better way to detect file type?
 	 *

--- a/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadLibrary.js
+++ b/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadLibrary.js
@@ -101,16 +101,17 @@
 			};
 
 			// load GoogleMaps main JS and provide a name of the callback to be called when API is fully initialized
-			$.loadLibrary('GoogleMaps', [{
-						url: 'http://maps.googleapis.com/maps/api/js?sensor=false&callback=onGoogleMapsLoaded',
-						type: 'js'
-					}],
-					typeof (window.google && window.google.maps)
-				).
-				// error handling
-			fail(function () {
-				dfd.reject();
-			});
+			$.loadLibrary(
+				'GoogleMaps',
+				[{
+					url: 'http://maps.googleapis.com/maps/api/js?sensor=false&callback=onGoogleMapsLoaded',
+					type: 'js'
+				}],
+				typeof (window.google && window.google.maps)
+			).
+				fail(function () {
+					dfd.reject();
+				});
 		}
 
 		return dfd.promise();


### PR DESCRIPTION
This is a modified version of the SDK loading that Facebook recommends on their [developer pages](https://developers.facebook.com/docs/javascript/quickstart/v2.2). The reason we weren't doing this before was for consistency with other library loaders, however, a [JavaScript limitation](http://bugs.jquery.com/ticket/13735) with cross site script loading causes `$.getScript` to not execute fail functions. 

We should really updating any external script loading that uses `$.getScript` to some other method. 
