### PR TITLE
ADEN-2472 SP recovery variable cleanup

### DIFF
--- a/extensions/wikia/AdEngine/AdEngine2.setup.php
+++ b/extensions/wikia/AdEngine/AdEngine2.setup.php
@@ -19,7 +19,7 @@ $wgAutoloadClasses['AdEngine2Service'] =  __DIR__ . '/AdEngine2Service.class.php
 $wgAutoloadClasses['ResourceLoaderAdEngineBase'] = __DIR__ . '/ResourceLoaders/ResourceLoaderAdEngineBase.php';
 $wgAutoloadClasses['ResourceLoaderScript'] = __DIR__ . '/ResourceLoaders/ResourceLoaderScript.php';
 $wgAutoloadClasses['ResourceLoaderAdEngineSevenOneMediaModule'] = __DIR__ . '/ResourceLoaders/ResourceLoaderAdEngineSevenOneMediaModule.php';
-$wgAutoloadClasses['ResourceLoaderAdEngineSourcePointModule'] = __DIR__ . '/ResourceLoaders/ResourceLoaderAdEngineSourcePointModule.php';
+$wgAutoloadClasses['ResourceLoaderAdEngineSourcePointRecoveryModule'] = __DIR__ . '/ResourceLoaders/ResourceLoaderAdEngineSourcePointRecoveryModule.php';
 $wgAutoloadClasses['ResourceLoaderAdEngineSourcePointDetectionModule'] = __DIR__ . '/ResourceLoaders/ResourceLoaderAdEngineSourcePointDetectionModule.php';
 
 // Hooks for Exitstitial ads
@@ -52,7 +52,7 @@ $wgResourceModules['wikia.ext.adengine.sevenonemedia'] = array(
 );
 
 $wgResourceModules['wikia.ext.adengine.sourcepoint'] = array(
-	'class' => 'ResourceLoaderAdEngineSourcePointModule',
+	'class' => 'ResourceLoaderAdEngineSourcePointRecoveryModule',
 );
 
 $wgResourceModules['wikia.ext.adengine.sourcepoint.detection'] = array(

--- a/extensions/wikia/AdEngine/AdEngine2.setup.php
+++ b/extensions/wikia/AdEngine/AdEngine2.setup.php
@@ -51,11 +51,11 @@ $wgResourceModules['wikia.ext.adengine.sevenonemedia'] = array(
 	'class' => 'ResourceLoaderAdEngineSevenOneMediaModule',
 );
 
-$wgResourceModules['wikia.ext.adengine.sourcepoint'] = array(
+$wgResourceModules['wikia.ext.adengine.sp.recovery'] = array(
 	'class' => 'ResourceLoaderAdEngineSourcePointRecoveryModule',
 );
 
-$wgResourceModules['wikia.ext.adengine.sourcepoint.detection'] = array(
+$wgResourceModules['wikia.ext.adengine.sp.detection'] = array(
 	'class' => 'ResourceLoaderAdEngineSourcePointDetectionModule',
 );
 

--- a/extensions/wikia/AdEngine/AdEngine2ContextService.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2ContextService.class.php
@@ -29,9 +29,9 @@ class AdEngine2ContextService {
 			}
 
 			$sourcePointRecoveryUrl = null;
-			$sourcePointDetectionUrl = ResourceLoader::makeCustomURL( $wg->Out, ['wikia.ext.adengine.sourcepoint.detection'], 'scripts' );
+			$sourcePointDetectionUrl = ResourceLoader::makeCustomURL( $wg->Out, ['wikia.ext.adengine.sp.detection'], 'scripts' );
 			if ( $skinName === 'oasis' ) {
-				$sourcePointRecoveryUrl = ResourceLoader::makeCustomURL( $wg->Out, ['wikia.ext.adengine.sourcepoint'], 'scripts' );
+				$sourcePointRecoveryUrl = ResourceLoader::makeCustomURL( $wg->Out, ['wikia.ext.adengine.sp.recovery'], 'scripts' );
 			}
 
 			$langCode = $title->getPageLanguage()->getCode();

--- a/extensions/wikia/AdEngine/AdEngine2ContextService.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2ContextService.class.php
@@ -28,12 +28,10 @@ class AdEngine2ContextService {
 				$monetizationServiceAds = F::app()->sendRequest( 'MonetizationModule', 'index' )->getData()['data'];
 			}
 
-			$sourcePointUrl = null;
 			$sourcePointRecoveryUrl = null;
 			$sourcePointDetectionUrl = ResourceLoader::makeCustomURL( $wg->Out, ['wikia.ext.adengine.sourcepoint.detection'], 'scripts' );
 			if ( $skinName === 'oasis' ) {
 				$sourcePointRecoveryUrl = ResourceLoader::makeCustomURL( $wg->Out, ['wikia.ext.adengine.sourcepoint'], 'scripts' );
-				$sourcePointUrl = $sourcePointRecoveryUrl;
 			}
 
 			$langCode = $title->getPageLanguage()->getCode();
@@ -54,7 +52,7 @@ class AdEngine2ContextService {
 					'showAds' => $adPageTypeService->areAdsShowableOnPage(),
 					'trackSlotState' => $wg->AdDriverTrackState,
 					'usePostScribe' => $wg->Request->getBool( 'usepostscribe', false ),
-					'sourcePointUrl' => $sourcePointUrl,
+					'sourcePointUrl' => $sourcePointRecoveryUrl,
 					'sourcePointDetectionUrl' => $sourcePointDetectionUrl,
 					'sourcePointRecoveryUrl' => $sourcePointRecoveryUrl,
 				] ),

--- a/extensions/wikia/AdEngine/AdEngine2ContextService.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2ContextService.class.php
@@ -52,7 +52,7 @@ class AdEngine2ContextService {
 					'showAds' => $adPageTypeService->areAdsShowableOnPage(),
 					'trackSlotState' => $wg->AdDriverTrackState,
 					'usePostScribe' => $wg->Request->getBool( 'usepostscribe', false ),
-					'sourcePointUrl' => $sourcePointRecoveryUrl,
+					'sourcePointUrl' => $sourcePointRecoveryUrl, // @TODO ADEN-2578 - cleanup
 					'sourcePointDetectionUrl' => $sourcePointDetectionUrl,
 					'sourcePointRecoveryUrl' => $sourcePointRecoveryUrl,
 				] ),

--- a/extensions/wikia/AdEngine/AdEngine2ContextService.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2ContextService.class.php
@@ -29,9 +29,11 @@ class AdEngine2ContextService {
 			}
 
 			$sourcePointUrl = null;
+			$sourcePointRecoveryUrl = null;
 			$sourcePointDetectionUrl = ResourceLoader::makeCustomURL( $wg->Out, ['wikia.ext.adengine.sourcepoint.detection'], 'scripts' );
 			if ( $skinName === 'oasis' ) {
-				$sourcePointUrl = ResourceLoader::makeCustomURL( $wg->Out, ['wikia.ext.adengine.sourcepoint'], 'scripts' );
+				$sourcePointRecoveryUrl = ResourceLoader::makeCustomURL( $wg->Out, ['wikia.ext.adengine.sourcepoint'], 'scripts' );
+				$sourcePointUrl = $sourcePointRecoveryUrl;
 			}
 
 			$langCode = $title->getPageLanguage()->getCode();
@@ -54,6 +56,7 @@ class AdEngine2ContextService {
 					'usePostScribe' => $wg->Request->getBool( 'usepostscribe', false ),
 					'sourcePointUrl' => $sourcePointUrl,
 					'sourcePointDetectionUrl' => $sourcePointDetectionUrl,
+					'sourcePointRecoveryUrl' => $sourcePointRecoveryUrl,
 				] ),
 				'targeting' => $this->filterOutEmptyItems( [
 					'enableKruxTargeting' => $wg->EnableKruxTargeting,

--- a/extensions/wikia/AdEngine/AdEngine2Hooks.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2Hooks.class.php
@@ -54,6 +54,7 @@ class AdEngine2Hooks {
 		$vars[] = 'wgAdDriverSourcePointCountries';
 		$vars[] = 'wgAdDriverSourcePointDetectionCountries';
 		$vars[] = 'wgAdDriverSourcePointDetectionMobileCountries';
+		$vars[] = 'wgAdDriverSourcePointRecoveryCountries';
 		$vars[] = 'wgAdDriverScrollHandlerConfig';
 		$vars[] = 'wgAdDriverScrollHandlerCountries';
 		$vars[] = 'wgAdDriverTurtleCountries';

--- a/extensions/wikia/AdEngine/AdEngine2Hooks.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2Hooks.class.php
@@ -51,7 +51,7 @@ class AdEngine2Hooks {
 		$vars[] = 'wgAdDriverKruxCountries';
 		$vars[] = 'wgAdDriverOpenXBidderCountries';
 		$vars[] = 'wgAdDriverOpenXBidderCountriesMobile';
-		$vars[] = 'wgAdDriverSourcePointCountries';
+		$vars[] = 'wgAdDriverSourcePointCountries'; // @TODO ADEN-2578 - cleanup
 		$vars[] = 'wgAdDriverSourcePointDetectionCountries';
 		$vars[] = 'wgAdDriverSourcePointDetectionMobileCountries';
 		$vars[] = 'wgAdDriverSourcePointRecoveryCountries';

--- a/extensions/wikia/AdEngine/ResourceLoaders/ResourceLoaderAdEngineSourcePointDetectionModule.php
+++ b/extensions/wikia/AdEngine/ResourceLoaders/ResourceLoaderAdEngineSourcePointDetectionModule.php
@@ -2,7 +2,7 @@
 
 class ResourceLoaderAdEngineSourcePointDetectionModule extends ResourceLoaderAdEngineSourcePointRecoveryModule {
 	const CACHE_BUSTER = 2;     // increase this any time the local files change
-	const SCRIPT_DETECTION_URL = 'https://api.getsentinel.com/script/detection?delivery=bundle';
+	const SCRIPT_DETECTION_URL = 'https://api.sourcepoint.com/script/detection?delivery=bundle';
 
 	/**
 	 * Configure scripts that should be loaded into one package

--- a/extensions/wikia/AdEngine/ResourceLoaders/ResourceLoaderAdEngineSourcePointDetectionModule.php
+++ b/extensions/wikia/AdEngine/ResourceLoaders/ResourceLoaderAdEngineSourcePointDetectionModule.php
@@ -1,6 +1,6 @@
 <?php
 
-class ResourceLoaderAdEngineSourcePointDetectionModule extends ResourceLoaderAdEngineSourcePointModule {
+class ResourceLoaderAdEngineSourcePointDetectionModule extends ResourceLoaderAdEngineSourcePointRecoveryModule {
 	const CACHE_BUSTER = 2;     // increase this any time the local files change
 	const SCRIPT_DETECTION_URL = 'https://api.getsentinel.com/script/detection?delivery=bundle';
 

--- a/extensions/wikia/AdEngine/ResourceLoaders/ResourceLoaderAdEngineSourcePointRecoveryModule.php
+++ b/extensions/wikia/AdEngine/ResourceLoaders/ResourceLoaderAdEngineSourcePointRecoveryModule.php
@@ -1,6 +1,6 @@
 <?php
 
-class ResourceLoaderAdEngineSourcePointModule extends ResourceLoaderAdEngineBase {
+class ResourceLoaderAdEngineSourcePointRecoveryModule extends ResourceLoaderAdEngineBase {
 	const TTL_SCRIPTS = 86400;   // one day for fresh scripts from SourcePoint
 	const TTL_GRACE = 3600; // one hour for old scripts (served if we fail to fetch fresh scripts)
 	const CACHE_BUSTER = 14;     // increase this any time the local files change

--- a/extensions/wikia/AdEngine/js/AdContext.js
+++ b/extensions/wikia/AdEngine/js/AdContext.js
@@ -66,7 +66,7 @@ define('ext.wikia.adEngine.adContext', [
 
 		// SourcePoint recovery integration
 		if (context.opts.sourcePointDetection && context.opts.sourcePointRecoveryUrl) {
-			context.opts.sourcePointRecovery = isUrlParamSet('sourcepoint') ||
+			context.opts.sourcePointRecovery = isUrlParamSet('sourcepointrecovery') ||
 				geo.isProperGeo(instantGlobals.wgAdDriverSourcePointRecoveryCountries);
 		}
 

--- a/extensions/wikia/AdEngine/js/AdContext.js
+++ b/extensions/wikia/AdEngine/js/AdContext.js
@@ -64,14 +64,14 @@ define('ext.wikia.adEngine.adContext', [
 				geo.isProperGeo(instantGlobals.wgAdDriverSourcePointDetectionMobileCountries));
 		}
 
-		// SourcePoint integration
+		// SourcePoint recovery integration
 		if (context.opts.sourcePointDetection && context.opts.sourcePointUrl) {
-			context.opts.sourcePoint = isUrlParamSet('sourcepoint') ||
+			context.opts.sourcePointRecovery = isUrlParamSet('sourcepoint') ||
 				geo.isProperGeo(instantGlobals.wgAdDriverSourcePointRecoveryCountries);
 		}
 
 		// Recoverable ads message
-		if (context.opts.sourcePointDetection && !context.opts.sourcePoint && context.opts.showAds) {
+		if (context.opts.sourcePointDetection && !context.opts.sourcePointRecovery && context.opts.showAds) {
 			context.opts.recoveredAdsMessage = geo.isProperGeo(instantGlobals.wgAdDriverAdsRecoveryMessageCountries);
 		}
 

--- a/extensions/wikia/AdEngine/js/AdContext.js
+++ b/extensions/wikia/AdEngine/js/AdContext.js
@@ -65,7 +65,7 @@ define('ext.wikia.adEngine.adContext', [
 		}
 
 		// SourcePoint recovery integration
-		if (context.opts.sourcePointDetection && context.opts.sourcePointUrl) {
+		if (context.opts.sourcePointDetection && context.opts.sourcePointRecoveryUrl) {
 			context.opts.sourcePointRecovery = isUrlParamSet('sourcepoint') ||
 				geo.isProperGeo(instantGlobals.wgAdDriverSourcePointRecoveryCountries);
 		}

--- a/extensions/wikia/AdEngine/js/AdContext.js
+++ b/extensions/wikia/AdEngine/js/AdContext.js
@@ -67,7 +67,7 @@ define('ext.wikia.adEngine.adContext', [
 		// SourcePoint integration
 		if (context.opts.sourcePointDetection && context.opts.sourcePointUrl) {
 			context.opts.sourcePoint = isUrlParamSet('sourcepoint') ||
-				geo.isProperGeo(instantGlobals.wgAdDriverSourcePointCountries);
+				geo.isProperGeo(instantGlobals.wgAdDriverSourcePointRecoveryCountries);
 		}
 
 		// Recoverable ads message

--- a/extensions/wikia/AdEngine/js/AdContext.js
+++ b/extensions/wikia/AdEngine/js/AdContext.js
@@ -64,8 +64,9 @@ define('ext.wikia.adEngine.adContext', [
 				geo.isProperGeo(instantGlobals.wgAdDriverSourcePointDetectionMobileCountries));
 		}
 
+		// @TODO ADEN-2578 - cleanup
 		// SourcePoint recovery integration
-		if (context.opts.sourcePointDetection && context.opts.sourcePointRecoveryUrl) {
+		if (context.opts.sourcePointDetection && (context.opts.sourcePointRecoveryUrl || context.opts.sourcePointUrl)) {
 			context.opts.sourcePointRecovery = isUrlParamSet('sourcepointrecovery') ||
 				geo.isProperGeo(instantGlobals.wgAdDriverSourcePointRecoveryCountries);
 		}

--- a/extensions/wikia/AdEngine/js/provider/gpt/helper.js
+++ b/extensions/wikia/AdEngine/js/provider/gpt/helper.js
@@ -27,14 +27,14 @@ define('ext.wikia.adEngine.provider.gpt.helper', [
 
 	var logGroup = 'ext.wikia.adEngine.provider.gpt.helper',
 		googleApi = new GoogleTag(),
-		sourcePointInitialized = false;
+		recoveryInitialized = false;
 
 	function loadRecovery() {
-		if (sourcePointInitialized) {
+		if (recoveryInitialized) {
 			return;
 		}
 		log('SourcePoint recovery enabled', 'debug', logGroup);
-		sourcePointInitialized = true;
+		recoveryInitialized = true;
 		googleApi = recoveryHelper.createSourcePointTag();
 		recoveryHelper.recoverSlots();
 	}

--- a/extensions/wikia/AdEngine/js/provider/gpt/sourcePointTag.js
+++ b/extensions/wikia/AdEngine/js/provider/gpt/sourcePointTag.js
@@ -28,7 +28,7 @@ define('ext.wikia.adEngine.provider.gpt.sourcePointTag', [
 
 		gads.async = true;
 		gads.type = 'text/javascript';
-		gads.src = context.opts.sourcePointUrl;
+		gads.src = context.opts.sourcePointRecoveryUrl;
 		gads.setAttribute('data-client-id', sourcePoint.getClientId());
 
 		gads.addEventListener('load', function () {

--- a/extensions/wikia/AdEngine/js/provider/gpt/sourcePointTag.js
+++ b/extensions/wikia/AdEngine/js/provider/gpt/sourcePointTag.js
@@ -28,7 +28,7 @@ define('ext.wikia.adEngine.provider.gpt.sourcePointTag', [
 
 		gads.async = true;
 		gads.type = 'text/javascript';
-		gads.src = context.opts.sourcePointRecoveryUrl;
+		gads.src = context.opts.sourcePointRecoveryUrl || context.opts.sourcePointUrl; // @TODO ADEN-2578 - cleanup
 		gads.setAttribute('data-client-id', sourcePoint.getClientId());
 
 		gads.addEventListener('load', function () {

--- a/extensions/wikia/AdEngine/js/recovery/helper.js
+++ b/extensions/wikia/AdEngine/js/recovery/helper.js
@@ -41,7 +41,7 @@ define('ext.wikia.adEngine.recovery.helper', [
 	}
 
 	function isRecoveryEnabled() {
-		return !!(context.opts.sourcePoint && SourcePointTag);
+		return !!(context.opts.sourcePointRecovery && SourcePointTag);
 	}
 
 	function isBlocking() {

--- a/extensions/wikia/AdEngine/js/recovery/helper.js
+++ b/extensions/wikia/AdEngine/js/recovery/helper.js
@@ -11,8 +11,8 @@ define('ext.wikia.adEngine.recovery.helper', [
 	doc,
 	lazyQueue,
 	log,
-	SourcePointTag,
-	win
+	win,
+	SourcePointTag
 ) {
 	'use strict';
 

--- a/extensions/wikia/AdEngine/js/recovery/helper.js
+++ b/extensions/wikia/AdEngine/js/recovery/helper.js
@@ -1,15 +1,18 @@
+/*global define, require*/
 define('ext.wikia.adEngine.recovery.helper', [
 	'ext.wikia.adEngine.adContext',
 	'wikia.document',
 	'wikia.lazyqueue',
 	'wikia.log',
+	'wikia.window',
 	require.optional('ext.wikia.adEngine.provider.gpt.sourcePointTag')
 ], function (
 	adContext,
 	doc,
 	lazyQueue,
 	log,
-	SourcePointTag
+	SourcePointTag,
+	win
 ) {
 	'use strict';
 
@@ -45,7 +48,7 @@ define('ext.wikia.adEngine.recovery.helper', [
 	}
 
 	function isBlocking() {
-		return !!(window.ads && window.ads.runtime.sp.blocking);
+		return !!(win.ads && win.ads.runtime.sp.blocking);
 	}
 
 	function isRecoverable(slotName, recoverableSlots) {
@@ -59,7 +62,7 @@ define('ext.wikia.adEngine.recovery.helper', [
 
 		log(['Starting recovery', slotsToRecover], 'debug', logGroup);
 		while (slotsToRecover.length) {
-			window.ads.runtime.sp.slots.push([slotsToRecover.shift()]);
+			win.ads.runtime.sp.slots.push([slotsToRecover.shift()]);
 		}
 	}
 

--- a/extensions/wikia/AdEngine/js/run/desktop.run.js
+++ b/extensions/wikia/AdEngine/js/run/desktop.run.js
@@ -90,7 +90,7 @@ require([
 		recoveryHelper.initEventQueue();
 		sourcePoint.initDetection();
 
-		if (context.opts.sourcePoint && win.ads) {
+		if (context.opts.sourcePointRecovery && win.ads) {
 			win.ads.runtime.sp.slots = win.ads.runtime.sp.slots || [];
 			recoveryHelper.addOnBlockingCallback(function () {
 				adTracker.measureTime('adengine.init', 'queue.desktop').track();

--- a/extensions/wikia/AdEngine/js/run/desktop.run.js
+++ b/extensions/wikia/AdEngine/js/run/desktop.run.js
@@ -93,7 +93,7 @@ require([
 		if (context.opts.sourcePointRecovery && win.ads) {
 			win.ads.runtime.sp.slots = win.ads.runtime.sp.slots || [];
 			recoveryHelper.addOnBlockingCallback(function () {
-				adTracker.measureTime('adengine.init', 'queue.desktop').track();
+				adTracker.measureTime('adengine.init', 'queue.sp').track();
 				adEngine.run(adConfigDesktop, win.ads.runtime.sp.slots, 'queue.sp');
 			});
 		}

--- a/extensions/wikia/AdEngine/js/spec/AdContext.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/AdContext.spec.js
@@ -406,49 +406,49 @@ describe('AdContext', function () {
 		expect(getModule().getContext().targeting.enableKruxTargeting).toBeFalsy();
 	});
 
-	it('disables SourcePoint when url is not set (e.g. for mercury skin)', function () {
+	it('disables recovery when url is not set (e.g. for mercury skin)', function () {
 		mocks.win = {ads: {context: {opts: {sourcePointDetection: true}}}};
 		mocks.instantGlobals = {wgAdDriverSourcePointRecoveryCountries: ['CURRENT_COUNTRY', 'ZZ']};
 
 		expect(getModule().getContext().opts.sourcePointRecovery).toBe(undefined);
 	});
 
-	it('enables SourcePoint when country in instant var', function () {
+	it('enables recovery when country in instant var', function () {
 		mocks.win = {ads: {context: {opts: {sourcePointRecoveryUrl: '//foo.bar', sourcePointDetection: true}}}};
 		mocks.instantGlobals = {wgAdDriverSourcePointRecoveryCountries: ['CURRENT_COUNTRY', 'ZZ']};
 
 		expect(getModule().getContext().opts.sourcePointRecovery).toBeTruthy();
 	});
 
-	it('enables SourcePoint when region in instant var', function () {
+	it('enables recovery when region in instant var', function () {
 		mocks.win = {ads: {context: {opts: {sourcePointRecoveryUrl: '//foo.bar', sourcePointDetection: true}}}};
 		mocks.instantGlobals = {wgAdDriverSourcePointRecoveryCountries: ['CURRENT_COUNTRY-CURRENT_REGION']};
 
 		expect(getModule().getContext().opts.sourcePointRecovery).toBeTruthy();
 	});
 
-	it('enables SourcePoint when country and region in instant var (country overwrites region)', function () {
+	it('enables recovery when country and region in instant var (country overwrites region)', function () {
 		mocks.win = {ads: {context: {opts: {sourcePointRecoveryUrl: '//foo.bar', sourcePointDetection: true}}}};
 		mocks.instantGlobals = {wgAdDriverSourcePointRecoveryCountries: ['CURRENT_COUNTRY-EE', 'CURRENT_COUNTRY']};
 
 		expect(getModule().getContext().opts.sourcePointRecovery).toBeTruthy();
 	});
 
-	it('disables SourcePoint when country and region in instant var and both are invalid', function () {
+	it('disables recovery when country and region in instant var and both are invalid', function () {
 		mocks.win = {ads: {context: {opts: {sourcePointRecoveryUrl: '//foo.bar', sourcePointDetection: true}}}};
 		mocks.instantGlobals = {wgAdDriverSourcePointRecoveryCountries: ['CURRENT_COUNTRY-EE', 'YY']};
 
 		expect(getModule().getContext().opts.sourcePointRecovery).toBeFalsy();
 	});
 
-	it('disables SourcePoint when detection is disabled', function () {
+	it('disables recovery when detection is disabled', function () {
 		mocks.win = {ads: {context: {opts: {sourcePointRecoveryUrl: '//foo.bar'}}}};
 		mocks.instantGlobals = {wgAdDriverSourcePointRecoveryCountries: ['CURRENT_COUNTRY', 'ZZ']};
 
 		expect(getModule().getContext().opts.sourcePointRecovery).toBeFalsy();
 	});
 
-	it('enables SourcePoint when url param sourcepoint is set', function () {
+	it('enables recovery when url param sourcepointrecovery is set', function () {
 		mocks.win = {ads: {context: {opts: {sourcePointRecoveryUrl: '//foo.bar', sourcePointDetection: true}}}};
 		spyOn(mocks.querystring, 'getVal').and.callFake(function (param) {
 			return param === 'sourcepointrecovery' ?  '1' : '0';
@@ -457,14 +457,14 @@ describe('AdContext', function () {
 		expect(getModule().getContext().opts.sourcePointRecovery).toBeTruthy();
 	});
 
-	it('disables SourcePoint detection when url is not set', function () {
+	it('disables detection when url is not set', function () {
 		mocks.instantGlobals = {wgAdDriverSourcePointDetectionCountries: ['CURRENT_COUNTRY', 'ZZ']};
 
 		expect(getModule().getContext().opts.sourcePointDetection).toBe(undefined);
 		expect(getModule().getContext().opts.sourcePointDetectionMobile).toBe(undefined);
 	});
 
-	it('enables SourcePoint detection when instantGlobals.wgAdDriverSourcePointDetectionCountries', function () {
+	it('enables detection when instantGlobals.wgAdDriverSourcePointDetectionCountries', function () {
 		mocks.win = {
 			ads: {
 				context: {
@@ -482,7 +482,7 @@ describe('AdContext', function () {
 		expect(getModule().getContext().opts.sourcePointDetection).toBeTruthy();
 	});
 
-	it('disables SourcePoint detection when url param noexternals=1 is set', function () {
+	it('disables detection when url param noexternals=1 is set', function () {
 		mocks.win = {ads: {context: {opts: {sourcePointDetectionUrl: '//foo.bar'}}}};
 		mocks.instantGlobals = {wgAdDriverSourcePointDetectionCountries: ['CURRENT_COUNTRY', 'ZZ']};
 		spyOn(mocks.querystring, 'getVal').and.callFake(function (param) {
@@ -492,7 +492,7 @@ describe('AdContext', function () {
 		expect(getModule().getContext().opts.sourcePointDetection).toBeFalsy();
 	});
 
-	it('enables SourcePoint detection when url param sourcepointdetection is set', function () {
+	it('enables detection when url param sourcepointdetection is set', function () {
 		mocks.win = {
 			ads: {
 				context: {
@@ -510,7 +510,7 @@ describe('AdContext', function () {
 		expect(getModule().getContext().opts.sourcePointDetectionMobile).toBeTruthy();
 	});
 
-	it('enables SourcePoint detection when instantGlobals.wgAdDriverSourcePointDetectionMobileCountries', function () {
+	it('enables detection when instantGlobals.wgAdDriverSourcePointDetectionMobileCountries', function () {
 		mocks.win = {
 			ads: {
 				context: {
@@ -528,7 +528,7 @@ describe('AdContext', function () {
 		expect(getModule().getContext().opts.sourcePointDetectionMobile).toBeTruthy();
 	});
 
-	it('enables SourcePoint detection when ' +
+	it('enables detection when ' +
 	'instantGlobals.wgAdDriverSourcePointDetectionCountries is enabled for continent', function () {
 		mocks.win = {
 			ads: {
@@ -582,7 +582,7 @@ describe('AdContext', function () {
 		expect(getModule().getContext().opts.scrollHandlerConfig).toBe(config);
 	});
 
-	it('enables recoveredAdsMessage when country in instant var and SourcePoint detection is on', function () {
+	it('enables recoveredAdsMessage when country in instant var and detection is on', function () {
 		mocks.win = {
 			ads: {
 				context: {
@@ -604,7 +604,7 @@ describe('AdContext', function () {
 		expect(getModule().getContext().opts.recoveredAdsMessage).toBeTruthy();
 	});
 
-	it('enables recoveredAdsMessage when region in instant var and SourcePoint detection is on', function () {
+	it('enables recoveredAdsMessage when region in instant var and detection is on', function () {
 		mocks.win = {
 			ads: {
 				context: {
@@ -669,7 +669,7 @@ describe('AdContext', function () {
 		expect(getModule().getContext().opts.recoveredAdsMessage).toBeFalsy();
 	});
 
-	it('disables recoveredAdsMessage when SourcePoint detection is off', function () {
+	it('disables recoveredAdsMessage when detection is off', function () {
 		mocks.win = {
 			ads: {
 				context: {

--- a/extensions/wikia/AdEngine/js/spec/AdContext.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/AdContext.spec.js
@@ -451,7 +451,7 @@ describe('AdContext', function () {
 	it('enables SourcePoint when url param sourcepoint is set', function () {
 		mocks.win = {ads: {context: {opts: {sourcePointRecoveryUrl: '//foo.bar', sourcePointDetection: true}}}};
 		spyOn(mocks.querystring, 'getVal').and.callFake(function (param) {
-			return param === 'sourcepoint' ?  '1' : '0';
+			return param === 'sourcepointrecovery' ?  '1' : '0';
 		});
 
 		expect(getModule().getContext().opts.sourcePointRecovery).toBeTruthy();

--- a/extensions/wikia/AdEngine/js/spec/AdContext.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/AdContext.spec.js
@@ -410,42 +410,42 @@ describe('AdContext', function () {
 		mocks.win = {ads: {context: {opts: {sourcePointDetection: true}}}};
 		mocks.instantGlobals = {wgAdDriverSourcePointRecoveryCountries: ['CURRENT_COUNTRY', 'ZZ']};
 
-		expect(getModule().getContext().opts.sourcePoint).toBe(undefined);
+		expect(getModule().getContext().opts.sourcePointRecovery).toBe(undefined);
 	});
 
 	it('enables SourcePoint when country in instant var', function () {
 		mocks.win = {ads: {context: {opts: {sourcePointUrl: '//foo.bar', sourcePointDetection: true}}}};
 		mocks.instantGlobals = {wgAdDriverSourcePointRecoveryCountries: ['CURRENT_COUNTRY', 'ZZ']};
 
-		expect(getModule().getContext().opts.sourcePoint).toBeTruthy();
+		expect(getModule().getContext().opts.sourcePointRecovery).toBeTruthy();
 	});
 
 	it('enables SourcePoint when region in instant var', function () {
 		mocks.win = {ads: {context: {opts: {sourcePointUrl: '//foo.bar', sourcePointDetection: true}}}};
 		mocks.instantGlobals = {wgAdDriverSourcePointRecoveryCountries: ['CURRENT_COUNTRY-CURRENT_REGION']};
 
-		expect(getModule().getContext().opts.sourcePoint).toBeTruthy();
+		expect(getModule().getContext().opts.sourcePointRecovery).toBeTruthy();
 	});
 
 	it('enables SourcePoint when country and region in instant var (country overwrites region)', function () {
 		mocks.win = {ads: {context: {opts: {sourcePointUrl: '//foo.bar', sourcePointDetection: true}}}};
 		mocks.instantGlobals = {wgAdDriverSourcePointRecoveryCountries: ['CURRENT_COUNTRY-EE', 'CURRENT_COUNTRY']};
 
-		expect(getModule().getContext().opts.sourcePoint).toBeTruthy();
+		expect(getModule().getContext().opts.sourcePointRecovery).toBeTruthy();
 	});
 
 	it('disables SourcePoint when country and region in instant var and both are invalid', function () {
 		mocks.win = {ads: {context: {opts: {sourcePointUrl: '//foo.bar', sourcePointDetection: true}}}};
 		mocks.instantGlobals = {wgAdDriverSourcePointRecoveryCountries: ['CURRENT_COUNTRY-EE', 'YY']};
 
-		expect(getModule().getContext().opts.sourcePoint).toBeFalsy();
+		expect(getModule().getContext().opts.sourcePointRecovery).toBeFalsy();
 	});
 
 	it('disables SourcePoint when detection is disabled', function () {
 		mocks.win = {ads: {context: {opts: {sourcePointUrl: '//foo.bar'}}}};
 		mocks.instantGlobals = {wgAdDriverSourcePointRecoveryCountries: ['CURRENT_COUNTRY', 'ZZ']};
 
-		expect(getModule().getContext().opts.sourcePoint).toBeFalsy();
+		expect(getModule().getContext().opts.sourcePointRecovery).toBeFalsy();
 	});
 
 	it('enables SourcePoint when url param sourcepoint is set', function () {
@@ -454,7 +454,7 @@ describe('AdContext', function () {
 			return param === 'sourcepoint' ?  '1' : '0';
 		});
 
-		expect(getModule().getContext().opts.sourcePoint).toBeTruthy();
+		expect(getModule().getContext().opts.sourcePointRecovery).toBeTruthy();
 	});
 
 	it('disables SourcePoint detection when url is not set', function () {

--- a/extensions/wikia/AdEngine/js/spec/AdContext.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/AdContext.spec.js
@@ -408,42 +408,42 @@ describe('AdContext', function () {
 
 	it('disables SourcePoint when url is not set (e.g. for mercury skin)', function () {
 		mocks.win = {ads: {context: {opts: {sourcePointDetection: true}}}};
-		mocks.instantGlobals = {wgAdDriverSourcePointCountries: ['CURRENT_COUNTRY', 'ZZ']};
+		mocks.instantGlobals = {wgAdDriverSourcePointRecoveryCountries: ['CURRENT_COUNTRY', 'ZZ']};
 
 		expect(getModule().getContext().opts.sourcePoint).toBe(undefined);
 	});
 
 	it('enables SourcePoint when country in instant var', function () {
 		mocks.win = {ads: {context: {opts: {sourcePointUrl: '//foo.bar', sourcePointDetection: true}}}};
-		mocks.instantGlobals = {wgAdDriverSourcePointCountries: ['CURRENT_COUNTRY', 'ZZ']};
+		mocks.instantGlobals = {wgAdDriverSourcePointRecoveryCountries: ['CURRENT_COUNTRY', 'ZZ']};
 
 		expect(getModule().getContext().opts.sourcePoint).toBeTruthy();
 	});
 
 	it('enables SourcePoint when region in instant var', function () {
 		mocks.win = {ads: {context: {opts: {sourcePointUrl: '//foo.bar', sourcePointDetection: true}}}};
-		mocks.instantGlobals = {wgAdDriverSourcePointCountries: ['CURRENT_COUNTRY-CURRENT_REGION']};
+		mocks.instantGlobals = {wgAdDriverSourcePointRecoveryCountries: ['CURRENT_COUNTRY-CURRENT_REGION']};
 
 		expect(getModule().getContext().opts.sourcePoint).toBeTruthy();
 	});
 
 	it('enables SourcePoint when country and region in instant var (country overwrites region)', function () {
 		mocks.win = {ads: {context: {opts: {sourcePointUrl: '//foo.bar', sourcePointDetection: true}}}};
-		mocks.instantGlobals = {wgAdDriverSourcePointCountries: ['CURRENT_COUNTRY-EE', 'CURRENT_COUNTRY']};
+		mocks.instantGlobals = {wgAdDriverSourcePointRecoveryCountries: ['CURRENT_COUNTRY-EE', 'CURRENT_COUNTRY']};
 
 		expect(getModule().getContext().opts.sourcePoint).toBeTruthy();
 	});
 
 	it('disables SourcePoint when country and region in instant var and both are invalid', function () {
 		mocks.win = {ads: {context: {opts: {sourcePointUrl: '//foo.bar', sourcePointDetection: true}}}};
-		mocks.instantGlobals = {wgAdDriverSourcePointCountries: ['CURRENT_COUNTRY-EE', 'YY']};
+		mocks.instantGlobals = {wgAdDriverSourcePointRecoveryCountries: ['CURRENT_COUNTRY-EE', 'YY']};
 
 		expect(getModule().getContext().opts.sourcePoint).toBeFalsy();
 	});
 
 	it('disables SourcePoint when detection is disabled', function () {
 		mocks.win = {ads: {context: {opts: {sourcePointUrl: '//foo.bar'}}}};
-		mocks.instantGlobals = {wgAdDriverSourcePointCountries: ['CURRENT_COUNTRY', 'ZZ']};
+		mocks.instantGlobals = {wgAdDriverSourcePointRecoveryCountries: ['CURRENT_COUNTRY', 'ZZ']};
 
 		expect(getModule().getContext().opts.sourcePoint).toBeFalsy();
 	});

--- a/extensions/wikia/AdEngine/js/spec/AdContext.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/AdContext.spec.js
@@ -414,42 +414,42 @@ describe('AdContext', function () {
 	});
 
 	it('enables SourcePoint when country in instant var', function () {
-		mocks.win = {ads: {context: {opts: {sourcePointUrl: '//foo.bar', sourcePointDetection: true}}}};
+		mocks.win = {ads: {context: {opts: {sourcePointRecoveryUrl: '//foo.bar', sourcePointDetection: true}}}};
 		mocks.instantGlobals = {wgAdDriverSourcePointRecoveryCountries: ['CURRENT_COUNTRY', 'ZZ']};
 
 		expect(getModule().getContext().opts.sourcePointRecovery).toBeTruthy();
 	});
 
 	it('enables SourcePoint when region in instant var', function () {
-		mocks.win = {ads: {context: {opts: {sourcePointUrl: '//foo.bar', sourcePointDetection: true}}}};
+		mocks.win = {ads: {context: {opts: {sourcePointRecoveryUrl: '//foo.bar', sourcePointDetection: true}}}};
 		mocks.instantGlobals = {wgAdDriverSourcePointRecoveryCountries: ['CURRENT_COUNTRY-CURRENT_REGION']};
 
 		expect(getModule().getContext().opts.sourcePointRecovery).toBeTruthy();
 	});
 
 	it('enables SourcePoint when country and region in instant var (country overwrites region)', function () {
-		mocks.win = {ads: {context: {opts: {sourcePointUrl: '//foo.bar', sourcePointDetection: true}}}};
+		mocks.win = {ads: {context: {opts: {sourcePointRecoveryUrl: '//foo.bar', sourcePointDetection: true}}}};
 		mocks.instantGlobals = {wgAdDriverSourcePointRecoveryCountries: ['CURRENT_COUNTRY-EE', 'CURRENT_COUNTRY']};
 
 		expect(getModule().getContext().opts.sourcePointRecovery).toBeTruthy();
 	});
 
 	it('disables SourcePoint when country and region in instant var and both are invalid', function () {
-		mocks.win = {ads: {context: {opts: {sourcePointUrl: '//foo.bar', sourcePointDetection: true}}}};
+		mocks.win = {ads: {context: {opts: {sourcePointRecoveryUrl: '//foo.bar', sourcePointDetection: true}}}};
 		mocks.instantGlobals = {wgAdDriverSourcePointRecoveryCountries: ['CURRENT_COUNTRY-EE', 'YY']};
 
 		expect(getModule().getContext().opts.sourcePointRecovery).toBeFalsy();
 	});
 
 	it('disables SourcePoint when detection is disabled', function () {
-		mocks.win = {ads: {context: {opts: {sourcePointUrl: '//foo.bar'}}}};
+		mocks.win = {ads: {context: {opts: {sourcePointRecoveryUrl: '//foo.bar'}}}};
 		mocks.instantGlobals = {wgAdDriverSourcePointRecoveryCountries: ['CURRENT_COUNTRY', 'ZZ']};
 
 		expect(getModule().getContext().opts.sourcePointRecovery).toBeFalsy();
 	});
 
 	it('enables SourcePoint when url param sourcepoint is set', function () {
-		mocks.win = {ads: {context: {opts: {sourcePointUrl: '//foo.bar', sourcePointDetection: true}}}};
+		mocks.win = {ads: {context: {opts: {sourcePointRecoveryUrl: '//foo.bar', sourcePointDetection: true}}}};
 		spyOn(mocks.querystring, 'getVal').and.callFake(function (param) {
 			return param === 'sourcepoint' ?  '1' : '0';
 		});

--- a/extensions/wikia/AdEngine/js/spec/provider/gpt/sourcePointTag.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/provider/gpt/sourcePointTag.spec.js
@@ -9,7 +9,7 @@ describe('ext.wikia.adEngine.provider.gpt.sourcePointTag', function () {
 				getContext: function () {
 					return {
 						opts: {
-							sourcePointUrl: '//foo.url'
+							sourcePointRecoveryUrl: '//foo.url'
 						}
 					};
 				}

--- a/extensions/wikia/AdEngine/tests/AdEngine2ContextServiceTest.php
+++ b/extensions/wikia/AdEngine/tests/AdEngine2ContextServiceTest.php
@@ -389,7 +389,7 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 		if ( $skinName === 'oasis' ) {
 			$this->assertStringMatchesFormat( $expectedSourcePointRecoveryUrlFormat, $result['opts']['sourcePointRecoveryUrl'] );
 			unset( $result['opts']['sourcePointRecoveryUrl'] );
-			unset( $result['opts']['sourcePointUrl'] );
+			unset( $result['opts']['sourcePointUrl'] ); // @TODO ADEN-2578 - cleanup
 		}
 		$this->assertStringMatchesFormat( $expectedSourcePointDetectionUrlFormat, $result['opts']['sourcePointDetectionUrl'] );
 		unset( $result['opts']['sourcePointDetectionUrl'] );

--- a/extensions/wikia/AdEngine/tests/AdEngine2ContextServiceTest.php
+++ b/extensions/wikia/AdEngine/tests/AdEngine2ContextServiceTest.php
@@ -264,8 +264,8 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 		$shortCat = 'shortcat';
 		$sevenOneMediaSub2Site = 'customsub2site';
 		$expectedSevenOneMediaUrlFormat = 'http://%s/__load/-/cb%3D%d%26debug%3Dfalse%26lang%3D%s%26only%3Dscripts%26skin%3Doasis/wikia.ext.adengine.sevenonemedia';
-		$expectedSourcePointDetectionUrlFormat = 'http://%s/__load/-/cb%3D%d%26debug%3Dfalse%26lang%3D%s%26only%3Dscripts%26skin%3Doasis/wikia.ext.adengine.sourcepoint.detection';
-		$expectedSourcePointRecoveryUrlFormat = 'http://%s/__load/-/cb%3D%d%26debug%3Dfalse%26lang%3D%s%26only%3Dscripts%26skin%3Doasis/wikia.ext.adengine.sourcepoint';
+		$expectedSourcePointDetectionUrlFormat = 'http://%s/__load/-/cb%3D%d%26debug%3Dfalse%26lang%3D%s%26only%3Dscripts%26skin%3Doasis/wikia.ext.adengine.sp.detection';
+		$expectedSourcePointRecoveryUrlFormat = 'http://%s/__load/-/cb%3D%d%26debug%3Dfalse%26lang%3D%s%26only%3Dscripts%26skin%3Doasis/wikia.ext.adengine.sp.recovery';
 
 		if ( $titleMockType === 'article' || $titleMockType === 'mainpage' ) {
 			$expectedTargeting['pageArticleId'] = $artId;

--- a/extensions/wikia/AdEngine/tests/AdEngine2ContextServiceTest.php
+++ b/extensions/wikia/AdEngine/tests/AdEngine2ContextServiceTest.php
@@ -266,7 +266,6 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 		$expectedSevenOneMediaUrlFormat = 'http://%s/__load/-/cb%3D%d%26debug%3Dfalse%26lang%3D%s%26only%3Dscripts%26skin%3Doasis/wikia.ext.adengine.sevenonemedia';
 		$expectedSourcePointDetectionUrlFormat = 'http://%s/__load/-/cb%3D%d%26debug%3Dfalse%26lang%3D%s%26only%3Dscripts%26skin%3Doasis/wikia.ext.adengine.sourcepoint.detection';
 		$expectedSourcePointRecoveryUrlFormat = 'http://%s/__load/-/cb%3D%d%26debug%3Dfalse%26lang%3D%s%26only%3Dscripts%26skin%3Doasis/wikia.ext.adengine.sourcepoint';
-		$expectedSourcePointUrlFormat = $expectedSourcePointRecoveryUrlFormat;
 
 		if ( $titleMockType === 'article' || $titleMockType === 'mainpage' ) {
 			$expectedTargeting['pageArticleId'] = $artId;

--- a/extensions/wikia/AdEngine/tests/AdEngine2ContextServiceTest.php
+++ b/extensions/wikia/AdEngine/tests/AdEngine2ContextServiceTest.php
@@ -264,8 +264,9 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 		$shortCat = 'shortcat';
 		$sevenOneMediaSub2Site = 'customsub2site';
 		$expectedSevenOneMediaUrlFormat = 'http://%s/__load/-/cb%3D%d%26debug%3Dfalse%26lang%3D%s%26only%3Dscripts%26skin%3Doasis/wikia.ext.adengine.sevenonemedia';
-		$expectedSourcePointUrlFormat = 'http://%s/__load/-/cb%3D%d%26debug%3Dfalse%26lang%3D%s%26only%3Dscripts%26skin%3Doasis/wikia.ext.adengine.sourcepoint';
 		$expectedSourcePointDetectionUrlFormat = 'http://%s/__load/-/cb%3D%d%26debug%3Dfalse%26lang%3D%s%26only%3Dscripts%26skin%3Doasis/wikia.ext.adengine.sourcepoint.detection';
+		$expectedSourcePointRecoveryUrlFormat = 'http://%s/__load/-/cb%3D%d%26debug%3Dfalse%26lang%3D%s%26only%3Dscripts%26skin%3Doasis/wikia.ext.adengine.sourcepoint';
+		$expectedSourcePointUrlFormat = $expectedSourcePointRecoveryUrlFormat;
 
 		if ( $titleMockType === 'article' || $titleMockType === 'mainpage' ) {
 			$expectedTargeting['pageArticleId'] = $artId;
@@ -387,7 +388,8 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 
 		// Check for SourcePoint URL
 		if ( $skinName === 'oasis' ) {
-			$this->assertStringMatchesFormat( $expectedSourcePointUrlFormat, $result['opts']['sourcePointUrl'] );
+			$this->assertStringMatchesFormat( $expectedSourcePointRecoveryUrlFormat, $result['opts']['sourcePointRecoveryUrl'] );
+			unset( $result['opts']['sourcePointRecoveryUrl'] );
 			unset( $result['opts']['sourcePointUrl'] );
 		}
 		$this->assertStringMatchesFormat( $expectedSourcePointDetectionUrlFormat, $result['opts']['sourcePointDetectionUrl'] );

--- a/extensions/wikia/AdEngine/tests/ResourceLoaderAdEngineTest.php
+++ b/extensions/wikia/AdEngine/tests/ResourceLoaderAdEngineTest.php
@@ -96,11 +96,11 @@ class ResourceLoaderAdEngineTest extends WikiaBaseTest {
 	public function testSourcePointModule() {
 		$this->disableMemCache();
 
-		$mock = $this->getMockBuilder('ResourceLoaderAdEngineSourcePointModule')
+		$mock = $this->getMockBuilder('ResourceLoaderAdEngineSourcePointRecoveryModule')
 			->disableOriginalConstructor()
 			->setMethods( [ 'fetchRemoteScript', 'fetchLocalScript', 'getInlineScript' ] )
 			->getMock();
-		ResourceLoaderAdEngineSourcePointModule::$localCache[get_class($mock)] = null;
+		ResourceLoaderAdEngineSourcePointRecoveryModule::$localCache[get_class($mock)] = null;
 		$mock->method( 'fetchRemoteScript' )->willReturn( self::REMOTE_SCRIPT_MOCK_CONTENT );
 		$mock->method( 'fetchLocalScript' )->willReturn( self::LOCAL_SCRIPT_MOCK_CONTENT );
 		$mock->method( 'getInlineScript' )->willReturn( self::INLINE_SCRIPT_MOCK_CONTENT );
@@ -113,7 +113,7 @@ class ResourceLoaderAdEngineTest extends WikiaBaseTest {
 
 		$this->assertEquals( implode( PHP_EOL, $sourcePointScripts ), $script );
 		$this->assertEquals( $mock->getModifiedTime( $this->resourceLoaderContext )
-			+ ResourceLoaderAdEngineSourcePointModule::TTL_SCRIPTS, $mock->getTtl() );
+			+ ResourceLoaderAdEngineSourcePointRecoveryModule::TTL_SCRIPTS, $mock->getTtl() );
 	}
 
 }

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1527,6 +1527,7 @@ $wgAdDriverOpenXCountries = null;
 
 /**
  * @name $wgAdDriverSourcePointCountries
+ * @TODO ADEN-2578 - cleanup
  * List of countries to call ads through SourcePoint
  * ONLY UPDATE THROUGH WIKI FACTORY ON COMMUNITY - it's an instant global.
  */

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1547,6 +1547,13 @@ $wgAdDriverSourcePointDetectionCountries = null;
 $wgAdDriverSourcePointDetectionMobileCountries = null;
 
 /**
+ * @name $wgAdDriverSourcePointRecoveryCountries
+ * List of countries to call ads through SourcePoint
+ * ONLY UPDATE THROUGH WIKI FACTORY ON COMMUNITY - it's an instant global.
+ */
+$wgAdDriverSourcePointRecoveryCountries = null;
+
+/**
  * trusted proxy service registry
  */
 $wgAutoloadClasses[ 'TrustedProxyService'] =  "$IP/includes/wikia/services/TrustedProxyService.class.php" ;


### PR DESCRIPTION
Before we release SourcePoint globally we want the code to be clean and variables' names as much descriptive as possible.
