### PR TITLE
[WikiaApiQueryPageinfo::getPageViews] The database query returns 114k+ rows

### DIFF
--- a/extensions/wikia/WikiaApi/WikiaApiQueryPageinfo.php
+++ b/extensions/wikia/WikiaApi/WikiaApiQueryPageinfo.php
@@ -1,19 +1,9 @@
 <?php
 
-if (!defined('MEDIAWIKI')) {
-	// Eclipse helper - will be ignored in production
-	require_once ("ApiQueryBase.php");
-}
-
 /**
- * A query module to generate pageviews .
- *
+ * A query module to generate pageviews
  */
 class WikiaApiQueryPageinfo extends ApiQueryInfo {
-
-	public function __construct($query, $moduleName) {
-		parent :: __construct($query, $moduleName);
-	}
 
 	public function execute() {
 		$prop = array();
@@ -35,7 +25,7 @@ class WikiaApiQueryPageinfo extends ApiQueryInfo {
 		parent :: execute(); 
 	}
 	
-	private function getPageViews(&$result) {
+	private function getPageViews(ApiResult $result) {
 		$res = $result->getData();
 		
 		if ( isset($res['query']) && isset($res['query']['pages']) ) {
@@ -64,7 +54,7 @@ class WikiaApiQueryPageinfo extends ApiQueryInfo {
 		}
 	}
 
-	private function getCreateDate(&$result) {
+	private function getCreateDate(ApiResult $result) {
 		$res = $result->getData();
 		
 		if ( isset($res['query']) && isset($res['query']['pages']) ) {
@@ -95,7 +85,7 @@ class WikiaApiQueryPageinfo extends ApiQueryInfo {
 		}
 	}
 
-	private function getRevCount(&$result) {
+	private function getRevCount(ApiResult $result) {
 		$res = $result->getData();
 		$db = $this->getDB();
 		if ( isset($res['query']) && isset($res['query']['pages']) ) {
@@ -108,10 +98,8 @@ class WikiaApiQueryPageinfo extends ApiQueryInfo {
 		}
 	}
 	
-	private function getRedirectName(&$result) {
-		global $wgContLang;
+	private function getRedirectName(ApiResult $result) {
 		$res = &$result->getData();
-		$db = $this->getDB();
 		if ( isset($res['query']) && isset($res['query']['pages']) ) {
 			foreach ($this->getPageSet()->getGoodTitles() as $page_id => $oTitle) {
 				$res['query']['pages'][$page_id]['redirectto'] = ""; 

--- a/extensions/wikia/WikiaApi/WikiaApiQueryPageinfo.php
+++ b/extensions/wikia/WikiaApi/WikiaApiQueryPageinfo.php
@@ -26,10 +26,22 @@ class WikiaApiQueryPageinfo extends ApiQueryInfo {
 	}
 	
 	private function getPageViews(ApiResult $result) {
+		/**
+		 * Do not run for an empty set of pages
+		 *
+		 * Otherwise we run the query without the WHERE that results with all wiki articles being returned to PHP:
+		 * SELECT article_id,count as page_counter  FROM `page_visited`
+		 *
+		 * @see PLATFORM-913
+		 */
+		$aTitles = $this->getPageSet()->getGoodTitles();
+		if ( empty( $aTitles ) ) {
+			return;
+		}
+
 		$res = $result->getData();
 		
 		if ( isset($res['query']) && isset($res['query']['pages']) ) {
-			$aTitles = $this->getPageSet()->getGoodTitles();
 			#---
 			$this->resetQueryParams();
 			$this->addFields( array( 'article_id', 'count as page_counter' ) );

--- a/extensions/wikia/WikiaApi/WikiaApiQueryPageinfo.php
+++ b/extensions/wikia/WikiaApi/WikiaApiQueryPageinfo.php
@@ -8,24 +8,24 @@ class WikiaApiQueryPageinfo extends ApiQueryInfo {
 	public function execute() {
 		$prop = array();
 		$params = $this->extractRequestParams();
-		if ( isset($params['prop']) ) {
-			$prop = array_flip($params['prop']);
+		if ( isset( $params['prop'] ) ) {
+			$prop = array_flip( $params['prop'] );
 		}
 
 		$result = $this->getResult();
 
-		foreach ( $prop as $param => $id) {
-			switch ($param) {
-				case "views" 	: $this->getPageViews($result); break;
-				case "revcount" : $this->getRevCount($result); break;
-				case "created"	: $this->getCreateDate($result); break;
-				case "redirect"	: $this->getRedirectName($result); break;
+		foreach ( $prop as $param => $id ) {
+			switch ( $param ) {
+				case "views" 	: $this->getPageViews( $result ); break;
+				case "revcount" : $this->getRevCount( $result ); break;
+				case "created"	: $this->getCreateDate( $result ); break;
+				case "redirect"	: $this->getRedirectName( $result ); break;
 			}
 		}
-		parent :: execute(); 
+		parent :: execute();
 	}
-	
-	private function getPageViews(ApiResult $result) {
+
+	private function getPageViews( ApiResult $result ) {
 		/**
 		 * Do not run for an empty set of pages
 		 *
@@ -40,102 +40,102 @@ class WikiaApiQueryPageinfo extends ApiQueryInfo {
 		}
 
 		$res = $result->getData();
-		
-		if ( isset($res['query']) && isset($res['query']['pages']) ) {
-			#---
+
+		if ( isset( $res['query'] ) && isset( $res['query']['pages'] ) ) {
+			# ---
 			$this->resetQueryParams();
 			$this->addFields( array( 'article_id', 'count as page_counter' ) );
-			#--- table
-			$this->addTables('page_visited');
-			#--- where
-			$this->addWhereFld('article_id', array_keys($aTitles));
-			#--- select 
+			# --- table
+			$this->addTables( 'page_visited' );
+			# --- where
+			$this->addWhereFld( 'article_id', array_keys( $aTitles ) );
+			# --- select
 			$db = $this->getDB();
-			$oRes = $this->select(__METHOD__);
+			$oRes = $this->select( __METHOD__ );
 			$pageviews = array();
-			while ($oRow = $db->fetchObject($oRes)) {
+			while ( $oRow = $db->fetchObject( $oRes ) ) {
 				$pageviews[$oRow->article_id] = $oRow->page_counter;
 			}
-			$db->freeResult($oRes);
-			
-			foreach ($aTitles as $page_id => $oTitle) {
-				if ( isset($res ['query']['pages'][$page_id]) ) {
-					$result->addValue(array("query", "pages", $page_id), "views", ( isset( $pageviews[$page_id] ) )  ? intval( $pageviews[$page_id] ) : 0 );
+			$db->freeResult( $oRes );
+
+			foreach ( $aTitles as $page_id => $oTitle ) {
+				if ( isset( $res ['query']['pages'][$page_id] ) ) {
+					$result->addValue( array( "query", "pages", $page_id ), "views", ( isset( $pageviews[$page_id] ) )  ? intval( $pageviews[$page_id] ) : 0 );
 				}
 			}
 		}
 	}
 
-	private function getCreateDate(ApiResult $result) {
+	private function getCreateDate( ApiResult $result ) {
 		$res = $result->getData();
-		
-		if ( isset($res['query']) && isset($res['query']['pages']) ) {
+
+		if ( isset( $res['query'] ) && isset( $res['query']['pages'] ) ) {
 			$aTitles = $this->getPageSet()->getGoodTitles();
-			#---
-			if ( !empty($aTitles) && is_array($aTitles) ) {
-				foreach ($aTitles as $page_id => $oTitle) {
+			# ---
+			if ( !empty( $aTitles ) && is_array( $aTitles ) ) {
+				foreach ( $aTitles as $page_id => $oTitle ) {
 					$this->resetQueryParams();
 					$this->addFields( array( 'min(rev_timestamp) as created' ) );
-					#--- table
-					$this->addTables('revision');
-					#--- where
-					$this->addWhereFld('rev_page', $page_id);
-					#--- select 
+					# --- table
+					$this->addTables( 'revision' );
+					# --- where
+					$this->addWhereFld( 'rev_page', $page_id );
+					# --- select
 					$db = $this->getDB();
-					$oRes = $this->select(__METHOD__);
+					$oRes = $this->select( __METHOD__ );
 					$created = "";
-					if ($oRow = $db->fetchObject($oRes)) {
-						$created = wfTimestamp(TS_ISO_8601, $oRow->created); 
+					if ( $oRow = $db->fetchObject( $oRes ) ) {
+						$created = wfTimestamp( TS_ISO_8601, $oRow->created );
 					}
-					$db->freeResult($oRes);
+					$db->freeResult( $oRes );
 
-					if ( isset($res ['query']['pages'][$page_id]) ) {
-						$result->addValue(array("query", "pages", $page_id), "created", $created);
+					if ( isset( $res ['query']['pages'][$page_id] ) ) {
+						$result->addValue( array( "query", "pages", $page_id ), "created", $created );
 					}
 				}
 			}
 		}
 	}
 
-	private function getRevCount(ApiResult $result) {
+	private function getRevCount( ApiResult $result ) {
 		$res = $result->getData();
 		$db = $this->getDB();
-		if ( isset($res['query']) && isset($res['query']['pages']) ) {
-			foreach ($this->getPageSet()->getGoodTitles() as $page_id => $oTitle) {
-				if ( isset($res['query']['pages'][$page_id]) ) {
-					$revcount = Revision :: countByPageId($db, $page_id);
-					$result->addValue(array("query", "pages", $page_id), "revcount", intval($revcount));
+		if ( isset( $res['query'] ) && isset( $res['query']['pages'] ) ) {
+			foreach ( $this->getPageSet()->getGoodTitles() as $page_id => $oTitle ) {
+				if ( isset( $res['query']['pages'][$page_id] ) ) {
+					$revcount = Revision :: countByPageId( $db, $page_id );
+					$result->addValue( array( "query", "pages", $page_id ), "revcount", intval( $revcount ) );
 				}
 			}
 		}
 	}
-	
-	private function getRedirectName(ApiResult $result) {
+
+	private function getRedirectName( ApiResult $result ) {
 		$res = &$result->getData();
-		if ( isset($res['query']) && isset($res['query']['pages']) ) {
-			foreach ($this->getPageSet()->getGoodTitles() as $page_id => $oTitle) {
-				$res['query']['pages'][$page_id]['redirectto'] = ""; 
+		if ( isset( $res['query'] ) && isset( $res['query']['pages'] ) ) {
+			foreach ( $this->getPageSet()->getGoodTitles() as $page_id => $oTitle ) {
+				$res['query']['pages'][$page_id]['redirectto'] = "";
 				if ( $oTitle->isRedirect() ) {
-					$oArticle = new Article($oTitle);
+					$oArticle = new Article( $oTitle );
 					$oRedirTitle = $oArticle->getRedirectTarget();
 					if ( $oRedirTitle instanceof Title ) {
-						$result->addValue(array("query", "pages", $page_id), "redirectto", Title::makeName($oRedirTitle->getNamespace(), $oRedirTitle->getDBkey()) );
+						$result->addValue( array( "query", "pages", $page_id ), "redirectto", Title::makeName( $oRedirTitle->getNamespace(), $oRedirTitle->getDBkey() ) );
 					}
-				} 
+				}
 			}
 		}
 	}
 
 	public function getExamples() {
 		return array_merge(
-			parent::getExamples(), 		
+			parent::getExamples(),
 			array (
 				"Get a pageviews of [[Main Page]] ",
 				"  api.php?action=query&prop=info&titles=Main%20Page&inprop=views|revcount"
 			)
 		);
 	}
-	
+
 	public function getAllowedParams() {
 		$params = parent :: getAllowedParams();
 		$params['prop'][ApiBase :: PARAM_TYPE] = array_merge(
@@ -149,11 +149,11 @@ class WikiaApiQueryPageinfo extends ApiQueryInfo {
 		);
 		return $params;
 	}
-	
+
 	public function getParamDescription() {
 		$description = parent :: getParamDescription();
 		$description['prop'] = array_merge(
-			$description['prop'], 
+			$description['prop'],
 			array (
 				' "views"        - The number of pageviews of each page',
 				' "revcount"     - The number of all revisions of each page',
@@ -163,5 +163,5 @@ class WikiaApiQueryPageinfo extends ApiQueryInfo {
 		);
 		return $description;
 	}
-	
+
 }

--- a/includes/Article.php
+++ b/includes/Article.php
@@ -21,6 +21,7 @@
  * @property Title mTitle
  * @method exists
  * @method getID
+ * @method getRedirectTarget
  * //Wikia Change End
  */
 class Article extends Page {

--- a/includes/api/ApiPageSet.php
+++ b/includes/api/ApiPageSet.php
@@ -165,7 +165,7 @@ class ApiPageSet extends ApiQueryBase {
 
 	/**
 	 * Title objects that were found in the database.
-	 * @return array page_id (int) => Title (obj)
+	 * @return Title[] page_id (int) => Title (obj)
 	 */
 	public function getGoodTitles() {
 		return $this->mGoodTitles;


### PR DESCRIPTION
Fix the performance of `WikiaApiQueryPageinfo` by avoiding querying `page_visited` DB table without `WHERE` provided.

The fix is in df1eb35

@michalroszka 
