### PR TITLE
SEO-279 Don't emit hreflang links on redirect pages

### DIFF
--- a/extensions/wikia/SeoLinkHreflang/SeoLinkHreflang.class.php
+++ b/extensions/wikia/SeoLinkHreflang/SeoLinkHreflang.class.php
@@ -62,7 +62,7 @@ class SeoLinkHreflang {
 		$title = $out->getTitle();
 
 		// No mapping for redirect pages
-		if ( !empty( $wgArticle->mRedirectedFrom ) ) {
+		if ( empty( $wgArticle ) || !empty( $wgArticle->mRedirectedFrom ) ) {
 			return [];
 		}
 

--- a/extensions/wikia/SeoLinkHreflang/SeoLinkHreflang.class.php
+++ b/extensions/wikia/SeoLinkHreflang/SeoLinkHreflang.class.php
@@ -57,12 +57,12 @@ class SeoLinkHreflang {
 	}
 
 	private static function generateHreflangLinks( OutputPage $out ) {
-		global $wgEnableLillyExt;
+		global $wgEnableLillyExt, $wgArticle;
 
 		$title = $out->getTitle();
 
 		// No mapping for redirect pages
-		if ( $title->isRedirect() ) {
+		if ( !empty( $wgArticle->mRedirectedFrom ) ) {
 			return [];
 		}
 


### PR DESCRIPTION
Apparently $wgTitle->isRedirect() is not how you check if the page is a
redirect, because the $wgTitle is already the target title in this case.

I haven't found a better way of checking this than inspecting
mRedirectedFrom member of $wgArticle.

Additional background is Google reports an error in Search Console when
you have a page A hreflang-linking to page B, which doesn't link back to
page A.

This is the case if you have a page C that's a MediaWiki redirect to
page A. That page has a hreflang link to B, but B links back to A.

The solution is the page C should not have the hreflang link emitted.
