### PR TITLE
(CE-1286,CE-1287) Fix XSS and CSRF issues in Top Ten Lists

### DIFF
--- a/extensions/wikia/TopLists/specials/SpecialCreateTopList.class.php
+++ b/extensions/wikia/TopLists/specials/SpecialCreateTopList.class.php
@@ -60,7 +60,7 @@ class SpecialCreateTopList extends SpecialPage {
 		$items = null;
 		$userCanEditItems = $userCanDeleteItems = true;
 
-		if( $wgRequest->wasPosted() ) {
+		if( $wgRequest->wasPosted() && $wgUser->matchEditToken( $wgRequest->getVal( 'wpEditToken' ) ) ) {
 			$listName = $wgRequest->getText( 'list_name' );
 			$relatedArticleName = $wgRequest->getText( 'related_article_name' );
 			$selectedPictureName = $wgRequest->getText( 'selected_picture_name' );
@@ -112,10 +112,10 @@ class SpecialCreateTopList extends SpecialPage {
 
 					if ( empty( $title ) ) {
 						$errors[ 'related_article_name' ] = array( wfMsg( 'toplists-error-invalid-title' )  );
-					} 
+					}
 					elseif ( !wfRunHooks( "PageTitleFilter", array( $title, &$error_msg ) ) ) {
 						$errors[ 'related_article_name' ] = array( ( !empty($error_msg) ) ? $error_msg : wfMsg( 'spamprotectiontext' ) );
-					} 
+					}
 					else {
 						$setResult = $list->setRelatedArticle( $title );
 
@@ -269,7 +269,8 @@ class SpecialCreateTopList extends SpecialPage {
 				$items
 			),
 			'userCanEditItems' => $userCanEditItems,
-			'userCanDeleteItems' => $userCanDeleteItems
+			'userCanDeleteItems' => $userCanDeleteItems,
+			'token' => $wgUser->getEditToken(),
 		) );
 
 		// render template

--- a/extensions/wikia/TopLists/specials/SpecialEditTopList.class.php
+++ b/extensions/wikia/TopLists/specials/SpecialEditTopList.class.php
@@ -81,7 +81,7 @@ class SpecialEditTopList extends SpecialPage {
 			$userCanEditItems = $list->checkUserItemsRight( 'edit' );
 			$userCanDeleteItems = $list->checkUserItemsRight( 'delete' );
 
-			if ( $wgRequest->wasPosted() ) {
+			if ( $wgRequest->wasPosted() && $wgUser->matchEditToken( $wgRequest->getVal( 'wpEditToken' ) ) ) {
 				TopListHelper::clearSessionItemsErrors();
 
 				$relatedArticleName = $wgRequest->getText( 'related_article_name' );
@@ -402,7 +402,8 @@ class SpecialEditTopList extends SpecialPage {
 				),
 				'removedItems' => $removedItems,
 				'userCanEditItems' => $userCanEditItems,
-				'userCanDeleteItems' => $userCanDeleteItems
+				'userCanDeleteItems' => $userCanDeleteItems,
+				'token' => $wgUser->getEditToken(),
 			) );
 
 			// render template

--- a/extensions/wikia/TopLists/templates/editor.tmpl.php
+++ b/extensions/wikia/TopLists/templates/editor.tmpl.php
@@ -4,24 +4,24 @@
 		<div class="frame">
 			<div class="NoPicture"
 				<?= ( !empty( $selectedImage ) ) ? 'style="display: none;"' : null ;?>
-			     title="<?= wfMsg( 'toplits-image-browser-no-picture-selected' ) ;?>">
+				title="<?= wfMessage( 'toplits-image-browser-no-picture-selected' )->escaped(); ?>">
 				<span>
-					<?= wfMsg( 'toplists-editor-image-browser-tooltip' ) ;?>
+					<?= wfMessage( 'toplists-editor-image-browser-tooltip' )->escaped(); ?>
 				</span>
 			</div>
 
 			<? if ( !empty( $selectedImage ) ) :?>
-				<img src="<?= $selectedImage[ 'url' ] ;?>"
-				     alt="<?= $selectedImage[ 'name' ] ;?>"
-				     title="<?= $selectedImage[ 'name' ] ;?>" />
+				<img src="<?= Sanitizer::encodeAttribute( $selectedImage[ 'url' ] ); ?>"
+				     alt="<?= Sanitizer::encodeAttribute( $selectedImage[ 'name' ] ); ?>"
+				     title="<?= Sanitizer::encodeAttribute( $selectedImage[ 'name' ] ); ?>" />
 			<? endif ;?>
 		</div>
 
-		<a class="wikia-chiclet-button" title="<?= wfMsg( 'toplists-editor-image-browser-tooltip' ); ?>" rel="nofollow">
-			<img class="sprite photo" alt="<?= wfMsg( 'toplists-editor-image-browser-tooltip' ); ?>" src="<?= wfBlankImgUrl() ;?>">
+		<a class="wikia-chiclet-button" title="<?= wfMessage( 'toplists-editor-image-browser-tooltip' )->escaped(); ?>" rel="nofollow">
+			<img class="sprite photo" alt="<?= wfMessage( 'toplists-editor-image-browser-tooltip' )->escaped(); ?>" src="<?= wfBlankImgUrl() ;?>">
 		</a>
 
-		<input type="hidden" name="selected_picture_name" value="<?= ( !empty( $selectedImage ) ) ? $selectedImage[ 'name' ] : null ;?>" />
+		<input type="hidden" name="selected_picture_name" value="<?= !empty( $selectedImage ) ? Sanitizer::encodeAttribute( $selectedImage[ 'name' ] ) : '' ;?>" />
 
 		<? if ( !empty( $errors[ 'selected_picture_name' ] ) ) :?>
 			<? foreach( $errors[ 'selected_picture_name' ] as $errorMessage ) :?>
@@ -29,30 +29,30 @@
 			<? endforeach ;?>
 		<? endif ;?>
 	</div>
-	
+
 	<div class="InputSet">
-		<label for="list_name"><?= wfMsg( 'toplists-editor-title-label' ) ;?></label>
+		<label for="list_name"><?= wfMessage( 'toplists-editor-title-label' )->escaped(); ?></label>
 		<? if ( $mode == 'create' ) :?>
-			<input type="text" name="list_name" id="list_name" placeholder="<?= wfMsg( 'toplists-editor-title-placeholder' ) ;?>"
-				value="<?= $listName ;?>"<?= ( !empty( $errors[ 'list_name' ] ) ) ? ' class="error"' : null ;?> />
+			<input type="text" name="list_name" id="list_name" placeholder="<?= wfMessage( 'toplists-editor-title-placeholder' )->escaped(); ?>"
+				value="<?= Sanitizer::encodeAttribute( $listName ); ?>"<?= ( !empty( $errors[ 'list_name' ] ) ) ? ' class="error"' : '' ;?> />
 			<? if ( !empty( $errors[ 'list_name' ] ) ) :?>
 				<? foreach( $errors[ 'list_name' ] as $errorMessage ) :?>
 					<p class="error"><?= $errorMessage ;?></p>
 				<? endforeach ;?>
 			<? endif ;?>
 		<? else :?>
-			<big><strong><?= htmlspecialchars($listName) ;?></strong></big>
+			<big><strong><?= htmlspecialchars( $listName ); ?></strong></big>
 		<? endif ;?>
 	</div>
 
 	<div class="InputSet AutoCompleteWrapper">
 		<label for="related_article_name">
-			<?= wfMsg( 'toplists-editor-related-article-label' ) ;?>
+			<?= wfMessage( 'toplists-editor-related-article-label' )->parse(); ?>
 		</label>
 
-		<input type="text" id="related_article_name" name="related_article_name" placeholder="<?= wfMsg( 'toplists-editor-related-article-placeholder' ) ;?>"
-			autocomplete="off" value="<?= $relatedArticleName ;?>"
-			<?= ( !empty( $errors[ 'related_article_name' ] ) ) ? ' class="error"' : null ;?> />
+		<input type="text" id="related_article_name" name="related_article_name" placeholder="<?= wfMessage( 'toplists-editor-related-article-placeholder' )->escaped(); ?>"
+			autocomplete="off" value="<?= Sanitizer::encodeAttribute( $relatedArticleName ); ?>"
+			<?= ( !empty( $errors[ 'related_article_name' ] ) ) ? ' class="error"' : '' ;?> />
 
 		<? if ( !empty( $errors[ 'related_article_name' ] ) ) :?>
 			<? foreach( $errors[ 'related_article_name' ] as $errorMessage ) :?>
@@ -63,12 +63,12 @@
 
     <div class="InputSet AutoCompleteWrapper">
         <label for="description">
-            <?= wfMsg( 'toplists-editor-description-label' ) ;?>
+            <?= wfMessage( 'toplists-editor-description-label' )->escaped(); ?>
         </label>
 
-        <input type="text" id="description" name="description" placeholder="<?= wfMsg( 'toplists-editor-description-placeholder' ) ;?>"
-               autocomplete="off" value="<?= htmlspecialchars( $description ); ?>"
-            <?= ( !empty( $errors[ 'description' ] ) ) ? ' class="error"' : null ;?> />
+        <input type="text" id="description" name="description" placeholder="<?= wfMessage( 'toplists-editor-description-placeholder' )->escaped(); ?>"
+               autocomplete="off" value="<?= Sanitizer::encodeAttribute( $description ); ?>"
+            <?= ( !empty( $errors[ 'description' ] ) ) ? ' class="error"' : '' ;?> />
 
         <? if ( !empty( $errors[ 'description' ] ) ) :?>
         <? foreach( $errors[ 'description' ] as $errorMessage ) :?>
@@ -80,30 +80,30 @@
 	<ul class="ItemsList">
 		<? foreach( $items as $position => $item ): ?>
 			<?$isDraggable = $isDeletable = $isEditable = ( in_array( $item['type'], array( 'new', 'template' ) ) ) ;?>
-			<li class="ListItem<?= ( $isDraggable )  ? ' NewItem' : null ;?><?= ( $item['type'] == 'template' ) ? ' ItemTemplate' : null ;?>">
+			<li class="ListItem<?= ( $isDraggable )  ? ' NewItem' : '' ;?><?= ( $item['type'] == 'template' ) ? ' ItemTemplate' : '' ;?>">
 				<? if ( $item['type'] == 'existing' && isset( $item['index'] ) ) :?>
-					<input type="hidden" value="<?= $item['index'] ;?>" />
+					<input type="hidden" value="<?= Sanitizer::encodeAttribute( $item['index'] ); ?>" />
 				<? endif ;?>
-				
-				<div class="ItemNumber">#<?= ( $item['type'] != 'template' ) ? $position : null ;?></div>
+
+				<div class="ItemNumber">#<?= ( $item['type'] != 'template' ) ? $position : '' ;?></div>
 
 				<div class="ItemName">
 					<? if ( $userCanEditItems || $isEditable ) :?>
-						<input type="text" name="items_names[]" value="<?= htmlspecialchars($item['value']) ;?>"
-							<?= ( $item['type'] == 'template' ) ? ' disabled' : null ;?>
-							<?= ( !empty( $errors[ "item_{$position}" ] ) ) ? ' class="error"' : null ;?> />
+						<input type="text" name="items_names[]" value="<?= Sanitizer::encodeAttribute( $item['value'] ); ?>"
+							<?= ( $item['type'] == 'template' ) ? ' disabled' : '' ;?>
+							<?= ( !empty( $errors[ "item_{$position}" ] ) ) ? ' class="error"' : '' ;?> />
 					<? else :?>
-						<div class="InputDisabled"><?= htmlspecialchars($item['value']) ;?></div>
-						<input type="hidden" name="items_names[]" value="<?= htmlspecialchars($item['value']) ;?>" />
+						<div class="InputDisabled"><?= htmlspecialchars( $item['value'] ); ?></div>
+						<input type="hidden" name="items_names[]" value="<?= Sanitizer::encodeAttribute( $item['value'] );?>" />
 					<? endif ;?>
-					
+
 				</div>
-				
+
 				<? if ( $userCanDeleteItems || $isDeletable ) :?>
 					<div class="ItemRemove">
-						<a title="<?= wfMsg( 'toplists-editor-remove-item-tooltip' ) ;?>" rel="nofollow">
+						<a title="<?= wfMessage( 'toplists-editor-remove-item-tooltip' )->escaped(); ?>" rel="nofollow">
 							<img class="sprite remove"
-							     alt="<?= wfMsg( 'toplists-editor-remove-item-tooltip' ) ;?>"
+							     alt="<?= wfMessage( 'toplists-editor-remove-item-tooltip' )->escaped(); ?>"
 							     src="<?= wfBlankImgUrl() ;?>" />
 						</a>
 					</div>
@@ -111,9 +111,9 @@
 
 				<? if ( $isDraggable ) :?>
 					<div class="ItemDrag">
-						<a title="<?= wfMsg( 'toplists-editor-drag-item-tooltip' ) ;?>" rel="nofollow">
+						<a title="<?= wfMessage( 'toplists-editor-drag-item-tooltip' )->escaped(); ?>" rel="nofollow">
 							<img class="sprite drag"
-							     alt="<?= wfMsg( 'toplists-editor-drag-item-tooltip' ) ;?>"
+							     alt="<?= wfMessage( 'toplists-editor-drag-item-tooltip' )->escaped(); ?>"
 							     src="<?= wfBlankImgUrl() ;?>" />
 						</a>
 					</div>
@@ -129,23 +129,23 @@
 	</ul>
 
 	<div class="AddControls">
-		<a id="toplist-add-item" class="wikia-chiclet-button" title="<?= wfMsg( 'toplists-editor-add-item-tooltip' ) ;?>" rel="nofollow">
-			<img class="sprite new" alt="<?= wfMsg( 'toplists-editor-add-item-tooltip' ) ;?>" src="<?= wfBlankImgUrl() ;?>">
+		<a id="toplist-add-item" class="wikia-chiclet-button" title="<?= wfMessage( 'toplists-editor-add-item-tooltip' )->escaped(); ?>" rel="nofollow">
+			<img class="sprite new" alt="<?= wfMessage( 'toplists-editor-add-item-tooltip' )->escaped(); ?>" src="<?= wfBlankImgUrl() ;?>">
 		</a>
-		<label><?= wfMsg( 'toplists-editor-add-item-label' ) ;?></label>
+		<label><?= wfMessage( 'toplists-editor-add-item-label' )->escaped(); ?></label>
 	</div>
 
 	<div class="FormButtons">
 		<? if ( $mode == 'update' ) :?>
-			<a class="wikia-button secondary" href="<?= $listUrl ;?>"><?= wfMsg( "toplists-cancel-button" ) ;?></a>
+			<a class="wikia-button secondary" href="<?= Sanitizer::encodeAttribute( $listUrl ); ?>"><?= wfMessage( 'toplists-cancel-button' )->escaped(); ?></a>
 		<? endif ;?>
-		
-		<input type="Submit" value="<?= wfMsg( "toplists-{$mode}-button" ) ;?>"/>
+
+		<input type="Submit" value="<?= wfMessage( "toplists-{$mode}-button" )->escaped(); ?>"/>
 	</div>
 
 	<? if ( $mode == 'update' && !empty( $removedItems ) ) :?>
 		<? foreach ( $removedItems as $item ) :?>
-			<input type="hidden" name="removed_items[]" value="<?= $item ;?>" />
+			<input type="hidden" name="removed_items[]" value="<?= Sanitizer::encodeAttribute( $item ); ?>" />
 		<? endforeach ;?>
 	<? endif ;?>
 </form>

--- a/extensions/wikia/TopLists/templates/editor.tmpl.php
+++ b/extensions/wikia/TopLists/templates/editor.tmpl.php
@@ -148,4 +148,5 @@
 			<input type="hidden" name="removed_items[]" value="<?= Sanitizer::encodeAttribute( $item ); ?>" />
 		<? endforeach ;?>
 	<? endif ;?>
+	<input type="hidden" name="wpEditToken" value="<?= Sanitizer::encodeAttribute( $token ); ?>" />
 </form>

--- a/extensions/wikia/TopLists/templates/image_browser.tmpl.php
+++ b/extensions/wikia/TopLists/templates/image_browser.tmpl.php
@@ -3,37 +3,37 @@ global $wgScriptPath;
 ?>
 <div id="image-browser-dialog">
 	<? if ( !empty( $selectedImage ) ) :?>
-		<img src="<?= $selectedImage[ 'url' ] ;?>" class="selected"
-		     alt="<?= wfMsg( 'toplits-image-browser-selected-picture', $selectedImage[ 'name' ] ) ;?>"
-		     title="<?= wfMsg( 'toplits-image-browser-selected-picture', $selectedImage[ 'name' ] ) ;?>"/>
+		<img src="<?= Sanitizer::encodeAttribute( $selectedImage[ 'url' ] ); ?>" class="selected"
+		     alt="<?= wfMessage( 'toplits-image-browser-selected-picture', $selectedImage[ 'name' ] )->escaped(); ?>"
+		     title="<?= wfMessage( 'toplits-image-browser-selected-picture', $selectedImage[ 'name' ] )->escaped(); ?>"/>
 	<? else :?>
 		<div class="selected"
-		     title="<?= wfMsg( 'toplits-image-browser-no-picture-selected' ) ;?>">
-			<span><?= wfMsg( 'toplits-image-browser-no-picture-selected' ) ;?></span>
+		     title="<?= wfMessage( 'toplits-image-browser-no-picture-selected' )->escaped(); ?>">
+			<span><?= wfMessage( 'toplits-image-browser-no-picture-selected' )->escaped(); ?></span>
 		</div>
 	<? endif ;?>
 
 	<ul class="SuggestedPictures">
 		<? foreach( $images as $img ) :?>
 			<li>
-				<a title="<?= $img[ 'name' ] ;?>">
-					<img src="<?= $img[ 'url' ] ;?>" alt="<?= $img[ 'name' ] ;?>" />
+				<a title="<?= Sanitizer::encodeAttribute( $img[ 'name' ] ); ?>">
+					<img src="<?= Sanitizer::encodeAttribute( $img[ 'url' ] ); ?>" alt="<?= Sanitizer::encodeAttribute( $img[ 'name' ] ); ?>" />
 				</a>
 			</li>
 		<? endforeach ;?>
 		<li>
 			<div class="NoPicture"
-			     title="<?= wfMsg( 'toplits-image-browser-clear-picture' ) ;?>">
-				<span><?= wfMsg( 'toplits-image-browser-clear-picture' ) ;?></span>
+			     title="<?= wfMessage( 'toplits-image-browser-clear-picture' )->escaped(); ?>">
+				<span><?= wfMessage( 'toplits-image-browser-clear-picture' )->escaped(); ?></span>
 			</div>
 		</li>
 	</ul>
 
 	<img class="osprite shadow-short" src="<?= wfBlankImgUrl() ;?>">
 	<form id="toplist-image-upload" action="<?= $wgScriptPath ?>/index.php?action=ajax&rs=TopListHelper::uploadImage" method="POST" enctype="multipart/form-data">
-		<label for="wpUploadFile"><?= wfMsg( 'toplists-image-browser-upload-label' ) ;?></label>
+		<label for="wpUploadFile"><?= wfMessage( 'toplists-image-browser-upload-label' )->escaped(); ?></label>
 		<div>
-			<div class="button"><?= wfMsg( 'toplists-image-browser-upload-btn' ) ;?><input type="file" name="wpUploadFile" /></div>
+			<div class="button"><?= wfMessage( 'toplists-image-browser-upload-btn' )->escaped(); ?><input type="file" name="wpUploadFile" /></div>
 		</div>
 		<p class="error"></p>
 		<div class="BlockInput"></div>

--- a/extensions/wikia/TopLists/templates/list.tmpl.php
+++ b/extensions/wikia/TopLists/templates/list.tmpl.php
@@ -1,31 +1,31 @@
 <p><?= htmlspecialchars( $description ) ?></p>
 <div id="toplists-list-body">
-	<input type="hidden" id="top-list-title" value="<?= htmlspecialchars( $listTitle ) ?>">
+	<input type="hidden" id="top-list-title" value="<?= Sanitizer::encodeAttribute( $listTitle ) ?>">
 	<? if ( !empty( $relatedImage ) ) :?>
 		<div class="thumb tright">
 			<div class="thumbinner" style="width:200px;">
-				<a href="<?= ( !is_null( $relatedTitleData ) ) ? $relatedTitleData['localURL'] : "/wiki/File:{$relatedImage[ 'name' ]}\" class=\"image" ;?>"
-				   title="<?= ( !is_null( $relatedTitleData ) ) ? $relatedTitleData['text'] : $relatedImage[ 'name' ] ;?>">
-					<img alt="<?= ( !is_null( $relatedTitleData ) ) ? $relatedTitleData['text'] : $relatedImage[ 'name' ] ;?>"
-					     src="<?= $relatedImage[ 'url' ] ;?>"
+				<a href="<?= Sanitizer::encodeAttribute( !is_null( $relatedTitleData ) ? $relatedTitleData['localURL'] : '/wiki/File:' . urlencode( $relatedImage[ 'name' ] ) ); ?>" class="image"
+				   title="<?= Sanitizer::encodeAttribute( !is_null( $relatedTitleData ) ? $relatedTitleData['text'] : $relatedImage[ 'name' ] ); ?>">
+					<img alt="<?= Sanitizer::encodeAttribute( !is_null( $relatedTitleData ) ? $relatedTitleData['text'] : $relatedImage[ 'name' ] ); ?>"
+					     src="<?= Sanitizer::encodeAttribute( $relatedImage[ 'url' ] ); ?>"
 					     border="0"
 					     class="thumbimage" />
 				</a>
 				<div class="thumbcaption">
 					<div class="magnify">
-						<a href="/wiki/File:<?= $relatedImage[ 'name' ] ;?>" class="internal" title="<?= wfMsgForContent( 'thumbnail-more' ); ?>">
+						<a href="/wiki/File:<?= Sanitizer::encodeAttribute( urlencode( $relatedImage[ 'name' ] ) ); ?>" class="internal" title="<?= wfMsgForContent( 'thumbnail-more' ); ?>">
 							<img src="<?= wfBlankImgUrl() ;?>" class="sprite details" width="16" height="16" alt="" />
 						</a>
 					</div>
 					<? if( !is_null( $relatedTitleData ) ) :?>
-						<a href="<?= $relatedTitleData['localURL'] ?>" title="<?= $relatedTitleData['text'] ?>"><?= $relatedTitleData['text'] ?></a>
+						<a href="<?= Sanitizer::encodeAttribute( $relatedTitleData['localURL'] ) ?>" title="<?= Sanitizer::encodeAttribute( $relatedTitleData['text'] ) ?>"><?= htmlspecialchars( $relatedTitleData['text'] ) ?></a>
 					<? endif ;?>
 				</div>
 			</div>
 		</div>
 	<? elseif( !is_null( $relatedTitleData ) ) :?>
 		<div class="ListRelatedArticle">
-			<?= wfMsgForContent( 'toplists-list-related-to' ) ;?> <a href="<?= $relatedTitleData['localURL'] ?>" title="<?= $relatedTitleData['text'] ?>"><?= $relatedTitleData['text'] ?></a>
+			<?= wfMessage( 'toplists-list-related-to' )->inContentLanguage()->escaped(); ?> <a href="<?= Sanitizer::encodeAttribute( $relatedTitleData['localURL'] ) ?>" title="<?= Sanitizer::encodeAttribute( $relatedTitleData['text'] ) ?>"><?= htmlspecialchars( $relatedTitleData['text'] ) ?></a>
 		</div>
 	<? endif ;?>
 
@@ -53,14 +53,14 @@
 				?>
 				<div class="ItemNumber<?= ( $isNumber1 ) ? ' No1' : ' NotVotable' ;?>">
 					<span>#<?= $index ;?></span>
-					<button class="VoteButton" id="<?= $item->getTitle()->getSubpageText() ;?>">
+					<button class="VoteButton" id="<?= Sanitizer::encodeAttribute( $item->getTitle()->getSubpageText() ); ?>">
 						<img src="<?= wfBlankImgUrl() ;?>" class="chevron"/>
-						<?= wfMsgForContent( 'toplists-list-vote-up' ) ;?>
+						<?= wfMessage( 'toplists-list-vote-up' )->inContentLanguage()->escaped(); ?>
 					</button>
 				</div>
 				<div class="ItemContent">
 					<?= $item->getParsedContent() ;?>
-					<span class="author"><?= wfMsgExt( 'toplists-list-created-by', array( 'parse', 'content' ), array( $item->getEditor()->getName() ) ) ;?></span>
+					<span class="author"><?= wfMessage( 'toplists-list-created-by', $item->getEditor()->getName() )->inContentLanguage()->parse(); ?></span>
 					<? if ( /*$isNumber1 && */!$hotFound ) :?>
 						<?
 						$timeStamps = $item->getVotesTimestamps();
@@ -85,29 +85,29 @@
 							<? if ( $count >= TOPLISTS_HOT_MIN_COUNT ) :?>
 								<? $hotFound = true ;?>
 								<div class="HotItem">
-									<span><?= wfMsgExt( 'toplists-list-hotitem-count', array( 'parsemag', 'content' ), array( $count, TopListHelper::formatTimeSpan( $latest - $oldest ) ) ) ;?></span>
+									<span><?= wfMessage( 'toplists-list-hotitem-count', $count, TopListHelper::formatTimeSpan( $latest - $oldest ) )->inContentLanguage()->escaped(); ?></span>
 								</div>
 							<? endif ;?>
 						<? endif ;?>
 					<? endif ;?>
 				</div>
-				<div class="ItemVotes"><?= wfMsgExt( 'toplists-list-votes-num', array( 'parsemag', 'content' ), array( $item->getVotesCount() ) ) ;?></div>
+				<div class="ItemVotes"><?= wfMessage( 'toplists-list-votes-num', $item->getVotesCount() )->inContentLanguage()->parse(); ?></div>
 			</li>
 		<? endforeach; ?>
 			<li>
 				<form class="NewItemForm">
-					<input type="text" id="toplist-new-item-name" placeholder="<?= wfMsgForContent( 'toplists-list-add-item-name-label' ) ;?>"/>
+					<input type="text" id="toplist-new-item-name" placeholder="<?= wfMessage( 'toplists-list-add-item-name-label' )->inContentLanguage()->escaped(); ?>"/>
 					<br>
-					<button title="<?= wfMsgForContent( 'toplists-list-add-item-label' ) ;?>" class="AddButton">
-						<img class="osprite icon-add" src="<?= wfBlankImgUrl() ;?>" alt = "<?= wfMsgForContent( 'toplists-list-add-item-label' ) ;?>"/>
-						<?= wfMsgForContent( 'toplists-list-add-item-label' ) ;?>
+					<button title="<?= wfMessage( 'toplists-list-add-item-label' )->inContentLanguage()->escaped(); ?>" class="AddButton">
+						<img class="osprite icon-add" src="<?= wfBlankImgUrl() ;?>" alt="<?= wfMessage( 'toplists-list-add-item-label' )->inContentLanguage()->escaped(); ?>"/>
+						<?= wfMessage( 'toplists-list-add-item-label' )->inContentLanguage()->escaped(); ?>
 					</button>
 					<p class="error"></p>
 				</form>
 			</li>
 	</ul>
 	<div class="create-new-list">
-		<h5><?= wfMsg('toplists-create-heading') ?></h5>
+		<h5><?= wfMessage( 'toplists-create-heading' )->inContentLanguage()->parse(); ?></h5>
 		<?= Wikia::specialPageLink('CreateTopList', 'toplists-create-button-msg', 'wikia-button createtoplist', 'blank.gif', 'toplists-create-button-msg', 'sprite new'); ?>
 	</div>
 </div>


### PR DESCRIPTION
Escape all attributes and content in Top Ten Lists to prevent various
stored XSS vulnerabilities.

Also protect against CSRF in Top Ten Lists.

Reviewed in https://github.com/Wikia/app/pull/6221
