### PR TITLE
DatabaseBase: improve reporting of writing queries issued during read-only

### DIFF
--- a/includes/db/Database.php
+++ b/includes/db/Database.php
@@ -905,7 +905,8 @@ abstract class DatabaseBase implements DatabaseType {
 				wfProfileOut( $totalProf );
 			}
 			WikiaLogger::instance()->error( 'DB readonly mode', [
-				'exception' => new Exception( $sql ),
+				'exception' => new WikiaException( $fname . ' called in read-only mode' ),
+				'sql'       => $sql,
 				'server'    => $this->mServer
 			] );
 			wfDebug( sprintf( "%s: DB read-only mode prevented the following query: %s\n", __METHOD__, $sql ) );


### PR DESCRIPTION
Or performed in Reston. An example of GET requests trying to perform DB writes in Reston - [VE-1956](https://wikia-inc.atlassian.net/browse/VE-1956)

`WikiaException` will cause Jira Reporter to group the tickets by the `$fname`.

@michalroszka 
