### PR TITLE
LoadMonitor_MySQL: cache lag times globally instead of per-wiki [release]

### DIFF
--- a/includes/db/LoadMonitor.php
+++ b/includes/db/LoadMonitor.php
@@ -124,7 +124,7 @@ class LoadMonitor_MySQL implements LoadMonitor {
 			$wgMemc = wfGetMainCache();
 
 		$masterName = $this->parent->getServerName( 0 );
-		$memcKey = wfMemcKey( 'db', 'lag_times', $masterName );
+		$memcKey = wfSharedMemcKey( 'db', 'lag_times', $masterName ); // Wikia change - PLATFORM-983
 		$times = $wgMemc->get( $memcKey );
 		if ( $times ) {
 			# Randomly recache with probability rising over $expiry


### PR DESCRIPTION
Backporting #6567
