### PR TITLE
ImageServingCroppingTest: better mocking

### DIFF
--- a/extensions/wikia/ImageServing/tests/ImageServingCroppingTest.php
+++ b/extensions/wikia/ImageServing/tests/ImageServingCroppingTest.php
@@ -3,7 +3,7 @@
  * @author macbre
  * @group Integration
  * @group MediaFeatures
- * @group Broken
+ * @group ImageServing
  *
  * TODO: Fix the test: https://wikia-inc.atlassian.net/browse/MAIN-6018
  */
@@ -18,6 +18,7 @@ class ImageServingCroppingTest extends WikiaBaseTest {
 		parent::setUp();
 
 		$this->mockGlobalVariable('wgEnableVignette', true);
+		$this->mockGlobalVariable('wgUploadPath', 'http://images.wikia.com/firefly/images');
 	}
 
 	public function testCropping() {


### PR DESCRIPTION
This test was failing with a following error:

```
1) ImageServingCroppingTest::testCropping
Failed asserting that 'http://vignette-poz.wikia-dev.com//images/8/89/Wiki-wordmark.png/revision/latest/window-crop/width/50/x-offset/94/y-offset/0/window-width/66/window-height/65?cb=20110304235605' contains "/firefly/images/8/89/Wiki-wordmark.png/revision/latest/".

/usr/wikia/source/app/extensions/wikia/ImageServing/tests/ImageServingCroppingTest.php:30
```

Mock `wgUploadPath` to make this test reliable.

@wladekb / @pchojnacki / @gabrys 
