### PR TITLE
Ce 1427 make all update fallback create

### DIFF
--- a/extensions/wikia/ExactTargetUpdates/ExactTargetUpdates.setup.php
+++ b/extensions/wikia/ExactTargetUpdates/ExactTargetUpdates.setup.php
@@ -55,7 +55,7 @@ $wgAutoloadClasses['Wikia\ExactTarget\ExactTargetWikiHooksHelper'] =  $dir . '/h
 /* Add base task class */
 $wgAutoloadClasses['Wikia\ExactTarget\ExactTargetTask'] =  $dir . '/tasks/ExactTargetTask.php' ;
 /* Add user-related tasks classes */
-$wgAutoloadClasses['Wikia\ExactTarget\ExactTargetUserDataVerificatorTask'] =  $dir . '/tasks/ExactTargetUserDataVerificatorTask.php';
+$wgAutoloadClasses['Wikia\ExactTarget\ExactTargetUserDataVerificationTask'] =  $dir . '/tasks/ExactTargetUserDataVerificationTask.php';
 $wgAutoloadClasses['Wikia\ExactTarget\ExactTargetUserTaskHelper'] =  $dir . '/tasks/ExactTargetUserTaskHelper.php' ;
 $wgAutoloadClasses['Wikia\ExactTarget\ExactTargetCreateUserTask'] =  $dir . '/tasks/ExactTargetCreateUserTask.php' ;
 $wgAutoloadClasses['Wikia\ExactTarget\ExactTargetRetrieveUserHelper'] =  $dir . '/tasks/ExactTargetRetrieveUserHelper.php' ;

--- a/extensions/wikia/ExactTargetUpdates/hooks/ExactTargetUser.hooks.php
+++ b/extensions/wikia/ExactTargetUpdates/hooks/ExactTargetUser.hooks.php
@@ -132,12 +132,11 @@ class ExactTargetUserHooks {
 	public function onUserSaveSettings( \User $user ) {
 		/* Prepare params */
 		$oUserHelper = $this->getUserHelper();
-		$aUserData = $oUserHelper->prepareUserParams( $user );
 		$aUserProperties = $oUserHelper->prepareUserPropertiesParams( $user );
 
 		/* Get and run the task */
-		$task = $oUserHelper->getUpdateUserTask();
-		$task->call( 'updateUserPropertiesData', $aUserData, $aUserProperties );
+		$task = $oUserHelper->getCreateUserTask();
+		$task->call( 'createUserProperties', $user->getId(), $aUserProperties );
 		$task->queue();
 		return true;
 	}

--- a/extensions/wikia/ExactTargetUpdates/hooks/ExactTargetUser.hooks.php
+++ b/extensions/wikia/ExactTargetUpdates/hooks/ExactTargetUser.hooks.php
@@ -11,38 +11,21 @@ class ExactTargetUserHooks {
 	 * @return bool
 	 */
 	public function onUserRenameAfterAccountRename( $iUserId, $sOldUsername, $sNewUsername ) {
-		/* Prepare params */
-		$aUserData = [
-			'user_id' => $iUserId,
-			'user_name' => $sNewUsername
-		];
-
-		/* Get and run the task */
-		$oUserHelper = $this->getUserHelper();
-		$task = $oUserHelper->getUpdateUserTask();
-		$task->call( 'updateUserData', $aUserData );
-		$task->queue();
+		$oUser = \User::newFromId( $iUserId );
+		$oUser->setName( $sNewUsername ); // Reset new username just in case it's not propagated yet
+		$this->addTheUpdateCreateUserTask( $oUser );
 		return true;
 	}
 
 	/**
-	 * Adds Task for updating user editcount to job queue
+	 * Adds Task for updating user editcount to job queue.
+	 * Updates whole user record
 	 * @param WikiPage $article
 	 * @param User $user
 	 * @return bool
 	 */
-	public function onArticleSaveComplete( \WikiPage $article, \User $user ) {
-		/* Prepare params */
-		$aUserData = [
-			'user_id' => $user->getId(),
-			'user_editcount' => $user->getEditCount()
-		];
-
-		/* Get and run the task */
-		$oUserHelper = $this->getUserHelper();
-		$task = $oUserHelper->getUpdateUserTask();
-		$task->call( 'updateUserData', $aUserData );
-		$task->queue();
+	public function onArticleSaveComplete( \WikiPage $article, \User $oUser ) {
+		$this->addTheUpdateCreateUserTask( $oUser );
 		return true;
 	}
 

--- a/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetCreateUserTask.php
+++ b/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetCreateUserTask.php
@@ -12,8 +12,7 @@ class ExactTargetCreateUserTask extends ExactTargetTask {
 	public function updateCreateUserData( array $aUserData, array $aUserProperties ) {
 		/* Delete subscriber (email address) used by touched user */
 		$oDeleteUserTask = $this->getDeleteUserTask();
-		// Pass task ID to have all logs under one task
-		$oDeleteUserTask->taskId( $this->getTaskId() );
+		$oDeleteUserTask->taskId( $this->getTaskId() ); // Pass task ID to have all logs under one task
 		$oDeleteUserTask->deleteSubscriber( $aUserData['user_id'] );
 
 		/* Create Subscriber with new email */
@@ -26,14 +25,7 @@ class ExactTargetCreateUserTask extends ExactTargetTask {
 		$this->createUserProperties( $aUserData['user_id'], $aUserProperties );
 
 		/* Verify data */
-		$oUserDtaVerificatorTask = $this->getUserDataVerificatorTask();
-		$oUserDtaVerificatorTask->taskId( $this->getTaskId() );
-		$sUserDataVerificationResult = $oUserDtaVerificatorTask->execute( 'verifyUserData', [ $aUserData['user_id'] ] );
-		if ( $sUserDataVerificationResult != 'OK' ) {
-			throw new \Exception( $sUserDataVerificationResult );
-		} else {
-			$this->info( 'Verification passed. User record in ExactTarget match record in Wikia database' );
-		}
+		$this->verifyUserData( $aUserData['user_id'] );
 
 		return 'OK';
 	}
@@ -99,4 +91,14 @@ class ExactTargetCreateUserTask extends ExactTargetTask {
 		return $oCreateUserPropertiesResult->OverallStatus;
 	}
 
+	protected function verifyUserData( $iUserId ) {
+		$oUserDataVerificationTask = $this->getUserDataVerificationTask();
+		$oUserDataVerificationTask->taskId( $this->getTaskId() ); // Pass task ID to have all logs under one task
+		$sUserDataVerificationResult = $oUserDataVerificationTask->execute( 'verifyUserData', [ $iUserId ] );
+		if ( $sUserDataVerificationResult != 'OK' ) {
+			throw new \Exception( $sUserDataVerificationResult );
+		} else {
+			$this->info( 'Verification passed. User record in ExactTarget match record in Wikia database' );
+		}
+	}
 }

--- a/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetCreateUserTask.php
+++ b/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetCreateUserTask.php
@@ -51,7 +51,7 @@ class ExactTargetCreateUserTask extends ExactTargetTask {
 		$createSubscriberResult = $oApiDataExtension->createRequest( $aApiParams );
 
 		$this->info( __METHOD__ . ' OverallStatus: ' . $createSubscriberResult->OverallStatus );
-		$this->info( __METHOD__ . ' result: ' . json_encode( (array)$createSubscriberResult ) );
+		$this->info( __METHOD__ . ' Result: ' . json_encode( (array)$createSubscriberResult ) );
 	}
 
 	/**
@@ -67,7 +67,7 @@ class ExactTargetCreateUserTask extends ExactTargetTask {
 		$oCreateUserResult = $oApiDataExtension->updateFallbackCreateRequest( $aApiParams );
 
 		$this->info( __METHOD__ . ' OverallStatus: ' . $oCreateUserResult->OverallStatus );
-		$this->info( __METHOD__ . ' result: ' . json_encode( (array)$oCreateUserResult ) );
+		$this->info( __METHOD__ . ' Result: ' . json_encode( (array)$oCreateUserResult ) );
 
 		if ( $oCreateUserResult->OverallStatus === 'Error' ) {
 			throw new \Exception(
@@ -89,7 +89,7 @@ class ExactTargetCreateUserTask extends ExactTargetTask {
 		$oCreateUserPropertiesResult = $oApiDataExtension->updateFallbackCreateRequest( $aApiParams );
 
 		$this->info( __METHOD__ . ' OverallStatus: ' . $oCreateUserPropertiesResult->OverallStatus );
-		$this->info( __METHOD__ . ' result: ' . json_encode( (array)$oCreateUserPropertiesResult ) );
+		$this->info( __METHOD__ . ' Result: ' . json_encode( (array)$oCreateUserPropertiesResult ) );
 
 		if ( $oCreateUserPropertiesResult->OverallStatus === 'Error' ) {
 			throw new \Exception(

--- a/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetCreateUserTask.php
+++ b/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetCreateUserTask.php
@@ -96,6 +96,7 @@ class ExactTargetCreateUserTask extends ExactTargetTask {
 				'Error in ' . __METHOD__ . ': ' . $oCreateUserPropertiesResult->Results[0]->StatusMessage
 			);
 		}
+		return $oCreateUserPropertiesResult->OverallStatus;
 	}
 
 }

--- a/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetDeleteUserTask.php
+++ b/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetDeleteUserTask.php
@@ -20,17 +20,28 @@ class ExactTargetDeleteUserTask extends ExactTargetTask {
 	public function deleteSubscriber( $iUserId ) {
 		$oRetrieveUserHelper = $this->getRetrieveUserHelper();
 		$sUserEmail = $oRetrieveUserHelper->getUserEmail( $iUserId );
-		if ( !$this->isEmailInUse( $sUserEmail, $iUserId ) ) {
-			$oHelper = $this->getUserHelper();
-			$aApiParams = $oHelper->prepareSubscriberDeleteData( $sUserEmail );
-			$this->info( __METHOD__ . ' ApiParams: ' . json_encode( $aApiParams ) );
 
-			$oDeleteSubscriberResult = $this->doDeleteSubscriber( $aApiParams );
-
-			$this->info( __METHOD__ . ' OverallStatus: ' . $oDeleteSubscriberResult->OverallStatus );
-			$this->info( __METHOD__ . ' result: ' . json_encode( (array)$oDeleteSubscriberResult ) );
+		/* Skip deletion if no email found */
+		if ( empty( $sUserEmail ) ) {
+			$this->info(__METHOD__ . ": No email found for the user or there's no user record. Deletion skipped.");
+			return;
 		}
-		$this->info(__METHOD__ . ': Email in use by different account (record). Removal skipped.');
+
+		/* Skip deletion if email is used by other account */
+		if ( $this->isEmailInUse( $sUserEmail, $iUserId ) ) {
+			$this->info(__METHOD__ . ': Email in use by different account (record). Deletion skipped.');
+			return;
+		}
+
+		$oHelper = $this->getUserHelper();
+		$aApiParams = $oHelper->prepareSubscriberDeleteData( $sUserEmail );
+		$this->info( __METHOD__ . ' ApiParams: ' . json_encode( $aApiParams ) );
+
+		/* Delete subscriber */
+		$oDeleteSubscriberResult = $this->doDeleteSubscriber( $aApiParams );
+
+		$this->info( __METHOD__ . ' OverallStatus: ' . $oDeleteSubscriberResult->OverallStatus );
+		$this->info( __METHOD__ . ' Result: ' . json_encode( (array)$oDeleteSubscriberResult ) );
 	}
 
 	/**
@@ -56,7 +67,7 @@ class ExactTargetDeleteUserTask extends ExactTargetTask {
 		$oDeleteUserResult = $oApiDataExtension->deleteRequest( $aApiParams );
 
 		$this->info( __METHOD__ . ' OverallStatus: ' . $oDeleteUserResult->OverallStatus );
-		$this->info( __METHOD__ . ' result: ' . json_encode( (array)$oDeleteUserResult ) );
+		$this->info( __METHOD__ . ' Result: ' . json_encode( (array)$oDeleteUserResult ) );
 	}
 
 	/**
@@ -73,7 +84,7 @@ class ExactTargetDeleteUserTask extends ExactTargetTask {
 		$oDeleteUserPropertiesResult = $oApiDataExtension->deleteRequest( $aApiParams );
 
 		$this->info( __METHOD__ . ' OverallStatus: ' . $oDeleteUserPropertiesResult->OverallStatus );
-		$this->info( __METHOD__ . ' result: ' . json_encode( (array)$oDeleteUserPropertiesResult ) );
+		$this->info( __METHOD__ . ' Result: ' . json_encode( (array)$oDeleteUserPropertiesResult ) );
 	}
 
 	/**

--- a/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetRetrieveUserHelper.php
+++ b/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetRetrieveUserHelper.php
@@ -9,21 +9,32 @@ class ExactTargetRetrieveUserHelper extends ExactTargetTask {
 	 * @return null|string
 	 */
 	public function getUserEmail( $iUserId ) {
+		/* Prepare retrieve params */
 		$aProperties = [ 'user_email' ];
 		$sFilterProperty = 'user_id';
 		$aFilterValues = [ $iUserId ];
 		$oHelper = $this->getUserHelper();
 		$aApiParams = $oHelper->prepareUserRetrieveParams( $aProperties, $sFilterProperty, $aFilterValues );
+		$this->info( __METHOD__ . ' ApiParams: ' . json_encode( $aApiParams ) );
 
 		$oApiDataExtension = $this->getApiDataExtension();
+		/* Send retrieve request */
 		$oEmailResult = $oApiDataExtension->retrieveRequest( $aApiParams );
+		$this->info( __METHOD__ . ' OverallStatus: ' . $oEmailResult->OverallStatus );
+		$this->info( __METHOD__ . ' Result: ' . json_encode( (array)$oEmailResult ) );
 
-		if ( isset( $oEmailResult->Results->Properties->Property->Value ) ) {
-			return $oEmailResult->Results->Properties->Property->Value;
+		if ( $oEmailResult->OverallStatus === 'Error' ) {
+			throw new \Exception(
+				'Error in ' . __METHOD__ . ': ' . $oEmailResult->Results->StatusMessage
+			);
 		}
 
-		// $this->info( __METHOD__ . ' user DataExtension object not found for user_id = ' . $iUserId );
-		return null;
+		if ( empty( $oEmailResult->Results->Properties->Property->Value ) ) {
+			$this->info( __METHOD__ . ' User DataExtension object not found for user_id = ' . $iUserId );
+			return null;
+		}
+
+		return $oEmailResult->Results->Properties->Property->Value;
 	}
 
 	public function retrieveUserDataById( $iUserId ) {

--- a/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetTask.php
+++ b/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetTask.php
@@ -63,11 +63,11 @@ class ExactTargetTask extends BaseTask {
 	}
 
 	/**
-	 * Returns an instance of ExactTargetUserDataVerificator class
-	 * @return ExactTargetUserDataVerificator
+	 * Returns an instance of ExactTargetUserDataVerification class
+	 * @return ExactTargetUserDataVerification
 	 */
-	protected function getUserDataVerificatorTask() {
-		return new ExactTargetUserDataVerificatorTask();
+	protected function getUserDataVerificationTask() {
+		return new ExactTargetUserDataVerificationTask();
 	}
 
 	/**

--- a/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetTask.php
+++ b/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetTask.php
@@ -55,6 +55,14 @@ class ExactTargetTask extends BaseTask {
 	}
 
 	/**
+	 * A simple getter for an object of ExactTargetUserHooksHelper class
+	 * @return ExactTargetUserHooksHelper
+	 */
+	protected function getUserHooksHelper() {
+		return new ExactTargetUserHooksHelper();
+	}
+
+	/**
 	 * Returns an instance of ExactTargetUserDataVerificator class
 	 * @return ExactTargetUserDataVerificator
 	 */

--- a/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetUpdateUserTask.php
+++ b/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetUpdateUserTask.php
@@ -9,6 +9,7 @@ class ExactTargetUpdateUserTask extends ExactTargetTask {
 	 * Task for updating user data in ExactTarget
 	 *
 	 * @info Removed updateUserData method as was unused
+	 * @commit 9efbaa4f3a148445d8fa5cef4d2842184c6ba577
 	 *
 	 * @param array $aUserData Selected fields from Wikia user table
 	 */

--- a/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetUpdateUserTask.php
+++ b/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetUpdateUserTask.php
@@ -4,15 +4,14 @@ namespace Wikia\ExactTarget;
 class ExactTargetUpdateUserTask extends ExactTargetTask {
 
 	/**
+	 * Here was
+	 * public function updateUserData( $aUserData )
 	 * Task for updating user data in ExactTarget
+	 *
+	 * @info Removed updateUserData method as was unused
+	 *
 	 * @param array $aUserData Selected fields from Wikia user table
 	 */
-	public function updateUserData( $aUserData ) {
-		$oHelper = $this->getUserHelper();
-		$aApiParams = $oHelper->prepareUserUpdateParams( $aUserData );
-		$oApiDataExtension = $this->getApiDataExtension();
-		$oApiDataExtension->updateRequest( $aApiParams );
-	}
 
 	/**
 	 * Sends update of user email to ExactTarget

--- a/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetUpdateUserTask.php
+++ b/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetUpdateUserTask.php
@@ -30,11 +30,12 @@ class ExactTargetUpdateUserTask extends ExactTargetTask {
 		$oCreateUserTask->createSubscriber( $sUserEmail );
 
 		/* Prepare user fields for update */
+		$oHelper = $this->getUserHelper();
 		$oUserHooksHelper = $this->getUserHooksHelper();
-		$aUserData = $oUserHooksHelper->prepareUserParams( \User::newFromId( $iUserId ) );
+		$oUser = $oHelper->getUserFromId( $iUserId );
+		$aUserData = $oUserHooksHelper->prepareUserParams( $oUser );
 
 		/* Prepare user update API params */
-		$oHelper = $this->getUserHelper();
 		$aApiParams = $oHelper->prepareUserUpdateParams( $aUserData );
 		$this->info( __METHOD__ . ' ApiParams: ' . json_encode( $aApiParams ) );
 

--- a/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetUpdateUserTask.php
+++ b/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetUpdateUserTask.php
@@ -39,7 +39,7 @@ class ExactTargetUpdateUserTask extends ExactTargetTask {
 		$aApiParams = $oHelper->prepareUserUpdateParams( $aUserData );
 		$this->info( __METHOD__ . ' ApiParams: ' . json_encode( $aApiParams ) );
 		$oApiDataExtension = $this->getApiDataExtension();
-		$oUpdateUserEmailResult = $oApiDataExtension->updateRequest( $aApiParams );
+		$oUpdateUserEmailResult = $oApiDataExtension->updateFallbackCreateRequest( $aApiParams );
 
 		$this->info( __METHOD__ . ' OverallStatus: ' . $oUpdateUserEmailResult->OverallStatus );
 		$this->info( __METHOD__ . ' result: ' . json_encode( (array)$oUpdateUserEmailResult ) );

--- a/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetUpdateUserTask.php
+++ b/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetUpdateUserTask.php
@@ -26,23 +26,23 @@ class ExactTargetUpdateUserTask extends ExactTargetTask {
 		/* Subscriber list contains unique emails
 		 * Assuming email may be new - try to create subscriber object using the email */
 		$oCreateUserTask = $this->getCreateUserTask();
-		// Pass task ID to have all logs under one task
-		$oCreateUserTask->taskId( $this->getTaskId() );
+		$oCreateUserTask->taskId( $this->getTaskId() ); // Pass task ID to have all logs under one task
 		$oCreateUserTask->createSubscriber( $sUserEmail );
 
-		/* Update email in user data extension */
-		$aUserData = [
-			'user_id' => $iUserId,
-			'user_email' => $sUserEmail
-		];
+		/* Prepare user fields for update */
+		$oUserHooksHelper = $this->getUserHooksHelper();
+		$aUserData = $oUserHooksHelper->prepareUserParams( \User::newFromId( $iUserId ) );
+
+		/* Prepare user update API params */
 		$oHelper = $this->getUserHelper();
 		$aApiParams = $oHelper->prepareUserUpdateParams( $aUserData );
 		$this->info( __METHOD__ . ' ApiParams: ' . json_encode( $aApiParams ) );
+
+		/* Update user */
 		$oApiDataExtension = $this->getApiDataExtension();
 		$oUpdateUserEmailResult = $oApiDataExtension->updateFallbackCreateRequest( $aApiParams );
-
 		$this->info( __METHOD__ . ' OverallStatus: ' . $oUpdateUserEmailResult->OverallStatus );
-		$this->info( __METHOD__ . ' result: ' . json_encode( (array)$oUpdateUserEmailResult ) );
+		$this->info( __METHOD__ . ' Result: ' . json_encode( (array)$oUpdateUserEmailResult ) );
 
 		if ( $oUpdateUserEmailResult->OverallStatus === 'Error' ) {
 			throw new \Exception(

--- a/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetUpdateUserTask.php
+++ b/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetUpdateUserTask.php
@@ -22,6 +22,7 @@ class ExactTargetUpdateUserTask extends ExactTargetTask {
 	public function updateUserEmail( $iUserId, $sUserEmail ) {
 		/* Delete subscriber (email address) used by touched user */
 		$oDeleteUserTask = $this->getDeleteUserTask();
+		$oDeleteUserTask->taskId( $this->getTaskId() ); // Pass task ID to have all logs under one task
 		$oDeleteUserTask->deleteSubscriber( $iUserId );
 		/* Subscriber list contains unique emails
 		 * Assuming email may be new - try to create subscriber object using the email */

--- a/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetUserDataVerificationTask.php
+++ b/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetUserDataVerificationTask.php
@@ -1,7 +1,7 @@
 <?php
 namespace Wikia\ExactTarget;
 
-class ExactTargetUserDataVerificatorTask extends ExactTargetTask {
+class ExactTargetUserDataVerificationTask extends ExactTargetTask {
 
 	/**
 	 * Retrieves data from ExactTarget and compares it with data in Wikia database

--- a/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetUserTaskHelper.php
+++ b/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetUserTaskHelper.php
@@ -281,6 +281,15 @@ class ExactTargetUserTaskHelper {
 	}
 
 	/**
+	 * Returns User object for provided user ID
+	 * @param int $iUserId
+	 * @return \User
+	 */
+	public function getUserFromId( $iUserId ) {
+		return \User::newFromId( $iUserId );
+	}
+
+	/**
 	 * Get Customer Keys
 	 * CustomerKey is a key that indicates Wikia table reflected by DataExtension
 	 */

--- a/extensions/wikia/ExactTargetUpdates/tests/ExactTargetCreateUserTaskTest.php
+++ b/extensions/wikia/ExactTargetUpdates/tests/ExactTargetCreateUserTaskTest.php
@@ -30,17 +30,6 @@ class ExactTargetCreateUserTaskTest extends WikiaBaseTest {
 			->method( 'deleteSubscriber' )
 			->will($this->returnValue(8));
 
-		/* @var ExactTargetUserDataVerificationTask $oUserDataVerificationTask mock of ExactTargetUserDataVerificationTask class */
-		$oMockUserDataVerificationTask = $this->getMockBuilder( 'Wikia\ExactTarget\ExactTargetUserDataVerificationTask' )
-			->disableOriginalConstructor()
-			->setMethods( [ 'execute', 'taskId' ] )
-			->getMock();
-
-		$oMockUserDataVerificationTask
-			->expects( $this->once() )
-			->method( 'execute' )
-			->will( $this->returnValue( 'OK' ) );
-
 		/* Mock tested class /*
 		/* @var ExactTargetCreateUserTask $addTaskMock mock of ExactTargetCreateUserTask class */
 		$addTaskMock = $this->getMockBuilder( 'Wikia\ExactTarget\ExactTargetCreateUserTask' )

--- a/extensions/wikia/ExactTargetUpdates/tests/ExactTargetCreateUserTaskTest.php
+++ b/extensions/wikia/ExactTargetUpdates/tests/ExactTargetCreateUserTaskTest.php
@@ -22,7 +22,7 @@ class ExactTargetCreateUserTaskTest extends WikiaBaseTest {
 		/* @var ExactTargetDeleteUserTask $addTaskMock mock of ExactTargetDeleteUserTask class */
 		$oDeleteUserTask = $this->getMockBuilder( 'Wikia\ExactTarget\ExactTargetDeleteUserTask' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'deleteSubscriber' ] )
+			->setMethods( [ 'deleteSubscriber', 'taskId' ] )
 			->getMock();
 
 		$oDeleteUserTask
@@ -30,11 +30,22 @@ class ExactTargetCreateUserTaskTest extends WikiaBaseTest {
 			->method( 'deleteSubscriber' )
 			->will($this->returnValue(8));
 
+		/* @var ExactTargetUserDataVerificatorTask $oUserDataVerificatorTask mock of ExactTargetUserDataVerificatorTask class */
+		$oMockUserDataVerificatorTask = $this->getMockBuilder( 'Wikia\ExactTarget\ExactTargetUserDataVerificatorTask' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'execute', 'taskId' ] )
+			->getMock();
+
+		$oMockUserDataVerificatorTask
+			->expects( $this->once() )
+			->method( 'execute' )
+			->will( $this->returnValue( 'OK' ) );
+
 		/* Mock tested class /*
 		/* @var ExactTargetCreateUserTask $addTaskMock mock of ExactTargetCreateUserTask class */
 		$addTaskMock = $this->getMockBuilder( 'Wikia\ExactTarget\ExactTargetCreateUserTask' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'createSubscriber', 'createUser', 'createUserProperties', 'getDeleteUserTask' ] )
+			->setMethods( [ 'createSubscriber', 'createUser', 'createUserProperties', 'getDeleteUserTask', 'getUserDataVerificatorTask', 'getTaskId' ] )
 			->getMock();
 
 		$addTaskMock
@@ -42,6 +53,10 @@ class ExactTargetCreateUserTaskTest extends WikiaBaseTest {
 			->method( 'getDeleteUserTask' )
 			->will( $this->returnValue( $oDeleteUserTask ) );
 
+		$addTaskMock
+			->expects( $this->once() )
+			->method( 'getUserDataVerificatorTask' )
+			->will( $this->returnValue( $oMockUserDataVerificatorTask ) );
 
 		/* test createSubscriber invoke params */
 		$addTaskMock

--- a/extensions/wikia/ExactTargetUpdates/tests/ExactTargetCreateUserTaskTest.php
+++ b/extensions/wikia/ExactTargetUpdates/tests/ExactTargetCreateUserTaskTest.php
@@ -30,13 +30,13 @@ class ExactTargetCreateUserTaskTest extends WikiaBaseTest {
 			->method( 'deleteSubscriber' )
 			->will($this->returnValue(8));
 
-		/* @var ExactTargetUserDataVerificatorTask $oUserDataVerificatorTask mock of ExactTargetUserDataVerificatorTask class */
-		$oMockUserDataVerificatorTask = $this->getMockBuilder( 'Wikia\ExactTarget\ExactTargetUserDataVerificatorTask' )
+		/* @var ExactTargetUserDataVerificationTask $oUserDataVerificationTask mock of ExactTargetUserDataVerificationTask class */
+		$oMockUserDataVerificationTask = $this->getMockBuilder( 'Wikia\ExactTarget\ExactTargetUserDataVerificationTask' )
 			->disableOriginalConstructor()
 			->setMethods( [ 'execute', 'taskId' ] )
 			->getMock();
 
-		$oMockUserDataVerificatorTask
+		$oMockUserDataVerificationTask
 			->expects( $this->once() )
 			->method( 'execute' )
 			->will( $this->returnValue( 'OK' ) );
@@ -45,18 +45,13 @@ class ExactTargetCreateUserTaskTest extends WikiaBaseTest {
 		/* @var ExactTargetCreateUserTask $addTaskMock mock of ExactTargetCreateUserTask class */
 		$addTaskMock = $this->getMockBuilder( 'Wikia\ExactTarget\ExactTargetCreateUserTask' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'createSubscriber', 'createUser', 'createUserProperties', 'getDeleteUserTask', 'getUserDataVerificatorTask', 'getTaskId' ] )
+			->setMethods( [ 'createSubscriber', 'createUser', 'createUserProperties', 'getDeleteUserTask', 'verifyUserData', 'getTaskId' ] )
 			->getMock();
 
 		$addTaskMock
 			->expects( $this->once() )
 			->method( 'getDeleteUserTask' )
 			->will( $this->returnValue( $oDeleteUserTask ) );
-
-		$addTaskMock
-			->expects( $this->once() )
-			->method( 'getUserDataVerificatorTask' )
-			->will( $this->returnValue( $oMockUserDataVerificatorTask ) );
 
 		/* test createSubscriber invoke params */
 		$addTaskMock

--- a/extensions/wikia/ExactTargetUpdates/tests/ExactTargetUpdateUserTaskTest.php
+++ b/extensions/wikia/ExactTargetUpdates/tests/ExactTargetUpdateUserTaskTest.php
@@ -104,7 +104,7 @@ class ExactTargetUpdateUserTaskTest extends WikiaBaseTest {
 			->expects( $this->once() )
 			->method( 'createSubscriber' );
 
-		/* Mock ExactTargetCreateUserTask */
+		/* Mock ExactTargetDeleteUserTask */
 		$mockDeleteUserTask = $this->getMockBuilder( 'Wikia\ExactTarget\ExactTargetDeleteUserTask' )
 			->disableOriginalConstructor()
 			->setMethods( [ 'deleteSubscriber', 'taskId' ] )

--- a/extensions/wikia/ExactTargetUpdates/tests/ExactTargetUpdateUserTaskTest.php
+++ b/extensions/wikia/ExactTargetUpdates/tests/ExactTargetUpdateUserTaskTest.php
@@ -55,30 +55,50 @@ class ExactTargetUpdateUserTaskTest extends WikiaBaseTest {
 	 */
 	function testUpdateUserEmailShouldSendData( $aUserData, $aApiParams, $aMockCustomerKey ) {
 
+		$userMock = $this->getMockBuilder( 'User' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		/* @var ExactTargetApiDataExtension $mockApiDataExtension mock of ExactTargetApiDataExtension */
 		$mockApiDataExtension = $this->getMockBuilder( 'Wikia\ExactTarget\ExactTargetApiDataExtension' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'updateRequest' ] )
+			->setMethods( [ 'updateFallbackCreateRequest' ] )
 			->getMock();
 		$mockApiDataExtension
 			->expects( $this->once() )
-			->method( 'updateRequest' )
+			->method( 'updateFallbackCreateRequest' )
 			->with( $aApiParams );
 
-		/* @var ExactTargetUserTaskHelper $mockApiDataExtension mock of ExactTargetUserTaskHelper */
+		/* @var ExactTargetUserTaskHelper $mockUserHelper mock of ExactTargetUserTaskHelper */
 		$mockUserHelper = $this->getMockBuilder( 'Wikia\ExactTarget\ExactTargetUserTaskHelper' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getCustomerKeys' ] )
+			->setMethods( [ 'getCustomerKeys', 'getUserFromId' ] )
 			->getMock();
 		$mockUserHelper
 			->expects( $this->once() )
 			->method( 'getCustomerKeys' )
 			->will( $this->returnValue( $aMockCustomerKey ) );
+		$mockUserHelper
+			->expects( $this->once() )
+			->method( 'getUserFromId' )
+			->with( $aUserData['user_id'] )
+			->will( $this->returnValue( $userMock ) );
+
+		/* @var ExactTargetUserHooksHelper $mockUserHooksHelper mock of ExactTargetUserHooksHelper */
+		$mockUserHooksHelper = $this->getMockBuilder( 'Wikia\ExactTarget\ExactTargetUserHooksHelper' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'prepareUserParams' ] )
+			->getMock();
+		$mockUserHooksHelper
+			->expects( $this->once() )
+			->method( 'prepareUserParams' )
+			->with( $userMock )
+			->will( $this->returnValue( $aUserData ) );
 
 		/* Mock ExactTargetCreateUserTask */
 		$mockCreateUserTask = $this->getMockBuilder( 'Wikia\ExactTarget\ExactTargetCreateUserTask' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'createSubscriber' ] )
+			->setMethods( [ 'createSubscriber', 'taskId' ] )
 			->getMock();
 		$mockCreateUserTask
 			->expects( $this->once() )
@@ -97,7 +117,7 @@ class ExactTargetUpdateUserTaskTest extends WikiaBaseTest {
 		/* @var Wikia\ExactTarget\ExactTargetUpdateUserTask $mockUpdateUserTask */
 		$mockUpdateUserTask = $this->getMockBuilder( 'Wikia\ExactTarget\ExactTargetUpdateUserTask' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getApiDataExtension', 'getCreateUserTask', 'getDeleteUserTask', 'getUserHelper' ] )
+			->setMethods( [ 'getApiDataExtension', 'getCreateUserTask', 'getDeleteUserTask', 'getUserHelper', 'getUserHooksHelper' ] )
 			->getMock();
 		$mockUpdateUserTask
 			->expects( $this->once() )
@@ -107,6 +127,10 @@ class ExactTargetUpdateUserTaskTest extends WikiaBaseTest {
 			->expects( $this->once() )
 			->method( 'getUserHelper' )
 			->will( $this->returnValue( $mockUserHelper ) );
+		$mockUpdateUserTask
+			->expects( $this->once() )
+			->method( 'getUserHooksHelper' )
+			->will( $this->returnValue( $mockUserHooksHelper ) );
 		$mockUpdateUserTask
 			->expects( $this->once() )
 			->method( 'getCreateUserTask' )

--- a/extensions/wikia/ExactTargetUpdates/tests/ExactTargetUpdateUserTaskTest.php
+++ b/extensions/wikia/ExactTargetUpdates/tests/ExactTargetUpdateUserTaskTest.php
@@ -179,27 +179,8 @@ class ExactTargetUpdateUserTaskTest extends WikiaBaseTest {
 			]
 		];
 
-		/* User update params */
-		$sUpdateUserMethodName = 'updateUserData';
-		$iUserId = 12345;
-		$aUserData2 = [
-			'user_field1' => 'value1',
-			'user_field2' => 'value2',
-		];
-		$aInvokeParamsUser = [ array_merge( $aUserData2, [ 'user_id' => $iUserId ] ) ];
-		$aUserApiParams = [
-			'DataExtension' => [
-				[
-					'CustomerKey' => $sCustomerKey,
-					'Properties' => $aUserData2,
-					'Keys' => [ 'user_id' => $iUserId ]
-				]
-			]
-		];
-
 		return [
 			[ $aInvokeParamsUserProperties, $aUserPropertiesApiParams, $aCustomerKeys, $sUpdateUserPropertiesMethodName ],
-			[ $aInvokeParamsUser, $aUserApiParams, $aCustomerKeys, $sUpdateUserMethodName ],
 		];
 	}
 

--- a/extensions/wikia/ExactTargetUpdates/tests/ExactTargetUpdateUserTaskTest.php
+++ b/extensions/wikia/ExactTargetUpdates/tests/ExactTargetUpdateUserTaskTest.php
@@ -107,7 +107,7 @@ class ExactTargetUpdateUserTaskTest extends WikiaBaseTest {
 		/* Mock ExactTargetCreateUserTask */
 		$mockDeleteUserTask = $this->getMockBuilder( 'Wikia\ExactTarget\ExactTargetDeleteUserTask' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'deleteSubscriber' ] )
+			->setMethods( [ 'deleteSubscriber', 'taskId' ] )
 			->getMock();
 		$mockDeleteUserTask
 			->expects( $this->once() )
@@ -117,7 +117,7 @@ class ExactTargetUpdateUserTaskTest extends WikiaBaseTest {
 		/* @var Wikia\ExactTarget\ExactTargetUpdateUserTask $mockUpdateUserTask */
 		$mockUpdateUserTask = $this->getMockBuilder( 'Wikia\ExactTarget\ExactTargetUpdateUserTask' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getApiDataExtension', 'getCreateUserTask', 'getDeleteUserTask', 'getUserHelper', 'getUserHooksHelper' ] )
+			->setMethods( [ 'getApiDataExtension', 'getCreateUserTask', 'getDeleteUserTask', 'getUserHelper', 'getUserHooksHelper', 'getTaskId' ] )
 			->getMock();
 		$mockUpdateUserTask
 			->expects( $this->once() )


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CE-1427

First part of fallback to create changes. Fallback to create for user data changes.

Aim is to make all ExactTarget updates fallback to create due to sync process concept between Wikia and ExactTarget. Once ET clears DB and waits for data dump from Wikia we want to send hot data and create missing records.

@Wikia/community-engineering 
