### PR TITLE
DatabaseBase::isWriteQuery - EXPLAIN should not be treated as writable query

### DIFF
--- a/includes/db/Database.php
+++ b/includes/db/Database.php
@@ -842,7 +842,7 @@ abstract class DatabaseBase implements DatabaseType {
 	 * @return bool
 	 */
 	function isWriteQuery( $sql ) {
-		return !preg_match( '/^(?:SELECT|BEGIN|COMMIT|SET|SHOW|\(SELECT)\b/i', ltrim( $sql ) ) && // PLATFORM-1417 (ltrim)
+		return !preg_match( '/^(?:SELECT|BEGIN|ROLLBACK|COMMIT|SET|SHOW|EXPLAIN|\(SELECT)\b/i', ltrim( $sql ) ) && // PLATFORM-1417 (ltrim)
 			!preg_match('/(FOR UPDATE|LOCK IN SHARE MODE)$/i', rtrim( $sql ) ); // MAIN-5810 (rtrim)
 	}
 


### PR DESCRIPTION
Backported the current regex from https://github.com/wikimedia/mediawiki/blob/master/includes/db/Database.php#L890-L892 (which adds `ROLLBACK` there as well).

@wladekb / @michalroszka 
