### PR TITLE
SOC-887 WallNotification emails are no longer being properly classified in Sendgrid

### DIFF
--- a/extensions/wikia/Email/Controller/ForumController.class.php
+++ b/extensions/wikia/Email/Controller/ForumController.class.php
@@ -8,7 +8,7 @@ use Email\Tracking\TrackingCategories;
 
 class ForumController extends EmailController {
 
-	const TRACKING_CATEGORY = TrackingCategories::WALL_NOTIFICATIONS;
+	const TRACKING_CATEGORY = TrackingCategories::WALL_NOTIFICATION;
 
 	protected $titleText;
 	protected $titleUrl;

--- a/extensions/wikia/Email/Controller/ForumController.class.php
+++ b/extensions/wikia/Email/Controller/ForumController.class.php
@@ -4,9 +4,11 @@ namespace Email\Controller;
 
 use Email\Check;
 use Email\EmailController;
-use Email\Fatal;
+use Email\Tracking\TrackingCategories;
 
 class ForumController extends EmailController {
+
+	const TRACKING_CATEGORY = TrackingCategories::WALL_NOTIFICATIONS;
 
 	protected $titleText;
 	protected $titleUrl;

--- a/extensions/wikia/Email/Controller/WallMessageController.class.php
+++ b/extensions/wikia/Email/Controller/WallMessageController.class.php
@@ -4,8 +4,11 @@ namespace Email\Controller;
 
 use Email\Check;
 use Email\EmailController;
+use Email\Tracking\TrackingCategories;
 
 abstract class WallMessageController extends EmailController {
+
+	const TRACKING_CATEGORY = TrackingCategories::WALL_NOTIFICATIONS;
 
 	protected $titleUrl;
 	protected $titleText;

--- a/extensions/wikia/Email/Controller/WallMessageController.class.php
+++ b/extensions/wikia/Email/Controller/WallMessageController.class.php
@@ -8,7 +8,7 @@ use Email\Tracking\TrackingCategories;
 
 abstract class WallMessageController extends EmailController {
 
-	const TRACKING_CATEGORY = TrackingCategories::WALL_NOTIFICATIONS;
+	const TRACKING_CATEGORY = TrackingCategories::WALL_NOTIFICATION;
 
 	protected $titleUrl;
 	protected $titleText;

--- a/extensions/wikia/Email/Email.setup.php
+++ b/extensions/wikia/Email/Email.setup.php
@@ -43,6 +43,7 @@ $wgAutoloadClasses['Email\Controller\ReplyWallMessageController'] =  $dir . 'Con
 $wgAutoloadClasses['Email\Controller\ForumController'] =  $dir . 'Controller/ForumController.class.php';
 $wgAutoloadClasses['Email\Controller\ReplyForumController'] =  $dir . 'Controller/ForumController.class.php';
 $wgAutoloadClasses['Email\SpecialSendEmailController'] = $dir .  'SpecialSendEmailController.class.php';
+$wgAutoloadClasses['Email\Tracking\TrackingCategories'] = $dir .  'tracking/TrackingCategories.class.php';
 
 /**
  * special pages

--- a/extensions/wikia/Email/EmailController.class.php
+++ b/extensions/wikia/Email/EmailController.class.php
@@ -4,9 +4,12 @@ namespace Email;
 
 use TijsVerkoyen\CssToInlineStyles\CssToInlineStyles;
 use Wikia\Logger\WikiaLogger;
+use Email\Tracking\TrackingCategories;
 
 abstract class EmailController extends \WikiaController {
 	const DEFAULT_TEMPLATE_ENGINE = \WikiaResponse::TEMPLATE_ENGINE_MUSTACHE;
+
+	const TRACKING_CATEGORY = TrackingCategories::DEFAULT_CATEGORY;
 
 	const AVATAR_SIZE = 50;
 
@@ -152,7 +155,9 @@ abstract class EmailController extends \WikiaController {
 					$fromAddress,
 					$subject,
 					$body,
-					$replyToAddress
+					$replyToAddress,
+					$contentType = null,
+					static::TRACKING_CATEGORY
 				);
 				$this->assertGoodStatus( $status );
 			}

--- a/extensions/wikia/Email/tracking/TrackingCategories.class.php
+++ b/extensions/wikia/Email/tracking/TrackingCategories.class.php
@@ -3,6 +3,6 @@
 namespace Email\Tracking;
 
 class TrackingCategories {
-	const DEFAULT_CATEGORY = "UserMail";
+	const DEFAULT_CATEGORY = "UserMailer";
 	const WALL_NOTIFICATION = "WallNotification";
 }

--- a/extensions/wikia/Email/tracking/TrackingCategories.class.php
+++ b/extensions/wikia/Email/tracking/TrackingCategories.class.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Email\Tracking;
+
+class TrackingCategories {
+	const DEFAULT_CATEGORY = "UserMail";
+	const WALL_NOTIFICATIONS = "WallNotifications";
+}

--- a/extensions/wikia/Email/tracking/TrackingCategories.class.php
+++ b/extensions/wikia/Email/tracking/TrackingCategories.class.php
@@ -4,5 +4,5 @@ namespace Email\Tracking;
 
 class TrackingCategories {
 	const DEFAULT_CATEGORY = "UserMail";
-	const WALL_NOTIFICATIONS = "WallNotification";
+	const WALL_NOTIFICATION = "WallNotification";
 }

--- a/extensions/wikia/Email/tracking/TrackingCategories.class.php
+++ b/extensions/wikia/Email/tracking/TrackingCategories.class.php
@@ -4,5 +4,5 @@ namespace Email\Tracking;
 
 class TrackingCategories {
 	const DEFAULT_CATEGORY = "UserMail";
-	const WALL_NOTIFICATIONS = "WallNotifications";
+	const WALL_NOTIFICATIONS = "WallNotification";
 }


### PR DESCRIPTION
As part of revamping the new emails, we stopped sending the custom categories used by send grid to categorize our emails. This fixes that.

Ticket: https://wikia-inc.atlassian.net/browse/SOC-887
