### PR TITLE
Make sure we don't have forms which point to abstract classes

### DIFF
--- a/extensions/wikia/Email/Controller/WatchedPageController.class.php
+++ b/extensions/wikia/Email/Controller/WatchedPageController.class.php
@@ -173,6 +173,33 @@ abstract class WatchedPageController extends EmailController {
 			$this->getAllChangesText( $this->title ),
 		];
 	}
+
+	protected static function getEmailSpecificFormFields() {
+		$form = [
+			'inputs' => [
+				[
+					'type' => 'text',
+					'name' => 'pageTitle',
+					'label' => "Article Title",
+					'tooltip' => "eg 'Rachel_Berry' (make sure it's on this wikia!)"
+				],
+				[
+					'type' => 'text',
+					'name' => 'currentRevId',
+					'label' => "Current Revision ID",
+					'tooltip' => "The current revision you want to compare to"
+				],
+				[
+					'type' => 'text',
+					'name' => 'previousRevId',
+					'label' => "Previous Revision ID",
+					'tooltip' => 'The previous revision you want to compare to'
+				],
+			]
+		];
+
+		return $form;
+	}
 }
 
 class WatchedPageEditedController extends WatchedPageController {
@@ -309,32 +336,5 @@ class WatchedPageRenamedController extends WatchedPageController {
 	 */
 	protected function getAllChangesText( $title ) {
 		return parent::getAllChangesText( $this->newTitle );
-	}
-
-	protected static function getEmailSpecificFormFields() {
-			$form = [
-				'inputs' => [
-					[
-						'type' => 'text',
-						'name' => 'pageTitle',
-						'label' => "Article Title",
-						'tooltip' => "eg 'Rachel_Berry' (make sure it's on this wikia!)"
-					],
-					[
-						'type' => 'text',
-						'name' => 'currentRevId',
-						'label' => "Current Revision ID",
-						'tooltip' => "The current revision you want to compare to"
-					],
-					[
-						'type' => 'text',
-						'name' => 'previousRevId',
-						'label' => "Previous Revision ID",
-						'tooltip' => 'The previous revision you want to compare to'
-					],
-				]
-			];
-
-		return $form;
 	}
 }

--- a/extensions/wikia/Email/SpecialSendEmailController.class.php
+++ b/extensions/wikia/Email/SpecialSendEmailController.class.php
@@ -135,11 +135,25 @@ class SpecialSendEmailController extends \WikiaSpecialPageController {
 		$emailControllerClasses = [];
 		foreach ( $allClasses as $className => $classPath ) {
 			if ( preg_match( EmailController::EMAIL_CONTROLLER_REGEX, $className, $matches ) ) {
-				$emailControllerClasses[] = $matches[0];
+				if ( !$this->isClassAbstract( $className ) ) {
+					$emailControllerClasses[] = $matches[0];
+				}
 			}
 		}
 
 		return $emailControllerClasses;
+	}
+
+	/**
+	 * Checks if the given class is abstract or not. We only want concrete classes when
+	 * creating the forms for Special:SendEmail. The abstract classes these concrete
+	 * classes inherit from create forms which throw fatals when submitted.
+	 * @param $className
+	 * @return bool
+	 */
+	public function isClassAbstract( $className ) {
+		$reflectionClass = new \ReflectionClass( $className );
+		return $reflectionClass->isAbstract();
 	}
 
 	/**


### PR DESCRIPTION
Special:SendEmail creates a list of forms which users can use to send off our emails. These forms are created programmatically by finding classes in our Email extension and then pointing those forms to those classes. We also have abstract classes in that extension and need to make sure we don't create forms for those classes.
