### PR TITLE
Special_DevBoxPanel: use MediaWiki DB layer

### DIFF
--- a/extensions/wikia/Development/SpecialDevBoxPanel/Special_DevBoxPanel.php
+++ b/extensions/wikia/Development/SpecialDevBoxPanel/Special_DevBoxPanel.php
@@ -300,6 +300,7 @@ function getForcedWikiValue(){
 
 
 /**
+ * @param DatabaseMysql $db
  * @return array - databases which are available on this cluster
  *					  use the writable devbox server instead of the production slaves.
  */
@@ -308,10 +309,9 @@ function getDevBoxOverrideDatabases(DatabaseMysql $db){
 	$IGNORE_DBS = array('information_schema', 'mysql', '#mysql50#lost+found', 'wikicities_c2');
 	$retval = array();
 
-	$info = $db->getLBInfo();
-	$connection = mysql_connect($info['host'], $info['user'], $info['password']);
-	$res = mysql_query('SHOW DATABASES', $connection);
-	while ($row = mysql_fetch_object($res)) {
+	$res = $db->query( 'SHOW DATABASES', __METHOD__ );
+
+	while( $row = $res->fetchObject() ) {
 		$retval[] = $row->Database;
 	}
 


### PR DESCRIPTION
Fixes `Deprecated: mysql_connect(): The mysql extension is deprecated and will be removed in the future: use mysqli or PDO instead in /usr/wikia/source/app/extensions/wikia/Development/SpecialDevBoxPanel/Special_DevBoxPanel.php` error on PHP 5.6-powered devbox.

@owend 
