### PR TITLE
ADEN-1989 Fix filling dynamic ad slots in Mercury

### DIFF
--- a/extensions/wikia/AdEngine/js/GptHelper.js
+++ b/extensions/wikia/AdEngine/js/GptHelper.js
@@ -175,13 +175,16 @@ define('ext.wikia.adEngine.gptHelper', [
 			setPageLevelParams(pageLevelParams);
 
 			adDiv = document.getElementById(adDivId);
+			log(['queueAd', slotName, slotDiv, adDiv], 'debug', logGroup);
 
 			if (!adDiv) {
 				// Create a div for the GPT ad
 				adDiv = document.createElement('div');
 				adDiv.id = adDivId;
 				slotDiv.appendChild(adDiv);
+			}
 
+			if (!gptSlots[adDivId]) {
 				sizes = convertSizesToGpt(slotTargeting.size);
 
 				if (slotName.match(/TOP_LEADERBOARD/)) {
@@ -204,11 +207,11 @@ define('ext.wikia.adEngine.gptHelper', [
 					}
 				}
 
-				gptSlots[adDivId] = slot;
-
 				// Display div through GPT
 				log(['googletag.display', adDivId], 'debug', logGroup);
 				googletag.display(adDivId);
+
+				gptSlots[adDivId] = slot;
 
 				// Save slot level params for easier ad delivery debugging
 				adDiv.setAttribute('data-gpt-slot-sizes', JSON.stringify(sizes));
@@ -223,6 +226,7 @@ define('ext.wikia.adEngine.gptHelper', [
 
 			// Some broken ads never fire "success" event, so we show the div now (and maybe hide later)
 			slotTweaker.show(adDivId);
+			log(['adding slot to the queue', adDivId], 'debug', logGroup);
 			slotQueue.push(gptSlots[adDivId]);
 		}
 


### PR DESCRIPTION
We found out that in Mercury some ad slots aren't being filled if it's not the first page load.

In changes below I fixed this issue. I changed the logic, so:
- we do not define and display ad divs which were already defined,
- we only create and append a div if it doesn't exist.

I also added some additional logging.
