### PR TITLE
CE-2949 Hotfix for failing user renames

### DIFF
--- a/extensions/wikia/EditAccount/SpecialEditAccount_body.php
+++ b/extensions/wikia/EditAccount/SpecialEditAccount_body.php
@@ -533,7 +533,7 @@ class EditAccount extends SpecialPage {
 	/** Hook for storing historical log of email changes **/
 	public static function logEmailChanges($user, $new_email, $old_email) {
 		global $wgExternalSharedDB, $wgUser, $wgRequest;
-		if ( $wgExternalSharedDB ) {
+		if ( $wgExternalSharedDB && isset( $new_email ) && isset( $old_email ) ) {
 			$dbw = wfGetDB( DB_MASTER, array(), $wgExternalSharedDB );
 			$dbw->insert(
 				'user_email_log',


### PR DESCRIPTION
The problem with renames was that it triggered a mechanism introduced by @owend that logs a user's email change. However, a `$new_email` var is empty in this case which results in DBException since neither `old_email` nor `new_email` allows `NULL` values.

A more permanent fix would be probably to untie this logging mechanisms from a user's rename process, but  would like to open a discussion with @owend.

/cc: @Grunny @lukaszkonieczny 
