### PR TITLE
Improve performance of founder_emails_event

### DIFF
--- a/extensions/wikia/FounderEmails/FounderEmails.sql
+++ b/extensions/wikia/FounderEmails/FounderEmails.sql
@@ -4,5 +4,6 @@ CREATE TABLE IF NOT EXISTS founder_emails_event (
  feev_timestamp VARCHAR(14) default NULL,
  feev_type VARCHAR(32),
  feev_data BLOB NOT NULL,
- PRIMARY KEY (`feev_id`)
+ PRIMARY KEY (`feev_id`),
+ KEY `feev_wiki_id` (`feev_wiki_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-1596

``` sql
ALTER TABLE founder_emails_event ADD INDEX feev_wiki_id (feev_wiki_id)
```

``` sql
mysql> EXPLAIN SELECT /* FounderEmails::processEvents ... */  *  FROM founder_emails_event  WHERE feev_type = 'edit' AND feev_wiki_id = '1276738'  ORDER BY feev_timestamp ;
+----+-------------+----------------------+------+---------------+--------------+---------+-------+------+-----------------------------+
| id | select_type | table                | type | possible_keys | key          | key_len | ref   | rows | Extra                       |
+----+-------------+----------------------+------+---------------+--------------+---------+-------+------+-----------------------------+
|  1 | SIMPLE      | founder_emails_event | ref  | feev_wiki_id  | feev_wiki_id | 4       | const |    1 | Using where; Using filesort |
+----+-------------+----------------------+------+---------------+--------------+---------+-------+------+-----------------------------+
1 row in set (0.01 sec)
```

@drozdo / @wladekb 
