### PR TITLE
DAT-3624 Fix for broken references in infobox image captions

### DIFF
--- a/extensions/wikia/PortableInfobox/PortableInfobox.setup.php
+++ b/extensions/wikia/PortableInfobox/PortableInfobox.setup.php
@@ -43,7 +43,7 @@ foreach ( $wgInfoboxParserNodes as $parserNode ) {
 }
 
 // helpers
-$wgAutoloadClasses[ 'Wikia\PortableInfobox\Helpers\InfoboParamsValidator' ] = $dir . 'services/Helpers/InfoboParamsValidator.php';
+$wgAutoloadClasses[ 'Wikia\PortableInfobox\Helpers\InfoboxParamsValidator' ] = $dir . 'services/Helpers/InfoboxParamsValidator.php';
 $wgAutoloadClasses[ 'Wikia\PortableInfobox\Helpers\PortableInfoboxDataBag' ] = $dir . 'services/Helpers/PortableInfoboxDataBag.php';
 $wgAutoloadClasses[ 'Wikia\PortableInfobox\Helpers\PortableInfoboxRenderServiceHelper' ] = $dir . 'services/Helpers/PortableInfoboxRenderServiceHelper.php';
 $wgAutoloadClasses[ 'Wikia\PortableInfobox\Helpers\PortableInfoboxTemplatesHelper' ] = $dir . 'services/Helpers/PortableInfoboxTemplatesHelper.php';

--- a/extensions/wikia/PortableInfobox/controllers/PortableInfoboxParserTagController.class.php
+++ b/extensions/wikia/PortableInfobox/controllers/PortableInfoboxParserTagController.class.php
@@ -76,7 +76,7 @@ class PortableInfoboxParserTagController extends WikiaController {
 			$params = ( $infoboxNode instanceof Nodes\NodeInfobox ) ? $infoboxNode->getParams() : [ ];
 		}
 
-		$infoboxParamsValidator = new Wikia\PortableInfobox\Helpers\InfoboParamsValidator();
+		$infoboxParamsValidator = new Wikia\PortableInfobox\Helpers\InfoboxParamsValidator();
 		$infoboxParamsValidator->validateParams( $params );
 
 		$data = $infoboxNode->getRenderData();

--- a/extensions/wikia/PortableInfobox/services/Helpers/InfoboxParamsValidator.php
+++ b/extensions/wikia/PortableInfobox/services/Helpers/InfoboxParamsValidator.php
@@ -1,7 +1,7 @@
 <?php
 namespace Wikia\PortableInfobox\Helpers;
 
-class InfoboParamsValidator {
+class InfoboxParamsValidator {
 	private $supportedParams = [
 		'theme',
 		'theme-source',

--- a/extensions/wikia/PortableInfobox/tests/InfoboxParamsValidatorTest.php
+++ b/extensions/wikia/PortableInfobox/tests/InfoboxParamsValidatorTest.php
@@ -9,7 +9,7 @@ class InfoboxParamsValidatorTest extends WikiaBaseTest {
 		$this->setupFile = dirname( __FILE__ ) . '/../PortableInfobox.setup.php';
 		parent::setUp();
 
-		$this->InfoboxParamsValidator = new \Wikia\PortableInfobox\Helpers\InfoboParamsValidator();
+		$this->InfoboxParamsValidator = new \Wikia\PortableInfobox\Helpers\InfoboxParamsValidator();
 	}
 
 	/**

--- a/includes/wikia/parser/templatetypes/TemplateTypesParser.class.php
+++ b/includes/wikia/parser/templatetypes/TemplateTypesParser.class.php
@@ -73,10 +73,7 @@ class TemplateTypesParser {
 				$outputText = ScrollboxTemplate::getLongestElement( $templateArgs );
 			}
 
-			if ( ( $type === TemplateClassificationService::TEMPLATE_QUOTE
-				   || $type === TemplateClassificationService::TEMPLATE_QUOTE )
-				 && $wgEnableQuoteTemplateParsing
-			) {
+			if ( $type === TemplateClassificationService::TEMPLATE_QUOTE && $wgEnableQuoteTemplateParsing ) {
 				$templateArgs = TemplateArgsHelper::getTemplateArgs( $args, $frame );
 				$outputText = QuoteTemplate::execute( $templateArgs );
 			}

--- a/includes/wikia/parser/templatetypes/TemplateTypesParser.class.php
+++ b/includes/wikia/parser/templatetypes/TemplateTypesParser.class.php
@@ -67,9 +67,9 @@ class TemplateTypesParser {
 
 		if ( self::shouldTemplateBeParsed() && !is_null( $args ) ) {
 			$type = self::getTemplateType( $title );
-			$templateArgs = TemplateArgsHelper::getTemplateArgs( $args, $frame );
 
 			if ( $type === TemplateClassificationService::TEMPLATE_SCROLLBOX && $wgEnableScrollboxTemplateParsing ) {
+				$templateArgs = TemplateArgsHelper::getTemplateArgs( $args, $frame );
 				$outputText = ScrollboxTemplate::getLongestElement( $templateArgs );
 			}
 
@@ -77,6 +77,7 @@ class TemplateTypesParser {
 				   || $type === TemplateClassificationService::TEMPLATE_QUOTE )
 				 && $wgEnableQuoteTemplateParsing
 			) {
+				$templateArgs = TemplateArgsHelper::getTemplateArgs( $args, $frame );
 				$outputText = QuoteTemplate::execute( $templateArgs );
 			}
 		}


### PR DESCRIPTION
Since cite stores reference list in global state, do not parse template args when they are not needed.
Tests added in: https://github.com/Wikia/api-tests/pull/168
