### PR TITLE
Lyr 237 2

### DIFF
--- a/extensions/3rdparty/LyricWiki/LyricFind/LyricFindTrackingService.class.php
+++ b/extensions/3rdparty/LyricWiki/LyricFind/LyricFindTrackingService.class.php
@@ -113,7 +113,8 @@ class LyricFindTrackingService extends WikiaService {
 		$url = $this->wg->LyricFindApiUrl . '/lyric.do';
 		$data = [
 			'apikey' => $this->wg->LyricFindApiKeys['display'],
-			'ipaddress' => $this->wg->Request->getIP(),
+			//'ipaddress' => $this->wg->Request->getIP(), // territory is better. If we used IP and someone hit from a place where a song is banned, it would ban accross the site.
+			'territory' => 'US',
 			'reqtype' => 'offlineviews',
 			'count' => 1,
 			'trackid' => $trackId,
@@ -193,7 +194,8 @@ class LyricFindTrackingService extends WikiaService {
 		$url = $app->wg->LyricFindApiUrl . '/lyric.do';
 		$data = [
 			'apikey' => $app->wg->LyricFindApiKeys['display'],
-			'ipaddress' => $app->wg->Request->getIP(),
+			//'ipaddress' => $this->wg->Request->getIP(), // territory is better. If we used IP and someone hit from a place where a song is banned, it would ban accross the site.
+			'territory' => 'US',
 			'reqtype' => 'offlineviews',
 			'count' => 1, // This is overcounting since we know it's not a view (page doesn't exist yet), but their API won't accept "0"
 			'trackid' => $trackId,

--- a/extensions/3rdparty/LyricWiki/LyricFind/LyricFindTrackingService.class.php
+++ b/extensions/3rdparty/LyricWiki/LyricFind/LyricFindTrackingService.class.php
@@ -113,6 +113,7 @@ class LyricFindTrackingService extends WikiaService {
 		$url = $this->wg->LyricFindApiUrl . '/lyric.do';
 		$data = [
 			'apikey' => $this->wg->LyricFindApiKeys['display'],
+			'ipaddress' => $this->wg->Request->getIP(),
 			'reqtype' => 'offlineviews',
 			'count' => 1,
 			'trackid' => $trackId,
@@ -192,6 +193,7 @@ class LyricFindTrackingService extends WikiaService {
 		$url = $app->wg->LyricFindApiUrl . '/lyric.do';
 		$data = [
 			'apikey' => $app->wg->LyricFindApiKeys['display'],
+			'ipaddress' => $app->wg->Request->getIP(),
 			'reqtype' => 'offlineviews',
 			'count' => 1, // This is overcounting since we know it's not a view (page doesn't exist yet), but their API won't accept "0"
 			'trackid' => $trackId,


### PR DESCRIPTION
Added territory=US parameter to the LyricFind API calls. Now they will return successfully as desired.

We'd like this to be released before April 1st so that we will have the automatic reporting restored for all of Q2 2016.

The test-case that this works is that this page now returns a status code 200:
http://lyrics.sean.wikia-dev.com/wikia.php?controller=LyricFind&method=track&title=Cake%3AGuitar&amgid=0&gracenoteid=0&rand=55725133
