### PR TITLE
HG-600: Add information about section indexes to WikiaMobile and ArticleAsJson output

### DIFF
--- a/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php
+++ b/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php
@@ -7,7 +7,7 @@ class ArticleAsJson extends WikiaService {
 		'imageMaxWidth' => false
 	];
 
-	const CACHE_VERSION = '0.0.2';
+	const CACHE_VERSION = '0.0.3';
 
 	private static function createMarker( $width = 0, $height = 0, $isGallery = false ){
 		$blankImgUrl = F::app()->wg->blankImgUrl;

--- a/extensions/wikia/WikiaMobile/WikiaMobileHooks.class.php
+++ b/extensions/wikia/WikiaMobile/WikiaMobileHooks.class.php
@@ -164,17 +164,18 @@ class WikiaMobileHooks {
 	 * @return bool
 	 */
 	static public function onMakeHeadline( $skin, $level, $attribs, $anchor, $text, $link, $legacyAnchor, &$ret ){
+		global $wgArticleAsJson;
 		wfProfileIn( __METHOD__ );
 
 		if ( F::app()->checkSkin( 'wikiamobile', $skin ) ) {
-			//remove bold, italics, underline and anchor tags from section headings (also optimizes output size)
-			$text = preg_replace( '/<\/?(b|u|i|a|em|strong){1}(\s+[^>]*)*>/im', '', $text );
-
-            if ( F::app()->wg->User->isAnon() ) {
+			//retrieve section index from mw:editsection tag
+			preg_match( '#section="(.*?)"#', $link, $matches );
+			if ( $wgArticleAsJson || F::app()->wg->User->isAnon() ) {
 				$link = '';
 			}
-
-			$ret = "<h{$level} id='{$anchor}' {$attribs}{$text}{$link}</h{$level}>";
+			//remove bold, italics, underline and anchor tags from section headings (also optimizes output size)
+			$text = preg_replace( '/<\/?(b|u|i|a|em|strong){1}(\s+[^>]*)*>/im', '', $text );
+			$ret = "<h{$level} id='{$anchor}' section='{$matches[1]}' {$attribs}{$text}{$link}</h{$level}>";
 		}
 
 		wfProfileOut( __METHOD__ );


### PR DESCRIPTION
Given the fact that WikiaMobile and ArticleAsJson are to be retired - and latter to be replaced by Article Service - this seems like a right solution

This change is also unifying output for ArticleAsJson so it does not depend on user state (logged in or out).
