### PR TITLE
(CE-1192) Fix creating new pages with forms on some SMW wikias

### DIFF
--- a/extensions/SemanticForms/includes/SF_FormPrinter.php
+++ b/extensions/SemanticForms/includes/SF_FormPrinter.php
@@ -423,12 +423,14 @@ END;
 			$wgOut->addHTML( "\n<hr />\n" );
 		}
 
-		$oldParser = $wgParser;
+//		$oldParser = $wgParser;
 
-		$wgParser = unserialize( serialize( $oldParser ) ); // deep clone of parser
-		$wgParser->Options( ParserOptions::newFromUser( $wgUser ) );
+//		$wgParser = unserialize( serialize( $oldParser ) ); // deep clone of parser
+		if ( !$wgParser->Options() ) {
+			$wgParser->Options( ParserOptions::newFromUser( $wgUser ) );
+		}
 		$wgParser->Title( $this->mPageTitle );
-		$wgParser->clearState();
+//		$wgParser->clearState();
 
 		$form_def = SFFormUtils::getFormDefinition( $wgParser, $form_def, $form_id );
 
@@ -1591,7 +1593,7 @@ END;
 		$parserOutput = $wgParser->getOutput();
 		$wgOut->addParserOutputNoText( $parserOutput );
 
-		$wgParser = $oldParser;
+//		$wgParser = $oldParser;
 
 		wfProfileOut( __METHOD__ );
 


### PR DESCRIPTION
SemanticForms was doing a hacky deep clone of the parser to get around a
bug I can't reproduce, by serializing and unserializing it and then using
the clone to parse the form. This caused an exception as parts of the parser
contain closures which cannot be serialized. So backporting the following
change from a newer version of the extension to fix it:
https://github.com/wikimedia/mediawiki-extensions-SemanticForms/commit/ca8d126424c1

Fixes fatal error:

```
Unexpected non-MediaWiki exception encountered, of type "Exception"
exception 'Exception' with message 'Serialization of 'Closure' is not allowed'
in extensions/SemanticForms/includes/SF_FormPrinter.php:428
```

/cc @Wikia/community-engineering 
