### PR TITLE
fix typo

### DIFF
--- a/extensions/SemanticDrilldown/includes/SD_FilterValue.php
+++ b/extensions/SemanticDrilldown/includes/SD_FilterValue.php
@@ -100,7 +100,7 @@ class SDFilterValue {
 
 		if ( $fv1->year != null && $fv2->year != null ) {
 			if ( $fv1->year == $fv2->year ) {
-				if ( $fv1->month == $fv1->month ) return 0;
+				if ( $fv1->month == $fv2->month ) return 0;
 				return ( $fv1->month > $fv2->month ) ? 1 : - 1;
 			}
 


### PR DESCRIPTION
Fix comparing  variable '$fv1->month'  with itself

This possible defect found by AppChecker (http://cnpo.ru/en/solutions/appchecker.php)
