### PR TITLE
SEO-181 Fix removal of hreflang link to self

### DIFF
--- a/extensions/wikia/SeoLinkHreflang/SeoLinkHreflang.class.php
+++ b/extensions/wikia/SeoLinkHreflang/SeoLinkHreflang.class.php
@@ -75,7 +75,7 @@ class SeoLinkHreflang {
 		}
 
 		// Remove link to self
-		$lang = $out->getLanguage()->getCode();
+		$lang = $title->getPageLanguage()->getCode();
 		unset( $links[$lang] );
 
 		return array_map( function ( $lang, $url ) {


### PR DESCRIPTION
The code checks the language code and removes the link from the
structure based on that language code, so there's no link to an English
article on an English article (no point linking to self).

The problem is the code checked the user language instead of the content
language and this commit fixes it by fetching the language from wgTitle.
