### PR TITLE
UC-148 Fill missing Facebook user emails on login via FB connect

### DIFF
--- a/extensions/wikia/FacebookClient/FacebookClient.class.php
+++ b/extensions/wikia/FacebookClient/FacebookClient.class.php
@@ -273,6 +273,21 @@ class FacebookClient {
 	}
 
 	/**
+	 * Returns user's email address from Facebook
+	 *
+	 * @param int $userId Facebook User id
+	 * @return string|null email address if exists
+	 */
+	public function getEmail( $userId ) {
+		$userInfo = $this->getUserInfo( $userId );
+		if ( !$userInfo ) {
+			return null;
+		}
+
+		return $userInfo->getProperty( 'email' );
+	}
+
+	/**
 	 * Returns a Wikia User object for the current (or passed) Facebook ID
 	 *
 	 * @param int|null $fbId [optional] A Facebook ID

--- a/extensions/wikia/FacebookClient/FacebookClient.class.php
+++ b/extensions/wikia/FacebookClient/FacebookClient.class.php
@@ -226,41 +226,6 @@ class FacebookClient {
 	}
 
 	/**
-	 * Same as FacebookClient::getUserInfo but returns the data as an array rather than a Facebook\GraphUser object.
-	 *
-	 * @param int $userId
-	 *
-	 * @return array
-	 */
-	public function getUserInfoAsArray( $userId = 0 ) {
-		$userInfo = $this->getUserInfo( $userId );
-		if ( ! $userInfo instanceof Facebook\GraphUser ) {
-			return [];
-		}
-
-		$properties = [
-			'email',
-			'first_name',
-			'middle_name',
-			'last_name',
-			'gender',
-			'link',
-			'locale',
-			'name',
-			'timezone',
-			'updated_time',
-			'verified'
-		];
-		$data = [];
-
-		foreach ( $properties as $prop ) {
-			$data[ $prop ] = $userInfo->getProperty( $prop );
-		}
-
-		return $data;
-	}
-
-	/**
 	 * Returns what Facebook reports as the full user name for the current user.
 	 *
 	 * @param int $user

--- a/extensions/wikia/UserLogin/FacebookSignupController.class.php
+++ b/extensions/wikia/UserLogin/FacebookSignupController.class.php
@@ -114,15 +114,13 @@ class FacebookSignupController extends WikiaController {
 		}
 
 		// get an email from Facebook API
-		$email = \FacebookClient::getInstance()->getEmail( $fbUserId );
-
+		$userInfo = \FacebookClient::getInstance()->getUserInfo( $fbUserId );
 		// BugId:24400
-		if ( !$email ) {
+		if ( !$userInfo ) {
 			$this->skipRendering();
 			return false;
 		}
-
-		$this->fbEmail = $email;
+		$this->fbEmail = $userInfo->getProperty( 'email' );
 
 		$returnTo = $this->wg->request->getVal( 'returnto' );
 		$returnToQuery = $this->wg->request->getVal( 'returntoquery' );

--- a/includes/wikia/tasks/Tasks/FacebookTask.class.php
+++ b/includes/wikia/tasks/Tasks/FacebookTask.class.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * FacebookTask - Contains tasks related to Facebook
+ */
+
+namespace Wikia\Tasks\Tasks;
+
+class FacebookTask extends BaseTask {
+
+	/**
+	 * Update User email to become Facebook-reported email
+	 *
+	 * @param int $userId
+	 * @return bool
+	 */
+	public function updateEmailFromFacebook( $userId ) {
+		$userMap = \FacebookMapModel::lookupFromWikiaID( $userId );
+		if ( !$userMap ) {
+			$this->error( 'Facebook user email update fail. Missing user mapping', [
+				'title' => __METHOD__,
+				'userid' => $userId,
+			] );
+			return false;
+		}
+
+		$fbUserId = $userMap->getFacebookUserId();
+		$email = \FacebookClient::getInstance()->getEmail( $fbUserId );
+
+		if ( !$email ) {
+			$this->info( 'Facebook user email update: No Facebook email', [
+				'title' => __METHOD__,
+				'userid' => $userId,
+				'facebookid' => $fbUserId,
+			] );
+			return false;
+		}
+
+		$status = ( bool ) $this->updateUserEmail( $userMap->getWikiaUserId(), $email );
+		$this->info( 'Facebook user email update complete', [
+			'title' => __METHOD__,
+			'userid' => $userId,
+			'facebookid' => $fbUserId,
+			'email' => $email,
+			'status' => ( $status ? 'success' : 'fail' ),
+		] );
+
+		return $status;
+	}
+
+	protected function updateUserEmail( $userId, $email ) {
+		$app = \F::app();
+
+		$dbw = wfGetDB( DB_MASTER, null, $app->wg->ExternalSharedDB );
+		( new \WikiaSQL() )
+			->UPDATE( 'user' )
+			->SET( 'user_email', $email )
+			->WHERE( 'user_id' )->EQUAL_TO( $userId )
+			->run( $dbw );
+
+		return $dbw->affectedRows();
+	}
+
+}

--- a/includes/wikia/tasks/Tasks/FacebookTask.class.php
+++ b/includes/wikia/tasks/Tasks/FacebookTask.class.php
@@ -36,29 +36,29 @@ class FacebookTask extends BaseTask {
 			return false;
 		}
 
-		$status = ( bool ) $this->updateUserEmail( $userMap->getWikiaUserId(), $email );
+		$this->updateUserEmail( $userMap->getWikiaUserId(), $email );
 		$this->info( 'Facebook user email update complete', [
 			'title' => __METHOD__,
 			'userid' => $userId,
 			'facebookid' => $fbUserId,
 			'email' => $email,
-			'status' => ( $status ? 'success' : 'fail' ),
 		] );
 
-		return $status;
+		return true;
 	}
 
+	/**
+	 * Update user email to the one given
+	 *
+	 * @param int $userId
+	 * @param string $email
+	 */
 	protected function updateUserEmail( $userId, $email ) {
-		$app = \F::app();
-
-		$dbw = wfGetDB( DB_MASTER, null, $app->wg->ExternalSharedDB );
-		( new \WikiaSQL() )
-			->UPDATE( 'user' )
-			->SET( 'user_email', $email )
-			->WHERE( 'user_id' )->EQUAL_TO( $userId )
-			->run( $dbw );
-
-		return $dbw->affectedRows();
+		/** @var \User $user */
+		$user = \User::newFromId( $userId );
+		$user->setEmail( $email );
+		$user->confirmEmail();
+		$user->saveSettings();
 	}
 
 }


### PR DESCRIPTION
Some Users that have previously signed up via Facebook are missing email addresses from their Wikia profile. This PR aims to retrieve missing emails once a user logs into Wikia via Facebook connect.

Also refactors the way email is looked up from FB.

https://wikia-inc.atlassian.net/browse/UC-148
