### PR TITLE
Platform 1116 - adding Mercury App support for Universal Analytics

### DIFF
--- a/extensions/wikia/MercuryApi/models/MercuryApi.class.php
+++ b/extensions/wikia/MercuryApi/models/MercuryApi.class.php
@@ -128,7 +128,7 @@ class MercuryApi {
 			'theme' => SassUtil::getOasisSettings(),
 			'wikiCategories' => WikiFactoryHub::getInstance()->getWikiCategoryNames( $wgCityId ),
 			'analytics' => [
-				'UAEnabled' => !empty( $wgAnalyticsProviderUseUA ) ? $wgAnalyticsProviderUseUA : false,
+				'UAEnabled' => !empty( $wgAnalyticsProviderUseUA ),
 			],
 		];
 	}

--- a/extensions/wikia/MercuryApi/models/MercuryApi.class.php
+++ b/extensions/wikia/MercuryApi/models/MercuryApi.class.php
@@ -128,7 +128,7 @@ class MercuryApi {
 			'theme' => SassUtil::getOasisSettings(),
 			'wikiCategories' => WikiFactoryHub::getInstance()->getWikiCategoryNames( $wgCityId ),
 			'analytics' => [
-				'UAEnabled' => $wgAnalyticsProviderUseUA,
+				'UAEnabled' => !empty( $wgAnalyticsProviderUseUA ) ? $wgAnalyticsProviderUseUA : false,
 			],
 		];
 	}

--- a/extensions/wikia/MercuryApi/models/MercuryApi.class.php
+++ b/extensions/wikia/MercuryApi/models/MercuryApi.class.php
@@ -108,7 +108,8 @@ class MercuryApi {
 	public function getWikiVariables() {
 		global $wgSitename, $wgCacheBuster, $wgDBname, $wgDefaultSkin,
 			   $wgLang, $wgLanguageCode, $wgContLang, $wgCityId,
-			   $wgAnalyticsProviderUseUA, $wgStagingEnvironment;
+			   $wgAnalyticsProviderUseUA;
+
 		return [
 			'cacheBuster' => (int) $wgCacheBuster,
 			'dbName' => $wgDBname,

--- a/extensions/wikia/MercuryApi/models/MercuryApi.class.php
+++ b/extensions/wikia/MercuryApi/models/MercuryApi.class.php
@@ -107,7 +107,8 @@ class MercuryApi {
 	 */
 	public function getWikiVariables() {
 		global $wgSitename, $wgCacheBuster, $wgDBname, $wgDefaultSkin,
-			   $wgLang, $wgLanguageCode, $wgContLang, $wgCityId;
+			   $wgLang, $wgLanguageCode, $wgContLang, $wgCityId,
+			   $wgAnalyticsProviderUseUA, $wgStagingEnvironment;
 		return [
 			'cacheBuster' => (int) $wgCacheBuster,
 			'dbName' => $wgDBname,
@@ -125,6 +126,9 @@ class MercuryApi {
 			'mainPageTitle' => Title::newMainPage()->getPrefixedDBkey(),
 			'theme' => SassUtil::getOasisSettings(),
 			'wikiCategories' => WikiFactoryHub::getInstance()->getWikiCategoryNames( $wgCityId ),
+			'analytics' => [
+				'UAEnabled' => $wgAnalyticsProviderUseUA,
+			],
 		];
 	}
 


### PR DESCRIPTION
Since Mercury has no simple way to query WikiFactory variables
for a specific wiki, new parameter is being sent with WikiVariables
response to allow enabling UA per wiki. It is temporary solution and
should be removed in next migration phases.
