### PR TITLE
CE-1259 Exclude blacklisted wikias from being displayed in WAM-related features

### DIFF
--- a/extensions/wikia/WAM/controllers/api/WAMApiController.class.php
+++ b/extensions/wikia/WAM/controllers/api/WAMApiController.class.php
@@ -172,7 +172,7 @@ class WAMApiController extends WikiaApiController {
 		$options['wikiLang'] = $this->request->getVal('wiki_lang', null);
 		$options['wikiId'] = $this->request->getInt('wiki_id', null);
 		$options['wikiWord'] = $this->request->getVal('wiki_word', null);
-		$options['excludeBlacklist'] = $this->request->getVal('exclude_blacklist', false);
+		$options['excludeBlacklist'] = $this->request->getVal('exclude_blacklist', true);
 		$options['excludeNonCommercial'] = $this->hideNonCommercialContent();
 		$options['fetchAdmins'] = $this->request->getBool('fetch_admins', false);
 		$options['avatarSize'] = $this->request->getInt('avatar_size', self::DEFAULT_AVATAR_SIZE);

--- a/includes/wikia/services/WAMService.class.php
+++ b/includes/wikia/services/WAMService.class.php
@@ -362,17 +362,17 @@ class WAMService extends Service {
 				$contentWarningWikis = $excludedWikis = [];
 
 				// Exlude wikias with ContentWarning extension enabled
-				$blacklistExt = WikiFactory::getVarByName( self::WAM_BLACKLIST_EXT_VAR_NAME, null );
-				if ( is_object( $blacklistExt ) ) {
+				$blacklistExtVarId = WikiFactory::getVarIdByName( self::WAM_BLACKLIST_EXT_VAR_NAME );
+				if ( $blacklistExtVarId ) {
 					$contentWarningWikis = array_keys(
-						WikiFactory::getListOfWikisWithVar($blacklistExt->cv_id, 'bool', '=', true )
+						WikiFactory::getListOfWikisWithVar($blacklistExtVarId, 'bool', '=', true )
 					);
 				}
 				// Exclude wikias with an exclusion flag set to true
-				$blacklistFlag = WikiFactory::getVarByName( self::WAM_EXCLUDE_FLAG_NAME, null );
-				if ( is_object( $blacklistFlag ) ) {
+				$blacklistFlagVarId = WikiFactory::getVarIdByName( self::WAM_EXCLUDE_FLAG_NAME );
+				if ( $blacklistFlagVarId ) {
 					$excludedWikis = array_keys(
-						WikiFactory::getListOfWikisWithVar( $blacklistFlag->cv_id, 'bool', '=', true )
+						WikiFactory::getListOfWikisWithVar( $blacklistFlagVarId, 'bool', '=', true )
 					);
 				}
 

--- a/includes/wikia/services/WAMService.class.php
+++ b/includes/wikia/services/WAMService.class.php
@@ -364,12 +364,16 @@ class WAMService extends Service {
 				// Exlude wikias with ContentWarning extension enabled
 				$blacklistExt = WikiFactory::getVarByName( self::WAM_BLACKLIST_EXT_VAR_NAME, null );
 				if ( is_object( $blacklistExt ) ) {
-					$contentWarningWikis = array_keys( WikiFactory::getListOfWikisWithVar($blacklistExt->cv_id, 'bool', '=', true ) );
+					$contentWarningWikis = array_keys(
+						WikiFactory::getListOfWikisWithVar($blacklistExt->cv_id, 'bool', '=', true )
+					);
 				}
 				// Exclude wikias with an exclusion flag set to true
 				$blacklistFlag = WikiFactory::getVarByName( self::WAM_EXCLUDE_FLAG_NAME, null );
 				if ( is_object( $blacklistFlag ) ) {
-					$excludedWikis = array_keys( WikiFactory::getListOfWikisWithVar( $blacklistFlag->cv_id, 'bool', '=', true ) );
+					$excludedWikis = array_keys(
+						WikiFactory::getListOfWikisWithVar( $blacklistFlag->cv_id, 'bool', '=', true )
+					);
 				}
 
 				return array_merge( $contentWarningWikis, $excludedWikis );

--- a/includes/wikia/services/WAMService.class.php
+++ b/includes/wikia/services/WAMService.class.php
@@ -365,7 +365,7 @@ class WAMService extends Service {
 				$blacklistExtVarId = WikiFactory::getVarIdByName( self::WAM_BLACKLIST_EXT_VAR_NAME );
 				if ( $blacklistExtVarId ) {
 					$contentWarningWikis = array_keys(
-						WikiFactory::getListOfWikisWithVar($blacklistExtVarId, 'bool', '=', true )
+						WikiFactory::getListOfWikisWithVar( $blacklistExtVarId, 'bool', '=', true )
 					);
 				}
 				// Exclude wikias with an exclusion flag set to true


### PR DESCRIPTION
Following a **[CE-1259](https://wikia-inc.atlassian.net/browse/CE-1259) P2** and [MAIN-3610](https://wikia-inc.atlassian.net/browse/MAIN-3601) tickets this fix allows us to exclude some wikias from being displayed in WAM-related features like WAM page and WAM widgets on Hubs pages. It also makes it a default behavior, as it should've always be one.

The new blacklist consists of the old check for a _ContentWarning_ extensions being enabled and a new _wgExcludeFromWAM_ flag that has no effect on the wikia itself and allows you to "silently" suppress it.

Pinging: @macbre, @Grunny, @lukaszkonieczny 
