### PR TITLE
SUS-254 P2 Fix Notifications Loading

### DIFF
--- a/extensions/wikia/GlobalNavigation/scripts/GlobalNavigationNotifications.js
+++ b/extensions/wikia/GlobalNavigation/scripts/GlobalNavigationNotifications.js
@@ -114,7 +114,7 @@ require(
 					var wikiEl = this.$wallNotifications.find('.notifications-for-wiki').first(),
 						firstWikiId = parseInt(wikiEl.data('wiki-id'), 10);
 
-					if (firstWikiId !== undefined) {
+					if ( !isNaN(firstWikiId) ) {
 						wikiEl.addClass('show');
 						this.fetchedCurrent = true;
 						this.currentWikiId = firstWikiId;
@@ -141,7 +141,6 @@ require(
 					method: 'markAllAsRead',
 					format: 'json',
 					data: {
-						username: window.wgTitle,
 						forceAll: forceAll
 					},
 					callback: this.proxy(function (data) {
@@ -174,7 +173,7 @@ require(
 				var wikiEl = this.$wallNotifications.find('.notifications-for-wiki').first(),
 					firstWikiId = parseInt(wikiEl.data('wiki-id'), 10);
 
-				if (firstWikiId !== undefined) {
+				if ( !isNaN(firstWikiId) ) {
 					wikiEl.addClass('show');
 					this.wikiShown = {};
 					this.wikiShown[firstWikiId] = true;
@@ -243,7 +242,6 @@ require(
 			updateWikiFetch: function (wikiId) {
 				var isCrossWiki = (wikiId === this.cityId) ? '0' : '1',
 					data = {
-						username: window.wgTitle,
 						wikiId: wikiId,
 						isCrossWiki: isCrossWiki
 					};

--- a/extensions/wikia/WallNotifications/scripts/WallNotifications.js
+++ b/extensions/wikia/WallNotifications/scripts/WallNotifications.js
@@ -135,9 +135,9 @@ var WallNotifications = $.createClass(Object, {
 		this.bucky.timer.start('fetchForCurrentWiki');
 		if ( this.fetchedCurrent == false ) {
 			var wikiEl = ( this.isMonobook ? $('#wall-notifications-inner') : this.$wallNotifications ).find('.notifications-for-wiki').first(),
-				firstWikiId = wikiEl.attr('data-wiki-id');
+				firstWikiId = parseInt(wikiEl.attr('data-wiki-id'));
 
-			if ( firstWikiId != undefined ) {
+			if ( !isNaN(firstWikiId) ) {
 				wikiEl.addClass('show');
 				this.fetchedCurrent = true;
 				this.currentWikiId = firstWikiId;
@@ -181,7 +181,6 @@ var WallNotifications = $.createClass(Object, {
 			method: 'markAllAsRead',
 			format: 'json',
 			data: {
-				username: wgTitle,
 				forceAll: forceAll
 			},
 			callback: this.proxy(function(data) {
@@ -228,9 +227,9 @@ var WallNotifications = $.createClass(Object, {
 
 	showFirst: function() {
 		var wikiEl = ( this.isMonobook ? $('#wall-notifications-inner') : this.$wallNotifications ).find('.notifications-for-wiki').first(),
-			firstWikiId = wikiEl.attr('data-wiki-id');
+			firstWikiId = parseInt(wikiEl.attr('data-wiki-id'));
 
-		if ( firstWikiId != undefined ) {
+		if ( !isNaN(firstWikiId) ) {
 			wikiEl.addClass('show');
 			this.wikiShown = {};
 			this.wikiShown[ firstWikiId ] = true;
@@ -263,11 +262,11 @@ var WallNotifications = $.createClass(Object, {
 		var wikiEl = $(e.target).closest('.notifications-for-wiki');
 		if(wikiEl.hasClass('show') ) {
 			wikiEl.removeClass('show');
-			var wikiId = wikiEl.attr('data-wiki-id');
+			var wikiId = parseInt(wikiEl.attr('data-wiki-id'));
 			delete this.wikiShown[ wikiId ];
 		} else {
 			wikiEl.addClass('show');
-			var wikiId = wikiEl.attr('data-wiki-id');
+			var wikiId = parseInt(wikiEl.attr('data-wiki-id'));
 			this.wikiShown[ wikiId ] = true;
 			this.updateWiki(wikiId);
 		}
@@ -299,7 +298,6 @@ var WallNotifications = $.createClass(Object, {
 	updateWikiFetch: function(wikiId) {
 		var isCrossWiki = (wikiId == wgCityId) ? '0' : '1',
 			data = {
-				username: wgTitle,
 				wikiId: wikiId,
 				isCrossWiki: isCrossWiki
 			};


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-254

parseInt returns NaN on failure, which is what we should be testing for (not undefined).  seems like there are cases when checking notifications on external/foreign wikis that this value is not set so it sends NaN to the server. 

also removed username= param which is unused by the controller.

@mixth-sense @Wikia/sustaining-team 
