### PR TITLE
PLATFORM-1039: Add logging for fatal error in LogEventsList

### DIFF
--- a/includes/logging/LogEventsList.php
+++ b/includes/logging/LogEventsList.php
@@ -216,6 +216,11 @@ class LogEventsList {
 	}
 
 	public function getContext() {
+		if ( !is_object( $this->out ) ) {
+			\Wikia\Logger\WikiaLogger::instance()->debug( 'LogEventsList getContext not an object', [
+				'exception' => new Exception(),
+			]);
+		}
 		return $this->out->getContext();
 	}
 


### PR DESCRIPTION
This fatal error is hard to track down without additional information.

https://wikia-inc.atlassian.net/browse/PLATFORM-1039

/cc @macbre 
