### PR TITLE
CE-1626 Adding extension that places redirect on Special:Insights...

### DIFF
--- a/extensions/wikia/Insights/Insights.setup.php
+++ b/extensions/wikia/Insights/Insights.setup.php
@@ -31,7 +31,6 @@ $wgAutoloadClasses['QueryPagesModel'] = $dir . 'models/QueryPagesModel.php';
 
 //special page
 $wgSpecialPages['Insights'] = 'InsightsController';
-$wgSpecialPageGroups['EditHub'] = 'wikia';
 
 //message files
 $wgExtensionMessagesFiles['Insights'] = $dir . 'Insights.i18n.php';

--- a/extensions/wikia/InsightsBlogpostRedirect/InsightsBlogpostRedirect.i18n.php
+++ b/extensions/wikia/InsightsBlogpostRedirect/InsightsBlogpostRedirect.i18n.php
@@ -1,0 +1,13 @@
+<?php
+
+$messages = [];
+
+$messages['en'] = [
+	'insightsblogpostredirect-desc' => 'This is small extension that redirects Special:Insights to community blogpost about Insights tool on wikias that don\'t have it enabled yet',
+	'insights-blogpost-url' => 'http://community.wikia.com',
+];
+
+$messages['qqq'] = [
+	'insightsblogpostredirect-desc' => 'Insights redirect extension description',
+	'insights-blogpost-url' => 'Url to blogpost about introducing Insights feature',
+];

--- a/extensions/wikia/InsightsBlogpostRedirect/InsightsBlogpostRedirect.setup.php
+++ b/extensions/wikia/InsightsBlogpostRedirect/InsightsBlogpostRedirect.setup.php
@@ -23,7 +23,6 @@ $wgAutoloadClasses['InsightsBlogpostRedirectController'] = $dir . 'InsightsBlogp
 
 //special page
 $wgSpecialPages['Insights'] = 'InsightsBlogpostRedirectController';
-$wgSpecialPageGroups['EditHub'] = 'wikia';
 
 //message files
 $wgExtensionMessagesFiles['InsightsBlogpostRedirect'] = $dir . 'InsightsBlogpostRedirect.i18n.php';

--- a/extensions/wikia/InsightsBlogpostRedirect/InsightsBlogpostRedirect.setup.php
+++ b/extensions/wikia/InsightsBlogpostRedirect/InsightsBlogpostRedirect.setup.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * InsightsBlogpostRedirect
+ *
+ * @author Kamil Koterba <kamil@wikia-inc.com>
+ */
+
+$dir = dirname(__FILE__) . '/';
+
+$wgExtensionCredits['specialpage'][] = [
+	'name' => 'InsightsBlogpostRedirect',
+	'descriptionmsg' => 'insightsblogpostredirect-desc',
+	'authors' => [
+		'Kamil Koterba <kamil@wikia-inc.com>',
+	],
+	'version' => 1.0,
+	'url' => 'https://github.com/Wikia/app/tree/dev/extensions/wikia/InsightsBlogpostRedirect'
+];
+
+//classes
+$wgAutoloadClasses['InsightsBlogpostRedirectController'] = $dir . 'InsightsBlogpostRedirectController.class.php';
+
+//special page
+$wgSpecialPages['Insights'] = 'InsightsBlogpostRedirectController';
+$wgSpecialPageGroups['EditHub'] = 'wikia';
+
+//message files
+$wgExtensionMessagesFiles['InsightsBlogpostRedirect'] = $dir . 'InsightsBlogpostRedirect.i18n.php';

--- a/extensions/wikia/InsightsBlogpostRedirect/InsightsBlogpostRedirectController.class.php
+++ b/extensions/wikia/InsightsBlogpostRedirect/InsightsBlogpostRedirectController.class.php
@@ -1,0 +1,13 @@
+<?php
+
+class InsightsBlogpostRedirectController extends WikiaSpecialPageController {
+
+	public function __construct() {
+		parent::__construct( 'Insights', 'insights', true );
+	}
+
+	public function index() {
+		$this->wg->Out->redirect( wfMessage('insights-blogpost-url')->escaped() );
+	}
+
+}


### PR DESCRIPTION
...to community blogpost

https://wikia-inc.atlassian.net/browse/CE-1626

It allows to put blogpost url in message 'insights-blogpost-url'
related Config change: https://github.com/Wikia/config/pull/1059

@Wikia/community-engineering 
