### PR TITLE
(CE-2841) Disable transactions on SMW temp table queries

### DIFF
--- a/extensions/wikia/SemanticMediaWiki/includes/storage/SQLStore/SMW_SQLStore3.php
+++ b/extensions/wikia/SemanticMediaWiki/includes/storage/SQLStore/SMW_SQLStore3.php
@@ -350,7 +350,9 @@ class SMWSQLStore3 extends SMWStore {
 	public function getQueryResult( SMWQuery $query ) {
 		wfProfileIn( 'SMWSQLStore3::getQueryResult (SMW)' );
 
-		$qe = new SMWSQLStore3QueryEngine( $this, wfGetDB( DB_SLAVE, 'smw' ) );
+		$dbr = wfGetDB( DB_SLAVE, 'smw' );
+		$dbr->clearFlag( DBO_TRX );
+		$qe = new SMWSQLStore3QueryEngine( $this, $dbr );
 		$result = $qe->getQueryResult( $query );
 		wfProfileOut( 'SMWSQLStore3::getQueryResult (SMW)' );
 

--- a/extensions/wikia/SemanticMediaWiki/includes/storage/compatSQLStore/SMW_SQLStore2.php
+++ b/extensions/wikia/SemanticMediaWiki/includes/storage/compatSQLStore/SMW_SQLStore2.php
@@ -1008,7 +1008,9 @@ class SMWSQLStore2 extends SMWStore {
 		global $smwgIP;
 		include_once( "$smwgIP/includes/storage/compatSQLStore/SMW_SQLStore2_Queries.php" );
 
-		$qe = new SMWSQLStore2QueryEngine( $this, wfGetDB( DB_SLAVE, 'smw' ) );
+		$dbr = wfGetDB( DB_SLAVE, 'smw' );
+		$dbr->clearFlag( DBO_TRX );
+		$qe = new SMWSQLStore2QueryEngine( $this, $dbr );
 		$result = $qe->getQueryResult( $query );
 		wfProfileOut( 'SMWSQLStore2::getQueryResult (SMW)' );
 
@@ -1071,6 +1073,7 @@ class SMWSQLStore2 extends SMWStore {
 
 		wfProfileIn( "SMWSQLStore2::getUnusedPropertiesSpecial (SMW)" );
 		$db = wfGetDB( DB_SLAVE, 'smw' );
+		$db->clearFlag( DBO_TRX );
 
 		// we use a temporary table for executing this costly operation on the DB side
 		$smw_tmp_unusedprops = $db->tableName( 'smw_tmp_unusedprops' );


### PR DESCRIPTION
Disable transactions on SMW temp table queries on slave connections.
MediaWiki automatically creates transactions a lot of the time, and
creating temporary tables in a transaction is not replication-safe
and causes errors in MySQL 5.6.

/cc @Wikia/community-engineering @drozdo 
