### PR TITLE
ApiWrapper: getInterfaceObjectFromType() method does not need an argument

### DIFF
--- a/extensions/wikia/VideoHandlers/apiwrappers/ApiWrapper.class.php
+++ b/extensions/wikia/VideoHandlers/apiwrappers/ApiWrapper.class.php
@@ -136,7 +136,7 @@ abstract class ApiWrapper {
 		$this->interfaceObj = $this->getInterfaceObjectFromType();
 	}
 
-	protected function getInterfaceObjectFromType( $type ) {
+	protected function getInterfaceObjectFromType() {
 
 		wfProfileIn( __METHOD__ );
 
@@ -642,7 +642,7 @@ class VideoNotFound extends Exception {}
  */
 abstract class PseudoApiWrapper extends ApiWrapper {
 
-	protected function getInterfaceObjectFromType( $type ) {
+	protected function getInterfaceObjectFromType() {
 		// override me!
 	}
 

--- a/extensions/wikia/VideoHandlers/apiwrappers/GamestarApiWrapper.class.php
+++ b/extensions/wikia/VideoHandlers/apiwrappers/GamestarApiWrapper.class.php
@@ -48,7 +48,7 @@ class GamestarApiWrapper extends ApiWrapper {
 		return $this->interfaceObj['title'];
 	}
 
-	protected function getInterfaceObjectFromType( $type ) {
+	protected function getInterfaceObjectFromType() {
 		wfProfileIn( __METHOD__ );
 
 		$apiUrl = $this->getApiUrl();


### PR DESCRIPTION
[PLATFORM-1979](https://wikia-inc.atlassian.net/browse/PLATFORM-1979)

Prevent `PHP Warning: Missing argument 1 for ApiWrapper::getInterfaceObjectFromType(), called in /extensions/wikia/VideoHandlers/apiwrappers/ApiWrapper.class.php on line 136 and defined in /extensions/wikia/VideoHandlers/apiwrappers/ApiWrapper.class.php on line 139`

`ApiWrapper::getInterfaceObjectFromType` is called just in one place in the code without an argument - let's skip it as it's obviously not needed.

A follow up of #9880 (4df15e99603e0f7594c64273aaae21362c5ab8b0)

@Wikia/sustaining-team 
