### PR TITLE
CE-3280: Fix translations for header, footer and shortcuts

### DIFF
--- a/extensions/wikia/GlobalShortcuts/scripts/GlobalShortcutsHelp.js
+++ b/extensions/wikia/GlobalShortcuts/scripts/GlobalShortcutsHelp.js
@@ -21,7 +21,6 @@ define('GlobalShortcutsHelp',
 							'extensions/wikia/GlobalShortcuts/templates/GlobalShortcutsController_help.mustache',
 						messages: 'GlobalShortcuts',
 						callback: function (pkg) {
-							mw.messages.set(pkg.messages);
 							templates.keyCombination = pkg.mustache[0];
 							templates.help = pkg.mustache[1];
 							dfd.resolve(templates);
@@ -64,7 +63,7 @@ define('GlobalShortcutsHelp',
 			var comboNum = 0,
 				combosCount,
 				keyCombination = [],
-				keyCombinationHtml = '',
+				keyCombinationHtml,
 				keysCount,
 				templateParams;
 

--- a/extensions/wikia/GlobalShortcuts/scripts/GlobalShortcutsRenderKeys.js
+++ b/extensions/wikia/GlobalShortcuts/scripts/GlobalShortcutsRenderKeys.js
@@ -16,7 +16,6 @@ define('GlobalShortcuts.RenderKeys',
 						mustache: 'extensions/wikia/GlobalShortcuts/templates/KeyCombination2.mustache',
 						messages: 'GlobalShortcuts',
 						callback: function (pkg) {
-							mw.messages.set(pkg.messages);
 							templates.keyCombination = pkg.mustache[0];
 							dfd.resolve(templates);
 						}


### PR DESCRIPTION
Fix translations for header, footer and for 'or' and 'then' words
