### PR TITLE
Common Request interface for WebRequest and WikiaRequest

### DIFF
--- a/includes/AutoLoader.php
+++ b/includes/AutoLoader.php
@@ -914,6 +914,9 @@ $wgAutoloadLocalClasses = array(
 	'UploadStashWrongOwnerException' => 'includes/upload/UploadStash.php',
 	'UploadStashNoSuchKeyException' => 'includes/upload/UploadStash.php',
 
+	# includes/wikia/interfaces
+	'Wikia\Interfaces\IRequest' => 'includes/wikia/interfaces/IRequest.php',
+
 	# languages
 	'FakeConverter' => 'languages/Language.php',
 	'Language' => 'languages/Language.php',

--- a/includes/WebRequest.php
+++ b/includes/WebRequest.php
@@ -35,7 +35,7 @@
  *
  * @ingroup HTTP
  */
-class WebRequest {
+class WebRequest implements Wikia\Interfaces\IRequest {
 	protected $data, $headers = array();
 
 	/**

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -308,11 +308,6 @@ $wgAutoloadClasses['TemplateClassification'] = "$IP/includes/wikia/TemplateClass
 $wgAutoloadClasses['TemplateDataExtractor'] = "$IP/includes/wikia/TemplateDataExtractor.class.php";
 
 /**
- * Custom Wikia interfaces
- */
-$wgAutoloadClasses['Wikia\\Interfaces\\IRequest'] = "$IP/includes/wikia/interfaces/IRequest.php";
-
-/**
  * Resource Loader enhancements
  */
 $wgAutoloadClasses[ 'ResourceLoaderGlobalWikiModule'  ]  = "$IP/includes/wikia/resourceloader/ResourceLoaderGlobalWikiModule.class.php";

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -308,6 +308,11 @@ $wgAutoloadClasses['TemplateClassification'] = "$IP/includes/wikia/TemplateClass
 $wgAutoloadClasses['TemplateDataExtractor'] = "$IP/includes/wikia/TemplateDataExtractor.class.php";
 
 /**
+ * Custom Wikia interfaces
+ */
+$wgAutoloadClasses['Wikia\\Interfaces\\IRequest'] = "$IP/includes/wikia/interfaces/IRequest.php";
+
+/**
  * Resource Loader enhancements
  */
 $wgAutoloadClasses[ 'ResourceLoaderGlobalWikiModule'  ]  = "$IP/includes/wikia/resourceloader/ResourceLoaderGlobalWikiModule.class.php";

--- a/includes/wikia/interfaces/IRequest.php
+++ b/includes/wikia/interfaces/IRequest.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * Interface IRequest
+ *
+ * An interface implemented by classes like WebRequest or WikiaRequest.
+ * Ensures that basic methods for interacting with a request exist.
+ *
+ * @author Adam Karmiński <adamk@wikia-inc.com>
+ */
+
+namespace Wikia\Interfaces;
+
+interface IRequest {
+
+	/**
+	 * Return true if the named value is set in the input, whatever that
+	 * value is (even "0"). Return false if the named value is not set.
+	 *
+	 * @param string $name
+	 * @return bool
+	 */
+	public function getCheck( $name );
+
+	/**
+	 * Fetch a scalar from the input or return $default if it's not set.
+	 * Returns a string. Arrays are discarded. Useful for
+	 * non-freeform text inputs (e.g. predefined internal text keys
+	 * selected by a drop-down menu).
+	 *
+	 * @param string $name
+	 * @param string|null $default
+	 * @return string
+	 */
+	public function getVal( $name, $default = null );
+
+	/**
+	 * Fetch a boolean value from the input or return $default if not set.
+	 * Guaranteed to return true or false, with normal PHP semantics for
+	 * boolean interpretation of strings.
+	 *
+	 * @param string $name
+	 * @param bool $default
+	 * @return bool
+	 */
+	public function getBool( $name, $default = false );
+
+	/**
+	 * Fetch an integer value from the input or return $default if not set.
+	 * Guaranteed to return an integer; non-numeric input should return 0.
+	 *
+	 * @param string $name
+	 * @param int $default
+	 * @return int
+	 */
+	public function getInt( $name, $default = 0 );
+
+	/**
+	 * Fetch an array from the input or return $default if it's not set.
+	 * If source was scalar, should return an array with a single element.
+	 * If no source and no default, should return an empty array.
+	 *
+	 * @param string $name
+	 * @param array $default
+	 * @return array
+	 */
+	public function getArray( $name, $default = [] );
+
+	/**
+	 * Set an arbitrary value into our get/post data.
+	 *
+	 * @param string $name Key name to use
+	 * @param mixed $value Value to set
+	 * @return mixed
+	 */
+	public function setVal( $name, $value );
+
+	/**
+	 * Get data from $_SESSION
+	 *
+	 * @param string $key Name of a key in $_SESSION
+	 * @return mixed
+	 */
+	public function getSessionData( $key );
+
+	/**
+	 * Set data to $_SESSION
+	 *
+	 * @param string $key Name of a key in $_SESSION
+	 * @param mixed $data
+	 */
+	public function setSessionData( $key, $data );
+
+	/**
+	 * Should verify if a request was a POST one and
+	 * return true if it was and false otherwise.
+	 *
+	 * @return bool
+	 */
+	public function wasPosted();
+}

--- a/includes/wikia/nirvana/WikiaRequest.class.php
+++ b/includes/wikia/nirvana/WikiaRequest.class.php
@@ -9,7 +9,7 @@
  * @author Owen Davis <owen(at)wikia-inc.com>
  * @author Wojciech Szela <wojtek(at)wikia-inc.com>
  */
-class WikiaRequest {
+class WikiaRequest implements Wikia\Interfaces\IRequest {
 
 	const EXCEPTION_MODE_RETURN = 0;
 	const EXCEPTION_MODE_WRAP_AND_THROW = 1;


### PR DESCRIPTION
I had issues trying to force a type of a method's argument but getting `WebRequest` || `WikiaRequest` which did not share any common parent class or interface. After consulting it with @macbre I decided to change it and provide an interface with the shared methods for interactions with a request.

/cc @macbre @Grunny
