### PR TITLE
Rename CONTROL group to something less misleading in A/B tests

### DIFF
--- a/extensions/wikia/AnalyticsEngine/js/analytics.js
+++ b/extensions/wikia/AnalyticsEngine/js/analytics.js
@@ -217,7 +217,7 @@
 			}
 			abSlot = window.Wikia.AbTest.getGASlot(abExp.name);
 			if (abSlot >= 40 && abSlot <= 49) {
-				abGroupName = abExp.group ? abExp.group.name : (abList.nouuid ? 'NOBEACON' : 'CONTROL');
+				abGroupName = abExp.group ? abExp.group.name : (abList.nouuid ? 'NOBEACON' : 'NOT_IN_ANY_GROUP');
 				_gaqWikiaPush(['_setCustomVar', abSlot, abExp.name, abGroupName, 3]);
 				abCustomVarsForAds.push(['ads._setCustomVar', abSlot, abExp.name, abGroupName, 3]);
 			}

--- a/extensions/wikia/AnalyticsEngine/js/universal_analytics.js
+++ b/extensions/wikia/AnalyticsEngine/js/universal_analytics.js
@@ -276,7 +276,7 @@
             }
             abSlot = window.Wikia.AbTest.getGASlot(abExp.name);
             if (abSlot >= 40 && abSlot <= 49) {
-                abGroupName = abExp.group ? abExp.group.name : (abList.nouuid ? 'NOBEACON' : 'CONTROL');
+                abGroupName = abExp.group ? abExp.group.name : (abList.nouuid ? 'NOBEACON' : 'NOT_IN_ANY_GROUP');
                 _gaWikiaPush(['set', 'dimension' + abSlot, abGroupName]);
                 abCustomVarsForAds.push(['ads.set', 'dimension' + abSlot, abGroupName]);
             }


### PR DESCRIPTION
Lack of assigned group in A/B test ends up reported as CONTROL group which happens to be misleading in current ads-related use cases. This change should make the name more descriptive and intuitive.

/cc @macbre 
