### PR TITLE
Ce 2672 unittest replace with last approved

### DIFF
--- a/extensions/wikia/ContentReview/ContentReview.hooks.php
+++ b/extensions/wikia/ContentReview/ContentReview.hooks.php
@@ -83,30 +83,9 @@ class Hooks {
 	 * @return bool
 	 */
 	public static function onRawPageViewBeforeOutput( \RawAction $rawAction, &$text ) {
-		global $wgCityId, $wgJsMimeType;
-
 		$title = $rawAction->getTitle();
-
-		if ( $title->isJsPage() || $rawAction->getContentType() == $wgJsMimeType ) {
-			$pageId = $title->getArticleID();
-			$latestRevId = $title->getLatestRevID();
-
-			$latestReviewedRev = ( new CurrentRevisionModel() )->getLatestReviewedRevision( $wgCityId, $pageId );
-			$helper = new Helper();
-
-			if ( $latestReviewedRev['revision_id'] != $latestRevId
-				&& !$helper->isContentReviewTestModeEnabled()
-			) {
-				$revision = \Revision::newFromId( $latestReviewedRev['revision_id'] );
-
-				if ( $revision ) {
-					$text = $revision->getRawText();
-				} else {
-					$text = '';
-				}
-			}
-		}
-
+		$helper = new Helper();
+		$helper->replaceWithLastApproved( $title, $rawAction->getContentType(), $text );
 		return true;
 	}
 

--- a/extensions/wikia/ContentReview/tests/ContentReviewHelperTest.php
+++ b/extensions/wikia/ContentReview/tests/ContentReviewHelperTest.php
@@ -1,0 +1,87 @@
+<?php
+
+class ContentReviewHelperTest extends WikiaBaseTest {
+	public function setUp() {
+		$this->setupFile = __DIR__ . '/../ContentReview.setup.php';
+		parent::setUp();
+	}
+
+	/**
+	 * @dataProvider replaceWithLastApprovedRevisionProvider
+	 * Test for \Wikia\ContentReview\Hooks::onRawPageViewBeforeOutput hook
+	 */
+	public function testReplaceWithLastApprovedRevision( $params, $textExpected, $message ) {
+
+		/* @var \Title $titleMock */
+		$titleMock = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'getArticleID', 'getLatestRevID', 'isJsPage' ] )
+			->getMock();
+		$titleMock->expects( $this->once() )
+			->method( 'getArticleID' )
+			->will( $this->returnValue( $params['pageId'] ) );
+		$titleMock->expects( $this->once() )
+			->method( 'getLatestRevID' )
+			->will( $this->returnValue( $params['latestRevId'] ) );
+		$titleMock->expects( $this->once() )
+			->method( 'isJsPage' )
+			->will( $this->returnValue( $params['isJsPage'] ) );
+
+		/* @var \Wikia\ContentReview\Models\CurrentRevisionModel $currentRevisionModelMock */
+		$currentRevisionModelMock = $this->getMockBuilder( '\Wikia\ContentReview\Models\CurrentRevisionModel' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'getLatestReviewedRevision' ] )
+			->getMock();
+		$currentRevisionModelMock->expects( $this->once() )
+			->method( 'getLatestReviewedRevision' )
+			->will( $this->returnValue( $params['latestApprovedRevData'] ) );
+
+		/* @var \Revision $revisionMock */
+		$revisionMock = $this->getMockBuilder( '\Revision' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'getRawText' ] )
+			->getMock();
+		$revisionMock->expects( $this->once() )
+			->method( 'getRawText' )
+			->will( $this->returnValue( $params['latestApprovedRevText'] ) );
+
+		/* @var \Wikia\ContentReview\Helper $helperMock */
+		$helperMock = $this->getMockBuilder( '\Wikia\ContentReview\Helper' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'getCurrentRevisionModel', 'getRevisionById', 'isContentReviewTestModeEnabled' ] )
+			->getMock();
+		$helperMock->expects( $this->once() )
+			->method( 'getCurrentRevisionModel' )
+			->will( $this->returnValue( $currentRevisionModelMock ) );
+		$helperMock->expects( $this->once() )
+			->method( 'isContentReviewTestModeEnabled' )
+			->will( $this->returnValue( $params['isContentReviewTestModeEnabled'] ) );
+		$helperMock->expects( $this->once() )
+			->method( 'getRevisionById' )
+			->will( $this->returnValue( $revisionMock ) );
+
+		$helperMock->replaceWithLastApproved( $titleMock, $params['contentType'], $params['text'] );
+
+		$this->assertEquals( $textExpected, $params['text'], $message );
+	}
+
+	public function replaceWithLastApprovedRevisionProvider() {
+		return [
+			[
+				[
+					'pageId' => 123,
+					'latestRevId' => 567,
+					'isJsPage' => true,
+					'contentType' => 'sometype',
+					'latestApprovedRevData' => [
+						'revision_id' => 123
+					],
+					'latestApprovedRevText' => 'revision text',
+					'isContentReviewTestModeEnabled' => false,
+				],
+				'revision text',
+				'Text replaced',
+			],
+		];
+	}
+}


### PR DESCRIPTION
Unit Test for functionality of hook \Wikia\ContentReview\Hooks::replaceWithLastApproved

to make it testable functionality moved to helper method: replaceWithLastApproved

https://wikia-inc.atlassian.net/browse/CE-2672
@Wikia/community-engineering 
