### PR TITLE
Explicitly set wikiamobile as the skin for WikiaMobileController

### DIFF
--- a/extensions/wikia/WikiaMobile/WikiaMobileController.class.php
+++ b/extensions/wikia/WikiaMobile/WikiaMobileController.class.php
@@ -6,6 +6,16 @@
  * @author Jakub Olek <jolek(at)wikia-inc.com>
  */
 class WikiaMobileController extends WikiaController{
+	function __construct() {
+		//Some internal methods called from this controller need the skin to be wikiamobile
+		//It makes sense to set it explicitly here as other skins shouldn't use it anyway
+		RequestContext::getMain()->setSkin(
+			Skin::newFromKey( 'wikiamobile' )
+		);
+
+		parent::__construct();
+	}
+
 	/**
 	 * Fetches the requested batch for a specific index
 	 * section in a category page


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CONCF-222

https://github.com/Wikia/app/blob/dev/extensions/wikia/Blogs/BlogArticle.php#L438 was sometimes getting skin other than `wikiamobile` while called by `WikiaMobileCategoryViewer::WikiaMobileCategoryViewer` hook. This caused PHP warnings as `WikiaMobileCategoryService_getBatch.php` was getting a string instead of an array.

This should never happen and it's hard to find why it does. With @hakubo we've decided it's best to set `wikiamobile` skin explicitly for `WikiaMobileController`.
