### PR TITLE
SwiftStorage: log failed connections / authentications

### DIFF
--- a/includes/wikia/SwiftStorage.class.php
+++ b/includes/wikia/SwiftStorage.class.php
@@ -90,11 +90,22 @@ class SwiftStorage {
 			$this->swiftConfig = $this->wg->FSSwiftConfig;
 			$this->swiftServer = $this->wg->FSSwiftServer;
 		}
-		$this->connect( $this->swiftConfig );
 
-		$this->container = $this->getContainerObject( $containerName );
 		$this->containerName = $containerName;
 		$this->pathPrefix = rtrim( $pathPrefix, '/' );
+
+		try {
+			$this->connect( $this->swiftConfig );
+		}
+		catch( \Exception $ex ) {
+			$this->error( 'SwiftStorage: connect failed', [
+				'exception'  => $ex,
+			]);
+
+			throw $ex;
+		}
+
+		$this->container = $this->getContainerObject( $containerName );
 	}
 
 	/**


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-890

Log something more meaningful than:

```
PHP Fatal Error: Exception from line 211 of /usr/wikia/slot1/3445/src/extensions/SwiftCloudFiles/php-cloudfiles-1.7.10/cloudfiles.php: Unexpected response (): http://10.x.x.x:8060/auth (curl error: 7) couldn't connect to host http://10.x.x.x:8060/auth (http://math.wikia.com/wiki/Fraction?action=submit) in /usr/wikia/slot1/3445/src/includes/wikia/nirvana/WikiaException.php on line 33
```

@michalroszka 
