### PR TITLE
(CE-2509,CE-2510) Tweaks to personal JS permissions

### DIFF
--- a/extensions/wikia/ProtectSiteJS/ProtectSiteJS.class.php
+++ b/extensions/wikia/ProtectSiteJS/ProtectSiteJS.class.php
@@ -37,8 +37,9 @@ class ProtectSiteJS {
 		global $wgCityId;
 		$allowedJsSubpages = [
 			'common',
-			'wikia',
 			'monobook',
+			'wikia',
+			'uncyclopedia',
 		];
 
 		if ( $wgCityId == Wikia::COMMUNITY_WIKI_ID ) {

--- a/extensions/wikia/ProtectSiteJS/ProtectSiteJS.class.php
+++ b/extensions/wikia/ProtectSiteJS/ProtectSiteJS.class.php
@@ -1,0 +1,60 @@
+<?php
+
+class ProtectSiteJS {
+	public static function handler() {
+		global $wgTitle, $wgUser, $wgOut;
+
+		if ( empty( $wgTitle ) ) {
+			return true;
+		}
+
+		if ( strtoupper( substr( $wgTitle->getText(), -3 ) ) === '.JS' ) {
+			$groups = $wgUser->getEffectiveGroups();
+			if (
+				!in_array( 'staff', $groups )
+				&& !$wgUser->isAllowed( 'editinterfacetrusted' )
+				&& !self::isUserSkinJS( $wgTitle, $wgUser )
+			) {
+				$wgOut->addHTML( '<div class="errorbox" style="width:92%;">' );
+				$wgOut->addWikiMsg( 'actionthrottledtext' );
+				$wgOut->addHTML( '</div>' );
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check if the page is one of the approved personal JS pages
+	 * for the given user that are loaded by ResourceLoader.
+	 *
+	 * @param  Title   $title The title to check.
+	 * @param  User    $user  The user to check the page against.
+	 * @return boolean
+	 */
+	private static function isUserSkinJS( Title $title, User $user ) {
+		global $wgCityId;
+		$allowedJsSubpages = [
+			'common',
+			'wikia',
+			'monobook',
+		];
+
+		if ( $wgCityId == Wikia::COMMUNITY_WIKI_ID ) {
+			$allowedJsSubpages[] = 'global';
+		}
+
+		$allowedJsSubpages = implode( '|', $allowedJsSubpages );
+		$regex = '/^' . preg_quote( $user->getName(), '/' ) . '\/(' . $allowedJsSubpages . ')\.js$/';
+
+		if (
+			$title->isJsSubpage()
+			&& preg_match( $regex, $title->getText() )
+		) {
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/extensions/wikia/ProtectSiteJS/ProtectSiteJS_setup.php
+++ b/extensions/wikia/ProtectSiteJS/ProtectSiteJS_setup.php
@@ -1,23 +1,13 @@
 <?php
-// @author: Inez
+/**
+ * Set restrictions on editing JS pages.
+ *
+ * @author Inez
+ * @author grunny
+ */
 
-$wgHooks['AlternateEdit'][] = 'ProtectSiteJS_handler';
-$wgHooks['ArticleSave'][] = 'ProtectSiteJS_handler';
-$wgHooks['EditPage::attemptSave'][] = 'ProtectSiteJS_handler';
+$wgHooks['AlternateEdit'][] = 'ProtectSiteJS::handler';
+$wgHooks['ArticleSave'][] = 'ProtectSiteJS::handler';
+$wgHooks['EditPage::attemptSave'][] = 'ProtectSiteJS::handler';
 
-function ProtectSiteJS_handler() {
-	global $wgTitle, $wgUser, $wgOut;
-	if ( empty( $wgTitle ) ) {
-		return true;
-	}
-	if ( strtoupper( substr( $wgTitle->getText(), -3 ) ) === '.JS' ) {
-		$groups = $wgUser->getEffectiveGroups();
-		if ( !in_array( 'staff', $groups ) && !$wgUser->isAllowed( 'editinterfacetrusted' ) ) {
-			$wgOut->addHTML( '<div class="errorbox" style="width:92%;">' );
-			$wgOut->addWikiMsg( 'actionthrottledtext' );
-			$wgOut->addHTML( '</div>' );
-			return false;
-		}
-	}
-	return true;
-}
+$wgAutoloadClasses['ProtectSiteJS'] =  __DIR__ . '/ProtectSiteJS.class.php';

--- a/extensions/wikia/ProtectSiteJS/tests/ProtectSiteJSTest.php
+++ b/extensions/wikia/ProtectSiteJS/tests/ProtectSiteJSTest.php
@@ -1,0 +1,179 @@
+<?php
+
+class ProtectSiteJSTest extends WikiaBaseTest {
+	public function setUp() {
+		$this->setupFile = __DIR__ . '/../ProtectSiteJS_setup.php';
+		parent::setUp();
+	}
+
+	/**
+	 * @dataProvider handlerProvider
+	 */
+	public function testHandler( $testData, $expectedResult ) {
+		$outputMock = $this->getMock( 'OutputPage', [ 'addHTML', 'addWikiMsg' ] );
+		$this->mockGlobalVariable( 'wgOut', $outputMock );
+
+		$title = Title::makeTitle( $testData['namespace'], $testData['title'] );
+		$this->mockGlobalVariable( 'wgTitle', $title );
+
+		$this->mockGlobalVariable( 'wgCityId', $testData['wikiId'] );
+
+		$userMock = $this->getMock( 'User', [ 'getName', 'getEffectiveGroups', 'isAllowed' ] );
+
+		$userMock->expects( $this->any() )
+			->method( 'getName' )
+			->will( $this->returnValue( $testData['username'] ) );
+
+		$userMock->expects( $this->any() )
+			->method( 'isAllowed' )
+			->with( 'editinterfacetrusted' )
+			->will( $this->returnValue( $testData['editinterfacetrusted'] ) );
+
+		$userMock->expects( $this->once() )
+			->method( 'getEffectiveGroups' )
+			->will( $this->returnValue( $testData['groups'] ) );
+
+		$this->mockGlobalVariable( 'wgUser', $userMock );
+
+		$result = ProtectSiteJS::handler();
+
+		$this->assertSame( $result, $expectedResult );
+	}
+
+	public function handlerProvider() {
+		return [
+			[
+				[
+					'title' => 'Foo.js',
+					'namespace' => NS_MEDIAWIKI,
+					'username' => 'SomeUser',
+					'groups' => [ 'sysop' ],
+					'editinterfacetrusted' => false,
+					'wikiId' => 147,
+				],
+				false
+			],
+			[
+				[
+					'title' => 'Foo.js',
+					'namespace' => NS_USER,
+					'username' => 'SomeUser',
+					'groups' => [ 'sysop' ],
+					'editinterfacetrusted' => false,
+					'wikiId' => 147,
+				],
+				false
+			],
+			[
+				[
+					'title' => 'Foo.js',
+					'namespace' => NS_MAIN,
+					'username' => 'SomeUser',
+					'groups' => [ 'sysop' ],
+					'editinterfacetrusted' => false,
+					'wikiId' => 147,
+				],
+				false
+			],
+			[
+				[
+					'title' => 'Foo.js',
+					'namespace' => NS_MEDIAWIKI,
+					'username' => 'SomeUser',
+					'groups' => [ 'staff' ],
+					'editinterfacetrusted' => false,
+					'wikiId' => 147,
+				],
+				true
+			],
+			[
+				[
+					'title' => 'Foo.js',
+					'namespace' => NS_MEDIAWIKI,
+					'username' => 'SomeUser',
+					'groups' => [ 'sysop' ],
+					'editinterfacetrusted' => true,
+					'wikiId' => 147,
+				],
+				true
+			],
+			[
+				[
+					'title' => 'SomeUser/common.js',
+					'namespace' => NS_MEDIAWIKI,
+					'username' => 'SomeUser',
+					'groups' => [],
+					'editinterfacetrusted' => false,
+					'wikiId' => 147,
+				],
+				false
+			],
+			[
+				[
+					'title' => 'SomeUser/common.js',
+					'namespace' => NS_USER,
+					'username' => 'SomeUser',
+					'groups' => [],
+					'editinterfacetrusted' => false,
+					'wikiId' => 147,
+				],
+				true
+			],
+			[
+				[
+					'title' => 'SomeUser/wikia.js',
+					'namespace' => NS_USER,
+					'username' => 'SomeUser',
+					'groups' => [],
+					'editinterfacetrusted' => false,
+					'wikiId' => 147,
+				],
+				true
+			],
+			[
+				[
+					'title' => 'SomeUser/monobook.js',
+					'namespace' => NS_USER,
+					'username' => 'SomeUser',
+					'groups' => [],
+					'editinterfacetrusted' => false,
+					'wikiId' => 147,
+				],
+				true
+			],
+			[
+				[
+					'title' => 'SomeUser/global.js',
+					'namespace' => NS_USER,
+					'username' => 'SomeUser',
+					'groups' => [],
+					'editinterfacetrusted' => false,
+					'wikiId' => Wikia::COMMUNITY_WIKI_ID,
+				],
+				true
+			],
+			[
+				[
+					'title' => 'SomeUser/global.js',
+					'namespace' => NS_USER,
+					'username' => 'SomeUser',
+					'groups' => [],
+					'editinterfacetrusted' => false,
+					'wikiId' => 147,
+				],
+				false
+			],
+			[
+				[
+					'title' => 'SomeUser/foo.js',
+					'namespace' => NS_USER,
+					'username' => 'SomeUser',
+					'groups' => [],
+					'editinterfacetrusted' => false,
+					'wikiId' => 147,
+				],
+				false
+			],
+		];
+	}
+}

--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -63,6 +63,7 @@ $wgHooks['TitleGetLangVariants'][] = 'Wikia::onTitleGetLangVariants';
 $wgHooks['LocalFilePurgeThumbnailsUrls'][] = 'Wikia::onLocalFilePurgeThumbnailsUrls';
 
 $wgHooks['BeforePageDisplay'][] = 'Wikia::onBeforePageDisplay';
+$wgHooks['GetPreferences'][] = 'Wikia::onGetPreferences';
 
 /**
  * This class has only static methods so they can be used anywhere
@@ -1624,8 +1625,15 @@ class Wikia {
 
 		$wgUseSiteJs = $wgUseSiteJs && $request->getBool( 'usesitejs', $wgUseSiteJs ) !== false;
 		$wgUseSiteCss = $wgUseSiteCss && $request->getBool( 'usesitecss', $wgUseSiteCss ) !== false;
-		$wgAllowUserJs = $wgAllowUserJs && $request->getBool( 'useuserjs',
-			$request->getBool( 'allowuserjs', $wgAllowUserJs ) ) !== false;
+
+		// Don't enable user JS unless explicitly enabled by the user (CE-2509)
+		if ( !$user->getGlobalPreference( 'enableuserjs', false ) ) {
+			$wgAllowUserJs = false;
+		} else {
+			$wgAllowUserJs = $wgAllowUserJs && $request->getBool( 'useuserjs',
+				$request->getBool( 'allowuserjs', $wgAllowUserJs ) ) !== false;
+		}
+
 		$wgAllowUserCss = $wgAllowUserCss && $request->getBool( 'useusercss',
 			$request->getBool( 'allowusercss', $wgAllowUserCss ) ) !== false;
 		$wgBuckySampling = $request->getInt( 'buckysampling', $wgBuckySampling );
@@ -2333,6 +2341,22 @@ class Wikia {
 			);
 		}
 
+		return true;
+	}
+
+	/**
+	 * Add a preference for enabling personal JavaScript.
+	 *
+	 * @param  User    $user        The current user.
+	 * @param  array   $preferences The preferences array.
+	 * @return boolean
+	 */
+	public static function onGetPreferences( User $user, array &$preferences ) {
+		$preferences['enableuserjs'] = array(
+			'type' => 'toggle',
+			'label-message' => 'tog-enableuserjs',
+			'section' => 'under-the-hood/advanced-displayv2',
+		);
 		return true;
 	}
 }

--- a/languages/messages/wikia/MessagesDe.php
+++ b/languages/messages/wikia/MessagesDe.php
@@ -168,4 +168,6 @@ Auf dieser Spezialseite kannst Du die '''letzten Änderungen''' in diesem Wiki n
 ***w:c:de.community:Spezial:Forum|Community-Forum
 ***w:c:de|Mehr...
 ",
+
+	'tog-enableuserjs' => 'Personal JavaScript aktivieren ([[Help:Personal_CSS_and_JS#JavaScript|Erfahre mehr]])',
 ));

--- a/languages/messages/wikia/MessagesEn.php
+++ b/languages/messages/wikia/MessagesEn.php
@@ -1038,4 +1038,5 @@ hu',
 'shared-News_box' => '[http://www.wikia.com/Hiring Wikia is now hiring for several open positions]',
 
 'usesitejs-disabled-warning' => 'Custom JavaScript is disabled on this wikia.',
+'tog-enableuserjs' => 'Enable personal JavaScript ([[Help:User_style|Learn more]])',
 ));

--- a/languages/messages/wikia/MessagesEn.php
+++ b/languages/messages/wikia/MessagesEn.php
@@ -1038,5 +1038,5 @@ hu',
 'shared-News_box' => '[http://www.wikia.com/Hiring Wikia is now hiring for several open positions]',
 
 'usesitejs-disabled-warning' => 'Custom JavaScript is disabled on this wikia.',
-'tog-enableuserjs' => 'Enable personal JavaScript ([[Help:User_style|Learn more]])',
+'tog-enableuserjs' => 'Enable personal JavaScript ([[Help:Personal_CSS_and_JS#JavaScript|Learn more]])',
 ));

--- a/languages/messages/wikia/MessagesEs.php
+++ b/languages/messages/wikia/MessagesEs.php
@@ -137,4 +137,6 @@ $messages = array_merge( $messages, array(
 ***w:c:es.gorillaz|Gorillaz
 ***w:c:arte|Arte
 ",
+
+'tog-enableuserjs' => 'Habilitar JavaScript personal ([[Ayuda:Css_y_JS_personal#JavaScript|Aprenda más]])',
 ) );

--- a/languages/messages/wikia/MessagesFr.php
+++ b/languages/messages/wikia/MessagesFr.php
@@ -133,4 +133,6 @@ $messages = array_merge( $messages, array(
 ***w:c:routes|Routes de France
 ***w:c:fr.encyclopedie|Encyclopédie
 ",
+
+'tog-enableuserjs' => 'Activer le code javascript personnalisé ([[Help:Personal_CSS_and_JS#JavaScript|En savoir plus]])',
 ) );

--- a/languages/messages/wikia/MessagesIt.php
+++ b/languages/messages/wikia/MessagesIt.php
@@ -7,4 +7,6 @@ $messages = array_merge( $messages, array(
 'not_you' => "Non sei tu?",
 'copyrightpage' => 'w:Wikia:Licensing|Wikia:Licensing',
 'addnewtalksection-link' => 'Inizia una nuova sezione',
+
+'tog-enableuserjs' => 'Abilita il tuo JavaScript ([[Help:Personal_CSS_and_JS#JavaScript|Per saperne di più]])',
 ) );

--- a/languages/messages/wikia/MessagesJa.php
+++ b/languages/messages/wikia/MessagesJa.php
@@ -159,4 +159,6 @@ $messages = array_merge( $messages , array(
 'vertical-comics' => '漫画',
 'vertical-lifestyle' => 'ライフスタイル',
 'vertical-movies' => '映画',
+
+'tog-enableuserjs' => '個人用JavaScriptを有効にする（[[ヘルプ:個人用CSSとJavaScript#JavaScript|詳細]]）',
 ));

--- a/languages/messages/wikia/MessagesPl.php
+++ b/languages/messages/wikia/MessagesPl.php
@@ -256,4 +256,6 @@ Zmień [[Special:Preferences#prefsection-1|swoje preferencje]], aby używać wid
 ***w:c:pl.bionicle|Bionicle
 ***w:c:pl.vocaloid|Vocaloid
 ",
+
+'tog-enableuserjs' => 'Włącz osobisty kod JavaScript ([[Help:Personal_CSS_and_JS#JavaScript|Dowiedz się więcej]])',
 ) );

--- a/languages/messages/wikia/MessagesPt.php
+++ b/languages/messages/wikia/MessagesPt.php
@@ -37,4 +37,6 @@ $messages = array_merge( $messages, array(
 'review_reason_5' => 'Motivo revisão 5',
 'copyrightpage' => 'w:Wikia:Licensing|Wikia:Licensing',
 'addnewtalksection-link' => 'Iniciar uma nova secção',
+
+'tog-enableuserjs' => 'Autorizar JavaScript pessoal ([[Help:Personal_CSS_and_JS#JavaScript|Saiba mais]])',
 ) );

--- a/languages/messages/wikia/MessagesQqq.php
+++ b/languages/messages/wikia/MessagesQqq.php
@@ -20,5 +20,6 @@ $messages = array_merge( $messages, array(
 'vertical-movies' => 'Movies vertical name',
 
 'usesitejs-disabled-warning' => 'Warning message displayed on site JS pages when JavaScript customisations are disabled.',
+'tog-enableuserjs' => 'Label for the checkbox on Special:Preferences to enable personal JavaScript.',
 ) );
 

--- a/languages/messages/wikia/MessagesZh_hans.php
+++ b/languages/messages/wikia/MessagesZh_hans.php
@@ -3,5 +3,6 @@
 $messages = array_merge( $messages, array(
 'copyrightpage' => 'w:Wikia:Licensing|Wikia:Licensing',
 'addnewtalksection-link' => '开始一个新小节',
+'tog-enableuserjs' => '启用个人JavaScript ([[Help:Personal_CSS_and_JS#JavaScript|了解更多]])',
 ) );
 

--- a/languages/messages/wikia/MessagesZh_hant.php
+++ b/languages/messages/wikia/MessagesZh_hant.php
@@ -5,5 +5,6 @@ $fallback = 'zh-hans';
 $messages = array_merge( $messages, array(
 'copyrightpage' => 'w:Wikia:Licensing|Wikia:Licensing',
 'addnewtalksection-link' => '開始一個新小節',
+'tog-enableuserjs' => '啟用個人JavaScript ([[Help:Personal_CSS_and_JS#JavaScript|了解更多]])',
 ) );
 


### PR DESCRIPTION
Add a preference requiring users to explicitly opt-in to personal JS. Allow
users to edit their personal JS, but only the main skin JS files.

/cc @Wikia/community-engineering 
