### PR TITLE
VE-2080: Set Ooyala video player to prioritize HTML5 over Flash

### DIFF
--- a/extensions/wikia/VideoHandlers/handlers/OoyalaVideoHandler.class.php
+++ b/extensions/wikia/VideoHandlers/handlers/OoyalaVideoHandler.class.php
@@ -16,7 +16,7 @@ class OoyalaVideoHandler extends VideoHandler {
 		$playerId = 'ooyalaplayer-'.$this->videoId.'-'.intval($isAjax);
 
 		$ooyalaPlayerId = F::app()->wg->OoyalaApiConfig['playerId'];
-		$jsFile = 'http://player.ooyala.com/v3/'.$ooyalaPlayerId;
+		$jsFile = 'http://player.ooyala.com/v3/'.$ooyalaPlayerId.'?platform=html5-priority';
 
 		$autoPlayStr = ( $autoplay ) ? 'true' : 'false';
 

--- a/extensions/wikia/VideoHandlers/js/handlers/Ooyala.js
+++ b/extensions/wikia/VideoHandlers/js/handlers/Ooyala.js
@@ -91,6 +91,14 @@ define('wikia.videohandler.ooyala', [
 			createParams.vast = {
 				tagUrl: tagUrl
 			};
+
+			createParams.vastAds = [{
+				first_shown: 0,
+				frequency: 1,
+				type: 'vast',
+				time: 0,
+				url: tagUrl
+			}];
 		}
 
 		// log any errors from failed script loading (VID-976)


### PR DESCRIPTION
As seen here: http://support.ooyala.com/developers/documentation/api/player_v3_api_qparams.html#player_v3_api_qparams
