### PR TITLE
Separate phpunit reports

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -49,7 +49,6 @@ phpunit-externals: prepare
 # runs tests for externally used parts
 phpunit-contractual-responsibilities: prepare
 	${CMD_PHPUNIT} \
-	externals
 		--log-junit=${LOGS_PATH}/phpunit-contractual-responsibilities.xml \
 		--group ContractualResponsibilitiesValidation
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,8 +1,10 @@
 # Wikia's Makefile for executing unit tests
 
+# path to logs folder
+LOGS_PATH=junit=build/logs
+
 # command to run PHPUnit
 CMD_PHPUNIT=php run-test.php \
-	--log-junit=build/logs/phpunit.xml \
 	--configuration=phpunit.xml
 
 # command to run karma
@@ -29,43 +31,52 @@ prepare:
 # runs unit tests
 phpunit: prepare
 	${CMD_PHPUNIT} \
+		--log-junit=${LOGS_PATH}/phpunit-unit.xml \
 		--exclude-group Infrastructure,Integration,Broken,Stub,Monitoring,Hack,ExternalIntegration,ContractualResponsibilitiesValidation
 
 # runs integration tests only
 phpunit-infrastructure: prepare
 	${CMD_PHPUNIT} \
+		--log-junit=${LOGS_PATH}/phpunit-infrastructure.xml \
 		--group Infrastructure,Integration
 
 # runs external partners api integration tests only
 phpunit-externals: prepare
 	${CMD_PHPUNIT} \
+		--log-junit=${LOGS_PATH}/phpunit-externals.xml \
 		--group ExternalIntegration
 
 # runs tests for externally used parts
 phpunit-contractual-responsibilities: prepare
 	${CMD_PHPUNIT} \
+	externals
+		--log-junit=${LOGS_PATH}/phpunit-contractual-responsibilities.xml \
 		--group ContractualResponsibilitiesValidation
 
 # runs all (i.e. both unit and integration) tests from a given directory or a file
 phpunit-single: prepare
 	${CMD_PHPUNIT} \
+		--log-junit=${LOGS_PATH}/phpunit-single.xml \
 		--exclude-group Broken \
 		${test}
 
 # runs fast unit tests only
 phpunit-fast: prepare
 	${CMD_PHPUNIT} \
+		--log-junit=${LOGS_PATH}/phpunit-fast.xml \
 		--exclude-group Slow,Infrastructure,Integration,Broken,Stub,Monitoring,Hack,UsingDB,ExternalIntegration
 
 # lists all slow test cases with execution time
 phpunit-slow-list: prepare
 	${CMD_PHPUNIT} \
+		--log-junit=${LOGS_PATH}/phpunit-slow.xml \
 		--exclude-group=Infrastructure,Integration,Broken,Stub,Monitoring,Hack \
 		--slow-list
 
 # run tests for a specific group
 phpunit-group: prepare
 	${CMD_PHPUNIT} \
+		--log-junit=${LOGS_PATH}/phpunit-group.xml \
 		--group $(GROUP)
 
 #
@@ -91,6 +102,7 @@ phpunit-coverage: prepare
 	mkdir -p build/coverage
 
 	${CMD_PHPUNIT} ${test} \
+		--log-junit=${LOGS_PATH}/phpunit-coverage.xml \
 		--exclude-group Broken \
 		--coverage-html build/coverage \
 		--coverage-clover build/coverage.xml

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,7 +1,7 @@
 # Wikia's Makefile for executing unit tests
 
 # path to logs folder
-LOGS_PATH=junit=build/logs
+LOGS_PATH=build/logs
 
 # command to run PHPUnit
 CMD_PHPUNIT=php run-test.php \


### PR DESCRIPTION
Reports needs to be separated, cause when running two different tasks (like `phpunit` `phpunit-infrastructure`) report is being overwritten by the last task run

Review? @mixth-sense @macbre @wladekb 
