### PR TITLE
Attributes on Special:Preferences

### DIFF
--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -3628,7 +3628,7 @@ function wfSplitWikiID( $wiki ) {
  * Note 2: use $this->getDB() in maintenance scripts that may be invoked by
  * updater to ensure that a proper database is being updated.
  *
- * @return DatabaseBase
+ * @return DatabaseMysqli
  */
 function &wfGetDB( $db, $groups = array(), $wiki = false ) {
 	// wikia change begin -- SMW DB separation project, @author Krzysztof Krzyżaniak (eloy)

--- a/includes/Preferences.php
+++ b/includes/Preferences.php
@@ -36,11 +36,6 @@ class Preferences {
 		'searchlimit' => array( 'Preferences', 'filterIntval' ),
 	);
 
-	private static $attributes = [
-		'nickname',
-		'fancysig'
-	];
-
 	/**
 	 * @throws MWException
 	 * @param $user User
@@ -1590,7 +1585,8 @@ class Preferences {
 
 	// attributes that show up on the preferences page. TODO: separate somehow?
 	private static function getAttributes() {
-		return self::$attributes;
+		global $wgUserAttributeWhitelist;
+		return $wgUserAttributeWhitelist;
 	}
 }
 

--- a/includes/Preferences.php
+++ b/includes/Preferences.php
@@ -109,15 +109,7 @@ class Preferences {
 	 * @return array|String
 	 */
 	static function getUserPreference( $name, $info, $user ) {
-		$getCallback = function($property) use ($user) {
-			if (in_array($property, self::getAttributes())) {
-				return $user->getGlobalAttribute($property);
-			} else {
-				return $user->getGlobalPreference($property);
-			}
-		};
-
-		$val = $getCallback($name);
+		$val = self::getUserPreferenceHelper($user, $name);
 
 		// Handling for array-type preferences
 		if ( ( isset( $info['type'] ) && $info['type'] == 'multiselect' ) ||
@@ -127,13 +119,21 @@ class Preferences {
 			$val = array();
 
 			foreach ( $options as $value ) {
-				if ( $getCallback( "$prefix$value" ) ) {
+				if ( self::getUserPreferenceHelper( $user, "$prefix$value" ) ) {
 					$val[] = $value;
 				}
 			}
 		}
 
 		return $val;
+	}
+
+	private static function getUserPreferenceHelper(User $user, $property) {
+		if (in_array($property, self::getAttributes())) {
+			return $user->getGlobalAttribute($property);
+		} else {
+			return $user->getGlobalPreference($property);
+		}
 	}
 
 	/**

--- a/includes/User.php
+++ b/includes/User.php
@@ -4839,7 +4839,7 @@ class User {
 			# <Wikia>
 			if ( $this->shouldOptionBeStored( $key, $value ) ) {
 				$insertRows[] = [ 'up_user' => $this->getId(), 'up_property' => $key, 'up_value' => $value ];
-			} elseif ($this->shouldOptionBeDeleted($key, $value)) {
+			} elseif ($this->isDefaultOption($key, $value)) {
 				$deletePrefs[] = $key;
 			}
 			# </Wikia>
@@ -4897,7 +4897,7 @@ class User {
 		return false;
 	}
 
-	private function shouldOptionBeDeleted($key, $value) {
+	private function isDefaultOption($key, $value) {
 		return $value == self::getDefaultOption($key);
 	}
 

--- a/includes/User.php
+++ b/includes/User.php
@@ -35,7 +35,7 @@ define( 'USER_TOKEN_LENGTH', 32 );
  * Int Serialized record version.
  * @ingroup Constants
  */
-define( 'MW_USER_VERSION', 8 );
+define( 'MW_USER_VERSION', 9 );
 
 /**
  * String Some punctuation to prevent editing from broken text-mangling proxies.
@@ -82,6 +82,8 @@ class User {
 	const EDIT_TOKEN_SUFFIX = EDIT_TOKEN_SUFFIX;
 	const CACHE_PREFERENCES_KEY = "preferences";
 	const GET_SET_OPTION_SAMPLE_RATE = 0.1;
+
+	private static $PROPERTY_UPSERT_SET_BLOCK = [ "up_user = VALUES(up_user)", "up_property = VALUES(up_property)", "up_value = VALUES(up_value)" ];
 
 	/**
 	 * Array of Strings List of member variables which are saved to the
@@ -330,7 +332,7 @@ class User {
 		}
 
 		# Try cache
-		$key = wfMemcKey( 'user', 'id', $this->mId );
+		$key = $this->getCacheKey();
 		$data = $wgMemc->get( $key );
 		if ( !is_array( $data ) || $data['mVersion'] < MW_USER_VERSION ) {
 			# Object is expired, load from DB
@@ -410,11 +412,15 @@ class User {
 		}
 		$data['mVersion'] = MW_USER_VERSION;
 		$data[self::CACHE_PREFERENCES_KEY] = $this->userPreferences()->getPreferences($this->mId);
-		$key = wfMemcKey( 'user', 'id', $this->mId );
+		$key = $this->getCacheKey();
 		global $wgMemc;
 		$wgMemc->set( $key, $data );
 
 		wfDebug( "User: user {$this->mId} stored in cache\n" );
+	}
+
+	private function getCacheKey() {
+		return wfMemcKey('user', 'id', $this->mId);
 	}
 
 	/** @name newFrom*() static factory methods */
@@ -4818,7 +4824,7 @@ class User {
 			$dbw = wfGetDB( DB_MASTER );
 		}
 
-		$insert_rows = array();
+		$insertRows = $deletePrefs = [];
 
 		$saveOptions = $this->mOptions;
 
@@ -4832,7 +4838,9 @@ class User {
 			# Don't bother storing default values
 			# <Wikia>
 			if ( $this->shouldOptionBeStored( $key, $value ) ) {
-				$insert_rows[] = array( 'up_user' => $this->getId(), 'up_property' => $key, 'up_value' => $value );
+				$insertRows[] = [ 'up_user' => $this->getId(), 'up_property' => $key, 'up_value' => $value ];
+			} elseif ($this->shouldOptionBeDeleted($key, $value)) {
+				$deletePrefs[] = $key;
 			}
 			# </Wikia>
 			if ( $extuser && isset( $wgAllowPrefChange[$key] ) ) {
@@ -4847,32 +4855,23 @@ class User {
 			}
 		}
 
-		// kinda ghetto, but :(
+		$preferencesFromService = [];
 		if ($wgPreferencesUseService) {
-			$preferenceNames = array_keys($this->userPreferences()->getPreferences($this->getId()));
-
-			$sql = (new WikiaSQL())
-				->DELETE('user_properties')
-				->WHERE('up_user')->EQUAL_TO($this->getId());
-
-			if (!empty($preferenceNames)) {
-				$sql->AND_('up_property')->NOT_IN($preferenceNames);
-			}
-
-			$sql->run($dbw);
-
-			$insert_rows = array_reduce($insert_rows, function($result, $current) use ($preferenceNames) {
-				if (!in_array($current['up_property'], $preferenceNames)) {
-					$result[] = $current;
-				}
-
-				return $result;
-			}, []);
-		} else {
-			$dbw->delete( 'user_properties', array( 'up_user' => $this->getId() ), __METHOD__ );
+			$preferencesFromService = array_keys($this->userPreferences()->getPreferences($this->getId()));
 		}
 
-		$dbw->insert( 'user_properties', $insert_rows, __METHOD__ );
+		$deletePrefs = array_diff($deletePrefs, $preferencesFromService);
+
+		// user has default set, so clear any other entries from db
+		if (!empty($deletePrefs)) {
+			(new WikiaSQL())
+				->DELETE('user_properties')
+				->WHERE('up_user')->EQUAL_TO($this->getId())
+					->AND_('up_property')->IN($deletePrefs)
+				->run($dbw);
+		}
+
+		$dbw->upsert('user_properties', $insertRows, [], self::$PROPERTY_UPSERT_SET_BLOCK);
 
 		if ( $extuser ) {
 			$extuser->updateUser();
@@ -4896,6 +4895,10 @@ class User {
 			return true;
 		}
 		return false;
+	}
+
+	private function shouldOptionBeDeleted($key, $value) {
+		return $value == self::getDefaultOption($key);
 	}
 
 	/**


### PR DESCRIPTION
@Wikia/services-team 
https://wikia-inc.atlassian.net/browse/SERVICES-536

There are some attributes on Special:Preferences, so when `$user->setGlobalPreference()` was called, the save would fail (because the preference is not on the whitelist). This PR adds a list of attributes to `Preferences.php` to account for that possibility.

Also, because all a user's entries in `user_properties` are deleted in `User->saveOptions`, it's possible that:

``` php
$user->setGlobalPreference('someAttribute', 'foo'); // this won't work, 'foo' isn't on the whitelist
$user->saveOptions();

// in saveOptions
$dbw->delete( 'user_properties', array( 'up_user' => $this->getId() ), __METHOD__ );
// attribute 'foo' is now deleted, but wasn't saved by `setGlobalPreference`
$dbw->insert(...); // 'foo' isn't here either, since it's managed by the UserPreference service
```

This also changes the semantics of `$user->saveOptions` to only delete options when they are equal to the default value for that option. This way, a bug with the above scenario will manifest as "this preference isn't being updated" instead of "this preference is getting deleted"

Requires the change in Wikia/config#1203 for the whitelist
