### PR TITLE
Add tests for our specific PHP extensions

### DIFF
--- a/includes/wikia/services/templates/test.mustache
+++ b/includes/wikia/services/templates/test.mustache
@@ -1,0 +1,7 @@
+start
+{{#check}}
+yes
+{{/check}}
+{{^check}}
+no
+{{/check}}

--- a/includes/wikia/services/tests/DiffEngineTest.php
+++ b/includes/wikia/services/tests/DiffEngineTest.php
@@ -1,0 +1,18 @@
+<?php
+
+class DiffEngineTest extends WikiaBaseTest {
+
+	public function testExtensionsIsLoaded() {
+		$this->assertTrue( extension_loaded( 'wikidiff2' ), '"wikidiff2" PHP extension needs to be loaded!' );
+	}
+
+	public function testGetDiff() {
+		$engine = new DifferenceEngine();
+
+		$textA = 'foo';
+		$textB = 'foobar';
+
+		$diff = $engine->generateDiffBody( $textA, $textB );
+		$this->assertContains( '<span class="diffchange diffchange-inline">foo</span>', $diff );
+	}
+}

--- a/includes/wikia/services/tests/MustacheServiceTest.php
+++ b/includes/wikia/services/tests/MustacheServiceTest.php
@@ -12,6 +12,10 @@ class MustacheServiceTest extends WikiaBaseTest {
 		$this->service = MustacheService::getInstance();
 	}
 
+	public function testExtensionsIsLoader() {
+		$this->assertTrue( extension_loaded( 'mustache' ), '"mustache" PHP extension needs to be loaded!' );
+	}
+
 	/**
 	 * @dataProvider renderDataProvider
 	 */

--- a/includes/wikia/services/tests/MustacheServiceTest.php
+++ b/includes/wikia/services/tests/MustacheServiceTest.php
@@ -12,7 +12,7 @@ class MustacheServiceTest extends WikiaBaseTest {
 		$this->service = MustacheService::getInstance();
 	}
 
-	public function testExtensionsIsLoader() {
+	public function testExtensionsIsLoaded() {
 		$this->assertTrue( extension_loaded( 'mustache' ), '"mustache" PHP extension needs to be loaded!' );
 	}
 

--- a/includes/wikia/services/tests/MustacheServiceTest.php
+++ b/includes/wikia/services/tests/MustacheServiceTest.php
@@ -1,0 +1,34 @@
+<?php
+
+class MustacheServiceTest extends WikiaBaseTest {
+
+	/* @var MustacheService $service */
+	private $file, $service;
+
+	public function setUp(){
+		parent::setUp();
+
+		$this->file = __DIR__ . '/../templates/test.mustache';
+		$this->service = MustacheService::getInstance();
+	}
+
+	/**
+	 * @dataProvider renderDataProvider
+	 */
+	public function testRender( $data, $expected ) {
+		$this->assertEquals( $expected, trim( $this->service->render( $this->file, $data ) ) );
+	}
+
+	public function renderDataProvider() {
+		return [
+			[
+				[ 'check' => true ],
+				"start\n\nyes"
+			],
+			[
+				[ 'check' => false ],
+				"start\n\n\nno"
+			]
+		];
+	}
+}


### PR DESCRIPTION
Prevent regressions during next PHP upgrade:
- https://wikia-inc.atlassian.net/browse/PLATFORM-1026
- https://wikia-inc.atlassian.net/browse/PLATFORM-1029

Check that `wikidiff2` and `mustache` PHP extensions are loaded..Our code & MW core depends on them and does not work well when applying a fallback.

@michalroszka 
