### PR TITLE
Return empty array if no redirects are find for a given pageType

### DIFF
--- a/includes/wikia/services/RedirectService.class.php
+++ b/includes/wikia/services/RedirectService.class.php
@@ -73,6 +73,7 @@ class RedirectService extends WikiaService {
 	public function getRedirects() {
 		if ( empty( $this->redirects ) ) {
 			global $wgRedirectPages;
+
 			if ( !empty( $wgRedirectPages ) ) {
 				$this->redirects = $wgRedirectPages;
 			}
@@ -82,11 +83,17 @@ class RedirectService extends WikiaService {
 			$this->redirects = $this->prepareRedirects();
 		}
 
-		if ( isset( $this->pageType )
-			&& isset( $this->redirects[ $this->pageType ] )
-			&& is_array( $this->redirects[ $this->pageType ]) )
-		{
-			return $this->redirects[ $this->pageType ];
+
+		if ( isset( $this->pageType ) ) {
+			if (
+				isset( $this->redirects[ $this->pageType ] )
+				&& is_array( $this->redirects[ $this->pageType ])
+			) {
+				return $this->redirects[ $this->pageType ];
+			} else {
+				//If we don't find redirects for this pageType
+				$this->redirects = [];
+			}
 		}
 
 		return $this->redirects;

--- a/includes/wikia/services/RedirectService.class.php
+++ b/includes/wikia/services/RedirectService.class.php
@@ -10,11 +10,6 @@
  *
  * Examples:
  *
- * 		$this->redirects = array(
- * 					'Old/Title' => 'Old/New title'
- * 					'next old title' => 'http://muppet.wikia.com/wiki/Some_page'
- * 				);
- *
  * If page type is set, it expects multidimensional array with page type on first level.
  *
  *		$this->redirects = array(
@@ -51,7 +46,7 @@ class RedirectService extends WikiaService {
 	 */
 	private $isFormatted;
 
-	public function __construct( $pageType = null, $httpStatus = null ) {
+	public function __construct( $pageType, $httpStatus = null ) {
 		if ( !is_null( $httpStatus ) && is_numeric( $httpStatus ) ) {
 			$this->httpStatus = $httpStatus;
 		} else {
@@ -84,7 +79,7 @@ class RedirectService extends WikiaService {
 		}
 
 
-		if ( isset( $this->pageType ) ) {
+		if ( !empty( $this->pageType ) ) {
 			if (
 				isset( $this->redirects[ $this->pageType ] )
 				&& is_array( $this->redirects[ $this->pageType ])
@@ -104,7 +99,7 @@ class RedirectService extends WikiaService {
 	 *
 	 * @param array $redirects
 	 */
-	public function setRedirects(Array $redirects ) {
+	public function setRedirects( Array $redirects ) {
 		$this->redirects = $redirects;
 		$this->isFormatted = false;
 	}

--- a/includes/wikia/services/tests/RedirectServiceTest.php
+++ b/includes/wikia/services/tests/RedirectServiceTest.php
@@ -19,12 +19,12 @@ class RedirectServiceTest extends WikiaBaseTest {
 	 * @dataProvider getRedirectsDataProvider
 	 */
 	public function testGetRedirects($redirects, $expected) {
-		$redirectService = new RedirectService();
+		$redirectService = new RedirectService(null);
 		$redirectService->setRedirects($redirects);
 
 		$redirects = $redirectService->getRedirects();
 
-		$this->assertEquals($redirects, $expected);
+		$this->assertEquals($expected, $redirects);
 	}
 
 	/**
@@ -40,88 +40,80 @@ class RedirectServiceTest extends WikiaBaseTest {
 	}
 
 	public function getRedirectsForPageTypeDataProvider() {
-		return array(
-			array(
-				array(
+		return [
+			[
+				[
 					'Old title' => 'New title',
 					'Other old Title' => 'Other new Title',
 					'Wiki/Title' => 'http://muppet.wikia.com'
-				),
+				],
 				'type',
-				array(
-					'old title' => 'New title',
-					'other old title' => 'Other new Title',
-					'wiki/title' => 'http://muppet.wikia.com'
-				)
-			),
-			array(
-				array(
-					'WAM' => array(
+				[]
+			],
+			[
+				[
+					'WAM' => [
 						'WamPageTitle' => 'WAM',
 						'WAM wikis' => 'WAM wikias'
-					),
-					'HubsV2' => array(
+					],
+					'HubsV2' => [
 						'Video Games' => 'http://videogames.wikia.com'
-					)
-				),
+					]
+				],
 				'WAM',
-				array(
+				[
 					'wampagetitle' => 'WAM',
 					'wam wikis' => 'WAM wikias'
-				)
-			),
-			array(
-				array(),
+				]
+			],
+			[
+				[],
 				'Wam',
-				array()
-			),
-			array(
-				array(
-					'WAM' => array(
+				[]
+			],
+			[
+				[
+					'WAM' => [
 						'WamPageTitle' => 'WAM',
 						'WAM wikis' => 'WAM wikias'
-					),
-					'HubsV2' => array(
+					],
+					'HubsV2' => [
 						'Video Games' => 'http://videogames.wikia.com'
-					)
-				),
+					]
+				],
 				'hubsV2',
-				array(
+				[
 					'video games' => 'http://videogames.wikia.com'
-				)
-			),
-			array(
-				array(
-					'WAM' => array(
+				]
+			],
+			[
+				[
+					'WAM' => [
 						'WamPageTitle' => 'WAM',
 						'WAM wikis' => 'WAM wikias'
-					),
-					'HubsV2' => array(
+					],
+					'HubsV2' => [
 						'Video Games' => 'http://videogames.wikia.com'
-					)
-				),
+					]
+				],
 				'wikia',
-				array(
-					'wam' => array(
-						'wampagetitle' => 'WAM',
-						'wam wikis' => 'WAM wikias'
-					),
-					'hubsv2' => array(
-						'video games' => 'http://videogames.wikia.com'
-					)
-				)
-			),
-		);
+				[]
+			]
+		];
 	}
 
 	/**
 	 * @dataProvider getRedirectURLDataProvider
 	 */
 	public function testGetRedirectURL($redirects, $title, $expected) {
-		$wgTitleMock = $this->getMock('Title', array('getText'));
-		$titleMock = $this->getMock('Title', array('getLocalURL'));
+		$wgTitleMock = $this->getMock('Title', ['getText']);
+		$titleMock = $this->getMock('Title', ['getLocalURL']);
 
-		$redirectMock = $this->getMock('RedirectService', array('getTitleFromText'));
+		$redirectMock = $this->getMockBuilder('RedirectService')
+			->setConstructorArgs(['test'])
+			->setMethods(['getTitleFromText'])
+			->getMock();
+
 		$redirectMock->setRedirects($redirects);
 
 		$redirects = $redirectMock->getRedirects();
@@ -151,35 +143,30 @@ class RedirectServiceTest extends WikiaBaseTest {
 	}
 
 	public function getRedirectURLDataProvider() {
-		return array(
-			array(
-				array(
-					'Old title' => 'New title',
-					'Other old Title' => 'Other new Title',
-					'Wiki/Title' => 'http://muppet.wikia.com'
-				),
-				'Wiki/Title',
-				'http://muppet.wikia.com'
-			),
-			array(
-				array(
-					'Old title' => 'New title',
-					'Other old Title' => 'Other new Title',
-					'Wiki/Title' => 'http://muppet.wikia.com'
-				),
+		return [
+			[
+				[
+					'test' => [
+						'Old title' => 'New title',
+						'Other old Title' => 'Other new Title',
+						'Wiki/Title' => 'http://muppet.wikia.com'
+					]
+				],
 				'other old Title',
 				self::MOCKED_DOMAIN . 'Other_new_Title'
-			),
-			array(
-				array(
-					'Old title' => 'New title',
-					'Other old Title' => 'Other new Title',
-					'Wiki/Title' => 'http://muppet.wikia.com'
-				),
+			],
+			[
+				[
+					'test' => [
+						'Old title' => 'New title',
+						'Other old Title' => 'Other new Title',
+						'Wiki/Title' => 'http://muppet.wikia.com'
+					]
+				],
 				'not existing Title',
 				null
-			)
-		);
+			]
+		];
 	}
 
 	private function getFakeUrlFromTitle($title) {
@@ -190,54 +177,42 @@ class RedirectServiceTest extends WikiaBaseTest {
 	 * @dataProvider getRedirectsDataProvider
 	 */
 	public function testPrepareRedirects($redirects, $expected) {
-		$redirectService = new RedirectService();
+		$redirectService = new RedirectService('wam');
 		$redirectService->setRedirects($redirects);
 
 		$prepare = $this->getReflectionMethod( 'prepareRedirects' );
 
 		$preparedRedirects = $prepare->invoke($redirectService);
 
-		$this->assertEquals($preparedRedirects, $expected);
+		$this->assertEquals($expected, $preparedRedirects);
 	}
 
 	public function getRedirectsDataProvider() {
-		return array(
-			array(
-				array(
-					'Old title' => 'New title',
-					'Other old Title' => 'Other new Title',
-					'Wiki/Title' => 'http://muppet.wikia.com'
-				),
-				array(
-					'old title' => 'New title',
-					'other old title' => 'Other new Title',
-					'wiki/title' => 'http://muppet.wikia.com'
-				)
-			),
-			array(
-				array(
-					'WAM' => array(
+		return [
+			[
+				[
+					'WAM' => [
 						'WamPageTitle' => 'WAM',
 						'WAM wikis' => 'WAM wikias'
-					),
-					'HubsV2' => array(
+					],
+					'HubsV2' => [
 						'Video Games' => 'http://videogames.wikia.com'
-					)
-				),
-				array(
-					'wam' => array(
+					]
+				],
+				[
+					'wam' => [
 						'wampagetitle' => 'WAM',
 						'wam wikis' => 'WAM wikias'
-					),
-					'hubsv2' => array(
+					],
+					'hubsv2' => [
 						'video games' => 'http://videogames.wikia.com'
-					)
-				)
-			),
-			array(
-				array(),
-				array()
-			)
-		);
+					]
+				]
+			],
+			[
+				[],
+				[]
+			]
+		];
 	}
 }


### PR DESCRIPTION
Previously if you wanted redirects for 'hubsv3' and it was not in the RedirectPages,
it would return the whole redirects list.
