### PR TITLE
(CE-1563) Backport patch for API vulnerability when running HHVM

### DIFF
--- a/includes/api/ApiFormatWddx.php
+++ b/includes/api/ApiFormatWddx.php
@@ -39,13 +39,7 @@ class ApiFormatWddx extends ApiFormatBase {
 	}
 
 	public function execute() {
-		// Some versions of PHP have a broken wddx_serialize_value, see
-		// PHP bug 45314. Test encoding an affected character (U+00A0)
-		// to avoid this.
-		$expected = "<wddxPacket version='1.0'><header/><data><string>\xc2\xa0</string></data></wddxPacket>";
-		if ( function_exists( 'wddx_serialize_value' )
-				&& !$this->getIsHtml()
-				&& wddx_serialize_value( "\xc2\xa0" ) == $expected ) {
+		if ( !$this->getIsHtml() && !static::useSlowPrinter() ) {
 			$this->printText( wddx_serialize_value( $this->getResultData() ) );
 		} else {
 			// Don't do newlines and indentation if we weren't asked
@@ -60,6 +54,44 @@ class ApiFormatWddx extends ApiFormatBase {
 			$this->printText( "$indstr</data>$nl" );
 			$this->printText( "</wddxPacket>$nl" );
 		}
+	}
+
+	public static function useSlowPrinter() {
+		if ( !function_exists( 'wddx_serialize_value' ) ) {
+			return true;
+		}
+
+		// Some versions of PHP have a broken wddx_serialize_value, see
+		// PHP bug 45314. Test encoding an affected character (U+00A0)
+		// to avoid this.
+		$expected =
+			"<wddxPacket version='1.0'><header/><data><string>\xc2\xa0</string></data></wddxPacket>";
+		if ( wddx_serialize_value( "\xc2\xa0" ) !== $expected ) {
+			return true;
+		}
+
+		// Some versions of HHVM don't correctly encode ampersands.
+		$expected =
+			"<wddxPacket version='1.0'><header/><data><string>&amp;</string></data></wddxPacket>";
+		if ( wddx_serialize_value( '&' ) !== $expected ) {
+			return true;
+		}
+
+		// Some versions of HHVM don't correctly encode empty arrays as subvalues.
+		$expected =
+			"<wddxPacket version='1.0'><header/><data><array length='1'><array length='0'></array></array></data></wddxPacket>";
+		if ( wddx_serialize_value( array( array() ) ) !== $expected ) {
+			return true;
+		}
+
+		// Some versions of HHVM don't correctly encode associative arrays with numeric keys.
+		$expected =
+			"<wddxPacket version='1.0'><header/><data><struct><var name='2'><number>1</number></var></struct></data></wddxPacket>";
+		if ( wddx_serialize_value( array( 2 => 1 ) ) !== $expected ) {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
The MW 1.24.2 security release included a fix for a vulnerability in
the MW API when running on HHVM:
https://phabricator.wikimedia.org/T85851

It wasn't backported as MediaWiki before 1.24 didn't officially support
HHVM. As we are testing HHVM, just in case we ever run the app on HHVM
on production, probably better to just backport it so we don't forget.

/cc @owend 
