### PR TITLE
axWFactoryDomainQuery: add a LIMIT to the query

### DIFF
--- a/extensions/wikia/WikiFactory/SpecialWikiFactory_ajax.php
+++ b/extensions/wikia/WikiFactory/SpecialWikiFactory_ajax.php
@@ -636,7 +636,10 @@ function axWFactoryDomainQuery() {
 				"city_domain not like '%.wikicities.com'",
 				"city_domain {$cityDomainLike}"
 			],
-			__METHOD__
+			__METHOD__,
+			[
+				'LIMIT' => 15
+			]
 		);
 
 		while( $domain = $dbr->fetchObject( $sth ) ) {
@@ -654,7 +657,9 @@ function axWFactoryDomainQuery() {
 		$return[ "data" ] = array_merge( $exact[ "data" ], $match[ "suggestions" ] );
 	}
 
-	return json_encode( $return );
+	$resp = new AjaxResponse( json_encode( $return ) );
+	$resp->setContentType( 'application/json; charset=utf-8' );
+	return $resp;
 }
 
 /**


### PR DESCRIPTION
This function makes queries that can return thousands of rows that are then transfered to the front-end (where only six first items are visible).

``` sql
SELECT /* axWFactoryDomainQuery Raylan13 */  city_id,city_domain  FROM `city_domains`  WHERE (city_domain not like 'www.%') AND (city_domain not like '%.wikicities.com') AND (city_domain  LIKE '%supe%' )
```
- set a proper response content type

@Grunny 
