### PR TITLE
ADEN-2044 Prepare Amazon mobile rollout

### DIFF
--- a/extensions/wikia/AdEngine/js/GptHelper.js
+++ b/extensions/wikia/AdEngine/js/GptHelper.js
@@ -73,6 +73,23 @@ define('ext.wikia.adEngine.gptHelper', [
 		}
 	}
 
+	function setSlotLevelParams(slot, slotTargeting) {
+		var name,
+			value;
+
+		log(['setSlotLevelParams', slotTargeting], 'debug', logGroup);
+
+		for (name in slotTargeting) {
+			if (slotTargeting.hasOwnProperty(name)) {
+				value = slotTargeting[name];
+				if (value) {
+					log(['defineSlot', 'slot.setTargeting', name, value], 'debug', logGroup);
+					slot.setTargeting(name, value);
+				}
+			}
+		}
+	}
+
 	function registerGptCallback(adDivId, gptCallback) {
 		log(['registerGptCallback', adDivId], 'info', logGroup);
 		gptCallbacks[adDivId] = gptCallback;
@@ -180,9 +197,7 @@ define('ext.wikia.adEngine.gptHelper', [
 		}
 
 		function queueAd() {
-			var name,
-				value,
-				sizes,
+			var sizes,
 				slot,
 				pageLevelParams = adLogicPageParams.getPageLevelParams();
 
@@ -211,22 +226,15 @@ define('ext.wikia.adEngine.gptHelper', [
 
 				delete slotTargeting.size;
 
-				for (name in slotTargeting) {
-					if (slotTargeting.hasOwnProperty(name)) {
-						value = slotTargeting[name];
-						if (value) {
-							log(['defineSlot', 'slot.setTargeting', name, value], 'debug', logGroup);
-							slot.setTargeting(name, value);
-						}
-					}
-				}
-
 				// Display div through GPT
 				log(['googletag.display', adDivId], 'debug', logGroup);
 				googletag.display(adDivId);
 
 				gptSlots[adDivId] = slot;
 			}
+
+			// Set it after we are sure slot is defined
+			setSlotLevelParams(gptSlots[adDivId], slotTargeting);
 
 			// Save slot level params for easier ad delivery debugging
 			adDiv.setAttribute('data-gpt-slot-sizes', JSON.stringify(sizes));

--- a/extensions/wikia/AdEngine/js/GptHelper.js
+++ b/extensions/wikia/AdEngine/js/GptHelper.js
@@ -224,14 +224,14 @@ define('ext.wikia.adEngine.gptHelper', [
 				slot = googletag.defineSlot(slotPath, sizes, adDivId);
 				slot.addService(pubads);
 
-				delete slotTargeting.size;
-
 				// Display div through GPT
 				log(['googletag.display', adDivId], 'debug', logGroup);
 				googletag.display(adDivId);
 
 				gptSlots[adDivId] = slot;
 			}
+
+			delete slotTargeting.size;
 
 			// Set it after we are sure slot is defined
 			setSlotLevelParams(gptSlots[adDivId], slotTargeting);

--- a/extensions/wikia/AdEngine/js/GptHelper.js
+++ b/extensions/wikia/AdEngine/js/GptHelper.js
@@ -79,6 +79,7 @@ define('ext.wikia.adEngine.gptHelper', [
 
 		log(['setSlotLevelParams', slotTargeting], 'debug', logGroup);
 
+		slot.clearTargeting();
 		for (name in slotTargeting) {
 			if (slotTargeting.hasOwnProperty(name)) {
 				value = slotTargeting[name];

--- a/extensions/wikia/AdEngine/js/lookup/amazonMatch.js
+++ b/extensions/wikia/AdEngine/js/lookup/amazonMatch.js
@@ -156,12 +156,18 @@ define('ext.wikia.adEngine.lookup.amazonMatch', [
 		log(['getSlotParams', slotName], 'debug', logGroup);
 
 		if (wasCalled() && wasRendered()) {
-			log([
-				'getSlotParams',
+			log(
+				['getSlotParams',
 				slotName,
-				'Not adding amznSlots since the Amazon ads has been already rendered'
-			], 'debug', logGroup);
-			return {};
+				'Cleaning amznSlots since the Amazon ads has been already rendered before'
+				],
+				'debug',
+				logGroup
+			);
+
+			return {
+				amznslots: []
+			};
 		}
 
 		var amznSlots = [];

--- a/extensions/wikia/AdEngine/js/lookup/amazonMatch.js
+++ b/extensions/wikia/AdEngine/js/lookup/amazonMatch.js
@@ -203,8 +203,7 @@ define('ext.wikia.adEngine.lookup.amazonMatch', [
 		trackState: function () {
 			log('fake trackState - module is not supported in IE8', 'debug', logGroup);
 		},
-		wasCalled: wasCalled,
-		wasRendered: wasRendered
+		wasCalled: wasCalled
 	};
 
 	if (!Object.keys) {

--- a/extensions/wikia/AdEngine/js/lookup/amazonMatch.js
+++ b/extensions/wikia/AdEngine/js/lookup/amazonMatch.js
@@ -157,31 +157,20 @@ define('ext.wikia.adEngine.lookup.amazonMatch', [
 
 		var amznSlots = [];
 
-		if (wasRendered()) {
-			log(
-				['getSlotParams',
-				slotName,
-				'Cleaning amznSlots since the Amazon ads has been already rendered before'
-				],
-				'debug',
-				logGroup
-			);
+		if (!wasRendered()) {
+			Object.keys(sizeMapping).forEach(function (amazonSize) {
+				var validSlotNames = sizeMapping[amazonSize],
+					amazonPricePoint = bestPricePointForSize[amazonSize];
 
-			return {
-				amznslots: amznSlots
-			};
+				if (validSlotNames.indexOf(slotName) !== -1 && amazonPricePoint) {
+					amznSlots.push('a' + amazonSize + 'p' + amazonPricePoint);
+				}
+			});
+
+			log(['getSlotParams - amznSlots: ', amznSlots], 'debug', logGroup);
+		} else {
+			log(['getSlotParams - no amznSlots since ads has been already displayed', slotName], 'debug', logGroup);
 		}
-
-		Object.keys(sizeMapping).forEach(function (amazonSize) {
-			var validSlotNames = sizeMapping[amazonSize],
-				amazonPricePoint = bestPricePointForSize[amazonSize];
-
-			if (validSlotNames.indexOf(slotName) !== -1 && amazonPricePoint) {
-				amznSlots.push('a' + amazonSize + 'p' + amazonPricePoint);
-			}
-		});
-
-		log(['getSlotParams - amznSlots: ', amznSlots], 'debug', logGroup);
 
 		if (amznSlots.length) {
 			return {

--- a/extensions/wikia/AdEngine/js/lookup/amazonMatch.js
+++ b/extensions/wikia/AdEngine/js/lookup/amazonMatch.js
@@ -147,6 +147,11 @@ define('ext.wikia.adEngine.lookup.amazonMatch', [
 		return amazonCalled;
 	}
 
+	function hasResponse() {
+		log(['hasResponse', amazonResponse], 'debug', logGroup);
+		return (amazonResponse) ? true : false;
+	}
+
 	function getSlotParams(slotName) {
 		log(['getSlotParams', slotName], 'debug', logGroup);
 
@@ -187,7 +192,8 @@ define('ext.wikia.adEngine.lookup.amazonMatch', [
 		trackState: function () {
 			log('fake trackState - module is not supported in IE8', 'debug', logGroup);
 		},
-		wasCalled: wasCalled
+		wasCalled: wasCalled,
+		hasResponse: hasResponse
 	};
 
 	if (!Object.keys) {

--- a/extensions/wikia/AdEngine/js/lookup/amazonMatch.js
+++ b/extensions/wikia/AdEngine/js/lookup/amazonMatch.js
@@ -155,7 +155,9 @@ define('ext.wikia.adEngine.lookup.amazonMatch', [
 	function getSlotParams(slotName) {
 		log(['getSlotParams', slotName], 'debug', logGroup);
 
-		if (wasCalled() && wasRendered()) {
+		var amznSlots = [];
+
+		if (wasRendered()) {
 			log(
 				['getSlotParams',
 				slotName,
@@ -166,11 +168,9 @@ define('ext.wikia.adEngine.lookup.amazonMatch', [
 			);
 
 			return {
-				amznslots: []
+				amznslots: amznSlots
 			};
 		}
-
-		var amznSlots = [];
 
 		Object.keys(sizeMapping).forEach(function (amazonSize) {
 			var validSlotNames = sizeMapping[amazonSize],

--- a/extensions/wikia/AdEngine/js/lookup/amazonMatch.js
+++ b/extensions/wikia/AdEngine/js/lookup/amazonMatch.js
@@ -147,17 +147,12 @@ define('ext.wikia.adEngine.lookup.amazonMatch', [
 		return amazonCalled;
 	}
 
-	function wasRendered() {
-		log(['wasRendered', amazonRendered], 'debug', logGroup);
-		return amazonRendered;
-	}
-
 	function getSlotParams(slotName) {
 		log(['getSlotParams', slotName], 'debug', logGroup);
 
 		var amznSlots = [];
 
-		if (!wasRendered()) {
+		if (!amazonRendered) {
 			Object.keys(sizeMapping).forEach(function (amazonSize) {
 				var validSlotNames = sizeMapping[amazonSize],
 					amazonPricePoint = bestPricePointForSize[amazonSize];

--- a/extensions/wikia/AdEngine/js/lookup/amazonMatch.js
+++ b/extensions/wikia/AdEngine/js/lookup/amazonMatch.js
@@ -111,6 +111,7 @@ define('ext.wikia.adEngine.lookup.amazonMatch', [
 
 	function renderAd(doc, adId) {
 		log(['renderAd', doc, adId, 'available: ' + !!amazonResponse[adId]], 'debug', logGroup);
+		amazonRendered = true;
 		doc.write(amazonResponse[adId]);
 	}
 

--- a/extensions/wikia/AdEngine/js/lookup/amazonMatch.js
+++ b/extensions/wikia/AdEngine/js/lookup/amazonMatch.js
@@ -14,6 +14,7 @@ define('ext.wikia.adEngine.lookup.amazonMatch', [
 		amazonResponse,
 		amazonTiming,
 		amazonCalled = false,
+		amazonRendered = false,
 		amazonParamPattern = /^a([0-9]x[0-9])p([0-9]+)$/,
 		sizeMapping = {
 			'1x6': ['LEFT_SKYSCRAPER_2', 'LEFT_SKYSCRAPER_3'],
@@ -109,7 +110,7 @@ define('ext.wikia.adEngine.lookup.amazonMatch', [
 	}
 
 	function renderAd(doc, adId) {
-		log(['getPageParams', doc, adId, 'available: ' + !!amazonResponse[adId]], 'debug', logGroup);
+		log(['renderAd', doc, adId, 'available: ' + !!amazonResponse[adId]], 'debug', logGroup);
 		doc.write(amazonResponse[adId]);
 	}
 
@@ -145,8 +146,22 @@ define('ext.wikia.adEngine.lookup.amazonMatch', [
 		return amazonCalled;
 	}
 
+	function wasRendered() {
+		log(['wasRendered', amazonRendered], 'debug', logGroup);
+		return amazonRendered;
+	}
+
 	function getSlotParams(slotName) {
 		log(['getSlotParams', slotName], 'debug', logGroup);
+
+		if (wasCalled() && wasRendered()) {
+			log([
+				'getSlotParams',
+				slotName,
+				'Not adding amznSlots since the Amazon ads has been already rendered'
+			], 'debug', logGroup);
+			return {};
+		}
 
 		var amznSlots = [];
 
@@ -181,7 +196,8 @@ define('ext.wikia.adEngine.lookup.amazonMatch', [
 		trackState: function () {
 			log('fake trackState - module is not supported in IE8', 'debug', logGroup);
 		},
-		wasCalled: wasCalled
+		wasCalled: wasCalled,
+		wasRendered: wasRendered
 	};
 
 	if (!Object.keys) {

--- a/extensions/wikia/AdEngine/js/provider/factoryWikiaGpt.js
+++ b/extensions/wikia/AdEngine/js/provider/factoryWikiaGpt.js
@@ -39,7 +39,7 @@ define('ext.wikia.adEngine.provider.factory.wikiaGpt', [
 					sraEnabled: extra.sraEnabled
 				},
 				pageParams = adLogicPageParams.getPageLevelParams(),
-				slotTargeting = slotMap[slotName],
+				slotTargeting = JSON.parse(JSON.stringify(slotMap[slotName])), // copy value
 				slotPath = [
 					'/5441', 'wka.' + pageParams.s0, pageParams.s1, '', pageParams.s2, src, slotName
 				].join('/');

--- a/extensions/wikia/AdEngine/js/spec/AmazonMatch.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/AmazonMatch.spec.js
@@ -140,4 +140,11 @@ describe('Method ext.wikia.adEngine.lookup.amazonMatch', function () {
 		mocks.window.amznads.renderAd(mocks.document);
 		expect(amazonMatch.getSlotParams('MOBILE_TOP_LEADERBOARD').amznslots).toEqual(undefined);
 	});
+
+	it('switch the flag when response from Amazon recieved', function () {
+		var amazonMatch = getModule();
+
+		initAndTestAmazon(amazonMatch, {'a3x5p14': 1});
+		expect(amazonMatch.hasResponse()).toEqual(true);
+	});
 });

--- a/extensions/wikia/AdEngine/js/spec/AmazonMatch.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/AmazonMatch.spec.js
@@ -138,6 +138,6 @@ describe('Method ext.wikia.adEngine.lookup.amazonMatch', function () {
 		initAndTestAmazon(amazonMatch, {'a3x5p14': 1});
 		expect(amazonMatch.getSlotParams('MOBILE_TOP_LEADERBOARD').amznslots).toEqual(['a3x5p14']);
 		mocks.window.amznads.renderAd(mocks.document);
-		expect(amazonMatch.getSlotParams('MOBILE_TOP_LEADERBOARD').amznslots).toEqual([]);
+		expect(amazonMatch.getSlotParams('MOBILE_TOP_LEADERBOARD').amznslots).toEqual(undefined);
 	});
 });


### PR DESCRIPTION
Before we rollout Amazon on mobile devices we want to have [automation tests for it](https://github.com/Wikia/selenium-tests/pull/665) ready and we want a mechanism which doesn't display Amazon ad once it was displayed in Mercury.

Changes below are supposed to provide such mechanism.
