### PR TITLE
SEO-146 Remove "In other languages" section from mobile skin

### DIFF
--- a/extensions/wikia/WikiaMobile/WikiaMobileHooks.class.php
+++ b/extensions/wikia/WikiaMobile/WikiaMobileHooks.class.php
@@ -129,6 +129,29 @@ class WikiaMobileHooks {
 				'',
 				$text
 			);
+
+			//Remove "In other languages" section from starwars wikis that looks like this:
+			//
+			//<div id="p-lang" class="portlet">
+			//<div>In other languages</div>
+			//<div class="pBody">
+			//<ul>
+			//<li class="interwiki-bg plainlinks" title="bg:Чубака"><a class="text" href=" [...]</ul>
+			//</div>
+			//</div>
+			//
+			//There's code in Mercury to generate the section based on links from Lilly
+
+			if ( F::app()->wg->EnableLillyExt ) {
+				$regex = '<div id="p-lang" class="portlet">\s*'
+					. '<div>[^<>]*</div>\s*'
+					. '<div class="pBody">\s*'
+					. '<ul>\s*'
+					. '([^<>]+|<li\s[^<>]*>|</li>|<a\s[^<>]*>|</a>)*</ul>\s*'
+					. '</div>\s*'
+					. '</div>';
+				$text = preg_replace(":$regex:im", '',	$text);
+			}
 		}
 
 		wfProfileOut( __METHOD__ );


### PR DESCRIPTION
This is only triggered on Star Wars wikis (where wgEnableLillyExt is
on). Only the Star Wars wikis are known to generate this section as a
part of the content (vs using the regular interwiki links).

There's code in Mercury to generate the section based on links from
Lilly (again for Star Wars wikis only).

See also Wikia/mercury#1813 and Wikia/app#9361
