### PR TITLE
WIP Get ExactTargetApiSubscriber under test

### DIFF
--- a/extensions/wikia/ExactTargetUpdates/api/ExactTargetApiSubscriber.php
+++ b/extensions/wikia/ExactTargetUpdates/api/ExactTargetApiSubscriber.php
@@ -23,6 +23,18 @@ class ExactTargetApiSubscriber extends ExactTargetApi {
 		return $oResults;
 	}
 
+
+	/**
+	 * Entry point for Subscriber object update requests
+	 * @param  Array  $aApiCallParams
+	 * @return stdObject|false  Returns false when an Exception is encountered and a stdObject otherwise
+	 */
+	public function updateRequest( Array $apiCallParams ) {
+		$aSubscribers = $this->helper->prepareSubscriberObjects( $apiCallParams['Subscriber'] );
+		$oResults = $this->makeUpdateRequest( $aSubscribers, 'Subscriber' );
+		return $oResults;
+	}
+
 	/**
 	 * An entry point for Subscriber Delete requests
 	 * @param  Array  $aApiCallParams

--- a/extensions/wikia/ExactTargetUpdates/tests/ExactTargetApiSubscriberTest.php
+++ b/extensions/wikia/ExactTargetUpdates/tests/ExactTargetApiSubscriberTest.php
@@ -1,0 +1,54 @@
+<?php
+
+require_once __DIR__ . '/helpers/ExactTargetApiTestBase.php';
+use Wikia\ExactTarget\ExactTargetApiSubscriber;
+
+class ExactTargetApiSubscriberTest extends ExactTargetApiTestBase {
+
+	const TEST_USER_ID = "1234";
+	const TEST_USER_EMAIL = "test@wikia-inc.com";
+
+	protected $taskHelper;
+
+	public function setUp() {
+		$this->setupFile = __DIR__ . '/../ExactTargetUpdates.setup.php';
+		parent::setUp();
+		require_once __DIR__ . '/helpers/ExactTargetApiWrapper.php';
+
+		$this->taskHelper = new Wikia\ExactTarget\ExactTargetUserTaskHelper();
+
+	}
+
+
+	public function testCreateRequest() {
+		$responseValue = 'response';
+		$lastRespose = 'last response';
+		$mockLogger = $this->getWikiaLoggerMock();
+		$mockSoapClient = $this->getExactTargetSoapClientMock();
+
+		$mockSoapClient
+			->expects( $this->once() )
+			->method( 'Create' )
+			// FIXME: we should be able to test what goes into Create
+			->with( $this->anything() )
+			->willReturn( $responseValue );
+
+		$mockSoapClient
+			->expects( $this->once() )
+			->method( '__getLastResponse' )
+			->willReturn( $lastRespose );
+
+		$mockLogger
+			->expects( $this->once() )
+			->method( 'info' )
+			->with( $this->matchesRegularExpression( "/.*{$lastRespose}.*/") );
+
+		$subscriber = new ExactTargetApiSubscriber();
+		$subscriber->setClient( $mockSoapClient );
+		$subscriber->setLogger( $mockLogger );
+
+		$params = $this->taskHelper->prepareSubscriberData( $sUserEmail );
+		$this->assertEquals( $responseValue, $subscriber->createRequest( $params ) );
+	}
+
+}

--- a/extensions/wikia/ExactTargetUpdates/tests/ExactTargetApiSubscriberTest.php
+++ b/extensions/wikia/ExactTargetUpdates/tests/ExactTargetApiSubscriberTest.php
@@ -51,6 +51,37 @@ class ExactTargetApiSubscriberTest extends ExactTargetApiTestBase {
 	}
 
 
+	public function testDeleteRequest() {
+		$responseValue = 'delete response';
+		$lastRespose = 'last delete response';
+		$mockLogger = $this->getWikiaLoggerMock();
+		$mockSoapClient = $this->getExactTargetSoapClientMock();
+
+		$params = $this->createSubscriberParams( self::TEST_USER_EMAIL, false );
+		$requestVars = $this->deleteRequestVars( $params );
+
+		$mockSoapClient
+			->expects( $this->once() )
+			->method( 'Delete' )
+			->with( $requestVars )
+			->willReturn( $responseValue );
+
+		$mockSoapClient
+			->expects( $this->once() )
+			->method( '__getLastResponse' )
+			->willReturn( $lastRespose );
+
+		$mockLogger
+			->expects( $this->once() )
+			->method( 'info' )
+			->with( $this->matchesRegularExpression( "/.*{$lastRespose}.*/") );
+
+		$subscriber = new ExactTargetApiSubscriber();
+		$subscriber->setClient( $mockSoapClient );
+		$subscriber->setLogger( $mockLogger );
+
+		$this->assertEquals( $responseValue, $subscriber->deleteRequest( $params ) );
+	}
 
 	protected function createSubscriberParams( $email, $unsubscribed ) {
 		return ['Subscriber' => array(array(
@@ -63,6 +94,14 @@ class ExactTargetApiSubscriberTest extends ExactTargetApiTestBase {
 		$makeCreateRequestParams = $this->helper->prepareSubscriberObjects( $params['Subscriber'] );
 		$requestVars = $this->helper->wrapCreateRequest(
 			$this->helper->prepareSoapVars( $makeCreateRequestParams, 'Subscriber' )
+		);
+		return $requestVars;
+	}
+
+	protected function deleteRequestVars( $params ) {
+		$makeDeleteRequestParams = $this->helper->prepareSubscriberObjects( $params['Subscriber'] );
+		$requestVars = $this->helper->wrapDeleteRequest(
+			$this->helper->prepareSoapVars( $makeDeleteRequestParams, 'Subscriber' )
 		);
 		return $requestVars;
 	}

--- a/extensions/wikia/ExactTargetUpdates/tests/ExactTargetApiSubscriberTest.php
+++ b/extensions/wikia/ExactTargetUpdates/tests/ExactTargetApiSubscriberTest.php
@@ -24,15 +24,8 @@ class ExactTargetApiSubscriberTest extends ExactTargetApiTestBase {
 		$mockLogger = $this->getWikiaLoggerMock();
 		$mockSoapClient = $this->getExactTargetSoapClientMock();
 
-		$params = ['Subscriber' => array(array(
-			'SubscriberKey' => self::TEST_USER_EMAIL,
-			'EmailAddress' => self::TEST_USER_EMAIL,
-			))];
-
-		$makeCreateRequestParams = $this->helper->prepareSubscriberObjects( $params['Subscriber'] );
-		$requestVars = $this->helper->wrapCreateRequest(
-			$this->helper->prepareSoapVars( $makeCreateRequestParams, 'Subscriber' )
-		);
+		$params = $this->createSubscriberParams( self::TEST_USER_EMAIL, false );
+		$requestVars = $this->createRequestVars( $params );
 
 		$mockSoapClient
 			->expects( $this->once() )
@@ -57,4 +50,20 @@ class ExactTargetApiSubscriberTest extends ExactTargetApiTestBase {
 		$this->assertEquals( $responseValue, $subscriber->createRequest( $params ) );
 	}
 
+
+
+	protected function createSubscriberParams( $email, $unsubscribed ) {
+		return ['Subscriber' => array(array(
+			'SubscriberKey' => self::TEST_USER_EMAIL,
+			'EmailAddress' => self::TEST_USER_EMAIL,
+			))];
+	}
+
+	protected function createRequestVars( $params ) {
+		$makeCreateRequestParams = $this->helper->prepareSubscriberObjects( $params['Subscriber'] );
+		$requestVars = $this->helper->wrapCreateRequest(
+			$this->helper->prepareSoapVars( $makeCreateRequestParams, 'Subscriber' )
+		);
+		return $requestVars;
+	}
 }

--- a/extensions/wikia/ExactTargetUpdates/tests/ExactTargetApiSubscriberTest.php
+++ b/extensions/wikia/ExactTargetUpdates/tests/ExactTargetApiSubscriberTest.php
@@ -9,6 +9,7 @@ class ExactTargetApiSubscriberTest extends ExactTargetApiTestBase {
 	const TEST_USER_EMAIL = "test@wikia-inc.com";
 
 	protected $helper;
+	protected $taskHelper;
 
 	public function setUp() {
 		$this->setupFile = __DIR__ . '/../ExactTargetUpdates.setup.php';
@@ -16,6 +17,7 @@ class ExactTargetApiSubscriberTest extends ExactTargetApiTestBase {
 		require_once __DIR__ . '/helpers/ExactTargetApiWrapper.php';
 
 		$this->helper = new Wikia\ExactTarget\ExactTargetApiHelper();
+		$this->taskHelper = new Wikia\ExactTarget\ExactTargetUserTaskHelper();
 	}
 
 	public function testCreateRequest() {
@@ -84,10 +86,7 @@ class ExactTargetApiSubscriberTest extends ExactTargetApiTestBase {
 	}
 
 	protected function createSubscriberParams( $email, $unsubscribed ) {
-		return ['Subscriber' => array(array(
-			'SubscriberKey' => self::TEST_USER_EMAIL,
-			'EmailAddress' => self::TEST_USER_EMAIL,
-			))];
+		return $this->taskHelper->prepareSubscriberData( $email );
 	}
 
 	protected function createRequestVars( $params ) {

--- a/extensions/wikia/ExactTargetUpdates/tests/ExactTargetApiSubscriberTest.php
+++ b/extensions/wikia/ExactTargetUpdates/tests/ExactTargetApiSubscriberTest.php
@@ -85,6 +85,38 @@ class ExactTargetApiSubscriberTest extends ExactTargetApiTestBase {
 		$this->assertEquals( $responseValue, $subscriber->deleteRequest( $params ) );
 	}
 
+	public function testUpdateRequest() {
+		$responseValue = 'update response';
+		$lastRespose = 'last update response';
+		$mockLogger = $this->getWikiaLoggerMock();
+		$mockSoapClient = $this->getExactTargetSoapClientMock();
+
+		$params = $this->createSubscriberParams( self::TEST_USER_EMAIL, false );
+		$requestVars = $this->updateRequestVars( $params );
+
+		$mockSoapClient
+			->expects( $this->once() )
+			->method( 'Update' )
+			->with( $requestVars )
+			->willReturn( $responseValue );
+
+		$mockSoapClient
+			->expects( $this->once() )
+			->method( '__getLastResponse' )
+			->willReturn( $lastRespose );
+
+		$mockLogger
+			->expects( $this->once() )
+			->method( 'info' )
+			->with( $this->matchesRegularExpression( "/.*{$lastRespose}.*/") );
+
+		$subscriber = new ExactTargetApiSubscriber();
+		$subscriber->setClient( $mockSoapClient );
+		$subscriber->setLogger( $mockLogger );
+
+		$this->assertEquals( $responseValue, $subscriber->updateRequest( $params ) );
+	}
+
 	protected function createSubscriberParams( $email, $unsubscribed ) {
 		return $this->taskHelper->prepareSubscriberData( $email );
 	}
@@ -101,6 +133,14 @@ class ExactTargetApiSubscriberTest extends ExactTargetApiTestBase {
 		$makeDeleteRequestParams = $this->helper->prepareSubscriberObjects( $params['Subscriber'] );
 		$requestVars = $this->helper->wrapDeleteRequest(
 			$this->helper->prepareSoapVars( $makeDeleteRequestParams, 'Subscriber' )
+		);
+		return $requestVars;
+	}
+
+	protected function updateRequestVars( $params ) {
+		$makeUpdateRequestParams = $this->helper->prepareSubscriberObjects( $params['Subscriber'] );
+		$requestVars = $this->helper->wrapUpdateRequest(
+			$this->helper->prepareSoapVars( $makeUpdateRequestParams, 'Subscriber' )
 		);
 		return $requestVars;
 	}

--- a/extensions/wikia/ExactTargetUpdates/tests/ExactTargetApiTest.php
+++ b/extensions/wikia/ExactTargetUpdates/tests/ExactTargetApiTest.php
@@ -1,15 +1,8 @@
 <?php
 
-require_once __DIR__ . '/../lib/exacttarget_soap_client.php';
-use Wikia\Logger\WikiaLogger;
+require_once __DIR__ . '/helpers/ExactTargetApiTestBase.php';
 
-class ExactTargetApiTest extends WikiaBaseTest {
-
-	public function setUp() {
-		$this->setupFile = __DIR__ . '/../ExactTargetUpdates.setup.php';
-		parent::setUp();
-		require_once __DIR__ . '/helpers/ExactTargetApiWrapper.php';
-	}
+class ExactTargetApiTest extends ExactTargetApiTestBase {
 
 	function testPrepareSoapVarsShouldReturnSoapVarsArray() {
 		/* Params to compare */
@@ -110,20 +103,6 @@ class ExactTargetApiTest extends WikiaBaseTest {
 		$api->setClient( $mockSoapClient );
 		$api->setLogger( $mockLogger );
 		$this->assertEquals( $responseValue, $api->sendRequest( 'Update', array() ) );
-	}
-
-	protected function getExactTargetSoapClientMock() {
-		return $this->getMockBuilder( '\ExactTargetSoapClient' )
-			->disableOriginalConstructor()
-			->setMethods( [ 'Update', '__getLastResponse' ] )
-			->getMock();
-	}
-
-	protected function getWikiaLoggerMock() {
-		return $this->getMockBuilder( 'Wikia\Logger\WikiaLogger' )
-			->disableOriginalConstructor()
-			->setMethods( [ 'info', 'error' ] )
-			->getMock();
 	}
 
 }

--- a/extensions/wikia/ExactTargetUpdates/tests/ExactTargetApiTest.php
+++ b/extensions/wikia/ExactTargetUpdates/tests/ExactTargetApiTest.php
@@ -86,7 +86,7 @@ class ExactTargetApiTest extends ExactTargetApiTestBase {
 		$mockSoapClient
 			->expects( $this->once() )
 			->method( 'Update' )
-			->with( array() )
+			->with( $this->anything() )
 			->willReturn( $responseValue );
 
 		$mockSoapClient

--- a/extensions/wikia/ExactTargetUpdates/tests/helpers/ExactTargetApiTestBase.php
+++ b/extensions/wikia/ExactTargetUpdates/tests/helpers/ExactTargetApiTestBase.php
@@ -1,0 +1,29 @@
+<?php
+
+require_once __DIR__ . '/../../lib/exacttarget_soap_client.php';
+use Wikia\Logger\WikiaLogger;
+
+class ExactTargetApiTestBase extends WikiaBaseTest {
+
+	public function setUp() {
+		$this->setupFile = __DIR__ . '/../../ExactTargetUpdates.setup.php';
+		parent::setUp();
+		require_once __DIR__ . '/ExactTargetApiWrapper.php';
+	}
+
+	protected function getExactTargetSoapClientMock() {
+		return $this->getMockBuilder( '\ExactTargetSoapClient' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'Update', '__getLastResponse' ] )
+			->getMock();
+	}
+
+	protected function getWikiaLoggerMock() {
+		return $this->getMockBuilder( 'Wikia\Logger\WikiaLogger' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'info', 'error' ] )
+			->getMock();
+	}
+
+
+}

--- a/extensions/wikia/ExactTargetUpdates/tests/helpers/ExactTargetApiTestBase.php
+++ b/extensions/wikia/ExactTargetUpdates/tests/helpers/ExactTargetApiTestBase.php
@@ -14,7 +14,7 @@ class ExactTargetApiTestBase extends WikiaBaseTest {
 	protected function getExactTargetSoapClientMock() {
 		return $this->getMockBuilder( '\ExactTargetSoapClient' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'Update', '__getLastResponse' ] )
+			->setMethods( [ 'Update', 'Delete', 'Create', '__getLastResponse' ] )
 			->getMock();
 	}
 
@@ -24,6 +24,5 @@ class ExactTargetApiTestBase extends WikiaBaseTest {
 			->setMethods( [ 'info', 'error' ] )
 			->getMock();
 	}
-
 
 }


### PR DESCRIPTION
I want to get the `ExactTargetApiSubscriber` class under test so I can more safely make changes to add an update method. Once the update method is in place then we can wire it in to the appropriate task and have the user properly unsubscribed.

https://wikia-inc.atlassian.net/browse/SUS-150

@Wikia/sustaining-team 

Todo:
- [x] add tests for `createRequest`
- [x] add tests for `deleteRequest`
