### PR TITLE
PLATFORM-409: fix issues with merging files without the semicolon in ArticlesAsResources

### DIFF
--- a/includes/resourceloader/ResourceLoaderWikiModule.php
+++ b/includes/resourceloader/ResourceLoaderWikiModule.php
@@ -122,7 +122,7 @@ abstract class ResourceLoaderWikiModule extends ResourceLoaderModule {
 				if ( strpos( $titleText, '*/' ) === false ) {
 					$scripts .=  "/* " . $this->getResourceName($title,$titleText,$options) . " */\n";
 				}
-				$scripts .= $script . "\n";
+				$scripts .= $script . "\n;\n";
 			}
 		}
 		return $scripts;


### PR DESCRIPTION
This fix addresses an issue when javascript files are merged using ArticlesAsResources and they do not have a semicolon at the end of the file.

https://wikia-inc.atlassian.net/browse/PLATFORM-409

/cc @macbre 
