### PR TITLE
SEO-233 Fix PHP Fatal in redirect-canonical and add logging

### DIFF
--- a/redirect-canonical.php
+++ b/redirect-canonical.php
@@ -13,9 +13,22 @@
  * ErrorDocument 404 /redirect-canonical.php
  */
 
+use \Wikia\Logger\WikiaLogger;
+
 require_once( dirname( __FILE__ ) . '/includes/WebStart.php' );
 
-$path = ltrim( parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH ), '/' );
+// Parse_url can technically parse just REQUEST_URI, but it doesn't work well
+// for URIs like Foo:100 which it understands as host: Foo, port: 100, no path
+// That's why we upgrade the URI to a full URL but prepending 'http://wikia.com/'
+// in front of it.
+$path = parse_url( 'http://wikia.com/' . $_SERVER['REQUEST_URI'], PHP_URL_PATH );
+$path = trim( rawurldecode( $path ), '/ _' );
+
+// Hack to better recover Mercury modular home pages URLs
+// (they are have double-encoded URLs for some reason)
+if ( startsWith( $path, 'main/' ) ) {
+	$path = rawurldecode( $path );
+}
 
 if ( isset( $_SERVER['REDIRECT_QUERY_STRING'] ) ) {
 	// Called from Apache's ErrorHandler
@@ -25,7 +38,29 @@ if ( isset( $_SERVER['REDIRECT_QUERY_STRING'] ) ) {
 	$qs = $_SERVER['QUERY_STRING'];
 }
 
-$title = Title::newFromText( rawurldecode( $path ) );
+$logContext = [
+	'ex' => new Exception(),
+	// To verify if Kibana trims the strings:
+	'uri' => $_SERVER['REQUEST_URI'],
+	'uriLen' => count( $_SERVER['REQUEST_URI'] ),
+];
+
+if ( !$path ) {
+	WikiaLogger::instance()->warning( '404 redirector: malformed URI', $logContext );
+}
+
+if ( in_string( '%', $path ) || in_string( '<', $path ) || in_string( '>', $path ) ) {
+	WikiaLogger::instance()->warning( '404 redirector: forbidden char in URI', $logContext );
+	$path = str_replace( ['%', '<', '>'], '_', $path );
+}
+
+$title = Title::newFromText( $path );
+
+if ( !$title ) {
+	WikiaLogger::instance()->warning( '404 redirector: not a valid title in URI', $logContext );
+	$title = Title::newMainPage();
+}
+
 $url = $title->getFullURL( $qs );
 
 header( 'Location: ' . $url, 302 );


### PR DESCRIPTION
Not coding defensively, this fatal revealed another issue.

Before the changes some URLs generated a MediaWiki page saying "Error
404: Page not found | Special page | These aren't the pages you're
looking for. Move along, please".

Now they return HTTP 404 with an empty response and a PHP Fatal logged.
This commit fixes that, but also logs the original REQUEST_URI for
catching what weird URIs like that are requested.

It seems there were three main problems:
1. URLs like http://some.wikia.com/Something:123 . PHP's parse_url given
   /Something:123 and the param interprets Something as the hostname and
   123 as the port and leaves path (which we're extracting) empty.
2. Modular main pages URLs requested on desktop. For some reason the
   URLs are double-encoded, so after initial decoding, there are still "%"
   signs in them, which are forbidden in MW Titles.
3. Plain broken URLs that don't map to any valid MW title.
   Title::newFromText doesn't return an object and code fails.

This pull request adds logging for all three, replaces the forbidden
characters with "_" and as a last resort redirects to the home page.
