### PR TITLE
VE-2126: Log VE<->Parsoid request duration and allow for switching caching off

### DIFF
--- a/extensions/VisualEditor/ApiVisualEditor.php
+++ b/extensions/VisualEditor/ApiVisualEditor.php
@@ -70,7 +70,14 @@ class ApiVisualEditor extends ApiBase {
 		) {
 			$req->setHeader( 'Cookie', $this->getRequest()->getHeader( 'Cookie' ) );
 		}
+
+		if ( $this->veConfig->get( 'VisualEditorNoCache' ) ) {
+			$req->setHeader( 'Cache-control', 'no-cache' );
+		}
+
+		$time_start = microtime(true);
 		$status = $req->execute();
+		$time_end = microtime(true);
 		if ( $status->isOK() ) {
 			// Pass thru performance data from Parsoid to the client, unless the response was
 			// served directly from Varnish, in  which case discard the value of the XPP header
@@ -88,7 +95,9 @@ class ApiVisualEditor extends ApiBase {
 			if ( $method === 'GET' ) {
 				\Wikia\Logger\WikiaLogger::instance()->info( 'ApiVisualEditor_requestParsoid', [
 					// sending string instead of boolean because our elasticsearch/kibana does not support the latter well
-					'hit' => $hit ? 'yes' : 'no'
+					'hit' => $hit ? 'yes' : 'no',
+					// we are interested in millisecond only (instead of microseconds)
+					'duration' => round ( ( $time_end - $time_start ) * 1000 )
 				] );
 			}
 

--- a/extensions/VisualEditor/wikia/VisualEditor.php
+++ b/extensions/VisualEditor/wikia/VisualEditor.php
@@ -261,6 +261,8 @@ $wgHooks['MakeGlobalVariablesScript'][] = 'VisualEditorWikiaHooks::onMakeGlobalV
 
 $wgDefaultUserOptions['useeditwarning'] = true;
 
+$wgVisualEditorNoCache = false;
+
 // Disable VE for blog namespaces
 if ( !empty( $wgEnableBlogArticles ) ) {
 	$tempArray = array();

--- a/extensions/VisualEditor/wikia/VisualEditor.php
+++ b/extensions/VisualEditor/wikia/VisualEditor.php
@@ -261,8 +261,6 @@ $wgHooks['MakeGlobalVariablesScript'][] = 'VisualEditorWikiaHooks::onMakeGlobalV
 
 $wgDefaultUserOptions['useeditwarning'] = true;
 
-$wgVisualEditorNoCache = false;
-
 // Disable VE for blog namespaces
 if ( !empty( $wgEnableBlogArticles ) ) {
 	$tempArray = array();


### PR DESCRIPTION
Switching caching off is needed just for our future experiment to find out if degraded performance is actually affecting our VE related metrics.
Having duration logged will let us verify that indeed performance is degraded.
