### PR TITLE
Ce 1833 admin dashboard buttons

### DIFF
--- a/extensions/wikia/AdminDashboard/AdminDashboardSpecialPageController.class.php
+++ b/extensions/wikia/AdminDashboard/AdminDashboardSpecialPageController.class.php
@@ -70,6 +70,10 @@ class AdminDashboardSpecialPageController extends WikiaSpecialPageController {
 
 		// add messages package
 		JSMessages::enqueuePackage('AdminDashboard', JSMessages::INLINE);
+
+		// Add Upload Photos Dialog
+		Wikia::addAssetsToOutput( 'upload_photos_dialog_js' );
+		Wikia::addAssetsToOutput( 'upload_photos_dialog_scss' );
 	}
 
 	/**

--- a/extensions/wikia/AdminDashboard/js/AdminDashboard.js
+++ b/extensions/wikia/AdminDashboard/js/AdminDashboard.js
@@ -124,7 +124,7 @@ var AdminDashboard = {
 	},
 	modalLoad: {
 		loadAddPage: function() {
-			CreatePage.openDialog();
+			CreatePage.requestDialog();
 		},
 		loadAddPhoto: function() {
 			UploadPhotos.showDialog();


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CE-1833

Fix add image and add page buttons on admin dashboard

add page was broken because name of method was changed to requestDialog
add photo was broken because assets weren't sent

@Wikia/community-engineering  
