### PR TITLE
MAIN-6319: move logEmailChanges hook to a global location

### DIFF
--- a/extensions/wikia/EditAccount/SpecialEditAccount.php
+++ b/extensions/wikia/EditAccount/SpecialEditAccount.php
@@ -42,9 +42,6 @@ $wgLogActions['editaccnt/realnamechange'] = 'editaccount-log-entry-realname';
 $wgLogActions['editaccnt/closeaccnt'] = 'editaccount-log-entry-close';
 $wgLogRestrictions['editaccnt'] = 'editaccount';
 
-// Log user email changes
-$wgHooks['BeforeUserSetEmail'][] = 'EditAccount::logEmailChanges';
-
 // Set up the new special page
 $wgExtensionMessagesFiles['EditAccount'] = __DIR__ . '/SpecialEditAccount.i18n.php';
 $wgAutoloadClasses['EditAccount'] = __DIR__ . '/SpecialEditAccount_body.php';

--- a/extensions/wikia/EditAccount/SpecialEditAccount_body.php
+++ b/extensions/wikia/EditAccount/SpecialEditAccount_body.php
@@ -530,23 +530,6 @@ class EditAccount extends SpecialPage {
 		return (wfGenerateToken() . $REQUIRED_CHARS);
 	}
 
-	/** Hook for storing historical log of email changes **/
-	public static function logEmailChanges($user, $new_email, $old_email) {
-		global $wgExternalSharedDB, $wgUser, $wgRequest;
-		if ( $wgExternalSharedDB && isset( $new_email ) && isset( $old_email ) ) {
-			$dbw = wfGetDB( DB_MASTER, array(), $wgExternalSharedDB );
-			$dbw->insert(
-				'user_email_log',
-				['user_id' => $user->getId(),
-				 'old_email' => $old_email,
-				 'new_email' => $new_email,
-				 'changed_by_id' => $wgUser->getId(),
-				 'changed_by_ip' => $wgRequest->getIP()		// stored as string
-				]);
-		}
-		return true;
-	}
-
 	public function displayLogData() {
 		global $wgExternalSharedDB, $wgOut, $wgRequest;
 


### PR DESCRIPTION
This hook was only installed where EditAccount was active (community wiki), but it should be global.

@Grunny 
