### PR TITLE
Do not create searchindex table only to drop it a minute later

### DIFF
--- a/maintenance/tables.sql
+++ b/maintenance/tables.sql
@@ -1103,30 +1103,6 @@ CREATE INDEX /*i*/namespace_title ON /*_*/watchlist (wl_namespace, wl_title);
 
 
 --
--- When using the default MySQL search backend, page titles
--- and text are munged to strip markup, do Unicode case folding,
--- and prepare the result for MySQL's fulltext index.
---
--- This table must be MyISAM; InnoDB does not support the needed
--- fulltext index.
---
-CREATE TABLE /*_*/searchindex (
-  -- Key to page_id
-  si_page int unsigned NOT NULL,
-
-  -- Munged version of title
-  si_title varchar(255) NOT NULL default '',
-
-  -- Munged version of body text
-  si_text mediumtext NOT NULL
-) ENGINE=MyISAM;
-
-CREATE UNIQUE INDEX /*i*/si_page ON /*_*/searchindex (si_page);
-CREATE FULLTEXT INDEX /*i*/si_title ON /*_*/searchindex (si_title);
-CREATE FULLTEXT INDEX /*i*/si_text ON /*_*/searchindex (si_text);
-
-
---
 -- Recognized interwiki link prefixes
 --
 CREATE TABLE /*_*/interwiki (


### PR DESCRIPTION
This should prevent CNW from creating the "searchindex" table only to be able to drop it a few minutes later.

https://wikia-inc.atlassian.net/browse/PLATFORM-1741

/cc @macbre @drozdo 
