### PR TITLE
CE-2922 check for user syntax highlighting preference 

### DIFF
--- a/extensions/wikia/EditPageLayout/EditPageLayoutHelper.class.php
+++ b/extensions/wikia/EditPageLayout/EditPageLayoutHelper.class.php
@@ -186,9 +186,11 @@ class EditPageLayoutHelper {
 	 * @return bool
 	 */
 	static public function isCodeSyntaxHighlightingEnabled( Title $articleTitle ) {
-		global $wgEnableEditorSyntaxHighlighting;
+		global $wgEnableEditorSyntaxHighlighting, $wgUser;
 
-		return self::isCodePage( $articleTitle ) && $wgEnableEditorSyntaxHighlighting;
+		return self::isCodePage( $articleTitle )
+			&& $wgEnableEditorSyntaxHighlighting
+			&& !$wgUser->getGlobalPreference( 'disablesyntaxhighlighting' );
 	}
 
 	static public function isInfoboxTemplate( Title $title ) {


### PR DESCRIPTION
This preference now controls both wikitext highlighting (in source) and code highlighting (in Ace editor on JS/CSS & template pages).

@Wikia/community-engineering 
