### PR TITLE
CE-2672 Refactoring of the replaceWithLastApprovedRevision unit test

### DIFF
--- a/extensions/wikia/ContentReview/ContentReview.hooks.php
+++ b/extensions/wikia/ContentReview/ContentReview.hooks.php
@@ -98,7 +98,7 @@ class Hooks {
 	public function onRawPageViewBeforeOutput( \RawAction $rawAction, &$text ) {
 		$title = $rawAction->getTitle();
 		$helper = new Helper();
-		$helper->replaceWithLastApproved( $title, $rawAction->getContentType(), $text );
+		$text = $helper->replaceWithLastApproved( $title, $rawAction->getContentType(), $text );
 		return true;
 	}
 

--- a/extensions/wikia/ContentReview/ContentReviewHelper.php
+++ b/extensions/wikia/ContentReview/ContentReviewHelper.php
@@ -331,7 +331,7 @@ class Helper extends \ContextSource {
 	public function replaceWithLastApproved( \Title $title, $contentType, $text ) {
 		global $wgCityId;
 
-		if ( $this->shouldPageContentBeReplaced( $title, $contentType ) ) {
+		if ( $this->isPageReviewed( $title, $contentType ) ) {
 			$pageId = $title->getArticleID();
 			$latestRevId = $title->getLatestRevID();
 			$latestReviewedRevData = $this->getCurrentRevisionModel()->getLatestReviewedRevision( $wgCityId, $pageId );
@@ -384,7 +384,7 @@ class Helper extends \ContextSource {
 	 * @param $contentType
 	 * @return bool
 	 */
-	public function shouldPageContentBeReplaced( \Title $title, $contentType ) {
+	public function isPageReviewed( \Title $title, $contentType ) {
 		global $wgJsMimeType;
 
 		return $title->isJsPage()

--- a/extensions/wikia/ContentReview/tests/ContentReviewHelperTest.php
+++ b/extensions/wikia/ContentReview/tests/ContentReviewHelperTest.php
@@ -234,10 +234,10 @@ class ContentReviewHelperTest extends WikiaBaseTest {
 			[
 				[
 					'isPageReviewed' => false,
-					'latestRevID' => 0,
+					'latestRevID' => 100,
 					'latestReviewedRevision' => [],
 					'isTestModeEnabled' => false,
-					'revisionExists' => false,
+					'revisionExists' => true,
 					'originalText' => $originalText,
 					'lastReviewedText' => $lastReviewedText,
 				],

--- a/extensions/wikia/ContentReview/tests/ContentReviewHelperTest.php
+++ b/extensions/wikia/ContentReview/tests/ContentReviewHelperTest.php
@@ -8,10 +8,10 @@ class ContentReviewHelperTest extends WikiaBaseTest {
 	}
 
 	/**
-	 * @param $isJsPage
-	 * @param $inNamespace
-	 * @param $contentType
-	 * @param $expected
+	 * @param bool $isJsPage
+	 * @param bool $inNamespace
+	 * @param string $contentType
+	 * @param bool $expected
 	 * @dataProvider shouldPageContentBeReplacedData
 	 */
 	public function testShouldPageContentBeReplaced( $isJsPage, $inNamespace, $contentType, $expected ) {
@@ -34,14 +34,14 @@ class ContentReviewHelperTest extends WikiaBaseTest {
 	 * To review different cases - check the documentation of the dataProvider.
 	 *
 	 * @dataProvider replaceWithLastApprovedRevisionProvider
-	 * @param $isPageReviewed
-	 * @param $latestRevID
+	 * @param bool $isPageReviewed
+	 * @param int $latestRevID
 	 * @param array $latestReviewedRevision
-	 * @param $isTestModeEnabled
-	 * @param $revisionExists
-	 * @param $originalText
-	 * @param $lastReviewedText
-	 * @param $expectedText
+	 * @param bool $isTestModeEnabled
+	 * @param bool $revisionExists
+	 * @param string $originalText
+	 * @param string $lastReviewedText
+	 * @param string $expectedText
 	 */
 	public function testReplaceWithLastApprovedRevision( $isPageReviewed, $latestRevID,
 		array $latestReviewedRevision, $isTestModeEnabled, $revisionExists, $originalText, $lastReviewedText, $expectedText

--- a/extensions/wikia/ContentReview/tests/ContentReviewHelperTest.php
+++ b/extensions/wikia/ContentReview/tests/ContentReviewHelperTest.php
@@ -43,8 +43,8 @@ class ContentReviewHelperTest extends WikiaBaseTest {
 	 * @param string $lastReviewedText
 	 * @param string $expectedText
 	 */
-	public function testReplaceWithLastApprovedRevision( $isPageReviewed, $latestRevID,
-		array $latestReviewedRevision, $isTestModeEnabled, $revisionExists, $originalText, $lastReviewedText, $expectedText
+	public function testReplaceWithLastApprovedRevision( $isPageReviewed, $latestRevID, array $latestReviewedRevision,
+		$isTestModeEnabled, $revisionExists, $originalText, $lastReviewedText, $expectedText, $message
 	) {
 		/**
 		 * Case 1 - if a page does not qualify to be reviewed just return the original text.
@@ -116,7 +116,7 @@ class ContentReviewHelperTest extends WikiaBaseTest {
 			$textReturn = $helperMock->replaceWithLastApproved( $titleMock, $mockContentType, $originalText );
 		}
 
-		$this->assertEquals( $expectedText, $textReturn );
+		$this->assertEquals( $expectedText, $textReturn, $message );
 	}
 
 	/**
@@ -199,9 +199,6 @@ class ContentReviewHelperTest extends WikiaBaseTest {
 		$emptyText = '';
 
 		return [
-			/**
-			 * Case 1 - a page does not qualify to be reviewed (isPageReviewed === false).
-			 */
 			[
 				false, // isPageReviewed()
 				0, // getLatestRevID()
@@ -211,10 +208,8 @@ class ContentReviewHelperTest extends WikiaBaseTest {
 				$originalText,
 				$lastReviewedText,
 				$originalText, // $expectedText
+				$message = 'Case 1 - a page does not qualify to be reviewed (isPageReviewed === false).',
 			],
-			/**
-			 * Case 2 - Latest rev_id matches the last reviewed rev_id
-			 */
 			[
 				true, // isPageReviewed()
 				100, // getLatestRevID()
@@ -224,10 +219,8 @@ class ContentReviewHelperTest extends WikiaBaseTest {
 				$originalText,
 				$lastReviewedText,
 				$originalText, // $expectedText
+				$message = 'Case 2 - Latest rev_id matches the last reviewed rev_id',
 			],
-			/**
-			 * Case 3 - Test mode is enabled
-			 */
 			[
 				true, // isPageReviewed()
 				100, // getLatestRevID()
@@ -237,10 +230,8 @@ class ContentReviewHelperTest extends WikiaBaseTest {
 				$originalText,
 				$lastReviewedText,
 				$originalText, // $expectedText
+				$message = 'Case 3 - Test mode is enabled',
 			],
-			/**
-			 * Case 4 - You want to get a reviewed revision but it does not exist (e.g. for new, unreviewed pages)
-			 */
 			[
 				true, // isPageReviewed()
 				99, // getLatestRevID()
@@ -250,10 +241,8 @@ class ContentReviewHelperTest extends WikiaBaseTest {
 				$originalText,
 				$lastReviewedText,
 				$emptyText, // $expectedText
+				$message = 'Case 4 - You want to get a reviewed revision but it does not exist (e.g. for new, unreviewed pages)',
 			],
-			/**
-			 * Case 5 - You get the latest approved revision.
-			 */
 			[
 				true, // isPageReviewed()
 				99, // getLatestRevID()
@@ -263,6 +252,7 @@ class ContentReviewHelperTest extends WikiaBaseTest {
 				$originalText,
 				$lastReviewedText,
 				$lastReviewedText, // $expectedText
+				$message = 'Case 5 - You get the latest approved revision.',
 			],
 		];
 	}

--- a/extensions/wikia/ContentReview/tests/ContentReviewHelperTest.php
+++ b/extensions/wikia/ContentReview/tests/ContentReviewHelperTest.php
@@ -14,7 +14,7 @@ class ContentReviewHelperTest extends WikiaBaseTest {
 	 * @param bool $expected
 	 * @dataProvider shouldPageContentBeReplacedData
 	 */
-	public function testShouldPageContentBeReplaced( $isJsPage, $inNamespace, $contentType, $expected ) {
+	public function testIsPageForReview( $isJsPage, $inNamespace, $contentType, $expected ) {
 		$titleMock = $this->getMock( '\Title', [ 'isJsPage', 'inNamespace' ] );
 		$titleMock->expects( $this->once() )
 			->method( 'isJsPage' )

--- a/extensions/wikia/ContentReview/tests/ContentReviewHelperTest.php
+++ b/extensions/wikia/ContentReview/tests/ContentReviewHelperTest.php
@@ -8,6 +8,27 @@ class ContentReviewHelperTest extends WikiaBaseTest {
 	}
 
 	/**
+	 * @param $isJsPage
+	 * @param $inNamespace
+	 * @param $contentType
+	 * @param $expected
+	 * @dataProvider shouldPageContentBeReplacedData
+	 */
+	public function testShouldPageContentBeReplaced( $isJsPage, $inNamespace, $contentType, $expected ) {
+		$titleMock = $this->getMock( '\Title', [ 'isJsPage', 'inNamespace' ] );
+		$titleMock->expects( $this->once() )
+			->method( 'isJsPage' )
+			->willReturn( $isJsPage );
+
+		$titleMock->expects( $this->any() )
+			->method( 'inNamespace' )
+			->willReturn( $inNamespace );
+
+		$value = ( new Wikia\ContentReview\Helper() )->shouldPageContentBeReplaced( $titleMock, $contentType );
+		$this->assertEquals( $expected, $value );
+	}
+
+	/**
 	 * @dataProvider replaceWithLastApprovedRevisionProvider
 	 * Test for \Wikia\ContentReview\Hooks::onRawPageViewBeforeOutput hook
 	 */
@@ -62,7 +83,6 @@ class ContentReviewHelperTest extends WikiaBaseTest {
 
 	/**
 	 * @dataProvider userCanEditJsPageProvider
-	 * @param bool $inNamespace
 	 * @param bool $isJsPage
 	 * @param bool $userCan
 	 * @param bool $expected
@@ -96,6 +116,43 @@ class ContentReviewHelperTest extends WikiaBaseTest {
 			->willReturn( $latestReviewedId );
 
 		$this->assertEquals( $expected, $this->getHelper()->hasPageApprovedId( $modelMock, 0, 0, $oldId ), $message );
+	}
+
+	public function shouldPageContentBeReplacedData() {
+		$goodMimeType = 'text/javascript';
+		$badMimeType = 'text/css';
+		return [
+			[
+				false, // isJsPage()
+				false, // inNamespace()
+				$badMimeType,
+				false, // expected
+			],
+			[
+				false, // isJsPage()
+				true, // inNamespace()
+				$badMimeType,
+				false, // expected
+			],
+			[
+				false, // isJsPage()
+				false, // inNamespace()
+				$goodMimeType,
+				false, // expected
+			],
+			[
+				false, // isJsPage()
+				true, // inNamespace()
+				$goodMimeType,
+				true, // expected
+			],
+			[
+				true, // isJsPage()
+				false, // inNamespace()
+				$badMimeType,
+				true, // expected
+			],
+		];
 	}
 
 	public function replaceWithLastApprovedRevisionProvider() {

--- a/extensions/wikia/ContentReview/tests/ContentReviewHelperTest.php
+++ b/extensions/wikia/ContentReview/tests/ContentReviewHelperTest.php
@@ -12,7 +12,7 @@ class ContentReviewHelperTest extends WikiaBaseTest {
 	 * @param bool $inNamespace
 	 * @param string $contentType
 	 * @param bool $expected
-	 * @dataProvider shouldPageContentBeReplacedData
+	 * @dataProvider isPageForReviewTestData
 	 */
 	public function testIsPageForReview( $isJsPage, $inNamespace, $contentType, $expected ) {
 		$titleMock = $this->getMock( '\Title', [ 'isJsPage', 'inNamespace' ] );
@@ -156,7 +156,7 @@ class ContentReviewHelperTest extends WikiaBaseTest {
 		$this->assertEquals( $expected, $this->getHelper()->hasPageApprovedId( $modelMock, 0, 0, $oldId ), $message );
 	}
 
-	public function shouldPageContentBeReplacedData() {
+	public function isPageForReviewTestData() {
 		$goodMimeType = 'text/javascript';
 		$badMimeType = 'text/css';
 		return [


### PR DESCRIPTION
I recommend viewing this one in the Split mode. :)

The refactoring included:
1. Separation of the `isPageReviewed()` method that initially qualifies pages to undergo the further process and writing a unit test for it.
2. Rewriting of the main unit test and adding cases that cover all possible scenarios.

/cc @Grunny @lukaszkonieczny 
