### PR TITLE
RemoveTempUserAccounts: run per cluster

### DIFF
--- a/maintenance/wikia/removeTempUser.php
+++ b/maintenance/wikia/removeTempUser.php
@@ -95,11 +95,6 @@ class RemoveTempUserAccounts extends Maintenance {
 
 		$dbw->commit( __METHOD__ );
 
-		// remove from wikicities_cX
-		foreach ( $batch as $userId ) {
-			ExternalUser_Wikia::removeFromSecondaryClusters( $userId );
-		}
-
 		$this->info( 'Batch removed', [
 			'batch' => count( $batch ),
 			'rows'  => $rows,
@@ -145,7 +140,7 @@ class RemoveTempUserAccounts extends Maintenance {
 
 			// prevent slave lag
 			// we're potentially performing deletes on all clusters
-			sleep( 15 );
+			wfWaitForSlaves( $db );
 		}
 
 		$this->output( "\n\nDone!\n" );


### PR DESCRIPTION
Improves #7295

Run this script on per-cluster basis to avoid causing lag on all clusters by calling `ExternalUser_Wikia::removeFromSecondaryClusters()`.

@michalroszka / @Wikia/community-engineering 
