### PR TITLE
CE-2299 Do not display a fix message for nonportable infoboxes

### DIFF
--- a/extensions/wikia/Insights/InsightsController.class.php
+++ b/extensions/wikia/Insights/InsightsController.class.php
@@ -54,7 +54,7 @@ class InsightsController extends WikiaSpecialPageController {
 		 * - getData() - returning all the helping data
 		 * - getTemplate() - returning an overriding template
 		 */
-		if ( $this->model instanceof InsightsModel ) {
+		if ( $this->model instanceof InsightsQuerypageModel ) {
 			$params = $this->request->getParams();
 			$this->content = $this->model->getContent( $params );
 			$this->preparePagination();
@@ -62,7 +62,7 @@ class InsightsController extends WikiaSpecialPageController {
 			$this->data = $this->model->getViewData();
 			$this->overrideTemplate( $this->model->getTemplate() );
 		} else {
-			throw new MWException( 'An Insights subpage should implement the InsightsModel interface.' );
+			throw new MWException( 'An Insights subpage should implement the InsightsQuerypageModel interface.' );
 		}
 	}
 
@@ -74,7 +74,7 @@ class InsightsController extends WikiaSpecialPageController {
 
 		if ( InsightsHelper::isInsightPage( $subpage ) ) {
 			$model = InsightsHelper::getInsightModel( $subpage );
-			if ( $model instanceof InsightsModel ) {
+			if ( $model instanceof InsightsQuerypageModel ) {
 				$params = [];
 				$type = '';
 				$isFixed = false;
@@ -122,7 +122,7 @@ class InsightsController extends WikiaSpecialPageController {
 	/**
 	 * Get params for notification template shown in edit mode
 	 *
-	 * @param String $subpage Insights subpage
+	 * @param string $subpage Insights subpage
 	 * @param InsightsQuerypageModel $model
 	 * @return array
 	 */
@@ -140,7 +140,7 @@ class InsightsController extends WikiaSpecialPageController {
 	/**
 	 * Get params for notification template shownwhen user dont fix an issue
 	 *
-	 * @param String $subpage Insights subpage
+	 * @param string $subpage Insights subpage
 	 * @param Title $title
 	 * @param InsightsQuerypageModel $model
 	 * @return array
@@ -170,8 +170,8 @@ class InsightsController extends WikiaSpecialPageController {
 	/**
 	 * Get params for notification template shown when user fix one issue from the insights list
 	 *
-	 * @param String $subpage Insights subpage
-	 * @param $next
+	 * @param string $subpage Insights subpage
+	 * @param array $next An array with a url and text for a link to the next item
 	 * @return array
 	 */
 	private function getInsightFixedNotificationParams( $subpage, $next ) {
@@ -186,7 +186,7 @@ class InsightsController extends WikiaSpecialPageController {
 	 * Get params to generate next item link in notification template
 	 *
 	 * @param String $subpage Insights subpage
-	 * @param $next
+	 * @param array $next An array with a url and text for a link to the next item
 	 * @return array
 	 */
 	private function getInsightNextLinkParams( $subpage, $next ) {
@@ -201,10 +201,10 @@ class InsightsController extends WikiaSpecialPageController {
 	 * Get params to generate link back to edit mode
 	 *
 	 * @param Title $title
-	 * @param InsightsModel $model
+	 * @param InsightsQuerypageModel $model
 	 * @return array
 	 */
-	private function getInsightFixItParams( Title $title, InsightsModel $model ) {
+	private function getInsightFixItParams( Title $title, InsightsQuerypageModel $model ) {
 		$link = InsightsHelper::getTitleLink( $title, $model->getUrlParams() );
 
 		return [

--- a/extensions/wikia/Insights/InsightsController.class.php
+++ b/extensions/wikia/Insights/InsightsController.class.php
@@ -92,7 +92,7 @@ class InsightsController extends WikiaSpecialPageController {
 				}
 
 				if ( $isEdit ) {
-					$params = $this->getInProgressNotificationParams( $subpage );
+					$params = $this->getInProgressNotificationParams( $subpage, $model );
 					$type = self::FLOW_STATUS_INPROGRESS;
 				} elseif ( !$isFixed ) {
 					$params = $this->getNotFixedNotificationParams( $subpage, $title, $model );
@@ -123,11 +123,16 @@ class InsightsController extends WikiaSpecialPageController {
 	 * Get params for notification template shown in edit mode
 	 *
 	 * @param String $subpage Insights subpage
+	 * @param InsightsQuerypageModel $model
+	 * @return array
 	 */
-	private function getInProgressNotificationParams( $subpage ) {
+	private function getInProgressNotificationParams( $subpage, InsightsQuerypageModel $model ) {
 		$params = $this->getInsightListLinkParams( $subpage );
-		$params['notificationMessage'] = wfMessage( InsightsHelper::INSIGHT_INPROGRESS_MSG_PREFIX . $subpage )->plain()
-			. ' ' . wfMessage( 'insights-notification-message-fixit' )->plain();
+		$params['notificationMessage'] = wfMessage( InsightsHelper::INSIGHT_INPROGRESS_MSG_PREFIX . $subpage )->plain();
+
+		if ( $model->getLoopNotificationConfig( 'displayFixItMessage' ) ) {
+			$params['fixItMessage'] = wfMessage( 'insights-notification-message-fixit' )->plain();
+		}
 
 		return $params;
 	}
@@ -137,11 +142,16 @@ class InsightsController extends WikiaSpecialPageController {
 	 *
 	 * @param String $subpage Insights subpage
 	 * @param Title $title
-	 * @param InsightsModel $model
+	 * @param InsightsQuerypageModel $model
+	 * @return array
 	 */
-	private function getNotFixedNotificationParams( $subpage, Title $title, InsightsModel $model ) {
-		$params = $this->getInsightFixItParams( $title, $model );
-		$params = array_merge( $params, $this->getInsightListLinkParams( $subpage ) );
+	private function getNotFixedNotificationParams( $subpage, Title $title, InsightsQuerypageModel $model ) {
+		$params = $this->getInsightListLinkParams( $subpage );
+
+		if ( $model->getLoopNotificationConfig( 'displayFixItMessage' ) ) {
+			$params = array_merge( $params, $this->getInsightFixItParams( $title, $model ) );
+		}
+
 		$params['notificationMessage'] = wfMessage( InsightsHelper::INSIGHT_INPROGRESS_MSG_PREFIX . $subpage )->plain();
 
 		return $params;
@@ -161,8 +171,8 @@ class InsightsController extends WikiaSpecialPageController {
 	 * Get params for notification template shown when user fix one issue from the insights list
 	 *
 	 * @param String $subpage Insights subpage
-	 * @param String $articleName current article name
-	 * @param InsightsModel $model
+	 * @param $next
+	 * @return array
 	 */
 	private function getInsightFixedNotificationParams( $subpage, $next ) {
 		$params = $this->getInsightNextLinkParams( $subpage, $next );
@@ -176,8 +186,8 @@ class InsightsController extends WikiaSpecialPageController {
 	 * Get params to generate next item link in notification template
 	 *
 	 * @param String $subpage Insights subpage
-	 * @param String $articleName current article name
-	 * @param InsightsModel $model
+	 * @param $next
+	 * @return array
 	 */
 	private function getInsightNextLinkParams( $subpage, $next ) {
 		return [
@@ -192,6 +202,7 @@ class InsightsController extends WikiaSpecialPageController {
 	 *
 	 * @param Title $title
 	 * @param InsightsModel $model
+	 * @return array
 	 */
 	private function getInsightFixItParams( Title $title, InsightsModel $model ) {
 		$link = InsightsHelper::getTitleLink( $title, $model->getUrlParams() );
@@ -206,6 +217,7 @@ class InsightsController extends WikiaSpecialPageController {
 	 * Get params to generate link to insight list in notification template
 	 *
 	 * @param String $subpage Insights subpage
+	 * @return array
 	 */
 	private function getInsightListLinkParams( $subpage ) {
 		return [

--- a/extensions/wikia/Insights/models/InsightsQuerypageModel.php
+++ b/extensions/wikia/Insights/models/InsightsQuerypageModel.php
@@ -110,7 +110,7 @@ abstract class InsightsQuerypageModel extends InsightsModel {
 	 * @param string $singleProperty
 	 * @return string|array
 	 */
-	public function getLoopNotificationConfig( $singleProperty = '' ){
+	public function getLoopNotificationConfig( $singleProperty = '' ) {
 		if ( !empty( $singleProperty )
 			&& isset( $this->loopNotificationConfig[$singleProperty] )
 		) {

--- a/extensions/wikia/Insights/models/InsightsQuerypageModel.php
+++ b/extensions/wikia/Insights/models/InsightsQuerypageModel.php
@@ -35,6 +35,9 @@ abstract class InsightsQuerypageModel extends InsightsModel {
 				'sortType' => SORT_NUMERIC,
 				'metadata' => 'pv7',
 			]
+		],
+		$loopNotificationConfig = [
+			'displayFixItMessage' => true,
 		];
 
 	abstract function getDataProvider();
@@ -100,6 +103,21 @@ abstract class InsightsQuerypageModel extends InsightsModel {
 
 	public function wlhLinkMessage() {
 		return 'insights-wanted-by';
+	}
+
+	/**
+	 * Returns a whole config for loop notification mechanism or its single property
+	 * @param string $singleProperty
+	 * @return string|array
+	 */
+	public function getLoopNotificationConfig( $singleProperty = '' ){
+		if ( !empty( $singleProperty )
+			&& isset( $this->loopNotificationConfig[$singleProperty] )
+		) {
+			return $this->loopNotificationConfig[$singleProperty];
+		}
+
+		return $this->loopNotificationConfig;
 	}
 
 	/**

--- a/extensions/wikia/Insights/models/InsightsUnconvertedInfoboxesModel.php
+++ b/extensions/wikia/Insights/models/InsightsUnconvertedInfoboxesModel.php
@@ -8,6 +8,10 @@
 class InsightsUnconvertedInfoboxesModel extends InsightsQuerypageModel {
 	const INSIGHT_TYPE = 'nonportableinfoboxes';
 
+	public $loopNotificationConfig = [
+		'displayFixItMessage' => false,
+	];
+
 	public function getDataProvider() {
 		return new UnconvertedInfoboxesPage();
 	}

--- a/extensions/wikia/Insights/templates/Insights_loopNotification.mustache
+++ b/extensions/wikia/Insights/templates/Insights_loopNotification.mustache
@@ -1,4 +1,7 @@
 {{notificationMessage}}
+{{#fixItMessage}}
+	{{fixItMessage}}
+{{/fixItMessage}}
 {{#editPageLink}}
 	<a id="InsightsEditPageButton" href="{{editPageLink}}" data-type="back-to-edit">{{editPageText}}</a>
 {{/editPageLink}}


### PR DESCRIPTION
Hello @Wikia/community-engineering !

In this PR I introduce a way to modify a behavior of our LoopNotification system. For now, it only includes a parameter that control displaying the "Let's fix it!" message, but can be expanded if needed.
