### PR TITLE
PLATFORM-1724 : Newwikis API entry point does not work

### DIFF
--- a/extensions/wikia/SpecialNewWikis/SpecialNewWikis.php
+++ b/extensions/wikia/SpecialNewWikis/SpecialNewWikis.php
@@ -25,28 +25,17 @@ $wgExtensionCredits['specialpage'][] = array(
 	'url' => 'https://github.com/Wikia/app/tree/dev/extensions/wikia/SpecialNewWikis'
 );
 
-$wgHooks['wgQueryPages'][] = 'wfSetupNewWikis';
-
 #--- messages file
 $wgExtensionMessagesFiles["Newwikis"] = __DIR__ . '/SpecialNewWikis.i18n.php';
 
-if ( !function_exists( 'extAddSpecialPage' ) ) {
-    require_once ( "$IP/extensions/ExtensionFunctions.php" );
-}
-
-extAddSpecialPage( dirname(__FILE__) . '/SpecialNewWikis_body.php', 'Newwikis', 'NewWikisSpecialPage' );
-
+#--- special pages
 $wgSpecialPageGroups['Newwikis'] = 'highuse';
+$wgSpecialPages['Newwikis'] = 'NewWikisSpecialPage';
+
+#--- classes autoloading
+$wgAutoloadClasses['NewWikisSpecialPage'] = __DIR__ . '/SpecialNewWikis_body.php';
+$wgAutoloadClasses['NewWikisPage'       ] = __DIR__ . '/SpecialNewWikis_body.php';
 
 $wgAvailableRights[] = 'newwikislist';
 $wgGroupPermissions['*']['newwikislist'] = false;
 $wgGroupPermissions['staff']['newwikislist'] = true;
-
-/**
- * @param array $queryPages
- * @return bool
- */
-function wfSetupNewWikis( &$queryPages ) {
-    $queryPages[] = array( 'NewWikisPage', 'Newwikis');
-    return true;
-}


### PR DESCRIPTION
[PLATFORM-1724](https://wikia-inc.atlassian.net/browse/PLATFORM-1724)

And probably never did. So remove the API query page registration and refactor how Special:NewWikis is set up.

I've tried to implement the NewWikis QueryPage class, but the way I had to build it scared me pretty badly ;) One can always use `format=csv` feature of a special page to get machine-readable data.

@michalroszka / @wladekb 
