### PR TITLE
SUS-78 | Special:Videos remove sort dropdown

### DIFF
--- a/extensions/wikia/AdminDashboard/AdminDashboardSpecialPageController.class.php
+++ b/extensions/wikia/AdminDashboard/AdminDashboardSpecialPageController.class.php
@@ -40,7 +40,7 @@ class AdminDashboardSpecialPageController extends WikiaSpecialPageController {
 		if( !empty( $this->wg->EnableSpecialVideosExt ) ) {
 			$this->showVideoLink = true;
 			$this->urlAddVideo = Title::newFromText('WikiaVideoAdd', NS_SPECIAL)->getFullURL();
-			$this->urlAddVideoReturnUrl = SpecialPage::getTitleFor("Videos")->escapeLocalUrl( "sort=recent" );
+			$this->urlAddVideoReturnUrl = SpecialPage::getTitleFor("Videos")->escapeLocalUrl();
 		} else {
 			$this->showVideoLink = false;
 		}

--- a/extensions/wikia/FilePage/FilePageController.class.php
+++ b/extensions/wikia/FilePage/FilePageController.class.php
@@ -544,8 +544,6 @@ SQL;
 		$this->providerUrl = $this->getVal( 'providerUrl' );
 		$this->expireDate = $expireDate;
 		$this->regionalRestrictions = $regionalRestrictions;
-		// FIXME: this isn't shown to users b/c it's buggy (CONSF-51)
-		$this->viewCount = $this->getVal( 'views' );
 
 		wfProfileOut( __METHOD__ );
 	}

--- a/extensions/wikia/Lightbox/Lightbox.i18n.php
+++ b/extensions/wikia/Lightbox/Lightbox.i18n.php
@@ -30,7 +30,6 @@ $messages['en'] = array(
 	'lightbox-pin-carousel-tooltip' => 'Pin top and bottom bars in place',
 	'lightbox-unpin-carousel-tooltip' => 'Unpin top and bottom bars',
 	'lightbox-carousel-more-items' => "'''$1''' {{PLURAL:$1|more item|more items}} on this wiki",
-	'lightbox-video-views' => "'''$1''' {{PLURAL:$1|view|views}}",
 
 	/* /new stuff */
 
@@ -106,7 +105,6 @@ $messages['qqq'] = array(
 * $1 is a username.',
 	'lightbox-share-email-body-video' => 'Parameters:
 * $1 is a link to the suggested image.',
-	'lightbox-video-views' => 'video views. $1 is number of video views.',
 );
 
 /** Azerbaijani (Azərbaycanca)

--- a/extensions/wikia/Lightbox/LightboxController.class.php
+++ b/extensions/wikia/Lightbox/LightboxController.class.php
@@ -202,8 +202,6 @@ class LightboxController extends WikiaController {
 		list( $smallerArticleList, $articleListIsSmaller ) = WikiaFileHelper::truncateArticleList( $articles, self::POSTED_IN_ARTICLES );
 
 		// file details
-		// FIXME: view count isn't shown to users b/c it's buggy (CONSF-51)
-		$this->views = wfMessage( 'lightbox-video-views', $this->wg->Lang->formatNum( $data['videoViews'] ) )->parse();
 		$this->title = $title->getDBKey();
 		$this->fileTitle = $title->getText();
 		$this->mediaType = $data['mediaType'];

--- a/extensions/wikia/Lightbox/tests/LightboxControllerTest.php
+++ b/extensions/wikia/Lightbox/tests/LightboxControllerTest.php
@@ -308,7 +308,6 @@ class LightboxControllerTest extends WikiaBaseTest {
 		$format = \WikiaResponse::FORMAT_JSON;
 
 		global $wgLang;
-		$views = wfMessage( 'lightbox-video-views', $wgLang->formatNum( $data['videoViews'] ) )->parse();
 
 		$mediaDetail = [
 			'mediaType'         => $mediaType,
@@ -322,7 +321,6 @@ class LightboxControllerTest extends WikiaBaseTest {
 			'userPageUrl'       => $userPageUrl,
 			'articles'          => $articles,
 			'providerName'      => $providerName,
-			'views'             => $views,
 			'exists'            => $exists,
 			'isAdded'           => $isAdded,
 			'extraHeight'       => $extraHeight,

--- a/extensions/wikia/SpecialVideos/SpecialVideosHelper.class.php
+++ b/extensions/wikia/SpecialVideos/SpecialVideosHelper.class.php
@@ -46,39 +46,6 @@ class SpecialVideosHelper extends WikiaModel {
 	}
 
 	/**
-	 * get list of sorting options
-	 * @return array $options
-	 */
-	public function getSortOptions() {
-		$options = [
-			'recent'  => wfMessage( 'specialvideos-sort-latest' )->escaped(),
-		];
-
-		return $options;
-	}
-
-	/**
-	 * get list of filter options
-	 * @return array $options
-	 */
-	public function getFilterOptions() {
-		$options = array();
-
-		$premiumVideos = $this->premiumVideosExist();
-		if ( !empty( $premiumVideos ) ) {
-			$options['premium'] = wfMessage( 'specialvideos-sort-featured' )->text();
-		}
-
-		if ( $this->wg->UseVideoVerticalFilters ) {
-			$options['trend:Games'] = wfMessage( 'specialvideos-filter-games' )->text();
-			$options['trend:Lifestyle'] = wfMessage( 'specialvideos-filter-lifestyle' )->text();
-			$options['trend:Entertainment'] = wfMessage( 'specialvideos-filter-entertainment' )->text();
-		}
-
-		return $options;
-	}
-
-	/**
 	 * get list of videos
 	 * @param integer $page
 	 * @param string $filter [all/premium]
@@ -130,7 +97,7 @@ class SpecialVideosHelper extends WikiaModel {
 			$videoDetail = $helper->getVideoDetail( $videoInfo, $videoOptions );
 			if ( !empty( $videoDetail ) ) {
 				$byUserMsg = WikiaFileHelper::getByUserMsg( $videoDetail['userName'], $videoDetail['timestamp'] );
-				// FIXME: this isn't shown to users b/c it's buggy (CONSF-51)
+				// SUS-78 | Not used in template but used by API clients - GameGuides App
 				$viewTotal = wfMessage( 'videohandler-video-views', $this->wg->Lang->formatNum( $videoDetail['viewsTotal'] ) )->text();
 
 				$videos[] = [

--- a/extensions/wikia/SpecialVideos/SpecialVideosHelper.class.php
+++ b/extensions/wikia/SpecialVideos/SpecialVideosHelper.class.php
@@ -97,8 +97,6 @@ class SpecialVideosHelper extends WikiaModel {
 			$videoDetail = $helper->getVideoDetail( $videoInfo, $videoOptions );
 			if ( !empty( $videoDetail ) ) {
 				$byUserMsg = WikiaFileHelper::getByUserMsg( $videoDetail['userName'], $videoDetail['timestamp'] );
-				// SUS-78 | Not used in template but used by API clients - GameGuides App
-				$viewTotal = wfMessage( 'videohandler-video-views', $this->wg->Lang->formatNum( $videoDetail['viewsTotal'] ) )->text();
 
 				$videos[] = [
 					'title' => $videoDetail['fileTitle'],
@@ -107,7 +105,6 @@ class SpecialVideosHelper extends WikiaModel {
 					'thumbnail' => $videoDetail['thumbnail'],
 					'timestamp' => wfTimeFormatAgo( $videoDetail['timestamp'], false ),
 					'updated' => $videoDetail['timestamp'],
-					'viewTotal' => $viewTotal,
 					'byUserMsg' => $byUserMsg,
 					'truncatedList' => $videoDetail['truncatedList'],
 					'duration' => $videoDetail['duration'],

--- a/extensions/wikia/SpecialVideos/SpecialVideosHelper.class.php
+++ b/extensions/wikia/SpecialVideos/SpecialVideosHelper.class.php
@@ -80,22 +80,15 @@ class SpecialVideosHelper extends WikiaModel {
 
 	/**
 	 * get list of videos
-	 * @param string $sort [recent/popular/trend]
 	 * @param integer $page
+	 * @param string $filter [all/premium]
 	 * @param array $providers
 	 * @param string $category
 	 * @param array $options
 	 * @return array $videos
 	 */
-	public function getVideos( $sort, $page, $providers = [], $category = '', $options = [] ) {
+	public function getVideos( $page, $filter = 'all', $providers = [], $category = '', $options = [] ) {
 		wfProfileIn( __METHOD__ );
-
-		if ( $sort == 'premium' ) {
-			$sort = 'recent';
-			$filter = 'premium';
-		} else {
-			$filter = 'all';
-		}
 
 		if ( $this->app->checkSkin( 'wikiamobile' ) ) {
 			$limit = self::VIDEOS_PER_PAGE_MOBILE;
@@ -120,7 +113,7 @@ class SpecialVideosHelper extends WikiaModel {
 
 		// get video list
 		$mediaService = new MediaQueryService();
-		$videoList = $mediaService->getVideoList( $sort, $filter, $limit, $page, $providers, $category );
+		$videoList = $mediaService->getVideoList( $filter, $limit, $page, $providers, $category );
 
 		$videoOptions = [
 			'thumbWidth'       => self::THUMBNAIL_WIDTH,

--- a/extensions/wikia/SpecialVideos/SpecialVideosHelper.class.php
+++ b/extensions/wikia/SpecialVideos/SpecialVideosHelper.class.php
@@ -50,21 +50,9 @@ class SpecialVideosHelper extends WikiaModel {
 	 * @return array $options
 	 */
 	public function getSortOptions() {
-		$options = $this->getSortOptionsMobile();
-		$options['popular'] = wfMessage( 'specialvideos-sort-most-popular' )->plain();
-
-		return $options;
-	}
-
-	/**
-	 * get list of sorting options for mobile
-	 * @return array $options
-	 */
-	public function getSortOptionsMobile() {
-		$options = array(
-			'trend'   => wfMessage( 'specialvideos-sort-trending' )->plain(),
-			'recent'  => wfMessage( 'specialvideos-sort-latest' )->plain(),
-		);
+		$options = [
+			'recent'  => wfMessage( 'specialvideos-sort-latest' )->escaped(),
+		];
 
 		return $options;
 	}

--- a/extensions/wikia/SpecialVideos/SpecialVideosSpecialController.class.php
+++ b/extensions/wikia/SpecialVideos/SpecialVideosSpecialController.class.php
@@ -13,7 +13,6 @@ class SpecialVideosSpecialController extends WikiaSpecialPageController {
 
 	/**
 	 * Videos page
-	 * @requestParam string sort [ recent/popular/trend/premium ]
 	 * @requestParam integer page - page number
 	 * @requestParam string category
 	 * @requestParam string msg - BannerNotifications message
@@ -22,8 +21,6 @@ class SpecialVideosSpecialController extends WikiaSpecialPageController {
 	 * @responseParam integer addVideo [0/1]
 	 * @responseParam string pagination
 	 * @responseParam string loadMore (For mobile only)
-	 * @responseParam string sortMsg - selected option (sorting)
-	 * @responseParam array sortingOptions - sorting options
 	 * @responseParam array videos - list of videos
 	 * @responseParam string message
 	 */
@@ -61,8 +58,6 @@ class SpecialVideosSpecialController extends WikiaSpecialPageController {
 		// Add meta description tag to HTML source
 		$this->getContext()->getOutput()->addMeta( 'description', $helper->getMetaTagDescription() );
 
-		// Sorting/filtering dropdown values
-		$sort = $this->request->getVal( 'sort', 'recent' );
 		$page = $this->request->getVal( 'page', 1 );
 		$category = $this->request->getVal( 'category', '' );
 		// Filter on a comma separated list of providers if given.
@@ -89,23 +84,8 @@ class SpecialVideosSpecialController extends WikiaSpecialPageController {
 		// Variable to display the "add video" link at the end of the results
 		$addVideo = 1;
 
-		// get sorting options
-		if ( $isMobile ) {
-			$sortingOptions = $helper->getSortOptions();
-		} else {
-			$sortingOptions = array_merge( $helper->getSortOptions(), $helper->getFilterOptions() );
-		}
-
-		if ( !array_key_exists( $sort, $sortingOptions ) ) {
-			$sort = 'recent';
-		}
-
-		// The new trending in <category> options have a slightly different key format
-		$sortKey = $sort.( empty( $category ) ? '' : ":$category" );
-
 		// get videos
 		$params = [
-			'sort' => $sort,
 			'page' => $page,
 			'category' => $category,
 			'provider' => $providers,
@@ -129,8 +109,6 @@ class SpecialVideosSpecialController extends WikiaSpecialPageController {
 
 		$this->addVideo = $addVideo;
 		$this->pagination = $paginationBar;
-		$this->sortMsg = $sortingOptions[$sortKey]; // selected sorting option to display in drop down
-		$this->sortingOptions = $sortingOptions; // populate the drop down
 		$this->videos = $videos;
 		$this->message = $message;
 

--- a/extensions/wikia/SpecialVideos/SpecialVideosSpecialController.class.php
+++ b/extensions/wikia/SpecialVideos/SpecialVideosSpecialController.class.php
@@ -147,14 +147,12 @@ class SpecialVideosSpecialController extends WikiaSpecialPageController {
 
 	/**
 	 * Get videos
-	 * @requestParam string sort [ recent/popular/trend/premium ]
 	 * @requestParam integer page - page number
 	 * @requestParam string category
 	 * @requestParam string provider
 	 * @responseParam array videos - list of videos
 	 */
 	public function getVideos() {
-		$sort = $this->request->getVal( 'sort', 'trend' );
 		$page = $this->request->getVal( 'page', 1 );
 		$category = $this->request->getVal( 'category', '' );
 		$providers = $this->request->getVal( 'provider', '' );
@@ -163,7 +161,7 @@ class SpecialVideosSpecialController extends WikiaSpecialPageController {
 		$options = ['getThumbnail'=> $getThumbnail ];
 
 		$helper = new SpecialVideosHelper();
-		$videos = $helper->getVideos( $sort, $page, $providers, $category, $options );
+		$videos = $helper->getVideos( $page, 'all', $providers, $category, $options );
 
 		$this->videos = $videos;
 	}

--- a/extensions/wikia/SpecialVideos/SpecialVideosSpecialController.class.php
+++ b/extensions/wikia/SpecialVideos/SpecialVideosSpecialController.class.php
@@ -62,7 +62,7 @@ class SpecialVideosSpecialController extends WikiaSpecialPageController {
 		$this->getContext()->getOutput()->addMeta( 'description', $helper->getMetaTagDescription() );
 
 		// Sorting/filtering dropdown values
-		$sort = $this->request->getVal( 'sort', 'trend' );
+		$sort = $this->request->getVal( 'sort', 'recent' );
 		$page = $this->request->getVal( 'page', 1 );
 		$category = $this->request->getVal( 'category', '' );
 		// Filter on a comma separated list of providers if given.
@@ -91,7 +91,7 @@ class SpecialVideosSpecialController extends WikiaSpecialPageController {
 
 		// get sorting options
 		if ( $isMobile ) {
-			$sortingOptions = $helper->getSortOptionsMobile();
+			$sortingOptions = $helper->getSortOptions();
 		} else {
 			$sortingOptions = array_merge( $helper->getSortOptions(), $helper->getFilterOptions() );
 		}

--- a/extensions/wikia/SpecialVideos/scripts/SpecialVideos.js
+++ b/extensions/wikia/SpecialVideos/scripts/SpecialVideos.js
@@ -80,7 +80,7 @@ $(function () {
 										.show();
 								} else {
 									VET.close();
-									(new Wikia.Querystring()).setVal('sort', 'recent').goTo();
+									(new Wikia.Querystring()).goTo();
 								}
 							},
 							// error callback

--- a/extensions/wikia/SpecialVideos/styles/SpecialVideos.scss
+++ b/extensions/wikia/SpecialVideos/styles/SpecialVideos.scss
@@ -54,11 +54,15 @@ $placeholder-bg-color: darken($color-page, 10%);
 	}
 }
 
+// tag name required to override strong grid selector
+.WikiaArticle ul.special-videos-grid {
+	margin: 16px 0;
+}
+
 .special-videos-grid {
 	@include clearfix;
 	border-bottom: 1px solid $color-page-border;
 	color: $color-alternate-text;
-	margin-bottom: 18px;
 
 	a {
 		color: $color-alternate-text;

--- a/extensions/wikia/SpecialVideos/templates/SpecialVideosSpecial_index.php
+++ b/extensions/wikia/SpecialVideos/templates/SpecialVideosSpecial_index.php
@@ -6,36 +6,6 @@
 /* @var $showAddVideoBtn bool */
 /* @var $pagination string */
 ?>
-
-<div class="ContentHeader sort-form">
-	<label><?= wfMsg('specialvideos-sort-by') ?></label>
-
-
-	<div class="WikiaDropdown MultiSelect" id="sorting-dropdown">
-		<div class="selected-items">
-			<span class="selected-items-list"><?= $sortMsg ?></span>
-			<img class="arrow" src="<?= $wg->BlankImgUrl ?>" />
-		</div>
-		<div class="dropdown">
-			<ul class="dropdown-list">
-				<? foreach ( $sortingOptions as $sortBy => $option ): ?>
-					<? if ( $sortMsg != $option ): ?>
-						<?
-							$parts = explode( ':', $sortBy );
-							$sortType = empty( $parts[0] ) ? '' : $parts[0];
-							$category = empty( $parts[1] ) ? '' : $parts[1];
-						?>
-						<li class="dropdown-item">
-							<label data-sort="<?= $sortType ?>" data-category="<?= $category ?>"><?= $option ?></label>
-						</li>
-					<? endif; ?>
-				<? endforeach; ?>
-			</ul>
-		</div>
-	</div>
-</div>
-
-
 <ul class="special-videos-grid small-block-grid-3 large-block-grid-3 x-large-block-grid-4">
 	<?php $counter = 0 ?>
 	<?php foreach( $videos as $video ): ?>

--- a/extensions/wikia/VideoHandlers/VideoHandlerController.class.php
+++ b/extensions/wikia/VideoHandlers/VideoHandlerController.class.php
@@ -330,7 +330,6 @@ class VideoHandlerController extends WikiaController {
 
 	/**
 	 * Get list of videos (controller that provides access to MediaQueryService::getVideoList method)
-	 * @requestParam string sort [recent/popular/trend]
 	 * @requestParam integer limit (maximum = 100)
 	 * @requestParam integer page
 	 * @requestParam string|array providers - Only videos hosted by these providers will be returned. Default: all providers.
@@ -360,7 +359,6 @@ class VideoHandlerController extends WikiaController {
 			function() use ( $params ) {
 				$mediaService = new \MediaQueryService();
 				$videoList = $mediaService->getVideoList(
-					$params['sort'],
 					$params['filter'],
 					$params['limit'],
 					$params['page'],
@@ -397,7 +395,6 @@ class VideoHandlerController extends WikiaController {
 
 	protected function getVideoListParams() {
 		return [
-			'sort' => $this->getVal( 'sort', 'recent' ),
 			'limit' => $this->getVideoListLimit(),
 			'page' => $this->getVal( 'page', 1 ),
 			'providers' => $this->getVideoListProviders(),

--- a/extensions/wikia/VideosModule/Modules/VideosModuleCategory.class.php
+++ b/extensions/wikia/VideosModule/Modules/VideosModuleCategory.class.php
@@ -50,7 +50,6 @@ class Category extends Base {
 	protected function getLogParams() {
 		$params = parent::getLogParams();
 
-		$params['sort'] = $this->sort;
 		$params['category'] = $this->categories;
 
 		return $params;
@@ -64,7 +63,7 @@ class Category extends Base {
 		sort( $category );
 		$hashCategory = md5( json_encode( $category ) );
 
-		return implode( ':', [ $cacheKey, $hashCategory, $this->sort ] );
+		return implode( ':', [ $cacheKey, $hashCategory ] );
 	}
 
 	/**

--- a/extensions/wikia/VideosModule/Modules/VideosModuleLocal.class.php
+++ b/extensions/wikia/VideosModule/Modules/VideosModuleLocal.class.php
@@ -11,23 +11,8 @@ namespace VideosModule\Modules;
  */
 class Local extends Base {
 
-	const SORT = 'trend';
-
 	public function getSource() {
 		return 'local';
-	}
-
-	public function getCacheKey() {
-		$cacheKey = parent::getCacheKey();
-
-		return implode( ':', [ $cacheKey, $this->sort ] );
-	}
-
-	protected function getLogParams() {
-		$params = parent::getLogParams();
-		$params['sort'] = $this->sort;
-
-		return $params;
 	}
 
 	/**
@@ -39,7 +24,7 @@ class Local extends Base {
 		$paddedLimit = $this->getPaddedVideoLimit( $this->limit );
 
 		$mediaService = new \MediaQueryService();
-		$videoList = $mediaService->getVideoList( $this->sort, $filter, $paddedLimit );
+		$videoList = $mediaService->getVideoList( $filter, $paddedLimit );
 		$videosWithDetails = $this->getVideoDetailFromLocalWiki( $videoList );
 
 		foreach ( $videosWithDetails as $video ) {

--- a/extensions/wikia/VideosModule/Modules/VideosModuleStaff.class.php
+++ b/extensions/wikia/VideosModule/Modules/VideosModuleStaff.class.php
@@ -38,7 +38,7 @@ class Staff extends Base {
 		sort( $category );
 		$hashCategory = md5( json_encode( $category ) );
 
-		return implode( ':', [ $cacheKey, $hashCategory, $this->sort ] );
+		return implode( ':', [ $cacheKey, $hashCategory ] );
 	}
 
 	/**

--- a/extensions/wikia/VideosModule/Modules/VideosModuleVertical.class.php
+++ b/extensions/wikia/VideosModule/Modules/VideosModuleVertical.class.php
@@ -55,7 +55,7 @@ class Vertical extends Base {
 		sort( $category );
 		$hashCategory = md5( json_encode( $category ) );
 
-		return implode( ':', [ $cacheKey, $hashCategory, $this->sort ] );
+		return implode( ':', [ $cacheKey, $hashCategory ] );
 	}
 
 	/**

--- a/includes/wikia/services/MediaQueryService.class.php
+++ b/includes/wikia/services/MediaQueryService.class.php
@@ -439,6 +439,7 @@ class MediaQueryService extends WikiaService {
 				'addedAt'    => $row->added_at,
 				'addedBy'    => $row->added_by,
 				'duration'   => $row->duration,
+				// SUS-78 | Not used in template but used by API clients - GameGuides App
 				'viewsTotal' => $row->views_total
 			];
 		});

--- a/includes/wikia/services/MediaQueryService.class.php
+++ b/includes/wikia/services/MediaQueryService.class.php
@@ -381,10 +381,6 @@ class MediaQueryService extends WikiaService {
 	 * Get list of videos based on a few filters ($type, $providers, $category)
 	 * and sort options ($sort, $limit, $page).
 	 *
-	 * @param string $sort How to sort the results.  Valid options are:
-	 *                     - recent  : Sort by the date the video was added (DEFAULT)
-	 *                     - popular : Sort by total views
-	 *                     - trend   : Sort by views over the last 7 days
 	 * @param string $type What type of videos to return.  Valid options are:
 	 *                     - all     : Show all videos (DEFAULT)
 	 *                     - premium : Show only premium videos
@@ -396,17 +392,8 @@ class MediaQueryService extends WikiaService {
 	 *                         (DEFAULT any category)
 	 * @return array $videoList
 	 */
-	public function getVideoList( $sort = 'recent', $type = 'all', $limit = 0, $page = 1, $providers = [], $categories = [] ) {
+	public function getVideoList( $type = 'all', $limit = 0, $page = 1, $providers = [], $categories = [] ) {
 		wfProfileIn( __METHOD__ );
-
-		// Determine the sort column
-		if ( $sort == 'popular' ) {
-			$sortCol = 'views_total';
-		} elseif ( $sort == 'trend' ) {
-			$sortCol = 'views_7day';
-		} else {
-			$sortCol = 'added_at';
-		}
 
 		// Setup the base query cache for a minimal amount of time
 		$query = (new WikiaSQL())->cache( 5 )
@@ -419,7 +406,7 @@ class MediaQueryService extends WikiaService {
 				->DISTINCT( 'video_title' )
 			->FROM( 'video_info' )
 			->WHERE( 'removed' )->EQUAL_TO( 0 )
-			->ORDER_BY( $sortCol )->DESC();
+			->ORDER_BY( 'added_at' )->DESC();
 
 		if ( $categories ) {
 				$query->JOIN( 'page' )->ON( 'video_title', 'page_title' )


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-78
- removed sort dropdown on [Special/Videos](http://community.wikia.com/wiki/Special:Videos)
- removed `viewCount` from `FilePageController` and `FilePageController`
- [API `SpecialVideosSpecialController` method `index`](http://elderscrolls.wikia.com/wikia.php?controller=SpecialVideosSpecial&method=index&sort=trend&format=json&provider=youtube,ooyala)
  - request - ignore sort parameter
  - response removed: `sortMsg` and `sortingOptions`
  - `viewsTotal` stays untouched because it's used by Mobile Apps, but it returns stale data
- [ API `VideoHandler` method `getVideoList`](http://elderscrolls.wikia.com/wikia.php?controller=VideoHandler&method=getVideoList&sort=popular&limit=4&format=json&providers[]=youtube&providers[]=ooyala&detail=1) - ignore sort parameter

cc: @Wikia/sustaining-team @aniaMu 
