### PR TITLE
Add a generateToken method to HeliosClient

### DIFF
--- a/extensions/wikia/Helios/tests/UserTest.php
+++ b/extensions/wikia/Helios/tests/UserTest.php
@@ -26,7 +26,7 @@ class UserTest extends \WikiaBaseTest {
 			->bind( HeliosClient::class )->to( function () {
 				return
 					$this->getMock( 'Wikia\Service\Helios\HeliosClient',
-						[ 'info', 'login', 'invalidateToken', 'register' ],
+						[ 'info', 'login', 'invalidateToken', 'generateToken', 'register' ],
 						[ ],
 						'',
 						false );

--- a/lib/Wikia/src/Service/Helios/HeliosClient.php
+++ b/lib/Wikia/src/Service/Helios/HeliosClient.php
@@ -31,4 +31,12 @@ interface HeliosClient {
 	 * A shortcut method for info requests
 	 */
 	public function info( $token );
+
+	/**
+	 * Generate a token for a user.
+	 * Warning: Assumes the user is already authenticated.
+	 *
+	 * @return array - JSON string deserialized into an associative array
+	 */
+	public function generateToken( $userId );
 }

--- a/lib/Wikia/src/Service/Helios/HeliosClientImpl.php
+++ b/lib/Wikia/src/Service/Helios/HeliosClientImpl.php
@@ -167,20 +167,6 @@ class HeliosClientImpl implements HeliosClient
 	}
 
 	/**
-	 * A shortcut method for refresh token requests.
-	 */
-	public function refreshToken( $token )
-	{
-		return $this->request(
-			'token',
-			[
-				'grant_type'	=> 'refresh_token',
-				'refresh_token'	=> $token
-			]
-		);
-	}
-
-	/**
 	 * A shortcut method for token invalidation requests.
 	 *
 	 * @param $token string - a token to be invalidated

--- a/lib/Wikia/src/Service/Helios/HeliosClientImpl.php
+++ b/lib/Wikia/src/Service/Helios/HeliosClientImpl.php
@@ -186,6 +186,24 @@ class HeliosClientImpl implements HeliosClient
 	}
 
 	/**
+	 * Generate a token for a user.
+	 * Warning: Assumes the user is already authenticated.
+	 *
+	 * @param $userId integer - the current user id
+	 *
+	 * @return array - JSON string deserialized into an associative array
+	 */
+	public function generateToken( $userId )
+	{
+		return $this->request(
+			sprintf('users/%s/tokens', $userId),
+			[],
+			[],
+			[ 'method' => 'POST' ]
+		);
+	}
+
+	/**
 	* A shortcut method for register requests.
 	*/
 	public function register( $username, $password, $email, $birthdate, $langCode )


### PR DESCRIPTION
Adding `generateToken( $userId )` to the MediaWiki HeliosClient. This will allow us to generate a token and add it to the cookie when we do facebook logins in MW.

https://wikia-inc.atlassian.net/browse/SERVICES-963

@Wikia/services-team 
