### PR TITLE
SERVICES-873: Added log when MW is falling back from Helios auth to legacy one

### DIFF
--- a/includes/context/RequestContext.php
+++ b/includes/context/RequestContext.php
@@ -207,20 +207,20 @@ class RequestContext implements IContextSource {
 
 		if ( $this->user === null && $wgEnableHeliosExt ) {
 			$this->user = \Wikia\Helios\User::newFromToken( $this->getRequest() );
-			$authPath[] = 'helios: ' . ($this->user !== null ? 'OK' : 'FAIL');
+			$authPath['helios'] = ($this->user !== null ? 'OK' : 'FAIL');
 		}
 		// Wikia change - end
 		// Wikia change - begin - @author: wladek
 		global $wgUserForceAnon;
 		if ( $this->user === null && $wgUserForceAnon ) {
 			$this->user = new User();
-			$authPath[] = 'force_anon';
+			$authPath['force_anon'] = 'OK';
 		}
 
 		if ( $this->user === null ) {
 		// Wikia change - end
 			$this->user = User::newFromSession( $this->getRequest() );
-			$authPath[] = 'MW: ' . ($this->user !== null ? 'OK' : 'FAIL');
+			$authPath['media_wiki'] = ($this->user !== null ? 'OK' : 'FAIL');
 		}
 
 		$this->logAuthenticationMethod($this->user, $authPath);
@@ -241,14 +241,14 @@ class RequestContext implements IContextSource {
 
 		$sampler = new \Wikia\Util\Statistics\BernoulliTrial( 0.05 );
 
-		if ( !$sampler->shouldSample() ) {
+		if ( 0 && !$sampler->shouldSample() ) {
 			return;
 		}
 
 		\Wikia\Logger\WikiaLogger::instance()->info(
 			'AUTHENTICATION_FALLBACK',
 			[
-				'auth_path'		=> $authSource,
+				'auth'			=> $authSource,
 				'ip'			=> $this->getRequest()->getIP(),
 				'session_id'	=> session_id(),
 				'from'			=> $user->mFrom,

--- a/includes/context/RequestContext.php
+++ b/includes/context/RequestContext.php
@@ -241,7 +241,9 @@ class RequestContext implements IContextSource {
 
 		$sampler = new \Wikia\Util\Statistics\BernoulliTrial( 0.05 );
 
-		if ( 0 && !$sampler->shouldSample() ) {
+		\Transaction::addEvent( \Transaction::EVENT_USER_AUTH, $authSource );
+
+		if ( !$sampler->shouldSample() ) {
 			return;
 		}
 

--- a/includes/wikia/transaction/Transaction.php
+++ b/includes/wikia/transaction/Transaction.php
@@ -54,6 +54,7 @@ class Transaction {
 	const EVENT_USER_PREFERENCES = 'user_preferences';
 	const EVENT_USER_PREFERENCES_COUNTERS = "user_preferences_counters";
 	const EVENT_USER_ATTRIBUTES = 'user_attributes';
+	const EVENT_USER_AUTH = 'user_auth';
 
 	/**
 	 * Returns TransactionTrace singleton instance


### PR DESCRIPTION
We need to know how many cases there are when for some reason user can't authenticate using Helios service but gets logged in by MW anyway using cookie/token/whatever. We need that to safely force Helios as one source of authentication.

One caveat of this solution is that we get a lot of those logs when user is beeing logged over and over again using native/legacy MW mechanisms.
@Wikia/services-team 
