### PR TITLE
CE-2103 mark templates as not infoboxes (and other classification)

### DIFF
--- a/extensions/wikia/TemplateDraft/TemplateDraft.setup.php
+++ b/extensions/wikia/TemplateDraft/TemplateDraft.setup.php
@@ -25,6 +25,7 @@ $wgExtensionMessagesFiles['TemplateDraft'] = __DIR__ . '/TemplateDraft.i18n.php'
  * Controllers
  */
 $wgAutoloadClasses['TemplateDraftController'] = __DIR__ . '/controllers/TemplateDraftController.class.php';
+$wgAutoloadClasses['TemplateClassificationController'] = __DIR__ . '/controllers/TemplateClassificationController.class.php';
 
 /**
  * Hooks

--- a/extensions/wikia/TemplateDraft/controllers/TemplateClassificationController.class.php
+++ b/extensions/wikia/TemplateDraft/controllers/TemplateClassificationController.class.php
@@ -27,14 +27,14 @@ class TemplateClassificationController extends WikiaController {
 	private function getClassificationProp( $type ) {
 		if ( array_search( $type, $this->templateTypes, true ) ) {
 			return self::TEMPLATE_CLASSIFICATION_DATA_PREFIX . $type;
-		} else {
-			// invalid type!
-			return false;
 		}
+		
+		// invalid type!
+		return false;
 	}
 
-	public function classifyTemplate( String $templateName, $type, bool $value, $actor = self::CLASSIFICATION_ACTOR_HUMAN ) {
-		$title = Title::newFromName( $titleName, NS_TITLE );
+	public function classifyTemplate ($templateName, $type, bool $value, $actor = self::CLASSIFICATION_ACTOR_HUMAN ) {
+		$title = Title::newFromName( $titleName, NS_TEMPLATE );
 
 		if ( is_null( $title ) ) {
 			return false;

--- a/extensions/wikia/TemplateDraft/controllers/TemplateClassificationController.class.php
+++ b/extensions/wikia/TemplateDraft/controllers/TemplateClassificationController.class.php
@@ -1,0 +1,65 @@
+<?php
+
+class TemplateClassificationController extends WikiaController {
+
+	static $templateTypes = array(
+		'infobox',
+		'quote',
+		'navbox',
+		/** more to come **/
+	);
+
+	/**
+	 * Flags indicating type of the template
+	 */
+	const TEMPLATE_GENERAL = 1;
+	const TEMPLATE_INFOBOX = 2;
+
+	const TEMPLATE_CLASSIFICATION_MAIN_PROP = 'tc-template-recognized-type'; // prop stores positive match for easy retrieval
+	const TEMPLATE_CLASSIFICATION_DATA_PREFIX = 'tc-data-'; // prop stores positive or negative match
+
+	/**
+	 * Flags indicating who's taking a classification action
+	 */
+	const CLASSIFICATION_ACTOR_AI = 0;
+	const CLASSIFICATION_ACTOR_HUMAN = 1;
+
+	private function getClassificationProp( $type ) {
+		if ( array_search( $type, $this->templateTypes, true ) ) {
+			return self::TEMPLATE_CLASSIFICATION_DATA_PREFIX . $type;
+		} else {
+			// invalid type!
+			return false;
+		}
+	}
+
+	public function classifyTemplate( String $templateName, $type, bool $value, $actor = self::CLASSIFICATION_ACTOR_HUMAN ) {
+		$title = Title::newFromName( $titleName, NS_TITLE );
+
+		if ( is_null( $title ) ) {
+			return false;
+		}
+
+		$prop = self::getClassificationProp( $type );
+		if ( !$prop ) {
+			// unrecognized property, quit early
+			return false;
+		}
+
+		// @TODO check permissions here
+
+		if ( $value ) {
+			// Huzzah! Template positively identified! Store in main property for easy retrieval
+			Wikia::setProps( $title->getArticleId(), array( self::TEMPLATE_CLASSIFICATION_MAIN_PROP => $type ) );
+		}
+
+		$data = array(
+			'value' => $value,
+			'actor' => $actor,
+			'actor-id' => $this->wg->User->getId(),
+			'timestamp' => wfTimestamp(),
+		);
+
+		Wikia::setProp( $title->getArticleId(), array( $prop => json_encode( $data ) ) );
+	}
+}

--- a/extensions/wikia/TemplateDraft/controllers/TemplateDraftController.class.php
+++ b/extensions/wikia/TemplateDraft/controllers/TemplateDraftController.class.php
@@ -3,21 +3,6 @@
 class TemplateDraftController extends WikiaController {
 
 	/**
-	 * Properties used in page_props table, construction:
-	 * * tc- - prefix for "template classification"
-	 * * -marked- - signifies classification decision made by human
-	 * * -auto- - signifies classification decision made by AI
-	 * * -infobox - suffix denoting the type of template we identified
-	 */
-	const TEMPLATE_INFOBOX_PROP = 'tc-marked-infobox';
-
-	/**
-	 * Flags indicating type of the template
-	 */
-	const TEMPLATE_GENERAL = 1;
-	const TEMPLATE_INFOBOX = 2;
-
-	/**
 	 * Converts the content of the template according to the given flags.
 	 *
 	 * @param $content
@@ -27,7 +12,11 @@ class TemplateDraftController extends WikiaController {
 	public function createDraftContent( Title $title, $content, Array $flags ) {
 		$flagsSum = array_sum( $flags );
 
-		if ( self::TEMPLATE_INFOBOX & $flagsSum ) {
+		if ( TemplateClassificationController::TEMPLATE_INFOBOX & $flagsSum ) {
+			// while we're at it we can mark the base template as an infobox
+			$tc = new TemplateClassificationController();
+			$tc->classifyTemplate( $title->getBaseText(), 'infobox', true );
+
 			$templateConverter = new TemplateConverter( $title );
 			$newContent = $templateConverter->convertAsInfobox( $content );
 			$newContent .= $templateConverter->generatePreviewSection( $content );
@@ -35,4 +24,5 @@ class TemplateDraftController extends WikiaController {
 
 		return $newContent;
 	}
+
 }


### PR DESCRIPTION
Basic assumptions:
- we want to classify any template
- a template can be positively classified as being of only one type
- ...but a template can also be negatively classified (i.e. "this is not an infobox)

Notes on future directions:
- should be part of Article service or a similar page-related metadata storage/retrieval mechanism
