### PR TITLE
SOC-701 Results count needs to be an integer

### DIFF
--- a/extensions/wikia/Blogs/BlogTemplate.php
+++ b/extensions/wikia/Blogs/BlogTemplate.php
@@ -951,7 +951,7 @@ class BlogTemplateClass {
 			__METHOD__
 		);
 
-		return $row ? $row : 0;
+		return $row ? (int)$row : 0;
 	}
 
 	private static function __makeRssOutput($aInput) {


### PR DESCRIPTION
This fixes https://wikia-inc.atlassian.net/browse/SOC-701

The BlogTemplate::getResultsCount() function was recently changed, and as a result returned a string instead of an integer. An integer is needed to be passed to Paginator::paginate() to calculate the number of pages. When a string was being passed, Paginator simply didn't attempt to create any pagination.

@armonr @jsutterfield Please review.
