### PR TITLE
(MAIN-4934,MAIN-4935) Make getExamples methods public

### DIFF
--- a/extensions/SemanticForms/includes/SF_AutocompleteAPI.php
+++ b/extensions/SemanticForms/includes/SF_AutocompleteAPI.php
@@ -133,7 +133,7 @@ class SFAutocompleteAPI extends ApiBase {
 		return 'Autocompletion call used by the Semantic Forms extension (http://www.mediawiki.org/Extension:Semantic_Forms)';
 	}
 
-	protected function getExamples() {
+	public function getExamples() {
 		return array (
 			'api.php?action=sfautocomplete&substr=te',
 			'api.php?action=sfautocomplete&substr=te&property=Has_author',
@@ -167,7 +167,7 @@ class SFAutocompleteAPI extends ApiBase {
 			if ( !is_null( $basePropertyName ) ) {
 				$cacheKeyString .= ',' . $basePropertyName . ',' . $baseValue;
 			}
-			$cacheKey = wfMemcKey( 'sf-autocomplete' , md5( $cacheKeyString ) ); 		
+			$cacheKey = wfMemcKey( 'sf-autocomplete' , md5( $cacheKeyString ) );
 			$values = $cache->get( $cacheKey );
 
 			if ( !empty( $values ) ){
@@ -274,7 +274,7 @@ class SFAutocompleteAPI extends ApiBase {
 			if ( !is_null( $baseCargoTable ) ) {
 				$cacheKeyString .= '|' . $baseCargoTable . '|' . $baseCargoField . '|' . $baseValue;
 			}
-			$cacheKey = wfMemcKey( 'sf-autocomplete' , md5( $cacheKeyString ) ); 		
+			$cacheKey = wfMemcKey( 'sf-autocomplete' , md5( $cacheKeyString ) );
 			$values = $cache->get( $cacheKey );
 
 			if ( !empty( $values ) ){

--- a/extensions/SemanticForms/includes/SF_AutoeditAPI.php
+++ b/extensions/SemanticForms/includes/SF_AutoeditAPI.php
@@ -1180,7 +1180,7 @@ END;
 	 *
 	 * @return mixed string or array of strings
 	 */
-	protected function getExamples() {
+	public function getExamples() {
 		return array(
 			'With query parameter:    api.php?action=sfautoedit&form=form-name&target=page-name&query=template-name[field-name-1]=field-value-1%26template-name[field-name-2]=field-value-2',
 			'Without query parameter: api.php?action=sfautoedit&form=form-name&target=page-name&template-name[field-name-1]=field-value-1&template-name[field-name-2]=field-value-2'


### PR DESCRIPTION
Make getExamples methods public to match Wikia core change.

Fixes the following fatal errors:

```
PHP Fatal error: Access level to SFAutocompleteAPI::getExamples()
must be public (as in class ApiBase) in
/extensions/SemanticForms/includes/SF_AutocompleteAPI.php on line 15

PHP Fatal error: Access level to SFAutoeditAPI::getExamples()
must be public (as in class ApiBase) in
/extensions/SemanticForms/includes/SF_AutoeditAPI.php on line 15
```

/cc @macbre 
