### PR TITLE
SOC-628 Make sure to construct the icon URLs we use so we can update and cache bust them

### DIFF
--- a/extensions/wikia/Email/Email.setup.php
+++ b/extensions/wikia/Email/Email.setup.php
@@ -23,6 +23,7 @@ $dir = dirname( __FILE__ ) . '/';
  * classes
  */
 $wgAutoloadClasses['Email\EmailController'] =  $dir . 'EmailController.class.php';
+$wgAutoloadClasses['Email\ImageHelper'] =  $dir . 'EmailImageHelper.class.php';
 $wgAutoloadClasses['Email\ControllerException'] =  $dir . 'EmailExceptions.class.php';
 $wgAutoloadClasses['Email\Fatal'] =  $dir . 'EmailExceptions.class.php';
 $wgAutoloadClasses['Email\Check'] =  $dir . 'EmailExceptions.class.php';

--- a/extensions/wikia/Email/EmailController.class.php
+++ b/extensions/wikia/Email/EmailController.class.php
@@ -131,15 +131,7 @@ abstract class EmailController extends \WikiaController {
 	 * @template main
 	 */
 	public function main() {
-		$this->response->setValues( [
-			'content' => $this->getVal( 'content' ),
-			'footerMessages' => $this->getVal( 'footerMessages' ),
-			'marketingFooter' => $this->getVal( 'marketingFooter' ),
-			'tagline' => $this->getVal( 'tagline' ),
-			'useTrademark' => $this->getVal( 'useTrademark' ),
-			'socialMessages' => $this->request->getVal( 'socialMessages' ),
-			'hubsMessages' => $this->request->getVal( 'hubsMessages' ),
-		] );
+		$this->response->setValues( $this->request->getParams() );
 	}
 
 	/**
@@ -223,6 +215,7 @@ abstract class EmailController extends \WikiaController {
 				'useTrademark' => $this->getUseTrademark(),
 				'hubsMessages' => $this->getHubsMessages(),
 				'socialMessages' => $this->getSocialMessages(),
+				'icons' => ImageHelper::getIconInfo(),
 			]
 		);
 

--- a/extensions/wikia/Email/EmailImageHelper.class.php
+++ b/extensions/wikia/Email/EmailImageHelper.class.php
@@ -8,6 +8,10 @@ namespace Email;
  * @package Email
  */
 class ImageHelper {
+
+	// Cache icon information for a day
+	const ICON_CACHE_TTL = 86400;
+
 	static public $icons = [
 		'Wikia',
 		'Comics',
@@ -30,19 +34,38 @@ class ImageHelper {
 		$info = [];
 
 		foreach ( self::$icons as $name ) {
+			$fileInfo = self::getFileInfo( $name );
+			$info[$name] = $fileInfo;
+		}
+
+		return $info;
+	}
+
+	protected static function getFileInfo( $name ) {
+		$key = self::getFileKey( $name );
+		$memc = \F::app()->wg->Memc;
+
+		$info = $memc->get( $key );
+		if ( empty( $info ) ) {
 			$file   = \GlobalFile::newFromText( $name . '.gif', \Wikia::NEWSLETTER_WIKI_ID );
 			$width  = $file->getWidth();
 			$height = $file->getHeight();
 			$url    = $file->getUrlGenerator()->url();
 
-			$info[$name] = [
-				'name' => $name,
-				'url' => $url,
+			$info = [
+				'name'   => $name,
+				'url'    => $url,
 				'height' => $height,
-				'width' => $width,
+				'width'  => $width,
 			];
+
+			$memc->set( $key, $info, self::ICON_CACHE_TTL );
 		}
 
 		return $info;
+	}
+
+	protected static function getFileKey( $name ) {
+		return wfSharedMemcKey( 'Email', 'ImageHelper', 'icon', $name );
 	}
 }

--- a/extensions/wikia/Email/EmailImageHelper.class.php
+++ b/extensions/wikia/Email/EmailImageHelper.class.php
@@ -42,25 +42,20 @@ class ImageHelper {
 	}
 
 	protected static function getFileInfo( $name ) {
-		$key = self::getFileKey( $name );
-		$memc = \F::app()->wg->Memc;
+		$info = \WikiaDataAccess::cache(
+			self::getFileKey( $name ),
+			self::ICON_CACHE_TTL,
+			function() use ( $name ) {
+				$file = \GlobalFile::newFromText( $name . '.gif', \Wikia::NEWSLETTER_WIKI_ID );
 
-		$info = $memc->get( $key );
-		if ( empty( $info ) ) {
-			$file   = \GlobalFile::newFromText( $name . '.gif', \Wikia::NEWSLETTER_WIKI_ID );
-			$width  = $file->getWidth();
-			$height = $file->getHeight();
-			$url    = $file->getUrlGenerator()->url();
-
-			$info = [
-				'name'   => $name,
-				'url'    => $url,
-				'height' => $height,
-				'width'  => $width,
-			];
-
-			$memc->set( $key, $info, self::ICON_CACHE_TTL );
-		}
+				return [
+					'name'   => $name,
+					'url'    => $file->getUrlGenerator()->url(),
+					'height' => $file->getHeight(),
+					'width'  => $file->getWidth(),
+				];
+			}
+		);
 
 		return $info;
 	}

--- a/extensions/wikia/Email/EmailImageHelper.class.php
+++ b/extensions/wikia/Email/EmailImageHelper.class.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Email;
+
+/**
+ * Class ImageHelper
+ *
+ * @package Email
+ */
+class ImageHelper {
+	static public $icons = [
+		'Wikia',
+		'Comics',
+		'Movies',
+		'Lifestyle',
+		'Music',
+		'Books',
+		'TV',
+		'Twitter',
+		'Facebook',
+		'YouTube',
+	];
+
+	/**
+	 * Get URL, size and name information about icons created in the newsletter wikia for our emails
+	 *
+	 * @return array
+	 */
+	public static function getIconInfo() {
+		$info = [];
+
+		foreach ( self::$icons as $name ) {
+			$file   = \GlobalFile::newFromText( $name . '.gif', \Wikia::NEWSLETTER_WIKI_ID );
+			$width  = $file->getWidth();
+			$height = $file->getHeight();
+			$url    = $file->getUrlGenerator()->url();
+
+			$info[$name] = [
+				'name' => $name,
+				'url' => $url,
+				'height' => $height,
+				'width' => $width,
+			];
+		}
+
+		return $info;
+	}
+}

--- a/extensions/wikia/Email/templates/main.mustache
+++ b/extensions/wikia/Email/templates/main.mustache
@@ -12,7 +12,7 @@
 				<div class="content">
 					<div class="header content-inner">
 						<a href="http://www.wikia.com" class="logo">
-							<img src="http://vignette3.wikia.nocookie.net/wikianewsletter/images/8/89/Wikia.gif/revision/latest?cb=20150330185243" alt="Wikia">
+                            {{# icons.Wikia}}<img src="{{url}}" width="{{width}}" height="{{height}}" alt="Wikia">{{/ icons.Wikia}}
 						</a>
 					</div>
 				</div>
@@ -42,44 +42,45 @@
 						<p>{{tagline}}{{#useTrademark}}<sup>TM</sup>{{/useTrademark}}</p>
 						<div class="hubs">
 							<a href="{{hubsMessages.comicsURL}}">
-								{{# marketingFooter}}<img src="http://vignette1.wikia.nocookie.net/wikianewsletter/images/e/e3/Comics.gif/revision/latest?cb=20150330185129" class="hub-icon">{{/ marketingFooter}}
+								{{# marketingFooter}}{{# icons.Comics}}<img src="{{url}}" width="{{width}}" height="{{height}}" class="hub-icon">{{/ icons.Comics}}{{/ marketingFooter}}
 								{{hubsMessages.comics}}
 							</a>
 							<a href="{{hubsMessages.videoGamesURL}}">
-								{{# marketingFooter}}<img src="http://vignette1.wikia.nocookie.net/wikianewsletter/images/e/e8/Games.gif/revision/latest?cb=20150330185144" class="hub-icon">{{/ marketingFooter}}
+								{{# marketingFooter}}{{# icons.Games}}<img src="{{url}}" width="{{width}}" height="{{height}}" class="hub-icon">{{/ icons.Games}}{{/ marketingFooter}}
 								{{hubsMessages.videoGames}}
 							</a>
 							<a href="{{hubsMessages.moviesURL}}">
-								{{# marketingFooter}}<img src="http://vignette1.wikia.nocookie.net/wikianewsletter/images/b/bf/Movies.gif/revision/latest?cb=20150330185202" class="hub-icon">{{/ marketingFooter}}
+								{{# marketingFooter}}{{# icons.Movies}}<img src="{{url}}" width="{{width}}" height="{{height}}" class="hub-icon">{{/ icons.Movies}}{{/ marketingFooter}}
 								{{hubsMessages.movies}}
 							</a>
 							<a href="{{hubsMessages.lifestyleURL}}">
-								{{# marketingFooter}}<img src="http://vignette4.wikia.nocookie.net/wikianewsletter/images/6/60/Lifestyle.gif/revision/latest?cb=20150330185152" class="hub-icon">{{/ marketingFooter}}
+								{{# marketingFooter}}{{# icons.Lifestyle}}<img src="{{url}}" width="{{width}}" height="{{height}}" class="hub-icon">{{/ icons.Lifestyle}}{{/ marketingFooter}}
 								{{hubsMessages.lifestyle}}
 							</a>
 							<a href="{{hubsMessages.musicURL}}">
-								{{# marketingFooter}}<img src="http://vignette4.wikia.nocookie.net/wikianewsletter/images/f/fb/Music.gif/revision/latest?cb=20150330185211" class="hub-icon">{{/ marketingFooter}}
+								{{# marketingFooter}}{{# icons.Music}}<img src="{{url}}" width="{{width}}" height="{{height}}" class="hub-icon">{{/ icons.Music}}{{/ marketingFooter}}
 								{{hubsMessages.music}}
 							</a>
 							<a href="{{hubsMessages.booksURL}}">
-								{{# marketingFooter}}<img src="http://vignette4.wikia.nocookie.net/wikianewsletter/images/c/c2/Books.gif/revision/latest?cb=20150330185117" class="hub-icon">{{/ marketingFooter}}
+								{{# marketingFooter}}{{# icons.Books}}<img src="{{url}}" width="{{width}}" height="{{height}}" class="hub-icon">{{/ icons.Books}}{{/ marketingFooter}}
 								{{hubsMessages.books}}
 							</a>
 							<a href="{{hubsMessages.tvURL}}">
-								{{# marketingFooter}}<img src="http://vignette1.wikia.nocookie.net/wikianewsletter/images/c/c5/TV.gif/revision/latest?cb=20150330185219" class="hub-icon">{{/ marketingFooter}}
+								{{# marketingFooter}}{{# icons.TV}}<img src="{{url}}" width="{{width}}" height="{{height}}" class="hub-icon">{{/ icons.TV}}{{/ marketingFooter}}
 								{{hubsMessages.tv}}
 							</a>
 						</div>
 						<p class="social-links">
 							<a href="{{socialMessages.twitter-link}}" >
-								<img src="http://vignette3.wikia.nocookie.net/wikianewsletter/images/8/88/Twitter.gif/revision/latest?cb=20150330185235" alt="{{socialMessages.twitter}}">
+                                {{# icons.Twitter}}<img src="{{url}}" width="{{width}}" height="{{height}}" alt="{{socialMessages.twitter}}">{{/ icons.Twitter}}
 							</a>
 							<a href="{{socialMessages.facebook-link}}" >
-								<img src="http://vignette2.wikia.nocookie.net/wikianewsletter/images/a/ad/Facebook.gif/revision/latest?cb=20150330185226" alt="{{socialMessages.facebook}}">
+                                {{# icons.Facebook}}<img src="{{url}}" width="{{width}}" height="{{height}}" alt="{{socialMessages.facebook}}">{{/ icons.Facebook}}
 							</a>
 							<a href="{{socialMessages.youtube-link}}" >
-								<img src="http://vignette4.wikia.nocookie.net/wikianewsletter/images/1/12/You-Tube.gif/revision/latest?cb=20150330185252" alt="{{socialMessages.youtube}}">
+                                {{# icons.YouTube}}<img src="{{url}}" width="{{width}}" height="{{height}}" alt="{{socialMessages.youtube}}">{{/ icons.YouTube}}
 							</a>
+                            <pre>{{iconURL}}</pre>
 						</p>
 
 						{{#footerMessages}}

--- a/extensions/wikia/Email/templates/main.mustache
+++ b/extensions/wikia/Email/templates/main.mustache
@@ -80,7 +80,6 @@
 							<a href="{{socialMessages.youtube-link}}" >
                                 {{# icons.YouTube}}<img src="{{url}}" width="{{width}}" height="{{height}}" alt="{{socialMessages.youtube}}">{{/ icons.YouTube}}
 							</a>
-                            <pre>{{iconURL}}</pre>
 						</p>
 
 						{{#footerMessages}}

--- a/extensions/wikia/Email/tests/EmailIntegrationTest.php
+++ b/extensions/wikia/Email/tests/EmailIntegrationTest.php
@@ -13,30 +13,16 @@ class EmailIntegrationTest extends WikiaBaseTest {
 	}
 
 	/**
-	 * We've hard-coded some image URLs into the HTML emails, so let's make sure they are where we expect them to be
-	 *
-	 * @param string $name Image identifier
-	 * @param string $url URL for accessing image
-	 * @dataProvider emailImagesDataProvider
+	 * Make sure all the images we're using exist
 	 */
-	public function testEmailImages( $name, $url ) {
-		$response = HTTP::get( $url );
-		$this->assertTrue($response !== false, "{$name} should return HTTP 200");
-	}
+	public function testEmailImages() {
+		$icons = Email\ImageHelper::getIconInfo();
 
-	public function emailImagesDataProvider() {
-		return [
-			['wikia image', 'http://vignette3.wikia.nocookie.net/wikianewsletter/images/8/89/Wikia.gif/revision/latest?cb=20150330185243'],
-			['comics image', 'http://vignette1.wikia.nocookie.net/wikianewsletter/images/e/e3/Comics.gif/revision/latest?cb=20150330185129'],
-			['games image', 'http://vignette1.wikia.nocookie.net/wikianewsletter/images/e/e8/Games.gif/revision/latest?cb=20150330185144'],
-			['movies image', 'http://vignette1.wikia.nocookie.net/wikianewsletter/images/b/bf/Movies.gif/revision/latest?cb=20150330185202'],
-			['lifestyle image', 'http://vignette4.wikia.nocookie.net/wikianewsletter/images/6/60/Lifestyle.gif/revision/latest?cb=20150330185152'],
-			['music image', 'http://vignette4.wikia.nocookie.net/wikianewsletter/images/f/fb/Music.gif/revision/latest?cb=20150330185211'],
-			['books image', 'http://vignette4.wikia.nocookie.net/wikianewsletter/images/c/c2/Books.gif/revision/latest?cb=20150330185117'],
-			['tv image', 'http://vignette1.wikia.nocookie.net/wikianewsletter/images/c/c5/TV.gif/revision/latest?cb=20150330185219'],
-			['twitter image', 'http://vignette3.wikia.nocookie.net/wikianewsletter/images/8/88/Twitter.gif/revision/latest?cb=20150330185235'],
-			['youtube image', 'http://vignette4.wikia.nocookie.net/wikianewsletter/images/1/12/You-Tube.gif/revision/latest?cb=20150330185252'],
-			['facebook image', 'http://vignette2.wikia.nocookie.net/wikianewsletter/images/a/ad/Facebook.gif/revision/latest?cb=20150330185226'],
-		];
+		foreach ( $icons as $info ) {
+			$url = $info['url'];
+			$name = $info['name'];
+			$response = HTTP::get( $url );
+			$this->assertTrue( $response !== false, "{$name} should return HTTP 200" );
+		}
 	}
 }

--- a/includes/wikia/GlobalFile.class.php
+++ b/includes/wikia/GlobalFile.class.php
@@ -49,6 +49,8 @@ class GlobalFile extends WikiaObject implements UrlGeneratorInterface {
 	 *
 	 * @param string $title file name
 	 * @param int $wikiId city ID
+	 *
+	 * @return GlobalFile
 	 */
 	static public function newFromText($title, $wikiId) {
 		$title = GlobalTitle::newFromText($title, NS_FILE, $wikiId);

--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -69,7 +69,10 @@ $wgHooks['LocalFilePurgeThumbnailsUrls'][] = 'Wikia::onLocalFilePurgeThumbnailsU
 class Wikia {
 
 	const REQUIRED_CHARS = '0123456789abcdefG';
-	const COMMUNITY_WIKI_ID = 177;
+
+	const COMMUNITY_WIKI_ID = 177; // community.wikia.com
+	const NEWSLETTER_WIKI_ID = 223496; // wikianewsletter.wikia.com
+
 	const FAVICON_URL_CACHE_KEY = 'favicon-v1';
 
 	private static $vars = array();


### PR DESCRIPTION
Also, add an explicit height and width in case (as has happened for some reason) the default image URL gets cached with a larger size.

https://wikia-inc.atlassian.net/browse/SOC-628
