### PR TITLE
VE-1898: Do not use a proxy when "uploading" video from 3rd party provider

### DIFF
--- a/extensions/VisualEditor/wikia/ApiAddMediaTemporary.php
+++ b/extensions/VisualEditor/wikia/ApiAddMediaTemporary.php
@@ -100,6 +100,7 @@ class ApiAddMediaTemporary extends ApiAddMedia {
 			if ( !UploadBase::isEnabled() ) {
 				$this->dieUsageMsg( 'uploaddisabled' );
 			}
+			F::app()->wg->DisableProxy = true;
 			$this->mUpload = new UploadFromUrl();
 			$this->mUpload->initializeFromRequest( new FauxRequest(
 				array(


### PR DESCRIPTION
This is implemented following suggestion from https://github.com/Wikia/app/commit/40e66384eff4755bf31c16ca4c7d316c783dfe66.
Ultimately it shouldn't be needed and there should be a nice API for video operation - but we don't have time to handle it now.

Proxy should not be used especially for uploading videos from Youtube since their recent change that video thumbnails are served with HTTPS (instead of HTTP as before), and our proxy does not support HTTPS.
