### PR TITLE
ADEN-2598 Add counter for close button on Oasis

### DIFF
--- a/extensions/wikia/AdEngine/js/spec/template/modalOasisHandler.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/template/modalOasisHandler.spec.js
@@ -7,6 +7,12 @@ describe('ext.wikia.adEngine.template.modalOasisHandler', function () {
 	}
 
 	var mocks = {
+		$: function () {
+			return {
+				addClass: noop,
+				text: noop
+			};
+		},
 		wikiaUiFactory: {
 			init: function () {
 				return mocks.promiseMock;
@@ -31,7 +37,12 @@ describe('ext.wikia.adEngine.template.modalOasisHandler', function () {
 			},
 			$close: {
 				hide: noop,
-				show: noop
+				show: noop,
+				parent: function () {
+					return {
+						prepend: noop
+					};
+				}
 			},
 			show: noop
 		}
@@ -39,6 +50,7 @@ describe('ext.wikia.adEngine.template.modalOasisHandler', function () {
 
 	function getModule() {
 		return modules['ext.wikia.adEngine.template.modalOasisHandler'](
+			mocks.$,
 			mocks.wikiaUiFactory
 		).prototype;
 	}

--- a/extensions/wikia/AdEngine/js/template/modalOasisHandler.js
+++ b/extensions/wikia/AdEngine/js/template/modalOasisHandler.js
@@ -1,12 +1,13 @@
 /*global define, require*/
 define('ext.wikia.adEngine.template.modalOasisHandler', [
+	'jquery',
 	require.optional('wikia.ui.factory')
-], function (uiFactory) {
+], function ($, uiFactory) {
 	'use strict';
 
 	var oasisHandler = function () {
-			this.modalId = 'ext-wikia-adEngine-template-modal';
-		};
+		this.modalId = 'ext-wikia-adEngine-template-modal';
+	};
 
 	oasisHandler.prototype.create = function (adContainer, modalVisible, closeButtonDelay) {
 		var modalConfig = {
@@ -22,16 +23,37 @@ define('ext.wikia.adEngine.template.modalOasisHandler', [
 
 		uiFactory.init('modal').then((function (uiModal) {
 			uiModal.createComponent(modalConfig, (function (modal) {
-				var closeBtnDelay = parseInt(closeButtonDelay, 10) * 1000 || 0;
+				var count = closeButtonDelay,
+					closeBtnDelay = parseInt(closeButtonDelay, 10) * 1000 || 0;
 				this.modal = modal;
 				modal.$content.append(adContainer);
 				modal.$element.width('auto');
 
-				if (closeBtnDelay > 0) {
-					modal.$close.hide();
-					setTimeout(function(){
+				function timer() {
+					count = count - 1;
+
+					if (count < 0) {
+						clearInterval(counter);
+						$counter.hide();
 						modal.$close.show();
-					}, closeBtnDelay);
+						return;
+					}
+
+					$counter.text(count);
+				}
+
+				if (closeBtnDelay > 0) {
+					var $header = modal.$close.parent(),
+						$counter = $(document.createElement('div'))
+							.addClass('close-counter')
+							.css('float', 'right')
+							.css('font-size', '17px')
+							.text(count);
+
+					modal.$close.hide();
+					$header.prepend($counter);
+
+					var counter = setInterval(timer, 1000);
 				}
 
 				if (modalVisible) {

--- a/extensions/wikia/AdEngine/js/template/modalOasisHandler.js
+++ b/extensions/wikia/AdEngine/js/template/modalOasisHandler.js
@@ -23,7 +23,11 @@ define('ext.wikia.adEngine.template.modalOasisHandler', [
 
 		uiFactory.init('modal').then((function (uiModal) {
 			uiModal.createComponent(modalConfig, (function (modal) {
-				var closeBtnDelay = parseInt(closeButtonDelay, 10) * 1000 || 0;
+				var closeBtnDelay = parseInt(closeButtonDelay, 10) * 1000 || 0,
+					$header,
+					$counter,
+					counter;
+
 				this.modal = modal;
 				modal.$content.append(adContainer);
 				modal.$element.width('auto');
@@ -42,8 +46,8 @@ define('ext.wikia.adEngine.template.modalOasisHandler', [
 				}
 
 				if (closeBtnDelay > 0) {
-					var $header = modal.$close.parent(),
-						$counter = $(document.createElement('div'));
+					$header = modal.$close.parent();
+					$counter = $(document.createElement('div'));
 
 					modal.$close.hide();
 
@@ -51,7 +55,7 @@ define('ext.wikia.adEngine.template.modalOasisHandler', [
 					$counter.text(closeButtonDelay);
 					$header.prepend($counter);
 
-					var counter = setInterval(timer, 1000);
+					counter = setInterval(timer, 1000);
 				}
 
 				if (modalVisible) {

--- a/extensions/wikia/AdEngine/js/template/modalOasisHandler.js
+++ b/extensions/wikia/AdEngine/js/template/modalOasisHandler.js
@@ -46,8 +46,6 @@ define('ext.wikia.adEngine.template.modalOasisHandler', [
 					var $header = modal.$close.parent(),
 						$counter = $(document.createElement('div'))
 							.addClass('close-counter')
-							.css('float', 'right')
-							.css('font-size', '17px')
 							.text(count);
 
 					modal.$close.hide();

--- a/extensions/wikia/AdEngine/js/template/modalOasisHandler.js
+++ b/extensions/wikia/AdEngine/js/template/modalOasisHandler.js
@@ -23,7 +23,8 @@ define('ext.wikia.adEngine.template.modalOasisHandler', [
 
 		uiFactory.init('modal').then((function (uiModal) {
 			uiModal.createComponent(modalConfig, (function (modal) {
-				var closeBtnDelay = parseInt(closeButtonDelay, 10) || 0,
+				closeButtonDelay = parseInt(closeButtonDelay, 10) || 0;
+				var hideCloseButton = closeButtonDelay > 0,
 					$header,
 					$counter,
 					counter;
@@ -45,7 +46,7 @@ define('ext.wikia.adEngine.template.modalOasisHandler', [
 					$counter.text(closeButtonDelay);
 				}
 
-				if (closeBtnDelay > 0) {
+				if (hideCloseButton) {
 					$header = modal.$close.parent();
 					$counter = $(document.createElement('div'));
 

--- a/extensions/wikia/AdEngine/js/template/modalOasisHandler.js
+++ b/extensions/wikia/AdEngine/js/template/modalOasisHandler.js
@@ -23,32 +23,32 @@ define('ext.wikia.adEngine.template.modalOasisHandler', [
 
 		uiFactory.init('modal').then((function (uiModal) {
 			uiModal.createComponent(modalConfig, (function (modal) {
-				var count = closeButtonDelay,
-					closeBtnDelay = parseInt(closeButtonDelay, 10) * 1000 || 0;
+				var closeBtnDelay = parseInt(closeButtonDelay, 10) * 1000 || 0;
 				this.modal = modal;
 				modal.$content.append(adContainer);
 				modal.$element.width('auto');
 
 				function timer() {
-					count = count - 1;
+					closeButtonDelay = closeButtonDelay - 1;
 
-					if (count < 0) {
+					if (closeButtonDelay < 0) {
 						clearInterval(counter);
 						$counter.hide();
 						modal.$close.show();
 						return;
 					}
 
-					$counter.text(count);
+					$counter.text(closeButtonDelay);
 				}
 
 				if (closeBtnDelay > 0) {
 					var $header = modal.$close.parent(),
-						$counter = $(document.createElement('div'))
-							.addClass('close-counter')
-							.text(count);
+						$counter = $(document.createElement('div'));
 
 					modal.$close.hide();
+
+					$counter.addClass('close-counter');
+					$counter.text(closeButtonDelay);
 					$header.prepend($counter);
 
 					var counter = setInterval(timer, 1000);

--- a/extensions/wikia/AdEngine/js/template/modalOasisHandler.js
+++ b/extensions/wikia/AdEngine/js/template/modalOasisHandler.js
@@ -23,7 +23,7 @@ define('ext.wikia.adEngine.template.modalOasisHandler', [
 
 		uiFactory.init('modal').then((function (uiModal) {
 			uiModal.createComponent(modalConfig, (function (modal) {
-				var closeBtnDelay = parseInt(closeButtonDelay, 10) * 1000 || 0,
+				var closeBtnDelay = parseInt(closeButtonDelay, 10) || 0,
 					$header,
 					$counter,
 					counter;

--- a/resources/wikia/ui_components/modal/css/modal_default.scss
+++ b/resources/wikia/ui_components/modal/css/modal_default.scss
@@ -79,11 +79,6 @@ $large-modal-margin: 50px;
 		width: 20px;
 	}
 
-  	> header .close-counter {
-		float: right;
-		font-size: 17px;
-  	}
-
 	> footer .button {
 		float: right;
 		margin-left: 20px;

--- a/resources/wikia/ui_components/modal/css/modal_default.scss
+++ b/resources/wikia/ui_components/modal/css/modal_default.scss
@@ -79,6 +79,11 @@ $large-modal-margin: 50px;
 		width: 20px;
 	}
 
+  	> header .close-counter {
+		float: right;
+		font-size: 17px;
+  	}
+
 	> footer .button {
 		float: right;
 		margin-left: 20px;

--- a/skins/oasis/css/core/ads.scss
+++ b/skins/oasis/css/core/ads.scss
@@ -278,6 +278,11 @@ body >a >img[src$="noad.gif"] {
 			overflow: hidden;
 		}
 	}
+
+	> header .close-counter {
+		float: right;
+		font-size: 17px;
+	}
 }
 
 //@TODO remove .oasis-responsive after deprecating responsive (July 2015)


### PR DESCRIPTION
PR adds counter for close button on modal window on Oasis.
This counter shows how long to wait (in seconds) till a close button appears in place of counter.
![closeCounter](http://content.screencast.com/users/DmytroRets/folders/Jing/media/7709bf84-4200-47a2-b7be-56a2f695c8a8/00000406.png)
