### PR TITLE
when setting preferences in memory, make sure to add defaults

### DIFF
--- a/lib/Wikia/src/Service/User/Preferences/UserPreferences.php
+++ b/lib/Wikia/src/Service/User/Preferences/UserPreferences.php
@@ -48,7 +48,11 @@ class UserPreferences {
 	}
 
 	public function setPreferencesInCache($userId, $preferences) {
-		$this->preferences[$userId] = $preferences;
+		$this->preferences[$userId] = $this->defaultPreferences;
+
+		foreach ($preferences as $key => $val) {
+			$this->preferences[$userId][$key] = $val;
+		}
 	}
 
 	public function get($userId, $pref, $default = null, $ignoreHidden = false) {


### PR DESCRIPTION
@Wikia/services-team 
https://wikia-inc.atlassian.net/browse/SERVICES-536

Previously we were initializing a user's preferences to an empty array in `load()`. We changed that to default to `$this->defaultPreferences`, but some users have their preferences array saved in memcache already. This change makes it so that a user's preferences are merged onto the defaults when their preferences are set from memcache
