### PR TITLE
(CE-1975) Ensure user is logged out when account requested closure

### DIFF
--- a/extensions/wikia/CloseMyAccount/CloseMyAccountHooks.class.php
+++ b/extensions/wikia/CloseMyAccount/CloseMyAccountHooks.class.php
@@ -16,6 +16,8 @@ class CloseMyAccountHooks {
 		$closeAccountHelper = new CloseMyAccountHelper();
 		if ( $closeAccountHelper->isScheduledForClosure( $user ) ) {
 			$wgRequest->setSessionData( 'closeAccountSessionId', $user->getId() );
+			// Ensure the user is logged out and access token is cleared
+			$user->logout();
 			$result = 'closurerequested';
 			$resultMsg = 'Account closure requested';
 			return false;


### PR DESCRIPTION
When a user who requested the closure of their account, when they attempt
to login and provide the correct credentials, we abort the login before the
cookies are set. With Helios, the access token is now set before that, so
we need to make sure the token is cleared before it can be used to initialise
the session.

/cc @michalroszka 
