### PR TITLE
[SERVICES-487] Extended time to 60 days before unconfirmed accounts are removed

### DIFF
--- a/extensions/wikia/UserLogin/maintenance.php
+++ b/extensions/wikia/UserLogin/maintenance.php
@@ -110,7 +110,7 @@
 				'user_email_authenticated' => NULL,
 				'up_property' => UserLoginSpecialController::NOT_CONFIRMED_SIGNUP_OPTION_NAME,
 				'up_value' => 1,
-				'date(user_registration) < curdate() - interval 30 day'
+				'date(user_registration) < curdate() - interval 60 day'
 			),
 			__METHOD__,
 			array(),


### PR DESCRIPTION
Before we provide final solution for user account removal, I'm extending time interval to 60 days, so we won't remove any more unconfirmed accounts that are active.

/cc @Wikia/services-team @garthwebb @kvas-damian @macbre 
