### PR TITLE
SEO-69 Fix PHP Warning

### DIFF
--- a/extensions/wikia/SeoLinkHreflang/SeoLinkHreflang.class.php
+++ b/extensions/wikia/SeoLinkHreflang/SeoLinkHreflang.class.php
@@ -74,6 +74,8 @@ class SeoLinkHreflang {
 	private static function generateHreflangLinks( OutputPage $out ) {
 		global $wgDBname;
 
+		$links = [];
+
 		if ( $wgDBname === 'starwars' ) {
 			$links = self::getStarWarsLinks( $out );
 		} else if ( $out->getTitle()->isMainPage() ) {


### PR DESCRIPTION
PHP Warning: array_values() expects parameter 1 to be array, null given in /extensions/wikia/SeoLinkHreflang/SeoLinkHreflang.class.php on line 89
