### PR TITLE
CE-2263 Fix removing flags if there are no parameters assigned

### DIFF
--- a/extensions/wikia/Flags/controllers/FlagsController.class.php
+++ b/extensions/wikia/Flags/controllers/FlagsController.class.php
@@ -243,7 +243,7 @@ class FlagsController extends WikiaController {
 	private function getFlagsForParserOutput( $currentFlags, $pageId ) {
 		$flagsOnPage = [];
 
-		foreach( $this->editFlags as $flagTypeId => $flag ) {
+		foreach ( $this->editFlags as $flagTypeId => $flag ) {
 			if ( isset( $flag[FlagsHelper::FLAGS_INPUT_NAME_CHECKBOX] ) ) {
 				$flagsOnPage[$flagTypeId] = $this->getFlagsHelper()->getFlagFromPostData(
 					$currentFlags[$flagTypeId],
@@ -273,9 +273,9 @@ class FlagsController extends WikiaController {
 				$flags = $this->getResponseData( $response );
 
 				return $this->getParsedFlags( $flags, $pageId );
-			} else {
-				return null;
 			}
+
+			return null;
 		} catch ( Exception $exception ) {
 			$this->logResponseException( $exception, $response->getRequest() );
 		}

--- a/extensions/wikia/Flags/controllers/FlagsController.class.php
+++ b/extensions/wikia/Flags/controllers/FlagsController.class.php
@@ -37,7 +37,7 @@ class FlagsController extends WikiaController {
 
 	private
 		$helper,
-		$postedFlags;
+		$editFlags;
 
 	public function init() {
 		global $wgLang;
@@ -181,9 +181,9 @@ class FlagsController extends WikiaController {
 			 * Get the current status to compare
 			 */
 			$currentFlags = $this->getResponseData( $this->requestGetFlagsForPageForEdit( $pageId ) );
-			$this->postedFlags = $this->request->getArray( 'editFlags' );
+			$this->editFlags = $this->request->getArray( 'editFlags' );
 
-			$flagsToChange = $this->getFlagsHelper()->compareDataAndGetFlagsToChange( $currentFlags, $this->postedFlags );
+			$flagsToChange = $this->getFlagsHelper()->compareDataAndGetFlagsToChange( $currentFlags, $this->editFlags );
 
 			if ( !empty( $flagsToChange ) ) {
 				$this->sendRequestsUsingPostedData( $pageId, $flagsToChange );
@@ -243,11 +243,11 @@ class FlagsController extends WikiaController {
 	private function getFlagsForParserOutput( $currentFlags, $pageId ) {
 		$flagsOnPage = [];
 
-		foreach( $this->postedFlags as $flagTypeId => $flag ) {
+		foreach( $this->editFlags as $flagTypeId => $flag ) {
 			if ( isset( $flag[FlagsHelper::FLAGS_INPUT_NAME_CHECKBOX] ) ) {
 				$flagsOnPage[$flagTypeId] = $this->getFlagsHelper()->getFlagFromPostData(
 					$currentFlags[$flagTypeId],
-					$this->postedFlags
+					$this->editFlags
 				);
 
 				$flagsOnPage[$flagTypeId]['flag_targeting'] = $currentFlags[$flagTypeId]['flag_targeting'];


### PR DESCRIPTION
@Wikia/community-engineering 

The PR prevents passing a `null` to `compareDataAndGetFlagsToChange` which causes an error.
`null` is sent from the edit form if no flag type on a given wikia has a parameter assigned and no flags are checked in the form. Casting `null` to `array` sends an empty array to the method and everything works fine.
