### PR TITLE
Soc 151

### DIFF
--- a/includes/DefaultSettings.php
+++ b/includes/DefaultSettings.php
@@ -3313,7 +3313,7 @@ $wgHiddenPrefs = array();
  * This is used in a regular expression character class during
  * registration (regex metacharacters like / are escaped).
  */
-$wgInvalidUsernameCharacters = '@';
+$wgInvalidUsernameCharacters = '/@|[\x{2460}-\x{2468}]|[\x{24B6}-\x{24EA}]/u';
 
 /**
  * Character used as a delimiter when testing for interwiki userrights

--- a/includes/DefaultSettings.php
+++ b/includes/DefaultSettings.php
@@ -3311,9 +3311,10 @@ $wgHiddenPrefs = array();
 /**
  * Characters to prevent during new account creations.
  * This is used in a regular expression character class during
- * registration (regex metacharacters like / are escaped).
+ * registration.
+ * Wikia: Added filtering circled latin characters
  */
-$wgInvalidUsernameCharacters = '/@|[\x{2460}-\x{2468}]|[\x{24B6}-\x{24EA}]/u';
+$wgInvalidUsernameCharacters = '/@|[\x{24B6}-\x{24E9}]|[\x{1F150}-\x{1F169}]/u';
 
 /**
  * Character used as a delimiter when testing for interwiki userrights

--- a/includes/User.php
+++ b/includes/User.php
@@ -671,7 +671,7 @@ class User {
 
 		// Preg yells if you try to give it an empty string
 		if( $wgInvalidUsernameCharacters !== '' ) {
-			if( preg_match( '/[' . preg_quote( $wgInvalidUsernameCharacters, '/' ) . ']/', $name ) ) {
+			if( preg_match( $wgInvalidUsernameCharacters, $name ) ) {
 				wfDebugLog( 'username', __METHOD__ .
 					": '$name' invalid due to wgInvalidUsernameCharacters" );
 				return false;


### PR DESCRIPTION
RFC

In https://wikia-inc.atlassian.net/browse/SOC-151 there was a request to filter out circled latin characters:

Requirements:
1) All new users cannot use circled latin characters
2) All users already registered with those are still able to log in

This is just a prototype of a solution and is currently under progress
