### PR TITLE
Ensure the helios access_token is set during the facebook authentication flow

### DIFF
--- a/extensions/wikia/Helios/User.class.php
+++ b/extensions/wikia/Helios/User.class.php
@@ -7,6 +7,7 @@ use Wikia\DependencyInjection\Injector;
 use Wikia\Logger\WikiaLogger;
 use Wikia\Service\Helios\ClientException;
 use Wikia\Service\Helios\HeliosClient;
+use Wikia\Service\User\Auth\CookieHelper;
 
 /**
  * A helper class for dealing with user-related objects.

--- a/extensions/wikia/Helios/User.class.php
+++ b/extensions/wikia/Helios/User.class.php
@@ -54,6 +54,7 @@ class User {
 	 */
 	public static function getAccessToken( \WebRequest $request ) {
 		// A cookie takes precedence over an HTTP header.
+		// FIXME: replace with CookieHelper
 		$token = $request->getCookie( self::ACCESS_TOKEN_COOKIE_NAME, '' );
 
 		// No access token in the cookie, try the HTTP header.
@@ -223,12 +224,7 @@ class User {
 	 */
 	public static function setAccessTokenCookie( $accessToken ) {
 		$response = \RequestContext::getMain()->getRequest()->response();
-		$response->setcookie(
-			self::ACCESS_TOKEN_COOKIE_NAME,
-			$accessToken,
-			time() + self::ACCESS_TOKEN_COOKIE_TTL,
-			\WebResponse::NO_COOKIE_PREFIX
-		);
+		self::getCookieHelper()->setAuthenticationCookieWithToken( $accessToken, $response );
 	}
 
 	public static function onUserLogout() {
@@ -254,6 +250,7 @@ class User {
 	 * Clear the access token cookie by setting a time in the past
 	 */
 	public static function clearAccessTokenCookie() {
+		// FIXME: replace with CookieHelper::clearAuthenticationCookie
 		self::clearCookie( self::ACCESS_TOKEN_COOKIE_NAME );
 
 		/*
@@ -479,4 +476,12 @@ class User {
 	public static function getHeliosClient() {
 		return Injector::getInjector()->get(HeliosClient::class);
 	}
+
+	/**
+	 * @return \Wikia\Service\User\Auth\CookieHelper
+	 */
+	private static function getCookieHelper() {
+		return Injector::getInjector()->get(CookieHelper::class);
+	}
+
 }

--- a/extensions/wikia/UserLogin/FacebookSignupController.class.php
+++ b/extensions/wikia/UserLogin/FacebookSignupController.class.php
@@ -71,7 +71,7 @@ class FacebookSignupController extends WikiaController {
 				] );
 			} else {
 				// account is connected - log the user in
-				UserLoginHelper::setCookiesForFacebookUser( $user, $this->response );
+				UserLoginHelper::setCookiesForFacebookUser( $user, \RequestContext::getMain()->getRequest()->response() );
 
 				$this->response->setData( [
 					'loggedIn' => true,
@@ -352,7 +352,7 @@ class FacebookSignupController extends WikiaController {
 			wfSetupSession();
 		}
 
-		UserLoginHelper::setCookiesForFacebookUser( $user, $this->response );
+		UserLoginHelper::setCookiesForFacebookUser( $user, \RequestContext::getMain()->getRequest()->response() );
 
 		// Store the user in the global user object
 		$wg->User = $user;

--- a/extensions/wikia/UserLogin/FacebookSignupController.class.php
+++ b/extensions/wikia/UserLogin/FacebookSignupController.class.php
@@ -71,7 +71,7 @@ class FacebookSignupController extends WikiaController {
 				] );
 			} else {
 				// account is connected - log the user in
-				$user->setCookies();
+				UserLoginHelper::setCookiesForFacebookUser( $user, $this->response );
 
 				$this->response->setData( [
 					'loggedIn' => true,
@@ -352,7 +352,7 @@ class FacebookSignupController extends WikiaController {
 			wfSetupSession();
 		}
 
-		$user->setCookies();
+		UserLoginHelper::setCookiesForFacebookUser( $user, $this->response );
 
 		// Store the user in the global user object
 		$wg->User = $user;

--- a/extensions/wikia/UserLogin/UserLoginFacebookForm.class.php
+++ b/extensions/wikia/UserLogin/UserLoginFacebookForm.class.php
@@ -78,7 +78,7 @@ class UserLoginFacebookForm extends UserLoginForm {
 
 			if ( $this->hasConfirmedEmail ) {
 				$this->confirmUser( $user );
-				$user->setCookies();
+				UserLoginHelper::setCookiesForFacebookUser( $user, $this->getRequest()->response() );
 				$this->addNewUserToLog( $user );
 			} else {
 				$this->sendConfirmationEmail( $user );

--- a/extensions/wikia/UserLogin/UserLoginHelper.class.php
+++ b/extensions/wikia/UserLogin/UserLoginHelper.class.php
@@ -642,7 +642,7 @@ class UserLoginHelper extends WikiaModel {
 	 */
 	private static function setCookiesForFacebookUser( \User $user, \Wikia\HTTP\Response $response ) {
 		$user->setCookies();
-		self::getCookieHelper()->setAuthenticationCookieWithUserId( $user->getId() );
+		self::getCookieHelper()->setAuthenticationCookieWithUserId( $user->getId(), $response );
 	}
 
 	/**

--- a/extensions/wikia/UserLogin/UserLoginHelper.class.php
+++ b/extensions/wikia/UserLogin/UserLoginHelper.class.php
@@ -1,5 +1,8 @@
 <?php
 
+use Wikia\DependencyInjection\Injector;
+use Wikia\Service\User\Auth\CookieHelper;
+
 /**
  * User Login Helper
  * @author Hyun
@@ -640,7 +643,7 @@ class UserLoginHelper extends WikiaModel {
 	 *
 	 * @param User the user that has been authenticated via facebook.
 	 */
-	private static function setCookiesForFacebookUser( \User $user, \Wikia\HTTP\Response $response ) {
+	public static function setCookiesForFacebookUser( \User $user, \Wikia\HTTP\Response $response ) {
 		$user->setCookies();
 		self::getCookieHelper()->setAuthenticationCookieWithUserId( $user->getId(), $response );
 	}

--- a/extensions/wikia/UserLogin/UserLoginHelper.class.php
+++ b/extensions/wikia/UserLogin/UserLoginHelper.class.php
@@ -634,4 +634,22 @@ class UserLoginHelper extends WikiaModel {
 		$lang = $this->wg->ContLang->mCode;
 		return $lang == 'en' ? '' : '&uselang=' . $lang;
 	}
+
+	/**
+	 * Set the cookies for the newly connected user.
+	 *
+	 * @param User the user that has been authenticated via facebook.
+	 */
+	private static function setCookiesForFacebookUser( \User $user, \Wikia\HTTP\Response $response ) {
+		$user->setCookies();
+		self::getCookieHelper()->setAuthenticationCookieWithUserId( $user->getId() );
+	}
+
+	/**
+	 * @return \Wikia\Service\User\Auth\CookieHelper
+	 */
+	private static function getCookieHelper() {
+		return Injector::getInjector()->get(CookieHelper::class);
+	}
+
 }

--- a/includes/WebResponse.php
+++ b/includes/WebResponse.php
@@ -25,7 +25,7 @@
  * and handle all outputting (or lack of outputting) via it.
  * @ingroup HTTP
  */
-class WebResponse {
+class WebResponse implements \Wikia\HTTP\Response {
 
 	const NO_COOKIE_PREFIX = '';
 

--- a/lib/Wikia/src/HTTP/Response.php
+++ b/lib/Wikia/src/HTTP/Response.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Wikia\HTTP;
+
+interface Response {
+	public function setcookie($name, $value, $ttl, $prefix=null, $domain=null);
+}

--- a/lib/Wikia/src/Service/User/Auth/AuthModule.php
+++ b/lib/Wikia/src/Service/User/Auth/AuthModule.php
@@ -13,6 +13,7 @@ class AuthModule implements Module {
 		$builder
 			->bind( AuthService::class )->toClass( MediaWikiAuthService::class )
 			->bind( HeliosClient::class )->toClass( HeliosClientImpl::class )
+			->bind( CookieHelper::class )->toClass( HeliosCookieHelper::class )
 			->bind( HeliosClientImpl::BASE_URI )->to( function () {
 				global $wgHeliosBaseUri;
 				return $wgHeliosBaseUri;

--- a/lib/Wikia/src/Service/User/Auth/CookieHelper.php
+++ b/lib/Wikia/src/Service/User/Auth/CookieHelper.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Wikia\Service\User\Auth;
+
+use Wikia\HTTP\Response;
+
+interface CookieHelper {
+	public function setAuthenticationCookieWithUserId( $userId, Response $response );
+	public function setAuthenticationCookieWithToken( $accessToken, Response $response );
+}

--- a/lib/Wikia/src/Service/User/Auth/CookieHelper.php
+++ b/lib/Wikia/src/Service/User/Auth/CookieHelper.php
@@ -7,4 +7,5 @@ use Wikia\HTTP\Response;
 interface CookieHelper {
 	public function setAuthenticationCookieWithUserId( $userId, Response $response );
 	public function setAuthenticationCookieWithToken( $accessToken, Response $response );
+	public function clearAuthenticationCookie( Response $response );
 }

--- a/lib/Wikia/src/Service/User/Auth/HeliosCookieHelper.php
+++ b/lib/Wikia/src/Service/User/Auth/HeliosCookieHelper.php
@@ -23,7 +23,7 @@ class HeliosCookieHelper implements CookieHelper {
 
 
 	/**
-		* @param HeliosClient $client
+	 * @param HeliosClient $client
 	 */
 	public function setHeliosClient( HeliosClient $client ) {
 		$this->heliosClient = $client;

--- a/lib/Wikia/src/Service/User/Auth/HeliosCookieHelper.php
+++ b/lib/Wikia/src/Service/User/Auth/HeliosCookieHelper.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Wikia\Service\User\Auth;
+
+use Wikia\HTTP\Response;
+use Wikia\Service\Helios\HeliosClient;
+
+class HeliosCookieHelper implements CookieHelper {
+
+	const ACCESS_TOKEN_COOKIE_NAME = 'access_token';
+	// This is set to 6 months,(365/2)*24*60*60 = 15768000
+	const ACCESS_TOKEN_COOKIE_TTL = 15768000;
+	const NO_COOKIE_PREFIX = '';
+
+	private $heliosClient;
+
+	/**
+	 * @Inject({Wikia\Service\Helios\HeliosClient::class})
+	 */
+	public function __construct( HeliosClient $client ) {
+		$this->heliosClient = $client;
+	}
+
+
+	/**
+		* @param HeliosClient $client
+	 */
+	public function setHeliosClient( HeliosClient $client ) {
+		$this->heliosClient = $client;
+	}
+
+
+	/**
+	 * Set the authentication cookie using the user id. This method will retrieve a new
+	 * authentication token from Helios and then set the authentication cookie.
+	 *
+	 * Warning: this should only be called once the user has been authenticated (e.g. from a 3rd party)
+	 *
+	 * @param int $userId
+	 * @param Response $response
+	 */
+	public function setAuthenticationCookieWithUserId( $userId, Response $response ) {
+		$tokenData = $this->heliosClient->generateToken( $userId );
+		$this->setAuthenticationCookieWithToken( $tokenData->access_token, $response );
+	}
+
+	/**
+	 * Set the authentication cookie for the user using the given access token.
+	 *
+	 * @param string $accessToken
+	 * @param Response $response
+	 */
+	public function setAuthenticationCookieWithToken( $accessToken, Response $response ) {
+		$response->setcookie(
+			self::ACCESS_TOKEN_COOKIE_NAME,
+			// FIXME: generateToken should return an object so we don't have to rely on the
+			// structure of the json map
+			$accessToken,
+			time() + self::ACCESS_TOKEN_COOKIE_TTL,
+			self::NO_COOKIE_PREFIX
+		);
+	}
+
+	/**
+	 * Clears the authentication cookie.
+	 *
+	 * @param Response $response
+	 *
+	 */
+	public function clearAuthenticationCookie( Response $response ) {
+		$response->setcookie(
+			self::ACCESS_TOKEN_COOKIE_NAME,
+			'',
+			time() - self::ACCESS_TOKEN_COOKIE_TTL,
+			self::NO_COOKIE_PREFIX
+		);
+	}
+
+}

--- a/lib/Wikia/src/Service/User/Auth/HeliosCookieHelper.php
+++ b/lib/Wikia/src/Service/User/Auth/HeliosCookieHelper.php
@@ -10,7 +10,7 @@ class HeliosCookieHelper implements CookieHelper {
 	const ACCESS_TOKEN_COOKIE_NAME = 'access_token';
 	// This is set to 6 months,(365/2)*24*60*60 = 15768000
 	const ACCESS_TOKEN_COOKIE_TTL = 15768000;
-	const NO_COOKIE_PREFIX = '';
+	const COOKIE_PREFIX = '';
 
 	private $heliosClient;
 
@@ -57,7 +57,7 @@ class HeliosCookieHelper implements CookieHelper {
 			// structure of the json map
 			$accessToken,
 			time() + self::ACCESS_TOKEN_COOKIE_TTL,
-			self::NO_COOKIE_PREFIX
+			self::COOKIE_PREFIX
 		);
 	}
 
@@ -72,7 +72,7 @@ class HeliosCookieHelper implements CookieHelper {
 			self::ACCESS_TOKEN_COOKIE_NAME,
 			'',
 			time() - self::ACCESS_TOKEN_COOKIE_TTL,
-			self::NO_COOKIE_PREFIX
+			self::COOKIE_PREFIX
 		);
 	}
 

--- a/lib/Wikia/tests/Service/User/Auth/CookieHelperTest.php
+++ b/lib/Wikia/tests/Service/User/Auth/CookieHelperTest.php
@@ -25,8 +25,7 @@ class CookieHelperTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->cookieHelper = new HeliosCookieHelper();
-		$this->cookieHelper->setHeliosClient($this->helios);
+		$this->cookieHelper = new HeliosCookieHelper( $this->helios );
 	}
 
 	public function testSetAuthenticationCookie() {

--- a/lib/Wikia/tests/Service/User/Auth/CookieHelperTest.php
+++ b/lib/Wikia/tests/Service/User/Auth/CookieHelperTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Wikia\Service\User\Auth;
+
+use Wikia\Domain\UserObject;
+use Wikia\HTTP\Response;
+use Wikia\Service\Helios\HeliosClient;
+
+class CookieHelperTest extends \PHPUnit_Framework_TestCase {
+
+	const TEST_USER_ID = 12345;
+	const TEST_TOKEN = 'abcdefghijk';
+
+	private $helios;
+	private $response;
+	private $cookieHelper;
+
+	public function setUp() {
+		$this->response = $this->getMockBuilder( Response::class )
+			->setMethods( ['setcookie'] )
+			->disableOriginalConstructor()
+			->getMock();
+		$this->helios = $this->getMockBuilder( HeliosClient::class )
+			->setMethods( ['generateToken', 'info', 'register', 'invalidateToken', 'login'] )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->cookieHelper = new HeliosCookieHelper();
+		$this->cookieHelper->setHeliosClient($this->helios);
+	}
+
+	public function testSetAuthenticationCookie() {
+		$tokenData = (object)array( HeliosCookieHelper::ACCESS_TOKEN_COOKIE_NAME => self::TEST_TOKEN );
+		$this->helios->expects( $this->once() )
+			->method( 'generateToken' )
+			->with( self::TEST_USER_ID )
+			->willReturn( $tokenData );
+
+		$this->response->expects( $this->once() )
+			->method( 'setcookie' )
+			->with(
+			 	HeliosCookieHelper::ACCESS_TOKEN_COOKIE_NAME,
+				$tokenData->access_token,
+				$this->isType('int'),
+				HeliosCookieHelper::NO_COOKIE_PREFIX
+		 	);
+
+		$this->cookieHelper->setAuthenticationCookieWithUserId( self::TEST_USER_ID, $this->response );
+	}
+
+	public function testClearAuthenticationCookie() {
+		$this->response->expects( $this->once() )
+			->method( 'setcookie' )
+			->with(
+			 	HeliosCookieHelper::ACCESS_TOKEN_COOKIE_NAME,
+				"",
+				$this->isType('int'),
+				HeliosCookieHelper::NO_COOKIE_PREFIX
+		 	);
+
+		$this->cookieHelper->clearAuthenticationCookie( $this->response );
+	}
+
+}

--- a/lib/Wikia/tests/Service/User/Auth/HeliosCookieHelperTest.php
+++ b/lib/Wikia/tests/Service/User/Auth/HeliosCookieHelperTest.php
@@ -41,7 +41,7 @@ class HeliosCookieHelperTest extends \PHPUnit_Framework_TestCase {
 			 	HeliosCookieHelper::ACCESS_TOKEN_COOKIE_NAME,
 				$tokenData->access_token,
 				$this->isType('int'),
-				HeliosCookieHelper::NO_COOKIE_PREFIX
+				HeliosCookieHelper::COOKIE_PREFIX
 		 	);
 
 		$this->cookieHelper->setAuthenticationCookieWithUserId( self::TEST_USER_ID, $this->response );
@@ -54,7 +54,7 @@ class HeliosCookieHelperTest extends \PHPUnit_Framework_TestCase {
 			 	HeliosCookieHelper::ACCESS_TOKEN_COOKIE_NAME,
 				"",
 				$this->isType('int'),
-				HeliosCookieHelper::NO_COOKIE_PREFIX
+				HeliosCookieHelper::COOKIE_PREFIX
 		 	);
 
 		$this->cookieHelper->clearAuthenticationCookie( $this->response );

--- a/lib/Wikia/tests/Service/User/Auth/HeliosCookieHelperTest.php
+++ b/lib/Wikia/tests/Service/User/Auth/HeliosCookieHelperTest.php
@@ -6,7 +6,7 @@ use Wikia\Domain\UserObject;
 use Wikia\HTTP\Response;
 use Wikia\Service\Helios\HeliosClient;
 
-class CookieHelperTest extends \PHPUnit_Framework_TestCase {
+class HeliosCookieHelperTest extends \PHPUnit_Framework_TestCase {
 
 	const TEST_USER_ID = 12345;
 	const TEST_TOKEN = 'abcdefghijk';


### PR DESCRIPTION
This PR ensures that the helios `access_token` is set during the facebook authentication flow. With this PR, I'm also adding a cookie helper under the `Auth` namespace. The cookie handling is sprinkled around the code base in core, in the Helios extension and in the `UserLogin` extension. The related cookie handling in this PR should enable us to start the process of consolidating that functionality into one place.

https://wikia-inc.atlassian.net/browse/SERVICES-962

@Wikia/services-team @wladekb @michalroszka 
