### PR TITLE
Soc 569 Force showing notification about deleted article instead of a comment

### DIFF
--- a/extensions/wikia/BannerNotifications/BannerNotificationsController.class.php
+++ b/extensions/wikia/BannerNotifications/BannerNotificationsController.class.php
@@ -108,12 +108,11 @@ class BannerNotificationsController extends WikiaController {
 			self::addConfirmation(
 				wfMessage(
 					'movepage-moved',
-					array('parseinline'),
 					$oldLink,
 					$newLink,
 					$oldText,
 					$newText
-				)->inContentLanguage()->escaped()
+				)->inContentLanguage()->parse()
 			);
 
 			// redirect to page with new title
@@ -150,9 +149,8 @@ class BannerNotificationsController extends WikiaController {
 
 			$message = wfMessage(
 				'oasis-confirmation-page-deleted',
-				array( 'parseinline' ),
 				$pageName
-			)->inContentLanguage()->escaped();
+			)->inContentLanguage()->parse();
 
 			wfRunHooks( 'OasisAddPageDeletedConfirmationMessage', array( &$title, &$message ) );
 

--- a/extensions/wikia/BannerNotifications/BannerNotificationsController.class.php
+++ b/extensions/wikia/BannerNotifications/BannerNotificationsController.class.php
@@ -22,7 +22,11 @@ class BannerNotificationsController extends WikiaController {
 	}
 
 	/**
-	 * Add confirmation message to the user session (so it persists between redirects)
+	 * @desc Add confirmation message to the user session (so it persists between redirects)
+	 *
+	 * @param String $message - message text
+	 * @param String $type - notification type, one of CONFIRMATION_ constants
+	 * @param Bool $force - flag that enforces to override existing notification
 	 */
 	public static function addConfirmation( $message, $type = self::CONFIRMATION_CONFIRM, $force = false ) {
 		//Add confirmation if there was none set yet or if it's forced

--- a/extensions/wikia/BannerNotifications/BannerNotificationsController.class.php
+++ b/extensions/wikia/BannerNotifications/BannerNotificationsController.class.php
@@ -24,8 +24,10 @@ class BannerNotificationsController extends WikiaController {
 	/**
 	 * Add confirmation message to the user session (so it persists between redirects)
 	 */
-	public static function addConfirmation( $message, $type = self::CONFIRMATION_CONFIRM ) {
-		if ( !empty( $message ) ) {
+	public static function addConfirmation( $message, $type = self::CONFIRMATION_CONFIRM, $force = false ) {
+		//Add confirmation if there was none set yet or if it's forced
+		if ( !empty( $message ) &&
+			( empty( $_SESSION[self::SESSION_KEY] ) || $force === true ) ) {
 			$_SESSION[self::SESSION_KEY] = array(
 				'message' => $message,
 				'type' => $type,
@@ -132,6 +134,7 @@ class BannerNotificationsController extends WikiaController {
 
 		if ( F::app()->checkSkin( 'oasis' ) ) {
 			$title = $article->getTitle();
+
 			// special handling of ArticleComments
 			if ( class_exists( 'ArticleComment' ) &&
 				MWNamespace::isTalk( $title->getNamespace() ) &&
@@ -154,7 +157,7 @@ class BannerNotificationsController extends WikiaController {
 
 			wfRunHooks( 'OasisAddPageDeletedConfirmationMessage', array( &$title, &$message ) );
 
-			self::addConfirmation( $message );
+			self::addConfirmation( $message, self::CONFIRMATION_CONFIRM, true );
 
 			// redirect to main page
 			$wgOut->redirect( Title::newMainPage()->getFullUrl( array( 'cb' => rand( 1, 1000 ) ) ) );


### PR DESCRIPTION
Since we are allowing for only one backend confirmation, sometimes there are conflicts and two methods want to use confirmation at the same time.

This pull request adds a 'force' flag to addConfirmation method, so the more important confirmations show instead of the less important ones.

It's a fix for a P2 listed here: https://wikia-inc.atlassian.net/browse/SOC-569
