### PR TITLE
CONCF-602 check if  $result has method "fetchObject" to avoid throwing fatals

### DIFF
--- a/includes/wikia/services/DataMartService.class.php
+++ b/includes/wikia/services/DataMartService.class.php
@@ -468,7 +468,9 @@ class DataMartService extends Service {
 				->LIMIT( 1 )
 				->cache( self::CACHE_TOP_ARTICLES )
 				->run( $db, function ( $result ) {
-					$row = $result->fetchObject( $result );
+					if ( method_exists( $result, 'fetchObject' ) ) {
+						$row = $result->fetchObject( $result );
+					}
 
 					if ( $row && isset( $row->c ) ) {
 						return $row->c;

--- a/includes/wikia/services/DataMartService.class.php
+++ b/includes/wikia/services/DataMartService.class.php
@@ -467,10 +467,8 @@ class DataMartService extends Service {
 				->AND_( 'period_id' )->EQUAL_TO( $period_id )
 				->LIMIT( 1 )
 				->cache( self::CACHE_TOP_ARTICLES )
-				->run( $db, function ( $result ) {
-					if ( method_exists( $result, 'fetchObject' ) ) {
-						$row = $result->fetchObject( $result );
-					}
+				->run( $db, function ( ResultWrapper $result ) {
+					$row = $result->fetchObject( $result );
 
 					if ( $row && isset( $row->c ) ) {
 						return $row->c;


### PR DESCRIPTION
Following fatal was thrown:
PHP Fatal error:  Call to a member function fetchObject() on a non-object in /usr/wikia/slot1/4119/src/includes/wikia/services/DataMartService.class.php on line 471

This fix should suppress the error.
Although I don't see this error happening in Kibana ([kibana](https://kibana.wikia-inc.com/index.html#/dashboard/script/logstash.js?query=%40source_host%3A%20ap-s%2A%20AND%20%22PHP%20Fatal%20error%3A%20%20Call%20to%20a%20member%20function%20fetchObject%28%29%20on%20a%20non-object%22%20AND%20%22/src/includes/wikia/services/DataMartService.class.php%20on%20line%20471%22&from=6h&fields=@timestamp,@message,@fields.url,@source_host)) - I blame host although it would be nice to know the root cause.

@macbre @hakubo @SebastianMarzjan 
