### PR TITLE
AdminDashboardSpecialPageController: fix warnings flood from Sanitizer

### DIFF
--- a/extensions/wikia/AdminDashboard/AdminDashboardSpecialPageController.class.php
+++ b/extensions/wikia/AdminDashboard/AdminDashboardSpecialPageController.class.php
@@ -17,7 +17,7 @@ class AdminDashboardSpecialPageController extends WikiaSpecialPageController {
 	 *
 	 */
 	public function index() {
-		$this->wg->Out->setPageTitle( [ wfMsg( 'admindashboard-header' ) ] );
+		$this->wg->Out->setPageTitle( wfMsg( 'admindashboard-header' ) );
 		if (!$this->wg->User->isAllowed( 'admindashboard' )) {
 			$this->displayRestrictionError();
 			return false;  // skip rendering


### PR DESCRIPTION
Get rid of `PHP Warning: substr() expects parameter 1 to be string, array given in /includes/Sanitizer.php on line 635` flood.

`OuttputPage::setPageTitle` should be called using string, not array.

@gabrys (#9858)
