### PR TITLE
UC-206, UC-82 Graceful handling of unreachable Facebook + Remove FB lib load on every page

### DIFF
--- a/extensions/wikia/CreateNewWiki/css/CreateNewWiki.scss
+++ b/extensions/wikia/CreateNewWiki/css/CreateNewWiki.scss
@@ -470,3 +470,7 @@ html[dir="rtl"] {
 		}
 	}
 }
+
+.hidden {
+	display: none;
+}

--- a/extensions/wikia/CreateNewWiki/js/CreateNewWiki.js
+++ b/extensions/wikia/CreateNewWiki/js/CreateNewWiki.js
@@ -88,10 +88,14 @@
 							UserLoginFacebook.closeSignupModal();
 						};
 					}
+
+					self.transition('NameWiki', true, '+');
+
 					// Load facebook assets before going to the login form
-					$.loadFacebookAPI(function () {
-						self.transition('NameWiki', true, '+');
-					});
+					$.loadFacebookAPI()
+						.done(function () {
+							$('.fb-loaded').removeClass('hidden');
+						});
 				}
 			});
 			this.wikiDomain.keyup(function () {

--- a/extensions/wikia/CreateNewWiki/js/CreateNewWiki.js
+++ b/extensions/wikia/CreateNewWiki/js/CreateNewWiki.js
@@ -94,7 +94,7 @@
 					// Load facebook assets before going to the login form
 					$.loadFacebookAPI()
 						.done(function () {
-							$('.fb-loaded').removeClass('hidden');
+							$('.sso-login').removeClass('hidden');
 						});
 				}
 			});

--- a/extensions/wikia/CreateNewWiki/js/CreateNewWiki.js
+++ b/extensions/wikia/CreateNewWiki/js/CreateNewWiki.js
@@ -95,6 +95,9 @@
 					$.loadFacebookAPI()
 						.done(function () {
 							$('.fb-loaded').removeClass('hidden');
+						})
+						.fail(function () {
+							// you can do something here if you want
 						});
 				}
 			});

--- a/extensions/wikia/CreateNewWiki/js/CreateNewWiki.js
+++ b/extensions/wikia/CreateNewWiki/js/CreateNewWiki.js
@@ -95,9 +95,6 @@
 					$.loadFacebookAPI()
 						.done(function () {
 							$('.fb-loaded').removeClass('hidden');
-						})
-						.fail(function () {
-							// you can do something here if you want
 						});
 				}
 			});

--- a/extensions/wikia/FacebookClient/FacebookClient.i18n.php
+++ b/extensions/wikia/FacebookClient/FacebookClient.i18n.php
@@ -16,6 +16,8 @@ $messages['en'] = [
 	'prefs-fbconnect-disconnect-prefstext' => 'Disconnect from Facebook',
 	'fbconnect-error-already-connected' => 'This Wikia account is already connected to Facebook. Please disconnect the original Facebook account prior to connecting another account.',
 	'fbconnect-error-fb-account-in-use' => 'This Facebook account is already connected to another Wikia user account. Please connect with a different account or log in with Facebook and disconnect the original Wikia account prior to connecting the $1 account.',
+	'fbconnect-error-fb-unavailable-title' => 'Error connecting to Facebook',
+	'fbconnect-error-fb-unavailable-text' => 'Facebook seems to be unavailable at this time. Please try again later.',
 
 	// Keys copied from FBConnect and in use
 
@@ -80,6 +82,8 @@ $messages['qqq'] = [
 	'fbconnect-error-already-connected' => 'Error message stating that Wikia account user is trying to connected to Facebook is already connected.',
 	'fbconnect-error-fb-account-in-use' => "Error message stating that another Wikia account is already connected to the Facebook account user is trying to connect to. Parameter:
 * $1 is a username.",
+	'fbconnect-error-fb-unavailable-title' => 'Error message title when Facebook is not reachable.',
+	'fbconnect-error-fb-unavailable-text' => 'Error message stating that Facebook is not available. Please ask user to try again later.',
 
 	'fbconnect-desc' => 'Short description of the FBConnect extension, shown in [[Special:Version]]. Do not translate or change links.',
 	'fbconnect-or' => 'This is just the word "OR" in English, used to separate the Facebook Connect login option from the normal Wikia login options on the AJAX login dialog box.',

--- a/extensions/wikia/FacebookClient/FacebookClient.setup.php
+++ b/extensions/wikia/FacebookClient/FacebookClient.setup.php
@@ -71,5 +71,7 @@ JSMessages::registerPackage( 'FacebookClient', [
 	'fbconnect-preferences-connected-error',
 	'fbconnect-disconnect-info-existing',
 	'fbconnect-disconnect-info',
+	'fbconnect-error-fb-unavailable-title',
+	'fbconnect-error-fb-unavailable-text',
 ] );
 

--- a/extensions/wikia/FacebookClient/FacebookClientController.class.php
+++ b/extensions/wikia/FacebookClient/FacebookClientController.class.php
@@ -15,6 +15,8 @@ class FacebookClientController extends WikiaController {
 	}
 
 	public function preferences() {
+		JSMessages::enqueuePackage( 'FacebookClient', JSMessages::EXTERNAL );
+
 		$this->response->addAsset( 'facebook_client_preferences_scss' );
 
 		$isUserConnected = $this->getVal( 'isConnected', false );

--- a/extensions/wikia/FacebookClient/scripts/FacebookClient.XFBML.js
+++ b/extensions/wikia/FacebookClient/scripts/FacebookClient.XFBML.js
@@ -9,9 +9,12 @@ $(function () {
 
 	// load api on page load and on demand
 	mw.hook('wikipage.content').add(function ($content) {
-		$.loadFacebookAPI(function () {
-			// scan the new content for any fb tags
-			FB.XFBML.parse($content[0]);
-		});
+		$.loadFacebookAPI()
+			.done(function () {
+				$('.fb-loaded').removeClass('hidden');
+
+				// scan the new content for any fb tags
+				FB.XFBML.parse($content[0]);
+			});
 	});
 });

--- a/extensions/wikia/FacebookClient/scripts/FacebookClient.XFBML.js
+++ b/extensions/wikia/FacebookClient/scripts/FacebookClient.XFBML.js
@@ -11,7 +11,7 @@ $(function () {
 	mw.hook('wikipage.content').add(function ($content) {
 		$.loadFacebookAPI()
 			.done(function () {
-				$('.fb-loaded').removeClass('hidden');
+				$('.sso-login').removeClass('hidden');
 
 				// scan the new content for any fb tags
 				FB.XFBML.parse($content[0]);

--- a/extensions/wikia/FacebookClient/scripts/SpecialFacebookConnect.js
+++ b/extensions/wikia/FacebookClient/scripts/SpecialFacebookConnect.js
@@ -88,7 +88,9 @@ $(function () {
 	};
 
 	// loads the SDK and calls facebook init functions
-	$.loadFacebookAPI(function () {
-		new SpecialPage().init();
-	});
+	$.loadFacebookAPI()
+		.done(function () {
+			$('.fb-loaded').removeClass('hidden');
+			new SpecialPage().init();
+		});
 });

--- a/extensions/wikia/FacebookClient/scripts/SpecialFacebookConnect.js
+++ b/extensions/wikia/FacebookClient/scripts/SpecialFacebookConnect.js
@@ -90,7 +90,7 @@ $(function () {
 	// loads the SDK and calls facebook init functions
 	$.loadFacebookAPI()
 		.done(function () {
-			$('.fb-loaded').removeClass('hidden');
+			$('.sso-login').removeClass('hidden');
 			new SpecialPage().init();
 		});
 });

--- a/extensions/wikia/FacebookClient/scripts/preferences.js
+++ b/extensions/wikia/FacebookClient/scripts/preferences.js
@@ -24,7 +24,14 @@
 			$disconnectButton = $('.fb-disconnect');
 			$connectLink = $('.sso-login-facebook');
 
-			$.loadFacebookAPI(bindEvents);
+			$.loadFacebookAPI()
+				.done(function () {
+					$('.fb-loaded').removeClass('hidden');
+
+					bindEvents();
+				});
+
+			return {};
 		}
 
 		/**
@@ -144,11 +151,51 @@
 					instance = init();
 				}
 				return instance;
+			},
+			facebookError: function () {
+				if (!window.FB) {
+					$(document).on('tab-fbconnect-prefstext-complete', function () {
+						$('.tab-fbconnect-prefstext').on('click', function () {
+							var $tabContentContainer = $('#mw-prefsection-fbconnect-prefstext');
+
+							// Disable everything within the tab
+							$tabContentContainer
+								.find('input, button')
+								.attr('disabled', 'disabled');
+							$tabContentContainer
+								.find('a')
+								.css('pointer-events', 'none');
+
+							// Throw an error message up
+							function createModal(uiModal) {
+								var modalConfig = {
+									vars: {
+										id: 'FbErrorModal',
+										size: 'medium',
+										title: $.msg('fbconnect-error-fb-unavailable-title'),
+										content: $.msg('fbconnect-error-fb-unavailable-text')
+									}
+								};
+								uiModal.createComponent(modalConfig, function (errorModal) {
+									errorModal.show();
+								});
+							}
+
+							require(['wikia.ui.factory'], function (uiFactory) {
+								$.when(uiFactory.init('modal'))
+									.then(createModal);
+							});
+						});
+					});
+				}
 			}
 		};
 
 	})();
 
-	// instantiate singleton on DOM ready
-	$(fbPreferences.getInstance);
+	$( function () {
+		// instantiate singleton on DOM ready
+		fbPreferences.getInstance();
+		//fbInstance.always(fbPreferences.facebookError);
+	});
 })(jQuery, mediaWiki);

--- a/extensions/wikia/FacebookClient/scripts/preferences.js
+++ b/extensions/wikia/FacebookClient/scripts/preferences.js
@@ -27,12 +27,9 @@
 			$.loadFacebookAPI()
 				.done(function () {
 					$('.fb-loaded').removeClass('hidden');
-
 					bindEvents();
 				})
-				.fail(function () {
-					facebookError();
-				});
+				.fail(facebookError);
 
 			return {};
 		}
@@ -145,37 +142,32 @@
 		}
 
 		function facebookError() {
-			$(document).on('tab-fbconnect-prefstext-complete', function () {
-				$('.tab-fbconnect-prefstext').on('click', function () {
-					var $tabContentContainer = $('#mw-prefsection-fbconnect-prefstext');
+			$(document).on('tab-fbconnect-prefstext-click', function () {
+				var $tabContentContainer = $('#mw-prefsection-fbconnect-prefstext');
 
-					// Disable everything within the tab
-					$tabContentContainer
-						.find('input, button')
-						.attr('disabled', 'disabled');
-					$tabContentContainer
-						.find('a')
-						.css('pointer-events', 'none');
+				// Disable all links within the tab
+				$tabContentContainer
+					.find('a')
+					.css('pointer-events', 'none');
 
-					// Throw an error message up
-					function createModal(uiModal) {
-						var modalConfig = {
-							vars: {
-								id: 'FbErrorModal',
-								size: 'medium',
-								title: $.msg('fbconnect-error-fb-unavailable-title'),
-								content: $.msg('fbconnect-error-fb-unavailable-text')
-							}
-						};
-						uiModal.createComponent(modalConfig, function (errorModal) {
-							errorModal.show();
-						});
-					}
-
-					require(['wikia.ui.factory'], function (uiFactory) {
-						$.when(uiFactory.init('modal'))
-							.then(createModal);
+				// Throw an error message up
+				function createModal(uiModal) {
+					var modalConfig = {
+						vars: {
+							id: 'fbErrorModal',
+							size: 'medium',
+							title: $.msg('fbconnect-error-fb-unavailable-title'),
+							content: $.msg('fbconnect-error-fb-unavailable-text')
+						}
+					};
+					uiModal.createComponent(modalConfig, function (errorModal) {
+						errorModal.show();
 					});
+				}
+
+				require(['wikia.ui.factory'], function (uiFactory) {
+					$.when(uiFactory.init('modal'))
+						.then(createModal);
 				});
 			});
 		}

--- a/extensions/wikia/FacebookClient/scripts/preferences.js
+++ b/extensions/wikia/FacebookClient/scripts/preferences.js
@@ -26,7 +26,7 @@
 
 			$.loadFacebookAPI()
 				.done(function () {
-					$('.fb-loaded').removeClass('hidden');
+					$('.sso-login').removeClass('hidden');
 					bindEvents();
 				})
 				.fail(facebookError);

--- a/extensions/wikia/FacebookClient/scripts/preferences.js
+++ b/extensions/wikia/FacebookClient/scripts/preferences.js
@@ -29,6 +29,9 @@
 					$('.fb-loaded').removeClass('hidden');
 
 					bindEvents();
+				})
+				.fail(function () {
+					facebookError();
 				});
 
 			return {};
@@ -141,6 +144,42 @@
 			window.GlobalNotification.show(msg, 'error');
 		}
 
+		function facebookError() {
+			$(document).on('tab-fbconnect-prefstext-complete', function () {
+				$('.tab-fbconnect-prefstext').on('click', function () {
+					var $tabContentContainer = $('#mw-prefsection-fbconnect-prefstext');
+
+					// Disable everything within the tab
+					$tabContentContainer
+						.find('input, button')
+						.attr('disabled', 'disabled');
+					$tabContentContainer
+						.find('a')
+						.css('pointer-events', 'none');
+
+					// Throw an error message up
+					function createModal(uiModal) {
+						var modalConfig = {
+							vars: {
+								id: 'FbErrorModal',
+								size: 'medium',
+								title: $.msg('fbconnect-error-fb-unavailable-title'),
+								content: $.msg('fbconnect-error-fb-unavailable-text')
+							}
+						};
+						uiModal.createComponent(modalConfig, function (errorModal) {
+							errorModal.show();
+						});
+					}
+
+					require(['wikia.ui.factory'], function (uiFactory) {
+						$.when(uiFactory.init('modal'))
+							.then(createModal);
+					});
+				});
+			});
+		}
+
 		/**
 		 * Return public methods
 		 */
@@ -151,51 +190,11 @@
 					instance = init();
 				}
 				return instance;
-			},
-			facebookError: function () {
-				if (!window.FB) {
-					$(document).on('tab-fbconnect-prefstext-complete', function () {
-						$('.tab-fbconnect-prefstext').on('click', function () {
-							var $tabContentContainer = $('#mw-prefsection-fbconnect-prefstext');
-
-							// Disable everything within the tab
-							$tabContentContainer
-								.find('input, button')
-								.attr('disabled', 'disabled');
-							$tabContentContainer
-								.find('a')
-								.css('pointer-events', 'none');
-
-							// Throw an error message up
-							function createModal(uiModal) {
-								var modalConfig = {
-									vars: {
-										id: 'FbErrorModal',
-										size: 'medium',
-										title: $.msg('fbconnect-error-fb-unavailable-title'),
-										content: $.msg('fbconnect-error-fb-unavailable-text')
-									}
-								};
-								uiModal.createComponent(modalConfig, function (errorModal) {
-									errorModal.show();
-								});
-							}
-
-							require(['wikia.ui.factory'], function (uiFactory) {
-								$.when(uiFactory.init('modal'))
-									.then(createModal);
-							});
-						});
-					});
-				}
 			}
 		};
 
 	})();
 
-	$( function () {
-		// instantiate singleton on DOM ready
-		fbPreferences.getInstance();
-		//fbInstance.always(fbPreferences.facebookError);
-	});
+	// instantiate singleton on DOM ready
+	$(fbPreferences.getInstance);
 })(jQuery, mediaWiki);

--- a/extensions/wikia/GlobalNavigation/styles/GlobalNavigation.scss
+++ b/extensions/wikia/GlobalNavigation/styles/GlobalNavigation.scss
@@ -113,3 +113,7 @@
 		position: relative;
 	}
 }
+
+.hidden {
+	display: none;
+}

--- a/extensions/wikia/UserLogin/css/UserLogin.scss
+++ b/extensions/wikia/UserLogin/css/UserLogin.scss
@@ -75,3 +75,7 @@ $input-width: 230px;
 		display: none;
 	}
 }
+
+.hidden {
+	display: none;
+}

--- a/extensions/wikia/UserLogin/css/UserLoginDropdown.globalNavigation.scss
+++ b/extensions/wikia/UserLogin/css/UserLoginDropdown.globalNavigation.scss
@@ -54,7 +54,7 @@
 	}
 
 	.WikiaForm {
-		padding: 0 $large-content-padding;
+		padding: 0 $large-content-padding $large-content-padding $large-content-padding;
 
 		.forgot-password {
 			color: $nav-foreground-bright-color;
@@ -66,7 +66,7 @@
 			@include box-sizing;
 			line-height: inherit;
 			margin: 0;
-			padding: 0px;
+			padding: 0;
 			width: 100%;
 
 			&.login-button {
@@ -227,7 +227,7 @@
 		}
 
 		.WikiaForm {
-			padding: 0 $small-content-padding;
+			padding: 0 $small-content-padding $small-content-padding $small-content-padding;
 		}
 	}
 }
@@ -246,7 +246,7 @@
 		}
 
 		.WikiaForm {
-			padding: 0 $medium-content-padding;
+			padding: 0 $medium-content-padding $medium-content-padding $medium-content-padding;
 		}
 	}
 }

--- a/extensions/wikia/UserLogin/css/UserLoginDropdown.globalNavigation.scss
+++ b/extensions/wikia/UserLogin/css/UserLoginDropdown.globalNavigation.scss
@@ -18,7 +18,7 @@
 	display: none;
 	font-size: 12px;
 	list-style: none;
-	padding: 0;
+	padding: 0 0 $large-content-padding 0;
 	position: relative;
 	right: $large-grid-column + $large-grid-gutter + $large-grid-column-padding + 1;
 	z-index: 5000100;
@@ -54,7 +54,7 @@
 	}
 
 	.WikiaForm {
-		padding: 0 $large-content-padding $large-content-padding;
+		padding: 0 $large-content-padding;
 
 		.forgot-password {
 			color: $nav-foreground-bright-color;
@@ -157,7 +157,7 @@
 	}
 
 	.sso-login {
-		padding: 0 $large-content-padding $large-content-padding;
+		padding: 0 $large-content-padding;
 
 		.sso-login-divider {
 			border-top: solid 1px $nav-border-color;
@@ -219,7 +219,7 @@
 		right: 2 * $small-grid-column + 1;
 
 		.sso-login {
-			padding: 0 $small-content-padding $small-content-padding;
+			padding: 0 $small-content-padding;
 		}
 
 		.ajaxRegisterContainer {
@@ -227,7 +227,7 @@
 		}
 
 		.WikiaForm {
-			padding: 0 $small-content-padding $small-content-padding;
+			padding: 0 $small-content-padding;
 		}
 	}
 }
@@ -238,7 +238,7 @@
 		right: $medium-grid-column + $medium-grid-gutter + $medium-grid-column-padding + 1;
 
 		.sso-login {
-			padding: 0 $medium-content-padding $medium-content-padding;
+			padding: 0 $medium-content-padding;
 		}
 
 		.ajaxRegisterContainer {
@@ -246,7 +246,7 @@
 		}
 
 		.WikiaForm {
-			padding: 0 $medium-content-padding $medium-content-padding;
+			padding: 0 $medium-content-padding;
 		}
 	}
 }

--- a/extensions/wikia/UserLogin/css/UserLoginDropdown.globalNavigation.scss
+++ b/extensions/wikia/UserLogin/css/UserLoginDropdown.globalNavigation.scss
@@ -54,7 +54,7 @@
 	}
 
 	.WikiaForm {
-		padding: 0 $large-content-padding $large-content-padding $large-content-padding;
+		padding: 0 $large-content-padding $large-content-padding;
 
 		.forgot-password {
 			color: $nav-foreground-bright-color;
@@ -227,7 +227,7 @@
 		}
 
 		.WikiaForm {
-			padding: 0 $small-content-padding $small-content-padding $small-content-padding;
+			padding: 0 $small-content-padding $small-content-padding;
 		}
 	}
 }
@@ -246,7 +246,7 @@
 		}
 
 		.WikiaForm {
-			padding: 0 $medium-content-padding $medium-content-padding $medium-content-padding;
+			padding: 0 $medium-content-padding $medium-content-padding;
 		}
 	}
 }

--- a/extensions/wikia/UserLogin/js/UserLoginFacebook.js
+++ b/extensions/wikia/UserLogin/js/UserLoginFacebook.js
@@ -60,7 +60,7 @@
 				// load when the login dropdown is shown or specific page is loaded
 				$.loadFacebookAPI()
 					.done(function () {
-						$('.fb-loaded').removeClass('hidden');
+						$('.sso-login').removeClass('hidden');
 					});
 
 				self.log('init');

--- a/extensions/wikia/UserLogin/js/UserLoginFacebook.js
+++ b/extensions/wikia/UserLogin/js/UserLoginFacebook.js
@@ -58,7 +58,10 @@
 				self.loginSetup();
 
 				// load when the login dropdown is shown or specific page is loaded
-				$.loadFacebookAPI();
+				$.loadFacebookAPI()
+					.done(function () {
+						$('.fb-loaded').removeClass('hidden');
+					});
 
 				self.log('init');
 				self.bucky.timer.stop('init');

--- a/extensions/wikia/UserLogin/js/UserLoginFacebook.wikiamobile.js
+++ b/extensions/wikia/UserLogin/js/UserLoginFacebook.wikiamobile.js
@@ -22,14 +22,16 @@ require(['track', 'wikia.querystring', 'toast', 'wikia.nirvana', 'JSMessages', '
 			};
 		})();
 
-	btn.disabled = false;
-	btn.addEventListener('click', function () {
-		fbInit();
+		if (window.FB) {
+			btn.disabled = false;
+			btn.addEventListener('click', function () {
+				fbInit();
 
-		window.FB.login(loginCallback, {
-			scope: 'email'
-		});
-	});
+				window.FB.login(loginCallback, {
+					scope: 'email'
+				});
+			});
+		}
 
 	function loginCallback(response) {
 		if (response && response.status === 'connected') {

--- a/extensions/wikia/UserLogin/templates/UserLoginSpecial_Providers.php
+++ b/extensions/wikia/UserLogin/templates/UserLoginSpecial_Providers.php
@@ -1,4 +1,4 @@
-	<div class="sso-login">
+	<div class="sso-login fb-loaded hidden">
 		<div class="sso-login-divider">
 			<span><?= wfMessage('userlogin-provider-or')->escaped() ?></span>
 		</div>

--- a/extensions/wikia/UserLogin/templates/UserLoginSpecial_Providers.php
+++ b/extensions/wikia/UserLogin/templates/UserLoginSpecial_Providers.php
@@ -1,4 +1,4 @@
-	<div class="sso-login fb-loaded hidden">
+	<div class="sso-login hidden">
 		<div class="sso-login-divider">
 			<span><?= wfMessage('userlogin-provider-or')->escaped() ?></span>
 		</div>

--- a/extensions/wikia/UserLogin/templates/UserLoginSpecial_ProvidersTop.php
+++ b/extensions/wikia/UserLogin/templates/UserLoginSpecial_ProvidersTop.php
@@ -1,4 +1,4 @@
-	<div class="sso-login">
+	<div class="sso-login fb-loaded hidden">
 		<?= $app->renderView('FacebookButton', 'index', array(
 			'class' => 'sso-login-facebook',
 			'text' => wfMessage('fbconnect-wikia-signup-w-facebook')->escaped()

--- a/extensions/wikia/UserLogin/templates/UserLoginSpecial_ProvidersTop.php
+++ b/extensions/wikia/UserLogin/templates/UserLoginSpecial_ProvidersTop.php
@@ -1,4 +1,4 @@
-	<div class="sso-login fb-loaded hidden">
+	<div class="sso-login hidden">
 		<?= $app->renderView('FacebookButton', 'index', array(
 			'class' => 'sso-login-facebook',
 			'text' => wfMessage('fbconnect-wikia-signup-w-facebook')->escaped()

--- a/extensions/wikia/WikiaQuiz/css/WikiaPlayQuiz.scss
+++ b/extensions/wikia/WikiaQuiz/css/WikiaPlayQuiz.scss
@@ -693,3 +693,7 @@ $dark-wiki: 1;
 .WikiaPageHeader h2,.commentslikes,.wikia-menu-button {
 	display: none;
 }
+
+.hidden {
+	display: none;
+}

--- a/extensions/wikia/WikiaQuiz/js/WikiaPlayQuiz.js
+++ b/extensions/wikia/WikiaQuiz/js/WikiaPlayQuiz.js
@@ -62,7 +62,7 @@ var WikiaQuiz = {
 
 		$.loadFacebookAPI()
 			.done(function () {
-				$('.fb-loaded').removeClass('hidden');
+				$('.sso-login').removeClass('hidden');
 			});
 
 		$().log('init', 'WikiaQuiz');

--- a/extensions/wikia/WikiaQuiz/js/WikiaPlayQuiz.js
+++ b/extensions/wikia/WikiaQuiz/js/WikiaPlayQuiz.js
@@ -60,7 +60,10 @@ var WikiaQuiz = {
 			WikiaQuiz.trackEvent('click-link-text', 'moreinfo', -1, $(e.target).attr('href'), e );
 		});
 
-		$.loadFacebookAPI();
+		$.loadFacebookAPI()
+			.done(function () {
+				$('.fb-loaded').removeClass('hidden');
+			});
 
 		$().log('init', 'WikiaQuiz');
 	},

--- a/resources/mediawiki.special/mediawiki.special.preferences.js
+++ b/resources/mediawiki.special/mediawiki.special.preferences.js
@@ -18,33 +18,33 @@ var $fieldsets = $preferences.children( 'fieldset' )
 var $legends = $fieldsets.children( 'legend' )
 	.addClass( 'mainLegend' );
 
-	/**
-	 * Wikia Function - @see UC-206
-	 * Normalize given class name using the prefix
-	 * @param {string} prefix
-	 * @param {string} tabClass
-	 * @returns {string}
-	 */
-	var normalizeTabClass = function (prefix, tabClass) {
-		'use strict';
-		return tabClass.replace('mw-prefsection', prefix);
-	};
+/**
+ * Wikia Function - @see UC-206
+ * Normalize given class name using the prefix
+ * @param {string} prefix
+ * @param {string} tabClass
+ * @returns {string}
+ */
+var normalizeTabClass = function (prefix, tabClass) {
+	'use strict';
+	return tabClass.replace('mw-prefsection', prefix);
+};
 
-	/**
-	 * Wikia Function - @see UC-145
-	 * Make tabs distinguishable based on provided id
-	 * @param {Element} element
-	 * @param {string} selectedTabId
-	 */
-	var makeTabsTargetable = function (element, selectedTabId) {
-		'use strict';
-		var prefix = 'container',
-			classes = element[0].className.split(' ').filter(function (className) {
-				return className.lastIndexOf(prefix, 0) !== 0;
-			});
-		element[0].className = $.trim(classes.join(' '));
-		$preferences.addClass(normalizeTabClass(prefix, selectedTabId));
-	};
+/**
+ * Wikia Function - @see UC-145
+ * Make tabs distinguishable based on provided id
+ * @param {Element} element
+ * @param {string} selectedTabId
+ */
+var makeTabsTargetable = function (element, selectedTabId) {
+	'use strict';
+	var prefix = 'container',
+		classes = element[0].className.split(' ').filter(function (className) {
+			return className.lastIndexOf(prefix, 0) !== 0;
+		});
+	element[0].className = $.trim(classes.join(' '));
+	$preferences.addClass(normalizeTabClass(prefix, selectedTabId));
+};
 
 // Populate the prefToc
 $legends.each( function( i, legend ) {

--- a/resources/mediawiki.special/mediawiki.special.preferences.js
+++ b/resources/mediawiki.special/mediawiki.special.preferences.js
@@ -75,9 +75,12 @@ $legends.each( function( i, legend ) {
 		$preftoc.find( 'li' ).removeClass( 'selected' );
 		$(this).parent().addClass( 'selected' );
 
-		/** Wikia change begin @see UC-145 */
-		// Make elements outside tabs targetable based on selected tab
+		/** Wikia change begin */
+		// Make elements outside tabs targetable based on selected tab - @see UC-145
 		makeTabsTargetable($preferences, ident);
+
+		// Add a custom event per tab - @see UC-206
+		$(document).trigger($tabName + '-click');
 		/** Wikia change end */
 
 		$( '#preferences > fieldset' ).hide();
@@ -85,10 +88,6 @@ $legends.each( function( i, legend ) {
 	});
 	$li.append( $a );
 	$preftoc.append( $li );
-
-	/** Wikia Change start - Add a custom event per tab - @see UC-206 */
-	$(document).trigger($tabName + '-complete');
-	/** Wikia Change end */
 } );
 
 // If we've reloaded the page or followed an open-in-new-window,

--- a/resources/mediawiki.special/mediawiki.special.preferences.js
+++ b/resources/mediawiki.special/mediawiki.special.preferences.js
@@ -19,6 +19,18 @@ var $legends = $fieldsets.children( 'legend' )
 	.addClass( 'mainLegend' );
 
 	/**
+	 * Wikia Function - @see UC-206
+	 * Normalize given class name using the prefix
+	 * @param {string} prefix
+	 * @param {string} tabClass
+	 * @returns {string}
+	 */
+	var normalizeTabClass = function (prefix, tabClass) {
+		'use strict';
+		return tabClass.replace('mw-prefsection', prefix);
+	};
+
+	/**
 	 * Wikia Function - @see UC-145
 	 * Make tabs distinguishable based on provided id
 	 * @param {Element} element
@@ -31,7 +43,7 @@ var $legends = $fieldsets.children( 'legend' )
 				return className.lastIndexOf(prefix, 0) !== 0;
 			});
 		element[0].className = $.trim(classes.join(' '));
-		$preferences.addClass(selectedTabId.replace('mw-prefsection', prefix));
+		$preferences.addClass(normalizeTabClass(prefix, selectedTabId));
 	};
 
 // Populate the prefToc
@@ -42,8 +54,11 @@ $legends.each( function( i, legend ) {
 	}
 	var ident = $legend.parent().attr( 'id' );
 
-	var $li = $( '<li/>', {
-		'class' : ( i === 0 ) ? 'selected' : null
+	/** Wikia Change start - Add a class - @see UC-206 */
+	var $tabName = normalizeTabClass('tab', ident),
+		$li = $( '<li/>', {
+		'class' : $tabName + (( i === 0 ) ? ' selected' : '')
+		/** Wikia Change end */
 	});
 	var $a = $( '<a/>', {
 		text : $legend.text(),
@@ -70,6 +85,10 @@ $legends.each( function( i, legend ) {
 	});
 	$li.append( $a );
 	$preftoc.append( $li );
+
+	/** Wikia Change start - Add a custom event per tab - @see UC-206 */
+	$(document).trigger($tabName + '-complete');
+	/** Wikia Change end */
 } );
 
 // If we've reloaded the page or followed an open-in-new-window,

--- a/resources/wikia/libraries/jquery/getResources/jquery.wikia.getResources.js
+++ b/resources/wikia/libraries/jquery/getResources/jquery.wikia.getResources.js
@@ -16,14 +16,14 @@
 	 */
 	var getResources = (function () {
 		var rAssetManagerGroup = new RegExp(window.wgAssetsManagerQuery
-					// Escape any special regex characters in the URL
-					.replace(/[\-\[\]{}()*+?.,\\\^$|#\s]/g, '\\$&')
-					// Escape forward slashes (required for string)
-					.replace(/\//g, '\\/')
-					// Replace the first parameter to match group or groups
-					.replace('%1\\$s', 'groups?')
-					// Replace remaining parameters with wildcard matches
-					.replace(/%\d\\\$(?:s|d)/g, '(.*)')
+				// Escape any special regex characters in the URL
+				.replace(/[\-\[\]{}()*+?.,\\\^$|#\s]/g, '\\$&')
+				// Escape forward slashes (required for string)
+				.replace(/\//g, '\\/')
+				// Replace the first parameter to match group or groups
+				.replace('%1\\$s', 'groups?')
+				// Replace remaining parameters with wildcard matches
+				.replace(/%\d\\\$(?:s|d)/g, '(.*)')
 			),
 			rAssetManagerGroupType = /(js|s?css)/,
 			rExtension = /\.(js|s?css)$/;

--- a/resources/wikia/libraries/jquery/getResources/jquery.wikia.getResources.js
+++ b/resources/wikia/libraries/jquery/getResources/jquery.wikia.getResources.js
@@ -1,101 +1,105 @@
-(function( window, $ ) {
+(function (window, $) {
+	'use strict';
 
-/**
- * Fetches a list of resources and fires a callback when they have all finished
- * loading. Supports CSS, JavaScript, Sass and AssetManager groups.
- *
- * TODO: Right now, asset group file type is determined by searching for a
- * file type extension in the URI. Is there a better way to detect file type?
- *
- * @author macbre
- * @author kflorence
- */
-var getResources = (function() {
-	var rAssetManagerGroup = new RegExp( window.wgAssetsManagerQuery
-			// Escape any special regex characters in the URL
-			.replace( /[\-\[\]{}()*+?.,\\\^$|#\s]/g, '\\$&' )
-			// Escape forward slashes (required for string)
-			.replace( /\//g, '\\/' )
-			// Replace the first parameter to match group or groups
-			.replace( '%1\\$s', 'groups?' )
-			// Replace remaining parameters with wildcard matches
-			.replace( /%\d\\\$(?:s|d)/g, '(.*)' )
-		),
-		rAssetManagerGroupType = /(js|s?css)/,
-		rExtension = /\.(js|s?css)$/;
+	/**
+	 * Fetches a list of resources and fires a callback when they have all finished
+	 * loading. Supports CSS, JavaScript, Sass and AssetManager groups.
+	 *
+	 * TODO: Right now, asset group file type is determined by searching for a
+	 * file type extension in the URI. Is there a better way to detect file type?
+	 *
+	 * @author macbre
+	 * @author kflorence
+	 */
+	var getResources = (function () {
+		var rAssetManagerGroup = new RegExp(window.wgAssetsManagerQuery
+					// Escape any special regex characters in the URL
+					.replace(/[\-\[\]{}()*+?.,\\\^$|#\s]/g, '\\$&')
+					// Escape forward slashes (required for string)
+					.replace(/\//g, '\\/')
+					// Replace the first parameter to match group or groups
+					.replace('%1\\$s', 'groups?')
+					// Replace remaining parameters with wildcard matches
+					.replace(/%\d\\\$(?:s|d)/g, '(.*)')
+			),
+			rAssetManagerGroupType = /(js|s?css)/,
+			rExtension = /\.(js|s?css)$/;
 
-	return function( resources, success, failure ) {
-		var l, n, matches, remaining,
-			dfd = new $.Deferred();
+		return function (resources, success, failure) {
+			var l, n, matches, remaining,
+				complete,
+				dfd = new $.Deferred(),
+				resource,
+				type;
 
-		// This will be called everytime a resource is loaded
-		var complete = function() {
-			remaining--;
+			// This will be called everytime a resource is loaded
+			complete = function () {
+				remaining--;
 
-			// All files have been downloaded
-			if ( remaining < 1 ) {
-				if ( typeof success == 'function' ) {
-					success();
+				// All files have been downloaded
+				if (remaining < 1) {
+					if (typeof success === 'function') {
+						success();
+					}
+
+					// Resolve the deferred object
+					dfd.resolve();
 				}
+			};
 
-				// Resolve the deferred object
-				dfd.resolve();
+			// Support single resource
+			if (!$.isArray(resources)) {
+				resources = [resources];
 			}
-		};
 
-		// Support single resource
-		if ( !$.isArray( resources ) ) {
-			resources = [ resources ];
-		}
+			// Nothing to load
+			if (!(l = remaining = resources.length)) {
+				complete();
+			}
 
-		// Nothing to load
-		if ( !( l = remaining = resources.length ) ) {
-			complete();
-		}
-
-		for ( n = 0; n < l; n++ ) {
-			var resource = resources[ n ],
+			for (n = 0; n < l; n++) {
+				resource = resources[n];
 				type = typeof resource;
 
-			// AssetsManager package object (e.g. as passed by JSSnippets)
-			if ( type == 'object' ) {
-				if ( resource.type && resource.url ) {
-					type = resource.type;
-					resource = resource.url;
+				// AssetsManager package object (e.g. as passed by JSSnippets)
+				if (type === 'object') {
+					if (resource.type && resource.url) {
+						type = resource.type;
+						resource = resource.url;
+					}
+
+					// URI string
+				} else if (type === 'string') {
+					matches = resource.match(rAssetManagerGroup);
+					matches = matches ? matches[3].match(rAssetManagerGroupType) : resource.match(rExtension);
+					type = matches ? matches[1] : 'unknown';
 				}
 
-			// URI string
-			} else if ( type == 'string' ) {
-				matches = resource.match( rAssetManagerGroup );
-				matches = matches ? matches[ 3 ].match( rAssetManagerGroupType ) : resource.match( rExtension );
-				type = matches ? matches[ 1 ] : 'unknown';
+				if (type === 'js') {
+					$.getScript(resource, complete, failure);
+
+				} else if (type === 'css' || type === 'scss') {
+					$.getCSS(resource, complete);
+
+					// Loader function: $.loadYUI, $.loadJQueryUI
+				} else if (type === 'function') {
+					resource.call($, complete);
+
+				} else {
+					$().log('getResources: unknown type ' + resource);
+
+					dfd.reject({
+						error: 'Unknown type',
+						resource: resource
+					});
+				}
 			}
 
-			if ( type == 'js' ) {
-				$.getScript( resource, complete, failure );
+			return dfd.promise();
+		};
+	}());
 
-			} else if ( type == 'css' || type == 'scss' ) {
-				$.getCSS( resource, complete );
+	// Exports
+	$.getResources = $.getResource = getResources;
 
-			// Loader function: $.loadYUI, $.loadJQueryUI
-			} else if ( type == 'function' ) {
-				resource.call( $, complete );
-
-			} else {
-				$().log('getResources: unknown type ' + resource);
-
-				dfd.reject({
-					error: 'Unknown type',
-					resource: resource
-				});
-			}
-		}
-
-		return dfd.promise();
-	}
-}());
-
-// Exports
-$.getResources = $.getResource = getResources;
-
-})( window, jQuery );
+})(window, jQuery);

--- a/resources/wikia/libraries/jquery/getResources/jquery.wikia.getResources.js
+++ b/resources/wikia/libraries/jquery/getResources/jquery.wikia.getResources.js
@@ -76,7 +76,9 @@
 				}
 
 				if (type === 'js') {
-					$.getScript(resource, complete, failure);
+
+					$.getScript(resource, complete)
+						.fail(failure);
 
 				} else if (type === 'css' || type === 'scss') {
 					$.getCSS(resource, complete);

--- a/resources/wikia/libraries/jquery/getResources/jquery.wikia.getResources.js
+++ b/resources/wikia/libraries/jquery/getResources/jquery.wikia.getResources.js
@@ -5,6 +5,9 @@
 	 * Fetches a list of resources and fires a callback when they have all finished
 	 * loading. Supports CSS, JavaScript, Sass and AssetManager groups.
 	 *
+	 * This is not recommended for cross-domain JS script loading, as the failure function will not be called.
+	 * @see http://bugs.jquery.com/ticket/13735
+	 *
 	 * TODO: Right now, asset group file type is determined by searching for a
 	 * file type extension in the URI. Is there a better way to detect file type?
 	 *

--- a/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadLibrary.js
+++ b/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadLibrary.js
@@ -101,16 +101,17 @@
 			};
 
 			// load GoogleMaps main JS and provide a name of the callback to be called when API is fully initialized
-			$.loadLibrary('GoogleMaps', [{
-						url: 'http://maps.googleapis.com/maps/api/js?sensor=false&callback=onGoogleMapsLoaded',
-						type: 'js'
-					}],
-					typeof (window.google && window.google.maps)
-				).
-				// error handling
-			fail(function () {
-				dfd.reject();
-			});
+			$.loadLibrary(
+				'GoogleMaps',
+				[{
+					url: 'http://maps.googleapis.com/maps/api/js?sensor=false&callback=onGoogleMapsLoaded',
+					type: 'js'
+				}],
+				typeof (window.google && window.google.maps)
+			).
+				fail(function () {
+					dfd.reject();
+				});
 		}
 
 		return dfd.promise();

--- a/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadLibrary.js
+++ b/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadLibrary.js
@@ -119,21 +119,17 @@
 
 	/**
 	 * Load the facebook JS library v2.x
-	 * @param {function} [callback] Function to be called after library is loaded
 	 * @returns {jQuery} Returns a jQuery promise
 	 */
-	$.loadFacebookAPI = function (callback) {
+	$.loadFacebookAPI = function () {
 		var $deferred = $.Deferred();
 
 		// if library is already loaded, fbAsyncInit won't be called,
 		// so make sure callback function still gets called
 		if (window.FB) {
-			if (typeof callback === 'function') {
-				callback();
-			}
-
 			$deferred.resolve();
 		} else {
+			// Do not call this! To be invoked by Facebook library ONLY!
 			window.fbAsyncInit = function () {
 				window.FB.init({
 					appId: window.fbAppId,
@@ -142,10 +138,6 @@
 					version: 'v2.1'
 				});
 
-				if (typeof callback === 'function') {
-					callback();
-				}
-
 				$deferred.resolve();
 			};
 
@@ -153,23 +145,13 @@
 				'Facebook API',
 				window.fbScript || '//connect.facebook.net/en_US/sdk.js',
 				typeof window.FB
-			);
+			).fail(function () {
+				$deferred.reject();
+			});
 		}
 
 		return $deferred;
 	};
-
-	/**
-	 * Load the facebook API on every page until the upgrade to v2.x is stable and parser cache has cleared.
-	 * Needed for XFBML tags to render with stale parser cache.
-	 * DO NOT rely on this library always being loaded.
-	 * Estimated removal date: Dec. 10 2014 (https://wikia-inc.atlassian.net/browse/UC-82)
-	 */
-	$(function () {
-		if (!window.wgNoExternals) {
-			$.loadFacebookAPI();
-		}
-	});
 
 	$.loadGooglePlusAPI = function (callback) {
 		return $.loadLibrary('Google Plus API',


### PR DESCRIPTION
This PR handles the case when Facebook is not available (blocked, or down) by:
- hiding FB login / signup controls throughout all login/signup page and global navigation
- Throwing an error to user on an attempt to navigate to their FB user preference tab.

Also it is removing load of Facebook on every page load. It is being done asynchronously.

Also loading Facebook is no longer using the `getResources` function because "cross site script loading causes `$.getScript` to not execute fail functions." Thanks @lizlux for this fix. More info: #5939

https://wikia-inc.atlassian.net/browse/UC-206
https://wikia-inc.atlassian.net/browse/UC-82
