### PR TITLE
SEO-50 Admin dashboard title

### DIFF
--- a/extensions/wikia/AdminDashboard/AdminDashboard.setup.php
+++ b/extensions/wikia/AdminDashboard/AdminDashboard.setup.php
@@ -21,7 +21,9 @@ $wgAutoloadClasses['AdminDashboardController'] =  $dir . 'AdminDashboardControll
 $wgAutoloadClasses['AdminDashboardLogic'] =  $dir . 'AdminDashboardLogic.class.php';
 $wgAutoloadClasses['QuickStatsController'] =  $dir . 'QuickStatsController.class.php';
 
+// hooks
 $wgHooks['BeforeToolbarMenu'][] = 'AdminDashboardLogic::onBeforeToolbarMenu';
+$wgHooks['WikiaHtmlTitleExtraParts'][] = 'AdminDashboardLogic::onWikiaHtmlTitleExtraParts';
 
 // i18n mapping
 $wgExtensionMessagesFiles['AdminDashboard'] = $dir . 'AdminDashboard.i18n.php';

--- a/extensions/wikia/AdminDashboard/AdminDashboardLogic.class.php
+++ b/extensions/wikia/AdminDashboard/AdminDashboardLogic.class.php
@@ -139,4 +139,21 @@ class AdminDashboardLogic {
 		}
 		return true;
 	}
+
+	/**
+	 * For the special pages grouped in admin dashboard, update the HTML title, so it says:
+	 * "Name of the special page - Admin Dashboard - Wiki name - Wikia"
+	 *
+	 * This hook adds the "Admin Dashboard" part.
+	 *
+	 * @param Title $title
+	 * @param array $extraParts
+	 * @return bool
+	 */
+	static function onWikiaHtmlTitleExtraParts( Title $title, array &$extraParts ) {
+		if ( self::displayAdminDashboard( F::app(), $title ) ) {
+			$extraParts = [ wfMessage( 'admindashboard-header' ) ];
+		}
+		return true;
+	}
 }

--- a/extensions/wikia/AdminDashboard/AdminDashboardSpecialPageController.class.php
+++ b/extensions/wikia/AdminDashboard/AdminDashboardSpecialPageController.class.php
@@ -17,7 +17,7 @@ class AdminDashboardSpecialPageController extends WikiaSpecialPageController {
 	 *
 	 */
 	public function index() {
-		$this->wg->Out->setPageTitle(wfMsg('admindashboard-title'));
+		$this->wg->Out->setPageTitle( [ wfMsg( 'admindashboard-header' ) ] );
 		if (!$this->wg->User->isAllowed( 'admindashboard' )) {
 			$this->displayRestrictionError();
 			return false;  // skip rendering

--- a/includes/OutputPage.php
+++ b/includes/OutputPage.php
@@ -831,11 +831,10 @@ class OutputPage extends ContextSource {
 	public function setHTMLTitle( $name ) {
 		/* Wikia change - begin */
 		if ( is_array( $name ) ) {
-			$parts = $name;
+			$this->mHTMLtitle = ( new WikiaHtmlTitle() )->setParts( $name )->getTitle();
 		} else {
-			$parts = [ $name ];
+			$this->mHTMLtitle = ( new WikiaHtmlTitle() )->generateTitle( $this, $name )->getTitle();
 		}
-		$this->mHTMLtitle = ( new WikiaHtmlTitle() )->setParts( $parts )->getTitle();
 		/* Wikia change - end */
 	}
 

--- a/includes/OutputPage.php
+++ b/includes/OutputPage.php
@@ -833,7 +833,7 @@ class OutputPage extends ContextSource {
 		if ( is_array( $name ) ) {
 			$this->mHTMLtitle = ( new WikiaHtmlTitle() )->setParts( $name )->getTitle();
 		} else {
-			$this->mHTMLtitle = ( new WikiaHtmlTitle() )->generateTitle( $this, $name )->getTitle();
+			$this->mHTMLtitle = ( new WikiaHtmlTitle() )->generateTitle( $this->getTitle(), $name )->getTitle();
 		}
 		/* Wikia change - end */
 	}

--- a/includes/wikia/WikiaHtmlTitle.class.php
+++ b/includes/wikia/WikiaHtmlTitle.class.php
@@ -117,26 +117,20 @@ class WikiaHtmlTitle {
 	 * Later we should add structure for images, videos, categories, blogs, etc.
 	 * Then this method should be promoted to a separate class with a set of tests.
 	 *
-	 * @param OutputPage $out
+	 * @param Title $title
 	 * @param string $name
 	 * @return WikiaHtmlTitle
 	 */
-	public function generateTitle( $out, $name ) {
-		global $wgEnableAdminDashboardExt;
-
-		$title = $out->getTitle();
-
+	public function generateTitle( $title, $name ) {
 		if ( !$title ) {
 			return $this->setParts( [ $name ] );
 		}
 
-		// Extra title for admin dashboard
-		if ( !empty( $wgEnableAdminDashboardExt ) ) {
-			if ( AdminDashboardLogic::displayAdminDashboard( F::app(), $title ) ) {
-				return $this->setParts( [ $name, wfMessage( 'admindashboard-header' ) ] );
-			}
-		}
+		// Extra title for admin dashboard (and maybe other pages handled by extensions)
+		$parts = [];
+		wfRunHooks( 'WikiaHtmlTitleExtraParts', [ $title, &$parts ] );
+		array_unshift( $parts, $name );
 
-		return $this->setParts( [ $name ] );
+		return $this->setParts( $parts );
 	}
 }

--- a/includes/wikia/WikiaHtmlTitle.class.php
+++ b/includes/wikia/WikiaHtmlTitle.class.php
@@ -109,4 +109,34 @@ class WikiaHtmlTitle {
 	public function getTitle() {
 		return join( $this->getSeparator(), $this->getAllParts() );
 	}
+
+	/**
+	 * Set HTML title based on the information passed from OutputPage
+	 *
+	 * This adds the HTML title structure for special pages.
+	 * Later we should add structure for images, videos, categories, blogs, etc.
+	 * Then this method should be promoted to a separate class with a set of tests.
+	 *
+	 * @param OutputPage $out
+	 * @param string $name
+	 * @return WikiaHtmlTitle
+	 */
+	public function generateTitle( $out, $name ) {
+		global $wgEnableAdminDashboardExt;
+
+		$title = $out->getTitle();
+
+		if ( !$title ) {
+			return $this->setParts( [ $name ] );
+		}
+
+		// Extra title for admin dashboard
+		if ( !empty( $wgEnableAdminDashboardExt ) ) {
+			if ( AdminDashboardLogic::displayAdminDashboard( F::app(), $title ) ) {
+				return $this->setParts( [ $name, wfMessage( 'admindashboard-header' ) ] );
+			}
+		}
+
+		return $this->setParts( [ $name ] );
+	}
 }


### PR DESCRIPTION
OutputPage::setHTMLTitle now calls WikiaHtmlTitle::generateTitle().

It sets HTML title based on the information passed from OutputPage,
adding the HTML title structure for admin dashboard.

Later we should expand this method, to add structure for images,
videos, categories, blogs, etc.

At that point, the method should be promoted to a separate class
with a set of tests.
