### PR TITLE
DAT-3035 article preview typography styles overwrite portable infobox font-size for labels

### DIFF
--- a/extensions/wikia/EditPageLayout/css/EditPageLayout.scss
+++ b/extensions/wikia/EditPageLayout/css/EditPageLayout.scss
@@ -349,11 +349,6 @@ body {
 			.ArticlePreviewInner {
 				height: 100%;
 				margin: 0 auto;
-				@include breakpoints-small-medium-typography;
-
-				&.large-typography {
-					@include breakpoints-large-typography;
-				}
 			}
 
 			.preview-modal-msg-wrapper {
@@ -593,5 +588,14 @@ body {
 		height: 100%;
 		margin: 0 auto;
 		width: 100%;
+	}
+}
+
+// add breakpoint typography styles to article preview
+.ArticlePreviewInner {
+	@include breakpoints-small-medium-typography;
+
+	&.large-typography {
+		@include breakpoints-large-typography;
 	}
 }


### PR DESCRIPTION
- reduce specificity of breakpoints typography css selectors in article preview
