### PR TITLE
PLATFORM-1320 - AbPerformanceTesting: phase #2

### DIFF
--- a/extensions/wikia/AbPerformanceTesting/AbPerformanceTesting.setup.php
+++ b/extensions/wikia/AbPerformanceTesting/AbPerformanceTesting.setup.php
@@ -72,8 +72,9 @@ $wgAbPerformanceTestingExperiments = [];
 
 /**
  * Wikia\\AbPerformanceTesting\\Experiments\\BackendDelay
+ *
+ * Add a delay of 0 / 100 / 200 / 300 / 400 ms (for 1% of traffic each)
  */
-/**
 $wgAbPerformanceTestingExperiments['backend_delay_0'] = [
 	'handler' => 'Wikia\\AbPerformanceTesting\\Experiments\\BackendDelay',
 	'params' => [
@@ -117,12 +118,23 @@ $wgAbPerformanceTestingExperiments['backend_delay_3'] = [
 		'traffic' => [30, 39],
 	]
 ];
-**/
+
+$wgAbPerformanceTestingExperiments['backend_delay_4'] = [
+	'handler' => 'Wikia\\AbPerformanceTesting\\Experiments\\BackendDelay',
+	'params' => [
+		'delay' => 400,
+	],
+	'criteria' => [
+		'oasisArticles' => true,
+		'traffic' => [40, 49],
+	]
+];
 
 /**
  * Wikia\\AbPerformanceTesting\\Experiments\\FrontendDelay
+ *
+ * Add a delay of 0 / 200 / 400 / 600 / 800 ms (for 1% of traffic each)
  */
-/**
 $wgAbPerformanceTestingExperiments['frontend_delay_0'] = [
 	'handler' => 'Wikia\\AbPerformanceTesting\\Experiments\\FrontendDelay',
 	'params' => [
@@ -137,7 +149,7 @@ $wgAbPerformanceTestingExperiments['frontend_delay_0'] = [
 $wgAbPerformanceTestingExperiments['frontend_delay_1'] = [
 	'handler' => 'Wikia\\AbPerformanceTesting\\Experiments\\FrontendDelay',
 	'params' => [
-		'delay' => 100,
+		'delay' => 200,
 	],
 	'criteria' => [
 		'oasisArticles' => true,
@@ -148,7 +160,7 @@ $wgAbPerformanceTestingExperiments['frontend_delay_1'] = [
 $wgAbPerformanceTestingExperiments['frontend_delay_2'] = [
 	'handler' => 'Wikia\\AbPerformanceTesting\\Experiments\\FrontendDelay',
 	'params' => [
-		'delay' => 200,
+		'delay' => 400,
 	],
 	'criteria' => [
 		'oasisArticles' => true,
@@ -159,11 +171,21 @@ $wgAbPerformanceTestingExperiments['frontend_delay_2'] = [
 $wgAbPerformanceTestingExperiments['frontend_delay_3'] = [
 	'handler' => 'Wikia\\AbPerformanceTesting\\Experiments\\FrontendDelay',
 	'params' => [
-		'delay' => 300,
+		'delay' => 600,
 	],
 	'criteria' => [
 		'oasisArticles' => true,
 		'traffic' => [530, 539],
 	]
 ];
-**/
+
+$wgAbPerformanceTestingExperiments['frontend_delay_4'] = [
+	'handler' => 'Wikia\\AbPerformanceTesting\\Experiments\\FrontendDelay',
+	'params' => [
+		'delay' => 800,
+	],
+	'criteria' => [
+		'oasisArticles' => true,
+		'traffic' => [540, 549],
+	]
+];


### PR DESCRIPTION
- backend: Add a delay of 0 / 100 / 200 / 300 / 400 ms (for 1% of traffic each)
- frontend: Add a delay of 0 / 200 / 400 / 600 / 800 ms (for 1% of traffic each)

And enable on all wikis - https://github.com/Wikia/config/pull/1182

Merging into release branch only as we want to run the test during the upcoming weekend only.

@jcellary / @wladekb 
