### PR TITLE
SOC-788 Make sure text field always contains most recent comment

### DIFF
--- a/extensions/wikia/ArticleComments/js/ArticleComments.js
+++ b/extensions/wikia/ArticleComments/js/ArticleComments.js
@@ -146,7 +146,6 @@
 						$textfield = $(textfieldSelector);
 						if (ArticleComments.miniEditorEnabled) {
 							ArticleComments.editorInit($textfield, content, json.edgeCases);
-
 						} else {
 							$textfield.val(content);
 						}
@@ -246,6 +245,7 @@
 
 							// Update DOM with information from saveTemplate
 							commentText.html(saveTemplateText.html()).show();
+							$textfield.val(content);
 
 							// fire event when new article comment is/will be added to DOM
 							mw.hook('wikipage.content').fire(commentText);


### PR DESCRIPTION
The mini editor used for article comments pulls its content from a hidden textarea, which is supposed to contain the latest content of a comment text. This change makes sure that textarea is always filled with the most recent edited version of the comment.

https://wikia-inc.atlassian.net/browse/SOC-788

@jsutterfield @garthwebb 
