### PR TITLE
SEO-221 Broken XML comment in sitemaps

### DIFF
--- a/extensions/wikia/Sitemap/SpecialSitemap_body.php
+++ b/extensions/wikia/Sitemap/SpecialSitemap_body.php
@@ -256,7 +256,6 @@ class SitemapPage extends UnlistedSpecialPage {
 		$dbr = wfGetDB( DB_SLAVE, "vslow" );
 
 		$out = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
-		$out .= sprintf( "<!-- generated on the fly by %s -->\n", $this->mTitle->getFullURL() );
 
 		$scope = array( 'page_namespace' => $this->mNamespace );
 		$index = is_array( $sitemapIndex ) ? $sitemapIndex : $wgMemc->get( wfMemcKey( "sitemap-index") );

--- a/extensions/wikia/Sitemap/SpecialSitemap_body.php
+++ b/extensions/wikia/Sitemap/SpecialSitemap_body.php
@@ -195,7 +195,6 @@ class SitemapPage extends UnlistedSpecialPage {
 
 		$out = "";
 		$out .= "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
-		$out .= sprintf( "<!-- generated on fly by %s -->\n", $this->mTitle->getFullURL() );
 		$out .= "<sitemapindex xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n";
 
 		header( "Content-type: application/xml; charset=UTF-8" );


### PR DESCRIPTION
For wikis with two consecutive dashes in the domain name, the XML comment
that we output is invalid as it contains "--" within a comment, which is
invalid.

There's no much use of the comment anyway, so I'm removing it.
