### PR TITLE
SOC-781 Use master when getting redirect URL, validate newTitle var

### DIFF
--- a/extensions/wikia/Email/Controller/WatchedPageController.class.php
+++ b/extensions/wikia/Email/Controller/WatchedPageController.class.php
@@ -299,7 +299,7 @@ class WatchedPageRenamedController extends WatchedPageController {
 	public function initEmail() {
 		parent::initEmail();
 
-		$this->newTitle = \WikiPage::factory( $this->title )->getRedirectTarget( $useMasterDb = \Title::GAID_FOR_UPDATE );
+		$this->newTitle = \WikiPage::factory( $this->title )->getRedirectTarget( \Title::GAID_FOR_UPDATE );
 		$this->assertValidNewTitle();
 	}
 

--- a/extensions/wikia/Email/Controller/WatchedPageController.class.php
+++ b/extensions/wikia/Email/Controller/WatchedPageController.class.php
@@ -292,10 +292,24 @@ class WatchedPageRenamedController extends WatchedPageController {
 	/** @var \Title */
 	protected $newTitle;
 
+	/**
+	 * Set newTitle (the new title the page was moved to). Make sure to use the master DB when getting the
+	 * redirect URL, this ensure that even if the slave hasn't caught up we get a valid redirect URL.
+	 */
 	public function initEmail() {
 		parent::initEmail();
 
-		$this->newTitle = \WikiPage::factory( $this->title )->getRedirectTarget();
+		$this->newTitle = \WikiPage::factory( $this->title )->getRedirectTarget( $userMaster = true );
+		$this->assertValidNewTitle();
+	}
+
+	/**
+	 * @throws \Email\Check
+	 */
+	private function assertValidNewTitle() {
+		if ( !$this->newTitle instanceof \Title ) {
+			throw new Check( "Invalid value found for newTitle" );
+		}
 	}
 
 	/**

--- a/extensions/wikia/Email/Controller/WatchedPageController.class.php
+++ b/extensions/wikia/Email/Controller/WatchedPageController.class.php
@@ -299,7 +299,7 @@ class WatchedPageRenamedController extends WatchedPageController {
 	public function initEmail() {
 		parent::initEmail();
 
-		$this->newTitle = \WikiPage::factory( $this->title )->getRedirectTarget( $userMaster = true );
+		$this->newTitle = \WikiPage::factory( $this->title )->getRedirectTarget( $useMasterDb = \Title::GAID_FOR_UPDATE );
 		$this->assertValidNewTitle();
 	}
 

--- a/includes/WikiPage.php
+++ b/includes/WikiPage.php
@@ -591,11 +591,11 @@ class WikiPage extends Page {
 	 * The target will be fetched from the redirect table if possible.
 	 * If this page doesn't have an entry there, call insertRedirect()
 	 *
-	 * @param bool $userMaster
+	 * @param int $useMasterDb
 	 * @return Title|mixed object, or null if this page is not a redirect
 	 */
-	public function getRedirectTarget( $userMaster = false ) {
-		if ( !$this->mTitle->isRedirect() ) {
+	public function getRedirectTarget( $useMasterDb = 0 ) {
+		if ( !$this->mTitle->isRedirect( $useMasterDb ) ) {
 			return null;
 		}
 
@@ -604,7 +604,7 @@ class WikiPage extends Page {
 		}
 
 		# Query the redirect table
-		$dbr = $userMaster ? wfGetDB( DB_MASTER ) : wfGetDB( DB_SLAVE );
+		$dbr = $useMasterDb ? wfGetDB( DB_MASTER ) : wfGetDB( DB_SLAVE );
 		$row = $dbr->selectRow( 'redirect',
 			array( 'rd_namespace', 'rd_title', 'rd_fragment', 'rd_interwiki' ),
 			array( 'rd_from' => $this->getId() ),

--- a/includes/WikiPage.php
+++ b/includes/WikiPage.php
@@ -590,9 +590,11 @@ class WikiPage extends Page {
 	 *
 	 * The target will be fetched from the redirect table if possible.
 	 * If this page doesn't have an entry there, call insertRedirect()
+	 *
+	 * @param bool $userMaster
 	 * @return Title|mixed object, or null if this page is not a redirect
 	 */
-	public function getRedirectTarget() {
+	public function getRedirectTarget( $userMaster = false ) {
 		if ( !$this->mTitle->isRedirect() ) {
 			return null;
 		}
@@ -602,7 +604,7 @@ class WikiPage extends Page {
 		}
 
 		# Query the redirect table
-		$dbr = wfGetDB( DB_SLAVE );
+		$dbr = $userMaster ? wfGetDB( DB_MASTER ) : wfGetDB( DB_SLAVE );
 		$row = $dbr->selectRow( 'redirect',
 			array( 'rd_namespace', 'rd_title', 'rd_fragment', 'rd_interwiki' ),
 			array( 'rd_from' => $this->getId() ),

--- a/includes/WikiPage.php
+++ b/includes/WikiPage.php
@@ -591,11 +591,11 @@ class WikiPage extends Page {
 	 * The target will be fetched from the redirect table if possible.
 	 * If this page doesn't have an entry there, call insertRedirect()
 	 *
-	 * @param int $useMasterDb
+	 * @param int $flags
 	 * @return Title|mixed object, or null if this page is not a redirect
 	 */
-	public function getRedirectTarget( $useMasterDb = 0 ) {
-		if ( !$this->mTitle->isRedirect( $useMasterDb ) ) {
+	public function getRedirectTarget( $flags = 0 ) {
+		if ( !$this->mTitle->isRedirect( $flags ) ) {
 			return null;
 		}
 
@@ -604,6 +604,7 @@ class WikiPage extends Page {
 		}
 
 		# Query the redirect table
+		$useMasterDb = $flags & Title::GAID_FOR_UPDATE;
 		$dbr = $useMasterDb ? wfGetDB( DB_MASTER ) : wfGetDB( DB_SLAVE );
 		$row = $dbr->selectRow( 'redirect',
 			array( 'rd_namespace', 'rd_title', 'rd_fragment', 'rd_interwiki' ),


### PR DESCRIPTION
This ticket fixes the fatal being thrown as part of https://wikia-inc.atlassian.net/browse/SOC-871. We're now both validating the value of `$newTitle`, as well as using the master database when querying for the redirectTarget in case the slave hasn't caught up yet.
