### PR TITLE
(CE-1230,CE-1227) Rename moderator group to threadmoderator and add i18n

### DIFF
--- a/extensions/wikia/Forum/Forum.setup.php
+++ b/extensions/wikia/Forum/Forum.setup.php
@@ -125,7 +125,7 @@ $wgGroupPermissions['staff']['forumadmin'] = true;
 $wgGroupPermissions['helper']['forumadmin'] = true;
 $wgGroupPermissions['sysop']['forumadmin'] = true;
 $wgGroupPermissions['helper']['forumadmin'] = true;
-$wgGroupPermissions['moderator']['forumadmin'] = true;
+$wgGroupPermissions['threadmoderator']['forumadmin'] = true;
 
 JSMessages::registerPackage('Forum', array(
 	'back',

--- a/extensions/wikia/UserProfilePageV3/UserProfilePage.i18n.php
+++ b/extensions/wikia/UserProfilePageV3/UserProfilePage.i18n.php
@@ -58,7 +58,7 @@ $messages['en'] = array(
 	'user-identity-box-group-adminmentor' => 'Admin Mentor',
 	'user-identity-box-group-wikiastars' => 'Wikia Star',
 	'user-identity-box-group-voldev' => 'Volunteer Developer',
-	'user-identity-box-group-moderator' => 'Moderator',
+	'user-identity-box-group-threadmoderator' => 'Moderator',
 
 	'user-identity-box-zero-state-location' => 'Location',
 	'user-identity-box-zero-state-birthday' => 'Birthday',
@@ -159,7 +159,7 @@ $messages['qqq'] = array(
 	'user-identity-box-group-adminmentor' => 'Group name shown on user profile for users who are Admin Mentors.',
 	'user-identity-box-group-wikiastars' => 'Wikiaster',
 	'user-identity-box-group-voldev' => 'Group name shown on user profile for users who are Volunteer Developers',
-	'user-identity-box-group-moderator' => 'Group name shown on user profile for users who are Moderators',
+	'user-identity-box-group-threadmoderator' => 'Group name shown on user profile for users who are Moderators',
 	'user-identity-box-join-more-wikis' => 'Message in user profile for when said user has not yet edited in wikis which could be displayed as his favourites',
 	'user-identity-remove-confirmation' => 'appears when user is trying to remove avatar',
 	'user-identity-remove-fail' => 'appears in alert box when there ware some when removing the avatar',

--- a/extensions/wikia/UserProfilePageV3/strategies/UserOneTagStrategy.class.php
+++ b/extensions/wikia/UserProfilePageV3/strategies/UserOneTagStrategy.class.php
@@ -12,7 +12,7 @@ class UserOneTagStrategy extends UserTagsStrategyBase {
 		'vstf' => 5,
 		'voldev' => 4,
 		'council' => 3,
-		'moderator' => 2,
+		'threadmoderator' => 2,
 		'chatmoderator' => 1,
 	);
 

--- a/extensions/wikia/UserProfilePageV3/strategies/UserTwoTagsStrategy.class.php
+++ b/extensions/wikia/UserProfilePageV3/strategies/UserTwoTagsStrategy.class.php
@@ -14,7 +14,7 @@ class UserTwoTagsStrategy extends UserTagsStrategyBase {
 		'vstf' => 5,
 		'voldev' => 4,
 		'council' => 3,
-		'moderator' => 2,
+		'threadmoderator' => 2,
 		'chatmoderator' => 1,
 	);
 

--- a/extensions/wikia/Wall/Wall.i18n.php
+++ b/extensions/wikia/Wall/Wall.i18n.php
@@ -378,6 +378,10 @@ your email preferences here: http://community.wikia.com/Special:Preferences',
 	'wall-topic-edit' => 'Edit Topics',
 	'wall-topic-edit-save' => 'Save',
 	'wall-topic-edit-cancel' => 'Cancel',
+
+	'group-threadmoderator' => 'Moderators',
+	'group-threadmoderator-member' => 'Moderator',
+	'grouppage-threadmoderator' => 'w:c:community:Help:Moderators',
 );
 
 /** Message documentation (Message documentation)
@@ -840,6 +844,9 @@ checkbox on Special:Block',
 {{Identical|Save}}',
 	'wall-topic-edit-cancel' => 'Edit Topics - Cancel button.
 {{Identical|Cancel}}',
+	'group-threadmoderator' => '{{doc-group|threadmoderator}}',
+	'group-threadmoderator-member' => '{{doc-group|threadmoderator|member}}',
+	'grouppage-threadmoderator' => '{{doc-group|threadmoderator|page}}',
 );
 
 /** Old English (Ænglisc)

--- a/extensions/wikia/Wall/Wall.setup.php
+++ b/extensions/wikia/Wall/Wall.setup.php
@@ -224,20 +224,20 @@ $wgGroupPermissions['staff']['wallarchive'] = true;
 $wgGroupPermissions['vstf']['wallarchive'] = true;
 $wgGroupPermissions['helper']['wallarchive'] = true;
 $wgGroupPermissions['sysop']['wallarchive'] = true;
-$wgGroupPermissions['moderator']['wallarchive'] = true;
+$wgGroupPermissions['threadmoderator']['wallarchive'] = true;
 
 $wgGroupPermissions['*']['wallremove'] = false;
 $wgGroupPermissions['staff']['wallremove'] = true;
 $wgGroupPermissions['vstf']['wallremove'] = true;
 $wgGroupPermissions['helper']['wallremove'] = true;
-$wgGroupPermissions['moderator']['wallremove'] = true;
+$wgGroupPermissions['threadmoderator']['wallremove'] = true;
 
 $wgGroupPermissions['*']['walledit'] = false;
 $wgGroupPermissions['staff']['walledit'] = true;
 $wgGroupPermissions['vstf']['walledit'] = true;
 $wgGroupPermissions['helper']['walledit'] = true;
 $wgGroupPermissions['sysop']['walledit'] = true;
-$wgGroupPermissions['moderator']['walledit'] = true;
+$wgGroupPermissions['threadmoderator']['walledit'] = true;
 
 $wgGroupPermissions['*']['editwallarchivedpages'] = false;
 $wgGroupPermissions['sysop']['editwallarchivedpages'] = true;
@@ -253,7 +253,7 @@ $wgGroupPermissions['sysop']['notifyeveryone'] = true;
 $wgGroupPermissions['vstf']['notifyeveryone'] = true;
 $wgGroupPermissions['staff']['notifyeveryone'] = true;
 $wgGroupPermissions['helper']['notifyeveryone'] = true;
-$wgGroupPermissions['moderator']['notifyeveryone'] = true;
+$wgGroupPermissions['threadmoderator']['notifyeveryone'] = true;
 
 $wgGroupPermissions['*']['wallfastadmindelete'] = false;
 $wgGroupPermissions['sysop']['wallfastadmindelete'] = false;
@@ -261,10 +261,10 @@ $wgGroupPermissions['vstf']['wallfastadmindelete'] = true;
 $wgGroupPermissions['staff']['wallfastadmindelete'] = true;
 
 $wgGroupPermissions['*']['wallmessagemove'] = false;
-$wgGroupPermissions['moderator']['wallmessagemove'] = true;
+$wgGroupPermissions['threadmoderator']['wallmessagemove'] = true;
 $wgGroupPermissions['sysop']['wallmessagemove'] = true;
 $wgGroupPermissions['vstf']['wallmessagemove'] = true;
 $wgGroupPermissions['helper']['wallmessagemove'] = true;
 $wgGroupPermissions['staff']['wallmessagemove'] = true;
 
-$wgAddGroups['bureaucrat']['moderator'] = true;
+$wgAddGroups['bureaucrat'][] = 'threadmoderator';

--- a/extensions/wikia/Wall/Wall.setup.php
+++ b/extensions/wikia/Wall/Wall.setup.php
@@ -268,3 +268,4 @@ $wgGroupPermissions['helper']['wallmessagemove'] = true;
 $wgGroupPermissions['staff']['wallmessagemove'] = true;
 
 $wgAddGroups['bureaucrat'][] = 'threadmoderator';
+$wgRemoveGroups['bureaucrat'][] = 'threadmoderator';


### PR DESCRIPTION
Renaming moderator group to threadmoderator which is more specific and
avoids clashes with Chat moderators. Also, fix adding the group for
bureaucrats, and let bureaucrats remove the Moderator group too.

Also adds i18n messages for new Moderator group.

/cc @Wikia/community-engineering 
