### PR TITLE
SOC-528 fixing race condition with JS asset loading

### DIFF
--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -2266,6 +2266,14 @@ $config['wikia_in_your_lang_js'] = [
 	]
 ];
 
+$config['cookie_policy_js'] = [
+	'type' => AssetsManager::TYPE_JS,
+	'skin' => ['oasis', 'monobook'],
+	'assets' => [
+		'//extensions/wikia/CookiePolicy/scripts/cookiePolicy.js',
+	]
+];
+
 $config['facebook_client_xfbml_js'] = [
 	'type' => AssetsManager::TYPE_JS,
 	'skin' => ['oasis', 'monobook'],

--- a/extensions/wikia/CookiePolicy/CookiePolicy.hooks.php
+++ b/extensions/wikia/CookiePolicy/CookiePolicy.hooks.php
@@ -14,7 +14,11 @@ class CookiePolicyHooks {
 	 * @return bool
 	 */
 	public static function onBeforePageDisplay( \OutputPage $out ) {
+		// use resource loader for i18n messages in JS
 		$out->addModules( 'ext.cookiePolicy' );
+
+		// use AssetsManager for script loading to avoid race conditions (SOC-528)
+		\Wikia::addAssetsToOutput( 'cookie_policy_js' );
 		return true;
 	}
 }

--- a/extensions/wikia/CookiePolicy/CookiePolicy.setup.php
+++ b/extensions/wikia/CookiePolicy/CookiePolicy.setup.php
@@ -1,5 +1,4 @@
 <?
-
 /**
  * @global Array $wgExtensionCredits The list of extension credits.
  * @see http://www.mediawiki.org/wiki/Manual:$wgExtensionCredits
@@ -25,16 +24,10 @@ $wgAutoloadClasses['Wikia\CookiePolicy\CookiePolicyHooks'] = __DIR__ . '/CookieP
 $wgResourceModules['ext.cookiePolicy'] = [
 	'localBasePath' => __DIR__ . '/scripts',
 	'remoteExtPath' => 'wikia/CookiePolicy/scripts',
-	'scripts' => 'cookiePolicy.js',
 	'messages' => [
 		'cookie-policy-notification-message',
 	],
 	'dependencies' => [
-		'jquery',
-		'mediawiki',
-		'wikia.window',
-		'wikia.cookies',
-		'wikia.geo',
 		// needed for message wikitext parsing
 		'mediawiki.jqueryMsg',
 	],

--- a/extensions/wikia/WikiaInYourLang/WikiaInYourLang.hooks.php
+++ b/extensions/wikia/WikiaInYourLang/WikiaInYourLang.hooks.php
@@ -10,7 +10,7 @@ class WikiaInYourLangHooks {
 
 	/**
 	 * Add JS assets package to the output
-	 * @param  \OutputPage $out  An output object passed from a hook
+	 * @param \OutputPage $out  An output object passed from a hook
 	 * @return bool
 	 */
 	public static function onBeforePageDisplay( \OutputPage $out ) {


### PR DESCRIPTION
This make sure we're using the same asset loading mechanism for the CookiePolicy extension and the BannerNotification extension. This should get rid of the race condition. 

Ticket: https://wikia-inc.atlassian.net/browse/SOC-528

Note that we're still using ResourceLoader for enabling wikitext parsing in JS messages. 
