### PR TITLE
Updated HeliosClientImpl::invalidateToken() to match Helios endpoint.

### DIFF
--- a/lib/Wikia/src/Service/Helios/HeliosClientImpl.php
+++ b/lib/Wikia/src/Service/Helios/HeliosClientImpl.php
@@ -161,8 +161,8 @@ class HeliosClientImpl implements HeliosClient
 	public function invalidateToken( $token )
 	{
 		return $this->request(
-			'token',
-			[ 'code' => $token ],
+			sprintf('token/%s', $token),
+			[],
 			[],
 			[ 'method' => 'DELETE' ]
 		);


### PR DESCRIPTION
After changes in Helios, initial endpoint for invalidating user access token changed so this change updates HeliosClient to use the current one.

@Wikia/services-team 
