### PR TITLE
INT-271: Achievements: Remove Image Badges for Wookiee

### DIFF
--- a/extensions/wikia/AchievementsII/AchConfig.class.php
+++ b/extensions/wikia/AchievementsII/AchConfig.class.php
@@ -351,8 +351,8 @@ class AchConfig {
 	}
 
 	public function shouldShow( $badgeTypeId ) {
-		global $wgAchievementsEditAddPhotoOnly;
-		if ( empty( $wgAchievementsEditAddPhotoOnly ) || in_array( $badgeTypeId, self::$mEditOnlyBadge ) ) {
+		global $wgAchievementsEditOnly;
+		if ( empty( $wgAchievementsEditOnly ) || in_array( $badgeTypeId, self::$mEditOnlyBadge ) ) {
 			return true;
 		}
 		return false;

--- a/extensions/wikia/AchievementsII/AchConfig.class.php
+++ b/extensions/wikia/AchievementsII/AchConfig.class.php
@@ -38,9 +38,8 @@ class AchConfig {
 		BADGE_LUCKYEDIT
 	);
 
-	private static $mEditAddphotoOnlyBadges = array(
-		BADGE_EDIT,
-		BADGE_PICTURE
+	private static $mEditOnlyBadge = array(
+		BADGE_EDIT
 	);
 
 	private static $mInstance;
@@ -353,7 +352,7 @@ class AchConfig {
 
 	public function shouldShow( $badgeTypeId ) {
 		global $wgAchievementsEditAddPhotoOnly;
-		if ( empty( $wgAchievementsEditAddPhotoOnly ) || in_array( $badgeTypeId, self::$mEditAddphotoOnlyBadges ) ) {
+		if ( empty( $wgAchievementsEditAddPhotoOnly ) || in_array( $badgeTypeId, self::$mEditOnlyBadge ) ) {
 			return true;
 		}
 		return false;

--- a/extensions/wikia/AchievementsII/services/AchAwardingService.class.php
+++ b/extensions/wikia/AchievementsII/services/AchAwardingService.class.php
@@ -362,7 +362,6 @@ class AchAwardingService {
 		if ( empty( $wgAchievementsEditOnly ) ) {
 			if ( $this->mTitle->isContentPage() ) {
 				$this->processInTrackPicture();
-				$this->processInTrackEditCategory();
 				$this->processInTrackCategory();
 			}
 			$this->processInTrackBlogPost();
@@ -372,6 +371,7 @@ class AchAwardingService {
 
 		if ( $this->mTitle->isContentPage() ) {
 			$this->processInTrackEdit();
+			$this->processInTrackEditCategory();
 		}
 
 		wfProfileOut( __METHOD__ );

--- a/extensions/wikia/AchievementsII/services/AchAwardingService.class.php
+++ b/extensions/wikia/AchievementsII/services/AchAwardingService.class.php
@@ -80,13 +80,13 @@ class AchAwardingService {
 	}
 
 	public function processSharing( $articleID, $sharerID, $IP ) {
-		global $wgEnableAchievementsForSharing, $wgAchievementsEditAddPhotoOnly;
+		global $wgEnableAchievementsForSharing, $wgAchievementsEditOnly;
 
 		if ( empty( $wgEnableAchievementsForSharing ) ) {
 			return;
 		}
 
-		if (!empty( $wgAchievementsEditAddPhotoOnly ) ) {
+		if (!empty( $wgAchievementsEditOnly ) ) {
 			return;
 		}
 
@@ -357,9 +357,9 @@ class AchAwardingService {
 	private function processAllInTrack() {
 		wfProfileIn( __METHOD__ );
 
-		global $wgAchievementsEditAddPhotoOnly;
+		global $wgAchievementsEditOnly;
 
-		if ( empty( $wgAchievementsEditAddPhotoOnly ) ) {
+		if ( empty( $wgAchievementsEditOnly ) ) {
 			if ( $this->mTitle->isContentPage() ) {
 				$this->processInTrackPicture();
 				$this->processInTrackEditCategory();
@@ -517,9 +517,9 @@ class AchAwardingService {
 	}
 
 	private function processAllNotInTrack() {
-		global $wgAchievementsEditAddPhotoOnly;
+		global $wgAchievementsEditOnly;
 
-		if ( !empty( $wgAchievementsEditAddPhotoOnly ) ) {
+		if ( !empty( $wgAchievementsEditOnly ) ) {
 			return;
 		}
 

--- a/extensions/wikia/AchievementsII/services/AchAwardingService.class.php
+++ b/extensions/wikia/AchievementsII/services/AchAwardingService.class.php
@@ -361,6 +361,7 @@ class AchAwardingService {
 
 		if ( empty( $wgAchievementsEditAddPhotoOnly ) ) {
 			if ( $this->mTitle->isContentPage() ) {
+				$this->processInTrackPicture();
 				$this->processInTrackEditCategory();
 				$this->processInTrackCategory();
 			}
@@ -371,7 +372,6 @@ class AchAwardingService {
 
 		if ( $this->mTitle->isContentPage() ) {
 			$this->processInTrackEdit();
-			$this->processInTrackPicture();
 		}
 
 		wfProfileOut( __METHOD__ );

--- a/extensions/wikia/AchievementsII/specials/templates/SpecialCustomize.tmpl.php
+++ b/extensions/wikia/AchievementsII/specials/templates/SpecialCustomize.tmpl.php
@@ -39,7 +39,7 @@ foreach( $config->getInTrackStatic() as $badgeTypeId => $trackData ){
 		$tracks[$badgeTypeId] = $trackData;
 		$editPlusCategoryTracks = $config->getInTrackEditPlusCategory();
 
-		if( $editPlusCategoryTracks && empty( $wgAchievementsEditAddPhotoOnly ) ) {
+		if( $editPlusCategoryTracks && empty( $wgAchievementsEditOnly ) ) {
 			foreach( $editPlusCategoryTracks as $editPlusCategoryTypeId => $editPlusCategoryData ) {
 				$tracks[$editPlusCategoryTypeId] = array( 'category' => $editPlusCategoryData['category'], 'enabled' => $editPlusCategoryData['enabled'], 'laps' => $tracks[$badgeTypeId]['laps'], 'infinite' => $tracks[$badgeTypeId]['infinite'] );
 			}
@@ -109,7 +109,7 @@ foreach( $config->getInTrackStatic() as $badgeTypeId => $trackData ){
 <?php
 $sections = array();
 
-if ( empty( $wgAchievementsEditAddPhotoOnly ) ) {
+if ( empty( $wgAchievementsEditOnly ) ) {
 	$sections = array(
 		'special' => array(),
 		'secret' => array()

--- a/extensions/wikia/AchievementsII/specials/templates/SpecialCustomize.tmpl.php
+++ b/extensions/wikia/AchievementsII/specials/templates/SpecialCustomize.tmpl.php
@@ -25,7 +25,7 @@
 	<div class="errorbox"><strong><?= $errorMsg ?></strong></div>
 <?endif;?>
 <?
-global $wgCityId, $wgScriptPath, $wgExternalSharedDB, $wgJsMimeType;
+global $wgCityId, $wgScriptPath, $wgExternalSharedDB, $wgJsMimeType, $wgAchievementsEditOnly;
 
 $tracks = array();
 foreach( $config->getInTrackStatic() as $badgeTypeId => $trackData ){
@@ -39,7 +39,7 @@ foreach( $config->getInTrackStatic() as $badgeTypeId => $trackData ){
 		$tracks[$badgeTypeId] = $trackData;
 		$editPlusCategoryTracks = $config->getInTrackEditPlusCategory();
 
-		if( $editPlusCategoryTracks && empty( $wgAchievementsEditOnly ) ) {
+		if( $editPlusCategoryTracks ) {
 			foreach( $editPlusCategoryTracks as $editPlusCategoryTypeId => $editPlusCategoryData ) {
 				$tracks[$editPlusCategoryTypeId] = array( 'category' => $editPlusCategoryData['category'], 'enabled' => $editPlusCategoryData['enabled'], 'laps' => $tracks[$badgeTypeId]['laps'], 'infinite' => $tracks[$badgeTypeId]['infinite'] );
 			}
@@ -107,8 +107,8 @@ foreach( $config->getInTrackStatic() as $badgeTypeId => $trackData ){
 <?endforeach;?>
 
 <?php
+global $wgAchievementsEditOnly;
 $sections = array();
-
 if ( empty( $wgAchievementsEditOnly ) ) {
 	$sections = array(
 		'special' => array(),
@@ -126,7 +126,6 @@ if ( empty( $wgAchievementsEditOnly ) ) {
 		$sections[$section][] = new AchBadge( $badgeTypeId, null, $badgeData['level'] );
 	}
 }
-
 ?>
 <?foreach($sections as $section => $badges):?>
 	<div class="customize-section" id="section<?= $section; ?>">


### PR DESCRIPTION
Spec change for achievement feature.
1: Remove image badge from achievement for Wookiee. It used to be edit and adding image but now we remove image.
2: Include edit-category (special achievement).
3: Minor bug fix described in INT-270
Ticket: https://wikia-inc.atlassian.net/browse/INT-271
