### PR TITLE
Queue: use "mediawiki.main" routing key

### DIFF
--- a/includes/wikia/tasks/Queues/Queue.class.php
+++ b/includes/wikia/tasks/Queues/Queue.class.php
@@ -17,8 +17,8 @@ class Queue {
 	protected $routingKey;
 
 	public function __construct() {
-		$this->name = 'mediawiki';
-		$this->routingKey = 'mediawiki';
+		$this->name = 'mediawiki_main';
+		$this->routingKey = 'mediawiki.main';
 	}
 
 	public function name() {


### PR DESCRIPTION
[PLATFORM-1943](https://wikia-inc.atlassian.net/browse/PLATFORM-1943)

Something is pushing empty messages (with no payload) to Rabbit with `mediawiki` routing key. Let's use a different routing key for MW tasks and then identify what's pushing empty messages.

@artursitarski / @wladekb / @owend 
