### PR TITLE
SEO-302 Allow Googlebot to crawl Android apps

### DIFF
--- a/extensions/wikia/RobotsTxt/RobotsTxt.class.php
+++ b/extensions/wikia/RobotsTxt/RobotsTxt.class.php
@@ -32,6 +32,17 @@ class RobotsTxt {
 	}
 
 	/**
+	 * Allow a specific path
+	 *
+	 * It emits the Allow directive
+	 *
+	 * @param string $path path prefix to allow (some robots accept wildcards)
+	 */
+	public function allowPath( $path ) {
+		$this->allowed[] = $path;
+	}
+
+	/**
 	 * Disallow a specific robot to crawl all the pages
 	 *
 	 * @param string $robot User-agent (fragment) of the robot

--- a/extensions/wikia/RobotsTxt/tests/RobotsTxtTest.php
+++ b/extensions/wikia/RobotsTxt/tests/RobotsTxtTest.php
@@ -110,19 +110,28 @@ class RobotsTxtTest extends WikiaBaseTest {
 	}
 
 	/**
-	 * Test disallowPath and limited URI encoding
+	 * Test disallowPath and allowPath, and limited URI encoding
 	 *
 	 * @covers RobotsTxt::disallowPath
+	 * @covers RobotsTxt::allowPath
 	 */
-	public function testDisallowPath() {
+	public function testDisallowAndAllowPath() {
 		$robots = new RobotsTxt();
 		$robots->disallowPath( '/some-path' );
 		$robots->disallowPath( '/some-path:ąść' );
 		$robots->disallowPath( '/some-path:サイトマップ' );
 		$robots->disallowPath( '/*/*%$' );
+		$robots->allowPath( '/other-path' );
+		$robots->allowPath( '/other-path:ąść' );
+		$robots->allowPath( '/other-path:サイトマップ' );
+		$robots->allowPath( '/*/*^$' );
 
 		$this->assertEquals( [
 			'User-agent: *',
+			'Allow: /other-path',
+			'Allow: /other-path:%C4%85%C5%9B%C4%87',
+			'Allow: /other-path:%E3%82%B5%E3%82%A4%E3%83%88%E3%83%9E%E3%83%83%E3%83%97',
+			'Allow: /*/*%5E$',
 			'Disallow: /some-path',
 			'Disallow: /some-path:%C4%85%C5%9B%C4%87',
 			'Disallow: /some-path:%E3%82%B5%E3%82%A4%E3%83%88%E3%83%9E%E3%83%83%E3%83%97',

--- a/wikia-robots-txt.php
+++ b/wikia-robots-txt.php
@@ -58,6 +58,17 @@ if ( !$allowRobots ) {
 	$robots->disallowParam( 'useskin' );
 	$robots->disallowParam( 'uselang' );
 
+	// SEO-302: Allow Googlebot to crawl Android app contents
+	// @see http://developer.android.com/training/app-indexing/enabling-app-indexing.html)
+	// The order of precedence between those two is undefined:
+	// "Disallow: /*?*action=" and "Allow: /api.php"
+	// @see https://developers.google.com/webmasters/control-crawl-index/docs/robots_txt#order-of-precedence-for-group-member-records
+	// That's why we're adding quite explicit "Allow: /api.php?*action=" (even though it's redundant)
+	// robots.txt Tester in Google Search Console shows this will do:
+	// @see https://www.google.com/webmasters/tools/robots-testing-tool?hl=en&siteUrl=http://muppet.wikia.com/
+	$robots->allowPath( '/api.php?' );
+	$robots->allowPath( '/api.php?*action=' );
+
 	// Nasty robots
 	$robots->blockRobot( 'IsraBot' );
 	$robots->blockRobot( 'Orthogaffe' );


### PR DESCRIPTION
Given APIs are for robots, we should just add an explicit Allow rule for
api.php that overrides the later generic block for the action param
(meant for blocking accessing ?action=edit ?action=purge, ?action=raw
etc).

Now because Googlebot doesn't follow standard, which tells that the first
matching rule wins, we also need to add a "more specific" rule to make
Googlebot crawl api.php URLs with "action" param.

Therefore we're adding code that causes the following two rules to be
emitted in robots.txt:

```
Allow: /api.php?
Allow: /api.php?*action=
```

The first one is meant for standards-compliant bots (enabling them to
use any api.php URLs). The second is just for Googlebot (to win over
Disallow /_?_action= rule).
