### PR TITLE
WikiaResponse: get rid of X-Wikia-Error response header

### DIFF
--- a/includes/wikia/nirvana/WikiaResponse.class.php
+++ b/includes/wikia/nirvana/WikiaResponse.class.php
@@ -12,11 +12,6 @@
  */
 class WikiaResponse {
 	/**
-	 * headers
-	 */
-	const ERROR_HEADER_NAME = 'X-Wikia-Error';
-
-	/**
 	 * Response codes
 	 */
 	const RESPONSE_CODE_OK = 200;
@@ -447,11 +442,6 @@ class WikiaResponse {
 	}
 
 	public function sendHeaders() {
-		if ( ( $this->getFormat() == WikiaResponse::FORMAT_JSON ) && $this->hasException() ) {
-			// set error header for JSON response (as requested for mobile apps)
-			$this->setHeader( self::ERROR_HEADER_NAME, $this->getException()->getMessage() );
-		}
-
 		if ( !$this->hasContentType() ) {
 			if ( ( $this->getFormat() == WikiaResponse::FORMAT_JSON ) ) {
 				$this->setContentType( 'application/json; charset=utf-8' );


### PR DESCRIPTION
Was causing `PHP Warning: Header may not contain more than a single header, new line detected in /includes/wikia/nirvana/WikiaResponse.class.php on line 557`

Reverts 77617714fcd486ab9f49a487d2cd4a44aebca82a

@michalroszka 
