### PR TITLE
Hide ads when ChangePay triggers paid event

### DIFF
--- a/extensions/wikia/AdEngine/AdEngine2Hooks.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2Hooks.class.php
@@ -322,6 +322,7 @@ changePay.init({
         console.log("canonical is: " + changePay.get_canonical_url());
     },
     paid: function(status_code, msg) {
+	$('wikia-ad').hide();
         console.log(status_code, "You are paid up, or no payment is required!");
     },
     unpaid: function(status_code, msg) {


### PR DESCRIPTION
I'm not sure if Wikia has another method to hide ads, including site skins that aren't matched by this simple jQuery selector, but please merge this if it'll help move you forward.
