### PR TITLE
add boolean toggle for do-nothing cache for preference cache

### DIFF
--- a/lib/Wikia/src/Service/User/Preferences/PreferenceModule.php
+++ b/lib/Wikia/src/Service/User/Preferences/PreferenceModule.php
@@ -2,6 +2,7 @@
 
 namespace Wikia\Service\User\Preferences;
 
+use Doctrine\Common\Cache\VoidCache;
 use Interop\Container\ContainerInterface;
 use User;
 use Wikia\Cache\BagOStuffCacheProvider;
@@ -14,12 +15,17 @@ use Wikia\Service\User\Preferences\Migration\PreferenceScopeService;
 
 class PreferenceModule implements Module {
 	const PREFERENCE_CACHE_VERSION = 3;
+	const PREFERENCE_CACHE = false;
 
 	public function configure( InjectorBuilder $builder ) {
 		$builder
 			->bind( PreferenceService::class )->toClass( PreferenceServiceImpl::class )
 			->bind( PreferencePersistence::class )->toClass( PreferencePersistenceSwaggerService::class )
 			->bind( PreferenceServiceImpl::CACHE_PROVIDER )->to( function() {
+				if ( !self::PREFERENCE_CACHE ) {
+					return new VoidCache();
+				}
+
 				global $wgMemc;
 				$provider = new BagOStuffCacheProvider( $wgMemc );
 				$provider->setNamespace( PreferenceService::class . ":" . self::PREFERENCE_CACHE_VERSION );


### PR DESCRIPTION
@Wikia/services-team 
https://wikia-inc.atlassian.net/browse/SERVICES-938

module configuration for using a noop cache for the user preference service, so that all requests for a user's preferences are sent to the service
