### PR TITLE
(MAIN-6855) Move adding to the querypage cache to the QueryPage class

### DIFF
--- a/extensions/wikia/PortableInfobox/PortableInfoboxHooks.class.php
+++ b/extensions/wikia/PortableInfobox/PortableInfoboxHooks.class.php
@@ -130,41 +130,11 @@ class PortableInfoboxHooks {
 	public static function onArticleInsertComplete( Page $page, User $user, $text, $summary, $minoredit,
 	                                                $watchThis, $sectionAnchor, &$flags, Revision $revision ) {
 		$title = $page->getTitle();
-		if ( self::hasInfobox( $title ) ) {
-			$dbw = wfGetDB( DB_MASTER );
-			( new WikiaSQL() )
-				->INSERT()->INTO( 'querycache', [
-					'qc_type',
-					'qc_value',
-					'qc_namespace',
-					'qc_title'
-				] )
-				->VALUES( [ [
-					AllinfoboxesQueryPage::ALL_INFOBOXES_TYPE,
-					$page->getId(),
-					$title->getNamespace(),
-					$title->getDBkey(),
-				] ] )
-				->run( $dbw );
-
-			wfRunHooks( 'AllInfoboxesQueryRecached' );
+		if ( $title->inNamespace( NS_TEMPLATE ) ) {
+			$queryPage = new AllinfoboxesQueryPage();
+			$queryPage->addTitleToCache( $title );
 		}
 
 		return true;
-	}
-
-	/**
-	 * Check whether or not a page has an infobox.
-	 *
-	 * @param  Title   $title Title to check
-	 * @return boolean
-	 */
-	private static function hasInfobox( Title $title ) {
-		return $title->inNamespace( NS_TEMPLATE ) &&
-			!(
-				$title->isSubpage() &&
-				in_array( mb_strtolower( $title->getSubpageText() ), AllinfoboxesQueryPage::$subpagesBlacklist )
-			) &&
-			!empty( PortableInfoboxDataService::newFromTitle( $title )->getData() );
 	}
 }

--- a/extensions/wikia/PortableInfobox/PortableInfoboxHooks.class.php
+++ b/extensions/wikia/PortableInfobox/PortableInfoboxHooks.class.php
@@ -131,8 +131,7 @@ class PortableInfoboxHooks {
 	                                                $watchThis, $sectionAnchor, &$flags, Revision $revision ) {
 		$title = $page->getTitle();
 		if ( $title->inNamespace( NS_TEMPLATE ) ) {
-			$queryPage = new AllinfoboxesQueryPage();
-			$queryPage->addTitleToCache( $title );
+			( new AllinfoboxesQueryPage() )->addTitleToCache( $title );
 		}
 
 		return true;

--- a/extensions/wikia/PortableInfobox/querypage/AllinfoboxesQueryPage.php
+++ b/extensions/wikia/PortableInfobox/querypage/AllinfoboxesQueryPage.php
@@ -113,7 +113,7 @@ class AllinfoboxesQueryPage extends PageQueryPage {
 				'qc_title'
 			] )
 			->VALUES( [ [
-				AllinfoboxesQueryPage::ALL_INFOBOXES_TYPE,
+				$this->getName(),
 				$title->getArticleID(),
 				$title->getNamespace(),
 				$title->getDBkey(),
@@ -123,16 +123,16 @@ class AllinfoboxesQueryPage extends PageQueryPage {
 		wfRunHooks( 'AllInfoboxesQueryRecached' );
 	}
 
-	protected function hasInfobox( Title $title ) {
+	private function hasInfobox( Title $title ) {
 		// omit subages from blacklist
 		return !(
 				$title->isSubpage() &&
 				in_array( mb_strtolower( $title->getSubpageText() ), self::$subpagesBlacklist )
 			) &&
-			!empty( PortableInfoboxDataService::newFromTitle( $title )->getData() );;
+			!empty( PortableInfoboxDataService::newFromTitle( $title )->getData() );
 	}
 
-	protected function filterInfoboxes( $tmpl ) {
+	private function filterInfoboxes( $tmpl ) {
 		$title = Title::newFromID( $tmpl[ 'pageid' ] );
 
 		return $title &&


### PR DESCRIPTION
Fixes fatal error:

```
PHP Fatal error: Cannot access private property
AllinfoboxesQueryPage::$subpagesBlacklist in /extensions/wikia/
PortableInfobox/PortableInfoboxHooks.class.php on line 166
```

/cc @SebastianMarzjan 
