### PR TITLE
DAT-3990 Introduce infobox to ThemeDesigner

### DIFF
--- a/extensions/wikia/ThemeDesigner/ThemeDesignerController.class.php
+++ b/extensions/wikia/ThemeDesigner/ThemeDesignerController.class.php
@@ -89,7 +89,9 @@ class ThemeDesignerController extends WikiaController {
 	}
 
 	public function executePreview() {
+		global $wgEnablePortableInfoboxEuropaTheme;
 
+		$this->infoboxTheme = $wgEnablePortableInfoboxEuropaTheme ? 'theme="europa"' : '';
 	}
 
 	/**

--- a/extensions/wikia/ThemeDesigner/js/ThemeDesignerPreview.js
+++ b/extensions/wikia/ThemeDesigner/js/ThemeDesignerPreview.js
@@ -1,13 +1,14 @@
 var ThemeDesignerPreview = {
 	init: function() {
-		$("#WikiaArticle figure")
+		$(".portable-infobox h2")
 			.first()
-			.addClass("tright")
-			.css("width", 300)
-			.find("a")
-			.first()
-			.html(
-				'<img width="300" src="' + wgExtensionsPath + '/wikia/ThemeDesigner/images/aquarium.jpg">'
+			.after(
+				'<figure class="pi-item pi-image">'+
+				'<a href="#" class="image image-thumbnail" title="">' +
+				'<img width="100%" src="' + wgExtensionsPath + '/wikia/ThemeDesigner/images/aquarium.jpg">' +
+				'</a>' +
+				'<figcaption class="pi-item-spacing pi-caption">Aliquam porttitor orci ac augue dictum</figcaption>' +
+				'</figure>'
 			);
 
 		$("a.new").removeClass("new");
@@ -20,7 +21,12 @@ var ThemeDesignerPreview = {
 	},
 
 	loadSASS: function(settings) {
-		var sassUrl = $.getSassCommonURL('/skins/oasis/css/oasis.scss', settings);
+		var sassUrl = $.getSassesURL([
+			'/skins/oasis/css/oasis.scss',
+			'/extensions/wikia/PortableInfobox/styles/PortableInfobox.scss',
+			'/extensions/wikia/PortableInfobox/styles/PortableInfoboxEuropaTheme.scss'
+		], settings);
+
 		$("#clickmask").animate({"opacity": 0.65}, "fast", function() {
 			$.getCSS(sassUrl, function(link) {
 				$(ThemeDesignerPreview.link).remove();

--- a/extensions/wikia/ThemeDesigner/js/ThemeDesignerPreview.js
+++ b/extensions/wikia/ThemeDesigner/js/ThemeDesignerPreview.js
@@ -7,7 +7,6 @@ var ThemeDesignerPreview = {
 				'<a href="#" class="image image-thumbnail" title="">' +
 				'<img width="100%" src="' + wgExtensionsPath + '/wikia/ThemeDesigner/images/aquarium.jpg">' +
 				'</a>' +
-				'<figcaption class="pi-item-spacing pi-caption">Aliquam porttitor orci ac augue dictum</figcaption>' +
 				'</figure>'
 			);
 

--- a/extensions/wikia/ThemeDesigner/templates/ThemeDesigner_Preview.php
+++ b/extensions/wikia/ThemeDesigner/templates/ThemeDesigner_Preview.php
@@ -1,4 +1,23 @@
-<?= ThemeDesignerHelper::parseText("[[File:Aquarium.jpg|thumb|Quisque pellentesque vestibulum ullamcorper.]]
+<?= ThemeDesignerHelper::parseText("
+<infobox <?= $infoboxTheme ?>>
+<title><default>Lorem ipsum</default></title>
+<group>
+<header>Eget euismod nisl dapibus</header>
+<data><label>Nullam</label><default>pulvinar vitae sem et finibus.</default></data>
+<data><label>Nunc</label><default>
+* in
+* tristique
+* sapien
+* ut
+* molestie
+* odio
+</default></data>
+<header>Fusce maximus facilisis ipsum</header>
+<data><label>nec</label><default>imperdiet mi gravida eu</default></data>
+<data><label>Praesent</label><default>finibus tellus sed enim rhoncus</default></data>
+</group>
+</infobox>
+
 Lorem ipsum dolor sit amet, [[consectetur]] adipiscing elit. Nunc molestie velit a ante [[fringilla vitae]] euismod velit gravida. [[Curabitur]] eu sem et justo sodales [[consequat quis]] vel justo. Vestibulum ante ipsum primis in faucibus orci [[luctus et ultrices]] posuere cubilia Curae. Quisque vitae lectus odio, quis porta orci. Etiam mattis volutpat enim, id posuere eros faucibus id. [[Integer vehicula libero]] vitae est ornare a pellentesque mauris pharetra. Nam eget lorem vestibulum nisi [[commodo suscipit]] non sit amet justo. Fusce imperdiet lacus sed [[turpis ornare]] pretium. ''Maecenas'' [[ante neque]], imperdiet sed accumsan id, gravida a sem. Morbi eu nisl quis nunc tincidunt condimentum euismod sit amet est.
 
 ==Donec dapibus==

--- a/resources/wikia/jquery.wikia.js
+++ b/resources/wikia/jquery.wikia.js
@@ -1,6 +1,34 @@
 (function (window, $) {
 	'use strict';
 
+	/**
+	 * Returns CDN-compatible url string to asset manager returning contents
+	 * for combined elements
+	 *
+	 * @param elements
+	 * @param params
+	 * @param requesttype 'groups'|'sasses'
+	 * @returns {*}
+     */
+	var getAssetManagerUrl = function ( elements, params, requesttype ) {
+		if (typeof elements === 'string') {
+			elements = [elements];
+		}
+
+		params = params || {};
+
+		// Don't minify the response when allinone=0
+		if (window.debug === true) {
+			params.minify = 0;
+		}
+
+		return wgCdnRootUrl + wgAssetsManagerQuery.
+			replace('%1$s', requesttype).
+			replace('%2$s', elements.join(',')).
+			replace('%3$s', $.isEmptyObject(params) ? '-' : encodeURIComponent($.param(params))).
+			replace('%4$d', wgStyleVersion);
+	};
+
 	$.getSassURL = function (rootURL, scssFilePath, params) {
 		return rootURL + wgAssetsManagerQuery.
 		replace('%1$s', 'sass').
@@ -18,27 +46,21 @@
 	};
 
 	/**
-	 *	Get URL for loading asset manager groups
+	 *	Get URL for loading asset manager groups (applicable to JS)
 	 *  @param {String|String[]} groups Assets manager group name
 	 *  @param {Object} params Extra params for url string. Ex: {minify:0}
 	 */
 	$.getAssetManagerGroupUrl = function (groups, params) {
-		if (typeof groups === 'string') {
-			groups = [groups];
-		}
+		return getAssetManagerUrl( groups, params, 'groups' );
+	};
 
-		params = params || {};
-
-		// Don't minify the response when allinone=0
-		if (window.debug === true) {
-			params.minify = 0;
-		}
-
-		return wgCdnRootUrl + wgAssetsManagerQuery.
-		replace('%1$s', 'groups').
-		replace('%2$s', groups.join(',')).
-		replace('%3$s', $.isEmptyObject(params) ? '-' : encodeURIComponent($.param(params))).
-		replace('%4$d', wgStyleVersion);
+	/**
+	 *	Get URL for loading asset manager groups (applicable to SCSS)
+	 *  @param {String|String[]} groups Assets manager group name
+	 *  @param {Object} params Extra params for url string. Ex: {minify:0}
+	 */
+	$.getSassesURL = function (sasses, params) {
+		return getAssetManagerUrl( sasses, params, 'sasses' );
 	};
 
 	//see http://jamazon.co.uk/web/2008/07/21/jquerygetscript-does-not-cache


### PR DESCRIPTION
## LINKS

https://wikia-inc.atlassian.net/browse/DAT-3990
## DESCRIPTION

This pull request introduces an infobox in place of image inside of a Theme Designer preview window. There was purposely no rework of Theme Designer's structure done as part of that change given the plans to address theming in a holistic manner this year.
