### PR TITLE
SUS-327 Fix the poll bars in speech bubbles

### DIFF
--- a/extensions/wikia/AjaxPoll/css/AjaxPoll.scss
+++ b/extensions/wikia/AjaxPoll/css/AjaxPoll.scss
@@ -26,7 +26,7 @@ div.ajax-poll div.row {
 }
 
 div.ajax-poll-bar {
-	background: $color-error /* is this an error? */;
+	background: $color-error; /* is this an error? */
 }
 
 .pollAnswerName {
@@ -37,7 +37,8 @@ div.ajax-poll-bar {
 .pollAnswerVotes {
 	border: 1px solid $color-page-border;
 	font-size: 10px;
-	height: 12px;
+	height: 19px;
+	margin-bottom: 4px;
 	margin-left: 10px;
 	position: relative;
 	width: 100%;
@@ -50,19 +51,18 @@ div.ajax-poll-bar {
 		background: mix($color-page, #000000, 75%);
 	}
 
-
 	border-right: 1px solid $color-page-border;
 	font-size: 1px;
-	height: 12px;
+	height: 19px;
 	left: 0;
-	line-height: 12px;
+	line-height: 19px;
 	position: absolute;
 	top: 0;
 	z-index: 2;
 }
 
 .poll .ourVote div {
-	border: 1px solid #777 /* foo */;
+	border: 1px solid #777;
 	left: -1px;
 	top: -1px;
 }

--- a/includes/wikia/GlobalFunctions.php
+++ b/includes/wikia/GlobalFunctions.php
@@ -1534,7 +1534,10 @@ function wfFixMalformedHTML( $html ) {
 
 	// Make sure loadHTML knows that text is utf-8 (it assumes ISO-88591)
 	// CONN-130 - Added <!DOCTYPE html> to allow HTML5 tags in the article comment
-	$htmlHeader = '<!DOCTYPE html><head><meta http-equiv="content-type" content="text/html; charset=utf-8"></head>';
+	$htmlHeader = '<!DOCTYPE html><html>';
+	$htmlHeader .= '<head><meta http-equiv="content-type" content="text/html; charset=utf-8"></head>';
+	$htmlHeader .= '<div id="wfFixMalformedHTML">';
+
 	$domDocument->loadHTML( $htmlHeader . $html );
 
 	// Strip doctype declaration, <html>, <body> tags created by saveHTML, as well as <meta> tag added to
@@ -1544,6 +1547,8 @@ function wfFixMalformedHTML( $html ) {
 			'/^.*?<body>/si', '/^.*?charset=utf-8">/si',
 			'/<\/body><\/html>$/si',
 			'/<\/head><\/html>$/si',
+			'/^<div id="wfFixMalformedHTML">/',
+			'/<\\/div>$/',
 		),
 		'',
 		$domDocument->saveHTML()

--- a/includes/wikia/GlobalFunctions.php
+++ b/includes/wikia/GlobalFunctions.php
@@ -1520,7 +1520,7 @@ function wfGetNamespaces() {
 
 /**
  * Repair malformed HTML without making semantic changes (ie, changing tags to more closely follow the HTML spec.)
- * Refs DAR-985 and VID-1011
+ * Refs DAR-985, VID-1011, SUS-327
  *
  * @param string $html - HTML to repair
  * @return string - repaired HTML
@@ -1532,11 +1532,15 @@ function wfFixMalformedHTML( $html ) {
 	// what we're using it to fix) see: http://www.php.net/manual/en/domdocument.loadhtml.php#95463
 	libxml_use_internal_errors( true );
 
-	// Make sure loadHTML knows that text is utf-8 (it assumes ISO-88591)
 	// CONN-130 - Added <!DOCTYPE html> to allow HTML5 tags in the article comment
 	$htmlHeader = '<!DOCTYPE html><html>';
+
+	// Make sure loadHTML knows that text is utf-8 (it assumes ISO-88591)
 	$htmlHeader .= '<head><meta http-equiv="content-type" content="text/html; charset=utf-8"></head>';
-	$htmlHeader .= '<div id="wfFixMalformedHTML">';
+
+	// SUS-237 - Wrap in <body> tag to prevent wrapping simple text with <p> tags and stripping HTML comments and script tags
+	// This also simplifies the return value extraction
+	$htmlHeader .= '<body>';
 
 	$domDocument->loadHTML( $htmlHeader . $html );
 
@@ -1544,11 +1548,8 @@ function wfFixMalformedHTML( $html ) {
 	// to html above to declare the charset as UTF-8
 	$html = preg_replace(
 		array(
-			'/^.*?<body>/si', '/^.*?charset=utf-8">/si',
-			'/<\/body><\/html>$/si',
-			'/<\/head><\/html>$/si',
-			'/^<div id="wfFixMalformedHTML">/',
-			'/<\\/div>$/',
+			'/^.*<body>/s',
+			'/<\/body>\s*<\/html>$/s',
 		),
 		'',
 		$domDocument->saveHTML()

--- a/includes/wikia/tests/FixMalformedHTMLTest.php
+++ b/includes/wikia/tests/FixMalformedHTMLTest.php
@@ -17,8 +17,12 @@ class FixMalformedHTMLTest extends WikiaBaseTest {
 	function validWikiaHTMLDataProvider() {
 		return [
 			[
-				'simplest text',
+				'simplest paragraph',
 				'<p>simplest</p>'
+			],
+			[
+				'simplest text',
+				'simplest'
 			],
 			[
 				'paragraph with some formatting',
@@ -35,6 +39,10 @@ class FixMalformedHTMLTest extends WikiaBaseTest {
 			[
 				'video markup',
 				'<figure class="article-thumb tright show-info-icon" style="width: 330px"><a href="http://lizlux.liz.wikia-dev.com/wiki/File:Injustice_-_Explaining_Blackest_Night" class="video video-thumbnail medium image lightbox " itemprop="video" itemscope="" itemtype="http://schema.org/VideoObject"><img src="http://static.liz.wikia-dev.com/__cb20130401202327/video151/images/thumb/f/f5/Injustice_-_Explaining_Blackest_Night/330px-Injustice_-_Explaining_Blackest_Night.jpg" data-video-key="Injustice_-_Explaining_Blackest_Night" data-video-name="Injustice - Explaining Blackest Night" width="330" height="185" alt="Injustice - Explaining Blackest Night" itemprop="thumbnail"><span class="duration" itemprop="duration">02:28</span><span class="play-circle"></span><meta itemprop="duration" content="PT02M28S"></a><figcaption><a href="/wiki/File:Injustice_-_Explaining_Blackest_Night" class="sprite info-icon"></a><p class="title">Injustice - Explaining Blackest Night</p></figcaption></figure>'
+			],
+			[
+				'polls markup',
+				'<!-- AjaxPoll #0 --><script>JSSnippetsStack.push({dependencies:["/extensions/wikia/AjaxPoll/css/AjaxPoll.scss","/extensions/wikia/AjaxPoll/js/AjaxPoll.js"],callback:function(json){AjaxPoll.init(json)},id:"AjaxPoll.init"})</script><!-- s:poll --><div class="ajax-poll" id="ajax-poll-1A3080EAB9A09BA16F83B62BAEA7336F"><div class="header">Glee is awesome	</div><div id="wpPollStatus1A3080EAB9A09BA16F83B62BAEA7336F" class="center"> </div><form action="#" method="post" id="axPoll1A3080EAB9A09BA16F83B62BAEA7336F"><input type="hidden" name="wpPollId" value="1A3080EAB9A09BA16F83B62BAEA7336F"><div id="ajax-poll-area"><div class="pollAnswer" id="pollAnswer2"><div class="pollAnswerName"><label for="pollAnswerRadio1A3080EAB9A09BA16F83B62BAEA7336F"><input type="radio" name="wpPollRadio1A3080EAB9A09BA16F83B62BAEA7336F" id="wpPollRadio1A3080EAB9A09BA16F83B62BAEA7336F" value="2">Polls are great			</label></div><div class="pollAnswerVotes" onmouseover=\'span=this.getElementsByTagName("span")[0];tmpPollVar=span.innerHTML;span.innerHTML=span.title;span.title="";\' onmouseout=\'span=this.getElementsByTagName("span")[0];span.title=span.innerHTML;span.innerHTML=tmpPollVar;\'><span id="wpPollVote1A3080EAB9A09BA16F83B62BAEA7336F-2" title="0">0</span><div class="wpPollBar1A3080EAB9A09BA16F83B62BAEA7336F" id="wpPollBar1A3080EAB9A09BA16F83B62BAEA7336F-2" style="width: 0%;"> </div></div></div><div class="pollAnswer" id="pollAnswer3"><div class="pollAnswerName"><label for="pollAnswerRadio1A3080EAB9A09BA16F83B62BAEA7336F"><input type="radio" name="wpPollRadio1A3080EAB9A09BA16F83B62BAEA7336F" id="wpPollRadio1A3080EAB9A09BA16F83B62BAEA7336F" value="3">Glee polls rock			</label></div><div class="pollAnswerVotes" onmouseover=\'span=this.getElementsByTagName("span")[0];tmpPollVar=span.innerHTML;span.innerHTML=span.title;span.title="";\' onmouseout=\'span=this.getElementsByTagName("span")[0];span.title=span.innerHTML;span.innerHTML=tmpPollVar;\'><span id="wpPollVote1A3080EAB9A09BA16F83B62BAEA7336F-3" title="100% aller Stimmen">1</span><div class="wpPollBar1A3080EAB9A09BA16F83B62BAEA7336F" id="wpPollBar1A3080EAB9A09BA16F83B62BAEA7336F-3" style="width: 100%; border:0;"> </div></div></div><br style="clear: both;"><div>Die Umfrage wurde am March 24, 2016 um 20:44 erstellt. Bisher haben <span class="total" id="wpPollTotal1A3080EAB9A09BA16F83B62BAEA7336F">1</span> Nutzer abgestimmt.			</div></div><input type="submit" name="wpVote" id="axPollSubmit1A3080EAB9A09BA16F83B62BAEA7336F" value="Abstimmen!"><span id="pollSubmittingInfo1A3080EAB9A09BA16F83B62BAEA7336F" style="padding-left: 10px; visibility: hidden;">Bitte warte kurz, deine Stimme wird verarbeitet.		</span></form></div><!-- e:poll -->'
 			],
 		];
 	}
@@ -96,7 +104,7 @@ class FixMalformedHTMLTest extends WikiaBaseTest {
 			[
 				'Russian text should be handled properly (ie, not returned as garbage)',
 				'Ед дуо малйж факилиз. Йн лорэм видырэр жкрибэнтур ыюм. Мэль альяквюам пырикюлёз ан, аугюэ аккюсам номинави ед жят. Вэл эи унюм емпэтюсъ инзтруктеор, эи модо конгуы дикырыт дуо',
-                '<p>Ед дуо малйж факилиз. Йн лорэм видырэр жкрибэнтур ыюм. Мэль альяквюам пырикюлёз ан, аугюэ аккюсам номинави ед жят. Вэл эи унюм емпэтюсъ инзтруктеор, эи модо конгуы дикырыт дуо</p>'
+                'Ед дуо малйж факилиз. Йн лорэм видырэр жкрибэнтур ыюм. Мэль альяквюам пырикюлёз ан, аугюэ аккюсам номинави ед жят. Вэл эи унюм емпэтюсъ инзтруктеор, эи модо конгуы дикырыт дуо',
 			],
 			[
 				'html snippet should close wrapping tags it opened, even with Russian text',

--- a/skins/oasis/css/core/SpeechBubble.scss
+++ b/skins/oasis/css/core/SpeechBubble.scss
@@ -56,7 +56,6 @@
 		}
 
 		div, figure {
-			height: auto;
 			max-width: 100%;
 		}
 
@@ -90,7 +89,7 @@
 		width: 0;
 	}
 
-	&.even, &.owner { 
+	&.even, &.owner {
 		.speech-bubble-message {
 			background: $color-speech-bubble-alt;
 


### PR DESCRIPTION
This removes a part of the speech bubble fix done in SUS-166. It removes
the `height: auto` on all `divs` within `.speech-bubble-message`. This
doesn't seem to break the original fix for `SUS-166` and also fixes the
current issue.

Also updated the sizing of bars a little bit to reflect the bigger font.
Made the poll bars 19px instead of 12px high and added 4px or margin
below them.

There's also a fix for `wfFixMalformedHTML` that makes the poll not to
load the CSS and JS while in the speech bubble if the poll is the only
content of the forum/wall message (an article comment probably too).
