### PR TITLE
PLATFORM-1513: user service does not need separate user object cache

### DIFF
--- a/extensions/wikia/Helios/User.class.php
+++ b/extensions/wikia/Helios/User.class.php
@@ -78,6 +78,7 @@ class User {
 	 */
 	public static function newFromToken( \WebRequest $request ) {
 		// Extract access token from HTTP request data.
+		wfProfileIn(__METHOD__);
 		$token = self::getAccessToken( $request );
 
 		// Authenticate with the token, if present.
@@ -93,6 +94,7 @@ class User {
 					// @see SERVICES-459
 					if ( (bool)$user->getGlobalFlag( 'disabled' ) ) {
 						self::clearAccessTokenCookie();
+						wfProfileOut(__METHOD__);
 						return null;
 					}
 
@@ -109,6 +111,7 @@ class User {
 					}
 
 					// return a MediaWiki's User object
+					wfProfileOut(__METHOD__);
 					return $user;
 				}
 			}
@@ -118,6 +121,7 @@ class User {
 			}
 		}
 
+		wfProfileOut(__METHOD__);
 		return null;
 	}
 

--- a/includes/User.php
+++ b/includes/User.php
@@ -1099,14 +1099,14 @@ class User {
 			return false;
 		}
 
-                // Wikia change start
-                global $wgExternalAuthType;
-                if ( $wgExternalAuthType ) { // in other words: unless Uncyclopedia
-                    $extUser = ExternalUser::newFromCookie();
-                    if ( $extUser ) {
-                            $extUser->linkToLocal( $sId );
-                    }
-                }
+		// Wikia change start
+		global $wgExternalAuthType;
+		if ( $wgExternalAuthType ) { // in other words: unless Uncyclopedia
+			$extUser = ExternalUser::newFromCookie();
+			if ( $extUser ) {
+					$extUser->linkToLocal( $sId );
+			}
+		}
 
 		$passwordCorrect = FALSE;
 		// wikia change end
@@ -1392,6 +1392,14 @@ class User {
 	public static function getDefaultOptions() {
 		global $wgNamespacesToBeSearchedDefault, $wgDefaultUserOptions, $wgContLang, $wgDefaultSkin;
 
+		static $defOpt = null;
+		if ( !defined( 'MW_PHPUNIT_TEST' ) && $defOpt !== null ) {
+			// Disabling this for the unit tests, as they rely on being able to change $wgContLang
+			// mid-request and see that change reflected in the return value of this function.
+			// Which is insane and would never happen during normal MW operation
+			// Owen backported this from MW 1.25
+			return $defOpt;
+		}
 		$defOpt = $wgDefaultUserOptions;
 		# default language setting
 		$variant = $wgContLang->getDefaultVariant();
@@ -1402,6 +1410,7 @@ class User {
 		}
 		$defOpt['skin'] = $wgDefaultSkin;
 
+		// Owen fixed this (see above)
 		// FIXME: Ideally we'd cache the results of this function so the hook is only run once,
 		// but that breaks the parser tests because they rely on being able to change $wgContLang
 		// mid-request and see that change reflected in the return value of this function.
@@ -1500,9 +1509,9 @@ class User {
 		wfRunHooks( 'GetBlockedStatus', array( &$this ) );
 
 		if ( !empty($this->mBlockedby) ) {
-		    $this->mBlock->mBy = $this->mBlockedby;
-		    $this->mBlock->mReason = $this->mBlockreason;
-        }
+			$this->mBlock->mBy = $this->mBlockedby;
+			$this->mBlock->mReason = $this->mBlockreason;
+		}
 
 		wfProfileOut( __METHOD__ );
 	}
@@ -2135,13 +2144,13 @@ class User {
 			$this->mTouched = self::newTouchedTimestamp();
 
 			#<Wikia>
-            global $wgExternalSharedDB, $wgSharedDB;
-            if( isset( $wgSharedDB ) ) {
-                    $dbw = wfGetDB( DB_MASTER, array(), $wgExternalSharedDB );
-            }
-            else {
-                    $dbw = wfGetDB( DB_MASTER );
-            }
+			global $wgExternalSharedDB, $wgSharedDB;
+			if( isset( $wgSharedDB ) ) {
+					$dbw = wfGetDB( DB_MASTER, array(), $wgExternalSharedDB );
+			}
+			else {
+					$dbw = wfGetDB( DB_MASTER );
+			}
 			#</Wikia>
 
 			$touched = $dbw->timestamp( $this->mTouched );
@@ -4697,16 +4706,16 @@ class User {
 	public function incEditCount() {
 		global $wgMemc, $wgCityId, $wgEnableEditCountLocal;
 		if( !$this->isAnon() ) {
-            // wikia change, load always from first cluster when we use
-            // shared users database
-            // @author Lucas Garczewski (tor)
-            global $wgExternalSharedDB, $wgSharedDB;
-            if( isset( $wgSharedDB ) ) {
-                    $dbw = wfGetDB( DB_MASTER, array(), $wgExternalSharedDB );
-            }
-            else {
-                    $dbw = wfGetDB( DB_MASTER );
-            }
+			// wikia change, load always from first cluster when we use
+			// shared users database
+			// @author Lucas Garczewski (tor)
+			global $wgExternalSharedDB, $wgSharedDB;
+			if( isset( $wgSharedDB ) ) {
+					$dbw = wfGetDB( DB_MASTER, array(), $wgExternalSharedDB );
+			}
+			else {
+					$dbw = wfGetDB( DB_MASTER );
+			}
 
 			$dbw->update( '`user`',
 				array( 'user_editcount=user_editcount+1' ),

--- a/includes/User.php
+++ b/includes/User.php
@@ -3525,32 +3525,6 @@ class User {
 			$this->mPassword = '';
 		}
 
-		// wikia change begin
-		/**
-		 * @author Krzysztof Krzyżaniak (eloy)
-		 * trap for BugId: 4013
-		 */
-		if( $this->mEmail == "devbox@wikia-inc.com" || $this->mEmail == "devbox+test@wikia-inc.com" ) {
-			// gather everything we know about request
-			global $wgCommandLineMode;
-			$log = "MOLI TRAP@devbox: ";
-			if( $wgCommandLineMode && !empty($argv)) {
-				$log .= $argv[ 0 ];
-				openlog( "trap", LOG_PID | LOG_PERROR, LOG_LOCAL6 );
-				syslog( LOG_WARNING, "$log");
-				closelog();
-			}
-			else {
-				global $wgTitle;
-				if (is_object($wgTitle)) {
-					$log .= $wgTitle->getFullUrl();
-					error_log( $log );
-				}
-			}
-		}
-
-		// wikia change end
-
 		$dbw = wfGetDB( DB_MASTER );
 		$dbw->update( 'user',
 			array( /* SET */

--- a/includes/User.php
+++ b/includes/User.php
@@ -2146,10 +2146,10 @@ class User {
 			#<Wikia>
 			global $wgExternalSharedDB, $wgSharedDB;
 			if( isset( $wgSharedDB ) ) {
-					$dbw = wfGetDB( DB_MASTER, array(), $wgExternalSharedDB );
+				$dbw = wfGetDB( DB_MASTER, array(), $wgExternalSharedDB );
 			}
 			else {
-					$dbw = wfGetDB( DB_MASTER );
+				$dbw = wfGetDB( DB_MASTER );
 			}
 			#</Wikia>
 
@@ -4711,10 +4711,10 @@ class User {
 			// @author Lucas Garczewski (tor)
 			global $wgExternalSharedDB, $wgSharedDB;
 			if( isset( $wgSharedDB ) ) {
-					$dbw = wfGetDB( DB_MASTER, array(), $wgExternalSharedDB );
+				$dbw = wfGetDB( DB_MASTER, array(), $wgExternalSharedDB );
 			}
 			else {
-					$dbw = wfGetDB( DB_MASTER );
+				$dbw = wfGetDB( DB_MASTER );
 			}
 
 			$dbw->update( '`user`',

--- a/includes/wikia/api/UserApiController.class.php
+++ b/includes/wikia/api/UserApiController.class.php
@@ -25,6 +25,7 @@ class UserApiController extends WikiaApiController {
 		wfProfileIn( __METHOD__ );
 		$ids =  $this->request->getVal( 'ids' );
 		if ( empty( $ids ) ) {
+			wfProfileOut( __METHOD__ );
 			throw new InvalidParameterApiException( 'ids' );
 		}
 		$ids = explode( ',', trim( $ids ) );
@@ -60,6 +61,7 @@ class UserApiController extends WikiaApiController {
 			);
 
 		} else {
+			wfProfileOut( __METHOD__ );
 			throw new NotFoundApiException();
 		}
 		wfProfileOut( __METHOD__ );

--- a/includes/wikia/services/UserService.class.php
+++ b/includes/wikia/services/UserService.class.php
@@ -31,13 +31,7 @@ class UserService extends Service {
 		wfProfileIn( __METHOD__ );
 
 		$where = $this->parseIds( $ids );
-		//check for cached data
-		//by id first
-		$result = $this->getUsersFromCacheById( $where[ 'user_id' ] );
-		//then check for names
-		$result = array_merge( $result, $this->getUsersFromCacheByName( $where[ 'user_name' ] ) );
-		//get user by id
-		$result = array_merge( $result, $this->getUsersObjects( $where ) );
+		$result = $this->getUsersObjects( $where );
 
 		wfProfileOut( __METHOD__ );
 		return array_unique( $result );
@@ -90,7 +84,6 @@ class UserService extends Service {
 				//skip default user
 				if ( $user->getTouched() != 0 ) {
 					$result[] = $user;
-					$this->cacheUser( $user );
 				}
 			}
 		}
@@ -100,7 +93,6 @@ class UserService extends Service {
 				//skip default user
 				if ( $user->getTouched() != 0 ) {
 					$result[] = $user;
-					$this->cacheUser( $user );
 				}
 			}
 		}
@@ -138,136 +130,5 @@ class UserService extends Service {
 			return $conds;
 		}
 		return $ids;
-	}
-
-	/**
-	 * Gets the users objects from local cache, and in case of miss from memcache. Method changes the ids list,
-	 * ids found in cache are removed from array.
-	 * @param $ids array list of user ids to check in cache
-	 * @return array User objects list
-	 */
-	private function getUsersFromCacheById( &$ids ) {
-		//extract getting from mem cache
-		$result = array();
-		if ( is_array( $ids ) ) {
-			foreach ( $ids as $id ) {
-				if ( ( $value = $this->getUserFromLocalCacheById( $id ) ) !== false ) {
-					$result[ $value->getId() ] = $value;
-				} elseif ( ( $value = $this->getUserFromMemCacheById( $id ) ) !== false ) {
-					$result[ $value->getId() ] = $value;
-				} else {
-					$idsToQuery[] = $id;
-				}
-			}
-
-			//set the list of ids that werent found in cache
-			if ( !empty( $idsToQuery ) ) {
-				$ids = $idsToQuery;
-			} else {
-				$ids = null;
-			}
-		}
-
-		return $result;
-	}
-
-	/**
-	 * Looks in cache for User object by user name, local cache is firstly check then memcache. Method changes the names list,
-	 * names found in cache are removed from array.
-	 * @param $names array list of user names to check in cache
-	 * @return array list of founded User objects
-	 */
-	private function getUsersFromCacheByName( &$names ) {
-		//extract getting from mem cache
-		$result = array();
-		if ( is_array( $names ) ) {
-			foreach ( $names as $name ) {
-				if ( ( $value = $this->getUserFromLocalCacheByName( $name ) ) !== false ) {
-					$result[ $value->getId() ] = $value;
-				} elseif ( ( $value = $this->getUserFromMemCacheByName( $name ) ) !== false ) {
-					$result[ $value->getId() ] = $value;
-				} else {
-					$namesToQuery[] = $name;
-				}
-			}
-
-			//set the list of names that werent found in cache
-			if ( !empty( $namesToQuery ) ) {
-				$names = $namesToQuery;
-			} else {
-				$names = null;
-			}
-		}
-
-		return $result;
-	}
-
-
-	private function getUserFromMemCacheById( $id ) {
-		$cacheIdKey = wfSharedMemcKey( "UserCache:".$id );
-		$value = F::app()->wg->memc->get( $cacheIdKey );
-
-		if ( $value instanceof User ) {
-			try {
-				//cache locally
-				$this->cacheLocalUser( $value );
-				return $value;
-			} catch ( Exception $e ) {
-				Wikia\Logger\WikiaLogger::instance()->debug(
-					'HG-519 MemCache returned invalid value from UserCache',
-					[
-						'id' => $id,
-						'cacheIdKey' => $cacheIdKey,
-						'value' => $value,
-						'stack' => $e->getTraceAsString()
-					]
-				);
-			}
-		}
-		return false;
-	}
-
-	private function getUserFromMemCacheByName( $name ) {
-		$cacheNameKey = wfSharedMemcKey( "UserCache:".$name );
-		if ( ( $value = F::app()->wg->memc->get( $cacheNameKey ) ) !== false ) {
-			if ( ( $value = $this->getUserFromMemCacheById( $value ) ) !== false ) {
-				return $value;
-			}
-		}
-		return false;
-	}
-
-	private function getUserFromLocalCacheById( $id ) {
-		if ( isset( static::$userCache[ $id ] ) ) {
-			return static::$userCache[ $id ];
-		}
-		return false;
-	}
-
-	private function getUserFromLocalCacheByName( $name ) {
-		if ( isset( static::$userCacheMapping[ $name ] ) ) {
-			return $this->getUserFromLocalCacheById( static::$userCacheMapping[ $name ] );
-		}
-		return false;
-	}
-
-	/**
-	 * @param $user User
-	 */
-	private function cacheUser( User $user ) {
-		$cacheIdKey = wfSharedMemcKey( "UserCache:".$user->getId() );
-		$cacheNameKey = wfSharedMemcKey( "UserCache:".$user->getName() );
-		F::app()->wg->memc->set( $cacheIdKey, $user, static::CACHE_EXPIRATION );
-		F::app()->wg->memc->set( $cacheNameKey, $user->getId(), static::CACHE_EXPIRATION );
-
-		$this->cacheLocalUser( $user );
-	}
-
-	/**
-	 * @param $user User
-	 */
-	private function cacheLocalUser( User $user ) {
-		static::$userCacheMapping[ $user->getName() ] = $user->getId();
-		static::$userCache[ $user->getId() ] = $user;
 	}
 }

--- a/includes/wikia/services/UserService.class.php
+++ b/includes/wikia/services/UserService.class.php
@@ -82,7 +82,7 @@ class UserService extends Service {
 			foreach( $ids[ 'user_id' ] as $id ) {
 				$user = User::newFromId( $id );
 				//skip default user
-				if ( $user->getTouched() != 0 ) {
+				if ( $user && $user->getTouched() != 0 ) {
 					$result[] = $user;
 				}
 			}
@@ -91,7 +91,7 @@ class UserService extends Service {
 			foreach( $ids[ 'user_name' ] as $name ) {
 				$user = User::newFromName( $name );
 				//skip default user
-				if ( $user->getTouched() != 0 ) {
+				if ( $user && $user->getTouched() != 0 ) {
 					$result[] = $user;
 				}
 			}

--- a/includes/wikia/services/tests/UserServiceTest.php
+++ b/includes/wikia/services/tests/UserServiceTest.php
@@ -18,59 +18,7 @@ class UserServiceTest extends WikiaBaseTest {
 
 	}
 
-	/**
-	 * @group UsingDB
-	 */
-	public function testCache() {
-		$user = $this->getTestUser();
-
-		//create object here, so we use the same one all the time, that way we can test local cache
-		$object = new UserService();
-
-		$cachedLocalUser = $this->invokePrivateMethod( 'UserService', 'getUserFromLocalCacheById', $user->getId(), $object );
-		$cachedLocalUserByName = $this->invokePrivateMethod( 'UserService', 'getUserFromLocalCacheByName', $user->getName(), $object );
-		//values are not cached localy yet
-		$this->assertEquals( false, $cachedLocalUser );
-		$this->assertEquals( false, $cachedLocalUserByName );
-
-		//cache user, both locally and mem cached
-		$this->invokePrivateMethod( 'UserService', 'cacheUser', $user, $object );
-
-		//do the assertion again, local cache should have hit one
-		$cachedLocalUser = $this->invokePrivateMethod( 'UserService', 'getUserFromLocalCacheById', $user->getId(), $object );
-		$cachedLocalUserByName = $this->invokePrivateMethod( 'UserService', 'getUserFromLocalCacheByName', $user->getName(), $object );
-		$this->assertEquals( $user, $cachedLocalUser );
-		$this->assertEquals( $user, $cachedLocalUserByName );
-
-		//check if user was cached in memcache, use new object for that
-		$cachedMemCacheById = $this->invokePrivateMethod( 'UserService', 'getUserFromMemCacheById', $user->getId() );
-		$cachedMemCacheByName = $this->invokePrivateMethod( 'UserService', 'getUserFromMemCacheByName', $user->getName() );
-		$this->assertEquals( $user, $cachedMemCacheById );
-		$this->assertEquals( $user, $cachedMemCacheByName );
-
-		//need for deleting form cache test values
-		$sharedIdKey = wfSharedMemcKey( "UserCache:".$user->getId() );
-		$sharedNameKey = wfSharedMemcKey( "UserCache:".$user->getName() );
-		//remove user from memcache
-		F::app()->wg->memc->delete( $sharedIdKey );
-		F::app()->wg->memc->delete( $sharedNameKey );
-
-		//do assert against memcache again
-		$cachedMemCacheById = $this->invokePrivateMethod( 'UserService', 'getUserFromMemCacheById', $user->getId() );
-		$cachedMemCacheByName = $this->invokePrivateMethod( 'UserService', 'getUserFromMemCacheByName', $user->getName() );
-		$this->assertEquals( false, $cachedMemCacheById );
-		$this->assertEquals( false, $cachedMemCacheByName );
-	}
-
 	/** Helpers */
-
-	private function getTestUser() {
-		$userData = new stdClass();
-		$userData->user_id = -1;
-		$userData->user_name = 'testUser';
-		$userData->user_editcount = 0;
-		return User::newFromRow( $userData );
-	}
 
 	private function invokePrivateMethod( $class, $method, $params, $object = null ) {
 		$method = new ReflectionMethod(


### PR DESCRIPTION
- removed user object cache from user service (these objects are already cached)
- cleaned up some space/tab issues in User.php from wikia code additions (use &w=1 to ignore those)
- added profiling to Helios::newFromToken function
- backported performance fix from MW1.25 for User::getDefaultOptions (cache using static var)

@drsnyder @ArturKlajnerok 
