### PR TITLE
(MAIN-4620) Sanitize custom theme class in PortableInfobox

### DIFF
--- a/extensions/wikia/PortableInfobox/controllers/PortableInfoboxParserTagController.class.php
+++ b/extensions/wikia/PortableInfobox/controllers/PortableInfoboxParserTagController.class.php
@@ -104,7 +104,7 @@ class PortableInfoboxParserTagController extends WikiaController {
 		$value = isset( $params[ 'theme-source' ] ) ? $frame->getArgument( $params[ 'theme-source' ] ) : false;
 		$themeName = $this->getThemeName( $params, $value );
 		//make sure no whitespaces, prevents side effects
-		return self::INFOBOX_THEME_PREFIX . preg_replace( '|\s+|s', '-', $themeName );
+		return Sanitizer::escapeClass( self::INFOBOX_THEME_PREFIX . preg_replace( '|\s+|s', '-', $themeName ) );
 	}
 
 	private function getThemeName( $params, $value ) {

--- a/extensions/wikia/PortableInfobox/templates/PortableInfoboxWrapper.mustache
+++ b/extensions/wikia/PortableInfobox/templates/PortableInfoboxWrapper.mustache
@@ -1,1 +1,1 @@
-<aside class="portable-infobox{{#theme}} {{{theme}}}{{/theme}}">{{{content}}}</aside>
+<aside class="portable-infobox{{#theme}} {{theme}}{{/theme}}">{{{content}}}</aside>


### PR DESCRIPTION
Sanitize the custom theme class users can provide in Portable Infoboxes.
Sanitizer::escapeClass only allows valid characters in a class name
through.

/cc @idradm @RafLeszczynski @SebastianMarzjan 
