### PR TITLE
LookupContribsCore: do not join with a (outdated) copy of wikicities.city_list

### DIFF
--- a/extensions/wikia/LookupContribs/SpecialLookupContribs_helper.php
+++ b/extensions/wikia/LookupContribs/SpecialLookupContribs_helper.php
@@ -162,7 +162,6 @@ class LookupContribsCore {
 				$where = [
 					'user_id' => $this->mUserId,
 					'event_type' => [ 1, 2 ],
-					'wiki_id = city_id',
 				];
 
 				if ( !empty( $excludedWikis ) && is_array( $excludedWikis ) ) {
@@ -182,7 +181,7 @@ class LookupContribsCore {
 				}
 
 				$res = $dbr->select(
-					[ 'events', 'wikicities.city_list' ],
+					'events',
 					[
 						'wiki_id',
 						'count(*) as edits',
@@ -260,11 +259,12 @@ class LookupContribsCore {
 		}
 	}
 
-	private function getActivityCount( DatabaseBase $dbr, $where ) {
+	private function getActivityCount( DatabaseBase $dbr, Array $where ) {
 		$res = $dbr->select(
-			[ 'events', 'wikicities.city_list' ],
+			'events'
 			[ 'count(distinct wiki_id) as num' ],
-			$where
+			$where,
+			__METHOD__
 		);
 
 		$row = $dbr->fetchObject( $res );


### PR DESCRIPTION
[PLATFORM-1768](https://wikia-inc.atlassian.net/browse/PLATFORM-1768)

`events` table is [cleaned up by the maintenance script](https://github.com/Wikia/app/blob/dev/maintenance/wikia/eventsCleanup.php#L78-78) that removes entries for old wikis. No need to make a join with an outdated copy of `wikicities.city_list` on stats DB.

@Grunny / @adamkarminski / @wladekb 
