### PR TITLE
CONCF-565 | Fix for ve toolbar

### DIFF
--- a/skins/oasis/css/core/breakpoints-layout.scss
+++ b/skins/oasis/css/core/breakpoints-layout.scss
@@ -222,6 +222,11 @@
 		margin-right: 0;
 	}
 
+	//
+	.ve-activated .WikiaMainContent {
+		position: static;
+	}
+
 	// "special case" for 1024px tablets (think landscape iPad)
 	@media #{$breakpoint-small-plus} {
 		.WikiaPage {


### PR DESCRIPTION
Fix for `ve-toolbar` hidden behind `ve-ui-wikiaFocusWidget-topShield`
/cc @hakubo @inez 
