### PR TITLE
SOC-1331 Some email should always be sent

### DIFF
--- a/extensions/wikia/Email/Controller/EmailConfirmationController.class.php
+++ b/extensions/wikia/Email/Controller/EmailConfirmationController.class.php
@@ -23,6 +23,18 @@ abstract class AbstractEmailConfirmationController extends EmailController {
 	}
 
 	/**
+	 * A redefinition of our parent's assertCanEmail which removes assertions:
+	 *
+	 * - assertUserWantsEmail : Even if a user says they don't want email, they should get this
+	 * - assertUserNotBlocked : Even if a user is blocked they should still get these emails
+	 *
+	 * @throws \Email\Fatal
+	 */
+	public function assertCanEmail() {
+		$this->assertUserHasEmail();
+	}
+
+	/**
 	 * @template emailConfirmation
 	 */
 	public function body() {


### PR DESCRIPTION
Make sure users who choose not to receive any wikia email or are blocked still get email change and confirm emails.

https://wikia-inc.atlassian.net/browse/SOC-1331
