### PR TITLE
Added X-Forwared-For for all HeliosClient calls (SERVICES-913)

### DIFF
--- a/lib/Wikia/src/Service/Helios/HeliosClientImpl.php
+++ b/lib/Wikia/src/Service/Helios/HeliosClientImpl.php
@@ -60,6 +60,18 @@ class HeliosClientImpl implements HeliosClient
 		// Request URI pre-processing.
 		$uri = "{$this->baseUri}{$resourceName}?" . http_build_query($getParams);
 
+		// Appending the request remote IP for client to be able to
+		// identify the source of the remote request.
+		if ( isset( $extraRequestOptions['headers'] ) ) {
+			$headers = $extraRequestOptions['headers'];
+			unset( $extraRequestOptions['headers'] );
+		} else {
+			$headers = [];
+		}
+
+		global $wgRequest;
+		$headers['X-Forwarded-For'] = $wgRequest->getIP();
+
 		// Request options pre-processing.
 		$options = [
 			'method'          => 'GET',
@@ -69,6 +81,7 @@ class HeliosClientImpl implements HeliosClient
 			'followRedirects' => false,
 			'returnInstance'  => true,
 			'internalRequest' => true,
+			'headers'         => $headers,
 		];
 
 		$options = array_merge( $options, $extraRequestOptions );


### PR DESCRIPTION
We need a way for Helios client and other services to identify source of the request even it was forwarded by Media Wiki. Now all calls through HeliosClient will get additional header `X-Forwarded-For` to allow backend services to detect if user's IP is blocked etc.

@Wikia/services-team 
