### PR TITLE
XW-1153 Remove redundant check from MercuryApi

### DIFF
--- a/extensions/wikia/MercuryApi/MercuryApiController.class.php
+++ b/extensions/wikia/MercuryApi/MercuryApiController.class.php
@@ -471,12 +471,13 @@ class MercuryApiController extends WikiaController {
 	 * @return array [Title, Article, array]
 	 */
 	private function handleRedirect( Title $title, Article $article, $data ) {
+		// It should never be null because we check if $title is a redirect before calling this method
 		/* @var Title $redirectTargetTitle */
 		$redirectTargetTitle = $article->getRedirectTarget();
 		$redirectTargetID = $redirectTargetTitle->getArticleID();
 		$data['redirected'] = true;
 
-		if ( $redirectTargetTitle instanceof Title ) {
+		if ( !empty( $redirectTargetID ) ) {
 			$title = $redirectTargetTitle;
 			$article = Article::newFromID( $redirectTargetID );
 		} else {

--- a/extensions/wikia/MercuryApi/MercuryApiController.class.php
+++ b/extensions/wikia/MercuryApi/MercuryApiController.class.php
@@ -471,12 +471,12 @@ class MercuryApiController extends WikiaController {
 	 * @return array [Title, Article, array]
 	 */
 	private function handleRedirect( Title $title, Article $article, $data ) {
-		/* @var Title|null $redirectTargetTitle */
+		/* @var Title $redirectTargetTitle */
 		$redirectTargetTitle = $article->getRedirectTarget();
 		$redirectTargetID = $redirectTargetTitle->getArticleID();
 		$data['redirected'] = true;
 
-		if ( $redirectTargetTitle instanceof Title && !empty( $redirectTargetID ) ) {
+		if ( $redirectTargetTitle instanceof Title ) {
 			$title = $redirectTargetTitle;
 			$article = Article::newFromID( $redirectTargetID );
 		} else {


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/XW-1153

`$redirectTargetTitle` shouldn't ever be a `null` because we check if `$title->isRedirect()` before calling `handleRedirect()` and `Article::getRedirectTarget()` returns `null` if `!$title->isRedirect()`.

Also, I've tested it on article with:

```
#REDIRECT [[Special:NonExistent]]
```

(http://concf.wikia.com/wiki/Redirect_empty_target) and it seems to work just fine.
