### PR TITLE
CE-1279 Bring back wikiaPageIsCorporate JS var and use it in WIYL

### DIFF
--- a/extensions/wikia/JSVariables/JSVariables.php
+++ b/extensions/wikia/JSVariables/JSVariables.php
@@ -64,6 +64,7 @@ function wfJSVariablesTopScripts(Array &$vars, &$scripts) {
 	$vars['wgCategories'] = $out->getCategories();
 	$vars['wgPageName'] = $title->getPrefixedDBKey();
 	$vars['wikiaPageType'] = WikiaPageType::getPageType();
+	$vars['wikiaPageIsCorporate'] = WikiaPageType::isCorporatePage();
 
 	// missing in 1.19
 	$skin = RequestContext::getMain()->getSkin();

--- a/extensions/wikia/WikiaInYourLang/modules/ext.wikiaInYourLang.js
+++ b/extensions/wikia/WikiaInYourLang/modules/ext.wikiaInYourLang.js
@@ -27,7 +27,7 @@ require(
 			cacheVersion = '1.01';
 
 		function init() {
-			if (targetLanguage !== false && targetLanguage !== contentLanguage) {
+			if (w.wikiaPageIsCorporate !== "home" && targetLanguage !== false && targetLanguage !== contentLanguage) {
 				// Check local browser cache to see if a request has been sent
 				// in the last month and if the notification has been shown to him.
 				// Both have to be !== true to continue.

--- a/extensions/wikia/WikiaInYourLang/modules/ext.wikiaInYourLang.js
+++ b/extensions/wikia/WikiaInYourLang/modules/ext.wikiaInYourLang.js
@@ -27,7 +27,7 @@ require(
 			cacheVersion = '1.01';
 
 		function init() {
-			if (w.wikiaPageIsCorporate !== "home" && targetLanguage !== false && targetLanguage !== contentLanguage) {
+			if (targetLanguage !== false && targetLanguage !== contentLanguage) {
 				// Check local browser cache to see if a request has been sent
 				// in the last month and if the notification has been shown to him.
 				// Both have to be !== true to continue.
@@ -154,6 +154,8 @@ require(
 			tracker.track(trackingParams);
 		}
 
-		$(init);
+		if (!w.wikiaPageIsCorporate) {
+			$(init);
+		}
 	}
 );


### PR DESCRIPTION
see: [CE-1279](https://wikia-inc.atlassian.net/browse/CE-1279)

When investigating CE-1279 it turned out that the wikiaPageIsCorporate JS variable has been removed. This pull request brings it back and uses it to exclude WikiaInYourLang from corporate pages.

Ping: @gabrys @vforge 
