### PR TITLE
CONCF-137 rename getMetadata to getVideoMetadata to avoid strict standar...

### DIFF
--- a/extensions/wikia/GameGuides/GameGuidesSpecialSponsoredController.class.php
+++ b/extensions/wikia/GameGuides/GameGuidesSpecialSponsoredController.class.php
@@ -154,7 +154,7 @@ class GameGuidesSpecialSponsoredController extends WikiaSpecialPageController {
 							$handler = $vid->getHandler();
 
 							if ( $handler instanceof OoyalaVideoHandler ) {
-								$metadata = $handler->getMetadata( true );
+								$metadata = $handler->getVideoMetadata( true );
 
 								$video['video_id'] = $metadata['videoId'];
 								$video['duration'] = WikiaFileHelper::formatDuration( $metadata['duration'] );

--- a/extensions/wikia/VideoHandlers/filerepo/WikiaLocalFileShared.class.php
+++ b/extensions/wikia/VideoHandlers/filerepo/WikiaLocalFileShared.class.php
@@ -236,7 +236,7 @@ class WikiaLocalFileShared  {
 			$handler = new $class();
 			$handler->setVideoId( $this->oFile->videoId );
 
-			$this->oFile->metadata = ( isset( $this->forceMetadata ) ) ? $this->forceMetadata : $handler->getMetadata();
+			$this->oFile->metadata = ( isset( $this->forceMetadata ) ) ? $this->forceMetadata : $handler->getVideoMetadata();
 			$this->oFile->media_type = MEDIATYPE_VIDEO;
 			$this->forceMime = false;
 		}

--- a/extensions/wikia/VideoHandlers/handlers/AnyclipVideoHandler.class.php
+++ b/extensions/wikia/VideoHandlers/handlers/AnyclipVideoHandler.class.php
@@ -8,7 +8,7 @@ class AnyclipVideoHandler extends VideoHandler {
 	protected static $providerHomeUrl = 'http://www.anyclip.com';
 
 	public function getProviderDetailUrl() {
-		$metadata = $this->getMetadata( true );
+		$metadata = $this->getVideoMetadata( true );
 		$url = $metadata['videoUrl'];
 
 		return $url;

--- a/extensions/wikia/VideoHandlers/handlers/CrunchyrollVideoHandler.class.php
+++ b/extensions/wikia/VideoHandlers/handlers/CrunchyrollVideoHandler.class.php
@@ -17,7 +17,7 @@ class CrunchyrollVideoHandler extends VideoHandler {
 	 * @inheritdoc
 	 */
 	public function getProviderDetailUrl() {
-		$metadata = $this->getMetadata( true );
+		$metadata = $this->getVideoMetadata( true );
 		$url = $metadata['videoUrl'];
 
 		return $url;

--- a/extensions/wikia/VideoHandlers/handlers/IgnVideoHandler.class.php
+++ b/extensions/wikia/VideoHandlers/handlers/IgnVideoHandler.class.php
@@ -33,7 +33,7 @@ EOT;
 	}
 
 	public function getEmbedUrl() {
-		$metadata = $this->getMetadata(true);
+		$metadata = $this->getVideoMetadata(true);
 		$url = $metadata['videoUrl'];
 
 		return $url;

--- a/extensions/wikia/VideoHandlers/handlers/UstreamVideoHandler.class.php
+++ b/extensions/wikia/VideoHandlers/handlers/UstreamVideoHandler.class.php
@@ -36,7 +36,7 @@ EOT;
 	 * @return string
 	 */
 	protected function getEmbedVideoId() {
-		$metadata = $this->getMetadata(true);
+		$metadata = $this->getVideoMetadata(true);
 
 		if ( !empty( $metadata['altVideoId'] ) ) {
 			return $metadata['altVideoId'];

--- a/extensions/wikia/VideoHandlers/handlers/VideoHandler.class.php
+++ b/extensions/wikia/VideoHandlers/handlers/VideoHandler.class.php
@@ -151,7 +151,7 @@ abstract class VideoHandler extends BitmapHandler {
 	function getAspectRatio() {
 		global $wgCityId;
 		wfProfileIn( __METHOD__ );
-		$metadata = $this->getMetadata(true);
+		$metadata = $this->getVideoMetadata(true);
 		$ratio = static::$aspectRatio;
 		if ( !empty($metadata['aspectRatio']) ) {
 			if ( floatval($metadata['aspectRatio']) == 0 ) {
@@ -192,7 +192,7 @@ abstract class VideoHandler extends BitmapHandler {
 	 * @param bool $unserialize
 	 * @return mixed array of data, or serialized version
 	 */
-	function getMetadata( $unserialize = false ) {
+	function getVideoMetadata( $unserialize = false ) {
 		wfProfileIn( __METHOD__ );
 		if ( empty($this->metadata) ) {
 			$this->metadata = $this->getApi() instanceof ApiWrapper
@@ -245,7 +245,7 @@ abstract class VideoHandler extends BitmapHandler {
 	 * @return boolean
 	 */
 	protected function isHd() {
-		$metadata = $this->getMetadata(true);
+		$metadata = $this->getVideoMetadata(true);
 		return (!empty($metadata['hd']));
 	}
 
@@ -254,7 +254,7 @@ abstract class VideoHandler extends BitmapHandler {
 	 * @return boolean
 	 */
 	protected function isAgeGate() {
-		$metadata = $this->getMetadata(true);
+		$metadata = $this->getVideoMetadata(true);
 		return (!empty($metadata['ageGate']));
 	}
 
@@ -263,7 +263,7 @@ abstract class VideoHandler extends BitmapHandler {
 	 * @return integer|null
 	 */
 	public function getExpirationDate() {
-		$metadata = $this->getMetadata(true);
+		$metadata = $this->getVideoMetadata(true);
 		return (!empty($metadata['expirationDate']) ? $metadata['expirationDate'] : null);
 	}
 
@@ -272,7 +272,7 @@ abstract class VideoHandler extends BitmapHandler {
 	 * @return string|null
 	 */
 	public function getRegionalRestrictions() {
-		$metadata = $this->getMetadata(true);
+		$metadata = $this->getVideoMetadata(true);
 		return ( !empty( $metadata['regionalRestrictions'] ) ? $metadata['regionalRestrictions'] : null );
 	}
 
@@ -281,7 +281,7 @@ abstract class VideoHandler extends BitmapHandler {
 	 * @return int duration in seconds, or null
 	 */
 	protected function getDuration() {
-		$metadata = $this->getMetadata(true);
+		$metadata = $this->getVideoMetadata(true);
 		return (!empty($metadata['duration']) ? $metadata['duration'] : null);
 	}
 
@@ -290,7 +290,7 @@ abstract class VideoHandler extends BitmapHandler {
 	 * @return string
 	 */
 	public function getFormattedDuration() {
-		$metadata = $this->getMetadata( true );
+		$metadata = $this->getVideoMetadata( true );
 		if ( !empty( $metadata['duration'] ) ) {
 			$sec = $metadata['duration'];
 			if ( is_numeric( $sec ) ) {
@@ -309,7 +309,7 @@ abstract class VideoHandler extends BitmapHandler {
 	 * @return string
 	 */
 	protected function getEmbedVideoId() {
-		$metadata = $this->getMetadata(true);
+		$metadata = $this->getVideoMetadata(true);
 		if ( !empty($metadata['altVideoId']) ) {
 			return $metadata['altVideoId'];
 		}

--- a/includes/wikia/api/ArticlesApiController.class.php
+++ b/includes/wikia/api/ArticlesApiController.class.php
@@ -846,7 +846,7 @@ class ArticlesApiController extends WikiaApiController {
 				/* @var VideoHandler $handler */
 				$handler = VideoHandler::getHandler( $file->getMimeType() );
 				$typeInfo = explode( '/', $file->getMimeType() );
-				$metadata = ( $handler ) ? $handler->getMetadata( true ) : null;
+				$metadata = ( $handler ) ? $handler->getVideoMetadata( true ) : null;
 				return [
 					'type' => static::VIDEO_TYPE,
 					'provider' => isset( $typeInfo[1] ) ? $typeInfo[1] : static::UNKNOWN_PROVIDER,

--- a/includes/wikia/services/MediaQueryService.class.php
+++ b/includes/wikia/services/MediaQueryService.class.php
@@ -226,7 +226,7 @@ class MediaQueryService extends WikiaService {
 					'title' => $media->getText(),
 					'desc' => $articleService->getTextSnippet( $length ),
 					'type' => ( $isVideo ? self::MEDIA_TYPE_VIDEO : self::MEDIA_TYPE_IMAGE ),
-					'meta' => ( $videoHandler ? array_merge( $videoHandler->getMetadata(true), $videoHandler->getEmbedSrcData() ) : array() ),
+					'meta' => ( $videoHandler ? array_merge( $videoHandler->getVideoMetadata(true), $videoHandler->getEmbedSrcData() ) : array() ),
 					'thumbUrl' => ( !empty($thumb) ? $thumb->getUrl() : false
 				));
 			}


### PR DESCRIPTION
...ds error

Method getMetadata was already defined in MediaHandler class with different set of arguments. I renamed the method from VideoHandler to avoid strict standards violation

Ticket: CONCF-137
