### PR TITLE
HealthCheck: do not check local Varnish instance

### DIFF
--- a/extensions/wikia/SpecialHealthcheck/SpecialHealthcheck_body.php
+++ b/extensions/wikia/SpecialHealthcheck/SpecialHealthcheck_body.php
@@ -99,18 +99,6 @@ class HealthCheck extends UnlistedSpecialPage {
 			$statusMsg  = 'Server status is: NOT OK - Disabled';
 		}
 
-
-		// Varnish should respond with a 200 for any request to any host with this path
-		// The Http class takes care of the proxying through varnish for us.
-		if ( empty( $wgDevelEnvironment ) ) {
-			$content = Http::get( "http://x/__varnish_nagios_check" );
-			if ( !$content ) {
-				$statusCode = 503;
-				$statusMsg  = 'Server status is: NOT OK - Varnish not responding';
-			}
-		}
-
-
 		// don't check POST on Iowa (i.e. when ready only mode is on)
 		if ( wfReadOnly() ) {
 			$statusMsg  = 'Server status is: POST check disabled';


### PR DESCRIPTION
Let's remove the check of local Varnish as it will be gone soon.

```
macbre@dell:~$ curl http://community.wikia.com/wiki/Special:HealthCheck -x preview:80 -v
* About to connect() to proxy preview port 80 (#0)
*   Trying 10.8.68.175...
* connected
* Connected to preview (10.8.68.175) port 80 (#0)
> GET http://community.wikia.com/wiki/Special:HealthCheck HTTP/1.1
> User-Agent: curl/7.26.0
> Host: community.wikia.com
> Accept: */*
> Proxy-Connection: Keep-Alive
> 
* additional stuff not fine transfer.c:1037: 0 0
* HTTP 1.1 or later with persistent connection, pipelining supported
< HTTP/1.1 503 Service Unavailable
< Date: Mon, 18 Jan 2016 10:38:50 GMT
< Server: Apache
< X-Content-Type-Options: nosniff
< Cpu-Count: 4
< Load: 0.4, 0.42, 0.53
< Max-Load: 
< Content-language: en
< X-Frame-Options: DENY
< X-Served-By: staging-s3
< X-Backend-Response-Time: 0.172
< X-Cache: ORIGIN
< X-Cache-Hits: ORIGIN
< Vary: Accept-Encoding,Cookie
< Expires: Thu, 01 Jan 1970 00:00:00 GMT
< Cache-Control: private, must-revalidate, max-age=0
< Content-Length: 50
< Connection: close
< Content-Type: text/html; charset=UTF-8
< 
Server status is: NOT OK - Varnish not responding
```

@artursitarski / @rmarchei / @wladekb 
