### PR TITLE
ER-12109: ParserCache - kill notice

### DIFF
--- a/includes/parser/ParserCache.php
+++ b/includes/parser/ParserCache.php
@@ -244,11 +244,10 @@ class ParserCache {
 
 			if ( !$wgArticleAsJson ) {
 				$info = "Saved in parser cache with key $parserOutputKey";
+				wfDebug( "$info\n" );
 
 				$parserOutput->mText .= "\n<!-- $info -->\n";
 			}
-
-			wfDebug( "$info\n" );
 			// Wikia change - end
 
 			// Save the parser output


### PR DESCRIPTION
[ER-12109](https://wikia-inc.atlassian.net/browse/ER-12109)

Get rid of `PHP Notice: Undefined variable: info in /includes/parser/ParserCache.php on line 251`

@mixth-sense 
