### PR TITLE
(CE-3282) Get time IDs starting from last week's Sunday

### DIFF
--- a/extensions/wikia/InsightsV2/helpers/InsightsPageViews.php
+++ b/extensions/wikia/InsightsV2/helpers/InsightsPageViews.php
@@ -98,7 +98,7 @@ class InsightsPageViews {
 		$lastTimeId = ( new DateTime() )->modify( 'last Sunday' );
 		$format = 'Y-m-d H:i:s';
 		return [
-			$lastTimeId->format( $format ),
+			$lastTimeId->modify( '-1 week' )->format( $format ),
 			$lastTimeId->modify( '-1 week' )->format( $format ),
 			$lastTimeId->modify( '-1 week' )->format( $format ),
 			$lastTimeId->modify( '-1 week' )->format( $format ),


### PR DESCRIPTION
Get time IDs starting from last week's Sunday rather than the Sunday
of the current week so that we have page view data for four complete
weeks.

/cc @Wikia/community-engineering 
