### PR TITLE
SEO-256 Local HTML Sitemap MVP

### DIFF
--- a/extensions/wikia/GlobalFooter/GlobalFooterController.class.php
+++ b/extensions/wikia/GlobalFooter/GlobalFooterController.class.php
@@ -105,21 +105,12 @@ class GlobalFooterController extends WikiaController {
 	private function generateSitemapLinks() {
 		$sitemapLinks = [];
 
-		$useGlobalSitemap = true;
-		$useLocalSitemap = $this->wg->UseSpecialAllpagesAsLocalSitemap;
+		$sitemapLinks[] = parseItem(
+			'*' . self::SITEMAP_GLOBAL . '|' . wfMessage( 'global-footer-global-sitemap' )->escaped()
+		);
 
-		// Don't link to local sitemap on corporate sites and community.wikia.com
-		if ( WikiaPageType::isCorporatePage() || $this->wg->CityId === COMMUNITY_CENTRAL_CITY_ID ) {
-			$useLocalSitemap = false;
-		}
-
-		if ( $useGlobalSitemap ) {
-			$sitemapLinks[] = parseItem(
-				'*' . self::SITEMAP_GLOBAL . '|' . wfMessage( 'global-footer-global-sitemap' )->escaped()
-			);
-		}
-
-		if ( $useLocalSitemap ) {
+		// Don't link to local sitemap on corporate sites and community.wikia.com (controlled via WikiFactory)
+		if ( $this->wg->EnableLocalSitemap ) {
 			$sitemapLinks[] = parseItem(
 				'*' . self::SITEMAP_LOCAL . '|' . wfMessage( 'global-footer-local-sitemap' )->escaped()
 			);

--- a/extensions/wikia/GlobalFooter/GlobalFooterController.class.php
+++ b/extensions/wikia/GlobalFooter/GlobalFooterController.class.php
@@ -105,19 +105,13 @@ class GlobalFooterController extends WikiaController {
 	private function generateSitemapLinks() {
 		$sitemapLinks = [];
 
-// SEO-84 Exploring the possibility of sitemap links update (SEO-6) breaking the SEO:
 		$useGlobalSitemap = true;
-		$useLocalSitemap = false;
+		$useLocalSitemap = $this->wg->UseSpecialAllpagesAsLocalSitemap;
 
-// Regular behaviour:
-//		if ( WikiaPageType::isCorporatePage() || $this->wg->CityId === COMMUNITY_CENTRAL_CITY_ID ) {
-//			$useGlobalSitemap = true;
-//		} elseif ( WikiaPageType::isMainPage() ) {
-//			$useGlobalSitemap = true;
-//			$useLocalSitemap = true;
-//		} else {
-//			$useLocalSitemap = true;
-//		}
+		// Don't link to local sitemap on corporate sites and community.wikia.com
+		if ( WikiaPageType::isCorporatePage() || $this->wg->CityId === COMMUNITY_CENTRAL_CITY_ID ) {
+			$useLocalSitemap = false;
+		}
 
 		if ( $useGlobalSitemap ) {
 			$sitemapLinks[] = parseItem(

--- a/includes/specials/SpecialAllpages.php
+++ b/includes/specials/SpecialAllpages.php
@@ -67,8 +67,8 @@ class SpecialAllpages extends IncludableSpecialPage {
 		/* Wikia change begin - @author: rychu */
 		// SEO-6: Remove the nofollow attribute from Special:AllPages
 		// SEO-256: Use Special:Allpages as local sitemaps
-		global $wgUseSpecialAllpagesAsLocalSitemap;
-		if ( !empty( $wgUseSpecialAllpagesAsLocalSitemap ) ) {
+		global $wgEnableLocalSitemap;
+		if ( !empty( $wgEnableLocalSitemap ) ) {
 			$out->setRobotPolicy( 'noindex,follow' );
 		}
 		/* Wikia change end */
@@ -295,8 +295,8 @@ class SpecialAllpages extends IncludableSpecialPage {
 
 		/* Wikia change begin - @author: rychu */
 		// SEO-256: Use Special:Allpages as local sitemaps
-		global $wgUseSpecialAllpagesAsLocalSitemap;
-		if ( !empty( $wgUseSpecialAllpagesAsLocalSitemap ) ) {
+		global $wgEnableLocalSitemap;
+		if ( !empty( $wgEnableLocalSitemap ) ) {
 			$out = '<div><a href="' . $link . '"><span>';
 			$out .= $this->msg( 'alphaindexline' )->rawParams(
 				'</span>' . $inpointf . '<span>',

--- a/includes/specials/SpecialAllpages.php
+++ b/includes/specials/SpecialAllpages.php
@@ -66,7 +66,11 @@ class SpecialAllpages extends IncludableSpecialPage {
 
 		/* Wikia change begin - @author: rychu */
 		// SEO-6: Remove the nofollow attribute from Special:AllPages
-		$out->setRobotPolicy( 'noindex,follow' );
+		// SEO-256: Use Special:Allpages as local sitemaps
+		global $wgUseSpecialAllpagesAsLocalSitemap;
+		if ( !empty( $wgUseSpecialAllpagesAsLocalSitemap ) ) {
+			$out->setRobotPolicy( 'noindex,follow' );
+		}
 		/* Wikia change end */
 
 		$this->outputHeader();
@@ -289,6 +293,20 @@ class SpecialAllpages extends IncludableSpecialPage {
 		$special = $this->getTitle();
 		$link = htmlspecialchars( $special->getLocalUrl( $queryparams . 'from=' . urlencode($inpoint) . '&to=' . urlencode($outpoint) ) );
 
+		/* Wikia change begin - @author: rychu */
+		// SEO-256: Use Special:Allpages as local sitemaps
+		global $wgUseSpecialAllpagesAsLocalSitemap;
+		if ( !empty( $wgUseSpecialAllpagesAsLocalSitemap ) ) {
+			$out = '<div><a href="' . $link . '"><span>';
+			$out .= $this->msg( 'alphaindexline' )->rawParams(
+				'</span>' . $inpointf . '<span>',
+				'</span>' . $outpointf . '<span>'
+			)->escaped();
+			$out .= '</span></a></div>';
+			return $out;
+		}
+		/* Wikia change end */
+
 		$out = $this->msg( 'alphaindexline' )->rawParams(
 			"<a href=\"$link\">$inpointf</a></td><td>",
 			"</td><td><a href=\"$link\">$outpointf</a>"
@@ -431,7 +449,10 @@ class SpecialAllpages extends IncludableSpecialPage {
 				$prevLink = Linker::linkKnown(
 					$self,
 					$this->msg( 'prevpage', $pt )->escaped(),
-					array(),
+					/* Wikia change begin - @author: rychu */
+					// SEO-256: Use Special:Allpages as local sitemaps
+					array( 'rel' => 'nofollow' ),
+					/* Wikia change end */
 					$query
 				);
 				$out2 = $this->getLanguage()->pipeList( array( $out2, $prevLink ) );
@@ -448,7 +469,10 @@ class SpecialAllpages extends IncludableSpecialPage {
 				$nextLink = Linker::linkKnown(
 					$self,
 					$this->msg( 'nextpage', $t->getText() )->escaped(),
-					array(),
+					/* Wikia change begin - @author: rychu */
+					// SEO-256: Use Special:Allpages as local sitemaps
+					array( 'rel' => 'nofollow' ),
+					/* Wikia change end */
 					$query
 				);
 				$out2 = $this->getLanguage()->pipeList( array( $out2, $nextLink ) );

--- a/skins/oasis/css/core/body.scss
+++ b/skins/oasis/css/core/body.scss
@@ -75,3 +75,10 @@ a {
 	border-color: $color-page;
 	color: $color-text;
 }
+
+// Customization for Special:Allpages
+.mw-special-Allpages {
+	#mw-content-text a span {
+		color: $color-text;
+	}
+}

--- a/wikia-robots-txt.php
+++ b/wikia-robots-txt.php
@@ -40,7 +40,7 @@ if ( !$allowRobots ) {
 	$robots->disallowNamespace( NS_TEMPLATE );
 	$robots->disallowNamespace( NS_TEMPLATE_TALK );
 
-	if ( !empty( $wgUseSpecialAllpagesAsLocalSitemap ) ) {
+	if ( !empty( $wgEnableLocalSitemap ) ) {
 		$robots->allowSpecialPage( 'Allpages' );
 	}
 	$robots->allowSpecialPage( 'CreateNewWiki' );

--- a/wikia-robots-txt.php
+++ b/wikia-robots-txt.php
@@ -40,7 +40,9 @@ if ( !$allowRobots ) {
 	$robots->disallowNamespace( NS_TEMPLATE );
 	$robots->disallowNamespace( NS_TEMPLATE_TALK );
 
-	//$robots->allowSpecialPage( 'Allpages' ); // TODO: SEO-64
+	if ( !empty( $wgUseSpecialAllpagesAsLocalSitemap ) ) {
+		$robots->allowSpecialPage( 'Allpages' );
+	}
 	$robots->allowSpecialPage( 'CreateNewWiki' );
 	$robots->allowSpecialPage( 'Forum' );
 	$robots->allowSpecialPage( 'Sitemap' );


### PR DESCRIPTION
If $wgUseSpecialAllpagesAsLocalSitemap is set:
- Change the styling of the "from A to B" link in Special:Allpages
- Allow Special:Allpages in robots.txt
- Allow Special:Allpages to be followed, but not indexed in <meta>
- Include a link saying "Local Sitemap" in the global footer pointing to Special:AllPages (there's additional caching for global footer contents, so the change might not be instanteneous)

Additionally:
- Mark the previous/next page on the page listing with rel="nofollow"
