### PR TITLE
TransactionClassifier: introduce "page/blog"

### DIFF
--- a/includes/wikia/transaction/TransactionClassifier.php
+++ b/includes/wikia/transaction/TransactionClassifier.php
@@ -23,6 +23,13 @@ class TransactionClassifier {
 	const NS_WIKIA_FORUM_BOARD_THREAD = 2001;
 	const NS_WIKIA_FORUM_TOPIC_BOARD = 2002;
 
+	// copied from extensions/wikia/Blogs/Blogs.php to use a constant below
+	// while not being dependant on Blogs extension inclusion
+	const NS_BLOG_ARTICLE = 500;
+	const NS_BLOG_ARTICLE_TALK = 501;
+	const NS_BLOG_LISTING = 502;
+	const NS_BLOG_LISTING_TALK = 503;
+
 	protected static $FILTER_ARTICLE_ACTIONS = array(
 		'view',
 		'edit',
@@ -75,6 +82,11 @@ class TransactionClassifier {
 		self::NS_WIKIA_FORUM_BOARD => 'forum',
 		self::NS_WIKIA_FORUM_BOARD_THREAD => 'forum',
 		self::NS_WIKIA_FORUM_TOPIC_BOARD => 'forum',
+
+		self::NS_BLOG_ARTICLE => 'blog',
+		self::NS_BLOG_ARTICLE_TALK => 'blog',
+		self::NS_BLOG_LISTING => 'blog',
+		self::NS_BLOG_LISTING_TALK => 'blog',
 	);
 
 	protected static $MAP_PARSER_CACHED_USED = array(

--- a/includes/wikia/transaction/tests/TransactionClassifierTest.php
+++ b/includes/wikia/transaction/tests/TransactionClassifierTest.php
@@ -155,6 +155,21 @@ class TransactionClassifierTest extends WikiaBaseTest {
 				],
 				'expectedName' => 'page/user_talk'
 			],
+			# blogs
+			[
+				'attributes' => [
+					Transaction::PARAM_ENTRY_POINT => Transaction::ENTRY_POINT_PAGE,
+					Transaction::PARAM_NAMESPACE => TransactionClassifier::NS_BLOG_ARTICLE,
+				],
+				'expectedName' => 'page/blog'
+			],
+			[
+				'attributes' => [
+					Transaction::PARAM_ENTRY_POINT => Transaction::ENTRY_POINT_PAGE,
+					Transaction::PARAM_NAMESPACE => TransactionClassifier::NS_BLOG_LISTING,
+				],
+				'expectedName' => 'page/blog'
+			],
 		];
 	}
 }


### PR DESCRIPTION
Make transactions reported to NewRelic (and other performance tools) more granular - report requests to blog namespaces as `page/blog` instead of `page/other` (which is responsible for ~9% of a total backend time of all requests).

@wladekb 
