### PR TITLE
SOC-1435 Refactor this extension to make it easier to read & disable bounce handling

### DIFF
--- a/includes/wikia/api/SendGridPostBackApiController.class.php
+++ b/includes/wikia/api/SendGridPostBackApiController.class.php
@@ -1,91 +1,115 @@
 <?php
 /**
- * API which SendGrid will post data to when an email is opened, clicked, bounced back, unsubscribed, marked as spam, etc..
+ * API which SendGrid will post data to when an email is opened, clicked, etc..
  *
- * @author Piotr Molski ( moli@wikia-inc.com )
+ * For more information see:
+ *
+ *   https://sendgrid.com/docs/API_Reference/Webhooks/event.html
  */
+
+use Wikia\Logger\WikiaLogger;
 
 class SendGridPostbackController extends WikiaApiController {
 
-	public function safe_get($arr, $key, $default = null) {
-		return isset($arr[$key]) ? $arr[$key] : $default;
-	}
-
+	/**
+	 * Requests from SendGrid are POSTed via this controller.  The POST data contains a JSON
+	 * encoded associative array with the following keys:
+	 *
+	 * - email
+	 * - wikia-email-id
+	 * - wikia-email-city-id
+	 * - wikia-db
+	 * - event
+	 * - url
+	 * - status
+	 * - reason
+	 *
+	 * NOTE: The 'response' key set before returning is for debugging purposes only.  SendGrid
+	 * only requires that we send back a 200 response code.
+	 *
+	 */
 	public function log() {
-		wfProfileIn( __METHOD__ );
-
-		// Sendgrid uses raw JSON POST format, this is how PHP ingests it
-		$data = file_get_contents("php://input");
-		$events = json_decode($data, true);  // true = return value is array
-
-		if (empty($events)) {
-			\Wikia\Logger\WikiaLogger::instance()->debug( __CLASS__ . ": No data to process");
-			wfProfileOut( __METHOD__ );
+		if ( !$this->wg->Request->wasPosted() ) {
+			// Log the token-validation problem.
+			WikiaLogger::instance()->debug( __CLASS__ . ': Request method must be POST' );
+			$this->response->setVal( 'response', 'Request method must be POST' );
 			return;
 		}
 
-		if (!is_array($events)) {
-			\Wikia\Logger\WikiaLogger::instance()->debug( __CLASS__ . ": Supplied data is not an array", [
-				'data_first_100_chars' => is_string($data) ? substr($data,0,100) : '[type: ' . gettype($data) . ']'
-			]);
-			wfProfileOut( __METHOD__ );
+		$events = $this->getEvents();
+		if ( empty( $events ) ) {
+			$this->response->setVal( 'response', 'Unable to find any events' );
 			return;
 		}
 
-		foreach ($events as $event) {
-			$email_addr = $this->safe_get($event, 'email', '');
-			$email_id 	= $this->safe_get($event, 'wikia-email-id');
-			$city_id 	= $this->safe_get($event, 'wikia-email-city-id');
-			$sender_db 	= $this->safe_get($event, 'wikia-db');
-			$token 		= $this->safe_get($event, 'wikia-token');
-			$event_type	= $this->safe_get($event, 'event');
-			$url 		= $this->safe_get($event, 'url', '');
-			$status 	= $this->safe_get($event, 'status', '');
-			$reason		= $this->safe_get($event, 'reason', '');
+		foreach ( $events as $event ) {
+			$eventType = $this->safeGet( $event, 'event' );
 
-			if ( $this->wg->Request->wasPosted() ) {
-				// log postback data
-				$insert_data = array(
-					"mail_id"      => $email_id,
-					"emailAddr"    => $email_addr,
-					"cityId"       => $city_id,
-					"eventType"    => $event_type,
-					"senderDbName" => $sender_db,
-					"url"          => $url,
-					"status"       => $status,
-					"reason"       => $reason
-				);
+			// Log to logstash/kibana
+			WikiaLogger::instance()->info( 'SendgridPostback', $event );
 
-				// Log to logstash/kibana
-				\Wikia\Logger\WikiaLogger::instance()->info( "SendgridPostback", $insert_data);
-
-				// On bounce, invalidate the users email to force them to re-verify it
-				if ( $event_type == 'bounce' ) {
-					if ( isset( $this->wg->SharedDB ) ) {
-						$dbr = wfGetDB( DB_SLAVE, array(), $this->wg->ExternalSharedDB );
-					} else {
-						$dbr = wfGetDB( DB_SLAVE );
-					}
-
-					$res = $dbr->select( array( '`user`' ), array( 'user_id' ), array( 'user_email' => $email_addr ), __METHOD__ );
-					while( $row = $dbr->fetchObject( $res ) ) {
-						$user = User::newFromId( $row->user_id );
-						if (!$user) {
-							continue;
-						}
-						$user->invalidateEmail();
-						$user->saveSettings();
-					}
-				}
-
-				$this->response->setVal( 'response', 'Postback processed.' );
-			} else {
-				// Log the token-validation problem.
-				Wikia::log(__METHOD__, false, "INVALID TOKEN DURING THIS POSTBACK: " . json_encode($_POST), true);
-				$this->response->setVal( 'response', 'Postback token did not match expected value.  Ignoring.' );
+			// On bounce, invalidate the users email to force them to re-verify it
+			if ( $eventType == 'bounce' ) {
+				// SOC-1435 : For now don't invalidate email on bounce
+				# $this->handleBounce( $event );
 			}
 
-			wfProfileOut( __METHOD__ );
+			$this->response->setVal( 'response', 'Postback processed' );
 		}
+	}
+
+	/**
+	 * Pull the event information from the POST data.  Return an array if successful, null otherwise
+	 *
+	 * @return mixed|null
+	 */
+	protected function getEvents() {
+		// Sendgrid uses raw JSON POST format, this is how PHP ingests it
+		$data = file_get_contents( "php://input" );
+		$events = json_decode( $data, $returnArray = true );
+
+		if ( empty( $events ) ) {
+			WikiaLogger::instance()->debug( __CLASS__ . ": No data to process" );
+			return null;
+		}
+
+		if ( !is_array( $events ) ) {
+			if ( is_string( $data ) ) {
+				$firstChars = substr( $data, 0, 100 );
+			} else {
+				$firstChars = '[type: ' . gettype( $data ) . ']';
+			}
+
+			WikiaLogger::instance()->debug( __CLASS__ . ": Supplied data is not an array", [
+				'data_first_100_chars' => $firstChars,
+			] );
+			return null;
+		}
+
+		return $events;
+	}
+
+	protected function handleBounce( Array $event ) {
+		$dbType = $this->wg->SharedDB ? $this->wg->ExternalSharedDB : null;
+		$dbr = wfGetDB( DB_SLAVE, [], $dbType );
+
+		$res = $dbr->select(
+			[ 'user' ],
+			[ 'user_id' ],
+			[ 'user_email' => $this->safeGet( $event, 'email' ) ],
+			__METHOD__
+		);
+		while ( $row = $dbr->fetchObject( $res ) ) {
+			$user = User::newFromId( $row->user_id );
+			if ( !$user ) {
+				continue;
+			}
+			$user->invalidateEmail();
+			$user->saveSettings();
+		}
+	}
+
+	public function safeGet( $arr, $key, $default = null ) {
+		return isset( $arr[$key] ) ? $arr[$key] : $default;
 	}
 }


### PR DESCRIPTION
Note that this extension essentially does nothing now that I've disabled the bounce handling.  I'm aware of this and I cleaned it up because we'll likely add new behavior in the near future when we decide what to do with the bounce info that SendGrid gives us.

Also, you can test this endpoint by sending a POST request here:

```
http://community.garth.wikia-dev.com/wikia.php?controller=SendGridPostback&method=log
```

The minimum data needed to be a valid postback is:

```
[{"event": "bounce"}]
```

This can be achieved via the `curl` request:

```
curl -d '[{"event": "bounce"}]' -X POST 'http://community.garth.wikia-dev.com/wikia.php?controller=SendGridPostback&method=log'
```

https://wikia-inc.atlassian.net/browse/SOC-1435
