### PR TITLE
window-crop negative offsets

### DIFF
--- a/extensions/wikia/ImageServing/imageServing.class.php
+++ b/extensions/wikia/ImageServing/imageServing.class.php
@@ -313,14 +313,21 @@ class ImageServing {
 	private function getVignetteUrl(URLGeneratorInterface $image, $width, $height) {
 		list($top, $right, $bottom, $left) = $this->getCutParams($width, $height);
 
-		return $image->getUrlGenerator()
-			->windowCrop()
-			->width($this->width)
-			->xOffset($left)
-			->yOffset($top)
-			->windowWidth($right - $left)
-			->windowHeight($bottom - $top)
-			->url();
+		$generator = $image->getUrlGenerator()
+			->width($this->width);
+
+		if ($top < 0 || $bottom < 0 || $right < 0 || $left < 0) {
+			$generator->scaleToWidth();
+		} else {
+			$generator
+				->windowCrop()
+				->xOffset($left)
+				->yOffset($top)
+				->windowWidth($right - $left)
+				->windowHeight($bottom - $top);
+		}
+
+		return $generator->url();
 	}
 
 	/**
@@ -360,7 +367,13 @@ class ImageServing {
 	 */
 	public function getCut( $width, $height, $align = "center", $issvg = false  ) {
 		list($top, $right, $bottom, $left) = $this->getCutParams($width, $height, $align, $issvg);
-		return "{$this->width}px-$left,$right,$top,$bottom";
+		$cut = "{$this->width}px";
+
+		if ($left >= 0 && $right >= 0 && $top >= 0 && $bottom >= 0) {
+			$cut .= "-$left,$right,$top,$bottom";
+		}
+
+		return $cut;
 	}
 
 	private function getCutParams($width, $height, $align="center", $issvg=false) {

--- a/extensions/wikia/ImageServing/imageServing.class.php
+++ b/extensions/wikia/ImageServing/imageServing.class.php
@@ -316,6 +316,10 @@ class ImageServing {
 		$generator = $image->getUrlGenerator()
 			->width($this->width);
 
+		/**
+		 * negative offsets are ignored in the legacy thumbnailer. Vignette respects these, so explicitly set
+		 * the mode to scale-to-width to maintain consistency with the legacy thumbnailer
+		 */
 		if ($top < 0 || $bottom < 0 || $right < 0 || $left < 0) {
 			$generator->scaleToWidth();
 		} else {


### PR DESCRIPTION
@drsnyder 
https://wikia-inc.atlassian.net/browse/PLATFORM-1018

The legacy thumbnailer ignored negative values for `x-offset` and `y-offset`, turning the mode into `scale-to-width`. Since Vignette supports negative offsets, this changes `ImageServing` to explicitly request `scale-to-width` when a negative value is calculated.
