### PR TITLE
SEO-194 Fix main page HTML title on Mercury

### DIFF
--- a/extensions/wikia/MercuryApi/MercuryApiController.class.php
+++ b/extensions/wikia/MercuryApi/MercuryApiController.class.php
@@ -385,7 +385,9 @@ class MercuryApiController extends WikiaController {
 				if ( !empty( $relatedPages ) ) {
 					$data['relatedPages'] = $relatedPages;
 				}
-				$titleBuilder->setParts( [ $articleAsJson['displayTitle'] ] );
+				if ( !$isMainPage ) {
+					$titleBuilder->setParts( [ $articleAsJson['displayTitle'] ] );
+				}
 			}
 			$data['htmlTitle'] = $titleBuilder->getTitle();
 


### PR DESCRIPTION
Don't add article name in front of the wiki name in the HTML title
exported by the API used by Mercury.
