### PR TITLE
Enable OX Bidder in default settings

### DIFF
--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1265,7 +1265,7 @@ $wgAmazonMatchCountriesMobile = null;
  * @name $wgEnableOpenXBidder
  * Enables OpenX bidder
  */
-$wgAdDriverEnableOpenXBidder = false;
+$wgAdDriverEnableOpenXBidder = true;
 
 /**
  * @name $wgAdDriverOpenXBidderCountries


### PR DESCRIPTION
It doesn't mean that OX bidder is enabled at all - it's needed to set up `wgAdDriverOpenXBidderCountries`, but it's possible in WikiFactory.
