### PR TITLE
TransactionClassifier: a separate transaction for Wall and Forum

### DIFF
--- a/includes/wikia/transaction/TransactionClassifier.php
+++ b/includes/wikia/transaction/TransactionClassifier.php
@@ -14,6 +14,14 @@ class TransactionClassifier {
 	// copied from extensions/wikia/Wall/WallNamespaces.php to use a constant below
 	// while not being dependant on Wall extension inclusion
 	const NS_USER_WALL = 1200;
+	const NS_USER_WALL_MESSAGE = 1201;
+	const NS_USER_WALL_MESSAGE_GREETING = 1202;
+
+	// copied from extensions/wikia/Forum/ForumNamespaces.php to use a constant below
+	// while not being dependant on Forum extension inclusion
+	const NS_WIKIA_FORUM_BOARD = 2000;
+	const NS_WIKIA_FORUM_BOARD_THREAD = 2001;
+	const NS_WIKIA_FORUM_TOPIC_BOARD = 2002;
 
 	protected static $FILTER_ARTICLE_ACTIONS = array(
 		'view',
@@ -57,7 +65,14 @@ class TransactionClassifier {
 		NS_MAIN => 'main',
 		NS_FILE => 'file',
 		NS_CATEGORY => 'category',
+
 		self::NS_USER_WALL => 'message_wall',
+		self::NS_USER_WALL_MESSAGE => 'message_wall',
+		self::NS_USER_WALL_MESSAGE_GREETING => 'message_wall',
+
+		self::NS_WIKIA_FORUM_BOARD => 'forum',
+		self::NS_WIKIA_FORUM_BOARD_THREAD => 'forum',
+		self::NS_WIKIA_FORUM_TOPIC_BOARD => 'forum',
 	);
 
 	protected static $MAP_PARSER_CACHED_USED = array(

--- a/includes/wikia/transaction/tests/TransactionClassifierTest.php
+++ b/includes/wikia/transaction/tests/TransactionClassifierTest.php
@@ -125,6 +125,21 @@ class TransactionClassifierTest extends WikiaBaseTest {
 				],
 				'expectedName' => 'maintenance/EventsCleanup'
 			],
+			# Wall / Forum
+			[
+				'attributes' => [
+					Transaction::PARAM_ENTRY_POINT => Transaction::ENTRY_POINT_PAGE,
+					Transaction::PARAM_NAMESPACE => TransactionClassifier::NS_USER_WALL,
+				],
+				'expectedName' => 'page/message_wall'
+			],
+			[
+				'attributes' => [
+					Transaction::PARAM_ENTRY_POINT => Transaction::ENTRY_POINT_PAGE,
+					Transaction::PARAM_NAMESPACE => TransactionClassifier::NS_WIKIA_FORUM_BOARD,
+				],
+				'expectedName' => 'page/forum'
+			],
 		];
 	}
 }


### PR DESCRIPTION
Wall and Forum requests were ending up in `page/other` transaction (which is the most frequent one). Improve the classification to have more more granular data in NewRelic.

@wladekb 
