### PR TITLE
PLATFORM-1915: Allow throwing exceptions in external requests in WikiaDispatcher

### DIFF
--- a/includes/wikia/nirvana/WikiaApp.class.php
+++ b/includes/wikia/nirvana/WikiaApp.class.php
@@ -603,7 +603,6 @@ class WikiaApp {
 	 * @param string $controllerName The name of the controller, without the 'Controller' or 'Model' suffix
 	 * @param string $methodName The name of the Controller method to call
 	 * @param array $params An array with the parameters to pass to the specified method
-	 * @param boolean $internal whether it's an internal (PHP to PHP) or external request
 	 * @param int $exceptionMode exception mode
 	 *
 	 * @return WikiaResponse a response object with the data produced by the method call
@@ -651,7 +650,6 @@ class WikiaApp {
 	 * @param string $controllerName The name of the controller, without the 'Controller' or 'Model' suffix
 	 * @param string $methodName The name of the Controller method to call
 	 * @param array $params An array with the parameters to pass to the specified method
-	 * @param boolean $internal whether it's an internal (PHP to PHP) or external request
 	 * @param int $exceptionMode exception mode
 	 *
 	 * @return WikiaResponse a response object with the data produced by the method call

--- a/includes/wikia/nirvana/WikiaApp.class.php
+++ b/includes/wikia/nirvana/WikiaApp.class.php
@@ -656,8 +656,8 @@ class WikiaApp {
 	 *
 	 * @return WikiaResponse a response object with the data produced by the method call
 	 */
-	public function sendExternalRequest( $controllerName, $methodName, $params = array() ) {
-		return $this->sendRequest( $controllerName, $methodName, $params, /* internal */ false );
+	public function sendExternalRequest( $controllerName, $methodName, $params = array(), $exceptionMode = null ) {
+		return $this->sendRequest( $controllerName, $methodName, $params, /* internal */ false, $exceptionMode );
 	}
 
 	/**

--- a/includes/wikia/nirvana/WikiaDispatchableObject.class.php
+++ b/includes/wikia/nirvana/WikiaDispatchableObject.class.php
@@ -102,10 +102,11 @@ abstract class WikiaDispatchableObject extends WikiaObject {
 	 * @param $controllerName
 	 * @param $methodName
 	 * @param array $params
+	 * @param int $exceptionMode exception mode
 	 * @return WikiaResponse
 	 */
-	protected function sendExternalRequest( $controllerName, $methodName, $params = array() ) {
-		return $this->app->sendExternalRequest( $controllerName, $methodName, $params );
+	protected function sendExternalRequest( $controllerName, $methodName, $params = array(), $exceptionMode = null ) {
+		return $this->app->sendExternalRequest( $controllerName, $methodName, $params, $exceptionMode );
 	}
 
 	protected function sendRequestAcceptExceptions( $controllerName, $methodName, $params = [] ) {

--- a/includes/wikia/nirvana/WikiaRequest.class.php
+++ b/includes/wikia/nirvana/WikiaRequest.class.php
@@ -11,18 +11,21 @@
  */
 class WikiaRequest implements Wikia\Interfaces\IRequest {
 
+	// default = "wrap and throw" for internal requests, "return" for external requests
+	const EXCEPTION_MODE_DEFAULT = -1;
 	const EXCEPTION_MODE_RETURN = 0;
 	const EXCEPTION_MODE_WRAP_AND_THROW = 1;
 	const EXCEPTION_MODE_THROW = 2;
 
 	static private $exceptionModes = [
+		self::EXCEPTION_MODE_DEFAULT,
 		self::EXCEPTION_MODE_RETURN,
 		self::EXCEPTION_MODE_WRAP_AND_THROW,
 		self::EXCEPTION_MODE_THROW,
 	];
 
 	private $isInternal = false;
-	private $exceptionMode = self::EXCEPTION_MODE_WRAP_AND_THROW;
+	private $exceptionMode = self::EXCEPTION_MODE_DEFAULT;
 	protected $params = array();
 
 	/**
@@ -102,6 +105,19 @@ class WikiaRequest implements Wikia\Interfaces\IRequest {
 			throw new InvalidArgumentException( 'Exception mode is invalid' );
 		}
 		$this->exceptionMode = $value;
+	}
+
+	/**
+	 * returns the effective exception mode (resolved the "default" mode depending on "isInternal" flag)
+	 * @return int One of WikiaRequest::EXCEPTION_MODE_*
+	 */
+	public function getEffectiveExceptionMode() {
+		$exceptionMode = $this->getExceptionMode();
+		if ( $exceptionMode == self::EXCEPTION_MODE_DEFAULT ) {
+			$exceptionMode = $this->isInternal() ? self::EXCEPTION_MODE_WRAP_AND_THROW : self::EXCEPTION_MODE_RETURN;
+		}
+
+		return $exceptionMode;
 	}
 
 	/**

--- a/includes/wikia/nirvana/WikiaSpecialPageController.class.php
+++ b/includes/wikia/nirvana/WikiaSpecialPageController.class.php
@@ -41,7 +41,7 @@ class WikiaSpecialPageController extends WikiaController {
 		unset($params['controller']);
 		unset($params['method']);
 
-		$response = $this->sendExternalRequest( get_class( $this ), null, $params );
+		$response = $this->sendExternalRequest( get_class( $this ), null, $params, WikiaRequest::EXCEPTION_MODE_THROW );
 		$this->response = $response;
 
 		if( $response->getFormat() == WikiaResponse::FORMAT_HTML ) {


### PR DESCRIPTION
There is an issue with no permissions error message on special pages powered by Nirvana controllers. This aims to fix the issue and improve the flexibility of `WikiaDispatcher` however I needed to introduce the new method `WikiaRequest::getEffectiveExceptionMode()` in order to keep the current behavior untouched for any other cases. The change will also make all exceptions occurring while handling external requests propagate to ELK.

Comments welcome!

https://wikia-inc.atlassian.net/browse/PLATFORM-1915

/cc @macbre @owend 
