### PR TITLE
SOC-2164 Discussion moderators should not be permitted to delete blog

### DIFF
--- a/extensions/wikia/Blogs/BlogLockdown.php
+++ b/extensions/wikia/Blogs/BlogLockdown.php
@@ -165,8 +165,20 @@ class BlogLockdown {
 	 */
 	public static function onBeforeDeletePermissionErrors( &$article, &$title, &$user, &$permission_errors ) {
 		// Only users with delete permission can delete a blog article
+
+		$accessErrorKey = 'badaccess-group0';
 		if ( $title->getNamespace() == NS_BLOG_ARTICLE && !$user->isAllowed( 'delete' ) ) {
-			$permission_errors[] = [ 'badaccess-group0' ];
+			$errorExists = false;
+			foreach ( $permission_errors as $errors ) {
+				if ( in_array( $accessErrorKey, $errors ) ) {
+					$errorExists = true;
+					break;
+				}
+			}
+
+			if ( !$errorExists ) {
+				$permission_errors[] = [ $accessErrorKey ];
+			}
 		}
 
 		return true;

--- a/extensions/wikia/Blogs/BlogLockdown.php
+++ b/extensions/wikia/Blogs/BlogLockdown.php
@@ -152,4 +152,23 @@ class BlogLockdown {
 
 		return $return;
 	}
+
+	/**
+	 * Checks permission before delete action on blog articles
+	 *
+	 * @param Article $article
+	 * @param Title $title
+	 * @param User $user
+	 * @param array $permission_errors
+	 *
+	 * @return boolean because it's a hook
+	 */
+	public static function onBeforeDeletePermissionErrors( &$article, &$title, &$user, &$permission_errors ) {
+		// Only users with delete permission can delete a blog article
+		if ( $title->getNamespace() == NS_BLOG_ARTICLE && !$user->isAllowed( 'delete' ) ) {
+			$permission_errors[] = [ 'badaccess-group0' ];
+		}
+
+		return true;
+	}
 }

--- a/extensions/wikia/Blogs/Blogs.php
+++ b/extensions/wikia/Blogs/Blogs.php
@@ -112,6 +112,9 @@ $wgHooks[ 'TitleMoveComplete' ][] = 'BlogsHelper::onTitleMoveComplete';
 // Usages of images on blogs on file pages
 $wgHooks['FilePageImageUsageSingleLink'][] = 'BlogsHelper::onFilePageImageUsageSingleLink';
 
+// Checking that user is permitted to delete blog articles
+$wgHooks['BeforeDeletePermissionErrors'][] = 'BlogLockdown::onBeforeDeletePermissionErrors';
+
 /**
  * load other parts
  */


### PR DESCRIPTION
Adds a hook to the pre-deletion action to make sure that users have delete permission prior to deleting a blog article. As a result, Discussion moderators will not be able to use a workaround to delete blog articles; they are and still should be able to delete blog comments.

/CC @jsutterfield 
