### PR TITLE
Made the ImpliedRedirect explicitly NOT run when action=submit which …

### DIFF
--- a/extensions/3rdparty/LyricWiki/lw_impliedRedirects.php
+++ b/extensions/3rdparty/LyricWiki/lw_impliedRedirects.php
@@ -33,8 +33,14 @@ function wfImpliedRedirects(){
 // Given a title, gives us a chance to create an article for it before MediaWiki takes its normal approach.
 ////
 function wfImpliedRedirects_articleFromTitle(Title &$title, &$article){
+	$action = F::app()->wg->Request->getVal('action', 'view');
+
+	
 	// We only want to mess with titles for pages that don't already exist.
-	if(!$title->exists() && ($title->getNamespace() == NS_MAIN)){
+	//
+	// MAIN-5845: Due to some changes in when this hook gets called, we need to explicitly ignore this functionality
+	// when action=submit so that we can create/edit pages that have implied redirects elsewhere.
+	if(!$title->exists() && ($title->getNamespace() == NS_MAIN) && ($action !== "submit")){
 		$origTitle = $title->getDBkey(); // this format has the characters as we need them already
 
 		// If there is more than one colon, the vast majority of the time it seems to be in the name of the song rather than the artist so we


### PR DESCRIPTION
…fixes some problems that showed up recently. For example, if "A:S" existed, we were unable to create "A:S (1984)" which was a common use-case when a song and album shared the same name.

Fixes MAIN-5845
