### PR TITLE
SOC-1619 User::newFromSession doesn't really work any more

### DIFF
--- a/extensions/wikia/WikiaApi/WikiaApiQuery.php
+++ b/extensions/wikia/WikiaApi/WikiaApiQuery.php
@@ -57,7 +57,7 @@ class WikiaApiQuery extends ApiQueryBase {
      */
 	public function __construct($query, $moduleName) {
 		$this->mAction = $query->getModuleName();
-		$this->mUser = User::newFromSession();
+		$this->mUser = $this->getContext()->getUser();
 		$this->mBrowser = $this->getUniqueBrowserId();
 		$this->mIndexTagName = 'item';
 		parent :: __construct($query, $moduleName, "wk");


### PR DESCRIPTION
The current auth code requires the access token be correct, but newFromSession doesn't set that.  So, this code:

``` php
$u = User::newFromSession();
$u->getId();
```

Will trigger a `User::loadFromSession` which will hit an auth check that will not find the token it wants.  This in turn sets all the log out cookies.

https://wikia-inc.atlassian.net/browse/SOC-1619
