### PR TITLE
SOC-1358 Throttle category add emails

### DIFF
--- a/extensions/wikia/Email/Controller/CategoryAddController.class.php
+++ b/extensions/wikia/Email/Controller/CategoryAddController.class.php
@@ -73,7 +73,7 @@ class CategoryAddController extends EmailController {
 	private function assertEmailsNotThrottled() {
 		global $wgMemc;
 		$emailsSent = $wgMemc->get( $this->getTargetUserCacheKey() );
-		if ( $emailsSent != false && $emailsSent['sent'] >=  self::EMAILS_PER_THROTTLE_PERIOD ) {
+		if ( !empty( $emailsSent['sent'] ) && $emailsSent['sent'] >=  self::EMAILS_PER_THROTTLE_PERIOD ) {
 			throw new Check( 'Attempt to send too many emails' );
 		}
 	}

--- a/extensions/wikia/Email/EmailController.class.php
+++ b/extensions/wikia/Email/EmailController.class.php
@@ -175,6 +175,7 @@ abstract class EmailController extends \WikiaController {
 					$sourceType = 'email-ext' // Remove when this is the only sourceType sent
 				);
 				$this->assertGoodStatus( $status );
+				$this->afterSuccess();
 			}
 		} catch ( \Exception $e ) {
 			$this->setErrorResponse( $e );
@@ -604,6 +605,12 @@ abstract class EmailController extends \WikiaController {
 			throw new Check( 'User is blocked from taking this action' );
 		}
 	}
+
+	/**
+	 * Allow child classes to perform actions after an email is successfully
+	 * sent
+	 */
+	protected function afterSuccess() {}
 
 	/**
 	 * Get the form field for this email to be used on Special:SendEmail

--- a/extensions/wikia/Email/tests/CategoryAddControllerTest.php
+++ b/extensions/wikia/Email/tests/CategoryAddControllerTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use \Email\Controller\CategoryAddController;
+
+class EmailControllerTest extends WikiaBaseTest {
+
+	private $wikiaRequestMock;
+
+	/**
+	 * @expectedException \Email\Check
+	 */
+	public function testAssertCanEmailFailsAfterThrottleAmountReached() {
+		$this->mockUser();
+		$this->mockTitle();
+		$this->mockInternalRequest();
+		$this->mockMemcache();
+
+		$controller = new CategoryAddController();
+		$controller->setRequest( $this->wikiaRequestMock );
+		$controller->init();
+		$controller->assertCanEmail();
+	}
+
+	private function mockUser() {
+		// wtf... http://stackoverflow.com/questions/12748607/phpunits-returnvaluemap-not-yielding-expected-results
+
+		$returnValueMap = [
+			[ 'unsubscribed', null, false, false ],
+			[ 'language', null, false, 'en' ]
+		];
+
+		$mockUser = $this->getMock( 'User', [ 'getEmail', 'getGlobalPreference', 'isBlocked' ] );
+		$mockUser->expects( $this->any() )
+			->method( 'getEmail' )
+			->will( $this->returnValue( 'some.email@example.com' ) );
+		$mockUser->expects( $this->any() )
+			->method( 'getGlobalPreference' )
+			->will($this->returnValueMap( $returnValueMap ) );
+		$mockUser->expects( $this->any() )
+			->method( 'isBlocked' )
+			->will( $this->returnValue( false ) );
+
+		$this->mockGlobalVariable( 'wgUser', $mockUser );
+	}
+
+	private function mockTitle() {
+		$mockedTitle = $this->getMock( '\Title', [ 'getPrefixedText', 'getText', 'exists' ] );
+		$mockedTitle->expects( $this->any() )
+			->method( 'exists' )
+			->will( $this->returnValue( true ) );
+
+		$this->mockClassEx('Title',  $mockedTitle );
+	}
+
+	private function mockInternalRequest() {
+		$this->wikiaRequestMock = $this->getMock( '\WikiaRequest', [ 'isInternal' ], [], '', false );
+		$this->wikiaRequestMock->expects( $this->any() )
+			->method( 'isInternal' )
+			->willReturn( true );
+	}
+
+	private function mockMemcache() {
+		$mock_cache = $this->getMock( 'stdClass', [ 'get', 'set', 'delete' ] );
+		$mock_cache->expects( $this->any() )
+			->method('get')
+			->will( $this->returnValue(
+				[ 'sent' => CategoryAddController::EMAILS_PER_THROTTLE_PERIOD + 1, 'ttl' => time() ]
+			) );
+
+		$this->mockGlobalVariable( 'wgMemc', $mock_cache );
+	}
+}

--- a/extensions/wikia/Email/tests/CategoryAddControllerTest.php
+++ b/extensions/wikia/Email/tests/CategoryAddControllerTest.php
@@ -2,7 +2,7 @@
 
 use \Email\Controller\CategoryAddController;
 
-class EmailControllerTest extends WikiaBaseTest {
+class CategoryAddControllerTest extends WikiaBaseTest {
 
 	private $wikiaRequestMock;
 

--- a/extensions/wikia/Email/tests/CategoryAddControllerTest.php
+++ b/extensions/wikia/Email/tests/CategoryAddControllerTest.php
@@ -22,8 +22,10 @@ class CategoryAddControllerTest extends WikiaBaseTest {
 	}
 
 	private function mockUser() {
-		// wtf... http://stackoverflow.com/questions/12748607/phpunits-returnvaluemap-not-yielding-expected-results
-
+		// In order have a mocked method return different values based on different inputs, you use
+		// a return value map. If that mocked method has default arguments, you have to add values for
+		// those args as well. That's what the 2nd and 3rd arguments here are doing (null and false).
+		// See: http://stackoverflow.com/questions/12748607/phpunits-returnvaluemap-not-yielding-expected-results#answer-15300642
 		$returnValueMap = [
 			[ 'unsubscribed', null, false, false ],
 			[ 'language', null, false, 'en' ]

--- a/extensions/wikia/Email/tests/CategoryAddControllerTest.php
+++ b/extensions/wikia/Email/tests/CategoryAddControllerTest.php
@@ -80,9 +80,7 @@ class CategoryAddControllerTest extends WikiaBaseTest {
 		$mock_cache = $this->getMock( 'stdClass', [ 'get', 'set', 'delete' ] );
 		$mock_cache->expects( $this->any() )
 			->method('get')
-			->will( $this->returnValue(
-				[ 'sent' => $emailsSent, 'ttl' => time() ]
-			) );
+			->will( $this->returnValue( $emailsSent ) );
 
 		$this->mockGlobalVariable( 'wgMemc', $mock_cache );
 	}


### PR DESCRIPTION
Ticket: https://wikia-inc.atlassian.net/browse/SOC-1358

There have been reports by users of mass floods of category add emails (up to 35k) which can be triggered when a commonly used template is edited to include new categories. This PR adds a throttle so we only send up to 10 category add emails every 30 mins.
