### PR TITLE
SEO-143 Tweaks to links extracting logic for lilly

### DIFF
--- a/extensions/wikia/Lilly/LillyHooks.class.php
+++ b/extensions/wikia/Lilly/LillyHooks.class.php
@@ -23,9 +23,9 @@ class LillyHooks {
 		'ru.starwars.wikia.com',
 		'sl.starwars.wikia.com',
 		'sr.starwars.wikia.com',
-		'fi.starwars.wikia.com',
 		'sv.starwars.wikia.com',
 		'tr.starwars.wikia.com',
+		'zh.starwars.wikia.com',
 		'zh-hk.starwars.wikia.com',
 	];
 
@@ -34,6 +34,7 @@ class LillyHooks {
 		'Česky',
 		'Dansk',
 		'Deutsch',
+		'English',
 		'Ελληνικά',
 		'Español',
 		'Français',
@@ -50,7 +51,6 @@ class LillyHooks {
 		'Русский',
 		'Slovenščina',
 		'Српски / Srpski',
-		'Suomi',
 		'Svenska',
 		'Türkçe',
 		// WARNING, There are Unicode LEFT-TO-RIGHT EMBEDDING and


### PR DESCRIPTION
- No more tracking links to (and from) Finnish starwars as it's not
  hosted on Wikia anymore
- Add English as the a language (so links to the English Star Wars are
  also tracked
- Add zh.starwars.wikia.com in addition to zh-hk.starwars.wikia.com as
  an expected target domain as both point to the Chinese Star Wars wiki
