### PR TITLE
SUS-180 In WallNotification remove strong typing

### DIFF
--- a/extensions/wikia/WallNotifications/GlobalNavigationWallNotificationsController.class.php
+++ b/extensions/wikia/WallNotifications/GlobalNavigationWallNotificationsController.class.php
@@ -31,7 +31,7 @@ class GlobalNavigationWallNotificationsController extends WallNotificationContro
 		$this->response->setVal( 'wikiCount', count( $notificationCounts ) );
 	}
 
-	public function getTitle( string $title ) {
+	public function getTitle( $title ) {
 		return $this->getWallHelper()->shortenText( $title, self::NOTIFICATION_TITLE_LIMIT );
 
 	}
@@ -43,7 +43,7 @@ class GlobalNavigationWallNotificationsController extends WallNotificationContro
 		return !empty( $suppressed );
 	}
 
-	protected function setUnread( bool $unread ) {
+	protected function setUnread( $unread ) {
 		$this->response->setVal( 'isUnread', $unread ? 'unread' : 'read' );
 	}
 

--- a/extensions/wikia/WallNotifications/WallNotificationControllerBase.class.php
+++ b/extensions/wikia/WallNotifications/WallNotificationControllerBase.class.php
@@ -289,13 +289,13 @@ abstract class WallNotificationControllerBase extends WikiaController {
 	 * @param string $title
 	 * @return string
 	 */
-	protected abstract function getTitle( string $title );
+	protected abstract function getTitle( $title );
 
 	/**
 	 * @param bool $unread
 	 * @return void
 	 */
-	protected abstract function setUnread( bool $unread );
+	protected abstract function setUnread( $unread );
 
 	/**
 	 * @return void

--- a/extensions/wikia/WallNotifications/WallNotificationsController.class.php
+++ b/extensions/wikia/WallNotifications/WallNotificationsController.class.php
@@ -28,7 +28,7 @@ class WallNotificationsController extends WallNotificationControllerBase {
 		// nothing to do in this controller
 	}
 
-	public function getTitle( string $title ) {
+	public function getTitle( $title ) {
 		return $title;
 	}
 
@@ -39,7 +39,7 @@ class WallNotificationsController extends WallNotificationControllerBase {
 		return !empty( $suppressed );
 	}
 
-	protected function setUnread( bool $unread ) {
+	protected function setUnread( $unread ) {
 		// nothing to do in this controller
 	}
 

--- a/extensions/wikia/WallNotifications/tests/WallNotificationsControllerTest.php
+++ b/extensions/wikia/WallNotifications/tests/WallNotificationsControllerTest.php
@@ -151,17 +151,20 @@ class WallNotificationsControllerTest extends WikiaBaseTest {
 						'msg_author_username' => 'Ann',
 						'wall_username' => 'Crazy frog',
 						'wall_displayname' => 'Crazy frog',
-						'parent_username' => 'Tom' ],
+						'parent_username' => 'Tom',
+						'thread_title' => 'hello message' ],
 					[ 'msg_author_displayname' => 'Bob',
 						'msg_author_username' => 'Bob',
 						'wall_username' => 'Crazy frog',
 						'wall_displayname' => 'Crazy frog',
-						'parent_username' => 'Tom' ],
+						'parent_username' => 'Tom',
+						'thread_title' => 'hello message' ],
 					[ 'msg_author_displayname' => 'Crazy frog',
 						'msg_author_username' => 'Crazy frog',
 						'wall_username' => 'Crazy frog',
 						'wall_displayname' => 'Crazy frog',
-						'parent_username' => 'Tom' ]
+						'parent_username' => 'Tom',
+						'thread_title' => 'hello message' ]
 				]
 			]
 		];


### PR DESCRIPTION
It seems php have some issue with strong typing here.
This should fix tests, and I will take some time to investigate why this is not working
//cc @Wikia/sustaining-team 
