### PR TITLE
this is really a flag

### DIFF
--- a/extensions/wikia/EditPageLayout/models/EditorUserPropertiesHandler.class.php
+++ b/extensions/wikia/EditPageLayout/models/EditorUserPropertiesHandler.class.php
@@ -17,7 +17,7 @@ class EditorUserPropertiesHandler extends WikiaUserPropertiesHandlerBase {
 		} else {
 			$this->throwExceptionForAnons();
 
-			$this->wg->User->setLocalPreference(MAIN_PAGE_NOTIFICATIONS_HIDDEN_PROP_NAME, true, $this->app->wg->CityId);
+			$this->wg->User->setLocalFlag(self::MAIN_PAGE_NOTIFICATIONS_HIDDEN_PROP_NAME, true, $this->app->wg->CityId);
 			$this->wg->User->saveSettings();
 			$results->success = true;
 		}
@@ -25,7 +25,7 @@ class EditorUserPropertiesHandler extends WikiaUserPropertiesHandlerBase {
 	}
     
 	public function getEditorMainPageNoticePropertyForCurrentUser() {
-		return $this->wg->User->getLocalPreference(MAIN_PAGE_NOTIFICATIONS_HIDDEN_PROP_NAME, $this->app->wg->CityId);
+		return $this->wg->User->getLocalFlag(self::MAIN_PAGE_NOTIFICATIONS_HIDDEN_PROP_NAME, $this->app->wg->CityId);
 	}
 
 }


### PR DESCRIPTION
@Wikia/services-team 

This is really a flag which controls a small one-time notif a user sees. Note that this was previously broken to not use the constant, so this changeset also fixes that.

See Wikia/config#1325 for the config change
