### PR TITLE
Ce 1427 fallback to create wiki updates

### DIFF
--- a/extensions/wikia/ExactTargetUpdates/hooks/ExactTargetWiki.hooks.php
+++ b/extensions/wikia/ExactTargetUpdates/hooks/ExactTargetWiki.hooks.php
@@ -83,7 +83,7 @@ class ExactTargetWikiHooks {
 	 */
 	private function addTheUpdateWikiTask( $iCityId ) {
 		$oTask = $this->getExactTargetUpdateWikiTask();
-		$oTask->call( 'updateWikiData', $iCityId );
+		$oTask->call( 'updateFallbackCreateWikiData', $iCityId );
 		$oTask->queue();
 	}
 

--- a/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetCreateWikiTask.php
+++ b/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetCreateWikiTask.php
@@ -10,7 +10,8 @@ class ExactTargetCreateWikiTask extends ExactTargetTask {
 	 * @return array
 	 */
 	public function sendNewWikiData( $iCityId ) {
-		$sCityListResult = $this->updateFallbackCreateCityList( $iCityId );
+		$oUpdateWikiTask = $this->getUpdateWikiHelper();
+		$sCityListResult = $oUpdateWikiTask->updateFallbackCreateWikiData( $iCityId );
 		$sCityCatResult = $this->createCityCatMapping( $iCityId );
 
 		$aResult = [
@@ -18,32 +19,6 @@ class ExactTargetCreateWikiTask extends ExactTargetTask {
 			'createCityCatMapping' => $sCityCatResult,
 		];
 		return $aResult;
-	}
-	/**
-	 * Update city_list data with fallback to create in ExactTarget
-	 * Builds $aDataExtensions array and passes it to a DE API interface.
-	 * @param  int $iCityId  A wiki's ID
-	 * @return string
-	 * @throws \Exception
-	 */
-	public function updateFallbackCreateCityList( $iCityId ) {
-		$oHelper = $this->getWikiHelper();
-		$oApiDataExtension = $this->getApiDataExtension();
-		$aDataExtensions = $oHelper->prepareWikiDataExtensionForUpdate( $iCityId );
-		$this->info( __METHOD__ . ' ApiParams: ' . json_encode( $aDataExtensions ) );
-
-		$oCreateWikiResult = $oApiDataExtension->updateFallbackCreateRequest( $aDataExtensions );
-
-		$this->info( __METHOD__ . ' OverallStatus: ' . $oCreateWikiResult->OverallStatus );
-		$this->info( __METHOD__ . ' Result: ' . json_encode( (array)$oCreateWikiResult ) );
-
-		if ( $oCreateWikiResult->OverallStatus === 'Error' ) {
-			throw new \Exception(
-				'Error in ' . __METHOD__ . ': ' . $oCreateWikiResult->Results->StatusMessage
-			);
-		}
-
-		return $oCreateWikiResult->Results->StatusMessage;
 	}
 
 	/**

--- a/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetCreateWikiTask.php
+++ b/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetCreateWikiTask.php
@@ -4,20 +4,38 @@ namespace Wikia\ExactTarget;
 class ExactTargetCreateWikiTask extends ExactTargetTask {
 
 	/**
-	 * Builds $aDataExtensions array and passes it to a DE API interface.
+	 * Runs wiki data updates to ExactTarget
+	 * (contents of city_list table and city_cat_mapping)
 	 * @param  int $iCityId  A wiki's ID
-	 * @return void
+	 * @return array
 	 */
 	public function sendNewWikiData( $iCityId ) {
+		$sCityListResult = $this->updateFallbackCreateCityList( $iCityId );
+		$sCityCatResult = $this->createCityCatMapping( $iCityId );
+
+		$aResult = [
+			'updateFallbackCreateCityList' => $sCityListResult,
+			'createCityCatMapping' => $sCityCatResult,
+		];
+		return $aResult;
+	}
+	/**
+	 * Update city_list data with fallback to create in ExactTarget
+	 * Builds $aDataExtensions array and passes it to a DE API interface.
+	 * @param  int $iCityId  A wiki's ID
+	 * @return string
+	 * @throws \Exception
+	 */
+	public function updateFallbackCreateCityList( $iCityId ) {
 		$oHelper = $this->getWikiHelper();
 		$oApiDataExtension = $this->getApiDataExtension();
-		$aDataExtensions = $oHelper->prepareDataExtensionsForCreate( $iCityId );
+		$aDataExtensions = $oHelper->prepareWikiDataExtensionForUpdate( $iCityId );
 		$this->info( __METHOD__ . ' ApiParams: ' . json_encode( $aDataExtensions ) );
 
-		$oCreateWikiResult = $oApiDataExtension->createRequest( $aDataExtensions );
+		$oCreateWikiResult = $oApiDataExtension->updateFallbackCreateRequest( $aDataExtensions );
 
 		$this->info( __METHOD__ . ' OverallStatus: ' . $oCreateWikiResult->OverallStatus );
-		$this->info( __METHOD__ . ' result: ' . json_encode( (array)$oCreateWikiResult ) );
+		$this->info( __METHOD__ . ' Result: ' . json_encode( (array)$oCreateWikiResult ) );
 
 		if ( $oCreateWikiResult->OverallStatus === 'Error' ) {
 			throw new \Exception(
@@ -26,6 +44,33 @@ class ExactTargetCreateWikiTask extends ExactTargetTask {
 		}
 
 		return $oCreateWikiResult->Results->StatusMessage;
+	}
+
+	/**
+	 * Create city_cat_mapping records for a wiki in ExactTarget
+	 * Builds $aDataExtensions array and passes it to a DE API interface.
+	 * @param int $iCityId A wiki's ID
+	 * @return string
+	 * @throws \Exception
+	 */
+	public function createCityCatMapping( $iCityId ) {
+		$oHelper = $this->getWikiHelper();
+		$oApiDataExtension = $this->getApiDataExtension();
+		$aDataExtensions = $oHelper->prepareCityCatMappingDataExtensionForCreate( $iCityId );
+		$this->info( __METHOD__ . ' ApiParams: ' . json_encode( $aDataExtensions ) );
+
+		$oCreateWikiResult = $oApiDataExtension->createRequest( $aDataExtensions );
+
+		$this->info( __METHOD__ . ' OverallStatus: ' . $oCreateWikiResult->OverallStatus );
+		$this->info( __METHOD__ . ' Result: ' . json_encode( (array)$oCreateWikiResult ) );
+
+		if ( $oCreateWikiResult->OverallStatus === 'Error' ) {
+			throw new \Exception(
+				'Error in ' . __METHOD__
+			);
+		}
+
+		return $oCreateWikiResult->OverallStatus;
 	}
 
 }

--- a/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetTask.php
+++ b/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetTask.php
@@ -71,6 +71,14 @@ class ExactTargetTask extends BaseTask {
 	}
 
 	/**
+	 * A simple getter for an object of an ExactTargetUpdateWikiTask class
+	 * @return ExactTargetUpdateWikiTask
+	 */
+	protected function getUpdateWikiHelper() {
+		return new ExactTargetUpdateWikiTask();
+	}
+
+	/**
 	 * A simple getter for an object of an ExactTargetWikiTaskHelper class
 	 * @return ExactTargetWikiTaskHelper
 	 */

--- a/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetUpdateCityCatMappingTask.php
+++ b/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetUpdateCityCatMappingTask.php
@@ -45,9 +45,8 @@ class ExactTargetUpdateCityCatMappingTask extends ExactTargetTask {
 			$this->info('No city cats found for the wiki, no cats deleted.');
 		}
 
-		// Delete wiki data
-		$aCityCatMappingDataForCreate = [];
-		$aCityCatMappingDataForCreate['DataExtension'] = $oHelper->prepareCityCatMappingDataExtensionForCreate( $aParams['city_id'] );
+		// Create city category mapping using fresh data from DB
+		$aCityCatMappingDataForCreate = $oHelper->prepareCityCatMappingDataExtensionForCreate( $aParams['city_id'] );
 		$this->info( 'RetrieveCityCatMapping' . ' ApiParams: ' . json_encode( $aCityCatMappingDataForCreate ) );
 		$oWikiCreateResult = $oApiDataExtension->createRequest( $aCityCatMappingDataForCreate );
 		$this->info( 'CreateWikiData' . ' OverallStatus: ' . $oWikiCreateResult->OverallStatus );

--- a/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetUpdateCityCatMappingTask.php
+++ b/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetUpdateCityCatMappingTask.php
@@ -50,15 +50,18 @@ class ExactTargetUpdateCityCatMappingTask extends ExactTargetTask {
 		$this->info( 'RetrieveCityCatMapping' . ' ApiParams: ' . json_encode( $aCityCatMappingDataForCreate ) );
 		$oWikiCreateResult = $oApiDataExtension->createRequest( $aCityCatMappingDataForCreate );
 		$this->info( 'CreateWikiData' . ' OverallStatus: ' . $oWikiCreateResult->OverallStatus );
-		$this->info( 'CreateWikiData' . ' result: ' . json_encode( (array)$oWikiCreateResult ) );
+		$this->info( 'CreateWikiData' . ' Result: ' . json_encode( (array)$oWikiCreateResult ) );
 
 		if ( $oWikiCreateResult->OverallStatus === 'Error' ) {
 			throw new \Exception(
-				'Error in ' . 'CreateWikiData' . ': ' . $oWikiCreateResult->Results->StatusMessage
+				'Error in ' . __METHOD__
 			);
 		}
 
-		return $oWikiCreateResult->Results->StatusMessage;
+		// Return OverallStatus if multiple records were inserted and StatusMessage if just one
+		return is_array($oWikiCreateResult->Results)
+			? $oWikiCreateResult->OverallStatus
+			: $oWikiCreateResult->Results->StatusMessage;
 	}
 
 }

--- a/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetUpdateWikiTask.php
+++ b/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetUpdateWikiTask.php
@@ -14,10 +14,10 @@ class ExactTargetUpdateWikiTask extends ExactTargetTask {
 		$aDataExtensions = $oHelper->prepareWikiDataExtensionForUpdate( $iCityId );
 		$this->info( __METHOD__ . ' ApiParams: ' . json_encode( $aDataExtensions ) );
 
-		$oUpdateWikiDataResult = $oApiDataExtension->updateRequest( $aDataExtensions );
+		$oUpdateWikiDataResult = $oApiDataExtension->updateFallbackCreateRequest( $aDataExtensions );
 
 		$this->info( __METHOD__ . ' OverallStatus: ' . $oUpdateWikiDataResult->OverallStatus );
-		$this->info( __METHOD__ . ' result: ' . json_encode( (array)$oUpdateWikiDataResult ) );
+		$this->info( __METHOD__ . ' Result: ' . json_encode( (array)$oUpdateWikiDataResult ) );
 
 		if ( $oUpdateWikiDataResult->OverallStatus === 'Error' ) {
 			throw new \Exception(

--- a/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetUpdateWikiTask.php
+++ b/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetUpdateWikiTask.php
@@ -4,11 +4,12 @@ namespace Wikia\ExactTarget;
 class ExactTargetUpdateWikiTask extends ExactTargetTask {
 
 	/**
-	 * Updates city_list record for a wiki
+	 * Updates city_list data with fallback to create in ExactTarget
+	 * Builds $aDataExtensions array and passes it to a DE API interface.
 	 * @param  int $iCityId  A wiki's ID
 	 * @return void
 	 */
-	public function updateWikiData( $iCityId ) {
+	public function updateFallbackCreateWikiData( $iCityId ) {
 		$oHelper = $this->getWikiHelper();
 		$oApiDataExtension = $this->getApiDataExtension();
 		$aDataExtensions = $oHelper->prepareWikiDataExtensionForUpdate( $iCityId );

--- a/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetWikiTaskHelper.php
+++ b/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetWikiTaskHelper.php
@@ -4,24 +4,6 @@ namespace Wikia\ExactTarget;
 class ExactTargetWikiTaskHelper {
 
 	/**
-	 * Merges tables with data for city_list and city_cat_mapping
-	 * @param  int $iCityId  A wiki's ID
-	 * @return array         An array with DataExtension objects data in a valid format
-	 */
-	public function prepareDataExtensionsForCreate( $iCityId ) {
-		$aWikiDataExtension = $this->prepareWikiDataExtensionForCreate( $iCityId );
-		$aCityCatMappingDataExtension = $this->prepareCityCatMappingDataExtensionForCreate( $iCityId );
-
-		$aDataExtensionsForCreate = [
-			'DataExtension' => [],
-		];
-
-		$aDataExtensionsForCreate['DataExtension'] = array_merge( $aDataExtensionsForCreate['DataExtension'], $aWikiDataExtension, $aCityCatMappingDataExtension );
-
-		return $aDataExtensionsForCreate;
-	}
-
-	/**
 	 * Prepares DataExtension objects data from a city_list record
 	 * @param  int $iCityId  A wiki's ID
 	 * @return array         An array with city_list DataExtension objects data in a valid format
@@ -88,23 +70,39 @@ class ExactTargetWikiTaskHelper {
 		/* Get wikidata from master */
 		$oWiki = \WikiFactory::getWikiById( $iCityId, true );
 		$aWikiData = [
+			'city_path' => $oWiki->city_path,
+			'city_dbname' => $oWiki->city_dbname,
+			'city_sitename' => $oWiki->city_sitename,
 			'city_url' => $oWiki->city_url,
 			'city_created' => $oWiki->city_created,
 			'city_founding_user' => $oWiki->city_founding_user,
+			'city_adult' => $oWiki->city_adult,
+			'city_public' => $oWiki->city_public,
 			'city_title' => $oWiki->city_title,
+			'city_founding_email' => $oWiki->city_founding_email,
 			'city_lang' => $oWiki->city_lang,
+			'city_special' => $oWiki->city_special,
+			'city_umbrella' => $oWiki->city_umbrella,
+			'city_ip' => $oWiki->city_ip,
+			'city_google_analytics' => $oWiki->city_google_analytics,
+			'city_google_search' => $oWiki->city_google_search,
+			'city_google_maps' => $oWiki->city_google_maps,
+			'city_indexed_rev' => $oWiki->city_indexed_rev,
+			'city_lastdump_timestamp' => $oWiki->city_lastdump_timestamp,
+			'city_factory_timestamp' => $oWiki->city_factory_timestamp,
+			'city_useshared' => $oWiki->city_useshared,
+			'ad_cat' => $oWiki->ad_cat,
+			'city_flags' => $oWiki->city_flags,
 			'city_cluster' => $oWiki->city_cluster,
+			'city_last_timestamp' => $oWiki->city_last_timestamp,
+			'city_founding_ip' => $oWiki->city_founding_ip,
 			'city_vertical' => $oWiki->city_vertical,
 		];
-
-		$aWikiDataExtension = [
-			'DataExtension' => [
-				[
-					'CustomerKey' => $aCustomerKeys['city_list'],
-					'Keys' => $aKeys,
-					'Properties' => $aWikiData,
-				],
-			],
+		$aWikiDataExtension = [ 'DataExtension' => [] ];
+		$aWikiDataExtension['DataExtension'][] =  [
+				'CustomerKey' => $aCustomerKeys['city_list'],
+				'Keys' => $aKeys,
+				'Properties' => $aWikiData,
 		];
 
 		return $aWikiDataExtension;
@@ -146,8 +144,10 @@ class ExactTargetWikiTaskHelper {
 
 		$oWikiFactoryHub = new \WikiFactoryHub();
 		$aCategories = $oWikiFactoryHub->getWikiCategories( $iCityId );
+		$aCityCatMappingDataExtension['DataExtension'] = [];
+
 		foreach( $aCategories as $aCategory ) {
-			$aCityCatMappingDataExtension[] = [
+			$aCityCatMappingDataExtension['DataExtension'][] = [
 				'CustomerKey' => $aCustomerKeys['city_cat_mapping'],
 				'Properties' => [
 					'city_id' => $iCityId,


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CE-1427

Second (last) part of fallback to create changes. Fallback to create for wiki data changes.

Aim is to make all ExactTarget updates fallback to create due to sync process concept between Wikia and ExactTarget. Once ET clears DB and waits for data dump from Wikia we want to send hot data and create missing records.

@Wikia/community-engineering 
