### PR TITLE
VE-1973: Disable pointer events from WikiaSiteWrapper when VE visible

### DIFF
--- a/skins/oasis/css/core/breakpoints-layout.scss
+++ b/skins/oasis/css/core/breakpoints-layout.scss
@@ -315,7 +315,9 @@
 $ve-overlay-color: rgba(0, 0, 0, .5);
 $vw-overlay-shadow-size: 1000vw; // IE does not support vmax
 body.ve {
-	pointer-events: none;
+	.WikiaSiteWrapper {
+		pointer-events: none;
+	}
 
 	.ve-ui-overlay {
 		pointer-events: all;


### PR DESCRIPTION
Disabling pointer events on the body was causing the recaptcha div to not be clickable. Scoping `pointer-events: none;` to `.WikiaSiteWrapper` fixes this
