### PR TITLE
LF changed it's response-code for SUCCESS_NO_LYRICS from 106 to 104 s…

### DIFF
--- a/extensions/3rdparty/LyricWiki/LyricFind/LyricFindTrackingService.class.php
+++ b/extensions/3rdparty/LyricWiki/LyricFind/LyricFindTrackingService.class.php
@@ -15,7 +15,7 @@ class LyricFindTrackingService extends WikiaService {
 
 	// Not documented. The response body says "SUCCESS: NO LYRICS" which I assume means that they
 	// have licensing in place, they just don't have lyrics for the song.
-	const CODE_SUCCESS_NO_LYRICS = 106;
+	const CODE_SUCCESS_NO_LYRICS = 104; // used to be 106, now they've changed it in late-March/early-April 2016
 
 	const DEFAULT_USER_AGENT = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.142 Safari/535.19';
 


### PR DESCRIPTION
…ometime in the last week or so. The requests should already be going through fine, but we'll be returning 404s to our client (which makes it artificially look like an issue to us) so fixing this up will let us get to a state where 404s will actually be 404s.
