### PR TITLE
VE-1799: Check if wikitext is empty insteaf of checking is extsrc is empty

### DIFF
--- a/extensions/VisualEditor/modules/ve-mw/ce/nodes/ve.ce.MWExtensionNode.js
+++ b/extensions/VisualEditor/modules/ve-mw/ce/nodes/ve.ce.MWExtensionNode.js
@@ -56,7 +56,7 @@ ve.ce.MWExtensionNode.prototype.generateContents = function ( config ) {
 		// XML-like tags in wikitext are not actually XML and don't expect their contents to be escaped.
 		wikitext = mw.html.element( tagName, attrs, new mw.html.Raw( extsrc ) );
 
-	if ( !this.constructor.static.rendersEmpty && extsrc.trim() !== '' ) {
+	if ( !this.constructor.static.rendersEmpty && wikitext.trim() !== '' ) {
 		xhr = ve.init.target.constructor.static.apiRequest( {
 			action: 'visualeditor',
 			paction: 'parsefragment',


### PR DESCRIPTION
This is because checking for extsrc does not make sense - even if extsrc is empty extension still can render - such as maps for instance.
