### PR TITLE
allow mOptions to reload properly

### DIFF
--- a/includes/User.php
+++ b/includes/User.php
@@ -1357,6 +1357,8 @@ class User {
 		$this->mEffectiveGroups = null;
 		$this->mImplicitGroups = null;
 		$this->mOptions = null;
+		$this->mOptionOverrides = null;
+		$this->mOptionsLoaded = false;
 
 		if ( $reloadFrom ) {
 			$this->mLoadedItems = array();
@@ -2105,7 +2107,7 @@ class User {
 		$this->load();
 		if( $this->mId ) {
 			global $wgMemc, $wgSharedDB; # Wikia
-			$wgMemc->delete( wfMemcKey( 'user', 'id', $this->mId ) );
+			$wgMemc->delete( $this->getCacheKey() );
 			// Wikia: and save updated user data in the cache to avoid memcache miss and DB query
 			$this->saveToCache();
 			if( !empty( $wgSharedDB ) ) {

--- a/includes/specials/SpecialUserlogin.php
+++ b/includes/specials/SpecialUserlogin.php
@@ -586,10 +586,12 @@ class LoginForm extends SpecialPage {
 			}
 		}
 
-		$u->setGlobalPreference( 'rememberpassword', $this->mRemember ? 1 : 0 );
-		$u->setGlobalPreference( 'marketingallowed', $this->mMarketingOptIn ? 1 : 0 );
 		$u->setGlobalAttribute( 'registrationCountry', $this->mRegistrationCountry );
-		$u->setGlobalPreference( 'skinoverwrite', 1 );
+		$u->setGlobalPreferences([
+			'skinoverwrite' => 1,
+			'rememberpassword' => $this->mRemember ? 1 : 0,
+			'marketingallowed' => $this->mMarketingOptIn ? 1 : 0,
+		]);
 		$u->saveSettings();
 
 		# Update user count


### PR DESCRIPTION
@Wikia/services-team 
https://wikia-inc.atlassian.net/browse/SERVICES-592

fixes an issue that was surfaced with the transition to the user preferences service where `clearInstanceCache()` clears a user's `mOptions`, subsequent `loadOptions()` would not properly fill out the user's `mOptions` since `mOptionsLoaded` was set to `true`.
