### PR TITLE
PLATFORM-807: MessageCache::parse can return a string

### DIFF
--- a/includes/Message.php
+++ b/includes/Message.php
@@ -566,7 +566,13 @@ class Message {
 	 * @return string Wikitext parsed into HTML
 	 */
 	protected function parseText( $string ) {
-		return MessageCache::singleton()->parse( $string, $this->title, /*linestart*/true, $this->interface, $this->language )->getText();
+		// Wikia change - start
+		// MessageCache::parse can return a string (PLATFORM-807)
+		$parserOutput = MessageCache::singleton()->parse( $string, $this->title, /*linestart*/true, $this->interface, $this->language );
+		Wikia\Util\Assert::true( $parserOutput instanceof ParserOutput, 'Message::parseText: parse() did not return ParserOutput' );
+
+		return $parserOutput->getText();
+		// Wikia change - end
 	}
 
 	/**

--- a/includes/cache/MessageCache.php
+++ b/includes/cache/MessageCache.php
@@ -928,7 +928,7 @@ class MessageCache {
 	 * @param $linestart bool
 	 * @param $interface bool
 	 * @param $language
-	 * @return ParserOutput
+	 * @return ParserOutput|string
 	 */
 	public function parse( $text, $title = null, $linestart = true, $interface = false, $language = null  ) {
 		if ( $this->mInParser ) {


### PR DESCRIPTION
Add an assertion to catch the following fatal: `PHP Fatal error:  Call to a member function getText() on a non-object in /includes/Message.php on line 569`

@michalroszka 
