### PR TITLE
(CE-1370) Switch allowuserjs/css to useuserjs/css

### DIFF
--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -1599,8 +1599,10 @@ class Wikia {
 
 		$wgUseSiteJs = $request->getBool( 'usesitejs', $wgUseSiteJs ) !== false;
 		$wgUseSiteCss = $request->getBool( 'usesitecss', $wgUseSiteCss ) !== false;
-		$wgAllowUserJs = $request->getBool( 'allowuserjs', $wgAllowUserJs ) !== false;
-		$wgAllowUserCss = $request->getBool( 'allowusercss', $wgAllowUserCss ) !== false;
+		$wgAllowUserJs = $request->getBool( 'useuserjs',
+			$request->getBool( 'allowuserjs', $wgAllowUserJs ) ) !== false;
+		$wgAllowUserCss = $request->getBool( 'useusercss',
+			$request->getBool( 'allowusercss', $wgAllowUserCss ) ) !== false;
 		$wgBuckySampling = $request->getInt( 'buckysampling', $wgBuckySampling );
 
 		return true;


### PR DESCRIPTION
Switch the URL parameters allowuserjs and allowusercss to useuserjs and
useusercss to be consistent with usesitejs/css. To avoid breaking things
for existing users, it will fallback to allowuserjs/css as aliases.

/cc @Wikia/community-engineering 
