### PR TITLE
CONCF-41 remove never assigned variable

### DIFF
--- a/extensions/wikia/Thumbnails/ThumbnailVideo.class.php
+++ b/extensions/wikia/Thumbnails/ThumbnailVideo.class.php
@@ -160,12 +160,6 @@ class ThumbnailVideo extends ThumbnailImage {
 			$linkAttribs['id'] = $options['id'];
 		}
 
-		if ( $useRDFData ) { // bugId: #46621
-			$linkAttribs['itemprop'] = 'video';
-			$linkAttribs['itemscope'] = '';
-			$linkAttribs['itemtype'] = 'http://schema.org/VideoObject';
-		}
-
 		// let extension override any link attributes
 		if ( isset( $options['linkAttribs'] ) && is_array( $options['linkAttribs'] ) ) {
 			$linkAttribs = array_merge( $linkAttribs, $options['linkAttribs'] );
@@ -190,11 +184,7 @@ class ThumbnailVideo extends ThumbnailImage {
 			'data-video-key' => htmlspecialchars( urlencode( $videoTitle->getDBKey() ) ),
 		);
 
-		if ( $useRDFData ) {
-			$attribs['itemprop'] = 'thumbnail';
-		}
-
-        // lazy loading
+		// lazy loading
 		if ( !empty( $options['usePreloading'] ) ) {
 			$attribs['data-src'] = $this->url;
 		}
@@ -225,13 +215,6 @@ class ThumbnailVideo extends ThumbnailImage {
 
 		if ( isset( $options['duration'] ) && $options['duration'] == true ) {
 			$duration = WikiaFileHelper::formatDuration( $this->file->getMetadataDuration() );
-		}
-
-		if ( !empty( $duration ) ) {
-			$timerProp = array( 'class'=>'timer' );
-			if ( $useRDFData ) {
-				$timerProp['itemprop'] = 'duration';
-			}
 		}
 
 		// WikiaMobile completely reconstructs the html

--- a/extensions/wikia/Thumbnails/ThumbnailVideo.class.php
+++ b/extensions/wikia/Thumbnails/ThumbnailVideo.class.php
@@ -149,15 +149,20 @@ class ThumbnailVideo extends ThumbnailImage {
 			] ) );
 
 		$alt = empty( $options['alt'] ) ? '' : $options['alt'];
-
 		$videoTitle = $this->file->getTitle();
-
+		$useRDFData = ( !empty( $options['disableRDF'] ) && $options['disableRDF'] == true ) ? false : true;
 		$linkAttribs = array(
 			'href' => $videoTitle->getLocalURL(),
 		);
 
 		if ( !empty( $options['id'] ) ) {
 			$linkAttribs['id'] = $options['id'];
+		}
+
+		if ( $useRDFData ) { // bugId: #46621
+			$linkAttribs['itemprop'] = 'video';
+			$linkAttribs['itemscope'] = '';
+			$linkAttribs['itemtype'] = 'http://schema.org/VideoObject';
 		}
 
 		// let extension override any link attributes
@@ -183,6 +188,10 @@ class ThumbnailVideo extends ThumbnailImage {
 			'data-video-name' => htmlspecialchars( $videoTitle->getText() ),
 			'data-video-key' => htmlspecialchars( urlencode( $videoTitle->getDBKey() ) ),
 		);
+
+		if ( $useRDFData ) {
+			$attribs['itemprop'] = 'thumbnail';
+		}
 
 		// lazy loading
 		if ( !empty( $options['usePreloading'] ) ) {
@@ -215,6 +224,13 @@ class ThumbnailVideo extends ThumbnailImage {
 
 		if ( isset( $options['duration'] ) && $options['duration'] == true ) {
 			$duration = WikiaFileHelper::formatDuration( $this->file->getMetadataDuration() );
+		}
+
+		if ( !empty( $duration ) ) {
+			$timerProp = array( 'class'=>'timer' );
+			if ( $useRDFData ) {
+				$timerProp['itemprop'] = 'duration';
+			}
 		}
 
 		// WikiaMobile completely reconstructs the html


### PR DESCRIPTION
I removed $useRDFData variable which was never assigned and $timer variable which was never used.
$useRDFData variable is causing PHP Erros.
@lizlux you removed the assignment in https://github.com/Wikia/app/commit/64643127112194a59f2e51c3e7a6609edec31543 - is it OK if I remove the rest?
