### PR TITLE
SOC-528 fixing race condition with message not loading

### DIFF
--- a/extensions/wikia/CookiePolicy/CookiePolicy.hooks.php
+++ b/extensions/wikia/CookiePolicy/CookiePolicy.hooks.php
@@ -15,7 +15,7 @@ class CookiePolicyHooks {
 	 */
 	public static function onBeforePageDisplay( \OutputPage $out ) {
 		// use resource loader for i18n messages in JS
-		$out->addModules( 'ext.cookiePolicy' );
+		$out->addModules( 'ext.cookiePolicyMessages' );
 
 		// use AssetsManager for script loading to avoid race conditions (SOC-528)
 		\Wikia::addAssetsToOutput( 'cookie_policy_js' );

--- a/extensions/wikia/CookiePolicy/CookiePolicy.setup.php
+++ b/extensions/wikia/CookiePolicy/CookiePolicy.setup.php
@@ -21,7 +21,7 @@ $wgAutoloadClasses['Wikia\CookiePolicy\CookiePolicyHooks'] = __DIR__ . '/CookieP
 /**
  * Use ResourceLoader to load the JavaScript module
  */
-$wgResourceModules['ext.cookiePolicy'] = [
+$wgResourceModules['ext.cookiePolicyMessages'] = [
 	'localBasePath' => __DIR__ . '/scripts',
 	'remoteExtPath' => 'wikia/CookiePolicy/scripts',
 	'messages' => [

--- a/extensions/wikia/CookiePolicy/scripts/cookiePolicy.js
+++ b/extensions/wikia/CookiePolicy/scripts/cookiePolicy.js
@@ -18,7 +18,7 @@ require([
 
 			// make sure messages are loading before we show the notification
 			mw.loader.use([
-				'ext.cookiePolicy'
+				'ext.cookiePolicyMessages'
 			]).then(showBanner);
 		}
 	}

--- a/extensions/wikia/CookiePolicy/scripts/cookiePolicy.js
+++ b/extensions/wikia/CookiePolicy/scripts/cookiePolicy.js
@@ -15,7 +15,11 @@ require([
 	 */
 	function initCookieNotification() {
 		if (shouldShowBanner()) {
-			showBanner();
+
+			// make sure messages are loading before we show the notification
+			mw.loader.use([
+				'ext.cookiePolicy'
+			]).then(showBanner);
 		}
 	}
 


### PR DESCRIPTION
I was see the cookie policy message showing up like `<cookie-policy-notification-message>`, even though the message was loading later on and was available when you type `mw.message('cookie-policy-notification-message').parse()` into the browser console. This will make sure the message is available before showing the banner. 

Also renaming `ext.cookiePolicy` to `ext.cookiePolicyMessages` to better describe what it is. 
