### PR TITLE
SUS-11: assert that we have Title instance in WikiaPageType::isWikiaHubMain

### DIFF
--- a/includes/wikia/WikiaPageType.class.php
+++ b/includes/wikia/WikiaPageType.class.php
@@ -1,5 +1,7 @@
 <?php
 
+use Wikia\Util\Assert;
+
 /**
  * Utility class to check types of currently rendered page
  */
@@ -241,6 +243,9 @@ class WikiaPageType {
 	 */
 	public static function isWikiaHubMain() {
 		$title = self::getTitle();
+
+		Assert::true( $title instanceof Title, __METHOD__ ); // SUS-11
+
 		$mainPageName = trim( str_replace( '_', ' ', wfMessage( 'mainpage' )->inContentLanguage()->text() ) );
 		$isMainPage = ( strcasecmp( $mainPageName, $title->getText() ) === 0 ) && $title->getNamespace() === NS_MAIN;
 


### PR DESCRIPTION
[SUS-11](https://wikia-inc.atlassian.net/browse/SUS-11)

`WikiaPageType::getTitle` returns null quite rare and only when `FollowEmailTask::emailFollowNotifications` task is executed. The task caller passes the title instance, but it does not always "propagate" to `WikiaPageType` class.

So, It should work. Because the `should` keyword is used, let's add an assert to get the backtrace and more context that should  :smile: :help us find the root cause.

@Wikia/sustaining-team 
