### PR TITLE
Reject authentication fallback to MW sessions

### DIFF
--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1829,4 +1829,4 @@ $wgLogRestrictions['piggyback'] = 'piggyback';
 /**
  * Reject attempts to fall back to the MediaWiki session for authentication.
  */
-$wgRejectAuthenticationFallback = false;
+$wgRejectAuthenticationFallback = true;


### PR DESCRIPTION
Second try. The first attempt broke the facebook integration. That was fixed with SERVICES-962.

https://wikia-inc.atlassian.net/browse/SERVICES-889

See also
- #8953 (dev for 962)
- #8961 (release-343 with this change and #8953)
- #8962 (release-344 with this change and #8953)

@Wikia/services-team 
