### PR TITLE
PLATFORM-1540 assert that User::saveSettings checks edit token

### DIFF
--- a/extensions/wikia/Security/Security.setup.php
+++ b/extensions/wikia/Security/Security.setup.php
@@ -11,10 +11,13 @@
 $wgAutoloadClasses['Wikia\\Security\\CSRFDetector'] = __DIR__ . '/classes/CSRFDetector.class.php';
 $wgAutoloadClasses['Wikia\\Security\\Exception'] = __DIR__ . '/classes/Exception.class.php';
 
-// PLATFORM-1540: detect revision inserts not guarded by user's edit token check
+// PLATFORM-1540: detect revision inserts not guarded by user's edit token check (@see MAIN-5465)
 $wgHooks['UserMatchEditToken'][] = 'Wikia\\Security\\CSRFDetector::onUserMatchEditToken';
 $wgHooks['RevisionInsertComplete'][] = 'Wikia\\Security\\CSRFDetector::onRevisionInsertComplete';
 
-// PLATFORM-1540: detect file uploads (local files and via URL) not guarded by user's edit token check
-$wgHooks['UploadFromUrlReallyFetchFile'][] = 'Wikia\\Security\\CSRFDetector::onUploadFromUrlReallyFetchFile';
+// PLATFORM-1540: detect file uploads (local files and via URL) not guarded by user's edit token check (@see PLATFORM-1531)
 $wgHooks['UploadComplete'][] = 'Wikia\\Security\\CSRFDetector::onUploadComplete';
+$wgHooks['UploadFromUrlReallyFetchFile'][] = 'Wikia\\Security\\CSRFDetector::onUploadFromUrlReallyFetchFile';
+
+// PLATFORM-1540: detect user settings saves not guarded by user's edit token check (@see CE-1224)
+$wgHooks['UserSaveSettings'][] = 'Wikia\\Security\\CSRFDetector::onUserSaveSettings';

--- a/extensions/wikia/Security/Security.setup.php
+++ b/extensions/wikia/Security/Security.setup.php
@@ -11,13 +11,15 @@
 $wgAutoloadClasses['Wikia\\Security\\CSRFDetector'] = __DIR__ . '/classes/CSRFDetector.class.php';
 $wgAutoloadClasses['Wikia\\Security\\Exception'] = __DIR__ . '/classes/Exception.class.php';
 
-// PLATFORM-1540: detect revision inserts not guarded by user's edit token check (@see MAIN-5465)
+// set per-request flags
 $wgHooks['UserMatchEditToken'][] = 'Wikia\\Security\\CSRFDetector::onUserMatchEditToken';
+
+// PLATFORM-1540: detect revision inserts not guarded by user's edit token check
 $wgHooks['RevisionInsertComplete'][] = 'Wikia\\Security\\CSRFDetector::onRevisionInsertComplete';
 
-// PLATFORM-1540: detect file uploads (local files and via URL) not guarded by user's edit token check (@see PLATFORM-1531)
+// PLATFORM-1540: detect file uploads (local files and via URL) not guarded by user's edit token check
 $wgHooks['UploadComplete'][] = 'Wikia\\Security\\CSRFDetector::onUploadComplete';
 $wgHooks['UploadFromUrlReallyFetchFile'][] = 'Wikia\\Security\\CSRFDetector::onUploadFromUrlReallyFetchFile';
 
-// PLATFORM-1540: detect user settings saves not guarded by user's edit token check (@see CE-1224)
+// PLATFORM-1540: detect user settings saves not guarded by user's edit token check
 $wgHooks['UserSaveSettings'][] = 'Wikia\\Security\\CSRFDetector::onUserSaveSettings';

--- a/extensions/wikia/Security/Security.setup.php
+++ b/extensions/wikia/Security/Security.setup.php
@@ -13,6 +13,8 @@ $wgAutoloadClasses['Wikia\\Security\\Exception'] = __DIR__ . '/classes/Exception
 
 // set per-request flags
 $wgHooks['UserMatchEditToken'][] = 'Wikia\\Security\\CSRFDetector::onUserMatchEditToken';
+$wgHooks['WebRequestWasPosted'][] = 'Wikia\\Security\\CSRFDetector::onRequestWasPosted';
+$wgHooks['WikiaRequestWasPosted'][] = 'Wikia\\Security\\CSRFDetector::onRequestWasPosted';
 
 // PLATFORM-1540: detect revision inserts not guarded by user's edit token check
 $wgHooks['RevisionInsertComplete'][] = 'Wikia\\Security\\CSRFDetector::onRevisionInsertComplete';

--- a/extensions/wikia/Security/classes/CSRFDetector.class.php
+++ b/extensions/wikia/Security/classes/CSRFDetector.class.php
@@ -73,10 +73,12 @@ class CSRFDetector {
 	 * @param string $fname the caller name
 	 */
 	private static function assertEditTokenWasChecked( $fname ) {
-		$request = \RequestContext::getMain()->getRequest();
+		// filter out maintenance scripts
+		if ( \RequestContext::getMain()->getRequest() instanceof \FauxRequest ) {
+			return;
+		}
 
-		# check the request against WebRequest to filter out maintenance scripts
-		if ( get_class( $request ) === \WebRequest::class && self::$userMatchEditTokenCalled === false ) {
+		if ( self::$userMatchEditTokenCalled === false ) {
 			wfDebug( __METHOD__ . ": {$fname} called, but edit token was not checked\n" );
 
 			WikiaLogger::instance()->warning( __METHOD__, [

--- a/extensions/wikia/Security/classes/CSRFDetector.class.php
+++ b/extensions/wikia/Security/classes/CSRFDetector.class.php
@@ -25,6 +25,8 @@ class CSRFDetector {
 	/**
 	 * Edit token should be checked before a revision is inserted
 	 *
+	 * @see MAIN-5465
+	 *
 	 * @param \Revision $revision
 	 * @param $data
 	 * @param $flags
@@ -59,6 +61,8 @@ class CSRFDetector {
 
 	/**
 	 * Edit token should be checked before saving user settings
+	 *
+	 * @see CE-1224
 	 *
 	 * @return bool true, continue hook processing
 	 */

--- a/extensions/wikia/Security/classes/CSRFDetector.class.php
+++ b/extensions/wikia/Security/classes/CSRFDetector.class.php
@@ -58,6 +58,16 @@ class CSRFDetector {
 	}
 
 	/**
+	 * Edit token should be checked before saving user settings
+	 *
+	 * @return bool true, continue hook processing
+	 */
+	public static function onUserSaveSettings() {
+		self::assertEditTokenWasChecked( __METHOD__ );
+		return true;
+	}
+
+	/**
 	 * Assert that User::matchEditToken was called in this request
 	 *
 	 * @param string $fname the caller name

--- a/includes/WebRequest.php
+++ b/includes/WebRequest.php
@@ -1286,6 +1286,8 @@ class FauxRequest extends WebRequest {
 	 * @return bool
 	 */
 	public function wasPosted() {
+		wfRunHooks( 'WebRequestWasPosted' ); # Wikia change
+
 		return $this->wasPosted;
 	}
 

--- a/includes/wikia/nirvana/WikiaRequest.class.php
+++ b/includes/wikia/nirvana/WikiaRequest.class.php
@@ -186,6 +186,8 @@ class WikiaRequest {
 	 * @return bool
 	 */
 	public function wasPosted() {
+		wfRunHooks( 'WikiaRequestWasPosted' );
+
 		return isset( $_SERVER['REQUEST_METHOD'] ) && $_SERVER['REQUEST_METHOD'] == 'POST';
 	}
 


### PR DESCRIPTION
Extends #8634

Bind to `UserSaveSettings` to protect us against cases like #5963

Check if `WebRequest::wasPosted` or `WikiaRequest::wasPosted` were called in addition to `User::matchEditToken` (and report the state of these checks when logging CSRF candidates).

@Grunny / @michalroszka
