### PR TITLE
VE-1854: Revert change to the box-sizing that break buttons in VE

### DIFF
--- a/skins/oasis/css/core/body.scss
+++ b/skins/oasis/css/core/body.scss
@@ -7,11 +7,6 @@ html {
 
 }
 
-*, *::before, *::after {
-	box-sizing: inherit;
-}
-
-
 body {
 	color: $color-text;
 	font-family: Helvetica, Arial, sans-serif;


### PR DESCRIPTION
This change is reverting box-sizing applied to all elements (*) that was introduced recently within this change https://github.com/Wikia/app/pull/6547 and it breaks buttons in VE (https://wikia-inc.atlassian.net/browse/VE-1854).
