### PR TITLE
CE-1429 Fix the query returning no rows

### DIFF
--- a/extensions/wikia/PowerUser/maintenance/PowerUserAddFrequentMaintenance.php
+++ b/extensions/wikia/PowerUser/maintenance/PowerUserAddFrequentMaintenance.php
@@ -49,7 +49,8 @@ class PowerUserAddFrequentMaintenance extends Maintenance {
 		$oSubQuery = ( new WikiaSQL() )
 			->SELECT( 'up_user' )
 			->FROM( 'user_properties' )
-			->WHERE( 'up_property' )->EQUAL_TO( PowerUser::TYPE_FREQUENT )
+			->WHERE( 'user_id' )->EQUAL_TO_FIELD( 'up_user' )
+			->AND_( 'up_property' )->EQUAL_TO( PowerUser::TYPE_FREQUENT )
 			->AND_( 'up_value' )->EQUAL_TO( '1' );
 
 		$aPotentialPowerUsersIds = ( new WikiaSQL() )


### PR DESCRIPTION
[See CE-1429](https://wikia-inc.atlassian.net/browse/CE-1429)

The previous query lacked a user's id matching resulting in no results.

``` sql
SELECT user_id FROM user WHERE user_editcount >= '140' AND NOT EXISTS ( SELECT up_user FROM user_properties WHERE up_user = user_id AND up_property = 'poweruser_frequent' AND up_value = '1' ) ORDER BY user_id DESC
```

**EXPLAIN**

``` sql
+----+--------------------+-----------------+-------+--------------------------------------------------------+-------------------------------+---------+-------------------------------+----------+-------------+
| id | select_type        | table           | type  | possible_keys                                          | key                           | key_len | ref                           | rows     | Extra       |
+----+--------------------+-----------------+-------+--------------------------------------------------------+-------------------------------+---------+-------------------------------+----------+-------------+
|  1 | PRIMARY            | user            | index | NULL                                                   | PRIMARY                       | 4       | NULL                          | 24059868 | Using where |
|  2 | DEPENDENT SUBQUERY | user_properties | ref   | user_properties_user_property,user_properties_property | user_properties_user_property | 262     | wikicities.user.user_id,const |        1 | Using where |
+----+--------------------+-----------------+-------+--------------------------------------------------------+-------------------------------+---------+-------------------------------+----------+-------------+
```
