### PR TITLE
Aden 2688 revive

### DIFF
--- a/extensions/wikia/Spotlights/SpotlightsHooks.class.php
+++ b/extensions/wikia/Spotlights/SpotlightsHooks.class.php
@@ -13,10 +13,11 @@ class SpotlightsHooks {
 	 */
 	public static function onWikiaSkinTopScripts(&$vars, &$scripts)
 	{
-		global $wgEnableOpenXSPC;
+		global $wgEnableOpenXSPC, $wgEnableReviveSpotlights;
 
 		if ($wgEnableOpenXSPC) {
 			$vars['wgEnableOpenXSPC'] = $wgEnableOpenXSPC;
+			$vars['wgEnableReviveSpotlights'] = $wgEnableReviveSpotlights;
 		}
 
 		return true;

--- a/extensions/wikia/Spotlights/js/AdProviderOpenX.js
+++ b/extensions/wikia/Spotlights/js/AdProviderOpenX.js
@@ -1,41 +1,55 @@
 var AdProviderOpenX = {
 	url : '',
-	url2 : '',
 	defaultHttpBase: 'http://spotlights.wikia.net/',
 	reviveHttpBase: 'http://spotlights-revive.wikia.net/'
 };
 
-AdProviderOpenX.getUrl2 = function() {
-
-	var httpBase = window.wgEnableReviveSpotlights ? AdProviderOpenX.reviveHttpBase : AdProviderOpenX.defaultHttpBase,
-		url = httpBase + "spc.php";
-		url += "?zones=14|15|16|17|18|19|20|21|22";
-		url += "&source=";
-		url += "&r=" + Math.floor(Math.random()*99999999);
-		url += "&loc=" + escape(window.location);
+AdProviderOpenX.getConfig = function() {
+	var config =  {
+		'zones':'14|15|16|17|18|19|20|21|22',
+		'source': '',
+		'r': Math.floor(Math.random()*99999999),
+		'loc': escape(window.location),
+		'target': '_top',
+		'cb': Math.floor(Math.random()*99999999),
+		'hub': window.wgWikiVertical,
+		'skin_name': window.skin,
+		'cont_lang': window.wgContentLanguage,
+		'user_lang': window.wgUserLanguage,
+		'dbname': wgDBname,
+		'tags': escape(window.wgWikiFactoryTagNames.join(",")),
+		'block': '1'
+	};
 	if (typeof document.referrer !== "undefined") {
-		url += "&referer=" + escape(document.referrer);
+		config.referer = escape(document.referrer);
 	}
-		url += "&target=_top";
-		url += "&cb=" + Math.floor(Math.random()*99999999);
-		url += "&hub=" + window.wgWikiVertical;
-		url += "&skin_name=" + skin;
-		url += "&cont_lang=" + wgContentLanguage;
-		url += "&user_lang=" + wgUserLanguage;
-		// varnish handles this url += "&browser_lang=X-BROWSER";
-		url += "&dbname=" + wgDBname;
-		url += "&tags=" + escape(wgWikiFactoryTagNames.join(","));
-		url += "&block=1";
-		url += (document.charset ? '&charset='+document.charset : (document.characterSet ? '&charset='+document.characterSet : ''));
-
-	AdProviderOpenX.url2 = url;
-
-	return AdProviderOpenX.url2;
+	if (document.charset || document.characterSet) {
+		config.charset = document.charset ? document.charset : document.characterSet;
+	}
+	return config;
 };
+
+AdProviderOpenX.getUrlParamsFromConfig = function(config) {
+	var params = [];
+	for (var key in config) {
+		if (config.hasOwnProperty(key)) {
+			params.push(key + '=' + config[key]);
+		}
+	}
+	return params.join('&');
+};
+
+AdProviderOpenX.getUrl = function() {
+	var httpBase = window.wgEnableReviveSpotlights ? AdProviderOpenX.reviveHttpBase : AdProviderOpenX.defaultHttpBase,
+		url = httpBase + 'spc.php?' + AdProviderOpenX.getUrlParamsFromConfig(AdProviderOpenX.getConfig());
+	AdProviderOpenX.url = url;
+	return AdProviderOpenX.url;
+};
+
 
 if (!window.wgNoExternals && window.wgEnableOpenXSPC && !window.wgIsEditPage && !window.navigator.userAgent.match(/sony_tvs/)) {
 	jQuery(function($) {
-		$.getScript(AdProviderOpenX.getUrl2(), function() {
+		$.getScript(AdProviderOpenX.getUrl(), function() {
 			var lazy = new window.Wikia.LazyLoadAds();
 		});
 	});

--- a/extensions/wikia/Spotlights/js/AdProviderOpenX.js
+++ b/extensions/wikia/Spotlights/js/AdProviderOpenX.js
@@ -1,55 +1,32 @@
 var AdProviderOpenX = {
 	url : '',
-	url2 : ''
-};
-
-AdProviderOpenX.getUrl = function (baseUrl, slotname, zoneId, affiliateId, hub, additionalParams) {
-	var url = baseUrl;
-	url += "?loc=" + escape(window.location);
-	if(typeof document.referrer != "undefined"){ url += "&referer=" + escape(document.referrer); }
-	if(typeof document.context != "undefined"){ url += "&context=" + escape(document.context); }
-	if(typeof document.mmm_fo != "undefined"){ url += "&mmm_fo=1"; }
-	url += "&target=_top";
-	if(typeof AdsCB != "undefined") { url += "&cb=" + AdsCB; } else { url += "&cb=" + Math.floor(Math.random()*99999999); }
-	if(typeof document.MAX_used != "undefined" && document.MAX_used != ","){ url += "&exclude=" + document.MAX_used; }
-	url += "&hub=" + hub;
-	url += "&skin_name=" + skin;
-	url += "&cont_lang=" + wgContentLanguage;
-	url += "&user_lang=" + wgUserLanguage;
-	// varnish handles this url += "&browser_lang=X-BROWSER";
-	url += "&dbname=" + wgDBname;
-	url += "&tags=" + wgWikiFactoryTagNames.join(",");
-	url += additionalParams;
-	if(slotname != ''){ url += "&slotname=" + slotname; }
-	if(zoneId != ''){ url += "&zoneid=" + zoneId; }
-	if(affiliateId != ''){ url += "&id=" + affiliateId; }
-	url += "&block=1";
-
-	AdProviderOpenX.url = url;
-
-	return AdProviderOpenX.url;
+	url2 : '',
+	defaultHttpBase: 'http://spotlights.wikia.net/',
+	reviveHttpBase: 'http://spotlights-revive.wikia.net/'
 };
 
 AdProviderOpenX.getUrl2 = function() {
-	var url = "/__spotlights/spc.php";
-	url += "?zones=14|15|16|17|18|19|20|21|22";
-	url += "&source=";
-	url += "&r=" + Math.floor(Math.random()*99999999);
-	url += "&loc=" + escape(window.location);
+
+	var httpBase = window.wgEnableReviveSpotlights ? AdProviderOpenX.reviveHttpBase : AdProviderOpenX.defaultHttpBase,
+		url = httpBase + "spc.php";
+		url += "?zones=14|15|16|17|18|19|20|21|22";
+		url += "&source=";
+		url += "&r=" + Math.floor(Math.random()*99999999);
+		url += "&loc=" + escape(window.location);
 	if (typeof document.referrer !== "undefined") {
 		url += "&referer=" + escape(document.referrer);
 	}
-	url += "&target=_top";
-	url += "&cb=" + Math.floor(Math.random()*99999999);
-	url += "&hub=" + window.wgWikiVertical;
-	url += "&skin_name=" + skin;
-	url += "&cont_lang=" + wgContentLanguage;
-	url += "&user_lang=" + wgUserLanguage;
-	// varnish handles this url += "&browser_lang=X-BROWSER";
-	url += "&dbname=" + wgDBname;
-	url += "&tags=" + escape(wgWikiFactoryTagNames.join(","));
-	url += "&block=1";
-	url += (document.charset ? '&charset='+document.charset : (document.characterSet ? '&charset='+document.characterSet : ''));
+		url += "&target=_top";
+		url += "&cb=" + Math.floor(Math.random()*99999999);
+		url += "&hub=" + window.wgWikiVertical;
+		url += "&skin_name=" + skin;
+		url += "&cont_lang=" + wgContentLanguage;
+		url += "&user_lang=" + wgUserLanguage;
+		// varnish handles this url += "&browser_lang=X-BROWSER";
+		url += "&dbname=" + wgDBname;
+		url += "&tags=" + escape(wgWikiFactoryTagNames.join(","));
+		url += "&block=1";
+		url += (document.charset ? '&charset='+document.charset : (document.characterSet ? '&charset='+document.characterSet : ''));
 
 	AdProviderOpenX.url2 = url;
 


### PR DESCRIPTION
Those changes are enabling us to use never version of OpenX server - Revive. In order to use it, you need to set wiki variable wgEnableReviveSpotlights to true; In the future we are going to set this variable based on geolocation - automatically.
