### PR TITLE
MAIN-6654: cache API calls to google geocode API

### DIFF
--- a/extensions/Maps/includes/Maps_Geocoder.php
+++ b/extensions/Maps/includes/Maps_Geocoder.php
@@ -111,7 +111,21 @@ abstract class MapsGeocoder {
 	 * @return array or false
 	 */
 	public function geocode( $address ) {
-		$response = ExternalHttp::get( $this->getRequestUrl( $address ) ); # Wikia change
+
+		// MAIN-6654: cache requests to this API because it has daily limits
+		global $wgMemc;
+		$key = wfMemcKey( "geocoder", $address );
+		$response = $wgMemc->get( $key );
+		if ( empty($response) ) {
+			$response = ExternalHttp::get( $this->getRequestUrl( $address ) ); # Wikia change
+			// MAIN-6654: make sure we do not return or store a bad response because it causes errors later
+			if ( strpos( $response, "OVER_QUERY_LIMIT" ) !== false ) {
+				$response = false;
+			}
+			if ( $response !== false ) {
+				$wgMemc->set( $key, $response, 86400 * 30 );  // 30 days
+			}
+		}
 
 		if ( $response === false ) {
 			return false;


### PR DESCRIPTION
This API currently has a limit of 2500 calls per day, which we hit.  This fix does 2 things: 

1) it will cache the data locally which should in most cases allow us to get all the data we need. 
2) if we do hit the API limit, it returns an empty result which isn't displayed.  this prevents the map rendering from crashing.  

@Wikia/sustaining-team  
