### PR TITLE
remove wgVideoHandlersVideosMigrated

### DIFF
--- a/extensions/wikia/CategoryExhibition/CategoryExhibitionSection.class.php
+++ b/extensions/wikia/CategoryExhibition/CategoryExhibitionSection.class.php
@@ -332,7 +332,6 @@ class CategoryExhibitionSection {
 	}
 
 	protected function getArticleData( $pageId ){
-		global $wgVideoHandlersVideosMigrated;
 
 		$oTitle = Title::newFromID( $pageId );
 		if(!($oTitle instanceof Title)) {
@@ -345,7 +344,6 @@ class CategoryExhibitionSection {
 			$pageId,
 			F::App()->wg->cityId,
 			$this->isVerify(),
-			$wgVideoHandlersVideosMigrated ? 1 : 0,
 			$this->getTouched($oTitle)
 		);
 
@@ -421,7 +419,6 @@ class CategoryExhibitionSection {
 	 * Caching functions.
 	 */
 	protected function getKey() {
-		global $wgVideoHandlersVideosMigrated;
 		return wfMemcKey(
 			'category_exhibition_section_0',
 			md5($this->categoryTitle->getDBKey()),
@@ -430,7 +427,6 @@ class CategoryExhibitionSection {
 			$this->getDisplayType(),
 			$this->getSortType(),
 			$this->isVerify(),
-			($wgVideoHandlersVideosMigrated ? 1 : 0),
 			$this->getTouched($this->categoryTitle),
 			self::CACHE_VERSION
 		);

--- a/extensions/wikia/CategoryExhibition/CategoryExhibitionSectionSubcategories.class.php
+++ b/extensions/wikia/CategoryExhibition/CategoryExhibitionSectionSubcategories.class.php
@@ -4,7 +4,7 @@
  * Category Exhibition sub-categories section class
  */
 class CategoryExhibitionSectionSubcategories extends CategoryExhibitionSection {
-	
+
 	public $urlParameter = 'subcategories'; // contains section url variable that stores pagination
 	public $templateName = 'subcategories';
 
@@ -25,7 +25,7 @@ class CategoryExhibitionSectionSubcategories extends CategoryExhibitionSection {
 	/**
 	 * Returns section HTML.
 	 * Used in ajax requests
-	 * 
+	 *
 	 * @return string
 	 */
 
@@ -40,17 +40,15 @@ class CategoryExhibitionSectionSubcategories extends CategoryExhibitionSection {
 	}
 
 	protected function getArticleData( $pageId ){
-		global $wgVideoHandlersVideosMigrated;
-		
+
 		$oTitle = Title::newFromID( $pageId );
-				
+
 		$oMemCache = F::App()->wg->memc;
 		$sKey = wfSharedMemcKey(
 			'category_exhibition_article_cache_0',
 			$pageId,
 			F::App()->wg->cityId,
 			$this->isVerify(),
-			$wgVideoHandlersVideosMigrated ? 1 : 0,
 			$this->getTouched($oTitle)
 		);
 
@@ -99,7 +97,7 @@ class CategoryExhibitionSectionSubcategories extends CategoryExhibitionSection {
 	 * @param $iCategoryId int category pageId
 	 * @return array
 	 */
-	
+
 	protected function getCategoryImageOrSnippet( $iCategoryId ){
 
 		$title = Title::newFromID( $iCategoryId );

--- a/extensions/wikia/VideoHandlers/VideoHandlers.setup.php
+++ b/extensions/wikia/VideoHandlers/VideoHandlers.setup.php
@@ -119,9 +119,7 @@ if ( !empty( $wgUseVideoVerticalFilters ) ) {
 	$wgHooks['CategorySelectSave'][] = 'VideoInfoHooksHelper::onCategorySelectSave';
 }
 
-if ( !empty($wgVideoHandlersVideosMigrated) ) {
-	$wgHooks['ParserFirstCallInit'][] = 'VideoHandlerHooks::initParserHook';
-}
+$wgHooks['ParserFirstCallInit'][] = 'VideoHandlerHooks::initParserHook';
 
 $wgHooks['VideoInfoSaveToCache'][] = 'VideoHandlerHooks::clearVideoCache';
 $wgHooks['VideoInfoInvalidateCache'][] = 'VideoHandlerHooks::clearVideoCache';


### PR DESCRIPTION
I was doing code review for removing variables and noticed that this one is enabled everywhere.  Removing the variable entirely allows us to also delete it from configuration.  

@saipetch @mixth-sense @wladekb 

This var is defined in wikifactory (as true in all cases) so it can be deleted from the db as well (but I haven't done that part yet) 
