### PR TITLE
(CE-1219) Add a user profile badge for the new Moderator group

### DIFF
--- a/extensions/wikia/UserProfilePageV3/UserProfilePage.i18n.php
+++ b/extensions/wikia/UserProfilePageV3/UserProfilePage.i18n.php
@@ -58,6 +58,7 @@ $messages['en'] = array(
 	'user-identity-box-group-adminmentor' => 'Admin Mentor',
 	'user-identity-box-group-wikiastars' => 'Wikia Star',
 	'user-identity-box-group-voldev' => 'Volunteer Developer',
+	'user-identity-box-group-moderator' => 'Moderator',
 
 	'user-identity-box-zero-state-location' => 'Location',
 	'user-identity-box-zero-state-birthday' => 'Birthday',
@@ -158,6 +159,7 @@ $messages['qqq'] = array(
 	'user-identity-box-group-adminmentor' => 'Group name shown on user profile for users who are Admin Mentors.',
 	'user-identity-box-group-wikiastars' => 'Wikiaster',
 	'user-identity-box-group-voldev' => 'Group name shown on user profile for users who are Volunteer Developers',
+	'user-identity-box-group-moderator' => 'Group name shown on user profile for users who are Moderators',
 	'user-identity-box-join-more-wikis' => 'Message in user profile for when said user has not yet edited in wikis which could be displayed as his favourites',
 	'user-identity-remove-confirmation' => 'appears when user is trying to remove avatar',
 	'user-identity-remove-fail' => 'appears in alert box when there ware some when removing the avatar',

--- a/extensions/wikia/UserProfilePageV3/strategies/UserOneTagStrategy.class.php
+++ b/extensions/wikia/UserProfilePageV3/strategies/UserOneTagStrategy.class.php
@@ -4,14 +4,15 @@
  */
 class UserOneTagStrategy extends UserTagsStrategyBase {
 	protected $groupsRank = array(
-		'authenticated' => 9,
-		'sysop' => 8,
-		'staff' => 7,
-		'helper' => 6,
-		'adminmentor' => 5,
-		'vstf' => 4,
-		'voldev' => 3,
-		'council' => 2,
+		'authenticated' => 10,
+		'sysop' => 9,
+		'staff' => 8,
+		'helper' => 7,
+		'adminmentor' => 6,
+		'vstf' => 5,
+		'voldev' => 4,
+		'council' => 3,
+		'moderator' => 2,
 		'chatmoderator' => 1,
 	);
 

--- a/extensions/wikia/UserProfilePageV3/strategies/UserTwoTagsStrategy.class.php
+++ b/extensions/wikia/UserProfilePageV3/strategies/UserTwoTagsStrategy.class.php
@@ -8,12 +8,13 @@ class UserTwoTagsStrategy extends UserTagsStrategyBase {
 	 * @var array
 	 */
 	protected $groupsRank = array(
-		'sysop' => 7,
-		'helper' => 6,
-		'adminmentor' => 5,
-		'vstf' => 4,
-		'voldev' => 3,
-		'council' => 2,
+		'sysop' => 8,
+		'helper' => 7,
+		'adminmentor' => 6,
+		'vstf' => 5,
+		'voldev' => 4,
+		'council' => 3,
+		'moderator' => 2,
 		'chatmoderator' => 1,
 	);
 


### PR DESCRIPTION
Add a user profile badge for the new Moderator group, with a precedence
over chatmoderators for displaying the badge.

Quick addition to https://wikia-inc.atlassian.net/browse/VOLDEV-79

/cc @Wikia/community-engineering @garthwebb @jsutterfield 
