### PR TITLE
ADEN-2438 fix hub verticals

### DIFF
--- a/extensions/wikia/AdEngine/js/AdLogicPageParams.js
+++ b/extensions/wikia/AdEngine/js/AdLogicPageParams.js
@@ -23,16 +23,6 @@ define('ext.wikia.adEngine.adLogicPageParams', [
 		context = adContext.getContext();
 	}
 
-	function getDartHubName() {
-		if (context.targeting.wikiVertical === 'Entertainment') {
-			return 'ent';
-		}
-		if (context.targeting.wikiVertical === 'Gaming') {
-			return 'gaming';
-		}
-		return 'life';
-	}
-
 	function getDomain() {
 		var lhost, pieces, sld = '', np;
 		lhost = hostname.toLowerCase();
@@ -220,6 +210,7 @@ define('ext.wikia.adEngine.adLogicPageParams', [
 			zone2,
 			params,
 			targeting = context.targeting,
+			mappedVertical = getVerticalName(targeting),
 			pvs = pvCounter.get();
 
 		options = options || {};
@@ -228,10 +219,10 @@ define('ext.wikia.adEngine.adLogicPageParams', [
 
 		if (targeting.pageIsHub) {
 			site = 'hub';
-			zone1 = '_' + getDartHubName() + '_hub';
+			zone1 = '_' + mappedVertical + '_hub';
 			zone2 = 'hub';
 		} else {
-			site = getVerticalName(targeting);
+			site = mappedVertical;
 			zone1 = dbName;
 			zone2 = targeting.pageType || 'article';
 		}

--- a/extensions/wikia/AdEngine/js/spec/AdLogicPageParams.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/AdLogicPageParams.spec.js
@@ -284,13 +284,14 @@ describe('AdLogicPageParams', function () {
 
 // Very specific tests for hubs:
 
-	it('getPageLevelParams Hub page: video games', function () {
+	it('getPageLevelParams Hub page: games', function () {
 		var params = getParams({
 			pageIsHub: true,
 			wikiCategory: 'wikia',
 			wikiDbName: 'wikiaglobal',
 			wikiLanguage: 'en',
-			wikiVertical: 'Gaming'
+			wikiVertical: 'games',
+			mappedVerticalName: 'gaming'
 		}, {
 			hostname: 'www.wikia.com'
 		});
@@ -303,13 +304,14 @@ describe('AdLogicPageParams', function () {
 		expect(params.lang).toBe('en');
 	});
 
-	it('getUrl Hub page: entertainment', function () {
+	it('getUrl Hub page: TV', function () {
 		var params = getParams({
 			pageIsHub: true,
 			wikiCategory: 'wikia',
 			wikiDbName: 'wikiaglobal',
 			wikiLanguage: 'en',
-			wikiVertical: 'Entertainment'
+			wikiVertical: 'tv',
+			mappedVerticalName: 'ent'
 		}, {
 			hostname: 'www.wikia.com'
 		});
@@ -328,7 +330,8 @@ describe('AdLogicPageParams', function () {
 			wikiCategory: 'wikia',
 			wikiDbName: 'wikiaglobal',
 			wikiLanguage: 'en',
-			wikiVertical: 'Lifestyle'
+			wikiVertical: 'lifestyle',
+			mappedVerticalName: 'life'
 		}, {
 			hostname: 'www.wikia.com'
 		});

--- a/extensions/wikia/AdEngine/js/spec/utils/cssTweaker.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/utils/cssTweaker.spec.js
@@ -32,6 +32,6 @@ describe('ext.wikia.adEngine.utils.cssTweaker', function () {
 	it('Initialization should prepare googletag object and configure pubads', function () {
 		cssTweaker.copyStyles('source', 'destination');
 
-		expect(mocks.destination.style.cssText).toBe('background-color: rgb(255, 255, 255); display: inline;');
+		expect(mocks.destination.style.cssText).toBe('background-color: rgb(255, 255, 255); display: inline; ');
 	});
 });

--- a/extensions/wikia/AdEngine/js/spec/utils/cssTweaker.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/utils/cssTweaker.spec.js
@@ -13,7 +13,6 @@ describe('ext.wikia.adEngine.utils.cssTweaker', function () {
 
 	beforeEach(function () {
 		mocks.destination = document.createElement('div');
-		mocks.destination.style = {};
 		mocks.source = document.createElement('div');
 		mocks.source.style.cssText = 'background-color: rgb(255, 255, 255); display: inline; ';
 
@@ -33,6 +32,6 @@ describe('ext.wikia.adEngine.utils.cssTweaker', function () {
 	it('Initialization should prepare googletag object and configure pubads', function () {
 		cssTweaker.copyStyles('source', 'destination');
 
-		expect(mocks.destination.style.cssText).toBe('background-color: rgb(255, 255, 255); display: inline; ');
+		expect(mocks.destination.style.cssText).toBe('background-color: rgb(255, 255, 255); display: inline;');
 	});
 });


### PR DESCRIPTION
After refactoring AdEng code and forcing our slot paths to have only one out of three verticals: ent, gaming and life. We found an issues with hub pages and slot paths there. The changes below fixes it and cleans the code.

Also, I removed one line in a unit test which was failing on my local machine.
