### PR TITLE
Clean up wfSuppressWarnings()

### DIFF
--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -2322,13 +2322,6 @@ function wfSuppressWarnings( $end = false ) {
 		}
 	} else {
 		if ( !$suppressCount ) {
-			// E_DEPRECATED and E_USER_DEPRECATED are undefined in PHP 5.2
-			if( !defined( 'E_DEPRECATED' ) ) {
-				define( 'E_DEPRECATED', 8192 );
-			}
-			if( !defined( 'E_USER_DEPRECATED' ) ) {
-				define( 'E_USER_DEPRECATED', 16384 );
-			}
 			$originalLevel = error_reporting( E_ALL & ~( E_WARNING | E_NOTICE | E_USER_WARNING | E_USER_NOTICE | E_DEPRECATED | E_USER_DEPRECATED | E_STRICT ) );
 		}
 		++$suppressCount;


### PR DESCRIPTION
wfSuppressWarnings() is called so many times and these checks are completely unnecessary. Let's remove them!

/cc @macbre 
