### PR TITLE
Preference Service Fixes

### DIFF
--- a/extensions/wikia/AutomaticWikiAdoption/AutomaticWikiAdoption_setup.php
+++ b/extensions/wikia/AutomaticWikiAdoption/AutomaticWikiAdoption_setup.php
@@ -39,23 +39,22 @@ $wgAutoloadClasses['AutomaticWikiAdoptionController'] = "$dir/AutomaticWikiAdopt
 $wgAutoloadClasses['SpecialWikiAdoption'] = "$dir/SpecialWikiAdoption.class.php";
 $wgSpecialPages['WikiAdoption'] = 'SpecialWikiAdoption';
 
+# 194785 = ID of wiki created on 2010-12-14 so it will work for wikis created after this project has been deployed
+if ( $wgCityId > 194785 ) {
+	$wgDefaultUserOptions["adoptionmails-$wgCityId"] = 1;
+}
+
 /**
  * Initialize hooks
  *
  * @author Maciej Błaszkowski <marooned at wikia-inc.com>
  */
 function AutomaticWikiAdoptionInit() {
-	global $wgHooks, $wgDefaultUserOptions, $wgCityId;
-
-	# 194785 = ID of wiki created on 2010-12-14 so it will work for wikis created after this project has been deployed
-	if ( $wgCityId > 194785 ) {
-		$wgDefaultUserOptions["adoptionmails-$wgCityId"] = 1;
-	}
+	global $wgHooks;
 
 	$wgHooks['SkinTemplateOutputPageBeforeExec'][] = 'AutomaticWikiAdoptionHelper::onSkinTemplateOutputPageBeforeExec';
 	$wgHooks['GetPreferences'][] = 'AutomaticWikiAdoptionHelper::onGetPreferences';
 	$wgHooks['ArticleSaveComplete'][] = 'AutomaticWikiAdoptionHelper::onArticleSaveComplete';
-
 }
 
 // Ajax dispatcher

--- a/extensions/wikia/FounderEmails/FounderEmails.php
+++ b/extensions/wikia/FounderEmails/FounderEmails.php
@@ -75,17 +75,16 @@ function wfFounderEmailsInit() {
 
 	$wgHooks['GetPreferences'][] = 'FounderEmails::onGetPreferences';
 	$wgHooks['UserRights'][] = 'FounderEmails::onUserRightsChange';
-
-	// Set default for the toggle (applied to all new user accounts).  This is safe even if this user isn't a founder yet.
-	// $wgDefaultUserOptions["founderemailsenabled"] = 1;  // Old preference not used any more
-	$wgDefaultUserOptions["founderemails-joins-$wgCityId"] = 0;
-	$wgDefaultUserOptions["founderemails-edits-$wgCityId"] = 0;
-	$wgDefaultUserOptions["founderemails-views-digest-$wgCityId"] = 0;
-	$wgDefaultUserOptions["founderemails-complete-digest-$wgCityId"] = 0;
 }
 
 $dir = dirname( __FILE__ ) . '/';
 $wgAutoloadClasses['FounderEmailsController'] = $dir . 'FounderEmailsController.class.php';
 $wgAutoloadClasses['SpecialFounderEmails'] = $dir . 'SpecialFounderEmails.class.php';
+
+// Set default for the toggle (applied to all new user accounts).  This is safe even if this user isn't a founder yet.
+$wgDefaultUserOptions["founderemails-joins-$wgCityId"] = 0;
+$wgDefaultUserOptions["founderemails-edits-$wgCityId"] = 0;
+$wgDefaultUserOptions["founderemails-views-digest-$wgCityId"] = 0;
+$wgDefaultUserOptions["founderemails-complete-digest-$wgCityId"] = 0;
 
 $wgSpecialPages['FounderEmails'] = 'SpecialFounderEmails';

--- a/includes/User.php
+++ b/includes/User.php
@@ -1413,27 +1413,6 @@ class User {
 		return $defOpt;
 	}
 
-	public static function getDefaultPreferences() {
-
-		global $wgLocalUserPreferenceWhiteList;
-		global $wgGlobalUserPreferenceWhiteList;
-		$whiteListLiterals = array_merge( (array)$wgLocalUserPreferenceWhiteList[ 'literals' ],
-			(array)$wgGlobalUserPreferenceWhiteList[ 'literals' ] );
-
-		$defaultOptions = User::getDefaultOptions();
-		$defaultOptionNames = array_keys( $defaultOptions );
-
-		return array_reduce(
-			$defaultOptionNames,
-			function ( $preferences, $option ) use ( $whiteListLiterals, $defaultOptions ) {
-				if ( in_array( $option, $whiteListLiterals ) ) {
-					$preferences[ $option ] = $defaultOptions[ $option ];
-				}
-
-				return $preferences;
-			}, [ ] );
-	}
-
 	/**
 	 * Get a given default option value.
 	 *
@@ -2689,8 +2668,8 @@ class User {
 	 * @return string
 	 * @see getGlobalPreference for documentation about preferences
 	 */
-	public function getDefaultGlobalPreference($preference) {
-		return $this->userPreferences()->getFromDefault($preference);
+	public function getDefaultGlobalPreference( $preference ) {
+		return $this->userPreferences()->getGlobalDefault( $preference );
 	}
 
 	/**

--- a/lib/Wikia/src/Domain/User/Preferences/GlobalPreference.php
+++ b/lib/Wikia/src/Domain/User/Preferences/GlobalPreference.php
@@ -13,6 +13,13 @@ class GlobalPreference {
 		Assert::true( !empty( $name ), "invalid preference name" );
 
 		$this->name = $name;
+
+		if ( $value === "true" ) {
+			$value = true;
+		} elseif ( $value === "false" ) {
+			$value = false;
+		}
+
 		$this->value = $value;
 	}
 

--- a/lib/Wikia/src/Domain/User/Preferences/LocalPreference.php
+++ b/lib/Wikia/src/Domain/User/Preferences/LocalPreference.php
@@ -14,6 +14,12 @@ class LocalPreference {
 		Assert::true( !empty( $name ), "invalid preference name" );
 		Assert::true( !empty( $wikiId ), "invalid wiki id" );
 
+		if ( $value === "true" ) {
+			$value = true;
+		} elseif ( $value === "false" ) {
+			$value = false;
+		}
+
 		$this->name = $name;
 		$this->value = $value;
 		$this->wikiId = $wikiId;

--- a/lib/Wikia/src/Service/User/Preferences/PreferenceModule.php
+++ b/lib/Wikia/src/Service/User/Preferences/PreferenceModule.php
@@ -2,12 +2,15 @@
 
 namespace Wikia\Service\User\Preferences;
 
+use Interop\Container\ContainerInterface;
 use User;
 use Wikia\Cache\BagOStuffCacheProvider;
 use Wikia\DependencyInjection\InjectorBuilder;
 use Wikia\DependencyInjection\Module;
+use Wikia\Domain\User\Preferences\UserPreferences;
 use Wikia\Persistence\User\Preferences\PreferencePersistence;
 use Wikia\Persistence\User\Preferences\PreferencePersistenceSwaggerService;
+use Wikia\Service\User\Preferences\Migration\PreferenceScopeService;
 
 class PreferenceModule implements Module {
 	const PREFERENCE_CACHE_VERSION = 1;
@@ -27,8 +30,22 @@ class PreferenceModule implements Module {
 				global $wgHiddenPrefs;
 				return $wgHiddenPrefs;
 			} )
-			->bind( PreferenceServiceImpl::DEFAULT_PREFERENCES )->to( function() {
-				return User::getDefaultPreferences();
+			->bind( PreferenceServiceImpl::DEFAULT_PREFERENCES )->to( function( ContainerInterface $c ) {
+				/** @var PreferenceScopeService $scopeService */
+				$scopeService = $c->get( PreferenceScopeService::class );
+				$defaultOptions = User::getDefaultOptions();
+				$defaultPreferences = new UserPreferences();
+
+				foreach ( $defaultOptions as $name => $val ) {
+					if ( $scopeService->isGlobalPreference( $name ) ) {
+						$defaultPreferences->setGlobalPreference( $name, $val );
+					} elseif ( $scopeService->isLocalPreference( $name ) ) {
+						list( $prefName, $wikiId ) = $scopeService->splitLocalPreference( $name );
+						$defaultPreferences->setLocalPreference( $prefName, $wikiId, $val );
+					}
+				}
+
+				return $defaultPreferences;
 			} )
 			->bind( PreferenceServiceImpl::FORCE_SAVE_PREFERENCES )->to( function() {
 				global $wgGlobalUserProperties;

--- a/lib/Wikia/src/Service/User/Preferences/PreferenceService.php
+++ b/lib/Wikia/src/Service/User/Preferences/PreferenceService.php
@@ -17,5 +17,5 @@ interface PreferenceService {
 	public function setLocalPreference( $userId, $wikiId, $name, $value );
 	public function deleteLocalPreference( $userId, $name, $wikiId );
 	public function save( $userId );
-	public function getFromDefault( $pref );
+	public function getGlobalDefault( $pref );
 }

--- a/lib/Wikia/src/Service/User/Preferences/PreferenceServiceImpl.php
+++ b/lib/Wikia/src/Service/User/Preferences/PreferenceServiceImpl.php
@@ -32,7 +32,7 @@ class PreferenceServiceImpl implements PreferenceService {
 	/** @var string[] */
 	private $hiddenPrefs;
 
-	/** @var string[] */
+	/** @var UserPreferences */
 	private $defaultPreferences;
 
 	/** @var string[] */
@@ -42,20 +42,20 @@ class PreferenceServiceImpl implements PreferenceService {
 	 * @Inject({
 	 *    Wikia\Service\User\Preferences\PreferenceServiceImpl::CACHE_PROVIDER,
 	 *    Wikia\Persistence\User\Preferences\PreferencePersistence::class,
-	 *    Wikia\Service\User\Preferences\PreferenceServiceImpl::HIDDEN_PREFS,
 	 *    Wikia\Service\User\Preferences\PreferenceServiceImpl::DEFAULT_PREFERENCES,
+	 *    Wikia\Service\User\Preferences\PreferenceServiceImpl::HIDDEN_PREFS,
 	 *    Wikia\Service\User\Preferences\PreferenceServiceImpl::FORCE_SAVE_PREFERENCES})
 	 * @param CacheProvider $cache,
 	 * @param PreferencePersistence $persistence
+	 * @param UserPreferences $defaultPrefs
 	 * @param string[] $hiddenPrefs preferences that fall back to the defaults, whether or not a user has them set
-	 * @param string[string] $defaultPrefs
 	 * @param string[] $forceSavePrefs
 	 */
 	public function __construct(
 		CacheProvider $cache,
 		PreferencePersistence $persistence,
+		UserPreferences $defaultPrefs,
 		$hiddenPrefs,
-		$defaultPrefs,
 		$forceSavePrefs ) {
 
 		$this->cache = $cache;
@@ -81,7 +81,7 @@ class PreferenceServiceImpl implements PreferenceService {
 
 	public function getGlobalPreference( $userId, $name, $default = null, $ignoreHidden = false ) {
 		if ( in_array( $name, $this->hiddenPrefs ) && !$ignoreHidden ) {
-			return $this->getFromDefault( $name );
+			return $this->getGlobalDefault( $name );
 		}
 
 		$preferences = $this->load( $userId );
@@ -94,7 +94,7 @@ class PreferenceServiceImpl implements PreferenceService {
 
 	public function setGlobalPreference( $userId, $name, $value ) {
 		if ( $value == null ) {
-			$value = $this->getFromDefault( $name );
+			$value = $this->getGlobalDefault( $name );
 		}
 
 		$this->load( $userId )->setGlobalPreference( $name, $value );
@@ -106,7 +106,7 @@ class PreferenceServiceImpl implements PreferenceService {
 
 	public function getLocalPreference( $userId, $wikiId, $name, $default = null, $ignoreHidden = false ) {
 		if ( in_array( $name, $this->hiddenPrefs ) && !$ignoreHidden ) {
-			return $this->getFromDefault( $name );
+			return $this->getGlobalDefault( $name );
 		}
 
 		$preferences = $this->load( $userId );
@@ -119,7 +119,7 @@ class PreferenceServiceImpl implements PreferenceService {
 
 	public function setLocalPreference( $userId, $wikiId, $name, $value ) {
 		if ( $value == null ) {
-			$value = $this->getFromDefault( $name );
+			$value = $this->getGlobalDefault( $name );
 		}
 
 		$this->load( $userId )->setLocalPreference( $name, $wikiId, $value );
@@ -179,12 +179,8 @@ class PreferenceServiceImpl implements PreferenceService {
 		return true;
 	}
 
-	public function getFromDefault( $pref ) {
-		if ( isset( $this->defaultPreferences[$pref] ) ) {
-			return $this->defaultPreferences[$pref];
-		}
-
-		return null;
+	public function getGlobalDefault( $pref ) {
+		return $this->defaultPreferences->getGlobalPreference( $pref );
 	}
 
 	/**
@@ -235,9 +231,18 @@ class PreferenceServiceImpl implements PreferenceService {
 	}
 
 	private function applyDefaults( UserPreferences $preferences ) {
-		foreach ( $this->defaultPreferences as $name => $val ) {
-			if ( !$preferences->hasGlobalPreference( $name ) ) {
-				$preferences->setGlobalPreference( $name, $val );
+		foreach ( $this->defaultPreferences->getGlobalPreferences() as $globalPreference ) {
+			if ( !$preferences->hasGlobalPreference( $globalPreference->getName() ) ) {
+				$preferences->setGlobalPreference( $globalPreference->getName(), $globalPreference->getValue() );
+			}
+		}
+
+		foreach ( $this->defaultPreferences->getLocalPreferences() as $wikiId => $localPreferences ) {
+			foreach ( $localPreferences as $localPreference ) {
+				/** @var LocalPreference $localPreference */
+				if ( !$preferences->hasLocalPreference( $localPreference->getName(), $wikiId ) ) {
+					$preferences->setLocalPreference( $localPreference->getName(), $wikiId, $localPreference->getValue() );
+				}
 			}
 		}
 
@@ -245,7 +250,7 @@ class PreferenceServiceImpl implements PreferenceService {
 	}
 
 	private function prefIsSaveable( $pref, $value ) {
-		$default = $this->getFromDefault( $pref );
+		$default = $this->getGlobalDefault( $pref );
 
 		if ( $value == $default ) {
 			return false;

--- a/lib/Wikia/src/Service/User/Preferences/PreferenceServiceImpl.php
+++ b/lib/Wikia/src/Service/User/Preferences/PreferenceServiceImpl.php
@@ -106,7 +106,7 @@ class PreferenceServiceImpl implements PreferenceService {
 
 	public function getLocalPreference( $userId, $wikiId, $name, $default = null, $ignoreHidden = false ) {
 		if ( in_array( $name, $this->hiddenPrefs ) && !$ignoreHidden ) {
-			return $this->getGlobalDefault( $name );
+			return $this->getLocalDefault($name, $wikiId );
 		}
 
 		$preferences = $this->load( $userId );
@@ -119,7 +119,7 @@ class PreferenceServiceImpl implements PreferenceService {
 
 	public function setLocalPreference( $userId, $wikiId, $name, $value ) {
 		if ( $value == null ) {
-			$value = $this->getGlobalDefault( $name );
+			$value = $this->getLocalDefault($name, $wikiId );
 		}
 
 		$this->load( $userId )->setLocalPreference( $name, $wikiId, $value );

--- a/lib/Wikia/src/Service/User/Preferences/PreferenceServiceImpl.php
+++ b/lib/Wikia/src/Service/User/Preferences/PreferenceServiceImpl.php
@@ -143,7 +143,7 @@ class PreferenceServiceImpl implements PreferenceService {
 		$prefsToSave = new UserPreferences();
 
 		foreach ( $prefs->getGlobalPreferences() as $pref ) {
-			if ( $this->prefIsSaveable( $pref->getName(), $pref->getValue() ) ) {
+			if ( $this->prefIsSaveable( $pref->getName(), $pref->getValue(), $this->getGlobalDefault( $pref->getName() ) ) ) {
 				$prefsToSave->setGlobalPreference( $pref->getName(), $pref->getValue() );
 			}
 		}
@@ -151,7 +151,7 @@ class PreferenceServiceImpl implements PreferenceService {
 		foreach ( $prefs->getLocalPreferences() as $wikiId => $wikiPreferences ) {
 			foreach ( $wikiPreferences as $pref ) {
 				/** @var $pref LocalPreference */
-				if ( $this->prefIsSaveable( $pref->getName(), $pref->getValue() ) ) {
+				if ( $this->prefIsSaveable( $pref->getName(), $pref->getValue(), $this->getLocalDefault( $pref->getName() ) ) ) {
 					$prefsToSave->setLocalPreference( $pref->getName(), $pref->getWikiId(), $pref->getValue() );
 				}
 			}
@@ -181,6 +181,10 @@ class PreferenceServiceImpl implements PreferenceService {
 
 	public function getGlobalDefault( $pref ) {
 		return $this->defaultPreferences->getGlobalPreference( $pref );
+	}
+
+	public function getLocalDefault( $pref, $wikiId ) {
+		return $this->defaultPreferences->getLocalPreference( $pref, $wikiId );
 	}
 
 	/**
@@ -249,14 +253,12 @@ class PreferenceServiceImpl implements PreferenceService {
 		return $preferences;
 	}
 
-	private function prefIsSaveable( $pref, $value ) {
-		$default = $this->getGlobalDefault( $pref );
-
-		if ( $value == $default ) {
+	private function prefIsSaveable( $pref, $value, $valueFromDefaults ) {
+		if ( $value == $valueFromDefaults ) {
 			return false;
 		}
 
-		return in_array( $pref, $this->forceSavePrefs ) || $value != $default ||
-			( $default != null && $value !== false && $value !== null );
+		return in_array( $pref, $this->forceSavePrefs ) || $value != $valueFromDefaults ||
+			( $valueFromDefaults != null && $value !== false && $value !== null );
 	}
 }

--- a/lib/Wikia/tests/Service/User/PreferenceServiceImplTest.php
+++ b/lib/Wikia/tests/Service/User/PreferenceServiceImplTest.php
@@ -46,8 +46,9 @@ class PreferenceServiceImplTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testGetFromDefault() {
-		$defaultPrefs = ["pref1" => "val1"];
-		$preferences = new PreferenceServiceImpl( $this->cache, $this->persistence, [], $defaultPrefs, [] );
+		$defaultPreferences = (new UserPreferences())
+			->setGlobalPreference('pref1', 'val1');
+		$preferences = new PreferenceServiceImpl( $this->cache, $this->persistence, $defaultPreferences, [], [] );
 
 		$this->assertEquals( "val1", $preferences->getGlobalDefault( "pref1" ) );
 		$this->assertNull( $preferences->getGlobalDefault( "pref2" ) );
@@ -55,7 +56,7 @@ class PreferenceServiceImplTest extends PHPUnit_Framework_TestCase {
 
 	public function testGet() {
 		$this->setupServiceExpects();
-		$preferences = new PreferenceServiceImpl( $this->cache, $this->persistence, [], [], [] );
+		$preferences = new PreferenceServiceImpl( $this->cache, $this->persistence, new UserPreferences(), [], [] );
 
 		$this->assertEquals( "en", $preferences->getGlobalPreference( $this->userId, "language" ) );
 		$this->assertEquals( "1", $preferences->getGlobalPreference( $this->userId, "marketingallowed" ) );
@@ -69,14 +70,16 @@ class PreferenceServiceImplTest extends PHPUnit_Framework_TestCase {
 
 	public function testGetWithHiddenNoDefaults() {
 		$this->setupServiceExpects();
-		$preferences = new PreferenceServiceImpl( $this->cache, $this->persistence, ["marketingallowed"], [], [] );
+		$preferences = new PreferenceServiceImpl( $this->cache, $this->persistence, new UserPreferences(), ['marketingallowed'], [] );
 		$this->assertEquals( "1", $preferences->getGlobalPreference( $this->userId, "marketingallowed", null, true ) );
 		$this->assertNull( $preferences->getGlobalPreference( $this->userId, "marketingallowed" ) );
 	}
 
 	public function testGetWithHiddenAndDefaults() {
 		$this->setupServiceExpects();
-		$preferences = new PreferenceServiceImpl( $this->cache, $this->persistence, ["marketingallowed"], ["marketingallowed" => "0"], [] );
+		$defaultPreferences = (new UserPreferences())
+			->setGlobalPreference('marketingallowed', '0');
+		$preferences = new PreferenceServiceImpl( $this->cache, $this->persistence, $defaultPreferences, ["marketingallowed"], [] );
 		$this->assertEquals( "1", $preferences->getGlobalPreference( $this->userId, "marketingallowed", null, true ) );
 		$this->assertEquals( "0", $preferences->getGlobalPreference( $this->userId, "marketingallowed" ) );
 		$this->assertNull( $preferences->getGlobalPreference( $this->userId, "unsetpreference" ) );
@@ -84,21 +87,23 @@ class PreferenceServiceImplTest extends PHPUnit_Framework_TestCase {
 
 	public function testSet() {
 		$this->setupServiceExpects();
-		$preferences = new PreferenceServiceImpl( $this->cache, $this->persistence, [], [], [] );
+		$preferences = new PreferenceServiceImpl( $this->cache, $this->persistence, new UserPreferences(), [], [] );
 		$preferences->setGlobalPreference( $this->userId, "newpreference", "foo" );
 		$this->assertEquals( "foo", $preferences->getGlobalPreference( $this->userId, "newpreference" ) );
 	}
 
 	public function testSetNullWithDefault() {
 		$this->setupServiceExpects();
-		$preferences = new PreferenceServiceImpl( $this->cache, $this->persistence, [], ["newpreference" => "foo"], [] );
+		$defaultPreferences = (new UserPreferences())
+			->setGlobalPreference('newpreference', 'foo');
+		$preferences = new PreferenceServiceImpl( $this->cache, $this->persistence, $defaultPreferences, [], [] );
 		$preferences->setGlobalPreference( $this->userId, "newpreference", null );
 		$this->assertEquals( "foo", $preferences->getPreferences( $this->userId )->getGlobalPreference( "newpreference" ) );
 	}
 
 	public function testSetNullWithoutDefault() {
 		$this->setupServiceExpects();
-		$preferences = new PreferenceServiceImpl( $this->cache, $this->persistence, [], [], [] );
+		$preferences = new PreferenceServiceImpl( $this->cache, $this->persistence, new UserPreferences(), [], [] );
 		$preferences->setGlobalPreference( $this->userId, "newpreference", null );
 		$this->assertNull( $preferences->getPreferences( $this->userId )->getGlobalPreference( "newpreference" ) );
 	}

--- a/lib/Wikia/tests/Service/User/PreferenceServiceImplTest.php
+++ b/lib/Wikia/tests/Service/User/PreferenceServiceImplTest.php
@@ -49,8 +49,8 @@ class PreferenceServiceImplTest extends PHPUnit_Framework_TestCase {
 		$defaultPrefs = ["pref1" => "val1"];
 		$preferences = new PreferenceServiceImpl( $this->cache, $this->persistence, [], $defaultPrefs, [] );
 
-		$this->assertEquals( "val1", $preferences->getFromDefault( "pref1" ) );
-		$this->assertNull( $preferences->getFromDefault( "pref2" ) );
+		$this->assertEquals( "val1", $preferences->getGlobalDefault( "pref1" ) );
+		$this->assertNull( $preferences->getGlobalDefault( "pref2" ) );
 	}
 
 	public function testGet() {

--- a/lib/Wikia/tests/Service/User/Preferences/Migration/PreferenceCorrectionServiceTest.php
+++ b/lib/Wikia/tests/Service/User/Preferences/Migration/PreferenceCorrectionServiceTest.php
@@ -34,7 +34,7 @@ class PreferenceCorrectionServiceTest extends PHPUnit_Framework_TestCase {
 				'getLocalPreference',
 				'setLocalPreference',
 				'deleteLocalPreference',
-				'getFromDefault',
+				'getGlobalDefault',
 			] )
 			->getMock();
 		$this->savedPreferences = ( new UserPreferences() )


### PR DESCRIPTION
@Wikia/services-team 
https://wikia-inc.atlassian.net/browse/SERVICES-770

Miscellaneous things I had to do to get the preference service to work. Had to move the default preferences outside of the extension functions, since those functions could be executed after a call to `loadOptions`, which would create the default preferences and so we'd be missing some defaults. Also had to move default preferences in `PreferenceServiceImpl` to be a `UserPreferences` object rather than a map, since it contains locals as well.
