### PR TITLE
Stop writing to user attribute service

### DIFF
--- a/includes/User.php
+++ b/includes/User.php
@@ -2741,7 +2741,6 @@ class User {
 	 */
 	public function setGlobalAttribute($attribute, $value) {
 		$this->setOptionHelper($attribute, $value);
-		$this->setAttributeInService($attribute, $value);
 	}
 
 	/**


### PR DESCRIPTION
Turn off writes to the attribute service as it's been disabled. Once we resolve the security concerns, we'll turn on the service again and can start writing to it.
