### PR TITLE
SEO-66 Fix SEO tweak for broken links and re-enable it

### DIFF
--- a/extensions/wikia/SEOTweaks/SEOTweaks.setup.php
+++ b/extensions/wikia/SEOTweaks/SEOTweaks.setup.php
@@ -17,7 +17,7 @@ $wgHooks['BeforePageDisplay'][] = 'SEOTweaksHooksHelper::onBeforePageDisplay';
 $wgHooks['AfterInitialize'][] = 'SEOTweaksHooksHelper::onAfterInitialize';
 $wgHooks['ImagePageAfterImageLinks'][] = 'SEOTweaksHooksHelper::onImagePageAfterImageLinks';
 $wgHooks['BeforeParserMakeImageLinkObjOptions'][] = 'SEOTweaksHooksHelper::onBeforeParserMakeImageLinkObjOptions';
-#$wgHooks['ArticleViewHeader'][] = 'SEOTweaksHooksHelper::onArticleViewHeader'; // macbre: disabled because of MON-416
+$wgHooks['ArticleViewHeader'][] = 'SEOTweaksHooksHelper::onArticleViewHeader';
 
 // messages
 $wgExtensionMessagesFiles['SEOTweaks'] = $dir . 'SEOTweaks.i18n.php';

--- a/extensions/wikia/SEOTweaks/SEOTweaksHooksHelper.class.php
+++ b/extensions/wikia/SEOTweaks/SEOTweaksHooksHelper.class.php
@@ -13,7 +13,7 @@ class SEOTweaksHooksHelper {
 	/**
 	 * List of hosts associated with external sharing services
 	 */
-	const SHARING_HOSTS_REGEX = '/\.(facebook)|(twitter)|(google)\./is';
+	const SHARING_HOSTS_REGEX = '/\.(facebook|twitter|google)\./is';
 
 	/**
 	 * @author mech
@@ -130,16 +130,23 @@ class SEOTweaksHooksHelper {
 	 */
 	static public function onArticleViewHeader( &$article, &$outputDone, &$pcache ) {
 		$title = $article->getTitle();
-		if ( ( ! $title->exists() )
-			&& ( isset( $_SERVER['HTTP_REFERER'] ) )
-			&& preg_match( self::SHARING_HOSTS_REGEX, parse_url( $_SERVER['HTTP_REFERER'], PHP_URL_HOST ) )
-		    ) {
+		if ( !$title->exists()
+				&& $title->isContentPage()
+				&& isset( $_SERVER['HTTP_REFERER'] )
+				&& preg_match( self::SHARING_HOSTS_REGEX, parse_url( $_SERVER['HTTP_REFERER'], PHP_URL_HOST ) )
+		) {
+			$namespace = $title->getNamespace();
 			$dbr = wfGetDB( DB_SLAVE );
-			$result = $dbr->query( sprintf( 'SELECT page_title FROM page WHERE page_title %s LIMIT 1', $dbr->buildLike( $title->getDBKey(), $dbr->anyString() ) ), __METHOD__ );
+			$query = sprintf(
+				'SELECT page_title FROM page WHERE page_title %s AND page_namespace = %d LIMIT 1',
+				$dbr->buildLike( $title->getDBKey(), $dbr->anyString() ),
+				$namespace
+			);
+			$result = $dbr->query( $query, __METHOD__ );
 			if ( $row = $dbr->fetchObject( $result ) ) {
-				$title = Title::newFromText( $row->page_title );
+				$title = Title::newFromText( $row->page_title, $namespace );
 				F::app()->wg->Out->redirect( $title->getFullUrl() );
-			    $outputDone = true;
+				$outputDone = true;
 			}
 		}
 		return true;

--- a/extensions/wikia/SEOTweaks/tests/SEOTweaksTest.php
+++ b/extensions/wikia/SEOTweaks/tests/SEOTweaksTest.php
@@ -2,14 +2,14 @@
 
 class SEOTweaksTest extends WikiaBaseTest
 {
-	
+
 	public function setUp() {
 		parent::setUp();
 		$this->helperMocker = $this->getMockBuilder( 'SEOTweaksHooksHelper' )
 									->disableOriginalConstructor();
 
 	}
-	
+
 	/**
 	 * @covers SEOTweaksHooksHelper::onBeforePageDisplay
 	 */
@@ -22,13 +22,13 @@ class SEOTweaksTest extends WikiaBaseTest
 						->disableOriginalConstructor()
 						->setMethods( array( 'addMeta', 'addLink' ) )
 						->getMock();
-		
+
 		$mockHelper = $this->helperMocker->setMethods( array( 'foo' ) ) // fake method required to run real methods
 										->getMock();
-		
+
 		$wgRefl = new ReflectionProperty( 'WikiaObject', 'wg' );
 		$wgRefl->setAccessible( true );
-		
+
 		$mockOut
 			->expects( $this->never() )
 			->method ( 'addMeta' )
@@ -37,14 +37,14 @@ class SEOTweaksTest extends WikiaBaseTest
 			->expects( $this->never() )
 			->method ( 'addLink' )
 		;
-		
+
 		// first, with neither setting -- nothing should happen
 		$this->assertTrue(
 				$mockHelper->onBeforePageDisplay( $mockOut ),
 				'SEOTweaksHooksHelper::onBeforePageDisplay should always return true'
 		);
 	}
-	
+
 	/**
 	 * @covers SEOTweaksHooksHelper::onBeforePageDisplay
 	 */
@@ -57,13 +57,13 @@ class SEOTweaksTest extends WikiaBaseTest
 						->disableOriginalConstructor()
 						->setMethods( array( 'addMeta', 'addLink' ) )
 						->getMock();
-		
+
 		$mockHelper = $this->helperMocker->setMethods( array( 'foo' ) ) // fake method required to run real methods
 										->getMock();
-		
+
 		$wgRefl = new ReflectionProperty( 'WikiaObject', 'wg' );
 		$wgRefl->setAccessible( true );
-		
+
 		$mockOut
 			->expects( $this->at( 0 ) )
 			->method ( 'addMeta' )
@@ -79,31 +79,31 @@ class SEOTweaksTest extends WikiaBaseTest
 				'SEOTweaksHooksHelper::onBeforePageDisplay should always return true'
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.01246 ms
 	 * @covers SEOTweaksHooksHelper::onAfterInitialize
 	 */
 	public function testOnAfterInitializeValid() {
-		
+
 		$mockHelper = $this->helperMocker->setMethods( array( 'foo' ) ) // fake method required to run real methods
 										->getMock();
-		
+
 		$mockTitle = $this->getMockBuilder( 'Title' )
 						->disableOriginalConstructor()
 						->setMethods( array( 'exists', 'isDeleted' ) )
 						->getMock();
-		
+
 		$mockArticle = $this->getMockBuilder( 'Article' )
 							->disableOriginalConstructor()
 							->getMock();
-		
+
 		$mockOut = $this->getMockbuilder( 'OutputPage' )
 						->disableOriginalConstructor()
 						->setMethods( array( 'setStatusCode' ) )
 						->getMock();
-		
+
 		$mockTitle
 			->expects( $this->at( 0 ) )
 			->method ( 'exists' )
@@ -119,37 +119,37 @@ class SEOTweaksTest extends WikiaBaseTest
 		;
 		$mockOut
 			->expects( $this->never() )
-			->method ( 'setStatusCode' ) 
+			->method ( 'setStatusCode' )
 		;
-		
+
 		$this->assertTrue(
 				$mockHelper->onAfterInitialize( $mockTitle, $mockArticle, $mockOut ),
 				'SEOTweaksHooksHelper::onAfterInitialize should always return true'
 		);
 	}
-	
+
 	/**
 	 * @covers SEOTweaksHooksHelper::onAfterInitialize
 	 */
 	public function testOnAfterInitializeNotValid() {
-		
+
 		$mockHelper = $this->helperMocker->setMethods( array( 'foo' ) ) // fake method required to run real methods
 										->getMock();
-		
+
 		$mockTitle = $this->getMockBuilder( 'Title' )
 						->disableOriginalConstructor()
 						->setMethods( array( 'exists', 'isDeleted', 'getNamespace' ) )
 						->getMock();
-		
+
 		$mockArticle = $this->getMockBuilder( 'Article' )
 							->disableOriginalConstructor()
 							->getMock();
-		
+
 		$mockOut = $this->getMockbuilder( 'OutputPage' )
 						->disableOriginalConstructor()
 						->setMethods( array( 'setStatusCode' ) )
 						->getMock();
-		
+
 		$mockTitle
 			->expects( $this->at( 0 ) )
 			->method ( 'exists' )
@@ -168,59 +168,59 @@ class SEOTweaksTest extends WikiaBaseTest
 		$mockOut
 			->expects( $this->at( 0 ) )
 			->method ( 'setStatusCode' )
-			->with   ( SEOTweaksHooksHelper::DELETED_PAGES_STATUS_CODE ) 
+			->with   ( SEOTweaksHooksHelper::DELETED_PAGES_STATUS_CODE )
 		;
-		
+
 		$this->assertTrue(
 				$mockHelper->onAfterInitialize( $mockTitle, $mockArticle, $mockOut ),
 				'SEOTweaksHooksHelper::onAfterInitialize should always return true'
 		);
 	}
-	
+
 	/**
 	 * @covers SEOTweaksHooksHelper::onImagePageAfterImageLinks
 	 * @group Broken
 	 */
 	public function testOnImagePageAfterImageLinksEmpties() {
-		
+
 		$mockHelper = $this->helperMocker->setMethods( array( 'foo' ) ) // fake method required to run real methods
 										->getMock();
-		
+
 		$mockImagePage = $this->getMockBuilder( 'ImagePage' )
 							->disableOriginalConstructor()
 							->setMethods( array( 'getDisplayedFile', 'getTitle' ) )
 							->getMock();
-		
+
 		$mockFileHelper = $this->getMockBuilder( 'WikiaFileHelper' )
 								->disableOriginalConstructor()
 								->setMethods( array( 'isFileTypeVideo' ) )
 								->getMock();
-		
+
 		$mockOut = $this->getMockBuilder( 'OutputPage' )
 						->disableOriginalConstructor()
 						->setMethods( array( 'setPageTitle' ) )
 						->getMock();
-		
+
 		$mockWrapper = $this->getMockBuilder( 'WikiaFunctionWrapper' )
 							->disableOriginalConstructor()
 							->setMethods( array( 'Msg' ) )
 							->getMock();
-		
+
 		$mockTitle = $this->getMockBuilder( 'Title' )
 							->disableOriginalConstructor()
 							->setMethods( array( 'getBaseText' ) )
 							->getMock();
-		
+
 		$mockFile = $this->getMockBuilder( 'File' )
 							->disableOriginalConstructor()
 							->setMethods( array( 'getHandler' ) )
 							->getMock();
 
-		
+
 		$wfRefl = new ReflectionProperty( 'WikiaObject', 'wf' );
 		$wfRefl->setAccessible( true );
 		$wfRefl->setValue( $mockHelper, $mockWrapper );
-		
+
 		$mockImagePage
 			->expects( $this->at( 0 ) )
 			->method ( 'getDisplayedFile' )
@@ -240,15 +240,15 @@ class SEOTweaksTest extends WikiaBaseTest
 			->expects( $this->never() )
 			->method ( 'setPageTitle' )
 		;
-		
+
 		$this->mockClass( 'WikiaFileHelper', $mockFileHelper );
-		
+
 		$this->assertTrue(
 				$mockHelper->onImagePageAfterImageLinks( $mockImagePage, '' ),
 				'SEOTweaksHooksHelper::onImagePageAfterImageLinks should always return true'
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @group Broken
@@ -256,44 +256,44 @@ class SEOTweaksTest extends WikiaBaseTest
 	 * @covers SEOTweaksHooksHelper::onImagePageAfterImageLinks
 	 */
 	public function testOnImagePageAfterImageLinksImage() {
-		
+
 		$mockHelper = $this->helperMocker->setMethods( array( 'foo' ) ) // fake method required to run real methods
 										->getMock();
-		
+
 		$mockImagePage = $this->getMockBuilder( 'ImagePage' )
 							->disableOriginalConstructor()
 							->setMethods( array( 'getDisplayedFile', 'getTitle' ) )
 							->getMock();
-		
+
 		$mockFileHelper = $this->getMockBuilder( 'WikiaFileHelper' )
 								->disableOriginalConstructor()
 								->setMethods( array( 'isFileTypeVideo' ) )
 								->getMock();
-		
+
 		$mockOut = $this->getMockBuilder( 'OutputPage' )
 						->disableOriginalConstructor()
 						->setMethods( array( 'setPageTitle' ) )
 						->getMock();
-		
+
 		$mockWrapper = $this->getMockBuilder( 'WikiaFunctionWrapper' )
 							->disableOriginalConstructor()
 							->setMethods( array( 'Msg' ) )
 							->getMock();
-		
+
 		$mockTitle = $this->getMockBuilder( 'Title' )
 							->disableOriginalConstructor()
 							->setMethods( array( 'getBaseText' ) )
 							->getMock();
-		
+
 		$mockFile = $this->getMockBuilder( 'LocalFile' )
 							->disableOriginalConstructor()
 							->setMethods( array( 'getHandler' ) )
 							->getMock();
-		
+
 		$mockHandler = $this->getMockBuilder( 'JpegHandler' )
 							->disableOriginalConstructor()
 							->getMock();
-		
+
 		$mockImagePage
 			->expects( $this->at( 0 ) )
 			->method ( 'getDisplayedFile' )
@@ -338,7 +338,7 @@ class SEOTweaksTest extends WikiaBaseTest
 				'SEOTweaksHooksHelper::onImagePageAfterImageLinks should always return true'
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @group Broken
@@ -346,39 +346,39 @@ class SEOTweaksTest extends WikiaBaseTest
 	 * @covers SEOTweaksHooksHelper::onImagePageAfterImageLinks
 	 */
 	public function testOnImagePageAfterImageLinksVideo() {
-		
+
 		$mockHelper = $this->helperMocker->setMethods( array( 'foo' ) ) // fake method required to run real methods
 										->getMock();
-		
+
 		$mockImagePage = $this->getMockBuilder( 'ImagePage' )
 							->disableOriginalConstructor()
 							->setMethods( array( 'getDisplayedFile', 'getTitle' ) )
 							->getMock();
-		
+
 		$mockFileHelper = $this->getMockBuilder( 'WikiaFileHelper' )
 								->disableOriginalConstructor()
 								->setMethods( array( 'isFileTypeVideo' ) )
 								->getMock();
-		
+
 		$mockOut = $this->getMockBuilder( 'OutputPage' )
 						->disableOriginalConstructor()
 						->setMethods( array( 'setPageTitle' ) )
 						->getMock();
-		
+
 		$mockTitle = $this->getMockBuilder( 'Title' )
 							->disableOriginalConstructor()
 							->setMethods( array( 'getBaseText' ) )
 							->getMock();
-		
+
 		$mockFile = $this->getMockBuilder( 'LocalFile' )
 							->disableOriginalConstructor()
 							->setMethods( array( 'getHandler' ) )
 							->getMock();
-		
+
 		$mockHandler = $this->getMockBuilder( 'JpegHandler' )
 							->disableOriginalConstructor()
 							->getMock();
-		
+
 		$mockImagePage
 			->expects( $this->at( 0 ) )
 			->method ( 'getDisplayedFile' )
@@ -418,7 +418,7 @@ class SEOTweaksTest extends WikiaBaseTest
 				'SEOTweaksHooksHelper::onImagePageAfterImageLinks should always return true'
 		);
 	}
-	
+
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.02121 ms
@@ -428,29 +428,29 @@ class SEOTweaksTest extends WikiaBaseTest
 	public function testBeforeParserMakeImageLinkObjOptionsAltIsset() {
 		$mockHelper = $this->helperMocker->setMethods( array( 'foo' ) ) // fake method required to run real methods
 										->getMock();
-		
+
 		$mockTitle = $this->getMockBuilder( 'Title' )
 							->disableOriginalConstructor()
 							->setMethods( array( 'getNamespace' ) )
 							->getMock();
-		
+
 		$mockParser = $this->getMockBuilder( 'Parser' )
 							->disableOriginalConstructor()
 							->getMock();
-		
+
 		$parts = array( 'alt=This is my alt text' );
 		$descQuery = false;
 		$time = time();
 		$options = array();
 		$descQuery = false;
 		$params = array();
-		
+
 		$mockTitle
 			->expects( $this->at( 0 ) )
 			->method ( 'getNamespace' )
 			->will   ( $this->returnValue( NS_FILE ) )
 		;
-		
+
 		$this->assertTrue(
 				$mockHelper->onBeforeParserMakeImageLinkObjOptions( $mockParser, $mockTitle, $parts, $params, $time, $descQuery, $options ),
 				'SEOTweaksHooksHelper::onBeforeParserMakeImageLinkObjOptions should always return true'
@@ -466,7 +466,7 @@ class SEOTweaksTest extends WikiaBaseTest
 				'SEOTweaksHooksHelper::onBeforeParserMakeImageLinkObjOptions should not change the alt text if the option has already been set'
 		);
 	}
-	
+
 	/**
 	 * If the file already has alt text, do nothing
 	 * @covers SEOTweaksHooksHelper::onBeforeParserMakeImageLinkObjOptions
@@ -474,22 +474,22 @@ class SEOTweaksTest extends WikiaBaseTest
 	public function testOnBeforeParserMakeImageLinkObjOptionsNoAlt() {
 		$mockHelper = $this->helperMocker->setMethods( array( 'foo' ) ) // fake method required to run real methods
 										->getMock();
-		
+
 		$mockTitle = $this->getMockBuilder( 'Title' )
 							->disableOriginalConstructor()
 							->setMethods( array( 'getNamespace', 'getText' ) )
 							->getMock();
-		
+
 		$mockParser = $this->getMockBuilder( 'Parser' )
 							->disableOriginalConstructor()
 							->getMock();
-		
+
 		$parts = array();
 		$descQuery = false;
 		$time = time();
 		$options = array();
 		$params = array();
-		
+
 		$mockTitle
 			->expects( $this->at( 0 ) )
 			->method ( 'getNamespace' )
@@ -510,7 +510,7 @@ class SEOTweaksTest extends WikiaBaseTest
 				'SEOTweaksHooksHelper::onBeforeParserMakeImageLinkObjOptions should add an alt tag stripping out the file extension if no alt tag has been set'
 		);
 	}
-	
+
 	/**
 	 * @covers SEOTweaksHooksHelper::onArticleViewHeader
 	 */
@@ -518,25 +518,25 @@ class SEOTweaksTest extends WikiaBaseTest
 	{
 		$mockHelper = $this->helperMocker->setMethods( array( 'foo' ) ) // fake method required to run real methods
 		                                 ->getMock();
-		
+
 		$mockArticle = $this->getMockBuilder( 'Article' )
 		                    ->disableOriginalConstructor()
 		                    ->setMethods( array( 'getTitle' ) )
 		                    ->getMock();
-		
+
 		$mockTitle = $this->getMockBuilder( 'Title' )
 		                  ->disableOriginalConstructor()
 		                  ->setMethods( array( 'exists' ) )
 		                  ->getMock();
-		
+
 		$mockWrapper = $this->getMockBuilder( 'WikiaFunctionWrapper' )
 		                    ->disableOriginalConstructor()
 		                    ->setMethods( array( 'GetDB' ) )
 		                    ->getMock();
-		
+
 		$outputDone = false;
 		$pcache = false;
-		
+
 		$mockArticle
 		    ->expects( $this->at( 0 ) )
 		    ->method ( 'getTitle' )
@@ -551,21 +551,21 @@ class SEOTweaksTest extends WikiaBaseTest
 		    ->expects( $this->never() )
 		    ->method ( 'getDB' )
 		;
-		
+
 		$reflWf = new ReflectionProperty( 'WikiaObject', 'wf' );
 		$reflWf->setAccessible( true );
 		$reflWf->setValue( $mockHelper, $mockWrapper );
-		
+
 		$this->assertTrue(
 				$mockHelper->onArticleViewHeader( $mockArticle, $outputDone, $pcache),
 				'SEOTweaksHooksHelper::onArticleViewHeader should always return true'
 		);
 		$this->assertFalse(
 				$outputDone,
-				'$outputDone should not be set to true by SEOTweaksHooksHelper::onArticleViewHeader unless we redirect' 
+				'$outputDone should not be set to true by SEOTweaksHooksHelper::onArticleViewHeader unless we redirect'
 		);
 	}
-	
+
     /**
 	 * @covers SEOTweaksHooksHelper::onArticleViewHeader
 	 */
@@ -573,25 +573,25 @@ class SEOTweaksTest extends WikiaBaseTest
 	{
 		$mockHelper = $this->helperMocker->setMethods( array( 'foo' ) ) // fake method required to run real methods
 		                                 ->getMock();
-		
+
 		$mockArticle = $this->getMockBuilder( 'Article' )
 		                    ->disableOriginalConstructor()
 		                    ->setMethods( array( 'getTitle' ) )
 		                    ->getMock();
-		
+
 		$mockTitle = $this->getMockBuilder( 'Title' )
 		                  ->disableOriginalConstructor()
 		                  ->setMethods( array( 'exists' ) )
 		                  ->getMock();
-		
+
 		$mockWrapper = $this->getMockBuilder( 'WikiaFunctionWrapper' )
 		                    ->disableOriginalConstructor()
 		                    ->setMethods( array( 'GetDB' ) )
 		                    ->getMock();
-		
+
 		$outputDone = false;
 		$pcache = false;
-		
+
 		$mockArticle
 		    ->expects( $this->at( 0 ) )
 		    ->method ( 'getTitle' )
@@ -606,21 +606,21 @@ class SEOTweaksTest extends WikiaBaseTest
 		    ->expects( $this->never() )
 		    ->method ( 'getDB' )
 		;
-		
+
 		$reflWf = new ReflectionProperty( 'WikiaObject', 'wf' );
 		$reflWf->setAccessible( true );
 		$reflWf->setValue( $mockHelper, $mockWrapper );
-		
+
 		$this->assertTrue(
 				$mockHelper->onArticleViewHeader( $mockArticle, $outputDone, $pcache),
 				'SEOTweaksHooksHelper::onArticleViewHeader should always return true'
 		);
 		$this->assertFalse(
 				$outputDone,
-				'$outputDone should not be set to true by SEOTweaksHooksHelper::onArticleViewHeader unless we redirect' 
+				'$outputDone should not be set to true by SEOTweaksHooksHelper::onArticleViewHeader unless we redirect'
 		);
 	}
-	
+
 	/**
      * @group Slow
      * @slowExecutionTime 0.03886 ms
@@ -630,41 +630,51 @@ class SEOTweaksTest extends WikiaBaseTest
 	{
 		$mockHelper = $this->helperMocker->setMethods( array( 'foo' ) ) // fake method required to run real methods
 		                                 ->getMock();
-		
+
 		$mockArticle = $this->getMockBuilder( 'Article' )
 		                    ->disableOriginalConstructor()
 		                    ->setMethods( array( 'getTitle' ) )
 		                    ->getMock();
-		
+
 		$mockTitle = $this->getMockBuilder( 'Title' )
 		                  ->disableOriginalConstructor()
-		                  ->setMethods( array( 'exists', 'getDBKey' ) )
+		                  ->setMethods( array( 'exists', 'getDBKey', 'isContentPage', 'getNamespace' ) )
 		                  ->getMock();
-		
+
 		$mockDb = $this->getMockBuilder( "DatabaseMysql" )
 		               ->disableOriginalConstructor()
 		               ->setMethods( array( 'query', 'fetchObject', 'buildLike', 'anyString' ) )
 		               ->getMock();
-		
+
 		$mockResultWrapper = $this->getMockBuilder( 'ResultWrapper' )
 		                          ->disableOriginalConstructor()
 		                          ->getMock();
-		
+
 		$outputDone = false;
 		$pcache = false;
-		
+
 		$dbKey = "Wanted";
-		$_SERVER['HTTP_REFERER'] = 'http://www.facebook.com'; 
-		
+		$_SERVER['HTTP_REFERER'] = 'http://www.facebook.com';
+
 		$mockArticle
-		    ->expects( $this->at( 0 ) )
+		    ->expects( $this->once() )
 		    ->method ( 'getTitle' )
 		    ->will   ( $this->returnValue( $mockTitle ) )
 		;
 		$mockTitle
-		    ->expects( $this->at( 0 ) )
-		    ->method ( 'exists' )
-		    ->will   ( $this->returnValue( false ) )
+			->expects( $this->once() )
+			->method ( 'exists' )
+			->will   ( $this->returnValue( false ) )
+		;
+		$mockTitle
+			->expects( $this->once() )
+			->method ( 'isContentPage' )
+			->will   ( $this->returnValue( true ) )
+		;
+		$mockTitle
+			->expects( $this->once() )
+			->method ( 'getNamespace' )
+			->will   ( $this->returnValue( 66 ) )
 		;
 		/*
 		$mockWrapper
@@ -674,29 +684,29 @@ class SEOTweaksTest extends WikiaBaseTest
 		;
 		*/
 		$mockTitle
-		    ->expects( $this->at( 1 ) )
-		    ->method ( 'getDBKey' )
-		    ->will   ( $this->returnValue( $dbKey ) )
+			->expects( $this->once() )
+			->method ( 'getDBKey' )
+			->will   ( $this->returnValue( $dbKey ) )
 		;
 		$mockDb
-		    ->expects( $this->at( 0 ) )
+		    ->expects( $this->once() )
 		    ->method ( 'anyString' )
 		    ->will   ( $this->returnValue( '%' ) )
 		;
 		$mockDb
-		    ->expects( $this->at( 1 ) )
+		    ->expects( $this->once() )
 		    ->method ( 'buildLike' )
 		    ->with   ( $dbKey, '%' )
 		    ->will   ( $this->returnValue( "LIKE '{$dbKey}%'" ) )
 		;
 		$mockDb
-		    ->expects( $this->at( 2 ) )
+		    ->expects( $this->once() )
 		    ->method ( 'query' )
-		    ->with   ( "SELECT page_title FROM page WHERE page_title LIKE '{$dbKey}%' LIMIT 1" )
+		    ->with   ( "SELECT page_title FROM page WHERE page_title LIKE '{$dbKey}%' AND page_namespace = 66 LIMIT 1" )
 		    ->will   ( $this->returnValue( $mockResultWrapper ) )
 		;
 		$mockDb
-		    ->expects( $this->at( 3 ) )
+		    ->expects( $this->once() )
 		    ->method ( 'fetchObject' )
 		    ->will   ( $this->returnValue( null ) )
 		;
@@ -715,10 +725,10 @@ class SEOTweaksTest extends WikiaBaseTest
 		);
 		$this->assertFalse(
 				$outputDone,
-				'$outputDone should not be set to true by SEOTweaksHooksHelper::onArticleViewHeader unless we redirect' 
+				'$outputDone should not be set to true by SEOTweaksHooksHelper::onArticleViewHeader unless we redirect'
 		);
 	}
-	
+
 	/**
      * @group Slow
      * @slowExecutionTime 0.09149 ms
@@ -728,26 +738,26 @@ class SEOTweaksTest extends WikiaBaseTest
 	{
 		$mockHelper = $this->helperMocker->setMethods( array( 'foo' ) ) // fake method required to run real methods
 		                                 ->getMock();
-		
+
 		$mockArticle = $this->getMockBuilder( 'Article' )
 		                    ->disableOriginalConstructor()
 		                    ->setMethods( array( 'getTitle' ) )
 		                    ->getMock();
-		
+
 		$mockTitle = $this->getMockBuilder( 'Title' )
 		                  ->disableOriginalConstructor()
-		                  ->setMethods( array( 'exists', 'getDBKey', 'getFullUrl' ) )
+		                  ->setMethods( array( 'exists', 'getDBKey', 'getFullUrl', 'isContentPage', 'getNamespace' ) )
 		                  ->getMock();
-		
+
 		$mockDb = $this->getMockBuilder( "DatabaseMysql" )
 		               ->disableOriginalConstructor()
 		               ->setMethods( array( 'query', 'fetchObject', 'buildLike', 'anyString' ) )
 		               ->getMock();
-		
+
 		$mockResultWrapper = $this->getMockBuilder( 'ResultWrapper' )
 		                          ->disableOriginalConstructor()
 		                          ->getMock();
-		
+
 		$mockOut = $this->getMockBuilder( 'OutputPage' )
 		                ->disableOriginalConstructor()
 		                ->setMethods( array( 'redirect' ) )
@@ -755,60 +765,70 @@ class SEOTweaksTest extends WikiaBaseTest
 
 		$outputDone = false;
 		$pcache = false;
-		
+
 		$dbKey = "Wanted";
 		$_SERVER['HTTP_REFERER'] = 'http://www.facebook.com';
 		$resultObject = (object) array( 'page_title' => "Wanted!" );
 		$fullUrl = 'http://foo.wikia.com/wiki/Wanted!';
-		
+
 		$mockArticle
-		    ->expects( $this->at( 0 ) )
+		    ->expects( $this->once() )
 		    ->method ( 'getTitle' )
 		    ->will   ( $this->returnValue( $mockTitle ) )
 		;
 		$mockTitle
-		    ->expects( $this->at( 0 ) )
+		    ->expects( $this->once() )
 		    ->method ( 'exists' )
 		    ->will   ( $this->returnValue( false ) )
 		;
 		$mockTitle
-		    ->expects( $this->at( 1 ) )
-		    ->method ( 'getDBKey' )
-		    ->will   ( $this->returnValue( $dbKey ) )
+			->expects( $this->once() )
+			->method ( 'getDBKey' )
+			->will   ( $this->returnValue( $dbKey ) )
+		;
+		$mockTitle
+			->expects( $this->once() )
+			->method ( 'getNamespace' )
+			->will   ( $this->returnValue( 66 ) )
+		;
+		$mockTitle
+			->expects( $this->once() )
+			->method ( 'isContentPage' )
+			->will   ( $this->returnValue( true ) )
 		;
 		$mockDb
-		    ->expects( $this->at( 0 ) )
+		    ->expects( $this->once() )
 		    ->method ( 'anyString' )
 		    ->will   ( $this->returnValue( '%' ) )
 		;
 		$mockDb
-		    ->expects( $this->at( 1 ) )
+		    ->expects( $this->once() )
 		    ->method ( 'buildLike' )
 		    ->with   ( $dbKey, '%' )
 		    ->will   ( $this->returnValue( "LIKE '{$dbKey}%'" ) )
 		;
 		$mockDb
-		    ->expects( $this->at( 2 ) )
+		    ->expects( $this->once() )
 		    ->method ( 'query' )
-		    ->with   ( "SELECT page_title FROM page WHERE page_title LIKE '{$dbKey}%' LIMIT 1" )
+		    ->with   ( "SELECT page_title FROM page WHERE page_title LIKE '{$dbKey}%' AND page_namespace = 66 LIMIT 1" )
 		    ->will   ( $this->returnValue( $mockResultWrapper ) )
 		;
 		$mockDb
-		    ->expects( $this->at( 3 ) )
+		    ->expects( $this->once() )
 		    ->method ( 'fetchObject' )
 		    ->will   ( $this->returnValue( $resultObject ) )
 		;
 		$mockTitle
-		    ->expects( $this->at( 2 ) )
+		    ->expects( $this->once() )
 		    ->method ( 'getFullUrl' )
 		    ->will   ( $this->returnValue( $fullUrl ) )
 		;
 		$mockOut
-		    ->expects( $this->at( 0 ) )
+		    ->expects( $this->once() )
 		    ->method ( 'redirect' )
 		    ->with   ( $fullUrl )
 		;
-		
+
 		$this->mockClass( 'Title', $mockTitle );
 		$this->mockClass( 'Title', $mockTitle, 'newFromText' );
 		$this->mockGlobalFunction('wfGetDB',$mockDb);
@@ -820,8 +840,8 @@ class SEOTweaksTest extends WikiaBaseTest
 		);
 		$this->assertTrue(
 				$outputDone,
-				'$outputDone should be set to true by SEOTweaksHooksHelper::onArticleViewHeader if we redirect' 
+				'$outputDone should be set to true by SEOTweaksHooksHelper::onArticleViewHeader if we redirect'
 		);
 	}
-	
+
 }


### PR DESCRIPTION
Reverts #8369 which might be the cause for the traffic drop.

The code is now enabled only for the content namespaces, which should eliminate the database calls for Thread pages.

Single queries are rather fast (roughly 0.1-0.3 seconds) so it seems it's the number of queries that made the database slow.

With this fix the number of queries should be reasonably small and traffic regained.
