### PR TITLE
WikiPage: call a proper task class

### DIFF
--- a/includes/WikiPage.php
+++ b/includes/WikiPage.php
@@ -1597,7 +1597,7 @@ class WikiPage extends Page {
 			if ( 0 == mt_rand( 0, 99 ) ) {
 				// Flush old entries from the `recentchanges` table
 				// Wikia: use a job backported from MediaWiki 1.25 (@see PLATFORM-965)
-				Wikia\Tasks\Tasks\RecentChangesUpdate::newPurgeTask();
+				Wikia\Tasks\Tasks\RecentChangesUpdateTask::newPurgeTask();
 			}
 		}
 


### PR DESCRIPTION
Fixes `PHP Fatal Error: Class 'Wikia\Tasks\Tasks\RecentChangesUpdate' not found in /includes/WikiPage.php on line 1600`

@michalroszka 
