### PR TITLE
Enable (more) text level semantics

### DIFF
--- a/includes/Sanitizer.php
+++ b/includes/Sanitizer.php
@@ -383,7 +383,7 @@ class Sanitizer {
 				'strike', 'strong', 'tt', 'var', 'div', 'center',
 				'blockquote', 'ol', 'ul', 'dl', 'table', 'caption', 'pre',
 				'ruby', 'rt' , 'rb' , 'rp', 'p', 'span', 'abbr', 'q', 'acronym', 'dfn',
-				'kbd', 'samp'
+				'kbd', 'samp', 'nav', 'time'
 			);
 			$htmlsingle = array(
 				'br', 'hr', 'li', 'dt', 'dd'


### PR DESCRIPTION
This change allows two additional HTML elements to be used in the content area: `nav` and `time`. 

As a step towards portability, in the [Portability Checklist](https://docs.google.com/document/d/1Kty5cRAMucbuBZXzYaa558NXQnmjnoTXWhpKX-bdW1w/edit) we have introduced a soft rule (not enforced by the system yet) for users to not used `div` elements outside of a limited set of recognised elements (templates).

Another route for replacing `div` elements is to use more meaningful semantic text elements. Adding these two to the list may give users more options.

CC: @SebastianMarzjan @Wikia/community-engineering @RafLeszczynski @idradm @dianafa 
