### PR TITLE
CONCF-433 disable brakpoints on german wikis and show skyscrapers for breakpoints

### DIFF
--- a/extensions/wikia/AdEngine/js/SevenOneMediaHelper.js
+++ b/extensions/wikia/AdEngine/js/SevenOneMediaHelper.js
@@ -65,8 +65,8 @@ define('ext.wikia.adEngine.sevenOneMediaHelper', [
 		},
 		slotsQueue = [];
 
-	if (!window.wgOasisResponsive) {
-		// turn off skyscrapers if it's not responsive Oasis view i.e. hubs pages (ADEN-1792)
+	if (!window.wgOasisBreakpoints && !window.wgOasisResponsive) {
+		// turn off skyscrapers if it's not responsive Oasis or Oasis breakpoints view i.e. hubs pages (ADEN-1792)
 		slotVars.skyscraper1.SOI_SC1 = false;
 		slotVars.skyscraper1.SOI_SB = false;
 	}

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1681,6 +1681,13 @@ $wgOasisTypography = false;
 $wgOasisBreakpoints = false;
 
 /**
+ * Force new breakpoints $wgOasisBreakpoints for German wikis
+ * see CONCF-433
+ * todo remove when 71M adjusts their styles
+ */
+$wgOasisBreakpointsDE = false;
+
+/**
  * Add poweruser to implicit groups
  */
 $wgImplicitGroups[] = 'poweruser';

--- a/skins/oasis/modules/BodyController.class.php
+++ b/skins/oasis/modules/BodyController.class.php
@@ -83,6 +83,7 @@ class BodyController extends WikiaController {
 		global $wgOasisBreakpoints, $wgRequest, $wgLanguageCode, $wgOasisBreakpointsDE;
 
 		//For now we want to disable breakpoints for German wikis if not turn on explicitly.
+		//@TODO remove when 71Media fixes their styles and $wgOasisBreakpointsDE will retire
 		if ( strtolower( $wgLanguageCode ) == 'de' && empty( $wgOasisBreakpointsDE ) ) {
 			$wgOasisBreakpoints = false;
 		}

--- a/skins/oasis/modules/BodyController.class.php
+++ b/skins/oasis/modules/BodyController.class.php
@@ -80,7 +80,12 @@ class BodyController extends WikiaController {
 	 * @return Boolean
 	 */
 	public static function isOasisBreakpoints() {
-		global $wgOasisBreakpoints, $wgRequest;
+		global $wgOasisBreakpoints, $wgRequest, $wgLanguageCode, $wgOasisBreakpointsDE;
+
+		//For now we want to disable breakpoints for German wikis if not turn on explicitly.
+		if ( strtolower( $wgLanguageCode ) == 'de' && empty( $wgOasisBreakpointsDE ) ) {
+			$wgOasisBreakpoints = false;
+		}
 
 		$wgOasisBreakpoints = $wgRequest->getBool( 'oasisbreakpoints', $wgOasisBreakpoints ) !== false;
 		return !empty( $wgOasisBreakpoints );


### PR DESCRIPTION
1. Add $wgOasisBreakpointsDE variable which has to be set to true in order to enable breakpoints on German wikis.
2. Enable Skyscrapers in Ad code for OasisBreakpoints

ping @vforge @nandy-andy 
