### PR TITLE
CE-1283 Add new 'poweruser' group for better tracking

### DIFF
--- a/extensions/wikia/PowerUser/PowerUser.class.php
+++ b/extensions/wikia/PowerUser/PowerUser.class.php
@@ -139,8 +139,8 @@ class PowerUser {
 	public function addPowerUserAddGroup( $sProperty ) {
 		if ( in_array( $sProperty, self::$aPowerUsersRightsMapping ) ) {
 			if ( !in_array( self::GROUP_NAME, $this->oUser->getGroups() ) ) {
-				$this->oUser->addGroup(self::GROUP_NAME);
-				$this->logSuccess($sProperty, self::ACTION_ADD_GROUP);
+				$this->oUser->addGroup( self::GROUP_NAME );
+				$this->logSuccess( $sProperty, self::ACTION_ADD_GROUP );
 			}
 			return true;
 		} else {
@@ -169,9 +169,9 @@ class PowerUser {
 	public function removePowerUserSetOption( $sProperty ) {
 		if ( in_array( $sProperty, self::$aPowerUserProperties ) ) {
 			if ( $this->oUser->getBoolOption( $sProperty ) === true ) {
-				$this->oUser->setOption($sProperty, null);
+				$this->oUser->setOption( $sProperty, null );
 				$this->oUser->saveSettings();
-				$this->logSuccess($sProperty, self::ACTION_REMOVE_SET_OPTION);
+				$this->logSuccess( $sProperty, self::ACTION_REMOVE_SET_OPTION );
 			}
 			return true;
 		} else {
@@ -191,8 +191,8 @@ class PowerUser {
 	public function removePowerUserRemoveGroup( $sProperty ) {
 		if ( in_array( $sProperty, self::$aPowerUsersRightsMapping ) ) {
 			if ( $this->isGroupForRemoval( $sProperty ) ) {
-				$this->oUser->removeGroup(self::GROUP_NAME);
-				$this->logSuccess($sProperty, self::ACTION_REMOVE_GROUP);
+				$this->oUser->removeGroup( self::GROUP_NAME );
+				$this->logSuccess( $sProperty, self::ACTION_REMOVE_GROUP );
 			}
 			return true;
 		} else {

--- a/extensions/wikia/PowerUser/PowerUser.class.php
+++ b/extensions/wikia/PowerUser/PowerUser.class.php
@@ -107,8 +107,8 @@ class PowerUser {
 	 * @return bool
 	 */
 	public function addPowerUserProperty( $sProperty ) {
-		return ( $this->addPowerUserSetOption( $sProperty ) &&
-			$this->addPowerUserAddGroup( $sProperty ) );
+		return ( $this->addPowerUserSetOption( $sProperty )
+			&& $this->addPowerUserAddGroup( $sProperty ) );
 	}
 
 	/**
@@ -137,8 +137,8 @@ class PowerUser {
 	 * @return bool
 	 */
 	public function addPowerUserAddGroup( $sProperty ) {
-		if ( in_array( $sProperty, self::$aPowerUsersRightsMapping ) &&
-			!in_array( self::GROUP_NAME, $this->oUser->getGroups() ) )
+		if ( in_array( $sProperty, self::$aPowerUsersRightsMapping )
+			&& !in_array( self::GROUP_NAME, $this->oUser->getGroups() ) )
 		{
 			$this->oUser->addGroup( self::GROUP_NAME );
 			$this->logSuccess( $sProperty, self::ACTION_ADD_GROUP );
@@ -156,8 +156,8 @@ class PowerUser {
 	 * @return bool
 	 */
 	public function removePowerUserProperty( $sProperty ) {
-		return ( $this->removePowerUserSetOption( $sProperty ) &&
-			$this->removePowerUserRemoveGroup( $sProperty ) );
+		return ( $this->removePowerUserSetOption( $sProperty )
+			&& $this->removePowerUserRemoveGroup( $sProperty ) );
 	}
 
 	/**
@@ -167,8 +167,8 @@ class PowerUser {
 	 * @return bool
 	 */
 	public function removePowerUserSetOption( $sProperty ) {
-		if ( in_array( $sProperty, self::$aPowerUserProperties ) &&
-			$this->oUser->getBoolOption( $sProperty ) === true
+		if ( in_array( $sProperty, self::$aPowerUserProperties )
+			&& $this->oUser->getBoolOption( $sProperty ) === true
 		) {
 			$this->oUser->setOption( $sProperty, null );
 			$this->oUser->saveSettings();
@@ -189,8 +189,8 @@ class PowerUser {
 	 * @return bool
 	 */
 	public function removePowerUserRemoveGroup( $sProperty ) {
-		if ( in_array( $sProperty, self::$aPowerUsersRightsMapping ) &&
-			$this->isGroupForRemoval( $sProperty ) )
+		if ( in_array( $sProperty, self::$aPowerUsersRightsMapping )
+			&& $this->isGroupForRemoval( $sProperty ) )
 		{
 			$this->oUser->removeGroup( self::GROUP_NAME );
 			$this->logSuccess( $sProperty, self::ACTION_REMOVE_GROUP );
@@ -211,8 +211,8 @@ class PowerUser {
 	 */
 	private function isGroupForRemoval( $sProperty ) {
 		foreach ( self::$aPowerUsersRightsMapping as $sMappedProperty ) {
-			if ( $sMappedProperty !== $sProperty &&
-				$this->oUser->isSpecificPowerUser( $sMappedProperty ) ) {
+			if ( $sMappedProperty !== $sProperty
+				&& $this->oUser->isSpecificPowerUser( $sMappedProperty ) ) {
 				return false;
 			}
 		}

--- a/extensions/wikia/PowerUser/PowerUser.class.php
+++ b/extensions/wikia/PowerUser/PowerUser.class.php
@@ -137,11 +137,11 @@ class PowerUser {
 	 * @return bool
 	 */
 	public function addPowerUserAddGroup( $sProperty ) {
-		if ( in_array( $sProperty, self::$aPowerUsersRightsMapping )
-			&& !in_array( self::GROUP_NAME, $this->oUser->getGroups() ) )
-		{
-			$this->oUser->addGroup( self::GROUP_NAME );
-			$this->logSuccess( $sProperty, self::ACTION_ADD_GROUP );
+		if ( in_array( $sProperty, self::$aPowerUsersRightsMapping ) ) {
+			if ( !in_array( self::GROUP_NAME, $this->oUser->getGroups() ) ) {
+				$this->oUser->addGroup(self::GROUP_NAME);
+				$this->logSuccess($sProperty, self::ACTION_ADD_GROUP);
+			}
 			return true;
 		} else {
 			$this->logError( $sProperty, self::ACTION_ADD_GROUP );
@@ -167,12 +167,12 @@ class PowerUser {
 	 * @return bool
 	 */
 	public function removePowerUserSetOption( $sProperty ) {
-		if ( in_array( $sProperty, self::$aPowerUserProperties )
-			&& $this->oUser->getBoolOption( $sProperty ) === true
-		) {
-			$this->oUser->setOption( $sProperty, null );
-			$this->oUser->saveSettings();
-			$this->logSuccess( $sProperty, self::ACTION_REMOVE_SET_OPTION );
+		if ( in_array( $sProperty, self::$aPowerUserProperties ) ) {
+			if ( $this->oUser->getBoolOption( $sProperty ) === true ) {
+				$this->oUser->setOption($sProperty, null);
+				$this->oUser->saveSettings();
+				$this->logSuccess($sProperty, self::ACTION_REMOVE_SET_OPTION);
+			}
 			return true;
 		} else {
 			$this->logError( $sProperty, self::ACTION_REMOVE_SET_OPTION );
@@ -189,11 +189,11 @@ class PowerUser {
 	 * @return bool
 	 */
 	public function removePowerUserRemoveGroup( $sProperty ) {
-		if ( in_array( $sProperty, self::$aPowerUsersRightsMapping )
-			&& $this->isGroupForRemoval( $sProperty ) )
-		{
-			$this->oUser->removeGroup( self::GROUP_NAME );
-			$this->logSuccess( $sProperty, self::ACTION_REMOVE_GROUP );
+		if ( in_array( $sProperty, self::$aPowerUsersRightsMapping ) ) {
+			if ( $this->isGroupForRemoval( $sProperty ) ) {
+				$this->oUser->removeGroup(self::GROUP_NAME);
+				$this->logSuccess($sProperty, self::ACTION_REMOVE_GROUP);
+			}
 			return true;
 		} else {
 			$this->logError( $sProperty, self::ACTION_REMOVE_GROUP );


### PR DESCRIPTION
[See CE-1283](https://wikia-inc.atlassian.net/browse/CE-1283)

This pull request binds a new 'poweruser' group with being a Power User. Using _user_groups_ to store information about Power Users allows us to use currently gathered statistics in our favor (most of them include users' groups).

It also implements a new method to get current PowerUser-related properties for a user.

Ping @Wikia/community-engineering 
