### PR TITLE
PLATFORM-1261: Helios - start the session when initializing the user from the access token

### DIFF
--- a/extensions/wikia/Helios/User.class.php
+++ b/extensions/wikia/Helios/User.class.php
@@ -82,6 +82,14 @@ class User {
 			global $wgHeliosBaseUri, $wgHeliosClientId, $wgHeliosClientSecret;
 			$heliosClient = new Client( $wgHeliosBaseUri, $wgHeliosClientId, $wgHeliosClientSecret );
 
+			// start the session if there's none so far
+			// the code is borrowed from SpecialUserlogin
+			// @see PLATFORM-1261
+			if ( session_id() == '' ) {
+				wfSetupSession();
+				WikiaLogger::instance()->debug( __METHOD__ . '::startSession' );
+			}
+
 			try {
 				$tokenInfo = $heliosClient->info( $token );
 				if ( !empty( $tokenInfo->user_id ) ) {


### PR DESCRIPTION
@michalroszka / @ArturKlajnerok 
- `access_token` cookie TTL is set to 6 months
- `wikicities_session` is set for browser session only

Hence, the user can stay logged-in even when he's session cookie expires.
