### PR TITLE
PLATFORM-931: fix PHP strict error in uncyclo skin

### DIFF
--- a/skins/Uncyclopedia.php
+++ b/skins/Uncyclopedia.php
@@ -22,8 +22,12 @@ if( !defined( 'MEDIAWIKI' ) )
 require_once("skins/MonoBook.php");
 
 class SkinUncyclopedia extends SkinMonoBook {
-	/** Using monobook. */
-	function initPage( &$out ) {
+	/**
+	 * Using monobook.
+	 *
+	 * @param OutputPage $out
+	 */
+	function initPage( OutputPage $out ) {
 		parent::initPage( $out );
 		$this->skinname  = 'uncyclopedia';
 		$this->stylename = 'uncyclopedia';


### PR DESCRIPTION
`PHP Strict Standards:  Declaration of SkinUncyclopedia::initPage() should be compatible with WikiaSkinMonoBook::initPage(OutputPage $out) in /skins/Uncyclopedia.php on line 24`

@michalroszka 
