### PR TITLE
SEO-62 Enable new robots extension globally

### DIFF
--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1807,7 +1807,7 @@ $wgPreferenceServiceShadowWrite = true;
  *
  * Enables extension that generates robots.txt
  */
-$wgEnableRobotsTxtExt = false;
+$wgEnableRobotsTxtExt = true;
 
 /**
  * @name $wgEnableFliteTagExt


### PR DESCRIPTION
Enables the new RobotsTxt extension, so that the logic in redirect-robots.php is skipped. In the next step
we can direct all robots.txt requests straight to wikia-robots-txt.php on the apache level.

We'll also need to remove the old redirect-robots.php file and possibly extend the caching time in RobotsTxt.
It's currently set to 0 in case we want a fast recovery to the old file.
