### PR TITLE
(MAIN-5818) Fix for user signup confirmation page

### DIFF
--- a/extensions/wikia/UserLogin/UserLoginSpecialController.class.php
+++ b/extensions/wikia/UserLogin/UserLoginSpecialController.class.php
@@ -264,7 +264,7 @@ class UserLoginSpecialController extends WikiaSpecialPageController {
 	public function getUnconfirmedUserRedirectUrl() {
 		$title = Title::newFromText( 'UserSignup', NS_SPECIAL );
 		$params = [
-			'method' => 'sendConfirmationEmail',
+			'sendConfirmationEmail' => true,
 			'username' => $this->getVal( 'username' ),
 			'uselang' => $this->getVal( 'uselang' ),
 		];

--- a/extensions/wikia/UserLogin/UserSignupSpecialController.class.php
+++ b/extensions/wikia/UserLogin/UserSignupSpecialController.class.php
@@ -42,6 +42,8 @@ class UserSignupSpecialController extends WikiaSpecialPageController {
 
 		if ( $this->wg->User->isLoggedIn() && !$this->wg->User->isAllowed( 'createaccount' ) ) {
 			$this->forward( 'UserLoginSpecialController', 'loggedIn' );
+		} elseif ( $this->request->getBool( 'sendConfirmationEmail' ) ) {
+			$this->forward( __CLASS__, 'sendConfirmationEmail' );
 		} else {
 			$this->forward( __CLASS__, 'signupForm' );
 		}
@@ -181,7 +183,7 @@ class UserSignupSpecialController extends WikiaSpecialPageController {
 				 * end remove
 				 */
 				$params = [
-					'method' => 'sendConfirmationEmail',
+					'sendConfirmationEmail' => true,
 					'username' => $this->username,
 					'byemail' => intval( $this->byemail ),
 				];


### PR DESCRIPTION
Controller and method names can no longer be set in the request for
special page controllers, so instead passing a separate parameter to
forward to the necessary method.

/cc @owend @jsutterfield
