### PR TITLE
Replace deprecated validateJSDoc rule with jsDoc rule

### DIFF
--- a/.jscs.json
+++ b/.jscs.json
@@ -36,7 +36,7 @@
 	"requireCapitalizedConstructors": true,
 	"safeContextKeyword": "self",
 	"requireDotNotation": true,
-	"validateJSDoc": {
+	"jsDoc": {
 		"checkParamNames": true,
 		"checkRedundantParams": true,
 		"requireParamTypes": true


### PR DESCRIPTION
Replace deprecated validateJSDoc rule with jsDoc rule: http://jscs.info/rule/jsDoc.html
