### PR TITLE
ADEN-2661 Extending functionality of InstantGlobals URL override

### DIFF
--- a/extensions/wikia/InstantGlobals/js/instantGlobalsOverride.js
+++ b/extensions/wikia/InstantGlobals/js/instantGlobalsOverride.js
@@ -9,3 +9,12 @@ location.search.replace(
 		Wikia.InstantGlobals[b] = c > 0;
 	}
 );
+
+location.search.replace(
+	/InstantGlobals\.(\w+)=\[(.*?)]/g,
+	//Applying all the InstantGlobals.*=Array params
+	//example: ?InstantGlobals.wgAdDriverOpenXBidderCountries=[DE,PL,XX]
+	function (a, b, c) {
+		Wikia.InstantGlobals[b] = c.split(',');
+	}
+);


### PR DESCRIPTION
Currently there is possibility to override instantGlobals via URL, but only for int values. I've added the possiblity of overriding arrays. 
The usage is:

```
?InstantGlobals.variableName=[VAL1,VAL2,VAL3]
(note: values are without quotes or single quotes)
```
