### PR TITLE
Transaction: set "hostname" parameter and sent it as a context

### DIFF
--- a/includes/wikia/transaction/Transaction.php
+++ b/includes/wikia/transaction/Transaction.php
@@ -19,6 +19,7 @@ class Transaction {
 
 	// Parameters
 	const PARAM_ENVIRONMENT = 'env';
+	const PARAM_HOSTNAME = 'hostname';
 	const PARAM_ENTRY_POINT = 'entry_point';
 	const PARAM_LOGGED_IN = 'logged_in';
 	const PARAM_PARSER_CACHE_USED = 'parser_cache_used';
@@ -63,6 +64,7 @@ class Transaction {
 				new TransactionTraceScribe(),
 			) );
 			$instance->set( self::PARAM_ENVIRONMENT, $wgWikiaEnvironment );
+			$instance->set( self::PARAM_HOSTNAME, wfHostname() );
 		}
 		return $instance;
 	}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-905

As a part of PHP upgrade we would like to set of the Apaches in the poll to use PHP 5.6 to do the final round of testing and compare the performance.

In order to do that I'll added the `hostname` parameter that will be sent with all performance messages.

@wladekb 
