### PR TITLE
(CE-3225) Redirect Special:Top and Special:WikiStats to Insights

### DIFF
--- a/extensions/wikia/InsightsV2/Insights.alias.php
+++ b/extensions/wikia/InsightsV2/Insights.alias.php
@@ -9,7 +9,7 @@ $specialPageAliases = [];
  * English (en)
  */
 $specialPageAliases['en'] = [
-	'Insights' => [ 'Insights' ],
+	'Insights' => [ 'Insights', 'Top', 'WikiStats' ],
 ];
 
 /**


### PR DESCRIPTION
This was previously done for the original Insights extension but the
changes didn't make it into InsightsV2.

/cc @Wikia/community-engineering
