### PR TITLE
UC-259 Fixing JS error caused by refactor

### DIFF
--- a/extensions/wikia/UserLogin/js/UserSignupAjaxValidation.js
+++ b/extensions/wikia/UserLogin/js/UserSignupAjaxValidation.js
@@ -57,7 +57,7 @@
 
 	UserSignupAjaxValidation.prototype.validateBirthdate = function (e) {
 		var el = $(e.target),
-			proxyObj = {'paramName':el.attr('name'), 'form': this},
+			paramName = el.attr('name'),
 			params = this.getDefaultParamsForAjax();
 
 		if (UserSignup.deferred && typeof UserSignup.deferred.reject === 'function') {
@@ -74,7 +74,7 @@
 		UserSignup.deferred = $.post(
 			wgScriptPath + '/wikia.php',
 			params,
-			$.proxy(this.validationHandler, proxyObj)
+			this.validationHandler.bind(this, paramName)
 		);
 	};
 


### PR DESCRIPTION
The context of the validationHandler method was being spoofed, so I had refactored it to be a bit more intuitive. However, I failed to update both places where the method was called. This PR should fix that.
