### PR TITLE
Withdraw from Hungarian notation in Helios

### DIFF
--- a/extensions/wikia/Helios/Client.class.php
+++ b/extensions/wikia/Helios/Client.class.php
@@ -9,85 +9,85 @@ use Wikia\Util\RequestId;
  */
 class Client
 {
-	protected $sBaseUri;
-	protected $sClientId;
-	protected $sClientSecret;
+	protected $baseUri;
+	protected $clientId;
+	protected $clientSecret;
 	
 	/**
 	 * The constructor.
 	 */
-	public function __construct( $sBaseUri, $sClientId, $sClientSecret )
+	public function __construct( $baseUri, $clientId, $clientSecret )
 	{
-		$this->sBaseUri = $sBaseUri;
-		$this->sClientId = $sClientId;
-		$this->sClientSecret = $sClientSecret;
+		$this->baseUri = $baseUri;
+		$this->clientId = $clientId;
+		$this->clientSecret = $clientSecret;
 	}
 
 	/**
 	 * The general method for handling the communication with the service.
 	 */
-	public function request( $sResource, $aGetData = [], $mPostData = [], $aCustomOptions = [] )
+	public function request( $resourceName, $getParams = [], $postData = [], $requestOptions = [] )
 	{
 		// Crash if we cannot make HTTP requests.
 		\Wikia\Util\Assert::true( \MWHttpRequest::canMakeRequests() );
 
 		// Add client_id and client_secret to the GET data.
-		$aGetData['client_id'] = $this->sClientId;
-		$aGetData['client_secret'] = $this->sClientSecret;
+		$getParams['client_id'] = $this->clientId;
+		$getParams['client_secret'] = $this->clientSecret;
 		
 		// Request URI pre-processing.
-		$sUri = "{$this->sBaseUri}{$sResource}?" . http_build_query($aGetData);
+		$uri = "{$this->baseUri}{$resourceName}?" . http_build_query($getParams);
 		
 		// Request options pre-processing.
-		$aDefaultOptions = [
+		$defaultOptions = [
 			'method'		=> 'GET',
 			'timeout'		=> 5,
-			'postData'		=> $mPostData,
+			'postData'		=> $postData,
 			'noProxy'		=> true,
 			'followRedirects'	=> false,
 			'returnInstance'	=> true
 		];
 
-		$aOptions = array_merge( $aDefaultOptions, $aCustomOptions );
+		$aOptions = array_merge( $defaultOptions, $requestOptions );
 
 		// Request execution.
-		$oRequest = \MWHttpRequest::factory( $sUri, $aOptions );
-		$oRequest->setHeader(RequestId::REQUEST_HEADER_NAME, RequestId::instance()->getRequestId());
-		$oRequest->setHeader(RequestId::REQUEST_HEADER_ORIGIN_HOST, wfHostname());
-		$oStatus = $oRequest->execute();
+		$request = \MWHttpRequest::factory( $uri, $aOptions );
+		$request->setHeader(RequestId::REQUEST_HEADER_NAME, RequestId::instance()->getRequestId());
+		$request->setHeader(RequestId::REQUEST_HEADER_ORIGIN_HOST, wfHostname());
+		$status = $request->execute();
 
 		// Response handling.
-		if ( !$oStatus->isGood() ) {
-			throw new ClientException( 'Request failed.', 0, null, $oStatus->getErrorsArray() );
+		if ( !$status->isGood() ) {
+			throw new ClientException( 'Request failed.', 0, null, $status->getErrorsArray() );
 		}
 
-		$sOutput = json_decode( $oRequest->getContent() );
+		$output = json_decode( $request->getContent() );
 		
-		if ( !$sOutput ) {
+		if ( !$output ) {
 			throw new ClientException( 'Invalid response.' );
 		}
 
-		return $sOutput;
+		return $output;
 	}
 
 	/**
 	 * A shortcut method for login requests.
 	 */
-	public function login( $sUsername, $sPassword )
+	public function login( $username, $password )
 	{
 		// Convert the array to URL-encoded query string, so the Content-Type
 		// for the POST request is application/x-www-form-urlencoded.
 		// It would be multipart/form-data which is not supported
 		// by the Helios service.
-		$sPostData = http_build_query([
-			'username'	=> $sUsername,
-			'password'	=> $sPassword
+		$postData = http_build_query([
+			'username'	=> $username,
+			'password'	=> $password
 		]);
 
 		return $this->request(
 			'token',
 			[ 'grant_type'	=> 'password' ],
-			$sPostData,
+			$postData,
 			[ 'method'	=> 'POST' ]
 		);
 	}
@@ -95,24 +95,24 @@ class Client
 	/**
 	 * A shortcut method for info requests
 	 */
-	public function info( $sToken )
+	public function info( $token )
 	{
 		return $this->request(
 			'info',
-			[ 'code' => $sToken ]
+			[ 'code' => $token ]
 		);
 	}
 
 	/**
 	 * A shortcut method for refresh token requests.
 	 */
-	public function refreshToken( $sToken )
+	public function refreshToken( $token )
 	{
 		return $this->request(
 			'token',
 			[
 				'grant_type'	=> 'refresh_token',
-				'refresh_token'	=> $sToken
+				'refresh_token'	=> $token
 			]
 		);
 	}

--- a/extensions/wikia/Helios/SampleController.class.php
+++ b/extensions/wikia/Helios/SampleController.class.php
@@ -11,42 +11,43 @@ class SampleController extends \WikiaController
 	 */
 	public function edit()
 	{
-		$oResponseData = new \StdClass;
-		$oResponseData->success = false;
-		$oResponseData->title = null;
-		$oResponseData->text = null;
-		$oResponseData->summary = null;
-		$oResponseData->user_id = 0;
-		$oResponseData->user_name = null;
+		$responseData = new \StdClass;
+		$responseData->success = false;
+		$responseData->title = null;
+		$responseData->text = null;
+		$responseData->summary = null;
+		$responseData->user_id = 0;
+		$responseData->user_name = null;
 		
 		$this->response->setFormat( 'json' );
 		$this->response->setCacheValidity( \WikiaResponse::CACHE_DISABLED );
 
 		if ( $this->getVal( 'secret' ) != $this->wg->TheSchwartzSecretToken || ! $this->request->wasPosted() ) {
-			$this->response->setVal( 'data', $oResponseData );
+			$this->response->setVal( 'data', $responseData );
 			return;
 		}
 
-		$sTitle = $this->getVal( 'title' );
-		$oResponseData->title = $sTitle;
-		$oTitle = \Title::newFromText( $sTitle );
-		\Wikia\Util\Assert::true( $oTitle instanceof \Title );
+		$titleText = $this->getVal( 'title' );
+		$responseData->title = $titleText;
 
-		$oArticle = new \Article( $oTitle );
-		\Wikia\Util\Assert::true( $oArticle instanceof \Article );
+		$title = \Title::newFromText( $titleText );
+		\Wikia\Util\Assert::true( $title instanceof \Title );
 
-		$sText = $this->getVal( 'text' );
-		$oResponseData->text = $sText;
+		$article = new \Article( $title );
+		\Wikia\Util\Assert::true( $article instanceof \Article );
 
-		$sSummary = $this->getVal( 'summary' );
-		$oResponseData->summary = $sSummary;
+		$text = $this->getVal( 'text' );
+		$responseData->text = $text;
+
+		$summary = $this->getVal( 'summary' );
+		$responseData->summary = $summary;
 
 		if ( $this->wg->User->isLoggedIn() ) {
-			$oResponseData->user_id = $this->wg->User->getId();
-			$oResponseData->user_name = $this->wg->User->getName();
-			$oResponseData->success = $oArticle->doEdit( $sText, $sSummary )->isOK();
+			$responseData->user_id = $this->wg->User->getId();
+			$responseData->user_name = $this->wg->User->getName();
+			$responseData->success = $article->doEdit( $text, $summary )->isOK();
 		}
 
-		$this->response->setVal( 'data', $oResponseData );
+		$this->response->setVal( 'data', $responseData );
 	}
 }

--- a/extensions/wikia/Helios/tests/ClientTest.php
+++ b/extensions/wikia/Helios/tests/ClientTest.php
@@ -16,8 +16,8 @@ class ClientTest extends \WikiaBaseTest {
 
 		$this->mockStaticMethod( '\MWHttpRequest', 'canMakeRequests', false );
 
-		$oClient = new Client( 'http://example.com', 'id', 'secret' );
-		$oClient->request( 'resource', [], [], [] );
+		$client = new Client( 'http://example.com', 'id', 'secret' );
+		$client->request( 'resource', [], [], [] );
 	}
 
 	public function testRequestFailed()
@@ -26,20 +26,20 @@ class ClientTest extends \WikiaBaseTest {
 
 		$this->mockStaticMethod( '\MWHttpRequest', 'canMakeRequests', true );
 
-		$oStatusMock = $this->getMock( '\Status', [ 'isGood' ], [], '', true );
-		$oStatusMock->expects( $this->once() )
+		$statusMock = $this->getMock( '\Status', [ 'isGood' ], [], '', true );
+		$statusMock->expects( $this->once() )
 			->method( 'isGood' )
 			->willReturn( false );
 
-		$oRequestMock = $this->getMock( '\CurlHttpRequest', [ 'execute' ], [ 'http://example.com' ], '', false );
-		$oRequestMock->expects( $this->once() )
+		$requestMock = $this->getMock( '\CurlHttpRequest', [ 'execute' ], [ 'http://example.com' ], '', false );
+		$requestMock->expects( $this->once() )
 			->method( 'execute' )
-			->willReturn( $oStatusMock );
+			->willReturn( $statusMock );
 
-		$this->mockStaticMethod( '\MWHttpRequest', 'factory', $oRequestMock );
+		$this->mockStaticMethod( '\MWHttpRequest', 'factory', $requestMock );
 
-		$oClient = new Client( 'http://example.com', 'id', 'secret' );
-		$oClient->request( 'resource', [], [], [] );
+		$client = new Client( 'http://example.com', 'id', 'secret' );
+		$client->request( 'resource', [], [], [] );
 	}
 
 	public function testInvalidResponse()
@@ -48,46 +48,46 @@ class ClientTest extends \WikiaBaseTest {
 
 		$this->mockStaticMethod( '\MWHttpRequest', 'canMakeRequests', true );
 
-		$oStatusMock = $this->getMock( '\Status', [ 'isGood' ], [], '', true );
-		$oStatusMock->expects( $this->once() )
+		$statusMock = $this->getMock( '\Status', [ 'isGood' ], [], '', true );
+		$statusMock->expects( $this->once() )
 			->method( 'isGood' )
 			->willReturn( true );
 
-		$oRequestMock = $this->getMock( '\CurlHttpRequest', [ 'execute', 'getContent' ], [ 'http://example.com' ], '', false );
-		$oRequestMock->expects( $this->once() )
+		$requestMock = $this->getMock( '\CurlHttpRequest', [ 'execute', 'getContent' ], [ 'http://example.com' ], '', false );
+		$requestMock->expects( $this->once() )
 			->method( 'execute' )
-			->willReturn( $oStatusMock );
-		$oRequestMock->expects( $this->once() )
+			->willReturn( $statusMock );
+		$requestMock->expects( $this->once() )
 			->method( 'getContent' )
 			->willReturn( null );
 
-		$this->mockStaticMethod( '\MWHttpRequest', 'factory', $oRequestMock );
+		$this->mockStaticMethod( '\MWHttpRequest', 'factory', $requestMock );
 
-		$oClient = new Client( 'http://example.com', 'id', 'secret' );
-		$oClient->request( 'resource', [], [], [] );
+		$client = new Client( 'http://example.com', 'id', 'secret' );
+		$client->request( 'resource', [], [], [] );
 	}
 
 	public function testSuccess()
 	{
 		$this->mockStaticMethod( '\MWHttpRequest', 'canMakeRequests', true );
 
-		$oStatusMock = $this->getMock( '\Status', [ 'isGood' ], [], '', true );
-		$oStatusMock->expects( $this->once() )
+		$statusMock = $this->getMock( '\Status', [ 'isGood' ], [], '', true );
+		$statusMock->expects( $this->once() )
 			->method( 'isGood' )
 			->willReturn( true );
 
-		$oRequestMock = $this->getMock( '\CurlHttpRequest', [ 'execute', 'getContent' ], [ 'http://example.com' ], '', false );
-		$oRequestMock->expects( $this->once() )
+		$requestMock = $this->getMock( '\CurlHttpRequest', [ 'execute', 'getContent' ], [ 'http://example.com' ], '', false );
+		$requestMock->expects( $this->once() )
 			->method( 'execute' )
-			->willReturn( $oStatusMock );
-		$oRequestMock->expects( $this->once() )
+			->willReturn( $statusMock );
+		$requestMock->expects( $this->once() )
 			->method( 'getContent' )
 			->willReturn( '{}' );
 
-		$this->mockStaticMethod( '\MWHttpRequest', 'factory', $oRequestMock );
+		$this->mockStaticMethod( '\MWHttpRequest', 'factory', $requestMock );
 
-		$oClient = new Client( 'http://example.com', 'id', 'secret' );
-		$this->assertInternalType( 'object', $oClient->request( 'resource', [], [], [] ) );
+		$client = new Client( 'http://example.com', 'id', 'secret' );
+		$this->assertInternalType( 'object', $client->request( 'resource', [], [], [] ) );
 	}
 
 }

--- a/extensions/wikia/Helios/tests/UserTest.php
+++ b/extensions/wikia/Helios/tests/UserTest.php
@@ -4,12 +4,12 @@ namespace Wikia\Helios;
 
 class UserTest extends \WikiaBaseTest {
 
-	private $oRequest;
+	private $webRequestMock;
 
 	public function setUp()
 	{
 		$this->setupFile =  __DIR__ . '/../Helios.setup.php';
-		$this->oRequest = $this->getMock( '\WebRequest', [ 'getHeader' ], [], '', false );
+		$this->webRequestMock = $this->getMock( '\WebRequest', [ 'getHeader' ], [], '', false );
 		$this->mockGlobalVariable( 'wgHeliosLoginSamplingRate', 100 );
 		$this->mockGlobalVariable( 'wgHeliosLoginShadowMode', false );
 		parent::setUp();
@@ -17,111 +17,111 @@ class UserTest extends \WikiaBaseTest {
 
 	public function testNewFromTokenNoAuthorizationHeader()
 	{
-		$this->oRequest->expects( $this->once() )
+		$this->webRequestMock->expects( $this->once() )
 			->method( 'getHeader' )
 			->with( 'AUTHORIZATION' )
 			->willReturn( false );
 
-		$this->assertNull( User::newFromToken( $this->oRequest ) );
+		$this->assertNull( User::newFromToken( $this->webRequestMock ) );
 	}
 
 	public function testNewFromTokenMalformedAuthorizationHeader()
 	{
-		$this->oRequest->expects( $this->once() )
+		$this->webRequestMock->expects( $this->once() )
 			->method( 'getHeader' )
 			->with( 'AUTHORIZATION' )
 			->willReturn( 'Malformed' );
 
-		$this->assertNull( User::newFromToken( $this->oRequest ) );
+		$this->assertNull( User::newFromToken( $this->webRequestMock ) );
 	}
 
 	public function testNewFromTokenAuthorizationGranted()
 	{
-		$this->oRequest->expects( $this->once() )
+		$this->webRequestMock->expects( $this->once() )
 			->method( 'getHeader' )
 			->with( 'AUTHORIZATION' )
 			->willReturn( 'Bearer qi8H8R7OM4xMUNMPuRAZxlY' );
 
-		$oUser = new \StdClass;
-		$oUser->user_id = 1;
+		$userInfo = new \StdClass;
+		$userInfo->user_id = 1;
 
 		$oClientMock = $this->getMock( 'Client', [ 'info' ], [], '', false );
 		$oClientMock->expects( $this->once() )
 			->method( 'info' )
 			->with( 'qi8H8R7OM4xMUNMPuRAZxlY' )
-			->willReturn( $oUser );
+			->willReturn( $userInfo );
 
 		$this->mockClass( 'Wikia\Helios\Client', $oClientMock );
 
-		$this->assertEquals( User::newFromToken( $this->oRequest ), \User::newFromId( 1 ) );
+		$this->assertEquals( User::newFromToken( $this->webRequestMock ), \User::newFromId( 1 ) );
 	}
 
 	public function testNewFromTokenAuthorizationDeclined()
 	{
-		$this->oRequest->expects( $this->once() )
+		$this->webRequestMock->expects( $this->once() )
 			->method( 'getHeader' )
 			->with( 'AUTHORIZATION' )
 			->willReturn( 'Bearer qi8H8R7OM4xMUNMPuRAZxlY' );
 
-		$oUser = new \StdClass;
+		$userInfo = new \StdClass;
 
-		$oClientMock = $this->getMock( 'Wikia\Helios\Client', [ 'info' ], [], '', false );
-		$oClientMock->expects( $this->once() )
+		$clientMock = $this->getMock( 'Wikia\Helios\Client', [ 'info' ], [], '', false );
+		$clientMock->expects( $this->once() )
 			->method( 'info' )
 			->with( 'qi8H8R7OM4xMUNMPuRAZxlY' )
-			->willReturn( $oUser );
+			->willReturn( $userInfo );
 
-		$this->mockClass( 'Wikia\Helios\Client', $oClientMock );
+		$this->mockClass( 'Wikia\Helios\Client', $clientMock );
 
-		$this->assertNull( User::newFromToken( $this->oRequest ) );
+		$this->assertNull( User::newFromToken( $this->webRequestMock ) );
 	}
 
 	public function testAuthenticateAuthenticationFailed()
 	{
-		$sUserName = 'SomeName';
-		$sPassword = 'Password';
+		$username = 'SomeName';
+		$password = 'Password';
 
-		$oClient = $this->getMock( 'Wikia\Helios\Client', [ 'login' ], [], '', false );
-		$oClient->expects( $this->once() )
+		$client = $this->getMock( 'Wikia\Helios\Client', [ 'login' ], [], '', false );
+		$client->expects( $this->once() )
 			->method( 'login' )
-			->with( $sUserName, $sPassword )
+			->with( $username, $password )
 			->willReturn( new \StdClass );
-		$this->mockClass( 'Wikia\Helios\Client', $oClient );
+		$this->mockClass( 'Wikia\Helios\Client', $client );
 
-		$this->assertFalse( User::authenticate( $sUserName, $sPassword ) );
+		$this->assertFalse( User::authenticate( $username, $password ) );
 	}
 
 	public function testAuthenticateAuthenticationImpossible()
 	{
-		$sUserName = 'SomeName';
-		$sPassword = 'Password';
+		$username = 'SomeName';
+		$password = 'Password';
 
-		$oClient = $this->getMock( 'Wikia\Helios\Client', [ 'login' ], [], '', false );
-		$oClient->expects( $this->once() )
+		$client = $this->getMock( 'Wikia\Helios\Client', [ 'login' ], [], '', false );
+		$client->expects( $this->once() )
 			->method( 'login' )
-			->with( $sUserName, $sPassword )
+			->with( $username, $password )
 			->will( $this->throwException( new ClientException ) );
-		$this->mockClass( 'Wikia\Helios\Client', $oClient );
+		$this->mockClass( 'Wikia\Helios\Client', $client );
 
-		$this->assertFalse( User::authenticate( $sUserName, $sPassword ) );
+		$this->assertFalse( User::authenticate( $username, $password ) );
 	}
 
 	public function testAuthenticateAuthenticationSucceded()
 	{
-		$sUserName = 'SomeName';
-		$sPassword = 'Password';
+		$username = 'SomeName';
+		$password = 'Password';
 
-		$oLogin = new \StdClass;
-		$oLogin->access_token = 'orvb9pM6wX';
+		$loginInfo = new \StdClass;
+		$loginInfo->access_token = 'orvb9pM6wX';
 
-		$oClient = $this->getMock( 'Wikia\Helios\Client', [ 'login' ], [], '', false );
-		$oClient->expects( $this->once() )
+		$client = $this->getMock( 'Wikia\Helios\Client', [ 'login' ], [], '', false );
+		$client->expects( $this->once() )
 			->method( 'login' )
-			->with( $sUserName, $sPassword )
-			->willReturn( $oLogin );
-		$this->mockClass( 'Wikia\Helios\Client', $oClient );
+			->with( $username, $password )
+			->willReturn( $loginInfo );
+		$this->mockClass( 'Wikia\Helios\Client', $client );
 
-		$this->assertTrue( User::authenticate( $sUserName, $sPassword ) );
+		$this->assertTrue( User::authenticate( $username, $password ) );
 	}
 
 }


### PR DESCRIPTION
This changeset withdraws from Hungarian notation used in Helios which is not popular in our code base. Achieved by using only automatic refactoring so I'll merge it right away.

/cc @michalroszka 
