### PR TITLE
(CE-1928) Fix sending error emails

### DIFF
--- a/extensions/wikia/ImageReview/ImageReviewTask.class.php
+++ b/extensions/wikia/ImageReview/ImageReviewTask.class.php
@@ -119,7 +119,9 @@ class ImageReviewTask extends BaseTask {
 		];
 		$from = $recipients[0];
 
-		\UserMailer::send( $recipients, $from, $subject, $body );
+		foreach ( $recipients as $recipient ) {
+			\UserMailer::send( $recipient, $from, $subject, $body );
+		}
 
 		WikiaLogger::instance()->error( "ImageReviewLog", [
 			'method' => __METHOD__,


### PR DESCRIPTION
UserMailer::send doesn't accept an array of addresses after:
https://github.com/Wikia/app/commit/b34bfb51

Fixes the following fatal error:

```
PHP Catchable fatal error: Argument 1 passed to UserMailer::send()
must be an instance of MailAddress, array given, called in
extensions/wikia/ImageReview/ImageReviewTask.class.php on line 122
and defined in includes/UserMailer.php on line 165
```

Avoiding changing UserMailer for this quick fix as I'm not sure if it was
intentional (/cc @garthwebb)

/cc @Wikia/community-engineering 
