### PR TITLE
LoadBalancer::doWait - log failed calls to Database::masterPosWait

### DIFF
--- a/includes/db/DatabaseMysqlBase.php
+++ b/includes/db/DatabaseMysqlBase.php
@@ -624,6 +624,20 @@ abstract class DatabaseMysqlBase extends DatabaseBase {
 			wfProfileOut( $fname );
 			return $row[0];
 		}
+
+		// Wikia change - begin
+		// log failed wfWaitForSlaves calls
+		// @see PLATFORM-1219
+		Wikia\Logger\WikiaLogger::instance()->error( 'LoadBalancer::doWait timed out', [
+			'exception' => new Exception( $this->lastError() ),
+			'db'        => $this->getDBname(),
+			'host'      => $this->getServer(),
+			'pos'       => (string) $pos,
+			'query'     => $this->lastQuery(),
+			'timeout'   => $timeout
+		] );
+		// Wikia change - end
+
 		wfProfileOut( $fname );
 		return false;
 	}

--- a/includes/db/LoadBalancer.php
+++ b/includes/db/LoadBalancer.php
@@ -434,19 +434,6 @@ class LoadBalancer {
 		if ( $result == -1 || is_null( $result ) ) {
 			# Timed out waiting for slave, use master instead
 			wfDebug( __METHOD__.": Timed out waiting for slave #$index pos {$this->mWaitForPos}\n" );
-
-			// Wikia change - begin
-			// log failed wfWaitForSlaves
-			// @see PLATFORM-1219
-			Wikia\Logger\WikiaLogger::instance()->error( 'LoadBalancer::doWait timed out', [
-				'exception' => new Exception(),
-				'db'        => $conn->getDBname(),
-				'host'      => $conn->getServer(),
-				'pos'       => (string) $this->mWaitForPos,
-				'result'    => $result,
-			] );
-			// Wikia change - end
-
 			return false;
 		} else {
 			wfDebug( __METHOD__.": Done\n" );


### PR DESCRIPTION
Move the logging to `DatabaseMysqlBase::masterPosWait` method.

Improve #7227
