### PR TITLE
wfWaitForSlaves: sleep a bit longer

### DIFF
--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -3809,6 +3809,8 @@ function wfGetNull() {
  * @param $wiki mixed Wiki identifier accepted by wfGetLB
  */
 function wfWaitForSlaves( $wiki = false ) {
+	$then = microtime( true ); // Wikia change
+
 	$lb = wfGetLB( $wiki );
 	// bug 27975 - Don't try to wait for slaves if there are none
 	// Prevents permission error when getting master position
@@ -3824,13 +3826,14 @@ function wfWaitForSlaves( $wiki = false ) {
 		if ( strpos( $masterHostName, '.service.consul' ) !== false ) {
 			# I am terribly sorry, but we do really need to wait for all slaves
 			# not just the one returned by consul
-			sleep( 1 );
+			sleep( $lb->waitTimeout() ); // use the default slaves wait timeout
 
 			/* @var MySQLMasterPos $pos */
 			\Wikia\Logger\WikiaLogger::instance()->info( 'wfWaitForSlaves for consul clusters',  [
 				'exception' => new Exception(),
 				'master' => $masterHostName,
 				'pos' => $pos->__toString(),
+				'waited' => microtime( true ) - $then,
 				'wiki' => $wiki
 			] );
 		}

--- a/includes/db/DatabaseMysqlBase.php
+++ b/includes/db/DatabaseMysqlBase.php
@@ -624,20 +624,6 @@ abstract class DatabaseMysqlBase extends DatabaseBase {
 			wfProfileOut( $fname );
 			return $row[0];
 		}
-
-		// Wikia change - begin
-		// log failed wfWaitForSlaves calls
-		// @see PLATFORM-1219
-		Wikia\Logger\WikiaLogger::instance()->error( 'LoadBalancer::doWait timed out', [
-			'exception' => new Exception( $this->lastError() ),
-			'db'        => $this->getDBname(),
-			'host'      => $this->getServer(),
-			'pos'       => (string) $pos,
-			'query'     => $this->lastQuery(),
-			'timeout'   => $timeout
-		] );
-		// Wikia change - end
-
 		wfProfileOut( $fname );
 		return false;
 	}

--- a/includes/db/LoadBalancer.php
+++ b/includes/db/LoadBalancer.php
@@ -434,6 +434,19 @@ class LoadBalancer {
 		if ( $result == -1 || is_null( $result ) ) {
 			# Timed out waiting for slave, use master instead
 			wfDebug( __METHOD__.": Timed out waiting for slave #$index pos {$this->mWaitForPos}\n" );
+
+			// Wikia change - begin
+			// log failed wfWaitForSlaves
+			// @see PLATFORM-1219
+			Wikia\Logger\WikiaLogger::instance()->error( 'LoadBalancer::doWait timed out', [
+				'exception' => new Exception(),
+				'db'        => $conn->getDBname(),
+				'host'      => $conn->getServer(),
+				'pos'       => (string) $this->mWaitForPos,
+				'result'    => $result,
+			] );
+			// Wikia change - end
+
 			return false;
 		} else {
 			wfDebug( __METHOD__.": Done\n" );

--- a/includes/db/LoadBalancer.php
+++ b/includes/db/LoadBalancer.php
@@ -428,6 +428,8 @@ class LoadBalancer {
 			}
 		}
 
+		$then = microtime( true ); // Wikia change
+
 		wfDebug( __METHOD__.": Waiting for slave #$index to catch up...\n" );
 		$result = $conn->masterPosWait( $this->mWaitForPos, $this->mWaitTimeout );
 
@@ -444,6 +446,7 @@ class LoadBalancer {
 				'host'      => $conn->getServer(),
 				'pos'       => (string) $this->mWaitForPos,
 				'result'    => $result,
+				'waited'    => microtime( true ) - $then,
 			] );
 			// Wikia change - end
 


### PR DESCRIPTION
Cluster G is lagged quite a bit. Increase the sleep in `wfWaitForSlaves`.

Revert #7230 - log timeouts when waiting for slaves in `LoadBalancer` class

@drozdo / @michalroszka / @wladekb / @harnash 
