### PR TITLE
PLATFORM-2079: emit X-Request-Path response header

### DIFF
--- a/includes/HttpFunctions.php
+++ b/includes/HttpFunctions.php
@@ -78,7 +78,7 @@ class Http {
 		$caller =  wfGetCallerClassMethod( [ __CLASS__, 'Hooks', 'ApiService', 'Solarium_Client', 'Solarium_Client_Adapter_Curl', 'ExternalHttp' ] );
 		$isOk = $status->isOK();
 
-		wfRunHooks( 'AfterHttpRequest', [ $method, $url, $caller, $requestTime, $req->getResponseHeaders() ] ); # Wikia change
+		wfRunHooks( 'AfterHttpRequest', [ $method, $url, $caller, $requestTime, $req ] ); # Wikia change
 
 		if ( class_exists( 'Wikia\\Logger\\WikiaLogger' ) ) {
 

--- a/includes/HttpFunctions.php
+++ b/includes/HttpFunctions.php
@@ -78,7 +78,7 @@ class Http {
 		$caller =  wfGetCallerClassMethod( [ __CLASS__, 'Hooks', 'ApiService', 'Solarium_Client', 'Solarium_Client_Adapter_Curl', 'ExternalHttp' ] );
 		$isOk = $status->isOK();
 
-		wfRunHooks( 'HttpRequestAfter', [ $method, $url, $caller, $requestTime, $req->getResponseHeaders() ] ); # Wikia change
+		wfRunHooks( 'AfterHttpRequest', [ $method, $url, $caller, $requestTime, $req->getResponseHeaders() ] ); # Wikia change
 
 		if ( class_exists( 'Wikia\\Logger\\WikiaLogger' ) ) {
 

--- a/includes/HttpFunctions.php
+++ b/includes/HttpFunctions.php
@@ -78,7 +78,7 @@ class Http {
 		$caller =  wfGetCallerClassMethod( [ __CLASS__, 'Hooks', 'ApiService', 'Solarium_Client', 'Solarium_Client_Adapter_Curl', 'ExternalHttp' ] );
 		$isOk = $status->isOK();
 
-		wfRunHooks( 'HttpRequestAfter', [ $method, $url, $caller, $requestTime, $status, $req->getResponseHeaders() ] ); # Wikia change
+		wfRunHooks( 'HttpRequestAfter', [ $method, $url, $caller, $requestTime, $req->getResponseHeaders() ] ); # Wikia change
 
 		if ( class_exists( 'Wikia\\Logger\\WikiaLogger' ) ) {
 

--- a/includes/HttpFunctions.php
+++ b/includes/HttpFunctions.php
@@ -77,6 +77,9 @@ class Http {
 		// log all the requests we make
 		$caller =  wfGetCallerClassMethod( [ __CLASS__, 'Hooks', 'ApiService', 'Solarium_Client', 'Solarium_Client_Adapter_Curl', 'ExternalHttp' ] );
 		$isOk = $status->isOK();
+
+		wfRunHooks( 'HttpRequestAfter', [ $method, $url, $caller, $requestTime, $status, $req->getResponseHeaders() ] ); # Wikia change
+
 		if ( class_exists( 'Wikia\\Logger\\WikiaLogger' ) ) {
 
 			$requestTime = (int)( ( microtime( true ) - $requestTime ) * 1000.0 );

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -457,11 +457,12 @@ $wgHooks['Debug'][] = 'Wikia\\Logger\\Hooks::onDebug';
 $wgHooks['WikiFactory::execute'][] = 'Wikia\\Logger\\Hooks::onWikiFactoryExecute';
 $wgHooks['WikiFactory::onExecuteComplete'][] = 'Wikia\\Logger\\Hooks::onWikiFactoryExecuteComplete';
 
-// WikiaRequest
+// WikiaTracer
 $wgHooks['WebRequestInitialized'][] = 'Wikia\\Tracer\\WikiaTracer::updateInstanceFromMediawiki';
 $wgHooks['AfterSetupUser'][] = 'Wikia\\Tracer\\WikiaTracer::updateInstanceFromMediawiki';
 $wgHooks['AfterUserLogin'][] = 'Wikia\\Tracer\\WikiaTracer::updateInstanceFromMediawiki';
 $wgHooks['BeforeWfShellExec'][] = 'Wikia\\Tracer\\WikiaTracer::onBeforeWfShellExec';
+$wgHooks['HttpRequestAfter'][] = 'Wikia\\Tracer\\WikiaTracer::onHttpRequestAfter';
 
 // memcache stats (PLATFORM-292)
 $wgAutoloadClasses['Wikia\\Memcached\\MemcachedStats'] = "$IP/includes/wikia/memcached/MemcachedStats.class.php";

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -462,7 +462,7 @@ $wgHooks['WebRequestInitialized'][] = 'Wikia\\Tracer\\WikiaTracer::updateInstanc
 $wgHooks['AfterSetupUser'][] = 'Wikia\\Tracer\\WikiaTracer::updateInstanceFromMediawiki';
 $wgHooks['AfterUserLogin'][] = 'Wikia\\Tracer\\WikiaTracer::updateInstanceFromMediawiki';
 $wgHooks['BeforeWfShellExec'][] = 'Wikia\\Tracer\\WikiaTracer::onBeforeWfShellExec';
-$wgHooks['HttpRequestAfter'][] = 'Wikia\\Tracer\\WikiaTracer::onHttpRequestAfter';
+$wgHooks['AfterHttpRequest'][] = 'Wikia\\Tracer\\WikiaTracer::onAfterHttpRequest';
 
 // memcache stats (PLATFORM-292)
 $wgAutoloadClasses['Wikia\\Memcached\\MemcachedStats'] = "$IP/includes/wikia/memcached/MemcachedStats.class.php";

--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -2247,6 +2247,8 @@ class Wikia {
 		$response->header( sprintf( 'X-Trace-Id:%s', WikiaTracer::instance()->getTraceId() ) );
 		$response->header( sprintf( 'X-Span-Id:%s', WikiaTracer::instance()->getSpanId() ) );
 
+		$response->header( sprintf( 'X-Request-Path: %s', WikiaTracer::instance()->getRequestPath() ) );
+
 		$response->header( 'X-Cache: ORIGIN' );
 		$response->header( 'X-Cache-Hits: ORIGIN' );
 	}

--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -74,11 +74,11 @@ $wgHooks['WebRequestInitialized'][] = 'Wikia::onWebRequestInitialized';
 # Log user email changes
 $wgHooks['BeforeUserSetEmail'][] = 'Wikia::logEmailChanges';
 
+use \Wikia\Tracer\WikiaTracer;
+
 /**
  * This class has only static methods so they can be used anywhere
- *
  */
-
 class Wikia {
 
 	const REQUIRED_CHARS = '0123456789abcdefG';
@@ -2243,6 +2243,9 @@ class Wikia {
 
 		$response->header( sprintf( 'X-Served-By:%s', wfHostname() ) );
 		$response->header( sprintf( 'X-Backend-Response-Time:%01.3f', $elapsed ) );
+
+		$response->header( sprintf( 'X-Trace-Id:%s', WikiaTracer::instance()->getTraceId() ) );
+		$response->header( sprintf( 'X-Span-Id:%s', WikiaTracer::instance()->getSpanId() ) );
 
 		$response->header( 'X-Cache: ORIGIN' );
 		$response->header( 'X-Cache-Hits: ORIGIN' );

--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -2241,11 +2241,11 @@ class Wikia {
 		global $wgRequestTime;
 		$elapsed = microtime( true ) - $wgRequestTime;
 
-		$response->header( sprintf( 'X-Served-By:%s', wfHostname() ) );
-		$response->header( sprintf( 'X-Backend-Response-Time:%01.3f', $elapsed ) );
+		$response->header( sprintf( 'X-Served-By: %s', wfHostname() ) );
+		$response->header( sprintf( 'X-Backend-Response-Time: %01.3f', $elapsed ) );
 
-		$response->header( sprintf( 'X-Trace-Id:%s', WikiaTracer::instance()->getTraceId() ) );
-		$response->header( sprintf( 'X-Span-Id:%s', WikiaTracer::instance()->getSpanId() ) );
+		$response->header( sprintf( 'X-Trace-Id: %s', WikiaTracer::instance()->getTraceId() ) );
+		$response->header( sprintf( 'X-Span-Id: %s', WikiaTracer::instance()->getSpanId() ) );
 
 		$response->header( sprintf( 'X-Request-Path: %s', WikiaTracer::instance()->getRequestPath() ) );
 

--- a/lib/Wikia/src/Service/Swagger/ApiClient.php
+++ b/lib/Wikia/src/Service/Swagger/ApiClient.php
@@ -35,7 +35,7 @@ class ApiClient extends \Swagger\Client\ApiClient {
 			$code = $e->getCode();
 		}
 
-		wfRunHooks( 'HttpRequestAfter', [ $method, $this->config->getHost(), $this->serviceName, $start, [] ] ); # PLATFORM-2079
+		wfRunHooks( 'AfterHttpRequest', [ $method, $this->config->getHost(), $this->serviceName, $start, [] ] ); # PLATFORM-2079
 
 		if ($this->logSampler->shouldSample()) {
 			$this->info("Http request", [

--- a/lib/Wikia/src/Service/Swagger/ApiClient.php
+++ b/lib/Wikia/src/Service/Swagger/ApiClient.php
@@ -35,7 +35,7 @@ class ApiClient extends \Swagger\Client\ApiClient {
 			$code = $e->getCode();
 		}
 
-		wfRunHooks( 'AfterHttpRequest', [ $method, $this->config->getHost(), $this->serviceName, $start, [] ] ); # PLATFORM-2079
+		wfRunHooks( 'AfterHttpRequest', [ $method, $this->config->getHost(), $this->serviceName, $start, null ] ); # PLATFORM-2079
 
 		if ($this->logSampler->shouldSample()) {
 			$this->info("Http request", [

--- a/lib/Wikia/src/Service/Swagger/ApiClient.php
+++ b/lib/Wikia/src/Service/Swagger/ApiClient.php
@@ -35,6 +35,8 @@ class ApiClient extends \Swagger\Client\ApiClient {
 			$code = $e->getCode();
 		}
 
+		wfRunHooks( 'HttpRequestAfter', [ $method, $this->config->getHost(), $this->serviceName, $start, [] ] ); # PLATFORM-2079
+
 		if ($this->logSampler->shouldSample()) {
 			$this->info("Http request", [
 				'statusCode' => $code,

--- a/lib/Wikia/src/Tracer/WikiaTracer.php
+++ b/lib/Wikia/src/Tracer/WikiaTracer.php
@@ -321,11 +321,10 @@ class WikiaTracer {
 	 * @param string $url
 	 * @param string $caller
 	 * @param float $requestTime UNIX timestamp (with microseconds precision when the request was sent
-	 * @param \Status $status
 	 * @param array $respHeaders
 	 * @return bool
 	 */
-	public static function onHttpRequestAfter( $method, $url, $caller, $requestTime, \Status $status, Array $respHeaders ) {
+	public static function onHttpRequestAfter( $method, $url, $caller, $requestTime, Array $respHeaders ) {
 		# print_pre(__METHOD__); print_pre(func_get_args());
 
 		// check if we received X-Request-Path header in a response and simply use it

--- a/lib/Wikia/src/Tracer/WikiaTracer.php
+++ b/lib/Wikia/src/Tracer/WikiaTracer.php
@@ -321,14 +321,18 @@ class WikiaTracer {
 	 * @param string $url
 	 * @param string $caller
 	 * @param float $requestTime UNIX timestamp (with microseconds precision when the request was sent
-	 * @param array $respHeaders
+	 * @param \MWHttpRequest|null $req request object to take HTTP response headers from
 	 * @return bool
 	 */
-	public static function onAfterHttpRequest( $method, $url, $caller, $requestTime, Array $respHeaders ) {
+	public static function onAfterHttpRequest( $method, $url, $caller, $requestTime, $req ) {
 		// check if we received X-Request-Path header in a response and simply use it
-		$headerName = strtolower( self::REQUEST_PATH_HEADER_NAME );
-		if ( !empty( $respHeaders[ $headerName ] ) ) {
-			self::instance()->requestPath[] = $respHeaders[ $headerName ][ 0 ];
+		$headerValue = null;
+		if ( $req instanceof \MWHttpRequest ) {
+			$headerValue = $req->getResponseHeader(self::REQUEST_PATH_HEADER_NAME);
+		}
+
+		if ( $headerValue !== null ) {
+			self::instance()->requestPath[] = $headerValue;
 			return true;
 		}
 

--- a/lib/Wikia/src/Tracer/WikiaTracer.php
+++ b/lib/Wikia/src/Tracer/WikiaTracer.php
@@ -324,7 +324,7 @@ class WikiaTracer {
 	 * @param array $respHeaders
 	 * @return bool
 	 */
-	public static function onHttpRequestAfter( $method, $url, $caller, $requestTime, Array $respHeaders ) {
+	public static function onAfterHttpRequest( $method, $url, $caller, $requestTime, Array $respHeaders ) {
 		// check if we received X-Request-Path header in a response and simply use it
 		$headerName = strtolower( self::REQUEST_PATH_HEADER_NAME );
 		if ( !empty( $respHeaders[ $headerName ] ) ) {

--- a/lib/Wikia/src/Tracer/WikiaTracer.php
+++ b/lib/Wikia/src/Tracer/WikiaTracer.php
@@ -338,17 +338,29 @@ class WikiaTracer {
 
 		$took = microtime( true ) - $requestTime;
 
-		// take appName from the name of the method that made the HTTP request
-		$caller = str_replace( '{closure}', '', $caller );
-		$caller = trim( $caller, '\\:' );
-		$appName = end( explode('\\', $caller ) );
-
+		$appName = self::getAppNameFromCaller( $caller );
 		$hostName = parse_url( $url, PHP_URL_HOST );
 		$timestamp = (int) $requestTime;
 
 		self::instance()->pushRequestPath( $appName, $hostName, $timestamp, $took );
 
 		return true;
+	}
+
+	/**
+	 * Get the app / service name using the name of the PHP method that performed the HTTP request
+	 *
+	 * For instance: "Wikia\Service\Helios\HeliosClientImpl:Wikia\Service\Helios\{closure}" will give "Helios"
+	 * For instance: "Wikia\Service\Gateway\ConsulUrlProvider:getUrl" will give "ConsulUrlProvider:getUrl"
+	 *
+	 * @param string $caller
+	 * @return string
+	 */
+	public static function getAppNameFromCaller( $caller ) {
+		$caller = str_replace( '{closure}', '', $caller );
+		$caller = trim( $caller, '\\:' );
+
+		return end( explode('\\', $caller ) );
 	}
 
 	/**

--- a/lib/Wikia/src/Tracer/WikiaTracer.php
+++ b/lib/Wikia/src/Tracer/WikiaTracer.php
@@ -325,8 +325,6 @@ class WikiaTracer {
 	 * @return bool
 	 */
 	public static function onHttpRequestAfter( $method, $url, $caller, $requestTime, Array $respHeaders ) {
-		# print_pre(__METHOD__); print_pre(func_get_args());
-
 		// check if we received X-Request-Path header in a response and simply use it
 		$headerName = strtolower( self::REQUEST_PATH_HEADER_NAME );
 		if ( !empty( $respHeaders[ $headerName ] ) ) {

--- a/lib/Wikia/src/Tracer/WikiaTracer.php
+++ b/lib/Wikia/src/Tracer/WikiaTracer.php
@@ -342,7 +342,7 @@ class WikiaTracer {
 		$hostName = parse_url( $url, PHP_URL_HOST );
 		$timestamp = (int) $requestTime;
 
-		self::instance()->requestPathPush( $appName, $hostName, $timestamp, $took );
+		self::instance()->pushRequestPath( $appName, $hostName, $timestamp, $took );
 
 		return true;
 	}
@@ -357,7 +357,7 @@ class WikiaTracer {
 	 * @param int $timestamp UNIX timestamp of when the sub-requests started
 	 * @param float $took how long it took to perform the sub-request (in seconds)
 	 */
-	private function requestPathPush( $appName, $hostName, $timestamp, $took ) {
+	private function pushRequestPath( $appName, $hostName, $timestamp, $took ) {
 		$this->requestPath[] = sprintf( "(%s %s %d %.6f)", $appName, $hostName, $timestamp, $took );
 	}
 

--- a/lib/Wikia/tests/Tracer/WikiaTracerTest.php
+++ b/lib/Wikia/tests/Tracer/WikiaTracerTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use Wikia\Tracer\WikiaTracer;
+
+/**
+ * Tests WikiaTracer class
+ *
+ * @group WikiaTracer
+ */
+class WikiaTracerTest extends WikiaBaseTest {
+
+	/**
+	 * @param string $caller
+	 * @param string $expected
+	 * @dataProvider getAppNameFromCallerProvider
+	 */
+	public function testGetAppNameFromCaller( $caller, $expected ) {
+		$this->assertEquals( $expected, WikiaTracer::getAppNameFromCaller( $caller ) );
+	}
+
+	public function getAppNameFromCallerProvider() {
+		return [
+			[
+				'Wikia\Service\Helios\HeliosClientImpl:Wikia\Service\Helios\{closure}',
+				'Helios'
+			],
+			[
+				'Wikia\Service\Gateway\ConsulUrlProvider:getUrl',
+				'ConsulUrlProvider:getUrl'
+			]
+		];
+	}
+}


### PR DESCRIPTION
[PLATFORM-2079](https://wikia-inc.atlassian.net/browse/PLATFORM-2079)

Emit `X-Request-Path` response header (along with `X-Trace-Id` and `X-Span-Id`) to ease debugging of HTTP sub-requests made to various services.

This a first step and it fully covers MediaWiki only. Calls to Pandora services are included as well, but we do not include any requests made the services itself in the response header (as Pandora does not expose any data regarding such calls in response headers).

Examples:

```
X-Span-Id: 2bfd5cea-49f4-4758-b7f6-908c8a1d500e
X-Trace-Id: 9930fed9-f148-4b35-ac29-c6233cc71ab3
X-Backend-Response-Time: 5.389
X-Request-Path: (mediawiki dev-macbre 1459943722 5.389362 (ConsulUrlProvider:getUrl localhost 1459943722 0.005425) (Helios 10.14.30.27 1459943722 0.001203) (ConsulUrlProvider:getUrl localhost 1459943722 0.001402) (user-preference 10.14.30.75 1459943722 0.005478) (ConsulUrlProvider:getUrl localhost 1459943727 0.001446) (user-attribute 10.14.30.75 1459943727 0.340781) (SpecialPageUserCommand:getExternalData messaging.wladek.wikia-dev.com 1459943728 0.005204))
```

```
$ curl -sv  'http://community.macbre.wikia-dev.com/wiki/Special:HealthCheck'
< X-Backend-Response-Time: 0.210
< X-Trace-Id: 5523bc42-56b1-49dd-a1de-8d099e5b1587
< X-Span-Id: 6a5a8fa1-1038-46d1-9537-304333be533d
< X-Request-Path: (mediawiki dev-macbre 1459934360 0.210250 (mediawiki dev-macbre 1459934360 0.092125))
```

Each bracket-wrapped section (e.g. `(user-attribute 10.14.30.75 1459943727 0.340781)`) consists of:
- app / service name,
- name of the host called,
- UNIX timestamp of when the request started,
- time it took to complete the request (in seconds).

@wladekb / @pchojnacki / @ljagiello 
