### PR TITLE
(CE-2160) Fix interface language always displaying content language

### DIFF
--- a/includes/context/RequestContext.php
+++ b/includes/context/RequestContext.php
@@ -343,6 +343,8 @@ class RequestContext implements IContextSource {
 				$obj = Language::factory( $code );
 				$this->lang = $obj;
 			}
+
+			$this->recursion = 0;
 		}
 
 		return $this->lang;


### PR DESCRIPTION
Fix interface language always displaying content language instead of the
user's language. The fix in #7591 removed the unsetting of the recursion
value after a language was returned from the main method (in the elseif block)
leading it to get stuck returning the content language on successive calls
due to always entering the recursion block which should only be called from
within the elseif block of the method.

/cc @macbre @michalroszka @Wikia/community-engineering 
