### PR TITLE
ZipDirectoryReaderError: do not play dirty tricks with build-in PHP classes

### DIFF
--- a/includes/ZipDirectoryReader.php
+++ b/includes/ZipDirectoryReader.php
@@ -672,17 +672,21 @@ class ZipDirectoryReader {
  * Internal exception class. Will be caught by private code.
  */
 class ZipDirectoryReaderError extends Exception {
-	var $code;
 
-	function __construct( $code ) {
-		$this->code = $code;
-		parent::__construct( "ZipDirectoryReader error: $code" );
+	protected $errorCode;
+
+	/**
+	 * @param string $errorCode
+	 */
+	function __construct( $errorCode ) {
+		$this->errorCode = $errorCode;
+		parent::__construct( "ZipDirectoryReader error: $errorCode"  );
 	}
 
 	/**
 	 * @return mixed
 	 */
 	function getErrorCode() {
-		return $this->code;
+		return $this->errorCode;
 	}
 }


### PR DESCRIPTION
[PLATFORM-2027](https://wikia-inc.atlassian.net/browse/PLATFORM-2027)

Writing string to `Exception::$code` field was causing Apache segfaults after upgrading PHP to 5.6.11:

```
UploadBase::detectScript: checking for embedded scripts and HTML stuff
UploadBase::detectScript: no scripts found
ZipDirectoryReader: Fatal error: zip file lacks EOCDR signature. It probably isn't a zip file.
(segfault here)
```

Introduce a custom field in `ZipDirectoryReaderError` class instead.

@artursitarski / @wladekb 
