### PR TITLE
(CE-2708) Fix importing non-MW JS pages when ContentReview is enabled

### DIFF
--- a/extensions/wikia/ContentReview/ContentReviewHelper.php
+++ b/extensions/wikia/ContentReview/ContentReviewHelper.php
@@ -330,7 +330,9 @@ class Helper extends \ContextSource {
 	public function replaceWithLastApproved( \Title $title, $contentType, &$text ) {
 		global $wgCityId, $wgJsMimeType;
 
-		if ( $title->isJsPage() || $contentType == $wgJsMimeType ) {
+		if ( $title->isJsPage()
+			|| ( $title->inNamespace( NS_MEDIAWIKI ) && $contentType == $wgJsMimeType )
+		) {
 			$pageId = $title->getArticleID();
 			$latestRevId = $title->getLatestRevID();
 


### PR DESCRIPTION
Make sure we only check the content type for pages in the MW namespace.

/cc @Wikia/community-engineering 
