### PR TITLE
Replace Bucky with Weppy

### DIFF
--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -2002,7 +2002,7 @@ $config['bucky_js'] = array(
 	'type' => AssetsManager::TYPE_JS,
 	'skin' => [ 'oasis', 'venus' ],
 	'assets' => array(
-		'//extensions/wikia/Bucky/vendor/BuckyClient/bucky.js',
+		'//extensions/wikia/Bucky/vendor/Weppy/dist/weppy.js',
 		'//extensions/wikia/Bucky/js/bucky_init.js',
 		'//extensions/wikia/Bucky/js/bucky_resources_timing.js',
 		'//extensions/wikia/Bucky/js/bucky_metrics.js',

--- a/extensions/wikia/Bucky/Bucky.class.php
+++ b/extensions/wikia/Bucky/Bucky.class.php
@@ -9,7 +9,7 @@ class Bucky {
 	const BASE_URL = '//speed.wikia.net/__rum';
 
 	/**
-	 * Adds wgBuckyConfig global JS variable
+	 * Adds wgWeppyConfig global JS variable
 	 *
 	 * @param array $vars
 	 * @param OutputPage $out
@@ -28,10 +28,9 @@ class Bucky {
 				'host' => $url,
 				'sample' => $sample,
 				'aggregationInterval' => 1000,
-				'protocol' => 2,
 			);
 
-			$vars['wgBuckyConfig'] = $config;
+			$vars['wgWeppyConfig'] = $config;
 		}
 
 		return true;

--- a/extensions/wikia/Bucky/js/bucky_init.js
+++ b/extensions/wikia/Bucky/js/bucky_init.js
@@ -2,18 +2,25 @@
 (function (context) {
 	'use strict';
 
+	context.Bucky = context.Weppy;
+
 	if (context.define && context.define.amd) {
-		context.define('bucky', [], Bucky);
+		context.define('bucky', [], function() {
+			return context.Weppy;
+		});
+		context.define('weppy', [], function() {
+			return context.Weppy;
+		});
 	}
 
 	$(function () {
-		var config = $.extend({}, context.wgBuckyConfig, {
+		var config = $.extend({}, context.wgWeppyConfig, {
 			'context': context.wgTransactionContext
 		});
-		Bucky.setOptions(config);
+		Weppy.setOptions(config);
 		$(context).load(function () {
 			setTimeout(function () {
-				Bucky.sendPagePerformance(false);
+				Weppy.sendPagePerformance(false);
 			}, 0);
 		});
 	});

--- a/extensions/wikia/Bucky/vendor/Weppy/LICENSE
+++ b/extensions/wikia/Bucky/vendor/Weppy/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Wikia, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/extensions/wikia/Bucky/vendor/Weppy/README.md
+++ b/extensions/wikia/Bucky/vendor/Weppy/README.md
@@ -1,0 +1,245 @@
+Weppy
+=====
+
+Weppy is a client-side library for reporting performance data. It can automatically collect page load data
+using window.performance API and allows any other metric to be reported as well.
+
+Weppy is heavily inspired by [BuckyClient](https://github.com/HubSpot/BuckyClient). However it puts more focus into
+structure of the reported data, allows custom attributes to be reported with the measurement itself and supports
+sending the page context with all the measurements done on a page. See [comparison with Bucky](#comparison-with-bucky)
+for more details.
+
+Example
+-------
+
+You can get the following data reported to the server:
+```json
+{
+	"context": {
+		"url": "http://my.domain.com/article/Some_great_article",
+		"skin": "modern",
+		"user-agent": "Whatever User Agent the visitor has"
+	},
+	"data": {
+		"Lightbox.open": [
+			[ 0.24, { "image-count": 12 } ],
+			[ 0.12, { "image-count": 3 } ]
+		],
+		"pageview.fromuser.Testuser": [
+			[ 1 ]
+		]
+	}
+}
+```
+
+by using code like this:
+```html
+<script src="weppy.js"></script>
+<script type="text/javascript">
+```
+Set your configuration
+```javascript
+	Weppy.setOptions({
+		context: {
+			url: window.location.href.split('#')[0],
+			skin: window.myApp.skinName,
+			'user-agent': window.navigator.userAgent
+		}
+	});
+```
+Report a page view from a user. You could as well want to include it in the global context and specify it above.
+```javascript
+	// report page view from logger in user
+	Weppy.count('pageview.fromuser.'+window.myApp.userName);
+```
+Create a helper Weppy object so you don't need to repeat the measurement name prefix
+```javascript
+	// handle Lightbox metrics
+	var lightboxMetrics = Weppy('Lightbox');
+```
+Let's try to report how long it takes to open a lightbox. First try to do it manually:
+```javascript
+	var openTimer = lightboxMetrics.timer.start('open');
+	// do some ajax call
+	ajax_call(function(response) {
+		openTimer.stop({
+			'image-count': response.imagesCount
+		});
+	});
+```
+On the other hand you might leverage the helper function timer.time():
+```javascript
+	lightboxMetrics.timer.time('open',function(stopTimer) {
+		ajax_call(function(response) { // called with global scope as we didn't pass third argument to .timer.time()
+			stopTimer({
+				'image-count': response.imagesCount
+			});
+		});
+	});
+```
+And then when a user opens two lightboxes during session, first one with 12 images and second with 3 images we might 
+get the example data reported to server. For more features please refer to the next section [API](#api).
+```javascript
+</script>
+```
+
+API
+---
+
+Weppy API can be accessed by using:
+* global variable named `Weppy` or `window.Weppy` (defined with empty namespace and empty prefix)
+* an object returned by `.into()` or `.namespace()` bound to a specific namespace and prefix
+
+Weppy API consists of the following methods:
+
+### `Weppy`.setOptions( options )
+Update global configuration. See [options reference](#options-reference)
+
+### `Weppy`.into( path ) *or* `Weppy`( path )
+
+Create and return a new Weppy object bound to a prefix with appended `path` at the end. 
+
+### `Weppy`.namespace( namespace, path )
+Create and return a new Weppy object bound to a different `namespace` and with specified prefix `path`. Both
+arguments can be an empty string meaning either selecting a default namespace or empty prefix.
+
+### `Weppy`.count( name, value = 1, annotations = null )
+Add a new measurement `name` (type: "counter") with `value` and optional `annotations`.
+
+### `Weppy`.store( name, value = 1, annotations = null )
+Add a new measurement `name` (type: "gauge") with `value` and optional `annotations`.
+
+### `Weppy`.flush()
+Send all pending measurements.
+
+### `Weppy`.sendPagePerformance()
+Instruct Weppy to report all metrics available in window.performance API as soon as DOMContentLoaded event is fired.
+
+### `Weppy`.timer.start( name, annotations = null )
+Start a new timer `name` with optional `annotations`. Return `Timer` object for convenience.
+
+### `Weppy`.timer.stop( name, annotations = null )
+Stop a timer `name` and add a new measurement `name` (type: "timer"). Extend previously defined annotations 
+with `annotations`.
+
+### `Weppy`.timer.send( name, duration, annotations = null )
+Add a new measurement `name` (type: "timer") with `duration` and optional `annotations`.
+
+### `Weppy`.timer.annotate( name, annotations )
+Update annotations of currently running timer `name` with `annotations`.
+
+### `Weppy`.timer.mark( name, annotations = null )
+Add a new measurement `name` (type: "timer") with the time passed after `window.performance.navigationStart` with
+optional `annotations`.
+
+### `Weppy`.timer.time( name, action, scope, args, annotations = null )
+Call a function `action` with `scope` and arguments `args` prepended by a callback that should be called when the
+asynchronous operation finishes. The callback takes one optional parameter `annotations` that are appended if specified.
+When a callback gets called add a new measurement `name` with the time of the operation and optional `annotations`.
+
+### `Weppy`.timer.timeSync( name, action, scope, args, annotations = null )
+Call a function `action` with `scope` and `args`. Then add a new measurement `name` (type: "timer") with the time taken 
+to execute the function and optional `annotations`.
+
+### `Weppy`.timer.wrap( name, action, scope, annotations = null )
+Create and return a wrapper function that calls the function `action` with optional scope override with `scope`. 
+Arguments and return value are passed without change.
+Each time the function gets called add a new measurement `name` (type: "timer") with the time taken to execute
+the function and optional `annotations`.
+
+### `Timer`.annotate( annotations )
+Update annotations of given `Timer` with `annotations`.
+
+### `Timer`.stop( annotations = null )
+Stop the timer and optionally update `annotations`. Then add a new measurement with previously specified name 
+(type: "timer").
+
+Options reference
+-----------------
+
+### host
+Type: string (default: "/weppy")
+
+Absolute or relative base path for reporting data. Some automatic suffix is added, currently "/v3/store".
+
+### transport
+Type: "url" | "post" | callback (default: "url")
+
+Transport that should be used to report collected measurements. 
+See [transport options](#transport-options) explanation for more information.
+
+### active
+Type: boolean (default: true)
+
+Disables Weppy completely if `active` is set to *false*.
+
+### sample
+Type: number (default: 0.01 = 1%)
+
+Sampling rate in the range between 0 and 1. 0 is 0%, 0.1 is 10% and 1 is 100%.
+
+### aggregationInterval
+Type: number (default: 1000)
+
+When no new measurement is added within `aggregationInterval` ms all the previously collected data is sent to the server. 
+
+### maxInterval
+Type: number (default: 5000)
+
+Maximum age that the measurement could have before getting reported to the server.
+
+### decimalPrecision
+Type: number (default: 3)
+
+Time ang gauge measurements decimal precision.
+
+### page
+Type: string (default: 'index')
+
+Page name used to report page load performance data by `sendPagePerformance()`.
+
+### context
+Type: object (default: {})
+
+Page context that is reported along with any measurement.
+
+### debug
+Type: boolean | function (default: false)
+
+Debug control. Set to true to send debugging information to console using `window.console.log()`. You also may pass
+a function that will receive all the calls instead of `console.log`.
+
+Transport options
+-----------------
+
+Weppy uses "host" option (default: "/weppy") to find the base path on the server to report collected data to. Then
+it adds suffix "/vX/send" where X is replaced by protocol version. It always does a POST request.
+
+Next you need to choose a method for encoding the data using the "transport" option. You have two options right now:
+- "url" (default one) - puts the entire JSON data into a single URL parameter "p", example:
+  "/weppy/v3/send?p=ENCODED_JSON_DATA"
+- "post" - does a POST request and puts the JSON data into POST data.
+
+To be correctly precise you have the third option for processing collected metrics. If you pass a function
+as a "transport" option you can take over the entire data reporting process. The normal request is not made in such
+case and your function will be called every time Weppy would send a request. The single parameter will be passed
+to this function containing the collected data as a plain Javascript object (exactly as in the [example](#example)).
+
+Comparison with Bucky
+---------------------
+
+Weppy is definitely a browser-only library while Bucky can also run in node.js environment.
+
+Page load data are reported using different namespacing.
+
+Binding measurements to a specific prefix is done using `Bucky('Lightbox')` in BuckyClient while you need to call
+`Weppy.into('Lightbox')` in Weppy. There is also support for namespaces in Weppy using
+`Weppy.namespace('MyNamespace','myprefix')` that ends up reporting `MyNamespace::myprefix.measurementname'`.
+
+Features not present in Bucky:
+- global context
+- measurement annotations
+
+Features not supported by Weppy:
+- requests
+- timer.stopwatch()

--- a/extensions/wikia/Bucky/vendor/Weppy/bower.json
+++ b/extensions/wikia/Bucky/vendor/Weppy/bower.json
@@ -1,0 +1,14 @@
+{
+	"name": "weppy",
+	"version": "0.9.0",
+	"main": [
+		"/dist/weppy.amd.js",
+		"/dist/weppy.cjs.js",
+		"/dist/weppy.js",
+		"/dist/weppy..d.ts"
+	],
+	"ignore": [
+		"tests"
+	],
+	"license": "MIT"
+}

--- a/extensions/wikia/Bucky/vendor/Weppy/dist/weppy.amd.js
+++ b/extensions/wikia/Bucky/vendor/Weppy/dist/weppy.amd.js
@@ -1,0 +1,386 @@
+/// <reference path="../weppy.d.ts"/>
+define(["require", "exports"], function (require, exports) {
+    var WeppyImpl;
+    (function (WeppyImpl) {
+        var PROTOCOL_VERSION = 3, PATH_DELIMITER = '.', NAMESPACE_DELIMITER = '::', active = false, options = {
+            "host": '/weppy',
+            "transport": 'url',
+            "active": true,
+            "sample": 0.01,
+            "aggregationInterval": 1000,
+            "maxInterval": 5000,
+            "decimalPrecision": 3,
+            "page": 'index',
+            "context": {},
+            "debug": false
+        }, initTime = +(new Date), queue, aggregationTimeout, maxTimeout, sentPerformanceData, now = function () {
+            return window.performance && window.performance.now ? window.performance.now() : +(new Date);
+        }, log = function () {
+            if (options.debug)
+                if (typeof options.debug == 'function')
+                    options.debug.apply(window, arguments);
+                else
+                    window.console && window.console.log && window.console.log.apply ? window.console.log.apply(window.console, arguments) : void 0;
+        }, logError = function () {
+            window.console && window.console.error && window.console.error.apply && window.console.error.apply(window.console, arguments);
+        };
+        function round(num, precision) {
+            if (precision === void 0) { precision = options.decimalPrecision; }
+            return Math.round(num * Math.pow(10, precision)) / Math.pow(10, precision);
+        }
+        function buildPath(path, subpath, glue) {
+            if (glue === void 0) { glue = PATH_DELIMITER; }
+            return path + (path != '' && subpath != '' ? glue : '') + subpath;
+        }
+        function updateActive() {
+            active = options.active && Math.random() < options.sample;
+        }
+        function extend(first, second) {
+            if (first && second) {
+                for (var key in second) {
+                    if (second.hasOwnProperty(key)) {
+                        first[key] = second[key];
+                    }
+                }
+            }
+            return first || second;
+        }
+        function sortedJson(obj) {
+            var keys = Object.keys(obj).sort(), i, ret = {};
+            for (i = 0; i < keys.length; i++) {
+                ret[keys[i]] = obj[keys[i]];
+            }
+            return JSON.stringify(ret);
+        }
+        (function (MetricType) {
+            MetricType[MetricType["Counter"] = 0] = "Counter";
+            MetricType[MetricType["Gauge"] = 1] = "Gauge";
+            MetricType[MetricType["Timer"] = 2] = "Timer";
+        })(WeppyImpl.MetricType || (WeppyImpl.MetricType = {}));
+        var MetricType = WeppyImpl.MetricType;
+        var Queue = (function () {
+            function Queue() {
+                this.clear();
+            }
+            Queue.prototype.clear = function () {
+                this.all = {};
+                this._empty = true;
+            };
+            Queue.prototype.empty = function () {
+                return this._empty;
+            };
+            Queue.prototype.add = function (name, value, rollingAverage, annotations) {
+                var data = this.find(name, annotations);
+                if (rollingAverage) {
+                    data.count = data.count || 0;
+                    data.count++;
+                    data.value += (value - data.value) / data.count;
+                    data.rollingAverage = true;
+                }
+                else {
+                    data.value += value;
+                }
+                this._empty = false;
+            };
+            Queue.prototype.find = function (name, annotations) {
+                var serializedAnnotations = annotations ? sortedJson(annotations) : false, scope = this.all[name] = this.all[name] || {}, data;
+                if (serializedAnnotations) {
+                    scope = scope.annotated = scope.annotated || {};
+                    scope = scope[serializedAnnotations] = scope[serializedAnnotations] || {};
+                }
+                data = scope.data = scope.data || { value: 0 };
+                return data;
+            };
+            Queue.prototype.get_clear = function () {
+                var measurements = {};
+                function addMeasurement(name, data, annotations) {
+                    if (data) {
+                        var value = data.value;
+                        if (data.rollingAverage) {
+                            value = round(value);
+                        }
+                        var measurement = [value];
+                        if (annotations) {
+                            measurement.push(annotations);
+                        }
+                        measurements[name].push(measurement);
+                    }
+                }
+                var names = Object.keys(this.all), data, annotated, i, k;
+                for (i = 0; i < names.length; i++) {
+                    measurements[names[i]] = [];
+                    data = this.all[names[i]].data;
+                    annotated = this.all[names[i]].annotated;
+                    if (data) {
+                        addMeasurement(names[i], data, null);
+                    }
+                    if (annotated) {
+                        for (k in annotated) {
+                            if (annotated.hasOwnProperty(k)) {
+                                addMeasurement(names[i], annotated[k].data, JSON.parse(k));
+                            }
+                        }
+                    }
+                }
+                this.clear();
+                return measurements;
+            };
+            return Queue;
+        })();
+        queue = new Queue();
+        function enqueue(type, name, value, annotations) {
+            if (!active) {
+                return;
+            }
+            var rollingAverage = type != 0 /* Counter */;
+            queue.add(name, value, rollingAverage, annotations);
+            scheduleSending();
+        }
+        function scheduleSending() {
+            clearTimeout(aggregationTimeout);
+            aggregationTimeout = setTimeout(sendQueue, options.aggregationInterval);
+            if (!maxTimeout) {
+                maxTimeout = setTimeout(sendQueue, options.maxInterval);
+            }
+        }
+        function clearSchedule() {
+            clearTimeout(aggregationTimeout);
+            clearTimeout(maxTimeout);
+            aggregationTimeout = null;
+            maxTimeout = null;
+        }
+        function sendQueue() {
+            clearSchedule();
+            if (queue.empty()) {
+                return;
+            }
+            if (!active) {
+                log("Weppy: would send queue but inactive");
+                return;
+            }
+            if (!window.JSON || !JSON.stringify) {
+                queue.clear();
+                return;
+            }
+            var all_measurements = queue.get_clear();
+            var all_data = {
+                context: options.context,
+                data: all_measurements
+            };
+            log('Weppy: sending', all_data);
+            sendData(all_data);
+        }
+        function sendData(data) {
+            if (typeof options.transport == 'function') {
+                options.transport(data);
+                return;
+            }
+            var url = options.host + '/v' + PROTOCOL_VERSION + '/send';
+            if (options.transport == 'url') {
+                url += '?p=' + encodeURIComponent(JSON.stringify(data));
+                sendRequest(url, null);
+            }
+            else if (options.transport == 'post') {
+                sendRequest(url, JSON.stringify(data));
+            }
+        }
+        function sendRequest(url, data) {
+            var corsSupport = window.XMLHttpRequest && (XMLHttpRequest['defake'] || (new XMLHttpRequest()).withCredentials);
+            var sameOrigin = true;
+            var match = /^(https?:\/\/[^\/]+)/i.exec(url);
+            if (match && match[1] != document.location.protocol + '//' + document.location.host) {
+                sameOrigin = false;
+            }
+            var req;
+            if (!sameOrigin && !corsSupport && window.XDomainRequest) {
+                req = new XDomainRequest();
+            }
+            else {
+                req = new XMLHttpRequest();
+            }
+            var contentType = data == null ? 'text/plain' : 'application/json';
+            req.weppy = req.bucky = { track: false };
+            req.open('POST', url, true);
+            req.setRequestHeader('Content-Type', contentType);
+            req.send(data);
+            return req;
+        }
+        var Namespace = (function () {
+            function Namespace(_root, _path) {
+                this._root = _root;
+                this._path = _path;
+                this.timer = new NamespaceTimer(this);
+            }
+            Namespace.prototype.namespace = function (root, path) {
+                return new Namespace(root, path || '');
+            };
+            Namespace.prototype.into = function (subpath) {
+                return new Namespace(this._root, buildPath(this._path, subpath));
+            };
+            Namespace.prototype.key = function (name) {
+                return buildPath(this._root, buildPath(this._path, name), NAMESPACE_DELIMITER);
+            };
+            Namespace.prototype.send = function (type, name, value, annotations) {
+                name = this.key(name);
+                enqueue(type, name, value, annotations);
+                log('Weppy: queued', {
+                    type: MetricType[type],
+                    name: name,
+                    value: value,
+                    annotations: annotations
+                });
+            };
+            Namespace.prototype.count = function (name, value, annotations) {
+                if (value === void 0) { value = 1; }
+                this.send(0 /* Counter */, name, value, annotations);
+            };
+            Namespace.prototype.store = function (name, value, annotations) {
+                this.send(1 /* Gauge */, name, value, annotations);
+            };
+            Namespace.prototype.flush = function () {
+                sendQueue();
+            };
+            Namespace.prototype.setOptions = function (opts) {
+                var key;
+                for (key in opts) {
+                    if (opts.hasOwnProperty(key)) {
+                        options[key] = opts[key];
+                    }
+                }
+                if ('sample' in opts || 'active' in opts) {
+                    updateActive();
+                }
+            };
+            Namespace.prototype.sendPagePerformance = function () {
+                if (!window.performance || !window.performance.timing || sentPerformanceData) {
+                    return false;
+                }
+                var self = this, readyState = document.readyState;
+                if (readyState == 'uninitialized' || readyState == 'loading') {
+                    if (document.addEventListener) {
+                        document.addEventListener("DOMContentLoaded", function () {
+                            self.sendPagePerformance();
+                        }, false);
+                    }
+                    return false;
+                }
+                sentPerformanceData = true;
+                var timing = window.performance.timing, start = timing.navigationStart, key, time, data = {};
+                for (key in timing) {
+                    time = timing[key];
+                    if (time && typeof time == 'number') {
+                        data[key] = (time - start);
+                    }
+                }
+                delete data['navigationStart'];
+                var name = options.page;
+                self.namespace('PAGELOAD').timer.send(name, start, data);
+                return true;
+            };
+            return Namespace;
+        })();
+        WeppyImpl.Namespace = Namespace;
+        var NamespaceTimer = (function () {
+            function NamespaceTimer(_namespace) {
+                this._namespace = _namespace;
+                this.PARTIALS = {};
+            }
+            NamespaceTimer.prototype.send = function (name, duration, annotations) {
+                this._namespace.send(2 /* Timer */, name, duration, annotations);
+            };
+            NamespaceTimer.prototype.start = function (name, annotations) {
+                this.PARTIALS[name] = [now(), annotations];
+                return new Timer(this, name);
+            };
+            NamespaceTimer.prototype.stop = function (name, annotations) {
+                if (!this.PARTIALS[name]) {
+                    logError("Timer " + name + " ended without having been started");
+                    return;
+                }
+                var duration = now() - this.PARTIALS[name][0];
+                annotations = extend(annotations, this.PARTIALS[name][1]);
+                this.PARTIALS[name] = false;
+                this.send(name, duration, annotations);
+            };
+            NamespaceTimer.prototype.annotate = function (name, annotations) {
+                if (!this.PARTIALS[name]) {
+                    logError("Timer " + name + " received annotation without having been started");
+                    return;
+                }
+                this.PARTIALS[name][1] = annotations;
+            };
+            NamespaceTimer.prototype.time = function (name, action, scope, args, annotations) {
+                this.start(name, annotations);
+                var self = this, done = function (annotations) {
+                    self.stop(name, annotations);
+                };
+                args = args ? args.slice(0) : [];
+                args.splice(0, 0, done);
+                return action.apply(scope, args);
+            };
+            NamespaceTimer.prototype.timeSync = function (name, action, scope, args, annotations) {
+                this.start(name, annotations);
+                var ret = action.apply(scope, args);
+                this.stop(name);
+                return ret;
+            };
+            NamespaceTimer.prototype.wrap = function (name, action, scope, annotations) {
+                var _this = this;
+                var self = this;
+                return function () {
+                    return self.timeSync(name, action, scope || _this, arguments, annotations);
+                };
+            };
+            NamespaceTimer.prototype.mark = function (name, annotations) {
+                this.send(name, now() - this.navigationStart(), annotations);
+            };
+            NamespaceTimer.prototype.navigationStart = function () {
+                return (window.performance && window.performance.timing && window.performance.timing.navigationStart) || initTime;
+            };
+            return NamespaceTimer;
+        })();
+        WeppyImpl.NamespaceTimer = NamespaceTimer;
+        var Timer = (function () {
+            function Timer(_timer, name) {
+                this._timer = _timer;
+                this.name = name;
+            }
+            Timer.prototype.stop = function (annotations) {
+                this._timer.stop(this.name, annotations);
+            };
+            Timer.prototype.annotate = function (annotations) {
+                this._timer.annotate(this.name, annotations);
+            };
+            return Timer;
+        })();
+        WeppyImpl.Timer = Timer;
+        function bindNamespaceFunction(fn, scope, callWrapNamespace) {
+            return callWrapNamespace ? function () {
+                return wrapNamespaceObject(fn.apply(scope, arguments));
+            } : function () {
+                return fn.apply(scope, arguments);
+            };
+        }
+        function wrapNamespaceObject(obj) {
+            var weppyObject = (function (subpath) {
+                return subpath ? weppyObject.into(subpath) : weppyObject;
+            }), k;
+            for (k in obj) {
+                if (typeof obj[k] == 'function') {
+                    weppyObject[k] = bindNamespaceFunction(obj[k], obj, k == 'into' || k == 'namespace');
+                }
+                else {
+                    weppyObject[k] = obj[k];
+                }
+            }
+            return weppyObject;
+        }
+        function getRootObject() {
+            return wrapNamespaceObject(new Namespace('', ''));
+        }
+        WeppyImpl.getRootObject = getRootObject;
+        updateActive();
+    })(WeppyImpl || (WeppyImpl = {}));
+    var Weppy = WeppyImpl.getRootObject();
+    return Weppy;
+});

--- a/extensions/wikia/Bucky/vendor/Weppy/dist/weppy.cjs.js
+++ b/extensions/wikia/Bucky/vendor/Weppy/dist/weppy.cjs.js
@@ -1,0 +1,384 @@
+/// <reference path="../weppy.d.ts"/>
+var WeppyImpl;
+(function (WeppyImpl) {
+    var PROTOCOL_VERSION = 3, PATH_DELIMITER = '.', NAMESPACE_DELIMITER = '::', active = false, options = {
+        "host": '/weppy',
+        "transport": 'url',
+        "active": true,
+        "sample": 0.01,
+        "aggregationInterval": 1000,
+        "maxInterval": 5000,
+        "decimalPrecision": 3,
+        "page": 'index',
+        "context": {},
+        "debug": false
+    }, initTime = +(new Date), queue, aggregationTimeout, maxTimeout, sentPerformanceData, now = function () {
+        return window.performance && window.performance.now ? window.performance.now() : +(new Date);
+    }, log = function () {
+        if (options.debug)
+            if (typeof options.debug == 'function')
+                options.debug.apply(window, arguments);
+            else
+                window.console && window.console.log && window.console.log.apply ? window.console.log.apply(window.console, arguments) : void 0;
+    }, logError = function () {
+        window.console && window.console.error && window.console.error.apply && window.console.error.apply(window.console, arguments);
+    };
+    function round(num, precision) {
+        if (precision === void 0) { precision = options.decimalPrecision; }
+        return Math.round(num * Math.pow(10, precision)) / Math.pow(10, precision);
+    }
+    function buildPath(path, subpath, glue) {
+        if (glue === void 0) { glue = PATH_DELIMITER; }
+        return path + (path != '' && subpath != '' ? glue : '') + subpath;
+    }
+    function updateActive() {
+        active = options.active && Math.random() < options.sample;
+    }
+    function extend(first, second) {
+        if (first && second) {
+            for (var key in second) {
+                if (second.hasOwnProperty(key)) {
+                    first[key] = second[key];
+                }
+            }
+        }
+        return first || second;
+    }
+    function sortedJson(obj) {
+        var keys = Object.keys(obj).sort(), i, ret = {};
+        for (i = 0; i < keys.length; i++) {
+            ret[keys[i]] = obj[keys[i]];
+        }
+        return JSON.stringify(ret);
+    }
+    (function (MetricType) {
+        MetricType[MetricType["Counter"] = 0] = "Counter";
+        MetricType[MetricType["Gauge"] = 1] = "Gauge";
+        MetricType[MetricType["Timer"] = 2] = "Timer";
+    })(WeppyImpl.MetricType || (WeppyImpl.MetricType = {}));
+    var MetricType = WeppyImpl.MetricType;
+    var Queue = (function () {
+        function Queue() {
+            this.clear();
+        }
+        Queue.prototype.clear = function () {
+            this.all = {};
+            this._empty = true;
+        };
+        Queue.prototype.empty = function () {
+            return this._empty;
+        };
+        Queue.prototype.add = function (name, value, rollingAverage, annotations) {
+            var data = this.find(name, annotations);
+            if (rollingAverage) {
+                data.count = data.count || 0;
+                data.count++;
+                data.value += (value - data.value) / data.count;
+                data.rollingAverage = true;
+            }
+            else {
+                data.value += value;
+            }
+            this._empty = false;
+        };
+        Queue.prototype.find = function (name, annotations) {
+            var serializedAnnotations = annotations ? sortedJson(annotations) : false, scope = this.all[name] = this.all[name] || {}, data;
+            if (serializedAnnotations) {
+                scope = scope.annotated = scope.annotated || {};
+                scope = scope[serializedAnnotations] = scope[serializedAnnotations] || {};
+            }
+            data = scope.data = scope.data || { value: 0 };
+            return data;
+        };
+        Queue.prototype.get_clear = function () {
+            var measurements = {};
+            function addMeasurement(name, data, annotations) {
+                if (data) {
+                    var value = data.value;
+                    if (data.rollingAverage) {
+                        value = round(value);
+                    }
+                    var measurement = [value];
+                    if (annotations) {
+                        measurement.push(annotations);
+                    }
+                    measurements[name].push(measurement);
+                }
+            }
+            var names = Object.keys(this.all), data, annotated, i, k;
+            for (i = 0; i < names.length; i++) {
+                measurements[names[i]] = [];
+                data = this.all[names[i]].data;
+                annotated = this.all[names[i]].annotated;
+                if (data) {
+                    addMeasurement(names[i], data, null);
+                }
+                if (annotated) {
+                    for (k in annotated) {
+                        if (annotated.hasOwnProperty(k)) {
+                            addMeasurement(names[i], annotated[k].data, JSON.parse(k));
+                        }
+                    }
+                }
+            }
+            this.clear();
+            return measurements;
+        };
+        return Queue;
+    })();
+    queue = new Queue();
+    function enqueue(type, name, value, annotations) {
+        if (!active) {
+            return;
+        }
+        var rollingAverage = type != 0 /* Counter */;
+        queue.add(name, value, rollingAverage, annotations);
+        scheduleSending();
+    }
+    function scheduleSending() {
+        clearTimeout(aggregationTimeout);
+        aggregationTimeout = setTimeout(sendQueue, options.aggregationInterval);
+        if (!maxTimeout) {
+            maxTimeout = setTimeout(sendQueue, options.maxInterval);
+        }
+    }
+    function clearSchedule() {
+        clearTimeout(aggregationTimeout);
+        clearTimeout(maxTimeout);
+        aggregationTimeout = null;
+        maxTimeout = null;
+    }
+    function sendQueue() {
+        clearSchedule();
+        if (queue.empty()) {
+            return;
+        }
+        if (!active) {
+            log("Weppy: would send queue but inactive");
+            return;
+        }
+        if (!window.JSON || !JSON.stringify) {
+            queue.clear();
+            return;
+        }
+        var all_measurements = queue.get_clear();
+        var all_data = {
+            context: options.context,
+            data: all_measurements
+        };
+        log('Weppy: sending', all_data);
+        sendData(all_data);
+    }
+    function sendData(data) {
+        if (typeof options.transport == 'function') {
+            options.transport(data);
+            return;
+        }
+        var url = options.host + '/v' + PROTOCOL_VERSION + '/send';
+        if (options.transport == 'url') {
+            url += '?p=' + encodeURIComponent(JSON.stringify(data));
+            sendRequest(url, null);
+        }
+        else if (options.transport == 'post') {
+            sendRequest(url, JSON.stringify(data));
+        }
+    }
+    function sendRequest(url, data) {
+        var corsSupport = window.XMLHttpRequest && (XMLHttpRequest['defake'] || (new XMLHttpRequest()).withCredentials);
+        var sameOrigin = true;
+        var match = /^(https?:\/\/[^\/]+)/i.exec(url);
+        if (match && match[1] != document.location.protocol + '//' + document.location.host) {
+            sameOrigin = false;
+        }
+        var req;
+        if (!sameOrigin && !corsSupport && window.XDomainRequest) {
+            req = new XDomainRequest();
+        }
+        else {
+            req = new XMLHttpRequest();
+        }
+        var contentType = data == null ? 'text/plain' : 'application/json';
+        req.weppy = req.bucky = { track: false };
+        req.open('POST', url, true);
+        req.setRequestHeader('Content-Type', contentType);
+        req.send(data);
+        return req;
+    }
+    var Namespace = (function () {
+        function Namespace(_root, _path) {
+            this._root = _root;
+            this._path = _path;
+            this.timer = new NamespaceTimer(this);
+        }
+        Namespace.prototype.namespace = function (root, path) {
+            return new Namespace(root, path || '');
+        };
+        Namespace.prototype.into = function (subpath) {
+            return new Namespace(this._root, buildPath(this._path, subpath));
+        };
+        Namespace.prototype.key = function (name) {
+            return buildPath(this._root, buildPath(this._path, name), NAMESPACE_DELIMITER);
+        };
+        Namespace.prototype.send = function (type, name, value, annotations) {
+            name = this.key(name);
+            enqueue(type, name, value, annotations);
+            log('Weppy: queued', {
+                type: MetricType[type],
+                name: name,
+                value: value,
+                annotations: annotations
+            });
+        };
+        Namespace.prototype.count = function (name, value, annotations) {
+            if (value === void 0) { value = 1; }
+            this.send(0 /* Counter */, name, value, annotations);
+        };
+        Namespace.prototype.store = function (name, value, annotations) {
+            this.send(1 /* Gauge */, name, value, annotations);
+        };
+        Namespace.prototype.flush = function () {
+            sendQueue();
+        };
+        Namespace.prototype.setOptions = function (opts) {
+            var key;
+            for (key in opts) {
+                if (opts.hasOwnProperty(key)) {
+                    options[key] = opts[key];
+                }
+            }
+            if ('sample' in opts || 'active' in opts) {
+                updateActive();
+            }
+        };
+        Namespace.prototype.sendPagePerformance = function () {
+            if (!window.performance || !window.performance.timing || sentPerformanceData) {
+                return false;
+            }
+            var self = this, readyState = document.readyState;
+            if (readyState == 'uninitialized' || readyState == 'loading') {
+                if (document.addEventListener) {
+                    document.addEventListener("DOMContentLoaded", function () {
+                        self.sendPagePerformance();
+                    }, false);
+                }
+                return false;
+            }
+            sentPerformanceData = true;
+            var timing = window.performance.timing, start = timing.navigationStart, key, time, data = {};
+            for (key in timing) {
+                time = timing[key];
+                if (time && typeof time == 'number') {
+                    data[key] = (time - start);
+                }
+            }
+            delete data['navigationStart'];
+            var name = options.page;
+            self.namespace('PAGELOAD').timer.send(name, start, data);
+            return true;
+        };
+        return Namespace;
+    })();
+    WeppyImpl.Namespace = Namespace;
+    var NamespaceTimer = (function () {
+        function NamespaceTimer(_namespace) {
+            this._namespace = _namespace;
+            this.PARTIALS = {};
+        }
+        NamespaceTimer.prototype.send = function (name, duration, annotations) {
+            this._namespace.send(2 /* Timer */, name, duration, annotations);
+        };
+        NamespaceTimer.prototype.start = function (name, annotations) {
+            this.PARTIALS[name] = [now(), annotations];
+            return new Timer(this, name);
+        };
+        NamespaceTimer.prototype.stop = function (name, annotations) {
+            if (!this.PARTIALS[name]) {
+                logError("Timer " + name + " ended without having been started");
+                return;
+            }
+            var duration = now() - this.PARTIALS[name][0];
+            annotations = extend(annotations, this.PARTIALS[name][1]);
+            this.PARTIALS[name] = false;
+            this.send(name, duration, annotations);
+        };
+        NamespaceTimer.prototype.annotate = function (name, annotations) {
+            if (!this.PARTIALS[name]) {
+                logError("Timer " + name + " received annotation without having been started");
+                return;
+            }
+            this.PARTIALS[name][1] = annotations;
+        };
+        NamespaceTimer.prototype.time = function (name, action, scope, args, annotations) {
+            this.start(name, annotations);
+            var self = this, done = function (annotations) {
+                self.stop(name, annotations);
+            };
+            args = args ? args.slice(0) : [];
+            args.splice(0, 0, done);
+            return action.apply(scope, args);
+        };
+        NamespaceTimer.prototype.timeSync = function (name, action, scope, args, annotations) {
+            this.start(name, annotations);
+            var ret = action.apply(scope, args);
+            this.stop(name);
+            return ret;
+        };
+        NamespaceTimer.prototype.wrap = function (name, action, scope, annotations) {
+            var _this = this;
+            var self = this;
+            return function () {
+                return self.timeSync(name, action, scope || _this, arguments, annotations);
+            };
+        };
+        NamespaceTimer.prototype.mark = function (name, annotations) {
+            this.send(name, now() - this.navigationStart(), annotations);
+        };
+        NamespaceTimer.prototype.navigationStart = function () {
+            return (window.performance && window.performance.timing && window.performance.timing.navigationStart) || initTime;
+        };
+        return NamespaceTimer;
+    })();
+    WeppyImpl.NamespaceTimer = NamespaceTimer;
+    var Timer = (function () {
+        function Timer(_timer, name) {
+            this._timer = _timer;
+            this.name = name;
+        }
+        Timer.prototype.stop = function (annotations) {
+            this._timer.stop(this.name, annotations);
+        };
+        Timer.prototype.annotate = function (annotations) {
+            this._timer.annotate(this.name, annotations);
+        };
+        return Timer;
+    })();
+    WeppyImpl.Timer = Timer;
+    function bindNamespaceFunction(fn, scope, callWrapNamespace) {
+        return callWrapNamespace ? function () {
+            return wrapNamespaceObject(fn.apply(scope, arguments));
+        } : function () {
+            return fn.apply(scope, arguments);
+        };
+    }
+    function wrapNamespaceObject(obj) {
+        var weppyObject = (function (subpath) {
+            return subpath ? weppyObject.into(subpath) : weppyObject;
+        }), k;
+        for (k in obj) {
+            if (typeof obj[k] == 'function') {
+                weppyObject[k] = bindNamespaceFunction(obj[k], obj, k == 'into' || k == 'namespace');
+            }
+            else {
+                weppyObject[k] = obj[k];
+            }
+        }
+        return weppyObject;
+    }
+    function getRootObject() {
+        return wrapNamespaceObject(new Namespace('', ''));
+    }
+    WeppyImpl.getRootObject = getRootObject;
+    updateActive();
+})(WeppyImpl || (WeppyImpl = {}));
+var Weppy = WeppyImpl.getRootObject();
+module.exports = Weppy;

--- a/extensions/wikia/Bucky/vendor/Weppy/dist/weppy.d.ts
+++ b/extensions/wikia/Bucky/vendor/Weppy/dist/weppy.d.ts
@@ -1,0 +1,53 @@
+interface WeppyObject extends WeppyNamespace {
+	(subpath:string): WeppyNamespace;
+}
+
+interface WeppyNamespace {
+	timer: WeppyNamespaceTimer;
+	namespace(root:string, path?:string): WeppyNamespace;
+	into(subpath:string): WeppyNamespace;
+	count(name:string, value?:number, annotations?:WeppyContext): void;
+	store(name:string, value?:number, annotations?:WeppyContext): void;
+	flush(): void;
+	setOptions(options:WeppySettings): void;
+	sendPagePerformance(): boolean;
+}
+
+interface WeppyNamespaceTimer {
+	send(name:string, duration:number, annotations?:WeppyContext): void;
+	start(name:string, annotations?:WeppyContext): WeppyTimer;
+	stop(name:string, annotations?:WeppyContext): void;
+	annotate(name:string, annotations:WeppyContext): void;
+	time(name:string, action:any, scope:any, args:any, annotations?:WeppyContext): any;
+	timeSync(name:string, action:any, scope:any, args:any, annotations?:WeppyContext): any;
+	wrap(name:string, action:any, scope:any, annotations?:WeppyContext): () => any;
+	mark(name:string, annotations?:any): void;
+}
+
+interface WeppyTimer {
+	stop(annotations?:WeppyContext): void;
+	annotate(annotations:WeppyContext): void;
+}
+
+interface WeppyContext {
+	[s:string]: any;
+}
+
+interface WeppySettings {
+	host?: string;
+	transport?: any;
+	active?: boolean;
+	sample?: number;
+	aggregationInterval?: number;
+	maxInterval?: number;
+	decimalPrecision?: number;
+	page?: string;
+	context?: {};
+	debug?: any; // boolean | function
+}
+
+interface Window {
+	Weppy: WeppyNamespace;
+}
+
+declare var Weppy:WeppyNamespace;

--- a/extensions/wikia/Bucky/vendor/Weppy/dist/weppy.d.ts
+++ b/extensions/wikia/Bucky/vendor/Weppy/dist/weppy.d.ts
@@ -1,32 +1,32 @@
 interface WeppyObject extends WeppyNamespace {
-	(subpath:string): WeppyNamespace;
+	(subpath: string): WeppyNamespace;
 }
 
 interface WeppyNamespace {
 	timer: WeppyNamespaceTimer;
-	namespace(root:string, path?:string): WeppyNamespace;
-	into(subpath:string): WeppyNamespace;
-	count(name:string, value?:number, annotations?:WeppyContext): void;
-	store(name:string, value?:number, annotations?:WeppyContext): void;
+	namespace(root: string, path?: string): WeppyNamespace;
+	into(subpath: string): WeppyNamespace;
+	count(name: string, value?: number, annotations?: WeppyContext): void;
+	store(name: string, value?: number, annotations?: WeppyContext): void;
 	flush(): void;
-	setOptions(options:WeppySettings): void;
+	setOptions(options: WeppySettings): void;
 	sendPagePerformance(): boolean;
 }
 
 interface WeppyNamespaceTimer {
-	send(name:string, duration:number, annotations?:WeppyContext): void;
-	start(name:string, annotations?:WeppyContext): WeppyTimer;
-	stop(name:string, annotations?:WeppyContext): void;
-	annotate(name:string, annotations:WeppyContext): void;
-	time(name:string, action:any, scope:any, args:any, annotations?:WeppyContext): any;
-	timeSync(name:string, action:any, scope:any, args:any, annotations?:WeppyContext): any;
-	wrap(name:string, action:any, scope:any, annotations?:WeppyContext): () => any;
-	mark(name:string, annotations?:any): void;
+	send(name: string, duration: number, annotations?: WeppyContext): void;
+	start(name: string, annotations?: WeppyContext): WeppyTimer;
+	stop(name: string, annotations?: WeppyContext): void;
+	annotate(name: string, annotations: WeppyContext): void;
+	time(name: string, action: any, scope: any, args: any, annotations?: WeppyContext): any;
+	timeSync(name: string, action: any, scope: any, args: any, annotations?: WeppyContext): any;
+	wrap(name: string, action: any, scope: any, annotations?: WeppyContext): () => any;
+	mark(name: string, annotations?: any): void;
 }
 
 interface WeppyTimer {
-	stop(annotations?:WeppyContext): void;
-	annotate(annotations:WeppyContext): void;
+	stop(annotations?: WeppyContext): void;
+	annotate(annotations: WeppyContext): void;
 }
 
 interface WeppyContext {
@@ -50,4 +50,4 @@ interface Window {
 	Weppy: WeppyNamespace;
 }
 
-declare var Weppy:WeppyNamespace;
+declare var Weppy: WeppyNamespace;

--- a/extensions/wikia/Bucky/vendor/Weppy/dist/weppy.js
+++ b/extensions/wikia/Bucky/vendor/Weppy/dist/weppy.js
@@ -1,0 +1,383 @@
+/// <reference path="../weppy.d.ts"/>
+var WeppyImpl;
+(function (WeppyImpl) {
+    var PROTOCOL_VERSION = 3, PATH_DELIMITER = '.', NAMESPACE_DELIMITER = '::', active = false, options = {
+        "host": '/weppy',
+        "transport": 'url',
+        "active": true,
+        "sample": 0.01,
+        "aggregationInterval": 1000,
+        "maxInterval": 5000,
+        "decimalPrecision": 3,
+        "page": 'index',
+        "context": {},
+        "debug": false
+    }, initTime = +(new Date), queue, aggregationTimeout, maxTimeout, sentPerformanceData, now = function () {
+        return window.performance && window.performance.now ? window.performance.now() : +(new Date);
+    }, log = function () {
+        if (options.debug)
+            if (typeof options.debug == 'function')
+                options.debug.apply(window, arguments);
+            else
+                window.console && window.console.log && window.console.log.apply ? window.console.log.apply(window.console, arguments) : void 0;
+    }, logError = function () {
+        window.console && window.console.error && window.console.error.apply && window.console.error.apply(window.console, arguments);
+    };
+    function round(num, precision) {
+        if (precision === void 0) { precision = options.decimalPrecision; }
+        return Math.round(num * Math.pow(10, precision)) / Math.pow(10, precision);
+    }
+    function buildPath(path, subpath, glue) {
+        if (glue === void 0) { glue = PATH_DELIMITER; }
+        return path + (path != '' && subpath != '' ? glue : '') + subpath;
+    }
+    function updateActive() {
+        active = options.active && Math.random() < options.sample;
+    }
+    function extend(first, second) {
+        if (first && second) {
+            for (var key in second) {
+                if (second.hasOwnProperty(key)) {
+                    first[key] = second[key];
+                }
+            }
+        }
+        return first || second;
+    }
+    function sortedJson(obj) {
+        var keys = Object.keys(obj).sort(), i, ret = {};
+        for (i = 0; i < keys.length; i++) {
+            ret[keys[i]] = obj[keys[i]];
+        }
+        return JSON.stringify(ret);
+    }
+    (function (MetricType) {
+        MetricType[MetricType["Counter"] = 0] = "Counter";
+        MetricType[MetricType["Gauge"] = 1] = "Gauge";
+        MetricType[MetricType["Timer"] = 2] = "Timer";
+    })(WeppyImpl.MetricType || (WeppyImpl.MetricType = {}));
+    var MetricType = WeppyImpl.MetricType;
+    var Queue = (function () {
+        function Queue() {
+            this.clear();
+        }
+        Queue.prototype.clear = function () {
+            this.all = {};
+            this._empty = true;
+        };
+        Queue.prototype.empty = function () {
+            return this._empty;
+        };
+        Queue.prototype.add = function (name, value, rollingAverage, annotations) {
+            var data = this.find(name, annotations);
+            if (rollingAverage) {
+                data.count = data.count || 0;
+                data.count++;
+                data.value += (value - data.value) / data.count;
+                data.rollingAverage = true;
+            }
+            else {
+                data.value += value;
+            }
+            this._empty = false;
+        };
+        Queue.prototype.find = function (name, annotations) {
+            var serializedAnnotations = annotations ? sortedJson(annotations) : false, scope = this.all[name] = this.all[name] || {}, data;
+            if (serializedAnnotations) {
+                scope = scope.annotated = scope.annotated || {};
+                scope = scope[serializedAnnotations] = scope[serializedAnnotations] || {};
+            }
+            data = scope.data = scope.data || { value: 0 };
+            return data;
+        };
+        Queue.prototype.get_clear = function () {
+            var measurements = {};
+            function addMeasurement(name, data, annotations) {
+                if (data) {
+                    var value = data.value;
+                    if (data.rollingAverage) {
+                        value = round(value);
+                    }
+                    var measurement = [value];
+                    if (annotations) {
+                        measurement.push(annotations);
+                    }
+                    measurements[name].push(measurement);
+                }
+            }
+            var names = Object.keys(this.all), data, annotated, i, k;
+            for (i = 0; i < names.length; i++) {
+                measurements[names[i]] = [];
+                data = this.all[names[i]].data;
+                annotated = this.all[names[i]].annotated;
+                if (data) {
+                    addMeasurement(names[i], data, null);
+                }
+                if (annotated) {
+                    for (k in annotated) {
+                        if (annotated.hasOwnProperty(k)) {
+                            addMeasurement(names[i], annotated[k].data, JSON.parse(k));
+                        }
+                    }
+                }
+            }
+            this.clear();
+            return measurements;
+        };
+        return Queue;
+    })();
+    queue = new Queue();
+    function enqueue(type, name, value, annotations) {
+        if (!active) {
+            return;
+        }
+        var rollingAverage = type != 0 /* Counter */;
+        queue.add(name, value, rollingAverage, annotations);
+        scheduleSending();
+    }
+    function scheduleSending() {
+        clearTimeout(aggregationTimeout);
+        aggregationTimeout = setTimeout(sendQueue, options.aggregationInterval);
+        if (!maxTimeout) {
+            maxTimeout = setTimeout(sendQueue, options.maxInterval);
+        }
+    }
+    function clearSchedule() {
+        clearTimeout(aggregationTimeout);
+        clearTimeout(maxTimeout);
+        aggregationTimeout = null;
+        maxTimeout = null;
+    }
+    function sendQueue() {
+        clearSchedule();
+        if (queue.empty()) {
+            return;
+        }
+        if (!active) {
+            log("Weppy: would send queue but inactive");
+            return;
+        }
+        if (!window.JSON || !JSON.stringify) {
+            queue.clear();
+            return;
+        }
+        var all_measurements = queue.get_clear();
+        var all_data = {
+            context: options.context,
+            data: all_measurements
+        };
+        log('Weppy: sending', all_data);
+        sendData(all_data);
+    }
+    function sendData(data) {
+        if (typeof options.transport == 'function') {
+            options.transport(data);
+            return;
+        }
+        var url = options.host + '/v' + PROTOCOL_VERSION + '/send';
+        if (options.transport == 'url') {
+            url += '?p=' + encodeURIComponent(JSON.stringify(data));
+            sendRequest(url, null);
+        }
+        else if (options.transport == 'post') {
+            sendRequest(url, JSON.stringify(data));
+        }
+    }
+    function sendRequest(url, data) {
+        var corsSupport = window.XMLHttpRequest && (XMLHttpRequest['defake'] || (new XMLHttpRequest()).withCredentials);
+        var sameOrigin = true;
+        var match = /^(https?:\/\/[^\/]+)/i.exec(url);
+        if (match && match[1] != document.location.protocol + '//' + document.location.host) {
+            sameOrigin = false;
+        }
+        var req;
+        if (!sameOrigin && !corsSupport && window.XDomainRequest) {
+            req = new XDomainRequest();
+        }
+        else {
+            req = new XMLHttpRequest();
+        }
+        var contentType = data == null ? 'text/plain' : 'application/json';
+        req.weppy = req.bucky = { track: false };
+        req.open('POST', url, true);
+        req.setRequestHeader('Content-Type', contentType);
+        req.send(data);
+        return req;
+    }
+    var Namespace = (function () {
+        function Namespace(_root, _path) {
+            this._root = _root;
+            this._path = _path;
+            this.timer = new NamespaceTimer(this);
+        }
+        Namespace.prototype.namespace = function (root, path) {
+            return new Namespace(root, path || '');
+        };
+        Namespace.prototype.into = function (subpath) {
+            return new Namespace(this._root, buildPath(this._path, subpath));
+        };
+        Namespace.prototype.key = function (name) {
+            return buildPath(this._root, buildPath(this._path, name), NAMESPACE_DELIMITER);
+        };
+        Namespace.prototype.send = function (type, name, value, annotations) {
+            name = this.key(name);
+            enqueue(type, name, value, annotations);
+            log('Weppy: queued', {
+                type: MetricType[type],
+                name: name,
+                value: value,
+                annotations: annotations
+            });
+        };
+        Namespace.prototype.count = function (name, value, annotations) {
+            if (value === void 0) { value = 1; }
+            this.send(0 /* Counter */, name, value, annotations);
+        };
+        Namespace.prototype.store = function (name, value, annotations) {
+            this.send(1 /* Gauge */, name, value, annotations);
+        };
+        Namespace.prototype.flush = function () {
+            sendQueue();
+        };
+        Namespace.prototype.setOptions = function (opts) {
+            var key;
+            for (key in opts) {
+                if (opts.hasOwnProperty(key)) {
+                    options[key] = opts[key];
+                }
+            }
+            if ('sample' in opts || 'active' in opts) {
+                updateActive();
+            }
+        };
+        Namespace.prototype.sendPagePerformance = function () {
+            if (!window.performance || !window.performance.timing || sentPerformanceData) {
+                return false;
+            }
+            var self = this, readyState = document.readyState;
+            if (readyState == 'uninitialized' || readyState == 'loading') {
+                if (document.addEventListener) {
+                    document.addEventListener("DOMContentLoaded", function () {
+                        self.sendPagePerformance();
+                    }, false);
+                }
+                return false;
+            }
+            sentPerformanceData = true;
+            var timing = window.performance.timing, start = timing.navigationStart, key, time, data = {};
+            for (key in timing) {
+                time = timing[key];
+                if (time && typeof time == 'number') {
+                    data[key] = (time - start);
+                }
+            }
+            delete data['navigationStart'];
+            var name = options.page;
+            self.namespace('PAGELOAD').timer.send(name, start, data);
+            return true;
+        };
+        return Namespace;
+    })();
+    WeppyImpl.Namespace = Namespace;
+    var NamespaceTimer = (function () {
+        function NamespaceTimer(_namespace) {
+            this._namespace = _namespace;
+            this.PARTIALS = {};
+        }
+        NamespaceTimer.prototype.send = function (name, duration, annotations) {
+            this._namespace.send(2 /* Timer */, name, duration, annotations);
+        };
+        NamespaceTimer.prototype.start = function (name, annotations) {
+            this.PARTIALS[name] = [now(), annotations];
+            return new Timer(this, name);
+        };
+        NamespaceTimer.prototype.stop = function (name, annotations) {
+            if (!this.PARTIALS[name]) {
+                logError("Timer " + name + " ended without having been started");
+                return;
+            }
+            var duration = now() - this.PARTIALS[name][0];
+            annotations = extend(annotations, this.PARTIALS[name][1]);
+            this.PARTIALS[name] = false;
+            this.send(name, duration, annotations);
+        };
+        NamespaceTimer.prototype.annotate = function (name, annotations) {
+            if (!this.PARTIALS[name]) {
+                logError("Timer " + name + " received annotation without having been started");
+                return;
+            }
+            this.PARTIALS[name][1] = annotations;
+        };
+        NamespaceTimer.prototype.time = function (name, action, scope, args, annotations) {
+            this.start(name, annotations);
+            var self = this, done = function (annotations) {
+                self.stop(name, annotations);
+            };
+            args = args ? args.slice(0) : [];
+            args.splice(0, 0, done);
+            return action.apply(scope, args);
+        };
+        NamespaceTimer.prototype.timeSync = function (name, action, scope, args, annotations) {
+            this.start(name, annotations);
+            var ret = action.apply(scope, args);
+            this.stop(name);
+            return ret;
+        };
+        NamespaceTimer.prototype.wrap = function (name, action, scope, annotations) {
+            var _this = this;
+            var self = this;
+            return function () {
+                return self.timeSync(name, action, scope || _this, arguments, annotations);
+            };
+        };
+        NamespaceTimer.prototype.mark = function (name, annotations) {
+            this.send(name, now() - this.navigationStart(), annotations);
+        };
+        NamespaceTimer.prototype.navigationStart = function () {
+            return (window.performance && window.performance.timing && window.performance.timing.navigationStart) || initTime;
+        };
+        return NamespaceTimer;
+    })();
+    WeppyImpl.NamespaceTimer = NamespaceTimer;
+    var Timer = (function () {
+        function Timer(_timer, name) {
+            this._timer = _timer;
+            this.name = name;
+        }
+        Timer.prototype.stop = function (annotations) {
+            this._timer.stop(this.name, annotations);
+        };
+        Timer.prototype.annotate = function (annotations) {
+            this._timer.annotate(this.name, annotations);
+        };
+        return Timer;
+    })();
+    WeppyImpl.Timer = Timer;
+    function bindNamespaceFunction(fn, scope, callWrapNamespace) {
+        return callWrapNamespace ? function () {
+            return wrapNamespaceObject(fn.apply(scope, arguments));
+        } : function () {
+            return fn.apply(scope, arguments);
+        };
+    }
+    function wrapNamespaceObject(obj) {
+        var weppyObject = (function (subpath) {
+            return subpath ? weppyObject.into(subpath) : weppyObject;
+        }), k;
+        for (k in obj) {
+            if (typeof obj[k] == 'function') {
+                weppyObject[k] = bindNamespaceFunction(obj[k], obj, k == 'into' || k == 'namespace');
+            }
+            else {
+                weppyObject[k] = obj[k];
+            }
+        }
+        return weppyObject;
+    }
+    function getRootObject() {
+        return wrapNamespaceObject(new Namespace('', ''));
+    }
+    WeppyImpl.getRootObject = getRootObject;
+    updateActive();
+})(WeppyImpl || (WeppyImpl = {}));
+var Weppy = WeppyImpl.getRootObject();

--- a/extensions/wikia/Bucky/vendor/Weppy/gulpfile.js
+++ b/extensions/wikia/Bucky/vendor/Weppy/gulpfile.js
@@ -1,0 +1,52 @@
+var gulp = require('gulp'),
+	qunit = require('gulp-qunit'),
+	rename = require('gulp-rename'),
+	ts = require('gulp-typescript'),
+	wrap = require('gulp-wrap'),
+	source = './src/weppy.ts',
+	destination = './dist';
+
+
+var all_deps = [];
+
+gulp.task('compile', function () {
+	return gulp.src(source)
+		.pipe(ts()).js
+		.pipe(gulp.dest(destination));
+});
+all_deps.push('compile');
+
+gulp.task('compileAMD', function () {
+	return gulp.src(source)
+		.pipe(wrap('<%= contents %> export = Weppy;'))
+		.pipe(ts({module: 'amd'})).js
+		.pipe(rename(function (path) {
+			path.basename += '.amd';
+		}))
+		.pipe(gulp.dest(destination));
+});
+all_deps.push('compileAMD');
+
+gulp.task('compileCommonJS', function () {
+	return gulp.src(source)
+		.pipe(wrap('<%= contents %> export = Weppy;'))
+		.pipe(ts({module: 'commonjs'})).js
+		.pipe(rename(function (path) {
+			path.basename += '.cjs';
+		}))
+		.pipe(gulp.dest(destination));
+});
+all_deps.push('compileCommonJS');
+
+gulp.task('copy-weppy.d.ts',function(){
+	return gulp.src('./weppy.d.ts')
+		.pipe(gulp.dest('./dist'));
+});
+all_deps.push('copy-weppy.d.ts');
+
+gulp.task('test',function(){
+	return gulp.src('./tests/index.html')
+		.pipe(qunit());
+});
+
+gulp.task('default', all_deps);

--- a/extensions/wikia/Bucky/vendor/Weppy/package.json
+++ b/extensions/wikia/Bucky/vendor/Weppy/package.json
@@ -1,0 +1,21 @@
+{
+	"name": "weppy",
+	"version": "0.9.0",
+	"description": "Library to collect and report web application performance metrics",
+	"repository": {
+		"type": "git",
+		"url": "git://github.com/Wikia/weppy.git"
+	},
+	"scripts": {
+		"test": "gulp test"
+	},
+	"license": "MIT",
+	"devDependencies": {
+		"gulp": "3.x.x",
+		"gulp-rename": "1.2.x",
+		"gulp-typescript": "2.x.x",
+		"gulp-wrap": "0.5.x",
+		"gulp-qunit": "1.2.x",
+		"qunit-js": "1.16.x"
+	}
+}

--- a/extensions/wikia/Bucky/vendor/Weppy/src/weppy.ts
+++ b/extensions/wikia/Bucky/vendor/Weppy/src/weppy.ts
@@ -1,0 +1,469 @@
+/// <reference path="../weppy.d.ts"/>
+
+// these seem not to be defined in window
+interface Window {
+	XMLHttpRequest?: XMLHttpRequest;
+	XDomainRequest?: XMLHttpRequest;
+	JSON?: JSON;
+}
+
+module WeppyImpl {
+
+	var PROTOCOL_VERSION = 3,
+		PATH_DELIMITER = '.',
+		NAMESPACE_DELIMITER = '::',
+		active = false,
+		options:WeppySettings = {
+			"host": '/weppy',
+			"transport": 'url', // 'url' or 'post'
+			"active": true,
+			"sample": 0.01,
+			"aggregationInterval": 1000,
+			"maxInterval": 5000,
+			"decimalPrecision": 3,
+			"page": 'index',
+			"context": {},
+			"debug": false
+		},
+		initTime = +(new Date),
+		queue, aggregationTimeout, maxTimeout, sentPerformanceData,
+		now = () => {
+			return window.performance && window.performance.now ? window.performance.now() : +(new Date);
+		},
+		log:any = () => {
+			if (options.debug)
+				if (typeof options.debug == 'function')
+					options.debug.apply(window, arguments);
+				else
+					window.console && window.console.log && window.console.log.apply
+						? window.console.log.apply(window.console, arguments) : void 0;
+		},
+		logError:any = () => {
+			window.console && window.console.error && window.console.error.apply &&
+				window.console.error.apply(window.console,arguments);
+		};
+
+	function round(num:number, precision = options.decimalPrecision) {
+		return Math.round(num * Math.pow(10, precision)) / Math.pow(10, precision)
+	}
+
+	function buildPath(path:string, subpath:string, glue:string = PATH_DELIMITER) {
+		return path + (path != '' && subpath != '' ? glue : '' ) + subpath;
+	}
+
+	function updateActive() {
+		active = options.active && Math.random() < options.sample;
+	}
+
+	function extend(first:any, second:any) {
+		if (first && second) {
+			for (var key in second) {
+				if (second.hasOwnProperty(key)) {
+					first[key] = second[key];
+				}
+			}
+		}
+		return first || second;
+	}
+
+	function sortedJson(obj) {
+		var keys = Object.keys(obj).sort(),
+			i, ret = {};
+		for (i = 0; i < keys.length; i++) {
+			ret[keys[i]] = obj[keys[i]];
+		}
+		return JSON.stringify(ret);
+	}
+
+	export enum MetricType { Counter, Gauge, Timer }
+
+	module QueueData {
+		export interface Root {
+			[key: string]: Node;
+		}
+		export interface Node {
+			annotated?: AnnotatedKey;
+			data?: Data;
+		}
+		export interface AnnotatedKey {
+			[key: string]: AnnotatedValue;
+		}
+		export interface AnnotatedValue {
+			[key: string]: Node;
+			[key: number]: Node;
+		}
+		export interface Data {
+			value: number;
+			count?: number;
+			rollingAverage?: boolean;
+		}
+	}
+	class Queue {
+		private all:QueueData.Root;
+		private _empty:boolean;
+
+		constructor() {
+			this.clear();
+		}
+
+		clear() {
+			this.all = {};
+			this._empty = true;
+		}
+
+		empty() {
+			return this._empty;
+		}
+
+		add(name:string, value:number, rollingAverage:boolean, annotations?) {
+			var data:QueueData.Data = this.find(name, annotations);
+			if (rollingAverage) {
+				data.count = data.count || 0;
+				data.count++;
+				data.value += (value - data.value) / data.count;
+				data.rollingAverage = true;
+			} else {
+				data.value += value;
+			}
+			this._empty = false;
+		}
+
+		private find(name:string, annotations?):QueueData.Data {
+			var serializedAnnotations:any = annotations ? sortedJson(annotations) : false,
+				scope = this.all[name] = this.all[name] || {}, data:QueueData.Data;
+			if (serializedAnnotations) {
+				scope = scope.annotated = scope.annotated || {};
+				scope = scope[serializedAnnotations] = scope[serializedAnnotations] || {};
+			}
+			data = scope.data = scope.data || {value: 0};
+			return data;
+		}
+
+		get_clear() {
+			var measurements = {};
+
+			function addMeasurement(name, data, annotations) {
+				if (data) {
+					var value = data.value;
+					if (data.rollingAverage) {
+						value = round(value);
+					}
+					var measurement = [value];
+					if (annotations) {
+						measurement.push(annotations);
+					}
+					measurements[name].push(measurement);
+				}
+			}
+
+			var names = Object.keys(this.all),
+				data, annotated, i, k;
+			for (i = 0; i < names.length; i++) {
+				measurements[names[i]] = [];
+				data = this.all[names[i]].data;
+				annotated = this.all[names[i]].annotated;
+				if (data) {
+					addMeasurement(names[i], data, null);
+				}
+				if (annotated) {
+					for (k in annotated) {
+						if (annotated.hasOwnProperty(k)) {
+							addMeasurement(names[i], annotated[k].data, JSON.parse(k));
+						}
+					}
+				}
+			}
+			this.clear();
+			return measurements;
+		}
+	}
+	queue = new Queue();
+
+	function enqueue(type:MetricType, name:string, value:number, annotations?) {
+		if (!active) {
+			return;
+		}
+		var rollingAverage = type != MetricType.Counter;
+		queue.add(name, value, rollingAverage, annotations);
+		scheduleSending();
+	}
+
+	function scheduleSending() {
+		clearTimeout(aggregationTimeout);
+		aggregationTimeout = setTimeout(sendQueue, options.aggregationInterval);
+		if (!maxTimeout) {
+			maxTimeout = setTimeout(sendQueue, options.maxInterval);
+		}
+	}
+
+	function clearSchedule() {
+		clearTimeout(aggregationTimeout);
+		clearTimeout(maxTimeout);
+		aggregationTimeout = null;
+		maxTimeout = null;
+	}
+
+
+	function sendQueue() {
+		clearSchedule();
+		if (queue.empty()) {
+			return;
+		}
+		if (!active) {
+			log("Weppy: would send queue but inactive");
+			return;
+		}
+		if (!window.JSON || !JSON.stringify) {
+			queue.clear();
+			return;
+		}
+		var all_measurements = queue.get_clear();
+		var all_data = {
+			context: options.context,
+			data: all_measurements
+		};
+		log('Weppy: sending', all_data);
+		sendData(all_data);
+	}
+
+	function sendData(data) {
+		if (typeof options.transport == 'function') {
+			options.transport(data);
+			return;
+		}
+		var url = options.host + '/v' + PROTOCOL_VERSION + '/send';
+		if (options.transport == 'url') {
+			url += '?p=' + encodeURIComponent(JSON.stringify(data));
+			sendRequest(url, null);
+		} else if (options.transport == 'post') {
+			sendRequest(url, JSON.stringify(data));
+		}
+	}
+
+	function sendRequest(url, data) {
+		var corsSupport = window.XMLHttpRequest && (XMLHttpRequest['defake'] || (new XMLHttpRequest()).withCredentials);
+		var sameOrigin = true;
+
+		var match = /^(https?:\/\/[^\/]+)/i.exec(url);
+		if (match && match[1] != document.location.protocol + '//' + document.location.host) {
+			sameOrigin = false;
+		}
+
+		var req;
+		if (!sameOrigin && !corsSupport && window.XDomainRequest) {
+			req = new XDomainRequest();
+		} else {
+			req = new XMLHttpRequest();
+		}
+
+		var contentType = data == null ? 'text/plain' : 'application/json';
+
+		req.weppy = req.bucky = {track: false};
+		req.open('POST', url, true);
+		req.setRequestHeader('Content-Type', contentType);
+		req.send(data);
+		return req;
+	}
+
+	export class Namespace implements WeppyNamespace {
+		public timer:NamespaceTimer;
+
+		constructor(private _root:string, private _path:string) {
+			this.timer = new NamespaceTimer(this);
+		}
+
+		namespace(root:string, path?:string) {
+			return new Namespace(root, path || '');
+		}
+
+		into(subpath:string) {
+			return new Namespace(this._root, buildPath(this._path, subpath))
+		}
+
+		private key(name:string) {
+			return buildPath(this._root, buildPath(this._path, name), NAMESPACE_DELIMITER);
+		}
+
+		send(type:MetricType, name:string, value:number, annotations?:WeppyContext) {
+			name = this.key(name);
+			enqueue(type, name, value, annotations);
+			log('Weppy: queued', {
+				type: MetricType[type],
+				name: name,
+				value: value,
+				annotations: annotations
+			});
+		}
+
+		count(name:string, value:number = 1, annotations?:WeppyContext) {
+			this.send(MetricType.Counter, name, value, annotations);
+		}
+
+		store(name:string, value:number, annotations?:WeppyContext) {
+			this.send(MetricType.Gauge, name, value, annotations);
+		}
+
+		flush() {
+			sendQueue();
+		}
+
+		setOptions(opts:WeppySettings) {
+			var key;
+			for (key in opts) {
+				if (opts.hasOwnProperty(key)) {
+					options[key] = opts[key];
+				}
+			}
+			if ('sample' in opts || 'active' in opts) {
+				updateActive();
+			}
+		}
+
+		sendPagePerformance() {
+			if (!window.performance || !window.performance.timing || sentPerformanceData) {
+				return false;
+			}
+
+			var self = this, readyState = document.readyState;
+			if (readyState == 'uninitialized' || readyState == 'loading') {
+				if (document.addEventListener) {
+					document.addEventListener("DOMContentLoaded", () => {
+						self.sendPagePerformance();
+					}, false);
+				}
+				return false;
+			}
+
+			sentPerformanceData = true;
+			var timing = window.performance.timing, start = timing.navigationStart, key, time,
+				data:WeppyContext = {};
+			for (key in timing) {
+				time = timing[key];
+				if (time && typeof time == 'number') {
+					data[key] = (time - start);
+				}
+			}
+			delete data['navigationStart'];
+
+			var name = options.page;
+			self.namespace('PAGELOAD').timer.send(name, start, data);
+
+			return true
+		}
+	}
+
+	export class NamespaceTimer implements WeppyNamespaceTimer {
+		private PARTIALS;
+
+		constructor(private _namespace:Namespace) {
+			this.PARTIALS = {}
+		}
+
+		send(name:string, duration:number, annotations?:WeppyContext) {
+			this._namespace.send(MetricType.Timer, name, duration, annotations);
+		}
+
+		start(name:string, annotations?:WeppyContext) {
+			this.PARTIALS[name] = [now(), annotations];
+			return new Timer(this, name);
+		}
+
+		stop(name:string, annotations?:WeppyContext) {
+			if (!this.PARTIALS[name]) {
+				logError("Timer " + name + " ended without having been started");
+				return;
+			}
+			var duration = now() - this.PARTIALS[name][0];
+			annotations = extend(annotations, this.PARTIALS[name][1]);
+			this.PARTIALS[name] = false;
+			this.send(name, duration, annotations);
+		}
+
+		annotate(name:string, annotations:WeppyContext) {
+			if (!this.PARTIALS[name]) {
+				logError("Timer " + name + " received annotation without having been started");
+				return;
+			}
+			this.PARTIALS[name][1] = annotations;
+		}
+
+		time(name:string, action, scope, args, annotations?:WeppyContext) {
+			this.start(name, annotations);
+			var self = this,
+				done = (annotations?) => {
+					self.stop(name, annotations);
+				};
+			args = args ? args.slice(0) : [];
+			args.splice(0, 0, done);
+			return action.apply(scope, args);
+		}
+
+		timeSync(name:string, action, scope, args, annotations?:WeppyContext) {
+			this.start(name, annotations);
+			var ret = action.apply(scope, args);
+			this.stop(name);
+			return ret;
+		}
+
+		wrap(name:string, action, scope, annotations?:WeppyContext) {
+			var self = this;
+			return () => {
+				return self.timeSync(name, action, scope || this, arguments, annotations);
+			};
+		}
+
+		mark(name:string, annotations?:WeppyContext) {
+			this.send(name, now() - this.navigationStart(), annotations);
+		}
+
+		private navigationStart() {
+			return (window.performance && window.performance.timing && window.performance.timing.navigationStart) ||
+				initTime;
+		}
+	}
+
+	export class Timer implements WeppyTimer {
+		constructor(private _timer:NamespaceTimer, private name:string) {
+		}
+
+		stop(annotations?) {
+			this._timer.stop(this.name, annotations);
+		}
+
+		annotate(annotations) {
+			this._timer.annotate(this.name, annotations);
+		}
+	}
+
+	function bindNamespaceFunction( fn, scope, callWrapNamespace ) {
+		return callWrapNamespace ?
+			() => {
+				return wrapNamespaceObject(fn.apply(scope,arguments));
+			} :
+			() => {
+				return fn.apply(scope,arguments);
+			}
+	}
+
+	function wrapNamespaceObject( obj: WeppyNamespace ) {
+		var weppyObject: WeppyObject = <WeppyObject>((subpath:string) => {
+				return subpath ? weppyObject.into(subpath) : weppyObject;
+			}), k;
+		for (k in obj) {
+			if ( typeof obj[k] == 'function' ) {
+				weppyObject[k] = bindNamespaceFunction(obj[k],obj,
+					k == 'into' || k == 'namespace');
+			} else {
+				weppyObject[k] = obj[k];
+			}
+		}
+		return weppyObject;
+	}
+
+	export function getRootObject() {
+		return wrapNamespaceObject(new Namespace('',''));
+	}
+	updateActive();
+}
+
+var Weppy:WeppyNamespace = WeppyImpl.getRootObject();

--- a/extensions/wikia/Bucky/vendor/Weppy/tests/index.html
+++ b/extensions/wikia/Bucky/vendor/Weppy/tests/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>QUnit Test Suite</title>
+	<link rel="stylesheet" href="../node_modules/qunitjs/qunit/qunit.css" type="text/css" media="screen">
+	<script type="text/javascript" src="../node_modules/qunitjs/qunit/qunit.js"></script>
+	<!-- Your project file goes here -->
+	<script type="text/javascript" src="../dist/weppy.js"></script>
+	<!-- Your tests file goes here -->
+	<script type="text/javascript" src="weppy-test.js"></script>
+</head>
+<body>
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+</body>
+</html>

--- a/extensions/wikia/Bucky/vendor/Weppy/tests/weppy-test.js
+++ b/extensions/wikia/Bucky/vendor/Weppy/tests/weppy-test.js
@@ -1,0 +1,482 @@
+var async = QUnit.assert.async,
+	_console = window.console,
+	consoleMock = {},
+	consoleCalls = {};
+QUnit.module('Weppy tests');
+
+/* propEqual copy from QUnit without adding an assertion */
+var hasOwn = Object.prototype.hasOwnProperty,
+	objectValues = function (obj) {
+		var key, val,
+			vals = QUnit.is("array", obj) ? [] : {};
+		for (key in obj) {
+			if (hasOwn.call(obj, key)) {
+				val = obj[key];
+				vals[key] = val === Object(val) ? objectValues(val) : val;
+			}
+		}
+		return vals;
+	},
+	equivObjects = function (a, b) {
+		a = objectValues(a);
+		b = objectValues(b);
+		return QUnit.equiv(a, b);
+	};
+/* end of propEqual copy */
+
+
+for (var k in _console) {
+	if (typeof _console[k] == 'function') {
+		consoleMock[k] = (function (k) {
+			return function () {
+				consoleCalls[k] = consoleCalls[k] || [];
+				consoleCalls[k].push(Array.prototype.slice.apply(arguments, [0]));
+				return _console[k].apply(_console, arguments);
+			}
+		})(k);
+	} else {
+		consoleMock[k] = _console[k];
+	}
+}
+
+window.console = consoleMock;
+
+function runWeppyReportTest(test) {
+	var done,
+		options = {
+			debug: false,
+			host: '/weppy',
+			sample: 100,
+			active: 1,
+			aggregationInterval: 0,
+			maxInterval: 0,
+			decimalPrecision: 3,
+			transport: function (data) {
+				if (test.check && test.check(data) !== false) {
+					done();
+				}
+			},
+			context: {}
+		};
+	if (!test.sync) {
+		done = async();
+	}
+	Weppy.setOptions(options);
+	test.setup(done);
+}
+
+function mockXMLHttpRequest(check) {
+	var _open = XMLHttpRequest.prototype.open,
+		_send = XMLHttpRequest.prototype.send,
+		url, data;
+	XMLHttpRequest.prototype.open = function () {
+		url = arguments[1];
+		return _open.apply(this, arguments);
+	};
+	XMLHttpRequest.prototype.send = function () {
+		data = arguments[0];
+		XMLHttpRequest.prototype.open = _open;
+		XMLHttpRequest.prototype.send = _send;
+		check(url, data);
+	};
+}
+
+function clearConsoleLog() {
+	consoleCalls = {};
+}
+
+function getConsoleLog() {
+	var currentLog = consoleCalls;
+	clearConsoleLog();
+	return currentLog;
+}
+
+QUnit.test('Report simple single point', function () {
+	runWeppyReportTest({
+		setup: function () {
+			Weppy.timer.send('axyz', 1.2);
+		},
+		check: function (data) {
+			propEqual(data['data'], {
+				axyz: [[1.2]]
+			}, 'axyz');
+		}
+	})
+});
+
+QUnit.test('Report global context', function () {
+	runWeppyReportTest({
+		setup: function () {
+			Weppy.setOptions({
+				context: {
+					asd: 12
+				}
+			});
+			Weppy.timer.send('axyz', 1.2);
+		},
+		check: function (data) {
+			// reported data
+			propEqual(data['data'], {
+				axyz: [[1.2]]
+			});
+			// context
+			propEqual(data['context'], {
+				asd: 12
+			}, 'context');
+		}
+	})
+});
+
+
+QUnit.test('Report average of two times', function () {
+	runWeppyReportTest({
+		setup: function () {
+			Weppy.timer.send('axyz', 1.2);
+			Weppy.timer.send('axyz', 1.8);
+		},
+		check: function (data) {
+			propEqual(data['data'], {
+				axyz: [[1.5]]
+			});
+		}
+	})
+});
+
+QUnit.test('Report sum of two counts', function () {
+	runWeppyReportTest({
+		setup: function () {
+			Weppy.count('axyz', 2);
+			Weppy.count('axyz', 6);
+		},
+		check: function (data) {
+			propEqual(data['data'], {
+				axyz: [[8]]
+			});
+		}
+	})
+});
+
+QUnit.test('Report metric once', function () {
+	var step = 1;
+	runWeppyReportTest({
+		setup: function () {
+			Weppy.count('axyz', 2);
+		},
+		check: function (data) {
+			if (step == 1) {
+				propEqual(data['data'], {
+					axyz: [[2]]
+				});
+				step = 2;
+				Weppy.count('azzz', 5);
+				return false;
+			} else {
+				equal(typeof data['data']['axyz'], 'undefined', 'axyz is not reported twice');
+				propEqual(data['data'], {
+					azzz: [[5]]
+				});
+			}
+			return true;
+		}
+	})
+});
+
+QUnit.test('Report single annotated point', function () {
+	runWeppyReportTest({
+		setup: function () {
+			Weppy.timer.send('axyz', 1.2, {size: 200});
+		},
+		check: function (data) {
+			propEqual(data['data'], {
+				axyz: [
+					[1.2, {size: 200}]
+				]
+			});
+		}
+	})
+});
+
+QUnit.test('Report merged point for points with the same annotations', function () {
+	runWeppyReportTest({
+		setup: function () {
+			Weppy.timer.send('axyz', 1.2, {size: 200});
+			Weppy.timer.send('axyz', 1.4, {size: 200});
+			Weppy.count('uuu', 2, {size: 100});
+			Weppy.count('uuu', 5, {size: 100});
+		},
+		check: function (data) {
+			propEqual(data['data'], {
+				axyz: [
+					[1.3, {size: 200}]
+				],
+				uuu: [
+					[7, {size: 100}]
+				]
+			});
+		}
+	})
+});
+
+QUnit.test('Report annotated points separately', function () {
+	runWeppyReportTest({
+		setup: function () {
+			Weppy.timer.send('axyz', 1.1);
+			Weppy.timer.send('axyz', 1.2, {size: 200});
+			Weppy.timer.send('axyz', 1.3, {size: 100});
+		},
+		check: function (data) {
+			propEqual(data['data'], {
+				axyz: [
+					[1.1],
+					[1.2, {size: 200}],
+					[1.3, {size: 100}]
+				]
+			});
+		}
+	})
+});
+
+QUnit.test('Use "active" setting', function () {
+	var sent = false;
+	runWeppyReportTest({
+		setup: function (done) {
+			Weppy.setOptions({active: false});
+			Weppy.timer.send('axyz', 1.2);
+			setTimeout(function () {
+				equal(sent, false, 'data was not sent');
+				done();
+			}, 10);
+		},
+		check: function (data) {
+			sent = true;
+			return false;
+		}
+	})
+});
+
+QUnit.test('Use "sample" setting', function () {
+	var sent = false;
+	runWeppyReportTest({
+		setup: function (done) {
+			Weppy.setOptions({sample: 0});
+			Weppy.timer.send('axyz', 1.2);
+			setTimeout(function () {
+				equal(sent, false, 'data was not sent');
+				done();
+			}, 10);
+		},
+		check: function (data) {
+			sent = true;
+			return false;
+		}
+	})
+});
+
+QUnit.test('Use "aggregationInterval" setting', function () {
+	var start = +(new Date);
+	runWeppyReportTest({
+		setup: function (done) {
+			Weppy.setOptions({aggregationInterval: 20, maxInterval: 50});
+			Weppy.timer.send('axyz', 1.2);
+			setTimeout(function () {
+				Weppy.timer.send('axyz', 1.2);
+			}, 10);
+		},
+		check: function (data) {
+			var delay = (+(new Date)) - start;
+			ok(delay >= 30 && delay < 50, '30ms <= delay < 50ms');
+		}
+	})
+});
+
+QUnit.test('Use "maxInterval" setting', function () {
+	var sent = 0, reported = false;
+	runWeppyReportTest({
+		setup: function (done) {
+			expect(0);
+			Weppy.setOptions({aggregationInterval: 20, maxInterval: 5});
+			Weppy.timer.send('axyz', 1.2);
+			setTimeout(function () {
+				Weppy.timer.send('axyz', 1.5);
+			}, 10);
+			setTimeout(function () {
+				if (!reported) {
+					ok(false, 'only one report within 40ms');
+				}
+			}, 40)
+		},
+		check: function (data) {
+			sent++;
+			if (sent == 2) {
+				reported = true;
+				return true;
+			} else if (sent > 2) {
+				ok(false, 'too many reports');
+			}
+			return false;
+		}
+	})
+});
+
+QUnit.test('Use "transport" setting = "url"', function () {
+	var sent = 0, reported = false;
+	runWeppyReportTest({
+		setup: function (done) {
+			Weppy.setOptions({host: '/weppy-url-test', transport: "url"});
+			mockXMLHttpRequest(function (url, data) {
+				equal(data, null, "data is empty");
+				equal(url, '/weppy-url-test/v3/send?p=%7B%22context%22%3A%7B%7D%2C%22data%22%3A%7B%22a%22%3A%5B%5B1%5D%5D%7D%7D', "data encoded in url");
+				done();
+			});
+			Weppy.count('a', 1);
+		}
+	})
+});
+
+QUnit.test('Use "transport" setting = "post"', function () {
+	var sent = 0, reported = false;
+	runWeppyReportTest({
+		setup: function (done) {
+			Weppy.setOptions({host: '/weppy-post-test', transport: "post"});
+			mockXMLHttpRequest(function (url, data) {
+				equal(data, '{"context":{},"data":{"a":[[1]]}}', "data is empty");
+				equal(url, '/weppy-post-test/v3/send', "data encoded in url");
+				done();
+			});
+			Weppy.count('a', 1);
+		}
+	})
+});
+
+QUnit.test('Resolve .into() correctly', function () {
+	runWeppyReportTest({
+		setup: function () {
+			Weppy.count('aaa', 1);
+			Weppy.into('test1').count('aab', 2);
+			Weppy.into('test1').into('test2').count('aac', 3);
+		},
+		check: function (data) {
+			propEqual(data['data'], {
+				aaa: [[1]],
+				'test1.aab': [[2]],
+				'test1.test2.aac': [[3]]
+			});
+		}
+	})
+});
+
+QUnit.test('Resolve .namespace() correctly', function () {
+	runWeppyReportTest({
+		setup: function () {
+			Weppy.count('aaa', 1);
+			Weppy.namespace('', 'test1').count('aab', 2);
+			Weppy.namespace('Feature', 'test2').count('aac', 3);
+		},
+		check: function (data) {
+			propEqual(data['data'], {
+				aaa: [[1]],
+				'test1.aab': [[2]],
+				'Feature::test2.aac': [[3]]
+			});
+		}
+	})
+});
+
+
+QUnit.test('Option "debug" is respected when false', function () {
+	clearConsoleLog();
+	runWeppyReportTest({
+		setup: function () {
+			Weppy.setOptions({debug: false});
+			Weppy.count('aaa', 1, {test: 1});
+			Weppy.timer.send('tmm', 1.2);
+		},
+		check: function (data) {
+			var logCalls = getConsoleLog().log || [];
+			console.log(logCalls);
+			var receivedLogs = {}, i;
+			for (i = 0; i < logCalls.length; i++) {
+				var logText = logCalls[i][0], logData = logCalls[i][1];
+				if (logText.indexOf('Weppy') < 0) continue;
+				if (logText.indexOf('queued') >= 0 && QUnit.is('object', logData)) {
+					if (logData.type == 'Counter' && logData.name == 'aaa' && logData.value == 1 && equivObjects(logData.annotations, {test: 1}))
+						receivedLogs['aaa'] = true;
+					if (logData.type == 'Timer' && logData.name == 'tmm' && logData.value == 1.2 && equivObjects(logData.annotations, {}))
+						receivedLogs['tmm'] = true;
+				}
+				if (logText.indexOf('sending') >= 0)
+					receivedLogs['sending'] = true;
+			}
+			ok(!receivedLogs['aaa'], "Counter aaa debug");
+			ok(!receivedLogs['tmm'], "Timer tmm debug");
+			ok(!receivedLogs['sending'], "Sending debug");
+		}
+	})
+});
+
+QUnit.test('Option "debug" is respected when true', function () {
+	clearConsoleLog();
+	runWeppyReportTest({
+		setup: function () {
+			Weppy.setOptions({debug: true});
+			Weppy.count('aaa', 1, {test: 1});
+			Weppy.timer.send('tmm', 1.2);
+		},
+		check: function (data) {
+			var logCalls = getConsoleLog().log || [];
+			console.log(logCalls);
+			var receivedLogs = {}, i;
+			for (i = 0; i < logCalls.length; i++) {
+				var logText = logCalls[i][0], logData = logCalls[i][1];
+				if (logText.indexOf('Weppy') < 0) continue;
+				if (logText.indexOf('queued') >= 0 && QUnit.is('object', logData)) {
+					if (logData.type == 'Counter' && logData.name == 'aaa' && logData.value == 1 && equivObjects(logData.annotations, {test: 1}))
+						receivedLogs['aaa'] = true;
+					if (logData.type == 'Timer' && logData.name == 'tmm' && logData.value == 1.2 && equivObjects(logData.annotations, {}))
+						receivedLogs['tmm'] = true;
+				}
+				if (logText.indexOf('sending') >= 0)
+					receivedLogs['sending'] = true;
+			}
+			ok(receivedLogs['aaa'], "Counter aaa debug");
+			ok(receivedLogs['tmm'], "Timer tmm debug");
+			ok(receivedLogs['sending'], "Sending debug");
+		}
+	})
+});
+
+QUnit.test('Option "debug" is respected when function', function () {
+	var _logCalls = [],
+		_logFunction = function () {
+			_logCalls.push(Array.prototype.slice.call(arguments, 0));
+		};
+	clearConsoleLog();
+	runWeppyReportTest({
+		setup: function () {
+			Weppy.setOptions({debug: _logFunction});
+			Weppy.count('aaa', 1, {test: 1});
+			Weppy.timer.send('tmm', 1.2);
+		},
+		check: function (data) {
+			var logCalls = getConsoleLog().log || [];
+			equal(logCalls.length, 0, 'no calls to console.log()');
+			logCalls = _logCalls;
+			var receivedLogs = {}, i;
+			for (i = 0; i < logCalls.length; i++) {
+				var logText = logCalls[i][0], logData = logCalls[i][1];
+				if (logText.indexOf('Weppy') < 0) continue;
+				if (logText.indexOf('queued') >= 0 && QUnit.is('object', logData)) {
+					if (logData.type == 'Counter' && logData.name == 'aaa' && logData.value == 1 && equivObjects(logData.annotations, {test: 1}))
+						receivedLogs['aaa'] = true;
+					if (logData.type == 'Timer' && logData.name == 'tmm' && logData.value == 1.2 && equivObjects(logData.annotations, {}))
+						receivedLogs['tmm'] = true;
+				}
+				if (logText.indexOf('sending') >= 0)
+					receivedLogs['sending'] = true;
+			}
+			ok(receivedLogs['aaa'], "Counter aaa debug");
+			ok(receivedLogs['tmm'], "Timer tmm debug");
+			ok(receivedLogs['sending'], "Sending debug");
+		}
+	})
+});

--- a/extensions/wikia/Bucky/vendor/Weppy/weppy.d.ts
+++ b/extensions/wikia/Bucky/vendor/Weppy/weppy.d.ts
@@ -1,0 +1,53 @@
+interface WeppyObject extends WeppyNamespace {
+	(subpath:string): WeppyNamespace;
+}
+
+interface WeppyNamespace {
+	timer: WeppyNamespaceTimer;
+	namespace(root:string, path?:string): WeppyNamespace;
+	into(subpath:string): WeppyNamespace;
+	count(name:string, value?:number, annotations?:WeppyContext): void;
+	store(name:string, value?:number, annotations?:WeppyContext): void;
+	flush(): void;
+	setOptions(options:WeppySettings): void;
+	sendPagePerformance(): boolean;
+}
+
+interface WeppyNamespaceTimer {
+	send(name:string, duration:number, annotations?:WeppyContext): void;
+	start(name:string, annotations?:WeppyContext): WeppyTimer;
+	stop(name:string, annotations?:WeppyContext): void;
+	annotate(name:string, annotations:WeppyContext): void;
+	time(name:string, action:any, scope:any, args:any, annotations?:WeppyContext): any;
+	timeSync(name:string, action:any, scope:any, args:any, annotations?:WeppyContext): any;
+	wrap(name:string, action:any, scope:any, annotations?:WeppyContext): () => any;
+	mark(name:string, annotations?:any): void;
+}
+
+interface WeppyTimer {
+	stop(annotations?:WeppyContext): void;
+	annotate(annotations:WeppyContext): void;
+}
+
+interface WeppyContext {
+	[s:string]: any;
+}
+
+interface WeppySettings {
+	host?: string;
+	transport?: any;
+	active?: boolean;
+	sample?: number;
+	aggregationInterval?: number;
+	maxInterval?: number;
+	decimalPrecision?: number;
+	page?: string;
+	context?: {};
+	debug?: any; // boolean | function
+}
+
+interface Window {
+	Weppy: WeppyNamespace;
+}
+
+declare var Weppy:WeppyNamespace;

--- a/extensions/wikia/Bucky/vendor/Weppy/weppy.d.ts
+++ b/extensions/wikia/Bucky/vendor/Weppy/weppy.d.ts
@@ -1,32 +1,32 @@
 interface WeppyObject extends WeppyNamespace {
-	(subpath:string): WeppyNamespace;
+	(subpath: string): WeppyNamespace;
 }
 
 interface WeppyNamespace {
 	timer: WeppyNamespaceTimer;
-	namespace(root:string, path?:string): WeppyNamespace;
-	into(subpath:string): WeppyNamespace;
-	count(name:string, value?:number, annotations?:WeppyContext): void;
-	store(name:string, value?:number, annotations?:WeppyContext): void;
+	namespace(root: string, path?: string): WeppyNamespace;
+	into(subpath: string): WeppyNamespace;
+	count(name: string, value?: number, annotations?: WeppyContext): void;
+	store(name: string, value?: number, annotations?: WeppyContext): void;
 	flush(): void;
-	setOptions(options:WeppySettings): void;
+	setOptions(options: WeppySettings): void;
 	sendPagePerformance(): boolean;
 }
 
 interface WeppyNamespaceTimer {
-	send(name:string, duration:number, annotations?:WeppyContext): void;
-	start(name:string, annotations?:WeppyContext): WeppyTimer;
-	stop(name:string, annotations?:WeppyContext): void;
-	annotate(name:string, annotations:WeppyContext): void;
-	time(name:string, action:any, scope:any, args:any, annotations?:WeppyContext): any;
-	timeSync(name:string, action:any, scope:any, args:any, annotations?:WeppyContext): any;
-	wrap(name:string, action:any, scope:any, annotations?:WeppyContext): () => any;
-	mark(name:string, annotations?:any): void;
+	send(name: string, duration: number, annotations?: WeppyContext): void;
+	start(name: string, annotations?: WeppyContext): WeppyTimer;
+	stop(name: string, annotations?: WeppyContext): void;
+	annotate(name: string, annotations: WeppyContext): void;
+	time(name: string, action: any, scope: any, args: any, annotations?: WeppyContext): any;
+	timeSync(name: string, action: any, scope: any, args: any, annotations?: WeppyContext): any;
+	wrap(name: string, action: any, scope: any, annotations?: WeppyContext): () => any;
+	mark(name: string, annotations?: any): void;
 }
 
 interface WeppyTimer {
-	stop(annotations?:WeppyContext): void;
-	annotate(annotations:WeppyContext): void;
+	stop(annotations?: WeppyContext): void;
+	annotate(annotations: WeppyContext): void;
 }
 
 interface WeppyContext {
@@ -50,4 +50,4 @@ interface Window {
 	Weppy: WeppyNamespace;
 }
 
-declare var Weppy:WeppyNamespace;
+declare var Weppy: WeppyNamespace;


### PR DESCRIPTION
This change replaces Bucky with Weppy for RUM measurements reporting. API of those two is very similar so I don't expect big problems during this transition. For now the old name "Bucky" is being kept and then I'll probably go through the code and remove all mentions of it and replace them with Weppy.

Weppy is our home-grown pseudo-clone written in TypeScript (https://github.com/Wikia/weppy/tree/weppy-0.9-wip). All the anticipated features were added and the system was stripped from unnecessary features to minimize size of the code. That seemed to be a good choice due to architectural constraints of original Bucky implementation.

WORK IN PROGRESS. PLEASE DO NOT MERGE YET!

/cc @macbre 
