### PR TITLE
SEO-252 Interwiki links sometimes add an extra "/Wiki/"

### DIFF
--- a/extensions/wikia/InterwikiDispatcher/SpecialInterwikiDispatcher_body.php
+++ b/extensions/wikia/InterwikiDispatcher/SpecialInterwikiDispatcher_body.php
@@ -128,7 +128,7 @@ class InterwikiDispatcher extends UnlistedSpecialPage {
 
 						//RT#54264,#41254
 						$sArticleTitle = str_replace(' ', '_', $sArticleTitle);
-						$sArticleTitle = urlencode($sArticleTitle);
+						$sArticleTitle = wfUrlencode($sArticleTitle);
 
 						$sCityUrl = self::getCityUrl($iCityId);
 						if (!empty($sCityUrl)) {

--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -339,6 +339,7 @@ function wfRandom() {
  * so no fancy : for IIS7.
  *
  * %2F in the page titles seems to fatally break for some reason.
+ * @see http://httpd.apache.org/docs/2.2/mod/core.html#allowencodedslashes
  *
  * @param $s String:
  * @return string

--- a/redirect-canonical.php
+++ b/redirect-canonical.php
@@ -17,51 +17,99 @@ use \Wikia\Logger\WikiaLogger;
 
 require_once( dirname( __FILE__ ) . '/includes/WebStart.php' );
 
-// Parse_url can technically parse just REQUEST_URI, but it doesn't work well
-// for URIs like Foo:100 which it understands as host: Foo, port: 100, no path
-// That's why we upgrade the URI to a full URL but prepending 'http://wikia.com/'
-// in front of it.
-$path = parse_url( 'http://wikia.com/' . $_SERVER['REQUEST_URI'], PHP_URL_PATH );
-$path = trim( rawurldecode( $path ), '/ _' );
 
-// Hack to better recover Mercury modular home pages URLs
-// (they are have double-encoded URLs for some reason)
-if ( startsWith( $path, 'main/' ) ) {
-	$path = rawurldecode( $path );
+/**
+ * Try to construct the MW title out of the given URL path.
+ *
+ * If unsuccessful return the title for the main page.
+ *
+ * @param $path
+ * @return Title
+ */
+function guessTitle( $path ) {
+	$path = trim( rawurldecode( $path ), '/ _' );
+
+	// Hack to better recover Mercury modular home pages URLs
+	// (they have double-encoded URLs for some reason)
+	if ( startsWith( $path, 'main/' ) ) {
+		$path = rawurldecode( $path );
+	}
+
+	$logContext = [
+		'ex' => new Exception(),
+		// To verify if Kibana trims the strings:
+		'uri' => $_SERVER['REQUEST_URI'],
+		'uriLen' => strlen( $_SERVER['REQUEST_URI'] ),
+	];
+
+	if ( !$path ) {
+		WikiaLogger::instance()->warning( '404 redirector: malformed URI', $logContext );
+	}
+
+	$path = str_replace( [ '%', '<', '>', '[', ']', '{', '}' ], '_', $path, $count );
+	if ( $count ) {
+		WikiaLogger::instance()->warning( '404 redirector: forbidden char in URI', $logContext );
+	}
+
+	$title = Title::newFromText( $path );
+
+	if ( !$title ) {
+		WikiaLogger::instance()->warning( '404 redirector: not a valid title in URI', $logContext );
+		$title = Title::newMainPage();
+	}
+
+	return $title;
 }
 
-if ( isset( $_SERVER['REDIRECT_QUERY_STRING'] ) ) {
-	// Called from Apache's ErrorHandler
-	$qs = $_SERVER['REDIRECT_QUERY_STRING'];
-} else {
-	// Called directly
-	$qs = $_SERVER['QUERY_STRING'];
+
+/**
+ * Read superglobal variables and return the URL to redirect to
+ *
+ * @return string
+ */
+function getTargetUrl() {
+	// Extract the URL path from the REQUEST_URI
+	$requestUri = $_SERVER['REQUEST_URI'];
+	if ( filter_var( $requestUri, FILTER_VALIDATE_URL ) ) {
+		// Possible when using proxies, like curl -x
+		$path = parse_url( $requestUri, PHP_URL_PATH );
+	} else {
+		// Upgrade the URI to a full URL to prevent URIs like Foo:111 being interpreted as host:port
+		$path = parse_url( 'http://wikia.com/' . $requestUri, PHP_URL_PATH );
+	}
+
+	// Strip the leading slashes
+	$path = ltrim( $path, '/' );
+
+	// Decide which URL to redirect to
+	if ( stripos( $path, '%2F' ) !== false ) {
+		// Called by Apache because there was "%2F" (an encoded slash) in the URL.
+		// @see http://httpd.apache.org/docs/2.2/mod/core.html#allowencodedslashes
+		$localUrl = '/' . str_ireplace( [ '%2F', '%3A' ], [ '/', ':' ], $path );
+		$url = wfExpandUrl( $localUrl, PROTO_CANONICAL );
+		header( 'X-Redirected-By: redirect-canonical.php (encoded slash)' );
+	} else {
+		// Called by Apache because the URL matched no rewrite rules
+		$title = guessTitle( $path );
+		$url = $title->getFullURL();
+		header( 'X-Redirected-By: redirect-canonical.php' );
+	}
+
+	// Preserve the query string
+	if ( isset( $_SERVER['REDIRECT_QUERY_STRING'] ) ) {
+		// Called from Apache's ErrorHandler
+		$qs = $_SERVER['REDIRECT_QUERY_STRING'];
+	} else {
+		// Called directly
+		$qs = $_SERVER['QUERY_STRING'];
+	}
+	$url = wfAppendQuery( $url, $qs );
+
+	return $url;
 }
 
-$logContext = [
-	'ex' => new Exception(),
-	// To verify if Kibana trims the strings:
-	'uri' => $_SERVER['REQUEST_URI'],
-	'uriLen' => strlen( $_SERVER['REQUEST_URI'] ),
-];
 
-if ( !$path ) {
-	WikiaLogger::instance()->warning( '404 redirector: malformed URI', $logContext );
-}
-
-$path = str_replace( [ '%', '<', '>', '[', ']', '{', '}' ], '_', $path, $count );
-if ( $count ) {
-	WikiaLogger::instance()->warning( '404 redirector: forbidden char in URI', $logContext );
-}
-
-$title = Title::newFromText( $path );
-
-if ( !$title ) {
-	WikiaLogger::instance()->warning( '404 redirector: not a valid title in URI', $logContext );
-	$title = Title::newMainPage();
-}
-
-$url = $title->getFullURL( $qs );
-
+// Issue the redirect
+$url = getTargetUrl();
 header( 'Location: ' . $url, 302 );
 echo sprintf( 'Moved to <a href="%s">%s</a>', htmlspecialchars( $url ), htmlspecialchars( $url ) );


### PR DESCRIPTION
The problematic part is the %2F in the URL. Apache treats that as an
incorrect URL
(http://httpd.apache.org/docs/2.2/mod/core.html#allowencodedslashes) and
fires the 404 handler. Before the changes the ErrorDocument was
index.php?title=Special:Our404Handler and the title was ignored if the
(URL-decoded) QUERY_STRING matched the MediaWiki $wgArticlePath.

With the updated code the 404 goes to the /redirect-canonical.php which
takes you to /wiki/(the-original-path). This code was not meant to
handle requests with /wiki/ in PATH.

We're fixing the redirect done in SpecialInterwikiDispatcher_body.php by
replacing the PHP's urlencode with MediaWiki's wfUrlencode, which
encodes fewer characters (for instance it leaves / and : intact).

Also we can extend the redirect-canonical.php to also work in the case
it's called as a broken-URL handler.

A comment mentioning the %2F breaks URLs was updated to point to the
Apache docs on AllowEncodedSlashes.

Redirect-canonical.php was also updated to output a X-Redirected-By
header (with a special version for %2F version) for easier debugging of
similar issues in the future.
