### PR TITLE
WScribeClient: improve errors logging

### DIFF
--- a/extensions/wikia/Scribe/ScribeClient.php
+++ b/extensions/wikia/Scribe/ScribeClient.php
@@ -15,7 +15,9 @@ class WScribeClient {
 
 	protected $category, $connected = false;
 	/* @var scribeClient $client */
-	protected $host, $port, $socket, $client, $protocol, $transport;
+	protected $host, $port, $socket, $client, $protocol;
+	/* @var TFramedTransport $transport */
+	protected $transport;
 
 	const CATEGORY_KEY = 'category';
 	const MESSAGE_KEY = 'message';


### PR DESCRIPTION
[PLATFORM-1955](https://wikia-inc.atlassian.net/browse/PLATFORM-1955)

Use a proper severity and emit log messages with context when reporting Scribe errors.

And get rid of `Wikia::log` calls that always emit log messages at `debug` level.

@wladekb 
