### PR TITLE
SOC-273 making sure facebook button shows up with force login modal

### DIFF
--- a/extensions/wikia/UserLogin/js/FacebookLogin.js
+++ b/extensions/wikia/UserLogin/js/FacebookLogin.js
@@ -30,12 +30,9 @@
 		/**
 		 * Initialize functionality needed to log in or sign up for a new account with facebook
 		 * @param {Object} origin Possible values are from FacebookLogin.origins. For tracking how a user got here.
-		 * @param {jQuery} [$el] Optional wrapper element for facebook button
 		 */
-		init: function (origin, $el) {
-			var self = this,
-				fbWrapperSelector = '.sso-login',
-				$fbWrapper;
+		init: function (origin) {
+			var self = this;
 
 			if (this.initialized || window.wgUserName) {
 				return;
@@ -66,12 +63,7 @@
 				// load when the login dropdown is shown or specific page is loaded
 				$.loadFacebookAPI()
 					.done(function () {
-						if ($el instanceof jQuery) {
-							$fbWrapper = $el.find(fbWrapperSelector);
-						} else {
-							$fbWrapper = $(fbWrapperSelector);
-						}
-						$fbWrapper.removeClass('hidden');
+						$('.sso-login').removeClass('hidden');
 					});
 
 				self.log('init');

--- a/extensions/wikia/UserLogin/js/FacebookLogin.js
+++ b/extensions/wikia/UserLogin/js/FacebookLogin.js
@@ -30,9 +30,12 @@
 		/**
 		 * Initialize functionality needed to log in or sign up for a new account with facebook
 		 * @param {Object} origin Possible values are from FacebookLogin.origins. For tracking how a user got here.
+		 * @param {jQuery} [$el] Optional wrapper element for facebook button
 		 */
-		init: function (origin) {
-			var self = this;
+		init: function (origin, $el) {
+			var self = this,
+				fbWrapperSelector = '.sso-login',
+				$fbWrapper;
 
 			if (this.initialized || window.wgUserName) {
 				return;
@@ -63,7 +66,12 @@
 				// load when the login dropdown is shown or specific page is loaded
 				$.loadFacebookAPI()
 					.done(function () {
-						$('.sso-login').removeClass('hidden');
+						if ($el instanceof jQuery) {
+							$fbWrapper = $el.find(fbWrapperSelector);
+						} else {
+							$fbWrapper = $(fbWrapperSelector);
+						}
+						$fbWrapper.removeClass('hidden');
 					});
 
 				self.log('init');

--- a/extensions/wikia/UserLogin/js/UserLoginModal.js
+++ b/extensions/wikia/UserLogin/js/UserLoginModal.js
@@ -75,6 +75,11 @@
 
 					// Init facebook button inside login modal
 					if (window.FacebookLogin) {
+						// SOC-273 remove 'hidden' class even if element isn't in the DOM yet
+						$.loadFacebookAPI()
+							.done(function () {
+								$loginModal.find('.sso-login').removeClass('hidden');
+							});
 						window.FacebookLogin.init(window.FacebookLogin.origins.MODAL, $loginModal);
 					}
 

--- a/extensions/wikia/UserLogin/js/UserLoginModal.js
+++ b/extensions/wikia/UserLogin/js/UserLoginModal.js
@@ -80,7 +80,7 @@
 							.done(function () {
 								$loginModal.find('.sso-login').removeClass('hidden');
 							});
-						window.FacebookLogin.init(window.FacebookLogin.origins.MODAL, $loginModal);
+						window.FacebookLogin.init(window.FacebookLogin.origins.MODAL);
 					}
 
 					UserLoginModal.loginAjaxForm = new window.UserLoginAjaxForm($loginModal, {

--- a/extensions/wikia/UserLogin/js/UserLoginModal.js
+++ b/extensions/wikia/UserLogin/js/UserLoginModal.js
@@ -41,10 +41,6 @@
 					self.uiFactory = uiFactory;
 					self.packagesData = packagesData;
 
-					if (window.FacebookLogin) {
-						window.FacebookLogin.init(window.FacebookLogin.origins.MODAL);
-					}
-
 					self.buildModal(options);
 					self.bucky.timer.stop('initModal');
 				});
@@ -76,6 +72,11 @@
 					UserLoginModal.$modal = loginModal;
 
 					var $loginModal = loginModal.$element;
+
+					// Init facebook button inside login modal
+					if (window.FacebookLogin) {
+						window.FacebookLogin.init(window.FacebookLogin.origins.MODAL, $loginModal);
+					}
 
 					UserLoginModal.loginAjaxForm = new window.UserLoginAjaxForm($loginModal, {
 						ajaxLogin: true,

--- a/extensions/wikia/UserLogin/mixins/_divider.scss
+++ b/extensions/wikia/UserLogin/mixins/_divider.scss
@@ -1,11 +1,12 @@
-@import "skins/shared/color";
+@import 'skins/shared/color';
 
 @mixin divider {
-	border-top: solid 1px $color-page-border;
+	border-top: 0;
 	margin-top: 25px;
 	text-align: center;
+
 	> span {
-		background-color: $color-page;
+		background-color: inherit;
 		display: inline-block;
 		padding: 0 21px;
 		position: relative;

--- a/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadExternalLibrary.js
+++ b/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadExternalLibrary.js
@@ -56,22 +56,28 @@
 			$deferred.done(callback);
 		}
 
-		// This is invoked by Facebook once the SDK is loaded.
-		window.fbAsyncInit = function () {
-			window.FB.init({
-				appId: window.fbAppId,
-				xfbml: true,
-				cookie: true,
-				version: 'v2.1'
-			});
-			// resolve after FB has finished inititalizing
+		if (typeof window.FB === 'object') {
+			// Since we have our own deferred object, we need to resolve it if FB is already loaded.
+			// We can't rely on the type check inside $.loadExternalLibrary.
 			$deferred.resolve();
-		};
+		} else {
+			// This is invoked by Facebook once the SDK is loaded.
+			window.fbAsyncInit = function () {
+				window.FB.init({
+					appId: window.fbAppId,
+					xfbml: true,
+					cookie: true,
+					version: 'v2.1'
+				});
+				// resolve after FB has finished inititalizing
+				$deferred.resolve();
+			};
 
-		$.when($.loadExternalLibrary('FacebookSDK', url, typeof window.FB))
-			.fail(function () {
-				$deferred.reject();
-			});
+			$.when($.loadExternalLibrary('FacebookSDK', url, typeof window.FB))
+				.fail(function () {
+					$deferred.reject();
+				});
+		}
 
 		return $deferred;
 	};


### PR DESCRIPTION
Fixing race condition where the facebook button inside the forced login modal wasn't being selected b/c it wasn't on the page at the time of the DOM query. 

I tried to find a good lifecycle event for the modal so I could know when the content had actually reached the DOM, but I couldn't find one. Maybe @kvas-damian knows more about it?

I also found a bug with the facebook sdk loading script where it didn't fire a callback on subsequent calls, so this PR fixes that. 
