### PR TITLE
Phalanx: use phalanx.service.sjc.consul instead of local Varnish as a proxy

### DIFF
--- a/extensions/wikia/PhalanxII/tests/PhalanxServiceTest.php
+++ b/extensions/wikia/PhalanxII/tests/PhalanxServiceTest.php
@@ -22,8 +22,7 @@ class PhalanxServiceTest extends WikiaBaseTest {
 		$this->service = new PhalanxService();
 		if (!$this->service->status()) {
 			//Skip test if phalanx service is not available
-			$this->markTestSkipped();
-			//throw new Exception("Can't connect to phalanx service on " . $this->app->wg->PhalanxServiceUrl);
+			throw new Exception("Can't connect to phalanx service on " . $this->app->wg->PhalanxServiceUrl);
 		}
 	}
 

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1178,12 +1178,14 @@ $wgEnableQuickToolsExt = true;
 
 /**
  * @name $wgPhalanxService
+ * @see extensions/wikia/PhalanxII
  * Use phalanx external service
  */
-$wgPhalanxService = false;
-$wgPhalanxServiceUrl = "http://phalanx";
-$wgPhalanxServiceOptions = [];
-
+$wgPhalanxService = true;
+$wgPhalanxServiceUrl = "http://phalanx.service.consul:4666"; # PLATFORM-1744
+$wgPhalanxServiceOptions = [
+	'noProxy' => true, # PLATFORM-1744: do not use the default HTTP proxy (defined in $wgHTTPProxy) for Phalanx requests
+];
 
 /**
  * @name $wgWikiaHubsFileRepoDBName


### PR DESCRIPTION
[PLATFORM-1744](https://wikia-inc.atlassian.net/browse/PLATFORM-1744)

Use consul to configure Phalanx hosts instead of relying on a local Varnish instance sending requests to the service.

And keep the config in a single place instead of three different places.

@wladekb / @pchojnacki / @michalroszka  / @artursitarski 
