### PR TITLE
TransactionTraceNewrelic: add custom tracer for Rabbit MQ PHP client

### DIFF
--- a/includes/wikia/transaction/TransactionTraceNewrelic.php
+++ b/includes/wikia/transaction/TransactionTraceNewrelic.php
@@ -1,5 +1,7 @@
 <?php
 
+use Wikia\Util\RequestId;
+
 /**
  * TransactionTraceNewrelic implements the TransactionTrace plugin interface and handles reporting
  * transaction type name as newrelic's transaction name and all attributes as custom parameters.
@@ -23,6 +25,11 @@ class TransactionTraceNewrelic {
 			foreach( self::$customTraces as $customTrace ) {
 				newrelic_add_custom_tracer( $customTrace );
 			}
+		}
+
+		// report request ID as a custom request parameter for easier debugging of slow transactions
+		if ( function_exists( 'newrelic_add_custom_parameter' ) ) {
+			newrelic_add_custom_parameter( 'requestId', RequestId::instance()->getRequestId() );
 		}
 	}
 

--- a/includes/wikia/transaction/TransactionTraceNewrelic.php
+++ b/includes/wikia/transaction/TransactionTraceNewrelic.php
@@ -3,8 +3,28 @@
 /**
  * TransactionTraceNewrelic implements the TransactionTrace plugin interface and handles reporting
  * transaction type name as newrelic's transaction name and all attributes as custom parameters.
+ *
+ * @see https://docs.newrelic.com/docs/agents/php-agent/configuration/php-agent-api
  */
 class TransactionTraceNewrelic {
+
+	// create custom transactions for given PHP calls
+	private static $customTraces = [
+		# PLATFORM-1696: RabbitMQ traffic
+		'Wikia\Tasks\Tasks\BaseTask::queue',
+		'PhpAmqpLib\Wire\IO\StreamIO::read',
+	];
+
+	/**
+	 * Set up NewRelic integration and custom PHP calls tracer
+	 */
+	function __construct() {
+		if ( function_exists( 'newrelic_add_custom_tracer' ) ) {
+			foreach( self::$customTraces as $customTrace ) {
+				newrelic_add_custom_tracer( $customTrace );
+			}
+		}
+	}
 
 	/**
 	 * Update Newrelic's transaction name


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-1696

RabbitMQ timeouts causes page submits to take over 30 seconds. Let's try to use `newrelic_add_custom_tracer` to have some insights on what's going on - performance data for these calls should end up in NewRelic's transaction traces.

And report request ID as a custom parameter.

@wladekb / @SebastianMarzjan 
