### PR TITLE
VOLDEV-77: Fix highlighted thread background on Monobook

### DIFF
--- a/extensions/wikia/Forum/css/monobook/ForumMonobook.scss
+++ b/extensions/wikia/Forum/css/monobook/ForumMonobook.scss
@@ -43,7 +43,7 @@
 
 		.thread {
 			&:hover {
-				background-color: $color-page-border;
+				background-color: #FAFAFA;
 			}
 		}
 	}


### PR DESCRIPTION
Changed to #fafafa per [VOLDEV-77](https://wikia-inc.atlassian.net/browse/VOLDEV-77)
