### PR TITLE
PLATFORM-1064: Add logging for warning in WikiFactory::getWikisByID() and fail early

### DIFF
--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -1262,7 +1262,7 @@ class WikiFactory {
 	 *
 	 * @return array an array of objects, keys are wikis ids.
 	 */
-	static public function getWikisByID( $ids, $master = false ) {
+	static public function getWikisByID( array $ids, $master = false ) {
 		if ( !self::isUsed() ) {
 			Wikia::log( __METHOD__, "", "WikiFactory is not used." );
 			return false;


### PR DESCRIPTION
Warning was produces infrequently in WikiFactory::getWikisByID() when the argument is not a valid array. This change logs the backtrace and returns an empty result early.

https://wikia-inc.atlassian.net/browse/PLATFORM-1064

/cc @macbre 
