### PR TITLE
SOC-1507 clear attribute cache when deleting avatars

### DIFF
--- a/extensions/wikia/UserProfilePageV3/UserProfilePageController.class.php
+++ b/extensions/wikia/UserProfilePageV3/UserProfilePageController.class.php
@@ -1009,8 +1009,9 @@ class UserProfilePageController extends WikiaController {
 			if ( $avUser->getID() !== 0 ) {
 				$avatar = Masthead::newFromUser( $avUser );
 				if ( $avatar->removeFile( true ) ) {
-					wfProfileOut( __METHOD__ );
+					$this->clearAttributeCache( $avUser->getId() );
 					$this->setVal( 'status', "ok" );
+					wfProfileOut( __METHOD__ );
 					return true;
 				}
 			}


### PR DESCRIPTION
When deleting an avatar, we weren't clearing the attribute cache as we do when an attribute is saved. This was resulting in the old attribute being shown until that cache expires. Clear the cache after a successful delete to fix that.

Ticket: https://wikia-inc.atlassian.net/browse/SOC-1507
