### PR TITLE
Bring back the list of global groups in siteinfo api

### DIFF
--- a/extensions/wikia/WikiaApi/WikiaApiQuerySiteinfo.php
+++ b/extensions/wikia/WikiaApi/WikiaApiQuerySiteinfo.php
@@ -66,7 +66,15 @@ class WikiaApiQuerySiteinfo extends ApiQuerySiteinfo {
 		$data = array ();
 		foreach ($this->variablesList as $id => $variableName) {
 			$data[$id] = array( 'id' => $variableName );
-			$value = (array_key_exists($variableName, $GLOBALS) && !is_null($GLOBALS[$variableName])) ? $GLOBALS[$variableName] : "";
+			switch ($variableName) {
+				case 'wgWikiaGlobalUserGroups':
+					/** @var \Wikia\Service\User\Permissions\PermissionsServiceImpl $permissionsService */
+					$permissionsService = \Wikia\DependencyInjection\Injector::getInjector()->get( \Wikia\Service\User\Permissions\PermissionsService::class );
+					$value = $permissionsService->getConfiguration()->getGlobalGroups();
+					break;
+				default:
+					$value = (array_key_exists($variableName, $GLOBALS) && !is_null($GLOBALS[$variableName])) ? $GLOBALS[$variableName] : "";
+			}
 			if ( is_array($value) ) {
 				$loop = 0; foreach ($value as $key => $v) {
 					$data[$id]["value".$loop] = array( 'id' => $key);


### PR DESCRIPTION
ApiQuery SiteInfo was missing the list of global groups after the recent changes around permissions. This is going to bring it back.

/cc @owend @jcellary
