### PR TITLE
PLATFORM-1828: Dedup SMWUpdateJob tasks

### DIFF
--- a/extensions/wikia/SemanticMediaWiki/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
+++ b/extensions/wikia/SemanticMediaWiki/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
@@ -802,6 +802,7 @@ class SMWSQLStore3Writers {
 								// wikia change start - jobqueue migration
 								$task = new \Wikia\Tasks\Tasks\JobWrapperTask();
 								$task->call( 'SMWUpdateJob', $title );
+								$task->dupCheck();
 								$jobs[] = $task;
 								// wikia change end
 							}
@@ -819,6 +820,7 @@ class SMWSQLStore3Writers {
 									// wikia change start - jobqueue migration
 									$task = new \Wikia\Tasks\Tasks\JobWrapperTask();
 									$task->call( 'SMWUpdateJob', $title );
+									$task->dupCheck();
 									$jobs[] = $task;
 									// wikia change end
 								}


### PR DESCRIPTION
We've had a long list of SMWUpdateJob tasks in the queue recently. At least part of these tasks seem to be duplicates of other ones which previously have been deduplicated by the built-in Mediawiki job queue. Current implementation doesn't make any dupe checks. Let's fix it!

https://wikia-inc.atlassian.net/browse/PLATFORM-1828

/cc @macbre @Grunny 
