### PR TITLE
SOC-1315 | Shared memcache for user attributes counter

### DIFF
--- a/lib/Wikia/src/Service/User/Attributes/UserAttributes.php
+++ b/lib/Wikia/src/Service/User/Attributes/UserAttributes.php
@@ -119,6 +119,6 @@ class UserAttributes {
 	}
 
 	public static function getCacheKey( $userId ) {
-		return wfMemcKey( $userId, __CLASS__ );
+		return wfSharedMemcKey($userId, __CLASS__);
 	}
 }


### PR DESCRIPTION
User attributes are global, so there is no need to count queries to service when shared instance of cache has this data.

ping @bkoval 
