### PR TITLE
PLATFORM-981: Get rid of wfDBLightMode

### DIFF
--- a/extensions/wikia/CreateNewWiki/CreateWiki.php
+++ b/extensions/wikia/CreateNewWiki/CreateWiki.php
@@ -35,7 +35,6 @@ class CreateWiki {
 	const ERROR_DATABASE_WRITE_TO_CITY_DOMAINS_BROKEN  = 11;
 	const ERROR_USER_IN_ANON                           = 12;
 	const ERROR_READONLY                               = 13;
-	const ERROR_DBLIGHTMODE                            = 14;
 	const ERROR_DATABASE_WRITE_TO_CITY_LIST_BROKEN     = 15;
 
 	const IMGROOT              = "/images/";
@@ -165,11 +164,6 @@ class CreateWiki {
 		if ( wfReadOnly() ) {
 			wfProfileOut( __METHOD__ );
 			throw new CreateWikiException('DB is read only', self::ERROR_READONLY);
-		}
-
-		if ( wfIsDBLightMode() ) {
-			wfProfileOut( __METHOD__ );
-			throw new CreateWikiException('DB is in light mode', self::ERROR_DBLIGHTMODE);
 		}
 
 		// check founder

--- a/includes/wikia/GlobalFunctions.php
+++ b/includes/wikia/GlobalFunctions.php
@@ -1304,34 +1304,6 @@ if (!function_exists('http_build_url')) {
 }
 
 /**
- * Sleep until wgDBLightMode is enable. This variable is used to disable (sleep) all
- * maintanance scripts while something is wrong with performance
- *
- * @author Piotr Molski (moli) <moli at wikia-inc.com>
- * @param int $maxSleep
- * @return null
- */
-function wfDBLightMode( $maxSleep ) {
-	global $wgExternalSharedDB;
-
-	if ( !$maxSleep ) return false;
-
-	while ( WikiFactory::getVarValueByName( 'wgDBLightMode', WikiFactory::DBToId( $wgExternalSharedDB ) ) ) {
-		Wikia::log( __METHOD__, "info", "All crons works in DBLightMode ( sleep $maxSleep ) ..." );
-		sleep($maxSleep);
-	}
-
-	return true;
-}
-
-function wfIsDBLightMode() {
-	global $wgExternalSharedDB;
-
-	$dbLightMode = WikiFactory::getVarValueByName( 'wgDBLightMode', WikiFactory::DBToId( $wgExternalSharedDB ) );
-	return (bool) $dbLightMode;
-}
-
-/**
  * return status code if the last failure was due to the database being read-only.
  *
  * @author Piotr Molski (moli) <moli at wikia-inc.com>

--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -21,7 +21,6 @@ $wgHooks['SetupAfterCache']          [] = "Wikia::setupAfterCache";
 $wgHooks['ComposeMail']              [] = "Wikia::ComposeMail";
 $wgHooks['SoftwareInfo']             [] = "Wikia::softwareInfo";
 $wgHooks['AddNewAccount']            [] = "Wikia::ignoreUser";
-$wgHooks['WikiFactory::execute']     [] = "Wikia::switchDBToLightMode";
 $wgHooks['ComposeMail']              [] = "Wikia::isUnsubscribed";
 $wgHooks['AllowNotifyOnPageChange']  [] = "Wikia::allowNotifyOnPageChange";
 $wgHooks['AfterInitialize']          [] = "Wikia::onAfterInitialize";
@@ -1285,25 +1284,6 @@ class Wikia {
 
 		wfProfileOut( __METHOD__ );
 		return $params;
-	}
-
-
-	/**
-	 * Sleep until wgDBLightMode is enable. This variable is used to disable (sleep) all
-	 * maintanance scripts while something is wrong with performance
-	 *
-	 * @static
-	 * @author Piotr Molski (moli) <moli at wikia-inc.com>
-	 * @param int $maxSleep
-	 * @return null
-	 */
-	static function switchDBToLightMode( $WFLoader ) {
-		// commandline scripts only
-		if ( $WFLoader->mCommandLine ) {
-			// switch db to light mode
-			wfDBLightMode(60);
-		}
-		return true;
 	}
 
 	static public function getAllHeaders() {


### PR DESCRIPTION
It's not being used often and is unreliable (features have to use it explicitly)

Additionally, it was making 2.5mm queries daily (that returns zero rows + no caching) - 22% of all queries hitting shared DB from task / cron machines.

``` sql
SELECT /* WikiFactory::getWikiByDB  */  *  FROM `city_list`  WHERE city_dbname = 'wikicities'  LIMIT 1
```

@owend / @wladekb / @drozdo 
