### PR TITLE
VE-1919: Remove blur-radius from VE as it was causing rendering issues

### DIFF
--- a/skins/oasis/css/core/breakpoints-layout.scss
+++ b/skins/oasis/css/core/breakpoints-layout.scss
@@ -334,7 +334,7 @@ body.ve {
 	}
 
 	.WikiaMainContent {
-		box-shadow: 0 0 $vw-overlay-shadow-size $vw-overlay-shadow-size $ve-overlay-color;
+		box-shadow: 0 0 0 $vw-overlay-shadow-size $ve-overlay-color;
 		padding: 0;
 		pointer-events: all;
 		z-index: $zTop;


### PR DESCRIPTION
The blur radius on the Visual Editors box shadow was causing VE to not render on newer versions of Microsoft Edge. Removing blur radius entirely has no change to the intended effect, while fixing rendering issues. May also cause an improvement to render times as per http://nerds.airbnb.com/box-shadows-are-expensive-to-paint/
