### PR TITLE
(CE-2810) Add a reusable method to check valid write requests

### DIFF
--- a/includes/wikia/nirvana/WikiaDispatchableObject.class.php
+++ b/includes/wikia/nirvana/WikiaDispatchableObject.class.php
@@ -186,6 +186,21 @@ abstract class WikiaDispatchableObject extends WikiaObject {
 		return $this->response;
 	}
 
+	/**
+	 * Check write requests were correctly POSTed and passed a valid edit
+	 * token.
+	 *
+	 * @throws BadRequestException If the request either wasn't POSTed or didn't provide
+	 *                             a valid edit token.
+	 */
+	public function checkWriteRequest() {
+		if ( !$this->request->wasPosted()
+			|| !$this->wg->User->matchEditToken( $this->request->getVal( 'token' ) )
+		) {
+			throw new BadRequestException( 'Request must be POSTed and provide a valid edit token.' );
+		}
+	}
+
 	// Magic setting of template variables so we don't have to do $this->response->setVal
 	// NOTE: This is the opposite behavior of the Oasis Module
 	// In a module, a public member variable goes to the template

--- a/includes/wikia/nirvana/WikiaException.php
+++ b/includes/wikia/nirvana/WikiaException.php
@@ -176,32 +176,32 @@ abstract class WikiaHttpException extends WikiaBaseException {
  * subclasses each matching a specific HTTP status code
  */
 
-abstract class BadRequestException extends WikiaHttpException {
+class BadRequestException extends WikiaHttpException {
 	protected $code = 400;
 	protected $message = 'Bad request';
 }
 
-abstract class ForbiddenException extends WikiaHttpException {
+class ForbiddenException extends WikiaHttpException {
 	protected $code = 403;
 	protected $message = 'Forbidden';
 }
 
-abstract class NotFoundException extends WikiaHttpException {
+class NotFoundException extends WikiaHttpException {
 	protected $code = 404;
 	protected $message = 'Not found';
 }
 
-abstract class MethodNotAllowedException extends WikiaHttpException {
+class MethodNotAllowedException extends WikiaHttpException {
 	protected $code = 405;
 	protected $message = 'Method not allowed';
 }
 
-abstract class NotImplementedException extends WikiaHttpException {
+class NotImplementedException extends WikiaHttpException {
 	protected $code = 501;
 	protected $message = 'Not implemented';
 }
 
-abstract class InvalidDataException extends WikiaHttpException {
+class InvalidDataException extends WikiaHttpException {
 	protected $code = 555;//custom HTTP status, 500 cannot be used as it makes us fallback to IOWA
 	protected $message = 'Invalid data';
 }
@@ -209,13 +209,13 @@ abstract class InvalidDataException extends WikiaHttpException {
 class ControllerNotFoundException extends NotFoundException {
 	function __construct($name) {
 		parent::__construct("Controller not found: $name");
-	}	
+	}
 }
 
 class MethodNotFoundException extends NotFoundException {
 	function __construct($name) {
 		parent::__construct("Method not found: $name");
-	}	
+	}
 }
 
 class PermissionsException extends ForbiddenException {


### PR DESCRIPTION
Add a reusable method to check valid write requests to verify that the
request was POSTed and provided a valid edit token. This can be used
in any Nirvana controller to protect against CSRF.

/cc @macbre @adamkarminski 
