### PR TITLE
CE-1318 Add AutoFollow extension to DefaultSettings

### DIFF
--- a/extensions/wikia/AutoFollow/AutoFollow.hooks.php
+++ b/extensions/wikia/AutoFollow/AutoFollow.hooks.php
@@ -18,8 +18,8 @@ class AutoFollowHooks {
 	 * Checks if a user's language in one of the sanctioned ones
 	 * and has agreed to receive marketing information.
 	 * If yes it adds a task to add the user to watchlists.
-	 * @param  User object The user's object
-	 * @return {bool} true
+	 * @param  \User object The user's object
+	 * @return bool
 	 */
 	public function addAutoFollowTask( \User $oUser ) {
 		global $wgAutoFollowLangCityIdMap;
@@ -40,15 +40,15 @@ class AutoFollowHooks {
 	/**
 	 * Check if the user hasn't been subscribed to a watchlist
 	 * and if he agreed to receive marketing information
-	 * @param  User   $oUser A user's object
-	 * @return {bool}        true is the conditions are met
+	 * @param  \User $oUser A user's object
+	 * @return bool
 	 */
 	private function checkAutoFollowConditions( \User $oUser ) {
 		global $wgAutoFollowFlag;
 
-		if ( intval( $oUser->getOption( $wgAutoFollowFlag ) ) === 1 ) {
+		if ( intval( $oUser->getBoolOption( $wgAutoFollowFlag ) ) === true ) {
 			return false;
-		} elseif ( $oUser->getOption( 'marketingallowed' ) === 0 ) {
+		} elseif ( $oUser->getBoolOption( 'marketingallowed' ) === false ) {
 			return false;
 		}
 

--- a/extensions/wikia/AutoFollow/AutoFollow.hooks.php
+++ b/extensions/wikia/AutoFollow/AutoFollow.hooks.php
@@ -25,7 +25,6 @@ class AutoFollowHooks {
 		global $wgAutoFollowLangCityIdMap;
 		// Check only a core of the language code
 		$sUserLanguage = explode( '-', $oUser->getOption( 'language' ) )[0];
-
 		if ( isset( $wgAutoFollowLangCityIdMap[ $sUserLanguage ] ) &&
 			$this->checkAutoFollowConditions( $oUser )
 		) {
@@ -45,8 +44,7 @@ class AutoFollowHooks {
 	 */
 	private function checkAutoFollowConditions( \User $oUser ) {
 		global $wgAutoFollowFlag;
-
-		if ( intval( $oUser->getBoolOption( $wgAutoFollowFlag ) ) === true ) {
+		if ( $oUser->getBoolOption( $wgAutoFollowFlag ) === true ) {
 			return false;
 		} elseif ( $oUser->getBoolOption( 'marketingallowed' ) === false ) {
 			return false;

--- a/extensions/wikia/AutoFollow/AutoFollow.setup.php
+++ b/extensions/wikia/AutoFollow/AutoFollow.setup.php
@@ -14,7 +14,7 @@
  * @global Array The list of extension credits.
  * @see http://www.mediawiki.org/wiki/Manual:$wgExtensionCredits
  */
-$wgExtensionCredits['other'][] = array(
+$wgExtensionCredits['other'][] = [
 	'path'              => __FILE__,
 	'name'              => 'AutoFollow',
 	'descriptionmsg'    => 'autofollow-ext-description',
@@ -23,14 +23,14 @@ $wgExtensionCredits['other'][] = array(
 		'Adam Karminski <adamk@wikia-inc.com>'
 	],
 	'url'               => 'https://github.com/Wikia/app/tree/dev/extensions/wikia/AutoFollow/',
-);
+];
 
 $wgExtensionMessagesFiles['AutoFollow'] = __DIR__ . '/AutoFollow.i18n.php';
 
 $wgAutoloadClasses['Wikia\AutoFollow\AutoFollowHooks'] = __DIR__ . '/AutoFollow.hooks.php';
 $wgAutoloadClasses['Wikia\AutoFollow\AutoFollowTask'] = __DIR__ . '/AutoFollowTask.class.php';
 
-$wgHooks['SignupConfirmEmailComplete'][] = "Wikia\AutoFollow\AutoFollowHooks::onSignupConfirmEmailComplete";
+$wgHooks['SignupConfirmEmailComplete'][] = 'Wikia\AutoFollow\AutoFollowHooks::onSignupConfirmEmailComplete';
 
 /**
  * @global Array A language code to its community wikia's city_id map

--- a/extensions/wikia/AutoFollow/AutoFollowTask.class.php
+++ b/extensions/wikia/AutoFollow/AutoFollowTask.class.php
@@ -45,7 +45,7 @@ class AutoFollowTask extends BaseTask {
 
 	/**
 	 * Sets the 'autowatched-already' option to 1
-	 * @param User $oUser A user's object
+	 * @param \User $oUser A user's object
 	 */
 	private function setFlag( \User $oUser ) {
 		global $wgAutoFollowFlag;
@@ -56,9 +56,9 @@ class AutoFollowTask extends BaseTask {
 
 	/**
 	 * Logs the results of all add-to-watchlist actions
-	 * @param  User   $oUser         A user's object
-	 * @param  Array  $aWatchSuccess An array of successfully watched articles' titles
-	 * @param  Array  $aWatchFail    An array of articles' titles that failed from being watched
+	 * @param \User $oUser A user's object
+	 * @param Array $aWatchSuccess An array of successfully watched articles' titles
+	 * @param Array $aWatchFail An array of articles' titles that failed from being watched
 	 */
 	private function logResults( \User $oUser, Array $aWatchSuccess, Array $aWatchFail ) {
 		global $wgSitename;

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -613,6 +613,7 @@ include_once( "$IP/extensions/wikia/CityVisualization/CityVisualization.setup.ph
 include_once( "$IP/extensions/wikia/Thumbnails/Thumbnails.setup.php" );
 include_once( "$IP/extensions/wikia/InstantGlobals/InstantGlobals.setup.php" );
 include_once( "$IP/extensions/wikia/UserTools/UserTools.setup.php" );
+include_once( "$IP/extensions/wikia/AutoFollow/AutoFollow.setup.php" );
 
 /**
  * @name $wgSkipSkins


### PR DESCRIPTION
See [CE-1318](https://wikia-inc.atlassian.net/browse/CE-1318)

Besides minor conventions and documentation fixes, the most important part here is to add AutoFollow to the wikia's DefaultSettings since it should be run site-wide and catch users of our officially supported languages.
