### PR TITLE
Update the class generated with the new special page name

### DIFF
--- a/extensions/wikia/WikiaNewFiles/scripts/uploadPhotosDialog.js
+++ b/extensions/wikia/WikiaNewFiles/scripts/uploadPhotosDialog.js
@@ -6,7 +6,7 @@ var UploadPhotos = {
 	status: false,
 	libinit: false,
 	init: function() {
-		$(".mw-special-Newimages").on('click', '.upphotos', $.proxy(this.loginBeforeShowDialog, this));
+		$(".mw-special-Images").on('click', '.upphotos', $.proxy(this.loginBeforeShowDialog, this));
 	},
 	loginBeforeShowDialog: function(evt) {
 		var UserLoginModal = window.UserLoginModal;


### PR DESCRIPTION
The CSS class of the "Upload new image" button is generated based on the special page's name. The fix is just updating the class selector.
