### PR TITLE
SOC-471 updating loadExternalLibrary to respect noexternals

### DIFF
--- a/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadLibrary.js
+++ b/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadLibrary.js
@@ -4,7 +4,7 @@
 	/**
 	 * Loads library file if it's not already loaded and fires callback
 	 * For "internal" use only. Please use $.loadFooBar() functions in extension code.
-	 * @deprecated Use $.loadExternalLibrary instead for better error handling
+	 * @deprecated Use loadExternalLibrary instead for better error handling
 	 */
 	$.loadLibrary = function (name, files, typeCheck, callback, failureFn) {
 		var dfd = new jQuery.Deferred();


### PR DESCRIPTION
I wanted to make sure external libraries weren't loaded when `noexternals=1`, but also to clean up this code a bit, as $.loadExternalLibrary shouldn't be called directly. 

We may want to split `loadExternalLibrary` out further into an AMD module that can be required by files like loadCaptcha and loadFacebook, but I think this is fine for now. 
