### PR TITLE
[PLATFORM-1985] Introduced shared memcache for permissions data

### DIFF
--- a/lib/Wikia/src/Service/User/Permissions/PermissionsServiceImpl.php
+++ b/lib/Wikia/src/Service/User/Permissions/PermissionsServiceImpl.php
@@ -55,7 +55,7 @@ class PermissionsServiceImpl implements PermissionsService {
 	 * @return string memcache key
 	 */
 	static public function getMemcKey( $userId ) {
-		return wfSharedMemcKey( __CLASS__, 'permissions-groups', $userId );
+		return implode( ':', [ 'GLOBAL', __CLASS__, 'permissions-groups', $userId ] );
 	}
 
 	/**


### PR DESCRIPTION
Changed caching of user groups to be shared between envs (sandbox/previe/prod) etc. to avoid problem that someone edit someone rights on sandbox and in prod that user doesn't have the new group, as it was cached without it and purging only affected one env.

@wladekb 
