### PR TITLE
Fix number of wikis with curated content

### DIFF
--- a/extensions/wikia/CuratedContent/CuratedContentController.class.php
+++ b/extensions/wikia/CuratedContent/CuratedContentController.class.php
@@ -593,7 +593,7 @@ class CuratedContentController extends WikiaController {
 
 	public function getWikisWithCuratedContent() {
 		$wikisList = WikiFactory::getListOfWikisWithVar(
-			self::CURATED_CONTENT_WG_VAR_ID_PROD, 'array', '=', []
+			self::CURATED_CONTENT_WG_VAR_ID_PROD, 'array', '!=', []
 		);
 
 		$this->response->setVal( 'ids_list', $wikisList );

--- a/extensions/wikia/CuratedContent/CuratedContentController.class.php
+++ b/extensions/wikia/CuratedContent/CuratedContentController.class.php
@@ -593,7 +593,7 @@ class CuratedContentController extends WikiaController {
 
 	public function getWikisWithCuratedContent() {
 		$wikisList = WikiFactory::getListOfWikisWithVar(
-			self::CURATED_CONTENT_WG_VAR_ID_PROD, "full", "LIKE", null, "true"
+			self::CURATED_CONTENT_WG_VAR_ID_PROD, 'array', '=', []
 		);
 
 		$this->response->setVal( 'ids_list', $wikisList );


### PR DESCRIPTION
We were using incorrect query to get list of wikis with `wgWikiaCuratedContent` filled. Now we'll get wikis which have value of this variable other than an empty array.

/cc @michalroszka @bognix 
