### PR TITLE
CE-1759 Move images back to the ImageReview queue

### DIFF
--- a/extensions/wikia/ImageReview/ImageReviewImageStatus.php
+++ b/extensions/wikia/ImageReview/ImageReviewImageStatus.php
@@ -64,6 +64,7 @@ function efImageReviewDisplayStatus( ImagePage $imagePage, &$html ) {
 					$logParams = [
 						'cityId' => $wgCityId,
 						'pageId' => $imagePage->getID(),
+						'pageTitle' => $imagePage->getTitle()->getText(),
 						'uploadUser' => $user->getName(),
 					];
 					\Wikia\Logger\WikiaLogger::instance()->info( 'ImageReviewLog',

--- a/extensions/wikia/ImageReview/ImageReviewImageStatus.php
+++ b/extensions/wikia/ImageReview/ImageReviewImageStatus.php
@@ -57,9 +57,9 @@ function efImageReviewDisplayStatus( ImagePage $imagePage, &$html ) {
 			$lastTouched = new DateTime( $imagePage->getRevisionFetched()->getTimestamp() );
 			$now = new DateTime();
 			$file = $imagePage->getDisplayedFile();
-			if ( $file instanceof LocalFile && $lastTouched < $now->modify( '-1 hour' ) ) {
+			if ( $file instanceof WikiaLocalFile && $lastTouched < $now->modify( '-1 hour' ) ) {
 				$scribeEventProducer = new ScribeEventProducer( 'edit' );
-				$user = User::newFromId( $file->getUser() );
+				$user = User::newFromText( $file->getUser() );
 				if ( $scribeEventProducer->buildEditPackage( $imagePage, $user, null, null, $file ) ) {
 					$logParams = [
 						'cityId' => $wgCityId,

--- a/extensions/wikia/ImageReview/ImageReviewImageStatus.php
+++ b/extensions/wikia/ImageReview/ImageReviewImageStatus.php
@@ -51,15 +51,15 @@ function efImageReviewDisplayStatus( ImagePage $imagePage, &$html ) {
 
 		if ( false === $imgCurState ) {
 			/**
-			 * If the file is older than 1 hour - send it to ImageReview
+			 * If the file is a local one and is older than 1 hour - send it to ImageReview
 			 * since it's probably been restored, and is not just a fresh file.
 			 */
 			$lastTouched = new DateTime( $imagePage->getRevisionFetched()->getTimestamp() );
 			$now = new DateTime();
-			if ( $lastTouched < $now->modify( '-1 hour' ) ) {
+			$file = $imagePage->getDisplayedFile();
+			if ( $file instanceof LocalFile && $lastTouched < $now->modify( '-1 hour' ) ) {
 				$scribeEventProducer = new ScribeEventProducer( 'edit' );
-				$user = $imagePage->getContext()->getUser();
-				$file = $imagePage->getDisplayedFile();
+				$user = User::newFromId( $file->getUser() );
 				if ( $scribeEventProducer->buildEditPackage( $imagePage, $user, null, null, $file ) ) {
 					$logParams = [
 						'cityId' => $wgCityId,


### PR DESCRIPTION
@see [CE-1759](https://wikia-inc.atlassian.net/browse/CE-1759)

Current behavior of once deleted images is not acceptable! If they are restored, they don't go back to the ImageReview queue! You can just add an [ugly picture](http://static.idolator.com/uploads/2013/09/09/miley-cyrus-wrecking-ball-video-600x337.jpg), get it deleted, restore it and still enjoy it being displayed. Let's put an end to this outrage!

We detect if an image has ImageReview records. If it does not - build a Scribe package and send it back where it belongs!

@Wikia/community-engineering @macbre 
