### PR TITLE
SEO-3 SEO Test: Limit H1s to One Per Page

### DIFF
--- a/extensions/wikia/AnalyticsEngine/js/universal_analytics.js
+++ b/extensions/wikia/AnalyticsEngine/js/universal_analytics.js
@@ -302,7 +302,8 @@
 		['set', 'dimension21', String(window.wgArticleId)],                     // ArticleId
 		['set', 'dimension23', window.wikiaIsPowerUserFrequent ? 'Yes' : 'No'], // IsPowerUser: Frequent
 		['set', 'dimension24', window.wikiaIsPowerUserLifetime ? 'Yes' : 'No'], // IsPowerUser: Lifetime
-		['set', 'dimension25', String(window.wgNamespaceNumber)]                // Namespace Number
+		['set', 'dimension25', String(window.wgNamespaceNumber)],               // Namespace Number
+		['set', 'dimension26', String(window.wgSeoTestingBucket || 0)]          // SEO Testing bucket
 	);
 
 	/*
@@ -443,26 +444,27 @@
 	window.ga('ads.require', 'displayfeatures');
 
 	/* Ads Account Custom Dimensions */
-	window.ga('ads.set', 'dimension1', window.wgDBname);                                // DBname
-	window.ga('ads.set', 'dimension2', window.wgContentLanguage);                       // ContentLanguage
-	window.ga('ads.set', 'dimension3', window.cscoreCat);                               // Hub
-	window.ga('ads.set', 'dimension4', window.skin);                                    // Skin
-	window.ga('ads.set', 'dimension5', !!window.wgUserName ? 'user' : 'anon');          // LoginStatus
+	window.ga('ads.set', 'dimension1', window.wgDBname);                                 // DBname
+	window.ga('ads.set', 'dimension2', window.wgContentLanguage);                        // ContentLanguage
+	window.ga('ads.set', 'dimension3', window.cscoreCat);                                // Hub
+	window.ga('ads.set', 'dimension4', window.skin);                                     // Skin
+	window.ga('ads.set', 'dimension5', !!window.wgUserName ? 'user' : 'anon');           // LoginStatus
 
 	/**** Medium-Priority Custom Dimensions ****/
-	window.ga('ads.set', 'dimension8', window.wikiaPageType);                           // PageType
-	window.ga('ads.set', 'dimension9', window.wgCityId);                                // CityId
-	window.ga('ads.set', 'dimension14', window.wgGaHasAds ? 'Yes' : 'No');              // HasAds
-	window.ga('ads.set', 'dimension15', window.wikiaPageIsCorporate ? 'Yes' : 'No');    // IsCorporatePage
-	window.ga('ads.set', 'dimension16', getKruxSegment());                              // Krux Segment
-	window.ga('ads.set', 'dimension17', window.wgWikiVertical);                         // Vertical
-	window.ga('ads.set', 'dimension18', window.wgWikiCategories.join(','));             // Categories
-	window.ga('ads.set', 'dimension19', window.wgArticleType);                          // ArticleType
-	window.ga('ads.set', 'dimension21', String(window.wgArticleId));                    // ArticleId
+	window.ga('ads.set', 'dimension8', window.wikiaPageType);                            // PageType
+	window.ga('ads.set', 'dimension9', window.wgCityId);                                 // CityId
+	window.ga('ads.set', 'dimension14', window.wgGaHasAds ? 'Yes' : 'No');               // HasAds
+	window.ga('ads.set', 'dimension15', window.wikiaPageIsCorporate ? 'Yes' : 'No');     // IsCorporatePage
+	window.ga('ads.set', 'dimension16', getKruxSegment());                               // Krux Segment
+	window.ga('ads.set', 'dimension17', window.wgWikiVertical);                          // Vertical
+	window.ga('ads.set', 'dimension18', window.wgWikiCategories.join(','));              // Categories
+	window.ga('ads.set', 'dimension19', window.wgArticleType);                           // ArticleType
+	window.ga('ads.set', 'dimension21', String(window.wgArticleId));                     // ArticleId
 	window.ga('ads.set', 'dimension21', String(window.wgArticleId));                     // ArticleId
 	window.ga('ads.set', 'dimension23', window.wikiaIsPowerUserFrequent ? 'Yes' : 'No'); // IsPowerUser: Frequent
 	window.ga('ads.set', 'dimension24', window.wikiaIsPowerUserLifetime ? 'Yes' : 'No'); // IsPowerUser: Lifetime
 	window.ga('ads.set', 'dimension25', String(window.wgNamespaceNumber));               // Namespace Number
+	window.ga('ads.set', 'dimension26', String(window.wgSeoTestingBucket || 0));         // SEO Testing bucket
 
 	/**** Include A/B testing status ****/
 	if (window.Wikia && window.Wikia.AbTest) {

--- a/extensions/wikia/SeoTesting/SeoTesting.class.php
+++ b/extensions/wikia/SeoTesting/SeoTesting.class.php
@@ -1,0 +1,91 @@
+<?php
+
+class SeoTesting {
+	const NO_SUCH_TEST = -1;
+	const TEST_NOT_ENABLED_HERE = -2;
+	const TEST_NOT_ENABLED_TODAY = -3;
+	const NOT_AN_ARTICLE = -4;
+
+	/**
+	 * Returns group for SEO testing
+	 *
+	 * Group 1 is about 40% of article traffic
+	 * Groups 2, 3 and 4 are about 20% of article traffic each
+	 *
+	 * Negative group means we should not experiment:
+	 *
+	 * Group -1 (NO_SUCH_TEST) means there no such test
+	 * Group -2 (TEST_NOT_ENABLED_HERE) means test is not enabled on this wiki
+	 * Group -3 (TEST_NOT_ENABLED_TODAY) means test is not enabled today
+	 * Group -4 (NOT_AN_ARTICLE) means not an article
+	 *
+	 * @param $experimentName string experiment name
+	 * @return int group number
+	 */
+	public static function getGroup( $experimentName ) {
+		global $wgDBname;
+
+		static $wgSeoTestingConfiguration = null;
+
+		if ( is_null( $wgSeoTestingConfiguration ) ) {
+			$wgSeoTestingConfiguration = WikiFactory::getVarValueByName( 'wgSeoTestingConfiguration', COMMUNITY_CENTRAL_CITY_ID );
+		}
+
+		if ( empty( $wgSeoTestingConfiguration[ $experimentName ] ) ) {
+			return self::NO_SUCH_TEST;
+		}
+
+		$experimentConfig = $wgSeoTestingConfiguration[ $experimentName ];
+		if ( !in_array( $wgDBname, $experimentConfig[ 'dbNames' ] ) ) {
+			return self::TEST_NOT_ENABLED_HERE;
+		}
+
+		$today = date( 'Y-m-d' );
+		if ( $today < $experimentConfig[ 'startDay' ] || $today > $experimentConfig[ 'endDay' ] ) {
+			return self::TEST_NOT_ENABLED_TODAY;
+		}
+
+		return self::getBucket();
+	}
+
+	/**
+	 * Returns bucket for SEO testing
+	 *
+	 * Group 1 is about 40% of article traffic
+	 * Groups 2, 3 and 4 are about 20% of article traffic each
+	 *
+	 * Group -4 (NOT_AN_ARTICLE) means not an article
+	 *
+	 * @return int group number
+	 */
+	public static function getBucket() {
+		global $wgTitle, $wgRequest;
+
+		static $bucket = null;
+
+		if ( !is_null( $bucket ) ) {
+			return $bucket;
+		}
+
+		$requestVars = $wgRequest->getValues();
+		unset( $requestVars[ 'title' ] );
+		if ( !empty($requestVars) || ! WikiaPageType::isArticlePage() ) {
+			$bucket = self::NOT_AN_ARTICLE;
+			return $bucket;
+		}
+
+		// Mapping based on 7th to last character in the URL
+		$url = $wgTitle->getLocalURL();
+		$char = substr( $url, strlen( $url ) - 7, 1 );
+		$charModulus = ord( $char ) % 5;
+		$bucket = min( $charModulus, 3 ) + 1;
+
+		return $bucket;
+	}
+
+	public static function onWikiaSkinTopScripts( &$vars, &$scripts ) {
+		// This is for analytics
+		$vars[ 'wgSeoTestingBucket' ] = self::getBucket();
+		return true;
+	}
+}

--- a/extensions/wikia/SeoTesting/SeoTesting.setup.php
+++ b/extensions/wikia/SeoTesting/SeoTesting.setup.php
@@ -1,0 +1,7 @@
+<?php
+
+// Autoload
+$wgAutoloadClasses['SeoTesting'] =  __DIR__ . '/SeoTesting.class.php';
+
+// Hooks
+$wgHooks['WikiaSkinTopScripts'][] = 'SeoTesting::onWikiaSkinTopScripts';

--- a/extensions/wikia/Spotlights/SpotlightsController.class.php
+++ b/extensions/wikia/Spotlights/SpotlightsController.class.php
@@ -1,5 +1,8 @@
 <?php
 class SpotlightsController extends WikiaController {
 	public function index() {
+		if ( class_exists( 'SeoTesting' ) ) {
+			$this->setVal( 'seoTestOneH1', SeoTesting::getGroup('One_H1') === 2 );
+		}
 	}
 }

--- a/extensions/wikia/Spotlights/templates/Spotlights_Index.php
+++ b/extensions/wikia/Spotlights/templates/Spotlights_Index.php
@@ -1,7 +1,11 @@
 <? if (!$wg->NoExternals && !$wg->SuppressSpotlights) { ?>
 <section>
 	<div class="header-container">
-		<h1><?= wfMsg('oasis-spotlights-footer-title') ?></h1>
+		<? if ( $seoTestOneH1 ): ?>
+			<h2><?= wfMsg('oasis-spotlights-footer-title') ?></h2>
+		<? else: ?>
+			<h1><?= wfMsg('oasis-spotlights-footer-title') ?></h1>
+		<? endif; ?>
 		<?= F::app()->renderView('RandomWiki', 'Index') ?>
 	</div>
 	<script type='text/javascript'>

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1816,12 +1816,23 @@ $wgEnableRobotsTxtExt = false;
  */
 $wgEnableFliteTagExt = false;
 
+// SEO-related variables start (keep them sorted)
+
 /**
  * @name $wgEnableSeoLinkHreflangExt
  *
  * Enables SEO Link Hreflang extension
  */
 $wgEnableSeoLinkHreflangExt = false;
+
+/**
+ * @name $wgEnableSeoTestingExt
+ *
+ * Enables SEO Testing extension
+ */
+$wgEnableSeoTestingExt = true;
+
+// SEO-related variables end
 
 /**
  * @name $wgAdDriverAdsRecoveryMessageCountries

--- a/skins/oasis/css/core/Footer.scss
+++ b/skins/oasis/css/core/Footer.scss
@@ -120,6 +120,12 @@
 			float: left;
 			margin:17px 0 17px 20px;
 		}
+		h2 {
+			// SEO Test "One_H1"
+			font-size: 18px;
+			float: left;
+			margin:17px 0 17px 20px;
+		}
 		.wikia-button {
 			float: right;
 			margin:17px 20px;

--- a/skins/oasis/css/core/WikiHeader.scss
+++ b/skins/oasis/css/core/WikiHeader.scss
@@ -54,6 +54,11 @@ $WikiNavWidth: $width-outside - 271px;
 			display: none;
 		}
 
+		> h2 {
+			// SEO Test "One_H1"
+			display: none;
+		}
+
 		>ul {
 			@include clearfix;
 			position: relative;

--- a/skins/oasis/css/core/body.scss
+++ b/skins/oasis/css/core/body.scss
@@ -15,6 +15,11 @@ body {
 	display: none;
 }
 
+.WikiaSiteWrapper > h2 {
+	// SEO Test "One_H1"
+	display: none;
+}
+
 a {
 	color: $color-links;
 	text-decoration: none;

--- a/skins/oasis/modules/BodyController.class.php
+++ b/skins/oasis/modules/BodyController.class.php
@@ -499,6 +499,10 @@ class BodyController extends WikiaController {
 		// bugid-70243: optionally hide navigation h1s for SEO
 		$this->setVal( 'displayHeader', !$this->wg->HideNavigationHeaders );
 
+		if ( class_exists( 'SeoTesting' ) ) {
+			$this->setVal( 'seoTestOneH1', SeoTesting::getGroup('One_H1') === 2 );
+		}
+
 		wfProfileOut(__METHOD__);
 	}
 

--- a/skins/oasis/modules/WikiHeaderController.class.php
+++ b/skins/oasis/modules/WikiHeaderController.class.php
@@ -37,6 +37,10 @@ class WikiHeaderController extends WikiaController {
 		$this->displaySearch = !empty($this->wg->EnableAdminDashboardExt) && AdminDashboardLogic::displayAdminDashboard($this, $this->wg->Title);
 		$this->setVal( 'displayHeader', !$this->wg->HideNavigationHeaders );
 		$this->displayHeaderButtons = !WikiaPageType::isWikiaHubMain();
+
+		if ( class_exists( 'SeoTesting' ) ) {
+			$this->setVal( 'seoTestOneH1', SeoTesting::getGroup('One_H1') === 2 );
+		}
 	}
 
 	public function executeWordmark() {
@@ -69,5 +73,9 @@ class WikiHeaderController extends WikiaController {
 		}
 
 		$this->mainPageURL = Title::newMainPage()->getLocalURL();
+
+		if ( class_exists( 'SeoTesting' ) ) {
+			$this->setVal( 'seoTestOneH1', SeoTesting::getGroup('One_H1') === 2 );
+		}
 	}
 }

--- a/skins/oasis/modules/templates/Body_Index.php
+++ b/skins/oasis/modules/templates/Body_Index.php
@@ -1,5 +1,9 @@
 <? if ( $displayHeader ): ?>
-<h1><?= wfMsg( 'oasis-global-page-header' ); ?></h1>
+	<? if ( $seoTestOneH1 ): ?>
+		<h2><?= wfMsg( 'oasis-global-page-header' ); ?></h2>
+	<? else: ?>
+		<h1><?= wfMsg( 'oasis-global-page-header' ); ?></h1>
+	<? endif; ?>
 <? endif; ?>
 <div class="skiplinkcontainer">
 <a class="skiplink" rel="nofollow" href="#WikiaArticle"><?= wfMsg( 'oasis-skip-to-content' ); ?></a>

--- a/skins/oasis/modules/templates/WikiHeader_Index.php
+++ b/skins/oasis/modules/templates/WikiHeader_Index.php
@@ -1,20 +1,19 @@
 <header id="WikiHeader" class="WikiHeader">
 	<?= $app->renderView( 'WikiHeader', 'Wordmark' ) ?>
-    <nav class="WikiNav">
-    	<? if ( $displayHeader ): ?>
-        <h1><?= wfMsg( 'oasis-wiki-navigation', $wordmarkText ) ?></h1>
-        <? endif; ?>
+	<nav class="WikiNav">
+		<? if ( $displayHeader ): ?>
+			<h1><?= wfMsg( 'oasis-wiki-navigation', $wordmarkText ) ?></h1>
+		<? endif; ?>
 		<?= $app->renderView( 'WikiNavigation', 'Index' ) ?>
-    </nav>
+	</nav>
 	<? if ( $displayHeaderButtons ) : ?>
-    <div class="buttons">
-		<?= $app->renderView( 'ContributeMenu', 'Index' ) ?>
-    </div>
+		<div class="buttons">
+			<?= $app->renderView( 'ContributeMenu', 'Index' ) ?>
+		</div>
 	<? endif ?>
-    <div class="hiddenLinks">
+	<div class="hiddenLinks">
 		<?= Wikia::specialPageLink( 'Watchlist', 'watchlist', array( 'accesskey' => 'l' ) ) ?>
 		<?= Wikia::specialPageLink( 'Random', 'randompage', array( 'accesskey' => 'x' ) ) ?>
 		<?= Wikia::specialPageLink( 'RecentChanges', 'recentchanges', array( 'accesskey' => 'r' ) ) ?>
-    </div>
+	</div>
 </header>
-

--- a/skins/oasis/modules/templates/WikiHeader_Index.php
+++ b/skins/oasis/modules/templates/WikiHeader_Index.php
@@ -2,7 +2,11 @@
 	<?= $app->renderView( 'WikiHeader', 'Wordmark' ) ?>
 	<nav class="WikiNav">
 		<? if ( $displayHeader ): ?>
-			<h1><?= wfMsg( 'oasis-wiki-navigation', $wordmarkText ) ?></h1>
+			<? if ( $seoTestOneH1 ): ?>
+				<h2><?= wfMsg( 'oasis-wiki-navigation', $wordmarkText ) ?></h2>
+			<? else: ?>
+				<h1><?= wfMsg( 'oasis-wiki-navigation', $wordmarkText ) ?></h1>
+			<? endif; ?>
 		<? endif; ?>
 		<?= $app->renderView( 'WikiNavigation', 'Index' ) ?>
 	</nav>

--- a/skins/oasis/modules/templates/WikiHeader_Wordmark.php
+++ b/skins/oasis/modules/templates/WikiHeader_Wordmark.php
@@ -1,9 +1,21 @@
-<h1 class="wordmark <?= $wordmarkSize ?> <?= $wordmarkType ?> <?= $wordmarkFontClass ?>">
-	<a accesskey="z" href="<?= htmlspecialchars($mainPageURL) ?>">
-		<? if (!empty($wordmarkUrl)) { ?>
-			<img src="<?= $wordmarkUrl ?>" alt="<?= htmlspecialchars($wordmarkText) ?>" <? if (!empty($wordmarkStyle)) { ?><?= $wordmarkStyle ?><? } ?>>
-		<? } else { ?>
-			<?= htmlspecialchars($wordmarkText) ?>
-		<? } ?>
-	</a>
-</h1>
+<? if ( $seoTestOneH1 ): ?>
+	<h2 class="wordmark <?= $wordmarkSize ?> <?= $wordmarkType ?> <?= $wordmarkFontClass ?>">
+		<a accesskey="z" href="<?= htmlspecialchars($mainPageURL) ?>">
+			<? if (!empty($wordmarkUrl)) { ?>
+				<img src="<?= $wordmarkUrl ?>" alt="<?= htmlspecialchars($wordmarkText) ?>" <? if (!empty($wordmarkStyle)) { ?><?= $wordmarkStyle ?><? } ?>>
+			<? } else { ?>
+				<?= htmlspecialchars($wordmarkText) ?>
+			<? } ?>
+		</a>
+	</h2>
+<? else: ?>
+	<h1 class="wordmark <?= $wordmarkSize ?> <?= $wordmarkType ?> <?= $wordmarkFontClass ?>">
+		<a accesskey="z" href="<?= htmlspecialchars($mainPageURL) ?>">
+			<? if (!empty($wordmarkUrl)) { ?>
+				<img src="<?= $wordmarkUrl ?>" alt="<?= htmlspecialchars($wordmarkText) ?>" <? if (!empty($wordmarkStyle)) { ?><?= $wordmarkStyle ?><? } ?>>
+			<? } else { ?>
+				<?= htmlspecialchars($wordmarkText) ?>
+			<? } ?>
+		</a>
+	</h1>
+<? endif; ?>


### PR DESCRIPTION
On 20% of article pages on selected wikis test whether having
only one H1 (the one with the article title) helps SEO or not.

There's a very basic version of SEO Testing commited including:
- Very basic article bucketing based on article URLs
- SeoTesting class for checking which group the page is in

The configuration is done through WikiFactory.

The variable $wgSeoTestingConfiguration is in the following format:

```
[
  'Name_of_test' => [
    'dbNames' => ['list', 'of', 'dbnames'],
    'startDay' => '2015-10-01',
    'endDay' => '2015-12-31',
  ],
  'Another_test' => [
    'dbNames' => ['other', 'wikis'],
    'startDay' => '2015-11-01',
    'endDay' => '2015-11-30',
  ],
]
```

This variable should be only set on community wiki (it's global).
