### PR TITLE
(CE-1534) Add undeleted images back to the image review queue

### DIFF
--- a/extensions/wikia/Scribe/ScribeEventProducer.class.php
+++ b/extensions/wikia/Scribe/ScribeEventProducer.class.php
@@ -183,7 +183,7 @@ class ScribeEventProducer {
 		return $logid;
 	}
 
-	public function buildUndeletePackage( $oTitle ) {
+	public function buildUndeletePackage( $oTitle, $created = false ) {
 		wfProfileIn( __METHOD__ );
 
 		if ( !is_object( $oTitle ) ) {
@@ -193,7 +193,7 @@ class ScribeEventProducer {
 		}
 
 		$oPage = WikiPage::factory( $oTitle );
-		if ( !$oPage instanceof Article ) {
+		if ( !$oPage instanceof WikiPage ) {
 			Wikia::log( __METHOD__, "error", "Cannot send log using scribe ({$this->app->wg->CityId}): invalid WikiPage object" );
 			wfProfileOut( __METHOD__ );
 			return true;
@@ -213,9 +213,14 @@ class ScribeEventProducer {
 			return true;
 		}
 
+		$oLocalFile = null;
+		if ( $created && $oTitle->getNamespace() == NS_FILE ) {
+			$oLocalFile = wfLocalFile( $oTitle );
+		}
+
 		wfProfileOut( __METHOD__ );
 
-		return $this->buildEditPackage( $oPage, $oUser );
+		return $this->buildEditPackage( $oPage, $oUser, null, null, $oLocalFile );
 	}
 
 	public function buildMovePackage( $oTitle, $oUser, $page_id = null, $redirect_id = null ) {

--- a/extensions/wikia/Scribe/ScribeEventProducerController.class.php
+++ b/extensions/wikia/Scribe/ScribeEventProducerController.class.php
@@ -126,12 +126,12 @@ class ScribeEventProducerController {
 		return true;
 	}
 
-	static public function onArticleUndelete( &$oTitle, $is_new = false ) {
+	static public function onArticleUndelete( &$oTitle, $created = false ) {
 		wfProfileIn( __METHOD__ );
 
  		$oScribeProducer = new ScribeEventProducer( 'undelete' );
 		if ( is_object( $oScribeProducer ) ) {
-			if ( $oScribeProducer->buildUndeletePackage( $oTitle ) ) {
+			if ( $oScribeProducer->buildUndeletePackage( $oTitle, $created ) ) {
 				$oScribeProducer->sendLog();
 			}
 		}


### PR DESCRIPTION
When a deleted file is undeleted, it should be readded to the image review
queue. This adds the image data with the undeletion and fixes a bug in the
undeletion event due to incorrectly checking for an instance of Article.

Tested on sandbox.

/cc @Wikia/community-engineering 
