### PR TITLE
CE-2676: Fix loading scripts with the same name

### DIFF
--- a/includes/wikia/resourceloader/ResourceLoaderCustomWikiModule.class.php
+++ b/includes/wikia/resourceloader/ResourceLoaderCustomWikiModule.class.php
@@ -18,7 +18,7 @@ class ResourceLoaderCustomWikiModule extends ResourceLoaderGlobalWikiModule {
 
 		if ( $this->type ) {
 			foreach ($this->articles as $article) {
-				$pageKey = $article['title'];
+				$pageKey = isset( $article['originalName'] ) ? $article['originalName'] : $article['title'];
 				$type = isset($article['type']) ? $article['type'] : $this->type;
 				$pageInfo = array(
 					'type' => $type,


### PR DESCRIPTION
If we want to import pages with the same name (via `importArticles` method), but from different subdomains ie.

from local (Mediawiki:Script.js) 
and external (external:subdomain:Mediawiki:Script.js) 

the last overwrites the first.
