### PR TITLE
CE-1771 Render flags when action=submit after an edit

### DIFF
--- a/extensions/wikia/Flags/Flags.hooks.php
+++ b/extensions/wikia/Flags/Flags.hooks.php
@@ -23,11 +23,11 @@ class Hooks {
 		 * - a user is on an edit page
 		 * - the request is from VE
 		 */
+		$helper = new Helper();
 		if ( !$parser->mFlagsParsed
-			&& !\WikiaPageType::isEditPage()
+			&& $helper->shouldDisplayFlags()
 			&& !( $wgRequest->getVal( 'action' ) == 'visualeditor' )
 		) {
-			$helper = new Helper();
 			$addText = $helper->getFlagsForPageWikitext( $parser->getTitle()->getArticleID() );
 
 			if ( $addText !== null ) {

--- a/extensions/wikia/Flags/FlagsHelper.class.php
+++ b/extensions/wikia/Flags/FlagsHelper.class.php
@@ -11,7 +11,7 @@ class Helper {
 
 		return !in_array(
 			$wgRequest->getVal( 'action', 'view' ),
-			array( 'edit', 'formedit' , 'history' )
+			[ 'edit', 'formedit' , 'history' ]
 		);
 	}
 

--- a/extensions/wikia/Flags/FlagsHelper.class.php
+++ b/extensions/wikia/Flags/FlagsHelper.class.php
@@ -6,6 +6,15 @@ use Flags\Views\FlagView;
 
 class Helper {
 
+	public function shouldDisplayFlags() {
+		global $wgRequest;
+
+		return !in_array(
+			$wgRequest->getVal( 'action', 'view' ),
+			array( 'edit', 'formedit' , 'history' )
+		);
+	}
+
 	public function getFlagsForPageWikitext( $pageId ) {
 		$flags = $this->sendGetFlagsForPageRequest( $pageId );
 		if ( !empty( $flags ) ) {


### PR DESCRIPTION
We cannot use `WikiaPageType::isEditPage` because it treats `action=submit` URLs as edit pages. This caused a bug with flags not being rendered when redirected to article view after an edit.

@Wikia/community-engineering 
