### PR TITLE
ADEN-2434 Region in geo for sourcepoint

### DIFF
--- a/extensions/wikia/AdEngine/js/AdContext.js
+++ b/extensions/wikia/AdEngine/js/AdContext.js
@@ -51,7 +51,7 @@ define('ext.wikia.adEngine.adContext', [
 	}
 
 	function isUrlParamSet(param) {
-		return !!parseInt(qs.getVal(param, '0'));
+		return !!parseInt(qs.getVal(param, '0'), 10);
 	}
 
 	function setContext(newContext) {

--- a/extensions/wikia/AdEngine/js/AdContext.js
+++ b/extensions/wikia/AdEngine/js/AdContext.js
@@ -38,6 +38,18 @@ define('ext.wikia.adEngine.adContext', [
 		return !!(countryList && countryList.indexOf && countryList.indexOf(geo.getCountryCode()) > -1);
 	}
 
+	function isProperRegion(countryList) {
+		return !!(
+			countryList &&
+			countryList.indexOf &&
+			countryList.indexOf(geo.getCountryCode() + '-' + geo.getRegionCode()) > -1
+		);
+	}
+
+	function isProperGeo(countryList) {
+		return isProperCountry(countryList) || isProperRegion(countryList);
+	}
+
 	function isUrlParamSet(param) {
 		return !!parseInt(qs.getVal(param, '0'));
 	}
@@ -64,7 +76,7 @@ define('ext.wikia.adEngine.adContext', [
 		// SourcePoint integration
 		if (context.opts.sourcePointUrl) {
 			context.opts.sourcePoint = isUrlParamSet('sourcepoint') ||
-				isProperCountry(instantGlobals.wgAdDriverSourcePointCountries);
+				isProperGeo(instantGlobals.wgAdDriverSourcePointCountries);
 		}
 
 		// SourcePoint detection integration

--- a/extensions/wikia/AdEngine/js/spec/AdContext.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/AdContext.spec.js
@@ -374,8 +374,7 @@ describe('AdContext', function () {
 		expect(getModule().getContext().opts.sourcePoint).toBeTruthy();
 	});
 
-	it(
-		'disables SourcePoint when country and region in instant var and both are invalid',
+	it('disables SourcePoint when country and region in instant var and both are invalid',
 		function () {
 			mocks.win = {ads: {context: {opts: {sourcePointUrl: '//foo.bar'}}}};
 			mocks.instantGlobals = {wgAdDriverSourcePointCountries: ['XX-EE', 'YY']};

--- a/extensions/wikia/AdEngine/js/spec/AdContext.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/AdContext.spec.js
@@ -180,8 +180,7 @@ describe('AdContext', function () {
 		expect(adContext.getContext().targeting.pageCategories).toEqual(['Category1', 'Category2']);
 	});
 
-	it(
-		'makes targeting.enableKruxTargeting false when disaster recovery instant global variable is set to true',
+	it('makes targeting.enableKruxTargeting false when disaster recovery instant global variable is set to true',
 		function () {
 			var adContext;
 			mocks.win = {ads: {context: {targeting: {enableKruxTargeting: true}}}};

--- a/extensions/wikia/AdEngine/js/spec/AdContext.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/AdContext.spec.js
@@ -12,6 +12,9 @@ describe('AdContext', function () {
 			geo: {
 				getCountryCode: function () {
 					return 'XX';
+				},
+				getRegionCode: function () {
+					return 'RR';
 				}
 			},
 			instantGlobals: {},
@@ -351,12 +354,36 @@ describe('AdContext', function () {
 		expect(getModule().getContext().opts.sourcePoint).toBe(undefined);
 	});
 
-	it('enables SourcePoint when country in instantGlobals.wgAdDriverSourcePointCountries', function () {
+	it('enables SourcePoint when country in instant var', function () {
 		mocks.win = {ads: {context: {opts: {sourcePointUrl: '//foo.bar'}}}};
 		mocks.instantGlobals = {wgAdDriverSourcePointCountries: ['XX', 'ZZ']};
 
 		expect(getModule().getContext().opts.sourcePoint).toBeTruthy();
 	});
+
+	it('enables SourcePoint when region in instant var', function () {
+		mocks.win = {ads: {context: {opts: {sourcePointUrl: '//foo.bar'}}}};
+		mocks.instantGlobals = {wgAdDriverSourcePointCountries: ['XX-RR']};
+
+		expect(getModule().getContext().opts.sourcePoint).toBeTruthy();
+	});
+
+	it('enables SourcePoint when country and region in instant var (country overwrites region)', function () {
+		mocks.win = {ads: {context: {opts: {sourcePointUrl: '//foo.bar'}}}};
+		mocks.instantGlobals = {wgAdDriverSourcePointCountries: ['XX-EE', 'XX']};
+
+		expect(getModule().getContext().opts.sourcePoint).toBeTruthy();
+	});
+
+	it(
+		'disables SourcePoint when country and region in instant var and both are invalid',
+		function () {
+			mocks.win = {ads: {context: {opts: {sourcePointUrl: '//foo.bar'}}}};
+			mocks.instantGlobals = {wgAdDriverSourcePointCountries: ['XX-EE', 'YY']};
+
+			expect(getModule().getContext().opts.sourcePoint).toBeFalsy();
+		}
+	);
 
 	it('enables SourcePoint when url param sourcepoint is set', function () {
 		mocks.win = {ads: {context: {opts: {sourcePointUrl: '//foo.bar'}}}};

--- a/resources/wikia/modules/geo.js
+++ b/resources/wikia/modules/geo.js
@@ -67,12 +67,25 @@
 			return data.continent;
 		}
 
+		/**
+		 * Returns the code for the region
+		 *
+		 * @public
+		 *
+		 * @return {String} The region code
+		 */
+		function getRegionCode() {
+			var data = getGeoData();
+			return data.region;
+		}
+
 		/** @public **/
 
 		return {
 			getGeoData: getGeoData,
 			getCountryCode: getCountryCode,
 			getContinentCode: getContinentCode,
+			getRegionCode: getRegionCode,
 			setCountryCode: setCountryCode
 		};
 	}


### PR DESCRIPTION
In order to enable SourcePoint feature in a specific region of a country we added new method to `Wikia.geo` module and made changes in our `AdContext` module.
