### PR TITLE
WebStart.php: modify the order of read-only and HTTP POST check

### DIFF
--- a/includes/WebStart.php
+++ b/includes/WebStart.php
@@ -192,7 +192,7 @@ if ( !defined( 'MW_NO_SETUP' ) ) {
 	require_once( MWInit::compiledPath( "includes/Setup.php" ) );
 }
 
-if(is_object($wgRequest) && $wgRequest->wasPosted() && wfReadOnly()) {
+if(wfReadOnly() && is_object($wgRequest) && $wgRequest->wasPosted()) {
 	if (
 		( strpos(strtolower($_SERVER['SCRIPT_URL']), 'datacenter') === false ) &&
 		( strpos(strtolower($_SERVER['SCRIPT_URL']), 'api.php') === false )


### PR DESCRIPTION
The previous order was setting the flag in [`CSRFDetector`](https://github.com/Wikia/app/blob/dev/extensions/wikia/Security/classes/CSRFDetector.class.php#L28-L36) that the HTTP method was checked for all requests. This change should improve the detection of "real" HTTP method checks.

@Grunny 
