### PR TITLE
[SERVICES-525] Making sure user is logged out when resetting password

### DIFF
--- a/extensions/wikia/UserLogin/UserLoginSpecialController.class.php
+++ b/extensions/wikia/UserLogin/UserLoginSpecialController.class.php
@@ -79,6 +79,12 @@ class UserLoginSpecialController extends WikiaSpecialPageController {
 	 * Route the view based on logged in status
 	 */
 	public function index() {
+		//Making sure that user is logged out for password reset
+		$action = $this->request->getVal( 'action', null );
+		if ( $action === wfMessage( 'resetpass_submit' )->escaped() ) {
+			$this->wg->User->logout();
+		}
+
 		if ( $this->wg->User->isLoggedIn() ) {
 			$this->forward( __CLASS__, 'loggedIn' );
 		} else {


### PR DESCRIPTION
As checking temporary password is now externalized to helios we need to be sure that user is not logged in MW to properly reset password.

/cc @Wikia/services-team  @garthwebb 
