### PR TITLE
VID-2153 Must also NFC Normalize metadata

### DIFF
--- a/maintenance/wikia/VideoHandlers/nfcNormalizeVideos.php
+++ b/maintenance/wikia/VideoHandlers/nfcNormalizeVideos.php
@@ -1,5 +1,4 @@
 <?php
-ini_set('display_errors', 'stderr');
 
 /**
  * Class NfcNormalizeVideos


### PR DESCRIPTION
Plus a few fixes to the script

Metadata needs to be normalized too otherwise it will not get `unserialize`d properly, so bunch of things breaks. Here is [an example](http://video.armon.wikia-dev.com/wiki/File:%E3%83%91%E3%82%BA%E3%83%89%E3%83%A9_%E9%AD%94%E6%B3%95%E7%9F%B3) of what I mean. Also here is [an example](http://glee.armon.wikia-dev.com/wiki/File:%E3%82%A6%E3%82%A3%E3%82%AD%E3%82%A2%E3%83%A6%E3%83%8B%E3%83%90%E3%83%BC%E3%82%B7%E3%83%86%E3%82%A3%E3%82%A6%E3%82%A3%E3%82%AD%E3%82%A2%E3%81%AE%E3%83%95%E3%82%A3%E3%83%BC%E3%83%81%E3%83%A3%E3%83%BC%E3%83%84%E3%82%A2%E3%83%BC) when metadata is cleaned.

Follow up on #6076 
https://wikia-inc.atlassian.net/browse/VID-2153
