### PR TITLE
Revert "SOC-1315 | UserAttributes service - add transaction classifier"

### DIFF
--- a/includes/wikia/transaction/Transaction.php
+++ b/includes/wikia/transaction/Transaction.php
@@ -39,7 +39,6 @@ class Transaction {
 	const PARAM_WIKI = 'wiki';
 	const PARAM_DPL = 'dpl';
 	const PARAM_AB_PERFORMANCE_TEST = 'perf_test';
-	const PARAM_USER_ATTRIBUTES = 'user_attributes';
 
 	const PSEUDO_PARAM_TYPE = 'type';
 
@@ -64,7 +63,7 @@ class Transaction {
 	public static function getInstance() {
 		static $instance;
 		if ( $instance === null ) {
-			global $wgWikiaEnvironment, $wgEnableReadsFromAttributeService;
+			global $wgWikiaEnvironment;
 			$instance = new TransactionTrace( array(
 				// plugins
 				new TransactionTraceNewrelic(),
@@ -73,9 +72,6 @@ class Transaction {
 			$instance->set( self::PARAM_ENVIRONMENT, $wgWikiaEnvironment );
 			$instance->set( self::PARAM_HOSTNAME, wfHostname() );
 			$instance->set( self::PARAM_PHP_VERSION, explode( '-', phpversion() )[0] ); // report "5.4.17-1~precise+1" as "5.4.17"
-
-			// TODO clean up User Attributes classification when service is fully rolled out - SOC-1350
-			$instance->set( self::PARAM_USER_ATTRIBUTES, $wgEnableReadsFromAttributeService );
 		}
 		return $instance;
 	}

--- a/includes/wikia/transaction/TransactionClassifier.php
+++ b/includes/wikia/transaction/TransactionClassifier.php
@@ -72,10 +72,6 @@ class TransactionClassifier {
 		true => 'dpl',
 	);
 
-	protected static $MAP_USER_ATTRIBUTES = [
-		true => 'user_attributes'
-	];
-
 	protected $dependencies = array( Transaction::PARAM_ENTRY_POINT );
 	protected $attributes = array();
 	protected $nameParts = null;
@@ -171,9 +167,6 @@ class TransactionClassifier {
 
 		// add "DPL was used" information
 		$this->addByMap( Transaction::PARAM_DPL, self::$MAP_DPL );
-
-		// add "user_attributes service was enabled" information
-		$this->addByMap( Transaction::PARAM_USER_ATTRIBUTES, self::$MAP_USER_ATTRIBUTES );
 
 		// add size category
 		if ( $this->add( Transaction::PARAM_SIZE_CATEGORY ) === null ) {

--- a/includes/wikia/transaction/tests/TransactionClassifierTest.php
+++ b/includes/wikia/transaction/tests/TransactionClassifierTest.php
@@ -83,18 +83,6 @@ class TransactionClassifierTest extends WikiaBaseTest {
 			],
 			[
 				'attributes' => [
-					Transaction::PARAM_ENTRY_POINT => Transaction::ENTRY_POINT_PAGE,
-					Transaction::PARAM_NAMESPACE => NS_MAIN,
-					Transaction::PARAM_ACTION => TransactionClassifier::ACTION_VIEW,
-					Transaction::PARAM_SKIN => 'foo-skin',
-					Transaction::PARAM_PARSER_CACHE_DISABLED => true,
-					Transaction::PARAM_DPL => true,
-					Transaction::PARAM_USER_ATTRIBUTES => true
-				],
-				'expectedName' => 'page/main/view/foo-skin/parser_cache_disabled/dpl/user_attributes'
-			],
-			[
-				'attributes' => [
 					Transaction::PARAM_ENTRY_POINT => Transaction::ENTRY_POINT_NIRVANA,
 					Transaction::PARAM_CONTROLLER => 'SearchSuggestionsApi',
 				],


### PR DESCRIPTION
Now that the attribute service is enabled at 100%, we can revert the code we had added to monitor performance on MW between wikis where UAS was enabled, versus wikis where it wasn't enabled.

This reverts commit 570bb1c55fe539032ef9b1c517cdd9b4c68a5fbb.

ping @kvas-damian 
