### PR TITLE
PLATFORM-841: improve logging of DFS storage errors

### DIFF
--- a/extensions/SwiftCloudFiles/php-cloudfiles-1.7.10/cloudfiles_http.php
+++ b/extensions/SwiftCloudFiles/php-cloudfiles-1.7.10/cloudfiles_http.php
@@ -1482,15 +1482,13 @@ class CF_Http
 				break;
 			}
 
-			// log errors
-			if ( is_numeric( $res ) ) {
-				$message = json_encode( [ $conn_type, $url_path, $hdrs, "HTTP {$res}" ] );
-			}
-			else {
-				$message = $this->error_str;
-			}
-
-			\Wikia\SwiftStorage::log( __CLASS__ . '::retryRequest::' . $retriesLeft, $message );
+			Wikia\Logger\WikiaLogger::instance()->error( 'SwiftStorage: retry', [
+				'exception'    => new Exception( $this->error_str, is_numeric($res) ? $res : 0 ),
+				'retries-left' => $retriesLeft,
+				'headers'      => $hdrs,
+				'conn-type'    => $conn_type,
+				'path'         => $url_path
+			] );
 
 			// wait a bit before retrying the request
 			usleep( self::RETRY_DELAY * 1000 );

--- a/extensions/SwiftCloudFiles/php-cloudfiles-1.7.10/cloudfiles_http.php
+++ b/extensions/SwiftCloudFiles/php-cloudfiles-1.7.10/cloudfiles_http.php
@@ -795,8 +795,14 @@ class CF_Http
         return array($return_code,$this->response_reason);
     }
 
-    # PUT /v1/Account/Container/Object
-    #
+	/**
+	 * PUT /v1/Account/Container/Object
+	 *
+	 * @param CF_Object $obj
+	 * @param resource $fp
+	 * @return array
+	 * @throws SyntaxException
+	 */
     function put_object(&$obj, &$fp)
     {
         if (!is_object($obj) || get_class($obj) != "CF_Object") {

--- a/extensions/wikia/SwiftSync/classes/ImageSync.class.php
+++ b/extensions/wikia/SwiftSync/classes/ImageSync.class.php
@@ -14,9 +14,9 @@ class ImageSync implements \Iterator {
 	protected $current;
 	
 	/* 
-	 * @param $res ResultWrapper
+	 * @param $res \ResultWrapper
 	 */
-	function __construct( $res ) {
+	function __construct( \ResultWrapper $res ) {
 		$this->res = $res;
 		$this->inx = 0;
 		$this->setCurrent( $this->res->current() );
@@ -46,10 +46,7 @@ class ImageSync implements \Iterator {
 		$syncResult = null;
 		if ( !is_null( $result ) ) {
 			$syncResult = new ImageSync( $result );
-		} else {
-			\Wikia\SwiftStorage::log( __METHOD__, 'No image to sync to other DC' );
 		}
-		
 		wfProfileOut( __METHOD__ );
 		
 		return $syncResult;
@@ -78,7 +75,7 @@ class ImageSync implements \Iterator {
 		return $this->current;
 	}
 
-	/* @return void */
+	/* @return int */
 	function key() {
 		return $this->inx;
 	}

--- a/extensions/wikia/SwiftSync/classes/Queue.class.php
+++ b/extensions/wikia/SwiftSync/classes/Queue.class.php
@@ -151,14 +151,7 @@ class Queue {
 		
 		return wfGetDB( ( empty( $master ) ) ? DB_SLAVE : DB_MASTER, array(), $wgSpecialsDB );
 	}
-	
-	/*
-	 * Return list of columns in self::SYNC_TABLE 
-	 */
-	private function tableColumns() {
-		
-	}
-	
+
 	/* 
 	 * Save information about uploaded image in database 
 	 * @return Boolean True/False

--- a/extensions/wikia/SwiftSync/classes/Queue.class.php
+++ b/extensions/wikia/SwiftSync/classes/Queue.class.php
@@ -4,6 +4,8 @@
  */
 namespace Wikia\SwiftSync;
 
+use \Wikia\Logger\WikiaLogger;
+
 /**
  * SwiftSync class needed to sync files between DC
  * 
@@ -40,7 +42,20 @@ class Queue {
 		$this->dst     = $dst;
 		$this->src     = $src;
 	}
-	
+
+	/**
+	 * Log erros from newFromParams method
+	 *
+	 * @param string $message
+	 * @param object $row row that caused an issue
+	 */
+	private static function log($message, $row) {
+		WikiaLogger::instance()->error( 'SwiftStorage: queue item error', [
+			'exception' => new \Exception( $message ),
+			'row'       => (array) $row
+		]);
+	}
+
 	/*
 	 * set id
 	 */
@@ -96,23 +111,23 @@ class Queue {
 		wfProfileIn( __METHOD__ );
 		
 		if ( !isset( $row->img_dest ) ) {
-			\Wikia\SwiftStorage::log( __METHOD__, 'Image destination is empty' );
+			self::log( 'Image destination is empty', $row );
 			wfProfileOut( __METHOD__ );
 			return false;
 		}
 		
 		if ( is_null( $row->city_id ) ) {
-			\Wikia\SwiftStorage::log( __METHOD__, 'Wikia identify is empty' );
+			self::log( 'Wikia identify is empty', $row );
 			wfProfileOut( __METHOD__ );
 			return false;
 		}
 		
 		if ( empty( $row->img_action ) ) {
-			\Wikia\SwiftStorage::log( __METHOD__, 'Sync action is empty' );
+			self::log( 'Sync action is empty', $row );
 			wfProfileOut( __METHOD__ );
 			return false;
 		}
-		
+
 		$obj = new Queue( $row->city_id, $row->img_action, $row->img_dest, $row->img_src );
 		
 		if ( $obj ) {

--- a/includes/wikia/SwiftStorage.class.php
+++ b/includes/wikia/SwiftStorage.class.php
@@ -2,6 +2,8 @@
 
 namespace Wikia;
 
+use Wikia\Logger\Loggable;
+
 /**
  * SwiftStorage
  *
@@ -16,6 +18,8 @@ namespace Wikia;
  * @see $wgFSSwiftConfig
  */
 class SwiftStorage {
+
+	use Loggable;
 
 	const LOG_GROUP = 'swift-storage';
 
@@ -38,7 +42,7 @@ class SwiftStorage {
 	 * Get storage instance to access uploaded files for a given wiki
 	 *
 	 * @param $cityId number|string city ID or wiki name
-	 * @param $dataCenter string|null name of datacenter (res, iowa ... )
+	 * @param $dataCenter string|null name of data center (res, iowa ... )
 	 * @return SwiftStorage storage instance
 	 */
 	public static function newFromWiki( $cityId, $dataCenter = null ) {
@@ -94,6 +98,18 @@ class SwiftStorage {
 	}
 
 	/**
+	 * Extend the context of all messages sent from this class
+	 *
+	 * @return array
+	 */
+	protected function getLoggerContext() {
+		return [
+			'container'    => $this->getContainerName(),
+			'swift-server' => $this->getSwiftServer(),
+		];
+	}
+
+	/**
 	 * Connect to Swift backend
 	 *
 	 * @param $config array Swift configuration
@@ -144,10 +160,12 @@ class SwiftStorage {
 		$status = $req->execute();
 
 		if (!$status->isOK()) {
-			self::log(
-				__METHOD__,
-				sprintf('can\'t set ACL [<%s> returned HTTP %d - %s] %s', $url, $req->getStatus(), json_encode($status->getErrorsArray()), json_encode($req->getResponseHeaders()))
-			);
+			$this->error( 'SwiftStorage: unable to set ACL', [
+				'exception' => new \Exception( $status->getMessage(), $req->getStatus() ),
+				'url'       => $url,
+				'errors'    => $status->getErrorsArray(),
+				'headers'   => $req->getResponseHeaders(),
+			]);
 		}
 
 		return $container;
@@ -187,18 +205,22 @@ class SwiftStorage {
 			if ( !is_resource( $localFile )  ) {
 				$fp = @fopen( $localFile, 'r' );
 				if ( !$fp ) {
-					self::log( __METHOD__ . '::fopen', "<{$localFile}> doesn't exist" );
+					$this->error( 'SwiftStorage: fopen - file does not exist', [
+						'exception'  => new \Exception($localFile)
+					]);
 					return \Status::newFatal( "{$localFile} doesn't exist" );
 				}
 			} else {
 				$fp = $localFile;
 			}
 
-			// check file size - sending empty file results in "HTTP 411 MissingContentLengh"
+			// check file size - sending empty file results in "HTTP 411 MissingContentLength"
 			$size = (float)fstat( $fp )['size'];
 			if ( $size === 0 ) {
-				self::log( __METHOD__ . '::fstat', "<{$file}> is empty" );
-				return \Status::newFatal( "{$file} is empty" );
+				$this->error( 'SwiftStorage: fopen - file is empty', [
+					'exception'  => new \Exception($localFile)
+				]);
+				return \Status::newFatal( "{$localFile} is empty" );
 			}
 
 			$object = $this->container->create_object( $remotePath );
@@ -220,7 +242,12 @@ class SwiftStorage {
 			}
 		}
 		catch ( \Exception $ex ) {
-			self::log( __METHOD__ . '::exception',  $localFile . ' - ' . $ex->getMessage() );
+			$this->error( 'SwiftStorage: exception', [
+				'op'         => 'store',
+				'args'       => [ $localFile, $remoteFile, $metadata, $mimeType ],
+				'exception'  => $ex
+			]);
+
 			return \Status::newFatal( $ex->getMessage() );
 		}
 
@@ -231,7 +258,7 @@ class SwiftStorage {
 	}
 
 	/**
-	 * Remove fiven remote file
+	 * Remove given remote file
 	 *
 	 * @param $remoteFile string remote file name
 	 * @return \Status result
@@ -246,7 +273,11 @@ class SwiftStorage {
 			$this->container->delete_object( $remotePath );
 		}
 		catch ( \Exception $ex ) {
-			self::log( __METHOD__ . '::exception',  $remotePath . ' - ' . $ex->getMessage() );
+			$this->error( 'SwiftStorage: exception', [
+				'op'         => 'remove',
+				'args'       => [ $remoteFile ],
+				'exception'  => $ex
+			]);
 			return \Status::newFatal( $ex->getMessage() );
 		}
 
@@ -265,17 +296,21 @@ class SwiftStorage {
 			$object = $this->container->get_object( $remoteFile );
 			$content = $object->read();
 		}
-		catch ( \InvalidResponseException $e ) {
-			self::log( __METHOD__ . '::exception', $remoteFile . ' - ' . $e->getMessage() );
+		catch ( \InvalidResponseException $ex ) {
+			$this->error( 'SwiftStorage: exception', [
+				'op'         => 'read',
+				'args'       => [ $remoteFile ],
+				'exception'  => $ex
+			]);
 			return null;
 		}
-		catch ( \NoSuchObjectException $e ) {
+		catch ( \NoSuchObjectException $ex ) {
 			return null;
 		}
-		
+
 		return $content;
 	}
-	 
+
 	/**
 	 * Check if given remote file exists
 	 *
@@ -309,19 +344,7 @@ class SwiftStorage {
 	}
 
 	/**
-	 * Log to /var/log/private file
-	 *
-	 * @param $method string method
-	 * @param $msg string message to log
-	 */
-	public static function log($method, $msg) {
-		\Wikia::log(self::LOG_GROUP . '-WIKIA', false, $method . ': ' . $msg, true /* $force */);
-	}
-
-	/**
 	 * Return Swift server 
-	 * 
-	 * @param - no params
 	 */
 	public function getSwiftServer() {
 		return $this->swiftServer;


### PR DESCRIPTION
Log more details when:
- Swift client returns HTTP error
- Swift operation retry is performed
- `ImageSync` gets an incorrect entry to synchronize from SJC to RES
- Swift basic operation fails: store / move / read

@ljagiello / @michalroszka / @wladekb 
