### PR TITLE
Fix Sass support in ResourceLoader

### DIFF
--- a/includes/resourceloader/ResourceLoaderContext.php
+++ b/includes/resourceloader/ResourceLoaderContext.php
@@ -212,6 +212,10 @@ class ResourceLoaderContext {
 		return $this->version;
 	}
 
+	public function getSassParams() {
+		return $this->sassParams;
+	}
+
 	/**
 	 * @return bool
 	 */

--- a/includes/resourceloader/ResourceLoaderFileModule.php
+++ b/includes/resourceloader/ResourceLoaderFileModule.php
@@ -712,8 +712,7 @@ class ResourceLoaderFileModule extends ResourceLoaderModule {
 				break;
 			case self::FILE_TYPE_SASS:
 				$sassService = SassService::newFromFile($fileName);
-				$params = $context->getRequest()->getVal('sass_params');
-				$params = !empty($params) ? FormatJson::decode($params,true) : array();
+				$params = $context->getSassParams();
 				$sassService->setSassVariables($params);
 				return $sassService->getCss();
 				break;


### PR DESCRIPTION
The sass_params URL var is never set, but the Sass params are available in
the ResourceLoaderContext so use it to get the params instead.

/cc @macbre 
