### PR TITLE
Helios Service Resolution and Cookie Deletion

### DIFF
--- a/includes/User.php
+++ b/includes/User.php
@@ -1151,14 +1151,14 @@ class User {
 		}
 
 		if ( !$this->isUserAuthenticatedViaAuthenticationService() ) {
-			global $wgAuthForceLogoutOnBadCredentials;
+			global $wgAuthForceLogoutOnFailedAuthSessionFallback;
 
 			/*
 			 * when failing over to Reston (readonly), users should be anonymous but their session
 			 * should resume without them having to do anything when we go back to r/w. See
 			 * SERVICES-1125
 			 */
-			if ( $wgAuthForceLogoutOnBadCredentials ) {
+			if ( $wgAuthForceLogoutOnFailedAuthSessionFallback ) {
 				$this->logFallbackToMediaWikiSessionRejection( $from );
 				$this->logout();
 			}

--- a/includes/User.php
+++ b/includes/User.php
@@ -1151,8 +1151,18 @@ class User {
 		}
 
 		if ( !$this->isUserAuthenticatedViaAuthenticationService() ) {
-			$this->logFallbackToMediaWikiSessionRejection( $from );
-			$this->logout();
+			global $wgAuthForceLogoutOnBadCredentials;
+
+			/*
+			 * when failing over to Reston (readonly), users should be anonymous but their session
+			 * should resume without them having to do anything when we go back to r/w. See
+			 * SERVICES-1125
+			 */
+			if ( $wgAuthForceLogoutOnBadCredentials ) {
+				$this->logFallbackToMediaWikiSessionRejection( $from );
+				$this->logout();
+			}
+
 			$this->loadDefaults();
 			return false;
 		}

--- a/lib/Wikia/src/Service/Helios/HeliosClientImpl.php
+++ b/lib/Wikia/src/Service/Helios/HeliosClientImpl.php
@@ -5,6 +5,7 @@ use Wikia\Util\GlobalStateWrapper;
 use Wikia\Service\Constants;
 
 /**
+ * @Injectable(lazy=true)
  * A client for Wikia authentication service.
  *
  * This is a naive implementation.

--- a/lib/Wikia/src/Service/User/Auth/AuthModule.php
+++ b/lib/Wikia/src/Service/User/Auth/AuthModule.php
@@ -2,8 +2,10 @@
 
 namespace Wikia\Service\User\Auth;
 
+use DI\Container;
 use Wikia\DependencyInjection\InjectorBuilder;
 use Wikia\DependencyInjection\Module;
+use Wikia\Service\Gateway\UrlProvider;
 use Wikia\Service\Helios\HeliosClient;
 use Wikia\Service\Helios\HeliosClientImpl;
 
@@ -14,17 +16,20 @@ class AuthModule implements Module {
 			->bind( AuthService::class )->toClass( MediaWikiAuthService::class )
 			->bind( HeliosClient::class )->toClass( HeliosClientImpl::class )
 			->bind( CookieHelper::class )->toClass( HeliosCookieHelper::class )
-			->bind( HeliosClientImpl::BASE_URI )->to( function () {
-				global $wgHeliosBaseUri;
-				return $wgHeliosBaseUri;
+			->bind( HeliosClientImpl::BASE_URI )->to( function ( Container $c ) {
+					global $wgAuthServiceName;
+
+					/** @var UrlProvider $urlProvider */
+					$urlProvider = $c->get(UrlProvider::class);
+					return "http://".$urlProvider->getUrl($wgAuthServiceName)."/";
 			} )
 			->bind( HeliosClientImpl::CLIENT_ID )->to( function () {
-				global $wgHeliosClientId;
-				return $wgHeliosClientId;
+					global $wgHeliosClientId;
+					return $wgHeliosClientId;
 			} )
 			->bind( HeliosClientImpl::CLIENT_SECRET )->to( function () {
-				global $wgHeliosClientSecret;
-				return $wgHeliosClientSecret;
+					global $wgHeliosClientSecret;
+					return $wgHeliosClientSecret;
 			} );
 	}
 }


### PR DESCRIPTION
@Wikia/services-team 
https://wikia-inc.atlassian.net/browse/SERVICES-1139

Change the DI container to resolve Helios the same way other services are resolved, rather than relying on a known host (`helios.service.consul`) and a known port. This allows us to use a different service more easily when failing over to Reston (the new `unavailable` service). There's a config change required for this, as well: Wikia/config#1600
