### PR TITLE
VE-1909: Fix API when loading visual editor content

### DIFF
--- a/extensions/VisualEditor/extension.json
+++ b/extensions/VisualEditor/extension.json
@@ -105,14 +105,8 @@
 		"VisualEditorParsoidTimeout": 100
 	},
 	"APIModules": {
-		"visualeditor": {
-			"class": "ApiVisualEditor",
-			"factory": "VisualEditorHooks::VisualEditorApiFactory"
-		},
-		"visualeditoredit": {
-			"class": "ApiVisualEditorEdit",
-			"factory": "VisualEditorHooks::VisualEditorApiFactory"
-		}
+		"visualeditor": "ApiVisualEditor",
+		"visualeditoredit": "ApiVisualEditorEdit"
 	},
 	"MessagesDirs": {
 		"VisualEditor": [


### PR DESCRIPTION
Update API for ApiVisualEditor to temporarily solve the problem of the API not working

We did this by reverting requestParsoid to the old version since the new code requires VRS
