### PR TITLE
ADEN-2847 Fix fastlane lookup_error events

### DIFF
--- a/extensions/wikia/AdEngine/js/lookup/rubiconFastlane.js
+++ b/extensions/wikia/AdEngine/js/lookup/rubiconFastlane.js
@@ -167,7 +167,7 @@ define('ext.wikia.adEngine.lookup.rubiconFastlane', [
 
 	function encodeParamsForTracking(params) {
 		if (!params[rubiconTierKey]) {
-			return {};
+			return;
 		}
 
 		return params[rubiconTierKey].join(';');


### PR DESCRIPTION
Put `nodata` instead of empty object to event label 
