### PR TITLE
Log strict standard errors in /var/log/php

### DIFF
--- a/lib/Wikia/src/Logger/WikiaLogger.php
+++ b/lib/Wikia/src/Logger/WikiaLogger.php
@@ -64,6 +64,9 @@ class WikiaLogger {
 				$priorityString = 'Fatal Error';
 				break;
 			case E_STRICT:
+				$method = 'warning';
+				$priorityString = 'Strict Standards';
+				break;
 			case E_PARSE:
 			case E_COMPILE_ERROR:
 			case E_COMPILE_WARNING:


### PR DESCRIPTION
Error Reporter creates P3s with Strict Standards violations.
I figured it makes sense to log them to /var/log/php so we can detect them during development.

This solution is the one which worked for me but I'm not sure if it's the best one.

/cc @macbre @michalroszka @hakubo 
