### PR TITLE
ADEN-2546 Use i18n messages in the new recoverable product

### DIFF
--- a/extensions/wikia/AdEngine/AdEngine.i18n.php
+++ b/extensions/wikia/AdEngine/AdEngine.i18n.php
@@ -14,6 +14,7 @@ $messages['en'] = array(
 	'adengine-recovery-message-blocking-welcome' => 'Hey! It looks like you\'re using ad blocking software!',
 	'adengine-recovery-message-blocking-click' => 'Click',
 	'adengine-recovery-message-blocking-message-a' => 'Wikia runs ads so we can keep the lights on and so Wikia will always be free to use. We can bring you fun, free, fan-oriented content until my glorious return to Earth if you add us to your adblock whitelist. $1 my face to refresh after you\'re done!',
+	'adengine-recovery-message-blocking-message-b' => 'Wikia runs ads so we can keep the lights on and so Wikia will always be free to use. We can bring you fun, free, fan-oriented content until my glorious return to Earth if you disable your adblock software while on Wikia. $1 my face to refresh after you\'re done!',
 );
 
 /** Message documentation (Message documentation)
@@ -29,8 +30,10 @@ $messages['qqq'] = array(
 	'adengine-desc' => '{{desc}}',
 	'adengine-recovery-message-blocking-welcome' => 'A bold title in comic bubble next to an image welcoming a user and saying our system detected she uses ad blocking software.',
 	'adengine-recovery-message-blocking-click' => 'A label of link in the last sentence in adengine-recovery-message-blocking-message-a message. This message is used as a parameter in the other, mentioned message.',
-	'adengine-recovery-message-blocking-message-a' => 'More in-depth explanation why using ad blocking software is not good for Wikia. This description is placed just under the welcome message in the comic bubble. Parameters:
+	'adengine-recovery-message-blocking-message-a' => 'More in-depth explanation why using ad blocking software is not good for Wikia. This description is placed just under the welcome message in the comic bubble. And for now it is in two similar versions. Parameters:
 * $1 is a translated call-to-action word which will be linked and clickable.',
+	'adengine-recovery-message-blocking-message-b' => 'More in-depth explanation why using ad blocking software is not good for Wikia. This description is placed just under the welcome message in the comic bubble. And for now it is in two similar versions. Parameters:
+* $1 is a translated call-to-action word which will be linked and clickable.'
 );
 
 /** Arabic (العربية)
@@ -177,6 +180,7 @@ $messages['de'] = array(
 	'adengine-recovery-message-blocking-welcome' => 'Hallo! Es sieht so aus als würdest du eine Werbeblocker-Software verwenden!',
 	'adengine-recovery-message-blocking-click' => 'klicke',
 	'adengine-recovery-message-blocking-message-a' => 'Bei Wikia wird Werbung angezeigt, damit wir auf Sendung bleiben können und Wikia auch weiterhin kostenlos angeboten werden kann. Bis zu meiner glorreichen Rückkehr zur Erde findest du bei uns kostenlose, auf unsere Fans zugeschnittene Inhalte, die Spaß machen. Dazu musst du uns nur auf die Whitelist deines Werbeblockers setzen. Wenn du damit fertig bist, $1 zur Aktualisierung einfach auf mein Gesicht!',
+	'adengine-recovery-message-blocking-message-b' => 'Bei Wikia wird Werbung angezeigt, damit wir auf Sendung bleiben können und Wikia auch weiterhin kostenlos angeboten werden kann. Bis zu meiner glorreichen Rückkehr zur Erde findest du bei uns kostenlose, auf unsere Fans zugeschnittene Inhalte, die Spaß machen. Dazu musst du nur deinen Werbeblocker deaktivieren, solange du auf Wikia unterwegs bist. Wenn du damit fertig bist, $1 zur Aktualisierung einfach auf mein Gesicht!'
 );
 
 /** Greek (Ελληνικά)
@@ -203,6 +207,7 @@ $messages['es'] = array(
 	'adengine-recovery-message-blocking-welcome' => '¡Hola!¡Parece que estás utilizando un software para bloquear publicidad!',
 	'adengine-recovery-message-blocking-click' => 'clic',
 	'adengine-recovery-message-blocking-message-a' => 'Wikia muestra publicidad para que podamos mantener las luces encendidas y que Wikia siempre sea libre de pago. Podemos brindar contenido divertido, libre y orientado a los fans hasta mi glorioso retorno a la tierra si es que nos añades a tu lista blanca de bloqueadores de publicidad. ¡Haz $1 en mi cara para refrescar después de que hayas terminado!',
+	'adengine-recovery-message-blocking-message-b' => 'Wikia muestra publicidad para que podamos mantener las luces encendidas y que Wikia siempre sea libre de pago. Podemos brindar contenido divertido, libre y orientado a los fans hasta mi glorioso retorno a la tierra si es que deshabilitas tu software para bloquear publicidad mientras te encuentres en Wikia. ¡Haz $1 en mi cara para refrescar después de que hayas terminado!',
 );
 
 /** Estonian (eesti)
@@ -393,6 +398,7 @@ $messages['ja'] = array(
 	'adengine-recovery-message-blocking-welcome' => '広告ブロック・ソフトウェアをお使いのようです。',
 	'adengine-recovery-message-blocking-click' => '手順が完了したら',
 	'adengine-recovery-message-blocking-message-a' => 'ウィキアでは、ウィキアの運営を持続し、またユーザーの皆さんにいつでも無料でウィキアをご利用いただけるようにするため、広告を掲載しています。広告ブロックのホワイトリストにウィキアを追加していただくと、ファン向けの楽しい無料コンテンツをご提供できます。$1、私の顔をクリックして更新してくださいね！',
+	'adengine-recovery-message-blocking-message-b' => 'ウィキアでは、ウィキアの運営を持続し、またユーザーの皆さんにいつでも無料でウィキアをご利用いただけるようにするため、広告を掲載しています。ウィキアのご利用時は広告ブロック・ソフトウェアを無効にしていただくと、ファン向けの楽しい無料コンテンツをご提供できます。$1、私の顔をクリックして更新してくださいね！',
 );
 
 /** Georgian (ქართული)
@@ -626,7 +632,8 @@ $messages['pl'] = array(
 	'adengine-desc' => 'Silnik reklam Wikii',
 	'adengine-recovery-message-blocking-welcome' => 'Cześć! Wygląda na to, że korzystasz z oprogramowania do blokowania reklam!',
 	'adengine-recovery-message-blocking-click' => 'Kliknij',
-	'adengine-recovery-message-blocking-message-a' => 'Wikia wyświetla reklamy, aby móc działać, dzięki czemu Wikia zawsze pozostanie darmowa. Możemy być Twoim źródłem zabawnych, bezpłatnych treści skierowanych do fanów do czasu mojego chwalebnego powrotu na ziemię, pod warunkiem że \'\'\'dodasz nas do listy wyjątków swojego programu do blokowania reklam\'\'\'. $1 na moją twarz, aby odświeżyć stronę, kiedy będziesz gotowy!',
+	'adengine-recovery-message-blocking-message-a' => 'Wikia wyświetla reklamy, aby móc działać, dzięki czemu Wikia zawsze pozostanie darmowa. Możemy być Twoim źródłem zabawnych, bezpłatnych treści skierowanych do fanów do czasu mojego chwalebnego powrotu na ziemię, pod warunkiem że dodasz nas do listy wyjątków swojego programu do blokowania reklam. $1 na moją twarz, aby odświeżyć stronę, kiedy będziesz gotowy!',
+	'adengine-recovery-message-blocking-message-b' => 'Wikia wyświetla reklamy, aby móc działać, dzięki czemu Wikia zawsze pozostanie darmowa. Możemy być Twoim źródłem zabawnych, bezpłatnych treści skierowanych do fanów do czasu mojego chwalebnego powrotu na ziemię, pod warunkiem że wyłączysz program do blokowania reklam na czas przeglądania Wikii. $1 na moją twarz, aby odświeżyć stronę, kiedy będziesz gotowy!',
 );
 
 /** Pashto (پښتو)

--- a/extensions/wikia/AdEngine/AdEngine.i18n.php
+++ b/extensions/wikia/AdEngine/AdEngine.i18n.php
@@ -13,7 +13,7 @@ $messages['en'] = array(
 	// Recoverable products
 	'adengine-recovery-message-blocking-welcome' => 'Hey! It looks like you\'re using ad blocking software!',
 	'adengine-recovery-message-blocking-click' => 'Click',
-	'adengine-recovery-message-blocking-message-a' => 'Wikia runs ads so we can keep the lights on and so Wikia will always be free to use. We can bring you fun, free, fan-oriented content until my glorious return to Earth if you <b>add us to your adblock whitelist</b>. $1 my face to refresh after you\'re done!',
+	'adengine-recovery-message-blocking-message-a' => 'Wikia runs ads so we can keep the lights on and so Wikia will always be free to use. We can bring you fun, free, fan-oriented content until my glorious return to Earth if you add us to your adblock whitelist. $1 my face to refresh after you\'re done!',
 );
 
 /** Message documentation (Message documentation)

--- a/extensions/wikia/AdEngine/AdEngine.i18n.php
+++ b/extensions/wikia/AdEngine/AdEngine.i18n.php
@@ -13,7 +13,7 @@ $messages['en'] = array(
 	// Recoverable products
 	'adengine-recovery-message-blocking-welcome' => 'Hey! It looks like you\'re using ad blocking software!',
 	'adengine-recovery-message-blocking-click' => 'Click',
-	'adengine-recovery-message-blocking-message-a' => 'Wikia runs ads so we can keep the lights on and so Wikia will always be free to use. We can bring you fun, free, fan-oriented content until my glorious return to Earth if you \'\'\'add us to your adblock whitelist\'\'\'. $1 my face to refresh after you\'re done!',
+	'adengine-recovery-message-blocking-message-a' => 'Wikia runs ads so we can keep the lights on and so Wikia will always be free to use. We can bring you fun, free, fan-oriented content until my glorious return to Earth if you <b>add us to your adblock whitelist</b>. $1 my face to refresh after you\'re done!',
 );
 
 /** Message documentation (Message documentation)

--- a/extensions/wikia/AdEngine/AdEngine2.setup.php
+++ b/extensions/wikia/AdEngine/AdEngine2.setup.php
@@ -43,8 +43,16 @@ $wgHooks['SkinAfterBottomScripts'][] = 'AdEngine2Hooks::onSkinAfterBottomScripts
 // i18n
 $wgExtensionMessagesFiles['AdEngine'] = __DIR__ . '/AdEngine.i18n.php';
 $wgExtensionFunctions[] = function() {
-	JSMessages::registerPackage( 'AdEngine', array( 'adengine-*' ) );
-} ;
+	JSMessages::registerPackage( 'AdEngine', [
+		'adengine-*'
+	] );
+};
+
+$wgExtensionFunctions[] = function() {
+	JSMessages::registerPackage( 'AdEngineRecoveryMessage', [
+		'adengine-recovery-message-*'
+	] );
+};
 
 // Register Resource Loader module for SevenOne Media files
 $wgResourceModules['wikia.ext.adengine.sevenonemedia'] = array(

--- a/extensions/wikia/AdEngine/js/recovery/message.js
+++ b/extensions/wikia/AdEngine/js/recovery/message.js
@@ -71,15 +71,14 @@ define('ext.wikia.adEngine.recovery.message', [
 	function createMessage(uniqueClassName) {
 		return getAssets().then(function (assets) {
 			var template = assets.mustache[0],
-				text = mw.message(
-					'adengine-recovery-message-blocking-message-a',
+				text = mw.message('adengine-recovery-message-blocking-message-a').rawParams([
 					'<a class="action-accept">' +
 						mw.message('adengine-recovery-message-blocking-click').escaped() +
 					'</a>'
-				).plain(),
+				]).escaped(),
 				params = {
 					positionClass: 'recovered-message-' + uniqueClassName,
-					header: mw.message('adengine-recovery-message-blocking-welcome').plain(),
+					header: mw.message('adengine-recovery-message-blocking-welcome').text(),
 					text: text
 				};
 

--- a/extensions/wikia/AdEngine/js/recovery/message.js
+++ b/extensions/wikia/AdEngine/js/recovery/message.js
@@ -3,6 +3,7 @@ define('ext.wikia.adEngine.recovery.message', [
 	'ext.wikia.adEngine.adTracker',
 	'ext.wikia.adEngine.recovery.helper',
 	'jquery',
+	'mw',
 	'wikia.document',
 	'wikia.loader',
 	'wikia.localStorage',
@@ -14,6 +15,7 @@ define('ext.wikia.adEngine.recovery.message', [
 	adTracker,
 	recoveryHelper,
 	$,
+	mw,
 	doc,
 	loader,
 	localStorage,
@@ -54,8 +56,9 @@ define('ext.wikia.adEngine.recovery.message', [
 					mustache: templatePath
 				}
 			})
-		).then(function (response) {
-			return response;
+		).then(function (assets) {
+			mw.messages.set(assets.messages);
+			return assets;
 		}).fail(function () {
 			log([
 				'recoveredAdsMessage.getAssets', 'Unable to load template or messages',
@@ -66,15 +69,18 @@ define('ext.wikia.adEngine.recovery.message', [
 	}
 
 	function createMessage(uniqueClassName) {
-		return getAssets().then(function (loaderResponse) {
-			var template = loaderResponse.mustache[0],
+		return getAssets().then(function (assets) {
+			var template = assets.mustache[0],
+				text = mw.message(
+					'adengine-recovery-message-blocking-message-a',
+					'<a class="action-accept">' +
+						mw.message('adengine-recovery-message-blocking-click').escaped() +
+					'</a>'
+				).plain(),
 				params = {
 					positionClass: 'recovered-message-' + uniqueClassName,
-					header: $.msg('adengine-recovery-message-blocking-welcome'),
-					text: $.msg(
-						'adengine-recovery-message-blocking-message-a',
-						'<a class="action-accept">' + $.msg('adengine-recovery-message-blocking-click') + '</a>'
-					)
+					header: mw.message('adengine-recovery-message-blocking-welcome').plain(),
+					text: text
 				};
 
 			return $(mustache.render(template, params));

--- a/extensions/wikia/AdEngine/js/recovery/message.js
+++ b/extensions/wikia/AdEngine/js/recovery/message.js
@@ -25,12 +25,7 @@ define('ext.wikia.adEngine.recovery.message', [
 	'use strict';
 
 	var logGroup = 'ext.wikia.adEngine.recovery.message',
-		localStorageKey = 'rejectedRecoveredMessage',
-		headerText = 'Hey! It looks like you\'re using ad blocking software!',
-		messageText = 'Wikia runs ads so we can keep the lights on and so Wikia will always be free to use. ' +
-			'We can bring you fun, free, fan-oriented content until my glorious return to Earh if you ' +
-			'<strong>add us to your adblock whitelist</strong>. ' +
-			'<a class="action-accept">Click</a> my face to refresh after you\'re done!';
+		localStorageKey = 'rejectedRecoveredMessage';
 
 	function accept() {
 		adTracker.track('recovery/message', 'accept');
@@ -47,29 +42,39 @@ define('ext.wikia.adEngine.recovery.message', [
 		return !!localStorage.getItem(localStorageKey);
 	}
 
-	function getTemplate() {
-		var templatePath = 'extensions/wikia/AdEngine/templates/recovered_message.mustache';
+	function getAssets() {
+		var templatePath = 'extensions/wikia/AdEngine/templates/recovered_message.mustache',
+			messagePackage = 'AdEngineRecoveryMessage';
 
 		return $.when(
 			loader({
 				type: loader.MULTI,
 				resources: {
+					messages: messagePackage,
 					mustache: templatePath
 				}
 			})
 		).then(function (response) {
-			return response.mustache[0];
+			return response;
 		}).fail(function () {
-			log(['recoveredAdsMessage.getTemplate', 'Unable to load template', templatePath], 'debug', logGroup);
+			log([
+				'recoveredAdsMessage.getAssets', 'Unable to load template or messages',
+				templatePath,
+				messagePackage
+			], 'debug', logGroup);
 		});
 	}
 
 	function createMessage(uniqueClassName) {
-		return getTemplate().then(function (template) {
-			var params = {
+		return getAssets().then(function (loaderResponse) {
+			var template = loaderResponse.mustache[0],
+				params = {
 					positionClass: 'recovered-message-' + uniqueClassName,
-					header: headerText,
-					text: messageText
+					header: $.msg('adengine-recovery-message-blocking-welcome'),
+					text: $.msg(
+						'adengine-recovery-message-blocking-message-a',
+						'<a class="action-accept">' + $.msg('adengine-recovery-message-blocking-click') + '</a>'
+					)
 				};
 
 			return $(mustache.render(template, params));

--- a/extensions/wikia/JSMessages/JSMessages.class.php
+++ b/extensions/wikia/JSMessages/JSMessages.class.php
@@ -108,9 +108,6 @@ class JSMessages {
 
 		$ret = array();
 		foreach( $messageKeys as $msg ) {
-			if ( is_array( $msg ) ) {
-				var_dump( $msg );
-			}
 			if (substr($msg, 0, $patternLen) === $pattern) {
 				$ret[$msg] = wfmsgExt($msg, array('language' => $langCode));
 			}

--- a/resources/wikia/modules/loader.js
+++ b/resources/wikia/modules/loader.js
@@ -325,7 +325,7 @@ define('wikia.loader', ['wikia.window', require.optional('mw'), 'wikia.nirvana',
 					options.sassParams = options.sassParams || window.wgSassParams;
 				}
 
-				if (typeof window.wgUserLanguage !== 'undefined') {
+				if (typeof window.wgUserLanguage !== 'undefined' && typeof options.messages  !== 'undefined') {
 					// Add language to avoid cache pollution
 					options.uselang = window.wgUserLanguage;
 				}

--- a/resources/wikia/modules/loader.js
+++ b/resources/wikia/modules/loader.js
@@ -325,6 +325,11 @@ define('wikia.loader', ['wikia.window', require.optional('mw'), 'wikia.nirvana',
 					options.sassParams = options.sassParams || window.wgSassParams;
 				}
 
+				if (typeof window.wgUserLanguage !== 'undefined') {
+					// Add language to avoid cache pollution
+					options.uselang = window.wgUserLanguage;
+				}
+
 				nirvana.getJson(
 					'AssetsManager',
 					'getMultiTypePackage',

--- a/skins/oasis/css/core/ads.scss
+++ b/skins/oasis/css/core/ads.scss
@@ -291,12 +291,14 @@ body >a >img[src$="noad.gif"] {
 			font-weight: bold;
 		}
 
-		strong {
-			font-weight: bold;
-		}
-
 		.action-accept {
+			color: #000;
 			cursor: pointer;
+			font-weight: bold;
+
+			&:hover {
+				text-decoration: underline;
+			}
 		}
 
 		.dialog-pointer {


### PR DESCRIPTION
With this changes we provide the message for users with ad blocking software visible in other languages. The message will be displayed in a wikia's content language. We also added second variant of the message which we'll re-use while implementing AB Test.
