### PR TITLE
(CE-1411) Escape alt attribute for thumbnails

### DIFF
--- a/extensions/wikia/Thumbnails/templates/Thumbnail_imgTag.mustache
+++ b/extensions/wikia/Thumbnails/templates/Thumbnail_imgTag.mustache
@@ -1,5 +1,5 @@
 <img src="{{imgSrc}}"
-	{{#alt}} alt="{{{alt}}}" {{/alt}}
+	{{#alt}} alt="{{alt}}" {{/alt}}
 	class="{{#imgClass}}{{.}} {{/imgClass}}"
 	{{#style}} style="{{style}}" {{/style}}
 	data-{{mediaType}}-key="{{mediaKey}}"


### PR DESCRIPTION
Escape alt attribute for thumbnails as it is user controlled and causes
an XSS vulnerability. The attribute used to be escaped in the controller
but that was removed while leaving it unescaped in the template (where the
escaping should occur).

/cc @bognix 
