### PR TITLE
(CE-1260) Properly escape search query in the Mobile skin

### DIFF
--- a/extensions/wikia/WikiaMobile/templates/WikiaMobileNavigationService_index.php
+++ b/extensions/wikia/WikiaMobile/templates/WikiaMobileNavigationService_index.php
@@ -10,7 +10,7 @@
  */
 
 	$loggedIn = $wg->User->isLoggedIn();
-    $searchPage = $wg->Title->isSpecial( 'Search' );
+	$searchPage = $wg->Title->isSpecial( 'Search' );
 
 	if ( $loggedIn ) {
 		$userName = $wg->User->getName();
@@ -18,9 +18,9 @@
 ?>
 <section id=wkTopNav<?= $searchPage ? ' class="srhOpn"' : ''?>>
 	<div id=wkTopBar>
-		<a href=<?= Title::newMainPage()->getFullURL() ?>>
+		<a href="<?= Sanitizer::encodeAttribute( Title::newMainPage()->getFullURL() ) ?>">
 		<? if( $wordmarkType == "graphic" ) :?>
-			<img id=wkImgMrk src="<?= $wordmarkUrl ;?>">
+			<img id=wkImgMrk src="<?= Sanitizer::encodeAttribute( $wordmarkUrl ); ?>">
 		<? else :?>
 			<div id=wkWrdMrk><?= $wikiName ;?></div>
 		<? endif ;?>
@@ -31,15 +31,15 @@
 		// This gives me image 50x50 but adds html attributes width and height with values 25
 		echo '<a id=wkPrfTgl class="tgl lgdin" href=#>' . AvatarService::renderAvatar( $userName, 25 ) . '</a>';
 	} else {
-		echo '<a id=wkPrfTgl class="tgl lgdout" href="' . SpecialPage::getTitleFor( 'UserLogin' )->getLocalURL() . '#"></a>';
+		echo '<a id=wkPrfTgl class="tgl lgdout" href="' . Sanitizer::encodeAttribute( SpecialPage::getTitleFor( 'UserLogin' )->getLocalURL() ) . '#"></a>';
 	}	?>
 	</div>
 	<div id=wkSrh>
-		<form id=wkSrhFrm action="<?= SpecialPage::getSafeTitleFor( 'Search' )->getLocalURL(); ?>" method=get class='wkForm hide-clear'>
+		<form id=wkSrhFrm action="<?= Sanitizer::encodeAttribute( SpecialPage::getSafeTitleFor( 'Search' )->getLocalURL() ); ?>" method=get class='wkForm hide-clear'>
 			<input type=hidden name=fulltext value=Search>
-			<input id=wkSrhInp type=text name=search placeholder="<?= wfMessage( 'wikiamobile-search-this-wiki')->text(); ?>" value="<?= $wg->request->getVal( 'search', '' ); ?>" required=required autocomplete=off autofocus>
+			<input id=wkSrhInp type=text name=search placeholder="<?= wfMessage( 'wikiamobile-search-this-wiki')->escaped(); ?>" value="<?= Sanitizer::encodeAttribute( $wg->request->getVal( 'search', '' ) ); ?>" required=required autocomplete=off autofocus>
 			<div id=wkClear class='clsIco'></div>
-			<input id=wkSrhSub class='wkBtn main' type=submit value='<?= wfMessage( 'wikiamobile-search' )->text(); ?>'>
+			<input id=wkSrhSub class='wkBtn main' type=submit value='<?= wfMessage( 'wikiamobile-search' )->escaped(); ?>'>
 		</form>
 		<ul id=wkSrhSug class=wkLst></ul>
 	</div>
@@ -55,8 +55,8 @@
 		</header>
 	<? if ( $loggedIn ) :?>
 		<ul class=wkLst>
-			<li><a class=chg href="<?= AvatarService::getUrl( $userName ) ;?>"><?= wfMsg( 'wikiamobile-profile' ); ?></a></li>
-			<li><a class=logout href="<?= str_replace( "$1", SpecialPage::getSafeTitleFor( 'UserLogout' )->getPrefixedText() . '?returnto=' . $wg->Title->getPrefixedURL(), $wg->ArticlePath ) ;?>"><?= wfMsg('logout'); ?></a></li>
+			<li><a class=chg href="<?= Sanitizer::encodeAttribute( AvatarService::getUrl( $userName ) ); ?>"><?= wfMessage( 'wikiamobile-profile' )->escaped(); ?></a></li>
+			<li><a class=logout href="<?= Sanitizer::encodeAttribute( str_replace( "$1", SpecialPage::getSafeTitleFor( 'UserLogout' )->getPrefixedText() . '?returnto=' . $wg->Title->getPrefixedURL(), $wg->ArticlePath ) ); ?>"><?= wfMessage( 'logout' )->escaped(); ?></a></li>
 		</ul>
 	<? endif; ?>
 	</div>


### PR DESCRIPTION
Properly escape the search query query parameter in the Mobile skin.

/cc @owend 
