### PR TITLE
Don't log as error when given a null revision

### DIFF
--- a/extensions/wikia/HAWelcome/HAWelcomeTaskHooks.php
+++ b/extensions/wikia/HAWelcome/HAWelcomeTaskHooks.php
@@ -33,7 +33,6 @@ class HAWelcomeTaskHooks {
 
 		// means we're dealing with a null edit (no content change) and therefore we don't have to welcome anybody
 		if ( is_null( $revisionObject ) ) {
-			WikiaLogger::instance()->error( "error, null \$revisionObject passed to " . __METHOD__ );
 			return true;
 		}
 


### PR DESCRIPTION
We short circuit the hook when this happens. This is probably not an error we need to act on.

https://wikia-inc.atlassian.net/browse/MAIN-5351

/cc @macbre 
