### PR TITLE
(CE-3331) Fix block info in the userinfo API module

### DIFF
--- a/includes/api/ApiQueryUserInfo.php
+++ b/includes/api/ApiQueryUserInfo.php
@@ -63,7 +63,10 @@ class ApiQueryUserInfo extends ApiQueryBase {
 
 		if ( isset( $this->prop['blockinfo'] ) ) {
 			if ( $user->isBlocked() ) {
-				$vals['blockedby'] = User::whoIs( $user->blockedBy() );
+				$block = $user->getBlock();
+
+				$vals['blockid'] = $block->getId();
+				$vals['blockedby'] = $block->getByName();
 				$vals['blockreason'] = $user->blockedFor();
 			}
 		}


### PR DESCRIPTION
The blockedby value was returning false for local blocks as User::blockedBy()
returns the user name for local blocks, rather than the ID. So, use the Block
object instead.

/cc @Wikia/community-engineering 
