### PR TITLE
Enable caching of Interwiki::getAllPrefixesDB

### DIFF
--- a/includes/DefaultSettings.php
+++ b/includes/DefaultSettings.php
@@ -2803,7 +2803,7 @@ $wgLocalInterwiki = false;
 /**
  * Expiry time for cache of interwiki table
  */
-$wgInterwikiExpiry = 10800;
+$wgInterwikiExpiry = 86400;
 
 /** Interwiki caching settings.
 	$wgInterwikiCache specifies path to constant database file


### PR DESCRIPTION
All calls to `Interwiki::getAllPrefixesDB` were making DB queries. Add a caching here.

Increase `$wgInterwikiExpiry` to a day (from 3 hours).

@drozdo / @michalroszka / @harnash / @wladekb 
