### PR TITLE
CE-2103 Setting up a JS module and hiding the right rail module

### DIFF
--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -2473,3 +2473,11 @@ $config['sitemap_page_css'] = array(
 		'//extensions/wikia/SitemapPage/styles/SitemapPage.scss',
 	]
 );
+
+$config['template_draft'] = [
+	'type' => AssetsManager::TYPE_JS,
+	'assets' => [
+		'//extensions/wikia/TemplateDraft/scripts/rightRailModule.js',
+		'//extensions/wikia/TemplateDraft/scripts/templateDraft.run.js',
+	]
+];

--- a/extensions/wikia/TemplateDraft/TemplateConverter.class.php
+++ b/extensions/wikia/TemplateDraft/TemplateConverter.class.php
@@ -151,8 +151,8 @@ class TemplateConverter {
 		$docs = $preview;
 
 		foreach ( $variables as $var ) {
-			$preview .= "|{$var}=This is a test\n";
-			$docs .= "|{$var}=\n";
+			$preview .= "|{$var['name']}=This is a test\n";
+			$docs .= "|{$var['name']}=\n";
 		}
 
 		$preview .= "}}\n";

--- a/extensions/wikia/TemplateDraft/TemplateDraft.i18n.php
+++ b/extensions/wikia/TemplateDraft/TemplateDraft.i18n.php
@@ -33,7 +33,7 @@ to see this:
 
 $2
 
-[{{fullurl:PAGENAME}}?action=purge Click here to refresh the preview above]',
+[{{fullurl:{{ns:Template}}:{{PAGENAME}}}}?action=purge Click here to refresh the preview above]',
 ];
 
 /**

--- a/extensions/wikia/TemplateDraft/TemplateDraft.setup.php
+++ b/extensions/wikia/TemplateDraft/TemplateDraft.setup.php
@@ -30,6 +30,7 @@ $wgAutoloadClasses['TemplateDraftController'] = __DIR__ . '/controllers/Template
  * Hooks
  */
 $wgAutoloadClasses['TemplateDraftHooks'] = __DIR__ . '/TemplateDraftHooks.class.php';
+$wgHooks['SkinAfterBottomScripts'][] = 'TemplateDraftHooks::onSkinAfterBottomScripts';
 $wgHooks['GetRailModuleList'][] = 'TemplateDraftHooks::onGetRailModuleList';
 $wgHooks['EditFormPreloadText'][] = 'TemplateDraftHooks::onEditFormPreloadText';
 $wgHooks['EditPageLayoutShowIntro'][] = 'TemplateDraftHooks::onEditPageLayoutShowIntro';

--- a/extensions/wikia/TemplateDraft/TemplateDraft.setup.php
+++ b/extensions/wikia/TemplateDraft/TemplateDraft.setup.php
@@ -22,6 +22,18 @@ $wgExtensionCredits['other'][] = [
 $wgExtensionMessagesFiles['TemplateDraft'] = __DIR__ . '/TemplateDraft.i18n.php';
 
 /**
+ * Rights and permissions
+ */
+$wgAvailableRights[] = [ 'templatedraft' ];
+
+$wgGroupPermissions['*']['templatedraft'] = false;
+$wgGroupPermissions['util']['templatedraft'] = true;
+$wgGroupPermissions['staff']['templatedraft'] = true;
+$wgGroupPermissions['helper']['templatedraft'] = true;
+$wgGroupPermissions['vstf']['templatedraft'] = true;
+$wgGroupPermissions['voldev']['templatedraft'] = true;
+
+/**
  * Controllers
  */
 $wgAutoloadClasses['TemplateDraftController'] = __DIR__ . '/controllers/TemplateDraftController.class.php';

--- a/extensions/wikia/TemplateDraft/TemplateDraft.setup.php
+++ b/extensions/wikia/TemplateDraft/TemplateDraft.setup.php
@@ -32,6 +32,7 @@ $wgAutoloadClasses['TemplateDraftController'] = __DIR__ . '/controllers/Template
 $wgAutoloadClasses['TemplateDraftHooks'] = __DIR__ . '/TemplateDraftHooks.class.php';
 $wgHooks['GetRailModuleList'][] = 'TemplateDraftHooks::onGetRailModuleList';
 $wgHooks['EditFormPreloadText'][] = 'TemplateDraftHooks::onEditFormPreloadText';
+$wgHooks['SkinAfterBottomScripts'][] = 'TemplateDraftHooks::onSkinAfterBottomScripts';
 
 /**
  * Helpers

--- a/extensions/wikia/TemplateDraft/TemplateDraftHelper.class.php
+++ b/extensions/wikia/TemplateDraft/TemplateDraftHelper.class.php
@@ -9,9 +9,6 @@ class TemplateDraftHelper {
 	 * @return bool
 	 */
 	public function isTitleDraft( Title $title ) {
-		/**
-		 * TODO: Improve this check (i18n)
-		 */
 		return $title->getNamespace() === NS_TEMPLATE
 			&& $title->isSubpage()
 			&& ( $title->getSubpageText() === wfMessage( 'templatedraft-subpage' )->inContentLanguage()->escaped()

--- a/extensions/wikia/TemplateDraft/TemplateDraftHelper.class.php
+++ b/extensions/wikia/TemplateDraft/TemplateDraftHelper.class.php
@@ -3,6 +3,17 @@
 class TemplateDraftHelper {
 
 	/**
+	 * Checks if a Title is a new one and if it fits /Draft criteria.
+	 *
+	 * @param Title $title
+	 * @return bool
+	 */
+	public function isTitleNewDraft( Title $title ) {
+		return !$title->exists()
+			&& $this->isTitleDraft( $title );
+	}
+
+	/**
 	 * Checks if the Title object is a Draft subpage of a template
 	 *
 	 * @param Title $title

--- a/extensions/wikia/TemplateDraft/TemplateDraftHooks.class.php
+++ b/extensions/wikia/TemplateDraft/TemplateDraftHooks.class.php
@@ -2,10 +2,8 @@
 
 class TemplateDraftHooks {
 
-	public static function onSkinAfterBottomScripts( $skin, &$text ) {
-		global $wgTitle, $wgUser;
-
-		if ( $wgUser->isPowerUser() && $wgTitle->getNamespace() === NS_TEMPLATE ) {
+	public static function onSkinAfterBottomScripts( Skin $skin, &$text ) {
+		if ( $skin->getUser()->isPowerUser() && $skin->getTitle()->getNamespace() === NS_TEMPLATE ) {
 			$scripts = AssetsManager::getInstance()->getURL( 'template_draft' );
 
 			foreach ( $scripts as $script ) {

--- a/extensions/wikia/TemplateDraft/TemplateDraftHooks.class.php
+++ b/extensions/wikia/TemplateDraft/TemplateDraftHooks.class.php
@@ -8,7 +8,7 @@ class TemplateDraftHooks {
 		if ( $wgUser->isPowerUser() && $wgTitle->getNamespace() === NS_TEMPLATE ) {
 			$scripts = AssetsManager::getInstance()->getURL( 'template_draft' );
 
-			foreach( $scripts as $script ) {
+			foreach ( $scripts as $script ) {
 				$text .= Html::linkedScript( $script );
 			}
 		}
@@ -63,7 +63,7 @@ class TemplateDraftHooks {
 				 */
 				$controller = new TemplateDraftController();
 				$text = $controller->createDraftContent(
-					$title, // @TODO this is currently taking the *edited* title (with subpage), not the *converted* title  
+					$title, // @TODO this is currently taking the *edited* title (with subpage), not the *converted* title
 					$parentContent,
 					[ $controller::TEMPLATE_INFOBOX ]
 				);
@@ -77,7 +77,7 @@ class TemplateDraftHooks {
 	 * It adds an editintro message with help and links.
 	 *
 	 * @param String $msgName
-	 * @param Array $msgParams 
+	 * @param Array $msgParams
 	 * @param Title $title
 	 * @return bool
 	 */

--- a/extensions/wikia/TemplateDraft/TemplateDraftHooks.class.php
+++ b/extensions/wikia/TemplateDraft/TemplateDraftHooks.class.php
@@ -3,7 +3,9 @@
 class TemplateDraftHooks {
 
 	public static function onSkinAfterBottomScripts( Skin $skin, &$text ) {
-		if ( $skin->getUser()->isPowerUser() && $skin->getTitle()->getNamespace() === NS_TEMPLATE ) {
+		if ( $skin->getTitle()->userCan( 'templatedraft', $skin->getUser() )
+			&& $skin->getTitle()->getNamespace() === NS_TEMPLATE
+		) {
 			$scripts = AssetsManager::getInstance()->getURL( 'template_draft' );
 
 			foreach ( $scripts as $script ) {
@@ -21,10 +23,10 @@ class TemplateDraftHooks {
 	 * @return bool
 	 */
 	public static function onGetRailModuleList( Array &$railModuleList ) {
-		global $wgTitle, $wgUser;
+		global $wgTitle;
 		$helper = new TemplateDraftHelper();
 
-		if ( $wgUser->isPowerUser()
+		if ( $wgTitle->userCan( 'templatedraft' )
 			&& $wgTitle->getNamespace() === NS_TEMPLATE
 			&& $wgTitle->exists()
 			&& !$helper->isTitleDraft( $wgTitle )

--- a/extensions/wikia/TemplateDraft/TemplateDraftHooks.class.php
+++ b/extensions/wikia/TemplateDraft/TemplateDraftHooks.class.php
@@ -2,6 +2,20 @@
 
 class TemplateDraftHooks {
 
+	public static function onSkinAfterBottomScripts( $skin, &$text ) {
+		global $wgTitle;
+
+		if ( $wgTitle->getNamespace() === NS_TEMPLATE ) {
+			$scripts = AssetsManager::getInstance()->getURL( 'template_draft' );
+
+			foreach( $scripts as $script ) {
+				$text .= Html::linkedScript( $script );
+			}
+		}
+
+		return true;
+	}
+
 	/**
 	 * Attaches a new module to right rail which is an entry point to convert a given template.
 	 *
@@ -13,7 +27,7 @@ class TemplateDraftHooks {
 
 		if ( $wgTitle->getNamespace() === NS_TEMPLATE
 			&& $wgTitle->exists()
-			&& Wikia::getProps( $wgTitle->getArticleID(), TemplateDraftController::TEMPLATE_INFOBOX_PROP ) !== 0
+			&& Wikia::getProps( $wgTitle->getArticleID(), TemplateDraftController::TEMPLATE_INFOBOX_PROP ) !== '0'
 		) {
 			$railModuleList[1502] = [ 'TemplateDraftModule', 'Index', null ];
 		}

--- a/extensions/wikia/TemplateDraft/controllers/TemplateDraftController.class.php
+++ b/extensions/wikia/TemplateDraft/controllers/TemplateDraftController.class.php
@@ -35,4 +35,23 @@ class TemplateDraftController extends WikiaController {
 
 		return $newContent;
 	}
+
+	public function markTemplateAsNotInfobox() {
+		$requestParams = $this->getRequest()->getParams();
+
+		if ( empty( $requestParams['pageId'] )
+			|| !is_numeric( $requestParams['pageId'] )
+		) {
+			$this->response->setVal( 'status', false );
+		}
+		/**
+		 * Wikia::setProps unfortunately fails silently so if we get to this point
+		 * we can set the response's status to true anyway...
+		 */
+		$this->response->setVal( 'status', true );
+
+		Wikia::setProps( $requestParams['pageId'], [
+			self::TEMPLATE_INFOBOX_PROP => 0,
+		] );
+	}
 }

--- a/extensions/wikia/TemplateDraft/controllers/TemplateDraftController.class.php
+++ b/extensions/wikia/TemplateDraft/controllers/TemplateDraftController.class.php
@@ -47,7 +47,7 @@ class TemplateDraftController extends WikiaController {
 		$parentTitle = $helper->getParentTitle( $title );
 
 		// Check edit rights
-		if ( !$parentTitle->userCan( 'edit' ) ) {
+		if ( !$parentTitle->userCan( 'templatedraft' ) ) {
 			throw new PermissionsException( 'edit' );
 		}
 
@@ -64,7 +64,7 @@ class TemplateDraftController extends WikiaController {
 		/**
 		 * First, validate a request
 		 */
-		if ( !$this->wg->User->isPowerUser()
+		if ( !$this->wg->Title->userCan( 'templatedraft', $this->wg->User )
 			|| !$this->isValidPostRequest()
 		) {
 			$this->response->setVal( 'status', false );

--- a/extensions/wikia/TemplateDraft/controllers/TemplateDraftController.class.php
+++ b/extensions/wikia/TemplateDraft/controllers/TemplateDraftController.class.php
@@ -70,7 +70,8 @@ class TemplateDraftController extends WikiaController {
 	}
 
 	private function isValidPostRequest() {
+		$editToken = $this->getRequest()->getParams()['editToken'];
 		return $this->getRequest()->wasPosted()
-			&& $this->wg->User->matchEditToken( 'editToken' );
+			&& $this->wg->User->matchEditToken( $editToken );
 	}
 }

--- a/extensions/wikia/TemplateDraft/controllers/TemplateDraftController.class.php
+++ b/extensions/wikia/TemplateDraft/controllers/TemplateDraftController.class.php
@@ -37,21 +37,40 @@ class TemplateDraftController extends WikiaController {
 	}
 
 	public function markTemplateAsNotInfobox() {
-		$requestParams = $this->getRequest()->getParams();
-
-		if ( empty( $requestParams['pageId'] )
-			|| !is_numeric( $requestParams['pageId'] )
+		/**
+		 * First, validate a request
+		 */
+		if ( !$this->wg->User->isPowerUser()
+			|| !$this->isValidPostRequest()
 		) {
 			$this->response->setVal( 'status', false );
+			return false;
 		}
+
+		/**
+		 * Then check the pageId param
+		 */
+		$pageId = $this->getRequest()->getInt( 'pageId' );
+		if ( $pageId === 0 ) {
+			$this->response->setVal( 'status', false );
+			return false;
+		}
+
 		/**
 		 * Wikia::setProps unfortunately fails silently so if we get to this point
 		 * we can set the response's status to true anyway...
 		 */
 		$this->response->setVal( 'status', true );
 
-		Wikia::setProps( $requestParams['pageId'], [
+		Wikia::setProps( $pageId, [
 			self::TEMPLATE_INFOBOX_PROP => 0,
 		] );
+
+		return true;
+	}
+
+	private function isValidPostRequest() {
+		return $this->getRequest()->wasPosted()
+			&& $this->wg->User->matchEditToken( 'editToken' );
 	}
 }

--- a/extensions/wikia/TemplateDraft/scripts/rightRailModule.js
+++ b/extensions/wikia/TemplateDraft/scripts/rightRailModule.js
@@ -2,10 +2,9 @@ define(
 	'ext.wikia.templateDraft.rightRailModule',
 	[
 		'jquery',
-		'wikia.window',
-		'wikia.tracker'
+		'mw',
 	],
-	function ($, w) {
+	function ($, mw) {
 		'use strict';
 
 		function bindCloseModuleLink() {
@@ -20,7 +19,8 @@ define(
 				controller: 'TemplateDraftController',
 				method: 'markTemplateAsNotInfobox',
 				data: {
-					'pageId': w.wgArticleId
+					'pageId': mw.config.get('wgArticleId'),
+					'editToken': mw.user.tokens.get('editToken')
 				}
 			});
 		}

--- a/extensions/wikia/TemplateDraft/scripts/rightRailModule.js
+++ b/extensions/wikia/TemplateDraft/scripts/rightRailModule.js
@@ -1,0 +1,36 @@
+define(
+	'ext.wikia.templateDraft.rightRailModule',
+	[
+		'jquery',
+		'wikia.window',
+		'wikia.tracker'
+	],
+	function ($, w) {
+		'use strict';
+
+		function bindCloseModuleLink() {
+			$('.templatedraft-module-closelink-link')
+				.on('click', closeModule);
+		}
+
+		function closeModule() {
+			$('.templatedraft-module').hide();
+
+			$.nirvana.sendRequest({
+				controller: 'TemplateDraftController',
+				method: 'markTemplateAsNotInfobox',
+				data: {
+					'pageId': w.wgArticleId
+				}
+			});
+		}
+
+		function init() {
+			bindCloseModuleLink();
+		}
+
+		return {
+			init: init
+		};
+	}
+);

--- a/extensions/wikia/TemplateDraft/scripts/templateDraft.run.js
+++ b/extensions/wikia/TemplateDraft/scripts/templateDraft.run.js
@@ -1,0 +1,7 @@
+/**
+ * This file is executed on view of a page in a template namespace
+ */
+require(['ext.wikia.templateDraft.rightRailModule'], function (rightRailModule) {
+	'use strict';
+	rightRailModule.init();
+});

--- a/skins/oasis/modules/templates/TemplateDraftModule_Index.php
+++ b/skins/oasis/modules/templates/TemplateDraftModule_Index.php
@@ -8,6 +8,8 @@
 		</button>
 	</a>
 	<p class="templatedraft-module-closelink">
-		<a href="#"><?= wfMessage( 'templatedraft-module-closelink' )->escaped() ?></a>
+		<a class="templatedraft-module-closelink-link">
+			<?= wfMessage( 'templatedraft-module-closelink' )->escaped() ?>
+		</a>
 	</p>
 </section>


### PR DESCRIPTION
Hey @Wikia/community-engineering !

This PR sets up a JS module for the TemplateDraft extension. The first functionality is hiding the right rail module when a user clicks the "This is not an infobox" link. Clicking the link also triggers marking the template as a non-infobox one.

In this PR you can also find a few adjustments to hooked methods firing conditions and minor fixes to a  documentation message for Drafts.
