### PR TITLE
CE-3436: Tracking for RC and diff page

### DIFF
--- a/extensions/wikia/RecentChanges/js/RecentChanges.js
+++ b/extensions/wikia/RecentChanges/js/RecentChanges.js
@@ -12,17 +12,6 @@ jQuery(function($) {
 
 			this.dropdown = new Wikia.MultiSelectDropdown(this.$dropdown);
 			this.dropdown.on('change', $.proxy(this.onChange, this));
-
-			if (window.Wikia.Tracker) {
-				$('#WikiaPage').on('mousedown', '.mw-rollback-link a', function () {
-					window.Wikia.Tracker.track({
-						trackingMethod: 'analytics',
-						category: 'recent-changes',
-						action: tracker.ACTIONS.CLICK,
-						label: 'rollback'
-					});
-				});
-			}
 		},
 
 		saveFilters: function(event) {

--- a/extensions/wikia/RecentChanges/js/RecentChanges.js
+++ b/extensions/wikia/RecentChanges/js/RecentChanges.js
@@ -13,6 +13,16 @@ jQuery(function($) {
 			this.dropdown = new Wikia.MultiSelectDropdown(this.$dropdown);
 			this.dropdown.on('change', $.proxy(this.onChange, this));
 
+			if (window.Wikia.Tracker) {
+				$('#WikiaPage').on('mousedown', '.mw-rollback-link a', function () {
+					window.Wikia.Tracker.track({
+						trackingMethod: 'analytics',
+						category: 'recent-changes',
+						action: tracker.ACTIONS.CLICK,
+						label: 'rollback'
+					});
+				});
+			}
 		},
 
 		saveFilters: function(event) {

--- a/includes/Linker.php
+++ b/includes/Linker.php
@@ -1790,7 +1790,7 @@ class Linker {
 		$query = array(
 			'action' => 'rollback',
 			'from' => $rev->getUserText(),
-			'token' => $wgUser->getEditToken( array( $title->getPrefixedText(), $rev->getUserText() ) ),
+			'token' => $wgUser->getEditToken( [ $title->getPrefixedText(), $rev->getUserText() ] ),
 		);
 		if ( $wgRequest->getBool( 'bot' ) ) {
 			$query['bot'] = '1';
@@ -1798,10 +1798,12 @@ class Linker {
 		}
 		return self::link(
 			$title,
-			wfMsgHtml( 'rollbacklink' ),
-			array( 'title' => wfMsg( 'tooltip-rollback' ) ),
+			wfMessage( 'rollbacklink' )->escaped(),
+			# Wikia change begin
+			[ 'title' => wfMessage( 'tooltip-rollback' ), 'data-action' => 'rollback' ],
+			# Wikia change end
 			$query,
-			array( 'known', 'noclasses' )
+			[ 'known', 'noclasses' ]
 		);
 	}
 

--- a/includes/diff/DifferenceEngine.php
+++ b/includes/diff/DifferenceEngine.php
@@ -900,7 +900,7 @@ class DifferenceEngine extends ContextSource {
 		}
 
 		# Wikia Change begin
-		$type = $rev->getId() === $this->mOldid ? 'before' : 'after';
+		$type = $rev->getId() == $this->getOldid() ? 'before' : 'after';
 		# Wikia Change end
 
 		$title = $rev->getTitle();

--- a/includes/diff/DifferenceEngine.php
+++ b/includes/diff/DifferenceEngine.php
@@ -908,7 +908,8 @@ class DifferenceEngine extends ContextSource {
 		$header = Linker::linkKnown(
 			$title,
 			$header,
-			# Wikia Change begin
+			/* Wikia Change begin
+			   Possible values: revision-link-before, revision-link-after */
 			[ 'data-action' => 'revision-link-' . $type ],
 			# Wikia Change end
 			[ 'oldid' => $rev->getID() ]
@@ -921,7 +922,8 @@ class DifferenceEngine extends ContextSource {
 			}
 
 			$msg = $this->msg( $title->userCan( 'edit', $user ) ? 'editold' : 'viewsourceold' )->escaped();
-			/* Wikia Change begin */
+			/* Wikia Change begin
+			   Possible values: edit-revision-before, edit-revision-after */
 			$header .= ' <span class="mw-rev-head-action">(' .
 				Linker::linkKnown( $title, $msg, [ 'data-action' => 'edit-revision-' . $type ], $editQuery ) .
 				')</span>';

--- a/includes/diff/DifferenceEngine.php
+++ b/includes/diff/DifferenceEngine.php
@@ -275,7 +275,10 @@ class DifferenceEngine extends ContextSource {
 								'action' => 'edit',
 								'undoafter' => $this->mOldid,
 								'undo' => $this->mNewid ) ),
-							'title' => Linker::titleAttrib( 'undo' )
+							'title' => Linker::titleAttrib( 'undo' ),
+							# Wikia Change begin
+							'data-action' => 'undo'
+							# Wikia Change end
 						),
 						$this->msg( 'editundo' )->text()
 					) )->escaped().'</span>';
@@ -287,8 +290,10 @@ class DifferenceEngine extends ContextSource {
 				$prevlink = Linker::linkKnown(
 					$this->mOldPage,
 					$this->msg( 'previousdiff' )->escaped(),
-					array( 'id' => 'differences-prevlink' ),
-					array( 'diff' => 'prev', 'oldid' => $this->mOldid ) + $query
+					# Wikia Change begin
+					[ 'id' => 'differences-prevlink', 'data-action' => 'older-edit-link' ],
+					# Wikia Change end
+					[ 'diff' => 'prev', 'oldid' => $this->mOldid ] + $query
 				);
 			} else {
 				$prevlink = '&#160;';
@@ -329,8 +334,10 @@ class DifferenceEngine extends ContextSource {
 			$nextlink = Linker::linkKnown(
 				$this->mNewPage,
 				$this->msg( 'nextdiff' )->escaped(),
-				array( 'id' => 'differences-nextlink' ),
-				array( 'diff' => 'next', 'oldid' => $this->mNewid ) + $query
+				# Wikia Change begin
+				[ 'id' => 'differences-nextlink', 'data-action' => 'newer-edit-link' ],
+				# Wikia Change end
+				[ 'diff' => 'next', 'oldid' => $this->mNewid ] + $query
 			);
 		} else {
 			$nextlink = '&#160;';
@@ -892,10 +899,20 @@ class DifferenceEngine extends ContextSource {
 			return $header;
 		}
 
+		# Wikia Change begin
+		$type = $rev->getId() === $this->mOldid ? 'before' : 'after';
+		# Wikia Change end
+
 		$title = $rev->getTitle();
 
-		$header = Linker::linkKnown( $title, $header, array(),
-			array( 'oldid' => $rev->getID() ) );
+		$header = Linker::linkKnown(
+			$title,
+			$header,
+			# Wikia Change begin
+			[ 'data-action' => 'revision-link-' . $type ],
+			# Wikia Change end
+			[ 'oldid' => $rev->getID() ]
+		);
 
 		if ( $rev->userCan( Revision::DELETED_TEXT, $user ) ) {
 			$editQuery = array( 'action' => 'edit' );
@@ -905,7 +922,9 @@ class DifferenceEngine extends ContextSource {
 
 			$msg = $this->msg( $title->userCan( 'edit', $user ) ? 'editold' : 'viewsourceold' )->escaped();
 			/* Wikia Change begin */
-			$header .= ' <span class="mw-rev-head-action">(' . Linker::linkKnown( $title, $msg, array(), $editQuery ) . ')</span>';
+			$header .= ' <span class="mw-rev-head-action">(' .
+				Linker::linkKnown( $title, $msg, [ 'data-action' => 'edit-revision-' . $type ], $editQuery ) .
+				')</span>';
 			/* Wikia Change end */
 			if ( $rev->isDeleted( Revision::DELETED_TEXT ) ) {
 				$header = Html::rawElement( 'span', array( 'class' => 'history-deleted' ), $header );
@@ -948,7 +967,7 @@ class DifferenceEngine extends ContextSource {
 				$multiColspan = 2;
 			}
 			$header .= "
-			<tr valign='top'>
+			<tr class='diff-header' valign='top'>
 			<td colspan='$colspan' class='diff-otitle'>{$otitle}</td>
 			<td colspan='$colspan' class='diff-ntitle'>{$ntitle}</td>
 			</tr>";

--- a/skins/oasis/js/Tracking.js
+++ b/skins/oasis/js/Tracking.js
@@ -262,24 +262,29 @@ jQuery(function ($) {
 	/** recent-changes **/
 
 	if ($body.hasClass('page-Special_RecentChanges')) {
-		$wikiaArticle.find('.rc-conntent').on('mousedown', 'a', function (e) {
+		// We need to bind to #WikiaArticle because users use scripts which reload the content
+		// see: http://dev.wikia.com/wiki/MediaWiki:AjaxRC/code.js
+		$wikiaArticle.on('mousedown', 'a', function (e) {
 			var label,
-				el = $(e.target),
-				href = el.attr('href');
+				$el = $(e.target),
+				label = $el.attr('data-action'),
+				href = $el.attr('href');
 
 			// Primary mouse button only
 			if (e.which !== 1) {
 				return;
 			}
 
-			if (rHrefDiff.test(href)) {
-				label = 'diff';
-			} else if (rHrefHistory.test(href)) {
-				label = 'history';
-			} else if (el.hasClass('mw-userlink')) {
-				label = 'username';
-			} else if (!el.parent().is('span')) {
-				label = 'title';
+			if (!label) {
+				if (rHrefDiff.test(href)) {
+					label = 'diff';
+				} else if (rHrefHistory.test(href)) {
+					label = 'history';
+				} else if ($el.hasClass('mw-userlink')) {
+					label = 'username';
+				} else if (!$el.parent().is('span')) {
+					label = 'title';
+				}
 			}
 
 			if (label !== undefined) {
@@ -296,10 +301,6 @@ jQuery(function ($) {
 	$wikiaArticle.find('.diff-header').on('mousedown', 'a', function(e) {
 		var $el = $(e.target),
 			action = $el.attr('data-action');
-
-		if (!action && $el.parent().hasClass('mw-rollback-link')) {
-			action = 'rollback';
-		}
 
 		if (action) {
 			track({

--- a/skins/oasis/js/Tracking.js
+++ b/skins/oasis/js/Tracking.js
@@ -292,6 +292,24 @@ jQuery(function ($) {
 		});
 	}
 
+	/** diff page **/
+	$wikiaArticle.find('.diff-header').on('mousedown', 'a', function(e) {
+		var $el = $(e.target),
+			action = $el.attr('data-action');
+
+		if (!action && $el.parent().hasClass('mw-rollback-link')) {
+			action = 'rollback';
+		}
+
+		if (action) {
+			track({
+				browserEvent: e,
+				category: 'oasis-diff',
+				label: action
+			});
+		}
+	});
+
 	/** search **/
 
 	(function () {

--- a/skins/oasis/js/Tracking.js
+++ b/skins/oasis/js/Tracking.js
@@ -265,8 +265,7 @@ jQuery(function ($) {
 		// We need to bind to #WikiaArticle because users use scripts which reload the content
 		// see: http://dev.wikia.com/wiki/MediaWiki:AjaxRC/code.js
 		$wikiaArticle.on('mousedown', 'a', function (e) {
-			var label,
-				$el = $(e.target),
+			var $el = $(e.target),
 				label = $el.attr('data-action'),
 				href = $el.attr('href');
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CE-3436

Added tracking for rollback action on Special:RecentChanges and for these actions on diff page:
- undo
- rollback (not seen in the screenshot)
- newer-edit-link
- older-edit-link
- revision-before-link
- revision-after-link
- edit-revision-before
- edit-revision-after

ping @Wikia/community-engineering 
