### PR TITLE
PLATFORM-733: Message::extractParam - log invalid message param

### DIFF
--- a/includes/Message.php
+++ b/includes/Message.php
@@ -547,6 +547,15 @@ class Message {
 				"Invalid message parameter: " . htmlspecialchars( serialize( $param ) ),
 				E_USER_WARNING
 			);
+
+			// Wikia change - start (@author macbre)
+			// log more details for PLATFORM-733
+			\Wikia\Logger\WikiaLogger::instance()->error( __METHOD__, [
+				'exception' => new Exception( 'Invalid message parameter' ),
+				'param' => serialize( $param ),
+			]);
+			// Wikia change - end
+
 			return array( 'before', '[INVALID]' );
 		}
 	}


### PR DESCRIPTION
Provide more context when logging an error from `Message.php`

```
PHP Warning: Invalid message parameter: a:1:{s:3:&quot;num&quot;;N;} in /includes/Message.php on line 549
```

@lgarczewski / @michalroszka 
