### PR TITLE
UC-200 applying unconfirmed email reponse to base class as it is needed ...

### DIFF
--- a/extensions/wikia/UserLogin/js/UserBaseAjaxForm.js
+++ b/extensions/wikia/UserLogin/js/UserBaseAjaxForm.js
@@ -89,6 +89,8 @@
 			this.onOkayResponse(json);
 		} else if (json.result === 'error') {
 			this.onErrorResponse(json);
+		} else if (json.result === 'unconfirm') {
+			this.onUnconfirmedEmailResponse();
 		}
 	};
 
@@ -123,6 +125,20 @@
 	UserBaseAjaxForm.prototype.onErrorResponse = function (json) {
 		this.submitButton.removeAttr('disabled');
 		this.errorValidation(json);
+	};
+
+	/**
+	 * User has signed up successfully but they haven't confirmed their email address yet.
+	 */
+	UserBaseAjaxForm.prototype.onUnconfirmedEmailResponse = function () {
+		$.get(window.wgScriptPath + '/wikia.php', {
+			controller: 'UserLoginSpecial',
+			method: 'getUnconfirmedUserRedirectUrl',
+			format: 'json',
+			username: this.inputs.username.val()
+		}, function (json) {
+			window.location = json.redirectUrl;
+		});
 	};
 
 	/**

--- a/extensions/wikia/UserLogin/js/UserLoginAjaxForm.js
+++ b/extensions/wikia/UserLogin/js/UserLoginAjaxForm.js
@@ -37,9 +37,7 @@
 		UserBaseAjaxForm.prototype.submitLoginHandler.call(this, json);
 
 		if (result === 'resetpass') {
-			this.onResetPasswordResponse();
-		} else if (result === 'unconfirm') {
-			this.onUnconfirmedEmailResponse();
+			this.onResetPasswordResponse(json);
 		} else if (result === 'closurerequested') {
 			this.onAccountClosureReqestResponse();
 		} else {
@@ -68,17 +66,6 @@
 				fakeGet: 1
 			}, this.retrieveTemplateCallback.bind(this));
 		}
-	};
-
-	UserLoginAjaxForm.prototype.onUnconfirmedEmailResponse = function () {
-		$.get(wgScriptPath + '/wikia.php', {
-			controller: 'UserLoginSpecial',
-			method: 'getUnconfirmedUserRedirectUrl',
-			format: 'json',
-			username: this.inputs.username.val()
-		}, function (json) {
-			window.location = json.redirectUrl;
-		});
 	};
 
 	/**


### PR DESCRIPTION
...for FB

I didn't realize that there was a use case for an unconfirmed email response upon signing up with FB. This occurs when a user does not provide their email via FB permissions. Therefor, the base class has to include unconfirmed email handling, since it's needed for all signups. 
