### PR TITLE
Tasks: validate incoming HTTP requests that trigger jobs

### DIFF
--- a/extensions/wikia/Tasks/proxy/proxy.php
+++ b/extensions/wikia/Tasks/proxy/proxy.php
@@ -1,6 +1,18 @@
 <?php
 set_time_limit( 0 );
 
+# SEC-21: make sure that this is called internally
+$headers = apache_request_headers();
+if ( empty( $headers['X-Wikia-Internal-Request'] ) ) {
+	trigger_error( 'X-Wikia-Internal-Request header is missing', E_USER_WARNING );
+
+	echo json_encode( [
+		'status' => 'failure',
+		'reason' => 'X-Wikia-Internal-Request header is missing'
+	] );
+	die;
+}
+
 $script = realpath( dirname( __FILE__ ) . '/../../../../maintenance/wikia/task_runner.php' );
 
 $taskId = escapeshellarg( $_POST['task_id'] );

--- a/maintenance/wikia/task_runner.php
+++ b/maintenance/wikia/task_runner.php
@@ -34,6 +34,12 @@ class TaskRunnerMaintenance extends Maintenance {
 			'task_id' => $this->mOptions['task_id']
 		] );
 
+		// an ugly c&p from Wikia::onWebRequestInitialized
+		// I'm going to burn in hell
+		Wikia\Logger\WikiaLogger::instance()->info( 'Wikia internal request', [
+			'source' => 'celery'
+		] );
+
 		$runner = new TaskRunner(
 			$this->mOptions['wiki_id'],
 			$this->mOptions['task_id'],


### PR DESCRIPTION
Validate incoming HTTP requests by checking `X-Wikia-Internal-Request` header.

See https://github.com/Wikia/celery-workers/pull/43 for how celery sends these requests

@wladekb / @Grunny / @nmonterroso 
