### PR TITLE
Made Block::purgeExpired() check for read-only mode.

### DIFF
--- a/includes/Block.php
+++ b/includes/Block.php
@@ -960,9 +960,11 @@ class Block {
 	 * Purge expired blocks from the ipblocks table
 	 */
 	public static function purgeExpired() {
-		$dbw = wfGetDB( DB_MASTER );
-		$dbw->delete( 'ipblocks',
-			array( 'ipb_expiry < ' . $dbw->addQuotes( $dbw->timestamp() ) ), __METHOD__ );
+		if ( !wfReadOnly() ) {
+			$dbw = wfGetDB( DB_MASTER );
+			$dbw->delete( 'ipblocks',
+				array( 'ipb_expiry < ' . $dbw->addQuotes( $dbw->timestamp() ) ), __METHOD__ );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes [PLATFORM-1757](https://wikia-inc.atlassian.net/browse/PLATFORM-1757)

Backporting https://github.com/wikimedia/mediawiki/commit/8feda3a26fa71128e7f2cfcdbd5fe7858f696b6e from MW 1.21

@wladekb / @michalroszka 
