### PR TITLE
DAT-2891 block elements will now be parsed correctly, test added

### DIFF
--- a/extensions/wikia/PortableInfobox/services/Parser/MediaWikiParserService.php
+++ b/extensions/wikia/PortableInfobox/services/Parser/MediaWikiParserService.php
@@ -21,17 +21,17 @@ class MediaWikiParserService implements ExternalParser {
 	 */
 	public function parse( $wikitext ) {
 		wfProfileIn( __METHOD__ );
-		if ( substr( $wikitext, 0, 1 ) == "*" ) {
+		if ( in_array( substr( $wikitext, 0, 1 ), [ '*', '#' ] ) ) {
 			//fix for first item list elements
 			$wikitext = "\n" . $wikitext;
 		}
-		$output = $this->parser->internalParse( $wikitext, false, $this->frame );
+		$parsed = $this->parser->internalParse( $wikitext, false, $this->frame );
+		$output = $this->parser->doBlockLevels( $parsed, false );
 		$this->parser->replaceLinkHolders( $output );
-		$result = $this->parser->killMarkers( $output );
 
 		wfProfileOut( __METHOD__ );
 
-		return $result;
+		return $output;
 	}
 
 	/**
@@ -69,16 +69,5 @@ class MediaWikiParserService implements ExternalParser {
 		$tmstmp = $file ? $file->getTimestamp() : false;
 		$sha1 = $file ? $file->getSha1() : false;
 		$this->parser->getOutput()->addImage( $title, $tmstmp, $sha1 );
-	}
-
-	private function getParserTitle() {
-		return $this->parser->getTitle();
-	}
-
-	private function getParserOptions() {
-		$options = $this->parser->getOptions();
-		$options->enableLimitReport( false );
-
-		return $options;
 	}
 }

--- a/extensions/wikia/PortableInfobox/tests/MediaWikiParserTest.php
+++ b/extensions/wikia/PortableInfobox/tests/MediaWikiParserTest.php
@@ -2,10 +2,60 @@
 
 class MediaWikiParserTest extends WikiaBaseTest {
 
+	/** @var Parser */
+	protected $parser;
+
+	public function setUp() {
+		$this->parser = new Parser();
+		$title = Title::newFromText( 'test' );
+		$options = new ParserOptions();
+		$this->parser->startExternalParse( $title, $options, 'text', true );
+		parent::setUp();
+	}
+
+	protected function parse( $wikitext, $params, $newline = false ) {
+		$withVars = $this->parser->replaceVariables( $wikitext,
+			$this->parser->getPreprocessor()->newCustomFrame( $params ) );
+		$parserOutput = $this->parser->parse( $withVars, $this->parser->getTitle(), $this->parser->getOptions(),
+			$newline );
+
+		return preg_replace( '|{{{.*}}}|Us', '', preg_replace( '|[\n\r]|Us', '', $parserOutput->getText() ) );
+	}
+
 	public function testAsideTagPWrappedDuringParsing() {
 		$aside = "<aside></aside>";
 		$result = ( new Parser() )->doBlockLevels( $aside, true );
 		//parser adds new line at the end of block
 		$this->assertEquals( $aside . "\n", $result );
+	}
+
+
+	/**
+	 * @dataProvider mwParserWrapperDataProvider
+	 *
+	 * @param $wikitext
+	 * @param $params
+	 */
+	public function testWrapper( $wikitext, $params, $newline ) {
+		$frame = $this->parser->getPreprocessor()->newCustomFrame( $params );
+		$wrapper = new \Wikia\PortableInfobox\Parser\MediaWikiParserService( $this->parser, $frame );
+
+		$output = $wrapper->parseRecursive( $wikitext );
+
+		$this->assertEquals( $this->parse( $wikitext, $params, $newline ), $output );
+	}
+
+	public function mwParserWrapperDataProvider() {
+		return [
+			[ "*1\n*2\n*3", [ ], true ],
+			[ "''d''", [ ], false ],
+			[ "'''dd'''", [ ], false ],
+			[ "#1\n#2\n#3 ksajdlk", [ ], true ],
+			[ "{{{test}}}", [ 'test' => 1 ], false ],
+			[ " :asdf", [ ], false ],
+			[ "\n:asdf", [ ], false ],
+			[ "\n;asdf", [ ], false ],
+			[ "[[asdf]]", [ ], false ]
+		];
 	}
 }


### PR DESCRIPTION
See https://github.com/Wikia/app/pull/7505
