### PR TITLE
ADEN-2815 Evolve2 section param

### DIFF
--- a/extensions/wikia/AdEngine/js/AdLogicPageParams.js
+++ b/extensions/wikia/AdEngine/js/AdLogicPageParams.js
@@ -169,7 +169,7 @@ define('ext.wikia.adEngine.adLogicPageParams', [
 			s0: zoneParams.getSite(),
 			s0v: zoneParams.getVertical(),
 			s0c: zoneParams.getWikiCategories(),
-			s1: zoneParams.getMappedVertical(),
+			s1: zoneParams.getName(),
 			s2: zoneParams.getPageType(),
 			ab: getAb(),
 			ar: getAspectRatio(),

--- a/extensions/wikia/AdEngine/js/lookup/openXBidder.js
+++ b/extensions/wikia/AdEngine/js/lookup/openXBidder.js
@@ -60,7 +60,7 @@ define('ext.wikia.adEngine.lookup.openXBidder', [
 			slotPath = [
 				'/5441',
 				'wka.' + adLogicZoneParams.getSite(),
-				adLogicZoneParams.getMappedVertical(),
+				adLogicZoneParams.getName(),
 				'',
 				adLogicZoneParams.getPageType()
 			].join('/');

--- a/extensions/wikia/AdEngine/js/lookup/rubiconFastlane.js
+++ b/extensions/wikia/AdEngine/js/lookup/rubiconFastlane.js
@@ -70,7 +70,7 @@ define('ext.wikia.adEngine.lookup.rubiconFastlane', [
 	}
 
 	function setTargeting(slotName, targeting, rubiconSlot, provider) {
-		var s1 = context.targeting.wikiIsTop1000 ? adLogicZoneParams.getMappedVertical() : 'not a top1k wiki';
+		var s1 = context.targeting.wikiIsTop1000 ? adLogicZoneParams.getName() : 'not a top1k wiki';
 		if (targeting) {
 			Object.keys(targeting).forEach(function (key) {
 				rubiconSlot.setFPI(key, targeting[key]);

--- a/extensions/wikia/AdEngine/js/provider/evolve2.js
+++ b/extensions/wikia/AdEngine/js/provider/evolve2.js
@@ -1,10 +1,10 @@
 /*global define*/
 define('ext.wikia.adEngine.provider.evolve2', [
-	'ext.wikia.adEngine.evolveHelper',
 	'ext.wikia.adEngine.provider.gpt.helper',
 	'ext.wikia.adEngine.slotTweaker',
+	'ext.wikia.adEngine.utils.adLogicZoneParams',
 	'wikia.log'
-], function (evolveHelper, gptHelper, slotTweaker, log) {
+], function (gptHelper, slotTweaker, zoneParams, log) {
 	'use strict';
 
 	var logGroup = 'ext.wikia.adEngine.provider.evolve2',
@@ -17,7 +17,6 @@ define('ext.wikia.adEngine.provider.evolve2', [
 			'320x50,320x100,300x250': 'a',
 			'300x250': 'a'
 		},
-		section = evolveHelper.getSect(),
 		site = 'wikia_intl',
 		slotMap = {
 			HOME_TOP_LEADERBOARD:     {size: '728x90,970x250,970x300,970x90'},
@@ -33,6 +32,26 @@ define('ext.wikia.adEngine.provider.evolve2', [
 			MOBILE_PREFOOTER:         {size: '300x250'}
 		};
 
+	function getSection() {
+		var vertical = zoneParams.getVertical(),
+			mappedVertical = zoneParams.getSite();
+
+		switch (vertical) {
+			case 'movies':
+			case 'tv':
+				return vertical;
+		}
+
+		switch (mappedVertical) {
+			case 'gaming':
+				return 'gaming';
+			case 'ent':
+				return 'entertainment';
+		}
+
+		return 'ros';
+	}
+
 	function nextChar(char) {
 		return String.fromCharCode(char.charCodeAt(0) + 1);
 	}
@@ -41,7 +60,6 @@ define('ext.wikia.adEngine.provider.evolve2', [
 		var position = posTargetingValue[slot.size];
 
 		slot.pos = position;
-		slot.sect = section;
 		slot.site = site;
 
 		// Increment pos value
@@ -58,8 +76,10 @@ define('ext.wikia.adEngine.provider.evolve2', [
 
 	function fillInSlot(slotName, slotElement, success, hop) {
 		log(['fillInSlot', slotName, slotElement, success, hop], 'debug', logGroup);
-		var slotCopy = JSON.parse(JSON.stringify(slotMap[slotName]));
+		var section = getSection(),
+			slotCopy = JSON.parse(JSON.stringify(slotMap[slotName]));
 
+		slotCopy.sect = section;
 		setTargeting(slotCopy);
 		gptHelper.pushAd(
 			slotName,

--- a/extensions/wikia/AdEngine/js/spec/AdLogicPageParams.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/AdLogicPageParams.spec.js
@@ -53,8 +53,8 @@ describe('AdLogicPageParams', function () {
 			getSite: function () {
 				return 'zone_site';
 			},
-			getMappedVertical: function () {
-				return 'zone_mapped_vertical';
+			getName: function () {
+				return 'zone_name';
 			},
 			getPageType: function () {
 				return 'zone_page_type';
@@ -125,7 +125,7 @@ describe('AdLogicPageParams', function () {
 		expect(params.s0).toBe('zone_site');
 		expect(params.s0v).toBe('zone_vertical');
 		expect(params.s0c).toEqual(['zone_wiki_category']);
-		expect(params.s1).toBe('zone_mapped_vertical');
+		expect(params.s1).toBe('zone_name');
 		expect(params.s2).toBe('zone_page_type');
 		expect(params.cat).toEqual(['zone_page_category']);
 		expect(params.dmn).toBe('zone_domain');

--- a/extensions/wikia/AdEngine/js/spec/lookup/rubiconFastlane.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/lookup/rubiconFastlane.spec.js
@@ -30,7 +30,7 @@ describe('ext.wikia.adEngine.lookup.rubiconFastlane', function () {
 				getSite: function () {
 					return 'life';
 				},
-				getMappedVertical: function () {
+				getName: function () {
 					return '_dragonball';
 				},
 				getPageType: function () {

--- a/extensions/wikia/AdEngine/js/spec/provider/evolve2.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/provider/evolve2.spec.js
@@ -1,33 +1,41 @@
 /*global beforeEach, describe, it, modules, expect, spyOn*/
-describe('OpenX Provider targeting', function () {
+describe('Evolve2 Provider targeting', function () {
 	'use strict';
 
 	var evolve2,
 		noop = function () {},
 		mocks = {
-			evolveHelper: {
-				getSect: function () {
-					return 'foo_section';
-				}
-			},
 			gptHelper: {
 				pushAd: noop
 			},
 			log: noop,
-			slotTweaker: {}
+			slotTweaker: {},
+			vertical: 'foo_vertical',
+			mappedVertical: 'bar_vertical',
+			zoneParams: {
+				getSite: function () {
+					return mocks.mappedVertical;
+				},
+				getVertical: function () {
+					return mocks.vertical;
+				}
+			}
 		};
 
 	function getEvolve2Provider() {
 		return modules['ext.wikia.adEngine.provider.evolve2'](
-			mocks.evolveHelper,
 			mocks.gptHelper,
 			mocks.slotTweaker,
+			mocks.zoneParams,
 			mocks.log
 		);
 	}
 
 	beforeEach(function () {
 		evolve2 = getEvolve2Provider();
+
+		mocks.vertical = 'foo_vertical';
+		mocks.mappedVertical = 'bar_vertical';
 		spyOn(mocks.gptHelper, 'pushAd');
 	});
 
@@ -40,7 +48,7 @@ describe('OpenX Provider targeting', function () {
 	});
 
 	it('Should push ad to helper with proper ad unit id', function () {
-		var expectedAdUnit = '/4403/ev/wikia_intl/foo_section/TOP_LEADERBOARD';
+		var expectedAdUnit = '/4403/ev/wikia_intl/ros/TOP_LEADERBOARD';
 
 		evolve2.fillInSlot('TOP_LEADERBOARD');
 
@@ -51,13 +59,49 @@ describe('OpenX Provider targeting', function () {
 		var expectedTargeting = {
 				size: '728x90,970x250,970x300,970x90',
 				pos: 'a',
-				sect: 'foo_section',
+				sect: 'ros',
 				site: 'wikia_intl'
 			};
 
 		evolve2.fillInSlot('TOP_LEADERBOARD');
 
 		expect(mocks.gptHelper.pushAd.calls.mostRecent().args[3]).toEqual(expectedTargeting);
+	});
+
+	it('Should push ad to helper with proper vertical', function () {
+		var expectedSection = 'tv';
+
+		mocks.vertical = 'tv';
+		evolve2.fillInSlot('LEFT_SKYSCRAPER_2');
+
+		expect(mocks.gptHelper.pushAd.calls.mostRecent().args[3].sect).toEqual(expectedSection);
+	});
+
+	it('Should push ad to helper with proper vertical', function () {
+		var expectedSection = 'movies';
+
+		mocks.vertical = 'movies';
+		evolve2.fillInSlot('LEFT_SKYSCRAPER_2');
+
+		expect(mocks.gptHelper.pushAd.calls.mostRecent().args[3].sect).toEqual(expectedSection);
+	});
+
+	it('Should push ad to helper with proper mapped vertical', function () {
+		var expectedSection = 'gaming';
+
+		mocks.mappedVertical = 'gaming';
+		evolve2.fillInSlot('LEFT_SKYSCRAPER_2');
+
+		expect(mocks.gptHelper.pushAd.calls.mostRecent().args[3].sect).toEqual(expectedSection);
+	});
+
+	it('Should push ad to helper with proper mapped vertical', function () {
+		var expectedSection = 'entertainment';
+
+		mocks.mappedVertical = 'ent';
+		evolve2.fillInSlot('LEFT_SKYSCRAPER_2');
+
+		expect(mocks.gptHelper.pushAd.calls.mostRecent().args[3].sect).toEqual(expectedSection);
 	});
 
 	it('Should increment pos tageting value for the same size slots', function () {

--- a/extensions/wikia/AdEngine/js/spec/utils/AdLogicZoneParams.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/utils/AdLogicZoneParams.spec.js
@@ -115,14 +115,14 @@ describe('ext.wikia.adEngine.utils.adLogicZoneParams', function () {
 		var zoneParams = getModule();
 
 		expect(zoneParams.getSite()).toBe('mappedVertical');
-		expect(zoneParams.getMappedVertical()).toBe('_dbname');
+		expect(zoneParams.getName()).toBe('_dbname');
 		expect(zoneParams.getPageType()).toBe('article');
 	});
 
-	it('MappedVertical default DB name', function () {
+	it('Name default DB name', function () {
 		var zoneParams = getModule();
 
-		expect(zoneParams.getMappedVertical()).toBe('_wikia', 's1=_wikia');
+		expect(zoneParams.getName()).toBe('_wikia', 's1=_wikia');
 	});
 
 	it('getPageType', function () {
@@ -217,7 +217,7 @@ describe('ext.wikia.adEngine.utils.adLogicZoneParams', function () {
 		var zoneParams = getModule();
 
 		expect(zoneParams.getSite()).toBe('hub');
-		expect(zoneParams.getMappedVertical()).toBe('_gaming_hub');
+		expect(zoneParams.getName()).toBe('_gaming_hub');
 		expect(zoneParams.getPageType()).toBe('hub');
 		expect(zoneParams.getDomain()).toBe('wikiacom');
 		expect(zoneParams.getHostnamePrefix()).toBe('www');
@@ -236,7 +236,7 @@ describe('ext.wikia.adEngine.utils.adLogicZoneParams', function () {
 		var zoneParams = getModule();
 
 		expect(zoneParams.getSite()).toBe('hub');
-		expect(zoneParams.getMappedVertical()).toBe('_ent_hub');
+		expect(zoneParams.getName()).toBe('_ent_hub');
 		expect(zoneParams.getPageType()).toBe('hub');
 		expect(zoneParams.getDomain()).toBe('wikiacom');
 		expect(zoneParams.getHostnamePrefix()).toBe('www');
@@ -255,7 +255,7 @@ describe('ext.wikia.adEngine.utils.adLogicZoneParams', function () {
 		var zoneParams = getModule();
 
 		expect(zoneParams.getSite()).toBe('hub');
-		expect(zoneParams.getMappedVertical()).toBe('_life_hub');
+		expect(zoneParams.getName()).toBe('_life_hub');
 		expect(zoneParams.getPageType()).toBe('hub');
 		expect(zoneParams.getDomain()).toBe('wikiacom');
 		expect(zoneParams.getHostnamePrefix()).toBe('www');

--- a/extensions/wikia/AdEngine/js/utils/AdLogicZoneParams.js
+++ b/extensions/wikia/AdEngine/js/utils/AdLogicZoneParams.js
@@ -83,7 +83,7 @@ define('ext.wikia.adEngine.utils.adLogicZoneParams', [
 		return site;
 	}
 
-	function getMappedVertical() {
+	function getName() {
 		if (!calculated) {
 			calculateParams();
 		}
@@ -128,7 +128,7 @@ define('ext.wikia.adEngine.utils.adLogicZoneParams', [
 		getDomain: getDomain,
 		getHostnamePrefix: getHostnamePrefix,
 		getSite: getSite,
-		getMappedVertical: getMappedVertical,
+		getName: getName,
 		getPageType: getPageType,
 		getVertical: getVertical,
 		getPageCategories: getPageCategories,


### PR DESCRIPTION
Please do CR for single commits:
- fixed calculation of section param for Evolve2 provider (now it's based on `s0` and `s0v` params)
- changed `getMappedVertical` method name to `getName` because it's more connected to dbname
