### PR TITLE
Make Language::getLanguageName a static method

### DIFF
--- a/languages/Language.php
+++ b/languages/Language.php
@@ -788,7 +788,7 @@ class Language {
 	 * @param $code string
 	 * @return string
 	 */
-	function getLanguageName( $code ) {
+	static function getLanguageName( $code ) {
 		$names = self::getLanguageNames();
 		if ( !array_key_exists( $code, $names ) ) {
 			return '';


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-1095

Prevent `PHP Deprecated: Non-static method Language::getLanguageName() should not be called statically, assuming $this from incompatible context in ...` after the upgrade to PHP 5.6

Before the fix:

``` php
> echo Language::getLanguageName( 'fo' );

Strict standards: Non-static method Language::getLanguageName() should not be called statically in /usr/wikia/source/app/maintenance/eval.php(74) : eval()'d code on line 1

Call Stack:
    0.0005     241712   1. {main}() /usr/wikia/source/app/maintenance/eval.php:0
    1.8821   26961768   2. eval('echo Language::getLanguageName( 'fo' );;') /usr/wikia/source/app/maintenance/eval.php:74

Føroyskt
```

And after:

``` php
> echo Language::getLanguageName( 'fo' );
Føroyskt
> echo $wgLang->getLanguageName( 'fo' );
Føroyskt
```

@michalroszka / @wladekb 
