### PR TITLE
ADEN-2669 Recovered message tracking in main profile

### DIFF
--- a/extensions/wikia/AdEngine/js/recovery/message.js
+++ b/extensions/wikia/AdEngine/js/recovery/message.js
@@ -46,9 +46,9 @@ define('ext.wikia.adEngine.recovery.message', [
 
 	function track(action, trackerAction) {
 		tracker.track({
-			category: 'ads',
+			category: 'ads-recovery-message',
 			action: trackerAction,
-			label: 'ads-recovery-message',
+			label: action,
 			value: 0,
 			trackingMethod: 'analytics'
 		});

--- a/extensions/wikia/AdEngine/js/recovery/message.js
+++ b/extensions/wikia/AdEngine/js/recovery/message.js
@@ -11,6 +11,7 @@ define('ext.wikia.adEngine.recovery.message', [
 	'wikia.location',
 	'wikia.log',
 	'wikia.mustache',
+	'wikia.tracker',
 	'wikia.window'
 ], function (
 	adTracker,
@@ -24,6 +25,7 @@ define('ext.wikia.adEngine.recovery.message', [
 	location,
 	log,
 	mustache,
+	tracker,
 	win
 ) {
 	'use strict';
@@ -42,13 +44,24 @@ define('ext.wikia.adEngine.recovery.message', [
 		logGroup = 'ext.wikia.adEngine.recovery.message',
 		localStorageKey = 'rejectedRecoveredMessage';
 
+	function track(action) {
+		tracker.track({
+			'ga_category': 'ads-recovery-message',
+			'ga_action': action,
+			'ga_label': '',
+			'ga_value': 0,
+			trackingMethod: 'analytics'
+		});
+		adTracker.track('recovery/message', action);
+	}
+
 	function accept() {
-		adTracker.track('recovery/message', 'accept');
+		track('accept');
 		location.reload();
 	}
 
 	function reject(messageContainer) {
-		adTracker.track('recovery/message', 'reject');
+		track('reject');
 		messageContainer.hide();
 		localStorage.setItem(localStorageKey, true);
 	}
@@ -111,7 +124,7 @@ define('ext.wikia.adEngine.recovery.message', [
 	function injectTopMessage(messageVariant) {
 		log('recoveredAdsMessage.recover - injecting top message', 'debug', logGroup);
 		createMessage('top', messageVariant).done(function (messageContainer) {
-			adTracker.track('recovery/message', 'impression');
+			track('impression');
 			$('#WikiaTopAds').before(messageContainer);
 		});
 	}
@@ -119,7 +132,7 @@ define('ext.wikia.adEngine.recovery.message', [
 	function injectRightRailMessage(messageVariant) {
 		log('recoveredAdsMessage.recover - injecting right rail message', 'debug', logGroup);
 		createMessage('right-rail', messageVariant).done(function (messageContainer) {
-			adTracker.track('recovery/message', 'impression');
+			track('impression');
 			$('#WikiaRail').prepend(messageContainer);
 		});
 	}

--- a/extensions/wikia/AdEngine/js/recovery/message.js
+++ b/extensions/wikia/AdEngine/js/recovery/message.js
@@ -1,4 +1,4 @@
-/*global define*/
+/*global define, setTimeout*/
 define('ext.wikia.adEngine.recovery.message', [
 	'ext.wikia.adEngine.adTracker',
 	'ext.wikia.adEngine.recovery.helper',
@@ -57,7 +57,9 @@ define('ext.wikia.adEngine.recovery.message', [
 
 	function accept() {
 		track('accept');
-		location.reload();
+		setTimeout(function () {
+			location.reload();
+		}, 200);
 	}
 
 	function reject(messageContainer) {

--- a/extensions/wikia/AdEngine/js/recovery/message.js
+++ b/extensions/wikia/AdEngine/js/recovery/message.js
@@ -44,26 +44,26 @@ define('ext.wikia.adEngine.recovery.message', [
 		logGroup = 'ext.wikia.adEngine.recovery.message',
 		localStorageKey = 'rejectedRecoveredMessage';
 
-	function track(action) {
+	function track(action, trackerAction) {
 		tracker.track({
-			'ga_category': 'ads-recovery-message',
-			'ga_action': action,
-			'ga_label': '',
-			'ga_value': 0,
+			category: 'ads',
+			action: trackerAction,
+			label: 'ads-recovery-message',
+			value: 0,
 			trackingMethod: 'analytics'
 		});
 		adTracker.track('recovery/message', action);
 	}
 
 	function accept() {
-		track('accept');
+		track('accept', win.Wikia.Tracker.ACTIONS.CLICK);
 		setTimeout(function () {
 			location.reload();
 		}, 200);
 	}
 
 	function reject(messageContainer) {
-		track('reject');
+		track('reject', win.Wikia.Tracker.ACTIONS.CLICK);
 		messageContainer.hide();
 		localStorage.setItem(localStorageKey, true);
 	}
@@ -126,7 +126,7 @@ define('ext.wikia.adEngine.recovery.message', [
 	function injectTopMessage(messageVariant) {
 		log('recoveredAdsMessage.recover - injecting top message', 'debug', logGroup);
 		createMessage('top', messageVariant).done(function (messageContainer) {
-			track('impression');
+			track('impression', win.Wikia.Tracker.ACTIONS.IMPRESSION);
 			$('#WikiaTopAds').before(messageContainer);
 		});
 	}
@@ -134,7 +134,7 @@ define('ext.wikia.adEngine.recovery.message', [
 	function injectRightRailMessage(messageVariant) {
 		log('recoveredAdsMessage.recover - injecting right rail message', 'debug', logGroup);
 		createMessage('right-rail', messageVariant).done(function (messageContainer) {
-			track('impression');
+			track('impression', win.Wikia.Tracker.ACTIONS.IMPRESSION);
 			$('#WikiaRail').prepend(messageContainer);
 		});
 	}


### PR DESCRIPTION
We would like to add tracking of recovered message also to regular profiles in GA (currently stats go only to ads profile). 
