### PR TITLE
non-static method was declared as static

### DIFF
--- a/includes/db/DatabaseSqlite.php
+++ b/includes/db/DatabaseSqlite.php
@@ -594,7 +594,7 @@ class DatabaseSqlite extends DatabaseBase {
 	/**
 	 * @return string wikitext of a link to the server software's web site
 	 */
-	public static function getSoftwareLink() {
+	public function getSoftwareLink() {
 		return "[http://sqlite.org/ SQLite]";
 	}
 


### PR DESCRIPTION
I was trying to set up a wikia server to test a plugin and my config kept getting stuck here, giving me an error that "Fatal error: Cannot make non static method DatabaseType::getSoftwareLink() static in class DatabaseSqlite in /var/www/html/includes/db/DatabaseSqlite.php on line 13"
