### PR TITLE
MAIN-4105 Make sure to only load Captha.js once

### DIFF
--- a/extensions/wikia/Captcha/Factory/Module.class.php
+++ b/extensions/wikia/Captcha/Factory/Module.class.php
@@ -48,6 +48,10 @@ class Module {
 	 * Load Captcha.js on demand when we're getting an instance of a Captcha.
 	 */
 	public static function addCaptchaJS() {
-		\Wikia::addAssetsToOutput( 'captcha_js' );
+		// Make sure we only load FancyCaptcha library once
+		if ( !\F::app()->wg->CaptchaLibraryLoaded ) {
+			\Wikia::addAssetsToOutput( 'captcha_js' );
+			\F::app()->wg->CaptchaLibraryLoaded = true;
+		}
 	}
 }


### PR DESCRIPTION
There was a bug where if a hook to get a Captcha was called multiple times, we would load the Captcha.js library multiple times as well. This fix makes sure we only load the Captcha.js library once.

Ticket: https://wikia-inc.atlassian.net/browse/MAIN-4105
