### PR TITLE
(CE-3037) Hide templates classified as notice in Mercury

### DIFF
--- a/includes/wikia/parser/templatetypes/TemplateTypesParser.class.php
+++ b/includes/wikia/parser/templatetypes/TemplateTypesParser.class.php
@@ -22,6 +22,9 @@ class TemplateTypesParser {
 				case TemplateClassificationService::TEMPLATE_NAVBOX:
 					$text = self::handleNavboxTemplate();
 					break;
+				case TemplateClassificationService::TEMPLATE_FLAG:
+					$text = self::handleNoticeTemplate();
+					break;
 				case AutomaticTemplateTypes::TEMPLATE_REFERENCES:
 				case TemplateClassificationService::TEMPLATE_REFERENCES:
 					$text = self::handleReferencesTemplate();
@@ -111,7 +114,7 @@ class TemplateTypesParser {
 		//remove all bold and italics from all of template content
 		$wikitext = preg_replace( '/\'{2,}/', '', $wikitext );
 		//remove all headings from all of template content
-		$wikitext = self::removeHeadings($wikitext);
+		$wikitext = self::removeHeadings( $wikitext );
 		//remove all newlines from the middle of the template text.
 		$wikitext = preg_replace( '/\n/', ' ', $wikitext );
 
@@ -152,6 +155,15 @@ class TemplateTypesParser {
 	 * @return string
 	 */
 	private static function handleNavboxTemplate() {
+		return '';
+	}
+
+	/**
+	 * @desc return skip rendering notice template
+	 *
+	 * @return string
+	 */
+	private static function handleNoticeTemplate() {
 		return '';
 	}
 

--- a/includes/wikia/parser/templatetypes/tests/TemplateTypesParserTest.php
+++ b/includes/wikia/parser/templatetypes/tests/TemplateTypesParserTest.php
@@ -1,7 +1,6 @@
 <?php
 
-class TemplateTypesParserTest extends WikiaBaseTest
-{
+class TemplateTypesParserTest extends WikiaBaseTest {
 	const TEST_TEMPLATE_TEXT = 'test-template-test';
 
 	/**
@@ -10,8 +9,7 @@ class TemplateTypesParserTest extends WikiaBaseTest
 	 *
 	 * @dataProvider shouldNotChangeTemplateParsingDataProvider
 	 */
-	public function testShouldNotChangeTemplateParsing( $enableTemplateTypesParsing, $wgArticleAsJson )
-	{
+	public function testShouldNotChangeTemplateParsing( $enableTemplateTypesParsing, $wgArticleAsJson ) {
 		$text = self::TEST_TEMPLATE_TEXT;
 		$title = $this->getMock( 'Title' );
 
@@ -75,6 +73,10 @@ class TemplateTypesParserTest extends WikiaBaseTest
 		return [
 			[
 				'navbox',
+				''
+			],
+			[
+				'notice',
 				''
 			],
 			[


### PR DESCRIPTION
In addition to navboxes, also hide templates classified as notice in
Mercury.

/cc @Wikia/community-engineering @SebastianMarzjan 
