### PR TITLE
wfSetupSession: log session_id and the full backtrace

### DIFF
--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -3532,7 +3532,8 @@ function wfSetupSession( $sessionId = false ) {
 		Wikia\Logger\WikiaLogger::instance()->info( __METHOD__, [
 			'caller' => wfGetAllCallers(),
 			'has_session_id' => ( $sessionId !== false ),
-			'is_anon' => $wgUser->isAnon()
+			'has_user' => is_object( $wgUser ),
+			'is_anon' => $wgUser && $wgUser->isAnon()
 		] );
 	}
 	// Wikia change - end

--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -3526,9 +3526,13 @@ function wfSetupSession( $sessionId = false ) {
 
 	// Wikia change - start
 	// log all sessions started with 1% sampling (PLATFORM-1266)
+	global $wgUser;
+
 	if ( ( new Wikia\Util\Statistics\BernoulliTrial( 0.01 ) )->shouldSample() ) {
 		Wikia\Logger\WikiaLogger::instance()->info( __METHOD__, [
-			'caller' => wfGetCaller(),
+			'caller' => wfGetAllCallers(),
+			'has_session_id' => ( $sessionId !== false ),
+			'is_anon' => $wgUser->isAnon()
 		] );
 	}
 	// Wikia change - end


### PR DESCRIPTION
See #7536

Log:
- the full backtrace (`wfGetCaller` was returnings `unknown`)
- does the anon started the session
- did we restart the existing session

@michalroszka 
