### PR TITLE
Always sample the authentication method unless the user is null or not logged in

### DIFF
--- a/includes/context/RequestContext.php
+++ b/includes/context/RequestContext.php
@@ -235,7 +235,7 @@ class RequestContext implements IContextSource {
 	 * @param $authSource array
 	 */
 	private function logAuthenticationMethod($user, $authSource) {
-		if ( count( $authSource ) <= 1 || $user === null || !$user->isLoggedIn() ) {
+		if ( $user === null || !$user->isLoggedIn() ) {
 			return;
 		}
 


### PR DESCRIPTION
Always sample the authentication method unless the user is null or not logged in. Without this change, we'll only log when we fall back which won't give use any information about the proportions of successful helios authentications vs MediaWiki fallbacks.

This is a follow on to #8761.

https://wikia-inc.atlassian.net/browse/SERVICES-873

@Wikia/services-team 
