### PR TITLE
Forum: make permissions applied even when the extension is disabled

### DIFF
--- a/extensions/wikia/Forum/Forum.rights.setup.php
+++ b/extensions/wikia/Forum/Forum.rights.setup.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * These permissions will be applied even when Forum extension is disabled
+ *
+ * @see PLATFORM-1664
+ */
+$wgAvailableRights[] = 'forum';
+$wgAvailableRights[] = 'boardedit';
+$wgAvailableRights[] = 'forumadmin';
+
+$wgGroupPermissions['*']['forum'] = false;
+$wgGroupPermissions['staff']['forum'] = true;
+$wgGroupPermissions['sysop']['forum'] = true;
+$wgGroupPermissions['bureaucrat']['forum'] = true;
+$wgGroupPermissions['helper']['forum'] = true;
+
+$wgRevokePermissions['vstf']['forum'] = true;
+
+$wgGroupPermissions['*']['boardedit'] = false;
+$wgGroupPermissions['staff']['boardedit'] = true;
+
+$wgGroupPermissions['*']['forumoldedit'] = false;
+$wgGroupPermissions['staff']['forumoldedit'] = true;
+$wgGroupPermissions['helper']['forumoldedit'] = true;
+$wgGroupPermissions['sysop']['forumoldedit'] = true;
+$wgGroupPermissions['bureaucrat']['forumoldedit'] = true;
+
+$wgGroupPermissions['*']['forumadmin'] = false;
+$wgGroupPermissions['staff']['forumadmin'] = true;
+$wgGroupPermissions['helper']['forumadmin'] = true;
+$wgGroupPermissions['sysop']['forumadmin'] = true;
+$wgGroupPermissions['threadmoderator']['forumadmin'] = true;

--- a/extensions/wikia/Forum/Forum.setup.php
+++ b/extensions/wikia/Forum/Forum.setup.php
@@ -14,7 +14,7 @@ $wgExtensionCredits['specialpage'][] = array(
 	'descriptionmsg' => 'forum-desc'
 );
 
-$dir = dirname( __FILE__ ) . '/';
+$dir = __DIR__ . '/';
 
 // classes
 $wgAutoloadClasses['ForumSpecialController'] =  $dir . 'ForumSpecialController.class.php' ;
@@ -97,32 +97,7 @@ $app->registerNamespaceControler( NS_WIKIA_FORUM_BOARD, 'ForumController', 'boar
 $app->registerNamespaceControler( NS_WIKIA_FORUM_TOPIC_BOARD, 'ForumController', 'board', true );
 
 // permissions
-$wgAvailableRights[] = 'forum';
-$wgAvailableRights[] = 'boardedit';
-$wgAvailableRights[] = 'forumadmin';
-
-$wgGroupPermissions['*']['forum'] = false;
-$wgGroupPermissions['staff']['forum'] = true;
-$wgGroupPermissions['sysop']['forum'] = true;
-$wgGroupPermissions['bureaucrat']['forum'] = true;
-$wgGroupPermissions['helper']['forum'] = true;
-
-$wgRevokePermissions['vstf']['forum'] = true;
-
-$wgGroupPermissions['*']['boardedit'] = false;
-$wgGroupPermissions['staff']['boardedit'] = true;
-
-$wgGroupPermissions['*']['forumoldedit'] = false;
-$wgGroupPermissions['staff']['forumoldedit'] = true;
-$wgGroupPermissions['helper']['forumoldedit'] = true;
-$wgGroupPermissions['sysop']['forumoldedit'] = true;
-$wgGroupPermissions['bureaucrat']['forumoldedit'] = true;
-
-$wgGroupPermissions['*']['forumadmin'] = false;
-$wgGroupPermissions['staff']['forumadmin'] = true;
-$wgGroupPermissions['helper']['forumadmin'] = true;
-$wgGroupPermissions['sysop']['forumadmin'] = true;
-$wgGroupPermissions['threadmoderator']['forumadmin'] = true;
+include ( $dir . '/Forum.rights.setup.php' );
 
 JSMessages::registerPackage( 'Forum', array(
 	'back',

--- a/extensions/wikia/Forum/ForumDisabled.setup.php
+++ b/extensions/wikia/Forum/ForumDisabled.setup.php
@@ -16,6 +16,7 @@ $wgExtensionCredits['specialpage'][] = array(
 $dir = dirname( __FILE__ ) . '/';
 
 include ( $dir . '/Forum.namespace.setup.php' );
+include ( $dir . '/Forum.rights.setup.php' );
 
 $wgAutoloadClasses[ 'ForumNotificationPlugin'] =  $dir . 'ForumNotificationPlugin.class.php' ;
 


### PR DESCRIPTION
See [PLATFORM-1664](https://wikia-inc.atlassian.net/browse/PLATFORM-1664)

Introduce a separate file with permissions definition and include it in both setup and `ForumDisabled.setup.php` which is loaded when the extension is, well.. disabled.

@jcellary / @michalroszka 
