### PR TITLE
ADEN-2396 Fix ad skin after recent changes

### DIFF
--- a/extensions/wikia/AdEngine/js/template/skin.js
+++ b/extensions/wikia/AdEngine/js/template/skin.js
@@ -70,7 +70,7 @@ define('ext.wikia.adEngine.template.skin', [
 			adSkinStyle.width = '100%';
 			adSkinStyle.left = 0;
 			adSkinStyle.top = 0;
-			adSkinStyle.zIndex = 0;
+			adSkinStyle.zIndex = 1;
 			adSkinStyle.cursor = 'pointer';
 
 			if (wikiaSkinStyle) {

--- a/extensions/wikia/AdEngine/toggle_skin.js
+++ b/extensions/wikia/AdEngine/toggle_skin.js
@@ -24,7 +24,7 @@ var displayToggleSkin = function(){
 					text-align: center;\
 					top: 0;\
 					width: 100%;\
-					z-index: 0;\
+					z-index: 1;\
 				}';
 			for (var i=0; i<ToggleSkin.settings.creativeSkins.length; i++) {
 				html += '\


### PR DESCRIPTION
We changed `z-index` property for different Oasis elements in 4873d09c3b19c6f07b25efd2675db60d29256375 which occurred in a regression that only half of the ad-skin was clickable. Changes below fixes the issue but we want to code review it and test it.
