### PR TITLE
VideoPageToolAssetTest: make the integration test more reliable

### DIFF
--- a/extensions/wikia/VideoPageTool/tests/VideoPageToolAssetTest.php
+++ b/extensions/wikia/VideoPageTool/tests/VideoPageToolAssetTest.php
@@ -151,7 +151,7 @@ class VideoPageToolAssetTest extends WikiaBaseTest {
 		}
 
 		// Let slave catch up
-		sleep(1);
+		wfWaitForSlaves();
 
 		/**
 		 * Check loading the object from database


### PR DESCRIPTION
[SUS-118](https://wikia-inc.atlassian.net/browse/SUS-118)

Actually wait for DB slave to catch up so that `VideoPageToolAsset::newAsset` can load a row from slave node.

Use `wfWaitForSlaves()` instead of `sleep(1)`. When I wait for a bus it does not always take exactly 5 minutes ;)

@Wikia/sustaining-team 
