### PR TITLE
removeTempUser: maintenance script removing TempUser accounts

### DIFF
--- a/includes/specials/SpecialUserlogin.php
+++ b/includes/specials/SpecialUserlogin.php
@@ -1080,14 +1080,7 @@ class LoginForm extends SpecialPage {
 
 		$np = $u->randomPassword();
 		$u->setNewpassword( $np, $throttle );
-
-		/* Wikia change begin */
-		//@TODO get rid of TempUser handling when it will be globally disabled
-		$tempUser = null;
-		wfRunHooks( 'MailPasswordTempUser' , array( &$u, &$tempUser ) );
-		if ( empty($tempUser) ) {
-			$u->saveSettings();
-		}
+		$u->saveSettings();
 
 		/* Wikia change begin - @author: Uberfuzzy */
 		/* use noReply address (if available) */

--- a/maintenance/wikia/removeTempUser.php
+++ b/maintenance/wikia/removeTempUser.php
@@ -144,8 +144,8 @@ class RemoveTempUserAccounts extends Maintenance {
 			$this->removeBatch( $dbw, $batch );
 
 			// prevent slave lag
-			wfWaitForSlaves( $db );
-			sleep( 1 );
+			// we're potentially performing deletes on all clusters
+			sleep( 15 );
 		}
 
 		$this->output( "\n\nDone!\n" );

--- a/maintenance/wikia/removeTempUser.php
+++ b/maintenance/wikia/removeTempUser.php
@@ -1,0 +1,138 @@
+<?php
+
+/**
+ * Script that removes old TempUser accounts
+ *
+ * @see PLATFORM-1146
+ * @see CE-1182
+ *
+ * @author Macbre
+ * @ingroup Maintenance
+ */
+
+require_once( __DIR__ . '/../Maintenance.php' );
+
+class RemoveTempUserAccounts extends Maintenance {
+
+	const BATCH = 1000;
+	const TEMPUSER_PREFIX = 'TempUser';
+	const USER_TABLE = '`user`';
+
+	/**
+	 * Set script options
+	 */
+	public function __construct() {
+		parent::__construct();
+		$this->addOption( 'dry-run', 'Don\'t perform any operations' );
+		$this->addOption( 'db', 'User database to clean [defaults to shared DB]', false, true /* $withArg */ );
+		$this->mDescription = 'This script removes TempUser accounts';
+	}
+
+	/**
+	 * Log helper
+	 *
+	 * @param string $msg
+	 * @param array $context
+	 */
+	private function info( $msg, Array $context = [] ) {
+		Wikia\Logger\WikiaLogger::instance()->info( $msg, $context );
+	}
+
+	/**
+	 * Get temp user accounts
+	 *
+	 * - check if these accounts are really temp ones
+	 * - skip accounts with user_touched changed in the last year
+	 *
+	 * @param DatabaseBase $db
+	 * @return array
+	 */
+	private function getTempUserAccounts( DatabaseBase $db ) {
+		$res = $db->select(
+			self::USER_TABLE,
+			[
+				'user_id',
+				'user_name'
+			],
+			[
+				'user_name ' . $db->buildLike( self::TEMPUSER_PREFIX, $db->anyString() ),
+				sprintf( 'user_touched < "%s"', wfTimestamp( TS_DB, time() - 86400 * 365 ) ),
+			]
+		);
+
+		$users = [];
+		while( $user = $res->fetchObject() ) {
+			// check if this is really a temp user: "TempUser" + <user ID>
+			if ( $user->user_name === self::TEMPUSER_PREFIX . $user->user_id ) {
+				$users[] = intval( $user->user_id );
+			}
+			else {
+				$this->output( sprintf(" > skipped %s (#%d)\n", $user->user_name, $user->user_id ) );
+			}
+		}
+
+		return $users;
+	}
+
+	public function execute() {
+		global $wgExternalSharedDB;
+		$db = $this->getOption( 'db', $wgExternalSharedDB );
+		$isDryRun = $this->hasOption( 'dry-run' );
+
+		$this->output( "Removing temp user accounts from '$db'...\n");
+
+		$dbr = wfGetDB( DB_SLAVE, [], $db );
+		$dbw = wfGetDB( DB_MASTER, [], $db );
+
+		// get the list of accounts for remove
+		$users =$this->getTempUserAccounts( $dbr );
+
+		// split accounts into batches and remove them
+		$batches = array_chunk( $users, self::BATCH );
+
+		$this->output( "\nAccounts found:      " . count( $users ) );
+		$this->output( "\nRemoving in batches: " . count( $batches ) );
+		$this->output( "\n\n" );
+
+		$this->info( 'Accounts found', [
+			'accounts' => count( $users ),
+			'batches'  => count( $batches ),
+		] );
+
+		if ( $isDryRun ) {
+			return;
+		}
+
+		$this->readconsole( "Hit enter to continue..." );
+
+		// close any open transaction
+		$dbw->commit( __METHOD__ );
+
+		foreach ($batches as $batch ) {
+			$dbw->begin( __METHOD__ );
+
+			$rows = 0;
+
+			// remove entries from user table
+			$dbw->delete( self::USER_TABLE,  [ 'user_id' => $batch ], __METHOD__ );
+			$rows += $dbw->affectedRows();
+
+			// remove entries from user_properties table
+			$dbw->delete( 'user_properties', [ 'up_user' => $batch ], __METHOD__ );
+			$rows += $dbw->affectedRows();
+
+			$dbw->commit( __METHOD__ );
+			wfWaitForSlaves( $db ); // prevent slave lag
+
+			$this->info( 'Batch removed', [
+				'batch' => count( $batch ),
+				'rows'  => $rows,
+			] );
+		}
+
+		$this->output( "\n\nDone!\n" );
+	}
+}
+
+$maintClass = "RemoveTempUserAccounts";
+require_once( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/wikia/removeTempUser.php
+++ b/maintenance/wikia/removeTempUser.php
@@ -61,13 +61,13 @@ class RemoveTempUserAccounts extends Maintenance {
 		);
 
 		$users = [];
-		while( $user = $res->fetchObject() ) {
+		while ( $user = $res->fetchObject() ) {
 			// check if this is really a temp user: "TempUser" + <user ID>
 			if ( $user->user_name === self::TEMPUSER_PREFIX . $user->user_id ) {
 				$users[] = intval( $user->user_id );
 			}
 			else {
-				$this->output( sprintf(" > skipped %s (#%d)\n", $user->user_name, $user->user_id ) );
+				$this->output( sprintf( " > skipped %s (#%d)\n", $user->user_name, $user->user_id ) );
 			}
 		}
 
@@ -79,13 +79,13 @@ class RemoveTempUserAccounts extends Maintenance {
 		$db = $this->getOption( 'db', $wgExternalSharedDB );
 		$isDryRun = $this->hasOption( 'dry-run' );
 
-		$this->output( "Removing temp user accounts from '$db'...\n");
+		$this->output( "Removing temp user accounts from '$db'...\n" );
 
 		$dbr = wfGetDB( DB_SLAVE, [], $db );
 		$dbw = wfGetDB( DB_MASTER, [], $db );
 
 		// get the list of accounts for remove
-		$users =$this->getTempUserAccounts( $dbr );
+		$users = $this->getTempUserAccounts( $dbr );
 
 		// split accounts into batches and remove them
 		$batches = array_chunk( $users, self::BATCH );
@@ -108,7 +108,7 @@ class RemoveTempUserAccounts extends Maintenance {
 		// close any open transaction
 		$dbw->commit( __METHOD__ );
 
-		foreach ($batches as $batch ) {
+		foreach ( $batches as $batch ) {
 			$dbw->begin( __METHOD__ );
 
 			$rows = 0;

--- a/maintenance/wikia/removeTempUser.php
+++ b/maintenance/wikia/removeTempUser.php
@@ -57,7 +57,8 @@ class RemoveTempUserAccounts extends Maintenance {
 			[
 				'user_name ' . $db->buildLike( self::TEMPUSER_PREFIX, $db->anyString() ),
 				sprintf( 'user_touched < "%s"', wfTimestamp( TS_DB, time() - 86400 * 365 ) ),
-			]
+			],
+			__METHOD__
 		);
 
 		$users = [];


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CE-1182 (required by https://wikia-inc.atlassian.net/browse/PLATFORM-1055)
- remove `TempUser%` accounts from a given database (defaults to `wikicities`, can be used on `uncyclo` as well - via `--db` option)
- check the structure of the user name - `TempUser+<user ID>`
- remove accounts not touched in the last year only
- perform deletes in batches of 1000 users to limit the impact on shared DB (load and slave lag)

**70% of all accounts** on `wikicities` are TempUsers and ~10% on uncyclo. Let's finally clean it up :)

Based on @kamilkoterba's https://github.com/Wikia/community-engineering-misc/pull/8

@Wikia/community-engineering / @michalroszka 
