### PR TITLE
PLATFORM-2061: remove incorrect entries from specials.events_local_users

### DIFF
--- a/maintenance/wikia/cleanEventsLocalUsers.php
+++ b/maintenance/wikia/cleanEventsLocalUsers.php
@@ -1,0 +1,28 @@
+<?php
+
+require_once( __DIR__ . '/../Maintenance.php' );
+
+/**
+ * Remove incorrect entries from specials.events_local_users
+ *
+ * @see PLATFORM-2061
+ */
+class CleanEventsLocalUsersMaintenance extends Maintenance {
+
+	public function execute() {
+		global $wgCityId, $wgSpecialsDB;
+
+		$dbw = $this->getDB( DB_MASTER, [], $wgSpecialsDB );
+		$dbw->query(
+			sprintf( "DELETE FROM events_local_users where wiki_id = '%d' and (user_name = '0' OR all_groups = '0' OR single_group = '0')", $wgCityId ),
+			__METHOD__
+		);
+
+		$this->output( sprintf ("Rows removed: %d\n", $dbw->affectedRows() ) );
+
+		wfWaitForSlaves( $wgSpecialsDB );
+	}
+}
+
+$maintClass = CleanEventsLocalUsersMaintenance::class;
+require_once( RUN_MAINTENANCE_IF_MAIN );


### PR DESCRIPTION
[PLATFORM-2061](https://wikia-inc.atlassian.net/browse/PLATFORM-2061)

Perform the following query for all active wikis (via `run_maintenance` helper script):

``` sql
delete from events_local_users where wiki_id = <city id> and (user_name = '0' OR all_groups = '0' OR single_group = '0')
```

``` sql
mysql@slave.db-specials.service.consul[specials]>explain select 1 from events_local_users where wiki_id = 177 and (user_name = '0' OR all_groups = '0' OR single_group = '0');
+----+-------------+--------------------+-------+-----------------+---------+---------+------+--------+-------------+
| id | select_type | table              | type  | possible_keys   | key     | key_len | ref  | rows   | Extra       |
+----+-------------+--------------------+-------+-----------------+---------+---------+------+--------+-------------+
|  1 | SIMPLE      | events_local_users | range | PRIMARY,wiki_id | PRIMARY | 4       | NULL | 274550 | Using where |
+----+-------------+--------------------+-------+-----------------+---------+---------+------+--------+-------------+
1 row in set (0.00 sec)

mysql@slave.db-specials.service.consul[specials]>explain select 1 from events_local_users where (user_name = '0' OR all_groups = '0' OR single_group = '0');
+----+-------------+--------------------+------+---------------+------+---------+------+------------+-------------+
| id | select_type | table              | type | possible_keys | key  | key_len | ref  | rows       | Extra       |
+----+-------------+--------------------+------+---------------+------+---------+------+------------+-------------+
|  1 | SIMPLE      | events_local_users | ALL  | NULL          | NULL | NULL    | NULL | 1194774417 | Using where |
+----+-------------+--------------------+------+---------------+------+---------+------+------------+-------------+
1 row in set (0.00 sec)
```

This will remove entries affected by https://github.com/Wikia/backend/pull/203

@wladekb / @mixth-sense 
