### PR TITLE
CONCF-80: support two endpoints for mercury api purges

### DIFF
--- a/includes/cache/wikia/CeleryPurge.class.php
+++ b/includes/cache/wikia/CeleryPurge.class.php
@@ -30,6 +30,7 @@ class CeleryPurge {
 				$carry['vignette'][] = $item;
 			} elseif ( strstr($item, 'MercuryApi') !== false ) {
 				$carry['mercury'][] = $item;
+				$carry['mediawiki'][] = $item;  // TODO: we can remove this when mercury is only using internal cache
 			} else {
 				$carry['mediawiki'][] = $item;
 			}


### PR DESCRIPTION
Purge both internal and external cache for mercury api calls. 
@bognix @Warkot 
