### PR TITLE
(SEC-12) Protect against CSRF on CreateNewWiki

### DIFF
--- a/extensions/wikia/CreateNewWiki/CreateNewWikiController.class.php
+++ b/extensions/wikia/CreateNewWiki/CreateNewWikiController.class.php
@@ -211,9 +211,13 @@ class CreateNewWikiController extends WikiaController {
 
 	/**
 	 * Ajax call to Create wiki
+	 *
+	 * @throws BadRequestException
 	 */
 	public function CreateWiki() {
 		wfProfileIn(__METHOD__);
+		$this->checkWriteRequest();
+
 		$wgRequest = $this->app->getGlobal('wgRequest'); /* @var $wgRequest WebRequest */
 		$wgDevelDomains = $this->app->getGlobal('wgDevelDomains');
 		$wgUser = $this->app->getGlobal('wgUser'); /* @var $wgUser User */

--- a/extensions/wikia/CreateNewWiki/js/CreateNewWiki.js
+++ b/extensions/wikia/CreateNewWiki/js/CreateNewWiki.js
@@ -492,7 +492,8 @@
 						wCategories: categories,
 						wAllAges: self.wikiAllAges.is(':checked') ? self.wikiAllAges.val() : null,
 						wAnswer: Math.floor(self.answer)
-					}
+					},
+					token: window.mw.user.tokens.get('editToken')
 				},
 				callback: function (res) {
 					self.createStatus = res.status;

--- a/extensions/wikia/CreateNewWiki/tests/CreateNewWikiControllerTest.php
+++ b/extensions/wikia/CreateNewWiki/tests/CreateNewWikiControllerTest.php
@@ -17,7 +17,7 @@ class CreateNewWikiControllerTest extends WikiaBaseTest {
 	 * @group hyun
 	 * @dataProvider getCreateWikiDataProvider
 	 */
-	public function testCreateWikiSuccess( $testCase, $userLoggedIn, $userEmailConfirmed, $status) {
+	public function testCreateWikiSuccess( $testCase, $testData ) {
 		$wikiName = 'Muppet is great';
 		$wikiDomain = 'muppet';
 		$wikiLanguage = 'en';
@@ -34,24 +34,32 @@ class CreateNewWikiControllerTest extends WikiaBaseTest {
 			"wAnswer" => $wikiAnswer);
 
 		$wgRequest = $this->getMock('WebRequest');
-		$wgRequest->expects($this->once())
+		$wgRequest->expects($this->any())
 			->method('getArray')
 			->will($this->returnValue($requestParams));
+
 		$wgDevelDomains = array();
-		$wgUser = $this->getMock('User');
+
+		$wgUser = $this->getMock( 'User', [ 'getId', 'isLoggedIn', 'isEmailConfirmed', 'getEditToken' ] );
 		$wgUser->expects($this->any())
 			->method('getId')
 			->will($this->returnValue(6));
-		$wgUser->expects($this->once())
+		$wgUser->expects($this->any())
 			->method('isLoggedIn')
-			->will($this->returnValue($userLoggedIn));
+			->will($this->returnValue( $testData['userLogged'] ) );
 		$wgUser->expects($this->any())
 			->method('isEmailConfirmed')
-			->will($this->returnValue($userEmailConfirmed));
+			->will( $this->returnValue( $testData['userEmailConfirmed'] ) );
+		$wgUser->expects( $this->any() )
+			->method( 'getEditToken' )
+			->will( $this->returnValue( $testData['userToken'] ) );
+
 		$app = $this->getMock('WikiaApp', array('getGlobal', 'runFunction'));
-		$app->expects($this->exactly(3))
+		$app->expects( $this->any() )
 			->method('getGlobal')
 			->will($this->onConsecutiveCalls($wgRequest, $wgDevelDomains, $wgUser));
+
+		$this->mockGlobalVariable( 'wgUser', $wgUser );
 
 		$createWiki = $this->getMock('CreateWiki', array('create', 'getWikiInfo'), array(), '', false);
 		$createWiki->expects($this->any())
@@ -68,11 +76,29 @@ class CreateNewWikiControllerTest extends WikiaBaseTest {
 		$this->mockClass('CreateWiki', $createWiki);
 		$this->mockClass('GlobalTitle', $mainPageTitle);
 
-		$response = $app->sendRequest('CreateNewWiki', 'CreateWiki');
+		$requestMock = $this->getMock( 'WikiaRequest', [ 'wasPosted' ], [ [ 'token' => $testData['requestToken'] ] ] );
+		$requestMock->expects( $this->once() )
+			->method( 'wasPosted' )
+			->will( $this->returnValue( $testData['wasPosted'] ) );
+		$response = new WikiaResponse( 'json', $requestMock );
 
-		$this->assertEquals($status, $response->getVal('status'), $testCase);
+		if ( !empty( $testData['expectedException'] ) ) {
+			$this->setExpectedException( $testData['expectedException'] );
+		}
 
-		if( $userLoggedIn && $userEmailConfirmed ) {
+		$createNewWikiController = new CreateNewWikiController();
+
+		$createNewWikiController->setRequest( $requestMock );
+		$createNewWikiController->setResponse( $response );
+		$createNewWikiController->setApp( $app );
+
+		$createNewWikiController->CreateWiki();
+
+		$response = $createNewWikiController->getResponse();
+
+		$this->assertEquals( $testData['status'], $response->getVal( 'status' ), $testCase );
+
+		if ( $userLoggedIn && $userEmailConfirmed ) {
 			$this->assertEquals($siteName, $response->getVal('siteName'));
 			$this->assertEquals($mainPageUrl, $response->getval('finishCreateUrl'));
 		}
@@ -82,22 +108,76 @@ class CreateNewWikiControllerTest extends WikiaBaseTest {
 		return [
 			[
 				'testCase' => 'Everything is OK',
-				'userLogged' => true,
-				'userEmailConfirmed' => true,
-				'status' => 'ok'
+				'testData' => [
+					'wasPosted' => true,
+					'userToken' => '1234',
+					'requestToken' => '1234',
+					'userLogged' => true,
+					'userEmailConfirmed' => true,
+					'status' => 'ok',
+					'expectedException' => false,
+				],
 			],
 			[
 				'testCase' => 'User logged-in but without confirmed e-mail',
-				'userLogged' => true,
-				'userEmailConfirmed' => false,
-				'status' => 'error'
+				'testData' => [
+					'wasPosted' => true,
+					'userToken' => '1234',
+					'requestToken' => '1234',
+					'userLogged' => true,
+					'userEmailConfirmed' => false,
+					'status' => 'error',
+					'expectedException' => false,
+				],
 			],
 			[
 				'testCase' => 'User not logged-in and therefore without confirmed e-mail',
-				'userLogged' => false,
-				'userEmailConfirmed' => false,
-				'status' => 'error'
-			]
+				'testData' => [
+					'wasPosted' => true,
+					'userToken' => '1234',
+					'requestToken' => '1234',
+					'userLogged' => false,
+					'userEmailConfirmed' => false,
+					'status' => 'error',
+					'expectedException' => false,
+				],
+			],
+			[
+				'testCase' => "Request wasn't POSTed",
+				'testData' => [
+					'wasPosted' => false,
+					'userToken' => '1234',
+					'requestToken' => '1234',
+					'userLogged' => true,
+					'userEmailConfirmed' => true,
+					'status' => null,
+					'expectedException' => 'BadRequestException',
+				],
+			],
+			[
+				'testCase' => "Invalid token provided",
+				'testData' => [
+					'wasPosted' => true,
+					'userToken' => '1234',
+					'requestToken' => '4321',
+					'userLogged' => true,
+					'userEmailConfirmed' => true,
+					'status' => null,
+					'expectedException' => 'BadRequestException',
+				],
+			],
+			[
+				'testCase' => "Request wasn't POSTed and invalid token provided",
+				'testData' => [
+					'wasPosted' => false,
+					'userToken' => '1234',
+					'requestToken' => '4321',
+					'userLogged' => true,
+					'userEmailConfirmed' => true,
+					'status' => null,
+					'expectedException' => 'BadRequestException',
+				],
+			],
 		];
 	}
 


### PR DESCRIPTION
Make sure the CreateNewWiki AJAX request is POSTed and has a valid
edit token to protect against CSRF.

/cc @Wikia/community-engineering @macbre
