### PR TITLE
(CE-3571) Insert new infobox into querycache on creation

### DIFF
--- a/extensions/wikia/PortableInfobox/PortableInfobox.setup.php
+++ b/extensions/wikia/PortableInfobox/PortableInfobox.setup.php
@@ -81,6 +81,7 @@ $wgHooks[ 'AllInfoboxesQueryRecached' ][] = 'PortableInfoboxHooks::onAllInfoboxe
 $wgHooks[ 'ArticlePurge' ][] = 'PortableInfoboxHooks::onArticlePurge';
 $wgHooks[ 'ArticleSave' ][] = 'PortableInfoboxHooks::onArticleSave';
 $wgHooks[ 'BacklinksPurge' ][] = 'PortableInfoboxHooks::onBacklinksPurge';
+$wgHooks[ 'ArticleInsertComplete' ][] = 'PortableInfoboxHooks::onArticleInsertComplete';
 
 // special pages
 $wgSpecialPages[ 'AllInfoboxes' ] = 'AllinfoboxesQueryPage';


### PR DESCRIPTION
When a new portable infobox is created, add it to the querycache for the
AllInfoboxes list and purge its cache.

/cc @Wikia/community-engineering 
