### PR TITLE
CE-2046 Allow merging vars from another ParserOutput object

### DIFF
--- a/includes/parser/ParserOutput.php
+++ b/includes/parser/ParserOutput.php
@@ -503,7 +503,6 @@ class ParserOutput extends CacheTime {
 			if ( is_array( $this->$var ) && is_array( $externalParserOutput->$var ) ) {
 				$this->$var = $this->mergeVars(
 					$this->$var, $externalParserOutput->$var );
-				var_dump( $this->$var );
 			} else {
 				throw new Exception( self::INVALID_MERGE_MESSAGE );
 			}
@@ -516,7 +515,7 @@ class ParserOutput extends CacheTime {
 	 * @param $new
 	 * @return array
 	 */
-	private function mergeVars( $source, $new ) {
+	private function mergeVars( Array $source, Array $new ) {
 		$result = [];
 
 		// Retrieve unique keys from both arrays and iterate over them

--- a/includes/parser/ParserOutput.php
+++ b/includes/parser/ParserOutput.php
@@ -501,7 +501,7 @@ class ParserOutput extends CacheTime {
 	public function mergeExternalParserOutputVars( ParserOutput $externalParserOutput ) {
 		foreach ( self::$varsToMerge as $var ) {
 			if ( is_array( $this->$var ) && is_array( $externalParserOutput->$var ) ) {
-				$this->$var = $this->mergeVars(
+				$this->$var = $this->mergeSingleVar(
 					$this->$var, $externalParserOutput->$var );
 			} else {
 				throw new Exception( self::INVALID_MERGE_MESSAGE );
@@ -515,7 +515,7 @@ class ParserOutput extends CacheTime {
 	 * @param $new
 	 * @return array
 	 */
-	private function mergeVars( Array $source, Array $new ) {
+	private function mergeSingleVar( Array $source, Array $new ) {
 		$result = [];
 
 		// Retrieve unique keys from both arrays and iterate over them

--- a/includes/parser/ParserOutput.php
+++ b/includes/parser/ParserOutput.php
@@ -527,7 +527,7 @@ class ParserOutput extends CacheTime {
 				$result[$key] = $new[$key];
 
 			// There is no such key in the new array OR
-			// the source has an array under this key and the new one does not.
+			// types of values under the key in source and new differ.
 			// Treat it as an invalid input and use only the source.
 			} elseif ( !isset( $new[$key] )
 				|| gettype( $source[$key] ) !== gettype( $new[$key] ) ) {

--- a/includes/parser/ParserOutput.php
+++ b/includes/parser/ParserOutput.php
@@ -530,8 +530,8 @@ class ParserOutput extends CacheTime {
 			// the source has an array under this key and the new one does not.
 			// Treat it as an invalid input and use only the source.
 			} elseif ( !isset( $new[$key] )
-				|| ( is_array( $source[$key] ) && !is_array( $new[$key] ) ) ) {
-				$result[$key] = $source[$key];
+				|| gettype( $source[$key] ) !== gettype( $new[$key] ) ) {
+					$result[$key] = $source[$key];
 
 			// The key exists in both arrays and values are also arrays. Use the unite
 			// operator to use values from both arrays.

--- a/includes/parser/tests/ParserOutputTest.php
+++ b/includes/parser/tests/ParserOutputTest.php
@@ -1,0 +1,382 @@
+<?php
+
+class ParserOutputTest extends WikiaBaseTest {
+
+	/**
+	 * @dataProvider getParserOutputVars
+	 */
+	public function testMergeExternalParserOutputVars( $sourceVars, $externalVars, $expectedVars ) {
+		$parserOutputSource = new ParserOutput();
+		$parserOutputExternal = new ParserOutput();
+
+		foreach ( $parserOutputSource::$varsToMerge as $var ) {
+			$parserOutputSource->$var = $sourceVars[$var];
+			$parserOutputExternal->$var = $externalVars[$var];
+		}
+
+		$parserOutputSource->mergeExternalParserOutputVars( $parserOutputExternal );
+
+		foreach ( $parserOutputSource::$varsToMerge as $var ) {
+			$this->assertSame( $expectedVars[$var], $parserOutputSource->$var );
+		}
+	}
+
+	public function getParserOutputVars() {
+		return [
+			// 1st test case
+			[
+				// $sourceVars
+				[
+					// Test merge of two flat arrays
+					'mLanguageLinks' => [
+						'es:Ayuda:Enlace interwiki',
+						'fr:Aide:Lien interwiki',
+						'it:Aiuto:Link interwiki',
+					],
+					// Test merge of two flat arrays
+					'mCategories' => [
+						'Pages_with_broken_file_links' => '',
+						'Mods' => '',
+					],
+					// Test merge of two nested arrays
+					'mLinks' => [
+						0 => [
+							'Combat_level' => 0,
+							'Gender' => 0,
+						],
+						10 => [
+							'CitePodcast' => 0,
+							'CiteGeneral' => 0,
+						],
+						11 => [
+							'Infobox_Deity' => 0
+						],
+					],
+					// Test merge of two nested arrays
+					'mTemplates' => [
+						10 => [
+							'Infobox_Deity' => 525824,
+							'CiteGeneral' => 0,
+						],
+					],
+					// Test merge of a nested source array with a string (should keep source)
+					'mTemplateIds' => [
+						10 => [
+							'Infobox_Deity' => 706876,
+							'CiteGeneral' => 0,
+						]
+					],
+					// Test empty source array
+					'mImages' => [],
+					// Test empty external array
+					'mFileSearchOptions' => [
+						'Tuska_concept_art.png' => [
+							'time' => false,
+							'sha1' => false,
+						],
+						'Tuska_logo.png' => [
+							'time' => false,
+							'sha1' => false,
+						],
+					],
+					// Test two empty arrays
+					'mExternalLinks' => [],
+					// Test merging of two nested arrays with string indexes
+					'mInterwikiLinks' => [
+						'w:' => [
+							'c:Help:Flags' => 1,
+							'c:starwars:Yoda' => 1,
+						]
+					],
+					// Test a case where a key does not exist in source but exists externally
+					'mModules' => [],
+					'mModuleScripts' => [],
+					'mModuleStyles' => [],
+					'mModuleMessages' => [],
+					'mWarnings' => [],
+				],
+				// $externalVars
+				[
+					// Test merge of two flat arrays
+					'mLanguageLinks' => [
+						'nl:Help:Interwiki links',
+						'pl:Pomoc:Linki interwiki',
+					],
+					// Test merge of two flat arrays
+					'mCategories' => [
+						'Editing' => '',
+						'Source_editing' => '',
+					],
+					// Test merge of nested arrays
+					'mLinks' => [
+						12 => [
+							'Contacting_Wikia' => '447598',
+							'Contents' => '447621',
+						],
+						10 => [
+							'Namespace' => '447655',
+							'Shared_help' => '448108',
+						]
+					],
+					// Test merge of nested arrays
+					'mTemplates' => [
+						10 => [
+							'Help_and_feedback_section' => 446666,
+						],
+					],
+					// Test merge of a nested source array with a string (should keep source)
+					'mTemplateIds' => [
+						10 => 'Just a random string',
+					],
+					// Test empty source array
+					'mImages' => [
+						'Search-local.png' => 1,
+						'Search-local-media.png' => 1,
+					],
+					// Test merge of nested arrays where
+					'mFileSearchOptions' => [],
+					// Test two empty arrays
+					'mExternalLinks' => [],
+					// Test merging of two nested arrays with string indexes
+					'mInterwikiLinks' => [
+						'w:' => [
+							'c:community:User_blog:Daniel_Baran\/Search_Developments:_Big_Picture' => 1,
+						],
+					],
+					// Test a case where a key does not exist in source but exists externally
+					'mModules' => [
+						'ext.wikia.venus.article.infobox' => [
+							'scripts' => [
+								'scripts/modules/infobox.module.js',
+								'scripts/Infobox.js'
+							],
+							'styles' => [
+								'styles/modules/infobox.module.scss',
+								'styles/Infobox.scss'
+							],
+							'messages' => [
+								'venus-article-infobox-see-more',
+							],
+							'localBasePath' => __DIR__,
+							'remoteExtPath' => 'wikia/Venus',
+						]
+					],
+					// Test a case where a key does not exist in source but exists externally
+					'mModuleScripts' => [
+						'ext.wikia.venus.article.infobox' => [
+							'scripts' => [
+								'scripts/modules/infobox.module.js',
+								'scripts/Infobox.js'
+							],
+							'styles' => [
+								'styles/modules/infobox.module.scss',
+								'styles/Infobox.scss'
+							],
+							'messages' => [
+								'venus-article-infobox-see-more',
+							],
+							'localBasePath' => __DIR__,
+							'remoteExtPath' => 'wikia/Venus',
+						]
+					],
+					// Test a case where a key does not exist in source but exists externally
+					'mModuleStyles' => [
+						'ext.wikia.venus.article.infobox' => [
+							'scripts' => [
+								'scripts/modules/infobox.module.js',
+								'scripts/Infobox.js'
+							],
+							'styles' => [
+								'styles/modules/infobox.module.scss',
+								'styles/Infobox.scss'
+							],
+							'messages' => [
+								'venus-article-infobox-see-more',
+							],
+							'localBasePath' => __DIR__,
+							'remoteExtPath' => 'wikia/Venus',
+						]
+					],
+					// Test a case where a key does not exist in source but exists externally
+					'mModuleMessages' => [
+						'ext.wikia.venus.article.infobox' => [
+							'scripts' => [
+								'scripts/modules/infobox.module.js',
+								'scripts/Infobox.js'
+							],
+							'styles' => [
+								'styles/modules/infobox.module.scss',
+								'styles/Infobox.scss'
+							],
+							'messages' => [
+								'venus-article-infobox-see-more',
+							],
+							'localBasePath' => __DIR__,
+							'remoteExtPath' => 'wikia/Venus',
+						]
+					],
+					// Test a case where a key does not exist in source but exists externally
+					'mWarnings' => [
+						'Warning no 1' => 1,
+						'Warning no 2' => 1,
+					],
+				],
+				// $expectedVars
+				[
+					// Test merge of two flat arrays
+					'mLanguageLinks' => [
+						'es:Ayuda:Enlace interwiki',
+						'fr:Aide:Lien interwiki',
+						'it:Aiuto:Link interwiki',
+						'nl:Help:Interwiki links',
+						'pl:Pomoc:Linki interwiki',
+					],
+					// Test merge of two flat arrays
+					'mCategories' => [
+						'Pages_with_broken_file_links' => '',
+						'Mods' => '',
+						'Editing' => '',
+						'Source_editing' => '',
+					],
+					// Test merge of two nested arrays
+					'mLinks' => [
+						0 => [
+							'Combat_level' => 0,
+							'Gender' => 0,
+						],
+						10 => [
+							'CitePodcast' => 0,
+							'CiteGeneral' => 0,
+							'Namespace' => '447655',
+							'Shared_help' => '448108',
+						],
+						11 => [
+							'Infobox_Deity' => 0
+						],
+						12 => [
+							'Contacting_Wikia' => '447598',
+							'Contents' => '447621',
+						],
+					],
+					// Test merge of two nested arrays
+					'mTemplates' => [
+						10 => [
+							'Infobox_Deity' => 525824,
+							'CiteGeneral' => 0,
+							'Help_and_feedback_section' => 446666,
+						],
+					],
+					// Test merge of a nested source array with a string (should keep source)
+					'mTemplateIds' => [
+						10 => [
+							'Infobox_Deity' => 706876,
+							'CiteGeneral' => 0,
+						],
+					],
+					// Test empty source array
+					'mImages' => [
+						'Search-local.png' => 1,
+						'Search-local-media.png' => 1,
+					],
+					// Test empty external array
+					'mFileSearchOptions' => [
+						'Tuska_concept_art.png' => [
+							'time' => false,
+							'sha1' => false,
+						],
+						'Tuska_logo.png' => [
+							'time' => false,
+							'sha1' => false,
+						],
+					],
+					// Test two empty arrays
+					'mExternalLinks' => [],
+					'mInterwikiLinks' => [
+						'w:' => [
+							'c:Help:Flags' => 1,
+							'c:starwars:Yoda' => 1,
+							'c:community:User_blog:Daniel_Baran\/Search_Developments:_Big_Picture' => 1,
+						]
+					],
+					// Test a case where a key does not exist in source but exists externally
+					'mModules' => [
+						'ext.wikia.venus.article.infobox' => [
+							'scripts' => [
+								'scripts/modules/infobox.module.js',
+								'scripts/Infobox.js'
+							],
+							'styles' => [
+								'styles/modules/infobox.module.scss',
+								'styles/Infobox.scss'
+							],
+							'messages' => [
+								'venus-article-infobox-see-more',
+							],
+							'localBasePath' => __DIR__,
+							'remoteExtPath' => 'wikia/Venus',
+						]
+					],
+					// Test a case where a key does not exist in source but exists externally
+					'mModuleScripts' => [
+						'ext.wikia.venus.article.infobox' => [
+							'scripts' => [
+								'scripts/modules/infobox.module.js',
+								'scripts/Infobox.js'
+							],
+							'styles' => [
+								'styles/modules/infobox.module.scss',
+								'styles/Infobox.scss'
+							],
+							'messages' => [
+								'venus-article-infobox-see-more',
+							],
+							'localBasePath' => __DIR__,
+							'remoteExtPath' => 'wikia/Venus',
+						]
+					],
+					// Test a case where a key does not exist in source but exists externally
+					'mModuleStyles' => [
+						'ext.wikia.venus.article.infobox' => [
+							'scripts' => [
+								'scripts/modules/infobox.module.js',
+								'scripts/Infobox.js'
+							],
+							'styles' => [
+								'styles/modules/infobox.module.scss',
+								'styles/Infobox.scss'
+							],
+							'messages' => [
+								'venus-article-infobox-see-more',
+							],
+							'localBasePath' => __DIR__,
+							'remoteExtPath' => 'wikia/Venus',
+						]
+					],
+					// Test a case where a key does not exist in source but exists externally
+					'mModuleMessages' => [
+						'ext.wikia.venus.article.infobox' => [
+							'scripts' => [
+								'scripts/modules/infobox.module.js',
+								'scripts/Infobox.js'
+							],
+							'styles' => [
+								'styles/modules/infobox.module.scss',
+								'styles/Infobox.scss'
+							],
+							'messages' => [
+								'venus-article-infobox-see-more',
+							],
+							'localBasePath' => __DIR__,
+							'remoteExtPath' => 'wikia/Venus',
+						]
+					],
+					// Test a case where a key does not exist in source but exists externally
+					'mWarnings' => [
+						'Warning no 1' => 1,
+						'Warning no 2' => 1,
+					],
+				],
+			],
+		];
+	}
+}

--- a/includes/parser/tests/ParserOutputTest.php
+++ b/includes/parser/tests/ParserOutputTest.php
@@ -23,10 +23,8 @@ class ParserOutputTest extends WikiaBaseTest {
 
 	public function getParserOutputVars() {
 		return [
-			// 1st test case
-			[
-				// $sourceVars
-				[
+			'Test case #1' => [
+				'sourceVars' => [
 					// Test merge of two flat arrays
 					'mLanguageLinks' => [
 						'es:Ayuda:Enlace interwiki',
@@ -95,8 +93,7 @@ class ParserOutputTest extends WikiaBaseTest {
 					'mModuleMessages' => [],
 					'mWarnings' => [],
 				],
-				// $externalVars
-				[
+				'externalVars' => [
 					// Test merge of two flat arrays
 					'mLanguageLinks' => [
 						'nl:Help:Interwiki links',
@@ -221,8 +218,7 @@ class ParserOutputTest extends WikiaBaseTest {
 						'Warning no 2' => 1,
 					],
 				],
-				// $expectedVars
-				[
+				'expectedVars' => [
 					// Test merge of two flat arrays
 					'mLanguageLinks' => [
 						'es:Ayuda:Enlace interwiki',


### PR DESCRIPTION
The idea here is to allow other instances of ParserOutput (e.g. coming from portable Flags) being merged into the one of the main article. This allows you to have control over parsing any block of wikitext and still take benefit of `LinksUpdate.php` (Categories, Special:WhatLinksHere etc.).

I'm not handling the `mText` var on purpose to allow flexible content manipulation.

cc: @wladekb @macbre @Grunny We've talked about it offline :)
