### PR TITLE
Http::get - use noProxy for external requests

### DIFF
--- a/extensions/3rdparty/LyricWiki/LyricFind/LyricFindTrackingService.class.php
+++ b/extensions/3rdparty/LyricWiki/LyricFind/LyricFindTrackingService.class.php
@@ -122,10 +122,7 @@ class LyricFindTrackingService extends WikiaService {
 
 		wfDebug(__METHOD__ . ': ' . json_encode($data) . "\n");
 
-		$resp = Http::post($url, [
-			'postData' => $data,
-			'noProxy' => true
-		]);
+		$resp = ExternalHttp::post($url, ['postData' => $data]);
 
 		if ($resp !== false) {
 			wfDebug(__METHOD__ . ": API response - {$resp}\n");
@@ -204,10 +201,7 @@ class LyricFindTrackingService extends WikiaService {
 
 		wfDebug(__METHOD__ . ': ' . json_encode($data) . "\n");
 
-		$resp = Http::post($url, [
-			'postData' => $data,
-			'noProxy' => true
-		]);
+		$resp = ExternalHttp::post($url, ['postData' => $data]);
 
 		if ($resp !== false) {
 			wfDebug(__METHOD__ . ": API response - {$resp}\n");

--- a/extensions/3rdparty/LyricWiki/LyricFind/LyricFindTrackingService.class.php
+++ b/extensions/3rdparty/LyricWiki/LyricFind/LyricFindTrackingService.class.php
@@ -122,7 +122,10 @@ class LyricFindTrackingService extends WikiaService {
 
 		wfDebug(__METHOD__ . ': ' . json_encode($data) . "\n");
 
-		$resp = Http::post($url, ['postData' => $data]);
+		$resp = Http::post($url, [
+			'postData' => $data,
+			'noProxy' => true
+		]);
 
 		if ($resp !== false) {
 			wfDebug(__METHOD__ . ": API response - {$resp}\n");
@@ -201,7 +204,10 @@ class LyricFindTrackingService extends WikiaService {
 
 		wfDebug(__METHOD__ . ': ' . json_encode($data) . "\n");
 
-		$resp = Http::post($url, ['postData' => $data]);
+		$resp = Http::post($url, [
+			'postData' => $data,
+			'noProxy' => true
+		]);
 
 		if ($resp !== false) {
 			wfDebug(__METHOD__ . ": API response - {$resp}\n");

--- a/extensions/3rdparty/LyricWiki/LyricFind/tests/LyricFindTrackingServiceTest.php
+++ b/extensions/3rdparty/LyricWiki/LyricFind/tests/LyricFindTrackingServiceTest.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @group LyricFindTracking
+ */
 class LyricFindTrackingServiceTest extends WikiaBaseTest {
 
 	const SERVICE_URL = 'http://api.foo.net/service/';
@@ -98,7 +101,7 @@ class LyricFindTrackingServiceTest extends WikiaBaseTest {
 		// mock API response
 		$respMock = is_array($apiResponse) ? json_encode($apiResponse) : $apiResponse;
 
-		$this->mockStaticMethod('Http', 'post', $respMock);
+		$this->mockStaticMethod('Http', 'request', $respMock);
 		$this->mockGlobalVariable('wgTitle', $this->mockClassWithMethods('Title', [
 			'getArticleID' => 666,
 			'getText' => 'Paradise_Lost:Forever_Failure'

--- a/extensions/3rdparty/LyricWiki/LyricFind/tests/LyricFindTrackingTest.php
+++ b/extensions/3rdparty/LyricWiki/LyricFind/tests/LyricFindTrackingTest.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @group LyricFindTracking
+ */
 class LyricFindTrackingTest extends WikiaBaseTest {
 
 	const TEST_NAMESPACE_TRACKED = 666;

--- a/extensions/Maps/includes/Maps_Geocoder.php
+++ b/extensions/Maps/includes/Maps_Geocoder.php
@@ -111,7 +111,7 @@ abstract class MapsGeocoder {
 	 * @return array or false
 	 */
 	public function geocode( $address ) {
-		$response = Http::get( $this->getRequestUrl( $address ), null, [ 'noProxy' => true ] ); # Wikia change
+		$response = ExternalHttp::get( $this->getRequestUrl( $address ) ); # Wikia change
 
 		if ( $response === false ) {
 			return false;

--- a/extensions/Maps/includes/Maps_Geocoder.php
+++ b/extensions/Maps/includes/Maps_Geocoder.php
@@ -111,8 +111,8 @@ abstract class MapsGeocoder {
 	 * @return array or false
 	 */
 	public function geocode( $address ) {
-		$response = Http::get( $this->getRequestUrl( $address ) );
-		
+		$response = Http::get( $this->getRequestUrl( $address ), null, [ 'noProxy' => true ] ); # Wikia change
+
 		if ( $response === false ) {
 			return false;
 		}

--- a/extensions/TorBlock/TorBlock.class.php
+++ b/extensions/TorBlock/TorBlock.class.php
@@ -175,7 +175,7 @@ class TorBlock {
 
 	public static function loadNodesForIP( $ip ) {
 		$url = 'https://check.torproject.org/cgi-bin/TorBulkExitList.py?ip='.$ip;
-		$data = Http::get( $url, 'default', array( 'sslVerifyCert' => false, 'noProxy' => true ) );
+		$data = ExternalHttp::get( $url, 'default', array( 'sslVerifyCert' => false ) );
 		$lines = explode("\n", $data);
 
 		$nodes = array();

--- a/extensions/wikia/AdEngine/ResourceLoaders/ResourceLoaderAdEngineBase.php
+++ b/extensions/wikia/AdEngine/ResourceLoaders/ResourceLoaderAdEngineBase.php
@@ -23,7 +23,7 @@ abstract class ResourceLoaderAdEngineBase extends ResourceLoaderModule {
 	 * @return bool|MWHttpRequest|string
 	 */
 	protected function fetchRemoteScript( $url ) {
-		return Http::get( $url, 'default', [ 'noProxy' => true ] );
+		return ExternalHttp::get( $url );
 	}
 
 	/**

--- a/extensions/wikia/AdEngine/ResourceLoaders/ResourceLoaderAdEngineSourcePointRecoveryModule.php
+++ b/extensions/wikia/AdEngine/ResourceLoaders/ResourceLoaderAdEngineSourcePointRecoveryModule.php
@@ -41,11 +41,10 @@ class ResourceLoaderAdEngineSourcePointRecoveryModule extends ResourceLoaderAdEn
 	protected function fetchRemoteScript( $url ) {
 		global $wgSourcePointApiKey;
 
-		$content = Http::get( $url,
+		$content = ExternalHttp::get( $url,
 			null,
 			[
 				'headers' => ['Authorization' =>  'Token '.$wgSourcePointApiKey],
-				'noProxy' => true,
 				'timeout' => self::REQUEST_TIMEOUT
 			]
 		);

--- a/extensions/wikia/Captcha/Module/ReCaptcha.class.php
+++ b/extensions/wikia/Captcha/Module/ReCaptcha.class.php
@@ -36,8 +36,7 @@ class ReCaptcha extends BaseCaptcha {
 	public function passCaptcha() {
 		$verifyUrl = $this->getVerifyUrl();
 
-		$responseObj = \Http::get( $verifyUrl, 'default', [
-			'noProxy' => true,
+		$responseObj = \ExternalHttp::get( $verifyUrl, 'default', [
 			'returnInstance' => true
 		] );
 

--- a/extensions/wikia/CensusDataRetrieval/CensusDataRetrieval.class.php
+++ b/extensions/wikia/CensusDataRetrieval/CensusDataRetrieval.class.php
@@ -143,8 +143,6 @@ class CensusDataRetrieval {
 	public function fetchData()	{
 		wfProfileIn( __METHOD__ );
 		// fetch data from API based on $this->query
-		$http = new Http();
-
 		$censusData = null;
 
 		//Check censusDataArr to find out if relevant data exists in Census
@@ -160,7 +158,7 @@ class CensusDataRetrieval {
 			$type = $key[0];
 			$id   = $key[1];
 			//fetch data from Census by type and id
-			$censusData = $http->get( sprintf( self::QUERY_URL, $type, $id ) );
+			$censusData = Http::get( sprintf( self::QUERY_URL, $type, $id ), null, [ 'noProxy' => true ] );
 			$map        = json_decode( $censusData );
 			if ( $map->returned > 0 ) {
 				$censusData = $map->{$type . '_list'}[0];
@@ -456,13 +454,14 @@ class CensusDataRetrieval {
 			return $data;
 		}
 
-		$http = new Http();
 		$data = array();
 		foreach ( $this->supportedTypes as $type ) {
-			$censusData = $http->get(
-				sprintf( self::QUERY_URL, $type, '?c:show=id,name.' . $wikilang . '&c:limit=0' )
+			$censusData = Http::get(
+				sprintf( self::QUERY_URL, $type, '?c:show=id,name.' . $wikilang . '&c:limit=0' ),
+				null,
+				[ 'noProxy' => true ]
 			);
-			$map        = json_decode( $censusData );
+			$map = json_decode( $censusData );
 			$this->mergeResult( $data, $map, $type );
 		}
 		// error handling

--- a/extensions/wikia/CensusDataRetrieval/CensusDataRetrieval.class.php
+++ b/extensions/wikia/CensusDataRetrieval/CensusDataRetrieval.class.php
@@ -158,7 +158,7 @@ class CensusDataRetrieval {
 			$type = $key[0];
 			$id   = $key[1];
 			//fetch data from Census by type and id
-			$censusData = Http::get( sprintf( self::QUERY_URL, $type, $id ), null, [ 'noProxy' => true ] );
+			$censusData = ExternalHttp::get( sprintf( self::QUERY_URL, $type, $id ) );
 			$map        = json_decode( $censusData );
 			if ( $map->returned > 0 ) {
 				$censusData = $map->{$type . '_list'}[0];
@@ -456,10 +456,8 @@ class CensusDataRetrieval {
 
 		$data = array();
 		foreach ( $this->supportedTypes as $type ) {
-			$censusData = Http::get(
-				sprintf( self::QUERY_URL, $type, '?c:show=id,name.' . $wikilang . '&c:limit=0' ),
-				null,
-				[ 'noProxy' => true ]
+			$censusData = ExternalHttp::get(
+				sprintf( self::QUERY_URL, $type, '?c:show=id,name.' . $wikilang . '&c:limit=0' )
 			);
 			$map = json_decode( $censusData );
 			$this->mergeResult( $data, $map, $type );

--- a/extensions/wikia/DMCARequest/ChillingEffectsClient.class.php
+++ b/extensions/wikia/DMCARequest/ChillingEffectsClient.class.php
@@ -125,7 +125,7 @@ class ChillingEffectsClient {
 			'notice' => $noticeData,
 		];
 
-		return \Http::post(
+		return \ExternalHttp::post(
 			$this->baseUrl . '/notices',
 			[
 				'postData' => json_encode( $requestData ),
@@ -133,8 +133,7 @@ class ChillingEffectsClient {
 					'Accept' => 'application/json',
 					'Content-type' => 'application/json',
 				],
-				'returnInstance' => true,
-				'noProxy' => true,
+				'returnInstance' => true
 			]
 		);
 	}

--- a/extensions/wikia/Recirculation/services/FandomDataService.class.php
+++ b/extensions/wikia/Recirculation/services/FandomDataService.class.php
@@ -55,7 +55,7 @@ class FandomDataService {
 		}
 
 		$url = $this->buildUrl( $endpoint, $options );
-		$data = Http::get( $url, null, [ 'noProxy' => true ] );
+		$data = ExternalHttp::get( $url );
 
 		$obj = json_decode( $data );
 		return $obj->data;

--- a/extensions/wikia/Recirculation/services/FandomDataService.class.php
+++ b/extensions/wikia/Recirculation/services/FandomDataService.class.php
@@ -55,7 +55,7 @@ class FandomDataService {
 		}
 
 		$url = $this->buildUrl( $endpoint, $options );
-		$data = Http::get( $url );
+		$data = Http::get( $url, null, [ 'noProxy' => true ] );
 
 		$obj = json_decode( $data );
 		return $obj->data;

--- a/extensions/wikia/VideoHandlers/apiwrappers/TwitchtvApiWrapper.class.php
+++ b/extensions/wikia/VideoHandlers/apiwrappers/TwitchtvApiWrapper.class.php
@@ -58,7 +58,7 @@ class TwitchtvApiWrapper extends ApiWrapper {
 		$url = str_replace( '$2', 'streams', static::$API_URL );
 		$url = str_replace( '$1', $this->videoId, $url );
 
-		$content = Http::request( 'GET', $url, array( 'noProxy' => true ) );
+		$content = ExternalHttp::get( $url );
 		if ( !empty( $content ) ) {
 			$result = json_decode( $content, true );
 			if ( isset( $result['stream']['preview']['large'] ) ) {

--- a/extensions/wikia/VideoHandlers/feedingesters/AnyclipFeedIngester.class.php
+++ b/extensions/wikia/VideoHandlers/feedingesters/AnyclipFeedIngester.class.php
@@ -195,7 +195,7 @@ class AnyclipFeedIngester extends VideoFeedIngester {
 		wfProfileIn( __METHOD__ );
 
 		$url = AnyclipApiWrapper::getApi( $code );
-		$response = Http::request( 'GET', $url, [ 'noProxy' => true ] );
+		$response = ExternalHttp::get( $url );
 		if ( $response !== false ) {
 			$content = json_decode( $response, true );
 

--- a/extensions/wikia/VideoHandlers/feedingesters/IvaFeedIngester.class.php
+++ b/extensions/wikia/VideoHandlers/feedingesters/IvaFeedIngester.class.php
@@ -929,7 +929,7 @@ class IvaFeedIngester extends RemoteAssetFeedIngester {
 
 		print( "Connecting to $url...\n" );
 
-		$resp = Http::request( 'GET', $url, [ 'noProxy' => true ] );
+		$resp = ExternalHttp::get( $url );
 		if ( $resp === false ) {
 			$this->logger->videoErrors( "ERROR: problem downloading content.\n" );
 

--- a/includes/AutoLoader.php
+++ b/includes/AutoLoader.php
@@ -75,6 +75,7 @@ $wgAutoloadLocalClasses = array(
 	'ErrorPageError' => 'includes/Exception.php',
 	'ExplodeIterator' => 'includes/StringUtils.php',
 	'ExternalEdit' => 'includes/ExternalEdit.php',
+	'ExternalHttp' => 'includes/HttpFunctions.php', # Wikia change
 	'ExternalStore' => 'includes/ExternalStore.php',
 	'ExternalStoreDB' => 'includes/ExternalStoreDB.php',
 	'ExternalStoreHttp' => 'includes/ExternalStoreHttp.php',

--- a/includes/filerepo/file/File.php
+++ b/includes/filerepo/file/File.php
@@ -1578,7 +1578,7 @@ abstract class File implements UrlGeneratorInterface {
 				wfDebug("miss\n");
 			}
 			wfDebug( "Fetching shared description from $renderUrl\n" );
-			$res = Http::get( $renderUrl, null, [ 'noProxy' => true ] ); # Wikia change
+			$res = ExternalHttp::get( $renderUrl ); # this can fetch file page from Wikimedia Commons or other Wikia's wiki (Wikia change)
 			if ( $res && $this->repo->descriptionCacheExpiry > 0 ) {
 				$wgMemc->set( $key, $res, $this->repo->descriptionCacheExpiry );
 			}

--- a/includes/filerepo/file/File.php
+++ b/includes/filerepo/file/File.php
@@ -1578,7 +1578,7 @@ abstract class File implements UrlGeneratorInterface {
 				wfDebug("miss\n");
 			}
 			wfDebug( "Fetching shared description from $renderUrl\n" );
-			$res = Http::get( $renderUrl );
+			$res = Http::get( $renderUrl, null, [ 'noProxy' => true ] ); # Wikia change
 			if ( $res && $this->repo->descriptionCacheExpiry > 0 ) {
 				$wgMemc->set( $key, $res, $this->repo->descriptionCacheExpiry );
 			}


### PR DESCRIPTION
[PLATFORM-1856](https://wikia-inc.atlassian.net/browse/PLATFORM-1856)

As we're planning to get rid of local Varnish instance running on Apache nodes, we want to use  border nodes as HTTP proxies. However, we do not want to use them when making external HTTP requests - hence this change

Introduce `ExternalHttp` helper class with `get` and `post` methods that will set `noProxy` option to true internally and clearly state what kind of HTTP request we want to perform here. In the near future we'll add more headers for tracing internal HTTP requests.

@wladekb / @artursitarski 
