### PR TITLE
only allow staff on preview/verify chat service

### DIFF
--- a/extensions/wikia/Chat2/Chat_setup.php
+++ b/extensions/wikia/Chat2/Chat_setup.php
@@ -35,7 +35,10 @@ $wgGroupPermissions['sysop']['chatadmin'] = true;
 
 $wgAvailableRights[] = 'chat';
 $wgGroupPermissions['*']['chat'] = false;
-$wgGroupPermissions['user']['chat'] = true;
+$wgGroupPermissions['staff']['chat'] = true;
+if ( $wgWikiaEnvironment == WIKIA_ENV_PROD ) {
+	$wgGroupPermissions['user']['chat'] = true;
+}
 
 $wgGroupPermissions['util']['chatfailover'] = true;
 


### PR DESCRIPTION
Preview/verify should definitely be locked down to staff only.  Only question: do we have any test bots that don't have staff permission?
