### PR TITLE
PLATFORM-997: improve user settings cache handling

### DIFF
--- a/includes/User.php
+++ b/includes/User.php
@@ -371,6 +371,8 @@ class User {
 		$key = wfMemcKey( 'user', 'id', $this->mId );
 		global $wgMemc;
 		$wgMemc->set( $key, $data );
+
+		wfDebug( "User: user {$this->mId} stored in cache\n" );
 	}
 
 	/** @name newFrom*() static factory methods */
@@ -2031,6 +2033,8 @@ class User {
 		if( $this->mId ) {
 			global $wgMemc, $wgSharedDB; # Wikia
 			$wgMemc->delete( wfMemcKey( 'user', 'id', $this->mId ) );
+			// Wikia: and save updated user data in the cache to avoid memcache miss and DB query
+			$this->saveToCache();
 			# not uncyclo
 			if( !empty( $wgSharedDB ) ) {
 				$memckey = wfSharedMemcKey( "user_touched", $this->mId );

--- a/includes/User.php
+++ b/includes/User.php
@@ -320,11 +320,16 @@ class User {
 				$_key = wfSharedMemcKey( "user_touched", $this->mId );
 				$_touched = $wgMemc->get( $_key );
 				if( empty( $_touched ) ) {
-					$wgMemc->set( $_key, $data['mTouched'] );
+					$wgMemc->set( $_key, self::newTouchedTimestamp() );
+					wfDebug( "Shared user: miss on shared user_touched\n" );
 				} else if( $_touched <= $data['mTouched'] ) {
 					$isExpired = false;
 				}
+				else {
+					wfDebug( "Shared user: invalidating local user cache due to shared user_touched\n" );
+				}
 			}
+			# /Wikia
 		}
 
 		if ( !$data || $isExpired ) { # Wikia
@@ -2029,7 +2034,8 @@ class User {
 			# not uncyclo
 			if( !empty( $wgSharedDB ) ) {
 				$memckey = wfSharedMemcKey( "user_touched", $this->mId );
-				$wgMemc->delete( $memckey );
+				$wgMemc->set( $memckey, self::newTouchedTimestamp() );
+				wfDebug( "Shared user: updating shared user_touched\n" );
 			}
 		}
 	}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-997

- set the shared `user_touched` key to the current timestamp on miss
- when invalidating the cache update `user_touched` shared key to the current timestamp instead of deleting it
- when invalidating the cache store the updated data in memcache, instead of deleting the key (reduce the number of misses on `*:user:id:*` keys by ~66% and avoid slave lag issues).

@michalroszka / @adamkarminski 
