### PR TITLE
INT-133: Fix issue by using mb_pathinfo instead of pathinfo

### DIFF
--- a/extensions/VisualEditor/wikia/ApiAddMediaPermanent.php
+++ b/extensions/VisualEditor/wikia/ApiAddMediaPermanent.php
@@ -99,8 +99,9 @@ class ApiAddMediaPermanent extends ApiAddMedia {
 	}
 
 	private function getUniqueTitle( $name ) {
-		$filename = pathinfo( $name, PATHINFO_FILENAME );
-		$extension = pathinfo( $name, PATHINFO_EXTENSION );
+		$pathinfo = mb_pathinfo( $name );
+		$filename = $pathinfo['filename'];
+		$extension = $pathinfo['extension'];
 		$title = Title::makeTitleSafe( NS_IMAGE, $filename . '.' . $extension );
 		if ( !empty( $title ) && $title->exists() ) {
 			for ( $i = 0; $i <= 3; $i++ ) {

--- a/includes/wikia/GlobalFunctions.php
+++ b/includes/wikia/GlobalFunctions.php
@@ -1618,10 +1618,18 @@ function wfGetUniqueArrayCI( array $arr ) {
  * Like pathinfo but with support for multibyte - copied from http://php.net/manual/en/function.pathinfo.php#107461
  */
 function mb_pathinfo($filepath) {
-	preg_match('%^(.*?)[\\\\/]*(([^/\\\\]*?)(\.([^\.\\\\/]+?)|))[\\\\/\.]*$%im',$filepath,$m);
-	if($m[1]) $ret['dirname']=$m[1];
-	if($m[2]) $ret['basename']=$m[2];
-	if($m[5]) $ret['extension']=$m[5];
-	if($m[3]) $ret['filename']=$m[3];
+	preg_match('%^(.*?)[\\\\/]*(([^/\\\\]*?)(\.([^\.\\\\/]+?)|))[\\\\/\.]*$%im', $filepath, $m);
+	if($m[1]) {
+		$ret['dirname'] = $m[1];
+	}
+	if($m[2]) {
+		$ret['basename'] = $m[2];
+	}
+	if($m[5]) {
+		$ret['extension'] = $m[5];
+	}
+	if($m[3]) {
+		$ret['filename'] = $m[3];
+	}
 	return $ret;
 }

--- a/includes/wikia/GlobalFunctions.php
+++ b/includes/wikia/GlobalFunctions.php
@@ -1613,3 +1613,15 @@ function wfGetUniqueArrayCI( array $arr ) {
 	$unique = array_intersect_key( $arr, array_unique( $lower ) );
 	return array_filter( $unique );
 }
+
+/**
+ * Like pathinfo but with support for multibyte - copied from http://php.net/manual/en/function.pathinfo.php#107461
+ */
+function mb_pathinfo($filepath) {
+	preg_match('%^(.*?)[\\\\/]*(([^/\\\\]*?)(\.([^\.\\\\/]+?)|))[\\\\/\.]*$%im',$filepath,$m);
+	if($m[1]) $ret['dirname']=$m[1];
+	if($m[2]) $ret['basename']=$m[2];
+	if($m[5]) $ret['extension']=$m[5];
+	if($m[3]) $ret['filename']=$m[3];
+	return $ret;
+}

--- a/includes/wikia/GlobalFunctions.php
+++ b/includes/wikia/GlobalFunctions.php
@@ -1617,18 +1617,18 @@ function wfGetUniqueArrayCI( array $arr ) {
 /**
  * Like pathinfo but with support for multibyte - copied from http://php.net/manual/en/function.pathinfo.php#107461
  */
-function mb_pathinfo($filepath) {
-	preg_match('%^(.*?)[\\\\/]*(([^/\\\\]*?)(\.([^\.\\\\/]+?)|))[\\\\/\.]*$%im', $filepath, $m);
-	if($m[1]) {
+function mb_pathinfo( $filepath ) {
+	preg_match( '%^(.*?)[\\\\/]*(([^/\\\\]*?)(\.([^\.\\\\/]+?)|))[\\\\/\.]*$%im', $filepath, $m );
+	if ( $m[1] ) {
 		$ret['dirname'] = $m[1];
 	}
-	if($m[2]) {
+	if ( $m[2] ) {
 		$ret['basename'] = $m[2];
 	}
-	if($m[5]) {
+	if ( $m[5] ) {
 		$ret['extension'] = $m[5];
 	}
-	if($m[3]) {
+	if ( $m[3] ) {
 		$ret['filename'] = $m[3];
 	}
 	return $ret;

--- a/includes/wikia/tests/MultiBytePathinfoTest.php
+++ b/includes/wikia/tests/MultiBytePathinfoTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Set of unit tests for GlobalFile class
+ *
+ * @author Inez Korczyński
+ */
+class MultiBytePathInfoTest extends WikiaBaseTest {
+
+	public function testAll() {
+		$this->assertEquals(mb_pathinfo("すどく.txt"), array(
+			"basename" => "すどく.txt",
+			"extension" => "txt",
+			"filename" => "すどく"
+		));
+
+		$this->assertEquals(mb_pathinfo("sudoku.すどく.txt"), array(
+			"basename" => "sudoku.すどく.txt",
+			"extension" => "txt",
+			"filename" => "sudoku.すどく"
+		));
+
+		$this->assertEquals(mb_pathinfo("/dir_すどく/すどく.txt"), array(
+			"dirname" => "/dir_すどく",
+			"basename" => "すどく.txt",
+			"extension" => "txt",
+			"filename" => "すどく"
+		));
+
+		$this->assertEquals(mb_pathinfo("/dir_すどく/すどく.すどく.txt"), array(
+			"dirname" => "/dir_すどく",
+			"basename" => "すどく.すどく.txt",
+			"extension" => "txt",
+			"filename" => "すどく.すどく"
+		));
+
+	}
+}

--- a/includes/wikia/tests/MultiBytePathinfoTest.php
+++ b/includes/wikia/tests/MultiBytePathinfoTest.php
@@ -7,31 +7,30 @@
 class MultiBytePathInfoTest extends WikiaBaseTest {
 
 	public function testAll() {
-		$this->assertEquals(mb_pathinfo("すどく.txt"), array(
-			"basename" => "すどく.txt",
-			"extension" => "txt",
-			"filename" => "すどく"
-		));
+		$this->assertEquals( mb_pathinfo( 'すどく.txt' ), [
+			'basename' => 'すどく.txt',
+			'extension' => 'txt',
+			'filename' => 'すどく'
+		] );
 
-		$this->assertEquals(mb_pathinfo("sudoku.すどく.txt"), array(
-			"basename" => "sudoku.すどく.txt",
-			"extension" => "txt",
-			"filename" => "sudoku.すどく"
-		));
+		$this->assertEquals( mb_pathinfo( 'sudoku.すどく.txt' ), [
+			'basename' => 'sudoku.すどく.txt',
+			'extension' => 'txt',
+			'filename' => 'sudoku.すどく'
+		] );
 
-		$this->assertEquals(mb_pathinfo("/dir_すどく/すどく.txt"), array(
-			"dirname" => "/dir_すどく",
-			"basename" => "すどく.txt",
-			"extension" => "txt",
-			"filename" => "すどく"
-		));
+		$this->assertEquals( mb_pathinfo( '/dir_すどく/すどく.txt' ), [
+			'dirname' => '/dir_すどく',
+			'basename' => 'すどく.txt',
+			'extension' => 'txt',
+			'filename' => 'すどく'
+		] );
 
-		$this->assertEquals(mb_pathinfo("/dir_すどく/すどく.すどく.txt"), array(
-			"dirname" => "/dir_すどく",
-			"basename" => "すどく.すどく.txt",
-			"extension" => "txt",
-			"filename" => "すどく.すどく"
-		));
-
+		$this->assertEquals( mb_pathinfo( '/dir_すどく/すどく.すどく.txt' ), [
+			'dirname' => '/dir_すどく',
+			'basename' => 'すどく.すどく.txt',
+			'extension' => 'txt',
+			'filename' => 'すどく.すどく'
+		] );
 	}
 }


### PR DESCRIPTION
PHP pathinfo does not work wiht multibyte strings - it's a known issue that is solved in PHP6. In the meantime I decided to use mb_pathinfo which I found here http://php.net/manual/en/function.pathinfo.php#107461 and for which implementation looks pretty solid.
