### PR TITLE
Services-528 harnash

### DIFF
--- a/includes/User.php
+++ b/includes/User.php
@@ -4798,7 +4798,7 @@ class User {
 	 * @todo document
 	 */
 	protected function saveOptions() {
-		global $wgAllowPrefChange, $wgPreferencesUseService;
+		global $wgAllowPrefChange, $wgPreferencesUseService, $wgUserPreferenceWhiteList;
 
 		$extuser = ExternalUser::newFromUser( $this );
 
@@ -4843,16 +4843,14 @@ class User {
 
 		// kinda ghetto, but :(
 		if ($wgPreferencesUseService) {
-			$preferenceNames = array_keys($this->userPreferences()->getPreferences($this->getId()));
-
 			(new WikiaSQL())
 				->DELETE('user_properties')
 				->WHERE('up_user')->EQUAL_TO($this->getId())
-					->AND_('up_property')->NOT_IN($preferenceNames)
+					->AND_('up_property')->NOT_IN($wgUserPreferenceWhiteList)
 				->run($dbw);
 
-			$insert_rows = array_reduce($insert_rows, function($result, $current) use ($preferenceNames) {
-				if (!in_array($current['up_property'], $preferenceNames)) {
+			$insert_rows = array_reduce($insert_rows, function($result, $current) use ($wgUserPreferenceWhiteList) {
+				if (!in_array($current['up_property'], $wgUserPreferenceWhiteList)) {
 					$result[] = $current;
 				}
 

--- a/includes/User.php
+++ b/includes/User.php
@@ -2556,7 +2556,7 @@ class User {
 		global $wgPreferencesUseService;
 		if ( $wgPreferencesUseService ) {
 			$this->load();
-			$this->sanitizePropertyArray( $preferences );
+			$preferences = $this->sanitizePropertyArray( $preferences );
 			$this->userPreferences()->setMultiple( $this->mId, $preferences );
 			if ( array_key_exists( 'skin', $preferences ) ) {
 				unset( $this->mSkin );
@@ -4798,7 +4798,7 @@ class User {
 	 * @todo document
 	 */
 	protected function saveOptions() {
-		global $wgAllowPrefChange;
+		global $wgAllowPrefChange, $wgPreferencesUseService;
 
 		$extuser = ExternalUser::newFromUser( $this );
 
@@ -4841,7 +4841,27 @@ class User {
 			}
 		}
 
-		$dbw->delete( 'user_properties', array( 'up_user' => $this->getId() ), __METHOD__ );
+		// kinda ghetto, but :(
+		if ($wgPreferencesUseService) {
+			$preferenceNames = array_keys($this->userPreferences()->getPreferences($this->getId()));
+
+			(new WikiaSQL())
+				->DELETE('user_properties')
+				->WHERE('up_user')->EQUAL_TO($this->getId())
+					->AND_('up_property')->NOT_IN($preferenceNames)
+				->run($dbw);
+
+			$insert_rows = array_reduce($insert_rows, function($result, $current) use ($preferenceNames) {
+				if (!in_array($current['up_property'], $preferenceNames)) {
+					$result[] = $current;
+				}
+
+				return $result;
+			}, []);
+		} else {
+			$dbw->delete( 'user_properties', array( 'up_user' => $this->getId() ), __METHOD__ );
+		}
+
 		$dbw->insert( 'user_properties', $insert_rows, __METHOD__ );
 
 		if ( $extuser ) {

--- a/includes/User.php
+++ b/includes/User.php
@@ -4843,14 +4843,18 @@ class User {
 
 		// kinda ghetto, but :(
 		if ($wgPreferencesUseService) {
-			(new WikiaSQL())
-				->DELETE('user_properties')
-				->WHERE('up_user')->EQUAL_TO($this->getId())
-					->AND_('up_property')->NOT_IN($wgUserPreferenceWhiteList)
-				->run($dbw);
-
-			$insert_rows = array_reduce($insert_rows, function($result, $current) use ($wgUserPreferenceWhiteList) {
-				if (!in_array($current['up_property'], $wgUserPreferenceWhiteList)) {
+			$regex = implode ('|', $wgUserPreferenceWhiteList['regexes']);
+			$dbw->delete( 'user_properties', [
+				'up_user' => $this->getId(),
+				'`up_property` NOT IN (' . $dbw->makeList($wgUserPreferenceWhiteList['literals']) . ') AND ' .
+				"`up_property` NOT REGEXP " . $dbw->addQuotes($regex)
+			]);
+			$regex = '/' . $regex . '/';
+			$insert_rows = array_reduce($insert_rows, function($result, $current) use ($wgUserPreferenceWhiteList, $regex) {
+				if (
+					!in_array( $current['up_property'], $wgUserPreferenceWhiteList['literals'] ) &&
+					!preg_match( $regex, $current['up_property'] )
+				) {
 					$result[] = $current;
 				}
 

--- a/lib/Wikia/src/Persistence/User/Preferences/PreferencePersistenceModuleMySQL.php
+++ b/lib/Wikia/src/Persistence/User/Preferences/PreferencePersistenceModuleMySQL.php
@@ -12,15 +12,20 @@ class PreferencePersistenceModuleMySQL implements Module {
 	/** @var callable */
 	private $slaveProvider;
 
-	public function __construct(callable $masterProvider, callable $slaveProvider) {
+	/** @var callable */
+	private $whiteListProvider;
+
+	public function __construct(callable $masterProvider, callable $slaveProvider, callable $whiteListProvider) {
 		$this->masterProvider = $masterProvider;
 		$this->slaveProvider = $slaveProvider;
+		$this->whiteListProvider = $whiteListProvider;
 	}
 
 	public function configure(InjectorBuilder $builder) {
 		$builder
 			->bind(PreferencePersistence::class)->toClass(PreferencePersistenceMySQL::class)
 			->bind(PreferencePersistenceMySQL::CONNECTION_MASTER)->to($this->masterProvider)
-			->bind(PreferencePersistenceMySQL::CONNECTION_SLAVE)->to($this->slaveProvider);
+			->bind(PreferencePersistenceMySQL::CONNECTION_SLAVE)->to($this->slaveProvider)
+			->bind(PreferencePersistenceMySQL::WHITE_LIST)->to($this->whiteListProvider);
 	}
 }

--- a/lib/Wikia/src/Persistence/User/Preferences/PreferencePersistenceMySQL.php
+++ b/lib/Wikia/src/Persistence/User/Preferences/PreferencePersistenceMySQL.php
@@ -52,9 +52,9 @@ class PreferencePersistenceMySQL implements PreferencePersistence {
 	}
 
 	/**
-	 * @param array $preferences
-	 * @return array
-     */
+	 * @param Preference[] $preferences
+	 * @return Preference[]
+	 */
 	private function applyWhitelist( array $preferences ) {
 		$whiteList = $this->whiteList;
 
@@ -63,6 +63,7 @@ class PreferencePersistenceMySQL implements PreferencePersistence {
 		}
 
 		$preferences =  array_reduce( $preferences, function ( $result, $item ) use ( $whiteList ) {
+			/** @var Preference $item */
 			$preference_name = $item->getName();
 
 			if (

--- a/lib/Wikia/src/Persistence/User/Preferences/PreferencePersistenceMySQL.php
+++ b/lib/Wikia/src/Persistence/User/Preferences/PreferencePersistenceMySQL.php
@@ -39,13 +39,15 @@ class PreferencePersistenceMySQL implements PreferencePersistence {
 	public function save( $userId, array $preferences ) {
 		// Filtering preferences against the whiteList
 		$whiteList = $this->whiteList;
-		$preferences = array_reduce($preferences, function($result, $value) use ($whiteList) {
-			if (in_array($value, $this->whiteList)) {
-				$result[] = $value;
-			}
+		if ( !empty($whiteList) ) {
+			$preferences = array_reduce( $preferences, function ( $result, $item ) use ( $whiteList ) {
+				if ( in_array( $item->getName(), $this->whiteList ) ) {
+					$result[] = $item;
+				}
 
-			return $result;
-		}, []);
+				return $result;
+			}, [] );
+		}
 		$tuples = $this->createTuplesFromPreferences( $userId, $preferences );
 
 		if ( empty( $tuples ) ) {

--- a/lib/Wikia/src/Persistence/User/Preferences/PreferencePersistenceMySQL.php
+++ b/lib/Wikia/src/Persistence/User/Preferences/PreferencePersistenceMySQL.php
@@ -40,7 +40,7 @@ class PreferencePersistenceMySQL implements PreferencePersistence {
 	 * @param array $whiteList
 	 * @return array
      */
-	private function buildWhitelist( array $whiteList ) {
+	private function buildWhitelist( $whiteList = [ ] ) {
 		if ( empty( $whiteList ) ) {
 			return [];
 		}

--- a/lib/Wikia/src/Service/User/Preferences/PreferenceModule.php
+++ b/lib/Wikia/src/Service/User/Preferences/PreferenceModule.php
@@ -38,8 +38,12 @@ class PreferenceModule implements Module {
 			global $wgExternalSharedDB;
 			return wfGetDB(DB_SLAVE, [], $wgExternalSharedDB);
 		};
+		$whiteListProvider = function() {
+			global $wgUserPreferenceWhiteList;
+			return $wgUserPreferenceWhiteList;
+		};
 
-		$builder->addModule(new PreferencePersistenceModuleMySQL($masterProvider, $slaveProvider));
+		$builder->addModule(new PreferencePersistenceModuleMySQL($masterProvider, $slaveProvider, $whiteListProvider));
 	}
 
 	private static function bindSwaggerService(InjectorBuilder $builder) {

--- a/lib/Wikia/src/Service/User/Preferences/UserPreferences.php
+++ b/lib/Wikia/src/Service/User/Preferences/UserPreferences.php
@@ -82,7 +82,7 @@ class UserPreferences {
 
 		foreach ( $prefs as $pref => $val ) {
 			$default = $this->getFromDefault( $pref );
-			if ( $val == null && isset( $default ) ) {
+			if ( $val === null && isset( $default ) ) {
 				$val = $default;
 			}
 			$this->preferences[ $userId ][ $pref ] = $val;
@@ -102,7 +102,7 @@ class UserPreferences {
 
 	private function load($userId) {
 		if (!isset($this->preferences[$userId])) {
-			$this->preferences[$userId] = [];
+			$this->preferences[$userId] = $this->defaultPreferences;
 			foreach ($this->service->getPreferences($userId) as $pref) {
 				$this->preferences[$userId][$pref->getName()] = $pref->getValue();
 			};

--- a/lib/Wikia/tests/Persistence/User/PreferencePersistenceMySQLTest.php
+++ b/lib/Wikia/tests/Persistence/User/PreferencePersistenceMySQLTest.php
@@ -8,11 +8,14 @@ class PreferencePersistenceMySQLTest extends \PHPUnit_Framework_TestCase {
 
 	protected $userId = 1;
 	protected $testPreference;
+	protected $testSuperfluousPreference;
 	protected $mysqliMockSlave;
 	protected $mysqliMockMaster;
+	protected $whiteListMock;
 
 	protected function setUp() {
 		$this->testPreference = new Preference( "pref-name", "pref-value" );
+		$this->testSuperfluousPreference = new Preference( "extra-pref-name", "extra-pref-value" );
 		$this->mysqliMockSlave = $this->getMockBuilder( '\DatabaseMysqli' )
 			->setMethods( [ 'select' ] )
 			->disableOriginalConstructor()
@@ -24,6 +27,8 @@ class PreferencePersistenceMySQLTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->disableAutoload()
 			->getMock();
+
+		$this->whiteListMock = ["pref-name"];
 	}
 
 	public function testGetSuccess() {
@@ -95,4 +100,40 @@ class PreferencePersistenceMySQLTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals( [ ], $output, "result failed to match" );
 	}
 
+	public function testGetWhiltelisted() {
+		$this->mysqliMockSlave->expects( $this->once() )
+			->method( 'select' )
+			->with( 'user_properties', [ 'up_property', 'up_value' ], [ 'up_user' => $this->userId, 'up_property' => $this->whiteListMock ], $this->anything() )
+			->willReturn( [
+				(object) [ 'up_user' => $this->userId, 'up_property' => $this->testPreference->getName(), 'up_value' => $this->testPreference->getValue() ],
+				(object) [ 'up_user' => $this->userId, 'up_property' => 'autopatrol', 'up_value' => '0' ],
+				(object) [ 'up_user' => $this->userId, 'up_property' => 'date', 'up_value' => '1' ],
+			] );
+
+		$persistence = new PreferencePersistenceMySQL( $this->mysqliMockMaster, $this->mysqliMockSlave, $this->whiteListMock );
+		$preferences = $persistence->get( $this->userId );
+
+		$this->assertTrue( is_array( $preferences ), "expecting an array" );
+		$this->assertCount(3, $preferences, "expecting exact array size" );
+		$this->assertEquals( $preferences[ 0 ]->getName(), $this->testPreference->getName(), "expecting the test preference name" );
+		$this->assertEquals( $preferences[ 0 ]->getValue(), $this->testPreference->getValue(), "expecting the test preference value" );
+	}
+
+	public function testSaveWhitelisted() {
+		$expected_preferences = [ $this->testPreference ];
+		$input_preferences = [ $this->testPreference, $this->testSuperfluousPreference ];
+		$this->mysqliMockMaster->expects( $this->once() )
+			->method( 'upsert' )
+			->with(
+				PreferencePersistenceMySQL::USER_PREFERENCE_TABLE,
+				PreferencePersistenceMySQL::createTuplesFromPreferences( $this->userId, $expected_preferences ),
+				[ ],
+				PreferencePersistenceMySQL::$UPSERT_SET_BLOCK )
+			->willReturn( true );
+
+		$persistence = new PreferencePersistenceMySQL( $this->mysqliMockMaster, $this->mysqliMockSlave, $this->whiteListMock );
+		$ret = $persistence->save( $this->userId, $input_preferences );
+
+		$this->assertTrue( $ret, "expected true" );
+	}
 }


### PR DESCRIPTION
Added support for User Properties white lists. Changes in wikia/config can be found on: https://github.com/Wikia/config/pull/1197

White lists are implemented in two contexts:
1. On Media Wiki core side (User.php) where we need to distinguish user preferences from other entities (options, flags, attributes) since User.saveOptions() clears all unnecessary entries in 'user_preferences' table
2. On PreferencePersistenceMySQL we do filter fields being saved by 'service mockup' to avoid overwriting entities managed by Media Wiki.

Since we are using regex'es there are some raw SQL statements added since not all API's allow using REGEXP statement (i.e. FluentSQL).

@Wikia/services-team 
