### PR TITLE
OPS-6007: Proper regex in php-cloudfiles

### DIFF
--- a/extensions/SwiftCloudFiles/php-cloudfiles-1.7.10/cloudfiles_http.php
+++ b/extensions/SwiftCloudFiles/php-cloudfiles-1.7.10/cloudfiles_http.php
@@ -1092,7 +1092,7 @@ class CF_Http
     {
         $header_len = strlen($header);
 
-        if (preg_match("/^(HTTP\/1\.[01]) (\d{3}) (.*)/", $header, $matches)) {
+        if (preg_match("/^(HTTP\/1\.[01]) (\d{3})\s?(.*)/", $header, $matches)) {
             $this->response_status = $matches[2];
             $this->response_reason = $matches[3];
             return $header_len;
@@ -1205,7 +1205,7 @@ class CF_Http
 
     private function _auth_hdr_cb($ch, $header)
     {
-        preg_match("/^HTTP\/1\.[01] (\d{3}) (.*)/", $header, $matches);
+        preg_match("/^HTTP\/1\.[01] (\d{3})\s?(.*)/", $header, $matches);
         if (isset($matches[1])) {
             $this->response_status = $matches[1];
         }


### PR DESCRIPTION
Apache answer: `HTTP/1.1 204 No Content\r\n`
Nginx answer: `HTTP/1.1 204\r\n`

Both are fine based on RFC (http://tools.ietf.org/html/rfc7231#section-6)

```
6.  Response Status Codes

   The status-code element is a three-digit integer code giving the
   result of the attempt to understand and satisfy the request.

   HTTP status codes are extensible.  HTTP clients are not required to
   understand the meaning of all registered status codes, though such
   understanding is obviously desirable.  However, a client MUST
   understand the class of any status code, as indicated by the first
   digit, and treat an unrecognized status code as being equivalent to
   the x00 status code of that class, with the exception that a
   recipient MUST NOT cache a response with an unrecognized status code.
```

php-cloudfiles did wrongly assume there must be a space and a message after status code.

/cc @drsnyder 
