### PR TITLE
TransactionClassifier: separate transactions from user / user talk pages

### DIFF
--- a/includes/wikia/transaction/TransactionClassifier.php
+++ b/includes/wikia/transaction/TransactionClassifier.php
@@ -63,6 +63,8 @@ class TransactionClassifier {
 
 	protected static $MAP_ARTICLE_NAMESPACES = array(
 		NS_MAIN => 'main',
+		NS_USER => 'user',
+		NS_USER_TALK => 'user_talk',
 		NS_FILE => 'file',
 		NS_CATEGORY => 'category',
 

--- a/includes/wikia/transaction/tests/TransactionClassifierTest.php
+++ b/includes/wikia/transaction/tests/TransactionClassifierTest.php
@@ -140,6 +140,21 @@ class TransactionClassifierTest extends WikiaBaseTest {
 				],
 				'expectedName' => 'page/forum'
 			],
+			# User pages
+			[
+				'attributes' => [
+					Transaction::PARAM_ENTRY_POINT => Transaction::ENTRY_POINT_PAGE,
+					Transaction::PARAM_NAMESPACE => NS_USER,
+				],
+				'expectedName' => 'page/user'
+			],
+			[
+				'attributes' => [
+					Transaction::PARAM_ENTRY_POINT => Transaction::ENTRY_POINT_PAGE,
+					Transaction::PARAM_NAMESPACE => NS_USER_TALK,
+				],
+				'expectedName' => 'page/user_talk'
+			],
 		];
 	}
 }


### PR DESCRIPTION
User talk pages perform heavy queries on `shared_newtalks` shared table causing `page/pther` average to go pretty high. Let's report a separate transaction for user / user talk pages.

@wladekb 
