### PR TITLE
Phalanx: handle internal requests

### DIFF
--- a/extensions/wikia/PhalanxII/hooks/PhalanxHooks.class.php
+++ b/extensions/wikia/PhalanxII/hooks/PhalanxHooks.class.php
@@ -243,6 +243,7 @@ class PhalanxHooks extends WikiaObject {
 	 * client original IP.
 	 *
 	 * @see PLATFORM-317
+	 * @see PLATFORM-1473
 	 * @author macbre
 	 *
 	 * @param User $user
@@ -254,7 +255,7 @@ class PhalanxHooks extends WikiaObject {
 		// get the client IP using Fastly-generated request header
 		$clientIPFromFastly = $wgRequest->getHeader( $wgClientIPHeader );
 
-		if ( !User::isIP( $clientIPFromFastly ) ) {
+		if ( !User::isIP( $clientIPFromFastly ) && !$wgRequest->isWikiaInternalRequest() ) {
 			WikiaLogger::instance()->error( 'Phalanx user IP incorrect', [
 				'ip_from_fastly' => $clientIPFromFastly,
 				'ip_from_user' => $user->getName(),

--- a/extensions/wikia/PhalanxII/models/PhalanxContentModel.php
+++ b/extensions/wikia/PhalanxII/models/PhalanxContentModel.php
@@ -16,11 +16,17 @@ class PhalanxContentModel extends PhalanxModel {
 		parent::__construct( __CLASS__, array( 'title' => $title, 'lang' => $lang, 'id' => $id ) );
 	}
 
+	/**
+	 * Skip calls to Phalanx service if this method returns true
+	 *
+	 * @return bool
+	 */
 	public function isOk() { 
 		return ( 
 			$this->wg->User->isAllowed( 'phalanxexempt' ) || 
 			!( $this->title instanceof Title ) || 
-			( $this->title->getPrefixedText() == self::SPAM_WHITELIST_NS_TITLE )  
+			( $this->title->getPrefixedText() == self::SPAM_WHITELIST_NS_TITLE ) ||
+			$this->isWikiaInternalRequest()
 		);
 	}
 

--- a/extensions/wikia/PhalanxII/models/PhalanxModel.php
+++ b/extensions/wikia/PhalanxII/models/PhalanxModel.php
@@ -89,10 +89,16 @@ abstract class PhalanxModel extends WikiaObject {
 		return $instance;
 	}
 
+	/**
+	 * Skip calls to Phalanx service if this method returns true
+	 *
+	 * @return bool
+	 */
 	public function isOk() {
 		return (
 			( ( $this->user instanceof User ) && ( $this->user->getName() == $this->wg->User->getName() && $this->wg->User->isAllowed( 'phalanxexempt' ) ) ) ||
-			( ( $this->user instanceof User ) && $this->user->isAllowed( 'phalanxexempt' ) )
+			( ( $this->user instanceof User ) && $this->user->isAllowed( 'phalanxexempt' ) ) ||
+			$this->isWikiaInternalRequest()
 		);
 	}
 
@@ -170,5 +176,17 @@ abstract class PhalanxModel extends WikiaObject {
 		}
 
 		return $ret;
+	}
+
+	/**
+	 * Check if the current request is an internal one (has the required header and is a GET)
+	 *
+	 * @see PLATFORM-1473
+	 *
+	 * @return bool
+	 */
+	public function isWikiaInternalRequest() {
+		$request = $this->wg->Request;
+		return !$request->wasPosted() && $request->isWikiaInternalRequest();
 	}
 }

--- a/extensions/wikia/Track/Track.php
+++ b/extensions/wikia/Track/Track.php
@@ -12,7 +12,6 @@ $wgHooks['WikiaSkinTopScripts'][] = 'Track::onWikiaSkinTopScripts';
 
 class Track {
 	const BASE_URL = 'http://a.wikia-beacon.com/__track';
-	const HEADER_MIRRORED_REQUEST = 'x-mirrored-request';
 
 	private static function getURL ($type=null, $name=null, $param=null, $for_html=true) {
 		global $wgStyleVersion, $wgCityId, $wgContLanguageCode, $wgDBname, $wgDBcluster, $wgUser, $wgArticle, $wgTitle, $wgAdServerTest;
@@ -112,7 +111,7 @@ SCRIPT1;
 	protected static function shouldTrackEvents() {
 		// Check request headers to make sure this is not a mirrored
 		// request, which could result in duplicate tracking events
-		return F::app()->wg->request->getHeader( self::HEADER_MIRRORED_REQUEST ) === false;
+		return F::app()->wg->request->isWikiaInternalRequest() === false;
 	}
 
 	/**

--- a/includes/HttpFunctions.php
+++ b/includes/HttpFunctions.php
@@ -490,6 +490,8 @@ class MWHttpRequest {
 		// @author macbre
 		// pass Request ID to internal requests
 		$this->setHeader( Wikia\Util\RequestId::REQUEST_HEADER_NAME, Wikia\Util\RequestId::instance()->getRequestId() );
+		// PLATFORM-1473: pass X-Wikia-Internal-Request
+		$this->setHeader( WebRequest::WIKIA_INTERNAL_REQUEST_HEADER, 'mediawiki' );
 
 		// Wikia change - begin - @author: wladek
 		// Append extra headers for internal requests, currently only X-Request-Origin-Host

--- a/includes/Setup.php
+++ b/includes/Setup.php
@@ -445,7 +445,7 @@ if ( $wgCommandLineMode ) {
 	wfDebug( "$debug\n" );
 }
 
-wfRunHooks('WebRequestInitialized', [ $wgRequest ] );
+wfRunHooks('WebRequestInitialized', [ $wgRequest ] ); // Wikia change
 
 wfProfileOut( $fname . '-misc1' );
 wfProfileIn( $fname . '-memcached' );

--- a/includes/WebRequest.php
+++ b/includes/WebRequest.php
@@ -1120,6 +1120,20 @@ HTML;
 			throw new BadRequestException( 'Request must be POSTed and provide a valid edit token.' );
 		}
 	}
+
+	const WIKIA_INTERNAL_REQUEST_HEADER = 'X-Wikia-Internal-Request';
+
+	/**
+	 * Use X-Wikia-Internal-Request request header to check if a given request should be treated as an internal one,
+	 * e.g. was sent via Http::get() helper or made by DC warmer
+	 *
+	 * @see PLATFORM-1473
+	 *
+	 * @return bool
+	 */
+	public function isWikiaInternalRequest() {
+		return $this->getHeader( self::WIKIA_INTERNAL_REQUEST_HEADER ) !== false;
+	}
 }
 
 /**

--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -65,6 +65,9 @@ $wgHooks['LocalFilePurgeThumbnailsUrls'][] = 'Wikia::onLocalFilePurgeThumbnailsU
 $wgHooks['BeforePageDisplay'][] = 'Wikia::onBeforePageDisplay';
 $wgHooks['GetPreferences'][] = 'Wikia::onGetPreferences';
 
+# handle internal requests - PLATFORM-1473
+$wgHooks['WebRequestInitialized'][] = 'Wikia::onWebRequestInitialized';
+
 /**
  * This class has only static methods so they can be used anywhere
  *
@@ -1662,6 +1665,27 @@ class Wikia {
 		$wgAllowUserCss = $wgAllowUserCss && $request->getBool( 'useusercss',
 			$request->getBool( 'allowusercss', $wgAllowUserCss ) ) !== false;
 		$wgBuckySampling = $request->getInt( 'buckysampling', $wgBuckySampling );
+
+		return true;
+	}
+
+	/**
+	 * Detect internal HTTP requests: log them and set a response header to ease debugging
+	 *
+	 * @see PLATFORM-1473
+	 *
+	 * @param WebRequest $request
+	 * @return bool true, it's a hook
+	 */
+	static public function onWebRequestInitialized( WebRequest $request ) {
+		if ( $request->isWikiaInternalRequest() ) {
+			$requestSource = $request->getHeader( WebRequest::WIKIA_INTERNAL_REQUEST_HEADER );
+
+			Wikia\Logger\WikiaLogger::instance()->info( 'Wikia internal request', [
+				'source' => $requestSource
+			] );
+			$request->response()->header( 'X-Wikia-Is-Internal-Request: ' . $requestSource );
+		}
 
 		return true;
 	}


### PR DESCRIPTION
Improve handling of internal HTTP requests in Phalanx:
- check `X-Wikia-Internal-Request` (added by `Http::get` and DC warmer when relying requests to Reston)
- if the request is a GET and has the above header set make Phalanx ignore it (i.e. do not perform a block check nor log missing client IP)
- log internal requests (including the source) and set `X-Wikia-Is-Internal-Request` response header to ease debugging (use `WebRequestInitialized` hook introduced in #8834 - thanks @wladekb)

@michalroszka / @wladekb / @drozdo 
