### PR TITLE
Lazy register the most often executed Insights hook

### DIFF
--- a/extensions/wikia/Insights/Insights.setup.php
+++ b/extensions/wikia/Insights/Insights.setup.php
@@ -68,11 +68,19 @@ $wgAutoloadClasses['InsightsHooks'] = $dir . 'InsightsHooks.class.php';
 $wgHooks['BeforePageDisplay'][] = 'InsightsHooks::onBeforePageDisplay';
 $wgHooks['ArticleUpdateBeforeRedirect'][] = 'InsightsHooks::AfterActionBeforeRedirect';
 $wgHooks['ArticleCreateBeforeRedirect'][] = 'InsightsHooks::AfterActionBeforeRedirect';
-$wgHooks['GetLocalURL'][] = 'InsightsHooks::onGetLocalURL';
 $wgHooks['MakeGlobalVariablesScript'][] = 'InsightsHooks::onMakeGlobalVariablesScript';
 $wgHooks['GetRailModuleList'][] = 'InsightsHooks::onGetRailModuleList';
 $wgHooks['wgQueryPages'][] = 'InsightsHooks::onwgQueryPages';
 $wgHooks['AfterUpdateSpecialPages'][] = 'InsightsHooks::onAfterUpdateSpecialPages';
+
+$wgExtensionFunctions[] = 'wfInsightsSetup';
+function wfInsightsSetup() {
+	global $wgRequest, $wgHooks;
+
+	if ( !empty( $wgRequest->getVal( 'insights', null ) ) ) {
+		$wgHooks['GetLocalURL'][] = 'InsightsHooks::onGetLocalURL';
+	}
+}
 
 /**
  * Message files

--- a/extensions/wikia/Insights/InsightsHelper.php
+++ b/extensions/wikia/Insights/InsightsHelper.php
@@ -101,7 +101,7 @@ class InsightsHelper {
 	/**
 	 * Checks if a given subpage is known
 	 *
-	 * @param $subpage A slug of a subpage
+	 * @param $subpage string|null A slug of a subpage
 	 * @return bool
 	 */
 	public static function isInsightPage( $subpage ) {
@@ -130,7 +130,7 @@ class InsightsHelper {
 	 * Returns a specific subpage model
 	 * If it does not exist a user is redirected to the Special:Insights landing page
 	 *
-	 * @param $subpage A slug of a subpage
+	 * @param $subpage string|null A slug of a subpage
 	 * @return InsightsModel|null
 	 */
 	public static function getInsightModel( $subpage ) {


### PR DESCRIPTION
Title::GetLocalURL is executed really often during each request. Let's register the hook handler only if it's gonna do anything.

/cc @macbre @michalroszka @adamkarminski @lukaszkonieczny @kamilkoterba 
