### PR TITLE
PLATFORM-1740: allow task broker to be disabled

### DIFF
--- a/includes/wikia/tasks/Tasks/BaseTask.class.php
+++ b/includes/wikia/tasks/Tasks/BaseTask.class.php
@@ -146,6 +146,7 @@ abstract class BaseTask {
 	public function queue() {
 		$this->info( 'BaseTask::queue', [
 			'task' => get_class( $this ),
+			'caller' => wfGetCallerClassMethod( __CLASS__ ),
 			'backtrace' => new \Exception()
 		] );
 


### PR DESCRIPTION
- throw `AMQPRuntimeException` when task broker is disabled in a cureent environment, it will be caught by the `AsyncTaskList` code and logged
- log the method that triggered task push
- remove duplicated code by introducing `getConnection` method

``` json
{
  "@timestamp": "2015-12-03T10:35:04.265428+00:00",
  "@message": "AsyncTaskList::batch",
  "@fields": {
    "db_name": "wikia",
    "city_id": "177",
    "maintenance_file": "/usr/wikia/source/app/maintenance/eval.php",
    "maintenance_class": "CommandLineInc",
    "request_id": "mw56601ad7071094.08292274"
  },
  "@exception": {
    "class": "PhpAmqpLib\\Exception\\AMQPRuntimeException",
    "message": "Task broker is disabled",
    "code": 0,
    "file": "/usr/wikia/source/app/includes/wikia/tasks/AsyncTaskList.class.php:372",
    "trace": [
      "/usr/wikia/source/app/includes/wikia/tasks/AsyncTaskList.class.php:424",
      "/usr/wikia/source/app/includes/wikia/tasks/Tasks/BaseTask.class.php:154",
      "/usr/wikia/source/app/includes/Title.php:4503",
      "/usr/wikia/source/app/maintenance/eval.php(88) : eval() code:1",
      "/usr/wikia/source/app/maintenance/eval.php:88"
    ]
  },
  "@context": {
    "caller": "Title:touchLinks"
  }
}
```

This change allows us to disable task broker in Reston. The config change will follow (set `$wgTaskBroker` to `false` for Reston).

@wladekb / @michalroszka / @pchojnacki 
