### PR TITLE
VE-1776: In dialogs display action buttons in the fotter instead of the head

### DIFF
--- a/extensions/VisualEditor/wikia/VisualEditor.scss
+++ b/extensions/VisualEditor/wikia/VisualEditor.scss
@@ -8,6 +8,7 @@
 
 // VE Imports
 @import "modules/ve/ui/styles/color";
+@import "modules/ve/ui/styles/ve.ui.Dialog";
 @import "modules/ve/ui/styles/ve.ui.Surface";
 @import "modules/ve/ui/styles/ve.ui.Toolbar";
 @import "modules/ve/ui/styles/ve.ui.WikiaFocusWidget";

--- a/extensions/VisualEditor/wikia/modules/ve/ui/styles/ve.ui.Dialog.scss
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/styles/ve.ui.Dialog.scss
@@ -1,0 +1,12 @@
+.oo-ui-dialog-content .oo-ui-window-closeButton {
+  float: right;
+  margin: 0.7em 0.7em;
+  position: relative;
+  z-index: 1;
+}
+
+.oo-ui-processDialog-actions-safe,
+.oo-ui-processDialog-actions-primary {
+	float: right;
+	position: static;
+}

--- a/resources/lib/oojs-ui/oojs-ui.js
+++ b/resources/lib/oojs-ui/oojs-ui.js
@@ -2503,10 +2503,18 @@ OO.ui.Dialog.prototype.initialize = function () {
 
 	// Properties
 	this.title = new OO.ui.LabelWidget( { $: this.$ } );
+	this.closeButton = new OO.ui.ButtonWidget( {
+		'$': this.$,
+		'framed': false,
+		'icon': 'close',
+		'title': OO.ui.msg( 'ooui-dialog-action-close' )
+	} );
 
 	// Initialization
 	this.$content.addClass( 'oo-ui-dialog-content' );
 	this.setPendingElement( this.$head );
+	this.closeButton.$element.addClass( 'oo-ui-window-closeButton' );
+	this.$head.append( this.closeButton.$element );
 };
 
 /**
@@ -6672,9 +6680,11 @@ OO.ui.ProcessDialog.prototype.initialize = function () {
 		.append( this.$errors );
 	this.$navigation
 		.addClass( 'oo-ui-processDialog-navigation' )
-		.append( this.$safeActions, this.$location, this.$primaryActions );
+		//.append( this.$safeActions, this.$location, this.$primaryActions );
+		.append( this.$location );
 	this.$head.append( this.$navigation );
-	this.$foot.append( this.$otherActions );
+	//this.$foot.append( this.$otherActions );
+	this.$foot.append( this.$primaryActions, this.$safeActions, this.$otherActions );
 };
 
 /**

--- a/resources/lib/oojs-ui/oojs-ui.js
+++ b/resources/lib/oojs-ui/oojs-ui.js
@@ -2510,11 +2510,21 @@ OO.ui.Dialog.prototype.initialize = function () {
 		'title': OO.ui.msg( 'ooui-dialog-action-close' )
 	} );
 
+	// Events
+	this.closeButton.connect( this, { 'click': 'onCloseButtonClick' } );
+
 	// Initialization
 	this.$content.addClass( 'oo-ui-dialog-content' );
 	this.setPendingElement( this.$head );
 	this.closeButton.$element.addClass( 'oo-ui-window-closeButton' );
 	this.$head.append( this.closeButton.$element );
+};
+
+/**
+ * Handle close button click events.
+ */
+OO.ui.Dialog.prototype.onCloseButtonClick = function () {
+	this.close( { 'action': 'cancel' } );
 };
 
 /**


### PR DESCRIPTION
This is done totally the same way as in https://github.com/Wikia/app/pull/6036 however that PR was too bug (was doing too many things, and some of them - wrong).

https://wikia-inc.atlassian.net/browse/VE-1776
