### PR TITLE
CleanEventsLocalUsersMaintenance: remove entries that do not have matching user ID and name

### DIFF
--- a/maintenance/wikia/cleanEventsLocalUsers.php
+++ b/maintenance/wikia/cleanEventsLocalUsers.php
@@ -26,7 +26,8 @@ class CleanEventsLocalUsersMaintenance extends Maintenance {
 			self::TABLE_NAME,
 			'user_id, user_name',
 			[
-				'wiki_id' => $wgCityId
+				'wiki_id' => $wgCityId,
+				'user_id > 0'
 			],
 			__METHOD__
 		);


### PR DESCRIPTION
[PLATFORM-2094](https://wikia-inc.atlassian.net/browse/PLATFORM-2094)

Remove `events_local_users` rows that do not have matching user ID and name as they cause duplicated entries and confuse admins and ComSup members.

@wladekb 
