### PR TITLE
SOC-886 Tie the ban TTL to the remaining ban time

### DIFF
--- a/extensions/wikia/Chat2/Chat.class.php
+++ b/extensions/wikia/Chat2/Chat.class.php
@@ -14,6 +14,9 @@ class Chat {
 	// Cache ban info for 24h, 24*60*60 = 86400
 	const BAN_INFO_TTL = 86400;
 
+	// Value to store in memcache when no ban information is found
+	const NO_BAN_INFORMATION = -1;
+
 	/**
 	 * The return value of this method gets passed to Javascript as the global wgChatKey.  It then becomes the 'key'
 	 * parameter sent with every chat request to the Node.js server.
@@ -299,8 +302,9 @@ class Chat {
 
 			// Only cache for as long as we have left in the ban, or a default if the ban has expired
 			if ( empty( $banInfo ) ) {
+				// Cache the absense of ban information since this will be the case most often
 				$ttl = self::BAN_INFO_TTL;
-				$banInfo = -1;
+				$banInfo = self::NO_BAN_INFORMATION;
 			} else {
 				$ttl = $banInfo->end_date - time();
 			}
@@ -308,7 +312,7 @@ class Chat {
 			$memc->set( $key, $banInfo, $ttl );
 		}
 
-		return $banInfo == -1 ? false : $banInfo;
+		return $banInfo == self::NO_BAN_INFORMATION ? false : $banInfo;
 	}
 
 	private static function getBanInfoFromDB( $cityID, $userID ) {


### PR DESCRIPTION
The TTL for `getBanInformation` is set at an arbitrary 24hrs.  That only works for bans over 1 day, but even then if the data gets cached near the end of the ban day, the user can end up banned for almost one extra day.

This PR changes the TTL to be the time remaining on the ban.

https://wikia-inc.atlassian.net/browse/SOC-886
