### PR TITLE
PLATFORM-1503: Nirvana controllers should respect wgShowSQLErrors

### DIFF
--- a/includes/wikia/nirvana/WikiaView.class.php
+++ b/includes/wikia/nirvana/WikiaView.class.php
@@ -340,6 +340,8 @@ class WikiaView {
 	}
 
 	protected function renderJson() {
+		global $wgShowSQLErrors;
+
 		if( $this->response->hasException() ) {
 			$exception = $this->response->getException();
 			$output = [
@@ -357,8 +359,8 @@ class WikiaView {
 				$output[ 'exception' ][ 'details' ] = $exception->getDetails();
 			}
 
-			// PLATFORM-1503: do not expose DB errors
-			if ( $exception instanceof DBError ) {
+			// PLATFORM-1503: do not expose DB errors when $wgShowSQLErrors is set to false
+			if ( $wgShowSQLErrors === false && $exception instanceof DBError ) {
 				$output['exception']['message'] = '';
 			}
 		}

--- a/includes/wikia/nirvana/WikiaView.class.php
+++ b/includes/wikia/nirvana/WikiaView.class.php
@@ -10,6 +10,8 @@
  * @author Wojciech Szela <wojtek(at)wikia-inc.com>
  * @author Federico "Lox" Lucignano <federico(at)wikia-inc.com>
  */
+use Wikia\Util\RequestId;
+
 class WikiaView {
 	/**
 	 * Response object
@@ -340,14 +342,24 @@ class WikiaView {
 	protected function renderJson() {
 		if( $this->response->hasException() ) {
 			$exception = $this->response->getException();
-			$output = array( 'exception' => array( 'message' => $exception->getMessage(), 'code' => $exception->getCode(), 'details' => '' ) );
+			$output = [
+				'exception' => [
+					'type' => get_class( $exception ),
+					'message' => $exception->getMessage(),
+					'code' => $exception->getCode(),
+					'details' => ''
+				],
+				// return RequestID for easier errors reporting
+				'request_id' => RequestId::instance()->getRequestId(),
+			];
+
 			if ( is_callable( [ $exception, 'getDetails' ] ) ) {
 				$output[ 'exception' ][ 'details' ] = $exception->getDetails();
 			}
 
 			// PLATFORM-1503: do not expose DB errors
 			if ( $exception instanceof DBError ) {
-				$output['exception']['message'] = get_class( $exception );
+				$output['exception']['message'] = '';
 			}
 		}
 		else {

--- a/includes/wikia/nirvana/WikiaView.class.php
+++ b/includes/wikia/nirvana/WikiaView.class.php
@@ -344,6 +344,11 @@ class WikiaView {
 			if ( is_callable( [ $exception, 'getDetails' ] ) ) {
 				$output[ 'exception' ][ 'details' ] = $exception->getDetails();
 			}
+
+			// PLATFORM-1503: do not expose DB errors
+			if ( $exception instanceof DBError ) {
+				$output['exception']['message'] = get_class( $exception );
+			}
 		}
 		else {
 			$output = $this->response->getData();


### PR DESCRIPTION
``` json
{
  "exception": {
    "type": "DBQueryError",
    "message": "",
    "code": 0,
    "details": ""
  },
  "request_id": "mw560152a11581e7.18358045"
}
```
- blank the `message` field when the exception is a `DBError` (when `$wgShowSQLErrors === false`)
- report exception type
- always report `request_id` for easier reporting and debugging

@michalroszka / @wladekb / @Grunny 
