### PR TITLE
CF_Http::authenticate - retry in case we do not get HTTP 2xx

### DIFF
--- a/extensions/SwiftCloudFiles/php-cloudfiles-1.7.10/cloudfiles_exceptions.php
+++ b/extensions/SwiftCloudFiles/php-cloudfiles-1.7.10/cloudfiles_exceptions.php
@@ -29,12 +29,4 @@ class BadContentTypeException extends Exception { }
 class InvalidUTF8Exception extends Exception { }
 class ConnectionNotOpenException extends Exception { }
 
-/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
-
-/*
- * Local variables:
- * tab-width: 4
- * c-basic-offset: 4
- * c-hanging-comment-ender-p: nil
- * End:
- */
+class SwiftRetryException extends Exception {} # Wikia change

--- a/extensions/SwiftCloudFiles/php-cloudfiles-1.7.10/cloudfiles_http.php
+++ b/extensions/SwiftCloudFiles/php-cloudfiles-1.7.10/cloudfiles_http.php
@@ -205,7 +205,7 @@ class CF_Http
 
     # Uses separate cURL connection to authenticate
     #
-    public function authenticate( $user, $pass, $host = NULL ) {
+    private function do_authenticate( $user, $pass, $host = NULL ) {
 		$path = array( );
 		$headers = array(
 			sprintf( "%s: %s", AUTH_USER_HEADER, $user ),
@@ -240,7 +240,43 @@ class CF_Http
 		return array( $this->response_status, $this->response_reason,
 			$this->storage_url, $this->cdnm_url, $this->auth_token );
 	}
-	
+
+	// Wikia change - begin
+	// retry auth request in case of an error (PLATFORM-1659)
+	public function authenticate( $user, $pass, $host = NULL ) {
+		$retriesLeft = self::MAX_RETRIES;
+		$res = false;
+
+		wfDebug( __METHOD__ . "\n" );
+
+		while( $retriesLeft >= 0 ) {
+			list( $status,$reason,$surl,$curl,$atoken ) = $this->do_authenticate( $user, $pass, $host );
+
+			# PLATFORM-1659 - retry all HTTP 50x responses
+			if ( ($status >= 200 && $status <= 299) ) {
+				wfDebug( __METHOD__ . ": ok\n" );
+				break;
+			}
+
+			# PLATFORM-1521 - report an error only when there are no retries left
+			$level = ( $retriesLeft === 0 ) ? 'error' : 'warning';
+
+			Wikia\Logger\WikiaLogger::instance()->$level( 'SwiftStorage: authentication retry', [
+				'exception'    => new Exception( $reason, is_numeric($status) ? $status : 0 ),
+				'retries-left' => $retriesLeft,
+			] );
+
+			wfDebug( sprintf( "%s : retrying as I got '%s' (%d retries left)\n", __METHOD__ , trim( $reason ), $retriesLeft ) );
+
+			// wait a bit before retrying the request
+			usleep( self::RETRY_DELAY * 1000 );
+			$retriesLeft--;
+		}
+
+		return array( $status,$reason,$surl,$curl,$atoken );
+	}
+	// Wikia change - end
+
     # (CDN) GET /v1/Account
     #
     function list_cdn_containers($enabled_only)

--- a/extensions/SwiftCloudFiles/php-cloudfiles-1.7.10/cloudfiles_http.php
+++ b/extensions/SwiftCloudFiles/php-cloudfiles-1.7.10/cloudfiles_http.php
@@ -262,7 +262,7 @@ class CF_Http
 			$level = ( $retriesLeft === 0 ) ? 'error' : 'warning';
 
 			Wikia\Logger\WikiaLogger::instance()->$level( 'SwiftStorage: authentication retry', [
-				'exception'    => new Exception( $reason, is_numeric($status) ? $status : 0 ),
+				'exception'    => new SwiftRetryException( $reason, is_numeric($status) ? $status : 0 ),
 				'retries-left' => $retriesLeft,
 			] );
 
@@ -1528,7 +1528,7 @@ class CF_Http
 			$level = ( $retriesLeft === 0 ) ? 'error' : 'warning';
 
 			Wikia\Logger\WikiaLogger::instance()->$level( 'SwiftStorage: retry', [
-				'exception'    => new Exception( $this->error_str, is_numeric($res) ? $res : 0 ),
+				'exception'    => new SwiftRetryException( $this->error_str, is_numeric($res) ? $res : 0 ),
 				'retries-left' => $retriesLeft,
 				'headers'      => $hdrs,
 				'conn-type'    => $conn_type,

--- a/extensions/SwiftCloudFiles/php-cloudfiles-1.7.10/cloudfiles_http.php
+++ b/extensions/SwiftCloudFiles/php-cloudfiles-1.7.10/cloudfiles_http.php
@@ -250,7 +250,7 @@ class CF_Http
 		wfDebug( __METHOD__ . "\n" );
 
 		while( $retriesLeft >= 0 ) {
-			list( $status,$reason,$surl,$curl,$atoken ) = $this->do_authenticate( $user, $pass, $host );
+			list( $status, $reason, $surl, $curl, $atoken ) = $this->do_authenticate( $user, $pass, $host );
 
 			# PLATFORM-1659 - retry all HTTP 50x responses
 			if ( ($status >= 200 && $status <= 299) ) {
@@ -261,10 +261,10 @@ class CF_Http
 			# PLATFORM-1521 - report an error only when there are no retries left
 			$level = ( $retriesLeft === 0 ) ? 'error' : 'warning';
 
-			Wikia\Logger\WikiaLogger::instance()->$level( 'SwiftStorage: authentication retry', [
+			Wikia\Logger\WikiaLogger::instance()->$level( 'SwiftStorage: authentication retry', array(
 				'exception'    => new SwiftRetryException( $reason, is_numeric($status) ? $status : 0 ),
 				'retries-left' => $retriesLeft,
-			] );
+			) );
 
 			wfDebug( sprintf( "%s : retrying as I got '%s' (%d retries left)\n", __METHOD__ , trim( $reason ), $retriesLeft ) );
 
@@ -273,7 +273,7 @@ class CF_Http
 			$retriesLeft--;
 		}
 
-		return array( $status,$reason,$surl,$curl,$atoken );
+		return array( $status, $reason, $surl, $curl, $atoken );
 	}
 	// Wikia change - end
 


### PR DESCRIPTION
[PLATFORM-1659](https://wikia-inc.atlassian.net/browse/PLATFORM-1659)

We sometimes get `HTTP 503` response for authentication requests sent to DFS nodes. It affects file uploads, `<math>` tag render and wiki creation (initial wiki dumps are fetched from DFS storage).

This PR adds a handling similar to the one introduced in [PLATFORM-1059](https://wikia-inc.atlassian.net/browse/PLATFORM-1059) - retry non-2xx requests up to five times.

@michalroszka / @wladekb / @lukaszkonieczny 
