### PR TITLE
Bucky: purge the queue before sending resource timing data

### DIFF
--- a/extensions/wikia/Bucky/js/bucky_resources_timing.js
+++ b/extensions/wikia/Bucky/js/bucky_resources_timing.js
@@ -161,6 +161,9 @@ define('bucky.resourceTiming', ['jquery', 'wikia.window', 'wikia.log', 'bucky'],
 		sink = bucky('resource_timing::' + eventName);
 		debug('Sending stats', eventName);
 
+		// flush pending Bucky data to avoid HTTP 756 response code (Too long request string)
+		sink.flush();
+
 		for (key in stats) {
 			for (subkey in stats[key]) {
 				value = Math.round(stats[key][subkey]);


### PR DESCRIPTION
Avoid `HTTP 756` response code (Too long request string)` (we were sending 4k+ long URLs)  that will skew the RUM metrics - see #6498

@wladekb 
