### PR TITLE
Fix <body> tag in Oasis

### DIFF
--- a/skins/oasis/modules/templates/Oasis_Index.php
+++ b/skins/oasis/modules/templates/Oasis_Index.php
@@ -61,7 +61,7 @@
 <?= $headItems ?>
 
 </head>
-<body class="<?= implode(' ', $bodyClasses) ?>"<?= $itemType ?>>
+<body class="<?= implode(' ', $bodyClasses) ?>" <?= $itemType ?>>
 <? if ( BodyController::isResponsiveLayoutEnabled() || BodyController::isOasisBreakpoints() ): ?>
 	<div class="background-image-gradient"></div>
 <? endif ?>


### PR DESCRIPTION
Fix for lack of space between `<body>` attributes eg.

```
<body class="mediawiki ltr ns-0 ns-subject page-Muppet_Wiki  oasis-one-column oasis-breakpoints wikinav2 notifications skin-oasis mainpage  user-logged background-fixed background-not-tiled background-dynamic"itemscope itemtype="http://schema.org/WebPage">
```

/cc @macbre 
