### PR TITLE
PLATFORM-2033: forward client data to wfShellExec

### DIFF
--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -2913,6 +2913,8 @@ function wfShellExec( $cmd, &$retval = null, $environ = array() ) {
 
 	wfInitShellLocale();
 
+	wfRunHooks( 'wfShellExecBeforeEnviron', [ &$cmd, &$environ ] ); // Wikia change
+
 	$envcmd = '';
 	foreach( $environ as $k => $v ) {
 		if ( wfIsWindows() ) {

--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -2913,7 +2913,7 @@ function wfShellExec( $cmd, &$retval = null, $environ = array() ) {
 
 	wfInitShellLocale();
 
-	wfRunHooks( 'wfShellExecBeforeEnviron', [ &$cmd, &$environ ] ); // Wikia change
+	wfRunHooks( 'BeforeWfShellExec', [ &$cmd, &$environ ] ); // Wikia change
 
 	$envcmd = '';
 	foreach( $environ as $k => $v ) {

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -461,7 +461,7 @@ $wgHooks['WikiFactory::onExecuteComplete'][] = 'Wikia\\Logger\\Hooks::onWikiFact
 $wgHooks['WebRequestInitialized'][] = 'Wikia\\Tracer\\WikiaTracer::updateInstanceFromMediawiki';
 $wgHooks['AfterSetupUser'][] = 'Wikia\\Tracer\\WikiaTracer::updateInstanceFromMediawiki';
 $wgHooks['AfterUserLogin'][] = 'Wikia\\Tracer\\WikiaTracer::updateInstanceFromMediawiki';
-$wgHooks['wfShellExecBeforeEnviron'][] = 'Wikia\\Tracer\\WikiaTracer::onWfShellExecBeforeEnviron';
+$wgHooks['BeforeWfShellExec'][] = 'Wikia\\Tracer\\WikiaTracer::onBeforeWfShellExec';
 
 // memcache stats (PLATFORM-292)
 $wgAutoloadClasses['Wikia\\Memcached\\MemcachedStats'] = "$IP/includes/wikia/memcached/MemcachedStats.class.php";

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -461,6 +461,7 @@ $wgHooks['WikiFactory::onExecuteComplete'][] = 'Wikia\\Logger\\Hooks::onWikiFact
 $wgHooks['WebRequestInitialized'][] = 'Wikia\\Tracer\\WikiaTracer::updateInstanceFromMediawiki';
 $wgHooks['AfterSetupUser'][] = 'Wikia\\Tracer\\WikiaTracer::updateInstanceFromMediawiki';
 $wgHooks['AfterUserLogin'][] = 'Wikia\\Tracer\\WikiaTracer::updateInstanceFromMediawiki';
+$wgHooks['wfShellExecBeforeEnviron'][] = 'Wikia\\Tracer\\WikiaTracer::onWfShellExecBeforeEnviron';
 
 // memcache stats (PLATFORM-292)
 $wgAutoloadClasses['Wikia\\Memcached\\MemcachedStats'] = "$IP/includes/wikia/memcached/MemcachedStats.class.php";

--- a/lib/Wikia/src/Tracer/RequestId.php
+++ b/lib/Wikia/src/Tracer/RequestId.php
@@ -1,7 +1,7 @@
 <?php
 
-/*
- * Generate unique request ID or use the value when passed as HTTP request header
+/**
+ * Generate unique request ID or use the value when passed as HTTP request header or env variable
  *
  * Usage:
  *
@@ -9,7 +9,6 @@
  *
  * @see PLATFORM-362
  */
-
 namespace Wikia\Tracer;
 
 class RequestId {
@@ -29,10 +28,11 @@ class RequestId {
 		return $instance;
 	}
 
-	/*
+	/**
 	 * Return unique request ID. Either:
 	 *
-	 * - get it from HTTP request header
+	 * - get it from HTTP request header (X-Request-Id)
+	 * - get it from env variable (X_TRACE_ID)
 	 * - generate a new one
 	 *
 	 * @return string unique ID
@@ -43,15 +43,20 @@ class RequestId {
 			return $this->requestId;
 		}
 
-		// try to get the value from request X-Request-Id header
+		// try to get the value from request's X-Request-Id header or env variable
 		// we can't simply use $wgRequest as it's not yet set at this point
 		// this method is called on WikiFactoryExecuteComplete hook
 		// TODO: handle X-Trace-Id header as well
 		$headerValue = !empty( $_SERVER['HTTP_X_REQUEST_ID'] ) ? $_SERVER['HTTP_X_REQUEST_ID'] : false;
+		$envValue = !empty( $_ENV['X_TRACE_ID'] ) ? $_ENV['X_TRACE_ID'] : false;
 
 		if ( self::isValidId( $headerValue ) ) {
 			$this->requestId = $headerValue;
 			wfDebug( __METHOD__ . ": from HTTP request\n" );
+		}
+		else if ( self::isValidId( $envValue ) ) {
+			$this->requestId = $envValue;
+			wfDebug( __METHOD__ . ": from env variable\n" );
 		}
 		else {
 			// return 23 characters long unique ID + mw prefix

--- a/lib/Wikia/src/Tracer/RequestId.php
+++ b/lib/Wikia/src/Tracer/RequestId.php
@@ -48,7 +48,7 @@ class RequestId {
 		// this method is called on WikiFactoryExecuteComplete hook
 		// TODO: handle X-Trace-Id header as well
 		$headerValue = !empty( $_SERVER['HTTP_X_REQUEST_ID'] ) ? $_SERVER['HTTP_X_REQUEST_ID'] : false;
-		$envValue = !empty( $_ENV['X_TRACE_ID'] ) ? $_ENV['X_TRACE_ID'] : false;
+		$envValue = !empty( $_ENV[WikiaTracer::ENV_VARIABLES_PREFIX . 'X_TRACE_ID'] ) ? $_ENV[WikiaTracer::ENV_VARIABLES_PREFIX . 'X_TRACE_ID'] : false;
 
 		if ( self::isValidId( $headerValue ) ) {
 			$this->requestId = $headerValue;

--- a/lib/Wikia/src/Tracer/WikiaTracer.php
+++ b/lib/Wikia/src/Tracer/WikiaTracer.php
@@ -248,7 +248,7 @@ class WikiaTracer {
 	 * @param array $environ
 	 * @return bool true - it's a hook
 	 */
-	public static function onWfShellExecBeforeEnviron( &$cmd, array &$environ ) {
+	public static function onBeforeWfShellExec( &$cmd, array &$environ ) {
 		$traceEnviron = [];
 		$traceHeaders = array_merge(
 			self::instance()->getInternalHeaders(),

--- a/lib/Wikia/src/Tracer/WikiaTracer.php
+++ b/lib/Wikia/src/Tracer/WikiaTracer.php
@@ -46,6 +46,8 @@ class WikiaTracer {
 	}
 
 	/**
+	 * Get trace entry from either HTTP request header or env variable. Returns null if none of these are set.
+	 *
 	 * @param string $entryName
 	 * @return string|null
 	 */

--- a/lib/Wikia/src/Tracer/WikiaTracer.php
+++ b/lib/Wikia/src/Tracer/WikiaTracer.php
@@ -22,6 +22,8 @@ class WikiaTracer {
 	const LEGACY_TRACE_ID_HEADER_NAME = 'X-Request-Id';
 	const LEGACY_BEACON_HEADER_NAME = 'X-Beacon';
 
+	const ENV_VARIABLES_PREFIX = 'WIKIA_TRACER_';
+
 	private $traceId;
 	private $clientIp;
 	private $clientBeaconId;
@@ -54,13 +56,15 @@ class WikiaTracer {
 	private function getTraceEntry( $entryName ) {
 		$entryName = str_replace( '-', '_', $entryName );
 		$entryName = strtoupper( $entryName );
+
 		$serverHeaderName = 'HTTP_' . $entryName;
+		$envName = self::ENV_VARIABLES_PREFIX . $entryName;
 
 		if ( isset( $_SERVER[$serverHeaderName] ) && $_SERVER[$serverHeaderName] !== '' ) {
 			return $_SERVER[$serverHeaderName];
 		}
-		else if ( isset( $_ENV[$entryName] ) && $_ENV[$entryName] !== '' ) {
-			return $_ENV[$entryName];
+		else if ( isset( $_ENV[$envName] ) && $_ENV[$envName] !== '' ) {
+			return $_ENV[$envName];
 		}
 		else {
 			return null;
@@ -259,7 +263,7 @@ class WikiaTracer {
 			$key = str_replace( '-', '_', $key );
 			$key = strtoupper( $key );
 
-			$traceEnviron[ $key ] = $val;
+			$traceEnviron[ self::ENV_VARIABLES_PREFIX . $key ] = $val;
 		}
 
 		$environ = array_merge(


### PR DESCRIPTION
[PLATFORM-2033](https://wikia-inc.atlassian.net/browse/PLATFORM-2033)

Allow client data to be passed to maintenance scripts run via `wfShellExec` using environment variables.

``` php
> echo wfShellExec("run_maintenance --id=177 --script 'updateSpecialPages.php --list' --ip $IP/maintenance")
wfShellExec: WIKIA_TRACER_X_TRACE_ID='mw56efc375ce98e0.87969882' WIKIA_TRACER_X_REQUEST_ID='mw56efc375ce98e0.87969882' WIKIA_TRACER_X_CLIENT_IP='127.0.0.1' WIKIA_TRACER_X_REQUEST_ORIGIN_HOST='dev-macbre' WIKIA_TRACER_X_WIKIA_INTERNAL_REQUEST='mediawiki' run_maintenance --id=177 --script 'updateSpecialPages.php --list' --ip /usr/wikia/source/app/maintenance
```

Introduce `BeforeWfShellExec` hook.

@wladekb 
