### PR TITLE
(CE-1223) Don't parse username parameter on email confirmation page

### DIFF
--- a/extensions/wikia/UserLogin/UserSignupSpecialController.class.php
+++ b/extensions/wikia/UserLogin/UserSignupSpecialController.class.php
@@ -292,18 +292,23 @@ class UserSignupSpecialController extends WikiaSpecialPageController {
 			if ( ( isset( $_SESSION['notConfirmedUserId'] ) && $_SESSION['notConfirmedUserId'] == $user->getId() ) ) {
 				$mailTo = $user->getEmail();
 			}
+		} else {
+			// Redirect back to login if we didn't get a valid user
+			$titleObj = SpecialPage::getTitleFor( 'Userlogin' );
+			$this->wg->out->redirect( $titleObj->getFullURL() );
+			return;
 		}
 
 		$this->result = 'ok';
 		$mailTo = htmlspecialchars( $mailTo );
 		if ( F::app()->checkskin( 'wikiamobile' ) ) {
-			$this->msg = wfMessage( 'usersignup-confirmation-email-sent-wikiamobile', $mailTo )->parse();
+			$this->msg = wfMessage( 'usersignup-confirmation-email-sent-wikiamobile' )->rawParams( $mailTo )->parse();
 			$this->overrideTemplate( 'WikiaMobileSendConfirmationEmail' );
 			$this->wg->Out->setPageTitle( wfMessage( 'usersignup-confirm-page-title-wikiamobile' )->plain() );
 		} else {
 			$this->heading = wfMessage( 'usersignup-confirmation-heading' )->escaped();
 			$this->subheading = wfMessage( 'usersignup-confirmation-subheading' )->escaped();
-			$this->msg = wfMessage( 'usersignup-confirmation-email-sent', $mailTo )->parse();
+			$this->msg = wfMessage( 'usersignup-confirmation-email-sent' )->rawParams( $mailTo )->parse();
 			$this->msgEmail = '';
 			$this->errParam = '';
 
@@ -347,8 +352,9 @@ class UserSignupSpecialController extends WikiaSpecialPageController {
 			} else {
 				if ( $this->byemail == true ) {
 					$this->heading = wfMessage( 'usersignup-account-creation-heading' )->escaped();
-					$this->subheading = wfMessage( 'usersignup-account-creation-subheading', $mailTo )->escaped();
-					$this->msg = wfMessage( 'usersignup-account-creation-email-sent', $mailTo, $this->username )->parse();
+					$this->subheading = wfMessage( 'usersignup-account-creation-subheading' )->rawParams( $mailTo )->escaped();
+					$this->msg = wfMessage( 'usersignup-account-creation-email-sent' )
+						->rawParams( $mailTo, htmlspecialchars( $this->username ) )->parse();
 				}
 			}
 		}

--- a/extensions/wikia/UserLogin/tests/UserSignupTest.php
+++ b/extensions/wikia/UserLogin/tests/UserSignupTest.php
@@ -574,7 +574,7 @@
 			$mockSession1 = null;
 			$mockCache1 = null;
 			$mockMessagesMap1 = array(
-				array('usersignup-confirmation-email-sent', self::TEST_USERNAME),
+				array('usersignup-confirmation-email-sent'),
 				array('usersignup-confirmation-heading'),
 				array('usersignup-confirmation-subheading'),
 			);
@@ -590,6 +590,7 @@
 				'loadFromDatabase' => null,
 				'isEmailConfirmed' => false,
 				'sendConfirmationMail' => null,
+				'getID' => 11,
 				'params' => array(
 					'mId' => 0,
 					'mName' => self::TEST_USERNAME,
@@ -608,9 +609,9 @@
 				'byemail' => 1,
 			);
 			$mockMessagesMap3 = array(
-				array('usersignup-account-creation-email-sent', self::TEST_USERNAME, self::TEST_USERNAME),
+				array('usersignup-account-creation-email-sent'),
 				array('usersignup-account-creation-heading'),
-				array('usersignup-account-creation-subheading', self::TEST_USERNAME),
+				array('usersignup-account-creation-subheading'),
 			);
 			$mockMsgExt3 = 'usersignup-account-creation-email-sent';
 			$expMsg3 = $mockMsgExt3;
@@ -665,6 +666,7 @@
 				'loadFromDatabase' => null,
 				'isEmailConfirmed' => false,
 				'sendConfirmationMail' => null,
+				'getID' => 11,
 				'params' => array(
 					'mId' => 11,
 					'mName' => self::TEST_USERNAME,
@@ -705,6 +707,7 @@
 				'loadFromDatabase' => null,
 				'isEmailConfirmed' => false,
 				'sendConfirmationMail' => null,
+				'getID' => 11,
 				'params' => array(
 					'mId' => 11,
 					'mName' => self::TEST_USERNAME,
@@ -723,6 +726,7 @@
 				'loadFromDatabase' => null,
 				'isEmailConfirmed' => true,
 				'sendConfirmationMail' => null,
+				'getID' => 11,
 				'params' => array(
 					'mId' => 11,
 					'mName' => self::TEST_USERNAME,
@@ -748,6 +752,7 @@
 				'isEmailConfirmed' => false,
 				'isEmailConfirmationPending' => true,
 				'sendConfirmationMail' => null,
+				'getID' => 11,
 				'params' => array(
 					'mId' => 11,
 					'mName' => self::TEST_USERNAME,
@@ -790,6 +795,7 @@
 					'mockExpTimes' => 1,
 					'mockExpValues' => $status109,
 				),
+				'getID' => 11,
 				'params' => array(
 					'mId' => 11,
 					'mName' => 'TempUser11',
@@ -806,25 +812,17 @@
 
 
 			return array (
-				'GET + temp user does not exist + not pass byemail' =>
-				array($mockWebRequest1, $params1, $mockEmailAuth1, $mockUser1, $mockSession1, $mockCache1, $mockMessagesMap1, $mockMsgExt1, 'ok', $expMsg1, $expMsgEmail1, '', $expHeading1, $expSubheading1),
-				'GET + temp user exists + not pass byemail' =>
-				array($mockWebRequest1, $params1, $mockEmailAuth1, $mockUser1, $mockSession1, $mockCache1, $mockMessagesMap1, $mockMsgExt1, 'ok', $expMsg1, $expMsgEmail1, '', $expHeading1, $expSubheading1),
-				'GET + temp user does not exist + pass byemail' =>
-				array($mockWebRequest1, $params3, $mockEmailAuth1, $mockUser1, $mockSession1, $mockCache1, $mockMessagesMap3, $mockMsgExt3, 'ok', $expMsg3, $expMsgEmail1, '', $expHeading3, $expSubheading3),
-				'GET + temp user exists + pass byemail' =>
+				'GET + user does not exist' =>
+				array($mockWebRequest1, $params1, $mockEmailAuth1, $mockUser1, $mockSession1, $mockCache1, [], '', null, null, null, '', null, null),
+				'GET + user exists + pass byemail' =>
 				array($mockWebRequest1, $params3, $mockEmailAuth1, $mockUser2, $mockSession1, $mockCache1, $mockMessagesMap3, $mockMsgExt3, 'ok', $expMsg3, $expMsgEmail1, '', $expHeading3, $expSubheading3),
-				'POST + temp user does not exist + empty action' =>
-				array($mockWebRequest5, $params5, $mockEmailAuth1, $mockUser1, $mockSession1, $mockCache1, $mockMessagesMap1, $mockMsgExt1, 'ok', $expMsg1, $expMsgEmail1, '', $expHeading1, $expSubheading1),
-				'POST + temp user exist + empty action' =>
+				'POST + user exist + empty action' =>
 				array($mockWebRequest5, $params5, $mockEmailAuth1, $mockUser2, $mockSession1, $mockCache1, $mockMessagesMap1, $mockMsgExt1, 'ok', $expMsg1, $expMsgEmail1, '', $expHeading1, $expSubheading1),
 
 				// test resend confirmation email
 				'error - empty username ( POST + action = resendconfirmation )' =>
-				array($mockWebRequest101, $params101, $mockEmailAuth1, $mockUser1, $mockSession1, $mockCache1, $mockMessagesMap101, '', 'error', $expMsg101, $expMsgEmail1, '', $expHeading101, $expSubheading1),
-				'error - temp user does not exist ( POST + action = resendconfirmation )' =>
-				array($mockWebRequest101, $params102, $mockEmailAuth1, $mockUser1, $mockSession1, $mockCache1, $mockMessagesMap102, '', 'error', $expMsg102, $expMsgEmail1, '', $expHeading101, $expSubheading1),
-				'error - temp user id does not match with one in $_SESSION ( POST + action = resendconfirmation )' =>
+				array($mockWebRequest101, $params101, $mockEmailAuth1, $mockUser1, $mockSession1, $mockCache1, [], '', null, null, null, '', null, null),
+				'error - user id does not match with one in $_SESSION ( POST + action = resendconfirmation )' =>
 				array($mockWebRequest101, $params102, $mockEmailAuth1, $mockUser3, $mockSession103, $mockCache1, $mockMessagesMap103, '', 'invalidsession', $expMsg103, $expMsgEmail1, '', $expHeading101, $expSubheading1),
 				'error - $wgEmailAuthentication == false ( POST + action = resendconfirmation )' =>
 				array($mockWebRequest101, $params102, $mockEmailAuth104, $mockUser3, $mockSession104, $mockCache1, $mockMessagesMap104, '', 'error', $expMsg104, $expMsgEmail1, '', $expHeading101, $expSubheading1),


### PR DESCRIPTION
Don't parse username parameter on email confirmation page. Also, don't show
the page if a valid username wasn't passed to it, and just redirect back to
login page as we do on an invalid session. Allowing the page to be navigated to
with an unvalidated username is probably a remnant of the temp user code
where there wouldn't have yet been a valid user created.

Fix UserSignup unit tests after changes. Most of these tests were written
when we had the temp user setup, and need cleanup. This removes those that
are no longer relevant such as the first two which were exactly the same, and
changes the expected result for when an invalid user is provided to match
the new behaviour. More cleanup is needed there, but this is the minimum
to update them for the changes.

See https://wikia-inc.atlassian.net/browse/CE-1223 for reasons behind the changes.

/cc @garthwebb
