### PR TITLE
CE-2885 Communicate with a user on classification action on a view page

### DIFF
--- a/extensions/wikia/TemplateClassification/TemplateClassification.i18n.php
+++ b/extensions/wikia/TemplateClassification/TemplateClassification.i18n.php
@@ -44,7 +44,7 @@ $messages['en'] = [
 	'template-classification-edit-modal-title-add-template' => 'Add template',
 	'template-classification-edit-modal-title-edit-type' => 'Edit template type',
 	'template-classification-edit-modal-select-type-sub-title' => 'Choose template type',
-	'template-classification-edit-modal-success' => 'The template is now classified! Thank you!',
+	'template-classification-edit-modal-success' => 'New classification of the template has been saved. Thank you!',
 	'template-classification-edit-modal-error' => 'Unfortunately, we were not able to classify this template. Would you mind trying it again?',
 
 	'template-classification-indicator' => 'Template type:',

--- a/extensions/wikia/TemplateClassification/TemplateClassification.i18n.php
+++ b/extensions/wikia/TemplateClassification/TemplateClassification.i18n.php
@@ -44,6 +44,8 @@ $messages['en'] = [
 	'template-classification-edit-modal-title-add-template' => 'Add template',
 	'template-classification-edit-modal-title-edit-type' => 'Edit template type',
 	'template-classification-edit-modal-select-type-sub-title' => 'Choose template type',
+	'template-classification-edit-modal-success' => 'The template is now classified! Thank you!',
+	'template-classification-edit-modal-error' => 'Unfortunately, we were not able to classify this template. Would you mind trying it again?',
 
 	'template-classification-indicator' => 'Template type:',
 ];
@@ -82,6 +84,8 @@ $messages['qqq'] = [
 	'template-classification-edit-modal-title-edit-type' => 'Title of modal for editing template type',
 	'template-classification-edit-modal-title-add-template' => 'Title of modal for choosing template type while adding new template',
 	'template-classification-edit-modal-select-type-sub-title' => 'Subtitle of modal for choosing template type while adding new template',
+	'template-classification-edit-modal-success' => 'A message shown in a Banner Notification after a user chooses a type of a template in a modal and the classification is successfully saved.',
+	'template-classification-edit-modal-error' => 'A message shown in a Banner Notification after a user chooses a type of a template in a modal and the classification trial results with an error.',
 
 	'template-classification-indicator' => 'Shown in page subheader and near classification dialog entry points to indicate which type the template is currently classified as.',
 ];

--- a/extensions/wikia/TemplateClassification/TemplateClassification.setup.php
+++ b/extensions/wikia/TemplateClassification/TemplateClassification.setup.php
@@ -56,3 +56,7 @@ $wgExtensionMessagesFiles['TemplateClassification'] = __DIR__ . '/TemplateClassi
 JSMessages::registerPackage( 'TemplateClassificationModal', [
 	'template-classification-edit-modal-*',
 ] );
+
+JSMessages::registerPackage( 'TemplateClassificationTypes', [
+	'template-classification-type-*',
+] );

--- a/extensions/wikia/TemplateClassification/scripts/TemplateClassificationInEdit.js
+++ b/extensions/wikia/TemplateClassification/scripts/TemplateClassificationInEdit.js
@@ -30,11 +30,12 @@ define('TemplateClassificationInEdit',
 
 		function getType() {
 			/* Return in format required by TemplateClassificationModal module */
-			return [{type: $editFormHiddenTypeField.val()}];
+			return $editFormHiddenTypeField.val();
 		}
 
 		function storeTypeForSend(templateType) {
 			$editFormHiddenTypeField.val(mw.html.escape(templateType));
+			templateClassificationModal.updateEntryPointLabel(templateType);
 		}
 
 		return {

--- a/extensions/wikia/TemplateClassification/scripts/TemplateClassificationInView.js
+++ b/extensions/wikia/TemplateClassification/scripts/TemplateClassificationInView.js
@@ -5,22 +5,22 @@
  *
  * Provides selected type for TemplateClassificationModal and handles type submit
  */
-define('TemplateClassificationInView', ['jquery', 'mw', 'wikia.nirvana', 'TemplateClassificationModal'],
-	function ($, mw, nirvana, templateClassificationModal) {
+define('TemplateClassificationInView', ['jquery', 'mw', 'wikia.nirvana', 'TemplateClassificationModal', 'BannerNotification'],
+	function ($, mw, nirvana, templateClassificationModal, BannerNotification) {
 		'use strict';
 
 		var $typeLabel;
 
 		function init() {
 			$typeLabel = $('.template-classification-type-text');
-			templateClassificationModal.init(getType, storeTypeForSend);
+			templateClassificationModal.init(getType, sendClassifyTemplateRequest);
 		}
 
 		function getType() {
 			return [{type: $typeLabel.data('type')}];
 		}
 
-		function storeTypeForSend() {
+		function sendClassifyTemplateRequest() {
 			nirvana.sendRequest({
 				controller: 'TemplateClassificationApi',
 				method: 'classifyTemplate',
@@ -28,6 +28,22 @@ define('TemplateClassificationInView', ['jquery', 'mw', 'wikia.nirvana', 'Templa
 					pageId: mw.config.get('wgArticleId'),
 					type: $('#TemplateClassificationEditForm [name="template-classification-types"]:checked').val(),
 					editToken: mw.user.tokens.get('editToken')
+				},
+				callback: function() {
+					var notification = new BannerNotification(
+						mw.message('template-classification-edit-modal-success').escaped(),
+						'success'
+					);
+
+					notification.show();
+				},
+				onErrorCallback: function() {
+					var notification = new BannerNotification(
+						mw.message('template-classification-edit-modal-error').escaped(),
+						'error'
+					);
+
+					notification.show();
 				}
 			});
 		}

--- a/extensions/wikia/TemplateClassification/scripts/TemplateClassificationInView.js
+++ b/extensions/wikia/TemplateClassification/scripts/TemplateClassificationInView.js
@@ -17,16 +17,20 @@ define('TemplateClassificationInView', ['jquery', 'mw', 'wikia.nirvana', 'Templa
 		}
 
 		function getType() {
-			return [{type: $typeLabel.data('type')}];
+			return $typeLabel.data('type');
 		}
 
-		function sendClassifyTemplateRequest() {
+		function sendClassifyTemplateRequest(selectedTemplateType) {
+			var previousType = getType();
+
+			templateClassificationModal.updateEntryPointLabel(selectedTemplateType);
+
 			nirvana.sendRequest({
 				controller: 'TemplateClassificationApi',
 				method: 'classifyTemplate',
 				data: {
 					pageId: mw.config.get('wgArticleId'),
-					type: $('#TemplateClassificationEditForm [name="template-classification-types"]:checked').val(),
+					type: selectedTemplateType,
 					editToken: mw.user.tokens.get('editToken')
 				},
 				callback: function() {
@@ -38,6 +42,9 @@ define('TemplateClassificationInView', ['jquery', 'mw', 'wikia.nirvana', 'Templa
 					notification.show();
 				},
 				onErrorCallback: function() {
+					templateClassificationModal.updateEntryPointLabel(previousType);
+					animateOnError($typeLabel);
+
 					var notification = new BannerNotification(
 						mw.message('template-classification-edit-modal-error').escaped(),
 						'error'
@@ -45,6 +52,13 @@ define('TemplateClassificationInView', ['jquery', 'mw', 'wikia.nirvana', 'Templa
 
 					notification.show();
 				}
+			});
+		}
+
+		function animateOnError($element) {
+			$element.toggleClass('template-classification-error');
+			$element.one('webkitAnimationEnd oanimationend msAnimationEnd animationend', function(e) {
+				$element.removeClass('template-classification-error');
 			});
 		}
 

--- a/extensions/wikia/TemplateClassification/scripts/TemplateClassificationInView.js
+++ b/extensions/wikia/TemplateClassification/scripts/TemplateClassificationInView.js
@@ -56,7 +56,7 @@ define('TemplateClassificationInView', ['jquery', 'mw', 'wikia.nirvana', 'Templa
 		}
 
 		function animateOnError($element) {
-			$element.toggleClass('template-classification-error');
+			$element.addClass('template-classification-error');
 			$element.one('webkitAnimationEnd oanimationend msAnimationEnd animationend', function(e) {
 				$element.removeClass('template-classification-error');
 			});

--- a/extensions/wikia/TemplateClassification/scripts/TemplateClassificationModal.js
+++ b/extensions/wikia/TemplateClassification/scripts/TemplateClassificationModal.js
@@ -56,18 +56,8 @@ function ($, mw, loader, nirvana, labeling) {
 		).done(handleRequestsForModal);
 	}
 
-	function getTypeLabel(templateType) {
-		var selectedTypeText;
-
-		if (!$classificationForm) {
-			return '';
-		}
-
-		selectedTypeText = $classificationForm.find(
-			'label[for="template-classification-' + mw.html.escape(templateType) + '"] .tc-type-name'
-		);
-
-		return selectedTypeText.html();
+	function getTypeMessage(templateType) {
+		return mw.message('template-classification-type-' + mw.html.escape(templateType));
 	}
 
 	function handleRequestsForModal(classificationForm, templateType, loaderRes) {
@@ -81,10 +71,13 @@ function ($, mw, loader, nirvana, labeling) {
 		}
 
 		if (templateType) {
-			var selectedType = mw.html.escape(templateType[0].type);
 			// Mark selected type
-			$classificationForm.find('input[checked="checked"]').removeAttr('checked');
-			$classificationForm.find('input[value="' + selectedType + '"]').attr('checked', 'checked');
+			var selectedType = $classificationForm.find('input[value="' + templateType + '"]');
+
+			if (selectedType.length > 0) {
+				$classificationForm.find('input[checked="checked"]').removeAttr('checked');
+				selectedType.attr('checked', 'checked');
+			}
 		}
 
 		// Set modal content
@@ -127,16 +120,13 @@ function ($, mw, loader, nirvana, labeling) {
 
 		saveHandler(templateType);
 
-		// Update entry point label
-		updateEntryPointLabel(templateType);
-
 		modalInstance.trigger('close');
 	}
 
 	function updateEntryPointLabel(templateType) {
 		$typeLabel
 			.data('type', mw.html.escape(templateType))
-			.html(getTypeLabel(templateType));
+			.html(getTypeMessage(templateType).escaped());
 	}
 
 	function setupTemplateClassificationModal(content) {
@@ -193,7 +183,7 @@ function ($, mw, loader, nirvana, labeling) {
 		return loader({
 			type: loader.MULTI,
 			resources: {
-				messages: 'TemplateClassificationModal'
+				messages: 'TemplateClassificationModal,TemplateClassificationTypes'
 			}
 		});
 	}
@@ -204,6 +194,7 @@ function ($, mw, loader, nirvana, labeling) {
 
 	return {
 		init: init,
-		open: openEditModal
+		open: openEditModal,
+		updateEntryPointLabel: updateEntryPointLabel
 	};
 });

--- a/extensions/wikia/TemplateClassification/styles/TemplateClassification.scss
+++ b/extensions/wikia/TemplateClassification/styles/TemplateClassification.scss
@@ -45,3 +45,14 @@
 .template-classification-edit-form-label .tc-type-name {
 	font-weight: bold;
 }
+
+@keyframes fadeBackground {
+	to {
+		background-color: transparent;
+	}
+}
+
+.template-classification-error {
+	background-color: #e1390b;
+	animation: fadeBackground 1s linear;
+}


### PR DESCRIPTION
Hello @Wikia/community-engineering !

In this pull request we implement confirmation and error messages when editing a classification from a template's view page. The desired behavior is:
1. User opens a modal with an edit form by clicking on the entry point under the template's title,
2. User selects a new type and clicks save,
3. The current classification in the entry point is **instantly changed** to the selected one and:
   
   a. If the save was successful - we display a success BannerNotification
   b. If the save failed - we display an error BannerNotification **and** change the current classification to the previous one with a nice, visual indicator that it was rolled back.

/cc: @kamilkoterba @Grunny 
