### PR TITLE
Add X-Request-Id header to Helios calls

### DIFF
--- a/extensions/wikia/Helios/Client.class.php
+++ b/extensions/wikia/Helios/Client.class.php
@@ -1,5 +1,6 @@
 <?php
 namespace Wikia\Helios;
+use Wikia\Util\RequestId;
 
 /**
  * A client for Wikia authentication service.
@@ -51,6 +52,7 @@ class Client
 
 		// Request execution.
 		$oRequest = \MWHttpRequest::factory( $sUri, $aOptions );
+		$oRequest->setHeader(RequestId::REQUEST_HEADER_NAME, RequestId::instance()->getRequestId());
 		$oStatus = $oRequest->execute();
 
 		// Response handling.


### PR DESCRIPTION
This adds X-Request-Id derived from MW's one so we'll be able to correctly correlate events on both ends.

/cc @michalroszka @ArturKlajnerok 
