### PR TITLE
ADEN-1831 do not load liftium if there is noexternals set to 1

### DIFF
--- a/extensions/wikia/AdEngine/AdEngine2Service.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2Service.class.php
@@ -26,10 +26,12 @@ class AdEngine2Service {
 		return in_array( $pageType, $pageTypes );
 	}
 
-
 	public static function shouldLoadLiftium() {
 		global $wgAdEngineDisableLateQueue;
-		return !$wgAdEngineDisableLateQueue;
+
+		$pageType = ( new AdEngine2PageTypeService() )->getPageType();
+
+		return !$wgAdEngineDisableLateQueue && ($pageType !== AdEngine2PageTypeService::PAGE_TYPE_NO_ADS);
 	}
 
 	public static function shouldLoadLateQueue() {


### PR DESCRIPTION
When we put `?noexternals=1` in the URL in network tab we can still see a call send to liftium. This behaviour is changed with code changes below.
