### PR TITLE
DataProvider - use DatamartService's memcache

### DIFF
--- a/extensions/wikia/DataProvider/DataProvider.php
+++ b/extensions/wikia/DataProvider/DataProvider.php
@@ -348,10 +348,12 @@ class DataProvider {
 		$results = array();
 		$data = DataMartService::getTopArticlesByPageview( $wgCityId, null, $ns, false, 2 * $limit );
 		if ( !empty( $data ) ) {
+			$mainPage = Title::newMainPage();
+
 			foreach ( $data as $article_id => $row ) {
 				$title = Title::newFromID($article_id);
 				if ( is_object($title) ) {
-					if ( wfMsg("mainpage") != $title->getText() ) {
+					if ( !$mainPage->equals( $title ) ) {
 						$article = array(
 							'url'	=> $title->getLocalUrl(),
 							'text'	=> $title->getPrefixedText(),

--- a/extensions/wikia/DataProvider/DataProvider.php
+++ b/extensions/wikia/DataProvider/DataProvider.php
@@ -343,34 +343,29 @@ class DataProvider {
 	 */
 	final public static function GetMostVisitedArticles($limit = 7, $ns = array(NS_MAIN), $fillUpMostPopular = true) {
 		wfProfileIn(__METHOD__);
-		global $wgMemc, $wgCityId;
+		global $wgCityId;
 
-		$memckey = wfMemcKey("MostVisited", $limit, implode(",", $ns), $fillUpMostPopular);
-		$results = $wgMemc->get($memckey);
-
-		if (!is_array($results)) {
-			$results = array();
-			$data = DataMartService::getTopArticlesByPageview( $wgCityId, null, $ns, false, 2 * $limit );
-			if ( !empty( $data ) ) {
-				foreach ( $data as $article_id => $row ) {
-					$title = Title::newFromID($article_id);
-					if ( is_object($title) ) {
-						if ( wfMsg("mainpage") != $title->getText() ) {
-							$article = array(
-								'url'	=> $title->getLocalUrl(),
-								'text'	=> $title->getPrefixedText(),
-								'count' => $row['pageviews']
-							);
-							$results[] = $article;
-						}
+		$results = array();
+		$data = DataMartService::getTopArticlesByPageview( $wgCityId, null, $ns, false, 2 * $limit );
+		if ( !empty( $data ) ) {
+			foreach ( $data as $article_id => $row ) {
+				$title = Title::newFromID($article_id);
+				if ( is_object($title) ) {
+					if ( wfMsg("mainpage") != $title->getText() ) {
+						$article = array(
+							'url'	=> $title->getLocalUrl(),
+							'text'	=> $title->getPrefixedText(),
+							'count' => $row['pageviews']
+						);
+						$results[] = $article;
 					}
 				}
+			}
 
-				self::removeAdultPages($results);
+			self::removeAdultPages($results);
 
-				if (!empty($results)) {
-					$results = array_slice($results, 0, $limit);
-				}
+			if (!empty($results)) {
+				$results = array_slice($results, 0, $limit);
 			}
 		}
 


### PR DESCRIPTION
Avoid one of the top misses on memcache.

This data is already cached by `DataMartService` class.

```
> Top memcache misses with no sets (67 rows)
------------------------------------------------------------------------------------------------------------------------
Key                                                                                                  Misses / 1h
------------------------------------------------------------------------------------------------------------------------
*:wgMWrevId                                                                                          4,082,200.00
*:RelatedPages::getCategoryRankByName:*                                                              676,100.00
*:abusefilter:block-autopromote:*                                                                    444,100.00
starter:file:*                                                                                       303,200.00
*:MostVisited:*:*:*                                                                                  271,400.00
```

@michalroszka / @wladekb / @harnash 
