### PR TITLE
PLATFORM-528 wfDevBox force wiki improved

### DIFF
--- a/extensions/wikia/Development/SpecialDevBoxPanel/Special_DevBoxPanel.php
+++ b/extensions/wikia/Development/SpecialDevBoxPanel/Special_DevBoxPanel.php
@@ -197,11 +197,6 @@ function wfDevBoxForceWiki(WikiFactoryLoader $wikiFactoryLoader){
 				die( "No local copy of database [$dbname] was found on {$cluster} cluster [using {$db->getServer()} DB]." );
 			}
 		}
-
-		// TODO: move this into the config file
-		global $wgReadOnly;
-		$wgReadOnly = false;
-
 	}
 	return true;
 } // end wfDevBoxForceWiki()

--- a/extensions/wikia/Development/SpecialDevBoxPanel/Special_DevBoxPanel.php
+++ b/extensions/wikia/Development/SpecialDevBoxPanel/Special_DevBoxPanel.php
@@ -151,7 +151,7 @@ function wfDevBoxForceWiki(WikiFactoryLoader $wikiFactoryLoader){
 				/**
 				 * find city_id by database name
 				 */
-				$dbr = wfGetDB( DB_SLAVE, "dump", $wgWikiFactoryDB );
+				$dbr = WikiFactory::db( DB_SLAVE );
 				$cityId = $dbr->selectField(
 					"city_list",
 					array( "city_id" ),


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-528
- check the existence of database using the master for a cluster where the database should be (instead of getting the list of 1k databases using `SHOW DATABASES`)
- set `X-Error: missing database` response header when the database can't be found on the devbox
- code cleanup

@michalroszka / @wladekb / @owend 
