### PR TITLE
(CE-1349) Remove double escaping on title attribute of thumbnails

### DIFF
--- a/extensions/wikia/Thumbnails/ThumbnailHelper.class.php
+++ b/extensions/wikia/Thumbnails/ThumbnailHelper.class.php
@@ -150,7 +150,7 @@ class ThumbnailHelper extends WikiaModel {
 		if ( !empty( $options['custom-url-link'] ) ) {
 			$href = $options['custom-url-link'];
 			if ( !empty( $options['title'] ) ) {
-				$title = Sanitizer::encodeAttribute( $options['title'] );
+				$title = $options['title'];
 			}
 			if ( !empty( $options['custom-target-link'] ) ) {
 				$target = $options['custom-target-link'];
@@ -160,14 +160,12 @@ class ThumbnailHelper extends WikiaModel {
 			/** @var Title $title */
 			$titleObj = $options['custom-title-link'];
 			$href = $titleObj->getLinkURL();
-			$title = Sanitizer::encodeAttribute(
-				empty( $options['title'] ) ? $titleObj->getFullText() : $options['title']
-			);
+			$title = empty( $options['title'] ) ? $titleObj->getFullText() : $options['title'];
 
 		} elseif ( !empty( $options['desc-link'] ) ) {
 			$href = self::getContextualFileUrl( $thumb );
 			if ( !empty( $options['title'] ) ) {
-				$title = Sanitizer::encodeAttribute( $options['title'] );
+				$title = $options['title'];
 			}
 
 		} elseif ( !empty( $options['file-link'] ) ) {


### PR DESCRIPTION
The title attribute of thumbnails was moved to be escaped in the template
(where the escaping should happen) in:
https://github.com/Wikia/app/commit/c668ed3283063a#diff-2

But, since it was already being escaped in the helper, it was being double
escaped leading to the title displaying the HTML entities to users.
