### PR TITLE
(CE-3417) Make ImportJS respect ?usesitejs=0

### DIFF
--- a/extensions/wikia/ContentReview/ContentReview.hooks.php
+++ b/extensions/wikia/ContentReview/ContentReview.hooks.php
@@ -123,7 +123,11 @@ class Hooks {
 	 * @throws \MWException
 	 */
 	public function onSkinAfterBottomScripts( $skin, &$bottomScripts ) {
-		$bottomScripts .= ( new ImportJS() )->getImportScripts();
+		global $wgUseSiteJs;
+
+		if ( !empty( $wgUseSiteJs ) ) {
+			$bottomScripts .= ( new ImportJS() )->getImportScripts();
+		}
 
 		return true;
 	}

--- a/extensions/wikia/ContentReview/tests/ContentReviewHooksTest.php
+++ b/extensions/wikia/ContentReview/tests/ContentReviewHooksTest.php
@@ -50,4 +50,40 @@ class ContentReviewHooksTest extends WikiaBaseTest {
 
 		( new Wikia\ContentReview\Hooks() )->onUserLogoutComplete( $userMock, $injectHtml, '' );
 	}
+
+	/**
+	 * @dataProvider addingImportJSScriptsProvider
+	 */
+	public function testAddingImportJSScripts( $jsEnabled, $importScripts, $bottomScriptsResult ) {
+		$skinMock = $this->getMock( 'Skin' );
+		$this->mockGlobalVariable( 'wgUseSiteJs', $jsEnabled );
+		$importJSMock = $this->getMock( 'Wikia\ContentReview\ImportJS', [ 'getImportScripts' ] );
+
+		$importJSMock->expects( $this->any() )
+			->method( 'getImportScripts' )
+			->will( $this->returnValue( $importScripts ) );
+
+		$this->mockClass( 'Wikia\ContentReview\ImportJS', $importJSMock );
+
+		$bottomScripts = '';
+
+		( new Wikia\ContentReview\Hooks() )->onSkinAfterBottomScripts( $skinMock, $bottomScripts );
+
+		$this->assertEquals( $bottomScripts, $bottomScriptsResult );
+	}
+
+	public function addingImportJSScriptsProvider() {
+		return [
+			[
+				true,
+				'<script>(function(){importWikiaScriptPages(["Script.js"]);})();</script>',
+				'<script>(function(){importWikiaScriptPages(["Script.js"]);})();</script>',
+			],
+			[
+				false,
+				'<script>(function(){importWikiaScriptPages(["Script.js"]);})();</script>',
+				'',
+			],
+		];
+	}
 }


### PR DESCRIPTION
Using the ?usesitejs=0 URL parameter results in wgUseSiteJs being set to
false for a request. ImportJS should respect this parameter so we need to
check wgUseSiteJs before adding ImportJS scripts.

/cc @Wikia/community-engineering 
