### PR TITLE
[SERVICES-672] Helios helper api for sending forgot password emails

### DIFF
--- a/extensions/wikia/Helios/HelperController.class.php
+++ b/extensions/wikia/Helios/HelperController.class.php
@@ -156,13 +156,13 @@ class HelperController extends \WikiaController
 	}
 
 	protected function getFieldFromRequest( $field, $failureMessage ) {
-		$username = $this->getVal( 'username', null );
-		if ( !isset( $username ) ) {
+		$fieldValue = $this->getVal( $field, null );
+		if ( !isset( $fieldValue ) ) {
 			$this->response->setVal( 'message', $failureMessage );
 			$this->response->setCode( \WikiaResponse::RESPONSE_CODE_BAD_REQUEST );
 		}
 
-		return $username;
+		return $fieldValue;
 	}
 
 	protected function authenticateViaTheSchwartz() {

--- a/extensions/wikia/Helios/HelperController.class.php
+++ b/extensions/wikia/Helios/HelperController.class.php
@@ -132,7 +132,10 @@ class HelperController extends \WikiaController
 		$this->response->setVal( 'success', true );
 	}
 
-	public function isBlocked() {
+  public function isBlocked() {
+    $this->response->setFormat( 'json' );
+    $this->response->setCacheValidity( \WikiaResponse::CACHE_DISABLED );
+
 		if ( !$this->authenticateViaTheSchwartz() ) {
 			return;
 		}

--- a/extensions/wikia/Helios/HelperController.class.php
+++ b/extensions/wikia/Helios/HelperController.class.php
@@ -182,9 +182,9 @@ class HelperController extends \WikiaController
 		}
 	}
 
-  public function isBlocked() {
-    $this->response->setFormat( 'json' );
-    $this->response->setCacheValidity( \WikiaResponse::CACHE_DISABLED );
+	public function isBlocked() {
+		$this->response->setFormat( 'json' );
+		$this->response->setCacheValidity( \WikiaResponse::CACHE_DISABLED );
 
 		if ( !$this->authenticateViaTheSchwartz() ) {
 			return;

--- a/extensions/wikia/Helios/HelperController.class.php
+++ b/extensions/wikia/Helios/HelperController.class.php
@@ -132,6 +132,56 @@ class HelperController extends \WikiaController
 		$this->response->setVal( 'success', true );
 	}
 
+	/**
+	 * UserLogin: send an email with temporary password
+	 */
+	public function sendTemporaryPasswordEmail() {
+		$this->response->setFormat( 'json' );
+		$this->response->setCacheValidity( \WikiaResponse::CACHE_DISABLED );
+		$this->response->setVal( 'success', false );
+
+		if ( !$this->authenticateViaTheSchwartz() ) {
+			return;
+		}
+
+		$username = $this->getFieldFromRequest( 'username', 'invalid username' );
+		if ( !isset( $username ) ) {
+			return;
+		}
+
+		$tempPassword = $this->getFieldFromRequest( 'password', 'invalid password' );
+		if ( !isset( $tempPassword ) ) {
+			return;
+		}
+
+		$user = \User::newFromName( $username );
+
+		if ( ! $user instanceof \User ) {
+			$this->response->setVal( 'message', 'unable to create a \User object from name' );
+			$this->response->setCode( \WikiaResponse::RESPONSE_CODE_BAD_REQUEST );
+			return;
+		}
+
+		if ( ! $user->getId() ) {
+			$this->response->setVal( 'message', 'no such user' );
+			$this->response->setCode( \WikiaResponse::RESPONSE_CODE_BAD_REQUEST );
+			return;
+		}
+
+		$resp = \F::app()->sendRequest( 'Email\Controller\ForgotPassword', 'handle', [
+			'targetUser' => $username,
+			'tempPass' => $tempPassword,
+		] );
+
+		$data = $resp->getData();
+		if ( !empty( $data['result'] ) && $data['result'] == 'ok' ) {
+			$this->response->setVal( 'success', true );
+		} else {
+			$this->response->setVal( 'message', 'could not send an email message' );
+			$this->response->setCode( \WikiaResponse::RESPONSE_CODE_NOT_FOUND );
+		}
+	}
+
   public function isBlocked() {
     $this->response->setFormat( 'json' );
     $this->response->setCacheValidity( \WikiaResponse::CACHE_DISABLED );


### PR DESCRIPTION
Dedicated api method is needed for sending temporary password email, as using email controller directly with `Email\\Controller\\ForgotPassword` don't return any http status information and using it with output set to json for additional success/error data in json object also changes the email body to json.   

/cc @Wikia/services-team 
