### PR TITLE
DataMartService - check wgStatsDBEnabled before making a query

### DIFF
--- a/includes/wikia/services/DataMartService.class.php
+++ b/includes/wikia/services/DataMartService.class.php
@@ -873,12 +873,15 @@ class DataMartService extends Service {
 	public static function getWAM200Wikis() {
 		$app = F::app();
 
-		$wikis = (new WikiaSQL())->cacheGlobal(60*60*12)
+		$db = wfGetDB( DB_SLAVE, [], $app->wg->DWStatsDB );
+
+		$wikis = (new WikiaSQL())->skipIf( !$app->wg->StatsDBEnabled )
+			->cacheGlobal(60*60*12)
 			->SELECT('wiki_id')
 			->FROM('dimension_top_wikis')
 			->ORDER_BY('rank')
 			->LIMIT(200)
-			->runLoop(wfGetDB( DB_SLAVE, [], $app->wg->DWStatsDB ), function(&$wikis, $row) {
+			->runLoop($db, function(&$wikis, $row) {
 				$wikis[] = intval($row->wiki_id);
 			});
 

--- a/includes/wikia/services/DataMartService.class.php
+++ b/includes/wikia/services/DataMartService.class.php
@@ -49,7 +49,8 @@ class DataMartService extends Service {
 		}
 
 		$db = DataMartService::getDB();
-		$pageviews = (new WikiaSQL())->skipIf(empty($app->wg->StatsDBEnabled))->cacheGlobal(60*60*12)
+		$pageviews = (new WikiaSQL())->skipIf( self::isDisabled() )
+			->cacheGlobal(60*60*12)
 			->SELECT("date_format(time_id,'%Y-%m-%d')")->AS_('date')
 				->FIELD('pageviews')->AS_('cnt')
 			->FROM('rollup_wiki_pageviews')
@@ -92,7 +93,8 @@ class DataMartService extends Service {
 		}
 
 		$db = DataMartService::getDB();
-		$pageviews = (new WikiaSQL())->skipIf(empty($app->wg->StatsDBEnabled))->cacheGlobal(60*60*12)
+		$pageviews = (new WikiaSQL())->skipIf( self::isDisabled() )
+			->cacheGlobal(60*60*12)
 			->SELECT('wiki_id')
 				->FIELD("date_format(time_id,'%Y-%m-%d')")->AS_('date')
 				->FIELD('pageviews')->AS_('cnt')
@@ -127,7 +129,8 @@ class DataMartService extends Service {
 		}
 
 		$db = DataMartService::getDB();
-		$pageviews = (new WikiaSQL())->skipIf(empty($app->wg->StatsDBEnabled))->cacheGlobal(60*60*12)
+		$pageviews = (new WikiaSQL())->skipIf( self::isDisabled() )
+			->cacheGlobal(60*60*12)
 			->SELECT('time_id')
 				->SUM('pageviews')->AS_('cnt')
 			->FROM('rollup_wiki_pageviews')
@@ -215,7 +218,8 @@ class DataMartService extends Service {
 
 		$db = DataMartService::getDB();
 
-		$sql = (new WikiaSQL())->skipIf(empty($app->wg->StatsDBEnabled))->cacheGlobal(43200)
+		$sql = (new WikiaSQL())->skipIf( self::isDisabled() )
+			->cacheGlobal(43200)
 			->SELECT('r.wiki_id')->AS_('id')
 				->FIELD($field)->AS_('pageviews')
 			->FROM('report_wiki_recent_pageviews')->AS_('r')
@@ -263,7 +267,8 @@ class DataMartService extends Service {
 
 		$db = DataMartService::getDB();
 
-		$topWikis = (new WikiaSQL())->skipIf(empty($app->wg->StatsDBEnabled))->cacheGlobal(43200)
+		$topWikis = (new WikiaSQL())->skipIf( self::isDisabled() )
+			->cacheGlobal(43200)
 			->SELECT('r.wiki_id')->AS_('id')
 				->SUM('views')->AS_('totalViews')
 			->FROM('rollup_wiki_video_views')->AS_('r')
@@ -310,7 +315,8 @@ class DataMartService extends Service {
 		}
 
 		$db = DataMartService::getDB();
-		$events = (new WikiaSQL())->skipIf(empty($app->wg->StatsDBEnabled))->cacheGlobal(60*60*12)
+		$events = (new WikiaSQL())->skipIf( self::isDisabled() )
+			->cacheGlobal(60*60*12)
 			->SELECT("date_format(time_id,'%Y-%m-%d')")->AS_('date')
 				->SUM('creates')->AS_('creates')
 				->SUM('edits')->AS_('edits')
@@ -379,7 +385,7 @@ class DataMartService extends Service {
 			86400 /* 24 hours */,
 			function () use ($app, $wikiId, $userIds, $periodId, $rollupDate) {
 				$db = DataMartService::getDB();
-				$events = (new WikiaSQL())->skipIf(empty($app->wg->StatsDBEnabled))
+				$events = (new WikiaSQL())->skipIf( self::isDisabled() )
 					->SELECT('user_id')
 						->SUM('creates')->AS_('creates')
 						->SUM('edits')->AS_('edits')
@@ -441,7 +447,7 @@ class DataMartService extends Service {
 		//compensation for NOW
 		$date = date( 'Y-m-d' ) . ' 00:00:01';
 		do {
-			$date = ( new WikiaSQL() )->skipIf( empty( $app->wg->StatsDBEnabled ) )
+			$date = ( new WikiaSQL() )->skipIf( self::isDisabled() )
 				->SELECT( 'max(time_id) as t' )
 				->FROM( 'rollup_wiki_article_pageviews' )
 				->WHERE( 'time_id' )->LESS_THAN( $date )
@@ -460,7 +466,7 @@ class DataMartService extends Service {
 				break;
 			}
 
-			$found =  ( new WikiaSQL() )->skipIf( empty( $app->wg->StatsDBEnabled ) )
+			$found =  ( new WikiaSQL() )->skipIf( self::isDisabled() )
 				->SELECT( '1 as c' )
 				->FROM( 'rollup_wiki_article_pageviews' )
 				->WHERE( 'time_id' )->EQUAL_TO( $date )
@@ -544,7 +550,7 @@ class DataMartService extends Service {
 			*/
 
 			$db = DataMartService::getDB();
-			$sql = (new WikiaSQL())->skipIf(empty($app->wg->StatsDBEnabled))
+			$sql = (new WikiaSQL())->skipIf( self::isDisabled() )
 				->SELECT('namespace_id', 'article_id', 'pageviews as pv')
 				->FROM('rollup_wiki_article_pageviews')
 				->WHERE('time_id')->EQUAL_TO(
@@ -801,7 +807,7 @@ class DataMartService extends Service {
 		$tagViews = $app->wg->Memc->get($memKey);
 		if (!is_array($tagViews)) {
 			$tagViews = array();
-			if (!empty($app->wg->StatsDBEnabled)) {
+			if ( !self::isDisabled() ) {
 				$db = DataMartService::getDB();
 
 				$tables = array(
@@ -856,7 +862,7 @@ class DataMartService extends Service {
 
 		$db = wfGetDB( DB_SLAVE, [], $app->wg->DWStatsDB );
 
-		$articlePageViews = ( new WikiaSQL() )->skipIf( !$app->wg->StatsDBEnabled )
+		$articlePageViews = ( new WikiaSQL() )->skipIf( self::isDisabled() )
 			->SELECT( 'article_id', 'pageviews' )
 			->FROM( 'rollup_wiki_article_pageviews' )
 			->WHERE( 'article_id' )->IN( $articlesIds )
@@ -875,7 +881,7 @@ class DataMartService extends Service {
 
 		$db = wfGetDB( DB_SLAVE, [], $app->wg->DWStatsDB );
 
-		$wikis = (new WikiaSQL())->skipIf( !$app->wg->StatsDBEnabled )
+		$wikis = (new WikiaSQL())->skipIf( self::isDisabled() )
 			->cacheGlobal(60*60*12)
 			->SELECT('wiki_id')
 			->FROM('dimension_top_wikis')
@@ -896,5 +902,13 @@ class DataMartService extends Service {
 		return $db;
 	}
 
+	/**
+	 * wgStatsDBEnabled can be used to disable queries to statsdb_mart database
+	 *
+	 * @return bool
+	 */
+	protected static function isDisabled() {
+		return empty( F::app()->wg->StatsDBEnabled );
+	}
 
 }

--- a/includes/wikia/services/DataMartService.class.php
+++ b/includes/wikia/services/DataMartService.class.php
@@ -23,6 +23,8 @@ class DataMartService extends Service {
 
 	const TOP_WIKIS_FOR_HUB = 10;
 
+	const TTL = 43200; // WikiaSQL results caching time (12 hours)
+
 	/**
 	 * get pageviews
 	 * @param integer $periodId
@@ -50,7 +52,7 @@ class DataMartService extends Service {
 
 		$db = DataMartService::getDB();
 		$pageviews = (new WikiaSQL())->skipIf( self::isDisabled() )
-			->cacheGlobal(60*60*12)
+			->cacheGlobal( self::TTL )
 			->SELECT("date_format(time_id,'%Y-%m-%d')")->AS_('date')
 				->FIELD('pageviews')->AS_('cnt')
 			->FROM('rollup_wiki_pageviews')
@@ -94,7 +96,7 @@ class DataMartService extends Service {
 
 		$db = DataMartService::getDB();
 		$pageviews = (new WikiaSQL())->skipIf( self::isDisabled() )
-			->cacheGlobal(60*60*12)
+			->cacheGlobal( self::TTL )
 			->SELECT('wiki_id')
 				->FIELD("date_format(time_id,'%Y-%m-%d')")->AS_('date')
 				->FIELD('pageviews')->AS_('cnt')
@@ -130,7 +132,7 @@ class DataMartService extends Service {
 
 		$db = DataMartService::getDB();
 		$pageviews = (new WikiaSQL())->skipIf( self::isDisabled() )
-			->cacheGlobal(60*60*12)
+			->cacheGlobal( self::TTL )
 			->SELECT('time_id')
 				->SUM('pageviews')->AS_('cnt')
 			->FROM('rollup_wiki_pageviews')
@@ -219,7 +221,7 @@ class DataMartService extends Service {
 		$db = DataMartService::getDB();
 
 		$sql = (new WikiaSQL())->skipIf( self::isDisabled() )
-			->cacheGlobal(43200)
+			->cacheGlobal( self::TTL )
 			->SELECT('r.wiki_id')->AS_('id')
 				->FIELD($field)->AS_('pageviews')
 			->FROM('report_wiki_recent_pageviews')->AS_('r')
@@ -268,7 +270,7 @@ class DataMartService extends Service {
 		$db = DataMartService::getDB();
 
 		$topWikis = (new WikiaSQL())->skipIf( self::isDisabled() )
-			->cacheGlobal(43200)
+			->cacheGlobal( self::TTL )
 			->SELECT('r.wiki_id')->AS_('id')
 				->SUM('views')->AS_('totalViews')
 			->FROM('rollup_wiki_video_views')->AS_('r')
@@ -316,7 +318,7 @@ class DataMartService extends Service {
 
 		$db = DataMartService::getDB();
 		$events = (new WikiaSQL())->skipIf( self::isDisabled() )
-			->cacheGlobal(60*60*12)
+			->cacheGlobal( self::TTL )
 			->SELECT("date_format(time_id,'%Y-%m-%d')")->AS_('date')
 				->SUM('creates')->AS_('creates')
 				->SUM('edits')->AS_('edits')
@@ -882,7 +884,7 @@ class DataMartService extends Service {
 		$db = wfGetDB( DB_SLAVE, [], $app->wg->DWStatsDB );
 
 		$wikis = (new WikiaSQL())->skipIf( self::isDisabled() )
-			->cacheGlobal(60*60*12)
+			->cacheGlobal( self::TTL )
 			->SELECT('wiki_id')
 			->FROM('dimension_top_wikis')
 			->ORDER_BY('rank')

--- a/includes/wikia/services/WAMService.class.php
+++ b/includes/wikia/services/WAMService.class.php
@@ -58,6 +58,10 @@ class WAMService extends Service {
 		$memKey = wfSharedMemcKey('datamart', self::MEMCACHE_VER, 'wam', $wikiId);
 
 		$getData = function () use ($wikiId) {
+			if ( $this->isDisabled() ) {
+				return 0;
+			}
+
 			$db = $this->getDB();
 
 			$result = $db->select(
@@ -112,6 +116,11 @@ class WAMService extends Service {
 			'wam_results_total' => 0
 		);
 
+		if ( $this->isDisabled() ) {
+			wfProfileOut( __METHOD__ );
+			return $wamIndex;
+		}
+
 		$db = $this->getDB();
 
 		$tables = $this->getWamIndexTables();
@@ -160,6 +169,10 @@ class WAMService extends Service {
 			'min_date' => null
 		);
 
+		if ( $this->isDisabled() ) {
+			return $dates;
+		}
+
 		wfProfileIn(__METHOD__);
 
 		$db = $this->getDB();
@@ -193,6 +206,10 @@ class WAMService extends Service {
 		$memKey = wfSharedMemcKey( 'wam-languages', self::MEMCACHE_VER, $date );
 
 		$getData = function () use ( $date ) {
+			if ( $this->isDisabled() ) {
+				return [];
+			}
+
 			$db = $this->getDB();
 			$result = $db->select(
 				[
@@ -406,5 +423,14 @@ class WAMService extends Service {
 		$db = wfGetDB( DB_SLAVE, array(), $app->wg->DatamartDB );
 		$db->clearFlag( DBO_TRX );
 		return $db;
+	}
+
+	/**
+	 * wgStatsDBEnabled can be used to disable queries to statsdb_mart database
+	 *
+	 * @return bool
+	 */
+	protected function isDisabled() {
+		return empty( F::app()->wg->StatsDBEnabled );
 	}
 }


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-1378

Prevent making queries to `statsdb_mart` when `$wgStatsDBEnabled` is set to false. Wikia One doesn't need to get any data from there.

Plus a small code cleanup.

@michalroszka / @wladekb 
