### PR TITLE
add ability to overwrite the langauge of email messages for a user

### DIFF
--- a/extensions/wikia/Email/Controller/EmailConfirmationController.class.php
+++ b/extensions/wikia/Email/Controller/EmailConfirmationController.class.php
@@ -84,6 +84,7 @@ abstract class AbstractEmailConfirmationController extends EmailController {
 }
 
 class EmailConfirmationController extends AbstractEmailConfirmationController {
+	const TYPE = "ConfirmationMail";
 
 	protected function getSubject() {
 		return $this->getMessage( 'emailext-emailconfirmation-subject' )->text();

--- a/extensions/wikia/Helios/HelperController.class.php
+++ b/extensions/wikia/Helios/HelperController.class.php
@@ -1,6 +1,7 @@
 <?php
 namespace Wikia\Helios;
 
+use Email\Controller\EmailConfirmationController;
 use Wikia\DependencyInjection\Injector;
 use Wikia\Service\User\Auth\AuthService;
 
@@ -122,7 +123,8 @@ class HelperController extends \WikiaController
 			return;
 		}
 
-		$mailStatus = $user->sendConfirmationMail();
+		$mailStatus = $user->sendConfirmationMail(
+			'created', EmailConfirmationController::TYPE, '', true, '', $this->getVal( 'langCode', 'en' ));
 
 		if ( ! $mailStatus->isGood() ) {
 			$this->response->setVal( 'message', 'could not send an email message' );

--- a/includes/User.php
+++ b/includes/User.php
@@ -20,6 +20,7 @@
  * @file
  */
 
+use Email\Controller\EmailConfirmationController;
 use Wikia\DependencyInjection\Injector;
 use Wikia\Domain\User\Attribute;
 use Wikia\Logger\Loggable;
@@ -4011,10 +4012,23 @@ class User {
 	 * Generate a new e-mail confirmation token and send a confirmation/invalidation
 	 * mail to the user's given address.
 	 *
-	 * @param $type String: message to send, either "created", "changed" or "set"
-	 * @return Status object
+	 * @param string $type
+	 * @param string $mailtype
+	 * @param string $mailmsg
+	 * @param bool|true $ip_arg
+	 * @param string $emailTextTemplate
+	 * @param null $language
+	 * @return Status
+	 * @throws MWException
 	 */
-	public function sendConfirmationMail( $type = 'created', $mailtype = "ConfirmationMail", $mailmsg = '', $ip_arg = true, $emailTextTemplate = '' ) {
+	public function sendConfirmationMail(
+		$type = 'created',
+		$mailtype = EmailConfirmationController::TYPE,
+		$mailmsg = '',
+		$ip_arg = true,
+		$emailTextTemplate = '',
+		$language = null ) {
+
 		global $wgLang;
 		$expiration = null; // gets passed-by-ref and defined in next line.
 		$token = $this->confirmationToken( $expiration );
@@ -4054,7 +4068,7 @@ class User {
 
 		$emailController = $this->getEmailController( $mailtype );
 		if ( !empty( $emailController ) ) {
-			return $this->sendUsingEmailExtension( $emailController, $url );
+			return $this->sendUsingEmailExtension( $emailController, $url, $language );
 		}
 
 		/* Wikia change begin - @author: Marooned */
@@ -4105,7 +4119,7 @@ class User {
 	}
 
 	private function isConfirmationMail( $mailType ) {
-		return $mailType == "ConfirmationMail";
+		return $mailType == EmailConfirmationController::TYPE;
 	}
 
 	private function isConfirmationReminderMail( $mailType ) {
@@ -4120,12 +4134,16 @@ class User {
 		return $mailType == "ReactivationMail";
 	}
 
-	private function sendUsingEmailExtension( $emailController, $url ) {
+	private function sendUsingEmailExtension( $emailController, $url, $language=null ) {
 		$params = [
 			'targetUser' => $this->getName(),
 			'newEmail' => $this->getNewEmail(),
 			'confirmUrl' => $url,
 		];
+
+		if ($language !== null) {
+			$params['targetLang'] = $language;
+		}
 
 		$responseData = F::app()->sendRequest( $emailController, 'handle', $params )->getData();
 
@@ -4147,7 +4165,7 @@ class User {
 		$this->saveSettings();
 		return $this->sendConfirmationMail(
 			false,
-			!empty( $this->getNewEmail() ) ? 'ReConfirmationMail' : 'ConfirmationMail'
+			!empty( $this->getNewEmail() ) ? 'ReConfirmationMail' : EmailConfirmationController::TYPE
 		);
 	}
 


### PR DESCRIPTION
@Wikia/services-team @jsutterfield 
https://wikia-inc.atlassian.net/browse/SERVICES-886

Because of the race condition with reading preferences from the preference service in MediaWiki as part of the registration request to Helios, pass the language code from Helios to MediaWiki, and honor that when sending a confirmation email.
