### PR TITLE
check value of $wgSharedDB when selecting the database

### DIFF
--- a/lib/Wikia/src/Service/User/Preferences/PreferenceModule.php
+++ b/lib/Wikia/src/Service/User/Preferences/PreferenceModule.php
@@ -31,12 +31,26 @@ class PreferenceModule implements Module {
 
 	private static function bindMysqlService(InjectorBuilder $builder) {
 		$masterProvider = function() {
-			global $wgExternalSharedDB;
-			return wfGetDB(DB_MASTER, [], $wgExternalSharedDB);
+			global $wgExternalSharedDB, $wgSharedDB;
+
+			if (isset($wgSharedDB)) {
+				$db = wfGetDB(DB_MASTER, [], $wgExternalSharedDB);
+			} else {
+				$db = wfGetDB(DB_MASTER);
+			}
+
+			return $db;
 		};
 		$slaveProvider = function() {
-			global $wgExternalSharedDB;
-			return wfGetDB(DB_SLAVE, [], $wgExternalSharedDB);
+			global $wgExternalSharedDB, $wgSharedDB;
+
+			if (isset($wgSharedDB)) {
+				$db = wfGetDB(DB_SLAVE, [], $wgExternalSharedDB);
+			} else {
+				$db = wfGetDB(DB_SLAVE);
+			}
+
+			return $db;
 		};
 		$whiteListProvider = function() {
 			global $wgUserPreferenceWhiteList;


### PR DESCRIPTION
@Wikia/services-team 
update the database selection in `PreferenceModule` to be consistent with what's in User.php [`loadOptions`](https://github.com/Wikia/app/blob/dev/includes/User.php#L4777) and [`saveOptions`](https://github.com/Wikia/app/blob/dev/includes/User.php#L4814)
