### PR TITLE
CE-2118 Make flags modal respect colors

### DIFF
--- a/extensions/wikia/AssetsManager/AssetsManagerController.class.php
+++ b/extensions/wikia/AssetsManager/AssetsManagerController.class.php
@@ -43,7 +43,6 @@ class AssetsManagerController extends WikiaController {
 		$mustache = $this->request->getVal( 'mustache', null );
 		$handlebars = $this->request->getVal( 'handlebars', null );
 		$sassParams = $this->request->getVal( 'sassParams', null );
-		$wikiaId = $this->request->getVal( 'wikiaId', null );
 
 		// handle templates via sendRequest
 		if ( !is_null( $templates ) ) {
@@ -72,7 +71,7 @@ class AssetsManagerController extends WikiaController {
 			$profileId = __METHOD__ . "::styles::{$styles}";
 			wfProfileIn( $profileId );
 
-			$key = $this->getComponentMemcacheKey( $styles, $sassParams, $wikiaId );
+			$key = $this->getComponentMemcacheKey( $styles, $sassParams );
 			$data = $this->wg->Memc->get( $key );
 
 			if ( empty( $data ) ) {
@@ -158,17 +157,11 @@ class AssetsManagerController extends WikiaController {
 		wfProfileOut( __METHOD__ );
 	}
 
-	private function getComponentMemcacheKey( $par, $sassParams = null, $wikiaId = null ) {
-		$key = self::MEMCKEY_PREFIX;
+	private function getComponentMemcacheKey( $par, $sassParams = null ) {
 		if ( $sassParams ) {
 			$par = json_encode( [ $par, $sassParams ] );
 		}
-		$key .= '::' . md5( $par );
-		$key .= '::' . $this->wg->StyleVersion;
-		if ( $wikiaId ) {
-			$key .= '::' . $wikiaId;
-		}
-		return $key;
+		return self::MEMCKEY_PREFIX . '::' . md5( $par ) . '::' . $this->wg->StyleVersion;
 	}
 
 	/**

--- a/extensions/wikia/AssetsManager/AssetsManagerController.class.php
+++ b/extensions/wikia/AssetsManager/AssetsManagerController.class.php
@@ -42,6 +42,8 @@ class AssetsManagerController extends WikiaController {
 		$messages = $this->request->getVal( 'messages', null );
 		$mustache = $this->request->getVal( 'mustache', null );
 		$handlebars = $this->request->getVal( 'handlebars', null );
+		$sassParams = $this->request->getVal( 'sassParams', null );
+		$wikiaId = $this->request->getVal( 'wikiaId', null );
 
 		// handle templates via sendRequest
 		if ( !is_null( $templates ) ) {
@@ -70,7 +72,7 @@ class AssetsManagerController extends WikiaController {
 			$profileId = __METHOD__ . "::styles::{$styles}";
 			wfProfileIn( $profileId );
 
-			$key = $this->getComponentMemcacheKey( $styles );
+			$key = $this->getComponentMemcacheKey( $styles, $sassParams, $wikiaId );
 			$data = $this->wg->Memc->get( $key );
 
 			if ( empty( $data ) ) {
@@ -81,8 +83,8 @@ class AssetsManagerController extends WikiaController {
 					$builder = $this->getBuilder( 'sass', $styleFile );
 
 					if ( !is_null( $builder ) ) {
-						if ( $this->app->checkSkin( 'oasis' ) ) {
-							$builder->addParams( SassUtil::getOasisSettings() );
+						if ( !empty( $sassParams ) ) {
+							$builder->addParams( $sassParams );
 						}
 						$data .= $builder->getContent();
 					}
@@ -156,8 +158,17 @@ class AssetsManagerController extends WikiaController {
 		wfProfileOut( __METHOD__ );
 	}
 
-	private function getComponentMemcacheKey( $par ) {
-		return self::MEMCKEY_PREFIX . '::' . md5( $par ) . '::' . $this->wg->StyleVersion;
+	private function getComponentMemcacheKey( $par, $sassParams = null, $wikiaId = null ) {
+		$key = self::MEMCKEY_PREFIX;
+		if ( $sassParams ) {
+			$par = json_encode( [ $par, $sassParams ] );
+		}
+		$key .= '::' . md5( $par );
+		$key .= '::' . $this->wg->StyleVersion;
+		if ( $wikiaId ) {
+			$key .= '::' . $wikiaId;
+		}
+		return $key;
 	}
 
 	/**

--- a/extensions/wikia/AssetsManager/builders/AssetsManagerSassBuilder.class.php
+++ b/extensions/wikia/AssetsManager/builders/AssetsManagerSassBuilder.class.php
@@ -103,6 +103,9 @@ class AssetsManagerSassBuilder extends AssetsManagerBaseBuilder {
 
 	/**
 	 * Add more params to already existing
+	 * Set to null if want to force fallback to default sass params
+	 * (fallback happens in SassService::getSassVariables)
+	 * by default $this->mParams is empty array so fallback don't happen
 	 * @param array $params
 	 */
 	public function addParams( array $params ) {

--- a/extensions/wikia/Flags/scripts/FlagsModal.js
+++ b/extensions/wikia/Flags/scripts/FlagsModal.js
@@ -88,10 +88,7 @@ require(
 					type: loader.MULTI,
 					resources: {
 						mustache: '/extensions/wikia/Flags/controllers/templates/FlagsController_editForm.mustache,/extensions/wikia/Flags/controllers/templates/FlagsController_editFormEmpty.mustache,/extensions/wikia/Flags/controllers/templates/FlagsController_editFormException.mustache',
-						styles: '/extensions/wikia/Flags/styles/EditFormModal.scss',
-						params: {
-							sassParams: window.wgSassParams // Ensure per-theme colors Varnish cache and mcache
-						}
+						styles: '/extensions/wikia/Flags/styles/EditFormModal.scss'
 					}
 				})
 			).done(function (flagsData, res) {

--- a/extensions/wikia/Flags/scripts/FlagsModal.js
+++ b/extensions/wikia/Flags/scripts/FlagsModal.js
@@ -88,7 +88,11 @@ require(
 					type: loader.MULTI,
 					resources: {
 						mustache: '/extensions/wikia/Flags/controllers/templates/FlagsController_editForm.mustache,/extensions/wikia/Flags/controllers/templates/FlagsController_editFormEmpty.mustache,/extensions/wikia/Flags/controllers/templates/FlagsController_editFormException.mustache',
-						styles: '/extensions/wikia/Flags/styles/EditFormModal.scss'
+						styles: '/extensions/wikia/Flags/styles/EditFormModal.scss',
+						params: {
+							sassParams: window.wgSassParams, // Ensure per-theme colors Varnish cache and mcache
+							wikiaId: window.wgCityId // Ensure per-wikia mcache
+						}
 					}
 				})
 			).done(function (flagsData, res) {

--- a/extensions/wikia/Flags/scripts/FlagsModal.js
+++ b/extensions/wikia/Flags/scripts/FlagsModal.js
@@ -90,8 +90,7 @@ require(
 						mustache: '/extensions/wikia/Flags/controllers/templates/FlagsController_editForm.mustache,/extensions/wikia/Flags/controllers/templates/FlagsController_editFormEmpty.mustache,/extensions/wikia/Flags/controllers/templates/FlagsController_editFormException.mustache',
 						styles: '/extensions/wikia/Flags/styles/EditFormModal.scss',
 						params: {
-							sassParams: window.wgSassParams, // Ensure per-theme colors Varnish cache and mcache
-							wikiaId: window.wgCityId // Ensure per-wikia mcache
+							sassParams: window.wgSassParams // Ensure per-theme colors Varnish cache and mcache
 						}
 					}
 				})

--- a/resources/wikia/modules/loader.js
+++ b/resources/wikia/modules/loader.js
@@ -314,6 +314,11 @@ define('wikia.loader', ['wikia.window', require.optional('mw'), 'wikia.nirvana',
 				// add a cache buster
 				options.cb = window.wgStyleVersion;
 
+				if (typeof options.styles !== 'undefined') {
+					// Add sass params to ensure per-theme colors Varnish cache and mcache
+					options.sassParams = options.sassParams || window.wgSassParams;
+				}
+
 				nirvana.getJson(
 					'AssetsManager',
 					'getMultiTypePackage',


### PR DESCRIPTION
:flags: @Wikia/community-engineering 
https://wikia-inc.atlassian.net/browse/CE-2118

Now theme designer colors are respected by modal. It was caching issue and the fix is to make varnish cache and mcache depend on sassParams.

At the same time refactoring code to use sass params sent from frontend not generating that within function. (replaced SassUtil::getOasisSettings with $sassParams)
