### PR TITLE
SOC-409 don't send emails to unconfirmed email addresses

### DIFF
--- a/extensions/wikia/Email/Controller/EmailConfirmationController.class.php
+++ b/extensions/wikia/Email/Controller/EmailConfirmationController.class.php
@@ -26,6 +26,7 @@ abstract class AbstractEmailConfirmationController extends EmailController {
 	 * A redefinition of our parent's assertCanEmail which removes assertions:
 	 *
 	 * - assertUserWantsEmail : Even if a user says they don't want email, they should get this
+	 * - assertEmailIsConfirmed : Even if a user hasn't confirmed their email address, they should get this
 	 * - assertUserNotBlocked : Even if a user is blocked they should still get these emails
 	 *
 	 * @throws \Email\Fatal

--- a/extensions/wikia/Email/Controller/ForgotPasswordController.class.php
+++ b/extensions/wikia/Email/Controller/ForgotPasswordController.class.php
@@ -20,6 +20,7 @@ class ForgotPasswordController extends EmailController {
 	 * A redefinition of our parent's assertCanEmail which removes assertions:
 	 *
 	 * - assertUserWantsEmail : Even if a user says they don't want email, they should get this
+	 * - assertEmailIsConfirmed : Even if a user hasn't confirmed their email address, they should get this
 	 * - assertUserNotBlocked : Even if a user is blocked they should still get these emails
 	 *
 	 * @throws \Email\Fatal

--- a/extensions/wikia/Email/EmailController.class.php
+++ b/extensions/wikia/Email/EmailController.class.php
@@ -541,6 +541,7 @@ abstract class EmailController extends \WikiaController {
 	public function assertCanEmail() {
 		$this->assertUserHasEmail();
 		$this->assertUserWantsEmail();
+		$this->assertEmailIsConfirmed();
 		$this->assertUserNotBlocked();
 	}
 
@@ -591,6 +592,17 @@ abstract class EmailController extends \WikiaController {
 	public function assertUserWantsEmail() {
 		if ( (bool)$this->targetUser->getGlobalPreference( 'unsubscribed' ) ) {
 			throw new Check( 'User does not wish to receive email' );
+		}
+	}
+
+	/**
+	 * This checks if the user has confirmed their email address
+	 *
+	 * @throws \Email\Check
+	 */
+	public function assertEmailIsConfirmed() {
+		if ( !$this->targetUser->isEmailConfirmed() ) {
+			throw new Check( 'User does not have a confirmed email address' );
 		}
 	}
 


### PR DESCRIPTION
Ticket: https://wikia-inc.atlassian.net/browse/SOC-409

Don't send emails to users who haven't confirmed their email address.

This is accomplished by adding an additional check inside of `EmailController:: assertCanEmail` which checks if target user's email is confirmed before sending.

The AC also state that confirmation emails and password reminder emails (which includes fb disconnect), should be sent no matter what. That will still be the case since the controllers for those emails override the `assertCanEmail` method which you can see in the PR below. Those are the only 2 email controllers which override the `assertCanEmail` method and do not call the base class version as well.
