### PR TITLE
Block access to the live_code_coverage directory

### DIFF
--- a/live_code_coverage/.htaccess
+++ b/live_code_coverage/.htaccess
@@ -1,0 +1,1 @@
+Deny from all


### PR DESCRIPTION
Adds an .htaccess file to the live_code_coverage directory, to prevent accidentally serving it.
