### PR TITLE
ADEN-3016 fix for BackgroundChanger

### DIFF
--- a/extensions/wikia/AdEngine/js/template/skin.js
+++ b/extensions/wikia/AdEngine/js/template/skin.js
@@ -63,7 +63,7 @@ define('ext.wikia.adEngine.template.skin', [
 				adSkinStyle.background = 'url("' + params.skinImage + '") no-repeat top center #' + params.backgroundColor;
 			}
 
-			doc.body.className += ' background-ad';
+			doc.body.classList.add('background-ad');
 
 			adSkinStyle.position = 'fixed';
 			adSkinStyle.height = '100%';

--- a/skins/oasis/js/BackgroundChanger.js
+++ b/skins/oasis/js/BackgroundChanger.js
@@ -79,12 +79,11 @@ define('wikia.backgroundchanger', function()  {
 		if (nodeIndex > -1) {
 			$('link[data-background-changer]').attr('disabled', true);
 			$('link[data-background-changer="'+nodeIndex+'"]').attr('disabled', false);
-
 			onCssLoadCallBack();
 		} else {
-			loadedCss.push(sassUrl);
 			// load CSS and apply class changes to body element after loading
 			$.getCSS(sassUrl, function(link) {
+				loadedCss.push(sassUrl);
 				$(link).attr('data-background-changer', loadedCss.length-1);
 				onCssLoadCallBack();
 			});

--- a/skins/oasis/js/BackgroundChanger.js
+++ b/skins/oasis/js/BackgroundChanger.js
@@ -45,7 +45,7 @@ define('wikia.backgroundchanger', ['wikia.document'], function(doc)  {
 		// preload adskin image
 		imagePreload.src = options.skinImage;
 
-		var onCssLoadCallBak = function(options) {
+		var onCssLoadCallBack = function(options) {
 			if (options.skinImage !== '' && options.skinImageWidth > 0 && options.skinImageHeight > 0) {
 				if ((options.backgroundFixed === undefined) || !!options.backgroundFixed) {
 					$('body').addClass('background-fixed');
@@ -82,13 +82,13 @@ define('wikia.backgroundchanger', ['wikia.document'], function(doc)  {
 		if (nodeIndex > -1) {
 			$('link.backgroundChanger').attr('disabled', true);
 			$('link.backgroundChanger.cssNode' + nodeIndex).attr('disabled', false);
-			onCssLoadCallBak(options);
+			onCssLoadCallBack(options);
 		} else {
 			doc.loadedCss.push(sassUrl);
 			// load CSS and apply class changes to body element after loading
 			$.getCSS(sassUrl, function(link) {
 				link.className = 'backgroundChanger cssNode' + nodeIndex;
-				onCssLoadCallBak(options);
+				onCssLoadCallBack(options);
 			});
 		}
 	}

--- a/skins/oasis/js/BackgroundChanger.js
+++ b/skins/oasis/js/BackgroundChanger.js
@@ -6,8 +6,9 @@
  * @type {{load: Function}}
  */
 
-define('wikia.backgroundchanger', ['wikia.document'], function(doc)  {
+define('wikia.backgroundchanger', function()  {
 	'use strict';
+	var loadedCss = [];
 	/**
 	 * Load background.scss with params
 	 *
@@ -45,7 +46,7 @@ define('wikia.backgroundchanger', ['wikia.document'], function(doc)  {
 		// preload adskin image
 		imagePreload.src = options.skinImage;
 
-		var onCssLoadCallBack = function(options) {
+		var onCssLoadCallBack = function() {
 			if (options.skinImage !== '' && options.skinImageWidth > 0 && options.skinImageHeight > 0) {
 				if ((options.backgroundFixed === undefined) || !!options.backgroundFixed) {
 					$('body').addClass('background-fixed');
@@ -73,22 +74,19 @@ define('wikia.backgroundchanger', ['wikia.document'], function(doc)  {
 			}
 		};
 
-		if (!$.isArray(doc.loadedCss)) {
-			doc.loadedCss = [];
-		}
-
-		var nodeIndex = doc.loadedCss.indexOf(sassUrl);
+		var nodeIndex = loadedCss.indexOf(sassUrl);
 
 		if (nodeIndex > -1) {
-			$('link.backgroundChanger').attr('disabled', true);
-			$('link.backgroundChanger.cssNode' + nodeIndex).attr('disabled', false);
-			onCssLoadCallBack(options);
+			$('link[data-background-changer]').attr('disabled', true);
+			$('link[data-background-changer="'+nodeIndex+'"]').attr('disabled', false);
+
+			onCssLoadCallBack();
 		} else {
-			doc.loadedCss.push(sassUrl);
+			loadedCss.push(sassUrl);
 			// load CSS and apply class changes to body element after loading
 			$.getCSS(sassUrl, function(link) {
-				link.className = 'backgroundChanger cssNode' + nodeIndex;
-				onCssLoadCallBack(options);
+				$(link).attr('data-background-changer', loadedCss.length-1);
+				onCssLoadCallBack();
 			});
 		}
 	}

--- a/skins/oasis/js/BackgroundChanger.js
+++ b/skins/oasis/js/BackgroundChanger.js
@@ -78,13 +78,13 @@ define('wikia.backgroundchanger', function()  {
 
 		if (nodeIndex > -1) {
 			$('link[data-background-changer]').attr('disabled', true);
-			$('link[data-background-changer="'+nodeIndex+'"]').attr('disabled', false);
+			$('link[data-background-changer="'+sassUrl+'"]').attr('disabled', false);
 			onCssLoadCallBack();
 		} else {
 			// load CSS and apply class changes to body element after loading
 			$.getCSS(sassUrl, function(link) {
 				loadedCss.push(sassUrl);
-				$(link).attr('data-background-changer', loadedCss.length-1);
+				$(link).attr('data-background-changer', sassUrl);
 				onCssLoadCallBack();
 			});
 		}

--- a/skins/oasis/js/BackgroundChanger.js
+++ b/skins/oasis/js/BackgroundChanger.js
@@ -6,7 +6,7 @@
  * @type {{load: Function}}
  */
 
-define('wikia.backgroundchanger', function()  {
+define('wikia.backgroundchanger', ['wikia.document'], function(doc)  {
 	'use strict';
 	/**
 	 * Load background.scss with params
@@ -45,8 +45,7 @@ define('wikia.backgroundchanger', function()  {
 		// preload adskin image
 		imagePreload.src = options.skinImage;
 
-		// load CSS and apply class changes to body element after loading
-		$.getCSS(sassUrl, function() {
+		var onCssLoadCallBak = function(options) {
 			if (options.skinImage !== '' && options.skinImageWidth > 0 && options.skinImageHeight > 0) {
 				if ((options.backgroundFixed === undefined) || !!options.backgroundFixed) {
 					$('body').addClass('background-fixed');
@@ -72,7 +71,26 @@ define('wikia.backgroundchanger', function()  {
 			} else {
 				$('body').removeClass('background-dynamic background-not-tiled background-fixed');
 			}
-		});
+		};
+
+		if (!$.isArray(doc.loadedCss)) {
+			doc.loadedCss = [];
+		}
+
+		var nodeIndex = doc.loadedCss.indexOf(sassUrl);
+
+		if (nodeIndex > -1) {
+			$('link.backgroundChanger').attr('disabled', true);
+			$('link.backgroundChanger.cssNode' + nodeIndex).attr('disabled', false);
+			onCssLoadCallBak(options);
+		} else {
+			doc.loadedCss.push(sassUrl);
+			// load CSS and apply class changes to body element after loading
+			$.getCSS(sassUrl, function(link) {
+				link.className = 'backgroundChanger cssNode' + nodeIndex;
+				onCssLoadCallBak(options);
+			});
+		}
 	}
 
 	return {


### PR DESCRIPTION
This is a fix for BackgroundChanger.js - which was not prepared for switching backgrounds multiple times. The problem was that every time you switched background it needed to reload whole CSS stylesheet. For first switch it is OK, but if you switch to background that was already loaded - it was a waste of resources.

The solution is to provide local cache loaded backgrounds, disable not used stylesheets and enable the needed one. 
