### PR TITLE
Make a login failure not to be handled by exception

### DIFF
--- a/extensions/wikia/Helios/Client.class.php
+++ b/extensions/wikia/Helios/Client.class.php
@@ -73,7 +73,6 @@ class Client
 	/**
 	 * A shortcut method for login requests.
 	 *
-	 * @throws LoginFailureException
 	 * @throws ClientException
 	 */
 	public function login( $username, $password )
@@ -93,14 +92,6 @@ class Client
 			$postData,
 			[ 'method'	=> 'POST' ]
 		);
-
-		if ( !empty( $response->error ) ) {
-			if ( $response->error === 'access_denied' ) {
-				throw new LoginFailureException( 'Login failed.', 0, null, [ 'response' => $response ] );
-			} else {
-				throw new ClientException( 'Response error: ' . $response->error, 0, null, [ 'response' => $response ] );
-			}
-		}
 
 		return $response;
 	}

--- a/extensions/wikia/Helios/Exceptions.php
+++ b/extensions/wikia/Helios/Exceptions.php
@@ -46,10 +46,3 @@ class ClientException extends Exception
 		$this->error( 'HELIOS_CLIENT client_exception' );
 	}
 }
-
-class LoginFailureException extends Exception
-{
-	protected function logMe() {
-		$this->info( 'HELIOS_CLIENT login_failure' );
-	}
-}

--- a/extensions/wikia/Helios/User.class.php
+++ b/extensions/wikia/Helios/User.class.php
@@ -96,15 +96,19 @@ class User {
 		// Authenticate with username and password.
 		try {
 			$loginInfo = $heliosClient->login( $username, $password );
+
+			if ( !empty($loginInfo->error) ) {
+				if ( $loginInfo->error === 'access_denied' ) {
+					$logger->info(
+						'HELIOS_LOGIN authentication_failed',
+						[ 'response' => $loginInfo, 'username' => $username, 'method' => __METHOD__ ]
+					);
+				} else {
+					throw new ClientException( 'Response error: ' . $loginInfo->error, 0, null, [ 'response' => $loginInfo ] );
+				}
+			}
+
 			$result = !empty( $loginInfo->access_token );
-		}
-		catch ( LoginFailureException $e )
-		{
-			// normal case: password incorrect, log it as info
-			$logger->info(
-				'HELIOS_LOGIN authentication_failed',
-				[ 'response' => $e->getResponse(), 'username' => $username, 'method' => __METHOD__ ]
-			);
 		}
 		catch ( ClientException $e )
 		{


### PR DESCRIPTION
Login failure is just one of the normal outcomes of authentication. It's not an exception.
Let's treat it this way. Exceptions are generally discouraged as flow control mechanism.

Work in progress. No test done yet!

/cc @michalroszka 
