### PR TITLE
PLATFORM-1476: WikiFactory AJAX entry point for changing variables is vulnerable to CSRF

### DIFF
--- a/extensions/wikia/WikiFactory/SpecialWikiFactory_ajax.php
+++ b/extensions/wikia/WikiFactory/SpecialWikiFactory_ajax.php
@@ -325,6 +325,9 @@ function axWFactoryDomainCRUD($type="add") {
     $city_id = $wgRequest->getVal("cityid");
     $reason  = $wgRequest->getVal("reason");
 
+	// this request needs to be a POST and has a valid token passed (PLATFORM-1476)
+	axWFactoryValidateRequest( $wgRequest, $wgUser, __METHOD__ );
+
     if ( !$wgUser->isAllowed( 'wikifactory' ) ) {
         $wgOut->readOnlyPage(); #--- later change to something reasonable
         return;
@@ -467,6 +470,9 @@ function axWFactoryClearCache()
     $city_id = $wgRequest->getVal("cityid");
     $iError = 0;
     $sError = "";
+
+	// this request needs to be a POST and has a valid token passed (PLATFORM-1476)
+	axWFactoryValidateRequest( $wgRequest, $wgUser, __METHOD__ );
 
     if ( !$wgUser->isAllowed( 'wikifactory' ) ) {
         #--- no permission, do nothing
@@ -727,6 +733,9 @@ function axWFactoryDomainQuery() {
  */
 function axWFactoryFilterVariables() {
 	global $wgRequest, $wgUser;
+
+	// this request needs to be a POST and has a valid token passed (PLATFORM-1476)
+	axWFactoryValidateRequest( $wgRequest, $wgUser, __METHOD__ );
 
 	if ( !$wgUser->isAllowed('wikifactory') ) {
 		return '';

--- a/extensions/wikia/WikiFactory/SpecialWikiFactory_ajax.php
+++ b/extensions/wikia/WikiFactory/SpecialWikiFactory_ajax.php
@@ -54,7 +54,7 @@ function axWFactoryValidateRequest( WebRequest $request, User $user, $method ) {
 		throw new WikiFactoryInvalidRequestException( $method );
 	}
 
-	if ( $user->matchEditToken( $request->getVal( 'token' ) ) ) {
+	if ( !$user->matchEditToken( $request->getVal( 'token' ) ) ) {
 		throw new WikiFactoryInvalidTokenException( $method );
 	}
 }

--- a/extensions/wikia/WikiFactory/SpecialWikiFactory_ajax.php
+++ b/extensions/wikia/WikiFactory/SpecialWikiFactory_ajax.php
@@ -14,6 +14,50 @@ if ( !defined( 'MEDIAWIKI' ) ) {
     exit( 1 ) ;
 }
 
+/**
+ * Exceptions to be thrown by AJAX request handlers
+ *
+ * @see PLATFORM-1476
+ *
+ * - WikiFactoryInvalidRequestException for requests that should be sent as POST
+ * - WikiFactoryInvalidTokenException for requests with invalid token
+ */
+abstract class WikiFactoryRequestException extends WikiaException {}
+
+class WikiFactoryInvalidRequestException extends WikiFactoryRequestException {
+	function __construct( $message ) {
+		parent::__construct( 'POST request should be made to ' . $message );
+	}
+}
+
+class WikiFactoryInvalidTokenException extends WikiFactoryRequestException {
+	function __construct( $message ) {
+		parent::__construct( 'Token check failed for ' . $message );
+	}
+}
+
+/**
+ * Check given request and make sure that:
+ *
+ *  - it's a POST request (throws WikiFactoryInvalidRequestException otherwise)
+ *  - it has a valid token (throws WikiFactoryInvalidTokenException otherwise)
+ *
+ * @see PLATFORM-1476
+ *
+ * @param WebRequest $request
+ * @param User $user
+ * @param string $method
+ * @throws WikiFactoryRequestException
+ */
+function axWFactoryValidateRequest( WebRequest $request, User $user, $method ) {
+	if ( !$request->wasPosted() ) {
+		throw new WikiFactoryInvalidRequestException( $method );
+	}
+
+	if ( $user->matchEditToken( $request->getVal( 'token' ) ) ) {
+		throw new WikiFactoryInvalidTokenException( $method );
+	}
+}
 
 ############################## Ajax methods ##################################
 
@@ -29,6 +73,9 @@ if ( !defined( 'MEDIAWIKI' ) ) {
  */
 function axWFactoryTagCheck() {
 	global $wgRequest, $wgUser;
+
+	// this request needs to be a POST and has a valid token passed (PLATFORM-1476)
+	axWFactoryValidateRequest( $wgRequest, $wgUser, __METHOD__ );
 
 	if ( !$wgUser->isAllowed( 'wikifactory' ) ) {
 		return;
@@ -182,6 +229,9 @@ function axWFactoryChangeVariable() {
  */
 function axWFactorySubmitChangeVariable() {
 	global $wgRequest, $wgUser, $wgOut;
+
+	// this request needs to be a POST and has a valid token passed (PLATFORM-1476)
+	axWFactoryValidateRequest( $wgRequest, $wgUser, __METHOD__ );
 
 	if ( !$wgUser->isAllowed( 'wikifactory' ) ) {
 		$wgOut->readOnlyPage(); #--- FIXME: later change to something reasonable
@@ -465,6 +515,9 @@ function axWFactorySaveVariable() {
 	$error     = 0;
 	$return    = "";
 
+	// this request needs to be a POST and has a valid token passed (PLATFORM-1476)
+	axWFactoryValidateRequest( $wgRequest, $wgUser, __METHOD__ );
+
 	if ( ! $wgUser->isAllowed('wikifactory') ) {
 		$error++;
 		$return = Wikia::errormsg( "You are not allowed to change variable value" );
@@ -712,6 +765,9 @@ function axWFactoryRemoveVariable( ) {
 
 	$error     = 0;
 	$return    = "";
+
+	// this request needs to be a POST and has a valid token passed (PLATFORM-1476)
+	axWFactoryValidateRequest( $wgRequest, $wgUser, __METHOD__ );
 
 	if ( ! $wgUser->isAllowed('wikifactory') ) {
 		$error++;

--- a/extensions/wikia/WikiFactory/templates/form.tmpl.php
+++ b/extensions/wikia/WikiFactory/templates/form.tmpl.php
@@ -127,6 +127,7 @@ $Factory.Variable = {};
 
 var ajaxpath = wgServer + wgScript;
 $Factory.city_id = <?php echo $wiki->city_id ?>;
+$Factory.token = <?= Xml::encodeJsVar( F::app()->wg->User->getEditToken() ) ?>;
 
 
 $Factory.VariableCallback = {
@@ -192,6 +193,8 @@ $Factory.BusyCache = function (state) {
 $Factory.Domain.CRUD = function(mode, domain, addparams) {
 	$Factory.Busy(1);
 	var params = "&cityid=" + $Factory.city_id + "&domain=" + domain + addparams;
+	params += "&token=" + encodeURIComponent($Factory.token);
+
 	$.ajax({
     	type:"POST",
     	dataType: "json",
@@ -394,6 +397,7 @@ $Factory.Variable.submitChangeVariable = function ( e, data ) {
 
 	// For restoring to the original form afterwards.
     values += "&wiki=" + $Factory.city_id;
+    values += "&token=" + encodeURIComponent($Factory.token);
 
 	$.ajax({
     	type:"POST",
@@ -421,6 +425,8 @@ $Factory.Variable.filter = function ( e ) {
     values += "&wiki=" + $Factory.city_id;
 	values += "&string=" + $( "#wfOnlyWithString" ).val();
 
+	values += "&token=" + encodeURIComponent($Factory.token);
+
     $.ajax({
     	type:"POST",
     	dataType: "json",
@@ -442,6 +448,9 @@ $Factory.Variable.filter = function ( e ) {
 $Factory.Variable.clear = function ( e ) {
     $Factory.BusyCache(1);
     var params = "&cityid=" + $Factory.city_id;
+
+	params += "&token=" + encodeURIComponent($Factory.token);
+
 	$.ajax({
     	type:"POST",
     	dataType: "json",
@@ -462,6 +471,8 @@ $Factory.Variable.post = function (form, mode) {
 
    $Factory.Busy(1);
    var params = $("#" + form).serialize();
+
+	params += "&token=" + encodeURIComponent($Factory.token);
 
 	$.ajax({
 		type:"POST",
@@ -506,7 +517,7 @@ $Factory.Variable.tagCheck = function ( submitType ) {
 	 	  	type:"POST",
 	 	  	dataType: "json",
 	 	  	url: ajaxpath,
-	 	  	data: "action=ajax&rs=axWFactoryTagCheck&tagName="+tagName,
+			data: "action=ajax&rs=axWFactoryTagCheck&tagName="+tagName+"&token="+encodeURIComponent($Factory.token),
 			success: function( oResponse ) {
 				var data = oResponse;
 				if( data.wikiCount == 0 ) {


### PR DESCRIPTION
Introduce `axWFactoryValidateRequest` helper that asserts:
- that the request was posted
- that the request has a valid edit token set

If not, throw an exception and return HTTP 500 response code.

@michalroszka / @Grunny 
