### PR TITLE
Revert "DatabaseMysqli::mysqlRealEscapeString - assert a proper argument...

### DIFF
--- a/includes/db/DatabaseMysqli.php
+++ b/includes/db/DatabaseMysqli.php
@@ -271,8 +271,6 @@ class DatabaseMysqli extends DatabaseMysqlBase {
 	 * @return string
 	 */
 	protected function mysqlRealEscapeString( $s ) {
-		\Wikia\Util\Assert::true( is_string( $s ) || is_int( $s ), 'DatabaseMysqli::mysqlRealEscapeString - expected a string' );
-
 		return $this->mConn->real_escape_string( $s );
 	}
 


### PR DESCRIPTION
Reverts Wikia/app#7080

Check was to strict - we're passing objects there that have `__toString` method 

@michalroszka / @kvas-damian 
