### PR TITLE
WIP Add test scaffolding for ExactTargetApi::sendRequest

### DIFF
--- a/extensions/wikia/ExactTargetUpdates/api/ExactTargetApi.php
+++ b/extensions/wikia/ExactTargetUpdates/api/ExactTargetApi.php
@@ -11,6 +11,9 @@ class ExactTargetApi {
 	/* @var ExactTargetSoapClient $client */
 	private $client;
 
+	/* @var \WikiaLogger $logger */
+	private $logger;
+
 	function __construct() {
 		$this->setupHelper();
 	}
@@ -114,11 +117,10 @@ class ExactTargetApi {
 	protected function sendRequest( $sType, $oRequestObject ) {
 		try {
 			$oResults = $this->getClient()->$sType( $oRequestObject );
-			WikiaLogger::instance()->info( $this->getClient()->__getLastResponse() );
+			$this->getLogger()->info( $this->getClient()->__getLastResponse() );
 			return $oResults;
 		} catch ( \SoapFault $e ) {
-			/* Log error */
-			WikiaLogger::instance()->error( __METHOD__ . "::{$sType} SoapFault: " . $e->getMessage() . ' ErrorCode:  ' . $e->getCode() );
+			$this->getLogger()->error( __METHOD__ . "::{$sType} SoapFault: " . $e->getMessage() . ' ErrorCode:  ' . $e->getCode() );
 			return false;
 		}
 	}
@@ -136,5 +138,23 @@ class ExactTargetApi {
 	 */
 	public function setClient(\ExactTargetSoapClient $client) {
 		$this->client = $client;
+	}
+
+	/**
+	 * @return WikiaLogger
+	 */
+	protected function getLogger() {
+		if ( !isset( $this->logger ) ) {
+			$this->logger = WikiaLogger::instance();
+		}
+
+		return $this->logger;
+	}
+
+	/**
+	 * @param WikiaLogger
+	 */
+	public function setLogger(WikiaLogger $logger) {
+		$this->logger = $logger;
 	}
 }

--- a/extensions/wikia/ExactTargetUpdates/api/ExactTargetApi.php
+++ b/extensions/wikia/ExactTargetUpdates/api/ExactTargetApi.php
@@ -120,7 +120,7 @@ class ExactTargetApi {
 			$this->getLogger()->info( $this->getClient()->__getLastResponse() );
 			return $oResults;
 		} catch ( \SoapFault $e ) {
-			$this->getLogger()->error( 'SUS-34-sendRequest-failure', [ 'exception' => $e] );
+			$this->getLogger()->error( __METHOD__, [ 'exception' => $e] );
 			return false;
 		}
 	}

--- a/extensions/wikia/ExactTargetUpdates/api/ExactTargetApi.php
+++ b/extensions/wikia/ExactTargetUpdates/api/ExactTargetApi.php
@@ -7,12 +7,12 @@ class ExactTargetApi {
 
 	/* @var ExactTargetApiHelper $helper */
 	protected $helper;
+
 	/* @var ExactTargetSoapClient $client */
-	protected $client;
+	private $client;
 
 	function __construct() {
 		$this->setupHelper();
-		$this->setupClient();
 	}
 
 	/**
@@ -113,13 +113,28 @@ class ExactTargetApi {
 	 */
 	protected function sendRequest( $sType, $oRequestObject ) {
 		try {
-			$oResults = $this->client->$sType( $oRequestObject );
-			WikiaLogger::instance()->info( $this->client->__getLastResponse() );
+			$oResults = $this->getClient()->$sType( $oRequestObject );
+			WikiaLogger::instance()->info( $this->getClient()->__getLastResponse() );
 			return $oResults;
-		} catch ( SoapFault $e ) {
+		} catch ( \SoapFault $e ) {
 			/* Log error */
 			WikiaLogger::instance()->error( __METHOD__ . "::{$sType} SoapFault: " . $e->getMessage() . ' ErrorCode:  ' . $e->getCode() );
 			return false;
 		}
+	}
+
+	/**
+	 * @return ExactTargetSoapClient
+	 */
+	protected function getClient() {
+		$this->setupClient();
+		return $this->client;
+	}
+
+	/**
+	 * @param \ExactTargetSoapClient $client
+	 */
+	public function setClient(\ExactTargetSoapClient $client) {
+		$this->client = $client;
 	}
 }

--- a/extensions/wikia/ExactTargetUpdates/api/ExactTargetApi.php
+++ b/extensions/wikia/ExactTargetUpdates/api/ExactTargetApi.php
@@ -120,7 +120,7 @@ class ExactTargetApi {
 			$this->getLogger()->info( $this->getClient()->__getLastResponse() );
 			return $oResults;
 		} catch ( \SoapFault $e ) {
-			$this->getLogger()->error( __METHOD__ . "::{$sType} SoapFault: " . $e->getMessage() . ' ErrorCode:  ' . $e->getCode() );
+			$this->getLogger()->error( 'SUS-34-sendRequest-failure', [ 'exception' => $e] );
 			return false;
 		}
 	}

--- a/extensions/wikia/ExactTargetUpdates/api/ExactTargetApi.php
+++ b/extensions/wikia/ExactTargetUpdates/api/ExactTargetApi.php
@@ -120,7 +120,7 @@ class ExactTargetApi {
 			$this->getLogger()->info( $this->getClient()->__getLastResponse() );
 			return $oResults;
 		} catch ( \SoapFault $e ) {
-			$this->getLogger()->error( __METHOD__, [ 'exception' => $e] );
+			$this->getLogger()->error( __METHOD__, [ 'exception' => $e ] );
 			return false;
 		}
 	}

--- a/extensions/wikia/ExactTargetUpdates/tests/ExactTargetApiTest.php
+++ b/extensions/wikia/ExactTargetUpdates/tests/ExactTargetApiTest.php
@@ -99,7 +99,7 @@ class ExactTargetApiTest extends WikiaBaseTest {
 		$mockLogger
 			->expects( $this->once() )
 			->method( 'error' )
-			->with( $this->matchesRegularExpression( "/.*SoapFault.*/") );
+			->with( 'Wikia\ExactTarget\ExactTargetApi::sendRequest' );
 
 
 		$api = new ExactTargetApiWrapper();

--- a/extensions/wikia/ExactTargetUpdates/tests/helpers/ExactTargetApiWrapper.php
+++ b/extensions/wikia/ExactTargetUpdates/tests/helpers/ExactTargetApiWrapper.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Wrapper for ExactTargetApi which does not export sendRequest. For testing
+ * purposes only.
+ */
+
+use Wikia\ExactTarget\ExactTargetApi;
+
+class ExactTargetApiWrapper extends ExactTargetApi {
+
+	public function sendRequest( $sType, $oRequestObject ) {
+		return parent::sendRequest( $sType, $oRequestObject );
+	}
+
+}


### PR DESCRIPTION
Work in progress to add test scaffolding for `ExactTargetApi::sendRequest`. It was discovered that the `sendRequest` method was not properly addressing the [`SoapFault`](https://github.com/Wikia/app/blob/dev/extensions/wikia/ExactTargetUpdates/api/ExactTargetApi.php#L119) exception which was rendering the `catch` a noop.

This PR adds test scaffolding to confirm the fix while also enabling additional testing for `sendRequest`. It should allow us to then move the [error handler](https://github.com/Wikia/app/blob/dev/extensions/wikia/ExactTargetUpdates/lib/ExactTargetSoapErrorHandler.php) logic closer to the source of the error.

https://wikia-inc.atlassian.net/browse/SUS-34

@Wikia/sustaining-team @kamilkoterba 
