### PR TITLE
preserve query string on 404Handler redirect to a known Special or Ti…

### DIFF
--- a/extensions/wikia/Our404Handler/SpecialOur404Handler_body.php
+++ b/extensions/wikia/Our404Handler/SpecialOur404Handler_body.php
@@ -81,19 +81,21 @@ class Our404HandlerPage extends UnlistedSpecialPage {
 		$oTitle = Title::newFromText( $title, $namespace );
 
 		if( !is_null( $oTitle ) ) {
+			// Preserve the query string on a redirect
+			$query = parse_url ( $_SERVER['REQUEST_URI'], PHP_URL_QUERY );
 			if( $namespace == NS_SPECIAL || $namespace == NS_MEDIA ) {
 				/**
 				 * these namespaces are special and don't have articles
 				 */
 				header( "X-Redirected-By: Our404Handler" );
-				header( sprintf( "Location: %s", $oTitle->getFullURL() ), true, 301 );
+				header( sprintf( "Location: %s", $oTitle->getFullURL($query) ), true, 301 );
 				exit( 0 );
 
 			} else {
 				$oArticle = new Article( $oTitle );
 				if( $oArticle->exists() ) {
 					header( "X-Redirected-By: Our404Handler" );
-					header( sprintf( "Location: %s", $oArticle->getTitle()->getFullURL() ), true, 301 );
+					header( sprintf( "Location: %s", $oArticle->getTitle()->getFullURL($query) ), true, 301 );
 					exit( 0 );
 				}
 			}


### PR DESCRIPTION
…tle page

Redirecting from a short url to a /wiki/ url caused the query string to drop off.  Can't think of any reason to do that, and there are some cases where it is the preferred behavior.  

@macbre 
Details in ticket PLATFORM-1358
