### PR TITLE
VE-2013: Fix problem with PI JS not being executed in preview by using wikipage.content hook

### DIFF
--- a/extensions/wikia/PortableInfobox/js/PortableInfobox.js
+++ b/extensions/wikia/PortableInfobox/js/PortableInfobox.js
@@ -2,11 +2,8 @@
 	'use strict';
 
 	var ImageCollection = {
-		init: function() {
-			this.setupTabs();
-		},
-		setupTabs: function() {
-			var $imageCollections = $('.pi-image-collection');
+		init: function($content) {
+			var $imageCollections = $content.find('.pi-image-collection');
 
 			$imageCollections.each( function( index, collection ) {
 				var $collection = $imageCollections.eq(index),
@@ -28,8 +25,8 @@
 	};
 
 	var CollapsibleGroup = {
-		init: function() {
-			var $collapsibleGroups = $('.pi-collapse');
+		init: function($content) {
+			var $collapsibleGroups = $content.find('.pi-collapse');
 
 			$collapsibleGroups.each( function( index, group ) {
 				var $group = $collapsibleGroups.eq(index),
@@ -40,8 +37,10 @@
 				});
 			});
 		}
-	}
+	};
 
-	ImageCollection.init();
-	CollapsibleGroup.init();
+	mw.hook('wikipage.content').add(function($content) {
+		ImageCollection.init($content);
+		CollapsibleGroup.init($content);
+	});
 })(window, jQuery);


### PR DESCRIPTION
JavaScript for PortableInfoboxes MediaCollections and CollapisbleGroups initialization was executed once while loading the file - so it was working propery for most common case which is displaying article (the view page). However sometimes content is loaded dynamically, after JavaScript already loaded and executed, and for such cases initialization was not happening. In particular such case is loading article preview from within the Classic Editor. Problem is solved by using solid and common MW approach of MediaWiki JavaScript hooks - specifically one named 'wikipage.content' which is meant to be fired whenever wikipage (in any context) is being displayed.
