### PR TITLE
SEO-292 Update WikiaMobile wgWikiaMobileNavigationBlacklist

### DIFF
--- a/extensions/wikia/WikiaMobile/WikiaMobile.setup.php
+++ b/extensions/wikia/WikiaMobile/WikiaMobile.setup.php
@@ -126,7 +126,7 @@ if ( empty($wgWikiaMobileGlobalNavigationMenu ) ) {
 
 //list of special pages (canonical names) to strip out from the navigation menu
 if ( empty( $wgWikiaMobileNavigationBlacklist ) ) {
-	$wgWikiaMobileNavigationBlacklist = array( 'Chat', 'WikiActivity', 'NewFiles' );
+	$wgWikiaMobileNavigationBlacklist = array( 'Chat', 'WikiActivity', 'NewFiles', 'Images' );
 }
 
 // white list of JS globals


### PR DESCRIPTION
Prevent both Special:NewFiles and Special:Images from appearing in the
WikiaMobile nav menu.
