### PR TITLE
ADEN-1558 Change the way how arrays are rendered in WikiFactory

### DIFF
--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -3344,14 +3344,16 @@ class WikiFactory {
 		global $$name;
 		global $preWFValues;
 
+		$value = "";
+
 		if( isset( $preWFValues[$name] ) ) {
 			// was modified, spit out saved default
-			return self::parseValue( $preWFValues[$name], $type );
+			$value = self::parseValue( $preWFValues[$name], $type );
 		} elseif( isset( $$name ) ) {
 			// was not modified, spit out actual value
-			return self::parseValue( $$name, $type );
+			$value = self::parseValue( $$name, $type );
 		}
-		return "";
+		return htmlspecialchars( $value );
 	}
 
 	/**
@@ -3368,8 +3370,8 @@ class WikiFactory {
 		if ( !isset( $variable->cv_value ) ) {
 			return "";
 		}
-
-		return self::parseValue( unserialize( $variable->cv_value ), $variable->cv_variable_type );
+		$value = self::parseValue( unserialize( $variable->cv_value ), $variable->cv_variable_type );
+		return htmlspecialchars( $value );
 	}
 
 	/**

--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -3329,4 +3329,73 @@ class WikiFactory {
 		$wgMemc->prefetch($keys);
 	}
 
+	/**
+	 * Renders community's value of given variable
+	 *
+	 * @access public
+	 * @static
+	 *
+	 * @param string $name name of wg variable
+	 * @param string $type type of variable ($variable->cv_variable_type)
+	 *
+	 * @return string
+	 */
+	static public function renderValueOnCommunity( $name, $type ) {
+		global $$name;
+		global $preWFValues;
+
+		if( isset( $preWFValues[$name] ) ) {
+			// was modified, spit out saved default
+			return self::parseValue( $preWFValues[$name], $type );
+		} elseif( isset( $$name ) ) {
+			// was not modified, spit out actual value
+			return self::parseValue( $$name, $type );
+		}
+		return "";
+	}
+
+	/**
+	 * Renders wg variable
+	 *
+	 * @access public
+	 * @static
+	 *
+	 * @param object $variable parameter passed to variable.tmpl.php
+	 *
+	 * @return string
+	 */
+	static public function renderValue( $variable ) {
+		if ( !isset( $variable->cv_value ) ) {
+			return "";
+		}
+
+		return self::parseValue( unserialize( $variable->cv_value ), $variable->cv_variable_type );
+	}
+
+	/**
+	 * Returns printable value based on type
+	 *
+	 * @access private
+	 * @static
+	 *
+	 * @param mixed  $value
+	 * @param string $type
+	 *
+	 * @return string
+	 */
+	static private function parseValue( $value, $type ) {
+		if ( $type == "string" || $type == "integer"  ) {
+			return $value;
+		}
+
+		if ( $type == "array" ) {
+			$json = json_encode ( $value );
+			if ( !preg_match_all( "/\".*\":/U", $json ) ) {
+				return $json;
+			}
+		}
+
+		return var_export( $value, true );
+	}
+
 };

--- a/extensions/wikia/WikiFactory/templates/variable.tmpl.php
+++ b/extensions/wikia/WikiFactory/templates/variable.tmpl.php
@@ -82,7 +82,7 @@ New value:
 <?php if( $variable->cv_variable_type === "boolean" ): ?>
 
 	<select name="varValue" id="varValue">
-	<?php   if( unserialize( $variable->cv_value === true ) ): ?>
+	<?php   if( unserialize( $variable->cv_value ) === true ): ?>
 		<option value="1" selected="selected">true</option>
 		<option value="0">false</option>
 	<?php   else: ?>

--- a/extensions/wikia/WikiFactory/templates/variable.tmpl.php
+++ b/extensions/wikia/WikiFactory/templates/variable.tmpl.php
@@ -53,26 +53,20 @@ Current value:
 <?php if( !isset( $variable->cv_value ) || is_null( $variable->cv_value ) ): ?>
     <strong>Value is not set</strong>
 <?php else: ?>
-    <pre><?php echo var_export( unserialize( $variable->cv_value ) ) ?></pre>
+    <pre><?php echo WikiFactory::renderValue( $variable ) ?></pre>
 <?php endif ?>
 </div>
 
 <div style="width: 45%; float: right">
 Value on community (possibly default value):
 <?php
-$name = $variable->cv_name;
-global $$name;
-global $preWFValues;
-if( isset( $preWFValues[$name] ) ) {
-	// was modified, spit out saved default
-	echo "<pre>" . var_export( $preWFValues[$name], true ) . "</pre>";
-} elseif( isset( $$name ) ) {
-	// was not modified, spit out actual value
-	echo "<pre>" . var_export( $$name, true ) . "</pre>";
-} else {
-	// no value set
-	echo "<strong>No value set.</strong>";
-} ?>
+	$value = WikiFactory::renderValueOnCommunity( $variable->cv_name, $variable->cv_variable_type );
+	if ( $value !== "" ) {
+		echo "<pre>{$value}</pre>";
+	} else {
+		echo "<strong>Value is not set</strong>";
+	}
+?>
 </div>
 
 <div style="margin-top: 2em; clear: both;">
@@ -99,19 +93,15 @@ New value:
 
 <?php elseif( $variable->cv_variable_type == "integer"): ?>
 
-	<input type="text" name="varValue" id="varValue" value="<?php echo unserialize( $variable->cv_value ) ?>" size="40" maxlength="255" />
+	<input type="text" name="varValue" id="varValue" value="<?php echo WikiFactory::renderValue( $variable ) ?>" size="40" maxlength="255" />
 
 <?php elseif( $variable->cv_variable_type == "string"): ?>
 
-	<input type="text" name="varValue" id="varValue" value="<?php echo unserialize( $variable->cv_value ) ?>" size="100" class="input-string" /><br />
-
-<?php elseif ($variable->cv_variable_type == "array" && !empty($wgDevelEnvironment)): ?>
-
-	<textarea name="varValue" id="varValue"><?php if( isset( $variable->cv_value ) ) echo var_export( unserialize( $variable->cv_value ), 1) ?></textarea><br />
+	<input type="text" name="varValue" id="varValue" value="<?php echo WikiFactory::renderValue( $variable ) ?>" size="100" class="input-string" /><br />
 
 <?php else: ?>
 
-	 <textarea name="varValue" id="varValue"><?php if( isset( $variable->cv_value ) ) echo var_export( unserialize( $variable->cv_value ), 1) ?></textarea><br />
+	<textarea name="varValue" id="varValue"><?php echo WikiFactory::renderValue( $variable ) ?></textarea><br />
 
 <?php endif ?>
 	<div class="clearfix">
@@ -169,15 +159,15 @@ New value:
 
 <?php elseif( $rel_var->cv_variable_type == "integer"): ?>
 
-	<input type="text" name="varValue" id="varValue" value="<?php echo unserialize( $rel_var->cv_value ) ?>" size="40" maxlength="255" />
+	<input type="text" name="varValue" id="varValue" value="<?php echo WikiFactory::renderValue( $rel_var ) ?>" size="40" maxlength="255" />
 
 <?php elseif( $rel_var->cv_variable_type == "string"): ?>
 
-	<input type="text" name="varValue" id="varValue" value="<?php echo unserialize( $rel_var->cv_value ) ?>" size="160" class="input-string" />
+	<input type="text" name="varValue" id="varValue" value="<?php echo WikiFactory::renderValue( $rel_var ) ?>" size="160" class="input-string" />
 
 <?php else: ?>
 
-	 <textarea name="varValue" id="varValue"><?php if( isset( $rel_var->cv_value ) ) echo var_export( unserialize( $rel_var->cv_value ), 1) ?></textarea><br />
+	 <textarea name="varValue" id="varValue"><?php echo WikiFactory::renderValue( $rel_var ) ?></textarea><br />
 
 <?php endif ?>
 	<input type="button" id="wk-submit" name="submit" value="<?= wfMsg('wikifactory-button-saveparse'); ?>" onclick="$Factory.Variable.submit($(this).parent().attr('id'));" />

--- a/extensions/wikia/WikiFactory/tests/WikiFactoryTest.php
+++ b/extensions/wikia/WikiFactory/tests/WikiFactoryTest.php
@@ -196,4 +196,18 @@ EOT;
 
 		$this->assertEquals( $expectedRender, WikiFactory::renderValue( $variable ) );
 	}
+
+	public function testRenderValueOfAssociativeArrayVariable2() {
+		$variable = new stdClass();
+		$variable->cv_value = serialize( array( 1 => "foo", 15 => "bar" ) );
+		$variable->cv_variable_type = "array";
+		$expectedRender = <<<EOT
+array (
+  1 => 'foo',
+  15 => 'bar',
+)
+EOT;
+
+		$this->assertEquals( $expectedRender, WikiFactory::renderValue( $variable ) );
+	}
 }

--- a/extensions/wikia/WikiFactory/tests/WikiFactoryTest.php
+++ b/extensions/wikia/WikiFactory/tests/WikiFactoryTest.php
@@ -180,7 +180,7 @@ class WikiFactoryTest extends WikiaBaseTest {
 		$variable->cv_value = serialize( array( "a", "b", "c" ) );
 		$variable->cv_variable_type = "array";
 
-		$this->assertEquals( '["a","b","c"]', WikiFactory::renderValue( $variable ) );
+		$this->assertEquals( '[&quot;a&quot;,&quot;b&quot;,&quot;c&quot;]', WikiFactory::renderValue( $variable ) );
 	}
 
 	public function testRenderValueOfAssociativeArrayVariable() {
@@ -189,8 +189,8 @@ class WikiFactoryTest extends WikiaBaseTest {
 		$variable->cv_variable_type = "array";
 		$expectedRender = <<<EOT
 array (
-  'foo' => 'bar',
-  0 => 'c',
+  'foo' =&gt; 'bar',
+  0 =&gt; 'c',
 )
 EOT;
 
@@ -203,8 +203,8 @@ EOT;
 		$variable->cv_variable_type = "array";
 		$expectedRender = <<<EOT
 array (
-  1 => 'foo',
-  15 => 'bar',
+  1 =&gt; 'foo',
+  15 =&gt; 'bar',
 )
 EOT;
 

--- a/extensions/wikia/WikiFactory/tests/WikiFactoryTest.php
+++ b/extensions/wikia/WikiFactory/tests/WikiFactoryTest.php
@@ -144,4 +144,56 @@ class WikiFactoryTest extends WikiaBaseTest {
 			]
 		];
 	}
+
+	public function testRenderValueOfVariableWithoutValue() {
+		$variable = new stdClass();
+
+		$this->assertEquals( "", WikiFactory::renderValue( $variable ) );
+	}
+
+	public function testRenderValueOfStringVariable() {
+		$variable = new stdClass();
+		$variable->cv_value = serialize( "foo" );
+		$variable->cv_variable_type = "string";
+
+		$this->assertEquals( "foo", WikiFactory::renderValue( $variable ) );
+	}
+
+	public function testRenderValueOfIntegerVariable() {
+		$variable = new stdClass();
+		$variable->cv_value = serialize( 15 );
+		$variable->cv_variable_type = "integer";
+
+		$this->assertEquals( 15, WikiFactory::renderValue( $variable ) );
+	}
+
+	public function testRenderValueOfFloatVariable() {
+		$variable = new stdClass();
+		$variable->cv_value = serialize( 5.234 );
+		$variable->cv_variable_type = "float";
+
+		$this->assertEquals( 5.234, WikiFactory::renderValue( $variable ) );
+	}
+
+	public function testRenderValueOfArrayVariable() {
+		$variable = new stdClass();
+		$variable->cv_value = serialize( array( "a", "b", "c" ) );
+		$variable->cv_variable_type = "array";
+
+		$this->assertEquals( '["a","b","c"]', WikiFactory::renderValue( $variable ) );
+	}
+
+	public function testRenderValueOfAssociativeArrayVariable() {
+		$variable = new stdClass();
+		$variable->cv_value = serialize( array( "foo" => "bar", "0" => "c" ) );
+		$variable->cv_variable_type = "array";
+		$expectedRender = <<<EOT
+array (
+  'foo' => 'bar',
+  0 => 'c',
+)
+EOT;
+
+		$this->assertEquals( $expectedRender, WikiFactory::renderValue( $variable ) );
+	}
 }


### PR DESCRIPTION
Simplify the way of rendering array objects in WikiFactory. Instead of rendering:

```
array (
  0 => 'foo', 
  1 => 'bar',
)
```

now it will look like:

```
["foo","bar"]
```

Associative array shouldn't be affected so `array(15=>'foo', 20=>'bar')` will be rendered as:

```
array (
  15 => 'foo', 
  20 => 'bar',
)
```
