### PR TITLE
Mercury opt in for whole wikia

### DIFF
--- a/extensions/wikia/MercuryApi/MercuryApi.i18n.php
+++ b/extensions/wikia/MercuryApi/MercuryApi.i18n.php
@@ -1,11 +1,15 @@
 <?php
 
-$messages = array();
+$messages = [];
 
-$messages['en'] = array(
+$messages['en'] = [
 	'mercuryapi-desc' => 'This extensions provides API classes for the Mercury project',
-);
+	'mercury-opt-in-label' => 'Opt in',
+	'mercury-opt-out-label' => 'Opt out',
+];
 
-$messages['qqq'] = array(
+$messages['qqq'] = [
 	'mercuryapi-desc' => '{{desc}}',
-);
+	'mercury-opt-in-label' => 'Clicking this button forces Mercury on user\'s mobile device for URLs that can be handled',
+	'mercury-opt-out-label' => 'Clicking this button disables Mercury forcing on user\'s mobile device',
+];

--- a/extensions/wikia/MercuryApi/MercurySpecialPageController.class.php
+++ b/extensions/wikia/MercuryApi/MercurySpecialPageController.class.php
@@ -16,12 +16,26 @@ class MercurySpecialPageController extends WikiaSpecialPageController {
 	}
 
 	public function index() {
+		global $wgCookiePath, $wgCookieDomain;
+
 		$opt = $this->request->getVal( 'opt' );
 		if ( !empty( $opt ) ) {
 			if ( $opt === 'in' ) {
-				$this->request->setCookie( self::COOKIE_NAME, self::OPT_IN, time() + 86400 * self::COOKIE_EXPIRE_DAYS );
+				$this->request->setCookie(
+					self::COOKIE_NAME,
+					self::OPT_IN,
+					time() + 86400 * self::COOKIE_EXPIRE_DAYS,
+					$wgCookiePath,
+					$wgCookieDomain
+				);
 			} elseif ( $opt === 'out' ) {
-				$this->request->setCookie( self::COOKIE_NAME, '', time() - 3600 );
+				$this->request->setCookie(
+					self::COOKIE_NAME,
+					'',
+					time() - 3600,
+					$wgCookiePath,
+					$wgCookieDomain
+				);
 			}
 			$this->response->redirect( SpecialPage::getTitleFor( self::PAGE_NAME )->getFullUrl() );
 		}

--- a/extensions/wikia/MercuryApi/MercurySpecialPageController.class.php
+++ b/extensions/wikia/MercuryApi/MercurySpecialPageController.class.php
@@ -44,10 +44,10 @@ class MercurySpecialPageController extends WikiaSpecialPageController {
 		if ( !empty( $cookie ) && $cookie == self::OPT_IN ) {
 			// OPTED IN
 			$this->setVal( 'buttonAction', 'out' );
-			$this->setVal( 'buttonLabel', 'Opt out' );
+			$this->setVal( 'buttonLabel', wfMessage('mercury-opt-out-label')->text() );
 		} else {
 			$this->setVal( 'buttonAction', 'in' );
-			$this->setVal( 'buttonLabel', 'Opt in' );
+			$this->setVal( 'buttonLabel', wfMessage('mercury-opt-in-label')->text() );
 		}
 
 		$this->setVal( 'pageName', self::PAGE_NAME );


### PR DESCRIPTION
Cookie was set only for the specific wiki domain (e.g. `.elderscrolls.wikia.com`), now user will have the mercury skin forced/not forced on the broader domain: `.wikia.com` or `.wikia-dev.com` (but custom domains stay the same like `.wowwiki.com`).
