### PR TITLE
Removed wgRevokePermissions

### DIFF
--- a/extensions/wikia/Forum/Forum.rights.setup.php
+++ b/extensions/wikia/Forum/Forum.rights.setup.php
@@ -14,8 +14,6 @@ $wgGroupPermissions['sysop']['forum'] = true;
 $wgGroupPermissions['bureaucrat']['forum'] = true;
 $wgGroupPermissions['helper']['forum'] = true;
 
-$wgRevokePermissions['vstf']['forum'] = true;
-
 $wgGroupPermissions['*']['boardedit'] = false;
 $wgGroupPermissions['staff']['boardedit'] = true;
 

--- a/includes/DefaultSettings.php
+++ b/includes/DefaultSettings.php
@@ -3543,16 +3543,6 @@ $wgGroupPermissions['bureaucrat']['noratelimit'] = true;
 /** @endcond */
 
 /**
- * Permission keys revoked from users in each group.
- * This acts the same way as wgGroupPermissions above, except that
- * if the user is in a group here, the permission will be removed from them.
- *
- * Improperly setting this could mean that your users will be unable to perform
- * certain essential tasks, so use at your own risk!
- */
-$wgRevokePermissions = array();
-
-/**
  * Implicit groups, aren't shown on Special:Listusers or somewhere else
  */
 $wgImplicitGroups = array( '*', 'user', 'autoconfirmed' );

--- a/includes/Title.php
+++ b/includes/Title.php
@@ -2186,7 +2186,7 @@ class Title {
 	 * @return Array list of errors
 	 */
 	private function checkReadPermissions( $action, $user, $errors, $doExpensiveQueries, $short ) {
-		global $wgWhitelistRead, $wgGroupPermissions, $wgRevokePermissions;
+		global $wgWhitelistRead, $wgGroupPermissions;
 		static $useShortcut = null;
 
 		# Initialize the $useShortcut boolean, to determine if we can skip quite a bit of code below
@@ -2195,20 +2195,6 @@ class Title {
 			if ( empty( $wgGroupPermissions['*']['read'] ) ) {
 				# Not a public wiki, so no shortcut
 				$useShortcut = false;
-			} elseif ( !empty( $wgRevokePermissions ) ) {
-				/**
-				 * Iterate through each group with permissions being revoked (key not included since we don't care
-				 * what the group name is), then check if the read permission is being revoked. If it is, then
-				 * we don't use the shortcut below since the user might not be able to read, even though anon
-				 * reading is allowed.
-				 */
-				foreach ( $wgRevokePermissions as $perms ) {
-					if ( !empty( $perms['read'] ) ) {
-						# We might be removing the read right from the user, so no shortcut
-						$useShortcut = false;
-						break;
-					}
-				}
 			}
 		}
 

--- a/includes/User.php
+++ b/includes/User.php
@@ -4436,7 +4436,7 @@ class User {
 	 * @return Array of Strings List of permission key names for given groups combined
 	 */
 	public static function getGroupPermissions( $groups ) {
-		global $wgGroupPermissions, $wgRevokePermissions;
+		global $wgGroupPermissions;
 		$rights = array();
 		// grant every granted permission first
 		foreach( $groups as $group ) {
@@ -4444,13 +4444,6 @@ class User {
 				$rights = array_merge( $rights,
 					// array_filter removes empty items
 					array_keys( array_filter( $wgGroupPermissions[$group] ) ) );
-			}
-		}
-		// now revoke the revoked permissions
-		foreach( $groups as $group ) {
-			if( isset( $wgRevokePermissions[$group] ) ) {
-				$rights = array_diff( $rights,
-					array_keys( array_filter( $wgRevokePermissions[$group] ) ) );
 			}
 		}
 		return array_unique( $rights );
@@ -4503,9 +4496,9 @@ class User {
 	 * @return Array of internal group names
 	 */
 	public static function getAllGroups() {
-		global $wgGroupPermissions, $wgRevokePermissions;
+		global $wgGroupPermissions;
 		return array_diff(
-			array_merge( array_keys( $wgGroupPermissions ), array_keys( $wgRevokePermissions ) ),
+			array_keys( $wgGroupPermissions ),
 			self::getImplicitGroups()
 		);
 	}

--- a/includes/specials/SpecialListgrouprights.php
+++ b/includes/specials/SpecialListgrouprights.php
@@ -42,7 +42,7 @@ class SpecialListGroupRights extends SpecialPage {
 	 */
 	public function execute( $par ) {
 		global $wgImplicitGroups;
-		global $wgGroupPermissions, $wgRevokePermissions, $wgAddGroups, $wgRemoveGroups;
+		global $wgGroupPermissions, $wgAddGroups, $wgRemoveGroups;
 		global $wgGroupsAddToSelf, $wgGroupsRemoveFromSelf;
 
 		$this->setHeaders();
@@ -61,7 +61,6 @@ class SpecialListGroupRights extends SpecialPage {
 
 		$allGroups = array_unique( array_merge(
 			array_keys( $wgGroupPermissions ),
-			array_keys( $wgRevokePermissions ),
 			array_keys( $wgAddGroups ),
 			array_keys( $wgRemoveGroups ),
 			array_keys( $wgGroupsAddToSelf ),
@@ -113,7 +112,6 @@ class SpecialListGroupRights extends SpecialPage {
 				$grouplink = '';
 			}
 
-			$revoke = isset( $wgRevokePermissions[$group] ) ? $wgRevokePermissions[$group] : array();
 			$addgroups = isset( $wgAddGroups[$group] ) ? $wgAddGroups[$group] : array();
 			$removegroups = isset( $wgRemoveGroups[$group] ) ? $wgRemoveGroups[$group] : array();
 			$addgroupsSelf = isset( $wgGroupsAddToSelf[$group] ) ? $wgGroupsAddToSelf[$group] : array();
@@ -124,7 +122,7 @@ class SpecialListGroupRights extends SpecialPage {
 				"
 				<td>$grouppage$grouplink</td>
 					<td>" .
-						$this->formatPermissions( $permissions, $revoke, $addgroups, $removegroups,
+						$this->formatPermissions( $permissions, $addgroups, $removegroups,
 							$addgroupsSelf, $removegroupsSelf ) .
 					'</td>
 				'
@@ -140,28 +138,18 @@ class SpecialListGroupRights extends SpecialPage {
 	 * Create a user-readable list of permissions from the given array.
 	 *
 	 * @param $permissions Array of permission => bool (from $wgGroupPermissions items)
-	 * @param $revoke Array of permission => bool (from $wgRevokePermissions items)
 	 * @param $add Array of groups this group is allowed to add or true
 	 * @param $remove Array of groups this group is allowed to remove or true
 	 * @param $addSelf Array of groups this group is allowed to add to self or true
 	 * @param $removeSelf Array of group this group is allowed to remove from self or true
 	 * @return string List of all granted permissions, separated by comma separator
 	 */
-	 private function formatPermissions( $permissions, $revoke, $add, $remove, $addSelf, $removeSelf ) {
+	 private function formatPermissions( $permissions, $add, $remove, $addSelf, $removeSelf ) {
 		$r = array();
 		foreach( $permissions as $permission => $granted ) {
 			//show as granted only if it isn't revoked to prevent duplicate display of permissions
 			if( $granted && ( !isset( $revoke[$permission] ) || !$revoke[$permission] ) ) {
 				$description = wfMsgExt( 'listgrouprights-right-display', array( 'parseinline' ),
-					User::getRightDescription( $permission ),
-					'<span class="mw-listgrouprights-right-name">' . $permission . '</span>'
-				);
-				$r[] = $description;
-			}
-		}
-		foreach( $revoke as $permission => $revoked ) {
-			if( $revoked ) {
-				$description = wfMsgExt( 'listgrouprights-right-revoked', array( 'parseinline' ),
 					User::getRightDescription( $permission ),
 					'<span class="mw-listgrouprights-right-name">' . $permission . '</span>'
 				);

--- a/tests/phpunit/includes/UserTest.php
+++ b/tests/phpunit/includes/UserTest.php
@@ -18,13 +18,12 @@ class UserTest extends MediaWikiTestCase {
 		parent::setUp();
 
 		$this->savedGroupPermissions = $GLOBALS['wgGroupPermissions'];
-		$this->savedRevokedPermissions = $GLOBALS['wgRevokePermissions'];
 
 		$this->setUpPermissionGlobals();
 		$this->setUpUser();
 	}
 	private function setUpPermissionGlobals() {
-		global $wgGroupPermissions, $wgRevokePermissions;
+		global $wgGroupPermissions;
 
 		# Data for regular $wgGroupPermissions test
 		$wgGroupPermissions['unittesters'] = array(
@@ -38,10 +37,6 @@ class UserTest extends MediaWikiTestCase {
 			'writetest' => true,
 			'modifytest' => true,
 		);
-		# Data for regular $wgRevokePermissions test
-		$wgRevokePermissions['formertesters'] = array(
-			'runtest' => true,
-		);
 	}
 	private function setUpUser() {
 		$this->user = new User;
@@ -52,7 +47,6 @@ class UserTest extends MediaWikiTestCase {
 		parent::tearDown();
 
 		$GLOBALS['wgGroupPermissions'] = $this->savedGroupPermissions;
-		$GLOBALS['wgRevokePermissions'] = $this->savedRevokedPermissions;
 	}
 
 	public function testGroupPermissions() {
@@ -66,13 +60,6 @@ class UserTest extends MediaWikiTestCase {
 		$this->assertContains( 'runtest', $rights );
 		$this->assertContains( 'writetest', $rights );
 		$this->assertContains( 'modifytest', $rights );
-		$this->assertNotContains( 'nukeworld', $rights );
-	}
-	public function testRevokePermissions() {
-		$rights = User::getGroupPermissions( array( 'unittesters', 'formertesters' ) );
-		$this->assertNotContains( 'runtest', $rights );
-		$this->assertNotContains( 'writetest', $rights );
-		$this->assertNotContains( 'modifytest', $rights );
 		$this->assertNotContains( 'nukeworld', $rights );
 	}
 


### PR DESCRIPTION
Another cleanup related to user permissions - the variable wgRevokePermissions was set only for vstf and forum. I confirmed with comsup, that we don't need that. Also this variable doesn't seem to be set in wiki factory DB in any local wiki.

Hence I'm deleting it completely to have less logic to port to user permissions service.
