### PR TITLE
ADEN-2770 Backported changes connected to Taboola

### DIFF
--- a/extensions/wikia/AdEngine/js/provider/taboola.js
+++ b/extensions/wikia/AdEngine/js/provider/taboola.js
@@ -15,7 +15,7 @@ define('ext.wikia.adEngine.provider.taboola', [
 	'use strict';
 
 	var abGroups = {
-			recovery: abTest.getGroup('PROJECT_43') === 'GROUP_6',
+			recovery: abTest.getGroup('PROJECT_43_TABOOLA') === 'YES',
 			regular: abTest.getGroup('NATIVE_ADS_TABOOLA') === 'YES'
 		},
 		config = instantGlobals.wgAdDriverTaboolaConfig || {},

--- a/extensions/wikia/AdEngine/js/spec/provider/taboola.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/provider/taboola.spec.js
@@ -20,9 +20,7 @@ describe('Taboola ', function () {
 				show: noop
 			},
 			abTest: {
-				getGroup: function () {
-					return 'YES';
-				}
+				getGroup: noop
 			},
 			geo: {
 				isProperGeo: function (countries) {
@@ -99,6 +97,7 @@ describe('Taboola ', function () {
 	});
 
 	it('Cannot handle slot from not listed country', function () {
+		spyOn(mocks.abTest, 'getGroup').and.returnValue('YES');
 		mocks.instantGlobals.wgAdDriverTaboolaConfig.NATIVE_TABOOLA_ARTICLE.regular = ['ZZ'];
 		var taboola = getTaboola();
 
@@ -106,12 +105,14 @@ describe('Taboola ', function () {
 	});
 
 	it('Handles NATIVE_TABOOLA_ARTICLE for given country and AbTest group', function () {
+		spyOn(mocks.abTest, 'getGroup').and.returnValue('YES');
 		var taboola = getTaboola();
 
 		expect(taboola.canHandleSlot('NATIVE_TABOOLA_ARTICLE')).toBeTruthy();
 	});
 
 	it('Cannot handle recovery NATIVE_TABOOLA_ARTICLE when AbTest group is wrong', function () {
+		spyOn(mocks.abTest, 'getGroup').and.returnValue('NO');
 		mocks.instantGlobals.wgAdDriverTaboolaConfig.NATIVE_TABOOLA_ARTICLE = {
 			recovery: ['CURRENT'],
 			regular: []
@@ -122,18 +123,22 @@ describe('Taboola ', function () {
 	});
 
 	it('Cannot handle recovery NATIVE_TABOOLA_ARTICLE from not listed country', function () {
-		spyOn(mocks.abTest, 'getGroup').and.returnValue('GROUP_6');
+		spyOn(mocks.abTest, 'getGroup').and.returnValue('YES');
+		mocks.instantGlobals.wgAdDriverTaboolaConfig.NATIVE_TABOOLA_ARTICLE = {
+			recovery: [],
+			regular: []
+		};
 		var taboola = getTaboola();
 
 		expect(taboola.canHandleSlot('NATIVE_TABOOLA_ARTICLE')).toBeFalsy();
 	});
 
 	it('Handles recovery NATIVE_TABOOLA_RAIL for given country and AbTest group', function () {
+		spyOn(mocks.abTest, 'getGroup').and.returnValue('YES');
 		mocks.instantGlobals.wgAdDriverTaboolaConfig.NATIVE_TABOOLA_RAIL = {
 			recovery: ['CURRENT'],
 			regular: []
 		};
-		spyOn(mocks.abTest, 'getGroup').and.returnValue('GROUP_6');
 		var taboola = getTaboola();
 
 		expect(taboola.canHandleSlot('NATIVE_TABOOLA_RAIL')).toBeTruthy();
@@ -142,6 +147,11 @@ describe('Taboola ', function () {
 	it('Fills regular slot without using recovery helper', function () {
 		spyOn(mocks.recoveryHelper, 'addOnBlockingCallback');
 		spyOn(mocks.slotTweaker, 'show');
+		spyOn(mocks.abTest, 'getGroup').and.returnValue('YES');
+		mocks.instantGlobals.wgAdDriverTaboolaConfig.NATIVE_TABOOLA_RAIL = {
+			recovery: ['CURRENT'],
+			regular: []
+		};
 		var taboola = getTaboola();
 
 		taboola.canHandleSlot('NATIVE_TABOOLA_ARTICLE');
@@ -156,7 +166,7 @@ describe('Taboola ', function () {
 			recovery: ['CURRENT'],
 			regular: []
 		};
-		spyOn(mocks.abTest, 'getGroup').and.returnValue('GROUP_6');
+		spyOn(mocks.abTest, 'getGroup').and.returnValue('YES');
 		spyOn(mocks.recoveryHelper, 'addOnBlockingCallback');
 		var taboola = getTaboola();
 


### PR DESCRIPTION
Currently Taboola is enabled to 60% of ad-blocking traffic. We want to ramp it up but until it's in `PROJECT_43` experiment it's impossible.

Changes below moves Taboola to new experiment and update unit tests. The original PR with the changes being merged to dev branch: https://github.com/Wikia/app/pull/9307.
