### PR TITLE
ADEN-3121 Enable Krux based on real ESRB rating and from PHP level

### DIFF
--- a/extensions/wikia/AdEngine/AdEngine2ContextService.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2ContextService.class.php
@@ -57,7 +57,7 @@ class AdEngine2ContextService {
 					'sourcePointRecoveryUrl' => $sourcePointRecoveryUrl,
 				] ),
 				'targeting' => $this->filterOutEmptyItems( [
-					'enableKruxTargeting' => $wg->EnableKruxTargeting,
+					'enableKruxTargeting' => AnalyticsProviderKrux::isEnabled(),
 					'enablePageCategories' => array_search( $langCode, $wg->AdPageLevelCategoryLangs ) !== false,
 					'esrbRating' => AdTargeting::getEsrbRating(),
 					'mappedVerticalName' => $this->getMappedVerticalName( $oldWikiVertical, $newWikiVertical ), //wikiCategory replacement for AdLogicPageParams.js::getPageLevelParams

--- a/extensions/wikia/AdEngine/AdEngine2ContextService.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2ContextService.class.php
@@ -71,7 +71,7 @@ class AdEngine2ContextService {
 					'wikiCategory' => $wikiFactoryHub->getCategoryShort( $wg->CityId ),
 					'wikiCustomKeyValues' => $wg->DartCustomKeyValues,
 					'wikiDbName' => $wg->DBname,
-					'wikiDirectedAtChildren' => $wg->WikiDirectedAtChildrenByFounder || $wg->WikiDirectedAtChildrenByStaff,
+					'wikiDirectedAtChildren' => $wg->WikiDirectedAtChildrenByFounder || $wg->WikiDirectedAtChildrenByStaff, // FIXME ADEN-3147
 					'wikiIsCorporate' => $wikiaPageType->isCorporatePage(),
 					'wikiIsTop1000' => $wg->AdDriverWikiIsTop1000,
 					'wikiLanguage' => $langCode,

--- a/extensions/wikia/AdEngine/AdTargeting.class.php
+++ b/extensions/wikia/AdEngine/AdTargeting.class.php
@@ -40,6 +40,9 @@ class AdTargeting {
 		$pairs = explode(';', $wgDartCustomKeyValues);
 
 		foreach ($pairs as $pair) {
+			if (strpos($pair, '=') === false) {
+				continue;
+			}
 			list($key, $value) = explode('=', $pair);
 			if ($key === 'esrb') {
 				$dartRating = $value;

--- a/extensions/wikia/AdEngine/AdTargeting.class.php
+++ b/extensions/wikia/AdEngine/AdTargeting.class.php
@@ -24,6 +24,13 @@ class AdTargeting {
 	}
 
 	/**
+	 * @return bool
+	 */
+	static public function isDirectedAtChildren() {
+		return self::getEsrbRating() === self::EARLY_CHILDHOOD;
+	}
+
+	/**
 	 * @return null|string
 	 */
 	static private function getEsrbRatingFromDartKeyValues() {

--- a/extensions/wikia/AdEngine/js/AdContext.js
+++ b/extensions/wikia/AdEngine/js/AdContext.js
@@ -126,7 +126,8 @@ define('ext.wikia.adEngine.adContext', [
 			isUrlParamSet('incontentplayer');
 
 		// INCONTENT_LEADERBOARD slot
-		context.slots.incontentLeaderboard = geo.isProperGeo(instantGlobals.wgAdDriverIncontentLeaderboardSlotCountries);
+		context.slots.incontentLeaderboard =
+			geo.isProperGeo(instantGlobals.wgAdDriverIncontentLeaderboardSlotCountries);
 
 		context.opts.scrollHandlerConfig = instantGlobals.wgAdDriverScrollHandlerConfig;
 		context.opts.enableScrollHandler = geo.isProperGeo(instantGlobals.wgAdDriverScrollHandlerCountries) ||
@@ -137,8 +138,8 @@ define('ext.wikia.adEngine.adContext', [
 			context.targeting.enableKruxTargeting &&
 			geo.isProperGeo(instantGlobals.wgAdDriverKruxCountries) &&
 			!instantGlobals.wgSitewideDisableKrux &&
-			!context.targeting.wikiDirectedAtChildren &&
-			!noExternals
+			context.targeting.esrbRating !== 'ec' && // FIXME ADEN-3147
+			!noExternals // FIXME ADEN-3147
 		);
 
 		// Floating medrec

--- a/extensions/wikia/AdEngine/js/AdLogicPageParams.js
+++ b/extensions/wikia/AdEngine/js/AdLogicPageParams.js
@@ -100,7 +100,7 @@ define('ext.wikia.adEngine.adLogicPageParams', [
 	function overrideEsrbRating(params) {
 		params.esrb = context.targeting.esrbRating || params.esrb;
 
-		if (!params.esrb) {
+		if (!params.esrb) { // FIXME ADEN-3147
 			params.esrb = context.targeting.wikiDirectedAtChildren ? 'ec' : 'teen';
 		}
 	}

--- a/extensions/wikia/AdEngine/js/spec/AdContext.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/AdContext.spec.js
@@ -385,12 +385,12 @@ describe('AdContext', function () {
 	it('disables krux when wiki is directed at children', function () {
 		var adContext;
 
-		mocks.win = {ads: {context: {targeting: {wikiDirectedAtChildren: false, enableKruxTargeting: true}}}};
+		mocks.win = {ads: {context: {targeting: {esrbRating: 'teen', enableKruxTargeting: true}}}};
 		mocks.instantGlobals = {wgAdDriverKruxCountries: ['CURRENT_COUNTRY']};
 		adContext = getModule();
 		expect(adContext.getContext().targeting.enableKruxTargeting).toBeTruthy();
 
-		mocks.win = {ads: {context: {targeting: {wikiDirectedAtChildren: true, enableKruxTargeting: true}}}};
+		mocks.win = {ads: {context: {targeting: {esrbRating: 'ec', enableKruxTargeting: true}}}};
 		mocks.instantGlobals = {wgAdDriverKruxCountries: ['CURRENT_COUNTRY']};
 		adContext = getModule();
 		expect(adContext.getContext().targeting.enableKruxTargeting).toBeFalsy();

--- a/extensions/wikia/AdEngine/tests/AdTargetingTest.php
+++ b/extensions/wikia/AdEngine/tests/AdTargetingTest.php
@@ -53,4 +53,14 @@ class AdTargetingTest extends WikiaBaseTest {
 		$this->assertEquals(AdTargeting::EVERYONE, AdTargeting::getEsrbRating());
 	}
 
+	public function testIsDirectedAtChildren() {
+		$this->mockGlobalVariable('wgWikiDirectedAtChildrenByStaff', true);
+
+		$this->assertTrue(AdTargeting::isDirectedAtChildren());
+	}
+
+	public function testIsNotDirectedAtChildren() {
+		$this->assertFalse(AdTargeting::isDirectedAtChildren());
+	}
+
 }

--- a/extensions/wikia/AdEngine/tests/AdTargetingTest.php
+++ b/extensions/wikia/AdEngine/tests/AdTargetingTest.php
@@ -48,7 +48,7 @@ class AdTargetingTest extends WikiaBaseTest {
 
 	public function testPickLastRatingFromDartParams() {
 		$this->mockGlobalVariable('wgWikiDirectedAtChildrenByStaff', true);
-		$this->mockGlobalVariable('wgDartCustomKeyValues', 'esrb=mature;key1=value1;esrb=everyone');
+		$this->mockGlobalVariable('wgDartCustomKeyValues', 'esrb=mature;key1=value1;esrb=everyone;non_key_value');
 
 		$this->assertEquals(AdTargeting::EVERYONE, AdTargeting::getEsrbRating());
 	}

--- a/extensions/wikia/AnalyticsEngine/AnalyticsProviderKrux.php
+++ b/extensions/wikia/AnalyticsEngine/AnalyticsProviderKrux.php
@@ -5,11 +5,21 @@ class AnalyticsProviderKrux implements iAnalyticsProvider {
 	private static $siteId = 'JU3_GW1b';
 	private static $template = 'extensions/wikia/AnalyticsEngine/templates/krux.mustache';
 
+	static function isEnabled() {
+		global $wgEnableKruxTargeting, $wgNoExternals;
+
+		return !$wgNoExternals && $wgEnableKruxTargeting && !AdTargeting::isDirectedAtChildren();
+	}
+
 	function getSetupHtml( $params = array() ) {
 		return null;
 	}
 
 	function trackEvent( $event, $eventDetails = array() ) {
+		if ( !self::isEnabled() ) {
+			return '<!-- Krux disabled -->';
+		}
+
 		switch ($event) {
 			case AnalyticsEngine::EVENT_PAGEVIEW:
 				return $this->trackPageView();


### PR DESCRIPTION
Changes:
- run krux code when ESRB rating != 'ec'
- move basic checking to php level and don't attach code if not needed 
