### PR TITLE
MAIN-5261: Fixing case when trying to delete access token when there is no token available

### DIFF
--- a/extensions/wikia/Helios/User.class.php
+++ b/extensions/wikia/Helios/User.class.php
@@ -233,7 +233,10 @@ class User {
 	private static function invalidateAccessTokenInHelios() {
 		$request = \RequestContext::getMain()->getRequest();
 		$heliosClient = self::getHeliosClient();
-		$heliosClient->invalidateToken( self::getAccessToken( $request ) );
+		$accessToken = self::getAccessToken( $request );
+		if ( !empty( $accessToken ) ) {
+			$heliosClient->invalidateToken( $accessToken );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Check if token exists before try to delete it.
