### PR TITLE
Add missing rollback to LocalFile::recordUpload2

### DIFF
--- a/includes/filerepo/file/LocalFile.php
+++ b/includes/filerepo/file/LocalFile.php
@@ -1009,6 +1009,7 @@ class LocalFile extends File {
 		# Fail now if the file isn't there
 		if ( !$this->fileExists ) {
 			wfDebug( __METHOD__ . ": File " . $this->getRel() . " went missing!\n" );
+			$dbw->rollback( __METHOD__ );
 
 			return false;
 		}

--- a/includes/filerepo/file/LocalFile.php
+++ b/includes/filerepo/file/LocalFile.php
@@ -1009,6 +1009,7 @@ class LocalFile extends File {
 		# Fail now if the file isn't there
 		if ( !$this->fileExists ) {
 			wfDebug( __METHOD__ . ": File " . $this->getRel() . " went missing!\n" );
+
 			return false;
 		}
 


### PR DESCRIPTION
When begin was called, all returns should have rollback called to close the transaction.

Backporting https://github.com/wikimedia/mediawiki/commit/d5d37cd034634156c494e7f3dd565895b98205ca from MW 1.24.0

@michalroszka 
