### PR TITLE
SERVICE-873: Sampling InfluxDb stats at 25%

### DIFF
--- a/includes/context/RequestContext.php
+++ b/includes/context/RequestContext.php
@@ -239,9 +239,15 @@ class RequestContext implements IContextSource {
 			return;
 		}
 
-		$sampler = new \Wikia\Util\Statistics\BernoulliTrial( 0.05 );
+		$sampler = new \Wikia\Util\Statistics\BernoulliTrial( 0.25 );
 
-		\Transaction::addEvent( \Transaction::EVENT_USER_AUTH, $authSource );
+		// send every 4-th request to InfluxDb
+		if ( $sampler->shouldSample() ) {
+			\Transaction::addEvent( \Transaction::EVENT_USER_AUTH, $authSource );
+		}
+
+		// now we sample logging at 5%
+		$sampler->setProbability( 0.05 );
 
 		if ( !$sampler->shouldSample() ) {
 			return;


### PR DESCRIPTION
To be safe and not to overload Scribe we will sample InfluxDb data at 25%.

@Wikia/services-team 
