### PR TITLE
LicensedVideoSwapSpecialController: prevent CSRF

### DIFF
--- a/extensions/wikia/LicensedVideoSwap/LicensedVideoSwapSpecialController.class.php
+++ b/extensions/wikia/LicensedVideoSwap/LicensedVideoSwapSpecialController.class.php
@@ -157,8 +157,12 @@ class LicensedVideoSwapSpecialController extends WikiaSpecialPageController {
 	 * @responseParam string html
 	 * @responseParam integer totalVideos - total videos with suggestions
 	 * @responseParam string redirect - redirect url
+	 *
+	 * @throws BadRequestException
 	 */
 	public function swapVideo() {
+		$this->checkWriteRequest();
+
 		$videoTitle = $this->request->getVal( 'videoTitle', '' );
 		$newTitle = $this->request->getVal( 'newTitle', '' );
 		$currentPage = $this->getVal( 'currentPage', 1 );
@@ -321,8 +325,12 @@ class LicensedVideoSwapSpecialController extends WikiaSpecialPageController {
 	 * @responseParam string html
 	 * @responseParam integer totalVideos - total videos with suggestions
 	 * @responseParam string redirect - redirect url
+	 *
+	 * @throws BadRequestException
 	 */
 	public function keepVideo() {
+		$this->checkWriteRequest();
+
 		$videoTitle = $this->request->getVal( 'videoTitle', '' );
 		$forever = $this->request->getVal( 'forever', '' );
 		$suggestions = $this->request->getVal( 'suggestions', array() );

--- a/extensions/wikia/LicensedVideoSwap/js/lvsSwapKeep.js
+++ b/extensions/wikia/LicensedVideoSwap/js/lvsSwapKeep.js
@@ -33,7 +33,8 @@ define('lvs.swapkeep', [
 		data = {
 			videoTitle: currTitle,
 			sort: qs.getVal('sort', 'recent'),
-			currentPage: qs.getVal('currentPage', 1)
+			currentPage: qs.getVal('currentPage', 1),
+			token: mw.user.tokens.get('editToken')
 		};
 
 		// if @params are explicitly passed through, extend our object with them


### PR DESCRIPTION
[SUS-25](https://wikia-inc.atlassian.net/browse/SUS-25)

Check token and HTTP request method in LicensedVideoSwapSpecialController's `swapVideo` and `keepVideo` methods. And pass `token` when making AJAX request.

@Wikia/sustaining-team 
