### PR TITLE
OPS-6532: clean stats_db rows for wikis removed before Jan 2015

### DIFF
--- a/maintenance/wikia/eventsCleanup.php
+++ b/maintenance/wikia/eventsCleanup.php
@@ -23,7 +23,7 @@ class EventsCleanup extends Maintenance {
 	const BATCH = 50;
 
 	// remove entries for wikis closed before this date
-	const CLOSED_BEFORE = '20130601000000';
+	const CLOSED_BEFORE = '20150101000000'; // Jan 2015
 
 	/**
 	 * Set script options
@@ -94,6 +94,9 @@ class EventsCleanup extends Maintenance {
 
 		$batches = array_chunk( $closedWikis, self::BATCH );
 		$this->output( sprintf( "Got %d closed wikis (before %s) in %d batches\n", count( $closedWikis ), self::CLOSED_BEFORE, count( $batches ) ) );
+
+		$this->output( "Starting in 5 seconds...\n" );
+		sleep(5);
 
 		foreach ( $batches as $n => $batch ) {
 			$this->cleanupBatch( $batch );


### PR DESCRIPTION
We're running out of disk space on `statsdb` machine. Clean up `dataware.pages`, `specials.events_local_users` and `stats.events` tables from entries for wikis closed before Jan 2015.

See #7161

![Scania](http://www.zabawki-modele.pl/catalog/images/imagebig/bruder/03560.jpg)

@michalroszka / @drozdo 
