### PR TITLE
don't save a preference value with what's already saved for the user

### DIFF
--- a/lib/Wikia/src/Service/User/Preferences/UserPreferences.php
+++ b/lib/Wikia/src/Service/User/Preferences/UserPreferences.php
@@ -81,10 +81,14 @@ class UserPreferences {
 	 * @param array $prefs
 	 */
 	public function setMultiple( $userId, $prefs ) {
-		$this->load( $userId );
+		$currentPreferences = $this->load( $userId );
 		$prefToSave = [ ];
 
 		foreach ( $prefs as $pref => $val ) {
+			if ($currentPreferences[$pref] == $val) {
+				continue;
+			}
+
 			$default = $this->getFromDefault( $pref );
 			if ( $val === null && isset( $default ) ) {
 				$val = $default;


### PR DESCRIPTION
@Wikia/services-team 
https://wikia-inc.atlassian.net/browse/SERVICES-572

We're currently always saving a preference when `setGlobalPreference` is called, regardless of whether or not the value is already stored for that user. This change makes it so only preferences that differ from what's stored in the database are set.
