### PR TITLE
Ce 2567 disable buttons, check in review status, check approved id

### DIFF
--- a/extensions/wikia/ContentReview/ContentReview.hooks.php
+++ b/extensions/wikia/ContentReview/ContentReview.hooks.php
@@ -76,13 +76,17 @@ class Hooks {
 	}
 
 	public static function onArticleContentOnDiff( $diffEngine, \OutputPage $output ) {
-		global $wgTitle, $wgCityId;
+		global $wgTitle, $wgCityId, $wgRequest;
+		$diff = $wgRequest->getInt( 'diff' );
+		$oldid = $wgRequest->getInt( 'oldid' );
 
 		$helper = new Helper();
 		if ( $wgTitle->inNamespace( NS_MEDIAWIKI )
 			&& $wgTitle->isJsPage()
 			&& $wgTitle->userCan( 'content-review' )
-			&& $helper->isDiffPageInReviewProcess()
+			&& $helper->isDiffPageInReviewProcess( $wgCityId, $wgTitle->getArticleID(), $diff )
+			&& $helper->hasPageApprovedId( $wgCityId, $wgTitle->getArticleID(), $oldid )
+
 		) {
 			\Wikia::addAssetsToOutput( 'content_review_diff_page_js' );
 			\JSMessages::enqueuePackage( 'ContentReviewDiffPage', \JSMessages::EXTERNAL );

--- a/extensions/wikia/ContentReview/ContentReview.hooks.php
+++ b/extensions/wikia/ContentReview/ContentReview.hooks.php
@@ -83,8 +83,8 @@ class Hooks {
 			&& $wgTitle->userCan( 'content-review' )
 		) {
 			$reviewModel = new ReviewModel();
-			$reviewData = $reviewModel->getReviewedContent( $wgCityId,
-				\Title::newFromText( $wgTitle->getArticleID() ), ReviewModel::CONTENT_REVIEW_STATUS_IN_REVIEW );
+			$pageId = \Title::newFromText( $wgTitle->getArticleID() );
+			$reviewData = $reviewModel->getReviewedContent( $wgCityId, $pageId, ReviewModel::CONTENT_REVIEW_STATUS_IN_REVIEW );
 			$diff = $wgRequest->getInt( 'diff' );
 			if ( !empty( $reviewData ) && (int)$reviewData['revision_id'] === $diff ) {
 
@@ -95,8 +95,8 @@ class Hooks {
 					\Xml::element( 'button',
 						[
 							'class' => 'content-review-diff-button',
-							'data-wiki-id' => ( $wgCityId ),
-							'data-page-id' => \Title::newFromText( $wgTitle->getArticleID() ),
+							'data-wiki-id' => $wgCityId,
+							'data-page-id' => $pageId,
 							'data-status' => ReviewModel::CONTENT_REVIEW_STATUS_REJECTED
 						],
 						wfMessage( 'content-review-diff-reject' )->plain()
@@ -116,6 +116,7 @@ class Hooks {
 				);
 			}
 		}
+		
 		return true;
 	}
 }

--- a/extensions/wikia/ContentReview/ContentReview.hooks.php
+++ b/extensions/wikia/ContentReview/ContentReview.hooks.php
@@ -82,7 +82,7 @@ class Hooks {
 		if ( $wgTitle->inNamespace( NS_MEDIAWIKI )
 			&& $wgTitle->isJsPage()
 			&& $wgTitle->userCan( 'content-review' )
-			&& $helper->isPageInReviewProcess()
+			&& $helper->isDiffPageInReviewProcess()
 		) {
 			\Wikia::addAssetsToOutput( 'content_review_diff_page_js' );
 			\JSMessages::enqueuePackage( 'ContentReviewDiffPage', \JSMessages::EXTERNAL );

--- a/extensions/wikia/ContentReview/ContentReview.i18n.php
+++ b/extensions/wikia/ContentReview/ContentReview.i18n.php
@@ -53,6 +53,7 @@ $messages['en'] = [
 	'content-review-diff-approve-confirmation' => 'Reviewed code has been approved.',
 	'content-review-diff-reject-confirmation' => 'Reviewed code has been rejected.',
 	'content-review-diff-page-error' => 'Something went wrong. Please try again later.',
+	'content-review-diff-already-done' => 'You are trying to add an changes to the a non-existent revision.',
 
 	'content-review-status-unreviewed' => 'Unreviewed',
 	'content-review-status-in-review' => 'In review',
@@ -103,8 +104,9 @@ $messages['qqq'] = [
 	'content-review-diff-approve-confirmation' => 'A message shown after click approve button.',
 	'content-review-diff-reject-confirmation' => 'A message shown after click reject button.',
 	'content-review-diff-page-error' => 'A message shown when something go wrong on diff page.',
+	'content-review-diff-already-done' => 'A message shown when someone is trying approve/reject on not in review or with wrong oldid revision',
 
-	'content-review-status-unreviewed' => 'Status Unreviewed',
+		'content-review-status-unreviewed' => 'Status Unreviewed',
 	'content-review-status-in-review' => 'Status In review',
 	'content-review-status-approved' => 'Status Approved',
 	'content-review-status-rejected' => 'Status Rejected,'

--- a/extensions/wikia/ContentReview/ContentReview.i18n.php
+++ b/extensions/wikia/ContentReview/ContentReview.i18n.php
@@ -106,7 +106,7 @@ $messages['qqq'] = [
 	'content-review-diff-page-error' => 'A message shown when something go wrong on diff page.',
 	'content-review-diff-already-done' => 'A message shown when someone is trying approve/reject on not in review or with wrong oldid revision',
 
-		'content-review-status-unreviewed' => 'Status Unreviewed',
+	'content-review-status-unreviewed' => 'Status Unreviewed',
 	'content-review-status-in-review' => 'Status In review',
 	'content-review-status-approved' => 'Status Approved',
 	'content-review-status-rejected' => 'Status Rejected,'

--- a/extensions/wikia/ContentReview/ContentReviewHelper.php
+++ b/extensions/wikia/ContentReview/ContentReviewHelper.php
@@ -93,7 +93,7 @@ class Helper {
 		return $contentReviewTestModeEnabled;
 	}
 
-	public function isPageInReviewProcess() {
+	public function isDiffPageInReviewProcess() {
 		global $wgTitle, $wgCityId, $wgRequest;
 
 		$reviewModel = new ReviewModel();

--- a/extensions/wikia/ContentReview/ContentReviewHelper.php
+++ b/extensions/wikia/ContentReview/ContentReviewHelper.php
@@ -2,6 +2,8 @@
 
 namespace Wikia\ContentReview;
 
+use Wikia\ContentReview\Models\ReviewModel;
+
 class Helper {
 
 	public function getSiteJsScriptsHash() {
@@ -89,5 +91,18 @@ class Helper {
 		}
 
 		return $contentReviewTestModeEnabled;
+	}
+
+	public function isPageInReviewProcess() {
+		global $wgTitle, $wgCityId, $wgRequest;
+
+		$reviewModel = new ReviewModel();
+		$reviewData = $reviewModel->getReviewedContent( $wgCityId, $wgTitle->getArticleID(), ReviewModel::CONTENT_REVIEW_STATUS_IN_REVIEW );
+		$diff = $wgRequest->getInt( 'diff' );
+
+		if ( !empty( $reviewData ) && (int)$reviewData['revision_id'] === $diff ) {
+			return true;
+		}
+		return false;
 	}
 }

--- a/extensions/wikia/ContentReview/ContentReviewHelper.php
+++ b/extensions/wikia/ContentReview/ContentReviewHelper.php
@@ -2,6 +2,7 @@
 
 namespace Wikia\ContentReview;
 
+use Wikia\ContentReview\Models\CurrentRevisionModel;
 use Wikia\ContentReview\Models\ReviewModel;
 
 class Helper {
@@ -93,14 +94,23 @@ class Helper {
 		return $contentReviewTestModeEnabled;
 	}
 
-	public function isDiffPageInReviewProcess() {
-		global $wgTitle, $wgCityId, $wgRequest;
+	public function isDiffPageInReviewProcess( $wikiId, $pageId, $diff ) {
 
 		$reviewModel = new ReviewModel();
-		$reviewData = $reviewModel->getReviewedContent( $wgCityId, $wgTitle->getArticleID(), ReviewModel::CONTENT_REVIEW_STATUS_IN_REVIEW );
-		$diff = $wgRequest->getInt( 'diff' );
+		$reviewData = $reviewModel->getReviewedContent( $wikiId, $pageId, ReviewModel::CONTENT_REVIEW_STATUS_IN_REVIEW );
 
 		if ( !empty( $reviewData ) && (int)$reviewData['revision_id'] === $diff ) {
+			return true;
+		}
+		return false;
+	}
+
+	public function hasPageApprovedId( $wikiId, $pageId, $oldid ) {
+
+		$currentModel = new CurrentRevisionModel();
+		$currentData = $currentModel->getLatestReviewedRevision( $wikiId, $pageId );
+
+		if ( !empty( $currentData ) && (int)$currentData['revision_id'] === $oldid ) {
 			return true;
 		}
 		return false;

--- a/extensions/wikia/ContentReview/controllers/ContentReviewApiController.class.php
+++ b/extensions/wikia/ContentReview/controllers/ContentReviewApiController.class.php
@@ -147,6 +147,9 @@ class ContentReviewApiController extends WikiaApiController {
 
 		$review = $reviewModel->getReviewedContent( $wikiId, $pageId, ReviewModel::CONTENT_REVIEW_STATUS_IN_REVIEW );
 
+		if ( empty( $review ) ) {
+			throw new ErrorException( 'Requested data not present in the database.' );
+		}
 		$reviewModel->backupCompletedReview( $review, $status, $reviewerId );
 
 		if( $status === ReviewModel::CONTENT_REVIEW_STATUS_APPROVED ) {

--- a/extensions/wikia/ContentReview/controllers/ContentReviewApiController.class.php
+++ b/extensions/wikia/ContentReview/controllers/ContentReviewApiController.class.php
@@ -159,7 +159,7 @@ class ContentReviewApiController extends WikiaApiController {
 			$reviewModel->backupCompletedReview( $review, $status, $reviewerId );
 
 			if ( $status === ReviewModel::CONTENT_REVIEW_STATUS_APPROVED ) {
-			//	$currentRevisionModel->approveRevision( $wikiId, $pageId, $review['revision_id'] );
+				$currentRevisionModel->approveRevision( $wikiId, $pageId, $review['revision_id'] );
 				$this->notification = wfMessage( 'content-review-diff-approve-confirmation' )->escaped();
 			} elseif ( $status === ReviewModel::CONTENT_REVIEW_STATUS_REJECTED ) {
 				$this->notification = wfMessage( 'content-review-diff-reject-confirmation' )->escaped();

--- a/extensions/wikia/ContentReview/controllers/ContentReviewApiController.class.php
+++ b/extensions/wikia/ContentReview/controllers/ContentReviewApiController.class.php
@@ -2,6 +2,7 @@
 
 use Wikia\ContentReview\Models\CurrentRevisionModel;
 use Wikia\ContentReview\Models\ReviewModel;
+use Wikia\ContentReview\Helper;
 
 class ContentReviewApiController extends WikiaApiController {
 
@@ -139,27 +140,35 @@ class ContentReviewApiController extends WikiaApiController {
 
 		$currentRevisionModel = new CurrentRevisionModel();
 		$reviewModel = new ReviewModel();
+		$helper = new Helper();
 
 		$reviewerId = $this->wg->User->getId();
 		$pageId = $this->request->getInt( 'pageId' );
 		$wikiId = $this->request->getInt( 'wikiId' );
 		$status = $this->request->getInt( 'status' );
+		$diff = $this->request->getInt( 'diff' );
+		$oldid = $this->request->getInt( 'oldid' );
 
-		$review = $reviewModel->getReviewedContent( $wikiId, $pageId, ReviewModel::CONTENT_REVIEW_STATUS_IN_REVIEW );
 
-		if ( empty( $review ) ) {
-			throw new ErrorException( 'Requested data not present in the database.' );
-		}
-		$reviewModel->backupCompletedReview( $review, $status, $reviewerId );
+		if ( $helper->hasPageApprovedId( $wikiId, $pageId, $oldid  ) && $helper->isDiffPageInReviewProcess( $wikiId, $pageId, $diff ) ) {
+			$review = $reviewModel->getReviewedContent( $wikiId, $pageId, ReviewModel::CONTENT_REVIEW_STATUS_IN_REVIEW );
 
-		if( $status === ReviewModel::CONTENT_REVIEW_STATUS_APPROVED ) {
-			$currentRevisionModel->approveRevision( $wikiId, $pageId, $review['revision_id'] );
-			$this->notification = wfMessage( 'content-review-diff-approve-confirmation' )->escaped();
+			if ( empty( $review ) ) {
+				throw new NotFoundApiException( 'Requested data not present in the database.' );
+			}
+			$reviewModel->backupCompletedReview( $review, $status, $reviewerId );
+
+			if ( $status === ReviewModel::CONTENT_REVIEW_STATUS_APPROVED ) {
+			//	$currentRevisionModel->approveRevision( $wikiId, $pageId, $review['revision_id'] );
+				$this->notification = wfMessage( 'content-review-diff-approve-confirmation' )->escaped();
+			} elseif ( $status === ReviewModel::CONTENT_REVIEW_STATUS_REJECTED ) {
+				$this->notification = wfMessage( 'content-review-diff-reject-confirmation' )->escaped();
+			}
+			$reviewModel->removeCompletedReview( $wikiId, $pageId );
 		}
-		elseif( $status === ReviewModel::CONTENT_REVIEW_STATUS_REJECTED )  {
-			$this->notification = wfMessage( 'content-review-diff-reject-confirmation' )->escaped();
+		else {
+			$this->notification = wfMessage( 'content-review-diff-already-done' )->escaped();
 		}
-		$reviewModel->removeCompletedReview( $wikiId, $pageId );
 	}
 
 	public function getCurrentPageData() {

--- a/extensions/wikia/ContentReview/scripts/contentReviewDiffPage.js
+++ b/extensions/wikia/ContentReview/scripts/contentReviewDiffPage.js
@@ -29,7 +29,7 @@ define(
 					status: $button.attr('data-status'),
 					editToken: mw.user.tokens.get('editToken')
 				};
-
+			$('.content-review-diff-button').prop("disabled",true);
 			nirvana.sendRequest({
 				controller: 'ContentReviewApiController',
 				method: 'removeCompletedAndUpdateLogs',
@@ -40,8 +40,6 @@ define(
 							response.notification,
 							'confirm'
 						);
-						$('.content-review-diff-button').hide();
-
 						notification.show();
 					}
 				},
@@ -50,6 +48,7 @@ define(
 						mw.message('content-review-diff-page-error').escaped(),
 						'error'
 					);
+					$('.content-review-diff-button').prop("disabled",false);
 					notification.show();
 				}
 			});

--- a/extensions/wikia/ContentReview/scripts/contentReviewDiffPage.js
+++ b/extensions/wikia/ContentReview/scripts/contentReviewDiffPage.js
@@ -29,7 +29,7 @@ define(
 					status: $button.attr('data-status'),
 					editToken: mw.user.tokens.get('editToken')
 				};
-			$('.content-review-diff-button').prop("disabled",true);
+			$('.content-review-diff-button').prop('disabled',true);
 			nirvana.sendRequest({
 				controller: 'ContentReviewApiController',
 				method: 'removeCompletedAndUpdateLogs',
@@ -48,7 +48,7 @@ define(
 						mw.message('content-review-diff-page-error').escaped(),
 						'error'
 					);
-					$('.content-review-diff-button').prop("disabled",false);
+					$('.content-review-diff-button').prop('disabled',false);
 					notification.show();
 				}
 			});

--- a/extensions/wikia/ContentReview/scripts/contentReviewDiffPage.js
+++ b/extensions/wikia/ContentReview/scripts/contentReviewDiffPage.js
@@ -40,6 +40,8 @@ define(
 							response.notification,
 							'confirm'
 						);
+						$('.content-review-diff-button').hide();
+
 						notification.show();
 					}
 				},

--- a/extensions/wikia/ContentReview/scripts/contentReviewDiffPage.js
+++ b/extensions/wikia/ContentReview/scripts/contentReviewDiffPage.js
@@ -1,6 +1,6 @@
 define(
 	'ext.wikia.contentReview.diff.page',
-	['BannerNotification', 'wikia.querystring','jquery', 'mw', 'wikia.loader', 'wikia.nirvana'],
+	['BannerNotification', 'wikia.querystring', 'jquery', 'mw', 'wikia.loader', 'wikia.nirvana'],
 	function (BannerNotification, Querystring, $, mw, loader, nirvana) {
 		'use strict';
 		var qs = new Querystring(),

--- a/extensions/wikia/ContentReview/scripts/contentReviewDiffPage.js
+++ b/extensions/wikia/ContentReview/scripts/contentReviewDiffPage.js
@@ -1,8 +1,11 @@
 define(
 	'ext.wikia.contentReview.diff.page',
-	['BannerNotification', 'jquery', 'mw', 'wikia.loader', 'wikia.nirvana'],
-	function (BannerNotification, $, mw, loader, nirvana) {
+	['BannerNotification', 'wikia.querystring','jquery', 'mw', 'wikia.loader', 'wikia.nirvana'],
+	function (BannerNotification, Querystring, $, mw, loader, nirvana) {
 		'use strict';
+		var qs = new Querystring(),
+			diff = qs.getVal('diff', null),
+			oldid = qs.getVal('oldid', null);
 
 		function init() {
 			$.when(loader({
@@ -21,14 +24,17 @@ define(
 		}
 
 		function removeCompletedAndUpdateLogs() {
-			var $button = $(this),
+			var	$button = $(this),
 				notification,
 				data = {
 					wikiId: $button.attr('data-wiki-id'),
 					pageId: $button.attr('data-page-id'),
 					status: $button.attr('data-status'),
+					diff: diff,
+					oldid: oldid,
 					editToken: mw.user.tokens.get('editToken')
 				};
+
 			$('.content-review-diff-button').prop('disabled',true);
 			nirvana.sendRequest({
 				controller: 'ContentReviewApiController',


### PR DESCRIPTION
This pull request contains:
CE-2526 - disable approve/reject buttons after click on one of them,
CE-2528 - check if approve/reject buttons should be shown,
CE-2567 - buttons should be visible only when you comparing with approved revision,
CE-2568 - validate if you're approving right revision.
