### PR TITLE
PLATFORM-742: Port ImgLzy loading to handle Vignette URLs

### DIFF
--- a/extensions/wikia/ImageLazyLoad/js/ImgLzy.module.js
+++ b/extensions/wikia/ImageLazyLoad/js/ImgLzy.module.js
@@ -71,6 +71,9 @@ define('wikia.ImgLzy', ['jquery', 'wikia.log', 'wikia.window', 'wikia.thumbnaile
 					src = src.replace(/\.[^\./]+$/, '.webp');
 				}
 				else {
+					// remove the existing format parameter
+					src = src.replace(/[\?&]format=\w+/, '');
+
 					// add "format=webp" to Vignette URL
 					src += src.indexOf('?') ? '&' : '?';
 					src += 'format=webp';

--- a/extensions/wikia/ImageLazyLoad/js/ImgLzy.module.js
+++ b/extensions/wikia/ImageLazyLoad/js/ImgLzy.module.js
@@ -3,13 +3,12 @@
 /* Lazy loading for images inside articles (skips wikiamobile)
  * @author Piotr Bablok <pbablok@wikia-inc.com>
  */
-define('wikia.ImgLzy', ['jquery', 'wikia.log', 'wikia.window'], function ($, log, w) {
+define('wikia.ImgLzy', ['jquery', 'wikia.log', 'wikia.window', 'wikia.thumbnailer'], function ($, log, w, thumbnailer) {
 	'use strict';
 
 	var ImgLzy,
-		// allow WebP thumbnails for JPG and PNG files only (exclude video thumbnails)
-		// e.g. /muppet/images/thumb/9/98/BBC1_promos_for_Muppets_Tonight/150px-BBC1_promos_for_Muppets_Tonight.jpg
-		thumbCheckRegExp = /\/images\/thumb\/[0-9a-f]\/[0-9a-f]{2}\/[^/]+\.(jpg|jpeg|jpe|png)(\/)/i;
+		// allow WebP thumbnails for JPG and PNG files only
+		thumbExtCheckRegExp = /\.(jpg|jpeg|jpe|png)(\/)/i;
 
 	function logger(msg) {
 		log(msg, log.levels.info, 'ImgLzy');
@@ -67,8 +66,15 @@ define('wikia.ImgLzy', ['jquery', 'wikia.log', 'wikia.window'], function ($, log
 
 		// rewrite the URL to request WebP thumbnails (if enabled on this wiki and supported by the browser)
 		rewriteURLForWebP: function (src) {
-			if (w.wgEnableWebPThumbnails === true && this.browserSupportsWebP && thumbCheckRegExp.test(src)) {
-				src = src.replace(/\.[^\./]+$/, '.webp');
+			if (w.wgEnableWebPThumbnails === true && this.browserSupportsWebP && thumbExtCheckRegExp.test(src) && thumbnailer.isThumbUrl(src)) {
+				if (thumbnailer.isLegacyThumbnailerUrl(src)) {
+					src = src.replace(/\.[^\./]+$/, '.webp');
+				}
+				else {
+					// add "format=webp" to Vignette URL
+					src += src.indexOf('?') ? '&' : '?';
+					src += 'format=webp';
+				}
 			}
 			return src;
 		},

--- a/extensions/wikia/ImageLazyLoad/spec/ImageLazyLoad.spec.js
+++ b/extensions/wikia/ImageLazyLoad/spec/ImageLazyLoad.spec.js
@@ -5,7 +5,7 @@ describe('ImgLzy', function () {
 	function getImgLzyMock(supportsWebP) {
 		var logMock = function () {},
 			windowMock = {
-				wgEnableWebPThumbnails: true,
+				wgEnableWebPThumbnails: true
 			},
 			ImgLzy;
 
@@ -17,20 +17,20 @@ describe('ImgLzy', function () {
 		return ImgLzy;
 	}
 
-	it('uses webp for selected thumbnails', function() {
-		var ImgLzy = getImgLzyMock(true), // "force" WebP support to test URL rewrites
-			urls;
+	it('uses webp for selected old thumbnails', function() {
+		var ImgLzy = getImgLzyMock(true); // "force" WebP support to test URL rewrites
 
 		// API check
 		expect(typeof ImgLzy).toBe('object');
 		expect(typeof ImgLzy.init).toBe('function');
 		expect(typeof ImgLzy.rewriteURLForWebP).toBe('function');
 
-		// test thumbnail URL rewrites
-		urls = [{
+		[
+			{
 				url: 'http://images.macbre.wikia-dev.com/__cb20120211200134/muppet/images/thumb/9/96/Early_elmo.jpg/300px-Early_elmo.png',
 				webp: true
-			}, {
+			},
+			{
 				url: 'http://images.macbre.wikia-dev.com/__cb20120211200134/muppet/images/thumb/9/96/Early_elmo.png/300px-Early_elmo.png',
 				webp: true
 			},
@@ -42,25 +42,39 @@ describe('ImgLzy', function () {
 			// not a thumb
 			{
 				url: 'http://images.macbre.wikia-dev.com/__cb20060721230014/muppet/images/4/45/Rovelive.jpg',
-				web: false,
+				web: false
 			},
 			// video thumb
 			{
 				url: 'http://images.macbre.wikia-dev.com/__cb20120603092251/muppet/images/thumb/9/92/The_Muppets_Bollywood_Spoof_trailer_Official_HD/150px-The_Muppets_Bollywood_Spoof_trailer_Official_HD.jpg',
 				webp: false
 			}
-		];
-
-		urls.forEach(function (testCase) {
+		].forEach(function (testCase) {
 			var url = ImgLzy.rewriteURLForWebP(testCase.url);
 			expect(url.indexOf('.webp') > -1).toBe(testCase.webp === true);
 		});
 	});
 
 	it('handles Vignette URLs', function() {
-		var url = 'http://vignette1.wikia.nocookie.net/nordycka/images/c/c5/Svolder%2C_by_Otto_Sinding.jpg/revision/latest/scale-to-width/300?cb=20141031163618&path-prefix=pl',
-			ImgLzy = getImgLzyMock(true);
+		var ImgLzy = getImgLzyMock(true);
 
-		expect(url + '&format=webp').toBe(ImgLzy.rewriteURLForWebP(url));
-	})
+		[
+			{
+				url: 'http://vignette1.wikia.nocookie.net/nordycka/images/c/c5/Svolder%2C_by_Otto_Sinding.jpg/revision/latest/scale-to-width/300?cb=20141031163618&path-prefix=pl',
+				expected: 'http://vignette1.wikia.nocookie.net/nordycka/images/c/c5/Svolder%2C_by_Otto_Sinding.jpg/revision/latest/scale-to-width/300?cb=20141031163618&path-prefix=pl&format=webp'
+			},
+			// replace the existing "format" parameter
+			{
+				url: 'http://vignette1.wikia.nocookie.net/nordycka/images/c/c5/Svolder%2C_by_Otto_Sinding.jpg/revision/latest/scale-to-width/300?cb=20141031163618&path-prefix=pl&format=jpg',
+				expected: 'http://vignette1.wikia.nocookie.net/nordycka/images/c/c5/Svolder%2C_by_Otto_Sinding.jpg/revision/latest/scale-to-width/300?cb=20141031163618&path-prefix=pl&format=webp'
+			},
+			{
+				url: 'http://vignette1.wikia.nocookie.net/nordycka/images/c/c5/Svolder%2C_by_Otto_Sinding.jpg/revision/latest/scale-to-width/300?cb=20141031163618&path-prefix=pl&format=jpg&foo=bar',
+				expected: 'http://vignette1.wikia.nocookie.net/nordycka/images/c/c5/Svolder%2C_by_Otto_Sinding.jpg/revision/latest/scale-to-width/300?cb=20141031163618&path-prefix=pl&foo=bar&format=webp'
+			}
+		].forEach(function (testCase) {
+			var url = ImgLzy.rewriteURLForWebP(testCase.url);
+			expect(url).toBe(testCase.expected);
+		});
+	});
 });

--- a/extensions/wikia/ImageLazyLoad/spec/ImageLazyLoad.spec.js
+++ b/extensions/wikia/ImageLazyLoad/spec/ImageLazyLoad.spec.js
@@ -11,47 +11,56 @@ describe('ImgLzy', function () {
 
 		logMock.levels = {};
 
-		ImgLzy = modules['wikia.ImgLzy'](jQuery, logMock, windowMock);
+		ImgLzy = modules['wikia.ImgLzy'](jQuery, logMock, windowMock, modules['wikia.thumbnailer']());
 		ImgLzy.browserSupportsWebP = (supportsWebP === true);
 
 		return ImgLzy;
 	}
 
-	var ImgLzy = getImgLzyMock(true), // "force" WebP support to test URL rewrites
-		urls;
+	it('uses webp for selected thumbnails', function() {
+		var ImgLzy = getImgLzyMock(true), // "force" WebP support to test URL rewrites
+			urls;
 
-	// API check
-	expect(typeof ImgLzy).toBe('object');
-	expect(typeof ImgLzy.init).toBe('function');
-	expect(typeof ImgLzy.rewriteURLForWebP).toBe('function');
+		// API check
+		expect(typeof ImgLzy).toBe('object');
+		expect(typeof ImgLzy.init).toBe('function');
+		expect(typeof ImgLzy.rewriteURLForWebP).toBe('function');
 
-	// test thumbnail URL rewrites
-	urls = [{
-			url: 'http://images.macbre.wikia-dev.com/__cb20120211200134/muppet/images/thumb/9/96/Early_elmo.jpg/300px-Early_elmo.png',
-			webp: true
-		}, {
-			url: 'http://images.macbre.wikia-dev.com/__cb20120211200134/muppet/images/thumb/9/96/Early_elmo.png/300px-Early_elmo.png',
-			webp: true
-		},
-		// skip GIFs
-		{
-			url: 'http://images.macbre.wikia-dev.com/__cb20120211200134/muppet/images/thumb/9/96/Early_elmo.gif/300px-Early_elmo.gif',
-			webp: false
-		},
-		// not a thumb
-		{
-			url: 'http://images.macbre.wikia-dev.com/__cb20060721230014/muppet/images/4/45/Rovelive.jpg',
-			web: false,
-		},
-		// video thumb
-		{
-			url: 'http://images.macbre.wikia-dev.com/__cb20120603092251/muppet/images/thumb/9/92/The_Muppets_Bollywood_Spoof_trailer_Official_HD/150px-The_Muppets_Bollywood_Spoof_trailer_Official_HD.jpg',
-			webp: false
-		}
-	];
+		// test thumbnail URL rewrites
+		urls = [{
+				url: 'http://images.macbre.wikia-dev.com/__cb20120211200134/muppet/images/thumb/9/96/Early_elmo.jpg/300px-Early_elmo.png',
+				webp: true
+			}, {
+				url: 'http://images.macbre.wikia-dev.com/__cb20120211200134/muppet/images/thumb/9/96/Early_elmo.png/300px-Early_elmo.png',
+				webp: true
+			},
+			// skip GIFs
+			{
+				url: 'http://images.macbre.wikia-dev.com/__cb20120211200134/muppet/images/thumb/9/96/Early_elmo.gif/300px-Early_elmo.gif',
+				webp: false
+			},
+			// not a thumb
+			{
+				url: 'http://images.macbre.wikia-dev.com/__cb20060721230014/muppet/images/4/45/Rovelive.jpg',
+				web: false,
+			},
+			// video thumb
+			{
+				url: 'http://images.macbre.wikia-dev.com/__cb20120603092251/muppet/images/thumb/9/92/The_Muppets_Bollywood_Spoof_trailer_Official_HD/150px-The_Muppets_Bollywood_Spoof_trailer_Official_HD.jpg',
+				webp: false
+			}
+		];
 
-	urls.forEach(function (testCase) {
-		var url = ImgLzy.rewriteURLForWebP(testCase.url);
-		expect(url.indexOf('.webp') > -1).toBe(testCase.webp === true);
+		urls.forEach(function (testCase) {
+			var url = ImgLzy.rewriteURLForWebP(testCase.url);
+			expect(url.indexOf('.webp') > -1).toBe(testCase.webp === true);
+		});
 	});
+
+	it('handles Vignette URLs', function() {
+		var url = 'http://vignette1.wikia.nocookie.net/nordycka/images/c/c5/Svolder%2C_by_Otto_Sinding.jpg/revision/latest/scale-to-width/300?cb=20141031163618&path-prefix=pl',
+			ImgLzy = getImgLzyMock(true);
+
+		expect(url + '&format=webp').toBe(ImgLzy.rewriteURLForWebP(url));
+	})
 });

--- a/resources/wikia/modules/spec/thumbnailer.spec.js
+++ b/resources/wikia/modules/spec/thumbnailer.spec.js
@@ -10,8 +10,14 @@ describe('thumbnailer', function () {
 	it('identifies thumbnails', function () {
 		expect(thumbnailer.isThumbUrl(legacyThumbnailerUrl)).toBe(true);
 		expect(thumbnailer.isThumbUrl(thumbnailerUrl)).toBe(true);
+		expect(thumbnailer.isThumbUrl(thumbnailerUrl.replace('vignette2', 'vignette-poz'))).toBe(true); // Poznań devbox
 		expect(thumbnailer.isThumbUrl(fullSizeImageUrl)).toBe(false);
 		expect(thumbnailer.isThumbUrl(articleUrl)).toBe(false);
+	});
+
+	it('detects old and new URL format', function() {
+		expect(thumbnailer.isLegacyThumbnailerUrl(legacyThumbnailerUrl)).toBe(true);
+		expect(thumbnailer.isLegacyThumbnailerUrl(thumbnailerUrl)).toBe(false);
 	});
 
 	it('returns proper nocrop thumbnail URL', function () {

--- a/resources/wikia/modules/thumbnailer.js
+++ b/resources/wikia/modules/thumbnailer.js
@@ -93,7 +93,7 @@
 		 * @returns {boolean}
 		 */
 		function isThumbnailerUrl(url) {
-			return url && /\/\/vignette\d?\.wikia/.test(url);
+			return url && /\/\/vignette(-poz|\d?)\.wikia/.test(url);
 		}
 
 		/**
@@ -229,7 +229,8 @@
 		return {
 			getThumbURL: getThumbURL,
 			getImageURL: getImageURL,
-			isThumbUrl: isThumbUrl
+			isThumbUrl: isThumbUrl,
+			isLegacyThumbnailerUrl: isLegacyThumbnailerUrl
 		};
 	}
 


### PR DESCRIPTION
- expose `isLegacyThumbnailerUrl` in `wikia.thumbnailer` module

@drsnyder / @nmonterroso / @michalroszka 
