### PR TITLE
DAT-3693 Update JsonFormat tests

### DIFF
--- a/extensions/wikia/JsonFormat/HtmlParser.php
+++ b/extensions/wikia/JsonFormat/HtmlParser.php
@@ -34,10 +34,11 @@ class HtmlParser {
 		$time = Time::start([__CLASS__, __METHOD__]);
 		$doc = new \DOMDocument();
 
-		libxml_use_internal_errors(true);
+		$libxmlErrorSetting = libxml_use_internal_errors(true);
 		$html = preg_replace("/\s+/", " ", $html);
 		$doc->loadHTML("<?xml encoding=\"UTF-8\">\n<html><body>" . $html . "</body></html>");
 		libxml_clear_errors();
+		libxml_use_internal_errors($libxmlErrorSetting);
 		$body = $doc->getElementsByTagName('body')->item(0);
 
 		$jsonFormatTraversingState = new \JsonFormatBuilder();

--- a/extensions/wikia/JsonFormat/tests/JsonFormatTest.php
+++ b/extensions/wikia/JsonFormat/tests/JsonFormatTest.php
@@ -149,6 +149,12 @@ class JsonFormatTest extends WikiaBaseTest {
 			//check for empty result
 			if ( !empty( $wikitext ) ) {
 				$this->assertNotEmpty( $htmlOutput->getText(), 'Provided WikiText could not be parsed.' );
+				\Wikia\Logger\WikiaLogger::instance()->info(
+					'JsonFormatTest::getParsedOutput', [
+						'wikitext' => $wikitext,
+						'html_output' => $htmlOutput->getText()
+					]
+				);
 			}
 
 			$htmlParser = new \Wikia\JsonFormat\HtmlParser();
@@ -492,6 +498,20 @@ width: 310px; padding: 10px; text-align: left; float: right; margin-bottom:15px;
 						],
 						'JsonFormatTextNode' => [ ],
 						'JsonFormatImageFigureNode' => [ 'src', 'caption' ]
+					]
+				]
+			],
+			[
+				'',
+				[
+					'JsonFormatRootNode' => []
+				]
+			],
+			[
+				'=h1=',
+				[
+					'JsonFormatRootNode' => [
+						'JsonFormatSectionNode' => [ 'level', 'title' ]
 					]
 				]
 			]

--- a/extensions/wikia/JsonFormat/tests/JsonFormatTest.php
+++ b/extensions/wikia/JsonFormat/tests/JsonFormatTest.php
@@ -429,6 +429,71 @@ anything here -->
 				  ]
 			  ]
 			  ]
+			],
+			[ '
+{| class="infobox" style="clear: right; border: solid #aaa 1px; margin: 0 0 1em 1em; background: #f9f9f9; color:black;
+width: 310px; padding: 10px; text-align: left; float: right; margin-bottom:15px;"
+|- class="hiddenStructure"
+| valign=top nowrap=nowrap | \'\'\'Written by\'\'\'&nbsp; || Lorem
+|- class="hiddenStructure"
+| valign=top | \'\'\'Illustrator\'\'\'&nbsp; || Ipsum
+|- class="hiddenStructure"
+| valign=top |\'\'\'Published\'\'\'&nbsp; || Kra
+|- class="hiddenStructure"
+| valign=top |\'\'\'Publisher\'\'\'&nbsp; || Kre
+|- class="hiddenStructure"
+| valign=top | \'\'\'Series\'\'\'&nbsp; || Mija
+|- class="hiddenStructure"
+| valign=top | \'\'\'ISBN\'\'\'&nbsp; || Lis
+|}
+',
+				[
+					'JsonFormatRootNode' => [
+						'JsonFormatInfoboxNode' => [
+							'JsonFormatInfoboxKeyValueNode' => [
+								'key', 'value'
+							],
+							'JsonFormatInfoboxKeyValueNode:1' => [
+								'key', 'value'
+							],
+							'JsonFormatInfoboxKeyValueNode:2' => [
+								'key', 'value'
+							],
+							'JsonFormatInfoboxKeyValueNode:3' => [
+								'key', 'value'
+							],
+							'JsonFormatInfoboxKeyValueNode:4' => [
+								'key', 'value'
+							],
+							'JsonFormatInfoboxKeyValueNode:5' => [
+								'key', 'value'
+							]
+						]
+					]
+				]
+			],
+			[
+				'Text',
+				[
+					'JsonFormatRootNode' => [
+						'JsonFormatParagraphNode' => [
+							'JsonFormatTextNode' => [ ]
+						],
+					]
+				]
+			],
+			[
+				'[[Image:Firefly_logo.png]]
+[[File:Firefly_logo.png|thumb|200px|adsfadsfasd]]',
+				[
+					'JsonFormatRootNode' => [
+						'JsonFormatParagraphNode' => [
+							'JsonFormatImageNode' => [ 'src' ],
+						],
+						'JsonFormatTextNode' => [ ],
+						'JsonFormatImageFigureNode' => [ 'src', 'caption' ]
+					]
+				]
 			]
 		];
 	}

--- a/extensions/wikia/JsonFormat/tests/JsonFormatTest.php
+++ b/extensions/wikia/JsonFormat/tests/JsonFormatTest.php
@@ -142,13 +142,16 @@ class JsonFormatTest extends WikiaBaseTest {
 
 	protected function getParsedOutput( $wikitext ) {
 		return $this->memCacheDisabledSection( function () use ( $wikitext ) {
-			global $wgOut;
+			global $wgOut, $wgWikiaEnvironment;
 			$parser = ParserPool::get();
 			$htmlOutput = $parser->parse( $wikitext, new Title(), $wgOut->parserOptions() );
 
 			//check for empty result
 			if ( !empty( $wikitext ) ) {
 				$this->assertNotEmpty( $htmlOutput->getText(), 'Provided WikiText could not be parsed.' );
+				if( $wgWikiaEnvironment == WIKIA_ENV_DEV ) {
+					\Wikia\Logger\WikiaLogger::instance()->setDevModeWithES();
+				}
 				\Wikia\Logger\WikiaLogger::instance()->info(
 					'JsonFormatTest::getParsedOutput', [
 						'wikitext' => $wikitext,


### PR DESCRIPTION
## LINKS
- https://wikia-inc.atlassian.net/browse/DAT-3693
- https://kibana.wikia-inc.com/#/dashboard/elasticsearch/DAT-3693
## DESCRIPTION
- added logging to validate if issue is MediaWiki - parser based or JsonFormat - parser based
- added a few more granular tests cases
- restoring of libxml error reporting settings added
