### PR TITLE
ADEN-1684 Block BTF slots on premium campaign

### DIFF
--- a/extensions/wikia/AdEngine/AdEngine2ContextService.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2ContextService.class.php
@@ -29,7 +29,7 @@ class AdEngine2ContextService {
 			return [
 				'opts' => $this->filterOutEmptyItems( [
 					'adsInContent' => $wg->EnableAdsInContent,
-					'delayBtf' => $wg->AdDelayBTF,
+					'delayBtf' => $wg->AdDriverDelayBelowTheFold,
 					'enableAdsInMaps' => $wg->AdDriverEnableAdsInMaps,
 					'enableInvisibleHighImpactSlot' => $wg->AdDriverEnableInvisibleHighImpactSlot,
 					'pageType' => $adPageTypeService->getPageType(),

--- a/extensions/wikia/AdEngine/AdEngine2ContextService.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2ContextService.class.php
@@ -29,6 +29,7 @@ class AdEngine2ContextService {
 			return [
 				'opts' => $this->filterOutEmptyItems( [
 					'adsInContent' => $wg->EnableAdsInContent,
+					'delayBtf' => $wg->AdDelayBTF,
 					'enableAdsInMaps' => $wg->AdDriverEnableAdsInMaps,
 					'enableInvisibleHighImpactSlot' => $wg->AdDriverEnableInvisibleHighImpactSlot,
 					'pageType' => $adPageTypeService->getPageType(),

--- a/extensions/wikia/AdEngine/AdEngine2Hooks.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2Hooks.class.php
@@ -92,7 +92,10 @@ class AdEngine2Hooks {
 
 		$adContext = ( new AdEngine2ContextService() )->getContext( $wgTitle, $skinName );
 
-		$vars['ads'] = ['context' => $adContext];
+		$vars['ads'] = [
+			'context' => $adContext,
+			'runtime' => [],
+		];
 
 		// Legacy vars:
 		$vars['adslots2'] = [];                  // Queue for ads registration

--- a/extensions/wikia/AdEngine/js/provider/directGpt.js
+++ b/extensions/wikia/AdEngine/js/provider/directGpt.js
@@ -130,13 +130,17 @@ define('ext.wikia.adEngine.provider.directGpt', [
 	}
 
 	function fillInSlotWithDelay(slotName, success, hop) {
-		if (context.opts.delayBtf && (!gptFlushed || pendingSlots.length > 0)) {
-			delayBtfSlot(slotName, success, hop);
-		} else if (window.ads.runtime.disableBtf && !gptConfig[slotName]) {
-			blockBtfSlot(slotName, success);
-		} else {
-			provider.fillInSlot(slotName, success, hop);
+		if (context.opts.delayBtf) {
+			if (!gptFlushed || pendingSlots.length > 0) {
+				delayBtfSlot(slotName, success, hop);
+				return;
+			} else if (window.ads.runtime.disableBtf && !gptConfig[slotName]) {
+				blockBtfSlot(slotName, success);
+				return;
+			}
 		}
+
+		provider.fillInSlot(slotName, success, hop);
 	}
 
 	return {

--- a/extensions/wikia/AdEngine/js/provider/directGpt.js
+++ b/extensions/wikia/AdEngine/js/provider/directGpt.js
@@ -102,14 +102,7 @@ define('ext.wikia.adEngine.provider.directGpt', [
 
 	function pushDelayedQueue() {
 		delayedSlotsQueue.forEach(function (slot) {
-			if (window.ads.runtime.disableBtf) {
-				slot.success({
-					adType: 'blocked'
-				});
-				slotTweaker.hide(slot.slotName);
-				return;
-			}
-			provider.fillInSlot(slot.slotName, slot.success, slot.hop);
+			fillInSlotWithDelay(slot.slotName, slot.success, slot.hop);
 		});
 	}
 
@@ -129,9 +122,18 @@ define('ext.wikia.adEngine.provider.directGpt', [
 		});
 	}
 
+	function blockBtfSlot(slotName, success) {
+		success({
+			adType: 'blocked'
+		});
+		slotTweaker.hide(slotName);
+	}
+
 	function fillInSlotWithDelay(slotName, success, hop) {
 		if (context.opts.delayBtf && (!gptFlushed || pendingSlots.length > 0)) {
 			delayBtfSlot(slotName, success, hop);
+		} else if (window.ads.runtime.disableBtf && !gptConfig[slotName]) {
+			blockBtfSlot(slotName, success);
 		} else {
 			provider.fillInSlot(slotName, success, hop);
 		}

--- a/extensions/wikia/AdEngine/js/provider/directGpt.js
+++ b/extensions/wikia/AdEngine/js/provider/directGpt.js
@@ -70,10 +70,10 @@ define('ext.wikia.adEngine.provider.directGpt', [
 					slotTweaker.removeDefaultHeight(slotName);
 					slotTweaker.removeTopButtonIfNeeded(slotName);
 					slotTweaker.adjustLeaderboardSize(slotName);
-					removePendingSlot(slotName);
+					removePendingSlotAndPushDelayedQueue(slotName);
 				},
 				beforeHop: function (slotName) {
-					removePendingSlot(slotName);
+					removePendingSlotAndPushDelayedQueue(slotName);
 				},
 				shouldFlush: function (slotName) {
 					log(['shouldFlush', slotName]);
@@ -87,7 +87,7 @@ define('ext.wikia.adEngine.provider.directGpt', [
 			}
 		);
 
-	function removePendingSlot(slotName) {
+	function removePendingSlotAndPushDelayedQueue(slotName) {
 		if (!context.opts.delayBtf) {
 			return;
 		}

--- a/extensions/wikia/AdEngine/js/provider/directGpt.js
+++ b/extensions/wikia/AdEngine/js/provider/directGpt.js
@@ -1,14 +1,18 @@
 /*global define*/
 /*jshint maxlen: 150*/
 define('ext.wikia.adEngine.provider.directGpt', [
+	'ext.wikia.adEngine.adContext',
 	'ext.wikia.adEngine.provider.factory.wikiaGpt',
 	'ext.wikia.adEngine.slotTweaker',
 	'wikia.log'
-], function (factory, slotTweaker, log) {
+], function (adContext, factory, slotTweaker, log) {
 	'use strict';
 
-	var logGroup = 'ext.wikia.adEngine.provider.directGpt',
+	var context = adContext.getContext(),
+		logGroup = 'ext.wikia.adEngine.provider.directGpt',
 		gptFlushed = false,
+		pendingSlots = [],
+		delayedSlotsQueue = [],
 		slotMap = {
 			CORP_TOP_LEADERBOARD:       {size: '728x90,1030x130,1030x65,1030x250,970x365,970x250,970x90,970x66,970x180,980x150', loc: 'top'},
 			CORP_TOP_RIGHT_BOXAD:       {size: '300x250,300x600,300x1050', loc: 'top'},
@@ -54,30 +58,88 @@ define('ext.wikia.adEngine.provider.directGpt', [
 			CORP_TOP_RIGHT_BOXAD: 'flush',
 			TOP_RIGHT_BOXAD:      'flush',
 			HOME_TOP_RIGHT_BOXAD: 'flush',
-			GPT_FLUSH:            'flushonly'
-		};
+			GPT_FLUSH:            'flush'
+		},
+		provider = factory.createProvider(
+			logGroup,
+			'DirectGpt',
+			'gpt',
+			slotMap,
+			{
+				beforeSuccess: function (slotName) {
+					slotTweaker.removeDefaultHeight(slotName);
+					slotTweaker.removeTopButtonIfNeeded(slotName);
+					slotTweaker.adjustLeaderboardSize(slotName);
+					removePendingSlot(slotName);
+				},
+				beforeHop: function (slotName) {
+					removePendingSlot(slotName);
+				},
+				shouldFlush: function (slotName) {
+					log(['shouldFlush', slotName]);
+					if (gptConfig[slotName] === 'flush') {
+						gptFlushed = true;
+					}
 
-	return factory.createProvider(
-		logGroup,
-		'DirectGpt',
-		'gpt',
-		slotMap,
-		{
-			beforeSuccess: function (slotName) {
-				slotTweaker.removeDefaultHeight(slotName);
-				slotTweaker.removeTopButtonIfNeeded(slotName);
-				slotTweaker.adjustLeaderboardSize(slotName);
-			},
-			shouldFlush: function (slotName) {
-				log(['shouldFlush', slotName]);
-
-				if (gptConfig[slotName] === 'flushonly' || gptConfig[slotName] === 'flush') {
-					gptFlushed = true; // Setting the module-scope var here
+					log(['shouldFlush', slotName, gptFlushed]);
+					return gptFlushed;
 				}
+			}
+		);
 
-				log(['shouldFlush', slotName, gptFlushed]);
-				return gptFlushed;
+	function removePendingSlot(slotName) {
+		if (!context.opts.delayBtf) {
+			return;
+		}
+		var index = pendingSlots.indexOf(slotName);
+		if (index > -1) {
+			pendingSlots.splice(index, 1);
+			if (pendingSlots.length === 0 && delayedSlotsQueue.length) {
+				pushDelayedQueue();
 			}
 		}
-	);
+	}
+
+	function pushDelayedQueue() {
+		delayedSlotsQueue.forEach(function (slot) {
+			if (window.ads.runtime.disableBtf) {
+				slot.success({
+					adType: 'blocked'
+				});
+				slotTweaker.hide(slot.slotName);
+				return;
+			}
+			provider.fillInSlot(slot.slotName, slot.success, slot.hop);
+		});
+	}
+
+	function delayBtfSlot(slotName, success, hop) {
+		if (!!gptConfig[slotName]) {
+			if (!gptFlushed) {
+				pendingSlots.push(slotName);
+			}
+			provider.fillInSlot(slotName, success, hop);
+			return;
+		}
+
+		delayedSlotsQueue.push({
+			slotName: slotName,
+			success: success,
+			hop: hop
+		});
+	}
+
+	function fillInSlotWithDelay(slotName, success, hop) {
+		if (context.opts.delayBtf && (!gptFlushed || pendingSlots.length > 0)) {
+			delayBtfSlot(slotName, success, hop);
+		} else {
+			provider.fillInSlot(slotName, success, hop);
+		}
+	}
+
+	return {
+		name: provider.providerName,
+		canHandleSlot: provider.canHandleSlot,
+		fillInSlot: fillInSlotWithDelay
+	};
 });

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1279,10 +1279,10 @@ $wgEnableJavaScriptErrorLogging = false;
 $wgEnableAdEngineExt = true;
 
 /**
- * @name $wgAdDelayBTF
+ * @name $wgAdDriverDelayBelowTheFold
  * Prevents from loading BTF before ATF ad slots
  */
-$wgAdDelayBTF;
+$wgAdDriverDelayBelowTheFold = false;
 
 /**
  * @name $wgAdDriverUseAdsAfterInfobox

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1279,6 +1279,12 @@ $wgEnableJavaScriptErrorLogging = false;
 $wgEnableAdEngineExt = true;
 
 /**
+ * @name $wgAdDelayBTF
+ * Prevents from loading BTF before ATF ad slots
+ */
+$wgAdDelayBTF;
+
+/**
  * @name $wgAdDriverUseAdsAfterInfobox
  * Enable new mobile_in_content slot after infobox placement
  */


### PR DESCRIPTION
Delay BTF slots load when wgAdDriverDelayBelowTheFold variable is enabled and after ATF slots are loaded, decide if BTF part should be flushed (based on window.ads.runtime.disableBtf variable).
