### PR TITLE
SOC-368 | UserLoginHooks fix fatal error

### DIFF
--- a/extensions/wikia/UserLogin/UserLoginHooksHelper.class.php
+++ b/extensions/wikia/UserLogin/UserLoginHooksHelper.class.php
@@ -60,7 +60,7 @@ class UserLoginHooksHelper {
 	}
 
 	// get email authentication for Preferences::profilePreferences
-	public static function onGetEmailAuthentication( User &$user, RequestContext $context, &$disableEmailPrefs, &$emailauthenticated ) {
+	public static function onGetEmailAuthentication( User &$user, IContextSource $context, &$disableEmailPrefs, &$emailauthenticated ) {
 		if ( $user->getEmail() ) {
 			$emailTimestamp = $user->getEmailAuthenticationTimestamp();
 			$optionNewEmail = $user->getOption( 'new_email' );


### PR DESCRIPTION
Make type hinting comaptible with Hook caller implementation: https://github.com/Wikia/app/blob/dev/includes/Preferences.php#L136

https://wikia-inc.atlassian.net/browse/SOC-368
