### PR TITLE
proxy.php: emit IP in the warning message when a header is missing

### DIFF
--- a/extensions/wikia/Tasks/proxy/proxy.php
+++ b/extensions/wikia/Tasks/proxy/proxy.php
@@ -5,8 +5,10 @@ ini_set('display_errors', 0);
 # SEC-21: make sure that this is called internally
 $headers = apache_request_headers();
 if ( empty( $headers['X-Wikia-Internal-Request'] ) ) {
-	trigger_error( 'X-Wikia-Internal-Request header is missing', E_USER_WARNING );
+	$ip = isset( $_SERVER['REMOTE_ADDR'] ) ? $_SERVER['REMOTE_ADDR'] : null;
+	trigger_error( "X-Wikia-Internal-Request header is missing (request from {$ip})", E_USER_WARNING );
 
+	header( 'HTTP/1.1 403 Forbidden' );
 	echo json_encode( [
 		'status' => 'failure',
 		'reason' => 'X-Wikia-Internal-Request header is missing'


### PR DESCRIPTION
Let's identify the source of [ER-8875](https://wikia-inc.atlassian.net/browse/ER-8875)

And return HTTP 403 Forbidden response code.

@michalroszka 
