### PR TITLE
Reduced some master queries by adding flags to Revision functions

### DIFF
--- a/includes/Article.php
+++ b/includes/Article.php
@@ -22,6 +22,7 @@
  * @method exists
  * @method getID
  * @method getRedirectTarget
+ * @method loadPageData
  * //Wikia Change End
  */
 class Article extends Page {

--- a/includes/Article.php
+++ b/includes/Article.php
@@ -104,8 +104,8 @@ class Article extends Page {
 	/**
 	 * Create an Article object of the appropriate class for the given page.
 	 *
-	 * @param Title $title
-	 * @param IContextSource $context
+	 * @param $title Title
+	 * @param $context IContextSource
 	 * @return Article object
 	 */
 	public static function newFromTitle( $title, IContextSource $context ) {

--- a/includes/AutoLoader.php
+++ b/includes/AutoLoader.php
@@ -400,6 +400,9 @@ $wgAutoloadLocalClasses = array(
 	'IContextSource' => 'includes/context/IContextSource.php',
 	'RequestContext' => 'includes/context/RequestContext.php',
 
+	# includes/dao
+	'IDBAccessObject' => 'includes/dao/IDBAccessObject.php',
+
 	# includes/db
 	'Blob' => 'includes/db/DatabaseUtility.php',
 	'ChronologyProtector' => 'includes/db/LBFactory.php',

--- a/includes/EditPage.php
+++ b/includes/EditPage.php
@@ -1229,9 +1229,10 @@ class EditPage {
 
 		wfProfileOut( __METHOD__ . '-checks' );
 
-		# If article is new, insert it.
-		$aid = $this->mTitle->getArticleID( Title::GAID_FOR_UPDATE );
-		$new = ( $aid == 0 );
+		// Use SELECT FOR UPDATE here to avoid transaction collision in
+		// WikiPage::updateRevisionOn() and ending in the self::AS_END case.
+		$this->mArticle->loadPageData( 'forupdate' );
+		$new = !$this->mArticle->exists();
 
 		if ( $new ) {
 			// Late check for create permission, just in case *PARANOIA*
@@ -1311,10 +1312,7 @@ class EditPage {
 		} else {
 
 			# Article exists. Check for edit conflict.
-
-			$this->mArticle->clear(); # Force reload of dates, etc.
 			$timestamp = $this->mArticle->getTimestamp();
-
 			wfDebug( "timestamp: {$timestamp}, edittime: {$this->edittime}\n" );
 
 			if ( $timestamp != $this->edittime ) {

--- a/includes/Revision.php
+++ b/includes/Revision.php
@@ -21,12 +21,13 @@ class Revision implements IDBAccessObject {
 	protected $mTitle;
 	protected $mCurrent;
 
+	// Revision deletion constants
 	const DELETED_TEXT = 1;
 	const DELETED_COMMENT = 2;
 	const DELETED_USER = 4;
 	const DELETED_RESTRICTED = 8;
-	// Convenience field
-	const SUPPRESSED_USER = 12;
+	const SUPPRESSED_USER = 12; // convenience
+
 	// Audience options for accessors
 	const FOR_PUBLIC = 1;
 	const FOR_THIS_USER = 2;
@@ -37,9 +38,8 @@ class Revision implements IDBAccessObject {
 	 * Returns null if no such revision can be found.
 	 *
 	 * $flags include:
-	 *      IDBAccessObject::LATEST_READ  : Select the data from the master
-	 *      IDBAccessObject::LOCKING_READ : Select & lock the data from the master
-	 *      IDBAccessObject::AVOID_MASTER : Avoid master queries; data may be stale
+	 *      Revision::READ_LATEST  : Select the data from the master
+	 *      Revision::READ_LOCKING : Select & lock the data from the master
 	 *
 	 * @param $id Integer
 	 * @return Revision or null
@@ -54,16 +54,15 @@ class Revision implements IDBAccessObject {
 	 * to that title, will return null.
 	 *
 	 * $flags include:
-	 *      IDBAccessObject::LATEST_READ  : Select the data from the master
-	 *      IDBAccessObject::LOCKING_READ : Select & lock the data from the master
-	 *      IDBAccessObject::AVOID_MASTER : Avoid master queries; data may be stale
+	 *      Revision::READ_LATEST  : Select the data from the master
+	 *      Revision::READ_LOCKING : Select & lock the data from the master
 	 *
 	 * @param $title Title
 	 * @param $id Integer (optional)
 	 * @param $flags Integer Bitfield (optional)
 	 * @return Revision or null
 	 */
-	public static function newFromTitle( $title, $id = 0, $flags = 0 ) {
+	public static function newFromTitle( $title, $id = 0, $flags = null ) {
 		$conds = array(
 			'page_namespace' => $title->getNamespace(),
 			'page_title' 	 => $title->getDBkey()
@@ -71,19 +70,13 @@ class Revision implements IDBAccessObject {
 		if ( $id ) {
 			// Use the specified ID
 			$conds['rev_id'] = $id;
-		} elseif ( !( $flags & self::AVOID_MASTER ) && wfGetLB()->getServerCount() > 1 ) {
-			// Get the latest revision ID from the master
-			$dbw = wfGetDB( DB_MASTER );
-			$latest = $dbw->selectField( 'page', 'page_latest', $conds, __METHOD__ );
-			if ( $latest === false ) {
-				return null; // page does not exist
-			}
-			$conds['rev_id'] = $latest;
 		} else {
 			// Use a join to get the latest revision
 			$conds[] = 'rev_id=page_latest';
+			// Callers assume this will be up-to-date
+			$flags = is_int( $flags ) ? $flags : self::READ_LATEST; // b/c
 		}
-		return self::newFromConds( $conds, $flags );
+		return self::newFromConds( $conds, (int)$flags );
 	}
 
 	/**
@@ -92,31 +85,25 @@ class Revision implements IDBAccessObject {
 	 * Returns null if no such revision can be found.
 	 *
 	 * $flags include:
-	 *      IDBAccessObject::LATEST_READ  : Select the data from the master
-	 *      IDBAccessObject::LOCKING_READ : Select & lock the data from the master
-	 *      IDBAccessObject::AVOID_MASTER : Avoid master queries; data may be stale
+	 *      Revision::READ_LATEST  : Select the data from the master
+	 *      Revision::READ_LOCKING : Select & lock the data from the master
 	 *
 	 * @param $revId Integer
 	 * @param $pageId Integer (optional)
 	 * @param $flags Integer Bitfield (optional)
 	 * @return Revision or null
 	 */
-	public static function newFromPageId( $pageId, $revId = 0, $flags = 0 ) {
+	public static function newFromPageId( $pageId, $revId = 0, $flags = null ) {
 		$conds = array( 'page_id' => $pageId );
 		if ( $revId ) {
 			$conds['rev_id'] = $revId;
-		} elseif ( !( $flags & self::AVOID_MASTER ) && wfGetLB()->getServerCount() > 1 ) {
-			// Get the latest revision ID from the master
-			$dbw = wfGetDB( DB_MASTER );
-			$latest = $dbw->selectField( 'page', 'page_latest', $conds, __METHOD__ );
-			if ( $latest === false ) {
-				return null; // page does not exist
-			}
-			$conds['rev_id'] = $latest;
 		} else {
+			// Use a join to get the latest revision
 			$conds[] = 'rev_id = page_latest';
+			// Callers assume this will be up-to-date
+			$flags = is_int( $flags ) ? $flags : self::READ_LATEST; // b/c
 		}
-		return self::newFromConds( $conds, $flags );
+		return self::newFromConds( $conds, (int)$flags );
 	}
 
 	/**
@@ -276,10 +263,10 @@ class Revision implements IDBAccessObject {
 	 * @return Revision or null
 	 */
 	private static function newFromConds( $conditions, $flags = 0 ) {
-		$db = wfGetDB( ( $flags & self::LATEST_READ ) ? DB_MASTER : DB_SLAVE );
+		$db = wfGetDB( ( $flags & self::READ_LATEST ) ? DB_MASTER : DB_SLAVE );
 		$rev = self::loadFromConds( $db, $conditions, $flags );
 		if ( is_null( $rev ) && wfGetLB()->getServerCount() > 1 ) {
-			if ( !( $flags & self::LATEST_READ ) && !( $flags & self::AVOID_MASTER ) ) {
+			if ( !( $flags & self::READ_LATEST ) ) {
 				$dbw = wfGetDB( DB_MASTER );
 				$rev = self::loadFromConds( $dbw, $conditions, $flags );
 			}
@@ -343,7 +330,7 @@ class Revision implements IDBAccessObject {
 			self::selectUserFields()
 		);
 		$options = array( 'LIMIT' => 1 );
-		if ( $flags & self::FOR_UPDATE ) {
+		if ( $flags & self::READ_LOCKING ) {
 			$options[] = 'FOR UPDATE';
 		}
 		return $db->select(

--- a/includes/Revision.php
+++ b/includes/Revision.php
@@ -93,15 +93,13 @@ class Revision implements IDBAccessObject {
 	 * @param $flags Integer Bitfield (optional)
 	 * @return Revision or null
 	 */
-	public static function newFromPageId( $pageId, $revId = 0, $flags = null ) {
+	public static function newFromPageId( $pageId, $revId = 0, $flags = 0 ) {
 		$conds = array( 'page_id' => $pageId );
 		if ( $revId ) {
 			$conds['rev_id'] = $revId;
 		} else {
 			// Use a join to get the latest revision
 			$conds[] = 'rev_id = page_latest';
-			// Callers assume this will be up-to-date
-			$flags = is_int( $flags ) ? $flags : self::READ_LATEST; // b/c
 		}
 		return self::newFromConds( $conds, (int)$flags );
 	}

--- a/includes/Revision.php
+++ b/includes/Revision.php
@@ -3,7 +3,7 @@
 /**
  * @todo document
  */
-class Revision {
+class Revision implements IDBAccessObject {
 	protected $mId;
 	protected $mPage;
 	protected $mUserText;
@@ -27,7 +27,7 @@ class Revision {
 	const DELETED_RESTRICTED = 8;
 	// Convenience field
 	const SUPPRESSED_USER = 12;
-	// Audience options for Revision::getText()
+	// Audience options for accessors
 	const FOR_PUBLIC = 1;
 	const FOR_THIS_USER = 2;
 	const RAW = 3;
@@ -36,11 +36,16 @@ class Revision {
 	 * Load a page revision from a given revision ID number.
 	 * Returns null if no such revision can be found.
 	 *
+	 * $flags include:
+	 *      IDBAccessObject::LATEST_READ  : Select the data from the master
+	 *      IDBAccessObject::LOCKING_READ : Select & lock the data from the master
+	 *      IDBAccessObject::AVOID_MASTER : Avoid master queries; data may be stale
+	 *
 	 * @param $id Integer
 	 * @return Revision or null
 	 */
-	public static function newFromId( $id ) {
-		return Revision::newFromConds( array( 'rev_id' => intval( $id ) ) );
+	public static function newFromId( $id, $flags = 0 ) {
+		return self::newFromConds( array( 'rev_id' => intval( $id ) ), $flags );
 	}
 
 	/**
@@ -48,11 +53,17 @@ class Revision {
 	 * that's attached to a given title. If not attached
 	 * to that title, will return null.
 	 *
+	 * $flags include:
+	 *      IDBAccessObject::LATEST_READ  : Select the data from the master
+	 *      IDBAccessObject::LOCKING_READ : Select & lock the data from the master
+	 *      IDBAccessObject::AVOID_MASTER : Avoid master queries; data may be stale
+	 *
 	 * @param $title Title
 	 * @param $id Integer (optional)
+	 * @param $flags Integer Bitfield (optional)
 	 * @return Revision or null
 	 */
-	public static function newFromTitle( $title, $id = 0 ) {
+	public static function newFromTitle( $title, $id = 0, $flags = 0 ) {
 		$conds = array(
 			'page_namespace' => $title->getNamespace(),
 			'page_title' 	 => $title->getDBkey()
@@ -60,7 +71,7 @@ class Revision {
 		if ( $id ) {
 			// Use the specified ID
 			$conds['rev_id'] = $id;
-		} elseif ( wfGetLB()->getServerCount() > 1 ) {
+		} elseif ( !( $flags & self::AVOID_MASTER ) && wfGetLB()->getServerCount() > 1 ) {
 			// Get the latest revision ID from the master
 			$dbw = wfGetDB( DB_MASTER );
 			$latest = $dbw->selectField( 'page', 'page_latest', $conds, __METHOD__ );
@@ -72,7 +83,7 @@ class Revision {
 			// Use a join to get the latest revision
 			$conds[] = 'rev_id=page_latest';
 		}
-		return Revision::newFromConds( $conds );
+		return self::newFromConds( $conds, $flags );
 	}
 
 	/**
@@ -80,15 +91,21 @@ class Revision {
 	 * that's attached to a given page ID.
 	 * Returns null if no such revision can be found.
 	 *
+	 * $flags include:
+	 *      IDBAccessObject::LATEST_READ  : Select the data from the master
+	 *      IDBAccessObject::LOCKING_READ : Select & lock the data from the master
+	 *      IDBAccessObject::AVOID_MASTER : Avoid master queries; data may be stale
+	 *
 	 * @param $revId Integer
 	 * @param $pageId Integer (optional)
+	 * @param $flags Integer Bitfield (optional)
 	 * @return Revision or null
 	 */
-	public static function newFromPageId( $pageId, $revId = 0 ) {
+	public static function newFromPageId( $pageId, $revId = 0, $flags = 0 ) {
 		$conds = array( 'page_id' => $pageId );
 		if ( $revId ) {
 			$conds['rev_id'] = $revId;
-		} elseif ( wfGetLB()->getServerCount() > 1 ) {
+		} elseif ( !( $flags & self::AVOID_MASTER ) && wfGetLB()->getServerCount() > 1 ) {
 			// Get the latest revision ID from the master
 			$dbw = wfGetDB( DB_MASTER );
 			$latest = $dbw->selectField( 'page', 'page_latest', $conds, __METHOD__ );
@@ -99,7 +116,7 @@ class Revision {
 		} else {
 			$conds[] = 'rev_id = page_latest';
 		}
-		return Revision::newFromConds( $conds );
+		return self::newFromConds( $conds, $flags );
 	}
 
 	/**
@@ -183,10 +200,11 @@ class Revision {
 	 *
 	 * @param $db DatabaseBase
 	 * @param $id Integer
+	 * @param $flags Integer (optional)
 	 * @return Revision or null
 	 */
 	public static function loadFromId( $db, $id ) {
-		return Revision::loadFromConds( $db, array( 'rev_id' => intval( $id ) ) );
+		return self::loadFromConds( $db, array( 'rev_id' => intval( $id ) ) );
 	}
 
 	/**
@@ -206,7 +224,7 @@ class Revision {
 		} else {
 			$conds[] = 'rev_id=page_latest';
 		}
-		return Revision::loadFromConds( $db, $conds );
+		return self::loadFromConds( $db, $conds );
 	}
 
 	/**
@@ -225,7 +243,7 @@ class Revision {
 		} else {
 			$matchId = 'page_latest';
 		}
-		return Revision::loadFromConds( $db,
+		return self::loadFromConds( $db,
 			array( "rev_id=$matchId",
 				   'page_namespace' => $title->getNamespace(),
 				   'page_title'     => $title->getDBkey() )
@@ -243,7 +261,7 @@ class Revision {
 	 * @return Revision or null
 	 */
 	public static function loadFromTimestamp( $db, $title, $timestamp ) {
-		return Revision::loadFromConds( $db,
+		return self::loadFromConds( $db,
 			array( 'rev_timestamp'  => $db->timestamp( $timestamp ),
 				   'page_namespace' => $title->getNamespace(),
 				   'page_title'     => $title->getDBkey() )
@@ -254,14 +272,17 @@ class Revision {
 	 * Given a set of conditions, fetch a revision.
 	 *
 	 * @param $conditions Array
+	 * @param $flags integer (optional)
 	 * @return Revision or null
 	 */
-	public static function newFromConds( $conditions ) {
-		$db = wfGetDB( DB_SLAVE );
-		$rev = Revision::loadFromConds( $db, $conditions );
-		if( is_null( $rev ) && wfGetLB()->getServerCount() > 1 ) {
-			$dbw = wfGetDB( DB_MASTER );
-			$rev = Revision::loadFromConds( $dbw, $conditions );
+	private static function newFromConds( $conditions, $flags = 0 ) {
+		$db = wfGetDB( ( $flags & self::LATEST_READ ) ? DB_MASTER : DB_SLAVE );
+		$rev = self::loadFromConds( $db, $conditions, $flags );
+		if ( is_null( $rev ) && wfGetLB()->getServerCount() > 1 ) {
+			if ( !( $flags & self::LATEST_READ ) && !( $flags & self::AVOID_MASTER ) ) {
+				$dbw = wfGetDB( DB_MASTER );
+				$rev = self::loadFromConds( $dbw, $conditions, $flags );
+			}
 		}
 		return $rev;
 	}
@@ -272,10 +293,11 @@ class Revision {
 	 *
 	 * @param $db DatabaseBase
 	 * @param $conditions Array
+	 * @param $flags integer (optional)
 	 * @return Revision or null
 	 */
-	private static function loadFromConds( $db, $conditions ) {
-		$res = Revision::fetchFromConds( $db, $conditions );
+	private static function loadFromConds( $db, $conditions, $flags = 0 ) {
+		$res = self::fetchFromConds( $db, $conditions, $flags );
 		if( $res ) {
 			$row = $res->fetchObject();
 			if( $row ) {
@@ -296,7 +318,7 @@ class Revision {
 	 * @return ResultWrapper
 	 */
 	public static function fetchRevision( $title ) {
-		return Revision::fetchFromConds(
+		return self::fetchFromConds(
 			wfGetDB( DB_SLAVE ),
 			array( 'rev_id=page_latest',
 				   'page_namespace' => $title->getNamespace(),
@@ -311,20 +333,25 @@ class Revision {
 	 *
 	 * @param $db DatabaseBase
 	 * @param $conditions Array
+	 * @param $flags integer (optional)
 	 * @return ResultWrapper
 	 */
-	private static function fetchFromConds( $db, $conditions ) {
+	private static function fetchFromConds( $db, $conditions, $flags = 0 ) {
 		$fields = array_merge(
 			self::selectFields(),
 			self::selectPageFields(),
 			self::selectUserFields()
 		);
+		$options = array( 'LIMIT' => 1 );
+		if ( $flags & self::FOR_UPDATE ) {
+			$options[] = 'FOR UPDATE';
+		}
 		return $db->select(
 			array( 'revision', 'page', 'user' ),
 			$fields,
 			$conditions,
 			__METHOD__,
-			array( 'LIMIT' => 1 ),
+			$options,
 			array( 'page' => self::pageJoinCond(), 'user' => self::userJoinCond() )
 		);
 	}
@@ -826,7 +853,7 @@ class Revision {
 			);
 	/* Wikia changes end */
 			if( $prev ) {
-				return Revision::newFromTitle( $this->getTitle(), $prev );
+				return self::newFromTitle( $this->getTitle(), $prev );
 			}
 		}
 		return null;
@@ -841,7 +868,7 @@ class Revision {
 		if( $this->getTitle() ) {
 			$next = $this->getTitle()->getNextRevisionID( $this->getId() );
 			if ( $next ) {
-				return Revision::newFromTitle( $this->getTitle(), $next );
+				return self::newFromTitle( $this->getTitle(), $next );
 			}
 		}
 		return null;
@@ -972,7 +999,7 @@ class Revision {
 				$text = gzdeflate( $text );
 				$flags[] = 'gzip';
 			} else {
-				wfDebug( "Revision::compressRevisionText() -- no zlib support, not compressing\n" );
+				wfDebug( __METHOD__ . " -- no zlib support, not compressing\n" );
 			}
 		}
 		return implode( ',', $flags );
@@ -991,7 +1018,7 @@ class Revision {
 		wfProfileIn( __METHOD__ );
 
 		$data = $this->mText;
-		$flags = Revision::compressRevisionText( $data );
+		$flags = self::compressRevisionText( $data );
 
 		# Write to external storage if required
 		if( $wgDefaultExternalStore ) {
@@ -1041,7 +1068,7 @@ class Revision {
 					? $this->getPreviousRevisionId( $dbw )
 					: $this->mParentId,
 				'rev_sha1'       => is_null( $this->mSha1 )
-					? Revision::base36Sha1( $this->mText )
+					? self::base36Sha1( $this->mText )
 					: $this->mSha1
 			), __METHOD__
 		);
@@ -1263,7 +1290,7 @@ class Revision {
 	static function countByTitle( $db, $title ) {
 		$id = $title->getArticleId();
 		if( $id ) {
-			return Revision::countByPageId( $db, $id );
+			return self::countByPageId( $db, $id );
 		}
 		return 0;
 	}

--- a/includes/WikiPage.php
+++ b/includes/WikiPage.php
@@ -37,6 +37,28 @@ class WikiPage extends Page {
 	 */
 	const DELETE_NO_REVISIONS = 2;
 
+	// Constants for $mDataLoadedFrom and related
+
+	/**
+	 * Data has not been loaded yet (or the object was cleared)
+	 */
+	const DATA_NOT_LOADED = 0;
+
+	/**
+	 * Data has been loaded from a slave database
+	 */
+	const DATA_FROM_SLAVE = 1;
+
+	/**
+	 * Data has been loaded from the master database
+	 */
+	const DATA_FROM_MASTER = 2;
+
+	/**
+	 * Data has been loaded from the master database using FOR UPDATE
+	 */
+	const DATA_FOR_UPDATE = 3;
+
 	/**
 	 * @var Title
 	 */
@@ -50,6 +72,11 @@ class WikiPage extends Page {
 	public $mLatest = false;             // !< Integer (false means "not loaded")
 	public $mPreparedEdit = false;       // !< Array
 	/**@}}*/
+
+	/**
+	 * @var int; one of the DATA_* constants
+	 */
+	protected $mDataLoadedFrom = self::DATA_NOT_LOADED;
 
 	/**
 	 * @var Title
@@ -117,16 +144,20 @@ class WikiPage extends Page {
 	 * Constructor from a page id
 	 *
 	 * @param $id Int article ID to load
+	 * @param $from string|int one of the following values:
+	 *        - "fromdb" or self::DATA_FROM_SLAVE to select from a slave database
+	 *        - "fromdbmaster" or self::DATA_FROM_MASTER to select from the master database
 	 *
 	 * @return WikiPage
 	 */
-	public static function newFromID( $id ) {
-		$dbr = wfGetDB( DB_SLAVE );
-		$row = $dbr->selectRow( 'page', self::selectFields(), array( 'page_id' => $id ), __METHOD__ );
+	public static function newFromID( $id, $from = 'fromdb' ) {
+		$from = self::convertSelectType( $from );
+		$db = wfGetDB( $from === self::DATA_FROM_MASTER ? DB_MASTER : DB_SLAVE );
+		$row = $db->selectRow( 'page', self::selectFields(), array( 'page_id' => $id ), __METHOD__ );
 		if ( !$row ) {
 			return null;
 		}
-		return self::newFromRow( $row );
+		return self::newFromRow( $row, $from );
 	}
 
 	/**
@@ -135,12 +166,36 @@ class WikiPage extends Page {
 	 * @since 1.20
 	 * @param $row object: database row containing at least fields returned
 	 *        by selectFields().
+	 * @param $from string|int: source of $data:
+	 *        - "fromdb" or self::DATA_FROM_SLAVE: from a slave DB
+	 *        - "fromdbmaster" or self::DATA_FROM_MASTER: from the master DB
+	 *        - "forupdate" or self::DATA_FOR_UPDATE: from the master DB using SELECT FOR UPDATE
 	 * @return WikiPage
 	 */
-	public static function newFromRow( $row ) {
+	public static function newFromRow( $row, $from = 'fromdb' ) {
 		$page = self::factory( Title::newFromRow( $row ) );
-		$page->loadFromRow( $row );
+		$page->loadFromRow( $row, $from );
 		return $page;
+	}
+
+	/**
+	 * Convert 'fromdb', 'fromdbmaster' and 'forupdate' to DATA_* constants.
+	 *
+	 * @param $type object|string|int
+	 * @return mixed
+	 */
+	private static function convertSelectType( $type ) {
+		switch ( $type ) {
+		case 'fromdb':
+			return self::DATA_FROM_SLAVE;
+		case 'fromdbmaster':
+			return self::DATA_FROM_MASTER;
+		case 'forupdate':
+			return self::DATA_FOR_UPDATE;
+		default:
+			// It may already be an integer or whatever else
+			return $type;
+		}
 	}
 
 	/**
@@ -170,6 +225,7 @@ class WikiPage extends Page {
 	 */
 	public function clear() {
 		$this->mDataLoaded = false;
+		$this->mDataLoadedFrom = self::DATA_NOT_LOADED;
 
 		$this->mCounter = null;
 		$this->mRedirectTarget = null; # Title object if set
@@ -207,14 +263,15 @@ class WikiPage extends Page {
 	 * Fetch a page record with the given conditions
 	 * @param $dbr DatabaseBase object
 	 * @param $conditions Array
+	 * @param $options Array
 	 * @return mixed Database result resource, or false on failure
 	 */
-	protected function pageData( $dbr, $conditions ) {
+	protected function pageData( $dbr, $conditions, $options = array() ) {
 		$fields = self::selectFields();
 
 		wfRunHooks( 'ArticlePageDataBefore', array( &$this, &$fields ) );
 
-		$row = $dbr->selectRow( 'page', $fields, $conditions, __METHOD__ );
+		$row = $dbr->selectRow( 'page', $fields, $conditions, __METHOD__, $options );
 
 		wfRunHooks( 'ArticlePageDataAfter', array( &$this, &$row ) );
 
@@ -227,12 +284,13 @@ class WikiPage extends Page {
 	 *
 	 * @param $dbr DatabaseBase object
 	 * @param $title Title object
+	 * @param $options Array
 	 * @return mixed Database result resource, or false on failure
 	 */
-	public function pageDataFromTitle( $dbr, $title ) {
+	public function pageDataFromTitle( $dbr, $title, $options = array() ) {
 		return $this->pageData( $dbr, array(
 			'page_namespace' => $title->getNamespace(),
-			'page_title'     => $title->getDBkey() ) );
+			'page_title'     => $title->getDBkey() ), $options );
 	}
 
 	/**
@@ -240,38 +298,54 @@ class WikiPage extends Page {
 	 *
 	 * @param $dbr DatabaseBase
 	 * @param $id Integer
+	 * @param $options Array
 	 * @return mixed Database result resource, or false on failure
 	 */
-	public function pageDataFromId( $dbr, $id ) {
-		return $this->pageData( $dbr, array( 'page_id' => $id ) );
+	public function pageDataFromId( $dbr, $id, $options = array() ) {
+		return $this->pageData( $dbr, array( 'page_id' => $id ), $options );
 	}
 
 	/**
 	 * Set the general counter, title etc data loaded from
 	 * some source.
 	 *
-	 * @param $data Object|String One of the following:
-	 *		A DB query result object or...
-	 *		"fromdb" to get from a slave DB or...
-	 *		"fromdbmaster" to get from the master DB
+	 * @param $from object|string|int One of the following:
+	 *        - A DB query result object
+	 *        - "fromdb" or self::DATA_FROM_SLAVE to get from a slave DB
+	 *        - "fromdbmaster" or self::DATA_FROM_MASTER to get from the master DB
+	 *        - "forupdate"  or self::DATA_FOR_UPDATE to get from the master DB using SELECT FOR UPDATE
+	 *
 	 * @return void
 	 */
-	public function loadPageData( $data = 'fromdb' ) {
-		if ( $data === 'fromdbmaster' ) {
+	public function loadPageData( $from = 'fromdb' ) {
+		$from = self::convertSelectType( $from );
+		if ( is_int( $from ) && $from <= $this->mDataLoadedFrom ) {
+			// We already have the data from the correct location, no need to load it twice.
+			return;
+		}
+
+		if ( $from === self::DATA_FOR_UPDATE ) {
+			$data = $this->pageDataFromTitle( wfGetDB( DB_MASTER ), $this->mTitle, array( 'FOR UPDATE' ) );
+		} elseif ( $from === self::DATA_FROM_MASTER ) {
 			$data = $this->pageDataFromTitle( wfGetDB( DB_MASTER ), $this->mTitle );
-		} elseif ( $data === 'fromdb' ) { // slave
+		} elseif ( $from === self::DATA_FROM_SLAVE ) {
 			$data = $this->pageDataFromTitle( wfGetDB( DB_SLAVE ), $this->mTitle );
 			# Use a "last rev inserted" timestamp key to dimish the issue of slave lag.
 			# Note that DB also stores the master position in the session and checks it.
 			$touched = $this->getCachedLastEditTime();
 			if ( $touched ) { // key set
 				if ( !$data || $touched > wfTimestamp( TS_MW, $data->page_touched ) ) {
+					$from = self::DATA_FROM_MASTER;
 					$data = $this->pageDataFromTitle( wfGetDB( DB_MASTER ), $this->mTitle );
 				}
 			}
+		} else {
+			// No idea from where the caller got this data, assume slave database.
+			$data = $from;
+			$from = self::DATA_FROM_SLAVE;
 		}
 
-		$this->loadFromRow( $data );
+		$this->loadFromRow( $data, $from );
 	}
 
 	/**
@@ -280,8 +354,13 @@ class WikiPage extends Page {
 	 * @since 1.20
 	 * @param $data object: database row containing at least fields returned
 	 *        by selectFields()
+	 * @param $from string|int One of the following:
+	 *        - "fromdb" or self::DATA_FROM_SLAVE if the data comes from a slave DB
+	 *        - "fromdbmaster" or self::DATA_FROM_MASTER if the data comes from the master DB
+	 *        - "forupdate"  or self::DATA_FOR_UPDATE if the data comes from from
+	 *          the master DB using SELECT FOR UPDATE
 	 */
-	public function loadFromRow( $data ) {
+	public function loadFromRow( $data, $from ) {
 		$lc = LinkCache::singleton();
 
 		if ( $data ) {
@@ -303,6 +382,7 @@ class WikiPage extends Page {
 		}
 
 		$this->mDataLoaded = true;
+		$this->mDataLoadedFrom = self::convertSelectType( $from );
 	}
 
 	/**
@@ -1304,7 +1384,9 @@ class WikiPage extends Page {
 		$user = is_null( $user ) ? $wgUser : $user;
 		$status = Status::newGood( array() );
 
-		# Load $this->mTitle->getArticleID() and $this->mLatest if it's not already
+		// Load the data from the master database if needed.
+		// The caller may already loaded it from the master or even loaded it using
+		// SELECT FOR UPDATE, so do not override that using clear().
 		$this->loadPageData( 'fromdbmaster' );
 
 		$flags = $this->checkFlags( $flags );
@@ -2011,19 +2093,24 @@ class WikiPage extends Page {
 		$reason, $suppress = false, $id = 0, $commit = true, &$error = '', User $user = null
 	) {
 		global $wgUser;
-		$user = is_null( $user ) ? $wgUser : $user;
 
 		wfDebug( __METHOD__ . "\n" );
 
+		if ( $this->mTitle->getDBkey() === '' ) {
+			return WikiPage::DELETE_NO_PAGE;
+		}
+
+		$user = is_null( $user ) ? $wgUser : $user;
 		if ( ! wfRunHooks( 'ArticleDelete', array( &$this, &$user, &$reason, &$error ) ) ) {
 			return WikiPage::DELETE_HOOK_ABORTED;
 		}
-		$dbw = wfGetDB( DB_MASTER );
-		$t = $this->mTitle->getDBkey();
-		$id = $id ? $id : $this->mTitle->getArticleID( Title::GAID_FOR_UPDATE );
 
-		if ( $t === '' || $id == 0 ) {
-			return WikiPage::DELETE_NO_PAGE;
+		if ( $id == 0 ) {
+			$this->loadPageData( 'forupdate' );
+			$id = $this->getID();
+			if ( $id == 0 ) {
+				return WikiPage::DELETE_NO_PAGE;
+			}
 		}
 
 		// Bitfields to further suppress the content
@@ -2038,6 +2125,7 @@ class WikiPage extends Page {
 			$bitfield = 'rev_deleted';
 		}
 
+		$dbw = wfGetDB( DB_MASTER );
 		$dbw->begin();
 		// For now, shunt the revision data into the archive table.
 		// Text is *not* removed from the text table; bulk storage

--- a/includes/WikiPage.php
+++ b/includes/WikiPage.php
@@ -12,7 +12,7 @@ abstract class Page {}
  *
  * internal documentation reviewed 15 Mar 2010
  */
-class WikiPage extends Page {
+class WikiPage extends Page implements IDBAccessObject {
 	// doDeleteArticleReal() return values. Values less than zero indicate fatal errors,
 	// values greater than zero indicate that there were problems not resulting in page
 	// not being deleted
@@ -40,26 +40,6 @@ class WikiPage extends Page {
 	// Constants for $mDataLoadedFrom and related
 
 	/**
-	 * Data has not been loaded yet (or the object was cleared)
-	 */
-	const DATA_NOT_LOADED = 0;
-
-	/**
-	 * Data has been loaded from a slave database
-	 */
-	const DATA_FROM_SLAVE = 1;
-
-	/**
-	 * Data has been loaded from the master database
-	 */
-	const DATA_FROM_MASTER = 2;
-
-	/**
-	 * Data has been loaded from the master database using FOR UPDATE
-	 */
-	const DATA_FOR_UPDATE = 3;
-
-	/**
 	 * @var Title
 	 */
 	public $mTitle = null;
@@ -74,9 +54,9 @@ class WikiPage extends Page {
 	/**@}}*/
 
 	/**
-	 * @var int; one of the DATA_* constants
+	 * @var int; one of the READ_* constants
 	 */
-	protected $mDataLoadedFrom = self::DATA_NOT_LOADED;
+	protected $mDataLoadedFrom = self::READ_NONE;
 
 	/**
 	 * @var Title
@@ -145,14 +125,14 @@ class WikiPage extends Page {
 	 *
 	 * @param $id Int article ID to load
 	 * @param $from string|int one of the following values:
-	 *        - "fromdb" or self::DATA_FROM_SLAVE to select from a slave database
-	 *        - "fromdbmaster" or self::DATA_FROM_MASTER to select from the master database
+	 *        - "fromdb" or WikiPage::READ_NORMAL to select from a slave database
+	 *        - "fromdbmaster" or WikiPage::READ_LATEST to select from the master database
 	 *
 	 * @return WikiPage
 	 */
 	public static function newFromID( $id, $from = 'fromdb' ) {
 		$from = self::convertSelectType( $from );
-		$db = wfGetDB( $from === self::DATA_FROM_MASTER ? DB_MASTER : DB_SLAVE );
+		$db = wfGetDB( $from === self::READ_LATEST ? DB_MASTER : DB_SLAVE );
 		$row = $db->selectRow( 'page', self::selectFields(), array( 'page_id' => $id ), __METHOD__ );
 		if ( !$row ) {
 			return null;
@@ -167,9 +147,9 @@ class WikiPage extends Page {
 	 * @param $row object: database row containing at least fields returned
 	 *        by selectFields().
 	 * @param $from string|int: source of $data:
-	 *        - "fromdb" or self::DATA_FROM_SLAVE: from a slave DB
-	 *        - "fromdbmaster" or self::DATA_FROM_MASTER: from the master DB
-	 *        - "forupdate" or self::DATA_FOR_UPDATE: from the master DB using SELECT FOR UPDATE
+	 *        - "fromdb" or WikiPage::READ_NORMAL: from a slave DB
+	 *        - "fromdbmaster" or WikiPage::READ_LATEST: from the master DB
+	 *        - "forupdate" or WikiPage::READ_LOCKING: from the master DB using SELECT FOR UPDATE
 	 * @return WikiPage
 	 */
 	public static function newFromRow( $row, $from = 'fromdb' ) {
@@ -179,7 +159,7 @@ class WikiPage extends Page {
 	}
 
 	/**
-	 * Convert 'fromdb', 'fromdbmaster' and 'forupdate' to DATA_* constants.
+	 * Convert 'fromdb', 'fromdbmaster' and 'forupdate' to READ_* constants.
 	 *
 	 * @param $type object|string|int
 	 * @return mixed
@@ -187,11 +167,11 @@ class WikiPage extends Page {
 	private static function convertSelectType( $type ) {
 		switch ( $type ) {
 		case 'fromdb':
-			return self::DATA_FROM_SLAVE;
+			return self::READ_NORMAL;
 		case 'fromdbmaster':
-			return self::DATA_FROM_MASTER;
+			return self::READ_LATEST;
 		case 'forupdate':
-			return self::DATA_FOR_UPDATE;
+			return self::READ_LOCKING;
 		default:
 			// It may already be an integer or whatever else
 			return $type;
@@ -225,7 +205,7 @@ class WikiPage extends Page {
 	 */
 	public function clear() {
 		$this->mDataLoaded = false;
-		$this->mDataLoadedFrom = self::DATA_NOT_LOADED;
+		$this->mDataLoadedFrom = self::READ_NONE;
 
 		$this->mCounter = null;
 		$this->mRedirectTarget = null; # Title object if set
@@ -311,9 +291,9 @@ class WikiPage extends Page {
 	 *
 	 * @param $from object|string|int One of the following:
 	 *        - A DB query result object
-	 *        - "fromdb" or self::DATA_FROM_SLAVE to get from a slave DB
-	 *        - "fromdbmaster" or self::DATA_FROM_MASTER to get from the master DB
-	 *        - "forupdate"  or self::DATA_FOR_UPDATE to get from the master DB using SELECT FOR UPDATE
+	 *        - "fromdb" or WikiPage::READ_NORMAL to get from a slave DB
+	 *        - "fromdbmaster" or WikiPage::READ_LATEST to get from the master DB
+	 *        - "forupdate"  or WikiPage::READ_LOCKING to get from the master DB using SELECT FOR UPDATE
 	 *
 	 * @return void
 	 */
@@ -324,25 +304,25 @@ class WikiPage extends Page {
 			return;
 		}
 
-		if ( $from === self::DATA_FOR_UPDATE ) {
+		if ( $from === self::READ_LOCKING ) {
 			$data = $this->pageDataFromTitle( wfGetDB( DB_MASTER ), $this->mTitle, array( 'FOR UPDATE' ) );
-		} elseif ( $from === self::DATA_FROM_MASTER ) {
+		} elseif ( $from === self::READ_LATEST ) {
 			$data = $this->pageDataFromTitle( wfGetDB( DB_MASTER ), $this->mTitle );
-		} elseif ( $from === self::DATA_FROM_SLAVE ) {
+		} elseif ( $from === self::READ_NORMAL ) {
 			$data = $this->pageDataFromTitle( wfGetDB( DB_SLAVE ), $this->mTitle );
 			# Use a "last rev inserted" timestamp key to dimish the issue of slave lag.
 			# Note that DB also stores the master position in the session and checks it.
 			$touched = $this->getCachedLastEditTime();
 			if ( $touched ) { // key set
 				if ( !$data || $touched > wfTimestamp( TS_MW, $data->page_touched ) ) {
-					$from = self::DATA_FROM_MASTER;
+					$from = self::READ_LATEST;
 					$data = $this->pageDataFromTitle( wfGetDB( DB_MASTER ), $this->mTitle );
 				}
 			}
 		} else {
 			// No idea from where the caller got this data, assume slave database.
 			$data = $from;
-			$from = self::DATA_FROM_SLAVE;
+			$from = self::READ_NORMAL;
 		}
 
 		$this->loadFromRow( $data, $from );
@@ -355,9 +335,9 @@ class WikiPage extends Page {
 	 * @param $data object: database row containing at least fields returned
 	 *        by selectFields()
 	 * @param $from string|int One of the following:
-	 *        - "fromdb" or self::DATA_FROM_SLAVE if the data comes from a slave DB
-	 *        - "fromdbmaster" or self::DATA_FROM_MASTER if the data comes from the master DB
-	 *        - "forupdate"  or self::DATA_FOR_UPDATE if the data comes from from
+	 *        - "fromdb" or WikiPage::READ_NORMAL if the data comes from a slave DB
+	 *        - "fromdbmaster" or WikiPage::READ_LATEST if the data comes from the master DB
+	 *        - "forupdate"  or WikiPage::READ_LOCKING if the data comes from from
 	 *          the master DB using SELECT FOR UPDATE
 	 */
 	public function loadFromRow( $data, $from ) {
@@ -487,7 +467,14 @@ class WikiPage extends Page {
 			return; // page doesn't exist or is missing page_latest info
 		}
 
-		$revision = Revision::newFromPageId( $this->getId(), $latest );
+		// Bug 37225: if session S1 loads the page row FOR UPDATE, the result always includes the
+		// latest changes committed. This is true even within REPEATABLE-READ transactions, where
+		// S1 normally only sees changes committed before the first S1 SELECT. Thus we need S1 to
+		// also gets the revision row FOR UPDATE; otherwise, it may not find it since a page row
+		// UPDATE and revision row INSERT by S2 may have happened after the first S1 SELECT.
+		// http://dev.mysql.com/doc/refman/5.0/en/set-transaction.html#isolevel_repeatable-read.
+		$flags = ( $this->mDataLoadedFrom == self::READ_LOCKING ) ? Revision::READ_LOCKING : 0;
+		$revision = Revision::newFromPageId( $this->getId(), $latest, $flags );
 		if ( $revision ) { // sanity
 			$this->setLastEdit( $revision );
 		}

--- a/includes/WikiPage.php
+++ b/includes/WikiPage.php
@@ -37,8 +37,6 @@ class WikiPage extends Page implements IDBAccessObject {
 	 */
 	const DELETE_NO_REVISIONS = 2;
 
-	// Constants for $mDataLoadedFrom and related
-
 	/**
 	 * @var Title
 	 */

--- a/includes/WikiPage.php
+++ b/includes/WikiPage.php
@@ -121,11 +121,26 @@ class WikiPage extends Page {
 	 * @return WikiPage
 	 */
 	public static function newFromID( $id ) {
-		$t = Title::newFromID( $id );
-		if ( $t ) {
-			return self::factory( $t );
+		$dbr = wfGetDB( DB_SLAVE );
+		$row = $dbr->selectRow( 'page', self::selectFields(), array( 'page_id' => $id ), __METHOD__ );
+		if ( !$row ) {
+			return null;
 		}
-		return null;
+		return self::newFromRow( $row );
+	}
+
+	/**
+	 * Constructor from a database row
+	 *
+	 * @since 1.20
+	 * @param $row object: database row containing at least fields returned
+	 *        by selectFields().
+	 * @return WikiPage
+	 */
+	public static function newFromRow( $row ) {
+		$page = self::factory( Title::newFromRow( $row ) );
+		$page->loadFromRow( $row );
+		return $page;
 	}
 
 	/**
@@ -256,6 +271,17 @@ class WikiPage extends Page {
 			}
 		}
 
+		$this->loadFromRow( $data );
+	}
+
+	/**
+	 * Load the object from a database row
+	 *
+	 * @since 1.20
+	 * @param $data object: database row containing at least fields returned
+	 *        by selectFields()
+	 */
+	public function loadFromRow( $data ) {
 		$lc = LinkCache::singleton();
 
 		if ( $data ) {

--- a/includes/dao/IDBAccessObject.php
+++ b/includes/dao/IDBAccessObject.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * This file contains database access object related constants.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * http://www.gnu.org/copyleft/gpl.html
+ *
+ * @file
+ * @ingroup Database
+ */
+
+/**
+ * Interface for database access objects
+ */
+interface IDBAccessObject {
+	const LATEST_READ  = 1; // read from the master
+	const FOR_UPDATE   = 2; // lock the rows read
+	const LOCKING_READ = 3; // LATEST_READ | FOR_UPDATE
+	const AVOID_MASTER = 4; // avoiding checking the master
+}

--- a/includes/dao/IDBAccessObject.php
+++ b/includes/dao/IDBAccessObject.php
@@ -22,11 +22,34 @@
  */
 
 /**
- * Interface for database access objects
+ * Interface for database access objects.
+ *
+ * Classes using this support a set of constants in a bitfield argument to their data loading
+ * functions. In general, objects should assume READ_NORMAL if no flags are explicitly given,
+ * though certain objects may assume READ_LATEST for common use case or legacy reasons.
+ *
+ * There are three types of reads:
+ *   - READ_NORMAL  : Potentially cached read of data (e.g. from a slave or stale replica)
+ *   - READ_LATEST  : Up-to-date read as of transaction start (e.g. from master or a quorum read)
+ *   - READ_LOCKING : Up-to-date read as of now, that locks the records for the transaction
+ *
+ * Callers should use READ_NORMAL (or pass in no flags) unless the read determines a write.
+ * In theory, such cases may require READ_LOCKING, though to avoid contention, READ_LATEST is
+ * often good enough. If UPDATE race condition checks are required on a row and expensive code
+ * must run after the row is fetched to determine the UPDATE, it may help to do something like:
+ *   - a) Read the current row
+ *   - b) Determine the new row (expensive, so we don't want to hold locks now)
+ *   - c) Re-read the current row with READ_LOCKING; if it changed then bail out
+ *   - d) otherwise, do the updates
  */
 interface IDBAccessObject {
-	const LATEST_READ  = 1; // read from the master
-	const FOR_UPDATE   = 2; // lock the rows read
-	const LOCKING_READ = 3; // LATEST_READ | FOR_UPDATE
-	const AVOID_MASTER = 4; // avoiding checking the master
+	// Constants for object loading bitfield flags (higher => higher QoS)
+	const READ_LATEST  = 1; // read from the master
+	const READ_LOCKING = 3; // READ_LATEST and "FOR UPDATE"
+
+	// Convenience constant for callers to explicitly request slave data
+	const READ_NORMAL = 0; // read from the slave
+
+	// Convenience constant for tracking how data was loaded (higher => higher QoS)
+	const READ_NONE = -1; // not loaded yet (or the object was cleared)
 }

--- a/includes/db/Database.php
+++ b/includes/db/Database.php
@@ -260,7 +260,7 @@ abstract class DatabaseBase implements DatabaseType {
 	 *   - false to disable debugging
 	 *   - omitted or null to do nothing
 	 *
-	 * @return bool The previous value of the flag
+	 * @return The previous value of the flag
 	 */
 	function debug( $debug = null ) {
 		return wfSetBit( $this->mFlags, DBO_DEBUG, $debug );
@@ -284,9 +284,9 @@ abstract class DatabaseBase implements DatabaseType {
 	 * split up queries into batches using a LIMIT clause than to switch off
 	 * buffering.
 	 *
-	 * @param  null|bool $buffer
+	 * @param $buffer null|bool
 	 *
-	 * @return bool The previous value of the flag
+	 * @return The previous value of the flag
 	 */
 	function bufferResults( $buffer = null ) {
 		if ( is_null( $buffer ) ) {
@@ -317,8 +317,8 @@ abstract class DatabaseBase implements DatabaseType {
 	 * Historically, transactions were allowed to be "nested". This is no
 	 * longer supported, so this function really only returns a boolean.
 	 *
-	 * @param int $level An integer (0 or 1), or omitted to leave it unchanged.
-	 * @return int The previous value
+	 * @param $level An integer (0 or 1), or omitted to leave it unchanged.
+	 * @return The previous value
 	 */
 	function trxLevel( $level = null ) {
 		return wfSetVar( $this->mTrxLevel, $level );
@@ -326,8 +326,8 @@ abstract class DatabaseBase implements DatabaseType {
 
 	/**
 	 * Get/set the number of errors logged. Only useful when errors are ignored
-	 * @param int $count The count to set, or omitted to leave it unchanged.
-	 * @return int The error count
+	 * @param $count The count to set, or omitted to leave it unchanged.
+	 * @return The error count
 	 */
 	function errorCount( $count = null ) {
 		return wfSetVar( $this->mErrorCount, $count );
@@ -335,8 +335,8 @@ abstract class DatabaseBase implements DatabaseType {
 
 	/**
 	 * Get/set the table prefix.
-	 * @param string $prefix The table prefix to set, or omitted to leave it unchanged.
-	 * @return string The previous table prefix.
+	 * @param $prefix The table prefix to set, or omitted to leave it unchanged.
+	 * @return The previous table prefix.
 	 */
 	function tablePrefix( $prefix = null ) {
 		return wfSetVar( $this->mTablePrefix, $prefix );
@@ -809,8 +809,6 @@ abstract class DatabaseBase implements DatabaseType {
 
 	/**
 	 * @param $error String: fallback error message, used if none is given by DB
-	 *
-	 * @throws DBConnectionError
 	 */
 	function reportConnectionError( $error = 'Unknown error' ) {
 		$myError = $this->lastError();
@@ -855,17 +853,14 @@ abstract class DatabaseBase implements DatabaseType {
 	 *
 	 * However, the query wrappers themselves should call this function.
 	 *
-	 * @param string $sql : SQL query
-	 * @param string $fname : Name of the calling function, for profiling/SHOW PROCESSLIST
+	 * @param  $sql        String: SQL query
+	 * @param  $fname      String: Name of the calling function, for profiling/SHOW PROCESSLIST
 	 *     comment (you can use __METHOD__ or add some extra info)
-	 * @param bool $tempIgnore : Whether to avoid throwing an exception on errors...
+	 * @param  $tempIgnore Boolean:   Whether to avoid throwing an exception on errors...
 	 *     maybe best to catch the exception instead?
-	 *
-	 * @return bool|ResultWrapper true for a successful write query, ResultWrapper object
+	 * @return boolean|ResultWrapper. true for a successful write query, ResultWrapper object
 	 *     for a successful read query, or false on failure if $tempIgnore set
-	 *
-	 * @throws DBQueryError
-	 * @throws MWException
+	 * @throws DBQueryError Thrown when the database returns an error of any kind
 	 */
 	public function query( $sql, $fname = '', $tempIgnore = false ) {
 		$isMaster = !is_null( $this->getLBInfo( 'master' ) );
@@ -894,7 +889,7 @@ abstract class DatabaseBase implements DatabaseType {
 		}
 
 		# <Wikia>
-		global $wgDBReadOnly;
+		global $wgProfiler, $wgDBReadOnly;
 		if ( $is_writeable && $wgDBReadOnly ) {
 			if ( !Profiler::instance()->isStub() ) {
 				wfProfileOut( $queryProf );
@@ -1017,13 +1012,11 @@ abstract class DatabaseBase implements DatabaseType {
 	 * Report a query error. Log the error, and if neither the object ignore
 	 * flag nor the $tempIgnore flag is set, throw a DBQueryError.
 	 *
-	 * @param String $error
-	 * @param Integer $errno
-	 * @param String $sql
-	 * @param String $fname
-	 * @param Boolean $tempIgnore
-	 *
-	 * @throws DBQueryError
+	 * @param $error String
+	 * @param $errno Integer
+	 * @param $sql String
+	 * @param $fname String
+	 * @param $tempIgnore Boolean
 	 */
 	function reportQueryError( $error, $errno, $sql, $fname, $tempIgnore = false ) {
 		# Ignore errors during error handling to avoid infinite recursion
@@ -1141,10 +1134,8 @@ abstract class DatabaseBase implements DatabaseType {
 	 * The arguments should be in $this->preparedArgs and must not be touched
 	 * while we're doing this.
 	 *
-	 * @param array $matches
-	 *
+	 * @param $matches Array
 	 * @return String
-	 * @throws DBUnexpectedError
 	 */
 	function fillPreparedArg( $matches ) {
 		switch( $matches[1] ) {
@@ -1256,8 +1247,7 @@ abstract class DatabaseBase implements DatabaseType {
 	 * @param string $fname The function name of the caller.
 	 * @param string|array $options The query options. See DatabaseBase::select() for details.
 	 *
-	 * @return array|bool The values from the field, or false on failure
-	 * @throws DBUnexpectedError
+	 * @return bool|array The values from the field, or false on failure
 	 * @since 1.25
 	 */
 	public function selectFieldValues(
@@ -1529,14 +1519,14 @@ abstract class DatabaseBase implements DatabaseType {
 	 * The equivalent of DatabaseBase::select() except that the constructed SQL
 	 * is returned, instead of being immediately executed.
 	 *
-	 * @param string|array $table Table name
-	 * @param string|array $vars Field names
-	 * @param string|array $conds Conditions
-	 * @param string $fname Caller function name
-	 * @param string|array $options Query options
-	 * @param string|array $join_conds Join conditions
+	 * @param $table string|array Table name
+	 * @param $vars string|array Field names
+	 * @param $conds string|array Conditions
+	 * @param $fname string Caller function name
+	 * @param $options string|array Query options
+	 * @param $join_conds string|array Join conditions
 	 *
-	 * @return string SQL query string.
+	 * @return SQL query string.
 	 * @see DatabaseBase::select()
 	 */
 	function selectSQLText( $table, $vars, $conds = '', $fname = 'DatabaseBase::select', $options = array(), $join_conds = array() ) {
@@ -1927,8 +1917,6 @@ abstract class DatabaseBase implements DatabaseType {
 	 *      - LIST_NAMES:          comma separated field names
 	 *
 	 * @return string
-	 * @throws DBUnexpectedError
-	 * @throws MWException
 	 */
 	function makeList( $a, $mode = LIST_COMMA ) {
 		if ( !is_array( $a ) ) {
@@ -2609,9 +2597,6 @@ abstract class DatabaseBase implements DatabaseType {
 	 *                    ANDed together in the WHERE clause
 	 * @param $fname      String: Calling function name (use __METHOD__) for
 	 *                    logs/profiling
-	 *
-	 * @throws DBUnexpectedError
-	 * @throws MWException
 	 */
 	function deleteJoin( $delTable, $joinTable, $delVar, $joinVar, $conds,
 		$fname = 'DatabaseBase::deleteJoin' )
@@ -2678,8 +2663,6 @@ abstract class DatabaseBase implements DatabaseType {
 	 * @param $fname String name of the calling function
 	 *
 	 * @return bool
-	 * @throws DBUnexpectedError
-	 * @throws MWException
 	 */
 	function delete( $table, $conds, $fname = 'DatabaseBase::delete' ) {
 		if ( !$conds ) {
@@ -2792,10 +2775,9 @@ abstract class DatabaseBase implements DatabaseType {
 	 *
 	 * @param $sql String SQL query we will append the limit too
 	 * @param $limit Integer the SQL limit
-	 * @param bool|false|int $offset Integer|false the SQL offset (default false)
+	 * @param $offset Integer|false the SQL offset (default false)
 	 *
 	 * @return string
-	 * @throws DBUnexpectedError
 	 */
 	function limitResult( $sql, $limit, $offset = false ) {
 		if ( !is_numeric( $limit ) ) {
@@ -3098,13 +3080,11 @@ abstract class DatabaseBase implements DatabaseType {
 	 * The table names passed to this function shall not be quoted (this
 	 * function calls addIdentifierQuotes when needed).
 	 *
-	 * @param String $oldName : name of table whose structure should be copied
-	 * @param String $newName : name of table to be created
-	 * @param Boolean $temporary : whether the new table should be temporary
-	 * @param String $fname : calling function name
-	 *
-	 * @return bool : true if operation was successful
-	 * @throws MWException
+	 * @param $oldName String: name of table whose structure should be copied
+	 * @param $newName String: name of table to be created
+	 * @param $temporary Boolean: whether the new table should be temporary
+	 * @param $fname String: calling function name
+	 * @return Boolean: true if operation was successful
 	 */
 	function duplicateTableStructure( $oldName, $newName, $temporary = false,
 		$fname = 'DatabaseBase::duplicateTableStructure' )
@@ -3116,10 +3096,8 @@ abstract class DatabaseBase implements DatabaseType {
 	/**
 	 * List all tables on the database
 	 *
-	 * @param string $prefix : Only show tables with this prefix, e.g. mw_
-	 * @param string $fname : calling function name
-	 *
-	 * @throws MWException
+	 * @param $prefix Only show tables with this prefix, e.g. mw_
+	 * @param $fname String: calling function name
 	 */
 	function listTables( $prefix = null, $fname = 'DatabaseBase::listTables' ) {
 		throw new MWException( 'DatabaseBase::listTables is not implemented in descendant class' );
@@ -3286,15 +3264,12 @@ abstract class DatabaseBase implements DatabaseType {
 	 * Returns true on success, error string or exception on failure (depending
 	 * on object's error ignore settings).
 	 *
-	 * @param String $filename : File name to open
-	 * @param bool|callable $lineCallback : Optional function called before reading each line
-	 * @param bool|callable $resultCallback : Optional function called for each MySQL result
-	 * @param bool|String $fname : Calling function name or false if name should be
+	 * @param $filename String: File name to open
+	 * @param $lineCallback Callback: Optional function called before reading each line
+	 * @param $resultCallback Callback: Optional function called for each MySQL result
+	 * @param $fname String: Calling function name or false if name should be
 	 *      generated dynamically using $filename
-	 *
 	 * @return bool|string
-	 * @throws Exception
-	 * @throws MWException
 	 */
 	function sourceFile( $filename, $lineCallback = false, $resultCallback = false, $fname = false ) {
 		wfSuppressWarnings();

--- a/includes/db/Database.php
+++ b/includes/db/Database.php
@@ -260,7 +260,7 @@ abstract class DatabaseBase implements DatabaseType {
 	 *   - false to disable debugging
 	 *   - omitted or null to do nothing
 	 *
-	 * @return The previous value of the flag
+	 * @return bool The previous value of the flag
 	 */
 	function debug( $debug = null ) {
 		return wfSetBit( $this->mFlags, DBO_DEBUG, $debug );
@@ -284,9 +284,9 @@ abstract class DatabaseBase implements DatabaseType {
 	 * split up queries into batches using a LIMIT clause than to switch off
 	 * buffering.
 	 *
-	 * @param $buffer null|bool
+	 * @param  null|bool $buffer
 	 *
-	 * @return The previous value of the flag
+	 * @return bool The previous value of the flag
 	 */
 	function bufferResults( $buffer = null ) {
 		if ( is_null( $buffer ) ) {
@@ -317,8 +317,8 @@ abstract class DatabaseBase implements DatabaseType {
 	 * Historically, transactions were allowed to be "nested". This is no
 	 * longer supported, so this function really only returns a boolean.
 	 *
-	 * @param $level An integer (0 or 1), or omitted to leave it unchanged.
-	 * @return The previous value
+	 * @param int $level An integer (0 or 1), or omitted to leave it unchanged.
+	 * @return int The previous value
 	 */
 	function trxLevel( $level = null ) {
 		return wfSetVar( $this->mTrxLevel, $level );
@@ -326,8 +326,8 @@ abstract class DatabaseBase implements DatabaseType {
 
 	/**
 	 * Get/set the number of errors logged. Only useful when errors are ignored
-	 * @param $count The count to set, or omitted to leave it unchanged.
-	 * @return The error count
+	 * @param int $count The count to set, or omitted to leave it unchanged.
+	 * @return int The error count
 	 */
 	function errorCount( $count = null ) {
 		return wfSetVar( $this->mErrorCount, $count );
@@ -335,8 +335,8 @@ abstract class DatabaseBase implements DatabaseType {
 
 	/**
 	 * Get/set the table prefix.
-	 * @param $prefix The table prefix to set, or omitted to leave it unchanged.
-	 * @return The previous table prefix.
+	 * @param string $prefix The table prefix to set, or omitted to leave it unchanged.
+	 * @return string The previous table prefix.
 	 */
 	function tablePrefix( $prefix = null ) {
 		return wfSetVar( $this->mTablePrefix, $prefix );
@@ -809,6 +809,8 @@ abstract class DatabaseBase implements DatabaseType {
 
 	/**
 	 * @param $error String: fallback error message, used if none is given by DB
+	 *
+	 * @throws DBConnectionError
 	 */
 	function reportConnectionError( $error = 'Unknown error' ) {
 		$myError = $this->lastError();
@@ -853,14 +855,17 @@ abstract class DatabaseBase implements DatabaseType {
 	 *
 	 * However, the query wrappers themselves should call this function.
 	 *
-	 * @param  $sql        String: SQL query
-	 * @param  $fname      String: Name of the calling function, for profiling/SHOW PROCESSLIST
+	 * @param string $sql : SQL query
+	 * @param string $fname : Name of the calling function, for profiling/SHOW PROCESSLIST
 	 *     comment (you can use __METHOD__ or add some extra info)
-	 * @param  $tempIgnore Boolean:   Whether to avoid throwing an exception on errors...
+	 * @param bool $tempIgnore : Whether to avoid throwing an exception on errors...
 	 *     maybe best to catch the exception instead?
-	 * @return boolean|ResultWrapper. true for a successful write query, ResultWrapper object
+	 *
+	 * @return bool|ResultWrapper true for a successful write query, ResultWrapper object
 	 *     for a successful read query, or false on failure if $tempIgnore set
-	 * @throws DBQueryError Thrown when the database returns an error of any kind
+	 *
+	 * @throws DBQueryError
+	 * @throws MWException
 	 */
 	public function query( $sql, $fname = '', $tempIgnore = false ) {
 		$isMaster = !is_null( $this->getLBInfo( 'master' ) );
@@ -889,7 +894,7 @@ abstract class DatabaseBase implements DatabaseType {
 		}
 
 		# <Wikia>
-		global $wgProfiler, $wgDBReadOnly;
+		global $wgDBReadOnly;
 		if ( $is_writeable && $wgDBReadOnly ) {
 			if ( !Profiler::instance()->isStub() ) {
 				wfProfileOut( $queryProf );
@@ -1012,11 +1017,13 @@ abstract class DatabaseBase implements DatabaseType {
 	 * Report a query error. Log the error, and if neither the object ignore
 	 * flag nor the $tempIgnore flag is set, throw a DBQueryError.
 	 *
-	 * @param $error String
-	 * @param $errno Integer
-	 * @param $sql String
-	 * @param $fname String
-	 * @param $tempIgnore Boolean
+	 * @param String $error
+	 * @param Integer $errno
+	 * @param String $sql
+	 * @param String $fname
+	 * @param Boolean $tempIgnore
+	 *
+	 * @throws DBQueryError
 	 */
 	function reportQueryError( $error, $errno, $sql, $fname, $tempIgnore = false ) {
 		# Ignore errors during error handling to avoid infinite recursion
@@ -1134,8 +1141,10 @@ abstract class DatabaseBase implements DatabaseType {
 	 * The arguments should be in $this->preparedArgs and must not be touched
 	 * while we're doing this.
 	 *
-	 * @param $matches Array
+	 * @param array $matches
+	 *
 	 * @return String
+	 * @throws DBUnexpectedError
 	 */
 	function fillPreparedArg( $matches ) {
 		switch( $matches[1] ) {
@@ -1247,7 +1256,8 @@ abstract class DatabaseBase implements DatabaseType {
 	 * @param string $fname The function name of the caller.
 	 * @param string|array $options The query options. See DatabaseBase::select() for details.
 	 *
-	 * @return bool|array The values from the field, or false on failure
+	 * @return array|bool The values from the field, or false on failure
+	 * @throws DBUnexpectedError
 	 * @since 1.25
 	 */
 	public function selectFieldValues(
@@ -1519,14 +1529,14 @@ abstract class DatabaseBase implements DatabaseType {
 	 * The equivalent of DatabaseBase::select() except that the constructed SQL
 	 * is returned, instead of being immediately executed.
 	 *
-	 * @param $table string|array Table name
-	 * @param $vars string|array Field names
-	 * @param $conds string|array Conditions
-	 * @param $fname string Caller function name
-	 * @param $options string|array Query options
-	 * @param $join_conds string|array Join conditions
+	 * @param string|array $table Table name
+	 * @param string|array $vars Field names
+	 * @param string|array $conds Conditions
+	 * @param string $fname Caller function name
+	 * @param string|array $options Query options
+	 * @param string|array $join_conds Join conditions
 	 *
-	 * @return SQL query string.
+	 * @return string SQL query string.
 	 * @see DatabaseBase::select()
 	 */
 	function selectSQLText( $table, $vars, $conds = '', $fname = 'DatabaseBase::select', $options = array(), $join_conds = array() ) {
@@ -1917,6 +1927,8 @@ abstract class DatabaseBase implements DatabaseType {
 	 *      - LIST_NAMES:          comma separated field names
 	 *
 	 * @return string
+	 * @throws DBUnexpectedError
+	 * @throws MWException
 	 */
 	function makeList( $a, $mode = LIST_COMMA ) {
 		if ( !is_array( $a ) ) {
@@ -2597,6 +2609,9 @@ abstract class DatabaseBase implements DatabaseType {
 	 *                    ANDed together in the WHERE clause
 	 * @param $fname      String: Calling function name (use __METHOD__) for
 	 *                    logs/profiling
+	 *
+	 * @throws DBUnexpectedError
+	 * @throws MWException
 	 */
 	function deleteJoin( $delTable, $joinTable, $delVar, $joinVar, $conds,
 		$fname = 'DatabaseBase::deleteJoin' )
@@ -2663,6 +2678,8 @@ abstract class DatabaseBase implements DatabaseType {
 	 * @param $fname String name of the calling function
 	 *
 	 * @return bool
+	 * @throws DBUnexpectedError
+	 * @throws MWException
 	 */
 	function delete( $table, $conds, $fname = 'DatabaseBase::delete' ) {
 		if ( !$conds ) {
@@ -2775,9 +2792,10 @@ abstract class DatabaseBase implements DatabaseType {
 	 *
 	 * @param $sql String SQL query we will append the limit too
 	 * @param $limit Integer the SQL limit
-	 * @param $offset Integer|false the SQL offset (default false)
+	 * @param bool|false|int $offset Integer|false the SQL offset (default false)
 	 *
 	 * @return string
+	 * @throws DBUnexpectedError
 	 */
 	function limitResult( $sql, $limit, $offset = false ) {
 		if ( !is_numeric( $limit ) ) {
@@ -3080,11 +3098,13 @@ abstract class DatabaseBase implements DatabaseType {
 	 * The table names passed to this function shall not be quoted (this
 	 * function calls addIdentifierQuotes when needed).
 	 *
-	 * @param $oldName String: name of table whose structure should be copied
-	 * @param $newName String: name of table to be created
-	 * @param $temporary Boolean: whether the new table should be temporary
-	 * @param $fname String: calling function name
-	 * @return Boolean: true if operation was successful
+	 * @param String $oldName : name of table whose structure should be copied
+	 * @param String $newName : name of table to be created
+	 * @param Boolean $temporary : whether the new table should be temporary
+	 * @param String $fname : calling function name
+	 *
+	 * @return bool : true if operation was successful
+	 * @throws MWException
 	 */
 	function duplicateTableStructure( $oldName, $newName, $temporary = false,
 		$fname = 'DatabaseBase::duplicateTableStructure' )
@@ -3096,8 +3116,10 @@ abstract class DatabaseBase implements DatabaseType {
 	/**
 	 * List all tables on the database
 	 *
-	 * @param $prefix Only show tables with this prefix, e.g. mw_
-	 * @param $fname String: calling function name
+	 * @param string $prefix : Only show tables with this prefix, e.g. mw_
+	 * @param string $fname : calling function name
+	 *
+	 * @throws MWException
 	 */
 	function listTables( $prefix = null, $fname = 'DatabaseBase::listTables' ) {
 		throw new MWException( 'DatabaseBase::listTables is not implemented in descendant class' );
@@ -3264,12 +3286,15 @@ abstract class DatabaseBase implements DatabaseType {
 	 * Returns true on success, error string or exception on failure (depending
 	 * on object's error ignore settings).
 	 *
-	 * @param $filename String: File name to open
-	 * @param $lineCallback Callback: Optional function called before reading each line
-	 * @param $resultCallback Callback: Optional function called for each MySQL result
-	 * @param $fname String: Calling function name or false if name should be
+	 * @param String $filename : File name to open
+	 * @param bool|callable $lineCallback : Optional function called before reading each line
+	 * @param bool|callable $resultCallback : Optional function called for each MySQL result
+	 * @param bool|String $fname : Calling function name or false if name should be
 	 *      generated dynamically using $filename
+	 *
 	 * @return bool|string
+	 * @throws Exception
+	 * @throws MWException
 	 */
 	function sourceFile( $filename, $lineCallback = false, $resultCallback = false, $fname = false ) {
 		wfSuppressWarnings();

--- a/includes/diff/DifferenceEngine.php
+++ b/includes/diff/DifferenceEngine.php
@@ -1036,7 +1036,7 @@ class DifferenceEngine extends ContextSource {
 		// Load the new revision object
 		$this->mNewRev = $this->mNewid
 			? Revision::newFromId( $this->mNewid )
-			: Revision::newFromTitle( $this->getTitle() );
+			: Revision::newFromTitle( $this->getTitle(), false, Revision::AVOID_MASTER );
 
 		if ( !$this->mNewRev instanceof Revision ) {
 			return false;

--- a/includes/diff/DifferenceEngine.php
+++ b/includes/diff/DifferenceEngine.php
@@ -1036,7 +1036,7 @@ class DifferenceEngine extends ContextSource {
 		// Load the new revision object
 		$this->mNewRev = $this->mNewid
 			? Revision::newFromId( $this->mNewid )
-			: Revision::newFromTitle( $this->getTitle(), false, Revision::AVOID_MASTER );
+			: Revision::newFromTitle( $this->getTitle(), false, Revision::READ_NORMAL );
 
 		if ( !$this->mNewRev instanceof Revision ) {
 			return false;

--- a/includes/filerepo/file/LocalFile.php
+++ b/includes/filerepo/file/LocalFile.php
@@ -1477,7 +1477,7 @@ class LocalFile extends File {
 	 */
 	function getDescriptionText() {
 		global $wgParser;
-		$revision = Revision::newFromTitle( $this->title, false, Revision::AVOID_MASTER );
+		$revision = Revision::newFromTitle( $this->title, false, Revision::READ_NORMAL );
 		if ( !$revision ) return false;
 		$text = $revision->getText();
 		if ( !$text ) return false;

--- a/includes/filerepo/file/LocalFile.php
+++ b/includes/filerepo/file/LocalFile.php
@@ -1477,7 +1477,7 @@ class LocalFile extends File {
 	 */
 	function getDescriptionText() {
 		global $wgParser;
-		$revision = Revision::newFromTitle( $this->title );
+		$revision = Revision::newFromTitle( $this->title, false, Revision::AVOID_MASTER );
 		if ( !$revision ) return false;
 		$text = $revision->getText();
 		if ( !$text ) return false;

--- a/includes/parser/Parser.php
+++ b/includes/parser/Parser.php
@@ -3868,7 +3868,7 @@ class Parser {
 			# Get the revision
 			$rev = $id
 				? Revision::newFromId( $id )
-				: Revision::newFromTitle( $title );
+				: Revision::newFromTitle( $title, 0, Revision::READ_NORMAL );
 			$rev_id = $rev ? $rev->getId() : 0;
 			# If there is no current revision, there is no page
 			if ( $id === false && !$rev ) {

--- a/includes/search/SearchEngine.php
+++ b/includes/search/SearchEngine.php
@@ -737,7 +737,8 @@ class SearchResult {
 	protected function initFromTitle( $title ) {
 		$this->mTitle = $title;
 		if ( !is_null( $this->mTitle ) ) {
-			$this->mRevision = Revision::newFromTitle( $this->mTitle );
+			$this->mRevision = Revision::newFromTitle(
+				$this->mTitle, false, Revision::AVOID_MASTER );
 			if ( $this->mTitle->getNamespace() === NS_FILE )
 				$this->mImage = wfFindFile( $this->mTitle );
 		}

--- a/includes/search/SearchEngine.php
+++ b/includes/search/SearchEngine.php
@@ -738,7 +738,7 @@ class SearchResult {
 		$this->mTitle = $title;
 		if ( !is_null( $this->mTitle ) ) {
 			$this->mRevision = Revision::newFromTitle(
-				$this->mTitle, false, Revision::AVOID_MASTER );
+				$this->mTitle, false, Revision::READ_NORMAL );
 			if ( $this->mTitle->getNamespace() === NS_FILE )
 				$this->mImage = wfFindFile( $this->mTitle );
 		}

--- a/includes/specials/SpecialBooksources.php
+++ b/includes/specials/SpecialBooksources.php
@@ -142,7 +142,7 @@ class SpecialBookSources extends SpecialPage {
 		$page = $this->msg( 'booksources' )->inContentLanguage()->text();
 		$title = Title::makeTitleSafe( NS_PROJECT, $page ); # Show list in content language
 		if( is_object( $title ) && $title->exists() ) {
-			$rev = Revision::newFromTitle( $title, false, Revision::AVOID_MASTER );
+			$rev = Revision::newFromTitle( $title, false, Revision::READ_NORMAL );
 			$this->getOutput()->addWikiText( str_replace( 'MAGICNUMBER', $this->isbn, $rev->getText() ) );
 			return true;
 		}

--- a/includes/specials/SpecialBooksources.php
+++ b/includes/specials/SpecialBooksources.php
@@ -142,7 +142,7 @@ class SpecialBookSources extends SpecialPage {
 		$page = $this->msg( 'booksources' )->inContentLanguage()->text();
 		$title = Title::makeTitleSafe( NS_PROJECT, $page ); # Show list in content language
 		if( is_object( $title ) && $title->exists() ) {
-			$rev = Revision::newFromTitle( $title );
+			$rev = Revision::newFromTitle( $title, false, Revision::AVOID_MASTER );
 			$this->getOutput()->addWikiText( str_replace( 'MAGICNUMBER', $this->isbn, $rev->getText() ) );
 			return true;
 		}

--- a/includes/wikia/services/ArticleService.class.php
+++ b/includes/wikia/services/ArticleService.class.php
@@ -203,7 +203,8 @@ class ArticleService extends WikiaObject {
 	 * Accesses a snippet from MediaWiki.
 	 * @return string
 	 */
-	public function getUncachedSnippetFromArticle() {
+	public function getUncachedSnippetFromArticle()
+	{
 		// get standard parser cache for anons,
 		// 99% of the times it will be available but
 		// generate it in case is not


### PR DESCRIPTION
## What?

Backporting the following commits from MediaWiki 1.20 and 1.21:
- https://github.com/wikimedia/mediawiki/commit/8288b34eaede7dd80a54a86dbde9f58ab6afd9a8
- https://github.com/wikimedia/mediawiki/commit/eb183bac87cb58ca910140a31a5f8b8c7916302f
- https://github.com/wikimedia/mediawiki/commit/402da95a4b59c2d2fa20692e2a8df17ee6a83432
- https://github.com/wikimedia/mediawiki/commit/658ae44bd13978a00820431887a21e8527709808
- https://github.com/wikimedia/mediawiki/commit/61f246aa786d824d0653522ed679c16be719da80

Partially revert d40c317 (namely core changes) by @garthwebb  (see #7086) to make it use core changes from MediaWiki upstream instead our home-grown hacks :)
## Why?

While working on [PLATFORM-1636](https://wikia-inc.atlassian.net/browse/PLATFORM-1636) it turned out that we're making ~240 mm queries daily from `Revision::newFromTitle` that hit master nodes (while most of the times they can get data from one of the slaves). Most of the calls are coming from `Parser::statelessFetchTemplate` method.

See #8973 for a similar fix / backport

@michalroszka / @wladekb / @drozdo 
