### PR TITLE
Security: introduce Utils::matchToken helper

### DIFF
--- a/extensions/wikia/Security/Security.setup.php
+++ b/extensions/wikia/Security/Security.setup.php
@@ -10,6 +10,7 @@
 // register classes
 $wgAutoloadClasses['Wikia\\Security\\CSRFDetector'] = __DIR__ . '/classes/CSRFDetector.class.php';
 $wgAutoloadClasses['Wikia\\Security\\Exception'] = __DIR__ . '/classes/Exception.class.php';
+$wgAutoloadClasses['Wikia\\Security\\Utils'] = __DIR__ . '/classes/Utils.class.php';
 
 // set per-request flags
 $wgHooks['UserMatchEditToken'][] = 'Wikia\\Security\\CSRFDetector::onUserMatchEditToken';

--- a/extensions/wikia/Security/classes/Utils.class.php
+++ b/extensions/wikia/Security/classes/Utils.class.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Wikia\Security;
+
+class Utils {
+
+	/**
+	 * A more generic version of User::matchEditToken that can be used for checking custom tokens
+	 *
+	 * @see PLATFORM-1703
+	 *
+	 * @param $expectedValue
+	 * @param $value
+	 * @return boolean
+	 */
+	public static function matchToken( $expectedValue, $value ) {
+		CSRFDetector::onUserMatchEditToken(); // set a flag that the token was checked
+
+		return $expectedValue === $value;
+	}
+}

--- a/extensions/wikia/SpecialEmailTest/SpecialEmailTest.php
+++ b/extensions/wikia/SpecialEmailTest/SpecialEmailTest.php
@@ -33,7 +33,7 @@ class SpecialEmailTest extends UnlistedSpecialPage {
 		wfProfileIn( __METHOD__ );
 
 		// Don't allow just anybody to use this
-		if ($this->mChallengeToken != $wgRequest->getVal('challenge')) {
+		if ( !Wikia\Security\Utils::matchToken( $this->mChallengeToken, $wgRequest->getVal('challenge') ) ) {
 			header("Status: 400");
 			header("Content-type: text/plain");
 			print("Challenge incorrect");


### PR DESCRIPTION
[PLATFORM-1703](https://wikia-inc.atlassian.net/browse/PLATFORM-1703)

Use `Wikia\Security\Utils::matchToken` for checking custom tokens in `Special:EmailTest`.

@wladekb / @Grunny 
