### PR TITLE
DAT-3105 Fix saving invalid titles to imagelinks table in PortableInfoboxes

### DIFF
--- a/extensions/wikia/PortableInfobox/services/Parser/Nodes/NodeImage.php
+++ b/extensions/wikia/PortableInfobox/services/Parser/Nodes/NodeImage.php
@@ -20,7 +20,9 @@ class NodeImage extends Node {
 
 			$title = $this->getImageAsTitleObject( $imageData );
 			$file = $this->getFilefromTitle( $title );
-			$this->getExternalParser()->addImage( $title ? $title->getDBkey() : $imageData );
+			if ( $title instanceof \Title ) {
+				$this->getExternalParser()->addImage( $title->getDBkey() );
+			}
 			$ref = null;
 			$alt = $this->getValueWithDefault( $this->xmlNode->{self::ALT_TAG_NAME} );
 			$caption = $this->getValueWithDefault( $this->xmlNode->{self::CAPTION_TAG_NAME} );
@@ -66,9 +68,9 @@ class NodeImage extends Node {
 
 	private function getImageAsTitleObject( $imageName ) {
 		global $wgContLang;
-		$title = \Title::newFromText(
-			ImageFilenameSanitizer::getInstance()->sanitizeImageFileName( $imageName, $wgContLang ),
-			NS_FILE
+		$title = \Title::makeTitleSafe(
+			NS_FILE,
+			ImageFilenameSanitizer::getInstance()->sanitizeImageFileName( $imageName, $wgContLang )
 		);
 
 		return $title;


### PR DESCRIPTION
- Use Title::makeTitleSafe instead of Title::newFromTitle
- Add image only if title is valid
