### PR TITLE
Fix broken path to wikia logo in GlobalFooter and GlobalNavigation

### DIFF
--- a/extensions/wikia/GlobalFooter/styles/GlobalFooter.scss
+++ b/extensions/wikia/GlobalFooter/styles/GlobalFooter.scss
@@ -51,7 +51,7 @@ $branding-color: #000;
 				color: #fff;
 
 				img {
-					background: $branding-color center / 60px 15px no-repeat url('/skins/shared/images/wikia_logo_white.svg'); /* inline */
+					background: $branding-color center / 60px 15px no-repeat url('/extensions/wikia/WikiaLogo/images/wikia_logo_white.svg'); /* inline */
 				}
 			}
 

--- a/extensions/wikia/GlobalNavigation/styles/GlobalNavigationInverse.scss
+++ b/extensions/wikia/GlobalNavigation/styles/GlobalNavigationInverse.scss
@@ -8,7 +8,7 @@ $global-nav-inverse-background-hover: #656E78;
 		box-shadow: 0 0 0 2px rgba(0,0,0,0);
 
 		.wikia-logo-container img {
-				background-image: url('/skins/shared/images/wikia_logo_white.svg'); /* inline */
+				background-image: url('/extensions/wikia/WikiaLogo/images/wikia_logo_white.svg'); /* inline */
 		}
 
 		.start-wikia-container {


### PR DESCRIPTION
Path for wikia_logo_white.svg was pointing to not existing file in GlobalNavigation and GlobalFooter scss files. Change updates broken path and points to correct location. 
