### PR TITLE
ADEN-1935 URL params for Mercury

### DIFF
--- a/extensions/wikia/AdEngine/AdEngine2ContextService.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2ContextService.class.php
@@ -73,7 +73,7 @@ class AdEngine2ContextService {
 					'exitstitialRedirectDelay' => $wg->OutboundScreenRedirectDelay,
 					'invisibleHighImpact' => $wg->AdDriverEnableInvisibleHighImpactSlot,
 				] ),
-				'forcedAdProvider' => $this->getForcedAdProvider(),
+				'forcedAdProvider' => $wg->AdDriverForcedProvider
 			];
 		} );
 	}
@@ -86,23 +86,5 @@ class AdEngine2ContextService {
 			}
 		}
 		return $output;
-	}
-
-	private function getForcedAdProvider() {
-		$wg = F::app()->wg;
-
-		$possibleForcedAdProviders = [
-			'AdDriverForceLiftiumAd' => 'liftium',
-			'AdDriverForceOpenXAd' => 'openx',
-			'AdDriverForceTurtleAd' => 'turtle'
-		];
-
-		foreach( $possibleForcedAdProviders as $enableFlag => $provider) {
-			if( $wg->$enableFlag === true ) {
-				return $provider;
-			}
-		}
-
-		return null;
 	}
 }

--- a/extensions/wikia/AdEngine/AdEngine2ContextService.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2ContextService.class.php
@@ -73,7 +73,6 @@ class AdEngine2ContextService {
 					'exitstitialRedirectDelay' => $wg->OutboundScreenRedirectDelay,
 					'invisibleHighImpact' => $wg->AdDriverEnableInvisibleHighImpactSlot,
 				] ),
-				// TODO: make it like forceadprovider=liftium
 				'forceProviders' => $this->filterOutEmptyItems( [
 					'liftium' => $wg->AdDriverForceLiftiumAd,
 					'openX' => $wg->AdDriverForceOpenXAd,

--- a/extensions/wikia/AdEngine/AdEngine2ContextService.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2ContextService.class.php
@@ -73,7 +73,7 @@ class AdEngine2ContextService {
 					'exitstitialRedirectDelay' => $wg->OutboundScreenRedirectDelay,
 					'invisibleHighImpact' => $wg->AdDriverEnableInvisibleHighImpactSlot,
 				] ),
-				'forcedAdProvider' => null,
+				'forcedAdProvider' => $this->getForcedAdProvider(),
 			];
 		} );
 	}
@@ -86,5 +86,23 @@ class AdEngine2ContextService {
 			}
 		}
 		return $output;
+	}
+
+	private function getForcedAdProvider() {
+		$wg = F::app()->wg;
+
+		$possibleForcedAdProviders = [
+			'AdDriverForceLiftiumAd' => 'liftium',
+			'AdDriverForceOpenXAd' => 'openx',
+			'AdDriverForceTurtleAd' => 'turtle'
+		];
+
+		foreach( $possibleForcedAdProviders as $enableFlag => $provider) {
+			if( $wg->$enableFlag === true ) {
+				return $provider;
+			}
+		}
+
+		return null;
 	}
 }

--- a/extensions/wikia/AdEngine/AdEngine2ContextService.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2ContextService.class.php
@@ -73,11 +73,7 @@ class AdEngine2ContextService {
 					'exitstitialRedirectDelay' => $wg->OutboundScreenRedirectDelay,
 					'invisibleHighImpact' => $wg->AdDriverEnableInvisibleHighImpactSlot,
 				] ),
-				'forceProviders' => $this->filterOutEmptyItems( [
-					'liftium' => $wg->AdDriverForceLiftiumAd,
-					'openX' => $wg->AdDriverForceOpenXAd,
-					'turtle' => $wg->AdDriverForceTurtleAd,
-				] ),
+				'forcedAdProvider' => null,
 			];
 		} );
 	}

--- a/extensions/wikia/AdEngine/AdEngine2ContextService.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2ContextService.class.php
@@ -73,7 +73,7 @@ class AdEngine2ContextService {
 					'exitstitialRedirectDelay' => $wg->OutboundScreenRedirectDelay,
 					'invisibleHighImpact' => $wg->AdDriverEnableInvisibleHighImpactSlot,
 				] ),
-				'forcedAdProvider' => $wg->AdDriverForcedProvider
+				'forcedProvider' => $wg->AdDriverForcedProvider
 			];
 		} );
 	}

--- a/extensions/wikia/AdEngine/AdEngine2Hooks.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2Hooks.class.php
@@ -29,7 +29,7 @@ class AdEngine2Hooks {
 		// TODO: we shouldn't have it in AdEngine - ticket for Platform: PLATFORM-1296
 		$wgNoExternals = $request->getBool( 'noexternals', $wgNoExternals );
 
-		if( $wgNoExternals ) {
+		if ( $wgNoExternals ) {
 			$wgEnableKruxTargeting = false;
 			$wgEnableKruxOnMobile = false;
 		}

--- a/extensions/wikia/AdEngine/AdEngine2Hooks.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2Hooks.class.php
@@ -20,11 +20,7 @@ class AdEngine2Hooks {
 	 * @author Sergey Naumov
 	 */
 	public static function onAfterInitialize( $title, $article, $output, $user, WebRequest $request, $wiki ) {
-		global
-			$wgAdDriverForceLiftiumAd,
-			$wgAdDriverForceOpenXAd,
-			$wgAdDriverForceTurtleAd,
-			$wgAdDriverUseSevenOneMedia,
+		global $wgAdDriverUseSevenOneMedia,
 			$wgEnableKruxOnMobile,
 			$wgEnableKruxTargeting,
 			$wgLiftiumOnLoad,
@@ -33,10 +29,6 @@ class AdEngine2Hooks {
 
 		$wgNoExternals = $request->getBool( 'noexternals', $wgNoExternals );
 		$wgLiftiumOnLoad = $request->getBool( 'liftiumonload', (bool)$wgLiftiumOnLoad );
-
-		$wgAdDriverForceLiftiumAd = $request->getBool( 'forceliftium', $wgAdDriverForceLiftiumAd );
-		$wgAdDriverForceOpenXAd = $request->getBool( 'forceopenx', $wgAdDriverForceOpenXAd );
-		$wgAdDriverForceTurtleAd = $request->getBool( 'forceturtle', $wgAdDriverForceTurtleAd );
 
 		$wgEnableKruxTargeting = !$wgNoExternals && $wgEnableKruxTargeting;
 		$wgEnableKruxOnMobile = $request->getBool( 'enablekrux', $wgEnableKruxOnMobile && !$wgNoExternals );

--- a/extensions/wikia/AdEngine/AdEngine2Hooks.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2Hooks.class.php
@@ -23,12 +23,10 @@ class AdEngine2Hooks {
 		global $wgAdDriverUseSevenOneMedia,
 			$wgEnableKruxOnMobile,
 			$wgEnableKruxTargeting,
-			$wgLiftiumOnLoad,
 			$wgNoExternals,
 			$wgUsePostScribe;
 
 		$wgNoExternals = $request->getBool( 'noexternals', $wgNoExternals );
-		$wgLiftiumOnLoad = $request->getBool( 'liftiumonload', (bool)$wgLiftiumOnLoad );
 
 		$wgEnableKruxTargeting = !$wgNoExternals && $wgEnableKruxTargeting;
 		$wgEnableKruxOnMobile = $request->getBool( 'enablekrux', $wgEnableKruxOnMobile && !$wgNoExternals );

--- a/extensions/wikia/AdEngine/AdEngine2Hooks.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2Hooks.class.php
@@ -26,10 +26,13 @@ class AdEngine2Hooks {
 			$wgNoExternals,
 			$wgUsePostScribe;
 
+		// TODO: we shouldn't have it in AdEngine - ticket for Platform: PLATFORM-1296
 		$wgNoExternals = $request->getBool( 'noexternals', $wgNoExternals );
 
-		$wgEnableKruxTargeting = !$wgNoExternals && $wgEnableKruxTargeting;
-		$wgEnableKruxOnMobile = $request->getBool( 'enablekrux', $wgEnableKruxOnMobile && !$wgNoExternals );
+		if( $wgNoExternals ) {
+			$wgEnableKruxTargeting = false;
+			$wgEnableKruxOnMobile = false;
+		}
 
 		// use PostScribe with 71Media - check scriptwriter.js:35
 		if ( $wgAdDriverUseSevenOneMedia ) {

--- a/extensions/wikia/AdEngine/js/AdContext.js
+++ b/extensions/wikia/AdEngine/js/AdContext.js
@@ -46,7 +46,7 @@ define('ext.wikia.adEngine.adContext', [
 		context.slots = context.slots || {};
 		context.targeting = context.targeting || {};
 		context.providers = context.providers || {};
-		context.forcedAdProvider = qs.getVal('forcead', null) || context.forcedAdProvider || null;
+		context.forcedProvider = qs.getVal('forcead', null) || context.forcedProvider || null;
 
 		// Don't show ads when Sony requests the page
 		if (doc && doc.referrer && doc.referrer.match(/info\.tvsideview\.sony\.net/)) {
@@ -70,7 +70,7 @@ define('ext.wikia.adEngine.adContext', [
 		}
 
 		// Turtle
-		if (context.forcedAdProvider === 'turtle') {
+		if (context.forcedProvider === 'turtle') {
 			context.providers.turtle = true;
 		}
 

--- a/extensions/wikia/AdEngine/js/AdContext.js
+++ b/extensions/wikia/AdEngine/js/AdContext.js
@@ -74,16 +74,6 @@ define('ext.wikia.adEngine.adContext', [
 			context.providers.turtle = true;
 		}
 
-		// OpenX
-		if (context.forcedAdProvider === 'openx') {
-			context.providers.openx = true;
-		}
-
-		// Liftium
-		if (context.forcedAdProvider === 'liftium') {
-			context.providers.liftium = true;
-		}
-
 		if (instantGlobals.wgAdDriverTurtleCountries &&
 				instantGlobals.wgAdDriverTurtleCountries.indexOf &&
 				instantGlobals.wgAdDriverTurtleCountries.indexOf(geo.getCountryCode()) > -1

--- a/extensions/wikia/AdEngine/js/AdContext.js
+++ b/extensions/wikia/AdEngine/js/AdContext.js
@@ -69,11 +69,6 @@ define('ext.wikia.adEngine.adContext', [
 				(context.targeting.pageType === 'article' || context.targeting.pageType === 'home');
 		}
 
-		// Turtle
-		if (context.forcedProvider === 'turtle') {
-			context.providers.turtle = true;
-		}
-
 		if (instantGlobals.wgAdDriverTurtleCountries &&
 				instantGlobals.wgAdDriverTurtleCountries.indexOf &&
 				instantGlobals.wgAdDriverTurtleCountries.indexOf(geo.getCountryCode()) > -1

--- a/extensions/wikia/AdEngine/js/AdContext.js
+++ b/extensions/wikia/AdEngine/js/AdContext.js
@@ -46,7 +46,7 @@ define('ext.wikia.adEngine.adContext', [
 		context.slots = context.slots || {};
 		context.targeting = context.targeting || {};
 		context.providers = context.providers || {};
-		context.forcedAdProvider = getForcedAdProvider(context);
+		context.forcedAdProvider = qs.getVal('forcead', null) || context.forcedAdProvider || null;
 
 		// Don't show ads when Sony requests the page
 		if (doc && doc.referrer && doc.referrer.match(/info\.tvsideview\.sony\.net/)) {
@@ -72,6 +72,16 @@ define('ext.wikia.adEngine.adContext', [
 		// Turtle
 		if (context.forcedAdProvider === 'turtle') {
 			context.providers.turtle = true;
+		}
+
+		// OpenX
+		if (context.forcedAdProvider === 'openx') {
+			context.providers.openx = true;
+		}
+
+		// Liftium
+		if (context.forcedAdProvider === 'liftium') {
+			context.providers.liftium = true;
 		}
 
 		if (instantGlobals.wgAdDriverTurtleCountries &&
@@ -104,24 +114,6 @@ define('ext.wikia.adEngine.adContext', [
 		for (i = 0, len = callbacks.length; i < len; i += 1) {
 			callbacks[i](context);
 		}
-	}
-
-	function getForcedAdProvider (context) {
-		var possibleForcedAdProviders = ['liftium', 'openx', 'turtle'],
-			possibleForcedAdProvidersNo = possibleForcedAdProviders.length - 1,
-			i, forced;
-
-		for (i = possibleForcedAdProvidersNo; i >= 0; i--) {
-			if (possibleForcedAdProviders.hasOwnProperty(i)) {
-				forced = !!qs.getVal('force' + possibleForcedAdProviders[i], false);
-
-				if (forced) {
-					return possibleForcedAdProviders[i];
-				}
-			}
-		}
-
-		return context.forcedAdProvider || null;
 	}
 
 	function addCallback(callback) {

--- a/extensions/wikia/AdEngine/js/config/desktop.js
+++ b/extensions/wikia/AdEngine/js/config/desktop.js
@@ -68,12 +68,12 @@ define('ext.wikia.adEngine.config.desktop', [
 		}
 
 		// Force OpenX
-		if (context.forceProviders.openX) {
+		if (context.forcedAdProvider === 'openx') {
 			log(['getProvider', slotName, 'OpenX (wgAdDriverForceOpenXAd)'], 'info', logGroup);
 			return [adProviderOpenX];
 		}
 
-		if (context.forceProviders.liftium) {
+		if (context.forcedAdProvider === 'liftium') {
 			return [adProviderLiftium];
 		}
 

--- a/extensions/wikia/AdEngine/js/config/desktop.js
+++ b/extensions/wikia/AdEngine/js/config/desktop.js
@@ -68,12 +68,12 @@ define('ext.wikia.adEngine.config.desktop', [
 		}
 
 		// Force OpenX
-		if (context.forcedAdProvider === 'openx') {
+		if (context.forcedProvider === 'openx') {
 			log(['getProvider', slotName, 'OpenX (wgAdDriverForceOpenXAd)'], 'info', logGroup);
 			return [adProviderOpenX];
 		}
 
-		if (context.forcedAdProvider === 'liftium') {
+		if (context.forcedProvider === 'liftium') {
 			return [adProviderLiftium];
 		}
 

--- a/extensions/wikia/AdEngine/js/config/desktop.js
+++ b/extensions/wikia/AdEngine/js/config/desktop.js
@@ -67,13 +67,21 @@ define('ext.wikia.adEngine.config.desktop', [
 			return [];
 		}
 
+		// Force Turtle
+		if (context.forcedProvider === 'turtle') {
+			log(['getProvider', slotName, 'Turtle (wgAdDriverForcedProvider)'], 'info', logGroup);
+			return [adProviderTurtle];
+		}
+
 		// Force OpenX
 		if (context.forcedProvider === 'openx') {
-			log(['getProvider', slotName, 'OpenX (wgAdDriverForceOpenXAd)'], 'info', logGroup);
+			log(['getProvider', slotName, 'OpenX (wgAdDriverForcedProvider)'], 'info', logGroup);
 			return [adProviderOpenX];
 		}
 
+		// Force Liftium
 		if (context.forcedProvider === 'liftium') {
+			log(['getProvider', slotName, 'Liftium (wgAdDriverForcedProvider)'], 'info', logGroup);
 			return [adProviderLiftium];
 		}
 

--- a/extensions/wikia/AdEngine/js/config/mobile.js
+++ b/extensions/wikia/AdEngine/js/config/mobile.js
@@ -30,7 +30,7 @@ define('ext.wikia.adEngine.config.mobile', [
 			return [];
 		}
 
-		if (context.forcedAdProvider === 'openx') {
+		if (context.forcedProvider === 'openx') {
 			return [openX];
 		}
 

--- a/extensions/wikia/AdEngine/js/config/mobile.js
+++ b/extensions/wikia/AdEngine/js/config/mobile.js
@@ -30,7 +30,7 @@ define('ext.wikia.adEngine.config.mobile', [
 			return [];
 		}
 
-		if (context.forceProviders.openX) {
+		if (context.forcedAdProvider === 'openx') {
 			return [openX];
 		}
 

--- a/extensions/wikia/AdEngine/js/spec/AdContext.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/AdContext.spec.js
@@ -3,30 +3,63 @@
 describe('AdContext', function () {
 	'use strict';
 
-	var geoMock = {
-		getCountryCode: function () { return 'XX'; }
+	function noop() {
+		return;
+	}
+
+	function getModule() {
+		return modules['ext.wikia.adEngine.adContext'](
+			mocks.win,
+			mocks.doc,
+			mocks.geo,
+			mocks.instantGlobals,
+			mocks.Querystring,
+			mocks.abTesting
+		);
+	}
+
+	var mocks = {
+		abTesting: {},
+		geo: {
+			getCountryCode: function () {
+				return 'XX';
+			}
+		},
+		instantGlobals: {},
+		win: {},
+		Querystring: function () {
+			return mocks.querystring;
+		},
+		querystring: {
+			getVal: noop
+		},
+		callback: noop
 	};
 
-	it('fills getContext() with context, targeting, providers and forceProviders even for empty (or missing) ads.context', function () {
-		var adContext;
+	it(
+		'fills getContext() with context, targeting, providers and forcedAdProvider ' +
+		'even for empty (or missing) ads.context',
+		function () {
+			var adContext = getModule();
 
-		adContext = modules['ext.wikia.adEngine.adContext']({}, {}, geoMock, {});
-		expect(adContext.getContext().opts).toEqual({});
-		expect(adContext.getContext().targeting).toEqual({});
-		expect(adContext.getContext().providers).toEqual({});
-		expect(adContext.getContext().forceProviders).toEqual({});
+			expect(adContext.getContext().opts).toEqual({});
+			expect(adContext.getContext().targeting).toEqual({});
+			expect(adContext.getContext().providers).toEqual({});
+			expect(adContext.getContext().forcedAdProvider).toEqual(null);
 
-		adContext = modules['ext.wikia.adEngine.adContext']({ads: {context: {}}}, {}, geoMock, {});
-		expect(adContext.getContext().opts).toEqual({});
-		expect(adContext.getContext().targeting).toEqual({});
-		expect(adContext.getContext().providers).toEqual({});
-		expect(adContext.getContext().forceProviders).toEqual({});
-	});
+			mocks.win = {ads: {context: {}}};
+			adContext = getModule();
+			expect(adContext.getContext().opts).toEqual({});
+			expect(adContext.getContext().targeting).toEqual({});
+			expect(adContext.getContext().providers).toEqual({});
+			expect(adContext.getContext().forcedAdProvider).toEqual(null);
+		}
+	);
 
 	it('copies ads.context into the returned context', function () {
 		var adContext;
 
-		adContext = modules['ext.wikia.adEngine.adContext']({
+		mocks.win = {
 			ads: {
 				context: {
 					opts: {
@@ -42,7 +75,9 @@ describe('AdContext', function () {
 					}
 				}
 			}
-		}, {}, geoMock, {});
+		};
+
+		adContext = getModule();
 		expect(adContext.getContext().opts.showAds).toBe(true);
 		expect(adContext.getContext().opts.xxx).toBe(true);
 		expect(adContext.getContext().targeting.yyy).toBe(true);
@@ -53,7 +88,7 @@ describe('AdContext', function () {
 	it('makes opts.showAds false for sony tvs', function () {
 		var adContext;
 
-		adContext = modules['ext.wikia.adEngine.adContext']({
+		mocks.win = {
 			ads: {
 				context: {
 					opts: {
@@ -61,120 +96,138 @@ describe('AdContext', function () {
 					}
 				}
 			}
-		}, {
+		};
+
+		mocks.doc = {
 			referrer: 'info.tvsideview.sony.net'
-		}, geoMock, {});
+		};
+
+		adContext = getModule();
 		expect(adContext.getContext().opts.showAds).toBeFalsy();
 	});
 
 	it('makes targeting.pageCategories filled with categories properly', function () {
 		var adContext;
 
-		adContext = modules['ext.wikia.adEngine.adContext']({
+		mocks.win = {
 			ads: {context: {}}
-		}, {}, geoMock, {});
-		expect(adContext.getContext().targeting.pageCategories && adContext.getContext().targeting.pageCategories.length).toBeFalsy();
+		};
+		adContext = getModule();
+		expect(
+			adContext.getContext().targeting.pageCategories &&
+			adContext.getContext().targeting.pageCategories.length
+		).toBeFalsy();
 
-		adContext = modules['ext.wikia.adEngine.adContext']({
+		mocks.win = {
 			ads: {context: {}},
 			wgCategories: ['Category1', 'Category2'],
-			Wikia: {article: {article: {categories: [{title: 'Category1', url: '/wiki/Category:Category1'}, {title: 'Category2', url: '/wiki/Category:Category2'}]}}}
-		}, {}, geoMock, {});
-		expect(adContext.getContext().targeting.pageCategories && adContext.getContext().targeting.pageCategories.length).toBeFalsy();
+			Wikia: {article: {article: {
+				categories: [
+					{title: 'Category1', url: '/wiki/Category:Category1'},
+					{title: 'Category2', url: '/wiki/Category:Category2'}
+				]
+			}}}
+		};
+		adContext = getModule();
+		expect(
+			adContext.getContext().targeting.pageCategories &&
+			adContext.getContext().targeting.pageCategories.length
+		).toBeFalsy();
 
-		adContext = modules['ext.wikia.adEngine.adContext']({
+		mocks.win = {
 			ads: {context: {targeting: {enablePageCategories: true}}}
-		}, {}, geoMock, {});
-		expect(adContext.getContext().targeting.pageCategories && adContext.getContext().targeting.pageCategories.length).toBeFalsy();
+		};
+		adContext = getModule();
+		expect(
+			adContext.getContext().targeting.pageCategories &&
+			adContext.getContext().targeting.pageCategories.length
+		).toBeFalsy();
 
-		adContext = modules['ext.wikia.adEngine.adContext']({
+		mocks.win = {
 			ads: {context: {targeting: {enablePageCategories: true}}},
 			wgCategories: ['Category1', 'Category2']
-		}, {}, geoMock, {});
+		};
+		adContext = getModule();
 		expect(adContext.getContext().targeting.pageCategories).toEqual(['Category1', 'Category2']);
 
-		adContext = modules['ext.wikia.adEngine.adContext']({
+		mocks.win = {
 			ads: {context: {targeting: {enablePageCategories: true}}},
-			Wikia: {article: {article: {categories: [{title: 'Category1', url: '/wiki/Category:Category1'}, {title: 'Category2', url: '/wiki/Category:Category2'}]}}}
-		}, {}, geoMock, {});
+			Wikia: {
+				article: {
+					article: {
+						categories: [
+							{title: 'Category1', url: '/wiki/Category:Category1'},
+							{title: 'Category2', url: '/wiki/Category:Category2'}
+						]
+					}
+				}
+			}
+		};
+		adContext = getModule();
 		expect(adContext.getContext().targeting.pageCategories).toEqual(['Category1', 'Category2']);
 	});
 
-	it('makes targeting.enableKruxTargeting false when disaster recovery instant global variable is set to true', function () {
-		var adContext,
-			getWindowMock = function() {
-				return {ads: {
-					context: {
-						targeting: {
-							enableKruxTargeting: true
-						}
-					}
-				}};
-			};
+	it(
+		'makes targeting.enableKruxTargeting false when disaster recovery instant global variable is set to true',
+		function () {
+			var adContext;
+			mocks.win = {ads: {context: {targeting: {enableKruxTargeting: true}}}};
 
-		adContext = modules['ext.wikia.adEngine.adContext'](getWindowMock(), {}, geoMock, {});
-		expect(adContext.getContext().targeting.enableKruxTargeting).toBeTruthy();
+			adContext = getModule();
+			expect(adContext.getContext().targeting.enableKruxTargeting).toBeTruthy();
 
-		adContext = modules['ext.wikia.adEngine.adContext'](getWindowMock(), {}, geoMock, {
-			wgSitewideDisableKrux: false
-		});
-		expect(adContext.getContext().targeting.enableKruxTargeting).toBeTruthy();
+			mocks.instantGlobals = {wgSitewideDisableKrux: false};
+			adContext = getModule();
+			expect(adContext.getContext().targeting.enableKruxTargeting).toBeTruthy();
 
-		adContext = modules['ext.wikia.adEngine.adContext'](getWindowMock(),  {}, geoMock, {
-			wgSitewideDisableKrux: true
-		});
-		expect(adContext.getContext().targeting.enableKruxTargeting).toBeFalsy();
+			mocks.instantGlobals = {wgSitewideDisableKrux: true};
+			adContext = getModule();
+			expect(adContext.getContext().targeting.enableKruxTargeting).toBeFalsy();
 
-		adContext = modules['ext.wikia.adEngine.adContext'](getWindowMock(), {}, geoMock, {
-			wgSitewideDisableKrux: 0
-		});
-		expect(adContext.getContext().targeting.enableKruxTargeting).toBeTruthy();
+			mocks.instantGlobals = {wgSitewideDisableKrux: 0};
+			adContext = getModule();
+			expect(adContext.getContext().targeting.enableKruxTargeting).toBeFalsy();
 
-		adContext = modules['ext.wikia.adEngine.adContext'](getWindowMock(),  {}, geoMock, {
-			wgSitewideDisableKrux: 1
-		});
-		expect(adContext.getContext().targeting.enableKruxTargeting).toBeFalsy();
-	});
+			mocks.instantGlobals = {wgSitewideDisableKrux: 1};
+			adContext = getModule();
+			expect(adContext.getContext().targeting.enableKruxTargeting).toBeFalsy();
+		}
+	);
 
 	it('makes providers.turtle true when country in instantGlobals.wgAdDriverTurtleCountries', function () {
 		var adContext;
 
-		adContext = modules['ext.wikia.adEngine.adContext']({}, {}, geoMock, {
-			wgAdDriverTurtleCountries: ['XX', 'ZZ']
-		});
+		mocks.win = {};
+		mocks.instantGlobals = {wgAdDriverTurtleCountries: ['XX', 'ZZ']};
+		adContext = getModule();
 		expect(adContext.getContext().providers.turtle).toBeTruthy();
 
-		adContext = modules['ext.wikia.adEngine.adContext']({},  {}, geoMock, {
-			wgAdDriverTurtleCountries: ['YY']
-		});
+		mocks.instantGlobals = {wgAdDriverTurtleCountries: ['YY']};
+		adContext = getModule();
 		expect(adContext.getContext().providers.turtle).toBeFalsy();
 	});
 
 	it('makes providers.openX true when country in instantGlobals.wgAdDriverOpenXCountries', function () {
 		var adContext;
 
-		adContext = modules['ext.wikia.adEngine.adContext']({}, {}, geoMock, {
-			wgAdDriverOpenXCountries: ['AA', 'XX', 'ZZ']
-		});
+		mocks.win = {};
+		mocks.instantGlobals = {wgAdDriverOpenXCountries: ['AA', 'XX', 'ZZ']};
+		adContext = getModule();
 		expect(adContext.getContext().providers.openX).toBeTruthy();
 
-		adContext = modules['ext.wikia.adEngine.adContext']({},  {}, geoMock, {
-			wgAdDriverOpenXCountries: ['YY']
-		});
+		mocks.instantGlobals = {wgAdDriverOpenXCountries: ['YY']};
+		adContext = getModule();
 		expect(adContext.getContext().providers.openX).toBeFalsy();
 	});
 
 	it('calls whoever registered with addCallback each time setContext is called', function () {
-		var adContext,
-			mocks = {
-				callback: function () {
-					return;
-				}
-			};
+		var adContext;
 
 		spyOn(mocks, 'callback');
 
-		adContext = modules['ext.wikia.adEngine.adContext']({}, {}, geoMock, {});
+		mocks.win = {};
+		mocks.instantGlobals = {};
+		adContext = getModule();
 		adContext.addCallback(mocks.callback);
 		adContext.setContext({});
 		expect(mocks.callback).toHaveBeenCalled();
@@ -183,14 +236,32 @@ describe('AdContext', function () {
 	it('enables high impact slot when country in instantGlobals.wgAdDriverHighImpactSlotCountries', function () {
 		var adContext;
 
-		adContext = modules['ext.wikia.adEngine.adContext']({}, {}, geoMock, {
-			wgAdDriverHighImpactSlotCountries: ['XX', 'ZZ']
-		});
+		mocks.win = {};
+		mocks.instantGlobals = {wgAdDriverHighImpactSlotCountries: ['HH', 'XX', 'ZZ']};
+		adContext = getModule();
 		expect(adContext.getContext().slots.invisibleHighImpact).toBeTruthy();
 
-		adContext = modules['ext.wikia.adEngine.adContext']({},  {}, geoMock, {
-			wgAdDriverHighImpactSlotCountries: ['YY']
-		});
+		mocks.instantGlobals = {wgAdDriverHighImpactSlotCountries: ['YY']};
+		adContext = getModule();
 		expect(adContext.getContext().slots.invisibleHighImpact).toBeFalsy();
+	});
+
+	it('forces provider if the query parameter set', function () {
+		var adContext;
+
+		spyOn(mocks.querystring, 'getVal').and.callFake(function (paramName) {
+			if (paramName === 'forceturtle') {
+				return true;
+			}
+		});
+
+		mocks.win = {};
+		mocks.instantGlobals = {};
+		adContext = getModule();
+		expect(mocks.querystring.getVal).toHaveBeenCalled();
+
+		adContext = adContext.getContext();
+		expect(adContext.forcedAdProvider).toEqual('turtle');
+		expect(adContext.providers.turtle).toBeTruthy();
 	});
 });

--- a/extensions/wikia/AdEngine/js/spec/AdContext.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/AdContext.spec.js
@@ -34,7 +34,12 @@ describe('AdContext', function () {
 				getVal: noop
 			},
 			callback: noop
-		};
+		},
+		queryParams = [
+			'liftium',
+			'openx',
+			'turtle'
+		];
 
 	it(
 		'fills getContext() with context, targeting, providers and forcedProvider ' +
@@ -246,19 +251,21 @@ describe('AdContext', function () {
 		expect(adContext.getContext().slots.invisibleHighImpact).toBeFalsy();
 	});
 
-	it('forces turtle provider if the query parameter set', function () {
+	it('query param is being passed to the adContext properly', function () {
 		spyOn(mocks.querystring, 'getVal');
-		var adContext;
 
-		mocks.win = {};
-		mocks.instantGlobals = {};
-		mocks.querystring.getVal.and.returnValue('turtle');
+		Object.keys(queryParams).forEach(function (k) {
+			var adContext;
 
-		adContext = getModule();
-		expect(mocks.querystring.getVal).toHaveBeenCalled();
+			mocks.win = {};
+			mocks.instantGlobals = {};
+			mocks.querystring.getVal.and.returnValue(queryParams[k]);
 
-		adContext = adContext.getContext();
-		expect(adContext.forcedProvider).toEqual('turtle');
-		expect(adContext.providers.turtle).toBeTruthy();
+			adContext = getModule();
+			expect(mocks.querystring.getVal).toHaveBeenCalled();
+
+			adContext = adContext.getContext();
+			expect(adContext.forcedProvider).toEqual(queryParams[k]);
+		});
 	});
 });

--- a/extensions/wikia/AdEngine/js/spec/AdContext.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/AdContext.spec.js
@@ -34,15 +34,10 @@ describe('AdContext', function () {
 				getVal: noop
 			},
 			callback: noop
-		},
-		forcedAdProviders = [
-		'openx',
-		'turtle',
-		'liftium'
-	];
+		};
 
 	it(
-		'fills getContext() with context, targeting, providers and forcedAdProvider ' +
+		'fills getContext() with context, targeting, providers and forcedProvider ' +
 		'even for empty (or missing) ads.context',
 		function () {
 			var adContext = getModule();
@@ -50,14 +45,14 @@ describe('AdContext', function () {
 			expect(adContext.getContext().opts).toEqual({});
 			expect(adContext.getContext().targeting).toEqual({});
 			expect(adContext.getContext().providers).toEqual({});
-			expect(adContext.getContext().forcedAdProvider).toEqual(null);
+			expect(adContext.getContext().forcedProvider).toEqual(null);
 
 			mocks.win = {ads: {context: {}}};
 			adContext = getModule();
 			expect(adContext.getContext().opts).toEqual({});
 			expect(adContext.getContext().targeting).toEqual({});
 			expect(adContext.getContext().providers).toEqual({});
-			expect(adContext.getContext().forcedAdProvider).toEqual(null);
+			expect(adContext.getContext().forcedProvider).toEqual(null);
 		}
 	);
 
@@ -251,22 +246,19 @@ describe('AdContext', function () {
 		expect(adContext.getContext().slots.invisibleHighImpact).toBeFalsy();
 	});
 
-	it('forces provider if the query parameter set', function () {
+	it('forces turtle provider if the query parameter set', function () {
 		spyOn(mocks.querystring, 'getVal');
+		var adContext;
 
-		Object.keys(forcedAdProviders).forEach(function (k) {
-			var adContext;
+		mocks.win = {};
+		mocks.instantGlobals = {};
+		mocks.querystring.getVal.and.returnValue('turtle');
 
-			mocks.win = {};
-			mocks.instantGlobals = {};
-			mocks.querystring.getVal.and.returnValue(forcedAdProviders[k]);
+		adContext = getModule();
+		expect(mocks.querystring.getVal).toHaveBeenCalled();
 
-			adContext = getModule();
-			expect(mocks.querystring.getVal).toHaveBeenCalled();
-
-			adContext = adContext.getContext();
-			expect(adContext.forcedAdProvider).toEqual(forcedAdProviders[k]);
-			expect(adContext.providers[forcedAdProviders[k]]).toBeTruthy();
-		});
+		adContext = adContext.getContext();
+		expect(adContext.forcedProvider).toEqual('turtle');
+		expect(adContext.providers.turtle).toBeTruthy();
 	});
 });

--- a/extensions/wikia/AdEngine/js/spec/AdLogicPageParams.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/AdLogicPageParams.spec.js
@@ -12,7 +12,7 @@ describe('AdLogicPageParams', function () {
 				return {
 					opts: {},
 					targeting: targeting || {},
-					forceProviders: {}
+					forcedAdProvider: null
 				};
 			},
 			addCallback: function () {

--- a/extensions/wikia/AdEngine/js/spec/AdLogicPageParams.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/AdLogicPageParams.spec.js
@@ -12,7 +12,7 @@ describe('AdLogicPageParams', function () {
 				return {
 					opts: {},
 					targeting: targeting || {},
-					forcedAdProvider: null
+					forcedProvider: null
 				};
 			},
 			addCallback: function () {

--- a/extensions/wikia/AdEngine/js/spec/config.desktop.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/config.desktop.spec.js
@@ -23,10 +23,21 @@ describe('ext.wikia.adEngine.config.desktop', function () {
 			},
 			getAdContextTargeting: returnEmpty,
 			getAdContextProviders: returnEmpty,
+			getAdContextForcedProvider: returnEmpty,
 			getInstantGlobals: returnEmpty,
 			getUserAgent: noop,
 			geo: {
 				getCountryCode: noop
+			},
+			adsContext: {
+				getContext: function () {
+					return {
+						opts: mocks.getAdContextOpts(),
+						targeting: mocks.getAdContextTargeting(),
+						providers: mocks.getAdContextProviders(),
+						forcedProvider: mocks.getAdContextForcedProvider()
+					};
+				}
 			},
 			log: noop,
 			providers: {
@@ -62,6 +73,11 @@ describe('ext.wikia.adEngine.config.desktop', function () {
 					name: 'turtle'
 				}
 			}
+		},
+		forcedProvidersMap = {
+			'liftium': mocks.providers.liftium.name,
+			'openx': mocks.providers.openX.name,
+			'turtle': mocks.providers.turtle.name
 		};
 
 	function getModule() {
@@ -70,16 +86,7 @@ describe('ext.wikia.adEngine.config.desktop', function () {
 			{navigator: {userAgent: mocks.getUserAgent()}},
 			mocks.getInstantGlobals(),
 			mocks.geo,
-			{
-				getContext: function () {
-					return {
-						opts: mocks.getAdContextOpts(),
-						targeting: mocks.getAdContextTargeting(),
-						providers: mocks.getAdContextProviders(),
-						forcedProvider: null
-					};
-				}
-			},
+			mocks.adsContext,
 			mocks.adDecoratorPageDimensions,
 			mocks.providers.evolve,
 			mocks.providers.directGpt,
@@ -219,5 +226,14 @@ describe('ext.wikia.adEngine.config.desktop', function () {
 	it('any country, OpenX on but cannot handle slot: Direct, Remnant, Liftium', function () {
 		spyOn(mocks, 'getAdContextProviders').and.returnValue({openX: true});
 		expect(getProviders('foo')).toEqual('direct,remnant,liftium');
+	});
+
+	it('returns correct providers depending on forcedProvider', function () {
+		spyOn(mocks, 'getAdContextForcedProvider');
+
+		Object.keys(forcedProvidersMap).forEach(function (k) {
+			mocks.getAdContextForcedProvider.and.returnValue(k);
+			expect(getProviders('foo')).toEqual(forcedProvidersMap[k]);
+		});
 	});
 });

--- a/extensions/wikia/AdEngine/js/spec/config.desktop.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/config.desktop.spec.js
@@ -76,7 +76,7 @@ describe('ext.wikia.adEngine.config.desktop', function () {
 						opts: mocks.getAdContextOpts(),
 						targeting: mocks.getAdContextTargeting(),
 						providers: mocks.getAdContextProviders(),
-						forcedAdProvider: null
+						forcedProvider: null
 					};
 				}
 			},

--- a/extensions/wikia/AdEngine/js/spec/config.desktop.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/config.desktop.spec.js
@@ -23,7 +23,6 @@ describe('ext.wikia.adEngine.config.desktop', function () {
 			},
 			getAdContextTargeting: returnEmpty,
 			getAdContextProviders: returnEmpty,
-			getAdContextForceProviders: returnEmpty,
 			getInstantGlobals: returnEmpty,
 			getUserAgent: noop,
 			geo: {
@@ -77,7 +76,7 @@ describe('ext.wikia.adEngine.config.desktop', function () {
 						opts: mocks.getAdContextOpts(),
 						targeting: mocks.getAdContextTargeting(),
 						providers: mocks.getAdContextProviders(),
-						forceProviders: mocks.getAdContextForceProviders()
+						forcedAdProvider: null
 					};
 				}
 			},

--- a/extensions/wikia/AdEngine/js/spec/config.mobile.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/config.mobile.spec.js
@@ -31,7 +31,7 @@ describe('ext.wikia.adEngine.config.mobile', function () {
 						invisibleHighImpact: enableInvisibleHighImpactSlot
 					},
 					providers: providers || {},
-					forcedAdProvider: null
+					forcedProvider: null
 				};
 			}
 		};

--- a/extensions/wikia/AdEngine/js/spec/config.mobile.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/config.mobile.spec.js
@@ -31,7 +31,7 @@ describe('ext.wikia.adEngine.config.mobile', function () {
 						invisibleHighImpact: enableInvisibleHighImpactSlot
 					},
 					providers: providers || {},
-					forceProviders: {}
+					forcedAdProvider: null
 				};
 			}
 		};

--- a/extensions/wikia/AdEngine/tests/AdEngine2ContextServiceTest.php
+++ b/extensions/wikia/AdEngine/tests/AdEngine2ContextServiceTest.php
@@ -46,24 +46,120 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 		return [
 			[ ],
 
-			[ 'article', ['wgAdDriverEnableAdsInMaps'], ['enableAdsInMaps' => true] ],
-			[ 'article', ['wgAdDriverEnableInvisibleHighImpactSlot'], [], [], [], [], ['invisibleHighImpact' => true] ],
-			[ 'article', ['wgAdDriverForceTurtleAd'], [], [], [], ['turtle' => true] ],
-			[ 'article', ['wgAdDriverTrackState'], ['trackSlotState' => true], [] ],
-			[ 'article', ['wgAdDriverUseMonetizationService', 'wgEnableMonetizationModuleExt'], [], [], ['monetizationService' => true] ],
-			[ 'article', ['wgAdDriverUseSevenOneMedia'], [], [], ['sevenOneMedia' => true] ],
-			[ 'article', ['wgAdDriverWikiIsTop1000'], [], ['wikiIsTop1000' => true] ],
-			[ 'article', ['wgEnableAdsInContent'], ['adsInContent' => true] ],
-			[ 'article', ['wgEnableKruxTargeting'], [], ['enableKruxTargeting' => true] ],
-			[ 'article', ['wgEnableOutboundScreenExt'], [], [], [], [], ['exitstitial' => true] ],
-			[ 'article', ['wgOutboundScreenRedirectDelay'], [], [], [], [], ['exitstitialRedirectDelay' => true] ],
-			[ 'article', ['wgEnableWikiaHomePageExt'], ['pageType' => 'corporate'], ['wikiIsCorporate' => true] ],
-			[ 'article', ['wgEnableWikiaHubsV3Ext'], ['pageType' => 'corporate'], ['pageIsHub' => true, 'wikiIsCorporate' => true] ],
-			[ 'article', ['wgWikiDirectedAtChildrenByFounder'], [], ['wikiDirectedAtChildren' => true] ],
-			[ 'article', ['wgWikiDirectedAtChildrenByStaff'], [], ['wikiDirectedAtChildren' => true] ],
+			[
+				'titleMockType' => 'article',
+				'flags' => ['wgAdDriverEnableAdsInMaps'],
+				'expectedOpts' => ['enableAdsInMaps' => true]
+			],
+			[
+				'titleMockType' => 'article',
+				'flags' => ['wgAdDriverEnableInvisibleHighImpactSlot'],
+				'expectedOpts' => [],
+				'expectedTargeting' => [],
+				'expectedProviders' => [],
+				'expectedForceProviders' => [],
+				'expectedSlots' => ['invisibleHighImpact' => true]
+			],
+			[
+				'titleMockType' => 'article',
+				'flags' => ['wgAdDriverForceTurtleAd'],
+				'expectedOpts' => [],
+				'expectedTargeting' => [],
+				'expectedProviders' => [],
+				'expectedForceProviders' => ['turtle' => true]
+			],
+			[
+				'titleMockType' => 'article',
+				'flags' => ['wgAdDriverTrackState'],
+				'expectedOpts' => ['trackSlotState' => true],
+				'expectedTargeting' => []
+			],
+			[
+				'titleMockType' => 'article',
+				'flags' => ['wgAdDriverUseMonetizationService', 'wgEnableMonetizationModuleExt'],
+				'expectedOpts' => [],
+				'expectedTargeting' => [],
+				'expectedProviders' => ['monetizationService' => true]
+			],
+			[
+				'titleMockType' => 'article',
+				'flags' => ['wgAdDriverUseSevenOneMedia'],
+				'expectedOpts' => [],
+				'expectedTargeting' => [],
+				'expectedProviders' => ['sevenOneMedia' => true]
+			],
+			[
+				'titleMockType' => 'article',
+				'flags' => ['wgAdDriverWikiIsTop1000'],
+				'expectedOpts' => [],
+				'expectedTargeting' => ['wikiIsTop1000' => true]
+			],
+			[
+				'titleMockType' => 'article',
+				'flags' => ['wgEnableAdsInContent'],
+				'expectedOpts' => ['adsInContent' => true]
+			],
+			[
+				'titleMockType' => 'article',
+				'flags' => ['wgEnableKruxTargeting'],
+				'expectedOpts' => [],
+				'expectedTargeting' => ['enableKruxTargeting' => true]
+			],
+			[
+				'titleMockType' => 'article',
+				'flags' => ['wgEnableOutboundScreenExt'],
+				'expectedOpts' => [],
+				'expectedTargeting' => [],
+				'expectedProviders' => [],
+				'expectedForceProviders' => [],
+				'expectedSlots' => ['exitstitial' => true]
+			],
+			[
+				'titleMockType' => 'article',
+				'flags' => ['wgOutboundScreenRedirectDelay'],
+				'expectedOpts' => [],
+				'expectedTargeting' => [],
+				'expectedProviders' => [],
+				'expectedForceProviders' => [],
+				'expectedSlots' => ['exitstitialRedirectDelay' => true]
+			],
+			[
+				'titleMockType' => 'article',
+				'flags' => ['wgEnableWikiaHomePageExt'],
+				'expectedOpts' => ['pageType' => 'corporate'],
+				'expectedTargeting' => ['wikiIsCorporate' => true]
+			],
+			[
+				'titleMockType' => 'article',
+				'flags' => ['wgEnableWikiaHubsV3Ext'],
+				'expectedOpts' => ['pageType' => 'corporate'],
+				'expectedTargeting' => ['pageIsHub' => true, 'wikiIsCorporate' => true]
+			],
+			[
+				'titleMockType' => 'article',
+				'flags' => ['wgWikiDirectedAtChildrenByFounder'],
+				'expectedOpts' => [],
+				'expectedTargeting' => ['wikiDirectedAtChildren' => true]
+			],
+			[
+				'titleMockType' => 'article',
+				'flags' => ['wgWikiDirectedAtChildrenByStaff'],
+				'expectedOpts' => [],
+				'expectedTargeting' => ['wikiDirectedAtChildren' => true]
+			],
 
-			[ 'mainpage', [], [], ['pageType' => 'home'] ],
-			[ 'search', [], ['pageType' => 'search'], ['pageType' => 'search', 'pageName' => 'Special:Search'] ],
+			[
+				'titleMockType' => 'mainpage',
+				'flags' => [],
+				'expectedOpts' => [],
+				'expectedTargeting' => ['pageType' => 'home']
+			],
+			[
+				'titleMockType' => 'search',
+				'flags' => [],
+				'expectedOpts' => ['pageType' => 'search'],
+				'expectedTargeting' => ['pageType' => 'search', 'pageName' => 'Special:Search']
+			],
 		];
 	}
 
@@ -163,7 +259,7 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 			'slots' => [
 			],
 			'forceProviders' => [
-			],
+			]
 		];
 
 		foreach ( $expectedOpts as $var => $val ) {

--- a/extensions/wikia/AdEngine/tests/AdEngine2ContextServiceTest.php
+++ b/extensions/wikia/AdEngine/tests/AdEngine2ContextServiceTest.php
@@ -203,7 +203,7 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 		$this->mockGlobalVariable( 'wgAdDriverSevenOneMediaOverrideSub2Site', $sevenOneMediaSub2Site );
 
 		if ( !is_null( $expectedForcedAdProvider ) ) {
-			$this->mockGlobalVariable( 'wgAdDriverForcedProvider', $expectedForcedAdProvider);
+			$this->mockGlobalVariable( 'wgAdDriverForcedProvider', $expectedForcedAdProvider );
 		}
 
 		// Flags

--- a/extensions/wikia/AdEngine/tests/AdEngine2ContextServiceTest.php
+++ b/extensions/wikia/AdEngine/tests/AdEngine2ContextServiceTest.php
@@ -202,6 +202,10 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 		$this->mockGlobalVariable( 'wgDBname', $dbName );
 		$this->mockGlobalVariable( 'wgAdDriverSevenOneMediaOverrideSub2Site', $sevenOneMediaSub2Site );
 
+		if ( !is_null( $expectedForcedAdProvider ) ) {
+			$this->mockGlobalVariable( 'wgAdDriverForcedProvider', $expectedForcedAdProvider);
+		}
+
 		// Flags
 		$this->mockGlobalVariable( 'wgAdDriverEnableAdsInMaps', false );
 		$this->mockGlobalVariable( 'wgAdDriverEnableInvisibleHighImpactSlot', false );

--- a/extensions/wikia/AdEngine/tests/AdEngine2ContextServiceTest.php
+++ b/extensions/wikia/AdEngine/tests/AdEngine2ContextServiceTest.php
@@ -57,7 +57,7 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 				'expectedOpts' => [],
 				'expectedTargeting' => [],
 				'expectedProviders' => [],
-				'expectedForceProviders' => [],
+				'expectedForceProviders' => null,
 				'expectedSlots' => ['invisibleHighImpact' => true]
 			],
 			[
@@ -66,7 +66,7 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 				'expectedOpts' => [],
 				'expectedTargeting' => [],
 				'expectedProviders' => [],
-				'expectedForceProviders' => ['turtle' => true]
+				'expectedForceProviders' => 'turtle'
 			],
 			[
 				'titleMockType' => 'article',
@@ -111,7 +111,7 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 				'expectedOpts' => [],
 				'expectedTargeting' => [],
 				'expectedProviders' => [],
-				'expectedForceProviders' => [],
+				'expectedForceProviders' => null,
 				'expectedSlots' => ['exitstitial' => true]
 			],
 			[
@@ -120,7 +120,7 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 				'expectedOpts' => [],
 				'expectedTargeting' => [],
 				'expectedProviders' => [],
-				'expectedForceProviders' => [],
+				'expectedForceProviders' => null,
 				'expectedSlots' => ['exitstitialRedirectDelay' => true]
 			],
 			[
@@ -175,7 +175,7 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 		$expectedOpts = [],
 		$expectedTargeting = [],
 		$expectedProviders = [],
-		$expectedForceProviders = [],
+		$expectedForcedAdProvider = null,
 		$expectedSlots = []
 	) {
 		$langCode = 'xx';
@@ -258,8 +258,7 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 			],
 			'slots' => [
 			],
-			'forceProviders' => [
-			]
+			'forcedAdProvider' => $expectedForcedAdProvider
 		];
 
 		foreach ( $expectedOpts as $var => $val ) {
@@ -272,10 +271,6 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 
 		foreach ( $expectedProviders as $var => $val ) {
 			$expected['providers'][$var] = $val;
-		}
-
-		foreach ( $expectedForceProviders as $var => $val ) {
-			$expected['forceProviders'][$var] = $val;
 		}
 
 		foreach ( $expectedSlots as $var => $val ) {

--- a/extensions/wikia/AdEngine/tests/AdEngine2ContextServiceTest.php
+++ b/extensions/wikia/AdEngine/tests/AdEngine2ContextServiceTest.php
@@ -66,7 +66,7 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 				'expectedOpts' => [],
 				'expectedTargeting' => [],
 				'expectedProviders' => [],
-				'expectedForceProviders' => 'turtle'
+				'expectedForcedProvider' => 'turtle'
 			],
 			[
 				'titleMockType' => 'article',
@@ -175,7 +175,7 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 		$expectedOpts = [],
 		$expectedTargeting = [],
 		$expectedProviders = [],
-		$expectedForcedAdProvider = null,
+		$expectedForcedProvider = null,
 		$expectedSlots = []
 	) {
 		$langCode = 'xx';
@@ -202,14 +202,13 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 		$this->mockGlobalVariable( 'wgDBname', $dbName );
 		$this->mockGlobalVariable( 'wgAdDriverSevenOneMediaOverrideSub2Site', $sevenOneMediaSub2Site );
 
-		if ( !is_null( $expectedForcedAdProvider ) ) {
-			$this->mockGlobalVariable( 'wgAdDriverForcedProvider', $expectedForcedAdProvider );
+		if ( !is_null( $expectedForcedProvider ) ) {
+			$this->mockGlobalVariable( 'wgAdDriverForcedProvider', $expectedForcedProvider );
 		}
 
 		// Flags
 		$this->mockGlobalVariable( 'wgAdDriverEnableAdsInMaps', false );
 		$this->mockGlobalVariable( 'wgAdDriverEnableInvisibleHighImpactSlot', false );
-		$this->mockGlobalVariable( 'wgAdDriverForceTurtleAd', false );
 		$this->mockGlobalVariable( 'wgAdDriverTrackState', false );
 		$this->mockGlobalVariable( 'wgAdDriverUseMonetizationService', false );
 		$this->mockGlobalVariable( 'wgAdDriverUseSevenOneMedia', false );
@@ -262,7 +261,7 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 			],
 			'slots' => [
 			],
-			'forcedAdProvider' => $expectedForcedAdProvider
+			'forcedProvider' => $expectedForcedProvider
 		];
 
 		foreach ( $expectedOpts as $var => $val ) {

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1419,16 +1419,11 @@ $wgAdDriverSevenOneMediaOverrideSub2Site = null;
 $wgAdDriverTrackState = false;
 
 /**
- * @name $wgAdDriverForceLiftiumAd
- * Forces to use Liftium for all slots managed by this provider and disables other providers
+ * @name $wgAdDriverForcedProvider
+ * @example 'liftium', 'turtle' or 'openx'
+ * Forces to use passed provider for all slots managed by this provider and disables other providers.
  */
-$wgAdDriverForceLiftiumAd = false;
-
-/**
- * @name $wgAdDriverForceOpenXAd
- * Forces to use OpenX for all slots managed by this provider and disables other providers
- */
-$wgAdDriverForceOpenXAd = false;
+$wgAdDriverForcedProvider = null;
 
 /**
  * @name $wgAdDriverEnableAdsInMaps


### PR DESCRIPTION
As `AdContext` is more widely used (Oasis, Mercury) we decided to move there some URL params logic. Especially, we were interested in `force[provider]=1` logic, so we can test specific providers on Mercury.

The main changes:
- `force[provider]=1` changed to `forcead=[provider]` and moved to `AdContext`,
- cleanup in `AdEngine2Hooks`,
- cleanup in unit tests.
