### PR TITLE
SOC-326 Make sure we don't include sensitive parameters in the returntoquery parameter

### DIFF
--- a/extensions/wikia/UserLogin/UserLoginSpecialController.class.php
+++ b/extensions/wikia/UserLogin/UserLoginSpecialController.class.php
@@ -276,7 +276,7 @@ class UserLoginSpecialController extends WikiaSpecialPageController {
 		}
 	}
 
-	private function getReturnToFromQuery( &$query ) {
+	public function getReturnToFromQuery( $query ) {
 		if ( !is_array( $query ) ) {
 			return '';
 		}
@@ -288,7 +288,6 @@ class UserLoginSpecialController extends WikiaSpecialPageController {
 
 		if ( isset( $query['title'] ) && !$this->isTitleBlacklisted( $query['title'] ) ) {
 			$returnTo = $query['title'];
-			unset( $query['title'] );
 		} else {
 			$returnTo = $this->getMainPagePartialUrl();
 		}
@@ -319,6 +318,8 @@ class UserLoginSpecialController extends WikiaSpecialPageController {
 			return '';
 		}
 
+		// Ignore the title parameter as it would either be used by the returnto or blacklisted
+		unset( $query['title'] );
 		return wfArrayToCGI( $query );
 	}
 

--- a/extensions/wikia/UserLogin/UserLoginSpecialController.class.php
+++ b/extensions/wikia/UserLogin/UserLoginSpecialController.class.php
@@ -282,10 +282,7 @@ class UserLoginSpecialController extends WikiaSpecialPageController {
 		}
 
 		// If there's already a returnto here, use it.
-		if ( !empty( $query['returnto'] ) ) {
-			if ( !array_key_exists( 'returntoquery', $query ) ) {
-				$query['returntoquery'] = '';
-			}
+		if ( isset( $query['returnto'] ) ) {
 			return $query['returnto'];
 		}
 
@@ -312,8 +309,10 @@ class UserLoginSpecialController extends WikiaSpecialPageController {
 			return '';
 		}
 
-		if ( array_key_exists( 'returntoquery', $query ) ) {
-			return $query['returntoquery'];
+		if ( isset( $query['returnto'] ) ) {
+			// If we're already got a 'returnto' value, make sure to pair it with the 'returntoquery' or
+			// default to blank if there isn't one.
+			return array_key_exists( 'returntoquery', $query ) ? $query['returntoquery'] : '';
 		} elseif ( $this->request->wasPosted() ) {
 			// Don't use any query parameters if this was a POST and we couldn't find
 			// a returntoquery param

--- a/extensions/wikia/UserLogin/UserLoginSpecialController.class.php
+++ b/extensions/wikia/UserLogin/UserLoginSpecialController.class.php
@@ -261,12 +261,10 @@ class UserLoginSpecialController extends WikiaSpecialPageController {
 	 * On GET, template partial for an ajax element will render
 	 */
 	public function dropdown() {
-		$query = $this->getSanitizedQueryString();
+		$query = $this->app->wg->Request->getValues();
 
-		$this->response->setData( [
-			'returnto' => $this->getReturnToFromQuery( $query ),
-			'returntoquery' => $this->getReturnToQueryFromQuery( $query ),
-		] );
+		$this->response->setVal( 'returnto', $this->getReturnToFromQuery( $query ) );
+		$this->response->setVal( 'returntoquery', $this->getReturnToQueryFromQuery( $query ) );
 
 		$requestParams = $this->getRequest()->getParams();
 		if ( !empty( $requestParams[ 'registerLink' ] ) ) {
@@ -276,21 +274,6 @@ class UserLoginSpecialController extends WikiaSpecialPageController {
 		if ( !empty( $requestParams[ 'template' ] ) ) {
 			$this->overrideTemplate( $requestParams[ 'template' ] );
 		}
-	}
-
-	/**
-	 * This method returns an array of query parameters that do not contain sensitive information
-	 * This can be used to construct returnto and returntoquery values that are not compromising.
-	 */
-	private function getSanitizedQueryString() {
-		$query = $this->app->wg->Request->getValues();
-		$filterParams = [ 'password', 'username', 'loginToken' ];
-
-		foreach ( $filterParams as $paramName ) {
-			unset( $query[$paramName] );
-		}
-
-		return $query;
 	}
 
 	private function getReturnToFromQuery( &$query ) {
@@ -335,9 +318,9 @@ class UserLoginSpecialController extends WikiaSpecialPageController {
 			// Don't use any query parameters if this was a POST and we couldn't find
 			// a returntoquery param
 			return '';
-		} else {
-			return wfArrayToCGI( $query );
 		}
+
+		return wfArrayToCGI( $query );
 	}
 
 	public function providers() {

--- a/extensions/wikia/UserLogin/UserLoginSpecialController.class.php
+++ b/extensions/wikia/UserLogin/UserLoginSpecialController.class.php
@@ -267,12 +267,12 @@ class UserLoginSpecialController extends WikiaSpecialPageController {
 		$this->response->setVal( 'returntoquery', $this->getReturnToQueryFromQuery( $query ) );
 
 		$requestParams = $this->getRequest()->getParams();
-		if ( !empty( $requestParams[ 'registerLink' ] ) ) {
-			$this->response->setVal( 'registerLink',  $requestParams[ 'registerLink' ] );
+		if ( !empty( $requestParams['registerLink'] ) ) {
+			$this->response->setVal( 'registerLink',  $requestParams['registerLink'] );
 		}
 
-		if ( !empty( $requestParams[ 'template' ] ) ) {
-			$this->overrideTemplate( $requestParams[ 'template' ] );
+		if ( !empty( $requestParams['template'] ) ) {
+			$this->overrideTemplate( $requestParams['template'] );
 		}
 	}
 


### PR DESCRIPTION
This addresses the P2 bug:

  https://wikia-inc.atlassian.net/browse/SOC-326

We're filtering out certain known bad params as well as not taking any parameters sent to us as part of a post request.
