### PR TITLE
Nirvana: Decrease the noise in reported transactions

### DIFF
--- a/wikia.php
+++ b/wikia.php
@@ -1,39 +1,39 @@
 <?php
 
 // This is from google translate, just return early.
-if ( $_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
-	header ( "HTTP/1.1 200", true, 200);
+if ( $_SERVER['REQUEST_METHOD'] == 'OPTIONS' ) {
+	header ( "HTTP/1.1 200", true, 200 );
 	return;
 }
 
 // prevent $_GET['title'] from being overwritten on API calls (BAC-906)
-define('DONT_INTERPOLATE_TITLE', true);
+define( 'DONT_INTERPOLATE_TITLE', true );
 
 // Initialise common MW code
 require ( dirname( __FILE__ ) . '/includes/WebStart.php' );
 
-if ($wgProfiler instanceof Profiler) {
-	$wgProfiler->setTemplated(true);
+if ( $wgProfiler instanceof Profiler ) {
+	$wgProfiler->setTemplated( true );
 }
 
 // Construct a tag for newrelic -- wgRequest is global in this scope
-Transaction::setEntryPoint(Transaction::ENTRY_POINT_NIRVANA);
-if ( is_object($wgRequest) ) {
-	Transaction::setAttribute(Transaction::PARAM_CONTROLLER, $wgRequest->getVal( 'controller' ));
-	Transaction::setAttribute(Transaction::PARAM_METHOD, $wgRequest->getVal( 'method' ));
+Transaction::setEntryPoint( Transaction::ENTRY_POINT_NIRVANA );
+if ( is_object( $wgRequest ) ) {
+	Transaction::setAttribute( Transaction::PARAM_CONTROLLER, $wgRequest->getVal( 'controller' ) );
+	Transaction::setAttribute( Transaction::PARAM_METHOD, $wgRequest->getVal( 'method' ) );
 }
 
-if ( function_exists( 'newrelic_disable_autorum') ) {
+if ( function_exists( 'newrelic_disable_autorum' ) ) {
 	newrelic_disable_autorum();
 }
 
 
-if ( !empty( $wgEnableNirvanaAPI ) ){
+if ( !empty( $wgEnableNirvanaAPI ) ) {
 	// temporarily force ApiDocs extension regardless of config
-	require_once $IP."/extensions/wikia/ApiDocs/ApiDocs.setup.php";
+	require_once $IP . "/extensions/wikia/ApiDocs/ApiDocs.setup.php";
 	// same for JsonFormat
-	require_once $IP."/extensions/wikia/JsonFormat/JsonFormat.setup.php";
-	
+	require_once $IP . "/extensions/wikia/JsonFormat/JsonFormat.setup.php";
+
 	$app = F::app();
 
 	// Ensure that we have a title stub, otherwise parser does not work BugId: 12901
@@ -50,8 +50,8 @@ if ( !empty( $wgEnableNirvanaAPI ) ){
 	// commit any open transactions just in case the controller forgot to
 	$app->commit();
 
-	//if cache policy wasn't explicitly set (e.g. WikiaResponse::setCacheValidity)
-	//then force no cache to reflect api.php default behavior
+	// if cache policy wasn't explicitly set (e.g. WikiaResponse::setCacheValidity)
+	// then force no cache to reflect api.php default behavior
 	$cacheControl = $response->getHeader( 'Cache-Control' );
 
 	if ( empty( $cacheControl ) ) {
@@ -66,7 +66,7 @@ if ( !empty( $wgEnableNirvanaAPI ) ){
 	// PLATFORM-1633: decrease the noise in reported transactions
 	$ex = $response->getException();
 
-	if ( $ex instanceof ControllerNotFoundException|| $ex instanceof MethodNotFoundException ) {
+	if ( $ex instanceof ControllerNotFoundException || $ex instanceof MethodNotFoundException ) {
 		Transaction::setAttribute( Transaction::PARAM_CONTROLLER, 'error' );
 		Transaction::setAttribute( Transaction::PARAM_METHOD, '' );
 

--- a/wikia.php
+++ b/wikia.php
@@ -63,6 +63,14 @@ if ( !empty( $wgEnableNirvanaAPI ) ){
 		] );
 	}
 
+	// PLATFORM-1633: decrease the noise in reported transactions
+	$ex = $response->getException();
+
+	if ( $ex instanceof ControllerNotFoundException|| $ex instanceof MethodNotFoundException ) {
+		Transaction::setAttribute( Transaction::PARAM_CONTROLLER, 'other' );
+		Transaction::setAttribute( Transaction::PARAM_METHOD, '' );
+	}
+
 	$response->sendHeaders();
 	wfRunHooks( 'NirvanaAfterRespond', [ $app, $response ] );
 

--- a/wikia.php
+++ b/wikia.php
@@ -67,8 +67,13 @@ if ( !empty( $wgEnableNirvanaAPI ) ){
 	$ex = $response->getException();
 
 	if ( $ex instanceof ControllerNotFoundException|| $ex instanceof MethodNotFoundException ) {
-		Transaction::setAttribute( Transaction::PARAM_CONTROLLER, 'other' );
+		Transaction::setAttribute( Transaction::PARAM_CONTROLLER, 'error' );
 		Transaction::setAttribute( Transaction::PARAM_METHOD, '' );
+
+		Wikia\Logger\WikiaLogger::instance()->info( 'wikia-php.not-found', [
+			'controller' => $response->getControllerName(),
+			'method' => $response->getMethodName()
+		] );
 	}
 
 	$response->sendHeaders();

--- a/wikia.php
+++ b/wikia.php
@@ -67,7 +67,7 @@ if ( !empty( $wgEnableNirvanaAPI ) ) {
 	$ex = $response->getException();
 
 	if ( $ex instanceof ControllerNotFoundException || $ex instanceof MethodNotFoundException ) {
-		Transaction::setAttribute( Transaction::PARAM_CONTROLLER, 'error' );
+		Transaction::setAttribute( Transaction::PARAM_CONTROLLER, 'notFound' );
 		Transaction::setAttribute( Transaction::PARAM_METHOD, '' );
 
 		Wikia\Logger\WikiaLogger::instance()->info( 'wikia-php.not-found', [

--- a/wikia.php
+++ b/wikia.php
@@ -63,10 +63,10 @@ if ( !empty( $wgEnableNirvanaAPI ) ) {
 		] );
 	}
 
-	// PLATFORM-1633: decrease the noise in reported transactions
+	// PLATFORM-1633: decrease the noise in reported transactions when we return HTTP 404
 	$ex = $response->getException();
 
-	if ( $ex instanceof ControllerNotFoundException || $ex instanceof MethodNotFoundException ) {
+	if ( $ex instanceof NotFoundException ) {
 		Transaction::setAttribute( Transaction::PARAM_CONTROLLER, 'notFound' );
 		Transaction::setAttribute( Transaction::PARAM_METHOD, '' );
 


### PR DESCRIPTION
We're getting many "interesting" requests that end up as unique NewRelic transactions. Decrease the noise by setting transaction name to `api/nirvana/notFound` when either controller or method can not be found.

```
/wikia.php?controller=Lightbox&method=getThumbImagesaaa
TransactionTrace: notification: ["onTypeChange","api\/nirvana\/notFound"]

/wikia.php?controller=Lightbox&method=getThumbImages
TransactionTrace: notification: ["onTypeChange","api\/nirvana\/Lightbox"]
```

Alternatively we can move [this block](https://github.com/Wikia/app/blob/dev/wikia.php#L19-L24) to be executed only on successful requests. But I'm not sure if that won't happen too late.

@wladekb / @jcellary 
