### PR TITLE
SOC | Sass - Removal of old base64 annotation

### DIFF
--- a/extensions/wikia/Wall/css/MessageTopic.scss
+++ b/extensions/wikia/Wall/css/MessageTopic.scss
@@ -20,7 +20,7 @@
 		background-color: $color-wall-input-new;
 		border: 1px solid $color-page-border;
 		color: $color-text;
-		
+
 		// Chrome needs this to get rid of empty space below textarea
 		display: block;
 		font-size: 13px;
@@ -73,7 +73,7 @@
 			opacity: .8;
 			padding-right: 15px;
 			position: relative;
-			
+
 			&:hover {
 				opacity: 1;
 				.remove-swatch {
@@ -87,7 +87,7 @@
 				}
 				@include transform(scale(0.8));
 				background-color: $color-remove-swatch;
-				background-image: url('/skins/oasis/images/icon_close.png'); /* $base64 */
+				background-image: url('/skins/oasis/images/icon_close.png'); /* inline */
 				background-position: -2px -2px;
 				cursor: pointer;
 				height: 12px;

--- a/extensions/wikia/Wall/css/RelatedTopics.scss
+++ b/extensions/wikia/Wall/css/RelatedTopics.scss
@@ -20,10 +20,10 @@
 		padding: 1px 5px 1px 21px;
 		position: relative;
 	}
-	
+
 	.related-topic:before {
 		background-repeat: no-repeat;
-		background-image: url('/extensions/wikia/Wall/images/forums-topic-icon.png'); /* $base64 */
+		background-image: url('/extensions/wikia/Wall/images/forums-topic-icon.png'); /* inline */
 		content: "";
 		display: block;
 		height: 13px;
@@ -32,7 +32,7 @@
 		top: 4px;
 		width: 11px;
 	}
-	
+
 	.edit-topic {
 		padding-left: 7px;
 		.edit-pencil {

--- a/includes/wikia/services/sass/Filter/InlineImageFilter.class.php
+++ b/includes/wikia/services/sass/Filter/InlineImageFilter.class.php
@@ -22,7 +22,7 @@ class InlineImageFilter extends Filter {
 	public function process( $contents ) {
 		wfProfileIn( __METHOD__ );
 
-		$contents = preg_replace_callback( "/([, ]url[^\n]*?\))([^\n]*?)(\s*\/\*\s*(base64|inline)\s*\*\/)/is", [$this, 'processMatches'], $contents );
+		$contents = preg_replace_callback( "/([, ]url[^\n]*?\))([^\n]*?)(\s*\/\*\s*inline\s*\*\/)/is", [$this, 'processMatches'], $contents );
 
 		wfProfileOut( __METHOD__ );
 

--- a/includes/wikia/services/sass/SassService.class.php
+++ b/includes/wikia/services/sass/SassService.class.php
@@ -25,7 +25,7 @@ use Wikia\Sass\Compiler\ExternalRubyCompiler;
  */
 class SassService extends WikiaObject {
 
-	const CACHE_VERSION = 5; # SASS caching does not depend on $wgStyleVersion, use this constant to bust SASS cache
+	const CACHE_VERSION = 6; # SASS caching does not depend on $wgStyleVersion, use this constant to bust SASS cache
 
 	const FILTER_IMPORT_CSS = 1;
 	const FILTER_CDN_REWRITE = 2;


### PR DESCRIPTION
This is follow up for: https://github.com/Wikia/app/pull/5926
Complete removal of old `/* base64 */` annotation - use `/* inline */` instead. 
