### PR TITLE
RelatedPages: Limit the number of results taken from categorylinks

### DIFF
--- a/extensions/wikia/RelatedPages/RelatedPages.class.php
+++ b/extensions/wikia/RelatedPages/RelatedPages.class.php
@@ -13,6 +13,15 @@ class RelatedPages {
 
 	const LIMIT_MAX = 10;
 
+	/**
+	 * Limit the number of results taken from categorylinks and improve the performance on big wikis
+	 * by making the temporary table much smaller
+	 *
+	 * @author macbre
+	 * @see PLATFORM-1591
+	 */
+	const CATEGORY_LINKS_LIMIT = 100000;
+
 	protected function __construct() {
 	}
 
@@ -250,7 +259,9 @@ class RelatedPages {
 			array( "cl_from AS page_id" ),
 			array( "cl_to IN ( " . $dbr->makeList( $categories ) . " )" ),
 			__METHOD__,
-			array(),
+			[
+				'LIMIT' => self::CATEGORY_LINKS_LIMIT
+			],
 			$joinSql
 		);
 

--- a/extensions/wikia/RelatedPages/RelatedPages.class.php
+++ b/extensions/wikia/RelatedPages/RelatedPages.class.php
@@ -265,6 +265,10 @@ class RelatedPages {
 			$joinSql
 		);
 
+		# sanitize query parameters
+		$articleId = intval( $articleId );
+		$limit = intval( $limit );
+
 		$sql = "SELECT page_id, count(*) c FROM ( $innerSQL ) i WHERE page_id != $articleId GROUP BY page_id ORDER BY c desc LIMIT $limit";
 		$res = $dbr->query( $sql, __METHOD__ );
 		while ( $row = $dbr->fetchObject( $res ) ) {


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-1591

`RelatedPages::getPagesForCategories` performs a really have query on huge wikis (lyrics, answers) that involves a rather big temporary table and filesort. Let's make it a bit smaller by applying a limit on rows returned from `categorylinks` table.

This will still return the pages that are members of all required categories.

``` sql
mysql@slave.db-a.service.consul[lyricwiki]>explain SELECT /* RelatedPages::getPagesForCategories 10.8.68.11 */ page_id, count(*) c FROM ( SELECT  cl_from AS page_id  FROM `categorylinks` JOIN `page` ON ((page_id = cl_from AND page_namespace in ( '0','220' )))  WHERE (cl_to IN ( 'Song','Language/English','MusicBrainz/Song','Spotify/Song','ITunes/Song','Allmusic/Song' )) LIMIT 100000  ) i WHERE page_id != 1766532 GROUP BY page_id ORDER BY c desc LIMIT 20;
+----+-------------+---------------+-------+---------------------------------+------------+---------+------------------------+---------+----------------------------------------------+
| id | select_type | table         | type  | possible_keys                   | key        | key_len | ref                    | rows    | Extra                                        |
+----+-------------+---------------+-------+---------------------------------+------------+---------+------------------------+---------+----------------------------------------------+
|  1 | PRIMARY     | <derived2>    | ALL   | NULL                            | NULL       | NULL    | NULL                   |  100000 | Using where; Using temporary; Using filesort |
|  2 | DERIVED     | page          | range | PRIMARY,name_title              | name_title | 4       | NULL                   | 1319166 | Using where; Using index                     |
|  2 | DERIVED     | categorylinks | ref   | cl_from,cl_timestamp,cl_sortkey | cl_from    | 4       | lyricwiki.page.page_id |       4 | Using where; Using index                     |
+----+-------------+---------------+-------+---------------------------------+------------+---------+------------------------+---------+----------------------------------------------+
```

The query above took 0.26 sec with a LIMIT applied and ~15 without it.

@wladekb / @drozdo
