### PR TITLE
PLATFORM-1659: decrease the request retry delay

### DIFF
--- a/extensions/SwiftCloudFiles/php-cloudfiles-1.7.10/cloudfiles_http.php
+++ b/extensions/SwiftCloudFiles/php-cloudfiles-1.7.10/cloudfiles_http.php
@@ -1510,7 +1510,7 @@ class CF_Http
 	// Wikia change - begin
 	// retry request in case of an error
 	const MAX_RETRIES = 5;
-	const RETRY_DELAY = 1000; // ms
+	const RETRY_DELAY = 250; // ms
 
 	private function _send_request($conn_type, $url_path, $hdrs=NULL, $method="GET", $force_new=False) {
 		$retriesLeft = self::MAX_RETRIES;


### PR DESCRIPTION
Let's decrease the Swift client request retry delay to 250 ms (after a suggestion from @wladekb)

Our logs claim that in 99% of cases one retry is enough.

See #9083
