### PR TITLE
Skip redundant HTTP requests to Helios for logged in users

### DIFF
--- a/includes/context/RequestContext.php
+++ b/includes/context/RequestContext.php
@@ -197,7 +197,7 @@ class RequestContext implements IContextSource {
 	public function getUser() {
 		// Wikia change - begin - @author: Michał Roszka
 		global $wgEnableHeliosExt;
-		if ( $wgEnableHeliosExt ) {
+		if ( $this->user === null && $wgEnableHeliosExt ) {
 			$this->user = \Wikia\Helios\User::newFromToken( $this->getRequest() );
 		}
 		// Wikia change - end
@@ -336,7 +336,7 @@ class RequestContext implements IContextSource {
 	public function getSkin() {
 		if ( $this->skin === null ) {
 			wfProfileIn( __METHOD__ . '-createskin' );
-			
+
 			$skin = null;
 			wfRunHooks( 'RequestContextCreateSkin', array( $this, &$skin ) );
 


### PR DESCRIPTION
Logged in users were causing too many helios/http requests:

before: 26.12% 0.090985     51 - Http::request::GET
after:  1.22% 0.015368      1 - Http::request::GET

@ArturKlajnerok @macbre @michalroszka 
