### PR TITLE
(CE-2623) Allow editing of MW JS pages when ContentReview is enabled

### DIFF
--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -2284,7 +2284,7 @@ class Wikia {
 	 * return false stops permissions processing and we are totally decided (nothing later can override)
 	 */
 	static function canEditInterfaceWhitelist (&$title, &$wgUser, $action, &$result) {
-		global $wgEditInterfaceWhitelist;
+		global $wgEditInterfaceWhitelist, $wgEnableContentReviewExt;
 
 		// List the conditions we don't care about for early exit
 		if ( $action == "read" || $title->getNamespace() != NS_MEDIAWIKI || empty( $wgEditInterfaceWhitelist )) {
@@ -2297,7 +2297,10 @@ class Wikia {
 		}
 
 		// In this NS, editinterface applies only to white listed pages
-		if (in_array($title->getDBKey(), $wgEditInterfaceWhitelist)) {
+		if ( in_array( $title->getDBKey(), $wgEditInterfaceWhitelist )
+			|| ( !empty( $wgEnableContentReviewExt )
+				&& preg_match( '!\.(js)$!u', $title->getDBKey() ) )
+		) {
 			return $wgUser->isAllowed('editinterface');
 		}
 


### PR DESCRIPTION
JS pages are now blacklisted from Verbatim, and the JS editing protections
are skipped for MediaWiki JS pages if ContentReview is enabled, so we
need to also whitelist them so those with editinterface but not
editinterfacetrusted can edit them. The extra check if ContentReview is
enabled is for paranoia as it should already be checked in the ProtectSiteJS
extension.

/cc @Wikia/community-engineering 
