### PR TITLE
ADEN-2894 Refactor success/hop flow and allow partner to collapse the slot 

### DIFF
--- a/extensions/wikia/AdEngine/InteractiveMaps/ads.js
+++ b/extensions/wikia/AdEngine/InteractiveMaps/ads.js
@@ -17,7 +17,7 @@ var ads = (function (window, document) {
 		});
 
 		define('ext.wikia.adEngine.provider.gpt.adDetect', function () {
-			function onAdLoad(slotname, gptEvent) {
+			function onAdLoad(slot, gptEvent) {
 				var parentIframeContainer,
 					height = gptEvent.size && gptEvent.size[1];
 

--- a/extensions/wikia/AdEngine/InteractiveMaps/ads.js
+++ b/extensions/wikia/AdEngine/InteractiveMaps/ads.js
@@ -17,7 +17,7 @@ var ads = (function (window, document) {
 		});
 
 		define('ext.wikia.adEngine.provider.gpt.adDetect', function () {
-			function onAdLoad(slot, gptEvent) {
+			function onAdLoad(slotname, gptEvent) {
 				var parentIframeContainer,
 					height = gptEvent.size && gptEvent.size[1];
 

--- a/extensions/wikia/AdEngine/js/AdEngine2.js
+++ b/extensions/wikia/AdEngine/js/AdEngine2.js
@@ -98,23 +98,23 @@ define('ext.wikia.adEngine.adEngine', [
 				slotElement = prepareAdProviderContainer(provider.name, slotName),
 				aSlotTracker = slotTracker(provider.name, slotName, queueName);
 
-			slot = adSlot.create(slotName, slotElement);
+			slot = adSlot.create(slotName, slotElement, {
+				success: function (adInfo) {
+					log(['success', provider.name, slotName, adInfo], 'debug', logGroup);
+					aSlotTracker.track('success', adInfo);
+				},
+				hop: function (adInfo) {
+					log(['hop', provider.name, slotName, adInfo], 'debug', logGroup);
+					aSlotTracker.track('hop', adInfo);
+					nextProvider();
+				}
+			});
 
 			// Notify people there's the slot handled
 			eventDispatcher.trigger('ext.wikia.adEngine fillInSlot', slotName, provider);
 
 			initializeProviderOnce(provider);
-
-			slot.post('success', function (extra) {
-				log(['success', provider.name, slotName, extra], 'debug', logGroup);
-				aSlotTracker.track('success', extra);
-			});
 			slot.post('success', queuedSlot.onSuccess);
-			slot.post('hop', function (extra) {
-				log(['hop', provider.name, slotName, extra], 'debug', logGroup);
-				aSlotTracker.track('hop', extra);
-				nextProvider();
-			});
 
 			provider.fillInSlotQueue.push([slot]);
 		}

--- a/extensions/wikia/AdEngine/js/AdEngine2.js
+++ b/extensions/wikia/AdEngine/js/AdEngine2.js
@@ -120,6 +120,10 @@ define('ext.wikia.adEngine.adEngine', [
 						log(['success', provider.name, slotName, adInfo], 'debug', logGroup);
 						tracker.track('success', adInfo);
 					},
+					collapse: function (adInfo) {
+						log(['collapse', provider.name, slotName, adInfo], 'debug', logGroup);
+						tracker.track('collapse', adInfo);
+					},
 					hop: function (adInfo) {
 						log(['hop', provider.name, slotName, adInfo], 'debug', logGroup);
 						tracker.track('hop', adInfo);
@@ -135,21 +139,21 @@ define('ext.wikia.adEngine.adEngine', [
 			provider.fillInSlotQueue.push([slot]);
 		}
 
-		function fillInSlot(queuedSlot) {
-			log(['fillInSlot', queuedSlot], 'debug', logGroup);
+		function fillInSlot(slot) {
+			log(['fillInSlot', slot], 'debug', logGroup);
 
-			var slotName = queuedSlot.slotName,
+			var slotName = slot.slotName,
 				providerList = adConfig.getProviderList(slotName).slice(); // Get a copy of the array
 
 			slotTweaker.show(slotName);
 
-			log(['fillInSlot', queuedSlot, 'provider list', JSON.stringify(providerList)], 'debug', logGroup);
+			log(['fillInSlot', slot, 'provider list', JSON.stringify(providerList)], 'debug', logGroup);
 
 			function handleNoAd() {
-				log(['handleNoAd', queuedSlot], 'debug', logGroup);
+				log(['handleNoAd', slot], 'debug', logGroup);
 				slotTweaker.hide(slotName);
-				if (typeof queuedSlot.onError === 'function') {
-					queuedSlot.onError(queuedSlot);
+				if (typeof slot.onError === 'function') {
+					slot.onError(slot);
 				}
 			}
 
@@ -165,11 +169,11 @@ define('ext.wikia.adEngine.adEngine', [
 					}
 
 					if (provider.canHandleSlot(slotName)) {
-						fillInSlotUsingProvider(queuedSlot, provider, nextProvider);
+						fillInSlotUsingProvider(slot, provider, nextProvider);
 						return;
 					}
 
-					log(['fillInSlot', queuedSlot, 'skipping provider, cannot handle slot', provider], 'debug', logGroup);
+					log(['fillInSlot', slot, 'skipping provider, cannot handle slot', provider], 'debug', logGroup);
 				} while (provider);
 			}
 

--- a/extensions/wikia/AdEngine/js/AdEngine2.js
+++ b/extensions/wikia/AdEngine/js/AdEngine2.js
@@ -98,8 +98,8 @@ define('ext.wikia.adEngine.adEngine', [
 		}
 	}
 
-	function createSlot(queuedSlot, slotElement, callbacks) {
-		var slot = adSlot.create(queuedSlot.slotName, slotElement, callbacks);
+	function createSlot(queuedSlot, container, callbacks) {
+		var slot = adSlot.create(queuedSlot.slotName, container, callbacks);
 		registerHooks(slot, ['success', 'collapse', 'hop']);
 		slot.post('success', queuedSlot.onSuccess);
 

--- a/extensions/wikia/AdEngine/js/AdEngine2.js
+++ b/extensions/wikia/AdEngine/js/AdEngine2.js
@@ -112,22 +112,20 @@ define('ext.wikia.adEngine.adEngine', [
 		function fillInSlotUsingProvider(queuedSlot, provider, nextProvider) {
 			log(['fillInSlotUsingProvider', provider.name, queuedSlot], 'debug', logGroup);
 
-			var slot,
-				slotName = queuedSlot.slotName,
-				slotElement = prepareAdProviderContainer(provider.name, slotName),
-				aSlotTracker = slotTracker(provider.name, slotName, queueName);
-
-			slot = createSlot(queuedSlot, slotElement, {
-				success: function (adInfo) {
-					log(['success', provider.name, slotName, adInfo], 'debug', logGroup);
-					aSlotTracker.track('success', adInfo);
-				},
-				hop: function (adInfo) {
-					log(['hop', provider.name, slotName, adInfo], 'debug', logGroup);
-					aSlotTracker.track('hop', adInfo);
-					nextProvider();
-				}
-			});
+			var slotName = queuedSlot.slotName,
+				container = prepareAdProviderContainer(provider.name, slotName),
+				tracker = slotTracker(provider.name, slotName, queueName),
+				slot = createSlot(queuedSlot, container, {
+					success: function (adInfo) {
+						log(['success', provider.name, slotName, adInfo], 'debug', logGroup);
+						tracker.track('success', adInfo);
+					},
+					hop: function (adInfo) {
+						log(['hop', provider.name, slotName, adInfo], 'debug', logGroup);
+						tracker.track('hop', adInfo);
+						nextProvider();
+					}
+				});
 
 			// Notify people there's the slot handled
 			eventDispatcher.trigger('ext.wikia.adEngine fillInSlot', slotName, provider);

--- a/extensions/wikia/AdEngine/js/provider/directGpt.js
+++ b/extensions/wikia/AdEngine/js/provider/directGpt.js
@@ -75,7 +75,7 @@ define('ext.wikia.adEngine.provider.directGpt', [
 		provider;
 
 	function fillInSlotWithDelay(slot) {
-		log(['fillInSlotWithDelay', slot.getName()], 'debug', logGroup);
+		log(['fillInSlotWithDelay', slot.name], 'debug', logGroup);
 
 		if (!context.opts.delayBtf) {
 			provider.fillInSlot(slot);
@@ -83,8 +83,8 @@ define('ext.wikia.adEngine.provider.directGpt', [
 		}
 
 		// For the above the fold slot:
-		if (atfSlots.indexOf(slot.getName()) > -1) {
-			pendingAtfSlots.push(slot.getName());
+		if (atfSlots.indexOf(slot.name) > -1) {
+			pendingAtfSlots.push(slot.name);
 			provider.fillInSlot(slot);
 			return;
 		}
@@ -94,7 +94,7 @@ define('ext.wikia.adEngine.provider.directGpt', [
 	}
 
 	function processBtfSlot(slot) {
-		log(['processBtfSlot', slot.getName()], 'debug', logGroup);
+		log(['processBtfSlot', slot.name], 'debug', logGroup);
 
 		if (!win.ads.runtime.disableBtf) {
 			provider.fillInSlot(slot);
@@ -102,7 +102,7 @@ define('ext.wikia.adEngine.provider.directGpt', [
 		}
 
 		slot.success({adType: 'blocked'});
-		slotTweaker.hide(slot.getName());
+		slotTweaker.hide(slot.name);
 	}
 
 	function startBtfQueue() {

--- a/extensions/wikia/AdEngine/js/provider/directGpt.js
+++ b/extensions/wikia/AdEngine/js/provider/directGpt.js
@@ -74,40 +74,35 @@ define('ext.wikia.adEngine.provider.directGpt', [
 		],
 		provider;
 
-	function fillInSlotWithDelay(slotName, slotElement, success, hop) {
-		log(['fillInSlotWithDelay', slotName], 'debug', logGroup);
+	function fillInSlotWithDelay(slot) {
+		log(['fillInSlotWithDelay', slot.getName()], 'debug', logGroup);
 
 		if (!context.opts.delayBtf) {
-			provider.fillInSlot(slotName, slotElement, success, hop);
+			provider.fillInSlot(slot);
 			return;
 		}
 
 		// For the above the fold slot:
-		if (atfSlots.indexOf(slotName) > -1) {
-			pendingAtfSlots.push(slotName);
-			provider.fillInSlot(slotName, slotElement, success, hop);
+		if (atfSlots.indexOf(slot.getName()) > -1) {
+			pendingAtfSlots.push(slot.getName());
+			provider.fillInSlot(slot);
 			return;
 		}
 
 		// For the below the fold slot:
-		btfQueue.push({
-			slotName: slotName,
-			slotElement: slotElement,
-			success: success,
-			hop: hop
-		});
+		btfQueue.push(slot);
 	}
 
 	function processBtfSlot(slot) {
-		log(['processBtfSlot', slot.slotName], 'debug', logGroup);
+		log(['processBtfSlot', slot.getName()], 'debug', logGroup);
 
 		if (!win.ads.runtime.disableBtf) {
-			provider.fillInSlot(slot.slotName, slot.slotElement, slot.success, slot.hop);
+			provider.fillInSlot(slot);
 			return;
 		}
 
 		slot.success({adType: 'blocked'});
-		slotTweaker.hide(slot.slotName);
+		slotTweaker.hide(slot.getName());
 	}
 
 	function startBtfQueue() {

--- a/extensions/wikia/AdEngine/js/provider/evolve.js
+++ b/extensions/wikia/AdEngine/js/provider/evolve.js
@@ -122,17 +122,18 @@ define('ext.wikia.adEngine.provider.evolve', [
 		hoppedSlots[sanitizeSlotname(slotname)] = true;
 	}
 
-	function fillInSlot(slotName, slotElement, pSuccess, pHop) {
-		log(['fillInSlot', slotName, slotElement], 5, logGroup);
+	function fillInSlot(slot) {
+		var slotName = slot.getName();
+		log(['fillInSlot', slotName], 5, logGroup);
 
 		if (slotName === slotForSkin) {
 			scriptWriter.injectScriptByUrl(
-				slotElement,
+				slot.getElement(),
 				'http://cdn.triggertag.gorillanation.com/js/triggertag.js',
 				function () {
 					log('(invisible triggertag) ghostwriter done', 5, logGroup);
 
-					scriptWriter.injectScriptByText(slotElement, getReskinAndSilverScript(slotName), function () {
+					scriptWriter.injectScriptByText(slot.getElement(), getReskinAndSilverScript(slotName), function () {
 						// gorrilla skin is suppressed by body.mediawiki !important so make it !important too
 						if (document.body.style.backgroundImage.search(/http:\/\/cdn\.assets\.gorillanation\.com/) !== -1) {
 							document.body.style.cssText = document.body.style.cssText.replace(document.body.style.backgroundImage, document.body.style.backgroundImage + ' !important');
@@ -140,18 +141,18 @@ define('ext.wikia.adEngine.provider.evolve', [
 						}
 
 						if (hoppedSlots[slotName]) {
-							pHop({method: 'hop'});
+							slot.hop({method: 'hop'});
 							return;
 						}
 
-						pSuccess();
+						slot.success();
 					});
 				}
 			);
 		} else {
-			scriptWriter.injectScriptByUrl(slotElement, getUrl(slotName), function () {
+			scriptWriter.injectScriptByUrl(slot.getElement(), getUrl(slotName), function () {
 				if (hoppedSlots[slotName]) {
-					pHop({method: 'hop'});
+					slot.hop({method: 'hop'});
 					return;
 				}
 
@@ -161,15 +162,15 @@ define('ext.wikia.adEngine.provider.evolve', [
 				slotTweaker.removeTopButtonIfNeeded(slotName);
 				slotTweaker.adjustLeaderboardSize(slotName);
 
-				pSuccess();
+				slot.success();
 			});
 		}
 	}
 
-	function canHandleSlot(slotname) {
-		log(['canHandleSlot', slotname], 5, logGroup);
+	function canHandleSlot(slotName) {
+		log(['canHandleSlot', slotName], 5, logGroup);
 
-		return evolveSlotConfig.canHandleSlot(slotname);
+		return evolveSlotConfig.canHandleSlot(slotName);
 	}
 
 	iface = {

--- a/extensions/wikia/AdEngine/js/provider/evolve.js
+++ b/extensions/wikia/AdEngine/js/provider/evolve.js
@@ -123,25 +123,23 @@ define('ext.wikia.adEngine.provider.evolve', [
 	}
 
 	function fillInSlot(slot) {
-		var container = slot.getContainer(),
-			slotName = slot.getName();
-		log(['fillInSlot', slotName], 5, logGroup);
+		log(['fillInSlot', slot.name], 5, logGroup);
 
-		if (slotName === slotForSkin) {
+		if (slot.name === slotForSkin) {
 			scriptWriter.injectScriptByUrl(
-				container,
+				slot.container,
 				'http://cdn.triggertag.gorillanation.com/js/triggertag.js',
 				function () {
 					log('(invisible triggertag) ghostwriter done', 5, logGroup);
 
-					scriptWriter.injectScriptByText(container, getReskinAndSilverScript(slotName), function () {
+					scriptWriter.injectScriptByText(slot.container, getReskinAndSilverScript(slot.name), function () {
 						// gorrilla skin is suppressed by body.mediawiki !important so make it !important too
 						if (document.body.style.backgroundImage.search(/http:\/\/cdn\.assets\.gorillanation\.com/) !== -1) {
 							document.body.style.cssText = document.body.style.cssText.replace(document.body.style.backgroundImage, document.body.style.backgroundImage + ' !important');
 							document.body.style.cssText = document.body.style.cssText.replace(document.body.style.backgroundColor, document.body.style.backgroundColor + ' !important');
 						}
 
-						if (hoppedSlots[slotName]) {
+						if (hoppedSlots[slot.name]) {
 							slot.hop({method: 'hop'});
 							return;
 						}
@@ -151,17 +149,17 @@ define('ext.wikia.adEngine.provider.evolve', [
 				}
 			);
 		} else {
-			scriptWriter.injectScriptByUrl(container, getUrl(slotName), function () {
-				if (hoppedSlots[slotName]) {
+			scriptWriter.injectScriptByUrl(slot.container, getUrl(slot.name), function () {
+				if (hoppedSlots[slot.name]) {
 					slot.hop({method: 'hop'});
 					return;
 				}
 
 				// Success
 				// TODO: find a better place for operation below
-				slotTweaker.removeDefaultHeight(slotName);
-				slotTweaker.removeTopButtonIfNeeded(slotName);
-				slotTweaker.adjustLeaderboardSize(slotName);
+				slotTweaker.removeDefaultHeight(slot.name);
+				slotTweaker.removeTopButtonIfNeeded(slot.name);
+				slotTweaker.adjustLeaderboardSize(slot.name);
 
 				slot.success();
 			});

--- a/extensions/wikia/AdEngine/js/provider/evolve.js
+++ b/extensions/wikia/AdEngine/js/provider/evolve.js
@@ -123,17 +123,18 @@ define('ext.wikia.adEngine.provider.evolve', [
 	}
 
 	function fillInSlot(slot) {
-		var slotName = slot.getName();
+		var container = slot.getContainer(),
+			slotName = slot.getName();
 		log(['fillInSlot', slotName], 5, logGroup);
 
 		if (slotName === slotForSkin) {
 			scriptWriter.injectScriptByUrl(
-				slot.getElement(),
+				container,
 				'http://cdn.triggertag.gorillanation.com/js/triggertag.js',
 				function () {
 					log('(invisible triggertag) ghostwriter done', 5, logGroup);
 
-					scriptWriter.injectScriptByText(slot.getElement(), getReskinAndSilverScript(slotName), function () {
+					scriptWriter.injectScriptByText(container, getReskinAndSilverScript(slotName), function () {
 						// gorrilla skin is suppressed by body.mediawiki !important so make it !important too
 						if (document.body.style.backgroundImage.search(/http:\/\/cdn\.assets\.gorillanation\.com/) !== -1) {
 							document.body.style.cssText = document.body.style.cssText.replace(document.body.style.backgroundImage, document.body.style.backgroundImage + ' !important');
@@ -150,7 +151,7 @@ define('ext.wikia.adEngine.provider.evolve', [
 				}
 			);
 		} else {
-			scriptWriter.injectScriptByUrl(slot.getElement(), getUrl(slotName), function () {
+			scriptWriter.injectScriptByUrl(container, getUrl(slotName), function () {
 				if (hoppedSlots[slotName]) {
 					slot.hop({method: 'hop'});
 					return;

--- a/extensions/wikia/AdEngine/js/provider/evolve2.js
+++ b/extensions/wikia/AdEngine/js/provider/evolve2.js
@@ -74,32 +74,30 @@ define('ext.wikia.adEngine.provider.evolve2', [
 		return ret;
 	}
 
-	function fillInSlot(slotName, slotElement, success, hop) {
-		log(['fillInSlot', slotName, slotElement, success, hop], 'debug', logGroup);
+	function fillInSlot(slot) {
+		log(['fillInSlot', slot.getName()], 'debug', logGroup);
 		var section = getSection(),
-			slotCopy = JSON.parse(JSON.stringify(slotMap[slotName]));
+			slotCopy = JSON.parse(JSON.stringify(slotMap[slot.getName()]));
 
 		slotCopy.sect = section;
 		setTargeting(slotCopy);
+		slot.pre('success', function () {
+			var slotName = slot.getName();
+
+			slotTweaker.removeDefaultHeight(slotName);
+			slotTweaker.removeTopButtonIfNeeded(slotName);
+			slotTweaker.adjustLeaderboardSize(slotName);
+		});
 		gptHelper.pushAd(
-			slotName,
-			slotElement,
-			'/4403/ev/' + site + '/' + section + '/' + slotName,
+			slot,
+			'/4403/ev/' + site + '/' + section + '/' + slot.getName(),
 			slotCopy,
 			{
-				success: function (adInfo) {
-					slotTweaker.removeDefaultHeight(slotName);
-					slotTweaker.removeTopButtonIfNeeded(slotName);
-					slotTweaker.adjustLeaderboardSize(slotName);
-
-					success(adInfo);
-				},
-				error: hop,
 				forcedAdType: 'evolve2'
 			}
 		);
 
-		log(['fillInSlot', slotName, slotElement, success, hop, 'done'], 'debug', logGroup);
+		log(['fillInSlot', slot.getName(), 'done'], 'debug', logGroup);
 	}
 
 	return {

--- a/extensions/wikia/AdEngine/js/provider/evolve2.js
+++ b/extensions/wikia/AdEngine/js/provider/evolve2.js
@@ -75,14 +75,14 @@ define('ext.wikia.adEngine.provider.evolve2', [
 	}
 
 	function fillInSlot(slot) {
-		log(['fillInSlot', slot.getName()], 'debug', logGroup);
+		log(['fillInSlot', slot.name], 'debug', logGroup);
 		var section = getSection(),
-			slotCopy = JSON.parse(JSON.stringify(slotMap[slot.getName()]));
+			slotCopy = JSON.parse(JSON.stringify(slotMap[slot.name]));
 
 		slotCopy.sect = section;
 		setTargeting(slotCopy);
 		slot.pre('success', function () {
-			var slotName = slot.getName();
+			var slotName = slot.name;
 
 			slotTweaker.removeDefaultHeight(slotName);
 			slotTweaker.removeTopButtonIfNeeded(slotName);
@@ -90,14 +90,14 @@ define('ext.wikia.adEngine.provider.evolve2', [
 		});
 		gptHelper.pushAd(
 			slot,
-			'/4403/ev/' + site + '/' + section + '/' + slot.getName(),
+			'/4403/ev/' + site + '/' + section + '/' + slot.name,
 			slotCopy,
 			{
 				forcedAdType: 'evolve2'
 			}
 		);
 
-		log(['fillInSlot', slot.getName(), 'done'], 'debug', logGroup);
+		log(['fillInSlot', slot.name, 'done'], 'debug', logGroup);
 	}
 
 	return {

--- a/extensions/wikia/AdEngine/js/provider/evolve2.js
+++ b/extensions/wikia/AdEngine/js/provider/evolve2.js
@@ -82,11 +82,9 @@ define('ext.wikia.adEngine.provider.evolve2', [
 		slotCopy.sect = section;
 		setTargeting(slotCopy);
 		slot.pre('success', function () {
-			var slotName = slot.name;
-
-			slotTweaker.removeDefaultHeight(slotName);
-			slotTweaker.removeTopButtonIfNeeded(slotName);
-			slotTweaker.adjustLeaderboardSize(slotName);
+			slotTweaker.removeDefaultHeight(slot.name);
+			slotTweaker.removeTopButtonIfNeeded(slot.name);
+			slotTweaker.adjustLeaderboardSize(slot.name);
 		});
 		gptHelper.pushAd(
 			slot,

--- a/extensions/wikia/AdEngine/js/provider/factoryWikiaGpt.js
+++ b/extensions/wikia/AdEngine/js/provider/factoryWikiaGpt.js
@@ -50,11 +50,7 @@ define('ext.wikia.adEngine.provider.factory.wikiaGpt', [
 		function fillInSlot(slot) {
 			log(['fillInSlot', slot.name], 'debug', logGroup);
 
-			var extraParams = {
-					sraEnabled: extra.sraEnabled,
-					recoverableSlots: extra.recoverableSlots
-				},
-				pageParams = adLogicPageParams.getPageLevelParams(),
+			var pageParams = adLogicPageParams.getPageLevelParams(),
 				slotTargeting = JSON.parse(JSON.stringify(slotMap[slot.name])), // copy value
 				slotPath = [
 					'/5441', 'wka.' + pageParams.s0, pageParams.s1, '', pageParams.s2, src, slot.name
@@ -78,7 +74,10 @@ define('ext.wikia.adEngine.provider.factory.wikiaGpt', [
 				lookups.extendSlotTargeting(slot.name, slotTargeting, providerName);
 			}
 
-			gptHelper.pushAd(slot, slotPath, slotTargeting, extraParams);
+			gptHelper.pushAd(slot, slotPath, slotTargeting, {
+				sraEnabled: extra.sraEnabled,
+				recoverableSlots: extra.recoverableSlots
+			});
 			log(['fillInSlot', slot.name, 'done'], 'debug', logGroup);
 		}
 

--- a/extensions/wikia/AdEngine/js/provider/factoryWikiaGpt.js
+++ b/extensions/wikia/AdEngine/js/provider/factoryWikiaGpt.js
@@ -47,32 +47,30 @@ define('ext.wikia.adEngine.provider.factory.wikiaGpt', [
 			return ret;
 		}
 
-		function fillInSlot(slotName, slotElement, success, hop) {
-			log(['fillInSlot', slotName, slotElement, success, hop], 'debug', logGroup);
+		function fillInSlot(slot) {
+			log(['fillInSlot', slot.getName()], 'debug', logGroup);
 
 			var extraParams = {
 					sraEnabled: extra.sraEnabled,
 					recoverableSlots: extra.recoverableSlots
 				},
 				pageParams = adLogicPageParams.getPageLevelParams(),
-				slotTargeting = JSON.parse(JSON.stringify(slotMap[slotName])), // copy value
+				slotName = slot.getName(),
+				slotTargeting = JSON.parse(JSON.stringify(slotMap[slot.getName()])), // copy value
 				slotPath = [
 					'/5441', 'wka.' + pageParams.s0, pageParams.s1, '', pageParams.s2, src, slotName
 				].join('/');
 
-			extraParams.success = function (adInfo) {
+			slot.pre('success', function (adInfo) {
 				if (typeof extra.beforeSuccess === 'function') {
 					extra.beforeSuccess(slotName, adInfo);
 				}
-				success(adInfo);
-			};
-
-			extraParams.error = function (adInfo) {
+			});
+			slot.pre('hop', function (adInfo) {
 				if (typeof extra.beforeHop === 'function') {
 					extra.beforeHop(slotName, adInfo);
 				}
-				hop(adInfo);
-			};
+			});
 
 			slotTargeting.pos = slotTargeting.pos || slotName;
 			slotTargeting.src = src;
@@ -81,8 +79,8 @@ define('ext.wikia.adEngine.provider.factory.wikiaGpt', [
 				lookups.extendSlotTargeting(slotName, slotTargeting, providerName);
 			}
 
-			gptHelper.pushAd(slotName, slotElement, slotPath, slotTargeting, extraParams);
-			log(['fillInSlot', slotName, success, hop, 'done'], 'debug', logGroup);
+			gptHelper.pushAd(slot, slotPath, slotTargeting, extraParams);
+			log(['fillInSlot', slotName, 'done'], 'debug', logGroup);
 		}
 
 		return {

--- a/extensions/wikia/AdEngine/js/provider/factoryWikiaGpt.js
+++ b/extensions/wikia/AdEngine/js/provider/factoryWikiaGpt.js
@@ -48,39 +48,38 @@ define('ext.wikia.adEngine.provider.factory.wikiaGpt', [
 		}
 
 		function fillInSlot(slot) {
-			log(['fillInSlot', slot.getName()], 'debug', logGroup);
+			log(['fillInSlot', slot.name], 'debug', logGroup);
 
 			var extraParams = {
 					sraEnabled: extra.sraEnabled,
 					recoverableSlots: extra.recoverableSlots
 				},
 				pageParams = adLogicPageParams.getPageLevelParams(),
-				slotName = slot.getName(),
-				slotTargeting = JSON.parse(JSON.stringify(slotMap[slot.getName()])), // copy value
+				slotTargeting = JSON.parse(JSON.stringify(slotMap[slot.name])), // copy value
 				slotPath = [
-					'/5441', 'wka.' + pageParams.s0, pageParams.s1, '', pageParams.s2, src, slotName
+					'/5441', 'wka.' + pageParams.s0, pageParams.s1, '', pageParams.s2, src, slot.name
 				].join('/');
 
 			slot.pre('success', function (adInfo) {
 				if (typeof extra.beforeSuccess === 'function') {
-					extra.beforeSuccess(slotName, adInfo);
+					extra.beforeSuccess(slot.name, adInfo);
 				}
 			});
 			slot.pre('hop', function (adInfo) {
 				if (typeof extra.beforeHop === 'function') {
-					extra.beforeHop(slotName, adInfo);
+					extra.beforeHop(slot.name, adInfo);
 				}
 			});
 
-			slotTargeting.pos = slotTargeting.pos || slotName;
+			slotTargeting.pos = slotTargeting.pos || slot.name;
 			slotTargeting.src = src;
 
 			if (lookups) {
-				lookups.extendSlotTargeting(slotName, slotTargeting, providerName);
+				lookups.extendSlotTargeting(slot.name, slotTargeting, providerName);
 			}
 
 			gptHelper.pushAd(slot, slotPath, slotTargeting, extraParams);
-			log(['fillInSlot', slotName, 'done'], 'debug', logGroup);
+			log(['fillInSlot', slot.name, 'done'], 'debug', logGroup);
 		}
 
 		return {

--- a/extensions/wikia/AdEngine/js/provider/gpt/adDetect.js
+++ b/extensions/wikia/AdEngine/js/provider/gpt/adDetect.js
@@ -150,9 +150,10 @@ define('ext.wikia.adEngine.provider.gpt.adDetect', [
 		return 'inspect_iframe';
 	}
 
-	function onAdLoad(slotName, gptEvent, iframe, slot, forcedAdType) {
+	function onAdLoad(slot, gptEvent, iframe, forcedAdType) {
 
-		var adType = forcedAdType || getAdType(slotName, gptEvent, iframe),
+		var slotName = slot.getName(),
+			adType = forcedAdType || getAdType(slotName, gptEvent, iframe),
 			shouldPollForSuccess = false,
 			expectAsyncHop = false,
 			expectAsyncHopWithSlotName = false,

--- a/extensions/wikia/AdEngine/js/provider/gpt/adDetect.js
+++ b/extensions/wikia/AdEngine/js/provider/gpt/adDetect.js
@@ -152,15 +152,13 @@ define('ext.wikia.adEngine.provider.gpt.adDetect', [
 
 	function onAdLoad(slot, gptEvent, iframe, forcedAdType) {
 
-		var slotName = slot.getName(),
-			adType = forcedAdType || getAdType(slotName, gptEvent, iframe),
+		var adType = forcedAdType || getAdType(slot.name, gptEvent, iframe),
 			shouldPollForSuccess = false,
 			expectAsyncHop = false,
 			expectAsyncHopWithSlotName = false,
 			expectAsyncSuccessWithSlotName = false,
 			expectAsyncSuccess = false,
-			successTimer,
-			shortSlotName = adSlot.getShortSlotName(slotName);
+			successTimer;
 
 		function noop() { return; }
 
@@ -179,21 +177,21 @@ define('ext.wikia.adEngine.provider.gpt.adDetect', [
 
 		function pollForSuccess() {
 			successTimer = setTimeout(function () {
-				log(['pollForSuccess', slotName], 'info', logGroup);
+				log(['pollForSuccess', slot.name], 'info', logGroup);
 				pollForSuccess();
-				findAdInIframe(slotName + ' (poll)', iframe, slot.success, noop);
+				findAdInIframe(slot.name + ' (poll)', iframe, slot.success, noop);
 			}, 500);
 		}
 
 		function msgCallback(data) {
-			log(['msgCallback', slotName, 'caught message', data], 'info', logGroup);
+			log(['msgCallback', slot.name, 'caught message', data], 'info', logGroup);
 
 			if (data.status === 'success') {
 				if (expectAsyncSuccess || expectAsyncSuccessWithSlotName) {
 					slot.success(data.extra);
 				} else {
 					log(
-						['msgCallback', slotName, 'Got asynchronous success message, while not expecting it'],
+						['msgCallback', slot.name, 'Got asynchronous success message, while not expecting it'],
 						'error',
 						logGroup
 					);
@@ -205,7 +203,7 @@ define('ext.wikia.adEngine.provider.gpt.adDetect', [
 					slot.hop(data.extra);
 				} else {
 					log(
-						['msgCallback', slotName, 'Got asynchronous hop message, while not expecting it'],
+						['msgCallback', slot.name, 'Got asynchronous hop message, while not expecting it'],
 						'error',
 						logGroup
 					);
@@ -233,7 +231,7 @@ define('ext.wikia.adEngine.provider.gpt.adDetect', [
 			expectAsyncSuccessWithSlotName = true;
 		}
 
-		log(['onAdLoad', slotName, 'adType', adType], 'info', logGroup);
+		log(['onAdLoad', slot.name, 'adType', adType], 'info', logGroup);
 
 		if (adType === 'forced_success' || adType === 'always_success' || adType === 'collapse') {
 			return slot.success();
@@ -244,7 +242,7 @@ define('ext.wikia.adEngine.provider.gpt.adDetect', [
 		}
 
 		if (adType === 'inspect_iframe') {
-			return inspectIframe(slotName, iframe, slot.success, slot.hop);
+			return inspectIframe(slot.name, iframe, slot.success, slot.hop);
 		}
 
 		if (shouldPollForSuccess) {
@@ -256,7 +254,7 @@ define('ext.wikia.adEngine.provider.gpt.adDetect', [
 		}
 
 		if (expectAsyncHopWithSlotName || expectAsyncSuccessWithSlotName) {
-			messageListener.register({dataKey: 'slot_' + shortSlotName}, msgCallback);
+			messageListener.register({dataKey: 'slot_' + slot.name}, msgCallback);
 		}
 
 		if (expectAsyncHop || expectAsyncHopWithSlotName) {

--- a/extensions/wikia/AdEngine/js/provider/gpt/helper.js
+++ b/extensions/wikia/AdEngine/js/provider/gpt/helper.js
@@ -49,6 +49,15 @@ define('ext.wikia.adEngine.provider.gpt.helper', [
 		}
 	}
 
+	function collapseElement(element) {
+		slotTweaker.removeDefaultHeight(element.getSlotName());
+		slotTweaker.removeTopButtonIfNeeded(element.getSlotName());
+		slotTweaker.hide(
+			element.getSlotContainerId(),
+			recoveryHelper.isBlocking() && recoveryHelper.isRecoveryEnabled()
+		);
+	}
+
 	/**
 	 * Push ad to queue and flush if it should be
 	 *
@@ -80,11 +89,11 @@ define('ext.wikia.adEngine.provider.gpt.helper', [
 
 		slot.pre('success', function (adInfo) {
 			if (adInfo && adInfo.adType === 'collapse') {
-				slotTweaker.hide(
-					element.getSlotContainerId(),
-					recoveryHelper.isBlocking() && recoveryHelper.isRecoveryEnabled()
-				);
+				collapseElement(element);
 			}
+		});
+		slot.pre('collapse', function () {
+			collapseElement(element);
 		});
 		slot.pre('hop', function () {
 			slotTweaker.hide(

--- a/extensions/wikia/AdEngine/js/provider/gpt/helper.js
+++ b/extensions/wikia/AdEngine/js/provider/gpt/helper.js
@@ -80,7 +80,7 @@ define('ext.wikia.adEngine.provider.gpt.helper', [
 
 		element = new AdElement(slot.name, slotPath, slotTargeting);
 
-		slot.pre('success', function (slot, adInfo) {
+		slot.pre('success', function (adInfo) {
 			if (adInfo && adInfo.adType === 'collapse') {
 				slotTweaker.hide(
 					element.getSlotContainerId(),
@@ -88,7 +88,7 @@ define('ext.wikia.adEngine.provider.gpt.helper', [
 				);
 			}
 		});
-		slot.pre('hop', function (slot, adInfo) {
+		slot.pre('hop', function (adInfo) {
 			slotTweaker.hide(
 				element.getSlotContainerId(),
 				recoveryHelper.isBlocking() && recoveryHelper.isRecoveryEnabled()

--- a/extensions/wikia/AdEngine/js/provider/gpt/helper.js
+++ b/extensions/wikia/AdEngine/js/provider/gpt/helper.js
@@ -65,21 +65,20 @@ define('ext.wikia.adEngine.provider.gpt.helper', [
 		var count,
 			element,
 			recoverableSlots = extra.recoverableSlots || [],
-			slotName = slot.getName(),
 			shouldPush = !recoveryHelper.isBlocking() ||
-				(recoveryHelper.isBlocking() && recoveryHelper.isRecoverable(slotName, recoverableSlots));
+				(recoveryHelper.isBlocking() && recoveryHelper.isRecoverable(slot.name, recoverableSlots));
 
 		extra = extra || {};
 		slotTargeting = JSON.parse(JSON.stringify(slotTargeting)); // copy value
 
 		if (scrollHandler) {
-			count = scrollHandler.getReloadedViewCount(slotName);
+			count = scrollHandler.getReloadedViewCount(slot.name);
 			if (count !== null) {
 				slotTargeting.rv = count.toString();
 			}
 		}
 
-		element = new AdElement(slotName, slotPath, slotTargeting);
+		element = new AdElement(slot.name, slotPath, slotTargeting);
 
 		slot.pre('success', function (slot, adInfo) {
 			if (adInfo && adInfo.adType === 'collapse') {
@@ -102,8 +101,8 @@ define('ext.wikia.adEngine.provider.gpt.helper', [
 		});
 
 		function queueAd() {
-			log(['queueAd', slotName, element], 'debug', logGroup);
-			slot.getContainer().appendChild(element.getNode());
+			log(['queueAd', slot.name, element], 'debug', logGroup);
+			slot.container.appendChild(element.getNode());
 
 			googleApi.addSlot(element);
 		}
@@ -120,7 +119,7 @@ define('ext.wikia.adEngine.provider.gpt.helper', [
 		function gptCallback(gptEvent) {
 			log(['gptCallback', element.getId(), gptEvent], 'info', logGroup);
 			element.updateDataParams(gptEvent);
-			googleApi.onAdLoad(slotName, element, gptEvent, onAdLoadCallback);
+			googleApi.onAdLoad(slot.name, element, gptEvent, onAdLoadCallback);
 		}
 
 		if (!googleApi.isInitialized()) {
@@ -133,22 +132,22 @@ define('ext.wikia.adEngine.provider.gpt.helper', [
 		}
 
 		if (!shouldPush) {
-			log(['Push blocked', slotName], 'debug', logGroup);
-			slotTweaker.removeDefaultHeight(slotName);
+			log(['Push blocked', slot.name], 'debug', logGroup);
+			slotTweaker.removeDefaultHeight(slot.name);
 			return;
 		}
 
 		if (!recoveryHelper.isBlocking() && recoveryHelper.isRecoveryEnabled()) {
-			recoveryHelper.addSlotToRecover(slotName);
+			recoveryHelper.addSlotToRecover(slot.name);
 		}
 
-		log(['pushAd', slotName], 'info', logGroup);
+		log(['pushAd', slot.name], 'info', logGroup);
 		if (!slotTargeting.flushOnly) {
 			googleApi.registerCallback(element.getId(), gptCallback);
 			googleApi.push(queueAd);
 		}
 
-		if (!extra.sraEnabled || sraHelper.shouldFlush(slotName)) {
+		if (!extra.sraEnabled || sraHelper.shouldFlush(slot.name)) {
 			log('flushing', 'debug', logGroup);
 			googleApi.flush();
 		}

--- a/extensions/wikia/AdEngine/js/provider/gpt/helper.js
+++ b/extensions/wikia/AdEngine/js/provider/gpt/helper.js
@@ -113,7 +113,7 @@ define('ext.wikia.adEngine.provider.gpt.helper', [
 			// Let's launch our callback in a setTimeout instead.
 			setTimeout(function () {
 				log(['onAdLoadCallback', slotElementId], 'info', logGroup);
-				adDetect.onAdLoad(slotElementId, gptEvent, iframe, slot, extra.forcedAdType);
+				adDetect.onAdLoad(slot, gptEvent, iframe, extra.forcedAdType);
 			}, 0);
 		}
 

--- a/extensions/wikia/AdEngine/js/provider/gpt/helper.js
+++ b/extensions/wikia/AdEngine/js/provider/gpt/helper.js
@@ -56,19 +56,17 @@ define('ext.wikia.adEngine.provider.gpt.helper', [
 	 * @param {string}   slotPath           - slot path
 	 * @param {Object}   slotTargeting      - slot targeting details
 	 * @param {Object}   extra              - optional parameters
-	 * @param {function} extra.success      - on success callback
-	 * @param {function} extra.error        - on error callback
 	 * @param {boolean}  extra.sraEnabled   - whether to use Single Request Architecture
 	 * @param {string}   extra.forcedAdType - ad type for callbacks info
 	 */
 	function pushAd(slot, slotPath, slotTargeting, extra) {
+		extra = extra || {};
 		var count,
 			element,
 			recoverableSlots = extra.recoverableSlots || [],
 			shouldPush = !recoveryHelper.isBlocking() ||
 				(recoveryHelper.isBlocking() && recoveryHelper.isRecoverable(slot.name, recoverableSlots));
 
-		extra = extra || {};
 		slotTargeting = JSON.parse(JSON.stringify(slotTargeting)); // copy value
 
 		if (scrollHandler) {
@@ -88,16 +86,11 @@ define('ext.wikia.adEngine.provider.gpt.helper', [
 				);
 			}
 		});
-		slot.pre('hop', function (adInfo) {
+		slot.pre('hop', function () {
 			slotTweaker.hide(
 				element.getSlotContainerId(),
 				recoveryHelper.isBlocking() && recoveryHelper.isRecoveryEnabled()
 			);
-			if (typeof extra.error === 'function') {
-				adInfo = adInfo || {};
-				adInfo.method = 'hop';
-				extra.error(adInfo);
-			}
 		});
 
 		function queueAd() {

--- a/extensions/wikia/AdEngine/js/provider/gpt/helper.js
+++ b/extensions/wikia/AdEngine/js/provider/gpt/helper.js
@@ -103,7 +103,7 @@ define('ext.wikia.adEngine.provider.gpt.helper', [
 
 		function queueAd() {
 			log(['queueAd', slotName, element], 'debug', logGroup);
-			slot.getElement().appendChild(element.getNode());
+			slot.getContainer().appendChild(element.getNode());
 
 			googleApi.addSlot(element);
 		}

--- a/extensions/wikia/AdEngine/js/provider/liftium.js
+++ b/extensions/wikia/AdEngine/js/provider/liftium.js
@@ -53,38 +53,39 @@ define('ext.wikia.adEngine.provider.liftium', [
 		return false;
 	};
 
-	fillInSlot = function (slotname, slotElement, success) {
-		log(['fillInSlot', slotname, slotElement], 'debug', logGroup);
+	fillInSlot = function (slot) {
+		var slotName = slot.getName();
+		log(['fillInSlot', slotName], 'debug', logGroup);
 
 		// TOP_BUTTON_WIDE after TOP_LEADERBOARD hack:
-		if (slotname === 'TOP_BUTTON_WIDE') {
+		if (slotName === 'TOP_BUTTON_WIDE') {
 			log('Tried TOP_BUTTON_WIDE. Disabled (waiting for leaderboard ads)', 'info', logGroup);
 			return;
 		}
-		if (slotname === 'TOP_BUTTON_WIDE.force') {
+		if (slotName === 'TOP_BUTTON_WIDE.force') {
 			log('Forced TOP_BUTTON_WIDE call (this means leaderboard is ready and standard)', 'info', logGroup);
-			slotname = slotname.replace('.force', '');
+			slotName = slotName.replace('.force', '');
 		}
-		if (slotname.indexOf('LEADERBOARD') !== -1) {
+		if (slotName.indexOf('LEADERBOARD') !== -1) {
 			log('LEADERBOARD-ish slot handled by Liftium. Running the forced TOP_BUTTON_WIDE now', 'info', logGroup);
 
 			win.adslots2.push('TOP_BUTTON_WIDE.force');
 		}
 		// END of hack
-		if (!doc.getElementById(slotname)) {
-			log('No such element in DOM: #' + slotname, 'info', logGroup);
+		if (!doc.getElementById(slotName)) {
+			log('No such element in DOM: #' + slotName, 'info', logGroup);
 			return;
 		}
 
-		var slotsize = slotMap[slotname].size;
+		var slotsize = slotMap[slotName].size;
 
-		log('using iframe for #' + slotname, 'debug', logGroup);
-		Liftium.injectAd(doc, slotname, slotElement, slotsize);
+		log('using iframe for #' + slotName, 'debug', logGroup);
+		Liftium.injectAd(doc, slotName, slot.getElement(), slotsize);
 
-		slotTweaker.removeDefaultHeight(slotname);
+		slotTweaker.removeDefaultHeight(slotName);
 
 		// Fake success, because we don't have the success event in Liftium
-		success();
+		slot.success();
 	};
 
 	return {

--- a/extensions/wikia/AdEngine/js/provider/liftium.js
+++ b/extensions/wikia/AdEngine/js/provider/liftium.js
@@ -54,35 +54,34 @@ define('ext.wikia.adEngine.provider.liftium', [
 	};
 
 	fillInSlot = function (slot) {
-		var slotName = slot.getName();
-		log(['fillInSlot', slotName], 'debug', logGroup);
+		log(['fillInSlot', slot.name], 'debug', logGroup);
 
 		// TOP_BUTTON_WIDE after TOP_LEADERBOARD hack:
-		if (slotName === 'TOP_BUTTON_WIDE') {
+		if (slot.name === 'TOP_BUTTON_WIDE') {
 			log('Tried TOP_BUTTON_WIDE. Disabled (waiting for leaderboard ads)', 'info', logGroup);
 			return;
 		}
-		if (slotName === 'TOP_BUTTON_WIDE.force') {
+		if (slot.name === 'TOP_BUTTON_WIDE.force') {
 			log('Forced TOP_BUTTON_WIDE call (this means leaderboard is ready and standard)', 'info', logGroup);
-			slotName = slotName.replace('.force', '');
+			slot.name = slot.name.replace('.force', '');
 		}
-		if (slotName.indexOf('LEADERBOARD') !== -1) {
+		if (slot.name.indexOf('LEADERBOARD') !== -1) {
 			log('LEADERBOARD-ish slot handled by Liftium. Running the forced TOP_BUTTON_WIDE now', 'info', logGroup);
 
 			win.adslots2.push('TOP_BUTTON_WIDE.force');
 		}
 		// END of hack
-		if (!doc.getElementById(slotName)) {
-			log('No such element in DOM: #' + slotName, 'info', logGroup);
+		if (!doc.getElementById(slot.name)) {
+			log('No such element in DOM: #' + slot.name, 'info', logGroup);
 			return;
 		}
 
-		var slotsize = slotMap[slotName].size;
+		var slotsize = slotMap[slot.name].size;
 
-		log('using iframe for #' + slotName, 'debug', logGroup);
-		Liftium.injectAd(doc, slotName, slot.getContainer(), slotsize);
+		log('using iframe for #' + slot.name, 'debug', logGroup);
+		Liftium.injectAd(doc, slot.name, slot.container, slotsize);
 
-		slotTweaker.removeDefaultHeight(slotName);
+		slotTweaker.removeDefaultHeight(slot.name);
 
 		// Fake success, because we don't have the success event in Liftium
 		slot.success();

--- a/extensions/wikia/AdEngine/js/provider/liftium.js
+++ b/extensions/wikia/AdEngine/js/provider/liftium.js
@@ -80,7 +80,7 @@ define('ext.wikia.adEngine.provider.liftium', [
 		var slotsize = slotMap[slotName].size;
 
 		log('using iframe for #' + slotName, 'debug', logGroup);
-		Liftium.injectAd(doc, slotName, slot.getElement(), slotsize);
+		Liftium.injectAd(doc, slotName, slot.getContainer(), slotsize);
 
 		slotTweaker.removeDefaultHeight(slotName);
 

--- a/extensions/wikia/AdEngine/js/provider/monetizationService.js
+++ b/extensions/wikia/AdEngine/js/provider/monetizationService.js
@@ -28,20 +28,20 @@ define('ext.wikia.adEngine.provider.monetizationService', [
 		return false;
 	}
 
-	function fillInSlot(slot, slotElement, success, hop) {
-		log(['fillInSlot', slot, slotElement], 'debug', logGroup);
+	function fillInSlot(slot) {
+		log(['fillInSlot', slot.getName()], 'debug', logGroup);
 
-		var slotName = slotMap[slot],
+		var slotName = slotMap[slot.getName()],
 			context = adContext.getContext();
 
 		if (context.providers.monetizationServiceAds && context.providers.monetizationServiceAds[slotName]) {
-			log(['fillInSlot', slot, 'injectScript'], 'debug', logGroup);
+			log(['fillInSlot', slot.getName(), 'injectScript'], 'debug', logGroup);
 
-			scriptWriter.injectHtml(slotElement, context.providers.monetizationServiceAds[slotName], function () {
-				success();
+			scriptWriter.injectHtml(slot.getElement(), context.providers.monetizationServiceAds[slotName], function () {
+				slot.success();
 			});
 		} else {
-			hop();
+			slot.hop();
 		}
 	}
 

--- a/extensions/wikia/AdEngine/js/provider/monetizationService.js
+++ b/extensions/wikia/AdEngine/js/provider/monetizationService.js
@@ -37,7 +37,7 @@ define('ext.wikia.adEngine.provider.monetizationService', [
 		if (context.providers.monetizationServiceAds && context.providers.monetizationServiceAds[slotName]) {
 			log(['fillInSlot', slot.getName(), 'injectScript'], 'debug', logGroup);
 
-			scriptWriter.injectHtml(slot.getElement(), context.providers.monetizationServiceAds[slotName], function () {
+			scriptWriter.injectHtml(slot.getContainer(), context.providers.monetizationServiceAds[slotName], function () {
 				slot.success();
 			});
 		} else {

--- a/extensions/wikia/AdEngine/js/provider/monetizationService.js
+++ b/extensions/wikia/AdEngine/js/provider/monetizationService.js
@@ -29,15 +29,14 @@ define('ext.wikia.adEngine.provider.monetizationService', [
 	}
 
 	function fillInSlot(slot) {
-		log(['fillInSlot', slot.getName()], 'debug', logGroup);
+		log(['fillInSlot', slot.name], 'debug', logGroup);
 
-		var slotName = slotMap[slot.getName()],
-			context = adContext.getContext();
+		var context = adContext.getContext();
 
-		if (context.providers.monetizationServiceAds && context.providers.monetizationServiceAds[slotName]) {
-			log(['fillInSlot', slot.getName(), 'injectScript'], 'debug', logGroup);
+		if (context.providers.monetizationServiceAds && context.providers.monetizationServiceAds[slot.name]) {
+			log(['fillInSlot', slot.name, 'injectScript'], 'debug', logGroup);
 
-			scriptWriter.injectHtml(slot.getContainer(), context.providers.monetizationServiceAds[slotName], function () {
+			scriptWriter.injectHtml(slot.container, context.providers.monetizationServiceAds[slot.name], function () {
 				slot.success();
 			});
 		} else {

--- a/extensions/wikia/AdEngine/js/provider/paidAssetDrop.js
+++ b/extensions/wikia/AdEngine/js/provider/paidAssetDrop.js
@@ -20,7 +20,7 @@ define('ext.wikia.adEngine.provider.paidAssetDrop', [
 		log(['fillInSlot', slot.getName()], 'debug', logGroup);
 
 		if (pad.isNowValid(adContext.getContext().opts.paidAssetDropConfig)) {
-			pad.injectPAD(slot.getElement(), 'mobile', pageType);
+			pad.injectPAD(slot.getContainer(), 'mobile', pageType);
 			slot.success();
 		} else {
 			slot.hop();

--- a/extensions/wikia/AdEngine/js/provider/paidAssetDrop.js
+++ b/extensions/wikia/AdEngine/js/provider/paidAssetDrop.js
@@ -17,10 +17,10 @@ define('ext.wikia.adEngine.provider.paidAssetDrop', [
 
 	function fillInSlot(slot) {
 		var pageType = adContext.getContext().targeting.pageType;
-		log(['fillInSlot', slot.getName()], 'debug', logGroup);
+		log(['fillInSlot', slot.name], 'debug', logGroup);
 
 		if (pad.isNowValid(adContext.getContext().opts.paidAssetDropConfig)) {
-			pad.injectPAD(slot.getContainer(), 'mobile', pageType);
+			pad.injectPAD(slot.container, 'mobile', pageType);
 			slot.success();
 		} else {
 			slot.hop();

--- a/extensions/wikia/AdEngine/js/provider/paidAssetDrop.js
+++ b/extensions/wikia/AdEngine/js/provider/paidAssetDrop.js
@@ -15,15 +15,15 @@ define('ext.wikia.adEngine.provider.paidAssetDrop', [
 		return (slotName === paidAssetDropSlot);
 	}
 
-	function fillInSlot(slotName, slotElement, success, hop) {
+	function fillInSlot(slot) {
 		var pageType = adContext.getContext().targeting.pageType;
-		log(['fillInSlot', slotName, slotElement], 'debug', logGroup);
+		log(['fillInSlot', slot.getName()], 'debug', logGroup);
 
 		if (pad.isNowValid(adContext.getContext().opts.paidAssetDropConfig)) {
-			pad.injectPAD(slotElement, 'mobile', pageType);
-			success();
+			pad.injectPAD(slot.getElement(), 'mobile', pageType);
+			slot.success();
 		} else {
-			hop();
+			slot.hop();
 		}
 	}
 

--- a/extensions/wikia/AdEngine/js/provider/recirculation.js
+++ b/extensions/wikia/AdEngine/js/provider/recirculation.js
@@ -18,9 +18,9 @@ define('ext.wikia.adEngine.provider.recirculation', [
 	}
 
 	function fillInSlot(slot) {
-		log(['fillInSlot', slot.getName()], 'debug', logGroup);
+		log(['fillInSlot', slot.name], 'debug', logGroup);
 
-		recirculation.injectRecirculationModule(slot.getName());
+		recirculation.injectRecirculationModule(slot.name);
 
 		slot.success();
 	}

--- a/extensions/wikia/AdEngine/js/provider/recirculation.js
+++ b/extensions/wikia/AdEngine/js/provider/recirculation.js
@@ -20,7 +20,7 @@ define('ext.wikia.adEngine.provider.recirculation', [
 	function fillInSlot(slot) {
 		log(['fillInSlot', slot.name], 'debug', logGroup);
 
-		recirculation.injectRecirculationModule(slot.name);
+		recirculation.injectRecirculationModule(slot.container);
 
 		slot.success();
 	}

--- a/extensions/wikia/AdEngine/js/provider/recirculation.js
+++ b/extensions/wikia/AdEngine/js/provider/recirculation.js
@@ -17,12 +17,12 @@ define('ext.wikia.adEngine.provider.recirculation', [
 		return (properSlot && recirculation);
 	}
 
-	function fillInSlot(slotName, slotElement, success) {
-		log(['fillInSlot', slotName, slotElement], 'debug', logGroup);
+	function fillInSlot(slot) {
+		log(['fillInSlot', slot.getName()], 'debug', logGroup);
 
-		recirculation.injectRecirculationModule(slotElement);
+		recirculation.injectRecirculationModule(slot.getName());
 
-		success();
+		slot.success();
 	}
 
 	return {

--- a/extensions/wikia/AdEngine/js/provider/sevenOneMedia.js
+++ b/extensions/wikia/AdEngine/js/provider/sevenOneMedia.js
@@ -90,7 +90,7 @@ define('ext.wikia.adEngine.provider.sevenOneMedia', [
 		if (slotDeName.match(/^(rectangle1|promo[123])$/)) {
 			$slot = $('<div class="ad-wrapper" style="display: none"></div>');
 			$slot.attr('id', 'ad-' + slotDeName);
-			$(slot.getElement()).append($slot);
+			$(slot.getContainer()).append($slot);
 			sevenOneMedia.pushAd(slotDeName, {beforeFinish: clearDefaultHeight, afterFinish: success});
 			sevenOneMedia.flushAds();
 		}

--- a/extensions/wikia/AdEngine/js/provider/sevenOneMedia.js
+++ b/extensions/wikia/AdEngine/js/provider/sevenOneMedia.js
@@ -65,18 +65,18 @@ define('ext.wikia.adEngine.provider.sevenOneMedia', [
 		}
 	}
 
-	function fillInSlot(slotname, slotElement, pSuccess) {
-		log(['fillInSlot', slotname], 'info', logGroup);
+	function fillInSlot(slot) {
+		log(['fillInSlot', slot.getName()], 'info', logGroup);
 
-		var slotDeName = slotMap[slotname],
+		var slotDeName = slotMap[slot.getName()],
 			$slot;
 
 		function clearDefaultHeight() {
-			$('#' + slotname).removeClass('default-height');
+			$('#' + slot.getName()).removeClass('default-height');
 		}
 
 		function success() {
-			pSuccess();
+			slot.success();
 		}
 
 		if (slotDeName === 'topAds') {
@@ -90,13 +90,13 @@ define('ext.wikia.adEngine.provider.sevenOneMedia', [
 		if (slotDeName.match(/^(rectangle1|promo[123])$/)) {
 			$slot = $('<div class="ad-wrapper" style="display: none"></div>');
 			$slot.attr('id', 'ad-' + slotDeName);
-			$(slotElement).append($slot);
+			$(slot.getElement()).append($slot);
 			sevenOneMedia.pushAd(slotDeName, {beforeFinish: clearDefaultHeight, afterFinish: success});
 			sevenOneMedia.flushAds();
 		}
 
 		if (slotDeName === 'trackEnd') {
-			sevenOneMedia.trackEnd(slotname);
+			sevenOneMedia.trackEnd(slot.getName());
 		}
 	}
 

--- a/extensions/wikia/AdEngine/js/provider/sevenOneMedia.js
+++ b/extensions/wikia/AdEngine/js/provider/sevenOneMedia.js
@@ -66,13 +66,13 @@ define('ext.wikia.adEngine.provider.sevenOneMedia', [
 	}
 
 	function fillInSlot(slot) {
-		log(['fillInSlot', slot.getName()], 'info', logGroup);
+		log(['fillInSlot', slot.name], 'info', logGroup);
 
-		var slotDeName = slotMap[slot.getName()],
+		var slotDeName = slotMap[slot.name],
 			$slot;
 
 		function clearDefaultHeight() {
-			$('#' + slot.getName()).removeClass('default-height');
+			$('#' + slot.name).removeClass('default-height');
 		}
 
 		function success() {
@@ -90,13 +90,13 @@ define('ext.wikia.adEngine.provider.sevenOneMedia', [
 		if (slotDeName.match(/^(rectangle1|promo[123])$/)) {
 			$slot = $('<div class="ad-wrapper" style="display: none"></div>');
 			$slot.attr('id', 'ad-' + slotDeName);
-			$(slot.getContainer()).append($slot);
+			$(slot.container).append($slot);
 			sevenOneMedia.pushAd(slotDeName, {beforeFinish: clearDefaultHeight, afterFinish: success});
 			sevenOneMedia.flushAds();
 		}
 
 		if (slotDeName === 'trackEnd') {
-			sevenOneMedia.trackEnd(slot.getName());
+			sevenOneMedia.trackEnd(slot.name);
 		}
 	}
 

--- a/extensions/wikia/AdEngine/js/provider/taboola.js
+++ b/extensions/wikia/AdEngine/js/provider/taboola.js
@@ -98,12 +98,12 @@ define('ext.wikia.adEngine.provider.taboola', [
 		slot.success();
 	}
 
-	function fillInSlotByConfig(slotName, slotElement, success) {
-		if (supportedSlots.regular.indexOf(slotName) !== -1) {
-			fillInSlot(slotName, slotElement, success);
-		} else if (supportedSlots.recovery.indexOf(slotName) !== -1) {
+	function fillInSlotByConfig(slot) {
+		if (supportedSlots.regular.indexOf(slot.getName()) !== -1) {
+			fillInSlot(slot);
+		} else if (supportedSlots.recovery.indexOf(slot.getName()) !== -1) {
 			recoveryHelper.addOnBlockingCallback(function () {
-				fillInSlot(slotName, slotElement, success);
+				fillInSlot(slot);
 			});
 		}
 	}

--- a/extensions/wikia/AdEngine/js/provider/taboola.js
+++ b/extensions/wikia/AdEngine/js/provider/taboola.js
@@ -85,7 +85,7 @@ define('ext.wikia.adEngine.provider.taboola', [
 		}
 
 		container.id = mappedSlot.id;
-		slot.getElement().appendChild(container);
+		slot.getContainer().appendChild(container);
 
 		taboolaHelper.initializeWidget({
 			mode: mappedSlot.mode,

--- a/extensions/wikia/AdEngine/js/provider/taboola.js
+++ b/extensions/wikia/AdEngine/js/provider/taboola.js
@@ -77,15 +77,15 @@ define('ext.wikia.adEngine.provider.taboola', [
 
 	function fillInSlot(slot) {
 		var container = document.createElement('div'),
-			mappedSlot = slots[slot.getName()];
-		log(['fillInSlot', slot.getName()], 'debug', logGroup);
+			mappedSlot = slots[slot.name];
+		log(['fillInSlot', slot.name], 'debug', logGroup);
 
-		if (slot.getName() === 'NATIVE_TABOOLA_ARTICLE') {
+		if (slot.name === 'NATIVE_TABOOLA_ARTICLE') {
 			readMoreDiv.parentNode.removeChild(readMoreDiv);
 		}
 
 		container.id = mappedSlot.id;
-		slot.getContainer().appendChild(container);
+		slot.container.appendChild(container);
 
 		taboolaHelper.initializeWidget({
 			mode: mappedSlot.mode,
@@ -94,14 +94,14 @@ define('ext.wikia.adEngine.provider.taboola', [
 			target_type: 'mix'
 		});
 
-		slotTweaker.show(slot.getName());
+		slotTweaker.show(slot.name);
 		slot.success();
 	}
 
 	function fillInSlotByConfig(slot) {
-		if (supportedSlots.regular.indexOf(slot.getName()) !== -1) {
+		if (supportedSlots.regular.indexOf(slot.name) !== -1) {
 			fillInSlot(slot);
-		} else if (supportedSlots.recovery.indexOf(slot.getName()) !== -1) {
+		} else if (supportedSlots.recovery.indexOf(slot.name) !== -1) {
 			recoveryHelper.addOnBlockingCallback(function () {
 				fillInSlot(slot);
 			});

--- a/extensions/wikia/AdEngine/js/provider/taboola.js
+++ b/extensions/wikia/AdEngine/js/provider/taboola.js
@@ -75,27 +75,27 @@ define('ext.wikia.adEngine.provider.taboola', [
 		return false;
 	}
 
-	function fillInSlot(slotName, slotElement, success) {
+	function fillInSlot(slot) {
 		var container = document.createElement('div'),
-			slot = slots[slotName];
-		log(['fillInSlot', slotName, slotElement], 'debug', logGroup);
+			mappedSlot = slots[slot.getName()];
+		log(['fillInSlot', slot.getName()], 'debug', logGroup);
 
-		if (slotName === 'NATIVE_TABOOLA_ARTICLE') {
+		if (slot.getName() === 'NATIVE_TABOOLA_ARTICLE') {
 			readMoreDiv.parentNode.removeChild(readMoreDiv);
 		}
 
-		container.id = slot.id;
-		slotElement.appendChild(container);
+		container.id = mappedSlot.id;
+		slot.getElement().appendChild(container);
 
 		taboolaHelper.initializeWidget({
-			mode: slot.mode,
+			mode: mappedSlot.mode,
 			container: container.id,
-			placement: slot.label + getVerticalName(),
+			placement: mappedSlot.label + getVerticalName(),
 			target_type: 'mix'
 		});
 
-		slotTweaker.show(slotName);
-		success();
+		slotTweaker.show(slot.getName());
+		slot.success();
 	}
 
 	function fillInSlotByConfig(slotName, slotElement, success) {

--- a/extensions/wikia/AdEngine/js/provider/turtle.js
+++ b/extensions/wikia/AdEngine/js/provider/turtle.js
@@ -29,11 +29,9 @@ define('ext.wikia.adEngine.provider.turtle', [
 		log(['fillInSlot', slot.name], 'debug', logGroup);
 
 		slot.pre('success', function () {
-			var slotName = slot.name;
-
-			slotTweaker.removeDefaultHeight(slotName);
-			slotTweaker.removeTopButtonIfNeeded(slotName);
-			slotTweaker.adjustLeaderboardSize(slotName);
+			slotTweaker.removeDefaultHeight(slot.name);
+			slotTweaker.removeTopButtonIfNeeded(slot.name);
+			slotTweaker.adjustLeaderboardSize(slot.name);
 		});
 		gptHelper.pushAd(
 			slot,

--- a/extensions/wikia/AdEngine/js/provider/turtle.js
+++ b/extensions/wikia/AdEngine/js/provider/turtle.js
@@ -26,10 +26,10 @@ define('ext.wikia.adEngine.provider.turtle', [
 	}
 
 	function fillInSlot(slot) {
-		log(['fillInSlot', slot.getName()], 'debug', logGroup);
+		log(['fillInSlot', slot.name], 'debug', logGroup);
 
 		slot.pre('success', function () {
-			var slotName = slot.getName();
+			var slotName = slot.name;
 
 			slotTweaker.removeDefaultHeight(slotName);
 			slotTweaker.removeTopButtonIfNeeded(slotName);
@@ -37,8 +37,8 @@ define('ext.wikia.adEngine.provider.turtle', [
 		});
 		gptHelper.pushAd(
 			slot,
-			'/98544404/Wikia/Nordics_RoN/' + slot.getName(),
-			slotMap[slot.getName()],
+			'/98544404/Wikia/Nordics_RoN/' + slot.name,
+			slotMap[slot.name],
 			{
 				forcedAdType: 'turtle',
 				sraEnabled: true

--- a/extensions/wikia/AdEngine/js/provider/turtle.js
+++ b/extensions/wikia/AdEngine/js/provider/turtle.js
@@ -25,31 +25,27 @@ define('ext.wikia.adEngine.provider.turtle', [
 		return ret;
 	}
 
-	function fillInSlot(slotName, slotElement, success, hop) {
-		log(['fillInSlot', slotName, slotElement, success, hop], 'debug', logGroup);
+	function fillInSlot(slot) {
+		log(['fillInSlot', slot.getName()], 'debug', logGroup);
 
+		slot.pre('success', function () {
+			var slotName = slot.getName();
+
+			slotTweaker.removeDefaultHeight(slotName);
+			slotTweaker.removeTopButtonIfNeeded(slotName);
+			slotTweaker.adjustLeaderboardSize(slotName);
+		});
 		gptHelper.pushAd(
-			slotName,
-			slotElement,
-			'/98544404/Wikia/Nordics_RoN/' + slotName,
-			slotMap[slotName],
+			slot,
+			'/98544404/Wikia/Nordics_RoN/' + slot.getName(),
+			slotMap[slot.getName()],
 			{
-				success: function (adInfo) {
-					// Success
-					// TODO: find a better place for operation below
-					slotTweaker.removeDefaultHeight(slotName);
-					slotTweaker.removeTopButtonIfNeeded(slotName);
-					slotTweaker.adjustLeaderboardSize(slotName);
-
-					success(adInfo);
-				},
-				error: hop,
 				forcedAdType: 'turtle',
 				sraEnabled: true
 			}
 		);
 
-		log(['fillInSlot', slotName, slotElement, success, hop, 'done'], 'debug', logGroup);
+		log(['fillInSlot', slot, 'done'], 'debug', logGroup);
 	}
 
 	return {

--- a/extensions/wikia/AdEngine/js/slot/adSlot.js
+++ b/extensions/wikia/AdEngine/js/slot/adSlot.js
@@ -3,14 +3,9 @@ define('ext.wikia.adEngine.slot.adSlot', [], function () {
 	'use strict';
 
 	function create(name, container, callbacks) {
-		var slot = {};
-
-		slot.getName = function () {
-			return name;
-		};
-
-		slot.getContainer = function () {
-			return container;
+		var slot = {
+			name: name,
+			container: container
 		};
 
 		slot.success = function (adInfo) {

--- a/extensions/wikia/AdEngine/js/slot/adSlot.js
+++ b/extensions/wikia/AdEngine/js/slot/adSlot.js
@@ -1,13 +1,35 @@
 /*global define*/
-define('ext.wikia.adEngine.slot.adSlot', [],
-function () {
+define('ext.wikia.adEngine.slot.adSlot', [
+	'ext.wikia.adEngine.utils.hooks'
+], function (registerHooks) {
 	'use strict';
+
+	function create(slotName, slotElement) {
+		var slot = {};
+
+		slot.getName = function () {
+			return slotName;
+		};
+
+		slot.getElement = function () {
+			return slotElement;
+		};
+
+		slot.success = function () {};
+		slot.collapse = function () {};
+		slot.hop = function () {};
+
+		registerHooks(slot, ['success', 'collapse', 'hop']);
+
+		return slot;
+	}
 
 	function getShortSlotName(slotName) {
 		return slotName.replace(/^.*\/([^\/]*)$/, '$1');
 	}
 
 	return {
+		create: create,
 		getShortSlotName: getShortSlotName
 	};
 });

--- a/extensions/wikia/AdEngine/js/slot/adSlot.js
+++ b/extensions/wikia/AdEngine/js/slot/adSlot.js
@@ -2,15 +2,15 @@
 define('ext.wikia.adEngine.slot.adSlot', [], function () {
 	'use strict';
 
-	function create(slotName, slotElement, callbacks) {
+	function create(name, container, callbacks) {
 		var slot = {};
 
 		slot.getName = function () {
-			return slotName;
+			return name;
 		};
 
-		slot.getElement = function () {
-			return slotElement;
+		slot.getContainer = function () {
+			return container;
 		};
 
 		slot.success = function (adInfo) {

--- a/extensions/wikia/AdEngine/js/slot/adSlot.js
+++ b/extensions/wikia/AdEngine/js/slot/adSlot.js
@@ -1,7 +1,5 @@
 /*global define*/
-define('ext.wikia.adEngine.slot.adSlot', [
-	'ext.wikia.adEngine.utils.hooks'
-], function (registerHooks) {
+define('ext.wikia.adEngine.slot.adSlot', [], function () {
 	'use strict';
 
 	function create(slotName, slotElement, callbacks) {
@@ -30,8 +28,6 @@ define('ext.wikia.adEngine.slot.adSlot', [
 				callbacks.hop(adInfo);
 			}
 		};
-
-		registerHooks(slot, ['success', 'collapse', 'hop']);
 
 		return slot;
 	}

--- a/extensions/wikia/AdEngine/js/slot/adSlot.js
+++ b/extensions/wikia/AdEngine/js/slot/adSlot.js
@@ -4,7 +4,7 @@ define('ext.wikia.adEngine.slot.adSlot', [
 ], function (registerHooks) {
 	'use strict';
 
-	function create(slotName, slotElement) {
+	function create(slotName, slotElement, callbacks) {
 		var slot = {};
 
 		slot.getName = function () {
@@ -15,9 +15,21 @@ define('ext.wikia.adEngine.slot.adSlot', [
 			return slotElement;
 		};
 
-		slot.success = function () {};
-		slot.collapse = function () {};
-		slot.hop = function () {};
+		slot.success = function (adInfo) {
+			if (typeof callbacks.success === 'function') {
+				callbacks.success(adInfo);
+			}
+		};
+		slot.collapse = function (adInfo) {
+			if (typeof callbacks.collapse === 'function') {
+				callbacks.collapse(adInfo);
+			}
+		};
+		slot.hop = function (adInfo) {
+			if (typeof callbacks.hop === 'function') {
+				callbacks.hop(adInfo);
+			}
+		};
 
 		registerHooks(slot, ['success', 'collapse', 'hop']);
 

--- a/extensions/wikia/AdEngine/js/spec/AdEngine2.decorators.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/AdEngine2.decorators.spec.js
@@ -18,6 +18,7 @@ describe('ext.wikia.adEngine.adEngine decorators', function () {
 		adDecoratorFake1: noop,
 		adDecoratorFake2: noop,
 		adDecoratorLegacyParamFormat: noop,
+		adSlot: {},
 		decoratedFillInSlot: noop,
 		decoratedFillInSlotFake1: noop,
 		decoratedFillInSlotFake2: noop,
@@ -48,6 +49,7 @@ describe('ext.wikia.adEngine.adEngine decorators', function () {
 			mocks.lazyQueue,
 			mocks.adDecoratorLegacyParamFormat,
 			mocks.eventDispatcher,
+			mocks.adSlot,
 			mocks.slotTracker,
 			mocks.slotTweaker
 		);

--- a/extensions/wikia/AdEngine/js/spec/AdEngine2.decorators.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/AdEngine2.decorators.spec.js
@@ -29,6 +29,7 @@ describe('ext.wikia.adEngine.adEngine decorators', function () {
 				};
 			}
 		},
+		hooks: noop,
 		lazyQueue: {
 			makeQueue: noop
 		},
@@ -44,14 +45,15 @@ describe('ext.wikia.adEngine.adEngine decorators', function () {
 
 	function getAdEngine() {
 		return modules['ext.wikia.adEngine.adEngine'](
-			mocks.doc,
-			mocks.log,
-			mocks.lazyQueue,
 			mocks.adDecoratorLegacyParamFormat,
 			mocks.eventDispatcher,
 			mocks.adSlot,
 			mocks.slotTracker,
-			mocks.slotTweaker
+			mocks.slotTweaker,
+			mocks.hooks,
+			mocks.doc,
+			mocks.lazyQueue,
+			mocks.log
 		);
 	}
 

--- a/extensions/wikia/AdEngine/js/spec/AdEngine2.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/AdEngine2.spec.js
@@ -19,6 +19,7 @@ describe('ext.wikia.adEngine.adEngine', function () {
 				};
 			}
 		},
+		hooksMock = noop,
 		slotTrackerMock = function () { return { track: noop }; },
 		slotTweakerMock = { show: noop, hide: noop },
 		docMock = {
@@ -55,14 +56,15 @@ describe('ext.wikia.adEngine.adEngine', function () {
 
 	function getAdEngine(lazyQueueMock, adDecoratorMock) {
 		return modules['ext.wikia.adEngine.adEngine'](
-			docMock,
-			logMock,
-			lazyQueueMock,
 			adDecoratorMock || adDecoratorLegacyParamFormatMock,
 			eventDispatcher,
 			adSlotMock,
 			slotTrackerMock,
-			slotTweakerMock
+			slotTweakerMock,
+			hooksMock,
+			docMock,
+			lazyQueueMock,
+			logMock
 		);
 	}
 

--- a/extensions/wikia/AdEngine/js/spec/AdEngine2.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/AdEngine2.spec.js
@@ -9,6 +9,18 @@ describe('ext.wikia.adEngine.adEngine', function () {
 		noop = function () { return; },
 		originalLazyQueue = modules['wikia.lazyqueue'](),
 		adDecoratorLegacyParamFormatMock = function (fillInSlot) { return fillInSlot; },
+		adSlotMock = {
+			create: function (slotName) {
+				var registerHooks = modules['ext.wikia.adEngine.utils.hooks'](),
+					slot = {
+						name: slotName,
+						success: noop,
+						hop: noop
+					};
+				registerHooks(slot, ['success', 'hop']);
+				return slot;
+			}
+		},
 		slotTrackerMock = function () { return { track: noop }; },
 		slotTweakerMock = { show: noop, hide: noop },
 		docMock = {
@@ -50,6 +62,7 @@ describe('ext.wikia.adEngine.adEngine', function () {
 			lazyQueueMock,
 			adDecoratorMock || adDecoratorLegacyParamFormatMock,
 			eventDispatcher,
+			adSlotMock,
 			slotTrackerMock,
 			slotTweakerMock
 		);
@@ -139,12 +152,12 @@ describe('ext.wikia.adEngine.adEngine', function () {
 			);
 
 			expect(fakeProvider.fillInSlot.calls.count()).toBe(2, 'AdProvider*.fillInSlot called 2 times');
-			expect(fakeProvider.fillInSlot.calls.argsFor(0)).toEqual(
-				['slot1', jasmine.any(Object), jasmine.any(Function), jasmine.any(Function)],
+			expect(fakeProvider.fillInSlot.calls.argsFor(0)[0].name).toEqual(
+				'slot1',
 				'AdProvider*.fillInSlot called for slot1'
 			);
-			expect(fakeProvider.fillInSlot.calls.argsFor(1)).toEqual(
-				['slot2', jasmine.any(Object), jasmine.any(Function), jasmine.any(Function)],
+			expect(fakeProvider.fillInSlot.calls.argsFor(1)[0].name).toEqual(
+				'slot2',
 				'AdProvider*.fillInSlot called for slot2'
 			);
 		}
@@ -182,8 +195,8 @@ describe('ext.wikia.adEngine.adEngine', function () {
 	});
 
 	it('Calls all the provider in the chain and then hides the slot if all of the hop', function () {
-		function callHop(slotname, slotElement, success, hop) {
-			hop();
+		function callHop(slot) {
+			slot.hop();
 		}
 
 		var fakeProvider1 = {

--- a/extensions/wikia/AdEngine/js/spec/AdEngine2.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/AdEngine2.spec.js
@@ -10,15 +10,13 @@ describe('ext.wikia.adEngine.adEngine', function () {
 		originalLazyQueue = modules['wikia.lazyqueue'](),
 		adDecoratorLegacyParamFormatMock = function (fillInSlot) { return fillInSlot; },
 		adSlotMock = {
-			create: function (slotName) {
-				var registerHooks = modules['ext.wikia.adEngine.utils.hooks'](),
-					slot = {
-						name: slotName,
-						success: noop,
-						hop: noop
-					};
-				registerHooks(slot, ['success', 'hop']);
-				return slot;
+			create: function (slotName, slotElement, callbacks) {
+				return {
+					name: slotName,
+					success: callbacks.success || noop,
+					hop: callbacks.hop || noop,
+					post: noop
+				};
 			}
 		},
 		slotTrackerMock = function () { return { track: noop }; },

--- a/extensions/wikia/AdEngine/js/spec/provider/evolve2.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/provider/evolve2.spec.js
@@ -36,11 +36,6 @@ describe('Evolve2 Provider targeting', function () {
 			getName: function () {
 				return slotName;
 			},
-			//getElement: function () {
-			//	return mocks.slotElement;
-			//},
-			//success: noop,
-			//hop: noop,
 			pre: noop
 		};
 	}

--- a/extensions/wikia/AdEngine/js/spec/provider/evolve2.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/provider/evolve2.spec.js
@@ -33,9 +33,7 @@ describe('Evolve2 Provider targeting', function () {
 
 	function createSlot(slotName) {
 		return {
-			getName: function () {
-				return slotName;
-			},
+			name: slotName,
 			pre: noop
 		};
 	}

--- a/extensions/wikia/AdEngine/js/spec/provider/evolve2.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/provider/evolve2.spec.js
@@ -31,6 +31,20 @@ describe('Evolve2 Provider targeting', function () {
 		);
 	}
 
+	function createSlot(slotName) {
+		return {
+			getName: function () {
+				return slotName;
+			},
+			//getElement: function () {
+			//	return mocks.slotElement;
+			//},
+			//success: noop,
+			//hop: noop,
+			pre: noop
+		};
+	}
+
 	beforeEach(function () {
 		evolve2 = getEvolve2Provider();
 
@@ -50,9 +64,9 @@ describe('Evolve2 Provider targeting', function () {
 	it('Should push ad to helper with proper ad unit id', function () {
 		var expectedAdUnit = '/4403/ev/wikia_intl/ros/TOP_LEADERBOARD';
 
-		evolve2.fillInSlot('TOP_LEADERBOARD');
+		evolve2.fillInSlot(createSlot('TOP_LEADERBOARD'));
 
-		expect(mocks.gptHelper.pushAd.calls.mostRecent().args[2]).toEqual(expectedAdUnit);
+		expect(mocks.gptHelper.pushAd.calls.mostRecent().args[1]).toEqual(expectedAdUnit);
 	});
 
 	it('Should push ad to helper with proper targeting', function () {
@@ -63,59 +77,59 @@ describe('Evolve2 Provider targeting', function () {
 				site: 'wikia_intl'
 			};
 
-		evolve2.fillInSlot('TOP_LEADERBOARD');
+		evolve2.fillInSlot(createSlot('TOP_LEADERBOARD'));
 
-		expect(mocks.gptHelper.pushAd.calls.mostRecent().args[3]).toEqual(expectedTargeting);
+		expect(mocks.gptHelper.pushAd.calls.mostRecent().args[2]).toEqual(expectedTargeting);
 	});
 
 	it('Should push ad to helper with proper vertical', function () {
 		var expectedSection = 'tv';
 
 		mocks.vertical = 'tv';
-		evolve2.fillInSlot('LEFT_SKYSCRAPER_2');
+		evolve2.fillInSlot(createSlot('LEFT_SKYSCRAPER_2'));
 
-		expect(mocks.gptHelper.pushAd.calls.mostRecent().args[3].sect).toEqual(expectedSection);
+		expect(mocks.gptHelper.pushAd.calls.mostRecent().args[2].sect).toEqual(expectedSection);
 	});
 
 	it('Should push ad to helper with proper vertical', function () {
 		var expectedSection = 'movies';
 
 		mocks.vertical = 'movies';
-		evolve2.fillInSlot('LEFT_SKYSCRAPER_2');
+		evolve2.fillInSlot(createSlot('LEFT_SKYSCRAPER_2'));
 
-		expect(mocks.gptHelper.pushAd.calls.mostRecent().args[3].sect).toEqual(expectedSection);
+		expect(mocks.gptHelper.pushAd.calls.mostRecent().args[2].sect).toEqual(expectedSection);
 	});
 
 	it('Should push ad to helper with proper mapped vertical', function () {
 		var expectedSection = 'gaming';
 
 		mocks.mappedVertical = 'gaming';
-		evolve2.fillInSlot('LEFT_SKYSCRAPER_2');
+		evolve2.fillInSlot(createSlot('LEFT_SKYSCRAPER_2'));
 
-		expect(mocks.gptHelper.pushAd.calls.mostRecent().args[3].sect).toEqual(expectedSection);
+		expect(mocks.gptHelper.pushAd.calls.mostRecent().args[2].sect).toEqual(expectedSection);
 	});
 
 	it('Should push ad to helper with proper mapped vertical', function () {
 		var expectedSection = 'entertainment';
 
 		mocks.mappedVertical = 'ent';
-		evolve2.fillInSlot('LEFT_SKYSCRAPER_2');
+		evolve2.fillInSlot(createSlot('LEFT_SKYSCRAPER_2'));
 
-		expect(mocks.gptHelper.pushAd.calls.mostRecent().args[3].sect).toEqual(expectedSection);
+		expect(mocks.gptHelper.pushAd.calls.mostRecent().args[2].sect).toEqual(expectedSection);
 	});
 
 	it('Should increment pos tageting value for the same size slots', function () {
-		evolve2.fillInSlot('TOP_RIGHT_BOXAD');
-		evolve2.fillInSlot('HOME_TOP_RIGHT_BOXAD');
+		evolve2.fillInSlot(createSlot('TOP_RIGHT_BOXAD'));
+		evolve2.fillInSlot(createSlot('HOME_TOP_RIGHT_BOXAD'));
 
-		expect(mocks.gptHelper.pushAd.calls.mostRecent().args[3].pos).toEqual('b');
+		expect(mocks.gptHelper.pushAd.calls.mostRecent().args[2].pos).toEqual('b');
 	});
 
 	it('Should start 160x600 with b pos and then increment', function () {
-		evolve2.fillInSlot('LEFT_SKYSCRAPER_2');
-		expect(mocks.gptHelper.pushAd.calls.mostRecent().args[3].pos).toEqual('b');
+		evolve2.fillInSlot(createSlot('LEFT_SKYSCRAPER_2'));
+		expect(mocks.gptHelper.pushAd.calls.mostRecent().args[2].pos).toEqual('b');
 
-		evolve2.fillInSlot('LEFT_SKYSCRAPER_2');
-		expect(mocks.gptHelper.pushAd.calls.mostRecent().args[3].pos).toEqual('c');
+		evolve2.fillInSlot(createSlot('LEFT_SKYSCRAPER_2'));
+		expect(mocks.gptHelper.pushAd.calls.mostRecent().args[2].pos).toEqual('c');
 	});
 });

--- a/extensions/wikia/AdEngine/js/spec/provider/factoryWikiaGpt.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/provider/factoryWikiaGpt.spec.js
@@ -38,9 +38,7 @@ describe('ext.wikia.adEngine.provider.factory.wikiaGpt', function () {
 			getName: function () {
 				return slotName;
 			},
-			getElement: function () {
-				return mocks.slotElement;
-			},
+			getContainer: noop,
 			success: noop,
 			hop: noop,
 			pre: function (name, callback) {

--- a/extensions/wikia/AdEngine/js/spec/provider/factoryWikiaGpt.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/provider/factoryWikiaGpt.spec.js
@@ -35,10 +35,7 @@ describe('ext.wikia.adEngine.provider.factory.wikiaGpt', function () {
 
 	function createSlot(slotName) {
 		return {
-			getName: function () {
-				return slotName;
-			},
-			getContainer: noop,
+			name: slotName,
 			success: noop,
 			hop: noop,
 			pre: function (name, callback) {

--- a/extensions/wikia/AdEngine/js/spec/provider/factoryWikiaGpt.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/provider/factoryWikiaGpt.spec.js
@@ -16,9 +16,9 @@ describe('ext.wikia.adEngine.provider.factory.wikiaGpt', function () {
 				}
 			},
 			gptHelper: {
-				pushAd: function (slotName, slotElement, slotPath, slotTargeting, extra) {
-					extra.success();
-					extra.error();
+				pushAd: function (slot, slotPath, slotTargeting, extra) {
+					slot.success();
+					slot.hop();
 				}
 			},
 			lookups: {
@@ -32,6 +32,22 @@ describe('ext.wikia.adEngine.provider.factory.wikiaGpt', function () {
 			beforeSuccess: noop,
 			beforeHop: noop
 		};
+
+	function createSlot(slotName) {
+		return {
+			getName: function () {
+				return slotName;
+			},
+			getElement: function () {
+				return mocks.slotElement;
+			},
+			success: noop,
+			hop: noop,
+			pre: function (name, callback) {
+				callback();
+			}
+		};
+	}
 
 	function getModule() {
 		return modules['ext.wikia.adEngine.provider.factory.wikiaGpt'](
@@ -73,9 +89,9 @@ describe('ext.wikia.adEngine.provider.factory.wikiaGpt', function () {
 	it('Build slot path based on page params', function () {
 		spyOn(mocks.gptHelper, 'pushAd');
 
-		getProvider().fillInSlot('TOP_LEADERBOARD');
+		getProvider().fillInSlot(createSlot('TOP_LEADERBOARD'));
 
-		expect(mocks.gptHelper.pushAd.calls.mostRecent().args[2]).toEqual(
+		expect(mocks.gptHelper.pushAd.calls.mostRecent().args[1]).toEqual(
 			'/5441/wka.ent/_muppet//home/testSource/TOP_LEADERBOARD'
 		);
 	});
@@ -85,7 +101,7 @@ describe('ext.wikia.adEngine.provider.factory.wikiaGpt', function () {
 
 		getProvider({
 			beforeSuccess: mocks.beforeSuccess
-		}).fillInSlot('TOP_LEADERBOARD', {}, noop, noop);
+		}).fillInSlot(createSlot('TOP_LEADERBOARD'));
 
 		expect(mocks.beforeSuccess).toHaveBeenCalled();
 	});
@@ -95,7 +111,7 @@ describe('ext.wikia.adEngine.provider.factory.wikiaGpt', function () {
 
 		getProvider({
 			beforeHop: mocks.beforeHop
-		}).fillInSlot('TOP_LEADERBOARD', {}, noop, noop);
+		}).fillInSlot(createSlot('TOP_LEADERBOARD'));
 
 		expect(mocks.beforeHop).toHaveBeenCalled();
 	});
@@ -110,10 +126,10 @@ describe('ext.wikia.adEngine.provider.factory.wikiaGpt', function () {
 				}
 			}
 		});
-		provider.fillInSlot('TOP_RIGHT_BOXAD');
-		expect(mocks.gptHelper.pushAd.calls.mostRecent().args[3].size).toEqual('3x3');
-		provider.fillInSlot('TOP_LEADERBOARD');
-		expect(mocks.gptHelper.pushAd.calls.mostRecent().args[3].size).toEqual('2x2');
+		provider.fillInSlot(createSlot('TOP_RIGHT_BOXAD'));
+		expect(mocks.gptHelper.pushAd.calls.mostRecent().args[2].size).toEqual('3x3');
+		provider.fillInSlot(createSlot('TOP_LEADERBOARD'));
+		expect(mocks.gptHelper.pushAd.calls.mostRecent().args[2].size).toEqual('2x2');
 	});
 
 	it('Do nothing when overriding other slots', function () {
@@ -125,9 +141,9 @@ describe('ext.wikia.adEngine.provider.factory.wikiaGpt', function () {
 					TOP_LEADERBOARD: '2x2'
 				}
 			}
-		}).fillInSlot('TOP_RIGHT_BOXAD');
+		}).fillInSlot(createSlot('TOP_RIGHT_BOXAD'));
 
-		expect(mocks.gptHelper.pushAd.calls.mostRecent().args[3].size).toEqual('300x250,300x600');
+		expect(mocks.gptHelper.pushAd.calls.mostRecent().args[2].size).toEqual('300x250,300x600');
 	});
 
 	it('Do nothing when overriding in different country', function () {
@@ -139,8 +155,8 @@ describe('ext.wikia.adEngine.provider.factory.wikiaGpt', function () {
 					TOP_LEADERBOARD: '2x2'
 				}
 			}
-		}).fillInSlot('TOP_LEADERBOARD');
+		}).fillInSlot(createSlot('TOP_LEADERBOARD'));
 
-		expect(mocks.gptHelper.pushAd.calls.mostRecent().args[3].size).toEqual('728x90,970x250,970x90');
+		expect(mocks.gptHelper.pushAd.calls.mostRecent().args[2].size).toEqual('728x90,970x250,970x90');
 	});
 });

--- a/extensions/wikia/AdEngine/js/spec/provider/gpt/adDetect.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/provider/gpt/adDetect.spec.js
@@ -5,6 +5,17 @@ describe('Method ext.wikia.adEngine.provider.gpt.adDetect.onAdLoad', function ()
 	var noop = function () {},
 		returnObj = function () { return {}; };
 
+	function createSlot(slotName, success, hop) {
+		return {
+			getName: function () {
+				return slotName;
+			},
+			success: success,
+			hop: hop,
+			pre: noop
+		};
+	}
+
 	function desktop(name, slotName, gptEvent, windowMock, successOrHop, forceAdType) {
 		it('calls ' + successOrHop + ' for ' + name + ' ' + slotName + ' on desktop', function () {
 			var gptHop, mocks = {
@@ -46,7 +57,7 @@ describe('Method ext.wikia.adEngine.provider.gpt.adDetect.onAdLoad', function ()
 			spyOn(mocks, 'success');
 			spyOn(mocks, 'hop');
 
-			gptHop.onAdLoad(slotName, gptEvent, mocks.iframe, mocks.success, mocks.hop);
+			gptHop.onAdLoad(createSlot(slotName, mocks.success, mocks.hop), gptEvent, mocks.iframe);
 
 			if (successOrHop === 'success') {
 				expect(mocks.success.calls.count()).toBe(1, 'Success callback should be called once');
@@ -110,7 +121,7 @@ describe('Method ext.wikia.adEngine.provider.gpt.adDetect.onAdLoad', function ()
 			spyOn(mocks, 'success');
 			spyOn(mocks, 'hop');
 
-			gptHop.onAdLoad(slotName, gptEvent, mocks.iframe, mocks.success, mocks.hop);
+			gptHop.onAdLoad(createSlot(slotName, mocks.success, mocks.hop), gptEvent, mocks.iframe);
 
 			if (successOrHop === 'success') {
 				expect(mocks.success.calls.count()).toBe(1, 'Success callback should be called once');

--- a/extensions/wikia/AdEngine/js/spec/provider/gpt/adDetect.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/provider/gpt/adDetect.spec.js
@@ -29,12 +29,7 @@ describe('Method ext.wikia.adEngine.provider.gpt.adDetect.onAdLoad', function ()
 						};
 					}
 				},
-				messageListener: {},
-				adSlot: {
-					getShortSlotName: function (slotName) {
-						return slotName;
-					}
-				}
+				messageListener: {}
 			};
 
 			mocks.iframe.contentWindow = {
@@ -48,8 +43,7 @@ describe('Method ext.wikia.adEngine.provider.gpt.adDetect.onAdLoad', function ()
 				mocks.log,
 				mocks.window,
 				mocks.adContext,
-				mocks.messageListener,
-				mocks.adSlot
+				mocks.messageListener
 			);
 
 			spyOn(mocks, 'success');
@@ -85,12 +79,7 @@ describe('Method ext.wikia.adEngine.provider.gpt.adDetect.onAdLoad', function ()
 						};
 					}
 				},
-				messageListener: {},
-				adSlot: {
-					getShortSlotName: function (slotName) {
-						return slotName;
-					}
-				}
+				messageListener: {}
 			};
 
 			mocks.iframe.contentWindow = {};
@@ -112,8 +101,7 @@ describe('Method ext.wikia.adEngine.provider.gpt.adDetect.onAdLoad', function ()
 				mocks.log,
 				mocks.window,
 				mocks.adContext,
-				mocks.messageListener,
-				mocks.adSlot
+				mocks.messageListener
 			);
 
 			spyOn(mocks, 'success');

--- a/extensions/wikia/AdEngine/js/spec/provider/gpt/adDetect.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/provider/gpt/adDetect.spec.js
@@ -7,9 +7,7 @@ describe('Method ext.wikia.adEngine.provider.gpt.adDetect.onAdLoad', function ()
 
 	function createSlot(slotName, success, hop) {
 		return {
-			getName: function () {
-				return slotName;
-			},
+			name: slotName,
 			success: success,
 			hop: hop,
 			pre: noop

--- a/extensions/wikia/AdEngine/js/spec/provider/gpt/helper.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/provider/gpt/helper.spec.js
@@ -78,7 +78,7 @@ describe('ext.wikia.adEngine.provider.gpt.helper', function () {
 			getName: function () {
 				return slotName;
 			},
-			getElement: function () {
+			getContainer: function () {
 				return mocks.slotElement;
 			},
 			success: noop,

--- a/extensions/wikia/AdEngine/js/spec/provider/gpt/helper.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/provider/gpt/helper.spec.js
@@ -73,6 +73,19 @@ describe('ext.wikia.adEngine.provider.gpt.helper', function () {
 		);
 	}
 
+	function createSlot(slotName) {
+		return {
+			getName: function () {
+				return slotName;
+			},
+			getElement: function () {
+				return mocks.slotElement;
+			},
+			success: noop,
+			pre: noop
+		};
+	}
+
 	beforeEach(function () {
 		AdElement = noop;
 
@@ -95,7 +108,7 @@ describe('ext.wikia.adEngine.provider.gpt.helper', function () {
 		spyOn(mocks.googleTag.prototype, 'isInitialized').and.returnValue(false);
 		spyOn(mocks.googleTag.prototype, 'init');
 
-		getModule().pushAd('TOP_LEADERBOARD', mocks.slotElement, '/foo/slot/path', {}, {});
+		getModule().pushAd(createSlot('TOP_LEADERBOARD'), '/foo/slot/path', {}, {});
 
 		expect(mocks.googleTag.prototype.init).toHaveBeenCalled();
 	});
@@ -103,7 +116,7 @@ describe('ext.wikia.adEngine.provider.gpt.helper', function () {
 	it('Prevent initializing googletag if module is already initialized', function () {
 		spyOn(mocks.googleTag.prototype, 'init');
 
-		getModule().pushAd('TOP_LEADERBOARD', mocks.slotElement, '/foo/slot/path', {}, {});
+		getModule().pushAd(createSlot('TOP_LEADERBOARD'), '/foo/slot/path', {}, {});
 
 		expect(mocks.googleTag.prototype.init).not.toHaveBeenCalled();
 	});
@@ -112,7 +125,7 @@ describe('ext.wikia.adEngine.provider.gpt.helper', function () {
 		spyOn(mocks.googleTag.prototype, 'push');
 		spyOn(mocks.googleTag.prototype, 'flush');
 
-		getModule().pushAd('TOP_LEADERBOARD', mocks.slotElement, '/foo/slot/path', {}, {});
+		getModule().pushAd(createSlot('TOP_LEADERBOARD'), '/foo/slot/path', {}, {});
 
 		expect(mocks.googleTag.prototype.push).toHaveBeenCalled();
 		expect(mocks.googleTag.prototype.flush).toHaveBeenCalled();
@@ -123,7 +136,7 @@ describe('ext.wikia.adEngine.provider.gpt.helper', function () {
 		spyOn(mocks.googleTag.prototype, 'flush');
 		spyOn(mocks.sraHelper, 'shouldFlush').and.returnValue(false);
 
-		getModule().pushAd('TOP_LEADERBOARD', mocks.slotElement, '/foo/slot/path', {}, { sraEnabled: true });
+		getModule().pushAd(createSlot('TOP_LEADERBOARD'), '/foo/slot/path', {}, { sraEnabled: true });
 
 		expect(mocks.googleTag.prototype.push).toHaveBeenCalled();
 		expect(mocks.googleTag.prototype.flush).not.toHaveBeenCalled();
@@ -133,7 +146,7 @@ describe('ext.wikia.adEngine.provider.gpt.helper', function () {
 		spyOn(mocks.googleTag.prototype, 'push');
 		spyOn(mocks.googleTag.prototype, 'flush');
 
-		getModule().pushAd('TOP_RIGHT_BOXAD', mocks.slotElement, '/foo/slot/path', {}, { sraEnabled: true });
+		getModule().pushAd(createSlot('TOP_RIGHT_BOXAD'), '/foo/slot/path', {}, { sraEnabled: true });
 
 		expect(mocks.googleTag.prototype.push).toHaveBeenCalled();
 		expect(mocks.googleTag.prototype.flush).toHaveBeenCalled();
@@ -143,14 +156,14 @@ describe('ext.wikia.adEngine.provider.gpt.helper', function () {
 		spyOn(mocks.googleTag.prototype, 'push');
 		spyOn(mocks.googleTag.prototype, 'flush');
 
-		getModule().pushAd('GPT_FLUSH', mocks.slotElement, '/foo/slot/path', { flushOnly: true }, {});
+		getModule().pushAd(createSlot('GPT_FLUSH'), '/foo/slot/path', { flushOnly: true }, {});
 
 		expect(mocks.googleTag.prototype.push).not.toHaveBeenCalled();
 		expect(mocks.googleTag.prototype.flush).toHaveBeenCalled();
 	});
 
 	it('Register slot callback on push', function () {
-		getModule().pushAd('TOP_RIGHT_BOXAD', mocks.slotElement, '/foo/slot/path', {}, {});
+		getModule().pushAd(createSlot('TOP_RIGHT_BOXAD'), '/foo/slot/path', {}, {});
 
 		expect(callbacks.length).toEqual(1);
 	});
@@ -167,7 +180,7 @@ describe('ext.wikia.adEngine.provider.gpt.helper', function () {
 		spyOn(mocks.googleTag.prototype, 'push');
 		spyOn(mocks.googleTag.prototype, 'flush');
 
-		getModule().pushAd('TOP_RIGHT_BOXAD', mocks.slotElement, '/foo/slot/path', {}, { sraEnabled: true });
+		getModule().pushAd(createSlot('TOP_RIGHT_BOXAD'), '/foo/slot/path', {}, { sraEnabled: true });
 
 		expect(mocks.googleTag.prototype.push).not.toHaveBeenCalled();
 		expect(mocks.googleTag.prototype.flush).not.toHaveBeenCalled();
@@ -185,7 +198,7 @@ describe('ext.wikia.adEngine.provider.gpt.helper', function () {
 		spyOn(mocks.googleTag.prototype, 'push');
 		spyOn(mocks.googleTag.prototype, 'flush');
 
-		getModule().pushAd('TOP_RIGHT_BOXAD', mocks.slotElement, '/foo/slot/path', {}, {
+		getModule().pushAd(createSlot('TOP_RIGHT_BOXAD'), '/foo/slot/path', {}, {
 			sraEnabled: true,
 			recoverableSlots: ['TOP_RIGHT_BOXAD']
 		});

--- a/extensions/wikia/AdEngine/js/spec/provider/gpt/helper.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/provider/gpt/helper.spec.js
@@ -75,12 +75,8 @@ describe('ext.wikia.adEngine.provider.gpt.helper', function () {
 
 	function createSlot(slotName) {
 		return {
-			getName: function () {
-				return slotName;
-			},
-			getContainer: function () {
-				return mocks.slotElement;
-			},
+			name: slotName,
+			container: mocks.slotElement,
 			success: noop,
 			pre: noop
 		};

--- a/extensions/wikia/AdEngine/js/spec/provider/gptProviders.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/provider/gptProviders.spec.js
@@ -51,9 +51,7 @@ describe('ext.wikia.adEngine.provider.*', function () {
 
 	function createSlot(slotName) {
 		return {
-			getName: function () {
-				return slotName;
-			},
+			name: slotName,
 			pre: noop,
 			post: noop
 		};

--- a/extensions/wikia/AdEngine/js/spec/provider/gptProviders.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/provider/gptProviders.spec.js
@@ -49,6 +49,16 @@ describe('ext.wikia.adEngine.provider.*', function () {
 			beforeHop: noop
 		};
 
+	function createSlot(slotName) {
+		return {
+			getName: function () {
+				return slotName;
+			},
+			pre: noop,
+			post: noop
+		};
+	}
+
 	function getFactory() {
 		return modules['ext.wikia.adEngine.provider.factory.wikiaGpt'](
 			mocks.adLogicPageParams,
@@ -84,8 +94,8 @@ describe('ext.wikia.adEngine.provider.*', function () {
 	}
 
 	function assertSlotSizes(provider, slotName, expectedSizes) {
-		provider.fillInSlot(slotName, {}, noop, noop);
-		expect(mocks.gptHelper.pushAd.calls.mostRecent().args[3].size)
+		provider.fillInSlot(createSlot(slotName));
+		expect(mocks.gptHelper.pushAd.calls.mostRecent().args[2].size)
 			.toBe(expectedSizes, provider.name + '.' + slotName + ' sizes');
 	}
 

--- a/extensions/wikia/AdEngine/js/spec/provider/taboola.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/provider/taboola.spec.js
@@ -69,6 +69,18 @@ describe('Taboola ', function () {
 		);
 	}
 
+	function createSlot(slotName) {
+		return {
+			getName: function () {
+				return slotName;
+			},
+			getElement: function () {
+				return mocks.document.node;
+			},
+			success: noop
+		};
+	}
+
 	beforeEach(function () {
 		mocks.instantGlobals.wgAdDriverTaboolaConfig = {
 			'NATIVE_TABOOLA_ARTICLE': {
@@ -161,7 +173,7 @@ describe('Taboola ', function () {
 		var taboola = getTaboola();
 
 		taboola.canHandleSlot('NATIVE_TABOOLA_ARTICLE');
-		taboola.fillInSlot('NATIVE_TABOOLA_ARTICLE', mocks.document.node, noop);
+		taboola.fillInSlot(createSlot('NATIVE_TABOOLA_ARTICLE'));
 
 		expect(mocks.recoveryHelper.addOnBlockingCallback).not.toHaveBeenCalled();
 		expect(mocks.slotTweaker.show).toHaveBeenCalled();
@@ -177,7 +189,7 @@ describe('Taboola ', function () {
 		var taboola = getTaboola();
 
 		taboola.canHandleSlot('NATIVE_TABOOLA_RAIL');
-		taboola.fillInSlot('NATIVE_TABOOLA_RAIL', mocks.document.node, noop);
+		taboola.fillInSlot(createSlot('NATIVE_TABOOLA_RAIL'));
 
 		expect(mocks.recoveryHelper.addOnBlockingCallback).toHaveBeenCalled();
 	});

--- a/extensions/wikia/AdEngine/js/spec/provider/taboola.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/provider/taboola.spec.js
@@ -71,12 +71,8 @@ describe('Taboola ', function () {
 
 	function createSlot(slotName) {
 		return {
-			getName: function () {
-				return slotName;
-			},
-			getContainer: function () {
-				return mocks.document.node;
-			},
+			name: slotName,
+			container: mocks.document.node,
 			success: noop
 		};
 	}

--- a/extensions/wikia/AdEngine/js/spec/provider/taboola.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/provider/taboola.spec.js
@@ -74,7 +74,7 @@ describe('Taboola ', function () {
 			getName: function () {
 				return slotName;
 			},
-			getElement: function () {
+			getContainer: function () {
 				return mocks.document.node;
 			},
 			success: noop

--- a/extensions/wikia/AdEngine/js/spec/template/modal.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/template/modal.spec.js
@@ -15,6 +15,15 @@ describe('ext.wikia.adEngine.template.modal', function () {
 				throttle: noop
 			},
 			adDetect: {},
+			adSlot: {
+				create: function (slotName) {
+					return {
+						name: slotName,
+						success: noop,
+						hop: noop
+					};
+				}
+			},
 			modalHandlerFactory: {
 				create: function () {
 					return mocks.modalHandlerMock;
@@ -78,6 +87,7 @@ describe('ext.wikia.adEngine.template.modal', function () {
 	function getModule() {
 		return modules['ext.wikia.adEngine.template.modal'](
 			mocks.adHelper,
+			mocks.adSlot,
 			mocks.adDetect,
 			mocks.modalHandlerFactory,
 			mocks.doc,

--- a/extensions/wikia/AdEngine/js/spec/utils/hooks.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/utils/hooks.spec.js
@@ -1,0 +1,122 @@
+/*global describe, it, expect, modules, beforeEach, spyOn*/
+describe('ext.wikia.adEngine.utils.hooks', function () {
+	'use strict';
+
+	var mocks = {},
+		registerHooks;
+
+	function noop () {}
+
+	function getModule() {
+		return modules['ext.wikia.adEngine.utils.hooks']();
+	}
+
+	beforeEach(function () {
+		mocks.fooObject = {
+			foo: noop,
+			bar: noop,
+			baz: noop
+		};
+		registerHooks = getModule();
+	});
+
+	it('Throw exception on registering not existing method', function () {
+		expect(function () {
+			registerHooks(mocks.fooObject, ['qux']);
+		}).toThrowError('Method qux does not exist.');
+	});
+
+	it('Throw exception on adding callbacks to not registered method', function () {
+		registerHooks(mocks.fooObject, ['foo', 'bar']);
+		expect(function () {
+			mocks.fooObject.pre('baz', noop);
+		}).toThrowError('Method baz is not registered.');
+	});
+
+	it('Call pre hooks on correctly registered method', function () {
+		var spies = {
+			preFoo1: noop,
+			preFoo2: noop
+		};
+		registerHooks(mocks.fooObject, ['foo', 'bar']);
+		spyOn(mocks.fooObject, 'foo').and.callThrough();
+		spyOn(spies, 'preFoo1');
+		spyOn(spies, 'preFoo2');
+
+		mocks.fooObject.pre('foo', spies.preFoo1);
+		mocks.fooObject.pre('foo', spies.preFoo2);
+		mocks.fooObject.foo();
+
+		expect(mocks.fooObject.foo).toHaveBeenCalled();
+		expect(spies.preFoo1).toHaveBeenCalled();
+		expect(spies.preFoo2).toHaveBeenCalled();
+	});
+
+	it('Call method and all pre hooks with correct arguments', function () {
+		var spies = {
+			preFoo: noop
+		};
+		registerHooks(mocks.fooObject, ['foo', 'bar']);
+		spyOn(mocks.fooObject, 'foo').and.callThrough();
+		spyOn(spies, 'preFoo').and.callThrough();
+
+		mocks.fooObject.pre('foo', spies.preFoo);
+		mocks.fooObject.foo('barArgument', []);
+
+		expect(mocks.fooObject.foo.calls.mostRecent().args[0]).toEqual('barArgument');
+		expect(mocks.fooObject.foo.calls.mostRecent().args[1]).toEqual([]);
+
+		expect(spies.preFoo.calls.mostRecent().args[0]).toEqual('barArgument');
+		expect(spies.preFoo.calls.mostRecent().args[1]).toEqual([]);
+	});
+
+	it('Call post hooks on correctly registered method', function () {
+		var spies = {
+			postBar1: noop,
+			postBar2: noop
+		};
+		registerHooks(mocks.fooObject, ['foo', 'bar']);
+		spyOn(mocks.fooObject, 'bar').and.callThrough();
+		spyOn(spies, 'postBar1');
+		spyOn(spies, 'postBar2');
+
+		mocks.fooObject.post('bar', spies.postBar1);
+		mocks.fooObject.post('bar', spies.postBar2);
+		mocks.fooObject.bar();
+
+		expect(mocks.fooObject.bar).toHaveBeenCalled();
+		expect(spies.postBar1).toHaveBeenCalled();
+		expect(spies.postBar2).toHaveBeenCalled();
+	});
+
+	it('Call method and all post hooks with correct arguments', function () {
+		var spies = {
+			postBar: noop
+		};
+		registerHooks(mocks.fooObject, ['foo', 'bar']);
+		spyOn(mocks.fooObject, 'bar').and.callThrough();
+		spyOn(spies, 'postBar').and.callThrough();
+
+		mocks.fooObject.post('bar', spies.postBar);
+		mocks.fooObject.bar('fooArgument', {a:1});
+
+		expect(mocks.fooObject.bar.calls.mostRecent().args[0]).toEqual('fooArgument');
+		expect(mocks.fooObject.bar.calls.mostRecent().args[1]).toEqual({a:1});
+
+		expect(spies.postBar.calls.mostRecent().args[0]).toEqual('fooArgument');
+		expect(spies.postBar.calls.mostRecent().args[1]).toEqual({a:1});
+	});
+
+	it('Do not call hooks of different method', function () {
+		var spies = {
+			preFoo: noop
+		};
+		registerHooks(mocks.fooObject, ['foo', 'bar']);
+		spyOn(spies, 'preFoo');
+
+		mocks.fooObject.pre('foo', spies.preFoo);
+		mocks.fooObject.bar();
+
+		expect(spies.preFoo).not.toHaveBeenCalled();
+	});
+});

--- a/extensions/wikia/AdEngine/js/template/floor.js
+++ b/extensions/wikia/AdEngine/js/template/floor.js
@@ -82,15 +82,16 @@ define('ext.wikia.adEngine.template.floor', [
 
 		if (async) {
 			log(['show', params.slotName, 'can hop'], 'info', logGroup);
-			slot = adSlot.create(params.slotName);
-			slot.pre('success', function () {
-				log(['ad detect', params.slotName, 'success'], 'info', logGroup);
-				win.postMessage('{"AdEngine":{"slot_' + params.slotName + '":true,"status":"success"}}', '*');
-				showFloor();
-			});
-			slot.pre('hop', function () {
-				log(['ad detect', params.slotName, 'hop'], 'info', logGroup);
-				win.postMessage('{"AdEngine":{"slot_' + params.slotName + '":true,"status":"hop"}}', '*');
+			slot = adSlot.create(params.slotName, null, {
+				success: function () {
+					log(['ad detect', params.slotName, 'success'], 'info', logGroup);
+					win.postMessage('{"AdEngine":{"slot_' + params.slotName + '":true,"status":"success"}}', '*');
+					showFloor();
+				},
+				hop: function () {
+					log(['ad detect', params.slotName, 'hop'], 'info', logGroup);
+					win.postMessage('{"AdEngine":{"slot_' + params.slotName + '":true,"status":"hop"}}', '*');
+				}
 			});
 			$(iframe).on('load', function () {
 				adDetect.onAdLoad(slot, gptEventMock, iframe);

--- a/extensions/wikia/AdEngine/js/template/floor.js
+++ b/extensions/wikia/AdEngine/js/template/floor.js
@@ -1,12 +1,13 @@
 /*global define*/
 define('ext.wikia.adEngine.template.floor', [
 	'ext.wikia.adEngine.adContext',
+	'ext.wikia.adEngine.slot.adSlot',
 	'ext.wikia.adEngine.provider.gpt.adDetect',
 	'wikia.log',
 	'wikia.document',
 	'wikia.iframeWriter',
 	'wikia.window'
-], function (adContext, adDetect, log, doc, iframeWriter, win) {
+], function (adContext, adSlot, adDetect, log, doc, iframeWriter, win) {
 	'use strict';
 
 	var logGroup = 'ext.wikia.adEngine.template.floor',
@@ -59,7 +60,8 @@ define('ext.wikia.adEngine.template.floor', [
 					height: params.height
 				}
 			},
-			async = params.canHop && params.slotName;
+			async = params.canHop && params.slotName,
+			slot;
 
 		function showFloor() {
 			var skin = adContext.getContext().targeting.skin;
@@ -80,15 +82,18 @@ define('ext.wikia.adEngine.template.floor', [
 
 		if (async) {
 			log(['show', params.slotName, 'can hop'], 'info', logGroup);
+			slot = adSlot.create(params.slotName);
+			slot.pre('success', function () {
+				log(['ad detect', params.slotName, 'success'], 'info', logGroup);
+				win.postMessage('{"AdEngine":{"slot_' + params.slotName + '":true,"status":"success"}}', '*');
+				showFloor();
+			});
+			slot.pre('hop', function () {
+				log(['ad detect', params.slotName, 'hop'], 'info', logGroup);
+				win.postMessage('{"AdEngine":{"slot_' + params.slotName + '":true,"status":"hop"}}', '*');
+			});
 			$(iframe).on('load', function () {
-				adDetect.onAdLoad(params.slotName + ' (floor inner iframe)', gptEventMock, iframe, function () {
-					log(['ad detect', params.slotName, 'success'], 'info', logGroup);
-					win.postMessage('{"AdEngine":{"slot_' + params.slotName + '":true,"status":"success"}}', '*');
-					showFloor();
-				}, function () {
-					log(['ad detect', params.slotName, 'hop'], 'info', logGroup);
-					win.postMessage('{"AdEngine":{"slot_' + params.slotName + '":true,"status":"hop"}}', '*');
-				});
+				adDetect.onAdLoad(slot, gptEventMock, iframe);
 			});
 		}
 

--- a/extensions/wikia/AdEngine/js/template/modal.js
+++ b/extensions/wikia/AdEngine/js/template/modal.js
@@ -88,15 +88,16 @@ define('ext.wikia.adEngine.template.modal', [
 		adContainer.appendChild(adIframe);
 
 		if (async) {
-			slot = adSlot.create(params.slotName);
-			slot.pre('success', function () {
-				log(['ad detect', params.slotName, 'success'], 'info', logGroup);
-				win.postMessage('{"AdEngine":{"slot_' + params.slotName + '":true,"status":"success"}}', '*');
-				modalHandler.show();
-			});
-			slot.pre('hop', function () {
-				log(['ad detect', params.slotName, 'hop'], 'info', logGroup);
-				win.postMessage('{"AdEngine":{"slot_' + params.slotName + '":true,"status":"hop"}}', '*');
+			slot = adSlot.create(params.slotName, null, {
+				success: function () {
+					log(['ad detect', params.slotName, 'success'], 'info', logGroup);
+					win.postMessage('{"AdEngine":{"slot_' + params.slotName + '":true,"status":"success"}}', '*');
+					modalHandler.show();
+				},
+				hop: function () {
+					log(['ad detect', params.slotName, 'hop'], 'info', logGroup);
+					win.postMessage('{"AdEngine":{"slot_' + params.slotName + '":true,"status":"hop"}}', '*');
+				}
 			});
 			adIframe.addEventListener('load', function () {
 				adDetect.onAdLoad(slot, gptEventMock, adIframe);

--- a/extensions/wikia/AdEngine/js/template/modal.js
+++ b/extensions/wikia/AdEngine/js/template/modal.js
@@ -1,13 +1,14 @@
 /*global define*/
 define('ext.wikia.adEngine.template.modal', [
 	'ext.wikia.adEngine.adHelper',
+	'ext.wikia.adEngine.slot.adSlot',
 	'ext.wikia.adEngine.provider.gpt.adDetect',
 	'ext.wikia.adEngine.template.modalHandlerFactory',
 	'wikia.document',
 	'wikia.log',
 	'wikia.iframeWriter',
 	'wikia.window'
-], function (adHelper, adDetect, modalHandlerFactory, doc, log, iframeWriter, win) {
+], function (adHelper, adSlot, adDetect, modalHandlerFactory, doc, log, iframeWriter, win) {
 	'use strict';
 
 	var logGroup = 'ext.wikia.adEngine.template.modal',
@@ -22,7 +23,7 @@ define('ext.wikia.adEngine.template.modal', [
 	 * @param {number} params.height - desired height of the Lightbox
 	 * @param {boolean} params.scalable - extend iframe to maximum sensible size of the Lightbox
 	 * @param {boolean} [params.canHop] - detect ad in the embedded iframe
-	 * @param {string}  [params.slotName] - name of the original slot (required if params.canHop set to true)
+	 * @param {string} [params.slotName] - name of the original slot (required if params.canHop set to true)
 	 * @param {number} [params.closeDelay] - delay (in seconds) after which a close button will appear and modal will be able to close
 	 */
 	function show(params) {
@@ -42,7 +43,8 @@ define('ext.wikia.adEngine.template.modal', [
 					height: params.height
 				}
 			},
-			lightboxParams = modalHandler.getExpansionModel();
+			lightboxParams = modalHandler.getExpansionModel(),
+			slot;
 
 		if (modalHandler === null) {
 			return;
@@ -86,15 +88,18 @@ define('ext.wikia.adEngine.template.modal', [
 		adContainer.appendChild(adIframe);
 
 		if (async) {
+			slot = adSlot.create(params.slotName);
+			slot.pre('success', function () {
+				log(['ad detect', params.slotName, 'success'], 'info', logGroup);
+				win.postMessage('{"AdEngine":{"slot_' + params.slotName + '":true,"status":"success"}}', '*');
+				modalHandler.show();
+			});
+			slot.pre('hop', function () {
+				log(['ad detect', params.slotName, 'hop'], 'info', logGroup);
+				win.postMessage('{"AdEngine":{"slot_' + params.slotName + '":true,"status":"hop"}}', '*');
+			});
 			adIframe.addEventListener('load', function () {
-				adDetect.onAdLoad(params.slotName + ' (modal inner iframe)', gptEventMock, adIframe, function () {
-					log(['ad detect', params.slotName, 'success'], 'info', logGroup);
-					win.postMessage('{"AdEngine":{"slot_' + params.slotName + '":true,"status":"success"}}', '*');
-					modalHandler.show();
-				}, function () {
-					log(['ad detect', params.slotName, 'hop'], 'info', logGroup);
-					win.postMessage('{"AdEngine":{"slot_' + params.slotName + '":true,"status":"hop"}}', '*');
-				});
+				adDetect.onAdLoad(slot, gptEventMock, adIframe);
 			});
 		}
 

--- a/extensions/wikia/AdEngine/js/utils/hooks.js
+++ b/extensions/wikia/AdEngine/js/utils/hooks.js
@@ -1,5 +1,5 @@
 /*global define*/
-define('ext.wikia.adEngine.utils.hooks', function () {
+define('ext.wikia.adEngine.utils.hooks', [], function () {
 	'use strict';
 
 	/**
@@ -20,13 +20,17 @@ define('ext.wikia.adEngine.utils.hooks', function () {
 				if (!hooks[methodName]) {
 					throw new Error('Method ' + methodName + ' is not registered.');
 				}
-				hooks[methodName].pre.push(callback);
+				if (typeof callback === 'function') {
+					hooks[methodName].pre.push(callback);
+				}
 			};
 			objectInstance.post = function (methodName, callback) {
 				if (!hooks[methodName]) {
 					throw new Error('Method ' + methodName + ' is not registered.');
 				}
-				hooks[methodName].post.push(callback);
+				if (typeof callback === 'function') {
+					hooks[methodName].post.push(callback);
+				}
 			};
 		}
 

--- a/extensions/wikia/AdEngine/js/utils/hooks.js
+++ b/extensions/wikia/AdEngine/js/utils/hooks.js
@@ -1,0 +1,59 @@
+/*global define*/
+define('ext.wikia.adEngine.utils.hooks', function () {
+	'use strict';
+
+	/**
+	 * Register "pre" and "post" hooks for given methods
+	 *
+	 * @param {object} objectInstance
+	 * @param {string[]} methodNames
+	 */
+	return function (objectInstance, methodNames) {
+		var hooks = {};
+
+		function addHookListeners() {
+			if (typeof objectInstance.pre === 'function' || typeof objectInstance.post === 'function') {
+				return;
+			}
+
+			objectInstance.pre = function (methodName, callback) {
+				if (!hooks[methodName]) {
+					throw new Error('Method ' + methodName + ' is not registered.');
+				}
+				hooks[methodName].pre.push(callback);
+			};
+			objectInstance.post = function (methodName, callback) {
+				if (!hooks[methodName]) {
+					throw new Error('Method ' + methodName + ' is not registered.');
+				}
+				hooks[methodName].post.push(callback);
+			};
+		}
+
+		function callAllCallbacks(callbacks, args) {
+			callbacks.forEach(function (callback) {
+				callback.apply(objectInstance, args);
+			});
+		}
+
+		methodNames.forEach(function (methodName) {
+			var copy = objectInstance[methodName];
+			if (typeof copy !== 'function') {
+				throw new Error('Method ' + methodName + ' does not exist.');
+			}
+
+			hooks[methodName] = {
+				pre: [],
+				post: []
+			};
+
+			objectInstance[methodName] = function () {
+				callAllCallbacks(hooks[methodName].pre, arguments);
+				copy.apply(objectInstance, arguments);
+				callAllCallbacks(hooks[methodName].post, arguments);
+			};
+		});
+
+		addHookListeners();
+	};
+});

--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -106,6 +106,7 @@ $config['adengine2_desktop_js'] = array(
 		'//extensions/wikia/AdEngine/js/template/modalOasisHandler.js',
 		'//extensions/wikia/AdEngine/js/template/skin.js',
 		'//extensions/wikia/AdEngine/js/utils/AdLogicZoneParams.js',
+		'//extensions/wikia/AdEngine/js/utils/hooks.js',
 		'//resources/wikia/modules/krux.js',
 
 		// was: late queue
@@ -817,6 +818,7 @@ $config['mobile_base_ads_js'] = array(
 		'//extensions/wikia/AdEngine/js/provider/remnantGptMobile.js',
 		'//extensions/wikia/AdEngine/js/slot/adSlot.js',
 		'//extensions/wikia/AdEngine/js/utils/AdLogicZoneParams.js',
+		'//extensions/wikia/AdEngine/js/utils/hooks.js',
 
 		// Video ads
 		'//extensions/wikia/AdEngine/js/WikiaDartVideoHelper.js',

--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -211,7 +211,6 @@ $config['adengine2_tracking_js'] = array(
 		'//extensions/wikia/AdEngine/js/lookup/lookupFactory.js',
 		'//extensions/wikia/AdEngine/js/slot/adSlot.js',
 		'//extensions/wikia/AdEngine/js/utils/AdLogicZoneParams.js',
-		'//extensions/wikia/AdEngine/js/utils/hooks.js',
 		'//resources/wikia/modules/krux.js'
 	),
 );

--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -211,7 +211,8 @@ $config['adengine2_tracking_js'] = array(
 		'//extensions/wikia/AdEngine/js/lookup/lookupFactory.js',
 		'//extensions/wikia/AdEngine/js/slot/adSlot.js',
 		'//extensions/wikia/AdEngine/js/utils/AdLogicZoneParams.js',
-		'//resources/wikia/modules/krux.js',
+		'//extensions/wikia/AdEngine/js/utils/hooks.js',
+		'//resources/wikia/modules/krux.js'
 	),
 );
 


### PR DESCRIPTION
Done:
- Refactor whole flow of success/hop callbacks - use kind of slot state instead of passing those functions as arguments through many classes
- Add one more partner type (more general) to be able reuse it in future and allow it to collapse slot

Still to do:
ADEN-2930, ADEN-2931, ADEN-2932
