### PR TITLE
SEO-294 Clean up NewFiles -> Images: Update VideoEmbedTool

### DIFF
--- a/extensions/wikia/VideoEmbedTool/VideoEmbedTool_body.php
+++ b/extensions/wikia/VideoEmbedTool/VideoEmbedTool_body.php
@@ -23,21 +23,6 @@ class VideoEmbedTool {
 		return $tmpl->render( "main" );
 	}
 
-	function recentlyUploaded() {
-		global $IP, $wmu;
-
-		require_once( $IP . '/includes/SpecialPage.php' );
-		require_once( $IP . '/includes/specials/SpecialNewimages.php' );
-		// this needs to be revritten, since we will not display recently uploaded, but embedded
-
-		$isp = new IncludableSpecialPage( 'Newimages', '', 1, 'wfSpecialNewimages', $IP . '/includes/specials/SpecialNewimages.php' );
-		wfSpecialNewimages( 8, $isp );
-		$tmpl = new EasyTemplate( dirname( __FILE__ ) . '/templates/' );
-		$tmpl->set_vars( array( 'data' => $wmu ) );
-
-		return $tmpl->render( "results_recently" );
-	}
-
 	function editVideo() {
 		global $wgRequest;
 


### PR DESCRIPTION
There's a method in VET called recentUploads that currently doesn't
work. You can asset it using an URL like this:

http://muppet.rychu.wikia-dev.com/index.php?action=ajax&rs=VET&method=recentlyUploaded

This returns a 500 response, because it calls a function that doesn't
exist.

Apparently (I checked the logs) this function is not even used, so the
only way to get this error to visit the URL manually. (The only errors
logged Kibana are those coming from me testing).

Long story short: I'm removing this method.
