### PR TITLE
Add an assert in WikiPage::updateRevisionOn() that page_latest is not a zero

### DIFF
--- a/includes/WikiPage.php
+++ b/includes/WikiPage.php
@@ -997,6 +997,22 @@ class WikiPage extends Page {
 			$conditions['page_latest'] = $lastRevision;
 		}
 
+		// Wikia change - begin
+		/**
+		 * PLATFORM-1311: page_latest can be set to zero only during page creation
+		 *
+		 * https://www.mediawiki.org/wiki/Manual:Page_table#page_latest says the following:
+		 *
+		 * WikiPage::updateRevisionOn() should set it to a non-zero value.
+		 * It needs to link to a revision with a valid revision.rev_page.
+		 */
+		Wikia\Util\Assert::true( $revision->getId() > 0 , 'PLATFORM-1311', [
+			'reason' => __METHOD__ . ' tried to set page_latest to zero',
+			'page_id' => $this->getId(),
+			'name' => $this->getTitle()->getPrefixedDBkey(),
+		] );
+		// Wikia change - end
+
 		$now = wfTimestampNow();
 		$dbw->update( 'page',
 			array( /* SET */

--- a/lib/Wikia/src/Util/Assert.php
+++ b/lib/Wikia/src/Util/Assert.php
@@ -16,15 +16,17 @@ class Assert {
 	/**
 	 * @param mixed $check
 	 * @param string|null $message
+	 * @param array $context additional fields to be pushed to logstash as context
 	 * @return bool true if the check passes
 	 * @throws AssertionException if the check fails
 	 */
-	public static function true( $check, $message = 'Assert::true failed' ) {
+	public static function true( $check, $message = 'Assert::true failed', Array $context = [] ) {
 		if ( !$check ) {
 			$exception = new AssertionException( $message );
-			WikiaLogger::instance()->error( $message, [
+			$context = array_merge($context, [
 				'exception' => $exception,
 			] );
+			WikiaLogger::instance()->error( $message, $context );
 			throw $exception;
 		}
 


### PR DESCRIPTION
https://www.mediawiki.org/wiki/Manual:Page_table#page_latest says the following:

> `WikiPage::updateRevisionOn()` should set `page_latest` to a non-zero value.
> It needs to link to a revision with a valid `revision.rev_page`

@michalroszka 
