### PR TITLE
CE-3295: Update recent changes API to return upvotes for revisions

### DIFF
--- a/includes/api/ApiQueryRecentChanges.php
+++ b/includes/api/ApiQueryRecentChanges.php
@@ -40,7 +40,7 @@ class ApiQueryRecentChanges extends ApiQueryGeneratorBase {
 			$fld_user = false, $fld_userid = false, $fld_useravatar = false,
 			$fld_flags = false, $fld_timestamp = false, $fld_title = false, $fld_ids = false,
 			$fld_sizes = false, $fld_redirect = false, $fld_patrolled = false,
-			$fld_loginfo = false, $fld_tags = false, $token = array();
+			$fld_loginfo = false, $fld_tags = false, $fld_upvotes, $token = array();
 
 	private $tokenFunctions;
 
@@ -111,6 +111,7 @@ class ApiQueryRecentChanges extends ApiQueryGeneratorBase {
 		$this->fld_patrolled = isset( $prop['patrolled'] );
 		$this->fld_loginfo = isset( $prop['loginfo'] );
 		$this->fld_tags = isset( $prop['tags'] );
+		$this->fld_upvotes = isset( $prop['upvotes'] );
 	}
 
 	public function execute() {
@@ -276,7 +277,8 @@ class ApiQueryRecentChanges extends ApiQueryGeneratorBase {
 		/* Perform the actual query. */
 		$res = $this->select( __METHOD__ );
 
-		$titles = array();
+		$titles = [];
+		$revisionsIds = [];
 
 		$result = $this->getResult();
 
@@ -287,6 +289,8 @@ class ApiQueryRecentChanges extends ApiQueryGeneratorBase {
 				$this->setContinueEnumParameter( 'start', wfTimestamp( TS_ISO_8601, $row->rc_timestamp ) );
 				break;
 			}
+
+			$revisionsIds[] = $row->rc_this_oldid;
 
 			if ( is_null( $resultPageSet ) ) {
 				/* Extract the data from a single row. */
@@ -305,6 +309,8 @@ class ApiQueryRecentChanges extends ApiQueryGeneratorBase {
 				$titles[] = Title::makeTitle( $row->rc_namespace, $row->rc_title );
 			}
 		}
+
+		$this->combineAdditionalData( $result, $revisionsIds );
 
 		if ( is_null( $resultPageSet ) ) {
 			/* Format the result */
@@ -525,6 +531,27 @@ class ApiQueryRecentChanges extends ApiQueryGeneratorBase {
 		}
 	}
 
+	private function combineAdditionalData( ApiResult $result, array $revisionsIds ) {
+		global $wgCityId;
+
+		if ( $this->fld_upvotes ) {
+			$upvotes = ( new RevisionUpvotesService() )->getRevisionsUpvotes( $wgCityId, $revisionsIds );
+			foreach( $revisionsIds as $index => $id ) {
+				$upvote = [];
+				$upvoteCount = 0;
+				$path = ['query', $this->getModuleName(), $index];
+
+				if ( isset( $upvotes[$id] ) ) {
+					$upvote = $upvotes[$id]['upvotes'];
+					$upvoteCount = $upvotes[$id]['count'];
+				}
+
+				$result->addValue( $path, 'upvotes', $upvote );
+				$result->addValue( $path, 'upvotes_count', $upvoteCount );
+			}
+		}
+	}
+
 	public function getCacheMode( $params ) {
 		if ( isset( $params['show'] ) ) {
 			foreach ( $params['show'] as $show ) {
@@ -587,7 +614,8 @@ class ApiQueryRecentChanges extends ApiQueryGeneratorBase {
 					'patrolled',
 					'loginfo',
 					'wikiamode',
-					'tags'
+					'upvotes',
+					'tags',
 				)
 			),
 			'token' => array(
@@ -657,6 +685,7 @@ class ApiQueryRecentChanges extends ApiQueryGeneratorBase {
 				' redirect       - Tags edit if page is a redirect',
 				' patrolled      - Tags edits that have been patrolled',
 				' loginfo        - Adds log information (logid, logtype, etc) to log entries',
+				' upvotes        - Adds data about upvotes for the edit',
 				' tags           - Lists tags for the entry',
 			),
 			'token' => 'Which tokens to obtain for each change',

--- a/includes/api/ApiQueryRecentChanges.php
+++ b/includes/api/ApiQueryRecentChanges.php
@@ -546,7 +546,7 @@ class ApiQueryRecentChanges extends ApiQueryGeneratorBase {
 				$upvoteCount = $upvotes[$id]['count'];
 			}
 			$result->addValue( $path, 'upvotes', $upvote );
-			$result->addValue( $path, 'upvotes_count', $upvoteCount );
+			$result->addValue( $path, 'upvotescount', $upvoteCount );
 		}
 	}
 

--- a/includes/wikia/api/RevisionApiController.class.php
+++ b/includes/wikia/api/RevisionApiController.class.php
@@ -87,7 +87,7 @@ class RevisionApiController extends WikiaApiController {
 			'isMinor' => $revision->isMinor(),
 			'parsedComment' => Linker::formatComment( $comment, $revision->getTitle() ),
 			'revisionId' => $revision->getId(),
-			'userId' => $revision->getId(),
+			'userId' => $revision->getUser(),
 			'userName' => $revision->getUserText(),
 			'timestamp' => wfTimestamp( TS_UNIX, $revision->getTimestamp() )
 		];

--- a/includes/wikia/api/RevisionApiController.class.php
+++ b/includes/wikia/api/RevisionApiController.class.php
@@ -29,15 +29,14 @@ class RevisionApiController extends WikiaApiController {
 			throw new MissingParameterApiException( 'newId' );
 		}
 
-		$avatar = $request->getBool( 'avatar' );
-		$oldRev = $request->getBool( 'oldRev' );
+		$params = $this->getParams( $request );
 
 		$data = [];
 		$revision = Revision::newFromId( $newId );
 
 		if ( $revision ) {
 			$diffs = $this->getDiffs( $revision->getTitle(), $oldId, $newId );
-			$revisionData = $this->prepareRevisionData( $revision, $avatar );
+			$revisionData = $this->prepareRevisionData( $revision, $params );
 			$pageData = $this->preparePageData( $revision );
 
 			$data = [
@@ -46,7 +45,7 @@ class RevisionApiController extends WikiaApiController {
 				'revision' => $revisionData
 			];
 
-			if ( $oldRev ) {
+			if ( $params['oldRev'] ) {
 				$oldRevision = Revision::newFromId( $oldId );
 				if ( $oldRevision ) {
 					$data['oldRevision'] = $this->prepareRevisionData( $oldRevision, $avatar );
@@ -77,10 +76,10 @@ class RevisionApiController extends WikiaApiController {
 	 * Prepares data about revision
 	 *
 	 * @param Revision $revision
-	 * @param bool $avatar should include user avatar
+	 * @param array $params
 	 * @return array
 	 */
-	private function prepareRevisionData( Revision $revision, $avatar ) {
+	private function prepareRevisionData( Revision $revision, $params ) {
 		$comment = $revision->getComment();
 		$revisionData = [
 			'comment' => $comment,
@@ -93,11 +92,31 @@ class RevisionApiController extends WikiaApiController {
 			'timestamp' => wfTimestamp( TS_UNIX, $revision->getTimestamp() )
 		];
 
-		if ( $avatar ) {
+		if ( $params['avatar'] ) {
 			$revisionData['userAvatar'] = AvatarService::getAvatarUrl( $revision->getUserText() );
 		}
 
+		if ( $params['upvotes'] ) {
+			$upvotes = ( new RevisionUpvotesService() )->getRevisionUpvotes( $this->wg->CityId, $revision->getId() );
+			$revisionData['upvotes'] = $upvotes['upvotes'];
+			$revisionData['upvotesCount'] = $upvotes['count'];
+		}
+
 		return $revisionData;
+	}
+
+	/**
+	 * Get params from request
+	 *
+	 * @param WikiaRequest $request
+	 * @return array
+	 */
+	private function getParams( WikiaRequest $request ) {
+		return [
+			'avatar' => $request->getBool( 'avatar' ),
+			'oldRev' => $request->getBool( 'oldRev' ),
+			'upvotes' => $request->getBool( 'upvotes' )
+		];
 	}
 
 	/**

--- a/includes/wikia/api/RevisionUpvotesApiController.class.php
+++ b/includes/wikia/api/RevisionUpvotesApiController.class.php
@@ -48,6 +48,7 @@ class RevisionUpvotesApiController extends WikiaApiController {
 	 * Remove upvote for given revision made by current user
 	 *
 	 * @requestParam int upvote id
+	 * @requestParam int user id who made an edit
 	 *
 	 * @throws MissingParameterApiException
 	 * @throws BadRequestApiException
@@ -66,7 +67,12 @@ class RevisionUpvotesApiController extends WikiaApiController {
 			throw new MissingParameterApiException( 'id' );
 		}
 
-		$removed = ( new RevisionUpvotesService() )->removeUpvote( $id, $user->getId() );
+		$userId = $request->getInt( 'userId' );
+		if ( empty( $userId ) ) {
+			throw new MissingParameterApiException( 'userId' );
+		}
+
+		$removed = ( new RevisionUpvotesService() )->removeUpvote( $id, $user->getId(), $userId );
 
 		$this->setResponseData( [
 			'success' => (bool) $removed

--- a/includes/wikia/services/RevisionUpvotesService.class.php
+++ b/includes/wikia/services/RevisionUpvotesService.class.php
@@ -95,6 +95,7 @@ class RevisionUpvotesService {
 				}
 
 				$upvote['upvotes'][] = [
+					'id' => $row->id,
 					'from_user' => $row->from_user
 				];
 			} );
@@ -133,6 +134,7 @@ class RevisionUpvotesService {
 				}
 
 				$upvotes[$row->revision_id]['upvotes'][] = [
+					'id' => $row->id,
 					'from_user' => $row->from_user
 				];
 			} );

--- a/includes/wikia/services/RevisionUpvotesService.class.php
+++ b/includes/wikia/services/RevisionUpvotesService.class.php
@@ -36,7 +36,7 @@ class RevisionUpvotesService {
 	 * @param int $id
 	 * @param int $fromUser
 	 */
-	public function removeUpvote( $id, $fromUser ) {
+	public function removeUpvote( $id, $fromUser, $userId ) {
 		$db = $this->getDatabaseForWrite();
 
 		$db->begin();
@@ -53,8 +53,7 @@ class RevisionUpvotesService {
 			->UPDATE( self::UPVOTE_USERS_TABLE )
 			->SET_RAW( 'total', 'IF(`total` > 0, `total` - 1, 0)' )
 			->SET_RAW( 'new', 'IF(`new` > 0, `new` - 1, 0)' )
-			->WHERE( 'id' )->EQUAL_TO( $id )
-			->AND_( 'from_user' )->EQUAL_TO( $fromUser )
+			->WHERE( 'user_id' )->EQUAL_TO( $userId )
 			->run( $db );
 
 		if ( $rowRemoved ) {


### PR DESCRIPTION
We added possibility to upvote for user edit/change. We want to get data about upvotes for each revision on Recent Wiki Activity on mobile, so we updated existing API to meet out requirements.
