### PR TITLE
(MAIN-5060) Fix Blog comment redirects

### DIFF
--- a/extensions/wikia/ArticleComments/classes/ArticleCommentList.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleCommentList.class.php
@@ -981,6 +981,8 @@ class ArticleCommentList {
 		}
 
 		F::app()->wg->Out->redirect( $redirectTitle->getFullUrl( $query ) );
+
+		return true;
 	}
 
 	/**
@@ -1000,6 +1002,8 @@ class ArticleCommentList {
 		if ( $title->getPrefixedDBkey() != F::app()->wg->Title->getPrefixedDBkey() ) {
 			return false;
 		}
+
+		return true;
 	}
 
 	static private function canSetRedirect() {


### PR DESCRIPTION
The fix for SOC-1027 (#7940) added ArticleCommentList::isTitleForCurrentRequest
to check if the comment was the current title, but it failed to return anything
when this was true, so the self::isTitleForCurrentRequest( $title ) check would
always evaluate to false (empty) and no redirect to the Blog page would occur
when viewing comments.

This explicitly returns true when the checks in isTitleForCurrentRequest pass
and adds a return value for the ArticleFromTitle when the redirect occurs, as
all hook methods require a return value.

/cc @garthwebb 
