### PR TITLE
VOLDEV-161: Remove strict type check from LinkSuggestHooks

### DIFF
--- a/extensions/wikia/LinkSuggest/LinkSuggestHooks.class.php
+++ b/extensions/wikia/LinkSuggest/LinkSuggestHooks.class.php
@@ -37,10 +37,10 @@ class LinkSuggestHooks {
 	 * Hook: UploadForm:Initial
 	 * VOLDEV-121: Add LinkSuggest to Special:Upload and MultipleUpload
 	 * @author TK-999
-	 * @param SpecialUpload $specialUpload
+	 * @param SpecialUpload|SFUploadWindow $specialUpload
 	 * @return bool true because it's a hook
 	*/
-	public static function onUploadFormInitial( SpecialUpload $specialUpload ) {
+	public static function onUploadFormInitial( $specialUpload ) {
 		LinkSuggestLoader::getInstance()->addSelectors( '#wpUploadDescription' );
 		return true;
 	}


### PR DESCRIPTION
Fixes regression causing the hook to not work with SemanticForms
@Grunny  @macbre fast-tracked this one due to priority
