### PR TITLE
SEO-289 Fix tracking for clicks in "Images" in top nav

### DIFF
--- a/skins/oasis/js/Tracking.js
+++ b/skins/oasis/js/Tracking.js
@@ -602,7 +602,7 @@ jQuery(function ($) {
 				case 'random':
 					label = 'on-the-wiki-random';
 					break;
-				case 'newfiles':
+				case 'images':
 					label = 'on-the-wiki-new-photos';
 					break;
 				case 'chat':


### PR DESCRIPTION
It was broken by updating the link from Special:NewFiles to
Special:Images in SEO-287

Check by logging to GA > All Wikis > Behavior > Events > Top events >
wiki-nav > on-the-wiki-new-photos

The number dropped between Feb 17 and Feb 18, 2016.
