### PR TITLE
SOC-860 make sure test doesn't use memcache

### DIFF
--- a/extensions/wikia/Email/tests/EmailIntegrationTest.php
+++ b/extensions/wikia/Email/tests/EmailIntegrationTest.php
@@ -21,6 +21,7 @@ class EmailIntegrationTest extends WikiaBaseTest {
 	public function testEmailImages() {
 
 		$this->setVignetteEnvToProd();
+		$this->disableMemCache();
 
 		foreach ( Email\ImageHelper::getIconInfo() as $iconInfo ) {
 			$url = $iconInfo['url'];


### PR DESCRIPTION
Fix for SOC-860. We need to make sure the test doesn't use memcached. If the test is run in dev, we'll most likely get the dev URLs we were trying to avoid.
