### PR TITLE
getSolariumClientConfig: simplify config setup

### DIFF
--- a/extensions/wikia/Search/classes/QueryService/Factory.php
+++ b/extensions/wikia/Search/classes/QueryService/Factory.php
@@ -41,16 +41,13 @@ class Factory
 		$service = (new \Wikia\Search\ProfiledClassFactory)->get( 'Wikia\Search\MediaWikiService' );
 
 		$host = $service->getGlobalWithDefault( 'SolrHost', 'localhost' );
-		$port = $service->getGlobalWithDefault( 'SolrPort', 8180 );
-
-		if ( $forceMaster ) {
-			$host = "search-master.service.sjc.consul";
-		}
+		$masterHost = $service->getGlobalWithDefault( 'SolrMaster', 'localhost' );
+		$port = $service->getGlobalWithDefault( 'SolrPort', 8983 );
 
 		$solariumConfig = [
 			'adapter' => 'Solarium_Client_Adapter_Curl',
 			'adapteroptions' => [
-				'host'    => $host,
+				'host'    => $forceMaster ? $masterHost : $host,
 				'port'    => $port,
 				'path'    => '/solr/',
 			]

--- a/extensions/wikia/Search/classes/QueryService/Factory.php
+++ b/extensions/wikia/Search/classes/QueryService/Factory.php
@@ -37,46 +37,24 @@ class Factory
 	}
 
 	public function getSolariumClientConfig($forceMaster = false) {
+		/* @var \Wikia\Search\MediaWikiService $service */
 		$service = (new \Wikia\Search\ProfiledClassFactory)->get( 'Wikia\Search\MediaWikiService' );
+
 		$host = $service->getGlobalWithDefault( 'SolrHost', 'localhost' );
-		$host = (! empty( $_GET['newsolrhost'] ) ) ? $service->getGlobal( 'AlternateSolrHost' ) : $host;
+		$port = $service->getGlobalWithDefault( 'SolrPort', 8180 );
 
-		$solariumConfig = [];
 		if ( $forceMaster ) {
-			$host = "search-master";
+			$host = "search-master.service.sjc.consul";
 		}
 
-		global $wgUseDevSearch;
-		if( !empty($wgUseDevSearch) && ($wgUseDevSearch == true)) {
-			$solariumConfig = array(
-				'adapter' => 'Solarium_Client_Adapter_Curl',
-				'adapteroptions' => array(
-					'host'    => "dev-search",
-					'port'    => null,
-					'path'    => '/solr/',
-				)
-			);
-
-			$SolrProxy = $service->getGlobal( 'SolrProxy' );
-			if ( !empty( $SolrProxy ) ) {
-				$solariumConfig[ 'adapteroptions' ][ 'proxy' ] = $SolrProxy;
-				$solariumConfig[ 'adapteroptions' ][ 'port' ] = null;
-			}
-
-		} else {
-			$solariumConfig = array(
-				'adapter' => 'Solarium_Client_Adapter_Curl',
-				'adapteroptions' => array(
-					'host'    => $host,
-					'port'    => empty( $_GET['newsolrhost'] ) ? $service->getGlobalWithDefault( 'SolrPort', 8180 ) : $service->getGlobal( 'SolrDefaultPort' ),
-					'path'    => '/solr/',
-				)
-			);
-			if ( $service->isOnDbCluster() && $service->getGlobal( 'WikiaSearchUseProxy' ) && $service->getGlobalWithDefault( 'SolrProxy' ) !== null && empty( $_GET['newsolrhost'] ) ) {
-				$solariumConfig['adapteroptions']['proxy'] = $service->getGlobal( 'SolrProxy' );
-				$solariumConfig['adapteroptions']['port'] = null;
-			}
-		}
+		$solariumConfig = [
+			'adapter' => 'Solarium_Client_Adapter_Curl',
+			'adapteroptions' => [
+				'host'    => $host,
+				'port'    => $port,
+				'path'    => '/solr/',
+			]
+		];
 
 		return $solariumConfig;
 	}


### PR DESCRIPTION
[PLATFORM-1759](https://wikia-inc.atlassian.net/browse/PLATFORM-1759)

Simplfy Solr config by using Consul address instead of hardcoded IPs and requests proxied via a local instance of Varnish. And remove support of `newsolrhost`.

See https://github.com/Wikia/config/pull/1515 for config changes

@SebastianMarzjan / @artursitarski 
