### PR TITLE
Assure edit button and edit link are always in the same line

### DIFF
--- a/extensions/wikia/NjordPrototype/css/Njord.scss
+++ b/extensions/wikia/NjordPrototype/css/Njord.scss
@@ -463,6 +463,8 @@ header.MainPageHeroHeader {
 		padding-left: 6px;
 		position: relative;
 		top: -3px;
+		//pencil icon and "edit" text should be always in the same line
+		white-space: nowrap;
 	}
 
 		&.edit-state {


### PR DESCRIPTION
Paweł Piekarski asked me to fix the issue with "edit button and edit link being in different lines" when Njord extension is enabled.
Sample page: http://pokemon.wikia.com

ping @idradm @RafLeszczynski 
