### PR TITLE
block access to /lib directory

### DIFF
--- a/lib/.htaccess
+++ b/lib/.htaccess
@@ -1,0 +1,1 @@
+Deny from all


### PR DESCRIPTION
Prevent executing php from /lib directory.

eg: http://poznan.macbre.wikia-dev.com/lib/composer/zendframework/zend-code/src/Reflection/ClassReflection.php - gives a fatal

cc @macbre 
