### PR TITLE
ADEN-1800 Enable turtle - fixes

### DIFF
--- a/extensions/wikia/AdEngine/js/WikiaGptAdDetect.js
+++ b/extensions/wikia/AdEngine/js/WikiaGptAdDetect.js
@@ -212,7 +212,7 @@ define('ext.wikia.adEngine.wikiaGptAdDetect', [
 			}
 		}
 
-		if (adType === 'openx' || adType === 'rubicon' || adType === 'saymedia') {
+		if (adType === 'openx' || adType === 'rubicon' || adType === 'saymedia' || adType === 'turtle') {
 			shouldPollForSuccess = true;
 			expectAsyncHop = true;
 		}

--- a/extensions/wikia/AdEngine/js/provider/turtle.js
+++ b/extensions/wikia/AdEngine/js/provider/turtle.js
@@ -43,7 +43,7 @@ define('ext.wikia.adEngine.provider.turtle', [
 				success(adInfo);
 			},
 			hop,
-			'async'
+			'turtle'
 		);
 		gptHelper.flushAds();
 


### PR DESCRIPTION
Added new adType: `turtle` which uses polling to check if an ad was successfully inserted since Turtle doesn't send us information about success.

//cc @gabrys: could you code review it, please? :smile_cat: 
