### PR TITLE
wgRevisionCacheExpiry: set to a month

### DIFF
--- a/includes/DefaultSettings.php
+++ b/includes/DefaultSettings.php
@@ -1422,7 +1422,7 @@ $wgDefaultExternalStore = false;
  *
  * Set to 0 to disable, or number of seconds before cache expiry.
  */
-$wgRevisionCacheExpiry = 86400;
+$wgRevisionCacheExpiry = 86400 * 30; // a month
 
 /** @} */ # end text storage }
 


### PR DESCRIPTION
The hit ratio for blobs memcache keys is at ~50%. Try to improve it.

@drozdo / @michalroszka / @harnash / @wladekb 
