### PR TITLE
CE-1839 Cache sub-products for Reffaral links message to enable i18n

### DIFF
--- a/extensions/wikia/Insights/models/InsightsPageModel.php
+++ b/extensions/wikia/Insights/models/InsightsPageModel.php
@@ -258,7 +258,11 @@ abstract class InsightsPageModel extends InsightsModel {
 				}
 
 				if ( $this->isWlhLinkRequired() ) {
-					$article['metadata']['wantedBy'] = $this->makeWlhLink( $title, $row );
+					$article['metadata']['wantedBy'] = [
+						'message' => $this->wlhLinkMessage(),
+						'value' => (int)$row->value,
+						'url' => $this->getWlhUrl( $title ),
+					];
 				}
 
 				if ( $this->arePageViewsRequired() ) {
@@ -379,6 +383,15 @@ abstract class InsightsPageModel extends InsightsModel {
 		$data['userpage'] = $userpage;
 
 		return $data;
+	}
+
+	/**
+	 * Returns a link to a WhatLinksHere page for the given Title.
+	 * @param Title $title The target article's title object
+	 * @return string
+	 */
+	public function getWlhUrl( Title $title ) {
+		return SpecialPage::getTitleFor( 'Whatlinkshere', $title->getPrefixedText() );
 	}
 
 	/**

--- a/extensions/wikia/Insights/models/InsightsPageModel.php
+++ b/extensions/wikia/Insights/models/InsightsPageModel.php
@@ -9,7 +9,7 @@ abstract class InsightsPageModel extends InsightsModel {
 
 	const
 		INSIGHTS_MEMC_PREFIX = 'insights',
-		INSIGHTS_MEMC_VERSION = '1.2',
+		INSIGHTS_MEMC_VERSION = '1.3',
 		INSIGHTS_MEMC_TTL = 259200, // Cache for 3 days
 		INSIGHTS_MEMC_ARTICLES_KEY = 'articlesData',
 		INSIGHTS_LIST_MAX_LIMIT = 100,

--- a/extensions/wikia/Insights/models/InsightsQueryPageModel.php
+++ b/extensions/wikia/Insights/models/InsightsQueryPageModel.php
@@ -90,21 +90,6 @@ abstract class InsightsQueryPageModel extends InsightsPageModel {
 	}
 
 	/**
-	 * Prepares a link to a Special:WhatLinksHere page
-	 * for the article
-	 * @param Title $title The target article's title object
-	 * @param $result A number of referring links
-	 * @param string $message A message key
-	 * @return string A URL to the WLH page
-	 * @throws MWException
-	 */
-	public function makeWlhLink( Title $title, $result ) {
-		$wlh = SpecialPage::getTitleFor( 'Whatlinkshere', $title->getPrefixedText() );
-		$label = wfMessage( $this->wlhLinkMessage() )->numParams( $result->value )->escaped();
-		return Linker::link( $wlh, $label );
-	}
-
-	/**
 	 * Removes an item from the querycache table if it has been fixed
 	 *
 	 * @param $type A qc_type value

--- a/extensions/wikia/Insights/models/InsightsWantedpagesModel.php
+++ b/extensions/wikia/Insights/models/InsightsWantedpagesModel.php
@@ -31,9 +31,11 @@ class InsightsWantedpagesModel extends InsightsQueryPageModel {
 				}
 
 				$article['link'] = InsightsHelper::getTitleLink( $title, $params );
-				$article['metadata']['wantedBy']['message'] = $this->wlhLinkMessage();
-				$article['metadata']['wantedBy']['value'] = (int)$row->value;
-				$article['metadata']['wantedBy']['url'] = $this->getWlhUrl( $title );
+				$article['metadata']['wantedBy'] = [
+					'message' => $this->wlhLinkMessage(),
+					'value' => (int)$row->value,
+					'url' => $this->getWlhUrl( $title ),
+				];
 
 				$data[] = $article;
 			}

--- a/extensions/wikia/Insights/models/InsightsWantedpagesModel.php
+++ b/extensions/wikia/Insights/models/InsightsWantedpagesModel.php
@@ -59,13 +59,4 @@ class InsightsWantedpagesModel extends InsightsQueryPageModel {
 		}
 		return false;
 	}
-
-	/**
-	 * Returns a link to a WhatLinksHere page for the given Title.
-	 * @param Title $title The target article's title object
-	 * @return string
-	 */
-	public function getWlhUrl( Title $title ) {
-		return SpecialPage::getTitleFor( 'Whatlinkshere', $title->getPrefixedText() );
-	}
 }

--- a/extensions/wikia/Insights/models/InsightsWantedpagesModel.php
+++ b/extensions/wikia/Insights/models/InsightsWantedpagesModel.php
@@ -31,7 +31,9 @@ class InsightsWantedpagesModel extends InsightsQueryPageModel {
 				}
 
 				$article['link'] = InsightsHelper::getTitleLink( $title, $params );
-				$article['metadata']['wantedBy'] = $this->makeWlhLink( $title, $row );
+				$article['metadata']['wantedBy']['message'] = $this->wlhLinkMessage();
+				$article['metadata']['wantedBy']['value'] = (int)$row->value;
+				$article['metadata']['wantedBy']['url'] = $this->getWlhUrl( $title );
 
 				$data[] = $article;
 			}
@@ -54,5 +56,14 @@ class InsightsWantedpagesModel extends InsightsQueryPageModel {
 			return $this->removeFixedItem( ucfirst( self::INSIGHT_TYPE ), $title );
 		}
 		return false;
+	}
+
+	/**
+	 * Returns a link to a WhatLinksHere page for the given Title.
+	 * @param Title $title The target article's title object
+	 * @return string
+	 */
+	public function getWlhUrl( Title $title ) {
+		return SpecialPage::getTitleFor( 'Whatlinkshere', $title->getPrefixedText() );
 	}
 }

--- a/extensions/wikia/Insights/templates/Insights_subpageList.php
+++ b/extensions/wikia/Insights/templates/Insights_subpageList.php
@@ -63,7 +63,12 @@
 									</p>
 									<p class="insights-list-item-metadata">
 										<?php if ( isset( $item['metadata']['wantedBy'] ) ) : ?>
-											<?= $item['metadata']['wantedBy'] ?>
+											<?php $wantedBy = $item['metadata']['wantedBy']; ?>
+											<?=
+												Linker::linkKnown(
+													$wantedBy['url'],
+													wfMessage( $wantedBy['message'] )->inLanguage( $wg->Lang )->numParams( $wantedBy['value'] )->escaped() );
+											?>
 										<?php endif; ?>
 									</p>
 								<?php endif; ?>

--- a/extensions/wikia/Insights/templates/Insights_subpageList.php
+++ b/extensions/wikia/Insights/templates/Insights_subpageList.php
@@ -65,8 +65,10 @@
 										<?php if ( isset( $item['metadata']['wantedBy'] ) ) : ?>
 											<?php $wantedBy = $item['metadata']['wantedBy']; ?>
 											<?=
-												Linker::linkKnown(
-													$wantedBy['url'],
+												Html::element( 'a',
+													[
+														'href' => $wantedBy['url'],
+													],
 													wfMessage( $wantedBy['message'] )->numParams( $wantedBy['value'] )->escaped()
 												);
 											?>

--- a/extensions/wikia/Insights/templates/Insights_subpageList.php
+++ b/extensions/wikia/Insights/templates/Insights_subpageList.php
@@ -67,7 +67,8 @@
 											<?=
 												Linker::linkKnown(
 													$wantedBy['url'],
-													wfMessage( $wantedBy['message'] )->inLanguage( $wg->Lang )->numParams( $wantedBy['value'] )->escaped() );
+													wfMessage( $wantedBy['message'] )->numParams( $wantedBy['value'] )->escaped()
+												);
 											?>
 										<?php endif; ?>
 									</p>


### PR DESCRIPTION
Do not cache the whole link to WhatLinksHere for given items because it makes localization impossible. Basically, the links were generated in a language of the first person seeing the page after cache invalidation.

/cc @Wikia/community-engineering @lukaszkonieczny
