### PR TITLE
Load BannerNotifications only when needed

### DIFF
--- a/extensions/wikia/CookiePolicy/scripts/cookiePolicy.js
+++ b/extensions/wikia/CookiePolicy/scripts/cookiePolicy.js
@@ -3,9 +3,8 @@ require([
 	'mw',
 	'wikia.window',
 	'wikia.cookies',
-	'wikia.geo',
-	'BannerNotification'
-], function ($, mw, window, cookies, geo, BannerNotification) {
+	'wikia.geo'
+], function ($, mw, window, cookies, geo) {
 	'use strict';
 
 	/**
@@ -33,16 +32,18 @@ require([
 	 * Display the cookie policy message to the user
 	 */
 	function showBanner() {
-		var message = mw.message('cookie-policy-notification-message').parse(),
-			bannerNotification = new BannerNotification(message, 'notify').show();
-
-		// currently, mw.message doesn't support the #NewWindowLink magic word, so we'll have to use JS
-		bannerNotification.$element.find('a').on('click', function (event) {
-			var url = $(this).attr('href');
-			event.preventDefault();
-			window.open(url, '_blank');
+		require(['BannerNotification'], function (BannerNotification) {
+			var message = mw.message('cookie-policy-notification-message').parse(),
+				bannerNotification = new BannerNotification(message, 'notify').show();
+			// currently, mw.message doesn't support the #NewWindowLink magic word,
+			// so we'll have to use JS
+			bannerNotification.$element.find('a').on('click', function (event) {
+				var url = $(this).attr('href');
+				event.preventDefault();
+				window.open(url, '_blank');
+			});
+			setCookie();
 		});
-		setCookie();
 	}
 
 	/**
@@ -64,7 +65,5 @@ require([
 		});
 	}
 
-	$(function () {
-		initCookieNotification();
-	});
+	$(initCookieNotification);
 });


### PR DESCRIPTION
@lizlux Could you take a look? This way we make sure to require BannerNotifications after the DOM is initialized. This should fix the Uncaught again (I was able to reproduce it in about 1/10 - 1/20 of the cases, really weird stuff).

I'm starting to feel this AMD support for BannerNotifications is to shaky, so maybe we should consider withdrawing it at some point and leaving just the global constructor...
