### PR TITLE
ExternalStoreDB: skip the datacenter check

### DIFF
--- a/extensions/wikia/Development/ExternalStoreDBFetchBlobHook.php
+++ b/extensions/wikia/Development/ExternalStoreDBFetchBlobHook.php
@@ -23,8 +23,15 @@
 
 global $wgFetchBlobApiURL;
 $wgFetchBlobApiURL = "http://community.wikia.com/api.php";
-// $app->registerHook( "ExternalStoreDB::fetchBlob", "ExternalStoreDBFetchBlobHook" );
+
 $wgHooks[ "ExternalStoreDB::fetchBlob" ][ ] = "ExternalStoreDBFetchBlobHook";
+
+$wgExtensionCredits['other'][] = [
+	'name' => 'ExternalStoreDB fetch blob',
+	'author' => [
+		'Krzysztof Krzyżaniak'
+	],
+];
 
 /**
  * hook for ExternalStoreDB::FetchBlob
@@ -83,22 +90,18 @@ function ExternalStoreDBFetchBlobHook( $cluster, $id, $itemID, &$ret ) {
 				wfDebug( __METHOD__ . ": md5 sum match\n" );
 				$ret = $blob;
 
-				// now store blob in local database but only when it's Poznan's devbox
-				$isPoznanDevbox = ( F::app()->wg->DevelEnvironment === true && F::app()->wg->WikiaDatacenter == "poz" );
-				if ( $isPoznanDevbox ) {
-					wfDebug( __METHOD__ . ": this is poznań devbox\n" );
-					$store = new ExternalStoreDB();
-					$dbw = $store->getMaster( $cluster );
-					if ( $dbw ) {
-						wfDebug( __METHOD__ . ": storing blob $id on local storage $cluster\n" );
-						$dbw->insert(
-							$store->getTable( $dbw ),
-							array( "blob_id" => $id, "blob_text" => $ret ),
-							__METHOD__,
-							array( "IGNORE" )
-						);
-						$dbw->commit();
-					}
+				// now store blob in local database
+				$store = new ExternalStoreDB();
+				$dbw = $store->getMaster( $cluster );
+				if ( $dbw ) {
+					wfDebug( __METHOD__ . ": storing blob $id on local storage $cluster\n" );
+					$dbw->insert(
+						$store->getTable( $dbw ),
+						array( "blob_id" => $id, "blob_text" => $ret ),
+						__METHOD__,
+						array( "IGNORE" )
+					);
+					$dbw->commit();
 				}
 			}
 			else {

--- a/maintenance/wikia/getDatabase.php
+++ b/maintenance/wikia/getDatabase.php
@@ -41,13 +41,13 @@ if (array_key_exists('p', $opts)) {
 switch($wgWikiaDatacenter) {
 	case WIKIA_DC_POZ:
 		$wgDBdevboxServer1 = 'dev-db-p1';
-		$wgDBdevboxServer2 = 'dev-db-p2';
+		$wgDBdevboxServer2 = 'dev-db-p1';
 		$wgDBdevboxCentral = 'dev-db-p1';
 		break;
 	case WIKIA_DC_SJC:
-		$wgDBdevboxServer1 = 'dev-db-a1';
-		$wgDBdevboxServer2 = 'dev-db-b1';
-		$wgDBdevboxCentral = 'dev-db-central';
+		$wgDBdevboxServer1 = 'dev-db-s1';
+		$wgDBdevboxServer2 = 'dev-db-s1';
+		$wgDBdevboxCentral = 'dev-db-s1';
 		break;
 	default:
 		die("unknown data center: {$opts['p']}\n$USAGE");


### PR DESCRIPTION
This extension is now loaded in both devbox datacenters - https://github.com/Wikia/config/commit/bdc78637d37380a26d856814aba66a658580dbb0. We can skip this check.

See https://github.com/Wikia/config/pull/1204

@drozdo / @michalroszka / @wladekb / @owend 
