### PR TITLE
Prevent Facebook logins for restrict-login group members

### DIFF
--- a/extensions/wikia/UserLogin/FacebookSignupController.class.php
+++ b/extensions/wikia/UserLogin/FacebookSignupController.class.php
@@ -39,7 +39,12 @@ class FacebookSignupController extends WikiaController {
 		if ( ( $user instanceof User ) && ( $fbUserId !== 0 ) ) {
 			$errorMsg = '';
 
-			if ( $this->isAccountDisabled( $user ) ) {
+			if ( $user->isAllowed( 'login-restrict-facebook' ) ) {
+				$this->response->setData([
+					'loginAborted' => true,
+					'errorMsg' => $errorMsg,
+				]);
+			} elseif ( $this->isAccountDisabled( $user ) ) {
 				// User account was disabled, abort the login
 				$errorMsg = wfMessage( 'userlogin-error-edit-account-closed-flag' )->escaped();
 


### PR DESCRIPTION
@Wikia/services-team 
https://wikia-inc.atlassian.net/browse/SERVICES-944
See Wikia/config#1435

Since the current MW Facebook login does not use Helios, we need to do the user rights check in MW when logging in with Facebook. This should only serve as a temporary solution until the MW login path is consolidated to use Helios (most likely through Mercury).
