### PR TITLE
(CE-2942) Enable word wrap in the Ace editor by default

### DIFF
--- a/extensions/wikia/EditPageLayout/js/editor/AceEditor.js
+++ b/extensions/wikia/EditPageLayout/js/editor/AceEditor.js
@@ -57,6 +57,7 @@ define(
 	 */
 	function initOptions() {
 		var options = {
+			wrap: true,
 			showPrintMargin: false,
 			fontFamily: 'Monaco, Menlo, Ubuntu Mono, Consolas, source-code-pro, monospace'
 		};


### PR DESCRIPTION
Enable word wrap in the ace editor by default by setting the default
option.

/cc @Wikia/community-engineering 
