### PR TITLE
SOC-375 PHP Fatal Error: Call to a member function doPurge() on a non-object RelatedForumDiscussionController.class.php

### DIFF
--- a/extensions/wikia/Forum/README.md
+++ b/extensions/wikia/Forum/README.md
@@ -1,0 +1,5 @@
+# Forum
+
+## Kibana Graphs
+
+* [All Forum Messages in Kibana](https://kibana.wikia-inc.com/index.html#/dashboard/elasticsearch/Extension%20-%20Forum)

--- a/extensions/wikia/Forum/RelatedForumDiscussionController.class.php
+++ b/extensions/wikia/Forum/RelatedForumDiscussionController.class.php
@@ -1,4 +1,7 @@
 <?php
+
+use Wikia\Logger\WikiaLogger;
+
 class RelatedForumDiscussionController extends WikiaController {
 
 	/** Expiry time to use in cache requests */
@@ -77,14 +80,19 @@ class RelatedForumDiscussionController extends WikiaController {
 	 * @param int $threadId
 	 */
 	public static function purgeCache( $threadId ) {
-		$rm = new WallRelatedPages();
-		$ids = $rm->getMessagesRelatedArticleIds($threadId, 'order_index', DB_MASTER);
+		$relatedPages = new WallRelatedPages();
+		$ids = $relatedPages->getMessagesRelatedArticleIds( $threadId, 'order_index', DB_MASTER );
 
-		foreach($ids as $id) {
+		foreach( $ids as $id ) {
 			$key = wfMemcKey( __CLASS__, 'getData', $id );
-			WikiaDataAccess::cachePurge($key);
+			WikiaDataAccess::cachePurge( $key );
 			// VOLDEV-46: Update module by purging page, not via AJAX
-			WikiPage::newFromID( $id )->doPurge();
+			$wikiaPage = WikiPage::newFromID( $id );
+			if ( !empty( $wikiaPage ) ) {
+				$wikiaPage->doPurge();
+			} else {
+				self::logError( "doPurge() attempted on non-object", [ "articleID" => $id ] );
+			}
 		}
 	}
 
@@ -100,5 +108,9 @@ class RelatedForumDiscussionController extends WikiaController {
 			$messages = $wlp->getArticlesRelatedMessgesSnippet( $articleId, 2, 2 );
 			return $messages;
 		});
+	}
+
+	private static function logError( $message, array $param = [] ) {
+			WikiaLogger::instance()->error( 'RelatedForumDiscussionController: ' . $message, $param );
 	}
 }

--- a/extensions/wikia/Forum/RelatedForumDiscussionController.class.php
+++ b/extensions/wikia/Forum/RelatedForumDiscussionController.class.php
@@ -111,6 +111,6 @@ class RelatedForumDiscussionController extends WikiaController {
 	}
 
 	private static function logError( $message, array $param = [] ) {
-			WikiaLogger::instance()->error( 'RelatedForumDiscussionController: ' . $message, $param );
+		WikiaLogger::instance()->error( 'RelatedForumDiscussionController: ' . $message, $param );
 	}
 }

--- a/extensions/wikia/Forum/RelatedForumDiscussionController.class.php
+++ b/extensions/wikia/Forum/RelatedForumDiscussionController.class.php
@@ -88,10 +88,10 @@ class RelatedForumDiscussionController extends WikiaController {
 			WikiaDataAccess::cachePurge( $key );
 			// VOLDEV-46: Update module by purging page, not via AJAX
 			$wikiaPage = WikiPage::newFromID( $id );
-			if ( !empty( $wikiaPage ) ) {
+			if ( $wikiaPage ) {
 				$wikiaPage->doPurge();
 			} else {
-				self::logError( "doPurge() attempted on non-object", [ "articleID" => $id ] );
+				self::logError( "Found a null related wikipage on thread purge", [ "articleID" => $id, "threadID" => $threadId ] );
 			}
 		}
 	}


### PR DESCRIPTION
Add a check inside of the purgeCache method of the RelatedForumDiscussionController that we are operating on an object before calling doPurge() on it. Also added logging for when this fails, a dashboard to display those failures, and a README with a link to the dashboard.

Ticket: https://wikia-inc.atlassian.net/browse/SOC-375
