### PR TITLE
NewRelic: mark transactions that trigger DPL database queries

### DIFF
--- a/extensions/DynamicPageList/DPLMain.php
+++ b/extensions/DynamicPageList/DPLMain.php
@@ -2579,6 +2579,9 @@ class DPLMain {
             return $result;
         }
 
+        // Wikia change - mark transactions that trigger DPL queries (PLATFORM-1074)
+        Transaction::setAttribute( Transaction::PARAM_DPL, true );
+
         if ($dbr->numRows( $res ) <= 0) {
 			$header = str_replace('%TOTALPAGES%','0',str_replace('%PAGES%','0',$sNoResultsHeader));
             if ($sNoResultsHeader != '')	$output .= 	str_replace( '\n', "\n", str_replace( "¶", "\n", $header));

--- a/includes/wikia/transaction/Transaction.php
+++ b/includes/wikia/transaction/Transaction.php
@@ -37,6 +37,7 @@ class Transaction {
 	const PARAM_SPECIAL_PAGE_NAME = 'special_page';
 	const PARAM_API_ACTION = 'api_action';
 	const PARAM_WIKI = 'wiki';
+	const PARAM_DPL = 'dpl';
 
 	const PSEUDO_PARAM_TYPE = 'type';
 

--- a/includes/wikia/transaction/TransactionClassifier.php
+++ b/includes/wikia/transaction/TransactionClassifier.php
@@ -78,6 +78,9 @@ class TransactionClassifier {
 		true => 'parser_cache_disabled',
 	);
 
+	protected static $MAP_DPL = array(
+		true => 'dpl',
+	);
 
 	protected $dependencies = array( Transaction::PARAM_ENTRY_POINT );
 	protected $attributes = array();
@@ -170,6 +173,10 @@ class TransactionClassifier {
 		else if ( $this->addByMap( Transaction::PARAM_PARSER_CACHE_USED, self::$MAP_PARSER_CACHED_USED ) === null ) {
 			return;
 		}
+
+		// add "DPL was used" information
+		$this->addByMap( Transaction::PARAM_DPL, self::$MAP_DPL );
+
 		// add size category
 		if ( $this->add( Transaction::PARAM_SIZE_CATEGORY ) === null ) {
 			return;

--- a/includes/wikia/transaction/tests/TransactionClassifierTest.php
+++ b/includes/wikia/transaction/tests/TransactionClassifierTest.php
@@ -69,6 +69,17 @@ class TransactionClassifierTest extends WikiaBaseTest {
 				],
 				'expectedName' => 'page/main/view/foo-skin/no_parser/medium-page'
 			],
+			[
+				'attributes' => [
+					Transaction::PARAM_ENTRY_POINT => Transaction::ENTRY_POINT_PAGE,
+					Transaction::PARAM_NAMESPACE => NS_MAIN,
+					Transaction::PARAM_ACTION => TransactionClassifier::ACTION_VIEW,
+					Transaction::PARAM_SKIN => 'foo-skin',
+					Transaction::PARAM_PARSER_CACHE_DISABLED => true,
+					Transaction::PARAM_DPL => true
+				],
+				'expectedName' => 'page/main/view/foo-skin/parser_cache_disabled/dpl'
+			],
 		];
 	}
 }


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-1074

In order to have a better insight into DPL's black magic let's start marking transactions that use DynamicPageList.

```
TransactionTrace: notification: ["onAttributeChange","dpl",true]
TransactionTrace: notification: ["onTypeChange","page\/main\/view\/oasis\/parser\/dpl"]
```

@wladekb / @michalroszka 
