### PR TITLE
VignetteRequest::isVignetteUrl - improve detection of b0rken URLs

### DIFF
--- a/includes/wikia/tests/VignetteRequestTest.php
+++ b/includes/wikia/tests/VignetteRequestTest.php
@@ -3,6 +3,9 @@
 use Wikia\Vignette\UrlConfig;
 use Wikia\Vignette\UrlGenerator;
 
+/**
+ * @group Vignette
+ */
 class VignetteRequestTest extends WikiaBaseTest {
 	private $vignetteUrl = 'http://vignette.wikia-dev.com';
 
@@ -29,6 +32,12 @@ class VignetteRequestTest extends WikiaBaseTest {
 		$this->assertEquals(
 			VignetteRequest::getImageFilename("{$this->vignetteUrl}/tests/images/a/ab/SomeFile.jpg/revision/latest?cb=12345"),
 			"SomeFile.jpg"
+		);
+
+		# the old thumb URL format
+		$this->assertEquals(
+			VignetteRequest::getImageFilename("{$this->vignetteUrl}/civilization/images/4/4a/Foo.png"),
+			null
 		);
 	}
 
@@ -93,6 +102,42 @@ class VignetteRequestTest extends WikiaBaseTest {
 			[
 				'window-crop/width/50/x-offset/-10/y-offset/-20/window-width/60/window-height/100?cb=123&format=jpg',
 				'50px--10,50,-20,80-filename.jpg'
+			],
+		];
+	}
+
+	/**
+	 * @param string $url
+	 * @param bool $expected
+	 * @dataProvider isVignetteUrlDataProvider
+	 */
+	public function testIsVignetteUrl($url, $expected) {
+		$this->mockGlobalVariable('wgVignetteUrl', $this->vignetteUrl);
+
+		$this->assertEquals($expected, VignetteRequest::isVignetteUrl($url));
+	}
+
+	public function isVignetteUrlDataProvider() {
+		return [
+			[
+				# thumb
+				$this->vignetteUrl . '/nordycka/images/f/f2/Saksunardalur.jpg/revision/latest/scale-to-width-down/300?cb=20150113215859&path-prefix=pl',
+				true
+			],
+			[
+				# original
+				$this->vignetteUrl . '/nordycka/images/f/f2/Saksunardalur.jpg/revision/latest?cb=20150113215859&path-prefix=pl',
+				true
+			],
+			[
+				# the old thumb URL format will still be treated as a Vignette URL
+				$this->vignetteUrl . '/civilization/images/4/4a/Dromon_%28Civ5%29.png',
+				true
+			],
+			[
+				# not an URL at all
+				"<img src=\"{$this->vignetteUrl}/nordycka/images/f/f2/Saksunardalur.jpg/revision/latest?cb=20150113215859&path-prefix=pl\" />",
+				false
 			],
 		];
 	}

--- a/includes/wikia/vignette/VignetteRequest.php
+++ b/includes/wikia/vignette/VignetteRequest.php
@@ -150,11 +150,11 @@ class VignetteRequest {
 		$isVignetteUrl = false;
 
 		if ( strpos( $wgVignetteUrl, '<SHARD>' ) === false ) {
-			$isVignetteUrl = strpos( $url, $wgVignetteUrl ) !== false;
+			$isVignetteUrl = strpos( $url, $wgVignetteUrl ) === 0;
 		} else {
 			for ( $i = 1; $i <= $wgImagesServers; ++$i ) {
 				$candidate = str_replace( '<SHARD>', $i, $wgVignetteUrl );
-				if ( strpos( $url, $candidate ) !== false ) {
+				if ( strpos( $url, $candidate ) === 0 ) {
 					$isVignetteUrl = true;
 					break;
 				}

--- a/includes/wikia/vignette/VignetteUrlToUrlGenerator.php
+++ b/includes/wikia/vignette/VignetteUrlToUrlGenerator.php
@@ -23,13 +23,13 @@ class VignetteUrlToUrlGenerator {
 		$this->asOriginal = $asOriginal;
 
 		if (!VignetteRequest::isVignetteUrl($url)) {
-			$this->reportError('invalid url');
+			$this->reportWarning('invalid url');
 		}
 	}
 
 	public function build() {
 		if (!$this->parseUrl()) {
-			$this->reportError('unable to parse url');
+			$this->reportWarning('unable to parse url');
 		}
 
 		$isArchive = $this->urlParts['revision'] != \Wikia\Vignette\UrlGenerator::REVISION_LATEST;
@@ -90,7 +90,7 @@ class VignetteUrlToUrlGenerator {
 
 		foreach (array_chunk($parts, 2) as $chunk) {
 			if (count($chunk) != 2) {
-				$this->reportError('invalid chunk');
+				$this->reportWarning('invalid chunk');
 			}
 
 			list($key, $val) = $chunk;
@@ -114,7 +114,7 @@ class VignetteUrlToUrlGenerator {
 					$generator->windowHeight($val);
 					break;
 				default:
-					$this->reportError('invalid key while building thumb mode', [
+					$this->reportWarning('invalid key while building thumb mode', [
 						'key' => $key,
 						'val' => $val,
 					]);
@@ -123,11 +123,11 @@ class VignetteUrlToUrlGenerator {
 		}
 	}
 
-	private function reportError($message, Array $context=[]) {
+	private function reportWarning($message, Array $context=[]) {
 		$exception = new InvalidArgumentException($message);
 		$context['exception'] = $exception;
 
-		$this->error($message, $context);
+		$this->warning($message, $context);
 		throw $exception;
 	}
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-1486

`<img>` tags with a proper Vignette URL were treated by `VignetteRequest::isVignetteUrl` as valid URLs.

And log `InvalidArgumentException` as warnings.

@pchojnacki 
