### PR TITLE
(CE-1420) Fix fatal error due incorrect case of class name in SMW

### DIFF
--- a/extensions/wikia/SemanticMediaWiki/includes/queryprinters/SMW_QP_JSONlink.php
+++ b/extensions/wikia/SemanticMediaWiki/includes/queryprinters/SMW_QP_JSONlink.php
@@ -352,6 +352,6 @@ class SMWJSON {
 	 * @return string
 	*/
 	public function getEncoding( $syntax = '' , $isPretty = false ){
-		return FormatJSON::encode( $syntax === 'basic' ? $this->getBasicSerialization() : $this->getSerialization(), $isPretty );
+		return FormatJson::encode( $syntax === 'basic' ? $this->getBasicSerialization() : $this->getSerialization(), $isPretty );
 	}
 }


### PR DESCRIPTION
We switched MediaWiki's autoloader to be case sensitive a while ago.
In one instance, SemanticMediaWiki was using incorrect capitalisation
for the FormatJson class. Fixes the following fatal error:

```
PHP Fatal error: Class 'FormatJSON' not found in /extensions/wikia/
SemanticMediaWiki/includes/queryprinters/SMW_QP_JSONlink.php on line 355
```

/cc @Wikia/community-engineering 
