### PR TITLE
return correct authentication method from helios

### DIFF
--- a/extensions/wikia/Helios/Helios.setup.php
+++ b/extensions/wikia/Helios/Helios.setup.php
@@ -30,6 +30,8 @@ $wgExtensionMessagesFiles['Helios'] = __DIR__ . '/Helios.i18n.php';
  * Hooks
  */
 $wgHooks['UserCheckPassword'][] = 'Wikia\\Helios\\User::onUserCheckPassword';
+$wgHooks['UserCheckPassword'][] = 'Wikia\\Helios\\User::onUserCheckPassword';
+$wgHooks['LoginSuccessModifyRetval'][] = 'Wikia\\Helios\\User::onLoginSuccessModifyRetval';
 $wgHooks['ExternalUserWikiaAuthenticate'][] = 'Wikia\\Helios\\User::onUserCheckPassword';
 
 $wgHooks['UserSaveSettings'][] = 'Wikia\\Helios\\User::onUserSave';

--- a/extensions/wikia/Helios/User.class.php
+++ b/extensions/wikia/Helios/User.class.php
@@ -2,6 +2,7 @@
 
 namespace Wikia\Helios;
 
+use LoginForm;
 use Wikia\Logger\WikiaLogger;
 
 /**
@@ -10,7 +11,12 @@ use Wikia\Logger\WikiaLogger;
 class User {
 
 	const ACCESS_TOKEN_COOKIE_NAME = 'access_token';
+	const AUTH_METHOD_NAME = 'auth_method';
 	const MERCURY_ACCESS_TOKEN_COOKIE_NAME = 'sid';
+	const AUTH_TYPE_FAILED = 0;
+	const AUTH_TYPE_NORMAL_PW = 1;
+	const AUTH_TYPE_RESET_PW = 2;
+	const AUTH_TYPE_FB_TOKEN = 4;
 
 	// This is set to 6 months,(365/2)*24*60*60 = 15768000
 	const ACCESS_TOKEN_COOKIE_TTL = 15768000;
@@ -143,6 +149,7 @@ class User {
 		$heliosClient = new Client( $wgHeliosBaseUri, $wgHeliosClientId, $wgHeliosClientSecret );
 
 		$result = false;
+		$authMethod = self::AUTH_TYPE_FAILED;
 		$throwException = null;
 
 		// Authenticate with username and password.
@@ -161,6 +168,7 @@ class User {
 			}
 
 			$result = !empty( $loginInfo->access_token );
+			$authMethod = $loginInfo->auth_method;
 		}
 		catch ( ClientException $e ) {
 			$logger->error(
@@ -173,7 +181,8 @@ class User {
 		// save in local cache
 		self::$authenticationCache[$username][$password] = [
 			'result' => $result,
-			'exception' => $throwException
+			'exception' => $throwException,
+			self::AUTH_METHOD_NAME => $authMethod,
 		];
 
 		if ( $throwException ) {
@@ -277,6 +286,23 @@ class User {
 			}
 
 			$result = $heliosResult;
+		}
+
+		return true;
+	}
+
+	public static function onLoginSuccessModifyRetval($username, $password, &$retval) {
+		if ( isset( self::$authenticationCache[$username][$password][self::AUTH_METHOD_NAME] ) ) {
+			$resultData = self::$authenticationCache[$username][$password];
+
+			switch ($resultData[ self::AUTH_METHOD_NAME ]) {
+				case self::AUTH_TYPE_RESET_PW:
+					$retval = \LoginForm::RESET_PASS;
+					break;
+				case self::AUTH_TYPE_NORMAL_PW:
+					$retval = \LoginForm::SUCCESS;
+					break;
+			}
 		}
 
 		return true;

--- a/extensions/wikia/Helios/User.class.php
+++ b/extensions/wikia/Helios/User.class.php
@@ -168,7 +168,7 @@ class User {
 			}
 
 			$result = !empty( $loginInfo->access_token );
-			$authMethod = $loginInfo->auth_method;
+			$authMethod = isset($loginInfo->auth_method) ? $loginInfo->auth_method : self::AUTH_TYPE_NORMAL_PW;
 		}
 		catch ( ClientException $e ) {
 			$logger->error(

--- a/includes/specials/SpecialUserlogin.php
+++ b/includes/specials/SpecialUserlogin.php
@@ -721,27 +721,6 @@ class LoginForm extends SpecialPage {
 				return self::ABORTED;
 			}
 			if( $u->checkTemporaryPassword( $this->mPassword ) ) {
-				// The e-mailed temporary password should not be used for actu-
-				// al logins; that's a very sloppy habit, and insecure if an
-				// attacker has a few seconds to click "search" on someone's o-
-				// pen mail reader.
-				//
-				// Allow it to be used only to reset the password a single time
-				// to a new value, which won't be in the user's e-mail ar-
-				// chives.
-				//
-				// For backwards compatibility, we'll still recognize it at the
-				// login form to minimize surprises for people who have been
-				// logging in with a temporary password for some time.
-				//
-				// As a side-effect, we can authenticate the user's e-mail ad-
-				// dress if it's not already done, since the temporary password
-				// was sent via e-mail.
-				if( !$u->isEmailConfirmed() ) {
-					$u->confirmEmail();
-					$u->saveSettings();
-				}
-
 				// At this point we just return an appropriate code/ indicating
 				// that the UI should show a password reset form; bot inter-
 				// faces etc will probably just fail cleanly here.
@@ -753,27 +732,68 @@ class LoginForm extends SpecialPage {
 			// If we've enabled it, make it so that a blocked user cannot login
 			$retval = self::USER_BLOCKED;
 		} else {
-			$wgAuth->updateUser( $u );
-			$wgUser = $u;
-			// This should set it for OutputPage and the Skin
-			// which is needed or the personal links will be
-			// wrong.
-			$this->getContext()->setUser( $u );
-
-			// Please reset throttle for successful logins, thanks!
-			if ( $throttleCount ) {
-				self::clearLoginThrottle( $this->mUsername );
-			}
-
-			if ( $isAutoCreated ) {
-				// Must be run after $wgUser is set, for correct new user log
-				wfRunHooks( 'AuthPluginAutoCreate', array( $u ) );
-			}
-
 			$retval = self::SUCCESS;
 		}
+
+		if ( in_array( $retval, [ self::SUCCESS, self::RESET_PASS ] ) ) {
+			wfRunHooks( 'LoginSuccessModifyRetval', [ $u->getName(), $this->mPassword, &$retval ] );
+		}
+
+		switch ($retval) {
+			case self::SUCCESS:
+				$this->onAuthenticateUserDataSuccess($u, $isAutoCreated, $throttleCount);
+				break;
+			case self::RESET_PASS:
+				$this->onAuthenticateUserDataResetPass($u);
+				break;
+		}
+
 		wfRunHooks( 'LoginAuthenticateAudit', array( $u, $this->mPassword, $retval ) );
 		return $retval;
+	}
+
+	private function onAuthenticateUserDataSuccess(User $u, $isAutoCreated, $throttleCount) {
+		global $wgAuth, $wgUser;
+
+		$wgAuth->updateUser( $u );
+		$wgUser = $u;
+		// This should set it for OutputPage and the Skin
+		// which is needed or the personal links will be
+		// wrong.
+		$this->getContext()->setUser( $u );
+
+		// Please reset throttle for successful logins, thanks!
+		if ( $throttleCount ) {
+			self::clearLoginThrottle( $this->mUsername );
+		}
+
+		if ( $isAutoCreated ) {
+			// Must be run after $wgUser is set, for correct new user log
+			wfRunHooks( 'AuthPluginAutoCreate', array( $u ) );
+		}
+	}
+
+	private function onAuthenticateUserDataResetPass(User $u) {
+		// The e-mailed temporary password should not be used for actu-
+		// al logins; that's a very sloppy habit, and insecure if an
+		// attacker has a few seconds to click "search" on someone's o-
+		// pen mail reader.
+		//
+		// Allow it to be used only to reset the password a single time
+		// to a new value, which won't be in the user's e-mail ar-
+		// chives.
+		//
+		// For backwards compatibility, we'll still recognize it at the
+		// login form to minimize surprises for people who have been
+		// logging in with a temporary password for some time.
+		//
+		// As a side-effect, we can authenticate the user's e-mail ad-
+		// dress if it's not already done, since the temporary password
+		// was sent via e-mail.
+		if( !$u->isEmailConfirmed() ) {
+			$u->confirmEmail();
+			$u->saveSettings();
+		}
 	}
 
 	/**


### PR DESCRIPTION
@Wikia/services-team 
https://wikia-inc.atlassian.net/browse/SERVICES-439

Allow Helios to modify the return value for authentication in `SpecialUserLogin->authenticateUserData`. This was done via hook to avoid breaking the return values between the various authentication functions and hooks, which expect `true`/`false` as return types. 

~~Wikia/helios#78 should be merged/deployed first~~
