### PR TITLE
SOC-683 Use unset() directly on global var

### DIFF
--- a/extensions/wikia/UserLogin/UserSignupSpecialController.class.php
+++ b/extensions/wikia/UserLogin/UserSignupSpecialController.class.php
@@ -652,10 +652,12 @@ class UserSignupSpecialController extends WikiaSpecialPageController {
 	 * Disables User Signup Captcha for automated tests, mobile skin, and sites such as internal
 	 */
 	private function disableCaptcha() {
+		global $wgHooks;
+
 		// Remove hook function
-		$hookArrayKey = array_search( 'Captcha\Hooks::confirmUserCreate', $this->wg->Hooks['AbortNewAccount'] );
+		$hookArrayKey = array_search( 'Captcha\Hooks::confirmUserCreate', $wgHooks['AbortNewAccount'] );
 		if ( $hookArrayKey !== false ) {
-			unset( $this->wg->Hooks['AbortNewAccount'][$hookArrayKey] );
+			unset( $wgHooks['AbortNewAccount'][$hookArrayKey] );
 		}
 		$this->wg->Out->addJsConfigVars( [
 			'wgUserSignupDisableCaptcha' => true


### PR DESCRIPTION
Currently it's not possible to unset an array value using $this->wg->Global from a controller, because it doesn't have a reference to the actual $wgGlobal var. I didn't see any applicable function in WikiaGlobalRegistry to handle a case like this, so I changed the code to directly reference the global variable.

https://wikia-inc.atlassian.net/browse/SOC-683
