### PR TITLE
VID-2153 NFC Normalize Videos' titles

### DIFF
--- a/extensions/wikia/VideoHandlers/tests/VideoFileUploaderTest.php
+++ b/extensions/wikia/VideoHandlers/tests/VideoFileUploaderTest.php
@@ -17,7 +17,7 @@ class VideoFileUploaderTest extends WikiaBaseTest {
 			$this->assertNotEquals( $expectedTitle, $title );
 		}
 
-		$videoFileUploader = $this->getMock( 'VideoFileUploader', array( 'getSanitizedTitleText' ) );
+		$videoFileUploader = $this->getMock( 'VideoFileUploader', [ 'getSanitizedTitleText' ] );
 		$videoFileUploader->expects( $this->once() )
 			->method( 'getSanitizedTitleText' )
 			->will( $this->returnValue( $title ) );

--- a/extensions/wikia/VideoHandlers/tests/VideoFileUploaderTest.php
+++ b/extensions/wikia/VideoHandlers/tests/VideoFileUploaderTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * Class VideoFileUploaderTest
+ *
+ * @group MediaFeatures
+ */
+class VideoFileUploaderTest extends WikiaBaseTest {
+
+	/**
+	 * @dataProvider destinationTitleDataProvider
+	 */
+	public function testGetNormalizedDestinationTitle( $areIdentical, $title, $expectedTitle ) {
+		if ( $areIdentical ) {
+			$this->assertEquals( $expectedTitle, $title );
+		} else {
+			$this->assertNotEquals( $expectedTitle, $title );
+		}
+
+		$videoFileUploader = $this->getMock( 'VideoFileUploader', array( 'getSanitizedTitleText' ) );
+		$videoFileUploader->expects( $this->once() )
+			->method( 'getSanitizedTitleText' )
+			->will( $this->returnValue( $title ) );
+
+		$actualTitle = $videoFileUploader->getNormalizedDestinationTitle();
+
+		$this->assertEquals( $expectedTitle, $actualTitle );
+	}
+
+	public function destinationTitleDataProvider() {
+		return [
+			// identical? - original title - normalized (composed) title
+			[ true,         "", "" ],
+			[ true,         "(S♥C)_-fall_for_you-_AU_(READ_DESCRIPTION!)", "(S♥C)_-fall_for_you-_AU_(READ_DESCRIPTION!)" ],
+			[ true,         "plain english", "plain english" ],
+			[ true,         "活動期間，大天使、新大天使與限定神（迦梨為通常機率）", "活動期間，大天使、新大天使與限定神（迦梨為通常機率）" ],
+			[ true,         "Jak przełączyć się na skórkę Wygodną?", "Jak przełączyć się na skórkę Wygodną?" ],
+			[ true,         " blah & @#$(*){}[]IY0987654321/?<>,.^", " blah & @#$(*){}[]IY0987654321/?<>,.^" ],
+			[ true,         "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ", "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ" ],
+			[ false,        "パズドラ", "パズドラ" ],
+			[ false,        "パズドラ_ビギナーズガイド", "パズドラ_ビギナーズガイド"]
+		];
+	}
+}

--- a/maintenance/wikia/VideoHandlers/nfcNormalizeVideos.php
+++ b/maintenance/wikia/VideoHandlers/nfcNormalizeVideos.php
@@ -1,0 +1,130 @@
+<?php
+ini_set('display_errors', 'stderr');
+putenv("SERVER_ID=177");
+
+/**
+ * Class NfcNormalizeVideos
+ * Usage: Use runOnCluster with --method run
+ *
+ * Normalizes video records into NFC form
+ * @see VID-2153 & http://unicode.org/reports/tr15/
+ */
+class NfcNormalizeVideos {
+	protected static $metadataFieldsContainingName = [
+		'title',
+		'name',
+		'keywords',
+	];
+
+	/**
+	 * Used by runOnCluster to Normalize video titles and metadata
+	 *
+	 * @param DatabaseMysql $db
+	 * @param bool $test
+	 * @param bool $verbose
+	 * @param array $params
+	 */
+	public static function run( DatabaseMysql $db, $test, $verbose = false, $params ) {
+
+		if ( !$db->tableExists( 'image' ) || !$db->tableExists( 'video_info' ) ) {
+			echo "ERROR: $params[dbname] (ID:$params[cityId]): image/video_info table not exist.\n";
+			return;
+		}
+
+		foreach ( self::getVideoRows( $db ) as $video ) {
+			$originalName = $video->img_name;
+			if ( \UtfNormal::quickIsNFC( $originalName ) ) {
+				if ( $verbose ) {
+					echo "Already in NFC form; skipping: $originalName\n";
+				}
+				continue;
+			}
+
+			self::updateVideo( $video, $db, $test, $verbose );
+		}
+	}
+
+	/**
+	 * Return an array of videos
+	 *
+	 * @param DatabaseMysql $db
+	 * @return array
+	 */
+	protected static function getVideoRows( DatabaseMysql $db ) {
+		return ( new WikiaSQL() )
+			->SELECT( 'img_name', 'img_metadata', 'img_sha1' )
+			->FROM( 'image' )
+			->WHERE( 'img_media_type' )->EQUAL_TO( 'VIDEO' )
+			->AND_( FluentSql\StaticSQL::RAW( 'img_name <> CONVERT(img_name USING ASCII)' ) )
+			->runLoop( $db, function ( &$videos, $row ) {
+				$videos[] = $row;
+			} );
+	}
+
+	/**
+	 * Update title and other meta data for videos with titles not in normalized NFC form
+	 *
+	 * @param stdClass $video
+	 * @param DatabaseMysql $db
+	 * @param bool $test
+	 * @param bool $verbose
+	 */
+	protected static function updateVideo( $video, DatabaseMysql $db, $test, $verbose ) {
+		$originalName = $video->img_name;
+
+		// image.img_name & video_info.video_title
+		$name = \UtfNormal::toNFC( $originalName );
+		if ( $name == $originalName ) {
+			echo "No change detected. Skipped conversion for: $originalName\n";
+			return;
+		}
+
+		$metadata = self::getNormalizedMetadata( $video );
+
+		$affectedImage = 0;
+		$affectedVideoInfo = 0;
+
+		if ( !$test ) {
+			$sql = new WikiaSQL();
+			$sql->UPDATE( 'image' )
+				->SET( 'img_name', $name )
+				->SET( 'img_metadata', $metadata )
+				->WHERE( 'video_title' )->EQUAL_TO( $originalName )
+				->run( $db );
+			$affectedImage = $db->affectedRows();
+
+			$sql->UPDATE( 'video_info' )
+				->SET( 'video_title', $name )
+				->WHERE( 'video_title' )->EQUAL_TO( $originalName )
+				->run( $db );
+			$affectedVideoInfo = $db->affectedRows();
+		}
+
+		echo "Updated $affectedImage image "
+			. "and $affectedVideoInfo video_info "
+			. "for: $originalName img_sha1: {$video->img_sha1}\n";
+
+		if ( $verbose ) {
+			echo "\tNew title: $name"
+				. "\n\tNew metadata: $metadata\n";
+		}
+	}
+
+	/**
+	 * Get Normalized metadata in PHP-serialized form
+	 *
+	 * @param stdClass $video
+	 * @return string
+	 */
+	protected static function getNormalizedMetadata( $video ) {
+		// image.img_metadata
+		$metadata = unserialize( $video->img_metadata );
+		foreach ( self::$metadataFieldsContainingName as $field ) {
+			if ( isset( $metadata[ $field ] ) ) {
+				$metadata[ $field ] = \UtfNormal::toNFC( $metadata[ $field ] );
+			}
+		}
+
+		return serialize( $metadata );
+	}
+}


### PR DESCRIPTION
We have been storing decomposed normalized form of video captions that contain non-ascii characters in many cases, most likely all ingested videos. The result is that client requesting a page by title with a different normalized form mismatches the persisted version and 404s.
To combat that, all video titles will now be NFC normalized before getting stored. Also there is a script to clean the existing data.

https://wikia-inc.atlassian.net/browse/VID-2153
