### PR TITLE
Dat 3576, allow for overwrite default portable infobox image width via wifi factory variable

### DIFF
--- a/extensions/wikia/PortableInfobox/services/Helpers/PortableInfoboxRenderServiceHelper.php
+++ b/extensions/wikia/PortableInfobox/services/Helpers/PortableInfoboxRenderServiceHelper.php
@@ -251,7 +251,7 @@ class PortableInfoboxRenderServiceHelper {
 	 * @return array width and height which will be displayed i.e. in the width
 	 * and height properties of the img tag
 	 */
-	private function getImageSizesToDisplay( $thumbnail ) {
+	public function getImageSizesToDisplay( $thumbnail ) {
 		global $wgPortableInfoboxCustomImageWidth;
 
 		if ( !$this->isWikiaMobile() && !empty( $wgPortableInfoboxCustomImageWidth ) ) {

--- a/extensions/wikia/PortableInfobox/services/Helpers/PortableInfoboxRenderServiceHelper.php
+++ b/extensions/wikia/PortableInfobox/services/Helpers/PortableInfoboxRenderServiceHelper.php
@@ -242,6 +242,15 @@ class PortableInfoboxRenderServiceHelper {
 		return [ 'height' => $height, 'width' => $width ];
 	}
 
+	/**
+	 * @desc if it's not a request from mobile skin and wgPortableInfoboxCustomImageWidth
+	 * is set, the $thumbnail->getWidth() can return some big value - we need
+	 * to adjust it to DESKTOP_THUMBNAIL_WIDTH to look good in the infobox.
+	 * Also, the $height have to be adjusted here to make image look good in infobox.
+	 * @param $thumbnail
+	 * @return array width and height which will be displayed i.e. in the width
+	 * and height properties of the img tag
+	 */
 	private function getImageSizesToDisplay( $thumbnail ) {
 		global $wgPortableInfoboxCustomImageWidth;
 

--- a/extensions/wikia/PortableInfobox/services/Helpers/PortableInfoboxRenderServiceHelper.php
+++ b/extensions/wikia/PortableInfobox/services/Helpers/PortableInfoboxRenderServiceHelper.php
@@ -116,7 +116,7 @@ class PortableInfoboxRenderServiceHelper {
 		$data[ 'ref' ] = $ref;
 		$data[ 'height' ] = $thumbnail->getHeight();
 		$data[ 'width' ] = $thumbnail->getWidth();
-		$data[ 'thumbnail' ] = $thumbnail->getUrl();
+		$data[ 'thumbnail' ] = $this->getPhysicalSizeThumbUrl( $thumbnail );
 		$data[ 'key' ] = urlencode( $data[ 'key' ] );
 		$data[ 'media-type' ] = $data[ 'isVideo' ] ? 'video' : 'image';
 
@@ -211,6 +211,27 @@ class PortableInfoboxRenderServiceHelper {
 		}
 
 		return false;
+	}
+
+	/**
+	 * @desc return physicalsize thumbnail URL
+	 * @todo Special case for starwars.wikia.com,
+	 * @todo rethink approach to images as a part of https://wikia-inc.atlassian.net/browse/DAT-3075
+	 * @param $thumbnail \MediaTransformOutput
+	 * @return string thumbnail URL
+	 */
+	private function getPhysicalSizeThumbUrl( $thumbnail ) {
+		global $wgPortableInfoboxCustomImageWidth;
+
+		if ( !empty( $wgPortableInfoboxCustomImageWidth ) ) {
+			$file = $thumbnail->file;
+			$height = min( self::MAX_DESKTOP_THUMBNAIL_HEIGHT, $file->getHeight() );
+
+			return $file->createThumb( $wgPortableInfoboxCustomImageWidth, $height );
+
+		} else {
+			return $thumbnail->getUrl();
+		}
 	}
 
 	/**

--- a/extensions/wikia/PortableInfobox/services/Helpers/PortableInfoboxRenderServiceHelper.php
+++ b/extensions/wikia/PortableInfobox/services/Helpers/PortableInfoboxRenderServiceHelper.php
@@ -247,7 +247,7 @@ class PortableInfoboxRenderServiceHelper {
 	 * is set, the $thumbnail->getWidth() can return some big value - we need
 	 * to adjust it to DESKTOP_THUMBNAIL_WIDTH to look good in the infobox.
 	 * Also, the $height have to be adjusted here to make image look good in infobox.
-	 * @param $thumbnail
+	 * @param $thumbnail \MediaTransformOutput
 	 * @return array width and height which will be displayed i.e. in the width
 	 * and height properties of the img tag
 	 */
@@ -255,13 +255,30 @@ class PortableInfoboxRenderServiceHelper {
 		global $wgPortableInfoboxCustomImageWidth;
 
 		if ( !$this->isWikiaMobile() && !empty( $wgPortableInfoboxCustomImageWidth ) ) {
-			$width = min( self::DESKTOP_THUMBNAIL_WIDTH, $thumbnail->getWidth() );
-			$height = min( self::MAX_DESKTOP_THUMBNAIL_HEIGHT, $width * $thumbnail->getHeight() / $thumbnail->getWidth());
+			if ( $this->isThumbAboveMaxAspectRatio( $thumbnail ) ) {
+				$height = min( self::MAX_DESKTOP_THUMBNAIL_HEIGHT, $thumbnail->getHeight() );
+				$width = min( self::DESKTOP_THUMBNAIL_WIDTH, $height * $thumbnail->getWidth() /
+						$thumbnail->getHeight() );
+			} else {
+				$width = min( self::DESKTOP_THUMBNAIL_WIDTH, $thumbnail->getWidth() );
+				$height = min( self::MAX_DESKTOP_THUMBNAIL_HEIGHT, $width * $thumbnail->getHeight() /
+						$thumbnail->getWidth() );
+			}
 		} else {
 			$width = $thumbnail->getWidth();
 			$height = $thumbnail->getHeight();
 		}
 
 		return [ 'height' => $height, 'width' => $width ];
+	}
+
+	/**
+	 * @desc checks if thumbnail aspect ratio is bigger than max aspect ratio (tall and thin images)
+	 * @param $thumbnail \MediaTransformOutput
+	 * @return bool
+	 */
+	private function isThumbAboveMaxAspectRatio( $thumbnail ) {
+		return $thumbnail->getHeight() / $thumbnail->getWidth() > self::MAX_DESKTOP_THUMBNAIL_HEIGHT /
+			self::DESKTOP_THUMBNAIL_WIDTH;
 	}
 }

--- a/extensions/wikia/PortableInfobox/services/Helpers/PortableInfoboxRenderServiceHelper.php
+++ b/extensions/wikia/PortableInfobox/services/Helpers/PortableInfoboxRenderServiceHelper.php
@@ -203,7 +203,7 @@ class PortableInfoboxRenderServiceHelper {
 		$file = \WikiaFileHelper::getFileFromTitle( $title );
 
 		if ( $file ) {
-			$size = $this->getAdjustedImageSize( $file );
+			$size = $this->getImageSizesForThumbnailer( $file );
 			$thumb = $file->transform( $size );
 
 			if ( !is_null( $thumb ) && !$thumb->isError() ) {
@@ -225,7 +225,7 @@ class PortableInfoboxRenderServiceHelper {
 	 * @param $image
 	 * @return array width and height
 	 */
-	public function getAdjustedImageSize( $image ) {
+	public function getImageSizesForThumbnailer( $image ) {
 		global $wgPortableInfoboxCustomImageWidth;
 
 		if ( $this->isWikiaMobile() ) {

--- a/extensions/wikia/PortableInfobox/tests/PortableInfoboxRenderServiceHelperTest.php
+++ b/extensions/wikia/PortableInfobox/tests/PortableInfoboxRenderServiceHelperTest.php
@@ -389,7 +389,7 @@ class PortableInfoboxRenderServiceHelperTest extends WikiaBaseTest {
 	}
 
 	/**
-	 * @desc test getAdjustedImageSize function. It should return the sizes we pass to transform function,
+	 * @desc test getImageSizesForThumbnailer function. It should return the sizes we pass to transform function,
 	 * not the sizes we want image to have. transform adjusts the correct sizes,
 	 * that is creates thumbnail with sizes not bigger than passed, keeping the original aspect ratio.
 	 *
@@ -398,9 +398,9 @@ class PortableInfoboxRenderServiceHelperTest extends WikiaBaseTest {
 	 * @param $wgPortableInfoboxCustomImageWidth
 	 * @param $result
 	 * @param $description
-	 * @dataProvider testGetAdjustedImageSizeDataProvider
+	 * @dataProvider testGetImageSizesForThumbnailerDataProvider
 	 */
-	public function testGetAdjustedImageSize( $mockParams, $isWikiaMobile, $wgPortableInfoboxCustomImageWidth, $result, $description ) {
+	public function testGetImageSizesForThumbnailer( $mockParams, $isWikiaMobile, $wgPortableInfoboxCustomImageWidth, $result, $description ) {
 		$this->mockGlobalVariable('wgPortableInfoboxCustomImageWidth', $wgPortableInfoboxCustomImageWidth);
 		$mock = $this->getMockBuilder( 'Wikia\PortableInfobox\Helpers\PortableInfoboxRenderServiceHelper' )
 			->setMethods( [ 'isWikiaMobile' ] )
@@ -411,12 +411,12 @@ class PortableInfoboxRenderServiceHelperTest extends WikiaBaseTest {
 
 		$this->assertEquals(
 			$result,
-			$mock->getAdjustedImageSize( $file ),
+			$mock->getImageSizesForThumbnailer( $file ),
 			$description
 		);
 	}
 
-	public function testGetAdjustedImageSizeDataProvider() {
+	public function testGetImageSizesForThumbnailerDataProvider() {
 		return [
 			[
 				'mockParams' => [

--- a/extensions/wikia/PortableInfobox/tests/PortableInfoboxRenderServiceHelperTest.php
+++ b/extensions/wikia/PortableInfobox/tests/PortableInfoboxRenderServiceHelperTest.php
@@ -671,35 +671,35 @@ class PortableInfoboxRenderServiceHelperTest extends WikiaBaseTest {
 				'isWikiaMobile' => true,
 				'wgPortableInfoboxCustomImageWidth' => null,
 				'result' => [
-					'height' => 500,
+					'height' => 250,
 					'width' => 270
 				],
 				'description' => 'Regular thumbnail image on mobile with no custom width; logical size = physical size'
 			],
 			[
 				'thumbnailSizes' => [
-					'height' => 250,
+					'height' => 360,
 					'width' => 270
 
 				],
 				'isWikiaMobile' => true,
 				'wgPortableInfoboxCustomImageWidth' => 540,
 				'result' => [
-					'height' => 500,
+					'height' => 360,
 					'width' => 270
 				],
 				'description' => 'Regular thumbnail image on mobile with double custom width; portrait; logical size = physical size'
 			],
 			[
 				'thumbnailSizes' => [
-					'height' => 250,
-					'width' => 270
+					'height' => 270,
+					'width' => 360
 				],
 				'isWikiaMobile' => true,
 				'wgPortableInfoboxCustomImageWidth' => 540,
 				'result' => [
-					'height' => 250,
-					'width' => 270
+					'height' => 270,
+					'width' => 360
 				],
 				'description' => 'Regular thumbnail image on desktop with double custom width; landscape; logical size = physical size'
 			]

--- a/extensions/wikia/PortableInfobox/tests/PortableInfoboxRenderServiceHelperTest.php
+++ b/extensions/wikia/PortableInfobox/tests/PortableInfoboxRenderServiceHelperTest.php
@@ -15,6 +15,7 @@ class PortableInfoboxRenderServiceHelperTest extends WikiaBaseTest {
 	/**
 	 * @desc mocks WikiaFileHelper methods
 	 * @param array $input
+	 * @return \PHPUnit_Framework_MockObject_MockObject
 	 */
 	public function createWikiaFileHelperMock( $input ) {
 		$fileWidth = isset( $input[ 'fileWidth' ] ) ? $input[ 'fileWidth' ] : null;
@@ -391,14 +392,16 @@ class PortableInfoboxRenderServiceHelperTest extends WikiaBaseTest {
 	 * @desc test getAdjustedImageSize function. It should return the sizes we pass to transform function,
 	 * not the sizes we want image to have. transform adjusts the correct sizes,
 	 * that is creates thumbnail with sizes not bigger than passed, keeping the original aspect ratio.
-	 * 
+	 *
 	 * @param $mockParams
 	 * @param $isWikiaMobile
+	 * @param $wgPortableInfoboxCustomImageWidth
 	 * @param $result
 	 * @param $description
 	 * @dataProvider testGetAdjustedImageSizeDataProvider
 	 */
-	public function testGetAdjustedImageSize( $mockParams, $isWikiaMobile, $result, $description ) {
+	public function testGetAdjustedImageSize( $mockParams, $isWikiaMobile, $wgPortableInfoboxCustomImageWidth, $result, $description ) {
+		$this->mockGlobalVariable('wgPortableInfoboxCustomImageWidth', $wgPortableInfoboxCustomImageWidth);
 		$mock = $this->getMockBuilder( 'Wikia\PortableInfobox\Helpers\PortableInfoboxRenderServiceHelper' )
 			->setMethods( [ 'isWikiaMobile' ] )
 			->getMock();
@@ -421,6 +424,7 @@ class PortableInfoboxRenderServiceHelperTest extends WikiaBaseTest {
 					'fileWidth' => 3000
 				],
 				'isWikiaMobile' => false,
+				'wgPortableInfoboxCustomImageWidth' => null,
 				'result' => [
 					'height' => 500,
 					'width' => 270
@@ -433,6 +437,7 @@ class PortableInfoboxRenderServiceHelperTest extends WikiaBaseTest {
 					'fileWidth' => 250
 				],
 				'isWikiaMobile' => false,
+				'wgPortableInfoboxCustomImageWidth' => null,
 				'result' => [
 					'height' => 500,
 					'width' => 270
@@ -445,6 +450,7 @@ class PortableInfoboxRenderServiceHelperTest extends WikiaBaseTest {
 					'fileWidth' => 2000
 				],
 				'isWikiaMobile' => false,
+				'wgPortableInfoboxCustomImageWidth' => null,
 				'result' => [
 					'height' => 200,
 					'width' => 270
@@ -457,6 +463,7 @@ class PortableInfoboxRenderServiceHelperTest extends WikiaBaseTest {
 					'fileWidth' => 45
 				],
 				'isWikiaMobile' => false,
+				'wgPortableInfoboxCustomImageWidth' => null,
 				'result' => [
 					'height' => 50,
 					'width' => 270
@@ -469,6 +476,7 @@ class PortableInfoboxRenderServiceHelperTest extends WikiaBaseTest {
 					'fileWidth' => 3000
 				],
 				'isWikiaMobile' => true,
+				'wgPortableInfoboxCustomImageWidth' => null,
 				'result' => [
 					'height' => null,
 					'width' => 360
@@ -481,6 +489,7 @@ class PortableInfoboxRenderServiceHelperTest extends WikiaBaseTest {
 					'fileWidth' => 250
 				],
 				'isWikiaMobile' => true,
+				'wgPortableInfoboxCustomImageWidth' => null,
 				'result' => [
 					'height' => null,
 					'width' => 360
@@ -493,6 +502,7 @@ class PortableInfoboxRenderServiceHelperTest extends WikiaBaseTest {
 					'fileWidth' => 2000
 				],
 				'isWikiaMobile' => true,
+				'wgPortableInfoboxCustomImageWidth' => null,
 				'result' => [
 					'height' => null,
 					'width' => 360
@@ -505,12 +515,65 @@ class PortableInfoboxRenderServiceHelperTest extends WikiaBaseTest {
 					'fileWidth' => 45
 				],
 				'isWikiaMobile' => true,
+				'wgPortableInfoboxCustomImageWidth' => null,
 				'result' => [
 					'height' => null,
 					'width' => 360
 				],
 				'description' => 'Small image on mobile'
-			]
+			],
+			[
+				'mockParams' => [
+					'fileHeight' => 2000,
+					'fileWidth' => 3000
+				],
+				'isWikiaMobile' => false,
+				'wgPortableInfoboxCustomImageWidth' => 400,
+				'result' => [
+					'height' => 2000,
+					'width' => 400
+				],
+				'description' => 'Big image on desktop with custom image width'
+			],
+			[
+				'mockParams' => [
+					'fileHeight' => 3000,
+					'fileWidth' => 250
+				],
+				'isWikiaMobile' => false,
+				'wgPortableInfoboxCustomImageWidth' => 400,
+				'result' => [
+					'height' => 3000,
+					'width' => 400
+				],
+				'description' => 'Tall image on desktop with custom image width'
+			],
+			[
+				'mockParams' => [
+					'fileHeight' => 200,
+					'fileWidth' => 2000
+				],
+				'isWikiaMobile' => false,
+				'wgPortableInfoboxCustomImageWidth' => 400,
+				'result' => [
+					'height' => 200,
+					'width' => 400
+				],
+				'description' => 'Wide image on desktop with custom image width'
+			],
+			[
+				'mockParams' => [
+					'fileHeight' => 2000,
+					'fileWidth' => 3000
+				],
+				'isWikiaMobile' => true,
+				'wgPortableInfoboxCustomImageWidth' => 400,
+				'result' => [
+					'height' => null,
+					'width' => 360
+				],
+				'description' => 'Big image on mobile with custom image width'
+			],
 		];
 	}
 }

--- a/extensions/wikia/PortableInfobox/tests/PortableInfoboxRenderServiceHelperTest.php
+++ b/extensions/wikia/PortableInfobox/tests/PortableInfoboxRenderServiceHelperTest.php
@@ -702,7 +702,21 @@ class PortableInfoboxRenderServiceHelperTest extends WikiaBaseTest {
 					'width' => 360
 				],
 				'description' => 'Regular thumbnail image on desktop with double custom width; landscape; logical size = physical size'
-			]
+			],
+				[
+					'thumbnailSizes' => [
+							'height' => 600,
+							'width' => 210
+					],
+					'isWikiaMobile' => false,
+					'wgPortableInfoboxCustomImageWidth' => 540,
+					'result' => [
+							'height' => 500,
+							'width' => 175
+					],
+					'description' => 'Regular thumbnail image on desktop with double custom width; portrait extra
+					thin image edge case'
+				]
 		];
 	}
 }


### PR DESCRIPTION
PLEASE DO NOT MERGE

https://wikia-inc.atlassian.net/browse/DAT-3576

This fix remove the blocker for migration of portable infoboxes on starwars.wikia.com

Deployment of this fix is delayed to Monday 14th of December
