### PR TITLE
TransactionClassifier: report all Nirvana API controllers

### DIFF
--- a/includes/wikia/transaction/TransactionClassifier.php
+++ b/includes/wikia/transaction/TransactionClassifier.php
@@ -33,23 +33,6 @@ class TransactionClassifier {
 		'Newimages',
 		'Videos',
 	);
-	protected static $FILTER_NIRVANA_CONTROLLERS = array(
-		'Rail',
-		//'RelatedPagesApi', moved to api/v1
-		'VideosModule',
-		'ArticleComments',
-		'WallNotificationsController',
-		'JSMessages',
-		'WikiaSearchIndexer',
-		'LatestActivity',
-
-		// controllers used by Mobile Apps (PLATFORM-1177)
-		'SpecialVideosSpecial',
-		'GameGuides',
-		'SearchApi',
-		'VideoHandler',
-		'SearchSuggestionsApi',
-	);
 
 	protected static $FILTER_AJAX_FUNCTIONS = array(
 		'getLinkSuggest',
@@ -138,8 +121,9 @@ class TransactionClassifier {
 				break;
 			// nirvana call - wikia.php
 			case Transaction::ENTRY_POINT_NIRVANA:
-				$this->addByList( Transaction::PARAM_CONTROLLER, self::$FILTER_NIRVANA_CONTROLLERS );
+				$this->add( Transaction::PARAM_CONTROLLER );
 				break;
+			// foo.wikia.com/api/v1 calls
 			case Transaction::ENTRY_POINT_API_V1:
 				$this->add( Transaction::PARAM_CONTROLLER );
 				break;

--- a/includes/wikia/transaction/tests/TransactionClassifierTest.php
+++ b/includes/wikia/transaction/tests/TransactionClassifierTest.php
@@ -4,6 +4,7 @@
  * Unit tests for TransactionClassifier
  *
  * @author macbre
+ * @group TransactionClassifier
  */
 class TransactionClassifierTest extends WikiaBaseTest {
 
@@ -92,7 +93,15 @@ class TransactionClassifierTest extends WikiaBaseTest {
 					Transaction::PARAM_ENTRY_POINT => Transaction::ENTRY_POINT_NIRVANA,
 					Transaction::PARAM_CONTROLLER => 'Places',
 				],
-				'expectedName' => 'api/nirvana/other'
+				'expectedName' => 'api/nirvana/Places'
+			],
+			[
+				'attributes' => [
+					Transaction::PARAM_ENTRY_POINT => Transaction::ENTRY_POINT_NIRVANA,
+					Transaction::PARAM_CONTROLLER => 'ImageServing',
+					Transaction::PARAM_METHOD => 'getImages',
+				],
+				'expectedName' => 'api/nirvana/ImageServing'
 			],
 		];
 	}


### PR DESCRIPTION
Report request to all Nirvana controllers as `'api/nirvana/<controller name>'` without any sort of a whitelist.

@wladekb 
