### PR TITLE
[SERVICES-723] Fixing helios client status check

### DIFF
--- a/lib/Wikia/src/Service/Helios/HeliosClientImpl.php
+++ b/lib/Wikia/src/Service/Helios/HeliosClientImpl.php
@@ -96,7 +96,7 @@ class HeliosClientImpl implements HeliosClient
 	}
 
 	protected function processResponseOutput( \MWHttpRequest $request ) {
-		if ( $request->status == Constants::HTTP_STATUS_NO_CONTENT ) {
+		if ( $request->getStatus() == Constants::HTTP_STATUS_NO_CONTENT ) {
 			return null;
 		}
 


### PR DESCRIPTION
Fix the comparison of the request status to the integer value and not the object.

/cc @Wikia/services-team 
