### PR TITLE
ADEN-2998 Monobook spotlights

### DIFF
--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -1020,7 +1020,6 @@ $config['monobook_js'] = array(
 		'//resources/wikia/modules/lazyqueue.js',
 		'//extensions/wikia/JSMessages/js/JSMessages.js',
 		'#group_imglzy_js',
-		'#group_spotlights_js',
 		'//resources/wikia/libraries/ghostwriter/gw.min.js',
 		'//skins/shared/scripts/onScroll.js',
 		'//extensions/wikia/VideoHandlers/js/VideoBootstrap.js',

--- a/extensions/wikia/Spotlights/js/AdProviderOpenX.js
+++ b/extensions/wikia/Spotlights/js/AdProviderOpenX.js
@@ -56,11 +56,15 @@ AdProviderOpenX.getUrl = function() {
 function isReviveEnabledInGeo() {
 	'use strict';
 
-	if (!window.Wikia.geo.isProperGeo) {
+	if (!window.Wikia) {
 		return false;
 	}
 
-	if (!window.Wikia.InstantGlobals.wgReviveSpotlightsCountries) {
+	if (!window.Wikia.geo || !window.Wikia.geo.isProperGeo) {
+		return false;
+	}
+
+	if (!window.Wikia.InstantGlobals || !window.Wikia.InstantGlobals.wgReviveSpotlightsCountries) {
 		return false;
 	}
 

--- a/extensions/wikia/Spotlights/js/AdProviderOpenX.js
+++ b/extensions/wikia/Spotlights/js/AdProviderOpenX.js
@@ -55,20 +55,12 @@ AdProviderOpenX.getUrl = function() {
 
 function isReviveEnabledInGeo() {
 	'use strict';
-
-	if (!window.Wikia) {
+	
+	try {
+		return window.Wikia.geo.isProperGeo(window.Wikia.InstantGlobals.wgReviveSpotlightsCountries);
+	} catch (e) {
 		return false;
 	}
-
-	if (!window.Wikia.geo || !window.Wikia.geo.isProperGeo) {
-		return false;
-	}
-
-	if (!window.Wikia.InstantGlobals || !window.Wikia.InstantGlobals.wgReviveSpotlightsCountries) {
-		return false;
-	}
-
-	return window.Wikia.geo.isProperGeo(window.Wikia.InstantGlobals.wgReviveSpotlightsCountries);
 }
 
 if (!window.wgNoExternals && window.wgEnableOpenXSPC && !window.wgIsEditPage && !window.navigator.userAgent.match(/sony_tvs/)) {


### PR DESCRIPTION
We don't have `InstantGlobals` in Monobook and we started serving a JS error on this skin. Changes below fixes those error and also remove spotlights assets from Monobook.
