### PR TITLE
CE-1612 adding user updates on user email confirm hook 

### DIFF
--- a/extensions/wikia/ExactTargetUpdates/hooks/ExactTargetSetup.hooks.php
+++ b/extensions/wikia/ExactTargetUpdates/hooks/ExactTargetSetup.hooks.php
@@ -20,6 +20,7 @@ class ExactTargetSetupHooks {
 		\Hooks::register( 'AddUserToDatabaseComplete', [ $oUserHooks, 'onCreateNewUserComplete' ] );
 		\Hooks::register( 'CreateNewUserComplete', [ $oUserHooks, 'onCreateNewUserComplete' ] );
 		\Hooks::register( 'ExternalUserAddUserToDatabaseComplete', [ $oUserHooks, 'onCreateNewUserComplete' ] );
+		\Hooks::register( 'ConfirmEmailComplete', [ $oUserHooks, 'onConfirmEmailComplete' ] );
 		\Hooks::register( 'EditAccountClosed', [ $oUserHooks, 'onEditAccountClosed' ] );
 		\Hooks::register( 'EditAccountEmailChanged', [ $oUserHooks, 'onEditAccountEmailChanged' ] );
 		\Hooks::register( 'EmailChangeConfirmed', [ $oUserHooks, 'onEmailChangeConfirmed' ] );

--- a/extensions/wikia/ExactTargetUpdates/hooks/ExactTargetSetup.hooks.php
+++ b/extensions/wikia/ExactTargetUpdates/hooks/ExactTargetSetup.hooks.php
@@ -20,10 +20,10 @@ class ExactTargetSetupHooks {
 		\Hooks::register( 'AddUserToDatabaseComplete', [ $oUserHooks, 'onCreateNewUserComplete' ] );
 		\Hooks::register( 'CreateNewUserComplete', [ $oUserHooks, 'onCreateNewUserComplete' ] );
 		\Hooks::register( 'ExternalUserAddUserToDatabaseComplete', [ $oUserHooks, 'onCreateNewUserComplete' ] );
-		\Hooks::register( 'ConfirmEmailComplete', [ $oUserHooks, 'onConfirmEmailComplete' ] );
 		\Hooks::register( 'EditAccountClosed', [ $oUserHooks, 'onEditAccountClosed' ] );
 		\Hooks::register( 'EditAccountEmailChanged', [ $oUserHooks, 'onEditAccountEmailChanged' ] );
-		\Hooks::register( 'EmailChangeConfirmed', [ $oUserHooks, 'onEmailChangeConfirmed' ] );
+		\Hooks::register( 'InvalidateEmailComplete', [ $oUserHooks, 'onInvalidateEmailComplete' ] );
+		\Hooks::register( 'ConfirmEmailComplete', [ $oUserHooks, 'onConfirmEmailComplete' ] );
 		\Hooks::register( 'AfterUserAddGlobalGroup', [ $oUserHooks, 'onAfterUserAddGlobalGroup' ] );
 		\Hooks::register( 'AfterUserRemoveGlobalGroup', [ $oUserHooks, 'onAfterUserRemoveGlobalGroup' ] );
 		\Hooks::register( 'UserSaveSettings', [ $oUserHooks, 'onUserSaveSettings' ] );

--- a/extensions/wikia/ExactTargetUpdates/hooks/ExactTargetUser.hooks.php
+++ b/extensions/wikia/ExactTargetUpdates/hooks/ExactTargetUser.hooks.php
@@ -42,11 +42,30 @@ class ExactTargetUserHooks {
 	}
 
 	/**
+	 * Adds Task for updating user due to email authentication field change
+	 * @param User $user
+	 * @return bool
+	 */
+	public function onInvalidateEmailComplete( \User $oUser ) {
+		/* Prepare params */
+		$oUserHelper = $this->getUserHelper();
+		$aUserData = $oUserHelper->prepareUserParams( $oUser );
+		$aUsersData = [ $aUserData ];
+
+		/* Get and run the task */
+		$task = $oUserHelper->getUpdateUserTask();
+		$task->call( 'updateFallbackCreateUsers', $aUsersData );
+		$task->queue();
+		return true;
+	}
+
+
+	/**
 	 * Adds Task for updating user email
 	 * @param User $user
 	 * @return bool
 	 */
-	public function onEmailChangeConfirmed( \User $oUser ) {
+	public function onConfirmEmailComplete( \User $oUser ) {
 		/* Get and run the task */
 		$oUserHelper = $this->getUserHelper();
 		$task = $oUserHelper->getUpdateUserTask();
@@ -61,16 +80,6 @@ class ExactTargetUserHooks {
 	 * @return bool
 	 */
 	public function onCreateNewUserComplete( \User $oUser ) {
-		$this->addTheUpdateCreateUserTask( $oUser );
-		return true;
-	}
-
-	/**
-	 * Adds Task to job queue that updates a user or adds a user if one doesn't exist
-	 * @param User $oUser
-	 * @return bool
-	 */
-	public function onConfirmEmailComplete( \User $oUser ) {
 		$this->addTheUpdateCreateUserTask( $oUser );
 		return true;
 	}

--- a/extensions/wikia/ExactTargetUpdates/hooks/ExactTargetUser.hooks.php
+++ b/extensions/wikia/ExactTargetUpdates/hooks/ExactTargetUser.hooks.php
@@ -66,6 +66,16 @@ class ExactTargetUserHooks {
 	}
 
 	/**
+	 * Adds Task to job queue that updates a user or adds a user if one doesn't exist
+	 * @param User $oUser
+	 * @return bool
+	 */
+	public function onConfirmEmailComplete( \User $oUser ) {
+		$this->addTheUpdateCreateUserTask( $oUser );
+		return true;
+	}
+
+	/**
 	 * Adds a task for adding user groups
 	 * @param User $user
 	 * @param string $sGroup Group name to add

--- a/extensions/wikia/ExactTargetUpdates/maintenance/ExactTargetUpdateUserGlobalEditCountMaintenance.php
+++ b/extensions/wikia/ExactTargetUpdates/maintenance/ExactTargetUpdateUserGlobalEditCountMaintenance.php
@@ -23,15 +23,10 @@ class ExactTargetUpdateUserGlobalEditCountMaintenance extends Maintenance {
 	 */
 	public function execute() {
 		global $wgDWStatsDB;
-		// Get DB
 		$oStatsDBr = wfGetDB( DB_SLAVE, [], $wgDWStatsDB );
-		// Get timestamp param
 		$sStartDate = $this->getLastDayDate();
-		// Get user ids
 		$aUsersIds = $this->getListOfUsersIdsEdited( $oStatsDBr, $sStartDate );
-		// Prepare user data required for update
 		$aUsersData = $this->prepareUsersParams( $aUsersIds );
-		// Add update tasks
 		$this->addUsersUpdateTasks( $aUsersData );
 	}
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CE-1612

We need to have user_email_authenticated field up to date.

Reorganized hooks on which we update user data due to email authentication process.

Removed EmailChangeConfirmed that runs on email change confirm, but not on user signup email confirm
Added ConfirmEmailComplete that runs both on email change confirm and user signup email confirm
Added InvalidateEmailComplete that runs when email was changed in options but isn't confirmed yet (user_email_authentication field set to null user_email not changed)

@Wikia/community-engineering 
