### PR TITLE
DAT-3348: Modified NodeImage to return array of images instead of one image

### DIFF
--- a/extensions/wikia/PortableInfobox/services/Parser/Nodes/NodeImage.php
+++ b/extensions/wikia/PortableInfobox/services/Parser/Nodes/NodeImage.php
@@ -12,41 +12,118 @@ class NodeImage extends Node {
 
 	public function getData() {
 		if ( !isset( $this->data ) ) {
-			$imageData = $this->getRawValueWithDefault( $this->xmlNode );
+			$this->data = array();
 
-			if( is_string($imageData) && PortableInfoboxDataBag::getInstance()->getGallery($imageData)) {
-				$imageData = PortableInfoboxDataBag::getInstance()->getGallery($imageData);
-			}
+			$parameterValue = $this->getRawValueWithDefault( $this->xmlNode );
 
-			$title = $this->getImageAsTitleObject( $imageData );
-			$file = $this->getFilefromTitle( $title );
-			if ( $title instanceof \Title ) {
-				$this->getExternalParser()->addImage( $title->getDBkey() );
-			}
-			$ref = null;
-			$alt = $this->getValueWithDefault( $this->xmlNode->{self::ALT_TAG_NAME} );
-			$caption = $this->getValueWithDefault( $this->xmlNode->{self::CAPTION_TAG_NAME} );
+			if ( $this->containsTabberOrGallery( $parameterValue ) ) {
+				$parsed = $this->getExternalParser()->parseRecursive( $parameterValue );
 
-			$this->data = [
-				'url' => $this->resolveImageUrl( $file ),
-				'name' => ( $title ) ? $title->getText() : '',
-				'key' => ( $title ) ? $title->getDBKey() : '',
-				'alt' => $alt,
-				'caption' => $caption
-			];
-
-			if ( $this->isVideo( $file ) ) {
-				$this->data = $this->videoDataDecorator( $this->data, $file );
+				$items = $this->getGalleryItems( $parsed ) + $this->getTabberItems( $parsed );
+				for( $i = 0; $i < count( $items ); $i++ ) {
+					$this->data[] = $this->getImage(
+						$items[$i]['title'],
+						$items[$i]['caption'],
+						$items[$i]['caption']
+					);
+				}
+			} else {
+				$this->data[] = $this->getImage(
+					$parameterValue,
+					$this->getValueWithDefault( $this->xmlNode->{self::ALT_TAG_NAME} ),
+					$this->getValueWithDefault( $this->xmlNode->{self::CAPTION_TAG_NAME} )
+				);
 			}
 		}
 
 		return $this->data;
 	}
 
+	private function getGalleryItems( $html ) {
+		$items = array();
+
+		if ( preg_match( '#\sdata-model="([^"]+)"#', $html, $galleryOut ) ) {
+			$model = json_decode( htmlspecialchars_decode( $galleryOut[1] ), true );
+			$items = array_map( function( $modelItem ) {
+				return array(
+					'title' => $modelItem['title'],
+					'caption' => $modelItem[ 'caption' ]
+				);
+			}, $model );
+		}
+
+		if ( preg_match_all('#data-image-key="([^"]+)".*?\s<h2>(.*?)<\/h2>#is', $html, $galleryOut ) ) {
+			for( $i = 0; $i < count( $galleryOut[0] ); $i++ ) {
+				$items[] = array(
+					'title' => $galleryOut[1][$i],
+					'caption' => $galleryOut[2][$i]
+				);
+			}
+		}
+
+		return $items;
+	}
+
+	private function getTabberItems( $html ) {
+		$items = array();
+
+		if ( preg_match_all('/class="tabbertab" title="([^"]+)".*?\sdata-image-key="([^"]+)"/is', $parsed, $tabberOut) ) {
+			for( $i = 0; $i < count( $tabberOut[0] ); $i++ ) {
+				$items[] = array(
+					'title' => $tabberOut[2][$i],
+					'caption' => $tabberOut[1][$i]
+				);
+			}
+		}
+
+		return $items;
+	}
+
+	/**
+	 * @desc Checks if parser preprocessed string containg Tabber or Gallery extension
+	 * @param string $str String to check
+	 * @return bool
+	 */
+	private function containsTabberOrGallery( $str ) {
+		// TODO: Consider more robust approach (UNIQ...QINU)
+		$strLower = strtolower( $str );
+		if ( strpos( $strLower, '-tabber-' ) !== false || strpos( $strLower, '-gallery-' ) !== false ) {
+			return true;
+		}
+		return false;
+	}
+
+	private function getImage( $parameterValue, $alt, $caption ) {
+		$titleObj = $this->getImageAsTitleObject( $parameterValue );
+		$fileObj = $this->getFilefromTitle( $titleObj );
+
+		if ( $titleObj instanceof \Title ) {
+			$this->getExternalParser()->addImage( $titleObj->getDBkey() );
+		}
+
+		$image = [
+			'url' => $this->resolveImageUrl( $fileObj ),
+			'name' => $titleObj ? $titleObj->getText() : '',
+			'key' => $titleObj ? $titleObj->getDBKey() : '',
+			'alt' => $alt,
+			'caption' => $caption
+		];
+
+		if ( $this->isVideo( $fileObj ) ) {
+			$image = $this->videoDataDecorator( $image, $fileObj );
+		}
+
+		return $image;
+	}
+
 	public function isEmpty() {
 		$data = $this->getData();
-
-		return empty( $data[ 'url' ] );
+		foreach ( $data as $dataItem ) {
+			if ( !empty( $dataItem[ 'url' ] ) ) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	public function getSource() {

--- a/extensions/wikia/PortableInfobox/services/PortableInfoboxRenderService.class.php
+++ b/extensions/wikia/PortableInfobox/services/PortableInfoboxRenderService.class.php
@@ -129,6 +129,7 @@ class PortableInfoboxRenderService extends WikiaService {
 		$helper = new PortableInfoboxRenderServiceHelper();
 
 		if ( array_key_exists( 'image', $data ) ) {
+			$data[ 'image' ] = $data[ 'image' ][ 0 ];
 			$data[ 'image' ][ 'context' ] = self::MEDIA_CONTEXT_INFOBOX_HERO_IMAGE;
 			$data[ 'image' ] = $helper->extendImageData( $data[ 'image' ] );
 			$markup = $this->renderItem( 'hero-mobile', $data );
@@ -152,6 +153,7 @@ class PortableInfoboxRenderService extends WikiaService {
 		$helper = new PortableInfoboxRenderServiceHelper();
 
 		if ( $type === 'image' ) {
+			$data = $data[ 0 ];
 			$data[ 'image' ][ 'context' ] = self::MEDIA_CONTEXT_INFOBOX;
 			$data = $helper->extendImageData( $data );
 			if ( !$data ) {


### PR DESCRIPTION
This change is needed in order to support backward compatiblty for case where <gallery> or <tabber> is passed as a single parameter to a template.
There is no proper rendering yet for collections of images so for now only the first item is rendered.
