### PR TITLE
SOC-665 pass namespace to watchedpagecontroller

### DIFF
--- a/extensions/wikia/Email/Controller/WatchedPageController.class.php
+++ b/extensions/wikia/Email/Controller/WatchedPageController.class.php
@@ -24,7 +24,8 @@ class WatchedPageController extends EmailController {
 	}
 
 	public function initEmail() {
-		$this->title = \Title::newFromText( $this->request->getVal( 'title' ) );
+		$nameSpace = $this->request->getVal( 'nameSpace', NS_MAIN );
+		$this->title = \Title::newFromText( $this->request->getVal( 'title' ), $nameSpace );
 		$this->summary = $this->request->getVal( 'summary' );
 		$this->currentRevId = $this->request->getVal( 'currentRevId' );
 		$this->previousRevId = $this->request->getVal( 'previousRevId' );

--- a/extensions/wikia/Email/Controller/WatchedPageController.class.php
+++ b/extensions/wikia/Email/Controller/WatchedPageController.class.php
@@ -24,7 +24,7 @@ class WatchedPageController extends EmailController {
 	}
 
 	public function initEmail() {
-		$nameSpace = $this->request->getVal( 'nameSpace', NS_MAIN );
+		$nameSpace = $this->request->getInt( 'nameSpace', NS_MAIN );
 		$this->title = \Title::newFromText( $this->request->getVal( 'title' ), $nameSpace );
 		$this->summary = $this->request->getVal( 'summary' );
 		$this->currentRevId = $this->request->getVal( 'currentRevId' );

--- a/includes/EmailNotification.php
+++ b/includes/EmailNotification.php
@@ -474,6 +474,7 @@ class EmailNotification {
 			[
 				'targetUser' => $user->getName(),
 				'title' => $this->title->getText(),
+				'nameSpace' => $this->title->getNamespace(),
 				'summary' => $this->summary,
 				'currentRevId' => $this->currentRevId,
 				'previousRevId' => $this->previousRevId,


### PR DESCRIPTION
Watched Page emails aren't being sent out properly for articles not in the main namespace. For Talk pages, this results incorrect links, and for Category and File pages, this was resulting in no email being sent out at all. This ticket sends the namespace with the title name so we can create the correct title object.

Ticket: https://wikia-inc.atlassian.net/browse/SOC-665
