### PR TITLE
(CE-1928) Fix failing image review deletion tasks

### DIFF
--- a/extensions/wikia/ImageReview/ImageReviewTask.class.php
+++ b/extensions/wikia/ImageReview/ImageReviewTask.class.php
@@ -25,7 +25,7 @@ class ImageReviewTask extends BaseTask {
 				continue;
 			}
 
-			$dbname = \WikiFactory::getWikisByID( $wikiId );
+			$dbname = \WikiFactory::getWikiByID( $wikiId );
 			if ( !$dbname ) {
 				$this->warning( 'did not find database', ['wiki_id' => $wikiId] );
 				continue;


### PR DESCRIPTION
ImageReview tasks have been failing since the [start of April](https://github.com/Wikia/app/pull/6839) when
WikiFactory::getWikisByID started failing due to strictly checking
for an array. It should have always been using WikiFactory::getWikiByID.

Fixes the fatal error:

```
PHP Catchable fatal error:  Argument 1 passed to WikiFactory::getWikisByID()
must be of the type array, string given, called in extensions/wikia/
ImageReview/ImageReviewTask.class.php on line 28 and defined in extensions/
wikia/WikiFactory/WikiFactory.php on line 1265
```

@Wikia/community-engineering 
