### PR TITLE
Wall: cache AJAX responses

### DIFF
--- a/extensions/wikia/GlobalNavigation/scripts/GlobalNavigationNotifications.js
+++ b/extensions/wikia/GlobalNavigation/scripts/GlobalNavigationNotifications.js
@@ -101,6 +101,7 @@ require(
 						controller: 'WallNotificationsExternalController',
 						method: 'getUpdateCounts',
 						format: 'json',
+						type: 'GET',
 						data: data,
 						callback: callback
 					});
@@ -252,6 +253,7 @@ require(
 				nirvana.sendRequest({
 					controller: 'WallNotificationsExternalController',
 					method: 'getUpdateWiki',
+					type: 'GET',
 					data: data,
 					callback: this.proxy(function (data) {
 						if (data.status !== true || data.html === '') {

--- a/extensions/wikia/WallNotifications/WallNotificationsExternalController.class.php
+++ b/extensions/wikia/WallNotifications/WallNotificationsExternalController.class.php
@@ -68,7 +68,7 @@ class WallNotificationsExternalController extends WikiaController {
 		wfProfileIn(__METHOD__);
 
 		$all = WikiaDataAccess::cache(
-			wfSharedMemcKey( __METHOD__, 'getCounts', $wgUser->getId() ),
+			wfMemcKey( __METHOD__, 'getCounts', $wgUser->getId() ),
 			self::TTL,
 			function() use ( $wn, $wgUser ) {
 				return $wn->getCounts( $wgUser->getId() );

--- a/extensions/wikia/WallNotifications/scripts/WallNotifications.js
+++ b/extensions/wikia/WallNotifications/scripts/WallNotifications.js
@@ -124,6 +124,7 @@ var WallNotifications = $.createClass(Object, {
 				controller: 'WallNotificationsExternalController',
 				method: 'getUpdateCounts',
 				format: 'json',
+				type: 'GET',
 				data: data,
 				callback: callback
 			});
@@ -308,6 +309,7 @@ var WallNotifications = $.createClass(Object, {
 		$.nirvana.sendRequest({
 			controller: 'WallNotificationsExternalController',
 			method: 'getUpdateWiki',
+			type: 'GET',
 			data: data,
 			callback: this.proxy(function(data) {
 				if(data.status != true || data.html == '') return;


### PR DESCRIPTION
- cache $wn->getCounts results for 5 minutes in memcache
- cache getUpdateCounts and getUpdateWiki in the browser cache for 5 minutes
- use GET HTTP method (instead of POST)

@drozdo / @kvas-damian / @garthwebb 
