### PR TITLE
CONCF-368 Fix encoding of category titles in WikiaMobileCategoryService

### DIFF
--- a/extensions/wikia/WikiaMobile/templates/WikiaMobileCategoryService_alphabeticalList.php
+++ b/extensions/wikia/WikiaMobile/templates/WikiaMobileCategoryService_alphabeticalList.php
@@ -17,7 +17,7 @@
 	$currentBatch = $itemsBatch['currentBatch'];
 	$nextBatch = $currentBatch + 1;
 	$prevBatch = $currentBatch - 1;
-	$urlSafeIndex = urlencode( $index );
+	$urlSafeIndex = rawurlencode( $index );
 	$id = 'catAlpha' . $urlSafeIndex;
 	?>
 	<h2 id="<?= $id ;?>" data-count="<?= $wg->ContLang->formatNum( $itemsBatch['total'] ) ;?>"><?= $index; ?></h2>


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CONCF-368
https://wikia-inc.atlassian.net/browse/CONCF-411

Use `rawurlencode` instead of `urlencode` as we want `%20` and not `%2B`.

http://php.net/manual/en/function.urlencode.php
http://php.net/manual/en/function.rawurlencode.php

/cc @hakubo @bognix @Warkot 
