### PR TITLE
PLATFORM-1393: improve special recentchanges performance

### DIFF
--- a/includes/DefaultSettings.php
+++ b/includes/DefaultSettings.php
@@ -4533,6 +4533,13 @@ $wgUpgradeKey = false;
 $wgRCMaxAge = 13 * 7 * 24 * 3600;
 
 /**
+ * Wikia change: Recentchanges items are periodically purged; keep the number of rows at the stable level
+ *
+ * @see PLATFORM-1393
+ */
+$wgRCMaxRows = 5000;
+
+/**
  * Filter $wgRCLinkDays by $wgRCMaxAge to avoid showing links for numbers
  * higher than what will be stored. Note that this is disabled by default
  * because we sometimes do have RC data which is beyond the limit for some

--- a/includes/wikia/tasks/Tasks/RecentChangesUpdateTask.class.php
+++ b/includes/wikia/tasks/Tasks/RecentChangesUpdateTask.class.php
@@ -30,15 +30,43 @@ class RecentChangesUpdateTask extends BaseTask {
 		return $task;
 	}
 
+	/**
+	 * Remove recentchanges rows older than $wgRCMaxAge.
+	 * Additionally limit he number of rows in this table (controlled by $wgRCMaxRows)
+	 *
+	 * @return bool
+	 * @throws \DBUnexpectedError
+	 */
 	public function purgeExpiredRows() {
-		global $wgRCMaxAge;
+		global $wgRCMaxAge, $wgRCMaxRows;
 
 		$dbw = wfGetDB( DB_MASTER );
 
 		$rows = 0;
-		$rowsBefore = $dbw->estimateRowCount( 'recentchanges', '*', '', __METHOD__ );
+		$rowsBefore = $dbw->estimateRowCount( 'recentchanges', '*' /* $vars */, '' /* $conds */, __METHOD__ );
 
 		$cutoff = $dbw->timestamp( time() - $wgRCMaxAge );
+
+		/**
+		 * Take the timestamp of the n-th row in recentchanges
+		 * if we have more rows in recentchanges than we allow
+		 *
+		 * @see PLATFORM-1393
+		 */
+		if ( $rowsBefore > $wgRCMaxRows ) {
+			$cutoff = $dbw->selectField(
+				'recentchanges',
+				'rc_timestamp',
+				'',
+				__METHOD__,
+				[
+					'ORDER BY' => 'rc_timestamp DESC',
+					'LIMIT' => 1,
+					'OFFSET' => $wgRCMaxRows
+				]
+			);
+		}
+
 		do {
 			$rcIds = $dbw->selectFieldValues( 'recentchanges',
 				'rc_id',
@@ -55,6 +83,7 @@ class RecentChangesUpdateTask extends BaseTask {
 		} while ( $rcIds );
 
 		$this->info( __METHOD__, [
+			'cutoff' => $cutoff,
 			'rows' => $rows,
 			'rows_before' => $rowsBefore,
 		] );

--- a/includes/wikia/tasks/Tasks/RecentChangesUpdateTask.class.php
+++ b/includes/wikia/tasks/Tasks/RecentChangesUpdateTask.class.php
@@ -34,7 +34,9 @@ class RecentChangesUpdateTask extends BaseTask {
 		global $wgRCMaxAge;
 
 		$dbw = wfGetDB( DB_MASTER );
+
 		$rows = 0;
+		$rowsBefore = $dbw->estimateRowCount( 'recentchanges', '*', '', __METHOD__ );
 
 		$cutoff = $dbw->timestamp( time() - $wgRCMaxAge );
 		do {
@@ -53,7 +55,8 @@ class RecentChangesUpdateTask extends BaseTask {
 		} while ( $rcIds );
 
 		$this->info( __METHOD__, [
-			'rows' => $rows
+			'rows' => $rows,
+			'rows_before' => $rowsBefore,
 		] );
 
 		return true;


### PR DESCRIPTION
Introduce `$wgRCMaxRows` variable (set to 5000) that controls how many rows in `recentchanges` table `RecentChangesUpdateTask` script should keep.

This should greatly improve the performance of queries performed by `SpecialRecentChanges` class.

https://wikia-inc.atlassian.net/browse/PLATFORM-1393

@michalroszka / @wladekb 
