### PR TITLE
Machine classify user submitted templates

### DIFF
--- a/extensions/wikia/IndexingPipeline/PipelineEventProducer.class.php
+++ b/extensions/wikia/IndexingPipeline/PipelineEventProducer.class.php
@@ -111,6 +111,24 @@ class PipelineEventProducer {
 		return true;
 	}
 
+	/**
+	 * @desc Fires on:
+	 *  - successful save from TemplateClassificationApiController
+	 *
+	 * @param integer $pageId The affected template's pageId
+	 * @param Title $title The affected template's Title object
+	 * @return bool
+	 */
+	public static function onTemplateClassified( $pageId, $title ) {
+		$ns = self::preparePageNamespaceName( $title );
+		$revisionId = $title->getLatestRevID();
+
+		// there is purposedly no legacy (unflagged) event sent here
+		self::sendFlaggedSyntax( self::ACTION_UPDATE, $pageId, $revisionId, $ns );
+
+		return true;
+	}
+
 	/*
 	 * Helper methods
 	 */

--- a/extensions/wikia/IndexingPipeline/PipelineEventProducer.class.php
+++ b/extensions/wikia/IndexingPipeline/PipelineEventProducer.class.php
@@ -114,6 +114,7 @@ class PipelineEventProducer {
 	/**
 	 * @desc Fires on:
 	 *  - successful save from TemplateClassificationApiController
+	 *  - successful classification of parent template during draft creation
 	 *
 	 * @param integer $pageId The affected template's pageId
 	 * @param Title $title The affected template's Title object

--- a/extensions/wikia/IndexingPipeline/PipelineEventProducer.setup.php
+++ b/extensions/wikia/IndexingPipeline/PipelineEventProducer.setup.php
@@ -19,4 +19,4 @@ $wgHooks['NewRevisionFromEditComplete'][] = 'PipelineEventProducer::onNewRevisio
 $wgHooks['ArticleDeleteComplete'][] = 'PipelineEventProducer::onArticleDeleteComplete';
 $wgHooks['ArticleUndelete'][] = 'PipelineEventProducer::onArticleUndelete';
 $wgHooks['TitleMoveComplete'][] = 'PipelineEventProducer::onTitleMoveComplete';
-
+$wgHooks['TemplateClassification::TemplateClassified'][] = 'PipelineEventProducer::onTemplateClassified';

--- a/extensions/wikia/TemplateDraft/controllers/TemplateDraftController.class.php
+++ b/extensions/wikia/TemplateDraft/controllers/TemplateDraftController.class.php
@@ -30,6 +30,12 @@ class TemplateDraftController extends WikiaController {
 					TemplateClassificationService::USER_PROVIDER,
 					$wgUser->getId()
 				);
+
+				wfRunHooks( 'TemplateClassification::TemplateClassified', [
+					$parentTitle->getArticleID(),
+					$parentTitle
+				] );
+
 			} catch ( Swagger\Client\ApiException $e ) {
 				// Do not worry if you're not able to classify the template.
 			}

--- a/includes/wikia/api/TemplateClassificationApiController.class.php
+++ b/includes/wikia/api/TemplateClassificationApiController.class.php
@@ -35,7 +35,7 @@ class TemplateClassificationApiController extends WikiaApiController {
 
 			$title = Title::newFromId( $pageId );
 			if ( $title instanceof Title ) {
-				wfRunHooks('TemplateClassification::TemplateClassified', [ $pageId, $title ] );
+				wfRunHooks( 'TemplateClassification::TemplateClassified', [ $pageId, $title ] );
 				$title->invalidateCache();
 			}
 		} catch ( InvalidArgumentException $e ) {

--- a/includes/wikia/api/TemplateClassificationApiController.class.php
+++ b/includes/wikia/api/TemplateClassificationApiController.class.php
@@ -35,6 +35,7 @@ class TemplateClassificationApiController extends WikiaApiController {
 
 			$title = Title::newFromId( $pageId );
 			if ( $title instanceof Title ) {
+				wfRunHooks('TemplateClassification::TemplateClassified', [ $pageId, $title ] );
 				$title->invalidateCache();
 			}
 		} catch ( InvalidArgumentException $e ) {


### PR DESCRIPTION
This CR introduces an extension to current manual template classification:
Publish a template update event whenever a user classifies a template, making sure we classify it automatically too.

/cc @lgarczewski @lukaszkonieczny @Grunny @adamkarminski @idradm @RafLeszczynski @rybmat @dianafa @azarek @nikodamn @kamilkoterba 
