### PR TITLE
RECIRC-35: Track recirculation impressions in GA

### DIFF
--- a/extensions/wikia/Recirculation/js/recirculation.js
+++ b/extensions/wikia/Recirculation/js/recirculation.js
@@ -1,17 +1,27 @@
 /*global define*/
 define('ext.wikia.recirculation.recirculation', [
 	'jquery',
+	'wikia.window',
 	'wikia.abTest',
 	'wikia.tracker',
 	'wikia.nirvana',
 	'videosmodule.controllers.rail',
 	'ext.wikia.adEngine.taboolaHelper'
-], function ($, abTest, tracker, nirvana, videosModule, taboolaHelper) {
+], function ($, w, abTest, tracker, nirvana, videosModule, taboolaHelper) {
 	'use strict';
 
 	function trackClick() {
 		tracker.track({
 			action: tracker.ACTIONS.CLICK,
+			category: 'recirculation',
+			label: 'rail',
+			trackingMethod: 'analytics'
+		});
+	}
+
+	function trackImpression() {
+		tracker.track({
+			action: tracker.ACTIONS.IMPRESSION,
 			category: 'recirculation',
 			label: 'rail',
 			trackingMethod: 'analytics'
@@ -34,6 +44,11 @@ define('ext.wikia.recirculation.recirculation', [
 	}
 
 	function injectRecirculationModule(element) {
+		if (w.wgContentLanguage !== 'en') {
+			videosModule(element);
+			return;
+		}
+
 		var group = abTest.getGroup('RECIRCULATION_RAIL');
 
 		switch (group) {
@@ -52,12 +67,15 @@ define('ext.wikia.recirculation.recirculation', [
 				});
 				break;
 			case 'VIDEOS_MODULE':
-			default:
 				videosModule(element);
 				break;
+			default:
+				videosModule(element);
+				return;
 		}
 
-		$(element).on('click', 'a', trackClick);
+		trackImpression();
+		$(element).on('mousedown', 'a', trackClick);
 	}
 
 	return {


### PR DESCRIPTION
There are various reasons why a user may not see the recirculation modules. By tracking impressions we will be able to properly measure funnels.
