### PR TITLE
SOC-1369 Fix URLs in message wall reply emails

### DIFF
--- a/extensions/wikia/Email/Controller/WallMessageController.class.php
+++ b/extensions/wikia/Email/Controller/WallMessageController.class.php
@@ -182,7 +182,7 @@ class OwnWallMessageController extends WallMessageController {
 	}
 }
 
-class ReplyWallMessageController extends OwnWallMessageController {
+class ReplyWallMessageController extends WallMessageController {
 
 	/** @var \Title */
 	protected $containingThread;

--- a/extensions/wikia/Email/Controller/WallMessageController.class.php
+++ b/extensions/wikia/Email/Controller/WallMessageController.class.php
@@ -166,6 +166,7 @@ class OwnWallMessageController extends WallMessageController {
 	 * @return string
 	 */
 	protected function getSummary() {
+		jmark();
 		return $this->getMessage( 'emailext-wallmessage-owned-summary',
 			$this->wallMessageTitle->getFullURL(),
 			$this->titleText
@@ -184,6 +185,14 @@ class OwnWallMessageController extends WallMessageController {
 
 class ReplyWallMessageController extends OwnWallMessageController {
 
+	/** @var \Title */
+	protected $containingThread;
+
+	public function initEmail() {
+		parent::initEmail();
+		$this->containingThread = \Title::newFromText( $this->getVal( 'parentId' ), NS_USER_WALL_MESSAGE );
+	}
+
 	/**
 	 * Get the summary text immediately following the salutation in the email
 	 *
@@ -191,7 +200,7 @@ class ReplyWallMessageController extends OwnWallMessageController {
 	 */
 	protected function getSummary() {
 		return $this->getMessage( 'emailext-wallmessage-reply-summary',
-			$this->wallMessageTitle->getFullURL(),
+			$this->containingThread->getFullURL(),
 			$this->titleText
 		)->parse();
 	}
@@ -206,12 +215,12 @@ class ReplyWallMessageController extends OwnWallMessageController {
 	}
 
 	protected function getFooterMessages() {
-		$unwatchUrl = $this->wallMessageTitle->getFullURL( [
+		$unwatchUrl = $this->containingThread->getFullURL( [
 			'action' => 'unwatch'
 		] );
 
 		$footerMessages = [
-			$this->getMessage( 'emailext-unfollow-text', $unwatchUrl, $this->wallMessageTitle->getPrefixedText() )
+			$this->getMessage( 'emailext-unfollow-text', $unwatchUrl, $this->containingThread->getPrefixedText() )
 				->parse()
 		];
 		return array_merge( $footerMessages, parent::getFooterMessages() );

--- a/extensions/wikia/Email/Controller/WallMessageController.class.php
+++ b/extensions/wikia/Email/Controller/WallMessageController.class.php
@@ -224,6 +224,22 @@ class ReplyWallMessageController extends WallMessageController {
 		];
 		return array_merge( $footerMessages, parent::getFooterMessages() );
 	}
+
+	protected static function getEmailSpecificFormFields() {
+		$formFields = [
+			"inputs" => [
+				[
+					'type'  => 'text',
+					'name' => 'parentId',
+					'label' => 'parentID',
+					'tooltip' => 'Message thread ID, eg. http://community.wikia.com/wiki/Thread:<threadId>. ' .
+						'Use the same value as you did for threadId.'
+				]
+			]
+		];
+
+		return array_merge_recursive( parent::getEmailSpecificFormFields(), $formFields );
+	}
 }
 
 class FollowedWallMessageController extends WallMessageController {

--- a/extensions/wikia/Email/Controller/WallMessageController.class.php
+++ b/extensions/wikia/Email/Controller/WallMessageController.class.php
@@ -166,7 +166,6 @@ class OwnWallMessageController extends WallMessageController {
 	 * @return string
 	 */
 	protected function getSummary() {
-		jmark();
 		return $this->getMessage( 'emailext-wallmessage-owned-summary',
 			$this->wallMessageTitle->getFullURL(),
 			$this->titleText


### PR DESCRIPTION
Ticket: https://wikia-inc.atlassian.net/browse/SOC-1369

This PR fixes links in the message wall reply emails which were incorrect. They were pointing to pages which only showed the individual replies (eg [this](http://community.wikia.com/wiki/Thread:918372)), rather than a page showing the whole thread (eg [this](http://community.wikia.com/wiki/Thread:918186)).

The problem was that we were using the pageId of the reply, rather than the pageId of the thread to construct the URLs. This is fixed by using the `parentId` value being passed into the controller, rather than `threadId` like we'd been using.
