### PR TITLE
DAT-2915 Pass only real Title object to viewRedirect() method

### DIFF
--- a/extensions/wikia/EditPageLayout/EditPageLayoutAjax.class.php
+++ b/extensions/wikia/EditPageLayout/EditPageLayoutAjax.class.php
@@ -74,7 +74,17 @@ class EditPageLayoutAjax {
 								$matches = array();
 								if ( preg_match_all( '/^#REDIRECT \[\[([^\]]+)\]\]/Um', $wikitext, $matches ) ) {
 									$redirectTitle = Title::newFromText( $matches[1][0] );
-									$html = $article->viewRedirect( array( $redirectTitle ) );
+									if ( $redirectTitle ) {
+										$html = $article->viewRedirect( array( $redirectTitle ) );
+									} else {
+										\Wikia\Logger\WikiaLogger::instance()->info(
+											'No redirect title',
+											[
+												'titleText' => $matches[1][0]
+											]
+										);
+										$html = '';
+									}
 								}
 							}
 


### PR DESCRIPTION
Otherwise, the Article code fails on trying to execute method on a null variable.
