### PR TITLE
remove hacks from AssetsManager config

### DIFF
--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -1654,16 +1654,6 @@ $config['wikia_photo_gallery_mosaic_scss'] = [
 	]
 ];
 
-// ImageDrop
-$config['imagedrop_js'] = array(
-	'skin' => array( 'monobook', 'oasis' ),
-	'type' => AssetsManager::TYPE_JS,
-	'assets' => array(
-		'//extensions/wikia/hacks/ImageDrop/js/ImageDrop.js',
-		'//resources/wikia/libraries/jquery/filedrop/jquery.filedrop.js'
-	)
-);
-
 $config['imagedrop_scss'] = array(
 	'type' => AssetsManager::TYPE_SCSS,
 	'skin' => array( 'monobook', 'oasis' ),
@@ -1690,16 +1680,6 @@ $config['analytics_bluekai_js'] = array(
 		'//extensions/wikia/AdEngine/js/AdLogicPageParams.js',
 		'//extensions/wikia/AdEngine/js/AdLogicPageViewCounter.js',
 	]
-);
-
-/** WikiMap Extension **/
-$config['wiki_map_js'] = array(
-	'type' => AssetsManager::TYPE_JS,
-	'assets' => array(
-		'//extensions/wikia/hacks/WikiMap/js/d3.v2.js',
-		'//extensions/wikia/hacks/WikiMap/js/jquery.xcolor.js',
-		'//extensions/wikia/hacks/WikiMap/js/WikiMapIndexContent.js'
-	)
 );
 
 /* Special:Leaderboard in AchievementsII extensions */


### PR DESCRIPTION
Remove leftovers from https://github.com/Wikia/app/pull/7925

```
Linting /usr/wikia/source/wiki/extensions/wikia/AssetsManager/config.php...
1662: extensions/wikia/hacks/ImageDrop/js/ImageDrop.js can not be found
        '//extensions/wikia/hacks/ImageDrop/js/ImageDrop.js',
1699: extensions/wikia/hacks/WikiMap/js/d3.v2.js can not be found
        '//extensions/wikia/hacks/WikiMap/js/d3.v2.js',
1700: extensions/wikia/hacks/WikiMap/js/jquery.xcolor.js can not be found
        '//extensions/wikia/hacks/WikiMap/js/jquery.xcolor.js',
1701: extensions/wikia/hacks/WikiMap/js/WikiMapIndexContent.js can not be found
        '//extensions/wikia/hacks/WikiMap/js/WikiMapIndexContent.js'
```

@wladekb / @hakubo / @michalroszka 
