### PR TITLE
PLATFORM-292: fix how memcache_stats_keys stats are formatted

### DIFF
--- a/includes/wikia/transaction/Transaction.php
+++ b/includes/wikia/transaction/Transaction.php
@@ -143,6 +143,17 @@ class Transaction {
 	}
 
 	/**
+	 * Return required attribute
+	 *
+	 * @param $name string attribute name
+	 * @return mixed|null attribute value or null when not set
+	 */
+	public static function getAttribute($name) {
+		$attributes = self::getAttributes();
+		return isset( $attributes[$name] ) ? $attributes[$name] : null;
+	}
+
+	/**
 	 * Returns all events recorded during current transaction
 	 *
 	 * @return array

--- a/includes/wikia/transaction/TransactionTraceScribe.php
+++ b/includes/wikia/transaction/TransactionTraceScribe.php
@@ -72,7 +72,8 @@ class TransactionTraceScribe {
 
 		// send raw events with the minimal context
 		self::send(Transaction::getRawEvents(), [
-			Transaction::PSEUDO_PARAM_TYPE => Transaction::getType()
+			Transaction::PSEUDO_PARAM_TYPE => Transaction::getType(),
+			Transaction::PARAM_ENVIRONMENT => Transaction::getAttribute(Transaction::PARAM_ENVIRONMENT),
 		]);
 	}
 


### PR DESCRIPTION
`env` entry is required to save stats to a proper InfluxDB database.

Thanks @wladekb for spotting this :)

Fixes #5837
