### PR TITLE
SUS-28 - More CR changes

### DIFF
--- a/extensions/wikia/Places/PlacesHooks.class.php
+++ b/extensions/wikia/Places/PlacesHooks.class.php
@@ -33,7 +33,7 @@ class PlacesHooks {
 						'href' => '#',
 						'text' => wfMessage( 'places-category-switch' )->escaped()
 					],
-					'class' =>  $commonClasses . (!$isGeotaggingEnabled ? $disabled : ''),
+					'class' =>  $commonClasses . ( !$isGeotaggingEnabled ? $disabled : '' ),
 					'name' => 'places-category-switch-on'
 				]
 			);

--- a/extensions/wikia/WikiaHubsV3/css/WikiaHubsV3.scss
+++ b/extensions/wikia/WikiaHubsV3/css/WikiaHubsV3.scss
@@ -23,6 +23,9 @@ $wikiahubs-line-height: 16px;
 }
 
 .page-header.hubs {
+	// set height so when the h1 is hidden it doesn't collapse
+	height: 34px;
+
 	.social-links {
 		float: right;
 		margin-right: 20px;
@@ -57,10 +60,7 @@ $wikiahubs-line-height: 16px;
 	}
 
 	h1 {
-		// making this display:none causes the bottom border to go above/across
-		// the social links because they're floated instead of using flex
-		// like the default page header
-		visibility: hidden;
+		display: none;
 	}
 }
 

--- a/skins/oasis/css/core/breakpoints-layout.scss
+++ b/skins/oasis/css/core/breakpoints-layout.scss
@@ -166,7 +166,7 @@
 				column-break-inside: avoid;
 
 				// fallback, because column-break-inside is currently NYI
-				display: inline-block;
+				display: table;
 				position: static;
 				width: 100%;
 

--- a/skins/oasis/css/modules/ContributeModule.scss
+++ b/skins/oasis/css/modules/ContributeModule.scss
@@ -1,18 +1,13 @@
 @import 'skins/shared/mixins/flexbox';
 
 .contribute-module {
-	@include align-content(stretch);
-	@include align-items(flex-start);
-	@include flex-direction(row);
-	@include flexbox;
-	@include flex-wrap(nowrap);
-	@include justify-content(flex-start);
+	.tally,
+	.buttons {
+		display: inline-block;
+	}
 
 	.tally {
-		@include align-self(flex-start);
-		@include flex(0 1 100%);
-		min-width: 0;
-		order: 0;
+		float: right;
 		white-space: nowrap;
 
 		em {
@@ -30,10 +25,6 @@
 	}
 
 	.buttons {
-		@include align-self(auto);
-		@include flex(0 0 auto);
-		order: 0;
-
 		.contribute {
 			vertical-align: middle;
 

--- a/skins/oasis/modules/BodyController.class.php
+++ b/skins/oasis/modules/BodyController.class.php
@@ -220,8 +220,6 @@ class BodyController extends WikiaController {
 
 		$railModuleList = [];
 
-		// temp location for testing
-		// @todo figure out where this should go
 		$railModuleList[1495] = [ 'Contribute', 'index', null ];
 
 		$latestActivityKey = $wg->User->isAnon() ? 1250 : 1300;


### PR DESCRIPTION
- Fix whitespace in PlacesHooks
- Set parent element height and display:none; h1 for hubs page header
- Remove completed TODO for contribute module positioning
- Fix contribute module using 2 lines at minimum width breakpoint
  - Also fix wikiactivity module splitting across multiple columns (tested in Chrome and FF).
