### PR TITLE
Add proper HTTP performance tracking to Helios requests

### DIFF
--- a/extensions/wikia/Helios/Client.class.php
+++ b/extensions/wikia/Helios/Client.class.php
@@ -53,7 +53,7 @@ class Client
 
 		// Request execution.
 		/** @var \MWHttpRequest $request */
-		$request = \Http::request($options['method'],$uri,$options);
+		$request = \Http::request( $options['method'], $uri, $options );
 		$status = $request->status;
 
 		// Response handling.

--- a/extensions/wikia/Helios/Client.class.php
+++ b/extensions/wikia/Helios/Client.class.php
@@ -39,22 +39,22 @@ class Client
 		$uri = "{$this->baseUri}{$resourceName}?" . http_build_query($getParams);
 		
 		// Request options pre-processing.
-		$defaultOptions = [
-			'method'		=> 'GET',
-			'timeout'		=> 5,
-			'postData'		=> $postData,
-			'noProxy'		=> true,
-			'followRedirects'	=> false,
-			'returnInstance'	=> true
+		$options = [
+			'method'          => 'GET',
+			'timeout'         => 5,
+			'postData'        => $postData,
+			'noProxy'         => true,
+			'followRedirects' => false,
+			'returnInstance'  => true,
+			'internalRequest' => true,
 		];
 
-		$requestOptions = array_merge( $defaultOptions, $extraRequestOptions );
+		$options = array_merge( $options, $extraRequestOptions );
 
 		// Request execution.
-		$request = \MWHttpRequest::factory( $uri, $requestOptions );
-		$request->setHeader(RequestId::REQUEST_HEADER_NAME, RequestId::instance()->getRequestId());
-		$request->setHeader(RequestId::REQUEST_HEADER_ORIGIN_HOST, wfHostname());
-		$status = $request->execute();
+		/** @var \MWHttpRequest $request */
+		$request = \Http::request($options['method'],$uri,$options);
+		$status = $request->status;
 
 		// Response handling.
 		if ( !$status->isGood() ) {

--- a/extensions/wikia/Helios/tests/ClientTest.php
+++ b/extensions/wikia/Helios/tests/ClientTest.php
@@ -32,11 +32,9 @@ class ClientTest extends \WikiaBaseTest {
 			->willReturn( false );
 
 		$requestMock = $this->getMock( '\CurlHttpRequest', [ 'execute' ], [ 'http://example.com' ], '', false );
-		$requestMock->expects( $this->once() )
-			->method( 'execute' )
-			->willReturn( $statusMock );
+		$requestMock->status = $statusMock;
 
-		$this->mockStaticMethod( '\MWHttpRequest', 'factory', $requestMock );
+		$this->mockStaticMethod( '\Http', 'request', $requestMock );
 
 		$client = new Client( 'http://example.com', 'id', 'secret' );
 		$client->request( 'resource', [], [], [] );
@@ -54,14 +52,12 @@ class ClientTest extends \WikiaBaseTest {
 			->willReturn( true );
 
 		$requestMock = $this->getMock( '\CurlHttpRequest', [ 'execute', 'getContent' ], [ 'http://example.com' ], '', false );
-		$requestMock->expects( $this->once() )
-			->method( 'execute' )
-			->willReturn( $statusMock );
+		$requestMock->status = $statusMock;
 		$requestMock->expects( $this->once() )
 			->method( 'getContent' )
 			->willReturn( null );
 
-		$this->mockStaticMethod( '\MWHttpRequest', 'factory', $requestMock );
+		$this->mockStaticMethod( '\Http', 'request', $requestMock );
 
 		$client = new Client( 'http://example.com', 'id', 'secret' );
 		$client->request( 'resource', [], [], [] );
@@ -77,14 +73,12 @@ class ClientTest extends \WikiaBaseTest {
 			->willReturn( true );
 
 		$requestMock = $this->getMock( '\CurlHttpRequest', [ 'execute', 'getContent' ], [ 'http://example.com' ], '', false );
-		$requestMock->expects( $this->once() )
-			->method( 'execute' )
-			->willReturn( $statusMock );
+		$requestMock->status = $statusMock;
 		$requestMock->expects( $this->once() )
 			->method( 'getContent' )
 			->willReturn( '{}' );
 
-		$this->mockStaticMethod( '\MWHttpRequest', 'factory', $requestMock );
+		$this->mockStaticMethod( '\Http', 'request', $requestMock );
 
 		$client = new Client( 'http://example.com', 'id', 'secret' );
 		$this->assertInternalType( 'object', $client->request( 'resource', [], [], [] ) );

--- a/includes/HttpFunctions.php
+++ b/includes/HttpFunctions.php
@@ -54,10 +54,6 @@ class Http {
 			}
 		}
 
-		// @author macbre
-		// pass Request ID to internal requests
-		$req->setHeader( Wikia\Util\RequestId::REQUEST_HEADER_NAME, Wikia\Util\RequestId::instance()->getRequestId() );
-
 		// Wikia change - end
 		if( isset( $options['userAgent'] ) ) {
 			$req->setUserAgent( $options['userAgent'] );
@@ -289,6 +285,7 @@ class MWHttpRequest {
 		// Wikia change - @author: wladek - begin
 		// allow overriding of curl options
 		$members[] = "curlOptions";
+		$members[] = "internalRequest";
 		// Wikia change - end
 
 		foreach ( $members as $o ) {
@@ -490,12 +487,14 @@ class MWHttpRequest {
 			$this->setUserAgent( Http::userAgent() );
 		}
 
+		// @author macbre
+		// pass Request ID to internal requests
+		$this->setHeader( Wikia\Util\RequestId::REQUEST_HEADER_NAME, Wikia\Util\RequestId::instance()->getRequestId() );
+
 		// Wikia change - begin - @author: wladek
-		// Append tracking headers: X-Request-Id and the family to internal requests
-		// so we can correlate them in the logs
-		if ( $this->internalRequest && is_callable( [ 'Wikia\\Util\\RequestId', 'instance'])) {
-			$this->setHeader(Wikia\Util\RequestId::REQUEST_HEADER_NAME, Wikia\Util\RequestId::instance()->getRequestId());
-			$this->setHeader(Wikia\Util\RequestId::REQUEST_HEADER_ORIGIN_HOST, wfHostname());
+		// Append extra headers for internal requests, currently only X-Request-Origin-Host
+		if ( $this->internalRequest ) {
+			$this->setHeader( Wikia\Util\RequestId::REQUEST_HEADER_ORIGIN_HOST, wfHostname() );
 		}
 		// Wikia change - end
 	}

--- a/includes/HttpFunctions.php
+++ b/includes/HttpFunctions.php
@@ -248,6 +248,17 @@ class MWHttpRequest {
 	protected $respStatus = "200 Ok";
 	protected $respHeaders = array();
 
+	// Wikia change - begin - @author: wladek
+	/**
+	 * Send X-Request-Id and X-Request-Origin-Host headers
+	 * @var bool
+	 */
+	protected $internalRequest = false;
+	// Wikia change - end
+
+	/**
+	 * @var Status
+	 */
 	public $status;
 
 	/**
@@ -478,6 +489,15 @@ class MWHttpRequest {
 		if ( !isset( $this->reqHeaders['User-Agent'] ) ) {
 			$this->setUserAgent( Http::userAgent() );
 		}
+
+		// Wikia change - begin - @author: wladek
+		// Append tracking headers: X-Request-Id and the family to internal requests
+		// so we can correlate them in the logs
+		if ( $this->internalRequest && is_callable( [ 'Wikia\\Util\\RequestId', 'instance'])) {
+			$this->setHeader(Wikia\Util\RequestId::REQUEST_HEADER_NAME, Wikia\Util\RequestId::instance()->getRequestId());
+			$this->setHeader(Wikia\Util\RequestId::REQUEST_HEADER_ORIGIN_HOST, wfHostname());
+		}
+		// Wikia change - end
 	}
 
 	/**


### PR DESCRIPTION
We need more data about performance of Helios from app perspective. 
I refactored how Helios interacts with the core http routines so the data will be logged.

/cc @macbre @michalroszka 
