### PR TITLE
Pref comparison fixes

### DIFF
--- a/lib/Wikia/src/Service/User/Preferences/Migration/PreferenceCorrectionService.php
+++ b/lib/Wikia/src/Service/User/Preferences/Migration/PreferenceCorrectionService.php
@@ -50,7 +50,7 @@ class PreferenceCorrectionService {
 				'correcting preferences',
 				[
 					'num_differences' => $differences,
-					'user_id' => $userId] );
+					'userId' => $userId] );
 			$this->preferenceService->setPreferences( $userId, $expected );
 			$this->preferenceService->save( $userId );
 		}
@@ -86,7 +86,7 @@ class PreferenceCorrectionService {
 				if ( !$actualPreferences->hasLocalPreference( $prefName, $wikiId ) ) {
 					$this->logMissingPreference( $userId, $name );
 					++$differences;
-				} elseif ( $actualPreferences->getLocalPreference( $prefName, $wikiId ) !== $value ) {
+				} elseif ( $actualPreferences->getLocalPreference( $prefName, $wikiId ) != $value ) {
 					$this->logPreferenceValueDifference( $userId, $name, $value, $actualPreferences->getLocalPreference( $prefName, $wikiId ) );
 					++$differences;
 				}

--- a/lib/Wikia/src/Service/User/Preferences/Migration/PreferenceCorrectionService.php
+++ b/lib/Wikia/src/Service/User/Preferences/Migration/PreferenceCorrectionService.php
@@ -67,13 +67,8 @@ class PreferenceCorrectionService {
 				$expectedPreferences->setGlobalPreference( $name, $value );
 
 				if ( !$actualPreferences->hasGlobalPreference( $name ) ) {
-					$default = $this->preferenceService->getGlobalDefault($name);
-
-					if ($this->preferenceService->prefIsSaveable($name, $value, $default)) {
-						$this->logMissingPreference( $userId, $name );
-						++$differences;
-					}
-
+					$this->logMissingPreference( $userId, $name );
+					++$differences;
 				} elseif ( $actualPreferences->getGlobalPreference( $name ) != $value ) {
 					$this->logPreferenceValueDifference( $userId, $name, $value, $actualPreferences->getGlobalPreference( $name ) );
 					++$differences;
@@ -89,13 +84,9 @@ class PreferenceCorrectionService {
 				$expectedPreferences->setLocalPreference( $prefName, $wikiId, $value );
 
 				if ( !$actualPreferences->hasLocalPreference( $prefName, $wikiId ) ) {
-					$default = $this->preferenceService->getLocalDefault($prefName, $wikiId);
-
-					if ($this->preferenceService->prefIsSaveable($prefName, $value, $default)) {
-						$this->logMissingPreference( $userId, $name );
-						++$differences;
-					}
-				} elseif ( $actualPreferences->getLocalPreference( $prefName, $wikiId ) != $value ) {
+					$this->logMissingPreference( $userId, $name );
+					++$differences;
+				} elseif ( $actualPreferences->getLocalPreference( $prefName, $wikiId ) !== $value ) {
 					$this->logPreferenceValueDifference( $userId, $name, $value, $actualPreferences->getLocalPreference( $prefName, $wikiId ) );
 					++$differences;
 				}

--- a/lib/Wikia/src/Service/User/Preferences/Migration/PreferenceCorrectionService.php
+++ b/lib/Wikia/src/Service/User/Preferences/Migration/PreferenceCorrectionService.php
@@ -67,8 +67,13 @@ class PreferenceCorrectionService {
 				$expectedPreferences->setGlobalPreference( $name, $value );
 
 				if ( !$actualPreferences->hasGlobalPreference( $name ) ) {
-					$this->logMissingPreference( $userId, $name );
-					++$differences;
+					$default = $this->preferenceService->getGlobalDefault($name);
+
+					if ($this->preferenceService->prefIsSaveable($name, $value, $default)) {
+						$this->logMissingPreference( $userId, $name );
+						++$differences;
+					}
+
 				} elseif ( $actualPreferences->getGlobalPreference( $name ) != $value ) {
 					$this->logPreferenceValueDifference( $userId, $name, $value, $actualPreferences->getGlobalPreference( $name ) );
 					++$differences;
@@ -84,9 +89,13 @@ class PreferenceCorrectionService {
 				$expectedPreferences->setLocalPreference( $prefName, $wikiId, $value );
 
 				if ( !$actualPreferences->hasLocalPreference( $prefName, $wikiId ) ) {
-					$this->logMissingPreference( $userId, $name );
-					++$differences;
-				} elseif ( $actualPreferences->getLocalPreference( $prefName, $wikiId ) !== $value ) {
+					$default = $this->preferenceService->getLocalDefault($prefName, $wikiId);
+
+					if ($this->preferenceService->prefIsSaveable($prefName, $value, $default)) {
+						$this->logMissingPreference( $userId, $name );
+						++$differences;
+					}
+				} elseif ( $actualPreferences->getLocalPreference( $prefName, $wikiId ) != $value ) {
 					$this->logPreferenceValueDifference( $userId, $name, $value, $actualPreferences->getLocalPreference( $prefName, $wikiId ) );
 					++$differences;
 				}

--- a/lib/Wikia/src/Service/User/Preferences/PreferenceService.php
+++ b/lib/Wikia/src/Service/User/Preferences/PreferenceService.php
@@ -18,11 +18,4 @@ interface PreferenceService {
 	public function deleteLocalPreference( $userId, $name, $wikiId );
 	public function save( $userId );
 	public function getGlobalDefault( $pref );
-	public function getLocalDefault( $pref, $wikiId );
-
-	/**
-	 * TODO: this should be a private method in PreferenceServiceImpl
-	 * but need it to be public while we do migrations for false-positive detection
-	 */
-	public function prefIsSaveable( $pref, $value, $valueFromDefaults );
 }

--- a/lib/Wikia/src/Service/User/Preferences/PreferenceService.php
+++ b/lib/Wikia/src/Service/User/Preferences/PreferenceService.php
@@ -18,4 +18,11 @@ interface PreferenceService {
 	public function deleteLocalPreference( $userId, $name, $wikiId );
 	public function save( $userId );
 	public function getGlobalDefault( $pref );
+	public function getLocalDefault( $pref, $wikiId );
+
+	/**
+	 * TODO: this should be a private method in PreferenceServiceImpl
+	 * but need it to be public while we do migrations for false-positive detection
+	 */
+	public function prefIsSaveable( $pref, $value, $valueFromDefaults );
 }

--- a/lib/Wikia/src/Service/User/Preferences/PreferenceServiceImpl.php
+++ b/lib/Wikia/src/Service/User/Preferences/PreferenceServiceImpl.php
@@ -258,11 +258,7 @@ class PreferenceServiceImpl implements PreferenceService {
 	}
 
 	private function prefIsSaveable( $pref, $value, $valueFromDefaults ) {
-		if ( $value == $valueFromDefaults ) {
-			return false;
-		}
-
 		return in_array( $pref, $this->forceSavePrefs ) || $value != $valueFromDefaults ||
-			( $valueFromDefaults != null && $value !== false && $value !== null );
+			( $valueFromDefaults === null && $value !== false && $value !== null );
 	}
 }

--- a/lib/Wikia/src/Service/User/Preferences/PreferenceServiceImpl.php
+++ b/lib/Wikia/src/Service/User/Preferences/PreferenceServiceImpl.php
@@ -257,7 +257,7 @@ class PreferenceServiceImpl implements PreferenceService {
 		return $preferences;
 	}
 
-	public function prefIsSaveable( $pref, $value, $valueFromDefaults ) {
+	private function prefIsSaveable( $pref, $value, $valueFromDefaults ) {
 		if ( $value == $valueFromDefaults ) {
 			return false;
 		}

--- a/lib/Wikia/src/Service/User/Preferences/PreferenceServiceImpl.php
+++ b/lib/Wikia/src/Service/User/Preferences/PreferenceServiceImpl.php
@@ -257,7 +257,7 @@ class PreferenceServiceImpl implements PreferenceService {
 		return $preferences;
 	}
 
-	private function prefIsSaveable( $pref, $value, $valueFromDefaults ) {
+	public function prefIsSaveable( $pref, $value, $valueFromDefaults ) {
 		if ( $value == $valueFromDefaults ) {
 			return false;
 		}


### PR DESCRIPTION
@Wikia/services-team 

The PreferenceCorrectionService has been trying to correct some preferences, but has been unsuccessful because our `prefIsSaveable` check is not the same as [`shouldOptionBeStored`](https://github.com/Wikia/app/blob/dev/includes/User.php#L5037).
