### PR TITLE
SOC-1203 update (set|get)GlobalAttribute calls to (set|get)Global(Flag|Preference) calls

### DIFF
--- a/extensions/wikia/JSVariables/JSVariables.php
+++ b/extensions/wikia/JSVariables/JSVariables.php
@@ -53,7 +53,7 @@ function wfJSVariablesTopScripts(Array &$vars, &$scripts) {
 		/*
 		 * Remove when SOC-217 ABTest is finished
 		 */
-		$vars['wgNotConfirmedEmail'] = $user->getGlobalAttribute( UserLoginSpecialController::NOT_CONFIRMED_LOGIN_OPTION_NAME );
+		$vars['wgNotConfirmedEmail'] = $user->getGlobalPreference( UserLoginSpecialController::NOT_CONFIRMED_LOGIN_OPTION_NAME );
 		/*
 		 * End remove
 		 */

--- a/extensions/wikia/UserLogin/FacebookSignupController.class.php
+++ b/extensions/wikia/UserLogin/FacebookSignupController.class.php
@@ -138,7 +138,7 @@ class FacebookSignupController extends WikiaController {
 	 * @return boolean true if the account is unconfirmed, false otherwise
 	 */
 	private function isAccountUnconfirmed( User $user ) {
-		return $user->getGlobalAttribute( UserLoginSpecialController::NOT_CONFIRMED_SIGNUP_OPTION_NAME );
+		return $user->getGlobalFlag( UserLoginSpecialController::NOT_CONFIRMED_SIGNUP_OPTION_NAME );
 	}
 
 	/**

--- a/extensions/wikia/UserLogin/UserLoginForm.class.php
+++ b/extensions/wikia/UserLogin/UserLoginForm.class.php
@@ -262,7 +262,7 @@ class UserLoginForm extends LoginForm {
 			/*
 			 * Remove when SOC-217 ABTest is finished
 			 */
-			$u->setGlobalAttribute(
+			$u->setGlobalPreference(
 				UserLoginSpecialController::NOT_CONFIRMED_LOGIN_OPTION_NAME,
 				$isAllowRegisterUnconfirmed
 					? UserLoginSpecialController::NOT_CONFIRMED_LOGIN_ALLOWED

--- a/extensions/wikia/UserLogin/UserLoginSpecialController.class.php
+++ b/extensions/wikia/UserLogin/UserLoginSpecialController.class.php
@@ -427,7 +427,7 @@ class UserLoginSpecialController extends WikiaSpecialPageController {
 					/*
 					 * Remove when SOC-217 ABTest is finished
 					 */
-					$this->wg->User->getGlobalAttribute( self::NOT_CONFIRMED_LOGIN_OPTION_NAME ) !== self::NOT_CONFIRMED_LOGIN_ALLOWED
+					$this->wg->User->getGlobalPreference( self::NOT_CONFIRMED_LOGIN_OPTION_NAME ) !== self::NOT_CONFIRMED_LOGIN_ALLOWED
 					/*
 					 * end remove
 					 */

--- a/extensions/wikia/UserProfilePageV3/UserIdentityBox.class.php
+++ b/extensions/wikia/UserProfilePageV3/UserIdentityBox.class.php
@@ -210,7 +210,10 @@ class UserIdentityBox {
 
 		if (empty($memcData)) {
 			foreach (array('location', 'occupation', 'gender', 'birthday', 'website', 'twitter', 'fbPage', 'hideEditsWikis') as $key) {
-				if (!in_array($key, array('gender', 'birthday'))) {
+				if ( $key === 'hideEditsWikis' ) {
+					// hideEditsWikis is a preference, everything else is an attribute
+					$data[$key] = $this->user->getGlobalPreference($key);
+				} elseif (!in_array($key, array('gender', 'birthday'))) {
 					$data[$key] = $this->user->getGlobalAttribute($key);
 				} else {
 					$data[$key] = $this->user->getGlobalAttribute(self::USER_PROPERTIES_PREFIX . $key);
@@ -314,7 +317,10 @@ class UserIdentityBox {
 						}
 					}
 
-					if ($option === 'gender') {
+					if ($option === 'hideEditsWikis') {
+						// hideEditsWikis is a preference, everything else is an attribute
+						$this->user->setGlobalPreference($option, $data->$option);
+					} elseif ($option === 'gender') {
 						$this->user->setGlobalAttribute(self::USER_PROPERTIES_PREFIX . $option, $data->$option);
 					} else {
 						$this->user->setGlobalAttribute($option, $data->$option);

--- a/extensions/wikia/UserProfilePageV3/UserIdentityBox.class.php
+++ b/extensions/wikia/UserProfilePageV3/UserIdentityBox.class.php
@@ -213,10 +213,10 @@ class UserIdentityBox {
 				if ( $key === 'hideEditsWikis' ) {
 					// hideEditsWikis is a preference, everything else is an attribute
 					$data[$key] = $this->user->getGlobalPreference($key);
-				} elseif (!in_array($key, array('gender', 'birthday'))) {
-					$data[$key] = $this->user->getGlobalAttribute($key);
-				} else {
+				} elseif ( $key === 'gender' || $key === 'birthday' ) {
 					$data[$key] = $this->user->getGlobalAttribute(self::USER_PROPERTIES_PREFIX . $key);
+				} else {
+					$data[$key] = $this->user->getGlobalAttribute($key);
 				}
 			}
 		} else {

--- a/includes/User.php
+++ b/includes/User.php
@@ -2664,19 +2664,6 @@ class User {
 	}
 
 	/**
-	 * Get a user attribute local to this wikia.
-	 *
-	 * @param string $attr the attribute name
-	 * @param int $cityId the city id
-	 * @param string $sep the separator between the name and the city id
-	 * @return string
-	 * @see getGlobalAttribute for more documentation about attributes
-	 */
-	public function getLocalAttribute($attr, $cityId = null, $sep = "-") {
-		return $this->getGlobalAttribute(self::localToGlobalPropertyName($attr, $cityId, $sep));
-	}
-
-	/**
 	 * Get a global user attribute.
 	 *
 	 * Attributes are facts about the user such as their avatar URL, their
@@ -2712,23 +2699,6 @@ class User {
 				'default' => $default,
 				'userId' => $this->getId()
 			] );
-	}
-
-	/**
-	 * Set an attribute local to a wikia. See createLocalOptionName for details regarding
-	 * the format. Note that the $sep param is provided in the rare case where
-	 * the option name is not normal. Should you have to use the separator, PLEASE MAKE
-	 * A PLAN TO NORMALIZE IT TO "-".
-	 *
-	 * @param string $attribute
-	 * @param string $value
-	 * @param int $cityId
-	 * @param string $sep
-	 * @return bool
-	 * @see getGlobalAttribute for more documentation about attributes
-	 */
-	public function setLocalAttribute($attribute, $value, $cityId = null, $sep = '-') {
-		$this->setGlobalAttribute(self::localToGlobalPropertyName($attribute, $cityId, $sep), $value);
 	}
 
 	/**

--- a/includes/wikia/models/WikiaUserPropertiesHandlerBase.class.php
+++ b/includes/wikia/models/WikiaUserPropertiesHandlerBase.class.php
@@ -7,12 +7,12 @@ class WikiaUserPropertiesHandlerBase extends WikiaModel {
 	protected function savePropertyValue($property, $value) {
 		$this->throwExceptionForAnons();
 
-		$this->wg->User->setGlobalAttribute($property, $value);
+		$this->wg->User->setGlobalPreference($property, $value);
 		$this->wg->User->saveSettings();
 	}
 
 	protected function getPropertyValue($propertyName, $defaultOption = null) {
-		$value = $this->wg->User->getGlobalAttribute($propertyName);
+		$value = $this->wg->User->getGlobalPreference($propertyName);
 		if (!$value) {
 			$value = $defaultOption;
 		}

--- a/includes/wikia/models/WikiaUserPropertiesHandlerBase.class.php
+++ b/includes/wikia/models/WikiaUserPropertiesHandlerBase.class.php
@@ -4,14 +4,14 @@ class WikiaUserPropertiesHandlerBase extends WikiaModel {
 	const EXCEPTION_USER_NOT_LOGGED_IN_CODE = 1;
 	const EXCEPTION_INVALID_PROPERTY_NAME = 2;
 
-	protected function savePreferenceValue($property, $value) {
+	protected function savePropertyValue($property, $value) {
 		$this->throwExceptionForAnons();
 
 		$this->wg->User->setGlobalPreference($property, $value);
 		$this->wg->User->saveSettings();
 	}
 
-	protected function getPreferenceValue($propertyName, $defaultOption = null) {
+	protected function getPropertyValue($propertyName, $defaultOption = null) {
 		$value = $this->wg->User->getGlobalPreference($propertyName);
 		if (!$value) {
 			$value = $defaultOption;

--- a/includes/wikia/models/WikiaUserPropertiesHandlerBase.class.php
+++ b/includes/wikia/models/WikiaUserPropertiesHandlerBase.class.php
@@ -4,14 +4,14 @@ class WikiaUserPropertiesHandlerBase extends WikiaModel {
 	const EXCEPTION_USER_NOT_LOGGED_IN_CODE = 1;
 	const EXCEPTION_INVALID_PROPERTY_NAME = 2;
 
-	protected function savePropertyValue($property, $value) {
+	protected function savePreferenceValue($property, $value) {
 		$this->throwExceptionForAnons();
 
 		$this->wg->User->setGlobalPreference($property, $value);
 		$this->wg->User->saveSettings();
 	}
 
-	protected function getPropertyValue($propertyName, $defaultOption = null) {
+	protected function getPreferenceValue($propertyName, $defaultOption = null) {
 		$value = $this->wg->User->getGlobalPreference($propertyName);
 		if (!$value) {
 			$value = $defaultOption;


### PR DESCRIPTION
Following the audit of which attributes we want to store in the attribute service, we came up with [a list](https://wikia-inc.atlassian.net/secure/attachment/66632/suggested_attributes.txt) for the time being. These attributes have been added to a `$wgPublicUserAttributes` array in the config which we'll use to filter which attributes we set in the service.

As part of this audit, I also went through and checked all `(set|get)Attribute` calls in MW. The changes below reflect `(set|get)Attribute` which should be actually be `(set|get)Flag` or `(set|get)Preference` calls. I also removed a couple unused methods.

Ticket: https://wikia-inc.atlassian.net/browse/SOC-1203
