### PR TITLE
SUS-266 Code to prevent (false) CSRF detection on Special:Forum

### DIFF
--- a/extensions/wikia/Forum/ForumSpecialController.class.php
+++ b/extensions/wikia/Forum/ForumSpecialController.class.php
@@ -1,6 +1,7 @@
 <?php
 
 use Wikia\Logger\WikiaLogger;
+use Wikia\Security\CSRFDetector;
 
 /**
  * Forum Special Page
@@ -67,7 +68,11 @@ class ForumSpecialController extends WikiaSpecialPageController {
 
 		$forum = new Forum();
 
-		if ( $forum->createDefaultBoard() ) {
+		$forumCreatedJustNow = CSRFDetector::disableCheck( function () use ( $forum ) {
+			return $forum->createDefaultBoard();
+		}, 'Default forum board created on first visit on Special:Forum. CRSF not possible here.' );
+
+		if ( $forumCreatedJustNow ) {
 			$this->boards = $forum->getBoardList( DB_MASTER );
 		} else {
 			$this->boards = $forum->getBoardList( DB_SLAVE );


### PR DESCRIPTION
Changes:
- Added `CSRFDetector::disableCheck` method (@macbre, a better name?)
  that allows you to wrap some code that would report CSRF in a way it
  won't report the CSRF issue.
- Wrapped `ForumSpecialController::createDefaultForum` call in
  `CSRFDetector::disableCheck`.
- Cleaned `Forum::createDefaultForum` method a bit with the help from
  `GlobalStateWrapper`. Also removed the `wfProfileIn`/`wfProfileOut` calls.
- Added all message labels generated in `Forum::createDefaultForum` in a
  comment for easier label grepping.
