### PR TITLE
SEO-115 Favicon is missing on section redirects

### DIFF
--- a/skins/common/wikibits.js
+++ b/skins/common/wikibits.js
@@ -529,6 +529,12 @@ window.redirectToFragment = function( fragment ) {
 				if ( window.location.hash == fragment ) {
 					window.location.hash = fragment;
 				}
+
+				// Firefox also has a strange bug where it doesn't show the proper
+				// favicon when redirecting to sections because of the code above.
+				// Refreshing the link tag is enough to fix it surprisingly...
+				// @see https://wikia-inc.atlassian.net/browse/SEO-115
+				$( 'head' ).append( $( 'link[rel="shortcut icon"]' ) );
 			});
 		}
 	}


### PR DESCRIPTION
There seems to be an issue with Firefox handling of favicons in
combination with pdating the location.hash. "Reloading" the
`<link rel="shortcut icon">` seems enough to fix it
