### PR TITLE
LYR-221 fix: removed use of now-private variable, removed use of regex w...

### DIFF
--- a/extensions/3rdparty/LyricWiki/lw_spiderableBadArtists.php
+++ b/extensions/3rdparty/LyricWiki/lw_spiderableBadArtists.php
@@ -37,27 +37,23 @@ function wfSpiderableBadArtists(){
 ////
 // Given a title, gives us a chance to create an article for it before MediaWiki takes its normal approach.
 ////
-function wfSpiderableBadArtists_outputPage(&$out, &$text){
+function wfSpiderableBadArtists_outputPage( OutputPage &$out, &$text ){
 	GLOBAL $wgTitle;
 
 	// For "virtual pages" that the spiders can index.
 	if(isset($_GET['virtPage'])){
-		$subTitle = $out->mSubtitle;
-		$matches = array();
-		if(0 < preg_match("/Redirected from <a href=\"[^\"]+&amp;redirect=no\" title=\"([^\"]+)\"/i", $subTitle, $matches)){
-			$redirFrom = $matches[1];
-			if(false === strpos($redirFrom, ":")){
-				$redirFrom = str_replace(" ", "_", $redirFrom);
-				$redirFrom = urlencode($redirFrom);
-				$from = $wgTitle->mUrlform;
-				if(strtolower($from) != strtolower($redirFrom)){
-					$text = str_replace("\"/$from", "\"/$redirFrom", $text);
-					$text = str_replace("\"$from", "\"$redirFrom", $text);
-				}
+		$vars = $out->getJSVars();
+		$redirFrom = $vars['wgRedirectedFrom'];
+		if((!empty($redirFrom)) && (false === strpos($redirFrom, ":"))){
+			$redirFrom = str_replace(" ", "_", $redirFrom);
+			$redirFrom = urlencode($redirFrom);
+			$from = $wgTitle->mUrlform;
+			if(strtolower($from) != strtolower($redirFrom)){
+				$text = str_replace("\"/$from", "\"/$redirFrom", $text);
+				$text = str_replace("\"$from", "\"$redirFrom", $text);
 			}
 		}
 	}
 
 	return true;
 } // end wfSpiderableBadArtists_outputPage()
-


### PR DESCRIPTION
...here an OutputPage variable will suffice, and added type-hinting to function parameters to get bonus points from Macbre ;)

Here was a good URL to test it on (I'll probably be switched back to another branch though, because there are other bugs to fix):
http://lyrics.sean.wikia-dev.com/index.php?virtPage&title=Angels_Fallen

When the page is working correctly, there is no PHP error thrown, and when the you mouse over a link to a song, you'll notice it points to "Angels_Fallen" as the artist. This intentionally makes pages with the wrong URL but which redirect to pages with the correct canonical URL.
