### PR TITLE
AdEngine: report AbPerformanceTesting experiment name

### DIFF
--- a/extensions/wikia/AdEngine/js/AdLogicPageParams.js
+++ b/extensions/wikia/AdEngine/js/AdLogicPageParams.js
@@ -6,10 +6,11 @@ define('ext.wikia.adEngine.adLogicPageParams', [
 	'wikia.log',
 	'wikia.document',
 	'wikia.location',
+	'wikia.window',
 	require.optional('ext.wikia.adEngine.lookup.services'),
 	require.optional('wikia.abTest'),
 	require.optional('wikia.krux')
-], function (adContext, pvCounter, log, doc, loc, lookups, abTest, krux) {
+], function (adContext, pvCounter, log, doc, loc, win, lookups, abTest, krux) {
 	'use strict';
 
 	var logGroup = 'ext.wikia.adEngine.adLogicPageParams',
@@ -77,6 +78,21 @@ define('ext.wikia.adEngine.adLogicPageParams', [
 			for (i = 0; i < experimentsNumber; i += 1) {
 				ab.push(experiments[i].id + '_' + experiments[i].group.id);
 			}
+		}
+
+		return ab;
+	}
+
+	/**
+	 * Get the AbPerformanceTesting experiment name
+	 *
+	 * @returns {string}
+	 */
+	function getPerformanceAb() {
+		var ab = '';
+
+		if (win.wgTransactionContext && typeof win.wgTransactionContext.perf_test === 'string') {
+			ab = win.wgTransactionContext.perf_test;
 		}
 
 		return ab;
@@ -220,6 +236,7 @@ define('ext.wikia.adEngine.adLogicPageParams', [
 			s1: zone1,
 			s2: zone2,
 			ab: getAb(),
+			perfab: getPerformanceAb(),
 			artid: targeting.pageArticleId && targeting.pageArticleId.toString(),
 			cat: getCategories(),
 			dmn: getDomain(),

--- a/extensions/wikia/AdEngine/js/AdLogicPageParams.js
+++ b/extensions/wikia/AdEngine/js/AdLogicPageParams.js
@@ -89,7 +89,7 @@ define('ext.wikia.adEngine.adLogicPageParams', [
 	 * @returns {string}
 	 */
 	function getPerformanceAb() {
-		var ab = '';
+		var ab;
 
 		if (win.wgTransactionContext && typeof win.wgTransactionContext.perf_test === 'string') {
 			ab = win.wgTransactionContext.perf_test;

--- a/extensions/wikia/AdEngine/js/spec/AdLogicPageParams.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/AdLogicPageParams.spec.js
@@ -21,7 +21,7 @@ describe('AdLogicPageParams', function () {
 		};
 	}
 
-	function mockWindow(document, hostname, amzn_targs) {
+	function mockWindow(document, hostname, amzn_targs, transaction_context) {
 
 		hostname = hostname || 'example.org';
 
@@ -29,7 +29,8 @@ describe('AdLogicPageParams', function () {
 			document: document || {},
 			location: { origin: 'http://' + hostname, hostname: hostname },
 			amzn_targs: amzn_targs,
-			wgCookieDomain: hostname.substr(hostname.indexOf('.'))
+			wgCookieDomain: hostname.substr(hostname.indexOf('.')),
+			wgTransactionContext: transaction_context || {}
 		};
 	}
 
@@ -92,7 +93,7 @@ describe('AdLogicPageParams', function () {
 				},
 				getGroup: function () { return; }
 			} : undefined,
-			windowMock = mockWindow(opts.document, opts.hostname, opts.amzn_targs);
+			windowMock = mockWindow(opts.document, opts.hostname, opts.amzn_targs, opts.transaction_context);
 
 		return modules['ext.wikia.adEngine.adLogicPageParams'](
 			mockAdContext(targeting),
@@ -100,6 +101,7 @@ describe('AdLogicPageParams', function () {
 			logMock,
 			windowMock.document,
 			windowMock.location,
+			windowMock,
 			undefined,
 			abTestMock,
 			kruxMock
@@ -248,6 +250,19 @@ describe('AdLogicPageParams', function () {
 			{ id: 76, group: { id: 112 } }
 		]});
 		expect(params.ab).toEqual(['17_34', '19_45', '76_112'], 'ab params passed');
+	});
+
+	it('getPageLevelParams abPerfTest info', function () {
+		var params;
+
+		params = getParams();
+		expect(params.perfab).toEqual('');
+
+		params = getParams({}, {transaction_context: {perf_test: 'foo'}});
+		expect(params.perfab).toEqual('foo');
+
+		params = getParams({}, {transaction_context: {perf_test: true}});
+		expect(params.perfab).toEqual('');
 	});
 
 	it('getPageLevelParams includeRawDbName', function () {

--- a/extensions/wikia/AdEngine/js/spec/AdLogicPageParams.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/AdLogicPageParams.spec.js
@@ -256,13 +256,13 @@ describe('AdLogicPageParams', function () {
 		var params;
 
 		params = getParams();
-		expect(params.perfab).toEqual('');
+		expect(params.perfab).toEqual(undefined);
 
 		params = getParams({}, {transaction_context: {perf_test: 'foo'}});
 		expect(params.perfab).toEqual('foo');
 
 		params = getParams({}, {transaction_context: {perf_test: true}});
-		expect(params.perfab).toEqual('');
+		expect(params.perfab).toEqual(undefined);
 	});
 
 	it('getPageLevelParams includeRawDbName', function () {


### PR DESCRIPTION
Report the name of the AbPerformanceTesting experiment as `perfab` field.

@gabrys 

See #7461 for more context
