### PR TITLE
CE-2159 Fetch flags ParserOutput to LinksUpdate

### DIFF
--- a/extensions/wikia/Flags/Flags.hooks.php
+++ b/extensions/wikia/Flags/Flags.hooks.php
@@ -124,7 +124,11 @@ class Hooks {
 				 * We need modified versions of names of templates and flag_view values to
 				 * compare in a case-insensitive and space-underscore-insensitive way.
 				 */
-				$templatesKeys = array_map( 'strtolower', array_keys( $templates ) );
+				$templatesKeys = [];
+				foreach( $templates as $template ) {
+					$templatesKeys = strtolower( $template['tl_title'] );
+				}
+
 				foreach ( $flagTypesResponse[\FlagsApiController::FLAGS_API_RESPONSE_DATA] as $flagType ) {
 					if ( isset( $flagType['flag_id'] ) ) {
 						continue;

--- a/extensions/wikia/Flags/Flags.hooks.php
+++ b/extensions/wikia/Flags/Flags.hooks.php
@@ -79,6 +79,21 @@ class Hooks {
 	}
 
 	/**
+	 * Modifies ParserOutput
+	 * @param \LinksUpdate $linksUpdate
+	 * @return bool
+	 */
+	public static function onLinksUpdate( \LinksUpdate $linksUpdate ) {
+		$linksUpdate->mParserOutput = ( new \FlagsController )
+			->modifyParserOutputWithFlags(
+				$linksUpdate->getParserOutput(),
+				$linksUpdate->getTitle()->getArticleID()
+			);
+
+		return true;
+	}
+
+	/**
 	 * @param \ParserOutput $parserOutput
 	 * @param \Title $title
 	 * @return bool
@@ -95,9 +110,10 @@ class Hooks {
 
 		if ( $app->wg->HideFlagsExt !== true ) {
 			$flagTypesResponse = $app->sendRequest( 'FlagsApiController',
-				'getFlagTypes',
+				'getFlagsForPageForEdit',
 				[
 					'wiki_id' => $app->wg->CityId,
+					'page_id' => $pageId,
 				]
 			)->getData();
 
@@ -110,6 +126,10 @@ class Hooks {
 				 */
 				$templatesKeys = array_map( 'strtolower', array_keys( $templates ) );
 				foreach ( $flagTypesResponse[\FlagsApiController::FLAGS_API_RESPONSE_DATA] as $flagType ) {
+					if ( isset( $flagType['flag_id'] ) ) {
+						continue;
+					}
+
 					$flagViewKey = strtolower( str_replace( ' ', '_', $flagType['flag_view'] ) );
 					if ( in_array( $flagViewKey, $templatesKeys ) ) {
 						$flagTypesToExtract[$flagType['flag_view']] = $flagType;

--- a/extensions/wikia/Flags/Flags.hooks.php
+++ b/extensions/wikia/Flags/Flags.hooks.php
@@ -108,7 +108,7 @@ class Hooks {
 	public static function onLinksUpdateInsertTemplates( $pageId, Array $templates ) {
 		$app = \F::app();
 
-		if ( $app->wg->HideFlagsExt !== true ) {
+		if ( !empty( $templates) && $app->wg->HideFlagsExt !== true ) {
 			$flagTypesResponse = $app->sendRequest( 'FlagsApiController',
 				'getFlagsForPageForEdit',
 				[

--- a/extensions/wikia/Flags/Flags.hooks.php
+++ b/extensions/wikia/Flags/Flags.hooks.php
@@ -126,7 +126,7 @@ class Hooks {
 				 */
 				$templatesKeys = [];
 				foreach( $templates as $template ) {
-					$templatesKeys = strtolower( $template['tl_title'] );
+					$templatesKeys[] = strtolower( $template['tl_title'] );
 				}
 
 				foreach ( $flagTypesResponse[\FlagsApiController::FLAGS_API_RESPONSE_DATA] as $flagType ) {

--- a/extensions/wikia/Flags/Flags.setup.php
+++ b/extensions/wikia/Flags/Flags.setup.php
@@ -77,6 +77,7 @@ $wgAutoloadClasses['Flags\Hooks'] = __DIR__ . '/Flags.hooks.php';
 $wgHooks['ArticlePreviewAfterParse'][] = 'Flags\Hooks::onArticlePreviewAfterParse';
 $wgHooks['BeforePageDisplay'][] = 'Flags\Hooks::onBeforePageDisplay';
 $wgHooks['BeforeParserCacheSave'][] = 'Flags\Hooks::onBeforeParserCacheSave';
+$wgHooks['LinksUpdate'][] = 'Flags\Hooks::onLinksUpdate';
 $wgHooks['LinksUpdateInsertTemplates'][] = 'Flags\Hooks::onLinksUpdateInsertTemplates';
 $wgHooks['PageHeaderDropdownActions'][] = 'Flags\Hooks::onPageHeaderDropdownActions';
 $wgHooks['SkinTemplateNavigation'][] = 'Flags\Hooks::onSkinTemplateNavigation';

--- a/extensions/wikia/Flags/controllers/FlagsController.class.php
+++ b/extensions/wikia/Flags/controllers/FlagsController.class.php
@@ -71,6 +71,8 @@ class FlagsController extends WikiaController {
 			$parserOutput->setText( $flagsParserOutput->getText() . $parserOutput->getText() );
 		}
 
+		$parserOutput->mergeExternalParserOutputVars( $flagsParserOutput );
+
 		return $parserOutput;
 	}
 

--- a/includes/LinksUpdate.php
+++ b/includes/LinksUpdate.php
@@ -542,8 +542,10 @@ class LinksUpdate {
 				);
 			}
 
-			wfRunHooks( 'LinksUpdateInsertTemplates', [ $this->mId, $diffs ] );
 		}
+
+		wfRunHooks( 'LinksUpdateInsertTemplates', [ $this->mId, $diffs ] );
+
 		return $arr;
 	}
 

--- a/includes/LinksUpdate.php
+++ b/includes/LinksUpdate.php
@@ -544,7 +544,7 @@ class LinksUpdate {
 
 		}
 
-		wfRunHooks( 'LinksUpdateInsertTemplates', [ $this->mId, $diffs ] );
+		wfRunHooks( 'LinksUpdateInsertTemplates', [ $this->mId, $arr ] );
 
 		return $arr;
 	}


### PR DESCRIPTION
This fix deals with flags ParserOutput not being available in LinksUpdate and Extraction tasks firing in a wrong context.

@Wikia/community-engineering 
