### PR TITLE
VE-1982: Unit tests for <gallery> and <tabber> passed to <image> (PI)

### DIFF
--- a/extensions/wikia/PortableInfobox/services/Parser/Nodes/NodeImage.php
+++ b/extensions/wikia/PortableInfobox/services/Parser/Nodes/NodeImage.php
@@ -10,6 +10,60 @@ class NodeImage extends Node {
 	const CAPTION_TAG_NAME = 'caption';
 	const MEDIA_TYPE_VIDEO = 'VIDEO';
 
+	public static function getMarkers( $value, $ext ) {
+		if ( preg_match_all('/\x7fUNIQ[A-Z0-9]*-' . $ext . '-[0-9]{8}-QINU\x7f/is', $value, $out ) ) {
+			return $out[0];
+		} else {
+			return [];
+		}
+	}
+
+	public static function getGalleryData( $html ) {
+		global $wgArticleAsJson;
+		$data = array();
+		if ( $wgArticleAsJson ) {
+			if ( preg_match( '/data-ref=\'([^\']+)\'/', $html, $out ) ) {
+				$media = \ArticleAsJson::$media[$out[1]];
+				for( $i = 0; $i < count( $media ); $i++ ) {
+					$data[] = array( 'label' => strip_tags( $media[$i]['caption'] ), 'title' => $media[$i]['title'] );
+				}
+			}
+		} else {
+			if ( preg_match( '#\sdata-model="([^"]+)"#', $html, $galleryOut ) ) {
+				$model = json_decode( htmlspecialchars_decode( $galleryOut[1] ), true );
+				for( $i = 0; $i < count( $model ); $i++ ) {
+					$data[] = array( 'label' => strip_tags( $model[$i][ 'caption' ] ), 'title' => $model[$i][ 'title' ] );
+				}
+			}
+			if ( preg_match_all('#data-image-key="([^"]+)".*?\s<h2>(.*?)<\/h2>#is', $html, $galleryOut ) ) {
+				for( $i = 0; $i < count( $galleryOut[0] ); $i++ ) {
+					$data[] = array( 'label' => $galleryOut[2][$i], 'title' => $galleryOut[1][$i] );
+				}
+			}
+		}
+		return $data;
+	}
+
+	public static function getTabberData( $html ) {
+		$data = array();
+		$doc = new \DOMDocument();
+		$doc->loadHTML( $html );
+		$sxml = simplexml_import_dom( $doc );
+		$divs = $sxml->xpath( '//div[@class=\'tabbertab\']' );
+		foreach ( $divs as $div ) {
+			if ( $wgArticleAsJson ) {
+				if ( preg_match( '/data-ref="([^"]+)"/', $div->p->asXML(), $out ) ) {
+					$data[] = array( 'label' => (string) $div['title'], 'title' => \ArticleAsJson::$media[$out[1]]['title'] );
+				}
+			} else {
+				if ( preg_match( '/data-image-key="([^"]+)"/', $div->p->asXML(), $out ) ) {
+					$data[] = array( 'label' => (string) $div['title'], 'title' => $out[1] );
+				}
+			}
+		}
+		return $data;
+	}
+
 	public function getData() {
 		if ( !isset( $this->data ) ) {
 			$this->data = array();
@@ -54,31 +108,11 @@ class NodeImage extends Node {
 	}
 
 	private function getGalleryItems( $value ) {
-		global $wgArticleAsJson;
 		$galleryItems = array();
-		$galleryMarkers = $this->getMarkers( $value, 'GALLERY' );
+		$galleryMarkers = self::getMarkers( $value, 'GALLERY' );
 		for ( $i = 0; $i < count ( $galleryMarkers ); $i++ ) {
 			$galleryHtml = $this->getExternalParser()->parseRecursive( $galleryMarkers[$i] );
-			if ( $wgArticleAsJson ) {
-				if ( preg_match( '/data-ref=\'([^\']+)\'/', $galleryHtml, $out ) ) {
-					$media = \ArticleAsJson::$media[$out[1]];
-					for( $j = 0; $j < count( $media ); $j++ ) {
-						$galleryItems[] = array( 'label' => strip_tags( $media[$j]['caption'] ), 'title' => $media[$j]['title'] );
-					}
-				}
-			} else {
-				if ( preg_match( '#\sdata-model="([^"]+)"#', $galleryHtml, $galleryOut ) ) {
-					$model = json_decode( htmlspecialchars_decode( $galleryOut[1] ), true );
-					$galleryItems = array_map( function( $modelItem ) {
-						return array( 'label' => strip_tags( $modelItem[ 'caption' ] ), 'title' => $modelItem['title'] );
-					}, $model );
-				}
-				if ( preg_match_all('#data-image-key="([^"]+)".*?\s<h2>(.*?)<\/h2>#is', $html, $galleryOut ) ) {
-					for( $j = 0; $j < count( $galleryOut[0] ); $j++ ) {
-						$galleryItems[] = array( 'label' => $galleryOut[2][$j], 'title' => $galleryOut[1][$j] );
-					}
-				}
-			}
+			$galleryItems = array_merge( $galleryItems, self::getGalleryData( $galleryHtml ) );
 		}
 		return $galleryItems;
 	}
@@ -86,40 +120,12 @@ class NodeImage extends Node {
 	private function getTabberItems( $value ) { 
 		global $wgArticleAsJson;
 		$tabberItems = array();
-		$tabberMarkers = $this->getMarkers( $value, 'TABBER' );
+		$tabberMarkers = self::getMarkers( $value, 'TABBER' );
 		for ( $i = 0; $i < count ( $tabberMarkers ); $i++ ) {
 			$tabberHtml = $this->getExternalParser()->parseRecursive( $tabberMarkers[$i] );
-			$tabberItems = array_merge( $tabberItems, $this->getTabberData( $tabberHtml ) );
+			$tabberItems = array_merge( $tabberItems, self::getTabberData( $tabberHtml ) );
 		}
 		return $tabberItems;
-	}
-
-	private function getMarkers( $value, $ext ) {
-		if ( preg_match_all('/\x7fUNIQ[A-Z0-9]*-' . $ext . '-[0-9]{8}-QINU\x7f/is', $value, $out ) ) {
-			return $out[0];
-		} else {
-			return [];
-		}
-	}
-
-	private function getTabberData( $html ) {
-		$data = array();
-		$doc = new \DOMDocument();
-		$doc->loadHTML( $html );
-		$sxml = simplexml_import_dom( $doc );
-		$divs = $sxml->xpath( '//div[@class=\'tabbertab\']' );
-		foreach ( $divs as $div ) {
-			if ( $wgArticleAsJson ) {
-				if ( preg_match( '/data-ref="([^"]+)"/', $div->p->asXML(), $out ) ) {
-					$data[] = array( 'label' => (string) $div['title'], 'title' => \ArticleAsJson::$media[$out[1]]['title'] );
-				}
-			} else {
-				if ( preg_match( '/data-image-key="([^"]+)"/', $div->p->asXML(), $out ) ) {
-					$data[] = array( 'label' => (string) $div['title'], 'title' => $out[1] );
-				}
-			}
-		}
-		return $data;
 	}
 
 	private function getImageData( $title, $alt, $caption ) {

--- a/extensions/wikia/PortableInfobox/services/Parser/Nodes/NodeImage.php
+++ b/extensions/wikia/PortableInfobox/services/Parser/Nodes/NodeImage.php
@@ -119,7 +119,6 @@ class NodeImage extends Node {
 	}
 
 	private function getTabberItems( $value ) { 
-		global $wgArticleAsJson;
 		$tabberItems = array();
 		$tabberMarkers = self::getMarkers( $value, 'TABBER' );
 		for ( $i = 0; $i < count ( $tabberMarkers ); $i++ ) {

--- a/extensions/wikia/PortableInfobox/services/Parser/Nodes/NodeImage.php
+++ b/extensions/wikia/PortableInfobox/services/Parser/Nodes/NodeImage.php
@@ -45,6 +45,7 @@ class NodeImage extends Node {
 	}
 
 	public static function getTabberData( $html ) {
+		global $wgArticleAsJson;
 		$data = array();
 		$doc = new \DOMDocument();
 		$doc->loadHTML( $html );

--- a/extensions/wikia/PortableInfobox/tests/nodes/NodeImageTest.php
+++ b/extensions/wikia/PortableInfobox/tests/nodes/NodeImageTest.php
@@ -7,6 +7,63 @@ class NodeImageTest extends WikiaBaseTest {
 	}
 
 	/**
+	 * @covers       NodeImage::getGalleryData
+	 */
+	public function testGalleryData() {
+		$input = '<div data-model="[{&quot;caption&quot;:&quot;_caption_&quot;,&quot;title&quot;:&quot;_title_&quot;}]"></div>';
+		$expected = array(
+			array(
+				'label' => '_caption_',
+				'title' => '_title_',
+			)
+		);
+		$this->assertEquals( $expected, Wikia\PortableInfobox\Parser\Nodes\NodeImage::getGalleryData( $input ) );
+	}
+
+	/**
+	 * @covers       NodeImage::getTabberData
+	 */
+	public function testTabberData() {
+		$input = '<div class="tabber"><div class="tabbertab" title="_title_"><p><a><img data-image-key="_data-image-key_"></a></p></div></div>';
+		$expected = array(
+			array(
+				'label' => '_title_',
+				'title' => '_data-image-key_',
+			)
+		);
+		$this->assertEquals( $expected, Wikia\PortableInfobox\Parser\Nodes\NodeImage::getTabberData( $input ) );
+	}
+
+	/**
+	 * @covers       NodeImage::getMarkers
+	 * @dataProvider markersProvider
+	 *
+	 * @param $markup
+	 * @param $params
+	 * @param $expected
+	 */
+	public function testMarkers( $ext, $value, $expected ) {
+		$this->assertEquals( $expected, Wikia\PortableInfobox\Parser\Nodes\NodeImage::getMarkers( $value, $ext ) );
+	}
+
+	public function markersProvider() {
+		return [
+			[
+				'TABBER',
+				"<div>\x7fUNIQ123456789-tAbBeR-12345678-QINU\x7f</div>",
+				[ "\x7fUNIQ123456789-tAbBeR-12345678-QINU\x7f" ]
+			],
+			[
+				'GALLERY',
+				"\x7fUNIQ123456789-tAbBeR-12345678-QINU\x7f<center>\x7fUNIQabcd-gAlLeRy-12345678-QINU\x7f</center>\x7fUNIQabcd-gAlLeRy-87654321-QINU\x7f",
+				[ "\x7fUNIQabcd-gAlLeRy-12345678-QINU\x7f", "\x7fUNIQabcd-gAlLeRy-87654321-QINU\x7f" ]
+			]
+		];
+	}
+
+
+
+	/**
 	 * @covers       NodeImage::getData
 	 * @dataProvider dataProvider
 	 *

--- a/extensions/wikia/PortableInfobox/tests/nodes/NodeImageTest.php
+++ b/extensions/wikia/PortableInfobox/tests/nodes/NodeImageTest.php
@@ -86,12 +86,25 @@ class NodeImageTest extends WikiaBaseTest {
 
 	public function sourceProvider() {
 		return [
-			[ '<image source="img"/>', [ 'img' ] ],
-			[ '<image source="img"><default>{{{img}}}</default><alt source="img" /></image>', [ 'img' ] ],
-			[ '<image source="img"><alt source="alt"/><caption source="cap"/></image>', [ 'img', 'alt', 'cap' ] ],
-			[ '<image source="img"><alt source="alt"><default>{{{def}}}</default></alt><caption source="cap"/></image>',
-			  [ 'img', 'alt', 'def', 'cap' ] ],
-			[ '<image/>', [ ] ],
+			[
+				'<image source="img"/>',
+				[ 'img' ]
+			],
+			[
+				'<image source="img"><default>{{{img}}}</default><alt source="img" /></image>',
+				[ 'img' ]
+			],
+			[
+				'<image source="img"><alt source="alt"/><caption source="cap"/></image>',
+				[ 'img', 'alt', 'cap' ]
+			],
+			[
+				'<image source="img"><alt source="alt"><default>{{{def}}}</default></alt><caption source="cap"/></image>',
+				[ 'img', 'alt', 'def', 'cap' ] ],
+			[
+				'<image/>',
+				[ ]
+			],
 		];
 	}
 

--- a/extensions/wikia/PortableInfobox/tests/nodes/NodeImageTest.php
+++ b/extensions/wikia/PortableInfobox/tests/nodes/NodeImageTest.php
@@ -21,19 +21,33 @@ class NodeImageTest extends WikiaBaseTest {
 	}
 
 	public function dataProvider() {
+		// markup, params, expected
 		return [
-			[ '<image source="img"></image>', [ ],
-			  [ [ 'url' => '', 'name' => '', 'key' => '', 'alt' => null, 'caption' => null ] ] ],
-			[ '<image source="img"></image>', [ 'img' => 'test.jpg' ],
-			  [ [ 'url' => '', 'name' => 'Test.jpg', 'key' => 'Test.jpg', 'alt' => null, 'caption' => null ] ] ],
-			[ '<image source="img"><alt><default>test alt</default></alt></image>', [ 'img' => 'test.jpg' ],
-			  [ [ 'url' => '', 'name' => 'Test.jpg', 'key' => 'Test.jpg', 'alt' => 'test alt', 'caption' => null ] ] ],
-			[ '<image source="img"><alt source="alt source"><default>test alt</default></alt></image>',
-			  [ 'img' => 'test.jpg', 'alt source' => 2 ],
-			  [ [ 'url' => '', 'name' => 'Test.jpg', 'key' => 'Test.jpg', 'alt' => 2, 'caption' => null ] ] ],
-			[ '<image source="img"><alt><default>test alt</default></alt><caption source="img"/></image>',
-			  [ 'img' => 'test.jpg' ],
-			  [ [ 'url' => '', 'name' => 'Test.jpg', 'key' => 'Test.jpg', 'alt' => 'test alt', 'caption' => 'test.jpg' ] ] ],
+			[ 
+				'<image source="img"></image>',
+				[ ],
+				[ [ 'url' => '', 'name' => '', 'key' => '', 'alt' => null, 'caption' => null ] ]
+			],
+			[
+				'<image source="img"></image>',
+				[ 'img' => 'test.jpg' ],
+			  	[ [ 'url' => '', 'name' => 'Test.jpg', 'key' => 'Test.jpg', 'alt' => null, 'caption' => null ] ]
+			],
+			[
+				'<image source="img"><alt><default>test alt</default></alt></image>',
+				[ 'img' => 'test.jpg' ],
+				[ [ 'url' => '', 'name' => 'Test.jpg', 'key' => 'Test.jpg', 'alt' => 'test alt', 'caption' => null ] ]
+			],
+			[
+				'<image source="img"><alt source="alt source"><default>test alt</default></alt></image>',
+				[ 'img' => 'test.jpg', 'alt source' => 2 ],
+				[ [ 'url' => '', 'name' => 'Test.jpg', 'key' => 'Test.jpg', 'alt' => 2, 'caption' => null ] ]
+			],
+			[
+				'<image source="img"><alt><default>test alt</default></alt><caption source="img"/></image>',
+				[ 'img' => 'test.jpg' ],
+				[ [ 'url' => '', 'name' => 'Test.jpg', 'key' => 'Test.jpg', 'alt' => 'test alt', 'caption' => 'test.jpg' ] ]
+			],
 		];
 	}
 


### PR DESCRIPTION
It would be preferred to test `<tabber>` and `<gallery>` with already existing "testData" and "dataProvider" methods in NodeImageTest.php but this is not possible at this moment because the way how PortableInfoboxes extension is written - it heavily depends on MediaWiki parsing pipeline and is very "statefull".

For instance let's say we are passing `<gallery>Wiki.png</gallery>` as a value of source parameter of `<image>` tag. One could expect that you would have access to that value inside the Node - but actually you can't - it's already replaced with UNIQ marker by Parser (specifically Preprocessor) - and that UNIQ marker does not refer to the original wikitext - but to the parsed wikitext (html).

I decided to identify most important and "tricky" methods in NodeImage.php code and test just them.

Currently we are working on first version/iteration of media collections in infoboxes - we don't know yet if we are going to stick to that backward compatibility so this code in the future might be either removed or refactored.
