### PR TITLE
PLATFORM-868: allow MW_INSTALL_PATH to control $IP in wikia-land also

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -4,7 +4,7 @@
 # We duplicate this code because some entry points do not go through webstart or maintenance
 $IP = getenv( 'MW_INSTALL_PATH' );
 if ( $IP === false ) {
-	$IP = realpath( '.' );
+	$IP = realpath( __DIR__ );
 }
 
 require __DIR__.'/../config/LocalSettings.php';

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1,4 +1,10 @@
 <?php
 
-$IP = __DIR__;
+# Determine $IP using the same process as mediawika core
+# We duplicate this code because some entry points do not go through webstart or maintenance
+$IP = getenv( 'MW_INSTALL_PATH' );
+if ( $IP === false ) {
+	$IP = realpath( '.' );
+}
+
 require __DIR__.'/../config/LocalSettings.php';


### PR DESCRIPTION
This change should be transparent, leaving us in the same place we were before, just using realpath() instead of **DIR**.  However, it allows us to override the path based on an env var. @macbre 
