### PR TITLE
SOC-579 Fix strict warning for extra function param

### DIFF
--- a/includes/wikia/WikiaSQL.class.php
+++ b/includes/wikia/WikiaSQL.class.php
@@ -26,7 +26,7 @@ class WikiaSQL extends FluentSql\SQL {
 
 	protected function getCacheKey(sql\Breakdown $breakDown) {
 		$cache = $this->getCache();
-		return $cache->generateKey($breakDown, $this->useSharedMemKey);
+		return $cache->generateKey( $breakDown );
 	}
 
 	protected function query($db, sql\Breakdown $breakDown, $autoIterate, callable $callback=null) {
@@ -44,7 +44,7 @@ class WikiaSQL extends FluentSql\SQL {
 		static $cache = null;
 
 		if ($cache === null) {
-			$cache = new WikiaSQLCache();
+			$cache = new WikiaSQLCache( $this->useSharedMemKey );
 		}
 
 		return $cache;

--- a/includes/wikia/WikiaSQLCache.class.php
+++ b/includes/wikia/WikiaSQLCache.class.php
@@ -9,7 +9,7 @@
 
 class WikiaSQLCache extends FluentSql\Cache\Cache {
 	/** @var bool */
-	private $useSharedKey = false;
+	private $useSharedKey;
 
 	/**
 	 * @param bool $useSharedKey Whether or not this memcache key is shared amongst wikis

--- a/includes/wikia/WikiaSQLCache.class.php
+++ b/includes/wikia/WikiaSQLCache.class.php
@@ -8,12 +8,21 @@
  */
 
 class WikiaSQLCache extends FluentSql\Cache\Cache {
+	/** @var bool */
+	private $useSharedKey = false;
+
+	/**
+	 * @param bool $useSharedKey Whether or not this memcache key is shared amongst wikis
+	 */
+	public function __construct( $useSharedKey=false ) {
+		$this->useSharedKey = $useSharedKey;
+	}
+
 	/**
 	 * @param \FluentSql\Breakdown $breakDown
-	 * @param bool $sharedKey whether or not this memkey is shared amongst wikis
-	 * @return string a memcache key to use
+	 * @return string A memcache key to use
 	 */
-	public function generateKey(\FluentSql\Breakdown $breakDown, $sharedKey) {
+	public function generateKey( \FluentSql\Breakdown $breakDown ) {
 		$stack = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 4);
 		$keyArgs = ['sql-cache'];
 
@@ -30,7 +39,7 @@ class WikiaSQLCache extends FluentSql\Cache\Cache {
 		}
 
 		$keyArgs []= parent::generateKey($breakDown);
-		$func = $sharedKey ? 'wfSharedMemcKey' : 'wfMemcKey';
+		$func = $this->useSharedKey ? 'wfSharedMemcKey' : 'wfMemcKey';
 
 		return call_user_func_array($func, $keyArgs);
 	}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SOC-579

This change fixes a strict standards warning:
`Strict standards: Declaration of WikiaSQLCache::generateKey() should be compatible with FluentSql\Cache\Cache::generateKey(FluentSql\Breakdown $breakDown) in /usr/wikia/source/app/includes/wikia/WikiaSQLCache.class.php on line 10`

I've borrowed the fix made by @nmonterroso here, https://github.com/Wikia/app/commit/5a2919411f72541ab5bd9b2fd1970e7f7e4e7c81, which was later reverted.
