### PR TITLE
CONCF-672 | CuratedContent/GameGuides setting/purging cache

### DIFF
--- a/extensions/wikia/CuratedContent/CuratedContentController.class.php
+++ b/extensions/wikia/CuratedContent/CuratedContentController.class.php
@@ -395,11 +395,10 @@ class CuratedContentController extends WikiaController {
 		global $wgServer;
 
 		$content = F::app()->wg->WikiaCuratedContent;
-		$mercuryApiExists = class_exists( 'MercuryApiHooks' );
 
 		( new SquidUpdate( array_unique( array_reduce(
 			$content,
-			function ( $urls, $item ) use ( $wgServer, $mercuryApiExists ) {
+			function ( $urls, $item ) use ( $wgServer ) {
 				if ( $item[ 'title' ] !== '' && empty( $item[ 'featured' ] ) ) {
 					// Purge section URLs using urlencode() (standard for MediaWiki), which uses implements RFC 1738
 					// https://tools.ietf.org/html/rfc1738#section-2.2 - spaces encoded as `+`.
@@ -414,13 +413,11 @@ class CuratedContentController extends WikiaController {
 					// Mercury web app uses this variant - request from Hapi.js to MediaWiki.
 					$urls[ ] = self::getUrl( 'getList' ) . '&section=' . self::encodeURIQueryParam( $item[ 'title' ] );
 					// Mercury web app uses this variant - request from Ember.js to Hapi.js.
-					if ( $mercuryApiExists ) {
-						$urls[ ] =
-							$wgServer .
-							MercuryApiHooks::SERVICE_API_BASE .
-							MercuryApiHooks::SERVICE_API_CURATED_CONTENT .
-							self::encodeURIQueryParam( $item[ 'title' ] );
-					}
+					$urls[ ] =
+						$wgServer .
+						MercuryApiHooks::SERVICE_API_BASE .
+						MercuryApiHooks::SERVICE_API_CURATED_CONTENT .
+						self::encodeURIQueryParam( $item[ 'title' ] );
 				}
 				return $urls;
 			},

--- a/extensions/wikia/CuratedContent/CuratedContentController.class.php
+++ b/extensions/wikia/CuratedContent/CuratedContentController.class.php
@@ -415,7 +415,7 @@ class CuratedContentController extends WikiaController {
 	 * @brief Purges API response for every section
 	 */
 	private function purgeSections() {
-		$content = $this->wg->WikiaCuratedContent;
+		$content = F::app()->wg->WikiaCuratedContent;
 
 		foreach ( $content as $item ) {
 			if ( $item[ 'title' ] !== '' && $item[ 'featured' ] == false ) {

--- a/extensions/wikia/CuratedContent/CuratedContentController.class.php
+++ b/extensions/wikia/CuratedContent/CuratedContentController.class.php
@@ -402,6 +402,14 @@ class CuratedContentController extends WikiaController {
 			}
 		}, $content ) );
 
+		$squidUpdate = new SquidUpdate( array_reduce( $content, function ( $urls, $item ) {
+			if ( $item[ 'title' ] !== '' && empty( $item[ 'featured' ] ) ) {
+				$urls[] = self::getUrl( 'getList' ) . '&section=' . rawurlencode( $item[ 'title' ] );
+			}
+			return $urls;
+		} ) );
+		$squidUpdate->doUpdate();
+
 		if ( class_exists( 'GameGuidesController' ) ) {
 			GameGuidesController::purgeMethod( 'getList' );
 		}

--- a/extensions/wikia/CuratedContent/CuratedContentController.class.php
+++ b/extensions/wikia/CuratedContent/CuratedContentController.class.php
@@ -363,7 +363,7 @@ class CuratedContentController extends WikiaController {
 			array_reduce(
 				$content,
 				function ( $ret, $item ) {
-					if ( $item[ 'title' ] !== '' && $item[ 'featured' ] == false ) {
+					if ( $item[ 'title' ] !== '' && empty( $item[ 'featured' ] ) ) {
 						$imageId = $item[ 'image_id' ] != 0 ? $item[ 'image_id' ] : null;
 						$ret[ ] = [
 							'title' => $item[ 'title' ],
@@ -404,7 +404,7 @@ class CuratedContentController extends WikiaController {
 		$content = F::app()->wg->WikiaCuratedContent;
 
 		self::purgeMethodVariants( 'getList', array_map( function ( $item ) {
-			if ( $item[ 'title' ] !== '' && $item[ 'featured' ] == false ) {
+			if ( $item[ 'title' ] !== '' && empty( $item[ 'featured' ] ) ) {
 				return [ 'section' => $item[ 'title' ] ];
 			}
 		}, $content ) );

--- a/extensions/wikia/CuratedContent/CuratedContentController.class.php
+++ b/extensions/wikia/CuratedContent/CuratedContentController.class.php
@@ -66,7 +66,7 @@ class CuratedContentController extends WikiaController {
 		//This will always return json
 		$this->response->setFormat( 'json' );
 
-		$this->cacheResponseFor( 7, self::DAYS );
+		$this->cacheResponseFor( 24, self::HOURS );
 
 		//set mobile skin as this is based on it
 		RequestContext::getMain()->setSkin(
@@ -86,12 +86,11 @@ class CuratedContentController extends WikiaController {
 
 			if ( $revId > 0 ) {
 				try {
-					$relatedPages =
-						$this->app->sendRequest( 'RelatedPagesApi', 'getList',
-							[
-								'ids' => [ $articleId ]
-							]
-						)->getVal( 'items' )[ $articleId ];
+					$relatedPages = $this->app->sendRequest(
+						'RelatedPagesApi',
+						'getList',
+						[ 'ids' => [ $articleId ] ]
+					)->getVal( 'items' )[ $articleId ];
 
 					if ( !empty( $relatedPages ) ) {
 						$this->response->setVal( 'relatedPages', $relatedPages );
@@ -102,15 +101,9 @@ class CuratedContentController extends WikiaController {
 
 				$this->response->setVal(
 					'html',
-					$this->sendSelfRequest( 'renderPage', array(
-							'page' => $titleName
-						)
-					)->toString() );
-
-				$this->response->setVal(
-					'revisionid',
-					$revId
+					$this->sendSelfRequest( 'renderPage', [ 'page' => $titleName ] )->toString()
 				);
+				$this->response->setVal( 'revisionid', $revId );
 			} else {
 				throw new NotFoundApiException( 'Revision ID = 0' );
 			}
@@ -192,7 +185,7 @@ class CuratedContentController extends WikiaController {
 			$scripts .= $s;
 		}
 
-		//getPage sets cache for a response for 7 days
+		//getPage sets cache for a response for 24 hours
 		$page = $this->sendSelfRequest( 'getPage', [
 			'page' => $this->getVal( 'page' )
 		] );
@@ -222,7 +215,7 @@ class CuratedContentController extends WikiaController {
 				$this->getSectionItems( $content, $section );
 			}
 
-			$this->cacheResponseFor( 14, self::DAYS );
+			$this->cacheResponseFor( 24, self::HOURS );
 		}
 
 		wfProfileOut( __METHOD__ );

--- a/extensions/wikia/CuratedContent/CuratedContentController.class.php
+++ b/extensions/wikia/CuratedContent/CuratedContentController.class.php
@@ -216,12 +216,13 @@ class CuratedContentController extends WikiaController {
 			$section = $this->request->getVal( 'section' );
 
 			if ( empty( $section ) ) {
-				$this->cacheResponseFor( 14, self::DAYS );
 				$this->getSections( $content );
 				$this->getFeaturedSection( $content );
 			} else {
 				$this->getSectionItems( $content, $section );
 			}
+
+			$this->cacheResponseFor( 14, self::DAYS );
 		}
 
 		wfProfileOut( __METHOD__ );
@@ -401,10 +402,26 @@ class CuratedContentController extends WikiaController {
 	 */
 	static function onCuratedContentSave() {
 		self::purgeMethod( 'getList' );
+		self::purgeSections();
+
 		if ( class_exists( 'GameGuidesController' ) ) {
 			GameGuidesController::purgeMethod( 'getList' );
 		}
+
 		return true;
+	}
+
+	/**
+	 * @brief Purges API response for every section
+	 */
+	private function purgeSections() {
+		$content = $this->wg->WikiaCuratedContent;
+
+		foreach ( $content as $item ) {
+			if ( $item[ 'title' ] !== '' && $item[ 'featured' ] == false ) {
+				self::purgeMethod( 'getList', [ 'section' => $item[ 'title' ] ] );
+			}
+		}
 	}
 }
 

--- a/extensions/wikia/CuratedContent/CuratedContentController.class.php
+++ b/extensions/wikia/CuratedContent/CuratedContentController.class.php
@@ -409,7 +409,7 @@ class CuratedContentController extends WikiaController {
 					// Purge section URLs using JavaScript encodeURIComponent() compatible standard,
 					// which works almost like rawurlencode(), but does not encode following characters: !'()*
 					// Mercury web app uses this variant.
-					$urls[ ] = self::getUrl( 'getList' ) . '&section=' . self::encodeURIComponent( $item[ 'title' ] );
+					$urls[ ] = self::getUrl( 'getList' ) . '&section=' . self::encodeURIQueryParam( $item[ 'title' ] );
 				}
 				return $urls;
 			},
@@ -429,13 +429,24 @@ class CuratedContentController extends WikiaController {
 	}
 
 	/**
-	 * @brief Emulates JavaScript URL encoding function
+	 * @brief Emulates JavaScript encodeURIComponent function.
 	 *
 	 * @param string $str
 	 * @return string
 	 */
 	private static function encodeURIComponent( $str ) {
 		return strtr( rawurlencode( $str ), [ '%21' => '!', '%27' => "'", '%28' => '(', '%29' => ')', '%2A' => '*' ] );
+	}
+
+	/**
+	 * @brief Similar to encodeURIComponent, but it's extended, so it also encodes single quote character as %27.
+	 * It's because raw ' does not function properly in query string params and it's auto-converted to %27.
+	 *
+	 * @param string $str
+	 * @return string
+	 */
+	private static function encodeURIQueryParam( $str ) {
+		return strtr( rawurlencode( $str ), [ '%21' => '!', '%28' => '(', '%29' => ')', '%2A' => '*' ] );
 	}
 }
 

--- a/extensions/wikia/CuratedContent/CuratedContentController.class.php
+++ b/extensions/wikia/CuratedContent/CuratedContentController.class.php
@@ -401,27 +401,19 @@ class CuratedContentController extends WikiaController {
 	 * @return bool
 	 */
 	static function onCuratedContentSave() {
-		self::purgeMethod( 'getList' );
-		self::purgeSections();
+		$content = F::app()->wg->WikiaCuratedContent;
+
+		self::purgeMethodVariants( 'getList', array_map( function ( $item ) {
+			if ( $item[ 'title' ] !== '' && $item[ 'featured' ] == false ) {
+				return [ 'section' => $item[ 'title' ] ];
+			}
+		}, $content ) );
 
 		if ( class_exists( 'GameGuidesController' ) ) {
 			GameGuidesController::purgeMethod( 'getList' );
 		}
 
 		return true;
-	}
-
-	/**
-	 * @brief Purges API response for every section
-	 */
-	private function purgeSections() {
-		$content = F::app()->wg->WikiaCuratedContent;
-
-		foreach ( $content as $item ) {
-			if ( $item[ 'title' ] !== '' && $item[ 'featured' ] == false ) {
-				self::purgeMethod( 'getList', [ 'section' => $item[ 'title' ] ] );
-			}
-		}
 	}
 }
 

--- a/extensions/wikia/CuratedContent/CuratedContentController.class.php
+++ b/extensions/wikia/CuratedContent/CuratedContentController.class.php
@@ -429,18 +429,9 @@ class CuratedContentController extends WikiaController {
 	}
 
 	/**
-	 * @brief Emulates JavaScript encodeURIComponent function.
-	 *
-	 * @param string $str
-	 * @return string
-	 */
-	private static function encodeURIComponent( $str ) {
-		return strtr( rawurlencode( $str ), [ '%21' => '!', '%27' => "'", '%28' => '(', '%29' => ')', '%2A' => '*' ] );
-	}
-
-	/**
-	 * @brief Similar to encodeURIComponent, but it's extended, so it also encodes single quote character as %27.
-	 * It's because raw ' does not function properly in query string params and it's auto-converted to %27.
+	 * @brief Similar to JavaScript encodeURIComponent, but it also encodes single quote character as %27.
+	 * It's because raw ' does not function properly in query string params and it's auto-converted to %27,
+	 * which break the purging.
 	 *
 	 * @param string $str
 	 * @return string

--- a/extensions/wikia/CuratedContent/CuratedContentController.class.php
+++ b/extensions/wikia/CuratedContent/CuratedContentController.class.php
@@ -411,13 +411,14 @@ class CuratedContentController extends WikiaController {
 					// Purge section URLs using JavaScript encodeURIComponent() compatible standard,
 					// which works almost like rawurlencode(), but does not encode following characters: !'()*
 					// Mercury web app uses this variant - request from Hapi.js to MediaWiki.
-					$urls[ ] = self::getUrl( 'getList' ) . '&section=' . self::encodeURIQueryParam( $item[ 'title' ] );
+					$javaScriptEncodedTitle = self::encodeURIQueryParam( $item[ 'title' ] );
+					$urls[ ] = self::getUrl( 'getList' ) . '&section=' . $javaScriptEncodedTitle;
 					// Mercury web app uses this variant - request from Ember.js to Hapi.js.
 					$urls[ ] =
 						$wgServer .
 						MercuryApiHooks::SERVICE_API_BASE .
 						MercuryApiHooks::SERVICE_API_CURATED_CONTENT .
-						self::encodeURIQueryParam( $item[ 'title' ] );
+						$javaScriptEncodedTitle;
 				}
 				return $urls;
 			},

--- a/extensions/wikia/MercuryApi/MercuryApiHooks.class.php
+++ b/extensions/wikia/MercuryApi/MercuryApiHooks.class.php
@@ -4,6 +4,7 @@ class MercuryApiHooks {
 
 	const SERVICE_API_BASE = '/api/v1/';
 	const SERVICE_API_ARTICLE = 'article/';
+	const SERVICE_API_CURATED_CONTENT = 'curatedContent/';
 
 	/**
 	 * @desc Get number of user's contribution from DB


### PR DESCRIPTION
It should be compatible with https://github.com/Wikia/mercury/pull/1001, but it seems that mercury is not so keen on caching these days. Nevertheless, stuff has to be purged, if it's cached it's changing afterwards.

Please CR. @Wikia/x-wing @owend @macbre 

:cat2: 
