### PR TITLE
Use Helios for login processing in all places

### DIFF
--- a/extensions/wikia/Helios/Client.class.php
+++ b/extensions/wikia/Helios/Client.class.php
@@ -26,7 +26,7 @@ class Client
 	/**
 	 * The general method for handling the communication with the service.
 	 */
-	public function request( $resourceName, $getParams = [], $postData = [], $requestOptions = [] )
+	public function request( $resourceName, $getParams = [], $postData = [], $extraRequestOptions = [] )
 	{
 		// Crash if we cannot make HTTP requests.
 		\Wikia\Util\Assert::true( \MWHttpRequest::canMakeRequests() );
@@ -48,10 +48,10 @@ class Client
 			'returnInstance'	=> true
 		];
 
-		$aOptions = array_merge( $defaultOptions, $requestOptions );
+		$requestOptions = array_merge( $defaultOptions, $extraRequestOptions );
 
 		// Request execution.
-		$request = \MWHttpRequest::factory( $uri, $aOptions );
+		$request = \MWHttpRequest::factory( $uri, $requestOptions );
 		$request->setHeader(RequestId::REQUEST_HEADER_NAME, RequestId::instance()->getRequestId());
 		$request->setHeader(RequestId::REQUEST_HEADER_ORIGIN_HOST, wfHostname());
 		$status = $request->execute();

--- a/extensions/wikia/Helios/Exceptions.php
+++ b/extensions/wikia/Helios/Exceptions.php
@@ -17,6 +17,16 @@ class Exception extends \Exception
 		$this->logMe();
 	}
 
+	public function getLoggerContext() {
+		$data = $this->getData();
+		if ( $data === null ) {
+			$data = [];
+		} elseif ( !is_array($data) ) {
+			$data = [ 'data' => $data ];
+		}
+		return array_merge( [ 'exception' => $this ], $data );
+	}
+
 	public function getData() {
 		return $this->data;
 	}
@@ -33,13 +43,13 @@ class Exception extends \Exception
 class ClientException extends Exception
 {
 	protected function logMe() {
-		$this->error( 'HELIOS_CLIENT client_exception' , [ 'exception' => $this, 'context' => $this->getData() ] );
+		$this->error( 'HELIOS_CLIENT client_exception' );
 	}
 }
 
 class LoginFailureException extends Exception
 {
 	protected function logMe() {
-		$this->info( 'HELIOS_CLIENT login_failure' , [ 'exception' => $this, 'context' => $this->getData() ] );
+		$this->info( 'HELIOS_CLIENT login_failure' );
 	}
 }

--- a/extensions/wikia/Helios/Exceptions.php
+++ b/extensions/wikia/Helios/Exceptions.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Wikia\Helios;
+
+/**
+ * An exception class for the client.
+ */
+class Exception extends \Exception
+{
+	use \Wikia\Logger\Loggable;
+
+	private $data;
+
+	public function __construct( $message = null, $code = 0, \Exception $previous = null, $data = null ) {
+		parent::__construct( $message, $code, $previous );
+		$this->data = $data;
+		$this->logMe();
+	}
+
+	public function getData() {
+		return $this->data;
+	}
+
+	public function getResponse() {
+		return !empty($this->data) && !empty($this->data['response']) ? $this->data['response'] : null;
+	}
+
+	protected function logMe() {
+		// noop
+	}
+}
+
+class ClientException extends Exception
+{
+	protected function logMe() {
+		$this->error( 'HELIOS_CLIENT client_exception' , [ 'exception' => $this, 'context' => $this->getData() ] );
+	}
+}
+
+class LoginFailureException extends Exception
+{
+	protected function logMe() {
+		$this->info( 'HELIOS_CLIENT login_failure' , [ 'exception' => $this, 'context' => $this->getData() ] );
+	}
+}

--- a/extensions/wikia/Helios/Helios.i18n.php
+++ b/extensions/wikia/Helios/Helios.i18n.php
@@ -6,12 +6,14 @@ $messages = [];
  * Message documentation.
  */
 $messages['qqq'] = [
-    'helios-desc' => 'Helios extension to support authorization against a separate OAuth2 service.',
+	'helios-desc' => 'Helios extension to support authorization against a separate OAuth2 service.',
+	'login-abort-service-unavailable' => 'Message shown to the user trying to log-in when we cannot contact authentication service.',
 ];
 
 /**
  * English.
  */
 $messages['en'] = [
-    'helios-desc' => 'OAuth2 authorization in ExternalUser',
+	'helios-desc' => 'OAuth2 authorization in ExternalUser',
+	'login-abort-service-unavailable' => 'Login is temporarily unavailable. Please try again later.',
 ];

--- a/extensions/wikia/Helios/Helios.setup.php
+++ b/extensions/wikia/Helios/Helios.setup.php
@@ -21,3 +21,12 @@ $wgAutoloadClasses["Wikia\\Helios\\HelperController"] = __DIR__ . "/HelperContro
  * Internationalisation.
  */
 $wgExtensionMessagesFiles['Helios'] = __DIR__ . '/Helios.i18n.php';
+
+/**
+ * Hooks
+ */
+$wgHooks['UserCheckPassword'][] = 'Wikia\\Helios\\User::onUserCheckPassword';
+$wgHooks['ExternalUserWikiaAuthenticate'][] = 'Wikia\\Helios\\User::onUserCheckPassword';
+
+$wgHooks['UserSaveSettings'][] = 'Wikia\\Helios\\User::onUserSave';
+$wgHooks['UserSaveOptions'][] = 'Wikia\\Helios\\User::onUserSave';

--- a/extensions/wikia/Helios/Helios.setup.php
+++ b/extensions/wikia/Helios/Helios.setup.php
@@ -17,6 +17,10 @@ $wgAutoloadClasses["Wikia\\Helios\\Client"] = __DIR__ . "/Client.class.php";
 $wgAutoloadClasses["Wikia\\Helios\\SampleController"] = __DIR__ . "/SampleController.class.php";
 $wgAutoloadClasses["Wikia\\Helios\\HelperController"] = __DIR__ . "/HelperController.class.php";
 
+$wgAutoloadClasses["Wikia\\Helios\\Exception"]   = __DIR__ . "/Exceptions.php";
+$wgAutoloadClasses["Wikia\\Helios\\ClientException"]   = __DIR__ . "/Exceptions.php";
+$wgAutoloadClasses["Wikia\\Helios\\LoginFailureException"]   = __DIR__ . "/Exceptions.php";
+
 /**
  * Internationalisation.
  */

--- a/extensions/wikia/Helios/User.class.php
+++ b/extensions/wikia/Helios/User.class.php
@@ -156,7 +156,7 @@ class User {
 			$mediawikiResult = \User::comparePasswords( $hash, $password, $id );
 
 			// Detect discrepancies between Helios and MediaWiki results.
-			if ( $result != $mediawikiResult ) {
+			if ( $heliosResult != $mediawikiResult ) {
 				\Wikia\Helios\User::debugLogin( $password, __METHOD__ );
 				\Wikia\Logger\WikiaLogger::instance()->error(
 					'HELIOS_LOGIN check_password_discrepancy',

--- a/extensions/wikia/Helios/User.class.php
+++ b/extensions/wikia/Helios/User.class.php
@@ -105,7 +105,6 @@ class User {
 				'HELIOS_LOGIN authentication_failed',
 				[ 'response' => $e->getResponse(), 'username' => $username, 'method' => __METHOD__ ]
 			);
-			$result = false;
 		}
 		catch ( ClientException $e )
 		{
@@ -160,7 +159,7 @@ class User {
 		$heliosResult = null;
 		$heliosException = null;
 		try {
-			$heliosResult = \Wikia\Helios\User::authenticate( $username, $password );
+			$heliosResult = self::authenticate( $username, $password );
 		}
 		catch ( ClientException $e )
 		{
@@ -173,7 +172,7 @@ class User {
 
 			// Detect discrepancies between Helios and MediaWiki results.
 			if ( $heliosResult !== null && $heliosResult != $mediawikiResult ) {
-				\Wikia\Helios\User::debugLogin( $password, __METHOD__ );
+				self::debugLogin( $password, __METHOD__ );
 				\Wikia\Logger\WikiaLogger::instance()->error(
 					'HELIOS_LOGIN check_password_discrepancy',
 					[	'helios'         => $heliosResult,
@@ -186,9 +185,9 @@ class User {
 			$result = $mediawikiResult;
 		} else { // pure-Helios mode
 			if ( $heliosException ) {
-
 				$errorMessageKey = 'login-abort-service-unavailable';
 			}
+
 			$result = $heliosResult;
 		}
 

--- a/extensions/wikia/Helios/User.class.php
+++ b/extensions/wikia/Helios/User.class.php
@@ -7,6 +7,8 @@ namespace Wikia\Helios;
  */
 class User {
 
+	private static $authenticationCache = [];
+
 	/**
 	 * Logs character encoding data for the given password.
 	 */
@@ -61,17 +63,24 @@ class User {
 	}
 
 	/**
-	 * Called in ExternalUser_Wikia::authenticate() authenticates a user.
+	 * Uses Helios to authenticate user credentials.
+	 *
+	 * Due to MediaWiki flow during authentication results are cached within the request
+	 * to prevent spamming Helios backend with the same calls.
 	 *
 	 * @param string &$username string of the user name
 	 * @param string &$password string of the plaintext password the user entered
 	 *
 	 * @return boolean true on success, false otherwise
 	 */
-	public static function authenticate( $username, $password )
-	{
+	public static function authenticate( $username, $password ) {
+		// check the local cache
+		if ( @self::$authenticationCache[$username][$password] !== null ) {
+			return self::$authenticationCache[$username][$password];
+		}
+
 		$logger = \Wikia\Logger\WikiaLogger::instance();
-		$logger->info( 'HELIOS_LOGIN', [ 'method' => __METHOD__, 'username' => $username ] );
+		$logger->info( 'HELIOS_LOGIN authenticate', [ 'method' => __METHOD__, 'username' => $username ] );
 
 		self::debugLogin( $password, __METHOD__ );
 
@@ -84,23 +93,98 @@ class User {
 			$result = !empty( $loginInfo->access_token );
 	
 			if ( !empty( $loginInfo->error ) ) {
-				$logger->error(
-					'HELIOS_LOGIN',
-					[ 'response' => $loginInfo, 'username' => $username, 'method' => __METHOD__ ]
-				);
+				if ( $loginInfo->error === "access_denied" ) {
+					// normal case: password incorrect, log it as info
+					$logger->info(
+						'HELIOS_LOGIN access_denied',
+						[ 'response' => $loginInfo, 'username' => $username, 'method' => __METHOD__ ]
+					);
+				} else {
+					$logger->error(
+						'HELIOS_LOGIN response_error',
+						[ 'response' => $loginInfo, 'username' => $username, 'method' => __METHOD__ ]
+					);
+				}
 				$result = false;
 			}
 		}
 
 		catch ( \Wikia\Helios\ClientException $e ) {
 			$logger->error(
-				'HELIOS_LOGIN',
+				'HELIOS_LOGIN client_exception',
 				[ 'exception' => $e, 'username' => $username, 'method' => __METHOD__ ]
 			);
 			$result = false;
 		}
 
+		// save in local cache
+		self::$authenticationCache[$username][$password] = $result;
+
 		return $result;
+	}
+
+	/**
+	 * Purge the authentication cache. If the username is specified only that username is affected.
+	 *
+	 * @param string $username (optional) Username
+	 */
+	public static function purgeAuthenticationCache( $username = null ) {
+		if ( $username === null ) {
+			self::$authenticationCache = [];
+		} else {
+			unset( self::$authenticationCache[$username] );
+		}
+	}
+
+
+	/**
+	 * Listens for any authentication attempts and uses Helios to determine the result
+	 *
+	 * @param int $id Id
+	 * @param string $username Username
+	 * @param string $hash Password hash
+	 * @param string $password Password
+	 * @param bool &$result Authentication result
+	 * @return bool true - hook handler
+	 */
+	public static function onUserCheckPassword( $id, $username, $hash, $password, &$result ) {
+		global $wgHeliosLoginShadowMode;
+		$heliosResult = \Wikia\Helios\User::authenticate( $username, $password );
+
+		// If we are in shadow mode calculate mediawiki response and log comparison result
+		if ( $wgHeliosLoginShadowMode ) {
+			$mediawikiResult = \User::comparePasswords( $hash, $password, $id );
+
+			// Detect discrepancies between Helios and MediaWiki results.
+			if ( $result != $mediawikiResult ) {
+				\Wikia\Helios\User::debugLogin( $password, __METHOD__ );
+				\Wikia\Logger\WikiaLogger::instance()->error(
+					'HELIOS_LOGIN check_password_discrepancy',
+					[	'helios'         => $heliosResult,
+						'mediawiki'      => $mediawikiResult,
+						'user_id'        => $id,
+						'username'       => $username ]
+				);
+			}
+
+			$result = $mediawikiResult;
+		} else { // pure-Helios mode
+			$result = $heliosResult;
+		}
+
+		return true;
+	}
+
+
+	/**
+	 * Listens for any user data save events and purges the authentication cache
+	 *
+	 * @param \User $user User
+	 * @return bool true - hook handler
+	 */
+	public static function onUserSave( \User $user ) {
+		self::purgeAuthenticationCache( $user->getName() );
+		return true;
 	}
 
 }

--- a/extensions/wikia/Helios/tests/UserTest.php
+++ b/extensions/wikia/Helios/tests/UserTest.php
@@ -95,6 +95,7 @@ class UserTest extends \WikiaBaseTest {
 
 	public function testAuthenticateAuthenticationImpossible()
 	{
+		$this->setExpectedException('Wikia\Helios\ClientException','test');
 		$username = 'SomeName';
 		$password = 'Password';
 
@@ -102,10 +103,10 @@ class UserTest extends \WikiaBaseTest {
 		$client->expects( $this->once() )
 			->method( 'login' )
 			->with( $username, $password )
-			->will( $this->throwException( new ClientException ) );
+			->will( $this->throwException( new ClientException( 'test' ) ) );
 		$this->mockClass( 'Wikia\Helios\Client', $client );
 
-		$this->assertFalse( User::authenticate( $username, $password ) );
+		User::authenticate( $username, $password );
 	}
 
 	public function testAuthenticateAuthenticationSucceded()

--- a/extensions/wikia/Helios/tests/UserTest.php
+++ b/extensions/wikia/Helios/tests/UserTest.php
@@ -12,6 +12,8 @@ class UserTest extends \WikiaBaseTest {
 		$this->webRequestMock = $this->getMock( '\WebRequest', [ 'getHeader' ], [], '', false );
 		$this->mockGlobalVariable( 'wgHeliosLoginSamplingRate', 100 );
 		$this->mockGlobalVariable( 'wgHeliosLoginShadowMode', false );
+		User::purgeAuthenticationCache();
+
 		parent::setUp();
 	}
 

--- a/extensions/wikia/UserLogin/UserLoginSpecialController.class.php
+++ b/extensions/wikia/UserLogin/UserLoginSpecialController.class.php
@@ -529,6 +529,10 @@ class UserLoginSpecialController extends WikiaSpecialPageController {
 				$this->result = 'error';
 				$this->msg = wfMessage( 'userlogin-error-login-userblocked' )->escaped();
 				break;
+			case LoginForm::ABORTED:
+				$this->result = 'error';
+				$this->msg = wfMessage( $loginForm->mAbortLoginErrorMsg )->escaped();
+				break;
 			default:
 				throw new MWException( "Unhandled case value" );
 		}

--- a/extensions/wikia/WikiaApi/WikiaApiAjaxLogin.php
+++ b/extensions/wikia/WikiaApi/WikiaApiAjaxLogin.php
@@ -96,6 +96,10 @@ class WikiaApiAjaxLogin extends ApiBase {
 					$result['result'] = 'Throttled';
 					$result['text'] = wfMsg('login-throttled');
 					break;
+				case LoginForm :: ABORTED :
+					$result['result'] = 'Aborted';
+					$result['text'] = wfMsg($loginForm->mAbortLoginErrorMsg);
+					break;
 				default :
 					ApiBase :: dieDebug(__METHOD__, "Unhandled case value: \"$caseCode\"");
 			}

--- a/includes/User.php
+++ b/includes/User.php
@@ -3382,6 +3382,15 @@ class User {
 			return false;
 		}
 
+		// Wikia change - begin - @author: wladek
+		// Helios integration
+		$result = null;
+		wfRunHooks( 'UserCheckPassword', [ $this->mId, $this->mName, $this->mPassword, $password, &$result ] );
+		if ( $result !== null ) {
+			return $result;
+		}
+		// Wikia change - end
+
 		if( $wgAuth->authenticate( $this->getName(), $password ) ) {
 			return true;
 		} elseif( $wgAuth->strict() ) {

--- a/includes/User.php
+++ b/includes/User.php
@@ -3369,7 +3369,7 @@ class User {
 	 * @param $password String: user password.
 	 * @return Boolean: True if the given password is correct, otherwise False.
 	 */
-	public function checkPassword( $password ) {
+	public function checkPassword( $password, &$errorMessageKey = null ) {
 		global $wgAuth, $wgLegacyEncoding;
 		$this->load();
 
@@ -3385,7 +3385,7 @@ class User {
 		// Wikia change - begin - @author: wladek
 		// Helios integration
 		$result = null;
-		wfRunHooks( 'UserCheckPassword', [ $this->mId, $this->mName, $this->mPassword, $password, &$result ] );
+		wfRunHooks( 'UserCheckPassword', [ $this->mId, $this->mName, $this->mPassword, $password, &$result, &$errorMessageKey ] );
 		if ( $result !== null ) {
 			return $result;
 		}

--- a/includes/specials/SpecialUserlogin.php
+++ b/includes/specials/SpecialUserlogin.php
@@ -627,14 +627,6 @@ class LoginForm extends SpecialPage {
 			return self::NO_NAME;
 		}
 
-		// Wikia change - begin - author: @wladek
-		// Don't bother going down the road if the password is invalid. Exit early.
-		if( !$this->getUser()->isValidPassword( $this->mPassword ) ) {
-			return ( $this->mPassword  == '' ) ? self::EMPTY_PASS : self::WRONG_PASS;
-		}
-		// Wikia change - end
-
-
 		// We require a login token to prevent login CSRF
 		// Handle part of this before incrementing the throttle so
 		// token-less login attempts don't count towards the throttle

--- a/includes/specials/SpecialUserlogin.php
+++ b/includes/specials/SpecialUserlogin.php
@@ -627,6 +627,14 @@ class LoginForm extends SpecialPage {
 			return self::NO_NAME;
 		}
 
+		// Wikia change - begin - author: @wladek
+		// Don't bother going down the road if the password is invalid. Exit early.
+		if( !$this->getUser()->isValidPassword( $this->mPassword ) ) {
+			return ( $this->mPassword  == '' ) ? self::EMPTY_PASS : self::WRONG_PASS;
+		}
+		// Wikia change - end
+
+
 		// We require a login token to prevent login CSRF
 		// Handle part of this before incrementing the throttle so
 		// token-less login attempts don't count towards the throttle

--- a/includes/wikia/ExternalUser_Wikia.php
+++ b/includes/wikia/ExternalUser_Wikia.php
@@ -198,42 +198,15 @@ class ExternalUser_Wikia extends ExternalUser {
 		return $this->mRow->user_birthdate;
 	}
 
-	public function authenticate( $sPassword ) {
-		// Authenticate with Helios if enabled.
-		global $wgEnableHeliosExt;
-		if ( $wgEnableHeliosExt ) {
-			$bHeliosResult = \Wikia\Helios\User::authenticate( $this->getName(), $sPassword );
+	public function authenticate( $password ) {
+		$result = null;
 
-			// Terminate unless in the shadow mode.
-			global $wgHeliosLoginShadowMode;
-			if ( !$wgHeliosLoginShadowMode ) {
-				return $bHeliosResult;
-			}
+		wfRunHooks( 'UserCheckPassword', [ $this->getId(), $this->getName(), $this->getPassword(), $password, &$result ] );
+		if ( $result === null ) {
+			$result = User::comparePasswords( $this->getPassword(), $password, $this->getId() );
 		}
 
-		// Authenticate with MediaWiki.
-		$bMediaWikiResult = User::comparePasswords( $this->getPassword(), $sPassword, $this->getId() );
-		// Detect discrepancies between Helios and MediaWiki results.
-		if ( $wgEnableHeliosExt && (  $bHeliosResult != $bMediaWikiResult ) ) {
-			
-			$sMWHashFirst  = substr( $this->getPassword(), 0, 3 ); // The first three bytes.
-			$sMWHashLast   = substr( $this->getPassword(),   -3 ); // The last three bytes.
-			$sMWHashLength = strlen( $this->getPassword() );       // The byte-length
-
-			\Wikia\Helios\User::debugLogin( $sPassword, __METHOD__ );
-			\Wikia\Logger\WikiaLogger::instance()->error(
-				'HELIOS_LOGIN',
-				[ 'helios'         => $bHeliosResult,
-				  'mediawiki'      => $bMediaWikiResult,
-				  'user_id'        => $this->getId(),
-				  'username'       => $this->getName(),
-				  'mw_hash_first'  => $sMWHashFirst,
-				  'mw_hash_last'   => $sMWHashLast,
-				  'mw_hash_length' => $sMWHashLength ]
-			);
-		}
-
-		return $bMediaWikiResult;
+		return $result;
 	}
 
 	public function getPref( $pref ) {


### PR DESCRIPTION
This changeset aims to replace all comparisons of the user's main password and delegate it to Helios (temporary password comparison is still left up to MediaWiki). We'll then have a single source of truth for authentication.

Work in progress.

/cc @michalroszka 
