### PR TITLE
Transactions more context for maintenance scripts

### DIFF
--- a/includes/wikia/transaction/Transaction.php
+++ b/includes/wikia/transaction/Transaction.php
@@ -39,6 +39,7 @@ class Transaction {
 	const PARAM_WIKI = 'wiki';
 	const PARAM_DPL = 'dpl';
 	const PARAM_AB_PERFORMANCE_TEST = 'perf_test';
+	const PARAM_MAINTENANCE_SCRIPT = 'maintenance_script';
 
 	const PSEUDO_PARAM_TYPE = 'type';
 

--- a/includes/wikia/transaction/TransactionClassifier.php
+++ b/includes/wikia/transaction/TransactionClassifier.php
@@ -136,6 +136,10 @@ class TransactionClassifier {
 			case Transaction::ENTRY_POINT_API:
 				$this->addByList( Transaction::PARAM_API_ACTION, self::$FILTER_API_CALLS );
 				break;
+			// MediaWiki maintenance scripts
+			case Transaction::ENTRY_POINT_MAINTENANCE:
+				$this->add( Transaction::PARAM_MAINTENANCE_SCRIPT );
+				break;
 		}
 	}
 

--- a/includes/wikia/transaction/tests/TransactionClassifierTest.php
+++ b/includes/wikia/transaction/tests/TransactionClassifierTest.php
@@ -112,6 +112,19 @@ class TransactionClassifierTest extends WikiaBaseTest {
 				],
 				'expectedName' => 'page/main/diff'
 			],
+			[
+				'attributes' => [
+					Transaction::PARAM_ENTRY_POINT => Transaction::ENTRY_POINT_MAINTENANCE,
+				],
+				'expectedName' => 'maintenance'
+			],
+			[
+				'attributes' => [
+					Transaction::PARAM_ENTRY_POINT => Transaction::ENTRY_POINT_MAINTENANCE,
+					Transaction::PARAM_MAINTENANCE_SCRIPT => 'EventsCleanup',
+				],
+				'expectedName' => 'maintenance/EventsCleanup'
+			],
 		];
 	}
 }

--- a/maintenance/doMaintenance.php
+++ b/maintenance/doMaintenance.php
@@ -109,6 +109,7 @@ if ( $wgProfiler instanceof Profiler ) {
 	}
 }
 Transaction::setEntryPoint(Transaction::ENTRY_POINT_MAINTENANCE);
+Transaction::setAttribute(Transaction::PARAM_MAINTENANCE_SCRIPT, $maintClass);
 // Wikia change - end
 
 if ( $maintenance->getDbType() === Maintenance::DB_ADMIN &&


### PR DESCRIPTION
When working on [PLATFORM-1648](https://wikia-inc.atlassian.net/browse/PLATFORM-1648) I've noticed that there's a huge difference between p50 and p95 of request times for maintenance scripts (they're obviously the slowest ones for 95th percentile):

```
> The slowest transactions (50 rows)
-----------------------------------------------------------------------------------------------------------------------------
 95th pct req t [ms]    Method                                                                                      Requests
-----------------------------------------------------------------------------------------------------------------------------
           31,181.74    maintenance                                                                                27,293.00


> The slowest transactions (50 rows)
-----------------------------------------------------------------------------------------------------------------------------
Median req time [ms]    Method                                                                                      Requests
-----------------------------------------------------------------------------------------------------------------------------
              ...
              232.30    maintenance                                                                                27,293.00
```

Report maintenance script as a separate transactions in the form of `maintenance/<maintance script name>`.

@wladekb / @jcellary 
