### PR TITLE
VE-2124: Make sure to set $wgArticleAsJson back to false even if Exception is thrown

### DIFF
--- a/includes/wikia/api/ArticlesApiController.class.php
+++ b/includes/wikia/api/ArticlesApiController.class.php
@@ -1031,11 +1031,12 @@ class ArticlesApiController extends WikiaApiController {
 			} else {
 				$content = $articleContent->content;
 			}
+			$wgArticleAsJson = false;
 		} else {
+			$wgArticleAsJson = false;
 			throw new ArticleAsJsonParserException( 'Parser is currently not available' );
 		}
 
-		$wgArticleAsJson = false;
 		$categories = [];
 
 		foreach ( array_keys( $parsedArticle->getCategories() ) as $category ) {


### PR DESCRIPTION
ArticleApiController might be called via FauxRequest which does not separates scopes between caller and callee - so this potentially could affect caller scope.
