### PR TITLE
Update run-test.php to avoid notices

### DIFF
--- a/tests/run-test.php
+++ b/tests/run-test.php
@@ -6,9 +6,8 @@ ini_set('display_errors', 1);
 $wgNoDBUnits = false;
 
 $params = getopt('', ['exclude-group::', 'slow-list']);
-$excludeGroups = explode(',', $params['exclude-group']);
-if (is_array($excludeGroups)) {
-	foreach($excludeGroups as $group) {
+if (isset($params['exclude-group'])) {
+	foreach(explode(',', $params['exclude-group']) as $group) {
 		if (trim($group) == 'UsingDB') {
 			$wgNoDBUnits = true;
 		}


### PR DESCRIPTION
## Description

As part of work on https://wikia-inc.atlassian.net/browse/DAT-3693 I noticed that run-test.php throws 

```

Notice: Undefined index: exclude-group in /usr/wikia/source/app/tests/run-test.php on line 9

Call Stack:
    0.0001     235720   1. {main}() /usr/wikia/source/app/tests/run-test.php:0

```

on each run when exclude-group param is not provided. This PR fixes that annoyance.
## Reviewers

@ludwikkazmierczak @mixth-sense
