### PR TITLE
WikiService::getTopEditors - improve DB profiling

### DIFF
--- a/includes/wikia/services/WikiService.class.php
+++ b/includes/wikia/services/WikiService.class.php
@@ -228,9 +228,10 @@ class WikiService extends WikiaModel {
 			wfSharedMemcKey( 'wiki_top_editors', $wikiId, $excludeBots ),
 			static::TOPUSER_CACHE_VALID,
 			function() use ( $wikiId, $excludeBots, $fname ) {
+				global $wgSpecialsDB;
 				$topEditors = array();
 
-				$db = wfGetDB( DB_SLAVE, array(), 'specials' );
+				$db = wfGetDB( DB_SLAVE, array(), $wgSpecialsDB );
 
 				$result = $db->select(
 					array( 'events_local_users' ),

--- a/includes/wikia/services/WikiService.class.php
+++ b/includes/wikia/services/WikiService.class.php
@@ -222,11 +222,12 @@ class WikiService extends WikiaModel {
 		wfProfileIn( __METHOD__ );
 
 		$wikiId = ( empty($wikiId) ) ? $this->wg->CityId : $wikiId ;
+		$fname = __METHOD__;
 
 		$topEditors = WikiaDataAccess::cache(
 			wfSharedMemcKey( 'wiki_top_editors', $wikiId, $excludeBots ),
 			static::TOPUSER_CACHE_VALID,
-			function() use ( $wikiId, $excludeBots ) {
+			function() use ( $wikiId, $excludeBots, $fname ) {
 				$topEditors = array();
 
 				$db = wfGetDB( DB_SLAVE, array(), 'specials' );
@@ -235,7 +236,7 @@ class WikiService extends WikiaModel {
 					array( 'events_local_users' ),
 					array( 'user_id', 'edits', 'all_groups' ),
 					array( 'wiki_id' => $wikiId, 'edits != 0' ),
-					__METHOD__,
+					$fname,
 					array( 'ORDER BY' => 'edits desc', 'LIMIT' => static::TOPUSER_LIMIT )
 				);
 


### PR DESCRIPTION
Log `WikiService::getTopEditors` instead of `WikiService::{closure}` as a method that sent the query.
- use `$wgSpecialsDB` instead of a hardcoded string

@owend / @michalroszka 
