### PR TITLE
Uc 67 adding div needed for facebook sdk to page html

### DIFF
--- a/extensions/wikia/FacebookClient/FacebookClient.setup.php
+++ b/extensions/wikia/FacebookClient/FacebookClient.setup.php
@@ -42,7 +42,7 @@ $wgAutoloadClasses['FacebookClientXFBML'] = $dir . 'FacebookClientXFBML.php';
  */
 $wgAutoloadClasses['FacebookClientHooks'] =  $dir . 'FacebookClientHooks.class.php';
 $wgHooks['MakeGlobalVariablesScript'][] = 'FacebookClientHooks::MakeGlobalVariablesScript';
-$wgHooks['SkinAfterBottomScripts'][] = 'FacebookClientHooks::SkinAfterBottomScripts';
+$wgHooks['GetHTMLAfterBody'][] = 'FacebookClientHooks::onGetHTMLAfterBody';
 $wgHooks['GetPreferences'][] = 'FacebookClientHooks::GetPreferences';
 $wgHooks['OasisSkinAssetGroups'][] = 'FacebookClientHooks::onSkinAssetGroups';
 $wgHooks['MonobookSkinAssetGroups'][] = 'FacebookClientHooks::onSkinAssetGroups';

--- a/extensions/wikia/FacebookClient/FacebookClientHooks.class.php
+++ b/extensions/wikia/FacebookClient/FacebookClientHooks.class.php
@@ -59,7 +59,7 @@ class FacebookClientHooks {
 	 * Create disconnect button and other things in pref
 	 *
 	 * @param User $user
-	 * @param $preferences
+	 * @param array $preferences
 	 * @return bool
 	 */
 	static function GetPreferences( $user, &$preferences ) {

--- a/extensions/wikia/FacebookClient/FacebookClientHooks.class.php
+++ b/extensions/wikia/FacebookClient/FacebookClientHooks.class.php
@@ -43,30 +43,23 @@ class FacebookClientHooks {
 	}
 
 	/**
-	 * Add Facebook SDK loading code at the bottom of the page
-	 *
-	 * Fixes IE issue (RT #140425)
-	 *
-	 * @param $skin Skin
-	 * @param $scripts
-	 *
+	 * Add Facebook div at the bottom of the page so we don't get JS console messages from FB about it.
+	 * @param Skin $skin
+	 * @param string $html
 	 * @return bool
 	 */
-	static function SkinAfterBottomScripts( $skin, &$scripts ) {
-		global $fbScript, $wgNoExternals;
-
-		if ( !empty( $fbScript ) && empty( $wgNoExternals ) ) {
-			$scripts .= '<div id="fb-root"></div>';
-		}
+	public static function onGetHTMLAfterBody($skin, &$html) {
+		$html .= '<div id="fb-root"></div>';
 
 		return true;
 	}
 
+
 	/**
 	 * Create disconnect button and other things in pref
 	 *
-	 * @param $user User
-	 *
+	 * @param User $user
+	 * @param $preferences
 	 * @return bool
 	 */
 	static function GetPreferences( $user, &$preferences ) {

--- a/extensions/wikia/UserLogin/UserLoginSpecialController.class.php
+++ b/extensions/wikia/UserLogin/UserLoginSpecialController.class.php
@@ -36,24 +36,22 @@ class UserLoginSpecialController extends WikiaSpecialPageController {
 	}
 
 	private function initializeTemplate() {
-		//Oasis/Monobook, will be filtered in AssetsManager :)
-		$this->response->addAsset( 'extensions/wikia/UserLogin/css/UserLogin.scss' );
-
-		if ( !empty( $this->wg->EnableFacebookClientExt ) ) {
+		// Load Facebook JS if extension is enabled and skin supports it
+		if ( !empty( $this->wg->EnableFacebookClientExt ) && !$this->isMonobookOrUncyclo ) {
 			$this->response->addAsset( 'extensions/wikia/UserLogin/js/UserLoginFacebookPageInit.js' );
-			$this->response->addAsset( 'extensions/wikia/UserLogin/js/FacebookLogin.js' );
 		}
 
+		$this->response->addAsset( 'extensions/wikia/UserLogin/css/UserLogin.scss' );
 		$this->response->addAsset( 'extensions/wikia/UserLogin/js/UserLoginSpecial.js' );
 
-		//Wikiamobile, will be filtered in AssetsManager by config :)
+		// Wikiamobile, will be filtered in AssetsManager by config :)
 		$this->response->addAsset(
 				( $this->wg->request->getInt( 'recover' ) === 1 || empty( $this->wg->EnableFacebookClientExt ) ) ?
 					'userlogin_js_wikiamobile' :
 					'userlogin_js_wikiamobile_fbconnect'
 		);
 
-		//Wikiamobile, will be filtered in AssetsManager by config :)
+		// Wikiamobile, will be filtered in AssetsManager by config :)
 		$this->response->addAsset( 'userlogin_scss_wikiamobile' );
 
 		// hide things in the skin

--- a/extensions/wikia/UserLogin/UserLoginSpecialController.class.php
+++ b/extensions/wikia/UserLogin/UserLoginSpecialController.class.php
@@ -31,8 +31,10 @@ class UserLoginSpecialController extends WikiaSpecialPageController {
 	public function init() {
 		$loginTitle = SpecialPage::getTitleFor( 'UserLogin' );
 		$this->formPostAction = $loginTitle->getLocalUrl();
-		$this->isMonobookOrUncyclo = ( $this->wg->User->getSkin() instanceof SkinMonoBook ||
-			$this->wg->User->getSkin() instanceof SkinUncyclopedia );
+
+		$skin = $this->wg->User->getSkin();
+		$this->isMonobookOrUncyclo = ( $skin instanceof SkinMonoBook || $skin instanceof SkinUncyclopedia );
+
 		$this->userLoginHelper = (new UserLoginHelper);
 	}
 

--- a/extensions/wikia/UserLogin/UserLoginSpecialController.class.php
+++ b/extensions/wikia/UserLogin/UserLoginSpecialController.class.php
@@ -31,7 +31,8 @@ class UserLoginSpecialController extends WikiaSpecialPageController {
 	public function init() {
 		$loginTitle = SpecialPage::getTitleFor( 'UserLogin' );
 		$this->formPostAction = $loginTitle->getLocalUrl();
-		$this->isMonobookOrUncyclo = ( $this->wg->User->getSkin() instanceof SkinMonoBook || $this->wg->User->getSkin() instanceof SkinUncyclopedia );
+		$this->isMonobookOrUncyclo = ( $this->wg->User->getSkin() instanceof SkinMonoBook ||
+			$this->wg->User->getSkin() instanceof SkinUncyclopedia );
 		$this->userLoginHelper = (new UserLoginHelper);
 	}
 

--- a/extensions/wikia/UserLogin/UserSignupSpecialController.class.php
+++ b/extensions/wikia/UserLogin/UserSignupSpecialController.class.php
@@ -18,7 +18,8 @@ class UserSignupSpecialController extends WikiaSpecialPageController {
 	}
 
 	public function init() {
-		$this->isMonobookOrUncyclo = ( $this->wg->User->getSkin() instanceof SkinMonoBook || $this->wg->User->getSkin() instanceof SkinUncyclopedia );
+		$this->isMonobookOrUncyclo = ( $this->wg->User->getSkin() instanceof SkinMonoBook ||
+			$this->wg->User->getSkin() instanceof SkinUncyclopedia );
 		$this->isEn = ( $this->wg->Lang->getCode() == 'en' ) ? true : false;
 		$this->userLoginHelper = ( new UserLoginHelper );
 	}
@@ -73,7 +74,11 @@ class UserSignupSpecialController extends WikiaSpecialPageController {
 		}
 
 		// We're not supporting connecting with facebook from this page while logged in
-		if ( !empty( $this->wg->EnableFacebookClientExt ) && !$this->wg->User->isLoggedIn() ) {
+		if (
+			!empty( $this->wg->EnableFacebookClientExt ) &&
+			!$this->wg->User->isLoggedIn() &&
+			!$this->isMonobookOrUncyclo
+		) {
 			$this->response->addAsset( 'extensions/wikia/UserLogin/js/UserLoginFacebookPageInit.js' );
 		}
 

--- a/extensions/wikia/UserLogin/UserSignupSpecialController.class.php
+++ b/extensions/wikia/UserLogin/UserSignupSpecialController.class.php
@@ -18,9 +18,9 @@ class UserSignupSpecialController extends WikiaSpecialPageController {
 	}
 
 	public function init() {
-		$this->isMonobookOrUncyclo = ( $this->wg->User->getSkin() instanceof SkinMonoBook ||
-			$this->wg->User->getSkin() instanceof SkinUncyclopedia );
-		$this->isEn = ( $this->wg->Lang->getCode() == 'en' ) ? true : false;
+		$skin = $this->wg->User->getSkin();
+		$this->isMonobookOrUncyclo = ( $skin instanceof SkinMonoBook || $skin instanceof SkinUncyclopedia );
+		$this->isEn = ( $this->wg->Lang->getCode() == 'en' );
 		$this->userLoginHelper = ( new UserLoginHelper );
 	}
 


### PR DESCRIPTION
Facebook likes to have this `div#fb-root` in the HTML, so if we don't add it ourselves, they do, and while they're at it, they add a console message to every page load. This PR adds that div correctly so that console message will go away. 

Also, while checking this code in monobook, I noticed that we were loading some facebook code on the user login and signup pages, even though we don't support facebook on those pages in that skin. I added a check since I was in there anyway.  

Note: `GetHTMLAfterBody` doesn't run in Venus, so we'll have to add this to the venus skin separately when the time comes. 
