### PR TITLE
MAIN-5937 use getName instead mUsername in wasResetPassAuth

### DIFF
--- a/includes/specials/SpecialUserlogin.php
+++ b/includes/specials/SpecialUserlogin.php
@@ -729,7 +729,7 @@ class LoginForm extends SpecialPage {
 			} else {
 				$retval = ( $this->mPassword  == '' ) ? self::EMPTY_PASS : self::WRONG_PASS;
 			}
-		} elseif ( $wgEnableHeliosExt && Wikia\Helios\User::wasResetPassAuth( $this->mUsername, $this->mPassword ) ) {
+		} elseif ( $wgEnableHeliosExt && Wikia\Helios\User::wasResetPassAuth( $u->getName(), $this->mPassword ) ) {
 			$retval = self::RESET_PASS;
 		} elseif ( $wgBlockDisablesLogin && $u->isBlocked() ) {
 			// If we've enabled it, make it so that a blocked user cannot login


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/MAIN-5937
authenticationCache in helios user use getName from user.
it was not consistent with check for wasResetPassAuth
