### PR TITLE
PhalanxService: improving logging of failed HTTP requests

### DIFF
--- a/extensions/wikia/PhalanxII/services/PhalanxService.class.php
+++ b/extensions/wikia/PhalanxII/services/PhalanxService.class.php
@@ -1,11 +1,13 @@
 <?php
-use \Wikia\Logger\WikiaLogger;
 
 /**
  * @method setLimit
  * @method setUser
  */
 class PhalanxService extends Service {
+
+	use \Wikia\Logger\Loggable;
+
 	/* limit of blocks */
 	private $limit = 1;
 	/* @var User */
@@ -18,6 +20,12 @@ class PhalanxService extends Service {
 
 	const PHALANX_SERVICE_TRIES_LIMIT = 3; // number of retries for phalanx POST requests
 	const PHALANX_SERVICE_TRY_USLEEP = 20000; // delay between retries - 0.2s
+
+	protected function getLoggerContext() {
+		return [
+			'class' => __CLASS__
+		];
+	}
 
 	/**
 	 * @param $name
@@ -168,10 +176,10 @@ class PhalanxService extends Service {
 					$parameters[ 'user' ][] = $this->user->getName();
 				} else {
 					if ( ( new \Wikia\Util\Statistics\BernoulliTrial( 0.001 ) )->shouldSample() ) {
-						\Wikia\Logger\WikiaLogger::instance()->debug(
+						$this->error(
 							'PLATFORM-1387',
 							[
-								'exception'    => new Exception,
+								'exception'    => new Exception(),
 								'block_params' => $parameters,
 								'user_name'    => F::app()->wg->User->getName()
 							]
@@ -222,15 +230,23 @@ class PhalanxService extends Service {
 			/* service doesn't work */
 			$res = false;
 
-			WikiaLogger::instance()->debug( "Phalanx service error", [ "phalanxUrl" => $url, 'requestTime' => $requestTime,
-				'postParams' => json_encode( $loggerPostParams ), 'tries' => $tries ] );
+			$this->error( "Phalanx service error", [
+				"phalanxUrl" => $url,
+				'requestTime' => $requestTime,
+				'postParams' => json_encode( $loggerPostParams ),
+				'tries' => $tries,
+				'exception' => new Exception( $action ),
+			] );
 
 			wfDebug( __METHOD__ . " - response failed!\n" );
 		} else {
 			wfDebug( __METHOD__ . " - received '{$response}'\n" );
 
-			WikiaLogger::instance()->debug( "Phalanx service success", ["phalanxUrl" => $url, 'requestTime' => $requestTime,
-				'tries' => $tries ] );
+			$this->debug( "Phalanx service success", [
+				"phalanxUrl" => $url,
+				'requestTime' => $requestTime,
+				'tries' => $tries
+			] );
 
 			switch ( $action ) {
 				case "stats":

--- a/includes/HttpFunctions.php
+++ b/includes/HttpFunctions.php
@@ -82,11 +82,18 @@ class Http {
 				'isOk' => $isOk,
 				'requestTimeMS' => $requestTime,
 				'backendTimeMS' => intval( 1000 * $backendTime),
+				'responseHeaders' => $req->getResponseHeaders(),
 			];
 			if ( !$isOk ) {
-				$params[ 'statusMessage' ] = $status->getMessage();
+				$params[ 'statusMessage' ] = $status;
+				$params[ 'exception' ] = new WikiaException( "{$caller} - HTTP request failed", $req->getStatus() );
+				$level = 'error';
 			}
-			\Wikia\Logger\WikiaLogger::instance()->debug( 'Http request' , $params );
+			else {
+				$level = 'debug';
+			}
+
+			\Wikia\Logger\WikiaLogger::instance()->$level( 'Http request' , $params );
 		}
 
 		// Wikia change - @author: nAndy - begin


### PR DESCRIPTION
[SUS-13](https://wikia-inc.atlassian.net/browse/SUS-13)

To prepare a solid ground for working on SUS-13, let's improve logging in Phalanx's integration in MediaWiki.

Additionally, log HTTP requests errors as errors. This will allow Jira Reporter to report such cases on per caller basis.

Example log entry from Phalanx:

``` json
{
  "@timestamp": "2016-01-20T13:23:32.467169+00:00",
  "@message": "Http request",
  "@fields": {
    "db_name": "wikia",
    "city_id": "177",
    "maintenance_file": "/usr/wikia/source/app/maintenance/eval.php",
    "maintenance_class": "CommandLineInc",
    "request_id": "mw569f8a538e4727.49247271"
  },
  "@context": {
    "statusCode": 200,
    "reqMethod": "POST",
    "reqUrl": "http://phalanx.service.consul:4666/stats",
    "caller": "PhalanxService:sendToPhalanxDaemon",
    "isOk": true,
    "requestTimeMS": 11,
    "backendTimeMS": 0,
    "responseHeaders": {
      "content-type": [
        "text/plain; charset=utf-8"
      ],
      "x-served-by": [
        "dev-cron-p2"
      ],
      "content-length": [
        "10299"
      ]
    }
  }
}
```

@Wikia/sustaining-team 
