### PR TITLE
CONCF-4 | any wiki can be added to the Corporate Footer dropdown (wgDisableWAMOnHubPages is irrelevant)

### DIFF
--- a/extensions/wikia/CityVisualization/helpers/WikiaHomePageHelper.class.php
+++ b/extensions/wikia/CityVisualization/helpers/WikiaHomePageHelper.class.php
@@ -17,7 +17,7 @@ class WikiaHomePageHelper extends WikiaModel {
 	const VIDEO_GAMES_SLOTS_VAR_NAME = 'wgWikiaHomePageVideoGamesSlots';
 	const ENTERTAINMENT_SLOTS_VAR_NAME = 'wgWikiaHomePageEntertainmentSlots';
 	const LIFESTYLE_SLOTS_VAR_NAME = 'wgWikiaHomePageLifestyleSlots';
-	const CORPORATE_ON_HUB_ENABLED = 'wgTreatAsCorporate';
+	const IS_WIKI_INCLUDED_IN_CORPORATE_FOOTER_DROPDOWN_VAR_NAME = 'wgIncludeWikiInCorporateFooterDropdown';
 	const SLOTS_IN_TOTAL = 17;
 
 	const SLOTS_BIG = 2;
@@ -802,16 +802,12 @@ class WikiaHomePageHelper extends WikiaModel {
 		return false;
 	}
 
-	public function getVisualizationWikisData() {
-		return $this->getVisualization()->getVisualizationWikisData();
-	}
-
-	public function getCorporateHubWikis() {
+	public function getWikisIncludedInCorporateFooterDropdown() {
 		$wikiFactoryList = [];
-		$varId = WikiFactory::getVarIdByName( self::CORPORATE_ON_HUB_ENABLED );
+		$varId = WikiFactory::getVarIdByName( self::IS_WIKI_INCLUDED_IN_CORPORATE_FOOTER_DROPDOWN_VAR_NAME );
 		if( is_int( $varId ) ) {
 			$wikiFactoryList = WikiaDataAccess::cache(
-				wfMemcKey( 'corporate_hub_pages_list', self::WIKIA_HOME_PAGE_HELPER_MEMC_VERSION ),
+				wfMemcKey( 'wikis_included_in_corporate_footer_dropdown', self::WIKIA_HOME_PAGE_HELPER_MEMC_VERSION ),
 				24 * 60 * 60,
 				function() use( $varId ) {
 					$list = WikiFactory::getListOfWikisWithVar( $varId, 'bool', '=', true );

--- a/extensions/wikia/CityVisualization/helpers/WikiaHomePageHelper.class.php
+++ b/extensions/wikia/CityVisualization/helpers/WikiaHomePageHelper.class.php
@@ -17,7 +17,7 @@ class WikiaHomePageHelper extends WikiaModel {
 	const VIDEO_GAMES_SLOTS_VAR_NAME = 'wgWikiaHomePageVideoGamesSlots';
 	const ENTERTAINMENT_SLOTS_VAR_NAME = 'wgWikiaHomePageEntertainmentSlots';
 	const LIFESTYLE_SLOTS_VAR_NAME = 'wgWikiaHomePageLifestyleSlots';
-	const CORPORATE_ON_HUB_ENABLED = 'wgDisableWAMOnHubs';
+	const CORPORATE_ON_HUB_ENABLED = 'wgTreatAsCorporate';
 	const SLOTS_IN_TOTAL = 17;
 
 	const SLOTS_BIG = 2;

--- a/extensions/wikia/CorporateFooter/CorporateFooterController.class.php
+++ b/extensions/wikia/CorporateFooter/CorporateFooterController.class.php
@@ -7,12 +7,10 @@ class CorporateFooterController extends WikiaController {
 		$this->response->addAsset( 'extensions/wikia/CorporateFooter/styles/CorporateFooter.scss' );
 
 		$helper = new WikiaHomePageHelper();
-		$corporateWikis = $helper->getVisualizationWikisData();
-		$corporateHubWikis = $helper->getCorporateHubWikis();
-		$corporateWikis = array_merge( $corporateWikis, $corporateHubWikis );
+		$wikisIncludedInCorporateFooterDropdown = $helper->getWikisIncludedInCorporateFooterDropdown();
 
 		$this->selectedLang = $this->wg->ContLang->getCode();
-		$this->dropDownItems = $this->prepareDropdownItems( $corporateWikis, $this->selectedLang );
+		$this->dropDownItems = $this->prepareDropdownItems( $wikisIncludedInCorporateFooterDropdown, $this->selectedLang );
 
 		if ( $this->app->wg->EnableWAMPageExt ) {
 			$wamModel = new WAMPageModel();

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1676,6 +1676,11 @@ $wgProfilerSendViaScribe = true;
  */
 $wgDisableWAMOnHubs = false;
 
+/* @name wgTreatAsCorporate
+ * Treat a wiki as if it was a corporate wiki
+ */
+$wgTreatAsCorporate = false;
+
 /**
  * Force ImageServing to return an empty list
  * see PLATFORM-392

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1676,10 +1676,10 @@ $wgProfilerSendViaScribe = true;
  */
 $wgDisableWAMOnHubs = false;
 
-/* @name wgTreatAsCorporate
- * Treat a wiki as if it was a corporate wiki
+/* @name wgIncludeWikiInCorporateFooterDropdown
+ * Include link to this wiki in the Corporate Footer dropdown (the one with flags).
  */
-$wgTreatAsCorporate = false;
+$wgIncludeWikiInCorporateFooterDropdown = false;
 
 /**
  * Force ImageServing to return an empty list


### PR DESCRIPTION
Added an independent wg variable (`wgIncludeWikiInCorporateFooterDropdown`) to determine if a wiki is supposed to act as a corporate wiki, thus added to the Corporate Footer (the one on Wikia Home Pages) dropdown (the one with flags). Still only one wiki per language is permitted as they would overwrite each other.

Previously `wgDisableWAMOnHubPages` was determining if a page is a corporate page on hub template. Now WAM can be disabled on any page, and any page can be set as corporate.
