### PR TITLE
INT-89: Added mercury variable isCoppaWiki

### DIFF
--- a/extensions/wikia/MercuryApi/models/MercuryApi.class.php
+++ b/extensions/wikia/MercuryApi/models/MercuryApi.class.php
@@ -105,7 +105,8 @@ class MercuryApi {
 	 */
 	public function getWikiVariables() {
 		global $wgSitename, $wgCacheBuster, $wgDBname, $wgDefaultSkin, $wgDisableAnonymousEditing,
-			   $wgLanguageCode, $wgContLang, $wgCityId, $wgEnableNewAuth, $wgDisableAnonymousUploadForMercury;
+			   $wgLanguageCode, $wgContLang, $wgCityId, $wgEnableNewAuth, $wgDisableAnonymousUploadForMercury,
+			   $wgWikiDirectedAtChildrenByFounder, $wgWikiDirectedAtChildrenByStaff;
 
 		return [
 			'cacheBuster' => (int) $wgCacheBuster,
@@ -116,7 +117,7 @@ class MercuryApi {
 			'enableNewAuth' => $wgEnableNewAuth,
 			'homepage' => $this->getHomepageUrl(),
 			'id' => (int) $wgCityId,
-			'isCoppaWiki' => (wgWikiDirectedAtChildrenByFounder || wgWikiDirectedAtChildrenByStaff),
+			'isCoppaWiki' => ($wgWikiDirectedAtChildrenByFounder || $wgWikiDirectedAtChildrenByStaff),
 			'language' => [
 				'content' => $wgLanguageCode,
 				'contentDir' => $wgContLang->getDir()

--- a/extensions/wikia/MercuryApi/models/MercuryApi.class.php
+++ b/extensions/wikia/MercuryApi/models/MercuryApi.class.php
@@ -116,6 +116,7 @@ class MercuryApi {
 			'enableNewAuth' => $wgEnableNewAuth,
 			'homepage' => $this->getHomepageUrl(),
 			'id' => (int) $wgCityId,
+			'isCoppaWiki' => (wgWikiDirectedAtChildrenByFounder || wgWikiDirectedAtChildrenByStaff),
 			'language' => [
 				'content' => $wgLanguageCode,
 				'contentDir' => $wgContLang->getDir()


### PR DESCRIPTION
For INT-89, we want to integrate login functionality with the Mercury section editor.

Coppa wikias (that is a wikia where wgWikiDirectedAtChildrenByStaff or wgWikiDirectedAtChildrenByFounder is set to true) should always require login in order to edit.

These variables are not currently available to Mercury, so they were added in getWikiVariables.
