### PR TITLE
ensure all ForumBoard are showed even if they are not have sort order in wikia props

### DIFF
--- a/extensions/wikia/Forum/Forum.class.php
+++ b/extensions/wikia/Forum/Forum.class.php
@@ -27,8 +27,19 @@ class Forum extends Walls {
 	const LEN_TOO_SMALL_ERR = -2;
 
 	public function getBoardList( $db = DB_SLAVE ) {
-		$titlesBatch = $this->getTitlesForNamespace( $db, NS_WIKIA_FORUM_BOARD );
+		$titlesBatch = TitleBatch::newFromConds( [ ],
+			[ 'page.page_namespace' => NS_WIKIA_FORUM_BOARD ],
+			__METHOD__,
+			[ 'ORDER BY' => 'page_title' ],
+			$db
+		);
+
 		$orderIndexes = $titlesBatch->getWikiaProperties( WPP_WALL_ORDER_INDEX, $db );
+		foreach ( $titlesBatch->getArticleIds() as $id ) {
+			if ( !isset( $orderIndexes[ $id ] ) ) {
+				$orderIndexes[ $id ] = $id;
+			}
+		}
 
 		$boards = [ ];
 		arsort( $orderIndexes );


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-388

@Wikia/sustaining-engineering-team 
