### PR TITLE
DAT-2660 Make sure memcache can be used in the service

### DIFF
--- a/extensions/wikia/Search/classes/IndexService/WikiViews.php
+++ b/extensions/wikia/Search/classes/IndexService/WikiViews.php
@@ -38,7 +38,7 @@ class WikiViews extends AbstractWikiService
 		
 		$stringKey = 'WikiaSearchPageViews';
 		$result = $this->service->getCacheResultFromString( $stringKey );
-		
+
 		if ( ( $result !== false ) && ( $result->weekly > 0 || $result->monthly > 0 ) ) {
 			wfProfileOut(__METHOD__);
 			$this->result = array(
@@ -69,8 +69,12 @@ class WikiViews extends AbstractWikiService
 				$row->monthly += $pview;
 			}
 		}
-	
-		$this->service->setCacheFromStringKey( $stringKey, $row, self::WIKIPAGES_CACHE_TTL ); 
+
+		$wrapper = new \Wikia\Util\GlobalStateWrapper(array('wgAllowMemcacheWrites' => true));
+		$wrapper->wrap(function () use ($stringKey, $row) {
+			$this->service->setCacheFromStringKey( $stringKey, $row, self::WIKIPAGES_CACHE_TTL );
+		});
+
 		$this->result = array(
 				'wikiviews_weekly' => (int) $row->weekly,
 				'wikiviews_monthly' => (int) $row->monthly, 


### PR DESCRIPTION
Using GlobalStateWrapper is hardly the most straightforward approach; However, this service is used only by the Indexer, which by itself sets wgAllowMemcacheWrites to false. This is unwanted in this context and the information returned by WikiViews does not need to be perfectly accurate, so it's fine.
