### PR TITLE
CE-2681 Add a unit test for removeCompletedAndUpdateLogs method

### DIFF
--- a/extensions/wikia/ContentReview/ContentReviewHelper.php
+++ b/extensions/wikia/ContentReview/ContentReviewHelper.php
@@ -227,7 +227,7 @@ class Helper extends \ContextSource {
 			return true;
 		}
 
-		$reviewData = $reviewModel->getReviewedContent( $wikiId, $pageId, ReviewModel::CONTENT_REVIEW_STATUS_IN_REVIEW );
+		$reviewData = $reviewModel->getReviewOfPageByStatus( $wikiId, $pageId, ReviewModel::CONTENT_REVIEW_STATUS_IN_REVIEW );
 		return ( !empty( $reviewData ) && (int)$reviewData['revision_id'] === $diff );
 	}
 

--- a/extensions/wikia/ContentReview/controllers/ContentReviewApiController.class.php
+++ b/extensions/wikia/ContentReview/controllers/ContentReviewApiController.class.php
@@ -127,9 +127,9 @@ class ContentReviewApiController extends WikiaApiController {
 			throw new PermissionsException( 'content-review' );
 		}
 
-		$currentRevisionModel = new CurrentRevisionModel();
-		$reviewModel = new ReviewModel();
-		$helper = new Helper();
+		$currentRevisionModel = $this->getCurrentRevisionModel();
+		$helper = $this->getHelper();
+		$reviewModel = $this->getReviewModel();
 
 		$reviewerId = $this->wg->User->getId();
 		$pageId = $this->request->getInt( 'pageId' );
@@ -138,17 +138,15 @@ class ContentReviewApiController extends WikiaApiController {
 		$diff = $this->request->getInt( 'diff' );
 		$oldid = $this->request->getInt( 'oldid' );
 
-
-		if ( $helper->hasPageApprovedId( $currentRevisionModel, $wikiId, $pageId, $oldid  )
+		if ( $helper->hasPageApprovedId( $currentRevisionModel, $wikiId, $pageId, $oldid )
 			&& $helper->isDiffPageInReviewProcess( $this->request, $reviewModel, $wikiId, $pageId, $diff ) )
 		{
-			$review = $reviewModel->getReviewedContent( $wikiId, $pageId, ReviewModel::CONTENT_REVIEW_STATUS_IN_REVIEW );
+			$review = $reviewModel->getReviewOfPageByStatus( $wikiId, $pageId, ReviewModel::CONTENT_REVIEW_STATUS_IN_REVIEW );
 
 			if ( empty( $review ) ) {
-				throw new NotFoundApiException( 'Requested data not present in the database.' );
+				throw new NotFoundApiException( 'There is no revision that is currently in review.' );
 			}
-			$reviewLogModel = new ReviewLogModel();
-			$reviewLogModel->backupCompletedReview( $review, $status, $reviewerId );
+			$this->getReviewLogModel()->backupCompletedReview( $review, $status, $reviewerId );
 
 			if ( $status === ReviewModel::CONTENT_REVIEW_STATUS_APPROVED ) {
 				$currentRevisionModel->approveRevision( $wikiId, $pageId, $review['revision_id'] );
@@ -159,11 +157,9 @@ class ContentReviewApiController extends WikiaApiController {
 				$feedbackLink = $helper->prepareProvideFeedbackLink( $title );
 				$this->notification = wfMessage( 'content-review-diff-reject-confirmation', $feedbackLink )->parse();
 			}
-
-			$reviewModel->updateCompletedReview( $wikiId, $pageId, $review['revision_id'], $status );
 		}
 		else {
-			$this->notification = wfMessage( 'content-review-diff-already-done' )->escaped();
+			$this->notification = $this->wfMessage( 'content-review-diff-already-done' )->escaped();
 		}
 	}
 
@@ -245,6 +241,11 @@ class ContentReviewApiController extends WikiaApiController {
 		$this->setResponseData( $res );
 	}
 
+	/**
+	 * @param $pageName
+	 * @return Title
+	 * @throws MWException
+	 */
 	protected function getTitle( $pageName ) {
 		return Title::newFromText( $pageName );
 	}
@@ -254,6 +255,27 @@ class ContentReviewApiController extends WikiaApiController {
 	 */
 	protected function getHelper() {
 		return new Helper();
+	}
+
+	/**
+	 * @return Wikia\ContentReview\Models\CurrentRevisionModel
+	 */
+	protected function getCurrentRevisionModel() {
+		return new CurrentRevisionModel();
+	}
+
+	/**
+	 * @return Wikia\ContentReview\Models\ReviewModel
+	 */
+	protected function getReviewModel() {
+		return new ReviewModel();
+	}
+
+	/**
+	 * @return Wikia\ContentReview\Models\ReviewLogModel
+	 */
+	protected function getReviewLogModel() {
+		return new ReviewLogModel();
 	}
 
 	private function isValidPostRequest( WikiaRequest $request, User $user ) {

--- a/extensions/wikia/ContentReview/controllers/ContentReviewApiController.class.php
+++ b/extensions/wikia/ContentReview/controllers/ContentReviewApiController.class.php
@@ -159,7 +159,7 @@ class ContentReviewApiController extends WikiaApiController {
 			}
 		}
 		else {
-			$this->notification = $this->wfMessage( 'content-review-diff-already-done' )->escaped();
+			$this->notification = wfMessage( 'content-review-diff-already-done' )->escaped();
 		}
 	}
 

--- a/extensions/wikia/ContentReview/models/ReviewModel.php
+++ b/extensions/wikia/ContentReview/models/ReviewModel.php
@@ -192,11 +192,21 @@ class ReviewModel extends ContentReviewBaseModel {
 		return $content;
 	}
 
-	public function getReviewedContent( $wiki_id, $page_id, $status ) {
+	/**
+	 * Retrieves a row from content_review_status table for a given based on a desired status.
+	 * If there is no review of the given page of the given status - a false is returned.
+	 *
+	 * @param $wiki_id
+	 * @param $page_id
+	 * @param $status
+	 * @return bool|array Returns an array that resembles a row from the content_review_status table,
+	 * or `false` if no is found.
+	 */
+	public function getReviewOfPageByStatus( $wiki_id, $page_id, $status ) {
 		$db = $this->getDatabaseForRead();
 
 		$content = ( new \WikiaSQL() )
-			->SELECT( '*' )
+			->SELECT_ALL()
 			->FROM( self::CONTENT_REVIEW_STATUS_TABLE )
 			->WHERE( 'wiki_id' )->EQUAL_TO( $wiki_id )
 			->AND_( 'page_id' )->EQUAL_TO( $page_id )

--- a/extensions/wikia/ContentReview/tests/ContentReviewApiControllerTest.php
+++ b/extensions/wikia/ContentReview/tests/ContentReviewApiControllerTest.php
@@ -151,7 +151,7 @@ class ContentReviewApiControllerTest extends WikiaBaseTest {
 		}
 
 		$requestMock = $this->preparePostRequestValidatingMock( $inputData['wasPosted'], $inputData['requestToken'], [ 'getInt' ] );
-		$requestMock->expects( $this->atLeastOnce() )
+		$requestMock->expects( $this->any() )
 			->method( 'getInt' );
 
 		$userMock = $this->prepareUserMockWithEditToken( $inputData['userEditToken'], [ 'getRights' ] );

--- a/extensions/wikia/ContentReview/tests/ContentReviewApiControllerTest.php
+++ b/extensions/wikia/ContentReview/tests/ContentReviewApiControllerTest.php
@@ -93,26 +93,16 @@ class ContentReviewApiControllerTest extends WikiaBaseTest {
 		/**
 		 * User Mock
 		 */
-		$userMock = $this->getMock( '\User', [ 'getId', 'getEditToken' ] );
+		$userMock = $this->prepareUserMockWithEditToken( $inputData['userEditToken'], [ 'getId' ] );
 		$userMock->expects( $this->any() )
 			->method( 'getId' )
 			->willReturn( $inputData['userId'] );
-		$userMock->expects( $this->any() )
-			->method( 'getEditToken' )
-			->willReturn( $inputData['userEditToken'] );
-
 		$this->mockGlobalVariable( 'wgUser', $userMock );
 
 		/**
 		 * Wikia Request Mock
 		 */
-		$requestMock = $this->getMock( '\WikiaRequest', [ 'wasPosted', 'getVal' ], [ [] ] );
-		$requestMock->expects( $this->any() )
-			->method( 'wasPosted' )
-			->willReturn( $inputData['wasPosted'] );
-		$requestMock->expects( $this->any() )
-			->method( 'getVal' )
-			->willReturn( $inputData['requestToken'] );
+		$requestMock = $this->preparePostRequestValidatingMock( $inputData['wasPosted'], $inputData['requestToken'] );
 		$requestMock->expects( $this->any() )
 			->method( 'getInt' )
 			->willReturn( 0 ); // pageId, does not really matter since the Title is overwritten
@@ -144,6 +134,102 @@ class ContentReviewApiControllerTest extends WikiaBaseTest {
 
 		$apiController->setRequest( $requestMock );
 		$apiController->enableTestMode();
+	}
+
+	/**
+	 * @dataProvider removeCompletedAndUpdateLogsDataProvider
+	 * @param array $inputData
+	 * @param string $expected
+	 * @param string $message
+	 */
+	public function testRemoveCompletedAndUpdateLogs( $inputData, $expected, $message ) {
+		/**
+		 * Set exception if expected
+		 */
+		if ( $inputData['exception'] ) {
+			$this->setExpectedException( $expected );
+		}
+
+		$requestMock = $this->preparePostRequestValidatingMock( $inputData['wasPosted'], $inputData['requestToken'], [ 'getInt' ] );
+		$requestMock->expects( $this->atLeastOnce() )
+			->method( 'getInt' );
+
+		$userMock = $this->prepareUserMockWithEditToken( $inputData['userEditToken'], [ 'getRights' ] );
+		$userMock->expects( $this->any() )
+			->method( 'getRights' )
+			->willReturn( $inputData['userGetRights'] );
+		$this->mockGlobalVariable( 'wgUser', $userMock );
+
+		$currentRevisionModelMock = $this->getMock( 'Wikia\ContentReview\Models\CurrentRevisionModel', [
+			'approveRevision',
+		] );
+
+		$helperMock = $this->getMock( 'Wikia\ContentReview\Helper', [
+			'hasPageApprovedId',
+			'isDiffPageInReviewProcess',
+			'purgeReviewedJsPagesTimestamp',
+			'prepareProvideFeedbackLink',
+		] );
+		$helperMock->expects( $this->any() )
+			->method( 'hasPageApprovedId' )
+			->willReturn( $inputData['hasPageApprovedId'] );
+		$helperMock->expects( $this->any() )
+			->method( 'isDiffPageInReviewProcess' )
+			->willReturn( $inputData['isDiffPageInReviewProcess'] );
+
+		$reviewLogModelMock = $this->getMock( 'Wikia\ContentReview\Models\ReviewLogModel', [
+			'backupCompletedReview',
+		] );
+
+		$reviewModelMock = $this->getMock( 'Wikia\ContentReview\Models\ReviewModel', [
+			'getReviewOfPageByStatus',
+			'updateCompletedReview',
+		] );
+		$reviewModelMock->expects( $this->any() )
+			->method( 'getReviewOfPageByStatus' )
+			->willReturn( $inputData['inReviewRevision'] );
+
+		$this->mockStaticMethod( '\Title', 'newFromId', 'Mocked title' );
+
+		$responseMock = $this->getMock( '\WikiaResponse' );
+
+		/**
+		 * Mock ContentReviewApiController
+		 * @var ContentReviewApiController
+		 */
+		$apiControllerMock = $this->getMock( '\ContentReviewApiController', [
+			'getCurrentRevisionModel',
+			'getHelper',
+			'getReviewLogModel',
+			'getReviewModel',
+		] );
+
+		$apiControllerMock->setRequest( $requestMock );
+		$apiControllerMock->setResponse( $responseMock );
+
+		$apiControllerMock->expects( $this->any() )
+			->method( 'getCurrentRevisionModel' )
+			->willReturn( $currentRevisionModelMock );
+		$apiControllerMock->expects( $this->any() )
+			->method( 'getHelper' )
+			->willReturn( $helperMock );
+		$apiControllerMock->expects( $this->any() )
+			->method( 'getReviewLogModel' )
+			->willReturn( $reviewLogModelMock );
+		$apiControllerMock->expects( $this->any() )
+			->method( 'getReviewModel' )
+			->willReturn( $reviewModelMock );
+
+		/**
+		 * If no exception occurs - check a status with which a notification has been retrieved
+		 */
+		if ( !$inputData['exception'] ) {
+			$apiControllerMock->expects( $this->once() )
+				->method( 'getReviewUpdateNotification' )
+				->with( $expected );
+		}
+
+		$apiControllerMock->removeCompletedAndUpdateLogs();
 	}
 
 	private function prepareControllerPropertiesMocks( $params ) {
@@ -201,6 +287,65 @@ class ContentReviewApiControllerTest extends WikiaBaseTest {
 
 		$this->contentReviewApiControllerMock->method( 'getTitle' )
 			->will( $this->returnValue( $titleMock ) );
+	}
+
+	/**
+	 * Returns a mock of WikiaRequest object that can be used for validating a POST request
+	 * with a matching edit token.
+	 * @param bool $wasPosted
+	 * @param string $requestToken
+	 * @param array $methodsToMock
+	 * @return PHPUnit_Framework_MockObject_MockObject
+	 */
+	private function preparePostRequestValidatingMock( $wasPosted, $requestToken, array $methodsToMock = [] ) {
+		/**
+		 * Wikia Request Mock
+		 */
+		if ( !in_array( 'wasPosted', $methodsToMock ) ) {
+			$methodsToMock[] = 'wasPosted';
+		}
+		if ( !in_array( 'getVal', $methodsToMock ) ) {
+			$methodsToMock[] = 'getVal';
+		}
+
+		$requestMock = $this->getMock( '\WikiaRequest', $methodsToMock, [ [] ] );
+		$requestMock->expects( $this->any() )
+			->method( 'wasPosted' )
+			->willReturn( $wasPosted );
+
+		if ( $wasPosted ) {
+			$requestTokenMatcher = $this->atLeastOnce();
+		} else {
+			$requestTokenMatcher = $this->never();
+		}
+		$requestMock->expects( $requestTokenMatcher )
+			->method( 'getVal' )
+			->willReturn( $requestToken );
+
+		return $requestMock;
+	}
+
+	/**
+	 * Returns a mock of User object that can be used for validating a POST request
+	 * with a matching edit token.
+	 * @param string $userEditToken
+	 * @param array $methodsToMock An array of methods other than getEditToken to mock
+	 * @return PHPUnit_Framework_MockObject_MockObject
+	 */
+	private function prepareUserMockWithEditToken( $userEditToken, array $methodsToMock = [] ) {
+		/**
+		 * User Mock
+		 */
+		if ( !in_array( 'getEditToken', $methodsToMock ) ) {
+			$methodsToMock[] = 'getEditToken';
+		}
+
+		$userMock = $this->getMock( '\User', $methodsToMock );
+		$userMock->expects( $this->any() )
+			->method( 'getEditToken' )
+			->willReturn( $userEditToken );
+
+		return $userMock;
 	}
 
 	public function submitPageForReviewProvider() {
@@ -348,7 +493,7 @@ class ContentReviewApiControllerTest extends WikiaBaseTest {
 			],
 			[
 				[
-					'wasPosted' => TRUE,
+					'wasPosted' => true,
 					'requestToken' => $validToken,
 					'userEditToken' => $validToken,
 					'isJsPage' => true,
@@ -360,7 +505,7 @@ class ContentReviewApiControllerTest extends WikiaBaseTest {
 			],
 			[
 				[
-					'wasPosted' => TRUE,
+					'wasPosted' => true,
 					'requestToken' => $validToken,
 					'userEditToken' => $validToken,
 					'isJsPage' => true,
@@ -372,7 +517,7 @@ class ContentReviewApiControllerTest extends WikiaBaseTest {
 			],
 			[
 				[
-					'wasPosted' => TRUE,
+					'wasPosted' => true,
 					'requestToken' => $validToken,
 					'userEditToken' => $validToken,
 					'isJsPage' => true,
@@ -381,6 +526,63 @@ class ContentReviewApiControllerTest extends WikiaBaseTest {
 				],
 				'success',
 				'Everything is fine, methods to enable the test mode and make a success response should be called once.',
+			],
+		];
+	}
+
+	public function removeCompletedAndUpdateLogsDataProvider() {
+		$validToken = MWCryptRand::generateHex( 32 );
+		$invalidToken = MWCryptRand::generateHex( 32 );
+
+		return [
+			[
+				[
+					'exception' => true,
+					'wasPosted' => false,
+				],
+				$expected = 'BadRequestApiException',
+				$message = 'The request would be ok if it was POSTed.',
+			],
+			[
+				[
+					'exception' => true,
+					'wasPosted' => true,
+					'requestToken' => $invalidToken,
+					'userEditToken' => $validToken,
+				],
+				$expected = 'BadRequestApiException',
+				$message = 'An invalid editToken was sent in the request.',
+			],
+			[
+				[
+					'exception' => true,
+					'wasPosted' => true,
+					'requestToken' => $validToken,
+					'userEditToken' => $validToken,
+					'userGetRights' => [
+						// empty array - no content-review rights
+					],
+				],
+				$expected = 'PermissionsException',
+				$message = 'User does not have content-review rights.',
+			],
+			[
+				[
+					'exception' => true,
+					'wasPosted' => true,
+					'requestToken' => $validToken,
+					'userEditToken' => $validToken,
+					'userGetRights' => [
+						'content-review',
+					],
+					'hasPageApprovedId' => true,
+					'isDiffPageInReviewProcess' => true,
+					'inReviewRevision' => [
+						// empty array
+					],
+				],
+				$expected = 'NotFoundApiException',
+				$message = 'No revision in review - should throw an exception.',
 			],
 		];
 	}

--- a/extensions/wikia/ContentReview/tests/ContentReviewApiControllerTest.php
+++ b/extensions/wikia/ContentReview/tests/ContentReviewApiControllerTest.php
@@ -151,8 +151,6 @@ class ContentReviewApiControllerTest extends WikiaBaseTest {
 		}
 
 		$requestMock = $this->preparePostRequestValidatingMock( $inputData['wasPosted'], $inputData['requestToken'], [ 'getInt' ] );
-		$requestMock->expects( $this->any() )
-			->method( 'getInt' );
 
 		$userMock = $this->prepareUserMockWithEditToken( $inputData['userEditToken'], [ 'getRights' ] );
 		$userMock->expects( $this->any() )


### PR DESCRIPTION
Hello @Wikia/community-engineering !

Ok, so this one is a really nasty one. It is complex, long and REALLY convinced me that we should extract the actual logic from the API controller to a service/class/whatever.

IMO it is pointless to waste time right now on trying to retrieve what is actually the outcome of the method (which is saving a notification message to `$this->notification`) in a test. I think that an API test should focus on request validation, permissions etc. They are being checked right now. The rest should go into the service test.

Please, review my point and code.

/cc @Grunny @lukaszkonieczny 
