### PR TITLE
VE-2117: Track Parsoid HIT ratio

### DIFF
--- a/extensions/VisualEditor/ApiVisualEditor.php
+++ b/extensions/VisualEditor/ApiVisualEditor.php
@@ -76,11 +76,22 @@ class ApiVisualEditor extends ApiBase {
 			// served directly from Varnish, in  which case discard the value of the XPP header
 			// and use it to declare the cache hit instead.
 			$xCache = $req->getResponseHeader( 'X-Cache' );
+			$hit = false;
 			if ( is_string( $xCache ) && strpos( $xCache, 'HIT' ) !== false ) {
 				$xpp = 'cached-response=true';
+				$hit = true;
 			} else {
 				$xpp = $req->getResponseHeader( 'X-Parsoid-Performance' );
 			}
+
+			// we cache only GET requests so hit ratio tracking makes sense only in such case
+			if ( $method === 'GET' ) {
+				\Wikia\Logger\WikiaLogger::instance()->info( 'ApiVisualEditor_requestParsoid', [
+					// sending string instead of boolean because our elasticsearch/kibana does not support the latter well
+					'hit' => $hit ? 'yes' : 'no'
+				] );
+			}
+
 			if ( $xpp !== null ) {
 				$resp = $this->getRequest()->response();
 				$resp->header( 'X-Parsoid-Performance: ' . $xpp );

--- a/extensions/VisualEditor/ApiVisualEditor.php
+++ b/extensions/VisualEditor/ApiVisualEditor.php
@@ -76,7 +76,7 @@ class ApiVisualEditor extends ApiBase {
 			// served directly from Varnish, in  which case discard the value of the XPP header
 			// and use it to declare the cache hit instead.
 			$xCache = $req->getResponseHeader( 'X-Cache' );
-			if ( is_string( $xCache ) && strpos( $xCache, 'hit' ) !== false ) {
+			if ( is_string( $xCache ) && strpos( $xCache, 'HIT' ) !== false ) {
 				$xpp = 'cached-response=true';
 			} else {
 				$xpp = $req->getResponseHeader( 'X-Parsoid-Performance' );


### PR DESCRIPTION
We are tracking it at a VisualEditor API level because this is the ratio that we are interested in - and VisualEditor is not the only client of Parsoid.
