### PR TITLE
SEO-197 Bring Noindex directives back to robots.txt

### DIFF
--- a/robots.txt.d/revised-robots-ext.txt
+++ b/robots.txt.d/revised-robots-ext.txt
@@ -1,0 +1,133 @@
+User-agent: IsraBot
+Disallow: /
+
+User-agent: Orthogaffe
+Disallow: /
+
+User-agent: UbiCrawler
+Disallow: /
+
+User-agent: DOC
+Disallow: /
+
+User-agent: Zao
+Disallow: /
+
+User-agent: sitecheck.internetseer.com
+Disallow: /
+
+User-agent: Zealbot
+Disallow: /
+
+User-agent: MSIECrawler
+Disallow: /
+
+User-agent: SiteSnagger
+Disallow: /
+
+User-agent: WebStripper
+Disallow: /
+
+User-agent: WebCopier
+Disallow: /
+
+User-agent: Fetch
+Disallow: /
+
+User-agent: Offline Explorer
+Disallow: /
+
+User-agent: Teleport
+Disallow: /
+
+User-agent: TeleportPro
+Disallow: /
+
+User-agent: WebZIP
+Disallow: /
+
+User-agent: linko
+Disallow: /
+
+User-agent: HTTrack
+Disallow: /
+
+User-agent: Microsoft.URL.Control
+Disallow: /
+
+User-agent: Xenu
+Disallow: /
+
+User-agent: larbin
+Disallow: /
+
+User-agent: libwww
+Disallow: /
+
+User-agent: ZyBORG
+Disallow: /
+
+User-agent: Download Ninja
+Disallow: /
+
+User-agent: sitebot
+Disallow: /
+
+User-agent: wget
+Disallow: /
+
+User-agent: k2spider
+Disallow: /
+
+User-agent: NPBot
+Disallow: /
+
+User-agent: WebReaper
+Disallow: /
+
+User-agent: *
+Allow: /wiki/Special:CreateNewWiki
+Allow: /wiki/Special:CreateWiki
+Allow: /wiki/Special:Forum
+Allow: /wiki/Special:Forums
+Allow: /wiki/Special:Sitemap
+Allow: /wiki/Special:Videos
+Allow: /wiki/Special:Video
+Disallow: /wiki/Special:
+Disallow: /*?*title=Special:
+Disallow: /index.php/Special:
+Disallow: /wiki/Template:
+Disallow: /*?*title=Template:
+Disallow: /index.php/Template:
+Disallow: /wiki/Template_talk:
+Disallow: /*?*title=Template_talk:
+Disallow: /index.php/Template_talk:
+Disallow: /*?*action=
+Disallow: /*?*feed=
+Disallow: /*?*oldid=
+Disallow: /*?*printable=
+Disallow: /*?*useskin=
+Disallow: /*?*uselang=
+Disallow: /w/
+Disallow: /trap/
+Disallow: /dbdumps/
+Disallow: /wikistats/
+Noindex: /wiki/Special:
+Noindex: /*?*title=Special:
+Noindex: /index.php/Special:
+Noindex: /wiki/Template:
+Noindex: /*?*title=Template:
+Noindex: /index.php/Template:
+Noindex: /wiki/Template_talk:
+Noindex: /*?*title=Template_talk:
+Noindex: /index.php/Template_talk:
+Noindex: /*?*action=
+Noindex: /*?*feed=
+Noindex: /*?*oldid=
+Noindex: /*?*printable=
+Noindex: /*?*useskin=
+Noindex: /*?*uselang=
+Noindex: /w/
+Noindex: /trap/
+Noindex: /dbdumps/
+Noindex: /wikistats/


### PR DESCRIPTION
When testing the new RobotsTxt extension we omitted the Noindex
directives, as they are not documented to be supported by any search
engines.

From experimenting though, it seems they do have an impact. Searching
for "gameofthrones.wikia.com/wiki/Special:WikiActivity" brings the
WikiActivity page as the first result, the summary is missing though
(replaced with "the content was blocked by robots.txt").

We don't want those results in search results at all and this is what
Noindex was doing for us. (Another solution is to not disallow those
pages to be crawled and add a proper META tag, but this means the
robots actually visit those pages and we don't want them to).

This particular commit adds a variant of robots.txt generated by the
updated version of RobotsTxt extension and allows us to put it to test
on a few English wikis.

The test needs to be enabled in WikiFactory and will be easy to disable
if something is wrong.
