### PR TITLE
SOC-460 Send error logging if error when querying for weekly digest

### DIFF
--- a/extensions/wikia/GlobalWatchlist/GlobalWatchlistBot.class.php
+++ b/extensions/wikia/GlobalWatchlist/GlobalWatchlistBot.class.php
@@ -40,7 +40,7 @@ class GlobalWatchlistBot {
 					$userIDs[] = $row->gwa_user_id;
 				} );
 		} catch ( Exception $e ) {
-			WikiaLogger::instance()->info( 'Weekly Digest Error', [
+			WikiaLogger::instance()->error( 'Weekly Digest Error', [
 				'exception' => $e->getMessage(),
 			] );
 		}

--- a/extensions/wikia/GlobalWatchlist/GlobalWatchlistBot.class.php
+++ b/extensions/wikia/GlobalWatchlist/GlobalWatchlistBot.class.php
@@ -1,6 +1,5 @@
 <?php
 
-use \Wikia\Tasks\AsyncTaskList;
 use \Wikia\Logger\WikiaLogger;
 
 class GlobalWatchlistBot {
@@ -31,19 +30,12 @@ class GlobalWatchlistBot {
 	 */
 	private function getUserIDs() {
 		$db = wfGetDB( DB_SLAVE, [], \F::app()->wg->ExternalDatawareDB );
-		$userIDs = [];
-		try {
-			$userIDs = ( new WikiaSQL() )
-				->SELECT()->DISTINCT( GlobalWatchlistTable::COLUMN_USER_ID )
-				->FROM( GlobalWatchlistTable::TABLE_NAME )
-				->runLoop( $db, function ( &$userIDs, $row ) {
-					$userIDs[] = $row->gwa_user_id;
-				} );
-		} catch ( Exception $e ) {
-			WikiaLogger::instance()->error( 'Weekly Digest Error', [
-				'exception' => $e->getMessage(),
-			] );
-		}
+		$userIDs = ( new WikiaSQL() )
+			->SELECT()->DISTINCT( GlobalWatchlistTable::COLUMN_USER_ID )
+			->FROM( GlobalWatchlistTable::TABLE_NAME )
+			->runLoop( $db, function ( &$userIDs, $row ) {
+				$userIDs[] = $row->gwa_user_id;
+			} );
 
 		return $userIDs;
 	}
@@ -88,7 +80,6 @@ class GlobalWatchlistBot {
 			->SELECT()->DISTINCT( GlobalWatchlistTable::COLUMN_CITY_ID )
 			->FROM( GlobalWatchlistTable::TABLE_NAME )
 			->WHERE( GlobalWatchlistTable::COLUMN_USER_ID )->EQUAL_TO( $userID )
-			->AND_( GlobalWatchlistTable::COLUMN_TIMESTAMP )->IS_NOT_NULL()
 			->runLoop( $db, function ( &$wikiIDs, $row ) {
 				$wikiIDs[] = $row->gwa_city_id;
 			} );

--- a/extensions/wikia/GlobalWatchlist/GlobalWatchlistBot.class.php
+++ b/extensions/wikia/GlobalWatchlist/GlobalWatchlistBot.class.php
@@ -23,9 +23,7 @@ class GlobalWatchlistBot {
 	}
 
 	/**
-	 * Return all users in the global_watchlist table. If there's a problem with the query
-	 * (eg, timing out), log the error. We have a Kibana check which will send out an alert
-	 * if any "Weekly Digest Error" messages are sent.
+	 * Return all users in the global_watchlist table.
 	 * @return array
 	 */
 	private function getUserIDs() {

--- a/maintenance/wikia/cronjobs/sendWeeklyDigest.php
+++ b/maintenance/wikia/cronjobs/sendWeeklyDigest.php
@@ -1,5 +1,7 @@
 <?php
 
+use \Wikia\Logger\WikiaLogger;
+
 /**
  * sendWeeklyDigest
  *
@@ -30,7 +32,13 @@ class sendWeeklyDigest extends Maintenance {
 	public function execute() {
 		$this->logRunTime();
 		$watchlistBot = new GlobalWatchlistBot();
-		$watchlistBot->sendWeeklyDigest();
+		try {
+			$watchlistBot->sendWeeklyDigest();
+		} catch ( Exception $e ) {
+			WikiaLogger::instance()->error( 'Weekly Digest Error', [
+				'exception' => $e->getMessage(),
+			] );
+		}
 	}
 
 	private function logRunTime() {

--- a/maintenance/wikia/cronjobs/sendWeeklyDigest.php
+++ b/maintenance/wikia/cronjobs/sendWeeklyDigest.php
@@ -35,15 +35,23 @@ class sendWeeklyDigest extends Maintenance {
 		try {
 			$watchlistBot->sendWeeklyDigest();
 		} catch ( Exception $e ) {
-			WikiaLogger::instance()->error( 'Weekly Digest Error', [
-				'exception' => $e->getMessage(),
-			] );
+			$this->logError( $e );
 		}
 	}
 
 	private function logRunTime() {
 		$message = "sendWeeklyDigest script run at " . date( "F j, Y, g:i a" ) . "\n";
 		$this->output( $message );
+	}
+
+	/**
+	 * If there's a problem when sending the weekly digest (ie, timing out), log the error. We have
+	 * a Kibana check which will send out an alert if any "Weekly Digest Error" messages are sent.
+	 */
+	private function logError( Exception $exception ) {
+		WikiaLogger::instance()->error( 'Weekly Digest Error', [
+			'exception' => $exception->getMessage(),
+		] );
 	}
 }
 


### PR DESCRIPTION
Add additional error logging to Kibana. A check will be made in Kibana to see if any errors are being reported and, if so, the Social Team will be notified. This will replaced the failing nagios check which the weekly digest used before. The Kibana check is going to be done by OPs in a separate ticket which can be found in the jira ticket below:

Ticket: https://wikia-inc.atlassian.net/browse/SOC-460
