### PR TITLE
SUS-80: filter out "not fully uploaded" videos from getVideoList response

### DIFF
--- a/extensions/wikia/VideoHandlers/VideoHandlerController.class.php
+++ b/extensions/wikia/VideoHandlers/VideoHandlerController.class.php
@@ -6,6 +6,8 @@ use \Wikia\Logger\WikiaLogger;
  * Class VideoHandlerController
  */
 class VideoHandlerController extends WikiaController {
+	use Wikia\Logger\Loggable;
+
 	const DEFAULT_TEMPLATE_ENGINE = WikiaResponse::TEMPLATE_ENGINE_MUSTACHE;
 
 	const VIDEO_LIMIT = 100;
@@ -380,11 +382,24 @@ class VideoHandlerController extends WikiaController {
 						if ( !empty( $videoDetail ) ) {
 							$videoInfo = array_merge( $videoInfo, $videoDetail );
 						}
+						else {
+							/**
+							 * SUS-80: because of the way videos upload was fixed before SUS-66 was applied,
+							 * rows to "page" table were added, but the actual video was never uploaded (i.e. "image" table row was missing)
+							 */
+							$videoInfo = false;  // this entry will be removed by array_filter() below
+
+							$this->error( __METHOD__ . ' - getVideoDetail returned no results', [
+								'title' => $videoInfo['title'],
+							] );
+						}
 					}
 					unset( $videoInfo );
 				}
 
-				return $videoList;
+				// filter out items that provide no details (see the comment above)
+				// array_values helps us keep consecutive index values
+				return array_values( array_filter( $videoList ) );
 			},
 			$cacheOptions
 		);


### PR DESCRIPTION
[SUS-80](https://wikia-inc.atlassian.net/browse/SUS-80)

Because of the way videos upload was fixed before SUS-66 was applied (#9638), rows to `page` and `video_info` tables were added, but the actual video was never uploaded (i.e. `image` table row was missing).

@Wikia/sustaining-team 
