### PR TITLE
LoadMonitor_MySQL: cache lag times globally instead of per-wiki

### DIFF
--- a/includes/db/LoadMonitor.php
+++ b/includes/db/LoadMonitor.php
@@ -124,7 +124,7 @@ class LoadMonitor_MySQL implements LoadMonitor {
 			$wgMemc = wfGetMainCache();
 
 		$masterName = $this->parent->getServerName( 0 );
-		$memcKey = wfMemcKey( 'db', 'lag_times', $masterName );
+		$memcKey = wfSharedMemcKey( 'db', 'lag_times', $masterName ); // Wikia change - PLATFORM-983
 		$times = $wgMemc->get( $memcKey );
 		if ( $times ) {
 			# Randomly recache with probability rising over $expiry


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-983

Cache lag times globally instead of per-wiki.

This should increase hit ratio on these memcache keys and get rid of most of `SHOW SLAVE STATUS` queries (10% of all that hit shared DB).

``` sql
site> select bucket, key, sum from Mediawiki_App_Memcache_Keys_Stats_60m where time > now() - 2h and key =~ /lag_times/ and bucket =~ /miss|hit/
┌─────────────────┬─────────────────┬────────┬────────────────────────────────┬───────┐
│       time      │ sequence_number │ bucket │ key                            │ sum   │
├─────────────────┼─────────────────┼────────┼────────────────────────────────┼───────┤
│ 6/3/15 11:00:00 │ 48              │ miss   │ *:*:lag_times:statsdb-s9       │ 413   │
│ 6/3/15 11:00:00 │ 47              │ hit    │ *:*:lag_times:statsdb-s9       │ 334   │
│ 6/3/15 11:00:00 │ 45              │ miss   │ *:*:lag_times:sharedb-s3       │ 7427  │
│ 6/3/15 11:00:00 │ 44              │ hit    │ *:*:lag_times:sharedb-s3       │ 22812 │
└─────────────────┴─────────────────┴────────┴────────────────────────────────┴───────┘
Query took  1603 ms
```

@wladekb / @michalroszka / @drozdo 
