### PR TITLE
account for reston for user preference

### DIFF
--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1815,7 +1815,7 @@ $wgAdDriverIncontentPlayerSlotCountries = null;
  * manage a user's preferences externally
  */
 $wgPreferenceServiceRead = false;
-$wgPreferenceServiceShadowWrite = true;
+$wgPreferenceServiceShadowWrite = true && $wgWikiaDatacenter != WIKIA_DC_RES;
 
 /**
  * @name $wgEnableRobotsTxtExt

--- a/lib/Wikia/src/Service/User/Preferences/Migration/PreferenceMigrationModule.php
+++ b/lib/Wikia/src/Service/User/Preferences/Migration/PreferenceMigrationModule.php
@@ -12,9 +12,9 @@ class PreferenceMigrationModule implements Module {
 	const PREFERENCE_CORRECTION_SAMPLE_RATE = 0.2;
 
 	public function configure( InjectorBuilder $builder ) {
-		global $wgGlobalUserPreferenceWhiteList, $wgLocalUserPreferenceWhiteList, $wgCityId;
+		global $wgGlobalUserPreferenceWhiteList, $wgLocalUserPreferenceWhiteList, $wgCityId, $wgWikiaDatacenter;
 
-		$preferenceCorrectionEnabled = isset( $wgCityId ) && $wgCityId % 100 < self::PREFERENCE_CORRECTION_RAMP;
+		$preferenceCorrectionEnabled = isset( $wgCityId ) && $wgCityId % 100 < self::PREFERENCE_CORRECTION_RAMP && $wgWikiaDatacenter != WIKIA_DC_RES;
 
 		$builder
 			->bind( PreferenceCorrectionService::PREFERENCE_CORRECTION_ENABLED )->to( $preferenceCorrectionEnabled )


### PR DESCRIPTION
@Wikia/services-team 

only write to preference service and compare preferences when not in Reston since there are currently no services in Reston. Related config PR Wikia/config#1362
