### PR TITLE
CloseWikiMaintenance: make sure that S3 bucket exists before running images backup

### DIFF
--- a/extensions/wikia/WikiFactory/Close/maintenance.php
+++ b/extensions/wikia/WikiFactory/Close/maintenance.php
@@ -167,24 +167,29 @@ class CloseWikiMaintenance {
 			if( $row->city_flags & WikiFactory::FLAG_CREATE_IMAGE_ARCHIVE ) {
 				if( $dbname && $folder ) {
 					$this->log( "Dumping images on remote host" );
-					$source = $this->tarFiles( $folder, $dbname, $cityid );
-					if( $source ) {
-                        $retval = DumpsOnDemand::putToAmazonS3( $source, !$hide,  MimeMagic::singleton()->guessMimeType( $source ) );
-						if( $retval > 0 ) {
-							$this->log( "putToAmazonS3 command failed." );
-							echo "Can't copy images to remote host. Please, fix that and rerun";
-							die( 1 );
-						} else {
-							$this->log( "{$source} copied to S3 Amazon" );
-							unlink( $source );
-							$newFlags = $newFlags | WikiFactory::FLAG_CREATE_IMAGE_ARCHIVE | WikiFactory::FLAG_HIDE_DB_IMAGES;
+					try {
+						$source = $this->tarFiles( $folder, $dbname, $cityid );
+
+						if( is_string( $source ) ) {
+							$retval = DumpsOnDemand::putToAmazonS3( $source, !$hide,  MimeMagic::singleton()->guessMimeType( $source ) );
+							if( $retval > 0 ) {
+								$this->log( "putToAmazonS3 command failed." );
+								echo "Can't copy images to remote host. Please, fix that and rerun";
+								die( 1 );
+							} else {
+								$this->log( "{$source} copied to S3 Amazon" );
+								unlink( $source );
+							}
 						}
+
+						$newFlags = $newFlags | WikiFactory::FLAG_CREATE_IMAGE_ARCHIVE | WikiFactory::FLAG_HIDE_DB_IMAGES;
 					}
-					else {
+					catch( WikiaException $e ) {
 						/**
 						 * actually it's better to die than remove
 						 * images later without backup
 						 */
+						$this->log( $e->getMessage() );
 						echo "Can't copy images to remote host. Source {$source} is not defined";
 					}
 				}
@@ -318,20 +323,21 @@ class CloseWikiMaintenance {
 	 * @param string $dbname database name
 	 * @param int $cityid city ID
 	 *
-	 * @return string path to created archive or false if not created
+	 * @return string path to created archive or false if there are no files to backup (S3 bucket does not exist / is empty)
+	 * @throws WikiaException thrown on failed backups
 	 */
-	public function tarFiles( $directory, $dbname, $cityid ) {
+	private function tarFiles( $directory, $dbname, $cityid ) {
 		$swiftEnabled = WikiFactory::getVarValueByName( 'wgEnableSwiftFileBackend', $cityid );
 		$wgUploadPath = WikiFactory::getVarValueByName( 'wgUploadPath', $cityid );
 
 		if ( $swiftEnabled ) {
 			// check that S3 bucket for this wiki exists (PLATFORM-1199)
 			$swiftStorage = \Wikia\SwiftStorage::newFromWiki( $cityid );
-			$isEmpty = $swiftStorage->getContainer()->object_count == 0;
+			$isEmpty = intval( $swiftStorage->getContainer()->object_count ) === 0;
 
-			if ($isEmpty) {
+			if ( $isEmpty ) {
 				$this->log( sprintf( "'%s' S3 bucket is empty, leave early\n", $swiftStorage->getContainerName() ) );
-				return true;
+				return false;
 			}
 
 			// sync Swift container to the local directory
@@ -382,7 +388,7 @@ class CloseWikiMaintenance {
 		}
 		else {
 			$this->log( "List of files in {$directory} is empty" );
-			$result = false;
+			throw new WikiaException( "List of files in {$directory} is empty" );
 		}
 		return $result;
 	}

--- a/extensions/wikia/WikiFactory/Close/maintenance.php
+++ b/extensions/wikia/WikiFactory/Close/maintenance.php
@@ -325,6 +325,15 @@ class CloseWikiMaintenance {
 		$wgUploadPath = WikiFactory::getVarValueByName( 'wgUploadPath', $cityid );
 
 		if ( $swiftEnabled ) {
+			// check that S3 bucket for this wiki exists (PLATFORM-1199)
+			$swiftStorage = \Wikia\SwiftStorage::newFromWiki( $cityid );
+			$isEmpty = $swiftStorage->getContainer()->object_count == 0;
+
+			if ($isEmpty) {
+				$this->log( sprintf( "'%s' S3 bucket is empty, leave early\n", $swiftStorage->getContainerName() ) );
+				return true;
+			}
+
 			// sync Swift container to the local directory
 			$directory = sprintf( "/tmp/images/{$dbname}/" );
 


### PR DESCRIPTION
[PLATFORM-1199](https://wikia-inc.atlassian.net/browse/PLATFORM-1199)

Maintenance script that is meant to remove old wikis is now not performing its job fully. It fails on generating backup of images - most of closed wikis do not have any images uploaded, further more - S3 bucket for them do not exist.

This PR adds a check for it (in `tarFiles` method):

```
> var_dump( \Wikia\SwiftStorage::newFromWiki( 1315266 )->getContainer()->object_count )
float(0)

> var_dump( \Wikia\SwiftStorage::newFromWiki( 831 )->getContainer()->object_count )
float(1560707)
```

@mixth-sense 
