### PR TITLE
SOC-1456 Save true and false values for hideEditsWikis

### DIFF
--- a/extensions/wikia/UserProfilePageV3/js/UserProfilePage.js
+++ b/extensions/wikia/UserProfilePageV3/js/UserProfilePage.js
@@ -452,7 +452,7 @@ var UserProfilePage = {
 			}
 		}
 
-		userData.hideEditsWikis = (document.userData.hideEditsWikis.checked) ? 1 : 0;
+		userData.hideEditsWikis = document.userData.hideEditsWikis.checked ? 1 : 0;
 
 		return userData;
 	},

--- a/extensions/wikia/UserProfilePageV3/js/UserProfilePage.js
+++ b/extensions/wikia/UserProfilePageV3/js/UserProfilePage.js
@@ -452,7 +452,7 @@ var UserProfilePage = {
 			}
 		}
 
-        userData.hideEditsWikis = (document.userData.hideEditsWikis.checked) ? 1 : 0;
+		userData.hideEditsWikis = (document.userData.hideEditsWikis.checked) ? 1 : 0;
 
 		return userData;
 	},

--- a/extensions/wikia/UserProfilePageV3/js/UserProfilePage.js
+++ b/extensions/wikia/UserProfilePageV3/js/UserProfilePage.js
@@ -451,9 +451,8 @@ var UserProfilePage = {
 				userData[i] = userDataItem;
 			}
 		}
-		if (document.userData.hideEditsWikis.checked) {
-			userData.hideEditsWikis = 1;
-		}
+
+        userData.hideEditsWikis = (document.userData.hideEditsWikis.checked) ? 1 : 0;
 
 		return userData;
 	},


### PR DESCRIPTION
When a user checked the box to hide their favorite wikis on their user profile page, we would save that value to the db and hide their wikis.

If they went back later and unchecked the box, we weren't actually sending that new value to the backend, so it wasn't getting saved to the db. The page would be cached for an hour, so their favorite wikis would show, but once that cached expired we were pulling the old value from the db and hiding their wikis again. This change fixes that.

https://wikia-inc.atlassian.net/browse/SOC-1456
