### PR TITLE
CE-2603 Lazy load the right rail module to always get the freshest info

### DIFF
--- a/extensions/wikia/ContentReview/ContentReview.hooks.php
+++ b/extensions/wikia/ContentReview/ContentReview.hooks.php
@@ -20,7 +20,7 @@ class Hooks {
 				true
 			)->getData();
 
-			$railModuleList[1503] = [ 'ContentReviewModule', 'Render', [
+			$railModuleList[1403] = [ 'ContentReviewModule', 'Render', [
 				'pageStatus' => $pageStatus,
 				'latestRevisionId' => $wgTitle->getLatestRevID(),
 			] ];


### PR DESCRIPTION
Since the lazy loaded modules are not cached - making our a lazy loaded one makes more sense. All it took was giving it an index lower than `const LAZY_LOADING_BEAKPOINT = 1440;`.
