### PR TITLE
Log attempts to fall back to authenticating via the session

### DIFF
--- a/includes/User.php
+++ b/includes/User.php
@@ -1142,6 +1142,8 @@ class User {
 			return false;
 		}
 
+		$this->logAuthenticationFallthrough($from, $passwordCorrect);
+
 		if ( ( $sName === $proposedUser->getName() ) && $passwordCorrect ) {
 			$this->loadFromUserObject( $proposedUser );
 			$request->setSessionData( 'wsToken', $this->mToken );
@@ -5173,5 +5175,28 @@ class User {
 	 */
 	public static function getUserTouchedKey( $user_id ) {
 		return wfSharedMemcKey( "user_touched", 'v1', $user_id );
+	}
+
+
+	/**
+	 * Log authentication fall through.
+	 *
+	 * @param string $from
+	 * @param bool $passwordCorrect
+	 */
+	private function logAuthenticationFallthrough($from, $passwordCorrect) {
+		$sampler = new BernoulliTrial( 0.05 );
+		if ( $sampler->shouldSample() ) {
+			Wikia\Logger\WikiaLogger::instance()->info(
+				'AUTHENTICATION_FALLBACK',
+				[
+					'from'              => $from,
+					'passwordCorrect'   => $passwordCorrect,
+					'ip'                => $this->getRequest()->getIP(),
+					'session_id'        => session_id(),
+					'user_id'           => $this->getId(),
+					'user_name'         => $this->getName(),
+				]);
+		}
 	}
 }


### PR DESCRIPTION
This is a precursor to https://wikia-inc.atlassian.net/browse/SERVICES-887. We would like to know how often we are falling back to loading the user from the session which is equivalent to authenticating via the session.

/cc @Wikia/services-team 

TODO:
- [x] confirm that this works as expected. I'm currently unable to load the app on my dev box
