### PR TITLE
SOC-361 make $timestamp a default argument

### DIFF
--- a/extensions/wikia/GlobalWatchlist/GlobalWatchlistHooks.class.php
+++ b/extensions/wikia/GlobalWatchlist/GlobalWatchlistHooks.class.php
@@ -75,7 +75,7 @@ class GlobalWatchlistHooks {
 	 * @param $timestamp Datetime or null
 	 * @return bool (always true)
 	 */
-	public static function updateGlobalWatchList( WatchedItem $watchedItem, $watchers, $timestamp ) {
+	public static function updateGlobalWatchList( WatchedItem $watchedItem, $watchers, $timestamp = null ) {
 		$watchers = wfReturnArray( $watchers );
 		if ( is_null( $timestamp ) ) {
 			self::removeWatchers( $watchedItem, $watchers );


### PR DESCRIPTION
Make the 3rd argument to `timestamp` default to null. This fixes PHP warnings which were arising from this method being called in places without the `timestamp` argument.

Ticket: https://wikia-inc.atlassian.net/browse/SOC-361
