### PR TITLE
PLATFORM-1169: do not report negative times from ResourceTiming + cached DNS calls

### DIFF
--- a/extensions/wikia/Bucky/js/bucky_resources_timing.js
+++ b/extensions/wikia/Bucky/js/bucky_resources_timing.js
@@ -168,8 +168,11 @@ define('bucky.resourceTiming', ['jquery', 'wikia.window', 'wikia.log', 'bucky'],
 			for (subkey in stats[key]) {
 				value = Math.round(stats[key][subkey]);
 
-				sink.store(key + '.' + subkey, value);
-				debug(key + '.' + subkey, value);
+				// do not report negative values (PLATFORM-)
+				if (value >= 0) {
+					sink.store(key + '.' + subkey, value);
+					debug(key + '.' + subkey, value);
+				}
 			}
 		}
 	}

--- a/extensions/wikia/Bucky/js/bucky_resources_timing.js
+++ b/extensions/wikia/Bucky/js/bucky_resources_timing.js
@@ -90,6 +90,7 @@ define('bucky.resourceTiming', ['jquery', 'wikia.window', 'wikia.log', 'bucky'],
 			'total',
 			'cached',
 			'dns',
+			'dns-cached',
 			'3rdparty',
 			'css',
 			'link',
@@ -127,7 +128,14 @@ define('bucky.resourceTiming', ['jquery', 'wikia.window', 'wikia.log', 'bucky'],
 				// count DNS calls and report the time
 				dnsTime = res.domainLookupStart ? res.domainLookupEnd - res.domainLookupStart : false;
 				if (dnsTime !== false) {
-					addStatsEntry('dns', dnsTime);
+					if (dnsTime === 0) {
+						addStatsEntry('dns-cached', dnsTime);
+					}
+					else {
+						addStatsEntry('dns', dnsTime);
+					}
+
+					debug('DNS', {dnsTime: dnsTime, url: res.name});
 				}
 
 				// browser cache hit

--- a/extensions/wikia/Bucky/js/spec/bucky_resources_timing.spec.js
+++ b/extensions/wikia/Bucky/js/spec/bucky_resources_timing.spec.js
@@ -19,6 +19,7 @@ describe('BuckyResourcesTiming', function () {
 		var resourcesTiming = getModule(),
 			urls = {
 				// Wikia assets
+				'http://vignette1.wikia.nocookie.net/nordycka/images/d/d7/Mykines_2.jpg/revision/latest/scale-to-width/300?cb=20141031093541&path-prefix=pl': true,
 				'http://img4.wikia.nocookie.net/__cb4/nordycka/pl/images/b/bc/Wiki.png': true,
 				'http://slot1.images2.wikia.nocookie.net/__am/1418375407/sasses/foo/extensions/wikia/Qualaroo/css/Qualaroo.scss': true,
 				'http://nordycka.wikia.com/__load/-/cb%3D1418375407%26debug%3Dfalse%26lang%3Dpl%26only%3Dstyles%26skin%3Doasis/site': true,


### PR DESCRIPTION
```
site> select key, value, userAgent from rum_metrics_resource_timing where time > now() - 5m and key = 'WindowLoad.total.time' and value < 0 limit 50
┌──────────────────┬─────────────────┬───────────────────────┬──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┬───────────┐
│       time       │ sequence_number │ key                   │ userAgent                                                                                                                                        │ value     │
├──────────────────┼─────────────────┼───────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼───────────┤
│ 21/4/15 15:04:34 │ 12375150001     │ WindowLoad.total.time │ Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1848.0 Safari/537.36                                      │ -2522211  │
│ 21/4/15 15:04:31 │ 12226910001     │ WindowLoad.total.time │ Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.117 Safari/537.36                                    │ -12943069 │
│ 21/4/15 15:04:22 │ 11845450001     │ WindowLoad.total.time │ Mozilla/5.0 (Linux; Android 4.4.3; KFAPWI Build/KTU84M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36                │ -63155142 │
│ 21/4/15 15:04:03 │ 11026000001     │ WindowLoad.total.time │ Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1848.0 Safari/537.36                                      │ -2063990  │
│ 21/4/15 15:03:43 │ 10049070001     │ WindowLoad.total.time │ Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.131 Safari/537.36                                    │ -11647037 │
```

@wladekb / @jcellary / @harnash 
