### PR TITLE
doDumpBackup: redirect stderr to stdout and print errors

### DIFF
--- a/extensions/wikia/WikiFactory/Dumps/runBackups.php
+++ b/extensions/wikia/WikiFactory/Dumps/runBackups.php
@@ -140,7 +140,7 @@ function doDumpBackup( $row, $path, array $args = [] ) {
 	$server = wfGetDB( DB_SLAVE, 'dumps', $row->city_dbname )->getProperty( "mServer" );
 	$cmd = implode( ' ', array_merge( [
 		"SERVER_ID={$row->city_id}",
-		"php",
+		"php -d display_errors=1",
 		"{$IP}/maintenance/dumpBackup.php",
 		"--conf {$wgWikiaLocalSettingsPath}",
 		"--aconf {$wgWikiaAdminSettingsPath}",
@@ -149,6 +149,9 @@ function doDumpBackup( $row, $path, array $args = [] ) {
 		"--server=$server",
 		"--output=".DumpsOnDemand::DEFAULT_COMPRESSION_FORMAT.":{$path}"
 	], $args ) );
+
+	// redirect stderr to stdout, so it becames a part of $output
+	$cmd .= ' 2>&1';
 
 	Wikia::log( __METHOD__, "info", "{$row->city_id} {$row->city_dbname} command: {$cmd}", true, true);
 


### PR DESCRIPTION
[PLATFORM-1909](https://wikia-inc.atlassian.net/browse/PLATFORM-1909)

In order to be able to debug the issue with broken XML content dumps log more things - including stderr output from `dumpBackup.php` script and any PHP errors / warnings (via `-d display_errors=1`).

@jcellary 
