### PR TITLE
Preference Scope

### DIFF
--- a/lib/Wikia/src/DependencyInjection/InjectorInitializer.php
+++ b/lib/Wikia/src/DependencyInjection/InjectorInitializer.php
@@ -4,6 +4,7 @@ namespace Wikia\DependencyInjection;
 
 use Doctrine\Common\Cache\CacheProvider;
 use Wikia\Service\Gateway\ConsulUrlProviderModule;
+use Wikia\Service\User\Preferences\Migration\PreferenceMigrationModule;
 use Wikia\Service\User\Preferences\PreferenceModule;
 use Wikia\Service\User\Attributes\AttributesModule;
 use Wikia\Service\User\Auth\AuthModule;
@@ -14,6 +15,7 @@ class InjectorInitializer {
 			(new InjectorBuilder())
 				->withCache($cacheProvider)
 				->addModule(new PreferenceModule())
+				->addModule(new PreferenceMigrationModule())
 				->addModule(new AttributesModule())
 				->addModule(new AuthModule())
 				->addModule(new ConsulUrlProviderModule())

--- a/lib/Wikia/src/Service/User/Preferences/Migration/PreferenceMigrationModule.php
+++ b/lib/Wikia/src/Service/User/Preferences/Migration/PreferenceMigrationModule.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Wikia\Service\User\Preferences\Migration;
+
+use Wikia\DependencyInjection\InjectorBuilder;
+use Wikia\DependencyInjection\Module;
+
+class PreferenceMigrationModule implements Module {
+
+	public function configure(InjectorBuilder $builder) {
+		global $wgGlobalUserPreferenceWhiteList, $wgLocalUserPreferenceWhiteList;
+
+		$builder
+			->bind(PreferenceScopeService::GLOBAL_SCOPE_PREFS)->to($wgGlobalUserPreferenceWhiteList)
+			->bind(PreferenceScopeService::LOCAL_SCOPE_PREFS)->to($wgLocalUserPreferenceWhiteList);
+	}
+}

--- a/lib/Wikia/src/Service/User/Preferences/Migration/PreferenceScopeService.php
+++ b/lib/Wikia/src/Service/User/Preferences/Migration/PreferenceScopeService.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Wikia\Service\User\Preferences\Migration;
+
+class PreferenceScopeService {
+
+	const GLOBAL_SCOPE_PREFS = 'global_scope_preferences';
+	const LOCAL_SCOPE_PREFS = 'local_scope_preferences';
+
+	/** @var array */
+	private $globalPreferenceLiterals = [];
+
+	/** @var string */
+	private $globalPreferenceRegex;
+
+	/** @var string */
+	private $localPreferenceRegex;
+
+	/**
+	 * @Inject({
+	 *    Wikia\Service\User\Preferences\Migration\PreferenceScopeService::GLOBAL_SCOPE_PREFS,
+	 *    Wikia\Service\User\Preferences\Migration\PreferenceScopeService::LOCAL_SCOPE_PREFS})
+	 * @param array $globalPreferences
+	 * @param array $localPreferences
+	 */
+	public function __construct(array $globalPreferences, array $localPreferences) {
+		$this->globalPreferenceLiterals = $globalPreferences['literals'];
+		$this->globalPreferenceRegex = '/'.implode('|', $globalPreferences['regexes']).'/';
+		$this->localPreferenceRegex = '/'.implode('|', $localPreferences['regexes']).'/';
+	}
+
+	public function splitLocalPreference($option) {
+		if (preg_match('/(.*?)-([0-9]+)$/', $option, $matches) && count($matches) == 3) {
+			return [$matches[1], $matches[2]];
+		}
+
+		return [null, null];
+	}
+
+	public function isLocalPreference($option) {
+		return preg_match($this->localPreferenceRegex, $option) > 0;
+	}
+
+	public function isGlobalPreference($option) {
+		if (in_array($option, $this->globalPreferenceLiterals)) {
+			return true;
+		}
+
+		return preg_match($this->globalPreferenceRegex, $option) > 0;
+	}
+}


### PR DESCRIPTION
@Wikia/services-team 
small mw service to test if a preference is local or global. I'll add some tests later, but since @ArturKlajnerok and I both need this functionality for our current tasks, it's probably best we just merge this now

Here is the output from a sample run with the current whitelist in MW:

``` php
        $scope = Injector::getInjector()->get(PreferenceScopeService::class);
        $a = $scope->isGlobalPreference('foo'); // false
        $b = $scope->isGlobalPreference('language'); // true
        $c = $scope->isGlobalPreference('oasis-toolbar-contents'); // true
        $d = $scope->isLocalPreference('bar'); // false
        $e = $scope->isLocalPreference('adoptionmails-12345'); // true
        list($name, $wikiId) = $scope->splitLocalPreference('adoptionmails-12345'); // ['adoptionmails', 12345]
```
