### PR TITLE
CE-2813: Script to approve revision before given date

### DIFF
--- a/extensions/wikia/ContentReview/maintenance/setLastRevisionsAsReviewed.php
+++ b/extensions/wikia/ContentReview/maintenance/setLastRevisionsAsReviewed.php
@@ -15,12 +15,20 @@ class ReviewedRevision extends Maintenance {
 	public function __construct() {
 		parent::__construct();
 
+		$this->addOption( 'excludeEnabled', 'Exclude wikis on which ContentReview extension is enabled.' );
 	}
 
 	public function execute() {
-		global $wgCityId, $wgUseSiteJs;
+		global $wgCityId, $wgUseSiteJs, $wgEnableContentReviewExt;
 
-		if ( !empty( $wgUseSiteJs ) ) {
+		$excludeWiki = false;
+		$excludeEnabled = $this->getOption( 'excludeEnabled', false );
+
+		if ( !empty( $excludeEnabled ) && !empty( $wgEnableContentReviewExt ) ) {
+			$excludeWiki = true;
+		}
+
+		if ( !empty( $wgUseSiteJs ) && !$excludeWiki ) {
 			$this->output( "Processing wiki id: {$wgCityId}\n" );
 
 			$jsPages = ( new \Wikia\ContentReview\Helper() )->getJsPages();

--- a/extensions/wikia/ContentReview/maintenance/setRevisionsBeforeDateAsReviewed.php
+++ b/extensions/wikia/ContentReview/maintenance/setRevisionsBeforeDateAsReviewed.php
@@ -5,8 +5,6 @@ require_once( $dir . 'maintenance/Maintenance.php' );
 
 class ReviewedBeforeDateRevision extends Maintenance {
 
-	const JS_FILE_EXTENSION = '.js';
-
 	private $contentReviewService,
 			$currentRevisionModel,
 			$wikiaUser;

--- a/extensions/wikia/ContentReview/maintenance/setRevisionsBeforeDateAsReviewed.php
+++ b/extensions/wikia/ContentReview/maintenance/setRevisionsBeforeDateAsReviewed.php
@@ -75,7 +75,7 @@ class ReviewedBeforeDateRevision extends Maintenance {
 
 			$helper->purgeReviewedJsPagesTimestamp();
 		} else {
-			$this->output( "Wiki (Id: {$wgCityId}) has disabled custom scripts.\n" );
+			$this->output( "Wiki (Id: {$wgCityId}) has disabled custom scripts or JSRT.\n" );
 		}
 
 	}

--- a/extensions/wikia/ContentReview/maintenance/setRevisionsBeforeDateAsReviewed.php
+++ b/extensions/wikia/ContentReview/maintenance/setRevisionsBeforeDateAsReviewed.php
@@ -56,7 +56,7 @@ class ReviewedBeforeDateRevision extends Maintenance {
 										$this->getWikiaUser(),
 										$wgCityId,
 										$jsPage['page_id'],
-										$jsPage['page_latest']
+										$revision->getId()
 									);
 									$this->output( "Added revision id for page {$jsPage['page_title']} (ID: {$jsPage['page_id']})\n" );
 								} catch( FluentSql\Exception\SqlException $e ) {


### PR DESCRIPTION
Script to approve last JS page revision made by user with `editinterfacetrusted` right before given date passed as script argument `beforeDate`
