### PR TITLE
Hg 754 adding another test and sections value

### DIFF
--- a/includes/wikia/api/ArticlesApiController.class.php
+++ b/includes/wikia/api/ArticlesApiController.class.php
@@ -1098,6 +1098,9 @@ class ArticlesApiController extends WikiaApiController {
 	private function getSectionNumbersArray( $sectionsToGet, $sectionCount ) {
 		if ( $sectionsToGet === 'all' ) {
 			$sectionsToGet = range( 0, $sectionCount - 1 );
+		} else if ( preg_match( '/(\d)\+/', $sectionsToGet, $matches ) ) {
+			// for an input like "3+", get specified section (section 3) and all following sections
+			$sectionsToGet = range( $matches[1], $sectionCount - 1 );
 		} else {
 			// decode strings like "1%2C%202%2C%203" or "1,2,3" into an array
 			$sectionsToGet = explode( ',', urldecode( preg_replace( '/\s*/', '', $sectionsToGet ) ) );

--- a/includes/wikia/api/ArticlesApiController.class.php
+++ b/includes/wikia/api/ArticlesApiController.class.php
@@ -1026,7 +1026,7 @@ class ArticlesApiController extends WikiaApiController {
 
 			if ( !empty( $sectionsToGet ) || $sectionsToGet == '0' ) {
 				$contentArray = $this->splitArticleIntoSections( $articleContent->content );
-				$sectionsArray = $this->getSectionNumbersArray( $sectionsToGet, count( $contentArray ) );
+				$sectionsArray = $this->getSectionNumbersArray( $sectionsToGet );
 				$content = $this->getArticleSections( $sectionsArray, $contentArray );
 			} else {
 				$content = $articleContent->content;
@@ -1081,12 +1081,18 @@ class ArticlesApiController extends WikiaApiController {
 		return $contentArray;
 	}
 
+	/**
+	 * Return a string of the specified sections joined from section array
+	 * @param $sectionsToGet
+	 * @param $contentArray
+	 * @return string
+	 */
 	private function getArticleSections( $sectionsToGet, $contentArray ) {
-		$retArr = [];
+		$content = '';
 		foreach ( $sectionsToGet as $section ) {
-			$retArr[] = $contentArray[$section];
+			$content .= $contentArray[$section];
 		}
-		return $retArr;
+		return $content;
 	}
 
 	/**
@@ -1095,16 +1101,9 @@ class ArticlesApiController extends WikiaApiController {
 	 * @return array
 	 * @throws BadRequestApiException
 	 */
-	private function getSectionNumbersArray( $sectionsToGet, $sectionCount ) {
-		if ( $sectionsToGet === 'all' ) {
-			$sectionsToGet = range( 0, $sectionCount - 1 );
-		} else if ( preg_match( '/(\d)\+/', $sectionsToGet, $matches ) ) {
-			// for an input like "3+", get specified section (section 3) and all following sections
-			$sectionsToGet = range( $matches[1], $sectionCount - 1 );
-		} else {
-			// decode strings like "1%2C%202%2C%203" or "1,2,3" into an array
-			$sectionsToGet = explode( ',', preg_replace( '/\s*/', '', urldecode( $sectionsToGet ) ) );
-		}
+	private function getSectionNumbersArray( $sectionsToGet ) {
+		// decode strings like "1%2C%202%2C%203" or "1,2,3" into an array
+		$sectionsToGet = explode( ',', preg_replace( '/\s*/', '', urldecode( $sectionsToGet ) ) );
 		return $sectionsToGet;
 	}
 

--- a/includes/wikia/api/ArticlesApiController.class.php
+++ b/includes/wikia/api/ArticlesApiController.class.php
@@ -1097,10 +1097,10 @@ class ArticlesApiController extends WikiaApiController {
 	 */
 	private function getSectionNumbersArray( $sectionsToGet, $sectionCount ) {
 		if ( $sectionsToGet === 'all' ) {
-			$sectionsToGet = range( 0, $sectionCount );
+			$sectionsToGet = range( 0, $sectionCount - 1 );
 		} else {
 			// decode strings like "1%2C%202%2C%203" or "1,2,3" into an array
-			$sectionsToGet = explode( ',', urldecode( $sectionsToGet ) );
+			$sectionsToGet = explode( ',', urldecode( preg_replace( '/\s*/', '', $sectionsToGet ) ) );
 		}
 		return $sectionsToGet;
 	}

--- a/includes/wikia/api/ArticlesApiController.class.php
+++ b/includes/wikia/api/ArticlesApiController.class.php
@@ -1103,7 +1103,7 @@ class ArticlesApiController extends WikiaApiController {
 			$sectionsToGet = range( $matches[1], $sectionCount - 1 );
 		} else {
 			// decode strings like "1%2C%202%2C%203" or "1,2,3" into an array
-			$sectionsToGet = explode( ',', urldecode( preg_replace( '/\s*/', '', $sectionsToGet ) ) );
+			$sectionsToGet = explode( ',', preg_replace( '/\s*/', '', urldecode( $sectionsToGet ) ) );
 		}
 		return $sectionsToGet;
 	}

--- a/includes/wikia/api/tests/ArticlesApiControllerTest.php
+++ b/includes/wikia/api/tests/ArticlesApiControllerTest.php
@@ -172,12 +172,12 @@ class ArticlesApiControllerTest extends \WikiaBaseTest {
 			[
 				'all',
 				3,
-				[0, 1, 2, 3]
+				[0, 1, 2]
 			],
-			// get all sections when there's no headers / TOC sections
+			// get all sections when there's only one section
 			[
 				'all',
-				0,
+				1,
 				[0]
 			],
 			// get specified sections
@@ -186,7 +186,7 @@ class ArticlesApiControllerTest extends \WikiaBaseTest {
 				4,
 				[0, 1, 2]
 			],
-			// different spacing and there's more sections requested than are available
+			// different spacing
 			[
 				'0, 1, 2',
 				2,
@@ -201,6 +201,51 @@ class ArticlesApiControllerTest extends \WikiaBaseTest {
 	public function testGetSectionNumbersArray( $sectionsToGet, $sectionCount, $sectionsArray ) {
 		$getSectionNumbersArray = self::getFn( new ArticlesApiController(), 'getSectionNumbersArray' );
 		$this->assertEquals( $sectionsArray, $getSectionNumbersArray( $sectionsToGet, $sectionCount ) );
+	}
+
+	public function splitArticleIntoSectionsDataProvider() {
+		return [
+			// real article output
+			[
+				'<p>Section 0 text </p><p><br /> </p> <h2 id=\'Section_1_heading\' section=\'1\' >Section 1 heading</h2> <p><img src=\'data:image/gif;base64,R0lGODlhAQABAIABAAAAAP///yH5BAEAAAEALAAAAAABAAEAQAICTAEAOw%3D%3D\' class=\'article-media\' data-ref=\'0\' width=\'800\' height=\'600\' /> Section 1 text <a rel="nofollow" class="external text exitstitial" href="http://www.google.com">Foo</a> </p> <h3 id=\'Section_1.1_heading\' section=\'2\' >Section 1.1 heading</h3> <p>Section1.1 text </p><p><img src=\'data:image/gif;base64,R0lGODlhAQABAIABAAAAAP///yH5BAEAAAEALAAAAAABAAEAQAICTAEAOw%3D%3D\' class=\'article-media\' data-ref=\'1\' width=\'960\' height=\'640\' /> </p> <h2 id=\'Section_2_heading\' section=\'3\' >Section 2 heading</h2> <p>Section 2 text <a rel="nofollow" class="external text exitstitial" href="http://www.google.com">Foo</a> </p> <h2 id=\'Section_3_heading\' section=\'4\' >Section 3 heading</h2> <p>Section 3 text <a rel="nofollow" class="external text exitstitial" href="http://www.google.com">Foo</a> </p><p><img src=\'data:image/gif;base64,R0lGODlhAQABAIABAAAAAP///yH5BAEAAAEALAAAAAABAAEAQAICTAEAOw%3D%3D\' class=\'article-media\' data-ref=\'2\' width=\'506\' height=\'506\' /> </p> <h2 id=\'Test_4th_Section\' section=\'\' >Test 4th Section</h2> <p>Test 4th section text. </p>',
+				[
+					'<p>Section 0 text </p><p><br /> </p> ',
+					'<h2 id=\'Section_1_heading\' section=\'1\' >Section 1 heading</h2> <p><img src=\'data:image/gif;base64,R0lGODlhAQABAIABAAAAAP///yH5BAEAAAEALAAAAAABAAEAQAICTAEAOw%3D%3D\' class=\'article-media\' data-ref=\'0\' width=\'800\' height=\'600\' /> Section 1 text <a rel="nofollow" class="external text exitstitial" href="http://www.google.com">Foo</a> </p> <h3 id=\'Section_1.1_heading\' section=\'2\' >Section 1.1 heading</h3> <p>Section1.1 text </p><p><img src=\'data:image/gif;base64,R0lGODlhAQABAIABAAAAAP///yH5BAEAAAEALAAAAAABAAEAQAICTAEAOw%3D%3D\' class=\'article-media\' data-ref=\'1\' width=\'960\' height=\'640\' /> </p> ',
+					'<h2 id=\'Section_2_heading\' section=\'3\' >Section 2 heading</h2> <p>Section 2 text <a rel="nofollow" class="external text exitstitial" href="http://www.google.com">Foo</a> </p> ',
+					'<h2 id=\'Section_3_heading\' section=\'4\' >Section 3 heading</h2> <p>Section 3 text <a rel="nofollow" class="external text exitstitial" href="http://www.google.com">Foo</a> </p><p><img src=\'data:image/gif;base64,R0lGODlhAQABAIABAAAAAP///yH5BAEAAAEALAAAAAABAAEAQAICTAEAOw%3D%3D\' class=\'article-media\' data-ref=\'2\' width=\'506\' height=\'506\' /> </p> ',
+					'<h2 id=\'Test_4th_Section\' section=\'\' >Test 4th Section</h2> <p>Test 4th section text. </p>',
+				]
+			],
+			// h2 without a section attribute
+			[
+				'<h2>Foo bar</h2> Foo bar baz qux <h2 section="2">Section with attribute</h2>',
+				[
+					'<h2>Foo bar</h2> Foo bar baz qux ',
+					'<h2 section="2">Section with attribute</h2>'
+				]
+			],
+			// empty article
+			[
+				'',
+				[]
+			],
+			// article without section 0
+			[
+				'<h2 id=\'Section_1_heading\' section=\'1\' >Section 1 heading</h2> <p>Section 1 text <a href="http://www.google.com">Foo</a> </p> <h2 id=\'Section_1.1_heading\' section=\'2\' >Section 1.1 heading</h2> <p>Section1.1 text </p><p><img src=\'data:image/gif;base64,R0lGODlhAQABAIABAAAAAP///yH5BAEAAAEALAAAAAABAAEAQAICTAEAOw%3D%3D\' class=\'article-media\' data-ref=\'1\' width=\'960\' height=\'640\' /> </p> ',
+				[
+					'<h2 id=\'Section_1_heading\' section=\'1\' >Section 1 heading</h2> <p>Section 1 text <a href="http://www.google.com">Foo</a> </p> ',
+					'<h2 id=\'Section_1.1_heading\' section=\'2\' >Section 1.1 heading</h2> <p>Section1.1 text </p><p><img src=\'data:image/gif;base64,R0lGODlhAQABAIABAAAAAP///yH5BAEAAAEALAAAAAABAAEAQAICTAEAOw%3D%3D\' class=\'article-media\' data-ref=\'1\' width=\'960\' height=\'640\' /> </p> '
+				]
+			]
+		];
+	}
+
+	/**
+	 * @dataProvider splitArticleIntoSectionsDataProvider
+	 */
+	public function testSplitArticleIntoSections( $content, $contentArray ) {
+		$splitArticleIntoSections = self::getFn( new ArticlesApiController(), 'splitArticleIntoSections' );
+		$this->assertEquals( $contentArray, $splitArticleIntoSections( $content ) );
 	}
 
 	protected static function getFn( $obj, $name ) {

--- a/includes/wikia/api/tests/ArticlesApiControllerTest.php
+++ b/includes/wikia/api/tests/ArticlesApiControllerTest.php
@@ -168,18 +168,6 @@ class ArticlesApiControllerTest extends \WikiaBaseTest {
 
 	public function getSectionNumbersArrayDataProvider() {
 		return [
-			// get all sections (inlcuding section 0, which isn't included in TOC sections array)
-			[
-				'all',
-				3,
-				[0, 1, 2]
-			],
-			// get all sections when there's only one section
-			[
-				'all',
-				1,
-				[0]
-			],
 			// get specified sections
 			[
 				'0,1,2',
@@ -191,12 +179,6 @@ class ArticlesApiControllerTest extends \WikiaBaseTest {
 				'0, 1, 2',
 				2,
 				[0, 1, 2]
-			],
-			// get specified and all remaining sections
-			[
-				'3+',
-				5,
-				[3,4]
 			],
 			// url encoded input
 			[

--- a/includes/wikia/api/tests/ArticlesApiControllerTest.php
+++ b/includes/wikia/api/tests/ArticlesApiControllerTest.php
@@ -191,7 +191,13 @@ class ArticlesApiControllerTest extends \WikiaBaseTest {
 				'0, 1, 2',
 				2,
 				[0, 1, 2]
-			]
+			],
+			// get specified and all remaining sections
+			[
+				'3+',
+				5,
+				[3,4]
+			],
 		];
 	}
 

--- a/includes/wikia/api/tests/ArticlesApiControllerTest.php
+++ b/includes/wikia/api/tests/ArticlesApiControllerTest.php
@@ -198,6 +198,18 @@ class ArticlesApiControllerTest extends \WikiaBaseTest {
 				5,
 				[3,4]
 			],
+			// url encoded input
+			[
+				'1%2C%202%2C%203',
+				5,
+				[1,2,3]
+			],
+			// url encoded input
+			[
+				'4%2C5%2C6',
+				5,
+				[4,5,6]
+			]
 		];
 	}
 


### PR DESCRIPTION
This is a follow-up PR to https://github.com/Wikia/app/pull/7796. It adds a test for `splitArticleIntoSections`, fixes an off-by-one error, and returns a string instead of an array of article sections. 
