### PR TITLE
Don't load Special:Preferences if prefs are RO

### DIFF
--- a/includes/Preferences.php
+++ b/includes/Preferences.php
@@ -54,6 +54,10 @@ class Preferences {
 	 * @return array|null
 	 */
 	static function getPreferences( $user, IContextSource $context ) {
+		if ( $user->arePreferencesReadOnly() ) {
+			throw new MWException("Error, preferences are read-only.");
+		}
+
 		if ( self::$defaultPreferences ) {
 			return self::$defaultPreferences;
 		}

--- a/includes/User.php
+++ b/includes/User.php
@@ -292,6 +292,13 @@ class User {
 	}
 
 	/**
+	 * @return bool
+	 */
+	public function arePreferencesReadOnly() {
+		return $this->userPreferences()->getPreferences( $this->getId() )->isReadOnly();
+	}
+
+	/**
 	 * @return PreferenceCorrectionService
 	 */
 	private function preferenceCorrection() {


### PR DESCRIPTION
Don't load `Special:Preferences` if the preferences for the current user are read-only. This a precautionary measure to prevent defaults from being loaded and overwriting a user's previously saved preferences.

https://wikia-inc.atlassian.net/browse/SERVICES-1056

@Wikia/services-team 
