### PR TITLE
Implement MemcacheUserBlock for short, per-wiki user blocks

### DIFF
--- a/extensions/wikia/MemcacheUserBlock/MemcacheUserBlock.class.php
+++ b/extensions/wikia/MemcacheUserBlock/MemcacheUserBlock.class.php
@@ -23,7 +23,8 @@ class MemcacheUserBlock {
 			$this->getMemcacheBlockKey(),
 			[
 				'expiry' => time() + $ttl,
-				'reason' => $reason
+				'reason' => $reason,
+				'set_at' => time()
 			],
 			$ttl
 		);
@@ -55,6 +56,7 @@ class MemcacheUserBlock {
 			$block->setBlockEmail( $blocker->getEmail() );
 			$block->mReason = $blockData['reason'];
 			$block->mExpiry = $blockData['expiry'];
+			$block->mTimestamp = wfTimestamp( TS_MW, $blockData['set_at'] );
 
 			$this->info( __METHOD__, [
 				'reason' => $block->mReason,

--- a/extensions/wikia/MemcacheUserBlock/MemcacheUserBlock.class.php
+++ b/extensions/wikia/MemcacheUserBlock/MemcacheUserBlock.class.php
@@ -99,6 +99,10 @@ class MemcacheUserBlock {
 		if ( $block instanceof Block ) {
 			$user->mBlock = $block;
 			$blocked = true;
+
+			// dirty hack to make the block be displayed properly to the user
+			$user->mBlockreason = $block->mReason;
+			$user->mBlockedby = $block->getByName();
 		}
 
 		return true;

--- a/extensions/wikia/MemcacheUserBlock/MemcacheUserBlock.class.php
+++ b/extensions/wikia/MemcacheUserBlock/MemcacheUserBlock.class.php
@@ -1,0 +1,107 @@
+<?php
+
+class MemcacheUserBlock {
+
+	use Wikia\Logger\Loggable;
+
+	const DEFAULT_BLOCK_TTL = 300; // 5 minutes
+	const BLOCKER_NAME = 'WikiaBot';
+
+	private $mUser;
+	private $memc;
+
+	function __construct( User $user ) {
+		global $wgMemc;
+
+		$this->mUser = $user;
+		$this->memc = $wgMemc;
+	}
+
+	public function setBlock( $reason, $ttl = self::DEFAULT_BLOCK_TTL ) {
+		// set the key with the block expiry time and the reason
+		$this->memc->set(
+			$this->getMemcacheBlockKey(),
+			[
+				'expiry' => time() + $ttl,
+				'reason' => $reason
+			],
+			$ttl
+		);
+
+		$this->info( __METHOD__, [
+			'reason' => $reason
+		] );
+	}
+
+	public function removeBlock() {
+		$this->memc->delete( $this->getMemcacheBlockKey() );
+		$this->info( __METHOD__ );
+	}
+
+	/**
+	 * Get block instance for the current user, if it exists
+	 *
+	 * @return Block|false
+	 */
+	public function getBlock() {
+		$blockData = $this->memc->get( $this->getMemcacheBlockKey() );
+
+		if ( is_array($blockData) ) {
+			$blocker = User::newFromName( self::BLOCKER_NAME );
+
+			$block = new Block();
+			$block->setTarget( $this->mUser );
+			$block->setBlocker( $blocker );
+			$block->setBlockEmail( $blocker->getEmail() );
+			$block->mReason = $blockData['reason'];
+			$block->mExpiry = $blockData['expiry'];
+
+			$this->info( __METHOD__, [
+				'reason' => $block->mReason,
+				'expiry' => $block->getExpiry()
+			] );
+
+			return $block;
+		}
+		else {
+			return false;
+		}
+	}
+
+	/**
+	 * @return String memcache key
+	 */
+	private function getMemcacheBlockKey( ) {
+		return wfMemcKey( __CLASS__, $this->mUser->getId() );
+	}
+
+	protected function getLoggerContext() {
+		return [
+			'user' => $this->mUser->getName()
+		];
+	}
+
+	/**
+	 * Check if the given user has a local block set in memcache
+	 *
+	 * Called via Hook
+	 *
+	 * @param User $user
+	 * @param Title $title
+	 * @param $blocked
+	 * @param $allowUsertalk
+	 * @return bool
+	 */
+	static public function onUserIsBlockedFrom( User $user, Title $title, &$blocked, &$allowUsertalk ) {
+		$instance = new self( $user );
+		$block = $instance->getBlock();
+
+		if ( $block instanceof Block ) {
+			$user->mBlock = $block;
+			$blocked = true;
+		}
+
+		return true;
+	}
+
+}

--- a/extensions/wikia/MemcacheUserBlock/MemcacheUserBlock.class.php
+++ b/extensions/wikia/MemcacheUserBlock/MemcacheUserBlock.class.php
@@ -46,7 +46,7 @@ class MemcacheUserBlock {
 	public function getBlock() {
 		$blockData = $this->memc->get( $this->getMemcacheBlockKey() );
 
-		if ( is_array($blockData) ) {
+		if ( is_array( $blockData ) ) {
 			$blocker = User::newFromName( self::BLOCKER_NAME );
 
 			$block = new Block();

--- a/extensions/wikia/MemcacheUserBlock/MemcacheUserBlock.setup.php
+++ b/extensions/wikia/MemcacheUserBlock/MemcacheUserBlock.setup.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Implements memcache-based local user blocks
+ *
+ * Temporary solution used during Uncyclopedia migration to apply user block for short periods (few seconds)
+ *
+ * @see PLATFORM-1055
+ * @author macbre
+ */
+
+$wgExtensionCredits['other'][] = array(
+	'name' => 'MemcacheUserBlock',
+	'description' => 'Implements memcache-based local user blocks',
+	'url' => 'https://github.com/Wikia/app/tree/dev/extensions/wikia/MemcacheUserBlock'
+);
+
+$wgAutoloadClasses['MemcacheUserBlock'] = __DIR__ . '/MemcacheUserBlock.class.php';
+
+$wgHooks['UserIsBlockedFrom'][] = 'MemcacheUserBlock::onUserIsBlockedFrom';


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-1055

As a part of Uncyclopedia migration we need to block user that is currently migrated for a very short time (up to 10 seconds). We can't use DB-based blocks as the migration is performed within a transaction.

**The solution**: use memcache-based, per-wiki blocks.

The API:

``` php
$blocker = new MemcacheUserBlock( $wgUser );

// apply a block for 60 seconds, memcache key will expire in 60 seconds
$blocker->setBlock('The block reason goes here', 60);

// check the block
$blocker->getBlock();

// remove a block
$blocker->removeBlock();

// memcached: MemCache: delete uncyclo:MemcacheUserBlock:119245
```
- this class binds to the MW via `UserIsBlockedFrom` hook.
- migration script will call `setBlock` and `removeBlock` methods

@michalroszka / @wladekb 
