### PR TITLE
ADEN-1727 Extend wgAdDriverAlwaysCallDartInCountries to mobile

### DIFF
--- a/extensions/wikia/AdEngine/AdEngine2Hooks.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2Hooks.class.php
@@ -60,6 +60,7 @@ class AdEngine2Hooks {
 	public static function onInstantGlobalsGetVariables( array &$vars )
 	{
 		$vars[] = 'wgAdDriverAlwaysCallDartInCountries';
+		$vars[] = 'wgAdDriverAlwaysCallDartInCountriesMobile';
 
 		$vars[] = 'wgAmazonMatchCountries';
 		$vars[] = 'wgAmazonMatchOldCountries';

--- a/extensions/wikia/AdEngine/js/AdContext.js
+++ b/extensions/wikia/AdEngine/js/AdContext.js
@@ -49,9 +49,16 @@ define('ext.wikia.adEngine.adContext', [
 		context.opts.usePostScribe = context.opts.usePostScribe || context.providers.sevenOneMedia;
 
 		// Always call DART in specific countries
-		var alwaysCallDartInCountries = instantGlobals.wgAdDriverAlwaysCallDartInCountries || [];
+		// TODO: make mobile code compatible with desktop (currently one uses opts and the other providers)
+		var alwaysCallDartInCountries = instantGlobals.wgAdDriverAlwaysCallDartInCountries || [],
+			alwaysCallDartInCountriesMobile = instantGlobals.wgAdDriverAlwaysCallDartInCountriesMobile || [];
+
 		if (alwaysCallDartInCountries.indexOf(geo.getCountryCode()) > -1) {
 			context.opts.alwaysCallDart = true;
+		}
+
+		if (alwaysCallDartInCountriesMobile.indexOf(geo.getCountryCode()) > -1) {
+			context.providers.remnantGptMobile = true;
 		}
 
 		// Targeting by page categories

--- a/extensions/wikia/AdEngine/js/spec/AdContext.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/AdContext.spec.js
@@ -164,4 +164,18 @@ describe('AdContext', function () {
 		});
 		expect(adContext.getContext().targeting.enableKruxTargeting).toBeFalsy();
 	});
+
+	it('makes providers.remnantGptMobile true when country in instantGlobals.wgAdDriverAlwaysCallDartInCountriesMobile', function () {
+		var adContext;
+
+		adContext = modules['ext.wikia.adEngine.adContext']({}, {}, geoMock, {
+			wgAdDriverAlwaysCallDartInCountriesMobile: ['XX']
+		});
+		expect(adContext.getContext().providers.remnantGptMobile).toBeTruthy();
+
+		adContext = modules['ext.wikia.adEngine.adContext']({},  {}, geoMock, {
+			wgAdDriverAlwaysCallDartInCountriesMobile: ['YY']
+		});
+		expect(adContext.getContext().providers.remnantGptMobile).toBeFalsy();
+	});
 });

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1289,6 +1289,13 @@ $wgAdDriverUseTaboola = false;
 $wgAdDriverAlwaysCallDartInCountries = [];
 
 /**
+ * @name $wgAdDriverAlwaysCallDartInCountriesMobile
+ * Enable Remnant GPT call in those countries on wikiamobile skin.
+ * ONLY UPDATE THROUGH WIKI FACTORY ON COMMUNITY - it's an instant global.
+ */
+$wgAdDriverAlwaysCallDartInCountriesMobile = [];
+
+/**
  * @name $wgAdDriverUseBottomLeaderboard
  * Whether to enable new fancy footer ad BOTTOM_LEADERBOARD
  */


### PR DESCRIPTION
Since Nef wanted this fast, I didn't unify the naming between desktop and mobile.

The WikiFactory vars for this are:
- $wgAdDriverAlwaysCallDartInCountries -- list of countries the all DART setting is on for Oasis
- $wgAdDriverAlwaysCallDartInCountriesMobile -- list of countries the all DART setting is on for wikiamobile

The vehicle for both is adContext.js, which sets:
- `context.opts.alwaysCallDart = true` if InstantGlobals.wgAdDriverAlwaysCallDartInCountries matches your country -- this is used on **desktop**
- `context.providers.remnantGptMobile = true` if InstantGlobals.wgAdDriverAlwaysCallDartInCountriesMobile matches your country -- this is used on **mobile**

Ideally both skins should use the same convention for both InstantGlobals and context vars.
