### PR TITLE
FilePageController: do not treat this query as a writable one

### DIFF
--- a/extensions/wikia/FilePage/FilePageController.class.php
+++ b/extensions/wikia/FilePage/FilePageController.class.php
@@ -115,7 +115,7 @@ class FilePageController extends WikiaController {
 				GROUP BY gil_wiki
 				LIMIT $limit
 SQL;
-			$result = $db->query( $sql, __METHOD__ );
+			$result = $db->query( trim( $sql ), __METHOD__ );
 
 			// We need to make sure $globalUsage is an array. If the query below returns no rows, $globalUsage
 			// ends up being null due to it's initial assignment of $globalUsage = $this->wg->Memc->get( $memcKey );


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-1012

MediaWiki fallbacks to database read-only mode when all slaves are lagged. When in read-only mode a simple check is performed on every query sent to the database. It assumes that the query does not contain leading spaces.

Trying to find the root cause of read-only fallback in #6622

@wladekb / @garthwebb 
