### PR TITLE
[PLATFORM-2006] Fixed checking for user rights on special contributions

### DIFF
--- a/includes/specials/SpecialContributions.php
+++ b/includes/specials/SpecialContributions.php
@@ -336,11 +336,14 @@ class SpecialContributions extends SpecialPage {
 		}
 
 		# Add a link to change user rights for privileged users
-		if ( $id !== null && UserrightsPage::userCanChangeRights($target, false ) ) {
-			$tools[] = Linker::linkKnown(
-				SpecialPage::getTitleFor( 'Userrights', $username ),
-				$this->msg( 'sp-contributions-userrights' )->escaped()
-			);
+		if ( !empty( $this->getUser()->getId() ) && !empty( $id ) ) {
+			$isself = $id === $this->getUser()->getId();
+			if ( UserrightsPage::userCanChangeRights( $this->getUser(), $isself, true ) ) {
+				$tools[] = Linker::linkKnown(
+					SpecialPage::getTitleFor( 'Userrights', $username ),
+					$this->msg( 'sp-contributions-userrights' )->escaped()
+				);
+			}
 		}
 
 		wfRunHooks( 'ContributionsToolLinks', array( $id, $userpage, &$tools ) );


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-2006

In a change some time ago I accidentally started to check for user permissions of the target user instead of the currently logged in user when determining whether a link to rights management should be provided. Also fixed setting of the isself parameter.
