### PR TITLE
ImageReviewHelperBase: fix PHP type hinting

### DIFF
--- a/extensions/wikia/ImageReview/ImageReviewHelper.class.php
+++ b/extensions/wikia/ImageReview/ImageReviewHelper.class.php
@@ -361,7 +361,7 @@ class ImageReviewHelper extends ImageReviewHelperBase {
 		return $imageList;
 	}
 
-	private function imageListAdditionalAction( $sType, DatabaseMysql $oDB, Array $aValues, Array $aWhere ) {
+	private function imageListAdditionalAction( $sType, DatabaseBase $oDB, Array $aValues, Array $aWhere ) {
 		$iCount = count( $aWhere );
 		if ( $iCount > 0 ) {
 			$oDatabaseHelper = $this->getDatabaseHelper();


### PR DESCRIPTION
Fixes `PHP Catchable fatal error: Argument 2 passed to ImageReviewHelper::imageListAdditionalAction() must be an instance of DatabaseMysql, instance of DatabaseMysqli given, called in /usr/wikia/slot1/3785/src/extensions/wikia/ImageReview/ImageReviewHelper.class.php on line 348 and defined in /usr/wikia/slot1/3785/src/extensions/wikia/ImageReview/ImageReviewHelper.class.php on line 364`

@adamkarminski 
