### PR TITLE
PLATFORM-1219: wait for slaves when creating a new wiki

### DIFF
--- a/extensions/wikia/CreateNewWiki/CreateWiki.php
+++ b/extensions/wikia/CreateNewWiki/CreateWiki.php
@@ -295,6 +295,8 @@ class CreateWiki {
 		$tmpSharedDB = $wgSharedDB;
 		$wgSharedDB = $this->mNewWiki->dbname;
 
+		$this->mDBw->commit( __METHOD__ ); // commit shared DB changes
+
 		/**
 		 * we got empty database created, now we have to create tables and
 		 * populate it with some default values
@@ -364,7 +366,10 @@ class CreateWiki {
 		 * destroy connection to newly created database
 		 */
 		$res = $this->mNewWiki->dbw->commit( __METHOD__ );
-		wfWaitForSlaves( $this->mNewWiki->dbname ); # OPS-6313
+
+		# OPS-6313 - wait for slaves to catch up (both shared DB and the current new wikis cluster)
+		wfWaitForSlaves( $wgExternalSharedDB );
+		wfWaitForSlaves( $this->mNewWiki->dbname );
 
 		$this->info( __METHOD__ . ": database changes commited", [
 			'commit_res' => $res

--- a/extensions/wikia/CreateNewWiki/CreateWiki.php
+++ b/extensions/wikia/CreateNewWiki/CreateWiki.php
@@ -1117,7 +1117,14 @@ class CreateWiki {
 				$wgDBadminpassword,
 				$this->mNewWiki->dbname
 			);
-			wfShellExec( $cmd );
+			wfShellExec( $cmd, $retVal );
+
+			if ($retVal > 0) {
+				$this->error( 'starter dump import failed', [
+					'starter_db' => $dbStarter
+				] );
+				return false;
+			}
 
 			wfDebugLog( "createwiki", __METHOD__ . ": Import {$this->mIP}/maintenance/cleanupStarter.sql \n", true );
 			$error = $this->mNewWiki->dbw->sourceFile( "{$this->mIP}/maintenance/cleanupStarter.sql", false, false, __METHOD__ );
@@ -1133,7 +1140,14 @@ class CreateWiki {
 				$this->mIP,
 				$wgWikiaLocalSettingsPath
 			);
-			wfShellExec( $cmd );
+			wfShellExec( $cmd, $retVal );
+
+			if ($retVal > 0) {
+				$this->error( 'updateArticleCount.php failed', [
+					'ret_val' => $retVal
+				] );
+				return false;
+			}
 
 			wfDebugLog( "createwiki", __METHOD__ . ": Starter database copied \n", true );
 		}


### PR DESCRIPTION
- wait for slaves shared DB and the new wiki DB after importing tables schema -  c44e04e
- check the exit codes of `wfShellExec` when importing starter, because world is not the perfect place - 9138679

Bonus points for cleanup of task invocation

``` php
> var_dump( TaskRunner::isModern('CreateWikiLocalJob') )
bool(true)
```

Tested on `sandbox-s1` - works like a charm

@harnash / @wladekb / @owend 
