### PR TITLE
Refactor of RTEParser::doHeadings to remove buggy loop

### DIFF
--- a/extensions/wikia/RTE/RTEParser.class.php
+++ b/extensions/wikia/RTE/RTEParser.class.php
@@ -145,10 +145,9 @@ class RTEParser extends Parser {
 	 */
 	function doHeadings($text) {
 		wfProfileIn(__METHOD__);
-		for ( $i = 6; $i >= 1; --$i ) {
-			$h = str_repeat( '=', $i );
-			$text = preg_replace( "/^$h(.+)$h(\\s*)$/m",
-				"<h$i>\\1</h$i>\\2", $text );
+		if (preg_match('/^(={1,5}).*/m', $text, $m)) {
+		    $n = strlen($m[1]);
+		    $text = preg_replace( "/^{$m[1]}(.+){$m[1]}(\\s*)$/", "<h$n>\\1</h$n>\\2", $text );
 		}
 		wfProfileOut(__METHOD__);
 		return $text;


### PR DESCRIPTION
I was asked how to improve this during an interview today by @rafalkalinski. I was too nervous to think of the solution during the interview, but as soon as the interview was finished I thought of a possible solution. 

My internet is too slow to download the vagrant image or clone the `app` repository, so I edited it directly on Github off the top of my head; i.e. I assume there are some CI to test this. 

I'm not familiar with your markdown but I kept the exclusion of the `h6` tag intact.

Where is the test class for this?
