### PR TITLE
SEO-213 Fix cropping of the images in the Special:NewFiles

### DIFF
--- a/extensions/wikia/WikiaNewFiles/WikiaNewFilesGallery.class.php
+++ b/extensions/wikia/WikiaNewFiles/WikiaNewFilesGallery.class.php
@@ -3,12 +3,9 @@
 class WikiaNewFilesGallery extends WikiaPhotoGallery {
 	const ANCHOR_LENGTH = 60;
 
-	/**
-	 * Generate WikiaPhotoGallery object from the images array
-	 *
-	 * @param Skin $skin
-	 */
 	public function __construct( Skin $skin ) {
+		parent::__construct();
+
 		$this->parseParams( array(
 			"rowdivider" => true,
 			"hideoverflow" => true
@@ -58,7 +55,7 @@ class WikiaNewFilesGallery extends WikiaPhotoGallery {
 			}
 
 			if ( $moreFiles ) {
-				$caption .= ", " . '<a href="' . $nt->getLocalUrl() .
+				$caption .= ", " . '<a href="' . htmlspecialchars( $nt->getLocalUrl() ) .
 					'#filelinks" class="wikia-gallery-item-more">' .
 					wfMessage( 'wikianewfiles-more' )->escaped() . '</a>';
 			}


### PR DESCRIPTION
The constructor for WikiaPhotoGallery was not called and apparently it
sets some important defaults!

Also HTML-escaping href attributes for the links below the images.
