### PR TITLE
PLATFORM-1065: Fix fatal error in ApiQueryCategoryInfo

### DIFF
--- a/includes/api/ApiQueryCategoryInfo.php
+++ b/includes/api/ApiQueryCategoryInfo.php
@@ -47,6 +47,14 @@ class ApiQueryCategoryInfo extends ApiQueryBase {
 					$this->getPageSet()->getMissingTitles();
 		$cattitles = array();
 		foreach ( $categories as $c ) {
+			// Wikia change - begin - @author: wladek
+			// PLATFORM-1065: categories redirecting to another category that is found in the set
+			// cause fatal errors during the call to getDBkey() as the title is a non-object in such case
+			// (is not returned as a good or missing title)
+			if ( !isset( $titles[$c] ) ) {
+				continue;
+			}
+			// Wikia change - end
 			$t = $titles[$c];
 			$cattitles[$c] = $t->getDBkey();
 		}


### PR DESCRIPTION
Fix for fatal error occuring in ApiQueryCategoryInfo when a category redirect points to another category which matches the query. Due to the way how it is solved internally in ApiPageSet and then iinterpreted in ApiQueryCategoryInfo it causes a call to getDBkey() on a non-object (please refer to inline docs for further info).

https://wikia-inc.atlassian.net/browse/PLATFORM-1065

/cc @macbre 
