### PR TITLE
PLATFORM-1788: use 30s timeout for Swift's PUT requests

### DIFF
--- a/extensions/SwiftCloudFiles/php-cloudfiles-1.7.10/cloudfiles_http.php
+++ b/extensions/SwiftCloudFiles/php-cloudfiles-1.7.10/cloudfiles_http.php
@@ -121,6 +121,8 @@ class CF_Http
     private $_cdn_acl_user_agent;
     private $_cdn_acl_referrer;
 
+    const PUT_TIMEOUT_MS = 30000; # Wikia change / PLATFORM-1788
+
     function __construct($api_version)
     {
         $this->dbug = False;
@@ -866,6 +868,7 @@ class CF_Http
         }
 
         $this->_init($conn_type);
+        curl_setopt($this->connections[$conn_type], CURLOPT_TIMEOUT_MS, self::PUT_TIMEOUT_MS); # Wikia change / PLATFORM-1788
         curl_setopt($this->connections[$conn_type],
                 CURLOPT_INFILE, $fp);
         if (!$obj->content_length) {


### PR DESCRIPTION
[PLATFORM-1788](https://wikia-inc.atlassian.net/browse/PLATFORM-1788)

It's better than no timeout at all that causes `MigrateImagesBetweenSwiftDC` script to hang on copying files from SJC to RES

@jcellary  / @ljagiello 
