### PR TITLE
(CE-3091) Remove "Best Practices" message in classic editor preview

### DIFF
--- a/extensions/wikia/EditPageLayout/css/EditPageLayout.scss
+++ b/extensions/wikia/EditPageLayout/css/EditPageLayout.scss
@@ -356,30 +356,6 @@ body {
 				margin: 0 auto;
 			}
 
-			.preview-modal-msg-wrapper {
-				border: 1px solid $color-page-border;
-				border-bottom: 0;
-				box-sizing: border-box;
-				max-height: 100px;
-				overflow-y: auto;
-				width: 100%;
-			}
-
-			.preview-modal-msg {
-				display: table;
-
-				.preview-message {
-					display: table-cell;
-					padding: 18px;
-				}
-
-				.preview-link {
-					display: table-cell;
-					padding: 0 18px;
-					text-align: right;
-				}
-			}
-
 			// FB#8087 - styling for interlanguage links in RTE popup preview
 			.WikiaArticleInterlang {
 				h3 {

--- a/extensions/wikia/EditPreview/EditPreview.i18n.php
+++ b/extensions/wikia/EditPreview/EditPreview.i18n.php
@@ -9,9 +9,6 @@ $messages['en'] = array(
 	'wikia-editor-preview-max-width' => 'Desktop XL',
 	'wikia-editor-preview-mobile-width' => 'Mobile',
 	'wikia-editor-preview-type-tooltip' => "Changing this option will show you what this article will look like when it's displayed in a browser on small screens, large screens, mobile devices, or your current display.",
-	'wikia-editor-preview-best-practices-notice' => 'Did you know that over 50% of Wikia visitors are reading your content on mobile? Some custom templates may not properly show on mobile devices. To make sure everything looks great to all visitors, follow our best practices.',
-	'wikia-editor-preview-best-practices-button' => 'Best practices',
-	'wikia-editor-preview-best-practices-button-link' => 'Help:Wikitext_best_practices',
 );
 
 /** Message Documentation */
@@ -21,9 +18,6 @@ $messages['qqq'] = array(
 	'wikia-editor-preview-min-width' => 'select option; after choosing it a user is shown a preview of the article in minimum supported width (768px)',
 	'wikia-editor-preview-max-width' => 'select option; after choosing it a user is shown a preview of the article in the lower bound of the maximum supported width range (1596px)',
 	'wikia-editor-preview-type-tooltip' => 'content of a comics bubble displayed after hovering over small icon with a question mark; it explains what preview type select does',
-	'wikia-editor-preview-best-practices-notice' => 'A notice shown at the top of the preview dialog, with a button (link) next to the notice',
-	'wikia-editor-preview-best-practices-button' => 'A button (link) label which leads to a separate page describing best practices and advice on how to create content for mobile and desktop',
-	'wikia-editor-preview-best-practices-button-link' => 'A button link URL to help page with wikitext best practices',
 );
 
 /** German */
@@ -34,9 +28,6 @@ $messages['de'] = array(
 	'wikia-editor-preview-type-tooltip' => 'Das Ändern dieser Option zeigt dir, wie dieser Artikel in in Browsern mit kleinen und großen Bildschirmen, auf Mobil-Geräten oder auf deinem jetzigen Bildschirm aussieht.',
 	'wikia-editor-preview-desc' => 'Ermöglicht den Benutzern ihre Änderungen vor dem Speichern in der Vorschau anzusehen',
 	'wikia-editor-preview-mobile-width' => 'Mobile Geräte',
-	'wikia-editor-preview-best-practices-notice' => 'Wusstest du, dass 50% der Netzverkehrs von mobilen Geräten kommt? Es kann sein, dass einige der Vorlagen auf den mobilen Geräten nicht richtig angezeigt werden. Folge unseren Empfehlungen um sicherzugehen, dass alles gut aussieht für die Besucher.',
-	'wikia-editor-preview-best-practices-button' => 'Empfehlungen',
-	'wikia-editor-preview-best-practices-button-link' => 'Hilfe:Optimaler_Wikitext',
 );
 
 /** Spanish */
@@ -47,9 +38,6 @@ $messages['es'] = array(
 	'wikia-editor-preview-type-tooltip' => "Changing this option will show you what this article will look like when it's displayed in a browser on small screens, large screens, mobile devies, or your current display.",
 	'wikia-editor-preview-desc' => 'Permite a los usuarios previsualizar sus ediciones antes de guardarlas',
 	'wikia-editor-preview-mobile-width' => 'Resolución de móvil',
-	'wikia-editor-preview-best-practices-notice' => '¿Sabías que más del 50% de los visitantes de Wikia leen el contenido desde un dispositivo móvil? Algunas plantillas personalizadas pueden no mostrarse correctamente en estos dispositivos. Para asegurarte de que todo se vea bien para los visitantes, sigue nuestras prácticas recomendadas.',
-	'wikia-editor-preview-best-practices-button' => 'Prácticas recomendadas',
-	'wikia-editor-preview-best-practices-button-link' => 'Ayuda:Mejores_pr%C3%A1cticas_en_Wikitext',
 );
 
 /** French */
@@ -60,9 +48,6 @@ $messages['fr'] = array(
 	'wikia-editor-preview-type-tooltip' => "Modifier cette option affichera l'article tel qu'il serait affiché sur un navigateur avec un écran petit, un écran large, un appareil mobile ou avec votre affichage actuel.",
 	'wikia-editor-preview-desc' => 'Enables users to preview their edits before saving them',
 	'wikia-editor-preview-mobile-width' => 'Mobile',
-	'wikia-editor-preview-best-practices-notice' => "Saviez-vous que plus de 50 % des visiteurs sur Wikia consultent vos articles sur un appareil mobile ? Certains modèles personnalisés risquent de ne pas s'afficher correctement sur de tels appareils.  Pour que l'ensemble de vos visiteurs bénéficient de la meilleure expérience possible, nous vous invitons à suivre ces quelques bonnes pratiques.",
-	'wikia-editor-preview-best-practices-button' => 'Bonnes pratiques',
-	'wikia-editor-preview-best-practices-button-link' => 'Aide:Bonnes_pratiques_wikitexte',
 );
 
 /** Italian */
@@ -73,9 +58,6 @@ $messages['it'] = array(
 	'wikia-editor-preview-type-tooltip' => "Cambiare questa opzione mostrerà come l'articolo viene visualizzato nel browser su schermi piccoli, grandi, dispositivi mobili o il tuo schermo corrente.",
 	'wikia-editor-preview-desc' => "Consente agli utenti di visualizzare l'anteprima delle modifiche prima di salvare",
 	'wikia-editor-preview-mobile-width' => 'Mobile',
-	'wikia-editor-preview-best-practices-notice' => 'Lo sapevi che oltre il 50% dei visitatori su Wikia leggono i tuoi contenuti su mobile? Alcuni template personalizzati potrebbero non essere visualizzati correttamente su dispositivi mobili. Per essere sicuri che tutto quanto funzioni al meglio, segui le nostre pratiche migliori.',
-	'wikia-editor-preview-best-practices-button' => 'Pratiche migliori',
-	'wikia-editor-preview-best-practices-button-link' => 'Aiuto:Pratiche_migliori_per_wikitext',
 );
 
 /** Japanese */
@@ -86,9 +68,6 @@ $messages['ja'] = array(
 	'wikia-editor-preview-type-tooltip' => 'このオプションを変更すると、小さな画面、大きな画面、モバイルデバイス、現在お使いの画面で、それぞれ記事がどのように見えるかを表示します。',
 	'wikia-editor-preview-desc' => '保存する前に編集をプレビューで見られるようにします',
 	'wikia-editor-preview-mobile-width' => 'モバイル',
-	'wikia-editor-preview-best-practices-notice' => 'ウィキア閲覧者の50%以上は、あなたが作ったコンテンツをモバイルデバイスから見ているということをご存知でしたか。独自のテンプレートを使うと、モバイルデバイスではうまく表示されないことがあります。誰が見ても見やすいコンテンツであるということを確実にするため、ベストプラクティスをご参照ください。',
-	'wikia-editor-preview-best-practices-button' => 'ベストプラクティス',
-	'wikia-editor-preview-best-practices-button-link' => 'ヘルプ:ウィキテキストのベストプラクティス',
 );
 
 $messages['nl'] = array(
@@ -98,9 +77,6 @@ $messages['nl'] = array(
 	'wikia-editor-preview-max-width' => 'Desktop XL',
 	'wikia-editor-preview-mobile-width' => 'Mobile',
 	'wikia-editor-preview-type-tooltip' => "Changing this option will show you what this article will look like when it's displayed in a browser on small screens, large screens, mobile devies, or your current display.",
-	'wikia-editor-preview-best-practices-notice' => 'Did you know that over 50% of Wikia visitors are reading your content on mobile? Some custom templates may not properly show on mobile devices. To make sure everything looks great to all visitors, follow our best practices.',
-	'wikia-editor-preview-best-practices-button' => 'Best practices',
-	'wikia-editor-preview-best-practices-button-link' => 'http://community.wikia.com/wiki/Help:Wikitext_best_practices',
 );
 
 /** Polish */
@@ -111,9 +87,6 @@ $messages['pl'] = array(
 	'wikia-editor-preview-max-width' => 'Monitor XL',
 	'wikia-editor-preview-type-tooltip' => "Zmiana tej opcji umożliwi Ci zobaczenie jak artykuł wyglądać będzie w skórce mobilnej lub w przeglądarce w małej, dużej lub obecnie wykorzystywanej przez Ciebie rozdzielczości.",
 	'wikia-editor-preview-mobile-width' => 'Skórka mobilna',
-	'wikia-editor-preview-best-practices-notice' => 'Czy wiesz, że ponad 50% czytelników odwiedza Wikię na urządzeniach mobilnych? Niektóre szablony mogą nie wyświetlać się poprawnie na urządzeniach mobilnych. Aby upewnić się, że wszystko prezentuje się jak najlepiej dla wszystkich czytelników, podążaj za naszymi najlepszymi praktykami.',
-	'wikia-editor-preview-best-practices-button' => 'Najlepsze praktyki',
-	'wikia-editor-preview-best-practices-button-link' => 'Pomoc:Najlepsze_praktyki_w_wikitek%C5%9Bcie',
 );
 
 $messages['pt'] = array(
@@ -123,9 +96,6 @@ $messages['pt'] = array(
 	'wikia-editor-preview-max-width' => 'Área de trabalho GG',
 	'wikia-editor-preview-mobile-width' => 'Dispositivo Móvel',
 	'wikia-editor-preview-type-tooltip' => "Changing this option will show you what this article will look like when it's displayed in a browser on small screens, large screens, mobile devies, or your current display.",
-	'wikia-editor-preview-best-practices-notice' => 'Você sabia que mais de 50% dos visitantes da Wikia estão lendo o seu conteúdo no celular? Algumas predefinições personalizadas não aparecem corretamente em dispositivos móveis. Para certificar-se de que tudo fica ótimo para todos os visitantes, siga as nossas melhores práticas.',
-	'wikia-editor-preview-best-practices-button' => 'Melhores práticas',
-	'wikia-editor-preview-best-practices-button-link' => 'Ajuda:Melhores_práticas_para_wikitext',
 );
 
 /** Russian */
@@ -136,9 +106,6 @@ $messages['ru'] = array(
 	'wikia-editor-preview-type-tooltip' => "Меняя значения в этом меню, вы можете проверить, как статья будет отображаться в браузере на маленьком и большом экранах, а также на вашем экране.",
 	'wikia-editor-preview-desc' => 'Enables users to preview their edits before saving them',
 	'wikia-editor-preview-mobile-width' => 'Мобильный',
-	'wikia-editor-preview-best-practices-notice' => 'Знаете ли вы, что более 50% пользователей читают статьи вики с планшета или мобильного телефона? А многие шаблоны не всегда корректно отображаются на мобильных устройствах. Лучшие примеры Викия помогут вам форматировать содержимое страниц так, чтобы они выглядели великолепно на любом устройстве.',
-	'wikia-editor-preview-best-practices-button' => 'Лучшие примеры',
-	'wikia-editor-preview-best-practices-button-link' => '%D0%A1%D0%BF%D1%80%D0%B0%D0%B2%D0%BA%D0%B0:%D0%92%D0%B8%D0%BA%D0%B8%D1%82%D0%B5%D0%BA%D1%81%D1%82/%D0%BB%D1%83%D1%87%D1%88%D0%B8%D0%B5_%D0%BF%D1%80%D0%B8%D0%BC%D0%B5%D1%80%D1%8B',
 );
 
 /** Chinese */
@@ -156,9 +123,6 @@ $messages['zh-hans'] = array(
 	'wikia-editor-preview-max-width' => '桌面XL',
 	'wikia-editor-preview-mobile-width' => '移动设备',
 	'wikia-editor-preview-type-tooltip' => "更改这个选项将为您展示这篇文章在不同电脑屏幕、手机以及平板电脑上的样式。",
-	'wikia-editor-preview-best-practices-notice' => '你知道吗？超过50%的Wikia访问用户都是通过手机或者平板电脑查阅内容的。某些模版在这些移动设备上或许不能正常显示。为了确保一切正常，请关注我们的最佳实践。',
-	'wikia-editor-preview-best-practices-button' => '最佳实践',
-	'wikia-editor-preview-best-practices-button-link' => 'Help:Wiki文本最佳實踐',
 );
 
 $messages['zh-tw'] = array(
@@ -168,8 +132,5 @@ $messages['zh-tw'] = array(
 	'wikia-editor-preview-max-width' => '桌面XL',
 	'wikia-editor-preview-mobile-width' => '行動裝置',
 	'wikia-editor-preview-type-tooltip' => "更改這個選項將為您展示這篇文章在不同電腦銀幕、手機以及平板電腦上的樣式。",
-	'wikia-editor-preview-best-practices-notice' => '你知道嗎？超過50%的Wikia訪問使用者都是通過手機或者平板電腦查閱內容的。某些模版在這些行動裝置上或許不能正常顯示。為了確保一切正常，請關注我們的最佳實踐。',
-	'wikia-editor-preview-best-practices-button' => '最佳實踐',
-	'wikia-editor-preview-best-practices-button-link' => 'Help:Wiki文本最佳實踐',
 );
 

--- a/extensions/wikia/EditPreview/EditPreview.setup.php
+++ b/extensions/wikia/EditPreview/EditPreview.setup.php
@@ -34,7 +34,3 @@ JSMessages::registerPackage('EditPreview', [
 	'wikia-editor-preview-mobile-width',
 	'wikia-editor-preview-type-tooltip'
 ]);
-
-JSMessages::registerPackage('EditPreviewInContLang', [
-	'wikia-editor-preview-best-practices-button-link'
-]);

--- a/extensions/wikia/EditPreview/js/preview.js
+++ b/extensions/wikia/EditPreview/js/preview.js
@@ -43,14 +43,8 @@ define('wikia.preview', [
 			callback: function () {
 				var $editPageDialog = $('#EditPageDialog'),
 					$contentNode = $editPageDialog.find('.ArticlePreviewInner'),
-					$previewMsgNode = $editPageDialog.find('.preview-modal-msg-wrapper'),
-					modalHeight = options.height,
+					modalHeight = options.height || $(window).height() - 250,
 					modalHeightModifier = 0;
-
-				if (!modalHeight) {
-					modalHeightModifier = -250 -($previewMsgNode.outerHeight() || 0);
-					modalHeight = $(window).height() + modalHeightModifier;
-				}
 
 				// block all clicks
 				$contentNode.on('click', function (ev) {
@@ -62,15 +56,6 @@ define('wikia.preview', [
 					'height': modalHeight,
 					'overflow': 'auto',
 					'overflow-x': 'hidden'
-				});
-
-				$previewMsgNode.on('click', 'a', function () {
-					tracker.track({
-						action: Wikia.Tracker.ACTIONS.CLICK,
-						category: 'edit-preview',
-						label: 'button-best-practices',
-						trackingMethod: 'analytics'
-					});
 				});
 
 				if (typeof callback === 'function') {
@@ -86,29 +71,7 @@ define('wikia.preview', [
 			window.stylepath +
 			'/common/images/ajax.gif" class="loading"></div></div>';
 
-		$.when(
-			loader({
-				type: loader.MULTI,
-				resources: {
-					mustache: 'extensions/wikia/EditPreview/templates/preview_best_practices.mustache'
-				}
-			}),
-			msg.getForContent('EditPreviewInContLang')
-		).done(function(response){
-			var params = {
-					bestPracticesMsg: $.htmlentities(msg('wikia-editor-preview-best-practices-notice')),
-					bestPracticesLinkText: $.htmlentities(msg('wikia-editor-preview-best-practices-button')),
-					bestPracticesLinkUrl:  window.wgArticlePath.replace(
-						'$1', $.htmlentities(msg('wikia-editor-preview-best-practices-button-link'))
-					)
-				},
-
-				template = response.mustache[0],
-				html = mustache.render(template, params);
-
-			content = html+content;
-			$.showCustomModal(title, content, options);
-		});
+		$.showCustomModal(title, content, options);
 	}
 
 	/**
@@ -177,7 +140,7 @@ define('wikia.preview', [
 				}
 
 				if (currentTypeName) {
-					var articleWidth = breakpointsLayout.getArticleWidth(currentTypeName ,isWidePage);
+					var articleWidth = breakpointsLayout.getArticleWidth(currentTypeName, isWidePage);
 					$article.width(articleWidth);
 				}
 			}

--- a/extensions/wikia/EditPreview/templates/preview_best_practices.mustache
+++ b/extensions/wikia/EditPreview/templates/preview_best_practices.mustache
@@ -1,6 +1,0 @@
-<div class="preview-modal-msg-wrapper">
-<div class="preview-modal-msg">
-<p class="preview-message">{{bestPracticesMsg}}</p>
-<div class="preview-link"><a href="{{bestPracticesLinkUrl}}" target="_blank" class="wikia-button">{{bestPracticesLinkText}}</a></div>
-</div>
-</div>


### PR DESCRIPTION
Remove the "Best Practices" message in classic editor preview.

/cc @Wikia/community-engineering 
