### PR TITLE
FSLockManager: log calls with a backtrace

### DIFF
--- a/extensions/wikia/SwiftSync/classes/Hooks.php
+++ b/extensions/wikia/SwiftSync/classes/Hooks.php
@@ -11,46 +11,6 @@ namespace Wikia\SwiftSync;
  * @package SwiftSync
  */
 class Hooks {
-	/* @String repoName - repo name */
-	static private $repoName = 'local';
-
-	/**
-	 * init config for FSFileBackend class
-	 *
-	 * @return \FSFileBackend
-	 */
-	static private function initLocalFS( ) {
-		global $wgUploadDirectory;
-
-		$repoName = self::$repoName;
-
-		$config = array (
-			'name'           => "{$repoName}-backend",
-			'class'          => 'FSFileBackend',
-			'lockManager'    => 'fsLockManager',
-			'containerPaths' => array(
-				"{$repoName}-public"  => "{$wgUploadDirectory}",
-				"{$repoName}-thumb"   => "{$wgUploadDirectory}/thumb",
-				"{$repoName}-deleted" => "{$wgUploadDirectory}",
-				"{$repoName}-temp"    => "{$wgUploadDirectory}/temp"
-			),
-			'fileMode'       => 0644,
-		);
-		$class = $config['class'];
-
-		return new $class( $config );
-	}
-
-	/* replace swift-backend with local-backend */
-	private static function replaceBackend( $path ) {
-		$path = preg_replace(
-			'/\/swift-backend\/(.*)\/images/',
-			sprintf( "/%s-backend/%s-public", self::$repoName, self::$repoName ),
-			$path
-		);
-
-		return $path;
-	}
 
 	/* save image into local repo */
 	public static function doStoreInternal( $params, \Status $status ) {

--- a/includes/filerepo/backend/lockmanager/FSLockManager.php
+++ b/includes/filerepo/backend/lockmanager/FSLockManager.php
@@ -81,6 +81,15 @@ class FSLockManager extends LockManager {
 		} elseif ( isset( $this->locksHeld[$path][self::LOCK_EX] ) ) {
 			$this->locksHeld[$path][$type] = 1;
 		} else {
+			// Wikia change
+			// PLATFORM-1735:
+			Wikia\Logger\WikiaLogger::instance()->error( __METHOD__, [
+				'exception' => new Exception(),
+				'lockDir' => $this->lockDir,
+				'path' => $path,
+				'type' => $type,
+			] );
+
 			wfSuppressWarnings();
 			$handle = fopen( $this->getLockPath( $path ), 'a+' );
 			wfRestoreWarnings();


### PR DESCRIPTION
[PLATFORM-1735](https://wikia-inc.atlassian.net/browse/PLATFORM-1735)

Get more context for `fopen(/images/f/fallout/ru/images/lockdir/1h559iuzy7dq6htol2fcmw5cubfzecx.lock): failed to open stream: No such file or directory in /includes/filerep
o/backend/lockmanager/FSLockManager.php on line 89` warnings

And `SwiftSync` cleanup

@michalroszka / @wladekb 
