### PR TITLE
PLATFORM-1540: detect file uploads (local files and via URL) not guarded by user's edit token check

### DIFF
--- a/extensions/wikia/Security/Security.setup.php
+++ b/extensions/wikia/Security/Security.setup.php
@@ -14,3 +14,7 @@ $wgAutoloadClasses['Wikia\\Security\\Exception'] = __DIR__ . '/classes/Exception
 // PLATFORM-1540: detect revision inserts not guarded by user's edit token check
 $wgHooks['UserMatchEditToken'][] = 'Wikia\\Security\\CSRFDetector::onUserMatchEditToken';
 $wgHooks['RevisionInsertComplete'][] = 'Wikia\\Security\\CSRFDetector::onRevisionInsertComplete';
+
+// PLATFORM-1540: detect file uploads (local files and via URL) not guarded by user's edit token check
+$wgHooks['UploadFromUrlReallyFetchFile'][] = 'Wikia\\Security\\CSRFDetector::onUploadFromUrlReallyFetchFile';
+$wgHooks['UploadComplete'][] = 'Wikia\\Security\\CSRFDetector::onUploadComplete';

--- a/extensions/wikia/Security/classes/CSRFDetector.class.php
+++ b/extensions/wikia/Security/classes/CSRFDetector.class.php
@@ -36,6 +36,28 @@ class CSRFDetector {
 	}
 
 	/**
+	 * Edit token should be checked before uploading image via URL
+	 *
+	 * @see PLATFORM-1531
+	 *
+	 * @return bool true, continue hook processing
+	 */
+	public static function onUploadFromUrlReallyFetchFile() {
+		self::assertEditTokenWasChecked( __METHOD__ );
+		return true;
+	}
+
+	/**
+	 * Edit token should be checked before uploading a file
+	 *
+	 * @return bool true, continue hook processing
+	 */
+	public static function onUploadComplete() {
+		self::assertEditTokenWasChecked( __METHOD__ );
+		return true;
+	}
+
+	/**
 	 * Assert that User::matchEditToken was called in this request
 	 *
 	 * @param string $fname the caller name


### PR DESCRIPTION
Extends #8634

Bind to `UploadFromUrlReallyFetchFile` and `UploadComplete` hooks.

@Grunny / @michalroszka 
