### PR TITLE
UncycloUserMigrator: authenticate all accounts that come from Uncyclopedia

### DIFF
--- a/maintenance/wikia/uncycloUsersMigrator.php
+++ b/maintenance/wikia/uncycloUsersMigrator.php
@@ -495,6 +495,8 @@ class UncycloUserMigrator extends Maintenance {
 						'user_token' => '',
 						'user_options' => '',
 						'user_registration' => $dbw->timestamp($user->mRegistration),
+						// avoid Uncyclopedia users be deleted by the cleanup script removing accounts without verified email address
+						'user_email_authenticated' => $dbw->timestamp($user->mRegistration),
 						'user_editcount' => $user->getEditCount(), // use uncyclo counter
 						'user_birthdate' => $user->mBirthDate
 					],


### PR DESCRIPTION
Avoid Uncyclopedia users be deleted by the cleanup script removing accounts without verified email address (`/extensions/wikia/UserLogin/maintenance.php`).

``` sql
mysql@x.x.x.x[uncyclo]>select count(*) from user where user_email_authenticated is null;
+----------+
| count(*) |
+----------+
|   112559 |
+----------+
1 row in set (0.07 sec)
```

@michalroszka 
