### PR TITLE
Fixes after switching to mysqli

### DIFF
--- a/extensions/wikia/CityVisualization/models/CityVisualization.class.php
+++ b/extensions/wikia/CityVisualization/models/CityVisualization.class.php
@@ -854,7 +854,7 @@ class CityVisualization extends WikiaModel {
 		$db = wfGetDB(DB_SLAVE, array(), $this->wg->ExternalSharedDB);
 		$table = $this->getTablesForStaffTool($opt);
 		$fields = array('count( ' . self::CITY_VISUALIZATION_TABLE_NAME . '.city_id ) as count');
-		$conds = $this->getConditionsForStaffTool($opt);
+		$conds = $this->getConditionsForStaffTool($opt, $db);
 		$options = $this->getOptionsForStaffTool($opt);
 		$joinConds = $this->getJoinsForStaffTool($opt);
 
@@ -875,7 +875,7 @@ class CityVisualization extends WikiaModel {
 			'city_list.city_title',
 			self::CITY_VISUALIZATION_TABLE_NAME . '.city_flags',
 		);
-		$conds = $this->getConditionsForStaffTool($opt);
+		$conds = $this->getConditionsForStaffTool($opt, $db);
 		$options = $this->getOptionsForStaffTool($opt);
 		$joinConds = $this->getJoinsForStaffTool($opt);
 
@@ -906,7 +906,7 @@ class CityVisualization extends WikiaModel {
 		return $joinConds;
 	}
 
-	protected function getConditionsForStaffTool($options) {
+	protected function getConditionsForStaffTool($options, DatabaseBase $db) {
 		$sqlOptions = array();
 
 		if( isset($options->lang) ) {
@@ -914,7 +914,7 @@ class CityVisualization extends WikiaModel {
 		}
 
 		if( !empty($options->wikiHeadline) ) {
-			$sqlOptions[] = 'city_list.city_title like "%' . mysql_real_escape_string($options->wikiHeadline) . '%"';
+			$sqlOptions[] = 'city_list.city_title like "%' . $db->strencode($options->wikiHeadline) . '%"';
 		}
 
 		if ( !empty($options->verticalId) ) {

--- a/extensions/wikia/VideoHandlers/feedingesters/VideoFeedIngester.class.php
+++ b/extensions/wikia/VideoHandlers/feedingesters/VideoFeedIngester.class.php
@@ -518,12 +518,11 @@ abstract class VideoFeedIngester {
 			'city_variables_pool',
 			'city_list',
 		];
-		$varName = mysql_real_escape_string( self::WIKI_INGESTION_DATA_VARNAME );
 		$aWhere = [ 'city_id = cv_city_id', 'cv_id = cv_variable_id' ];
 
 		$aWhere[] = "cv_value is not null";
 
-		$aWhere[] = "cv_name = '$varName'";
+		$aWhere['cv_name'] = self::WIKI_INGESTION_DATA_VARNAME;
 
 
 		$oRes = $dbr->select(

--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -3146,7 +3146,7 @@ class WikiFactory {
 		$selectedVal = serialize( $val );
 		$aTables = array( 'city_variables', 'city_list' );
 		$aWhere = array(
-			'city_id' => cv_city_id,
+			'city_id = cv_city_id',
 			'cv_variable_id' => $varId,
 		);
 

--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -3086,7 +3086,7 @@ class WikiFactory {
 			'city_variables',
 			'city_list',
 		);
-		$varId = intval($varId);
+		$varId = mysql_real_escape_string($varId);
 		$aWhere = array('city_id = cv_city_id');
 
 		$aOptions = array( 'ORDER BY' => 'city_title ASC' );

--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -3145,10 +3145,9 @@ class WikiFactory {
 
 		$selectedVal = serialize( $val );
 		$aTables = array( 'city_variables', 'city_list' );
-		$varId = mysql_real_escape_string( $varId );
 		$aWhere = array(
-			'city_id = cv_city_id',
-			"cv_variable_id = '$varId'"
+			'city_id' => cv_city_id,
+			'cv_variable_id' => $varId,
 		);
 
 		if ( 'full' == $type ) {

--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -3086,7 +3086,6 @@ class WikiFactory {
 			'city_variables',
 			'city_list',
 		);
-		$varId = mysql_real_escape_string($varId);
 		$aWhere = array('city_id = cv_city_id');
 
 		$aOptions = array( 'ORDER BY' => 'city_title ASC' );
@@ -3105,7 +3104,7 @@ class WikiFactory {
 			$aWhere[] = "cv_value $selectedCond '$selectedVal'";
 		}
 
-		$aWhere[] = "cv_variable_id = '$varId'";
+		$aWhere['cv_variable_id'] = $varId;
 
 
 		$oRes = $dbr->select(

--- a/extensions/wikia/hacks/BatchVarnishPurgeTool/BatchVarnishPurgeToolController.class.php
+++ b/extensions/wikia/hacks/BatchVarnishPurgeTool/BatchVarnishPurgeToolController.class.php
@@ -85,7 +85,6 @@ class BatchVarnishPurgeToolController extends WikiaSpecialPageController {
 			'city_variables',
 			'city_list'
 		);
-		$varId = mysql_real_escape_string($varId);
 		$aWhere = array('city_id = cv_city_id');
 		
 		if( $type == "full" ) {
@@ -94,7 +93,7 @@ class BatchVarnishPurgeToolController extends WikiaSpecialPageController {
 			$aWhere[] = "cv_value $selectedCond '$selectedVal'";
 		}
 		
-		$aWhere[] = "cv_variable_id = '$varId'";
+		$aWhere['cv_variable_id'] = $varId;
 
 		$oRes = $dbr->select(
 			$aTables,


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-982

After moving from `mysql` to `mysqli` PHP extension (#6401) `mysql_*` functions do not work anymore. For instance [`mysql_real_escape_string`](http://pl1.php.net/manual/en/function.mysql-real-escape-string.php#refsect1-function.mysql-real-escape-string-notes) will now return false, because there's no active DB connection created by `mysql` extension. Use MW build-in escaping features instead of calling these functions directly.

@wladekb / @michalroszka / @bognix 
