### PR TITLE
Ce 1550 fix inconsisent user updates

### DIFF
--- a/extensions/wikia/ExactTargetUpdates/hooks/ExactTargetSetup.hooks.php
+++ b/extensions/wikia/ExactTargetUpdates/hooks/ExactTargetSetup.hooks.php
@@ -17,11 +17,13 @@ class ExactTargetSetupHooks {
 	 */
 	public function registerUserHooks() {
 		$oUserHooks = $this->getUserHooks();
+		\Hooks::register( 'AddUserToDatabaseComplete', [ $oUserHooks, 'onCreateNewUserComplete' ] );
+		\Hooks::register( 'CreateNewUserComplete', [ $oUserHooks, 'onCreateNewUserComplete' ] );
+		\Hooks::register( 'ExternalUserAddUserToDatabaseComplete', [ $oUserHooks, 'onCreateNewUserComplete' ] );
 		\Hooks::register( 'ArticleSaveComplete', [ $oUserHooks, 'onArticleSaveComplete' ] );
 		\Hooks::register( 'EditAccountClosed', [ $oUserHooks, 'onEditAccountClosed' ] );
 		\Hooks::register( 'EditAccountEmailChanged', [ $oUserHooks, 'onEditAccountEmailChanged' ] );
 		\Hooks::register( 'EmailChangeConfirmed', [ $oUserHooks, 'onEmailChangeConfirmed' ] );
-		\Hooks::register( 'ExternalUserAddUserToDatabaseComplete', [ $oUserHooks, 'onExternalUserAddUserToDatabaseComplete' ] );
 		\Hooks::register( 'AfterUserAddGlobalGroup', [ $oUserHooks, 'onAfterUserAddGlobalGroup' ] );
 		\Hooks::register( 'AfterUserRemoveGlobalGroup', [ $oUserHooks, 'onAfterUserRemoveGlobalGroup' ] );
 		\Hooks::register( 'UserSaveSettings', [ $oUserHooks, 'onUserSaveSettings' ] );

--- a/extensions/wikia/ExactTargetUpdates/hooks/ExactTargetSetup.hooks.php
+++ b/extensions/wikia/ExactTargetUpdates/hooks/ExactTargetSetup.hooks.php
@@ -21,7 +21,7 @@ class ExactTargetSetupHooks {
 		\Hooks::register( 'EditAccountClosed', [ $oUserHooks, 'onEditAccountClosed' ] );
 		\Hooks::register( 'EditAccountEmailChanged', [ $oUserHooks, 'onEditAccountEmailChanged' ] );
 		\Hooks::register( 'EmailChangeConfirmed', [ $oUserHooks, 'onEmailChangeConfirmed' ] );
-		\Hooks::register( 'SignupConfirmEmailComplete', [ $oUserHooks, 'onSignupConfirmEmailComplete' ] );
+		\Hooks::register( 'ExternalUserAddUserToDatabaseComplete', [ $oUserHooks, 'onExternalUserAddUserToDatabaseComplete' ] );
 		\Hooks::register( 'AfterUserAddGlobalGroup', [ $oUserHooks, 'onAfterUserAddGlobalGroup' ] );
 		\Hooks::register( 'AfterUserRemoveGlobalGroup', [ $oUserHooks, 'onAfterUserRemoveGlobalGroup' ] );
 		\Hooks::register( 'UserSaveSettings', [ $oUserHooks, 'onUserSaveSettings' ] );

--- a/extensions/wikia/ExactTargetUpdates/hooks/ExactTargetUser.hooks.php
+++ b/extensions/wikia/ExactTargetUpdates/hooks/ExactTargetUser.hooks.php
@@ -74,7 +74,7 @@ class ExactTargetUserHooks {
 	 * @param User $oUser
 	 * @return bool
 	 */
-	public function onExternalUserAddUserToDatabaseComplete( \User $oUser ) {
+	public function onCreateNewUserComplete( \User $oUser ) {
 		$this->addTheUpdateCreateUserTask( $oUser );
 		return true;
 	}

--- a/extensions/wikia/ExactTargetUpdates/hooks/ExactTargetUser.hooks.php
+++ b/extensions/wikia/ExactTargetUpdates/hooks/ExactTargetUser.hooks.php
@@ -74,7 +74,7 @@ class ExactTargetUserHooks {
 	 * @param User $oUser
 	 * @return bool
 	 */
-	public function onSignupConfirmEmailComplete( \User $oUser ) {
+	public function onExternalUserAddUserToDatabaseComplete( \User $oUser ) {
 		$this->addTheUpdateCreateUserTask( $oUser );
 		return true;
 	}

--- a/extensions/wikia/ExactTargetUpdates/hooks/ExactTargetUserHooksHelper.php
+++ b/extensions/wikia/ExactTargetUpdates/hooks/ExactTargetUserHooksHelper.php
@@ -15,7 +15,7 @@ class ExactTargetUserHooksHelper {
 			'user_email' => $oUser->getEmail(),
 			'user_email_authenticated' => $oUser->getEmailAuthenticationTimestamp(),
 			'user_registration' => $oUser->getRegistration(),
-			'user_editcount' => $oUser->getEditCount(),
+			'user_editcount' => (int)$oUser->getEditCount(),
 			'user_touched' => $oUser->getTouched()
 		];
 		return $aUserParams;

--- a/includes/User.php
+++ b/includes/User.php
@@ -3200,6 +3200,8 @@ class User {
 			global $wgMemc;
 			$wgMemc->incr( wfSharedMemcKey( "registered-users-number" ) );
 
+			wfRunHooks( 'CreateNewUserComplete', [ &$newUser ] );
+
 		} else {
 			$newUser = null;
 		}
@@ -3231,6 +3233,8 @@ class User {
 			), __METHOD__
 		);
 		$this->mId = $dbw->insertId();
+
+		wfRunHooks( 'AddUserToDatabaseComplete', [ &$this ] );
 
 		// Clear instance cache other than user table data, which is already accurate
 		$this->clearInstanceCache();

--- a/includes/wikia/ExternalUser_Wikia.php
+++ b/includes/wikia/ExternalUser_Wikia.php
@@ -272,6 +272,8 @@ class ExternalUser_Wikia extends ExternalUser {
 			$User->mId = $dbw->insertId();
 			$dbw->commit( __METHOD__ );
 
+			wfRunHooks( 'ExternalUserAddUserToDatabaseComplete', [ &$User ] );
+
 			\Wikia\Logger\WikiaLogger::instance()->info(
 				'HELIOS_REGISTRATION_INSERTS',
 				[ 'exception' => new Exception, 'userid' => $User->mId, 'username' => $User->mName ]


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CE-1550

Found that number of missed user records in ExactTarget database is rising.
It's caused by a bug being fixed in https://wikia-inc.atlassian.net/browse/SOC-603

Decided to change place where we send new user to ExactTarget. Till now it was on user signup email confirm. Now we want to send user data right after it's added to Wikia DB.

It will save us from future traps of users being added and activated beyond user signup email confirm.

Spotted three places where insert operation on user DB happens
\User::addToDatabase
\User::createNew
\ExternalUser_Wikia::addToDatabase

covered all.

@Wikia/community-engineering, @michalroszka , @kvas-damian 
