### PR TITLE
In WikiaBaseTest add mockStaticMethodWithCallBack

### DIFF
--- a/includes/wikia/tests/core/WikiaBaseTest.class.php
+++ b/includes/wikia/tests/core/WikiaBaseTest.class.php
@@ -225,6 +225,34 @@ abstract class WikiaBaseTest extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * Mock a static method using callback
+	 *
+	 * Example:
+	 *
+	 * $this->mockStaticMethodWithCallBack( 'Title', 'newFromID',
+	 *   function ( $titleId ) {
+	 *     $titleMock = $this->getMock( 'Title', [ 'getArticleID' ] );
+	 *     $titleMock->expects( $this->any() )
+	 *       ->method( 'getArticleID' )
+	 *       ->willReturn( $titleId );
+	 *     return $titleMock;
+	 *   }
+	 * );
+	 * $this->assertEquals( 7, Title::newFromID( 7 )->getArticleID() );
+	 * $this->assertEquals( 12, Title::newFromID( 12 )->getArticleID() );
+	 * $this->assertEquals( 123, Title::newFromID( 123 )->getArticleID() );
+	 *
+	 * @param $className string
+	 * @param $methodName string
+	 * @param $callBack callable
+	 */
+	protected function mockStaticMethodWithCallBack( $className, $methodName, callable $callBack) {
+		$this->getMockProxy()
+			->getStaticMethod($className, $methodName)
+			->willCall($callBack);
+	}
+
+	/**
 	 * Mock global ($wg...) variable.
 	 *
 	 * @param $globalName string name of global variable (e.g. wgCity - WITH wg prefix)


### PR DESCRIPTION
Media wiki has a lot of static methods that act as constructors such as `Revision::newFromId`

In some tests we want to return a specific instance depending on params instead of using one single mock

@Wikia/engineers 
