### PR TITLE
Update WikiaView to allow for finer grain template locations/names

### DIFF
--- a/includes/wikia/nirvana/WikiaController.class.php
+++ b/includes/wikia/nirvana/WikiaController.class.php
@@ -147,4 +147,15 @@ abstract class WikiaController extends WikiaDispatchableObject {
 	public function isAnonAccessAllowedInCurrentContext() {
 		return false;
 	}
+
+	/**
+	 * Allow controllers to define an alternate location for where templates can be found.
+	 * This base definition returns null so by default WikiaView.class.php will determine
+	 * this directory.
+	 *
+	 * @return null
+	 */
+	public function getTemplateDir() {
+		return null;
+	}
 }

--- a/includes/wikia/nirvana/WikiaView.class.php
+++ b/includes/wikia/nirvana/WikiaView.class.php
@@ -205,7 +205,7 @@ class WikiaView {
 
 		// If the above fails, or returns a non-existent directory, fallback to the default.
 		if ( empty( $dirName ) || !file_exists( $dirName ) ) {
-			$dirName = dirname( F::app()->wg->AutoloadClasses[ $controllerClass ] ) . '/templates';
+			$dirName = dirname( F::app()->wg->AutoloadClasses[$controllerClass] ) . '/templates';
 		}
 
 		return $dirName;

--- a/includes/wikia/nirvana/WikiaView.class.php
+++ b/includes/wikia/nirvana/WikiaView.class.php
@@ -34,7 +34,7 @@ class WikiaView {
 	 *
 	 * @return WikiaView
 	 */
-	public static function newFromControllerAndMethodName( $controllerName, $methodName, Array $data = array(), $format = WikiaResponse::FORMAT_HTML ) {
+	public static function newFromControllerAndMethodName( $controllerName, $methodName, Array $data = [], $format = WikiaResponse::FORMAT_HTML ) {
 		// Service classes must be dispatched by full name otherwise we default to a controller.
 		$controllerClassName = self::normalizeControllerClass( $controllerName );
 

--- a/includes/wikia/nirvana/WikiaView.class.php
+++ b/includes/wikia/nirvana/WikiaView.class.php
@@ -31,16 +31,12 @@ class WikiaView {
 	 * @param string $methodName
 	 * @param array $data
 	 * @param string $format
+	 *
+	 * @return WikiaView
 	 */
 	public static function newFromControllerAndMethodName( $controllerName, $methodName, Array $data = array(), $format = WikiaResponse::FORMAT_HTML ) {
-		$app = F::app();
 		// Service classes must be dispatched by full name otherwise we default to a controller.
-		$controllerBaseName = $app->getBaseName( $controllerName );
-		if ($app->isService($controllerName)) {
-			$controllerClassName = $app->getServiceClassName( $controllerBaseName );
-		} else {
-			$controllerClassName = $app->getControllerClassName( $controllerBaseName );
-		}
+		$controllerClassName = self::normalizeControllerClass( $controllerName );
 
 		$response = new WikiaResponse( $format );
 		$response->setControllerName( $controllerName );
@@ -97,16 +93,15 @@ class WikiaView {
 	/**
 	 * build template path for given controller and method name
 	 *
-	 * @param string $controllerName
+	 * @param string $controllerClass
 	 * @param string $methodName
 	 * @param bool $forceRebuild
+	 *
+	 * @throws WikiaException
 	 */
 	protected function buildTemplatePath( $controllerClass, $methodName, $forceRebuild = false ) {
 		wfProfileIn(__METHOD__);
-		if( ( $this->templatePath == null ) || $forceRebuild ) {
-			global $wgAutoloadClasses;
-			$app = F::app();
-
+		if ( ( $this->templatePath == null ) || $forceRebuild ) {
 			if ( !empty( $this->response ) ) {
 				$extension = $this->response->getTemplateEngine();
 			} else {
@@ -114,36 +109,98 @@ class WikiaView {
 			}
 
 			// Service classes must be dispatched by full name otherwise we default to a controller.
-			$controllerBaseName = $app->getBaseName( $controllerClass );
-			if ($app->isService($controllerClass)) {
-				$controllerClass = $app->getServiceClassName( $controllerBaseName );
-			} else {
-				$controllerClass = $app->getControllerClassName( $controllerBaseName );
+			$controllerClass = $this->normalizeControllerClass( $controllerClass );
+
+			$templateExists = false;
+			$templatePath = '';
+			$templates = $this->getTemplateOptions( $controllerClass, $methodName );
+			$dirName = $this->getTemplateDir( $controllerClass );
+			foreach ( $templates as $templateName ) {
+				$templatePath = $dirName . '/' . $templateName . '.' . $extension;
+
+				if ( file_exists( $templatePath ) ) {
+					$templateExists = true;
+					break;
+				}
 			}
 
-			if( empty( $wgAutoloadClasses[$controllerClass] ) ) {
-				throw new WikiaException( "Invalid controller or service name: {$controllerClass}" );
-			}
-
-			// First we look for BaseName_MethodName
-			$dirName = dirname( $wgAutoloadClasses[$controllerClass] );
-			$basePath = "{$dirName}/templates/{$controllerBaseName}_{$methodName}";
-			$templatePath = "{$basePath}.$extension";
-			$templateExists = file_exists( $templatePath );
-
-			// Fall back to ControllerClass_MethodName
-			if( !$templateExists ) {
-				$templatePath = "{$dirName}/templates/{$controllerClass}_{$methodName}.$extension";
-				$templateExists = file_exists( $templatePath );
-			}
-
-			if( !$templateExists ) {
+			if ( !$templateExists ) {
 				throw new WikiaException( "Template file not found: {$templatePath}" );
 			}
 
 			$this->setTemplatePath( $templatePath );
 		}
 		wfProfileOut(__METHOD__);
+	}
+
+	/**
+	 * For legacy reasons we sometimes get a $controllerClass name that doesn't end with
+	 * 'Controller' or 'Service'.  Normalize to this form.
+	 *
+	 * @param $controllerClass
+	 *
+	 * @return string
+	 *
+	 * @throws WikiaException
+	 */
+	public static function normalizeControllerClass( $controllerClass ) {
+		$app = F::app();
+		$controllerBaseName = $app->getBaseName( $controllerClass );
+		if ( $app->isService( $controllerClass ) ) {
+			$controllerClass = $app->getServiceClassName( $controllerBaseName );
+		} else {
+			$controllerClass = $app->getControllerClassName( $controllerBaseName );
+		}
+
+		if ( empty( $app->wg->AutoloadClasses[$controllerClass] ) ) {
+			throw new WikiaException( "Invalid controller or service name: {$controllerClass}" );
+		}
+
+		return $controllerClass;
+	}
+
+	/**
+	 * Generates a list of possible template names ordered by preference
+	 *
+	 * @param $controllerClass
+	 * @param $methodName
+	 *
+	 * @return array
+	 */
+	public function getTemplateOptions( $controllerClass, $methodName ) {
+		$templates = [];
+
+		// See if there is a @template annotation for the method we're generating a view for
+		$reflection = new ReflectionClass( $controllerClass );
+		$method = $reflection->getMethod($methodName );
+		$comment = $method->getDocComment();
+		if ( preg_match( '/@template ([^ ]+)/', $comment, $matches ) ) {
+			$templates[] = trim( $matches[1] );
+		}
+
+		// Add variations on the controller name
+		$controllerBaseName = F::app()->getBaseName( $controllerClass );
+		$templates[] = "{$controllerBaseName}_{$methodName}";
+		$templates[] = "{$controllerClass}_{$methodName}";
+
+		return $templates;
+	}
+
+	/**
+	 * See if the controller defines a custom template directory, otherwise use the default directory
+	 *
+	 * @param $controllerClass
+	 *
+	 * @return string
+	 */
+	public function getTemplateDir( $controllerClass ) {
+		if ( method_exists( $controllerClass, 'getTemplateDir' ) ) {
+			$dirName = call_user_func( [ $controllerClass, 'getTemplateDir' ] );
+		} else {
+			$dirName = dirname( F::app()->wg->AutoloadClasses[ $controllerClass ] ) . '/templates';
+		}
+
+		return $dirName;
 	}
 
 	public function __toString() {

--- a/includes/wikia/nirvana/WikiaView.class.php
+++ b/includes/wikia/nirvana/WikiaView.class.php
@@ -196,7 +196,10 @@ class WikiaView {
 	public function getTemplateDir( $controllerClass ) {
 		if ( method_exists( $controllerClass, 'getTemplateDir' ) ) {
 			$dirName = call_user_func( [ $controllerClass, 'getTemplateDir' ] );
-		} else {
+		}
+
+		// If the above fails, or returns a non-existent directory, fallback to the default.
+		if ( empty( $dirName ) || !file_exists( $dirName ) ) {
 			$dirName = dirname( F::app()->wg->AutoloadClasses[ $controllerClass ] ) . '/templates';
 		}
 

--- a/includes/wikia/nirvana/WikiaView.class.php
+++ b/includes/wikia/nirvana/WikiaView.class.php
@@ -170,12 +170,17 @@ class WikiaView {
 	public function getTemplateOptions( $controllerClass, $methodName ) {
 		$templates = [];
 
-		// See if there is a @template annotation for the method we're generating a view for
-		$reflection = new ReflectionClass( $controllerClass );
-		$method = $reflection->getMethod($methodName );
-		$comment = $method->getDocComment();
-		if ( preg_match( '/@template ([^ ]+)/', $comment, $matches ) ) {
-			$templates[] = trim( $matches[1] );
+		// Make sure this method exists, otherwise the call to getMethod crashes PHP
+		// so badly it can't even log that a problem occurred.
+		if ( method_exists( $controllerClass, $methodName ) ) {
+			// See if there is a @template annotation for the method we're generating a view for
+			$reflection = new ReflectionClass( $controllerClass );
+			$method = $reflection->getMethod( $methodName );
+
+			$comment = $method->getDocComment();
+			if ( preg_match( '/@template ([^ ]+)/', $comment, $matches ) ) {
+				$templates[] = trim( $matches[ 1 ] );
+			}
 		}
 
 		// Add variations on the controller name

--- a/includes/wikia/tests/WikiaViewTest.php
+++ b/includes/wikia/tests/WikiaViewTest.php
@@ -37,11 +37,10 @@ class WikiaViewTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function setTemplateDataProvider() {
-		return array(
-		 array( true, 'Test' ),
-		 array( true, 'Oasis' ), // tmp, while modules still exists
-		 array( false, 'NonExistent' )
-		);
+		return [
+			[ true, 'Test' ],
+			[ false, 'NonExistent' ],
+		];
 	}
 
 	/**


### PR DESCRIPTION
This allows controller methods to define a @template annotation which will determine what base template name will be used to render that method's output, e.g.:

``` php
class FooController {
  const DEFAULT_TEMPLATE_ENGINE = \WikiaResponse::TEMPLATE_ENGINE_MUSTACHE;

  /**
   * @template myView
   */
  public function bar() {
    // code
  }
}
```

The view will look for a series of possible template names, falling back until it finds one that exists.  So in the above example it will check:
- extensions/wikia/Foo/templates/myView.mustache
- extensions/wikia/Foo/templates/Foo_bar.mustache
- extensions/wikia/Foo/templates/FooController_bar.mustache

This pull request also allows the controller to define an alternate template path via a `getTemplateDir` method.  If this method exists, the return value will be used as the template directory:

``` php
class FooController {
  public static function getTemplateDir() {
    return dirname( __FILE__ ) . '/subfolder/templates';
  }
}
```

In this case the search paths will look like:
- extensions/wikia/Foo/subfolder/templates/myView.mustache
- extensions/wikia/Foo/subfolder/templates/Foo_bar.mustache
- extensions/wikia/Foo/subfolder/templates/FooController_bar.mustache

Note if the directory given does not exist, it will fall back to the default location.

@Wikia/platform-team 
