### PR TITLE
Combined SEO changes for easier code review

### DIFF
--- a/extensions/wikia/MercuryApi/MercuryApiController.class.php
+++ b/extensions/wikia/MercuryApi/MercuryApiController.class.php
@@ -385,7 +385,9 @@ class MercuryApiController extends WikiaController {
 				if ( !empty( $relatedPages ) ) {
 					$data['relatedPages'] = $relatedPages;
 				}
-				$titleBuilder->setParts( [ $articleAsJson['displayTitle'] ] );
+				if ( !$isMainPage ) {
+					$titleBuilder->setParts( [ $articleAsJson['displayTitle'] ] );
+				}
 			}
 			$data['htmlTitle'] = $titleBuilder->getTitle();
 

--- a/extensions/wikia/SeoLinkHreflang/SeoLinkHreflang.class.php
+++ b/extensions/wikia/SeoLinkHreflang/SeoLinkHreflang.class.php
@@ -75,7 +75,7 @@ class SeoLinkHreflang {
 		}
 
 		// Remove link to self
-		$lang = $out->getLanguage()->getCode();
+		$lang = $title->getPageLanguage()->getCode();
 		unset( $links[$lang] );
 
 		return array_map( function ( $lang, $url ) {

--- a/includes/wikia/WikiaHtmlTitle.class.php
+++ b/includes/wikia/WikiaHtmlTitle.class.php
@@ -41,14 +41,6 @@ class WikiaHtmlTitle {
 	}
 
 	/**
-	 * Get brand name
-	 * @return String
-	 */
-	public function getBrandName() {
-		return $this->brandName->inContentLanguage()->escaped();
-	}
-
-	/**
 	 * Set the HTML title parts
 	 *
 	 * You can pass an empty array: the generated title will be wiki name + brand name
@@ -73,7 +65,7 @@ class WikiaHtmlTitle {
 
 		foreach ( $parts as $part ) {
 			if ( $part instanceof Message ) {
-				$newParts[] = $part->inContentLanguage()->escaped();
+				$newParts[] = $part->inContentLanguage()->plain();
 			}
 			if ( is_string( $part ) ) {
 				$newParts[] = $part;


### PR DESCRIPTION
- SEO-199 Don't HTML encode the title coming from WikiaHtmlTitle

(Also removed an unused getter method)
- SEO-194 Fix main page HTML title on Mercury

Don't add article name in front of the wiki name in the HTML title exported
by the API used by Mercury.
- SEO-181 Fix removal of hreflang link to self

The code checks the language code and removes the link from the structure
based on that language code, so there's no link to an English article on an
English article (no point linking to self).

The problem is the code checked the user language instead of the content
language and this commit fixes it by fetching the language from wgTitle.
