### PR TITLE
SOC-2269 make sure we have watchers before calling addWatchersToDb

### DIFF
--- a/extensions/wikia/GlobalWatchlist/GlobalWatchlistTask.class.php
+++ b/extensions/wikia/GlobalWatchlist/GlobalWatchlistTask.class.php
@@ -67,7 +67,9 @@ class GlobalWatchlistTask extends BaseTask {
 					}
 				}
 
-				$this->addWatchersToDb( $watchersToAdd );
+				if ( count( $watchersToAdd ) ) {
+					$this->addWatchersToDb( $watchersToAdd );
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Ticket: https://wikia-inc.atlassian.net/browse/SOC-2269

Since we're now doing bulk updates, I forgot the case where all users can be filtered out in the check [here](https://github.com/Wikia/app/blob/dev/extensions/wikia/GlobalWatchlist/GlobalWatchlistTask.class.php#L51), which results in invalid SQL when we make the last call [here](https://github.com/Wikia/app/blob/dev/extensions/wikia/GlobalWatchlist/GlobalWatchlistTask.class.php#L70).

This PR fixes that by checking if we have watchers before calling `addWatchersToDb`.
