### PR TITLE
PLATFORM-1028: improve sessions handling around log in and log out actions

### DIFF
--- a/extensions/wikia/UserLogin/UserLoginSpecialController.class.php
+++ b/extensions/wikia/UserLogin/UserLoginSpecialController.class.php
@@ -477,6 +477,10 @@ class UserLoginSpecialController extends WikiaSpecialPageController {
 						'username' => $loginForm->mUsername,
 						'result' => 'ok',
 					] );
+
+					// regenerate session ID on user logout to avoid race conditions with
+					// long running requests logging the user back in (@see PLATFORM-1028)
+					wfResetSessionID();
 				}
 				break;
 

--- a/extensions/wikia/UserLogin/UserLoginSpecialController.class.php
+++ b/extensions/wikia/UserLogin/UserLoginSpecialController.class.php
@@ -478,8 +478,9 @@ class UserLoginSpecialController extends WikiaSpecialPageController {
 						'result' => 'ok',
 					] );
 
-					// regenerate session ID on user logout to avoid race conditions with
-					// long running requests logging the user back in (@see PLATFORM-1028)
+					// regenerate session ID on user login (the approach MW's core SpecialUserLogin uses)
+					// to avoid race conditions with long running requests logging the user back in & out
+					// @see PLATFORM-1028
 					wfResetSessionID();
 				}
 				break;

--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -3454,6 +3454,29 @@ function wfFixSessionID() {
 }
 
 /**
+ * Reset the session_id
+ *
+ * Backported from MW 1.22
+ */
+function wfResetSessionID() {
+	global $wgCookieSecure;
+	$oldSessionId = session_id();
+	$cookieParams = session_get_cookie_params();
+	if ( wfCheckEntropy() && $wgCookieSecure == $cookieParams['secure'] ) {
+		session_regenerate_id( false );
+	} else {
+		$tmp = $_SESSION;
+		session_destroy();
+		wfSetupSession( MWCryptRand::generateHex( 32 ) );
+		$_SESSION = $tmp;
+	}
+	$newSessionId = session_id();
+	Hooks::run( 'ResetSessionID', array( $oldSessionId, $newSessionId ) );
+
+	wfDebug( sprintf( "%s: new ID is '%s'\n", __METHOD__, $newSessionId ) );
+}
+
+/**
  * Initialise php session
  *
  * @param $sessionId Bool

--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -3463,7 +3463,7 @@ function wfResetSessionID() {
 	$oldSessionId = session_id();
 	$cookieParams = session_get_cookie_params();
 	if ( wfCheckEntropy() && $wgCookieSecure == $cookieParams['secure'] ) {
-		session_regenerate_id( false );
+		session_regenerate_id( true ); // Wikia - $delete_old_session = true
 	} else {
 		$tmp = $_SESSION;
 		session_destroy();

--- a/includes/User.php
+++ b/includes/User.php
@@ -3026,6 +3026,13 @@ class User {
 		$this->clearCookie( 'UserID' );
 		$this->clearCookie( 'Token' );
 
+		// Wikia change - begin (@see PLATFORM-1028)
+		// @author macbre
+		// There's no need to keep the user name (in both session and cookie) when you log out
+		$this->getRequest()->setSessionData( 'wsUserName', null );
+		$this->clearCookie( 'UserName' );
+		// Wikia change - end
+
 		# Remember when user logged out, to prevent seeing cached pages
 		$this->setCookie( 'LoggedOut', wfTimestampNow(), time() + 86400 );
 	}

--- a/includes/cache/MemcachedSessions.php
+++ b/includes/cache/MemcachedSessions.php
@@ -59,6 +59,8 @@ function memsess_read( $id ) {
 	$memc =& getMemc();
 	$data = $memc->get( memsess_key( $id ) );
 
+	wfDebug( sprintf( "%s[%s]: %s\n", __METHOD__, $id, $data ) );
+
 	if( ! $data ) return '';
 	return $data;
 }
@@ -81,6 +83,7 @@ function memsess_write( $id, $data ) {
 	$memc =& getMemc();
 	$memc->set( memsess_key( $id ), $data, 3600 );
 
+	wfDebug( sprintf( "%s[%s]: %s\n", __METHOD__, $id, $data ) );
 	return true;
 }
 
@@ -93,6 +96,8 @@ function memsess_write( $id, $data ) {
 function memsess_destroy( $id ) {
 	$memc =& getMemc();
 	$memc->delete( memsess_key( $id ) );
+
+	wfDebug( sprintf( "%s[%s]\n", __METHOD__, $id ) );
 	return true;
 }
 

--- a/includes/specials/SpecialUserlogin.php
+++ b/includes/specials/SpecialUserlogin.php
@@ -1478,17 +1478,12 @@ class LoginForm extends SpecialPage {
 	 * Renew the user's session id, using strong entropy
 	 */
 	private function renewSessionId() {
-		if ( wfCheckEntropy() ) {
-			session_regenerate_id( false );
-		} else {
-			//If we don't trust PHP's entropy, we have to replace the session manually
-			$tmp = $_SESSION;
-			session_unset();
-			session_write_close();
-			session_id( MWCryptRand::generateHex( 32 ) );
-			session_start();
-			$_SESSION = $tmp;
+		global $wgSecureLogin, $wgCookieSecure;
+		if ( $wgSecureLogin && !$this->mStickHTTPS ) {
+			$wgCookieSecure = false;
 		}
+
+		wfResetSessionID();
 	}
 
 	/**

--- a/includes/specials/SpecialUserlogout.php
+++ b/includes/specials/SpecialUserlogout.php
@@ -61,6 +61,11 @@ class SpecialUserlogout extends UnlistedSpecialPage {
 		*/
 		$wgUser->logout();	 /* wikia change */
 
+		// Wikia change
+		// regenerate session ID on user logout to avoid race conditions with
+		// long running requests logging the user back in (@see PLATFORM-1028)
+		wfResetSessionID();
+
 		$out = $this->getOutput();
 		$out->addWikiMsg( 'logouttext' );
 


### PR DESCRIPTION
This pull request tries to improve the handling of log in and log out actions and avoid race conditions problems caused by long running requests.

https://wikia-inc.atlassian.net/browse/PLATFORM-1028
## Part 1:

Clear `wsUserName` session entry and the cookie when logging out. There's no need to keep the user name (in both session and cookie) when you log out.
## Part 2

Regenerate session ID on user login and logout (and delete the memcache entry for the old session)

@michalroszka / @Grunny  / @garthwebb (as the member of the team that owns the login)
