### PR TITLE
CE-3019: Add support for imports from dev.wikia.com

### DIFF
--- a/extensions/wikia/ContentReview/ContentReview.hooks.php
+++ b/extensions/wikia/ContentReview/ContentReview.hooks.php
@@ -139,7 +139,22 @@ class Hooks {
 	 * @return bool
 	 */
 	public function onRawPageViewBeforeOutput( \RawAction $rawAction, &$text ) {
+		global $wgCityId;
+
 		$title = $rawAction->getTitle();
+		$titleText = $title->getText();
+
+		if ( $wgCityId == Helper::DEV_WIKI_ID && !$title->inNamespace( NS_MEDIAWIKI ) ) {
+			$title = \Title::newFromText( $titleText, NS_MEDIAWIKI );
+
+			// TODO: After scripts transition on dev wiki is done, remove this if statement (CE-3093)
+			if ( !$title || !$title->exists() ) {
+				return true;
+			}
+
+			$text = \Revision::newFromTitle( $title )->getRawText();
+		}
+
 		$helper = new Helper();
 		$text = $helper->replaceWithLastApproved( $title, $rawAction->getContentType(), $text );
 		return true;

--- a/extensions/wikia/ContentReview/ContentReviewHelper.php
+++ b/extensions/wikia/ContentReview/ContentReviewHelper.php
@@ -15,6 +15,8 @@ class Helper extends \ContextSource {
 	const CONTENT_REVIEW_CURRENT_KEY = 'current-js-pages';
 	const JS_FILE_EXTENSION = '.js';
 
+	const DEV_WIKI_ID = 7931;
+
 
 	/**
 	 * Returns data about all approved revisions (of JS pages) for current wiki

--- a/includes/wikia/resourceloader/ResourceLoaderGlobalWikiModule.class.php
+++ b/includes/wikia/resourceloader/ResourceLoaderGlobalWikiModule.class.php
@@ -103,11 +103,11 @@ abstract class ResourceLoaderGlobalWikiModule extends ResourceLoaderWikiModule {
 
 		$title = null;
 		$external = false;
-		$targetCityId = !empty( $options['city_id'] ) ? $options['city_id'] : 0;
+		$targetCityId = (int) $options['city_id'];
 
 		list( $text, $namespace ) = $this->parseTitle( $titleText );
 
-		if ( $targetCityId !== 0 && $wgCityId != $targetCityId && $text !== false ) {
+		if ( $targetCityId !== 0 && $wgCityId !== $targetCityId && $text !== false ) {
 			$external = true;
 			$title = GlobalTitle::newFromTextCached( $text, NS_MEDIAWIKI, $targetCityId );
 		} else {
@@ -115,7 +115,7 @@ abstract class ResourceLoaderGlobalWikiModule extends ResourceLoaderWikiModule {
 		}
 
 		// TODO: After scripts transition on dev wiki is done, remove this if statement (CE-3093)
-		if ( ( !$title || !$title->exists() ) && $targetCityId == Wikia\ContentReview\Helper::DEV_WIKI_ID ) {
+		if ( ( !$title || !$title->exists() ) && $targetCityId === Wikia\ContentReview\Helper::DEV_WIKI_ID ) {
 			$title = $this->devWikiFallback( $text, $external );
 		}
 

--- a/includes/wikia/resourceloader/ResourceLoaderGlobalWikiModule.class.php
+++ b/includes/wikia/resourceloader/ResourceLoaderGlobalWikiModule.class.php
@@ -103,22 +103,23 @@ abstract class ResourceLoaderGlobalWikiModule extends ResourceLoaderWikiModule {
 
 		$title = null;
 		$external = false;
+		$targetCityId = !empty( $options['city_id'] ) ? $options['city_id'] : 0;
 
 		list( $text, $namespace ) = $this->parseTitle( $titleText );
 
-		if ( !empty( $options['city_id'] ) && $wgCityId != $options['city_id'] && $text !== false ) {
+		if ( $targetCityId !== 0 && $wgCityId != $targetCityId && $text !== false ) {
 			$external = true;
-			$title = GlobalTitle::newFromTextCached( $text, NS_MEDIAWIKI, $options['city_id'] );
+			$title = GlobalTitle::newFromTextCached( $text, NS_MEDIAWIKI, $targetCityId );
 		} else {
 			$title = Title::newFromText( $text, NS_MEDIAWIKI );
 		}
 
 		// TODO: After scripts transition on dev wiki is done, remove this if statement (CE-3093)
-		if ( ( !$title || !$title->exists() ) && $options['city_id'] == Wikia\ContentReview\Helper::DEV_WIKI_ID ) {
+		if ( ( !$title || !$title->exists() ) && $targetCityId == Wikia\ContentReview\Helper::DEV_WIKI_ID ) {
 			$title = $this->devWikiFallback( $text, $external );
 		}
 
-		$title = $this->resolveRedirect($title);
+		$title = $this->resolveRedirect( $title );
 
 		return $title;
 	}

--- a/includes/wikia/resourceloader/ResourceLoaderGlobalWikiModule.class.php
+++ b/includes/wikia/resourceloader/ResourceLoaderGlobalWikiModule.class.php
@@ -105,18 +105,18 @@ abstract class ResourceLoaderGlobalWikiModule extends ResourceLoaderWikiModule {
 		$external = false;
 		$targetCityId = (int) $options['city_id'];
 
-		list( $text, $namespace ) = $this->parseTitle( $titleText );
+		list( $titleText, $namespace ) = $this->parseTitle( $titleText );
 
-		if ( $targetCityId !== 0 && $wgCityId !== $targetCityId && $text !== false ) {
+		if ( $targetCityId !== 0 && $wgCityId !== $targetCityId && $titleText !== false ) {
 			$external = true;
-			$title = GlobalTitle::newFromTextCached( $text, NS_MEDIAWIKI, $targetCityId );
+			$title = GlobalTitle::newFromTextCached( $titleText, NS_MEDIAWIKI, $targetCityId );
 		} else {
-			$title = Title::newFromText( $text, NS_MEDIAWIKI );
+			$title = Title::newFromText( $titleText, NS_MEDIAWIKI );
 		}
 
 		// TODO: After scripts transition on dev wiki is done, remove this if statement (CE-3093)
-		if ( ( !$title || !$title->exists() ) && $targetCityId === Wikia\ContentReview\Helper::DEV_WIKI_ID ) {
-			$title = $this->devWikiFallback( $text, $external );
+		if ( $targetCityId === Wikia\ContentReview\Helper::DEV_WIKI_ID && ( !$title || !$title->exists() ) ) {
+			$title = $this->devWikiFallback( $titleText, $external );
 		}
 
 		$title = $this->resolveRedirect( $title );


### PR DESCRIPTION
We want to move scripts on dev.wikia.com to MediaWiki namespace to handle scripts on all platform in the same way by using JS review tool. At the same time, we dont want to break existing imports from dev wiki. We also added fallback to Main namespace until transition is complete.
