### PR TITLE
AbPerformanceTesting: fix a fatal

### DIFF
--- a/extensions/wikia/AbPerformanceTesting/classes/Hooks.class.php
+++ b/extensions/wikia/AbPerformanceTesting/classes/Hooks.class.php
@@ -60,7 +60,7 @@ class Hooks {
 	 * @param \MediaWiki $wiki
 	 * @return bool it's a hook
 	 */
-	static function onAfterInitialize( \Title $title, \Article $article, \OutputPage $output, \User $user, \WebRequest $request, \MediaWiki $wiki ) {
+	static function onAfterInitialize( $title, $article, $output, $user, $request, $wiki ) {
 		global $wgAbPerformanceTestingExperiments;
 		wfDebug( sprintf( "%s - checking experiments (with beacon ID set to '%s')...\n", __METHOD__, wfGetBeaconId() ) );
 


### PR DESCRIPTION
We do not use any arguments passed to this function, do not force types

@michalroszka / @wladekb 
