### PR TITLE
WikiaTracer: pass the current span ID and report it as parent_span_id in subrequests / subprocesses

### DIFF
--- a/includes/wikia/transaction/TransactionTraceNewrelic.php
+++ b/includes/wikia/transaction/TransactionTraceNewrelic.php
@@ -36,9 +36,10 @@ class TransactionTraceNewrelic {
 			}
 		}
 
-		// report request ID as a custom request parameter for easier debugging of slow transactions
+		// report trace ID and (optionally) parent span ID as a custom request parameter for easier debugging of slow transactions in SOA world
 		if ( function_exists( 'newrelic_add_custom_parameter' ) ) {
 			newrelic_add_custom_parameter( 'traceId', WikiaTracer::instance()->getTraceId() );
+			newrelic_add_custom_parameter( 'parentSpanId', WikiaTracer::instance()->getParentSpanId() );
 		}
 	}
 

--- a/includes/wikia/transaction/TransactionTraceNewrelic.php
+++ b/includes/wikia/transaction/TransactionTraceNewrelic.php
@@ -39,6 +39,7 @@ class TransactionTraceNewrelic {
 		// report trace ID and (optionally) parent span ID as a custom request parameter for easier debugging of slow transactions in SOA world
 		if ( function_exists( 'newrelic_add_custom_parameter' ) ) {
 			newrelic_add_custom_parameter( 'traceId', WikiaTracer::instance()->getTraceId() );
+			newrelic_add_custom_parameter( 'spanId', WikiaTracer::instance()->getSpanId() );
 			newrelic_add_custom_parameter( 'parentSpanId', WikiaTracer::instance()->getParentSpanId() );
 		}
 	}

--- a/lib/Wikia/src/Tracer/WikiaTracer.php
+++ b/lib/Wikia/src/Tracer/WikiaTracer.php
@@ -215,6 +215,13 @@ class WikiaTracer {
 	}
 
 	/**
+	 * @return string
+	 */
+	public function getSpanId() {
+		return $this->spanId;
+	}
+
+	/**
 	 * @return null|string
 	 */
 	public function getParentSpanId() {

--- a/lib/Wikia/src/Tracer/WikiaTracer.php
+++ b/lib/Wikia/src/Tracer/WikiaTracer.php
@@ -9,6 +9,7 @@ class WikiaTracer {
 	const APPLICATION_NAME = 'mediawiki';
 
 	const TRACE_ID_HEADER_NAME = 'X-Trace-Id';
+	const PARENT_SPAN_ID_HEADER_NAME = 'X-Parent-Span-Id';
 	const CLIENT_IP_HEADER_NAME = 'X-Client-Ip';
 	const CLIENT_BEACON_ID_HEADER_NAME = 'X-Client-Beacon-Id';
 	const CLIENT_DEVICE_ID_HEADER_NAME = 'X-Client-Device-Id';
@@ -25,6 +26,7 @@ class WikiaTracer {
 	const ENV_VARIABLES_PREFIX = 'WIKIA_TRACER_';
 
 	private $traceId;
+	private $parentSpanId;
 	private $clientIp;
 	private $clientBeaconId;
 	private $clientDeviceId;
@@ -40,6 +42,7 @@ class WikiaTracer {
 		$this->spanId = RequestId::generateId();
 		$this->traceId = RequestId::instance()->getRequestId();
 
+		$this->parentSpanId = $this->getTraceEntry( self::PARENT_SPAN_ID_HEADER_NAME );
 		$this->clientIp = $this->getTraceEntry( self::CLIENT_IP_HEADER_NAME );
 		$this->clientBeaconId = $this->getTraceEntry( self::CLIENT_BEACON_ID_HEADER_NAME );
 		$this->clientDeviceId = $this->getTraceEntry( self::CLIENT_DEVICE_ID_HEADER_NAME );
@@ -82,6 +85,7 @@ class WikiaTracer {
 				'client_device_id' => $this->clientDeviceId,
 				'user_id' => $this->userId,
 				'span_id' => $this->spanId,
+				'parent_span_id' => $this->parentSpanId,
 				'trace_id' => $this->traceId,
 			] )
 		);
@@ -225,6 +229,7 @@ class WikiaTracer {
 		return $this->removeNullEntries( [
 			self::TRACE_ID_HEADER_NAME => $this->traceId,
 			self::LEGACY_TRACE_ID_HEADER_NAME => $this->traceId, // duplicated until we move to X-Trace-Id everywhere
+			self::PARENT_SPAN_ID_HEADER_NAME => $this->spanId, // pass the current span ID to the subrequest, it will be logged as parent_span_id there
 		] );
 	}
 

--- a/lib/Wikia/src/Tracer/WikiaTracer.php
+++ b/lib/Wikia/src/Tracer/WikiaTracer.php
@@ -207,8 +207,18 @@ class WikiaTracer {
 		return $instance;
 	}
 
+	/**
+	 * @return string
+	 */
 	public function getTraceId() {
 		return $this->traceId;
+	}
+
+	/**
+	 * @return null|string
+	 */
+	public function getParentSpanId() {
+		return $this->parentSpanId;
 	}
 
 	public function getInternalHeaders() {


### PR DESCRIPTION
[PLATFORM-1951](https://wikia-inc.atlassian.net/browse/PLATFORM-1951)

The request making an internal HTTP :request:

``` json
{
     "span_id": "326a819b-d77d-46b1-9da5-6e5a7c4037d1",
     "trace_id": "d4e1c276-b07f-4862-b89e-73d2397fd351"
}
```

HTTP sub-request will report `span_id` of the calling request as the `parent_span_id`: (will be passed as `X-Parent-Span-Id` header / `WIKIA_TRACER_X_PARENT_SPAN_ID` env variable) `trace_id` will share the value of the main request for both of these sub requests.

``` json
{
      "span_id": "b37389ab-a0e5-48cd-a53c-2a8d83c10e04",
      "parent_span_id": "326a819b-d77d-46b1-9da5-6e5a7c4037d1",
      "trace_id": "d4e1c276-b07f-4862-b89e-73d2397fd351"
}
```

@wladekb 
