### PR TITLE
WikiPage: log revision and page id when page.page_latest update fails

### DIFF
--- a/includes/WikiPage.php
+++ b/includes/WikiPage.php
@@ -1376,6 +1376,8 @@ class WikiPage extends Page {
 						'reason' => 'ArticleDoEdit rollback - updateRevisionOn failed',
 						'exception' => new Exception(),
 						'name' => $this->mTitle->getPrefixedDBkey(),
+						'rev_id' => $revisionId,
+						'page_id' => $this->getId(),
 					]);
 
 					$revisionId = 0;


### PR DESCRIPTION
This will allow us to verify that the transaction is rolled back on failure.

@michalroszka 
