### PR TITLE
(CE-2814) Add token to template draft approval action

### DIFF
--- a/extensions/wikia/TemplateDraft/ApprovedraftAction.php
+++ b/extensions/wikia/TemplateDraft/ApprovedraftAction.php
@@ -22,9 +22,10 @@
  */
 
 class ApprovedraftAction extends FormlessAction {
+	const ACTION_NAME = 'approvedraft';
 
 	public function getName() {
-		return 'approvedraft';
+		return self::ACTION_NAME;
 	}
 
 	protected function getDescription() {
@@ -33,13 +34,20 @@ class ApprovedraftAction extends FormlessAction {
 
 	public function onView() {
 		$title = $this->getTitle();
+		$request = $this->getRequest();
 
 		$redirectParams = wfArrayToCGI( array_diff_key(
 			$this->getRequest()->getQueryValues(),
-			[ 'title' => null, 'action' => null ]
-		));
+			[ 'title' => null, 'action' => null, 'token' => null ]
+		) );
 
-		if ( !$title->exists() ) {
+		// Must have valid token for this action/title
+		$salt = [ $this->getName(), $this->getTitle()->getDBkey() ];
+
+		if ( !$this->getUser()->matchEditToken( $request->getVal( 'token' ), $salt ) ) {
+			$this->addBannerNotificationMessage( 'sessionfailure' );
+			$redirectTitle = $title;
+		} elseif ( !$title->exists() ) {
 
 			$this->addBannerNotificationMessage( 'templatedraft-approval-no-page-error' );
 			$redirectTitle = $title;
@@ -59,6 +67,21 @@ class ApprovedraftAction extends FormlessAction {
 		}
 
 		$this->getOutput()->redirect( $redirectTitle->getFullUrl( $redirectParams ) );
+	}
+
+	/**
+	 * Get token to approve a draft page for a user.
+	 *
+	 * @param Title $title Title object of the draft page to approve
+	 * @param User $user User for whom the action is going to be performed
+	 * @return string Token
+	 */
+	public static function getApproveToken( Title $title, User $user ) {
+		$salt = [ self::ACTION_NAME, $title->getDBkey() ];
+
+		// This token stronger salted
+		// It's title/action specific because index.php is GET and API is POST
+		return $user->getEditToken( $salt );
 	}
 
 	/**

--- a/skins/oasis/modules/TemplateDraftModuleController.class.php
+++ b/skins/oasis/modules/TemplateDraftModuleController.class.php
@@ -35,7 +35,8 @@ class TemplateDraftModuleController extends WikiaController {
 		if ( $draftTitle->userCan( 'edit' ) && $parentTitle->userCan( 'edit' ) ) {
 			$this->allowApprove = true;
 			$this->draftUrl = $draftTitle->getFullUrl( [
-				'action' => 'approvedraft'
+				'action' => 'approvedraft',
+				'token' => ApprovedraftAction::getApproveToken( $draftTitle, $this->wg->User ),
 			] );
 		}
 	}


### PR DESCRIPTION
Add a required salted token to the template draft approval action. Standard
protections against CSRF in actions (such as watching and patrolling) involve
a salted token as actions are performed as GET requests.

/cc @macbre 
