### PR TITLE
SOC-261 Restore support for XFBML plugin code

### DIFF
--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -2282,3 +2282,11 @@ $config['facebook_client_preferences_scss'] = [
 		'//extensions/wikia/FacebookClient/styles/preferences.scss',
 	]
 ];
+
+$config['facebook_client_xfbml_js'] = [
+	'type' => AssetsManager::TYPE_JS,
+	'skin' => ['oasis', 'monobook'],
+	'assets' => [
+		'//extensions/wikia/FacebookClient/scripts/FacebookClient.XFBML.js',
+	]
+];

--- a/extensions/wikia/CreateNewWiki/js/CreateNewWiki.js
+++ b/extensions/wikia/CreateNewWiki/js/CreateNewWiki.js
@@ -92,10 +92,7 @@
 					self.transition('NameWiki', true, '+');
 
 					// Load facebook assets before going to the login form
-					$.loadFacebookAPI()
-						.done(function () {
-							$('.sso-login').removeClass('hidden');
-						});
+					$.loadFacebookAPI();
 				}
 			});
 			this.wikiDomain.keyup(function () {

--- a/extensions/wikia/CreateNewWiki/js/CreateNewWiki.js
+++ b/extensions/wikia/CreateNewWiki/js/CreateNewWiki.js
@@ -92,7 +92,7 @@
 					self.transition('NameWiki', true, '+');
 
 					// Load facebook assets before going to the login form
-					$.loadFacebookAPI();
+					$.loadFacebookSDK();
 				}
 			});
 			this.wikiDomain.keyup(function () {

--- a/extensions/wikia/FacebookClient/FacebookClient.setup.php
+++ b/extensions/wikia/FacebookClient/FacebookClient.setup.php
@@ -47,20 +47,12 @@ $wgHooks['OasisSkinAssetGroups'][] = 'FacebookClientHooks::onSkinAssetGroups';
 $wgHooks['MonobookSkinAssetGroups'][] = 'FacebookClientHooks::onSkinAssetGroups';
 $wgHooks['ParserFirstCallInit'][] = 'FacebookClientHooks::setupParserHook';
 $wgHooks['SkinTemplatePageBeforeUserMsg'][] = 'FacebookClientHooks::onSkinTemplatePageBeforeUserMsg';
+$wgHooks['SkinAfterBottomScripts'][] = 'FacebookClientHooks::onSkinAfterBottomScripts';
 
 /**
  * messages
  */
 $wgExtensionMessagesFiles['FacebookClient'] = $dir . 'FacebookClient.i18n.php';
-
-/**
- * ResourceLoader modules
- */
-$wgResourceModules['ext.wikia.FacebookClient.XFBML'] = [
-	'scripts' => 'scripts/FacebookClient.XFBML.js',
-	'localBasePath' => __DIR__,
-	'remoteExtPath' => 'wikia/FacebookClient',
-];
 
 JSMessages::registerPackage( 'FacebookClient', [
 	'fbconnect-preferences-connected',

--- a/extensions/wikia/FacebookClient/FacebookClientHooks.class.php
+++ b/extensions/wikia/FacebookClient/FacebookClientHooks.class.php
@@ -135,5 +135,11 @@ class FacebookClientHooks {
 		return true;
 	}
 
+	public static function onSkinAfterBottomScripts( $skin, &$text ) {
 
+		$script = AssetsManager::getInstance()->getURL( 'facebook_client_xfbml_js' );
+		$text .= Html::linkedScript( $script[0] );
+
+		return true;
+	}
 }

--- a/extensions/wikia/FacebookClient/FacebookClientXFBML.php
+++ b/extensions/wikia/FacebookClient/FacebookClientXFBML.php
@@ -48,11 +48,12 @@ class FacebookClientXFBML {
 			unset( $args['profileid'] );
 		}
 
+		// add custom attribute to look for in DOM. We use this to determine
+		// if the Facebook SDK should be loaded.
+		$args['data-type'] = 'xfbml-tag';
+
 		// Allow other tags by default
 		$attrs = self::implodeAttrs( $args );
-
-		// Load Facebook's JS API on demand
-		$parser->getOutput()->addModules( 'ext.wikia.FacebookClient.XFBML' );
 
 		return "<{$tag}{$attrs}>" . $parser->recursiveTagParse( $text ) . "</$tag>";
 	}

--- a/extensions/wikia/FacebookClient/scripts/FacebookClient.XFBML.js
+++ b/extensions/wikia/FacebookClient/scripts/FacebookClient.XFBML.js
@@ -11,8 +11,6 @@ $(function () {
 	mw.hook('wikipage.content').add(function ($content) {
 		$.loadFacebookAPI()
 			.done(function () {
-				$('.sso-login').removeClass('hidden');
-
 				// scan the new content for any fb tags
 				FB.XFBML.parse($content[0]);
 			});

--- a/extensions/wikia/FacebookClient/scripts/FacebookClient.XFBML.js
+++ b/extensions/wikia/FacebookClient/scripts/FacebookClient.XFBML.js
@@ -2,17 +2,34 @@
 
 /**
  * Render FB XML tags emebedded into wikitext
- * This file is loaded via ResourceLoader only when FB XML tags are present on the page
  */
 $(function () {
 	'use strict';
 
 	// load api on page load and on demand
 	mw.hook('wikipage.content').add(function ($content) {
-		$.loadFacebookAPI()
-			.done(function () {
-				// scan the new content for any fb tags
-				FB.XFBML.parse($content[0]);
-			});
+
+		if ((xfbmlTagsOnPage())) {
+			if (facebookSDKNotLoaded()) {
+				// XFBML tags rendered automatically when SDK loads
+				$.loadFacebookSDK();
+			} else {
+				renderXFBMLTags();
+			}
+		}
+
+		function xfbmlTagsOnPage() {
+			var numOfXFBMLTags = $content.find('[data-type="xfbml-tag"]').length;
+			return numOfXFBMLTags > 0;
+		}
+
+		function facebookSDKNotLoaded() {
+			return typeof FB === 'undefined';
+		}
+
+		function renderXFBMLTags() {
+			FB.XFBML.parse($content[0]);
+		}
+
 	});
 });

--- a/extensions/wikia/FacebookClient/scripts/FacebookClient.XFBML.js
+++ b/extensions/wikia/FacebookClient/scripts/FacebookClient.XFBML.js
@@ -6,11 +6,18 @@
 mw.hook('wikipage.content').add(function ($content) {
 	'use strict';
 
-	if ((xfbmlTagsOnPage())) {
-		$.loadFacebookSDK().done(function () {
-			renderXFBMLTags();
-		});
-	}
+	// TODO This can be uncommented and lines 18 through 20 can be deleted 2 weeks after this is released.
+	// We need to wait for parser cache to be cleared so that "data-type='xfbml-tag'" will be added to the
+	// tags during parsing.
+	//	if ((xfbmlTagsOnPage())) {
+	//		$.loadFacebookSDK().done(function () {
+	//			renderXFBMLTags();
+	//		});
+	//	}
+
+	$.loadFacebookSDK().done(function () {
+		renderXFBMLTags();
+	});
 
 	function xfbmlTagsOnPage() {
 		var numOfXFBMLTags = $content.find('[data-type="xfbml-tag"]').length;

--- a/extensions/wikia/FacebookClient/scripts/FacebookClient.XFBML.js
+++ b/extensions/wikia/FacebookClient/scripts/FacebookClient.XFBML.js
@@ -1,35 +1,23 @@
 /* global FB */
 
 /**
- * Render FB XML tags emebedded into wikitext
+ * Render XFBML tags emebedded into wikitext
  */
-$(function () {
+mw.hook('wikipage.content').add(function ($content) {
 	'use strict';
 
-	// load api on page load and on demand
-	mw.hook('wikipage.content').add(function ($content) {
+	if ((xfbmlTagsOnPage())) {
+		$.loadFacebookSDK().done(function () {
+			renderXFBMLTags();
+		});
+	}
 
-		if ((xfbmlTagsOnPage())) {
-			if (facebookSDKNotLoaded()) {
-				// XFBML tags rendered automatically when SDK loads
-				$.loadFacebookSDK();
-			} else {
-				renderXFBMLTags();
-			}
-		}
+	function xfbmlTagsOnPage() {
+		var numOfXFBMLTags = $content.find('[data-type="xfbml-tag"]').length;
+		return numOfXFBMLTags > 0;
+	}
 
-		function xfbmlTagsOnPage() {
-			var numOfXFBMLTags = $content.find('[data-type="xfbml-tag"]').length;
-			return numOfXFBMLTags > 0;
-		}
-
-		function facebookSDKNotLoaded() {
-			return typeof FB === 'undefined';
-		}
-
-		function renderXFBMLTags() {
-			FB.XFBML.parse($content[0]);
-		}
-
-	});
+	function renderXFBMLTags() {
+		FB.XFBML.parse($content[0]);
+	}
 });

--- a/extensions/wikia/FacebookClient/scripts/preferences.js
+++ b/extensions/wikia/FacebookClient/scripts/preferences.js
@@ -24,7 +24,7 @@
 			$disconnectButton = $('.fb-disconnect');
 			$connectLink = $('.sso-login-facebook');
 
-			$.loadFacebookAPI()
+			$.loadFacebookSDK()
 				.done(function () {
 					bindEvents();
 				})

--- a/extensions/wikia/FacebookClient/scripts/preferences.js
+++ b/extensions/wikia/FacebookClient/scripts/preferences.js
@@ -26,7 +26,6 @@
 
 			$.loadFacebookAPI()
 				.done(function () {
-					$('.sso-login').removeClass('hidden');
 					bindEvents();
 				})
 				.fail(facebookError);

--- a/extensions/wikia/ShareButtons/js/ShareButtonFacebook.js
+++ b/extensions/wikia/ShareButtons/js/ShareButtonFacebook.js
@@ -6,7 +6,7 @@ var Wikia = window.Wikia || {},
 
 if ( ShareButtons ) {
 	ShareButtons.add({
-		dependencies: [ $.loadFacebookAPI ],
+		dependencies: [ $.loadFacebookSDK ],
 		callback: function() {
 			var dfd = new $.Deferred();
 

--- a/extensions/wikia/UserLogin/js/FacebookLogin.js
+++ b/extensions/wikia/UserLogin/js/FacebookLogin.js
@@ -61,7 +61,7 @@
 				self.bindEvents();
 
 				// load when the login dropdown is shown or specific page is loaded
-				$.loadFacebookAPI();
+				$.loadFacebookSDK();
 
 				self.log('init');
 				self.bucky.timer.stop('init');

--- a/extensions/wikia/UserLogin/js/FacebookLogin.js
+++ b/extensions/wikia/UserLogin/js/FacebookLogin.js
@@ -61,10 +61,7 @@
 				self.bindEvents();
 
 				// load when the login dropdown is shown or specific page is loaded
-				$.loadFacebookAPI()
-					.done(function () {
-						$('.sso-login').removeClass('hidden');
-					});
+				$.loadFacebookAPI();
 
 				self.log('init');
 				self.bucky.timer.stop('init');

--- a/extensions/wikia/UserLogin/js/UserLoginModal.js
+++ b/extensions/wikia/UserLogin/js/UserLoginModal.js
@@ -76,10 +76,7 @@
 					// Init facebook button inside login modal
 					if (window.FacebookLogin) {
 						// SOC-273 remove 'hidden' class even if element isn't in the DOM yet
-						$.loadFacebookAPI()
-							.done(function () {
-								$loginModal.find('.sso-login').removeClass('hidden');
-							});
+						$.loadFacebookSDK();
 						window.FacebookLogin.init(window.FacebookLogin.origins.MODAL);
 					}
 

--- a/extensions/wikia/WikiaQuiz/js/WikiaPlayQuiz.js
+++ b/extensions/wikia/WikiaQuiz/js/WikiaPlayQuiz.js
@@ -60,7 +60,7 @@ var WikiaQuiz = {
 			WikiaQuiz.trackEvent('click-link-text', 'moreinfo', -1, $(e.target).attr('href'), e );
 		});
 
-		$.loadFacebookAPI();
+		$.loadFacebookSDK();
 
 		$().log('init', 'WikiaQuiz');
 	},

--- a/extensions/wikia/WikiaQuiz/js/WikiaPlayQuiz.js
+++ b/extensions/wikia/WikiaQuiz/js/WikiaPlayQuiz.js
@@ -60,10 +60,7 @@ var WikiaQuiz = {
 			WikiaQuiz.trackEvent('click-link-text', 'moreinfo', -1, $(e.target).attr('href'), e );
 		});
 
-		$.loadFacebookAPI()
-			.done(function () {
-				$('.sso-login').removeClass('hidden');
-			});
+		$.loadFacebookAPI();
 
 		$().log('init', 'WikiaQuiz');
 	},

--- a/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadExternalLibrary.js
+++ b/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadExternalLibrary.js
@@ -68,6 +68,9 @@
 					cookie: true,
 					version: 'v2.1'
 				});
+
+				// show facebook login button
+				$('.sso-login').removeClass('hidden');
 				// resolve after FB has finished inititalizing
 				$deferred.resolve();
 			};

--- a/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadExternalLibrary.js
+++ b/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadExternalLibrary.js
@@ -56,6 +56,11 @@
 			$deferred.done(callback);
 		}
 
+		// If the FB SDK successfully loads, show the fb login button
+		$deferred.done(function () {
+			$('.sso-login').removeClass('hidden');
+		});
+
 		if (typeof window.FB === 'object') {
 			// Since we have our own deferred object, we need to resolve it if FB is already loaded.
 			// We can't rely on the type check inside $.loadExternalLibrary.
@@ -69,8 +74,6 @@
 					version: 'v2.1'
 				});
 
-				// show facebook login button
-				$('.sso-login').removeClass('hidden');
 				// resolve after FB has finished inititalizing
 				$deferred.resolve();
 			};

--- a/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadExternalLibrary.js
+++ b/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadExternalLibrary.js
@@ -46,7 +46,7 @@
 	 * @returns {jQuery} Returns a jQuery promise
 	 * @see https://developers.facebook.com/docs/javascript/quickstart/v2.2
 	 */
-	$.loadFacebookAPI = function (callback) {
+	$.loadFacebookSDK = function (callback) {
 		// create our own deferred object to resolve after FB.init finishes
 		var $deferred = $.Deferred(),
 			url = window.fbScript || '//connect.facebook.net/en_US/sdk.js';

--- a/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadExternalLibrary.js
+++ b/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadExternalLibrary.js
@@ -65,7 +65,6 @@
 			window.fbAsyncInit = function () {
 				window.FB.init({
 					appId: window.fbAppId,
-					xfbml: true,
 					cookie: true,
 					version: 'v2.1'
 				});


### PR DESCRIPTION
The original implementation for supporting XFBML tags didn't work. The problem was that we were relying on the parser on the server side to check for XFBML tags and add the js to render them if present. This was fine most of the time, however if a page with XFBML tags was edited using VE, after the save the page wasn't refreshed and therefore the js which runs at page load to render the tags wasn't firing.

This implementation now checks for the XFBML tags on the client side and, if they're present, loads the SDK and renders them. It's registered to the 'wikipage.content' event, which occurs both on page load and after a VE edit.

Ticket: https://wikia-inc.atlassian.net/browse/SOC-261

Note: the original pull requests were #6297 and #6347 which contain additional discussion. Somehow I mangled both of those branches and it was easier to create a new one. After this ticket I'm going to sit down and have a long discussion with git about how we can work together better in the future.
