### PR TITLE
SERVICES-644 Read-only mode for preferences

### DIFF
--- a/lib/Wikia/src/Persistence/User/Preferences/PreferencePersistenceMySQL.php
+++ b/lib/Wikia/src/Persistence/User/Preferences/PreferencePersistenceMySQL.php
@@ -83,6 +83,10 @@ class PreferencePersistenceMySQL implements PreferencePersistence {
 	}
 
 	public function save( $userId, array $preferences ) {
+		// temorary read-only mode for SERVICES-644
+		return false;
+
+
 		// Filtering preferences against the whiteList if needed
 		$preferences = $this->applyWhitelist( $preferences );
 

--- a/lib/Wikia/src/Persistence/User/Preferences/PreferencePersistenceMySQL.php
+++ b/lib/Wikia/src/Persistence/User/Preferences/PreferencePersistenceMySQL.php
@@ -83,10 +83,6 @@ class PreferencePersistenceMySQL implements PreferencePersistence {
 	}
 
 	public function save( $userId, array $preferences ) {
-		// temorary read-only mode for SERVICES-644
-		return false;
-
-
 		// Filtering preferences against the whiteList if needed
 		$preferences = $this->applyWhitelist( $preferences );
 

--- a/lib/Wikia/src/Service/User/Preferences/PreferenceKeyValueService.php
+++ b/lib/Wikia/src/Service/User/Preferences/PreferenceKeyValueService.php
@@ -40,6 +40,10 @@ class PreferenceKeyValueService implements PreferenceService {
 	}
 
 	public function setPreferences( $userId, array $preferences ) {
+		// temorary read-only mode for SERVICES-644
+		return false;
+
+
 		if ( !is_array( $preferences ) || empty( $preferences ) || $userId == 0 ) {
 			return false;
 		}


### PR DESCRIPTION
This is for emergency use only to assist in the resolution of https://wikia-inc.atlassian.net/browse/SERVICES-644. While the new table is being moved into place we don't want to write to preferences.

https://wikia-inc.atlassian.net/browse/SERVICES-644

Failed tests are expected since this is unexpected behavior. Once the table is in place on the slaves this can be reverted.
