### PR TITLE
PLATFORM-1582: Fix error and exception logging in tasks

### DIFF
--- a/includes/wikia/tasks/TaskRunner.class.php
+++ b/includes/wikia/tasks/TaskRunner.class.php
@@ -76,6 +76,11 @@ class TaskRunner {
 
 			WikiaLogger::instance()->pushContext( [ 'task_call' => get_class($task)."::{$method}"] );
 			$result = $task->execute( $method, $args );
+			if ( $result instanceof Exception ) {
+				WikiaLogger::instance()->error( 'Exception: ' . $result->getMessage(), [
+					'exception' => $result,
+				] );
+			}
 			WikiaLogger::instance()->popContext();
 			$this->results [] = $result;
 

--- a/lib/Wikia/src/Logger/WikiaLogger.php
+++ b/lib/Wikia/src/Logger/WikiaLogger.php
@@ -60,6 +60,7 @@ class WikiaLogger implements LoggerInterface {
 			case E_ERROR:
 			case E_CORE_ERROR:
 			case E_USER_ERROR:
+			case E_RECOVERABLE_ERROR:
 				$exit = true;
 				$method = 'error';
 				$priorityString = 'Fatal Error';
@@ -72,6 +73,7 @@ class WikiaLogger implements LoggerInterface {
 			case E_COMPILE_ERROR:
 			case E_COMPILE_WARNING:
 			case E_DEPRECATED:
+			case E_USER_DEPRECATED:
 				// compile-time errors don't call autoload callbacks, so let the standard php error log handle them - BAC-1225
 				return false;
 			default:


### PR DESCRIPTION
There were a few reports that failed tasks don't leave any trace about that fact. This should improve logging in two cases:
- tasks execution throws an exception
- Catchable Fatal Errors were never reported by our customized error handler

/cc @macbre @kvas-damian 
