### PR TITLE
MAIN-3358: properly register UnusedVideos API entry point

### DIFF
--- a/extensions/wikia/SpecialUnusedVideos/SpecialUnusedVideosHooks.class.php
+++ b/extensions/wikia/SpecialUnusedVideos/SpecialUnusedVideosHooks.class.php
@@ -12,7 +12,7 @@ class SpecialUnusedVideosHooks {
 	 * @return true
 	 */
 	public static function registerUnusedVideos( &$wgQueryPages ) {
-		$wgQueryPages[] = array( 'UnusedVideos', 'UnusedVideos' );
+		$wgQueryPages[] = array( 'SpecialUnusedVideos', 'UnusedVideos' );
 		return true;
 	}
 


### PR DESCRIPTION
Resolves `PHP Fatal Error: Class 'UnusedVideos' not found in /includes/api/ApiQueryQueryPage.php on line 141`

@SebastianMarzjan 
