### PR TITLE
update User::setGlobalAttribute calls to User::setGlobalFlag calls

### DIFF
--- a/extensions/wikia/UserProfilePageV3/UserIdentityBox.class.php
+++ b/extensions/wikia/UserProfilePageV3/UserIdentityBox.class.php
@@ -350,8 +350,8 @@ class UserIdentityBox {
 		}
 
 		if( !$this->hasUserEditedMastheadBefore($wgCityId) ) {
-			$this->user->setGlobalAttribute(self::USER_EDITED_MASTHEAD_PROPERTY . $wgCityId, true);
-			$this->user->setGlobalAttribute(self::USER_FIRST_MASTHEAD_EDIT_DATE_PROPERTY . $wgCityId, date('YmdHis'));
+			$this->user->setGlobalFlag(self::USER_EDITED_MASTHEAD_PROPERTY . $wgCityId, true);
+			$this->user->setGlobalFlag(self::USER_FIRST_MASTHEAD_EDIT_DATE_PROPERTY . $wgCityId, date('YmdHis'));
 
 			$this->addTopWiki($wgCityId);
 			$changed = true;


### PR DESCRIPTION
These `User::setGlobalAttribute` calls should be `User::setGlobalFlag` calls.

When pulling this data, we're using `User::getGlobalFlag` which is inconsistent. You can see [Here](https://github.com/Wikia/app/blob/1741bf19b3205c85d3c3d9d3dbfbe3c9388048e5/extensions/wikia/UserProfilePageV3/UserIdentityBox.class.php#L273) and [here](https://github.com/Wikia/app/blob/1741bf19b3205c85d3c3d9d3dbfbe3c9388048e5/extensions/wikia/UserProfilePageV3/UserIdentityBox.class.php#L137)
