### PR TITLE
WikiFactoryTags::getTags - optimize the query

### DIFF
--- a/extensions/wikia/WikiFactory/Tags/WikiFactoryTags.php
+++ b/extensions/wikia/WikiFactory/Tags/WikiFactoryTags.php
@@ -109,8 +109,7 @@ class WikiFactoryTags {
 				array( "city_tag", "city_tag_map" ),
 				array( "tag_id", "name" ),
 				array( "tag_id = id", "city_id" => $this->mCityId ),
-				__METHOD__,
-				array( "ORDER BY" => "name" )
+				__METHOD__
 			);
 			while( $row = $dbr->fetchObject( $sth ) ) {
 				$result[ $row->tag_id ] = $row->name;


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-1590

No need to `ORDER BY name` as it causes `Using temporary; Using filesort`

```
+----+-------------+--------------+--------+----------------+---------+---------+--------------------------------+------+----------------------------------------------+
| id | select_type | table        | type   | possible_keys  | key     | key_len | ref                            | rows | Extra                                        |
+----+-------------+--------------+--------+----------------+---------+---------+--------------------------------+------+----------------------------------------------+
|  1 | SIMPLE      | city_tag_map | ref    | PRIMARY,tag_id | PRIMARY | 4       | const                          |    1 | Using index; Using temporary; Using filesort |
|  1 | SIMPLE      | city_tag     | eq_ref | PRIMARY        | PRIMARY | 4       | wikicities.city_tag_map.tag_id |    1 |                                              |
+----+-------------+--------------+--------+----------------+---------+---------+--------------------------------+------+----------------------------------------------+
```

@drozdo / @michalroszka / @wladekb / @owend 
