### PR TITLE
ApiQueryUsers: allow user id in addition to user name

### DIFF
--- a/includes/api/ApiQueryUsers.php
+++ b/includes/api/ApiQueryUsers.php
@@ -84,6 +84,19 @@ class ApiQueryUsers extends ApiQueryBase {
 		$users = (array)$params['users'];
 		$goodNames = $done = array();
 		$result = $this->getResult();
+
+		// Wikia change - begin
+		// @see PLATFORM-1561
+		$ids = (array)$params['ids'];
+
+		foreach( $ids as $id ) {
+			$u = User::newFromId( $id );
+			if ( $u->isLoggedIn() ) {
+				$users[] = $u->getName();
+			}
+		}
+		// Wikia change - end
+
 		// Canonicalize user names
 		foreach ( $users as $u ) {
 			$n = User::getCanonicalName( $u );
@@ -288,6 +301,9 @@ class ApiQueryUsers extends ApiQueryBase {
 			'users' => array(
 				ApiBase::PARAM_ISMULTI => true
 			),
+			'ids' => array(
+				ApiBase::PARAM_ISMULTI => true
+			),
 			'token' => array(
 				ApiBase::PARAM_TYPE => array_keys( $this->getTokenFunctions() ),
 				ApiBase::PARAM_ISMULTI => true
@@ -308,7 +324,8 @@ class ApiQueryUsers extends ApiQueryBase {
 				'  emailable      - Tags if the user can and wants to receive e-mail through [[Special:Emailuser]]',
 				'  gender         - Tags the gender of the user. Returns "male", "female", or "unknown"',
 			),
-			'users' => 'A list of users to obtain the same information for',
+			'users' => 'A list of user names to obtain the same information for',
+			'ids' => 'A list of user IDs to obtain the same information for',
 			'token' => 'Which tokens to obtain for each user',
 		);
 	}
@@ -318,7 +335,10 @@ class ApiQueryUsers extends ApiQueryBase {
 	}
 
 	public function getExamples() {
-		return 'api.php?action=query&list=users&ususers=brion|TimStarling&usprop=groups|editcount|gender';
+		return [
+			'api.php?action=query&list=users&ususers=brion|TimStarling&usprop=groups|editcount|gender',
+			'api.php?action=query&list=users&usids=1|2&usprop=groups|editcount|gender',
+		];
 	}
 
 	public function getHelpUrls() {

--- a/includes/api/ApiQueryUsers.php
+++ b/includes/api/ApiQueryUsers.php
@@ -91,7 +91,7 @@ class ApiQueryUsers extends ApiQueryBase {
 
 		foreach( $ids as $id ) {
 			$u = User::newFromId( $id );
-			if ( $u->isLoggedIn() ) {
+			if ( !$u->isAnon() ) { # do not add anons as IP addresses
 				$users[] = $u->getName();
 			}
 		}


### PR DESCRIPTION
Allow Pandora services to query for user information (block info, groups and rights) by user ID.

[The example API request](http://poznan.macbre.wikia-dev.com/api.php?action=query&list=users&usids=0|1|119245&usprop=groups|rights|blockinfo)

@michalroszka / @wladekb / @jcellary 
