### PR TITLE
don't let core-mw save options that conflict with preferences

### DIFF
--- a/includes/User.php
+++ b/includes/User.php
@@ -36,7 +36,7 @@ define( 'USER_TOKEN_LENGTH', 32 );
  * Int Serialized record version.
  * @ingroup Constants
  */
-define( 'MW_USER_VERSION', 10 );
+define( 'MW_USER_VERSION', 11 );
 
 /**
  * String Some punctuation to prevent editing from broken text-mangling proxies.
@@ -4908,6 +4908,13 @@ class User {
 		$preferencesFromService = [];
 		if ($wgPreferencesUseService) {
 			$preferencesFromService = array_keys($this->userPreferences()->getPreferences($this->getId()));
+			$insertRows = array_reduce($insertRows, function($rows, $current) use ($preferencesFromService) {
+				if (!in_array($current['up_property'], $preferencesFromService)) {
+					$rows[] = $current;
+				}
+
+				return $rows;
+			}, []);
 		}
 
 		$deletePrefs = array_diff($deletePrefs, $preferencesFromService);


### PR DESCRIPTION
@Wikia/services-team 
https://wikia-inc.atlassian.net/browse/SERVICES-588

Core functionality is currently overwriting preferences in the case that a user's `mOptions` contains a preference key. This change filters those out so only preferences should be saving them now.
