### PR TITLE
Update DefaultSettings.php

### DIFF
--- a/includes/DefaultSettings.php
+++ b/includes/DefaultSettings.php
@@ -33,7 +33,7 @@ $wgConf = new SiteConfiguration;
 /** @endcond */
 
 /** MediaWiki version number */
-$wgVersion = '1.19.24';
+$wgVersion = '1.25';
 
 /** Name of the site. It must be changed in LocalSettings.php */
 $wgSitename = 'MediaWiki';


### PR DESCRIPTION
When will Wikia use a newer mediawiki version since mediawiki 1.19 gets discontinued this month. and wikia should use latest mediawiki to get latest features.
