### PR TITLE
Mark preferences read-only after a failed read

### DIFF
--- a/lib/Wikia/src/Domain/User/Preferences/UserPreferences.php
+++ b/lib/Wikia/src/Domain/User/Preferences/UserPreferences.php
@@ -4,6 +4,9 @@ namespace Wikia\Domain\User\Preferences;
 
 class UserPreferences {
 
+	/** @var boolean */
+	private $readOnly = false;
+
 	/** @var GlobalPreference[] */
 	private $globalPreferences;
 
@@ -79,5 +82,29 @@ class UserPreferences {
 	 */
 	public function getLocalPreferences() {
 		return $this->localPreferences;
+	}
+
+	/**
+	 * This toggle is to flag the object as being not suitable for saving.
+	 *
+	 * @param boolean state true to set the preferences to read only
+	 */
+	public function setReadOnly( $state ) {
+		$this->readOnly = $state;
+		return $this;
+	}
+
+	/**
+	 * @return boolean the read only state
+	 */
+	public function getReadOnly() {
+		return $this->readOnly;
+	}
+
+	/**
+	 * @return boolean the read only state
+	 */
+	public function isReadOnly() {
+		return $this->getReadOnly();
 	}
 }

--- a/lib/Wikia/src/Domain/User/Preferences/UserPreferences.php
+++ b/lib/Wikia/src/Domain/User/Preferences/UserPreferences.php
@@ -97,14 +97,7 @@ class UserPreferences {
 	/**
 	 * @return boolean the read only state
 	 */
-	public function getReadOnly() {
-		return $this->readOnly;
-	}
-
-	/**
-	 * @return boolean the read only state
-	 */
 	public function isReadOnly() {
-		return $this->getReadOnly();
+		return $this->readOnly;
 	}
 }

--- a/lib/Wikia/src/Service/User/Preferences/PreferenceServiceImpl.php
+++ b/lib/Wikia/src/Service/User/Preferences/PreferenceServiceImpl.php
@@ -8,6 +8,7 @@ use Wikia\Domain\User\Preferences\UserPreferences;
 use Wikia\Logger\Loggable;
 use Wikia\Persistence\User\Preferences\PreferencePersistence;
 use Wikia\Util\WikiaProfiler;
+use Wikia\Service\PersistenceException;
 
 class PreferenceServiceImpl implements PreferenceService {
 
@@ -228,6 +229,11 @@ class PreferenceServiceImpl implements PreferenceService {
 			if ( !$preferences ) {
 				try {
 					$preferences = $this->persistence->get( $userId );
+				} catch ( PersistenceException $e ) {
+					$this->error( $e->getMessage() . ": setting preferences in read-only mode",
+						['user' => $userId] );
+					$preferences = ( new UserPreferences() )
+						->setReadOnly( true );
 				} catch ( \Exception $e ) {
 					$this->error( $e->getMessage(), ['user' => $userId] );
 					throw $e;

--- a/lib/Wikia/src/Service/User/Preferences/PreferenceServiceImpl.php
+++ b/lib/Wikia/src/Service/User/Preferences/PreferenceServiceImpl.php
@@ -165,6 +165,12 @@ class PreferenceServiceImpl implements PreferenceService {
 		}
 
 		$prefs = $this->load( $userId );
+
+		// if the UserPreferences have been marked as read-only they should NOT be saved
+		if ( $prefs->isReadOnly() ) {
+			return false;
+		}
+
 		$prefsToSave = new UserPreferences();
 
 		foreach ( $prefs->getGlobalPreferences() as $pref ) {

--- a/lib/Wikia/src/Service/User/Preferences/PreferenceServiceImpl.php
+++ b/lib/Wikia/src/Service/User/Preferences/PreferenceServiceImpl.php
@@ -129,6 +129,12 @@ class PreferenceServiceImpl implements PreferenceService {
 	}
 
 	public function deleteAllPreferences( $userId ) {
+		// if the preferences are marked as read-only DO NOT allow
+		// purging. this is to ensure we don't make a mistake after a failed read
+		if ( $this->load( $userId )->isReadOnly() ) {
+			return false;
+		}
+
 		try {
 			$deleted = $this->persistence->deleteAll( $userId );
 			if ( $deleted ) {

--- a/lib/Wikia/tests/Domain/User/Preferences/UserPreferencesTest.php
+++ b/lib/Wikia/tests/Domain/User/Preferences/UserPreferencesTest.php
@@ -54,4 +54,20 @@ class UserPreferencesTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertTrue( $prefs->isEmpty() );
 	}
+
+	public function testIsReadOnly() {
+		$prefs = ( new UserPreferences() )
+			->setReadOnly( true );
+		$this->assertTrue( $prefs->isReadOnly() );
+		$this->assertTrue( $prefs->getReadOnly() );
+
+		$this->assertTrue( $prefs->isEmpty() );
+
+		// in read-only mode preference setting should go on as usual
+		// this state is intended to prevent preferences from being saved
+		$prefs->setGlobalPreference( 'foo', '1' );
+		$this->assertEquals( '1', $prefs->getGlobalPreference( 'foo' ) );
+
+		$this->assertFalse( $prefs->isEmpty() );
+	}
 }

--- a/lib/Wikia/tests/Domain/User/Preferences/UserPreferencesTest.php
+++ b/lib/Wikia/tests/Domain/User/Preferences/UserPreferencesTest.php
@@ -59,7 +59,6 @@ class UserPreferencesTest extends \PHPUnit_Framework_TestCase {
 		$prefs = ( new UserPreferences() )
 			->setReadOnly( true );
 		$this->assertTrue( $prefs->isReadOnly() );
-		$this->assertTrue( $prefs->getReadOnly() );
 
 		$this->assertTrue( $prefs->isEmpty() );
 

--- a/lib/Wikia/tests/Service/User/PreferenceServiceImplTest.php
+++ b/lib/Wikia/tests/Service/User/PreferenceServiceImplTest.php
@@ -8,6 +8,7 @@ use PHPUnit_Framework_MockObject_MockObject;
 use PHPUnit_Framework_TestCase;
 use Wikia\Domain\User\Preferences\UserPreferences;
 use Wikia\Persistence\User\Preferences\PreferencePersistence;
+use Wikia\Service\PersistenceException;
 
 class PreferenceServiceImplTest extends PHPUnit_Framework_TestCase {
 	const TEST_WIKI_ID = 123;
@@ -139,6 +140,18 @@ class PreferenceServiceImplTest extends PHPUnit_Framework_TestCase {
 
 		$list = $preferences->findWikisWithLocalPreferenceValue( 'test-preference', '1' );
 		$this->assertEquals( $wikiList, $list );
+	}
+
+	public function testGetWithPersistenceExceptionReturnsReadOnly() {
+		$preferences = new PreferenceServiceImpl( $this->cache, $this->persistence, new UserPreferences(), [], [] );
+
+		$this->persistence->expects( $this->once() )
+			->method( 'get' )
+			->with( self::TEST_WIKI_ID )
+			->will( $this->throwException( new PersistenceException ) );
+
+		$prefs = $preferences->getPreferences( self::TEST_WIKI_ID );
+		$this->assertTrue( $prefs->isReadOnly() );
 	}
 
 	protected function setupServiceExpects() {

--- a/lib/Wikia/tests/Service/User/PreferenceServiceImplTest.php
+++ b/lib/Wikia/tests/Service/User/PreferenceServiceImplTest.php
@@ -172,6 +172,21 @@ class PreferenceServiceImplTest extends PHPUnit_Framework_TestCase {
 		$this->assertFalse( $preferences->save( $this->userId ) );
 	}
 
+	public function testDeleteAllShortCircuit() {
+		$preferences = new PreferenceServiceImpl( $this->cache, $this->persistence, new UserPreferences(), [], [] );
+
+		$this->persistence->expects( $this->exactly( 1 ) )
+			->method( 'get' )
+			->with( $this->userId )
+			->will( $this->throwException( new PersistenceException ) );
+
+		$this->persistence->expects( $this->never() )
+			->method( 'deleteAll' )
+			->with( $this->userId );
+
+		$this->assertFalse( $preferences->deleteAllPreferences( $this->userId ) );
+	}
+
 	protected function setupServiceExpects() {
 		$this->persistence->expects( $this->once() )
 			->method( "get" )


### PR DESCRIPTION
This PR marks preferences as read-only after a failed read. The `UserPreference` persistence operations are then aborted when presented with read-only preferences to prevent the corruption / loss of preferences due to populating the user preferences solely with the defaults.

https://wikia-inc.atlassian.net/browse/SERVICES-943

@Wikia/services-team  
