### PR TITLE
(CE-2555) Re-enable editing of all MediaWiki CSS pages

### DIFF
--- a/extensions/3rdparty/Verbatim/Verbatim.php
+++ b/extensions/3rdparty/Verbatim/Verbatim.php
@@ -27,7 +27,7 @@ function renderVerbatim( $input ) {
 			&& in_array( $formattedInput, $wgEditInterfaceWhitelist ) )
 		|| ( !empty( $wgVerbatimBlacklist )
 			&& in_array( $formattedInput, $wgVerbatimBlacklist ) )
-		|| preg_match( '!\.(js)$!u', $formattedInput )
+		|| preg_match( '!\.(?:css|js)$!u', $formattedInput )
 	) {
 		// Do not allow transclusion into Verbatim tags
 		return '';

--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -2298,6 +2298,7 @@ class Wikia {
 
 		// In this NS, editinterface applies only to white listed pages
 		if ( in_array( $title->getDBKey(), $wgEditInterfaceWhitelist )
+			|| $title->isCssPage()
 			|| ( !empty( $wgEnableContentReviewExt ) && $title->isJsPage() )
 		) {
 			return $wgUser->isAllowed('editinterface');


### PR DESCRIPTION
Re-enable editing of all MediaWiki CSS pages, and blacklist CSS pages
from Verbatim.

/cc @Wikia/community-engineering 
