### PR TITLE
CurlHttpRequest: set a proxy to an empty string instead of null

### DIFF
--- a/includes/HttpFunctions.php
+++ b/includes/HttpFunctions.php
@@ -764,7 +764,7 @@ class CurlHttpRequest extends MWHttpRequest {
 
 		// Wikia change PLATFORM-1298 michal@wikia-inc.com
 		if ( $this->parsedUrl['scheme'] == 'https' ) {
-			$this->curlOptions[CURLOPT_PROXY] = null;
+			$this->curlOptions[CURLOPT_PROXY] = '';
 		} else {
 			$this->curlOptions[CURLOPT_PROXY] = $this->proxy;
 		}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-1317

Try to avoid `PHP Warning: curl_setopt_array(): Curl option contains invalid characters (\0) in /includes/HttpFunctions.php on line 824`

@michalroszka 
