### PR TITLE
(CE-2327) Backport wfRandomString for use in SemanticForms

### DIFF
--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -4082,3 +4082,20 @@ function wfUnpack( $format, $data, $length=false ) {
 	}
 	return $result;
 }
+
+/**
+ * Get a random string containing a number of pseudo-random hex
+ * characters.
+ * @note This is not secure, if you are trying to generate some sort
+ *       of token please use MWCryptRand instead.
+ *
+ * @param int $length The length of the string to generate
+ * @return string
+ */
+function wfRandomString( $length = 32 ) {
+	$str = '';
+	for ( $n = 0; $n < $length; $n += 7 ) {
+		$str .= sprintf( '%07x', mt_rand() & 0xfffffff );
+	}
+	return substr( $str, 0, $length );
+}


### PR DESCRIPTION
SemanticForms claims to be compatible with MW 1.19 but is using some
methods from MW 1.20. Backport wfRandomString to make the editing
form work.
