### PR TITLE
PLATFORM-1672 - the REPLACE was removing city_variables entries on other wikis

### DIFF
--- a/maintenance/wikia/getDatabase.php
+++ b/maintenance/wikia/getDatabase.php
@@ -208,9 +208,12 @@ if ( array_key_exists('h', $opts) || array_key_exists ('f', $opts) ) {
 	$prod->csv("SELECT * from city_domains where city_id = $city_id", $file);
 	$dev->import($file);
 
+	# commented out due to PLATFORM-1672 - the REPLACE was removing city_variables entries on other wikis
+	/**
 	$file = "/tmp/city_variables_pool.csv";
 	$prod->csv("SELECT * from city_variables_pool where cv_id in (select cv_variable_id from city_variables where cv_city_id = $city_id)", $file);
 	$dev->import($file);
+	**/
 
 	$file = "/tmp/city_variables.csv";
 	$prod->csv("SELECT * from city_variables where cv_city_id = $city_id", $file);


### PR DESCRIPTION
See [PLATFORM-1672](https://wikia-inc.atlassian.net/browse/PLATFORM-1672) for more details

Comment out import of `city_variables_pool` as the `DELETE` / `INSERT` combos were removing rows from `city_variables` table for all wikis.

@wladekb / @michalroszka / @pchojnacki / @owend 
