### PR TITLE
One weird trick to reduce ELK log volume by 40%

### DIFF
--- a/includes/media/MediaTransformOutput.php
+++ b/includes/media/MediaTransformOutput.php
@@ -247,15 +247,6 @@ class ThumbnailImage extends MediaTransformOutput {
 	}
 
 	function renderView( array $options = [] ) {
-		WikiaLogger::instance()->debug( 'Media method '.__METHOD__.' called',
-			array_merge( $options, [
-				'url'       => $this->url,
-				'method'    => __METHOD__,
-				'page'      => $this->page,
-				'mediaType' => $this->mediaType(),
-				'fileType'  => get_class( $this->file )
-			] ) );
-
 		// Make sure to trim the output so that there is no leading whitespace.  The output of this method
 		// may be fed back into code that will be parsed for wikitext and leading whitespace will be
 		// wrap this HTML in <pre> tags.  VID-1819
@@ -301,15 +292,6 @@ class ThumbnailImage extends MediaTransformOutput {
 		if ( count( func_get_args() ) == 2 ) {
 			throw new MWException( __METHOD__ .' called in the old style' );
 		}
-
-		WikiaLogger::instance()->debug('Media method '.__METHOD__.' called',
-			array_merge( $options, [
-				'url'       => $this->url,
-				'method'    => __METHOD__,
-				'page'      => $this->page,
-				'mediaType' => $this->mediaType(),
-				'fileType'  => get_class( $this->file )
-			] ) );
 
 		$alt = empty( $options['alt'] ) ? '' : $options['alt'];
 


### PR DESCRIPTION
@garthwebb 

These two log statements are responsible for over 1 billion log messages per day -- more than 40% of our total ELK messages.  Probably >500GB per day.

https://kibana.wikia-inc.com/index.html#dashboard/temp/AUw04FaMY8rZYlgy-cq3

![screenshot 2015-03-19 18 42 33](https://cloud.githubusercontent.com/assets/122499/6744587/daf508c8-ce68-11e4-8c0a-e0439dcb76da.png)

Can these be removed?  Or sampled at 1%? (I'd be happy to update the PR to sample, if that's preferable)
