### PR TITLE
CE-2853 Enable marking templates as not-needing classification

### DIFF
--- a/extensions/wikia/TemplateClassification/TemplateClassification.hooks.php
+++ b/extensions/wikia/TemplateClassification/TemplateClassification.hooks.php
@@ -2,6 +2,8 @@
 
 namespace Wikia\TemplateClassification;
 
+use Wikia\TemplateClassification\UnusedTemplates\Handler;
+
 class Hooks {
 
 	public static function register() {
@@ -9,14 +11,22 @@ class Hooks {
 		\Hooks::register( 'QueryPageUseResultsBeforeRecache', [ $hooks, 'onQueryPageUseResultsBeforeRecache' ] );
 	}
 
-	public function onQueryPageUseResultsBeforeRecache( $queryCacheType, $results ) {
-		if ( $queryCacheType === \UnusedtemplatesPage::UNUSED_TEMPLATES_PAGE_NAME ) {
+	public function onQueryPageUseResultsBeforeRecache( \QueryPage $queryPage, $results ) {
+		if ( $queryPage->getName() === \UnusedtemplatesPage::UNUSED_TEMPLATES_PAGE_NAME ) {
+			$handler = $this->getUnusedTemplatesHandler();
 			if ( $results instanceof \ResultWrapper ) {
-				// Mark these results as not-needing classification
+				$handler->markAsUnusedFromResults( $results );
 			} else {
-				// Mark all templates as needing classification
+				$handler->markAllAsUsed();
 			}
 		}
 		return true;
+	}
+
+	/**
+	 * @return Handler
+	 */
+	protected function getUnusedTemplatesHandler() {
+		return new Handler();
 	}
 }

--- a/extensions/wikia/TemplateClassification/TemplateClassification.setup.php
+++ b/extensions/wikia/TemplateClassification/TemplateClassification.setup.php
@@ -27,3 +27,8 @@ $wgExtensionCredits['other'][] = [
  */
 $wgAutoloadClasses['Wikia\TemplateClassification\Hooks'] = __DIR__ . '/TemplateClassification.hooks.php';
 $wgExtensionFunctions[] = 'Wikia\TemplateClassification\Hooks::register';
+
+/**
+ * UnusedTemplates
+ */
+$wgAutoloadClasses['Wikia\TemplateClassification\UnusedTemplates\Handler'] = __DIR__ . '/UnusedTemplates/UnusedTemplatesHandler.class.php';

--- a/extensions/wikia/TemplateClassification/UnusedTemplates/UnusedTemplatesHandler.class.php
+++ b/extensions/wikia/TemplateClassification/UnusedTemplates/UnusedTemplatesHandler.class.php
@@ -2,7 +2,7 @@
 
 namespace Wikia\TemplateClassification\UnusedTemplates;
 
-class Handler extends \WikiaService {
+class Handler {
 	/**
 	 * Reflects a `propname` in the `page_wikia_props` table.
 	 */

--- a/extensions/wikia/TemplateClassification/UnusedTemplates/UnusedTemplatesHandler.class.php
+++ b/extensions/wikia/TemplateClassification/UnusedTemplates/UnusedTemplatesHandler.class.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Wikia\TemplateClassification\UnusedTemplates;
+
+class Handler extends \WikiaService {
+	/**
+	 * Reflects a `propname` in the `page_wikia_props` table.
+	 */
+	const PROPERTY_NAME = 11000;
+	const USED = 1;
+	const UNUSED = 0;
+
+	/**
+	 * Checks if a template is used and needs to be classified because of that.
+	 * Returns true if a property is NOT FOUND for a given pageId
+	 * or if the property's value indicates that it is used.
+	 *
+	 * @param int $pageId
+	 * @return bool
+	 */
+	public function isUsed( $pageId ) {
+		$db = $this->getDatabaseForRead();
+
+		$row = $db->selectRow(
+			'page_wikia_props',
+			[ 'props' ],
+			[
+				'page_id' => (int)$pageId,
+				'propname' => self::PROPERTY_NAME,
+			]
+		);
+
+		if ( is_object( $row ) ) {
+			return (int)$row->props === self::USED;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Uses `title` fields of the rows to mark given templates as unused.
+	 * It resets the data first using the markAllAsUsed method.
+	 *
+	 * @param \ResultWrapper $results
+	 * @param \DatabaseBase $db
+	 * @return bool
+	 * @throws \MWException
+	 */
+	public function markAsUnusedFromResults( \ResultWrapper $results, \DatabaseBase $db = null ) {
+		if ( $db === null ) {
+			$db = $this->getDatabaseForWrite();
+		}
+
+		$this->markAllAsUsed( $db );
+
+		$insertRows = $this->getInsertRowsFromResults( $results );
+		if ( empty( $insertRows ) ) {
+			return false;
+		}
+
+		$db->begin( __METHOD__ );
+
+		try {
+			$db->upsert(
+				'page_wikia_props',
+				$insertRows,
+				[ 'page_id', 'propname' ],
+				[ 'props' => self::UNUSED ]
+			);
+			$db->commit( __METHOD__ );
+		} catch ( \MWException $e ) {
+			$db->rollback( __METHOD__ );
+			throw $e;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Marks all templates on a given wikia as used.
+	 * It only updates the `page_wikia_props` table since we assume
+	 * that if a template is not there - it is used.
+	 *
+	 * @param \DatabaseBase $db
+	 * @return true
+	 * @throws \MWException
+	 */
+	public function markAllAsUsed( \DatabaseBase $db = null ) {
+		if ( $db === null ) {
+			$db = $this->getDatabaseForWrite();
+		}
+
+		$db->begin( __METHOD__ );
+
+		try {
+			$db->update(
+				'page_wikia_props',
+				[ 'props' => self::USED ],
+				[ 'propname' => self::PROPERTY_NAME ],
+				__METHOD__
+			);
+
+			$db->commit( __METHOD__ );
+			$db->close();
+		} catch ( \MWException $e ) {
+			$db->rollback( __METHOD__ );
+			throw $e;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Converts results with a `title` property to an array of IDs of pages.
+	 *
+	 * @param \ResultWrapper $results
+	 * @return array
+	 */
+	protected function getInsertRowsFromResults( \ResultWrapper $results ) {
+		$insertRows = [];
+
+		while ( $row = $results->fetchObject() ) {
+			if ( !isset( $row->title ) ) {
+				continue;
+			}
+
+			$title = \Title::newFromText( $row->title, NS_TEMPLATE );
+			if ( $title === null ) {
+				continue;
+			}
+
+			$pageId = $title->getArticleID();
+			if ( $pageId !== 0 ) {
+				$insertRows[] = [
+					'page_id' => $pageId,
+					'propname' => self::PROPERTY_NAME,
+					'props' => self::UNUSED,
+				];
+			}
+		}
+
+		return $insertRows;
+	}
+
+	/**
+	 * @return \DatabaseMysqli
+	 */
+	protected function getDatabaseForRead() {
+		return wfGetDB( DB_SLAVE );
+	}
+
+	/**
+	 * @return \DatabaseMysqli
+	 */
+	protected function getDatabaseForWrite() {
+		return wfGetDB( DB_MASTER );
+	}
+}

--- a/extensions/wikia/TemplateClassification/tests/TemplateClassificationHooksTest.php
+++ b/extensions/wikia/TemplateClassification/tests/TemplateClassificationHooksTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * Unit tests for TC Hooks
+ */
+
+class TemplateClassificationHooksTest extends WikiaBaseTest {
+
+	public function setUp() {
+		$this->setupFile = __DIR__ . '/../TemplateClassification.setup.php';
+		parent::setUp();
+	}
+
+	public function testQueryPageBeforeRecacheWrongPage() {
+		$queryPageMock = $this->getMock( 'UnusedtemplatesPage', [ 'getName' ] );
+		$queryPageMock
+			->expects( $this->once() )
+			->method( 'getName' )
+			->willReturn( 'invalid special page name' );
+
+		$hooksMock = $this->getHooksMockForUnusedTemplates();
+		$hooksMock->expects( $this->never() )->method( 'getUnusedTemplatesHandler' );
+
+		$resultsMock = $this->getMock( 'ResultWrapper' );
+
+		$hooksMock->onQueryPageUseResultsBeforeRecache( $queryPageMock, $resultsMock );
+	}
+
+	public function testQueryPageBeforeRecacheNoResults() {
+		$queryPage = new UnusedtemplatesPage();
+
+		$handlerMock = $this->getUnusedTemplatesHandlerMock();
+		$handlerMock->expects( $this->once() )
+			->method( 'markAllAsUsed' );
+
+		$hooksMock = $this->getHooksMockForUnusedTemplates();
+		$hooksMock
+			->expects( $this->once() )
+			->method( 'getUnusedTemplatesHandler' )
+			->willReturn( $handlerMock );
+
+		$results = false;
+
+		$hooksMock->onQueryPageUseResultsBeforeRecache( $queryPage, $results );
+	}
+
+	public function testQueryPageBeforeRecacheGoodResults() {
+		$queryPage = new UnusedtemplatesPage();
+
+		$handlerMock = $this->getUnusedTemplatesHandlerMock();
+		$handlerMock->expects( $this->once() )
+			->method( 'markAsUnusedFromResults' );
+
+		$hooksMock = $this->getHooksMockForUnusedTemplates();
+		$hooksMock
+			->expects( $this->once() )
+			->method( 'getUnusedTemplatesHandler' )
+			->willReturn( $handlerMock );
+
+		$results = $this->getMock( 'ResultWrapper' );
+
+		$hooksMock->onQueryPageUseResultsBeforeRecache( $queryPage, $results );
+	}
+
+	/**
+	 * @return PHPUnit_Framework_MockObject_MockObject
+	 */
+	private function getHooksMockForUnusedTemplates() {
+		return $this->getMock( 'Wikia\TemplateClassification\Hooks', [
+			'getUnusedTemplatesHandler',
+		] );
+	}
+
+	/**
+	 * @return PHPUnit_Framework_MockObject_MockObject
+	 */
+	private function getUnusedTemplatesHandlerMock() {
+		return $this->getMock( 'Wikia\TemplateClassification\UnusedTemplates\Handler', [
+			'markAsUnusedFromResults',
+			'markAllAsUsed',
+		] );
+	}
+}

--- a/extensions/wikia/TemplateClassification/tests/UnusedTemplates/UnusedTemplatesHandlerTest.php
+++ b/extensions/wikia/TemplateClassification/tests/UnusedTemplates/UnusedTemplatesHandlerTest.php
@@ -1,0 +1,74 @@
+<?php
+
+class UnusedTemplatesHandlerTest extends WikiaBaseTest {
+
+	public function setUp() {
+		$this->setupFile = __DIR__ . '/../../TemplateClassification.setup.php';
+		parent::setUp();
+	}
+
+	/**
+	 * @dataProvider isUsedDataProvider
+	 */
+	public function testIsUsed( $selectResult, $expected, $message ) {
+		$dbMock = $this->getMock( 'DatabaseMysqli', [ 'selectRow' ] );
+		$dbMock->expects( $this->once() )
+			->method( 'selectRow' )
+			->willReturn( $selectResult );
+
+		$handlerMock = $this->getMock( 'Wikia\TemplateClassification\UnusedTemplates\Handler', [
+			'getDatabaseForRead'
+		] );
+		$handlerMock->expects( $this->once() )
+			->method( 'getDatabaseForRead' )
+			->willReturn( $dbMock );
+
+		$this->assertSame( $expected, $handlerMock->isUsed( 123 ), $message );
+	}
+
+	/**
+	 * A simple test that checks if the `markAsUnusedFromResults` method will quit
+	 * early and return `false` if no valid pageIds are generated from the results.
+	 */
+	public function testMarkAsUnusedFromResultsInvalidData() {
+		$resultsMock = $this->getMock( 'ResultWrapper' );
+
+		$dbMock = $this->getMock( 'DatabaseMysqli', [ 'begin' ] );
+		$dbMock->expects( $this->never() )
+			->method( 'begin' );
+
+		$handlerMock = $this->getMock( 'Wikia\TemplateClassification\UnusedTemplates\Handler', [
+			'markAllAsUsed',
+			'getInsertRowsFromResults',
+		] );
+
+		$handlerMock->expects( $this->once() )
+			->method( 'getInsertRowsFromResults' )
+			->willReturn( [] );
+
+		$this->assertFalse( $handlerMock->markAsUnusedFromResults( $resultsMock, $dbMock ) );
+	}
+
+	/**
+	 * @return array
+	 */
+	public function isUsedDataProvider() {
+		return [
+			[
+				false,
+				true,
+				'The selectRow method returns false (no results) so we assume the template is used.',
+			],
+			[
+				(object)[ 'props' => 1 ],
+				true,
+				'The selectRow method returns an object and the `props` field value indicates the template is used',
+			],
+			[
+				(object)[ 'props' => 0 ],
+				false,
+				'The selectRow method returns an object and the `props` field value indicates the template is unused',
+			],
+		];
+	}
+}

--- a/includes/QueryPage.php
+++ b/includes/QueryPage.php
@@ -292,6 +292,17 @@ abstract class QueryPage extends SpecialPage {
 		# Do query
 		$res = $this->reallyDoQuery( $limit, false );
 		$num = false;
+
+		/**
+		 * Wikia change begin
+		 * @author <adamk@wikia-inc.com>
+		 */
+		$resClone = clone $res;
+		wfRunHooks( 'QueryPageUseResultsBeforeRecache', [ $this, $resClone ] );
+		/**
+		 * Wikia change end
+		 */
+
 		if ( $res ) {
 			$num = $dbr->numRows( $res );
 			# Fetch results

--- a/includes/specials/SpecialUnusedtemplates.php
+++ b/includes/specials/SpecialUnusedtemplates.php
@@ -30,8 +30,9 @@
  * @ingroup SpecialPage
  */
 class UnusedtemplatesPage extends QueryPage {
+	const UNUSED_TEMPLATES_PAGE_NAME = 'Unusedtemplates';
 
-	function __construct( $name = 'Unusedtemplates' ) {
+	function __construct( $name = self::UNUSED_TEMPLATES_PAGE_NAME ) {
 		parent::__construct( $name );
 	}
 


### PR DESCRIPTION
This PR enables marking templates as not-needing classification and storing the information in `page_wikia_props`. If a template's ID is not present in the table we assume that the template is used and needs to be classified. The same goes for a property value (`props`) being `1`. Only if the template is deliberately marked as `0` - we consider it unused.

/cc: @Wikia/community-engineering 
