### PR TITLE
SpecialMultipleLookup_helper: fix a fatal

### DIFF
--- a/extensions/wikia/SpecialMultipleLookup/SpecialMultipleLookup_helper.php
+++ b/extensions/wikia/SpecialMultipleLookup/SpecialMultipleLookup_helper.php
@@ -94,7 +94,7 @@ class MultipleLookupCore {
 	}
 
 	function checkUserActivity( $order = null ) {
-		global $wgMemc, $wgSpecialsDB;
+		global $wgMemc, $wgSpecialsDB, $wgLang;
 
 		$userActivity = array();
 


### PR DESCRIPTION
`PHP Fatal error:  Call to a member function timeanddate() on null in /extensions/wikia/SpecialMultipleLookup/SpecialMultipleLookup_helper.php on line 125`

@michalroszka 
