### PR TITLE
Re-add required $optionsWithArgs array

### DIFF
--- a/maintenance/wikia/ingestPartnerVideoWithData.php
+++ b/maintenance/wikia/ingestPartnerVideoWithData.php
@@ -13,7 +13,7 @@ ini_set( 'display_errors', 'stdout' );
 
 // This global array is used by commandLine.inc included below. Without this line,
 // arguments passed to this script are not processed correctly.
-$optionsWithArgs = [ 's', 'e', ];
+$optionsWithArgs = [ 's', 'e' ];
 
 ini_set( "include_path", dirname(__FILE__)."/.." );
 require_once( 'commandLine.inc' );

--- a/maintenance/wikia/ingestPartnerVideoWithData.php
+++ b/maintenance/wikia/ingestPartnerVideoWithData.php
@@ -10,6 +10,11 @@
  */
 
 ini_set( 'display_errors', 'stdout' );
+
+// This global array is used by commandLine.inc included below. Without this line,
+// arguments passed to this script are not processed correctly.
+$optionsWithArgs = [ 'u', 's', 'e', 'i' ];
+
 ini_set( "include_path", dirname(__FILE__)."/.." );
 require_once( 'commandLine.inc' );
 

--- a/maintenance/wikia/ingestPartnerVideoWithData.php
+++ b/maintenance/wikia/ingestPartnerVideoWithData.php
@@ -13,7 +13,7 @@ ini_set( 'display_errors', 'stdout' );
 
 // This global array is used by commandLine.inc included below. Without this line,
 // arguments passed to this script are not processed correctly.
-$optionsWithArgs = [ 'u', 's', 'e', 'i' ];
+$optionsWithArgs = [ 's', 'e', ];
 
 ini_set( "include_path", dirname(__FILE__)."/.." );
 require_once( 'commandLine.inc' );


### PR DESCRIPTION
During the refactor of VideoIngestion done a few months ago (https://github.com/Wikia/app/pull/5339), a bug was introduced which borked the way command line arguments were being processed. This meant that when you passed any unix time stamp for start time or end time, it would always evaluate to 1.

The problem was the removal of [this line](https://github.com/Wikia/app/pull/5339/files#diff-e0718dbca917544223928e9a3ebc229fL14). That `$optionsWithArgs` array is used by the included `commandLine.inc` file below it. This PR re-adds that line to get the command line arguments working again.
