### PR TITLE
DAT-3969 update special pages cache on create step

### DIFF
--- a/includes/wikia/tasks/Tasks/CreateNewWikiTask.class.php
+++ b/includes/wikia/tasks/Tasks/CreateNewWikiTask.class.php
@@ -102,6 +102,10 @@ class CreateNewWikiTask extends BaseTask {
 		$output = wfShellExec( $cmd, $exitStatus );
 		$this->info( 'run refreshLinks.php', ['exitStatus' => $exitStatus, 'output' => $output] );
 
+		$cmd = sprintf( "SERVER_ID={$wgCityId} php {$IP}/maintenance/updateSpecialPages.php --server={$server}" );
+		$output = wfShellExec( $cmd, $exitStatus );
+		$this->info( 'run updateSpecialPages.php', ['exitStatus' => $exitStatus, 'output' => $output] );
+
 		$this->info( "Remove edit lock" );
 		$variable = \WikiFactory::getVarByName( 'wgReadOnly', $wgCityId );
 		if ( isset( $variable->cv_variable_id ) ) {


### PR DESCRIPTION
## DESCRIPTION

This PR introduces updating of special page lists on wiki creation to ensure all pages imported from starter are properly indexed.
The time consequence is that this will extend the execution of the async task by ~1 second.

/CC @macbre for visibility
