### PR TITLE
(CE-1827) Add additional Wikia submitter entity to CE notices

### DIFF
--- a/extensions/wikia/DMCARequest/ChillingEffectsClient.class.php
+++ b/extensions/wikia/DMCARequest/ChillingEffectsClient.class.php
@@ -128,6 +128,10 @@ class ChillingEffectsClient {
 			],
 			'entity_notice_roles_attributes' => [
 				[
+					'name' => 'submitter',
+					'entity_attributes' => $orgDetails,
+				],
+				[
 					'name' => 'recipient',
 					'entity_attributes' => $orgDetails,
 				],


### PR DESCRIPTION
Adds Wikia as the submitter of the CE notice as requested.

/cc @Wikia/community-engineering 
