### PR TITLE
AvatarService: fix PHP Strict Standards

### DIFF
--- a/includes/wikia/services/AvatarService.class.php
+++ b/includes/wikia/services/AvatarService.class.php
@@ -269,8 +269,7 @@ class AvatarService extends Service {
 				$url = self::buildVignetteUrl( $width, $bucket, $relativePath, $timestamp, false );
 			}
 		} else { // default avatar
-			$defaultAvatars = $masthead->getDefaultAvatars( 'thumb/' );
-			$legacyDefaultUrl = array_shift( $defaultAvatars );
+			$legacyDefaultUrl = $masthead->getDefaultAvatars( 'thumb/' )[0];
 			$bucket = VignetteRequest::parseBucket( $legacyDefaultUrl );
 			$relativePath = VignetteRequest::parseRelativePath( $legacyDefaultUrl );
 			$url = self::buildVignetteUrl( $width, $bucket, $relativePath, $timestamp, false );

--- a/includes/wikia/services/AvatarService.class.php
+++ b/includes/wikia/services/AvatarService.class.php
@@ -269,7 +269,8 @@ class AvatarService extends Service {
 				$url = self::buildVignetteUrl( $width, $bucket, $relativePath, $timestamp, false );
 			}
 		} else { // default avatar
-			$legacyDefaultUrl = array_shift( $masthead->getDefaultAvatars( 'thumb/' ) );
+			$defaultAvatars = $masthead->getDefaultAvatars( 'thumb/' );
+			$legacyDefaultUrl = array_shift( $defaultAvatars );
 			$bucket = VignetteRequest::parseBucket( $legacyDefaultUrl );
 			$relativePath = VignetteRequest::parseRelativePath( $legacyDefaultUrl );
 			$url = self::buildVignetteUrl( $width, $bucket, $relativePath, $timestamp, false );


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-855

```
PHP Strict Standards: Only variables should be passed by reference in /usr/wikia/slot1/3338/src/includes/wikia/services/AvatarService.class.php on line 271
```

@wladekb 
