### PR TITLE
ResourceLoaderUserModule: add an assert to find the root cause of PLATFORM-1980

### DIFF
--- a/includes/resourceloader/ResourceLoaderUserModule.php
+++ b/includes/resourceloader/ResourceLoaderUserModule.php
@@ -37,6 +37,12 @@ class ResourceLoaderUserModule extends ResourceLoaderGlobalWikiModule {
 			// Get the normalized title of the user's user page
 			$username = $context->getUser();
 			$userpageTitle = Title::makeTitleSafe( NS_USER, $username );
+
+			// PLATFORM-1980
+			Wikia\Util\Assert::true( $userpageTitle instanceof Title, __METHOD__, [
+				'username' => $username
+			] );
+
 			$userpage = $userpageTitle->getPrefixedDBkey(); // Needed so $excludepages works
 
 			$pages = array(


### PR DESCRIPTION
[PLATFORM-1980](https://wikia-inc.atlassian.net/browse/PLATFORM-1980)

`Title::makeTitleSafe` is getting not valid input - let's add an assert here.

`PHP Fatal Error: Call to a member function getPrefixedDBkey() on null in /includes/resourceloader/ResourceLoaderUserModule.php on line 40`

@wladekb 
