### PR TITLE
(CE-1532) Make sure we always have a parameter array

### DIFF
--- a/extensions/wikia/SemanticMediaWiki/includes/api/ApiAskArgs.php
+++ b/extensions/wikia/SemanticMediaWiki/includes/api/ApiAskArgs.php
@@ -31,6 +31,9 @@ class ApiAskArgs extends ApiSMWQuery {
 
 	public function execute() {
 		$params = $this->extractRequestParams();
+		// Wikia change - start - Make sure we always have an array (CE-1532)
+		$this->parameters = [];
+		// Wikia change - end
 
 		foreach ( $params['parameters'] as $param ) {
 			$parts = explode( '=', $param, 2 );


### PR DESCRIPTION
Fixes the following fatal error:

```
PHP Catchable fatal error: Argument 2 passed to
SMWQueryProcessor::addThisPrintout() must be of the type array,
null given, called in extensions/wikia/SemanticMediaWiki/
includes/api/ApiSMWQuery.php on line 50 and defined in
extensions/wikia/SemanticMediaWiki/includes/SMW_QueryProcessor.php
on line 234
```

/cc @Wikia/community-engineering 
