### PR TITLE
CE-3438: Remove key shortcut for Start a Wiki

### DIFF
--- a/extensions/wikia/GlobalShortcuts/scripts/AddDefaultShortcuts.js
+++ b/extensions/wikia/GlobalShortcuts/scripts/AddDefaultShortcuts.js
@@ -22,7 +22,7 @@ require(['GlobalShortcuts', 'PageActions', 'mw', 'wikia.loader'],
 		function addShortcuts() {
 			var INITIAL_SHORTCUTS = {
 				'general:StartWikia': {
-					shortcuts: ['s'],
+					shortcuts: [],
 					actionParams: {
 						id: 'general:StartWikia',
 						caption: mw.message('global-shortcuts-caption-start-a-new-wikia').plain(),


### PR DESCRIPTION
Remove key shortcut for Start a Wiki

@Wikia/community-engineering 
