### PR TITLE
[SERVICES-481] Helios confirmation email language cleanup 

### DIFF
--- a/extensions/wikia/Helios/HelperController.class.php
+++ b/extensions/wikia/Helios/HelperController.class.php
@@ -118,7 +118,7 @@ class HelperController extends \WikiaController
 			return;
 		}
 
-		$mailStatus = $user->sendConfirmationMail( false, 'ConfirmationMail' );
+		$mailStatus = $user->sendConfirmationMail();
 
 		if ( ! $mailStatus->isGood() ) {
 			$this->response->setVal( 'message', 'could not send an email message' );

--- a/extensions/wikia/Helios/HelperController.class.php
+++ b/extensions/wikia/Helios/HelperController.class.php
@@ -1,8 +1,6 @@
 <?php
 namespace Wikia\Helios;
 
-use Wikia\Util\GlobalStateWrapper;
-
 /**
  * A helper controller to provide end points exposing MediaWiki functionality to Helios.
  */
@@ -120,28 +118,7 @@ class HelperController extends \WikiaController
 			return;
 		}
 
-		$langCode = $this->getVal( 'langCode', 'en' );
-		$mailTemplate = $this->app->renderView(
-			'UserLogin',
-			'GeneralMail',
-			[
-				'language' => $langCode,
-				'type' => 'confirmation-email'
-			]
-		);
-
-		$lang = \Language::factory($langCode);
-		$mailStatus = (new GlobalStateWrapper(['wgLang' => $lang]))
-			->wrap(function() use ($user, $mailTemplate, $langCode) {
-				return $user->sendConfirmationMail(
-					false,
-					'ConfirmationMail',
-					'usersignup-confirmation-email',
-					true,
-					$mailTemplate,
-					$langCode
-				);
-			});
+		$mailStatus = $user->sendConfirmationMail( false, 'ConfirmationMail' );
 
 		if ( ! $mailStatus->isGood() ) {
 			$this->response->setVal( 'message', 'could not send an email message' );

--- a/includes/User.php
+++ b/includes/User.php
@@ -3844,7 +3844,7 @@ class User {
 	 * @param $type String: message to send, either "created", "changed" or "set"
 	 * @return Status object
 	 */
-	public function sendConfirmationMail( $type = 'created', $mailtype = "ConfirmationMail", $mailmsg = '', $ip_arg = true, $emailTextTemplate = '', $langCode = null ) {
+	public function sendConfirmationMail( $type = 'created', $mailtype = "ConfirmationMail", $mailmsg = '', $ip_arg = true, $emailTextTemplate = '' ) {
 		global $wgLang;
 		$expiration = null; // gets passed-by-ref and defined in next line.
 		$token = $this->confirmationToken( $expiration );
@@ -3903,11 +3903,8 @@ class User {
 				$wgLang->time( $expiration, false ) ), null, null, $mailtype, null, $priority );
 		} else {
 			$wantHTML = $this->isAnon() || $this->getGlobalPreference( 'htmlemails' );
-			if ( empty( $langCode ) ) {
-				$langCode = $this->getGlobalPreference( 'language' );
-			}
 
-			list($body, $bodyHTML) = wfMsgHTMLwithLanguage( $message, $langCode, array(), $args, $wantHTML );
+			list($body, $bodyHTML) = wfMsgHTMLwithLanguage( $message, $this->getGlobalPreference( 'language' ), array(), $args, $wantHTML );
 
 			if ( !empty($emailTextTemplate) && $wantHTML ) {
 				$emailParams = array(


### PR DESCRIPTION
With new emails language is set based on user preference so there's no point to pass it as a parameter.

/cc @Wikia/services-team 
