### PR TITLE
SUS-291: VideoHandler::getVideoList should always return json

### DIFF
--- a/extensions/wikia/VideoHandlers/VideoHandlerController.class.php
+++ b/extensions/wikia/VideoHandlers/VideoHandlerController.class.php
@@ -390,6 +390,9 @@ class VideoHandlerController extends WikiaController {
 
 		$this->response->setVal( 'videos', $videoList );
 
+		// SUS-291: This method is only called via ajax/internal requests expecting json data
+		$this->response->setFormat( \WikiaResponse::FORMAT_JSON );
+
 		/**
 		 * SUS-81: let's rely on CDN cache only
 		 *


### PR DESCRIPTION
Spent some time on it but could not reproduce the error manually.  We will just have to look at the error logs to verify that this is fixed. 

@Wikia/sustaining-team 
