### PR TITLE
SOC-2114 | Helios antispoof check now skips exact match on username

### DIFF
--- a/extensions/wikia/Helios/HelperController.class.php
+++ b/extensions/wikia/Helios/HelperController.class.php
@@ -43,7 +43,7 @@ class HelperController extends \WikiaController
 		$spoofUser = new \SpoofUser( $username );
 
 		// Allow the given user name if it is legal and does not conflict with other names.
-		$this->response->setVal( 'allow', $spoofUser->isLegal() && ! $spoofUser->getConflicts() );
+		$this->response->setVal( 'allow', $spoofUser->isLegal() && ! $spoofUser->getConflicts( true ) );
 		return;
 	}
 

--- a/extensions/wikia/Helios/HelperController.class.php
+++ b/extensions/wikia/Helios/HelperController.class.php
@@ -43,7 +43,7 @@ class HelperController extends \WikiaController
 		$spoofUser = new \SpoofUser( $username );
 
 		// Allow the given user name if it is legal and does not conflict with other names.
-		$this->response->setVal( 'allow', $spoofUser->isLegal() && ! $spoofUser->getConflicts( true ) );
+		$this->response->setVal( 'allow', $spoofUser->isLegal() && !$spoofUser->getConflicts( true ) );
 		return;
 	}
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SOC-2114

**Problem**
Helios returns 2 different error message when username is already taken

**Reason**
Helios has many validators for username, including:
- internal check if username is already taken (exact match check)
- antispoof check using Wikia API

**Solution**
Antispoof API method provided for Helios skips exact match username when checking for username conflicts. 

Ping @harnash
