### PR TITLE
DatabaseBase::logSql - skip for queries that failed

### DIFF
--- a/includes/db/Database.php
+++ b/includes/db/Database.php
@@ -3529,6 +3529,10 @@ abstract class DatabaseBase implements DatabaseType {
 	protected function logSql( $sql, $ret, $fname, $elapsedTime, $isMaster ) {
 		global $wgDBcluster;
 
+		if ( $ret === false ) {
+			return;
+		}
+
 		if ($this->getSampler()->shouldSample()) {
 			$this->getWikiaLogger()->info( "SQL $sql", [
 				'method'      => $fname,


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-902

Resolves an issue introduced by #6289:

`PHP Warning: mysql_num_rows() expects parameter 1 to be resource, boolean given in /usr/wikia/slot1/3479/src/includes/db/Database.php on line 3536`

@wladekb 
