### PR TITLE
(CE-2642) Move the creation of achievements tables out of CreateWiki

### DIFF
--- a/includes/wikia/WikiaUpdater.php
+++ b/includes/wikia/WikiaUpdater.php
@@ -33,12 +33,6 @@ class WikiaUpdater {
 			array( 'addTable', 'page_wikia_props', $ext_dir . '/wikia/ImageServing/sql/table.sql', true ),
 			array( 'addTable', 'wall_history', $ext_dir . '/wikia/Wall/sql/wall_history_local.sql', true ),
 			array( 'addTable', 'wall_related_pages', $ext_dir . '/wikia/Wall/sql/wall_related_pages.sql', true ),
-			array( 'addTable', 'ach_user_score', $dir . 'patch-create-achievements_user_score.sql', true ),
-			array( 'addTable', 'ach_user_badges', $dir . 'patch-create-achievements_user_badges.sql', true ),
-			array( 'addTable', 'ach_user_badges_notified', $dir . 'patch-create-achievements_user_badges_notified.sql', true ),
-			array( 'addTable', 'ach_user_counters', $dir . 'patch-create-achievements_user_counters.sql', true ),
-			array( 'addTable', 'ach_custom_badges', $dir . 'patch-create-achievements_custom_badges.sql', true ),
-			array( 'addTable', 'ach_ranking_snapshots', $dir . 'patch-create-achievements_ranking_snapshots.sql', true ),
 			# fields
 			array( 'addField', 'watchlist', 'wl_wikia_addedtimestamp', $dir . 'patch-watchlist-improvements.sql', true ),
 


### PR DESCRIPTION
Move the creation of the achievements tables out of the CreateWiki flow
and instead create them if needed when the extension is enabled. This
follows the same approach [we use for AbuseFilter](https://github.com/Wikia/app/blob/106d8bcf1da2b/extensions/wikia/WikiFactoryChangedHooks/WikiFactoryChangedHooks.class.php#L154-L194), and is less prone to
errors.

/cc @Wikia/community-engineering @owend 
