### PR TITLE
PLATFORM-1192 report tasks processing delay

### DIFF
--- a/extensions/wikia/Tasks/proxy/proxy.php
+++ b/extensions/wikia/Tasks/proxy/proxy.php
@@ -23,8 +23,9 @@ $wikiId = escapeshellarg( $_POST['wiki_id'] );
 $list = escapeshellarg( $_POST['task_list'] );
 $order = escapeshellarg( $_POST['call_order'] );
 $createdBy = escapeshellarg( $_POST['created_by'] );
+$createdAt = escapeshellarg( $_POST['created_at'] );
 
-$command = "php {$script} --wiki_id={$wikiId} --task_id={$taskId} --task_list={$list} --call_order={$order} --created_by={$createdBy}";
+$command = "php {$script} --wiki_id={$wikiId} --task_id={$taskId} --task_list={$list} --call_order={$order} --created_by={$createdBy} --created_at={$createdAt}";
 
 // can't use globals here, this doesn't execute within mediawiki
 if ( getenv( 'WIKIA_ENVIRONMENT' ) == 'dev' ) {
@@ -32,8 +33,9 @@ if ( getenv( 'WIKIA_ENVIRONMENT' ) == 'dev' ) {
 	require_once( __DIR__ . '/../../../../lib/composer/autoload.php' );
 
 	\Wikia\Logger\WikiaLogger::instance()->setDevModeWithES();
-	\Wikia\Logger\WikiaLogger::instance()->debug( $command, [
-		'task_id' => $taskId
+	\Wikia\Logger\WikiaLogger::instance()->debug( 'Tasks - proxy.php', [
+		'cmd' => $command,
+		'data' => $_POST,
 	] );
 }
 

--- a/includes/wikia/tasks/AsyncTaskList.class.php
+++ b/includes/wikia/tasks/AsyncTaskList.class.php
@@ -226,6 +226,7 @@ class AsyncTaskList {
 			'call_order' => $this->calls,
 			'task_list' => $taskList,
 			'created_by' => $this->createdBy,
+			'created_at' => microtime( true ),
 		]];
 	}
 

--- a/includes/wikia/tasks/TaskRunner.class.php
+++ b/includes/wikia/tasks/TaskRunner.class.php
@@ -48,7 +48,7 @@ class TaskRunner {
 	}
 
 	function run() {
-		$this->startTime = $this->endTime = time();
+		$this->startTime = $this->endTime = microtime( true );
 		if ( $this->exception ) {
 			$this->results [] = $this->exception;
 			return;
@@ -89,9 +89,12 @@ class TaskRunner {
 			}
 		}
 
-		$this->endTime = time();
+		$this->endTime = microtime( true );
 	}
 
+	/**
+	 * @return float
+	 */
 	public function runTime() {
 		return $this->endTime - $this->startTime;
 	}

--- a/includes/wikia/tasks/Tasks/BaseTask.class.php
+++ b/includes/wikia/tasks/Tasks/BaseTask.class.php
@@ -96,13 +96,17 @@ abstract class BaseTask {
 			throw new \InvalidArgumentException;
 		}
 
-		$this->info( 'BaseTask::execute' );
+		$then = microtime( true );
 
 		try {
 			$result = call_user_func_array( [$this, $method], $args );
 		} catch ( \Exception $e ) {
 			$result = $e;
 		}
+
+		$this->info( 'BaseTask::execute', [
+			'took' => microtime( true ) - $then, // [sec]
+		] );
 
 		return $result;
 	}

--- a/maintenance/wikia/task_runner.php
+++ b/maintenance/wikia/task_runner.php
@@ -11,6 +11,7 @@ class TaskRunnerMaintenance extends Maintenance {
 		$this->addOption('task_id', '', true, true);
 		$this->addOption('call_order', '', true, true);
 		$this->addOption('task_list', '', true, true);
+		$this->addOption('created_at', '', true, true);
 		$this->addOption('created_by', '', true, true);
 		$this->addOption('wiki_id', '', false, true);
 	}
@@ -64,6 +65,12 @@ class TaskRunnerMaintenance extends Maintenance {
 				] ),
 			] );
 		}
+
+		Wikia\Logger\WikiaLogger::instance()->info( __METHOD__, [
+			'took' => $runner->runTime(),
+			'delay' => microtime( true ) - (float) $this->mOptions['created_at'],
+			'state' => $result->status,
+		] );
 
 		ob_end_clean();
 		echo json_encode( $result );


### PR DESCRIPTION
Report the following:

`BaseTask::execute` - per task execution time (will help us identify long running task types)

``` json
{
      "took": 0.0042750835418701,
      "task_id": "mw-9D2B826A-8E1A-48A9-887D-C0A79E9721D0",
      "task_call": "Wikia\\Tasks\\Tasks\\HTMLCacheUpdateTask::purge"
}
```

`TaskRunnerMaintenance::execute` - per task-batch execution delay (seconds it took to execute the tasks batch after it was pushed to the queue):

``` json
{
      "took": 0.004500150680542,
      "delay": 0.59833192825317,
      "state": "success",
      "task_id": "mw-9D2B826A-8E1A-48A9-887D-C0A79E9721D0"
}
```

@pchojnacki / @wladekb / @michalroszka 
