### PR TITLE
Add logging for attepmts to store large values in memcached

### DIFF
--- a/includes/objectcache/MemcachedClient.php
+++ b/includes/objectcache/MemcachedClient.php
@@ -1157,6 +1157,18 @@ class MWMemcached {
 				$flags |= self::COMPRESSED;
 			}
 		}
+		// Wikia change - begin - @author: wladek
+		// Log details if we try to store value that will not fit the default item_max_size
+		if ( $len > 1024 * 1024 - 2 ) {
+			// default item_max_size is 1mb, 2 characters are reserved for trailing "\r\n"
+			if ( class_exists( 'Wikia\\Logger\\WikiaLogger' ) ) {
+				\Wikia\Logger\WikiaLogger::instance()->debug( 'MemcachedClient - large value' , [
+					'key' => $key,
+					'len' => $len,
+				] );
+			}
+		}
+		// Wikia change - end
 		if ( !$this->_safe_fwrite( $sock, $host, "$cmd $key $flags $exp $len\r\n$val\r\n" ) ) {
 			return $this->_dead_sock( $sock );
 		}

--- a/includes/objectcache/MemcachedClient.php
+++ b/includes/objectcache/MemcachedClient.php
@@ -98,6 +98,7 @@ class MWMemcached {
 
 	// }}}
 
+	const MEMCACHED_ITEM_MAX_SIZE = 1048576; // 1MB
 
 	/**
 	 * Command statistics
@@ -1159,10 +1160,11 @@ class MWMemcached {
 		}
 		// Wikia change - begin - @author: wladek
 		// Log details if we try to store value that will not fit the default item_max_size
-		if ( $len > 1024 * 1024 - 2 ) {
+		if ( $len > self::MEMCACHED_ITEM_MAX_SIZE - 2 ) {
 			// default item_max_size is 1mb, 2 characters are reserved for trailing "\r\n"
 			if ( class_exists( 'Wikia\\Logger\\WikiaLogger' ) ) {
 				\Wikia\Logger\WikiaLogger::instance()->debug( 'MemcachedClient: large value' , [
+					'exception' => new Exception(),
 					'key' => $key,
 					'len' => $len,
 				] );

--- a/includes/objectcache/MemcachedClient.php
+++ b/includes/objectcache/MemcachedClient.php
@@ -1162,7 +1162,7 @@ class MWMemcached {
 		if ( $len > 1024 * 1024 - 2 ) {
 			// default item_max_size is 1mb, 2 characters are reserved for trailing "\r\n"
 			if ( class_exists( 'Wikia\\Logger\\WikiaLogger' ) ) {
-				\Wikia\Logger\WikiaLogger::instance()->debug( 'MemcachedClient - large value' , [
+				\Wikia\Logger\WikiaLogger::instance()->debug( 'MemcachedClient: large value' , [
 					'key' => $key,
 					'len' => $len,
 				] );


### PR DESCRIPTION
This small change will give us more insight into cases that we discovered today when we try to store overly large values into memcached. The size limit (of the default 1mb) is currently hardcoded.

/cc @macbre @owend 
