### PR TITLE
Ignore .mweval_history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,5 @@ spamAccountIds.txt
 lib/composer/**/.git
 node_modules
 
-# Ignore log of eval.php log
+# Ignore eval.php log
 maintenance/.mweval_history

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ spamAccountIds.txt
 
 lib/composer/**/.git
 node_modules
+
+# Ignore log of eval.php log
+maintenance/.mweval_history


### PR DESCRIPTION
@Grunny Using `maintenance/eval.php` creates a log file: `maintenance/.mweval_history`. This makes git ignore it :)
