### PR TITLE
GlobalFileTest: improve mocking

### DIFF
--- a/includes/wikia/tests/GlobalFileTest.php
+++ b/includes/wikia/tests/GlobalFileTest.php
@@ -4,6 +4,7 @@
  * Set of unit tests for GlobalFile class
  *
  * @author macbre
+ * @group GlobalFile
  */
 class GlobalFileTest extends WikiaBaseTest {
 
@@ -45,6 +46,9 @@ class GlobalFileTest extends WikiaBaseTest {
 					return $this->getCurrentInvocation()->callOriginal();
 				}
 			}));
+
+		$this->mockGlobalVariable('wgCityId', $cityId);
+		$this->mockGlobalVariable('wgUploadPath', "http://images.wikia.com/{$path}/images");
 
 		$file = GlobalFile::newFromText('Gzik.jpg', $cityId);
 		$title = $file->getTitle();


### PR DESCRIPTION
[PLATFORM-1672](https://wikia-inc.atlassian.net/browse/PLATFORM-1672)

Do not rely on WikiFactory variables in unit tests - use the mock, Luke :)

```
1) GlobalFileTest::testNewFromText with data set #0 (stdClass, 5915, 'poznan/pl', true, 600, 450, '200px-76%2C527%2C0%2C450-Gzik.jpg', 'image/jpeg', 'http://images3.wikia.nocookie.net/__cb20111213221639/poznan/pl/images/0/06/Gzik.jpg')
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'http://images3.wikia.nocookie.net/__cb20111213221639/poznan/pl/images/0/06/Gzik.jpg'
+'/0/06/Gzik.jpg'

/usr/wikia/source/app/includes/wikia/tests/GlobalFileTest.php:59

2) GlobalFileTest::testNewFromText with data set #2 (false, 5915, 'poznan/pl', false, NULL, NULL, NULL, NULL, 'http://images3.wikia.nocookie.net/__cb123456789/poznan/pl/images/0/06/Gzik.jpg')
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'http://images3.wikia.nocookie.net/__cb123456789/poznan/pl/images/0/06/Gzik.jpg'
+'/0/06/Gzik.jpg'

/usr/wikia/source/app/includes/wikia/tests/GlobalFileTest.php:59
```

@michalroszka / @pchojnacki / @wladekb 
