### PR TITLE
CE-1392: Highlight wikitext syntax if article starts with text

### DIFF
--- a/extensions/wikia/EditPageLayout/js/plugins/WikitextSyntaxHighlighter.js
+++ b/extensions/wikia/EditPageLayout/js/plugins/WikitextSyntaxHighlighter.js
@@ -124,7 +124,7 @@ define('WikiTextSyntaxHighlighter', ['wikia.window', 'wikia.document', 'wikia.lo
 
 		before = true;
 		css = '';
-		lastColor = '';
+		lastColor = undefined;
 		spanNumber = 0;
 
 		/* Highlighting bold or italic markup presents a special challenge


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CE-1392
