### PR TITLE
SUS-234 Maintain the watch status for the forum board when editing it

### DIFF
--- a/extensions/wikia/Forum/Forum.class.php
+++ b/extensions/wikia/Forum/Forum.class.php
@@ -261,6 +261,8 @@ class Forum extends Walls {
 
 		$editPage->edittime = $article->getPage()->getTimestamp();
 		$editPage->textbox1 = $body;
+		// Maintain the "watch" status for the page after the edit
+		$editPage->watchthis = $article->getTitle()->userIsWatching();
 
 		$result = [ ];
 		$retval = $editPage->internalAttemptSave( $result, $bot );


### PR DESCRIPTION
While editing a page you can specify if you want to watch the page or
not. When issuing an edit programmatically you need to pass the watch
status, or otherwise the user will unfollow the page after any changes
we want to contribute to the user (which is very counter-intuitive).

This fix just reads the watch status for the board article and passes it
to the edit page class, so the status is maintained after you edit board
description or title.
