### PR TITLE
SEO-288 Include the Special:Images in the My Tools selection

### DIFF
--- a/extensions/wikia/WikiaNewFiles/WikiaNewFiles.i18n.php
+++ b/extensions/wikia/WikiaNewFiles/WikiaNewFiles.i18n.php
@@ -9,6 +9,7 @@
 $messages = [ ];
 
 $messages['en'] = [
+	'images' => '{{int:wikianewfiles-title}}',
 	'wikianewfiles-title' => 'Images',
 	'wikianewfiles-desc' => 'Extends a [[Special:NewFiles|special page]] to override some of the header formatting',
 	'wikianewfiles-uploadby' => 'by {{GENDER:$2|$1}}',

--- a/extensions/wikia/WikiaNewFiles/WikiaNewFilesSpecialController.class.php
+++ b/extensions/wikia/WikiaNewFiles/WikiaNewFilesSpecialController.class.php
@@ -18,7 +18,6 @@ class WikiaNewFilesSpecialController extends WikiaSpecialPageController {
 		$output = $this->getContext()->getOutput();
 		$request = $this->getRequest();
 
-		$output->setPageTitle( wfMessage( 'wikianewfiles-title' ) );
 		$this->wg->SupressPageSubtitle = true;
 
 		Wikia::addAssetsToOutput( 'upload_photos_dialog_js' );

--- a/includes/wikia/services/SharedToolbarService.class.php
+++ b/includes/wikia/services/SharedToolbarService.class.php
@@ -110,7 +110,7 @@ class SharedToolbarService extends ToolbarService {
 			'SpecialPage:MostLinkedTemplates',
 			'SpecialPage:Mostpopularcategories',
 			'SpecialPage:NewPages',
-			'SpecialPage:NewFiles',
+			'SpecialPage:Images',
 			'SpecialPage:AncientPages',
 			'SpecialPage:LonelyPages',
 			'SpecialPage:FewestRevisions',


### PR DESCRIPTION
My Tools selection lists the selected special pages using their
description (getDescription) as the label for the translation.

We're adding a translation of 'images' label to read it from
'wikianewfiles-title'.

This makes the "Images" appear in the selection of the tools suggested
for users.

I also updated the content of the following help page:

http://community.wikia.com/wiki/Help:Toolbar/List_of_available_tools

Help in other languages should be also updated.
