### PR TITLE
Related Pages performance improvements

### DIFF
--- a/extensions/wikia/RelatedPages/RelatedPages.class.php
+++ b/extensions/wikia/RelatedPages/RelatedPages.class.php
@@ -4,8 +4,6 @@ class RelatedPages {
 
 	protected $pages = null;
 	protected $categories = null;
-	protected $categoryCacheTTL = 8; // in hours
-	protected $categoryRankCacheTTL = 24; // in hours
 	protected $categoriesLimit = 6;
 	protected $pageSectionNo = 4; // number of section before which module should be injected (for long articles)
 	protected $isRendered = false;
@@ -212,7 +210,7 @@ class RelatedPages {
 			$pages[] = $row->page_id;
 		}
 
-		$wgMemc->set( $cacheKey, $pages, ( $this->categoryCacheTTL * 3600 ) );
+		$wgMemc->set( $cacheKey, $pages, WikiaResponse::CACHE_STANDARD );
 
 		wfProfileOut( __METHOD__ );
 		return $pages;
@@ -276,7 +274,7 @@ class RelatedPages {
 			}
 		}
 
-		$wgMemc->set( $cacheKey, $pages, ( $this->categoryCacheTTL * 3600 ) );
+		$wgMemc->set( $cacheKey, $pages, WikiaResponse::CACHE_STANDARD );
 		wfProfileOut( __METHOD__ );
 		return $pages;
 	}
@@ -346,7 +344,7 @@ class RelatedPages {
 
 		$results = WikiaDataAccess::cacheWithLock(
 			( empty( $this->memcKeyPrefix ) ) ? wfMemcKey( __METHOD__ ) : wfMemcKey( $this->memcKeyPrefix, __METHOD__ ),
-			$this->categoryRankCacheTTL * 3600,
+			WikiaResponse::CACHE_STANDARD,
 			function () use ( $wgContentNamespaces ) {
 				$db = wfGetDB( DB_SLAVE );
 				$sql = ( new WikiaSQL() )
@@ -401,7 +399,7 @@ class RelatedPages {
 
 			$count = ( is_object( $result ) ) ? $result->count : 0;
 			if ( $count > 0 ) {
-				$wgMemc->set( $cacheKey, $count, $this->categoryRankCacheTTL * 3600 );
+				$wgMemc->set( $cacheKey, $count, WikiaResponse::CACHE_STANDARD );
 			}
 		}
 

--- a/extensions/wikia/RelatedPages/RelatedPages.class.php
+++ b/extensions/wikia/RelatedPages/RelatedPages.class.php
@@ -217,11 +217,21 @@ class RelatedPages {
 	}
 
 	/**
-	* get pages that belong to a list of categories
-	* @author Owen
-	*/
+	 * get pages that belong to a list of categories
+	 * @author Owen
+	 *
+	 * @param int $articleId
+	 * @param int $limit
+	 * @param array $categories
+	 * @return array
+	 * @throws DBUnexpectedError|MWException
+	 */
 	protected function getPagesForCategories( $articleId, $limit, Array $categories ) {
 		global $wgMemc;
+
+		if ( empty( $categories ) ) {
+			return [];
+		}
 
 		wfProfileIn( __METHOD__ );
 		if ( empty( $this->memcKeyPrefix ) ) {
@@ -238,11 +248,6 @@ class RelatedPages {
 
 		$dbr = wfGetDB( DB_SLAVE );
 		$pages = array();
-
-		if ( empty( $categories ) ) {
-			wfProfileOut( __METHOD__ );
-			return $pages;
-		}
 
 		$tables = array( "categorylinks" );
 		$joinSql = $this->getPageJoinSql( $dbr, $tables );


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-1097 / https://wikia-inc.atlassian.net/browse/PLATFORM-1098
- cache zeros returned by `RelatedPages::getCategoryRankByName` method
- use `WikiaDataAccess` to simplify the code
- clean up the code

Try to improve the following memcache metrics:

```
> Top memcache misses with no sets (71 rows)
------------------------------------------------------------------------------------------------------------------------
Key                                                                                                  Misses / 1h
------------------------------------------------------------------------------------------------------------------------
*:protectsite2                                                                                       8,729,100.00
*:wgMWrevId                                                                                          4,402,600.00
*:RelatedPages::getCategoryRankByName:*                                                              704,600.00
*:abusefilter:block-autopromote:*                                                                    463,900.00
*:MostVisited:*:*:*                                                                                  302,600.00
starter:file:*                                                                                       297,500.00
*:RelatedPages::getPagesForCategories:*                                                              183,000.00
```

@wladekb / @michalroszka / @harnash 
