### PR TITLE
Add an iterator constructor that accepts a WikiaSQL object.

### DIFF
--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -271,6 +271,7 @@ $wgAutoloadClasses[ 'MemcacheClientShadower'          ] = "{$IP}/includes/wikia/
 $wgAutoloadClasses[ 'Wikia\\SwiftStorage'             ] = "$IP/includes/wikia/SwiftStorage.class.php";
 $wgAutoloadClasses[ 'WikiaSQL'                        ] = "$IP/includes/wikia/WikiaSQL.class.php";
 $wgAutoloadClasses[ 'WikiaSQLCache'                   ] = "$IP/includes/wikia/WikiaSQLCache.class.php";
+$wgAutoloadClasses[ 'WikiaSQLIterator'                ] = "$IP/includes/wikia/WikiaSQLIterator.class.php";
 $wgAutoloadClasses[ 'WikiaSanitizer'                  ] = "$IP/includes/wikia/WikiaSanitizer.class.php";
 $wgAutoloadClasses[ 'ScribePurge'                     ] = "$IP/includes/cache/wikia/ScribePurge.class.php";
 $wgAutoloadClasses[ 'Transaction'                     ] = "$IP/includes/wikia/transaction/Transaction.php";

--- a/includes/wikia/WikiaSQLIterator.class.php
+++ b/includes/wikia/WikiaSQLIterator.class.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * WikiaSQLIterator
+ */
+
+class WikiaSQLIterator {
+
+	const DEFAULT_CHUNK_SIZE = 1000;
+
+	private $limit = self::DEFAULT_CHUNK_SIZE;
+	private $offset = 0;
+	private $needsInit = true;
+	private $queryDone = false;
+
+	private $chunkSize = 0;
+	private $chunkIndex = 0;
+	private $recordNum = 0;
+
+	/** @var DatabaseBase */
+	private $dbh;
+
+	/** @var WikiaSQL */
+	private $sql;
+
+	/** @var ResultWrapper|bool  */
+	private $result;
+
+	/**
+	 * Create a new WikiaSQL iterator
+	 *
+	 * @param DatabaseBase $dbh
+	 * @param WikiaSQL $sql
+	 */
+	public function __construct( DatabaseBase $dbh, WikiaSQL $sql ) {
+		$this->sql = $sql;
+		$this->dbh = $dbh;
+		return $this;
+	}
+
+	/**
+	 * Set the maximum number of rows to select at once
+	 *
+	 * @param $limit
+	 *
+	 * @return $this
+	 */
+	public function resultLimit( $limit ) {
+		$this->limit = $limit;
+		$this->sql->limit( $limit );
+		return $this;
+	}
+
+	/**
+	 * The record to start at.  Defaults to 0.
+	 *
+	 * @param $offset
+	 *
+	 * @return $this
+	 */
+	public function startAt( $offset ) {
+		$this->offset = $offset;
+		$this->sql->offset( $offset );
+		return $this;
+	}
+
+	/**
+	 * Return the next row in the query or null when finished
+	 *
+	 * @return null|stdClass
+	 */
+	public function next() {
+		if ( $this->needsInit ) {
+			$this->loadNextChunk();
+			$this->needsInit = false;
+		}
+
+		if ( $this->chunkProcessed() ) {
+			$this->loadNextChunk();
+		}
+
+		if ( $this->queryDone ) {
+			return null;
+		}
+
+		return $this->getNextRecord();
+	}
+
+	protected function loadNextChunk() {
+		$this->result = $this->sql->run( $this->dbh );
+		$this->chunkSize = $this->result->numRows();
+		$this->chunkIndex = 0;
+
+		if ( $this->chunkSize > 0 ) {
+			// Line up the offset for the next call
+			$this->offset += $this->limit;
+			$this->sql->offset( $this->offset );
+		} else {
+			// If no rows are returned after a fetch, we're done
+			$this->queryDone = true;
+		}
+	}
+
+	protected function chunkProcessed() {
+		return $this->chunkIndex >= $this->chunkSize;
+	}
+
+	/**
+	 * Returns the next row from the query.
+	 *
+	 * @return stdClass
+	 */
+	protected function getNextRecord() {
+		$row = $this->result->fetchObject();
+		$this->chunkIndex++;
+		$this->recordNum++;
+
+		return $row;
+	}
+
+	/**
+	 * Returns the current record in the query
+	 *
+	 * @return int
+	 */
+	public function currentRecordNum() {
+		return $this->recordNum;
+	}
+
+	/**
+	 * Reports on the state of this iterator
+	 *
+	 * @return bool
+	 */
+	public function isDone() {
+		return $this->queryDone;
+	}
+}
+
+class WikiaSQLIteratorException extends Exception {}

--- a/maintenance/wikia/userIter.php
+++ b/maintenance/wikia/userIter.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * @ingroup Maintenance
+ */
+
+// Eliminate the need to set this on the command line
+if ( !getenv( 'SERVER_ID' ) ) {
+	putenv( "SERVER_ID=177" );
+}
+
+ini_set('display_errors', 'stderr');
+ini_set('error_reporting', E_NOTICE);
+
+require_once( dirname( __FILE__ ) . '/../Maintenance.php' );
+
+class UserIter extends Maintenance {
+
+	public function __construct() {
+		parent::__construct();
+		$this->mDescription = "User Iter";
+	}
+
+	public function execute() {
+		$dbh = wfGetDB( DB_SLAVE, null, F::app()->wg->ExternalSharedDB );
+		$sql = ( new WikiaSQL() )
+			->select( 'user_name' )
+			->from( 'user' );
+
+		$iter = ( new WikiaSQLIterator( $dbh, $sql ) )
+			->startAt( 10 )
+			->resultLimit( 100 );
+
+		$stopAt = 30;
+
+		while ( $row = $iter->next() ) {
+			echo '>> '.$iter->currentRecordNum() . ' : ' . $row->user_name . "\n";
+
+			if ( $iter->currentRecordNum() >= $stopAt ) {
+				break;
+			}
+		}
+
+		return;
+	}
+}
+
+$maintClass = "UserIter";
+require_once( RUN_MAINTENANCE_IF_MAIN );


### PR DESCRIPTION
A common problem in codebases with a lot of legacy code are queries that return huge amounts of data when before they may have only returned a small number of rows.

It occurred to me that with the WikiaSQL class, it would be trivial to create a class that would take an existing WikiaSQL object (possibly with a simple conversion from the old style syntax) and create an iterator that would automatically handle chunking the data into smaller sets, re-querying for subsequent sets when necessary.

This is that class.  Here is sample usage:

``` php
// Define a query that returns ALL user records
$dbh = wfGetDB( DB_SLAVE, null, F::app()->wg->ExternalSharedDB );
$sql = ( new WikiaSQL() )
    ->select( 'user_name' )
    ->from( 'user' );

// Create an iterator that will actually only grab 100 at a time while processing the entire set
$iter = ( new WikiaSQLIterator( $dbh, $sql ) )->resultLimit( 100 );

while ( $row = $iter->next() ) {
    $name = $row->user_name;
    $recordNum = $iter->currentRecordNum();
}
```

It also supports a `->startAt( $num )` initializer that lets you set the starting offset in the set.  With only a little effort I can see this as an easy way to paginate existing queries that return too much data.  Of course, it can also alleviate the tedious task of paginating any new queries.

This PR also includes a test script, `maintenance/wikia/userIter.php`.  It essentially implements the above query, breaking out of the loop after 30 records.  It can be run like:

``` bash
php maintenance/wikia/userIter.php
```
