### PR TITLE
Fix missing slashes in i18n paths

### DIFF
--- a/extensions/wikia/ArticlesAsResources/ArticlesAsResources.setup.php
+++ b/extensions/wikia/ArticlesAsResources/ArticlesAsResources.setup.php
@@ -53,5 +53,5 @@ $wgAutoloadClasses['ArticlesAsResources'] =  $dir . '/ArticlesAsResources.class.
 $wgHooks['ResourceLoaderBeforeRespond'][] = 'ArticlesAsResources::onResourceLoaderBeforeRespond';
 
 //i18n
-$wgExtensionMessagesFiles['ArticlesAsResources'] = $dir . 'ArticlesAsResources.i18n.php';
+$wgExtensionMessagesFiles['ArticlesAsResources'] = $dir . '/ArticlesAsResources.i18n.php';
 

--- a/extensions/wikia/WallNotifications/WallNotifications.setup.php
+++ b/extensions/wikia/WallNotifications/WallNotifications.setup.php
@@ -7,7 +7,7 @@ $wgExtensionCredits[ 'other' ][ ] = array(
 );
 
 //i18n
-$wgExtensionMessagesFiles['WallNotifications'] = __DIR__ . 'i18n/WallNotifications.i18n.php';
+$wgExtensionMessagesFiles['WallNotifications'] = __DIR__ . '/i18n/WallNotifications.i18n.php';
 
 $wgAutoloadClasses['WallNotifications'] =  __DIR__ . '/WallNotifications.class.php';
 


### PR DESCRIPTION
```
PHP Warning: include(/extensions/wikia/WallNotificationsi18n/WallNotifications.i18n.php): failed to open stream: No such file or directory in /includes/LocalisationCache.php on line 461
PHP Warning: include(/extensions/wikia/ArticlesAsResourcesArticlesAsResources.i18n.php): failed to open stream: No such file or directory in /includes/LocalisationCache.php on line 461
```

@Wikia/platform-team 
