### PR TITLE
ADEN-1775 Fixed image placement when ad-in-content is loaded

### DIFF
--- a/extensions/wikia/AdEngine/js/AdLogicPageDimensions.js
+++ b/extensions/wikia/AdEngine/js/AdLogicPageDimensions.js
@@ -250,8 +250,8 @@ define('ext.wikia.adEngine.adLogicPageDimensions', [
 
 		return !!(
 			slotsOnlyOnLongPages[slotname] ||
-				slotsToHideOnMediaQuery[slotname] ||
-				slotsOnlyWithRail[slotname]
+			slotsToHideOnMediaQuery[slotname] ||
+			slotsOnlyWithRail[slotname]
 		);
 	}
 

--- a/extensions/wikia/AdEngine/js/SlotTweaker.js
+++ b/extensions/wikia/AdEngine/js/SlotTweaker.js
@@ -39,6 +39,8 @@ define('ext.wikia.adEngine.slotTweaker', [
 			parent = slot.parentNode;
 
 			if (parent.classList && parent.classList.contains('ad-in-content')) {
+				log('hide ad-in-content slot (' + slotname + ') setting its clear rule to none', 6, logGroup);
+
 				parent.style.clear = 'none';
 			}
 		}

--- a/extensions/wikia/AdEngine/js/SlotTweaker.js
+++ b/extensions/wikia/AdEngine/js/SlotTweaker.js
@@ -28,10 +28,19 @@ define('ext.wikia.adEngine.slotTweaker', [
 	function hide(slotname) {
 		log('hide ' + slotname + ' using class hidden', 6, logGroup);
 
-		var slot = document.getElementById(slotname);
+		var slot = document.getElementById(slotname),
+			parent;
 
 		if (slot) {
 			slot.className += ' hidden';
+		}
+
+		if (slot.parentNode) {
+			parent = slot.parentNode;
+
+			if (parent.classList && parent.classList.contains('ad-in-content')) {
+				parent.style.clear = 'none';
+			}
 		}
 	}
 

--- a/extensions/wikia/AdEngine/js/SlotTweaker.js
+++ b/extensions/wikia/AdEngine/js/SlotTweaker.js
@@ -28,26 +28,15 @@ define('ext.wikia.adEngine.slotTweaker', [
 	function hide(slotname) {
 		log('hide ' + slotname + ' using class hidden', 6, logGroup);
 
-		var slot = document.getElementById(slotname),
-			parent;
+		var slot = document.getElementById(slotname);
 
 		if (slot) {
 			slot.className += ' hidden';
 		}
-
-		if (slot.parentNode) {
-			parent = slot.parentNode;
-
-			if (parent.classList && parent.classList.contains('ad-in-content')) {
-				log('hide ad-in-content slot (' + slotname + ') setting its clear rule to none', 6, logGroup);
-
-				parent.style.clear = 'none';
-			}
-		}
 	}
 
 	function show(slotname) {
-		log('hide ' + slotname + ' using class hidden', 6, logGroup);
+		log('show ' + slotname + ' removing class hidden', 6, logGroup);
 
 		var slot = document.getElementById(slotname);
 

--- a/skins/oasis/css/core/article.scss
+++ b/skins/oasis/css/core/article.scss
@@ -42,6 +42,7 @@
 
 	h3 {
 		font-size: 16px;
+		overflow: hidden;
 	}
 
 	h4 {


### PR DESCRIPTION
After extending functionality of ad in content feature to place an ad below not only h2 but also h3 we didn't notice our `<h3>` tags don't have CSS rule `overflow: hidden` just like `<h2>`s have.

Adding this rule fixes issues with image placement described in [ADEN-1775](https://wikia-inc.atlassian.net/browse/ADEN-1775). The changes below contain also small code clean ups.

//cc Content Team and ComEng representatives: @Grunny @hakubo @lgarczewski @SebastianMarzjan - please let us know till Mon 2nd March 2015 if it's fine; if yes, we'll move it to QA and merge it most likely next week.
