### PR TITLE
[SERVICES-661] Save preferences when options are saved.

### DIFF
--- a/extensions/SemanticWatchlist/SemanticWatchlist.php
+++ b/extensions/SemanticWatchlist/SemanticWatchlist.php
@@ -87,7 +87,6 @@ $wgAPIListModules['semanticwatchlist'] = 'ApiQuerySemanticWatchlist';
 $wgHooks['LoadExtensionSchemaUpdates'][] = 'SWLHooks::onSchemaUpdate';
 $wgHooks['SMWStore::updateDataBefore'][] = 'SWLHooks::onDataUpdate';
 $wgHooks['GetPreferences'][] = 'SWLHooks::onGetPreferences';
-$wgHooks['UserSetPreferences'][] = 'SWLHooks::onUserSaveOptions';
 $wgHooks['UserSaveOptions'][] = 'SWLHooks::onUserSaveOptions';
 $wgHooks['AdminLinks'][] = 'SWLHooks::addToAdminLinks';
 $wgHooks['PersonalUrls'][] = 'SWLHooks::onPersonalUrls';

--- a/extensions/wikia/Helios/Helios.setup.php
+++ b/extensions/wikia/Helios/Helios.setup.php
@@ -32,5 +32,4 @@ $wgHooks['ExternalUserWikiaAuthenticate'][] = 'Wikia\\Helios\\User::onUserCheckP
 
 $wgHooks['UserSaveSettings'][] = 'Wikia\\Helios\\User::onUserSave';
 $wgHooks['UserSaveOptions'][] = 'Wikia\\Helios\\User::onUserSave';
-$wgHooks['UserSetPreferences'][] = 'Wikia\\Helios\\User::onUserSave';
 $wgHooks['UserLogout'][] = 'Wikia\\Helios\\User::onUserLogout';

--- a/extensions/wikia/Helios/Helios.setup.php
+++ b/extensions/wikia/Helios/Helios.setup.php
@@ -32,4 +32,5 @@ $wgHooks['ExternalUserWikiaAuthenticate'][] = 'Wikia\\Helios\\User::onUserCheckP
 
 $wgHooks['UserSaveSettings'][] = 'Wikia\\Helios\\User::onUserSave';
 $wgHooks['UserSaveOptions'][] = 'Wikia\\Helios\\User::onUserSave';
+$wgHooks['UserSetPreferences'][] = 'Wikia\\Helios\\User::onUserSave';
 $wgHooks['UserLogout'][] = 'Wikia\\Helios\\User::onUserLogout';

--- a/includes/User.php
+++ b/includes/User.php
@@ -5007,6 +5007,8 @@ class User {
 
 		$dbw->upsert('user_properties', $insertRows, [], self::$PROPERTY_UPSERT_SET_BLOCK);
 
+		$this->userPreferences()->save($this->getId());
+
 		if ( $extuser ) {
 			$extuser->updateUser();
 		}

--- a/includes/User.php
+++ b/includes/User.php
@@ -3547,6 +3547,7 @@ class User {
 		);
 
 		$this->saveOptions();
+		$this->savePreferences();
 
 		wfRunHooks( 'UserSaveSettings', array( $this ) );
 		$this->clearSharedCache();
@@ -3670,6 +3671,7 @@ class User {
 		$this->clearInstanceCache();
 
 		$this->saveOptions();
+		$this->savePreferences();
 	}
 
 	/**
@@ -4945,6 +4947,11 @@ class User {
 		] );
 	}
 
+	protected function savePreferences() {
+		$this->userPreferences()->save($this->getId());
+		wfRunHooks( "UserSetPreferences", array( $this ) );
+	}
+
 	/**
 	 * @todo document
 	 */
@@ -5006,8 +5013,6 @@ class User {
 		}
 
 		$dbw->upsert('user_properties', $insertRows, [], self::$PROPERTY_UPSERT_SET_BLOCK);
-
-		$this->userPreferences()->save($this->getId());
 
 		if ( $extuser ) {
 			$extuser->updateUser();

--- a/includes/User.php
+++ b/includes/User.php
@@ -4954,7 +4954,6 @@ class User {
 	 */
 	protected function savePreferences() {
 		$this->userPreferences()->save($this->getId());
-		wfRunHooks( "UserSetPreferences", array( $this ) );
 	}
 
 	/**

--- a/includes/User.php
+++ b/includes/User.php
@@ -4947,6 +4947,11 @@ class User {
 		] );
 	}
 
+	/**
+	 * Save this user's preferences into the database.
+	 *
+	 * @see getGlobalPreference for documentation about preferences
+	 */
 	protected function savePreferences() {
 		$this->userPreferences()->save($this->getId());
 		wfRunHooks( "UserSetPreferences", array( $this ) );


### PR DESCRIPTION
Saving preferences each time `User::saveOptions()` is called, also removed unused `UserSetPreferences` hook that duplicated `UserSaveOptions` hook.

/cc @Wikia/services-team 
