### PR TITLE
PLATFORM-1914: update querycache schema for new wikis

### DIFF
--- a/maintenance/tables.sql
+++ b/maintenance/tables.sql
@@ -1146,8 +1146,9 @@ CREATE TABLE /*_*/querycache (
   qc_title varchar(255) binary NOT NULL default ''
 ) /*$wgDBTableOptions*/;
 
-CREATE INDEX /*i*/qc_type ON /*_*/querycache (qc_type,qc_value);
+-- CREATE INDEX /*i*/qc_type ON /*_*/querycache (qc_type,qc_value); // PLATFORM-1914
 
+CREATE UNIQUE INDEX /*i*/qc_type_value_ns_title ON /*_*/querycache (qc_type,qc_value,qc_namespace,qc_title);
 
 --
 -- For a few generic cache operations if not using Memcached


### PR DESCRIPTION
[PLATFORM-1914](https://wikia-inc.atlassian.net/browse/PLATFORM-1914)

Due to a [MySQL 5.6 bug](https://bugs.mysql.com/bug.php?id=76252) InnoDB tables that do not have primary key defined has problems with replication of heavy transactions (with tens of thousands of rows involved).

We noticed this behavior during `updateSpecialPages.php` script run which performs heavy (DELETE + INSERT queries) operations on `querycache` table. This was quite visible when `ruvlab` wiki was processed - the maintenance script was performing a transaction with delete and insert of 75k rows causing huge lag on c1 cluster.

`querycache` table indeed lacks a primary key, so let's add it for new wikis.

Before:

```
CREATE TABLE `querycache` (
  `qc_type` varbinary(32) NOT NULL,
  `qc_value` int(10) unsigned NOT NULL DEFAULT '0',
  `qc_namespace` int(11) NOT NULL DEFAULT '0',
  `qc_title` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
  KEY `qc_type` (`qc_type`,`qc_value`)
) ENGINE=InnoDB DEFAULT CHARSET=latin1

+--------------+------------------+------+-----+---------+-------+
| Field        | Type             | Null | Key | Default | Extra |
+--------------+------------------+------+-----+---------+-------+
| qc_type      | varbinary(32)    | NO   | MUL | NULL    |       |
| qc_value     | int(10) unsigned | NO   |     | 0       |       |
| qc_namespace | int(11)          | NO   |     | 0       |       |
| qc_title     | varchar(255)     | NO   |     |         |       |
+--------------+------------------+------+-----+---------+-------+
```

After:

```
CREATE TABLE `querycache` (
  `qc_type` varbinary(32) NOT NULL,
  `qc_value` int(10) unsigned NOT NULL DEFAULT '0',
  `qc_namespace` int(11) NOT NULL DEFAULT '0',
  `qc_title` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
  UNIQUE KEY `qc_type_value_ns_title` (`qc_type`,`qc_value`,`qc_namespace`,`qc_title`)
) ENGINE=InnoDB DEFAULT CHARSET=latin1

+--------------+------------------+------+-----+---------+-------+
| Field        | Type             | Null | Key | Default | Extra |
+--------------+------------------+------+-----+---------+-------+
| qc_type      | varbinary(32)    | NO   | PRI | NULL    |       |
| qc_value     | int(10) unsigned | NO   | PRI | 0       |       |
| qc_namespace | int(11)          | NO   | PRI | 0       |       |
| qc_title     | varchar(255)     | NO   | PRI |         |       |
+--------------+------------------+------+-----+---------+-------+
```

@drozdo / @wladekb / @adamkarminski 
