### PR TITLE
CE-2704 Hide the diff view for new JS pages

### DIFF
--- a/extensions/wikia/ContentReview/ContentReview.hooks.php
+++ b/extensions/wikia/ContentReview/ContentReview.hooks.php
@@ -19,6 +19,7 @@ class Hooks {
 		\Hooks::register( 'SkinTemplateNavigation', [ $hooks, 'onSkinTemplateNavigation' ] );
 		\Hooks::register( 'UserLogoutComplete', [ $hooks, 'onUserLogoutComplete' ] );
 		\Hooks::register( 'ArticleSaveComplete', [ $hooks, 'onArticleSaveComplete' ] );
+		\Hooks::register( 'ShowDiff', [ $hooks, 'onShowDiff' ] );
 	}
 
 	public function onGetRailModuleList( Array &$railModuleList ) {
@@ -157,6 +158,23 @@ class Hooks {
 			( new Helper() )->purgeCurrentJsPagesTimestamp();
 		}
 
+		return true;
+	}
+
+	/**
+	 * Overwrites a message key used instead of a diff view when no `oldid` for comparison is provided.
+	 * @param \DifferenceEngine $diff
+	 * @param string $notice
+	 * @return bool
+	 */
+	public function onShowDiff( \DifferenceEngine $diff, &$notice ) {
+		if ( $diff->getTitle()->inNamespace( NS_MEDIAWIKI )
+			&& $diff->getRequest()->getBool( Helper::CONTENT_REVIEW_PARAM )
+			&& !$diff->getRequest()->getBool( 'oldid' )
+		) {
+			$notice = wfMessage( 'content-review-diff-hidden' )->escaped();
+			return false;
+		}
 		return true;
 	}
 

--- a/extensions/wikia/ContentReview/ContentReview.hooks.php
+++ b/extensions/wikia/ContentReview/ContentReview.hooks.php
@@ -172,7 +172,11 @@ class Hooks {
 			&& $diff->getRequest()->getBool( Helper::CONTENT_REVIEW_PARAM )
 			&& !$diff->getRequest()->getBool( 'oldid' )
 		) {
-			$notice = wfMessage( 'content-review-diff-hidden' )->escaped();
+			$notice = \HTML::rawElement(
+				'div',
+				[ 'class' => 'content-review-diff-hidden-notice' ],
+				wfMessage( 'content-review-diff-hidden' )->escaped()
+			);
 			return false;
 		}
 		return true;

--- a/extensions/wikia/ContentReview/ContentReview.i18n.php
+++ b/extensions/wikia/ContentReview/ContentReview.i18n.php
@@ -66,6 +66,7 @@ $messages['en'] = [
 	'content-review-diff-toolbar-talkpage' => 'Talk page',
 	'content-review-diff-toolbar-guidelines' => 'Reviewer guidelines',
 	'content-review-diff-toolbar-guidelines-url' => 'http://dev.wikia.com/wiki/Help:JavaScript_review_guidelines',
+	'content-review-diff-hidden' => 'Since no revision of this page has been approved yet, the diff is hidden. Please review the changes based on the latest revision state below.',
 
 	'content-review-status-unreviewed' => 'Unreviewed',
 	'content-review-status-in-review' => 'In review',
@@ -142,6 +143,7 @@ $messages['qqq'] = [
 	'content-review-diff-toolbar-talkpage' => 'A text of a link to a talk page of a page that is being reviewed.',
 	'content-review-diff-toolbar-guidelines' => 'A text of a link to a page with guidelines for reviewers.',
 	'content-review-diff-toolbar-guidelines-url' => 'A URL of a page with guidelines for reviewers.',
+	'content-review-diff-hidden' => 'A message shown to a reviewer if he is reviewing a page that does not have an initial revision. In this case the regular diff view is hidden and replaced by this message to focus them on an actual content that they review.',
 
 	'content-review-feedback-link-text' => 'Text on a link for providing feedback on script change being reviewed',
 	'content-review-rejection-explanation' => 'Standard explanation response when script changes were rejected. This text is a prefill to script talk page when reviewer is redirected there to provide feedback on rejection.',

--- a/includes/diff/DifferenceEngine.php
+++ b/includes/diff/DifferenceEngine.php
@@ -164,6 +164,13 @@ class DifferenceEngine extends ContextSource {
 		}
 	}
 
+	/**
+	 * Add an HTML of a page with a diff between revisions. It has the following switches that
+	 * allow you to controll the output:
+	 * * $diffOnly - `True` hides the actual content after the latest revision.
+	 * @param bool|false $diffOnly
+	 * @throws PermissionsError
+	 */
 	function showDiffPage( $diffOnly = false ) {
 		wfProfileIn( __METHOD__ );
 
@@ -382,7 +389,20 @@ class DifferenceEngine extends ContextSource {
 				$msg = $suppressed ? 'rev-suppressed-diff-view' : 'rev-deleted-diff-view';
 				$notice = "<div id='mw-$msg' class='mw-warning plainlinks'>\n" . $this->msg( $msg )->parse() . "</div>\n";
 			}
-			$this->showDiff( $oldHeader, $newHeader, $notice );
+			/**
+			 * Wikia change begin
+			 * Allows to hide a diff view and display a notice instead.
+			 * @author adamk@wikia-inc.com
+			 * @see CE-2704
+			 */
+			if ( !wfRunHooks( 'ShowDiff', [ $this, &$notice ] ) ) {
+				$out->addHTML( $notice );
+			} else {
+				$this->showDiff( $oldHeader, $newHeader, $notice );
+			}
+			/**
+			 * Wikia change end
+			 */
 			if ( !$diffOnly ) {
 				$this->renderNewRevision();
 			}


### PR DESCRIPTION
If you review a page that does not have an approved revision - no oldid param will be provided for a diff view.
It makes it really easy to miss any changes not introduced only by the latest revision since the diff is constructed
from it and the previous one. In this case it makes sense to hide the diff view.

/cc @Wikia/community-engineering @Grunny 
