### PR TITLE
PLATFORM-1537 AssetsManagerServer::serve failed

### DIFF
--- a/skins/oasis/css/core/background.scss
+++ b/skins/oasis/css/core/background.scss
@@ -13,10 +13,10 @@ $background-height: get_command_line_param( "background-image-height", 0 );
 $background-width: get_command_line_param( "background-image-width", 0 );
 
 // convert unitless int values to pixels
-@if unitless($background-height) {
+@if type-of($background-height) == number and unitless($background-height) {
   $background-height : $background-height * 1px;
 }
-@if unitless($background-width) {
+@if type-of($background-width) == number and unitless($background-width) {
   $background-width : $background-width * 1px;
 }
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-1537

After quick investigation it seems that Sass threw following error:

```
Error: argument `$number` of `unitless($number)` must be a number
```

for `number` with `px` suffix.

For example: 

```
/__am/62254/sass/background-align%3Dcenter%26background-fixed%3Dtrue%26background-image%3Dhttp%253A%252F%252Fslot1.images.wikia.nocookie.net%252F__cb60998%252Fcommon%252Fskins%252Foasis%252Fimages%252Fthemes%252Fpolice.jpg%26background-image-height%3D800px%26background-image-width%3D2000px%26background-tiled%3Dfalse%26color-body%3D%25231a1a1a%26color-buttons%3D%25230300ce%26color-header%3D%25236d0d00%26color-links%3D%25230066cc%26color-page%3D%2523fdfdfd%26page-opacity%3D100%26widthType%3D3%26wordmark-font%3D/skins/oasis/css/oasis.scss
```

To me, seems that `unitless` function is not working properly. Seems that other people also has that problem:
https://github.com/thoughtbot/bourbon/issues/508
https://github.com/oddbird/susy/issues/452
https://github.com/sass/libsass/issues/293

So I've added another check to compare `type-of(variable)` with `number`
