### PR TITLE
ignore duplicate key error which happens when removing a group from a us...

### DIFF
--- a/extensions/wikia/SharedUserrights/SharedUserrights.class.php
+++ b/extensions/wikia/SharedUserrights/SharedUserrights.class.php
@@ -134,7 +134,8 @@ class UserRights {
 					'ufg_user'  => $user->getID(),
 					'ufg_group' => $group,
 				],
-				__METHOD__
+				__METHOD__,
+				array( 'IGNORE' )
 		);
 
 		WikiaDataAccess::cachePurge( self::getMemcKey( $user ) );


### PR DESCRIPTION
...er twice
