### PR TITLE
XW-395 | Remove deprecated /api/v1/* Mercury paths

### DIFF
--- a/extensions/wikia/MercuryApi/MercuryApiHooks.class.php
+++ b/extensions/wikia/MercuryApi/MercuryApiHooks.class.php
@@ -91,8 +91,7 @@ class MercuryApiHooks {
 
 		if ( $title->inNamespaces( NS_MAIN ) ) {
 			// Mercury API call from Ember.js to Hapi.js e.g.
-			// http://elderscrolls.wikia.com/api/v1/article/Morrowind
-			// To access it, you have to set your client to be directed to the Mercury machines.
+			// http://elderscrolls.wikia.com/api/mercury/article/Morrowind
 			$urls[] =
 				$wgServer .
 				self::SERVICE_API_ROOT .


### PR DESCRIPTION
`/api/v1/` → `/api/mercury/`
Now Mercury API can be accessed from any client, not only mobile.
