### PR TITLE
CE-2405 Create a maintenance script for reruning the local rename job

### DIFF
--- a/includes/User.php
+++ b/includes/User.php
@@ -70,6 +70,7 @@ class User {
 	 * Traits extending the class
 	 */
 	use PowerUserTrait;
+	use GlobalUserDataTrait;
 	# WIKIA CHANGE END
 
 	use Loggable;

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -427,6 +427,7 @@ $wgAutoloadClasses['UserAllowedRequirementTrait'] = $IP . '/includes/wikia/trait
 $wgAutoloadClasses['UserAllowedRequirementThrowsErrorTrait'] = $IP . '/includes/wikia/traits/UserAllowedRequirementTrait.php';
 $wgAutoloadClasses['IncludeMessagesTrait'] = $IP . '/includes/wikia/traits/IncludeMessagesTrait.php';
 $wgAutoloadClasses['PowerUserTrait'] = $IP . '/includes/wikia/traits/PowerUserTrait.php';
+$wgAutoloadClasses['GlobalUserDataTrait'] = $IP . '/includes/wikia/traits/GlobalUserDataTrait.php';
 $wgAutoloadClasses['TitleTrait'] = $IP . '/includes/wikia/traits/TitleTrait.php';
 
 // Profiler classes

--- a/includes/wikia/traits/GlobalUserDataTrait.php
+++ b/includes/wikia/traits/GlobalUserDataTrait.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * A trait that extends the User class with methods to gather
+ * global data on a user's activity.
+ *
+ * @author Adam Karmiński <adamk@wikia-inc.com>
+ */
+
+trait GlobalUserDataTrait {
+	// Required base-class methods
+	abstract function getId();
+
+	/**
+	 * Gets unique IDs of wikias that a user has contributed at.
+	 *
+	 * @return array An array of IDs
+	 */
+	public function getWikiasWithUserContributions() {
+		$db = wfGetDB( DB_SLAVE, [], F::app()->wg->DatamartDB );
+
+		$wikis = ( new WikiaSQL() )->skipIf( empty( F::app()->wg->StatsDBEnabled ) )
+			->SELECT( 'wiki_id' )
+			->FROM( 'rollup_edit_events' )
+			->WHERE( 'user_id' )->EQUAL_TO( $this->getId() )
+			->GROUP_BY( 'wiki_id' )
+			->runLoop( $db, function( &$wikis, $row ) {
+				$wikis[] = intval( $row->wiki_id );
+			} );
+
+		return (array) $wikis;
+	}
+}

--- a/maintenance/wikia/RerunRenameUserLocal.class.php
+++ b/maintenance/wikia/RerunRenameUserLocal.class.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * RerunRenameUserLocal maintenance script
+ *
+ * This script is an answer to a lot of unfinished and broken user rename processes. It allows
+ * you to easily rerun the RenameUser_local.php script on every wikia that a user has contributed at.
+ */
+require_once( __DIR__ . '/../Maintenance.php' );
+
+class RerunRenameUserLocal extends Maintenance {
+
+	const RERUN_RENAME_DATE_FORMAT = 'Y-m-d H:i:s';
+
+	private
+		$userId,
+		$oldName,
+		$newName,
+		$log = '',
+		$startTime,
+		$endTime;
+
+	function __construct() {
+		parent::__construct();
+		$this->addOption( 'userId', 'An ID of the renamed user', true, true, 'u' );
+		$this->addOption( 'oldName', 'An old name of the renamed user', true, true, 'o' );
+		$this->addOption( 'newName', 'An old name of the renamed user', true, true, 'n' );
+	}
+
+	public function execute() {
+		$this->getOptions();
+
+		/**
+		 * Fetch IDs of wikias that a user has contributed at.
+		 */
+		$user = User::newFromId( $this->userId );
+		$wikis = $user->getWikiasWithUserContributions();
+
+		/**
+		 * If there are any - run RenameUser_local.php for them.
+		 */
+		if ( !empty( $wikis ) ) {
+			/**
+			 * Log the start time of the process.
+			 */
+			$this->startProcedure();
+
+			$dir = __DIR__;
+			foreach ( $wikis as $wikiId ) {
+				$cmd = sprintf( 'SERVER_ID=%d /usr/bin/php %s/RenameUser_local.php --rename-user-id=%d --rename-old-name="%s" --rename-new-name="%s"',
+					$wikiId, $dir, $this->userId, $this->oldName, $this->newName );
+
+				$this->addLog( "Running: {$cmd}" );
+
+				$scriptOutput = wfShellExec( $cmd );
+				$this->addLog( $scriptOutput );
+			}
+
+			/**
+			 * Log the end time of the process.
+			 */
+			$this->endProcedure();
+		} else {
+			$this->addLog( 'The user has no contributions.' );
+		}
+
+		/**
+		 * Save and return the logs as a subpage of a user page
+		 */
+		return $this->saveLog( $user );
+	}
+
+	private function getOptions() {
+		$this->userId = intval( $this->getOption( 'userId' ) );
+		$this->oldName = $this->getOption( 'oldName' );
+		$this->newName = $this->getOption( 'newName' );
+	}
+
+	/**
+	 * Adds a text to logs and outputs it to console.
+	 * @param $s
+	 */
+	private function addLog( $s ) {
+		$s = "\n\n{$s}\n\n";
+		$this->output( $s );
+		$this->log .= $s;
+	}
+
+	/**
+	 * Creates a subpage of a user's page and saves the process logs there.
+	 * If the edit fails it logs the exception to Kibana with the
+	 * class name RerunRenameUserLocal as its message.
+	 */
+	private function saveLog() {
+		$logTitleText = sprintf( '%s/%s to %s rename rerun log',
+			$this->newName, $this->oldName, $this->newName );
+
+		$logTitle = Title::newFromText( $logTitleText, NS_USER );
+
+		try {
+			if ( $logTitle === null ) {
+				$wikiPage = new WikiPage( $logTitle );
+				$wikiaBot = User::newFromName( 'WikiaBot' );
+				$wikiPage->doEdit( $this->log,
+					'Logs from an operation of renaming the user.',
+					EDIT_NEW | EDIT_FORCE_BOT | EDIT_SUPPRESS_RC,
+					false,
+					$wikiaBot
+				);
+			} else {
+				throw new RerunRenameUserLocalException( $logTitleText );
+			}
+		} catch ( Exception $e ) {
+			$msg = $e->getMessage();
+			$this->addLog( "Saving logs to a subpage failed: {$msg}" );
+			$this->logException( $e );
+		}
+
+		return $this->log;
+	}
+
+	/**
+	 * Log an exception to Kibana
+	 * @param Exception $e
+	 */
+	private function logException( Exception $e ) {
+		$logger = Wikia\Logger\WikiaLogger::instance();
+		$logger->error( __CLASS__, [
+			'excptMsg' => $e->getMessage(),
+			'excptTrace' => $e->getTrace()
+		] );
+	}
+
+	/**
+	 * Logs the beginning time of the process.
+	 */
+	private function startProcedure() {
+		$this->startTime = new DateTime();
+		$this->addLog( sprintf( 'Renaming scripts rerun started at %s.',
+			$this->startTime->format( self::RERUN_RENAME_DATE_FORMAT ) ) );
+	}
+
+	/**
+	 * Logs the end time of the process.
+	 */
+	private function endProcedure() {
+		$this->endTime = new DateTime();
+		$this->addLog( sprintf( 'Renaming scripts rerun ended at %s.',
+			$this->endTime->format( self::RERUN_RENAME_DATE_FORMAT ) ) );
+	}
+}
+
+class RerunRenameUserLocalException extends Exception {
+
+	public function __construct( $titleText ) {
+		$msg = sprintf( 'The Title object creation for "%s" failed.', $titleText );
+		parent::__construct( $msg );
+	}
+}
+
+$maintClass = 'RerunRenameUserLocal';
+require_once( RUN_MAINTENANCE_IF_MAIN );


### PR DESCRIPTION
Hello @Wikia/community-engineering !

This is a maintenance script that makes it easier to rerun the local rename job for all wikias that a user has contributed at. It saves logs from the procedure to a subpage in a User's namespace. The goal here is to enable a ComSup member and a user to be able to take a look at it and ensure that every wikia has been covered.

The next step will be providing a visual interface for running the script.

CC: @michalroszka @Grunny @lukaszkonieczny 
