### PR TITLE
SOC-565: Solve problem by adding missing reference

### DIFF
--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -1199,6 +1199,7 @@ $config['chat_js2'] = array(
 	'assets' => array(
 		'#group_oasis_jquery',
 		'#group_oasis_shared_core_js',
+		'//skins/shared/scripts/onScroll.js',
 
 		// shared libraries
 		'//extensions/wikia/AssetsManager/js/AssetsManager.js',


### PR DESCRIPTION
BannerNotifications.js depends on onScroll which wasn't present in AssetsManager group for Chat special page. Perhaps BannerNotifications.js does not make much sense on that special page - but given that page is still considered "oasis" skin then this is the way to go.
