### PR TITLE
Use ImageBeforeProduceHTML hook in FeedRenderer

### DIFF
--- a/extensions/wikia/MyHome/renderers/FeedRenderer.php
+++ b/extensions/wikia/MyHome/renderers/FeedRenderer.php
@@ -666,8 +666,6 @@ class FeedRenderer {
 	 * @author Maciej Brencz <macbre@wikia-inc.com>
 	 */
 	public static function getAddedMediaRow( $row, $type ) {
-		global $wgArticleAsJson;
-
 		$wg = F::app()->wg;
 
 		$key = "new_{$type}";

--- a/extensions/wikia/MyHome/renderers/FeedRenderer.php
+++ b/extensions/wikia/MyHome/renderers/FeedRenderer.php
@@ -704,18 +704,16 @@ class FeedRenderer {
 				$attribs['href'] = $title->getLocalUrl();
 			}
 
-			if ( $wgArticleAsJson ) {
-				$dummy = new DummyLinker;
-				$file = false;
-				$frameParams = [];
-				$handlerParams = [];
-				$time = false;
-				$res = null;
-				if ( !wfRunHooks( 'ImageBeforeProduceHTML',
-					array( &$dummy, &$title, &$file, &$frameParams, &$handlerParams, &$time, &$res ) ) ) {
-					$thumbs[] = "<li>$res</li>";
-				}
-				// TODO what if not?
+			$hookDummy = new DummyLinker;
+			$hookFile = false;
+			$hookFrameParams = [];
+			$hookHandlerParams = [];
+			$hookTime = false;
+			$hookRes = null;
+
+			if ( !wfRunHooks( 'ImageBeforeProduceHTML',
+				array( &$hookDummy, &$title, &$hookFile, &$hookFrameParams, &$hookHandlerParams, &$hookTime, &$hookRes ) ) ) {
+				$thumbs[] = "<li>$hookRes</li>";
 			} else {
 				$thumb = $item['html'];
 				// Only wrap the line in an anchor if it doesn't already include one

--- a/extensions/wikia/MyHome/renderers/FeedRenderer.php
+++ b/extensions/wikia/MyHome/renderers/FeedRenderer.php
@@ -666,6 +666,8 @@ class FeedRenderer {
 	 * @author Maciej Brencz <macbre@wikia-inc.com>
 	 */
 	public static function getAddedMediaRow( $row, $type ) {
+		global $wgArticleAsJson;
+
 		$wg = F::app()->wg;
 
 		$key = "new_{$type}";
@@ -702,12 +704,26 @@ class FeedRenderer {
 				$attribs['href'] = $title->getLocalUrl();
 			}
 
-			$thumb = $item['html'];
-			// Only wrap the line in an anchor if it doesn't already include one
-			if ( preg_match('/<a[^>]+href/', $thumb) ) {
-				$thumbs[] = "<li>$thumb</li>";
+			if ( $wgArticleAsJson ) {
+				$dummy = new DummyLinker;
+				$file = false;
+				$frameParams = [];
+				$handlerParams = [];
+				$time = false;
+				$res = null;
+				if ( !wfRunHooks( 'ImageBeforeProduceHTML',
+					array( &$dummy, &$title, &$file, &$frameParams, &$handlerParams, &$time, &$res ) ) ) {
+					$thumbs[] = "<li>$res</li>";
+				}
+				// TODO what if not?
 			} else {
-				$thumbs[] = "<li><a data-image-link href=\"{$title->getLocalUrl()}\">$thumb</a></li>";
+				$thumb = $item['html'];
+				// Only wrap the line in an anchor if it doesn't already include one
+				if ( preg_match('/<a[^>]+href/', $thumb) ) {
+					$thumbs[] = "<li>$thumb</li>";
+				} else {
+					$thumbs[] = "<li><a data-image-link href=\"{$title->getLocalUrl()}\">$thumb</a></li>";
+				}
 			}
 		}
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/HG-529

We need to modify output of FeedRenderer using [ArticleAsJson::onImageBeforeProduceHTML](https://github.com/Wikia/app/blob/dev/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php#L116) as we want to display thumbs in _Last activity_ within Mercury skin.

/cc @hakubo @nandy-andy @macbre 
