### PR TITLE
PLATFORM-1310: Move user history related tables to specials

### DIFF
--- a/extensions/wikia/FounderEmails/FounderEmails.class.php
+++ b/extensions/wikia/FounderEmails/FounderEmails.class.php
@@ -305,31 +305,29 @@ class FounderEmails {
 	}
 
 	public function getJoinedUsers ( $cityID, $day = null ) {
-		global $wgStatsDB, $wgStatsDBEnabled;
+		global $wgSpecialsDB;
 
 		wfProfileIn( __METHOD__ );
 
 		$userJoined = array();
-		if ( !empty( $wgStatsDBEnabled ) ) {
-			$today = ( empty( $day ) ) ? date( 'Y-m-d', strtotime( '-1 day' ) ) : $day;
+		$today = ( empty( $day ) ) ? date( 'Y-m-d', strtotime( '-1 day' ) ) : $day;
 
-			$db = wfGetDB( DB_SLAVE, array(), $wgStatsDB );
-			$oRes = $db->select(
-				array( 'user_login_history' ),
-				array( 'user_id', 'min(ulh_timestamp) as min_ts' ),
-				array(
-					'city_id' => $cityID,
-					'user_id > 0'
-				),
-				__METHOD__,
-				array( 'GROUP BY' => 'user_id', 'HAVING' => "min(ulh_timestamp)" .  $db->buildLike( $today, $db->anyString() ) )
-			);
+		$db = wfGetDB( DB_SLAVE, array(), $wgSpecialsDB );
+		$oRes = $db->select(
+			array( 'user_login_history' ),
+			array( 'user_id', 'min(ulh_timestamp) as min_ts' ),
+			array(
+				'city_id' => $cityID,
+				'user_id > 0'
+			),
+			__METHOD__,
+			array( 'GROUP BY' => 'user_id', 'HAVING' => "min(ulh_timestamp)" .  $db->buildLike( $today, $db->anyString() ) )
+		);
 
-			while ( $oRow = $db->fetchObject ( $oRes ) ) {
-				$userJoined[ $oRow->user_id ] = $oRow->min_ts;
-			}
-			$db->freeResult( $oRes );
+		while ( $oRow = $db->fetchObject ( $oRes ) ) {
+			$userJoined[ $oRow->user_id ] = $oRow->min_ts;
 		}
+		$db->freeResult( $oRes );
 
 		wfProfileOut( __METHOD__ );
 		return $userJoined;

--- a/extensions/wikia/UserChangesHistory/UserChangesHistory.class.php
+++ b/extensions/wikia/UserChangesHistory/UserChangesHistory.class.php
@@ -70,7 +70,7 @@ class UserChangesHistory {
 							WScribeClient::singleton('trigger')->send($data);
 						}
 						catch( TException $e ) {
-							Wikia\Logger\WikiaLogger::instance()->error( __METHOD__, [
+							Wikia\Logger\WikiaLogger::instance()->error( __METHOD__, ' - scribeClient exception', [
 								'exception' => $e
 							] );
 						}

--- a/extensions/wikia/UserChangesHistory/UserChangesHistory.class.php
+++ b/extensions/wikia/UserChangesHistory/UserChangesHistory.class.php
@@ -119,7 +119,7 @@ class UserChangesHistory {
 	 * @return bool true		process other hooks
 	 */
 	static public function SavePreferencesHook($formData, $error) {
-		global $$wgSpecialsDB, $wgEnableScribeReport, $wgUser;
+		global $wgSpecialsDB, $wgEnableScribeReport, $wgUser;
 
 		if( wfReadOnly() ) { return true; }
 

--- a/extensions/wikia/UserChangesHistory/UserChangesHistory.class.php
+++ b/extensions/wikia/UserChangesHistory/UserChangesHistory.class.php
@@ -70,7 +70,7 @@ class UserChangesHistory {
 							WScribeClient::singleton('trigger')->send($data);
 						}
 						catch( TException $e ) {
-							Wikia\Logger\WikiaLogger::instance()->error( __METHOD__, ' - scribeClient exception', [
+							Wikia\Logger\WikiaLogger::instance()->error( __METHOD__ . ' - scribeClient exception', [
 								'exception' => $e
 							] );
 						}

--- a/extensions/wikia/UserChangesHistory/UserChangesHistory.sql
+++ b/extensions/wikia/UserChangesHistory/UserChangesHistory.sql
@@ -1,24 +1,31 @@
 CREATE TABLE `user_login_history` (
   `user_id` int(5) unsigned NOT NULL,
-  `city_id` int(9) unsigned default '0',
-  `ulh_timestamp` timestamp NOT NULL default CURRENT_TIMESTAMP,
-  `ulh_from` tinyint(4) default '0',
-  `ulh_rememberme` tinyint(4) default NULL,
+  `city_id` int(9) unsigned DEFAULT '0',
+  `ulh_timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `ulh_from` tinyint(4) DEFAULT '0',
+  `ulh_rememberme` tinyint(4) DEFAULT NULL,
   KEY `idx_user_login_history_timestamp` (`ulh_timestamp`),
-  KEY `idx_user_id` (`user_id`)
+  KEY `idx_user_id` (`user_id`),
+  KEY `idx_user_login_history_wikia_timestamp` (`city_id`,`user_id`,`ulh_timestamp`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `user_login_history_summary` (
+  `user_id` int(8) unsigned NOT NULL,
+  `ulh_timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 CREATE TABLE `user_history` (
   `user_id` int(5) unsigned NOT NULL,
-  `user_name` varchar(255) character set latin1 collate latin1_bin NOT NULL default '',
-  `user_real_name` varchar(255) character set latin1 collate latin1_bin NOT NULL default '',
+  `user_name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `user_real_name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   `user_password` tinyblob NOT NULL,
   `user_newpassword` tinyblob NOT NULL,
   `user_email` tinytext NOT NULL,
   `user_options` blob NOT NULL,
-  `user_touched` varchar(14) character set latin1 collate latin1_bin NOT NULL default '',
-  `user_token` varchar(32) character set latin1 collate latin1_bin NOT NULL default '',
-  `uh_timestamp` timestamp NOT NULL default CURRENT_TIMESTAMP,
+  `user_touched` varchar(14) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `user_token` varchar(32) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `uh_timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   KEY `user_name` (`user_name`(10)),
   KEY `idx_user_history_timestamp` (`uh_timestamp`),
   KEY `idx_user_id` (`user_id`)

--- a/extensions/wikia/UserLogin/UserLoginHelper.class.php
+++ b/extensions/wikia/UserLogin/UserLoginHelper.class.php
@@ -75,6 +75,7 @@ class UserLoginHelper extends WikiaModel {
 	 * @return array $wikiUsers
 	 */
 	protected function getWikiUsers( $wikiId = null, $limit = 30 ) {
+		global $wgSpecialsDB;
 		wfProfileIn( __METHOD__ );
 
 		if ( !$this->wg->StatsDBEnabled ) {
@@ -90,7 +91,7 @@ class UserLoginHelper extends WikiaModel {
 		if ( !is_array( $wikiUsers ) ) {
 			$wikiUsers = array();
 
-			$db = wfGetDB( DB_SLAVE, array(), $this->wg->StatsDB );
+			$db = wfGetDB( DB_SLAVE, array(), $wgSpecialsDB );
 			$result = $db->select(
 				array( 'user_login_history' ),
 				array( 'distinct user_id' ),
@@ -110,7 +111,7 @@ class UserLoginHelper extends WikiaModel {
 				$this->addUserToUserList( $founder, $wikiUsers );
 			}
 
-			$this->wg->Memc->set( $memKey, $wikiUsers, 60 * 60 * 24 );
+			$this->wg->Memc->set( $memKey, $wikiUsers, WikiaResponse::CACHE_STANDARD );
 		}
 
 		wfProfileOut( __METHOD__ );

--- a/extensions/wikia/UserLogin/UserLoginHelper.class.php
+++ b/extensions/wikia/UserLogin/UserLoginHelper.class.php
@@ -78,12 +78,6 @@ class UserLoginHelper extends WikiaModel {
 		global $wgSpecialsDB;
 		wfProfileIn( __METHOD__ );
 
-		if ( !$this->wg->StatsDBEnabled ) {
-			// no stats DB, can't get list of users with avatars
-			wfProfileOut( __METHOD__ );
-			return array();
-		}
-
 		$wikiId = ( empty( $wikiId ) ) ? $this->wg->CityId : $wikiId;
 
 		$memKey = wfSharedMemcKey( 'userlogin', 'users_with_avatar', $wikiId );
@@ -115,7 +109,6 @@ class UserLoginHelper extends WikiaModel {
 		}
 
 		wfProfileOut( __METHOD__ );
-
 		return $wikiUsers;
 	}
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-1310

`user_login_history_summary` is used in joins with `events_local_users` - they both need to be on specials DB.

To keep all related tables in the same place let's move these tables from stats to specials:
- user_history (2.4 mm rows)
- user_login_history (500 mm rows)
- user_login_history_summary (6.7 mm rows)

@michalroszka / @wladekb / @drozdo
