### PR TITLE
MAIN-5111 Omit helper name from Phalanx block

### DIFF
--- a/includes/Title.php
+++ b/includes/Title.php
@@ -2153,6 +2153,7 @@ class Title {
 				$groups = [
 					'staff',
 					'vstf',
+					'helper',
 				];
 				$blockerGroups = $blocker->getEffectiveGroups();
 


### PR DESCRIPTION
Omit helper name from Phalanx block for privacy reasons.
