### PR TITLE
ADEN-2862 Move krux to Analytics Engine

### DIFF
--- a/extensions/wikia/AdEngine/js/run/desktop.run.js
+++ b/extensions/wikia/AdEngine/js/run/desktop.run.js
@@ -14,7 +14,6 @@ require([
 	'ext.wikia.adEngine.slotTracker',
 	'ext.wikia.adEngine.slotTweaker',
 	'ext.wikia.adEngine.sourcePointDetection',
-	'wikia.krux',
 	'wikia.window',
 	'wikia.loader',
 	require.optional('ext.wikia.adEngine.recovery.gcs')
@@ -32,15 +31,13 @@ require([
 	slotTracker,
 	slotTweaker,
 	sourcePoint,
-	krux,
 	win,
 	loader,
 	gcs
 ) {
 	'use strict';
 
-	var kruxSiteId = 'JU3_GW1b',
-		context = adContext.getContext(),
+	var context = adContext.getContext(),
 		skin = 'oasis';
 
 	win.AdEngine_getTrackerStats = slotTracker.getStats;
@@ -110,9 +107,6 @@ require([
 				});
 			});
 		}
-
-		// Krux
-		krux.load(kruxSiteId);
 	});
 });
 

--- a/extensions/wikia/AnalyticsEngine/AnalyticsEngine.php
+++ b/extensions/wikia/AnalyticsEngine/AnalyticsEngine.php
@@ -41,6 +41,8 @@ class AnalyticsEngine {
 				return new AnalyticsProviderExelate();
 			case 'GoogleUA':
 				return new AnalyticsProviderGoogleUA();
+			case 'Krux':
+				return new AnalyticsProviderKrux();
 			case 'AmazonMatch':
 				return new AnalyticsProviderAmazonMatch();
 			case 'Nielsen':

--- a/extensions/wikia/AnalyticsEngine/AnalyticsEngine.setup.php
+++ b/extensions/wikia/AnalyticsEngine/AnalyticsEngine.setup.php
@@ -19,6 +19,7 @@ $wgAutoloadClasses['AnalyticsProviderAmazonMatch'] = __DIR__ . '/AnalyticsProvid
 $wgAutoloadClasses['AnalyticsProviderDynamicYield'] = __DIR__ . '/AnalyticsProviderDynamicYield.php';
 $wgAutoloadClasses['AnalyticsProviderIVW2'] = __DIR__ . '/AnalyticsProviderIVW2.php';
 $wgAutoloadClasses['AnalyticsProviderIVW3'] = __DIR__ . '/AnalyticsProviderIVW3.php';
+$wgAutoloadClasses['AnalyticsProviderKrux'] = __DIR__ . '/AnalyticsProviderKrux.php';
 $wgAutoloadClasses['AnalyticsProviderBlueKai'] = __DIR__ . '/AnalyticsProviderBlueKai.php';
 $wgAutoloadClasses['AnalyticsProviderDatonics'] = __DIR__ . '/AnalyticsProviderDatonics.php';
 $wgAutoloadClasses['AnalyticsProviderNielsen'] = __DIR__ . '/AnalyticsProviderNielsen.php';

--- a/extensions/wikia/AnalyticsEngine/AnalyticsProviderKrux.php
+++ b/extensions/wikia/AnalyticsEngine/AnalyticsProviderKrux.php
@@ -1,0 +1,29 @@
+<?php
+
+class AnalyticsProviderKrux implements iAnalyticsProvider {
+
+	private static $siteId = 'JU3_GW1b';
+	private static $template = 'extensions/wikia/AnalyticsEngine/templates/krux.mustache';
+
+	function getSetupHtml( $params = array() ) {
+		return null;
+	}
+
+	function trackEvent( $event, $eventDetails = array() ) {
+		switch ($event) {
+			case AnalyticsEngine::EVENT_PAGEVIEW:
+				return $this->trackPageView();
+			default:
+				return '<!-- Unsupported event for Krux -->';
+		}
+	}
+
+	private function trackPageView() {
+		return \MustacheService::getInstance()->render(
+			self::$template,
+			[
+				'siteId' => self::$siteId
+			]
+		);
+	}
+}

--- a/extensions/wikia/AnalyticsEngine/templates/krux.mustache
+++ b/extensions/wikia/AnalyticsEngine/templates/krux.mustache
@@ -1,0 +1,7 @@
+<!-- Begin Krux Tag -->
+<script type="text/javascript">
+	require(['wikia.krux'], function (krux) {
+		krux.load('{{siteId}}');
+	});
+</script>
+<!-- End Krux Tag -->

--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -198,10 +198,13 @@ $config['adengine2_tracking_js'] = array(
 	'skin' => [ 'oasis', 'wikiamobile' ],
 	'assets' => array(
 		'//extensions/wikia/AdEngine/js/AdContext.js',
+		'//extensions/wikia/AdEngine/js/AdLogicPageParams.js',
+		'//extensions/wikia/AdEngine/js/AdLogicPageViewCounter.js',
 		'//extensions/wikia/AdEngine/js/AdTracker.js',
 		'//extensions/wikia/AdEngine/js/slot/adSlot.js',
 		'//extensions/wikia/AdEngine/js/utils/AdLogicZoneParams.js',
-		'//extensions/wikia/AdEngine/js/lookup/lookupFactory.js'
+		'//extensions/wikia/AdEngine/js/lookup/lookupFactory.js',
+		'//resources/wikia/modules/krux.js',
 	),
 );
 

--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -201,9 +201,9 @@ $config['adengine2_tracking_js'] = array(
 		'//extensions/wikia/AdEngine/js/AdLogicPageParams.js',
 		'//extensions/wikia/AdEngine/js/AdLogicPageViewCounter.js',
 		'//extensions/wikia/AdEngine/js/AdTracker.js',
+		'//extensions/wikia/AdEngine/js/lookup/lookupFactory.js',
 		'//extensions/wikia/AdEngine/js/slot/adSlot.js',
 		'//extensions/wikia/AdEngine/js/utils/AdLogicZoneParams.js',
-		'//extensions/wikia/AdEngine/js/lookup/lookupFactory.js',
 		'//resources/wikia/modules/krux.js',
 	),
 );

--- a/skins/oasis/modules/OasisController.class.php
+++ b/skins/oasis/modules/OasisController.class.php
@@ -47,6 +47,7 @@ class OasisController extends WikiaController {
 		$this->dynamicYield = null;
 		$this->ivw2 = null;
 		$this->ivw3 = null;
+		$this->krux = null;
 
 		wfProfileOut(__METHOD__);
 	}
@@ -236,6 +237,7 @@ class OasisController extends WikiaController {
 			$this->dynamicYield = AnalyticsEngine::track('DynamicYield', AnalyticsEngine::EVENT_PAGEVIEW);
 			$this->ivw2 = AnalyticsEngine::track('IVW2', AnalyticsEngine::EVENT_PAGEVIEW);
 			$this->ivw3 = AnalyticsEngine::track('IVW3', AnalyticsEngine::EVENT_PAGEVIEW);
+			$this->krux = AnalyticsEngine::track('Krux', AnalyticsEngine::EVENT_PAGEVIEW);
 		}
 
 		if (!empty($wgEnableAdminDashboardExt) && AdminDashboardLogic::displayAdminDashboard($this->app, $wgTitle)) {

--- a/skins/oasis/modules/templates/Oasis_Index.php
+++ b/skins/oasis/modules/templates/Oasis_Index.php
@@ -71,6 +71,7 @@
 <?= $amazonMatch ?>
 <?= $openXBidder ?>
 <?= $rubiconFastlane ?>
+<?= $krux ?>
 <?= $dynamicYield ?>
 <?= $ivw3 ?>
 <?= $ivw2 ?>


### PR DESCRIPTION
Call krux at the top of page (using Analytics Engine), but after bidders.
