### PR TITLE
ApiQueryUsers: include global groups when getting list of groups and rights

### DIFF
--- a/includes/api/ApiQueryUsers.php
+++ b/includes/api/ApiQueryUsers.php
@@ -163,7 +163,7 @@ class ApiQueryUsers extends ApiQueryBase {
 
 					$data[$name]['blockedby'] = $blockInfo->getByName();
 					$data[$name]['blockreason'] = $blockInfo->mReason;
-					$data[$name]['blockexpiry'] = $blockInfo->mExpiry;
+					$data[$name]['blockexpiry'] = $blockInfo->getExpiry();
 				}
 
 				if ( isset( $this->prop['emailable'] ) && $user->canReceiveEmail() ) {

--- a/includes/api/ApiQueryUsers.php
+++ b/includes/api/ApiQueryUsers.php
@@ -120,22 +120,17 @@ class ApiQueryUsers extends ApiQueryBase {
 
 		if ( count( $goodNames ) ) {
 			$this->addTables( 'user' );
-			$this->addFields( '*' );
+			$this->addFields( 'user_id' );
 			$this->addWhereFld( 'user_name', $goodNames );
 
-			if ( isset( $this->prop['groups'] ) || isset( $this->prop['rights'] ) ) {
-				$this->addTables( 'user_groups' );
-				$this->addJoinConds( array( 'user_groups' => array( 'LEFT JOIN', 'ug_user=user_id' ) ) );
-				$this->addFields( 'ug_group' );
-			}
-
-			$this->showHiddenUsersAddBlockInfo( isset( $this->prop['blockinfo'] ) );
+			// Wikia: there's no point in querying a per-cluster user table for IP blocks
+			#$this->showHiddenUsersAddBlockInfo( isset( $this->prop['blockinfo'] ) );
 
 			$data = array();
 			$res = $this->select( __METHOD__ );
 
 			foreach ( $res as $row ) {
-				$user = User::newFromRow( $row );
+				$user = User::newFromId( $row->user_id );
 				$name = $user->getName();
 
 				$data[$name]['userid'] = $user->getId();
@@ -150,14 +145,7 @@ class ApiQueryUsers extends ApiQueryBase {
 				}
 
 				if ( isset( $this->prop['groups'] ) ) {
-					if ( !isset( $data[$name]['groups'] ) ) {
-						$data[$name]['groups'] = self::getAutoGroups( $user );
-					}
-
-					if ( !is_null( $row->ug_group ) ) {
-						// This row contains only one group, others will be added from other rows
-						$data[$name]['groups'][] = $row->ug_group;
-					}
+					$data[$name]['groups'] = $user->getEffectiveGroups();
 				}
 
 				if ( isset( $this->prop['implicitgroups'] ) && !isset( $data[$name]['implicitgroups'] ) ) {
@@ -165,22 +153,17 @@ class ApiQueryUsers extends ApiQueryBase {
 				}
 
 				if ( isset( $this->prop['rights'] ) ) {
-					if ( !isset( $data[$name]['rights'] ) ) {
-						$data[$name]['rights'] = User::getGroupPermissions( $user->getAutomaticGroups() );
-					}
-
-					if ( !is_null( $row->ug_group ) ) {
-						$data[$name]['rights'] = array_unique( array_merge( $data[$name]['rights'],
-							User::getGroupPermissions( array( $row->ug_group ) ) ) );
-					}
+					$data[$name]['rights'] = $user->getRights();
 				}
 				if ( $row->ipb_deleted ) {
 					$data[$name]['hidden'] = '';
 				}
-				if ( isset( $this->prop['blockinfo'] ) && !is_null( $row->ipb_by_text ) ) {
-					$data[$name]['blockedby'] = $row->ipb_by_text;
-					$data[$name]['blockreason'] = $row->ipb_reason;
-					$data[$name]['blockexpiry'] = $row->ipb_expiry;
+				if ( isset( $this->prop['blockinfo'] ) && $user->isBlocked() ) {
+					$blockInfo = $user->getBlock();
+
+					$data[$name]['blockedby'] = $blockInfo->getByName();
+					$data[$name]['blockreason'] = $blockInfo->mReason;
+					$data[$name]['blockexpiry'] = $blockInfo->mExpiry;
 				}
 
 				if ( isset( $this->prop['emailable'] ) && $user->canReceiveEmail() ) {


### PR DESCRIPTION
And improve the way blocks are handled (previously per-wiki IP blocks were checked on per-cluster shared users database)
- construct a "full" `User` object instead of relying on "partial" data from database query.
- make `blockinfo` prop work as well, it will call `User::getBlock` (which triggers both local blocks and Phalanx check)

http://poznan.macbre.wikia-dev.com/api.php?action=query&list=users&ususers=macbre|ABX|Fuck&usprop=groups|editcount|rights|blockinfo

@jcellary / @wladekb 
