### PR TITLE
prioritize HAWelcomeTask

### DIFF
--- a/extensions/wikia/HAWelcome/HAWelcomeHooks.php
+++ b/extensions/wikia/HAWelcome/HAWelcomeHooks.php
@@ -18,6 +18,7 @@ class HAWelcomeHooks {
 		$task->call( 'sendWelcomeMessage', $aParams );
 		$task->wikiId( $wgCityId );
 		$task->title( $oTitle ); // use $this->title in the job
+		$task->prioritize();
 		$task->queue();
 	}
 


### PR DESCRIPTION
@Wikia/platform-team 
Prioritizing, since there are community complaints that these are very delayed when the queue is really busy. These only happen when a user posts for the first time, so shouldn't overwhelm the priority queue.
