### PR TITLE
MemcachedStats::normalizeKey: improve IP addresses normalization

### DIFF
--- a/includes/wikia/memcached/MemcachedStats.class.php
+++ b/includes/wikia/memcached/MemcachedStats.class.php
@@ -79,8 +79,8 @@ class MemcachedStats {
 
 		$parts = array_map(
 			function($part) {
-				// replace IDs and hashes with *
-				return ctype_xdigit($part) ? '*' : $part;
+				// replace IP addresses, IDs and hashes with *
+				return ctype_xdigit( str_replace('.', '', $part) ) ? '*' : $part;
 			},
 			explode(':', $key)
 		);

--- a/includes/wikia/tests/MemcachedStatsTest.php
+++ b/includes/wikia/tests/MemcachedStatsTest.php
@@ -44,6 +44,10 @@ class MemcachedStatsTest extends WikiaBaseTest {
 				'key' => self::WIKI_PREFIX . ':favicon-v1',
 				'expected' => '*:favicon-v1'
 			],
+			[
+				'key' => self::WIKI_PREFIX . ':VoteHelper:VoteHelper::getUserCacheKey:123:0:84.77.150.66:VER1',
+				'expected' => '*:VoteHelper:VoteHelper::getUserCacheKey:*:*:*:VER1'
+			],
 			// shared keys
 			[
 				'key' => 'wikifactory:wikia:v1:1031256',


### PR DESCRIPTION
Normalize memcache keys with IP addresses before sending them (as a part of statistics package) to InfluxDB.

Example: normalize `foo:VoteHelper:VoteHelper::getUserCacheKey:123:0:84.77.150.66:VER1` to `*:VoteHelper:VoteHelper::getUserCacheKey:*:*:*:VER1`

@michalroszka 

See https://github.com/Wikia/cheetah/pull/94
