### PR TITLE
fixPageLatest: fix empty articles with page_latest = 0

### DIFF
--- a/maintenance/wikia/fixPageLatest.php
+++ b/maintenance/wikia/fixPageLatest.php
@@ -100,7 +100,14 @@ class FixPageLatest extends Maintenance {
 			// no revision data - we can generate an empty revision if "page_len" is set to 0 (PLATFORM-1286)
 			if ($revId == 0 &&  $row->page_len == 0 ) {
 				$this->output(" - making an empty edit");
-				$revId = $this->insertEmptyRevision( $row->page_id );
+
+				try {
+					$revId = $this->insertEmptyRevision($row->page_id);
+				}
+				catch(MWException $ex) {
+					$this->output(" - error: " . $ex->getMessage() . "\n");
+					continue;
+				}
 			}
 
 			$this->dbw->update(

--- a/maintenance/wikia/fixPageLatest.php
+++ b/maintenance/wikia/fixPageLatest.php
@@ -71,13 +71,17 @@ class FixPageLatest extends Maintenance {
 					// make an empty edit - the affected article will have at least an empty revision
 					if ( !$isDryRun ) {
 						$page = WikiPage::newFromID( $row->page_id );
-						$page->doEdit(
+						$status = $page->doEdit(
 							'',
 							'Fixing empty articles with no revisions',
-							EDIT_NEW,
+							0, // $flags
 							false, // $baseRevId
 							User::newFromName( 'WikiaBot' )
 						);
+
+						if ( !$status->isOK() ) {
+							$this->output( "\n\t[ERR] " . $status->getMessage() . "\n\n" );
+						}
 
 						$fixed++;
 					}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-1206

"Fix" articles that have both `page_latest` and `page_len` set to zero by making an empty edit. Revisions are missing (highly likely they've never existed) - "restore"  them by adding empty ones to every affected article.

A script from #876 improved

@wladekb / @harnash / @owend 
