### PR TITLE
Don't Filter Preferences When Saving

### DIFF
--- a/includes/User.php
+++ b/includes/User.php
@@ -36,7 +36,7 @@ define( 'USER_TOKEN_LENGTH', 32 );
  * Int Serialized record version.
  * @ingroup Constants
  */
-define( 'MW_USER_VERSION', 11 );
+define( 'MW_USER_VERSION', 12 );
 
 /**
  * String Some punctuation to prevent editing from broken text-mangling proxies.
@@ -2646,7 +2646,7 @@ class User {
 	 * @see getGlobalPreference for documentation about preferences
 	 */
 	public function getDefaultGlobalPreference($preference) {
-		return $this->userPreferences()->getFromDefault($preference);
+		return $this->userPreferences()->getFromDefault($preference)->orElse(null);
 	}
 
 	/**

--- a/lib/Wikia/src/Service/User/Preferences/UserPreferences.php
+++ b/lib/Wikia/src/Service/User/Preferences/UserPreferences.php
@@ -22,25 +22,19 @@ class UserPreferences {
 	/** @var string[string] */
 	private $defaultPreferences;
 
-	/** @var string[] */
-	private $forceSavePrefs;
-
 	/**
 	 * @Inject({
 	 *    Wikia\Service\User\Preferences\PreferenceService::class,
 	 *    Wikia\Service\User\Preferences\UserPreferences::HIDDEN_PREFS,
-	 *    Wikia\Service\User\Preferences\UserPreferences::DEFAULT_PREFERENCES,
-	 *    Wikia\Service\User\Preferences\UserPreferences::FORCE_SAVE_PREFERENCES})
+	 *    Wikia\Service\User\Preferences\UserPreferences::DEFAULT_PREFERENCES})
 	 * @param PreferenceService $preferenceService
 	 * @param string[] $hiddenPrefs
 	 * @param string[string] $defaultPrefs
-	 * @param string[] $forceSavePrefs
 	 */
-	public function __construct(PreferenceService $preferenceService, $hiddenPrefs, $defaultPrefs, $forceSavePrefs) {
+	public function __construct(PreferenceService $preferenceService, $hiddenPrefs, $defaultPrefs) {
 		$this->service = $preferenceService;
 		$this->hiddenPrefs = $hiddenPrefs;
 		$this->defaultPreferences = $defaultPrefs;
-		$this->forceSavePrefs = $forceSavePrefs;
 		$this->preferences = [];
 	}
 
@@ -133,25 +127,8 @@ class UserPreferences {
 			return;
 		}
 
-		$prefsToSave = [];
-
-		foreach ($prefs as $p) {
-			if ($this->prefIsSaveable($p->getName(), $p->getValue())) {
-				$prefsToSave[] = $p;
-			}
+		if (!empty($prefs)) {
+			$this->service->setPreferences($userId, $prefs);
 		}
-
-		if (!empty($prefsToSave)) {
-			$this->service->setPreferences($userId, $prefsToSave);
-		}
-	}
-
-	private function prefIsSaveable($pref, $value) {
-		$default = $this->getFromDefault($pref);
-
-		return
-			in_array($pref, $this->forceSavePrefs) ||
-			!$default->isPresent() ||
-			$value !== $default->get();
 	}
 }

--- a/lib/Wikia/src/Util/Optional/InvalidOptionalOperation.php
+++ b/lib/Wikia/src/Util/Optional/InvalidOptionalOperation.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Wikia\Util\Optional;
+
+use Exception;
+
+class InvalidOptionalOperation extends Exception {
+
+}

--- a/lib/Wikia/src/Util/Optional/Optional.php
+++ b/lib/Wikia/src/Util/Optional/Optional.php
@@ -2,6 +2,7 @@
 
 namespace Wikia\Util\Optional;
 
+use Exception;
 use Wikia\Util\Assert;
 
 class Optional {
@@ -29,7 +30,7 @@ class Optional {
 		return $value;
 	}
 
-	public function orElseThrow($exception=null) {
+	public function orElseThrow(Exception $exception=null) {
 		if ($this->isPresent()) {
 			return $this->value;
 		}

--- a/lib/Wikia/src/Util/Optional/Optional.php
+++ b/lib/Wikia/src/Util/Optional/Optional.php
@@ -6,14 +6,15 @@ use Wikia\Util\Assert;
 
 class Optional {
 
-	/** @var bool */
-	private $isPresent;
-
 	/** @var mixed */
 	private $value;
 
+	private function __construct($value) {
+		$this->value = $value;
+	}
+
 	public function isPresent() {
-		return $this->isPresent;
+		return $this->value !== null;
 	}
 
 	public function get() {
@@ -21,7 +22,7 @@ class Optional {
 	}
 
 	public function orElse($value) {
-		if ($this->isPresent) {
+		if ($this->isPresent()) {
 			return $this->value;
 		}
 
@@ -29,7 +30,7 @@ class Optional {
 	}
 
 	public function orElseThrow($exception=null) {
-		if ($this->isPresent) {
+		if ($this->isPresent()) {
 			return $this->value;
 		}
 
@@ -42,12 +43,7 @@ class Optional {
 
 	public static function of($value) {
 		Assert::true($value !== null);
-
-		$optional = new Optional();
-		$optional->value = $value;
-		$optional->isPresent = true;
-
-		return $optional;
+		return new Optional($value);
 	}
 
 	public static function ofNullable($value) {
@@ -59,9 +55,6 @@ class Optional {
 	}
 
 	public static function emptyOptional() {
-		$optional = new Optional();
-		$optional->isPresent = false;
-
-		return $optional;
+		return new Optional(null);
 	}
 }

--- a/lib/Wikia/src/Util/Optional/Optional.php
+++ b/lib/Wikia/src/Util/Optional/Optional.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Wikia\Util\Optional;
+
+use Wikia\Util\Assert;
+
+class Optional {
+
+	/** @var bool */
+	private $isPresent;
+
+	/** @var mixed */
+	private $value;
+
+	public function isPresent() {
+		return $this->isPresent;
+	}
+
+	public function get() {
+		return $this->orElseThrow();
+	}
+
+	public function orElse($value) {
+		if ($this->isPresent) {
+			return $this->value;
+		}
+
+		return $value;
+	}
+
+	public function orElseThrow($exception=null) {
+		if ($this->isPresent) {
+			return $this->value;
+		}
+
+		if ($exception == null) {
+			$exception = new InvalidOptionalOperation();
+		}
+
+		throw $exception;
+	}
+
+	public static function of($value) {
+		Assert::true($value !== null);
+
+		$optional = new Optional();
+		$optional->value = $value;
+		$optional->isPresent = true;
+
+		return $optional;
+	}
+
+	public static function ofNullable($value) {
+		if ($value === null) {
+			return self::emptyOptional();
+		}
+
+		return self::of($value);
+	}
+
+	public static function emptyOptional() {
+		$optional = new Optional();
+		$optional->isPresent = false;
+
+		return $optional;
+	}
+}

--- a/lib/Wikia/tests/Service/User/UserPreferencesTest.php
+++ b/lib/Wikia/tests/Service/User/UserPreferencesTest.php
@@ -29,8 +29,8 @@ class UserPreferencesTest extends PHPUnit_Framework_TestCase {
 		$defaultPrefs = ["pref1" => "val1"];
 		$preferences = new UserPreferences($this->service, [], $defaultPrefs, []);
 
-		$this->assertEquals("val1", $preferences->getFromDefault("pref1"));
-		$this->assertNull($preferences->getFromDefault("pref2"));
+		$this->assertEquals("val1", $preferences->getFromDefault("pref1")->get());
+		$this->assertNull($preferences->getFromDefault("pref2")->get());
 	}
 
 	public function testGet() {

--- a/lib/Wikia/tests/Service/User/UserPreferencesTest.php
+++ b/lib/Wikia/tests/Service/User/UserPreferencesTest.php
@@ -27,15 +27,15 @@ class UserPreferencesTest extends PHPUnit_Framework_TestCase {
 
 	public function testGetFromDefault() {
 		$defaultPrefs = ["pref1" => "val1"];
-		$preferences = new UserPreferences($this->service, [], $defaultPrefs, []);
+		$preferences = new UserPreferences($this->service, [], $defaultPrefs);
 
 		$this->assertEquals("val1", $preferences->getFromDefault("pref1")->get());
-		$this->assertNull($preferences->getFromDefault("pref2")->get());
+		$this->assertNull($preferences->getFromDefault("pref2")->orElse(null));
 	}
 
 	public function testGet() {
 		$this->setupServiceExpects();
-		$preferences = new UserPreferences($this->service, [], [], []);
+		$preferences = new UserPreferences($this->service, [], []);
 
 		$this->assertEquals("en", $preferences->get($this->userId, "language"));
 		$this->assertEquals("1", $preferences->get($this->userId, "marketingallowed"));
@@ -46,14 +46,14 @@ class UserPreferencesTest extends PHPUnit_Framework_TestCase {
 
 	public function testGetWithHiddenNoDefaults() {
 		$this->setupServiceExpects();
-		$preferences = new UserPreferences($this->service, ["marketingallowed"], [], []);
+		$preferences = new UserPreferences($this->service, ["marketingallowed"], []);
 		$this->assertEquals("1", $preferences->get($this->userId, "marketingallowed", null, true));
 		$this->assertNull($preferences->get($this->userId, "marketingallowed"));
 	}
 
 	public function testGetWithHiddenAndDefaults() {
 		$this->setupServiceExpects();
-		$preferences = new UserPreferences($this->service, ["marketingallowed"], ["marketingallowed" => "0"], []);
+		$preferences = new UserPreferences($this->service, ["marketingallowed"], ["marketingallowed" => "0"]);
 		$this->assertEquals("1", $preferences->get($this->userId, "marketingallowed", null, true));
 		$this->assertEquals("0", $preferences->get($this->userId, "marketingallowed"));
 		$this->assertNull($preferences->get($this->userId, "unsetpreference"));
@@ -61,21 +61,21 @@ class UserPreferencesTest extends PHPUnit_Framework_TestCase {
 	
 	public function testSet() {
 		$this->setupServiceExpects();
-		$preferences = new UserPreferences($this->service, [], [], []);
+		$preferences = new UserPreferences($this->service, [], []);
 		$preferences->set($this->userId, "newpreference", "foo");
 		$this->assertEquals("foo", $preferences->get($this->userId, "newpreference"));
 	}
 
 	public function testSetNullWithDefault() {
 		$this->setupServiceExpects();
-		$preferences = new UserPreferences($this->service, [], ["newpreference" => "foo"], []);
+		$preferences = new UserPreferences($this->service, [], ["newpreference" => "foo"]);
 		$preferences->set($this->userId, "newpreference", null);
 		$this->assertEquals("foo", $preferences->getPreferences($this->userId)["newpreference"]);
 	}
 
 	public function testSetNullWithoutDefault() {
 		$this->setupServiceExpects();
-		$preferences = new UserPreferences($this->service, [], [], []);
+		$preferences = new UserPreferences($this->service, [], []);
 		$preferences->set($this->userId, "newpreference", null);
 		$this->assertNull($preferences->getPreferences($this->userId)["newpreference"]);
 	}

--- a/lib/Wikia/tests/Util/Optional/OptionalTest.php
+++ b/lib/Wikia/tests/Util/Optional/OptionalTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use Wikia\Util\Optional\Optional;
+
+class OptionalTest extends PHPUnit_Framework_TestCase {
+
+	public function testIsPresent() {
+		$this->assertFalse(Optional::emptyOptional()->isPresent());
+		$this->assertTrue(Optional::of(5)->isPresent());
+		$this->assertTrue(Optional::ofNullable("hi")->isPresent());
+		$this->assertFalse(Optional::ofNullable(null)->isPresent());
+	}
+
+	public function testValid() {
+		$optional = Optional::of("test");
+
+		$this->assertTrue($optional->isPresent());
+		$this->assertEquals("test", $optional->get());
+		$this->assertEquals("test", $optional->orElse("other"));
+		$this->assertEquals("test", $optional->orElseThrow());
+	}
+
+	/**
+	 * @expectedException Wikia\Util\AssertionException
+	 */
+	public function testNullWhenUsingOf() {
+		Optional::of(null);
+	}
+
+	/**
+	 * @expectedException Wikia\Util\Optional\InvalidOptionalOperation
+	 */
+	public function testGetWhenNotPresent() {
+		Optional::emptyOptional()->get();
+	}
+
+	public function testOrElseWhenNotPresent() {
+		$this->assertEquals(5, Optional::emptyOptional()->orElse(5));
+	}
+
+	/**
+	 * @expectedException Wikia\Util\Optional\InvalidOptionalOperation
+	 */
+	public function testOrElseThrowWhenNotPresent() {
+		Optional::emptyOptional()->orElseThrow();
+	}
+
+	/**
+	 * @expectedException Exception
+	 */
+	public function testOrElseThrowWhenNotPresentCustomException() {
+		Optional::emptyOptional()->orElseThrow(new Exception());
+	}
+}


### PR DESCRIPTION
@Wikia/services-team 
https://wikia-inc.atlassian.net/browse/SERVICES-639

Now that we don't wipe `user_properties` rows for a user when saving their preferences, it's now impossible for a user to delete a preference that has no default defined. This is because since getting a non-existent default returns `null`, it would never pass the `isSaveable` check, so the changed value would never appear in the database. 

At first my approach was to modify the `isSaveable` check to account for missing default values, but I realized that would introduce a different bug since preferences still are not deleted. Instead, I've removed the filtering of preferences to save altogether, so preferences will always be saved, regardless of how they compare to the default value.

I added a simple `Wikia\Util\Optional\Optional` class as part of my initial implementation. It's not strictly needed, but it's probably a good addition to have. I can remove it if the team feels it's unnecessary.
