### PR TITLE
SOC-2280 | QueryString don't encode params two times

### DIFF
--- a/resources/wikia/modules/querystring.js
+++ b/resources/wikia/modules/querystring.js
@@ -103,7 +103,7 @@
 			for (attr in this.cache) {
 				if (this.cache.hasOwnProperty(attr)) {
 					val = this.cache[attr];
-					tmpArr.push(encodeURIComponent(attr) + (val === u ? '' : '=' + encodeURIComponent(val)));
+					tmpArr.push(encodeURIComponent(attr) + (val === u ? '' : '=' + val));
 				}
 			}
 

--- a/resources/wikia/modules/spec/querystring.spec.js
+++ b/resources/wikia/modules/spec/querystring.spec.js
@@ -214,6 +214,10 @@ describe("Querystring", function () {
 		expect(qs.toString()).toContain('prefixA=a&prefixB=b');
 		expect(qs.toString()).toContain('0=val1&1=val2');
 		expect(qs.toString()).toContain('prefix0=val1&prefix1=val2');
+		expect(qs.toString()).toContain('val=val%26val');
+
+		qs.setVal('val', 'val val');
+		expect(qs.toString()).toContain('val=val%20val');
 
 		qs.clearVals();
 


### PR DESCRIPTION
QueryString module encodes values on `setVal()` so there is no need for escaping it again in `toString()`

https://github.com/Wikia/app/blob/ee56454d5f1191dabbf93c3b9c58082d7d311ca9/resources/wikia/modules/querystring.js#L165-165

Ping @mixth-sense  @macbre @hakubo 
