### PR TITLE
SEO-290 Update link generated in CityVisualization

### DIFF
--- a/extensions/wikia/CityVisualization/helpers/WikiaHomePageHelper.class.php
+++ b/extensions/wikia/CityVisualization/helpers/WikiaHomePageHelper.class.php
@@ -443,7 +443,7 @@ class WikiaHomePageHelper extends WikiaModel {
 	}
 
 	protected function getNewFilesUrl($wikiId) {
-		$globalNewFilesTitle = GlobalTitle::newFromText('NewFiles', NS_SPECIAL, $wikiId);
+		$globalNewFilesTitle = GlobalTitle::newFromText('Images', NS_SPECIAL, $wikiId);
 		if ($globalNewFilesTitle instanceof Title) {
 			$newFilesUrl = $globalNewFilesTitle->getFullURL();
 			return $newFilesUrl;


### PR DESCRIPTION
I wanted to remove the extension, but it seems it's actually used by the
next version of hubs code, so I'm just updating the link to point to the
new URL for Special:Images
