### PR TITLE
(CE-3062) Add missing messages for the context link type

### DIFF
--- a/extensions/wikia/TemplateClassification/TemplateClassification.i18n.php
+++ b/extensions/wikia/TemplateClassification/TemplateClassification.i18n.php
@@ -16,6 +16,9 @@ $messages['en'] = [
 	'template-classification-type-notice' => 'Notice',
 	'template-classification-description-notice' => 'Also known as tophats or alerts, these templates notify the reader about the status of the article itself, such as stub, disambiguation, or spoiler.',
 
+	'template-classification-type-context-link' => 'Context-link',
+	'template-classification-description-context-link' => 'Suggests another page to readers that is related to the current page or section. Usually these include “Main article” or “See also” and display as italicized text.',
+
 	'template-classification-type-reference' => 'Citation or reference',
 	'template-classification-description-reference' => 'Organizes and standardizes how sources of content on an article page are annotated.',
 
@@ -66,6 +69,7 @@ $messages['qqq'] = [
 	'template-classification-type-notice' => 'Name of a notice type',
 	'template-classification-type-reference' => 'Name of a reference type',
 	'template-classification-type-unknown' => 'Name of an unknown template type',
+	'template-classification-type-context-link' => 'Name of the context link type',
 
 	'template-classification-description-infobox' => 'Description (additional label) for the infobox type. This is shown in dialog box under the type name to explain what each type is.',
 	'template-classification-description-navbox' => 'Description (additional label) for the navbox type. This is shown in dialog box under the type name to explain what each type is.',
@@ -78,6 +82,7 @@ $messages['qqq'] = [
 	'template-classification-description-media' => 'Description (additional label) for the media template type. This is shown in dialog box under the type name to explain what each type is.',
 	'template-classification-description-notice' => 'Description (additional label) for the notice template type. This is shown in dialog box under the type name to explain what each type is.',
 	'template-classification-description-reference' => 'Description (additional label) for the reference template type. This is shown in dialog box under the type name to explain what each type is.',
+	'template-classification-description-context-link' => 'Description (additional label) for the context link template type. This is shown in the dialog box under the type name to explain what each type is.',
 
 	'template-classification-type-header' => 'A header of all boxes that display a type of a template.',
 	'template-classification-edit-modal-add-button-text' => 'Text on add button on modal for proceeding to template adding after template type is choose',

--- a/includes/wikia/services/TemplateClassificationService.class.php
+++ b/includes/wikia/services/TemplateClassificationService.class.php
@@ -33,20 +33,24 @@ class TemplateClassificationService {
 
 	/**
 	 * Allowed types of templates stored in an array to make a validation process easier.
+	 *
+	 * The order of types in this array determines the order of the types displayed in the
+	 * classification dialog.
+	 *
 	 * @var array
 	 */
 	static $templateTypes = [
+		self::TEMPLATE_INFOBOX,
+		self::TEMPLATE_QUOTE,
+		self::TEMPLATE_NAVBOX,
+		self::TEMPLATE_FLAG,
 		self::TEMPLATE_CONTEXT_LINK,
+		self::TEMPLATE_REFERENCES,
+		self::TEMPLATE_MEDIA,
 		self::TEMPLATE_DATA,
 		self::TEMPLATE_DESIGN,
-		self::TEMPLATE_FLAG,
-		self::TEMPLATE_INFOBOX,
-		self::TEMPLATE_MEDIA,
 		self::TEMPLATE_NAV,
-		self::TEMPLATE_NAVBOX,
 		self::TEMPLATE_NOT_ART,
-		self::TEMPLATE_QUOTE,
-		self::TEMPLATE_REFERENCES,
 		self::TEMPLATE_UNKNOWN,
 	];
 


### PR DESCRIPTION
Add missing messages for the context link type and reset the order of template
types in the dialog.

/cc @Wikia/community-engineering 
