### PR TITLE
LocalFile: do not call $dbw->begin when we are in the middle of transaction

### DIFF
--- a/includes/WikiPage.php
+++ b/includes/WikiPage.php
@@ -910,7 +910,7 @@ class WikiPage extends Page {
 		if ( $wgUseSquid ) {
 			// Commit the transaction before the purge is sent
 			$dbw = wfGetDB( DB_MASTER );
-			$dbw->commit();
+			$dbw->commit( __METHOD__ );
 
 			// Send purge
 			$update = SquidUpdate::newSimplePurge( $this->mTitle );

--- a/includes/filerepo/file/LocalFile.php
+++ b/includes/filerepo/file/LocalFile.php
@@ -989,6 +989,7 @@ class LocalFile extends File {
 			$user = $wgUser;
 		}
 
+		/* @var DatabaseBase $dbw */
 		$dbw = $this->repo->getMasterDB();
 		$dbw->begin();
 

--- a/includes/filerepo/file/LocalFile.php
+++ b/includes/filerepo/file/LocalFile.php
@@ -1097,14 +1097,14 @@ class LocalFile extends File {
 		} else {
 			# This is a new file
 			# Update the image count
-			$dbw->begin( __METHOD__ );
+			#$dbw->begin( __METHOD__ ); // macbre: see PLATFORM-1311 (Beginning a transaction causes any pending transaction to be committed)
 			$dbw->update(
 				'site_stats',
 				array( 'ss_images = ss_images+1' ),
 				'*',
 				__METHOD__
 			);
-			$dbw->commit( __METHOD__ );
+			#$dbw->commit( __METHOD__ ); // macbre: see PLATFORM-1311
 		}
 
 		$descTitle = $this->getTitle();


### PR DESCRIPTION
> Beginning a transaction causes any pending transaction to be committed

Inspired by https://github.com/wikimedia/mediawiki/commit/b9ac85cbf304a65d900cda00fafe53bf82d7a227

And log commits from `WikiPage::doPurge` method

@michalroszka 
