### PR TITLE
XW | Handle invalid Vignette URLs gracefully

### DIFF
--- a/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php
+++ b/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php
@@ -27,11 +27,16 @@ class ArticleAsJson extends WikiaService {
 	private static function renderIcon( $media ) {
 		$scaledSize = self::scaleIconSize( $media['height'], $media['width'] );
 
-		$thumbUrl = VignetteRequest::fromUrl( $media['url'] )
-			->thumbnailDown()
-			->height( $scaledSize['height'] )
-			->width( $scaledSize['width'] )
-			->url();
+		try {
+			$thumbUrl = VignetteRequest::fromUrl( $media['url'] )
+				->thumbnailDown()
+				->height( $scaledSize['height'] )
+				->width( $scaledSize['width'] )
+				->url();
+		} catch (InvalidArgumentException $e) {
+			// Media URL isn't valid Vignette URL so we can't generate the thumbnail
+			$thumbUrl = null;
+		}
 
 		return self::removeNewLines(
 			\MustacheService::getInstance()->render(


### PR DESCRIPTION
Without `try catch` block we have fatal errors on devboxes where broken URLs are common. Don't know if it happens on production too but better to be safe.

/cc @Warkot 
