### PR TITLE
RECIRC 94: Improve loading of Lateral

### DIFF
--- a/extensions/wikia/Recirculation/js/experiments/placement.js
+++ b/extensions/wikia/Recirculation/js/experiments/placement.js
@@ -3,6 +3,7 @@ require([
 	'jquery',
 	'wikia.window',
 	'wikia.abTest',
+	'wikia.log',
 	'ext.wikia.recirculation.tracker',
 	'ext.wikia.recirculation.utils',
 	'ext.wikia.recirculation.views.incontent',
@@ -18,6 +19,7 @@ require([
 	$,
 	w,
 	abTest,
+	log,
 	tracker,
 	utils,
 	incontentView,
@@ -31,6 +33,7 @@ require([
 	videosModule
 ) {
 	var experimentName = 'RECIRCULATION_PLACEMENT',
+		logGroup = 'ext.wikia.recirculation.experiments.placement',
 		railContainerId = 'RECIRCULATION_RAIL',
 		railSelector = '#' + railContainerId,
 		group = abTest.getGroup(experimentName),
@@ -151,7 +154,11 @@ require([
 			.fail(handleError);
 	}
 
-	function handleError() {
+	function handleError(err) {
+		if (err) {
+			log(err, 'info', logGroup);
+		}
+
 		// If there is an error somewhere we render the control group with no tracking
 		if (errorHandled) {
 			return;
@@ -165,8 +172,11 @@ require([
 				limit: 5
 			}).loadData()
 				.then(rail.render)
-				.fail(function() {
-					// No-op if this doesn't work. We tried our best.
+				.fail(function(err) {
+					// If this doesn't work, log out why. We tried our best.
+					if (err) {
+						log(err, 'info', logGroup);
+					}
 				});
 		});
 	}
@@ -189,6 +199,9 @@ require([
 			.then(incontent.setupTracking(experimentName))
 			.fail(function(err) {
 				// We fail silently for the in-content widget
+				if (err) {
+					log(err, 'info', logGroup);
+				}
 			});
 
 		afterRailLoads(function() {

--- a/extensions/wikia/Recirculation/js/helpers/ContentLinksHelper.js
+++ b/extensions/wikia/Recirculation/js/helpers/ContentLinksHelper.js
@@ -4,14 +4,12 @@ define('ext.wikia.recirculation.helpers.contentLinks', [
 	'wikia.window',
 	'wikia.abTest',
 	'wikia.nirvana',
-	'wikia.log',
 	'wikia.mustache',
 	'ext.wikia.recirculation.tracker',
 	'ext.wikia.recirculation.utils'
-], function ($, w, abTest, nirvana, log, Mustache, tracker, utils) {
+], function ($, w, abTest, nirvana, Mustache, tracker, utils) {
 
-	var logGroup = 'ext.wikia.recirculation.helpers.contentLinks',
-		placeholderImage = w.wgExtensionsPath + '/wikia/Recirculation/images/placeholder.png',
+	var placeholderImage = w.wgExtensionsPath + '/wikia/Recirculation/images/placeholder.png',
 		$container = $('#mw-content-text'),
 		minimumLinksNumber = 8,
 		minimumSectionsNumber = 3;
@@ -24,14 +22,12 @@ define('ext.wikia.recirculation.helpers.contentLinks', [
 
 		// If this page does not have enough links we don't want to show this widget
 		if ($links.length < minimumLinksNumber) {
-			log('Recirculation in-content widget not shown - Not enough links in article', 'debug', logGroup);
-			return deferred.reject().promise();
+			return deferred.reject('Recirculation in-content widget not shown - Not enough links in article').promise();
 		}
 
 		topTitles = findTopTitles($links);
 		if (topTitles.length < 3) {
-			log('Recirculation in-content widget not shown - Not enough top links', 'debug', logGroup);
-			return deferred.reject().promise();
+			return deferred.reject('Recirculation in-content widget not shown - Not enough top links').promise();
 		}
 
 		nirvana.sendRequest({
@@ -50,8 +46,7 @@ define('ext.wikia.recirculation.helpers.contentLinks', [
 				if (data.items && data.items.length >=3 ) {
 					deferred.resolve(data);
 				} else {
-					log('Recirculation in-content widget not shown - Not enough items returned from API', 'debug', logGroup);
-					deferred.reject();
+					deferred.reject('Recirculation in-content widget not shown - Not enough items returned from API');
 				}
 			}
 		});

--- a/extensions/wikia/Recirculation/js/helpers/LateralHelper.js
+++ b/extensions/wikia/Recirculation/js/helpers/LateralHelper.js
@@ -30,7 +30,7 @@ define('ext.wikia.recirculation.helpers.lateral', [
 
 	function processQueue(lateral) {
 		while(queue.length > 0) {
-			var callback = queue.pop();
+			var callback = queue.shift();
 
 			callback(lateral);
 		}

--- a/extensions/wikia/Recirculation/js/views/incontent.js
+++ b/extensions/wikia/Recirculation/js/views/incontent.js
@@ -37,7 +37,7 @@ define('ext.wikia.recirculation.views.incontent', [
 			section = findSuitableSection();
 
 		if (!section) {
-			return deferred.reject();
+			return deferred.reject('Recirculation in-content widget not shown - Not enough sections in article');
 		}
 
 		utils.renderTemplate('incontent.mustache', data).then(function($html) {


### PR DESCRIPTION
There are currently instances where the Lateral script is getting loaded twice, which is causing issues with analytics data. This change makes it so the call to load lateral will only get run once, and callbacks get added to a queue to be run after Lateral has finished loading. This PR also adds client side error logging for the placement test.
