### PR TITLE
Add X-Request-Origin-Host to Helios calls

### DIFF
--- a/extensions/wikia/Helios/Client.class.php
+++ b/extensions/wikia/Helios/Client.class.php
@@ -53,6 +53,7 @@ class Client
 		// Request execution.
 		$oRequest = \MWHttpRequest::factory( $sUri, $aOptions );
 		$oRequest->setHeader(RequestId::REQUEST_HEADER_NAME, RequestId::instance()->getRequestId());
+		$oRequest->setHeader(RequestId::REQUEST_HEADER_ORIGIN_HOST, wfHostname());
 		$oStatus = $oRequest->execute();
 
 		// Response handling.

--- a/lib/Wikia/src/Util/RequestId.php
+++ b/lib/Wikia/src/Util/RequestId.php
@@ -15,6 +15,7 @@ namespace Wikia\Util;
 class RequestId {
 
 	const REQUEST_HEADER_NAME = 'X-Request-Id';
+	const REQUEST_HEADER_ORIGIN_HOST = 'X-Request-Origin-Host';
 	private $requestId = false;
 
 	/**


### PR DESCRIPTION
Add an extra header with the origin server issuing a request to Helios.

/cc @michalroszka @ArturKlajnerok 
