### PR TITLE
SEO-51 New robots.txt as an extension

### DIFF
--- a/extensions/wikia/CreateNewWiki/CreateNewWiki.alias.php
+++ b/extensions/wikia/CreateNewWiki/CreateNewWiki.alias.php
@@ -2,10 +2,10 @@
 /**
  * Aliases for special pages of CreateNewWiki extension.
  */
-$specialPageAliases = array();
+$specialPageAliases = [];
 
 /** English
  */
-$specialPageAliases['en'] = array(
-	'CreateNewWiki' => array( 'CreateNewWiki', 'CreateWiki' ),
-);
+$specialPageAliases['en'] = [
+	'CreateNewWiki' => [ 'CreateNewWiki', 'CreateWiki' ],
+];

--- a/extensions/wikia/CreateNewWiki/CreateNewWiki.alias.php
+++ b/extensions/wikia/CreateNewWiki/CreateNewWiki.alias.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Aliases for special pages of CreateNewWiki extension.
+ */
+$specialPageAliases = array();
+
+/** English
+ */
+$specialPageAliases['en'] = array(
+	'CreateNewWiki' => array( 'CreateNewWiki', 'CreateWiki' ),
+);

--- a/extensions/wikia/CreateNewWiki/CreateNewWiki_setup.php
+++ b/extensions/wikia/CreateNewWiki/CreateNewWiki_setup.php
@@ -25,11 +25,11 @@ $wgAutoloadClasses['CreateNewWikiController'] = $dir . 'CreateNewWikiController.
 
 // special page mapping
 $wgSpecialPages['CreateNewWiki'] = 'SpecialCreateNewWiki';
-$wgSpecialPages['CreateWiki'] = 'SpecialCreateNewWiki';
 
 // i18n mapping
 $wgExtensionMessagesFiles['AutoCreateWiki'] = $dir . 'AutoCreateWiki.i18n.php';
 $wgExtensionMessagesFiles['CreateNewWiki'] = $dir . 'CreateNewWiki.i18n.php';
+$wgExtensionMessagesFiles['CreateNewWikiAlias'] = $dir . 'CreateNewWiki.alias.php';
 
 // permissions
 $wgAvailableRights[] = 'createnewwiki';

--- a/extensions/wikia/RobotsTxt/RobotsTxt.class.php
+++ b/extensions/wikia/RobotsTxt/RobotsTxt.class.php
@@ -1,0 +1,190 @@
+<?php
+
+class RobotsTxt {
+
+	//// Caching for 1 hour in case this does a lot of damage and we need to revert quickly
+	//// In the long run, we can for longer, much longer
+	const CACHE_PERIOD = 3600;
+
+	private $allowed = [];
+	private $blockedRobots = [];
+	private $disallowed = [];
+	private $sitemap;
+
+	public function __construct() {
+		global $wgContLang;
+
+		$this->englishLang = new Language();
+		$this->specialNamespaces = array_unique( [
+			$wgContLang->getNamespaces()[NS_SPECIAL],
+			$this->englishLang->getNamespaces()[NS_SPECIAL],
+		] );
+	}
+
+	/**
+	 * Allow a special page to be crawled
+	 *
+	 * Allows crawling a page when accessed using /wiki/Special:XXX URL
+	 * and the localized variants of the URL.
+	 *
+	 * @param $pageName string name of the special page as exposed in alias file for the special page
+	 */
+	public function allowSpecialPage( $pageName ) {
+		foreach ( $this->specialNamespaces as $specialNamespace ) {
+			foreach ( $this->getSpecialPageNames( $pageName ) as $localPageName ) {
+				$this->allowed[] = $this->buildUrl( $specialNamespace, $localPageName );
+			}
+		}
+	}
+
+	/**
+	 * Disallow a specific robot to crawl all the pages
+	 *
+	 * @param $robot string User-agent (fragment) of the robot
+	 */
+	public function blockRobot( $robot ) {
+		$this->blockedRobots[] = $robot;
+	}
+
+	/**
+	 * Disallow crawling pages with a given query param
+	 *
+	 * This will only block robots that understand wildcards.
+	 * The param is matched loosely, so ABCsomeparam is blocked as well when you block someparam
+	 *
+	 * @param $param param to block
+	 */
+	public function disallowParam( $param ) {
+		$this->disallowed[] = '/*?*' . $param . '=';
+	}
+
+	/**
+	 * Disallow a specific path
+	 *
+	 * @param $path the path prefix to block (some robots accept wildcards)
+	 */
+	public function disallowPath( $path ) {
+		$this->disallowed[] = $path;
+	}
+
+	/**
+	 * Disallow all special pages (use allowSpecialPage to whitelist some)
+	 *
+	 * Multiple ways of accessing the special pages are blocked:
+	 *
+	 *  * /wiki/Special:XXX
+	 *  * /index.php?title=Special:XXX
+	 *  * /index.php/Special:XXX
+	 *  * all above in the wiki content language
+	 */
+	public function disallowSpecialPages() {
+		foreach ( $this->specialNamespaces as $namespace ) {
+			$this->disallowed[] = $this->buildUrl( $namespace );
+			$this->disallowed[] = '/*?*title=' . $namespace . ':';
+			$this->disallowed[] = '/index.php/' . $namespace . ':';
+		}
+	}
+
+	/**
+	 * Get robots.txt contents as array of lines
+	 *
+	 * @return array
+	 */
+	public function getContents() {
+		return array_merge(
+			$this->getBlockedRobotsSection(),
+			$this->getAllowDisallowSection(),
+			$this->getSitemapSection()
+		);
+	}
+
+	/**
+	 * Get headers to set
+	 *
+	 * @return array
+	 */
+	public function getHeaders() {
+		return [
+			'Content-Type: text/plain',
+			'Cache-Control: s-maxage=' . self::CACHE_PERIOD,
+			'X-Pass-Cache-Control: public, max-age=3600' . self::CACHE_PERIOD,
+		];
+	}
+
+	/**
+	 * Set Sitemap URL
+	 *
+	 * @param $sitemapUrl
+	 */
+	public function setSitemap( $sitemapUrl ) {
+		$this->sitemap = $sitemapUrl;
+	}
+
+	// Private methods follow:
+
+	private function buildUrl( $specialNamespace, $localPageName = '' ) {
+		global $wgArticlePath;
+		return str_replace( '$1', $specialNamespace . ':' . $localPageName, $wgArticlePath );
+	}
+
+	private function encodeUri( $in ) {
+		return str_replace(
+			['%2F', '%3A', '%2A', '%3F', '%3D', '%24'],
+			['/', ':', '*', '?', '=', '$'],
+			rawurlencode( $in )
+		);
+	}
+
+	private function getAllowDisallowSection() {
+		$allowSection = array_map(
+			function ( $prefix ) {
+				return 'Allow: ' . $this->encodeUri( $prefix );
+			} ,
+			$this->allowed
+		);
+
+		$disallowSection = array_map(
+			function ( $prefix ) {
+				return 'Disallow: ' . $this->encodeUri( $prefix );
+			} ,
+			$this->disallowed
+		);
+
+		if ( count( $allowSection ) || count( $disallowSection ) ) {
+			return array_merge(
+				['User-agent: *'],
+				$allowSection,
+				$disallowSection,
+				['']
+			);
+		}
+
+		return [];
+	}
+
+	private function getBlockedRobotsSection() {
+		$r = [];
+		foreach ( $this->blockedRobots as $robot ) {
+			$r[] = 'User-agent: ' . $robot;
+			$r[] = 'Disallow: /';
+			$r[] = '';
+		}
+		return $r;
+	}
+
+	private function getSitemapSection() {
+		if ( $this->sitemap ) {
+			return ['Sitemap: ' . $this->encodeUri( $this->sitemap )];
+		}
+		return [];
+	}
+
+	private function getSpecialPageNames( $pageName ) {
+		global $wgContLang;
+		$aliases = $wgContLang->getSpecialPageAliases()[ $pageName ];
+		if ( empty( $aliases ) ) {
+			$aliases = [];
+		}
+		return $aliases;
+	}
+}

--- a/extensions/wikia/RobotsTxt/RobotsTxt.class.php
+++ b/extensions/wikia/RobotsTxt/RobotsTxt.class.php
@@ -2,8 +2,8 @@
 
 class RobotsTxt {
 
-	//// Caching for 1 hour in case this does a lot of damage and we need to revert quickly
-	//// In the long run, we can for longer, much longer
+	// Caching for 1 hour in case this does a lot of damage and we need to revert quickly
+	// In the long run, we can for longer, much longer
 	const CACHE_PERIOD = 3600;
 
 	private $allowed = [];

--- a/extensions/wikia/RobotsTxt/RobotsTxt.setup.php
+++ b/extensions/wikia/RobotsTxt/RobotsTxt.setup.php
@@ -1,0 +1,4 @@
+<?php
+
+// Autoload
+$wgAutoloadClasses['RobotsTxt'] =  __DIR__ . '/RobotsTxt.class.php';

--- a/extensions/wikia/RobotsTxt/tests/RobotsTest.php
+++ b/extensions/wikia/RobotsTxt/tests/RobotsTest.php
@@ -1,0 +1,143 @@
+<?php
+
+class RobotsTest extends WikiaBaseTest {
+
+	public function setUp() {
+		global $IP;
+		$this->setupFile = "$IP/extensions/wikia/RobotsTxt/RobotsTxt.setup.php";
+		parent::setUp();
+	}
+
+	/**
+	 * Test empty robots.txt
+	 */
+	public function testEmpty() {
+		$robots = new RobotsTxt();
+		$this->assertEquals( [], $robots->getContents() );
+	}
+
+	/**
+	 * Test allowSpecialPage
+	 *
+	 * @covers RobotsTxt::allowSpecialPage
+	 */
+	public function testAllowSpecialPage() {
+		$robots = new RobotsTxt();
+		$robots->allowSpecialPage( 'Randompage' );
+		$this->assertEquals( [
+			'User-agent: *',
+			'Allow: /wiki/Special:Random',
+			'Allow: /wiki/Special:RandomPage',
+			'',
+		], $robots->getContents() );
+	}
+
+	/**
+	 * Test blockRobot
+	 *
+	 * @covers RobotsTxt::testBlockRobot
+	 */
+	public function testBlockRobot() {
+		$robots = new RobotsTxt();
+		$robots->blockRobot( 'my-fancy-robot' );
+		$robots->blockRobot( 'your-nasty-robot' );
+		$this->assertEquals( [
+			'User-agent: my-fancy-robot',
+			'Disallow: /',
+			'',
+			'User-agent: your-nasty-robot',
+			'Disallow: /',
+			'',
+		], $robots->getContents() );
+	}
+
+	/**
+	 * Test disallowParam
+	 *
+	 * @covers RobotsTxt::disallowParam
+	 */
+	public function testDisallowParam() {
+		$robots = new RobotsTxt();
+		$robots->disallowParam( 'someparam' );
+		$this->assertEquals( [
+			'User-agent: *',
+			'Disallow: /*?*someparam=',
+			'',
+		], $robots->getContents() );
+	}
+
+	/**
+	 * Test disallowPath and limited URI encoding
+	 *
+	 * @covers RobotsTxt::disallowPath
+	 */
+	public function testDisallowPath() {
+		$robots = new RobotsTxt();
+		$robots->disallowPath( '/some-path' );
+		$robots->disallowPath( '/some-path:ąść' );
+		$robots->disallowPath( '/some-path:サイトマップ' );
+		$robots->disallowPath( '/*/*%$' );
+		$this->assertEquals( [
+			'User-agent: *',
+			'Disallow: /some-path',
+			'Disallow: /some-path:%C4%85%C5%9B%C4%87',
+			'Disallow: /some-path:%E3%82%B5%E3%82%A4%E3%83%88%E3%83%9E%E3%83%83%E3%83%97',
+			'Disallow: /*/*%25$',
+			'',
+		], $robots->getContents() );
+	}
+
+	/**
+	 * Test disallowSpecialPages
+	 *
+	 * @covers RobotsTxt::testDisallowSpecialPages
+	 */
+	public function testDisallowSpecialPages() {
+		$robots = new RobotsTxt();
+		$robots->disallowSpecialPages();
+		$this->assertEquals( [
+			'User-agent: *',
+			'Disallow: /wiki/Special:',
+			'Disallow: /*?*title=Special:',
+			'Disallow: /index.php/Special:',
+			'',
+		], $robots->getContents() );
+	}
+
+	/**
+	 * Test setSitemap
+	 *
+	 * @covers RobotsTxt::setSitemap
+	 */
+	public function testSetSitemap() {
+		$robots = new RobotsTxt();
+		$robots->setSitemap( 'http://www.my-site.com/sitemap.xml' );
+		$this->assertEquals( [
+			'Sitemap: http://www.my-site.com/sitemap.xml',
+		], $robots->getContents() );
+	}
+
+	/**
+	 * Test getContents produces the output in the right order
+	 *
+	 * @covers RobotsTxt::getContents
+	 */
+	public function testGetContentsOrder() {
+		$robots = new RobotsTxt();
+		$robots->disallowPath( '/abc' );
+		$robots->blockRobot( 'robot-1' );
+		$robots->allowSpecialPage( 'Randompage' );
+		$robots->setSitemap( 'http://www.my-site.com/sitemap.xml' );
+		$this->assertEquals( [
+			'User-agent: robot-1',
+			'Disallow: /',
+			'',
+			'User-agent: *',
+			'Allow: /wiki/Special:Random',
+			'Allow: /wiki/Special:RandomPage',
+			'Disallow: /abc',
+			'',
+			'Sitemap: http://www.my-site.com/sitemap.xml',
+		], $robots->getContents() );
+	}
+}

--- a/extensions/wikia/Sitemap/SpecialSitemap.php
+++ b/extensions/wikia/Sitemap/SpecialSitemap.php
@@ -39,7 +39,7 @@ $wgExtensionCredits['specialpage'][] = array(
  */
 $dir = dirname( __FILE__ ) . '/';
 $wgExtensionMessagesFiles['Sitemap'] = $dir . 'Sitemap.i18n.php';
-$wgExtensionMessagesFiles['Sitemap'] = $dir . 'Sitemap.alias.php';
+$wgExtensionMessagesFiles['SitemapAlias'] = $dir . 'Sitemap.alias.php';
 $wgAutoloadClasses['SitemapPage'] = $dir . 'SpecialSitemap_body.php';
 $wgSpecialPages['Sitemap'] = 'SitemapPage';
 $wgSpecialPageGroups['Sitemap'] = 'wikia';

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1803,3 +1803,10 @@ $wgPreferencesUseService = false;
  * Parser Tag
  */
 require_once "$IP/extensions/wikia/SoundCloudTag/SoundCloudTag.setup.php" ;
+
+/**
+ * @name $wgEnableRobotsTxtExt
+ *
+ * Enables extension that generates robots.txt
+ */
+$wgEnableRobotsTxtExt = false;

--- a/redirect-robots.php
+++ b/redirect-robots.php
@@ -8,6 +8,12 @@ $wgDBadminuser = $wgDBadminpassword = $wgDBserver = $wgDBname = $wgEnableProfile
 define( 'MW_NO_SETUP', 1 );
 require_once( dirname(__FILE__) . '/includes/WebStart.php' );
 require_once( dirname(__FILE__) . '/includes/Setup.php' );
+
+if ( !empty( $wgEnableRobotsTxtExt ) ) {
+	require(__DIR__ . '/wikia-robots-txt.php');
+	exit;
+}
+
 require_once( dirname(__FILE__) . '/includes/StreamFile.php' );
 require_once( dirname(__FILE__) . '/includes/SpecialPage.php' );
 require_once( dirname(__FILE__) . '/languages/Language.php' );

--- a/redirect-robots.php
+++ b/redirect-robots.php
@@ -10,7 +10,7 @@ require_once( dirname(__FILE__) . '/includes/WebStart.php' );
 require_once( dirname(__FILE__) . '/includes/Setup.php' );
 
 if ( !empty( $wgEnableRobotsTxtExt ) ) {
-	require(__DIR__ . '/wikia-robots-txt.php');
+	require( __DIR__ . '/wikia-robots-txt.php' );
 	exit;
 }
 

--- a/wikia-robots-txt.php
+++ b/wikia-robots-txt.php
@@ -21,7 +21,7 @@ if ( !$allowRobots ) {
 	// Special pages
 	$robots->disallowSpecialPages();
 
-	$robots->allowSpecialPage( 'Allpages' );
+	//$robots->allowSpecialPage( 'Allpages' ); // TODO: SEO-64
 	$robots->allowSpecialPage( 'CreateNewWiki' );
 	$robots->allowSpecialPage( 'Forum' );
 	$robots->allowSpecialPage( 'Sitemap' );

--- a/wikia-robots-txt.php
+++ b/wikia-robots-txt.php
@@ -3,16 +3,15 @@
 if ( !defined( 'MW_NO_SETUP' ) ) {
 	define( 'MW_NO_SETUP', 1 );
 }
+
 require_once( __DIR__ . '/includes/WebStart.php' );
 require_once( __DIR__ . '/includes/Setup.php' );
 
-if ( empty( $wgEnableRobotsTxtExt ) ) {
-	exit;
-}
+$allowRobots = ( $wgWikiaEnvironment === WIKIA_ENV_PROD || $wgRequest->getBool( 'forcerobots' ) );
 
 $robots = new RobotsTxt();
 
-if ( !empty( $_SERVER['HTTP_X_STAGING'] ) ) {
+if ( !$allowRobots ) {
 	// No crawling preview, verify, sandboxes, showcase, etc
 	$robots->disallowPath( '/' );
 } else {

--- a/wikia-robots-txt.php
+++ b/wikia-robots-txt.php
@@ -1,0 +1,80 @@
+<?php
+
+if ( !defined( 'MW_NO_SETUP' ) ) {
+	define( 'MW_NO_SETUP', 1 );
+}
+require_once( __DIR__ . '/includes/WebStart.php' );
+require_once( __DIR__ . '/includes/Setup.php' );
+
+if ( empty( $wgEnableRobotsTxtExt ) ) {
+	exit;
+}
+
+$robots = new RobotsTxt();
+
+if ( !empty( $_SERVER['HTTP_X_STAGING'] ) ) {
+	// No crawling preview, verify, sandboxes, showcase, etc
+	$robots->disallowPath( '/' );
+} else {
+	// Sitemap
+	$robots->setSitemap( sprintf( 'http://%s/sitemap-index.xml', $_SERVER['SERVER_NAME'] ) );
+
+	// Special pages
+	$robots->disallowSpecialPages();
+
+	$robots->allowSpecialPage( 'Allpages' );
+	$robots->allowSpecialPage( 'CreateNewWiki' );
+	$robots->allowSpecialPage( 'Forum' );
+	$robots->allowSpecialPage( 'Sitemap' );
+	$robots->allowSpecialPage( 'Videos' );
+
+	// Params
+	$robots->disallowParam( 'action' );
+	$robots->disallowParam( 'feed' );
+	$robots->disallowParam( 'printable' );
+	$robots->disallowParam( 'useskin' );
+	$robots->disallowParam( 'uselang' );
+
+	// Nasty robots
+	$robots->blockRobot( 'IsraBot' );
+	$robots->blockRobot( 'Orthogaffe' );
+	$robots->blockRobot( 'UbiCrawler' );
+	$robots->blockRobot( 'DOC' );
+	$robots->blockRobot( 'Zao' );
+	$robots->blockRobot( 'sitecheck.internetseer.com' );
+	$robots->blockRobot( 'Zealbot' );
+	$robots->blockRobot( 'MSIECrawler' );
+	$robots->blockRobot( 'SiteSnagger' );
+	$robots->blockRobot( 'WebStripper' );
+	$robots->blockRobot( 'WebCopier' );
+	$robots->blockRobot( 'Fetch' );
+	$robots->blockRobot( 'Offline Explorer' );
+	$robots->blockRobot( 'Teleport' );
+	$robots->blockRobot( 'TeleportPro' );
+	$robots->blockRobot( 'WebZIP' );
+	$robots->blockRobot( 'linko' );
+	$robots->blockRobot( 'HTTrack' );
+	$robots->blockRobot( 'Microsoft.URL.Control' );
+	$robots->blockRobot( 'Xenu' );
+	$robots->blockRobot( 'larbin' );
+	$robots->blockRobot( 'libwww' );
+	$robots->blockRobot( 'ZyBORG' );
+	$robots->blockRobot( 'Download Ninja' );
+	$robots->blockRobot( 'sitebot' );
+	$robots->blockRobot( 'wget' );
+	$robots->blockRobot( 'k2spider' );
+	$robots->blockRobot( 'NPBot' );
+	$robots->blockRobot( 'WebReaper' );
+
+	// Deprecated items, probably we should delete them
+	$robots->disallowPath( '/w/' );
+	$robots->disallowPath( '/trap/' );
+	$robots->disallowPath( '/dbdumps/' );
+	$robots->disallowPath( '/wikistats/' );
+}
+
+foreach ( $robots->getHeaders() as $header ) {
+	header( $header );
+}
+
+echo join( PHP_EOL, $robots->getContents() ) . PHP_EOL;


### PR DESCRIPTION
Robots.txt is currently generated by redirect-robots.php file in the main directory. It has a few problems:
- A separate section for Googlebot
- Using a NoIndex keyword, which according to the Google docs is not recognized by the bot
- It's quite hard to mainain
- It uses wildcards when they are not necessary (at the ends of lines). Remember some robots may not understand wildcards
- It allows crawling special pages by their English and local wiki language names, but not mixed ones (Spezial:Random)
- You cannot test robots on devboxes or sandboxes because the code always serves a "Disallow everything" rule on those.

This PR basically fixes all the above by supplying a RobotsTxt class with a clean API (and a unit test) and a new version of the entry PHP script: wikia-robots-txt.php, which can be used to add more special pages to white list or to block more bots.

I want wikia-robots-txt.php to eventually replace redirect-robots.php (once we prove there's no negative impact of the changes proposed).
