### PR TITLE
PLATFORM-922: Use memcached for AbTesting config

### DIFF
--- a/extensions/wikia/AbTesting/AbTesting.class.php
+++ b/extensions/wikia/AbTesting/AbTesting.class.php
@@ -152,11 +152,16 @@ class AbTesting extends WikiaObject {
 	}
 
 	protected function getConfig() {
-		return $this->generateConfigObj();
+		$data = $this->wg->memc->get($this->getMemcKey());
+		if ( empty($data) ) {
+			$data = $this->generateConfigObj();
+		}
+		return $data;
 	}
 
-	protected function generateConfigObj() {
+	protected function generateConfigObj( $useMaster = false ) {
 		$dataClass = new AbTestingData();
+		$dataClass->setUseMaster($useMaster);
 		$memcKey = $this->getMemcKey();
 		// find last modification time
 		$lastModified = $dataClass->getLastEffectiveChangeTime(self::VARNISH_CACHE_TIME);
@@ -202,8 +207,7 @@ class AbTesting extends WikiaObject {
 	}
 
 	public function invalidateCache() {
-		//$this->wg->memc->delete($this->getMemcKey());
-		$this->generateConfigObj();
+		$this->generateConfigObj( /* useMaster */ true );
 	}
 
 	/**

--- a/extensions/wikia/AbTesting/AbTestingData.class.php
+++ b/extensions/wikia/AbTesting/AbTestingData.class.php
@@ -16,6 +16,8 @@ class AbTestingData extends WikiaObject {
 	const MIN = 'min';
 	const MAX = 'max';
 
+	protected $useMaster = false;
+
 	protected $blacklistedColumns = array(
 		self::TABLE_EXPERIMENTS => array(
 			'groups',
@@ -27,9 +29,15 @@ class AbTestingData extends WikiaObject {
 	);
 
 	public function getDb( $db_type = DB_SLAVE ) {
+		if ( $this->useMaster ) {
+			$db_type = DB_MASTER;
+		}
 		return wfGetDB( $db_type, array(), $this->wg->ExternalDatawareDB );
 	}
 
+	public function setUseMaster( $useMaster = true ) {
+		$this->useMaster = $useMaster;
+	}
 
 
 	/* READ METHODS */


### PR DESCRIPTION
The memcached layer in AbTesting was disabled some time ago (2.5y) in order to solve issues with reading recently-written data from slave. This change seems to solve the issue in a way that doesn't put a lot of unnecessary load on database.

https://wikia-inc.atlassian.net/browse/PLATFORM-922

/cc @macbre 
