### PR TITLE
Fix for making sure we get ResultWrapper from query().

### DIFF
--- a/extensions/wikia/ImageServing/drivers/ImageServingDriverMainNS.class.php
+++ b/extensions/wikia/ImageServing/drivers/ImageServingDriverMainNS.class.php
@@ -137,14 +137,14 @@ class ImageServingDriverMainNS extends ImageServingDriverBase {
 				__METHOD__
 			);
 
-			if ($result instanceof ResultWrapper && $result->numRows() > 0) {
-				foreach ($result as $row) {
+			if ( $result instanceof ResultWrapper && $result->numRows() > 0 ) {
+				foreach ( $result as $row ) {
 					/* @var mixed $row */
-					if ($row->img_height >= $this->minHeight && $row->img_width >= $this->minWidth) {
-						if (!in_array($row->img_minor_mime, self::$mimeTypesBlacklist)) {
+					if ( $row->img_height >= $this->minHeight && $row->img_width >= $this->minWidth ) {
+						if ( !in_array( $row->img_minor_mime, self::$mimeTypesBlacklist ) ) {
 							$imageDetails[$row->img_name] = $row;
 						} else {
-							wfDebug(__METHOD__ . ": {$row->img_name} - filtered out because of {$row->img_minor_mime} minor MIME type\n");
+							wfDebug( __METHOD__ . ": {$row->img_name} - filtered out because of {$row->img_minor_mime} minor MIME type\n" );
 						}
 					}
 				}

--- a/extensions/wikia/ImageServing/drivers/ImageServingDriverMainNS.class.php
+++ b/extensions/wikia/ImageServing/drivers/ImageServingDriverMainNS.class.php
@@ -137,17 +137,20 @@ class ImageServingDriverMainNS extends ImageServingDriverBase {
 				__METHOD__
 			);
 
-			foreach ( $result as $row ) {
-				/* @var mixed $row */
-				if ( $row->img_height >= $this->minHeight && $row->img_width >= $this->minWidth ) {
-					if ( !in_array( $row->img_minor_mime, self::$mimeTypesBlacklist ) ) {
-						$imageDetails[$row->img_name] = $row;
-					} else {
-						wfDebug( __METHOD__ . ": {$row->img_name} - filtered out because of {$row->img_minor_mime} minor MIME type\n" );
+			if ($result instanceof ResultWrapper && $result->numRows() > 0) {
+				foreach ($result as $row) {
+					/* @var mixed $row */
+					if ($row->img_height >= $this->minHeight && $row->img_width >= $this->minWidth) {
+						if (!in_array($row->img_minor_mime, self::$mimeTypesBlacklist)) {
+							$imageDetails[$row->img_name] = $row;
+						} else {
+							wfDebug(__METHOD__ . ": {$row->img_name} - filtered out because of {$row->img_minor_mime} minor MIME type\n");
+						}
 					}
 				}
+				$result->free();
 			}
-			$result->free();
+
 			$imageNames = array_keys( $imageDetails );
 		}
 

--- a/extensions/wikia/ImageServing/drivers/ImageServingDriverMainNS.class.php
+++ b/extensions/wikia/ImageServing/drivers/ImageServingDriverMainNS.class.php
@@ -137,19 +137,25 @@ class ImageServingDriverMainNS extends ImageServingDriverBase {
 				__METHOD__
 			);
 
-			if ( $result instanceof ResultWrapper && $result->numRows() > 0 ) {
-				foreach ( $result as $row ) {
-					/* @var mixed $row */
-					if ( $row->img_height >= $this->minHeight && $row->img_width >= $this->minWidth ) {
-						if ( !in_array( $row->img_minor_mime, self::$mimeTypesBlacklist ) ) {
-							$imageDetails[$row->img_name] = $row;
-						} else {
-							wfDebug( __METHOD__ . ": {$row->img_name} - filtered out because of {$row->img_minor_mime} minor MIME type\n" );
-						}
+			// if query was terminated - return and abort the process
+			if ( !$result ) {
+				wfProfileOut( __METHOD__ );
+
+				return;
+			}
+
+			foreach ( $result as $row ) {
+				/* @var mixed $row */
+				if ( $row->img_height >= $this->minHeight && $row->img_width >= $this->minWidth ) {
+					if ( !in_array( $row->img_minor_mime, self::$mimeTypesBlacklist ) ) {
+						$imageDetails[$row->img_name] = $row;
+					} else {
+						wfDebug( __METHOD__ . ": {$row->img_name} - filtered out because of {$row->img_minor_mime} minor MIME type\n" );
 					}
 				}
-				$result->free();
 			}
+
+			$result->free();
 
 			$imageNames = array_keys( $imageDetails );
 		}


### PR DESCRIPTION
In some rare caese Database::query() returs false and it was causing
errors when trying to use reuturned value as an instance of ResultWrapper.
Added some safe checks to detect such cases.
