### PR TITLE
Masthead: improve detection of default avatars

### DIFF
--- a/extensions/wikia/UserProfilePageV3/Masthead.class.php
+++ b/extensions/wikia/UserProfilePageV3/Masthead.class.php
@@ -453,7 +453,7 @@ class Masthead {
 		$url = $this->mUser->getGlobalAttribute( AVATAR_USER_OPTION_NAME );
 		if ( $url ) {
 			# all avatars (including the default ones) are always stored with a full URL
-			if ( startsWith( $url, 'http://' ) and preg_match('#/Avatar\d+.jpg$#', $url) ) {
+			if ( startsWith( $url, 'http://' ) and preg_match('#/Avatar\d?.jpg$#', $url) ) {
 				return true;
 			}
 

--- a/extensions/wikia/UserProfilePageV3/Masthead.class.php
+++ b/extensions/wikia/UserProfilePageV3/Masthead.class.php
@@ -452,9 +452,12 @@ class Masthead {
 	public function isDefault() {
 		$url = $this->mUser->getGlobalAttribute( AVATAR_USER_OPTION_NAME );
 		if ( $url ) {
-			/**
-			 * default avatar are only filenames without path
-			 */
+			# all avatars (including the default ones) are always stored with a full URL
+			if ( startsWith( $url, 'http://' ) and preg_match('#/Avatar\d+.jpg$#', $url) ) {
+				return true;
+			}
+
+			 # Legacy: default avatar are only filenames without path
 			if ( strpos( $url, '/' ) !== false ) {
 				return false;
 			}

--- a/extensions/wikia/UserProfilePageV3/Masthead.class.php
+++ b/extensions/wikia/UserProfilePageV3/Masthead.class.php
@@ -549,7 +549,8 @@ class Masthead {
 			global $wgAvatarsUseService;
 
 			// user avatars service updates user preferences on its own
-			if ( empty( $wgAvatarsUseService ) ) {
+			// removing default avatars is hanlded by MW even when the service is enabled (PLATFORM-1617)
+			if ( empty( $wgAvatarsUseService ) || $this->isDefault() ) {
 				$this->mUser->setGlobalAttribute( AVATAR_USER_OPTION_NAME, "" );
 				$this->mUser->saveSettings();
 			}

--- a/extensions/wikia/UserProfilePageV3/tests/MastheadTest.php
+++ b/extensions/wikia/UserProfilePageV3/tests/MastheadTest.php
@@ -82,6 +82,10 @@ class MastheadTest extends WikiaBaseTest {
 			],
 			# PLATFORM-1617: full URLs
 			[
+				'http://images.wikia.com/messaging/images//1/19/Avatar.jpg',
+				true
+			],
+			[
 				'http://images.wikia.com/messaging/images/e/e5/Avatar4.jpg',
 				true
 			],

--- a/extensions/wikia/UserProfilePageV3/tests/MastheadTest.php
+++ b/extensions/wikia/UserProfilePageV3/tests/MastheadTest.php
@@ -79,6 +79,19 @@ class MastheadTest extends WikiaBaseTest {
 			[
 				'/f/fc/119245.png',
 				false
+			],
+			# PLATFORM-1617: full URLs
+			[
+				'http://images.wikia.com/messaging/images/e/e5/Avatar4.jpg',
+				true
+			],
+			[
+				'http://images.wikia.com/common/avatars/3/3b/27078273.png',
+				false
+			],
+			[
+				'http://static.wikia.nocookie.net/ba2cd689-8297-4fba-b739-0b6e08efc794',
+				false
 			]
 		];
 	}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-1617
- after avatars migration even the default ones are stored with their full URL
- removing default avatars is handled by MW even when the service is enabled

@jcellary / @jsutterfield 
