### PR TITLE
MAIN-6631: Fix bug by using variable that is actually defined

### DIFF
--- a/extensions/VisualEditor/VisualEditor.hooks.php
+++ b/extensions/VisualEditor/VisualEditor.hooks.php
@@ -437,7 +437,7 @@ class VisualEditorHooks {
 
 		foreach ( $veConfig->get( 'VisualEditorPreferenceModules' ) as $pref => $module ) {
 			$vars['wgVisualEditorConfig']['defaultUserOptions'][$pref] =
-				$defaultUserOptions[$pref];
+				$wgDefaultUserOptions[$pref];
 		}
 
 		return true;


### PR DESCRIPTION
Explanation: In newer version of MW globals are usually not directly used but instead they are accessed via context object and often assigned to local variables - in this case it was $defaultUserOptions. However in our version of MW we don't use contexts so we refer to those global variables directly - as someone (maybe me) was updating this code to use globals directly that person forgot to update this particular reference.
