### PR TITLE
CE-2529 Content Review right rail module 2.0 upgrade

### DIFF
--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -2545,6 +2545,13 @@ $config['content_review_module_js'] = [
 	]
 ];
 
+$config['content_review_module_scss'] = [
+	'type' => AssetsManager::TYPE_SCSS,
+	'assets' => [
+		'//skins/oasis/css/modules/ContentReview.scss',
+	],
+];
+
 $config['content_review_test_mode_js'] = [
 	'type' => AssetsManager::TYPE_JS,
 	'assets' => [

--- a/extensions/wikia/ContentReview/ContentReview.hooks.php
+++ b/extensions/wikia/ContentReview/ContentReview.hooks.php
@@ -13,9 +13,9 @@ class Hooks {
 			&& $wgTitle->isJsPage()
 			&& $wgTitle->userCan( 'edit', $wgUser )
 		) {
-			$currentPageData = \F::app()->sendRequest(
+			$pageStatus = \F::app()->sendRequest(
 				'ContentReviewApiController',
-				'getCurrentPageData',
+				'getPageStatus',
 				[
 					'wikiId' => $wgCityId,
 					'pageId' => $wgTitle->getArticleID(),
@@ -23,43 +23,16 @@ class Hooks {
 				true
 			)->getData();
 
-			$latestRevId = $wgTitle->getLatestRevID();
-
-			/**
-			 * 1. If the latest rev_id is equal to the current reviewed one - do nothing
-			 */
-			if ( intval( $currentPageData['reviewedRevisionId'] ) !== $latestRevId ) {
-				/**
-				 * 2. If there is no revision in review - display the module with a submit call.
-				 */
-				if ( $currentPageData['revisionInReviewId'] === null ) {
-					$railModuleList[1503] = [ 'ContentReviewModule', 'Render', [
-						'moduleType' => \ContentReviewModuleController::MODULE_TYPE_UNREVIEWED,
-					] ];
-				/**
-				 * 3. If the latest rev_id is equal to the one that is already in review -
-				 * display the module without an action call.
-				 */
-				} elseif ( intval( $currentPageData['revisionInReviewId'] ) === $latestRevId ) {
-					$railModuleList[1503] = [ 'ContentReviewModule', 'Render', [
-						'moduleType' => \ContentReviewModuleController::MODULE_TYPE_CURRENT,
-					] ];
-				/**
-				 * 4. If the latest rev_id is not equal to the one that is already in review -
-				 * display the module with an update action call.
-				 */
-				} elseif ( intval( $currentPageData['revisionInReviewId'] ) !== $latestRevId ) {
-					$railModuleList[1503] = [ 'ContentReviewModule', 'Render', [
-						'moduleType' => \ContentReviewModuleController::MODULE_TYPE_IN_REVIEW,
-					] ];
-				}
-			}
+			$railModuleList[1503] = [ 'ContentReviewModule', 'Render', [
+				'pageStatus' => $pageStatus,
+				'latestRevisionId' => $wgTitle->getLatestRevID(),
+			] ];
 		}
 
 		return true;
 	}
 
-	public static function onMakeGlobalVariablesScript(&$vars) {
+	public static function onMakeGlobalVariablesScript( &$vars ) {
 		$vars['contentReviewTestModeEnabled'] = Helper::isContentReviewTestModeEnabled();
 
 		return true;

--- a/extensions/wikia/ContentReview/ContentReview.i18n.php
+++ b/extensions/wikia/ContentReview/ContentReview.i18n.php
@@ -7,28 +7,35 @@ $messages = [];
  */
 $messages['en'] = [
 	'content-review-desc' => 'After a major exploit of customizable JavaScript we can no longer allow for unreviewed code to be executed on wikia\'s pages. This extension is the control room for code reviewing.',
+	'content-review-module-title' => 'Custom JavaScript status',
 
-	'content-review-module-unreviewed-title' => 'This page has unreviewed changes',
-	'content-review-module-unreviewed-description' => 'For security reasons every change made in the MediaWiki namespace has to be reviewed by a Wikia\'s staff member. For development you can use the unreviewed version, however it is not going to be served to other users that are not in the development mode.',
-	'content-review-module-unreviewed-submit' => 'Submit page for a review',
-	'content-review-module-enable-test-mode' => 'Enable Test Mode',
-	'content-review-module-disable-test-mode' => 'Disable Test Mode',
+	'content-review-module-header-latest' => 'Latest revision:',
+	'content-review-module-header-last' => 'Last reviewed revision:',
+	'content-review-module-header-live' => 'Live revision:',
 
-	'content-review-module-inreview-title' => 'A version of this page is waiting for a review',
-	'content-review-module-inreview-description' => 'For security reasons every change made in the MediaWiki namespace has to be reviewed by a Wikia\'s staff member. This page is waiting for a review. Use the button if you want to update the version submitted for a review.',
-	'content-review-module-inreview-submit' => 'Update the unreviewed changes',
+	'content-review-module-status-none' => 'None',
+	'content-review-module-status-unsubmitted' => 'needs to be submitted',
+	'content-review-module-status-live' => 'is live!',
+	'content-review-module-status-awaiting' => 'is awaiting review',
+	'content-review-module-status-approved' => 'was approved',
+	'content-review-module-status-rejected' => 'was rejected',
 
-	'content-review-module-current-title' => 'The current version of this page is waiting for a review',
-	'content-review-module-current-description' => 'For security reasons every change made in the MediaWiki namespace has to be reviewed by a Wikia\'s staff member. The current version page is waiting for a review.',
+	'content-review-rejection-reason-link' => 'Why?',
 
-	'content-review-test-mode-disable' => 'Disable Test Mode',
-	'content-review-test-mode-error' => 'Something went wrong. Please try again later.',
-	'content-review-test-mode-enabled' => 'You are now in test mode.',
+	'content-review-module-help' => '[[Help:Custom Javascript|Help]]',
 
+	'content-review-module-submit' => 'Submit for review',
 	'content-review-module-submit-success-unreviewed' => 'The changes have been successfully submitted for a review.',
 	'content-review-module-submit-success-inreview' => 'The previous unreviewed revision has been successfully updated with the changes.',
 	'content-review-module-submit-exception' => 'Unfortunately, we could not submit the changes for a review due to the following error: $1.',
 	'content-review-module-submit-error' => 'Unfortunately, we could not submit the changes for a review.',
+
+	'content-review-module-enable-test-mode' => 'Enter test mode',
+	'content-review-module-disable-test-mode' => 'Exit test mode',
+
+	'content-review-test-mode-disable' => 'Exit test mode',
+	'content-review-test-mode-error' => 'Something went wrong. Please try again later.',
+	'content-review-test-mode-enabled' => 'You are currently using unreviewed versions of custom JavaScript files. ',
 
 	'contentreview' => 'Content Review',
 	'action-content-review' => 'Content Review',

--- a/extensions/wikia/ContentReview/ContentReview.i18n.php
+++ b/extensions/wikia/ContentReview/ContentReview.i18n.php
@@ -25,8 +25,7 @@ $messages['en'] = [
 	'content-review-module-help' => '[[Help:Custom Javascript|Help]]',
 
 	'content-review-module-submit' => 'Submit for review',
-	'content-review-module-submit-success-unreviewed' => 'The changes have been successfully submitted for a review.',
-	'content-review-module-submit-success-inreview' => 'The previous unreviewed revision has been successfully updated with the changes.',
+	'content-review-module-submit-success' => 'The changes have been successfully submitted for a review.',
 	'content-review-module-submit-exception' => 'Unfortunately, we could not submit the changes for a review due to the following error: $1.',
 	'content-review-module-submit-error' => 'Unfortunately, we could not submit the changes for a review.',
 
@@ -37,7 +36,7 @@ $messages['en'] = [
 	'content-review-test-mode-error' => 'Something went wrong. Please try again later.',
 	'content-review-test-mode-enabled' => 'You are currently using unreviewed versions of custom JavaScript files. ',
 
-	'contentreview' => 'Content Review',
+	'content-review-special-title' => 'Content Review',
 	'action-content-review' => 'Content Review',
 	'content-review-special-list-header-wiki-name' => 'Wiki name',
 	'content-review-special-list-header-page-name' => 'Page name',
@@ -51,8 +50,8 @@ $messages['en'] = [
 
 	'content-review-special-start-review' => 'Start review',
 	'content-review-special-continue-review' => 'Continue review',
-	'content-review-special-review-started' => 'You have started review process.',
-	'content-review-special-review-open' => 'Please complete open review for this page first.',
+	'content-review-special-review-started' => 'You have started a review process.',
+	'content-review-special-review-open' => 'Please complete a review process for a previous revision first.',
 	'content-review-special-error' => 'Unfortunately, an error happened.',
 
 	'content-review-diff-approve' => 'Approve',
@@ -64,7 +63,7 @@ $messages['en'] = [
 	'content-review-status-unreviewed' => 'Unreviewed',
 	'content-review-status-in-review' => 'In review',
 	'content-review-status-approved' => 'Approved',
-	'content-review-status-rejected' => 'Rejected,',
+	'content-review-status-rejected' => 'Rejected',
 ];
 
 /**
@@ -72,22 +71,34 @@ $messages['en'] = [
  */
 $messages['qqq'] = [
 	'content-review-desc' => '{{desc}}',
+	'content-review-module-title' => 'Title of a the right rail module with information on a page status.',
 
-	'content-review-module-unreviewed-title' => 'Title of a the right rail module with a button to submit a page to review.',
-	'content-review-module-unreviewed-description' => 'The content of the right rail module explaining that the current version of a page has not been reviewed.',
-	'content-review-module-unreviewed-submit' => 'Text of a button that sends a page to review.',
+	'content-review-module-header-latest' => 'Header of a section of the right rail module with information on the latest revision submitted for a review.',
+	'content-review-module-header-last' => 'Header of a section of the right rail module with information on the last reviewed revision.',
+	'content-review-module-header-live' => 'Header of a section of the right rail module with information on the revision that is currently live and served to users.',
 
-	'content-review-module-inreview-title' => 'Title of a the right rail module with a button to update a version of a page already sent for a review.',
-	'content-review-module-inreview-description' => 'The content of the right rail module explaining that a page is awaiting a review and that a user can update the submitted code with the current changes.',
-	'content-review-module-inreview-submit' => 'Text of a button that updates the version submitted for a review.',
+	'content-review-module-status-none' => 'Message shown as a revision\'s status when there is no information on it.',
+	'content-review-module-status-unsubmitted' => 'Message shown as a revision\'s status when the latest made revision has not yet been sent for a review.',
+	'content-review-module-status-live' => 'Message shown as a revision\'s status when it is currently live and served to users.',
+	'content-review-module-status-awaiting' => 'Message shown as a revision\'s status when a revision is waiting for a review.',
+	'content-review-module-status-approved' => 'Message shown as a revision\'s status if ',
+	'content-review-module-status-rejected' => 'was rejected',
 
-	'content-review-module-current-title' => 'Title of a the right rail module on a page already sent for a review with the current version.',
-	'content-review-module-current-description' => 'The content of the right rail module explaining that the current version of a page is awaiting for a review.',
+	'content-review-rejection-reason-link' => 'Text of a link that leads a users to a Talk page with an explanation on why their code was rejected.',
 
-	'content-review-module-submit-success-insert' => 'A message shown to a user in a Banner Notification if a page has been added to review.',
-	'content-review-module-submit-success-update' => 'A message shown to a user in a Banner Notification if a page had an unreviewed version submitted and it got updated.',
-	'content-review-module-submit-success-exception' => 'A message shown to a user in a Banner Notification if a known error happened. $1 is the error message.',
-	'content-review-module-submit-success-error' => 'A message shown to a user in a Banner Notification if an unknown error happened.',
+	'content-review-module-help' => 'A link to a Help page explaining how the review system works.',
+
+	'content-review-module-submit' => 'A text of a button that sends a given page for a review.',
+	'content-review-module-submit-success' => 'A message shown to a user in a Banner Notification if a page has been added to review.',
+	'content-review-module-submit-exception' => 'A message shown to a user in a Banner Notification if a known error happened. $1 is the error message.',
+	'content-review-module-submit-error' => 'A message shown to a user in a Banner Notification if an unknown error happened.',
+
+	'content-review-module-enable-test-mode' => 'A text of a button which clicked enables user to test unreviewed changes made in JavaScript articles.',
+	'content-review-module-disable-test-mode' => 'A text of a button which clicked disables serving unreviewed JavaScript to a user.',
+
+	'content-review-test-mode-disable' => 'A text of a link that disables serving unreviewed JavaScript to a user. Shown in a Banner Notification.',
+	'content-review-test-mode-error' => 'A message shown if there was a problem with enabling the test mode to a user.',
+	'content-review-test-mode-enabled' => 'A message shown in Banner Notification with an information that a user is curently being served unreviewed JavaScript pages.',
 
 	'content-review-special-title' => 'Title for special page',
 	'action-content-review' => 'Title for permissions',
@@ -107,12 +118,14 @@ $messages['qqq'] = [
 	'content-review-special-review-open' => 'A message shown when another review for the page is in progress and ask user to complete that first.',
 	'content-review-special-error' => 'Information that some error occurs.',
 
-	'content-review-diff-approve-confirmation' => 'A message shown after click approve button.',
-	'content-review-diff-reject-confirmation' => 'A message shown after click reject button.',
-	'content-review-diff-page-error' => 'A message shown when something go wrong on diff page.',
+	'content-review-diff-approve' => 'A text of a button which clicked approves a given revision.',
+	'content-review-diff-reject' => 'A text of a button which clicked rejects a given revision.',
+	'content-review-diff-approve-confirmation' => 'A message shown in a Banner Notification after a click on the approve button if everything went well.',
+	'content-review-diff-reject-confirmation' => 'A message shown in a Banner Notification after click reject button if everything went well.',
+	'content-review-diff-page-error' => 'A message shown in a Banner Notification when something go wrong on diff page.',
 
-	'content-review-status-unreviewed' => 'Status Unreviewed',
-	'content-review-status-in-review' => 'Status In review',
-	'content-review-status-approved' => 'Status Approved',
-	'content-review-status-rejected' => 'Status Rejected,'
+	'content-review-status-unreviewed' => 'A name of a status of a revision that has not yet been reviewed.',
+	'content-review-status-in-review' => 'A name of a status of a revision that is being reviewed.',
+	'content-review-status-approved' => 'A name of a status of a revision that has been approved.',
+	'content-review-status-rejected' => 'A name of a status of a revision that has been rejected.'
 ];

--- a/extensions/wikia/ContentReview/ContentReviewHelper.php
+++ b/extensions/wikia/ContentReview/ContentReviewHelper.php
@@ -2,6 +2,8 @@
 
 namespace Wikia\ContentReview;
 
+use Wikia\ContentReview\Models\ReviewModel;
+
 class Helper {
 
 	public function getSiteJsScriptsHash() {
@@ -100,5 +102,13 @@ class Helper {
 		}
 
 		return $contentReviewTestModeEnabled;
+	}
+
+	public static function isStatusAwaiting( $status ) {
+		return in_array( (int) $status, [
+				ReviewModel::CONTENT_REVIEW_STATUS_UNREVIEWED,
+				ReviewModel::CONTENT_REVIEW_STATUS_IN_REVIEW,
+			]
+		);
 	}
 }

--- a/extensions/wikia/ContentReview/controllers/ContentReviewApiController.class.php
+++ b/extensions/wikia/ContentReview/controllers/ContentReviewApiController.class.php
@@ -159,22 +159,20 @@ class ContentReviewApiController extends WikiaApiController {
 		$reviewModel->removeCompletedReview( $wikiId, $pageId );
 	}
 
-	public function getCurrentPageData() {
+	public function getPageStatus() {
 		$wikiId = $this->request->getInt( 'wikiId' );
 		$pageId = $this->request->getInt( 'pageId' );
 
-		$revisionData = $this->getLatestReviewedRevisionFromDB( $wikiId, $pageId );
+		$liveRevisionData = [
+			'liveId' => $this->getLatestReviewedRevisionFromDB( $wikiId, $pageId )['revision_id'],
+		];
 
 		$reviewModel = new ReviewModel();
 		$reviewData = $reviewModel->getPageStatus( $wikiId, $pageId );
 
-		$data = [
-			'reviewedRevisionId' => $revisionData['revision_id'],
-			'touched' => $revisionData['touched'],
-			'revisionInReviewId' => $reviewData['revision_id'],
-			'reviewStatus' => $reviewData['status'],
-		];
-		$this->makeSuccessResponse( $data );
+		$currentPageData = array_merge( $liveRevisionData, $reviewData );
+
+		$this->makeSuccessResponse( $currentPageData );
 	}
 
 	public function getLatestReviewedRevision() {

--- a/extensions/wikia/ContentReview/controllers/ContentReviewApiController.class.php
+++ b/extensions/wikia/ContentReview/controllers/ContentReviewApiController.class.php
@@ -156,7 +156,8 @@ class ContentReviewApiController extends WikiaApiController {
 		elseif( $status === ReviewModel::CONTENT_REVIEW_STATUS_REJECTED )  {
 			$this->notification = wfMessage( 'content-review-diff-reject-confirmation' )->escaped();
 		}
-		$reviewModel->removeCompletedReview( $wikiId, $pageId );
+
+		$reviewModel->updateCompletedReview( $wikiId, $pageId, $review['revision_id'], $status );
 	}
 
 	public function getPageStatus() {

--- a/extensions/wikia/ContentReview/controllers/ContentReviewApiController.class.php
+++ b/extensions/wikia/ContentReview/controllers/ContentReviewApiController.class.php
@@ -150,7 +150,9 @@ class ContentReviewApiController extends WikiaApiController {
 		$oldid = $this->request->getInt( 'oldid' );
 
 
-		if ( $helper->hasPageApprovedId( $wikiId, $pageId, $oldid  ) && $helper->isDiffPageInReviewProcess( $wikiId, $pageId, $diff ) ) {
+		if ( $helper->hasPageApprovedId( $wikiId, $pageId, $oldid  )
+			&& $helper->isDiffPageInReviewProcess( $wikiId, $pageId, $diff ) )
+		{
 			$review = $reviewModel->getReviewedContent( $wikiId, $pageId, ReviewModel::CONTENT_REVIEW_STATUS_IN_REVIEW );
 
 			if ( empty( $review ) ) {
@@ -164,13 +166,12 @@ class ContentReviewApiController extends WikiaApiController {
 			} elseif ( $status === ReviewModel::CONTENT_REVIEW_STATUS_REJECTED ) {
 				$this->notification = wfMessage( 'content-review-diff-reject-confirmation' )->escaped();
 			}
-			$reviewModel->removeCompletedReview( $wikiId, $pageId );
+
+			$reviewModel->updateCompletedReview( $wikiId, $pageId, $review['revision_id'], $status );
 		}
 		else {
 			$this->notification = wfMessage( 'content-review-diff-already-done' )->escaped();
 		}
-
-		$reviewModel->updateCompletedReview( $wikiId, $pageId, $review['revision_id'], $status );
 	}
 
 	public function getPageStatus() {

--- a/extensions/wikia/ContentReview/controllers/ContentReviewSpecialController.class.php
+++ b/extensions/wikia/ContentReview/controllers/ContentReviewSpecialController.class.php
@@ -3,7 +3,7 @@ use  Wikia\ContentReview\Models\ReviewModel;
 
 class ContentReviewSpecialController extends WikiaSpecialPageController {
 
-	public static $status = [
+	public static $statusMessageKeys = [
 		ReviewModel::CONTENT_REVIEW_STATUS_UNREVIEWED => 'content-review-status-unreviewed',
 		ReviewModel::CONTENT_REVIEW_STATUS_IN_REVIEW => 'content-review-status-in-review',
 		ReviewModel::CONTENT_REVIEW_STATUS_APPROVED => 'content-review-status-approved',
@@ -35,6 +35,8 @@ class ContentReviewSpecialController extends WikiaSpecialPageController {
 			$this->displayRestrictionError();
 			return false;
 		}
+
+		$this->wg->Out->setPageTitle( wfMessage( 'content-review-special-title' )->escaped() );
 
 		$model = new ReviewModel();
 		$reviews = $model->getContentToReviewFromDatabase();
@@ -74,5 +76,4 @@ class ContentReviewSpecialController extends WikiaSpecialPageController {
 
 		return $reviews;
 	}
-
 }

--- a/extensions/wikia/ContentReview/controllers/ContentReviewSpecialController.class.php
+++ b/extensions/wikia/ContentReview/controllers/ContentReviewSpecialController.class.php
@@ -36,7 +36,7 @@ class ContentReviewSpecialController extends WikiaSpecialPageController {
 			return false;
 		}
 
-		$this->wg->Out->setPageTitle( wfMessage( 'content-review-special-title' )->escaped() );
+		$this->getOutput()->setPageTitle( wfMessage( 'content-review-special-title' )->plain() );
 
 		$model = new ReviewModel();
 		$reviews = $model->getContentToReviewFromDatabase();

--- a/extensions/wikia/ContentReview/controllers/templates/ContentReviewSpecialController_index.php
+++ b/extensions/wikia/ContentReview/controllers/templates/ContentReviewSpecialController_index.php
@@ -1,7 +1,7 @@
 <div class="content-review-special-header">
 	<div class="content-review-special-header-content">
 		<h1 class="content-review-special-header-content-title">
-			<?= wfMessage( 'contentreview' )->escaped() ?>
+			<?= wfMessage( 'content-review-special-title' )->escaped() ?>
 		</h1>
 	</div>
 </div>
@@ -26,7 +26,7 @@
 				<td><?= htmlspecialchars( $review['wiki'] ) ?></td>
 				<td><a href="<?= Sanitizer::encodeAttribute( $review['url'] ) ?>" target="_blank"><?= htmlspecialchars( $review['title'] ) ?></a></td>
 				<td><?= $review['revision_id'] ?></td>
-				<td><?= wfMessage( ContentReviewSpecialController::$status[$review['status']] )->escaped() ?></td>
+				<td><?= wfMessage( ContentReviewSpecialController::$statusMessageKeys[$review['status']] )->escaped() ?></td>
 				<td><?= htmlspecialchars( $review['user'] ) ?></td>
 				<td><?= $review['submit_time'] ?></td>
 				<td><?= htmlspecialchars( $review['review_user_name'] ) ?></td>
@@ -36,7 +36,7 @@
 						<?= wfMessage( 'content-review-special-review-open' )->escaped() ?>
 					<? else: ?>
 						<a href="<?= Sanitizer::encodeAttribute( $review['diff'] ) ?>" target="_blank"
-						   class="<?= ContentReviewSpecialController::$status[$review['status']] ?><?= $review['class'] ?> wikia-button primary"
+						   class="<?= ContentReviewSpecialController::$statusMessageKeys[$review['status']] ?><?= $review['class'] ?> wikia-button primary"
 						   data-wiki-id="<?= $review['wiki_id'] ?>"
 						   data-page-id="<?= $review['page_id'] ?>"
 						   data-old-status="<?= $review['status'] ?>"

--- a/extensions/wikia/ContentReview/models/ReviewModel.php
+++ b/extensions/wikia/ContentReview/models/ReviewModel.php
@@ -2,6 +2,8 @@
 
 namespace Wikia\ContentReview\Models;
 
+use Wikia\ContentReview\Helper;
+
 class ReviewModel extends ContentReviewBaseModel {
 
 	/**
@@ -20,12 +22,9 @@ class ReviewModel extends ContentReviewBaseModel {
 			->FROM( self::CONTENT_REVIEW_STATUS_TABLE )
 			->WHERE( 'wiki_id' )->EQUAL_TO( $wikiId )
 				->AND_( 'page_id' )->EQUAL_TO( $pageId )
-			->ORDER_BY( 'submit_time' )
+			->ORDER_BY( [ 'revision_id', 'ASC' ] )
 			->runLoop( $db, function ( &$pageStatus, $row ) {
-				if ( in_array( $row->status, [
-					self::CONTENT_REVIEW_STATUS_UNREVIEWED,
-					self::CONTENT_REVIEW_STATUS_IN_REVIEW,
-				] ) ) {
+				if ( Helper::isStatusAwaiting( $row->status ) ) {
 					$pageStatus['latestId'] = $row->revision_id;
 					$pageStatus['latestStatus'] = $row->status;
 				} else {
@@ -86,7 +85,7 @@ class ReviewModel extends ContentReviewBaseModel {
 
 		( new \WikiaSQL() )
 			->INSERT( self::CONTENT_REVIEW_STATUS_TABLE )
-			// wiki_id, page_id and revision_id are a unique key
+			// wiki_id, page_id and status are a unique key
 			->SET( 'wiki_id', $wikiId )
 			->SET( 'page_id', $pageId )
 			->SET( 'revision_id', $revisionId )
@@ -116,24 +115,37 @@ class ReviewModel extends ContentReviewBaseModel {
 	 *
 	 * @param int $wikiId
 	 * @param int $pageId
+	 * @param int $revisionId
+	 * @param int $status
 	 * @return bool
 	 * @throws \FluentSql\Exception\SqlException
 	 */
-	public function removeCompletedReview( $wikiId, $pageId ) {
+	public function updateCompletedReview( $wikiId, $pageId, $revisionId, $status ) {
 		$db = $this->getDatabaseForWrite();
 
 		( new \WikiaSQL() )
-			->DELETE( self::CONTENT_REVIEW_STATUS_TABLE )
-			->WHERE( 'wiki_id')->EQUAL_TO( $wikiId )
-			->AND_( 'page_id' )->EQUAL_TO( $pageId )
-			->AND_( 'status' )->EQUAL_TO( self::CONTENT_REVIEW_STATUS_IN_REVIEW )
-			->run( $db);
+			->DELETE()
+			->FROM( self::CONTENT_REVIEW_STATUS_TABLE )
+			->WHERE( 'wiki_id' )->EQUAL_TO( $wikiId )
+				->AND_( 'page_id' )->EQUAL_TO( $pageId )
+				->AND_( 'status' )->EQUAL_TO( $status )
+			->run( $db );
+
+		( new \WikiaSQL() )
+			->UPDATE( self::CONTENT_REVIEW_STATUS_TABLE )
+			->SET( 'status', $status )
+			->WHERE( 'wiki_id' )->EQUAL_TO( $wikiId )
+				->AND_( 'page_id' )->EQUAL_TO( $pageId )
+				->AND_( 'revision_id' )->EQUAL_TO( $revisionId )
+			->run( $db );
 
 		$affectedRows = $db->affectedRows();
 
 		if ( $affectedRows === 0 ) {
-			throw new \FluentSql\Exception\SqlException( 'The DELETE operation failed.' );
+			throw new \FluentSql\Exception\SqlException( 'The DELETE and UPDATE operation failed.' );
 		}
+
+		$db->commit();
 
 		return true;
 	}
@@ -197,11 +209,12 @@ class ReviewModel extends ContentReviewBaseModel {
 		$db = $this->getDatabaseForRead();
 
 		$content = ( new \WikiaSQL() )
-			->SELECT( self::CONTENT_REVIEW_STATUS_TABLE .'.*', self::CONTENT_REVIEW_CURRENT_REVISIONS_TABLE .'.revision_id AS reviewed_id' )
+			->SELECT( self::CONTENT_REVIEW_STATUS_TABLE . '.*', self::CONTENT_REVIEW_CURRENT_REVISIONS_TABLE . '.revision_id AS reviewed_id' )
 			->FROM( self::CONTENT_REVIEW_STATUS_TABLE )
 			->LEFT_JOIN( self::CONTENT_REVIEW_CURRENT_REVISIONS_TABLE )
-			->ON( self::CONTENT_REVIEW_STATUS_TABLE.'.wiki_id', self::CONTENT_REVIEW_CURRENT_REVISIONS_TABLE.'.wiki_id' )
-			->AND_( self::CONTENT_REVIEW_STATUS_TABLE.'.page_id', self::CONTENT_REVIEW_CURRENT_REVISIONS_TABLE.'.page_id' )
+			->ON( self::CONTENT_REVIEW_STATUS_TABLE . '.wiki_id', self::CONTENT_REVIEW_CURRENT_REVISIONS_TABLE . '.wiki_id' )
+				->AND_( self::CONTENT_REVIEW_STATUS_TABLE . '.page_id', self::CONTENT_REVIEW_CURRENT_REVISIONS_TABLE . '.page_id' )
+			->WHERE( 'status' )->IN( self::CONTENT_REVIEW_STATUS_UNREVIEWED, self::CONTENT_REVIEW_STATUS_IN_REVIEW )
 			->ORDER_BY( ['submit_time', 'asc'], ['status', 'desc'] )
 			->runLoop( $db, function ( &$content, $row ) {
 				$content[$row->page_id][$row->status] = get_object_vars( $row );

--- a/extensions/wikia/ContentReview/schema.sql
+++ b/extensions/wikia/ContentReview/schema.sql
@@ -13,6 +13,7 @@ CREATE TABLE content_review_status (
 ) ENGINE = INNODB CHARACTER SET utf8 COLLATE utf8_unicode_ci;
 CREATE INDEX content_review_status_idx         ON content_review_status (status);
 CREATE UNIQUE INDEX content_review_unique_idx  ON content_review_status (wiki_id, page_id, status);
+CREATE UNIQUE INDEX content_review_unique_idx2 ON content_review_status (wiki_id, page_id, revision_id);
 
 -- Table reviewed_content_logs
 DROP TABLE IF EXISTS reviewed_content_logs;

--- a/extensions/wikia/ContentReview/scripts/contentReviewModule.js
+++ b/extensions/wikia/ContentReview/scripts/contentReviewModule.js
@@ -23,31 +23,18 @@ define(
 		function submitPageForReview(event) {
 			event.preventDefault();
 
-			var moduleType = $(this).data('type'),
-				notification,
+			var
 				data = {
-				pageId: mw.config.get('wgArticleId'),
-				editToken: mw.user.tokens.get('editToken')
-			};
+					pageId: mw.config.get('wgArticleId'),
+					editToken: mw.user.tokens.get('editToken')
+				};
 
 			nirvana.sendRequest({
 				controller: 'ContentReviewApiController',
 				method: 'submitPageForReview',
 				data: data,
 				callback: function () {
-					notification = new BannerNotification(
-						/**
-						 * The following message keys may be generated:
-						 * content-review-module-submit-success-insert
-						 * content-review-module-submit-success-update
-						 */
-						mw.message('content-review-module-submit-success-' + moduleType).escaped(),
-						'confirm'
-					);
-
-					$('.content-review-module').hide();
-
-					notification.show();
+					location.reload();
 				},
 				onErrorCallback: function(response) {
 					var e, errorMsg;
@@ -58,7 +45,7 @@ define(
 						} else {
 							errorMsg = e.exception.message;
 						}
-						notification = new BannerNotification(
+						var notification = new BannerNotification(
 							mw.message('content-review-module-submit-exception', errorMsg).escaped(),
 							'error'
 						);

--- a/extensions/wikia/ContentReview/scripts/contentReviewModule.js
+++ b/extensions/wikia/ContentReview/scripts/contentReviewModule.js
@@ -23,7 +23,7 @@ define(
 		function submitPageForReview(event) {
 			event.preventDefault();
 
-			var
+			var notification,
 				data = {
 					pageId: mw.config.get('wgArticleId'),
 					editToken: mw.user.tokens.get('editToken')
@@ -45,7 +45,7 @@ define(
 						} else {
 							errorMsg = e.exception.message;
 						}
-						var notification = new BannerNotification(
+						notification = new BannerNotification(
 							mw.message('content-review-module-submit-exception', errorMsg).escaped(),
 							'error'
 						);

--- a/extensions/wikia/ContentReview/scripts/contentReviewSpecialPage.js
+++ b/extensions/wikia/ContentReview/scripts/contentReviewSpecialPage.js
@@ -38,7 +38,7 @@ define(
                 method: 'updateReviewsStatus',
                 data: data,
                 callback: function() {
-                    var notification = new BannerNotification(
+                    notification = new BannerNotification(
                        mw.message('content-review-special-review-started').escaped(),
                         'confirm'
                     );

--- a/extensions/wikia/ContentReview/templates/ContentReviewModuleStatus.mustache
+++ b/extensions/wikia/ContentReview/templates/ContentReviewModuleStatus.mustache
@@ -1,0 +1,3 @@
+<div class="content-review-status content-review-status-{{statusKey}}">
+	{{{diffLink}}} {{message}} {{#reasonLink}}({{{reasonLink}}}){{/reasonLink}}
+</div>

--- a/skins/oasis/css/modules/ContentReview.scss
+++ b/skins/oasis/css/modules/ContentReview.scss
@@ -1,0 +1,55 @@
+/* Variables */
+$content-review-status-border: 14px solid;
+$content-review-color-none: #aaa;
+$content-review-color-live: #76bf06;
+$content-review-color-approved: #76bf06;
+$content-review-color-rejected: #e1390b;
+$content-review-color-awaiting: #008cce;
+$content-review-color-unsubmitted: #ffad00;
+
+.content-review-module-help {
+	text-align: right;
+}
+
+.content-review-module-submit-container {
+	margin-top: 15px;
+	text-align: center;
+}
+
+.content-review-module-test-mode {
+	margin-top: 15px;
+	text-align: center;
+}
+
+.content-review-module-header {
+	margin-top: 15px;
+}
+
+.content-review-status {
+	border-left: $content-review-status-border;
+	padding-left: 10px;
+}
+
+.content-review-status-none {
+	border-color: $content-review-color-none;
+}
+
+.content-review-status-approved {
+	border-color: $content-review-color-approved;
+}
+
+.content-review-status-live {
+	border-color: $content-review-color-live;
+}
+
+.content-review-status-rejected {
+	border-color: $content-review-color-rejected;
+}
+
+.content-review-status-unsubmitted {
+	border-color: $content-review-color-unsubmitted;
+}
+
+.content-review-status-awaiting {
+	border-color: $content-review-color-awaiting;
+}

--- a/skins/oasis/modules/ContentReviewModuleController.class.php
+++ b/skins/oasis/modules/ContentReviewModuleController.class.php
@@ -96,7 +96,7 @@ class ContentReviewModuleController extends WikiaController {
 		return $liveStatus;
 	}
 
-	public function prepareTemplateData( $status, $revisionId = null, $withReason = false ) {
+	protected function prepareTemplateData( $status, $revisionId = null, $withReason = false ) {
 		$templateData = [
 			'statusKey' => $status,
 			'message' => wfMessage( "content-review-module-status-{$status}" )->escaped(),
@@ -112,7 +112,7 @@ class ContentReviewModuleController extends WikiaController {
 		return $templateData;
 	}
 
-	public function createRevisionLink( $revisionId ) {
+	protected function createRevisionLink( $revisionId ) {
 		return Linker::linkKnown(
 			$this->getContext()->getTitle(),
 			"#{$revisionId}",
@@ -125,7 +125,7 @@ class ContentReviewModuleController extends WikiaController {
 		);
 	}
 
-	public function createRevisionTalkpageLink( $revisionId ) {
+	protected function createRevisionTalkpageLink( $revisionId ) {
 		return Linker::linkKnown(
 			$this->getContext()->getTitle()->getTalkPage(),
 			wfMessage( 'content-review-rejection-reason-link' )->escaped(),

--- a/skins/oasis/modules/ContentReviewModuleController.class.php
+++ b/skins/oasis/modules/ContentReviewModuleController.class.php
@@ -1,10 +1,18 @@
 <?php
 
+use Wikia\ContentReview\Helper;
+use Wikia\ContentReview\Models\ReviewModel;
+
 class ContentReviewModuleController extends WikiaController {
 
-	const MODULE_TYPE_UNREVIEWED = 'unreviewed';
-	const MODULE_TYPE_IN_REVIEW = 'inreview';
-	const MODULE_TYPE_CURRENT = 'current';
+	const STATUS_NONE = 'none';
+	const STATUS_LIVE = 'live';
+	const STATUS_AWAITING = 'awaiting';
+	const STATUS_REJECTED = 'rejected';
+	const STATUS_APPROVED = 'approved';
+	const STATUS_UNSUBMITTED = 'unsubmitted';
+
+	const STATUS_TEMPLATE_PATH = 'extensions/wikia/ContentReview/templates/ContentReviewModuleStatus.mustache';
 
 	/**
 	 * Executed when a page has unreviewed changes.
@@ -12,10 +20,118 @@ class ContentReviewModuleController extends WikiaController {
 	 */
 	public function executeRender( $params ) {
 		Wikia::addAssetsToOutput( 'content_review_module_js' );
+		Wikia::addAssetsToOutput( 'content_review_module_scss' );
 		JSMessages::enqueuePackage( 'ContentReviewModule', JSMessages::EXTERNAL );
 
+		$this->setVal( 'isTestModeEnabled', Helper::isContentReviewTestModeEnabled() );
 
-		$this->moduleType = $params['moduleType'];
-		$this->isTestModeEnabled = Wikia\ContentReview\Helper::isContentReviewTestModeEnabled();
+		/**
+		 * Latest revision status
+		 */
+		$latestStatus = $this->getLatestRevisionStatus( (int) $params['latestRevisionId'], $params['pageStatus'] );
+		$this->setVal( 'latestStatus', MustacheService::getInstance()->render(
+			self::STATUS_TEMPLATE_PATH, $latestStatus
+		) );
+		$this->setVal( 'displaySubmit', $latestStatus['statusKey'] === self::STATUS_UNSUBMITTED );
+
+		/**
+		 * Last reviewed status
+		 */
+		$lastStatus = $this->getLastRevisionStatus( $params['pageStatus'] );
+		$this->setVal( 'lastStatus', MustacheService::getInstance()->render(
+			self::STATUS_TEMPLATE_PATH, $lastStatus
+		) );
+
+		/**
+		 * Live revision status
+		 */
+		$liveStatus = $this->getLiveRevisionStatus( $params['pageStatus'] );
+		$this->setVal( 'liveStatus', MustacheService::getInstance()->render(
+			self::STATUS_TEMPLATE_PATH, $liveStatus
+		) );
+	}
+
+	public function getLatestRevisionStatus( $latestRevisionId, array $pageStatus ) {
+		$latestRevisionId = (int) $latestRevisionId;
+		if ( $latestRevisionId === 0 ) {
+			$latestStatus = $this->prepareTemplateData( self::STATUS_NONE );
+		} elseif ( $latestRevisionId === (int) $pageStatus['liveId'] ) {
+			$latestStatus = $this->prepareTemplateData( self::STATUS_LIVE, $latestRevisionId );
+		} elseif ( $latestRevisionId === (int) $pageStatus['latestId']
+			&& Helper::isStatusAwaiting( $pageStatus['latestStatus'] ) )
+		{
+			$latestStatus = $this->prepareTemplateData( self::STATUS_AWAITING, $latestRevisionId );
+		} elseif ( $latestRevisionId === (int) $pageStatus['lastReviewedId']
+			&& (int) $pageStatus['lastReviewedStatus'] === ReviewModel::CONTENT_REVIEW_STATUS_REJECTED )
+		{
+			$latestStatus = $this->prepareTemplateData( self::STATUS_REJECTED, $latestRevisionId, true );
+		} elseif ( $latestRevisionId > (int) $pageStatus['liveId']
+			&& $latestRevisionId > (int) $pageStatus['latestId']
+			&& $latestRevisionId > (int) $pageStatus['lastReviewedId'] ) {
+			$latestStatus = $this->prepareTemplateData( self::STATUS_UNSUBMITTED, $latestRevisionId );
+		}
+
+		return $latestStatus;
+	}
+
+	public function getLastRevisionStatus( array $pageStatus ) {
+		if ( is_null( $pageStatus['lastReviewedId'] ) ) {
+			$lastStatus = $this->prepareTemplateData( self::STATUS_NONE );
+		} elseif ( (int) $pageStatus['lastReviewedStatus'] === ReviewModel::CONTENT_REVIEW_STATUS_APPROVED ) {
+			$lastStatus = $this->prepareTemplateData( self::STATUS_APPROVED, $pageStatus['lastReviewedId'] );
+		} elseif ( (int) $pageStatus['lastReviewedStatus'] === ReviewModel::CONTENT_REVIEW_STATUS_REJECTED ) {
+			$lastStatus = $this->prepareTemplateData( self::STATUS_REJECTED, $pageStatus['lastReviewedId'], true );
+		}
+
+		return $lastStatus;
+	}
+
+	public function getLiveRevisionStatus( array $pageStatus ) {
+		if ( !is_null( $pageStatus['liveId'] ) ) {
+			$liveStatus = $this->prepareTemplateData( self::STATUS_LIVE, $pageStatus['liveId'] );
+		} else {
+			$liveStatus = $this->prepareTemplateData( self::STATUS_NONE );
+		}
+
+		return $liveStatus;
+	}
+
+	public function prepareTemplateData( $status, $revisionId = null, $withReason = false ) {
+		$templateData = [
+			'statusKey' => $status,
+			'message' => wfMessage( "content-review-module-status-{$status}" )->escaped(),
+		];
+
+		if ( !is_null( $revisionId ) ) {
+			$templateData['diffLink'] = $this->createRevisionLink( $revisionId );
+			if ( $withReason ) {
+				$templateData['reasonLink'] = $this->createRevisionTalkpageLink( $revisionId );
+			}
+		}
+
+		return $templateData;
+	}
+
+	public function createRevisionLink( $revisionId ) {
+		return Linker::linkKnown(
+			$this->getContext()->getTitle(),
+			"#{$revisionId}",
+			[
+				'target' => '_blank'
+			],
+			[
+				'diff' => $revisionId,
+			]
+		);
+	}
+
+	public function createRevisionTalkpageLink( $revisionId ) {
+		return Linker::linkKnown(
+			$this->getContext()->getTitle()->getTalkPage(),
+			wfMessage( 'content-review-rejection-reason-link' )->escaped(),
+			[
+				'target' => '_blank'
+			]
+		);
 	}
 }

--- a/skins/oasis/modules/ContentReviewModuleController.class.php
+++ b/skins/oasis/modules/ContentReviewModuleController.class.php
@@ -116,9 +116,7 @@ class ContentReviewModuleController extends WikiaController {
 		return Linker::linkKnown(
 			$this->getContext()->getTitle(),
 			"#{$revisionId}",
-			[
-				'target' => '_blank'
-			],
+			[],
 			[
 				'diff' => $revisionId,
 			]
@@ -128,10 +126,7 @@ class ContentReviewModuleController extends WikiaController {
 	protected function createRevisionTalkpageLink( $revisionId ) {
 		return Linker::linkKnown(
 			$this->getContext()->getTitle()->getTalkPage(),
-			wfMessage( 'content-review-rejection-reason-link' )->escaped(),
-			[
-				'target' => '_blank'
-			]
+			wfMessage( 'content-review-rejection-reason-link' )->escaped()
 		);
 	}
 }

--- a/skins/oasis/modules/templates/ContentReviewModule_Render.php
+++ b/skins/oasis/modules/templates/ContentReviewModule_Render.php
@@ -1,33 +1,36 @@
 <section class="content-review-module module">
-	<h2><?=
-		/**
-		 * Possible keys:
-		 * content-review-module-unreviewed-title
-		 * content-review-module-inreview-title
-		 * content-review-module-current-title
-		 */
-		wfMessage( "content-review-module-{$moduleType}-title" )->escaped() ?></h2>
-	<p><?=
-		/**
-		 * Possible keys:
-		 * content-review-module-unreviewed-description
-		 * content-review-module-inreview-description
-		 * content-review-module-current-description
-		 */
-		wfMessage( "content-review-module-{$moduleType}-description" )->escaped() ?></p>
-	<? if ( $moduleType !== ContentReviewModuleController::MODULE_TYPE_CURRENT ) : ?>
-		<a href="#" id="content-review-module-submit" title="<?= wfMessage( "content-review-module-{$moduleType}-submit" )->escaped() ?>" data-type="<?= $moduleType ?>">
-			<button class="content-review-module-button" type="button">
-				<?= wfMessage( "content-review-module-{$moduleType}-submit" )->escaped() ?>
-			</button>
-		</a>
+	<h2><?= wfMessage( 'content-review-module-title' )->escaped() ?></h2>
+
+	<h4 class="content-review-module-header"><?= wfMessage( 'content-review-module-header-latest' )->escaped() ?></h4>
+		<?= $latestStatus ?>
+	<h4 class="content-review-module-header"><?= wfMessage( 'content-review-module-header-last' )->escaped() ?></h4>
+		<?= $lastStatus ?>
+	<h4 class="content-review-module-header"><?= wfMessage( 'content-review-module-header-live' )->escaped() ?></h4>
+		<?= $liveStatus ?>
+
+	<? if ( $displaySubmit ) : ?>
+		<div class="content-review-module-submit-container">
+			<a href="#" id="content-review-module-submit" title="<?= wfMessage( "content-review-module-submit" )->escaped() ?>">
+				<button class="content-review-module-button primary" type="button">
+					<?= wfMessage( "content-review-module-submit" )->escaped() ?>
+				</button>
+			</a>
+		</div>
 	<? endif; ?>
-	<? if ( $isTestModeEnabled ) : ?>
-		<button id="content-review-module-disable-test-mode"><?= wfMessage('content-review-module-disable-test-mode')->escaped() ?></button>
-	<? else: ?>
-		<button id="content-review-module-enable-test-mode"><?= wfMessage('content-review-module-enable-test-mode')->escaped() ?></button>
-	<? endif ?>
 
+	<div class="content-review-module-test-mode">
+		<? if ( $isTestModeEnabled ) : ?>
+			<button id="content-review-module-disable-test-mode" class="secondary">
+				<?= wfMessage('content-review-module-disable-test-mode')->escaped() ?>
+			</button>
+		<? else: ?>
+			<button id="content-review-module-enable-test-mode" class="secondary">
+				<?= wfMessage('content-review-module-enable-test-mode')->escaped() ?>
+			</button>
+		<? endif ?>
+	</div>
 
-
+	<div class="content-review-module-help">
+		<?= wfMessage( 'content-review-module-help' )->parse() ?>
+	</div>
 </section>

--- a/skins/oasis/modules/tests/ContentReviewModuleControllerTest.php
+++ b/skins/oasis/modules/tests/ContentReviewModuleControllerTest.php
@@ -1,0 +1,184 @@
+<?php
+
+class ContentReviewModuleControllerTest extends WikiaBaseTest {
+
+	public function setUp() {
+		global $IP;
+		$this->setupFile = "{$IP}/skins/oasis/modules/ContentReviewModuleController.class.php";
+		parent::setUp();
+	}
+
+	/**
+	 * @param $latestRevisionId
+	 * @param $pageStatus
+	 * @param $expectedStatus
+	 *
+	 * @dataProvider latestRevisionStatusDataProvider
+	 */
+	public function testGetLatestRevisionStatus( $latestRevisionId, $pageStatus, $expectedStatus ) {
+		$controllerMock = $this->getControllerMock( $expectedStatus );
+		$latestRevisionStatus = $controllerMock->getLatestRevisionStatus( $latestRevisionId, $pageStatus );
+
+		$this->assertEquals(
+			$expectedStatus,
+			$latestRevisionStatus['statusKey']
+		);
+	}
+
+	/**
+	 * @param $pageStatus
+	 * @param $expectedStatus
+	 *
+	 * @dataProvider lastRevisionStatusDataProvider
+	 */
+	public function testGetLastRevisionStatus( $pageStatus, $expectedStatus ) {
+		$controllerMock = $this->getControllerMock( $expectedStatus );
+		$lastRevisionStatus = $controllerMock->getLastRevisionStatus( $pageStatus );
+
+		$this->assertEquals(
+			$expectedStatus,
+			$lastRevisionStatus['statusKey']
+		);
+	}
+
+	/**
+	 * @param $pageStatus
+	 * @param $expectedStatus
+	 *
+	 * @dataProvider liveRevisionStatusDataProvider
+	 */
+	public function testGetLiveRevisionStatus( $pageStatus, $expectedStatus ) {
+		$controllerMock = $this->getControllerMock( $expectedStatus );
+		$liveRevisionStatus = $controllerMock->getLiveRevisionStatus( $pageStatus );
+
+		$this->assertEquals(
+			$expectedStatus,
+			$liveRevisionStatus['statusKey']
+		);
+	}
+
+	private function getControllerMock( $expectedStatus ) {
+		$controllerMock = $this->getMockBuilder( 'ContentReviewModuleController' )
+			->setMethods( [
+				'createRevisionLink',
+				'createRevisionTalkpageLink',
+			] )
+			->getMock();
+
+		if ( $expectedStatus !== ContentReviewModuleController::STATUS_NONE ) {
+			$controllerMock->expects( $this->once() )
+				->method( 'createRevisionLink' );
+		} else {
+			$controllerMock->expects( $this->never() )
+				->method( 'createRevisionLink' );
+		}
+
+		if ( $expectedStatus !== ContentReviewModuleController::STATUS_REJECTED ) {
+			$controllerMock->expects( $this->never() )
+				->method( 'createRevisionTalkpageLink' );
+		} else {
+			$controllerMock->expects( $this->once() )
+				->method( 'createRevisionTalkpageLink' );
+		}
+
+		return $controllerMock;
+	}
+
+	public function latestRevisionStatusDataProvider() {
+		return [
+			[
+				'0',
+				[],
+				ContentReviewModuleController::STATUS_NONE
+			],
+			[
+				'1491141',
+				[
+					'liveId' => '1491141',
+					'lastReviewedId' => '1491141',
+					'lastReviewedStatus' => '3',
+				],
+				ContentReviewModuleController::STATUS_LIVE
+			],
+			[
+				'1491141',
+				[
+					'liveId' => '1491120',
+					'latestId' => '1491141',
+					'latestStatus' => '1',
+					'lastReviewedId' => '1491130',
+					'lastReviewedStatus' => '4',
+				],
+				ContentReviewModuleController::STATUS_AWAITING
+			],
+			[
+				'1491141',
+				[
+					'liveId' => '1491120',
+					'latestId' => '1491141',
+					'latestStatus' => '2',
+					'lastReviewedId' => '1491130',
+					'lastReviewedStatus' => '4',
+				],
+				ContentReviewModuleController::STATUS_AWAITING
+			],
+			[
+				'1491141',
+				[
+					'liveId' => '1491120',
+					'lastReviewedId' => '1491141',
+					'lastReviewedStatus' => '4',
+				],
+				ContentReviewModuleController::STATUS_REJECTED
+			],
+
+			[
+				'1491141',
+				[
+					'liveId' => '1491120',
+					'lastReviewedId' => '1491131',
+					'lastReviewedStatus' => '4',
+				],
+				ContentReviewModuleController::STATUS_UNSUBMITTED
+			],
+		];
+	}
+
+	public function lastRevisionStatusDataProvider() {
+		return [
+			[
+				[],
+				ContentReviewModuleController::STATUS_NONE
+			],
+			[
+				[
+					'lastReviewedId' => '1491131',
+					'lastReviewedStatus' => '3',
+				],
+				ContentReviewModuleController::STATUS_APPROVED
+			],
+			[
+				[
+					'lastReviewedId' => '1491131',
+					'lastReviewedStatus' => '4',
+				],
+				ContentReviewModuleController::STATUS_REJECTED
+			],
+		];
+	}
+
+	public function liveRevisionStatusDataProvider() {
+		return [
+			[
+				[],
+				ContentReviewModuleController::STATUS_NONE
+			],
+			[
+				[
+					'liveId' => '1491131',
+				],
+				ContentReviewModuleController::STATUS_LIVE
+			],
+		];
+	}
+}


### PR DESCRIPTION
Hello @Wikia/community-engineering !

This PR upgrades the existing right rail module into an informative and visually appealing tool. To achieve this I had to do the following:
1. Change the data retrieved by `ReviewModel::getPageStatus()` so that it returns data on the Latest, Last and Live revisions.
2. Adjust the `ContentReviewModuleController.class.php` to interpret the data to a set of status messages.
3. Write unit tests to check the logic behind the interpretation process.
4. Modify what we store in the database - **the last** approved and rejected revisions are stored in the `content_review_status` table so it is easy to retrieve all necessary info in 1 query.
5. Add styling and modify JS to interact well with the new module.

Besides that I made some changes in naming which I found confusing and cleaned up i18n documentation.

Have a good review!

Yours,
Adam
