### PR TITLE
WikiFactoryHub:getWikiCategories: cache even if there are no results

### DIFF
--- a/extensions/wikia/WikiFactory/Hubs/WikiFactoryHub.php
+++ b/extensions/wikia/WikiFactory/Hubs/WikiFactoryHub.php
@@ -155,7 +155,7 @@ class WikiFactoryHub extends WikiaModel {
 			->JOIN ( "city_cat_mapping" )->USING( "cat_id" )
 			->WHERE( "city_id" )->EQUAL_TO( $city_id )
 			->AND_( "cat_deprecated" )->EQUAL_TO ( 1 )  // always return the "old" category
-			->cache( $this->cache_ttl, wfSharedMemcKey( __METHOD__, $city_id ) )
+			->cache( $this->cache_ttl, wfSharedMemcKey( __METHOD__, $city_id ), true /* $cacheEmpty */ )
 			->runLoop ( $this->getSharedDB(), function ( &$result, $row ) {
 				$result[]= $row->cat_id;
 			});
@@ -275,6 +275,9 @@ class WikiFactoryHub extends WikiaModel {
 			$city_id = 11;
 		}
 
+		// invalidated in clearCache method
+		$memckey = wfSharedMemcKey( __METHOD__, $city_id, $active ? 1 : 0 );
+
 		// query instead of lookup in AllCategories list
 		$categories = (new WikiaSQL())
 			->SELECT( "*" )
@@ -282,7 +285,7 @@ class WikiFactoryHub extends WikiaModel {
 			->JOIN ( "city_cat_mapping" )->USING( "cat_id" )
 			->WHERE( "city_id ")->EQUAL_TO( $city_id )
 			->AND_( "cat_active" )->EQUAL_TO ( $active )
-			->cache ( $this->cache_ttl, wfSharedMemcKey( __METHOD__, $city_id, "$active" ) )
+			->cache( $this->cache_ttl, $memckey, true /* $cacheEmpty */ )
 			->runLoop( $this->getSharedDB(), function ( &$result, $row)  {
 				$result[] = get_object_vars($row);
 			});

--- a/extensions/wikia/WikiFactory/Hubs/WikiFactoryHub.php
+++ b/extensions/wikia/WikiFactory/Hubs/WikiFactoryHub.php
@@ -237,10 +237,9 @@ class WikiFactoryHub extends WikiaModel {
 	 * @access public
 	 *
 	 * @param $city_id
-	 * @return array of categories (empty if wiki is not in a category)
-	 *
+	 * @param int $active pass 0 if you want to get deprecated categories
+	 * @return array array of categories (empty if wiki is not in a category)
 	 */
-
 	public function getCategoryIds( $city_id, $active = 1 ) {
 		global $wgExternalSharedDB;
 		if( !$wgExternalSharedDB || empty($city_id) ) {
@@ -266,10 +265,10 @@ class WikiFactoryHub extends WikiaModel {
 	 * This function returns the list of categories AND category metadata for a wiki
 	 * get category metadata (id, name, url, short, deprecated, active) for a wiki
 	 * @param  integer $city_id  wiki_id
+	 * @param int $active pass 0 if you want to get deprecated categories
 	 * @return array of keys/values (id, name, url, short, deprecated, active)
 	 */
 	public function getWikiCategories( $city_id, $active = 1 ) {
-
 		global $wgWikiaEnvironment;
 		if ( $wgWikiaEnvironment == WIKIA_ENV_INTERNAL ) {
 			$city_id = 11;


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-1087

`WikiFactoryHub:getWikiCategories` makes 100mm queries daily to shared DB (~20% of all queries). Most of them can and should be cached. However, `WikiaSQL` by default does **not** cache results with empty rows set.

There are lots of memcache misses and just a few sets:

```
site> select bucket, key, sum(sum) from Mediawiki_App_Memcache_Keys_Stats_60m where time > now() - 6h and key =~ /getWikiCategories/ group by bucket;
┌─────────────────┬────────┬────────┐
│       time      │ sum    │ bucket │
├─────────────────┼────────┼────────┤
│ 1/1/70 01:00:00 │ 65993  │ hit    │
│ 1/1/70 01:00:00 │ 133478 │ miss   │
│ 1/1/70 01:00:00 │ 298    │ set    │
└─────────────────┴────────┴────────┘
```

@owend / @wladekb / @drozdo 
