### PR TITLE
SUS-281 Handle retrieve responses with status MoreDataAvailable

### DIFF
--- a/extensions/wikia/ExactTargetUpdates/client/adapters/BaseAdapter.class.php
+++ b/extensions/wikia/ExactTargetUpdates/client/adapters/BaseAdapter.class.php
@@ -4,7 +4,7 @@ namespace Wikia\ExactTarget;
 
 abstract class BaseAdapter {
 
-	public function __construct($results ) {
+	public function __construct( array $results ) {
 		foreach ( $results as $result ) {
 			if ( $result->Properties instanceof \stdClass ) {
 				$this->extractResult( $result->Properties->Property );

--- a/extensions/wikia/ExactTargetUpdates/client/adapters/BaseAdapter.class.php
+++ b/extensions/wikia/ExactTargetUpdates/client/adapters/BaseAdapter.class.php
@@ -4,20 +4,13 @@ namespace Wikia\ExactTarget;
 
 abstract class BaseAdapter {
 
-	public function __construct( $result ) {
-		if ( $result->Properties instanceof \stdClass ) {
-			$this->extractSingle( $result->Properties->Property );
-		}
-		if ( is_array( $result ) ) {
-			$this->extractMultiple( $result );
-		}
-	}
-
-	protected function extractMultiple( array $properties ) {
-		foreach ( $properties as $property ) {
-			$this->extractSingle( $property->Properties->Property );
+	public function __construct($results ) {
+		foreach ( $results as $result ) {
+			if ( $result->Properties instanceof \stdClass ) {
+				$this->extractResult( $result->Properties->Property );
+			}
 		}
 	}
 
-	abstract protected function extractSingle( $property );
+	abstract protected function extractResult($property );
 }

--- a/extensions/wikia/ExactTargetUpdates/client/adapters/UserEditsAdapter.class.php
+++ b/extensions/wikia/ExactTargetUpdates/client/adapters/UserEditsAdapter.class.php
@@ -12,7 +12,7 @@ class UserEditsAdapter extends BaseAdapter{
 		return $this->edits;
 	}
 
-	protected function extractSingle( $property ) {
+	protected function extractResult( $property ) {
 		foreach ( $property as $value ) {
 			if ( $value->Name === Enum::USER_ID ) {
 				$userId = $value->Value;

--- a/extensions/wikia/ExactTargetUpdates/client/adapters/UserEmailAdapter.class.php
+++ b/extensions/wikia/ExactTargetUpdates/client/adapters/UserEmailAdapter.class.php
@@ -10,7 +10,7 @@ class UserEmailAdapter extends BaseAdapter {
 		return $this->userEmail;
 	}
 
-	protected function extractSingle( $property ) {
+	protected function extractResult( $property ) {
 		$this->userEmail = $property->Value;
 	}
 }

--- a/extensions/wikia/ExactTargetUpdates/client/adapters/UserIdsAdapter.class.php
+++ b/extensions/wikia/ExactTargetUpdates/client/adapters/UserIdsAdapter.class.php
@@ -10,7 +10,7 @@ class UserIdsAdapter extends BaseAdapter {
 		return $this->ids;
 	}
 
-	protected function extractSingle( $property ) {
+	protected function extractResult( $property ) {
 		if ( isset( $property->Value ) ) {
 			$this->ids[ ] = $property->Value;
 		}

--- a/extensions/wikia/ExactTargetUpdates/client/adapters/WikiCategoriesAdapter.class.php
+++ b/extensions/wikia/ExactTargetUpdates/client/adapters/WikiCategoriesAdapter.class.php
@@ -12,7 +12,7 @@ class WikiCategoriesAdapter extends BaseAdapter {
 		return $this->mapping;
 	}
 
-	protected function extractSingle( $property ) {
+	protected function extractResult( $property ) {
 		foreach ( $property as $value ) {
 			if ( $value->Name === Enum::WIKI_ID ) {
 				$wikiId = $value->Value;

--- a/extensions/wikia/ExactTargetUpdates/maintenance/ExactTargetUpdateUserEditsPerWikiMaintenance.php
+++ b/extensions/wikia/ExactTargetUpdates/maintenance/ExactTargetUpdateUserEditsPerWikiMaintenance.php
@@ -68,8 +68,8 @@ class ExactTargetUpdateUserEditsPerWikiMaintenance extends Maintenance {
 	private function addEditsUpdateTasks( $aUsersEditsData ) {
 		$aUsersEditsData = array_chunk( $aUsersEditsData, ExactTargetClient::OBJECTS_PER_REQUEST_LIMIT, true );
 		foreach ( $aUsersEditsData as $aUsersEditsDataChunk ) {
-			$aUsersEditsData = $this->prepareDataFormat( $aUsersEditsDataChunk );
-			$this->addEditsUpdateTask( $aUsersEditsData );
+			$aPreparedUsersEditsData = $this->prepareDataFormat( $aUsersEditsDataChunk );
+			$this->addEditsUpdateTask( $aPreparedUsersEditsData );
 		}
 	}
 

--- a/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetUserUpdateDriver.php
+++ b/extensions/wikia/ExactTargetUpdates/tasks/ExactTargetUserUpdateDriver.php
@@ -45,6 +45,8 @@ class ExactTargetUserUpdateDriver {
 		$ids = array_unique( array_merge( (array)array_keys( $first ), (array)array_keys( $second ) ) );
 
 		foreach ( $ids as $userId ) {
+			$first[ $userId ] = isset( $first[ $userId ] ) && is_array( $first[ $userId ] ) ? $first[ $userId ] : [ ];
+			$second[ $userId ] = isset( $second[ $userId ] ) && is_array( $second[ $userId ] ) ? $second[ $userId ] : [ ];
 			$wikis = array_unique(
 				array_merge( (array)array_keys( $first[ $userId ] ), (array)array_keys( $second[ $userId ] ) ) );
 			foreach ( $wikis as $wikiId ) {

--- a/extensions/wikia/ExactTargetUpdates/tests/client/adapters/UserEditsAdapterTest.php
+++ b/extensions/wikia/ExactTargetUpdates/tests/client/adapters/UserEditsAdapterTest.php
@@ -9,8 +9,8 @@ class UserEditsAdapterTest extends WikiaBaseTest {
 
 	public function testGetEdits() {
 		// Params
-		$param = new stdClass();
-		$param->Properties->Property = [
+		$result = new stdClass();
+		$result->Properties->Property = [
 			$this->buildResultPair( 'user_id', 1 ),
 			$this->buildResultPair( 'wiki_id', 177 ),
 			$this->buildResultPair( 'contributions', 6 ),
@@ -23,7 +23,7 @@ class UserEditsAdapterTest extends WikiaBaseTest {
 			]
 		];
 
-		$userEdits = ( new \Wikia\ExactTarget\UserEditsAdapter( $param ) )->getEdits();
+		$userEdits = ( new \Wikia\ExactTarget\UserEditsAdapter( [ $result ] ) )->getEdits();
 		$this->assertEquals( $expected, $userEdits );
 	}
 
@@ -39,7 +39,7 @@ class UserEditsAdapterTest extends WikiaBaseTest {
 			$this->buildResultPair( 'wiki_id', 831 ),
 			$this->buildResultPair( 'contributions', 8 ),
 		];
-		$param = [
+		$results = [
 			$this->wrapProperty( $p1 ),
 			$this->wrapProperty( $p2 )
 		];
@@ -52,7 +52,7 @@ class UserEditsAdapterTest extends WikiaBaseTest {
 			]
 		];
 
-		$userEdits = ( new \Wikia\ExactTarget\UserEditsAdapter( $param ) )->getEdits();
+		$userEdits = ( new \Wikia\ExactTarget\UserEditsAdapter( $results ) )->getEdits();
 		$this->assertEquals( $expected, $userEdits );
 	}
 
@@ -68,7 +68,7 @@ class UserEditsAdapterTest extends WikiaBaseTest {
 			$this->buildResultPair( 'wiki_id', 177 ),
 			$this->buildResultPair( 'contributions', 8 ),
 		];
-		$param = [
+		$results = [
 			$this->wrapProperty( $p1 ),
 			$this->wrapProperty( $p2 )
 		];
@@ -83,7 +83,7 @@ class UserEditsAdapterTest extends WikiaBaseTest {
 			]
 		];
 
-		$userEdits = ( new \Wikia\ExactTarget\UserEditsAdapter( $param ) )->getEdits();
+		$userEdits = ( new \Wikia\ExactTarget\UserEditsAdapter( $results ) )->getEdits();
 		$this->assertEquals( $expected, $userEdits );
 	}
 
@@ -104,7 +104,7 @@ class UserEditsAdapterTest extends WikiaBaseTest {
 			$this->buildResultPair( 'wiki_id', 177 ),
 			$this->buildResultPair( 'contributions', 8 ),
 		];
-		$param = [
+		$results = [
 			$this->wrapProperty( $p1 ),
 			$this->wrapProperty( $p2 ),
 			$this->wrapProperty( $p3 )
@@ -121,7 +121,7 @@ class UserEditsAdapterTest extends WikiaBaseTest {
 			]
 		];
 
-		$userEdits = ( new \Wikia\ExactTarget\UserEditsAdapter( $param ) )->getEdits();
+		$userEdits = ( new \Wikia\ExactTarget\UserEditsAdapter( $results ) )->getEdits();
 		$this->assertEquals( $expected, $userEdits );
 	}
 

--- a/extensions/wikia/ExactTargetUpdates/tests/client/adapters/UserEmailAdapterTest.php
+++ b/extensions/wikia/ExactTargetUpdates/tests/client/adapters/UserEmailAdapterTest.php
@@ -9,14 +9,14 @@ class UserEmailAdapterTest extends WikiaBaseTest {
 
 	public function testGetEmptyEmail() {
 		$result = new stdClass();
-		$adapter = new \Wikia\ExactTarget\UserEmailAdapter( $result );
+		$adapter = new \Wikia\ExactTarget\UserEmailAdapter( [ $result ] );
 		$this->assertEquals( '', $adapter->getEmail() );
 	}
 
 	public function testGetEmail() {
 		$result = new stdClass();
 		$result->Properties->Property->Value = 'test@wikiatest.com';
-		$adapter = new \Wikia\ExactTarget\UserEmailAdapter( $result );
+		$adapter = new \Wikia\ExactTarget\UserEmailAdapter( [ $result ] );
 		$this->assertEquals( 'test@wikiatest.com', $adapter->getEmail() );
 	}
 }

--- a/extensions/wikia/ExactTargetUpdates/tests/client/adapters/UserIdsAdapterTest.php
+++ b/extensions/wikia/ExactTargetUpdates/tests/client/adapters/UserIdsAdapterTest.php
@@ -9,19 +9,19 @@ class UserIdsAdapterTest extends WikiaBaseTest {
 
 	public function testOnEmptyResult() {
 		$result = new stdClass();
-		$adapter = new \Wikia\ExactTarget\UserIdsAdapter( $result );
+		$adapter = new \Wikia\ExactTarget\UserIdsAdapter( [ $result ] );
 		$this->assertEquals( [ ], $adapter->getUsersIds() );
 	}
 
 	public function testOnNullResult() {
-		$adapter = new \Wikia\ExactTarget\UserIdsAdapter( null );
+		$adapter = new \Wikia\ExactTarget\UserIdsAdapter( [ null ] );
 		$this->assertEquals( [ ], $adapter->getUsersIds() );
 	}
 
 	public function testGetEmail() {
 		$result = new stdClass();
 		$result->Properties->Property->Value = 1;
-		$adapter = new \Wikia\ExactTarget\UserIdsAdapter( $result );
+		$adapter = new \Wikia\ExactTarget\UserIdsAdapter( [ $result ] );
 		$this->assertEquals( [ 1 ], $adapter->getUsersIds() );
 	}
 }

--- a/extensions/wikia/ExactTargetUpdates/tests/client/adapters/WikiCategoriesAdapterTest.php
+++ b/extensions/wikia/ExactTargetUpdates/tests/client/adapters/WikiCategoriesAdapterTest.php
@@ -9,8 +9,8 @@ class WikiCategoriesAdapterTest extends WikiaBaseTest {
 
 	public function testGetCategoriesMapping() {
 		// Params
-		$param = new stdClass();
-		$param->Properties->Property = [
+		$result = new stdClass();
+		$result->Properties->Property = [
 			$this->buildResultPair( 'city_id', 1 ),
 			$this->buildResultPair( 'cat_id', 3 )
 		];
@@ -20,7 +20,7 @@ class WikiCategoriesAdapterTest extends WikiaBaseTest {
 			[ 'city_id' => 1, 'cat_id' => 3 ]
 		];
 
-		$categoriesMapping = ( new \Wikia\ExactTarget\WikiCategoriesAdapter( $param ) )->getCategoriesMapping();
+		$categoriesMapping = ( new \Wikia\ExactTarget\WikiCategoriesAdapter( [ $result ] ) )->getCategoriesMapping();
 		$this->assertEquals( $expected, $categoriesMapping );
 	}
 
@@ -34,7 +34,7 @@ class WikiCategoriesAdapterTest extends WikiaBaseTest {
 			$this->buildResultPair( 'city_id', 5 ),
 			$this->buildResultPair( 'cat_id', 23423 )
 		];
-		$param = [
+		$results = [
 			$this->wrapProperty( $p1 ),
 			$this->wrapProperty( $p2 )
 		];
@@ -45,7 +45,7 @@ class WikiCategoriesAdapterTest extends WikiaBaseTest {
 			[ 'city_id' => 5, 'cat_id' => 23423 ]
 		];
 
-		$categoriesMapping = ( new \Wikia\ExactTarget\WikiCategoriesAdapter( $param ) )->getCategoriesMapping();
+		$categoriesMapping = ( new \Wikia\ExactTarget\WikiCategoriesAdapter( $results ) )->getCategoriesMapping();
 		$this->assertEquals( $expected, $categoriesMapping );
 	}
 


### PR DESCRIPTION
Changes:
- handle retrieve responses that should return more than 2500 objects (with status `MoreDataAvailable`)
- prevent logging request/response body to elasticsearch (they were too big, up to 6MB)
- change adapters interface to accept only arrays

@Wikia/sustaining-team 
