### PR TITLE
SOC-261 Restore support for XFBML plugin code

### DIFF
--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -2282,3 +2282,11 @@ $config['facebook_client_preferences_scss'] = [
 		'//extensions/wikia/FacebookClient/styles/preferences.scss',
 	]
 ];
+
+$config['facebook_client_xfbml_js'] = [
+	'type' => AssetsManager::TYPE_JS,
+	'skin' => ['oasis', 'monobook'],
+	'assets' => [
+		'//extensions/wikia/FacebookClient/scripts/FacebookClient.XFBML.js',
+	]
+];

--- a/extensions/wikia/Captcha/Module/BaseCaptcha.class.php
+++ b/extensions/wikia/Captcha/Module/BaseCaptcha.class.php
@@ -152,16 +152,16 @@ abstract class BaseCaptcha extends \WikiaObject {
 		$info = $this->retrieveCaptcha();
 		if ( $info ) {
 			if ( $this->keyMatch( $this->wg->Request->getVal( 'wpCaptchaWord' ), $info ) ) {
-				$this->log( "passed" );
+				$this->log( "verification passed" );
 				$this->clearCaptcha( $info );
 				return true;
 			} else {
 				$this->clearCaptcha( $info );
-				$this->log( "bad form input" );
+				$this->log( "verification failed" );
 				return false;
 			}
 		} else {
-			$this->log( "new captcha session" );
+			$this->log( "verification failed - stored captcha not found" );
 			return false;
 		}
 	}

--- a/extensions/wikia/Captcha/Module/FancyCaptcha.class.php
+++ b/extensions/wikia/Captcha/Module/FancyCaptcha.class.php
@@ -294,7 +294,8 @@ class FancyCaptcha extends BaseCaptcha {
 	}
 
 	/**
-	 * Delete a solved captcha image.
+	 * Determine if a captcha is correct. This will possibly delete the solved captcha image
+	 * if wgCaptchaDeleteOnSolve is true
 	 *
 	 * @return bool
 	 */

--- a/extensions/wikia/Captcha/Module/ReCaptcha.class.php
+++ b/extensions/wikia/Captcha/Module/ReCaptcha.class.php
@@ -45,10 +45,15 @@ class ReCaptcha extends BaseCaptcha {
 			$response = json_decode( $responseObj->getContent() );
 
 			if ( $response->success === true ) {
+				$this->log( "verification passed" );
 				return true;
+			} else {
+				$this->log( "verification failed" );
+				return false;
 			}
 		}
 
+		$this->log( "verification failed - bad status returned from Google" );
 		return false;
 	}
 

--- a/extensions/wikia/CreateNewWiki/js/CreateNewWiki.js
+++ b/extensions/wikia/CreateNewWiki/js/CreateNewWiki.js
@@ -92,10 +92,7 @@
 					self.transition('NameWiki', true, '+');
 
 					// Load facebook assets before going to the login form
-					$.loadFacebookAPI()
-						.done(function () {
-							$('.sso-login').removeClass('hidden');
-						});
+					$.loadFacebookAPI();
 				}
 			});
 			this.wikiDomain.keyup(function () {

--- a/extensions/wikia/CreateNewWiki/js/CreateNewWiki.js
+++ b/extensions/wikia/CreateNewWiki/js/CreateNewWiki.js
@@ -92,7 +92,7 @@
 					self.transition('NameWiki', true, '+');
 
 					// Load facebook assets before going to the login form
-					$.loadFacebookAPI();
+					$.loadFacebookSDK();
 				}
 			});
 			this.wikiDomain.keyup(function () {

--- a/extensions/wikia/FacebookClient/FacebookClient.setup.php
+++ b/extensions/wikia/FacebookClient/FacebookClient.setup.php
@@ -47,20 +47,12 @@ $wgHooks['OasisSkinAssetGroups'][] = 'FacebookClientHooks::onSkinAssetGroups';
 $wgHooks['MonobookSkinAssetGroups'][] = 'FacebookClientHooks::onSkinAssetGroups';
 $wgHooks['ParserFirstCallInit'][] = 'FacebookClientHooks::setupParserHook';
 $wgHooks['SkinTemplatePageBeforeUserMsg'][] = 'FacebookClientHooks::onSkinTemplatePageBeforeUserMsg';
+$wgHooks['SkinAfterBottomScripts'][] = 'FacebookClientHooks::onSkinAfterBottomScripts';
 
 /**
  * messages
  */
 $wgExtensionMessagesFiles['FacebookClient'] = $dir . 'FacebookClient.i18n.php';
-
-/**
- * ResourceLoader modules
- */
-$wgResourceModules['ext.wikia.FacebookClient.XFBML'] = [
-	'scripts' => 'scripts/FacebookClient.XFBML.js',
-	'localBasePath' => __DIR__,
-	'remoteExtPath' => 'wikia/FacebookClient',
-];
 
 JSMessages::registerPackage( 'FacebookClient', [
 	'fbconnect-preferences-connected',

--- a/extensions/wikia/FacebookClient/FacebookClientHooks.class.php
+++ b/extensions/wikia/FacebookClient/FacebookClientHooks.class.php
@@ -135,5 +135,11 @@ class FacebookClientHooks {
 		return true;
 	}
 
+	public static function onSkinAfterBottomScripts( $skin, &$text ) {
 
+		$script = AssetsManager::getInstance()->getURL( 'facebook_client_xfbml_js' );
+		$text .= Html::linkedScript( $script[0] );
+
+		return true;
+	}
 }

--- a/extensions/wikia/FacebookClient/FacebookClientXFBML.php
+++ b/extensions/wikia/FacebookClient/FacebookClientXFBML.php
@@ -48,11 +48,12 @@ class FacebookClientXFBML {
 			unset( $args['profileid'] );
 		}
 
+		// add custom attribute to look for in DOM. We use this to determine
+		// if the Facebook SDK should be loaded.
+		$args['data-type'] = 'xfbml-tag';
+
 		// Allow other tags by default
 		$attrs = self::implodeAttrs( $args );
-
-		// Load Facebook's JS API on demand
-		$parser->getOutput()->addModules( 'ext.wikia.FacebookClient.XFBML' );
 
 		return "<{$tag}{$attrs}>" . $parser->recursiveTagParse( $text ) . "</$tag>";
 	}

--- a/extensions/wikia/FacebookClient/scripts/FacebookClient.XFBML.js
+++ b/extensions/wikia/FacebookClient/scripts/FacebookClient.XFBML.js
@@ -11,8 +11,6 @@ $(function () {
 	mw.hook('wikipage.content').add(function ($content) {
 		$.loadFacebookAPI()
 			.done(function () {
-				$('.sso-login').removeClass('hidden');
-
 				// scan the new content for any fb tags
 				FB.XFBML.parse($content[0]);
 			});

--- a/extensions/wikia/FacebookClient/scripts/FacebookClient.XFBML.js
+++ b/extensions/wikia/FacebookClient/scripts/FacebookClient.XFBML.js
@@ -2,17 +2,34 @@
 
 /**
  * Render FB XML tags emebedded into wikitext
- * This file is loaded via ResourceLoader only when FB XML tags are present on the page
  */
 $(function () {
 	'use strict';
 
 	// load api on page load and on demand
 	mw.hook('wikipage.content').add(function ($content) {
-		$.loadFacebookAPI()
-			.done(function () {
-				// scan the new content for any fb tags
-				FB.XFBML.parse($content[0]);
-			});
+
+		if ((xfbmlTagsOnPage())) {
+			if (facebookSDKNotLoaded()) {
+				// XFBML tags rendered automatically when SDK loads
+				$.loadFacebookSDK();
+			} else {
+				renderXFBMLTags();
+			}
+		}
+
+		function xfbmlTagsOnPage() {
+			var numOfXFBMLTags = $content.find('[data-type="xfbml-tag"]').length;
+			return numOfXFBMLTags > 0;
+		}
+
+		function facebookSDKNotLoaded() {
+			return typeof FB === 'undefined';
+		}
+
+		function renderXFBMLTags() {
+			FB.XFBML.parse($content[0]);
+		}
+
 	});
 });

--- a/extensions/wikia/FacebookClient/scripts/FacebookClient.XFBML.js
+++ b/extensions/wikia/FacebookClient/scripts/FacebookClient.XFBML.js
@@ -6,11 +6,18 @@
 mw.hook('wikipage.content').add(function ($content) {
 	'use strict';
 
-	if ((xfbmlTagsOnPage())) {
-		$.loadFacebookSDK().done(function () {
-			renderXFBMLTags();
-		});
-	}
+	// TODO This can be uncommented and lines 18 through 20 can be deleted 2 weeks after this is released.
+	// We need to wait for parser cache to be cleared so that "data-type='xfbml-tag'" will be added to the
+	// tags during parsing.
+	//	if ((xfbmlTagsOnPage())) {
+	//		$.loadFacebookSDK().done(function () {
+	//			renderXFBMLTags();
+	//		});
+	//	}
+
+	$.loadFacebookSDK().done(function () {
+		renderXFBMLTags();
+	});
 
 	function xfbmlTagsOnPage() {
 		var numOfXFBMLTags = $content.find('[data-type="xfbml-tag"]').length;

--- a/extensions/wikia/FacebookClient/scripts/FacebookClient.XFBML.js
+++ b/extensions/wikia/FacebookClient/scripts/FacebookClient.XFBML.js
@@ -1,35 +1,23 @@
 /* global FB */
 
 /**
- * Render FB XML tags emebedded into wikitext
+ * Render XFBML tags emebedded into wikitext
  */
-$(function () {
+mw.hook('wikipage.content').add(function ($content) {
 	'use strict';
 
-	// load api on page load and on demand
-	mw.hook('wikipage.content').add(function ($content) {
+	if ((xfbmlTagsOnPage())) {
+		$.loadFacebookSDK().done(function () {
+			renderXFBMLTags();
+		});
+	}
 
-		if ((xfbmlTagsOnPage())) {
-			if (facebookSDKNotLoaded()) {
-				// XFBML tags rendered automatically when SDK loads
-				$.loadFacebookSDK();
-			} else {
-				renderXFBMLTags();
-			}
-		}
+	function xfbmlTagsOnPage() {
+		var numOfXFBMLTags = $content.find('[data-type="xfbml-tag"]').length;
+		return numOfXFBMLTags > 0;
+	}
 
-		function xfbmlTagsOnPage() {
-			var numOfXFBMLTags = $content.find('[data-type="xfbml-tag"]').length;
-			return numOfXFBMLTags > 0;
-		}
-
-		function facebookSDKNotLoaded() {
-			return typeof FB === 'undefined';
-		}
-
-		function renderXFBMLTags() {
-			FB.XFBML.parse($content[0]);
-		}
-
-	});
+	function renderXFBMLTags() {
+		FB.XFBML.parse($content[0]);
+	}
 });

--- a/extensions/wikia/FacebookClient/scripts/preferences.js
+++ b/extensions/wikia/FacebookClient/scripts/preferences.js
@@ -24,7 +24,7 @@
 			$disconnectButton = $('.fb-disconnect');
 			$connectLink = $('.sso-login-facebook');
 
-			$.loadFacebookAPI()
+			$.loadFacebookSDK()
 				.done(function () {
 					bindEvents();
 				})

--- a/extensions/wikia/FacebookClient/scripts/preferences.js
+++ b/extensions/wikia/FacebookClient/scripts/preferences.js
@@ -26,7 +26,6 @@
 
 			$.loadFacebookAPI()
 				.done(function () {
-					$('.sso-login').removeClass('hidden');
 					bindEvents();
 				})
 				.fail(facebookError);

--- a/extensions/wikia/Follow/FollowHelper.class.php
+++ b/extensions/wikia/Follow/FollowHelper.class.php
@@ -108,6 +108,7 @@ class FollowHelper {
 		if ( !empty( $watchers ) ) {
 			$oTask = new FollowEmailTask();
 			$oTask->title( $childTitle );
+			$oTask->wikiId( F::app()->wg->CityId );
 			$oTask->call( 'emailFollowNotifications', $watchers, $user->getId(), $namespace, $message, $action );
 			$oTask->queue();
 		}

--- a/extensions/wikia/GlobalWatchlist/GlobalWatchlistHooks.class.php
+++ b/extensions/wikia/GlobalWatchlist/GlobalWatchlistHooks.class.php
@@ -75,7 +75,7 @@ class GlobalWatchlistHooks {
 	 * @param $timestamp Datetime or null
 	 * @return bool (always true)
 	 */
-	public static function updateGlobalWatchList( WatchedItem $watchedItem, $watchers, $timestamp ) {
+	public static function updateGlobalWatchList( WatchedItem $watchedItem, $watchers, $timestamp = null ) {
 		$watchers = wfReturnArray( $watchers );
 		if ( is_null( $timestamp ) ) {
 			self::removeWatchers( $watchedItem, $watchers );

--- a/extensions/wikia/MediaGallery/styles/MediaGallery.scss
+++ b/extensions/wikia/MediaGallery/styles/MediaGallery.scss
@@ -94,7 +94,6 @@ $media-margin: 2.5px;
 	}
 
 	.toggler {
-		clear: both;
 		margin-left: $media-margin * -1;
 		padding: .5em;
 		text-align: center;

--- a/extensions/wikia/ShareButtons/js/ShareButtonFacebook.js
+++ b/extensions/wikia/ShareButtons/js/ShareButtonFacebook.js
@@ -6,7 +6,7 @@ var Wikia = window.Wikia || {},
 
 if ( ShareButtons ) {
 	ShareButtons.add({
-		dependencies: [ $.loadFacebookAPI ],
+		dependencies: [ $.loadFacebookSDK ],
 		callback: function() {
 			var dfd = new $.Deferred();
 

--- a/extensions/wikia/UserLogin/UserLoginSpecialController.class.php
+++ b/extensions/wikia/UserLogin/UserLoginSpecialController.class.php
@@ -15,8 +15,8 @@ class UserLoginSpecialController extends WikiaSpecialPageController {
 	 * Remove when SOC-217 ABTest is finished
 	 */
 	const NOT_CONFIRMED_LOGIN_OPTION_NAME = 'NotConfirmedLogin';
-	const NOT_CONFIRMED_LOGIN_ALLOWED = 1;
-	const NOT_CONFIRMED_LOGIN_NOT_ALLOWED = 2;
+	const NOT_CONFIRMED_LOGIN_ALLOWED = '1';
+	const NOT_CONFIRMED_LOGIN_NOT_ALLOWED = '2';
 	/*
 	 * end remove
 	 */

--- a/extensions/wikia/UserLogin/UserSignupSpecialController.class.php
+++ b/extensions/wikia/UserLogin/UserSignupSpecialController.class.php
@@ -620,6 +620,11 @@ class UserSignupSpecialController extends WikiaSpecialPageController {
 		$this->errParam = $signupForm->errParam;
 	}
 
+	/**
+	 * Disables User Signup Captcha for automated tests, mobile skin, and sites such as internal
+	 *
+	 * @throws MWException
+	 */
 	private function disableCaptcha() {
 		global $wgHooks;
 
@@ -627,8 +632,8 @@ class UserSignupSpecialController extends WikiaSpecialPageController {
 		$isAutomatedTest = in_array( $this->wg->Request->getIP(), $this->wg->AutomatedTestsIPsList );
 		$isNoCaptchaTest = $this->wg->Request->getInt( 'nocaptchatest' ) == 1;
 
-		//Disable captcha for automated tests and wikia mobile
-		if ( $isMobile || ( $isAutomatedTest && $isNoCaptchaTest ) ) {
+		//Disable captcha for automated tests and wikia mobile and sites disabling it
+		if ( $isMobile || ( $isAutomatedTest && $isNoCaptchaTest ) || $this->wg->UserSignupDisableCaptcha ) {
 			//Switch off global var
 			$this->wg->WikiaEnableConfirmEditExt = false;
 			//Remove hook function
@@ -637,7 +642,7 @@ class UserSignupSpecialController extends WikiaSpecialPageController {
 				unset( $wgHooks['AbortNewAccount'][$hookArrayKey] );
 			}
 			$this->wg->Out->addJsConfigVars( [
-				'wgUserLoginDisableCaptcha' => true
+				'wgUserSignupDisableCaptcha' => true
 			] );
 		}
 	}

--- a/extensions/wikia/UserLogin/js/FacebookLogin.js
+++ b/extensions/wikia/UserLogin/js/FacebookLogin.js
@@ -61,7 +61,7 @@
 				self.bindEvents();
 
 				// load when the login dropdown is shown or specific page is loaded
-				$.loadFacebookAPI();
+				$.loadFacebookSDK();
 
 				self.log('init');
 				self.bucky.timer.stop('init');

--- a/extensions/wikia/UserLogin/js/FacebookLogin.js
+++ b/extensions/wikia/UserLogin/js/FacebookLogin.js
@@ -61,10 +61,7 @@
 				self.bindEvents();
 
 				// load when the login dropdown is shown or specific page is loaded
-				$.loadFacebookAPI()
-					.done(function () {
-						$('.sso-login').removeClass('hidden');
-					});
+				$.loadFacebookAPI();
 
 				self.log('init');
 				self.bucky.timer.stop('init');

--- a/extensions/wikia/UserLogin/js/UserLoginModal.js
+++ b/extensions/wikia/UserLogin/js/UserLoginModal.js
@@ -41,10 +41,6 @@
 					self.uiFactory = uiFactory;
 					self.packagesData = packagesData;
 
-					if (window.FacebookLogin) {
-						window.FacebookLogin.init(window.FacebookLogin.origins.MODAL);
-					}
-
 					self.buildModal(options);
 					self.bucky.timer.stop('initModal');
 				});
@@ -76,6 +72,16 @@
 					UserLoginModal.$modal = loginModal;
 
 					var $loginModal = loginModal.$element;
+
+					// Init facebook button inside login modal
+					if (window.FacebookLogin) {
+						// SOC-273 remove 'hidden' class even if element isn't in the DOM yet
+						$.loadFacebookAPI()
+							.done(function () {
+								$loginModal.find('.sso-login').removeClass('hidden');
+							});
+						window.FacebookLogin.init(window.FacebookLogin.origins.MODAL);
+					}
 
 					UserLoginModal.loginAjaxForm = new window.UserLoginAjaxForm($loginModal, {
 						ajaxLogin: true,

--- a/extensions/wikia/UserLogin/js/UserSignup.js
+++ b/extensions/wikia/UserLogin/js/UserSignup.js
@@ -13,7 +13,7 @@
 		/**
 		 * WikiaMobile, Wikia One, and some automated tests do not use captcha
 		 */
-		useCaptcha: !window.wgUserLoginDisableCaptcha,
+		useCaptcha: !window.wgUserSignupDisableCaptcha,
 
 		/**
 		 * Enable user signup form with ajax validation
@@ -94,10 +94,7 @@
 				.add(inputs.birthyear)
 				.on('change.UserSignup', this.validator.validateBirthdate.bind(this.validator));
 
-			if (
-				window.wgUserLoginDisableCaptcha !== true &&
-				inputs['g-recaptcha-response']
-			) {
+			if (this.useCaptcha && inputs['g-recaptcha-response']) {
 				inputs['g-recaptcha-response']
 					.on('keyup.UserSignup', this.validator.activateSubmit.bind(this.validator));
 			}

--- a/extensions/wikia/UserLogin/mixins/_divider.scss
+++ b/extensions/wikia/UserLogin/mixins/_divider.scss
@@ -1,11 +1,12 @@
-@import "skins/shared/color";
+@import 'skins/shared/color';
 
 @mixin divider {
-	border-top: solid 1px $color-page-border;
+	border-top: 0;
 	margin-top: 25px;
 	text-align: center;
+
 	> span {
-		background-color: $color-page;
+		background-color: inherit;
 		display: inline-block;
 		padding: 0 21px;
 		position: relative;

--- a/extensions/wikia/Wall/css/MessageTopic.scss
+++ b/extensions/wikia/Wall/css/MessageTopic.scss
@@ -20,7 +20,7 @@
 		background-color: $color-wall-input-new;
 		border: 1px solid $color-page-border;
 		color: $color-text;
-		
+
 		// Chrome needs this to get rid of empty space below textarea
 		display: block;
 		font-size: 13px;
@@ -73,7 +73,7 @@
 			opacity: .8;
 			padding-right: 15px;
 			position: relative;
-			
+
 			&:hover {
 				opacity: 1;
 				.remove-swatch {
@@ -87,7 +87,7 @@
 				}
 				@include transform(scale(0.8));
 				background-color: $color-remove-swatch;
-				background-image: url('/skins/oasis/images/icon_close.png'); /* $base64 */
+				background-image: url('/skins/oasis/images/icon_close.png'); /* inline */
 				background-position: -2px -2px;
 				cursor: pointer;
 				height: 12px;

--- a/extensions/wikia/Wall/css/RelatedTopics.scss
+++ b/extensions/wikia/Wall/css/RelatedTopics.scss
@@ -20,10 +20,10 @@
 		padding: 1px 5px 1px 21px;
 		position: relative;
 	}
-	
+
 	.related-topic:before {
 		background-repeat: no-repeat;
-		background-image: url('/extensions/wikia/Wall/images/forums-topic-icon.png'); /* $base64 */
+		background-image: url('/extensions/wikia/Wall/images/forums-topic-icon.png'); /* inline */
 		content: "";
 		display: block;
 		height: 13px;
@@ -32,7 +32,7 @@
 		top: 4px;
 		width: 11px;
 	}
-	
+
 	.edit-topic {
 		padding-left: 7px;
 		.edit-pencil {

--- a/extensions/wikia/WikiaMobile/WikiaMobile.setup.php
+++ b/extensions/wikia/WikiaMobile/WikiaMobile.setup.php
@@ -207,7 +207,7 @@ if ( empty( $wgWikiaMobileIncludeJSGlobals ) ) {
 			'wgLoginToken',
 
 			//signup
-			'wgUserLoginDisableCaptcha',
+			'wgUserSignupDisableCaptcha',
 
 			//AbTesting
 			'wgCdnApiUrl',

--- a/extensions/wikia/WikiaQuiz/js/WikiaPlayQuiz.js
+++ b/extensions/wikia/WikiaQuiz/js/WikiaPlayQuiz.js
@@ -60,7 +60,7 @@ var WikiaQuiz = {
 			WikiaQuiz.trackEvent('click-link-text', 'moreinfo', -1, $(e.target).attr('href'), e );
 		});
 
-		$.loadFacebookAPI();
+		$.loadFacebookSDK();
 
 		$().log('init', 'WikiaQuiz');
 	},

--- a/extensions/wikia/WikiaQuiz/js/WikiaPlayQuiz.js
+++ b/extensions/wikia/WikiaQuiz/js/WikiaPlayQuiz.js
@@ -60,10 +60,7 @@ var WikiaQuiz = {
 			WikiaQuiz.trackEvent('click-link-text', 'moreinfo', -1, $(e.target).attr('href'), e );
 		});
 
-		$.loadFacebookAPI()
-			.done(function () {
-				$('.sso-login').removeClass('hidden');
-			});
+		$.loadFacebookAPI();
 
 		$().log('init', 'WikiaQuiz');
 	},

--- a/includes/normal/README.md
+++ b/includes/normal/README.md
@@ -1,13 +1,15 @@
+# Unicode Normalization
+
 This directory contains some Unicode normalization routines. These routines
 are meant to be reusable in other projects, so I'm not tying them to the
 MediaWiki utility functions.
 
-The main function to care about is UtfNormal::toNFC(); this will convert
+The main function to care about is ```UtfNormal::toNFC()``` this will convert
 a given UTF-8 string to Normalization Form C if it's not already such.
 The function assumes that the input string is already valid UTF-8; if there
 are corrupt characters this may produce erroneous results.
 
-To also check for illegal characters, use UtfNormal::cleanUp(). This will
+To also check for illegal characters, use ```UtfNormal::cleanUp()```. This will
 strip illegal UTF-8 sequences and characters that are illegal in XML, and
 if necessary convert to normalization form C.
 
@@ -18,33 +20,35 @@ particularly for Korean text (the hangul decomposition/composition code is
 extra slow).
 
 
-== Regenerating data tables ==
+## Regenerating data tables
 
-UtfNormalData.inc and UtfNormalDataK.inc are generated from the Unicode
-Character Database by the script UtfNormalGenerate.php. On a *nix system
-'make' should fetch the necessary files and regenerate it if the scripts
+```UtfNormalData.inc``` and ```UtfNormalDataK.inc``` are generated from the Unicode
+Character Database by the script ```UtfNormalGenerate.php```. On a *nix system
+```make``` should fetch the necessary files and regenerate it if the scripts
 have been changed or you remove it.
 
 
-== Testing ==
+## Testing
 
-'make test' will run the conformance test (UtfNormalTest.php), fetching the
+```make test``` will run the conformance test (UtfNormalTest.php), fetching the
 data from from the net if necessary. If it reports failure, something is
 going wrong!
 
 You may have to set up PHPUnit first.
 
+```bash
 $ pear channel-discover pear.phpunit.de
 $ pear install phpunit/PHPUnit
+```
 
-== Benchmarks ==
+## Benchmarks
 
-Run 'make bench' to download some sample texts from Wikipedia and run some
+Run ```make bench``` to download some sample texts from Wikipedia and run some
 cheap benchmarks of some of the functions. Take all numbers with large
 grains of salt.
 
 
-== PHP module extension ==
+## PHP module extension
 
 There's an experimental PHP extension module which wraps the ICU library's
 normalization functions. This is *MUCH* faster than doing this work in pure
@@ -52,8 +56,8 @@ PHP code. This is in the 'normal' directory in MediaWiki's CVS extensions
 module. It is known to work with PHP 4.3.8 and 5.0.2 on Linux/x86 but hasn't
 been thoroughly tested on other configurations.
 
-If the php_normal.so module is loaded in php.ini, the normalization functions
-will automatically use it. If you can't (or don't want to) load it in php.ini,
-you may be able to load it using the dl() function before include()ing or
-require()ing UtfNormal.php, and it will be picked up.
+If the ```php_normal.so``` module is loaded in ```php.ini```, the normalization functions
+will automatically use it. If you can't (or don't want to) load it in ```php.ini```,
+you may be able to load it using the ```dl()``` function before include()ing or
+require()ing ```UtfNormal.php```, and it will be picked up.
 

--- a/includes/wikia/services/sass/Filter/InlineImageFilter.class.php
+++ b/includes/wikia/services/sass/Filter/InlineImageFilter.class.php
@@ -22,7 +22,7 @@ class InlineImageFilter extends Filter {
 	public function process( $contents ) {
 		wfProfileIn( __METHOD__ );
 
-		$contents = preg_replace_callback( "/([, ]url[^\n]*?\))([^\n]*?)(\s*\/\*\s*(base64|inline)\s*\*\/)/is", [$this, 'processMatches'], $contents );
+		$contents = preg_replace_callback( "/([, ]url[^\n]*?\))([^\n]*?)(\s*\/\*\s*inline\s*\*\/)/is", [$this, 'processMatches'], $contents );
 
 		wfProfileOut( __METHOD__ );
 

--- a/includes/wikia/services/sass/SassService.class.php
+++ b/includes/wikia/services/sass/SassService.class.php
@@ -25,7 +25,7 @@ use Wikia\Sass\Compiler\ExternalRubyCompiler;
  */
 class SassService extends WikiaObject {
 
-	const CACHE_VERSION = 5; # SASS caching does not depend on $wgStyleVersion, use this constant to bust SASS cache
+	const CACHE_VERSION = 6; # SASS caching does not depend on $wgStyleVersion, use this constant to bust SASS cache
 
 	const FILTER_IMPORT_CSS = 1;
 	const FILTER_CDN_REWRITE = 2;

--- a/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadExternalLibrary.js
+++ b/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadExternalLibrary.js
@@ -65,8 +65,9 @@
 				version: 'v2.1'
 			});
 
+			// show facebook login button
 			$('.sso-login').removeClass('hidden');
-			// resolve after FB has finished inititalizing
+			// resolve after FB has finished initializing
 			$deferred.resolve();
 		};
 

--- a/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadExternalLibrary.js
+++ b/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadExternalLibrary.js
@@ -56,25 +56,28 @@
 			$deferred.done(callback);
 		}
 
-		// This is invoked by Facebook once the SDK is loaded.
-		window.fbAsyncInit = function () {
-			window.FB.init({
-				appId: window.fbAppId,
-				xfbml: true,
-				cookie: true,
-				version: 'v2.1'
-			});
-
-			// show facebook login button
-			$('.sso-login').removeClass('hidden');
-			// resolve after FB has finished initializing
+		if (typeof window.FB === 'object') {
+			// Since we have our own deferred object, we need to resolve it if FB is already loaded.
+			// We can't rely on the type check inside $.loadExternalLibrary.
 			$deferred.resolve();
-		};
+		} else {
+			// This is invoked by Facebook once the SDK is loaded.
+			window.fbAsyncInit = function () {
+				window.FB.init({
+					appId: window.fbAppId,
+					xfbml: true,
+					cookie: true,
+					version: 'v2.1'
+				});
+				// resolve after FB has finished inititalizing
+				$deferred.resolve();
+			};
 
-		$.when($.loadExternalLibrary('FacebookSDK', url, typeof window.FB))
-			.fail(function () {
-				$deferred.reject();
-			});
+			$.when($.loadExternalLibrary('FacebookSDK', url, typeof window.FB))
+				.fail(function () {
+					$deferred.reject();
+				});
+		}
 
 		return $deferred;
 	};

--- a/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadExternalLibrary.js
+++ b/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadExternalLibrary.js
@@ -68,6 +68,9 @@
 					cookie: true,
 					version: 'v2.1'
 				});
+
+				// show facebook login button
+				$('.sso-login').removeClass('hidden');
 				// resolve after FB has finished inititalizing
 				$deferred.resolve();
 			};

--- a/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadExternalLibrary.js
+++ b/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadExternalLibrary.js
@@ -64,6 +64,8 @@
 				cookie: true,
 				version: 'v2.1'
 			});
+
+			$('.sso-login').removeClass('hidden');
 			// resolve after FB has finished inititalizing
 			$deferred.resolve();
 		};

--- a/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadExternalLibrary.js
+++ b/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadExternalLibrary.js
@@ -56,6 +56,11 @@
 			$deferred.done(callback);
 		}
 
+		// If the FB SDK successfully loads, show the fb login button
+		$deferred.done(function () {
+			$('.sso-login').removeClass('hidden');
+		});
+
 		if (typeof window.FB === 'object') {
 			// Since we have our own deferred object, we need to resolve it if FB is already loaded.
 			// We can't rely on the type check inside $.loadExternalLibrary.
@@ -69,8 +74,6 @@
 					version: 'v2.1'
 				});
 
-				// show facebook login button
-				$('.sso-login').removeClass('hidden');
 				// resolve after FB has finished inititalizing
 				$deferred.resolve();
 			};

--- a/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadExternalLibrary.js
+++ b/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadExternalLibrary.js
@@ -46,7 +46,7 @@
 	 * @returns {jQuery} Returns a jQuery promise
 	 * @see https://developers.facebook.com/docs/javascript/quickstart/v2.2
 	 */
-	$.loadFacebookAPI = function (callback) {
+	$.loadFacebookSDK = function (callback) {
 		// create our own deferred object to resolve after FB.init finishes
 		var $deferred = $.Deferred(),
 			url = window.fbScript || '//connect.facebook.net/en_US/sdk.js';

--- a/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadExternalLibrary.js
+++ b/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadExternalLibrary.js
@@ -65,7 +65,6 @@
 			window.fbAsyncInit = function () {
 				window.FB.init({
 					appId: window.fbAppId,
-					xfbml: true,
 					cookie: true,
 					version: 'v2.1'
 				});


### PR DESCRIPTION
The original implementation for supporting XFBML tags didn't work. The problem was that we were relying on the parser on the server side to check for XFBML tags and add the js to render them if present. This was fine most of the time, however if a page with XFBML tags was edited using VE, after the save the page wasn't refreshed and therefore the js which runs at page load to render the tags wasn't firing.

This implementation now checks for the XFBML tags on the client side and, if they're present, loads the SDK and renders them. It's registered to the 'wikipage.content' event, which occurs both on page load and after a VE edit.

Ticket: https://wikia-inc.atlassian.net/browse/SOC-261

Note: the original pull request was #6297 which contains additional discussion. The commit history got mangled with a couple bad merges and it was just easier to cherry-pick out the important commits, put them in this new branch, and open a new pull request.
