### PR TITLE
Uc 229 fixing Special:UserSignup on mobile

### DIFF
--- a/extensions/wikia/UserLogin/css/UserSignup.wikiamobile.scss
+++ b/extensions/wikia/UserLogin/css/UserSignup.wikiamobile.scss
@@ -19,7 +19,7 @@ fieldset {
 .input-group {
 	margin: 0 0 10px 0;
 
-	input {
+	input:not([type=checkbox]) {
 		background-color: $transparent;
 		border: {
 			radius: 2px;

--- a/extensions/wikia/UserLogin/js/UserSignup.js
+++ b/extensions/wikia/UserLogin/js/UserSignup.js
@@ -2,6 +2,9 @@
 (function () {
 	'use strict';
 
+	/**
+	 * JS for signing up with a new account, both on mobile and desktop
+	 */
 	var UserSignup = {
 		inputsToValidate: ['userloginext01', 'email', 'userloginext02', 'birthday'],
 		notEmptyFields: ['userloginext01', 'email', 'userloginext02', 'birthday', 'birthmonth', 'birthyear'],
@@ -42,7 +45,8 @@
 			var $captchaInput;
 
 			// if we don't need captcha on this form, there's nothing to fail
-			if (!this.useCaptcha) {
+			// Temporary skin check fix until we sort out captcha on mobile UC-162
+			if (!this.useCaptcha || window.skin === 'wikiamobile') {
 				return false;
 			}
 

--- a/extensions/wikia/UserLogin/templates/UserSignupSpecial_WikiaMobileIndex.php
+++ b/extensions/wikia/UserLogin/templates/UserSignupSpecial_WikiaMobileIndex.php
@@ -13,13 +13,13 @@
 				'type' => 'hidden',
 				'name' => 'username',
 				'value' => '',
-				'label' => wfMessage( 'yourname' )->text(),
+				'label' => wfMessage( 'yourname' )->escaped(),
 			],
 			[ //actual username field
 				'type' => 'text',
 				'name' => 'userloginext01',
 				'value' => htmlspecialchars( $username ),
-				'placeholder' => wfMessage( 'yourname' )->text(),
+				'placeholder' => wfMessage( 'yourname' )->escaped(),
 				'isRequired' => true,
 				'isInvalid' => ( !empty( $errParam ) && $errParam === 'username' ),
 				'errorMsg' => ( !empty( $msg ) ? $msg : '' )
@@ -28,7 +28,7 @@
 				'type' => 'email',
 				'name' => 'email',
 				'value' => Sanitizer::encodeAttribute( $email ),
-				'placeholder' => wfMessage( 'email' )->text(),
+				'placeholder' => wfMessage( 'email' )->escaped(),
 				'isRequired' => true,
 				'isInvalid' => ( !empty( $errParam ) && $errParam === 'email' ),
 				'errorMsg' => ( !empty( $msg ) ? $msg : '' )
@@ -37,13 +37,13 @@
 				'type' => 'hidden',
 				'name' => 'password',
 				'value' => '',
-				'label' => wfMessage( 'yourpassword' )->text(),
+				'label' => wfMessage( 'yourpassword' )->escaped(),
 			],
 			[ //actual password field
 				'type' => 'password',
 				'name' => 'userloginext02',
 				'value' => '',
-				'placeholder' => wfMessage( 'yourpassword' )->text(),
+				'placeholder' => wfMessage( 'yourpassword' )->escaped(),
 				'isRequired' => true,
 				'isInvalid' => ( !empty( $errParam ) && $errParam === 'password' ),
 				'errorMsg' => ( !empty( $msg ) ? $msg : '' )
@@ -59,9 +59,8 @@
 				'view' => 'birthday',
 				'isRequired' => true,
 				'class' => 'birthday-group',
-				'isInvalid' => ( !empty( $errParam ) && $errParam === 'birthyear' ) ||
-					( !empty( $errParam ) && $errParam === 'birthmonth' ) ||
-					( !empty( $errParam ) && $errParam === 'birthday' ),
+				'isInvalid' => ( !empty( $errParam )  ) &&
+					( $errParam === 'birthyear' || $errParam === 'birthmonth' || $errParam === 'birthday' ),
 				'errorMsg' => ( !empty( $msg ) ? $msg : '' ),
 				'params' => [
 					'birthyear' => $birthyear,

--- a/extensions/wikia/UserLogin/templates/UserSignupSpecial_WikiaMobileIndex.php
+++ b/extensions/wikia/UserLogin/templates/UserSignupSpecial_WikiaMobileIndex.php
@@ -71,6 +71,12 @@
 				],
 			],
 			[
+				'class' => 'opt-in-container hidden',
+				'type' => 'checkbox',
+				'name' => 'wpMarketingOptIn',
+				'label' => wfMessage( 'userlogin-opt-in-label' )->escaped(),
+			],
+			[
 				'type' => 'nirvanaview',
 				'controller' => 'UserSignupSpecial',
 				'view' => 'WikiaMobileSubmit',

--- a/extensions/wikia/UserLogin/templates/UserSignupSpecial_WikiaMobileIndex.php
+++ b/extensions/wikia/UserLogin/templates/UserSignupSpecial_WikiaMobileIndex.php
@@ -1,92 +1,104 @@
 <section class="WikiaSignup wkForm">
 <?php
-	$form = array(
+	$form = [
 		'id' => 'WikiaSignupForm',
 		'method' => 'post',
-		'inputs' => array(
-			array(
+		'inputs' => [
+			[
 				'type' => 'hidden',
 				'name' => 'signupToken',
 				'value' => Sanitizer::encodeAttribute( $signupToken ),
-			),
-			array( //fake username field (not in use)
+			],
+			[ //fake username field ( not in use )
 				'type' => 'hidden',
 				'name' => 'username',
 				'value' => '',
-				'label' => wfMessage('yourname')->text(),
-			),
-			array( //actual username field
+				'label' => wfMessage( 'yourname' )->text(),
+			],
+			[ //actual username field
 				'type' => 'text',
 				'name' => 'userloginext01',
-				'value' => htmlspecialchars($username),
-				'placeholder' => wfMessage('yourname')->text(),
+				'value' => htmlspecialchars( $username ),
+				'placeholder' => wfMessage( 'yourname' )->text(),
 				'isRequired' => true,
-				'isInvalid' => (!empty($errParam) && $errParam === 'username'),
-				'errorMsg' => (!empty($msg) ? $msg : '')
-			),
-			array(
+				'isInvalid' => ( !empty( $errParam ) && $errParam === 'username' ),
+				'errorMsg' => ( !empty( $msg ) ? $msg : '' )
+			],
+			[
 				'type' => 'email',
 				'name' => 'email',
 				'value' => Sanitizer::encodeAttribute( $email ),
-				'placeholder' => wfMessage('email')->text(),
+				'placeholder' => wfMessage( 'email' )->text(),
 				'isRequired' => true,
-				'isInvalid' => (!empty($errParam) && $errParam === 'email'),
-				'errorMsg' => (!empty($msg) ? $msg : '')
-			),
-			array( //fake password field (not in use)
+				'isInvalid' => ( !empty( $errParam ) && $errParam === 'email' ),
+				'errorMsg' => ( !empty( $msg ) ? $msg : '' )
+			],
+			[ //fake password field ( not in use )
 				'type' => 'hidden',
 				'name' => 'password',
 				'value' => '',
-				'label' => wfMessage('yourpassword')->text(),
-			),
-			array( //actual password field
+				'label' => wfMessage( 'yourpassword' )->text(),
+			],
+			[ //actual password field
 				'type' => 'password',
 				'name' => 'userloginext02',
 				'value' => '',
-				'placeholder' => wfMessage('yourpassword')->text(),
+				'placeholder' => wfMessage( 'yourpassword' )->text(),
 				'isRequired' => true,
-				'isInvalid' => (!empty($errParam) && $errParam === 'password'),
-				'errorMsg' => (!empty($msg) ? $msg : '')
-			),
-			array(
+				'isInvalid' => ( !empty( $errParam ) && $errParam === 'password' ),
+				'errorMsg' => ( !empty( $msg ) ? $msg : '' )
+			],
+			[
+				'type' => 'hidden',
+				'name' => 'wpRegistrationCountry',
+				'value' => '',
+			],
+			[
 				'type' => 'nirvanaview',
 				'controller' => 'UserSignupSpecial',
 				'view' => 'birthday',
 				'isRequired' => true,
 				'class' => 'birthday-group',
-				'isInvalid' => (!empty($errParam) && $errParam === 'birthyear') || (!empty($errParam) && $errParam === 'birthmonth') || (!empty($errParam) && $errParam === 'birthday'),
-				'errorMsg' => (!empty($msg) ? $msg : ''),
-				'params' => array('birthyear' => $birthyear, 'birthmonth' => $birthmonth, 'birthday' => $birthday, 'isEn' => $isEn),
-			),
-			array(
+				'isInvalid' => ( !empty( $errParam ) && $errParam === 'birthyear' ) ||
+					( !empty( $errParam ) && $errParam === 'birthmonth' ) ||
+					( !empty( $errParam ) && $errParam === 'birthday' ),
+				'errorMsg' => ( !empty( $msg ) ? $msg : '' ),
+				'params' => [
+					'birthyear' => $birthyear,
+					'birthmonth' => $birthmonth,
+					'birthday' => $birthday,
+					'isEn' => $isEn
+				],
+			],
+			[
 				'type' => 'nirvanaview',
 				'controller' => 'UserSignupSpecial',
 				'view' => 'WikiaMobileSubmit',
 				'class' => 'submit-pane',
-				'params' => array('createAccountButtonLabel' => $createAccountButtonLabel)
-			)
-		)
-	);
+				'params' => ['createAccountButtonLabel' => $createAccountButtonLabel]
+			]
+		]
+	];
 
-	$form['isInvalid'] = !empty($result) && $result === 'error' && empty($errParam);
+	$form['isInvalid'] = !empty( $result ) && $result === 'error' && empty( $errParam );
 	$form['errorMsg'] = $form['isInvalid'] ? $msg : '';
 
-	if(!empty($returnto)) {
-		$form['inputs'][] = array(
+	if( !empty( $returnto ) ) {
+		$form['inputs'][] = [
 			'type' => 'hidden',
 			'name' => 'returnto',
 			'value' => Sanitizer::encodeAttribute( $returnto )
-		);
+		];
 	}
 
-	if(!empty($byemail)) {
-		$form['inputs'][] = array(
+	if( !empty( $byemail ) ) {
+		$form['inputs'][] = [
 			'type' => 'hidden',
 			'name' => 'byemail',
 			'value' => Sanitizer::encodeAttribute( $byemail )
-		);
+		];
 	}
 
-	echo F::app()->renderView('WikiaStyleGuideForm', 'index', array('form' => $form));
+	echo F::app()->renderView( 'WikiaStyleGuideForm', 'index', ['form' => $form] );
 ?>
 </section>

--- a/extensions/wikia/WikiaMobile/css/form.scss
+++ b/extensions/wikia/WikiaMobile/css/form.scss
@@ -3,14 +3,14 @@
 .wkForm, .WikiaForm {
 	text-align: center;
 
-	input, textarea {
+	input:not([type=checkbox]), textarea {
 		width: 100%;
 		border: 1px solid $border-color;
 		background-color: $input-bg-color;
 		font-weight: 100;
 	}
 
-	input {
+	input:not([type=checkbox]) {
 		padding: 0 10px;
 		height: 40px;
 		margin: 0 0 20px 0;


### PR DESCRIPTION
Fixing JS errors on mobile signup page that started after some recent changes we made to the oasis version of the form. 

Fixes: 
- Captcha check now disregards mobile b/c there's no captcha on mobile at the moment
- Marketing opt-in and tracking of the country code are now set up on mobile. The JS was expecting those inputs to be there and they weren't. 
- Checkboxes weren't styled properly on mobile. I guess we didn't have any before this!

https://wikia-inc.atlassian.net/browse/UC-229
