### PR TITLE
SUS-183: Return null if getApiWrapper returns null

### DIFF
--- a/extensions/wikia/VideoHandlers/VideoFileUploader.class.php
+++ b/extensions/wikia/VideoHandlers/VideoFileUploader.class.php
@@ -520,24 +520,25 @@ class VideoFileUploader {
 	 * @return null|Title
 	 */
 	public static function URLtoTitle( $url, $sTitle = '', $sDescription = '' ) {
-
 		wfProfileIn( __METHOD__ );
 		$oTitle = null;
 		$oUploader = new self();
 		$oUploader->setExternalUrl( $url );
 		$oUploader->setTargetTitle( $sTitle );
-		if ( !empty($sDescription) ) {
-			$categoryVideosTxt = self::getCategoryVideosWikitext();
-			if ( strpos( $sDescription, $categoryVideosTxt ) === false ) {
-				$sDescription .= $categoryVideosTxt;
+		if ( $oUploader->getApiWrapper() !== null ) {
+			if ( !empty($sDescription) ) {
+				$categoryVideosTxt = self::getCategoryVideosWikitext();
+				if ( strpos( $sDescription, $categoryVideosTxt ) === false ) {
+					$sDescription .= $categoryVideosTxt;
+				}
+				$oUploader->setDescription( $sDescription );
 			}
-			$oUploader->setDescription( $sDescription );
-		}
 
-		$status = $oUploader->upload( $oTitle );
-		if ( $status->isOK() ) {
-			wfProfileOut( __METHOD__ );
-			return $oTitle;
+			$status = $oUploader->upload( $oTitle );
+			if ( $status->isOK() ) {
+				wfProfileOut( __METHOD__ );
+				return $oTitle;
+			}
 		}
 		wfProfileOut( __METHOD__ );
 		return null;

--- a/extensions/wikia/VideoHandlers/VideoFileUploader.class.php
+++ b/extensions/wikia/VideoHandlers/VideoFileUploader.class.php
@@ -525,7 +525,7 @@ class VideoFileUploader {
 		$oUploader = new self();
 		$oUploader->setExternalUrl( $url );
 		$oUploader->setTargetTitle( $sTitle );
-		if ( $oUploader->getApiWrapper() !== null ) {
+		if ( !empty( $oUploader->getApiWrapper() ) ) {
 			if ( !empty($sDescription) ) {
 				$categoryVideosTxt = self::getCategoryVideosWikitext();
 				if ( strpos( $sDescription, $categoryVideosTxt ) === false ) {


### PR DESCRIPTION
Method getApiWrapper internally tries to figure our video provider and video id - if it fails it means that provided URL is incorrect - so we should not attempt to "uplod" such a broken URL.
