### PR TITLE
removeRenamedUser.php: remove fake user accounts created by RenameUser process

### DIFF
--- a/maintenance/wikia/RemoveUserBase.class.php
+++ b/maintenance/wikia/RemoveUserBase.class.php
@@ -1,0 +1,120 @@
+<?php
+
+/**
+ * Base class used by:
+ *  - removeTempUser.php
+ *  - removeRenamedUser.php
+ *
+ * @see PLATFORM-1146
+ * @see CE-1182
+ *
+ * @author Macbre
+ * @ingroup Maintenance
+ */
+
+require_once( __DIR__ . '/../Maintenance.php' );
+
+abstract class RemoveUserBase extends Maintenance {
+
+	const BATCH = 1000;
+
+	/**
+	 * Set script options
+	 */
+	public function __construct() {
+		parent::__construct();
+		$this->addOption( 'dry-run', 'Don\'t perform any operations' );
+		$this->addOption( 'db', 'User database to clean [defaults to shared DB]', false, true /* $withArg */ );
+	}
+
+	/**
+	 * Log helper
+	 *
+	 * @param string $msg
+	 * @param array $context
+	 */
+	private function info( $msg, Array $context = [] ) {
+		Wikia\Logger\WikiaLogger::instance()->info( $msg, $context );
+	}
+
+	/**
+	 * Get the list of user accounts to remove
+	 *
+	 * @param DatabaseBase $db
+	 * @return int[] array with user IDs to be removed
+	 */
+	abstract protected function getAccountsToRemove( DatabaseBase $db ) ;
+
+	/**
+	 * Remove a batch of users
+	 *
+	 * @param DatabaseBase $dbw
+	 * @param int[] $batch list of user IDs to remove
+	 */
+	private function removeBatch( DatabaseBase $dbw, Array $batch ) {
+		$rows = 0;
+		$dbw->begin( __METHOD__ );
+
+		// remove entries from user table
+		$dbw->delete( self::USER_TABLE,  [ 'user_id' => $batch ], __METHOD__ );
+		$rows += $dbw->affectedRows();
+
+		// remove entries from user_properties table
+		$dbw->delete( 'user_properties', [ 'up_user' => $batch ], __METHOD__ );
+		$rows += $dbw->affectedRows();
+
+		$dbw->commit( __METHOD__ );
+
+		$this->info( 'Batch removed', [
+			'batch' => count( $batch ),
+			'rows'  => $rows,
+		] );
+	}
+
+	public function execute() {
+		global $wgExternalSharedDB;
+		$db = $this->getOption( 'db', $wgExternalSharedDB );
+		$isDryRun = $this->hasOption( 'dry-run' );
+
+		$this->output( "Removing user accounts from '$db'...\n" );
+
+		$dbr = wfGetDB( DB_SLAVE, [], $db );
+		$dbw = wfGetDB( DB_MASTER, [], $db );
+
+		// get the list of accounts for remove
+		$users = $this->getAccountsToRemove( $dbr );
+		$this->output( "\nSQL used:            " . $dbr->lastQuery() );
+
+		// split accounts into batches and remove them
+		$batches = array_chunk( $users, self::BATCH );
+
+		$this->output( "\nAccounts found:      " . count( $users ) );
+		$this->output( "\nRemoving in batches: " . count( $batches ) );
+		$this->output( "\n\n" );
+
+		$this->info( 'Accounts found', [
+			'accounts' => count( $users ),
+			'batches'  => count( $batches ),
+		] );
+
+		if ( $isDryRun ) {
+			return;
+		}
+
+		$this->readconsole( "Hit enter to continue..." );
+
+		// close any open transaction
+		$dbw->commit( __METHOD__ );
+
+		foreach ( $batches as $batch ) {
+			/* @var int[] $batch */
+			$this->removeBatch( $dbw, $batch );
+
+			// prevent slave lag
+			// we're potentially performing deletes on all clusters
+			wfWaitForSlaves( $db );
+		}
+
+		$this->output( "\n\nDone!\n" );
+	}
+}

--- a/maintenance/wikia/RemoveUserBase.class.php
+++ b/maintenance/wikia/RemoveUserBase.class.php
@@ -6,6 +6,7 @@
  *  - removeRenamedUser.php
  *
  * @see PLATFORM-1146
+ * @see PLATFORM-1318
  * @see CE-1182
  *
  * @author Macbre
@@ -17,6 +18,7 @@ require_once( __DIR__ . '/../Maintenance.php' );
 abstract class RemoveUserBase extends Maintenance {
 
 	const BATCH = 1000;
+	const USER_TABLE = 'user';
 
 	/**
 	 * Set script options

--- a/maintenance/wikia/removeRenamedUser.php
+++ b/maintenance/wikia/removeRenamedUser.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Script that removes fake users created during RenameUser process
+ *
+ * @see PLATFORM-1318
+ * @see uncycloUsersMigrator.php
+ *
+ * @author Macbre
+ * @ingroup Maintenance
+ */
+
+require_once( __DIR__ . '/RemoveUserBase.class.php' );
+
+class RemoveRenamedAccounts extends RemoveUserBase {
+
+	const RENAMEDUSER_PROPERTY_PREFIX = 'renamed_to=W-';
+	const USER_PROPERTIES_TABLE = '`user_properties`';
+
+	protected $mDescription = 'This script removes fake user accounts created by RenameUser process';
+
+	/**
+	 * RenameUser process marks fake user accounts in user_properties table:
+	 *
+	 * select up_user, up_value from user_properties where  up_property = 'renameData' and up_value LIKE 'renamed_to=W-%' limit 15;
+	 *
+	 * @see https://github.com/Wikia/app/commit/14238c4bdace691da929b46a55012f152ac815fa
+	 *
+	 * @param DatabaseBase $db
+	 * @return int[]
+	 */
+	protected function getAccountsToRemove( DatabaseBase $db ) {
+		$users = $db->selectFieldValues(
+			self::USER_PROPERTIES_TABLE,
+			'up_user',
+			[
+				'up_property' => 'renameData',
+				'up_value ' . $db->buildLike( self::RENAMEDUSER_PROPERTY_PREFIX, $db->anyString() ),
+			],
+			__METHOD__
+		);
+
+		return $users;
+	}
+}
+
+$maintClass = "RemoveRenamedAccounts";
+require_once( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/wikia/removeTempUser.php
+++ b/maintenance/wikia/removeTempUser.php
@@ -10,33 +10,14 @@
  * @ingroup Maintenance
  */
 
-require_once( __DIR__ . '/../Maintenance.php' );
+require_once( __DIR__ . '/RemoveUserBase.class.php' );
 
-class RemoveTempUserAccounts extends Maintenance {
+class RemoveTempUserAccounts extends RemoveUserBase {
 
-	const BATCH = 1000;
 	const TEMPUSER_PREFIX = 'TempUser';
 	const USER_TABLE = '`user`';
 
-	/**
-	 * Set script options
-	 */
-	public function __construct() {
-		parent::__construct();
-		$this->addOption( 'dry-run', 'Don\'t perform any operations' );
-		$this->addOption( 'db', 'User database to clean [defaults to shared DB]', false, true /* $withArg */ );
-		$this->mDescription = 'This script removes TempUser accounts';
-	}
-
-	/**
-	 * Log helper
-	 *
-	 * @param string $msg
-	 * @param array $context
-	 */
-	private function info( $msg, Array $context = [] ) {
-		Wikia\Logger\WikiaLogger::instance()->info( $msg, $context );
-	}
+	protected $mDescription = 'This script removes TempUser accounts';
 
 	/**
 	 * Get temp user accounts
@@ -45,9 +26,9 @@ class RemoveTempUserAccounts extends Maintenance {
 	 * - do not remove accounts with password set (122 of them)
 	 *
 	 * @param DatabaseBase $db
-	 * @return array
+	 * @return int[]
 	 */
-	private function getTempUserAccounts( DatabaseBase $db ) {
+	protected function getAccountsToRemove( DatabaseBase $db ) {
 		$res = $db->select(
 			self::USER_TABLE,
 			[
@@ -73,77 +54,6 @@ class RemoveTempUserAccounts extends Maintenance {
 		}
 
 		return $users;
-	}
-
-	/**
-	 * Remove a batch of users
-	 *
-	 * @param DatabaseBase $dbw
-	 * @param array $batch list of user IDs to remove
-	 */
-	private function removeBatch( DatabaseBase $dbw, Array $batch ) {
-		$rows = 0;
-		$dbw->begin( __METHOD__ );
-
-		// remove entries from user table
-		$dbw->delete( self::USER_TABLE,  [ 'user_id' => $batch ], __METHOD__ );
-		$rows += $dbw->affectedRows();
-
-		// remove entries from user_properties table
-		$dbw->delete( 'user_properties', [ 'up_user' => $batch ], __METHOD__ );
-		$rows += $dbw->affectedRows();
-
-		$dbw->commit( __METHOD__ );
-
-		$this->info( 'Batch removed', [
-			'batch' => count( $batch ),
-			'rows'  => $rows,
-		] );
-	}
-
-	public function execute() {
-		global $wgExternalSharedDB;
-		$db = $this->getOption( 'db', $wgExternalSharedDB );
-		$isDryRun = $this->hasOption( 'dry-run' );
-
-		$this->output( "Removing temp user accounts from '$db'...\n" );
-
-		$dbr = wfGetDB( DB_SLAVE, [], $db );
-		$dbw = wfGetDB( DB_MASTER, [], $db );
-
-		// get the list of accounts for remove
-		$users = $this->getTempUserAccounts( $dbr );
-
-		// split accounts into batches and remove them
-		$batches = array_chunk( $users, self::BATCH );
-
-		$this->output( "\nAccounts found:      " . count( $users ) );
-		$this->output( "\nRemoving in batches: " . count( $batches ) );
-		$this->output( "\n\n" );
-
-		$this->info( 'Accounts found', [
-			'accounts' => count( $users ),
-			'batches'  => count( $batches ),
-		] );
-
-		if ( $isDryRun ) {
-			return;
-		}
-
-		$this->readconsole( "Hit enter to continue..." );
-
-		// close any open transaction
-		$dbw->commit( __METHOD__ );
-
-		foreach ( $batches as $batch ) {
-			$this->removeBatch( $dbw, $batch );
-
-			// prevent slave lag
-			// we're potentially performing deletes on all clusters
-			wfWaitForSlaves( $db );
-		}
-
-		$this->output( "\n\nDone!\n" );
 	}
 }
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-1318

We need to remove fake user accounts created when pre-migrating global accounts to make a room for Uncyclopedia accounts that will be moved to the shared users database.

```
macbre@dev-macbre:~/app/maintenance/wikia$ SERVER_ID=177 php removeRenamedUser.php --dry-run
Removing user accounts from 'wikicities'...

SQL used:            SELECT  up_user  FROM `user_properties`  WHERE up_property = 'renameData' AND (up_value  LIKE 'renamed\_to=W-%' )  
Accounts found:      723
Removing in batches: 1
```

@michalroszka / @wladekb 
