### PR TITLE
wfShellExec: do not run scripts via ulimit4.sh

### DIFF
--- a/includes/DefaultSettings.php
+++ b/includes/DefaultSettings.php
@@ -5339,7 +5339,7 @@ $wgCrossSiteAJAXdomainExceptions = array();
 /**
  * Maximum amount of virtual memory available to shell processes under linux, in KB.
  */
-$wgMaxShellMemory = 102400;
+$wgMaxShellMemory = 0; // Wikia change - OPS-8226
 
 /**
  * Maximum file size created by shell processes under linux, in KB


### PR DESCRIPTION
[OPS-8226](https://wikia-inc.atlassian.net/browse/OPS-8226)

It causes 

```
setaffinity: Invalid argument
Segmentation fault
```

when run in containers.

@adamw-wikia / @wladekb 
