### PR TITLE
CE-2323 Move Title creation from API to places of its usage

### DIFF
--- a/extensions/wikia/Flags/Flags.hooks.php
+++ b/extensions/wikia/Flags/Flags.hooks.php
@@ -299,7 +299,6 @@ class Hooks {
 	public static function getCommonParams( $flagType, $flagParamsNames ) {
 		return [
 			'template' => $flagType['flag_view'],
-			'template_url' => $flagType['flag_view_url'],
 			'flag_type_id' => $flagType['flag_type_id'],
 			'flag_old_params' => $flagType['flag_params_names'],
 			'flag_new_params' => $flagParamsNames

--- a/extensions/wikia/Flags/controllers/FlagsApiController.class.php
+++ b/extensions/wikia/Flags/controllers/FlagsApiController.class.php
@@ -97,7 +97,6 @@ class FlagsApiController extends WikiaApiController {
 	 * 		int flag_group
 	 * 		string flag_name
 	 * 		string flag_view A name of a template of the flag
-	 * 		string flag_view_url A full URL of the template
 	 * 		int flag_targeting
 	 * 		string|null flag_params_names
 	 *

--- a/extensions/wikia/Flags/controllers/FlagsController.class.php
+++ b/extensions/wikia/Flags/controllers/FlagsController.class.php
@@ -126,12 +126,23 @@ class FlagsController extends WikiaController {
 			);
 		} elseif ( $this->getResponseStatus( $response ) ) {
 			$flags = array_values( $this->getResponseData( $response ) );
+
+			foreach ( $flags as $i => $flag ) {
+				$title = Title::newFromText( $flag['flag_view'], NS_TEMPLATE );
+				$flags[$i]['flag_view_link'] = Linker::link(
+					$title,
+					wfMessage( 'flags-edit-form-more-info' )->plain(),
+					[
+						'target' => '_blank',
+					]
+				);
+			}
+
 			$this->setVal( 'editToken', $this->wg->User->getEditToken() );
 			$this->setVal( 'flags', $flags );
 			$this->setVal( 'formSubmitUrl', $this->getLocalUrl( 'postFlagsEditForm' ) );
 			$this->setVal( 'inputNamePrefix', FlagsHelper::FLAGS_INPUT_NAME_PREFIX );
 			$this->setVal( 'inputNameCheckbox', FlagsHelper::FLAGS_INPUT_NAME_CHECKBOX );
-			$this->setVal( 'moreInfo', wfMessage( 'flags-edit-form-more-info' )->plain() );
 			$this->setVal( 'pageId', $pageId );
 		} else {
 			$this->setVal(

--- a/extensions/wikia/Flags/controllers/templates/FlagsController_editForm.mustache
+++ b/extensions/wikia/Flags/controllers/templates/FlagsController_editForm.mustache
@@ -4,7 +4,7 @@
 			<li>
 				<input type="checkbox" id="{{inputNamePrefix}}:{{flag_type_id}}" name="{{inputNamePrefix}}[{{flag_type_id}}][{{inputNameCheckbox}}]" {{#flag_id}}checked{{/flag_id}}>
 				<label for="{{inputNamePrefix}}:{{flag_type_id}}">{{flag_name}}</label>
-				<a href="{{flag_view_url}}" data-id="more-info" target="_blank">{{moreInfo}}</a>
+				{{{flag_view_link}}}
 				{{#flag_params_names.length}}
 					<fieldset class="params">
 						{{#flag_params_names}}

--- a/extensions/wikia/Flags/controllers/templates/SpecialFlagsController_index.php
+++ b/extensions/wikia/Flags/controllers/templates/SpecialFlagsController_index.php
@@ -23,9 +23,10 @@
 		<tr class="flags-special-list-item">
 			<td class="flags-special-list-item-name"><?= $flag['flag_name'] ?></td>
 			<td class="flags-special-list-item-template">
-				<a class="flags-special-list-item-template-link" href="<?= Sanitizer::cleanUrl( $title->getFullURL() ) ?>" target="_blank">
-					<?= $flag['flag_view'] ?>
-				</a>
+				<?= Linker::link( $title, $flag['flag_view'], [
+					'class' => 'flags-special-list-item-template-link',
+					'target' => '_blank',
+				] ); ?>
 			</td>
 			<td class="flags-special-list-item-params">
 				<?php

--- a/extensions/wikia/Flags/models/Flag.class.php
+++ b/extensions/wikia/Flags/models/Flag.class.php
@@ -72,14 +72,6 @@ class Flag extends FlagsBaseModel {
 			->AND_( 'flags_to_pages.page_id' )->EQUAL_TO( $pageId )
 			->runLoop( $db, function( &$flagsWithTypes, $row ) {
 				$flagsWithTypes[$row->flag_type_id] = get_object_vars( $row );
-
-				/**
-				 * Get a URL for a template of the flag.
-				 * If the template under flag_view does not exist - we will just
-				 * display a red link so there is no need to check if $title exists.
-				 */
-				$title = \Title::newFromText( $row->flag_view, NS_TEMPLATE );
-				$flagsWithTypes[$row->flag_type_id]['flag_view_url'] = $title->getFullURL();
 			} );
 
 		return $flagsWithTypes;

--- a/extensions/wikia/Flags/models/FlagType.class.php
+++ b/extensions/wikia/Flags/models/FlagType.class.php
@@ -133,12 +133,6 @@ class FlagType extends FlagsBaseModel {
 			->ORDER_BY( 'flag_name ASC' )
 			->runLoop( $db, function( &$flagTypesForWikia, $row ) {
 				$flagTypesForWikia[$row->flag_type_id] = get_object_vars( $row );
-
-				/**
-				 * Create URLs for a template of the flag
-				 */
-				$title = \Title::newFromText( $row->flag_view, NS_TEMPLATE );
-				$flagTypesForWikia[$row->flag_type_id]['flag_view_url'] = $title->getFullURL();
 			} );
 
 		return $flagTypesForWikia;
@@ -221,8 +215,6 @@ class FlagType extends FlagsBaseModel {
 		$flagTypeId = $db->insertId();
 
 		$db->commit();
-
-		$this->paramsVerified = false;
 
 		return $flagTypeId;
 	}


### PR DESCRIPTION
Hello @Wikia/community-engineering !

This is a permanent fix for [CE-2323](https://wikia-inc.atlassian.net/browse/CE-2323). I've removed Title object creation from API entirely. It is now created only when needed. I also use the `Linker` class to create Links since it deals with `Title === null` well by creating a red link.

CC: @lgarczewski @kamilkoterba 
