### PR TITLE
CE-2009 Add a control mechanism for displaying Flags 

### DIFF
--- a/extensions/wikia/Flags/Flags.hooks.php
+++ b/extensions/wikia/Flags/Flags.hooks.php
@@ -75,12 +75,12 @@ class Hooks {
 	public static function onParserBeforeInternalParse( \Parser $parser, &$text, &$stripState ) {
 		/**
 		 * Don't check for flags if:
-		 * - you've already checked
+		 * - Parser is not used for the main content
 		 * - a user is on an edit page
 		 * - the request is from VE
 		 */
 		$helper = new FlagsHelper();
-		if ( $parser->getOptions()->getShouldDisplayFlags() && $helper->shouldInjectFlags() ) {
+		if ( $parser->getOptions()->getIsMain() && $helper->shouldInjectFlags() ) {
 			$addText = ( new \FlagsController )
 				->getFlagsForPageWikitext( $parser->getTitle()->getArticleID() );
 

--- a/extensions/wikia/Flags/Flags.hooks.php
+++ b/extensions/wikia/Flags/Flags.hooks.php
@@ -73,8 +73,6 @@ class Hooks {
 	 * @return bool
 	 */
 	public static function onParserBeforeInternalParse( \Parser $parser, &$text, &$stripState ) {
-		global $wgRequest;
-
 		/**
 		 * Don't check for flags if:
 		 * - you've already checked
@@ -82,8 +80,9 @@ class Hooks {
 		 * - the request is from VE
 		 */
 		$helper = new FlagsHelper();
-		if ( !$parser->mFlagsParsed && $helper->shouldInjectFlags() ) {
-			$addText = ( new \FlagsController )->getFlagsForPageWikitext( $parser->getTitle()->getArticleID() );
+		if ( $parser->getOptions()->getShouldDisplayFlags() && $helper->shouldInjectFlags() ) {
+			$addText = ( new \FlagsController )
+				->getFlagsForPageWikitext( $parser->getTitle()->getArticleID() );
 
 			if ( $addText !== null ) {
 				$mwf = \MagicWord::get( 'flags' );

--- a/includes/Article.php
+++ b/includes/Article.php
@@ -456,19 +456,19 @@ class Article extends Page {
 		$parserCache = ParserCache::singleton();
 
 		$parserOptions = $this->getParserOptions();
-		# Render printable version, use printable version cache
 
 		/**
 		 * Wikia change begin
 		 */
 		$skin = $wgOut->getSkin();
 		if ( in_array( $skin->getSkinName(), [ 'oasis', 'monobook' ] ) ) {
-			$parserOptions->setShouldDisplayFlags( true );
+			$parserOptions->setIsMain( true );
 		}
 		/**
 		 * Wikia change end
 		 */
 
+		# Render printable version, use printable version cache
 		if ( $wgOut->isPrintable() ) {
 			$parserOptions->setIsPrintable( true );
 			$parserOptions->setEditSection( false );

--- a/includes/Article.php
+++ b/includes/Article.php
@@ -457,6 +457,18 @@ class Article extends Page {
 
 		$parserOptions = $this->getParserOptions();
 		# Render printable version, use printable version cache
+
+		/**
+		 * Wikia change begin
+		 */
+		$skin = $wgOut->getSkin();
+		if ( in_array( $skin->getSkinName(), [ 'oasis', 'monobook' ] ) ) {
+			$parserOptions->setShouldDisplayFlags( true );
+		}
+		/**
+		 * Wikia change end
+		 */
+
 		if ( $wgOut->isPrintable() ) {
 			$parserOptions->setIsPrintable( true );
 			$parserOptions->setEditSection( false );

--- a/includes/WikiPage.php
+++ b/includes/WikiPage.php
@@ -1511,6 +1511,7 @@ class WikiPage extends Page {
 		}
 		$options->enableLimitReport(); // show inclusion/loop reports
 		$options->setTidy( true ); // fix bad HTML
+		$options->setShouldDisplayFlags( true ); // display flags after an edit
 		return $options;
 	}
 

--- a/includes/WikiPage.php
+++ b/includes/WikiPage.php
@@ -1511,7 +1511,6 @@ class WikiPage extends Page {
 		}
 		$options->enableLimitReport(); // show inclusion/loop reports
 		$options->setTidy( true ); // fix bad HTML
-		$options->setShouldDisplayFlags( true ); // display flags after an edit
 		return $options;
 	}
 
@@ -1539,6 +1538,13 @@ class WikiPage extends Page {
 		$edit->newText = $text;
 		$edit->pst = $wgParser->preSaveTransform( $text, $this->mTitle, $user, $popts );
 		$edit->popts = $this->makeParserOptions( 'canonical' );
+		/**
+		 * Wikia change begin
+		 */
+		$edit->popts->setIsMain( true );
+		/**
+		 * Wikia change end
+		 */
 		$edit->output = $wgParser->parse( $edit->pst, $this->mTitle, $edit->popts, true, true, $revid );
 		$edit->oldText = $this->getRawText();
 

--- a/includes/parser/ParserOptions.php
+++ b/includes/parser/ParserOptions.php
@@ -180,6 +180,8 @@ class ParserOptions {
 	 */
 	var $mExtraKey = '';
 
+	var $mShouldDisplayFlags = false;
+
 	/**
 	 * Function to be called when an option is accessed.
 	 */
@@ -217,6 +219,9 @@ class ParserOptions {
 	function getIsSectionPreview()              { return $this->mIsSectionPreview; }
 	function getIsPrintable()                   { $this->optionUsed( 'printable' );
 												  return $this->mIsPrintable; }
+
+	function getShouldDisplayFlags()            { return $this->mShouldDisplayFlags; }
+
 	function getUser()                          { return $this->mUser; }
 	function getPreSaveTransform()              { return $this->mPreSaveTransform; }
 
@@ -306,6 +311,8 @@ class ParserOptions {
 	function setIsPreview( $x )                 { return wfSetVar( $this->mIsPreview, $x ); }
 	function setIsSectionPreview( $x )          { return wfSetVar( $this->mIsSectionPreview, $x ); }
 	function setIsPrintable( $x )               { return wfSetVar( $this->mIsPrintable, $x ); }
+
+	function setShouldDisplayFlags( $x )        { return wfSetVar( $this->mShouldDisplayFlags, $x ); }
 
 	/**
 	 * Extra key that should be present in the parser cache key.

--- a/includes/parser/ParserOptions.php
+++ b/includes/parser/ParserOptions.php
@@ -180,7 +180,11 @@ class ParserOptions {
 	 */
 	var $mExtraKey = '';
 
-	var $mShouldDisplayFlags = false;
+	/**
+	 * Parsing the main content? BEWARE! This might not be set to true in all contexts, always
+	 * check it before using.
+	 */
+	var $mIsMain = false;
 
 	/**
 	 * Function to be called when an option is accessed.
@@ -220,7 +224,7 @@ class ParserOptions {
 	function getIsPrintable()                   { $this->optionUsed( 'printable' );
 												  return $this->mIsPrintable; }
 
-	function getShouldDisplayFlags()            { return $this->mShouldDisplayFlags; }
+	function getIsMain()                        { return $this->mIsMain; }
 
 	function getUser()                          { return $this->mUser; }
 	function getPreSaveTransform()              { return $this->mPreSaveTransform; }
@@ -312,7 +316,7 @@ class ParserOptions {
 	function setIsSectionPreview( $x )          { return wfSetVar( $this->mIsSectionPreview, $x ); }
 	function setIsPrintable( $x )               { return wfSetVar( $this->mIsPrintable, $x ); }
 
-	function setShouldDisplayFlags( $x )        { return wfSetVar( $this->mShouldDisplayFlags, $x ); }
+	function setIsMain( $x )                    { return wfSetVar( $this->mIsMain, $x ); }
 
 	/**
 	 * Extra key that should be present in the parser cache key.


### PR DESCRIPTION
Hey @Wikia/community-engineering !

I've added a new ParserOption to control the display of Flags. It's set in `Article::view` for Oasis and Monobook and after an edit (which can only happen in Oasis and Monobook for now).
