### PR TITLE
SUS-8 Prevent SQL Injection and CSRF in the ManageHomePage controller

### DIFF
--- a/extensions/wikia/CityVisualization/helpers/WikiaHomePageHelper.class.php
+++ b/extensions/wikia/CityVisualization/helpers/WikiaHomePageHelper.class.php
@@ -751,7 +751,7 @@ class WikiaHomePageHelper extends WikiaModel {
 
 		/* @var $visualization CityVisualization */
 		$visualization = new CityVisualization();
-		$result = $visualization->setFlag($wikiId, $langCode, $flag);
+		$result = $visualization->addFlag($wikiId, $langCode, $flag);
 
 		if ($result === true) {
 			//purge cache

--- a/extensions/wikia/CityVisualization/models/CityVisualization.class.php
+++ b/extensions/wikia/CityVisualization/models/CityVisualization.class.php
@@ -344,9 +344,7 @@ class CityVisualization extends WikiaModel {
 		$mdb = wfGetDB( DB_MASTER, [], $this->wg->ExternalSharedDB );
 
 		$result = $mdb->update( self::CITY_VISUALIZATION_TABLE_NAME,
-			[
-				'city_flags' => "(city_flags | {$flag})",
-			],
+			[ "city_flags = {$mdb->bitOr( 'city_flags', $flag )}" ],
 			[
 				'city_id' => $wikiId,
 				'city_lang_code' => $langCode,

--- a/extensions/wikia/CityVisualization/models/CityVisualization.class.php
+++ b/extensions/wikia/CityVisualization/models/CityVisualization.class.php
@@ -373,16 +373,18 @@ class CityVisualization extends WikiaModel {
 		return $row['city_flags'];
 	}
 
-	public function removeFlag($wikiId, $langCode, $flag) {
-		wfProfileIn(__METHOD__);
-		$mdb = wfGetDB(DB_MASTER, array(), $this->wg->ExternalSharedDB);
-
-		$sql = 'update ' . self::CITY_VISUALIZATION_TABLE_NAME . ' set city_flags = (city_flags & ~' . $flag . ') where city_id = ' . $wikiId. ' and city_lang_code = "' . $langCode . '"';;
-
-		$result = $mdb->query($sql);
-		$mdb->commit(__METHOD__);
-
-		wfProfileOut(__METHOD__);
+	public function removeFlag( $wikiId, $langCode, $flag ) {
+		wfProfileIn( __METHOD__ );
+		$mdb = wfGetDB( DB_MASTER, [], $this->wg->ExternalSharedDB );
+		$result = $mdb->update( self::CITY_VISUALIZATION_TABLE_NAME,
+			[ "city_flags = {$mdb->bitAnd( 'city_flags', $mdb->bitNot( $flag ) )}" ],
+			[
+				'city_id' => $wikiId,
+				'city_lang_code' => $langCode,
+			]
+		);
+		$mdb->commit( __METHOD__ );
+		wfProfileOut( __METHOD__ );
 		return $result;
 	}
 

--- a/extensions/wikia/CityVisualization/models/CityVisualization.class.php
+++ b/extensions/wikia/CityVisualization/models/CityVisualization.class.php
@@ -339,16 +339,22 @@ class CityVisualization extends WikiaModel {
 	}
 
 
-	public function setFlag($wikiId, $langCode, $flag) {
-		wfProfileIn(__METHOD__);
-		$mdb = wfGetDB(DB_MASTER, array(), $this->wg->ExternalSharedDB);
+	public function setFlag( $wikiId, $langCode, $flag ) {
+		wfProfileIn( __METHOD__ );
+		$mdb = wfGetDB( DB_MASTER, [], $this->wg->ExternalSharedDB );
 
-		$sql = 'update ' . self::CITY_VISUALIZATION_TABLE_NAME . ' set city_flags = (city_flags | ' . $flag . ') where city_id = ' . $wikiId . ' and city_lang_code = "' . $langCode . '"';
+		$result = $mdb->update( self::CITY_VISUALIZATION_TABLE_NAME,
+			[
+				'city_flags' => "(city_flags | {$flag})",
+			],
+			[
+				'city_id' => $wikiId,
+				'city_lang_code' => $langCode,
+			]
+		);
+		$mdb->commit( __METHOD__ );
 
-		$result = $mdb->query($sql);
-		$mdb->commit(__METHOD__);
-
-		wfProfileOut(__METHOD__);
+		wfProfileOut( __METHOD__ );
 		return $result;
 	}
 

--- a/extensions/wikia/SpecialManageWikiaHome/ManageWikiaHomeController.class.php
+++ b/extensions/wikia/SpecialManageWikiaHome/ManageWikiaHomeController.class.php
@@ -452,6 +452,10 @@ class ManageWikiaHomeController extends WikiaSpecialPageController {
 	public function changeFlag() {
 		wfProfileIn(__METHOD__);
 
+		if ( !$this->request->isValidWriteRequest( $this->getContext()->getUser() ) ) {
+			$this->status = false;
+		}
+
 		if( !$this->checkAccess() ) {
 			$this->status = false;
 		} else {

--- a/extensions/wikia/SpecialManageWikiaHome/ManageWikiaHomeController.class.php
+++ b/extensions/wikia/SpecialManageWikiaHome/ManageWikiaHomeController.class.php
@@ -452,9 +452,7 @@ class ManageWikiaHomeController extends WikiaSpecialPageController {
 	public function changeFlag() {
 		wfProfileIn(__METHOD__);
 
-		if ( !$this->request->isValidWriteRequest( $this->getContext()->getUser() ) ) {
-			$this->status = false;
-		}
+		$this->checkWriteRequest();
 
 		if( !$this->checkAccess() ) {
 			$this->status = false;

--- a/extensions/wikia/SpecialManageWikiaHome/js/ManageWikiaHome.js
+++ b/extensions/wikia/SpecialManageWikiaHome/js/ManageWikiaHome.js
@@ -93,6 +93,7 @@ $(function () {
 					type: type,
 					flag: flagType,
 					lang: this.visualizationLang,
+					token: mw.user.tokens.get('editToken'),
 					corpWikiId: $('#visualizationWikiId').val(),
 					wikiId: wikiId
 				},


### PR DESCRIPTION
This PR covers fixes for:
1. **SQL Injection** in the `WikiaHomePageHelper::addFlag()` and `WikiaHomePageHelper::removeFlag()` methods.
2. **CSRF** in the `WikiaHomePageController::changeFlag()` method.

Pinging @macbre and the @Wikia/sustaining-team 
