### PR TITLE
LocalFile: log failed Revision::newNullRevision()

### DIFF
--- a/includes/filerepo/file/LocalFile.php
+++ b/includes/filerepo/file/LocalFile.php
@@ -1129,6 +1129,13 @@ class LocalFile extends File {
 				wfRunHooks( 'NewRevisionFromEditComplete', array( $wikiPage, $nullRevision, $latest, $user ) );
 				$wikiPage->updateRevisionOn( $dbw, $nullRevision );
 			}
+			else {
+				\Wikia\Logger\WikiaLogger::instance()->warning('PLATFORM-1311', [
+					'reason' => 'LocalFile no nullRevision',
+					'page_id' => $descTitle->getArticleId(),
+					'exception' => new Exception()
+				]);
+			}
 			# Invalidate the cache for the description page
 			$descTitle->invalidateCache();
 			$descTitle->purgeSquid();


### PR DESCRIPTION
The [PLATFORM-1311 saga](https://wikia-inc.atlassian.net/browse/PLATFORM-1311) continues as the latest logs show that `NS_FILE` pages are the most affected ones. Add more logging in `LocalFile`

@michalroszka 
