### PR TITLE
Fix 4 issues related to a PHP strict message. The SpecialPage::execute()...

### DIFF
--- a/extensions/3rdparty/LyricWiki/Special_BatchMove.php
+++ b/extensions/3rdparty/LyricWiki/Special_BatchMove.php
@@ -61,7 +61,11 @@ class Batchmove extends SpecialPage{
 		parent::__construct('Batchmove');
 	}
 
-	function execute() {
+	/**
+	 *
+	 * @param $par String subpage string, if one was specified
+	 */
+	function execute( $par ){
 		global $wgOut;
 		global $wgRequest, $wgUser;
 

--- a/extensions/3rdparty/LyricWiki/Special_LinksToRedirects.php
+++ b/extensions/3rdparty/LyricWiki/Special_LinksToRedirects.php
@@ -41,7 +41,11 @@ class Linkstoredirects extends SpecialPage{
 		parent::__construct('Linkstoredirects');
 	}
 
-	function execute(){
+	/**
+	 *
+	 * @param $par String subpage string, if one was specified
+	 */
+	function execute( $par ){
 		global $wgOut;
 		global $wgRequest, $wgUser;
 

--- a/extensions/3rdparty/LyricWiki/Special_MobileSearches.php
+++ b/extensions/3rdparty/LyricWiki/Special_MobileSearches.php
@@ -32,7 +32,11 @@ class MobileSearches extends SpecialPage{
 		parent::__construct('MobileSearches');
 	}
 
-	function execute(){
+	/**
+	 *
+	 * @param $par String subpage string, if one was specified
+	 */
+	function execute( $par ){
 		global $wgOut;
 		global $wgRequest, $wgUser, $wgMemc;
 

--- a/extensions/3rdparty/LyricWiki/Special_Soapfailures.php
+++ b/extensions/3rdparty/LyricWiki/Special_Soapfailures.php
@@ -55,7 +55,11 @@ class Soapfailures extends SpecialPage{
 		parent::__construct('Soapfailures');
 	}
 
-	function execute(){
+	/**
+	 *
+	 * @param $par String subpage string, if one was specified
+	 */
+	function execute( $par ){
 		global $wgOut;
 		global $wgRequest, $wgUser, $wgMemc;
 


### PR DESCRIPTION
... implementations should have the  parameter to match their parent-class.

Very simple cleanup. This fixes four JIRA issues: LYR-225, LYR-226, LYR-227, LYR-228
