### PR TITLE
Fix JSCS after change deprecated validateJSDoc to jsDoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ spamAccountIds.txt
 
 lib/composer/**/.git
 node_modules
+npm-debug.log
 
 # Ignore eval.php log
 maintenance/.mweval_history

--- a/.jscs.json
+++ b/.jscs.json
@@ -1,4 +1,7 @@
 {
+	"plugins": [
+		"jscs-jsdoc"
+	],
 	"requireCurlyBraces": ["if", "else", "for", "while", "do"],
 	"requireSpaceAfterKeywords": ["if", "else", "for", "while", "do", "switch", "case", "catch", "return", "function"],
 	"requireParenthesesAroundIIFE": true,

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "karma-phantomjs-launcher": "~0.1.4",
     "karma-requirejs": "~0.2.2",
     "karma-script-launcher": "~0.1.0",
-    "requirejs": "~2.1.15"
+    "requirejs": "~2.1.15",
+    "jscs-jsdoc": "~1.2.0"
   }
 }


### PR DESCRIPTION
After this change https://github.com/Wikia/app/commit/2e39f3a1d6a5e25aaf8feb1e20a177c58d1f4664
JSCS started to break on rule prior to jsDoc in .jscs.json

@lizlux @drets @Wikia/community-engineering 

Remember to run `npm update` to make it work on your computer.
