### PR TITLE
Preferences::validateSignature - force the class of $form argument

### DIFF
--- a/includes/Preferences.php
+++ b/includes/Preferences.php
@@ -1223,7 +1223,7 @@ class Preferences {
 	 * @param $form HTMLForm
 	 * @return bool|string
 	 */
-	static function validateSignature( $signature, $alldata, $form ) {
+	static function validateSignature( $signature, $alldata, HTMLForm $form ) {
 		global $wgParser, $wgMaxSigChars;
 		if ( mb_strlen( $signature ) > $wgMaxSigChars ) {
 			return Xml::element( 'span', array( 'class' => 'error' ),


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/ER-5850

Give more context for `PHP Fatal error:  Call to a member function msg() on a non-object in /includes/Preferences.php on line 1234`.

@michalroszka 
