### PR TITLE
SEO-291 Fix the link to 'Photos & Videos' in the founder email

### DIFF
--- a/extensions/wikia/Email/Controller/FounderController.class.php
+++ b/extensions/wikia/Email/Controller/FounderController.class.php
@@ -501,7 +501,7 @@ class FounderTipsController extends EmailController {
 			],
 			[
 				"iconSrc" => Email\ImageHelper::getFileUrl( "Add_photo.png" ),
-				"iconLink" => \GlobalTitle::newFromText( "NewFiles", NS_SPECIAL, $this->wikiId )->getFullURL( [ "modal" => "UploadImage" ] ),
+				"iconLink" => \GlobalTitle::newFromText( "Images", NS_SPECIAL, $this->wikiId )->getFullURL( [ "modal" => "UploadImage" ] ),
 				"detailsHeader" => $this->getMessage( "emailext-founder-add-photos-header" )->text(),
 				"details" => $this->getMessage( "emailext-founder-add-photos-details" )->text()
 			],

--- a/extensions/wikia/WikiaNewFiles/scripts/uploadPhotosDialog.js
+++ b/extensions/wikia/WikiaNewFiles/scripts/uploadPhotosDialog.js
@@ -7,6 +7,9 @@ var UploadPhotos = {
 	libinit: false,
 	init: function() {
 		$(".mw-special-Images").on('click', '.upphotos', $.proxy(this.loginBeforeShowDialog, this));
+		if (Wikia.Querystring().getVal('modal') === 'UploadImage') {
+			this.loginBeforeShowDialog();
+		}
 	},
 	loginBeforeShowDialog: function(evt) {
 		var UserLoginModal = window.UserLoginModal;
@@ -134,7 +137,7 @@ var UploadPhotos = {
 			var json = JSON.parse(res);
 			if(json) {
 				if(json['status'] == 0) {	// 0 is success...
-					window.location = wgArticlePath.replace('$1', 'Special:NewFiles');
+					window.location = wgArticlePath.replace('$1', 'Special:Images');
 				} else if(json['status'] == -2) {	// show conflict dialog
 					UploadPhotos.step1.hide(400, function() {
 						UploadPhotos.advanced.hide();


### PR DESCRIPTION
- Support ?modal=UploadImage param for Special:Images
- Update the link in the e-mail to point straight to Special:Images
- Also a fix for the minor SEO-293 (shaved one redirect after successfully uploading an image)
