### PR TITLE
SOC-365 fixing gallery toggle button float issue

### DIFF
--- a/extensions/wikia/MediaGallery/styles/MediaGallery.scss
+++ b/extensions/wikia/MediaGallery/styles/MediaGallery.scss
@@ -94,7 +94,6 @@ $media-margin: 2.5px;
 	}
 
 	.toggler {
-		clear: both;
 		margin-left: $media-margin * -1;
 		padding: .5em;
 		text-align: center;


### PR DESCRIPTION
Since we're no longer floating the gallery items (they are `display:inline-block`), we don't have to set `clear:both` on the show more/less buttons. Removing the clear property of that button wrapper avoids issues where the buttons clear a tall floated item (like an infobox) and are separated vertically from the gallery items. 
