### PR TITLE
CSRFDetector check WikiFactory related actions

### DIFF
--- a/extensions/wikia/Security/Security.setup.php
+++ b/extensions/wikia/Security/Security.setup.php
@@ -16,12 +16,16 @@ $wgHooks['UserMatchEditToken'][] = 'Wikia\\Security\\CSRFDetector::onUserMatchEd
 $wgHooks['WebRequestWasPosted'][] = 'Wikia\\Security\\CSRFDetector::onRequestWasPosted';
 $wgHooks['WikiaRequestWasPosted'][] = 'Wikia\\Security\\CSRFDetector::onRequestWasPosted';
 
-// PLATFORM-1540: detect revision inserts not guarded by user's edit token check
+// detect revision inserts not guarded by user's edit token check
 $wgHooks['RevisionInsertComplete'][] = 'Wikia\\Security\\CSRFDetector::onRevisionInsertComplete';
 
-// PLATFORM-1540: detect file uploads (local files and via URL) not guarded by user's edit token check
+// detect file uploads (local files and via URL) not guarded by user's edit token check
 $wgHooks['UploadComplete'][] = 'Wikia\\Security\\CSRFDetector::onUploadComplete';
 $wgHooks['UploadFromUrlReallyFetchFile'][] = 'Wikia\\Security\\CSRFDetector::onUploadFromUrlReallyFetchFile';
 
-// PLATFORM-1540: detect user settings saves not guarded by user's edit token check
+// detect user settings saves not guarded by user's edit token check
 $wgHooks['UserSaveSettings'][] = 'Wikia\\Security\\CSRFDetector::onUserSaveSettings';
+
+// WikiFactory related actions should be protected as well
+$wgHooks['WikiFactoryChanged'][] = 'Wikia\\Security\\CSRFDetector::onWikiFactory';
+$wgHooks['WikiFactoryVariableRemoved'][] = 'Wikia\\Security\\CSRFDetector::onWikiFactory';

--- a/extensions/wikia/Security/Security.setup.php
+++ b/extensions/wikia/Security/Security.setup.php
@@ -16,16 +16,28 @@ $wgHooks['UserMatchEditToken'][] = 'Wikia\\Security\\CSRFDetector::onUserMatchEd
 $wgHooks['WebRequestWasPosted'][] = 'Wikia\\Security\\CSRFDetector::onRequestWasPosted';
 $wgHooks['WikiaRequestWasPosted'][] = 'Wikia\\Security\\CSRFDetector::onRequestWasPosted';
 
-// detect revision inserts not guarded by user's edit token check
-$wgHooks['RevisionInsertComplete'][] = 'Wikia\\Security\\CSRFDetector::onRevisionInsertComplete';
+/**
+ * CSRFDetector
+ *
+ * List of hooks to bind, actions that triggered them will be checked against token and HTTP method validation
+ *
+ * @see PLATFORM-1540
+ */
+$wgCSRFDetectorHooks = [
+	// MAIN-5465: detect revision inserts not guarded by user's edit token check
+	'RevisionInsertComplete',
 
-// detect file uploads (local files and via URL) not guarded by user's edit token check
-$wgHooks['UploadComplete'][] = 'Wikia\\Security\\CSRFDetector::onUploadComplete';
-$wgHooks['UploadFromUrlReallyFetchFile'][] = 'Wikia\\Security\\CSRFDetector::onUploadFromUrlReallyFetchFile';
+	// PLATFORM-1531: detect file uploads (local files and via URL) not guarded by user's edit token check
+	'UploadComplete',
+	'UploadFromUrlReallyFetchFile',
 
-// detect user settings saves not guarded by user's edit token check
-$wgHooks['UserSaveSettings'][] = 'Wikia\\Security\\CSRFDetector::onUserSaveSettings';
+	// CE-1224: detect user settings saves not guarded by user's edit token check
+	'UserSaveSettings',
 
-// WikiFactory related actions should be protected as well
-$wgHooks['WikiFactoryChanged'][] = 'Wikia\\Security\\CSRFDetector::onWikiFactory';
-$wgHooks['WikiFactoryVariableRemoved'][] = 'Wikia\\Security\\CSRFDetector::onWikiFactory';
+	// WikiFactory related actions should be protected as well
+	'WikiFactoryChanged',
+	'WikiFactoryVariableRemoved',
+];
+
+// bind to all hooks defined in $wgCSRFDetectorHooks
+$wgExtensionFunctions[] = 'Wikia\\Security\\CSRFDetector::setupHooks';

--- a/extensions/wikia/Security/classes/CSRFDetector.class.php
+++ b/extensions/wikia/Security/classes/CSRFDetector.class.php
@@ -46,6 +46,7 @@ class CSRFDetector {
 		foreach( $wgCSRFDetectorHooks as $hookName ) {
 			$wgHooks[$hookName][] = function() use ( $hookName ) {
 				self::assertEditTokenAndMethodWereChecked( $hookName );
+				return true;
 			};
 		}
 	}

--- a/extensions/wikia/Security/classes/CSRFDetector.class.php
+++ b/extensions/wikia/Security/classes/CSRFDetector.class.php
@@ -83,6 +83,16 @@ class CSRFDetector {
 	}
 
 	/**
+	 * Edit token should be checked before making changes in WikiFactory
+	 *
+	 * @return bool true, continue hook processing
+	 */
+	public static function onWikiFactory() {
+		self::assertEditTokenAndMethodWereChecked( __METHOD__ );
+		return true;
+	}
+
+	/**
 	 * Assert that edit token and HTTP method were checked in this request
 	 *
 	 * @see https://kibana.wikia-inc.com/#/dashboard/elasticsearch/PLATFORM-1540


### PR DESCRIPTION
Extend #8634

And simplify hooks registration

The following messages will be reported:

``` json
{
  "message": "Wikia\\Security\\CSRFDetector::assertEditTokenAndMethodWereChecked",
  "context": {
    "hookName": "UploadFromUrlReallyFetchFile",
    "transaction": "api\\/ajax\\/other",
    "editTokenChecked": false,
    "httpMethodChecked": false,
    "exception": {}
  }
}
```

@Grunny 
