### PR TITLE
MON-416: disable SEOTweaks heavy database query

### DIFF
--- a/extensions/wikia/SEOTweaks/SEOTweaks.setup.php
+++ b/extensions/wikia/SEOTweaks/SEOTweaks.setup.php
@@ -17,7 +17,7 @@ $wgHooks['BeforePageDisplay'][] = 'SEOTweaksHooksHelper::onBeforePageDisplay';
 $wgHooks['AfterInitialize'][] = 'SEOTweaksHooksHelper::onAfterInitialize';
 $wgHooks['ImagePageAfterImageLinks'][] = 'SEOTweaksHooksHelper::onImagePageAfterImageLinks';
 $wgHooks['BeforeParserMakeImageLinkObjOptions'][] = 'SEOTweaksHooksHelper::onBeforeParserMakeImageLinkObjOptions';
-#$wgHooks['ArticleViewHeader'][] = 'SEOTweaksHooksHelper::onArticleViewHeader';
+#$wgHooks['ArticleViewHeader'][] = 'SEOTweaksHooksHelper::onArticleViewHeader'; // macbre: disabled because of MON-416
 
 // messages
 $wgExtensionMessagesFiles['SEOTweaks'] = $dir . 'SEOTweaks.i18n.php';

--- a/extensions/wikia/SEOTweaks/SEOTweaks.setup.php
+++ b/extensions/wikia/SEOTweaks/SEOTweaks.setup.php
@@ -17,7 +17,7 @@ $wgHooks['BeforePageDisplay'][] = 'SEOTweaksHooksHelper::onBeforePageDisplay';
 $wgHooks['AfterInitialize'][] = 'SEOTweaksHooksHelper::onAfterInitialize';
 $wgHooks['ImagePageAfterImageLinks'][] = 'SEOTweaksHooksHelper::onImagePageAfterImageLinks';
 $wgHooks['BeforeParserMakeImageLinkObjOptions'][] = 'SEOTweaksHooksHelper::onBeforeParserMakeImageLinkObjOptions';
-$wgHooks['ArticleViewHeader'][] = 'SEOTweaksHooksHelper::onArticleViewHeader';
+#$wgHooks['ArticleViewHeader'][] = 'SEOTweaksHooksHelper::onArticleViewHeader';
 
 // messages
 $wgExtensionMessagesFiles['SEOTweaks'] = $dir . 'SEOTweaks.i18n.php';


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/MON-416

Disable `SEOTweaksHooksHelper::onArticleViewHeader` hook.

``` sql
SELECT page_title FROM page WHERE page_title LIKE '255961%' LIMIT 1
```

These queries take a really long time to complete (median value is around a minute) generating a long tail of MediaWiki response times. Additionally, [in only 5% of cases it actually returns matching article](https://kibana.wikia-inc.com/index.html#/dashboard/elasticsearch/MON-416).

@wladekb / @michalroszka / @jacekjursza 
