### PR TITLE
SitemapPage::getNamespacesList - always return the list of namespaces

### DIFF
--- a/extensions/wikia/Sitemap/SpecialSitemap_body.php
+++ b/extensions/wikia/Sitemap/SpecialSitemap_body.php
@@ -117,6 +117,7 @@ class SitemapPage extends UnlistedSpecialPage {
 	 * get all namespaces, take them from article so will only have
 	 * pages for existed namespaces
 	 *
+	 * @return array
 	 * @access public
 	 */
 	public function getNamespacesList() {
@@ -124,7 +125,7 @@ class SitemapPage extends UnlistedSpecialPage {
 
 		if ( is_array( $wgSitemapNamespaces ) ) {
 			$this->mNamespaces = $wgSitemapNamespaces;
-			return;
+			return $this->mNamespaces;
 		}
 
 		$excludeList = array(NS_USER, NS_PROJECT, NS_MEDIAWIKI, NS_TEMPLATE, NS_HELP, 110, 1100, 1200, 1202);


### PR DESCRIPTION
Fixes PLATFORM-762

Avoid `PHP Warning: Invalid argument supplied for foreach() in /extensions/wikia/Sitemap/maintenance.php on line 29`

@michalroszka 
