### PR TITLE
SOC-1315 When clearing user cache for attribute service, clear staging envs as well

### DIFF
--- a/extensions/wikia/AttributeServiceMWApi/AttributeServiceMWApiController.class.php
+++ b/extensions/wikia/AttributeServiceMWApi/AttributeServiceMWApiController.class.php
@@ -105,8 +105,8 @@ class AttributeServiceMWApiController extends WikiaController {
     private function clearCacheInStagingEnvs( $userId ) {
         global $wgStagingList, $wgPreviewHostname, $wgVerifyHostname;
 
-        // $wgStagingList uses the domain name "preview" and "verify" rather than the hostnames "staging-s2"
-        // and "staging-s3" for those 2 envs, so we have to manually add the hostnames for those here.
+        // $wgStagingList uses the domain names "preview" and "verify" rather than the hostnames "staging-s2" and
+        // "staging-s3", so we have to manually add the those hostnames here.
         $stagingEnvs = array_merge( $wgStagingList, [ $wgPreviewHostname, $wgVerifyHostname ] );
         foreach ( $stagingEnvs as $stagingEnv ) {
             $this->clearCacheInEnv( $userId, $stagingEnv );

--- a/extensions/wikia/AttributeServiceMWApi/AttributeServiceMWApiController.class.php
+++ b/extensions/wikia/AttributeServiceMWApi/AttributeServiceMWApiController.class.php
@@ -5,9 +5,9 @@ use \Wikia\Util\GlobalStateWrapper;
 class AttributeServiceMWApiController extends WikiaController {
 
 	/**
-	 * Helper function for the attribute service to clear user MediaWiki.
-	 * This is called when a client other than MW updates an attribute
-	 * using the attribute service to clear the User cache.
+	 * Helper function for the attribute service to clear user cache in MediaWiki.
+	 * This is called by the attribute service when a client other than MW updates
+     * an attribute in the service.
 	 */
 	public function purgeUserCache() {
 

--- a/extensions/wikia/AttributeServiceMWApi/AttributeServiceMWApiController.class.php
+++ b/extensions/wikia/AttributeServiceMWApi/AttributeServiceMWApiController.class.php
@@ -7,7 +7,7 @@ class AttributeServiceMWApiController extends WikiaController {
 	/**
 	 * Helper function for the attribute service to clear user cache in MediaWiki.
 	 * This is called by the attribute service when a client other than MW updates
-     * an attribute in the service.
+	 * an attribute in the service.
 	 */
 	public function purgeUserCache() {
 
@@ -25,10 +25,10 @@ class AttributeServiceMWApiController extends WikiaController {
 			return;
 		}
 
-        $this->clearUserCache( $userId );
-        if ( !$this->inDevEnvironment() ) {
-            $this->clearCacheInStagingEnvs( $userId );
-        }
+		$this->clearUserCache( $userId );
+		if ( !$this->inDevEnvironment() ) {
+			$this->clearCacheInStagingEnvs( $userId );
+		}
 	}
 
 	/**
@@ -83,41 +83,41 @@ class AttributeServiceMWApiController extends WikiaController {
 
 	private function clearUserCache( $userId ) {
 
-        // Clear user cache
-        $user = User::newFromId( $userId );
-        $user->invalidateCache();
+		// Clear user cache
+		$user = User::newFromId( $userId );
+		$user->invalidateCache();
 
-        // Clear User Profile cache
-        $userIdentityBox = new UserIdentityBox( $user );
-        $userIdentityBox->clearCache();
-    }
+		// Clear User Profile cache
+		$userIdentityBox = new UserIdentityBox( $user );
+		$userIdentityBox->clearCache();
+	}
 
-    private function inDevEnvironment() {
-        global $wgDevelEnvironment;
+	private function inDevEnvironment() {
+		global $wgDevelEnvironment;
 
-        return $wgDevelEnvironment === true;
-    }
+		return $wgDevelEnvironment === true;
+	}
 
-    /**
-     * If we're not in a development environment, clear the cache for all staging environments as well
-     * @param $userId
-     */
-    private function clearCacheInStagingEnvs( $userId ) {
-        global $wgStagingList, $wgPreviewHostname, $wgVerifyHostname;
+	/**
+	 * If we're not in a development environment, clear the cache for all staging environments as well
+	 * @param $userId
+	 */
+	private function clearCacheInStagingEnvs( $userId ) {
+		global $wgStagingList, $wgPreviewHostname, $wgVerifyHostname;
 
-        // $wgStagingList uses the domain names "preview" and "verify" rather than the hostnames "staging-s2" and
-        // "staging-s3", so we have to manually add the those hostnames here.
-        $stagingEnvs = array_merge( $wgStagingList, [ $wgPreviewHostname, $wgVerifyHostname ] );
-        foreach ( $stagingEnvs as $stagingEnv ) {
-            $this->clearCacheInEnv( $userId, $stagingEnv );
-        }
-    }
+		// $wgStagingList uses the domain names "preview" and "verify" rather than the hostnames "staging-s2" and
+		// "staging-s3", so we have to manually add the those hostnames here.
+		$stagingEnvs = array_merge( $wgStagingList, [ $wgPreviewHostname, $wgVerifyHostname ] );
+		foreach ( $stagingEnvs as $stagingEnv ) {
+			$this->clearCacheInEnv( $userId, $stagingEnv );
+		}
+	}
 
-    private function clearCacheInEnv( $userId, $stagingEnv ) {
-        $wrapper = new GlobalStateWrapper( [ 'wgSharedKeyPrefix' => Wikia::getSharedKeyPrefix( $stagingEnv ) ] );
-        $wrapper->wrap( function() use ( $userId ) {
-            $this->clearUserCache( $userId );
-        } );
-    }
+	private function clearCacheInEnv( $userId, $stagingEnv ) {
+		$wrapper = new GlobalStateWrapper( [ 'wgSharedKeyPrefix' => Wikia::getSharedKeyPrefix( $stagingEnv ) ] );
+		$wrapper->wrap( function() use ( $userId ) {
+			$this->clearUserCache( $userId );
+		} );
+	}
 }
 

--- a/extensions/wikia/AttributeServiceMWApi/AttributeServiceMWApiController.class.php
+++ b/extensions/wikia/AttributeServiceMWApi/AttributeServiceMWApiController.class.php
@@ -103,16 +103,19 @@ class AttributeServiceMWApiController extends WikiaController {
      * @param $userId
      */
     private function clearCacheInStagingEnvs( $userId ) {
-        global $wgStagingList;
+        global $wgStagingList, $wgPreviewHostname, $wgVerifyHostname;
 
-        foreach ( $wgStagingList as $stagingEnv ) {
+        // $wgStagingList uses the domain name "preview" and "verify" rather than the hostnames "staging-s2"
+        // and "staging-s3" for those 2 envs, so we have to manually add the hostnames for those here.
+        $stagingEnvs = array_merge( $wgStagingList, [ $wgPreviewHostname, $wgVerifyHostname ] );
+        foreach ( $stagingEnvs as $stagingEnv ) {
             $this->clearCacheInEnv( $userId, $stagingEnv );
         }
     }
 
     private function clearCacheInEnv( $userId, $stagingEnv ) {
         $wrapper = new GlobalStateWrapper( [ 'wgSharedKeyPrefix' => Wikia::getSharedKeyPrefix( $stagingEnv ) ] );
-        $wrapper->wrap(function() use ($userId) {
+        $wrapper->wrap( function() use ( $userId ) {
             $this->clearUserCache( $userId );
         } );
     }

--- a/extensions/wikia/AttributeServiceMWApi/AttributeServiceMWApiController.class.php
+++ b/extensions/wikia/AttributeServiceMWApi/AttributeServiceMWApiController.class.php
@@ -99,31 +99,22 @@ class AttributeServiceMWApiController extends WikiaController {
     }
 
     /**
-     * If we're not in a development environment, clear the cache for staging environments as well (preview and
-     * verify).
+     * If we're not in a development environment, clear the cache for all staging environments as well
      * @param $userId
      */
     private function clearCacheInStagingEnvs( $userId ) {
-        $this->clearCacheInPreview( $userId );
-        $this->clearCacheInVerify( $userId );
+        global $wgStagingList;
+
+        foreach ( $wgStagingList as $stagingEnv ) {
+            $this->clearCacheInEnv( $userId, $stagingEnv );
+        }
     }
 
-	private function clearCacheInPreview( $userId ) {
-		global $wgPreviewHostname;
-
-        $wrapper = new GlobalStateWrapper( [ 'wgSharedKeyPrefix' => Wikia::getSharedKeyPrefix( $wgPreviewHostname ) ] );
+    private function clearCacheInEnv( $userId, $stagingEnv ) {
+        $wrapper = new GlobalStateWrapper( [ 'wgSharedKeyPrefix' => Wikia::getSharedKeyPrefix( $stagingEnv ) ] );
         $wrapper->wrap(function() use ($userId) {
             $this->clearUserCache( $userId );
         } );
-	}
-
-	private function clearCacheInVerify( $userId ) {
-        global $wgVerifyHostname;
-
-        $wrapper = new GlobalStateWrapper( [ 'wgSharedKeyPrefix' => Wikia::getSharedKeyPrefix( $wgVerifyHostname ) ] );
-        $wrapper->wrap(function() use ($userId) {
-            $this->clearUserCache( $userId );
-        } );
-	}
+    }
 }
 

--- a/extensions/wikia/AttributeServiceMWApi/AttributeServiceMWApiController.class.php
+++ b/extensions/wikia/AttributeServiceMWApi/AttributeServiceMWApiController.class.php
@@ -25,7 +25,6 @@ class AttributeServiceMWApiController extends WikiaController {
 
 		// Clear user cache
 		$user = User::newFromId( $userId );
-		User::clearUserCache( $user->getId() );
 		$user->invalidateCache();
 
 		// Clear User Profile cache

--- a/extensions/wikia/Staging/Staging.setup.php
+++ b/extensions/wikia/Staging/Staging.setup.php
@@ -31,4 +31,4 @@ $wgHooks['BeforePageRedirect'][] = 'StagingHooks::onBeforePageRedirect';
  */
 $wgBaseShareKeyPrefix = $wgSharedKeyPrefix;
 $wgCachePrefix = gethostname() . '-' . wfWikiID(); // e.g. staging-s3-muppet / sandbox-qa02-glee / ...
-$wgSharedKeyPrefix = Wikia::getCurrentServerSharedKeyPrefix();
+$wgSharedKeyPrefix = Wikia::getCurrentServerSharedKeyPrefix(); // e.g. staging-s3-wikicities

--- a/extensions/wikia/Staging/Staging.setup.php
+++ b/extensions/wikia/Staging/Staging.setup.php
@@ -29,5 +29,6 @@ $wgHooks['BeforePageRedirect'][] = 'StagingHooks::onBeforePageRedirect';
  * @author macbre
  * @see PLATFORM-664
  */
+$wgBaseShareKeyPrefix = $wgSharedKeyPrefix;
 $wgCachePrefix = gethostname() . '-' . wfWikiID(); // e.g. staging-s3-muppet / sandbox-qa02-glee / ...
-$wgSharedKeyPrefix = gethostname() . '-' . $wgSharedKeyPrefix; // e.g. staging-s3-wikicities
+$wgSharedKeyPrefix = Wikia::getCurrentServerSharedKeyPrefix();

--- a/includes/User.php
+++ b/includes/User.php
@@ -2123,8 +2123,6 @@ class User {
 		if( $this->mId ) {
 			global $wgMemc, $wgSharedDB; # Wikia
 			$wgMemc->delete( $this->getCacheKey() );
-			// Wikia: and save updated user data in the cache to avoid memcache miss and DB query
-			$this->saveToCache();
 			if( !empty( $wgSharedDB ) ) {
 				$memckey = self::getUserTouchedKey( $this->mId );
 				$wgMemc->set( $memckey, $this->mTouched );

--- a/includes/User.php
+++ b/includes/User.php
@@ -2165,9 +2165,8 @@ class User {
 				$dbw->update( '`user`',
 					array( 'user_touched' => $touched ), array( 'user_id' => $this->mId ),
 					__METHOD__ );
+				$dbw->commit();
 			}
-
-			$dbw->commit();
 
 			$this->clearSharedCache();
 		}

--- a/includes/User.php
+++ b/includes/User.php
@@ -2167,6 +2167,8 @@ class User {
 					__METHOD__ );
 			}
 
+			$dbw->commit();
+
 			$this->clearSharedCache();
 		}
 	}

--- a/includes/User.php
+++ b/includes/User.php
@@ -4889,15 +4889,17 @@ class User {
 	}
 
 	private function loadAttributes() {
-		global $wgEnableReadsFromAttributeService;
+		global $wgEnableReadsFromAttributeService, $wgPublicUserAttributes;
 
 		if ( !empty( $wgEnableReadsFromAttributeService ) ) {
-			$attributes = $this->userAttributes()->getAttributes($this->getId());
-			foreach ( $attributes as $attributeName => $attributeValue ) {
-				$this->compareAttributeValueFromService( $attributeName, $attributeValue );
+			$attributesFromService = $this->userAttributes()->getAttributes( $this->getId() );
 
-				 $this->mOptionOverrides[$attributeName] = $attributeValue;
-				 $this->mOptions[$attributeName] = $attributeValue;
+			// Currently the attribute service only stores public attributes. Once it stores private as well
+			// this can be updated to $wgUserAttributeWhitelist which contains all attributes
+			foreach ( $wgPublicUserAttributes as $attributeName ) {
+				$this->compareAttributeValueFromService( $attributeName, $attributesFromService[$attributeName] );
+				$this->mOptionOverrides[$attributeName] = $attributesFromService[$attributeName];
+				$this->mOptions[$attributeName] = $attributesFromService[$attributeName];
 			}
 		}
 	}

--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -2377,4 +2377,27 @@ class Wikia {
 		);
 		return true;
 	}
+
+    /**
+     * Get the sharedKeyPrefix for the current server (eg staging-s3, sandbox-s5). $wgSharedKeyPrefix is used
+     * inside of wfSharedMemcKey when constructing shared cache keys.
+     * @return string
+     */
+    public static function getCurrentServerSharedKeyPrefix() {
+
+        return self::getSharedKeyPrefix( gethostname() );
+    }
+
+    /**
+     * Get the sharedKeyPrefix for an arbitrary server. This allows us to set/clear the shared cached
+     * for multiple environments. (eg, if we're on preview, we can clear shared cache for a user, then
+     * update the value of $wgSharedKeyPrefix using this function passing in the hostname for verify,
+     * and then clear the cache there as well.
+     * @return string
+     */
+    public static function getSharedKeyPrefix( $hostname ) {
+        global $wgBaseShareKeyPrefix;
+
+        return $hostname . '-' . $wgBaseShareKeyPrefix; // e.g. staging-s3-wikicities
+    }
 }

--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -2398,6 +2398,6 @@ class Wikia {
     public static function getSharedKeyPrefix( $hostname ) {
         global $wgBaseShareKeyPrefix;
 
-        return $hostname . '-' . $wgBaseShareKeyPrefix; // e.g. staging-s3-wikicities
+        return $hostname . '-' . $wgBaseShareKeyPrefix;
     }
 }


### PR DESCRIPTION
When a client other than MediaWiki writes an attribute to the attribute service, the attribute service sends a request to MediaWiki to clear the user cache for that user.

The problem was clearing this user cache only cleared for one of 2 environments, production or dev. This meant if an attribute was updated in preview or verify, the cache wouldn't be cleared and the old value would continue to show. This ticket makes sure we clear the cache in all staging environments when an attribute is updated outside of dev.

Ticket: https://wikia-inc.atlassian.net/browse/SOC-1315
