### PR TITLE
PLATFORM-2008: handle AMQP exceptions gracefully

### DIFF
--- a/extensions/wikia/IndexingPipeline/ConnectionBase.class.php
+++ b/extensions/wikia/IndexingPipeline/ConnectionBase.class.php
@@ -3,6 +3,7 @@
 namespace Wikia\IndexingPipeline;
 
 use PhpAmqpLib\Connection\AMQPConnection;
+use PhpAmqpLib\Exception\AMQPExceptionInterface;
 use PhpAmqpLib\Message\AMQPMessage;
 use Wikia\Util\RequestId;
 
@@ -38,8 +39,9 @@ class ConnectionBase {
 	 * @param $body
 	 */
 	public function publish( $routingKey, $body ) {
-		$channel = $this->getChannel();
 		try {
+			$channel = $this->getChannel();
+
 			$channel->basic_publish(
 				new AMQPMessage( json_encode( $body ), [
 					'delivery_mode' => self::DURABLE_MESSAGE,
@@ -50,8 +52,11 @@ class ConnectionBase {
 				$this->exchange,
 				$routingKey
 			);
-		} catch ( \Exception $e ) {
-			\Wikia\Logger\WikiaLogger::instance()->error( $e->getMessage() );
+		} catch ( AMQPExceptionInterface $e ) {
+			\Wikia\Logger\WikiaLogger::instance()->error( __METHOD__, [
+				'exception' => $e,
+				'routing_key' => $routingKey,
+			] );
 		}
 	}
 

--- a/includes/Exception.php
+++ b/includes/Exception.php
@@ -596,6 +596,13 @@ class MWExceptionHandler {
 			} else {
 				self::escapeEchoAndDie( $message );
 			}
+
+			# Wikia change - begin
+			# @see PLATFORM-2008 - report non-MediawWiki exceptions to ELK
+			Wikia\Logger\WikiaLogger::instance()->error( __METHOD__ . ' - unexpected non-MediaWiki exception encountered', [
+				'exception' => $e,
+			] );
+			# Wikia change - end
 		}
 	}
 

--- a/includes/wikia/tasks/AsyncTaskList.class.php
+++ b/includes/wikia/tasks/AsyncTaskList.class.php
@@ -13,7 +13,7 @@ use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Connection\AMQPConnection;
 use PhpAmqpLib\Message\AMQPMessage;
 use PhpAmqpLib\Exception\AMQPRuntimeException;
-use PhpAmqpLib\Exception\AMQPTimeoutException;
+use PhpAmqpLib\Exception\AMQPExceptionInterface;
 use Wikia\Logger\WikiaLogger;
 use Wikia\Tasks\Queues\ParsoidPurgePriorityQueue;
 use Wikia\Tasks\Queues\ParsoidPurgeQueue;
@@ -273,8 +273,7 @@ class AsyncTaskList {
 	 *
 	 * @param AMQPChannel $channel channel to publish messages to, if part of a batch
 	 * @return string the task list's id
-	 * @throws \PhpAmqpLib\Exception\AMQPRuntimeException
-	 * @throws \PhpAmqpLib\Exception\AMQPTimeoutException
+	 * @throws AMQPExceptionInterface
 	 */
 	public function queue( AMQPChannel $channel = null ) {
 		global $wgUser;
@@ -321,9 +320,7 @@ class AsyncTaskList {
 				$connection = $this->connection();
 				$channel = $connection->channel();
 				$channel->basic_publish( $message, '', $this->getQueue()->name() );
-			} catch ( AMQPRuntimeException $e ) {
-				$exception = $e;
-			} catch ( AMQPTimeoutException $e ) {
+			} catch ( AMQPExceptionInterface $e ) {
 				$exception = $e;
 			}
 
@@ -360,8 +357,7 @@ class AsyncTaskList {
 
 	/**
 	 * @return AMQPConnection connection to message broker
-	 * @throws AMQPRuntimeException
-	 * @throws AMQPTimeoutException
+	 * @throws AMQPExceptionInterface
 	 */
 	protected function connection() {
 		if ( $this->connection == null ) {
@@ -437,9 +433,7 @@ class AsyncTaskList {
 
 		try {
 			$connection = self::getConnection();
-		} catch ( AMQPRuntimeException $e ) {
-			return $logError( $e );
-		} catch ( AMQPTimeoutException $e ) {
+		} catch ( AMQPExceptionInterface $e ) {
 			return $logError( $e );
 		}
 
@@ -454,9 +448,7 @@ class AsyncTaskList {
 
 		try {
 			$channel->publish_batch();
-		} catch ( AMQPRuntimeException $e ) {
-			$exception = $e;
-		} catch ( AMQPTimeoutException $e ) {
+		} catch ( AMQPExceptionInterface $e ) {
 			$exception = $e;
 		}
 

--- a/includes/wikia/tasks/AsyncTaskList.class.php
+++ b/includes/wikia/tasks/AsyncTaskList.class.php
@@ -336,7 +336,7 @@ class AsyncTaskList {
 			}
 
 			if ( $exception !== null ) {
-				WikiaLogger::instance()->critical( 'AsyncTaskList::queue', [
+				WikiaLogger::instance()->error( 'AsyncTaskList::queue', [
 					'exception' => $exception
 				] );
 				return null;
@@ -427,7 +427,7 @@ class AsyncTaskList {
 	 */
 	public static function batch( $taskLists ) {
 		$logError = function( \Exception $e ) {
-			WikiaLogger::instance()->critical( 'AsyncTaskList::batch', [
+			WikiaLogger::instance()->error( 'AsyncTaskList::batch', [
 				'exception' => $e,
 				'caller' => wfGetCallerClassMethod( [ __CLASS__, 'Wikia\\Tasks\\Tasks\\BaseTask' ] ),
 			] );


### PR DESCRIPTION
[PLATFORM-2008](https://wikia-inc.atlassian.net/browse/PLATFORM-2008)

`ConnectionBase::getChannel` throws an exception when it cannot connect to Rabbit. Move this method to try / catch block and report the full exception (including the backtrace and the routing key) to Logstash.

Additionally:
- use the standard `error` level when reporting AMQP exceptions from `AsyncTaskList` class, so that Jira Reporter can find and report them
- log non-MediaWiki exceptions that reached the `MWExceptionHandler` (they were pushed to stderr in plain text with debug level)

For instance:

``` php
> (new Wikia\IndexingPipeline\ConnectionBase([]))->publish('foo', []);
```

will log:

``` json
{
  "@timestamp": "2016-03-11T10:40:28.924764+00:00",
  "@message": "Wikia\\IndexingPipeline\\ConnectionBase::publish",
  "@fields": {
    "db_name": "wikia",
    "city_id": "177",
    "maintenance_file": "/usr/wikia/source/app/maintenance/eval.php",
    "maintenance_class": "CommandLineInc",
    "request_id": "mw56e2a085595dd6.61831613"
  },
  "@exception": {
    "class": "PhpAmqpLib\\Exception\\AMQPRuntimeException",
    "message": "Error Connecting to server(0): Failed to parse address \":\" ",
    "code": 0,
    "file": "/usr/wikia/source/app/lib/composer/videlalvaro/php-amqplib/PhpAmqpLib/Wire/IO/StreamIO.php:27",
    "trace": [
      "/usr/wikia/source/app/lib/composer/videlalvaro/php-amqplib/PhpAmqpLib/Connection/AMQPStreamConnection.php:21",
      "/usr/wikia/source/app/extensions/wikia/IndexingPipeline/ConnectionBase.class.php:72",
      "/usr/wikia/source/app/extensions/wikia/IndexingPipeline/ConnectionBase.class.php:78",
      "/usr/wikia/source/app/extensions/wikia/IndexingPipeline/ConnectionBase.class.php:64",
      "/usr/wikia/source/app/extensions/wikia/IndexingPipeline/ConnectionBase.class.php:42",
      "/usr/wikia/source/app/maintenance/eval.php(88) : eval()d code:1",
      "/usr/wikia/source/app/maintenance/eval.php:88"
    ]
  },
  "@context": {
    "routing_key": "foo"
  }
}
```

@wladekb / @SebastianMarzjan 
