### PR TITLE
XML dumps 7zip compression

### DIFF
--- a/extensions/wikia/WikiFactory/Close/SpecialCloseWiki_body.php
+++ b/extensions/wikia/WikiFactory/Close/SpecialCloseWiki_body.php
@@ -401,8 +401,8 @@ class CloseWikiPage extends SpecialPage {
 		if ( !($this->closedWiki->city_flags & WikiFactory::FLAG_HIDE_DB_IMAGES)
 				&& $this->closedWiki->city_lastdump_timestamp >= DumpsOnDemand::S3_MIGRATION ) {
 			$aFiles = array(
-				'pages_current'	=> '_pages_current.xml.gz',
-				'pages_full'	=> '_pages_full.xml.gz',
+				'pages_current'	=> '_pages_current.xml.7z',
+				'pages_full'	=> '_pages_full.xml.7z',
 			);
 
 			foreach ( $aFiles as $sKey => $sValue ) {

--- a/extensions/wikia/WikiFactory/Close/SpecialCloseWiki_body.php
+++ b/extensions/wikia/WikiFactory/Close/SpecialCloseWiki_body.php
@@ -29,6 +29,7 @@ class CloseWikiPage extends SpecialPage {
 		$mTmpl,
 		$mStep      	= 1,
 		$mAction,
+		$mReason,
 		$mErrors    	= array(),
 		$mRedirects 	= array(),
 		$mRedirect		= "",
@@ -400,9 +401,11 @@ class CloseWikiPage extends SpecialPage {
 
 		if ( !($this->closedWiki->city_flags & WikiFactory::FLAG_HIDE_DB_IMAGES)
 				&& $this->closedWiki->city_lastdump_timestamp >= DumpsOnDemand::S3_MIGRATION ) {
+			$dumpInfo = DumpsOnDemand::getLatestDumpInfo($this->closedWiki->city_id);
+			$extension = DumpsOnDemand::getExtensionFromCompression($dumpInfo?$dumpInfo['compression']:false);
 			$aFiles = array(
-				'pages_current'	=> '_pages_current.xml.7z',
-				'pages_full'	=> '_pages_full.xml.7z',
+				'pages_current'	=> "_pages_current.xml{$extension}",
+				'pages_full'	=> "_pages_full.xml{$extension}",
 			);
 
 			foreach ( $aFiles as $sKey => $sValue ) {

--- a/extensions/wikia/WikiFactory/Close/SpecialCloseWiki_body.php
+++ b/extensions/wikia/WikiFactory/Close/SpecialCloseWiki_body.php
@@ -327,10 +327,10 @@ class CloseWikiPage extends SpecialPage {
 					WikiFactory::setFlags($wiki->city_id, $city_flags);
 				}
 
-                                // Let's request the XML dump if needed
-                                if ( isset( $this->mFlags[WikiFactory::FLAG_CREATE_DB_DUMP] ) ) {
-                                    DumpsOnDemand::queueDump( $wiki->city_id, isset( $this->mFlags[WikiFactory::FLAG_HIDE_DB_IMAGES] ), true );
-                                }
+				// Let's request the XML dump if needed
+				if ( isset( $this->mFlags[WikiFactory::FLAG_CREATE_DB_DUMP] ) ) {
+					DumpsOnDemand::queueDump( $wiki->city_id, isset( $this->mFlags[WikiFactory::FLAG_HIDE_DB_IMAGES] ), true );
+				}
 
 				if ( empty($this->mReason) ) {
 					$this->mReason = "-";

--- a/extensions/wikia/WikiFactory/Dumps/DumpsOnDemand.php
+++ b/extensions/wikia/WikiFactory/Dumps/DumpsOnDemand.php
@@ -18,6 +18,7 @@ $wgGroupPermissions['autoconfirmed']['dumpsondemand'] = true;
 class DumpsOnDemand {
 
 	const BASEURL = "http://dumps.wikia.net";
+	const DEFAULT_COMPRESSION_FORMAT = '7zip';
 
     /**
      * From this moment on we use Amazon S3 storage for the dumps.

--- a/extensions/wikia/WikiFactory/Dumps/DumpsOnDemand.php
+++ b/extensions/wikia/WikiFactory/Dumps/DumpsOnDemand.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * simple hook for displaying additional informations in Special:Statistics
+ * Simple hook for displaying additional information in Special:Statistics
  * 
  * @author Krzysztof Krzyżaniak <eloy@wikia-inc.com>
  * @author Michał ‘Mix’ Roszka <mix@wikia-inc.com>
@@ -48,7 +48,9 @@ class DumpsOnDemand {
 		$tmpl->set( "title", $wgTitle );
 		$tmpl->set( "isAnon", $wgUser->isAnon() );
 
-		$sTimestamp = self::getLatestDumpTimestamp( $wgCityId );
+		$dumpInfo = self::getLatestDumpInfo( $wgCityId );
+		$sTimestamp = $dumpInfo ? $dumpInfo['timestamp'] : false;
+		$sDumpExtension = self::getExtensionFromCompression($dumpInfo ? $dumpInfo['compression'] : false);
 		$tmpl->set( 'nolink', false);
 		if ( empty( $sTimestamp ) ) {
 			$sTimestamp = wfMessage( 'dump-database-last-unknown' )->escaped();
@@ -56,12 +58,12 @@ class DumpsOnDemand {
 		}
 
 		$tmpl->set( "curr", array(
-			"url" => 'http://s3.amazonaws.com/wikia_xml_dumps/' . self::getPath( "{$wgDBname}_pages_current.xml.7z" ),
+			"url" => 'http://s3.amazonaws.com/wikia_xml_dumps/' . self::getPath( "{$wgDBname}_pages_current.xml{$sDumpExtension}" ),
 			"timestamp" => $sTimestamp
 		));
 
 		$tmpl->set( "full", array(
-			"url" => 'http://s3.amazonaws.com/wikia_xml_dumps/' . self::getPath( "{$wgDBname}_pages_full.xml.7z" ),
+			"url" => 'http://s3.amazonaws.com/wikia_xml_dumps/' . self::getPath( "{$wgDBname}_pages_full.xml{$sDumpExtension}" ),
 			"timestamp" => $sTimestamp
 		));
 
@@ -103,15 +105,15 @@ class DumpsOnDemand {
 		);
 	}
         
-        /**
-         * @static
-         * @access public
-         * @deprecated
-         */
-        static public function sendMail( $sDbName = null, $iCityId = null, $bHidden = false, $bClose = false ) {
-            trigger_error( sprintf( 'Using of deprecated method %s.', __METHOD__ ) , E_USER_WARNING );
-            self::queueDump( $iCityId, $bHidden, $bClose );
-        }
+	/**
+	 * @static
+	 * @access public
+	 * @deprecated
+	 */
+	static public function sendMail( $sDbName = null, $iCityId = null, $bHidden = false, $bClose = false ) {
+		trigger_error( sprintf( 'Using of deprecated method %s.', __METHOD__ ) , E_USER_WARNING );
+		self::queueDump( $iCityId, $bHidden, $bClose );
+	}
 
 	/**
 	 * @static
@@ -208,17 +210,25 @@ class DumpsOnDemand {
 	}
 
 	/**
-	 * Gets the timestamp of the latest dump.
+	 * Get the timestamp and compression format of the latest completed dump for given wikia.
+	 *
+	 * Returns false or an associative array with "timestamp" and "compression" keys.
+	 *
+	 * @param $iWikiaId int Wikia ID
+	 * @return array|bool Latest dump info or false
 	 */
-	static public function getLatestDumpTimestamp( $iWikiaId ) {
+	static public function getLatestDumpInfo( $iWikiaId ) {
 		global $wgMemc;
-		$sKey = wfSharedMemcKey( $iWikiaId, 'latest_dump_timestamp' );
-		$sTimestamp = $wgMemc->get( $sKey );
-		if ( !$sTimestamp ) {
+		$sKey = wfSharedMemcKey( $iWikiaId, 'latest_dump_info' );
+		$dumpInfo = $wgMemc->get( $sKey );
+		if ( !$dumpInfo ) {
 			$oDB = wfGetDB( DB_SLAVE, array(), 'wikicities' );
-			$sTimestamp = (string) $oDB->selectField(
+			$row = $oDB->selectRow(
 				'dumps',
-				'dump_completed',
+				array(
+					'dump_completed',
+					'dump_compression'
+				),
 				array(
 					'dump_completed IS NOT NULL',
 					'dump_wiki_id' => $iWikiaId
@@ -229,10 +239,40 @@ class DumpsOnDemand {
 					'LIMIT' => 1
 				)
 			);
-			if ( $sTimestamp ) {
-				$wgMemc->set( $sKey, $sTimestamp, 7*24*60*60 ); // a week
+			if ( $row ) {
+				$dumpInfo = array(
+					'timestamp' => $row->dump_completed,
+					'compression' => $row->dump_compression,
+				);
+			}
+			if ( $dumpInfo ) {
+				$wgMemc->set( $sKey, $dumpInfo, 7*24*60*60 ); // a week
 			}
 		}
-		return $sTimestamp;
+		return $dumpInfo;
+	}
+
+	/**
+	 * Purge information about latest dump for a given wikia.
+	 *
+	 * @param $iWikiaId int Wikia ID
+	 */
+	static public function purgeLatestDumpInfo( $iWikiaId ) {
+		global $wgMemc;
+		$sKey = wfSharedMemcKey( $iWikiaId, 'latest_dump_info' );
+		$wgMemc->delete($sKey);
+	}
+
+	/**
+	 * Get file extension from compression format.
+	 *
+	 * @param $compression string Compression format (should be one of "gzip" or "7zip")
+	 * @return string File extension (including dot)
+	 */
+	static public function getExtensionFromCompression( $compression ) {
+		if ( $compression == 'gzip' ) { # old compression format
+			return '.gz';
+		}
+		return '.7z';
 	}
 }

--- a/extensions/wikia/WikiFactory/Dumps/DumpsOnDemand.php
+++ b/extensions/wikia/WikiFactory/Dumps/DumpsOnDemand.php
@@ -56,12 +56,12 @@ class DumpsOnDemand {
 		}
 
 		$tmpl->set( "curr", array(
-			"url" => 'http://s3.amazonaws.com/wikia_xml_dumps/' . self::getPath( "{$wgDBname}_pages_current.xml.gz" ),
+			"url" => 'http://s3.amazonaws.com/wikia_xml_dumps/' . self::getPath( "{$wgDBname}_pages_current.xml.7z" ),
 			"timestamp" => $sTimestamp
 		));
 
 		$tmpl->set( "full", array(
-			"url" => 'http://s3.amazonaws.com/wikia_xml_dumps/' . self::getPath( "{$wgDBname}_pages_full.xml.gz" ),
+			"url" => 'http://s3.amazonaws.com/wikia_xml_dumps/' . self::getPath( "{$wgDBname}_pages_full.xml.7z" ),
 			"timestamp" => $sTimestamp
 		));
 
@@ -162,7 +162,7 @@ class DumpsOnDemand {
 	static public function getPath( $sName ) {
 		/*
 		 * Get the actual name:
-		 *    * 'muppet' for 'muppet.xml.gz'
+		 *    * 'muppet' for 'muppet.xml.7z'
 		 *    * 'muppet' for 'muppet'
 		 *    * 'htaccess' for '.htaccess'
 		 * The name will be in $aMatches[1].

--- a/extensions/wikia/WikiFactory/Dumps/maintenance/DumpsOnDemandCron.php
+++ b/extensions/wikia/WikiFactory/Dumps/maintenance/DumpsOnDemandCron.php
@@ -63,13 +63,18 @@ class DumpsOnDemandCron extends Maintenance {
 
         $oDB->update(
             'dumps',
-            array( 'dump_completed' => wfTimestampNow() ),
+            array(
+                'dump_completed' => wfTimestampNow(),
+                'dump_compression' => '7zip' // keep in sync with compression format in runBackups.php
+            ),
             array(
                 'dump_wiki_id' => $sWikiaId,
                 'dump_completed IS NULL'
             ),
             __METHOD__
         );
+
+        DumpsOnDemand::purgeLatestDumpInfo(intval($sWikiaId));
 
         $this->output( "Done.\n" );
         unlink( self::PIDFILE );

--- a/extensions/wikia/WikiFactory/Dumps/maintenance/DumpsOnDemandCron.php
+++ b/extensions/wikia/WikiFactory/Dumps/maintenance/DumpsOnDemandCron.php
@@ -65,7 +65,7 @@ class DumpsOnDemandCron extends Maintenance {
             'dumps',
             array(
                 'dump_completed' => wfTimestampNow(),
-                'dump_compression' => '7zip' // keep in sync with compression format in runBackups.php
+                'dump_compression' => DumpsOnDemand::DEFAULT_COMPRESSION_FORMAT,
             ),
             array(
                 'dump_wiki_id' => $sWikiaId,

--- a/extensions/wikia/WikiFactory/Dumps/runBackups.php
+++ b/extensions/wikia/WikiFactory/Dumps/runBackups.php
@@ -137,7 +137,7 @@ function runBackups( $from, $to, $full, $options ) {
 				"--xml",
 				"--quiet",
 				"--server=$server",
-				"--output=7zip:{$path}" // keep in sync with compression format in DumpsOnDemandCron.php
+				"--output=".DumpsOnDemand::DEFAULT_COMPRESSION_FORMAT.":{$path}"
 			);
 			wfShellExec( implode( " ", $cmd ), $status );
 			$time = Wikia::timeDuration( wfTime() - $time );
@@ -161,7 +161,7 @@ function runBackups( $from, $to, $full, $options ) {
 				"--xml",
 				"--quiet",
 				"--server=$server",
-				"--output=7zip:{$path}" // keep in sync with compression format in DumpsOnDemandCron.php
+				"--output=".DumpsOnDemand::DEFAULT_COMPRESSION_FORMAT.":{$path}"
 			);
 			wfShellExec( implode( " ", $cmd ), $status );
 			$time = Wikia::timeDuration( wfTime() - $time );

--- a/extensions/wikia/WikiFactory/Dumps/runBackups.php
+++ b/extensions/wikia/WikiFactory/Dumps/runBackups.php
@@ -137,7 +137,7 @@ function runBackups( $from, $to, $full, $options ) {
 				"--xml",
 				"--quiet",
 				"--server=$server",
-				"--output=7zip:{$path}"
+				"--output=7zip:{$path}" // keep in sync with compression format in DumpsOnDemandCron.php
 			);
 			wfShellExec( implode( " ", $cmd ), $status );
 			$time = Wikia::timeDuration( wfTime() - $time );
@@ -161,7 +161,7 @@ function runBackups( $from, $to, $full, $options ) {
 				"--xml",
 				"--quiet",
 				"--server=$server",
-				"--output=7zip:{$path}"
+				"--output=7zip:{$path}" // keep in sync with compression format in DumpsOnDemandCron.php
 			);
 			wfShellExec( implode( " ", $cmd ), $status );
 			$time = Wikia::timeDuration( wfTime() - $time );

--- a/extensions/wikia/WikiFactory/Dumps/runBackups.php
+++ b/extensions/wikia/WikiFactory/Dumps/runBackups.php
@@ -124,7 +124,7 @@ function runBackups( $from, $to, $full, $options ) {
 		$basedir = getDirectory( $row->city_dbname, $hide, $use_temp );
 
 		if( $full || $both ) {
-			$path = sprintf("%s/%s_pages_full.xml.gz", $basedir, $row->city_dbname );
+			$path = sprintf("%s/%s_pages_full.xml.7z", $basedir, $row->city_dbname );
 			$time = wfTime();
 			Wikia::log( __METHOD__, "info", "{$row->city_id} {$row->city_dbname} {$path}", true, true );
 			$cmd = array(
@@ -137,7 +137,7 @@ function runBackups( $from, $to, $full, $options ) {
 				"--xml",
 				"--quiet",
 				"--server=$server",
-				"--output=gzip:{$path}"
+				"--output=7zip:{$path}"
 			);
 			wfShellExec( implode( " ", $cmd ), $status );
 			$time = Wikia::timeDuration( wfTime() - $time );
@@ -148,7 +148,7 @@ function runBackups( $from, $to, $full, $options ) {
 
 		}
 		if( !$full || $both ) {
-			$path = sprintf("%s/%s_pages_current.xml.gz", $basedir, $row->city_dbname );
+			$path = sprintf("%s/%s_pages_current.xml.7z", $basedir, $row->city_dbname );
 			$time = wfTime();
 			Wikia::log( __METHOD__, "info", "{$row->city_id} {$row->city_dbname} {$path}", true, true);
 			$cmd = array(
@@ -161,7 +161,7 @@ function runBackups( $from, $to, $full, $options ) {
 				"--xml",
 				"--quiet",
 				"--server=$server",
-				"--output=gzip:{$path}"
+				"--output=7zip:{$path}"
 			);
 			wfShellExec( implode( " ", $cmd ), $status );
 			$time = Wikia::timeDuration( wfTime() - $time );

--- a/includes/Export.php
+++ b/includes/Export.php
@@ -915,7 +915,9 @@ class Dump7ZipOutput extends DumpPipeOutput {
 	}
 
 	function setup7zCommand( $file ) {
-		$command = "7za a -bd -si " . wfEscapeShellArg( $file );
+		// Wikia change - begin - @upstream: I07ab5f93ecd6d706460691db5181de89ef31cbea
+		$command = "7za a -bd -si -mx=4 " . wfEscapeShellArg( $file );
+		// Wikia change - end
 		// Suppress annoying useless crap from p7zip
 		// Unfortunately this could suppress real error messages too
 		$command .= ' >' . wfGetNull() . ' 2>&1';


### PR DESCRIPTION
As a continuation of #6029 a few extra necessary changes were made to get a smooth user experience when we switch the compression format to 7zip (please refer the #6029 to learn the rationale behind this change). Old links should still be valid and work correctly while the new dumps will be compressed using 7zip and the links will be adjusted accordingly.

Thanks @nemobis for suggesting this change!

https://wikia-inc.atlassian.net/browse/PLATFORM-803

/cc @nemobis @macbre @lgarczewski @michalroszka @owend 
