### PR TITLE
PLATFORM-1648 add index hints to queries on specials DB

### DIFF
--- a/extensions/wikia/DataProvider/DataProvider.php
+++ b/extensions/wikia/DataProvider/DataProvider.php
@@ -470,7 +470,8 @@ class DataProvider {
 				$fname,
 				[
 					'LIMIT' => self::TOP_USERS_MAX_LIMIT * 4,
-					'ORDER BY' => 'edits DESC'
+					'ORDER BY' => 'edits DESC',
+					'USE INDEX' => 'PRIMARY', # mysql in Reston wants to use a different key (PLATFORM-1648)
 				]
 			);
 

--- a/extensions/wikia/DataProvider/DataProvider.php
+++ b/extensions/wikia/DataProvider/DataProvider.php
@@ -436,14 +436,6 @@ class DataProvider {
 	 * @return array
 	 */
 	final public static function GetTopFiveUsers($limit = 7) {
-		global $wgDBReadOnly;
-
-		# PLATFORM-1648: running queries on events_local_users in Reston takes ages
-		if ( !empty( $wgDBReadOnly ) ) {
-			wfDebug( __METHOD__ . " disabled\n" );
-			return [];
-		}
-
 		wfProfileIn(__METHOD__);
 
 		$fname = __METHOD__;

--- a/includes/wikia/services/WikiService.class.php
+++ b/includes/wikia/services/WikiService.class.php
@@ -250,7 +250,11 @@ class WikiService extends WikiaModel {
 					array( 'user_id', 'edits', 'all_groups' ),
 					array( 'wiki_id' => $wikiId, 'edits != 0' ),
 					$fname,
-					array( 'ORDER BY' => 'edits desc', 'LIMIT' => static::TOPUSER_LIMIT )
+					array(
+						'ORDER BY' => 'edits desc',
+						'LIMIT' => static::TOPUSER_LIMIT,
+						'USE INDEX' => 'PRIMARY', # mysql in Reston wants to use a different key (PLATFORM-1648)
+					)
 				);
 
 				while( $row = $db->fetchObject($result) ) {


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-1648
### Problem

MySQL in Reston makes a bit different decisions on which index to use when compared with SJC.

This hits the performance of `DataProvider::GetTopFiveUsers` and `WikiService::getTopEditors` creating spikes and roller coaster syndrome in NewRelic 
### Solution

Force the primary index in two above queries.

This partially reverts #9046 

@drozdo / @michalroszka 
