### PR TITLE
fixing fatal due to static keyword

### DIFF
--- a/extensions/wikia/Email/EmailController.class.php
+++ b/extensions/wikia/Email/EmailController.class.php
@@ -23,7 +23,7 @@ abstract class EmailController extends \WikiaController {
 	 *
 	 * @return string
 	 */
-	public static function getTemplateDir() {
+	public function getTemplateDir() {
 		return dirname( __FILE__ ) . '/templates';
 	}
 


### PR DESCRIPTION
Fixing a fatal: `Fatal error: Cannot make non static method WikiaController::getTemplateDir() static in class Email\EmailController in /usr/wikia/source/app/extensions/wikia/Email/EmailController.class.php on line 5`
@garthwebb 
