### PR TITLE
(SEC-19,SEC-22,SEC-23) Fix multiple vulnerabilities in CreatePage

### DIFF
--- a/extensions/wikia/CreatePage/monobook/SpecialCreatePage.class.php
+++ b/extensions/wikia/CreatePage/monobook/SpecialCreatePage.class.php
@@ -67,37 +67,41 @@ class SpecialCreatePage extends SpecialEditPage {
 	}
 
 	protected function parseFormData() {
-		global $wgRequest;
-
 		wfRunHooks( 'BlogsAlternateEdit', array( false ) );
 
-		$this->mFormData['postBody'] = $wgRequest->getVal( 'wpTextbox1' );
-		$this->mFormData['postTitle'] = $wgRequest->getVal( 'postTitle' );
-		$this->mFormData['postEditSummary'] = $wgRequest->getVal( 'wpSummary' );
-		$this->mFormData['postCategories'] = $wgRequest->getVal( 'wpCategoryTextarea1' );
+		$request = $this->getRequest();
+
+		$this->mFormData['postBody'] = $request->getVal( 'wpTextbox1' );
+		$this->mFormData['postTitle'] = $request->getVal( 'postTitle' );
+		$this->mFormData['postEditSummary'] = $request->getVal( 'wpSummary' );
+		$this->mFormData['postCategories'] = $request->getVal( 'wpCategoryTextarea1' );
+
+		if ( !$this->getUser()->matchEditToken( $request->getVal( 'wpEditToken' ) ) ) {
+			$this->mFormErrors[] = $this->msg( 'sessionfailure' )->escaped();
+		}
 
 		$postBody = trim( $this->mFormData['postBody'] );
 		if ( empty( $postBody ) ) {
-			$this->mFormErrors[] = wfMsg( 'createpage_empty_article_body_error' );
+			$this->mFormErrors[] = $this->msg( 'createpage_empty_article_body_error' )->escaped();
 		}
 
 		if ( empty( $this->mFormData['postTitle'] ) ) {
-			$this->mFormErrors[] = wfMsg( 'createpage_empty_title_error' );
+			$this->mFormErrors[] = $this->msg( 'createpage_empty_title_error' )->escaped();
 		}
 		else {
 			$oPostTitle = Title::newFromText( $this->mFormData['postTitle'], NS_MAIN );
 
 			if ( !( $oPostTitle instanceof Title ) ) {
-				$this->mFormErrors[] = wfMsg( 'createpage_invalid_title_error' );
+				$this->mFormErrors[] = $this->msg( 'createpage_invalid_title_error' )->escaped();
 			}
 			else {
 				$sFragment = $oPostTitle->getFragment();
 				if ( strlen( $sFragment ) > 0 ) {
-					$this->mFormErrors[] = wfMsg( 'createpage_invalid_title_error' );
+					$this->mFormErrors[] = $this->msg( 'createpage_invalid_title_error' )->escaped();
 				} else {
 					$this->mPostArticle = new Article( $oPostTitle, 0 );
 					if ( $this->mPostArticle->exists() ) {
-						$this->mFormErrors[] = wfMsg( 'createpage_article_already_exists' );
+						$this->mFormErrors[] = $this->msg( 'createpage_article_already_exists' )->escaped();
 					}
 				}
 			}

--- a/extensions/wikia/CreatePage/monobook/templates/createFormHeader.tmpl.php
+++ b/extensions/wikia/CreatePage/monobook/templates/createFormHeader.tmpl.php
@@ -10,11 +10,11 @@
 <?php endif; ?>
 
 <div id="createpage_messenger" style="display:none; color:red;" ></div>
-<b><?=wfMsg ('createpage_title_caption');?></b>
+<b><?= wfMessage( 'createpage_title_caption' )->escaped(); ?></b>
 <br/>
-<input name="postTitle" id="postTitle" value="<?=isset($formData['postTitle'])?$formData['postTitle']:"";?>" style="width: 70%" /><br/><br/>
+<input name="postTitle" id="postTitle" value="<?= Sanitizer::encodeAttribute( isset( $formData['postTitle'] ) ? $formData['postTitle'] : '' ); ?>" style="width: 70%" /><br/><br/>
 <?php if(!empty($editIntro)): ?>
 	<?php echo $editIntro; ?>
 	<br />
 <?php endif; ?>
-<b><?=wfMsg ('createpage_enter_text');?></b>
+<b><?= wfMessage( 'createpage_enter_text' )->escaped(); ?></b>

--- a/extensions/wikia/CreatePage/templates/dialog-ve.tmpl.php
+++ b/extensions/wikia/CreatePage/templates/dialog-ve.tmpl.php
@@ -1,4 +1,4 @@
 <div >
-	<?= wfMsg( 'createpage-ve-body', $article ) ?>
-	<input id="wpCreatePageDialogTitle" value="<?= $article ?>" type="text" style="display: none" />
+	<?= wfMessage( 'createpage-ve-body' )->rawParams( htmlspecialchars( $article, ENT_QUOTES ) )->parse() ?>
+	<input id="wpCreatePageDialogTitle" value="<?= Sanitizer::encodeAttribute( $article ) ?>" type="text" style="display: none" />
 </div>


### PR DESCRIPTION
- Make sure CreatePage submission in Monobook also verifies the submitted
  edit token to protect against CSRF.
- Properly escape link title in VE create page dialog
- Properly escape POSTed page title in CreatePage in Monobook

/cc @macbre 
