### PR TITLE
CE-3486 Add a method to get an anti-CSRF token and adjust the API

### DIFF
--- a/includes/wikia/api/UserFeedbackStorageApiController.class.php
+++ b/includes/wikia/api/UserFeedbackStorageApiController.class.php
@@ -39,7 +39,7 @@ class UserFeedbackStorageApiController extends WikiaApiController {
 	 * @responseParam string editToken
 	 */
 	public function getEditToken() {
-		$this->response->setFormat('json');
+		$this->response->setFormat( WikiaResponse::FORMAT_JSON );
 		$this->response->setVal( 'token', $this->getContext()->getUser()->getEditToken() );
 	}
 

--- a/includes/wikia/api/UserFeedbackStorageApiController.class.php
+++ b/includes/wikia/api/UserFeedbackStorageApiController.class.php
@@ -19,8 +19,8 @@ class UserFeedbackStorageApiController extends WikiaApiController {
 	 * @throws MissingParameterApiException
 	 */
 	public function saveUserFeedback() {
-		$this->checkWriteRequest();
 		$request = $this->getRequest();
+		$this->verifyRequest( $request );
 
 		$requestParams = $this->getRequestParams( $request );
 
@@ -35,6 +35,20 @@ class UserFeedbackStorageApiController extends WikiaApiController {
 	}
 
 	/**
+	 * Verifies if a request was posted and comes from a wikia's domain.
+	 * @param IRequest $request
+	 * @return bool
+	 * @throws BadRequestApiException
+	 */
+	private function verifyRequest( IRequest $request ) {
+		if ( $request->wasPosted() && preg_match( '/wikia(\-dev)?\.com$/', $_SERVER['HTTP_HOST'] ) ) {
+			return true;
+		} else {
+			throw new BadRequestApiException;
+		}
+	}
+
+	/**
 	 * @param IRequest $request
 	 * @return array
 	 * @throws MissingParameterApiException
@@ -43,7 +57,6 @@ class UserFeedbackStorageApiController extends WikiaApiController {
 		$requestParams = [];
 		$positiveIntRequired = [
 			'experimentId' => 'experiment_id',
-			'variationId' => 'variation_id',
 			'wikiId' => 'wiki_id',
 			'pageId' => 'page_id',
 		];
@@ -59,7 +72,8 @@ class UserFeedbackStorageApiController extends WikiaApiController {
 		}
 
 		$requestParams = $requestParams + [
-				'user_id' => $request->getInt( 'userId' ),
+				'user_id' => $this->getContext()->getUser()->getId(),
+				'variation_id' => $this->getInt( 'variationId' ),
 				'feedback' => $request->getVal( 'feedback', '' ),
 				'feedback_impressions_count' => $request->getInt( 'feedbackImpressionsCount' ),
 				'feedback_previous_count' => $request->getInt( 'feedbackPreviousCount' ),

--- a/includes/wikia/api/UserFeedbackStorageApiController.class.php
+++ b/includes/wikia/api/UserFeedbackStorageApiController.class.php
@@ -73,7 +73,7 @@ class UserFeedbackStorageApiController extends WikiaApiController {
 
 		$requestParams = $requestParams + [
 				'user_id' => $this->getContext()->getUser()->getId(),
-				'variation_id' => $this->getInt( 'variationId' ),
+				'variation_id' => $request->getInt( 'variationId' ),
 				'feedback' => $request->getVal( 'feedback', '' ),
 				'feedback_impressions_count' => $request->getInt( 'feedbackImpressionsCount' ),
 				'feedback_previous_count' => $request->getInt( 'feedbackPreviousCount' ),

--- a/includes/wikia/api/UserFeedbackStorageApiController.class.php
+++ b/includes/wikia/api/UserFeedbackStorageApiController.class.php
@@ -19,8 +19,8 @@ class UserFeedbackStorageApiController extends WikiaApiController {
 	 * @throws MissingParameterApiException
 	 */
 	public function saveUserFeedback() {
+		$this->checkWriteRequest();
 		$request = $this->getRequest();
-		$this->verifyRequest( $request );
 
 		$requestParams = $this->getRequestParams( $request );
 
@@ -32,20 +32,6 @@ class UserFeedbackStorageApiController extends WikiaApiController {
 		}
 
 		$this->response->setVal( 'status', $status );
-	}
-
-	/**
-	 * Verifies if a request was posted and comes from a wikia's domain.
-	 * @param IRequest $request
-	 * @return bool
-	 * @throws BadRequestApiException
-	 */
-	private function verifyRequest( IRequest $request ) {
-		if ( $request->wasPosted() && preg_match( '/wikia(\-dev)?\.com$/', $_SERVER['HTTP_HOST'] ) ) {
-			return true;
-		} else {
-			throw new BadRequestApiException;
-		}
 	}
 
 	/**

--- a/includes/wikia/api/UserFeedbackStorageApiController.class.php
+++ b/includes/wikia/api/UserFeedbackStorageApiController.class.php
@@ -39,6 +39,7 @@ class UserFeedbackStorageApiController extends WikiaApiController {
 	 * @responseParam string editToken
 	 */
 	public function getEditToken() {
+		$this->response->setFormat('json');
 		$this->response->setVal( 'token', $this->getContext()->getUser()->getEditToken() );
 	}
 

--- a/includes/wikia/api/UserFeedbackStorageApiController.class.php
+++ b/includes/wikia/api/UserFeedbackStorageApiController.class.php
@@ -8,10 +8,10 @@ class UserFeedbackStorageApiController extends WikiaApiController {
 	/**
 	 * Saves user feedback to a temporary table in the portable_flags db
 	 *
-	 * @requestParam int wikiId
-	 * @requestParam int pageId
-	 * @requestParam int experimentId
-	 * @requestParam int variationId
+	 * @requestParam int wikiId (required)
+	 * @requestParam string pageTitle (required)
+	 * @requestParam string experimentId (required)
+	 * @requestParam string variationId (required)
 	 * @requestParam int userId
 	 * @requestParam string feedback
 	 * @requestParam int feedback_impression_count
@@ -50,25 +50,30 @@ class UserFeedbackStorageApiController extends WikiaApiController {
 	 */
 	private function getRequestParams( IRequest $request ) {
 		$requestParams = [];
-		$positiveIntRequired = [
+		$requiredParams = [
 			'experimentId' => 'experiment_id',
-			'wikiId' => 'wiki_id',
-			'pageId' => 'page_id',
+			'pageTitle' => 'page_title',
+			'variationId' => 'variation_id',
 		];
 
-		foreach ( $positiveIntRequired as $paramName => $dbFieldName ) {
-			$paramValue = $request->getInt( $paramName );
+		foreach ( $requiredParams as $paramName => $dbFieldName ) {
+			$paramValue = $request->getVal( $paramName );
 
-			if ( $paramValue === 0 ) {
+			if ( empty( $paramValue ) ) {
 				throw new MissingParameterApiException( $paramName );
 			} else {
 				$requestParams[$dbFieldName] = $paramValue;
 			}
 		}
 
+		$wikiId = $request->getInt( 'wikiId' );
+		if ( $wikiId === 0 ) {
+			throw new MissingParameterApiException( 'wikiId' );
+		}
+
 		$requestParams = $requestParams + [
+				'wiki_id' => $wikiId,
 				'user_id' => $this->getContext()->getUser()->getId(),
-				'variation_id' => $request->getInt( 'variationId' ),
 				'feedback' => $request->getVal( 'feedback', '' ),
 				'feedback_impressions_count' => $request->getInt( 'feedbackImpressionsCount' ),
 				'feedback_previous_count' => $request->getInt( 'feedbackPreviousCount' ),

--- a/includes/wikia/api/UserFeedbackStorageApiController.class.php
+++ b/includes/wikia/api/UserFeedbackStorageApiController.class.php
@@ -16,6 +16,7 @@ class UserFeedbackStorageApiController extends WikiaApiController {
 	 * @requestParam string feedback
 	 * @requestParam int feedback_impression_count
 	 * @requestParam int feedback_previous_count
+	 * @responseParam bool status
 	 * @throws MissingParameterApiException
 	 */
 	public function saveUserFeedback() {
@@ -32,6 +33,13 @@ class UserFeedbackStorageApiController extends WikiaApiController {
 		}
 
 		$this->response->setVal( 'status', $status );
+	}
+
+	/**
+	 * @responseParam string editToken
+	 */
+	public function getEditToken() {
+		$this->response->setVal( 'token', $this->getContext()->getUser()->getEditToken() );
 	}
 
 	/**


### PR DESCRIPTION
Hello @Wikia/community-engineering !

Since the [API:Info](https://www.mediawiki.org/wiki/API:Info) requires users to be able to edit a specific article to get their editToken - I've implemented a simple method to that does just what we need - returns a token to protect against CSRF.

A small tweak to `variationId` is introduced to allow a zero value for it and retrieving a `userId` on the backend side.
