### PR TITLE
SwiftSync: use $wgSwiftSyncDB global

### DIFF
--- a/extensions/wikia/SwiftSync/classes/Queue.class.php
+++ b/extensions/wikia/SwiftSync/classes/Queue.class.php
@@ -30,9 +30,7 @@ class Queue {
 	const SYNC_TABLE = 'image_sync';
 	/* archive sync files table */
 	const SYNC_ARCH_TABLE = 'image_sync_done';
-	/* sync files db */
-	const SYNC_DB = 'swift_sync';
-	
+
 	/*
 	 * constructor
 	 */
@@ -139,17 +137,16 @@ class Queue {
 	}
 	
 	static public function getTable() {
-		return sprintf( "`%s`.`%s`", self::SYNC_DB, self::SYNC_TABLE );
+		return self::SYNC_TABLE;
 	}
 	
 	static public function getArchTable() {
-		return sprintf( "`%s`.`%s`", self::SYNC_DB, self::SYNC_ARCH_TABLE );
+		return self::SYNC_ARCH_TABLE;
 	}
 	
 	static public function getDB( $master = false ) {
-		global $wgSpecialsDB;
-		
-		return wfGetDB( ( empty( $master ) ) ? DB_SLAVE : DB_MASTER, array(), $wgSpecialsDB );
+		global $wgSwiftSyncDB;
+		return wfGetDB( ( empty( $master ) ) ? DB_SLAVE : DB_MASTER, array(), $wgSwiftSyncDB );
 	}
 
 	/* 

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -774,6 +774,7 @@ $wgDWStatsDB = 'statsdb';
 $wgStatsDBEnabled = true;
 $wgExternalWikiaStatsDB = 'wikiastats';
 $wgSpecialsDB = 'specials';
+$wgSwiftSyncDB = 'swift_sync';
 $wgSharedKeyPrefix = "wikicities"; // default value for shared key prefix, @see wfSharedMemcKey
 $wgWikiaMailerDB = 'wikia_mailer';
 $wgForceMasterDatabase = false;  // true only during wiki creation process

--- a/maintenance/wikia/fixes/fixswiftsyncdata.php
+++ b/maintenance/wikia/fixes/fixswiftsyncdata.php
@@ -46,12 +46,12 @@ function getCityIdByImagePath( $image_path ) {
 }
 
 function moveRecordToActiveQueue( $row, $dry ) {
-	global $wgSpecialsDB;
-	$dbw = wfGetDB( DB_MASTER, array(), $wgSpecialsDB );
+	global $wgSwiftSyncDB;
+	$dbw = wfGetDB( DB_MASTER, array(), $wgSwiftSyncDB );
 	# move record to image_sync table
 
 	if ( !$dry ) {
-		$dbw->insert( '`swift_sync`.`image_sync`', 
+		$dbw->insert( 'image_sync',
 			[ 
 				'id'			=> $row->id,
 				'city_id'		=> $row->city_id,
@@ -69,7 +69,7 @@ function moveRecordToActiveQueue( $row, $dry ) {
 			print " added \n"; 
 					
 			# remove record from image_sync_done table;
-			$dbw->delete( '`swift_sync`.`image_sync_done`', array( 'id' => $row->id ), 	__METHOD__ );
+			$dbw->delete( 'image_sync_done', array( 'id' => $row->id ), 	__METHOD__ );
 			return true;
 		} else {
 			print " cannot be added \n"; 
@@ -81,11 +81,11 @@ function moveRecordToActiveQueue( $row, $dry ) {
 }
 
 function fixAllSwiftSyncData( $dry, $limit ) {
-	global $wgSpecialsDB, $method;
+	global $wgSwiftSyncDB, $method;
 
-	$dbr = wfGetDB( DB_SLAVE, array(), $wgSpecialsDB );
+	$dbr = wfGetDB( DB_SLAVE, array(), $wgSwiftSyncDB );
 	$res = $dbr->select(
-		[ '`swift_sync`.`image_sync_done`' ],
+		[ 'image_sync_done' ],
 		[ 'id, city_id, img_action, img_src, img_dest, img_added, img_sync, img_error' ],
 		[
 			'city_id' => 0,


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-1287

As we're going to move specials database to a separate cluster we have to make sure that no other databases are accessed via $wgSpecialsDB global.

@wladekb / @michalroszka / @drozdo
