### PR TITLE
phpFlickr: use SSL API endpoint

### DIFF
--- a/extensions/wikia/WikiaMiniUpload/WikiaMiniUpload_body.php
+++ b/extensions/wikia/WikiaMiniUpload/WikiaMiniUpload_body.php
@@ -115,7 +115,7 @@ class WikiaMiniUpload {
 	}
 
      function query() {
-        global $wgRequest, $wgHTTPProxy;
+        global $wgRequest;
 
         $query = $wgRequest->getText('query');
         $page = $wgRequest->getVal('page', 1);
@@ -124,8 +124,6 @@ class WikiaMiniUpload {
         if ( $sourceId == 1 ) {
 
             $flickrAPI = new phpFlickr('bac0bd138f5d0819982149f67c0ca734');
-            $proxyArr = explode(':', $wgHTTPProxy);
-            $flickrAPI->setProxy($proxyArr[0], $proxyArr[1]);
             $flickrResult = $flickrAPI->photos_search(array('tags' => $query, 'tag_mode' => 'all', 'page' => $page, 'per_page' => 8, 'license' => '4,5', 'sort' => 'interestingness-desc'));
 
 			$tmpl = new EasyTemplate(dirname(__FILE__).'/templates/');
@@ -787,11 +785,7 @@ class WikiaMiniUpload {
 	}
 
 	function getFlickrPhotoInfo( $itemId ) {
-		global $wgHTTPProxy;
-
 		$flickrAPI = new phpFlickr( 'bac0bd138f5d0819982149f67c0ca734' );
-		$proxyArr = explode( ':', $wgHTTPProxy );
-		$flickrAPI->setProxy( $proxyArr[0], $proxyArr[1] );
 		$flickrResult = $flickrAPI->photos_getInfo( $itemId );
 
 		// phpFlickr 3.x has different response structure than previous version

--- a/lib/vendor/phpFlickr/phpFlickr.php
+++ b/lib/vendor/phpFlickr/phpFlickr.php
@@ -23,9 +23,9 @@ if ( !class_exists('phpFlickr') ) {
 		var $api_key;
 		var $secret;
 
-		var $rest_endpoint = 'http://api.flickr.com/services/rest/';
-		var $upload_endpoint = 'http://api.flickr.com/services/upload/';
-		var $replace_endpoint = 'http://api.flickr.com/services/replace/';
+		var $rest_endpoint = 'https://api.flickr.com/services/rest/';
+		var $upload_endpoint = 'https://api.flickr.com/services/upload/';
+		var $replace_endpoint = 'https://api.flickr.com/services/replace/';
 		var $req;
 		var $response;
 		var $parsed_response;
@@ -209,7 +209,7 @@ if ( !class_exists('phpFlickr') ) {
 				return call_user_func($this->custom_post, $url, $data);
 			}
 
-			if ( !preg_match("|http://(.*?)(/.*)|", $url, $matches) ) {
+			if ( !preg_match("|https?://(.*?)(/.*)|", $url, $matches) ) {
 				die('There was some problem figuring out your endpoint');
 			}
 


### PR DESCRIPTION
In the process of working on [PLATFORM-825](https://wikia-inc.atlassian.net/browse/PLATFORM-825) I've managed to fix the Flickr upload in WikiaMiniUpload (which is still used quite often, judging by the logs) - use SSL API endpoint and skip setting a proxy.

@michalroszka / @wladekb / @Grunny 
