### PR TITLE
SOC-500 add template to showImage method of CaptchaController

### DIFF
--- a/extensions/wikia/Captcha/CaptchaController.class.php
+++ b/extensions/wikia/Captcha/CaptchaController.class.php
@@ -5,6 +5,8 @@
  */
 class CaptchaController extends WikiaController {
 
+	const DEFAULT_TEMPLATE_ENGINE = WikiaResponse::TEMPLATE_ENGINE_MUSTACHE;
+
 	/**
 	 * Displays a captcha image. This is used exclusively by FancyCaptcha.
 	 */

--- a/extensions/wikia/Captcha/templates/CaptchaController_showImage.mustache
+++ b/extensions/wikia/Captcha/templates/CaptchaController_showImage.mustache
@@ -1,0 +1,3 @@
+{{#error}}
+	<p>{{error}}</p>
+{{/error}}


### PR DESCRIPTION
After the release of the FancyCaptcha fallback, fatal errors are showing up in the logs when requests are made to get the FancyCaptcha image, eg `http://jsutterfield.wikia.com/wikia.php?controller=Captcha&method=showImage&wpCaptchaId=301606261` b/c Nirvana is looking for a template to use for the request. The image is being delivered, and FancyCaptcha still works, so it doesn't affect the user however we should prevent these fatals from happening.

Initially my thought was to alter the request so that Nirvana didn't try and use a template since the image itself doesn't need a template, however there is a fail condition in the showImage method which returns an error message if the image can't be loaded so we should have a template for that case. This PR adds that template.

Ticket: https://wikia-inc.atlassian.net/browse/SOC-500
