### PR TITLE
Make a softer is_object() check - selectRow return value inconsistency

### DIFF
--- a/extensions/wikia/WikiaInYourLang/WikiaInYourLangController.class.php
+++ b/extensions/wikia/WikiaInYourLang/WikiaInYourLangController.class.php
@@ -53,7 +53,7 @@ class WikiaInYourLangController extends WikiaController {
 			 * If a wikia is found - send a response with its url and sitename.
 			 * Send success=false otherwise.
 			 */
-			if ( $oNativeWiki instanceof ResultWrapper ) {
+			if ( is_object( $oNativeWiki ) ) {
 				/**
 				 * Check for false-positives - see CE-1216
 				 * Per request we should unify dialects like pt and pt-br
@@ -169,7 +169,7 @@ class WikiaInYourLangController extends WikiaController {
 		if ( $oRow !== false ) {
 			$iNativeWikiId = $oRow->city_id;
 			$oNativeWiki = WikiFactory::getWikiById( $iNativeWikiId );
-			if ( $oNativeWiki instanceof ResultWrapper ) {
+			if ( is_object( $oNativeWiki ) ) {
 				return $oNativeWiki;
 			} else {
 				$this->response->setVal( 'error', "A native wikia with id={$iNativeWikiId} not found." );
@@ -185,11 +185,11 @@ class WikiaInYourLangController extends WikiaController {
 	 * Checks if a native wikia is not:
 	 * - closed
 	 * - in a different language than the target one
-	 * @param ResultWrapper $oWiki A native wikia city_list row
+	 * @param object $oWiki A native wikia city_list row
 	 * @param string $sTargetLanguage The target language code
 	 * @return bool
 	 */
-	private function isNativeWikiaValid( ResultWrapper $oWiki, $sTargetLanguage ) {
+	private function isNativeWikiaValid( $oWiki, $sTargetLanguage ) {
 		if ( $oWiki->city_public === WikiFactory::CLOSE_ACTION ) {
 			$this->response->setVal( 'error', "A native wikia is closed." );
 			return false;


### PR DESCRIPTION
Since Database.php method selectRow() can't decide if it wants to return an stdClass object or a ResultWrapper one - the check should be soften to accept valid stdClass results.

Ping @macbre 
