### PR TITLE
Prevent smart banner on Windows Phone devices.

### DIFF
--- a/extensions/wikia/WikiaMobile/SmartBanner/smartbanner.bootstrap.js
+++ b/extensions/wikia/WikiaMobile/SmartBanner/smartbanner.bootstrap.js
@@ -13,7 +13,7 @@ $(function () {
 			)) {
 				type = 'ios';
 			}
-		} else if (ua.match(/Android/i) !== null) {
+		} else if (ua.match(/Android/i) !== null && (ua.match(/Windows Phone/i) === null)) {
 			type = 'android';
 		}
 


### PR DESCRIPTION
I've found that on Windows Phone/Mobile devices, due to "Andoid" being in the user agent the banner would appear. (reason for this craziness was developers blocking a finally properly working IE on Windows Phone 8)

To get around the issue, I've added a check for the presence of "Windows Phone" in the user agent string.
