### PR TITLE
Get rid of wgDBtransactions

### DIFF
--- a/includes/DefaultSettings.php
+++ b/includes/DefaultSettings.php
@@ -1327,9 +1327,6 @@ $wgDBClusterTimeout = 10;
  */
 $wgDBAvgStatusPoll = 2000;
 
-/** Set to true if using InnoDB tables */
-$wgDBtransactions = false;
-
 /**
  * Set to true to engage MySQL 4.1/5.0 charset-related features;
  * for now will just cause sending of 'SET NAMES=utf8' on connect.


### PR DESCRIPTION
https://www.mediawiki.org/wiki/Manual:$wgDBtransactions - was removed completely in MW 1.20.0.

This was set to false in our case (despite us using transactions-aware InnoDB) potentially causing data inconsistency issues like [PLATFORM-1311](https://wikia-inc.atlassian.net/browse/PLATFORM-1311)

@michalroszka / @wladekb / @owend / @drozdo 
