### PR TITLE
JPN-394 Use string for task page call to action for both task page 

### DIFF
--- a/extensions/wikia/CommunityPageExperiment/modules/ext.communityPageExperimentEntryPoint.js
+++ b/extensions/wikia/CommunityPageExperiment/modules/ext.communityPageExperimentEntryPoint.js
@@ -21,13 +21,12 @@ require([
 			useTasksPage = inCommunityTasksBucket(),
 			linkUrl = '/wiki/Special:Community',
 			trackingLabel = 'entry-point',
-			callToActionMsg = 'communitypageexperiment-entry-join',
+			callToActionMsg = 'communitypageexperiment-entry-tasks',
 			buttonMsg = 'communitypageexperiment-entry-learn-more';
 
 		if (useTasksPage) {
 			linkUrl = '/wiki/Special:CommunityTasks';
 			trackingLabel = 'tasks-entry-point';
-			callToActionMsg = 'communitypageexperiment-entry-tasks';
 		}
 
 		if (mw.user.anonymous()) {


### PR DESCRIPTION
and community page.

With this change the communitypageexperiment-entry-join is now unused, but I didn't bother removing it since the whole extension will be removed once the experiment is over.
