### PR TITLE
Candidate fix for LYR-230: an invalid param to implode().

### DIFF
--- a/extensions/3rdparty/LyricWiki/Tag_XML.php
+++ b/extensions/3rdparty/LyricWiki/Tag_XML.php
@@ -170,7 +170,15 @@ function renderXML( $input, $argv, $parser )
 				{
 					// SWC 20061113 - Broke the accessing into two lines so that it parses
 					$tempArray = $item[strtoupper($field)];
-					$currValue = implode("", $tempArray[0]);
+					
+					// LYR-230 sometimes tempArray[0] isn't an array, apparently - SWC 20150301
+					if(empty($tempArray[0])){
+						$currentValue = "";
+					} else if(is_array($tempArray[0])){
+						$currValue = implode("", $tempArray[0]);
+					} else {
+						$currValue = $tempArray[0];
+					}
 					$text = str_replace( "{{{{$field}}}}", $currValue, $text );
 				}
 			}


### PR DESCRIPTION
When hitting /LyricWiki:New_Releases?oldid=6461363 I don't actually see the error either before or after the change. Perhaps it is dependent on certain data that was coming in from the input-XML.

This code-change should make it pretty robust to different types of tempArray[0] though.
