### PR TITLE
(MAIN-5420) Properly sanitize and validate timestamp in Lightbox query

### DIFF
--- a/extensions/wikia/Lightbox/LightboxController.class.php
+++ b/extensions/wikia/Lightbox/LightboxController.class.php
@@ -58,11 +58,12 @@ class LightboxController extends WikiaController {
 
 		$thumbs = array();
 		$minTimestamp = 0;
+		$toTimestamp = wfTimestamp( TS_MW, $to );
 		if ( !empty( $to ) ) {
 			// get image list - exclude Latest Photos
 			$images = array();
 			$helper = $this->getLightboxHelper();
-			$imageList = $helper->getImageList( $count, $to );
+			$imageList = $helper->getImageList( $count, $toTimestamp );
 			extract( $imageList );
 
 			// add Latest Photos if not exist

--- a/extensions/wikia/Lightbox/LightboxHelper.class.php
+++ b/extensions/wikia/Lightbox/LightboxHelper.class.php
@@ -27,7 +27,7 @@ class LightboxHelper extends WikiaModel {
 				array( 'img_name, img_timestamp' ),
 				array(
 					"img_media_type in ('".MEDIATYPE_BITMAP."', '".MEDIATYPE_DRAWING."')",
-					"img_timestamp < $to",
+					"img_timestamp < " . $db->addQuotes( $to ),
 				),
 				__METHOD__,
 				array(
@@ -109,7 +109,7 @@ class LightboxHelper extends WikiaModel {
 				array( 'count(*) cnt' ),
 				array(
 					"img_media_type in ('".MEDIATYPE_BITMAP."', '".MEDIATYPE_DRAWING."')",
-					"img_timestamp < $timestamp",
+					"img_timestamp < " . $db->addQuotes( $timestamp ),
 				),
 				__METHOD__
 			);


### PR DESCRIPTION
Make sure the passed value is a timestamp and make sure to still escape
it in the queries.

/cc @macbre @Wikia/community-engineering 
