### PR TITLE
SOC-791 | Disable browser cache on WallNotifications

### DIFF
--- a/extensions/wikia/WallNotifications/WallNotifications.class.php
+++ b/extensions/wikia/WallNotifications/WallNotifications.class.php
@@ -725,6 +725,8 @@ class WallNotifications {
 			}
 		);
 
+		$this->purgeCache( $userId );
+
 		$this->cleanEntitiesFromDB();
 	}
 

--- a/extensions/wikia/WallNotifications/WallNotifications.class.php
+++ b/extensions/wikia/WallNotifications/WallNotifications.class.php
@@ -188,7 +188,7 @@ class WallNotifications {
 	}
 
 	private function getCacheKey( $userId ) {
-		return wfMemcKey( __METHOD__, 'getCounts', $userId );
+		return wfMemcKey( __CLASS__, 'getCounts', $userId );
 	}
 
 	private function purgeCache( $userId ) {

--- a/extensions/wikia/WallNotifications/WallNotifications.class.php
+++ b/extensions/wikia/WallNotifications/WallNotifications.class.php
@@ -154,7 +154,7 @@ class WallNotifications {
 	 */
 	public function getCounts( $userId ) {
 		return WikiaDataAccess::cache(
-			$this->getCacheKey( $userId ),
+			$this->getCountsCacheKey( $userId ),
 			self::TTL,
 			function() use ( $userId ) {
 				global $wgMemc, $wgCityId;
@@ -186,12 +186,12 @@ class WallNotifications {
 		);
 	}
 
-	private function getCacheKey( $userId ) {
+	private function getCountsCacheKey( $userId ) {
 		return wfMemcKey( __CLASS__, 'getCounts', $userId );
 	}
 
-	private function purgeCache( $userId ) {
-		WikiaDataAccess::cachePurge( $this->getCacheKey( $userId ) );
+	private function purgeCountsCache( $userId ) {
+		WikiaDataAccess::cachePurge( $this->getCountsCacheKey( $userId ) );
 	}
 
 	private function sortByTimestamp( $array ) {
@@ -571,7 +571,7 @@ class WallNotifications {
 				$memcSync->delete();
 			}
 		);
-		$this->purgeCache( $userId );
+		$this->purgeCountsCache( $userId );
 
 		foreach ( $updateDBlist as $value ) {
 			$this->getDB( true )->update( 'wall_notification' , ['is_read' =>  1], $value, __METHOD__ );
@@ -724,7 +724,7 @@ class WallNotifications {
 			}
 		);
 
-		$this->purgeCache( $userId );
+		$this->purgeCountsCache( $userId );
 
 		$this->cleanEntitiesFromDB();
 	}

--- a/extensions/wikia/WallNotifications/WallNotifications.class.php
+++ b/extensions/wikia/WallNotifications/WallNotifications.class.php
@@ -156,10 +156,9 @@ class WallNotifications {
 		return WikiaDataAccess::cache(
 			$this->getCacheKey( $userId ),
 			self::TTL,
-			function() use ( $userId ){
+			function() use ( $userId ) {
 				global $wgMemc, $wgCityId;
 
-				wfProfileIn(__METHOD__);
 				$wikiList = $this->getWikiList( $userId );
 
 				// prefetch data
@@ -178,10 +177,10 @@ class WallNotifications {
 					$total += $wiki['unread'];
 					// show only Wikis with unread notifications
 					// current Wiki is an exception (show always)
-					if ( $wiki['unread'] > 0 || $wiki['id'] == $wgCityId )
+					if ( $wiki['unread'] > 0 || $wiki['id'] == $wgCityId ) {
 						$output[] = $wiki;
+					}
 				}
-				wfProfileOut(__METHOD__);
 				return $output;
 			}
 		);

--- a/extensions/wikia/WallNotifications/WallNotifications.class.php
+++ b/extensions/wikia/WallNotifications/WallNotifications.class.php
@@ -679,6 +679,8 @@ class WallNotifications {
 		} else {
 			$this->getDB( true )->delete( 'wall_notification' , $where, __METHOD__ );
 		}
+
+		$this->purgeCountsCache( $userId );
 	}
 
 	protected function unhideNotificationsForUniqueIDDB( $wikiId, $uniqueId ) {

--- a/extensions/wikia/WallNotifications/WallNotificationsExternalController.class.php
+++ b/extensions/wikia/WallNotifications/WallNotificationsExternalController.class.php
@@ -3,8 +3,6 @@
 class WallNotificationsExternalController extends WikiaController {
 	const WALL_WIKI_NAME_MAX_LEN = 32;
 
-	const TTL = 300; // 5 minutes
-
 	private $controllerName;
 
 	public function __construct() {
@@ -47,7 +45,9 @@ class WallNotificationsExternalController extends WikiaController {
 		if( $ret === false || $forceAll == 'FORCE' ) {
 			$ret = $wn->markReadAllWikis( $wgUser->getId() );
 		}
+
 		$this->getUpdateCountsInternal( $wn );
+
 		return true;
 	}
 
@@ -67,13 +67,7 @@ class WallNotificationsExternalController extends WikiaController {
 		global $wgUser, $wgLang, $wgMemc;
 		wfProfileIn(__METHOD__);
 
-		$all = WikiaDataAccess::cache(
-			wfMemcKey( __METHOD__, 'getCounts', $wgUser->getId() ),
-			self::TTL,
-			function() use ( $wn, $wgUser ) {
-				return $wn->getCounts( $wgUser->getId() );
-			}
-		);
+		$all = $wn->getCounts( $wgUser->getId() );
 
 		$sum = 0;
 		foreach( $all as $k => $wiki ) {
@@ -97,9 +91,8 @@ class WallNotificationsExternalController extends WikiaController {
 		$this->response->setVal( 'reminder', wfMessage('wall-notifications-reminder', $sum)->text() );
 		$this->response->setVal( 'status', true );
 
-		// PLATFORM-1194: cache the response for 5 minutes in the browser cache
 		$this->response->setCachePolicy( WikiaResponse::CACHE_PRIVATE );
-		$this->response->setCacheValidity( self::TTL );
+		$this->response->setCacheValidity( WikiaResponse::CACHE_DISABLED );
 
 		wfProfileOut(__METHOD__);
 	}
@@ -120,9 +113,7 @@ class WallNotificationsExternalController extends WikiaController {
 		$this->response->setVal( 'unread', $all[ 'unread_count' ] );
 		$this->response->setVal( 'status', true );
 
-		// PLATFORM-1194: cache the response for 5 minutes in the browser cache
 		$this->response->setCachePolicy( WikiaResponse::CACHE_PRIVATE );
-		$this->response->setCacheValidity( self::TTL );
+		$this->response->setCacheValidity( WikiaResponse::CACHE_DISABLED );
 	}
-
 }


### PR DESCRIPTION
- purging memcache when notification is marked as read
- purging memcache when new notification is stored in DB.

https://wikia-inc.atlassian.net/browse/SOC-791
There is no way to clear browser cache for notifications while requesting different URL, that's why we cannot cache it in browser.

ping @macbre 
