### PR TITLE
CloseWikiMaintenance: introduce a helper for removing wiki DFS bucket

### DIFF
--- a/extensions/wikia/CreateNewWiki/CreateWiki.php
+++ b/extensions/wikia/CreateNewWiki/CreateWiki.php
@@ -319,16 +319,6 @@ class CreateWiki {
 		$this->mNewWiki->dbw->insert( "site_stats", array( "ss_row_id" => "1"), __METHOD__ );
 
 		/**
-		 * copy default logo
-		 */
-		$res = ImagesService::uploadImageFromUrl( self::CREATEWIKI_LOGO, (object) ['name' => 'Wiki.png'], $uploader );
-		if ( $res['status'] === true ) {
-			wfDebugLog( "createwiki", __METHOD__ . ": Default logo has been uploaded\n", true );
-		} else {
-			wfDebugLog( "createwiki", __METHOD__ . ": Default logo has not been uploaded - " . print_r($res['errors'], true) . "\n", true );
-		}
-
-		/**
 		 * destroy connection to newly created database
 		 */
 		$this->waitForSlaves( __METHOD__ );

--- a/extensions/wikia/CreateNewWiki/CreateWiki.php
+++ b/extensions/wikia/CreateNewWiki/CreateWiki.php
@@ -267,15 +267,6 @@ class CreateWiki {
 
 		wfDebugLog( "createwiki", __METHOD__ . ": Row added into city_domains table, city_id = {$this->mNewWiki->city_id}\n", true );
 
-		/**
-		 * create image folder
-		 */
-		global $wgEnableSwiftFileBackend;
-		if (empty($wgEnableSwiftFileBackend)) {
-			wfMkdirParents( "{$this->mNewWiki->images_dir}" );
-			wfDebugLog( "createwiki", __METHOD__ . ": Folder {$this->mNewWiki->images_dir} created\n", true );
-		}
-
 		// Force initialize uploader user from correct shared db
 		$uploader = User::newFromName( 'CreateWiki script' );
 		$uploader->getId();
@@ -330,8 +321,6 @@ class CreateWiki {
 		/**
 		 * copy default logo
 		 */
-
-
 		$res = ImagesService::uploadImageFromUrl( self::CREATEWIKI_LOGO, (object) ['name' => 'Wiki.png'], $uploader );
 		if ( $res['status'] === true ) {
 			wfDebugLog( "createwiki", __METHOD__ . ": Default logo has been uploaded\n", true );

--- a/extensions/wikia/WikiFactory/Close/maintenance.php
+++ b/extensions/wikia/WikiFactory/Close/maintenance.php
@@ -18,7 +18,7 @@ class CloseWikiMaintenance {
 
 	const CLOSE_WIKI_DELAY = 30;
 
-	private $mTarget, $mOptions;
+	private $mOptions;
 
 	/**
 	 * constructor
@@ -26,13 +26,6 @@ class CloseWikiMaintenance {
 	 * @access public
 	 */
 	public function __construct( $options ) {
-		global $wgDevelEnvironment;
-		if( !empty( $wgDevelEnvironment ) ) {
-			$this->mTarget = "root@127.0.0.1:/tmp/dumps";
-		}
-		else {
-			$this->mTarget = "root@file-i6:/raid/dumps";
-		}
 		$this->mOptions = $options;
 	}
 
@@ -149,7 +142,6 @@ class CloseWikiMaintenance {
 			}
 			if( $row->city_flags & WikiFactory::FLAG_CREATE_DB_DUMP ) {
 				$this->log( "Dumping database on remote host" );
-				list ( $remote  ) = explode( ":", $this->mTarget, 2 );
 
 				$script = ( $hide )
 					? "--script='../extensions/wikia/WikiFactory/Dumps/runBackups.php --both --id={$cityid} --tmp --s3'"

--- a/extensions/wikia/WikiFactory/Close/maintenance.php
+++ b/extensions/wikia/WikiFactory/Close/maintenance.php
@@ -18,6 +18,8 @@ class CloseWikiMaintenance {
 
 	const CLOSE_WIKI_DELAY = 30;
 
+	const S3_CONFIG = '/etc/s3cmd/sjc_prod.cfg'; # s3cmd config for Swift storage
+
 	private $mOptions;
 
 	/**
@@ -337,7 +339,7 @@ class CloseWikiMaintenance {
 			// s3cmd sync --dry-run s3://dilbert ~/images/dilbert/ --exclude "/thumb/*" --exclude "/temp/*"
 			$cmd = sprintf(
 				'sudo /usr/bin/s3cmd -c %s sync s3://%s/images "%s" --exclude "/thumb/*" --exclude "/temp/*"',
-				'/etc/s3cmd/sjc_prod.cfg', // s3cmd config for Swift storage
+				self::S3_CONFIG,
 				$container,
 				$directory
 			);
@@ -424,7 +426,7 @@ class CloseWikiMaintenance {
 			//  Remove bucket / s3cmd rb s3://BUCKET
 			$cmd = sprintf(
 				'sudo /usr/bin/s3cmd -c %s --verbose rb s3://%s/',
-				'/etc/s3cmd/sjc_prod.cfg', // s3cmd config for Swift storage
+				self::S3_CONFIG,
 				$container->name
 			);
 			$out = wfShellExec( $cmd, $iStatus );

--- a/includes/wikia/SwiftStorage.class.php
+++ b/includes/wikia/SwiftStorage.class.php
@@ -391,4 +391,11 @@ class SwiftStorage {
 	public function getPathPrefix() {
 		return $this->pathPrefix;
 	}
+
+	/**
+	 * @return \CF_Connection
+	 */
+	public function getConnection() {
+		return $this->connection;
+	}
 }


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-1700

Maintenance script that closes old wikis used to remove upload directory in the medieval, NFS-powered times. The obsolete code was removed in 60b7121.

This pull request introduces a helper method that recursively removes wiki files (using `s3cmd --recursive del` command). Small code cleanup included :smiley: 

@michalroszka / @wladekb / @ljagiello 
