### PR TITLE
(MAIN-4139) Fix message output format

### DIFF
--- a/includes/Skin.php
+++ b/includes/Skin.php
@@ -1589,9 +1589,10 @@ abstract class Skin extends ContextSource {
 	protected function getWrappedEditSectionLink( $link, $langCode ) {
 		if ( $this->getSkinName() !== WikiaSkin::SKIN_VENUS ) {
 			// Wrap in brackets
-			$link = wfMessage( 'editsection-brackets', $link )
+			$link = wfMessage( 'editsection-brackets' )
+				->rawParams( $link )
 				->inLanguage( $langCode )
-				->text();
+				->escaped();
 		}
 		return "<span class=\"editsection\">$link</span>";
 	}


### PR DESCRIPTION
Fix message output format to prevent stored XSS issue.

The link is HTML and so the contents shouldn't be further processed and
the output format should be `escaped()`.

/cc @owend 
