### PR TITLE
ExternalStoreDBFetchBlobHook: improve handling of dev-archive blobs cluster

### DIFF
--- a/extensions/wikia/Development/ExternalStoreDBFetchBlobHook.php
+++ b/extensions/wikia/Development/ExternalStoreDBFetchBlobHook.php
@@ -39,9 +39,25 @@ function ExternalStoreDBFetchBlobHook( $cluster, $id, $itemID, &$ret ) {
 	wfProfileIn( __METHOD__ );
 
 	// there's already blob text
-	if ($ret !== false) {
+	if ( $ret !== false ) {
 		wfProfileOut( __METHOD__ );
 		return true;
+	}
+
+	// PLATFORM-1381: don't try to fetch revisions from "dev-archive" cluster from production
+	// @see $wgDefaultExternalStore
+	global $wgDefaultExternalStore;
+
+	if ( is_array( $wgDefaultExternalStore ) ) {
+		list( $proto, $devCluster ) = explode( '://', $wgDefaultExternalStore[0], 2 );
+
+		if ( $cluster === $devCluster ) {
+			wfProfileOut( __METHOD__ );
+			$ret = false;
+
+			wfDebug( sprintf( "%s: blob #%d is missing on %s - won't check the production!\n", __METHOD__, $id, $cluster ) );
+			return true;
+		}
 	}
 
 	// wikia doesn't use $itemID
@@ -54,26 +70,26 @@ function ExternalStoreDBFetchBlobHook( $cluster, $id, $itemID, &$ret ) {
 
 	$response = json_decode( Http::get( $url, "default", array( 'noProxy' => true ) ) );
 
-	if( isset( $response->fetchblob ) ) {
+	if ( isset( $response->fetchblob ) ) {
 		$blob = isset( $response->fetchblob->blob ) ? $response->fetchblob->blob : false;
 		$hash = isset( $response->fetchblob->hash ) ? $response->fetchblob->hash : null;
 
-		if( $blob ) {
+		if ( $blob ) {
 			// pack to binary
 			$blob = pack( "H*", $blob );
 			$hash = md5( $blob );
 			// check md5 sum for binary
-			if(  $hash == $response->fetchblob->hash ) {
+			if (  $hash == $response->fetchblob->hash ) {
 				wfDebug( __METHOD__ . ": md5 sum match\n" );
 				$ret = $blob;
 
 				// now store blob in local database but only when it's Poznan's devbox
 				$isPoznanDevbox = ( F::app()->wg->DevelEnvironment === true && F::app()->wg->WikiaDatacenter == "poz" );
-				if( $isPoznanDevbox ) {
+				if ( $isPoznanDevbox ) {
 					wfDebug( __METHOD__ . ": this is poznań devbox\n" );
 					$store = new ExternalStoreDB();
 					$dbw = $store->getMaster( $cluster );
-					if( $dbw ) {
+					if ( $dbw ) {
 						wfDebug( __METHOD__ . ": storing blob $id on local storage $cluster\n" );
 						$dbw->insert(
 							$store->getTable( $dbw ),
@@ -91,7 +107,7 @@ function ExternalStoreDBFetchBlobHook( $cluster, $id, $itemID, &$ret ) {
 		}
 	}
 	else {
-		wfDebug( __METHOD__ . ": malformed response from API call\n" );
+		wfDebug( sprintf( "%s: malformed response from API call (%s)\n", __METHOD__, json_encode( func_get_args() ) ) );
 	}
 	wfProfileOut( __METHOD__ );
 

--- a/extensions/wikia/Development/ExternalStoreDBFetchBlobHook.php
+++ b/extensions/wikia/Development/ExternalStoreDBFetchBlobHook.php
@@ -107,7 +107,7 @@ function ExternalStoreDBFetchBlobHook( $cluster, $id, $itemID, &$ret ) {
 		}
 	}
 	else {
-		wfDebug( sprintf( "%s: malformed response from API call (%s)\n", __METHOD__, json_encode( func_get_args() ) ) );
+		wfDebug( __METHOD__ . ": malformed response from API call\n" );
 	}
 	wfProfileOut( __METHOD__ );
 

--- a/includes/Revision.php
+++ b/includes/Revision.php
@@ -890,6 +890,7 @@ class Revision {
 				wfProfileOut( __METHOD__ );
 				return false;
 			}
+			wfDebug( sprintf( "%s: for '%s'\n", __METHOD__, $row->page_title ) ); // Wikia change - PLATFORM-1381
 			$text = ExternalStore::fetchFromURL( $url );
 		}
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-1381

Do not try to fetch missing blobs from production when revision entry clearly states that the blob is stored on `dev-archive` cluster. I'm 100% sure that it won't be on production blobs cluster as well ;)

The fix is appllied on Poznań devbox only.

Added logging of the page title we want to get blob for. For instance:

```
Revision::getRevisionText: for 'Wikia-navigation-global'
ExternalStoreDB::fetchBlob cache miss on dev-archive/96229171
writable external storeQuery dataware (2916) (master): SELECT /* ExternalStoreDB::fetchBlob Macbre */  blob_text  FROM `blobs`  WHERE blob_id = '96229171'  LIMIT 1  
Query dataware (2917) (master): SELECT /* ExternalStoreDB::fetchBlob Macbre */  blob_text  FROM `blobs`  WHERE blob_id = '96229171'  LIMIT 1  
ExternalStoreDBFetchBlobHook: blob #96229171 is missing on dev-archive - won't check the production!
```

@wladekb / @michalroszka / @RafLeszczynski / @owend 
