### PR TITLE
SOC-568 Move default definiton of getTemplateDir up two parents

### DIFF
--- a/includes/wikia/nirvana/WikiaController.class.php
+++ b/includes/wikia/nirvana/WikiaController.class.php
@@ -147,15 +147,4 @@ abstract class WikiaController extends WikiaDispatchableObject {
 	public function isAnonAccessAllowedInCurrentContext() {
 		return false;
 	}
-
-	/**
-	 * Allow controllers to define an alternate location for where templates can be found.
-	 * This base definition returns null so by default WikiaView.class.php will determine
-	 * this directory.
-	 *
-	 * @return null
-	 */
-	public function getTemplateDir() {
-		return null;
-	}
 }

--- a/includes/wikia/nirvana/WikiaDispatchableObject.class.php
+++ b/includes/wikia/nirvana/WikiaDispatchableObject.class.php
@@ -364,4 +364,15 @@ abstract class WikiaDispatchableObject extends WikiaObject {
 
 		return self::purgeMethods( $map );
 	}
+
+	/**
+	 * Allow dispatchable objects to define an alternate location for where templates can be found.
+	 * This base definition returns null so by default WikiaView.class.php will determine
+	 * this directory.
+	 *
+	 * @return null
+	 */
+	public static function getTemplateDir() {
+		return null;
+	}
 }


### PR DESCRIPTION
This takes care of weird "Service" classes that are not under the WikiaController inheritance tree.

https://wikia-inc.atlassian.net/browse/SOC-568
