### PR TITLE
removed conditional part of TLS usage

### DIFF
--- a/extensions/wikia/TwitterTag/scripts/twitter.min.js
+++ b/extensions/wikia/TwitterTag/scripts/twitter.min.js
@@ -1,1 +1,1 @@
-!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");
+!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="https://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");


### PR DESCRIPTION
This change gets rid of the regular expression which determines the use of TLS, and changes the feed source to always use HTTPS instead of varying it. This is simpler and more secure.
