### PR TITLE
Started caching the 404s that the Lyrics mobile app's API sends. This…

### DIFF
--- a/extensions/wikia/LyricsApi/LyricsApiController.class.php
+++ b/extensions/wikia/LyricsApi/LyricsApiController.class.php
@@ -2,7 +2,9 @@
 /**
  * Class LyricsApiController
  *
- * @desc Entry point for LyricsAPI
+ * @desc Entry point for LyricsAPI used by the Lyrically app. For the LyricWiki API that runs
+ *       through the standard MediaWiki and is accessible to the public, please use the
+ *       extension in /extensions/wikia/WikiaApiLyricWiki and /extensions/3rdparty/LyricWiki
  */
 class LyricsApiController extends WikiaController {
 	const PARAM_ARTIST = 'artist';
@@ -58,6 +60,11 @@ class LyricsApiController extends WikiaController {
 
 		// Validate result
 		if( is_null( $results ) ) {
+			// New songs that we don't have yet are likely to get hit repeatedly by a
+			// ton of users until we get the song, so this is a special case where it
+			// is helpful to cache 404s for a little while.
+			$this->response->setCacheValidity( WikiaResponse::CACHE_VERY_SHORT );
+
 			throw new NotFoundApiException( $this->getNotFoundDetails( $method ) );
 		}
 

--- a/includes/wikia/nirvana/WikiaResponse.class.php
+++ b/includes/wikia/nirvana/WikiaResponse.class.php
@@ -43,6 +43,7 @@ class WikiaResponse {
 	const CACHE_LONG = 2592000; // 30 days
 	const CACHE_STANDARD = 86400; // 24 hours
 	const CACHE_SHORT = 10800; // 3 hours
+	const CACHE_VERY_SHORT = 300; // 5 minutes
 
 	/**
 	 * Caching policy


### PR DESCRIPTION
… is because of the special nature of Lyrics mobile apps that popular songs that we don't have pages for yet, will be requested hundreds (thousands?) of times per hour.  The caching is a very short duration (5 minutes) which will just unburden the backend (max of 12 requests per hour per 404).  LYR-235

I'm not sure if the preference is there for a CACHE_VERY_SHORT to exist, or if that should be a local var (like in ChatRailController).  I'm considering making another branch & just letting Macbre choose which one he'd rather merge ;)
