### PR TITLE
PLATFORM-1355: Log to Kibana information about serving an empty page

### DIFF
--- a/includes/SkinTemplate.php
+++ b/includes/SkinTemplate.php
@@ -498,6 +498,7 @@ class SkinTemplate extends Skin {
 		$bodyTextTrimmed = trim( $out->mBodytext );
 		if ( startsWith( $bodyTextTrimmed, "<!-- \nNewPP" ) || startsWith( $bodyTextTrimmed, "<!-- Saved" ) ) {
 			if ( $title->exists() && $title->isContentPage() && $title->getLength() > 50 ) {
+				// We use 50 because 50 is a magic number.
 				\Wikia\Logger\WikiaLogger::instance()->error( 'PLATFORM-1355' );
 			}
 		}

--- a/includes/SkinTemplate.php
+++ b/includes/SkinTemplate.php
@@ -493,6 +493,16 @@ class SkinTemplate extends Skin {
 			$realBodyAttribs['class'] = 'mw-content-'.$pageLang->getDir().' mw-content-text';
 		}
 
+		// Wikia change begin - Inez
+		// This is a temporary code meant to help with debugging PLATFORM-1355 issue
+		$bodyTextTrimmed = trim( $out->mBodytext );
+		if ( startsWith( $bodyTextTrimmed, "<!-- \nNewPP" ) || startsWith( $bodyTextTrimmed, "<!-- Saved" ) ) {
+			if ( $title->exists() && $title->isContentPage() && $title->getLength() > 50 ) {
+				\Wikia\Logger\WikiaLogger::instance()->error( 'PLATFORM-1355' );
+			}
+		}
+		// Wikia change end
+
 		$out->mBodytext = Html::rawElement( 'div', $realBodyAttribs, $out->mBodytext );
 		$tpl->setRef( 'bodytext', $out->mBodytext );
 

--- a/includes/SkinTemplate.php
+++ b/includes/SkinTemplate.php
@@ -497,8 +497,10 @@ class SkinTemplate extends Skin {
 		// This is a temporary code meant to help with debugging PLATFORM-1355 issue
 		$bodyTextTrimmed = trim( $out->mBodytext );
 		if ( startsWith( $bodyTextTrimmed, "<!-- \nNewPP" ) || startsWith( $bodyTextTrimmed, "<!-- Saved" ) ) {
+			// Check if wikitext length is greater than 50 to eliminate noise of reporting pages
+			// which contains only categories. It won't eliminate all the noise, because there
+			// could be categories wikitext longer than 50, but should take care of most of it.
 			if ( $title->exists() && $title->isContentPage() && $title->getLength() > 50 ) {
-				// We use 50 because 50 is a magic number.
 				\Wikia\Logger\WikiaLogger::instance()->error( 'PLATFORM-1355' );
 			}
 		}

--- a/includes/WikiPage.php
+++ b/includes/WikiPage.php
@@ -3199,21 +3199,6 @@ class PoolWorkArticleView extends PoolCounterWork {
 				$this->page->getTitle()->getPrefixedDBkey() ) );
 		}
 
-		# PLATFORM-1355 (investigate blank pages)
-		# Check to see if Input exists but Output is just a Parser Performance dump with no other content
-		global $wgContentNamespaces;
-		if ( !empty($text) &&
-			 in_array ( $this->page->getTitle()->getNamespace(), $wgContentNamespaces ) &&
-			 preg_match("/^\n<!-- \nNewPP/s", $this->parserOutput->mText) === 1 ) {
-			global $wgArticleAsJson;
-			\Wikia\Logger\WikiaLogger::instance()->error( __METHOD__ . ' empty content PLAT1355', [
-				'wgArticleAsJson' => empty($wgArticleAsJson) ? 'no' : 'yes'
-			] );
-			// In addition to logging, do this quick hack/fix for blank pages
-			$this->cacheable = false;
-		}
-		// End PLATFORM-1355 investigation code
-
 		if ( $this->cacheable && $this->parserOutput->isCacheable() ) {
 			ParserCache::singleton()->save( $this->parserOutput, $this->page, $this->parserOptions );
 		}


### PR DESCRIPTION
I'm checking if the length of wikitext is greater than 50 to avoid noise of logging pages which contains just a category (or few categories) and their content is meant to be empty. This simple check will not eliminiate all the "noise" but probably most of it.

I also removed the previously added logging which wasn't helpful in debugging this issue - but was sending tons of data to Kibana and making bunch of pages "not cachable"
