### PR TITLE
Add a one minute cache to attribute logging

### DIFF
--- a/includes/User.php
+++ b/includes/User.php
@@ -2695,7 +2695,7 @@ class User {
 	 * Returns true if 1.) User is logged in, 2.) The attribute is one used by clients other
 	 * than MW (eg, the avatar service or discussion app), and 3.) the cache for that user is
 	 * not expired. We're testing to see how many requests would make it to the attribute service
-	 * if we cached the attributes used by outside clients for 1 minute.
+	 * if we cached the attributes used by outside clients for 1 minute. See SOC-1315.
 	 * @param $attributeName
 	 * @return bool
 	 */

--- a/includes/User.php
+++ b/includes/User.php
@@ -2692,7 +2692,7 @@ class User {
 	}
 
 	/**
-	 * Returns true if 1.) User is logged in, 2.) The attribute is one used by clients other
+	 * Returns true if 0.) Options are not loaded yet - we should , 1.) User is logged in, 2.) The attribute is one used by clients other
 	 * than MW (eg, the avatar service or discussion app), and 3.) the cache for that user is
 	 * expired. This is to test how many requests per minutes we could expect the attribute
 	 * service to receive if we had MW call out to it whenever it needed a value for "avatar"
@@ -2702,6 +2702,10 @@ class User {
 	 */
 	private function shouldLogAttribute( $attributeName ) {
 		global $wgMemc;
+
+		if ( $this->mOptionsLoaded ) {
+			return false;
+		}
 
 		if ( !$this->isLoggedIn() ) {
 			return false;

--- a/includes/User.php
+++ b/includes/User.php
@@ -2694,8 +2694,9 @@ class User {
 	/**
 	 * Returns true if 1.) User is logged in, 2.) The attribute is one used by clients other
 	 * than MW (eg, the avatar service or discussion app), and 3.) the cache for that user is
-	 * expired. We're testing to see how many requests would make it to the attribute service
-	 * if we cached the attributes used by outside clients for 1 minute. See SOC-1315.
+	 * expired. This is to test how many requests per minutes we could expect the attribute
+	 * service to receive if we had MW call out to it whenever it needed a value for "avatar"
+	 * or "location", with a one minute cache after each request.
 	 * @param $attributeName
 	 * @return bool
 	 */

--- a/includes/User.php
+++ b/includes/User.php
@@ -2694,7 +2694,7 @@ class User {
 	/**
 	 * Returns true if 1.) User is logged in, 2.) The attribute is one used by clients other
 	 * than MW (eg, the avatar service or discussion app), and 3.) the cache for that user is
-	 * not expired. We're testing to see how many requests would make it to the attribute service
+	 * expired. We're testing to see how many requests would make it to the attribute service
 	 * if we cached the attributes used by outside clients for 1 minute. See SOC-1315.
 	 * @param $attributeName
 	 * @return bool

--- a/lib/Wikia/src/Service/User/Attributes/UserAttributes.php
+++ b/lib/Wikia/src/Service/User/Attributes/UserAttributes.php
@@ -18,6 +18,8 @@ class UserAttributes {
 	// outside of MW.
 	public static $ATTRIBUTES_USED_BY_OUTSIDE_CLIENTS = [ AVATAR_USER_OPTION_NAME, "location" ];
 
+	const CACHE_TTL = 60; // 1 minute
+
 	/**
 	 * @Inject({
 	 *    Wikia\Service\User\Attributes\AttributeService::class,
@@ -114,5 +116,9 @@ class UserAttributes {
 
 	private function deleteAttributeFromService( $userId, Attribute $attribute ) {
 		$this->attributeService->delete( $userId, $attribute );
+	}
+
+	public static function getCacheKey( $userId ) {
+		return wfMemcKey( $userId, __CLASS__ );
 	}
 }


### PR DESCRIPTION
Update the logging we're doing to include a one minute cache. This is to test how many requests per minutes we could expect the attribute service to receive if we had MW call out to it whenever it needed a value for "avatar" or "location", with a one minute cache after each request. 

See https://wikia-inc.atlassian.net/browse/SOC-1315 for more details.
