### PR TITLE
WikiaTracer: introduce span_id

### DIFF
--- a/lib/Wikia/src/Tracer/RequestId.php
+++ b/lib/Wikia/src/Tracer/RequestId.php
@@ -59,14 +59,22 @@ class RequestId {
 			wfDebug( __METHOD__ . ": from env variable\n" );
 		}
 		else {
-			// return 23 characters long unique ID + mw prefix
-			// e.g. mw5405bb3d129e76.46189257
-			$this->requestId = uniqid( 'mw', true );
+			$this->requestId = self::generateId();
 			wfDebug( __METHOD__ . ": generated a new one\n" );
 		}
 
 		wfDebug( __METHOD__ . ": {$this->requestId}\n" );
 		return $this->requestId;
+	}
+
+	/**
+	 * Return 23 characters long unique ID + mw prefix
+	 * e.g. mw5405bb3d129e76.46189257
+	 *
+	 * @return string
+	 */
+	public static function generateId() {
+		return uniqid( 'mw', true );
 	}
 
 	/**

--- a/lib/Wikia/src/Tracer/WikiaTracer.php
+++ b/lib/Wikia/src/Tracer/WikiaTracer.php
@@ -37,7 +37,9 @@ class WikiaTracer {
 	private $contextSource;
 
 	private function __construct() {
+		$this->spanId = RequestId::generateId();
 		$this->traceId = RequestId::instance()->getRequestId();
+
 		$this->clientIp = $this->getTraceEntry( self::CLIENT_IP_HEADER_NAME );
 		$this->clientBeaconId = $this->getTraceEntry( self::CLIENT_BEACON_ID_HEADER_NAME );
 		$this->clientDeviceId = $this->getTraceEntry( self::CLIENT_DEVICE_ID_HEADER_NAME );
@@ -79,6 +81,7 @@ class WikiaTracer {
 				'client_beacon_id' => $this->clientBeaconId,
 				'client_device_id' => $this->clientDeviceId,
 				'user_id' => $this->userId,
+				'span_id' => $this->spanId,
 				'trace_id' => $this->traceId,
 			] )
 		);


### PR DESCRIPTION
[PLATFORM-1948](https://wikia-inc.atlassian.net/browse/PLATFORM-1948)

Log both `trace_id` and `span_id`:
- `span_id` is sub-request specific ID (used to separate sub-requests made to compose a response for the end-user)
- `trace_id` comes from the parent call and is used to group messages from all sub-requests

@wladekb 
