### PR TITLE
ForeignAPIRepo: fetch thumbs directly from Wikimedia

### DIFF
--- a/includes/Setup.php
+++ b/includes/Setup.php
@@ -201,7 +201,7 @@ if ( $wgUseInstantCommons ) {
 		'hashLevels'             => 2,
 		'fetchDescription'       => true,
 		'descriptionCacheExpiry' => 43200,
-		'apiThumbCacheExpiry'    => 86400,
+		'apiThumbCacheExpiry'    => 0, # PLATFORM-1735 (do not try to fetch thumbs and store them on our DFS, serve them from Wikimedia Commons)
 	);
 }
 /*


### PR DESCRIPTION
[PLATFORM-1735](https://wikia-inc.atlassian.net/browse/PLATFORM-1735) / [`$wgUseInstantCommons`](https://www.mediawiki.org/wiki/Manual:$wgUseInstantCommons)

`ForeignAPIRepo` was trying to fetch and store thumbs on our DFS and use file-based locks on `/images`. This obviously did not work in our environment and caused a fallback to fetching thumbs directly from Wikimedia (i.e. hotlink them).

```
ForeignAPIRepo: HTTP GET: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c1/Kamas.jpg/250px-Kamas.jpg
ForeignAPIRepo::getThumbUrlFromCache could not write to thumb path
BitmapHandler::doTransform: Transforming later per flags.
wfReplaceImageServer: requested url https://upload.wikimedia.org/wikipedia/commons/thumb/c/c1/Kamas.jpg/250px-Kamas.jpg
```
## Solution

Change the `$wgForeignFileRepos` config that handles `$wgUseInstantCommons` setting to skip the thumbs caching step.

```
ForeignAPIRepo::getThumbUrl got remote thumb https://upload.wikimedia.org/wikipedia/commons/thumb/c/c1/Kamas.jpg/250px-Kamas.jpg
BitmapHandler::doTransform: Transforming later per flags.
wfReplaceImageServer: requested url https://upload.wikimedia.org/wikipedia/commons/thumb/c/c1/Kamas.jpg/250px-Kamas.jpg
```

@wladekb / @pchojnacki / @michalroszka 
