### PR TITLE
(CE-2628) Allow editing of *.js talk pages

### DIFF
--- a/extensions/wikia/ProtectSiteJS/ProtectSiteJS.class.php
+++ b/extensions/wikia/ProtectSiteJS/ProtectSiteJS.class.php
@@ -13,6 +13,8 @@ class ProtectSiteJS {
 			if (
 				!in_array( 'staff', $groups )
 				&& !$wgUser->isAllowed( 'editinterfacetrusted' )
+				// Talk pages have always been editable by all, and are not script pages
+				&& !$wgTitle->isTalkPage()
 				&& !self::isUserSkinJS( $wgTitle, $wgUser )
 				&& !self::isAllowedForContentReview( $wgTitle )
 			) {

--- a/extensions/wikia/ProtectSiteJS/tests/ProtectSiteJSTest.php
+++ b/extensions/wikia/ProtectSiteJS/tests/ProtectSiteJSTest.php
@@ -282,6 +282,34 @@ class ProtectSiteJSTest extends WikiaBaseTest {
 				false,
 				'Admins cannot edit MediaWiki JS pages if content review is enabled but site JS is disabled',
 			],
+			[
+				[
+					'title' => 'Foo.js',
+					'namespace' => NS_MEDIAWIKI_TALK,
+					'username' => 'SomeUser',
+					'groups' => [ 'sysop' ],
+					'editinterfacetrusted' => false,
+					'wikiId' => 147,
+					'wgEnableContentReviewExt' => false,
+					'wgUseSiteJs' => false,
+				],
+				true,
+				'Edits to *.js talk pages are allowed',
+			],
+			[
+				[
+					'title' => 'SomeOtherUser/foo.js',
+					'namespace' => NS_USER_TALK,
+					'username' => 'SomeUser',
+					'groups' => [],
+					'editinterfacetrusted' => false,
+					'wikiId' => 147,
+					'wgEnableContentReviewExt' => false,
+					'wgUseSiteJs' => true,
+				],
+				true,
+				'Edits to *.js talk pages are allowed',
+			],
 		];
 	}
 }


### PR DESCRIPTION
These are normal talk pages, so were always editable by all users.
This allows editing of MediaWiki talk:*.js pages in order to raise
issues with the scripts.

/cc @Wikia/community-engineering 
