### PR TITLE
SERVICES-184 Log user_properties lookups for usage analysis

### DIFF
--- a/includes/User.php
+++ b/includes/User.php
@@ -2311,6 +2311,7 @@ class User {
 	 * @see getIntOption()
 	 */
 	public function getOption( $oname, $defaultOverride = null, $ignoreHidden = false ) {
+		\Wikia\Logger\WikiaLogger::instance()->info( 'user_properties lookup' , array( 'name' => $oname ) );
 		global $wgHiddenPrefs;
 		$this->loadOptions();
 


### PR DESCRIPTION
Log `user_properties` lookups for usage analysis. We want to know which properties are actually being used.

I'm aware that this probably isn't 100% coverage because of direct lookups into `user_properties` but it should give us some data on the "legitimate" usage via the user object.

https://wikia-inc.atlassian.net/browse/SERVICES-184

/cc @nmonterroso @garthwebb 
