### PR TITLE
Bucky: report last two domain segments only

### DIFF
--- a/extensions/wikia/Bucky/js/bucky_resources_timing.js
+++ b/extensions/wikia/Bucky/js/bucky_resources_timing.js
@@ -41,12 +41,14 @@ define('bucky.resourceTiming', ['jquery', 'wikia.window', 'wikia.log', 'bucky'],
 	/**
 	 * Returns the domain name from the full URL
 	 *
+	 * Only last two segments will be returned, e.g. "vignette1.wikia.nocookie.net" will give you "nocookie.net"
+	 *
 	 * @param {string} url URL to get domain for
 	 * @return {string|false} domain or false when URLs in invalid
 	 */
 	function getDomain(url) {
 		var matches = url.match(/\/\/([^/]+)/);
-		return !!matches && matches[1];
+		return !!matches && matches[1].split('.').slice(-2).join('.');
 	}
 
 	/**

--- a/extensions/wikia/Bucky/js/spec/bucky_resources_timing.spec.js
+++ b/extensions/wikia/Bucky/js/spec/bucky_resources_timing.spec.js
@@ -38,11 +38,11 @@ describe('BuckyResourcesTiming', function () {
 		var resourcesTiming = getModule(),
 			urls = {
 				// Wikia assets
-				'http://vignette1.wikia.nocookie.net/nordycka/images/d/d7/Mykines_2.jpg/revision/latest/scale-to-width/300?cb=20141031093541&path-prefix=pl': 'vignette1.wikia.nocookie.net',
+				'http://vignette1.wikia.nocookie.net/nordycka/images/d/d7/Mykines_2.jpg/revision/latest/scale-to-width/300?cb=20141031093541&path-prefix=pl': 'nocookie.net',
 				// 3rd party assets
-				'http://edge.quantserve.com/quant-wikia.js': 'edge.quantserve.com',
-				'http://www.google-analytics.com/ga.js': 'www.google-analytics.com',
-				'http://www.google-analytics.com': 'www.google-analytics.com',
+				'http://edge.quantserve.com/quant-wikia.js': 'quantserve.com',
+				'http://www.google-analytics.com/ga.js': 'google-analytics.com',
+				'http://www.google-analytics.com': 'google-analytics.com',
 				// invalid URL
 				'foo.bar/test.css': false
 			};


### PR DESCRIPTION
[PLATFORM-1903](https://wikia-inc.atlassian.net/browse/PLATFORM-1903)

Reporting 3rd party assets stats increased the traffic that we generate to InfluxDB. Let's improve grouping of domain names by reporting only the last two segments: `vignette1.wikia.nocookie.net` will be reported as `nocookie.net`.

@nandy-andy / @wladekb 
