### PR TITLE
PLATFORM-879: Add reasonable limit for the lookahead in geshi regexp

### DIFF
--- a/extensions/SyntaxHighlight_GeSHi/geshi/geshi.php
+++ b/extensions/SyntaxHighlight_GeSHi/geshi/geshi.php
@@ -2129,7 +2129,7 @@ class GeSHi {
                 }
 
                 $this->language_data['NUMBERS_RXCACHE'][$key] =
-                    "/(?<!<\|\/)(?<!<\|!REG3XP)(?<!<\|\/NUM!)(?<!\d\/>)($regexp)(?!(?:<DOT>|(?>[^\<]))+>)(?![^<]*>)(?!\|>)(?!\/>)/i"; //
+                    "/(?<!<\|\/)(?<!<\|!REG3XP)(?<!<\|\/NUM!)(?<!\d\/>)($regexp)(?!(?><DOT>|(?>[^\<])){1,500}>)(?![^<]*>)(?!\|>)(?!\/>)/i"; //
             }
 
             if(!isset($this->language_data['PARSER_CONTROL']['NUMBERS']['PRECHECK_RX'])) {


### PR DESCRIPTION
This fixes an issue in GeSHi that triggers a stack limit exceeded error and segfault when CSS contains an invalid and long input.

https://wikia-inc.atlassian.net/browse/PLATFORM-879

/cc @macbre @sqreek 
