### PR TITLE
CE-2615 Compose the valid check for toolbar appearance

### DIFF
--- a/extensions/wikia/ContentReview/ContentReviewHelper.php
+++ b/extensions/wikia/ContentReview/ContentReviewHelper.php
@@ -149,9 +149,12 @@ class Helper extends \ContextSource {
 				$diffRevisionId
 			);
 
-			return ( !self::isStatusCompleted( $diffRevisionInfo['status'] )
-				&& ( $this->getRequest()->getInt( self::CONTENT_REVIEW_URL_PARAM ) === 1
-					|| self::isStatusAwaiting( $diffRevisionInfo['status'] ) )
+			$status = (int)$diffRevisionInfo['status'];
+			return ( $status === ReviewModel::CONTENT_REVIEW_STATUS_IN_REVIEW
+				/* Fallback to URL param if a master-slave replication has not finished */
+				|| ( $this->getRequest()->getInt( self::CONTENT_REVIEW_URL_PARAM ) === 1
+					&& $status === ReviewModel::CONTENT_REVIEW_STATUS_UNREVIEWED
+				)
 			);
 		}
 


### PR DESCRIPTION
Now, the toolbar will only appear for diffs of revisions "In review" or for the ones with a status "Unreviewed" and a `contentreview=1` URL param in case of slow master-slave replication.

@lukaszkonieczny 
