### PR TITLE
(SEC-54) Disable NewWindowLinks functionality

### DIFF
--- a/extensions/wikia/NewWindowLinks/NewWindowLinks.php
+++ b/extensions/wikia/NewWindowLinks/NewWindowLinks.php
@@ -64,7 +64,8 @@ function efParserCreateLink( $parser, $target, $label = null ) {
         $label = $parser->recursiveTagParse( $label );
         $label = preg_replace( "/\b({$parser->mUrlProtocols}) /", "$1", $label ); // Put them back together
     }
-    $attributes = array( 'target' => '_blank' );
+    // Functionality disabled per SEC-54
+    $attributes = [];// array( 'target' => '_blank' );
 
     // WARNING: the order of the statements below does matter!
     //


### PR DESCRIPTION
Disable NewWindowLinks functionality due to the risks of allowing this
with user generated content.

The tag will still work so that existing uses of the tag will work, just
without the links opening in a new tab.

/cc @Wikia/community-engineering 
