### PR TITLE
Experimental unrolling of selected functions

### DIFF
--- a/includes/wikia/nirvana/WikiaGlobalRegistry.class.php
+++ b/includes/wikia/nirvana/WikiaGlobalRegistry.class.php
@@ -41,6 +41,8 @@ class WikiaGlobalRegistry extends WikiaRegistry {
 	);
 
 	public function get($propertyName) {
+		// body of this method is also copied/inlined in WikiaGlobalRegistry::__get()
+		// don't forget to update it as well if you modify this one
 		$this->validatePropertyName($propertyName);
 		if( isset($GLOBALS[$propertyName]) )
 			return $GLOBALS[$propertyName];
@@ -94,7 +96,16 @@ class WikiaGlobalRegistry extends WikiaRegistry {
 	}
 
 	public function __get($propertyName) {
-		return $this->get( 'wg' . ucfirst($propertyName) );
+		// inlines WikiaGlobalRegistry::get() and WikiaRegistry::validatePropertyName()
+		// make sure the changes are made in both places
+		$propertyName = 'wg' . ucfirst($propertyName);
+		if ( empty( $propertyName ) || is_numeric( $propertyName ) ) {
+			throw new WikiaException( "WikiaProperty - invalid or empty property name ({$propertyName})" );
+		}
+		if( isset($GLOBALS[$propertyName]) )
+			return $GLOBALS[$propertyName];
+		return null;
+//		return $this->get( 'wg' . ucfirst($propertyName) );
 	}
 
 	public function __set($propertyName, $value) {

--- a/includes/wikia/nirvana/WikiaGlobalRegistry.class.php
+++ b/includes/wikia/nirvana/WikiaGlobalRegistry.class.php
@@ -96,6 +96,7 @@ class WikiaGlobalRegistry extends WikiaRegistry {
 	}
 
 	public function __get($propertyName) {
+		// @author: wladek
 		// inlines WikiaGlobalRegistry::get() and WikiaRegistry::validatePropertyName()
 		// make sure the changes are made in both places
 		$propertyName = 'wg' . ucfirst($propertyName);

--- a/includes/wikia/nirvana/WikiaRegistry.class.php
+++ b/includes/wikia/nirvana/WikiaRegistry.class.php
@@ -13,6 +13,8 @@
 abstract class WikiaRegistry implements ArrayAccess {
 
 	protected function validatePropertyName( $propertyName ) {
+		// body of this method is also copied/inlined in WikiaGlobalRegistry::__get()
+		// don't forget to update it as well if you modify this one
 		if ( empty( $propertyName ) || is_numeric( $propertyName ) ) {
 			throw new WikiaException( "WikiaProperty - invalid or empty property name ({$propertyName})" );
 		}

--- a/includes/wikia/nirvana/WikiaView.class.php
+++ b/includes/wikia/nirvana/WikiaView.class.php
@@ -109,11 +109,12 @@ class WikiaView {
 			}
 
 			// Service classes must be dispatched by full name otherwise we default to a controller.
-			$controllerClass = self::normalizeControllerClass( $controllerClass );
+			$controllerBaseName = null;
+			$controllerClass = self::normalizeControllerClass( $controllerClass, $controllerBaseName );
 
 			$templateExists = false;
 			$templatePath = '';
-			$templates = $this->getTemplateOptions( $controllerClass, $methodName );
+			$templates = $this->getTemplateOptions( $controllerClass, $methodName, $controllerBaseName );
 			$dirName = $this->getTemplateDir( $controllerClass );
 			foreach ( $templates as $templateName ) {
 				$templatePath = $dirName . '/' . $templateName . '.' . $extension;
@@ -138,18 +139,31 @@ class WikiaView {
 	 * 'Controller' or 'Service'.  Normalize to this form.
 	 *
 	 * @param string $controllerClass
+	 * @param string $controllerBaseName (out, optional) Controller class base name
 	 *
 	 * @return string
 	 *
 	 * @throws WikiaException
 	 */
-	private static function normalizeControllerClass( $controllerClass ) {
+	private static function normalizeControllerClass( $controllerClass, &$controllerBaseName = null ) {
 		$app = F::app();
+		// @author: wladek
+		// Improve performance by providing the same behavior without calling external functions
+		/*
 		$controllerBaseName = $app->getBaseName( $controllerClass );
 		if ( $app->isService( $controllerClass ) ) {
 			$controllerClass = $app->getServiceClassName( $controllerBaseName );
 		} else {
 			$controllerClass = $app->getControllerClassName( $controllerBaseName );
+		}
+		*/
+		if ( substr( $controllerClass, -7 ) === 'Service' ) {
+			$controllerBaseName = substr( $controllerClass, 0, -7 );
+		} elseif ( substr( $controllerClass, -10 ) === 'Controller' ) {
+			$controllerBaseName = substr( $controllerClass, 0, -10 );
+		} else {
+			$controllerBaseName = $controllerClass;
+			$controllerClass .= 'Controller';
 		}
 
 		if ( empty( $app->wg->AutoloadClasses[$controllerClass] ) ) {
@@ -164,10 +178,11 @@ class WikiaView {
 	 *
 	 * @param string $controllerClass
 	 * @param string $methodName
+	 * @param string $controllerBaseName (optional) save cpu cycles by not
 	 *
 	 * @return array
 	 */
-	private function getTemplateOptions( $controllerClass, $methodName ) {
+	private function getTemplateOptions( $controllerClass, $methodName, $controllerBaseName = null ) {
 		$templates = [];
 
 		$fromAnnotation = $this->getTemplateAnnotation( $controllerClass, $methodName );
@@ -176,9 +191,13 @@ class WikiaView {
 		}
 
 		// Add variations on the controller name
-		$controllerBaseName = F::app()->getBaseName( $controllerClass );
+		if ( $controllerBaseName === null ) {
+			$controllerBaseName = F::app()->getBaseName( $controllerClass );
+		}
 		$templates[] = "{$controllerBaseName}_{$methodName}";
-		$templates[] = "{$controllerClass}_{$methodName}";
+		if ( $controllerClass !== $controllerBaseName ) {
+			$templates[] = "{$controllerClass}_{$methodName}";
+		}
 
 		return $templates;
 	}


### PR DESCRIPTION
There are some hotspots that are executed thousands or millions times per minute. Some of them can be easily optimized for performance without a big cost for code readability or maintainability.

Let's try a few of them to collect more data how much unrolling of those functions helps us achieve better backend performance.

List of functions that are unrolled:
- WikiaGlobalRegistry::__get()
- WikiaView::normalizeControllerClass()

/cc @macbre 
