### PR TITLE
return 404 if the user page does not exist

### DIFF
--- a/extensions/wikia/UserProfilePageV3/UserProfilePage.setup.php
+++ b/extensions/wikia/UserProfilePageV3/UserProfilePage.setup.php
@@ -51,7 +51,6 @@ $wgAutoloadClasses['UserWikisFilterPrivateDecorator'] = $dir . '/filters/UserWik
 $wgAutoloadClasses['UserProfilePageHooks'] =  $dir . '/UserProfilePageHooks.class.php';
 
 $wgHooks['SkinTemplateOutputPageBeforeExec'][] = 'UserProfilePageHooks::onSkinTemplateOutputPageBeforeExec';
-$wgHooks['BeforeDisplayNoArticleText'][] = 'UserProfilePageHooks::onBeforeDisplayNoArticleText';
 $wgHooks['SkinSubPageSubtitleAfterTitle'][] = 'UserProfilePageHooks::onSkinSubPageSubtitleAfterTitle';
 $wgHooks['ArticleSaveComplete'][] = 'UserProfilePageHooks::onArticleSaveComplete';
 $wgHooks['WikiaMobileAssetsPackages'][] = 'UserProfilePageHooks::onWikiaMobileAssetsPackages';

--- a/extensions/wikia/UserProfilePageV3/UserProfilePageHooks.class.php
+++ b/extensions/wikia/UserProfilePageV3/UserProfilePageHooks.class.php
@@ -151,35 +151,6 @@ class UserProfilePageHooks {
 	}
 
 	/**
-	 * Don't send 404 status for user pages with filled in masthead (bugid:44602)
-	 * @brief hook handler
-	 *
-	 * @param Article $article
-	 *
-	 * @return Boolean
-	 */
-	static public function onBeforeDisplayNoArticleText($article) {
-		global $UPPNamespaces;
-		$wg = F::app()->wg;
-
-		$title = $article->getTitle();
-		if ($title instanceof Title && in_array($title->getNamespace(), $UPPNamespaces)) {
-			$user = UserProfilePageHelper::getUserFromTitle($title);
-			if ( $user instanceof User && $user->getId() > 0) {
-				$userIdentityBox = new UserIdentityBox( $user );
-				$userData = $userIdentityBox->getFullData();
-				if ( is_array( $userData ) && array_key_exists( 'showZeroStates', $userData ) ) {
-					if ( !$userData['showZeroStates'] ) {
-						$wg->Out->setStatusCode ( 200 );
-					}
-				}
-			}
-		}
-		return true;
-	}
-
-
-	/**
 	 * @brief Hook on WikiFactory change and update wikis's visibility if the wgGroupPermissionsLocal is changed
 	 *
 	 * @param String $cv_name


### PR DESCRIPTION
MAIN-4970 was opened to investigate an increase in "soft 404" responses.  These are pages that do not actually have any content, but we return 200 anyway.  A few years ago, this hook was added to UPPV3 to return a 200 if the global profile masthead exists.  This was fine at the time, but it's bad for SEO now. 

There's no visible change for the user, just the status code and the caching behavior.   
