### PR TITLE
SUS-6 - fix BadRequestException for video upload on Hubs caused by missing edit token

### DIFF
--- a/extensions/wikia/SpecialEditHub/EditHubController.class.php
+++ b/extensions/wikia/SpecialEditHub/EditHubController.class.php
@@ -371,6 +371,8 @@ class EditHubController extends WikiaSpecialPageController {
 	}
 
 	public function uploadAndGetVideo() {
+		$this->checkWriteRequest();
+
 		if (!$this->checkAccess()) {
 			return false;
 		}

--- a/extensions/wikia/SpecialEditHub/js/EditHub.js
+++ b/extensions/wikia/SpecialEditHub/js/EditHub.js
@@ -35,7 +35,8 @@
 							method: 'uploadAndGetVideo',
 							type: 'post',
 							data: {
-								'url': url
+								url: url,
+								token: window.mw.user.tokens.get('editToken')
 							},
 							callback: function (response) {
 								require( ['wikia.throbber'], function( throbber ) {

--- a/includes/wikia/nirvana/WikiaDispatchableObject.class.php
+++ b/includes/wikia/nirvana/WikiaDispatchableObject.class.php
@@ -207,7 +207,10 @@ abstract class WikiaDispatchableObject extends WikiaObject {
 	 *                             a valid edit token.
 	 */
 	public function checkWriteRequest() {
-		$this->request->isValidWriteRequest( $this->wg->User );
+		// skip internal requests, write access should be checked when direct user interaction happen
+		if ( !$this->request->isInternal() ) {
+			$this->request->isValidWriteRequest( $this->wg->User );
+		}
 	}
 
 	protected function setTokenMismatchError() {

--- a/includes/wikia/tests/WikiaDispatchableObjectTest.php
+++ b/includes/wikia/tests/WikiaDispatchableObjectTest.php
@@ -114,11 +114,15 @@ class WikiaDispatchableObjectTest extends WikiaBaseTest {
 	/**
 	 * @dataProvider checkWriteRequestProvider
 	 */
-	public function testCheckWriteRequest( $params, $wasPosted, $token, $exceptionExpected ) {
-		$requestMock = $this->getMock( 'WikiaRequest', [ 'wasPosted' ], [ $params ] );
-		$requestMock->expects( $this->once() )
+	public function testCheckWriteRequest( $params, $wasPosted, $isInternal, $token, $exceptionExpected ) {
+		$requestMock = $this->getMock( 'WikiaRequest', [ 'wasPosted', 'isInternal' ], [ $params ] );
+		$requestMock->expects( !$isInternal ? $this->once() : $this->never() )
 			->method( 'wasPosted' )
 			->will( $this->returnValue( $wasPosted ) );
+
+		$requestMock->expects( $this->once() )
+			->method( 'isInternal' )
+			->will( $this->returnValue( $isInternal ) );
 
 		$userMock = $this->getMock( 'User', [ 'getEditToken' ] );
 		$userMock->expects( $this->any() )
@@ -141,11 +145,12 @@ class WikiaDispatchableObjectTest extends WikiaBaseTest {
 
 	public function checkWriteRequestProvider() {
 		return [
-			[ [ 'token' => '1234' ], true, '1234', false ],
-			[ [], true, '1234', true ],
-			[ [], false, '1234', true ],
-			[ [ 'token' => '4321' ], true, '1234', true ],
-			[ [ 'token' => '1234' ], false, '1234', true ],
+			[ [ 'token' => '1234' ], true, false, '1234', false ],
+			[ [], true, false, '1234', true ],
+			[ [], false, false, '1234', true ],
+			[ [ 'token' => '4321' ], true, false, '1234', true ],
+			[ [ 'token' => '1234' ], false, false, '1234', true ],
+			[ [], true, true, '1234', false ]
 		];
 	}
 }


### PR DESCRIPTION
Jira issue: https://wikia-inc.atlassian.net/browse/SUS-6
- added edit token to AJAX request
- added checkWriteAccess check to the method called via AJAX
- refactored checkWriteAccess method to skip internal requests
- add / refactored unit tests to check for internal requests
