### PR TITLE
ADEN-2837 Get RPFL targeting params based on their value

### DIFF
--- a/extensions/wikia/AdEngine/js/lookup/lookupFactory.js
+++ b/extensions/wikia/AdEngine/js/lookup/lookupFactory.js
@@ -53,7 +53,7 @@ define('ext.wikia.adEngine.lookup.lookupFactory', [
 		function trackState(providerName, slotName, params) {
 			log(['trackState', response, providerName, slotName], 'debug', module.logGroup);
 			var category,
-				encodedParams = module.encodeParamsForTracking(params),
+				encodedParams,
 				eventName;
 
 			if (!module.isSlotSupported(slotName)) {
@@ -61,6 +61,7 @@ define('ext.wikia.adEngine.lookup.lookupFactory', [
 				return;
 			}
 
+			encodedParams = module.encodeParamsForTracking(params);
 			eventName = encodedParams ? 'lookup_success' : 'lookup_error';
 			category = module.name + '/' + eventName + '/' + providerName;
 

--- a/extensions/wikia/AdEngine/js/lookup/lookupFactory.js
+++ b/extensions/wikia/AdEngine/js/lookup/lookupFactory.js
@@ -53,7 +53,7 @@ define('ext.wikia.adEngine.lookup.lookupFactory', [
 		function trackState(providerName, slotName, params) {
 			log(['trackState', response, providerName, slotName], 'debug', module.logGroup);
 			var category,
-				encodedParams,
+				encodedParams = module.encodeParamsForTracking(params),
 				eventName;
 
 			if (!module.isSlotSupported(slotName)) {
@@ -61,18 +61,17 @@ define('ext.wikia.adEngine.lookup.lookupFactory', [
 				return;
 			}
 
-			eventName = response ? 'lookup_success' : 'lookup_error';
+			eventName = encodedParams ? 'lookup_success' : 'lookup_error';
 			category = module.name + '/' + eventName + '/' + providerName;
-			encodedParams = module.encodeParamsForTracking(params) || 'nodata';
 
-			adTracker.track(category, slotName, 0, encodedParams);
+			adTracker.track(category, slotName, 0, encodedParams || 'nodata');
 		}
 
 		function getSlotParams(slotName) {
-			log(['getSlotParams', slotName, response], 'debug', module.logGroup);
+			log(['getSlotParams', slotName, called, response], 'debug', module.logGroup);
 
-			if (!response || !module.isSlotSupported(slotName)) {
-				log(['getSlotParams', 'No response yet or slot is not supported', slotName], 'debug', module.logGroup);
+			if (!called || !module.isSlotSupported(slotName)) {
+				log(['getSlotParams', 'Not called or slot is not supported', slotName], 'debug', module.logGroup);
 				return {};
 			}
 

--- a/extensions/wikia/AdEngine/js/lookup/rubiconFastlane.js
+++ b/extensions/wikia/AdEngine/js/lookup/rubiconFastlane.js
@@ -151,6 +151,10 @@ define('ext.wikia.adEngine.lookup.rubiconFastlane', [
 			values,
 			parameters = {};
 
+		if (!slots[slotName].getAdServerTargeting) {
+			return {};
+		}
+
 		targeting = slots[slotName].getAdServerTargeting();
 		targeting.forEach(function (params) {
 			if (params.key !== rubiconElementKey) {


### PR DESCRIPTION
Instead of checking whether rubicon has responded (to all slots or by timeout) check the real value of provided targeting params. It's not affecting other bidders because they are returning params based on priceMap calculated in onResponse callback.
