### PR TITLE
PLATFORM-811:Our404Handler is broken on non-English wikias

### DIFF
--- a/extensions/wikia/Our404Handler/SpecialOur404Handler.php
+++ b/extensions/wikia/Our404Handler/SpecialOur404Handler.php
@@ -29,3 +29,5 @@ $dir = dirname(__FILE__) . '/';
 $wgExtensionMessagesFiles['Our404Handler'] = $dir . 'SpecialOur404Handler.i18n.php';
 $wgAutoloadClasses['Our404HandlerPage'] = $dir. 'SpecialOur404Handler_body.php';
 $wgSpecialPages['Our404Handler'] = 'Our404HandlerPage';
+
+$wgHooks['TestCanonicalRedirect'][] = 'Our404HandlerPage::onTestCanonicalRedirect';

--- a/extensions/wikia/Our404Handler/SpecialOur404Handler_body.php
+++ b/extensions/wikia/Our404Handler/SpecialOur404Handler_body.php
@@ -17,8 +17,6 @@ if ( !defined( 'MEDIAWIKI' ) ) {
 
 class Our404HandlerPage extends UnlistedSpecialPage {
 
-	public $mTitle;
-
 	const NAME = 'Our404Handler';
 
 	/**
@@ -37,30 +35,26 @@ class Our404HandlerPage extends UnlistedSpecialPage {
 	 */
 	public function execute( $subpage ) {
 		$this->setHeaders();
-		$this->mTitle = Title::makeTitle( NS_SPECIAL, 'Our404Handler' );
 		$this->doRender404();
 	}
 
 
 	/**
 	 * Just render some simple 404 page
-	 *
-	 * @access public
 	 */
-	public function doRender404( $uri = null ) {
+	public function doRender404() {
 		global $wgOut, $wgContLang, $wgCanonicalNamespaceNames;
 
 		/**
 		 * check, maybe we have article with that title, if yes 301redirect to
 		 * this article
 		 */
-		if( $uri === null ) {
-			$uri = $_SERVER['REQUEST_URI'];
-			if ( !preg_match( '!^https?://!', $uri ) ) {
-				$uri = 'http://unused' . $uri;
-			}
-			$uri = substr( parse_url( $uri, PHP_URL_PATH ), 1 );
+		$uri = $_SERVER['REQUEST_URI'];
+		if ( !preg_match( '!^https?://!', $uri ) ) {
+			$uri = 'http://unused' . $uri;
 		}
+		$uri = substr( parse_url( $uri, PHP_URL_PATH ), 1 );
+
 		Wikia::log( __METHOD__, false,  isset($_SERVER[ 'HTTP_REFERER' ])?$_SERVER[ 'HTTP_REFERER' ]:"[no referer]" );
 		$title = $wgContLang->ucfirst( urldecode( ltrim( $uri, "/" ) ) );
 		$namespace = NS_MAIN;
@@ -99,7 +93,7 @@ class Our404HandlerPage extends UnlistedSpecialPage {
 				$oArticle = new Article( $oTitle );
 				if( $oArticle->exists() ) {
 					header( "X-Redirected-By: Our404Handler" );
-					header( sprintf( "Location: %s", $oArticle->mTitle->getFullURL() ), true, 301 );
+					header( sprintf( "Location: %s", $oArticle->getTitle()->getFullURL() ), true, 301 );
 					exit( 0 );
 				}
 			}

--- a/extensions/wikia/Our404Handler/SpecialOur404Handler_body.php
+++ b/extensions/wikia/Our404Handler/SpecialOur404Handler_body.php
@@ -19,11 +19,13 @@ class Our404HandlerPage extends UnlistedSpecialPage {
 
 	public $mTitle;
 
+	const NAME = 'Our404Handler';
+
 	/**
 	 * Constructor
 	 */
 	public function  __construct() {
-		parent::__construct( 'Our404Handler'/*class*/ );
+		parent::__construct( self::NAME );
 	}
 
 	/**
@@ -112,5 +114,27 @@ class Our404HandlerPage extends UnlistedSpecialPage {
 		$info = wfMsgForContent( 'message404', $uri, urldecode( $title ) );
 		$wgOut->addHTML( '<h2>'.wfMsg( 'our404handler-oops' ).'</h2>
 						<div>'. $wgOut->parse( $info ) .'</div>' );
+	}
+
+	/**
+	 * This hook is called when about to force a redirect to a canonical URL
+	 * for a title when we have no other parameters on the URL.
+	 *
+	 * Return false when we want to prevent the redirect to the canonical URL
+	 * for Our404Handler special page
+	 *
+	 * @see PLATFORM-811
+	 *
+	 * @param WebRequest $request
+	 * @param Title $title
+	 * @param OutputPage $output
+	 * @return bool
+	 */
+	public static function onTestCanonicalRedirect( WebRequest $request, Title $title, OutputPage $output) {
+		if ( $title->isSpecial( self::NAME ) ) {
+			return false;
+		}
+
+		return true;
 	}
 };

--- a/extensions/wikia/Our404Handler/SpecialOur404Handler_body.php
+++ b/extensions/wikia/Our404Handler/SpecialOur404Handler_body.php
@@ -34,7 +34,6 @@ class Our404HandlerPage extends UnlistedSpecialPage {
 	 * @param $subpage Mixed: subpage of SpecialPage
 	 */
 	public function execute( $subpage ) {
-		global $wgRequest;
 		$this->setHeaders();
 		$this->mTitle = Title::makeTitle( NS_SPECIAL, 'Our404Handler' );
 		$this->doRender404();
@@ -90,12 +89,14 @@ class Our404HandlerPage extends UnlistedSpecialPage {
 				/**
 				 * these namespaces are special and don't have articles
 				 */
+				header( "X-Redirected-By: Our404Handler" );
 				header( sprintf( "Location: %s", $oTitle->getFullURL() ), true, 301 );
 				exit( 0 );
 
 			} else {
 				$oArticle = new Article( $oTitle );
 				if( $oArticle->exists() ) {
+					header( "X-Redirected-By: Our404Handler" );
 					header( sprintf( "Location: %s", $oArticle->mTitle->getFullURL() ), true, 301 );
 					exit( 0 );
 				}

--- a/includes/Article.php
+++ b/includes/Article.php
@@ -19,6 +19,7 @@
  *
  * //Wikia Change Start - helping PHP lint
  * @property Title mTitle
+ * @method exists
  * //Wikia Change End
  */
 class Article extends Page {


### PR DESCRIPTION
- add `X-Redirected-By` header (for debugging purposes)
- use TestCanonicalRedirect hook to avoid redirecting to localized NS_SPECIAL URL when requesting `Our404Handler` special page

@michalroszka 
