### PR TITLE
ER-9507: add an assert on Parser::mSubstWords instead of throwing a fatal

### DIFF
--- a/includes/parser/Parser.php
+++ b/includes/parser/Parser.php
@@ -3387,6 +3387,7 @@ class Parser {
 		# SUBST
 		wfProfileIn( __METHOD__.'-modifiers' );
 		if ( !$found ) {
+			Wikia\Util\Assert::true( $this->mSubstWords instanceof MagicWordArray, 'Parser::mSubstWords should be an instance of MagicWordArray', [ 'part1' => $part1 ] ); // ER-9507
 
 			$substMatch = $this->mSubstWords->matchStartAndRemove( $part1 );
 


### PR DESCRIPTION
[ER-9507](https://wikia-inc.atlassian.net/browse/ER-9507)

Report a backtrace instead of throwing a fatal:

```
PHP Fatal Error: Call to a member function matchStartAndRemove() on null in /includes/parser/Parser.php on line 3391
```

@michalroszka 
