### PR TITLE
Started caching 404s from the lyrically mobile app's API because of t…

### DIFF
--- a/extensions/wikia/LyricsApi/LyricsApiController.class.php
+++ b/extensions/wikia/LyricsApi/LyricsApiController.class.php
@@ -14,6 +14,11 @@ class LyricsApiController extends WikiaController {
 
 	const SEARCH_RESULTS_DEFAULT_LIMIT = 25;
 	const SEARCH_RESULTS_DEFAULT_OFFSET = 0;
+	
+	// New songs that we don't have yet are likely to get hit repeatedly by a
+	// ton of users until we get the song, so this is a special case where it
+	// is helpful to cache 404s for a little while.
+	const CACHE_DURATION_FOR_404 = (5*60); // 5 minutes
 
 	private $lyricsApiHandler = null;
 
@@ -58,6 +63,10 @@ class LyricsApiController extends WikiaController {
 
 		// Validate result
 		if( is_null( $results ) ) {
+			// Since there will often be a ton of repeated 404s for the same song, cache
+			// it for a little while to lighten the load on the backend.
+			$this->response->setCacheValidity( self::CACHE_DURATION_FOR_404 );
+
 			throw new NotFoundApiException( $this->getNotFoundDetails( $method ) );
 		}
 


### PR DESCRIPTION
…he special nature of Lyrics mobile apps that popular songs that we don't have pages for yet, will be requested hundreds (thousands?) of times per hour. The caching is a very short duration (5 minutes) which will just unburden the backend (max of 12 requests per hour per 404). LYR-235

This is the same fix as https://github.com/Wikia/app/pull/7457 ...just another option for how it's coded. PLEASE MERGE JUST ONE OF THEM... WHICHEVER IS PREFERRED :)
