### PR TITLE
(CE-3192) Fix missing comma in LookupContribsCore::getActivityCount

### DIFF
--- a/extensions/wikia/LookupContribs/SpecialLookupContribs_helper.php
+++ b/extensions/wikia/LookupContribs/SpecialLookupContribs_helper.php
@@ -261,7 +261,7 @@ class LookupContribsCore {
 
 	private function getActivityCount( DatabaseBase $dbr, Array $where ) {
 		$res = $dbr->select(
-			'events'
+			'events',
 			[ 'count(distinct wiki_id) as num' ],
 			$where,
 			__METHOD__


### PR DESCRIPTION
Comma was missing after the change in https://github.com/Wikia/app/pull/9342 which
caused UserActivity data loading to fail due to a fatal error.

/cc @Wikia/community-engineering @macbre 
