### PR TITLE
[PLATFORM-1999] Added global variable wgWikiaGlobalUserGroups

### DIFF
--- a/lib/Wikia/src/Service/User/Permissions/PermissionsConfigurationImpl.php
+++ b/lib/Wikia/src/Service/User/Permissions/PermissionsConfigurationImpl.php
@@ -258,6 +258,11 @@ class PermissionsConfigurationImpl implements PermissionsConfiguration {
 	public function __construct() {
 		$this->loadExplicitGroups();
 		$this->loadGroupsChangeableByGroups();
+
+		//This global is not used in wikia app any more, but it is queried through api from backend,
+		//so we need to retain it
+		global $wgWikiaGlobalUserGroups;
+		$wgWikiaGlobalUserGroups = $this->globalGroups;
 	}
 
 	/**


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-1999

In last refactoring I removed wgWikiaGlobalUserGroups global variable, as I refactored all its usages in code. Unfortunately it turns out it is being queried by backend scripts through our api and used to feed data that is then used by listusers special page. So this change reintroduces this variable.
