### PR TITLE
CE-2905 Add tracking of Template Classification actions

### DIFF
--- a/extensions/wikia/TemplateClassification/scripts/TemplateClassificationInEdit.js
+++ b/extensions/wikia/TemplateClassification/scripts/TemplateClassificationInEdit.js
@@ -23,11 +23,11 @@ define('TemplateClassificationInEdit',
 				templateClassificationModal.open('addTemplate');
 			}
 
-			$('.template-classification-edit').on('click', function() {
+			$('.template-classification-edit').on('mousedown', function () {
 				tracker.track({
-					trackingMethod: 'both',
+					trackingMethod: 'analytics',
 					category: 'template-classification-entry-point',
-					action: 'click',
+					action: tracker.ACTIONS.CLICK,
 					label: 'edit-page'
 				});
 			});

--- a/extensions/wikia/TemplateClassification/scripts/TemplateClassificationInEdit.js
+++ b/extensions/wikia/TemplateClassification/scripts/TemplateClassificationInEdit.js
@@ -7,8 +7,8 @@
  * handles type submit that is stored in hidden input in editform
  */
 define('TemplateClassificationInEdit',
-	['jquery', 'mw', 'TemplateClassificationModal'],
-	function ($, mw, templateClassificationModal) {
+	['jquery', 'mw', 'wikia.tracker', 'TemplateClassificationModal'],
+	function ($, mw, tracker, templateClassificationModal) {
 		'use strict';
 
 		var $editFormHiddenTypeField;
@@ -22,6 +22,15 @@ define('TemplateClassificationInEdit',
 			if (isNewArticle()) {
 				templateClassificationModal.open('addTemplate');
 			}
+
+			$('.template-classification-edit').on('click', function() {
+				tracker.track({
+					trackingMethod: 'both',
+					category: 'template-classification-entry-point',
+					action: 'click',
+					label: 'edit-page'
+				});
+			});
 		}
 
 		function isNewArticle() {

--- a/extensions/wikia/TemplateClassification/scripts/TemplateClassificationInView.js
+++ b/extensions/wikia/TemplateClassification/scripts/TemplateClassificationInView.js
@@ -5,8 +5,8 @@
  *
  * Provides selected type for TemplateClassificationModal and handles type submit
  */
-define('TemplateClassificationInView', ['jquery', 'mw', 'wikia.nirvana', 'TemplateClassificationModal', 'BannerNotification'],
-	function ($, mw, nirvana, templateClassificationModal, BannerNotification) {
+define('TemplateClassificationInView', ['jquery', 'mw', 'wikia.nirvana', 'wikia.tracker', 'TemplateClassificationModal', 'BannerNotification'],
+	function ($, mw, nirvana, tracker, templateClassificationModal, BannerNotification) {
 		'use strict';
 
 		var $typeLabel;
@@ -14,6 +14,15 @@ define('TemplateClassificationInView', ['jquery', 'mw', 'wikia.nirvana', 'Templa
 		function init() {
 			$typeLabel = $('.template-classification-type-text');
 			templateClassificationModal.init(getType, sendClassifyTemplateRequest);
+
+			$('.template-classification-edit').on('click', function() {
+				tracker.track({
+					trackingMethod: 'both',
+					category: 'template-classification-entry-point',
+					action: 'click',
+					label: 'view-page'
+				});
+			});
 		}
 
 		function getType() {

--- a/extensions/wikia/TemplateClassification/scripts/TemplateClassificationInView.js
+++ b/extensions/wikia/TemplateClassification/scripts/TemplateClassificationInView.js
@@ -15,11 +15,11 @@ define('TemplateClassificationInView', ['jquery', 'mw', 'wikia.nirvana', 'wikia.
 			$typeLabel = $('.template-classification-type-text');
 			templateClassificationModal.init(getType, sendClassifyTemplateRequest);
 
-			$('.template-classification-edit').on('click', function() {
+			$('.template-classification-edit').on('mousedown', function () {
 				tracker.track({
-					trackingMethod: 'both',
+					trackingMethod: 'analytics',
 					category: 'template-classification-entry-point',
-					action: 'click',
+					action: tracker.ACTIONS.CLICK,
 					label: 'view-page'
 				});
 			});

--- a/extensions/wikia/TemplateClassification/scripts/TemplateClassificationInView.js
+++ b/extensions/wikia/TemplateClassification/scripts/TemplateClassificationInView.js
@@ -42,7 +42,7 @@ define('TemplateClassificationInView', ['jquery', 'mw', 'wikia.nirvana', 'wikia.
 					type: selectedTemplateType,
 					editToken: mw.user.tokens.get('editToken')
 				},
-				callback: function() {
+				callback: function () {
 					var notification = new BannerNotification(
 						mw.message('template-classification-edit-modal-success').escaped(),
 						'success'
@@ -50,7 +50,7 @@ define('TemplateClassificationInView', ['jquery', 'mw', 'wikia.nirvana', 'wikia.
 
 					notification.show();
 				},
-				onErrorCallback: function() {
+				onErrorCallback: function () {
 					templateClassificationModal.updateEntryPointLabel(previousType);
 					animateOnError($typeLabel);
 
@@ -66,7 +66,7 @@ define('TemplateClassificationInView', ['jquery', 'mw', 'wikia.nirvana', 'wikia.
 
 		function animateOnError($element) {
 			$element.addClass('template-classification-error');
-			$element.one('webkitAnimationEnd oanimationend msAnimationEnd animationend', function(e) {
+			$element.one('webkitAnimationEnd oanimationend msAnimationEnd animationend', function (e) {
 				$element.removeClass('template-classification-error');
 			});
 		}

--- a/extensions/wikia/TemplateClassification/scripts/TemplateClassificationModal.js
+++ b/extensions/wikia/TemplateClassification/scripts/TemplateClassificationModal.js
@@ -5,8 +5,8 @@
  * Provides two params in init method for handling save and providing selected type
  */
 define('TemplateClassificationModal',
-	['jquery', 'mw', 'wikia.loader', 'wikia.nirvana', 'TemplateClassificationLabeling'],
-function ($, mw, loader, nirvana, labeling) {
+	['jquery', 'mw', 'wikia.loader', 'wikia.nirvana', 'wikia.tracker', 'TemplateClassificationLabeling'],
+function ($, mw, loader, nirvana, tracker, labeling) {
 	'use strict';
 
 	var $classificationForm,
@@ -88,6 +88,13 @@ function ($, mw, loader, nirvana, labeling) {
 		require(['wikia.ui.factory'], function (uiFactory) {
 			/* Initialize the modal component */
 			uiFactory.init(['modal']).then(createComponent);
+
+			// Track - open TC modal
+			tracker.track({
+				trackingMethod: 'both',
+				category: 'template-classification-dialog',
+				action: 'open'
+			});
 		});
 	}
 

--- a/extensions/wikia/TemplateClassification/scripts/TemplateClassificationModal.js
+++ b/extensions/wikia/TemplateClassification/scripts/TemplateClassificationModal.js
@@ -133,7 +133,7 @@ function ($, mw, loader, nirvana, tracker, labeling) {
 			});
 		});
 
-		modalInstance.bind('option-select', function(e) {
+		modalInstance.bind('option-select', function (e) {
 			var $input = $(e.currentTarget).find('input:radio');
 
 			$input.attr('checked', 'checked');

--- a/extensions/wikia/TemplateClassification/scripts/TemplateClassificationModal.js
+++ b/extensions/wikia/TemplateClassification/scripts/TemplateClassificationModal.js
@@ -118,6 +118,16 @@ function ($, mw, loader, nirvana, tracker, labeling) {
 			processSave(modalInstance);
 		});
 
+		modalInstance.bind('close', function () {
+			// Track - close TC modal
+			tracker.track({
+				trackingMethod: 'both',
+				category: 'template-classification-dialog',
+				action: 'close',
+				label: 'close-event'
+			});
+		});
+
 		/* Show the modal */
 		modalInstance.show();
 	}

--- a/extensions/wikia/TemplateClassification/scripts/TemplateClassificationModal.js
+++ b/extensions/wikia/TemplateClassification/scripts/TemplateClassificationModal.js
@@ -136,6 +136,20 @@ function ($, mw, loader, nirvana, tracker, labeling) {
 			});
 		});
 
+		modalInstance.bind('option-select', function(e) {
+			var $input = $(e.currentTarget).find('input:radio');
+
+			$input.prop('checked', true);
+
+			// Track - click to change a template's type
+			tracker.track({
+				trackingMethod: 'both',
+				category: 'template-classification-dialog',
+				action: 'change',
+				label: $input.val()
+			});
+		});
+
 		/* Show the modal */
 		modalInstance.show();
 	}

--- a/extensions/wikia/TemplateClassification/scripts/TemplateClassificationModal.js
+++ b/extensions/wikia/TemplateClassification/scripts/TemplateClassificationModal.js
@@ -10,6 +10,7 @@ function ($, mw, loader, nirvana, tracker, labeling) {
 	'use strict';
 
 	var $classificationForm,
+		$preselectedType,
 		$typeLabel,
 		modalConfig,
 		messagesLoaded,
@@ -72,11 +73,11 @@ function ($, mw, loader, nirvana, tracker, labeling) {
 
 		if (templateType) {
 			// Mark selected type
-			var selectedType = $classificationForm.find('input[value="' + templateType + '"]');
+			$preselectedType = $classificationForm.find('input[value="' + templateType + '"]');
 
-			if (selectedType.length > 0) {
+			if ($preselectedType.length > 0) {
 				$classificationForm.find('input[checked="checked"]').removeAttr('checked');
-				selectedType.attr('checked', 'checked');
+				$preselectedType.attr('checked', 'checked');
 			}
 		}
 
@@ -139,7 +140,7 @@ function ($, mw, loader, nirvana, tracker, labeling) {
 		modalInstance.bind('option-select', function(e) {
 			var $input = $(e.currentTarget).find('input:radio');
 
-			$input.prop('checked', true);
+			$input.attr('checked', 'checked');
 
 			// Track - click to change a template's type
 			tracker.track({
@@ -155,9 +156,34 @@ function ($, mw, loader, nirvana, tracker, labeling) {
 	}
 
 	function processSave(modalInstance) {
-		var templateType = $('#TemplateClassificationEditForm [name="template-classification-types"]:checked').val();
+		var newTemplateType = $('#TemplateClassificationEditForm [name="template-classification-types"]:checked').val(),
+			oldTemplateType = '';
 
-		saveHandler(templateType);
+		if ( $preselectedType.length > 0 ) {
+			oldTemplateType = $preselectedType.val();
+		}
+
+		if ( newTemplateType !== oldTemplateType ) {
+			// Track - modal saved with changes
+			tracker.track({
+				trackingMethod: 'both',
+				category: 'template-classification-dialog',
+				action: 'close',
+				label: 'changed',
+				value: newTemplateType
+			});
+
+			saveHandler(newTemplateType);
+		} else {
+			// Track - modal saved without changes
+			tracker.track({
+				trackingMethod: 'both',
+				category: 'template-classification-dialog',
+				action: 'close',
+				label: 'nochange',
+				value: oldTemplateType
+			});
+		}
 
 		modalInstance.trigger('close');
 	}

--- a/extensions/wikia/TemplateClassification/scripts/TemplateClassificationModal.js
+++ b/extensions/wikia/TemplateClassification/scripts/TemplateClassificationModal.js
@@ -15,7 +15,11 @@ function ($, mw, loader, nirvana, tracker, labeling) {
 		modalConfig,
 		messagesLoaded,
 		saveHandler = falseFunction,
-		typeGetter = falseFunction;
+		typeGetter = falseFunction,
+		track = tracker.buildTrackingFunction({
+			category: 'template-classification-dialog',
+			trackingMethod: 'analytics'
+		});
 
 	/**
 	 * @param {function} typeGetterProvided Method that should return type in json format,
@@ -91,11 +95,7 @@ function ($, mw, loader, nirvana, tracker, labeling) {
 			uiFactory.init(['modal']).then(createComponent);
 
 			// Track - open TC modal
-			tracker.track({
-				trackingMethod: 'both',
-				category: 'template-classification-dialog',
-				action: 'open'
-			});
+			track({action: tracker.ACTIONS.OPEN});
 		});
 	}
 
@@ -119,20 +119,16 @@ function ($, mw, loader, nirvana, tracker, labeling) {
 			processSave(modalInstance);
 
 			// Track - primary-button click
-			tracker.track({
-				trackingMethod: 'both',
-				category: 'template-classification-dialog',
-				action: 'primary-button',
+			track({
+				action: tracker.ACTIONS.CLICK_LINK_BUTTON,
 				label: $(e.currentTarget).text()
 			});
 		});
 
 		modalInstance.bind('close', function () {
 			// Track - close TC modal
-			tracker.track({
-				trackingMethod: 'both',
-				category: 'template-classification-dialog',
-				action: 'close',
+			track({
+				action: tracker.ACTIONS.CLOSE,
 				label: 'close-event'
 			});
 		});
@@ -143,10 +139,8 @@ function ($, mw, loader, nirvana, tracker, labeling) {
 			$input.attr('checked', 'checked');
 
 			// Track - click to change a template's type
-			tracker.track({
-				trackingMethod: 'both',
-				category: 'template-classification-dialog',
-				action: 'change',
+			track({
+				action: tracker.ACTIONS.CLICK_LINK_TEXT,
 				label: $input.val()
 			});
 		});
@@ -159,16 +153,14 @@ function ($, mw, loader, nirvana, tracker, labeling) {
 		var newTemplateType = $('#TemplateClassificationEditForm [name="template-classification-types"]:checked').val(),
 			oldTemplateType = '';
 
-		if ( $preselectedType.length > 0 ) {
+		if ($preselectedType.length > 0) {
 			oldTemplateType = $preselectedType.val();
 		}
 
-		if ( newTemplateType !== oldTemplateType ) {
+		if (newTemplateType !== oldTemplateType) {
 			// Track - modal saved with changes
-			tracker.track({
-				trackingMethod: 'both',
-				category: 'template-classification-dialog',
-				action: 'close',
+			track({
+				action: tracker.ACTIONS.SUBMIT,
 				label: 'changed',
 				value: newTemplateType
 			});
@@ -176,10 +168,8 @@ function ($, mw, loader, nirvana, tracker, labeling) {
 			saveHandler(newTemplateType);
 		} else {
 			// Track - modal saved without changes
-			tracker.track({
-				trackingMethod: 'both',
-				category: 'template-classification-dialog',
-				action: 'close',
+			track({
+				action: tracker.ACTIONS.SUBMIT,
 				label: 'nochange',
 				value: oldTemplateType
 			});

--- a/extensions/wikia/TemplateClassification/scripts/TemplateClassificationModal.js
+++ b/extensions/wikia/TemplateClassification/scripts/TemplateClassificationModal.js
@@ -114,8 +114,16 @@ function ($, mw, loader, nirvana, tracker, labeling) {
 	 */
 	function processInstance(modalInstance) {
 		/* Submit template type edit form on Done button click */
-		modalInstance.bind('done', function runSave() {
+		modalInstance.bind('done', function runSave(e) {
 			processSave(modalInstance);
+
+			// Track - primary-button click
+			tracker.track({
+				trackingMethod: 'both',
+				category: 'template-classification-dialog',
+				action: 'primary-button',
+				label: $(e.currentTarget).text()
+			});
 		});
 
 		modalInstance.bind('close', function () {

--- a/extensions/wikia/TemplateClassification/templates/TemplateClassificationController_editForm.mustache
+++ b/extensions/wikia/TemplateClassification/templates/TemplateClassificationController_editForm.mustache
@@ -1,6 +1,6 @@
 <form id="TemplateClassificationEditForm">
 	{{#templateTypes}}
-		<label for="template-classification-{{type}}" class="template-classification-edit-form-label">
+		<label for="template-classification-{{type}}" class="template-classification-edit-form-label modalEvent" data-event="option-select">
 			<input type="radio" id="template-classification-{{type}}" value="{{type}}" name="template-classification-types" class="template-classification-edit-form-input">
 			<div>
 				<span class="tc-type-name">{{name}}</span>

--- a/resources/wikia/ui_components/modal/js/modal.js
+++ b/resources/wikia/ui_components/modal/js/modal.js
@@ -180,7 +180,7 @@ define('wikia.ui.modal', [
 		/** ATTACHING EVENT HANDLERS TO MODAL */
 
 		// trigger custom buttons events based on button 'data-event' attribute
-		this.$element.on('click', 'button, a.modalEvent', $.proxy(function (event) {
+		this.$element.on('click', 'button, .modalEvent', $.proxy(function (event) {
 			var $target = $(event.currentTarget),
 				modalEventName = $target.data('event');
 


### PR DESCRIPTION
This PR covers tracking of user actions related to Template Classification.

It also introduces one important change - if the classification has not changed, i.e. somebody opened the modal and saved it without selecting another option, a request to re-classify the template **will not be sent** ([see here](https://github.com/Wikia/app/compare/CE-2905?expand=1#diff-d5bde9afc6a40ff66cf72bf44a3fc4b2R166)).

/cc: @bkoval @kamilkoterba @Grunny 
