### PR TITLE
ADEN-2620 Remove floor adhesion container on consecutive pages

### DIFF
--- a/extensions/wikia/AdEngine/js/template/floor.js
+++ b/extensions/wikia/AdEngine/js/template/floor.js
@@ -109,6 +109,13 @@ define('ext.wikia.adEngine.template.floor', [
 		}
 	}
 
+	adContext.addCallback(function () {
+		var floor = doc.getElementById(floorId);
+		if (floor) {
+			floor.parentElement.removeChild(floor);
+		}
+	});
+
 	return {
 		show: show
 	};


### PR DESCRIPTION
Because of Mercury SPA architecture we have to remove DOM element which contains floor adhesion on every pageview (if ad exists).
