### PR TITLE
SpecialUpload: only validate the token when we have one

### DIFF
--- a/includes/User.php
+++ b/includes/User.php
@@ -3976,7 +3976,7 @@ class User {
 	 */
 	public function matchEditToken( $val, $salt = '', $request = null ) {
 		$sessionToken = $this->getEditToken( $salt, $request );
-		$equals = hash_equals( $sessionToken, $val );
+		$equals = !is_null( $val ) && hash_equals( $sessionToken, $val );
 		if ( !$equals ) {
 			wfDebug( "User::matchEditToken: broken session data\n" );
 
@@ -4015,7 +4015,7 @@ class User {
 	 */
 	public function matchEditTokenNoSuffix( $val, $salt = '', $request = null ) {
 		$sessionToken = $this->getEditToken( $salt, $request );
-		return hash_equals( substr( $sessionToken, 0, 32 ), substr( $val, 0, 32 ) );
+		return !is_null( $val ) && hash_equals( substr( $sessionToken, 0, 32 ), substr( $val, 0, 32 ) );
 	}
 
 	/**

--- a/includes/specials/SpecialUpload.php
+++ b/includes/specials/SpecialUpload.php
@@ -110,7 +110,7 @@ class SpecialUpload extends SpecialPage {
 
 		// If it was posted check for the token (no remote POST'ing with user credentials)
 		$token = $request->getVal( 'wpEditToken' );
-		$this->mTokenOk = !is_null( $token ) && $this->getUser()->matchEditToken( $token ); # Wikia change
+		$this->mTokenOk = $this->getUser()->matchEditToken( $token );
 
 		$this->uploadFormTextTop = '';
 		$this->uploadFormTextAfterSummary = '';

--- a/includes/specials/SpecialUpload.php
+++ b/includes/specials/SpecialUpload.php
@@ -110,7 +110,7 @@ class SpecialUpload extends SpecialPage {
 
 		// If it was posted check for the token (no remote POST'ing with user credentials)
 		$token = $request->getVal( 'wpEditToken' );
-		$this->mTokenOk = $this->getUser()->matchEditToken( $token );
+		$this->mTokenOk = !is_null( $token ) && $this->getUser()->matchEditToken( $token ); # Wikia change
 
 		$this->uploadFormTextTop = '';
 		$this->uploadFormTextAfterSummary = '';


### PR DESCRIPTION
[PLATFORM-1881](https://wikia-inc.atlassian.net/browse/PLATFORM-1881)

99% of `hash_equals(): Expected user_string to be a string, null given` warnings came from `SpecialUpload` class that tries to validate the token on the first requests to `Special:Upload`. This obviously makes no sense - add a check for not null token before validating it.

@wladekb 
