### PR TITLE
bumping user version to force db read

### DIFF
--- a/includes/User.php
+++ b/includes/User.php
@@ -37,7 +37,7 @@ define( 'USER_TOKEN_LENGTH', 32 );
  * Int Serialized record version.
  * @ingroup Constants
  */
-define( 'MW_USER_VERSION', 15 );
+define( 'MW_USER_VERSION', 16 );
 
 /**
  * String Some punctuation to prevent editing from broken text-mangling proxies.


### PR DESCRIPTION
@Wikia/services-team 
https://wikia-inc.atlassian.net/browse/SERVICES-670

Users are reporting that their preferences are not showing up as expected. I did a db check on some of the users and their data seems fine. I think this has to do with the memcache object being saved from when we were still using the preference object
