### PR TITLE
(CE-2166) Fix missing parameters on Special:Flags

### DIFF
--- a/extensions/wikia/Flags/controllers/templates/SpecialFlagsController_index.php
+++ b/extensions/wikia/Flags/controllers/templates/SpecialFlagsController_index.php
@@ -28,7 +28,7 @@
 			</td>
 			<td class="flags-special-list-item-params">
 				<?php
-					$paramsNames = json_decode( $flag['flag_params_names'] );
+					$paramsNames = json_decode( $flag['flag_params_names'], true );
 					if ( is_array( $paramsNames ) ) :
 				?>
 					<?php foreach ( $paramsNames as $name => $description ): ?>


### PR DESCRIPTION
In commit be8778f309e486e3 a check for whether or not the JSON decoded
flag names was an array was added; however, by default json_decode will
return an StdClass object for a decode JSON object, not an array. This
makes json_decode return an associative array instead.

/cc @Wikia/community-engineering 
