### PR TITLE
changing the auth header name to X-Wikia-AccessToken

### DIFF
--- a/extensions/wikia/Helios/User.class.php
+++ b/extensions/wikia/Helios/User.class.php
@@ -14,6 +14,7 @@ use Wikia\Service\Helios\HeliosClient;
 class User {
 
 	const ACCESS_TOKEN_COOKIE_NAME = 'access_token';
+	const ACCESS_TOKEN_HEADER_NAME = 'X-Wikia-AccessToken';
 	const AUTH_METHOD_NAME = 'auth_method';
 	const MERCURY_ACCESS_TOKEN_COOKIE_NAME = 'sid';
 	const AUTH_TYPE_FAILED = 0;
@@ -57,14 +58,7 @@ class User {
 
 		// No access token in the cookie, try the HTTP header.
 		if ( ! $token ) {
-			$header = $request->getHeader( 'AUTHORIZATION' );
-
-			$matches = [];
-			preg_match( '/^Bearer\s*(\S*)$/', $header, $matches );
-
-			if ( ! empty( $matches[1] ) ) {
-				$token = $matches[1];
-			}
+			$token = $request->getHeader( self::ACCESS_TOKEN_HEADER_NAME );
 		}
 
 		// Normalize the value so the method returns a non-empty string or null.

--- a/extensions/wikia/Helios/tests/UserTest.php
+++ b/extensions/wikia/Helios/tests/UserTest.php
@@ -56,8 +56,8 @@ class UserTest extends \WikiaBaseTest {
 
 		$this->webRequestMock->expects( $this->once() )
 			->method( 'getHeader' )
-			->with( 'AUTHORIZATION' )
-			->willReturn( "Bearer $token" );
+			->with( User::ACCESS_TOKEN_HEADER_NAME )
+			->willReturn( $token );
 
 		$this->assertEquals( User::getAccessToken( $this->webRequestMock ), $token );
 	}
@@ -66,7 +66,7 @@ class UserTest extends \WikiaBaseTest {
 		// No HTTP header
 		$this->webRequestMock->expects( $this->any() )
 			->method( 'getHeader' )
-			->with( 'AUTHORIZATION' )
+			->with( User::ACCESS_TOKEN_HEADER_NAME )
 			->willReturn( '' );
 
 		// Cookie with no value
@@ -98,29 +98,22 @@ class UserTest extends \WikiaBaseTest {
 		// Header with no value
 		$this->webRequestMock->expects( $this->any() )
 			->method( 'getHeader' )
-			->with( 'AUTHORIZATION' )
+			->with( User::ACCESS_TOKEN_HEADER_NAME )
 			->willReturn( '' );
 
 		$this->assertNull( User::getAccessToken( $this->webRequestMock ) );
 
 		$this->webRequestMock->expects( $this->any() )
 			->method( 'getHeader' )
-			->with( 'AUTHORIZATION' )
+			->with( User::ACCESS_TOKEN_HEADER_NAME )
 			->willReturn( false );
 
 		$this->assertNull( User::getAccessToken( $this->webRequestMock ) );
 
 		$this->webRequestMock->expects( $this->any() )
 			->method( 'getHeader' )
-			->with( 'AUTHORIZATION' )
+			->with( User::ACCESS_TOKEN_HEADER_NAME )
 			->willReturn( null );
-
-		$this->assertNull( User::getAccessToken( $this->webRequestMock ) );
-
-		$this->webRequestMock->expects( $this->any() )
-			->method( 'getHeader' )
-			->with( 'AUTHORIZATION' )
-			->willReturn( 'Bearer ' );
 
 		$this->assertNull( User::getAccessToken( $this->webRequestMock ) );
 	}
@@ -136,8 +129,8 @@ class UserTest extends \WikiaBaseTest {
 
 		$this->webRequestMock->expects( $this->any() )
 			->method( 'getHeader' )
-			->with( 'AUTHORIZATION' )
-			->willReturn( "Bearer $tokenInHeader" );
+			->with( User::ACCESS_TOKEN_HEADER_NAME )
+			->willReturn( $tokenInHeader );
 
 		$this->assertEquals( User::getAccessToken( $this->webRequestMock ), $tokenInCookie );
 	}
@@ -149,7 +142,7 @@ class UserTest extends \WikiaBaseTest {
 
 		$this->webRequestMock->expects( $this->once() )
 			->method( 'getHeader' )
-			->with( 'AUTHORIZATION' )
+			->with( User::ACCESS_TOKEN_HEADER_NAME )
 			->willReturn( false );
 
 		$this->assertNull( User::getAccessToken( $this->webRequestMock ) );
@@ -162,8 +155,8 @@ class UserTest extends \WikiaBaseTest {
 
 		$this->webRequestMock->expects( $this->once() )
 			->method( 'getHeader' )
-			->with( 'AUTHORIZATION' )
-			->willReturn( 'Malformed' );
+			->with( User::ACCESS_TOKEN_HEADER_NAME )
+			->willReturn( false );
 
 		$this->assertNull( User::getAccessToken( $this->webRequestMock ) );
 	}


### PR DESCRIPTION
@Wikia/services-team @ludwikkazmierczak @justnpT 

updating the auth header in MediaWiki from the oauth `AUTHORIZATION` header to `X-Wikia-AccessToken`, to be consistent with what's expected in the API gateway.

From what I understand, social and mobile do not use the `AUTHORIZATION` header, so there are no updates or backwards compatibility needed there, but the Selenium tests need to be updated with the new header.
