### PR TITLE
SOC-1710 Fix WallNotifications query

### DIFF
--- a/extensions/wikia/WallNotifications/WallNotifications.class.php
+++ b/extensions/wikia/WallNotifications/WallNotifications.class.php
@@ -1057,7 +1057,7 @@ class WallNotifications {
 	}
 
 	public function getKey( $userId, $wikiId ) {
-		return wfSharedMemcKey( __CLASS__, $userId, $wikiId . 'v31' );
+		return wfSharedMemcKey( __CLASS__, $userId, $wikiId . 'v32' );
 	}
 
 	/**

--- a/extensions/wikia/WallNotifications/WallNotifications.class.php
+++ b/extensions/wikia/WallNotifications/WallNotifications.class.php
@@ -995,7 +995,7 @@ class WallNotifications {
 			[
 				'DISTINCT',
 				'LIMIT' => '50',
-				'ORDER BY' => 'unique_id'
+				'ORDER BY' => 'unique_id DESC'
 			]
 		);
 


### PR DESCRIPTION
As part of https://github.com/Wikia/app/pull/9048 we updated the query used to get notifications, making it more efficient. That pull request had a mistake however, it was missing the "DESCENDING" qualifier for the "ORDER BY". This PR adds "DESC" into the query.

Ticket: https://wikia-inc.atlassian.net/browse/SOC-1710
