### PR TITLE
MAIN-2878 use replace instead of update (both for watched item and globa...

### DIFF
--- a/extensions/wikia/GlobalWatchlist/GlobalWatchlistTask.class.php
+++ b/extensions/wikia/GlobalWatchlist/GlobalWatchlistTask.class.php
@@ -154,6 +154,16 @@ class GlobalWatchlistTask extends BaseTask {
 	 */
 	public function renameTitleInGlobalWatchlist( array $oldTitleValues, array $newTitleValues ) {
 		$db = wfGetDB( DB_MASTER, [], \F::app()->wg->ExternalDatawareDB );
+
+		// If the rename is overwriting an existing page, delete those records so we don't
+		// run into conflicts from the update below.
+		( new WikiaSQL() )
+			->DELETE()->FROM( GlobalWatchlistTable::TABLE_NAME )
+			->WHERE( GlobalWatchlistTable::COLUMN_TITLE )->EQUAL_TO( $newTitleValues['databaseKey'] )
+			->AND_( GlobalWatchlistTable::COLUMN_NAMESPACE )->EQUAL_TO( $newTitleValues['nameSpace'] )
+			->AND_( GlobalWatchlistTable::COLUMN_CITY_ID )->EQUAL_TO( \F::app()->wg->CityId )
+			->run( $db );
+
 		( new WikiaSQL() )
 			->UPDATE( GlobalWatchlistTable::TABLE_NAME )
 			->SET( GlobalWatchlistTable::COLUMN_TITLE, $newTitleValues['databaseKey'] )


### PR DESCRIPTION
...l watchlist)

When working on UC-153, a query inside of WatchedItem.php was changed from an REPLACE to an UPDATE. This wasn't the same behavior and was causing problems when trying to rename a page to a title which already exists. Revert to the REPLACE query, and update the globalwatchlist logic to account for that case.

Ticket: https://wikia-inc.atlassian.net/browse/MAIN-3878
