### PR TITLE
(CE-2892) Fix content review modal in Monobook

### DIFF
--- a/extensions/wikia/ContentReview/controllers/ContentReviewApiController.class.php
+++ b/extensions/wikia/ContentReview/controllers/ContentReviewApiController.class.php
@@ -210,24 +210,13 @@ class ContentReviewApiController extends WikiaApiController {
 		/* Override global title to provide context */
 		$this->wg->Title = Title::newFromText( $pageName );
 
-		/* Get page status */
-		$pageStatus = \F::app()->sendRequest(
-			'ContentReviewApiController',
-			'getPageStatus',
+		/* Render status module */
+		$res = $this->app->sendRequest(
+			'ContentReviewModule',
+			'Render',
 			[
 				'wikiId' => $this->wg->CityId,
 				'pageId' => $this->wg->Title->getArticleID(),
-			],
-			true
-		)->getData();
-
-		/* Render status module */
-		$res = \F::app()->sendRequest(
-			'ContentReviewModule',
-			'executeRender',
-			[
-				'pageStatus' => $pageStatus,
-				'latestRevisionId' => $this->wg->Title->getLatestRevID(),
 			],
 			true
 		)->getData();

--- a/extensions/wikia/ContentReview/controllers/ContentReviewApiController.class.php
+++ b/extensions/wikia/ContentReview/controllers/ContentReviewApiController.class.php
@@ -164,22 +164,6 @@ class ContentReviewApiController extends WikiaApiController {
 		}
 	}
 
-	public function getPageStatus() {
-		$wikiId = $this->request->getInt( 'wikiId' );
-		$pageId = $this->request->getInt( 'pageId' );
-
-		$liveRevisionData = [
-			'liveId' => $this->getLatestReviewedRevisionFromDB( $wikiId, $pageId )['revision_id'],
-		];
-
-		$reviewModel = new ReviewModel();
-		$reviewData = $reviewModel->getPageStatus( $wikiId, $pageId );
-
-		$currentPageData = array_merge( $liveRevisionData, $reviewData );
-
-		$this->makeSuccessResponse( $currentPageData );
-	}
-
 	public function getLatestReviewedRevision() {
 		$wikiId = $this->request->getInt( 'wikiId' );
 		$pageId = $this->request->getInt( 'pageId' );

--- a/extensions/wikia/ContentReview/models/ReviewModel.php
+++ b/extensions/wikia/ContentReview/models/ReviewModel.php
@@ -16,37 +16,6 @@ class ReviewModel extends ContentReviewBaseModel {
 			CONTENT_REVIEW_STATUS_REJECTED = 4,
 			CONTENT_REVIEW_STATUS_AUTOAPPROVED = 5;
 
-	public function getPageStatus( $wikiId, $pageId ) {
-		$db = $this->getDatabaseForRead();
-
-		$pageStatus = ( new \WikiaSQL() )
-			->SELECT( 'revision_id', 'status' )
-			->FROM( self::CONTENT_REVIEW_STATUS_TABLE )
-			->WHERE( 'wiki_id' )->EQUAL_TO( $wikiId )
-				->AND_( 'page_id' )->EQUAL_TO( $pageId )
-			->ORDER_BY( [ 'revision_id', 'ASC' ] )
-			->runLoop( $db, function ( &$pageStatus, $row ) {
-				if ( Helper::isStatusAwaiting( $row->status ) ) {
-					$pageStatus['latestId'] = (int)$row->revision_id;
-					$pageStatus['latestStatus'] = (int)$row->status;
-				} else {
-					$pageStatus['lastReviewedId'] = (int)$row->revision_id;
-					$pageStatus['lastReviewedStatus'] = (int)$row->status;
-				}
-			} );
-
-		if ( empty( $pageStatus ) ) {
-			$pageStatus = [
-				'latestId' => null,
-				'latestStatus' => null,
-				'lastReviewedId' => null,
-				'lastReviewedStatus' => null,
-			];
-		}
-
-		return $pageStatus;
-	}
-
 	public function getPagesStatuses( $wikiId ) {
 		$db = $this->getDatabaseForRead();
 

--- a/skins/oasis/modules/ContentReviewModuleController.class.php
+++ b/skins/oasis/modules/ContentReviewModuleController.class.php
@@ -21,17 +21,6 @@ class ContentReviewModuleController extends WikiaController {
 
 		$this->setVal( 'isTestModeEnabled', $helper->isContentReviewTestModeEnabled() );
 
-		/*
-		 * This part allows fetches required params if not set. This allows direct usage via API
-		 * (not needed in standard flow via $railModuleList loaded modules)
-		 */
-		if ( empty( $params ) ) {
-			$params = [
-				'pageStatus' => $this->getVal( 'pageStatus' ),
-				'latestRevisionId' => $this->getVal( 'latestRevisionId' )
-			];
-		}
-
 		$contentReviewStatusesService = new ContentReviewStatusesService();
 		$pageStatus = $contentReviewStatusesService->getJsPageStatus( $params['wikiId'], $params['pageId'] );
 


### PR DESCRIPTION
Fix content review modal in Monobook as it was no longer showing the
status of pages. This was because the ContentReviewModule which is
called by the API now requires the wiki ID and page ID to be passed
as parameters.

/cc @Wikia/community-engineering
