### PR TITLE
eval.php: debug memcache operations when in -d 3 mode

### DIFF
--- a/maintenance/eval.php
+++ b/maintenance/eval.php
@@ -51,6 +51,7 @@ if ( isset( $options['d'] ) ) {
 		}
 	}
 	if ( $d > 2 ) {
+		$wgMemc->setDebug(true);
 		$wgDebugFunctionEntry = true;
 	}
 }


### PR DESCRIPTION
Emit memcache debug log to stdout when `eval.php` is run with `-d 3`

```
SERVER_DBNAME=plpoznan php -d display_errors=1 ~/app/maintenance/eval.php -d 3
```

Example:

```
> var_dump( (new WikiFactoryHub())->getWikiCategories($wgCityId) )
...
LoadBalancer::openForeignConnection: opened new connection for 0/wikicities
memcached: get(wikicities:WikiFactoryHub::getWikiCategories:5915:1)
memcached: MemCache: sock i:0; got wikicities:WikiFactoryHub::getWikiCategories:5915:1
array(0) {
}

> 
```

@wladekb / @michalroszka / @owend / @adamkarminski 
