### PR TITLE
CE-2064 Preserve whitelisted magic words for later processing

### DIFF
--- a/includes/MagicWord.php
+++ b/includes/MagicWord.php
@@ -197,7 +197,12 @@ class MagicWord {
 	);
 
 	static public $mObjects = array();
+
 	static public $mDoubleUnderscoreArray = null;
+
+	static public $mWhitelistedIDs = [
+		'flags',
+	];
 
 	/**#@-*/
 
@@ -266,7 +271,17 @@ class MagicWord {
 	 */
 	static function getDoubleUnderscoreArray() {
 		if ( is_null( self::$mDoubleUnderscoreArray ) ) {
-			self::$mDoubleUnderscoreArray = new MagicWordArray( self::$mDoubleUnderscoreIDs );
+			self::$mDoubleUnderscoreArray = new MagicWordArray(
+				/**
+				 * Wikia change begin
+				 *
+				 * Allow different behavior for some magic words from a white list
+				 */
+				array_diff( self::$mDoubleUnderscoreIDs, self::$mWhitelistedIDs )
+				/**
+				 * Wikia change end
+				 */
+			);
 		}
 		return self::$mDoubleUnderscoreArray;
 	}


### PR DESCRIPTION
@Wikia/community-engineering 

See [CE-2064](https://wikia-inc.atlassian.net/browse/CE-2064)

This PR prevents the `__FLAGS__` magic word (and ultimately - any whitelisted one as well) being removed from a content before it can be replaced by portable flags (or processed later).
