### PR TITLE
(SOC-412) Fix WikiahomePage Sass compilation

### DIFF
--- a/extensions/wikia/WikiaHomePage/css/WikiaHomePage.scss
+++ b/extensions/wikia/WikiaHomePage/css/WikiaHomePage.scss
@@ -1,11 +1,11 @@
-@import "skins/shared/color";
-@import "skins/oasis/css/core/layout";
-@import "skins/shared/mixins/clearfix";
-@import "skins/shared/mixins/gradient";
-@import "skins/shared/mixins/box-shadow";
-@import "skins/shared/mixins/transition";
-@import "skins/shared/mixins/transform";
-@import "../../UserLogin/mixins/tooltip-icon";
+@import 'skins/shared/color';
+@import 'skins/oasis/css/core/layout';
+@import 'skins/shared/mixins/clearfix';
+@import 'skins/shared/mixins/gradient';
+@import 'skins/shared/mixins/box-shadow';
+@import 'skins/shared/mixins/transition';
+@import 'skins/shared/mixins/transform';
+@import 'extensions/wikia/WikiaStyleGuide/css/tooltip-icon';
 
 @mixin interstitial-toggle-animation {
 	-webkit-animation: InterstitialToggle 900ms;
@@ -909,12 +909,4 @@ $wikiahomepage-line-height: 16px;
 }
 @-ms-keyframes InterstitialToggle2 {
 	@include interstitial-toggle-style;
-}
-
-.tooltip-icon-wrapper {
-	padding-right: 0.3em;
-	position: relative;
-	.tooltip-icon {
-		@include tooltip-icon;
-	}
 }


### PR DESCRIPTION
The tooltip-icon mixin was updated and moved to the styleguide in
commit 7b79d5fb5ce8. The WikiaHomePage extension wasn't updated,
however. This fixes Sass compilation of WikiaHomePage.scss:

```
SASS error: Could not resolve dependency "../../UserLogin/mixins/tooltip-icon"
in context of: extensions/wikia/WikiaHomePage/css/WikiaHomePage.scss
– Wikia\Sass\Source\Context::getFile: Requested SASS file not found:
../../UserLogin/mixins/tooltip-icon
```

/cc @nandy-andy @lizlux 
