### PR TITLE
ADEN-1676 Floor adhesion on Mercury

### DIFF
--- a/extensions/wikia/AdEngine/AdEngine2ContextService.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2ContextService.class.php
@@ -31,10 +31,11 @@ class AdEngine2ContextService {
 					'adsInContent' => $wg->EnableAdsInContent,
 					'disableLateQueue' => $wg->AdEngineDisableLateQueue,
 					'enableAdsInMaps' => $wg->AdDriverEnableAdsInMaps,
+					'enableInvisibleHighImpactSlot' => $wg->AdDriverEnableInvisibleHighImpactSlot,
 					'pageType' => $adPageTypeService->getPageType(),
 					'showAds' => $adPageTypeService->areAdsShowableOnPage(),
-					'usePostScribe' => $wg->Request->getBool( 'usepostscribe', false ),
 					'trackSlotState' => $wg->AdDriverTrackState,
+					'usePostScribe' => $wg->Request->getBool( 'usepostscribe', false ),
 				] ),
 				'targeting' => $this->filterOutEmptyItems( [
 					'enableKruxTargeting' => $wg->EnableKruxTargeting,

--- a/extensions/wikia/AdEngine/js/AdContext.js
+++ b/extensions/wikia/AdEngine/js/AdContext.js
@@ -83,6 +83,13 @@ define('ext.wikia.adEngine.adContext', [
 			context.providers.turtle = true;
 		}
 
+		if (instantGlobals.wgAdDriverHighImpactSlotCountries &&
+			instantGlobals.wgAdDriverHighImpactSlotCountries.indexOf &&
+			instantGlobals.wgAdDriverHighImpactSlotCountries.indexOf(geo.getCountryCode()) > -1
+		) {
+			context.opts.enableInvisibleHighImpactSlot = true;
+		}
+
 		// Export the context back to ads.context
 		// Only used by Lightbox.js, WikiaBar.js and AdsInContext.js
 		if (w.ads && w.ads.context) {

--- a/extensions/wikia/AdEngine/js/config/mobile.js
+++ b/extensions/wikia/AdEngine/js/config/mobile.js
@@ -27,6 +27,10 @@ define('ext.wikia.adEngine.config.mobile', [
 			return [];
 		}
 
+		if (!context.opts.enableInvisibleHighImpactSlot && slotName === 'INVISIBLE_HIGH_IMPACT') {
+			return [];
+		}
+
 		if (context.providers.taboola && taboola && taboola.canHandleSlot(slotName)) {
 			return [taboola];
 		}

--- a/extensions/wikia/AdEngine/js/provider/directGptMobile.js
+++ b/extensions/wikia/AdEngine/js/provider/directGptMobile.js
@@ -9,7 +9,7 @@ define('ext.wikia.adEngine.provider.directGptMobile', [
 		'DirectGptMobile',
 		'mobile',
 		{
-			INVISIBLE_HIGH_IMPACT:      {size: '320x50,320x100'},
+			INVISIBLE_HIGH_IMPACT:      {size: '1x1'},
 			MOBILE_TOP_LEADERBOARD:     {size: '320x50,320x100,1x1'},
 			MOBILE_IN_CONTENT:          {size: '300x250,1x1'},
 			MOBILE_PREFOOTER:           {size: '300x250,1x1'}

--- a/extensions/wikia/AdEngine/js/provider/directGptMobile.js
+++ b/extensions/wikia/AdEngine/js/provider/directGptMobile.js
@@ -9,6 +9,7 @@ define('ext.wikia.adEngine.provider.directGptMobile', [
 		'DirectGptMobile',
 		'mobile',
 		{
+			INVISIBLE_HIGH_IMPACT:      {size: '320x50,320x100'},
 			MOBILE_TOP_LEADERBOARD:     {size: '320x50,320x100,1x1'},
 			MOBILE_IN_CONTENT:          {size: '300x250,1x1'},
 			MOBILE_PREFOOTER:           {size: '300x250,1x1'}

--- a/extensions/wikia/AdEngine/js/spec/AdContext.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/AdContext.spec.js
@@ -180,4 +180,18 @@ describe('AdContext', function () {
 		adContext.setContext({});
 		expect(mocks.callback).toHaveBeenCalled();
 	});
+
+	it('enables high impact slot when country in instantGlobals.wgAdDriverHighImpactSlotCountries', function () {
+		var adContext;
+
+		adContext = modules['ext.wikia.adEngine.adContext']({}, {}, geoMock, {
+			wgAdDriverHighImpactSlotCountries: ['XX', 'ZZ']
+		});
+		expect(adContext.getContext().opts.enableInvisibleHighImpactSlot).toBeTruthy();
+
+		adContext = modules['ext.wikia.adEngine.adContext']({},  {}, geoMock, {
+			wgAdDriverHighImpactSlotCountries: ['YY']
+		});
+		expect(adContext.getContext().opts.enableInvisibleHighImpactSlot).toBeFalsy();
+	});
 });

--- a/extensions/wikia/AdEngine/js/spec/config.mobile.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/config.mobile.spec.js
@@ -11,13 +11,14 @@ describe('ext.wikia.adEngine.config.mobile', function () {
 			canHandleSlot: function () { return true; }
 		};
 
-	function mockAdContext(showAds) {
+	function mockAdContext(showAds, enableInvisibleHighImpactSlot) {
 		return {
 			getContext: function () {
 				return {
 					opts: {
 						showAds: showAds,
-						pageType: 'all_ads'
+						pageType: 'all_ads',
+						enableInvisibleHighImpactSlot: enableInvisibleHighImpactSlot
 					},
 					providers: {
 					}
@@ -44,5 +45,25 @@ describe('ext.wikia.adEngine.config.mobile', function () {
 		);
 
 		expect(adConfigMobile.getProviderList('foo')).toEqual([]);
+	});
+
+	it('getProviderList returns DirectGPT, RemnantGPT for high impact slot', function () {
+		var adConfigMobile = modules['ext.wikia.adEngine.config.mobile'](
+			mockAdContext(true, true),
+			adProviderDirectMock,
+			adProviderRemnantMock
+		);
+
+		expect(adConfigMobile.getProviderList('INVISIBLE_HIGH_IMPACT')).toEqual([adProviderDirectMock, adProviderRemnantMock]);
+	});
+
+	it('getProviderLists returns [] for high impact slot when high impact slot is turned off', function () {
+		var adConfigMobile = modules['ext.wikia.adEngine.config.mobile'](
+			mockAdContext(true, false),
+			adProviderDirectMock,
+			adProviderRemnantMock
+		);
+
+		expect(adConfigMobile.getProviderList('INVISIBLE_HIGH_IMPACT')).toEqual([]);
 	});
 });

--- a/extensions/wikia/AdEngine/js/template/floor.js
+++ b/extensions/wikia/AdEngine/js/template/floor.js
@@ -1,12 +1,15 @@
 /*global define*/
 define('ext.wikia.adEngine.template.floor', [
-	'jquery',
+	require.optional('jquery'),
 	'wikia.log',
 	'wikia.document',
 	'wikia.iframeWriter',
 	'wikia.window'
 ], function ($, log, doc, iframeWriter, win) {
 	'use strict';
+
+	// Use our jQuery module or in Mercury Ember's jQuery
+	$ = $ || win.$;
 
 	var logGroup = 'ext.wikia.adEngine.template.floor',
 		footerHtml = '<div id="ext-wikia-adEngine-template-footer">' +
@@ -42,7 +45,9 @@ define('ext.wikia.adEngine.template.floor', [
 				height: params.height
 			});
 
-		win.WikiaBar.hideContainer();
+		if (win.WikiaBar) {
+			win.WikiaBar.hideContainer();
+		}
 
 		$footer.find('a.close').click(function (event) {
 			event.preventDefault();

--- a/extensions/wikia/AdEngine/js/template/floor.js
+++ b/extensions/wikia/AdEngine/js/template/floor.js
@@ -1,21 +1,30 @@
 /*global define*/
 define('ext.wikia.adEngine.template.floor', [
+	'ext.wikia.adEngine.adContext',
 	require.optional('jquery'),
 	'wikia.log',
 	'wikia.document',
 	'wikia.iframeWriter',
 	'wikia.window'
-], function ($, log, doc, iframeWriter, win) {
+], function (adContext, $, log, doc, iframeWriter, win) {
 	'use strict';
 
 	// Use our jQuery module or in Mercury Ember's jQuery
 	$ = $ || win.$;
 
 	var logGroup = 'ext.wikia.adEngine.template.floor',
-		footerHtml = '<div id="ext-wikia-adEngine-template-footer">' +
+		footerId = 'ext-wikia-adEngine-template-footer',
+		oasisFooterHtml = '<div id="' + footerId + '">' +
 			'<div class="background"></div>' +
 			'<div class="ad"></div>' +
 			'<a class="close" title="Close" href="#"><span>Close</span></a>' +
+			'</div>',
+		mercuryFooterHtml = '<div id="' + footerId + '">' +
+			'<div class="background"></div>' +
+			'<div class="ad"></div>' +
+			'<a class="close" title="Close" href="#">' +
+			'<svg role="img" class="ads-floor-close-button"><use xlink:href="#close"></use></svg>' +
+			'</a>' +
 			'</div>';
 
 	/**
@@ -38,15 +47,21 @@ define('ext.wikia.adEngine.template.floor', [
 	function show(params) {
 		log(['show', params], 'debug', logGroup);
 
-		var $footer = $(footerHtml),
-			iframe = iframeWriter.getIframe({
+		var iframe = iframeWriter.getIframe({
 				code: params.code,
 				width: params.width,
 				height: params.height
-			});
+			}),
+			skin = adContext.getContext().targeting.skin,
+			$footer;
 
-		if (win.WikiaBar) {
+		if (skin === 'oasis') {
+			$footer = $(oasisFooterHtml);
 			win.WikiaBar.hideContainer();
+		}
+
+		if (skin === 'mercury') {
+			$footer = $(mercuryFooterHtml);
 		}
 
 		$footer.find('a.close').click(function (event) {

--- a/extensions/wikia/AdEngine/js/template/floor.js
+++ b/extensions/wikia/AdEngine/js/template/floor.js
@@ -17,7 +17,7 @@ define('ext.wikia.adEngine.template.floor', [
 			'<svg role="img" class="ads-floor-close-button"><use xlink:href="#close"></use></svg>' +
 			'</a>' +
 			'</div>',
-		$ = $ || win.$;
+		$ = win.$;
 
 	/**
 	 * Show the floor ad.

--- a/extensions/wikia/AdEngine/js/template/floor.js
+++ b/extensions/wikia/AdEngine/js/template/floor.js
@@ -1,31 +1,23 @@
 /*global define*/
 define('ext.wikia.adEngine.template.floor', [
 	'ext.wikia.adEngine.adContext',
-	require.optional('jquery'),
 	'wikia.log',
 	'wikia.document',
 	'wikia.iframeWriter',
 	'wikia.window'
-], function (adContext, $, log, doc, iframeWriter, win) {
+], function (adContext, log, doc, iframeWriter, win) {
 	'use strict';
-
-	// Use our jQuery module or in Mercury Ember's jQuery
-	$ = $ || win.$;
 
 	var logGroup = 'ext.wikia.adEngine.template.floor',
 		footerId = 'ext-wikia-adEngine-template-footer',
-		oasisFooterHtml = '<div id="' + footerId + '">' +
-			'<div class="background"></div>' +
-			'<div class="ad"></div>' +
-			'<a class="close" title="Close" href="#"><span>Close</span></a>' +
-			'</div>',
-		mercuryFooterHtml = '<div id="' + footerId + '">' +
+		footerHtml = '<div id="' + footerId + '">' +
 			'<div class="background"></div>' +
 			'<div class="ad"></div>' +
 			'<a class="close" title="Close" href="#">' +
 			'<svg role="img" class="ads-floor-close-button"><use xlink:href="#close"></use></svg>' +
 			'</a>' +
-			'</div>';
+			'</div>',
+		$ = $ || win.$;
 
 	/**
 	 * Show the floor ad.
@@ -53,15 +45,10 @@ define('ext.wikia.adEngine.template.floor', [
 				height: params.height
 			}),
 			skin = adContext.getContext().targeting.skin,
-			$footer;
+			$footer = $(footerHtml);
 
 		if (skin === 'oasis') {
-			$footer = $(oasisFooterHtml);
 			win.WikiaBar.hideContainer();
-		}
-
-		if (skin === 'mercury') {
-			$footer = $(mercuryFooterHtml);
 		}
 
 		$footer.find('a.close').click(function (event) {

--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -748,6 +748,7 @@ $config['mercury_ads_js'] = array(
 		'//extensions/wikia/AbTesting/js/AbTest.js',
 		'//resources/wikia/modules/abTest.js',
 		'//extensions/wikia/AdEngine/js/CustomAdsLoader.js',
+		'//extensions/wikia/AdEngine/js/template/floor.js',
 		'//extensions/wikia/AdEngine/js/template/modal.js',
 		'//resources/wikia/modules/krux.js',
 

--- a/skins/oasis/css/core/ads-floor.scss
+++ b/skins/oasis/css/core/ads-floor.scss
@@ -17,7 +17,7 @@ $close-image: '/resources/wikia/ui_components/modal/images/close-light.svg';
 		position: absolute;
 		right: 0;
 
-		span {
+		.ads-floor-close-button {
 			@include image-replacement();
 			background: url($close-image);
 			background-size: 20px 20px;


### PR DESCRIPTION
We want a new ad product on all skins: Oasis (desktop, tablet) and Mercury (mobile). It's already working on Oasis and to make it working on mobile we needed small changes:
- send requests to DFP for new mobile slot `INVISIBLE_HIGH_IMPACT`,
- customize `floor.js` so it can work nicely on both skins.

Connected to PR: https://github.com/Wikia/mercury/pull/697
