### PR TITLE
Quick fix for not showing carousel on load

### DIFF
--- a/extensions/wikia/VideoPageTool/scripts/homepage/views/featured.js
+++ b/extensions/wikia/VideoPageTool/scripts/homepage/views/featured.js
@@ -55,6 +55,7 @@ define('videohomepage.views.featured', [
 
 			this.timeout = 0;
 			this.initSlider();
+			this.slider.redrawSlider();
 
 			$(window).on('resize', _.bind(this.collection.resetEmbedData, this.collection))
 				.on('lightboxOpened', this.reloadVideo);


### PR DESCRIPTION
This fixes carousel for featured video not being shown on load
