### PR TITLE
CE-3034: Posibility to add custom badges to users without review process

### DIFF
--- a/extensions/wikia/ContentReview/ContentReview.hooks.php
+++ b/extensions/wikia/ContentReview/ContentReview.hooks.php
@@ -39,7 +39,13 @@ class Hooks {
 		$title = $out->getTitle();
 
 		if ( $title->exists() ) {
-			$content = $this->getImportJSContent( $title, $content );
+			if ( ImportJS::isImportJSPage( $title ) ) {
+				$message = ImportJS::getImportJSDescriptionMessage();
+				$content = $this->prepareContent( $title, $content, $message );
+			} elseif ( UserBadges::isUserBadgesPage( $title ) ) {
+				$message = UserBadges::getUserBadgesDescriptionMessage();
+				$content = $this->prepareContent( $title, $content, $message );
+			}
 		}
 
 		return true;
@@ -53,7 +59,15 @@ class Hooks {
 	 * @return bool
 	 */
 	public function onArticleNonExistentPage( \Article $article, \OutputPage $out, &$content ) {
-		$content = $this->getImportJSContent( $article->getTitle(), $content, false );
+		$title = $article->getTitle();
+
+		if ( ImportJS::isImportJSPage( $title ) ) {
+			$message = ImportJS::getImportJSDescriptionMessage();
+			$content = $this->prepareContent( $title, $content, $message, false );
+		} elseif ( UserBadges::isUserBadgesPage( $title ) ) {
+			$message = UserBadges::getUserBadgesDescriptionMessage();
+			$content = $this->prepareContent( $title, $content, $message, false );
+		}
 
 		return true;
 	}
@@ -355,15 +369,12 @@ class Hooks {
 		ContentReviewStatusesService::purgeJsPagesCache();
 	}
 
-	private function getImportJSContent( \Title $title, $content, $parse = true ) {
-		if ( ImportJS::isImportJSPage( $title ) ) {
-			$isViewPage = empty( \RequestContext::getMain()->getRequest()->getVal( 'action' ) );
+	private function prepareContent( \Title $title, $content, \Message $message, $parse = true ) {
+		$isViewPage = empty( \RequestContext::getMain()->getRequest()->getVal( 'action' ) );
 
-			if ( $isViewPage ) {
-				$message = ImportJS::getImportJSDescriptionMessage();
-				$text = $parse ? $message->parse() : $message->escaped();
-				$content = $text . '<pre>' . trim( strip_tags( $content ) ) . '</pre>';
-			}
+		if ( $isViewPage ) {
+			$text = $parse ? $message->parse() : $message->escaped();
+			$content = $text . '<pre>' . trim( strip_tags( $content ) ) . '</pre>';
 		}
 
 		return $content;

--- a/extensions/wikia/ContentReview/ContentReview.i18n.php
+++ b/extensions/wikia/ContentReview/ContentReview.i18n.php
@@ -49,8 +49,14 @@ The recently submitted change to this JavaScript page (revision [$2 $3]) was rej
 Names should not contain the MediaWiki namespace prefix. Write each script on a new line. See [[Help:Including additional CSS and JS]] for more information.
 ----
 ',
-	'content-review-user-badges-description' => 'Here, you can easily add custom badges to users. Just separate user name and rights by colon. If there is more rights list them using comma,
-e.g. User name : Trainee, Newbie. Write each pair on a new line.
+	'content-review-user-badges-description' => 'To use this feature, you must import UserBadges.js from dev.wikia.com. [[w:c:dev:UserBadges.js/doc|Learn more]]
+
+    Use this page to customize the badges that appear on user profiles. Separate usernames and badges by a colon. To display multiple badges for a user, separate each badge text with commas. Write each username on a new line.
+
+    Examples:
+
+    * ExampleUsername : Trainee, Newbie
+    * ExampleUsername2 : Guru
 ----
 ',
 );
@@ -97,6 +103,11 @@ $messages['qqq'] = array(
 	'content-review-special-js-description' => 'Text with description of this special page that contains lists with all scripts in MediaWiki namespace on that community with their review statuses and linking to help page.',
 	'content-review-special-js-importjs-description' => 'Information that user can manage script imports from community or dev.wikia.com by editing  MediaWiki:ImportJS page.',
 	'content-review-importjs-description' => 'Information for user how to add scripts. For scripts from local wikia, user should only add article name and from dev.wikia.com should preceded them by "dev:". Also user should add MediaWiki namespace and should add each script in separate line.',
+	'content-review-user-badges-description' => 'Inform user that to use this feature user must import UserBadge.js script from dev.wikia.com. Then explain that user should use current page to customize user badges on their profiles by adding user name and badges separated by colon.
+	 If user wants to provide for than one badge for user should separate them by comma. Also each user name should be written in new line. Examples:
+
+    * ExampleUsername : Trainee, Newbie
+    * ExampleUsername2 : Guru'
 );
 
 $messages['de'] = array(

--- a/extensions/wikia/ContentReview/ContentReview.i18n.php
+++ b/extensions/wikia/ContentReview/ContentReview.i18n.php
@@ -49,7 +49,7 @@ The recently submitted change to this JavaScript page (revision [$2 $3]) was rej
 Names should not contain the MediaWiki namespace prefix. Write each script on a new line. See [[Help:Including additional CSS and JS]] for more information.
 ----
 ',
-	'content-review-user-badges-description' => 'To use this feature, you must import UserBadges.js from dev.wikia.com. [[w:c:dev:UserBadges.js/doc|Learn more]]
+	'content-review-user-badges-description' => 'To use this feature, you must import [[w:c:dev:UserBadges|UserBadges.js]] from dev.wikia.com. [[w:c:dev:UserBadges|Learn more]].
 
     Use this page to customize the badges that appear on user profiles. Separate usernames and badges by a colon. To display multiple badges for a user, separate each badge text with commas. Write each username on a new line.
 

--- a/extensions/wikia/ContentReview/ContentReview.i18n.php
+++ b/extensions/wikia/ContentReview/ContentReview.i18n.php
@@ -49,6 +49,10 @@ The recently submitted change to this JavaScript page (revision [$2 $3]) was rej
 Names should not contain the MediaWiki namespace prefix. Write each script on a new line. See [[Help:Including additional CSS and JS]] for more information.
 ----
 ',
+	'content-review-user-badges-description' => 'Here, you can easily add custom badges to users. Just separate user name and rights by colon. If there is more rights list them using comma,
+e.g. User name : Trainee, Newbie. Write each pair on a new line.
+----
+',
 );
 
 $messages['qqq'] = array(

--- a/extensions/wikia/ContentReview/ContentReview.i18n.php
+++ b/extensions/wikia/ContentReview/ContentReview.i18n.php
@@ -51,12 +51,12 @@ Names should not contain the MediaWiki namespace prefix. Write each script on a 
 ',
 	'content-review-user-badges-description' => 'To use this feature, you must import [[w:c:dev:UserBadges|UserBadges.js]] from dev.wikia.com. [[w:c:dev:UserBadges|Learn more]].
 
-    Use this page to customize the badges that appear on user profiles. Separate usernames and badges by a colon. To display multiple badges for a user, separate each badge text with commas. Write each username on a new line.
+Use this page to customize the badges that appear on user profiles. Separate usernames and badges by a colon. To display multiple badges for a user, separate each badge text with commas. Write each username on a new line.
 
-    Examples:
+Examples:
 
-    * ExampleUsername : Trainee, Newbie
-    * ExampleUsername2 : Guru
+ ExampleUsername : Trainee, Newbie
+ ExampleUsername2 : Guru
 ----
 ',
 );

--- a/extensions/wikia/ContentReview/ContentReview.setup.php
+++ b/extensions/wikia/ContentReview/ContentReview.setup.php
@@ -67,7 +67,8 @@ $wgAutoloadClasses['Wikia\ContentReview\ContentReviewStatusesService'] = __DIR__
  * Helpers
  */
 $wgAutoloadClasses['Wikia\ContentReview\Helper'] = __DIR__ . '/ContentReviewHelper.php';
-$wgAutoloadClasses['Wikia\ContentReview\ImportJS'] = __DIR__ . '/ContentReviewImportJS.php';
+$wgAutoloadClasses['Wikia\ContentReview\ImportJS'] = __DIR__ . '/jsmodules/ImportJS.php';
+$wgAutoloadClasses['Wikia\ContentReview\UserBadges'] = __DIR__ . '/jsmodules/UserBadges.php';
 
 /**
  * Hooks

--- a/extensions/wikia/ContentReview/jsmodules/ImportJS.php
+++ b/extensions/wikia/ContentReview/jsmodules/ImportJS.php
@@ -3,7 +3,7 @@
 namespace Wikia\ContentReview;
 
 class ImportJS {
-	const IMPORT_SCRIPTS_ENTRYPOINT = 'ImportJS';
+	const MODULE_ENTRYPOINT = 'ImportJS';
 	const IMPORT_SCRIPTS_FUNCTION = 'importWikiaScriptPages';
 	const IMPORT_SCRIPTS_KEY = 'content-review-importjs';
 	const IMPORT_SCRIPTS_VERSION = '1.0';
@@ -19,7 +19,7 @@ class ImportJS {
 			2592000, // 30 days,
 			function() {
 				$importScripts = '';
-				$title = \Title::newFromText( self::IMPORT_SCRIPTS_ENTRYPOINT, NS_MEDIAWIKI );
+				$title = \Title::newFromText( self::MODULE_ENTRYPOINT, NS_MEDIAWIKI );
 
 				if ( $title instanceof \Title && $title->exists() ) {
 					$revision = \Revision::newFromTitle( $title );
@@ -100,7 +100,7 @@ class ImportJS {
 	 * @return bool
 	 */
 	static public function isImportJSPage( \Title $title ) {
-		return $title->inNamespace( NS_MEDIAWIKI ) && $title->getText() === self::IMPORT_SCRIPTS_ENTRYPOINT;
+		return $title->inNamespace( NS_MEDIAWIKI ) && $title->getText() === self::MODULE_ENTRYPOINT;
 	}
 
 	/**

--- a/extensions/wikia/ContentReview/jsmodules/UserBadges.php
+++ b/extensions/wikia/ContentReview/jsmodules/UserBadges.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Wikia\ContentReview;
+
+class UserBadges {
+	const MODULE_ENTRYPOINT = 'UserBadges';
+
+	/**
+	 * Check if given page is MediaWiki:UserBadges page
+	 *
+	 * @param \Title $title
+	 * @return bool
+	 */
+	static public function isUserBadgesPage( \Title $title ) {
+		return $title->inNamespace( NS_MEDIAWIKI ) && $title->getText() === self::MODULE_ENTRYPOINT;
+	}
+
+	/**
+	 * Get description how to manage user badges
+	 *
+	 * @return \Message
+	 */
+	static public function getUserBadgesDescriptionMessage() {
+		return wfMessage( 'content-review-user-badges-description' );
+	}
+}

--- a/extensions/wikia/UserProfilePageV3/css/UserProfilePage.scss
+++ b/extensions/wikia/UserProfilePageV3/css/UserProfilePage.scss
@@ -135,7 +135,7 @@ $color-user-profile-gradient-bottom: desaturate(darken($color-menu-highlight, 5%
 			text-transform: uppercase;
 			top: -4px;
 			+.tag {
-				margin-left: 0;
+				margin-left: 5px;
 			}
 		}
 		h2 {


### PR DESCRIPTION
To add custom badge, user needs to import script from dev.wikia.com/wiki/UserBadges.js (https://gist.github.com/lukaszkonieczny/c9cb046a7b0c5819a07d) and add pairs containing user name and rights on local wiki in MediaWiki:UserBadges article.

Do not merge without https://github.com/Wikia/config/pull/1495
