### PR TITLE
CE-2210 Display injected flags as a flex-box

### DIFF
--- a/extensions/wikia/Flags/controllers/FlagsController.class.php
+++ b/extensions/wikia/Flags/controllers/FlagsController.class.php
@@ -84,9 +84,12 @@ class FlagsController extends WikiaController {
 		$flagsText = $flagsParserOutput->getText();
 
 		/**
-		 * Update the mText of the original ParserOutput object and merge other properties
+		 * Update the mText of the original ParserOutput object and merge other properties.
+		 * If the __FLAGS__ magic word is matched - replace the CSS class of the flags container
+		 * to an inline one.
 		 */
 		if ( $mwf->match( $pageText ) ) {
+			$flagsText = $this->makeFlagsInline( $flagsText );
 			$pageText = $mwf->replace( $flagsText, $pageText );
 		} else {
 			$pageText = $flagsText . $pageText;
@@ -469,5 +472,9 @@ class FlagsController extends WikiaController {
 				'prms' => $request->getParams(),
 			]
 		);
+	}
+
+	private function makeFlagsInline( $flagsHtml ) {
+		return str_replace( FlagView::FLAGS_CSS_CLASS, FlagView::FLAGS_CSS_CLASS_INLINE, $flagsHtml );
 	}
 }

--- a/extensions/wikia/Flags/scripts/FlagsModal.js
+++ b/extensions/wikia/Flags/scripts/FlagsModal.js
@@ -243,7 +243,11 @@ require(
 			$div = $(document.createElement('div'))
 				.addClass('flags-edit')
 				.html($a);
-		$('.portable-flags').prepend($div).append($div.clone(true));
+		if ($('.portable-flags').length !== 0) {
+			$('.portable-flags').prepend($div).append($div.clone(true));
+		} else if ($('.portable-flags-inline').length !== 0) {
+			$('.portable-flags-inline').prepend($div).append($div.clone(true));
+		}
 	}
 
 	// Run initialization method on DOM ready

--- a/extensions/wikia/Flags/scripts/FlagsModal.js
+++ b/extensions/wikia/Flags/scripts/FlagsModal.js
@@ -243,10 +243,14 @@ require(
 			$div = $(document.createElement('div'))
 				.addClass('flags-edit')
 				.html($a);
-		if ($('.portable-flags').length !== 0) {
-			$('.portable-flags').prepend($div).append($div.clone(true));
-		} else if ($('.portable-flags-inline').length !== 0) {
-			$('.portable-flags-inline').prepend($div).append($div.clone(true));
+		var flagsContainer = $('.portable-flags');
+		if (flagsContainer.length !== 0) {
+			flagsContainer.prepend($div).append($div.clone(true));
+		} else {
+			flagsContainer = $('.portable-flags-inline');
+			if (flagsContainer.length !== 0) {
+				flagsContainer.prepend($div).append($div.clone(true));
+			}
 		}
 	}
 

--- a/extensions/wikia/Flags/styles/Flags.scss
+++ b/extensions/wikia/Flags/styles/Flags.scss
@@ -19,8 +19,8 @@
 	display: -ms-flexbox;
 	display: -webkit-flex;
 	display: flex;
-	-webkit-flex-direction: column;
 	-ms-flex-direction: column;
+	-webkit-flex-direction: column;
 	flex-direction: column;
 	margin: 5px 0;
 }

--- a/extensions/wikia/Flags/styles/Flags.scss
+++ b/extensions/wikia/Flags/styles/Flags.scss
@@ -15,6 +15,12 @@
 	margin: 5px 0;
 }
 
+.portable-flags-inline {
+	display: flex;
+	flex-direction: column;
+	margin: 5px 0;
+}
+
 .user-anon .flags-targeting-contributors {
 	display: none;
 }

--- a/extensions/wikia/Flags/styles/Flags.scss
+++ b/extensions/wikia/Flags/styles/Flags.scss
@@ -16,7 +16,11 @@
 }
 
 .portable-flags-inline {
+	display: -ms-flexbox;
+	display: -webkit-flex;
 	display: flex;
+	-webkit-flex-direction: column;
+	-ms-flex-direction: column;
 	flex-direction: column;
 	margin: 5px 0;
 }

--- a/extensions/wikia/Flags/styles/FlagsViewEditEntryPoint.scss
+++ b/extensions/wikia/Flags/styles/FlagsViewEditEntryPoint.scss
@@ -1,6 +1,7 @@
 @import 'skins/shared/color';
 
-.portable-flags {
+.portable-flags,
+.portable-flags-inline {
 	position: relative;
 
 	/* Show edit flags entry point on portable-flags hover */

--- a/extensions/wikia/Flags/views/FlagView.class.php
+++ b/extensions/wikia/Flags/views/FlagView.class.php
@@ -14,6 +14,9 @@ use Flags\Models\FlagType;
 
 class FlagView {
 
+	const FLAGS_CSS_CLASS = 'portable-flags';
+	const FLAGS_CSS_CLASS_INLINE = 'portable-flags-inline';
+
 	public static $flagsTargetingCssClasses = [
 		FlagType::FLAG_TARGETING_READERS => 'flags-targeting-readers',
 		FlagType::FLAG_TARGETING_CONTRIBUTORS => 'flags-targeting-contributors',
@@ -71,7 +74,7 @@ class FlagView {
 	 */
 	public function wrapAllFlags( Array $templateCalls ) {
 		return \Html::rawElement( 'div', [
-			'class' => 'portable-flags',
+			'class' => self::FLAGS_CSS_CLASS,
 		], implode( '', $templateCalls ) );
 	}
 }


### PR DESCRIPTION
Hey all!

Portable flags are usually displayed at the top of an article. However, you can modify this behavior with the _**FLAGS**_ magic word. If you put it in a content of an article, flags are injected in this specific place.

The problem was that sometimes the flags container was pushing other elements down on the page because of a `clear: both;` rule.

This PR differentiates flags displayed at the top from the ones injected in the content. The _inline_ ones are going to be displayed with the `display: flex;` rule which allows them to fit to the rest of a page nicely.

CC: @bkoval 
