### PR TITLE
DatabaseBase: make connectionErrorHandler public

### DIFF
--- a/includes/db/Database.php
+++ b/includes/db/Database.php
@@ -789,10 +789,10 @@ abstract class DatabaseBase implements DatabaseType {
 	}
 
 	/**
-	 * @param $errno
-	 * @param $errstr
+	 * @param int $errno
+	 * @param string $errstr
 	 */
-	protected function connectionErrorHandler( $errno,  $errstr ) {
+	public function connectionErrorHandler( $errno,  $errstr ) {
 		$this->mPHPError = $errstr;
 	}
 


### PR DESCRIPTION
Fixes `PHP Warning:  Invalid callback DatabaseMysqli::connectionErrorHandler, cannot access protected method DatabaseMysqli::connectionErrorHandler() in /includes/db/DatabaseMysqli.php on line 108`

@wladekb / @michalroszka 
