### PR TITLE
ADEN-1566 wgSitewideDisableKrux InstantGlobal

### DIFF
--- a/extensions/wikia/AdEngine/AdEngine2Hooks.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2Hooks.class.php
@@ -64,6 +64,7 @@ class AdEngine2Hooks {
 		$vars[] = 'wgSitewideDisableLiftium';
 		$vars[] = 'wgSitewideDisableSevenOneMedia';
 		$vars[] = 'wgSitewideDisableRubiconRTP';
+		$vars[] = 'wgSitewideDisableKrux';
 
 		$vars[] = 'wgHighValueCountries';
 		$vars[] = 'wgAmazonMatchCountries';

--- a/extensions/wikia/AdEngine/AdEngine2Hooks.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2Hooks.class.php
@@ -59,18 +59,21 @@ class AdEngine2Hooks {
 	 */
 	public static function onInstantGlobalsGetVariables( array &$vars )
 	{
-		// DR
-		$vars[] = 'wgSitewideDisableGpt';
-		$vars[] = 'wgSitewideDisableLiftium';
-		$vars[] = 'wgSitewideDisableSevenOneMedia';
-		$vars[] = 'wgSitewideDisableRubiconRTP';
-		$vars[] = 'wgSitewideDisableKrux';
+		$vars[] = 'wgAdDriverAlwaysCallDartInCountries';
 
-		$vars[] = 'wgHighValueCountries';
 		$vars[] = 'wgAmazonMatchCountries';
 		$vars[] = 'wgAmazonMatchOldCountries';
+		$vars[] = 'wgHighValueCountries';
 
-		$vars[] = 'wgAdDriverAlwaysCallDartInCountries';
+		/**
+		 * Disaster Recovery
+		 * @link https://one.wikia-inc.com/wiki/Ads/Disaster_recovery
+		 */
+		$vars[] = 'wgSitewideDisableGpt';
+		$vars[] = 'wgSitewideDisableKrux';
+		$vars[] = 'wgSitewideDisableLiftium';
+		$vars[] = 'wgSitewideDisableRubiconRTP';
+		$vars[] = 'wgSitewideDisableSevenOneMedia';
 
 		return true;
 	}

--- a/extensions/wikia/AdEngine/js/AdContext.js
+++ b/extensions/wikia/AdEngine/js/AdContext.js
@@ -48,6 +48,12 @@ define('ext.wikia.adEngine.adContext', [
 		// Use PostScribe for ScriptWriter implementation when SevenOne Media ads are enabled
 		context.opts.usePostScribe = context.opts.usePostScribe || context.providers.sevenOneMedia;
 
+		// Always call DART in specific countries
+		var alwaysCallDartInCountries = instantGlobals.wgAdDriverAlwaysCallDartInCountries || [];
+		if (alwaysCallDartInCountries.indexOf(geo.getCountryCode()) > -1) {
+			context.opts.alwaysCallDart = true;
+		}
+
 		// Targeting by page categories
 		if (context.targeting.enablePageCategories) {
 			context.targeting.pageCategories = w.wgCategories || getMercuryCategories();
@@ -62,12 +68,6 @@ define('ext.wikia.adEngine.adContext', [
 		if (context.providers.taboola) {
 			context.providers.taboola = abTest && abTest.inGroup('NATIVE_ADS_TABOOLA', 'YES') &&
 			(context.targeting.pageType === 'article' || context.targeting.pageType === 'home');
-		}
-
-		// Always call DART in specific countries
-		var alwaysCallDartInCountries = instantGlobals.wgAdDriverAlwaysCallDartInCountries || [];
-		if (alwaysCallDartInCountries.indexOf(geo.getCountryCode()) > -1) {
-			context.opts.alwaysCallDart = true;
 		}
 
 		// Export the context back to ads.context

--- a/extensions/wikia/AdEngine/js/AdContext.js
+++ b/extensions/wikia/AdEngine/js/AdContext.js
@@ -53,16 +53,21 @@ define('ext.wikia.adEngine.adContext', [
 			context.targeting.pageCategories = w.wgCategories || getMercuryCategories();
 		}
 
-		// Always call DART in specific countries
-		var alwaysCallDartInCountries = instantGlobals.wgAdDriverAlwaysCallDartInCountries || [];
-		if (alwaysCallDartInCountries.indexOf(geo.getCountryCode()) > -1) {
-			context.opts.alwaysCallDart = true;
+		// Krux integration
+		if (instantGlobals.wgSitewideDisableKrux) {
+			context.targeting.enableKruxTargeting = false;
 		}
 
 		// Taboola integration
 		if (context.providers.taboola) {
 			context.providers.taboola = abTest && abTest.inGroup('NATIVE_ADS_TABOOLA', 'YES') &&
-				(context.targeting.pageType === 'article' || context.targeting.pageType === 'home');
+			(context.targeting.pageType === 'article' || context.targeting.pageType === 'home');
+		}
+
+		// Always call DART in specific countries
+		var alwaysCallDartInCountries = instantGlobals.wgAdDriverAlwaysCallDartInCountries || [];
+		if (alwaysCallDartInCountries.indexOf(geo.getCountryCode()) > -1) {
+			context.opts.alwaysCallDart = true;
 		}
 
 		// Export the context back to ads.context

--- a/extensions/wikia/AdEngine/js/spec/AdContext.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/AdContext.spec.js
@@ -128,4 +128,31 @@ describe('AdContext', function () {
 		});
 		expect(adContext.getContext().opts.alwaysCallDart).toBeFalsy();
 	});
+
+	it('makes targeting.enableKruxTargeting false when disaster recovery instant global variable is set to true', function () {
+		var adContext;
+
+		adContext = modules['ext.wikia.adEngine.adContext']({}, {}, geoMock, {});
+		expect(adContext.getContext().targeting.enableKruxTargeting).toBeUndefined();
+
+		adContext = modules['ext.wikia.adEngine.adContext']({}, {}, geoMock, {
+			wgSitewideDisableKrux: false
+		});
+		expect(adContext.getContext().targeting.enableKruxTargeting).toBeUndefined();
+
+		adContext = modules['ext.wikia.adEngine.adContext']({},  {}, geoMock, {
+			wgSitewideDisableKrux: true
+		});
+		expect(adContext.getContext().targeting.enableKruxTargeting).toBeFalsy();
+
+		adContext = modules['ext.wikia.adEngine.adContext']({}, {}, geoMock, {
+			wgSitewideDisableKrux: 0
+		});
+		expect(adContext.getContext().targeting.enableKruxTargeting).toBeUndefined();
+
+		adContext = modules['ext.wikia.adEngine.adContext']({},  {}, geoMock, {
+			wgSitewideDisableKrux: 1
+		});
+		expect(adContext.getContext().targeting.enableKruxTargeting).toBeFalsy();
+	});
 });

--- a/extensions/wikia/AdEngine/js/spec/AdContext.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/AdContext.spec.js
@@ -130,27 +130,36 @@ describe('AdContext', function () {
 	});
 
 	it('makes targeting.enableKruxTargeting false when disaster recovery instant global variable is set to true', function () {
-		var adContext;
+		var adContext,
+			getWindowMock = function() {
+				return {ads: {
+					context: {
+						targeting: {
+							enableKruxTargeting: true
+						}
+					}
+				}};
+			};
 
-		adContext = modules['ext.wikia.adEngine.adContext']({}, {}, geoMock, {});
-		expect(adContext.getContext().targeting.enableKruxTargeting).toBeUndefined();
+		adContext = modules['ext.wikia.adEngine.adContext'](getWindowMock(), {}, geoMock, {});
+		expect(adContext.getContext().targeting.enableKruxTargeting).toBeTruthy();
 
-		adContext = modules['ext.wikia.adEngine.adContext']({}, {}, geoMock, {
+		adContext = modules['ext.wikia.adEngine.adContext'](getWindowMock(), {}, geoMock, {
 			wgSitewideDisableKrux: false
 		});
-		expect(adContext.getContext().targeting.enableKruxTargeting).toBeUndefined();
+		expect(adContext.getContext().targeting.enableKruxTargeting).toBeTruthy();
 
-		adContext = modules['ext.wikia.adEngine.adContext']({},  {}, geoMock, {
+		adContext = modules['ext.wikia.adEngine.adContext'](getWindowMock(),  {}, geoMock, {
 			wgSitewideDisableKrux: true
 		});
 		expect(adContext.getContext().targeting.enableKruxTargeting).toBeFalsy();
 
-		adContext = modules['ext.wikia.adEngine.adContext']({}, {}, geoMock, {
+		adContext = modules['ext.wikia.adEngine.adContext'](getWindowMock(), {}, geoMock, {
 			wgSitewideDisableKrux: 0
 		});
-		expect(adContext.getContext().targeting.enableKruxTargeting).toBeUndefined();
+		expect(adContext.getContext().targeting.enableKruxTargeting).toBeTruthy();
 
-		adContext = modules['ext.wikia.adEngine.adContext']({},  {}, geoMock, {
+		adContext = modules['ext.wikia.adEngine.adContext'](getWindowMock(),  {}, geoMock, {
 			wgSitewideDisableKrux: 1
 		});
 		expect(adContext.getContext().targeting.enableKruxTargeting).toBeFalsy();

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1369,6 +1369,17 @@ $wgSitewideDisableRubiconRTP = false;
 $wgSitewideDisableSevenOneMedia = false;
 
 /**
+ * @name $wgSitewideDisableKrux
+ * @link https://one.wikia-inc.com/wiki/Ads/Disaster_recovery
+ * @link http://community.wikia.com/wiki/Special:WikiFactory/community/variables/wgSitewideDisableKrux
+ *
+ * Disable Krux sitewide in case a disaster happens.
+ * ONLY UPDATE THROUGH WIKI FACTORY ON COMMUNITY - it's an instant global.
+ * For more details consult https://one.wikia-inc.com/wiki/Ads/Disaster_recovery
+ */
+$wgSitewideDisableKrux = false;
+
+/**
  * @name $wgAdDriverUseSevenOneMedia
  * Whether to use SevenOne Media ads (true) or the other ads (false)
  * Null means true for languages within $wgAdDriverUseSevenOneMediaInLanguages


### PR DESCRIPTION
In order to react fast when there is something bad happening in our site integration with Krux we want new `Wikia.GlobalInstance` variable.

Changes below implement it. For more information check Jira ticket or Wikia One documentation:
https://one.wikia-inc.com/wiki/Ads/Disaster_recovery
