### PR TITLE
VE-2069: Adjust getImages method to work well with recent changes to ImageNode

### DIFF
--- a/extensions/wikia/PortableInfobox/services/PortableInfoboxDataService.class.php
+++ b/extensions/wikia/PortableInfobox/services/PortableInfoboxDataService.class.php
@@ -89,7 +89,7 @@ class PortableInfoboxDataService {
 	private function getImageFromOneInfoboxData( $infoboxData ) {
 		$images = [];
 		foreach ( $infoboxData as $infoboxDataField ) {
-			if ( $infoboxDataField[ 'type' ] == self::IMAGE_FIELD_TYPE && isset( $infoboxDataField[ 'data' ] ) ) {
+			if ( $infoboxDataField[ 'type' ] === self::IMAGE_FIELD_TYPE && isset( $infoboxDataField[ 'data' ] ) ) {
 				$images = array_merge( $images, $this->getImagesFromOneNodeImageData( $infoboxDataField[ 'data' ] ) );
 			}
 		}

--- a/extensions/wikia/PortableInfobox/services/PortableInfoboxDataService.class.php
+++ b/extensions/wikia/PortableInfobox/services/PortableInfoboxDataService.class.php
@@ -77,12 +77,14 @@ class PortableInfoboxDataService {
 		foreach ( $this->getData() as $infobox ) {
 			// ensure data array exists
 			$data = is_array( $infobox[ 'data' ] ) ? $infobox[ 'data' ] : [ ];
+
 			foreach ( $data as $field ) {
-				if ( $field[ 'type' ] == self::IMAGE_FIELD_TYPE &&
-					 isset( $field[ 'data' ] ) &&
-					 !empty( $field[ 'data' ][ 'key' ] )
-				) {
-					$images[ $field[ 'data' ][ 'key' ] ] = true;
+				if ( $field[ 'type' ] == self::IMAGE_FIELD_TYPE && isset( $field[ 'data' ] ) ) {
+					for ( $i = 0; $i < count( $field[ 'data' ] ); $i++ ) {
+						if ( !empty( $field[ 'data' ][ $i ] [ 'key' ] ) ) {
+							$images[ $field[ 'data' ][ $i ][ 'key' ] ] = true;
+						}
+					}
 				}
 			}
 		}

--- a/extensions/wikia/PortableInfobox/services/PortableInfoboxDataService.class.php
+++ b/extensions/wikia/PortableInfobox/services/PortableInfoboxDataService.class.php
@@ -51,7 +51,7 @@ class PortableInfoboxDataService {
 	/**
 	 * Returns infobox data, chain terminator method
 	 *
-	 * @return array in format [ 'data' => [], 'sources' => [] ] or [] will be returned
+	 * @return array in format [ [ 'data' => [], 'sources' => [] ] or [] will be returned
 	 */
 	public function getData() {
 		if ( $this->title && $this->title->exists() && $this->title->inNamespace( NS_TEMPLATE ) ) {
@@ -67,29 +67,48 @@ class PortableInfoboxDataService {
 	}
 
 	/**
-	 * Get image list from infobox data, chain terminator method
+	 * Get image list from multiple infoboxes data
 	 *
 	 * @return array
 	 */
 	public function getImages() {
-		$images = [ ];
-
+		$images = [];
 		foreach ( $this->getData() as $infobox ) {
-			// ensure data array exists
-			$data = is_array( $infobox[ 'data' ] ) ? $infobox[ 'data' ] : [ ];
-
-			foreach ( $data as $field ) {
-				if ( $field[ 'type' ] == self::IMAGE_FIELD_TYPE && isset( $field[ 'data' ] ) ) {
-					for ( $i = 0; $i < count( $field[ 'data' ] ); $i++ ) {
-						if ( !empty( $field[ 'data' ][ $i ] [ 'key' ] ) ) {
-							$images[ $field[ 'data' ][ $i ][ 'key' ] ] = true;
-						}
-					}
-				}
+			if ( is_array( $infobox[ 'data' ] ) ) {
+				$images = array_merge( $images, $this->getImageFromOneInfoboxData( $infobox[ 'data' ] ) );
 			}
 		}
+		return array_unique( $images );
+	}
 
-		return array_keys( $images );
+	/**
+	 * Get image list from single infobox data
+	 *
+	 * @return array
+	 */
+	private function getImageFromOneInfoboxData( $infoboxData ) {
+		$images = [];
+		foreach ( $infoboxData as $infoboxDataField ) {
+			if ( $infoboxDataField[ 'type' ] == self::IMAGE_FIELD_TYPE && isset( $infoboxDataField[ 'data' ] ) ) {
+				$images = array_merge( $images, $this->getImagesFromOneNodeImageData( $infoboxDataField[ 'data' ] ) );
+			}
+		}
+		return $images;
+	}
+
+	/**
+	 * Get image list from single NodeImage data
+	 *
+	 * @return array
+	 */
+	private function getImagesFromOneNodeImageData( $nodeImageData ) {
+		$images = [];
+		for ( $i = 0; $i < count( $nodeImageData ); $i++ ) {
+			if ( !empty( $nodeImageData[ $i ] [ 'key' ] ) ) {
+				$images[] = $nodeImageData[ $i ][ 'key' ];
+			}
+		}
+		return $images;
 	}
 
 	/**

--- a/extensions/wikia/PortableInfobox/tests/PortableInfoboxDataServiceTest.php
+++ b/extensions/wikia/PortableInfobox/tests/PortableInfoboxDataServiceTest.php
@@ -134,23 +134,23 @@ class PortableInfoboxDataServiceTest extends WikiaBaseTest {
 									 "label" => "BBBB"
 								 ]
 							   ], [ "type" => "image",
-									"data" => [
+									"data" => [ [
 										"key" => "Test.jpg",
 										"alt" => null,
 										"caption" => null,
-									]
+									] ]
 							   ], [ "type" => "image",
-									"data" => [
+									"data" => [ [
 										"key" => "Test2.jpg",
 										"alt" => null,
 										"caption" => null
-									] ] ] ],
+									] ] ] ] ],
 				 [ 'data' => [ [ "type" => "image",
-								 "data" => [
+								 "data" => [ [
 									 "key" => "Test2.jpg",
 									 "alt" => null,
 									 "caption" => null
-								 ] ] ] ] ];
+								 ] ] ] ] ] ];
 	}
 }
 


### PR DESCRIPTION
I'm not very happy with how nested this method is but it seems that it is the convention taken within PortableInfobox project.
I would much better prefer if there was more object oriented way to delegate for instance task of retrieving images list directly to NodeImage but that would be much greater refactoring.
