### PR TITLE
DataProvider::GetTopFiveUsers - disable in Reston

### DIFF
--- a/extensions/wikia/DataProvider/DataProvider.php
+++ b/extensions/wikia/DataProvider/DataProvider.php
@@ -436,6 +436,14 @@ class DataProvider {
 	 * @return array
 	 */
 	final public static function GetTopFiveUsers($limit = 7) {
+		global $wgDBReadOnly;
+
+		# PLATFORM-1648: running queries on events_local_users in Reston takes ages
+		if ( !empty( $wgDBReadOnly ) ) {
+			wfDebug( __METHOD__ . " disabled\n" );
+			return [];
+		}
+
 		wfProfileIn(__METHOD__);
 
 		$fname = __METHOD__;

--- a/includes/db/Database.php
+++ b/includes/db/Database.php
@@ -204,6 +204,9 @@ abstract class DatabaseBase implements DatabaseType {
 	// @const log 1% of queries
 	const QUERY_SAMPLE_RATE = 0.01;
 
+	// @const log queries that took more than 15 seconds
+	const SLOW_QUERY_LOG_THRESHOLD = 15;
+
 	protected $sampler = null;
 
 # ------------------------------------------------------------------------------
@@ -3731,17 +3734,25 @@ abstract class DatabaseBase implements DatabaseType {
 			$num_rows = false;
 		}
 
+		$context = [
+			'method'      => $fname,
+			'elapsed'     => $elapsedTime,
+			'num_rows'    => $num_rows,
+			'cluster'     => $wgDBcluster,
+			'server'      => $this->mServer,
+			'server_role' => $isMaster ? 'master' : 'slave',
+			'db_name'     => $this->mDBname,
+			'exception'   => new Exception(), // log the backtrace
+		];
+
 		if ( $this->getSampler()->shouldSample() ) {
-			$this->getWikiaLogger()->info( "SQL $sql", [
-				'method'      => $fname,
-				'elapsed'     => $elapsedTime,
-				'num_rows'    => $num_rows,
-				'cluster'     => $wgDBcluster,
-				'server'      => $this->mServer,
-				'server_role' => $isMaster ? 'master' : 'slave',
-				'db_name'     => $this->mDBname,
-				'exception'   => new Exception(), // log the backtrace
-			] );
+			$this->getWikiaLogger()->info( "SQL {$sql}", $context );
+		}
+
+		# PLATFORM-1648: 1% sampling does not really catch spikes of slow DB queries
+		# e.g. queries on events_local_users via DataProvider::GetTopFiveUsers
+		if ( $elapsedTime > self::SLOW_QUERY_LOG_THRESHOLD ) {
+			$this->getWikiaLogger()->info( "Slow query {$sql}", $context );
 		}
 	}
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-1648

Average query time (selects on `events_local_users` table) is at ~8 seconds in Reston.

Additionally log slow queries (that took more than 15 seconds) without sampling - the average query time form sampled log did not provide much value here

@wladekb / @michalroszka 
