### PR TITLE
SUS-266 Code to prevent (false) CSRF detection on Special:Forum

### DIFF
--- a/extensions/wikia/Forum/Forum.class.php
+++ b/extensions/wikia/Forum/Forum.class.php
@@ -337,8 +337,8 @@ class Forum extends Walls {
 	public function createDefaultBoard() {
 		wfProfileIn( __METHOD__ );
 		$app = F::App();
-		if ( !$this->hasAtLeast( NS_WIKIA_FORUM_BOARD, 0 ) ) {
-			WikiaDataAccess::cachePurge( wfMemcKey( 'Forum_hasAtLeast', NS_WIKIA_FORUM_BOARD, 0 ) );
+		if ( !$this->hasMoreThan( NS_WIKIA_FORUM_BOARD, 0 ) ) {
+			WikiaDataAccess::cachePurge( wfMemcKey( 'Forum_hasMoreThan', NS_WIKIA_FORUM_BOARD, 0 ) );
 			/* the wgUser swap is the only way to create page as other user then current */
 			$tmpUser = $app->wg->User;
 			$app->wg->User = User::newFromName( Forum::AUTOCREATE_USER );

--- a/extensions/wikia/Forum/Forum.class.php
+++ b/extensions/wikia/Forum/Forum.class.php
@@ -1,5 +1,6 @@
 <?php
 use Wikia\Logger\WikiaLogger;
+use Wikia\Util\GlobalStateWrapper;
 
 /**
  * Forum
@@ -149,10 +150,10 @@ class Forum extends Walls {
 		$this->clearCacheTotalThreads( self::ACTIVE_DAYS );
 	}
 
-	public function hasAtLeast( $ns, $count ) {
+	public function hasMoreThan( $ns, $count ) {
 		wfProfileIn( __METHOD__ );
 
-		$out = WikiaDataAccess::cache( wfMemcKey( 'Forum_hasAtLeast', $ns, $count ), 24 * 60 * 60/* one day */, function() use ( $ns, $count ) {
+		$out = WikiaDataAccess::cache( wfMemcKey( 'Forum_hasMoreThan', $ns, $count ), 24 * 60 * 60/* one day */, function() use ( $ns, $count ) {
 			$db = wfGetDB( DB_MASTER );
 			// check if there is more then 5 forum pages (5 is number of forum pages from starter)
 			// limit 6 is faster solution then count(*) and the compare in php
@@ -172,7 +173,7 @@ class Forum extends Walls {
 	}
 
 	public function haveOldForums() {
-		return $this->hasAtLeast( NS_FORUM, 5 );
+		return $this->hasMoreThan( NS_FORUM, 5 );
 	}
 
 	public function swapBoards( $boardId1, $boardId2 ) {
@@ -233,7 +234,6 @@ class Forum extends Walls {
 	 * @throws MWException
 	 */
 	protected function createOrEditBoard( $board, $titletext, $body, $bot = false ) {
-		wfProfileIn( __METHOD__ );
 		$id = null;
 		if ( !empty( $board ) ) {
 			$id = $board->getId();
@@ -243,7 +243,6 @@ class Forum extends Walls {
 			self::LEN_OK !== $this->validateLength( $titletext, 'title' ) ||
 			self::LEN_OK !== $this->validateLength( $body, 'desc' )
 		) {
-			wfProfileOut( __METHOD__ );
 			return false;
 		}
 
@@ -276,7 +275,6 @@ class Forum extends Walls {
 
 		Forum::$allowToEditBoard = false;
 
-		wfProfileOut( __METHOD__ );
 		return $retval;
 	}
 
@@ -335,28 +333,33 @@ class Forum extends Walls {
 	}
 
 	public function createDefaultBoard() {
-		wfProfileIn( __METHOD__ );
-		$app = F::App();
-		if ( !$this->hasAtLeast( NS_WIKIA_FORUM_BOARD, 0 ) ) {
-			WikiaDataAccess::cachePurge( wfMemcKey( 'Forum_hasAtLeast', NS_WIKIA_FORUM_BOARD, 0 ) );
-			/* the wgUser swap is the only way to create page as other user then current */
-			$tmpUser = $app->wg->User;
-			$app->wg->User = User::newFromName( Forum::AUTOCREATE_USER );
+		if ( $this->hasMoreThan( NS_WIKIA_FORUM_BOARD, 0 ) ) {
+			return false;
+		}
+
+		WikiaDataAccess::cachePurge( wfMemcKey( 'Forum_hasMoreThan', NS_WIKIA_FORUM_BOARD, 0 ) );
+
+		// The wgUser swap is the only way to create page as other user then current
+		$autoCreateUser = User::newFromName( Forum::AUTOCREATE_USER );
+		$wrapper = new GlobalStateWrapper( [ 'wgUser' => $autoCreateUser ] );
+		$wrapper->wrap( function () {
+			$app = F::App();
+
+			// Labels used (for grep): forum-autoboard-title-1, forum-autoboard-body-1, forum-autoboard-title-2
+			// forum-autoboard-body-2, forum-autoboard-title-3, forum-autoboard-body-3, forum-autoboard-title-4,
+			// forum-autoboard-body-4, forum-autoboard-title-5, forum-autoboard-body-5
+
 			for ( $i = 1; $i <= 5; $i++ ) {
 				$body = wfMessage( 'forum-autoboard-body-' . $i, $app->wg->Sitename )->inContentLanguage()->text();
 				$title = wfMessage( 'forum-autoboard-title-' . $i, $app->wg->Sitename )->inContentLanguage()->text();
 
+				// Ignoring the result here :-(
+				// This returns EditPage::AS_BLOCKED_PAGE_FOR_USER (215) on permissions error
 				$this->createBoard( $title, $body, true );
 			}
+		} );
 
-			$app->wg->User = $tmpUser;
-
-			wfProfileOut( __METHOD__ );
-			return true;
-		}
-
-		wfProfileOut( __METHOD__ );
-		return false;
+		return true;
 	}
 
 }

--- a/extensions/wikia/Forum/ForumSpecialController.class.php
+++ b/extensions/wikia/Forum/ForumSpecialController.class.php
@@ -1,6 +1,7 @@
 <?php
 
 use Wikia\Logger\WikiaLogger;
+use Wikia\Security\CSRFDetector;
 
 /**
  * Forum Special Page
@@ -67,7 +68,11 @@ class ForumSpecialController extends WikiaSpecialPageController {
 
 		$forum = new Forum();
 
-		if ( $forum->createDefaultBoard() ) {
+		$forumCreatedJustNow = CSRFDetector::disableCheck( function () use ( $forum ) {
+			return $forum->createDefaultBoard();
+		}, 'Default forum board created on first visit on Special:Forum. CRSF not possible here.' );
+
+		if ( $forumCreatedJustNow ) {
 			$this->boards = $forum->getBoardList( DB_MASTER );
 		} else {
 			$this->boards = $forum->getBoardList( DB_SLAVE );

--- a/extensions/wikia/Forum/ForumSpecialController.class.php
+++ b/extensions/wikia/Forum/ForumSpecialController.class.php
@@ -1,7 +1,6 @@
 <?php
 
 use Wikia\Logger\WikiaLogger;
-use Wikia\Security\CSRFDetector;
 
 /**
  * Forum Special Page
@@ -68,11 +67,9 @@ class ForumSpecialController extends WikiaSpecialPageController {
 
 		$forum = new Forum();
 
-		$forumCreatedJustNow = CSRFDetector::disableCheck( function () use ( $forum ) {
-			return $forum->createDefaultBoard();
-		}, 'Default forum board created on first visit on Special:Forum. CRSF not possible here.' );
-
-		if ( $forumCreatedJustNow ) {
+		// TODO: once we're sure the forums are properly created when importing starter wiki
+		// don't call createDefaultBoard anymore
+		if ( $forum->createDefaultBoard() ) {
 			$this->boards = $forum->getBoardList( DB_MASTER );
 		} else {
 			$this->boards = $forum->getBoardList( DB_SLAVE );

--- a/extensions/wikia/Security/classes/CSRFDetector.class.php
+++ b/extensions/wikia/Security/classes/CSRFDetector.class.php
@@ -14,7 +14,6 @@ class CSRFDetector {
 	// flags to be checked when performing certain actions
 	private static $userMatchEditTokenCalled = false;
 	private static $requestWasPostedCalled = false;
-	private static $disabledReason = false;
 
 	/**
 	 * Set a flag when User::matchEditToken is called
@@ -34,23 +33,6 @@ class CSRFDetector {
 	public static function onRequestWasPosted() {
 		self::$requestWasPostedCalled = true;
 		return true;
-	}
-
-	/**
-	 * Run code that would trigger the CSRF error without triggering it
-	 *
-	 * You never want to use this function, but sometimes you must. That is when pages are created
-	 * automatically on the fly and the user cannot override any of the params of that process.
-	 *
-	 * @see ForumSpecialController::index
-	 *
-	 * @param \Closure $closure
-	 * @param string $reason
-	 */
-	public static function disableCheck( \Closure $closure, $reason ) {
-		self::$disabledReason = $reason;
-		$closure();
-		self::$disabledReason = false;
 	}
 
 	/**
@@ -84,11 +66,6 @@ class CSRFDetector {
 
 		if ( self::$userMatchEditTokenCalled === false || self::$requestWasPostedCalled == false ) {
 			wfDebug( __METHOD__ . ": {$hookName} hook triggered, but edit token and / or HTTP method was not checked\n" );
-
-			if ( is_string( self::$disabledReason ) ) {
-				wfDebug( __METHOD__ . ': Not logging, because ' . self::$disabledReason . PHP_EOL );
-				return;
-			}
 
 			WikiaLogger::instance()->warning( __METHOD__, [
 				'hookName' => $hookName,

--- a/extensions/wikia/Security/classes/CSRFDetector.class.php
+++ b/extensions/wikia/Security/classes/CSRFDetector.class.php
@@ -14,6 +14,7 @@ class CSRFDetector {
 	// flags to be checked when performing certain actions
 	private static $userMatchEditTokenCalled = false;
 	private static $requestWasPostedCalled = false;
+	private static $disabledReason = false;
 
 	/**
 	 * Set a flag when User::matchEditToken is called
@@ -33,6 +34,23 @@ class CSRFDetector {
 	public static function onRequestWasPosted() {
 		self::$requestWasPostedCalled = true;
 		return true;
+	}
+
+	/**
+	 * Run code that would trigger the CSRF error without triggering it
+	 *
+	 * You never want to use this function, but sometimes you must. That is when pages are created
+	 * automatically on the fly and the user cannot override any of the params of that process.
+	 *
+	 * @see ForumSpecialController::index
+	 *
+	 * @param \Closure $closure
+	 * @param string $reason
+	 */
+	public static function disableCheck( \Closure $closure, $reason ) {
+		self::$disabledReason = $reason;
+		$closure();
+		self::$disabledReason = false;
 	}
 
 	/**
@@ -66,6 +84,11 @@ class CSRFDetector {
 
 		if ( self::$userMatchEditTokenCalled === false || self::$requestWasPostedCalled == false ) {
 			wfDebug( __METHOD__ . ": {$hookName} hook triggered, but edit token and / or HTTP method was not checked\n" );
+
+			if ( is_string( self::$disabledReason ) ) {
+				wfDebug( __METHOD__ . ': Not logging, because ' . self::$disabledReason . PHP_EOL );
+				return;
+			}
 
 			WikiaLogger::instance()->warning( __METHOD__, [
 				'hookName' => $hookName,


### PR DESCRIPTION
Changes:
- Marked `Forum::createDefaultForum` method as deprecated. We want to remove it after SUS-302 and SUS-303 are completed
- Removed some `wfProfileIn` and `wfProfileOut` calls from `createOrEditBoard`
- Renamed `hasAtLeast` method to `hasMoreThan` as it checks if there's MORE than a given number of pages

Next steps:
- Once SUS-302 and SUS-303 are done we can remove the `Forum::createDefaultForum`. Created SUS-315 for that.
