### PR TITLE
DAT-4051 ad related temporary changes to maps

### DIFF
--- a/extensions/wikia/WikiaMaps/controllers/WikiaMapsBaseController.class.php
+++ b/extensions/wikia/WikiaMaps/controllers/WikiaMapsBaseController.class.php
@@ -207,4 +207,20 @@ class WikiaMapsBaseController extends WikiaController {
 		return $this->wg->User->getName() === $mapData->created_by;
 	}
 
+	/**
+	 * Temporary change required for ad purpose - https://wikia-inc.atlassian.net/browse/DAT-4051.
+	 * We need to limit contribution options on protected maps related to the ad campaign only to stuff
+	 * users.
+	 * @todo: remove this as a part of https://wikia-inc.atlassian.net/browse/DAT-4055
+	 *
+	 * @param Integer $mapId
+	 * @return bool
+	 */
+	protected function shouldDisableProtectedMapEdit( $mapId ) {
+		$IntMapConfig = $this->wg->IntMapConfig;
+
+		return array_key_exists( 'protectedMaps', $IntMapConfig ) &&
+			array_key_exists($mapId, $IntMapConfig[ 'protectedMaps' ]) &&
+			$this->wg->User->isStaff() === false;
+	}
 }

--- a/extensions/wikia/WikiaMaps/controllers/WikiaMapsPoiCategoryController.class.php
+++ b/extensions/wikia/WikiaMaps/controllers/WikiaMapsPoiCategoryController.class.php
@@ -29,6 +29,14 @@ class WikiaMapsPoiCategoryController extends WikiaMapsBaseController {
 	 * @throws BadRequestApiException
 	 */
 	public function editPoiCategories() {
+		// Temporary change required for ad purpose - https://wikia-inc.atlassian.net/browse/DAT-4051.
+		// We need to limit contribution options on protected maps related to the ad campaign only to stuff
+		// users.
+		// TODO: remove this as a part of https://wikia-inc.atlassian.net/browse/DAT-4055
+		if ( $this->shouldDisableProtectedMapEdit( $this->request->getInt( 'mapId' ) ) ) {
+			return;
+		}
+
 		$this->setData( 'userName', $this->wg->User->getName() );
 
 		$this->organizePoiCategoriesData();

--- a/extensions/wikia/WikiaMaps/controllers/WikiaMapsPoiController.class.php
+++ b/extensions/wikia/WikiaMaps/controllers/WikiaMapsPoiController.class.php
@@ -33,6 +33,15 @@ class WikiaMapsPoiController extends WikiaMapsBaseController {
 		$poiId = $this->request->getInt( 'id' );
 		$mapId = $this->request->getInt( 'mapId' );
 		$name = $this->request->getVal( 'name' );
+
+		// Temporary change required for ad purpose - https://wikia-inc.atlassian.net/browse/DAT-4051.
+		// We need to limit contribution options on protected maps related to the ad campaign only to stuff
+		// users.
+		// TODO: remove this as a part of https://wikia-inc.atlassian.net/browse/DAT-4055
+		if ( $this->shouldDisableProtectedMapEdit( $mapId ) ) {
+			return;
+		}
+
 		$this->setData( 'poiId', $poiId );
 		$this->setData( 'mapId', $mapId );
 		$this->setData( 'name', $name );

--- a/extensions/wikia/WikiaMaps/js/WikiaMapsPontoBridge.js
+++ b/extensions/wikia/WikiaMaps/js/WikiaMapsPontoBridge.js
@@ -100,7 +100,7 @@ define(
 				// We need to limit contribution options on protected maps related to the ad campaign only to stuff
 				// users.
 				// TODO: remove this as a part of https://wikia-inc.atlassian.net/browse/DAT-4055
-				isUserStuff: w.wgUserGroups.indexOf('stuff') !== -1
+				isUserStaff: w.wgUserGroups.indexOf('staff') !== -1
 			};
 
 			if (adContext && adContext.getContext().opts.enableAdsInMaps && adParams) {

--- a/extensions/wikia/WikiaMaps/js/WikiaMapsPontoBridge.js
+++ b/extensions/wikia/WikiaMaps/js/WikiaMapsPontoBridge.js
@@ -96,7 +96,9 @@ define(
 				cityId: parseInt(w.wgCityId, 10),
 				mobile: w.skin === 'wikiamobile',
 				skin: w.skin,
-				// temporary change required for ad purpose https://wikia-inc.atlassian.net/browse/DAT-4051
+				// Temporary change required for ad purpose - https://wikia-inc.atlassian.net/browse/DAT-4051.
+				// We need to limit contribution options on protected maps related to the ad campaign only to stuff
+				// users.
 				// TODO: remove this as a part of https://wikia-inc.atlassian.net/browse/DAT-4055
 				isUserStuff: w.wgUserGroups.indexOf('stuff') !== -1
 			};

--- a/extensions/wikia/WikiaMaps/js/WikiaMapsPontoBridge.js
+++ b/extensions/wikia/WikiaMaps/js/WikiaMapsPontoBridge.js
@@ -95,7 +95,10 @@ define(
 			var settings = {
 				cityId: parseInt(w.wgCityId, 10),
 				mobile: w.skin === 'wikiamobile',
-				skin: w.skin
+				skin: w.skin,
+				// temporary change required for ad purpose https://wikia-inc.atlassian.net/browse/DAT-4051
+				// TODO: remove this as a part of https://wikia-inc.atlassian.net/browse/DAT-4055
+				isUserStuff: w.wgUserGroups.indexOf('stuff') !== -1
 			};
 
 			if (adContext && adContext.getContext().opts.enableAdsInMaps && adParams) {


### PR DESCRIPTION
## Description:

These are temporary changes and will be removed after the ad campaign
- Restrict editing maps that are included in ad campaign only to stuff users
- Change popup display from click to on hover for maps that are included in ad campaign
## Links:
- https://wikia-inc.atlassian.net/browse/DAT-4051
- https://wikia-inc.atlassian.net/browse/DAT-4055

DO NOT MERGE !!!!!
Need to go live together with interactive-maps and config changes
