### PR TITLE
[PLATFORM-1991 Expanded groups in SpecialListGroupRights with implicit groups

### DIFF
--- a/includes/specials/SpecialListgrouprights.php
+++ b/includes/specials/SpecialListgrouprights.php
@@ -60,7 +60,10 @@ class SpecialListGroupRights extends SpecialPage {
 				'</tr>'
 		);
 
-		$allGroups = User::getAllGroups();
+		$allGroups = array_unique( array_merge(
+			User::getAllGroups(),
+			User::getImplicitGroups()
+		) );
 		asort( $allGroups );
 
 		foreach ( $allGroups as $group ) {

--- a/includes/specials/SpecialListgrouprights.php
+++ b/includes/specials/SpecialListgrouprights.php
@@ -61,8 +61,8 @@ class SpecialListGroupRights extends SpecialPage {
 		);
 
 		$allGroups = array_unique( array_merge(
-			User::getAllGroups(),
-			User::getImplicitGroups()
+			$this->permissionsService()->getConfiguration()->getExplicitGroups(),
+			$this->permissionsService()->getConfiguration()->getImplicitGroups()
 		) );
 		asort( $allGroups );
 


### PR DESCRIPTION
This fix is adding showing of rights associated with implicit groups on the ListGroupRights special page. They were being shown in the past, but accidentally hidden away in a recent change.

@wladekb 
