### PR TITLE
default preferences fix

### DIFF
--- a/includes/Preferences.php
+++ b/includes/Preferences.php
@@ -1460,20 +1460,16 @@ class Preferences {
 		}
 
 		$attributes = self::getAttributes();
+		$preferences = [];
 		foreach ($formData as $key => $val) {
 			if (in_array($key, $attributes)) {
 				$user->setGlobalAttribute($key, $val);
+			} else {
+				$preferences[$key] = $val;
 			}
 		}
 
-		//  Keeps old preferences from interfering due to back-compat
-		//  code, etc.
-		// <Wikia> RT#144314
-		//$user->resetOptions();
-		// </Wikia>
-
-		$user->setGlobalPreferences($formData);
-
+		$user->setGlobalPreferences($preferences);
 		$user->saveSettings();
 
 		return $result;

--- a/includes/User.php
+++ b/includes/User.php
@@ -1393,6 +1393,22 @@ class User {
 		return $defOpt;
 	}
 
+	public static function getDefaultPreferences() {
+		global $wgUserPreferenceWhiteList;
+		$defaultOptions = User::getDefaultOptions();
+		$defaultOptionNames = array_keys($defaultOptions);
+
+		return array_reduce(
+			$defaultOptionNames,
+			function($preferences, $option) use ($wgUserPreferenceWhiteList, $defaultOptions) {
+				if (in_array($option, $wgUserPreferenceWhiteList['literals'])) {
+					$preferences[$option] = $defaultOptions[$option];
+				}
+
+				return $preferences;
+			}, []);
+	}
+
 	/**
 	 * Get a given default option value.
 	 *

--- a/includes/User.php
+++ b/includes/User.php
@@ -36,7 +36,7 @@ define( 'USER_TOKEN_LENGTH', 32 );
  * Int Serialized record version.
  * @ingroup Constants
  */
-define( 'MW_USER_VERSION', 9 );
+define( 'MW_USER_VERSION', 10 );
 
 /**
  * String Some punctuation to prevent editing from broken text-mangling proxies.

--- a/lib/Wikia/src/Service/User/Preferences/PreferenceModule.php
+++ b/lib/Wikia/src/Service/User/Preferences/PreferenceModule.php
@@ -18,7 +18,19 @@ class PreferenceModule implements Module {
 				return $wgHiddenPrefs;
 			})
 			->bind(UserPreferences::DEFAULT_PREFERENCES)->to(function() {
-				return User::getDefaultOptions();
+				global $wgUserPreferenceWhiteList;
+				$defaultOptions = User::getDefaultOptions();
+				$defaultOptionNames = array_keys($defaultOptions);
+
+				return array_reduce(
+					$defaultOptionNames,
+					function($preferences, $option) use ($wgUserPreferenceWhiteList, $defaultOptions) {
+						if (in_array($option, $wgUserPreferenceWhiteList['literals'])) {
+							$preferences[$option] = $defaultOptions[$option];
+						}
+
+						return $preferences;
+					}, []);
 			})
 			->bind(UserPreferences::FORCE_SAVE_PREFERENCES)->to(function() {
 				global $wgGlobalUserProperties;

--- a/lib/Wikia/src/Service/User/Preferences/PreferenceModule.php
+++ b/lib/Wikia/src/Service/User/Preferences/PreferenceModule.php
@@ -18,19 +18,7 @@ class PreferenceModule implements Module {
 				return $wgHiddenPrefs;
 			})
 			->bind(UserPreferences::DEFAULT_PREFERENCES)->to(function() {
-				global $wgUserPreferenceWhiteList;
-				$defaultOptions = User::getDefaultOptions();
-				$defaultOptionNames = array_keys($defaultOptions);
-
-				return array_reduce(
-					$defaultOptionNames,
-					function($preferences, $option) use ($wgUserPreferenceWhiteList, $defaultOptions) {
-						if (in_array($option, $wgUserPreferenceWhiteList['literals'])) {
-							$preferences[$option] = $defaultOptions[$option];
-						}
-
-						return $preferences;
-					}, []);
+				return User::getDefaultPreferences();
 			})
 			->bind(UserPreferences::FORCE_SAVE_PREFERENCES)->to(function() {
 				global $wgGlobalUserProperties;


### PR DESCRIPTION
@Wikia/services-team 

I noticed a bug introduced in [earlier](https://github.com/Wikia/app/commit/18ab54b8bac76bd9ae2d6c944613697fa686ee6c#diff-897fba1dd6b8edc3238762e35d0b7c71R4845) where, because we are now preventing the `User` object from deleting preferences contained by the `UserPreferences` module, but we're setting defaults which contain non-preferences into that `UserPreferences` module, we wouldn't properly delete non-preferences in the `user_properties` table when the user reset those properties to their default.

This hasn't been brought up (at least that I know about) in any bug reports, but we should get ahead of that and push this out since it will definitely come up at some point.
