### PR TITLE
Filtering variable list does not work in Special:WhereIsExtension

### DIFF
--- a/extensions/wikia/WikiFactory/SpecialWikiFactory_ajax.php
+++ b/extensions/wikia/WikiFactory/SpecialWikiFactory_ajax.php
@@ -734,9 +734,6 @@ function axWFactoryDomainQuery() {
 function axWFactoryFilterVariables() {
 	global $wgRequest, $wgUser;
 
-	// this request needs to be a POST and has a valid token passed (PLATFORM-1476)
-	axWFactoryValidateRequest( $wgRequest, $wgUser, __METHOD__ );
-
 	if ( !$wgUser->isAllowed('wikifactory') ) {
 		return '';
 	}
@@ -754,9 +751,9 @@ function axWFactoryFilterVariables() {
 		$selector .= Xml::element( 'option', [ 'value' => $Var->cv_id ], $Var->cv_name );
 	}
 
-	return json_encode(array(
-	    "selector" => $selector,
-	));
+	$resp = new AjaxResponse( json_encode( [ "selector" => $selector ] ) );
+	$resp->setContentType( 'application/json; charset=utf-8' );
+	return $resp;
 }
 
 /**


### PR DESCRIPTION
`axWFactoryFilterVariables` AJAX method: no need to force POST and check the token here + send a proper `Content-Type` response header.

Fix a regression introduced by #8473

@michalroszka / @wladekb / @Grunny / @lukaszkonieczny 
