### PR TITLE
ADEN-1563 Enable Krux on Mobile site-wide

### DIFF
--- a/extensions/wikia/AdEngine/AdEngine2Hooks.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2Hooks.class.php
@@ -45,7 +45,7 @@ class AdEngine2Hooks {
 		$wgLoadLateAdsAfterPageLoad = $request->getBool( 'lateadsafterload', $wgLoadLateAdsAfterPageLoad );
 
 		$wgEnableKruxTargeting = !$wgAdEngineDisableLateQueue && !$wgNoExternals && $wgEnableKruxTargeting;
-		$wgEnableKruxOnMobile = $request->getBool( 'enablekrux', $wgEnableKruxOnMobile );
+		$wgEnableKruxOnMobile = $request->getBool( 'enablekrux', $wgEnableKruxOnMobile && !$wgNoExternals );
 
 		return true;
 	}

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1448,10 +1448,10 @@ $wgAdDriverRubiconRTPConfig = null;
 $wgAdDriverRubiconRTPCountries = null;
 
 /**
- * @name $wgAdDriverEnableKruxOnMobile
+ * @name $wgEnableKruxOnMobile
  * Whether to enable Krux on wikiamobile skin
  */
-$wgEnableKruxOnMobile = false;
+$wgEnableKruxOnMobile = true;
 
 /**
  * @name $wgHighValueCountries


### PR DESCRIPTION
After a testing period we're ready to enable Krux on mobile (WikiaMobile skin) site-wide.

Changes below do this and additionally they disable Krux when `noexternals=1` is passed in query params.
