### PR TITLE
(CE-2260) Display a warning on JS pages when site JS is disabled

### DIFF
--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -62,6 +62,8 @@ $wgHooks['TitleGetLangVariants'][] = 'Wikia::onTitleGetLangVariants';
 # don't purge all thumbs - PLATFORM-161
 $wgHooks['LocalFilePurgeThumbnailsUrls'][] = 'Wikia::onLocalFilePurgeThumbnailsUrls';
 
+$wgHooks['BeforePageDisplay'][] = 'Wikia::onBeforePageDisplay';
+
 /**
  * This class has only static methods so they can be used anywhere
  *
@@ -2310,5 +2312,27 @@ class Wikia {
 		}
 
 		return $countryNames;
+	}
+
+	/**
+	 * Displays a warning when viewing site JS pages if JavaScript is disabled
+	 * on the wikia.
+	 *
+	 * @param  OutputPage $out  The OutputPage object
+	 * @param  Skin       $skin The Skin object that will be used to render the page.
+	 * @return boolean
+	 */
+	public static function onBeforePageDisplay( OutputPage $out, Skin $skin ) {
+		global $wgUseSiteJs;
+		$title = $out->getTitle();
+
+		if ( !$wgUseSiteJs && $title->isJsPage() ) {
+			\BannerNotificationsController::addConfirmation(
+				wfMessage( 'usesitejs-disabled-warning' )->escaped(),
+				\BannerNotificationsController::CONFIRMATION_NOTIFY
+			);
+		}
+
+		return true;
 	}
 }

--- a/languages/messages/wikia/MessagesEn.php
+++ b/languages/messages/wikia/MessagesEn.php
@@ -1037,4 +1037,5 @@ hu',
 
 'shared-News_box' => '[http://www.wikia.com/Hiring Wikia is now hiring for several open positions]',
 
+'usesitejs-disabled-warning' => 'JavaScript customizations are disabled on this wikia.',
 ));

--- a/languages/messages/wikia/MessagesQqq.php
+++ b/languages/messages/wikia/MessagesQqq.php
@@ -19,5 +19,6 @@ $messages = array_merge( $messages, array(
 'vertical-music' => 'Music vertical name',
 'vertical-movies' => 'Movies vertical name',
 
+'usesitejs-disabled-warning' => 'Warning message displayed on site JS pages when JavaScript customisations are disabled.',
 ) );
 


### PR DESCRIPTION
Display a warning on JS pages when site JS is disabled for that wikia.

/cc @Wikia/community-engineering 
