### PR TITLE
MAIN-4228: limit wall replies to 500 per thread

### DIFF
--- a/extensions/wikia/Wall/Wall.i18n.php
+++ b/extensions/wikia/Wall/Wall.i18n.php
@@ -66,6 +66,7 @@ $messages['en'] = array(
 	'wall-message-closed-by' => "[[$2|$1]] closed this thread",
 	'wall-message-closed-by-because' => "$1 closed this thread because:",
 	'wall-message-restore-reply' => "Restore Reply",
+	'wall-message-limit-reached' => "There is a limit of $1 posts per thread.",
 	'wall-delete-reason' => "User/admin action",
 	'wall-user-talk-page-archive-anchor' => 'See archived talk page',
 	'wall-user-talk-archive-page-title' => 'User_talk_archive',
@@ -419,6 +420,7 @@ $messages['qqq'] = array(
 	'wall-message-closed-by-because' => 'Summary at the top of a closed thread page. Parameters:
 * $1 is the user who closed the thread (GENDER is supported in this message).',
 	'wall-message-restore-reply' => 'Button to restore a reply on a removed reply page',
+	'wall-message-limit-reached' => 'Error message displayed instead of edit form when thread reaches the maximum number of replies',
 	'wall-delete-reason' => 'default user/admin action',
 	'wall-user-talk-page-archive-anchor' => "Link on a Message Wall page to the user's old talk page archive",
 	'wall-user-talk-archive-page-title' => "Title on a user's talk page archive",

--- a/extensions/wikia/Wall/WallBaseController.class.php
+++ b/extensions/wikia/Wall/WallBaseController.class.php
@@ -212,6 +212,7 @@ class WallBaseController extends WikiaController {
 			$replies = $this->getVal( 'replies', array() );
 			$repliesCount = count( $replies );
 			$this->response->setVal( 'repliesNumber', $repliesCount );
+			$this->response->setVal( 'repliesLimit', WallThread::FETCHED_REPLIES_LIMIT);
 			$this->response->setVal( 'showRepliesNumber', $repliesCount );
 			$this->response->setVal( 'showLoadMore', false );
 

--- a/extensions/wikia/Wall/WallThread.class.php
+++ b/extensions/wikia/Wall/WallThread.class.php
@@ -112,6 +112,7 @@ class WallThread {
 
 		$lastId = end( $list );
 
+		// TODO: add pagination or a limit here because this will return all replies
 		return empty( $lastId ) ? $list :
 			array_merge( $list, $this->getReplyIdsFromDB( $dbr, $lastId ) );
 	}

--- a/extensions/wikia/Wall/templates/Wall_message.php
+++ b/extensions/wikia/Wall/templates/Wall_message.php
@@ -1,13 +1,13 @@
-<li class="SpeechBubble message <?php echo ($isreply ? '':'message-main'); ?> <?php echo ($removedOrDeletedMessage ? 'hide ':'') . ($showRemovedBox?' message-removed':''); ?> <? echo 'message-'.$linkid ?>" id="<? echo $linkid ?>" data-id="<? echo $id ?>" data-is-reply="<?= $isreply == true ?>" <? if($collapsed):?> style="display:none" <? endif;?> >	
+<li class="SpeechBubble message <?php echo ($isreply ? '':'message-main'); ?> <?php echo ($removedOrDeletedMessage ? 'hide ':'') . ($showRemovedBox?' message-removed':''); ?> <? echo 'message-'.$linkid ?>" id="<? echo $linkid ?>" data-id="<? echo $id ?>" data-is-reply="<?= $isreply == true ?>" <? if($collapsed):?> style="display:none" <? endif;?> >
 	<?php echo $head ?>
 	<?php echo $app->renderView( 'WallController', 'statusInfoBox', array('showDeleteOrRemoveInfo' => $showDeleteOrRemoveInfo, 'comment' => $comment) ); ?>
-	
+
 	<? if($showRemovedBox): ?>
 		<div class='removed-info speech-bubble-message-removed' >
 			<?php echo wfMsg('wall-removed-reply'); ?>
 		</div>
 	<? endif; ?>
-	
+
 	<div class="speech-bubble-avatar">
 		<a href="<?= $user_author_url ?>">
 			<? if(!$isreply): ?>
@@ -17,7 +17,7 @@
 			<? endif ?>
 		</a>
 	</div>
-	
+
 	<div class="speech-bubble-message">
 		<? if(!$isreply): ?>
 			<?php if($isWatched): ?>
@@ -31,16 +31,16 @@
 			<div class="voting-controls">
 				<a class="votes<?= $votes > 0 ? "" : " notlink" ?>" data-votes="<?= $votes ?>">
 					<?= wfMsg('wall-votes-number', '<span class="number" >'.$votes.'</span>') ?>
-				</a>			
+				</a>
 				<?php if($canVotes):?>
 					<a class="vote <?php if($isVoted): ?>voted<?php endif;?>">
 						<img src="<?= $wg->BlankImgUrl ?>" height="19" width="19" >
 					</a>
 				<?php endif; ?>
 			</div>
-		<?php endif; ?>	
-		
-		
+		<?php endif; ?>
+
+
 		<? if ( $wg->EnableMiniEditorExtForWall ):
 			echo $app->renderPartialCached( 'MiniEditorController', 'Header', 'Wall_message', array(
 				'attributes' => array( 'data-min-height' => 100, 'data-max-height' => 400 )
@@ -49,7 +49,7 @@
 		<? if(!$isreply): ?>
 			<div class="msg-title"><a href="<?= $fullpageurl; ?>"><? echo $feedtitle ?></a></div>
 		<? endif; ?>
-		
+
 		<div class="edited-by">
 			<a href="<?= $user_author_url ?>"><?= $displayname ?></a>
 			<a href="<?= $user_author_url ?>" class="subtle"><?= $displayname2 ?></a>
@@ -57,7 +57,7 @@
 				<span class="stafflogo"></span>
 			<?php endif; ?>
 		</div>
-		
+
 		<?php if($quote_of): ?>
 		<div class="quote-of">
 			<a href="<?php echo $quote_of_url; ?>" data-postfix="<?php echo $quote_of_postfix; ?>" >
@@ -65,7 +65,7 @@
 			</a>
 		</div>
 		<?php endif; ?>
-		
+
 		<? if ( $wg->EnableMiniEditorExtForWall ):
 			echo $app->renderPartialCached( 'MiniEditorController', 'Editor_Header', 'Wall_message' );
 		endif; ?>
@@ -78,9 +78,9 @@
 		<div class="msg-toolbar">
 			<div class="timestamp">
 				<?php if($isEdited):?>
-					<? if($showSummary): ?> 
+					<? if($showSummary): ?>
 						<? echo wfMsg('wall-message-edited-summary', array('$1' => $summary, '$2' => $editorUrl, '$3' => $editorName, '$4' => $historyUrl )); ?>
-					<? else: ?> 	
+					<? else: ?>
 						<? echo wfMsg('wall-message-edited', array( '$1' => $editorUrl, '$2' => $editorName, '$3' => $historyUrl )); ?>
 					<? endif; ?>
 				<?php endif; ?>
@@ -102,9 +102,9 @@
 			echo $app->renderPartialCached( 'MiniEditorController', 'Footer', 'Wall_message' );
 		endif; ?>
 	</div>
-	
+
 	<?php echo $app->renderView( 'WallController', 'statusInfoBox', array('showDeleteOrRemoveInfo' => $showClosedBox, 'comment' => $comment) ); ?>
-	
+
 	<? if(!$isreply): ?>
 		<ul class="replies">
 			<? if(!empty($replies)): ?>
@@ -122,7 +122,11 @@
 					<? $i++; ?>
 				<? endforeach; ?>
 			<? endif; ?>
-			<?= $app->renderViewCached( 'WallController', 'reply', 'Wall_message'.$showReplyForm, array('showReplyForm' => $showReplyForm )); ?>
+			<? if( $repliesNumber < $repliesLimit ) {
+				echo $app->renderViewCached( 'WallController', 'reply', 'Wall_message'.$showReplyForm, array('showReplyForm' => $showReplyForm ));
+			} else {
+				echo "<div class=message-topic-error >" . wfMsgExt('wall-message-limit-reached', array('parsemag'), array( $repliesLimit ));
+			} ?>
 			<?php if($showTopics): ?>
 				<?= F::app()->renderPartial( 'Wall', 'relatedTopics', array('relatedTopics' => $relatedTopics) ) ?>
 			<?php endif; ?>


### PR DESCRIPTION
FETCHED_REPLIES_LIMIT is 500 which seems like a reasonable number of replies in a thread.
This patch just shuts off the edit box when that limit is reached.  A better long term fix is to add pagination. 
