### PR TITLE
instead of creating a new user object, create a mock

### DIFF
--- a/extensions/wikia/AutoFollow/tests/AutoFollowHooksTest.php
+++ b/extensions/wikia/AutoFollow/tests/AutoFollowHooksTest.php
@@ -45,10 +45,17 @@ class AutoFollowHooksTest extends \WikiaBaseTest {
 		 * Mocked User object with necessary options set
 		 * @var object User
 		 */
-		$newUser = new \User();
-		$newUser->setGlobalPreference( 'language', $sLanguage );
-		$newUser->setGlobalPreference( 'marketingallowed', 1 );
-		$newUser->setGlobalFlag( $wgAutoFollowFlag, 0 );
+		$newUser = $this->getMock( \User::class, ['getGlobalPreference', 'getGlobalFlag'] );
+		$newUser->expects( $this->exactly( 2 ) )
+			->method( 'getGlobalPreference' )
+			->will( $this->returnValueMap( [
+				['language', null, false, $sLanguage],
+				['marketingallowed', null, false, 1]
+			] ) );
+		$newUser->expects( $this->once() )
+			->method( 'getGlobalFlag', null )
+			->with( $wgAutoFollowFlag )
+			->willReturn( 0 );
 
 		/**
 		 * For the given set of data a task should be queued once


### PR DESCRIPTION
@Wikia/services-team 

When running tests with `$wgPreferenceServiceRead = true`, these tests failed because we don't allow an anonymous user to have preferences in the preference service (but mediawiki allows it for the `User` object), so this changeset changes this test to mock the user object rather than use it directly, which is probably better anyway
