### PR TITLE
Improve IP logging

### DIFF
--- a/includes/Setup.php
+++ b/includes/Setup.php
@@ -445,6 +445,8 @@ if ( $wgCommandLineMode ) {
 	wfDebug( "$debug\n" );
 }
 
+wfRunHooks('WebRequestInitialized', [ $wgRequest ] );
+
 wfProfileOut( $fname . '-misc1' );
 wfProfileIn( $fname . '-memcached' );
 

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -447,6 +447,7 @@ $wgHooks['WikiaSkinTopScripts'][] = 'WikiFactoryHubHooks::onWikiaSkinTopScripts'
 $wgHooks['Debug'][] = 'Wikia\\Logger\\Hooks::onDebug';
 $wgHooks['WikiFactory::execute'][] = 'Wikia\\Logger\\Hooks::onWikiFactoryExecute';
 $wgHooks['WikiFactory::onExecuteComplete'][] = 'Wikia\\Logger\\Hooks::onWikiFactoryExecuteComplete';
+$wgHooks['WebRequestInitialized'][] = 'Wikia\\Logger\\Hooks::onWebRequestInitialized';
 
 // memcache stats (PLATFORM-292)
 $wgAutoloadClasses['Wikia\\Memcached\\MemcachedStats'] = "$IP/includes/wikia/memcached/MemcachedStats.class.php";

--- a/lib/Wikia/src/Logger/Hooks.php
+++ b/lib/Wikia/src/Logger/Hooks.php
@@ -108,7 +108,7 @@ class Hooks {
 	 * @return bool true
 	 */
 	public static function onWikiFactoryExecuteComplete( \WikiFactoryLoader $wikiFactoryLoader ) {
-		global $wgRequest, $wgDBname, $wgCityId, $maintClass;
+		global $wgDBname, $wgCityId, $maintClass;
 
 		$fields = [];
 
@@ -122,15 +122,6 @@ class Hooks {
 
 		if ( isset( $_SERVER['REQUEST_URI'] ) ) {
 			$fields['url'] = $_SERVER['REQUEST_URI'];
-
-			$ip = !empty( $wgRequest ) ? $wgRequest->getIP() : null;
-			if ( $ip === null ) {
-				$ip = isset( $_SERVER['REMOTE_ADDR'] ) ? $_SERVER['REMOTE_ADDR'] : null;
-			}
-
-			if ( $ip != null ) {
-				$fields['ip'] = $ip;
-			}
 
 			if ( isset( $_SERVER['REQUEST_METHOD'] ) ) {
 				$fields['http_method'] = $_SERVER['REQUEST_METHOD'];
@@ -159,6 +150,27 @@ class Hooks {
 		$fields['request_id'] = RequestId::instance()->getRequestId();
 
 		WikiaLogger::instance()->pushContext( $fields, WebProcessor::RECORD_TYPE_FIELDS );
+
+		return true;
+	}
+
+	public function onWebRequestInitialized( \WebRequest $webRequest ) {
+		$fields = [];
+
+		if ( isset( $_SERVER['REQUEST_URI'] ) ) {
+			$ip = $webRequest->getIP();
+			if ( $ip === null ) {
+				$ip = isset( $_SERVER['REMOTE_ADDR'] ) ? $_SERVER['REMOTE_ADDR'] : null;
+			}
+
+			if ( $ip != null ) {
+				$fields['ip'] = $ip;
+			}
+		}
+
+		if ( !empty( $fields ) ) {
+			WikiaLogger::instance()->pushContext( $fields, WebProcessor::RECORD_TYPE_FIELDS );
+		}
 
 		return true;
 	}


### PR DESCRIPTION
WikiaLogger intiialization happens before `$wgRequest` is intiialized and IPs that we log are our internal ones. This change fixes the issue by fetching IP from Mediawiki when it is available.

/cc @macbre @Grunny @ljagiello @owend 
