### PR TITLE
SEO-50 Update the title for Special:AdminDashboard

### DIFF
--- a/extensions/wikia/AdminDashboard/AdminDashboardLogic.class.php
+++ b/extensions/wikia/AdminDashboard/AdminDashboardLogic.class.php
@@ -152,7 +152,9 @@ class AdminDashboardLogic {
 	 */
 	static function onWikiaHtmlTitleExtraParts( Title $title, array &$extraParts ) {
 		if ( self::displayAdminDashboard( F::app(), $title ) ) {
-			$extraParts = [ wfMessage( 'admindashboard-header' ) ];
+			if ( !$title->isSpecial( 'AdminDashboard' ) ) {
+				$extraParts = [ wfMessage( 'admindashboard-header' ) ];
+			}
 		}
 		return true;
 	}

--- a/extensions/wikia/AdminDashboard/AdminDashboardLogic.class.php
+++ b/extensions/wikia/AdminDashboard/AdminDashboardLogic.class.php
@@ -151,10 +151,8 @@ class AdminDashboardLogic {
 	 * @return bool
 	 */
 	static function onWikiaHtmlTitleExtraParts( Title $title, array &$extraParts ) {
-		if ( self::displayAdminDashboard( F::app(), $title ) ) {
-			if ( !$title->isSpecial( 'AdminDashboard' ) ) {
-				$extraParts = [ wfMessage( 'admindashboard-header' ) ];
-			}
+		if ( self::displayAdminDashboard( F::app(), $title ) && !$title->isSpecial( 'AdminDashboard' ) ) {
+			$extraParts = [ wfMessage( 'admindashboard-header' ) ];
 		}
 		return true;
 	}


### PR DESCRIPTION
The title is now "AdminDashboard - AdminDashboard - Xyz Wiki - Wikia".
We want it to be "AdminDashboard - Xyz Wiki - Wikia".
