### PR TITLE
ADEN-2298 New wiki vertical and wiki cats in page params

### DIFF
--- a/extensions/wikia/AdEngine/AdEngine2ContextService.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2ContextService.class.php
@@ -41,7 +41,7 @@ class AdEngine2ContextService {
 			$oldWikiVertical = $hubService->getCategoryInfoForCity( $wg->CityId )->cat_name;
 
 			// 1 of 7 verticals
-			$newWikiVertical = $wikiFactoryHub->getWikiVertical( $wg-CityId );
+			$newWikiVertical = $wikiFactoryHub->getWikiVertical( $wg->CityId );
 			$newWikiVertical = !empty($newWikiVertical['short']) ? $newWikiVertical['short'] : 'error';
 
 			$newWikiCategories = $wikiFactoryHub->getWikiCategories( $wg->CityId );

--- a/extensions/wikia/AdEngine/AdEngine2ContextService.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2ContextService.class.php
@@ -43,6 +43,8 @@ class AdEngine2ContextService {
 			// 1 of 7 verticals
 			$newWikiVertical = $wikiFactoryHub->getWikiVertical( $wg-CityId );
 			$newWikiVertical = !empty($newWikiVertical['short']) ? $newWikiVertical['short'] : 'error';
+
+			$newWikiCategories = $wikiFactoryHub->getWikiCategories( $wg->CityId );
 			return [
 				'opts' => $this->filterOutEmptyItems( [
 					'adsInContent' => $wg->EnableAdsInContent,
@@ -75,6 +77,7 @@ class AdEngine2ContextService {
 					'wikiIsTop1000' => $wg->AdDriverWikiIsTop1000,
 					'wikiLanguage' => $langCode,
 					'wikiVertical' => $newWikiVertical,
+					'newWikiCategories' => $this->stringifyCategories($newWikiCategories),
 				] ),
 				'providers' => $this->filterOutEmptyItems( [
 					'monetizationService' => $wg->AdDriverUseMonetizationService,
@@ -115,6 +118,17 @@ class AdEngine2ContextService {
 		}
 
 		return 'error';
+	}
+
+	private function stringifyCategories( $categories ) {
+		$out = '';
+
+		foreach($categories as $cat) {
+			$out .= $cat['cat_short'] . ',';
+		}
+		$out = rtrim($out, ',');
+
+		return $out;
 	}
 
 	private function filterOutEmptyItems( $input ) {

--- a/extensions/wikia/AdEngine/AdEngine2ContextService.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2ContextService.class.php
@@ -132,7 +132,7 @@ class AdEngine2ContextService {
 			$wikiCategories = [];
 		}
 
-		return $wikiCategories;
+		return array_unique($wikiCategories);
 	}
 
 	private function filterOutEmptyItems( $input ) {

--- a/extensions/wikia/AdEngine/AdEngine2ContextService.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2ContextService.class.php
@@ -36,7 +36,13 @@ class AdEngine2ContextService {
 			}
 
 			$langCode = $title->getPageLanguage()->getCode();
-			$wikiVertical = $hubService->getCategoryInfoForCity( $wg->CityId )->cat_name;
+
+			// 1 of 3 verticals
+			$oldWikiVertical = $hubService->getCategoryInfoForCity( $wg->CityId )->cat_name;
+
+			// 1 of 7 verticals
+			$newWikiVertical = $wikiFactoryHub->getWikiVertical( $wg-CityId );
+			$newWikiVertical = !empty($newWikiVertical['short']) ? $newWikiVertical['short'] : 'error';
 			return [
 				'opts' => $this->filterOutEmptyItems( [
 					'adsInContent' => $wg->EnableAdsInContent,
@@ -53,7 +59,7 @@ class AdEngine2ContextService {
 				'targeting' => $this->filterOutEmptyItems( [
 					'enableKruxTargeting' => $wg->EnableKruxTargeting,
 					'enablePageCategories' => array_search( $langCode, $wg->AdPageLevelCategoryLangs ) !== false,
-					'mappedVerticalName' => $this->getMappedVerticalName( $wg->CityId, $wikiVertical ), //wikiCategory replacement for AdLogicPageParams.js::getPageLevelParams
+					'mappedVerticalName' => $this->getMappedVerticalName( $oldWikiVertical, $newWikiVertical ), //wikiCategory replacement for AdLogicPageParams.js::getPageLevelParams
 					'pageArticleId' => $title->getArticleId(),
 					'pageIsArticle' => !!$title->getArticleId(),
 					'pageIsHub' => $wikiaPageType->isWikiaHub(),
@@ -68,7 +74,7 @@ class AdEngine2ContextService {
 					'wikiIsCorporate' => $wikiaPageType->isCorporatePage(),
 					'wikiIsTop1000' => $wg->AdDriverWikiIsTop1000,
 					'wikiLanguage' => $langCode,
-					'wikiVertical' => $wikiVertical,
+					'wikiVertical' => $newWikiVertical,
 				] ),
 				'providers' => $this->filterOutEmptyItems( [
 					'monetizationService' => $wg->AdDriverUseMonetizationService,
@@ -87,27 +93,27 @@ class AdEngine2ContextService {
 		} );
 	}
 
-	private function getMappedVerticalName( $cityId, $wikiVertical ) {
-		if ($wikiVertical === 'Wikia') {
+	private function getMappedVerticalName( $oldWikiVertical, $newWikiVertical ) {
+		if ($oldWikiVertical === 'Wikia') {
 			return 'wikia';
 		}
-		$wikiVertical = WikiFactoryHub::getInstance()->getWikiVertical( $cityId );
-		if ( !empty( $wikiVertical['short'] ) ) {
-			$mapping = [
-				'other' => 'life',
-				'tv' => 'ent',
-				'games' => 'gaming',
-				'books' => 'ent',
-				'comics' => 'ent',
-				'lifestyle' => 'life',
-				'music' => 'ent',
-				'movies' => 'ent'
-			];
-			$newVerticalName = strtolower( $wikiVertical['short'] );
-			if ( !empty( $mapping[$newVerticalName] ) ) {
-				return $mapping[$newVerticalName];
-			}
+
+		$mapping = [
+			'other' => 'life',
+			'tv' => 'ent',
+			'games' => 'gaming',
+			'books' => 'ent',
+			'comics' => 'ent',
+			'lifestyle' => 'life',
+			'music' => 'ent',
+			'movies' => 'ent'
+		];
+
+		$newVerticalName = strtolower( $newWikiVertical );
+		if ( !empty( $mapping[$newVerticalName] ) ) {
+			return $mapping[$newVerticalName];
 		}
+
 		return 'error';
 	}
 

--- a/extensions/wikia/AdEngine/AdEngine2ContextService.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2ContextService.class.php
@@ -43,8 +43,6 @@ class AdEngine2ContextService {
 			// 1 of 7 verticals
 			$newWikiVertical = $wikiFactoryHub->getWikiVertical( $wg->CityId );
 			$newWikiVertical = !empty($newWikiVertical['short']) ? $newWikiVertical['short'] : 'error';
-
-			$newWikiCategories = $wikiFactoryHub->getWikiCategories( $wg->CityId );
 			return [
 				'opts' => $this->filterOutEmptyItems( [
 					'adsInContent' => $wg->EnableAdsInContent,
@@ -77,7 +75,7 @@ class AdEngine2ContextService {
 					'wikiIsTop1000' => $wg->AdDriverWikiIsTop1000,
 					'wikiLanguage' => $langCode,
 					'wikiVertical' => $newWikiVertical,
-					'newWikiCategories' => $this->stringifyCategories($newWikiCategories),
+					'newWikiCategories' => $this->getNewWikiCategories($wikiFactoryHub, $wg->CityId),
 				] ),
 				'providers' => $this->filterOutEmptyItems( [
 					'monetizationService' => $wg->AdDriverUseMonetizationService,
@@ -120,15 +118,21 @@ class AdEngine2ContextService {
 		return 'error';
 	}
 
-	private function stringifyCategories( $categories ) {
-		$out = '';
+	private function getNewWikiCategories(WikiFactoryHub $wikiFactoryHub, $cityId) {
+		$oldWikiCategories = $wikiFactoryHub->getWikiCategoryNames( $cityId, false );
+		$newWikiCategories = $wikiFactoryHub->getWikiCategoryNames( $cityId, true );
 
-		foreach($categories as $cat) {
-			$out .= $cat['cat_short'] . ',';
+		if( is_array($oldWikiCategories) && is_array($newWikiCategories) ) {
+			$wikiCategories = array_merge($oldWikiCategories, $newWikiCategories);
+		} else if ( is_array($oldWikiCategories) ) {
+			$wikiCategories = $oldWikiCategories;
+		} else if ( is_array($newWikiCategories) ) {
+			$wikiCategories = $newWikiCategories;
+		} else {
+			$wikiCategories = [];
 		}
-		$out = rtrim($out, ',');
 
-		return $out;
+		return $wikiCategories;
 	}
 
 	private function filterOutEmptyItems( $input ) {

--- a/extensions/wikia/AdEngine/js/AdLogicPageParams.js
+++ b/extensions/wikia/AdEngine/js/AdLogicPageParams.js
@@ -238,6 +238,8 @@ define('ext.wikia.adEngine.adLogicPageParams', [
 
 		params = {
 			s0: site,
+			s0v: targeting.wikiVertical,
+			s0c: targeting.newWikiCategories,
 			s1: zone1,
 			s2: zone2,
 			ab: getAb(),

--- a/extensions/wikia/AdEngine/js/SevenOneMediaHelper.js
+++ b/extensions/wikia/AdEngine/js/SevenOneMediaHelper.js
@@ -265,14 +265,14 @@ define('ext.wikia.adEngine.sevenOneMediaHelper', [
 	function initialize(firstSlotname) {
 		var subsite, sub2site, sub3site, targeting = adContext.getContext().targeting;
 
-		subsite = targeting.wikiVertical && targeting.wikiVertical.toLowerCase();
+		subsite = targeting.mappedVerticalName;
 
 		if (targeting.sevenOneMediaSub2Site) {
 			sub2site = targeting.sevenOneMediaSub2Site;
 			sub3site = pageLevelParams.s1.replace('_', '');
 		} else {
 			sub2site = pageLevelParams.s1.replace('_', '');
-			sub3site = subsite === 'lifestyle' ? targeting.mappedVerticalName : '';
+			sub3site = subsite === 'life' ? targeting.wikiCategory : '';
 		}
 
 		initialized = true;

--- a/extensions/wikia/AdEngine/tests/AdEngine2ContextServiceTest.php
+++ b/extensions/wikia/AdEngine/tests/AdEngine2ContextServiceTest.php
@@ -47,7 +47,7 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 			'titleMockType' => 'article',
 			'flags' => [],
 			'expectedOpts' => [],
-			'expectedTargeting' => [ 'newWikiCategories' => [ 'test', 'test' ] ],
+			'expectedTargeting' => [ 'newWikiCategories' => [ 'test' ] ],
 			'expectedProviders' => [],
 			'expectedForceProviders' => null,
 			'expectedSlots' => [],
@@ -65,7 +65,7 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 				'titleMockType' => 'article',
 				'flags' => ['wgAdDriverEnableInvisibleHighImpactSlot'],
 				'expectedOpts' => [],
-				'expectedTargeting' => [ 'newWikiCategories' => [ 'test', 'test' ] ],
+				'expectedTargeting' => [ 'newWikiCategories' => [ 'test' ] ],
 				'expectedProviders' => [],
 				'expectedForceProviders' => null,
 				'expectedSlots' => ['invisibleHighImpact' => true]
@@ -74,7 +74,7 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 				'titleMockType' => 'article',
 				'flags' => ['wgAdDriverForceTurtleAd'],
 				'expectedOpts' => [],
-				'expectedTargeting' => [ 'newWikiCategories' => [ 'test', 'test' ] ],
+				'expectedTargeting' => [ 'newWikiCategories' => [ 'test' ] ],
 				'expectedProviders' => [],
 				'expectedForcedProvider' => 'turtle'
 			],
@@ -82,27 +82,27 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 				'titleMockType' => 'article',
 				'flags' => ['wgAdDriverTrackState'],
 				'expectedOpts' => ['trackSlotState' => true],
-				'expectedTargeting' => [ 'newWikiCategories' => [ 'test', 'test' ] ]
+				'expectedTargeting' => [ 'newWikiCategories' => [ 'test' ] ]
 			],
 			[
 				'titleMockType' => 'article',
 				'flags' => ['wgAdDriverUseMonetizationService', 'wgEnableMonetizationModuleExt'],
 				'expectedOpts' => [],
-				'expectedTargeting' => [ 'newWikiCategories' => [ 'test', 'test' ] ],
+				'expectedTargeting' => [ 'newWikiCategories' => [ 'test' ] ],
 				'expectedProviders' => ['monetizationService' => true]
 			],
 			[
 				'titleMockType' => 'article',
 				'flags' => ['wgAdDriverUseSevenOneMedia'],
 				'expectedOpts' => [],
-				'expectedTargeting' => [ 'newWikiCategories' => [ 'test', 'test' ] ],
+				'expectedTargeting' => [ 'newWikiCategories' => [ 'test' ] ],
 				'expectedProviders' => ['sevenOneMedia' => true]
 			],
 			[
 				'titleMockType' => 'article',
 				'flags' => ['wgAdDriverWikiIsTop1000'],
 				'expectedOpts' => [],
-				'expectedTargeting' => [ 'newWikiCategories' => [ 'test', 'test' ], 'wikiIsTop1000' => true ]
+				'expectedTargeting' => [ 'newWikiCategories' => [ 'test' ], 'wikiIsTop1000' => true ]
 			],
 			[
 				'titleMockType' => 'article',
@@ -113,7 +113,7 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 				'titleMockType' => 'article',
 				'flags' => ['wgEnableOutboundScreenExt'],
 				'expectedOpts' => [],
-				'expectedTargeting' => [ 'newWikiCategories' => [ 'test', 'test' ] ],
+				'expectedTargeting' => [ 'newWikiCategories' => [ 'test' ] ],
 				'expectedProviders' => [],
 				'expectedForceProviders' => null,
 				'expectedSlots' => ['exitstitial' => true]
@@ -122,7 +122,7 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 				'titleMockType' => 'article',
 				'flags' => ['wgOutboundScreenRedirectDelay'],
 				'expectedOpts' => [],
-				'expectedTargeting' => [ 'newWikiCategories' => [ 'test', 'test' ] ],
+				'expectedTargeting' => [ 'newWikiCategories' => [ 'test' ] ],
 				'expectedProviders' => [],
 				'expectedForceProviders' => null,
 				'expectedSlots' => ['exitstitialRedirectDelay' => true]
@@ -131,14 +131,14 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 				'titleMockType' => 'article',
 				'flags' => ['wgEnableWikiaHomePageExt'],
 				'expectedOpts' => ['pageType' => 'corporate'],
-				'expectedTargeting' => [ 'newWikiCategories' => [ 'test', 'test' ], 'wikiIsCorporate' => true ]
+				'expectedTargeting' => [ 'newWikiCategories' => [ 'test' ], 'wikiIsCorporate' => true ]
 			],
 			[
 				'titleMockType' => 'article',
 				'flags' => ['wgEnableWikiaHubsV3Ext'],
 				'expectedOpts' => ['pageType' => 'corporate'],
 				'expectedTargeting' => [
-					'newWikiCategories' => [ 'test', 'test' ],
+					'newWikiCategories' => [ 'test' ],
 					'pageIsHub' => true,
 					'wikiIsCorporate' => true
 				]
@@ -147,26 +147,26 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 				'titleMockType' => 'article',
 				'flags' => ['wgWikiDirectedAtChildrenByFounder'],
 				'expectedOpts' => [],
-				'expectedTargeting' => [ 'newWikiCategories' => [ 'test', 'test' ], 'wikiDirectedAtChildren' => true ]
+				'expectedTargeting' => [ 'newWikiCategories' => [ 'test' ], 'wikiDirectedAtChildren' => true ]
 			],
 			[
 				'titleMockType' => 'article',
 				'flags' => ['wgWikiDirectedAtChildrenByStaff'],
 				'expectedOpts' => [],
-				'expectedTargeting' => [ 'newWikiCategories' => [ 'test', 'test' ], 'wikiDirectedAtChildren' => true ]
+				'expectedTargeting' => [ 'newWikiCategories' => [ 'test' ], 'wikiDirectedAtChildren' => true ]
 			],
 			[
 				'titleMockType' => 'mainpage',
 				'flags' => [],
 				'expectedOpts' => [],
-				'expectedTargeting' => [ 'newWikiCategories' => [ 'test', 'test' ], 'pageType' => 'home' ]
+				'expectedTargeting' => [ 'newWikiCategories' => [ 'test' ], 'pageType' => 'home' ]
 			],
 			[
 				'titleMockType' => 'search',
 				'flags' => [],
 				'expectedOpts' => ['pageType' => 'search'],
 				'expectedTargeting' => [
-					'newWikiCategories' => [ 'test', 'test' ],
+					'newWikiCategories' => [ 'test' ],
 					'pageType' => 'search',
 					'pageName' => 'Special:Search'
 				]
@@ -214,8 +214,13 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 			]),
 
 			array_merge($defaultParameters, [
-				'expectedTargeting' => [ 'newWikiCategories' => [ 'test', 'test', 'test1' ] ],
+				'expectedTargeting' => [ 'newWikiCategories' => [ 0 => 'test', 2 => 'test1' ] ],
 				'categories' => [ 'old' => ['test'], 'new' => ['test', 'test1'] ]
+			]),
+
+			array_merge($defaultParameters, [
+				'expectedTargeting' => [ 'newWikiCategories' => [ 0 => 'test', 1 => 'test1', 4 => 'test2' ] ],
+				'categories' => [ 'old' => ['test', 'test1' ], 'new' => ['test', 'test1', 'test2'] ]
 			]),
 
 			array_merge($defaultParameters, [
@@ -240,7 +245,7 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 		$titleMockType = 'article',
 		$flags = [],
 		$expectedOpts = [],
-		$expectedTargeting = [ 'newWikiCategories' => [ 'test', 'test' ] ],
+		$expectedTargeting = [ 'newWikiCategories' => [ 'test' ] ],
 		$expectedProviders = [],
 		$expectedForcedProvider = null,
 		$expectedSlots = [],

--- a/extensions/wikia/AdEngine/tests/AdEngine2ContextServiceTest.php
+++ b/extensions/wikia/AdEngine/tests/AdEngine2ContextServiceTest.php
@@ -47,10 +47,11 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 			'titleMockType' => 'article',
 			'flags' => [],
 			'expectedOpts' => [],
-			'expectedTargeting' => [],
+			'expectedTargeting' => [ 'newWikiCategories' => [ 'test', 'test' ] ],
 			'expectedProviders' => [],
 			'expectedForceProviders' => null,
 			'expectedSlots' => [],
+			'verticals' => [ 'newVertical' => 'other', 'expectedMappedVertical' => 'life' ]
 		];
 
 		return [
@@ -64,7 +65,7 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 				'titleMockType' => 'article',
 				'flags' => ['wgAdDriverEnableInvisibleHighImpactSlot'],
 				'expectedOpts' => [],
-				'expectedTargeting' => [],
+				'expectedTargeting' => [ 'newWikiCategories' => [ 'test', 'test' ] ],
 				'expectedProviders' => [],
 				'expectedForceProviders' => null,
 				'expectedSlots' => ['invisibleHighImpact' => true]
@@ -73,7 +74,7 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 				'titleMockType' => 'article',
 				'flags' => ['wgAdDriverForceTurtleAd'],
 				'expectedOpts' => [],
-				'expectedTargeting' => [],
+				'expectedTargeting' => [ 'newWikiCategories' => [ 'test', 'test' ] ],
 				'expectedProviders' => [],
 				'expectedForcedProvider' => 'turtle'
 			],
@@ -81,27 +82,27 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 				'titleMockType' => 'article',
 				'flags' => ['wgAdDriverTrackState'],
 				'expectedOpts' => ['trackSlotState' => true],
-				'expectedTargeting' => []
+				'expectedTargeting' => [ 'newWikiCategories' => [ 'test', 'test' ] ]
 			],
 			[
 				'titleMockType' => 'article',
 				'flags' => ['wgAdDriverUseMonetizationService', 'wgEnableMonetizationModuleExt'],
 				'expectedOpts' => [],
-				'expectedTargeting' => [],
+				'expectedTargeting' => [ 'newWikiCategories' => [ 'test', 'test' ] ],
 				'expectedProviders' => ['monetizationService' => true]
 			],
 			[
 				'titleMockType' => 'article',
 				'flags' => ['wgAdDriverUseSevenOneMedia'],
 				'expectedOpts' => [],
-				'expectedTargeting' => [],
+				'expectedTargeting' => [ 'newWikiCategories' => [ 'test', 'test' ] ],
 				'expectedProviders' => ['sevenOneMedia' => true]
 			],
 			[
 				'titleMockType' => 'article',
 				'flags' => ['wgAdDriverWikiIsTop1000'],
 				'expectedOpts' => [],
-				'expectedTargeting' => ['wikiIsTop1000' => true]
+				'expectedTargeting' => [ 'newWikiCategories' => [ 'test', 'test' ], 'wikiIsTop1000' => true ]
 			],
 			[
 				'titleMockType' => 'article',
@@ -112,7 +113,7 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 				'titleMockType' => 'article',
 				'flags' => ['wgEnableOutboundScreenExt'],
 				'expectedOpts' => [],
-				'expectedTargeting' => [],
+				'expectedTargeting' => [ 'newWikiCategories' => [ 'test', 'test' ] ],
 				'expectedProviders' => [],
 				'expectedForceProviders' => null,
 				'expectedSlots' => ['exitstitial' => true]
@@ -121,7 +122,7 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 				'titleMockType' => 'article',
 				'flags' => ['wgOutboundScreenRedirectDelay'],
 				'expectedOpts' => [],
-				'expectedTargeting' => [],
+				'expectedTargeting' => [ 'newWikiCategories' => [ 'test', 'test' ] ],
 				'expectedProviders' => [],
 				'expectedForceProviders' => null,
 				'expectedSlots' => ['exitstitialRedirectDelay' => true]
@@ -130,37 +131,45 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 				'titleMockType' => 'article',
 				'flags' => ['wgEnableWikiaHomePageExt'],
 				'expectedOpts' => ['pageType' => 'corporate'],
-				'expectedTargeting' => ['wikiIsCorporate' => true]
+				'expectedTargeting' => [ 'newWikiCategories' => [ 'test', 'test' ], 'wikiIsCorporate' => true ]
 			],
 			[
 				'titleMockType' => 'article',
 				'flags' => ['wgEnableWikiaHubsV3Ext'],
 				'expectedOpts' => ['pageType' => 'corporate'],
-				'expectedTargeting' => ['pageIsHub' => true, 'wikiIsCorporate' => true]
+				'expectedTargeting' => [
+					'newWikiCategories' => [ 'test', 'test' ],
+					'pageIsHub' => true,
+					'wikiIsCorporate' => true
+				]
 			],
 			[
 				'titleMockType' => 'article',
 				'flags' => ['wgWikiDirectedAtChildrenByFounder'],
 				'expectedOpts' => [],
-				'expectedTargeting' => ['wikiDirectedAtChildren' => true]
+				'expectedTargeting' => [ 'newWikiCategories' => [ 'test', 'test' ], 'wikiDirectedAtChildren' => true ]
 			],
 			[
 				'titleMockType' => 'article',
 				'flags' => ['wgWikiDirectedAtChildrenByStaff'],
 				'expectedOpts' => [],
-				'expectedTargeting' => ['wikiDirectedAtChildren' => true]
+				'expectedTargeting' => [ 'newWikiCategories' => [ 'test', 'test' ], 'wikiDirectedAtChildren' => true ]
 			],
 			[
 				'titleMockType' => 'mainpage',
 				'flags' => [],
 				'expectedOpts' => [],
-				'expectedTargeting' => ['pageType' => 'home']
+				'expectedTargeting' => [ 'newWikiCategories' => [ 'test', 'test' ], 'pageType' => 'home' ]
 			],
 			[
 				'titleMockType' => 'search',
 				'flags' => [],
 				'expectedOpts' => ['pageType' => 'search'],
-				'expectedTargeting' => ['pageType' => 'search', 'pageName' => 'Special:Search']
+				'expectedTargeting' => [
+					'newWikiCategories' => [ 'test', 'test' ],
+					'pageType' => 'search',
+					'pageName' => 'Special:Search'
+				]
 			],
 
 			$defaultParameters + ['expectedMappings' => [
@@ -198,6 +207,26 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 				'newVertical' => 'other',
 				'expectedMappedVertical' => 'wikia']
 			],
+
+			array_merge($defaultParameters, [
+				'expectedTargeting' => [ 'newWikiCategories' => [ 'test', 'test1' ] ],
+				'categories' => [ 'old' => ['test'], 'new' => ['test1'] ]
+			]),
+
+			array_merge($defaultParameters, [
+				'expectedTargeting' => [ 'newWikiCategories' => [ 'test', 'test', 'test1' ] ],
+				'categories' => [ 'old' => ['test'], 'new' => ['test', 'test1'] ]
+			]),
+
+			array_merge($defaultParameters, [
+				'expectedTargeting' => [ 'newWikiCategories' => [ 'test2' ] ],
+				'categories' => [ 'old' => ['test2'] ]
+			]),
+
+			array_merge($defaultParameters, [
+				'expectedTargeting' => [ 'newWikiCategories' => [ 'test3' ] ],
+				'categories' => [ 'new' => ['test3'] ]
+			]),
 		];
 	}
 
@@ -211,11 +240,12 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 		$titleMockType = 'article',
 		$flags = [],
 		$expectedOpts = [],
-		$expectedTargeting = [],
+		$expectedTargeting = [ 'newWikiCategories' => [ 'test', 'test' ] ],
 		$expectedProviders = [],
 		$expectedForcedProvider = null,
 		$expectedSlots = [],
-		$verticals = ['newVertical' => 'other', 'expectedMappedVertical' => 'life']
+		$verticals = ['newVertical' => 'other', 'expectedMappedVertical' => 'life'],
+		$categories = []
 	) {
 		$langCode = 'xx';
 		$artId = 777;
@@ -267,9 +297,34 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 		}
 
 		// Mock WikiFactoryHub
-		$this->mockStaticMethod( 'WikiFactoryHub', 'getCategoryId', $catId );
-		$this->mockStaticMethod( 'WikiFactoryHub', 'getCategoryShort', $shortCat );
-		$this->mockStaticMethod( 'WikiFactoryHub', 'getWikiVertical', [ 'short' => $verticals['newVertical'] ] );
+		$wikiFactoryHubMock = $this->getMockBuilder('WikiFactoryHub')
+			->disableOriginalConstructor()
+			->setMethods( [ 'getCategoryId', 'getCategoryShort', 'getWikiVertical', 'getWikiCategoryNames' ])
+			->getMock();
+
+		$wikiFactoryHubMock->expects( $this->any() )
+			->method( 'getCategoryId' )
+			->willReturn( $catId );
+
+		$wikiFactoryHubMock->expects( $this->any() )
+			->method( 'getCategoryShort' )
+			->willReturn( $shortCat );
+
+		$wikiFactoryHubMock->expects( $this->any() )
+			->method( 'getWikiVertical' )
+			->willReturn( [ 'short' => $verticals['newVertical'] ] );
+
+		if ( !empty( $categories['old'] ) || !empty( $categories['new'] ) ) {
+			$wikiFactoryHubMock->expects( $this->any() )
+				->method( 'getWikiCategoryNames' )
+				->will( $this->onConsecutiveCalls( $categories['old'], $categories['new'] ) );
+		} else {
+			$wikiFactoryHubMock->expects( $this->any() )
+				->method( 'getWikiCategoryNames' )
+				->willReturn( [ 'test' ] );
+		}
+
+		$this->mockStaticMethod( 'WikiFactoryHub', 'getInstance', $wikiFactoryHubMock);
 
 		// Mock HubService
 		$this->mockStaticMethod( 'HubService', 'getCategoryInfoForCity', (object) [

--- a/extensions/wikia/AdEngine/tests/AdEngine2ContextServiceTest.php
+++ b/extensions/wikia/AdEngine/tests/AdEngine2ContextServiceTest.php
@@ -164,38 +164,38 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 			],
 
 			$defaultParameters + ['expectedMappings' => [
-				'sourceVertical' => 'tv',
+				'newVertical' => 'tv',
 				'expectedMappedVertical' => 'ent'
 			]],
 
 			$defaultParameters + ['expectedMappings' => [
-				'sourceVertical' => 'games',
+				'newVertical' => 'games',
 				'expectedMappedVertical' => 'gaming'
 			]],
 
 			$defaultParameters + ['expectedMappings' => [
-				'sourceVertical' => 'books',
+				'newVertical' => 'books',
 				'expectedMappedVertical' => 'ent'
 			]],
 
 			$defaultParameters + ['expectedMappings' => [
-				'sourceVertical' => 'comics',
+				'newVertical' => 'comics',
 				'expectedMappedVertical' => 'ent'
 			]],
 
 			$defaultParameters + ['expectedMappings' => [
-				'sourceVertical' => 'lifestyle',
+				'newVertical' => 'lifestyle',
 				'expectedMappedVertical' => 'life'
 			]],
 
 			$defaultParameters + ['expectedMappings' => [
-				'sourceVertical' => 'not-existing',
+				'newVertical' => 'not-existing',
 				'expectedMappedVertical' => 'error'
 			]],
 
 			$defaultParameters + ['expectedMappings' => [
-				'verticalFromCategoryInfo' => 'Wikia',
-				'sourceVertical' => 'other',
+				'oldVertical' => 'Wikia',
+				'newVertical' => 'other',
 				'expectedMappedVertical' => 'wikia']
 			],
 		];
@@ -215,13 +215,13 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 		$expectedProviders = [],
 		$expectedForcedProvider = null,
 		$expectedSlots = [],
-		$verticals = ['sourceVertical' => 'other', 'expectedMappedVertical' => 'life']
+		$verticals = ['newVertical' => 'other', 'expectedMappedVertical' => 'life']
 	) {
 		$langCode = 'xx';
 		$artId = 777;
 		$artDbKey = 'articledbkey';
 		$skinName = 'someskin';
-		$vertical = isset($verticals['verticalFromCategoryInfo']) ? $verticals['verticalFromCategoryInfo'] : 'Fakevertical';
+		$vertical = $verticals['newVertical'];
 		$dbName = 'mydbname';
 		$cityId = 666;
 		$customDartKvs = 'a=b;c=d';
@@ -269,10 +269,12 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 		// Mock WikiFactoryHub
 		$this->mockStaticMethod( 'WikiFactoryHub', 'getCategoryId', $catId );
 		$this->mockStaticMethod( 'WikiFactoryHub', 'getCategoryShort', $shortCat );
-		$this->mockStaticMethod( 'WikiFactoryHub', 'getWikiVertical', ['short'=>$verticals['sourceVertical']] );
+		$this->mockStaticMethod( 'WikiFactoryHub', 'getWikiVertical', [ 'short' => $verticals['newVertical'] ] );
 
 		// Mock HubService
-		$this->mockStaticMethod( 'HubService', 'getCategoryInfoForCity', (object) ['cat_name' => $vertical] );
+		$this->mockStaticMethod( 'HubService', 'getCategoryInfoForCity', (object) [
+			'cat_name' => !empty($verticals['oldVertical']) ? $verticals['oldVertical'] : $vertical
+		] );
 
 		// Mock MonetizationModule
 		if ( in_array( 'wgAdDriverUseMonetizationService', $flags ) ) {


### PR DESCRIPTION
Recently we mapped all verticals to one of "three musketeers" (gaming, life and ent). But we still want to use new verticals (a wikia belongs to one from seven verticals) and possibly categories (a wikia belongs to none or many categories). In this pull request we're passing this data to page params, so they can be sent to DFP when requesting for an ad.
