### PR TITLE
SOC-223 | Fix forum create default boards

### DIFF
--- a/extensions/wikia/Wall/Walls.class.php
+++ b/extensions/wikia/Wall/Walls.class.php
@@ -44,7 +44,8 @@ class Walls extends WikiaModel {
 				'page_wikia_props.page_id = page.page_id'
 			),
 			__METHOD__,
-			array( 'ORDER BY' => 'page_title' )
+			array( 'ORDER BY' => 'page_title' ),
+			$db
 		);
 
 		wfProfileOut( __METHOD__ );


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SOC-223

https://github.com/Wikia/app/blob/dev/extensions/wikia/Forum/Forum.class.php#L29
Default boards are created and taken from DB in one request.
In order to avoid problems with master/slave lag we need to query master db.
