### PR TITLE
DatabaseBase: improve SHOW PROCESSLIST debugging

### DIFF
--- a/includes/db/Database.php
+++ b/includes/db/Database.php
@@ -920,6 +920,18 @@ abstract class DatabaseBase implements DatabaseType {
 			$userName = str_replace( '/', '', $userName );
 		} else {
 			$userName = '';
+
+			# Wikia change - if the user object is not ready yet, show the client IP (see PLATFORM-1671 for examples)
+			global $wgRequest;
+			if ( $wgRequest instanceof WebRequest ) {
+				$userName = $wgRequest->getIP();
+			}
+		}
+
+		# Wikia change - log the name of the maintenance class that run this query (instead of 127.0.0.1)
+		global $maintClass;
+		if ( !empty( $maintClass ) ) {
+			$userName = str_replace( '/', '', $maintClass );
 		}
 
 		# Wikia change - begin


### PR DESCRIPTION
- show client IP address if the `$wgUser` object is not ready yet (use `$wgRequest`)
- show maintenance script class name when running in CLI mode (instead of `127.0.0.1`)

Compare:

``` sql
Query wikicities (8) (slave): SELECT /* AvatarsMigrator::execute AvatarsMigrator */  user_id AS id  FROM `user`   ORDER BY user_id 
```

vs

``` sql
Query wikicities (8) (slave): SELECT /* AvatarsMigrator::execute 127.0.0.1 */  user_id AS id  FROM `user`   ORDER BY user_id 
```

This should help us when debugging DB performance issues using `SHOW PROCESSLIST`

@drozdo / @wladekb / @michalroszka 
