### PR TITLE
SitemapPage::generateNamespace - add index hint

### DIFF
--- a/extensions/wikia/Sitemap/SpecialSitemap_body.php
+++ b/extensions/wikia/Sitemap/SpecialSitemap_body.php
@@ -313,7 +313,10 @@ class SitemapPage extends UnlistedSpecialPage {
 			),
 			$scope,
 			__METHOD__,
-			array( "ORDER BY" => "page_id" )
+			[
+				"ORDER BY" => "page_id",
+				"USE INDEX" => "PRIMARY", # PLATFORM-1286
+			]
 		);
 
 		$includeVideo = (bool) F::app()->wg->EnableVideoSitemaps;


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-1286

Add index hint to use a primary key and avoid `Using filesort`. This query was failing on huge wikis (lyricwiki, glee, answers, ...).

``` sql
[lyricwiki]>explain SELECT /* SitemapPage::generateNamespace  */  page_namespace,page_title,page_touched  FROM `page`  WHERE page_namespace = '0'  ORDER BY page_id;
+----+-------------+-------+------+---------------+------------+---------+-------+---------+-----------------------------+
| id | select_type | table | type | possible_keys | key        | key_len | ref   | rows    | Extra                       |
+----+-------------+-------+------+---------------+------------+---------+-------+---------+-----------------------------+
|  1 | SIMPLE      | page  | ref  | name_title    | name_title | 4       | const | 1401891 | Using where; Using filesort |
+----+-------------+-------+------+---------------+------------+---------+-------+---------+-----------------------------+
```

vs

``` sql
[lyricwiki]>explain SELECT /* SitemapPage::generateNamespace  */  page_namespace,page_title,page_touched  FROM `page`  USE INDEX (PRIMARY) WHERE page_namespace = '0'  ORDER BY page_id;
+----+-------------+-------+-------+---------------+---------+---------+------+---------+-------------+
| id | select_type | table | type  | possible_keys | key     | key_len | ref  | rows    | Extra       |
+----+-------------+-------+-------+---------------+---------+---------+------+---------+-------------+
|  1 | SIMPLE      | page  | index | NULL          | PRIMARY | 4       | NULL | 2803782 | Using where |
+----+-------------+-------+-------+---------------+---------+---------+------+---------+-------------+
```

And ~2 sec (with index hint) vs 8-10 sec in terms of query execution time

@drozdo / @wladekb 
