### PR TITLE
SOC-1145 re-add threadId parameter when sending emails from WallNotif…

### DIFF
--- a/extensions/wikia/WallNotifications/WallNotifications.class.php
+++ b/extensions/wikia/WallNotifications/WallNotifications.class.php
@@ -414,6 +414,7 @@ class WallNotifications {
 				'details' => $text,
 				'targetUser' => $watcherName,
 				'wallUserName' => $notifData->wall_username,
+				'threadId' => $notifData->title_id,
 				'parentId' => $notifData->parent_id,
 			];
 


### PR DESCRIPTION
…ications.class.php

This ended up getting caused by [this change](https://github.com/Wikia/app/commit/b00dd8fce32b720af3fd646e45204effb7b9ed2e#diff-09fcb40d2b29574334a271df5c14202aL417). We fixed one bug, but caused another by not checking to see if any other emails were using `threadId`.

Turns out `WallMessageController` uses that value when constructing a title [here](https://github.com/Wikia/app/blob/dev/extensions/wikia/Email/Controller/WallMessageController.class.php#L48), but since that value is null, the title object is null, and when we try and call methods on it (like [here](https://github.com/Wikia/app/blob/dev/extensions/wikia/Email/Controller/WallMessageController.class.php#L197)), it's throwing a fatal.

Ticket: https://wikia-inc.atlassian.net/browse/SOC-1145
