### PR TITLE
Restore the disabled test to ensure we cover the partners api.

### DIFF
--- a/extensions/wikia/VideoHandlers/tests/GamestarApiWrapperTest.php
+++ b/extensions/wikia/VideoHandlers/tests/GamestarApiWrapperTest.php
@@ -34,11 +34,6 @@ class GamestarApiWrapperTest extends WikiaBaseTest {
 	 * @group Infrastructure
 	 */
 	public function testgetDataFromValidHtmlResponse() {
-		// TODO: ticket connected: MAIN-4761
-		$this->markTestSkipped(
-			'2015-06-15 test started to fail randomly; The 3rd party link returned 503 - should it be integration test?'
-		);
-
 		// setup
 		$this->setUpMock();
 


### PR DESCRIPTION
Next step: move to a separate group
