### PR TITLE
Switch dumps compressions to 7z

### DIFF
--- a/extensions/wikia/WikiFactory/Close/SpecialCloseWiki_body.php
+++ b/extensions/wikia/WikiFactory/Close/SpecialCloseWiki_body.php
@@ -398,8 +398,8 @@ class CloseWikiPage extends SpecialPage {
 
 		if ( $this->closedWiki->city_lastdump_timestamp >= DumpsOnDemand::S3_MIGRATION ) {
 			$aFiles = array(
-				'pages_current'	=> '_pages_current.xml.gz',
-				'pages_full'	=> '_pages_full.xml.gz',
+				'pages_current'	=> '_pages_current.xml.7z',
+				'pages_full'	=> '_pages_full.xml.7z',
 			);
 
 			foreach ( $aFiles as $sKey => $sValue ) {

--- a/extensions/wikia/WikiFactory/Dumps/DumpsOnDemand.php
+++ b/extensions/wikia/WikiFactory/Dumps/DumpsOnDemand.php
@@ -56,12 +56,12 @@ class DumpsOnDemand {
 		}
 
 		$tmpl->set( "curr", array(
-			"url" => 'http://s3.amazonaws.com/wikia_xml_dumps/' . self::getPath( "{$wgDBname}_pages_current.xml.gz" ),
+			"url" => 'http://s3.amazonaws.com/wikia_xml_dumps/' . self::getPath( "{$wgDBname}_pages_current.xml.7z" ),
 			"timestamp" => $sTimestamp
 		));
 
 		$tmpl->set( "full", array(
-			"url" => 'http://s3.amazonaws.com/wikia_xml_dumps/' . self::getPath( "{$wgDBname}_pages_full.xml.gz" ),
+			"url" => 'http://s3.amazonaws.com/wikia_xml_dumps/' . self::getPath( "{$wgDBname}_pages_full.xml.7z" ),
 			"timestamp" => $sTimestamp
 		));
 
@@ -162,7 +162,7 @@ class DumpsOnDemand {
 	static public function getPath( $sName ) {
 		/*
 		 * Get the actual name:
-		 *    * 'muppet' for 'muppet.xml.gz'
+		 *    * 'muppet' for 'muppet.xml.7z'
 		 *    * 'muppet' for 'muppet'
 		 *    * 'htaccess' for '.htaccess'
 		 * The name will be in $aMatches[1].

--- a/extensions/wikia/WikiFactory/Dumps/runBackups.php
+++ b/extensions/wikia/WikiFactory/Dumps/runBackups.php
@@ -124,7 +124,7 @@ function runBackups( $from, $to, $full, $options ) {
 		$basedir = getDirectory( $row->city_dbname, $hide, $use_temp );
 
 		if( $full || $both ) {
-			$path = sprintf("%s/%s_pages_full.xml.gz", $basedir, $row->city_dbname );
+			$path = sprintf("%s/%s_pages_full.xml.7z", $basedir, $row->city_dbname );
 			$time = wfTime();
 			Wikia::log( __METHOD__, "info", "{$row->city_id} {$row->city_dbname} {$path}", true, true );
 			$cmd = array(
@@ -137,7 +137,7 @@ function runBackups( $from, $to, $full, $options ) {
 				"--xml",
 				"--quiet",
 				"--server=$server",
-				"--output=gzip:{$path}"
+				"--output=7zip:{$path}"
 			);
 			wfShellExec( implode( " ", $cmd ), $status );
 			$time = Wikia::timeDuration( wfTime() - $time );
@@ -148,7 +148,7 @@ function runBackups( $from, $to, $full, $options ) {
 
 		}
 		if( !$full || $both ) {
-			$path = sprintf("%s/%s_pages_current.xml.gz", $basedir, $row->city_dbname );
+			$path = sprintf("%s/%s_pages_current.xml.7z", $basedir, $row->city_dbname );
 			$time = wfTime();
 			Wikia::log( __METHOD__, "info", "{$row->city_id} {$row->city_dbname} {$path}", true, true);
 			$cmd = array(
@@ -161,7 +161,7 @@ function runBackups( $from, $to, $full, $options ) {
 				"--xml",
 				"--quiet",
 				"--server=$server",
-				"--output=gzip:{$path}"
+				"--output=7zip:{$path}"
 			);
 			wfShellExec( implode( " ", $cmd ), $status );
 			$time = Wikia::timeDuration( wfTime() - $time );

--- a/includes/Export.php
+++ b/includes/Export.php
@@ -915,7 +915,9 @@ class Dump7ZipOutput extends DumpPipeOutput {
 	}
 
 	function setup7zCommand( $file ) {
-		$command = "7za a -bd -si " . wfEscapeShellArg( $file );
+		// Wikia change - begin - @upstream: I07ab5f93ecd6d706460691db5181de89ef31cbea
+		$command = "7za a -bd -si -mx=4 " . wfEscapeShellArg( $file );
+		// Wikia change - end
 		// Suppress annoying useless crap from p7zip
 		// Unfortunately this could suppress real error messages too
 		$command .= ' >' . wfGetNull() . ' 2>&1';


### PR DESCRIPTION
Currently, several dump gzip files are truncated to 419430400 bytes and are invalid:
d/dr/dragonball_pages_full.xml.gz
f/fa/fairytail_pages_full.xml.gz
h/ha/harrypotter_pages_full.xml.gz
h/hu/hurricanes_pages_full.xml.gz
n/na/naruto_pages_full.xml.gz
o/on/onepiece_pages_full.xml.gz
s/sm/smallville_pages_full.xml.gz
s/so/sonic_pages_full.xml.gz
s/st/starwars_pages_full.xml.gz

This should be fixed, but perhaps it's easier to compress the files below that limit.
Alternatives tested for compression of chillsonicfanon_pages_full.xml, 1.2 G:

```
gzip -9 (current): 326 MB output, 1m28.592s user CPU
7z -mx=4: 8.4 MB, 0m37.062s
7z -mx=5 (default): 5 MB, 6m4.659s
bzip2 (default): 70 MB, 4m51.169s
bzip2 -1: 272 MB, 2m52.304s
```

We do not have an environment variable to use for 7z configuration:
https://sourceforge.net/p/sevenzip/discussion/45798/thread/70f81b1a/
We instead hack the 7z commandline in MediaWiki core and use that.
