### PR TITLE
PLATFORM-814: use a single memcached key for FastLinkCache

### DIFF
--- a/includes/RecentChange.php
+++ b/includes/RecentChange.php
@@ -150,7 +150,7 @@ class RecentChange {
 			# resetArticleID clears this memcached key when its likely we
 			# just set it earlier in this request.  BugID 42735
 			global $wgEnableFastLinkCache;
-			if (!$wgEnableFastLinkCache) {
+			if (empty($wgEnableFastLinkCache)) {
 				# Make sure the correct page ID is process cached
 				$this->mTitle->resetArticleID( $this->mAttribs['rc_cur_id'] );
 			}

--- a/includes/cache/LinkCache.php
+++ b/includes/cache/LinkCache.php
@@ -48,7 +48,8 @@ class LinkCache {
 		}
 		// start wikia change
 		elseif( $wgEnableFastLinkCache ) {
-			return (int) $wgMemc->get(self::getMemcKey($title, 'good'));
+			$fields = $wgMemc->get(self::getMemcKey($title, 'combined'));
+			return isset($fields['id']) ? intval($fields['id']) : 0;
 		}
 		// end wikia change
 		else {
@@ -72,7 +73,7 @@ class LinkCache {
 		}
 		// start wikia change
 		elseif( $wgEnableFastLinkCache ) {
-			$fields = $wgMemc->get(self::getMemcKey($dbkey, 'fields'));
+			$fields = $wgMemc->get(self::getMemcKey($dbkey, 'combined'));
 			return isset($fields[$field]) ? $fields[$field] : null;
 		}
 		// end wikia change
@@ -102,6 +103,7 @@ class LinkCache {
 		$dbkey = $title->getPrefixedDbKey();
 		$this->mGoodLinks[$dbkey] = intval( $id );
 		$this->mGoodLinkFields[$dbkey] = array(
+			'id' => intval( $id ),
 			'length' => intval( $len ),
 			'redirect' => intval( $redir ),
 			'revision' => intval( $revision ) );
@@ -109,8 +111,7 @@ class LinkCache {
 		// start wikia change
 		global $wgMemc, $wgEnableFastLinkCache;
 		if ( $wgEnableFastLinkCache ) {
-			$wgMemc->set(self::getMemcKey($dbkey, 'good'), intval( $id ), 3600);
-			$wgMemc->set(self::getMemcKey($dbkey, 'fields'), $this->mGoodLinkFields[$dbkey], 3600);
+			$wgMemc->set(self::getMemcKey($dbkey, 'combined'), $this->mGoodLinkFields[$dbkey], 3600);
 		}
 		// end wikia change
 	}
@@ -126,6 +127,7 @@ class LinkCache {
 		$dbkey = $title->getPrefixedDbKey();
 		$this->mGoodLinks[$dbkey] = intval( $row->page_id );
 		$this->mGoodLinkFields[$dbkey] = array(
+			'id' => intval( $row->page_id ),
 			'length' => intval( $row->page_len ),
 			'redirect' => intval( $row->page_is_redirect ),
 			'revision' => intval( $row->page_latest ),
@@ -134,8 +136,7 @@ class LinkCache {
 		// start wikia change
 		global $wgMemc, $wgEnableFastLinkCache;
 		if ( $wgEnableFastLinkCache ) {
-			$wgMemc->set(self::getMemcKey($dbkey, 'good'), intval( $row->page_id ), 3600);
-			$wgMemc->set(self::getMemcKey($dbkey, 'fields'), $this->mGoodLinkFields[$dbkey], 3600);
+			$wgMemc->set(self::getMemcKey($dbkey, 'combined'), $this->mGoodLinkFields[$dbkey], 3600);
 		}
 		// end wikia change
 	}
@@ -166,8 +167,7 @@ class LinkCache {
 		// start wikia change
 		global $wgMemc, $wgEnableFastLinkCache;
 		if( $wgEnableFastLinkCache ) {
-			$wgMemc->delete(self::getMemcKey($dbkey, 'good'));
-			$wgMemc->delete(self::getMemcKey($dbkey, 'fields'));
+			$wgMemc->delete(self::getMemcKey($dbkey, 'combined'));
 		}
 		// end wikia change
 	}
@@ -259,7 +259,7 @@ class LinkCache {
 	 * Gets memcache key for given title's DB key and entry's type
 	 *
 	 * @param string $dbkey title's DB key
-	 * @param string $type either "good" or "fields"
+	 * @param string $type "combined" (or obsolete "good" or "fields")
 	 * @return string memcache key
 	 *
 	 * @aauthor macbre

--- a/includes/parser/LinkHolderArray.php
+++ b/includes/parser/LinkHolderArray.php
@@ -269,30 +269,6 @@ class LinkHolderArray {
 
 		$linkcolour_ids = array();
 
-		// experimental - begin - @author: wladek - preload data from memcached
-		// todo: verify results
-		global $wgMemc, $wgEnableFastLinkCache, $wgEnableMemcachedBulkMode;
-		if ( !empty( $wgEnableFastLinkCache ) && !empty( $wgEnableMemcachedBulkMode ) ) {
-			$memcKeys = array();
-			foreach ( $this->internals as $ns => $entries ) {
-				if ( $ns == NS_SPECIAL ) {
-					continue;
-				}
-				foreach ( $entries as $entry ) {
-					if ( is_null( $entry['title'] ) ) {
-						continue;
-					}
-					if ( $entry['pdbk'] !== '' ) {
-						$memcKeys[] = LinkCache::getMemcKey($entry['pdbk'], 'good');
-						$memcKeys[] = LinkCache::getMemcKey($entry['pdbk'], 'fields');
-					}
-				}
-			}
-			$wgMemc->prefetch($memcKeys);
-		}
-		// experimental - end
-
-
 		# Generate query
 		$queries = array();
 		foreach ( $this->internals as $ns => $entries ) {


### PR DESCRIPTION
We used to keep FastLinkCache data in two separate memcached keys which does not seem to have much sense at the moment. Moreover there are a couple of issues identified that look like being caused by that fact. Switching to use a single memcached key in order to verify if that helps with those.

As a bonus some experimental code that is 2 years old was removed.

https://wikia-inc.atlassian.net/browse/PLATFORM-814

/cc @macbre @jacekjursza @owend 
