### PR TITLE
ImageServing performance improvements - phase #2

### DIFF
--- a/extensions/wikia/ImageServing/drivers/ImageServingDriverMainNS.class.php
+++ b/extensions/wikia/ImageServing/drivers/ImageServingDriverMainNS.class.php
@@ -197,11 +197,11 @@ class ImageServingDriverMainNS extends ImageServingDriverBase {
 		// - update with the data from query cache
 		$result = array_fill_keys( $imageNames, 1 );
 
-		foreach($ret as $row) {
+		foreach ( $ret as $row ) {
 			/* @var mixed $row */
 			$popularity = intval( $row->popularity );
 
-			if ($popularity > $limit) {
+			if ( $popularity > $limit ) {
 				unset( $result[ $row->image ] );
 				wfDebug( __METHOD__ . ": filtered out {$row->image} - used {$popularity} time(s)\n" );
 			}

--- a/extensions/wikia/ImageServing/drivers/ImageServingDriverMainNS.class.php
+++ b/extensions/wikia/ImageServing/drivers/ImageServingDriverMainNS.class.php
@@ -138,6 +138,7 @@ class ImageServingDriverMainNS extends ImageServingDriverBase {
 			);
 
 			foreach ( $result as $row ) {
+				/* @var mixed $row */
 				if ( $row->img_height >= $this->minHeight && $row->img_width >= $this->minWidth ) {
 					if ( !in_array( $row->img_minor_mime, self::$mimeTypesBlacklist ) ) {
 						$imageDetails[$row->img_name] = $row;
@@ -160,74 +161,55 @@ class ImageServingDriverMainNS extends ImageServingDriverBase {
 		wfProfileOut( __METHOD__ );
 	}
 
-	protected function getImagesPopularity( $imageNames, $limit ) {
-		global $wgContentNamespaces;
-
+	/**
+	 * Returns the popularity of given set of images (popularity = the number of articles in content namespaces that use an image)
+	 *
+	 * $limit is applied - images that have popularity that is higher than $limit will not be returned
+	 *
+	 * Example:
+	 *
+	 * $imageNames = [ 'IMG_7303.jpg', 'Koziołki.jpg' ]
+	 * Result: [ 'IMG_7303.jpg' => 1, 'Koziołki.jpg' => 2 ]
+	 *
+	 * @param string[] $imageNames
+	 * @param int $limit
+	 * @return array associative array [image name] => [popularity]
+	 */
+	protected function getImagesPopularity( Array $imageNames, $limit ) {
 		wfProfileIn( __METHOD__ );
-		$result = [ ];
 
-		$sqlCount = $limit + 1;
 		$imageNames = array_values( $imageNames );
-		$count = count( $imageNames );;
-		$i = 0;
 
-		$imageLinksTable = $this->db->tableName( 'imagelinks' );
-		$pageTable = $this->db->tableName( 'page' );
-		$redirectTable = $this->db->tableName( 'redirect' );
+		// MostimagesInContentPage generates daily reports with images
+		// that are included at least twice in article in content namespaces
+		$ret = $this->db->select(
+			'querycache',
+			[ 'qc_title as image', 'qc_value as popularity' ],
+			[
+				'qc_type' => 'MostimagesInContent',
+				'qc_title' => $imageNames,
+			],
+			__METHOD__
+		);
 
-		$contentNamespaces = implode( ',', $wgContentNamespaces );
+		// MostimagesInContent includes images used at least twice
+		// - make popularity default to one here
+		// - update with the data from query cache
+		$result = array_fill_keys( $imageNames, 1 );
 
-		while ( $i < $count ) {
-			$batch = array_slice( $imageNames, $i, 100 );
-			$i += 100;
+		foreach($ret as $row) {
+			/* @var mixed $row */
+			$popularity = intval( $row->popularity );
 
-			// get all possible redirects for a given image (BAC-589)
-			$imageRedirectsMap = [ ]; // from image -> to image
-			$sql = [ ];
-			foreach ( $batch as $imageName ) {
-				$imageRedirectsMap[$imageName] = $imageName;
-				$sql[] = "(SELECT page_title, rd_title FROM {$redirectTable} LEFT JOIN {$pageTable} ON page_id = rd_from WHERE rd_namespace = " . NS_FILE . " AND rd_title = {$this->db->addQuotes( $imageName )} LIMIT 5)";
+			if ($popularity > $limit) {
+				unset( $result[ $row->image ] );
+				wfDebug( __METHOD__ . ": filtered out {$row->image} - used {$popularity} time(s)\n" );
 			}
-			$sql = implode( ' UNION ALL ', $sql );
-			$batchResult = $this->db->query( $sql, __METHOD__ . '::redirects' );
-
-			foreach ( $batchResult as $row ) {
-				wfDebug( __METHOD__ . ": redirect found - {$row->page_title} -> {$row->rd_title}\n" );
-				$imageRedirectsMap[$row->page_title] = $row->rd_title;
+			else {
+				$result[$row->image] = $popularity;
 			}
-			$batchResult->free();
-
-			// get image usage
-			$sql = [ ];
-			$batchResponse = [ ];
-
-			foreach ( $imageRedirectsMap as $fromImg => $toImg ) {
-				// prepare the results array )see PLATFORM-358)
-				$batchResponse[$toImg] = 0;
-
-				$sql[] = "(SELECT {$this->db->addQuotes( $toImg )} AS il_to FROM {$imageLinksTable} JOIN {$pageTable} on page.page_id = il_from WHERE il_to = {$this->db->addQuotes( $fromImg )} AND page_namespace IN ({$contentNamespaces}) LIMIT {$sqlCount} )";
-			}
-			$sql = implode( ' UNION ALL ', $sql );
-			$batchResult = $this->db->query( $sql, __METHOD__ . '::imagelinks' );
-
-			// do a "group by" on PHP side
-			foreach ( $batchResult as $row ) {
-				$batchResponse[$row->il_to]++;
-			}
-			$batchResult->free();
-
-			// remove rows that exceed usage limit
-			foreach ( $batchResponse as $k => $imageCount ) {
-				if ( $imageCount > $limit ) {
-					wfDebug( __METHOD__ . ": filtered out {$k} - used {$imageCount} time(s)\n" );
-					unset( $batchResponse[$k] );
-				} else {
-					wfDebug( __METHOD__ . ": {$k} - used {$imageCount} time(s)\n" );
-				}
-			}
-
-			$result = array_merge( $result, $batchResponse );
 		}
+
 		wfProfileOut( __METHOD__ );
 
 		return $result;

--- a/extensions/wikia/ImageServing/drivers/ImageServingDriverMainNS.class.php
+++ b/extensions/wikia/ImageServing/drivers/ImageServingDriverMainNS.class.php
@@ -168,8 +168,8 @@ class ImageServingDriverMainNS extends ImageServingDriverBase {
 	 *
 	 * Example:
 	 *
-	 * $imageNames = [ 'IMG_7303.jpg', 'Koziołki.jpg' ]
-	 * Result: [ 'IMG_7303.jpg' => 1, 'Koziołki.jpg' => 2 ]
+	 * $imageNames = [ 'IMG_7303.jpg', 'Goats.jpg' ]
+	 * Result: [ 'IMG_7303.jpg' => 1, 'Goats.jpg' => 2 ]
 	 *
 	 * @param string[] $imageNames
 	 * @param int $limit

--- a/includes/wikia/services/AvatarService.class.php
+++ b/includes/wikia/services/AvatarService.class.php
@@ -269,7 +269,7 @@ class AvatarService extends Service {
 				$url = self::buildVignetteUrl( $width, $bucket, $relativePath, $timestamp, false );
 			}
 		} else { // default avatar
-			$legacyDefaultUrl = array_shift( $masthead->getDefaultAvatars( 'thumb/' ) );
+			$legacyDefaultUrl = @array_shift( $masthead->getDefaultAvatars( 'thumb/' ) );
 			$bucket = VignetteRequest::parseBucket( $legacyDefaultUrl );
 			$relativePath = VignetteRequest::parseRelativePath( $legacyDefaultUrl );
 			$url = self::buildVignetteUrl( $width, $bucket, $relativePath, $timestamp, false );

--- a/includes/wikia/services/AvatarService.class.php
+++ b/includes/wikia/services/AvatarService.class.php
@@ -269,7 +269,7 @@ class AvatarService extends Service {
 				$url = self::buildVignetteUrl( $width, $bucket, $relativePath, $timestamp, false );
 			}
 		} else { // default avatar
-			$legacyDefaultUrl = @array_shift( $masthead->getDefaultAvatars( 'thumb/' ) );
+			$legacyDefaultUrl = array_shift( $masthead->getDefaultAvatars( 'thumb/' ) );
 			$bucket = VignetteRequest::parseBucket( $legacyDefaultUrl );
 			$relativePath = VignetteRequest::parseRelativePath( $legacyDefaultUrl );
 			$url = self::buildVignetteUrl( $width, $bucket, $relativePath, $timestamp, false );

--- a/maintenance/wikia/imageServing.php
+++ b/maintenance/wikia/imageServing.php
@@ -47,7 +47,8 @@ class ImageServingScript extends Maintenance {
 		$wgAllowMemcacheReads = false;
 
 		$im = new ImageServing( array( $title->getArticleID() ), 32, 32 );
-		$images = reset($im->getImages(20));
+		$ret = $im->getImages(20);
+		$images = reset($ret);
 
 		$this->output("\nImages list as returned by ImageServing (min size: 32x32 px):\n");
 


### PR DESCRIPTION
For the first phase see #6232

https://wikia-inc.atlassian.net/browse/PLATFORM-817

This change will make ImageServing use pre-generated reports stored in `querycache` table instead of making selects with union on each request.

Before the change:

``` sql
> explain (SELECT /* ImageServingDriverMainNS::getImagesPopularity::imagelinks 127.0.0.1 */ 'Ulica_Strzelecka_1917.jpg' AS il_to FROM `imagelinks` JOIN `page` on page.page_id = il_from WHERE il_to = 'Ulica_Strzelecka_1917.jpg' AND page_namespace IN (0) LIMIT 11 ) UNION ALL (SELECT 'IMG_7303.jpg' AS il_to FROM `imagelinks` JOIN `page` on page.page_id = il_from WHERE il_to = 'IMG_7303.jpg' AND page_namespace IN (0) LIMIT 11 );
+----+--------------+------------+--------+--------------------+---------+---------+-----------------------------+------+--------------------------+
| id | select_type  | table      | type   | possible_keys      | key     | key_len | ref                         | rows | Extra                    |
+----+--------------+------------+--------+--------------------+---------+---------+-----------------------------+------+--------------------------+
|  1 | PRIMARY      | imagelinks | ref    | il_from,il_to      | il_to   | 257     | const                       |    3 | Using where; Using index |
|  1 | PRIMARY      | page       | eq_ref | PRIMARY,name_title | PRIMARY | 4       | plpoznan.imagelinks.il_from |    1 | Using where              |
|  2 | UNION        | imagelinks | ref    | il_from,il_to      | il_to   | 257     | const                       |    3 | Using where; Using index |
|  2 | UNION        | page       | eq_ref | PRIMARY,name_title | PRIMARY | 4       | plpoznan.imagelinks.il_from |    1 | Using where              |
| NULL | UNION RESULT | <union1,2> | ALL    | NULL               | NULL    | NULL    | NULL                        | NULL |                          |
+----+--------------+------------+--------+--------------------+---------+---------+-----------------------------+------+--------------------------+
5 rows in set (0.00 sec)
```

After the change:

``` sql
> explain SELECT /* ImageServingDriverMainNS::getImagesPopularity 127.0.0.1 */  qc_title as image,qc_value as popularity  FROM `querycache`  WHERE qc_type = 'MostimagesInContent' AND qc_title IN ('Ulica_Strzelecka_1917.jpg','IMG_7303.jpg','Ulica_23_Lutego_zniszczenia_wojenne.jpg','Nazwy_ulic_w_Poznaniu_z_planem_Wielkiego_Poznania.jpg','Koziołki.jpg','Citroen_2CV6_and_Poznań_Cathedral_07-Oct-2011.JPG','Ratusz_ujęcie_od_dołu.jpg','Kamieniczki_budnicze.png','TEY.jpg');
+----+-------------+------------+------+---------------+---------+---------+-------+------+-------------+
| id | select_type | table      | type | possible_keys | key     | key_len | ref   | rows | Extra       |
+----+-------------+------------+------+---------------+---------+---------+-------+------+-------------+
|  1 | SIMPLE      | querycache | ref  | qc_type       | qc_type | 34      | const |    1 | Using where |
+----+-------------+------------+------+---------------+---------+---------+-------+------+-------------+
1 row in set (0.00 sec)
```

@michalroszka / @wladekb / @drozdo 
