### PR TITLE
PLATFORM-1494: store the full URL of the predefined avatar and skip an upload via service

### DIFF
--- a/extensions/wikia/UserProfilePageV3/Masthead.class.php
+++ b/extensions/wikia/UserProfilePageV3/Masthead.class.php
@@ -5,7 +5,7 @@ class Masthead {
 	/**
 	 * default avatar path
 	 */
-	public $mDefaultPath = 'http://images.wikia.com/messaging/images/';
+	const DEFAULT_PATH = 'http://images.wikia.com/messaging/images/';
 
 	/**
 	 * path to file, relative
@@ -127,7 +127,7 @@ class Masthead {
 		if ( is_array( $images ) ) {
 			foreach ( $images as $image ) {
 				$hash = FileRepo::getHashPathForLevel( $image, 2 );
-				$this->mDefaultAvatars[] = $this->mDefaultPath . $thumb . $hash . $image;
+				$this->mDefaultAvatars[] = self::DEFAULT_PATH . $thumb . $hash . $image;
 			}
 		}
 
@@ -239,7 +239,7 @@ class Masthead {
 				 * default avatar, path from messaging.wikia.com
 				 */
 				$hash = FileRepo::getHashPathForLevel( $url, 2 );
-				$url = $this->mDefaultPath . trim( $thumb, '/' ) . '/' . $hash . $url;
+				$url = self::DEFAULT_PATH . trim( $thumb, '/' ) . '/' . $hash . $url;
 			}
 		} else {
 			$defaults = $this->getDefaultAvatars( trim( $thumb, "/" ) . "/" );

--- a/extensions/wikia/UserProfilePageV3/Masthead.class.php
+++ b/extensions/wikia/UserProfilePageV3/Masthead.class.php
@@ -205,6 +205,20 @@ class Masthead {
 	}
 
 	/**
+	 * Return a full avatar for a given default avatar
+	 *
+	 * @param string $avatar (e.g. Avatar3.jpg)
+	 * @return string full URL (e.g. http://images.wikia.com/messaging/images/4/46/Avatar3.jpg)
+	 */
+	public static function getDefaultAvatarUrl( $avatar ) {
+		/**
+		 * default avatar, path from messaging.wikia.com
+		 */
+		$hash = FileRepo::getHashPathForLevel( $avatar, 2 );
+		return self::DEFAULT_PATH . $hash . $avatar;
+	}
+
+	/**
 	 * getPurgeUrl -- the basic URL (without image server rewriting, cachebuster,
 	 * etc.) of the avatar.  This can be sent to squid to purge it.
 	 *
@@ -238,8 +252,7 @@ class Masthead {
 				/**
 				 * default avatar, path from messaging.wikia.com
 				 */
-				$hash = FileRepo::getHashPathForLevel( $url, 2 );
-				$url = self::DEFAULT_PATH . trim( $thumb, '/' ) . '/' . $hash . $url;
+				$url = self::getDefaultAvatarUrl( $url );
 			}
 		} else {
 			$defaults = $this->getDefaultAvatars( trim( $thumb, "/" ) . "/" );

--- a/extensions/wikia/UserProfilePageV3/UserProfilePageController.class.php
+++ b/extensions/wikia/UserProfilePageV3/UserProfilePageController.class.php
@@ -526,9 +526,8 @@ class UserProfilePageController extends WikiaController {
 			if ( empty( $wgAvatarsUseService ) ) {
 				// TODO: $user->getTouched() get be used to invalidate avatar URLs instead
 				$user->setGlobalAttribute( 'avatar_rev', date( 'U' ) );
+				$user->saveSettings();
 			}
-
-			$user->saveSettings();
 		}
 
 		wfProfileOut( __METHOD__ );

--- a/extensions/wikia/UserProfilePageV3/UserProfilePageController.class.php
+++ b/extensions/wikia/UserProfilePageV3/UserProfilePageController.class.php
@@ -507,6 +507,7 @@ class UserProfilePageController extends WikiaController {
 					else {
 						// store the full URL of the predefined avatar and skip an upload via service (PLATFORM-1494)
 						$user->setGlobalAttribute( AVATAR_USER_OPTION_NAME, Masthead::getDefaultAvatarUrl( $data->file ) );
+						$user->saveSettings();
 					}
 					break;
 				case 'uploaded':

--- a/extensions/wikia/UserProfilePageV3/UserProfilePageController.class.php
+++ b/extensions/wikia/UserProfilePageV3/UserProfilePageController.class.php
@@ -504,6 +504,10 @@ class UserProfilePageController extends WikiaController {
 					if ( empty( $wgAvatarsUseService ) ) {
 						$user->setGlobalAttribute( AVATAR_USER_OPTION_NAME, $data->file );
 					}
+					else {
+						// store the full URL of the predefined avatar and skip an upload via service (PLATFORM-1494)
+						$user->setGlobalAttribute( AVATAR_USER_OPTION_NAME, Masthead::getDefaultAvatarUrl( $data->file ) );
+					}
 					break;
 				case 'uploaded':
 					$errorMsg = wfMessage( 'userprofilepage-interview-save-internal-error' )->escaped();
@@ -522,8 +526,9 @@ class UserProfilePageController extends WikiaController {
 			if ( empty( $wgAvatarsUseService ) ) {
 				// TODO: $user->getTouched() get be used to invalidate avatar URLs instead
 				$user->setGlobalAttribute( 'avatar_rev', date( 'U' ) );
-				$user->saveSettings();
 			}
+
+			$user->saveSettings();
 		}
 
 		wfProfileOut( __METHOD__ );

--- a/extensions/wikia/UserProfilePageV3/tests/MastheadTest.php
+++ b/extensions/wikia/UserProfilePageV3/tests/MastheadTest.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @group Avatar
+ */
 class MastheadTest extends WikiaBaseTest {
 
 	/**
@@ -48,7 +51,7 @@ class MastheadTest extends WikiaBaseTest {
 			// one of the default avatars
 			[
 				'avatarOption' => 'Avatar2.jpg',
-				'expectedUrl'  => 'http://images.wikia.com/messaging/images//e/e8/Avatar2.jpg',
+				'expectedUrl'  => 'http://images.wikia.com/messaging/images/e/e8/Avatar2.jpg',
 			],
 		];
 	}

--- a/includes/wikia/services/AvatarService.class.php
+++ b/includes/wikia/services/AvatarService.class.php
@@ -268,7 +268,7 @@ class AvatarService extends Service {
 				$url = self::vignetteCustomUrl( $width, $relativePath, $timestamp );
 			} else { // wikia-provided avatars
 				$hash = FileRepo::getHashPathForLevel( $relativePath, 2 );
-				$bucket = VignetteRequest::parseBucket( $masthead->mDefaultPath );
+				$bucket = VignetteRequest::parseBucket( Masthead::DEFAULT_PATH );
 				$relativePath = $hash . $relativePath;
 				$url = self::buildVignetteUrl( $width, $bucket, $relativePath, $timestamp, false );
 			}


### PR DESCRIPTION
When the avatar service is enabled **always** store the full avatar URL - even if it's one of the predefined ones

``` sql
mysql> select * from user_properties where up_user = 119245 and up_property = 'avatar';
+---------+-------------+-----------------------------------------------------------+
| up_user | up_property | up_value                                                  |
+---------+-------------+-----------------------------------------------------------+
|  119245 | avatar      | http://images.wikia.com/messaging/images/c/cf/Avatar6.jpg |
+---------+-------------+-----------------------------------------------------------+
```

See #8181 for more context

@jcellary / @jsutterfield 
