### PR TITLE
DAT-3002 Use wfMemcKey instead of manual implode

### DIFF
--- a/includes/wikia/GlobalTitle.php
+++ b/includes/wikia/GlobalTitle.php
@@ -122,7 +122,7 @@ class GlobalTitle extends Title {
 			throw new \Exception( 'Invalid $city_id.' );
 		}
 
-		$memkey = sprintf( "GlobalTitle:%d:%d", $id, $city_id );
+		$memkey = wfSharedMemcKey( "GlobalTitle", $id, $city_id );
 		$res = $wgMemc->get( $memkey );
 		if ( empty($res) && WikiFactory::isPublic($city_id) ) {
 			$dbname = ( $dbname ) ? $dbname : WikiFactory::IDtoDB($city_id);

--- a/includes/wikia/models/NavigationModel.class.php
+++ b/includes/wikia/models/NavigationModel.class.php
@@ -83,8 +83,7 @@ class NavigationModel extends WikiaModel {
 	 */
 	private function getMemcKey( $messageName, $cityId = false ) {
 		if ( $this->useSharedMemcKey ) {
-			$wikiId = substr( wfSharedMemcKey(), 0, -1 );
-
+			$wikiId = wfWikiID();
 		} else {
 			$wikiId = ( is_numeric($cityId)) ? $cityId : intval( $this->wg->CityId );
 
@@ -96,7 +95,7 @@ class NavigationModel extends WikiaModel {
 
 		$messageName = str_replace(' ', '_', $messageName);
 
-		return wfMemcKey( __CLASS__, $wikiId, $this->wg->Lang->getCode(), $messageName, self::version );
+		return wfSharedMemcKey( __CLASS__, $wikiId, $this->wg->Lang->getCode(), $messageName, self::version );
 	}
 
 	public function clearMemc( $key = self::WIKIA_GLOBAL_VARIABLE, $city_id = false ){

--- a/includes/wikia/models/NavigationModel.class.php
+++ b/includes/wikia/models/NavigationModel.class.php
@@ -96,7 +96,7 @@ class NavigationModel extends WikiaModel {
 
 		$messageName = str_replace(' ', '_', $messageName);
 
-		return implode( ':', array( __CLASS__, $wikiId, $this->wg->Lang->getCode(), $messageName, self::version ) );
+		return wfMemcKey( __CLASS__, $wikiId, $this->wg->Lang->getCode(), $messageName, self::version );
 	}
 
 	public function clearMemc( $key = self::WIKIA_GLOBAL_VARIABLE, $city_id = false ){


### PR DESCRIPTION
This PR fixes manually constructing of memcache keys that causes crosstalk between staging and production environments for both the global nav and GlobalTitle in general.
