### PR TITLE
(CE-2670) Properly escape user name in remove avatar link attribute

### DIFF
--- a/extensions/wikia/UserProfilePageV3/UserIdentityBox.class.php
+++ b/extensions/wikia/UserProfilePageV3/UserIdentityBox.class.php
@@ -121,7 +121,7 @@ class UserIdentityBox {
 		}
 
 		// Sanitize data to prevent XSS (VE-720)
-		$keysToSanitize = [ 'gender', 'location', 'occupation', 'realName', 'twitter', 'fbPage', 'website' ];
+		$keysToSanitize = [ 'gender', 'location', 'name', 'occupation', 'realName', 'twitter', 'fbPage', 'website' ];
 		foreach ( $keysToSanitize as $key ) {
 			if ( !empty( $data[ $key ] ) ) {
 				$data[ $key ] = htmlspecialchars( strip_tags( $data[ $key ] ), ENT_QUOTES );

--- a/extensions/wikia/UserProfilePageV3/templates/UserProfilePage_renderUserIdentityBox.php
+++ b/extensions/wikia/UserProfilePageV3/templates/UserProfilePage_renderUserIdentityBox.php
@@ -13,7 +13,7 @@
 			<?php if ( $canRemoveAvatar ): ?>
 				<span>
 					<img src="<?= $wgBlankImgUrl ?>" class="sprite trash">
-					<a id="UserAvatarRemove" data-name="<?= Sanitizer::encodeAttribute( $user['name'] ); ?>" href="#" data-confirm="<?= wfMessage( 'user-identity-remove-confirmation' )->escaped(); ?>">
+					<a id="UserAvatarRemove" data-name="<?= $user['name']; ?>" href="#" data-confirm="<?= wfMessage( 'user-identity-remove-confirmation' )->escaped(); ?>">
 						<?= wfMessage( 'user-identity-box-delete-avatar' )->escaped(); ?>
 					</a>
 				</span>
@@ -23,7 +23,7 @@
 
 	<div class="masthead-info">
 		<hgroup>
-			<h1 itemprop="name"><?= htmlspecialchars( $user['name'] ); ?></h1>
+			<h1 itemprop="name"><?= $user['name']; ?></h1>
 			<? if ( !empty( $user['realName'] ) ): ?>
 				<h2><?= wfMessage( 'user-identity-box-aka-label', $user['realName'] )->plain(); ?></h2>
 			<? endif; ?>

--- a/extensions/wikia/UserProfilePageV3/templates/UserProfilePage_renderUserIdentityBox.php
+++ b/extensions/wikia/UserProfilePageV3/templates/UserProfilePage_renderUserIdentityBox.php
@@ -13,7 +13,7 @@
 			<?php if ( $canRemoveAvatar ): ?>
 				<span>
 					<img src="<?= $wgBlankImgUrl ?>" class="sprite trash">
-					<a id="UserAvatarRemove" data-name="<?= $user['name']; ?>" href="#" data-confirm="<?= wfMessage( 'user-identity-remove-confirmation' )->escaped(); ?>">
+					<a id="UserAvatarRemove" data-name="<?= Sanitizer::encodeAttribute( $user['name'] ); ?>" href="#" data-confirm="<?= wfMessage( 'user-identity-remove-confirmation' )->escaped(); ?>">
 						<?= wfMessage( 'user-identity-box-delete-avatar' )->escaped(); ?>
 					</a>
 				</span>


### PR DESCRIPTION
Properly escape user name in remove avatar link attribute in the user profile
boxes.

/cc @jsutterfield 
