### PR TITLE
(CE-1714) Fix removal of fixed items from Insights

### DIFF
--- a/extensions/wikia/Insights/models/InsightsQuerypageModel.php
+++ b/extensions/wikia/Insights/models/InsightsQuerypageModel.php
@@ -117,9 +117,21 @@ abstract class InsightsQuerypageModel extends InsightsModel {
 
 
 	public function removeFixedItem( $type, Title $title ) {
-		$dbr = wfGetDB( DB_MASTER );
-		$dbr->delete( 'querycache', [ 'qc_type' => $type, 'qc_title' => $title->getDBkey() ] );
-		return $dbr->affectedRows() > 0;
+		$dbw = wfGetDB( DB_MASTER );
+		$dbw->delete(
+			'querycache',
+			[
+				'qc_type' => $type,
+				'qc_namespace' => $title->getNamespace(),
+				'qc_title' => $title->getDBkey(),
+			],
+			__METHOD__
+		);
+
+		$affectedRows = $dbw->affectedRows();
+		$dbw->commit( __METHOD__ );
+
+		return $affectedRows > 0;
 	}
 
 	/**
@@ -152,4 +164,4 @@ abstract class InsightsQuerypageModel extends InsightsModel {
 
 		return $next;
 	}
-} 
+}

--- a/extensions/wikia/Insights/scripts/LoopNotification.js
+++ b/extensions/wikia/Insights/scripts/LoopNotification.js
@@ -83,7 +83,7 @@ require(
 			$.nirvana.sendRequest({
 				controller: 'Insights',
 				method: 'loopNotification',
-				type: 'get',
+				type: 'POST',
 				data: {
 					insight: insights,
 					isEdit: isEdit,


### PR DESCRIPTION
Because of the way our DB transactions are handled, the removal of
fixed items from the Insights list was failing due to the changes
not being committed. This fixes it by both explicitly committing the
changes and switching the request to a POST (which would auto-commit
at the end of the request anyway) as it performs a write action.

Also fixes a small bug where the deletion did not include the namespace
of the article.

/cc @Wikia/community-engineering 
