### PR TITLE
CONCF-135 check if caption not empty on video file page

### DIFF
--- a/extensions/wikia/FilePage/templates/FilePage_videoCaption.php
+++ b/extensions/wikia/FilePage/templates/FilePage_videoCaption.php
@@ -9,7 +9,7 @@
 <div class="video-page-caption">
 	<div class="inner">
 		<p class="video-provider"><?= $providerPhrase ?></p>
-		<? if (!empty($viewCount)): ?>
+		<? if ( !empty( $viewCount ) ): ?>
 			<p class="video-views"><?= wfMessage( 'video-page-views' )->numParams( $viewCount )->parse() ?></p>
 		<? endif; ?>
 		<? if ( $regionalRestrictions ) : ?>

--- a/extensions/wikia/FilePage/templates/FilePage_videoCaption.php
+++ b/extensions/wikia/FilePage/templates/FilePage_videoCaption.php
@@ -9,7 +9,9 @@
 <div class="video-page-caption">
 	<div class="inner">
 		<p class="video-provider"><?= $providerPhrase ?></p>
-		<p class="video-views"><?= wfMessage( 'video-page-views' )->numParams( $viewCount )->parse() ?></p>
+		<? if (!empty($viewCount)): ?>
+			<p class="video-views"><?= wfMessage( 'video-page-views' )->numParams( $viewCount )->parse() ?></p>
+		<? endif; ?>
 		<? if ( $regionalRestrictions ) : ?>
 			<p class="regional-restriction hidden" id="restricted-content-viewable" data-regional-restrictions="<?= htmlspecialchars( strtolower( $regionalRestrictions ) ) ?>">
 				<?= wfMessage('video-page-regional-restrictions-viewable')->plain() ?>


### PR DESCRIPTION
Hide caption with number of views on video file page if number of views is not a number (null).
It is caused by a bug with inserting videos to video_info table.
Ticket for investigation of this issue was created - https://wikia-inc.atlassian.net/browse/CONCF-176
