### PR TITLE
HG-785 - replace data://uri with //:0 for images in HG article API response

### DIFF
--- a/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php
+++ b/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php
@@ -17,7 +17,7 @@ class ArticleAsJson extends WikiaService {
 	const MEDIA_CONTEXT_INFOBOX = 'infobox';
 
 	private static function createMarker( $width = 0, $height = 0, $isGallery = false ){
-		$blankImgUrl = 'foo';//F::app()->wg->blankImgUrl;
+		$blankImgUrl = '//:0';
 		$id = count( self::$media ) - 1;
 		$classes = 'article-media' . ($isGallery ? ' gallery' : '');
 		$width = !empty( $width ) ? " width='{$width}'" : '';

--- a/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php
+++ b/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php
@@ -17,7 +17,7 @@ class ArticleAsJson extends WikiaService {
 	const MEDIA_CONTEXT_INFOBOX = 'infobox';
 
 	private static function createMarker( $width = 0, $height = 0, $isGallery = false ){
-		$blankImgUrl = F::app()->wg->blankImgUrl;
+		$blankImgUrl = '//:0';
 		$id = count( self::$media ) - 1;
 		$classes = 'article-media' . ($isGallery ? ' gallery' : '');
 		$width = !empty( $width ) ? " width='{$width}'" : '';

--- a/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php
+++ b/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php
@@ -17,7 +17,7 @@ class ArticleAsJson extends WikiaService {
 	const MEDIA_CONTEXT_INFOBOX = 'infobox';
 
 	private static function createMarker( $width = 0, $height = 0, $isGallery = false ){
-		$blankImgUrl = F::app()->wg->blankImgUrl;
+		$blankImgUrl = 'foo';//F::app()->wg->blankImgUrl;
 		$id = count( self::$media ) - 1;
 		$classes = 'article-media' . ($isGallery ? ' gallery' : '');
 		$width = !empty( $width ) ? " width='{$width}'" : '';

--- a/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php
+++ b/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php
@@ -17,7 +17,7 @@ class ArticleAsJson extends WikiaService {
 	const MEDIA_CONTEXT_INFOBOX = 'infobox';
 
 	private static function createMarker( $width = 0, $height = 0, $isGallery = false ){
-		$blankImgUrl = '//:0';
+		$blankImgUrl = F::app()->wg->blankImgUrl;
 		$id = count( self::$media ) - 1;
 		$classes = 'article-media' . ($isGallery ? ' gallery' : '');
 		$width = !empty( $width ) ? " width='{$width}'" : '';

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -854,7 +854,7 @@ $wgCdnStylePath = '';
 /**
  * Transpaent 1x1 GIF URI-encoded (BugId:9975)
  */
-$wgBlankImgUrl = 'data:image/gif;base64,R0lGODlhAQABAIABAAAAAP///yH5BAEAAAEALAAAAAABAAEAQAICTAEAOw%3D%3D';
+$wgBlankImgUrl = '//:0';//'data:image/gif;base64,R0lGODlhAQABAIABAAAAAP///yH5BAEAAAEALAAAAAABAAEAQAICTAEAOw%3D%3D';
 
 /**
  * Serve jQuery from Google's CDN. Disable this variable to serve jQuery as a part of AssetsManager package.

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -854,7 +854,7 @@ $wgCdnStylePath = '';
 /**
  * Transpaent 1x1 GIF URI-encoded (BugId:9975)
  */
-$wgBlankImgUrl = '//:0';//'data:image/gif;base64,R0lGODlhAQABAIABAAAAAP///yH5BAEAAAEALAAAAAABAAEAQAICTAEAOw%3D%3D';
+$wgBlankImgUrl = 'data:image/gif;base64,R0lGODlhAQABAIABAAAAAP///yH5BAEAAAEALAAAAAABAAEAQAICTAEAOw%3D%3D';
 
 /**
  * Serve jQuery from Google's CDN. Disable this variable to serve jQuery as a part of AssetsManager package.


### PR DESCRIPTION
Because base 64 image processing is slower on mobile devices, it is faster to use a `src='//:0'`.
