### PR TITLE
(CE-2948) Expose wgWikiDirectedAtChildrenByFounder as a JS var

### DIFF
--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -66,6 +66,7 @@ $wgHooks['LocalFilePurgeThumbnailsUrls'][] = 'Wikia::onLocalFilePurgeThumbnailsU
 
 $wgHooks['BeforePageDisplay'][] = 'Wikia::onBeforePageDisplay';
 $wgHooks['GetPreferences'][] = 'Wikia::onGetPreferences';
+$wgHooks['WikiaSkinTopScripts'][] = 'Wikia::onWikiaSkinTopScripts';
 
 # handle internal requests - PLATFORM-1473
 $wgHooks['WebRequestInitialized'][] = 'Wikia::onWebRequestInitialized';
@@ -2483,5 +2484,15 @@ class Wikia {
 		global $wgUseSiteJs, $wgEnableContentReviewExt;
 
 		return !empty( $wgUseSiteJs ) && !empty( $wgEnableContentReviewExt );
+	}
+
+	public static function onWikiaSkinTopScripts( &$vars, &$scripts, Skin $skin ) {
+		global $wgWikiDirectedAtChildrenByFounder;
+
+		if ( !empty( $wgWikiDirectedAtChildrenByFounder ) ) {
+			$vars['wgWikiDirectedAtChildrenByFounder'] = $wgWikiDirectedAtChildrenByFounder;
+		}
+
+		return true;
 	}
 }


### PR DESCRIPTION
Quick solution to make this variable available to Selenium tests without
WikiFactory access.

/cc @Wikia/community-engineering 
