### PR TITLE
PLATFORM-1727: Add extra logging around (un)deleting articles

### DIFF
--- a/includes/WikiPage.php
+++ b/includes/WikiPage.php
@@ -2112,6 +2112,36 @@ class WikiPage extends Page implements IDBAccessObject {
 
 		$dbw = wfGetDB( DB_MASTER );
 		$dbw->begin();
+
+		// Wikia change - begin -@author: wladek
+		$pageRow = $dbw->selectRow('page','*',[
+			'page_id' => $id,
+		],__METHOD__);
+		if (!$pageRow){
+			$pageRow = (object)[
+				'page_namespace' => '-1',
+				'page_title' => '???',
+			];
+		}
+		$beforeRevisionCount = $dbw->selectField('revision','count(*)',[
+			'rev_page' => $id,
+		],__METHOD__);
+		$beforeArchiveCount = $dbw->selectField('archive','count(*)',[
+			'ar_namespace' => $pageRow->page_namespace,
+			'ar_title'     => $pageRow->page_title,
+		],__METHOD__);
+		\Wikia\Logger\WikiaLogger::instance()->debug(
+			'RevisionAudit - before delete revisions',[
+				'exception' => new Exception(),
+				'page_namespace' => $pageRow->page_namespace,
+				'page_title' => $pageRow->page_title,
+				'page_id' => $id,
+				'rev_count_before' => $beforeRevisionCount,
+				'ar_count_before' => $beforeArchiveCount,
+			]
+		);
+		// Wikia change - end
+
 		// For now, shunt the revision data into the archive table.
 		// Text is *not* removed from the text table; bulk storage
 		// is left intact to avoid breaking block-compression or
@@ -2151,6 +2181,20 @@ class WikiPage extends Page implements IDBAccessObject {
 		$ok = ( $dbw->affectedRows() > 0 ); // getArticleId() uses slave, could be laggy
 
 		if ( !$ok ) {
+			// Wikia change - begin - @author: wladek
+			\Wikia\Logger\WikiaLogger::instance()->debug(
+				'RevisionAudit - delete revision error',[
+					'exception' => new Exception(),
+					'page_namespace' => $pageRow->page_namespace,
+					'page_title' => $pageRow->page_title,
+					'page_id' => $id,
+					'rev_count_before' => $beforeRevisionCount,
+					'ar_count_before' => $beforeArchiveCount,
+					'error_name' => 'no page row deleted',
+				]
+			);
+			// Wikia change - end
+
 			$dbw->rollback();
 			return WikiPage::DELETE_NO_REVISIONS;
 		}
@@ -2179,6 +2223,28 @@ class WikiPage extends Page implements IDBAccessObject {
 		// page if they rely on the title or related associations.
 		$this->doDeleteUpdates( $id );
 		// Wikia change end
+
+		// Wikia change - begin - @author: wladek
+		$afterRevisionCount = $dbw->selectField('revision','count(*)',[
+			'rev_page' => $id,
+		],__METHOD__);
+		$afterArchiveCount = $dbw->selectField('archive','count(*)',[
+			'ar_namespace' => $pageRow->page_namespace,
+			'ar_title'     => $pageRow->page_title,
+		],__METHOD__);
+		\Wikia\Logger\WikiaLogger::instance()->debug(
+			'RevisionAudit - after delete revisions',[
+				'exception' => new Exception(),
+				'page_namespace' => $pageRow->page_namespace,
+				'page_title' => $pageRow->page_title,
+				'page_id' => $id,
+				'rev_count_before' => $beforeRevisionCount,
+				'ar_count_before' => $beforeArchiveCount,
+				'rev_count_after' => $afterRevisionCount,
+				'ar_count_after' => $afterArchiveCount,
+			]
+		);
+		// Wikia change - end
 
 		if ( $commit ) {
 			$dbw->commit();

--- a/includes/specials/SpecialUndelete.php
+++ b/includes/specials/SpecialUndelete.php
@@ -451,6 +451,26 @@ class PageArchive {
 			$previousTimestamp = 0;
 		}
 
+		// Wikia change - begin -@author: wladek
+		$beforeRevisionCount = !empty($pageId) ? $dbw->selectField('revision','count(*)',[
+			'rev_page' => $page->page_id,
+		],__METHOD__) : 0;
+		$beforeArchiveCount = $dbw->selectField('archive','count(*)',[
+			'ar_namespace' => $this->title->getNamespace(),
+			'ar_title'     => $this->title->getDBkey(),
+		],__METHOD__);
+		\Wikia\Logger\WikiaLogger::instance()->debug(
+			'RevisionAudit - before undelete revisions',[
+				'exception' => new Exception(),
+				'page_namespace' => $this->title->getNamespace(),
+				'page_title' => $this->title->getDBkey(),
+				'page_id' => !empty($pageId) ? $pageId : 0,
+				'rev_count_before' => $beforeRevisionCount,
+				'ar_count_before' => $beforeArchiveCount,
+			]
+		);
+		// Wikia change - end
+
 		if( $restoreAll ) {
 			$oldones = '1 = 1'; # All revisions...
 		} else {
@@ -548,6 +568,28 @@ class PageArchive {
 				'ar_title' => $this->title->getDBkey(),
 				$oldones ),
 			__METHOD__ );
+
+		// Wikia change - begin -@author: wladek
+		$afterRevisionCount = $dbw->selectField('revision','count(*)',[
+			'rev_page' => $pageId,
+		],__METHOD__);
+		$afterArchiveCount = $dbw->selectField('archive','count(*)',[
+			'ar_namespace' => $this->title->getNamespace(),
+			'ar_title'     => $this->title->getDBkey(),
+		],__METHOD__);
+		\Wikia\Logger\WikiaLogger::instance()->debug(
+			'RevisionAudit - after undelete revisions',[
+				'exception' => new Exception(),
+				'page_namespace' => $this->title->getNamespace(),
+				'page_title' => $this->title->getDBkey(),
+				'page_id' => !empty($pageId) ? $pageId : 0,
+				'rev_count_before' => $beforeRevisionCount,
+				'ar_count_before' => $beforeArchiveCount,
+				'rev_count_after' => $afterRevisionCount,
+				'ar_count_after' => $afterArchiveCount,
+			]
+		);
+		// Wikia change - end
 
 		// Was anything restored at all?
 		if ( $restored == 0 ) {


### PR DESCRIPTION
We've caught some cases that deleted articles are missing the revisions. Let's add some logging to have a better overview of what's going under the hood.

https://wikia-inc.atlassian.net/browse/PLATFORM-1727

/cc @macbre 
