### PR TITLE
CE-1326: Exclude some pages from showing mobile/desktop preview icon

### DIFF
--- a/extensions/wikia/EditPageLayout/EditPageLayoutController.class.php
+++ b/extensions/wikia/EditPageLayout/EditPageLayoutController.class.php
@@ -42,6 +42,9 @@ class EditPageLayoutController extends WikiaController {
 
 		// extra buttons
 		$this->buttons = $editPage->getControlButtons();
+
+		// Should show mobile preview icon
+		$this->showMobilePreview = $this->request->getVal('showMobilePreview');
 	}
 
 	/**
@@ -110,6 +113,9 @@ class EditPageLayoutController extends WikiaController {
 
 		// Text for Edit summary label
 		$wpSummaryLabelText = 'editpagelayout-edit-summary-label';
+
+		// Should show mobile preview icon
+		$this->showMobilePreview = $helper->showMobilePreview( $editPage->getTitle() );
 
 		if ($section == 'new') {
 			$msgKey = 'editingcomment';

--- a/extensions/wikia/EditPageLayout/EditPageLayoutHelper.class.php
+++ b/extensions/wikia/EditPageLayout/EditPageLayoutHelper.class.php
@@ -183,6 +183,24 @@ class EditPageLayoutHelper {
 	}
 
 	/**
+	 * Check if we should show mobile and desktop preview icon
+	 * Excluded pages:
+	 * - Main page
+	 * - Code page (CSS, JS and Lua)
+	 * - MediaWiki:Wiki-navigation
+	 *
+	 * @param Title $title
+	 * @return bool
+	 */
+	public function showMobilePreview( Title $title ) {
+		$blacklistedPages = self::isCodePage( $title )
+				|| $title->isMainPage()
+				|| NavigationModel::isWikiNavMessage( $title );
+
+		return !$blacklistedPages;
+	}
+
+	/**
 	 * Prepare variables to init and support edit code pages
 	 *
 	 * @param Title $title

--- a/extensions/wikia/EditPageLayout/EditPageLayoutHelper.class.php
+++ b/extensions/wikia/EditPageLayout/EditPageLayoutHelper.class.php
@@ -193,11 +193,11 @@ class EditPageLayoutHelper {
 	 * @return bool
 	 */
 	public function showMobilePreview( Title $title ) {
-		$blacklistedPages = self::isCodePage( $title )
+		$blacklistedPage = self::isCodePage( $title )
 				|| $title->isMainPage()
 				|| NavigationModel::isWikiNavMessage( $title );
 
-		return !$blacklistedPages;
+		return !$blacklistedPage;
 	}
 
 	/**

--- a/extensions/wikia/EditPageLayout/css/core/modules.scss
+++ b/extensions/wikia/EditPageLayout/css/core/modules.scss
@@ -99,7 +99,11 @@ $color-icon: mix($color-text, #fff, 90%);
 			@include clearfix;
 		}
 
-		#wpDiff {
+		#wpPreview {
+			text-align: center;
+		}
+
+		#wpDiff.diff-link {
 			color: $color-links;
 			display: inline-block;
 			font-size: 12px;

--- a/extensions/wikia/EditPageLayout/templates/EditPageLayout_Buttons.php
+++ b/extensions/wikia/EditPageLayout/templates/EditPageLayout_Buttons.php
@@ -13,9 +13,29 @@
 			<script type="text/javascript">document.getElementById('wpSave').disabled=true;</script>
 			<?php break ?>
 		<?php case 'preview': ?>
-			<a href="#" id="wpDiff" accesskey="<?= wfMessage('accesskey-diff')->escaped() ?>">
-				<?= wfMessage('showdiff')->escaped() ?>
-			</a>
+			<?php
+			$diff = [[
+				"id" => "wpDiff",
+				"accesskey" => wfMessage('accesskey-diff')->escaped(),
+				"text" => wfMessage('showdiff')->escaped()
+			]];
+
+			if ( $showMobilePreview ): ?>
+				<a href="#" id="<?= $diff[0]['id'] ?>" class="diff-link" accesskey="<?= $diff[0]['accesskey'] ?>">
+					<?= $diff[0]['text'] ?>
+				</a>
+			<?php else: ?>
+				<?= $app->renderView( 'MenuButton', 'Index', [
+					'action' => [
+						'href' => '#',
+						'text' => wfMessage( 'preview' )->escaped(),
+						'id' => 'wpPreview',
+						'tabindex' => 23
+					],
+					'class' => 'secondary '.$buttonClasses,
+					'dropdown' => $diff
+				]) ?>
+			<?php endif ?>
 			<?php break ?>
 		<?php default: ?>
 			<input class="<?=$buttonClasses?>"<?= !empty($button['disabled']) ? ' disabled="disabled"' : '' ?> id="<?=$button['name']?>" name="<?=$button['name']?>" type="<?=$buttonType?>" value="<?=$button['caption']?>" />

--- a/extensions/wikia/EditPageLayout/templates/EditPageLayout_EditPage.php
+++ b/extensions/wikia/EditPageLayout/templates/EditPageLayout_EditPage.php
@@ -107,26 +107,28 @@
 									<?= $summaryBox ?>
 								</div>
 							</div>
-							<div class="preview_box">
-								<h3><?= wfMessage( 'preview' )->escaped() ?></h3>
-								<a id="wpPreviewMobile" class="preview_mobile preview_icon" href="#">
-									<svg xmlns="http://www.w3.org/2000/svg" version="1.0" x="0px" y="0px" viewBox="0 0 32 48" xml:space="preserve">
-										<path d="M28 0C26.5 0 5.4 0 4 0C2.1 0 0 2.2 0 4c0 37.9 0 2.6 0 40c0 2 2.2 4 4 4c2 0 22.2 0 24 0 c1.8 0 3.9-2 3.9-4C31.9 30.2 32 5.2 32 4C32 1.9 29.8 0 28 0z M16 46c-1.1 0-2-0.9-2-2c0-1.1 0.9-2 2-2s2 0.9 2 2 C18 45.1 17.1 46 16 46z M28 40H4c0 0 0-25.7 0-36c7.1 0 24 0 24 0V40z"/>
-									</svg>
-									<p><?= wfMessage('editpagelayout-preview-label-mobile')->escaped() ?></p>
-								</a>
-								<a accesskey="e" id="wpPreview" class="preview_desktop preview_icon" href="#">
-									<svg xmlns="http://www.w3.org/2000/svg" version="1.0" x="0px" y="0px" viewBox="0 0 48 40" xml:space="preserve">
-										<path d="M48 34V0H0.1L0 34h18v4h-8v2h28v-2c0 0-8 0.3-8 0v-4H48z M2 30 V2h44v28H2z"/>
-									</svg>
-									<p><?= wfMessage('editpagelayout-preview-label-desktop')->escaped() ?></p>
-								</a>
-							</div>
+							<?php if ( $showMobilePreview ): ?>
+								<div class="preview_box">
+									<h3><?= wfMessage( 'preview' )->escaped() ?></h3>
+									<a id="wpPreviewMobile" class="preview_mobile preview_icon" href="#">
+										<svg xmlns="http://www.w3.org/2000/svg" version="1.0" x="0px" y="0px" viewBox="0 0 32 48" xml:space="preserve">
+											<path d="M28 0C26.5 0 5.4 0 4 0C2.1 0 0 2.2 0 4c0 37.9 0 2.6 0 40c0 2 2.2 4 4 4c2 0 22.2 0 24 0 c1.8 0 3.9-2 3.9-4C31.9 30.2 32 5.2 32 4C32 1.9 29.8 0 28 0z M16 46c-1.1 0-2-0.9-2-2c0-1.1 0.9-2 2-2s2 0.9 2 2 C18 45.1 17.1 46 16 46z M28 40H4c0 0 0-25.7 0-36c7.1 0 24 0 24 0V40z"/>
+										</svg>
+										<p><?= wfMessage('editpagelayout-preview-label-mobile')->escaped() ?></p>
+									</a>
+									<a accesskey="e" id="wpPreview" class="preview_desktop preview_icon" href="#">
+										<svg xmlns="http://www.w3.org/2000/svg" version="1.0" x="0px" y="0px" viewBox="0 0 48 40" xml:space="preserve">
+											<path d="M48 34V0H0.1L0 34h18v4h-8v2h28v-2c0 0-8 0.3-8 0v-4H48z M2 30 V2h44v28H2z"/>
+										</svg>
+										<p><?= wfMessage('editpagelayout-preview-label-desktop')->escaped() ?></p>
+									</a>
+								</div>
+							<?php endif ?>
 							<nav class="buttons">
 								<?php if ( $pagetype == 'codepage' ): ?>
 									<?= $app->renderView( 'EditPageLayout', 'CodeButtons'); ?>
 								<?php else: ?>
-									<?= $app->renderView( 'EditPageLayout', 'Buttons'); ?>
+									<?= $app->renderView( 'EditPageLayout', 'Buttons', [ 'showMobilePreview' => $showMobilePreview ]); ?>
 								<?php endif ?>
 							</nav>
 						</div>


### PR DESCRIPTION
We are excluding
- Main page
- Code pages (CSS, JS, Lua)
- MediaWiki: Wiki-navigation
