### PR TITLE
SEO-134 HTML <title> as a list

### DIFF
--- a/extensions/wikia/MercuryApi/MercuryApiController.class.php
+++ b/extensions/wikia/MercuryApi/MercuryApiController.class.php
@@ -316,7 +316,7 @@ class MercuryApiController extends WikiaController {
 		}
 
 		// template for non-main pages (use $1 for article name)
-		$wikiVariables['htmlTitleTemplate'] = WikiaHtmlTitle::getPageTitle( '$1', false );
+		$wikiVariables['htmlTitleTemplate'] = ( new WikiaHtmlTitle() )->setParts( ['$1'] )->getTitle();
 
 		$this->response->setVal( 'data', $wikiVariables );
 		$this->response->setFormat( WikiaResponse::FORMAT_JSON );
@@ -370,6 +370,8 @@ class MercuryApiController extends WikiaController {
 			$isMainPage = $title->isMainPage();
 			$data['isMainPage'] = $isMainPage;
 
+			$titleBuilder = new WikiaHtmlTitle();
+
 			if ( $isMainPage && !empty( $wgEnableMainPageDataMercuryApi ) && !empty( $wgWikiaCuratedContent ) ) {
 				$data['mainPageData'] = $this->getMainPageData();
 			} else {
@@ -383,9 +385,10 @@ class MercuryApiController extends WikiaController {
 				if ( !empty( $relatedPages ) ) {
 					$data['relatedPages'] = $relatedPages;
 				}
+				$titleBuilder->setParts( [ $articleAsJson['displayTitle'] ] );
 			}
+			$data['htmlTitle'] = $titleBuilder->getTitle();
 
-			$data['htmlTitle'] = WikiaHtmlTitle::getPageTitle( $title->getPrefixedText(), $title->isMainPage() );
 		} catch ( WikiaHttpException $exception ) {
 			$this->response->setCode( $exception->getCode() );
 

--- a/includes/Article.php
+++ b/includes/Article.php
@@ -695,13 +695,10 @@ class Article extends Page {
 		# that's not empty).
 		# This message always exists because it is in the i18n files
 		# Wikia change - begin
-		# This logic is moved to OutputPage::setHTMLTitle
-		#if ( $this->getTitle()->isMainPage() ) {
-		#	$msg = wfMessage( 'pagetitle-view-mainpage' )->inContentLanguage();
-		#	if ( !$msg->isDisabled() ) {
-		#		$wgOut->setHTMLTitle( $msg->title( $this->getTitle() )->text() );
-		#	}
-		#}
+		if ( $this->getTitle()->isMainPage() ) {
+			// The wiki name and brand name are added to all titles
+			$wgOut->setHTMLTitle( '' );
+		}
 		# Wikia change - end
 
 		# Check for any __NOINDEX__ tags on the page using $pOutput

--- a/includes/OutputPage.php
+++ b/includes/OutputPage.php
@@ -830,11 +830,12 @@ class OutputPage extends ContextSource {
 	 */
 	public function setHTMLTitle( $name ) {
 		/* Wikia change - begin */
-		if ( $name instanceof Message ) {
-			$name = $name->setContext( $this->getContext() )->text();
+		if ( is_array( $name ) ) {
+			$parts = $name;
+		} else {
+			$parts = [ $name ];
 		}
-
-		$this->mHTMLtitle = WikiaHtmlTitle::getPageTitle( $name, $this->getTitle()->isMainPage() );
+		$this->mHTMLtitle = ( new WikiaHtmlTitle() )->setParts( $parts )->getTitle();
 		/* Wikia change - end */
 	}
 

--- a/includes/wikia/WikiaHtmlTitle.class.php
+++ b/includes/wikia/WikiaHtmlTitle.class.php
@@ -6,23 +6,117 @@
 class WikiaHtmlTitle {
 
 	/**
-	 * Get page title
-	 * @param string $name
-	 * @param boolean $isMainPage
-	 * @return string
+	 * @var string - The separator used to separate parts of the HTML title
+	 *
+	 * Note there is a logic that guesses the separator from a MediaWiki message <pagetitle>
+	 * This logic might be removed later for consistency and simplicity (see the file below)
 	 */
-	public static function getPageTitle( $name, $isMainPage ) {
-		// First apply the per-wiki template (editable by communitiess)
-		if ( $isMainPage ) {
-			$title = wfMessage( 'pagetitle-view-mainpage', $name )->inContentLanguage()->text();
-		} else {
-			$title = wfMessage( 'pagetitle', $name )->inContentLanguage()->text();
+	private $separator = ' - ';
+
+	/** @var array - Configurable parts of the title */
+	private $parts = [];
+
+	/** @var array - Environment like dev-rychu, sandbox-s4, etc */
+	private $environment;
+
+	/** @var string - The site name to include in the title */
+	private $siteName;
+
+	/** @var string - The brand name to include in the title */
+	private $brandName;
+
+	public function __construct() {
+		global $wgWikiaEnvironment;
+
+		if ( $wgWikiaEnvironment !== WIKIA_ENV_PROD ) {
+			$this->environment = wfHostname();
 		}
 
-		// Now apply Wikia-wide template on top of that
-		$fullTitle = wfMessage( 'wikia-pagetitle', $title )->inContentLanguage()->text();
+		$this->brandName = wfMessage( 'wikia-pagetitle-brand' );
+		$this->siteName = wfMessage( 'wikia-pagetitle-sitename' );
 
-		return $fullTitle;
+		if ( WikiaPageType::isWikiaHomePage() ) {
+			$this->siteName = null;
+		}
+
+		// Compatibility mode: extract the wiki title from <pagetitle> MW message
+		// Remove later
+		$pageTitleTemplate = wfMessage( 'pagetitle' )->inContentLanguage()->text();
+
+		if (preg_match( '/^\\$1( \\W )(.*)$/u', $pageTitleTemplate, $m ) ) {
+			$this->separator = $m[1];
+			$this->siteName = $m[2];
+		}
+		// End of compatibility mode
 	}
 
+	/**
+	 * Set the HTML title parts
+	 *
+	 * You can pass an empty array: the generated title will be wiki name + brand name
+	 * You can pass one-item array: the generated title will be the passed item + wiki name + brand name
+	 * You can pass more items: the generated title will be the passed items + wiki name + brand name
+	 *
+	 * It's useful to pass many items at once to construct titles like that:
+	 *
+	 * "A few words about the admin - George User Blog - My Wiki - Wikia"
+	 *
+	 * Just do:
+	 *
+	 * $titleBuilder->setParts( $blogTitle, wfMessage( 'user-blog-title' )->params( $userName ) );
+	 *
+	 * The wiki name and brand name are added to all titles, so you don't worry about them.
+	 *
+	 * @param array $parts - title parts as Message and/or strings, empty parts will be ignored
+	 * @return $this
+	 */
+	public function setParts( array $parts ) {
+		$newParts = [];
+
+		foreach ( $parts as $part ) {
+			if ( $part instanceof Message ) {
+				$newParts[] = $part->inContentLanguage()->text();
+			}
+			if ( is_string( $part ) ) {
+				$newParts[] = $part;
+			}
+		}
+
+		$this->parts = $newParts;
+		return $this;
+	}
+
+	/**
+	 * Get all parts including the automatically generated ones
+	 *
+	 * @return array
+	 */
+	public function getAllParts() {
+		$parts = array_merge(
+			[$this->environment],
+			$this->parts,
+			[$this->siteName, $this->brandName]
+		);
+		return array_filter( $parts, function ( $part ) {
+			return !empty( $part );
+		} );
+	}
+
+	/**
+	 * Get the separator used for building HTML titles
+	 *
+	 * @return string
+	 */
+	public function getSeparator() {
+		return $this->separator;
+	}
+
+	/**
+	 * Get fully built HTML title
+	 *
+	 * @return string
+	 */
+	public function getTitle() {
+		return join( $this->getSeparator(), $this->getAllParts() );
+	}
 }

--- a/includes/wikia/WikiaHtmlTitle.class.php
+++ b/includes/wikia/WikiaHtmlTitle.class.php
@@ -38,16 +38,6 @@ class WikiaHtmlTitle {
 		if ( WikiaPageType::isWikiaHomePage() ) {
 			$this->siteName = null;
 		}
-
-		// Compatibility mode: extract the wiki title from <pagetitle> MW message
-		// Remove later
-		$pageTitleTemplate = wfMessage( 'pagetitle' )->inContentLanguage()->text();
-
-		if (preg_match( '/^\\$1( \\W )(.*)$/u', $pageTitleTemplate, $m ) ) {
-			$this->separator = $m[1];
-			$this->siteName = $m[2];
-		}
-		// End of compatibility mode
 	}
 
 	/**

--- a/includes/wikia/api/ArticlesApiController.class.php
+++ b/includes/wikia/api/ArticlesApiController.class.php
@@ -1052,7 +1052,8 @@ class ArticlesApiController extends WikiaApiController {
 			'content' => $content,
 			'media' => $articleContent->media,
 			'users' => $articleContent->users,
-			'categories' => $categories
+			'categories' => $categories,
+			'displayTitle' => $parsedArticle->getTitleText(),
 		];
 
 		$this->setResponseData( $result, '', self::SIMPLE_JSON_VARNISH_CACHE_EXPIRATION );

--- a/languages/messages/wikia/MessagesEn.php
+++ b/languages/messages/wikia/MessagesEn.php
@@ -1054,5 +1054,6 @@ hu',
 'import-article-not-js-single' => '$1 was not loaded as it\'s not a JS page (requested by user-supplied javascript). Please make sure the article title has .js extension.',
 'import-article-not-js-multiple' => '$1 $2 were not loaded as they\'re not JS pages (requested by user-supplied javascript). Please make sure the articles titles have .js extension.',
 
-'wikia-pagetitle' => '$1 - Wikia',
+'wikia-pagetitle-brand' => 'Wikia',
+'wikia-pagetitle-sitename' => '{{SITENAME}}',
 ) );


### PR DESCRIPTION
Changing the code for generating the `<title>` tags, so that it accepts a list of parts rather than a string.

The code still acts in a compatibility mode, which means it preserves the behavior of reading the templates saved in MW messages: pagetitle.

Ideally that code should be dropped and replaced with the one that only reads the wikia-pagetitle-site for the middle part ("Site") of the "Article - Site - Wikia" template.
