### PR TITLE
CE-2020 Display Flags when previewing an article

### DIFF
--- a/extensions/wikia/EditPageLayout/EditPageService.class.php
+++ b/extensions/wikia/EditPageLayout/EditPageService.class.php
@@ -45,14 +45,14 @@ class EditPageService extends Service {
 		return Html::rawElement( 'div', $realBodyAttribs, $html );
 	}
 
-	public function getPreview($wikitext) {
+	public function getPreview( $wikitext ) {
 		// TODO: use wgParser here because some parser hooks initialize themselves on wgParser (should on provided parser instance)
 		global $wgParser, $wgUser, $wgRequest;
-		wfProfileIn(__METHOD__);
+		wfProfileIn( __METHOD__ );
 
 		$wg = $this->app->wg;
 
-		$parserOptions = new ParserOptions($wgUser);
+		$parserOptions = new ParserOptions( $wgUser );
 
 		$originalWikitext = $wikitext;
 
@@ -63,17 +63,22 @@ class EditPageService extends Service {
 		}
 
 		// call preSaveTransform so signatures, {{subst:foo}}, etc. will work
-		$wikitext = $wgParser->preSaveTransform($wikitext, $this->mTitle, $this->app->getGlobal('wgUser'), $parserOptions);
+		$wikitext = $wgParser->preSaveTransform( $wikitext, $this->mTitle, $this->app->getGlobal( 'wgUser' ), $parserOptions );
 
 		// parse wikitext using MW parser
-		$html = $wgParser->parse($wikitext, $this->mTitle, $parserOptions)->getText();
+		$parserOutput = $wgParser->parse( $wikitext, $this->mTitle, $parserOptions );
 
-		$html = EditPageService::wrapBodyText($this->mTitle, $wgRequest, $html);
+		/**
+		 * Allow extensions to modify the ParserOutput
+		 */
+		wfRunHooks( 'ArticlePreviewAfterParse', [ $parserOutput, $this->mTitle ] );
+
+		$html = $parserOutput->getText();
+		$html = EditPageService::wrapBodyText( $this->mTitle, $wgRequest, $html );
 
 		// we should also render categories and interlanguage links
-		$parserOutput = $wgParser->getOutput();
-		$catbox = $this->renderCategoryBoxFromParserOutput($parserOutput);
-		$interlanglinks = $this->renderInterlangBoxFromParserOutput($parserOutput);
+		$catbox = $this->renderCategoryBoxFromParserOutput( $parserOutput );
+		$interlanglinks = $this->renderInterlangBoxFromParserOutput( $parserOutput );
 
 		/**
 		 * bugid: 47995 -- Treat JavaScript and CSS as raw text wrapped in <pre> tags

--- a/extensions/wikia/Flags/Flags.hooks.php
+++ b/extensions/wikia/Flags/Flags.hooks.php
@@ -73,7 +73,19 @@ class Hooks {
 	 */
 	public static function onBeforeParserCacheSave( \ParserOutput $parserOutput, \Page $article ) {
 		$parserOutput = ( new \FlagsController )
-			->modifyParserOutputWithFlags( $parserOutput, $article );
+			->modifyParserOutputWithFlags( $parserOutput, $article->getID() );
+
+		return true;
+	}
+
+	/**
+	 * @param \ParserOutput $parserOutput
+	 * @param \Title $title
+	 * @return bool
+	 */
+	public static function onArticlePreviewAfterParse( \ParserOutput $parserOutput, \Title $title ) {
+		$parserOutput = ( new \FlagsController )
+			->modifyParserOutputWithFlags( $parserOutput, $title->getArticleID() );
 
 		return true;
 	}

--- a/extensions/wikia/Flags/Flags.setup.php
+++ b/extensions/wikia/Flags/Flags.setup.php
@@ -73,6 +73,7 @@ $wgAutoloadClasses['Flags\FlagsExtractTemplatesTask'] = __DIR__ . '/tasks/FlagsE
  * Hooks
  */
 $wgAutoloadClasses['Flags\Hooks'] = __DIR__ . '/Flags.hooks.php';
+$wgHooks['ArticlePreviewAfterParse'][] = 'Flags\Hooks::onArticlePreviewAfterParse';
 $wgHooks['BeforePageDisplay'][] = 'Flags\Hooks::onBeforePageDisplay';
 $wgHooks['BeforeParserCacheSave'][] = 'Flags\Hooks::onBeforeParserCacheSave';
 $wgHooks['LinksUpdateInsertTemplates'][] = 'Flags\Hooks::onLinksUpdateInsertTemplates';

--- a/extensions/wikia/Flags/controllers/FlagsController.class.php
+++ b/extensions/wikia/Flags/controllers/FlagsController.class.php
@@ -43,12 +43,12 @@ class FlagsController extends WikiaController {
 		$wgLang->getLangObj();
 	}
 
-	public function modifyParserOutputWithFlags( ParserOutput $parserOutput, Page $article ) {
+	public function modifyParserOutputWithFlags( ParserOutput $parserOutput, $pageId ) {
 		/**
 		 * First, get ParserOutput for flags for the article.
 		 * If it's null - return the original $parserOutput.
 		 */
-		$flagsParserOutput = $this->getFlagsParserOutputForPage( $article->getID() );
+		$flagsParserOutput = $this->getFlagsParserOutputForPage( $pageId );
 		if ( $flagsParserOutput === null ) {
 			return $parserOutput;
 		}


### PR DESCRIPTION
Hello @Wikia/community-engineering!

This pull request brings Flags back to an article preview. I added a new hook called `ArticlePreviewAfterParse` that allows extensions to modify the ParserOutput for preview. The rest works the same as for the regular view.

Please CR and have fun!
