### PR TITLE
Remove the dimension test for the rendered image from vignette from the ImageServingCroppingTest

### DIFF
--- a/extensions/wikia/ImageServing/tests/ImageServingCroppingTest.php
+++ b/extensions/wikia/ImageServing/tests/ImageServingCroppingTest.php
@@ -9,17 +9,14 @@ class ImageServingCroppingTest extends WikiaBaseTest {
 
 	const FILE_NAME = 'Wiki-wordmark.png';
 
-	private $tmpFile;
-
 	public function setUp() {
 		$this->setupFile =  __DIR__ . '/../imageServing.setup.php';
 		parent::setUp();
 
 		$this->mockGlobalVariable('wgEnableVignette', true);
-		$this->mockGlobalVariable('wgUploadPath', 'http://images.wikia.com/firefly/images');
 	}
 
-	public function testCropping() {
+	public function testCroppingPath() {
 		// requested crop size is 50 x 50
 		$im = new ImageServing(null, 50);
 		$file = wfFindFile(self::FILE_NAME);
@@ -27,29 +24,8 @@ class ImageServingCroppingTest extends WikiaBaseTest {
 		// pass dimensions of full size image
 		$cropUrl = $im->getUrl($file, $file->getWidth(), $file->getHeight());
 
-		$this->assertContains('/firefly/images/8/89/Wiki-wordmark.png/revision/latest/', $cropUrl);
+		$this->assertContains(sprintf('/firefly/images/8/89/%s/revision/latest/', self::FILE_NAME), $cropUrl);
 		$this->assertContains('/width/50/', $cropUrl);
-
-		// verify crop response
-		$res = Http::get($cropUrl, 'default', ['noProxy' => true]);
-		$this->assertTrue($res !== false, "<{$cropUrl}> should return HTTP 200");
-
-		// verify crop size
-		$this->tmpFile = tempnam( wfTempDir(), 'img' );
-		file_put_contents($this->tmpFile, $res);
-
-		list($tmpWidth, $tmpHeight) = getimagesize($this->tmpFile);
-
-		$this->assertEquals(50, $tmpWidth, 'expected crop width not matched - ' . $cropUrl);
-		$this->assertEquals(49, $tmpHeight, 'expected crop height not matched - ' . $cropUrl);
-	}
-
-	public function tearDown() {
-		if (!empty($this->tmpFile)) {
-			unlink($this->tmpFile);
-		}
-
-		parent::tearDown();
 	}
 
 }


### PR DESCRIPTION
Remove the dimension test for the rendered image from vignette from the ImageServingCroppingTest. 

We have experimented with integration / validation testing in vignette in the past. We should revisit that issue and add some tests to confirm that vignette behaves as advertised. 

The ticket owner will determine where is the best place to run this kind of test.

https://wikia-inc.atlassian.net/browse/SERVICES-1168

@Wikia/platform 
