### PR TITLE
Reject authentication fallback to MW by default

### DIFF
--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1828,5 +1828,6 @@ $wgLogRestrictions['piggyback'] = 'piggyback';
 
 /**
  * Reject attempts to fall back to the MediaWiki session for authentication.
+ * The user MUST have a valid helios authentication token.
  */
-$wgRejectAuthenticationFallback = false;
+$wgRejectAuthenticationFallback = true;


### PR DESCRIPTION
This changes the feature flag to reject fallbacks to the MW session for authentication by default. This means that a valid helios access token is required for successful authentication.

https://wikia-inc.atlassian.net/browse/SERVICES-889

The corresponding config change is https://github.com/Wikia/config/pull/1437.

@Wikia/services-team 
