### PR TITLE
(CE-3223) Fix fatal error in InsightsV2

### DIFF
--- a/extensions/wikia/Flags/controllers/FlagsApiController.class.php
+++ b/extensions/wikia/Flags/controllers/FlagsApiController.class.php
@@ -566,14 +566,13 @@ class FlagsApiController extends FlagsApiBaseController {
 		if ( !empty( $wgEnableInsightsExt ) ) {
 			$flagsIds = $this->prepareFlagTypesIds( $flags );
 
-			$insightsFlagsModel = new InsightsFlagsModel();
-
 			foreach ( $flagsIds as $flagId ) {
-				$insightsFlagsModel->initModel( [ 'flagTypeId' => $flagId ] );
+				$insightsFlagsModel = new InsightsFlagsModel( $flagId );
+				$insightsCache = new InsightsCache( $insightsFlagsModel->getConfig() );
 				if ( !is_null( $pageId ) ) {
-					$insightsFlagsModel->updateInsightsCache( $pageId );
+					$insightsCache->updateInsightsCache( $pageId );
 				} else {
-					$insightsFlagsModel->purgeInsightsCache();
+					$insightsCache->purgeInsightsCache();
 				}
 			}
 		}

--- a/extensions/wikia/InsightsV2/InsightsHooks.class.php
+++ b/extensions/wikia/InsightsV2/InsightsHooks.class.php
@@ -144,9 +144,9 @@ class InsightsHooks {
 		if ( !RecognizedTemplatesProvider::isUnrecognized( $templateType ) ) {
 			$model = new InsightsTemplatesWithoutTypeModel();
 			$model->removeFixedItem( TemplatesWithoutTypePage::TEMPLATES_WITHOUT_TYPE_TYPE, $title );
-			$model->updateInsightsCache( $pageId );
+			( new InsightsCache( $model->getConfig() ) )->updateInsightsCache( $pageId );
 		}
 		return true;
 	}
 
-} 
+}

--- a/extensions/wikia/InsightsV2/InsightsLoopController.class.php
+++ b/extensions/wikia/InsightsV2/InsightsLoopController.class.php
@@ -28,7 +28,7 @@ class InsightsLoopController extends WikiaController {
 					if ( !$isEdit ) {
 						$isFixed = $model->isItemFixed( $title );
 						if ( $isFixed ) {
-							$model->updateInsightsCache( $title->getArticleId() );
+							( new InsightsCache( $model->getConfig() ) )->updateInsightsCache( $title->getArticleId() );
 						}
 					}
 

--- a/extensions/wikia/TemplateDraft/ApprovedraftAction.php
+++ b/extensions/wikia/TemplateDraft/ApprovedraftAction.php
@@ -123,7 +123,7 @@ class ApprovedraftAction extends FormlessAction {
 		// Update Infoboxes Insights list if enabled
 		if ( $wgEnableInsightsInfoboxes ) {
 			$model = new InsightsUnconvertedInfoboxesModel();
-			$model->updateInsightsCache( $parentTitle->getArticleID() );
+			( new InsightsCache( $model->getConfig() ) )->updateInsightsCache( $parentTitle->getArticleID() );
 		}
 
 		// Show a confirmation message to a user after redirect


### PR DESCRIPTION
Fix fatal error in InsightsV2 due to outdated calls to cache methods
on the model rather than the cache class.

Fixes the following fatal error:

```
PHP Fatal Error: Call to undefined method
InsightsTemplatesWithoutTypeModel::updateInsightsCache()
in /extensions/wikia/InsightsV2/InsightsHooks.class.php on line 147
```

/cc @Wikia/community-engineering 
