### PR TITLE
[internal] PLATFORM-1384 Don't try to call FacebookClient code if the extension is not enabled

### DIFF
--- a/includes/specials/SpecialUserlogout.php
+++ b/includes/specials/SpecialUserlogout.php
@@ -44,8 +44,11 @@ class SpecialUserlogout extends UnlistedSpecialPage {
 			throw new HttpError( 400, wfMessage( 'suspicious-userlogout' ), wfMessage( 'loginerror' ) );
 		}
 
-		// Clean up any facebook cookies/data
-		FacebookClient::getInstance()->logout();
+		// Some communities (notably uncyclopedia) do not have FacebookClient enabled
+		if ( F::app()->wg->EnableFacebookClientExt ) {
+			// Clean up any facebook cookies/data
+			FacebookClient::getInstance()->logout();
+		}
 
 		$this->setHeaders();
 		$this->outputHeader();


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-1384 - fix broken logout on internal

Backporting #7604 for internal

@michalroszka / @wladekb 
