### PR TITLE
CreateWiki: wait for slaves to catch up

### DIFF
--- a/extensions/wikia/CreateNewWiki/CreateWiki.php
+++ b/extensions/wikia/CreateNewWiki/CreateWiki.php
@@ -347,7 +347,7 @@ class CreateWiki {
 		 * destroy connection to newly created database
 		 */
 		$this->mNewWiki->dbw->commit();
-		sleep(2); # I'm terribly sorry, we need to wait for slaves here (OPS-6313)
+		wfWaitForSlaves( $this->mNewWiki->dbname ); # OPS-6313
 
 		wfDebugLog( "createwiki", __METHOD__ . ": Database changes commited \n", true );
 		$wgSharedDB = $tmpSharedDB;

--- a/extensions/wikia/CreateNewWiki/CreateWiki.php
+++ b/extensions/wikia/CreateNewWiki/CreateWiki.php
@@ -347,6 +347,8 @@ class CreateWiki {
 		 * destroy connection to newly created database
 		 */
 		$this->mNewWiki->dbw->commit();
+		sleep(2); # I'm terribly sorry, we need to wait for slaves here (OPS-6313)
+
 		wfDebugLog( "createwiki", __METHOD__ . ": Database changes commited \n", true );
 		$wgSharedDB = $tmpSharedDB;
 

--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -3826,6 +3826,7 @@ function wfWaitForSlaves( $wiki = false ) {
 			# not just the one returned by consul
 			sleep( 1 );
 
+			/* @var MySQLMasterPos $pos */
 			\Wikia\Logger\WikiaLogger::instance()->info( 'wfWaitForSlaves for consul clusters',  [
 				'exception' => new Exception(),
 				'master' => $masterHostName,

--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -3817,6 +3817,21 @@ function wfWaitForSlaves( $wiki = false ) {
 		$dbw = $lb->getConnection( DB_MASTER, array(), $wiki );
 		$pos = $dbw->getMasterPos();
 		$lb->waitForAll( $pos, $wiki );
+
+		// Wikia change - begin
+		// OPS-6313 - sleep-based implementaion for cluster G (it uses consul-powered DB config)
+		if ( $lb->parentInfo()['id'] === 'main-c7' ) {
+			# I am terribly sorry, but we do really need to wait for all slaves
+			# not just the one returned by consul
+			sleep( 1 );
+
+			\Wikia\Logger\WikiaLogger::instance()->info( 'wfWaitForSlaves for c7',  [
+				'exception' => new Exception(),
+				'pos' => $pos->__toString(),
+				'wiki' => $wiki
+			] );
+		}
+		// Wikia change - end
 	}
 }
 

--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -3819,14 +3819,16 @@ function wfWaitForSlaves( $wiki = false ) {
 		$lb->waitForAll( $pos, $wiki );
 
 		// Wikia change - begin
-		// OPS-6313 - sleep-based implementaion for cluster G (it uses consul-powered DB config)
-		if ( $lb->parentInfo()['id'] === 'main-c7' ) {
+		// OPS-6313 - sleep-based implementaion for consul-powered DB clusters
+		$masterHostName = $lb->getServerName(0);
+		if ( strpos( $masterHostName, '.service.consul' ) !== false ) {
 			# I am terribly sorry, but we do really need to wait for all slaves
 			# not just the one returned by consul
 			sleep( 1 );
 
-			\Wikia\Logger\WikiaLogger::instance()->info( 'wfWaitForSlaves for c7',  [
+			\Wikia\Logger\WikiaLogger::instance()->info( 'wfWaitForSlaves for consul clusters',  [
 				'exception' => new Exception(),
+				'master' => $masterHostName,
 				'pos' => $pos->__toString(),
 				'wiki' => $wiki
 			] );


### PR DESCRIPTION
First of all: I'm going to burn in hell until the end of time for this commit.

Long story short: CreateWiki process redirect to the newly created wiki which pretty often results with a fatal / blank page due to slave not catching up and missing the wiki database or lacking part of required tables.

Sleep for a second in `wfWaitForSlaves`  when called for wiki from G cluster.

@drozdo / @michalroszka / @harnash / @wladekb / @owend 
