### PR TITLE
LocalPreference usage fixes

### DIFF
--- a/extensions/wikia/AutomaticWikiAdoption/AutomaticWikiAdoptionHelper.class.php
+++ b/extensions/wikia/AutomaticWikiAdoption/AutomaticWikiAdoptionHelper.class.php
@@ -190,7 +190,7 @@ class AutomaticWikiAdoptionHelper {
 					//log
 					self::addLogEntry($admin, $oldGroups, $newGroups);
 					//Unset preference for receiving future adoption emails
-					$admin->setLocalPreference( "adoptionmails", $wikiId, 0 );
+					$admin->setLocalPreference( "adoptionmails", 0, $wikiId );
 					$admin->saveSettings();
 				}
 			}

--- a/extensions/wikia/FounderEmails/events/FounderEmailsDaysPassedEvent.class.php
+++ b/extensions/wikia/FounderEmails/events/FounderEmailsDaysPassedEvent.class.php
@@ -79,13 +79,13 @@ class FounderEmailsDaysPassedEvent extends FounderEmailsEvent {
 	}
 
 	public static function register( $wikiParams, $debugMode = false ) {
-		global $wgFounderEmailsEvents;
+		global $wgFounderEmailsEvents, $wgCityId;
 
 		$founderEmailObj = FounderEmails::getInstance();
 
 		$wikiFounder = $founderEmailObj->getWikiFounder();
-		$wikiFounder->setLocalPreference( "founderemails-joins", true );
-		$wikiFounder->setLocalPreference( "founderemails-edits", true );
+		$wikiFounder->setLocalPreference( "founderemails-joins", true, $wgCityId );
+		$wikiFounder->setLocalPreference( "founderemails-edits", true, $wgCityId );
 
 		$wikiFounder->saveSettings();
 

--- a/includes/User.php
+++ b/includes/User.php
@@ -2553,7 +2553,7 @@ class User {
 	 * @return string
 	 * @see getGlobalPreference
 	 */
-	public function getLocalPreference($preference, $cityId = null, $sep = "-", $default = null, $ignoreHidden = false) {
+	public function getLocalPreference($preference, $cityId, $sep = "-", $default = null, $ignoreHidden = false) {
 		global $wgPreferenceServiceRead;
 
 		if ($wgPreferenceServiceRead) {
@@ -2615,7 +2615,7 @@ class User {
 	 * @param string $sep [optional, defaults to '-']
 	 * @see getGlobalPreference
 	 */
-	public function setLocalPreference($preference, $value, $cityId = null, $sep = '-') {
+	public function setLocalPreference($preference, $value, $cityId, $sep = '-') {
 		global $wgPreferenceServiceShadowWrite;
 
 		if ( $wgPreferenceServiceShadowWrite ) {


### PR DESCRIPTION
@Wikia/services-team @garthwebb 
https://wikia-inc.atlassian.net/browse/SERVICES-781
The branch name here is wrong - this is actually for SERVICES-781.

Making cityId non-optional for getting/setting local preferences, and fixing usages. The initial cause for investigation here was dcabb300a1771363dcc050c9ba5607b34cc65238
