### PR TITLE
Ce 1877 flags empty state modal message 2

### DIFF
--- a/extensions/wikia/Flags/Flags.i18n.php
+++ b/extensions/wikia/Flags/Flags.i18n.php
@@ -11,9 +11,11 @@ $messages = [];
 $messages['en'] = [
 	'flags-description' => 'Portable flags',
 	'flags-edit-form-more-info' => 'More info >',
-	'flags-edit-modal-title' => 'Flags',
-	'flags-edit-modal-done-button-text' => 'Done',
 	'flags-edit-modal-cancel-button-text' => 'Cancel',
+	'flags-edit-modal-close-button-text' => 'Close',
+	'flags-edit-modal-done-button-text' => 'Done',
+	'flags-edit-modal-no-flags-on-community' => 'This community doesn\'t have any flags set up. [[Help:Interwiki_link|Learn more about flags]] or [[Special:Flags|define the flags for this community]].',
+	'flags-edit-modal-title' => 'Flags'
 ];
 
 /**
@@ -22,7 +24,9 @@ $messages['en'] = [
 $messages['qqq'] = [
 	'flags-description' => '{{desc}}',
 	'flags-edit-form-more-info' => 'A link that is displayed next to a checkbox in the edit form of Flags. It links to a template used by the flag that it is next to.',
-	'flags-edit-modal-title' => 'Title of the form for editing flags displayed on headline of modal containing the form.',
-	'flags-edit-modal-done-button-text' => 'Text on the button that submits changes done to flags.',
 	'flags-edit-modal-cancel-button-text' => 'Text on the button that closes flags edit modal and ignores changes.',
+	'flags-edit-modal-close-button-text' => 'Text on the button that closes flags edit modal.',
+	'flags-edit-modal-done-button-text' => 'Text on the button that submits changes done to flags.',
+	'flags-edit-modal-no-flags-on-community' => 'Message on modal appearing when there are no flags types defined on the wiki.',
+	'flags-edit-modal-title' => 'Title of the form for editing flags displayed on headline of modal containing the form.'
 ];

--- a/extensions/wikia/Flags/Flags.setup.php
+++ b/extensions/wikia/Flags/Flags.setup.php
@@ -73,6 +73,7 @@ $wgResourceModules['ext.wikia.Flags'] = [
 		'flags-edit-modal-title',
 		'flags-edit-modal-done-button-text',
 		'flags-edit-modal-cancel-button-text',
+		'flags-edit-modal-close-button-text',
 	],
 	'localBasePath' => __DIR__,
 	'remoteExtPath' => 'wikia/Flags'

--- a/extensions/wikia/Flags/controllers/templates/FlagsController_editForm.php
+++ b/extensions/wikia/Flags/controllers/templates/FlagsController_editForm.php
@@ -1,3 +1,8 @@
+<?php
+if ( empty($flags) ) :
+	echo wfMessage( 'flags-edit-modal-no-flags-on-community' )->parse();
+else:
+ ?>
 <form action="<?= Sanitizer::cleanUrl( $formSubmitUrl ) ?>" method="POST" id="flagsEditForm">
 	<ul>
 		<?php foreach ( $flags as $flagTypeId => $flag ): ?>
@@ -30,3 +35,6 @@
 	<input type="hidden" name="page_id" value="<?= Sanitizer::encodeAttribute( $pageId ) ?>">
 	<input type="hidden" name="edit_token" value="<?= Sanitizer::encodeAttribute( $editToken ) ?>">
 </form>
+<?php
+endif;
+?>

--- a/extensions/wikia/Flags/scripts/FlagsModal.js
+++ b/extensions/wikia/Flags/scripts/FlagsModal.js
@@ -33,7 +33,8 @@ require(['jquery', 'wikia.loader', 'mw'], function ($, loader, mw) {
 				{
 					key: 'event',
 					value: 'close'
-				}]
+				}
+			]
 		}
 	}],
 
@@ -97,6 +98,12 @@ require(['jquery', 'wikia.loader', 'mw'], function ($, loader, mw) {
 	 * One of sub-tasks for getting modal shown
 	 */
 	function createComponent(uiModal) {
+		/* Look for existence of form tag to determine whether there are any flags on the wikia */
+		if (modalConfig.vars.content.indexOf('<form') > -1) {
+			modalConfig.vars.buttons = buttonsForFlagsExistingState;
+		} else {
+			modalConfig.vars.buttons = buttonForEmptyState;
+		}
 		/* Create the wrapping JS Object using the modalConfig */
 		uiModal.createComponent(modalConfig, processInstance);
 	}
@@ -109,18 +116,10 @@ require(['jquery', 'wikia.loader', 'mw'], function ($, loader, mw) {
 	function processInstance(modalInstance) {
 		var $flagsEditForm = modalInstance.$element.find('#flagsEditForm');
 		if ($flagsEditForm.length > 0) {
-			/* Render and add Done and Cancel buttons */
-			modalInstance.renderButtons(buttonsForFlagsExistingState);
-			modalInstance.$element.find('footer').html(buttonsForFlagsExistingState);
-
 			/* Submit flags edit form on Done button click */
 			modalInstance.bind('done', function () {
 				$flagsEditForm.trigger('submit');
 			});
-		} else {
-			/* Render and add Close button */
-			modalInstance.renderButtons(buttonForEmptyState);
-			modalInstance.$element.find('footer').html(buttonForEmptyState);
 		}
 
 		/* Show the modal */

--- a/extensions/wikia/Flags/scripts/FlagsModal.js
+++ b/extensions/wikia/Flags/scripts/FlagsModal.js
@@ -1,38 +1,50 @@
 require(['jquery', 'wikia.loader', 'mw'], function ($, loader, mw) {
 	'use strict';
 
+	/* Modal buttons config for done and cancel buttons */
+	var buttonsForFlagsExistingState = [{
+		vars: {
+			value: mw.message('flags-edit-modal-done-button-text').escaped(),
+			data: [
+				{
+					key: 'event',
+					value: 'done'
+				}
+			]
+		}
+	},
+	{
+		vars: {
+			value: mw.message('flags-edit-modal-cancel-button-text').escaped(),
+			data: [
+				{
+					key: 'event',
+					value: 'close'
+				}
+			]
+		}
+	}],
+
+	/* Modal close button config*/
+	buttonForEmptyState = [{
+		vars: {
+			value: mw.message('flags-edit-modal-close-button-text').escaped(),
+			data: [
+				{
+					key: 'event',
+					value: 'close'
+				}]
+		}
+	}],
+
 	/* Modal component configuration */
-	var modalConfig = {
+	modalConfig = {
 		vars: {
 			id: 'FlagsModal',
 			classes: ['edit-flags'],
 			size: 'medium', // size of the modal
 			content: '', // content
-			title: mw.message('flags-edit-modal-title').escaped(),
-			buttons: [ // buttons in the footer
-				{
-					vars: {
-						value: mw.message('flags-edit-modal-done-button-text').escaped(),
-						data: [
-							{
-								key: 'event',
-								value: 'done'
-							}
-						]
-					}
-				},
-				{
-					vars: {
-						value: mw.message('flags-edit-modal-cancel-button-text').escaped(),
-						data: [
-							{
-								key: 'event',
-								value: 'close'
-							}
-						]
-					}
-				}
-			]
+			title: mw.message('flags-edit-modal-title').escaped()
 		}
 	};
 
@@ -96,11 +108,20 @@ require(['jquery', 'wikia.loader', 'mw'], function ($, loader, mw) {
 	 */
 	function processInstance(modalInstance) {
 		var $flagsEditForm = modalInstance.$element.find('#flagsEditForm');
+		if ($flagsEditForm.length > 0) {
+			/* Render and add Done and Cancel buttons */
+			modalInstance.renderButtons(buttonsForFlagsExistingState);
+			modalInstance.$element.find('footer').html(buttonsForFlagsExistingState);
 
-		/* Submit flags edit form on Done button click */
-		modalInstance.bind('done', function () {
-			$flagsEditForm.trigger('submit');
-		});
+			/* Submit flags edit form on Done button click */
+			modalInstance.bind('done', function () {
+				$flagsEditForm.trigger('submit');
+			});
+		} else {
+			/* Render and add Close button */
+			modalInstance.renderButtons(buttonForEmptyState);
+			modalInstance.$element.find('footer').html(buttonForEmptyState);
+		}
 
 		/* Show the modal */
 		modalInstance.show();

--- a/resources/wikia/ui_components/modal/js/modal.js
+++ b/resources/wikia/ui_components/modal/js/modal.js
@@ -149,19 +149,7 @@ define( 'wikia.ui.modal', [
 		}
 
 		buttons = params.vars.buttons;
-		if ( $.isArray( buttons ) ) {
-			// Create buttons
-			buttons.forEach(function( button, index ) {
-				if ( typeof button === 'object' ) {
-
-					// Extend the button param with the modal default, get the button uicomponent,
-					// and render the params then replace the button params with the rendered html
-					buttons[ index ] = uiComponent.getSubComponent( 'button' ).render(
-						$.extend( true, {}, btnConfig, button )
-					);
-				}
-			});
-		}
+		Modal.prototype.renderButtons(buttons);
 
 		// extend default modal params with the one passed in constructor call
 		params = $.extend( true, {}, modalDefaults, params );
@@ -372,6 +360,26 @@ define( 'wikia.ui.modal', [
 	 */
 	Modal.prototype.setTitle = function( title ) {
 		this.$element.find( 'header h3' ).text( title );
+	};
+
+	/**
+	 * Renders buttons HTML and overrides buttons param with rendered values
+	 * @param {Array} title text
+	 */
+	Modal.prototype.renderButtons = function ( buttons ) {
+		if ( $.isArray( buttons ) ) {
+			// Create buttons
+			buttons.forEach(function( button, index ) {
+				if ( typeof button === 'object' ) {
+
+					// Extend the button param with the modal default, get the button uicomponent,
+					// and render the params then replace the button params with the rendered html
+					buttons[ index ] = uiComponent.getSubComponent( 'button' ).render(
+						$.extend( true, {}, btnConfig, button )
+					);
+				}
+			});
+		}
 	};
 
 	/** Public API */

--- a/resources/wikia/ui_components/modal/js/modal.js
+++ b/resources/wikia/ui_components/modal/js/modal.js
@@ -149,7 +149,19 @@ define( 'wikia.ui.modal', [
 		}
 
 		buttons = params.vars.buttons;
-		Modal.prototype.renderButtons(buttons);
+		if ( $.isArray( buttons ) ) {
+			// Create buttons
+			buttons.forEach(function( button, index ) {
+				if ( typeof button === 'object' ) {
+
+					// Extend the button param with the modal default, get the button uicomponent,
+					// and render the params then replace the button params with the rendered html
+					buttons[ index ] = uiComponent.getSubComponent( 'button' ).render(
+						$.extend( true, {}, btnConfig, button )
+					);
+				}
+			});
+		}
 
 		// extend default modal params with the one passed in constructor call
 		params = $.extend( true, {}, modalDefaults, params );
@@ -360,26 +372,6 @@ define( 'wikia.ui.modal', [
 	 */
 	Modal.prototype.setTitle = function( title ) {
 		this.$element.find( 'header h3' ).text( title );
-	};
-
-	/**
-	 * Renders buttons HTML and overrides buttons param with rendered values
-	 * @param {Array} title text
-	 */
-	Modal.prototype.renderButtons = function ( buttons ) {
-		if ( $.isArray( buttons ) ) {
-			// Create buttons
-			buttons.forEach(function( button, index ) {
-				if ( typeof button === 'object' ) {
-
-					// Extend the button param with the modal default, get the button uicomponent,
-					// and render the params then replace the button params with the rendered html
-					buttons[ index ] = uiComponent.getSubComponent( 'button' ).render(
-						$.extend( true, {}, btnConfig, button )
-					);
-				}
-			});
-		}
 	};
 
 	/** Public API */


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CE-1877
Adding empty message to modal instead of edit form when there are no flags on wiki.
Also needed to add buttons depending on whether there are flags or not, as we don't want to have save button when there are not flags.

To do that I also abstracted modal piece of code for rendering buttons to separate public method.

@Wikia/community-engineering , @nandy-andy
