### PR TITLE
Retarget to dev: Create a MySQL persistence implementation to support user preference CRUD in MW

### DIFF
--- a/lib/Wikia/src/Persistence/User/PreferencePersistenceMySQL.php
+++ b/lib/Wikia/src/Persistence/User/PreferencePersistenceMySQL.php
@@ -3,6 +3,7 @@
 namespace Wikia\Persistence\User;
 
 use Wikia\Service\User\PreferencePersistence;
+use Wikia\Domain\User\Preference;
 
 class PreferencePersistenceMySQL implements PreferencePersistence {
 
@@ -19,7 +20,37 @@ class PreferencePersistenceMySQL implements PreferencePersistence {
 	}
 
 	public function get( $userId ) {
+		$userId = intval($userId);
+		$result = $this->slave->select(
+			'user_properties',
+			'*',
+			array( 'up_user' => $userId ),
+			__METHOD__
+		);
 
+		$preferences = [];
+		if (is_array($result) && !empty($result)) {
+			$preferences = $this->userPropertiesResultToPreferenceArray($result);
+		}
+
+		return $preferences;
+	}
+
+	/**
+	 * Convert a user_properties row into a Preference object.
+	 *
+	 * @param array of ['up_user', 'up_property', 'up_value'] tuples
+	 * @return Preference[]
+	 */
+	public function userPropertiesResultToPreferenceArray(array $result) {
+		$preferences = [];
+		foreach( $result as $index => $row ) {
+			if (isset($row["up_property"]) && isset($row["up_value"])) {
+				$preferences[] = new Preference($row["up_property"], $row["up_value"]);
+			}
+		}
+
+		return $preferences;
 	}
 
 }

--- a/lib/Wikia/src/Persistence/User/PreferencePersistenceMySQL.php
+++ b/lib/Wikia/src/Persistence/User/PreferencePersistenceMySQL.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Wikia\Persistence\User;
+
+use Wikia\Service\User\PreferencePersistence;
+
+class PreferencePersistenceMySQL implements PreferencePersistence {
+
+	private $master;
+	private $slave;
+
+	function __construct(\DatabaseMysqli $master, \DatabaseMysqli $slave) {
+		$this->master = $master;
+		$this->slave = $slave;
+	}
+
+	public function save( $userId, array $preferences ) {
+
+	}
+
+	public function get( $userId ) {
+
+	}
+
+}

--- a/lib/Wikia/src/Persistence/User/PreferencePersistenceMySQL.php
+++ b/lib/Wikia/src/Persistence/User/PreferencePersistenceMySQL.php
@@ -13,29 +13,29 @@ class PreferencePersistenceMySQL implements PreferencePersistence {
 	private $master;
 	private $slave;
 
-	function __construct(\DatabaseMysqli $master, \DatabaseMysqli $slave) {
+	function __construct( \DatabaseMysqli $master, \DatabaseMysqli $slave ) {
 		$this->master = $master;
 		$this->slave = $slave;
 	}
 
 	public function save( $userId, array $preferences ) {
-		$tuples = $this->createTuplesFromPreferences($userId, $preferences);
-		return $this->master->upsert(self::USER_PREFERENCE_TABLE, $tuples, [], self::$UPSERT_SET_BLOCK);
+		$tuples = $this->createTuplesFromPreferences( $userId, $preferences );
+		return $this->master->upsert( self::USER_PREFERENCE_TABLE, $tuples, [], self::$UPSERT_SET_BLOCK );
 	}
 
-	public static function createTuplesFromPreferences($userId, array $preferences) {
-		$userId = intval($userId);
-		return array_map(function(Preference $e) use ($userId) {
+	public static function createTuplesFromPreferences( $userId, array $preferences ) {
+		$userId = intval( $userId );
+		return array_map( function( Preference $e ) use ( $userId ) {
 			return [
 				'up_user' =>  $userId,
 				'up_property' => $e->getName(),
 				'up_value' => $e->getValue()
 				];
-		}, $preferences);
+		} , $preferences );
 	}
 
 	public function get( $userId ) {
-		$userId = intval($userId);
+		$userId = intval( $userId );
 		$result = $this->slave->select(
 			self::USER_PREFERENCE_TABLE,
 			'*',
@@ -44,8 +44,8 @@ class PreferencePersistenceMySQL implements PreferencePersistence {
 		);
 
 		$preferences = [];
-		if (is_array($result) && !empty($result)) {
-			$preferences = $this->userPropertiesResultToPreferenceArray($result);
+		if ( is_array( $result ) && !empty( $result ) ) {
+			$preferences = $this->userPropertiesResultToPreferenceArray( $result );
 		}
 
 		return $preferences;
@@ -57,11 +57,11 @@ class PreferencePersistenceMySQL implements PreferencePersistence {
 	 * @param array of ['up_user', 'up_property', 'up_value'] tuples
 	 * @return Preference[]
 	 */
-	public function userPropertiesResultToPreferenceArray(array $result) {
+	public function userPropertiesResultToPreferenceArray( array $result ) {
 		$preferences = [];
-		foreach( $result as $index => $row ) {
-			if (isset($row["up_property"]) && isset($row["up_value"])) {
-				$preferences[] = new Preference($row["up_property"], $row["up_value"]);
+		foreach ( $result as $index => $row ) {
+			if ( isset( $row["up_property"] ) && isset( $row["up_value"] ) ) {
+				$preferences[] = new Preference( $row["up_property"], $row["up_value"] );
 			}
 		}
 

--- a/lib/Wikia/src/Persistence/User/PreferenceStorageMySQL.php
+++ b/lib/Wikia/src/Persistence/User/PreferenceStorageMySQL.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace Wikia\Persistence\User;
-
-use Wikia\Service\User\PreferencePersistence;
-
-class PreferenceStorageMySQL implements PreferencePersistence {
-
-}

--- a/lib/Wikia/src/Service/User/PreferencePersistence.php
+++ b/lib/Wikia/src/Service/User/PreferencePersistence.php
@@ -8,10 +8,10 @@ interface PreferencePersistence {
 	 * Save the users preferences.
 	 *
 	 * @param int $userId
-	 * @param array [\Wikia\Domain\User\Preference, ... ]
+	 * @param array [\Wikia\Domain\User\PreferenceValue, ... ]
 	 * @return true success, false or exception otherwise
 	 */
-	public function save( int $userId, array $preferences );
+	public function save( $userId, array $preferences );
 
 	/**
 	 * Get the users preferences.
@@ -19,6 +19,6 @@ interface PreferencePersistence {
 	 * @param int $userId
 	 * @return array of maps of the form {"name": <name>, "value", <value>}
 	 */
-	public function get( int $userId );
+	public function get( $userId );
 
 }

--- a/lib/Wikia/tests/Persistence/User/PreferencePersistenceMySQLTest.php
+++ b/lib/Wikia/tests/Persistence/User/PreferencePersistenceMySQLTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Wikia\Persistence\User;
+use Wikia\Domain\User\PreferenceValue;
+use Wikia\Persistence\User\PreferencePersistenceMySQL;
+
+class PreferencePersistenceMySQLTest extends \PHPUnit_Framework_TestCase {
+
+	protected $userId = 1;
+	protected $testPreference;
+	protected $mysqliMockSlave;
+	protected $mysqliMockMaster;
+
+	protected function setUp() {
+		$this->testPreference = new PreferenceValue( "pref-name", "pref-value" );
+		$this->mysqliMockSlave = $this->getMockBuilder( '\DatabaseMysqli' )
+			->setMethods( ['select' ] )
+			->disableOriginalConstructor()
+			->disableAutoload()
+			->getMock();
+
+		$this->mysqliMockMaster = $this->getMockBuilder( '\DatabaseMysqli' )
+			->setMethods( ['update', 'delete' ] )
+			->disableOriginalConstructor()
+			->disableAutoload()
+			->getMock();
+	}
+
+	public function testGetSuccess() {
+			//$res = $dbr->select(
+				//'user_properties',
+				//'*',
+				//array( 'up_user' => $this->getId() ),
+				//__METHOD__
+			//);
+		$persistence = new PreferencePersistenceMySQL($this->mysqliMockMaster, $this->mysqliMockSlave);
+		$result = $persistence->get( $this->userId );
+
+		$this->assertTrue( is_array($result), "expecting an array" );
+		$this->assertTrue( !empty($result), "expecting an array" );
+		$this->assertEquals( $result[0]->getName(), $this->testPreference->getName(), "expecting the test preference name" );
+		$this->assertEquals( $result[0]->getValue(), $this->testPreference->getValue(), "expecting the test preference value" );
+	}
+}

--- a/lib/Wikia/tests/Persistence/User/PreferencePersistenceMySQLTest.php
+++ b/lib/Wikia/tests/Persistence/User/PreferencePersistenceMySQLTest.php
@@ -27,71 +27,71 @@ class PreferencePersistenceMySQLTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testGetSuccess() {
-		$this->mysqliMockSlave->expects($this->once())
-			->method('select')
-			->with('user_properties', '*', array( 'up_user' => $this->userId ), $this->anything())
-			->willReturn([
+		$this->mysqliMockSlave->expects( $this->once() )
+			->method( 'select' )
+			->with( 'user_properties', '*', array( 'up_user' => $this->userId ), $this->anything() )
+			->willReturn( [
 			 [ 'up_user' => $this->userId, 'up_property' => $this->testPreference->getName(), 'up_value' => $this->testPreference->getValue() ],
 			 [ 'up_user' => $this->userId, 'up_property' => 'autopatrol', 'up_value' => '0' ],
 			 [ 'up_user' => $this->userId, 'up_property' => 'date', 'up_value' => '1' ],
-			]);
+			] );
 
-		$persistence = new PreferencePersistenceMySQL($this->mysqliMockMaster, $this->mysqliMockSlave);
+		$persistence = new PreferencePersistenceMySQL( $this->mysqliMockMaster, $this->mysqliMockSlave );
 		$preferences = $persistence->get( $this->userId );
 
-		$this->assertTrue( is_array($preferences), "expecting an array" );
-		$this->assertTrue( !empty($preferences), "expecting a non-empty array" );
+		$this->assertTrue( is_array( $preferences ), "expecting an array" );
+		$this->assertTrue( !empty( $preferences ), "expecting a non-empty array" );
 		$this->assertEquals( $preferences[0]->getName(), $this->testPreference->getName(), "expecting the test preference name" );
 		$this->assertEquals( $preferences[0]->getValue(), $this->testPreference->getValue(), "expecting the test preference value" );
 	}
 
 	public function testGetEmpty() {
-		$this->mysqliMockSlave->expects($this->once())
-			->method('select')
-			->with('user_properties', '*', array( 'up_user' => $this->userId ), $this->anything())
-			->willReturn([]);
+		$this->mysqliMockSlave->expects( $this->once() )
+			->method( 'select' )
+			->with( 'user_properties', '*', array( 'up_user' => $this->userId ), $this->anything() )
+			->willReturn( [] );
 
-		$persistence = new PreferencePersistenceMySQL($this->mysqliMockMaster, $this->mysqliMockSlave);
+		$persistence = new PreferencePersistenceMySQL( $this->mysqliMockMaster, $this->mysqliMockSlave );
 		$preferences = $persistence->get( $this->userId );
 
-		$this->assertTrue( is_array($preferences), "expecting an array" );
-		$this->assertTrue( empty($preferences), "expecting an empty array" );
+		$this->assertTrue( is_array( $preferences ), "expecting an array" );
+		$this->assertTrue( empty( $preferences ), "expecting an empty array" );
 	}
 
 	public function testSave() {
 		$preferences = [$this->testPreference];
-		$this->mysqliMockMaster->expects($this->once())
-			->method('upsert')
+		$this->mysqliMockMaster->expects( $this->once() )
+			->method( 'upsert' )
 			->with(
 				PreferencePersistenceMySQL::USER_PREFERENCE_TABLE,
-				PreferencePersistenceMySQL::createTuplesFromPreferences($this->userId, $preferences),
+				PreferencePersistenceMySQL::createTuplesFromPreferences( $this->userId, $preferences ),
 				[],
-			 	PreferencePersistenceMySQL::$UPSERT_SET_BLOCK)
-			->willReturn(true);
+			 	PreferencePersistenceMySQL::$UPSERT_SET_BLOCK )
+			->willReturn( true );
 
-		$persistence = new PreferencePersistenceMySQL($this->mysqliMockMaster, $this->mysqliMockSlave);
+		$persistence = new PreferencePersistenceMySQL( $this->mysqliMockMaster, $this->mysqliMockSlave );
 		$ret = $persistence->save( $this->userId, [$this->testPreference] );
 
 		$this->assertTrue( $ret, "expected true" );
 	}
 
 	public function testCreateTuples() {
-		$input = [ new Preference('name-a', 'value-a'), new Preference('name-b', 'value-b') ];
+		$input = [ new Preference( 'name-a', 'value-a' ), new Preference( 'name-b', 'value-b' ) ];
 
-		$output = PreferencePersistenceMySQL::createTuplesFromPreferences($this->userId, $input);
+		$output = PreferencePersistenceMySQL::createTuplesFromPreferences( $this->userId, $input );
 
-		$this->assertTrue( is_array($output), "failed to create tuple array" );
+		$this->assertTrue( is_array( $output ), "failed to create tuple array" );
 		$this->assertEquals( 1, $output[0]['up_user'], "user failed to match" );
 		$this->assertEquals( 'name-a', $output[0]['up_property'], "name failed to match" );
 		$this->assertEquals( 'value-a', $output[0]['up_value'], "value failed to match" );
 	}
 
 	public function testCreateTuplesEmpty() {
-		$persistence = new PreferencePersistenceMySQL($this->mysqliMockMaster, $this->mysqliMockSlave);
+		$persistence = new PreferencePersistenceMySQL( $this->mysqliMockMaster, $this->mysqliMockSlave );
 		$input = [ ];
-		$output = PreferencePersistenceMySQL::createTuplesFromPreferences($this->userId, $input);
+		$output = PreferencePersistenceMySQL::createTuplesFromPreferences( $this->userId, $input );
 
-		$this->assertTrue( is_array($output), "unexpected output" );
+		$this->assertTrue( is_array( $output ), "unexpected output" );
 		$this->assertEquals( [], $output, "result failed to match" );
 	}
 

--- a/lib/Wikia/tests/Persistence/User/PreferencePersistenceMySQLTest.php
+++ b/lib/Wikia/tests/Persistence/User/PreferencePersistenceMySQLTest.php
@@ -27,12 +27,6 @@ class PreferencePersistenceMySQLTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testGetSuccess() {
-			//$res = $dbr->select(
-				//'user_properties',
-				//'*',
-				//array( 'up_user' => $this->getId() ),
-				//__METHOD__
-			//);
 		$this->mysqliMockSlave->expects($this->once())
 			->method('select')
 			->with('user_properties', '*', array( 'up_user' => $this->userId ), $this->anything())
@@ -49,5 +43,18 @@ class PreferencePersistenceMySQLTest extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue( !empty($preferences), "expecting a non-empty array" );
 		$this->assertEquals( $preferences[0]->getName(), $this->testPreference->getName(), "expecting the test preference name" );
 		$this->assertEquals( $preferences[0]->getValue(), $this->testPreference->getValue(), "expecting the test preference value" );
+	}
+
+	public function testGetEmpty() {
+		$this->mysqliMockSlave->expects($this->once())
+			->method('select')
+			->with('user_properties', '*', array( 'up_user' => $this->userId ), $this->anything())
+			->willReturn([]);
+
+		$persistence = new PreferencePersistenceMySQL($this->mysqliMockMaster, $this->mysqliMockSlave);
+		$preferences = $persistence->get( $this->userId );
+
+		$this->assertTrue( is_array($preferences), "expecting an array" );
+		$this->assertTrue( empty($preferences), "expecting an empty array" );
 	}
 }

--- a/lib/Wikia/tests/Service/User/PreferenceTest.php
+++ b/lib/Wikia/tests/Service/User/PreferenceTest.php
@@ -7,11 +7,11 @@ class PreferenceTest extends \PHPUnit_Framework_TestCase {
 
 	protected $userId = 1;
 	protected $testPreference;
-	protected $gatewayMock;
+	protected $persistenceMock;
 
 	protected function setUp() {
 		$this->testPreference = new PreferenceValue( "pref-name", "pref-value" );
-		$this->gatewayMock = $this->getMockBuilder( '\Wikia\Service\User\PreferencePersistence' )
+		$this->persistenceMock = $this->getMockBuilder( '\Wikia\Service\User\PreferencePersistence' )
 			->setMethods( ['save', 'get'] )
 			->disableOriginalConstructor()
 			->disableAutoload()
@@ -19,24 +19,24 @@ class PreferenceTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testSetPreferenceSuccess() {
-		$this->gatewayMock->expects( $this->once() )
+		$this->persistenceMock->expects( $this->once() )
 			->method( 'save' )
 			->with( $this->userId, [$this->testPreference] )
 			->willReturn( true );
 
-		$service = new Preference( $this->gatewayMock );
+		$service = new Preference( $this->persistenceMock );
 		$ret = $service->setPreferences( $this->userId, [ $this->testPreference ] );
 
 		$this->assertTrue( $ret, "the preference was not set" );
 	}
 
 	public function testSetWithEmptyPreferences() {
-		$this->gatewayMock->expects( $this->exactly( 0 ) )
+		$this->persistenceMock->expects( $this->exactly( 0 ) )
 			->method( 'save' )
 			->with( $this->userId, [] )
 			->willReturn( null );
 
-		$service = new Preference( $this->gatewayMock );
+		$service = new Preference( $this->persistenceMock );
 		$ret = $service->setPreferences( $this->userId, [ ] );
 
 		$this->assertFalse( $ret, "expected false when providing an empty preference set" );
@@ -47,12 +47,12 @@ class PreferenceTest extends \PHPUnit_Framework_TestCase {
 	 * @expectedException	\Wikia\Service\PersistenceException
 	 */
 	public function testSetWithDatabaseError() {
-		$this->gatewayMock->expects( $this->once() )
+		$this->persistenceMock->expects( $this->once() )
 			->method( 'save' )
 			->with( $this->userId, [$this->testPreference] )
 			->will( $this->throwException( new \Wikia\Service\PersistenceException() ) );
 
-		$service = new Preference( $this->gatewayMock );
+		$service = new Preference( $this->persistenceMock );
 		$ret = $service->setPreferences( $this->userId, [ $this->testPreference ] );
 
 		$this->fail( "exception was not thrown" );
@@ -60,26 +60,26 @@ class PreferenceTest extends \PHPUnit_Framework_TestCase {
 
 
 	public function testGetPreferencesSuccess() {
-		$this->gatewayMock->expects( $this->once() )
+		$this->persistenceMock->expects( $this->once() )
 			->method( 'get' )
 			->with( $this->userId )
 			->willReturn( [
 			[ $this->testPreference->getName() => $this->testPreference->getValue() ]
 			] );
 
-		$service = new Preference( $this->gatewayMock );
+		$service = new Preference( $this->persistenceMock );
 		$preferences = $service->getPreferences( $this->userId );
 
 		$this->assertTrue( is_array($preferences), "expecting an array" );
 	}
 
 	public function testGetPreferencesEmpty() {
-		$this->gatewayMock->expects( $this->once() )
+		$this->persistenceMock->expects( $this->once() )
 			->method( 'get' )
 			->with( $this->userId )
 			->willReturn( false );
 
-		$service = new Preference( $this->gatewayMock );
+		$service = new Preference( $this->persistenceMock );
 		$preferences = $service->getPreferences( $this->userId );
 
 		$this->assertTrue( is_array($preferences), "expecting an array" );
@@ -87,12 +87,12 @@ class PreferenceTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testEmptyGet() {
-		$this->gatewayMock->expects( $this->exactly( 1 ) )
+		$this->persistenceMock->expects( $this->exactly( 1 ) )
 			->method( 'get' )
 			->with( $this->userId )
 			->willReturn( [] );
 
-		$service = new Preference( $this->gatewayMock );
+		$service = new Preference( $this->persistenceMock );
 		$preferences = $service->getPreferences( $this->userId );
 
 		$this->assertTrue( is_array($preferences), "expecting an array" );


### PR DESCRIPTION
This PR create a MySQL persistence implementation to support user preference CRUD in MW. It's a follow on to implement a concrete persistence class for getting/storing user preferences in MW. See https://github.com/Wikia/app/pull/7572 for the parent branch.

https://wikia-inc.atlassian.net/browse/SERVICES-450

/cc @Wikia/services-team
