### PR TITLE
PLATFORM-1007: rename MostimagesInContent to MostLinkedFilesInContent

### DIFF
--- a/extensions/wikia/ImageServing/ImageServing.i18n.php
+++ b/extensions/wikia/ImageServing/ImageServing.i18n.php
@@ -9,7 +9,7 @@ $messages = array();
 
 $messages['en'] = array(
 	'imageserving-desc' => 'Selects images from a specified array of pages based on visual requirements',
-	'mostimagesincontent' => 'Most linked-to files in content namespaces',
+	'mostlinkedfilesincontent' => 'Most linked-to files in content namespaces',
 );
 
 /** Message documentation (Message documentation)
@@ -17,7 +17,7 @@ $messages['en'] = array(
  */
 $messages['qqq'] = array(
 	'imageserving-desc' => '{{desc}}',
-	'mostimagesincontent' => 'The name of the special page showing the list of the most popular images on pages in content namespaces',
+	'mostlinkedfilesincontent' => 'The name of the special page showing the list of the most popular images on pages in content namespaces',
 );
 
 /** Arabic (العربية)
@@ -187,7 +187,7 @@ $messages['oc'] = array(
  */
 $messages['pl'] = array(
 	'imageserving-desc' => 'Wybiera obrazy z określonej grupy stron na bazie preferencji wizualnych.',
-	'mostimagesincontent' => 'Najczęściej linkowane pliki w przestrzeniach nazw z treścią',
+	'mostlinkedfilesincontent' => 'Najczęściej linkowane pliki w przestrzeniach nazw z treścią',
 );
 
 /** Piedmontese (Piemontèis)

--- a/extensions/wikia/ImageServing/imageServing.setup.php
+++ b/extensions/wikia/ImageServing/imageServing.setup.php
@@ -52,13 +52,13 @@ $wgAutoloadClasses[ "WikiaApiImageServing"         ] = "{$dir}/api//WikiaApiImag
 $wgAPIModules['imageserving'] = 'WikiaApiImageServing';
 
 // query page for caching images popularity (see PLAQTFORM-817)
-$wgSpecialPages[ 'MostimagesInContent' ] =  'MostimagesInContentPage';
-$wgSpecialPageGroups['MostimagesInContent'] = 'maintenance';
+$wgSpecialPages[ 'MostLinkedFilesInContent' ] =  'MostimagesInContentPage';
+$wgSpecialPageGroups['MostLinkedFilesInContent'] = 'maintenance';
 
 $wgAutoloadClasses[ 'MostimagesInContentPage' ] = "{$dir}/querypage/MostimagesInContentPage.class.php";
 
 $wgHooks['wgQueryPages'][] = function( Array &$wgQueryPages ) {
 	//                  QueryPage subclass         Special page name
-	$wgQueryPages[] = [ 'MostimagesInContentPage', 'MostimagesInContent' ];
+	$wgQueryPages[] = [ 'MostimagesInContentPage', 'MostLinkedFilesInContent' ];
 	return true;
 };

--- a/extensions/wikia/ImageServing/querypage/MostimagesInContentPage.class.php
+++ b/extensions/wikia/ImageServing/querypage/MostimagesInContentPage.class.php
@@ -10,7 +10,7 @@
  * @author macbre
  */
 class MostimagesInContentPage extends MostimagesPage {
-	function __construct( $name = 'MostimagesInContent' ) {
+	function __construct( $name = 'MostLinkedFilesInContent' ) {
 		parent::__construct( $name );
 	}
 

--- a/extensions/wikia/ImageServing/querypage/MostimagesInContentPage.class.php
+++ b/extensions/wikia/ImageServing/querypage/MostimagesInContentPage.class.php
@@ -14,6 +14,18 @@ class MostimagesInContentPage extends MostimagesPage {
 		parent::__construct( $name );
 	}
 
+	/**
+	 * Force an old name of the special page here.
+	 * We need to keep the old name in querycache's qc_type column to keep ImageServing working
+	 *
+	 * @see PLATFORM-1007
+	 *
+	 * @return String
+	 */
+	function getName() {
+		return 'MostimagesInContent';
+	}
+
 	function getQueryInfo() {
 		global $wgContentNamespaces;
 


### PR DESCRIPTION
Use a bit different approach than in #6909 - rename only the special page name and i18n messages. Do not touch class names and query pages.

@jcellary 
