### PR TITLE
HG-765: Setup session for edits done within API

### DIFF
--- a/includes/api/ApiEditPage.php
+++ b/includes/api/ApiEditPage.php
@@ -336,6 +336,7 @@ class ApiEditPage extends ApiBase {
 					$r['newtimestamp'] = wfTimestamp( TS_ISO_8601,
 						$articleObj->getTimestamp() );
 					wfRunHooks( 'ApiEditPage::SuccessfulApiEdit', [ $newRevId ] );
+					wfSetupSession();
 				}
 				break;
 


### PR DESCRIPTION
This is important fo Mercury - in which edits are done within API, and having session_cookie is important to know, at cache layer, so skip caches and serve fresh content.
