### PR TITLE
CE-2017: Adding flags to parser cache

### DIFF
--- a/extensions/wikia/Flags/Flags.setup.php
+++ b/extensions/wikia/Flags/Flags.setup.php
@@ -77,7 +77,6 @@ $wgAutoloadClasses['Flags\Hooks'] = __DIR__ . '/Flags.hooks.php';
 $wgHooks['ArticlePreviewAfterParse'][] = 'Flags\Hooks::onArticlePreviewAfterParse';
 $wgHooks['BeforePageDisplay'][] = 'Flags\Hooks::onBeforePageDisplay';
 $wgHooks['BeforeParserCacheSave'][] = 'Flags\Hooks::onBeforeParserCacheSave';
-$wgHooks['LinksUpdate'][] = 'Flags\Hooks::onLinksUpdate';
 $wgHooks['PageHeaderDropdownActions'][] = 'Flags\Hooks::onPageHeaderDropdownActions';
 $wgHooks['SkinTemplateNavigation'][] = 'Flags\Hooks::onSkinTemplateNavigation';
 

--- a/includes/WikiPage.php
+++ b/includes/WikiPage.php
@@ -840,10 +840,10 @@ class WikiPage extends Page {
 	 *               get the current revision (default value)
 	 * @return ParserOutput or false if the revision was not found
 	 */
-	public function getParserOutput( ParserOptions $parserOptions, $oldid = null ) {
+	public function getParserOutput( ParserOptions $parserOptions, $oldid = null, $fromCache = true ) {
 		wfProfileIn( __METHOD__ );
 
-		$useParserCache = $this->isParserCacheUsed( $parserOptions, $oldid );
+		$useParserCache = $this->isParserCacheUsed( $parserOptions, $oldid ) && $fromCache;
 		wfDebug( __METHOD__ . ': using parser cache: ' . ( $useParserCache ? 'yes' : 'no' ) . "\n" );
 		if ( $parserOptions->getStubThreshold() ) {
 			wfIncrStats( 'pcache_miss_stub' );
@@ -3019,6 +3019,7 @@ class PoolWorkArticleView extends PoolCounterWork {
 		}
 
 		if ( $this->cacheable && $this->parserOutput->isCacheable() ) {
+			wfRunHooks( 'BeforeParserCacheSave', [ $this->parserOutput, $this->page ] );
 			ParserCache::singleton()->save( $this->parserOutput, $this->page, $this->parserOptions );
 		}
 

--- a/includes/parser/ParserCache.php
+++ b/includes/parser/ParserCache.php
@@ -215,8 +215,6 @@ class ParserCache {
 	 */
 	public function save( ParserOutput $parserOutput, Page $article, ParserOptions $popts ) {
 
-		wfRunHooks( 'BeforeParserCacheSave', [ $parserOutput, $article ] );
-
 		$expire = $parserOutput->getCacheExpiry();
 
 		if( $expire > 0 ) {


### PR DESCRIPTION
@Wikia/community-engineering 

PLEASE DONT MERGE!

Hi guys,
I tried to find the root cause why categories and whatlinkshere weren't updated and probably I found it :) 

I think it's here: https://github.com/Wikia/app/blob/dev/extensions/wikia/Flags/controllers/FlagsController.class.php#L88. There was a lag between master and slaves, so sometimes we didn't get just added flags. Also, not always ParserCache was purged.

In my approach I'm using flags from form instead fetching them from db. And this code still needs some work - there are some hacks to check if it works. I'm sure there are things we can do better and more kosher.
