### PR TITLE
Soc 442 app

### DIFF
--- a/extensions/wikia/Chat2/js/models/models.js
+++ b/extensions/wikia/Chat2/js/models/models.js
@@ -52,14 +52,6 @@ var STATUS_STATE_AWAY = 'away';
 		}
 	});
 
-	models.InitqueryCommand = models.Command.extend({
-		initialize: function(){
-			this.set({
-				command: 'initquery'
-			});
-		}
-	});
-
 	models.LogoutCommand = models.Command.extend({
 		initialize: function(){
 			this.set({
@@ -161,6 +153,7 @@ var STATUS_STATE_AWAY = 'away';
 			'temp': false //use for long time connection with private
 		}
 	});
+
 	/**
 	 * Inline alerts are a special type of ChatEntry which aren't from a user and should be displayed differently (like system messages basically).
 	 *

--- a/extensions/wikia/Chat2/templates/Chat_Index.php
+++ b/extensions/wikia/Chat2/templates/Chat_Index.php
@@ -21,7 +21,7 @@
 	<?php endforeach;?>
 
 	<!-- temporary hack -->
-	<script src="https://cdn.socket.io/socket.io-1.0.6.js"></script>
+	<script src="https://cdn.socket.io/socket.io-1.3.5.js"></script>
 	<?= $globalVariablesScript ?>
 	<?php //TODO: use js var?>
 


### PR DESCRIPTION
Two small changes related to the front-end of chat.

The first one is just deleting a method-definition that was literally a duplicate. The benefit is really small, just somewhat-smaller filesize and one less potential area for disaster (if you changed the first method definition, the second method would actually still be overwriting it, so your changes wouldn't work). ;) #Cleanliness.

The second change is to upgrade the client-side to use the latest socket.io: 1.3.5.  The server is already using 1.3.5 to great success... this will put them on the same version.  The only expected changes are that the socket.io team claims there are some performance improvements (those might have all been server-side though, because the server is doing great now).
