### PR TITLE
ADEN-2681 Exclude geo using 'non-' prefix

### DIFF
--- a/extensions/wikia/AdEngine/js/spec/AdContext.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/AdContext.spec.js
@@ -40,15 +40,6 @@ describe('AdContext', function () {
 						return true;
 					}
 					return false;
-				},
-				isProperRegion: function () {
-					return false;
-				},
-				isProperContinent: function () {
-					return false;
-				},
-				isProperCountry: function () {
-					return false;
 				}
 			},
 			instantGlobals: {},

--- a/resources/wikia/modules/geo.js
+++ b/resources/wikia/modules/geo.js
@@ -85,7 +85,12 @@
 		 * @returns {boolean}
 		 */
 		function isProperCountry(countryList) {
-			return !!(countryList && countryList.indexOf && countryList.indexOf(getCountryCode()) > -1);
+			return !!(
+				countryList &&
+				countryList.indexOf &&
+				countryList.indexOf(getCountryCode()) > -1 &&
+				countryList.indexOf('non-' + getCountryCode()) === -1
+			);
 		}
 
 		/**
@@ -97,7 +102,8 @@
 			return !!(
 				countryList &&
 				countryList.indexOf &&
-				countryList.indexOf(getCountryCode() + '-' + getRegionCode()) > -1
+				countryList.indexOf(getCountryCode() + '-' + getRegionCode()) > -1 &&
+				countryList.indexOf('non-' + getCountryCode() + '-' + getRegionCode()) === -1
 			);
 		}
 
@@ -110,10 +116,23 @@
 			if (countryList && countryList.indexOf) {
 				return !!(
 					countryList.indexOf('XX') > -1 ||
-					countryList.indexOf('XX-'+getContinentCode())  > -1
-				);
+					countryList.indexOf('XX-' + getContinentCode()) > -1
+				) && countryList.indexOf('non-XX-' + getContinentCode()) === -1;
 			}
 			return false;
+		}
+
+		/**
+		 * Returns true if current region/country/continent is not excluded in countryList
+		 * @param {array} countryList
+		 * @returns {boolean}
+		 */
+		function isGeoExcluded(countryList) {
+			return !!(
+				countryList.indexOf('non-' + getCountryCode()) > -1 ||
+				countryList.indexOf('non-' + getCountryCode() + '-' + getRegionCode()) > -1 ||
+				countryList.indexOf('non-XX-' + getContinentCode()) > -1
+			);
 		}
 
 		/**
@@ -122,15 +141,14 @@
 		 * @returns {boolean}
 		 */
 		function isProperGeo(countryList) {
-			return  !!(countryList &&
+			return !!(countryList &&
 				countryList.indexOf &&
+				!isGeoExcluded(countryList) &&
 				(isProperContinent(countryList) || isProperCountry(countryList) || isProperRegion(countryList))
 			);
 		}
 
-
 		/** @public **/
-
 		return {
 			getGeoData: getGeoData,
 			getCountryCode: getCountryCode,

--- a/resources/wikia/modules/geo.js
+++ b/resources/wikia/modules/geo.js
@@ -7,7 +7,9 @@
 
 	function geo(cookies) {
 		var cookieName = 'Geo',
-			geoData = false;
+			earth = 'XX',
+			geoData = false,
+			negativePrefix = 'non-';
 
 		/**
 		 * Gets the whole data as an object representation
@@ -88,8 +90,7 @@
 			return !!(
 				countryList &&
 				countryList.indexOf &&
-				countryList.indexOf(getCountryCode()) > -1 &&
-				countryList.indexOf('non-' + getCountryCode()) === -1
+				countryList.indexOf(getCountryCode()) > -1
 			);
 		}
 
@@ -102,8 +103,7 @@
 			return !!(
 				countryList &&
 				countryList.indexOf &&
-				countryList.indexOf(getCountryCode() + '-' + getRegionCode()) > -1 &&
-				countryList.indexOf('non-' + getCountryCode() + '-' + getRegionCode()) === -1
+				countryList.indexOf(getCountryCode() + '-' + getRegionCode()) > -1
 			);
 		}
 
@@ -115,9 +115,9 @@
 		function isProperContinent(countryList) {
 			if (countryList && countryList.indexOf) {
 				return !!(
-					countryList.indexOf('XX') > -1 ||
-					countryList.indexOf('XX-' + getContinentCode()) > -1
-				) && countryList.indexOf('non-XX-' + getContinentCode()) === -1;
+					countryList.indexOf(earth) > -1 ||
+					countryList.indexOf(earth + '-' + getContinentCode()) > -1
+				);
 			}
 			return false;
 		}
@@ -129,9 +129,9 @@
 		 */
 		function isGeoExcluded(countryList) {
 			return !!(
-				countryList.indexOf('non-' + getCountryCode()) > -1 ||
-				countryList.indexOf('non-' + getCountryCode() + '-' + getRegionCode()) > -1 ||
-				countryList.indexOf('non-XX-' + getContinentCode()) > -1
+				countryList.indexOf(negativePrefix + getCountryCode()) > -1 ||
+				countryList.indexOf(negativePrefix + getCountryCode() + '-' + getRegionCode()) > -1 ||
+				countryList.indexOf(negativePrefix + earth + '-' + getContinentCode()) > -1
 			);
 		}
 
@@ -155,10 +155,7 @@
 			getContinentCode: getContinentCode,
 			getRegionCode: getRegionCode,
 			setCountryCode: setCountryCode,
-			isProperGeo: isProperGeo,
-			isProperRegion: isProperRegion,
-			isProperContinent: isProperContinent,
-			isProperCountry: isProperCountry
+			isProperGeo: isProperGeo
 		};
 	}
 

--- a/resources/wikia/modules/spec/geo.spec.js
+++ b/resources/wikia/modules/spec/geo.spec.js
@@ -45,45 +45,40 @@ describe('Geo', function () {
 		expect(geo.getRegionCode()).toBe('72');
 	});
 
-	it('isProperCountry test', function () {
-		expect(geo.isProperCountry(['ZZ', 'PL', 'non-YY'])).toBeTruthy();
-		expect(geo.isProperCountry(['ZZ', 'YY'])).toBeFalsy();
-		expect(geo.isProperCountry(['ZZ', 'non-PL'])).toBeFalsy();
-		expect(geo.isProperCountry(['ZZ', 'PL', 'non-PL'])).toBeFalsy();
-	});
-
-	it('isProperRegion test', function () {
-		expect(geo.isProperRegion(['ZZ', 'PL-72', 'non-PL-33'])).toBeTruthy();
-		expect(geo.isProperRegion(['ZZ', 'PL-33'])).toBeFalsy();
-		expect(geo.isProperRegion(['ZZ', 'non-PL-72'])).toBeFalsy();
-		expect(geo.isProperRegion(['ZZ', 'PL-72', 'non-PL-72'])).toBeFalsy();
-	});
-
-	it('isProperContinent test', function () {
-		expect(geo.isProperContinent(['XX-NA','XX-EU', 'non-XX-SA'])).toBeTruthy();
-		expect(geo.isProperContinent(['XX-NA','XX-SA'])).toBeFalsy();
-		expect(geo.isProperContinent(['XX-NA','XX-SA', 'non-XX-EU'])).toBeFalsy();
-		expect(geo.isProperContinent(['XX-NA','XX-EU', 'non-XX-EU'])).toBeFalsy();
-	});
-
-	it('isProperContinent test - any region (XX)', function () {
-		expect(geo.isProperContinent(['XX'])).toBeTruthy();
-		expect(geo.isProperContinent(['XX', 'non-XX-SA'])).toBeTruthy();
-		expect(geo.isProperContinent(['XX', 'non-XX-EU'])).toBeFalsy();
-	});
-
 	it('isProperGeo test', function () {
-		expect(geo.isProperGeo(['PL'])).toBeTruthy();
-		expect(geo.isProperGeo(['XX-EU'])).toBeTruthy();
-		expect(geo.isProperGeo(['XX'])).toBeTruthy();
-		expect(geo.isProperGeo(['PL-72'])).toBeTruthy();
-		expect(geo.isProperGeo(['non-PL'])).toBeFalsy();
-		expect(geo.isProperGeo(['non-PL-72'])).toBeFalsy();
-		expect(geo.isProperGeo(['non-XX-EU'])).toBeFalsy();
-		expect(geo.isProperGeo(['XX', 'non-PL'])).toBeFalsy();
-		expect(geo.isProperGeo(['XX', 'non-PL-72'])).toBeFalsy();
-		expect(geo.isProperGeo(['XX', 'non-XX-EU'])).toBeFalsy();
-
 		expect(geo.isProperGeo()).toBeFalsy();
+
+		// Region
+		expect(geo.isProperGeo(['PL-72'])).toBeTruthy();
+		expect(geo.isProperGeo(['ZZ', 'PL-72', 'non-PL-33'])).toBeTruthy();
+		expect(geo.isProperGeo(['ZZ', 'PL-33'])).toBeFalsy();
+		expect(geo.isProperGeo(['non-PL-72'])).toBeFalsy();
+		expect(geo.isProperGeo(['ZZ', 'non-PL-72'])).toBeFalsy();
+		expect(geo.isProperGeo(['ZZ', 'PL-72', 'non-PL-72'])).toBeFalsy();
+
+		// Country
+		expect(geo.isProperGeo(['PL'])).toBeTruthy();
+		expect(geo.isProperGeo(['ZZ', 'PL', 'non-YY'])).toBeTruthy();
+		expect(geo.isProperGeo(['ZZ', 'YY'])).toBeFalsy();
+		expect(geo.isProperGeo(['non-PL'])).toBeFalsy();
+		expect(geo.isProperGeo(['ZZ', 'non-PL'])).toBeFalsy();
+		expect(geo.isProperGeo(['ZZ', 'PL', 'non-PL'])).toBeFalsy();
+
+		// Continent
+		expect(geo.isProperGeo(['XX-EU'])).toBeTruthy();
+		expect(geo.isProperGeo(['XX-NA','XX-EU', 'non-XX-SA'])).toBeTruthy();
+		expect(geo.isProperGeo(['XX-NA','XX-SA'])).toBeFalsy();
+		expect(geo.isProperGeo(['XX-NA','XX-SA', 'non-XX-EU'])).toBeFalsy();
+		expect(geo.isProperGeo(['XX-NA','XX-EU', 'non-XX-EU'])).toBeFalsy();
+		expect(geo.isProperGeo(['non-XX-EU'])).toBeFalsy();
+
+		// Earth
+		expect(geo.isProperGeo(['XX'])).toBeTruthy();
+		expect(geo.isProperGeo(['XX', 'non-PL-33'])).toBeTruthy();
+		expect(geo.isProperGeo(['XX', 'non-PL-72'])).toBeFalsy();
+		expect(geo.isProperGeo(['XX', 'non-DE'])).toBeTruthy();
+		expect(geo.isProperGeo(['XX', 'non-PL'])).toBeFalsy();
+		expect(geo.isProperGeo(['XX', 'non-XX-SA'])).toBeTruthy();
+		expect(geo.isProperGeo(['XX', 'non-XX-EU'])).toBeFalsy();
 	});
 });

--- a/resources/wikia/modules/spec/geo.spec.js
+++ b/resources/wikia/modules/spec/geo.spec.js
@@ -2,8 +2,8 @@
  @test-require-asset /resources/wikia/libraries/define.mock.js
  @test-require-asset /resources/wikia/modules/geo.js
  */
-
-describe("Geo", function () {
+/*global it, describe, expect, modules, window*/
+describe('Geo', function () {
 	'use strict';
 
 	window.Wikia = {
@@ -14,14 +14,14 @@ describe("Geo", function () {
 	var cookieData = '{"city":"Poznan","country":"PL","continent":"EU","region":"72"}',
 		cookieName = 'Geo',
 		cookiesMock = {
-			get: function(name) {
+			get: function (name) {
 				expect(name).toBe(cookieName);
 				return cookieData;
 			}
 		},
 		geo = modules['wikia.geo'](cookiesMock);
 
-	it('registers AMD module', function() {
+	it('registers AMD module', function () {
 		expect(typeof geo).toBe('object');
 
 		expect(typeof geo.getGeoData).toBe('function');
@@ -29,46 +29,60 @@ describe("Geo", function () {
 		expect(typeof geo.getContinentCode).toBe('function');
 	});
 
-	it('getGeoData returns parsed data', function() {
+	it('getGeoData returns parsed data', function () {
 		var geoData = geo.getGeoData();
 
 		expect(typeof geoData).toBe('object');
 		expect(geoData.city).toBe('Poznan');
 	});
 
-	it('returns country and continent code', function() {
+	it('returns country and continent code', function () {
 		expect(geo.getCountryCode()).toBe('PL');
 		expect(geo.getContinentCode()).toBe('EU');
 	});
 
-	it('returns region code', function() {
+	it('returns region code', function () {
 		expect(geo.getRegionCode()).toBe('72');
 	});
 
-	it('isProperCountry test', function() {
-		expect(geo.isProperCountry(['ZZ', 'PL'])).toBeTruthy();
+	it('isProperCountry test', function () {
+		expect(geo.isProperCountry(['ZZ', 'PL', 'non-YY'])).toBeTruthy();
 		expect(geo.isProperCountry(['ZZ', 'YY'])).toBeFalsy();
+		expect(geo.isProperCountry(['ZZ', 'non-PL'])).toBeFalsy();
+		expect(geo.isProperCountry(['ZZ', 'PL', 'non-PL'])).toBeFalsy();
 	});
 
-	it('isProperRegion test', function() {
-		expect(geo.isProperRegion(['ZZ', 'PL-72'])).toBeTruthy();
+	it('isProperRegion test', function () {
+		expect(geo.isProperRegion(['ZZ', 'PL-72', 'non-PL-33'])).toBeTruthy();
 		expect(geo.isProperRegion(['ZZ', 'PL-33'])).toBeFalsy();
+		expect(geo.isProperRegion(['ZZ', 'non-PL-72'])).toBeFalsy();
+		expect(geo.isProperRegion(['ZZ', 'PL-72', 'non-PL-72'])).toBeFalsy();
 	});
 
-	it('isProperContinent test', function() {
-		expect(geo.isProperContinent(['XX-NA','XX-EU'])).toBeTruthy();
+	it('isProperContinent test', function () {
+		expect(geo.isProperContinent(['XX-NA','XX-EU', 'non-XX-SA'])).toBeTruthy();
 		expect(geo.isProperContinent(['XX-NA','XX-SA'])).toBeFalsy();
+		expect(geo.isProperContinent(['XX-NA','XX-SA', 'non-XX-EU'])).toBeFalsy();
+		expect(geo.isProperContinent(['XX-NA','XX-EU', 'non-XX-EU'])).toBeFalsy();
 	});
 
-	it('isProperContinent test - any region (XX)', function() {
+	it('isProperContinent test - any region (XX)', function () {
 		expect(geo.isProperContinent(['XX'])).toBeTruthy();
+		expect(geo.isProperContinent(['XX', 'non-XX-SA'])).toBeTruthy();
+		expect(geo.isProperContinent(['XX', 'non-XX-EU'])).toBeFalsy();
 	});
 
-	it('isProperGeo test', function() {
+	it('isProperGeo test', function () {
 		expect(geo.isProperGeo(['PL'])).toBeTruthy();
 		expect(geo.isProperGeo(['XX-EU'])).toBeTruthy();
 		expect(geo.isProperGeo(['XX'])).toBeTruthy();
 		expect(geo.isProperGeo(['PL-72'])).toBeTruthy();
+		expect(geo.isProperGeo(['non-PL'])).toBeFalsy();
+		expect(geo.isProperGeo(['non-PL-72'])).toBeFalsy();
+		expect(geo.isProperGeo(['non-XX-EU'])).toBeFalsy();
+		expect(geo.isProperGeo(['XX', 'non-PL'])).toBeFalsy();
+		expect(geo.isProperGeo(['XX', 'non-PL-72'])).toBeFalsy();
+		expect(geo.isProperGeo(['XX', 'non-XX-EU'])).toBeFalsy();
 
 		expect(geo.isProperGeo()).toBeFalsy();
 	});


### PR DESCRIPTION
Changes:
- possibility to exclude region/country/continent from countryList using `non-` prefix
- fixed code style errors
