### PR TITLE
PLATFORM-965: async Recent Changes update task

### DIFF
--- a/includes/WikiPage.php
+++ b/includes/WikiPage.php
@@ -1595,17 +1595,9 @@ class WikiPage extends Page {
 
 		if ( wfRunHooks( 'ArticleEditUpdatesDeleteFromRecentchanges', array( &$this ) ) ) {
 			if ( 0 == mt_rand( 0, 99 ) ) {
-				// Flush old entries from the `recentchanges` table; we do this on
-				// random requests so as to avoid an increase in writes for no good reason
-				global $wgRCMaxAge;
-
-				$dbw = wfGetDB( DB_MASTER );
-				$cutoff = $dbw->timestamp( time() - $wgRCMaxAge );
-				$dbw->delete(
-					'recentchanges',
-					array( "rc_timestamp < '$cutoff'" ),
-					__METHOD__
-				);
+				// Flush old entries from the `recentchanges` table
+				// Wikia: use a job backported from MediaWiki 1.25 (@see PLATFORM-965)
+				Wikia\Tasks\Tasks\RecentChangesUpdate::newPurgeTask();
 			}
 		}
 

--- a/includes/db/Database.php
+++ b/includes/db/Database.php
@@ -1220,6 +1220,48 @@ abstract class DatabaseBase implements DatabaseType {
 	}
 
 	/**
+	 * A SELECT wrapper which returns a list of single field values from result rows.
+	 *
+	 * Usually throws a DBQueryError on failure. If errors are explicitly
+	 * ignored, returns false on failure.
+	 *
+	 * If no result rows are returned from the query, false is returned.
+	 *
+	 * @param string|array $table Table name. See DatabaseBase::select() for details.
+	 * @param string $var The field name to select. This must be a valid SQL
+	 *   fragment: do not use unvalidated user input.
+	 * @param string|array $cond The condition array. See DatabaseBase::select() for details.
+	 * @param string $fname The function name of the caller.
+	 * @param string|array $options The query options. See DatabaseBase::select() for details.
+	 *
+	 * @return bool|array The values from the field, or false on failure
+	 * @since 1.25
+	 */
+	public function selectFieldValues(
+		$table, $var, $cond = '', $fname = __METHOD__, $options = array()
+	) {
+		if ( $var === '*' ) { // sanity
+			throw new DBUnexpectedError( $this, "Cannot use a * field: got '$var'" );
+		}
+
+		if ( !is_array( $options ) ) {
+			$options = array( $options );
+		}
+
+		$res = $this->select( $table, $var, $cond, $fname, $options );
+		if ( $res === false ) {
+			return false;
+		}
+
+		$values = array();
+		foreach ( $res as $row ) {
+			$values[] = $row->$var;
+		}
+
+		return $values;
+	}
+
+	/**
 	 * Returns an optional USE INDEX clause to go after the table, and a
 	 * string to go at the end of the query.
 	 *

--- a/includes/wikia/tasks/Tasks/RecentChangesUpdateTask.class.php
+++ b/includes/wikia/tasks/Tasks/RecentChangesUpdateTask.class.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * Replacement task for the MediaWiki 1.25 RecentChangesUpdateJob
+ *
+ * @see PLATFORM-965
+ */
+namespace Wikia\Tasks\Tasks;
+
+/**
+ * Job for pruning recent changes
+ *
+ * @ingroup JobQueue
+ * @since 1.25
+ */
+class RecentChangesUpdateTask extends BaseTask {
+
+	/**
+	 * @return self
+	 */
+	public static function newPurgeTask() {
+		global $wgCityId;
+
+		$task = new self();
+		$task->call( 'purgeExpiredRows' );
+		$task->wikiId( $wgCityId );
+		$task->title( \SpecialPage::getTitleFor( 'Recentchanges' ) );
+		$task->queue();
+
+		return $task;
+	}
+
+	public function purgeExpiredRows() {
+		global $wgRCMaxAge;
+
+		$dbw = wfGetDB( DB_MASTER );
+		$rows = 0;
+
+		$cutoff = $dbw->timestamp( time() - $wgRCMaxAge );
+		do {
+			$rcIds = $dbw->selectFieldValues( 'recentchanges',
+				'rc_id',
+				array( 'rc_timestamp < ' . $dbw->addQuotes( $cutoff ) ),
+				__METHOD__,
+				array( 'LIMIT' => 100 ) // avoid slave lag
+			);
+			if ( $rcIds ) {
+				$dbw->delete( 'recentchanges', array( 'rc_id' => $rcIds ), __METHOD__ );
+				$rows += $dbw->affectedRows();
+			}
+			// No need for this to be in a transaction.
+			$dbw->commit( __METHOD__, 'flush' );
+		} while ( $rcIds );
+
+		$this->info( __METHOD__, [
+			'rows' => $rows
+		] );
+
+		return true;
+	}
+}


### PR DESCRIPTION
Avoid deleting ~1k rows when saving an edit (that can take up to 200 ms). Queue an async task instead and clean up the recent changes off-line

Backport `RecentChangesUpdateJob` class and  `DatabaseBase::selectFieldValues` from MediaWiki 1.25.

@michalroszka / @nmonterroso 
