### PR TITLE
WikiFactory::loadVariableFromDB - improve caching

### DIFF
--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -3067,7 +3067,7 @@ class WikiFactory {
 	 *
 	 * @return string - variables key for memcached
 	 */
-	static public function getWikiaCacheKey( $city_id ) {
+	static private function getWikiaCacheKey( $city_id ) {
 		return "wikifactory:wikia:v1:{$city_id}";
 	}
 
@@ -3084,7 +3084,7 @@ class WikiFactory {
 	 *
 	 * @return string - variables key for memcached
 	 */
-	static public function getWikiaDBCacheKey( $city_dbname ) {
+	static private function getWikiaDBCacheKey( $city_dbname ) {
 		return "wikifactory:wikia:db:v1:{$city_dbname}";
 	}
 

--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -1497,7 +1497,7 @@ class WikiFactory {
 	 * @param string $id can be either "id:<var id>" or "name:<var name>"
 	 * @return string formatted memcache key
 	 */
-	static private function getVarMetadataKey( $id ) {
+	static protected function getVarMetadataKey( $id ) {
 		return wfSharedMemcKey( 'wikifactory:variables:metadata:v5', $id );
 	}
 
@@ -1508,7 +1508,7 @@ class WikiFactory {
 	 * @param int $var_id variable ID
 	 * @return string formatted memcache key
 	 */
-	static private function getVarValueKey( $city_id, $var_id ) {
+	static protected function getVarValueKey( $city_id, $var_id ) {
 		return wfSharedMemcKey( 'wikifactory:variables:value:v5', $city_id, $var_id );
 	}
 
@@ -3067,7 +3067,7 @@ class WikiFactory {
 	 *
 	 * @return string - variables key for memcached
 	 */
-	static private function getWikiaCacheKey( $city_id ) {
+	static protected function getWikiaCacheKey( $city_id ) {
 		return "wikifactory:wikia:v1:{$city_id}";
 	}
 
@@ -3084,7 +3084,7 @@ class WikiFactory {
 	 *
 	 * @return string - variables key for memcached
 	 */
-	static private function getWikiaDBCacheKey( $city_dbname ) {
+	static protected function getWikiaDBCacheKey( $city_dbname ) {
 		return "wikifactory:wikia:db:v1:{$city_dbname}";
 	}
 

--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -2041,7 +2041,7 @@ class WikiFactory {
 					return $oRow;
 				},
 				// always hit the database when $master set to true
-				$master ? WikiaDataAccess::SKIP_CACHE : WikiaDataAccess::USE_CACHE
+				$master ? WikiaDataAccess::REFRESH_CACHE : WikiaDataAccess::USE_CACHE
 			);
 
 			self::$variablesCache[$cacheKey] = $oRow;

--- a/includes/wikia/WikiaDataAccess.class.php
+++ b/includes/wikia/WikiaDataAccess.class.php
@@ -82,7 +82,10 @@ class WikiaDataAccess {
 		$negativeCacheTTL = isset( $options['negativeCacheTTL'] ) ? $options['negativeCacheTTL'] : $cacheTTL;
 
 		if ( $command == self::SKIP_CACHE ) {
-			Wikia::log( __METHOD__, 'debug', "Cache disabled for key:{$key}, if this is on production please contact the author of the code.", true);
+			WikiaLogger::instance()->error( "WikiaDataAccess: cache disabled" , [
+				'key' => $key,
+				'exception' => new Exception()
+			] );
 		}
 
 		$result = ($command == self::USE_CACHE) ? $wg->Memc->get( $key ) : null;


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-600

`WikiFactory::loadVariableFromDB` method is responsible for **~70mm queries to shared DB daily** (that's ~**14% of all queries** from MW hitting shared DB).

Add caching in two places:
- when getting variable metadata from `city_variables_pool`
- when getting variable value from `city_variables` table

and invalidate the cache properly.

`WikiFactory::loadVariableFromDB` method queries the database mostly in two cases:
- when there's a miss on a wiki cache (that stores wiki metadata including WF variables)
- when given variable is not set on this wiki

@michalroszka / @wladekb / @owend / @drozdo 
