### PR TITLE
(CE-1275) Properly sanitize various queries in Lyric Wiki extension

### DIFF
--- a/extensions/3rdparty/LyricWiki/Special_ArtistRedirects.body.php
+++ b/extensions/3rdparty/LyricWiki/Special_ArtistRedirects.body.php
@@ -69,15 +69,16 @@ class ArtistRedirects extends SpecialPage
 				$wgMemc->set($currCacheKey, $content, strtotime("+$cacheHours hour"));
 			}
 		} else {
-			$offset = max(0, $_GET['offset']);
-			$limit = min($_GET['limit'], $MAX_LIMIT);
+			$request = $this->getRequest();
+			$offset = max( 0, $request->getInt( 'offset' ) );
+			$limit = min( $request->getInt( 'limit' ), $MAX_LIMIT );
 			$currCacheKey = $cacheKey."_$offset"."_$limit";
 
 			$content = $wgMemc->get($currCacheKey);
 			if(!$content){
 				ob_start();
 
-				$db = &wfGetDB(DB_SLAVE)->getProperty('mConn'); /* @var $db Resource */
+				$db = wfGetDB( DB_SLAVE );
 
 				print "This page lists artist redirects.  It will help you find abbreviations, nick-names, misspellings, and more. ";
 				print "It may not be extremely interesting, but it also allows search engines to index all of these varaints so that ";
@@ -88,35 +89,44 @@ class ArtistRedirects extends SpecialPage
 				print "This page is cached every $cacheHours hours - \n";
 				print "last cached: <strong>".date('m/d/Y \a\t g:ia')."</strong>\n";
 
-				$queryString = "SELECT page_title FROM $tablePrefix"."page WHERE page_is_redirect=1 AND page_title NOT LIKE '%:%' ORDER BY page_title LIMIT $offset,$limit";
-				if($result = mysql_query($queryString,$db)){
-					if(($numRows = mysql_num_rows($result)) && ($numRows > 0)){
-						print "<table>\n";
-						$COLS_TO_USE = 3;
-						$REQUEST_URI = $_SERVER['REQUEST_URI'];
-						for($cnt=0; $cnt<$numRows; $cnt++){
-							$pageTitle = mysql_result($result, $cnt, "page_title");
-							if(($cnt % $COLS_TO_USE) == 0){
-								print "\t<tr".((($cnt%2)!=0)?" class='odd'":"").">\n\t\t";
-							}
-							print "<td>";
-							print "<a href='/index.php?virtPage&amp;title=".urlencode($pageTitle)."'>";
-							print utf8_encode(str_replace("_", " ", $pageTitle));
-							print "</a>";
-							print "</td>";
-							if((($cnt+1) % $COLS_TO_USE) == 0){
-								print "\n\t</tr>\n";
-							}
+				$result = $db->select(
+					[ 'page' ],
+					[ 'page_title' ],
+					[
+						'page_is_redirect' => 1,
+						'page_title NOT ' . $db->buildLike( $db->anyString(), ':' , $db->anyString() ),
+					],
+					__METHOD__,
+					[
+						'ORDER BY' => 'page_title',
+						'OFFSET' => $offset,
+						'LIMIT' => $limit,
+					]
+				);
+				if ( $result->numRows() > 0 ) {
+					print "<table>\n";
+					$COLS_TO_USE = 3;
+					$REQUEST_URI = $_SERVER['REQUEST_URI'];
+					foreach ( $result as $row ) {
+						$pageTitle = $row->page_title;
+						if(($cnt % $COLS_TO_USE) == 0){
+							print "\t<tr".((($cnt%2)!=0)?" class='odd'":"").">\n\t\t";
 						}
-						while(($cnt % $COLS_TO_USE) != 0){
-							print "<td>&nbsp;</td>";
-							if((($cnt+1) % $COLS_TO_USE) == 0){
-								print "\n\t</tr>\n";
-							}
-							$cnt++;
+						print "<td>";
+						print Xml::element( 'a', [ 'href' => '/index.php?virtPage&title=' . urlencode( $pageTitle ) ], utf8_encode( str_replace( '_', ' ', $pageTitle ) ) );
+						print "</td>";
+						if((($cnt+1) % $COLS_TO_USE) == 0){
+							print "\n\t</tr>\n";
 						}
-						print "</table>\n";
 					}
+					while(($cnt % $COLS_TO_USE) != 0){
+						print "<td>&nbsp;</td>";
+						if((($cnt+1) % $COLS_TO_USE) == 0){
+							print "\n\t</tr>\n";
+						}
+						$cnt++;
+					}
+					print "</table>\n";
 				}
 
 				$content = ob_get_clean();

--- a/extensions/3rdparty/LyricWiki/Special_Soapfailures.php
+++ b/extensions/3rdparty/LyricWiki/Special_Soapfailures.php
@@ -104,17 +104,23 @@ class Soapfailures extends SpecialPage{
 
 			if(($songResult['lyrics'] == $failedLyrics) || ($songResult['lyrics'] == "")){
 				print "<html><head><title>Error</title></head><body>\n"; // TODO: i18n
-				print "<div style='background-color:#fcc'>Sorry, but $artist:$song song still failed.</div>\n";
+				print '<div style="background-color:#fcc">Sorry, but ' . htmlspecialchars( $artist ) . ':' . htmlspecialchars( $song ) . " song still failed.</div>\n";
 				print_r($songResult);
 			} else {
-				$artist = str_replace("'", "\\'", $artist);
-				$song = str_replace("'", "\\'", $song);
-
-				$db = &wfGetDB(DB_MASTER)->getProperty('mConn');
+				$dbw = wfGetDB( DB_MASTER );
 
 				print "<html><head><title>Success</title></head><body>\n"; // TODO: i18n
 				print "Deleting record... ";
-				if(mysql_query("DELETE FROM lw_soap_failures WHERE request_artist='$artist' AND request_song='$song'", $db)){
+
+				$result = $dbw->delete(
+					'lw_soap_failures',
+					[
+						'request_artist' => $artist,
+						'request_song' => $song,
+					],
+					__METHOD__
+				);
+				if ( $result ) {
 					print "Deleted.";
 				} else {
 					print "Failed. ".mysql_error();
@@ -255,9 +261,9 @@ class Soapfailures extends SpecialPage{
 						$wgOut->addWikiText("$lookedFor");
 						$wgOut->addHTML("</td><td>");
 						$wgOut->addHTML("<form action='' method='POST' target='_blank'>
-								<input type='hidden' name='artist' value=\"$artist\"/>
-								<input type='hidden' name='song' value=\"$song\"/>
-								<input type='submit' name='fixed' value='".wfMsg('soapfailures-fixed')."'/>
+								<input type='hidden' name='artist' value=\"" . Sanitizer::encodeAttribute( $artist ) . "\"/>
+								<input type='hidden' name='song' value=\"" . Sanitizer::encodeAttribute( $song ) . "\"/>
+								<input type='submit' name='fixed' value=\"" . wfMessage( 'soapfailures-fixed' )->escaped() . "\"/>
 							</form>\n");
 						$wgOut->addHTML("</td>");
 						$wgOut->addHTML("</tr>\n");

--- a/extensions/3rdparty/LyricWiki/lw_cache.php
+++ b/extensions/3rdparty/LyricWiki/lw_cache.php
@@ -18,31 +18,35 @@
 // Slightly modified from version in itms_teknomunk.php
 class DurableCache {
 
-	/* @var $db Resource */
-	var $db;
-
-	/* @var $db_master Resource */
-	var $db_master;
-
-	function DurableCache(){
-		$this->db = &wfGetDB(DB_SLAVE)->getProperty('mConn');
-		$this->db_master = &wfGetDB(DB_MASTER)->getProperty('mConn');
-	}
-
-	function fetch($key){
+	function fetch( $key ) {
 		$retVal = null;
-		$queryString = "SELECT value FROM lw_map WHERE keyName='$key'";
-		if($result = mysql_query($queryString,$this->db)){
-			if(($numRows = mysql_num_rows($result)) && ($numRows > 0)){
-				$retVal = mysql_result($result, 0, "value");
-			}
+		$dbr = wfGetDB( DB_SLAVE );
+		$result = $dbr->selectRow(
+			[ 'lw_map' ],
+			[ 'value' ],
+			[
+				'keyName' => $key,
+			],
+			__METHOD__
+		);
+		if ( $result !== false ) {
+			$retVal = $result->value;
 		}
 		return $retVal;
 	}
-	function store($key, $value){
-		$source = str_replace("'", "\'", $value); // to prevent query errors
-		$queryString = "REPLACE INTO lw_map (keyName, value) VALUES ('$key', '$source')";
-		return mysql_query($queryString, $this->db_master); // need to use the master db connection to write
+
+	function store( $key, $value ) {
+		$dbw = wfGetDB( DB_MASTER );
+		$result = $dbw->replace(
+			'lw_map',
+			[ 'keyName' ],
+			[
+				'keyName' => $key,
+				'value' => $value,
+			],
+			__METHOD__
+		);
+		return $result;
 	}
 
 	function fetchExpire( $entryKey, $validAfter ){

--- a/extensions/3rdparty/LyricWiki/lw_cache.php
+++ b/extensions/3rdparty/LyricWiki/lw_cache.php
@@ -21,16 +21,16 @@ class DurableCache {
 	function fetch( $key ) {
 		$retVal = null;
 		$dbr = wfGetDB( DB_SLAVE );
-		$result = $dbr->selectRow(
+		$result = $dbr->selectField(
 			[ 'lw_map' ],
-			[ 'value' ],
+			'value',
 			[
 				'keyName' => $key,
 			],
 			__METHOD__
 		);
 		if ( $result !== false ) {
-			$retVal = $result->value;
+			$retVal = $result;
 		}
 		return $retVal;
 	}


### PR DESCRIPTION
Many areas of Lyric Wiki extension did not properly sanitize queries,
in particular just doing a string replace to put a backslash in front
of a single quote, does not escape that value.

Reviewed in https://github.com/Wikia/app/pull/6107
