### PR TITLE
wfSetupSession: log all calls with 1% sampling

### DIFF
--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -3523,6 +3523,15 @@ function wfSetupSession( $sessionId = false ) {
 	wfSuppressWarnings();
 	session_start();
 	wfRestoreWarnings();
+
+	// Wikia change - start
+	// log all sessions started with 1% sampling (PLATFORM-1266)
+	if ( ( new Wikia\Util\Statistics\BernoulliTrial( 0.01 ) )->shouldSample() ) {
+		Wikia\Logger\WikiaLogger::instance()->info( __METHOD__, [
+			'caller' => wfGetCaller(),
+		] );
+	}
+	// Wikia change - end
 }
 
 /**


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-1266

We'd like to know how many PHP sessions we start now and compare it with the number of sessions started by performance A/B testing. This will allow us to measure the impact of increased logged-in traffic on various metrics (CDN hit ratio, # of requests hitting the backend, # of database queries. backend response time, # of calls to services such as Helios or Phalanx).

@wladekb / @jcellary / @michalroszka
