### PR TITLE
Fix CSRF in UserSignupSpecialController

### DIFF
--- a/extensions/wikia/UserLogin/UserSignupSpecialController.class.php
+++ b/extensions/wikia/UserLogin/UserSignupSpecialController.class.php
@@ -300,6 +300,8 @@ class UserSignupSpecialController extends WikiaSpecialPageController {
 	 * @responseParam string errParam
 	 * @responseParam string heading
 	 * @responseParam string subheading
+	 *
+	 * @throws BadRequestException
 	 */
 	public function sendConfirmationEmail() {
 		if ( $this->request->getVal( 'format', '' ) !== 'json' ) {
@@ -318,6 +320,7 @@ class UserSignupSpecialController extends WikiaSpecialPageController {
 
 		$this->username = $this->request->getVal( 'username', '' );
 		$this->byemail = $this->request->getBool( 'byemail', false );
+		$this->token = $this->wg->User->getEditToken();
 
 		// default heading, subheading, msg
 		// depending on what happens, default will be over written below
@@ -348,6 +351,8 @@ class UserSignupSpecialController extends WikiaSpecialPageController {
 			$this->errParam = '';
 
 			if ( $this->wg->Request->wasPosted() ) {
+				$this->checkWriteRequest(); // SUS-20: require a user token when handling POST requests
+
 				$action = $this->request->getVal( 'action', '' );
 				if ( $action == 'resendconfirmation' ) {
 					$response = $this->userLoginHelper->sendConfirmationEmail( $this->username );

--- a/extensions/wikia/UserLogin/templates/UserSignupSpecial_sendConfirmationEmail.php
+++ b/extensions/wikia/UserLogin/templates/UserSignupSpecial_sendConfirmationEmail.php
@@ -14,6 +14,7 @@
 			<div class="input-group">
 				<input type="hidden" name="action" value="resendconfirmation">
 				<input type="hidden" name="username" value="<?= Sanitizer::encodeAttribute( $username ); ?>">
+				<input type="hidden" name="token" value="<?= Sanitizer::encodeAttribute( $token ) ?>">
 				<input type="submit" value="<?= wfMessage( 'usersignup-confirm-email-resend-email' )->escaped() ?>" class="link">
 			</div>
 		</fieldset>
@@ -47,6 +48,11 @@
 				'type' => 'hidden',
 				'name' => 'username',
 				'value' => htmlspecialchars( $username )
+			),
+			array(
+				'type' => 'hidden',
+				'name' => 'token',
+				'value' => Sanitizer::encodeAttribute( $token )
 			),
 			array(
 				'type' => 'text',

--- a/includes/User.php
+++ b/includes/User.php
@@ -3949,7 +3949,7 @@ class User {
 			$request = $this->getRequest();
 		}
 
-		if ( $this->isAnon() ) {
+		if ( $this->isAnon() && session_status() !== PHP_SESSION_ACTIVE /* Wikia change (SUS-20) */ ) {
 			return EDIT_TOKEN_SUFFIX;
 		} else {
 			$token = $request->getSessionData( 'wsEditToken' );

--- a/includes/wikia/nirvana/WikiaDispatchableObject.class.php
+++ b/includes/wikia/nirvana/WikiaDispatchableObject.class.php
@@ -207,7 +207,10 @@ abstract class WikiaDispatchableObject extends WikiaObject {
 	 *                             a valid edit token.
 	 */
 	public function checkWriteRequest() {
-		$this->request->isValidWriteRequest( $this->wg->User );
+		// skip internal requests, write access should be checked when direct user interaction happen
+		if ( !$this->request->isInternal() ) {
+			$this->request->isValidWriteRequest( $this->wg->User );
+		}
 	}
 
 	protected function setTokenMismatchError() {

--- a/includes/wikia/tests/WikiaDispatchableObjectTest.php
+++ b/includes/wikia/tests/WikiaDispatchableObjectTest.php
@@ -114,11 +114,15 @@ class WikiaDispatchableObjectTest extends WikiaBaseTest {
 	/**
 	 * @dataProvider checkWriteRequestProvider
 	 */
-	public function testCheckWriteRequest( $params, $wasPosted, $token, $exceptionExpected ) {
-		$requestMock = $this->getMock( 'WikiaRequest', [ 'wasPosted' ], [ $params ] );
-		$requestMock->expects( $this->once() )
+	public function testCheckWriteRequest( $params, $wasPosted, $isInternal, $token, $exceptionExpected ) {
+		$requestMock = $this->getMock( 'WikiaRequest', [ 'wasPosted', 'isInternal' ], [ $params ] );
+		$requestMock->expects( !$isInternal ? $this->once() : $this->never() )
 			->method( 'wasPosted' )
 			->will( $this->returnValue( $wasPosted ) );
+
+		$requestMock->expects( $this->once() )
+			->method( 'isInternal' )
+			->will( $this->returnValue( $isInternal ) );
 
 		$userMock = $this->getMock( 'User', [ 'getEditToken' ] );
 		$userMock->expects( $this->any() )
@@ -141,11 +145,12 @@ class WikiaDispatchableObjectTest extends WikiaBaseTest {
 
 	public function checkWriteRequestProvider() {
 		return [
-			[ [ 'token' => '1234' ], true, '1234', false ],
-			[ [], true, '1234', true ],
-			[ [], false, '1234', true ],
-			[ [ 'token' => '4321' ], true, '1234', true ],
-			[ [ 'token' => '1234' ], false, '1234', true ],
+			[ [ 'token' => '1234' ], true, false, '1234', false ],
+			[ [], true, false, '1234', true ],
+			[ [], false, false, '1234', true ],
+			[ [ 'token' => '4321' ], true, false, '1234', true ],
+			[ [ 'token' => '1234' ], false, false, '1234', true ],
+			[ [], true, true, '1234', false ]
 		];
 	}
 }


### PR DESCRIPTION
[SUS-20](https://wikia-inc.atlassian.net/browse/SUS-20)

Check edit token when sending confirmation email & changing user's unconfirmed email.

To increase the security, let's generate the "full" edit token when the PHP session is started (even when  the user is not logged in).

@Wikia/sustaining-team 
