### PR TITLE
CE-2453 Better reflect the state of a review and update the schema

### DIFF
--- a/extensions/wikia/ContentReview/ContentReview.hooks.php
+++ b/extensions/wikia/ContentReview/ContentReview.hooks.php
@@ -21,11 +21,35 @@ class Hooks {
 				true
 			)->getData();
 
-			if ( intval( $currentPageData['revision_id'] ) !== $wgTitle->getLatestRevID() ) {
-				if ( intval( $currentPageData['review_status'] ) !== null ) {
-					$railModuleList[1503] = [ 'ContentReviewModule', 'InReview', null ];
-				} else {
-					$railModuleList[1503] = [ 'ContentReviewModule', 'Unreviewed', null ];
+			$latestRevId = $wgTitle->getLatestRevID();
+
+			/**
+			 * 1. If the latest rev_id is equal to the current reviewed one - do nothing
+			 */
+			if ( intval( $currentPageData['currentRevisionId'] ) !== $latestRevId ) {
+				/**
+				 * 2. If there is no revision in review - display the module with a submit call.
+				 */
+				if ( $currentPageData['revisionInReviewId'] === null ) {
+					$railModuleList[1503] = [ 'ContentReviewModule', 'Render', [
+						'moduleType' => \ContentReviewModuleController::MODULE_TYPE_UNREVIEWED,
+					] ];
+				/**
+				 * 3. If the latest rev_id is equal to the one that is already in review -
+				 * display the module without an action call.
+				 */
+				} elseif ( intval( $currentPageData['revisionInReviewId'] ) === $latestRevId ) {
+					$railModuleList[1503] = [ 'ContentReviewModule', 'Render', [
+						'moduleType' => \ContentReviewModuleController::MODULE_TYPE_CURRENT,
+					] ];
+				/**
+				 * 4. If the latest rev_id is not equal to the one that is already in review -
+				 * display the module with an update action call.
+				 */
+				} elseif ( intval( $currentPageData['revisionInReviewId'] ) !== $latestRevId ) {
+					$railModuleList[1503] = [ 'ContentReviewModule', 'Render', [
+						'moduleType' => \ContentReviewModuleController::MODULE_TYPE_IN_REVIEW,
+					] ];
 				}
 			}
 		}

--- a/extensions/wikia/ContentReview/ContentReview.hooks.php
+++ b/extensions/wikia/ContentReview/ContentReview.hooks.php
@@ -26,7 +26,7 @@ class Hooks {
 			/**
 			 * 1. If the latest rev_id is equal to the current reviewed one - do nothing
 			 */
-			if ( intval( $currentPageData['currentRevisionId'] ) !== $latestRevId ) {
+			if ( intval( $currentPageData['reviewedRevisionId'] ) !== $latestRevId ) {
 				/**
 				 * 2. If there is no revision in review - display the module with a submit call.
 				 */

--- a/extensions/wikia/ContentReview/ContentReview.i18n.php
+++ b/extensions/wikia/ContentReview/ContentReview.i18n.php
@@ -16,10 +16,13 @@ $messages['en'] = [
 	'content-review-module-inreview-description' => 'For security reasons every change made in the MediaWiki namespace has to be reviewed by a Wikia\'s staff member. This page is waiting for a review. Use the button if you want to update the version submitted for a review.',
 	'content-review-module-inreview-submit' => 'Update the unreviewed changes',
 
-	'content-review-module-submit-success-insert' => 'The changes have been submitted submitted to review.',
-	'content-review-module-submit-success-update' => 'The previous unreviewed revision has been successfully updated with the changes.',
-	'content-review-module-submit-success-exception' => 'Unfortunately, we could not submit the changes to review due to the following error: $1.',
-	'content-review-module-submit-success-error' => 'Unfortunately, we could not submit the changes to review.',
+	'content-review-module-current-title' => 'The current version of this page is waiting for a review',
+	'content-review-module-current-description' => 'For security reasons every change made in the MediaWiki namespace has to be reviewed by a Wikia\'s staff member. The current version page is waiting for a review.',
+
+	'content-review-module-submit-success-unreviewed' => 'The changes have been successfully submitted for a review.',
+	'content-review-module-submit-success-inreview' => 'The previous unreviewed revision has been successfully updated with the changes.',
+	'content-review-module-submit-exception' => 'Unfortunately, we could not submit the changes for a review due to the following error: $1.',
+	'content-review-module-submit-error' => 'Unfortunately, we could not submit the changes for a review.',
 ];
 
 /**
@@ -35,6 +38,9 @@ $messages['qqq'] = [
 	'content-review-module-inreview-title' => 'Title of a the right rail module with a button to update a version of a page already sent for a review.',
 	'content-review-module-inreview-description' => 'The content of the right rail module explaining that a page is awaiting a review and that a user can update the submitted code with the current changes.',
 	'content-review-module-inreview-submit' => 'Text of a button that updates the version submitted for a review.',
+
+	'content-review-module-current-title' => 'Title of a the right rail module on a page already sent for a review with the current version.',
+	'content-review-module-current-description' => 'The content of the right rail module explaining that the current version of a page is awaiting for a review.',
 
 	'content-review-module-submit-success-insert' => 'A message shown to a user in a Banner Notification if a page has been added to review.',
 	'content-review-module-submit-success-update' => 'A message shown to a user in a Banner Notification if a page had an unreviewed version submitted and it got updated.',

--- a/extensions/wikia/ContentReview/controllers/ContentReviewApiController.class.php
+++ b/extensions/wikia/ContentReview/controllers/ContentReviewApiController.class.php
@@ -33,13 +33,11 @@ class ContentReviewApiController extends WikiaApiController {
 			$revisionId = $title->getLatestRevID();
 
 			$reviewModel= new ReviewModel();
-			$reviewStatus = $reviewModel->addOrUpdatePageForReview( $wikiId, $pageId,
+			$reviewStatus = $reviewModel->submitPageForReview( $wikiId, $pageId,
 				$revisionId, $submitUserId );
 
 			if ( $reviewStatus['status'] ) {
-				$this->makeSuccessResponse( [
-					'action' => $reviewStatus['action'],
-				] );
+				$this->makeSuccessResponse();
 			} else {
 				$this->makeFailureResponse();
 			}

--- a/extensions/wikia/ContentReview/controllers/ContentReviewApiController.class.php
+++ b/extensions/wikia/ContentReview/controllers/ContentReviewApiController.class.php
@@ -58,7 +58,7 @@ class ContentReviewApiController extends WikiaApiController {
 			$reviewData = $reviewModel->getPageStatus( $wikiId, $pageId );
 
 			$data = [
-				'currentRevisionId' => $revisionData['revision_id'],
+				'reviewedRevisionId' => $revisionData['revision_id'],
 				'touched' => $revisionData['touched'],
 				'revisionInReviewId' => $reviewData['revision_id'],
 				'reviewStatus' => $reviewData['status'],

--- a/extensions/wikia/ContentReview/models/ReviewModel.php
+++ b/extensions/wikia/ContentReview/models/ReviewModel.php
@@ -64,7 +64,7 @@ class ReviewModel extends ContentReviewBaseModel {
 		return $reviewId;
 	}
 
-	public function addOrUpdatePageForReview( $wikiId, $pageId, $revisionId, $submitUserId ) {
+	public function submitPageForReview( $wikiId, $pageId, $revisionId, $submitUserId ) {
 		try {
 			$db = $this->getDatabaseForWrite();
 

--- a/extensions/wikia/ContentReview/schema.sql
+++ b/extensions/wikia/ContentReview/schema.sql
@@ -1,7 +1,6 @@
--- Table content_review_status
+-- Table content_for_review
 DROP TABLE IF EXISTS content_review_status;
 CREATE TABLE content_review_status (
-  review_id       INT unsigned      NOT NULL  AUTO_INCREMENT,
   wiki_id         INT unsigned      NOT NULL,
   page_id         INT unsigned      NOT NULL,
   revision_id     INT unsigned      NOT NULL,
@@ -9,12 +8,24 @@ CREATE TABLE content_review_status (
   submit_user_id  INT unsigned      NOT NULL,
   submit_time     DATETIME          NOT NULL  DEFAULT CURRENT_TIMESTAMP,
   review_user_id  INT unsigned      NULL,
-  review_time     DATETIME          NULL,
-  CONSTRAINT content_review_status_pk PRIMARY KEY (review_id)
+  review_start    DATETIME          NULL,
+  UNIQUE KEY page_id (wiki_id, page_id, revision_id)
 ) ENGINE = INNODB CHARACTER SET utf8 COLLATE utf8_unicode_ci;
-CREATE INDEX content_review_status_wiki_id_idx ON content_review_status (wiki_id);
-CREATE INDEX content_review_status_page_id_idx ON content_review_status (page_id);
 CREATE INDEX content_review_status_idx         ON content_review_status (status);
+
+-- Table reviewed_content_logs
+DROP TABLE IF EXISTS reviewed_content_logs;
+CREATE TABLE reviewed_content_logs (
+  wiki_id         INT unsigned      NOT NULL,
+  page_id         INT unsigned      NOT NULL,
+  revision_id     INT unsigned      NOT NULL,
+  status          SMALLINT unsigned NOT NULL,
+  submit_user_id  INT unsigned      NOT NULL,
+  submit_time     DATETIME          NOT NULL,
+  review_user_id  INT unsigned      NOT NULL,
+  review_start    DATETIME          NOT NULL,
+  review_end      DATETIME          NOT NULL  DEFAULT CURRENT_TIMESTAMP
+) ENGINE = INNODB CHARACTER SET utf8 COLLATE utf8_unicode_ci;
 
 -- Table current_reviewed_revisions
 DROP TABLE IF EXISTS current_reviewed_revisions;

--- a/extensions/wikia/ContentReview/scripts/contentReviewModule.js
+++ b/extensions/wikia/ContentReview/scripts/contentReviewModule.js
@@ -23,7 +23,8 @@ define(
 		function submitPageForReview(event) {
 			event.preventDefault();
 
-			var data = {
+			var moduleType = $(this).data('type'),
+				data = {
 				pageId: mw.config.get('wgArticleId'),
 				wikiId: mw.config.get('wgCityId'),
 				editToken: mw.user.tokens.get('editToken')
@@ -43,7 +44,7 @@ define(
 							 * content-review-module-submit-success-insert
 							 * content-review-module-submit-success-update
 							 */
-							mw.message('content-review-module-submit-success-' + response.action).escaped(),
+							mw.message('content-review-module-submit-success-' + moduleType).escaped(),
 							'confirm'
 						);
 

--- a/skins/oasis/modules/ContentReviewModuleController.class.php
+++ b/skins/oasis/modules/ContentReviewModuleController.class.php
@@ -2,17 +2,18 @@
 
 class ContentReviewModuleController extends WikiaController {
 
+	const MODULE_TYPE_UNREVIEWED = 'unreviewed';
+	const MODULE_TYPE_IN_REVIEW = 'inreview';
+	const MODULE_TYPE_CURRENT = 'current';
+
 	/**
-	 * Executed when a page has unreviewed changes and has not yet been submitted for review
+	 * Executed when a page has unreviewed changes.
 	 * @param $params
 	 */
-	public function executeUnreviewed( $params ) {
+	public function executeRender( $params ) {
 		Wikia::addAssetsToOutput( 'content_review_module_js' );
 		JSMessages::enqueuePackage( 'ContentReviewModule' );
-	}
 
-	public function executeInReview( $params ) {
-		Wikia::addAssetsToOutput( 'content_review_module_js' );
-		JSMessages::enqueuePackage( 'ContentReviewModule' );
+		$this->moduleType = $params['moduleType'];
 	}
 }

--- a/skins/oasis/modules/templates/ContentReviewModule_InReview.php
+++ b/skins/oasis/modules/templates/ContentReviewModule_InReview.php
@@ -1,9 +1,0 @@
-<section class="content-review-module module">
-	<h2><?= wfMessage( 'content-review-module-inreview-title' )->escaped() ?></h2>
-	<p><?= wfMessage( 'content-review-module-inreview-description' )->escaped() ?></p>
-	<a href="#" id="content-review-module-submit" title="<?= wfMessage( 'content-review-module-inreview-submit' )->escaped() ?>">
-		<button class="content-review-module-button" type="button">
-			<?= wfMessage( 'content-review-module-inreview-submit' )->escaped() ?>
-		</button>
-	</a>
-</section>

--- a/skins/oasis/modules/templates/ContentReviewModule_Render.php
+++ b/skins/oasis/modules/templates/ContentReviewModule_Render.php
@@ -1,0 +1,25 @@
+<section class="content-review-module module">
+	<h2><?=
+		/**
+		 * Possible keys:
+		 * content-review-module-unreviewed-title
+		 * content-review-module-inreview-title
+		 * content-review-module-current-title
+		 */
+		wfMessage( "content-review-module-{$moduleType}-title" )->escaped() ?></h2>
+	<p><?=
+		/**
+		 * Possible keys:
+		 * content-review-module-unreviewed-description
+		 * content-review-module-inreview-description
+		 * content-review-module-current-description
+		 */
+		wfMessage( "content-review-module-{$moduleType}-description" )->escaped() ?></p>
+	<? if ( $moduleType !== ContentReviewModuleController::MODULE_TYPE_CURRENT ) : ?>
+		<a href="#" id="content-review-module-submit" title="<?= wfMessage( "content-review-module-{$moduleType}-submit" )->escaped() ?>" data-type="<?= $moduleType ?>">
+			<button class="content-review-module-button" type="button">
+				<?= wfMessage( "content-review-module-{$moduleType}-submit" )->escaped() ?>
+			</button>
+		</a>
+	<? endif; ?>
+</section>

--- a/skins/oasis/modules/templates/ContentReviewModule_Unreviewed.php
+++ b/skins/oasis/modules/templates/ContentReviewModule_Unreviewed.php
@@ -1,9 +1,0 @@
-<section class="content-review-module module">
-	<h2><?= wfMessage( 'content-review-module-unreviewed-title' )->escaped() ?></h2>
-	<p><?= wfMessage( 'content-review-module-unreviewed-description' )->escaped() ?></p>
-	<a href="#" id="content-review-module-submit" title="<?= wfMessage( 'content-review-module-unreviewed-submit' )->escaped() ?>">
-		<button class="content-review-module-button" type="button">
-			<?= wfMessage( 'content-review-module-unreviewed-submit' )->escaped() ?>
-		</button>
-	</a>
-</section>


### PR DESCRIPTION
@lukaszkonieczny @Grunny 

Hey guys!

This PR is about two major things:
1. Updating the schema to hold a unique `wiki_id`, `page_id` and `revision_id` combination.
2. The right rail module to better reflect a status of a page review.
