### PR TITLE
SEO-132 Fix PHP Fatal Error

### DIFF
--- a/extensions/wikia/Lilly/LillyHooks.class.php
+++ b/extensions/wikia/Lilly/LillyHooks.class.php
@@ -64,6 +64,11 @@ class LillyHooks {
 	static function onLinkerMakeExternalLink( &$url, &$text, &$link, &$attribs ) {
 		global $wgLillyServiceUrl, $wgTitle;
 
+		// wgTitle is null sometimes
+		if ( !( $wgTitle instanceof Title ) ) {
+			return true;
+		}
+
 		$sourceUrl = $wgTitle->getFullURL();
 		$targetUrl = $url;
 


### PR DESCRIPTION
PHP Fatal Error: Call to a member function getFullURL() on null in
/extensions/wikia/Lilly/LillyHooks.class.php on line 67
