### PR TITLE
CE-2707 Add a new method to retrieve just a revision raw from any DB

### DIFF
--- a/includes/Revision.php
+++ b/includes/Revision.php
@@ -152,6 +152,35 @@ class Revision {
 	}
 
 	/**
+	 * Wikia change begin
+	 *
+	 * Loads Revision with raw data from its ID which is an equivalent of a row in the `revision` table.
+	 *
+	 * @param $revisionId
+	 * @param DatabaseMysqli $db Optional parameter to overwrite usage of the local db.
+	 * @return bool|Revision
+	 */
+	public static function loadRawRevision( $revisionId, DatabaseMysqli $db = null ) {
+		if ( $db === null ) {
+			$db = wfGetDB( DB_SLAVE );
+		}
+
+		$revision = ( new WikiaSQL() )
+			->SELECT_ALL()
+			->FROM( 'revision' )
+			->WHERE( 'rev_id' )->EQUAL_TO( $revisionId )
+			->LIMIT( 1 )
+			->runLoop( $db, function( &$revision, $row ) {
+				$revision = self::newFromRow( $row );
+			} );
+
+		return $revision;
+	}
+	/**
+	 * Wikia change end
+	 */
+
+	/**
 	 * Load a page revision from a given revision ID number.
 	 * Returns null if no such revision can be found.
 	 *

--- a/includes/Revision.php
+++ b/includes/Revision.php
@@ -157,24 +157,26 @@ class Revision {
 	 * Loads Revision with raw data from its ID which is an equivalent of a row in the `revision` table.
 	 *
 	 * @param $revisionId
-	 * @param DatabaseMysqli $db Optional parameter to overwrite usage of the local db.
+	 * @param DatabaseBase $db Optional parameter to overwrite usage of the local db.
 	 * @return bool|Revision
 	 */
-	public static function loadRawRevision( $revisionId, DatabaseMysqli $db = null ) {
+	public static function loadRawRevision( $revisionId, DatabaseBase $db = null ) {
 		if ( $db === null ) {
 			$db = wfGetDB( DB_SLAVE );
 		}
 
-		$revision = ( new WikiaSQL() )
-			->SELECT_ALL()
-			->FROM( 'revision' )
-			->WHERE( 'rev_id' )->EQUAL_TO( $revisionId )
-			->LIMIT( 1 )
-			->runLoop( $db, function( &$revision, $row ) {
-				$revision = self::newFromRow( $row );
-			} );
+		$row = $db->selectRow( 'revision', self::selectFields(), [
+			'rev_id' => (int)$revisionId,
+		] );
 
-		return $revision;
+		if ( is_object( $row ) ) {
+			return self::newFromRow( $row );
+		}
+
+		/**
+		 * If no records were found - return false which $db->selectRow returned.
+		 */
+		return $row;
 	}
 	/**
 	 * Wikia change end

--- a/includes/Revision.php
+++ b/includes/Revision.php
@@ -156,7 +156,7 @@ class Revision {
 	 *
 	 * Loads Revision with raw data from its ID which is an equivalent of a row in the `revision` table.
 	 *
-	 * @param $revisionId
+	 * @param int $revisionId
 	 * @param DatabaseBase $db Optional parameter to overwrite usage of the local db.
 	 * @return bool|Revision
 	 */
@@ -174,9 +174,9 @@ class Revision {
 		}
 
 		/**
-		 * If no records were found - return false which $db->selectRow returned.
+		 * If no records were found - return false.
 		 */
-		return $row;
+		return false;
 	}
 	/**
 	 * Wikia change end

--- a/includes/wikia/GlobalTitle.php
+++ b/includes/wikia/GlobalTitle.php
@@ -427,6 +427,14 @@ class GlobalTitle extends Title {
 	public function getRevisionText( $revisionId ) {
 		$db = wfGetDB( DB_SLAVE, [], $this->getDatabaseName() );
 		$revision = Revision::loadRawRevision( $revisionId, $db );
+
+		/**
+		 * If no records were found - return an empty string.
+		 */
+		if ( !$revision ) {
+			return '';
+		}
+
 		$text = $this->getContentByTextId( $revision->getTextId() );
 
 		return $text;

--- a/includes/wikia/GlobalTitle.php
+++ b/includes/wikia/GlobalTitle.php
@@ -426,7 +426,7 @@ class GlobalTitle extends Title {
 	 */
 	public function getRevisionText( $revisionId ) {
 		$db = wfGetDB( DB_SLAVE, [], $this->getDatabaseName() );
-		$revision = Revision::loadFromId( $db, $revisionId );
+		$revision = Revision::loadRawRevision( $revisionId, $db );
 		$text = $this->getContentByTextId( $revision->getTextId() );
 
 		return $text;


### PR DESCRIPTION
This PR creates a new way to retrieve data on a revision. Instead of trying to supply you with a full dataset with page and user JOINS it reflects the data that is stored only in the revision table.

That makes it possible to retrieve the data from a GlobalTitle which calls an external DB. Using Revision::loadFromId results in an error because the logic beneath tries to find a User on a given cluster instead of the shared db. Also, if you do not need all the additional data - why bother with retrieving it?
