### PR TITLE
Ce 3107 restrict mw ns move

### DIFF
--- a/includes/Exception.php
+++ b/includes/Exception.php
@@ -374,24 +374,31 @@ class PermissionsError extends ErrorPageError {
 	public $permission, $errors;
 
 	function __construct( $permission, $errors = array() ) {
-		global $wgLang;
-
 		$this->permission = $permission;
 
 		if ( !count( $errors ) ) {
-			$groups = array_map(
-				array( 'User', 'makeGroupLinkWiki' ),
-				User::getGroupsWithPermission( $this->permission )
-			);
-
-			if ( $groups ) {
-				$errors[] = array( 'badaccess-groups', $wgLang->commaList( $groups ), count( $groups ) );
-			} else {
-				$errors[] = array( 'badaccess-group0' );
-			}
+			$errors[] = self::prepareBadAccessErrorArray( $this->permission );
 		}
 
 		$this->errors = $errors;
+	}
+
+	/**
+	 * @param string $permission Name of action
+	 * @return array error message key and message params (optionally)
+	 */
+	public static function prepareBadAccessErrorArray( $permission ) {
+		global $wgLang;
+		$groups = array_map(
+			[ 'User', 'makeGroupLinkWiki' ],
+			User::getGroupsWithPermission( $permission )
+		);
+
+		if ( $groups ) {
+			return [ 'badaccess-groups', $wgLang->commaList( $groups ), count( $groups ) ];
+		}
+
+		return [ 'badaccess-group0' ];
 	}
 
 	function report() {

--- a/includes/specials/SpecialMovepage.php
+++ b/includes/specials/SpecialMovepage.php
@@ -419,6 +419,13 @@ class MovePageForm extends UnlistedSpecialPage {
 			return;
 		}
 
+		# Check rights for new title
+		$permErrors = $nt->getUserPermissionsErrors( 'move', $user );
+		if ( count( $permErrors ) ) {
+			$this->showForm( $permErrors );
+			return;
+		}
+
 		# don't allow moving to pages with # in
 		if ( !$nt || $nt->getFragment() != '' ) {
 			$this->showForm( array( array( 'badtitletext' ) ) );

--- a/includes/specials/SpecialUndelete.php
+++ b/includes/specials/SpecialUndelete.php
@@ -328,9 +328,9 @@ class PageArchive {
 	function undelete( $timestamps, $comment = '', $fileVersions = array(), $unsuppress = false ) {
 		global $wgUser;
 
-		$resultMock = '';
-		if ( !$this->title->userCan( 'undelete' ) ) {
-			throw new PermissionsError( 'editinterfacetrusted' );
+		$permErrors = $this->title->getUserPermissionsErrors( 'undelete', $wgUser );
+		if ( count( $permErrors ) ) {
+			throw new PermissionsError( 'undelete', $permErrors );
 		}
 
 		// If both the set of text revisions and file revisions are empty,

--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -2333,19 +2333,20 @@ class Wikia {
 	 * usually return true to allow processing other hooks
 	 * return false stops permissions processing and we are totally decided (nothing later can override)
 	 */
-	static function canEditInterfaceWhitelist (&$title, &$wgUser, $action, &$result) {
+	static function canEditInterfaceWhitelist ( &$title, &$wgUser, $action, &$result ) {
 		global $wgEditInterfaceWhitelist;
 
 		// List the conditions we don't care about for early exit
 		if ( $action == "read"
 			|| $action == "undelete" // Is being checked in next hook canUndeleteMediaWikiNS
 			|| $title->getNamespace() != NS_MEDIAWIKI
-			|| empty( $wgEditInterfaceWhitelist )) {
+			|| empty( $wgEditInterfaceWhitelist )
+		) {
 			return true;
 		}
 
 		// Allow trusted users to edit interface messages (util, vstf, select admins)
-		if ( $wgUser->isAllowed('editinterfacetrusted') ) {
+		if ( $wgUser->isAllowed( 'editinterfacetrusted' ) ) {
 			return true;
 		}
 
@@ -2359,7 +2360,7 @@ class Wikia {
 			|| ( Wikia::isUsingSafeJs() && $title->isJsPage() )
 			|| startsWith( lcfirst( $title->getDBKey() ), self::CUSTOM_INTERFACE_PREFIX )
 		) {
-			return $wgUser->isAllowed('editinterface');
+			return $wgUser->isAllowed( 'editinterface' );
 		}
 
 		return false;
@@ -2373,17 +2374,15 @@ class Wikia {
 	 * @param $result Allows to pass error. Set $result true to allow, false to deny, leave alone means don't care
 	 * @return bool False to break flow to throw an error, true to continue
 	 */
-	public static function canMoveMediaWikiNS(\Title $title, \User $user, $action, &$result) {
-		global $wgLang;
-		if ( $action === 'move' && $title->inNamespace( NS_MEDIAWIKI ) && !$user->isAllowed('editinterfacetrusted') ) {
-			$groups = array_map(
-				array( 'User', 'makeGroupLinkWiki' ),
-				User::getGroupsWithPermission( 'editinterfacetrusted' )
-			);
-			$result = [ [ 'badaccess-groups', $wgLang->commaList( $groups ), count( $groups ) ] ];
+	public static function canMoveMediaWikiNS( \Title $title, \User $user, $action, &$result ) {
+		if ( $action === 'move'
+			&& $title->inNamespace( NS_MEDIAWIKI )
+			&& !$user->isAllowed( 'editinterfacetrusted' )
+		) {
+			$result = [ \PermissionsError::prepareBadAccessErrorArray( 'editinterfacetrusted' ) ];
 			return false;
 		}
-		$result = true;
+
 		return true;
 	}
 
@@ -2395,19 +2394,15 @@ class Wikia {
 	 * @param $result Allows to pass error. Set $result true to allow, false to deny, leave alone means don't care
 	 * @return bool False to break flow to throw an error, true to continue
 	 */
-	public static function canUndeleteMediaWikiNS(\Title $title, \User $user, $action, &$result) {
-		global $wgLang;
+	public static function canUndeleteMediaWikiNS( \Title $title, \User $user, $action, &$result ) {
 		if ( $action === 'undelete'
 			&& $title->inNamespace( NS_MEDIAWIKI )
-			&& !$user->isAllowed('editinterfacetrusted') ) {
-			$groups = array_map(
-				array( 'User', 'makeGroupLinkWiki' ),
-				User::getGroupsWithPermission( 'editinterfacetrusted' )
-			);
-			$result = [ [ 'badaccess-groups', $wgLang->commaList( $groups ), count( $groups ) ] ];
+			&& !$user->isAllowed( 'editinterfacetrusted' )
+		) {
+			$result = [ \PermissionsError::prepareBadAccessErrorArray( 'editinterfacetrusted' ) ];
 			return false;
 		}
-		$result = true;
+
 		return true;
 	}
 

--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -2336,9 +2336,15 @@ class Wikia {
 	static function canEditInterfaceWhitelist ( &$title, &$wgUser, $action, &$result ) {
 		global $wgEditInterfaceWhitelist;
 
+		// Allowed actions at this point
+		$notRelevantActions = [
+			'read',
+			'move', // Is being checked in next hook canMoveMediaWikiNS
+			'undelete' // Is being checked in next hook canUndeleteMediaWikiNS
+		];
+
 		// List the conditions we don't care about for early exit
-		if ( $action == "read"
-			|| $action == "undelete" // Is being checked in next hook canUndeleteMediaWikiNS
+		if ( in_array( $action, $notRelevantActions )
 			|| $title->getNamespace() != NS_MEDIAWIKI
 			|| empty( $wgEditInterfaceWhitelist )
 		) {

--- a/languages/messages/MessagesEn.php
+++ b/languages/messages/MessagesEn.php
@@ -3008,7 +3008,6 @@ It may have already been undeleted.',
 $1',
 'undelete-show-file-confirm'   => 'Are you sure you want to view the deleted revision of the file "<nowiki>$1</nowiki>" from $2 at $3?',
 'undelete-show-file-submit'    => 'Yes',
-'action-editinterfacetrusted'  => 'restore pages in MediaWiki namespace',
 
 # Namespace form on various pages
 'namespace'                     => 'Namespace:',


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CE-3107

Moving into within and out of MW namespace for whitelisted pages was allowed.
This is restricting moves for whitelisted pages as well.

Also did some refactoring of 'move' error messages to be more verbose and display allowed groups as well and in same way changed check for 'undelete' to check for 'editinterfacetrusted' right and reuse message for 'undelete' that already exists.

@Wikia/community-engineering 
