### PR TITLE
SOC-1820 Delete attributes from service with value set to null.

### DIFF
--- a/lib/Wikia/src/Service/User/Attributes/UserAttributes.php
+++ b/lib/Wikia/src/Service/User/Attributes/UserAttributes.php
@@ -141,7 +141,10 @@ class UserAttributes {
 	}
 
 	private function attributeShouldBeDeleted( $name, $value ) {
-		return isset( $this->defaultAttributes[$name] ) && $value == $this->defaultAttributes[$name];
+		return (
+			( isset( $this->defaultAttributes[$name] ) && $value == $this->defaultAttributes[$name] ) ||
+			is_null( $value )
+		);
 	}
 
 	/**

--- a/lib/Wikia/tests/Service/User/UserAttributesTest.php
+++ b/lib/Wikia/tests/Service/User/UserAttributesTest.php
@@ -137,6 +137,18 @@ class UserAttributeTest extends PHPUnit_Framework_TestCase {
 		$this->assertNull( $userAttributes->getAttribute( $this->userId, $this->attribute1->getName() ) );
 	}
 
+	public function testDeleteAttrbutesWithNullValue() {
+		$attrNullValue = new Attribute( "someKey", null );
+		$this->setupServiceGetExpects();
+		$this->service->expects( $this->once() )
+			->method( 'delete' )
+			->with( $this->userId, $attrNullValue );
+
+		$userAttributes = new UserAttributes( $this->service, $this->cache, [] );
+		$userAttributes->setAttribute( $this->userId, $attrNullValue );
+		$userAttributes->save( $this->userId );
+	}
+
 	protected function setupServiceGetExpects() {
 		$this->service->expects( $this->once( ))
 			->method( 'get' )


### PR DESCRIPTION
This PR makes sure that if an attribute is set with a value of  `NULL`, it's deleted from the attribute service. That's the way `User.php` used to handle attributes. When we ported over that logic, we missed that case. See [here](https://github.com/Wikia/app/blob/dev/includes/User.php#L5032) (`isDefaultOption` returns true for null attributes without a default value).

This fixes the bug of a user not being able to clear out their birthday on their profile page. 

Ticket: https://wikia-inc.atlassian.net/browse/SOC-1820
