### PR TITLE
don't save language to the user_properties table

### DIFF
--- a/includes/User.php
+++ b/includes/User.php
@@ -5050,9 +5050,7 @@ class User {
 	 * @return bool
 	 */
 	private function shouldOptionBeStored( $key, $value ) {
-		global $wgGlobalUserProperties;
 		if (
-			( is_array( $wgGlobalUserProperties ) && in_array( $key, $wgGlobalUserProperties ) ) ||
 			( is_null( self::getDefaultOption( $key ) ) && !( $value === false || is_null($value) ) ) ||
 			$value != self::getDefaultOption( $key )
 		) {

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1017,7 +1017,7 @@ $wgAssetsManagerQuery = '/__am/%4$d/%1$s/%3$s/%2$s';
 /**
  * global user_options
  */
-$wgGlobalUserProperties = array('language');
+$wgGlobalUserProperties = [];
 
 /**
  * debug level for memcached

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1015,11 +1015,6 @@ $wgAssetsManagerQuery = '/__am/%4$d/%1$s/%3$s/%2$s';
 //$wgAssetsManagerQuery = '/index.php?action=ajax&rs=AssetsManagerEntryPoint&__am&type=%1$s&cb=%4$d&params=%3$s&oid=%2$s';
 
 /**
- * global user_options
- */
-$wgGlobalUserProperties = [];
-
-/**
  * debug level for memcached
  */
 $wgMemCachedDebugLevel = 1;

--- a/lib/Wikia/src/Service/User/Preferences/PreferenceModule.php
+++ b/lib/Wikia/src/Service/User/Preferences/PreferenceModule.php
@@ -48,8 +48,7 @@ class PreferenceModule implements Module {
 				return $defaultPreferences;
 			} )
 			->bind( PreferenceServiceImpl::FORCE_SAVE_PREFERENCES )->to( function() {
-				global $wgGlobalUserProperties;
-				return $wgGlobalUserProperties;
+				return ['language'];
 			} );
 	}
 }


### PR DESCRIPTION
@Wikia/services-team 
https://wikia-inc.atlassian.net/browse/SERVICES-733

Even though the preference service is the authority for preference data, we're currently still saving the default value for language (`en`) for every user. This is because of `$wgGlobalUserProperties` usage in [`User->shouldOptionBeStored`](https://github.com/Wikia/app/blob/dev/includes/User.php#L5052), so we should remove the `language` entry from the global and maintain that configuration in the `PreferenceModule`

Since this was the only usage of `$wgGlobalUserProperties`, we can also remove that global now. :tada: 
