### PR TITLE
SOC-2014 Allow for floating point unix timestamps

### DIFF
--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -2416,9 +2416,9 @@ function wfTimestamp( $outputtype = TS_UNIX, $ts = 0 ) {
 		# TS_EXIF
 	} elseif ( preg_match( '/^(\d{4})(\d\d)(\d\d)(\d\d)(\d\d)(\d\d)$/D', $ts, $da ) ) {
 		# TS_MW
-	} elseif ( preg_match( '/^-?\d{1,13}$/D', $ts ) ) {
+	} elseif ( preg_match( '/^-?\d{1,13}(\.\d+)?$/D', $ts ) ) {
 		# TS_UNIX
-		$uts = $ts;
+		$uts = (int) $ts;
 		$strtime = "@$ts"; // http://php.net/manual/en/datetime.formats.compound.php
 	} elseif ( preg_match( '/^\d{2}-\d{2}-\d{4} \d{2}:\d{2}:\d{2}.\d{6}$/', $ts ) ) {
 		# TS_ORACLE // session altered to DD-MM-YYYY HH24:MI:SS.FF6


### PR DESCRIPTION
Apparently when we upgraded from MySQL 5.5 to 5.7 something changed with the unix_timestamp function.  It now _may_ return a floating point timestamp.  Here are two queries that differ only by an "ORDER BY rev_timestamp" that give different results:

``` sql
mysql> SELECT page_id,page_title,unix_timestamp(rev_timestamp) as timestamp,rev_timestamp FROM page, revision WHERE rev_page = page_id AND page_id in (441819, 432376) GROUP BY page_id;
+---------+--------------------------------+------------+----------------+
| page_id | page_title                     | timestamp  | rev_timestamp  |
+---------+--------------------------------+------------+----------------+
|  432376 | Sannse/Don't_Feed_the_Trolls   | 1347381202 | 20120911163322 |
|  441819 | Sannse/Blocking_Best_Practices | 1349727642 | 20121008202042 |
+---------+--------------------------------+------------+----------------+
2 rows in set (0.00 sec)
```

``` sql
mysql> SELECT page_id,page_title,unix_timestamp(rev_timestamp) as timestamp,rev_timestamp FROM page, revision WHERE rev_page = page_id AND page_id in (441819, 432376) GROUP BY page_id ORDER BY rev_timestamp;
+---------+--------------------------------+-------------------+----------------+
| page_id | page_title                     | timestamp         | rev_timestamp  |
+---------+--------------------------------+-------------------+----------------+
|  432376 | Sannse/Don't_Feed_the_Trolls   | 1347381202.000000 | 20120911163322 |
|  441819 | Sannse/Blocking_Best_Practices | 1349727642.000000 | 20121008202042 |
+---------+--------------------------------+-------------------+----------------+
2 rows in set (0.00 sec)
```

Regardless, lets start accepting floating point timestamps here so that we can continue to parse these into dates.

Jira issue: https://wikia-inc.atlassian.net/browse/SOC-2014
