### PR TITLE
only do comparisons when loading a user from the database

### DIFF
--- a/includes/User.php
+++ b/includes/User.php
@@ -4905,12 +4905,12 @@ class User {
 			}
 
 			$this->loadAttributes();
+			$this->preferenceCorrection()->compareAndCorrect($this->getId(), $this->mOptions);
 		}
 
 		$this->mOptionsLoaded = true;
 
 		wfRunHooks( 'UserLoadOptions', array( $this, &$this->mOptions ) );
-		$this->preferenceCorrection()->compareAndCorrect($this->getId(), $this->mOptions);
 	}
 
 	private function loadAttributes() {

--- a/includes/wikia/tests/UserTest.php
+++ b/includes/wikia/tests/UserTest.php
@@ -31,7 +31,7 @@ class UserTest extends WikiaBaseTest {
 
 		$this->userPreferenceServiceMock = $this->getMock( PreferenceService::class,
 			['getGlobalPreference', 'getPreferences', 'setPreferences', 'setGlobalPreference', 'deleteGlobalPreference',
-			'getLocalPreference', 'setLocalPreference', 'deleteLocalPreference', 'save', 'getGlobalDefault'] );
+			'getLocalPreference', 'setLocalPreference', 'deleteLocalPreference', 'save', 'getGlobalDefault', 'deleteFromCache'] );
 
 		$this->userAttributeServiceMock = $this->getMock( AttributeService::class );
 

--- a/lib/Wikia/tests/Service/User/Preferences/Migration/PreferenceCorrectionServiceTest.php
+++ b/lib/Wikia/tests/Service/User/Preferences/Migration/PreferenceCorrectionServiceTest.php
@@ -35,6 +35,7 @@ class PreferenceCorrectionServiceTest extends PHPUnit_Framework_TestCase {
 				'setLocalPreference',
 				'deleteLocalPreference',
 				'getGlobalDefault',
+				'deleteFromCache',
 			] )
 			->getMock();
 		$this->savedPreferences = ( new UserPreferences() )


### PR DESCRIPTION
@Wikia/services-team 

Only do comparisons when loading a user's options from the database. We need this because there are multiple caches inside mediawiki for a user (ex: `UserService`, `User`), which are not kept in sync, so we can't be certain that the options we're comparing against are up-to-date with the preferences (which only maintain a single cache, so should always be up-to-date)
