### PR TITLE
Platform 1103 analytics switch

### DIFF
--- a/extensions/wikia/AnalyticsEngine/AnalyticsEngine.php
+++ b/extensions/wikia/AnalyticsEngine/AnalyticsEngine.php
@@ -33,16 +33,12 @@ class AnalyticsEngine {
 
 	private static function getProvider($provider) {
 		switch ($provider) {
-			case 'GA_Urchin':
-				return new AnalyticsProviderGAS();
 			case 'QuantServe':
 				return new AnalyticsProviderQuantServe();
 			case 'Comscore':
 				return new AnalyticsProviderComscore();
 			case 'Exelate':
 				return new AnalyticsProviderExelate();
-			case 'GAS':
-				return new AnalyticsProviderGAS();
 			case 'GoogleUA':
 				return new AnalyticsProviderGoogleUA();
 			case 'AmazonMatch':

--- a/extensions/wikia/AnalyticsEngine/AnalyticsEngine.setup.php
+++ b/extensions/wikia/AnalyticsEngine/AnalyticsEngine.setup.php
@@ -13,10 +13,8 @@ $wgExtensionMessagesFiles['AnalyticsEngine'] = __DIR__ . '/i18n/AnalyticsEngine.
 $wgAutoloadClasses['iAnalyticsProvider'] = __DIR__ . '/iAnalyticsProvider.php';
 $wgAutoloadClasses['AnalyticsEngine'] = __DIR__ . '/AnalyticsEngine.php';
 $wgAutoloadClasses['AnalyticsProviderQuantServe'] = __DIR__ . '/AnalyticsProviderQuantServe.php';
-$wgAutoloadClasses['AnalyticsProviderGA_Urchin'] = __DIR__ . '/AnalyticsProviderGA_Urchin.php';
 $wgAutoloadClasses['AnalyticsProviderComscore'] = __DIR__ . '/AnalyticsProviderComscore.php';
 $wgAutoloadClasses['AnalyticsProviderExelate'] = __DIR__ . '/AnalyticsProviderExelate.php';
-$wgAutoloadClasses['AnalyticsProviderGAS'] = __DIR__ . '/AnalyticsProviderGAS.php';
 $wgAutoloadClasses['AnalyticsProviderAmazonMatch'] = __DIR__ . '/AnalyticsProviderAmazonMatch.php';
 $wgAutoloadClasses['AnalyticsProviderDynamicYield'] = __DIR__ . '/AnalyticsProviderDynamicYield.php';
 $wgAutoloadClasses['AnalyticsProviderIVW2'] = __DIR__ . '/AnalyticsProviderIVW2.php';
@@ -28,19 +26,13 @@ $wgAutoloadClasses['AnalyticsProviderRubiconRTP'] = __DIR__ . '/AnalyticsProvide
 $wgAutoloadClasses['AnalyticsProviderGoogleUA'] = __DIR__ . '/AnalyticsProviderGoogleUA.php';
 
 //hooks
-//register hook to inject gas js library (MW 1.19)
-$wgHooks['WikiaSkinTopScripts'][] = 'AnalyticsProviderGAS::onWikiaSkinTopScripts';
+//register hook to inject GA js library (MW 1.19)
 $wgHooks['WikiaSkinTopScripts'][] = 'AnalyticsProviderGoogleUA::onWikiaSkinTopScripts';
 $wgHooks['SkinAfterBottomScripts'][] = 'AnalyticsProviderClarityRay::onSkinAfterBottomScripts';
 $wgHooks['SkinAfterBottomScripts'][] = 'AnalyticsProviderPageFair::onSkinAfterBottomScripts';
-$wgHooks['OasisSkinAssetGroupsBlocking'][] = 'AnalyticsProviderGAS::onOasisSkinAssetGroupsBlocking';
 $wgHooks['OasisSkinAssetGroupsBlocking'][] = 'AnalyticsProviderGoogleUA::onOasisSkinAssetGroupsBlocking';
 $wgHooks['InstantGlobalsGetVariables'][] = 'AnalyticsProviderIVW2::onInstantGlobalsGetVariables';
 
 //register hook for WikiaMobile skin to get the asset as part of the head js package in one request
-$wgHooks['WikiaMobileAssetsPackages'][] = 'AnalyticsProviderGAS::onWikiaMobileAssetsPackages';
 $wgHooks['WikiaMobileAssetsPackages'][] = 'AnalyticsProviderGoogleUA::onWikiaMobileAssetsPackages';
 $wgHooks['WikiaMobileAssetsPackages'][] = 'AnalyticsProviderBlueKai::onWikiaMobileAssetsPackages';
-
-// register hooks for Venus
-$wgHooks['VenusAssetsPackages'][] = 'AnalyticsProviderGAS::onVenusAssetsPackages';

--- a/extensions/wikia/AnalyticsEngine/AnalyticsProviderGoogleUA.php
+++ b/extensions/wikia/AnalyticsEngine/AnalyticsProviderGoogleUA.php
@@ -1,11 +1,5 @@
 <?php
 class AnalyticsProviderGoogleUA implements iAnalyticsProvider {
-	static private function isEnabled() {
-		global $wgAnalyticsProviderUseUA;
-
-		return !empty($wgAnalyticsProviderUseUA);
-	}
-
 	public function getSetupHtml($params=array()){
 		return '';
 	}
@@ -18,18 +12,12 @@ class AnalyticsProviderGoogleUA implements iAnalyticsProvider {
 		//should be added unprocessed as per Cardinal Path's request
 		//but screw it, that's an additional single request that adds overhead
 		//and the main experiment is done on Oasis :P
-		if (self::isEnabled()) {
-			array_unshift( $jsStaticPackages, 'universal_analytics_js' );
-		}
+		array_unshift( $jsStaticPackages, 'universal_analytics_js' );
 
 		return true;
 	}
 
 	static public function onWikiaSkinTopScripts( &$vars, &$scripts, $skin ){
-		if (!self::isEnabled()) {
-			return true;
-		}
-
 		global $wgDevelEnvironment, $wgGAUserIdSalt, $wgStagingEnvironment;
 
 		$app = F::app();
@@ -58,9 +46,8 @@ class AnalyticsProviderGoogleUA implements iAnalyticsProvider {
 
 	static public function onOasisSkinAssetGroupsBlocking( &$jsAssetGroups ) {
 		// this is only called in Oasis, so there's no need to double-check it
-		if (self::isEnabled()) {
-			$jsAssetGroups[] = 'universal_analytics_js';
-		}
+		$jsAssetGroups[] = 'universal_analytics_js';
+
 		return true;
 	}
 }

--- a/extensions/wikia/AnalyticsEngine/js/universal_analytics.js
+++ b/extensions/wikia/AnalyticsEngine/js/universal_analytics.js
@@ -361,8 +361,9 @@
 
     /**** Include A/B testing status ****/
     if (window.Wikia && window.Wikia.AbTest) {
-        if (abCustomVarsForAds.length) {
-            window.ga.apply(window, abCustomVarsForAds);
+        var i;
+        for (i = 0; i < abCustomVarsForAds.length; i++) {
+            window.ga.apply(window, abCustomVarsForAds[i]);
         }
     }
 

--- a/extensions/wikia/AnalyticsEngine/js/universal_analytics.js
+++ b/extensions/wikia/AnalyticsEngine/js/universal_analytics.js
@@ -258,7 +258,7 @@
     /*
      * Remove when SOC-217 ABTest is finished
      */
-    window.ga('set', 'dimension20', getUnconfirmedEmailUserType());                 // UnconfirmedEmailUserType
+    window.ga('set', 'dimension39', getUnconfirmedEmailUserType());                 // UnconfirmedEmailUserType
     /*
      * end remove
      */

--- a/extensions/wikia/AnalyticsEngine/js/universal_analytics.js
+++ b/extensions/wikia/AnalyticsEngine/js/universal_analytics.js
@@ -58,7 +58,7 @@
     if (isProductionEnv) {
         // Production Environment
         window.ga(
-            'create', 'UA-32129070-4', 'auto',
+            'create', 'UA-32129070-1', 'auto',
             {
                 'sampleRate': (cookieExists('qualaroo_survey_submission') ? 100 : 10),
                 'allowLinker': true,
@@ -69,7 +69,7 @@
     } else {
         // Development Environment
         window.ga(
-            'create', 'UA-32129070-3', 'auto',
+            'create', 'UA-32129070-2', 'auto',
             {
                 'sampleRate': (cookieExists('qualaroo_survey_submission') ? 100 : 10),
                 'allowLinker': true,
@@ -83,7 +83,7 @@
         if (isProductionEnv) {
             // Production Environment
             window.ga(
-                'create', 'UA-32129070-4', 'auto',
+                'create', 'UA-32132943-1', 'auto',
                 {
                     'name': 'special',
                     'sampleRate': 100,
@@ -94,7 +94,7 @@
         } else {
             // Development Environment
             window.ga(
-                'create', 'UA-32129070-3', 'auto',
+                'create', 'UA-32132943-2', 'auto',
                 {
                     'name': 'special',
                     'sampleRate': 100,
@@ -111,7 +111,7 @@
     if (isProductionEnv) {
         // VE account - UA-32132943-4'
         window.ga(
-            'create', 'UA-32129070-4', 'auto',
+            'create', 'UA-32132943-4', 'auto',
             {
                 'name': 've',
                 'sampleRate': 100,
@@ -316,7 +316,7 @@
     // Advertisment Account UA-32129071-1/UA-32129071-2
     if (isProductionEnv) {
         window.ga(
-            'create', 'UA-32129070-4', 'auto',
+            'create', 'UA-32129071-1', 'auto',
             {
                 'name': 'ads',
                 'sampleRate': 100,
@@ -326,7 +326,7 @@
         );
     } else {
         window.ga(
-            'create', 'UA-32129070-3', 'auto',
+            'create', 'UA-32129071-2', 'auto',
             {
                 'name': 'ads',
                 'sampleRate': 100,

--- a/extensions/wikia/AnalyticsEngine/test_page.php
+++ b/extensions/wikia/AnalyticsEngine/test_page.php
@@ -9,15 +9,9 @@ $wgCityId = "831";
 ini_set('display_errors', true);
 require_once 'AnalyticsEngine.php';
 echo AnalyticsEngine::track('QuantServe', AnalyticsEngine::EVENT_PAGEVIEW);
-echo AnalyticsEngine::track('GA_Urchin', AnalyticsEngine::EVENT_PAGEVIEW);
 ?>
 </head>
 <body>
 Hi
 </body>
-<?php
-echo AnalyticsEngine::track('GA_Urchin', 'dbname', array($wgDBname));
-echo AnalyticsEngine::track('GA_Urchin', 'main_page');
-echo AnalyticsEngine::track('GA_Urchin', 'onewiki', array($wgCityId));
-?>
 </html>

--- a/extensions/wikia/ThemeDesigner/ThemeDesignerController.class.php
+++ b/extensions/wikia/ThemeDesigner/ThemeDesignerController.class.php
@@ -55,9 +55,6 @@ class ThemeDesignerController extends WikiaController {
 			$this->returnTo = $this->wg->Script;
 		}
 
-		// load Google Analytics code
-		$this->analytics = AnalyticsEngine::track('GA_Urchin', AnalyticsEngine::EVENT_PAGEVIEW);
-
 		$wgOut->getResourceLoader()->getModule( 'mediawiki' );
 
 		$ret = implode( "\n", array(

--- a/extensions/wikia/Venus/VenusController.class.php
+++ b/extensions/wikia/Venus/VenusController.class.php
@@ -55,24 +55,6 @@ class VenusController extends WikiaController {
 		$this->setHeadItems();
 		$this->setAssets();
 
-		// FIXME: create separate module for stats stuff?
-		// load Google Analytics code
-		$this->googleAnalytics = AnalyticsEngine::track('GA_Urchin', AnalyticsEngine::EVENT_PAGEVIEW);
-
-		// onewiki GA
-		$this->googleAnalytics .= AnalyticsEngine::track('GA_Urchin', 'onewiki', array($wgCityId));
-
-		// track page load time
-		$this->googleAnalytics .= AnalyticsEngine::track('GA_Urchin', 'pagetime', array('oasis'));
-
-		// record which varnish this page was served by
-		$this->googleAnalytics .= AnalyticsEngine::track('GA_Urchin', 'varnish-stat');
-
-		// Add important Gracenote analytics for reporting needed for licensing on LyricWiki.
-		if (43339 == $wgCityId){
-			$this->googleAnalytics .= AnalyticsEngine::track('GA_Urchin', 'lyrics');
-		}
-
 		$this->comScore = AnalyticsEngine::track('Comscore', AnalyticsEngine::EVENT_PAGEVIEW);
 		$this->quantServe = AnalyticsEngine::track('QuantServe', AnalyticsEngine::EVENT_PAGEVIEW);
 		$this->amazonMatch = AnalyticsEngine::track('AmazonMatch', AnalyticsEngine::EVENT_PAGEVIEW);

--- a/extensions/wikia/WikiaMobile/WikiaMobileService.class.php
+++ b/extensions/wikia/WikiaMobile/WikiaMobileService.class.php
@@ -157,15 +157,7 @@ class WikiaMobileService extends WikiaService {
 		}
 
 		//Stats for Gracenote reporting
-		if ( $this->wg->cityId == self::LYRICSWIKI_ID ){
-			$trackingCode .= AnalyticsEngine::track('GA_Urchin', 'lyrics');
-		}
-
-		$trackingCode .= AnalyticsEngine::track( 'GA_Urchin', AnalyticsEngine::EVENT_PAGEVIEW ).
-			AnalyticsEngine::track( 'GA_Urchin', 'onewiki', [$this->wg->cityId] ).
-			AnalyticsEngine::track( 'GA_Urchin', 'pagetime', ['wikiamobile'] ).
-			AnalyticsEngine::track( 'GA_Urchin', 'varnish-stat').
-			AnalyticsEngine::track( 'GAS', 'usertiming' );
+		$trackingCode .= AnalyticsEngine::track( 'GoogleUA', 'usertiming' );
 
 		$this->response->setVal( 'trackingCode', $trackingCode );
 

--- a/resources/wikia/modules/tracker.js
+++ b/resources/wikia/modules/tracker.js
@@ -44,9 +44,7 @@
 				'ga_label',
 				'ga_value'
 			],
-			// @see /extensions/wikia/AnalyticsEngine/js/analytics.js
-			gaTrackAdEvent = window.gaTrackAdEvent,
-			gaTrackEvent = window.gaTrackEvent,
+			// @see /extensions/wikia/AnalyticsEngine/js/universal_analytics.js
 			guaTrackEvent = window.guaTrackEvent,
 			guaTrackAdEvent = window.guaTrackAdEvent,
 			logGroup = 'Wikia.Tracker',
@@ -302,19 +300,11 @@
 			analyticsArgs.push( true );
 
 			if ( tracking.ad ) {
-				if ( gaTrackAdEvent ) {
-					gaTrackAdEvent.apply(null, analyticsArgs);
-				}
-
 				if ( guaTrackAdEvent ) {
 					guaTrackAdEvent.apply( null, analyticsArgs );
 				}
 			} else {
 				if ( tracking.analytics ) {
-					if ( gaTrackEvent ) {
-						gaTrackEvent.apply(null, analyticsArgs);
-					}
-
 					if ( guaTrackEvent ) {
 						guaTrackEvent.apply( null, analyticsArgs );
 					}

--- a/skins/LyricsMinimal.php
+++ b/skins/LyricsMinimal.php
@@ -824,17 +824,6 @@ if(empty($wgEnableRecipesTweaksExt) || !RecipesTweaks::isHeaderStripeShown()) {
 		?>
 		</div>
 		<!-- /PAGE -->
-<!-- Begin Analytics -->
-<?php
-// Note, these were placed above the Ad calls intentionally because ad code screws with analytics
-echo AnalyticsEngine::track('GA_Urchin', AnalyticsEngine::EVENT_PAGEVIEW);
-echo AnalyticsEngine::track('GA_Urchin', 'hub', AdEngine2Service::getCachedCategory());
-global $wgCityId;
-echo AnalyticsEngine::track('GA_Urchin', 'onewiki', array($wgCityId));
-echo AnalyticsEngine::track('GA_Urchin', 'pagetime', array('lean_monaco'));
-if (43339 == $wgCityId) echo AnalyticsEngine::track("GA_Urchin", "lyrics");
-?>
-<!-- End Analytics -->
 
 <?php		wfProfileOut( __METHOD__ . '-page'); ?>
 

--- a/skins/oasis/modules/OasisController.class.php
+++ b/skins/oasis/modules/OasisController.class.php
@@ -204,33 +204,6 @@ class OasisController extends WikiaController {
 		// setup loading of JS/CSS
 		$this->loadJs();
 
-		// FIXME: create separate module for stats stuff?
-		// load Google Analytics code
-		$this->googleAnalytics = AnalyticsEngine::track('GA_Urchin', AnalyticsEngine::EVENT_PAGEVIEW);
-
-		// onewiki GA
-		$this->googleAnalytics .= AnalyticsEngine::track('GA_Urchin', 'onewiki', array($wgCityId));
-
-		// track page load time
-		$this->googleAnalytics .= AnalyticsEngine::track('GA_Urchin', 'pagetime', array('oasis'));
-
-		// track browser height TODO NEF no browser height tracking code anymore, remove
-		//$this->googleAnalytics .= AnalyticsEngine::track('GA_Urchin', 'browser-height');
-
-		// record which varnish this page was served by
-		$this->googleAnalytics .= AnalyticsEngine::track('GA_Urchin', 'varnish-stat');
-
-		// TODO NEF not used, remove
-		//$this->googleAnalytics .= AnalyticsEngine::track('GA_Urchin', 'noads');
-
-		// TODO NEF we dont do AB this way anymore, remove
-		//$this->googleAnalytics .= AnalyticsEngine::track('GA_Urchin', 'abtest');
-
-		// Add important Gracenote analytics for reporting needed for licensing on LyricWiki.
-		if (43339 == $wgCityId){
-			$this->googleAnalytics .= AnalyticsEngine::track('GA_Urchin', 'lyrics');
-		}
-
 		// macbre: RT #25697 - hide Comscore & QuantServe tags on edit pages
 		if(!in_array($wgRequest->getVal('action'), array('edit', 'submit'))) {
 			$this->comScore = AnalyticsEngine::track('Comscore', AnalyticsEngine::EVENT_PAGEVIEW);

--- a/skins/wikia/WikiaMonoBook.php
+++ b/skins/wikia/WikiaMonoBook.php
@@ -132,10 +132,7 @@ abstract class WikiaSkinMonoBook extends WikiaSkin {
 	private function getAnalyticsCode() {
 		global $wgCityId;
 
-		return AnalyticsEngine::track('GA_Urchin', AnalyticsEngine::EVENT_PAGEVIEW) .
-			AnalyticsEngine::track('GA_Urchin', 'hub', AdEngine2Service::getCachedCategory()) .
-			AnalyticsEngine::track('GA_Urchin', 'onewiki', array($wgCityId)) .
-			AnalyticsEngine::track('QuantServe', AnalyticsEngine::EVENT_PAGEVIEW);
+		return AnalyticsEngine::track('QuantServe', AnalyticsEngine::EVENT_PAGEVIEW);
 	}
 
 	/**


### PR DESCRIPTION
Switching from legacy Google Analytics to Universal Analytics. Changing properties to production ones and removing references to GAS and Urchin. Next step will remove all the legacy files.

Urchin tacker was disabled and seems that any events were not sent so I removed all of references to that tracker.

Since production properties are Premium we can add all custom dimensions to represent current custom variables.
