### PR TITLE
(CE-1385) Make visibility of getExamples match ApiBase

### DIFF
--- a/extensions/wikia/SemanticMediaWiki/includes/api/ApiAsk.php
+++ b/extensions/wikia/SemanticMediaWiki/includes/api/ApiAsk.php
@@ -69,7 +69,7 @@ class ApiAsk extends ApiSMWQuery {
 		);
 	}
 
-	protected function getExamples() {
+	public function getExamples() {
 		return array(
 			'api.php?action=ask&query=[[Modification%20date::%2B]]|%3FModification%20date|sort%3DModification%20date|order%3Ddesc',
 		);
@@ -77,6 +77,6 @@ class ApiAsk extends ApiSMWQuery {
 
 	public function getVersion() {
 		return __CLASS__ . '-' . SMW_VERSION;
-	}		
+	}
 
 }

--- a/extensions/wikia/SemanticMediaWiki/includes/api/ApiAskArgs.php
+++ b/extensions/wikia/SemanticMediaWiki/includes/api/ApiAskArgs.php
@@ -2,7 +2,7 @@
 
 /**
  * API module to query SMW by providing a query specified as
- * a list of conditions, printouts and parameters. 
+ * a list of conditions, printouts and parameters.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -28,30 +28,30 @@
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class ApiAskArgs extends ApiSMWQuery {
-	
+
 	public function execute() {
 		$params = $this->extractRequestParams();
 
 		foreach ( $params['parameters'] as $param ) {
 			$parts = explode( '=', $param, 2 );
-			
+
 			if ( count( $parts ) == 2 ) {
 				$this->parameters[$parts[0]] = $parts[1];
 			}
 		}
-		
-		$query = $this->getQuery( 
+
+		$query = $this->getQuery(
 			implode( ' ', array_map( array( __CLASS__, 'wrapCondition' ), $params['conditions'] ) ),
 			array_map( array( __CLASS__, 'printoutFromString' ), $params['printouts'] )
 		);
-		
+
 		$this->addQueryResult( $this->getQueryResult( $query ) );
 	}
-	
+
 	public static function wrapCondition( $c ) {
-		return "[[$c]]"; 
+		return "[[$c]]";
 	}
-	
+
 	public static function printoutFromString( $printout ) {
 		return new SMWPrintRequest(
 			SMWPrintRequest::PRINT_PROP,
@@ -79,7 +79,7 @@ class ApiAskArgs extends ApiSMWQuery {
 			),
 		);
 	}
-	
+
 	public function getParamDescription() {
 		return array(
 			'conditions' => 'The query conditions, i.e. the requirements for a subject to be included',
@@ -87,14 +87,14 @@ class ApiAskArgs extends ApiSMWQuery {
 			'parameters' => 'The query parameters, i.e. all non-condition and non-printout arguments',
 		);
 	}
-	
+
 	public function getDescription() {
 		return array(
 			'API module to query SMW by providing a query specified as a list of conditions, printouts and parameters.'
 		);
 	}
 
-	protected function getExamples() {
+	public function getExamples() {
 		return array(
 			'api.php?action=askargs&conditions=Modification%20date::%2B&printouts=Modification%20date&parameters=|sort%3DModification%20date|order%3Ddesc',
 		);
@@ -103,5 +103,5 @@ class ApiAskArgs extends ApiSMWQuery {
 	public function getVersion() {
 		return __CLASS__ . '-' . SMW_VERSION;
 	}
-	
+
 }

--- a/extensions/wikia/SemanticMediaWiki/includes/api/ApiSMWInfo.php
+++ b/extensions/wikia/SemanticMediaWiki/includes/api/ApiSMWInfo.php
@@ -14,16 +14,16 @@
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class ApiSMWInfo extends ApiBase {
-	
+
 	public function __construct( $main, $action ) {
 		parent::__construct( $main, $action );
 	}
-	
+
 	public function execute() {
 		$params = $this->extractRequestParams();
 		$requestedInfo = $params['info'];
 		$resultInfo = array();
-		
+
 		if ( in_array( 'proppagecount', $requestedInfo ) ) {
 			$resultInfo['proppagecount'] = wfGetDB( DB_SLAVE )->estimateRowCount(
 				'page',
@@ -31,28 +31,28 @@ class ApiSMWInfo extends ApiBase {
 				array(
 					'page_namespace' => SMW_NS_PROPERTY
 				)
-			);	
+			);
 		}
-		
+
 		if ( in_array( 'propcount', $requestedInfo )
-			|| in_array( 'usedpropcount', $requestedInfo ) 
+			|| in_array( 'usedpropcount', $requestedInfo )
 			|| in_array( 'declaredpropcount', $requestedInfo ) ) {
 
 			$semanticStats = smwfGetStore()->getStatistics();
-			
+
 			$map = array(
 				'propcount' => 'PROPUSES',
 				'usedpropcount' => 'USEDPROPS',
 				'declaredpropcount' => 'DECLPROPS',
 			);
-			
+
 			foreach ( $map as $apiName => $smwName ) {
 				if ( in_array( $apiName, $requestedInfo ) ) {
 					$resultInfo[$apiName] = $semanticStats[$smwName];
 				}
 			}
 		}
-		
+
 		$this->getResult()->addValue(
 			null,
 			'info',
@@ -74,27 +74,27 @@ class ApiSMWInfo extends ApiBase {
 			),
 		);
 	}
-	
+
 	public function getParamDescription() {
 		return array(
 			'info' => 'The info to provide.'
 		);
 	}
-	
+
 	public function getDescription() {
 		return array(
 			'API module get info about this SMW install.'
 		);
 	}
 
-	protected function getExamples() {
+	public function getExamples() {
 		return array(
 			'api.php?action=smwinfo&info=proppagecount|propcount',
 		);
-	}	
-	
+	}
+
 	public function getVersion() {
 		return __CLASS__ . ': $Id$';
-	}		
-	
+	}
+
 }


### PR DESCRIPTION
Fixes fatal error:

```
PHP Fatal error: Access level to ApiSMWInfo::getExamples() must be
public (as in class ApiBase) in extensions/wikia/SemanticMediaWiki
/includes/api/ApiSMWInfo.php on line 16
```

Reviewed in https://github.com/Wikia/app/pull/6442
