### PR TITLE
Update ApiService to support Helios user token

### DIFF
--- a/extensions/wikia/WallNotifications/WallNotificationEntity.class.php
+++ b/extensions/wikia/WallNotifications/WallNotificationEntity.class.php
@@ -145,7 +145,7 @@ class WallNotificationEntity {
 			'useMasterDB' => $useMasterDB,
 		];
 
-		$response = ApiService::foreignCall( $dbName, $params, ApiService::WIKIA );
+		$response = ApiService::foreignCall( $dbName, $params, ApiService::WIKIA, /* loginAsUser */ true );
 		if ( !empty( $response['status'] ) && $response['status'] == 'ok' ) {
 			$this->parentTitleDbKey = $response['parentTitleDbKey'];
 			$this->msgText = $response['msgText'];

--- a/includes/wikia/services/ApiService.class.php
+++ b/includes/wikia/services/ApiService.class.php
@@ -114,7 +114,6 @@ class ApiService extends Service {
 	 * @return array $options
 	 */
 	public static function loginAsUser() {
-		global $wgEnableHeliosExt;
 		$app = F::app();
 
 		$options = array();
@@ -135,8 +134,8 @@ class ApiService extends Service {
 			$cookie .= $app->wg->CookiePrefix.$key.'='.$value.';';
 		}
 
-		if ( $wgEnableHeliosExt ) {
-			$token = \Wikia\Helios\User::getAccessToken($app->wg->Request);
+		if ( $app->wg->EnableHeliosExt ) {
+			$token = \Wikia\Helios\User::getAccessToken( $app->wg->Request );
 			if ( !empty($token) ) {
 				$cookie .= HeliosCookieHelper::ACCESS_TOKEN_COOKIE_NAME . "=" . $token . ";";
 			}

--- a/includes/wikia/services/ApiService.class.php
+++ b/includes/wikia/services/ApiService.class.php
@@ -1,4 +1,6 @@
 <?php
+use \Wikia\Service\User\Auth\HeliosCookieHelper;
+
 class ApiService extends Service {
 
 	/**
@@ -112,6 +114,7 @@ class ApiService extends Service {
 	 * @return array $options
 	 */
 	public static function loginAsUser() {
+		global $wgEnableHeliosExt;
 		$app = F::app();
 
 		$options = array();
@@ -132,6 +135,12 @@ class ApiService extends Service {
 			$cookie .= $app->wg->CookiePrefix.$key.'='.$value.';';
 		}
 
+		if ( $wgEnableHeliosExt ) {
+			$token = \Wikia\Helios\User::getAccessToken($app->wg->Request);
+			if ( !empty($token) ) {
+				$cookie .= HeliosCookieHelper::ACCESS_TOKEN_COOKIE_NAME . "=" . $token . ";";
+			}
+		}
 		$options['curlOptions'] = array( CURLOPT_COOKIE => $cookie );
 
 		return $options;

--- a/includes/wikia/services/tests/ApiServiceTest.php
+++ b/includes/wikia/services/tests/ApiServiceTest.php
@@ -1,0 +1,60 @@
+<?php
+
+
+class ApiAccessServiceTest extends \WikiaBaseTest {
+
+	public function testCall() {
+
+		$this->markTestSkipped("testing");
+		$mockResults = array("key", "value");
+
+		$apiMock = $this->mockClassWithMethods("ApiMain", array ('execute' => null, 'getResultData' => $mockResults));
+
+		$result = ApiService::call(array());
+
+		$this->assertEquals($result, $mockResults);
+
+	}
+
+	public function testForeignCall() {
+
+		$this->markTestSkipped("testing");
+		# used by private method ApiService::getHostByDbName
+		$this->mockStaticMethod("WikiFactory", 'DBtoID', "1");
+		$this->mockStaticMethod("WikiFactory", 'getVarValueByName', "foo.wikia.com");
+
+		$fakeJson = '{"a": "b"}'; // some non-null json formatted data
+		$httpMock = $this->mockStaticMethod("Http", 'get', $fakeJson);
+
+		$result = ApiService::foreignCall("foo", array());
+
+		$this->assertEquals($result, json_decode($fakeJson, true));
+
+	}
+
+	public function testLoginAsUser() {
+
+		# 2 methods and 1 var used by private method ApiService::getHostByDbName, not directly mockable
+		$this->mockStaticMethod("WikiFactory", 'DBtoID', "1");
+		$this->mockStaticMethod("WikiFactory", 'getVarValueByName', "foo.wikia.com");
+		#turn off special case url building inside getHostByDbName
+		$this->mockGlobalVariable("wgDevelEnvironment", false);
+
+		# user data doesn't matter, just make sure the function is called and the data is passed along to Http::get
+		$fakeUserData = array("curlOptions" => "COOKIE_STUFF");
+		$this->mockStaticMethod("ApiService", "loginAsUser", $fakeUserData );
+
+		$fakeJson = '{"a": "b"}'; // any non-null json formatted data
+		$fakeUrl = "foo.wikia.com/wikia.php?format=json";  // with our fake data, this is the fake url the code builds
+        $mockHttp = $this->getStaticMethodMock( 'Http', 'get' );
+        $mockHttp->expects( $this->once() )
+        		->method('get')
+        		->with($fakeUrl, 'default', $fakeUserData )
+        		->will($this->returnValue($fakeJson));
+
+        // test that calling with setUser==true calls loginAsUser and passes the returned data to Http::get as $options
+		$result = ApiService::foreignCall("foo", array(), "wikia.php", true);
+
+		$this->assertEquals($result, json_decode($fakeJson, true));
+	}
+ }

--- a/includes/wikia/services/tests/ApiServiceTest.php
+++ b/includes/wikia/services/tests/ApiServiceTest.php
@@ -5,20 +5,15 @@ class ApiAccessServiceTest extends \WikiaBaseTest {
 
 	public function testCall() {
 
-		$this->markTestSkipped("testing");
 		$mockResults = array("key", "value");
-
 		$apiMock = $this->mockClassWithMethods("ApiMain", array ('execute' => null, 'getResultData' => $mockResults));
 
 		$result = ApiService::call(array());
-
 		$this->assertEquals($result, $mockResults);
-
 	}
 
 	public function testForeignCall() {
 
-		$this->markTestSkipped("testing");
 		# used by private method ApiService::getHostByDbName
 		$this->mockStaticMethod("WikiFactory", 'DBtoID', "1");
 		$this->mockStaticMethod("WikiFactory", 'getVarValueByName', "foo.wikia.com");
@@ -27,9 +22,7 @@ class ApiAccessServiceTest extends \WikiaBaseTest {
 		$httpMock = $this->mockStaticMethod("Http", 'get', $fakeJson);
 
 		$result = ApiService::foreignCall("foo", array());
-
 		$this->assertEquals($result, json_decode($fakeJson, true));
-
 	}
 
 	public function testLoginAsUser() {
@@ -54,7 +47,6 @@ class ApiAccessServiceTest extends \WikiaBaseTest {
 
         // test that calling with setUser==true calls loginAsUser and passes the returned data to Http::get as $options
 		$result = ApiService::foreignCall("foo", array(), "wikia.php", true);
-
 		$this->assertEquals($result, json_decode($fakeJson, true));
 	}
  }

--- a/includes/wikia/services/tests/ApiServiceTest.php
+++ b/includes/wikia/services/tests/ApiServiceTest.php
@@ -33,19 +33,19 @@ class ApiAccessServiceTest extends \WikiaBaseTest {
 		#turn off special case url building inside getHostByDbName
 		$this->mockGlobalVariable("wgDevelEnvironment", false);
 
-		# user data doesn't matter, just make sure the function is called and the data is passed along to Http::get
+		# user data doesn't matter, just make sure loginAsJson is called and the data is passed along to Http::get
 		$fakeUserData = array("curlOptions" => "COOKIE_STUFF");
 		$this->mockStaticMethod("ApiService", "loginAsUser", $fakeUserData );
 
 		$fakeJson = '{"a": "b"}'; // any non-null json formatted data
 		$fakeUrl = "foo.wikia.com/wikia.php?format=json";  // with our fake data, this is the fake url the code builds
-        $mockHttp = $this->getStaticMethodMock( 'Http', 'get' );
-        $mockHttp->expects( $this->once() )
-        		->method('get')
-        		->with($fakeUrl, 'default', $fakeUserData )
-        		->will($this->returnValue($fakeJson));
+		$mockHttp = $this->getStaticMethodMock( 'Http', 'get' );
+		$mockHttp->expects( $this->once() )
+				->method('get')
+				->with($fakeUrl, 'default', $fakeUserData )
+				->will($this->returnValue($fakeJson));
 
-        // test that calling with setUser==true calls loginAsUser and passes the returned data to Http::get as $options
+		// test that calling with setUser==true calls loginAsUser and passes the returned data to Http::get as $options
 		$result = ApiService::foreignCall("foo", array(), "wikia.php", true);
 		$this->assertEquals($result, json_decode($fakeJson, true));
 	}


### PR DESCRIPTION
MAIN-6612 / SUS-293 / SUS-158

WallNotification uses ApiService::foreignCall but was not passing user credentials. 
ApiService didn't support Helios token for user credentials
This patch updates ApiService and adds unit tests

@Wikia/sustaining-team
