### PR TITLE
CE-2388 Fix for fatal error on non existent parent page. 

### DIFF
--- a/extensions/wikia/TemplateDraft/ApprovedraftAction.php
+++ b/extensions/wikia/TemplateDraft/ApprovedraftAction.php
@@ -88,7 +88,7 @@ class ApprovedraftAction extends FormlessAction {
 		);
 
 		// Get WikiPage object of parent page
-		$page = WikiPage::newFromID( $parentTitle->getArticleID() );
+		$page = WikiPage::factory( $parentTitle );
 		// Save to parent page
 		$page->doEdit( $draftContent, wfMessage( 'templatedraft-approval-summary' )->inContentLanguage()->plain() );
 


### PR DESCRIPTION
If parent page doesn't exist it should create it

https://wikia-inc.atlassian.net/browse/CE-2388

@Wikia/community-engineering 
