### PR TITLE
(CE-2565,CE-2566) Fix some Achievements security issues

### DIFF
--- a/extensions/wikia/AchievementsII/AchBadge.class.php
+++ b/extensions/wikia/AchievementsII/AchBadge.class.php
@@ -62,7 +62,7 @@ class AchBadge {
 	}
 
 	public function getDetails() {
-		return wfMsgForContent(AchConfig::getInstance()->getBadgeToGetDetailsKey($this->mBadgeTypeId), array($this->getCategory()));
+		return wfMessage( AchConfig::getInstance()->getBadgeToGetDetailsKey( $this->mBadgeTypeId ), $this->getCategory() )->parse();
 	}
 
 	public function getToGet($i = null) {

--- a/extensions/wikia/AchievementsII/specials/SpecialAchievementsCustomize.class.php
+++ b/extensions/wikia/AchievementsII/specials/SpecialAchievementsCustomize.class.php
@@ -31,7 +31,9 @@ class SpecialAchievementsCustomize extends SpecialPage {
 		$errorMsg = null;
 		$successMsg = null;
 
-		if($wgRequest->wasPosted()) {
+		if ( $wgRequest->wasPosted()
+			&& $wgUser->matchEditToken( $wgRequest->getVal( 'editToken' ) )
+		) {
 
 			$jsonObj = json_decode($wgRequest->getVal('json-data'));
 			$dbw = null;
@@ -108,7 +110,8 @@ class SpecialAchievementsCustomize extends SpecialPage {
 			'config' => AchConfig::getInstance(),
 			'scrollTo' => (isset($jsonObj->sectionId)) ? $jsonObj->sectionId : null,
 			'successMsg' => $successMsg,
-			'errorMsg' => $errorMsg
+			'errorMsg' => $errorMsg,
+			'editToken' => $wgUser->getEditToken(),
 		));
 
 		$wgOut->addHTML($template->render('SpecialCustomize'));

--- a/extensions/wikia/AchievementsII/specials/templates/SpecialCustomize.tmpl.php
+++ b/extensions/wikia/AchievementsII/specials/templates/SpecialCustomize.tmpl.php
@@ -6,6 +6,7 @@
 	<form method="POST" class="customize-edit-plus-category" onsubmit="Achievements.AchPrepareData(true);">
 		<input type="hidden" name="add_edit_plus_category_track" value="1"/>
 		<input type="hidden" name="json-data" class="c-messages-ec" />
+		<input type="hidden" name="editToken" value="<?= Sanitizer::encodeAttribute( $editToken ); ?>" />
 		<h2><?=wfMessage('achievements-create-edit-plus-category-title')->escaped();?></h2>
 		<?=wfMessage( 'achievements-create-edit-plus-category-content' )->parse();?>
 		<p class="input">
@@ -47,16 +48,17 @@ foreach($config->getInTrackStatic() as $badgeTypeId => $trackData){
 		<div class="save-title-button">
 			<span class="enabled-flag">
 				<?= (isset($trackData['category'])) ?
-					"<input class=\"c-enabled-flags\" type=\"checkbox\" name=\"ec_{$badgeTypeId}\" value=\"1\"". (($trackData['enabled']) ? ' checked' : null) . '/><label>' . wfMsg('achievements-enable-track') . '</label> '
+					"<input class=\"c-enabled-flags\" type=\"checkbox\" name=\"ec_{$badgeTypeId}\" value=\"1\"". (($trackData['enabled']) ? ' checked' : null) . '/><label>' . wfMessage( 'achievements-enable-track' )->escaped() . '</label> '
 				:
 					null?>
 			</span>
 			<form method="POST" class="save-all">
 				<input type="hidden" name="json-data" class="c-messages" />
+				<input type="hidden" name="editToken" value="<?= Sanitizer::encodeAttribute( $editToken ); ?>" />
 				<input type="submit" value="<?= wfMessage('achievements-save')->escaped() ?>" onclick="Achievements.AchPrepareData(false, '<?= $badgeTypeId; ?>');"/>
 			</form>
 		</div>
-		<h2><?=wfMsg($config->getTrackNameKey($badgeTypeId), (isset($trackData['category']) ? $trackData['category'] : null));?></h2>
+		<h2><?= wfMessage( $config->getTrackNameKey($badgeTypeId), (isset($trackData['category']) ? $trackData['category'] : null) )->escaped(); ?></h2>
 
 		<ul class="custom-badges">
 			<?php
@@ -72,7 +74,7 @@ foreach($config->getInTrackStatic() as $badgeTypeId => $trackData){
 						<p class="input">
 							<input class="c-message" type="text" name="msg_<?=$badgeTypeId;?>_<?=$lap;?>" value="<?=htmlspecialchars($badge->getName());?>">
 						</p>
-						<p><?=$config->getLevelName($badge->getLevel());?> (<?=wfMsg( 'achievements-points', $config->getLevelScore( $badge->getLevel() ) );?>)</p>
+						<p><?=$config->getLevelName($badge->getLevel());?> (<?= wfMessage( 'achievements-points', $config->getLevelScore( $badge->getLevel() ) )->escaped(); ?>)</p>
 						<p><?=$badge->getGiveFor();?></p>
 					</div>
 
@@ -80,17 +82,17 @@ foreach($config->getInTrackStatic() as $badgeTypeId => $trackData){
 						<p>
 							<img width="90" height="90" src="<?=$badge->getPictureUrl(90);?>" />
 							<br />
-							<span class="custom-text"><?=wfMsg('achievements-customize')?>
+							<span class="custom-text"><?= wfMessage( 'achievements-customize' )->escaped(); ?>
 								<br />
 								<a href="#" onclick="Achievements.revert(this, <?=$badgeTypeId;?>, <?=$lap;?>); return false;">
-									<?=wfMsg('achievements-revert');?>
+									<?= wfMessage( 'achievements-revert' )->escaped(); ?>
 								</a>
 							</span>
 						</p>
 						<form method="POST" enctype="multipart/form-data" class="customize-upload" action="<?= $wgScriptPath ?>/index.php?action=ajax&amp;rs=AchAjax&amp;method=uploadBadgeImage&amp;type_id=<?=$badgeTypeId?>&amp;lap=<?=$lap?>&amp;level=<?=$badge->getLevel();?>" onsubmit="return Achievements.submitPicture(this);">
 							<p class="input">
 								<input name="wpUploadFile" type="file"/>
-								<button type="submit"><?=wfMsg('achievements-send');?></button>
+								<button type="submit"><?= wfMessage( 'achievements-send' )->escaped(); ?></button>
 							</p>
 						</form>
 					</div>
@@ -126,11 +128,12 @@ foreach($config->getNotInTrackStatic() as $badgeTypeId => $badgeData) {
 		<div class="save-title-button">
 			<form method="POST">
 				<input type="hidden" name="json-data" class="c-messages" />
-				<input type="submit" value="<?= wfMsg('achievements-save') ?>" onclick="Achievements.AchPrepareData(false, '<?= $section; ?>');"/>
+				<input type="hidden" name="editToken" value="<?= Sanitizer::encodeAttribute( $editToken ); ?>" />
+				<input type="submit" value="<?= wfMessage( 'achievements-save' )->escaped() ?>" onclick="Achievements.AchPrepareData(false, '<?= $section; ?>');"/>
 			</form>
 		</div>
 
-		<h2><?= wfMsg('achievements-'.$section) ?></h2>
+		<h2><?= wfMessage( 'achievements-' . $section )->escaped() ?></h2>
 		<ul class="custom-badges">
 			<?php
 			$badgesCount = count($badges);
@@ -139,18 +142,18 @@ foreach($config->getNotInTrackStatic() as $badgeTypeId => $badgeData) {
 				<li class="<?= ($index == ($badgesCount-1)) ? ' last' : '' ?>">
 					<div class="content-form">
 						<p class="input">
-							<input class="c-message" type="text" name="msg_<?=$badge->getTypeId();?>" value="<?=htmlspecialchars($badge->getName());?>">
+							<input class="c-message" type="text" name="msg_<?=$badge->getTypeId();?>" value="<?= Sanitizer::encodeAttribute( $badge->getName() ); ?>">
 						</p>
-						<p><?=$config->getLevelName($badge->getLevel());?> (<?=wfMsg( 'achievements-points', $config->getLevelScore( $badge->getLevel() ) );?>)</p>
+						<p><?=$config->getLevelName($badge->getLevel());?> (<?= wfMessage( 'achievements-points', $config->getLevelScore( $badge->getLevel() ) )->escaped(); ?>)</p>
 						<p><?=$badge->getGiveFor();?></p>
 					</div>
 
 					<div class="image-form">
-						<p><img width="90" height="90" src="<?=$badge->getPictureUrl(90);?>" /><br /><span class="custom-text"><?= wfMsg('achievements-customize') ?><br /><a href="#" onclick="Achievements.revert(this, <?=$badge->getTypeId();?>); return false;"><?= wfMsg('achievements-revert') ?></a></span></p>
+						<p><img width="90" height="90" src="<?=$badge->getPictureUrl(90);?>" /><br /><span class="custom-text"><?= wfMessage( 'achievements-customize' )->escaped(); ?><br /><a href="#" onclick="Achievements.revert(this, <?=$badge->getTypeId();?>); return false;"><?= wfMessage( 'achievements-revert' )->escaped(); ?></a></span></p>
 						<form method="POST" enctype="multipart/form-data" class="customize-upload" action="<?= $wgScriptPath ?>/index.php?action=ajax&amp;rs=AchAjax&amp;method=uploadBadgeImage&amp;type_id=<?=$badge->getTypeId();?>&amp;level=<?=$badge->getLevel();?>" onsubmit="return Achievements.submitPicture(this);">
 							<p class="input">
 								<input name="wpUploadFile" type="file"/>
-								<button><?= wfMsg('achievements-send') ?></button>
+								<button><?= wfMessage( 'achievements-send' )->escaped(); ?></button>
 							</p>
 						</form>
 					</div>
@@ -161,6 +164,7 @@ foreach($config->getNotInTrackStatic() as $badgeTypeId => $badgeData) {
 <?endforeach;?>
 	<form method="POST" class="save-all">
 		<input type="hidden" name="json-data" class="c-messages" />
+		<input type="hidden" name="editToken" value="<?= Sanitizer::encodeAttribute( $editToken ); ?>" />
 		<input type="submit"  value="<?= wfMessage( 'achievements-save' )->escaped() ?>" onclick="Achievements.AchPrepareData(false, '');"/>
 	</form>
 </div>

--- a/extensions/wikia/AchievementsII/specials/templates/SpecialLeaderboard.tmpl.php
+++ b/extensions/wikia/AchievementsII/specials/templates/SpecialLeaderboard.tmpl.php
@@ -1,35 +1,35 @@
 <div id="about-achievements">
-	<span class="hide"><?= wfMsg('leaderboard-intro-hide') ?></span>
-	<span class="open"><?= wfMsg('leaderboard-intro-open') ?></span>
-	<h1><?= wfMsg('leaderboard-intro-headline') ?></h1>
+	<span class="hide"><?= wfMessage( 'leaderboard-intro-hide' )->escaped(); ?></span>
+	<span class="open"><?= wfMessage( 'leaderboard-intro-open' )->escaped(); ?></span>
+	<h1><?= wfMessage( 'leaderboard-intro-headline' )->escaped(); ?></h1>
 	<div>
-		<?= wfMsgExt( 'leaderboard-intro', 'parse', $userpage ) ?>
+		<?= wfMessage( 'leaderboard-intro', $userpage )->parseAsBlock(); ?>
 		<ul>
 			<li class="bronze">
-				<?= wfMsg('achievements-bronze') ?>
-				<span><?= wfMsg('achievements-bronze-points') ?></span>
+				<?= wfMessage( 'achievements-bronze' )->escaped(); ?>
+				<span><?= wfMessage( 'achievements-bronze-points' )->parse(); ?></span>
 			</li>
 			<li class="silver">
-				<?= wfMsg('achievements-silver') ?>
-				<span><?= wfMsg('achievements-silver-points') ?></span>
+				<?= wfMessage( 'achievements-silver' )->escaped(); ?>
+				<span><?= wfMessage( 'achievements-silver-points' )->parse(); ?></span>
 			</li>
 			<li class="gold">
-				<?= wfMsg('achievements-gold') ?>
-				<span><?= wfMsg('achievements-gold-points') ?></span>
+				<?= wfMessage( 'achievements-gold' )->escaped(); ?>
+				<span><?= wfMessage( 'achievements-gold-points' )->parse(); ?></span>
 			</li>
 		</ul>
 	</div>
 </div>
 
-<h2 class="achievements-title"><?= wfMsg('leaderboard-title') ?></h2>
+<h2 class="achievements-title"><?= wfMessage( 'leaderboard-title' )->escaped(); ?></h2>
 
 <table id="LeaderboardTable" class="LeaderboardTable">
 	<thead>
 		<tr>
-			<th><?= wfMsg('achievements-leaderboard-rank-label'); ?></th>
-			<th><?= wfMsg('achievements-leaderboard-member-label'); ?></th>
-			<th><?= wfMsg('achievements-leaderboard-points-label'); ?></th>
-			<th><?= wfMsg('achievements-leaderboard-most-recently-earned-label'); ?></th>
+			<th><?= wfMessage( 'achievements-leaderboard-rank-label' )->escaped(); ?></th>
+			<th><?= wfMessage( 'achievements-leaderboard-member-label' )->escaped(); ?></th>
+			<th><?= wfMessage( 'achievements-leaderboard-points-label' )->escaped(); ?></th>
+			<th><?= wfMessage( 'achievements-leaderboard-most-recently-earned-label' )->escaped(); ?></th>
 		</tr>
 	</thead>
 	<tbody>
@@ -64,18 +64,18 @@
 			</td>
 			<td class="tally">
 				<em><?=$wgLang->formatNum($userScore);?></em>
-				<span><?= wfMsg('achievements-leaderboard-points', $userScore) ?></span>
+				<span><?= wfMessage( 'achievements-leaderboard-points', $userScore )->escaped(); ?></span>
 			</td>
 			<td class="badge">
 				<div class="badges" style="position: relative;">
 					<div class="profile-hover<?= ( $badgeIsSponsored ) ? ' sponsored-hover' : null ;?>"<?= ( $badgeIsSponsored && !empty( $hoverTrackingUrl ) ) ? " data-hovertrackurl=\"{$hoverTrackingUrl}\"" : null ;?>>
 						<? if ( $badgeIsSponsored ) :?>
 							<img src="<?= $hoverUrl ;?>"/>
-							<p class="earned"><?= wfMsgExt('achievements-earned', array('parsemag'), $badgeEarnedBy) ?></p>
+							<p class="earned"><?= wfMessage( 'achievements-earned', $badgeEarnedBy )->escaped(); ?></p>
 						<? else :?>
 							<img src="<?=$badge->getPictureURL(90)?>" width="90" height="90" />
 							<div class="profile-hover-text">
-								<h3 class="badge-name"><?=$badge->getName()?></h3>
+								<h3 class="badge-name"><?= htmlspecialchars( $badge->getName() ); ?></h3>
 								<p><?=$badge->getDetails()?></p>
 							</div>
 						<? endif ;?>
@@ -89,7 +89,7 @@
 					<? if ( $badgeIsSponsored ) :?>
 						</a>
 					<? endif ;?>
-					<?=$badge->getName()?>
+					<?= htmlspecialchars( $badge->getName() ); ?>
 				</div>
 			</td>
 		</tr>


### PR DESCRIPTION
Properly escape Leaderboard messages and prevent CSRF on
Special:AchievementsCustomize.

/cc @Wikia/community-engineering 
