### PR TITLE
SOC-1075 Make sure cache is cleared for the old user ID

### DIFF
--- a/extensions/wikia/UserRenameTool/RenameUserHelper.class.php
+++ b/extensions/wikia/UserRenameTool/RenameUserHelper.class.php
@@ -50,7 +50,7 @@ class RenameUserHelper {
 		}
 		else { // on devbox - set up the list manually
 			$result = array(
-				//165, // firefly
+				165, // firefly
 				831, // muppet
 			);
 		}

--- a/extensions/wikia/UserRenameTool/RenameUserHelper.class.php
+++ b/extensions/wikia/UserRenameTool/RenameUserHelper.class.php
@@ -50,7 +50,7 @@ class RenameUserHelper {
 		}
 		else { // on devbox - set up the list manually
 			$result = array(
-				165, // firefly
+				//165, // firefly
 				831, // muppet
 			);
 		}
@@ -64,7 +64,10 @@ class RenameUserHelper {
 	 * Gets wikis an IP address might have edits on
 	 *
 	 * @author Daniel Grunwell (Grunny)
+	 *
 	 * @param String $ipAddress The IP address to lookup
+	 *
+	 * @return array
 	 */
 	public static function lookupIPActivity( $ipAddress ) {
 		global $wgDevelEnvironment, $wgSpecialsDB;

--- a/extensions/wikia/UserRenameTool/SpecialRenameuser_body.php
+++ b/extensions/wikia/UserRenameTool/SpecialRenameuser_body.php
@@ -22,10 +22,11 @@ class SpecialRenameuser extends SpecialPage {
 	 * Show the special page
 	 *
 	 * @param mixed $par Parameter passed to the page
+	 *
+	 * @throws PermissionsError
+	 * @throws ReadOnlyError
 	 */
 	public function execute( $par ) {
-		wfProfileIn( __METHOD__ );
-
 		global $wgOut, $wgUser, $wgTitle, $wgRequest, $wgStatsDBEnabled, $wgJsMimeType;
 
 		$this->setHeaders();
@@ -37,86 +38,93 @@ class SpecialRenameuser extends SpecialPage {
 
 		if ( wfReadOnly() || !$wgStatsDBEnabled ) {
 			$wgOut->readOnlyPage();
-
-			wfProfileOut( __METHOD__ );
 			return;
 		}
 
 		if ( !$wgUser->isAllowed( 'renameuser' ) ) {
-			wfProfileOut( __METHOD__ );
 			throw new PermissionsError( 'renameuser' );
 		}
 
 		// Get the request data
-		$oldusername = $wgRequest->getText( 'oldusername', $par );
-		$newusername = $wgRequest->getText( 'newusername' );
+		$oldUsername = $wgRequest->getText( 'oldusername', $par );
+		$newUsername = $wgRequest->getText( 'newusername' );
 		$reason = $wgRequest->getText( 'reason' );
 		$token = $wgUser->getEditToken();
 		$notifyRenamed = $wgRequest->getBool( 'notify_renamed', false );
-		$confirmaction = false;
+		$confirmAction = false;
 
 		if ( $wgRequest->wasPosted() && $wgRequest->getInt( 'confirmaction' ) ) {
-			$confirmaction = true;
+			$confirmAction = true;
 		}
 
-		$warnings = array();
-		$errors = array();
-		$infos = array();
+		$warnings = [];
+		$errors = [];
+		$info = [];
 
-		if (
-			$wgRequest->wasPosted() &&
-			$wgRequest->getText( 'token' ) !== '' &&
-			$wgUser->matchEditToken( $wgRequest->getVal( 'token' ) )
-		) {
-			$process = new RenameUserProcess( $oldusername, $newusername, $confirmaction, $reason, $notifyRenamed );
+		if ( $this->validRenameRequest() ) {
+			$process = new RenameUserProcess( $oldUsername, $newUsername, $confirmAction, $reason, $notifyRenamed );
 			$status = $process->run();
 			$warnings = $process->getWarnings();
 			$errors = $process->getErrors();
 			if ( $status ) {
-				$infos[] = wfMessage( 'userrenametool-info-in-progress' )->inContentLanguage()->text();
+				$info[] = wfMessage( 'userrenametool-info-in-progress' )->inContentLanguage()->text();
 			}
 		}
 
-		$showConfirm = ( empty( $errors ) && empty( $infos ) );
+		$showConfirm = ( empty( $errors ) && empty( $info ) );
 
-		// note: errors and infos beyond this point are non-blocking
+		// note: errors and info beyond this point are non-blocking
 
-		if ( !empty( $oldusername ) ) {
-			$olduser = User::newFromName( $oldusername );
-			if ( $olduser->getGlobalFlag( 'requested-rename', 0 ) ) {
-				$infos[] = wfMsg( 'userrenametool-requested-rename', $oldusername );
+		if ( !empty( $oldUsername ) ) {
+			$oldUser = User::newFromName( $oldUsername );
+			if ( $oldUser->getGlobalFlag( 'requested-rename', 0 ) ) {
+				$info[] = wfMsg( 'userrenametool-requested-rename', $oldUsername );
 			} else {
-				$errors[] = wfMsg( 'userrenametool-did-not-request-rename', $oldusername );
+				$errors[] = wfMsg( 'userrenametool-did-not-request-rename', $oldUsername );
 			}
-			if ( $olduser->getGlobalFlag( 'wasRenamed', 0 ) ) {
-				$errors[] = wfMsg( 'userrenametool-previously-renamed', $oldusername );
+			if ( $oldUser->getGlobalFlag( 'wasRenamed', 0 ) ) {
+				$errors[] = wfMsg( 'userrenametool-previously-renamed', $oldUsername );
 			}
 		}
 
 		$template = new EasyTemplate( dirname( __FILE__ ) . '/templates/' );
 		$template->set_vars(
-			array (
+			[
 				"submitUrl"     	=> $wgTitle->getLocalUrl(),
-				"oldusername"   	=> $oldusername,
-				"oldusername_hsc"	=> htmlspecialchars( $oldusername ),
-				"newusername"   	=> $newusername,
-				"newusername_hsc"	=> htmlspecialchars( $newusername ),
+				"oldusername"   	=> $oldUsername,
+				"oldusername_hsc"	=> htmlspecialchars( $oldUsername ),
+				"newusername"   	=> $newUsername,
+				"newusername_hsc"	=> htmlspecialchars( $newUsername ),
 				"reason"        	=> $reason,
 				"move_allowed"  	=> $wgUser->isAllowed( 'move' ),
-				"confirmaction" 	=> $confirmaction,
+				"confirmaction" 	=> $confirmAction,
 				"warnings"      	=> $warnings,
 				"errors"        	=> $errors,
-				"infos"         	=> $infos,
+				"infos"         	=> $info,
 				"show_confirm"  	=> $showConfirm,
 				"token"         	=> $token,
 				"notify_renamed" 	=> $notifyRenamed,
-			)
+			]
 		);
 
 		$text = $template->render( "rename-form" );
 		$wgOut->addHTML( $text );
 
-		wfProfileOut( __METHOD__ );
 		return;
+	}
+
+	private function validRenameRequest() {
+		$wg = F::app()->wg;
+
+		if ( !$wg->Request->wasPosted() ) {
+			return false;
+		}
+
+		$token = $wg->Request->getText( 'token' );
+		if ( $token === '' ) {
+			return false;
+		}
+
+		return $wg->User->matchEditToken( $token );
 	}
 }

--- a/extensions/wikia/UserRenameTool/UserRenameTask.class.php
+++ b/extensions/wikia/UserRenameTool/UserRenameTask.class.php
@@ -8,7 +8,7 @@
 use Wikia\Tasks\Tasks\BaseTask;
 
 class UserRenameTask extends BaseTask {
-	const EMAIL_CONTROLLER = 'Email\Controller\UserNameChange';
+	const EMAIL_CONTROLLER = \Email\Controller\UserNameChangeController::class;
 
 	/**
 	 * Marshal & execute the RenameUserProcess functions to rename a user

--- a/includes/ExternalUser.php
+++ b/includes/ExternalUser.php
@@ -122,7 +122,7 @@ abstract class ExternalUser {
 			}
 			$obj = self::newFromId( $id );
 		}
-		
+
 		return $obj;
 	}
 	

--- a/includes/User.php
+++ b/includes/User.php
@@ -429,7 +429,11 @@ class User {
 	}
 
 	private function getCacheKey() {
-		return wfMemcKey('user', 'id', $this->mId);
+		return self::getCacheKeyById( $this->mId );
+	}
+
+	private static function getCacheKeyById( $id ) {
+		return wfMemcKey( 'user', 'id', $id );
 	}
 
 	/** @name newFrom*() static factory methods */
@@ -2176,6 +2180,19 @@ class User {
 	public function getTouched() {
 		$this->load();
 		return $this->mTouched;
+	}
+
+	/**
+	 * A function to clear cache with no side effects.  Functions such as clearSharedCache
+	 * or invalidateCache both have side effects like loading things from cache before clearing
+	 * it and writing back to cache after finishing.
+	 *
+	 * @param int $userId
+	 */
+	public static function clearUserCache( $userId ) {
+		global $wgMemc;
+		$memKey = self::getCacheKeyById( $userId );
+		$wgMemc->delete( $memKey );
 	}
 
 	/**


### PR DESCRIPTION
Previously, user data was loaded from cache to delete user data from cache.  This ridiculous loop meant that the very thing we were trying to clear was overwriting the new data we were trying to write.

Also quite a bit of code clean up was done while trying to understand what was going on in the rename code.

https://wikia-inc.atlassian.net/browse/SOC-1075
