### PR TITLE
Vary memcache by devbox (improved)

### DIFF
--- a/extensions/wikia/Development/SpecialDevBoxPanel/Special_DevBoxPanel.php
+++ b/extensions/wikia/Development/SpecialDevBoxPanel/Special_DevBoxPanel.php
@@ -405,3 +405,25 @@ function getHtmlForInfo(){
 	return $html;
 } // end getHtmlForInfo()
 
+/**
+ * Vary memcache by devbox
+ *
+ * We append wfWikiID() here as wfMemcKey() uses
+ * $wgCachePrefix or wfWikiID() if the first one is not set
+ *
+ * Sessions are shared between devboxes
+ *
+ * E.g. memcached: get(dev-macbre-plpoznan:revisiontext:textid:96888)
+ *
+ * @author macbre
+ * @see PLATFORM-1401
+ * @see https://github.com/Wikia/app/pull/5842
+ */
+$wgHooks['WikiFactory::onExecuteComplete'][] = function() {
+	global $wgCachePrefix, $wgSharedKeyPrefix, $wgDevelEnvironmentName;
+
+	$wgCachePrefix = 'dev-' . $wgDevelEnvironmentName . '-' . wfWikiID(); // e.g. dev-macbre-muppet / dev-macbre-glee / ...
+	$wgSharedKeyPrefix = 'dev-' . $wgDevelEnvironmentName . '-' . $wgSharedKeyPrefix; // e.g. dev-macbre-wikicities
+
+	return true;
+};


### PR DESCRIPTION
Add a `dev-(name)-` prefix to memcache keys to avoid cross-devbox memcache pollution (e.g. [PLATFORM-1401](https://wikia-inc.atlassian.net/browse/PLATFORM-1401))

```
MWMemcached::get::dev-macbre-wikicities:NavigationModel:5915:pl:wgOasisGlobalNavigation:1
MWMemcached::get::dev-macbre-plpoznan:user:id:119245
MWMemcached::get::dev-macbre-wikicities:wikifactory:variables:value:v5:177:5
```

See https://github.com/Wikia/app/pull/5842 for a similar change for sandboxes and staging environment.

@michalroszka / @wladekb / @SebastianMarzjan 

https://github.com/Wikia/config/pull/1276 caused `db2yml` to die a slow and painful death.
