### PR TITLE
DAT-2591 Really use DBname for Latest Activity API

### DIFF
--- a/includes/wikia/services/RevisionService.class.php
+++ b/includes/wikia/services/RevisionService.class.php
@@ -69,7 +69,7 @@ class RevisionService {
 	 * @return array
 	 */
 	public function getLatestRevisions( $limit, $namespaces ) {
-		$key = self::createCacheKey( $this->queryLimit, $namespaces, $this->getFilterMethod() );
+		$key = self::createCacheKey( $this->queryLimit, $namespaces );
 		$listOfRevisions = WikiaDataAccess::cache( $key, $this->cacheTime, function() use( $namespaces ) {
 			return $this->getLatestRevisionsNoCacheAllowDuplicates( $this->queryLimit, $namespaces );
 		});
@@ -212,9 +212,9 @@ class RevisionService {
 		}
 		$key = implode("_", [
 			"RevisionService",
-			$dbName,
 			strval($limit),
-			implode(",",$namespaces)
+			implode(",",$namespaces),
+			$dbName
 		]);
 		return $key;
 	}


### PR DESCRIPTION
The WikiaDataAccess used the same key for different wikis. Despite the 5s TTL,
it was still noticed by users. This REALLY uses the dbname.
Also, we do not use filter method for cache (not needed)
