### PR TITLE
CurlHttpRequest: cast proxy to a string to avoid passing a null value to cURL

### DIFF
--- a/includes/HttpFunctions.php
+++ b/includes/HttpFunctions.php
@@ -770,7 +770,7 @@ class CurlHttpRequest extends MWHttpRequest {
 		if ( $this->parsedUrl['scheme'] == 'https' ) {
 			$this->curlOptions[CURLOPT_PROXY] = '';
 		} else {
-			$this->curlOptions[CURLOPT_PROXY] = $this->proxy;
+			$this->curlOptions[CURLOPT_PROXY] = (string) $this->proxy; // cast to string to avoid setting a proxy to a null (PLATFORM-1317)
 		}
 		// End of Wikia change
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-1317

`MWHttpRequest::$proxy` default value is `null`. Cast to string to avoid `PHP Warning: curl_setopt_array(): Curl option contains invalid characters (\0) in /includes/HttpFunctions.php on line 824`

See #8140

@michalroszka 
