### PR TITLE
CE-1543 Fix editcount ET updates

### DIFF
--- a/extensions/wikia/ExactTargetUpdates/api/ExactTargetApiHelper.php
+++ b/extensions/wikia/ExactTargetUpdates/api/ExactTargetApiHelper.php
@@ -37,7 +37,7 @@ class ExactTargetApiHelper {
 	 */
 	public function prepareSoapVars( $aObjects, $sObjectType = 'DataExtensionObject' ) {
 		$aSoapVars = [];
-		foreach( $aObjects as $object ) {
+		foreach ( $aObjects as $object ) {
 			$aSoapVars[] = $this->wrapToSoapVar( $object, $sObjectType );
 		}
 		return $aSoapVars;
@@ -160,13 +160,13 @@ class ExactTargetApiHelper {
 	public function prepareDataExtensionObjects( $aObjectsParams ) {
 		$aDE = [];
 
-		foreach( $aObjectsParams as $aObjectParams ) {
+		foreach ( $aObjectsParams as $aObjectParams ) {
 			$oDE = new \ExactTarget_DataExtensionObject();
 			$oDE->CustomerKey = $aObjectParams[ 'CustomerKey' ];
 
 			if( isset( $aObjectParams[ 'Properties' ] ) ) {
 				$aApiProperties = [];
-				foreach( $aObjectParams[ 'Properties' ] as $sKey => $sValue ) {
+				foreach ( $aObjectParams[ 'Properties' ] as $sKey => $sValue ) {
 					$aApiProperties[] = $this->wrapApiProperty( $sKey, $sValue );
 				}
 				$oDE->Properties = $aApiProperties;
@@ -174,7 +174,7 @@ class ExactTargetApiHelper {
 
 			if( isset( $aObjectParams[ 'Keys' ] ) ) {
 				$aApiKeys = [];
-				foreach( $aObjectParams[ 'Keys' ] as $sKey => $sValue ) {
+				foreach ( $aObjectParams[ 'Keys' ] as $sKey => $sValue ) {
 					$aApiKeys[] = $this->wrapApiProperty( $sKey, $sValue );
 				}
 				$oDE->Keys = $aApiKeys;

--- a/extensions/wikia/ExactTargetUpdates/hooks/ExactTargetSetup.hooks.php
+++ b/extensions/wikia/ExactTargetUpdates/hooks/ExactTargetSetup.hooks.php
@@ -20,7 +20,6 @@ class ExactTargetSetupHooks {
 		\Hooks::register( 'AddUserToDatabaseComplete', [ $oUserHooks, 'onCreateNewUserComplete' ] );
 		\Hooks::register( 'CreateNewUserComplete', [ $oUserHooks, 'onCreateNewUserComplete' ] );
 		\Hooks::register( 'ExternalUserAddUserToDatabaseComplete', [ $oUserHooks, 'onCreateNewUserComplete' ] );
-		\Hooks::register( 'ArticleSaveComplete', [ $oUserHooks, 'onArticleSaveComplete' ] );
 		\Hooks::register( 'EditAccountClosed', [ $oUserHooks, 'onEditAccountClosed' ] );
 		\Hooks::register( 'EditAccountEmailChanged', [ $oUserHooks, 'onEditAccountEmailChanged' ] );
 		\Hooks::register( 'EmailChangeConfirmed', [ $oUserHooks, 'onEmailChangeConfirmed' ] );

--- a/extensions/wikia/ExactTargetUpdates/hooks/ExactTargetUser.hooks.php
+++ b/extensions/wikia/ExactTargetUpdates/hooks/ExactTargetUser.hooks.php
@@ -18,20 +18,6 @@ class ExactTargetUserHooks {
 	}
 
 	/**
-	 * Adds Task for updating user editcount to job queue.
-	 * Updates whole user record
-	 * @param WikiPage $article
-	 * @param User $user
-	 * @return bool
-	 */
-	public function onArticleSaveComplete( \WikiPage $article, \User $oUser ) {
-		if ( !$oUser->isAnon() ) {
-			$this->addTheUpdateCreateUserTask( $oUser );
-		}
-		return true;
-	}
-
-	/**
 	 * Adds Task for removing user to job queue
 	 * @param User $oUser
 	 * @return bool

--- a/extensions/wikia/ExactTargetUpdates/maintenance/ExactTargetUpdateUserGlobalEditCountMaintenance.php
+++ b/extensions/wikia/ExactTargetUpdates/maintenance/ExactTargetUpdateUserGlobalEditCountMaintenance.php
@@ -39,7 +39,6 @@ class ExactTargetUpdateUserGlobalEditCountMaintenance extends Maintenance {
 	 * Fetches user ids from statsDB from last period determined by prepareTimeCondition function
 	 * @param DatabaseBase $oStatsDBr
 	 * @param string $sStartDate e.g. 2014-12-31
-	 * @param boolean|ResultWrapper $oUsersListResult
 	 * @return array of user ids
 	 */
 	private function getListOfUsersIdsEdited( DatabaseBase $oStatsDBr, $sStartDate ) {
@@ -54,7 +53,7 @@ class ExactTargetUpdateUserGlobalEditCountMaintenance extends Maintenance {
 
 		$aUsersIdsDidEdit = $oWikiaSQL->runLoop( $oStatsDBr, function( &$aUsersIdsDidEdit, $oUsersIdsDidEdit ) {
 			$aUsersIdsDidEdit[] = $oUsersIdsDidEdit->user_id;
-		});
+		} );
 		return $aUsersIdsDidEdit;
 	}
 
@@ -90,8 +89,8 @@ class ExactTargetUpdateUserGlobalEditCountMaintenance extends Maintenance {
 
 	private function getLastDayDate() {
 		$oNow = new DateTime();
-		$oNow->sub(new DateInterval('P1D'));
-		$sStartDate = $oNow->format('Y-m-d H:i:s');
+		$oNow->sub( new DateInterval( 'P1D' ) );
+		$sStartDate = $oNow->format( 'Y-m-d H:i:s' );
 		return $sStartDate;
 	}
 

--- a/extensions/wikia/ExactTargetUpdates/maintenance/ExactTargetUpdateUserGlobalEditCountMaintenance.php
+++ b/extensions/wikia/ExactTargetUpdates/maintenance/ExactTargetUpdateUserGlobalEditCountMaintenance.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Maintenance script for updating user data in ExactTarget database of users that edited last day
+ *
+ * @package MediaWiki
+ * @addtopackage maintenance
+ *
+ * @author Kamil Koterba <kamil@wikia-inc.com>
+ *
+ */
+
+require_once( __DIR__.'/../../../../maintenance/Maintenance.php' );
+
+use Wikia\ExactTarget\ExactTargetUserHooksHelper;
+use Wikia\ExactTarget\ExactTargetApiDataExtension;
+use Wikia\ExactTarget\ExactTargetUpdateUserTask;
+
+class ExactTargetUpdateUserGlobalEditCountMaintenance extends Maintenance {
+
+	/**
+	 * Maintenance script entry point.
+	 * Gathering users' ids who edited last day and adding update task to job queue.
+	 */
+	public function execute() {
+		global $wgDWStatsDB;
+		// Get DB
+		$oStatsDBr = wfGetDB( DB_SLAVE, [], $wgDWStatsDB );
+		// Get timestamp param
+		$sStartDate = $this->getLastDayDate();
+		// Get user ids
+		$aUsersIds = $this->getListOfUsersIdsEdited( $oStatsDBr, $sStartDate );
+		// Prepare user data required for update
+		$aUsersData = $this->prepareUsersParams( $aUsersIds );
+		// Add update tasks
+		$this->addUsersUpdateTasks( $aUsersData );
+	}
+
+	/**
+	 * Fetches user ids from statsDB from last period determined by prepareTimeCondition function
+	 * @param DatabaseBase $oStatsDBr
+	 * @param string $sStartDate e.g. 2014-12-31
+	 * @param boolean|ResultWrapper $oUsersListResult
+	 * @return array of user ids
+	 */
+	private function getListOfUsersIdsEdited( DatabaseBase $oStatsDBr, $sStartDate ) {
+		// Get user edits
+		$oWikiaSQL = new WikiaSQL();
+		$oWikiaSQL->SELECT()
+			->DISTINCT( 'user_id' )
+			->FROM( 'rollup_wiki_user_events' )
+			->WHERE( 'time_id' )->GREATER_THAN( $sStartDate )
+			->AND_( 'period_id' )->EQUAL_TO( DataMartService::PERIOD_ID_DAILY )
+			->AND_( 'user_id' )->NOT_EQUAL_TO( 0 );
+
+		$aUsersIdsDidEdit = $oWikiaSQL->runLoop( $oStatsDBr, function( &$aUsersIdsDidEdit, $oUsersIdsDidEdit ) {
+			$aUsersIdsDidEdit[] = $oUsersIdsDidEdit->user_id;
+		});
+		return $aUsersIdsDidEdit;
+	}
+
+	/**
+	 * Returns array of users data arrays
+	 * user fields returned are defined by ExactTargetUserHooksHelper::prepareUserParams method
+	 * @param array $aUsersIds array of user ids
+	 * @return array
+	 */
+	private function prepareUsersParams( array $aUsersIds ) {
+		$aUsersParams = [];
+		foreach ( $aUsersIds as $iUserId ) {
+			$oUser = User::newFromId( $iUserId );
+			$oExactTargetUserHooksHelper = new ExactTargetUserHooksHelper();
+			$aUsersParams[] = $oExactTargetUserHooksHelper->prepareUserParams( $oUser );
+		}
+		return $aUsersParams;
+	}
+
+	private function addUsersUpdateTasks( $aUsersData ) {
+		$aUsersDataChunked = array_chunk( $aUsersData, ExactTargetApiDataExtension::OBJECTS_PER_REQUEST_LIMIT );
+		foreach ( $aUsersDataChunked as $aUsersDataChunk ) {
+			$this->addUsersUpdateTask( $aUsersDataChunk );
+		}
+	}
+
+	private function addUsersUpdateTask( $aUsersData ) {
+		/* Get and run the task */
+		$task = new ExactTargetUpdateUserTask();
+		$task->call( 'updateFallbackCreateUsers', $aUsersData );
+		$task->queue();
+	}
+
+	private function getLastDayDate() {
+		$oNow = new DateTime();
+		$oNow->sub(new DateInterval('P1D'));
+		$sStartDate = $oNow->format('Y-m-d H:i:s');
+		return $sStartDate;
+	}
+
+}
+
+$maintClass = "ExactTargetUpdateUserGlobalEditCountMaintenance";
+require_once( RUN_MAINTENANCE_IF_MAIN );

--- a/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetCreateUserTask.php
+++ b/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetCreateUserTask.php
@@ -69,7 +69,7 @@ class ExactTargetCreateUserTask extends ExactTargetTask {
 		}
 
 		$oHelper = $this->getUserHelper();
-		$aApiParams = $oHelper->prepareUserUpdateParams( $aUserData );
+		$aApiParams = $oHelper->prepareUsersUpdateParams( [ $aUserData ] );
 		$this->info( __METHOD__ . ' ApiParams: ' . json_encode( $aApiParams ) );
 		$oApiDataExtension = $this->getApiDataExtension();
 

--- a/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetCreateUserTask.php
+++ b/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetCreateUserTask.php
@@ -87,7 +87,7 @@ class ExactTargetCreateUserTask extends ExactTargetTask {
 		/* Verify data */
 		$oUserDataVerificationTask = $this->getUserDataVerificationTask();
 		$oUserDataVerificationTask->taskId( $this->getTaskId() ); // Pass task ID to have all logs under one task
-		$bUserDataVerificationResult = $oUserDataVerificationTask->verifyUserData( $aUserData['user_id'] );
+		$bUserDataVerificationResult = $oUserDataVerificationTask->verifyUsersData( [ $aUserData['user_id'] ] );
 
 		return $bUserDataVerificationResult;
 	}

--- a/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetDataComparisonHelper.php
+++ b/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetDataComparisonHelper.php
@@ -10,7 +10,6 @@ trait ExactTargetDataComparisonHelper {
 	 * @param string $sCallerName name of function that called this one, needed for logs
 	 * @param string $sIgnoredProperty Name of property that doesn't have to be equal
 	 * @return bool true if equal
-	 * @throws \Exception when results are not equals
 	 */
 	protected function compareResults( $aExactTargetData, $aWikiaData, $sCallerName, $sIgnoredProperty = '' ) {
 		// Remove ignored property from compared arrays
@@ -33,7 +32,8 @@ trait ExactTargetDataComparisonHelper {
 				$aDiffRes[] = "+ '{$key}' => '{$aDiffWikiaDB[$key]}'";
 			}
 			$this->debug( $sCallerName . ' ' . json_encode( $aDiffRes ) );
-			throw new \Exception( $sCallerName . " Verification failed, Record in ExactTarget doesn't match record in Wikia database." );
+			$this->error( $sCallerName . " Verification failed, Record in ExactTarget doesn't match record in Wikia database." );
+			return false;
 		}
 
 		$this->info( 'Verification passed. Record in ExactTarget match record in Wikia database' );

--- a/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetRetrieveUserTask.php
+++ b/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetRetrieveUserTask.php
@@ -37,7 +37,7 @@ class ExactTargetRetrieveUserTask extends ExactTargetTask {
 		return $oEmailResult->Results->Properties->Property->Value;
 	}
 
-	public function retrieveUserDataById( $iUserId ) {
+	public function retrieveUsersDataByIds( array $aUsersIds ) {
 		$aProperties = [
 			'user_id',
 			'user_name',
@@ -50,7 +50,7 @@ class ExactTargetRetrieveUserTask extends ExactTargetTask {
 		];
 
 		$oHelper = $this->getUserHelper();
-		$aApiParams = $oHelper->prepareUserRetrieveParams( $aProperties, 'user_id', [ $iUserId ] );
+		$aApiParams = $oHelper->prepareUserRetrieveParams( $aProperties, 'user_id', $aUsersIds );
 
 		$oApiDataExtension = $this->getApiDataExtension();
 		$oUserResult = $oApiDataExtension->retrieveRequest( $aApiParams );

--- a/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetRetrieveUserTask.php
+++ b/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetRetrieveUserTask.php
@@ -59,15 +59,27 @@ class ExactTargetRetrieveUserTask extends ExactTargetTask {
 			throw new \Exception( $oUserResult->OverallStatus );
 		}
 
-		if ( !empty( $oUserResult->Results->Properties->Property ) ) {
-			$aProperties = $oUserResult->Results->Properties->Property;
-			foreach ( $aProperties as $value ) {
-				$oExactTargetUserData[$value->Name] = $value->Value;
+		$aExactTargetUsersData = [];
+		if ( !empty( $oUserResult->Results ) ) {
+			/* Multiple records returned */
+			if ( is_array( $oUserResult->Results ) ) {
+				foreach ( $oUserResult->Results as $oResults ) {
+					$aExactTargetUserData = [];
+					$aProperties = $oResults->Properties->Property;
+					foreach ( $aProperties as $value ) {
+						$aExactTargetUserData[$value->Name] = $value->Value;
+					}
+					$aExactTargetUsersData[] = $aExactTargetUserData;
+				}
+			} else {
+				$aProperties = $oUserResult->Results->Properties->Property;
+				foreach ( $aProperties as $value ) {
+					$oExactTargetUserData[$value->Name] = $value->Value;
+				}
+				$aExactTargetUsersData = [ $oExactTargetUserData ];
 			}
-			return $oExactTargetUserData;
 		}
-
-		return null;
+		return $aExactTargetUsersData;
 	}
 
 	public function retrieveUserPropertiesByUserId( $iUserId ) {
@@ -171,7 +183,7 @@ class ExactTargetRetrieveUserTask extends ExactTargetTask {
 	public function retrieveUserIdsByEmail( $sEmail ) {
 		$aProperties = ['user_id'];
 		$sFilterProperty = 'user_email';
-		$aFilterValues = [$sEmail];
+		$aFilterValues = [ $sEmail ];
 		$oHelper = $this->getUserHelper();
 		$aApiParams = $oHelper->prepareUserRetrieveParams( $aProperties, $sFilterProperty, $aFilterValues );
 

--- a/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetTask.php
+++ b/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetTask.php
@@ -64,7 +64,7 @@ class ExactTargetTask extends BaseTask {
 
 	/**
 	 * Returns an instance of ExactTargetUserDataVerification class
-	 * @return ExactTargetUserDataVerification
+	 * @return ExactTargetUserDataVerificationTask
 	 */
 	protected function getUserDataVerificationTask() {
 		return new ExactTargetUserDataVerificationTask();

--- a/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetUpdateUserTask.php
+++ b/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetUpdateUserTask.php
@@ -26,10 +26,8 @@ class ExactTargetUpdateUserTask extends ExactTargetTask {
 			if ( empty( $aUserData['user_id'] ) ) {
 				$this->error( __METHOD__ . ' user under ' . $iArrayKey . ' index of $aUsersData has no ID' );
 				unset( $aUsersData[$iArrayKey] );
-			}
-
-			elseif ( empty( $aUserData['user_email'] ) ) {
-				$this->error( __METHOD__ . ' user under ' . $iArrayKey . ' index of $aUsersData has no ID' );
+			} elseif ( empty( $aUserData['user_email'] ) ) {
+				$this->error( __METHOD__ . ' user under ' . $iArrayKey . ' index of $aUsersData has no email' );
 				unset( $aUsersData[$iArrayKey] );
 			}
 		}
@@ -52,7 +50,7 @@ class ExactTargetUpdateUserTask extends ExactTargetTask {
 		}
 
 		/* Verify data */
-		$aUserIds = $oHelper->prepareUserIds( $aUsersData );
+		$aUserIds = array_column( $aUsersData , 'user_id' );
 		$oUserDataVerificationTask = $this->getUserDataVerificationTask();
 		$oUserDataVerificationTask->taskId( $this->getTaskId() ); // Pass task ID to have all logs under one task
 		$bUserDataVerificationResult = $oUserDataVerificationTask->verifyUsersData( $aUserIds );

--- a/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetUpdateUserTask.php
+++ b/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetUpdateUserTask.php
@@ -52,9 +52,10 @@ class ExactTargetUpdateUserTask extends ExactTargetTask {
 		}
 
 		/* Verify data */
+		$aUserIds = $oHelper->prepareUserIds( $aUsersData );
 		$oUserDataVerificationTask = $this->getUserDataVerificationTask();
 		$oUserDataVerificationTask->taskId( $this->getTaskId() ); // Pass task ID to have all logs under one task
-		$bUserDataVerificationResult = $oUserDataVerificationTask->verifyUserData( $aUserData );
+		$bUserDataVerificationResult = $oUserDataVerificationTask->verifyUsersData( $aUserIds );
 
 		return $bUserDataVerificationResult;
 	}

--- a/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetUserDataVerificationTask.php
+++ b/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetUserDataVerificationTask.php
@@ -12,21 +12,26 @@ class ExactTargetUserDataVerificationTask extends ExactTargetTask {
 	 * if data isn't equal throws exception with result diff
 	 */
 	public function verifyUserData( $iUserId ) {
+		$bSummaryResult = true;
 		// Fetch data from ExactTarget
 		$oRetriveveUserTask = $this->getRetrieveUserTask();
-		$oExactTargetUserData = $oRetriveveUserTask->retrieveUserDataById( $iUserId );
-		$this->info( __METHOD__ . ' ExactTarget user data record: ' . json_encode( $oExactTargetUserData ) );
+		$oExactTargetUsersData = $oRetriveveUserTask->retrieveUserDataById( $iUserId );
+		foreach( $oExactTargetUsersData as $oExactTargetUserData ) {
+			$this->info( __METHOD__ . ' ExactTarget user data record: ' . json_encode( $oExactTargetUserData ) );
 
-		// Fetch data from Wikia DB
-		$oWikiaUser = \User::newFromId( $iUserId );
-		$oUserHooksHelper = $this->getUserHooksHelper();
-		$oWikiaUserData = $oUserHooksHelper->prepareUserParams( $oWikiaUser );
-		$this->info( __METHOD__ . ' Wikia DB user data record: ' . json_encode( $oWikiaUserData ) );
+			// Fetch data from Wikia DB
+			$oWikiaUser = \User::newFromId( $iUserId );
+			$oUserHooksHelper = $this->getUserHooksHelper();
+			$oWikiaUserData = $oUserHooksHelper->prepareUserParams( $oWikiaUser );
+			$this->info( __METHOD__ . ' Wikia DB user data record: ' . json_encode( $oWikiaUserData ) );
 
-		// Compare results
-		$bResult = $this->compareResults( $oExactTargetUserData, $oWikiaUserData, __METHOD__, 'user_touched' );
-
-		return $bResult;
+			// Compare results
+			$bResult = $this->compareResults( $oExactTargetUserData, $oWikiaUserData, __METHOD__, 'user_touched' );
+			if ( $bResult === false ) {
+				$bSummaryResult = $bResult;
+			}
+		}
+		return $bSummaryResult;
 	}
 
 

--- a/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetUserDataVerificationTask.php
+++ b/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetUserDataVerificationTask.php
@@ -14,10 +14,10 @@ class ExactTargetUserDataVerificationTask extends ExactTargetTask {
 	public function verifyUsersData( array $aUsersIds ) {
 		$bSummaryResult = true;
 		// Fetch data from ExactTarget
-		$oRetriveveUserTask = $this->getRetrieveUserTask();
-		$aExactTargetUsersData = $oRetriveveUserTask->retrieveUsersDataByIds( $aUsersIds );
+		$oRetrieveUserTask = $this->getRetrieveUserTask();
+		$aExactTargetUsersData = $oRetrieveUserTask->retrieveUsersDataByIds( $aUsersIds );
 		$aUsersIdsFlipped = array_flip( $aUsersIds );
-		foreach( $aExactTargetUsersData as $aExactTargetUserData ) {
+		foreach ( $aExactTargetUsersData as $aExactTargetUserData ) {
 			$this->info( __METHOD__ . ' ExactTarget user data record: ' . json_encode( $aExactTargetUserData ) );
 
 			// Fetch data from Wikia DB
@@ -55,8 +55,8 @@ class ExactTargetUserDataVerificationTask extends ExactTargetTask {
 	 */
 	public function verifyUserPropertiesData( $iUserId ) {
 		// Fetch data from ExactTarget
-		$oRetriveveUserTask = $this->getRetrieveUserTask();
-		$oExactTargetUserProperties = $oRetriveveUserTask->retrieveUserPropertiesByUserId( $iUserId );
+		$oRetrieveUserTask = $this->getRetrieveUserTask();
+		$oExactTargetUserProperties = $oRetrieveUserTask->retrieveUserPropertiesByUserId( $iUserId );
 		$this->info( __METHOD__ . ' ExactTarget user_properties data record: ' . json_encode( $oExactTargetUserProperties ) );
 
 		// Fetch data from Wikia DB

--- a/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetUserTaskHelper.php
+++ b/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetUserTaskHelper.php
@@ -362,16 +362,4 @@ class ExactTargetUserTaskHelper {
 		}
 	}
 
-	/**
-	 * Extracts list of users ids from provided $aUsersData
-	 * @param $aUsersData array of users data arrays consistent with structure of ExactTargetUserHooksHelper::prepareUserParams
-	 * @return array
-	 */
-	public function prepareUserIds( $aUsersData ) {
-		foreach( $aUsersData as $aUserData ) {
-			$aUserIds[] = $aUserData['user_id'];
-		}
-		return $aUserIds;
-	}
-
 }

--- a/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetUserTaskHelper.php
+++ b/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetUserTaskHelper.php
@@ -14,12 +14,18 @@ class ExactTargetUserTaskHelper {
 		/* Get Customer Keys specific for production or development */
 		$aCustomerKeys = $this->getCustomerKeys();
 
+		$sSimpleOperator = 'equals';
+		if ( count( $aFilterValues ) > 1 ) {
+			$sSimpleOperator = 'IN';
+		}
+
 		$aApiParams = [
 			'DataExtension' => [
 				'ObjectType' => "DataExtensionObject[{$aCustomerKeys['user']}]",
 				'Properties' => $aProperties,
 			],
 			'SimpleFilterPart' => [
+				'SimpleOperator' => $sSimpleOperator,
 				'Property' => $sFilterProperty,
 				'Value' => $aFilterValues
 			]
@@ -34,21 +40,28 @@ class ExactTargetUserTaskHelper {
 	 * @param  array $aUserData  User key value array
 	 * @return array             Array of DataExtension data arrays (nested arrays)
 	 */
-	public function prepareUserUpdateParams( array $aUserData ) {
-		$userId = $this->extractUserIdFromData( $aUserData );
-		/* Get Customer Keys specific for production or development */
-		$aCustomerKeys = $this->getCustomerKeys();
-		$sCustomerKey = $aCustomerKeys['user'];
-
+	public function prepareUsersUpdateParams( array $aUsersData ) {
 		$aApiParams = [
-			'DataExtension' => [
-				[
-					'CustomerKey' => $sCustomerKey,
-					'Properties' => $aUserData,
-					'Keys' => [ 'user_id' => $userId ]
-				]
-			]
+			'DataExtension' => []
 		];
+
+		foreach ( $aUsersData as $aUserData ) {
+
+			/* Get Customer Keys specific for production or development */
+			$aCustomerKeys = $this->getCustomerKeys();
+			$sCustomerKey = $aCustomerKeys['user'];
+
+			$userId = $this->extractUserIdFromData( $aUserData );
+
+			/* Prepare API params for one user */
+			$aApiParams['DataExtension'][] = [
+				'CustomerKey' => $sCustomerKey,
+				'Properties' => $aUserData,
+				'Keys' => [ 'user_id' => $userId ]
+			];
+
+		};
+
 		return $aApiParams;
 	}
 

--- a/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetUserTaskHelper.php
+++ b/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetUserTaskHelper.php
@@ -362,4 +362,16 @@ class ExactTargetUserTaskHelper {
 		}
 	}
 
+	/**
+	 * Extracts list of users ids from provided $aUsersData
+	 * @param $aUsersData array of users data arrays consistent with structure of ExactTargetUserHooksHelper::prepareUserParams
+	 * @return array
+	 */
+	public function prepareUserIds( $aUsersData ) {
+		foreach( $aUsersData as $aUserData ) {
+			$aUserIds[] = $aUserData['user_id'];
+		}
+		return $aUserIds;
+	}
+
 }

--- a/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetWikiTaskHelper.php
+++ b/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetWikiTaskHelper.php
@@ -182,7 +182,7 @@ class ExactTargetWikiTaskHelper {
 		$aCategories = $oWikiFactoryHub->getWikiCategories( $iCityId );
 		$aCityCatMappingDataExtension['DataExtension'] = [];
 
-		foreach( $aCategories as $aCategory ) {
+		foreach ( $aCategories as $aCategory ) {
 			$aCityCatMappingDataExtension['DataExtension'][] = [
 				'CustomerKey' => $aCustomerKeys['city_cat_mapping'],
 				'Properties' => [

--- a/extensions/wikia/ExactTargetUpdates/tests/ExactTargetCreateUserTaskTest.php
+++ b/extensions/wikia/ExactTargetUpdates/tests/ExactTargetCreateUserTaskTest.php
@@ -34,7 +34,7 @@ class ExactTargetCreateUserTaskTest extends WikiaBaseTest {
 		/* @var ExactTargetCreateUserTask $addTaskMock mock of ExactTargetCreateUserTask class */
 		$addTaskMock = $this->getMockBuilder( 'Wikia\ExactTarget\ExactTargetCreateUserTask' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'createSubscriber', 'createUser', 'createUserProperties', 'getDeleteUserTask', 'verifyUserData', 'getTaskId' ] )
+			->setMethods( [ 'createSubscriber', 'createUser', 'createUserProperties', 'getDeleteUserTask', 'getTaskId' ] )
 			->getMock();
 
 		$addTaskMock


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CE-1543

Previously user record was updated in ExactTarget after each ArticleSaveComplete. Some inconsistencies in editcount user number updates found. Decided to change approach and update numbers once a day based on list of users that edited previous day. (same as it's done for incremental user per wiki daily updates)

This way we gain data consistency and reduce number of updates.
Assume 4k users edited 3 times each. It was causing 12k updates. Now it will be two updates one with 2.5k users and second with remaining 1.5k (chunk limit 2.5k)

@SQLReview 

```
SELECT DISTINCT user_id
     FROM rollup_wiki_user_events
     WHERE time_id > '2015-04-13 02:47:26'
     AND period_id = '1'
     AND user_id <> '0'
```

time_id is always set to be greater than day before

EXPLAIN

```
          id: 1
  select_type: SIMPLE
        table: rollup_wiki_user_events
         type: range
possible_keys: PRIMARY,time_id
          key: PRIMARY
      key_len: 8
          ref: NULL
         rows: 67732
        Extra: Using where; Using index; Using temporary
```

@Wikia/community-engineering 
