### PR TITLE
(CE-2754) Add chat.js to personal JS editing whitelist

### DIFF
--- a/extensions/wikia/ProtectSiteJS/ProtectSiteJS.class.php
+++ b/extensions/wikia/ProtectSiteJS/ProtectSiteJS.class.php
@@ -39,6 +39,7 @@ class ProtectSiteJS {
 	private static function isUserSkinJS( Title $title, User $user ) {
 		global $wgCityId;
 		$allowedJsSubpages = [
+			'chat',
 			'common',
 			'monobook',
 			'wikia',

--- a/extensions/wikia/ProtectSiteJS/tests/ProtectSiteJSTest.php
+++ b/extensions/wikia/ProtectSiteJS/tests/ProtectSiteJSTest.php
@@ -130,6 +130,20 @@ class ProtectSiteJSTest extends WikiaBaseTest {
 			],
 			[
 				[
+					'title' => 'SomeUser/chat.js',
+					'namespace' => NS_USER,
+					'username' => 'SomeUser',
+					'groups' => [],
+					'editinterfacetrusted' => false,
+					'wikiId' => 147,
+					'wgEnableContentReviewExt' => false,
+					'wgUseSiteJs' => true,
+				],
+				true,
+				'Valid user JS subpages can be edited by the user',
+			],
+			[
+				[
 					'title' => 'SomeUser/common.js',
 					'namespace' => NS_USER,
 					'username' => 'SomeUser',


### PR DESCRIPTION
Add chat.js to personal JS editing whitelist which is loaded in Chat
for the individual user.

/cc @Wikia/community-engineering 
