### PR TITLE
Merge pull request #9862 from Wikia/DAT-3877

### DIFF
--- a/extensions/wikia/PortableInfobox/styles/PortableInfoboxMixins.scss
+++ b/extensions/wikia/PortableInfobox/styles/PortableInfoboxMixins.scss
@@ -60,7 +60,7 @@
 
 	.pi-data-label {
 		@include flex-basis($infobox-width / 3);
-		max-width: $infobox-width / 3 - $padding;
+		overflow: hidden;
 		word-wrap: break-word;
 	}
 


### PR DESCRIPTION
DAT-3877 do not use max-width in infobox label styles
