### PR TITLE
PLATFORM-1909: mark failed dumps in the database

### DIFF
--- a/extensions/wikia/WikiFactory/Dumps/maintenance/DumpsOnDemandCron.php
+++ b/extensions/wikia/WikiFactory/Dumps/maintenance/DumpsOnDemandCron.php
@@ -4,11 +4,7 @@ include __DIR__ . '/../../../../../maintenance/Maintenance.php';
 class DumpsOnDemandCron extends Maintenance {
     
     const PIDFILE = '/var/run/MediaWikiDumpsOnDemandCron.pid';
-    
-    public function __construct() {
-        parent::__construct();
-    }
-    
+
     public function execute() {
 
         global $wgExternalSharedDB;
@@ -49,13 +45,19 @@ class DumpsOnDemandCron extends Maintenance {
 
         $this->output( "INFO: Creating dumps for Wikia #{$sWikiaId}.\n" );
 
-        $sCommand = sprintf( 'SERVER_ID=177 php %s/extensions/wikia/WikiFactory/Dumps/runBackups.php --conf %s --id=%d --both --tmp --s3', $IP, $wgWikiaLocalSettingsPath, $sWikiaId );
-
-        wfShellExec( $sCommand, $iStatus );
+        $sCommand = sprintf( 'SERVER_ID=177 php %s/extensions/wikia/WikiFactory/Dumps/runBackups.php --conf %s --id=%d --both --tmp --s3 2>&1', $IP, $wgWikiaLocalSettingsPath, $sWikiaId );
+		$sOutput = wfShellExec( $sCommand, $iStatus );
 
         $oDB = wfGetDB( DB_MASTER, array(), $wgExternalSharedDB );
 
-        if ( $iStatus ) {
+		$logger = Wikia\Logger\WikiaLogger::instance();
+
+        if ( $iStatus > 0 ) {
+			$logger->error( __METHOD__ . ' - failed creating dumps', [
+				'exception' => new Exception( $sCommand, $iStatus ),
+				'output' => $sOutput,
+			] );
+
             $this->output( "ERROR: Failed creating dumps. Terminating.\n" );
             $oDB->update(
                 'dumps',
@@ -99,5 +101,5 @@ class DumpsOnDemandCron extends Maintenance {
     }
 }
 
-$maintClass = 'DumpsOnDemandCron';
+$maintClass = DumpsOnDemandCron::class;
 include RUN_MAINTENANCE_IF_MAIN;

--- a/extensions/wikia/WikiFactory/Dumps/maintenance/DumpsOnDemandCron.php
+++ b/extensions/wikia/WikiFactory/Dumps/maintenance/DumpsOnDemandCron.php
@@ -45,7 +45,7 @@ class DumpsOnDemandCron extends Maintenance {
 
         $this->output( "INFO: Creating dumps for Wikia #{$sWikiaId}.\n" );
 
-        $sCommand = sprintf( 'SERVER_ID=177 php %s/extensions/wikia/WikiFactory/Dumps/runBackups.php --conf %s --id=%d --both --tmp --s3 2>&1', $IP, $wgWikiaLocalSettingsPath, $sWikiaId );
+        $sCommand = sprintf( 'SERVER_ID=%d php %s/extensions/wikia/WikiFactory/Dumps/runBackups.php --conf %s --id=%d --both --tmp --s3 2>&1', Wikia::COMMUNITY_WIKI_ID, $IP, $wgWikiaLocalSettingsPath, $sWikiaId );
 		$sOutput = wfShellExec( $sCommand, $iStatus );
 
         $oDB = wfGetDB( DB_MASTER, array(), $wgExternalSharedDB );

--- a/extensions/wikia/WikiFactory/Dumps/maintenance/DumpsOnDemandCron.php
+++ b/extensions/wikia/WikiFactory/Dumps/maintenance/DumpsOnDemandCron.php
@@ -2,7 +2,7 @@
 include __DIR__ . '/../../../../../maintenance/Maintenance.php';
 
 class DumpsOnDemandCron extends Maintenance {
-    
+
     const PIDFILE = '/var/run/MediaWikiDumpsOnDemandCron.pid';
 
     public function execute() {
@@ -93,7 +93,7 @@ class DumpsOnDemandCron extends Maintenance {
             __METHOD__
         );
 
-        DumpsOnDemand::purgeLatestDumpInfo(intval($sWikiaId));
+        DumpsOnDemand::purgeLatestDumpInfo( intval( $sWikiaId ) );
 
         $this->output( "Done.\n" );
         unlink( self::PIDFILE );

--- a/extensions/wikia/WikiFactory/Dumps/runBackups.php
+++ b/extensions/wikia/WikiFactory/Dumps/runBackups.php
@@ -170,6 +170,8 @@ function doDumpBackup( $row, $path, array $args = [] ) {
 					'exception' => new Exception( 'putToAmazonS3 failed', $res ),
 					'row' => (array) $row,
 				] );
+
+				exit( 1 );
 			}
 		}
 	}
@@ -178,6 +180,8 @@ function doDumpBackup( $row, $path, array $args = [] ) {
 			'exception' => new Exception( $cmd, $status ),
 			'row' => (array) $row,
 		]);
+
+		exit( 2 );
 	}
 }
 


### PR DESCRIPTION
[PLATFORM-1909](https://wikia-inc.atlassian.net/browse/PLATFORM-1909)

Emit non-zero exit code when we fail to generate or upload XML content dump. Then we can mark a failed dump attempt in the database.

Thanks to this change whoever requested the dump will see the correct timestamp on [Special:Statistics](http://monsterhunter.wikia.com/wiki/Special:Statistics) and can always require dump generation once more.

@jcellary 
