### PR TITLE
PLATFORM-1594 improve query efficiency inside of WallNotifications::g…

### DIFF
--- a/extensions/wikia/WallNotifications/WallNotifications.class.php
+++ b/extensions/wikia/WallNotifications/WallNotifications.class.php
@@ -984,30 +984,18 @@ class WallNotifications {
 		// for many notifications we want to make sure we 50 notifications from different pages hance distinct
 		$db = $this->getDB( $useMaster );
 		$res = $db->select(
-			[ 'wn1' => 'wall_notification', 'wn2' => 'wall_notification' ],
-			[ 'wn1.unique_id' ],
+			'wall_notification',
+			'unique_id' ,
 			[
-				'wn1.user_id' => $userId,
-				'wn1.wiki_id' => $wikiId,
-				'wn1.is_hidden' => 0,
-				'wn2.id' => null
+				'user_id' => $userId,
+				'wiki_id' => $wikiId,
+				'is_hidden' => 0,
 			],
 			__METHOD__,
 			[
+				'DISTINCT',
 				'LIMIT' => '50',
-				'ORDER BY' => 'wn1.id DESC'
-			],
-			[
-				'wn2' => [
-					'LEFT JOIN',
-					[
-						'wn1.user_id = wn2.user_id',
-						'wn1.wiki_id = wn2.wiki_id',
-						'wn1.is_hidden = wn2.is_hidden',
-						'wn1.unique_id = wn2.unique_id',
-						'wn2.id < wn1.id'
-					]
-				],
+				'ORDER BY' => 'unique_id'
 			]
 		);
 


### PR DESCRIPTION
…etBackupData

Ticket: https://wikia-inc.atlassian.net/browse/PLATFORM-1594

`WallNotifications::getBackupData` has been causing issues with our databases, almost bringing down the site the last time it spiked. One of the queries it executes is long and convoluted:

``` SQL
SELECT wn1.unique_id  FROM `wall_notification` `wn1`
LEFT JOIN `wall_notification` `wn2` ON (
    (wn1.user_id = wn2.user_id)
    AND (wn1.wiki_id = wn2.wiki_id)
    AND (wn1.is_hidden = wn2.is_hidden)
    AND (wn1.unique_id = wn2.unique_id)
    AND (wn2.id < wn1.id))
WHERE wn1.user_id = '25126627' 
AND wn1.wiki_id = '453462'
AND wn1.is_hidden = '0'
AND wn2.id IS NULL
ORDER BY wn1.id DESC
LIMIT 50;
```

Basically what this is doing is finding all pages (aka, unique_ids) that a user has a notification on. It takes that list and finds the oldest notification on that page, and then orders that list with newest to oldest.

With some tweaks, this can be simplified greatly as a straightforward distinct.

``` SQL
SELECT DISTINCT unique_id
FROM wall_notification
WHERE user_id = '25126627'
AND wiki_id = '453462'
AND is_hidden = '0' 
ORDER BY unique_id DESC
limit 50;
```

This updated query runs about 5 times faster than the old one:

``` SQL
mysql@slave.db-archive.service.consul[dataware]>show profiles\G
*************************** 1. row ***************************
Query_ID: 1
Duration: 0.00498200
   Query: SELECT wn1.unique_id  FROM `wall_notification` `wn1`
LEFT JOIN `wall_notification` `wn2` ON (
    (wn1.user_id = wn2.user_id)
    AND (wn1.wiki_id = wn2.wiki_id)
    AND (wn1.is_hidden = wn2.is_hidden)
    AND (wn1.unique_id = wn2.unique_id)
    AND (wn2.id < wn1.id))
WHERE wn1.user_id = '25126627'
*************************** 2. row ***************************
Query_ID: 2
Duration: 0.00097850
   Query: SELECT DISTINCT unique_id
FROM wall_notification
WHERE user_id = '25126627'
AND wiki_id = '453462'
AND is_hidden = '0'
ORDER BY unique_id DESC
limit 50
************
```

This solution isn't 100%, but it's pretty close. Since we are no longer sorting by `id` but rather by `unique_id`, the result sets are different. In the example queries above the updated query lacked 6 results from the original. Garth looked into what kind of effect this would have, and in the `wall_notification` table there are 2,655,471 user, wiki combinations. Of those, 77,688 have more than 50 distinct unique_ids per that combo. Which it could affect around 3% of users.

Given the last time this spiked it got close to bringing down the site, and that these notifications are going to be replaced by the notification service which is actively being worked on, this just serves as a temporary measure to add to site stability until notifications are replaced.
