### PR TITLE
ArticleService: /e modifier is not really needed here

### DIFF
--- a/includes/Article.php
+++ b/includes/Article.php
@@ -20,6 +20,7 @@
  * //Wikia Change Start - helping PHP lint
  * @property Title mTitle
  * @method exists
+ * @method getID
  * //Wikia Change End
  */
 class Article extends Page {

--- a/includes/wikia/services/ArticleService.class.php
+++ b/includes/wikia/services/ArticleService.class.php
@@ -29,11 +29,11 @@ class ArticleService extends WikiaObject {
 			'h6'
 	);
 	private $patterns = array(
-		//strip decimal entities
+		// strip decimal entities
 		'/&#\d{2,5};/ue' => '',
-		//strip hex entities
+		// strip hex entities
 		'/&#x[a-fA-F0-7]{2,8};/ue' => '',
-		//this should be always the last
+		// this should be always the last
 		'/\s+/' => ' '
 	);
 	private static $localCache = array();
@@ -79,20 +79,21 @@ class ArticleService extends WikiaObject {
 	 * @param integer $articleId A valid article ID from which
 	 * an Article instance will be constructed to be used as a
 	 * source of content
+	 * @return ArticleService fluent interface
 	 */
 	public function setArticleById( $articleId ) {
-		$this->article = Article::newFromID($articleId);
+		$this->article = Article::newFromID( $articleId );
 		return $this;
 	}
 
 	/**
 	 * Sets the Article instance via Title object
-	 * @param Title $article Title object
+	 * @param Title $title Title object
 	 * class to use as a source of content
 	 * @return ArticleService fluent interface
 	 */
 	public function setArticleByTitle( Title $title ) {
-		$this->article = new Article($title);
+		$this->article = new Article( $title );
 		return $this;
 	}
 
@@ -118,7 +119,7 @@ class ArticleService extends WikiaObject {
 	 * $snippet = $service->getTextSnippet();
 	 */
 	public function getTextSnippet( $length = 100 ) {
-		//don't allow more than the maximum to avoid flooding Memcached
+		// don't allow more than the maximum to avoid flooding Memcached
 		if ( $length > self::MAX_LENGTH ) {
 			throw new WikiaException( 'Maximum allowed length is ' . self::MAX_LENGTH );
 		}
@@ -138,9 +139,9 @@ class ArticleService extends WikiaObject {
 			return '';
 		}
 
-		//memoize to avoid Memcache access overhead
-		//when the same article needs to be processed
-		//more than once in the same process
+		// memoize to avoid Memcache access overhead
+		// when the same article needs to be processed
+		// more than once in the same process
 		if ( array_key_exists( $id, self::$localCache ) ) {
 			$text = self::$localCache[$id];
 		} else {
@@ -149,7 +150,7 @@ class ArticleService extends WikiaObject {
 			$text = self::$localCache[$id] = WikiaDataAccess::cache(
 				$key,
 				86400 /*24h*/,
-				function() use ( $service, $fname ){
+				function() use ( $service, $fname ) {
 					wfProfileIn( $fname . '::CacheMiss' );
 
 					$content = '';
@@ -178,41 +179,52 @@ class ArticleService extends WikiaObject {
 	 * Accesses a snippet from MediaWiki.
 	 * @return string
 	 */
-	public function getUncachedSnippetFromArticle() {
-		//get standard parser cache for anons,
-		//99% of the times it will be available but
-		//generate it in case is not
+	public function getUncachedSnippetFromArticle()
+	{
+		// get standard parser cache for anons,
+		// 99% of the times it will be available but
+		// generate it in case is not
 		$content = '';
 		$page = $this->article->getPage();
 		$opts = $page->makeParserOptions( new User() );
 		$parserOutput = $page->getParserOutput( $opts );
 		try {
-			$content = $this->getContentFromParser($parserOutput);
+			$content = $this->getContentFromParser( $parserOutput );
 		} catch ( Exception $e ) {
 			\Wikia\Logger\WikiaLogger::instance()->error(
 				'ArticleService, not parser output object found',
-				[ 'parserOutput' => $parserOutput, 'parserOptions' => $opts, 'page' => $page, 'exception' => $e ]
+				['parserOutput' => $parserOutput, 'parserOptions' => $opts, 'page' => $page, 'exception' => $e]
 			);
 		}
 
-		//Run hook to allow wikis to modify the content (ie: customize their snippets) before the stripping and length limitations are done.
+		// Run hook to allow wikis to modify the content (ie: customize their snippets) before the stripping and length limitations are done.
 		wfRunHooks( 'ArticleService::getTextSnippet::beforeStripping', array( &$this->article, &$content, ArticleService::MAX_LENGTH ) );
 
+		return $this->cleanArticleSnippet( $content );
+	}
+
+	/**
+	 * Cleans up the content of the article snippet
+	 *
+	 * @param string $content
+	 * @return string
+	 */
+	public function cleanArticleSnippet( $content ) {
 		if ( mb_strlen( $content ) > 0 ) {
-			//remove all unwanted tag pairs and their contents
+			// remove all unwanted tag pairs and their contents
 			foreach ( $this->tags as $tag ) {
 				$content = preg_replace( "/<{$tag}\b[^>]*>.*<\/{$tag}>/imsU", '', $content );
 			}
 
-			//cleanup remaining tags
+			// cleanup remaining tags
 			$content = strip_tags( $content );
 
-			//apply some replacements
+			// apply some replacements
 			foreach ( $this->patterns as $reg => $rep ) {
 				$content = preg_replace( $reg, $rep, $content );
 			}
 
-			//decode entities
+			// decode entities
 			$content = html_entity_decode( $content );
 			$content = trim( $content );
 
@@ -223,7 +235,7 @@ class ArticleService extends WikiaObject {
 		return $content;
 	}
 
-	private function getContentFromParser(ParserOutput $output) {
+	private function getContentFromParser( ParserOutput $output ) {
 		return $output->getText();
 	}
 

--- a/includes/wikia/services/ArticleService.class.php
+++ b/includes/wikia/services/ArticleService.class.php
@@ -30,9 +30,9 @@ class ArticleService extends WikiaObject {
 	);
 	private $patterns = array(
 		// strip decimal entities
-		'/&#\d{2,5};/ue' => '',
+		'/&#\d{2,5};/u' => '',
 		// strip hex entities
-		'/&#x[a-fA-F0-7]{2,8};/ue' => '',
+		'/&#x[a-fA-F0-7]{2,8};/u' => '',
 		// this should be always the last
 		'/\s+/' => ' '
 	);

--- a/includes/wikia/services/tests/ArticleServiceTest.php
+++ b/includes/wikia/services/tests/ArticleServiceTest.php
@@ -427,5 +427,42 @@ TEXT;
 		);
 	}
 
+	/**
+	 * @param string $content
+	 * @param string $expected
+	 * @dataProvider cleanArticleSnippetProvider
+	 */
+	public function testCleanArticleSnippet( $content, $expected ) {
+		/* @var $title Title */
+		$title = $this->mockClassWithMethods( 'Title' );
+		$service = new ArticleService( $title );
+
+		$this->assertEquals($expected, $service->cleanArticleSnippet( $content ) );
+	}
+
+	public function cleanArticleSnippetProvider() {
+		return [
+			[
+				// tags stripping
+				'<h1>foo</h1><p>bar</p><div>text</div>',
+				'bar'
+			],
+			[
+				// removing multiple spaces
+				'<p>test    test</p>',
+				'test test'
+			],
+			[
+				// stripping entities
+				'<p>hard&#160;space</p>',
+				'hardspace'
+			],
+			[
+				// stripping entities
+				'<p>enti&#xFF;ty</p>',
+				'entity'
+			]
+		];
+	}
 
 }


### PR DESCRIPTION
Fixes `Deprecated: preg_replace(): The /e modifier is deprecated, use preg_replace_callback instead in /usr/wikia/source/app/includes/wikia/services/ArticleService.class.php on line 212` when run using PHP 5.6
- extracted `cleanArticleSnippet` method to make unit testing a bit easier

@owend / @SebastianMarzjan 
