### PR TITLE
SOC-2123 Add additional logging when MW tries to save attributes for non-existent users

### DIFF
--- a/lib/Wikia/src/Service/User/Attributes/AttributeKeyValueService.php
+++ b/lib/Wikia/src/Service/User/Attributes/AttributeKeyValueService.php
@@ -47,7 +47,7 @@ class AttributeKeyValueService implements AttributeService {
 
 			return $ret;
 		} catch ( \Exception $e ) {
-			$this->logError( $userId, $e, "USER_ATTRIBUTE error saving to service" );
+			$this->logError( $userId, $e, "USER_ATTRIBUTES error saving to service" );
 			return false;
 		}
 	}
@@ -66,7 +66,7 @@ class AttributeKeyValueService implements AttributeService {
 		try {
 			$attributeArray = $this->persistenceAdapter->getAttributes( $userId );
 		} catch ( \Exception $e ) {
-			$this->logError( $userId, $e, "USER_ATTRIBUTE error getting from service" );
+			$this->logError( $userId, $e, "USER_ATTRIBUTES error getting from service" );
 		}
 
 		return $attributeArray;
@@ -87,7 +87,7 @@ class AttributeKeyValueService implements AttributeService {
 			$ret = $this->persistenceAdapter->deleteAttribute( $userId, $attribute );
 			return $ret;
 		} catch ( \Exception $e ) {
-			$this->logError( $userId, $e, "USER_ATTRIBUTE error deleting from service" );
+			$this->logError( $userId, $e, "USER_ATTRIBUTES error deleting from service" );
 			return false;
 		}
 	}

--- a/lib/Wikia/src/Service/User/Attributes/AttributeKeyValueService.php
+++ b/lib/Wikia/src/Service/User/Attributes/AttributeKeyValueService.php
@@ -47,7 +47,7 @@ class AttributeKeyValueService implements AttributeService {
 
 			return $ret;
 		} catch ( \Exception $e ) {
-			$this->logError( $userId, $e );
+			$this->logError( $userId, $e, "USER_ATTRIBUTE error saving to service" );
 			return false;
 		}
 	}
@@ -66,7 +66,7 @@ class AttributeKeyValueService implements AttributeService {
 		try {
 			$attributeArray = $this->persistenceAdapter->getAttributes( $userId );
 		} catch ( \Exception $e ) {
-			$this->logError( $userId, $e );
+			$this->logError( $userId, $e, "USER_ATTRIBUTE error getting from service" );
 		}
 
 		return $attributeArray;
@@ -87,13 +87,13 @@ class AttributeKeyValueService implements AttributeService {
 			$ret = $this->persistenceAdapter->deleteAttribute( $userId, $attribute );
 			return $ret;
 		} catch ( \Exception $e ) {
-			$this->logError( $userId, $e );
+			$this->logError( $userId, $e, "USER_ATTRIBUTE error deleting from service" );
 			return false;
 		}
 	}
 
-	private function logError( $userId, \Exception $e ) {
-		$this->error( 'USER_ATTRIBUTE error contacting service' , [
+	private function logError( $userId, \Exception $e, $msg ) {
+		$this->error( $msg , [
 			'user' => $userId,
 			'exception' => $e
 		] );

--- a/lib/Wikia/src/Service/User/Attributes/AttributeKeyValueService.php
+++ b/lib/Wikia/src/Service/User/Attributes/AttributeKeyValueService.php
@@ -93,9 +93,9 @@ class AttributeKeyValueService implements AttributeService {
 	}
 
 	private function logError( $userId, \Exception $e ) {
-		$this->error( $e->getMessage(), [
+		$this->error( 'USER_ATTRIBUTE error contacting service' , [
 			'user' => $userId,
-			'exceptionType' => get_class( $e ),
+			'exception' => $e
 		] );
 	}
 


### PR DESCRIPTION
There are currently values in the attribute service for non-existent users and we're not sure why. This ticket adds additional logging to help track down the issue.

We already have logging when MW receives errors from the attribute service, but this PR makes it more fine-grained by passing the entire exception which will provide us with a stack trace, as well as giving a more detailed message about what was happening when an error occurred (we're only curious about save errors right now).

This should help us narrow down the conditions when this bad data was being saved, as the attribute service throws a 404 when an attempt to save data for a non-existent user happens. Those 404 manifest as exceptions in MW which are being caught and logged here.

Ticket: https://wikia-inc.atlassian.net/browse/SOC-2123
