### PR TITLE
XW-287 | Removing user language from wiki variables call

### DIFF
--- a/extensions/wikia/MercuryApi/models/MercuryApi.class.php
+++ b/extensions/wikia/MercuryApi/models/MercuryApi.class.php
@@ -247,9 +247,9 @@ class MercuryApi {
 	 * @return string homepage URL. Default is US homepage.
 	 */
 	private function getHomepageUrl() {
-		global $wgLang;
+		global $wgContLang;
 		if ( class_exists('WikiaLogoHelper') ) {
-			return ( new WikiaLogoHelper() )->getCentralUrlForLang( $wgLang->getCode() );
+			return ( new WikiaLogoHelper() )->getCentralUrlForLang( $wgContLang->getCode() );
 		}
 		return 'http://www.wikia.com'; //default homepage url
 	}

--- a/extensions/wikia/MercuryApi/models/MercuryApi.class.php
+++ b/extensions/wikia/MercuryApi/models/MercuryApi.class.php
@@ -246,9 +246,9 @@ class MercuryApi {
 	 * @return string homepage URL. Default is US homepage.
 	 */
 	private function getHomepageUrl() {
-		global $wgContLang;
+		global $wgLanguageCode;
 		if ( class_exists('WikiaLogoHelper') ) {
-			return ( new WikiaLogoHelper() )->getCentralUrlForLang( $wgContLang->getCode() );
+			return ( new WikiaLogoHelper() )->getCentralUrlForLang( $wgLanguageCode );
 		}
 		return 'http://www.wikia.com'; //default homepage url
 	}

--- a/extensions/wikia/MercuryApi/models/MercuryApi.class.php
+++ b/extensions/wikia/MercuryApi/models/MercuryApi.class.php
@@ -105,7 +105,7 @@ class MercuryApi {
 	 */
 	public function getWikiVariables() {
 		global $wgSitename, $wgCacheBuster, $wgDBname, $wgDefaultSkin, $wgDisableAnonymousEditing,
-			   $wgLang, $wgLanguageCode, $wgContLang, $wgCityId, $wgEnableNewAuth, $wgDisableAnonymousUploadForMercury;
+			   $wgLanguageCode, $wgContLang, $wgCityId, $wgEnableNewAuth, $wgDisableAnonymousUploadForMercury;
 
 		return [
 			'cacheBuster' => (int) $wgCacheBuster,
@@ -117,7 +117,6 @@ class MercuryApi {
 			'homepage' => $this->getHomepageUrl(),
 			'id' => (int) $wgCityId,
 			'language' => [
-				'user' => $wgLang->getCode(),
 				'userDir' => SassUtil::isRTL() ? 'rtl' : 'ltr',
 				'content' => $wgLanguageCode,
 				'contentDir' => $wgContLang->getDir()

--- a/extensions/wikia/MercuryApi/models/MercuryApi.class.php
+++ b/extensions/wikia/MercuryApi/models/MercuryApi.class.php
@@ -117,7 +117,6 @@ class MercuryApi {
 			'homepage' => $this->getHomepageUrl(),
 			'id' => (int) $wgCityId,
 			'language' => [
-				'userDir' => SassUtil::isRTL() ? 'rtl' : 'ltr',
 				'content' => $wgLanguageCode,
 				'contentDir' => $wgContLang->getDir()
 			],


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/XW-287 

User lang will be fetched through UserInfo call https://github.com/Wikia/mercury/pull/1465

There is already a ticket (https://wikia-inc.atlassian.net/browse/XW-423) to implement user language properly in Mercury. WikiVariables won't be involved.
