### PR TITLE
INT-221: Redlink dialog isn't firing under certain [currently unknown] circumstances

### DIFF
--- a/extensions/wikia/CreatePage/js/CreatePage.js
+++ b/extensions/wikia/CreatePage/js/CreatePage.js
@@ -40,15 +40,18 @@ var CreatePage = {
 		'use strict';
 
 		var rs, dialogCallback;
+
 		// BugId:4941
 		if ( Boolean( window.WikiaEnableNewCreatepage ) === false ) {
 			// create page popouts are disabled - follow the link
 			return;
 		}
+
 		// Ignore middle-click. BugId:12544
 		if ( e && e.which === 2 ) {
 			return;
 		}
+
 		// don't follow the link
 		if ( e && e.preventDefault ) {
 			e.preventDefault();
@@ -59,8 +62,10 @@ var CreatePage = {
 			CreatePage.checkTitle( titleText );
 			return;
 		}
+
 		if ( false === CreatePage.loading ) {
 			CreatePage.loading = true;
+
 			if ( CreatePage.canUseVisualEditor() && titleText ) {
 				rs = 'wfCreatePageAjaxGetVEDialog';
 				dialogCallback = CreatePage.openVEDialog;
@@ -263,6 +268,7 @@ var CreatePage = {
 			visualEditorActive = $( 'html' ).hasClass( 've-activated' );
 
 		CreatePage.redlinkParam = '&redlink=1';
+
 		if ( CreatePage.canUseVisualEditor() ) {
 			CreatePage.track( { action: 'click', label: 've-redlink-click' } );
 		}
@@ -282,9 +288,9 @@ var CreatePage = {
 	init: function( context ) {
 		'use strict';
 		CreatePage.context = context;
-
 		if ( window.WikiaEnableNewCreatepage ) {
 			$().log( 'init', 'CreatePage' );
+			
 			if ( !window.WikiaDisableDynamicLinkCreatePagePopup ) {
 				$( '#dynamic-links-write-article-link, #dynamic-links-write-article-icon' ).click(function( e ) {
 					CreatePage.requestDialog( e, null );

--- a/extensions/wikia/CreatePage/js/CreatePage.js
+++ b/extensions/wikia/CreatePage/js/CreatePage.js
@@ -266,25 +266,37 @@ var CreatePage = {
 	},
 
 	redLinkClick: function( e, titleText ) {
+		console.log('qqq redlinkclick titleText', titleText);
 		'use strict';
 		var title = new mw.Title.newFromText( titleText ),
 			namespace = title.getNamespacePrefix().replace( ':', '' ),
 			visualEditorActive = $( 'html' ).hasClass( 've-activated' );
 
 		CreatePage.redlinkParam = '&redlink=1';
-
+		console.log('qqq CreatePage.canUseVisualEditor()', CreatePage.canUseVisualEditor());
 		if ( CreatePage.canUseVisualEditor() ) {
 			CreatePage.track( { action: 'click', label: 've-redlink-click' } );
 		}
-
+		console.log('qqq visualEditorActive', visualEditorActive);
+		console.log("qqq mw.config.get( 'wgNamespaceIds' )[ namespace.toLowerCase() ]", mw.config.get( 'wgNamespaceIds' )[ namespace.toLowerCase() ]);
+		console.log('qqq window.ContentNamespacesText', window.ContentNamespacesText);
+		console.log('qqq window.ContentNamespacesText.indexOf( title[0] )', window.ContentNamespacesText.indexOf( title[0] ));
+		console.log('qqq condition evaluate ', (
+			visualEditorActive ||
+			mw.config.get( 'wgNamespaceIds' )[ namespace.toLowerCase() ] &&
+			window.ContentNamespacesText &&
+			window.ContentNamespacesText.indexOf( title[0] ) === -1
+		));
 		if (
 			visualEditorActive ||
 			mw.config.get( 'wgNamespaceIds' )[ namespace.toLowerCase() ] &&
 			window.ContentNamespacesText &&
 			window.ContentNamespacesText.indexOf( title[0] ) === -1
 		) {
+			console.log('qqq stop not request dialog');
 			return false;
 		} else {
+			console.log('qqq go request dialog');
 			CreatePage.requestDialog( e, titleText );
 		}
 	},
@@ -322,6 +334,7 @@ var CreatePage = {
 			}
 
 			$( '#WikiaArticle' ).on( 'click', 'a.new', function( e ) {
+				console.log('qqq attaching event handler to a new', $( '#WikiaArticle' ).find('a.new').length);
 				CreatePage.redLinkClick( e, CreatePage.getTitleFromUrl( this.href ) );
 			});
 

--- a/extensions/wikia/CreatePage/js/CreatePage.js
+++ b/extensions/wikia/CreatePage/js/CreatePage.js
@@ -37,37 +37,30 @@ var CreatePage = {
 	},
 
 	requestDialog: function( e, titleText ) {
-		console.log('qqq requestDialog titleText',titleText );
 		'use strict';
 
 		var rs, dialogCallback;
-		console.log('qqq window.WikiaEnableNewCreatepage', window.WikiaEnableNewCreatepage);
 		// BugId:4941
 		if ( Boolean( window.WikiaEnableNewCreatepage ) === false ) {
 			// create page popouts are disabled - follow the link
 			return;
 		}
-		console.log('qqq e.which', e.which);
 		// Ignore middle-click. BugId:12544
 		if ( e && e.which === 2 ) {
 			return;
 		}
-		console.log('qqq e.preventDefault', e.preventDefault);
 		// don't follow the link
 		if ( e && e.preventDefault ) {
 			e.preventDefault();
 		}
-		console.log('qqq CreatePage.canUseVisualEditor()', CreatePage.canUseVisualEditor());
-		console.log("qqq  $( e.target ).hasClass( 'createboxButton' )",  $( e.target ).hasClass( 'createboxButton' ));
+
 		// VE and <createbox>
 		if ( CreatePage.canUseVisualEditor() && $( e.target ).hasClass( 'createboxButton' ) ) {
 			CreatePage.checkTitle( titleText );
 			return;
 		}
-		console.log('qqq CreatePage.loading', CreatePage.loading);
 		if ( false === CreatePage.loading ) {
 			CreatePage.loading = true;
-			console.log('qqq CreatePage.canUseVisualEditor()', CreatePage.canUseVisualEditor());
 			if ( CreatePage.canUseVisualEditor() && titleText ) {
 				rs = 'wfCreatePageAjaxGetVEDialog';
 				dialogCallback = CreatePage.openVEDialog;
@@ -75,7 +68,7 @@ var CreatePage = {
 				rs = 'wfCreatePageAjaxGetDialog';
 				dialogCallback = CreatePage.openDialog;
 			}
-			console.log('qqq', dialogCallback);
+
 			$.getJSON(
 				CreatePage.context.wgScript,
 				{
@@ -89,7 +82,6 @@ var CreatePage = {
 	},
 
 	openVEDialog: function( data ) {
-		console.log('qqq openVEDialog', data);
 		require( [ 'wikia.ui.factory' ], function( uiFactory ) {
 			uiFactory.init( [ 'modal' ] ).then( function( uiModal ) {
 				var createPageModalConfig = {
@@ -159,7 +151,6 @@ var CreatePage = {
 	},
 
 	openDialog: function( data ) {
-		console.log('qqq openDialog', data);
 		require( [ 'wikia.ui.factory' ], function( uiFactory ) {
 			uiFactory.init( [ 'modal' ] ).then( function( uiModal ) {
 				var createPageModalConfig = {
@@ -266,37 +257,24 @@ var CreatePage = {
 	},
 
 	redLinkClick: function( e, titleText ) {
-		console.log('qqq redlinkclick titleText', titleText);
 		'use strict';
-		var title = new mw.Title.newFromText( titleText ),
+		var title = new mw.Title.newFromText( decodeURIComponent(titleText) ),
 			namespace = title.getNamespacePrefix().replace( ':', '' ),
 			visualEditorActive = $( 'html' ).hasClass( 've-activated' );
 
 		CreatePage.redlinkParam = '&redlink=1';
-		console.log('qqq CreatePage.canUseVisualEditor()', CreatePage.canUseVisualEditor());
 		if ( CreatePage.canUseVisualEditor() ) {
 			CreatePage.track( { action: 'click', label: 've-redlink-click' } );
 		}
-		console.log('qqq visualEditorActive', visualEditorActive);
-		console.log("qqq mw.config.get( 'wgNamespaceIds' )[ namespace.toLowerCase() ]", mw.config.get( 'wgNamespaceIds' )[ namespace.toLowerCase() ]);
-		console.log('qqq window.ContentNamespacesText', window.ContentNamespacesText);
-		console.log('qqq window.ContentNamespacesText.indexOf( title[0] )', window.ContentNamespacesText.indexOf( title[0] ));
-		console.log('qqq condition evaluate ', (
-			visualEditorActive ||
-			mw.config.get( 'wgNamespaceIds' )[ namespace.toLowerCase() ] &&
-			window.ContentNamespacesText &&
-			window.ContentNamespacesText.indexOf( title[0] ) === -1
-		));
+
 		if (
 			visualEditorActive ||
 			mw.config.get( 'wgNamespaceIds' )[ namespace.toLowerCase() ] &&
 			window.ContentNamespacesText &&
 			window.ContentNamespacesText.indexOf( title[0] ) === -1
 		) {
-			console.log('qqq stop not request dialog');
 			return false;
 		} else {
-			console.log('qqq go request dialog');
 			CreatePage.requestDialog( e, titleText );
 		}
 	},
@@ -304,15 +282,13 @@ var CreatePage = {
 	init: function( context ) {
 		'use strict';
 		CreatePage.context = context;
-		console.log('qqq init', window.WikiaEnableNewCreatepage);
+
 		if ( window.WikiaEnableNewCreatepage ) {
 			$().log( 'init', 'CreatePage' );
-			console.log('qqq', window.WikiaDisableDynamicLinkCreatePagePopup);
 			if ( !window.WikiaDisableDynamicLinkCreatePagePopup ) {
 				$( '#dynamic-links-write-article-link, #dynamic-links-write-article-icon' ).click(function( e ) {
 					CreatePage.requestDialog( e, null );
 				});
-				console.log('qqq jquery obj', $( '.noarticletext a[href*="redlink=1"]' ));
 				$( '.noarticletext a[href*="redlink=1"]' ).click(function( e ) {
 					CreatePage.requestDialog( e, CreatePage.context.wgPageName ); return false;
 				});
@@ -334,7 +310,6 @@ var CreatePage = {
 			}
 
 			$( '#WikiaArticle' ).on( 'click', 'a.new', function( e ) {
-				console.log('qqq attaching event handler to a new', $( '#WikiaArticle' ).find('a.new').length);
 				CreatePage.redLinkClick( e, CreatePage.getTitleFromUrl( this.href ) );
 			});
 

--- a/extensions/wikia/CreatePage/js/CreatePage.js
+++ b/extensions/wikia/CreatePage/js/CreatePage.js
@@ -37,35 +37,37 @@ var CreatePage = {
 	},
 
 	requestDialog: function( e, titleText ) {
+		console.log('qqq requestDialog titleText',titleText );
 		'use strict';
 
 		var rs, dialogCallback;
-
+		console.log('qqq window.WikiaEnableNewCreatepage', window.WikiaEnableNewCreatepage);
 		// BugId:4941
 		if ( Boolean( window.WikiaEnableNewCreatepage ) === false ) {
 			// create page popouts are disabled - follow the link
 			return;
 		}
-
+		console.log('qqq e.which', e.which);
 		// Ignore middle-click. BugId:12544
 		if ( e && e.which === 2 ) {
 			return;
 		}
-
+		console.log('qqq e.preventDefault', e.preventDefault);
 		// don't follow the link
 		if ( e && e.preventDefault ) {
 			e.preventDefault();
 		}
-
+		console.log('qqq CreatePage.canUseVisualEditor()', CreatePage.canUseVisualEditor());
+		console.log("qqq  $( e.target ).hasClass( 'createboxButton' )",  $( e.target ).hasClass( 'createboxButton' ));
 		// VE and <createbox>
 		if ( CreatePage.canUseVisualEditor() && $( e.target ).hasClass( 'createboxButton' ) ) {
 			CreatePage.checkTitle( titleText );
 			return;
 		}
-
+		console.log('qqq CreatePage.loading', CreatePage.loading);
 		if ( false === CreatePage.loading ) {
 			CreatePage.loading = true;
-
+			console.log('qqq CreatePage.canUseVisualEditor()', CreatePage.canUseVisualEditor());
 			if ( CreatePage.canUseVisualEditor() && titleText ) {
 				rs = 'wfCreatePageAjaxGetVEDialog';
 				dialogCallback = CreatePage.openVEDialog;
@@ -73,7 +75,7 @@ var CreatePage = {
 				rs = 'wfCreatePageAjaxGetDialog';
 				dialogCallback = CreatePage.openDialog;
 			}
-
+			console.log('qqq', dialogCallback);
 			$.getJSON(
 				CreatePage.context.wgScript,
 				{
@@ -87,6 +89,7 @@ var CreatePage = {
 	},
 
 	openVEDialog: function( data ) {
+		console.log('qqq openVEDialog', data);
 		require( [ 'wikia.ui.factory' ], function( uiFactory ) {
 			uiFactory.init( [ 'modal' ] ).then( function( uiModal ) {
 				var createPageModalConfig = {
@@ -156,6 +159,7 @@ var CreatePage = {
 	},
 
 	openDialog: function( data ) {
+		console.log('qqq openDialog', data);
 		require( [ 'wikia.ui.factory' ], function( uiFactory ) {
 			uiFactory.init( [ 'modal' ] ).then( function( uiModal ) {
 				var createPageModalConfig = {
@@ -288,13 +292,15 @@ var CreatePage = {
 	init: function( context ) {
 		'use strict';
 		CreatePage.context = context;
+		console.log('qqq init', window.WikiaEnableNewCreatepage);
 		if ( window.WikiaEnableNewCreatepage ) {
 			$().log( 'init', 'CreatePage' );
-
+			console.log('qqq', window.WikiaDisableDynamicLinkCreatePagePopup);
 			if ( !window.WikiaDisableDynamicLinkCreatePagePopup ) {
 				$( '#dynamic-links-write-article-link, #dynamic-links-write-article-icon' ).click(function( e ) {
 					CreatePage.requestDialog( e, null );
 				});
+				console.log('qqq jquery obj', $( '.noarticletext a[href*="redlink=1"]' ));
 				$( '.noarticletext a[href*="redlink=1"]' ).click(function( e ) {
 					CreatePage.requestDialog( e, CreatePage.context.wgPageName ); return false;
 				});

--- a/extensions/wikia/CreatePage/js/CreatePage.js
+++ b/extensions/wikia/CreatePage/js/CreatePage.js
@@ -290,7 +290,7 @@ var CreatePage = {
 		CreatePage.context = context;
 		if ( window.WikiaEnableNewCreatepage ) {
 			$().log( 'init', 'CreatePage' );
-			
+
 			if ( !window.WikiaDisableDynamicLinkCreatePagePopup ) {
 				$( '#dynamic-links-write-article-link, #dynamic-links-write-article-icon' ).click(function( e ) {
 					CreatePage.requestDialog( e, null );

--- a/extensions/wikia/CreatePage/js/CreatePage.js
+++ b/extensions/wikia/CreatePage/js/CreatePage.js
@@ -263,7 +263,7 @@ var CreatePage = {
 
 	redLinkClick: function( e, titleText ) {
 		'use strict';
-		var title = new mw.Title.newFromText( decodeURIComponent(titleText) ),
+		var title = new mw.Title.newFromText( decodeURIComponent( titleText ) ),
 			namespace = title.getNamespacePrefix().replace( ':', '' ),
 			visualEditorActive = $( 'html' ).hasClass( 've-activated' );
 


### PR DESCRIPTION
The cause was due to URL-encoded link title. So if English, it worked but if Japanese, then not. Fixed to decode URL-encoded title at the right spot. Ticket: https://wikia-inc.atlassian.net/browse/INT-221
