### PR TITLE
CE-2240 Link items to view pages of templates

### DIFF
--- a/extensions/wikia/Insights/models/InsightsUnconvertedInfoboxesModel.php
+++ b/extensions/wikia/Insights/models/InsightsUnconvertedInfoboxesModel.php
@@ -38,6 +38,14 @@ class InsightsUnconvertedInfoboxesModel extends InsightsQuerypageModel {
 		return false;
 	}
 
+	/**
+	 * Get a type of a subpage only, we want a user to be directed to view.
+	 * @return array
+	 */
+	public function getUrlParams() {
+		return $this->getInsightParam();
+	}
+
 	public function hasAltAction() {
 		return class_exists( 'TemplateConverter' );
 	}


### PR DESCRIPTION
@Wikia/community-engineering 

By overwriting the parent `getUrlParams` method, we get links to view pages on non-portable infoboxes Insights list.

@lgarczewski 
