### PR TITLE
[SERVICES-421] Extending invalid username characters with round brackets

### DIFF
--- a/includes/DefaultSettings.php
+++ b/includes/DefaultSettings.php
@@ -3303,7 +3303,7 @@ $wgHiddenPrefs = array();
  * This is used in a regular expression character class during
  * registration (regex metacharacters like / are escaped).
  */
-$wgInvalidUsernameCharacters = '@';
+$wgInvalidUsernameCharacters = '@()';
 
 /**
  * Character used as a delimiter when testing for interwiki userrights


### PR DESCRIPTION
Additional invalid characters for username registration.

/cc @Wikia/services-team @garthwebb @jsutterfield 
