### PR TITLE
Ce 1869 flags tracking

### DIFF
--- a/extensions/wikia/Flags/controllers/templates/FlagsController_editForm.mustache
+++ b/extensions/wikia/Flags/controllers/templates/FlagsController_editForm.mustache
@@ -4,7 +4,7 @@
 			<li>
 				<input type="checkbox" id="{{inputNamePrefix}}:{{flag_type_id}}" name="{{inputNamePrefix}}:{{flag_type_id}}:{{inputNameCheckbox}}" {{#flag_id}}checked{{/flag_id}}>
 				<label for="{{inputNamePrefix}}:{{flag_type_id}}">{{flag_name}}</label>
-				<a href="{{flag_view_url}}" target="_blank">{{moreInfo}}</a>
+				<a href="{{flag_view_url}}" data-id="more-info" target="_blank">{{moreInfo}}</a>
 				{{#flag_params_names.length}}
 					<fieldset class="params">
 						{{#flag_params_names}}

--- a/extensions/wikia/Flags/controllers/templates/FlagsController_editForm.php
+++ b/extensions/wikia/Flags/controllers/templates/FlagsController_editForm.php
@@ -6,7 +6,7 @@
 			<?php isset( $flag['flag_id'] ) ? $checked = 'checked' : $checked = '';	?>
 			<input type="checkbox" id="<?= Sanitizer::encodeAttribute( $prefix ) ?>" name="<?= Sanitizer::encodeAttribute( "{$prefix}:{$inputNameCheckbox}" ) ?>" <?= $checked ?>>
 			<label for="<?= Sanitizer::encodeAttribute( $prefix ) ?>"><?= $flag['flag_name'] ?></label>
-			<a href="<?= Sanitizer::cleanUrl( $flag['flag_view_url'] ) ?>" target="_blank"><?= wfMessage( 'flags-edit-form-more-info' )->escaped() ?></a>
+			<a href="<?= Sanitizer::cleanUrl( $flag['flag_view_url'] ) ?>" data-id="more-info" target="_blank"><?= wfMessage( 'flags-edit-form-more-info' )->escaped() ?></a>
 			<?php
 			$flagParamsNames = json_decode( $flag['flag_params_names'] );
 			if ( !empty( $flagParamsNames ) ):

--- a/extensions/wikia/Flags/scripts/FlagsModal.js
+++ b/extensions/wikia/Flags/scripts/FlagsModal.js
@@ -58,7 +58,10 @@ require(
 		action: tracker.ACTIONS.CLICK,
 		category: 'flags-edit',
 		trackingMethod: 'analytics'
-	});
+	}),
+
+	/* Label for on submit tracking event */
+	labelForSubmitAction = 'submit-form-untouched';
 
 	function init() {
 		$('#ca-flags').on('click', showModal);
@@ -157,16 +160,21 @@ require(
 			modalInstance.bind('done', function () {
 				track({
 					action: tracker.ACTIONS.CLICK_LINK_BUTTON,
-					label: 'submit'
+					label: labelForSubmitAction
 				});
 				$flagsEditForm.trigger('submit');
 			});
 			/* Track clicks on modal form */
 			$flagsEditForm.bind('click', trackModalFormClicks);
+			/* Detect form change */
+			$flagsEditForm.on('change', function() {
+				labelForSubmitAction = 'submit-form-touched';
+				$flagsEditForm.off('change');
+			});
 		}
 
 		/* Track all ways of closing modal */
-		modalInstance.bind( 'close', function() {
+		modalInstance.bind('close', function() {
 			track({
 				label: 'modal-close'
 			});

--- a/extensions/wikia/Flags/scripts/FlagsModal.js
+++ b/extensions/wikia/Flags/scripts/FlagsModal.js
@@ -158,7 +158,7 @@ require(
 				$flagsEditForm.trigger('submit');
 			});
 			/* Track clicks on modal form */
-			$flagsEditForm.bind('mousedown', trackModalFormClicks);
+			$flagsEditForm.bind('click', trackModalFormClicks);
 		}
 
 		/* Track all ways of closing modal */
@@ -177,18 +177,36 @@ require(
 	}
 
 	/**
-	 * Track clicks on links within modal form
+	 * Track clicks within modal form
+	 * (links and checkboxes)
 	 */
 	function trackModalFormClicks(e) {
-		var $targetLink = $(e.target).closest('a'),
+		var $target = $(e.target),
 			$targetLinkDataId;
 
-		if ($targetLink.length > 0) {
-			$targetLinkDataId = $targetLink.data('id');
+		/* Track checkbox toggling */
+		if ($target.is('input[type=checkbox]')) {
+			if ($target[0].checked) {
+				track({
+					action: tracker.ACTIONS.CLICK,
+					label: 'checkbox-checked'
+				});
+			} else {
+				track({
+					action: tracker.ACTIONS.CLICK,
+					label: 'checkbox-unchecked'
+				});
+			}
+			return;
+		}
+
+		/* Track links clicks */
+		if ($target.is('a')) {
+			$targetLinkDataId = $target.data('id');
 			if($targetLinkDataId) {
 				track({
 					action: tracker.ACTIONS.CLICK_LINK_TEXT,
-					label: $targetLink.data('id')
+					label: $targetLinkDataId
 				});
 			}
 		}

--- a/extensions/wikia/Flags/scripts/FlagsModal.js
+++ b/extensions/wikia/Flags/scripts/FlagsModal.js
@@ -56,7 +56,7 @@ require(
 	/* Tracking wrapper function */
 	track = Wikia.Tracker.buildTrackingFunction({
 		action: tracker.ACTIONS.CLICK,
-		category: 'insights-loop-notification',
+		category: 'flags-edit',
 		trackingMethod: 'analytics'
 	});
 
@@ -157,12 +157,14 @@ require(
 			modalInstance.bind('done', function () {
 				$flagsEditForm.trigger('submit');
 			});
+			/* Track clicks on modal form */
+			$flagsEditForm.bind('mousedown', trackModalFormClicks);
 		}
 
 		/* Track all ways of closing modal */
 		modalInstance.bind( 'close', function() {
 			track({
-				label: 'flags-edit-modal-close'
+				label: 'modal-close'
 			});
 		});
 
@@ -170,8 +172,26 @@ require(
 		modalInstance.show();
 		track({
 			action: tracker.ACTIONS.IMPRESSION,
-			label: 'flags-edit-modal-shown'
+			label: 'modal-shown'
 		});
+	}
+
+	/**
+	 * Track clicks on links within modal form
+	 */
+	function trackModalFormClicks(e) {
+		var $targetLink = $(e.target).closest('a'),
+			$targetLinkDataId;
+
+		if ($targetLink.length > 0) {
+			$targetLinkDataId = $targetLink.data('id');
+			if($targetLinkDataId) {
+				track({
+					action: tracker.ACTIONS.CLICK_LINK_TEXT,
+					label: $targetLink.data('id')
+				});
+			}
+		}
 	}
 
 	// Run initialization method on DOM ready

--- a/extensions/wikia/Flags/scripts/FlagsModal.js
+++ b/extensions/wikia/Flags/scripts/FlagsModal.js
@@ -1,6 +1,6 @@
 require(
-	['jquery', 'wikia.loader', 'wikia.nirvana', 'wikia.mustache', 'mw'],
-	function ($, loader, nirvana, mustache, mw)
+	['jquery', 'wikia.loader', 'wikia.nirvana', 'wikia.mustache', 'mw', 'wikia.tracker'],
+	function ($, loader, nirvana, mustache, mw, tracker)
 {
 	'use strict';
 
@@ -51,7 +51,13 @@ require(
 			content: '', // content
 			title: mw.message('flags-edit-modal-title').escaped()
 		}
-	};
+	},
+
+	track = Wikia.Tracker.buildTrackingFunction({
+		category: 'insights-loop-notification',
+		trackingMethod: 'analytics',
+		action: tracker.ACTIONS.IMPRESSION
+	});
 
 	function init() {
 		$('#ca-flags').on('click', showModal);
@@ -154,6 +160,9 @@ require(
 
 		/* Show the modal */
 		modalInstance.show();
+		track({
+			label: 'flags-edit-modal-shown'
+		});
 	}
 
 	// Run initialization method on DOM ready

--- a/extensions/wikia/Flags/scripts/FlagsModal.js
+++ b/extensions/wikia/Flags/scripts/FlagsModal.js
@@ -155,6 +155,10 @@ require(
 		if ($flagsEditForm.length > 0) {
 			/* Submit flags edit form on Done button click */
 			modalInstance.bind('done', function () {
+				track({
+					action: tracker.ACTIONS.CLICK_LINK_BUTTON,
+					label: 'submit'
+				});
 				$flagsEditForm.trigger('submit');
 			});
 			/* Track clicks on modal form */

--- a/extensions/wikia/Flags/scripts/FlagsModal.js
+++ b/extensions/wikia/Flags/scripts/FlagsModal.js
@@ -53,10 +53,11 @@ require(
 		}
 	},
 
+	/* Tracking wrapper function */
 	track = Wikia.Tracker.buildTrackingFunction({
+		action: tracker.ACTIONS.CLICK,
 		category: 'insights-loop-notification',
-		trackingMethod: 'analytics',
-		action: tracker.ACTIONS.IMPRESSION
+		trackingMethod: 'analytics'
 	});
 
 	function init() {
@@ -158,9 +159,17 @@ require(
 			});
 		}
 
+		/* Track all ways of closing modal */
+		modalInstance.bind( 'close', function() {
+			track({
+				label: 'flags-edit-modal-close'
+			});
+		});
+
 		/* Show the modal */
 		modalInstance.show();
 		track({
+			action: tracker.ACTIONS.IMPRESSION,
 			label: 'flags-edit-modal-shown'
 		});
 	}

--- a/skins/oasis/js/Tracking.js
+++ b/skins/oasis/js/Tracking.js
@@ -104,6 +104,7 @@ jQuery(function ($) {
 			case 'history':
 			case 'move':
 			case 'protect':
+			case 'flags':
 				label = 'edit-' + id;
 				break;
 			}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CE-1869

Added clicktracking for flags edit modal for following events:

An impression when the dialog is opened [DONE]
When the dialog is closed and no changes are saved ("x", "cancel," clicking outside the dialog) [DONE]
When "done" is clicked but no changes are actually made
When the dialog is closed and some changes are saved [DONE] note: checking only if form was touched
so if user checks checkbox and unchecks back before save it's stored as changed
When the dialog is submitted [DONE]

When "Flags" is selected from the edit dropdown (similar to how other buttons there are tracked) [DONE]
When a flag is toggled on [DONE]
When a flag is toggled off [DONE]
When "More info -->" is clicked [DONE]

@Wikia/community-engineering 
