### PR TITLE
(SEC-14) Don't process message further when replacing rawParams

### DIFF
--- a/resources/mediawiki/mediawiki.js
+++ b/resources/mediawiki/mediawiki.js
@@ -266,6 +266,8 @@ var mw = ( function ( $, undefined ) {
 				text = mw.html.escape( text );
 			}
 
+			// The raw replacesments shouldn't go through any more transformations
+			this.format = 'plain';
 			text = this.parser( text, true );
 
 			return text;

--- a/resources/src/mediawiki/mediawiki.jqueryMsg.js
+++ b/resources/src/mediawiki/mediawiki.jqueryMsg.js
@@ -1217,7 +1217,7 @@
 
 	// Replace the default message parser with jqueryMsg
 	oldParser = mw.Message.prototype.parser;
-	mw.Message.prototype.parser = function () {
+	mw.Message.prototype.parser = function ( messageContent, insertRaw ) {
 		var messageFunction;
 
 		// TODO: should we cache the message function so we don't create a new one every time? Benchmark this maybe?
@@ -1226,7 +1226,7 @@
 		// Do not use mw.jqueryMsg unless required
 		if ( this.format === 'plain' || !/\{\{|[\[<>]/.test( this.map.get( this.key ) ) ) {
 			// Fall back to mw.msg's simple parser
-			return oldParser.apply( this );
+			return oldParser.apply( this, [ messageContent, insertRaw ] );
 		}
 
 		messageFunction = mw.jqueryMsg.getMessageFunction( {


### PR DESCRIPTION
In https://github.com/Wikia/app/pull/8457 we added the ability to
supply rawParams to mw.message so that they would be passed after
the message is escaped. But if the jqueryMsg library is loaded, the
current implementation means this becomes unescaped because rather
than using the parser in mediawiki.js, it uses the parser in jqueryMsg
again. The jqueryMsg parser actually unescapes text because it
expects mediawiki.js to escape the text after the parser is run, which
we're running again after escaping.

/cc @lukaszkonieczny @macbre @kvas-damian 
