### PR TITLE
SOC-603 | Store filtered mOptions in user memcache object

### DIFF
--- a/includes/User.php
+++ b/includes/User.php
@@ -331,7 +331,6 @@ class User {
 			}
 			# /Wikia
 		}
-
 		if ( !$data || $isExpired ) { # Wikia
 			wfDebug( "User: cache miss for user {$this->mId}\n" );
 			# Load from DB
@@ -363,6 +362,15 @@ class User {
 			// Anonymous users are uncached
 			return;
 		}
+
+		// prepare mOptionOverrides for caching
+		$this->mOptionOverrides = [];
+		foreach ( $this->mOptions as $optionKey => $optionValue ) {
+			if ( $this->shouldOptionBeStored( $optionKey, $optionValue ) ) {
+				$this->mOptionOverrides[$optionKey] = $optionValue;
+			}
+		}
+
 		$data = array();
 		foreach ( self::$mCacheVars as $name ) {
 			$data[$name] = $this->$name;
@@ -3061,7 +3069,6 @@ class User {
 	 */
 	public function saveSettings() {
 		global $wgAuth;
-
 		$this->load();
 		if ( wfReadOnly() ) { return; }
 		if ( 0 == $this->mId ) { return; }
@@ -4364,7 +4371,6 @@ class User {
 			return;
 
 		$this->mOptions = self::getDefaultOptions();
-
 		// Maybe load from the object
 		if ( !is_null( $this->mOptionOverrides ) ) {
 			wfDebug( "User: loading options for user " . $this->getId() . " from override cache.\n" );
@@ -4435,21 +4441,10 @@ class User {
 		foreach( $saveOptions as $key => $value ) {
 			# Don't bother storing default values
 			# <Wikia>
-			if ( is_array( $wgGlobalUserProperties ) && in_array( $key, $wgGlobalUserProperties ) ) {
+			if ( $this->shouldOptionBeStored( $key, $value ) ) {
 				$insert_rows[] = array( 'up_user' => $this->getId(), 'up_property' => $key, 'up_value' => $value );
 			}
 			# </Wikia>
-			else {
-				if ( ( is_null( self::getDefaultOption( $key ) ) &&
-						!( $value === false || is_null($value) ) ) ||
-						$value != self::getDefaultOption( $key ) ) {
-					$insert_rows[] = array(
-							'up_user' => $this->getId(),
-							'up_property' => $key,
-							'up_value' => $value,
-						);
-				}
-			}
 			if ( $extuser && isset( $wgAllowPrefChange[$key] ) ) {
 				switch ( $wgAllowPrefChange[$key] ) {
 					case 'local':
@@ -4468,6 +4463,25 @@ class User {
 		if ( $extuser ) {
 			$extuser->updateUser();
 		}
+	}
+
+	/**
+	 * @desc Check if user option should be stored in DataBase.
+	 * We don't want to store default values in order to easily change them in future.
+	 * @param $key
+	 * @param $value
+	 * @return bool
+	 */
+	private function shouldOptionBeStored( $key, $value ) {
+		global $wgGlobalUserProperties;
+		if (
+			( is_array( $wgGlobalUserProperties ) && in_array( $key, $wgGlobalUserProperties ) ) ||
+			( is_null( self::getDefaultOption( $key ) ) && !( $value === false || is_null($value) ) ) ||
+			$value != self::getDefaultOption( $key )
+		) {
+			return true;
+		}
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SOC-603

Fix for user account creation.
During account creation `mOptions` are saved to database, but not to memcache. When sending confirmation email new user object is created based on data stored in memcache: https://github.com/Wikia/app/blob/dev/extensions/wikia/UserLogin/UserLoginHelper.class.php#L240
and when saving changes on `User` object `mOptions` are overwritten by empty array in DB.

This finally allows user to login without email confirmation because there is no flag that is required for this check.

It's connected with better memcache caching for `User` merged last week: https://github.com/Wikia/app/commit/5bfcdf701acc7c527c731cef2b5de8e936b2db92

Ping @wladekb @michalroszka 
