### PR TITLE
SOC-797 Clearing encrypted access_token cookie on logout

### DIFF
--- a/extensions/wikia/Helios/User.class.php
+++ b/extensions/wikia/Helios/User.class.php
@@ -196,6 +196,22 @@ class User {
 			time() - self::ACCESS_TOKEN_COOKIE_TTL,
 			\WebResponse::NO_COOKIE_PREFIX
 		);
+		self::clearEncryptedAccessTokenCookie($response);
+	}
+
+	/**
+	 * Mercury's backend (Hapi) is setting access_token cookie in an encrypted form, so we need
+	 * to destroy this one as well on UserLogout
+	 * This is a temporary change which will be deleted while implementing SOC-798
+	 * @param $response
+	 */
+	public static function clearEncryptedAccessTokenCookie($response) {
+		$response->setcookie(
+			'sid',
+			'',
+			time() - self::ACCESS_TOKEN_COOKIE_TTL,
+			\WebResponse::NO_COOKIE_PREFIX
+		);
 	}
 
 	/**

--- a/extensions/wikia/Helios/User.class.php
+++ b/extensions/wikia/Helios/User.class.php
@@ -196,7 +196,7 @@ class User {
 			time() - self::ACCESS_TOKEN_COOKIE_TTL,
 			\WebResponse::NO_COOKIE_PREFIX
 		);
-		self::clearEncryptedAccessTokenCookie($response);
+		self::clearEncryptedAccessTokenCookie( $response );
 	}
 
 	/**

--- a/extensions/wikia/Helios/User.class.php
+++ b/extensions/wikia/Helios/User.class.php
@@ -205,7 +205,7 @@ class User {
 	 * This is a temporary change which will be deleted while implementing SOC-798
 	 * @param $response
 	 */
-	public static function clearEncryptedAccessTokenCookie($response) {
+	public static function clearEncryptedAccessTokenCookie( $response ) {
 		$response->setcookie(
 			'sid',
 			'',


### PR DESCRIPTION
Mercury's backend for the New Login Flow is dependent on hapi-auth-cookie, which authenticates all the routes and controls the session. It has one downside for us - it's encrypting the cookie and this feature cannot be switched off. 

To work in compliance with Mediawiki Login, we need to set the unencrypted access_token cookie anyway, which means we end up setting it two times (one is encrypted, the second one is not). We will get rid of the hapi-auth-cookie support here: https://wikia-inc.atlassian.net/browse/SOC-798 , however, this might take a bit of time on implementation and considering the business value of releasing the New Login as soon as possible we should end up with the safest workaround until the SOC-798 is done.

Since we're using Mediawiki's logout so far, it's just enough to clear the 'sid' cookie (the encrypted one) once the user is logging out, since access_token is already being cleared.
