### PR TITLE
SEO-68 Add redirect support for URLs missing a character

### DIFF
--- a/extensions/wikia/Custom404Page/Custom404Page.i18n.php
+++ b/extensions/wikia/Custom404Page/Custom404Page.i18n.php
@@ -1,0 +1,17 @@
+<?php
+
+$messages = [];
+
+$messages['en'] = [
+	'custom404page-noarticletext-alternative-found' => '=== \'\'\'Did you mean [[$1]]?\'\'\' ===
+
+Article {{FULLPAGENAME}} was not found. What do you want to do?
+
+* Go to [[$1]] instead
+* Search for <span class="plainlinks">[{{fullurl:Special:Search|search={{urlencode:{{PAGENAME}}}}}} {{PAGENAME}}]</span>
+* Create article <span class="plainlinks">[{{fullurl:{{FULLPAGENAME}}|action=create}} {{FULLPAGENAME}}]</span>',
+];
+
+$messages['qqq'] = [
+	'custom404page-noarticletext-alternative-found' => 'Message shown when the article was not found, but we have an alternative one to direct user to.',
+];

--- a/extensions/wikia/Custom404Page/Custom404Page.setup.php
+++ b/extensions/wikia/Custom404Page/Custom404Page.setup.php
@@ -7,3 +7,6 @@ $wgAutoloadClasses['Custom404PageHooks'] =  __DIR__ . '/Custom404PageHooks.class
 // Hooks
 $wgHooks['BeforeDisplayNoArticleText'][] = 'Custom404PageHooks::onBeforeDisplayNoArticleText';
 $wgHooks['WikiaCanonicalHref'][] = 'Custom404PageHooks::onWikiaCanonicalHref';
+
+// Messages
+$wgExtensionMessagesFiles['Custom404Page'] = __DIR__ . '/Custom404Page.i18n.php';

--- a/extensions/wikia/Custom404Page/Custom404Page.setup.php
+++ b/extensions/wikia/Custom404Page/Custom404Page.setup.php
@@ -1,0 +1,9 @@
+<?php
+
+// Autoload
+$wgAutoloadClasses['Custom404PageBestMatchingPageFinder'] =  __DIR__ . '/Custom404PageBestMatchingPageFinder.class.php';
+$wgAutoloadClasses['Custom404PageHooks'] =  __DIR__ . '/Custom404PageHooks.class.php';
+
+// Hooks
+$wgHooks['BeforeDisplayNoArticleText'][] = 'Custom404PageHooks::onBeforeDisplayNoArticleText';
+$wgHooks['WikiaCanonicalHref'][] = 'Custom404PageHooks::onWikiaCanonicalHref';

--- a/extensions/wikia/Custom404Page/Custom404PageBestMatchingPageFinder.class.php
+++ b/extensions/wikia/Custom404Page/Custom404PageBestMatchingPageFinder.class.php
@@ -52,7 +52,7 @@ class Custom404PageBestMatchingPageFinder {
 
 		$originalLowerCase = mb_strtolower( $originalTitle );
 		$originalLength = mb_strlen( $originalLowerCase );
-		$originalWords = trim( preg_replace( '/\\W+/', ' ', $originalLowerCase ) );
+		$originalWords = trim( preg_replace( '/\\W+/u', ' ', $originalLowerCase ) );
 		$mismatchingCaseTitles = [];
 		$matchingPrefixTitles = [];
 		$matchingPrefixTitlesIncludingSubPages = [];
@@ -117,7 +117,7 @@ class Custom404PageBestMatchingPageFinder {
 
 			if ( $queryResults['numFound'] === 0 ) {
 				// Strip last (maybe incomplete?) word form the title
-				$titleTextStripped = trim( preg_replace( '/\\W*\\w+\\W*$/', '', $titleText ) );
+				$titleTextStripped = trim( preg_replace( '/\\W*\\w+\\W*$/u', '', $titleText ) );
 				if ( !empty( $titleTextStripped ) ) {
 					$queryResults = $this->query( $titleTextStripped, $namespaceId );
 				}

--- a/extensions/wikia/Custom404Page/Custom404PageBestMatchingPageFinder.class.php
+++ b/extensions/wikia/Custom404Page/Custom404PageBestMatchingPageFinder.class.php
@@ -116,8 +116,8 @@ class Custom404PageBestMatchingPageFinder {
 			$queryResults = $this->query( $titleText, $namespaceId );
 
 			if ( $queryResults['numFound'] === 0 ) {
-				// Strip last "word" form the title
-				$titleTextStripped = preg_replace( '/\\W*\\w+\\W*$/', '', $titleText );
+				// Strip last (maybe incomplete?) word form the title
+				$titleTextStripped = trim( preg_replace( '/\\W*\\w+\\W*$/', '', $titleText ) );
 				if ( !empty( $titleTextStripped ) ) {
 					$queryResults = $this->query( $titleTextStripped, $namespaceId );
 				}
@@ -125,7 +125,12 @@ class Custom404PageBestMatchingPageFinder {
 
 			if ( $queryResults['numFound'] < self::MAX_SOLR_RESULTS ) {
 				$titleText = self::findTheBestMatchingTitleText( $titleText, $queryResults['titles'] );
-				return Title::newFromText( $titleText );
+				if ( $titleText ) {
+					$title = Title::newFromText( $titleText );
+					if ( $title->exists() ) {
+						return $title;
+					}
+				}
 			}
 
 		}

--- a/extensions/wikia/Custom404Page/Custom404PageBestMatchingPageFinder.class.php
+++ b/extensions/wikia/Custom404Page/Custom404PageBestMatchingPageFinder.class.php
@@ -62,7 +62,7 @@ class Custom404PageBestMatchingPageFinder {
 			$lowerCase = mb_strtolower( $suggestedTitle );
 			$words = trim( preg_replace( '/\\W+/u', ' ', $lowerCase ) );
 
-			if ( $originalLowerCase == $lowerCase ) {
+			if ( $originalLowerCase === $lowerCase ) {
 				$mismatchingCaseTitles[] = $suggestedTitle;
 			}
 

--- a/extensions/wikia/Custom404Page/Custom404PageBestMatchingPageFinder.class.php
+++ b/extensions/wikia/Custom404Page/Custom404PageBestMatchingPageFinder.class.php
@@ -1,0 +1,135 @@
+<?php
+
+class Custom404PageBestMatchingPageFinder {
+
+	// Maximum sensible number of pages returned by Solr that we can parse to find the one match
+	const MAX_SOLR_RESULTS = 200;
+
+	private function query( $titleIn, $namespaceId ) {
+		global $wgCityId, $wgContLang;
+
+		$titleLowercase = mb_strtolower( $titleIn );
+		$titleQ = str_replace( ['"', '\\'], ' ', $titleLowercase );
+
+		$titleKey = 'title_' . $wgContLang->getCode();
+		$luceneQuery = sprintf(
+			'wid:%d AND ns:%d AND %s:"%s"',
+			$wgCityId,
+			$namespaceId,
+			$titleKey,
+			$titleQ
+		);
+
+		$config = new Wikia\Search\Config();
+		$config->setDirectLuceneQuery( true );
+		$config->setLimit( self::MAX_SOLR_RESULTS );
+		$config->setRequestedFields( ['titleStrict'] );
+		$config->setQuery( $luceneQuery );
+
+		$queryServiceFactory = new Wikia\Search\QueryService\Factory();
+		$response = $queryServiceFactory->getFromConfig( $config )->search();
+		$results = (array) $response->getResults();
+
+		return [
+			'numFound' => $response->getResultsNum(),
+			'titles' => array_map( function ( $result ) {
+				return $result->getFields()['titleStrict'];
+			} , $results )
+		];
+	}
+
+	/**
+	 * Get the title from the suggested titles that matches the best, false for no good match.
+	 *
+	 * This is string-manipulation only: no database or service connection whatsoever.
+	 *
+	 * @param $originalTitle   string
+	 * @param $suggestedTitles array of strings
+	 *
+	 * @return string|bool the best matching string or false
+	 */
+	public function findTheBestMatchingTitleText( $originalTitle, $suggestedTitles ) {
+
+		$originalLowerCase = mb_strtolower( $originalTitle );
+		$originalLength = mb_strlen( $originalLowerCase );
+		$originalWords = trim( preg_replace( '/\\W+/', ' ', $originalLowerCase ) );
+		$mismatchingCaseTitles = [];
+		$matchingPrefixTitles = [];
+		$matchingPrefixTitlesIncludingSubPages = [];
+		$matchingWithoutSpecialsTitles = [];
+
+		foreach ( $suggestedTitles as $suggestedTitle ) {
+			$lowerCase = mb_strtolower( $suggestedTitle );
+			$words = trim( preg_replace( '/\\W+/u', ' ', $lowerCase ) );
+
+			if ( $originalLowerCase == $lowerCase ) {
+				$mismatchingCaseTitles[] = $suggestedTitle;
+			}
+
+			if ( mb_strpos( $lowerCase, $originalLowerCase ) === 0 ) {
+				$reminder = mb_strcut( $lowerCase, $originalLength );
+				if ( mb_strpos( $reminder, '/' ) === false ) {
+					// Don't consider subpages:
+					$matchingPrefixTitles[] = $suggestedTitle;
+				}
+				$matchingPrefixTitlesIncludingSubPages[] = $suggestedTitle;
+			}
+
+			if ( $originalWords == $words ) {
+				$matchingWithoutSpecialsTitles[] = $suggestedTitle;
+			}
+		}
+
+		if ( count( $mismatchingCaseTitles ) === 1 ) {
+			return $mismatchingCaseTitles[0];
+		}
+
+		if ( count( $matchingPrefixTitles ) === 1 ) {
+			return $matchingPrefixTitles[0];
+		}
+
+		if ( count( $matchingWithoutSpecialsTitles ) === 1 ) {
+			return $matchingWithoutSpecialsTitles[0];
+		}
+
+		if ( count( $matchingPrefixTitlesIncludingSubPages ) === 1 ) {
+			return $matchingPrefixTitlesIncludingSubPages[0];
+		}
+
+		return false;
+	}
+
+	/**
+	 * Given a non-existing Title, get an existing one that matching the title the best.
+	 *
+	 * If there's no good match, or there's more than one match, return null
+	 *
+	 * @param Title $title
+	 * @return Title|null
+	 */
+	public function findBestMatchingArticle( Title $title ) {
+
+		$namespaceId = $title->getNamespace();
+		$titleText = $title->getPrefixedText();
+
+		if ( $title->isContentPage() && !$title->exists() ) {
+			$queryResults = $this->query( $titleText, $namespaceId );
+
+			if ( $queryResults['numFound'] === 0 ) {
+				// Strip last "word" form the title
+				$titleTextStripped = preg_replace( '/\\W*\\w+\\W*$/', '', $titleText );
+				if ( !empty( $titleTextStripped ) ) {
+					$queryResults = $this->query( $titleTextStripped, $namespaceId );
+				}
+			}
+
+			if ( $queryResults['numFound'] < self::MAX_SOLR_RESULTS ) {
+				$titleText = self::findTheBestMatchingTitleText( $titleText, $queryResults['titles'] );
+				return Title::newFromText( $titleText );
+			}
+
+		}
+
+		return null;
+	}
+}

--- a/extensions/wikia/Custom404Page/Custom404PageHooks.class.php
+++ b/extensions/wikia/Custom404Page/Custom404PageHooks.class.php
@@ -17,8 +17,8 @@ class Custom404PageHooks {
 	 *
 	 * In case a good matching page is found, we'll:
 	 *  * display a custom no-article text,
-	 *  * set a canonical URL
-	 *  * serve HTTP 200 (instead of 404)
+	 *  * set a canonical URL to the suggested URL,
+	 *  * serve HTTP 200 (instead of 404),
 	 *  * set the robots policy to noindex,follow
 	 *
 	 * If more than one, or none matching pages where found, allow the standard MediaWiki behavior.
@@ -29,10 +29,15 @@ class Custom404PageHooks {
 	 */
 	static public function onBeforeDisplayNoArticleText( Article $article ) {
 
-		$originalTitle = $article->getTitle();
-		$pageFinder = new Custom404PageBestMatchingPageFinder();
+		$title = $article->getTitle();
 
-		$bestMatchingTitle = $pageFinder->findBestMatchingArticle( $originalTitle );
+		if ( $article->getOldID() || !$title || !$title->isContentPage() ) {
+			// MW will treat those cases specially, don't try to direct users to other pages
+			return true;
+		}
+
+		$pageFinder = new Custom404PageBestMatchingPageFinder();
+		$bestMatchingTitle = $pageFinder->findBestMatchingArticle( $title );
 
 		if ( empty( $bestMatchingTitle ) ) {
 			// Just the regular 404 MediaWiki page
@@ -40,16 +45,17 @@ class Custom404PageHooks {
 		}
 
 		// Display the custom 404 page
-		$suggestedTitle = $bestMatchingTitle->getPrefixedText();
+		$text = wfMessage( 'custom404page-noarticletext-alternative-found' )
+			->params( $bestMatchingTitle->getPrefixedText() )
+			->text();
+		$text = '<div class="noarticletext">' . PHP_EOL . $text . PHP_EOL . '</div>';
 
-		$text = "Just go to [[$suggestedTitle]], will'ya?";
-		$text = "<div class='noarticletext'>\n$text\n</div>";
 		$wgOut = $article->getContext()->getOutput();
 		$wgOut->addWikiText( $text );
 		$wgOut->setStatusCode( 200 );
 		$wgOut->setRobotPolicy( 'noindex,follow' );
 
-		self::$canonicalUrlOverride = Title::newFromText( $suggestedTitle )->getFullURL();
+		self::$canonicalUrlOverride = $bestMatchingTitle->getFullURL();
 
 		return false;
 	}

--- a/extensions/wikia/Custom404Page/Custom404PageHooks.class.php
+++ b/extensions/wikia/Custom404Page/Custom404PageHooks.class.php
@@ -1,0 +1,63 @@
+<?php
+
+class Custom404PageHooks {
+
+	/**
+	 * The canonical URL to set
+	 *
+	 * This is set in BeforeDisplayNoArticleText hook and read in WikiaCanonicalHref hook,
+	 * so the order of executing the hooks is critical for this to work.
+	 *
+	 * @var string
+	 */
+	static private $canonicalUrlOverride;
+
+	/**
+	 * Attempt to recover a URL that was truncated by an external service (e.g. Wanted -> Wanted!).
+	 *
+	 * In case a good matching page is found, we'll:
+	 *  * display a custom no-article text,
+	 *  * set a canonical URL
+	 *  * serve HTTP 200 (instead of 404)
+	 *  * set the robots policy to noindex,follow
+	 *
+	 * If more than one, or none matching pages where found, allow the standard MediaWiki behavior.
+	 *
+	 * @param Article $article
+	 *
+	 * @return bool
+	 */
+	static public function onBeforeDisplayNoArticleText( Article $article ) {
+
+		$originalTitle = $article->getTitle();
+		$pageFinder = new Custom404PageBestMatchingPageFinder();
+
+		$bestMatchingTitle = $pageFinder->findBestMatchingArticle( $originalTitle );
+
+		if ( empty( $bestMatchingTitle ) ) {
+			// Just the regular 404 MediaWiki page
+			return true;
+		}
+
+		// Display the custom 404 page
+		$suggestedTitle = $bestMatchingTitle->getPrefixedText();
+
+		$text = "Just go to [[$suggestedTitle]], will'ya?";
+		$text = "<div class='noarticletext'>\n$text\n</div>";
+		$wgOut = $article->getContext()->getOutput();
+		$wgOut->addWikiText( $text );
+		$wgOut->setStatusCode( 200 );
+		$wgOut->setRobotPolicy( 'noindex,follow' );
+
+		self::$canonicalUrlOverride = Title::newFromText( $suggestedTitle )->getFullURL();
+
+		return false;
+	}
+
+	static public function onWikiaCanonicalHref( &$canonicalUrl ) {
+		if ( self::$canonicalUrlOverride ) {
+			$canonicalUrl = self::$canonicalUrlOverride;
+		}
+		return true;
+	}
+}

--- a/extensions/wikia/Custom404Page/tests/Custom404PageTest.php
+++ b/extensions/wikia/Custom404Page/tests/Custom404PageTest.php
@@ -1,0 +1,63 @@
+<?php
+
+class Custom404PageTest extends WikiaBaseTest {
+
+	public function setUp() {
+		global $IP;
+		$this->setupFile = "$IP/extensions/wikia/Custom404Page/Custom404Page.setup.php";
+		parent::setUp();
+	}
+
+	public function dataProviderSuggestedTitles() {
+		return [
+			// One page only
+			['Page 1', ['Page 2'], false],
+
+			// More pages with no easy match
+			['Page 1', ['Page 2', 'Page 3'], false],
+			['Page 1', ['Page 10', 'Page 11'], false],
+			['Page 1', ['Page 1/a', 'Page 1/b'], false],
+
+			// Upper/lowercase
+			['miss piggy', ['A page', 'Miss Piggy', 'Other page'], 'Miss Piggy'],
+			['Miss piggy', ['A page', 'Miss Piggy', 'Other page'], 'Miss Piggy'],
+
+			// Multiple choices for upper/lowercase
+			['Miss piggy', ['A page', 'Miss Piggy', 'Miss PIGGY', 'Other page'], false],
+
+			// Missing character (prefix matches)
+			['Miss Pigg', ['A page', 'Miss Piggy', 'Other page'], 'Miss Piggy'],
+			['Miss Piggy', ['A page', 'Miss Piggy!', 'Other page'], 'Miss Piggy!'],
+
+			// Missing character vs mismatching case
+			['Miss piggy', ['A page', 'Miss Piggy', 'Miss piggy!', 'Other page'], 'Miss Piggy'],
+
+			// Extra/missing non-alphanumerical characters mismatch
+			['John Fitzgerald Kennedy', ['A page', 'John (Fitzgerald) Kennedy', 'Other page'], 'John (Fitzgerald) Kennedy'],
+			['John (Fitzgerald) Kennedy', ['A page', 'John Fitzgerald Kennedy', 'Other page'], 'John Fitzgerald Kennedy'],
+
+			// Subpages -- chose the page that doesn't contain a "/" in the reminder
+			['Miss Pig', ['A page', 'Miss Piggy', 'Miss Piggy/Page 1', 'Miss Piggy/Page 2', 'Miss Piggy/Page 1/Page 2', 'Other page'], 'Miss Piggy'],
+			['Miss Piggy/Page', ['A page', 'Miss Piggy/Page 1', 'Miss Piggy/Page 1/Page 2', 'Miss Piggy/Page 1/Page 3', 'Other page'], 'Miss Piggy/Page 1'],
+
+			// ... Unless it's the only match
+			['Miss Piggy/Page', ['A page', 'Miss Piggy/Page 1/Page 2', 'Other page'], 'Miss Piggy/Page 1/Page 2'],
+		];
+	}
+
+	/**
+	 * Test findTheBestMatchingTitleText
+	 *
+	 * @covers Custom404PageBestMatchingPageFinder::findTheBestMatchingTitleText
+	 * @dataProvider dataProviderSuggestedTitles
+	 *
+	 * @param $originalTitle   string the original title
+	 * @param $suggestedTitles array  array of titles matching according to the Solr search
+	 * @param $expectedOut     mixed  the expected title selected
+	 */
+	public function testFindTheBestMatchingTitleText( $originalTitle, $suggestedTitles, $expectedOut ) {
+		$pageFinder = new Custom404PageBestMatchingPageFinder();
+		$actualOut = $pageFinder->findTheBestMatchingTitleText( $originalTitle, $suggestedTitles );
+		$this->assertEquals( $expectedOut, $actualOut );
+	}
+}

--- a/extensions/wikia/SEOTweaks/SEOTweaksHooksHelper.class.php
+++ b/extensions/wikia/SEOTweaks/SEOTweaksHooksHelper.class.php
@@ -128,7 +128,7 @@ class SEOTweaksHooksHelper {
 	static public function onArticleViewHeader( &$article, &$outputDone, &$pcache ) {
 		global $wgEnableCustom404PageExt;
 
-		if ( $wgEnableCustom404PageExt ) {
+		if ( !empty( $wgEnableCustom404PageExt ) ) {
 			// Custom404Page does the same, just better
 			return true;
 		}

--- a/extensions/wikia/SEOTweaks/SEOTweaksHooksHelper.class.php
+++ b/extensions/wikia/SEOTweaks/SEOTweaksHooksHelper.class.php
@@ -126,6 +126,13 @@ class SEOTweaksHooksHelper {
 	 * @param bool $pcache
 	 */
 	static public function onArticleViewHeader( &$article, &$outputDone, &$pcache ) {
+		global $wgEnableCustom404PageExt;
+
+		if ( $wgEnableCustom404PageExt ) {
+			// Custom404Page does the same, just better
+			return true;
+		}
+
 		$title = $article->getTitle();
 		if ( !$title->exists()
 				&& $title->isContentPage()

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1813,13 +1813,6 @@ $wgPreferenceServiceRead = false;
 $wgPreferenceServiceWrite = true;
 
 /**
- * @name $wgEnableRobotsTxtExt
- *
- * Enables extension that generates robots.txt
- */
-$wgEnableRobotsTxtExt = true;
-
-/**
  * @name $wgEnableFliteTagExt
  *
  * Enables FliteTag extension which makes it possible to use <flite> tag within an article content
@@ -1827,6 +1820,20 @@ $wgEnableRobotsTxtExt = true;
 $wgEnableFliteTagExt = false;
 
 // SEO-related variables start (keep them sorted)
+
+/**
+ * @name $wgEnableCustom404PageExt
+ *
+ * Enables custom 404 page for missing articles suggesting the closest matching article
+ */
+$wgEnableCustom404PageExt = true;
+
+/**
+ * @name $wgEnableRobotsTxtExt
+ *
+ * Enables extension that generates robots.txt
+ */
+$wgEnableRobotsTxtExt = true;
 
 /**
  * @name $wgEnableSeoLinkHreflangExt

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1826,7 +1826,7 @@ $wgEnableFliteTagExt = false;
  *
  * Enables custom 404 page for missing articles suggesting the closest matching article
  */
-$wgEnableCustom404PageExt = true;
+$wgEnableCustom404PageExt = false;
 
 /**
  * @name $wgEnableRobotsTxtExt


### PR DESCRIPTION
The SEO effect on redirecting from Mapping_keys_in_Vim_-_Tutorial_(Part_2 to
Mapping_keys_in_Vim_-_Tutorial_(Part_2) is minimal, it's mostly about the UX.

A good "No such article page" should do the following:
1. Inform there's no such article
2. If there's a really good match (like just a missing character in the URL), suggest the article you wanted
3. Allow you to create the page (if appropriate)
4. Let you search for other pages

SEO-wise only the second part is important. If we believe there is an article that user/crawler meant to go to,
the page should serve HTTP 200 with a link to the suggested page and canonical URL set to the suggested page.
Otherwise this should be a regular HTTP 404.

Note:

We don't do a HTTP redirect because this means users cannot create page that matches some other URL. For example
if there's already /wiki/R2D20 users won't be able to create /wiki/R2D2 .
