### PR TITLE
SEO-151 One <h1> per page

### DIFF
--- a/extensions/wikia/Spotlights/SpotlightsController.class.php
+++ b/extensions/wikia/Spotlights/SpotlightsController.class.php
@@ -1,8 +1,5 @@
 <?php
 class SpotlightsController extends WikiaController {
 	public function index() {
-		if ( $this->wg->EnableSeoTestingExt ) {
-			$this->setVal( 'seoTestOneH1', SeoTesting::getGroup('One_H1') === 2 );
-		}
 	}
 }

--- a/extensions/wikia/Spotlights/templates/Spotlights_Index.php
+++ b/extensions/wikia/Spotlights/templates/Spotlights_Index.php
@@ -1,7 +1,7 @@
 <? if (!$wg->NoExternals && !$wg->SuppressSpotlights) { ?>
 <section>
 	<div class="header-container">
-		<h1><?= wfMsg('oasis-spotlights-footer-title') ?></h1>
+		<h2><?= wfMsg('oasis-spotlights-footer-title') ?></h2>
 		<?= F::app()->renderView('RandomWiki', 'Index') ?>
 	</div>
 	<script type='text/javascript'>

--- a/extensions/wikia/Spotlights/templates/Spotlights_Index.php
+++ b/extensions/wikia/Spotlights/templates/Spotlights_Index.php
@@ -1,11 +1,7 @@
 <? if (!$wg->NoExternals && !$wg->SuppressSpotlights) { ?>
 <section>
 	<div class="header-container">
-		<? if ( $seoTestOneH1 ): ?>
-			<h2><?= wfMsg('oasis-spotlights-footer-title') ?></h2>
-		<? else: ?>
-			<h1><?= wfMsg('oasis-spotlights-footer-title') ?></h1>
-		<? endif; ?>
+		<h1><?= wfMsg('oasis-spotlights-footer-title') ?></h1>
 		<?= F::app()->renderView('RandomWiki', 'Index') ?>
 	</div>
 	<script type='text/javascript'>

--- a/skins/oasis/css/core/Footer.scss
+++ b/skins/oasis/css/core/Footer.scss
@@ -115,7 +115,7 @@
 	}
 	.header-container {
 		@include clearfix;
-		h1 {
+		h2 {
 			font-size: 18px;
 			float: left;
 			margin:17px 0 17px 20px;

--- a/skins/oasis/css/core/Footer.scss
+++ b/skins/oasis/css/core/Footer.scss
@@ -120,12 +120,6 @@
 			float: left;
 			margin:17px 0 17px 20px;
 		}
-		h2 {
-			// SEO Test "One_H1"
-			font-size: 18px;
-			float: left;
-			margin:17px 0 17px 20px;
-		}
 		.wikia-button {
 			float: right;
 			margin:17px 20px;

--- a/skins/oasis/css/core/WikiHeader.scss
+++ b/skins/oasis/css/core/WikiHeader.scss
@@ -50,7 +50,7 @@ $WikiNavWidth: $width-outside - 271px;
 		width: $WikiNavWidth - 155px /* 155px is a spacing for contribute button (BugId:12490) */;
 		z-index: 3;
 
-		>h1 {
+		>h2 {
 			display: none;
 		}
 

--- a/skins/oasis/css/core/WikiHeader.scss
+++ b/skins/oasis/css/core/WikiHeader.scss
@@ -54,11 +54,6 @@ $WikiNavWidth: $width-outside - 271px;
 			display: none;
 		}
 
-		> h2 {
-			// SEO Test "One_H1"
-			display: none;
-		}
-
 		>ul {
 			@include clearfix;
 			position: relative;

--- a/skins/oasis/css/core/body.scss
+++ b/skins/oasis/css/core/body.scss
@@ -11,7 +11,7 @@ body {
 	padding: 0 0 30px 0;
 }
 
-.WikiaSiteWrapper > h1 {
+.WikiaSiteWrapper > h2 {
 	display: none;
 }
 

--- a/skins/oasis/css/core/body.scss
+++ b/skins/oasis/css/core/body.scss
@@ -15,11 +15,6 @@ body {
 	display: none;
 }
 
-.WikiaSiteWrapper > h2 {
-	// SEO Test "One_H1"
-	display: none;
-}
-
 a {
 	color: $color-links;
 	text-decoration: none;

--- a/skins/oasis/modules/BodyController.class.php
+++ b/skins/oasis/modules/BodyController.class.php
@@ -500,10 +500,6 @@ class BodyController extends WikiaController {
 		// bugid-70243: optionally hide navigation h1s for SEO
 		$this->setVal( 'displayHeader', !$this->wg->HideNavigationHeaders );
 
-		if ( $this->wg->EnableSeoTestingExt ) {
-			$this->setVal( 'seoTestOneH1', SeoTesting::getGroup('One_H1') === 2 );
-		}
-
 		wfProfileOut(__METHOD__);
 	}
 

--- a/skins/oasis/modules/WikiHeaderController.class.php
+++ b/skins/oasis/modules/WikiHeaderController.class.php
@@ -37,10 +37,6 @@ class WikiHeaderController extends WikiaController {
 		$this->displaySearch = !empty($this->wg->EnableAdminDashboardExt) && AdminDashboardLogic::displayAdminDashboard($this, $this->wg->Title);
 		$this->setVal( 'displayHeader', !$this->wg->HideNavigationHeaders );
 		$this->displayHeaderButtons = !WikiaPageType::isWikiaHubMain();
-
-		if ( $this->wg->EnableSeoTestingExt ) {
-			$this->setVal( 'seoTestOneH1', SeoTesting::getGroup('One_H1') === 2 );
-		}
 	}
 
 	public function executeWordmark() {
@@ -73,9 +69,5 @@ class WikiHeaderController extends WikiaController {
 		}
 
 		$this->mainPageURL = Title::newMainPage()->getLocalURL();
-
-		if ( $this->wg->EnableSeoTestingExt ) {
-			$this->setVal( 'seoTestOneH1', SeoTesting::getGroup('One_H1') === 2 );
-		}
 	}
 }

--- a/skins/oasis/modules/templates/Body_Index.php
+++ b/skins/oasis/modules/templates/Body_Index.php
@@ -1,9 +1,5 @@
 <? if ( $displayHeader ): ?>
-	<? if ( $seoTestOneH1 ): ?>
-		<h2><?= wfMsg( 'oasis-global-page-header' ); ?></h2>
-	<? else: ?>
-		<h1><?= wfMsg( 'oasis-global-page-header' ); ?></h1>
-	<? endif; ?>
+	<h2><?= wfMsg( 'oasis-global-page-header' ); ?></h2>
 <? endif; ?>
 <div class="skiplinkcontainer">
 <a class="skiplink" rel="nofollow" href="#WikiaArticle"><?= wfMsg( 'oasis-skip-to-content' ); ?></a>

--- a/skins/oasis/modules/templates/WikiHeader_Index.php
+++ b/skins/oasis/modules/templates/WikiHeader_Index.php
@@ -2,11 +2,7 @@
 	<?= $app->renderView( 'WikiHeader', 'Wordmark' ) ?>
 	<nav class="WikiNav">
 		<? if ( $displayHeader ): ?>
-			<? if ( $seoTestOneH1 ): ?>
-				<h2><?= wfMessage( 'oasis-wiki-navigation', $wordmarkText )->escaped() ?></h2>
-			<? else: ?>
-				<h1><?= wfMessage( 'oasis-wiki-navigation', $wordmarkText )->escaped() ?></h1>
-			<? endif; ?>
+			<h1><?= wfMsg( 'oasis-wiki-navigation', $wordmarkText )->escaped() ?></h1>
 		<? endif; ?>
 		<?= $app->renderView( 'WikiNavigation', 'Index' ) ?>
 	</nav>

--- a/skins/oasis/modules/templates/WikiHeader_Index.php
+++ b/skins/oasis/modules/templates/WikiHeader_Index.php
@@ -2,7 +2,7 @@
 	<?= $app->renderView( 'WikiHeader', 'Wordmark' ) ?>
 	<nav class="WikiNav">
 		<? if ( $displayHeader ): ?>
-			<h1><?= wfMsg( 'oasis-wiki-navigation', $wordmarkText )->escaped() ?></h1>
+			<h2><?= wfMessage( 'oasis-wiki-navigation', $wordmarkText )->escaped() ?></h2>
 		<? endif; ?>
 		<?= $app->renderView( 'WikiNavigation', 'Index' ) ?>
 	</nav>

--- a/skins/oasis/modules/templates/WikiHeader_Wordmark.php
+++ b/skins/oasis/modules/templates/WikiHeader_Wordmark.php
@@ -1,4 +1,4 @@
-<h1 class="wordmark <?= $wordmarkSize ?> <?= $wordmarkType ?> <?= $wordmarkFontClass ?>">
+<h2 class="wordmark <?= $wordmarkSize ?> <?= $wordmarkType ?> <?= $wordmarkFontClass ?>">
 	<a accesskey="z" href="<?= htmlspecialchars($mainPageURL) ?>">
 		<? if (!empty($wordmarkUrl)) { ?>
 			<img src="<?= $wordmarkUrl ?>" alt="<?= htmlspecialchars($wordmarkText) ?>" <? if (!empty($wordmarkStyle)) { ?><?= $wordmarkStyle ?><? } ?>>
@@ -6,4 +6,4 @@
 			<?= htmlspecialchars($wordmarkText) ?>
 		<? } ?>
 	</a>
-</h1>
+</h2>

--- a/skins/oasis/modules/templates/WikiHeader_Wordmark.php
+++ b/skins/oasis/modules/templates/WikiHeader_Wordmark.php
@@ -1,21 +1,9 @@
-<? if ( $seoTestOneH1 ): ?>
-	<h2 class="wordmark <?= $wordmarkSize ?> <?= $wordmarkType ?> <?= $wordmarkFontClass ?>">
-		<a accesskey="z" href="<?= htmlspecialchars($mainPageURL) ?>">
-			<? if (!empty($wordmarkUrl)) { ?>
-				<img src="<?= $wordmarkUrl ?>" alt="<?= htmlspecialchars($wordmarkText) ?>" <? if (!empty($wordmarkStyle)) { ?><?= $wordmarkStyle ?><? } ?>>
-			<? } else { ?>
-				<?= htmlspecialchars($wordmarkText) ?>
-			<? } ?>
-		</a>
-	</h2>
-<? else: ?>
-	<h1 class="wordmark <?= $wordmarkSize ?> <?= $wordmarkType ?> <?= $wordmarkFontClass ?>">
-		<a accesskey="z" href="<?= htmlspecialchars($mainPageURL) ?>">
-			<? if (!empty($wordmarkUrl)) { ?>
-				<img src="<?= $wordmarkUrl ?>" alt="<?= htmlspecialchars($wordmarkText) ?>" <? if (!empty($wordmarkStyle)) { ?><?= $wordmarkStyle ?><? } ?>>
-			<? } else { ?>
-				<?= htmlspecialchars($wordmarkText) ?>
-			<? } ?>
-		</a>
-	</h1>
-<? endif; ?>
+<h1 class="wordmark <?= $wordmarkSize ?> <?= $wordmarkType ?> <?= $wordmarkFontClass ?>">
+	<a accesskey="z" href="<?= htmlspecialchars($mainPageURL) ?>">
+		<? if (!empty($wordmarkUrl)) { ?>
+			<img src="<?= $wordmarkUrl ?>" alt="<?= htmlspecialchars($wordmarkText) ?>" <? if (!empty($wordmarkStyle)) { ?><?= $wordmarkStyle ?><? } ?>>
+		<? } else { ?>
+			<?= htmlspecialchars($wordmarkText) ?>
+		<? } ?>
+	</a>
+</h1>


### PR DESCRIPTION
Following experiment conducted in SEO-3 and after confirming there's no negative impact of having just one `<h1>` tag on each page (for the article title, usually matching the `<title>` tag), we're making the changes persistent, converting all the additional `<h1>` tags to `<h2>`.
