### PR TITLE
(JPN-404) Only redirect to VE if VE is enabled for that namespace

### DIFF
--- a/extensions/InputBox/InputBox.hooks.php
+++ b/extensions/InputBox/InputBox.hooks.php
@@ -31,49 +31,36 @@ class InputBoxHooks {
 		// Return output
 		return $inputBox->render();
 	}
-	
+
 	/**
-	 * <inputbox type=create...> sends requests with action=edit, and 
-	 * possibly a &prefix=Foo.  So we pick that up here, munge prefix 
+	 * <inputbox type=create...> sends requests with action=edit, and
+	 * possibly a &prefix=Foo.  So we pick that up here, munge prefix
 	 * and title together, and redirect back out to the real page
 	 * @param $output OutputPage
 	 * @param $article Article
 	 * @param $title Title
 	 * @param $user User
-	 * @param $request WebRequest 
+	 * @param $request WebRequest
 	 * @param $wiki MediaWiki
 	 * @return True
 	 */
-	public static function onMediaWikiPerformAction( 
-		$output, 
-		$article, 
-		$title, 
-		$user, 
-		$request, 
+	public static function onMediaWikiPerformAction(
+		$output,
+		$article,
+		$title,
+		$user,
+		$request,
 		$wiki )
 	{
-		global $wgScript;
+		global $wgScript, $wgVisualEditorNamespaces;
 
-		if( $wiki->getAction( $request ) !== 'edit' ) {
-			# not our problem
+		if ( $wiki->getAction( $request ) !== 'edit' ) {
+			// not our problem
 			return true;
 		}
 
+		$doRedirect = false;
 		$params = $request->getValues();
-
-		$redirectToVE = !empty( $params['preload'] ) &&
-			EditorPreference::isVisualEditorPrimary() &&
-			$user->isLoggedIn();
-
-		if ( empty( $params['prefix'] ) && !$redirectToVE ) {
-			// Fine
-			return true;
-		}
-
-		if ( $redirectToVE ) {
-			$params['veaction'] = 'edit';
-			unset( $params['action'] );
-		}
 
 		if ( !empty( $params['prefix'] ) ) {
 			$title = $params['prefix'];
@@ -82,6 +69,25 @@ class InputBoxHooks {
 			}
 			unset( $params['prefix'] );
 			$params['title'] = $title;
+			$doRedirect = true;
+		}
+
+		$title = Title::newFromText( $params['title'] );
+
+		if (
+			!empty( $params['preload'] ) &&
+			EditorPreference::isVisualEditorPrimary() &&
+			$user->isLoggedIn() &&
+			$title instanceof Title &&
+			$title->inNamespaces( $wgVisualEditorNamespaces )
+		) {
+			$params['veaction'] = 'edit';
+			unset( $params['action'] );
+			$doRedirect = true;
+		}
+
+		if ( !$doRedirect ) {
+			return true;
 		}
 
 		$output->redirect( wfAppendQuery( $wgScript, $params ), '301' );

--- a/extensions/InputBox/InputBox.hooks.php
+++ b/extensions/InputBox/InputBox.hooks.php
@@ -76,6 +76,7 @@ class InputBoxHooks {
 
 		if (
 			!empty( $params['preload'] ) &&
+			empty( $params['section'] ) &&
 			EditorPreference::isVisualEditorPrimary() &&
 			$user->isLoggedIn() &&
 			$title instanceof Title &&


### PR DESCRIPTION
The previous code was always redirecting to VE even if VE was disabled
for a namespace. This checks if the namespace has VE enabled first which
needs to occur after making changes to the title with the prefix parameter.

/cc @perjg 
