### PR TITLE
MAIN-5131: load global groups early without breaking add/remove groups

### DIFF
--- a/extensions/wikia/SharedUserrights/SharedUserrights.class.php
+++ b/extensions/wikia/SharedUserrights/SharedUserrights.class.php
@@ -23,8 +23,6 @@ class UserRights {
 	/**
 	 * data provider
 	 *
-	 * @author Maciej Błaszkowski <marooned at wikia-inc.com>
-	 *
 	 * @param User $user
 	 * @return array list of global groups
 	 */
@@ -41,7 +39,7 @@ class UserRights {
 				self::getMemcKey( $user ),
 				WikiaResponse::CACHE_LONG,
 				function() use ( $userId, $fname ) {
-					$dbr = self::getDB();
+					$dbr = self::getDB( DB_MASTER );
 
 					return $dbr->selectFieldValues(
 						'user_groups',
@@ -60,9 +58,11 @@ class UserRights {
 	}
 
 	/**
-	 * Get group data for the user object. Needed for removing global group rights.
+	 * Get group data for the user object.
+	 * Global groups are always loaded here.
+	 * We filter them out for the add/remove hooks so that global groups can't be edited from local wikis.
 	 *
-	 * @author grunny
+	 * @author grunny, owen
 	 */
 	public static function onUserLoadGroups( User $user ) {
 		$userId = $user->getId();
@@ -84,9 +84,13 @@ class UserRights {
 	static function addGlobalGroup( User $user, $group ) {
 		global $wgWikiaGlobalUserGroups;
 
-		if ( !in_array( $group, $wgWikiaGlobalUserGroups ) ) {
+		if ( !self::isCentralWiki() || !in_array( $group, $wgWikiaGlobalUserGroups ) ) {
 			return true;
 		}
+
+		// Purge cache first so in case of DB failure we don't leave inconsistent data in cache
+		WikiaDataAccess::cachePurge( self::getMemcKey( $user ) );
+		unset(self::$globalGroups[$user->getID()]);
 
 		$dbw = self::getDB( DB_MASTER );
 		if ( $user->getId() ) {
@@ -98,8 +102,6 @@ class UserRights {
 				__METHOD__
 			);
 		}
-
-		WikiaDataAccess::cachePurge( self::getMemcKey( $user ) );
 
 		wfRunHooks( 'AfterUserAddGlobalGroup', [ $user, $group ] );
 
@@ -116,9 +118,13 @@ class UserRights {
 	static function removeGlobalGroup( User $user, $group ) {
 		global $wgWikiaGlobalUserGroups;
 
-		if ( !in_array( $group, $wgWikiaGlobalUserGroups ) ) {
+		if ( !self::isCentralWiki() || !in_array( $group, $wgWikiaGlobalUserGroups ) ) {
 			return true;
 		}
+
+		// Purge cache first so in case of DB failure we don't leave inconsistent data in cache
+		WikiaDataAccess::cachePurge( self::getMemcKey( $user ) );
+		unset(self::$globalGroups[$user->getID()]);
 
 		$dbw = self::getDB( DB_MASTER );
 		$dbw->delete( 'user_groups',
@@ -139,8 +145,6 @@ class UserRights {
 				[ 'IGNORE' ]
 		);
 
-		WikiaDataAccess::cachePurge( self::getMemcKey( $user ) );
-
 		wfRunHooks( 'AfterUserRemoveGlobalGroup', [ $user, $group ] );
 
 		// return true to let the User class clean up any residual staff rights stored locally
@@ -160,8 +164,6 @@ class UserRights {
 
 	/**
 	 * hook handler
-	 *
-	 * @author Maciej Błaszkowski <marooned at wikia-inc.com>
 	 */
 	static function userEffectiveGroups( User $user, Array &$groups ) {
 		$groups = array_unique( array_merge( $groups, self::getGlobalGroups( $user ) ) );
@@ -170,8 +172,6 @@ class UserRights {
 
 	/**
 	 * hook handler
-	 *
-	 * @author Maciej Błaszkowski <marooned at wikia-inc.com>
 	 */
 	static function showEditUserGroupsForm( User $user, Array &$groups ) {
 		$groups = array_unique( array_merge( $groups, self::getGlobalGroups( $user ) ) );
@@ -181,8 +181,6 @@ class UserRights {
 
 	/**
 	 * hook handler
-	 *
-	 * @author Maciej Błaszkowski <marooned at wikia-inc.com>
 	 */
 	static function groupCheckboxes( $group, &$disabled, &$irreversible ) {
 		global $wgWikiaGlobalUserGroups;


### PR DESCRIPTION
FIxed 3 bugs
- possibility of leaving stale data in memcache if the db query fails
- master/slave race condition during add/remove process
- and the original bug: not able to edit local mediawiki namespace because global groups were null

@macbre @michalroszka @Grunny 

The fix is basically the same one I made before, I just added isCentralWiki() checks to add/remove group hook handlers so that you can't accidentally remove global groups from a local wiki.  During testing, I found the other bugs and fixed them also.  
