### PR TITLE
SEO-202 Cache Special:Images and expose it to robots

### DIFF
--- a/extensions/wikia/WikiaNewFiles/WikiaNewFilesSpecialController.class.php
+++ b/extensions/wikia/WikiaNewFiles/WikiaNewFilesSpecialController.class.php
@@ -12,8 +12,25 @@ class WikiaNewFilesSpecialController extends WikiaSpecialPageController {
 		parent::__construct( 'Images', '', false );
 	}
 
+	/**
+	 * If $wgAllowSpecialImagesInRobots is set, make the page discoverable by robots and cached.
+	 * If not set, the regular policy applies: page is not cached and disallowed for robots.
+	 * Logged in users should see the page non-cached.
+	 */
+	private function setupCachingAndRobots() {
+		global $wgAllowSpecialImagesInRobots, $wgUser;
+
+		if ( $wgAllowSpecialImagesInRobots ) {
+			if ( $wgUser && !$wgUser->isLoggedIn() ) {
+				$this->getContext()->getOutput()->setRobotPolicy( 'index,follow' );
+				$this->setVarnishCacheTime( WikiaResponse::CACHE_VERY_SHORT );
+			}
+		}
+	}
+
 	public function index() {
 		$this->setHeaders();
+		$this->setupCachingAndRobots();
 
 		$output = $this->getContext()->getOutput();
 		$request = $this->getRequest();

--- a/extensions/wikia/WikiaNewFiles/WikiaNewFilesSpecialController.class.php
+++ b/extensions/wikia/WikiaNewFiles/WikiaNewFilesSpecialController.class.php
@@ -20,8 +20,8 @@ class WikiaNewFilesSpecialController extends WikiaSpecialPageController {
 	private function setupCachingAndRobots() {
 		global $wgAllowSpecialImagesInRobots, $wgUser;
 
-		if ( $wgAllowSpecialImagesInRobots ) {
-			if ( $wgUser && !$wgUser->isLoggedIn() ) {
+		if ( !empty( $wgAllowSpecialImagesInRobots ) ) {
+			if ( !empty( $wgUser ) && !$wgUser->isLoggedIn() ) {
 				$this->getContext()->getOutput()->setRobotPolicy( 'index,follow' );
 				$this->setVarnishCacheTime( WikiaResponse::CACHE_VERY_SHORT );
 			}

--- a/wikia-robots-txt.php
+++ b/wikia-robots-txt.php
@@ -42,6 +42,10 @@ if ( !$allowRobots ) {
 	$robots->allowSpecialPage( 'Sitemap' );
 	$robots->allowSpecialPage( 'Videos' );
 
+	if ( !empty( $wgAllowSpecialImagesInRobots ) ) {
+		$robots->allowSpecialPage( 'Images' );
+	}
+
 	// Params
 	$robots->disallowParam( 'action' );
 	$robots->disallowParam( 'feed' );


### PR DESCRIPTION
For a fraction of our wikis (1/10) we want Special:Images exposed to
robots. To avoid a potential performance drop, we're also enabling
caching on those pages (5 minutes TTL). The caching is only enabled for
anonymous users (including bots), so the logged in users should be
unaffected.
