### PR TITLE
SEO-75 Replace Our404Handler extension with a simpler approach

### DIFF
--- a/extensions/wikia/Our404Handler/SpecialOur404Handler.php
+++ b/extensions/wikia/Our404Handler/SpecialOur404Handler.php
@@ -29,5 +29,3 @@ $dir = dirname(__FILE__) . '/';
 $wgExtensionMessagesFiles['Our404Handler'] = $dir . 'SpecialOur404Handler.i18n.php';
 $wgAutoloadClasses['Our404HandlerPage'] = $dir. 'SpecialOur404Handler_body.php';
 $wgSpecialPages['Our404Handler'] = 'Our404HandlerPage';
-
-$wgHooks['TestCanonicalRedirect'][] = 'Our404HandlerPage::onTestCanonicalRedirect';

--- a/extensions/wikia/Our404Handler/SpecialOur404Handler_body.php
+++ b/extensions/wikia/Our404Handler/SpecialOur404Handler_body.php
@@ -43,97 +43,28 @@ class Our404HandlerPage extends UnlistedSpecialPage {
 	 * Just render some simple 404 page
 	 */
 	public function doRender404() {
-		global $wgOut, $wgContLang, $wgCanonicalNamespaceNames, $wgOur404HandlerBroaderRedirects;
+		global $wgOut, $wgContLang;
 
-		/**
-		 * check, maybe we have article with that title, if yes 301redirect to
-		 * this article
-		 */
-		$uri = $_SERVER['REQUEST_URI'];
-		if ( !preg_match( '!^https?://!', $uri ) ) {
-			$uri = 'http://unused' . $uri;
-		}
-		$uri = substr( parse_url( $uri, PHP_URL_PATH ), 1 );
-
-		Wikia::log( __METHOD__, false,  isset($_SERVER[ 'HTTP_REFERER' ])?$_SERVER[ 'HTTP_REFERER' ]:"[no referer]" );
+		$uri = substr( parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH ), 1 );
 		$title = $wgContLang->ucfirst( urldecode( ltrim( $uri, "/" ) ) );
-		$namespace = NS_MAIN;
+		$oTitle = Title::newFromText( $title );
 
-		/**
-		 * first check if title is in namespace other than main
-		 */
-		$parts = explode( ":", $title, 2 );
-		if( count( $parts ) == 2 ) {
-			foreach( $wgCanonicalNamespaceNames as $id => $name ) {
-				$translated = $wgContLang->getNsText( $id );
-				if( strtolower( $translated ) === strtolower( $parts[0] ) ||
-					strtolower( $name ) === strtolower( $parts[0] ) ) {
-					$namespace = $id;
-					$title = $parts[1];
-					break;
-				}
-			}
+		if ( is_null( $oTitle ) ) {
+			$wgOut->setStatusCode( 404 );
+
+			$info = wfMsgForContent( 'message404', $uri, urldecode( $title ) );
+			$wgOut->addHTML( '<h2>' . wfMsg( 'our404handler-oops' ) . '</h2>
+						<div>' . $wgOut->parse( $info ) . '</div>' );
+			return;
 		}
 
-		/**
-		 * create title from parts
-		 */
-		$oTitle = Title::newFromText( $title, $namespace );
+		// Preserve the query string on a redirect
+		$query = parse_url( $_SERVER['REQUEST_URI'], PHP_URL_QUERY );
 
-		if( !is_null( $oTitle ) ) {
-			// Preserve the query string on a redirect
-			$query = parse_url ( $_SERVER['REQUEST_URI'], PHP_URL_QUERY );
-			if( $namespace == NS_SPECIAL
-				|| $namespace == NS_MEDIA
-				|| $wgOur404HandlerBroaderRedirects
-			) {
-				/**
-				 * these namespaces are special and don't have articles
-				 */
-				header( "X-Redirected-By: Our404Handler" );
-				header( sprintf( "Location: %s", $oTitle->getFullURL($query) ), true, 301 );
-				exit( 0 );
+		// Log the query string to understand what params are used
+		Wikia\Logger\WikiaLogger::instance()->debug( __METHOD__, [ 'qs' => $query, 'ex' => new Exception() ] );
 
-			} else {
-				$oArticle = new Article( $oTitle );
-				if( $oArticle->exists() ) {
-					header( "X-Redirected-By: Our404Handler" );
-					header( sprintf( "Location: %s", $oArticle->getTitle()->getFullURL($query) ), true, 301 );
-					exit( 0 );
-				}
-			}
-
-		}
-
-		/**
-		 * but if doesn't exist, we eventually show 404page
-		 */
-		$wgOut->setStatusCode( 404 );
-
-		$info = wfMsgForContent( 'message404', $uri, urldecode( $title ) );
-		$wgOut->addHTML( '<h2>'.wfMsg( 'our404handler-oops' ).'</h2>
-						<div>'. $wgOut->parse( $info ) .'</div>' );
+		header( "X-Redirected-By: Our404Handler" );
+		header( sprintf( "Location: %s", $oTitle->getFullURL( $query ) ), true, 301 );
 	}
-
-	/**
-	 * This hook is called when about to force a redirect to a canonical URL
-	 * for a title when we have no other parameters on the URL.
-	 *
-	 * Return false when we want to prevent the redirect to the canonical URL
-	 * for Our404Handler special page
-	 *
-	 * @see PLATFORM-811
-	 *
-	 * @param WebRequest $request
-	 * @param Title $title
-	 * @param OutputPage $output
-	 * @return bool
-	 */
-	public static function onTestCanonicalRedirect( WebRequest $request, Title $title, OutputPage $output) {
-		if ( $title->isSpecial( self::NAME ) ) {
-			return false;
-		}
-
-		return true;
-	}
-};
+}


### PR DESCRIPTION
A two-line redirect-canon.php PHP script will do the same as the whole extension. We'll just need to point ErrorDocument 404 to this file in Apache config.

The problem is it would discard the URL params. So let's log the query strings to find out if they are worth keeping.
