### PR TITLE
fix equality checks

### DIFF
--- a/lib/Wikia/src/Service/User/Preferences/Migration/PreferenceCorrectionService.php
+++ b/lib/Wikia/src/Service/User/Preferences/Migration/PreferenceCorrectionService.php
@@ -69,7 +69,7 @@ class PreferenceCorrectionService {
 				if ( !$actualPreferences->hasGlobalPreference( $name ) ) {
 					$this->logMissingPreference( $userId, $name );
 					++$differences;
-				} elseif ( $actualPreferences->getGlobalPreference( $name ) !== $value ) {
+				} elseif ( $actualPreferences->getGlobalPreference( $name ) != $value ) {
 					$this->logPreferenceValueDifference( $userId, $name, $value, $actualPreferences->getGlobalPreference( $name ) );
 					++$differences;
 				}

--- a/lib/Wikia/src/Service/User/Preferences/PreferenceServiceImpl.php
+++ b/lib/Wikia/src/Service/User/Preferences/PreferenceServiceImpl.php
@@ -93,7 +93,7 @@ class PreferenceServiceImpl implements PreferenceService {
 	}
 
 	public function setGlobalPreference( $userId, $name, $value ) {
-		if ( $value == null ) {
+		if ( $value === null ) {
 			$value = $this->getGlobalDefault( $name );
 		}
 
@@ -118,7 +118,7 @@ class PreferenceServiceImpl implements PreferenceService {
 	}
 
 	public function setLocalPreference( $userId, $wikiId, $name, $value ) {
-		if ( $value == null ) {
+		if ( $value === null ) {
 			$value = $this->getLocalDefault($name, $wikiId );
 		}
 


### PR DESCRIPTION
@Wikia/services-team 
changing the equality check in the preference correction service to be non-strict, since in mediawiki `false`-like values get translated to empty strings when saving to the db, but from the preference service `false` is returned. Also changing the `null` check when setting preferences to be strict, because otherwise we couldn't set preferences to `false`-like values. 
