### PR TITLE
enable preference service in reston

### DIFF
--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1815,7 +1815,7 @@ $wgAdDriverIncontentPlayerSlotCountries = null;
  * manage a user's preferences externally
  */
 $wgPreferenceServiceRead = false;
-$wgPreferenceServiceWrite = true && $wgWikiaDatacenter != WIKIA_DC_RES;
+$wgPreferenceServiceWrite = true;
 
 /**
  * @name $wgEnableRobotsTxtExt

--- a/lib/Wikia/src/Service/User/Preferences/Migration/PreferenceMigrationModule.php
+++ b/lib/Wikia/src/Service/User/Preferences/Migration/PreferenceMigrationModule.php
@@ -12,9 +12,9 @@ class PreferenceMigrationModule implements Module {
 	const PREFERENCE_CORRECTION_SAMPLE_RATE = 0.2;
 
 	public function configure( InjectorBuilder $builder ) {
-		global $wgGlobalUserPreferenceWhiteList, $wgLocalUserPreferenceWhiteList, $wgCityId, $wgWikiaDatacenter;
+		global $wgGlobalUserPreferenceWhiteList, $wgLocalUserPreferenceWhiteList, $wgCityId;
 
-		$preferenceCorrectionEnabled = isset( $wgCityId ) && $wgCityId % 100 < self::PREFERENCE_CORRECTION_RAMP && $wgWikiaDatacenter != WIKIA_DC_RES;
+		$preferenceCorrectionEnabled = isset( $wgCityId ) && $wgCityId % 100 < self::PREFERENCE_CORRECTION_RAMP;
 
 		$builder
 			->bind( PreferenceCorrectionService::PREFERENCE_CORRECTION_ENABLED )->to( $preferenceCorrectionEnabled )


### PR DESCRIPTION
@Wikia/services-team 
https://wikia-inc.atlassian.net/browse/SERVICES-732
See Wikia/config#1413

`user-preference` is now deployed in Reston, so the mediawiki app can read from the service in Reston now.
