### PR TITLE
PLATFORM-1955: unify logs severity level

### DIFF
--- a/extensions/wikia/ArticleComments/classes/ArticleCommentList.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleCommentList.class.php
@@ -776,8 +776,6 @@ class ArticleCommentList {
 						$task = new \Wikia\Tasks\Tasks\MultiTask();
 						$task->call( 'delete', $data );
 						$submit_id = $task->queue();
-
-						Wikia::log( __METHOD__, 'deletecomment', "Added task ($submit_id) for {$data['page']} page" );
 					}
 				}
 			}
@@ -817,7 +815,14 @@ class ArticleCommentList {
 						$ok = $archive->undelete( '', wfMsg( 'article-comments-undeleted-comment', $new_page_id ) );
 
 						if ( !is_array( $ok ) ) {
-							Wikia::log( __METHOD__, 'error', "cannot restore comment {$page_value['title']} (id: {$page_id})" );
+							Wikia\Logger\WikiaLogger::instance()->error(
+								__METHOD__ . ' - cannot restore comment',
+								[
+									'exception' => new Exception(),
+									'page_id' => (string) $page_id,
+									'page_title' => $page_value['title']
+								]
+							);
 						}
 					}
 				}
@@ -1129,7 +1134,14 @@ class ArticleCommentList {
 				// and WallArticleComment/classes/ArticleComments.class.php have
 				// the same definition of explode() method)
 				// and static constructor newFromText() should create a Title instance for $parts['title']
-				Wikia::log( __METHOD__, false, 'WALL_ARTICLE_COMMENT_ERROR: no main article title: ' . print_r( $parts, true ) . ' namespace: ' . $rcNamespace );
+				Wikia\Logger\WikiaLogger::instance()->error(
+					__METHOD__ . ' - WALL_ARTICLE_COMMENT_ERROR: no main article title',
+					[
+						'exception' => new Exception(),
+						'namespace' => $rcNamespace,
+						'parts' => print_r( $parts, true )
+					]
+				);
 			}
 		}
 

--- a/extensions/wikia/ArticleComments/modules/ArticleCommentsController.class.php
+++ b/extensions/wikia/ArticleComments/modules/ArticleCommentsController.class.php
@@ -200,7 +200,12 @@ class ArticleCommentsController extends WikiaController {
 
 		if ( empty( $data ) ) {
 			// Seems like we should always have data, let's leave a log somewhere if this happens
-			Wikia::log( __METHOD__, false, 'No data, this should not happen.' );
+			Wikia\Logger\WikiaLogger::instance()->error(
+				__METHOD__ . ' - no data, this should not happen',
+				[
+					'exception' => new Exception()
+				]
+			);
 		}
 
 		$this->ajaxicon = $this->wg->StylePath.'/common/images/ajax.gif';

--- a/extensions/wikia/CategoryExhibition/CategoryExhibitionSection.class.php
+++ b/extensions/wikia/CategoryExhibition/CategoryExhibitionSection.class.php
@@ -449,16 +449,13 @@ class CategoryExhibitionSection {
 		$wgMemc->set($this->getTouchedKey($title), time() . rand(0,9999), 60*60*24 );
 	}
 
-	protected function getTouchedKey($title) {
-		//fb#24914
-		if( $title instanceof Title ) {
-			$key = wfMemcKey( 'category_touched', md5($title->getDBKey()), self::CACHE_VERSION );
-			return $key;
-		} else {
-			Wikia::log(__METHOD__, '', '$title not an instance of Title');
-			Wikia::logBacktrace(__METHOD__);
-			return null;
-		}
+	/**
+	 * @param Title $title
+	 * @return string
+	 */
+	protected function getTouchedKey( Title $title ) {
+		$key = wfMemcKey( 'category_touched', md5($title->getDBKey()), self::CACHE_VERSION );
+		return $key;
 	}
 
 	protected function saveToCache( $content ) {

--- a/extensions/wikia/Optimizely/OptimizelyController.class.php
+++ b/extensions/wikia/Optimizely/OptimizelyController.class.php
@@ -2,8 +2,9 @@
 
 class OptimizelyController extends WikiaController {
 
+	use Wikia\Logger\Loggable;
+
 	const OPTIMIZELY_SCRIPT_KEY = 'optimizely_script_v.1.0';
-	const CACHE_DURATION = 300; /* 5 minutes */
 
 	public function getCode() {
 		$response = $this->getResponse();
@@ -13,10 +14,10 @@ class OptimizelyController extends WikiaController {
 		try {
 			$this->code = $storageModel->get( self::OPTIMIZELY_SCRIPT_KEY );
 		} catch ( Exception $e ) {
-			Wikia::log( __METHOD__, false, 'Cannot read Optimizely code from storage.' );
+			$this->error( __METHOD__ . ' - cannot read Optimizely code from storage.', [ 'exception' => $e ] );
 			$this->code = '';
 		}
 
-		$response->setCacheValidity( self::CACHE_DURATION );
+		$response->setCacheValidity( WikiaResponse::CACHE_VERY_SHORT );
 	}
 }

--- a/extensions/wikia/PhalanxII/fallback/Phalanx.class.php
+++ b/extensions/wikia/PhalanxII/fallback/Phalanx.class.php
@@ -347,7 +347,13 @@ class PhalanxFallback {
 			wfSuppressWarnings();
 			$matched = preg_match($blockText, $text, $matches);
 			if ($matched === false) {
-				Wikia::log(__METHOD__, __LINE__, "Bad regex found: $blockText");
+				Wikia\Logger\WikiaLogger::instance()->error(
+					__METHOD__ . ' - bad regex found',
+					[
+						'exception' => new Exception(),
+						'regex' => $blockText
+					]
+				);
 			}
 			wfRestoreWarnings();
 			if ($matched) {
@@ -435,7 +441,13 @@ class PhalanxFallback {
 				wfSuppressWarnings();
 				$matched = preg_match($blockText, $text, $matches);
 				if ($matched === false) {
-					Wikia::log(__METHOD__, __LINE__, "Bad regex found: $blockText");
+					Wikia\Logger\WikiaLogger::instance()->error(
+						__METHOD__ . ' - bad regex found',
+						[
+							'exception' => new Exception(),
+							'regex' => $blockText
+						]
+					);
 				}
 				wfRestoreWarnings();
 				if ($matched) {

--- a/extensions/wikia/PhalanxII/models/PhalanxModel.php
+++ b/extensions/wikia/PhalanxII/models/PhalanxModel.php
@@ -136,7 +136,6 @@ abstract class PhalanxModel extends WikiaObject {
 				'exception' => new Exception( 'Phalanx fallback triggered' )
 			] );
 
-			Wikia::log( __METHOD__, __LINE__, "Call method from previous version of Phalanx - check Phalanx service!\n" );
 			$ret = call_user_func( array( $this, $fallback ) );
 		}
 		return $ret;

--- a/extensions/wikia/UserProfilePageV3/Masthead.class.php
+++ b/extensions/wikia/UserProfilePageV3/Masthead.class.php
@@ -485,9 +485,7 @@ class Masthead {
 
 		$result = $this->doRemoveFile();
 
-		if ( $result === false ) {
-			Wikia::log( __METHOD__, false, 'cannot remove avatar - ' . $this->getLocalPath() );
-		} else {
+		if ( $result !== false ) {
 			// removing default avatars is hanlded by MW even when the service is enabled (PLATFORM-1617)
 			if ( $this->isDefault() ) {
 				$this->mUser->setGlobalAttribute( AVATAR_USER_OPTION_NAME, "" );

--- a/includes/Article.php
+++ b/includes/Article.php
@@ -324,7 +324,7 @@ class Article extends Page {
 				$this->mRevision = Revision::newFromId( $oldid );
 				if ( !$this->mRevision ) {
 					wfDebug( __METHOD__ . " failed to retrieve specified revision, id $oldid\n" );
-					Wikia::log(__METHOD__, 1, "failed to retrieve specified revision, title '$t', id $oldid", true); # Wikia change - @author macbre
+					Wikia\Logger\WikiaLogger::instance()->error( __METHOD__ . " - failed to retrieve specified revision", [ 'title' => $t, 'rev_id' => (string) $oldid ] ); # Wikia change - @author macbre
 					wfProfileOut( __METHOD__ );
 					return false;
 				}
@@ -339,7 +339,7 @@ class Article extends Page {
 			$this->mRevision = $this->mPage->getRevision();
 			if ( !$this->mRevision ) {
 				wfDebug( __METHOD__ . " failed to retrieve current page, rev_id " . $this->mPage->getLatest() . "\n" );
-				Wikia::log(__METHOD__, 3, "failed to retrieve current page, title '$t', rev_id " . $this->mPage->getLatest(), true); # Wikia change - @author macbre
+				Wikia\Logger\WikiaLogger::instance()->error( __METHOD__ . " - failed to retrieve current page", [ 'title' => $t, 'rev_id' => (string) $this->mPage->getLatest() ] ); # Wikia change - @author macbre
 				wfProfileOut( __METHOD__ );
 				return false;
 			}

--- a/includes/parser/Parser.php
+++ b/includes/parser/Parser.php
@@ -4029,6 +4029,14 @@ class Parser {
 
 		$text = Http::get( $url );
 		if ( !$text ) {
+			// Wikia change - begin
+			if ( $text === '' ) {
+				Wikia\Logger\WikiaLogger::instance()->error( __METHOD__ . ' - empty response', [
+					'url' => $url,
+				] );
+			}
+			// Wikia change - end
+
 			return wfMsgForContent( 'scarytranscludefailed', $url );
 		}
 

--- a/includes/parser/Parser.php
+++ b/includes/parser/Parser.php
@@ -4029,9 +4029,6 @@ class Parser {
 
 		$text = Http::get( $url );
 		if ( !$text ) {
-			# wikia start
-			Wikia::log(__METHOD__, false, "Scary transclusion failed for <{$url}>");
-			# wikia end
 			return wfMsgForContent( 'scarytranscludefailed', $url );
 		}
 

--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -453,7 +453,10 @@ class Wikia {
 		$method = $sub ? $method . "-" . $sub : $method;
 		if( $wgDevelEnvironment || $wgErrorLog || $always ) {
 			$method = preg_match('/-WIKIA$/', $method) ? str_replace('-WIKIA', '', $method) : $method;
-			\Wikia\Logger\WikiaLogger::instance()->debug($message, ['method' => $method]);
+			\Wikia\Logger\WikiaLogger::instance()->debug( $message, [
+				'exception' => new Exception(),
+				'method' => $method
+			] );
 		}
 
 		/**

--- a/includes/wikia/nirvana/WikiaDispatcher.class.php
+++ b/includes/wikia/nirvana/WikiaDispatcher.class.php
@@ -250,7 +250,15 @@ class WikiaDispatcher {
 				}
 
 				$response->setException($e);
-				Wikia::log(__METHOD__, $e->getMessage() );
+
+				Wikia\Logger\WikiaLogger::instance()->error(
+					__METHOD__ . " - {$controllerClassName} controller dispatch exception",
+					[
+						'exception' => $e,
+						'controller_name' => $controllerClassName,
+						'method_name' => $method
+					]
+				);
 
 				// if we catch an exception, forward to the WikiaError controller unless we are already dispatching Error
 				if ( empty($controllerClassName) || $controllerClassName != 'WikiaErrorController' ) {


### PR DESCRIPTION
[PLATFORM-1955](https://wikia-inc.atlassian.net/browse/PLATFORM-1955)

Unify severity of error messages sent by MediaWiki
- replace `Wikia::log` calls with `WikiaLogger` + proper severity
- remove `Wikia::log` calls that duplicates `WikiaLogger` messages

@wladekb
