### PR TITLE
CE-3024: use dataSeek instead of object cloning in hook

### DIFF
--- a/extensions/wikia/TemplateClassification/TemplateClassification.hooks.php
+++ b/extensions/wikia/TemplateClassification/TemplateClassification.hooks.php
@@ -153,11 +153,12 @@ class Hooks {
 	 * @param $results
 	 * @return bool
 	 */
-	public function onQueryPageUseResultsBeforeRecache( \QueryPage $queryPage, $results ) {
+	public function onQueryPageUseResultsBeforeRecache( \QueryPage $queryPage, \DatabaseBase $db, $results ) {
 		if ( $queryPage->getName() === \UnusedtemplatesPage::UNUSED_TEMPLATES_PAGE_NAME ) {
 			$handler = $this->getUnusedTemplatesHandler();
 			if ( $results instanceof \ResultWrapper ) {
 				$handler->markAsUnusedFromResults( $results );
+				$db->dataSeek( $results, 0 );	// CE-3024: reset cursor because hook caller needs the results also
 			} else {
 				$handler->markAllAsUsed();
 			}

--- a/extensions/wikia/TemplateClassification/tests/TemplateClassificationHooksTest.php
+++ b/extensions/wikia/TemplateClassification/tests/TemplateClassificationHooksTest.php
@@ -23,7 +23,9 @@ class TemplateClassificationHooksTest extends WikiaBaseTest {
 
 		$resultsMock = $this->getMock( 'ResultWrapper' );
 
-		$hooksMock->onQueryPageUseResultsBeforeRecache( $queryPageMock, $resultsMock );
+		$dbMock = $this->getMock( 'DatabaseMysqli' );
+
+		$hooksMock->onQueryPageUseResultsBeforeRecache( $queryPageMock, $dbMock, $resultsMock );
 	}
 
 	public function testQueryPageBeforeRecacheNoResults() {
@@ -41,7 +43,9 @@ class TemplateClassificationHooksTest extends WikiaBaseTest {
 
 		$results = false;
 
-		$hooksMock->onQueryPageUseResultsBeforeRecache( $queryPage, $results );
+		$dbMock = $this->getMock( 'DatabaseMysqli' );
+
+		$hooksMock->onQueryPageUseResultsBeforeRecache( $queryPage, $dbMock, $results );
 	}
 
 	public function testQueryPageBeforeRecacheGoodResults() {
@@ -59,7 +63,9 @@ class TemplateClassificationHooksTest extends WikiaBaseTest {
 
 		$results = $this->getMock( 'ResultWrapper' );
 
-		$hooksMock->onQueryPageUseResultsBeforeRecache( $queryPage, $results );
+		$dbMock = $this->getMock( 'DatabaseMysqli' );
+
+		$hooksMock->onQueryPageUseResultsBeforeRecache( $queryPage, $dbMock, $results );
 	}
 
 	/**

--- a/includes/QueryPage.php
+++ b/includes/QueryPage.php
@@ -297,8 +297,7 @@ abstract class QueryPage extends SpecialPage {
 		 * Wikia change begin
 		 * @author <adamk@wikia-inc.com>
 		 */
-		$resClone = clone $res;
-		wfRunHooks( 'QueryPageUseResultsBeforeRecache', [ $this, $resClone ] );
+		wfRunHooks( 'QueryPageUseResultsBeforeRecache', [ $this, $dbr, $res ] );
 		/**
 		 * Wikia change end
 		 */

--- a/includes/Revision.php
+++ b/includes/Revision.php
@@ -831,10 +831,10 @@ class Revision implements IDBAccessObject {
 	/* Wikia changes end */
 		$title = $this->getTitle( $useMaster );
 		if( $title ) {
-			$prev = ( 
-				$useMaster === false ? 
-					$title->getPreviousRevisionID( $this->getId() ) : 
-					$title->getPreviousRevisionID( $this->getId(), Title::GAID_FOR_UPDATE ) 
+			$prev = (
+				$useMaster === false ?
+					$title->getPreviousRevisionID( $this->getId() ) :
+					$title->getPreviousRevisionID( $this->getId(), Title::GAID_FOR_UPDATE )
 			);
 	/* Wikia changes end */
 			if( $prev ) {
@@ -921,7 +921,9 @@ class Revision implements IDBAccessObject {
 				wfProfileOut( __METHOD__ );
 				return false;
 			}
-			wfDebug( sprintf( "%s: for '%s'\n", __METHOD__, $row->page_title ) ); // Wikia change - PLATFORM-1381
+			if ( property_exists($row, 'page_title') ) {
+				wfDebug( sprintf( "%s: for '%s'\n", __METHOD__, $row->page_title ) ); // Wikia change - PLATFORM-1381
+			}
 			$text = ExternalStore::fetchFromURL( $url );
 		}
 


### PR DESCRIPTION
$res was sometimes null, so clone() failed.  Instead of putting more if/else logic around the hook, I just fixed it inside the hook with a reset of the db result obj that only runs if the hook actually does something.  

In testing, I also found a PHP notice in the logging added to Revision.php as part of the infobox project.

@adamkarminski 
