### PR TITLE
album_name_fc and genres were not being entered into Solr correctly d…

### DIFF
--- a/maintenance/wikia/lyrics/scrapers/AlbumScraper.class.php
+++ b/maintenance/wikia/lyrics/scrapers/AlbumScraper.class.php
@@ -18,11 +18,11 @@ class AlbumScraper extends BaseScraper {
 			'article_id' => $article->getId(),
 		];
 		$albumData = array_merge( $albumData, $this->getHeader( $article ) );
-		$albumData['album_lowercase'] = LyricsUtils::lowercase( $albumData['Album'] );
+		$albumData['album_lowercase'] = LyricsUtils::lowercase( $albumData['album'] );
 
 		$albumData['genres'] = $this->getGenres( $article );
-		if ( isset( $albumData['Genre']) && !in_array($albumData['Genre'], $albumData['genres'] ) ) {
-			$albumData['genres'][] = $albumData['Genre'];
+		if ( isset( $albumData['genre']) && !in_array($albumData['genre'], $albumData['genres'] ) ) {
+			$albumData['genres'][] = $albumData['genre'];
 		}
 		return array_merge( $albumData, $this->getFooter( $article ) );
 	}


### PR DESCRIPTION
…ue to a difference in the expected case of some array values.

To verify the data is getting where you want now, you can go to sandbox-s1 and modify some code in /usr/wikia/slot1/current/src/maintenance/wikia/lyrics to output info, then run "perl /usr/wikia/backend/bin/run_maintenance --id=43339 --script='wikia/lyrics/LyricsWikiCrawler.php' >> /home/sean/lyricsSolrScrape.log" and inspect the log that it's appending to.

Hopefully once this fix is live, the indexing will cause album results to start showing up in the mobile app again. We will probably have to re-index the whole site for all of our current albums to show up though.
