### PR TITLE
ADEN-2297 Get mappedVerticalName in a safer way

### DIFF
--- a/extensions/wikia/AdEngine/js/AdLogicPageParams.js
+++ b/extensions/wikia/AdEngine/js/AdLogicPageParams.js
@@ -224,7 +224,7 @@ define('ext.wikia.adEngine.adLogicPageParams', [
 			zone1 = '_' + getDartHubName() + '_hub';
 			zone2 = 'hub';
 		} else {
-			site = targeting.mappedVerticalName;
+			site = targeting.mappedVerticalName || targeting.wikiCategory;
 			zone1 = dbName;
 			zone2 = targeting.pageType || 'article';
 		}


### PR DESCRIPTION
The `adsContext` may be cached on varnishes whereas changed JS code may come "fresh". Therefore, we need this safety fallback to the old version.
