### PR TITLE
(CE-2623) Allow editing of MW JS pages if ContentReview is enabled

### DIFF
--- a/extensions/3rdparty/Verbatim/Verbatim.php
+++ b/extensions/3rdparty/Verbatim/Verbatim.php
@@ -20,15 +20,17 @@ function wfVerbatimExtension( $parser ) {
 function renderVerbatim( $input ) {
 	global $wgEditInterfaceWhitelist, $wgVerbatimBlacklist;
 
+	$formattedInput = ucfirst( trim( $input ) );
 	// Begin wikia change
 	if (
 		( !empty( $wgEditInterfaceWhitelist )
-			&& in_array( ucfirst( trim( $input ) ), $wgEditInterfaceWhitelist ) )
+			&& in_array( $formattedInput, $wgEditInterfaceWhitelist ) )
 		|| ( !empty( $wgVerbatimBlacklist )
-			&& in_array( ucfirst( trim( $input ) ), $wgVerbatimBlacklist ) )
+			&& in_array( $formattedInput, $wgVerbatimBlacklist ) )
+		|| preg_match( '!\.(js)$!u', $formattedInput )
 	) {
 		// Do not allow transclusion into Verbatim tags
-		return "";
+		return '';
 	}
 	// End wikia change
 

--- a/extensions/wikia/ProtectSiteJS/ProtectSiteJS.class.php
+++ b/extensions/wikia/ProtectSiteJS/ProtectSiteJS.class.php
@@ -14,6 +14,7 @@ class ProtectSiteJS {
 				!in_array( 'staff', $groups )
 				&& !$wgUser->isAllowed( 'editinterfacetrusted' )
 				&& !self::isUserSkinJS( $wgTitle, $wgUser )
+				&& !self::isAllowedForContentReview( $wgTitle )
 			) {
 				$wgOut->addHTML( '<div class="errorbox" style="width:92%;">' );
 				$wgOut->addWikiMsg( 'actionthrottledtext' );
@@ -57,5 +58,20 @@ class ProtectSiteJS {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Check if a JS page is allowed to pass through due to
+	 * Content Review being enabled, and the wikia has site
+	 * JS enabled.
+	 *
+	 * @param  Title   $title The title to check.
+	 * @return boolean
+	 */
+	private static function isAllowedForContentReview( Title $title ) {
+		global $wgEnableContentReviewExt, $wgUseSiteJs;
+		return !empty( $wgEnableContentReviewExt ) &&
+			!empty( $wgUseSiteJs ) &&
+			$title->inNamespace( NS_MEDIAWIKI );
 	}
 }

--- a/extensions/wikia/ProtectSiteJS/tests/ProtectSiteJSTest.php
+++ b/extensions/wikia/ProtectSiteJS/tests/ProtectSiteJSTest.php
@@ -9,7 +9,7 @@ class ProtectSiteJSTest extends WikiaBaseTest {
 	/**
 	 * @dataProvider handlerProvider
 	 */
-	public function testHandler( $testData, $expectedResult ) {
+	public function testHandler( $testData, $expectedResult, $message ) {
 		$outputMock = $this->getMock( 'OutputPage', [ 'addHTML', 'addWikiMsg' ] );
 		$this->mockGlobalVariable( 'wgOut', $outputMock );
 
@@ -17,6 +17,8 @@ class ProtectSiteJSTest extends WikiaBaseTest {
 		$this->mockGlobalVariable( 'wgTitle', $title );
 
 		$this->mockGlobalVariable( 'wgCityId', $testData['wikiId'] );
+		$this->mockGlobalVariable( 'wgEnableContentReviewExt', $testData['wgEnableContentReviewExt'] );
+		$this->mockGlobalVariable( 'wgUseSiteJs', $testData['wgUseSiteJs'] );
 
 		$userMock = $this->getMock( 'User', [ 'getName', 'getEffectiveGroups', 'isAllowed' ] );
 
@@ -37,7 +39,7 @@ class ProtectSiteJSTest extends WikiaBaseTest {
 
 		$result = ProtectSiteJS::handler();
 
-		$this->assertSame( $result, $expectedResult );
+		$this->assertSame( $result, $expectedResult, $message );
 	}
 
 	public function handlerProvider() {
@@ -50,8 +52,11 @@ class ProtectSiteJSTest extends WikiaBaseTest {
 					'groups' => [ 'sysop' ],
 					'editinterfacetrusted' => false,
 					'wikiId' => 147,
+					'wgEnableContentReviewExt' => false,
+					'wgUseSiteJs' => true,
 				],
-				false
+				false,
+				'Admins cannot edit MediaWiki JS pages',
 			],
 			[
 				[
@@ -61,8 +66,11 @@ class ProtectSiteJSTest extends WikiaBaseTest {
 					'groups' => [ 'sysop' ],
 					'editinterfacetrusted' => false,
 					'wikiId' => 147,
+					'wgEnableContentReviewExt' => false,
+					'wgUseSiteJs' => true,
 				],
-				false
+				false,
+				'Admins cannot edit User JS pages',
 			],
 			[
 				[
@@ -72,8 +80,11 @@ class ProtectSiteJSTest extends WikiaBaseTest {
 					'groups' => [ 'sysop' ],
 					'editinterfacetrusted' => false,
 					'wikiId' => 147,
+					'wgEnableContentReviewExt' => false,
+					'wgUseSiteJs' => true,
 				],
-				false
+				false,
+				'Admins cannot edit other namespace JS pages',
 			],
 			[
 				[
@@ -83,8 +94,11 @@ class ProtectSiteJSTest extends WikiaBaseTest {
 					'groups' => [ 'staff' ],
 					'editinterfacetrusted' => false,
 					'wikiId' => 147,
+					'wgEnableContentReviewExt' => false,
+					'wgUseSiteJs' => true,
 				],
-				true
+				true,
+				'Staff can edit MediaWiki JS pages',
 			],
 			[
 				[
@@ -94,8 +108,11 @@ class ProtectSiteJSTest extends WikiaBaseTest {
 					'groups' => [ 'sysop' ],
 					'editinterfacetrusted' => true,
 					'wikiId' => 147,
+					'wgEnableContentReviewExt' => false,
+					'wgUseSiteJs' => true,
 				],
-				true
+				true,
+				'Admins with editinterfacetrusted can edit MediaWiki JS pages',
 			],
 			[
 				[
@@ -105,8 +122,11 @@ class ProtectSiteJSTest extends WikiaBaseTest {
 					'groups' => [],
 					'editinterfacetrusted' => false,
 					'wikiId' => 147,
+					'wgEnableContentReviewExt' => false,
+					'wgUseSiteJs' => true,
 				],
-				false
+				false,
+				'Valid user JS subpage names cannot be edited in other namespaces',
 			],
 			[
 				[
@@ -116,8 +136,11 @@ class ProtectSiteJSTest extends WikiaBaseTest {
 					'groups' => [],
 					'editinterfacetrusted' => false,
 					'wikiId' => 147,
+					'wgEnableContentReviewExt' => false,
+					'wgUseSiteJs' => true,
 				],
-				true
+				true,
+				'Valid user JS subpages can be edited by the user',
 			],
 			[
 				[
@@ -127,8 +150,11 @@ class ProtectSiteJSTest extends WikiaBaseTest {
 					'groups' => [],
 					'editinterfacetrusted' => false,
 					'wikiId' => 147,
+					'wgEnableContentReviewExt' => false,
+					'wgUseSiteJs' => true,
 				],
-				true
+				true,
+				'Valid user JS subpages can be edited by the user',
 			],
 			[
 				[
@@ -138,8 +164,11 @@ class ProtectSiteJSTest extends WikiaBaseTest {
 					'groups' => [],
 					'editinterfacetrusted' => false,
 					'wikiId' => 147,
+					'wgEnableContentReviewExt' => false,
+					'wgUseSiteJs' => true,
 				],
-				true
+				true,
+				'Valid user JS subpages can be edited by the user',
 			],
 			[
 				[
@@ -149,8 +178,11 @@ class ProtectSiteJSTest extends WikiaBaseTest {
 					'groups' => [],
 					'editinterfacetrusted' => false,
 					'wikiId' => Wikia::COMMUNITY_WIKI_ID,
+					'wgEnableContentReviewExt' => false,
+					'wgUseSiteJs' => true,
 				],
-				true
+				true,
+				'User global JS subpage can be edited by the user on central wikia',
 			],
 			[
 				[
@@ -160,8 +192,11 @@ class ProtectSiteJSTest extends WikiaBaseTest {
 					'groups' => [],
 					'editinterfacetrusted' => false,
 					'wikiId' => 147,
+					'wgEnableContentReviewExt' => false,
+					'wgUseSiteJs' => true,
 				],
-				false
+				false,
+				'User global JS subpage cannot be edited on wikias other than central',
 			],
 			[
 				[
@@ -171,8 +206,81 @@ class ProtectSiteJSTest extends WikiaBaseTest {
 					'groups' => [],
 					'editinterfacetrusted' => false,
 					'wikiId' => 147,
+					'wgEnableContentReviewExt' => false,
+					'wgUseSiteJs' => true,
 				],
-				false
+				false,
+				'Invalid user JS subpages cannot be edited',
+			],
+			[
+				[
+					'title' => 'Foo.js',
+					'namespace' => NS_MEDIAWIKI,
+					'username' => 'SomeUser',
+					'groups' => [ 'sysop' ],
+					'editinterfacetrusted' => false,
+					'wikiId' => 147,
+					'wgEnableContentReviewExt' => true,
+					'wgUseSiteJs' => true,
+				],
+				true,
+				'Admins can edit MediaWiki JS pages if content review is enabled',
+			],
+			[
+				[
+					'title' => 'Foo.js',
+					'namespace' => NS_MAIN,
+					'username' => 'SomeUser',
+					'groups' => [ 'sysop' ],
+					'editinterfacetrusted' => false,
+					'wikiId' => 147,
+					'wgEnableContentReviewExt' => true,
+					'wgUseSiteJs' => true,
+				],
+				false,
+				'Admins cannot edit non-MediaWiki JS pages if content review is enabled',
+			],
+			[
+				[
+					'title' => 'SomeOtherUser/foo.js',
+					'namespace' => NS_USER,
+					'username' => 'SomeUser',
+					'groups' => [ 'sysop' ],
+					'editinterfacetrusted' => false,
+					'wikiId' => 147,
+					'wgEnableContentReviewExt' => true,
+					'wgUseSiteJs' => true,
+				],
+				false,
+				"Admins cannot edit other user's JS pages even if content review is enabled",
+			],
+			[
+				[
+					'title' => 'SomeUser/foo.js',
+					'namespace' => NS_USER,
+					'username' => 'SomeUser',
+					'groups' => [],
+					'editinterfacetrusted' => false,
+					'wikiId' => 147,
+					'wgEnableContentReviewExt' => true,
+					'wgUseSiteJs' => true,
+				],
+				false,
+				'Invalid user JS subpages cannot be edited even if content review is enabled',
+			],
+			[
+				[
+					'title' => 'Foo.js',
+					'namespace' => NS_MEDIAWIKI,
+					'username' => 'SomeUser',
+					'groups' => [ 'sysop' ],
+					'editinterfacetrusted' => false,
+					'wikiId' => 147,
+					'wgEnableContentReviewExt' => true,
+					'wgUseSiteJs' => false,
+				],
+				false,
+				'Admins cannot edit MediaWiki JS pages if content review is enabled but site JS is disabled',
 			],
 		];
 	}


### PR DESCRIPTION
Allow editing of MediaWiki JS pages if ContentReview and site JS are
enabled. Checking site JS as well allows us to enable ContentReview
everywhere in the future without opening up editing of site JS where
it's not in use.

Also blacklist *.js pages from Verbatim now that they will be editable.

/cc @Wikia/community-engineering 
