### PR TITLE
ADEN-1859: Fix two ads in one slote (Evolve)

### DIFF
--- a/extensions/wikia/AdEngine/js/provider/evolve.js
+++ b/extensions/wikia/AdEngine/js/provider/evolve.js
@@ -193,6 +193,12 @@ define('ext.wikia.adEngine.provider.evolve', [
 					return;
 				}
 
+				// Success
+				// TODO: find a better place for operation below
+				slotTweaker.removeDefaultHeight(slotname);
+				slotTweaker.removeTopButtonIfNeeded(slotname);
+				slotTweaker.adjustLeaderboardSize(slotname);
+
 				pSuccess();
 			});
 		}

--- a/extensions/wikia/AdEngine/js/provider/evolve.js
+++ b/extensions/wikia/AdEngine/js/provider/evolve.js
@@ -166,7 +166,7 @@ define('ext.wikia.adEngine.provider.evolve', [
 		hoppedSlots[sanitizeSlotname(slotname)] = true;
 	}
 
-	function fillInSlot(slotname, pSuccess) {
+	function fillInSlot(slotname, pSuccess, pHop) {
 		log('fillInSlot', 5, logGroup);
 		log(slotname, 5, logGroup);
 
@@ -188,6 +188,11 @@ define('ext.wikia.adEngine.provider.evolve', [
 			);
 		} else {
 			scriptWriter.injectScriptByUrl(slotname, getUrl(slotname), function () {
+				if (hoppedSlots[slotname]) {
+					pHop({method: 'hop'});
+					return;
+				}
+
 				pSuccess();
 			});
 		}

--- a/extensions/wikia/AdEngine/js/provider/evolve.js
+++ b/extensions/wikia/AdEngine/js/provider/evolve.js
@@ -166,7 +166,7 @@ define('ext.wikia.adEngine.provider.evolve', [
 		hoppedSlots[sanitizeSlotname(slotname)] = true;
 	}
 
-	function fillInSlot(slotname, pSuccess, pHop) {
+	function fillInSlot(slotname, pSuccess) {
 		log('fillInSlot', 5, logGroup);
 		log(slotname, 5, logGroup);
 
@@ -188,31 +188,7 @@ define('ext.wikia.adEngine.provider.evolve', [
 			);
 		} else {
 			scriptWriter.injectScriptByUrl(slotname, getUrl(slotname), function () {
-				var slot = document.getElementById(slotname),
-					height;
-
-				if (hoppedSlots[slotname]) {
-					pHop({method: 'hop'});
-					return;
-				}
-
-				// Don't rely completely on Evolve hop
-				slotTweaker.removeDefaultHeight(slotname);
-				height = getHeight(slot);
-
-				// Only assume success if > 1x1 ad is returned or there's embed
-				// in the slot (it seems Evolves returns an embed that causes
-				// more HTML to appear after GhostWriter calls finish callback).
-				if (height === undef || height > 1 || hasEmbed(slot)) {
-					// Real success
-					slotTweaker.removeTopButtonIfNeeded(slotname);
-					pSuccess();
-					return;
-				}
-
-				slotTweaker.addDefaultHeight(slotname);
-				log('Evolve did not hop, but returned 1x1 ad instead for slot ' + slotname, 1, logGroup);
-				pHop({method: '1x1'});
+				pSuccess();
 			});
 		}
 	}

--- a/extensions/wikia/AdEngine/js/provider/evolve.js
+++ b/extensions/wikia/AdEngine/js/provider/evolve.js
@@ -19,8 +19,7 @@ define('ext.wikia.adEngine.provider.evolve', [
 		tile = 0,
 		slotForSkin = 'INVISIBLE_SKIN',
 		hoppedSlots = {},
-		iface,
-		undef;
+		iface;
 
 	slotMap = evolveSlotConfig.getConfig();
 
@@ -34,41 +33,6 @@ define('ext.wikia.adEngine.provider.evolve', [
 		var embedNo = slot.getElementsByTagName('embed').length || slot.getElementsByTagName('object').length;
 		log(['hasEmbed', slot, embedNo], 5, logGroup);
 		return !!embedNo;
-	}
-
-	/**
-	 * Get element height like $.height. For IE get offsetHeight and subtracts margin and padding.
-	 *
-	 * TODO: in future we should rely entirely on offsetHeight, so the actual ad should be loaded
-	 * in a div with no paddings and margins.
-	 *
-	 * @param {Element} slot
-	 * @return {Number}
-	 */
-	function getHeight(slot) {
-		var margins = 0,
-			height,
-			undef;
-
-		log(['getHeight', slot], 5, logGroup);
-
-		if (window.getComputedStyle) {
-			height = parseInt(window.getComputedStyle(slot).getPropertyValue('height'), 10);
-			log(['getHeight (regular browser version)', slot, height], 5, logGroup);
-		}
-
-		// IE8
-		if (height === undef && slot.currentStyle) {
-			margins += parseInt('0' + slot.currentStyle.marginTop, 10);
-			margins += parseInt('0' + slot.currentStyle.marginBottom, 10);
-			margins += parseInt('0' + slot.currentStyle.paddingTop, 10);
-			margins += parseInt('0' + slot.currentStyle.paddingBottom, 10);
-
-			height = slot.offsetHeight - margins;
-			log(['getHeight (IE version)', slot, height], 5, logGroup);
-		}
-
-		return height;
 	}
 
 	function getKv(slotname) {


### PR DESCRIPTION
Evolve is now returning the correct hops. Therefore, we don't need custom logic which is causing now two ads in one slow.

Once I removed the custom logic I started receiving only one ad in a slot in New Zealand and Canada. There is still remaining issue with not hiding slots after Evolve's hop but I'll follow working on it in `dev` branch. From business reasons it's very important to fix the two ads in one slot ASAP.
