### PR TITLE
INT-155: Adding new wiki global vairable available for Mercury

### DIFF
--- a/extensions/wikia/MercuryApi/models/MercuryApi.class.php
+++ b/extensions/wikia/MercuryApi/models/MercuryApi.class.php
@@ -105,13 +105,14 @@ class MercuryApi {
 	 */
 	public function getWikiVariables() {
 		global $wgSitename, $wgCacheBuster, $wgDBname, $wgDefaultSkin, $wgDisableAnonymousEditing,
-			   $wgLang, $wgLanguageCode, $wgContLang, $wgCityId, $wgEnableNewAuth;
+			   $wgLang, $wgLanguageCode, $wgContLang, $wgCityId, $wgEnableNewAuth, $wgDisableAnonymousUploadForMercury;
 
 		return [
 			'cacheBuster' => (int) $wgCacheBuster,
 			'dbName' => $wgDBname,
 			'defaultSkin' => $wgDefaultSkin,
 			'disableAnonymousEditing' => $wgDisableAnonymousEditing,
+			'disableAnonymousUploadForMercury' => $wgDisableAnonymousUploadForMercury,
 			'enableNewAuth' => $wgEnableNewAuth,
 			'id' => (int) $wgCityId,
 			'language' => [


### PR DESCRIPTION
For JP wikia on Mercury, we currently allow anonymous file upload. We would like to add a new control for enable/disable anonymous file upload. Please also see https://github.com/Wikia/config/pull/1249 for the new global variable to control this. This change makes this variable available for Mercury front-end so that we can control UI.
