### PR TITLE
MAIN-3568 use more specific selector for facebook login button 	

### DIFF
--- a/extensions/wikia/GlobalNavigation/styles/GlobalNavigation.scss
+++ b/extensions/wikia/GlobalNavigation/styles/GlobalNavigation.scss
@@ -114,6 +114,6 @@
 	}
 }
 
-.hidden {
+.sso-login.hidden {
 	display: none;
 }

--- a/extensions/wikia/VideoPageTool/scripts/homepage/views/featured.js
+++ b/extensions/wikia/VideoPageTool/scripts/homepage/views/featured.js
@@ -55,7 +55,6 @@ define('videohomepage.views.featured', [
 
 			this.timeout = 0;
 			this.initSlider();
-			this.slider.redrawSlider();
 
 			$(window).on('resize', _.bind(this.collection.resetEmbedData, this.collection))
 				.on('lightboxOpened', this.reloadVideo);


### PR DESCRIPTION
This is kind of a tricky bug. I don't 100% understand what's going on, but I have a general idea.

I was able to use git bisect to track the issue down this [this commit](https://github.com/Wikia/app/commit/bff73cc519ab9190ad49ebd9c35932d5dc623202), specifically [this line](https://github.com/Wikia/app/commit/bff73cc519ab9190ad49ebd9c35932d5dc623202#diff-662336823bd17df55ca0f34a18d1aa41R118).

The issue seems to have to do with the .hidden class being styled there with `display: none;`, but [here](https://github.com/Wikia/app/blob/dev/extensions/wikia/VideoPageTool/css/homepage/featured.scss#L201-L203) with `visibility: hidden;`. When the featured js removes the hidden class [here](https://github.com/Wikia/app/blob/dev/extensions/wikia/VideoPageTool/scripts/homepage/views/featured.js#L125), the browser seems to be removing one of the stylings, but keeping the other.

Anyways, there's 2 ways which reliably fix this. Either have both of those selectors use the same styling (eg, `display: none;`), or just use a more specific selector inside of GlobalNavigation.scss. I opted for the later since it seems like that selector should be more specific anyways.
