### PR TITLE
PLATFORM-412: add error message when redirect URL is invalid in Special:CloseWiki

### DIFF
--- a/extensions/wikia/WikiFactory/Close/SpecialCloseWiki_body.php
+++ b/extensions/wikia/WikiFactory/Close/SpecialCloseWiki_body.php
@@ -207,7 +207,7 @@ class CloseWikiPage extends SpecialPage {
 			if( !$city_id ) {
 				Wikia::log( __METHOD__, "domain doesn't exist" );
 				$valid = false;
-				$this->mErrors[] = "Redirect URL does not point to any existing wiki: \"{$this->mRedirect}\"";
+				$this->mErrors[] = wfMsg('closed-wiki-invalid-redirect-url',$this->mRedirect);
 			} else {
 				$newWiki = $city_id;
 			}

--- a/extensions/wikia/WikiFactory/Close/SpecialCloseWiki_body.php
+++ b/extensions/wikia/WikiFactory/Close/SpecialCloseWiki_body.php
@@ -207,7 +207,7 @@ class CloseWikiPage extends SpecialPage {
 			if( !$city_id ) {
 				Wikia::log( __METHOD__, "domain doesn't exist" );
 				$valid = false;
-				$this->mErrors[] = $this->mRedirect;
+				$this->mErrors[] = "Redirect URL does not point to any existing wiki: \"{$this->mRedirect}\"";
 			} else {
 				$newWiki = $city_id;
 			}

--- a/extensions/wikia/WikiFactory/Close/templates/confirm.tmpl.php
+++ b/extensions/wikia/WikiFactory/Close/templates/confirm.tmpl.php
@@ -102,6 +102,13 @@ function close_allowToSave() {
 				<textarea name="close_reason"><?=$reason?></textarea>
 			</li>
 		</ul>
+		<? if ($errors) { ?>
+		<ul style="list-style:none;padding:1px 10px;color:red">
+			<? foreach ($errors as $error) { ?>
+			<li>Error: <?= $error ?></li>
+			<? } ?>
+		</ul>
+		<? } ?>
 		<ul style="list-style:none;padding:1px 10px;">
 			<li style="text-align:left;padding-left:200px;">
 				<input type="submit" name="close_saveBtn" value="<?=wfMsg('closed-confirm-btn')?>" onclick="return close_allowToSave();" /> 

--- a/extensions/wikia/WikiFactory/Close/templates/confirm.tmpl.php
+++ b/extensions/wikia/WikiFactory/Close/templates/confirm.tmpl.php
@@ -105,7 +105,7 @@ function close_allowToSave() {
 		<? if ($errors) { ?>
 		<ul style="list-style:none;padding:1px 10px;color:red">
 			<? foreach ($errors as $error) { ?>
-			<li>Error: <?= $error ?></li>
+			<li><?= $error ?></li>
 			<? } ?>
 		</ul>
 		<? } ?>

--- a/extensions/wikia/WikiFactory/SpecialWikiFactory.i18n.php
+++ b/extensions/wikia/WikiFactory/SpecialWikiFactory.i18n.php
@@ -127,6 +127,7 @@ $messages['en'] = array(
 	"closed-wiki-dump-noexists" => "This wiki has been closed. Content dump will be available within 24 hours. Please check back.",
 	"closed-wiki-create-wiki" => "Create a new wiki",
 	"closed-wiki-policy" => "View Wikia's Close Policy",
+	"closed-wiki-invalid-redirect-url" => "Error: Redirect URL does not point to any existing wiki: \"\$1\"",
 	"closed-create-dump" => "Create a database dump",
 	"closed-create-image-archive" => "Create an image archive",
 	"closed-delete-database-images" => "Delete the database and images",


### PR DESCRIPTION
Add an error message in the Close WIki process when redirect URL is not a valid one (doesn't point to any existing wiki) instead of failing silently.

https://wikia-inc.atlassian.net/browse/PLATFORM-412

/cc @macbre 
