### PR TITLE
SUS-134 Content Warning message is impossible to bypass on smaller browser windows

### DIFF
--- a/extensions/wikia/ContentWarning/css/ContentWarning.scss
+++ b/extensions/wikia/ContentWarning/css/ContentWarning.scss
@@ -49,22 +49,24 @@
 
 	.WikiaMainContent,
 	.WikiaRail,
-    .WikiaFooter {
+	.WikiaFooter {
 		overflow: hidden;
 		visibility: hidden;
 	}
 
-    .WikiaRail {
-      .wikia-ad {
-        display:none;
-      }
-    }
+	.WikiaMainContent {
+		height: 0;
+	}
 
+	.WikiaRail {
+		.wikia-ad {
+			display: none;
+		}
+	}
 
 	.ContentWarning {
-        display: block;
-        position: fixed;
-    }
+		display: block;
+	}
 
 	.adm-dash-search,
 	.WikiaWideTablesWrapper {

--- a/extensions/wikia/ContentWarning/css/ContentWarning.scss
+++ b/extensions/wikia/ContentWarning/css/ContentWarning.scss
@@ -50,12 +50,9 @@
 	.WikiaMainContent,
 	.WikiaRail,
 	.WikiaFooter {
+		height: 0;
 		overflow: hidden;
 		visibility: hidden;
-	}
-
-	.WikiaMainContent {
-		height: 0;
 	}
 
 	.WikiaRail {

--- a/extensions/wikia/ContentWarning/js/ContentWarning.js
+++ b/extensions/wikia/ContentWarning/js/ContentWarning.js
@@ -1,4 +1,5 @@
-jQuery(function($) {
+/*global jQuery, window*/
+jQuery(function ($) {
 	'use strict';
 	// Hide content warning, show content
 	function afterApproved() {
@@ -15,22 +16,11 @@ jQuery(function($) {
 			method: 'index',
 			format: 'html',
 			type: 'GET',
-			callback: function(html) {
-
-				var parent, container, railWidth;
-
+			callback: function (html) {
 				$(window.skin === 'oasis' ? '#WikiaMainContent' : '#bodyContent').before($(html));
 
-				container = $('#ContentWarning' );
-
-				parent = container.parent();
-
-				railWidth = ($('#WikiaRail').width() || 0) + 50;
-
-				container.width(parent.width() - railWidth);
 				// User acknowledges the content warning message and wishes to proceed
-				container.on('click', '#ContentWarningApprove', function() {
-
+				$('#ContentWarning').on('click', '#ContentWarningApprove', function () {
 					// Logged in user
 					if (window.wgUserName) {
 						$.nirvana.sendRequest({
@@ -41,15 +31,13 @@ jQuery(function($) {
 							format: 'json',
 							callback: afterApproved
 						});
-
-					// Anonymous user
 					} else {
+						// Anonymous user
 						afterApproved();
 					}
 
 					$.cookies.set('ContentWarningApproved', '1', {
-						hoursToLive: 24,
-						domain: wgServer.split('/')[2]
+						hoursToLive: 24
 					});
 				});
 			}


### PR DESCRIPTION
Two changes here:
- Removal of `position: fixed` for the ContentWarning message
- Added `height: 0` for the WikiaMainContent if ShowContentWarning

This makes the warning scrollable, but at the same time eliminates the
possibility to scroll away from it on long articles.

Also reindented the file to used tabs instead of spaces.

You might want to use the `w=1` param for GitHub: https://github.com/Wikia/app/pull/10049/files?w=1
