### PR TITLE
PLATFORM-1219: skip starter cleanup during CNW

### DIFF
--- a/extensions/wikia/CreateNewWiki/CreateWiki.php
+++ b/extensions/wikia/CreateNewWiki/CreateWiki.php
@@ -1113,6 +1113,7 @@ class CreateWiki {
 		if ( $starter ) {
 			$tables = $this->mStarterTables[ "*" ];
 
+			$then = microtime( true );
 			$cmd = sprintf(
 				"%s -h%s -u%s -p%s %s %s | %s -h%s -u%s -p%s %s",
 				$this->mMYSQLdump,
@@ -1129,6 +1130,13 @@ class CreateWiki {
 			);
 			wfShellExec( $cmd, $retVal );
 
+			$this->info( 'importStarter: mysqldump', [
+				'host'    => $starter[ "host" ],
+				'retval'  => $retVal,
+				'starter' => $starter[ "dbStarter" ],
+				'took'    => microtime( true ) - $then,
+			] );
+
 			if ($retVal > 0) {
 				$this->error( 'starter dump import failed', [
 					'starter_db' => $dbStarter
@@ -1136,8 +1144,16 @@ class CreateWiki {
 				return false;
 			}
 
+			$then = microtime( true );
+
 			wfDebugLog( "createwiki", __METHOD__ . ": Import {$this->mIP}/maintenance/cleanupStarter.sql \n", true );
 			$error = $this->mNewWiki->dbw->sourceFile( "{$this->mIP}/maintenance/cleanupStarter.sql", false, false, __METHOD__ );
+
+			$this->info( 'importStarter: cleanup', [
+				'err'     => $error,
+				'took'    => microtime( true ) - $then,
+			] );
+
 			if ($error !== true) {
 				wfDebugLog( "createwiki", __METHOD__ . ": Import starter failed\n", true );
 				return false;

--- a/extensions/wikia/CreateNewWiki/CreateWiki.php
+++ b/extensions/wikia/CreateNewWiki/CreateWiki.php
@@ -1159,6 +1159,10 @@ class CreateWiki {
 				return false;
 			}
 **/
+
+			// starter import performs lots of inserts, wait for slaves to catch up
+			$this->waitForSlaves( __METHOD__ );
+
 			$cmd = sprintf(
 				"SERVER_ID=%d %s %s/maintenance/updateArticleCount.php --update --conf %s",
 				$this->mNewWiki->city_id,

--- a/extensions/wikia/CreateNewWiki/CreateWiki.php
+++ b/extensions/wikia/CreateNewWiki/CreateWiki.php
@@ -1143,7 +1143,7 @@ class CreateWiki {
 				] );
 				return false;
 			}
-
+/**
 			$then = microtime( true );
 
 			wfDebugLog( "createwiki", __METHOD__ . ": Import {$this->mIP}/maintenance/cleanupStarter.sql \n", true );
@@ -1158,7 +1158,7 @@ class CreateWiki {
 				wfDebugLog( "createwiki", __METHOD__ . ": Import starter failed\n", true );
 				return false;
 			}
-
+**/
 			$cmd = sprintf(
 				"SERVER_ID=%d %s %s/maintenance/updateArticleCount.php --update --conf %s",
 				$this->mNewWiki->city_id,


### PR DESCRIPTION
Apply a hot fix for [PLATFORM-1219](https://wikia-inc.atlassian.net/browse/PLATFORM-1219) by skipping starter cleanup step which performs DELETE queries that affect ~4k rows.

@adamkarminski / @Grunny / @lgarczewski / @michalroszka 
