### PR TITLE
SUS-108: check read-only state of ACTIVE_CLUSTER before performing any DB-related actions

### DIFF
--- a/extensions/wikia/CreateNewWiki/CreateWiki.php
+++ b/extensions/wikia/CreateNewWiki/CreateWiki.php
@@ -227,6 +227,13 @@ class CreateWiki {
 		$this->mClusterDB = ( self::ACTIVE_CLUSTER ) ? "wikicities_" . self::ACTIVE_CLUSTER : "wikicities";
 		$this->mNewWiki->dbw = wfGetDB( DB_MASTER, array(), $this->mClusterDB ); // database handler, old $dbwTarget
 
+		// SUS-108: check read-only state of ACTIVE_CLUSTER before performing any DB-related actions
+		$readOnlyReason = $this->mNewWiki->dbw->getLBInfo( 'readOnlyReason' );
+		if ( $readOnlyReason !== false ) {
+			wfProfileOut( __METHOD__ );
+			throw new CreateWikiException( sprintf( '%s is in read-only mode: %s', self::ACTIVE_CLUSTER, $readOnlyReason ), self::ERROR_READONLY );
+		}
+
 		// check if database is creatable
 		// @todo move all database creation checkers to canCreateDatabase
 		if( !$this->canCreateDatabase() ) {

--- a/includes/db/LoadBalancer.php
+++ b/includes/db/LoadBalancer.php
@@ -21,11 +21,15 @@ class LoadBalancer {
 	private $mParentInfo, $mLagTimes;
 	private $mLoadMonitorClass, $mLoadMonitor;
 
+	/** @var string|bool Reason the LB is read-only or false if not */
+	private $readOnlyReason = false;
+
 	/**
 	 * @param $params Array with keys:
 	 *    servers           Required. Array of server info structures.
 	 *    masterWaitTimeout Replication lag wait timeout
 	 *    loadMonitor       Name of a class used to fetch server lag and load.
+	 *    readOnlyReason    Reason the master DB is read-only if so [optional]
 	 */
 	function __construct( $params ) {
 		if ( !isset( $params['servers'] ) ) {
@@ -50,6 +54,10 @@ class LoadBalancer {
 		$this->mLaggedSlaveMode = false;
 		$this->mErrorConnection = false;
 		$this->mAllowLagged = false;
+
+		if ( isset( $params['readOnlyReason'] ) && is_string( $params['readOnlyReason'] ) ) {
+			$this->readOnlyReason = $params['readOnlyReason'];
+		}
 
 		if ( isset( $params['loadMonitor'] ) ) {
 			$this->mLoadMonitorClass = $params['loadMonitor'];
@@ -735,6 +743,19 @@ class LoadBalancer {
 		}
 
 		$db->setLBInfo( $server );
+
+		/**
+		 * Wikia change
+		 *
+		 * Manually apply https://github.com/wikimedia/mediawiki/commit/52010e6d21d8bdefa1c89fbc9421850185cc5011
+		 *
+		 * Thanks to this we can call $db->getLBInfo( 'readOnlyReason' )
+		 *
+		 * @see SUS-108
+		 * @author macbre
+		 */
+		$db->setLBInfo( 'readOnlyReason', $this->readOnlyReason );
+
 		if ( isset( $server['fakeSlaveLag'] ) ) {
 			$db->setFakeSlaveLag( $server['fakeSlaveLag'] );
 		}
@@ -971,6 +992,28 @@ class LoadBalancer {
 	 */
 	function getLaggedSlaveMode() {
 		return $this->mLaggedSlaveMode;
+	}
+
+	/**
+	 * @note This method may trigger a DB connection if not yet done
+	 * @param string|bool $wiki Wiki ID, or false for the current wiki
+	 * @return string|bool Reason the master is read-only or false if it is not
+	 * @since 1.27
+	 */
+	public function getReadOnlyReason( $wiki = false ) {
+		if ( $this->readOnlyReason !== false ) {
+			return $this->readOnlyReason;
+		} elseif ( $this->getLaggedSlaveMode( $wiki ) ) {
+			if ( $this->slavesDownMode ) {
+				return 'The database has been automatically locked ' .
+				'until the slave database servers become available';
+			} else {
+				return 'The database has been automatically locked ' .
+				'while the slave database servers catch up to the master.';
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/includes/db/LoadBalancer.php
+++ b/includes/db/LoadBalancer.php
@@ -995,22 +995,12 @@ class LoadBalancer {
 	}
 
 	/**
-	 * @note This method may trigger a DB connection if not yet done
-	 * @param string|bool $wiki Wiki ID, or false for the current wiki
 	 * @return string|bool Reason the master is read-only or false if it is not
 	 * @since 1.27
 	 */
-	public function getReadOnlyReason( $wiki = false ) {
+	public function getReadOnlyReason() {
 		if ( $this->readOnlyReason !== false ) {
 			return $this->readOnlyReason;
-		} elseif ( $this->getLaggedSlaveMode( $wiki ) ) {
-			if ( $this->slavesDownMode ) {
-				return 'The database has been automatically locked ' .
-				'until the slave database servers become available';
-			} else {
-				return 'The database has been automatically locked ' .
-				'while the slave database servers catch up to the master.';
-			}
 		}
 
 		return false;


### PR DESCRIPTION
[SUS-108](https://wikia-inc.atlassian.net/browse/SUS-108)

This pull request backports https://github.com/wikimedia/mediawiki/commit/52010e6d21d8bdefa1c89fbc9421850185cc5011 from MW 1.27.

Let's pass reao-only state to `LoadBalancer` and `Database` instances, so that we can easily check if another cluster is in read-only mode. This will be used in CreateWiki code (that runs on c1) to check the read-only state of a different cluster (currently c7).
- pass `$wgReadOnly` (global read-only mode switch) to `LBFactory` constructor
- pass per DB section read-only (controlled by `$wgLBFactoryConf['readOnlyBySection']`) to `LoadBalancer` instance and when creating a database connection (via `Database::setLBInfo` )

Thanks to this change we can finally perform the following checks:

``` php
# set in the DB config
$wgLBFactoryConf['readOnlyBySection']['c7'] = 'We apologise, this wiki is temporarily in read-only state';

# in eval.php
> var_dump( wfGetLB('wikicities_c7')->getReadOnlyReason() )
string(57) "We apologise, this wiki is temporarily in read-only state"

> var_dump( wfGetDB(DB_MASTER, [], 'wikicities_c7')->getLBInfo( 'readOnlyReason' ) )
string(57) "We apologise, this wiki is temporarily in read-only state"

> var_dump( wfGetLB()->getReadOnlyReason() );
bool(false)
```

@Wikia/sustaining-team / @wladekb (touches MW core, namely LoadBalancer)
