### PR TITLE
OutputPage: log empty parser outputs

### DIFF
--- a/includes/OutputPage.php
+++ b/includes/OutputPage.php
@@ -1649,6 +1649,14 @@ class OutputPage extends ContextSource {
 		$this->addParserOutputNoText( $parserOutput );
 		$text = $parserOutput->getText();
 		wfRunHooks( 'OutputPageBeforeHTML', array( &$this, &$text ) );
+
+		// Wikia change - begin
+		// log empty articles showing up randomly - @see PLATFORM-1212
+		if ( $text == '') {
+			\Wikia\Logger\WikiaLogger::instance()->warning( 'PLATFORM-1212 - empty parser output', [ 'exception' => new Exception() ] );
+		}
+		// Wikia change - end
+
 		$this->addHTML( $text );
 	}
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-1212

Articles are randomly showing up blank - try to find the root cause.

@michalroszka / @harnash / @wladekb 
