### PR TITLE
CE-1326 Adjust input form height to be consistend with add category

### DIFF
--- a/extensions/wikia/EditPageLayout/css/core/modules.scss
+++ b/extensions/wikia/EditPageLayout/css/core/modules.scss
@@ -89,7 +89,7 @@ $color-icon: mix($color-text, #fff, 90%);
 		// edit summary
 		#wpSummary {
 			@include epl-textfield;
-			height: 27px;
+			height: 23px;
 			line-height: 15px;
 			margin: 5px 0;
 			resize: none; /* remove resize grip in Webkit / Fx4 */


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CE-1326

Per request:
1. Edit summary box feels extra large
I am not sure that I'm seeing this fix on http://sandbox-venus.scrubs.wikia.com/wiki/Andy_Kreiss?action=edit 0 - it's still taller than the 'Add category...' input further down the right rail. Can we shave off a few more pixels for consistency?

---

Reduced edit summary height of input for 4px to be consistent with add category input height.
