### PR TITLE
SUS-320 add editor reset for overridden NewMessageForm

### DIFF
--- a/extensions/wikia/MiniEditor/js/Forum/Forum.NewMessageForm.js
+++ b/extensions/wikia/MiniEditor/js/Forum/Forum.NewMessageForm.js
@@ -2,6 +2,7 @@
 
 MiniEditor.Forum.NewMessageForm = $.createClass(Wall.settings.classBindings.newMessageForm, {
 	disableNewMessage: function() {
+		this.messageBody.data('wikiaEditor').fire('editorReset');
 		this.message.find('.submit').attr('disabled', 'disabled');
 		this.message.addClass('loading');
 	},


### PR DESCRIPTION
[P2 Ticket](https://wikia-inc.atlassian.net/browse/SUS-320)

NewMessageForm overridden default behaviour and do not reset wikia editor.
this change add explicit reset in overridden function
