### PR TITLE
MAIN-3581 | making $.loadFacebookAPI backward compatible with $.getResources

### DIFF
--- a/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadLibrary.js
+++ b/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadLibrary.js
@@ -122,9 +122,13 @@
 	 * @returns {jQuery} Returns a jQuery promise
 	 * @see https://developers.facebook.com/docs/javascript/quickstart/v2.2
 	 */
-	$.loadFacebookAPI = function () {
+	$.loadFacebookAPI = function (callback) {
 		// create our own deferred object to resolve after FB.init finishes
 		var $deferred = $.Deferred();
+
+		if (typeof(callback) === 'function') {
+			$deferred.done(callback);
+		}
 
 		// This is invoked by Facebook once the SDK is loaded.
 		window.fbAsyncInit = function () {

--- a/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadLibrary.js
+++ b/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadLibrary.js
@@ -126,7 +126,7 @@
 		// create our own deferred object to resolve after FB.init finishes
 		var $deferred = $.Deferred();
 
-		if (typeof(callback) === 'function') {
+		if (typeof callback === 'function') {
 			$deferred.done(callback);
 		}
 


### PR DESCRIPTION
Because $.getResources calls $.loadFacebookAPI using old way - using calback parameter instead using Deferred capabilities, added handling callback parameter to $.loadFacebookAPI
