### PR TITLE
LoadBalancer::doWait - log failed calls to Database::masterPosWait

### DIFF
--- a/includes/db/Database.php
+++ b/includes/db/Database.php
@@ -2962,7 +2962,7 @@ abstract class DatabaseBase implements DatabaseType {
 	 * @param $timeout Integer: the maximum number of seconds to wait for
 	 *   synchronisation
 	 *
-	 * @return An integer: zero if the slave was past that position already,
+	 * @return integer: zero if the slave was past that position already,
 	 *   greater than zero if we waited for some period of time, less than
 	 *   zero if we timed out.
 	 */

--- a/includes/db/LoadBalancer.php
+++ b/includes/db/LoadBalancer.php
@@ -434,6 +434,19 @@ class LoadBalancer {
 		if ( $result == -1 || is_null( $result ) ) {
 			# Timed out waiting for slave, use master instead
 			wfDebug( __METHOD__.": Timed out waiting for slave #$index pos {$this->mWaitForPos}\n" );
+
+			// Wikia change - begin
+			// log failed wfWaitForSlaves
+			// @see PLATFORM-1219
+			Wikia\Logger\WikiaLogger::instance()->error( 'LoadBalancer::doWait timed out', [
+				'exception' => new Exception(),
+				'db'        => $conn->getDBname(),
+				'host'      => $conn->getServer(),
+				'pos'       => (string) $this->mWaitForPos,
+				'result'    => $result,
+			] );
+			// Wikia change - end
+
 			return false;
 		} else {
 			wfDebug( __METHOD__.": Done\n" );


### PR DESCRIPTION
MediaWiki does not log failed calls to `Database::masterPosWait`, hence `wfWaitForSlaves` is not 100% reliable. Yay!

Add logging in `LoadBalancer::doWait` in the hope of finding the root cause of PLATFORM-1219.

@michalroszka / @harnash / @wladekb 
