### PR TITLE
(CE-2155) Only show right rail on templates with "infobox" in title

### DIFF
--- a/extensions/wikia/TemplateDraft/TemplateDraftHooks.class.php
+++ b/extensions/wikia/TemplateDraft/TemplateDraftHooks.class.php
@@ -11,7 +11,10 @@ class TemplateDraftHooks {
 	public static function onGetRailModuleList( Array &$railModuleList ) {
 		global $wgTitle;
 
+		$titleNeedle = 'infobox';
 		if ( $wgTitle->getNamespace() === NS_TEMPLATE
+			&& $wgTitle->exists()
+			&& strripos( $wgTitle->getText(), $titleNeedle ) !== false
 			&& Wikia::getProps( $wgTitle->getArticleID(), TemplateDraftController::TEMPLATE_INFOBOX_PROP ) !== 0
 		) {
 			$railModuleList[1502] = [ 'TemplateDraftModule', 'Index', null ];


### PR DESCRIPTION
Only show right rail on templates with "infobox" in title for now. Also
check the template exists so we don't show "migrate this infobox" on a
non-existent template page.

/cc @Wikia/community-engineering 
