### PR TITLE
ADEN-2936 Fix ad tracking on mercury skin

### DIFF
--- a/resources/wikia/modules/tracker.js
+++ b/resources/wikia/modules/tracker.js
@@ -46,7 +46,7 @@
 			],
 			// @see /extensions/wikia/AnalyticsEngine/js/universal_analytics.js
 			guaTrackEvent = window.guaTrackEvent,
-			guaTrackAdEvent = window.guaTrackAdEvent,
+			guaTrackAdEvent = window.guaTrackAdEvent || (window.Mercury && window.Mercury.Modules.Ads.gaTrackAdEvent),
 			logGroup = 'Wikia.Tracker',
 			// These keys will be removed from tracking data before it gets sent to
 			// GA or the internal datawarehouse.

--- a/resources/wikia/modules/tracker.js
+++ b/resources/wikia/modules/tracker.js
@@ -46,7 +46,7 @@
 			],
 			// @see /extensions/wikia/AnalyticsEngine/js/universal_analytics.js
 			guaTrackEvent = window.guaTrackEvent,
-			guaTrackAdEvent = window.guaTrackAdEvent || (window.Mercury && window.Mercury.Modules.Ads.gaTrackAdEvent),
+			guaTrackAdEvent = window.guaTrackAdEvent || window.gaTrackAdEvent,
 			logGroup = 'Wikia.Tracker',
 			// These keys will be removed from tracking data before it gets sent to
 			// GA or the internal datawarehouse.


### PR DESCRIPTION
Use `window.Mercury.Modules.Ads.gaTrackAdEvent` to track ads events on Mercury skin. It has own sampling [in Ads.js file](https://github.com/Wikia/mercury/blob/dev/front/common/modules/Ads.js#L116) like `window.guaTrackAdEvent` [in universal_analytics.js](https://github.com/Wikia/app/blob/dev/extensions/wikia/AnalyticsEngine/js/universal_analytics.js#L493).
