### PR TITLE
TransactionClassifier: report "list" query parameter of MW API requests

### DIFF
--- a/api.php
+++ b/api.php
@@ -52,6 +52,7 @@ if ( isset( $_SERVER['MW_COMPILED'] ) ) {
 
 Transaction::setEntryPoint(Transaction::ENTRY_POINT_API);
 Transaction::setAttribute(Transaction::PARAM_API_ACTION, $wgRequest->getVal('action',null));
+Transaction::setAttribute(Transaction::PARAM_API_LIST, $wgRequest->getVal('list',null));
 
 wfProfileIn( 'api.php' );
 $starttime = microtime( true );

--- a/includes/wikia/transaction/Transaction.php
+++ b/includes/wikia/transaction/Transaction.php
@@ -36,6 +36,7 @@ class Transaction {
 	const PARAM_FUNCTION = 'function';
 	const PARAM_SPECIAL_PAGE_NAME = 'special_page';
 	const PARAM_API_ACTION = 'api_action';
+	const PARAM_API_LIST = 'api_list';
 	const PARAM_WIKI = 'wiki';
 	const PARAM_DPL = 'dpl';
 	const PARAM_AB_PERFORMANCE_TEST = 'perf_test';

--- a/includes/wikia/transaction/TransactionClassifier.php
+++ b/includes/wikia/transaction/TransactionClassifier.php
@@ -152,6 +152,7 @@ class TransactionClassifier {
 			// api call - api.php
 			case Transaction::ENTRY_POINT_API:
 				$this->addByList( Transaction::PARAM_API_ACTION, self::$FILTER_API_CALLS );
+				$this->add( Transaction::PARAM_API_LIST );
 				break;
 			// MediaWiki maintenance scripts
 			case Transaction::ENTRY_POINT_MAINTENANCE:

--- a/includes/wikia/transaction/tests/TransactionClassifierTest.php
+++ b/includes/wikia/transaction/tests/TransactionClassifierTest.php
@@ -91,6 +91,13 @@ class TransactionClassifierTest extends WikiaBaseTest {
 			[
 				'attributes' => [
 					Transaction::PARAM_ENTRY_POINT => Transaction::ENTRY_POINT_NIRVANA,
+					Transaction::PARAM_CONTROLLER => 'SearchSuggestionsApi',
+				],
+				'expectedName' => 'api/nirvana/SearchSuggestionsApi'
+			],
+			[
+				'attributes' => [
+					Transaction::PARAM_ENTRY_POINT => Transaction::ENTRY_POINT_NIRVANA,
 					Transaction::PARAM_CONTROLLER => 'Places',
 				],
 				'expectedName' => 'api/nirvana/Places'
@@ -154,6 +161,22 @@ class TransactionClassifierTest extends WikiaBaseTest {
 					Transaction::PARAM_NAMESPACE => NS_USER_TALK,
 				],
 				'expectedName' => 'page/user_talk'
+			],
+			# MW API
+			[
+				'attributes' => [
+					Transaction::PARAM_ENTRY_POINT => Transaction::ENTRY_POINT_API,
+					Transaction::PARAM_API_ACTION => 'query',
+				],
+				'expectedName' => 'api/api/query'
+			],
+			[
+				'attributes' => [
+					Transaction::PARAM_ENTRY_POINT => Transaction::ENTRY_POINT_API,
+					Transaction::PARAM_API_ACTION => 'query',
+					Transaction::PARAM_API_LIST => 'users',
+				],
+				'expectedName' => 'api/api/query/users'
 			],
 		];
 	}


### PR DESCRIPTION
Report `/api.php?action=query&list=users&ususers=macbre&usprop=groups|editcount|gender` MW API requests as `api/api/query/users` transaction for, you're right, better granularity. This specific request is used by permissions service, so let's keep an eye on its performance.

@wladekb / @jcellary 
