### PR TITLE
PLATFORM-1909: runBackups - log commands and errors + prevent uploading broken dumps to S3

### DIFF
--- a/extensions/wikia/WikiFactory/Dumps/DumpsOnDemand.php
+++ b/extensions/wikia/WikiFactory/Dumps/DumpsOnDemand.php
@@ -189,7 +189,10 @@ class DumpsOnDemand {
 			's3://wikia_xml_dumps/'
 			. DumpsOnDemand::getPath( basename( $sPath ) )
 		);
+
+		$size = filesize( $sPath );
 		$sPath = wfEscapeShellArg( $sPath );
+
 		$sCmd = 'sudo /usr/bin/s3cmd -c /root/.s3cfg --add-header=Content-Disposition:attachment';
 		if ( !is_null( $sMimeType ) ) {
 			$sMimeType = wfEscapeShellArg( $sMimeType );
@@ -197,9 +200,14 @@ class DumpsOnDemand {
 		}
 		$sCmd .= ($bPublic)? ' --acl-public' : '';
 		$sCmd .= " put {$sPath} {$sDestination}";
+
+		Wikia::log( __METHOD__, "info", "Put {$sPath} to Amazon S3 storage: command: {$sCmd} size: {$size}", true, true);
+
 		wfShellExec( $sCmd, $iStatus );
+
 		$time = Wikia::timeDuration( wfTime() - $time );
 		Wikia::log( __METHOD__, "info", "Put {$sPath} to Amazon S3 storage: status: {$iStatus}, time: {$time}", true, true);
+
 		return $iStatus;
 	}
 

--- a/extensions/wikia/WikiFactory/Dumps/runBackups.php
+++ b/extensions/wikia/WikiFactory/Dumps/runBackups.php
@@ -10,8 +10,8 @@
  * SERVER_ID=177 php runBackups.php  -- generate current backups for all
  *	active wikis
  *
- * SERVER_ID=177 php runBackups.php  --both --id=177 -- generate full & current
- * 	backups for city_id = 177
+ * SERVER_ID=177 php runBackups.php  --both --id=177 --s3 -- generate full & current
+ * 	backups for city_id = 177 and upload it to S3
  *
  * SERVER_ID=177 php runBackups.php  --both --db=wikicities -- generate full & current
  * 	backups for city_dbname = wikicities
@@ -111,65 +111,70 @@ function runBackups( $from, $to, $full, $options ) {
 			array( "ORDER BY" => "city_id" )
 	);
 	while( $row = $dbw->fetchObject( $sth ) ) {
-		/**
-		 * get cluster for this wiki
-		 */
-		$cluster = WikiFactory::getVarValueByName( "wgDBcluster", $row->city_id );
-		$server  = wfGetDB( DB_SLAVE, 'dumps', $row->city_dbname )->getProperty( "mServer" );
-		/**
-		 * build command
-		 */
-		$status  = false;
-
 		$basedir = getDirectory( $row->city_dbname, $hide, $use_temp );
 
 		if( $full || $both ) {
-			$path = sprintf("%s/%s_pages_full.xml.7z", $basedir, $row->city_dbname );
-			$time = wfTime();
-			Wikia::log( __METHOD__, "info", "{$row->city_id} {$row->city_dbname} {$path}", true, true );
-			$cmd = array(
-				"SERVER_ID={$row->city_id}",
-				"php",
-				"{$IP}/maintenance/dumpBackup.php",
-				"--conf {$wgWikiaLocalSettingsPath}",
-				"--aconf {$wgWikiaAdminSettingsPath}",
-				"--full",
-				"--xml",
-				"--quiet",
-				"--server=$server",
-				"--output=".DumpsOnDemand::DEFAULT_COMPRESSION_FORMAT.":{$path}"
-			);
-			wfShellExec( implode( " ", $cmd ), $status );
-			$time = Wikia::timeDuration( wfTime() - $time );
-			Wikia::log( __METHOD__, "info", "{$row->city_id} {$row->city_dbname} status: {$status}, time: {$time}", true, true );
-			if ( $s3 && 0 == DumpsOnDemand::putToAmazonS3( $path, !$hide,  MimeMagic::singleton()->guessMimeType( $path ) ) ) {
-				unlink( $path );
-			}
-
+			doDumpBackup( $row, sprintf("%s/%s_pages_full.xml.7z", $basedir, $row->city_dbname ), [ '--full' ] );
 		}
 		if( !$full || $both ) {
-			$path = sprintf("%s/%s_pages_current.xml.7z", $basedir, $row->city_dbname );
-			$time = wfTime();
-			Wikia::log( __METHOD__, "info", "{$row->city_id} {$row->city_dbname} {$path}", true, true);
-			$cmd = array(
-				"SERVER_ID={$row->city_id}",
-				"php",
-				"{$IP}/maintenance/dumpBackup.php",
-				"--conf {$wgWikiaLocalSettingsPath}",
-				"--aconf {$wgWikiaAdminSettingsPath}",
-				"--current",
-				"--xml",
-				"--quiet",
-				"--server=$server",
-				"--output=".DumpsOnDemand::DEFAULT_COMPRESSION_FORMAT.":{$path}"
-			);
-			wfShellExec( implode( " ", $cmd ), $status );
-			$time = Wikia::timeDuration( wfTime() - $time );
-			Wikia::log( __METHOD__, "info", "{$row->city_id} {$row->city_dbname} status: {$status}, time: {$time}", true, true);
-			if ( $s3 && 0 == DumpsOnDemand::putToAmazonS3( $path, !$hide,  MimeMagic::singleton()->guessMimeType( $path ) ) ) {
-				unlink( $path );
+			doDumpBackup( $row, sprintf("%s/%s_pages_current.xml.7z", $basedir, $row->city_dbname ), [ '--current' ] );
+		}
+	}
+}
+
+/**
+ * Perform backup generation and upload to S3
+ *
+ * @param object $row wiki entry from city_list
+ * @param string $path where to upload the generated dump
+ * @param string $path where to upload the generated dump
+ * @param array $args optional extra arguments for dumpBackup.php
+ */
+function doDumpBackup( $row, $path, array $args = [] ) {
+	global $IP, $wgWikiaLocalSettingsPath, $wgWikiaAdminSettingsPath, $options;
+	$logger = Wikia\Logger\WikiaLogger::instance();
+
+	$time = wfTime();
+	Wikia::log( __METHOD__, "info", "{$row->city_id} {$row->city_dbname} {$path}", true, true);
+
+	$server = wfGetDB( DB_SLAVE, 'dumps', $row->city_dbname )->getProperty( "mServer" );
+	$cmd = implode( ' ', array_merge( [
+		"SERVER_ID={$row->city_id}",
+		"php",
+		"{$IP}/maintenance/dumpBackup.php",
+		"--conf {$wgWikiaLocalSettingsPath}",
+		"--aconf {$wgWikiaAdminSettingsPath}",
+		"--xml",
+		"--quiet",
+		"--server=$server",
+		"--output=".DumpsOnDemand::DEFAULT_COMPRESSION_FORMAT.":{$path}"
+	], $args ) );
+
+	Wikia::log( __METHOD__, "info", "{$row->city_id} {$row->city_dbname} command: {$cmd}", true, true);
+
+	$output = wfShellExec( $cmd, $status );
+	$time = Wikia::timeDuration( wfTime() - $time );
+
+	Wikia::log( __METHOD__, "info", "{$row->city_id} {$row->city_dbname} status: {$status}, time: {$time}", true, true);
+
+	if ( $status === 0 ) {
+		if ( isset( $options['s3'] ) ) {
+			$res = DumpsOnDemand::putToAmazonS3( $path, !isset( $options[ "hide" ] ),  MimeMagic::singleton()->guessMimeType( $path ) );
+			unlink( $path );
+
+			if ( $res !== 0 ) {
+				$logger->error( __METHOD__ . '::putToAmazonS3', [
+					'exception' => new Exception( 'putToAmazonS3 failed', $res ),
+					'row' => (array) $row,
+				] );
 			}
 		}
+	}
+	else {
+		$logger->error( __METHOD__ . '::dumpBackup', [
+			'exception' => new Exception( $cmd, $status ),
+			'row' => (array) $row,
+		]);
 	}
 }
 


### PR DESCRIPTION
[PLATFORM-1909](https://wikia-inc.atlassian.net/browse/PLATFORM-1909)

We sometimes get errors like `509 harrypotter status: 137, time: 4 min, 52 sec` (this means that `maintenance/dumpBackup.php` failed to run correctly). However, we still try to upload the XML dump file .Let's start with improving the errors logging (including the `dumpBackup.php` and s3 upload commands output and error codes).

Addresses the issue mentioned in #6118

@wladekb / @mixth-sense 
