### PR TITLE
SEO-67 Allow broader redirects from /foo:bar to /wiki/Foo:Bar

### DIFF
--- a/extensions/wikia/Our404Handler/SpecialOur404Handler_body.php
+++ b/extensions/wikia/Our404Handler/SpecialOur404Handler_body.php
@@ -43,7 +43,7 @@ class Our404HandlerPage extends UnlistedSpecialPage {
 	 * Just render some simple 404 page
 	 */
 	public function doRender404() {
-		global $wgOut, $wgContLang, $wgCanonicalNamespaceNames;
+		global $wgOut, $wgContLang, $wgCanonicalNamespaceNames, $wgOur404HandlerBroaderRedirects;
 
 		/**
 		 * check, maybe we have article with that title, if yes 301redirect to
@@ -83,7 +83,9 @@ class Our404HandlerPage extends UnlistedSpecialPage {
 		if( !is_null( $oTitle ) ) {
 			// Preserve the query string on a redirect
 			$query = parse_url ( $_SERVER['REQUEST_URI'], PHP_URL_QUERY );
-			if( $namespace == NS_SPECIAL || $namespace == NS_MEDIA ) {
+			if( $namespace == NS_SPECIAL || $namespace == NS_MEDIA
+				|| ( $namespace && $wgOur404HandlerBroaderRedirects )
+			) {
 				/**
 				 * these namespaces are special and don't have articles
 				 */


### PR DESCRIPTION
It seems the redirects are not present when the destination page is not a proper article, like:
- http://marvel.wikia.com/Thread:838034 ($title->exists() return false)
- http://marvel.wikia.com/Category:2005_Character_Debuts (the category is correct, but the category page is empty)

while "the regular" articles are fine:
- http://marvel.wikia.com/Charlotte_Beck_(Earth-148611)
- http://marvel.wikia.com/Category:Framework (the category page has some content)

Interestingly MediaWiki itself should always redirect from /fooabc to /wiki/Fooabc, like it happens on devboxes:

http://muppet.rychu.wikia-dev.com/fooabc redirects to http://muppet.rychu.wikia-dev.com/wiki/Fooabc

For some reason back in 2008 we implemented a "smart" redirect that first checks whether the page it's about to redirect you to actually exists. The problem is the check is not really precise and fails with the examples above.

I'm going to code the following fix:
-    If the URL corresponds to any non-main namespace, the code will redirect you to /wiki/The:Rest_of_the_URL without checking if the destination page exists or not
-    If the URL corresponds to the main namespace, the code will behave as before: check if the destination page exists or not and only redirect if there is such article
-    The new behavior will be guarded with $wgOur404HandlerBroaderRedirects
-    $wgOur404HandlerBroaderRedirects will be enabled on marvel and gta wikis only to check whether it helps and if it's safe

Long term solution:
-    Remove Our404Handler if there's no more use for it and let MediaWiki always do the redirects (even to non-existing articles)
