### PR TITLE
(CE-3194) Fix LookupContribs data for users with quotes in their names

### DIFF
--- a/extensions/wikia/LookupContribs/templates/main-form.tmpl.php
+++ b/extensions/wikia/LookupContribs/templates/main-form.tmpl.php
@@ -136,12 +136,12 @@ $(document).ready(function() {
 				"type": "POST",
 				"url": sSource,
 				"data": [
-					{ 'name' : 'username',	'value' : ( $('#lc_search').exists() ) ? mw.html.escape( $('#lc_search').val() ) : '' },
+					{ 'name' : 'username',	'value' : ( $('#lc_search').length ) ? $('#lc_search').val() : '' },
 					{ 'name' : 'limit', 	'value' : limit },
 					{ 'name' : 'offset',	'value' : offset },
 					{ 'name' : 'loop',      'value' : loop },
 					{ 'name' : 'numOrder',	'value' : sortingCols },
-					{ 'name' : 'order',     'value' : mw.html.escape( order ) }
+					{ 'name' : 'order',     'value' : order }
 				],
 				"success": fnCallback
 			} );

--- a/extensions/wikia/LookupUser/templates/contribution.table.tmpl.php
+++ b/extensions/wikia/LookupUser/templates/contribution.table.tmpl.php
@@ -109,12 +109,12 @@ $(document).ready(function() {
 				type: "POST",
 				url: sSource,
 				data: [
-					{ name: 'username', value: ( $('#lu_name').exists() ) ? mw.html.escape( $('#lu_name').val() ) : '' },
+					{ name: 'username', value: ( $('#lu_name').length ) ? $('#lu_name').val() : '' },
 					{ name: 'limit', value: limit },
 					{ name: 'offset', value: offset },
 					{ name: 'loop', value: loop },
 					{ name: 'numOrder', value: sortingCols },
-					{ name: 'order', value: mw.html.escape( order ) }
+					{ name: 'order', value: order }
 				],
 				success: function(json) {
 					fnCallback(json);


### PR DESCRIPTION
No need to HTML escape data sent in an AJAX request, which results in quotes
in usernames being HTML encoded before being sent in the request.

/cc @Wikia/community-engineering @macbre 
