### PR TITLE
PLATFORM-1192 batch refresh links for template throttling

### DIFF
--- a/includes/DefaultSettings.php
+++ b/includes/DefaultSettings.php
@@ -5618,7 +5618,7 @@ $wgJobRunRate = 1;
 /**
  * Number of rows to update per job
  */
-$wgUpdateRowsPerJob = 500;
+$wgUpdateRowsPerJob = 50;
 
 /**
  * Number of rows to update per query

--- a/includes/LinksUpdate.php
+++ b/includes/LinksUpdate.php
@@ -278,7 +278,6 @@ class LinksUpdate {
 
 	private function queueRefreshTasks( $batches ) {
 		global $wgCityId;
-		$legacyJobs = array();
 
 		foreach ( $batches as $batch ) {
 			list( $start, $end ) = $batch;
@@ -287,10 +286,6 @@ class LinksUpdate {
 			$task->wikiId( $wgCityId );
 			$task->call( 'refreshTemplateLinks', $start, $end );
 			$task->queue();
-		}
-
-		if ( !empty( $legacyJobs ) ) {
-			Job::batchInsert( $legacyJobs );
 		}
 
 	}

--- a/includes/LinksUpdate.php
+++ b/includes/LinksUpdate.php
@@ -286,6 +286,12 @@ class LinksUpdate {
 			$task->wikiId( $wgCityId );
 			$task->call( 'refreshTemplateLinks', $start, $end );
 			$task->queue();
+
+			Wikia\Logger\WikiaLogger::instance()->info( 'LinksUpdate::queueRefreshTasks', [
+				'title' => $this->mTitle->getPrefixedDBkey(),
+				'start' => $start,
+				'end' => $end,
+			] );
 		}
 
 	}

--- a/includes/wikia/tasks/Tasks/BaseTask.class.php
+++ b/includes/wikia/tasks/Tasks/BaseTask.class.php
@@ -143,6 +143,11 @@ abstract class BaseTask {
 	 * @return string|array the task's id or array of such IDs if the given wikiID is an array
 	 */
 	public function queue() {
+		$this->info( 'BaseTask::queue', [
+			'type' => get_class( $this ),
+			'backtrace' => new \Exception()
+		] );
+
 		$taskLists = $this->convertToTaskLists();
 		$taskIds = AsyncTaskList::batch( $taskLists );
 
@@ -388,6 +393,12 @@ abstract class BaseTask {
 			/** @var BaseTask $task $taskLists */
 			$taskLists = array_merge( $taskLists, $task->convertToTaskLists() );
 		}
+
+		\Wikia\Logger\WikiaLogger::instance()->info( 'BaseTask::batch', [
+			'tasks' => count( $tasks ),
+			'type' => get_class( reset( $tasks ) ),
+			'backtrace' => new \Exception()
+		] );
 
 		return AsyncTaskList::batch( $taskLists );
 	}

--- a/includes/wikia/tasks/Tasks/BaseTask.class.php
+++ b/includes/wikia/tasks/Tasks/BaseTask.class.php
@@ -96,6 +96,7 @@ abstract class BaseTask {
 			throw new \InvalidArgumentException;
 		}
 
+		$this->info( 'BaseTask::execute' );
 
 		try {
 			$result = call_user_func_array( [$this, $method], $args );
@@ -144,7 +145,7 @@ abstract class BaseTask {
 	 */
 	public function queue() {
 		$this->info( 'BaseTask::queue', [
-			'type' => get_class( $this ),
+			'task' => get_class( $this ),
 			'backtrace' => new \Exception()
 		] );
 
@@ -395,8 +396,8 @@ abstract class BaseTask {
 		}
 
 		\Wikia\Logger\WikiaLogger::instance()->info( 'BaseTask::batch', [
-			'tasks' => count( $tasks ),
-			'type' => get_class( reset( $tasks ) ),
+			'count' => count( $tasks ),
+			'task' => get_class( reset( $tasks ) ),
 			'backtrace' => new \Exception()
 		] );
 

--- a/includes/wikia/tasks/Tasks/BatchRefreshLinksForTemplate.class.php
+++ b/includes/wikia/tasks/Tasks/BatchRefreshLinksForTemplate.class.php
@@ -88,7 +88,12 @@ class BatchRefreshLinksForTemplate extends BaseTask {
 
 	protected function batchEnqueue( array $tasks ) {
 		if ( !empty( $tasks ) ) {
-			$this->info( sprintf( "batching %d jobs %d from %s between %d and %d", count( $tasks ), $this->getTaskId(), $this->title->getText(), $this->getStart(), $this->getEnd() ) );
+			$this->info( 'BatchRefreshLinksForTemplate::batchEnqueue', [
+				'tasks' => count( $tasks ),
+				'title' => $this->title->getText(),
+				'start' => $this->getStart(),
+				'end' => $this->getEnd()
+			] );
 			BaseTask::batch( $tasks );
 		}
 	}

--- a/includes/wikia/tasks/Tasks/BatchRefreshLinksForTemplate.class.php
+++ b/includes/wikia/tasks/Tasks/BatchRefreshLinksForTemplate.class.php
@@ -83,6 +83,9 @@ class BatchRefreshLinksForTemplate extends BaseTask {
 		$task->title( $title );
 		$task->call( 'refresh' );
 		$task->wikiId( $this->getWikiId() );
+
+		// TODO: delay the tasks - see PLATFORM-1192
+
 		return $task;
 	}
 

--- a/includes/wikia/tasks/Tasks/RefreshLinksForTitleTask.class.php
+++ b/includes/wikia/tasks/Tasks/RefreshLinksForTitleTask.class.php
@@ -44,6 +44,9 @@ class RefreshLinksForTitleTask extends BaseTask {
 		return \ParserOptions::newFromUserAndLang( new \User, $this->getLanguage() );
 	}
 
+	/**
+	 * @return \Parser
+	 */
 	protected function getParser() {
 		global $wgParser;
 		return $wgParser;


### PR DESCRIPTION
- decrease the value of `$wgUpdateRowsPerJob` to 50 - throttle tasks that parse the articles latest revision after a template edit
- improve logging around tasks queue pushing and execution

@michalroszka / @nmonterroso 
