### PR TITLE
CONCF-119 fixes and one background color for all modules

### DIFF
--- a/extensions/wikia/Rail/styles/RailElement.scss
+++ b/extensions/wikia/Rail/styles/RailElement.scss
@@ -42,10 +42,10 @@ $color-rail-background: mix($color-page, $black, 90%);
         font-weight: bold;
 
         a {
-            color: $color-links-default;
+            color: $color-links;
 
             &:hover {
-                color: $color-links-default;
+                color: $color-links;
                 text-decoration: underline;
                 text-shadow: initial;
             }
@@ -232,51 +232,51 @@ $color-rail-background: mix($color-page, $black, 90%);
 
                 .carousel-container {
                     left: 16px;
-                    width: 260px;
+                    width: 220px;
                 }
 
                 .since, .chatter {
-                    width: 32px;
-                }
-
-                .UserStatsMenu {
-                    outline: rgba($color-divider, .3) solid 2px;
-                    width: 220px;
-
-                    .actions ul {
-                        margin: 0;
-
-                        li {
-                            border-bottom: $color-divider solid thin;
-                            cursor: pointer;
-                            height: 44px;
-                            margin: 0;
-                            white-space: nowrap;
-
-                            .label {
-                                color: mix($color-text, $color-links, 80%);
-                                line-height: 44px;
-                                padding-left: 10px;
-                            }
-
-                            &:hover {
-                                background-color: $color-buttons;
-                            }
-                        }
-                    }
-
-                    .info {
-                        background: $color-menu-highlight;
-                        padding: 10px;
-
-                        ul .username {
-                            font-weight: bold;
-                            margin-bottom: 10px;
-                            text-transform: uppercase;
-                        }
-                    }
+                    width: 30px;
                 }
             }
+        }
+    }
+}
+
+.UserStatsMenu .new-chat {
+    outline: rgba($color-divider, .3) solid 2px;
+    width: 220px;
+
+    .actions ul {
+        margin: 0;
+
+        li {
+            border-bottom: $color-divider solid thin;
+            cursor: pointer;
+            height: 24px;
+            margin: 0;
+            white-space: nowrap;
+
+            .label {
+                color: mix($color-text, $color-links, 80%);
+                line-height: 44px;
+                padding-left: 10px;
+            }
+
+            &:hover {
+                background-color: $color-buttons;
+            }
+        }
+    }
+
+    .info {
+        background: $color-menu-highlight;
+        padding: 10px;
+
+        ul .username {
+            font-weight: bold;
+            margin-bottom: 10px;
+            text-transform: uppercase;
         }
     }
 }

--- a/extensions/wikia/Rail/styles/RailElement.scss
+++ b/extensions/wikia/Rail/styles/RailElement.scss
@@ -3,10 +3,6 @@
 $black: #000;
 $white: #FFF;
 $color-divider: mix($color-page, $color-text, 80%);
-$color-rail-background: mix($color-page, $black, 90%);
-@if $is-dark-wiki {
-    $color-rail-background: mix($color-page, $white, 90%);
-}
 
 @mixin standard-primary-button() {
     background-image: none;

--- a/extensions/wikia/Rail/styles/RailElement.scss
+++ b/extensions/wikia/Rail/styles/RailElement.scss
@@ -17,7 +17,7 @@ $color-divider: mix($color-page, $color-text, 80%);
 }
 
 @mixin wikia-rail-element() {
-    background-color: $color-new-module-background;
+    background-color: $color-unified-module-background;
     margin-bottom: 10px;
     padding: 20px;
 }
@@ -185,7 +185,7 @@ $color-divider: mix($color-page, $color-text, 80%);
             }
 
             .chat-total {
-                background-color: $color-new-module-background;
+                background-color: $color-unified-module-background;
                 border: 1px solid;
                 border-radius: 50%;
                 font-size: 10px;

--- a/extensions/wikia/Rail/styles/RailElement.scss
+++ b/extensions/wikia/Rail/styles/RailElement.scss
@@ -1,4 +1,4 @@
-@import "skins/shared/color";
+@import 'skins/shared/color';
 
 $black: #000;
 $white: #FFF;
@@ -17,7 +17,7 @@ $color-divider: mix($color-page, $color-text, 80%);
 }
 
 @mixin wikia-rail-element() {
-    background-color: $color-rail-background;
+    background-color: $color-new-module-background;
     margin-bottom: 10px;
     padding: 20px;
 }
@@ -85,7 +85,7 @@ $color-divider: mix($color-page, $color-text, 80%);
 
             //Activity Feed
             &.edit {
-                background-image: url(/skins/shared/images/editpen.svg);
+                background-image: url('/skins/shared/images/editpen.svg');
                 height: 20px;
                 left: 5px;
                 opacity: .6;
@@ -94,7 +94,7 @@ $color-divider: mix($color-page, $color-text, 80%);
             }
 
             &.new {
-                background-image: url(/skins/shared/images/new_article_icon.svg);
+                background-image: url('/skins/shared/images/new_article_icon.svg');
                 height: 27px;
                 left: 0;
                 opacity: .8;
@@ -185,7 +185,7 @@ $color-divider: mix($color-page, $color-text, 80%);
             }
 
             .chat-total {
-                background-color: $color-rail-background;
+                background-color: $color-new-module-background;
                 border: 1px solid;
                 border-radius: 50%;
                 font-size: 10px;

--- a/extensions/wikia/Rail/styles/RailElement.scss
+++ b/extensions/wikia/Rail/styles/RailElement.scss
@@ -85,7 +85,7 @@ $color-divider: mix($color-page, $color-text, 80%);
 
             //Activity Feed
             &.edit {
-                background-image: url('/skins/shared/images/editpen.svg');
+                background-image: url('/skins/shared/images/editpen.svg'); /* inline */
                 height: 20px;
                 left: 5px;
                 opacity: .6;
@@ -94,7 +94,7 @@ $color-divider: mix($color-page, $color-text, 80%);
             }
 
             &.new {
-                background-image: url('/skins/shared/images/new_article_icon.svg');
+                background-image: url('/skins/shared/images/new_article_icon.svg'); /* inline */
                 height: 27px;
                 left: 0;
                 opacity: .8;

--- a/extensions/wikia/Rail/styles/RailElement.scss
+++ b/extensions/wikia/Rail/styles/RailElement.scss
@@ -144,6 +144,7 @@ $color-divider: mix($color-page, $color-text, 80%);
         }
     }
 
+    // TODO: remove when chat will be ready to be pushed to prod together with other rail changes
     &.new-chat {
         .ChatModule {
             @include wikia-rail-element;
@@ -239,6 +240,7 @@ $color-divider: mix($color-page, $color-text, 80%);
     }
 }
 
+// TODO: remove new-chat when chat will be ready to be pushed to prod together with other rail changes
 .UserStatsMenu .new-chat {
     outline: rgba($color-divider, .3) solid 2px;
     width: 220px;
@@ -268,7 +270,9 @@ $color-divider: mix($color-page, $color-text, 80%);
     .info {
         background: $color-menu-highlight;
         padding: 10px;
-
+        
+        // TODO: remove unnecessary nesting when chat will be ready to be 
+        // pushed to prod together with other rail changes
         ul .username {
             font-weight: bold;
             margin-bottom: 10px;

--- a/skins/shared/color.scss
+++ b/skins/shared/color.scss
@@ -201,3 +201,9 @@ $color-vertical-tv-secondary: #008cce;
 // Venus article
 $color-article-navigation-inactive: if($is-dark-wiki, mix(#fff, $color-page, 30%), mix(#000, $color-page, 30%));
 $image-caption-border-color: if($is-dark-wiki, darken($color-text, 30%), lighten($color-text, 30%));
+
+//New site modernizations module background
+$color-new-module-background: mix($color-page, black, 90%);
+@if $is-dark-wiki {
+	$color-new-module-background: mix($color-page, white, 90%);
+}

--- a/skins/shared/color.scss
+++ b/skins/shared/color.scss
@@ -202,8 +202,8 @@ $color-vertical-tv-secondary: #008cce;
 $color-article-navigation-inactive: if($is-dark-wiki, mix(#fff, $color-page, 30%), mix(#000, $color-page, 30%));
 $image-caption-border-color: if($is-dark-wiki, darken($color-text, 30%), lighten($color-text, 30%));
 
-//New site modernizations module background
-$color-new-module-background: mix($color-page, black, 90%);
+//Site modernizations (ticket CONCF-119) module background
+$color-unified-module-background: mix($color-page, black, 90%);
 @if $is-dark-wiki {
-	$color-new-module-background: mix($color-page, white, 90%);
+	$color-unified-module-background: mix($color-page, white, 90%);
 }


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CONCF-119

When code appeared on production I had an occasion to test how does the chat behave. I've made some  CSS fixes and moved right rail background color to shared/color.scss as it will be used in all restyled modules. 

@bognix @Warkot 
