### PR TITLE
PLATFORM-1417 - DatabaseBase::isWriteQuery - ignore leading whitespaces

### DIFF
--- a/extensions/wikia/Wall/Wall.class.php
+++ b/extensions/wikia/Wall/Wall.class.php
@@ -316,7 +316,7 @@ class Wall extends WikiaModel {
 				LIMIT $offset, {$this->mMaxPerPage}
 			";
 
-			$res = $db->query( $query );
+			$res = $db->query( $query, __METHOD__ );
 
 
 

--- a/includes/db/Database.php
+++ b/includes/db/Database.php
@@ -839,7 +839,7 @@ abstract class DatabaseBase implements DatabaseType {
 	 * @return bool
 	 */
 	function isWriteQuery( $sql ) {
-		return !preg_match( '/^(?:SELECT|BEGIN|COMMIT|SET|SHOW|\(SELECT)\b/i', $sql );
+		return !preg_match( '/^(?:SELECT|BEGIN|COMMIT|SET|SHOW|\(SELECT)\b/i', ltrim( $sql ) ); // PLATFORM-1417 (ltrim)
 	}
 
 	/**


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-1417

This is actually a "SELECT" query despite all leading whitespaces

``` sql

            SELECT comment_id FROM comments_index
                WHERE parent_page_id = 12648  and deleted = 0 and removed = 0 and parent_comment_id = 0 
                ORDER BY last_child_comment_id desc
                LIMIT 0, 25
```

This will allow Message Wall to work correctly on Reston instead of throwing 20k of `DB readonly mode` exceptions each hour.

@michalroszka / @wladekb / @drozdo 
