### PR TITLE
DAT-3693 Preparing JsonFormatTest for more descriptive logging

### DIFF
--- a/extensions/wikia/JsonFormat/tests/JsonFormatTest.php
+++ b/extensions/wikia/JsonFormat/tests/JsonFormatTest.php
@@ -118,7 +118,7 @@ class JsonFormatTest extends WikiaBaseTest {
 	protected function checkClassStructure( $data, $structure ) {
 		foreach ( $structure as $class => $params ) {
 			$classInfo = explode( ':', $class );
-			$this->assertInstanceOf( $classInfo[ 0 ], $data );
+			$this->assertInstanceOf( $classInfo[ 0 ], $data, sprintf('Instance check failed for %s', $class) );
 			$i = 0;
 			foreach ( $params as $keyOrClass => $element ) {
 				if ( is_numeric( $keyOrClass ) || !method_exists( $data, 'getChildren' ) ) {
@@ -143,10 +143,8 @@ class JsonFormatTest extends WikiaBaseTest {
 	protected function getParsedOutput( $wikitext ) {
 		return $this->memCacheDisabledSection( function () use ( $wikitext ) {
 			global $wgOut;
-			if ( !isset( $this->parser ) ) {
-				$this->parser = new Parser();
-			}
-			$htmlOutput = $this->parser->parse( $wikitext, new Title(), $wgOut->parserOptions() );
+			$parser = ParserPool::get();
+			$htmlOutput = $parser->parse( $wikitext, new Title(), $wgOut->parserOptions() );
 
 			//check for empty result
 			if ( !empty( $wikitext ) ) {


### PR DESCRIPTION
- added logging of class match failure
- removed local caching of parser object
- fetch parser from pool instad of invoking new Parser()
