### PR TITLE
ADEN-2728 Recovered message enabled only on article page types

### DIFF
--- a/extensions/wikia/AdEngine/js/AdContext.js
+++ b/extensions/wikia/AdEngine/js/AdContext.js
@@ -73,7 +73,8 @@ define('ext.wikia.adEngine.adContext', [
 
 		// Recoverable ads message
 		if (context.opts.sourcePointDetection && !context.opts.sourcePointRecovery && context.opts.showAds) {
-			context.opts.recoveredAdsMessage = geo.isProperGeo(instantGlobals.wgAdDriverAdsRecoveryMessageCountries);
+			context.opts.recoveredAdsMessage = context.targeting.pageType === 'article' &&
+				geo.isProperGeo(instantGlobals.wgAdDriverAdsRecoveryMessageCountries);
 		}
 
 		// Google Consumer Surveys

--- a/extensions/wikia/AdEngine/js/spec/AdContext.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/AdContext.spec.js
@@ -590,6 +590,7 @@ describe('AdContext', function () {
 						showAds: true
 					},
 					targeting: {
+						pageType: 'article',
 						skin: 'oasis'
 					}
 				}
@@ -612,6 +613,7 @@ describe('AdContext', function () {
 						showAds: true
 					},
 					targeting: {
+						pageType: 'article',
 						skin: 'oasis'
 					}
 				}
@@ -634,6 +636,7 @@ describe('AdContext', function () {
 						showAds: true
 					},
 					targeting: {
+						pageType: 'article',
 						skin: 'oasis'
 					}
 				}
@@ -647,6 +650,29 @@ describe('AdContext', function () {
 		expect(getModule().getContext().opts.recoveredAdsMessage).toBeTruthy();
 	});
 
+	it('disabled recoveredAdsMessage on non article page type', function () {
+		mocks.win = {
+			ads: {
+				context: {
+					opts: {
+						sourcePointDetectionUrl: '//foo.bar',
+						showAds: true
+					},
+					targeting: {
+						pageType: 'home',
+						skin: 'oasis'
+					}
+				}
+			}
+		};
+		mocks.instantGlobals = {
+			wgAdDriverSourcePointDetectionCountries: ['CURRENT_COUNTRY'],
+			wgAdDriverAdsRecoveryMessageCountries: ['CURRENT_COUNTRY-EE', 'CURRENT_COUNTRY']
+		};
+
+		expect(getModule().getContext().opts.recoveredAdsMessage).toBeFalsy();
+	});
+
 	it('disables recoveredAdsMessage when country and region in instant var and both are invalid', function () {
 		mocks.win = {
 			ads: {
@@ -655,6 +681,7 @@ describe('AdContext', function () {
 						sourcePointDetectionUrl: '//foo.bar'
 					},
 					targeting: {
+						pageType: 'article',
 						skin: 'oasis'
 					}
 				}
@@ -676,6 +703,7 @@ describe('AdContext', function () {
 						sourcePointDetectionUrl: '//foo.bar'
 					},
 					targeting: {
+						pageType: 'article',
 						skin: 'oasis'
 					}
 				}
@@ -698,6 +726,7 @@ describe('AdContext', function () {
 						showAds: false
 					},
 					targeting: {
+						pageType: 'article',
 						skin: 'oasis'
 					}
 				}


### PR DESCRIPTION
Restrict places where recovered message can be displayed - now only on pages with `article` type.
