### PR TITLE
Serve Optimizely script from original CDN for devbox and sandbox

### DIFF
--- a/extensions/wikia/Optimizely/Optimizely.class.php
+++ b/extensions/wikia/Optimizely/Optimizely.class.php
@@ -64,17 +64,6 @@ class Optimizely {
 		return true;
 	}
 
-	/**
-	 * Is current environment considered a developemnt/testing environment for Optimizely experiments?
-	 *
-	 * @return bool
-	 */
-	public static function isOptimizelyDevEnv() {
-		global $wgWikiaEnvironment;
-
-		return in_array( $wgWikiaEnvironment, static::OPTIMIZELY_DEV_ENVIRONMENTS );
-	}
-
 	protected static function loadFromOurCDN() {
 		$scriptDomain = WikiFactory::getLocalEnvURL(
 			WikiFactory::getVarValueByName( 'wgServer', Wikia::COMMUNITY_WIKI_ID )
@@ -87,5 +76,16 @@ class Optimizely {
 		global $wgOptimizelyUrl, $wgOptimizelyDevUrl;
 		// do not async - we need it for UA tracking
 		return '<script src="' . ( static::isOptimizelyDevEnv() ? $wgOptimizelyDevUrl : $wgOptimizelyUrl ) . '"></script>';
+	}
+
+	/**
+	 * Is current environment considered a developemnt/testing environment for Optimizely experiments?
+	 *
+	 * @return bool
+	 */
+	protected static function isOptimizelyDevEnv() {
+		global $wgWikiaEnvironment;
+
+		return in_array( $wgWikiaEnvironment, static::OPTIMIZELY_DEV_ENVIRONMENTS );
 	}
 }

--- a/extensions/wikia/Optimizely/Optimizely.class.php
+++ b/extensions/wikia/Optimizely/Optimizely.class.php
@@ -6,14 +6,6 @@
  *
  */
 class Optimizely {
-
-	/**
-	 * Which environments are considered a developemnt/testing environments for Optimizely experiments?
-	 * Optimizely Wikia Dev project script should be served also on sandboxes, to prevent poluting Wikia Prod project
-	 * script with experiments that are still under developement.
-	 */
-	const OPTIMIZELY_DEV_ENVIRONMENTS = [ WIKIA_ENV_DEV, WIKIA_ENV_SANDBOX ];
-
 	static public function onOasisSkinAssetGroupsBlocking( &$jsAssetGroups ) {
 		global $wgNoExternals;
 
@@ -43,7 +35,7 @@ class Optimizely {
 	}
 
 	public static function onWikiaSkinTopScripts( &$vars, &$scripts, $skin ) {
-		global $wgOptimizelyLoadFromOurCDN, $wgNoExternals;
+		global $wgOptimizelyLoadFromOurCDN, $wgNoExternals, $wgWikiaEnvironment;
 
 		if ( !$wgNoExternals ) {
 			// load optimizely_blocking_js on wikiamobile
@@ -53,8 +45,9 @@ class Optimizely {
 				}
 			}
 
-			// On dev envs Optimizely script should be laoded from original CDN for the ease of testing the experiments.
-			if ( $wgOptimizelyLoadFromOurCDN && !static::isOptimizelyDevEnv() ) {
+			if ( $wgOptimizelyLoadFromOurCDN &&
+				!in_array( $wgWikiaEnvironment, [ WIKIA_ENV_DEV, WIKIA_ENV_SANDBOX ] )
+			) {
 				$scripts .= static::loadFromOurCDN();
 			} else {
 				$scripts .= static::loadOriginal();
@@ -73,19 +66,8 @@ class Optimizely {
 	}
 
 	protected static function loadOriginal() {
-		global $wgOptimizelyUrl, $wgOptimizelyDevUrl;
+		global $wgDevelEnvironment, $wgOptimizelyUrl, $wgOptimizelyDevUrl;
 		// do not async - we need it for UA tracking
-		return '<script src="' . ( static::isOptimizelyDevEnv() ? $wgOptimizelyDevUrl : $wgOptimizelyUrl ) . '"></script>';
-	}
-
-	/**
-	 * Is current environment considered a developemnt/testing environment for Optimizely experiments?
-	 *
-	 * @return bool
-	 */
-	protected static function isOptimizelyDevEnv() {
-		global $wgWikiaEnvironment;
-
-		return in_array( $wgWikiaEnvironment, static::OPTIMIZELY_DEV_ENVIRONMENTS );
+		return '<script src="' . ($wgDevelEnvironment ? $wgOptimizelyDevUrl : $wgOptimizelyUrl) . '"></script>';
 	}
 }

--- a/extensions/wikia/Optimizely/Optimizely.class.php
+++ b/extensions/wikia/Optimizely/Optimizely.class.php
@@ -64,6 +64,17 @@ class Optimizely {
 		return true;
 	}
 
+	/**
+	 * Is current environment considered a developemnt/testing environment for Optimizely experiments?
+	 *
+	 * @return bool
+	 */
+	public static function isOptimizelyDevEnv() {
+		global $wgWikiaEnvironment;
+
+		return in_array( $wgWikiaEnvironment, static::OPTIMIZELY_DEV_ENVIRONMENTS );
+	}
+
 	protected static function loadFromOurCDN() {
 		$scriptDomain = WikiFactory::getLocalEnvURL(
 			WikiFactory::getVarValueByName( 'wgServer', Wikia::COMMUNITY_WIKI_ID )
@@ -76,16 +87,5 @@ class Optimizely {
 		global $wgOptimizelyUrl, $wgOptimizelyDevUrl;
 		// do not async - we need it for UA tracking
 		return '<script src="' . ( static::isOptimizelyDevEnv() ? $wgOptimizelyDevUrl : $wgOptimizelyUrl ) . '"></script>';
-	}
-
-	/**
-	 * Is current environment considered a developemnt/testing environment for Optimizely experiments?
-	 *
-	 * @return bool
-	 */
-	protected static function isOptimizelyDevEnv() {
-		global $wgWikiaEnvironment;
-
-		return in_array( $wgWikiaEnvironment, static::OPTIMIZELY_DEV_ENVIRONMENTS );
 	}
 }

--- a/extensions/wikia/Optimizely/Optimizely.class.php
+++ b/extensions/wikia/Optimizely/Optimizely.class.php
@@ -35,7 +35,7 @@ class Optimizely {
 	}
 
 	public static function onWikiaSkinTopScripts( &$vars, &$scripts, $skin ) {
-		global $wgOptimizelyLoadFromOurCDN, $wgNoExternals, $wgDevelEnvironment;
+		global $wgOptimizelyLoadFromOurCDN, $wgNoExternals, $wgWikiaEnvironment;
 
 		if ( !$wgNoExternals ) {
 			// load optimizely_blocking_js on wikiamobile
@@ -45,7 +45,9 @@ class Optimizely {
 				}
 			}
 
-			if ( $wgOptimizelyLoadFromOurCDN && !$wgDevelEnvironment ) {
+			if ( $wgOptimizelyLoadFromOurCDN &&
+				!in_array( $wgWikiaEnvironment, [ WIKIA_ENV_DEV, WIKIA_ENV_SANDBOX ] )
+			) {
 				$scripts .= static::loadFromOurCDN();
 			} else {
 				$scripts .= static::loadOriginal();

--- a/extensions/wikia/Optimizely/Optimizely.class.php
+++ b/extensions/wikia/Optimizely/Optimizely.class.php
@@ -45,6 +45,9 @@ class Optimizely {
 				}
 			}
 
+			// On devboxes and sandboxes Optimizely script should be laoded from original CDN for the ease of testing
+			// the experiments, by mitigating the need to run the fetchOptimizelyScript.php (or waiting for it to be run
+			// by cron for sandbox).
 			if ( $wgOptimizelyLoadFromOurCDN &&
 				!in_array( $wgWikiaEnvironment, [ WIKIA_ENV_DEV, WIKIA_ENV_SANDBOX ] )
 			) {

--- a/extensions/wikia/Optimizely/Optimizely.class.php
+++ b/extensions/wikia/Optimizely/Optimizely.class.php
@@ -64,12 +64,18 @@ class Optimizely {
 		return true;
 	}
 
+	public static function getOptimizelyUrl() {
+		global $wgOptimizelyUrl, $wgOptimizelyDevUrl;
+
+		return static::isOptimizelyDevEnv() ? $wgOptimizelyDevUrl : $wgOptimizelyUrl;
+	}
+
 	/**
 	 * Is current environment considered a developemnt/testing environment for Optimizely experiments?
 	 *
 	 * @return bool
 	 */
-	public static function isOptimizelyDevEnv() {
+	protected static function isOptimizelyDevEnv() {
 		global $wgWikiaEnvironment;
 
 		return in_array( $wgWikiaEnvironment, static::OPTIMIZELY_DEV_ENVIRONMENTS );
@@ -84,8 +90,7 @@ class Optimizely {
 	}
 
 	protected static function loadOriginal() {
-		global $wgOptimizelyUrl, $wgOptimizelyDevUrl;
 		// do not async - we need it for UA tracking
-		return '<script src="' . ( static::isOptimizelyDevEnv() ? $wgOptimizelyDevUrl : $wgOptimizelyUrl ) . '"></script>';
+		return '<script src="' . static::getOptimizelyUrl() . '"></script>';
 	}
 }

--- a/extensions/wikia/Optimizely/Optimizely.class.php
+++ b/extensions/wikia/Optimizely/Optimizely.class.php
@@ -64,18 +64,12 @@ class Optimizely {
 		return true;
 	}
 
-	public static function getOptimizelyUrl() {
-		global $wgOptimizelyUrl, $wgOptimizelyDevUrl;
-
-		return static::isOptimizelyDevEnv() ? $wgOptimizelyDevUrl : $wgOptimizelyUrl;
-	}
-
 	/**
 	 * Is current environment considered a developemnt/testing environment for Optimizely experiments?
 	 *
 	 * @return bool
 	 */
-	protected static function isOptimizelyDevEnv() {
+	public static function isOptimizelyDevEnv() {
 		global $wgWikiaEnvironment;
 
 		return in_array( $wgWikiaEnvironment, static::OPTIMIZELY_DEV_ENVIRONMENTS );
@@ -90,7 +84,8 @@ class Optimizely {
 	}
 
 	protected static function loadOriginal() {
+		global $wgOptimizelyUrl, $wgOptimizelyDevUrl;
 		// do not async - we need it for UA tracking
-		return '<script src="' . static::getOptimizelyUrl() . '"></script>';
+		return '<script src="' . ( static::isOptimizelyDevEnv() ? $wgOptimizelyDevUrl : $wgOptimizelyUrl ) . '"></script>';
 	}
 }

--- a/extensions/wikia/Optimizely/Optimizely.class.php
+++ b/extensions/wikia/Optimizely/Optimizely.class.php
@@ -68,13 +68,13 @@ class Optimizely {
 		$scriptDomain = WikiFactory::getLocalEnvURL(
 			WikiFactory::getVarValueByName( 'wgServer', Wikia::COMMUNITY_WIKI_ID )
 		);
-		// do not asyc - we need it for UA tracking
+		// do not async - we need it for UA tracking
 		return '<script src="' . $scriptDomain . '/wikia.php?controller=Optimizely&method=getCode"></script>';
 	}
 
 	protected static function loadOriginal() {
 		global $wgOptimizelyUrl, $wgOptimizelyDevUrl;
-		// do not asyc - we need it for UA tracking
+		// do not async - we need it for UA tracking
 		return '<script src="' . ( static::isOptimizelyDevEnv() ? $wgOptimizelyDevUrl : $wgOptimizelyUrl ) . '"></script>';
 	}
 

--- a/extensions/wikia/Optimizely/Optimizely.class.php
+++ b/extensions/wikia/Optimizely/Optimizely.class.php
@@ -35,7 +35,7 @@ class Optimizely {
 	}
 
 	public static function onWikiaSkinTopScripts( &$vars, &$scripts, $skin ) {
-		global $wgOptimizelyLoadFromOurCDN, $wgNoExternals;
+		global $wgOptimizelyLoadFromOurCDN, $wgNoExternals, $wgDevelEnvironment;
 
 		if ( !$wgNoExternals ) {
 			// load optimizely_blocking_js on wikiamobile
@@ -45,7 +45,7 @@ class Optimizely {
 				}
 			}
 
-			if ( $wgOptimizelyLoadFromOurCDN ) {
+			if ( $wgOptimizelyLoadFromOurCDN && !$wgDevelEnvironment ) {
 				$scripts .= static::loadFromOurCDN();
 			} else {
 				$scripts .= static::loadOriginal();

--- a/maintenance/wikia/cronjobs/fetchOptimizelyScript.php
+++ b/maintenance/wikia/cronjobs/fetchOptimizelyScript.php
@@ -9,9 +9,9 @@
 
 require_once( dirname( __FILE__ ) . '/../../commandLine.inc' );
 
-global $wgOptimizelyUrl, $wgOptimizelyDevUrl;
+global $wgDevelEnvironment, $wgOptimizelyUrl, $wgOptimizelyDevUrl;
 
-$url = Optimizely::isOptimizelyDevEnv() ? $wgOptimizelyDevUrl : $wgOptimizelyUrl;
+$url = $wgDevelEnvironment ? $wgOptimizelyDevUrl : $wgOptimizelyUrl;
 $data = trim( Http::get( $url ) );
 
 if ( !empty( $data ) ) {

--- a/maintenance/wikia/cronjobs/fetchOptimizelyScript.php
+++ b/maintenance/wikia/cronjobs/fetchOptimizelyScript.php
@@ -9,9 +9,7 @@
 
 require_once( dirname( __FILE__ ) . '/../../commandLine.inc' );
 
-global $wgOptimizelyUrl, $wgOptimizelyDevUrl;
-
-$url = Optimizely::isOptimizelyDevEnv() ? $wgOptimizelyDevUrl : $wgOptimizelyUrl;
+$url = Optimizely::getOptimizelyUrl();
 $data = trim( Http::get( $url ) );
 
 if ( !empty( $data ) ) {

--- a/maintenance/wikia/cronjobs/fetchOptimizelyScript.php
+++ b/maintenance/wikia/cronjobs/fetchOptimizelyScript.php
@@ -9,7 +9,9 @@
 
 require_once( dirname( __FILE__ ) . '/../../commandLine.inc' );
 
-$url = Optimizely::getOptimizelyUrl();
+global $wgOptimizelyUrl, $wgOptimizelyDevUrl;
+
+$url = Optimizely::isOptimizelyDevEnv() ? $wgOptimizelyDevUrl : $wgOptimizelyUrl;
 $data = trim( Http::get( $url ) );
 
 if ( !empty( $data ) ) {

--- a/maintenance/wikia/cronjobs/fetchOptimizelyScript.php
+++ b/maintenance/wikia/cronjobs/fetchOptimizelyScript.php
@@ -9,9 +9,9 @@
 
 require_once( dirname( __FILE__ ) . '/../../commandLine.inc' );
 
-global $wgDevelEnvironment, $wgOptimizelyUrl, $wgOptimizelyDevUrl;
+global $wgOptimizelyUrl, $wgOptimizelyDevUrl;
 
-$url = $wgDevelEnvironment ? $wgOptimizelyDevUrl : $wgOptimizelyUrl;
+$url = Optimizely::isOptimizelyDevEnv() ? $wgOptimizelyDevUrl : $wgOptimizelyUrl;
 $data = trim( Http::get( $url ) );
 
 if ( !empty( $data ) ) {


### PR DESCRIPTION
On prod env Optimizely script is loaded by default from our CDN (http://community.wikia.com/wikia.php?controller=Optimizely&method=getCode). It's periodically downloaded by cron running `/maintenance/wikia/cronjobs/fetchOptimizelyScript.php` script (every 10 minutes as I recall and according to https://one.wikia-inc.com/wiki/Engineering/ABTesting/Optimizely#Technical_implementation). There's no such job for devboxes — developer has to know to set `$wgOptimizelyLoadFromOurCDN` to `false` in `DevboxSettings.php` or run the script manually using a command like this:

```
/usr/wikia/backend/bin/run_maintenance --script=fetchOptimizelyScript.php --ip=/usr/wikia/source/app/maintenance/wikia/cronjobs/ --id=80433
```

This is counter intuitive and adds redundant complexity.

Nevertheless, if you make changes to an experiment in Optimizely, you would probably want to see the changes ASAP on the sandbox where you're testing it. ASAP in this case is after clicking save in Optimizely app and after propagation in their CDN, without the need to wait for coping the script to Wikia's CDN.

By the way, sandboxes are serving Optimizely code meant for production — testing the experiments on sandboxes then could pollute the production Optimizely script, which should be kept as thin as possible and not change to often to encourage caching. But that could be a subject of a different PR preceded by a long discussion. :wink: 
