### PR TITLE
AbPerformanceTesting: improve tracking

### DIFF
--- a/extensions/wikia/AbPerformanceTesting/classes/Hooks.class.php
+++ b/extensions/wikia/AbPerformanceTesting/classes/Hooks.class.php
@@ -21,11 +21,10 @@ class Hooks {
 		// mark a transaction with an experiment name
 		\Transaction::getInstance()->set( \Transaction::PARAM_AB_PERFORMANCE_TEST, $experimentName );
 
-		// mark a transaction using UA's custom dimensions
+		// set a global JS variable with an experiment name
 		global $wgHooks;
 		$wgHooks['WikiaSkinTopScripts'][] = function( Array &$vars, &$scripts ) use ( $experimentName ) {
-			$val = \Xml::encodeJsVar( $experimentName );
-			$scripts .= \Html::inlineScript( "_gaq.push(['set', 'dimension20', {$val}]);" );
+			$vars['wgABPerformanceTest'] = $experimentName;
 			return true;
 		} ;
 

--- a/extensions/wikia/AdEngine/js/AdLogicPageParams.js
+++ b/extensions/wikia/AdEngine/js/AdLogicPageParams.js
@@ -89,13 +89,7 @@ define('ext.wikia.adEngine.adLogicPageParams', [
 	 * @returns {string}
 	 */
 	function getPerformanceAb() {
-		var ab;
-
-		if (win.wgTransactionContext && typeof win.wgTransactionContext.perf_test === 'string') {
-			ab = win.wgTransactionContext.perf_test;
-		}
-
-		return ab;
+		return win.wgABPerformanceTest;
 	}
 
 	/**

--- a/extensions/wikia/AdEngine/js/spec/AdLogicPageParams.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/AdLogicPageParams.spec.js
@@ -21,7 +21,7 @@ describe('AdLogicPageParams', function () {
 		};
 	}
 
-	function mockWindow(document, hostname, amzn_targs, transaction_context) {
+	function mockWindow(document, hostname, amzn_targs, perfab) {
 
 		hostname = hostname || 'example.org';
 
@@ -30,7 +30,7 @@ describe('AdLogicPageParams', function () {
 			location: { origin: 'http://' + hostname, hostname: hostname },
 			amzn_targs: amzn_targs,
 			wgCookieDomain: hostname.substr(hostname.indexOf('.')),
-			wgTransactionContext: transaction_context || {}
+			wgABPerformanceTest: perfab
 		};
 	}
 
@@ -93,7 +93,7 @@ describe('AdLogicPageParams', function () {
 				},
 				getGroup: function () { return; }
 			} : undefined,
-			windowMock = mockWindow(opts.document, opts.hostname, opts.amzn_targs, opts.transaction_context);
+			windowMock = mockWindow(opts.document, opts.hostname, opts.amzn_targs, opts.perfab);
 
 		return modules['ext.wikia.adEngine.adLogicPageParams'](
 			mockAdContext(targeting),
@@ -258,11 +258,8 @@ describe('AdLogicPageParams', function () {
 		params = getParams();
 		expect(params.perfab).toEqual(undefined);
 
-		params = getParams({}, {transaction_context: {perf_test: 'foo'}});
+		params = getParams({}, {perfab: 'foo'});
 		expect(params.perfab).toEqual('foo');
-
-		params = getParams({}, {transaction_context: {perf_test: true}});
-		expect(params.perfab).toEqual(undefined);
 	});
 
 	it('getPageLevelParams includeRawDbName', function () {

--- a/extensions/wikia/AnalyticsEngine/js/universal_analytics.js
+++ b/extensions/wikia/AnalyticsEngine/js/universal_analytics.js
@@ -246,7 +246,8 @@
         ['set', 'dimension16', getKruxSegment()],                              // Krux Segment
         ['set', 'dimension17', window.wgWikiVertical],                         // Vertical
         ['set', 'dimension18', window.wgWikiCategories.join(',')],             // Categories
-        ['set', 'dimension19', window.wgArticleType]                          // ArticleType
+        ['set', 'dimension19', window.wgArticleType],                          // ArticleType
+        ['set', 'dimension20', window.wgABPerformanceTest || 'not set']        // Performance A/B testing
     );
 
     /*


### PR DESCRIPTION
Set `wgABPerformanceTest` JS global with a name of the experiment currently being run.

Improves:
- Universal Analytics tracking from #7461 (@harnash) 
- ads-specific reporting introduced in #7517 (@gabrys)
