### PR TITLE
SEO-58 Block Template pages from being crawled

### DIFF
--- a/extensions/wikia/RobotsTxt/tests/RobotsTxtTest.php
+++ b/extensions/wikia/RobotsTxt/tests/RobotsTxtTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class RobotsTest extends WikiaBaseTest {
+class RobotsTxtTest extends WikiaBaseTest {
 
 	public function setUp() {
 		global $IP;

--- a/extensions/wikia/RobotsTxt/tests/RobotsTxtTest.php
+++ b/extensions/wikia/RobotsTxt/tests/RobotsTxtTest.php
@@ -88,18 +88,18 @@ class RobotsTxtTest extends WikiaBaseTest {
 	}
 
 	/**
-	 * Test disallowSpecialPages
+	 * Test disallowNamespace
 	 *
-	 * @covers RobotsTxt::testDisallowSpecialPages
+	 * @covers RobotsTxt::disallowNamespace
 	 */
-	public function testDisallowSpecialPages() {
+	public function testDisallowNamespace() {
 		$robots = new RobotsTxt();
-		$robots->disallowSpecialPages();
+		$robots->disallowNamespace( NS_FILE );
 		$this->assertEquals( [
 			'User-agent: *',
-			'Disallow: /wiki/Special:',
-			'Disallow: /*?*title=Special:',
-			'Disallow: /index.php/Special:',
+			'Disallow: /wiki/File:',
+			'Disallow: /*?*title=File:',
+			'Disallow: /index.php/File:',
 			'',
 		], $robots->getContents() );
 	}

--- a/extensions/wikia/RobotsTxt/tests/RobotsTxtTest.php
+++ b/extensions/wikia/RobotsTxt/tests/RobotsTxtTest.php
@@ -33,6 +33,27 @@ class RobotsTxtTest extends WikiaBaseTest {
 	}
 
 	/**
+	 * Test allowSpecialPage in non-English language
+	 *
+	 * @covers RobotsTxt::allowSpecialPage
+	 */
+	public function testAllowSpecialPageInternational() {
+		$this->mockGlobalVariable( 'wgContLang', Language::factory('de') );
+		$robots = new RobotsTxt();
+		$robots->allowSpecialPage( 'Randompage' );
+		$this->assertEquals( [
+			'User-agent: *',
+			'Allow: /wiki/Spezial:Zuf%C3%A4llige_Seite',
+			'Allow: /wiki/Spezial:Random',
+			'Allow: /wiki/Spezial:RandomPage',
+			'Allow: /wiki/Special:Zuf%C3%A4llige_Seite',
+			'Allow: /wiki/Special:Random',
+			'Allow: /wiki/Special:RandomPage',
+			'',
+		], $robots->getContents() );
+	}
+
+	/**
 	 * Test blockRobot
 	 *
 	 * @covers RobotsTxt::testBlockRobot
@@ -97,6 +118,27 @@ class RobotsTxtTest extends WikiaBaseTest {
 		$robots->disallowNamespace( NS_FILE );
 		$this->assertEquals( [
 			'User-agent: *',
+			'Disallow: /wiki/File:',
+			'Disallow: /*?*title=File:',
+			'Disallow: /index.php/File:',
+			'',
+		], $robots->getContents() );
+	}
+
+	/**
+	 * Test disallowNamespace in non-English language
+	 *
+	 * @covers RobotsTxt::disallowNamespace
+	 */
+	public function testDisallowNamespaceInternational() {
+		$this->mockGlobalVariable( 'wgContLang', Language::factory('de') );
+		$robots = new RobotsTxt();
+		$robots->disallowNamespace( NS_FILE );
+		$this->assertEquals( [
+			'User-agent: *',
+			'Disallow: /wiki/Datei:',
+			'Disallow: /*?*title=Datei:',
+			'Disallow: /index.php/Datei:',
 			'Disallow: /wiki/File:',
 			'Disallow: /*?*title=File:',
 			'Disallow: /index.php/File:',

--- a/wikia-robots-txt.php
+++ b/wikia-robots-txt.php
@@ -20,6 +20,8 @@ if ( !$allowRobots ) {
 
 	// Special pages
 	$robots->disallowNamespace( NS_SPECIAL );
+	$robots->disallowNamespace( NS_TEMPLATE );
+	$robots->disallowNamespace( NS_TEMPLATE_TALK );
 
 	//$robots->allowSpecialPage( 'Allpages' ); // TODO: SEO-64
 	$robots->allowSpecialPage( 'CreateNewWiki' );

--- a/wikia-robots-txt.php
+++ b/wikia-robots-txt.php
@@ -32,6 +32,7 @@ if ( !$allowRobots ) {
 	// Params
 	$robots->disallowParam( 'action' );
 	$robots->disallowParam( 'feed' );
+	$robots->disallowParam( 'oldid' );
 	$robots->disallowParam( 'printable' );
 	$robots->disallowParam( 'useskin' );
 	$robots->disallowParam( 'uselang' );

--- a/wikia-robots-txt.php
+++ b/wikia-robots-txt.php
@@ -19,7 +19,7 @@ if ( !$allowRobots ) {
 	$robots->setSitemap( sprintf( 'http://%s/sitemap-index.xml', $_SERVER['SERVER_NAME'] ) );
 
 	// Special pages
-	$robots->disallowSpecialPages();
+	$robots->disallowNamespace( NS_SPECIAL );
 
 	//$robots->allowSpecialPage( 'Allpages' ); // TODO: SEO-64
 	$robots->allowSpecialPage( 'CreateNewWiki' );


### PR DESCRIPTION
Template pages should be tagged as noindex; these pages are not a major problem, but Google is seeing these as soft 404s.
