### PR TITLE
SOC-926 Load localized Facebook JS SDK

### DIFF
--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -233,7 +233,9 @@ $config['oasis_noads_extensions_js'] = array(
 		'//extensions/wikia/Thumbnails/scripts/templates.mustache.js',
 		// handlebars - uncomment this when introducing first client-side rendered handlebars template
 		// '//resources/wikia/libraries/handlebars/handlebars.js',
-		'//extensions/wikia/JSSnippets/js/JSSnippets.js'
+		'//extensions/wikia/JSSnippets/js/JSSnippets.js',
+		// facebook
+		'//resources/wikia/modules/facebookLocale.js',
 	)
 );
 
@@ -609,6 +611,9 @@ $config['wikiamobile_js_body_minimal'] = array(
 
 		// video
 		'//extensions/wikia/VideoHandlers/js/VideoBootstrap.js',
+
+		// facebook
+		'//resources/wikia/modules/facebookLocale.js',
 	)
 );
 

--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -234,8 +234,6 @@ $config['oasis_noads_extensions_js'] = array(
 		// handlebars - uncomment this when introducing first client-side rendered handlebars template
 		// '//resources/wikia/libraries/handlebars/handlebars.js',
 		'//extensions/wikia/JSSnippets/js/JSSnippets.js',
-		// facebook
-		'//resources/wikia/modules/facebookLocale.js',
 	)
 );
 

--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -290,6 +290,9 @@ $config['oasis_jquery'] = array(
 		'//resources/wikia/libraries/jquery/expirystorage/jquery.expirystorage.js',
 		'//resources/wikia/libraries/jquery/focusNoScroll/jquery.focusNoScroll.js',
 
+		// Facebook
+		'//resources/wikia/modules/facebookLocale.js',
+
 		// libraries loaders
 		'//resources/wikia/libraries/jquery/getResources/jquery.wikia.getResources.js',
 		'//resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadLibrary.js',
@@ -469,6 +472,7 @@ $config['gameguides_js'] = array(
 		'//resources/wikia/modules/window.js',
 		'//resources/wikia/modules/location.js',
 		'//resources/wikia/modules/nirvana.js',
+		'//resources/wikia/modules/facebookLocale.js',
 		'//resources/wikia/modules/loader.js',
 		'//resources/wikia/modules/querystring.js',
 		'//resources/wikia/modules/history.js',
@@ -604,6 +608,9 @@ $config['wikiamobile_js_body_minimal'] = array(
 		// performance
 		'#group_bucky_js',
 
+		// facebook
+		'//resources/wikia/modules/facebookLocale.js',
+
 		//modules
 		'//resources/wikia/modules/nirvana.js',
 		'//resources/wikia/modules/loader.js',
@@ -611,9 +618,6 @@ $config['wikiamobile_js_body_minimal'] = array(
 
 		// video
 		'//extensions/wikia/VideoHandlers/js/VideoBootstrap.js',
-
-		// facebook
-		'//resources/wikia/modules/facebookLocale.js',
 	)
 );
 

--- a/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadExternalLibrary.js
+++ b/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadExternalLibrary.js
@@ -66,7 +66,7 @@
 	$.loadFacebookSDK = function (callback) {
 		// create our own deferred object to resolve after FB.init finishes
 		var $deferred = $.Deferred(),
-			url = window.fbScript || window.Wikia.fbLocale.getSdkUrl(window.wgContentLanguage);
+			url = window.fbScript || window.Wikia.fbLocale.getSdkUrl(window.wgUserLanguage);
 
 		// ShareButton code still uses the callback, but it's deprecated.
 		if (typeof callback === 'function') {

--- a/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadExternalLibrary.js
+++ b/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadExternalLibrary.js
@@ -1,3 +1,4 @@
+/*global jQuery, Wikia*/
 (function ($) {
 	'use strict';
 
@@ -65,7 +66,7 @@
 	$.loadFacebookSDK = function (callback) {
 		// create our own deferred object to resolve after FB.init finishes
 		var $deferred = $.Deferred(),
-			url = window.fbScript || '//connect.facebook.net/en_US/sdk.js';
+			url = window.fbScript || window.Wikia.fbLocale.getSdkUrl(window.wgContentLanguage);
 
 		// ShareButton code still uses the callback, but it's deprecated.
 		if (typeof callback === 'function') {

--- a/resources/wikia/modules/facebookLocale.js
+++ b/resources/wikia/modules/facebookLocale.js
@@ -132,7 +132,7 @@
 		function getSdkUrl(langCode) {
 			var lowerLangCode = langCode.toLowerCase(),
 				countryCode = codes[langCode];
-			if (langCode.length !== 2 || countryCode === undefined) {
+			if (langCode.length !== 2 || !countryCode) {
 				lowerLangCode = 'en';
 				countryCode = 'US';
 			}

--- a/resources/wikia/modules/facebookLocale.js
+++ b/resources/wikia/modules/facebookLocale.js
@@ -2,10 +2,15 @@
 (function (context) {
 	'use strict';
 
+	/**
+	 * Determines the locale for a Facebook user based on Wikia language and user's location
+	 *
+	 * Facebook languages/countries supported: https://www.facebook.com/translations/FacebookLocales.xml
+	 **/
 	function facebookLocale() {
-		/** https://www.facebook.com/translations/FacebookLocales.xml
-		 *  Note: only one code per language is used. **/
-		var languageCodes = {
+		/** Note: only one default country per language is used. */
+		var defaultCountryCodes = {
+			// languageCode: CountryCode
 			'af': 'ZA',
 			'ak': 'GH',
 			'am': 'ET',
@@ -129,7 +134,8 @@
 			'zu': 'ZA',
 			'zz': 'TR'
 			},
-			countryCodes = {
+			languagesOfCountry = {
+				// CountryCode: languageCodes
 				'AF': ['ps'],
 				'AL': ['sq'],
 				'AM': ['hy'],
@@ -237,7 +243,7 @@
 		 * In case language is invalid or unsupported, defaults to en/US
 		 *
 		 * @param {string} inputLanguageCode
-		 * @returns {string}
+		 * @returns {string} URL of localized Facebook SDK
 		 */
 		function getSdkUrl(inputLanguageCode) {
 			var matchingLanguages,
@@ -245,13 +251,13 @@
 				geoCountryCode = Geo.getCountryCode(),
 				countryCode = '';
 			if (geoCountryCode) {
-				matchingLanguages = countryCodes[geoCountryCode.toUpperCase()];
+				matchingLanguages = languagesOfCountry[geoCountryCode.toUpperCase()];
 				if (languageCode in matchingLanguages) {
 					countryCode = matchingLanguages[languageCode];
 				}
 			}
 			if (!countryCode) {
-				countryCode = languageCodes[languageCode];
+				countryCode = defaultCountryCodes[languageCode];
 				if (!countryCode) {
 					languageCode = 'en';
 					countryCode = 'US';

--- a/resources/wikia/modules/facebookLocale.js
+++ b/resources/wikia/modules/facebookLocale.js
@@ -1,0 +1,159 @@
+(function (context) {
+	'use strict';
+
+	function facebookLocale() {
+		/** https://www.facebook.com/translations/FacebookLocales.xml
+		 *  Note: only one code per language is used since proper country cannot be reliably retrieved. **/
+		var codes = {
+			'af': 'ZA',
+			'ak': 'GH',
+			'am': 'ET',
+			'ar': 'AR',
+			'as': 'IN',
+			'ay': 'BO',
+			'az': 'AZ',
+			'be': 'BY',
+			'bg': 'BG',
+			'bn': 'IN',
+			'br': 'FR',
+			'bs': 'BA',
+			'ca': 'ES',
+			'cb': 'IQ',
+			'ck': 'US',
+			'co': 'FR',
+			'cs': 'CZ',
+			'cx': 'PH',
+			'cy': 'GB',
+			'da': 'DK',
+			'de': 'DE',
+			'el': 'GR',
+			'en': 'US',
+			'eo': 'EO',
+			'es': 'ES',
+			'et': 'EE',
+			'eu': 'ES',
+			'fa': 'IR',
+			'fb': 'LT',
+			'ff': 'NG',
+			'fi': 'FI',
+			'fo': 'FO',
+			'fr': 'FR',
+			'fy': 'NL',
+			'ga': 'IE',
+			'gl': 'ES',
+			'gn': 'PY',
+			'gu': 'IN',
+			'gx': 'GR',
+			'ha': 'NG',
+			'he': 'IL',
+			'hi': 'IN',
+			'hr': 'HR',
+			'hu': 'HU',
+			'hy': 'AM',
+			'id': 'ID',
+			'ig': 'NG',
+			'is': 'IS',
+			'it': 'IT',
+			'ja': 'JP',
+			'jv': 'ID',
+			'ka': 'GE',
+			'kk': 'KZ',
+			'km': 'KH',
+			'kn': 'IN',
+			'ko': 'KR',
+			'ku': 'TR',
+			'la': 'VA',
+			'lg': 'UG',
+			'li': 'NL',
+			'ln': 'CD',
+			'lo': 'LA',
+			'lt': 'LT',
+			'lv': 'LV',
+			'mg': 'MG',
+			'mk': 'MK',
+			'ml': 'IN',
+			'mn': 'MN',
+			'mr': 'IN',
+			'ms': 'MY',
+			'mt': 'MT',
+			'my': 'MM',
+			'nb': 'NO',
+			'nd': 'ZW',
+			'ne': 'NP',
+			'nl': 'NL',
+			'nn': 'NO',
+			'ny': 'MW',
+			'or': 'IN',
+			'pa': 'IN',
+			'pl': 'PL',
+			'ps': 'AF',
+			'pt': 'PT',
+			'qu': 'PE',
+			'rm': 'CH',
+			'ro': 'RO',
+			'ru': 'RU',
+			'rw': 'RW',
+			'sa': 'IN',
+			'sc': 'IT',
+			'se': 'NO',
+			'si': 'LK',
+			'sk': 'SK',
+			'sl': 'SI',
+			'sn': 'ZW',
+			'so': 'SO',
+			'sq': 'AL',
+			'sr': 'RS',
+			'sv': 'SE',
+			'sw': 'KE',
+			'sy': 'SY',
+			'sz': 'PL',
+			'ta': 'IN',
+			'te': 'IN',
+			'tg': 'TJ',
+			'th': 'TH',
+			'tk': 'TM',
+			'tl': 'PH',
+			'tr': 'TR',
+			'tt': 'RU',
+			'tz': 'MA',
+			'uk': 'UA',
+			'ur': 'PK',
+			'uz': 'UZ',
+			'vi': 'VN',
+			'wo': 'SN',
+			'xh': 'ZA',
+			'yi': 'DE',
+			'yo': 'NG',
+			'zh': 'CN',
+			'zu': 'ZA',
+			'zz': 'TR'
+		};
+
+		function getSdkUrl(langCode) {
+			var lowerLangCode = langCode.toLowerCase(),
+				countryCode = codes[langCode];
+			if (langCode.length !== 2 || typeof countryCode === 'undefined') {
+				lowerLangCode = 'en';
+				countryCode = 'US';
+			}
+
+			return '//connect.facebook.net/' + lowerLangCode + '_' + countryCode + '/sdk.js';
+		}
+
+		return {
+			getSdkUrl: getSdkUrl
+		};
+	}
+
+	//UMD inclusive
+	if (!context.Wikia) {
+		context.Wikia = {};
+	}
+
+	//namespace
+	context.Wikia.fbLocale = facebookLocale(context);
+
+	if (context.define && context.define.amd) {
+		context.define('wikia.fbLocale', ['wikia.window'], facebookLocale);
+	}
+}(this));

--- a/resources/wikia/modules/facebookLocale.js
+++ b/resources/wikia/modules/facebookLocale.js
@@ -1,10 +1,11 @@
+/*global Geo*/
 (function (context) {
 	'use strict';
 
 	function facebookLocale() {
 		/** https://www.facebook.com/translations/FacebookLocales.xml
-		 *  Note: only one code per language is used since proper country cannot be reliably retrieved. **/
-		var codes = {
+		 *  Note: only one code per language is used. **/
+		var languageCodes = {
 			'af': 'ZA',
 			'ak': 'GH',
 			'am': 'ET',
@@ -127,17 +128,137 @@
 			'zh': 'CN',
 			'zu': 'ZA',
 			'zz': 'TR'
-		};
+			},
+			countryCodes = {
+				'AF': ['ps'],
+				'AL': ['sq'],
+				'AM': ['hy'],
+				'AR': ['ar'],
+				'AZ': ['az'],
+				'BA': ['bs'],
+				'BE': ['nl'],
+				'BG': ['bg'],
+				'BO': ['ay'],
+				'BR': ['pt'],
+				'BY': ['be'],
+				'CA': ['fr'],
+				'CD': ['ln'],
+				'CH': ['rm'],
+				'CL': ['es'],
+				'CN': ['zh'],
+				'CO': ['es'],
+				'CZ': ['cs'],
+				'DE': ['de', 'yi'],
+				'DK': ['da'],
+				'EE': ['et'],
+				'EO': ['eo'],
+				'ES': ['ca', 'es', 'eu', 'gl'],
+				'ET': ['am'],
+				'FI': ['fi'],
+				'FR': ['br', 'co', 'fr'],
+				'FO': ['fo'],
+				'GB': ['cy', 'en'],
+				'GE': ['ka'],
+				'GH': ['ak'],
+				'GR': ['el', 'gx'],
+				'HK': ['zh'],
+				'HR': ['hr'],
+				'HU': ['hu'],
+				'ID': ['id', 'jv'],
+				'IE': ['ga'],
+				'IL': ['he'],
+				'IN': ['as', 'bn', 'en', 'gu', 'hi', 'kn', 'ml', 'mr', 'or', 'pa', 'sa', 'ta', 'te'],
+				'IQ': ['cb'],
+				'IR': ['fa'],
+				'IS': ['is'],
+				'IT': ['it', 'sc'],
+				'JP': ['ja'],
+				'KE': ['sw'],
+				'KH': ['km'],
+				'KR': ['ko'],
+				'KS': ['ja'],
+				'KZ': ['kk'],
+				'LA': ['es', 'lo'],
+				'LK': ['si'],
+				'LT': ['fb', 'lt'],
+				'LV': ['lv'],
+				'MA': ['tz'],
+				'MG': ['mg'],
+				'MK': ['mk'],
+				'MM': ['my'],
+				'MN': ['mn'],
+				'MT': ['mt'],
+				'MW': ['ny'],
+				'MX': ['es'],
+				'MY': ['ms'],
+				'NG': ['ff', 'ha', 'ig', 'yo'],
+				'NL': ['fy', 'li', 'nl'],
+				'NO': ['nb', 'nn', 'se'],
+				'NP': ['ne'],
+				'PE': ['qu'],
+				'PH': ['cx', 'tl'],
+				'PI': ['en'],
+				'PK': ['ur'],
+				'PL': ['pl', 'sz'],
+				'PT': ['pt'],
+				'PY': ['gn'],
+				'RO': ['ro'],
+				'RS': ['sr'],
+				'RU': ['ru', 'tt'],
+				'RW': ['rw'],
+				'SE': ['sv'],
+				'SI': ['sl'],
+				'SK': ['sk'],
+				'SN': ['wo'],
+				'SO': ['so'],
+				'ST': ['tl'],
+				'SY': ['sy'],
+				'TH': ['th'],
+				'TJ': ['tg'],
+				'TM': ['tk'],
+				'TR': ['ku', 'tr', 'zz'],
+				'TW': ['zh'],
+				'UA': ['uk'],
+				'UD': ['en'],
+				'UG': ['lg'],
+				'US': ['ck', 'en'],
+				'UZ': ['uz'],
+				'VA': ['la'],
+				'VE': ['es'],
+				'VN': ['vi'],
+				'ZA': ['af', 'xh', 'zu'],
+				'ZW': ['nd', 'sn']
+			};
 
-		function getSdkUrl(langCode) {
-			var lowerLangCode = langCode.toLowerCase(),
-				countryCode = codes[langCode];
-			if (langCode.length !== 2 || !countryCode) {
-				lowerLangCode = 'en';
-				countryCode = 'US';
+		/**
+		 * Gets the Localized URL of the FB JS SDK
+		 * To localize, it attempts to match user location (country) with the language;
+		 * if unsuccessful, it falls back to a default country associated with the language
+		 * In case language is invalid or unsupported, defaults to en/US
+		 *
+		 * @param {string} inputLanguageCode
+		 * @returns {string}
+		 */
+		function getSdkUrl(inputLanguageCode) {
+			var matchingLanguages,
+				languageCode = inputLanguageCode.length === 2 ? inputLanguageCode.toLowerCase() : 'en',
+				geoCountryCode = Geo.getCountryCode(),
+				countryCode = '';
+			if (geoCountryCode) {
+				matchingLanguages = countryCodes[geoCountryCode.toUpperCase()];
+				if (languageCode in matchingLanguages) {
+					countryCode = matchingLanguages[languageCode];
+				}
+			}
+			if (!countryCode) {
+				countryCode = languageCodes[languageCode];
+				if (!countryCode) {
+					languageCode = 'en';
+					countryCode = 'US';
+				}
 			}
 
-			return '//connect.facebook.net/' + lowerLangCode + '_' + countryCode + '/sdk.js';
+			return '//connect.facebook.net/' + languageCode + '_' + countryCode + '/sdk.js';
 		}
 
 		return {
@@ -154,6 +275,6 @@
 	context.Wikia.fbLocale = facebookLocale(context);
 
 	if (context.define && context.define.amd) {
-		context.define('wikia.fbLocale', ['wikia.window'], facebookLocale);
+		context.define('wikia.fbLocale', [], facebookLocale);
 	}
 }(this));

--- a/resources/wikia/modules/facebookLocale.js
+++ b/resources/wikia/modules/facebookLocale.js
@@ -132,7 +132,7 @@
 		function getSdkUrl(langCode) {
 			var lowerLangCode = langCode.toLowerCase(),
 				countryCode = codes[langCode];
-			if (langCode.length !== 2 || typeof countryCode === 'undefined') {
+			if (langCode.length !== 2 || countryCode === undefined) {
 				lowerLangCode = 'en';
 				countryCode = 'US';
 			}

--- a/resources/wikia/modules/loader.js
+++ b/resources/wikia/modules/loader.js
@@ -1,3 +1,4 @@
+/*global define, require*/
 /**
  * Single place to call when you want to load something from server
  *
@@ -135,7 +136,7 @@ define('wikia.loader', ['wikia.window', require.optional('mw'), 'wikia.nirvana',
 				}
 			},
 			facebook: {
-				file: window.fbScript || '//connect.facebook.net/en_US/sdk.js',
+				file: window.fbScript || window.Wikia.fbLocale.getSdkUrl(window.wgContentLanguage),
 				check: function () {
 					return typeof window.FB;
 				},

--- a/resources/wikia/modules/loader.js
+++ b/resources/wikia/modules/loader.js
@@ -7,8 +7,9 @@
  * @author Jakub Olek <jolek@wikia-inc.com>
  *
  */
-define('wikia.loader', ['wikia.window', require.optional('mw'), 'wikia.nirvana', 'jquery', 'wikia.log'],
-	function loader (window, mw, nirvana, $, log) {
+define('wikia.loader', ['wikia.window', require.optional('mw'), 'wikia.nirvana', 'jquery', 'wikia.log', 'wikia.fbLocale'
+	],
+	function loader (window, mw, nirvana, $, log, fbLocale) {
 	'use strict';
 
 	var loader,
@@ -136,7 +137,7 @@ define('wikia.loader', ['wikia.window', require.optional('mw'), 'wikia.nirvana',
 				}
 			},
 			facebook: {
-				file: window.fbScript || window.Wikia.fbLocale.getSdkUrl(window.wgContentLanguage),
+				file: window.fbScript || fbLocale.getSdkUrl(window.wgContentLanguage),
 				check: function () {
 					return typeof window.FB;
 				},

--- a/resources/wikia/modules/loader.js
+++ b/resources/wikia/modules/loader.js
@@ -143,7 +143,7 @@ define('wikia.loader', [
 				}
 			},
 			facebook: {
-				file: window.fbScript || fbLocale.getSdkUrl(window.wgContentLanguage),
+				file: window.fbScript || fbLocale.getSdkUrl(window.wgUserLanguage),
 				check: function () {
 					return typeof window.FB;
 				},

--- a/resources/wikia/modules/loader.js
+++ b/resources/wikia/modules/loader.js
@@ -7,7 +7,13 @@
  * @author Jakub Olek <jolek@wikia-inc.com>
  *
  */
-define('wikia.loader', ['wikia.window', require.optional('mw'), 'wikia.nirvana', 'jquery', 'wikia.log', 'wikia.fbLocale'
+define('wikia.loader', [
+		'wikia.window',
+		require.optional('mw'),
+		'wikia.nirvana',
+		'jquery',
+		'wikia.log',
+		'wikia.fbLocale'
 	],
 	function loader (window, mw, nirvana, $, log, fbLocale) {
 	'use strict';

--- a/resources/wikia/modules/spec/integration/loader.spec.js
+++ b/resources/wikia/modules/spec/integration/loader.spec.js
@@ -1,4 +1,4 @@
-/*global describe, getBody, spyOn*/
+/*global describe, getBody, spyOn, modules*/
 describe('Loader Module', function () {
 	'use strict';
 
@@ -6,13 +6,13 @@ describe('Loader Module', function () {
 			document: window.document,
 			wgCdnRootUrl: '',
 			wgAssetsManagerQuery: '/__am/%4$d/%1$s/%3$s/%2$s',
+			wgContentLanguage: 'ja',
 			wgStyleVersion: ~~(Math.random() * 99999)
 		},
 		mwMock,
 		nirvanaMock = {},
 		logMock = function () {},
-		fbLocaleMock = {getSdkUrl: function () {
-			return '//connect.facebook.net/ja_JP/sdk.js';}};
+		fbLocaleMock = modules['wikia.fbLocale']();
 
 	logMock.levels = {};
 
@@ -128,6 +128,7 @@ describe('Loader Module', function () {
 	it('Facebook library is properly initialized when lazy loaded', function (done) {
 		var windowMock = {
 				document: window.document,
+				wgContentLanguage: 'ja',
 				onFBloaded: function () {}
 			},
 			loader = modules['wikia.loader'](windowMock, mwMock, nirvanaMock, jQuery, logMock, fbLocaleMock);

--- a/resources/wikia/modules/spec/integration/loader.spec.js
+++ b/resources/wikia/modules/spec/integration/loader.spec.js
@@ -10,11 +10,13 @@ describe('Loader Module', function () {
 		},
 		mwMock,
 		nirvanaMock = {},
-		logMock = function () {};
+		logMock = function () {},
+		fbLocaleMock = {getSdkUrl: function () {
+			return '//connect.facebook.net/ja_JP/sdk.js';}};
 
 	logMock.levels = {};
 
-	var loader = modules['wikia.loader'](windowMock, mwMock, nirvanaMock, jQuery, logMock);
+	var loader = modules['wikia.loader'](windowMock, mwMock, nirvanaMock, jQuery, logMock, fbLocaleMock);
 
 	it('registers itself', function () {
 		expect(typeof loader).toBe('function');
@@ -108,7 +110,7 @@ describe('Loader Module', function () {
 					}
 				}
 			},
-			loader = modules['wikia.loader'](windowMock, mwMock, nirvanaMock, jQuery, logMock);
+			loader = modules['wikia.loader'](windowMock, mwMock, nirvanaMock, jQuery, logMock, fbLocaleMock);
 
 		// check calls to this function
 		spyOn(mwMock.loader, 'use').and.callThrough();
@@ -128,7 +130,7 @@ describe('Loader Module', function () {
 				document: window.document,
 				onFBloaded: function () {}
 			},
-			loader = modules['wikia.loader'](windowMock, mwMock, nirvanaMock, jQuery, logMock);
+			loader = modules['wikia.loader'](windowMock, mwMock, nirvanaMock, jQuery, logMock, fbLocaleMock);
 
 		document.head.appendChild = function (script) {
 			script.onload();

--- a/resources/wikia/modules/spec/integration/loader.spec.js
+++ b/resources/wikia/modules/spec/integration/loader.spec.js
@@ -12,11 +12,11 @@ describe('Loader Module', function () {
 		mwMock,
 		nirvanaMock = {},
 		logMock = function () {},
-		fbLocaleMock = modules['wikia.fbLocale']();
+		fbLocale = modules['wikia.fbLocale']();
 
 	logMock.levels = {};
 
-	var loader = modules['wikia.loader'](windowMock, mwMock, nirvanaMock, jQuery, logMock, fbLocaleMock);
+	var loader = modules['wikia.loader'](windowMock, mwMock, nirvanaMock, jQuery, logMock, fbLocale);
 
 	it('registers itself', function () {
 		expect(typeof loader).toBe('function');
@@ -110,7 +110,7 @@ describe('Loader Module', function () {
 					}
 				}
 			},
-			loader = modules['wikia.loader'](windowMock, mwMock, nirvanaMock, jQuery, logMock, fbLocaleMock);
+			loader = modules['wikia.loader'](windowMock, mwMock, nirvanaMock, jQuery, logMock, fbLocale);
 
 		// check calls to this function
 		spyOn(mwMock.loader, 'use').and.callThrough();
@@ -131,7 +131,7 @@ describe('Loader Module', function () {
 				wgContentLanguage: 'ja',
 				onFBloaded: function () {}
 			},
-			loader = modules['wikia.loader'](windowMock, mwMock, nirvanaMock, jQuery, logMock, fbLocaleMock);
+			loader = modules['wikia.loader'](windowMock, mwMock, nirvanaMock, jQuery, logMock, fbLocale);
 
 		document.head.appendChild = function (script) {
 			script.onload();

--- a/resources/wikia/modules/spec/integration/loader.spec.js
+++ b/resources/wikia/modules/spec/integration/loader.spec.js
@@ -6,7 +6,7 @@ describe('Loader Module', function () {
 			document: window.document,
 			wgCdnRootUrl: '',
 			wgAssetsManagerQuery: '/__am/%4$d/%1$s/%3$s/%2$s',
-			wgContentLanguage: 'ja',
+			wgUserLanguage: 'ja',
 			wgStyleVersion: ~~(Math.random() * 99999)
 		},
 		mwMock,
@@ -128,7 +128,7 @@ describe('Loader Module', function () {
 	it('Facebook library is properly initialized when lazy loaded', function (done) {
 		var windowMock = {
 				document: window.document,
-				wgContentLanguage: 'ja',
+				wgUserLanguage: 'ja',
 				onFBloaded: function () {}
 			},
 			loader = modules['wikia.loader'](windowMock, mwMock, nirvanaMock, jQuery, logMock, fbLocale);

--- a/tests/karma/js-integration.conf.js
+++ b/tests/karma/js-integration.conf.js
@@ -60,6 +60,7 @@ module.exports = function (config) {
 			'resources/wikia/modules/geo.js',
 			'resources/wikia/modules/history.js',
 			'resources/wikia/modules/lazyqueue.js',
+			'resources/wikia/modules/facebookLocale.js',
 			'resources/wikia/modules/loader.js',
 			'resources/wikia/modules/nirvana.js',
 			'resources/wikia/modules/nodeFinder.js',

--- a/tests/karma/js-unit.conf.js
+++ b/tests/karma/js-unit.conf.js
@@ -51,6 +51,7 @@ module.exports = function (config) {
 			'resources/wikia/modules/imageServing.js',
 			'resources/wikia/modules/krux.js',
 			'resources/wikia/modules/lazyqueue.js',
+			'resources/wikia/modules/facebookLocale.js',
 			'resources/wikia/modules/loader.js',
 			'resources/wikia/modules/nirvana.js',
 			'resources/wikia/modules/querystring.js',


### PR DESCRIPTION
/CC @lizlux @bkoval @jsutterfield 

Previously, all Facebook plugins on Wikia pages have been rendered in English because the SDK URL had been hardcoded to point to the English version. This changeset aims respect the language of the Wikia the SDK loads for; as a result, all FB plugins on a page are properly localized to the same language.
Facebook documentation on supported languages can be found [here](https://developers.facebook.com/docs/internationalization#locales). Also both country code and language code are required to get the locale right.

Update: Geo cookie is being used now to try and match the user's location with Wikia's language if possible.

For more background info, please see [SOC-926](https://wikia-inc.atlassian.net/browse/SOC-926)
