### PR TITLE
Fix unit tests as the constructor now requires a Title

### DIFF
--- a/extensions/wikia/TemplateDraft/TemplateConverter.class.php
+++ b/extensions/wikia/TemplateDraft/TemplateConverter.class.php
@@ -4,7 +4,7 @@ class TemplateConverter {
 
 	const TEMPLATE_VARIABLE_REGEX = '/{{{([^|{}]+)(\|([^{}]*|.*{{.*}}.*))?}}}/';
 
-	var $title; // Title object of the template we're converting
+	private $title; // Title object of the template we're converting
 
 	/**
 	 * Names of variables that should be converted to a <title> tag
@@ -162,4 +162,4 @@ class TemplateConverter {
 
 		return $return;
 	}
-} 
+}

--- a/extensions/wikia/TemplateDraft/tests/TemplateConverterTest.php
+++ b/extensions/wikia/TemplateDraft/tests/TemplateConverterTest.php
@@ -11,7 +11,8 @@ class TemplateConverterTest extends WikiaBaseTest {
 	 * @dataProvider convertAsInfoboxProvider
 	 */
 	public function testConvertAsInfobox( $content, $expected, $comment ) {
-		$templateConverter = new TemplateConverter();
+		$mockTitle = $this->getMock( 'Title' );
+		$templateConverter = new TemplateConverter( $mockTitle );
 
 		$result = $templateConverter->convertAsInfobox( $content );
 


### PR DESCRIPTION
#7644 introduced a required Title object to the constructor. Updating the

unit tests so this works again.

/cc @Wikia/community-engineering 
