### PR TITLE
SUS-92 | Fix logging to PhalanxStats

### DIFF
--- a/extensions/CheckUser/CheckUser_body.php
+++ b/extensions/CheckUser/CheckUser_body.php
@@ -1035,7 +1035,9 @@ class CheckUser extends SpecialPage {
 				$s .= '</li>';
 			}
 			$s .= "</ul></div>\n";
-			if ( $wgUser->isAllowed( 'block' ) && !$wgUser->isBlocked() ) {
+			/* Wikia change begin - SUS-92 */
+			if ( $wgUser->isAllowed( 'block' ) && !$wgUser->isBlocked( true, false ) ) {
+			/* Wikia change end */
 				$s .= "<fieldset>\n";
 				$s .= '<legend>' . wfMsgHtml( 'checkuser-massblock' ) . "</legend>\n";
 				$s .= '<p>' . wfMsgExt( 'checkuser-massblock-text', array( 'parseinline' ) ) . "</p>\n";

--- a/extensions/wikia/AchievementsII/services/AchAwardingService.class.php
+++ b/extensions/wikia/AchievementsII/services/AchAwardingService.class.php
@@ -60,7 +60,7 @@ class AchAwardingService {
 
 			$dbr = wfGetDB( DB_SLAVE );
 
-			$badge = $dbr->selectField( 
+			$badge = $dbr->selectField(
 				'ach_user_badges',
 				'badge_type_id',
 				$where,
@@ -418,7 +418,7 @@ class AchAwardingService {
 						//calls api.php?action=query&list=imageusage&iulimit=10&iutitle=File:File_mame.ext
 						$imageUsageCount = 0;
 						$imageUsageLimit = 10;
-						$params = array( 
+						$params = array(
 							'action' => 'query',
 							'list' => 'imageusage',
 							'iutitle' => "File:{$inserted_image['il_to']}",
@@ -530,7 +530,7 @@ class AchAwardingService {
 			$where = array( 'badge_type_id' => BADGE_LUCKYEDIT );
 			$dbr = wfGetDB( DB_SLAVE );
 
-			$maxLap = $dbr->selectField( 
+			$maxLap = $dbr->selectField(
 				'ach_user_badges',
 				'max( badge_lap ) as cnt',
 				$where,
@@ -686,7 +686,7 @@ class AchAwardingService {
 		$where = array( 'user_id' => $this->mUser->getId() );
 		$dbr = wfGetDB( DB_SLAVE );
 
-		$res = $dbr->select( 
+		$res = $dbr->select(
 			'ach_user_badges',
 			'badge_type_id, badge_lap',
 			$where,
@@ -729,9 +729,9 @@ class AchAwardingService {
 			$user = $wgUser;
 		}
 
-		if ( 
+		if (
 			$user->isAnon() ||
-			$user->isBlocked() ||
+			$user->isBlocked( true, false ) ||
 			( $user->isAllowed( 'bot' ) || in_array( $user->getName(), $wgWikiaBotLikeUsers ) ) ||
 			( is_array( $wgAchievementsExemptUsers ) && in_array( $user->getId(), $wgAchievementsExemptUsers ) ) ||
 			/*

--- a/extensions/wikia/ArticleComments/classes/ArticleCommentList.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleCommentList.class.php
@@ -402,7 +402,7 @@ class ArticleCommentList {
 
 		// $isSysop = in_array('sysop', $groups) || in_array('staff', $groups);
 		$canEdit = $wgUser->isAllowed( 'edit' );
-		$isBlocked = $wgUser->isBlocked();
+		$isBlocked = $wgUser->isBlocked( true, false );
 		$isReadOnly = wfReadOnly();
 		// $showall = $wgRequest->getText( 'showall', false );
 

--- a/extensions/wikia/CityVisualization/helpers/WikiaHomePageHelper.class.php
+++ b/extensions/wikia/CityVisualization/helpers/WikiaHomePageHelper.class.php
@@ -11,7 +11,7 @@
  */
 use \Wikia\Logger\WikiaLogger;
 
- 
+
 class WikiaHomePageHelper extends WikiaModel {
 
 	const VIDEO_GAMES_SLOTS_VAR_NAME = 'wgWikiaHomePageVideoGamesSlots';
@@ -343,7 +343,7 @@ class WikiaHomePageHelper extends WikiaModel {
 			!$user->isIP($userName)
 			&& !in_array($userId, WikiService::$excludedWikiaUsers)
 			&& !in_array('bot', $user->getRights())
-			&& !$user->isBlocked()
+			&& !$user->isBlocked( true, false )
 			&& !$user->isBlockedGlobally()
 		);
 	}
@@ -544,7 +544,7 @@ class WikiaHomePageHelper extends WikiaModel {
 		}
 		WikiaLogger::instance()->debug( "Special:Promote", ['method' => __METHOD__, 'imageName' => $imageName,
 			'imageTitle' => $imageTitle, 'imageId' => $imageId] );
-		
+
 
 		wfProfileOut(__METHOD__);
 		return $imageId;

--- a/extensions/wikia/CommentsOnly/CommentsOnly.php
+++ b/extensions/wikia/CommentsOnly/CommentsOnly.php
@@ -87,7 +87,7 @@ function wfCOQuestionBox(Parser &$parser) {
 function wfCOQuestionBoxRender($input, $argv, Parser $parser) {
 	global $wgUser;
 
-	if (wfReadOnly() || !$wgUser->isAllowed('edit') || $wgUser->isBlocked()) {
+	if (wfReadOnly() || !$wgUser->isAllowed('edit') || $wgUser->isBlocked( true, false )) {
 		return '';
 	}
 

--- a/extensions/wikia/DataProvider/DataProvider.php
+++ b/extensions/wikia/DataProvider/DataProvider.php
@@ -479,7 +479,7 @@ class DataProvider {
 			while ($row = $dbs->fetchObject($res)) {
 				$user = User::newFromID($row->user_id);
 
-				if (!$user->isBlocked() && !$user->isAllowed('bot')
+				if (!$user->isBlocked( true, false ) && !$user->isAllowed('bot')
 					&& $user->getUserPage()->exists()
 				) {
 					$article['url'] = $user->getUserPage()->getLocalUrl();

--- a/extensions/wikia/Listusers/SpecialListusers_helper.php
+++ b/extensions/wikia/Listusers/SpecialListusers_helper.php
@@ -181,7 +181,7 @@ class ListusersData {
 			}
 
 			if ( $data['cnt'] > 0 ) {
-				$userIsBlocked = $wgUser->isBlocked();
+				$userIsBlocked = $wgUser->isBlocked( true, false );
 				$sk = RequestContext::getMain()->getSkin();
 				/* select records */
 				$oRes = $dbs->select(

--- a/extensions/wikia/PhalanxII/hooks/PhalanxUserBlock.class.php
+++ b/extensions/wikia/PhalanxII/hooks/PhalanxUserBlock.class.php
@@ -12,19 +12,29 @@ class PhalanxUserBlock extends WikiaObject {
 	function __construct(){
 		parent::__construct();
 	}
-	
+
 	/**
 	 * handler for hook blockCheck
 	 *
 	 * @static
 	 *
+	 * @param User $user
+	 * @param Bool $shouldLogBlockInStats flag that decides whether to log or not in PhalanxStats
+	 *
 	 * @desc blockCheck() will return false if user is blocked. The reason why it was
 	 * written in such way is below when you look at method UserBlock::onUserCanSendEmail().
+	 *
+	 * @return bool
 	 */
-	static public function blockCheck( User $user ) {
+	static public function blockCheck( User $user, $shouldLogBlockInStats = true ) {
 		wfProfileIn( __METHOD__ );
 
 		$phalanxModel = new PhalanxUserModel( $user );
+
+		if ( !$shouldLogBlockInStats ) {
+			$phalanxModel->setShouldLogInStats( false );
+		}
+
 		$ret = $phalanxModel->match_user();
 		if ( $ret !== false ){
 			if ( self::$checkEmail === true ) {
@@ -34,7 +44,7 @@ class PhalanxUserBlock extends WikiaObject {
 				}
 			}
 		}
-		
+
 		if ( $ret === false ) {
 			$user = $phalanxModel->userBlock( $user->isAnon() ? 'ip' : 'exact' )->getUser();
 			self::$typeBlock = (empty( self::$typeBlock ) ) ? 'user' : self::$typeBlock;
@@ -55,7 +65,7 @@ class PhalanxUserBlock extends WikiaObject {
 
 	/**
 	 * hook
-	 * 
+	 *
 	 * @static
 	 */
 	static public function abortNewAccount( $user, &$abortError ) {
@@ -77,7 +87,7 @@ class PhalanxUserBlock extends WikiaObject {
 
 	/**
 	 * hook
-	 * 
+	 *
 	 * @static
 	 */
 	static public function validateUserName( $userName, &$abortError ) {

--- a/extensions/wikia/PhalanxII/hooks/PhalanxUserBlock.class.php
+++ b/extensions/wikia/PhalanxII/hooks/PhalanxUserBlock.class.php
@@ -30,10 +30,7 @@ class PhalanxUserBlock extends WikiaObject {
 		wfProfileIn( __METHOD__ );
 
 		$phalanxModel = new PhalanxUserModel( $user );
-
-		if ( !$shouldLogBlockInStats ) {
-			$phalanxModel->setShouldLogInStats( false );
-		}
+		$phalanxModel->setShouldLogInStats( $shouldLogBlockInStats );
 
 		$ret = $phalanxModel->match_user();
 		if ( $ret !== false ){

--- a/extensions/wikia/PhalanxII/models/PhalanxModel.php
+++ b/extensions/wikia/PhalanxII/models/PhalanxModel.php
@@ -18,9 +18,13 @@ abstract class PhalanxModel extends WikiaObject {
 	private $service = null;
 	public $ip = null;
 
+	protected $shouldLogInStats = true;
+
 	public function __construct( $model, $data = array() ) {
 		parent::__construct();
 		$this->model = $model;
+
+		$this->user = $this->wg->user;
 		if ( !empty( $data ) ) {
 			foreach ( $data as $key => $value ) {
 				$method = "set{$key}";
@@ -104,7 +108,7 @@ abstract class PhalanxModel extends WikiaObject {
 
 	public function __call($name, $args) {
 		$method = substr($name, 0, 3);
-		$key = strtolower( substr( $name, 3 ) );
+		$key = lcfirst( substr( $name, 3 ) );
 
 		$result = null;
 		switch($method) {
@@ -145,14 +149,12 @@ abstract class PhalanxModel extends WikiaObject {
 		$ret = true;
 
 		if ( !$this->isOk() ) {
-			$isUser = ($this->user instanceof User) && ( $this->user->getName() == $this->wg->User->getName() );
-
 			$content = $this->getText();
 
 			# send request to service
 			$result = $this->service
 				->setLimit(1)
-				->setUser( $isUser ? $this->user : null )
+				->setUser( ( $this->getShouldLogInStats() && $this->user instanceof User ) ? $this->user : null )
 				->match( $type, $content, $this->getLang() );
 
 			if ( $result !== false ) {

--- a/extensions/wikia/PhalanxII/services/PhalanxService.class.php
+++ b/extensions/wikia/PhalanxII/services/PhalanxService.class.php
@@ -34,7 +34,7 @@ class PhalanxService extends Service {
 	 */
 	public function __call($name, $args) {
 		$method = substr($name, 0, 3);
-		$key = strtolower( substr( $name, 3 ) );
+		$key = lcfirst( substr( $name, 3 ) );
 
 		$result = null;
 		switch($method) {
@@ -145,7 +145,6 @@ class PhalanxService extends Service {
 	 * @return integer|mixed data of blocks applied or numeric value (0 - block applied, 1 - no block applied)
 	 */
 	private function sendToPhalanxDaemon( $action, $parameters ) {
-		
 		$baseurl = F::app()->wg->PhalanxServiceUrl;
 		$options = F::app()->wg->PhalanxServiceOptions;
 

--- a/extensions/wikia/UserProfilePageV3/UserProfilePageController.class.php
+++ b/extensions/wikia/UserProfilePageV3/UserProfilePageController.class.php
@@ -120,7 +120,7 @@ class UserProfilePageController extends WikiaController {
 
 		$userData = $userIdentityBox->getFullData();
 
-		$this->setVal( 'isBlocked', ( $user->isBlocked() || $user->isBlockedGlobally() ) );
+		$this->setVal( 'isBlocked', ( $user->isBlocked( true, false ) || $user->isBlockedGlobally() ) );
 		$this->setVal( 'zeroStateCssClass', ( $userData['showZeroStates'] ) ? 'zero-state' : '' );
 
 		$this->setVal( 'user', $userData );

--- a/extensions/wikia/UserProfilePageV3/strategies/UserOneTagStrategy.class.php
+++ b/extensions/wikia/UserProfilePageV3/strategies/UserOneTagStrategy.class.php
@@ -23,7 +23,7 @@ class UserOneTagStrategy extends UserTagsStrategyBase {
 	public function getUserTags() {
 		wfProfileIn(__METHOD__);
 
-		if( $this->isBlocked() ) {
+		if( $this->isBlocked( true, false ) ) {
 			$tag = wfMessage('user-identity-box-group-blocked')->escaped();
 		} elseif( $this->isFounder() ) {
 			$tag = wfMessage('user-identity-box-group-founder')->escaped();

--- a/extensions/wikia/UserProfilePageV3/strategies/UserTagsStrategyBase.class.php
+++ b/extensions/wikia/UserProfilePageV3/strategies/UserTagsStrategyBase.class.php
@@ -37,7 +37,7 @@ abstract class UserTagsStrategyBase {
 		wfProfileIn(__METHOD__);
 
 		// check if the user is blocked locally, if not, also check if they're blocked globally (via Phalanx)
-		$isBlocked = $this->user->isBlocked() || $this->user->isBlockedGlobally();
+		$isBlocked = $this->user->isBlocked( true, false) || $this->user->isBlockedGlobally();
 
 		if( $isBlocked && !$this->isUserInGroup(self::WIKIA_GROUP_STAFF_NAME) ) {
 			wfProfileOut(__METHOD__);

--- a/extensions/wikia/Wall/WallBaseController.class.php
+++ b/extensions/wikia/Wall/WallBaseController.class.php
@@ -615,7 +615,7 @@ class WallBaseController extends WikiaController {
 	protected function checkAndSetUserBlockedStatus( $wallOwner = null ) {
 		$user = $this->app->wg->User;
 
-		if ( $user->isBlocked() || $user->isBlockedGlobally() ) {
+		if ( $user->isBlocked( true, false ) || $user->isBlockedGlobally() ) {
 			if (	!empty( $wallOwner ) &&
 				$wallOwner->getName() == $this->wg->User->getName() &&
 				!( empty( $user->mAllowUsertalk ) ) ) {

--- a/extensions/wikia/Wall/WallBaseController.class.php
+++ b/extensions/wikia/Wall/WallBaseController.class.php
@@ -137,13 +137,13 @@ class WallBaseController extends WikiaController {
 
 	public function messageButtons() {
 		$wallMessage = $this->getWallMessage();
-		$this->response->setVal( 'canEdit', $wallMessage->canEdit( $this->wg->User ) );
-		$this->response->setVal( 'canDelete', $wallMessage->canDelete( $this->wg->User ) );
-		$this->response->setVal( 'canAdminDelete', $wallMessage->canAdminDelete( $this->wg->User )  && $wallMessage->isRemove()  );
-		$this->response->setVal( 'canFastAdminDelete', $wallMessage->canFastAdminDelete( $this->wg->User ) );
-		$this->response->setVal( 'canRemove', $wallMessage->canRemove( $this->wg->User )  && !$wallMessage->isRemove() );
-		$this->response->setVal( 'canClose', $wallMessage->canArchive( $this->wg->User ) );
-		$this->response->setVal( 'canReopen', $wallMessage->canReopen( $this->wg->User ) );
+		$this->response->setVal( 'canEdit', $wallMessage->canEdit( $this->wg->User, false ) );
+		$this->response->setVal( 'canDelete', $wallMessage->canDelete( $this->wg->User, false ) );
+		$this->response->setVal( 'canAdminDelete', $wallMessage->canAdminDelete( $this->wg->User, false )  && $wallMessage->isRemove()  );
+		$this->response->setVal( 'canFastAdminDelete', $wallMessage->canFastAdminDelete( $this->wg->User, false ) );
+		$this->response->setVal( 'canRemove', $wallMessage->canRemove( $this->wg->User, false )  && !$wallMessage->isRemove() );
+		$this->response->setVal( 'canClose', $wallMessage->canArchive( $this->wg->User, false ) );
+		$this->response->setVal( 'canReopen', $wallMessage->canReopen( $this->wg->User, false ) );
 		$this->response->setVal( 'showViewSource', $this->wg->User->getGlobalPreference( 'wallshowsource', false ) );
 		$this->response->setVal( 'threadHistoryLink', $wallMessage->getMessagePageUrl( true ) . '?action=history' );
 		$this->response->setVal( 'wgBlankImgUrl', $this->wg->BlankImgUrl );
@@ -151,7 +151,7 @@ class WallBaseController extends WikiaController {
 		$this->response->setVal( 'isAnon', $this->wg->User->isAnon() );
 		$this->response->setVal( 'canNotifyeveryone', $wallMessage->canNotifyeveryone() );
 		$this->response->setVal( 'canUnnotifyeveryone', $wallMessage->canUnnotifyeveryone() );
-		$this->response->setVal( 'canMove', $wallMessage->canMove( $this->wg->User ) );
+		$this->response->setVal( 'canMove', $wallMessage->canMove( $this->wg->User, false ) );
 
 		$wallThread = $wallMessage;
 		if ( !$wallMessage->isMain() ) {
@@ -371,8 +371,8 @@ class WallBaseController extends WikiaController {
 				$this->response->setVal( 'statusInfo', $info );
 				$this->response->setVal( 'id', $wallMessage->getId() );
 				if ( $showRemoveOrDeleteInfo ) {
-					$this->response->setVal( 'canRestore', $wallMessage->canRestore( $this->app->wg->User ) );
-					$this->response->setVal( 'fastrestore', $wallMessage->canFastrestore( $this->app->wg->User ) );
+					$this->response->setVal( 'canRestore', $wallMessage->canRestore( $this->app->wg->User, false ) );
+					$this->response->setVal( 'fastrestore', $wallMessage->canFastRestore( $this->app->wg->User, false ) );
 					$this->response->setVal( 'isreply', !$wallMessage->isMain() );
 				}
 			}

--- a/extensions/wikia/Wall/WallController.class.php
+++ b/extensions/wikia/Wall/WallController.class.php
@@ -144,7 +144,7 @@ class WallController extends WallBaseController {
 	protected function checkAndSetUserBlockedStatus( $wallOwner = null ) {
 		$user = $this->app->wg->User;
 
-		if ( $user->isBlocked() || $user->isBlockedGlobally() ) {
+		if ( $user->isBlocked( true, false ) || $user->isBlockedGlobally() ) {
 			if (	!empty( $wallOwner ) &&
 				$wallOwner->getName() == $this->wg->User->getName() &&
 				!( empty( $user->mAllowUsertalk ) ) ) {

--- a/extensions/wikia/Wall/WallExternalController.class.php
+++ b/extensions/wikia/Wall/WallExternalController.class.php
@@ -427,7 +427,7 @@ class WallExternalController extends WikiaController {
 
 			$reason = isset( $formassoc['reason'] ) ? $formassoc['reason'] : '';
 
-			if ( empty( $reason ) && !$mw->canFastrestore( $this->wg->User ) ) {
+			if ( empty( $reason ) && !$mw->canFastRestore( $this->wg->User ) ) {
 				$this->response->setVal( 'status', false );
 				return true;
 			}

--- a/extensions/wikia/Wall/WallHistoryController.class.php
+++ b/extensions/wikia/Wall/WallHistoryController.class.php
@@ -253,7 +253,7 @@ class WallHistoryController extends WallController {
 			}
 
 			if ( ( $type == WH_REMOVE && !$wm->isAdminDelete() ) || ( $type == WH_DELETE && $wm->isAdminDelete() ) ) {
-				if ( $wm->canRestore( $this->getContext()->getUser() ) ) {
+				if ( $wm->canRestore( $this->getContext()->getUser(), false ) ) {
 					if ( $this->isThreadLevel ) {
 						$restoreActionMsg = ( $isReply === '1' ) ? wfMessage( 'wall-history-action-restore-reply' )->text() : wfMessage( 'wall-history-action-restore-thread' )->text();
 					} else {
@@ -263,7 +263,7 @@ class WallHistoryController extends WallController {
 					$history[$key]['actions'][] = array(
 						'class' => 'message-restore', // TODO: ?
 						'data-id' => $value['page_id'],
-						'data-mode' => 'restore' . ( $wm->canFastrestore( $this->getContext()->getUser() ) ? '-fast' : '' ),
+						'data-mode' => 'restore' . ( $wm->canFastRestore( $this->getContext()->getUser(), false ) ? '-fast' : '' ),
 						'href' => '#',
 						'msg' => $restoreActionMsg
 					);

--- a/extensions/wikia/WidgetFramework/Widgets/WidgetEditedRecently/WidgetEditedRecently.php
+++ b/extensions/wikia/WidgetFramework/Widgets/WidgetEditedRecently/WidgetEditedRecently.php
@@ -10,7 +10,7 @@ global $wgWidgets;
 $wgWidgets['WidgetEditedRecently'] = array(
 	'callback' => 'WidgetEditedRecently',
 	'title' => 'widget-title-editedrecently',
-	'desc' => 'widget-desc-editedrecently',  
+	'desc' => 'widget-desc-editedrecently',
     	'params' => array(
 		'limit' => array(
 			'type' => 'text',
@@ -24,7 +24,7 @@ $wgWidgets['WidgetEditedRecently'] = array(
 function WidgetEditedRecently($id, $params) {
 	wfProfileIn( __METHOD__ );
 	global $wgTitle, $wgRequest;
-	
+
 	if ( (!is_object($wgTitle) || ($wgTitle->mArticleID == -1)) && ($wgRequest->getVal('actionType') == 'add') ) {
 		// ask for page refresh
 		wfProfileOut( __METHOD__ );
@@ -55,14 +55,14 @@ function WidgetEditedRecently($id, $params) {
 			foreach ($contribs['revisions'] as $contrib) {
 				$is_anon = isset($contrib['anon']);
 				$author = $contrib['user'];
-				
+
 				if ($is_anon) {
 					// don't show anon edits - requested by JohnQ
 					continue;
 				} else {
 					$oUser = User::newFromName( $author );
-					if ( ( $oUser instanceof User ) && 
-						 ( !$oUser->isBlocked() ) 
+					if ( ( $oUser instanceof User ) &&
+						 ( !$oUser->isBlocked( true, false ) )
 					) {
 						$userPage = $oUser->getUserPage();
 						if ( ($userPage instanceof Title) && ($userPage->exists()) ) {

--- a/extensions/wikia/WidgetFramework/Widgets/WidgetShoutBox/WidgetShoutBox.php
+++ b/extensions/wikia/WidgetFramework/Widgets/WidgetShoutBox/WidgetShoutBox.php
@@ -207,7 +207,7 @@ function WidgetShoutBox($id, $params) {
 	$ret .= '</ul>';
 
 	// show form only for non-blocked and logged in users
-	if ( $wgUser->isLoggedIn() && !$wgUser->isBlocked() && !isset($params['_widgetTag']) ) {
+	if ( $wgUser->isLoggedIn() && !$wgUser->isBlocked( true, false ) && !isset($params['_widgetTag']) ) {
 		$ret .= '<form onsubmit="WidgetShoutBoxSend('.$id.'); return false;" action="">'."\n";
 		$ret .= '<input type="text" name="message" autocomplete="off" id="widget_'.$id.'_message" maxlength="100" />'."\n";
 		$ret .= '<input type="submit" value="'.wfMsg('send').'" />'."\n";

--- a/includes/Article.php
+++ b/includes/Article.php
@@ -1046,7 +1046,9 @@ class Article extends Page {
 			if ( !($user && $user->isLoggedIn()) && !$ip ) { # User does not exist
 				$wgOut->wrapWikiMsg( "<div class=\"mw-userpage-userdoesnotexist error\">\n\$1\n</div>",
 					array( 'userpage-userdoesnotexist-view', wfEscapeWikiText( $rootPart ) ) );
+			/* Wikia change begin - SUS-92 */
 			} elseif ( $user->isBlocked( true, false ) ) { # Show log extract if the user is currently blocked
+			/* Wikia change end */
 				LogEventsList::showLogExtract(
 					$wgOut,
 					'block',

--- a/includes/Article.php
+++ b/includes/Article.php
@@ -1046,7 +1046,7 @@ class Article extends Page {
 			if ( !($user && $user->isLoggedIn()) && !$ip ) { # User does not exist
 				$wgOut->wrapWikiMsg( "<div class=\"mw-userpage-userdoesnotexist error\">\n\$1\n</div>",
 					array( 'userpage-userdoesnotexist-view', wfEscapeWikiText( $rootPart ) ) );
-			} elseif ( $user->isBlocked() ) { # Show log extract if the user is currently blocked
+			} elseif ( $user->isBlocked( true, false ) ) { # Show log extract if the user is currently blocked
 				LogEventsList::showLogExtract(
 					$wgOut,
 					'block',

--- a/includes/EditPage.php
+++ b/includes/EditPage.php
@@ -1697,7 +1697,9 @@ class EditPage {
 			if ( !($user && $user->isLoggedIn()) && !$ip ) { # User does not exist
 				$wgOut->wrapWikiMsg( "<div class=\"mw-userpage-userdoesnotexist error\">\n$1\n</div>",
 					array( 'userpage-userdoesnotexist', wfEscapeWikiText( $username ) ) );
-			} elseif ( $user->isBlocked() ) { # Show log extract if the user is currently blocked
+			/* Wikia change begin - SUS-92 */
+			} elseif ( $user->isBlocked( true, false ) ) { # Show log extract if the user is currently blocked
+			/* Wikia change end */
 				LogEventsList::showLogExtract(
 					$wgOut,
 					'block',

--- a/includes/User.php
+++ b/includes/User.php
@@ -1461,6 +1461,7 @@ class User {
 	}
 
 
+	/* Wikia change begin - SUS-92 */
 	/**
 	 * Get blocking information
 	 * @param $bFromSlave Bool Whether to check the slave database first. To
@@ -1470,6 +1471,7 @@ class User {
 	 * @param $shouldLogBlockInStats Bool flag that decides whether to log or not in PhalanxStats
 	 */
 	private function getBlockedStatus( $bFromSlave = true, $shouldLogBlockInStats = true ) {
+	/* Wikia change end */
 		global $wgProxyWhitelist, $wgUser;
 
 		if ( -1 != $this->mBlockedby ) {
@@ -1530,7 +1532,9 @@ class User {
 		}
 
 		# Extensions
+		/* Wikia change begin - SUS-92 */
 		wfRunHooks( 'GetBlockedStatus', array( &$this, $shouldLogBlockInStats ) );
+		/* Wikia change end */
 
 		if ( !empty($this->mBlockedby) ) {
 			$this->mBlock->mBy = $this->mBlockedby;
@@ -1757,6 +1761,7 @@ class User {
 		return $triggered;
 	}
 
+	/* Wikia change begin - SUS-92 */
 	/**
 	 * Check if user is blocked
 	 *
@@ -1781,6 +1786,7 @@ class User {
 		$this->getBlockedStatus( $bFromSlave, $shouldLogBlockInStats );
 		return $this->mBlock instanceof Block ? $this->mBlock : null;
 	}
+	/* Wikia change end */
 
 	/**
 	 * Check if user is blocked from editing a particular article

--- a/includes/User.php
+++ b/includes/User.php
@@ -1770,7 +1770,7 @@ class User {
 	 *
 	 * @return Bool True if blocked, false otherwise
 	 */
-	public function isBlocked( $bFromSlave = true, $shouldLogBlockInStats = true  ) { // hacked from false due to horrible probs on site
+	public function isBlocked( $bFromSlave = true, $shouldLogBlockInStats = true ) { // hacked from false due to horrible probs on site
 		return $this->getBlock( $bFromSlave, $shouldLogBlockInStats ) instanceof Block && $this->getBlock()->prevents( 'edit' );
 	}
 

--- a/includes/User.php
+++ b/includes/User.php
@@ -1467,8 +1467,9 @@ class User {
 	 *                    improve performance, non-critical checks are done
 	 *                    against slaves. Check when actually saving should be
 	 *                    done against master.
+	 * @param $shouldLogBlockInStats Bool flag that decides whether to log or not in PhalanxStats
 	 */
-	private function getBlockedStatus( $bFromSlave = true ) {
+	private function getBlockedStatus( $bFromSlave = true, $shouldLogBlockInStats = true ) {
 		global $wgProxyWhitelist, $wgUser;
 
 		if ( -1 != $this->mBlockedby ) {
@@ -1529,7 +1530,7 @@ class User {
 		}
 
 		# Extensions
-		wfRunHooks( 'GetBlockedStatus', array( &$this ) );
+		wfRunHooks( 'GetBlockedStatus', array( &$this, $shouldLogBlockInStats ) );
 
 		if ( !empty($this->mBlockedby) ) {
 			$this->mBlock->mBy = $this->mBlockedby;
@@ -1760,20 +1761,24 @@ class User {
 	 * Check if user is blocked
 	 *
 	 * @param $bFromSlave Bool Whether to check the slave database instead of the master
+	 * @param $shouldLogBlockInStats Bool flag that decides whether to log or not in PhalanxStats
+	 *
 	 * @return Bool True if blocked, false otherwise
 	 */
-	public function isBlocked( $bFromSlave = true ) { // hacked from false due to horrible probs on site
-		return $this->getBlock( $bFromSlave ) instanceof Block && $this->getBlock()->prevents( 'edit' );
+	public function isBlocked( $bFromSlave = true, $shouldLogBlockInStats = true  ) { // hacked from false due to horrible probs on site
+		return $this->getBlock( $bFromSlave, $shouldLogBlockInStats ) instanceof Block && $this->getBlock()->prevents( 'edit' );
 	}
 
 	/**
 	 * Get the block affecting the user, or null if the user is not blocked
 	 *
 	 * @param $bFromSlave Bool Whether to check the slave database instead of the master
+	 * @param $shouldLogBlockInStats Bool flag that decides whether to log or not in PhalanxStats
+	 *
 	 * @return Block|null
 	 */
-	public function getBlock( $bFromSlave = true ){
-		$this->getBlockedStatus( $bFromSlave );
+	public function getBlock( $bFromSlave = true, $shouldLogBlockInStats = true ){
+		$this->getBlockedStatus( $bFromSlave, $shouldLogBlockInStats );
 		return $this->mBlock instanceof Block ? $this->mBlock : null;
 	}
 

--- a/includes/api/ApiQueryUserInfo.php
+++ b/includes/api/ApiQueryUserInfo.php
@@ -66,7 +66,7 @@ class ApiQueryUserInfo extends ApiQueryBase {
 			if ( $user->isBlocked( true, false ) ) {
 			/* Wikia change end */
 				$block = $user->getBlock();
-				
+
 				$vals['blockid'] = $block->getId();
 				$vals['blockedby'] = $block->getByName();
 				$vals['blockreason'] = $user->blockedFor();

--- a/includes/api/ApiQueryUserInfo.php
+++ b/includes/api/ApiQueryUserInfo.php
@@ -62,7 +62,9 @@ class ApiQueryUserInfo extends ApiQueryBase {
 		}
 
 		if ( isset( $this->prop['blockinfo'] ) ) {
-			if ( $user->isBlocked() ) {
+			/* Wikia change begin - SUS-92 */
+			if ( $user->isBlocked( true, false ) ) {
+			/* Wikia change end */
 				$vals['blockedby'] = User::whoIs( $user->blockedBy() );
 				$vals['blockreason'] = $user->blockedFor();
 			}

--- a/includes/api/ApiQueryUsers.php
+++ b/includes/api/ApiQueryUsers.php
@@ -158,8 +158,10 @@ class ApiQueryUsers extends ApiQueryBase {
 				if ( $row->ipb_deleted ) {
 					$data[$name]['hidden'] = '';
 				}
-				if ( isset( $this->prop['blockinfo'] ) && $user->isBlocked() ) {
-					$blockInfo = $user->getBlock();
+				/* Wikia change begin - SUS-92 */
+				if ( isset( $this->prop['blockinfo'] ) && $user->isBlocked( true, false ) ) {
+				/* Wikia change end */
+					$blockInfo = $user->getBlock( true, false );
 
 					$data[$name]['blockedby'] = $blockInfo->getByName();
 					$data[$name]['blockreason'] = $blockInfo->mReason;

--- a/includes/api/ApiQueryUsers.php
+++ b/includes/api/ApiQueryUsers.php
@@ -160,9 +160,9 @@ class ApiQueryUsers extends ApiQueryBase {
 				}
 				/* Wikia change begin - SUS-92 */
 				if ( isset( $this->prop['blockinfo'] ) && $user->isBlocked( true, false ) ) {
-				/* Wikia change end */
 					$blockInfo = $user->getBlock( true, false );
-
+				/* Wikia change end */
+					
 					$data[$name]['blockedby'] = $blockInfo->getByName();
 					$data[$name]['blockreason'] = $blockInfo->mReason;
 					$data[$name]['blockexpiry'] = $blockInfo->getExpiry();

--- a/includes/specials/SpecialContributions.php
+++ b/includes/specials/SpecialContributions.php
@@ -232,7 +232,9 @@ class SpecialContributions extends SpecialPage {
 			$links = $this->getLanguage()->pipeList( $tools );
 
 			// Show a note if the user is blocked and display the last block log entry.
-			if ( $userObj->isBlocked() ) {
+			/* Wikia change begin - SUS-92 */
+			if ( $userObj->isBlocked( true, false ) ) {
+			/* Wikia change end */
 				$out = $this->getOutput(); // showLogExtract() wants first parameter by reference
 				//If user is blocked globally we do not show local log extract as it doesn't contain information about this block
 				if ( wfRunHooks('ContributionsLogEventsList', array( $out, $userObj) ) ) {
@@ -285,7 +287,9 @@ class SpecialContributions extends SpecialPage {
 
 		if ( ( $id !== null ) || ( $id === null && IP::isIPAddress( $username ) ) ) {
 			if ( $this->getUser()->isAllowed( 'block' ) ) { # Block / Change block / Unblock links
-				if ( $target->isBlocked() && $target->getBlock()->getType() != Block::TYPE_AUTO ) {
+				/* Wikia change begin - SUS-92 */
+				if ( $target->isBlocked( true, false) && $target->getBlock( true, false )->getType() != Block::TYPE_AUTO ) {
+				/* Wikia change end */
 					$tools[] = Linker::linkKnown( # Change block link
 						SpecialPage::getTitleFor( 'Block', $username ),
 						$this->msg( 'change-blocklink' )->escaped()

--- a/includes/specials/SpecialDeletedContributions.php
+++ b/includes/specials/SpecialDeletedContributions.php
@@ -354,7 +354,9 @@ class DeletedContributionsPage extends SpecialPage {
 			$tools[] = Linker::link( $talk, $this->msg( 'sp-contributions-talk' )->escaped() );
 			if( ( $id !== null ) || ( $id === null && IP::isIPAddress( $nt->getText() ) ) ) {
 				if( $this->getUser()->isAllowed( 'block' ) ) { # Block / Change block / Unblock links
-					if ( $userObj->isBlocked() && $userObj->getBlock()->getType() !== Block::TYPE_AUTO ) {
+					/* Wikia change begin - SUS-92 */
+					if ( $userObj->isBlocked( true, false ) && $userObj->getBlock( true, false )->getType() !== Block::TYPE_AUTO ) {
+					/* Wikia change end */
 						$tools[] = Linker::linkKnown( # Change block link
 							SpecialPage::getTitleFor( 'Block', $nt->getDBkey() ),
 							$this->msg( 'change-blocklink' )->escaped()
@@ -415,7 +417,9 @@ class DeletedContributionsPage extends SpecialPage {
 			$links = $this->getLanguage()->pipeList( $tools );
 
 			// Show a note if the user is blocked and display the last block log entry.
-			if ( $userObj->isBlocked() ) {
+			/* Wikia change begin - SUS-92 */
+			if ( $userObj->isBlocked( true, false ) ) {
+			/* Wikia change end */
 				$out = $this->getOutput(); // LogEventsList::showLogExtract() wants the first parameter by ref
 				LogEventsList::showLogExtract(
 					$out,

--- a/includes/wikia/services/PageStatsService.class.php
+++ b/includes/wikia/services/PageStatsService.class.php
@@ -256,7 +256,7 @@ class PageStatsService extends Service {
 
 				if (!empty($user)) {
 					// remove bots and blocked users
-					$res = !$user->isBlocked() && !$user->isAllowed('bot');
+					$res = !$user->isBlocked( true, false ) && !$user->isAllowed('bot');
 				}
 			}
 

--- a/skins/oasis/modules/MenuButtonController.class.php
+++ b/skins/oasis/modules/MenuButtonController.class.php
@@ -136,7 +136,7 @@ class MenuButtonController extends WikiaController {
 		if ( $this->actionName == 'edit' &&
 			isset($data['action']['href']) /* BugId:12613 */ &&
 			!$wgTitle->userCan( 'edit' ) &&
-			!$wgUser->isBlocked() /* CE-18 */ &&
+			!$wgUser->isBlocked( true, false ) /* CE-18 */ &&
 			!$wgUser->isLoggedIn() /* VOLDEV-74 */
 		) {
 			$signUpTitle = SpecialPage::getTitleFor('SignUp');


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-92

During investigation we found that application checks blocks in two different scenarios:
- prevent user from performing action - edit, move, create user, etc. Those checks should create new row in PhalanxStats
- check if user is blocked to modify UI - hide UI controls, show user is blocked flag, etc. Checks of this kind doesn't mean that action was stopped or something was protected by this block. They're only informational. It means that those actions shouldn't trigger adding new record to PhalanxStats

In order to achieve that goal, `$shouldLogBlockInStats` was introduced as a second parameter for `User:isBlock` method.

Most important changes happen in `PhalanxUserBlock` and `PhalanxModel`. Other changes are just passing new flag to `isBlocked` method.

/cc @Wikia/sustaining-team 
