### PR TITLE
eval.php -d 4: emit WikiaLogger messages to stderr

### DIFF
--- a/maintenance/eval.php
+++ b/maintenance/eval.php
@@ -31,6 +31,11 @@
  * @ingroup Maintenance
  */
 
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Wikia\Logger\WikiaLogger;
+use Wikia\Logger\LogstashFormatter;
+
 $optionsWithArgs = array( 'd' );
 
 /** */
@@ -55,6 +60,15 @@ if ( isset( $options['d'] ) ) {
 		$wgMemc->setDebug(true);
 		$wgDebugFunctionEntry = true;
 	}
+
+	// Wikia change - start
+	// emit WikiaLogger messages to stderr
+	if ( $d > 3 ) {
+		$stdErrHandler = new StreamHandler( STDERR, Logger::DEBUG );
+		$stdErrHandler->setFormatter( new LogstashFormatter( 'eval.php' ) );
+		WikiaLogger::instance()->getLogger()->pushHandler( $stdErrHandler );
+	}
+	// Wikia change - end
 }
 
 $useReadline = function_exists( 'readline_add_history' )


### PR DESCRIPTION
An example:

``` php
$ eval.php -d 4

> $title = Title::newMainPage();
memcached: get(dev-macbre-wikia:messages:en)
memcached: MemCache: sock i:0; got dev-macbre-wikia:messages:en
MessageCache::load: Loading en... got from global cache

> $title->touchLinks();
{"@timestamp":"2015-12-03T10:00:43.358666+00:00","@message":"BaseTask::queue","@fields":{"db_name":"wikia","city_id":"177","maintenance_file":"/usr/wikia/source/app/maintenance/eval.php","maintenance_class":"CommandLineInc","request_id":"mw566012c8466443.15075884"},"@context":{"task":"Wikia\\Tasks\\Tasks\\HTMLCacheUpdateTask","backtrace":{"class":"Exception","message":"","code":0,"file":"/usr/wikia/source/app/includes/wikia/tasks/Tasks/BaseTask.class.php:149","trace":["/usr/wikia/source/app/includes/Title.php:4503","/usr/wikia/source/app/maintenance/eval.php(88) : eval()'d code:1","/usr/wikia/source/app/maintenance/eval.php:88"]}}}
```

@michalroszka / @wladekb / @owend 
