### PR TITLE
CE-3001: Check if script exists

### DIFF
--- a/includes/wikia/resourceloader/ResourceLoaderGlobalWikiModule.class.php
+++ b/includes/wikia/resourceloader/ResourceLoaderGlobalWikiModule.class.php
@@ -258,6 +258,10 @@ abstract class ResourceLoaderGlobalWikiModule extends ResourceLoaderWikiModule {
 		$revisionId = null;
 		$wikiId = 0;
 
+		if ( empty( $title->getArticleID() ) ) {
+			return 0;
+		}
+
 		$contentReviewHelper = new Wikia\ContentReview\Helper();
 
 		if ( $title instanceof GlobalTitle ) {


### PR DESCRIPTION
Sometimes users import scripts from external wikis which were deleted. By this fix for non existing articles we will serve empty string `''`.
