### PR TITLE
 CE-2824: Add content-reviewer permission group

### DIFF
--- a/extensions/wikia/ContentReview/ContentReview.hooks.php
+++ b/extensions/wikia/ContentReview/ContentReview.hooks.php
@@ -20,6 +20,8 @@ class Hooks {
 		\Hooks::register( 'ArticleDeleteComplete', [ $hooks, 'onArticleDeleteComplete' ] );
 		\Hooks::register( 'ArticleUndelete', [ $hooks, 'onArticleUndelete' ] );
 		\Hooks::register( 'ShowDiff', [ $hooks, 'onShowDiff' ] );
+		\Hooks::register( 'UserRights::groupCheckboxes', [ $hooks, 'onUserRightsGroupCheckboxes' ] );
+		\Hooks::register( 'UserAddGroup', [ $hooks, 'onUserAddGroup' ] );
 	}
 
 	public function onGetRailModuleList( Array &$railModuleList ) {
@@ -231,6 +233,26 @@ class Hooks {
 			);
 			return false;
 		}
+		return true;
+	}
+
+	public function onUserRightsGroupCheckboxes( $group, &$disabled, &$irreversible ) {
+		global $wgUser;
+
+		if ( $group === 'content-reviewer' && ( !$wgUser->isAllowed( 'content-review' ) || !$wgUser->isStaff() ) ) {
+			$disabled = true;
+		}
+
+		return true;
+	}
+
+	public function onUserAddGroup( \User $user, $group ) {
+		global $wgUser;
+
+		if ( $group === 'content-reviewer' && ( !$wgUser->isAllowed( 'content-review' ) || !$wgUser->isStaff() ) ) {
+			return false;
+		}
+
 		return true;
 	}
 

--- a/extensions/wikia/ContentReview/ContentReview.setup.php
+++ b/extensions/wikia/ContentReview/ContentReview.setup.php
@@ -31,9 +31,10 @@ $wgExtensionCredits['other'][] = [
  */
 $wgAvailableRights[] = 'content-review';
 $wgGroupPermissions['*']['content-review'] = false;
-$wgGroupPermissions['content-reviewers']['content-review'] = true;
-$wgAddGroups['content-reviewers'][] = 'content-reviewers';
-$wgRemoveGroups['content-reviewers'][] = 'content-reviewers';
+$wgGroupPermissions['content-reviewer']['content-review'] = true;
+$wgAddGroups['content-reviewer'][] = 'content-reviewer';
+$wgRemoveGroups['content-reviewer'][] = 'content-reviewer';
+$wgWikiaGlobalUserGroups[] = 'content-reviewer';
 
 $wgAvailableRights[] = 'content-review-test-mode';
 $wgGroupPermissions['user']['content-review-test-mode'] = true;

--- a/extensions/wikia/ContentReview/ContentReview.setup.php
+++ b/extensions/wikia/ContentReview/ContentReview.setup.php
@@ -31,8 +31,9 @@ $wgExtensionCredits['other'][] = [
  */
 $wgAvailableRights[] = 'content-review';
 $wgGroupPermissions['*']['content-review'] = false;
-$wgGroupPermissions['util']['content-review'] = true;
-$wgGroupPermissions['staff']['content-review'] = true;
+$wgGroupPermissions['content-reviewers']['content-review'] = true;
+$wgAddGroups['content-reviewers'][] = 'content-reviewers';
+$wgRemoveGroups['content-reviewers'][] = 'content-reviewers';
 
 $wgAvailableRights[] = 'content-review-test-mode';
 $wgGroupPermissions['user']['content-review-test-mode'] = true;


### PR DESCRIPTION
Added new group `content-reviewer`

Users in this group are only which have access to Special:ContentReview and can approve or reject JS page revision.

Only user in this group can add/remove other user.
