### PR TITLE
Proper Tracker.track() parameter send in legacy code.

### DIFF
--- a/extensions/VisualEditor-old/wikia/modules/ve/init/ve.init.mw.WikiaViewPageTarget.init.js
+++ b/extensions/VisualEditor-old/wikia/modules/ve/init/ve.init.mw.WikiaViewPageTarget.init.js
@@ -25,7 +25,7 @@
 		// Used by tracking calls that go out before ve.track is available.
 		trackerConfig = {
 			'category': 'editor-ve',
-			'trackingMethod': 'both'
+			'trackingMethod': 'analytics'
 		},
 		spinnerTimeoutId = null,
 		skin = mw.config.get( 'skin' );


### PR DESCRIPTION
Leftovers after changing Tracker.track() method parameters.
