### PR TITLE
Automate detection of cases where revision is inserted, but the edit token is not checked

### DIFF
--- a/extensions/wikia/Security/Security.setup.php
+++ b/extensions/wikia/Security/Security.setup.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * This is a set of tools that automates the reporting of potential security problems
+ *
+ * @see PLATFORM-1491
+ * @author macbre
+ */
+
+// register classes
+$wgAutoloadClasses['Wikia\\Security\\CSRFDetector'] = __DIR__ . '/classes/CSRFDetector.class.php';
+$wgAutoloadClasses['Wikia\\Security\\Exception'] = __DIR__ . '/classes/Exception.class.php';
+
+// PLATFORM-1540: detect revision inserts not guarded by user's edit token check
+$wgHooks['UserMatchEditToken'][] = 'Wikia\\Security\\CSRFDetector::onUserMatchEditToken';
+$wgHooks['RevisionInsertComplete'][] = 'Wikia\\Security\\CSRFDetector::onRevisionInsertComplete';

--- a/extensions/wikia/Security/classes/CSRFDetector.class.php
+++ b/extensions/wikia/Security/classes/CSRFDetector.class.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Wikia\Security;
+
+use Wikia\Logger\WikiaLogger;
+
+/**
+ * Automate detection of cases where revision is inserted, but the edit token is not checked
+ *
+ * @see PLATFORM-1540
+ */
+class CSRFDetector {
+	private static $userMatchEditTokenCalled = false;
+
+	/**
+	 * @return bool
+	 */
+	public static function onUserMatchEditToken() {
+		self::$userMatchEditTokenCalled = true;
+		return true;
+	}
+
+	/**
+	 * Edit token should be checked before a revision is inserted
+	 *
+	 * @param \Revision $revision
+	 * @param $data
+	 * @param $flags
+	 * @return bool
+	 */
+	public static function onRevisionInsertComplete( \Revision $revision, $data, $flags ) {
+		self::assertEditTokenWasChecked( __METHOD__ );
+		return true;
+	}
+
+	/**
+	 * Assert that User::matchEditToken was called in this request
+	 *
+	 * @param string $fname the caller name
+	 */
+	private static function assertEditTokenWasChecked( $fname ) {
+		$request = \RequestContext::getMain()->getRequest();
+
+		if ( get_class( $request ) === \WebRequest::class && self::$userMatchEditTokenCalled === false ) {
+			wfDebug( __METHOD__ . ": revision was inserted, but edit token was not checked\n" );
+
+			WikiaLogger::instance()->warning( __METHOD__ . '::noEditTokenCheck', [
+				'caller' => $fname,
+				'exception' => new Exception(),
+			] );
+		}
+	}
+}

--- a/extensions/wikia/Security/classes/CSRFDetector.class.php
+++ b/extensions/wikia/Security/classes/CSRFDetector.class.php
@@ -13,7 +13,9 @@ class CSRFDetector {
 	private static $userMatchEditTokenCalled = false;
 
 	/**
-	 * @return bool
+	 * Set a flag when User::matchEditToken is called
+	 *
+	 * @return bool true, continue hook processing
 	 */
 	public static function onUserMatchEditToken() {
 		self::$userMatchEditTokenCalled = true;
@@ -26,7 +28,7 @@ class CSRFDetector {
 	 * @param \Revision $revision
 	 * @param $data
 	 * @param $flags
-	 * @return bool
+	 * @return bool true, continue hook processing
 	 */
 	public static function onRevisionInsertComplete( \Revision $revision, $data, $flags ) {
 		self::assertEditTokenWasChecked( __METHOD__ );
@@ -41,10 +43,11 @@ class CSRFDetector {
 	private static function assertEditTokenWasChecked( $fname ) {
 		$request = \RequestContext::getMain()->getRequest();
 
+		# check the request against WebRequest to filter out maintenance scripts
 		if ( get_class( $request ) === \WebRequest::class && self::$userMatchEditTokenCalled === false ) {
-			wfDebug( __METHOD__ . ": revision was inserted, but edit token was not checked\n" );
+			wfDebug( __METHOD__ . ": {$fname} called, but edit token was not checked\n" );
 
-			WikiaLogger::instance()->warning( __METHOD__ . '::noEditTokenCheck', [
+			WikiaLogger::instance()->warning( __METHOD__, [
 				'caller' => $fname,
 				'exception' => new Exception(),
 			] );

--- a/extensions/wikia/Security/classes/Exception.class.php
+++ b/extensions/wikia/Security/classes/Exception.class.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Wikia\Security;
+
+class Exception extends \Exception {}

--- a/includes/User.php
+++ b/includes/User.php
@@ -4004,6 +4004,9 @@ class User {
 			}
 			// Wikia change - end
 		}
+
+		wfRunHooks( 'UserMatchEditToken' ); # Wikia change
+
 		return $val == $sessionToken;
 	}
 

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -640,6 +640,7 @@ include_once( "$IP/extensions/wikia/Rail/Rail.setup.php" );
 include_once( "$IP/extensions/wikia/PageShare/PageShare.setup.php" );
 include_once( "$IP/extensions/wikia/PaidAssetDrop/PaidAssetDrop.setup.php" );
 include_once( "$IP/extensions/wikia/CreateNewWiki/CreateNewWiki_global_setup.php" );
+include_once( "$IP/extensions/wikia/Security/Security.setup.php" );
 
 /**
  * @name $wgSkipSkins


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-1540
- introduce `UserMatchEditToken` hook
- set a flag when `User::matchEditToken` is called
- on revision insert (bind to `RevisionInsertComplete` hook) assert that the edit token has been checked, if not - log a report

Feel free to suggest more hooks to bind this check to :)

@Grunny / @michalroszka 
