### PR TITLE
Removed helios client credentials

### DIFF
--- a/lib/Wikia/src/Service/Helios/HeliosClientImpl.php
+++ b/lib/Wikia/src/Service/Helios/HeliosClientImpl.php
@@ -13,29 +13,19 @@ use Wikia\Service\Constants;
 class HeliosClientImpl implements HeliosClient
 {
 	const BASE_URI = "helios_base_uri";
-	const CLIENT_ID = "client_id";
-	const CLIENT_SECRET = "client_secret";
 
 	protected $baseUri;
-	protected $clientId;
-	protected $clientSecret;
 	protected $status;
 
 	/**
 	 * @Inject({
-	 *   Wikia\Service\Helios\HeliosClientImpl::BASE_URI,
-	 *   Wikia\Service\Helios\HeliosClientImpl::CLIENT_ID,
-	 *   Wikia\Service\Helios\HeliosClientImpl::CLIENT_SECRET})
+	 *   Wikia\Service\Helios\HeliosClientImpl::BASE_URI})
 	 * The constructor.
 	 * @param string $baseUri
-	 * @param string $clientId
-	 * @param string $clientSecret
 	 */
-	public function __construct( $baseUri, $clientId, $clientSecret )
+	public function __construct( $baseUri )
 	{
 		$this->baseUri = $baseUri;
-		$this->clientId = $clientId;
-		$this->clientSecret = $clientSecret;
 	}
 
 	/**
@@ -53,10 +43,6 @@ class HeliosClientImpl implements HeliosClient
 	{
 		// Crash if we cannot make HTTP requests.
 		\Wikia\Util\Assert::true( \MWHttpRequest::canMakeRequests() );
-
-		// Add client_id and client_secret to the GET data.
-		$getParams['client_id'] = $this->clientId;
-		$getParams['client_secret'] = $this->clientSecret;
 
 		// Request URI pre-processing.
 		$uri = "{$this->baseUri}{$resourceName}?" . http_build_query($getParams);
@@ -145,7 +131,7 @@ class HeliosClientImpl implements HeliosClient
 
 		$response = $this->request(
 			'token',
-			[ 'grant_type'	=> 'password' ],
+			[],
 			$postData,
 			[ 'method'	=> 'POST' ]
 		);

--- a/lib/Wikia/src/Service/User/Auth/AuthModule.php
+++ b/lib/Wikia/src/Service/User/Auth/AuthModule.php
@@ -22,14 +22,6 @@ class AuthModule implements Module {
 					/** @var UrlProvider $urlProvider */
 					$urlProvider = $c->get(UrlProvider::class);
 					return "http://".$urlProvider->getUrl($wgAuthServiceName)."/";
-			} )
-			->bind( HeliosClientImpl::CLIENT_ID )->to( function () {
-					global $wgHeliosClientId;
-					return $wgHeliosClientId;
-			} )
-			->bind( HeliosClientImpl::CLIENT_SECRET )->to( function () {
-					global $wgHeliosClientSecret;
-					return $wgHeliosClientSecret;
 			} );
 	}
 }


### PR DESCRIPTION
Since we don't implement Oauth2 and client credentials are not required this should simplify implementation and help avoid errors with credentials mismatch.

/cc @Wikia/services-team @wladekb @owend @mixth-sense 
