### PR TITLE
[SERVICES-908] Increases the length of the temporary generated password from 10 characters to 20.

### DIFF
--- a/includes/User.php
+++ b/includes/User.php
@@ -977,7 +977,7 @@ class User {
 	public static function randomPassword() {
 		global $wgMinimalPasswordLength;
 		// Decide the final password length based on our min password length, stopping at a minimum of 10 chars
-		$length = max( 10, $wgMinimalPasswordLength );
+		$length = max( 20, $wgMinimalPasswordLength );
 		// Multiply by 1.25 to get the number of hex characters we need
 		$length = $length * 1.25;
 		// Generate random hex chars


### PR DESCRIPTION
NOTE: This is an emergency fix, so I’m specifically not trying to make
the generated passwords better yet.
