### PR TITLE
(CE-2214) Fix ArticleAsJson output when a page has Flags

### DIFF
--- a/extensions/wikia/Flags/controllers/FlagsController.class.php
+++ b/extensions/wikia/Flags/controllers/FlagsController.class.php
@@ -75,14 +75,29 @@ class FlagsController extends WikiaController {
 			return $parserOutput;
 		}
 
+		$pageText = $parserOutput->getText();
+		$flagsText = $flagsParserOutput->getText();
+
+		if ( $this->wg->ArticleAsJson ) {
+			$pageOutput = json_decode( $pageText, true );
+			$pageText = $pageOutput['content'];
+		}
+
 		/**
 		 * Update the mText of the original ParserOutput object and merge other properties
 		 */
-		if ( $mwf->match( $parserOutput->getText() ) ) {
-			$parserOutput->setText( $mwf->replace( $flagsParserOutput->getText(), $parserOutput->getText() ) );
+		if ( $mwf->match( $pageText ) ) {
+			$pageText = $mwf->replace( $flagsText, $pageText );
 		} else {
-			$parserOutput->setText( $flagsParserOutput->getText() . $parserOutput->getText() );
+			$pageText = $flagsText . $pageText;
 		}
+
+		if ( $this->wg->ArticleAsJson ) {
+			$pageOutput['content'] = $pageText;
+			$pageText = json_encode( $pageOutput );
+		}
+
+		$parserOutput->setText( $pageText );
 
 		$parserOutput->mergeExternalParserOutputVars( $flagsParserOutput );
 


### PR DESCRIPTION
ArticleAsJson modifies the ParserOutput before we do, and converts it to
JSON. As a quick fix, this handles this situation when modifying the
parser output.

We'll soon take flags out of the content for Mercury and have them handled
in their own component, but we'll also follow this up with investigating alternative
places to modify the parser output.

/cc @Wikia/community-engineering @rogatty 
