### PR TITLE
CE-1856 i18n fixes

### DIFF
--- a/extensions/wikia/Flags/Flags.hooks.php
+++ b/extensions/wikia/Flags/Flags.hooks.php
@@ -34,7 +34,7 @@ class Hooks {
 		if ( \Wikia::isContentNamespace() ) {
 			$links['views'][self::FLAGS_DROPDOWN_ACTION] = [
 				'href' => '#',
-				'text' => 'Flags',
+				'text' => wfMessage( 'flags-edit-modal-title' )->escaped(),
 				'class' => 'flags-access-class',
 			];
 		}

--- a/extensions/wikia/Flags/Flags.i18n.php
+++ b/extensions/wikia/Flags/Flags.i18n.php
@@ -14,7 +14,7 @@ $messages['en'] = [
 	'flags-edit-modal-cancel-button-text' => 'Cancel',
 	'flags-edit-modal-close-button-text' => 'Close',
 	'flags-edit-modal-done-button-text' => 'Done',
-	'flags-edit-modal-no-flags-on-community' => 'This community doesn\'t have any flags set up. [[Help:Interwiki_link|Learn more about flags]] or [[Special:Flags|define the flags for this community]].',
+	'flags-edit-modal-no-flags-on-community' => 'This community doesn\'t have any flags set up. [[Help:Flags|Learn more about flags]] or [[Special:Flags|define the flags for this community]].',
 	'flags-edit-modal-title' => 'Flags',
 	'flags-edit-modal-exception' => "Unfortunately, we are not able to display this due to the following error:\n\n\n\n$1\n\n\n\nThis error has already been reported to the technical team. Please feel free to use [[Special:Contact]] to get in contact with Wikia support team if you continue to see this issue.",
 	'flags-edit-modal-post-exception' => "Unfortunately, we are not able to complete the process due to the following error:\n\n\n\n$1\n\n\n\nThis error has already been reported to the technical team. Please feel free to use [[Special:Contact]] to get in contact with Wikia support team if you continue to see this issue.",
@@ -33,4 +33,16 @@ $messages['qqq'] = [
 	'flags-edit-modal-title' => 'Title of the form for editing flags displayed on headline of modal containing the form.',
 	'flags-edit-modal-exception' => 'A message shown in the modal instead of an edit form if an error makes it impossible to display it. $1 is a text of the error.',
 	'flags-edit-modal-post-exception' => 'A message shown in a banner notification if posting of edit forms fails due to an error. $1 is a text of the error.',
+];
+
+/**
+ * Polish (pl)
+ */
+$messages['pl'] = [
+	'flags-edit-form-more-info' => 'Więcej informacji >',
+	'flags-edit-modal-cancel-button-text' => 'Anuluj',
+	'flags-edit-modal-close-button-text' => 'Zamknij',
+	'flags-edit-modal-done-button-text' => 'Gotowe',
+	'flags-edit-modal-no-flags-on-community' => 'Ta społeczność nie ma zdefiniowanych żadnych flag. [[Help:Flags|Dowiedz się więcej o flagach]] or [[Special:Flags|zdefiniuj flagi dla tej społeczności]].',
+	'flags-edit-modal-title' => 'Flagi',
 ];

--- a/extensions/wikia/Flags/controllers/FlagsController.class.php
+++ b/extensions/wikia/Flags/controllers/FlagsController.class.php
@@ -198,7 +198,7 @@ class FlagsController extends WikiaController {
 			BannerNotificationsController::addConfirmation(
 				wfMessage( 'flags-edit-modal-post-exception' )
 					->params( $exception->getMessage() )
-					->escaped(),
+					->parse(),
 				BannerNotificationsController::CONFIRMATION_ERROR,
 				true
 			);

--- a/extensions/wikia/Flags/controllers/templates/FlagsController_editFormEmpty.php
+++ b/extensions/wikia/Flags/controllers/templates/FlagsController_editFormEmpty.php
@@ -1,3 +1,3 @@
 <div class="flags-edit-form-message">
-	<?= wfMessage( 'flags-edit-modal-no-flags-on-community' )->escaped(); ?>
+	<?= wfMessage( 'flags-edit-modal-no-flags-on-community' )->parse(); ?>
 </div>

--- a/extensions/wikia/Flags/controllers/templates/FlagsController_editFormException.php
+++ b/extensions/wikia/Flags/controllers/templates/FlagsController_editFormException.php
@@ -1,3 +1,3 @@
 <div class="flags-edit-form-message">
-	<?= wfMessage( 'flags-edit-modal-exception' )->params( $exceptionMessage )->escaped() ?>
+	<?= wfMessage( 'flags-edit-modal-exception' )->params( $exceptionMessage )->parse() ?>
 </div>


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CE-1856
- messages containing links should be parsed,
- using message for flags item on modal dropdown,
- added PL translations for modal.

@Wikia/community-engineering 
