### PR TITLE
DifferenceEngine performance improvements

### DIFF
--- a/includes/Article.php
+++ b/includes/Article.php
@@ -735,6 +735,8 @@ class Article extends Page {
 	public function showDiffPage() {
 		global $wgRequest, $wgUser;
 
+		Transaction::setAttribute( Transaction::PARAM_ACTION, 'diff' ); # Wikia change
+
 		$diff = $wgRequest->getVal( 'diff' );
 		$rcid = $wgRequest->getVal( 'rcid' );
 		$diffOnly = $wgRequest->getBool( 'diffonly', $wgUser->getGlobalPreference( 'diffonly' ) );

--- a/includes/Feed.php
+++ b/includes/Feed.php
@@ -384,7 +384,7 @@ class AtomFeed extends ChannelFeed {
 
 	/**
 	 * Output a given item.
-	 * @param $item
+	 * @param $item FeedItem: item to be output
 	 */
 	function outItem( $item ) {
 		global $wgMimeType;

--- a/includes/diff/DifferenceEngine.php
+++ b/includes/diff/DifferenceEngine.php
@@ -736,6 +736,13 @@ class DifferenceEngine extends ContextSource {
 			return $text;
 		}
 		if ( $wgExternalDiffEngine != 'wikidiff3' && $wgExternalDiffEngine !== false ) {
+			# Wikia change - begin
+			# PLATFORM-1668: log fallback to external diff engine
+			Wikia\Logger\WikiaLogger::instance()->warning( 'External diff engine used', [
+				'engine' => $wgExternalDiffEngine
+			] );
+			# Wikia change - end
+
 			# Diff via the shell
 			global $wgTmpDirectory;
 			$tempName1 = tempnam( $wgTmpDirectory, 'diff_' );
@@ -765,6 +772,11 @@ class DifferenceEngine extends ContextSource {
 			wfProfileOut( __METHOD__ );
 			return $difftext;
 		}
+
+		# Wikia change - begin
+		# PLATFORM-1668: it's better to fail early then use a heavy diff generator as a fallback
+		throw new WikiaException( "Diff engine fallback to PHP prevented" );
+		# Wikia change - end
 
 		# Native PHP diff
 		$ota = explode( "\n", $wgContLang->segmentForDiff( $otext ) );

--- a/includes/wikia/transaction/TransactionClassifier.php
+++ b/includes/wikia/transaction/TransactionClassifier.php
@@ -19,6 +19,7 @@ class TransactionClassifier {
 		'view',
 		'edit',
 		'submit',
+		'diff',
 	);
 
 	protected static $FILTER_SPECIAL_PAGES = array(

--- a/includes/wikia/transaction/tests/TransactionClassifierTest.php
+++ b/includes/wikia/transaction/tests/TransactionClassifierTest.php
@@ -103,6 +103,15 @@ class TransactionClassifierTest extends WikiaBaseTest {
 				],
 				'expectedName' => 'api/nirvana/ImageServing'
 			],
+			[
+				'attributes' => [
+					Transaction::PARAM_ENTRY_POINT => Transaction::ENTRY_POINT_PAGE,
+					Transaction::PARAM_NAMESPACE => NS_MAIN,
+					Transaction::PARAM_ACTION => 'diff',
+					Transaction::PARAM_SKIN => 'foo-skin',
+				],
+				'expectedName' => 'page/main/diff'
+			],
 		];
 	}
 }


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-1668
- log fallback to external diff engine (run via `wfShellExec`)
- prevent (by throwing `WikiaException` - it will be logged and detected by Jira Reporter) fallback to PHP-powered diff engine that simply burns the server
- report diff pages as `page/main/diff` transactions to be able to catch similar problems in the future way faster

@michalroszka / @wladekb 
