### PR TITLE
MAIN-3427: Use keypress instead of keyup event to handle "enter key" in title input box

### DIFF
--- a/extensions/wikia/EditPageLayout/js/plugins/PageControls.js
+++ b/extensions/wikia/EditPageLayout/js/plugins/PageControls.js
@@ -310,7 +310,7 @@
 					$( '#HiddenFieldsDialog label' ).children().focus();
 
 					//add press "Enter" = submit form functionality - BugId: 38480
-					$( '#HiddenFieldsDialog input[name="wpTitle"]' ).keyup( function ( event ) {
+					$( '#HiddenFieldsDialog input[name="wpTitle"]' ).keypress( function ( event ) {
 						if ( event.keyCode == 13 ) {
 							$( '#ok' ).click();
 						}


### PR DESCRIPTION
This solved the problem which was occurring within IME input (for instance Hiragana). In IME while typing "enter key" sometimes have to be used to accept composition - and it triggers keydown, keyup, but no keypress. As previously handler was attached to keyup instead of accepting composition dialog was being closed.

https://wikia-inc.atlassian.net/browse/MAIN-3427
