### PR TITLE
Fix for strict error 

### DIFF
--- a/extensions/wikia/AssetsManager/builders/AssetsManagerBaseBuilder.class.php
+++ b/extensions/wikia/AssetsManager/builders/AssetsManagerBaseBuilder.class.php
@@ -34,6 +34,11 @@ class AssetsManagerBaseBuilder {
 		}
 	}
 
+	/**
+	 * @param float $processingTimeStart Unix timestamp in microseconds used for profiling (when profiling is forced)
+	 * @return string
+	 * @throws Exception
+	 */
 	public function getContent( $processingTimeStart = null ) {
 		$minifyTimeStart = null;
 

--- a/extensions/wikia/AssetsManager/builders/AssetsManagerGroupsBuilder.class.php
+++ b/extensions/wikia/AssetsManager/builders/AssetsManagerGroupsBuilder.class.php
@@ -26,7 +26,7 @@ class AssetsManagerGroupsBuilder extends AssetsManagerBaseBuilder {
 	}
 
 	// no need to compress concatenated content once more
-	public function getContent() {
+	public function getContent( $processingTimeStart = null ) {
 		return trim($this->mContent);
 	}
 }


### PR DESCRIPTION
Not ticketed. Just fixing what is annoying ;)

'Strict standards: Declaration of AssetsManagerGroupsBuilder::getContent() should be compatible with AssetsManagerBaseBuilder::getContent' 
that was braking assets build because error text was rendered within js assets code

@Wikia/community-engineering, @macbre 
