### PR TITLE
PLATFORM-1099: Fix broken call to Wikia::log()

### DIFF
--- a/extensions/wikia/CreatePage/monobook/SpecialCreatePage.class.php
+++ b/extensions/wikia/CreatePage/monobook/SpecialCreatePage.class.php
@@ -165,7 +165,7 @@ class SpecialCreatePage extends SpecialEditPage {
 				$wgOut->redirect( $this->mPostArticle->getTitle()->getFullUrl() );
 				break;
 			default:
-				Wikia::log( __METHOD__, "createpage", $status );
+				Wikia::log( __METHOD__, "createpage", $status->getMessage() );
 				if ( ( $status == EditPage::AS_READ_ONLY_PAGE_LOGGED ) || ( $status == EditPage::AS_READ_ONLY_PAGE_ANON ) ) {
 					$sMsg = wfMsg( 'createpage_cant_edit' );
 				}


### PR DESCRIPTION
Status object cannot be converted to string implicitly. Feed the textual version of Status to Wikia::log().

https://wikia-inc.atlassian.net/browse/PLATFORM-1099

/cc @macbre 
