### PR TITLE
AsyncTaskList: forward client data to tasks spawned by MediaWiki

### DIFF
--- a/extensions/wikia/Tasks/proxy/proxy.php
+++ b/extensions/wikia/Tasks/proxy/proxy.php
@@ -25,7 +25,15 @@ $order = escapeshellarg( $_POST['call_order'] );
 $createdBy = escapeshellarg( $_POST['created_by'] );
 $createdAt = escapeshellarg( $_POST['created_at'] );
 
-$command = "php {$script} --wiki_id={$wikiId} --task_id={$taskId} --task_list={$list} --call_order={$order} --created_by={$createdBy} --created_at={$createdAt}";
+// PLATFORM-2034: Forward client data to tasks spawned by MediaWiki
+$traceEnv = json_decode( $_POST['trace_env'] );
+$env = '';
+
+foreach($traceEnv as $key => $val) {
+	$env .= sprintf( '%s=%s ', $key, escapeshellarg( $val ) );
+}
+
+$command = "{$env}php {$script} --wiki_id={$wikiId} --task_id={$taskId} --task_list={$list} --call_order={$order} --created_by={$createdBy} --created_at={$createdAt}";
 
 // can't use globals here, this doesn't execute within mediawiki
 if ( getenv( 'WIKIA_ENVIRONMENT' ) == 'dev' ) {

--- a/includes/wikia/tasks/AsyncTaskList.class.php
+++ b/includes/wikia/tasks/AsyncTaskList.class.php
@@ -228,6 +228,7 @@ class AsyncTaskList {
 			'task_list' => $taskList,
 			'created_by' => $this->createdBy,
 			'created_at' => microtime( true ),
+			'trace_env' => \Wikia\Tracer\WikiaTracer::instance()->getEnvVariables(),
 		]];
 	}
 

--- a/lib/Wikia/src/Tracer/WikiaTracer.php
+++ b/lib/Wikia/src/Tracer/WikiaTracer.php
@@ -246,13 +246,11 @@ class WikiaTracer {
 	}
 
 	/**
-	 * Pass request context to maintenance scripts run via wfShellExec
+	 * Get the array of env variables with client data
 	 *
-	 * @param string $cmd
-	 * @param array $environ
-	 * @return bool true - it's a hook
+	 * @return array
 	 */
-	public static function onBeforeWfShellExec( &$cmd, array &$environ ) {
+	public function getEnvVariables() {
 		$traceEnviron = [];
 		$traceHeaders = array_merge(
 			self::instance()->getInternalHeaders(),
@@ -266,9 +264,20 @@ class WikiaTracer {
 			$traceEnviron[ self::ENV_VARIABLES_PREFIX . $key ] = $val;
 		}
 
+		return $traceEnviron;
+	}
+
+	/**
+	 * Pass request context to maintenance scripts run via wfShellExec
+	 *
+	 * @param string $cmd
+	 * @param array $environ
+	 * @return bool true - it's a hook
+	 */
+	public static function onBeforeWfShellExec( &$cmd, array &$environ ) {
 		$environ = array_merge(
 			$environ,
-			$traceEnviron
+			self::instance()->getEnvVariables()
 		);
 
 		return true;


### PR DESCRIPTION
[PLATFORM-2034](https://wikia-inc.atlassian.net/browse/PLATFORM-2034)

Forward client data to tasks spawned by MediaWiki. This will give us the context (i.e. what kind of action triggered the task) for tasks that get out of control.

No changes in celery-workers are needed. A set of environment variables is passed to HTTP request made for `proxy.php` endpoint [auto-magically (as a part of `**kwargs`)](https://github.com/Wikia/celery-workers/blob/master/celery_workers/helpers/executors.py#L32).

The following command is executed on task machine:

``` sh
WIKIA_TRACER_X_CLIENT_IP='127.0.0.1' WIKIA_TRACER_X_REQUEST_ORIGIN_HOST='dev-macbre' WIKIA_TRACER_X_TRACE_ID='mw56f1110fa43951.66762093' WIKIA_TRACER_X_REQUEST_ID='mw56f1110fa43951.66762093' WIKIA_TRACER_X_WIKIA_INTERNAL_REQUEST='mediawiki' php /usr/wikia/source/app/maintenance/wikia/task_runner.php --wiki_id='177' --task_id='mw-2CB07D36-1ACD-4553-85F9-D820B0A980B6' --task_list='[{\"calls\": [[\"purge\", [\"imagelinks\"]]], \"class\": \"Wikia\\\\Tasks\\\\Tasks\\\\HTMLCacheUpdateTask\", \"context\": {\"titleParams\": {\"namespace\": 0, \"dbKey\": \"Community_Central\"}}}]' --call_order='[[0, 0]]' --created_by='{\"name\": \"127.0.0.1\", \"id\": 0}' --created_at='1458639122.2621'
```

@wladekb / @pchojnacki 
