### PR TITLE
Change @internal from classes in includes

### DIFF
--- a/includes/Article.php
+++ b/includes/Article.php
@@ -15,7 +15,7 @@
  * Note: edit user interface and cache support functions have been
  * moved to separate EditPage and HTMLFileCache classes.
  *
- * @internal documentation reviewed 15 Mar 2010
+ * internal documentation reviewed 15 Mar 2010
  *
  * //Wikia Change Start - helping PHP lint
  * @property Title mTitle

--- a/includes/BacklinkCache.php
+++ b/includes/BacklinkCache.php
@@ -17,7 +17,7 @@
  *
  * Introduced by r47317
  *
- * @internal documentation reviewed on 18 Mar 2011 by hashar
+ * internal documentation reviewed on 18 Mar 2011 by hashar
  *
  * @author Tim Starling
  * @copyright © 2009, Tim Starling, Domas Mituzas

--- a/includes/Title.php
+++ b/includes/Title.php
@@ -26,7 +26,7 @@
  * @note This class can fetch various kinds of data from the database;
  *       however, it does so inefficiently.
  *
- * @internal documentation reviewed 15 Mar 2010
+ * internal documentation reviewed 15 Mar 2010
  */
 class Title {
 	/** @name Static cache variables */
@@ -882,7 +882,7 @@ class Title {
 	 * Is this in a namespace that allows actual pages?
 	 *
 	 * @return Bool
-	 * @internal note -- uses hardcoded namespace index instead of constants
+	 * internal note -- uses hardcoded namespace index instead of constants
 	 */
 	public function canExist() {
 		return $this->mNamespace >= NS_MAIN;

--- a/includes/User.php
+++ b/includes/User.php
@@ -3075,7 +3075,7 @@ class User {
 	/**
 	 * Check if user is allowed to access a feature / make an action
 	 *
-	 * @internal param \String $varargs permissions to test
+	 * internal param \String $varargs permissions to test
 	 * @return Boolean: True if user is allowed to perform *any* of the given actions
 	 *
 	 * @return bool
@@ -3092,7 +3092,7 @@ class User {
 
 	/**
 	 *
-	 * @internal param $varargs string
+	 * internal param $varargs string
 	 * @return bool True if the user is allowed to perform *all* of the given actions
 	 */
 	public function isAllowedAll( /*...*/ ){

--- a/includes/Wiki.php
+++ b/includes/Wiki.php
@@ -23,7 +23,7 @@
 /**
  * The MediaWiki class is the helper class for the index.php entry point.
  *
- * @internal documentation reviewed 15 Mar 2010
+ * internal documentation reviewed 15 Mar 2010
  */
 class MediaWiki {
 

--- a/includes/WikiPage.php
+++ b/includes/WikiPage.php
@@ -10,7 +10,7 @@ abstract class Page {}
  * Some fields are public only for backwards-compatibility. Use accessors.
  * In the past, this class was part of Article.php and everything was public.
  *
- * @internal documentation reviewed 15 Mar 2010
+ * internal documentation reviewed 15 Mar 2010
  */
 class WikiPage extends Page {
 	// doDeleteArticleReal() return values. Values less than zero indicate fatal errors,


### PR DESCRIPTION
Remove obsolete "@" from docblocks allows us to see classnames without strikeout in phpStorm :)

/cc @hakubo @lgarczewski @bognix @Warkot  
