### PR TITLE
VE-2004: Silencing loadHTML warning

### DIFF
--- a/extensions/wikia/PortableInfobox/services/Parser/Nodes/NodeImage.php
+++ b/extensions/wikia/PortableInfobox/services/Parser/Nodes/NodeImage.php
@@ -53,16 +53,18 @@ class NodeImage extends Node {
 		global $wgArticleAsJson;
 		$data = array();
 		$doc = new \DOMDocument();
+		libxml_use_internal_errors( true );
 		$doc->loadHTML( $html );
+		libxml_use_internal_errors( false );
 		$sxml = simplexml_import_dom( $doc );
 		$divs = $sxml->xpath( '//div[@class=\'tabbertab\']' );
 		foreach ( $divs as $div ) {
 			if ( $wgArticleAsJson ) {
-				if ( preg_match( '/data-ref="([^"]+)"/', $div->p->asXML(), $out ) ) {
+				if ( preg_match( '/data-ref="([^"]+)"/', $div->asXML(), $out ) ) {
 					$data[] = array( 'label' => (string) $div['title'], 'title' => \ArticleAsJson::$media[$out[1]]['title'] );
 				}
 			} else {
-				if ( preg_match( '/data-(video|image)-key="([^"]+)"/', $div->p->asXML(), $out ) ) {
+				if ( preg_match( '/data-(video|image)-key="([^"]+)"/', $div->asXML(), $out ) ) {
 					$data[] = array( 'label' => (string) $div['title'], 'title' => $out[2] );
 				}
 			}


### PR DESCRIPTION
I carefully researched the topic and it seems that there is no way to instruct DOMDocument to accept "lower" quality HTML. Specifically in HTML <div> or <figure> (block elements) are not allowed inside <p> (which accepts only inline elements) - hence it's complaining about.

Based on comments from stackoverflow it seems that such practice (silencing it) is commong practice in this situation.

(I also now run regex on the entire DIV which makes it more robust.)
