### PR TITLE
Add X-Served-By and X-Backend-Response-Time response headers to api.php

### DIFF
--- a/includes/api/ApiMain.php
+++ b/includes/api/ApiMain.php
@@ -406,6 +406,8 @@ class ApiMain extends ApiBase {
 		global $wgUseXVO, $wgVaryOnXFP;
 		$response = $this->getRequest()->response();
 
+		wfRunHooks( 'ApiMainBeforeSendCacheHeaders', [ $response ] ); # Wikia change
+
 		if ( $this->mCacheMode == 'private' ) {
 			$response->header( 'Cache-Control: private' );
 			return;

--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -55,6 +55,7 @@ $wgHooks['ParserCacheGetETag']       [] = 'Wikia::onParserCacheGetETag';
 $wgHooks['BeforeSendCacheControl']    [] = 'Wikia::onBeforeSendCacheControl';
 $wgHooks['ResourceLoaderAfterRespond'][] = 'Wikia::onResourceLoaderAfterRespond';
 $wgHooks['NirvanaAfterRespond']       [] = 'Wikia::onNirvanaAfterRespond';
+$wgHooks['ApiMainBeforeSendCacheHeaders'][] = 'Wikia::onApiMainBeforeSendCacheHeaders';
 
 # don't purge all variants of articles in Chinese - BAC-1278
 $wgHooks['TitleGetLangVariants'][] = 'Wikia::onTitleGetLangVariants';
@@ -2268,6 +2269,18 @@ class Wikia {
 	 */
 	static function onNirvanaAfterRespond(WikiaApp $app, WikiaResponse $response) {
 		self::addExtraHeaders( $app->wg->Request->response() );
+		return true;
+	}
+
+	/**
+	 * Add X-Served-By and X-Backend-Response-Time response headers to api.php
+	 *
+	 * @param WebResponse $response
+	 * @return bool
+	 * @author macbre
+	 */
+	static function onApiMainBeforeSendCacheHeaders( WebResponse $response ) {
+		self::addExtraHeaders( $response );
 		return true;
 	}
 


### PR DESCRIPTION
Let's be consistent with the rest of MW entry points and emit `X-Served-By` and `X-Backend-Response-Time` headers.

See [BAC-550](https://wikia-inc.atlassian.net/browse/BAC-550) and #2587 for more details

After this change:

```
$ curl "http://poznan.macbre.wikia-dev.com/api.php" -svo /dev/null 2>&1 | grep -E "X-Served|X-Backend"
< X-Backend-Response-Time: 0.138
< X-Backend: dev_macbre
< X-Served-By: dev-macbre, cache-wk-sjc3160-WIKIA, cache-fra1222-FRA
```

Currently on production:

```
$ curl "http://poznan.wikia.com/api.php" -svo /dev/null 2>&1 | grep -E "X-Served|X-Backend"
< X-Served-By: cache-wk-sjc3161-WIKIA, cache-fra1241-FRA
```

@Grunny 
