### PR TITLE
(SOC-469) Only run this hook if Wall is enabled

### DIFF
--- a/extensions/wikia/Wall/WallHooksHelper.class.php
+++ b/extensions/wikia/Wall/WallHooksHelper.class.php
@@ -1,5 +1,12 @@
 <?php
 
+/**
+ * Hooks for Message Wall.
+ *
+ * All of these hooks will be executed when Forums are enabled
+ * even if Message Wall is disabled, so appropriate checks are
+ * needed if the hook should only take effect if Wall is enabled.
+ */
 class WallHooksHelper {
 	const RC_WALL_COMMENTS_MAX_LEN = 50;
 	const RC_WALL_SECURENAME_PREFIX = 'WallMessage_';
@@ -2218,8 +2225,7 @@ class WallHooksHelper {
 	 * @return bool
 	 */
 	public static function onGetTalkPage( Title $title, Title &$talkPageTitle ) {
-		global $wgEnableWallExt;
-		if ( !empty( $wgEnableWallExt )
+		if ( !empty( F::app()->wg->EnableWallExt )
 			&& !$title->isSubpage()
 			&& $title->getNamespace() == NS_USER
 		) {

--- a/extensions/wikia/Wall/WallHooksHelper.class.php
+++ b/extensions/wikia/Wall/WallHooksHelper.class.php
@@ -2218,7 +2218,11 @@ class WallHooksHelper {
 	 * @return bool
 	 */
 	public static function onGetTalkPage( Title $title, Title &$talkPageTitle ) {
-		if ( !$title->isSubpage() && $title->getNamespace() == NS_USER ) {
+		global $wgEnableWallExt;
+		if ( !empty( $wgEnableWallExt )
+			&& !$title->isSubpage()
+			&& $title->getNamespace() == NS_USER
+		) {
 			$talkPageTitle = Title::makeTitle( NS_USER_WALL, $title->getDBkey() );
 		}
 


### PR DESCRIPTION
Message Wall and Forum are intertwined right now so that if Forum is
enabled but Wall is disabled, then Message Wall's setup file and hooks
are still loaded, so we need this check in the hook method after all
as a quick fix...

/cc @jsutterfield @lizlux 
