### PR TITLE
adding noblockcheck query param to /info call

### DIFF
--- a/lib/Wikia/src/Service/Helios/HeliosClientImpl.php
+++ b/lib/Wikia/src/Service/Helios/HeliosClientImpl.php
@@ -142,7 +142,10 @@ class HeliosClientImpl implements HeliosClient
 	{
 		return $this->request(
 			'info',
-			[ 'code' => $token ]
+			[
+				'code' => $token,
+				'noblockcheck' => 1,
+			]
 		);
 	}
 


### PR DESCRIPTION
@Wikia/services-team 
https://wikia-inc.atlassian.net/browse/SERVICES-853

adding the `noblockcheck` query parameter to `/info` calls in mediawiki
