### PR TITLE
(CE-1679) Remove Phalanx block from the rename process

### DIFF
--- a/extensions/wikia/UserRenameTool/RenameUserProcess.class.php
+++ b/extensions/wikia/UserRenameTool/RenameUserProcess.class.php
@@ -600,41 +600,6 @@ class RenameUserProcess {
 
 		$this->invalidateUser($this->mOldUsername);
 
-		//Block the user from logging in before logging him out
-		$this->addLog("Creating a Phalanx block for the user.");
-
-		if(empty($this->mPhalanxBlockId)){
-			$data = array(
-				'id'          => $this->mPhalanxBlockId,
-				'text'        => $this->mNewUsername,
-				'exact'       => 1,
-				'case'        => 1,
-				'regex'       => 0,
-				'timestamp'   => wfTimestampNow(),
-				'expire'      => null,
-				'author_id'   => $this->mRequestorId,
-				'reason'      => 'User rename process requested',
-				'lang'        => null,
-				'type'        => Phalanx::TYPE_USER
-			);
-
-			wfRunHooks( "EditPhalanxBlock", array( &$data ) );
-			$this->mPhalanxBlockId = $data['id'];
-			if(!$this->mPhalanxBlockId) {
-				$this->addLog("Creation of the block failed.");
-				$this->addError( wfMessage('userrenametool-error-cannot-create-block')->inContentLanguage()->text() );
-				wfProfileOut(__METHOD__);
-				return false;
-			} else {
-				$fakeUser->setOption( 'renameData', $fakeUser->getOption( 'renameData', '') . ';' . self::PHALANX_BLOCK_TAG . '=' . $this->mPhalanxBlockId);
-				$fakeUser->saveSettings();
-				$this->addLog("Block created with ID {$this->mPhalanxBlockId}.");
-			}
-		}
-		else{
-			$this->addLog("Block with ID {$this->mPhalanxBlockId} already exists.");
-		}
-
 		$hookName = 'UserRename::AfterAccountRename';
 		$this->addLog("Broadcasting hook: {$hookName}");
 		wfRunHooks($hookName, array($this->mUserId, $this->mOldUsername, $this->mNewUsername));
@@ -957,23 +922,7 @@ class RenameUserProcess {
 	 * @author Federico "Lox" Lucignano <federico@wikia-inc.com>
 	 * Performs action for cleaning up temporary data at the very end of a process
 	 */
-	public function cleanup(){
-		//remove phalanx user block
-
-		if ( $this->mPhalanxBlockId ) {
-			if ( !wfRunHooks( "DeletePhalanxBlock", array( $this->mPhalanxBlockId ) ) ) {
-				$result = false;
-			} else {
-				$result = true;
-			}
-
-			if ( !$result ) {
-				$this->addLog("Error removing Phalanx user block with ID {$this->mPhalanxBlockId}");
-			} else {
-				$this->addLog("Phalanx user block with ID {$this->mPhalanxBlockId} has been removed");
-			}
-		}
-
+	public function cleanup() {
 		if($this->mFakeUserId){
 			$this->addLog("Cleaning up process data in user option renameData for ID {$this->mFakeUserId}");
 


### PR DESCRIPTION
When the local rename part of the rename process fails at any point
the user is regularly left blocked until we can clean up the rename.
This is unnecessary as there is no reason to stop the user making use
of the new name after the global rename has happened but before all
the edits and so forth have been reattributed.

This removes the Phalanx block as when it is put in place, the main
rename that updates the user table and creates a fake user at the old
name has already occurred.

/cc @Wikia/community-engineering @michalroszka 
