### PR TITLE
SERVICES-463: Added invalidateToken() to Helios/Client.

### DIFF
--- a/extensions/wikia/Helios/Client.class.php
+++ b/extensions/wikia/Helios/Client.class.php
@@ -141,7 +141,24 @@ class Client
 		);
 	}
 
-    /**
+	/**
+	 * A shortcut method for token invalidation requests.
+	 *
+	 * @param $token string - a token to be invalidated
+	 *
+	 * @return string - json encoded response
+	 */
+	public function invalidateToken( $token )
+	{
+		return $this->request(
+			'token',
+			[ 'code' => $token ],
+			[],
+			[ 'method' => 'DELETE' ]
+		);
+	}
+
+	/**
      * A shortcut method for register requests.
      */
     public function register( $username, $password, $email, $birthdate, $langCode )


### PR DESCRIPTION
This is the implementation of token invalidation request to Helios. I've tried to follow the conventions but there are some parameters in existing calls that are not documented (i.e. `grant_type` etc.).

@Wikia/services-team 
