### PR TITLE
SEO-283 Remove XML Sitemaps from www.wikia.com and hubs

### DIFF
--- a/wikia-robots-txt.php
+++ b/wikia-robots-txt.php
@@ -23,13 +23,17 @@ if ( !$allowRobots ) {
 	$robots->disallowPath( '/' );
 } elseif ( $experimentalRobots ) {
 	// Sitemap
-	$robots->setSitemap( sprintf( 'http://%s/sitemap-index.xml', $_SERVER['SERVER_NAME'] ) );
+	if ( !empty( $wgEnableSpecialSitemapExt ) ) {
+		$robots->setSitemap( sprintf( 'http://%s/sitemap-index.xml', $_SERVER['SERVER_NAME'] ) );
+	}
 
 	// Experimental content
 	$robots->setExperimentalAllowDisallowSection( $experimentalRobots );
 } else {
 	// Sitemap
-	$robots->setSitemap( sprintf( 'http://%s/sitemap-index.xml', $_SERVER['SERVER_NAME'] ) );
+	if ( !empty( $wgEnableSpecialSitemapExt ) ) {
+		$robots->setSitemap( sprintf( 'http://%s/sitemap-index.xml', $_SERVER['SERVER_NAME'] ) );
+	}
 
 	// Special pages
 	$robots->disallowNamespace( NS_SPECIAL );


### PR DESCRIPTION
When $wgEnableSpecialSitemapExt is false, there no point in robots.txt
pointing robots to the /sitemap-index.xml, because it's gonna serve 404
saying no such special page.

Robots.txt now check the variable and only include the Sitemap rule if
the extension serving the sitemap is enabled.
