### PR TITLE
[PLATFORM-2011] Fixed changing list of groups

### DIFF
--- a/extensions/wikia/SpecialBatchUserRights/SpecialBatchUserRights.php
+++ b/extensions/wikia/SpecialBatchUserRights/SpecialBatchUserRights.php
@@ -346,18 +346,16 @@ class SpecialBatchUserRights extends SpecialPage {
 		$settable_col = '';
 		$unsettable_col = '';
 		$changeableGroups = $this->getUser()->changeableGroups();
+		$globalGroups = $this->permissionsService()->getConfiguration()->getGlobalGroups();
 
 		foreach ( $allgroups as $group ) {
 			$set = false;
+			$canAdd = UserrightsPage::canAdd( $globalGroups, $changeableGroups, $group, $this->isself );
+			$canRemove = UserrightsPage::canRemove( $globalGroups, $changeableGroups, $group, $this->isself );
 			# Should the checkbox be disabled?
-			$isGlobalNonEditableGroup = UserrightsPage::isGlobalNonEditableGroup(
-				$this->permissionsService()->getConfiguration()->getGlobalGroups(), $group );
-			$disabled = !( !$set && UserrightsPage::canAdd( $changeableGroups, $group, $this->isself ) && !$isGlobalNonEditableGroup );
+			$disabled = !( !$set && $canAdd );
 			# Do we need to point out that this action is irreversible?
-			$irreversible = !$disabled && (
-				( $set && !UserrightsPage::canAdd( $changeableGroups, $group, $this->isself ) ) ||
-				( !$set && !UserrightsPage::canRemove( $changeableGroups, $group, $this->isself ) ) );
-
+			$irreversible = !$disabled && ( ( $set && !$canAdd ) || ( !$set && !$canRemove ) );
 			$attr = $disabled ? array( 'disabled' => 'disabled' ) : array();
 			$attr['title'] = $group;
 			$text = $irreversible

--- a/includes/User.php
+++ b/includes/User.php
@@ -4723,7 +4723,7 @@ class User {
 	}
 
 	/**
-	 * Add the user to the given group.
+	 * Add the user to the given group(s).
 	 * This takes immediate effect.
 	 * @param $groups string Name of group or array with list of groups
 	 * @return true if operation was successful, false otherwise
@@ -4733,7 +4733,7 @@ class User {
 	}
 
 	/**
-	 * Remove the user from the given group.
+	 * Remove the user from the given group(s).
 	 * This takes immediate effect.
 	 * @param $groups string Name of group or array with list of groups
 	 * @return true if operation was successful, false otherwise

--- a/includes/User.php
+++ b/includes/User.php
@@ -4725,19 +4725,21 @@ class User {
 	/**
 	 * Add the user to the given group.
 	 * This takes immediate effect.
-	 * @param $group String Name of the group to add
+	 * @param $groups string Name of group or array with list of groups
+	 * @return true if operation was successful, false otherwise
 	 */
-	public function addGroup( $group ) {
-		return self::permissionsService()->addToGroup( RequestContext::getMain()->getUser(), $this, $group );
+	public function addGroup( $groups ) {
+		return self::permissionsService()->addToGroup( RequestContext::getMain()->getUser(), $this, $groups );
 	}
 
 	/**
 	 * Remove the user from the given group.
 	 * This takes immediate effect.
-	 * @param $group String Name of the group to remove
+	 * @param $groups string Name of group or array with list of groups
+	 * @return true if operation was successful, false otherwise
 	 */
-	public function removeGroup( $group ) {
-		return self::permissionsService()->removeFromGroup( RequestContext::getMain()->getUser(), $this, $group );
+	public function removeGroup( $groups ) {
+		return self::permissionsService()->removeFromGroup( RequestContext::getMain()->getUser(), $this, $groups );
 	}
 
 	/**

--- a/includes/specials/SpecialUserrights.php
+++ b/includes/specials/SpecialUserrights.php
@@ -244,19 +244,20 @@ class UserrightsPage extends SpecialPage {
 	 * @return Array: Tuple of added, then removed groups
 	 */
 	function doSaveUserGroups( $user, $groupsToAdd, $groupsToRemove, $reason = '' ) {
+		$groups = $user->getGroups();
 		$globalGroups = $this->permissionsService()->getConfiguration()->getGlobalGroups();
 		$changeable = $this->getUser()->changeableGroups();
 		$validGroupsToAdd = [];
 		$validGroupsToRemove = [];
 
 		foreach ( $groupsToAdd as $group ) {
-			if( self::canAdd( $globalGroups, $changeable, $group, $this->isself ) ) {
+			if( self::canAdd( $globalGroups, $changeable, $group, $this->isself ) && !in_array( $group, $groups ) ) {
 				$validGroupsToAdd[] = $group;
 			}
 		}
 
 		foreach ( $groupsToRemove as $group ) {
-			if( self::canRemove( $globalGroups, $changeable, $group, $this->isself ) ) {
+			if( self::canRemove( $globalGroups, $changeable, $group, $this->isself ) && in_array( $group, $groups ) ) {
 				$validGroupsToRemove[] = $group;
 			}
 		}

--- a/includes/specials/SpecialUserrights.php
+++ b/includes/specials/SpecialUserrights.php
@@ -261,6 +261,7 @@ class UserrightsPage extends SpecialPage {
 
 		$success = true;
 
+		//First add, then remove, otherwise addition may not be possible due to lack of permissions
 		if( $add ) {
 			$newGroups = array_merge( $newGroups, $add );
 			$success = $user->addGroup( $add ) && $success;
@@ -268,20 +269,17 @@ class UserrightsPage extends SpecialPage {
 
 		if( $remove ) {
 			$newGroups = array_diff( $newGroups, $remove );
-			$success = $user->removeGroup( $remove );
+			$success = $user->removeGroup( $remove ) && $success;
 		}
 
 		$newGroups = array_unique( $newGroups );
 		sort( $newGroups );
 
-		// Ensure that caches are cleared
-		$user->invalidateCache();
-
-		if ( !$success ) {
+		if( !$success ) {
 			$newGroups = $user->getGroups();
 			sort( $newGroups );
 			\Wikia\Logger\WikiaLogger::instance()->error(
-				'Error occurred while changing groups. Groups requested to add: $add ' . json_encode( $add )
+				'Error occurred while changing groups. Groups requested to add: ' . json_encode( $add )
 				. ", groups request to remove: " . json_encode( $remove ) );
 		}
 
@@ -290,7 +288,7 @@ class UserrightsPage extends SpecialPage {
 
 		wfRunHooks( 'UserRights', array( &$user, $add, $remove ) );
 
-		if ( $newGroups != $oldGroups ) {
+		if( $newGroups != $oldGroups ) {
 			$this->addLogEntry( $user, $oldGroups, $newGroups, $reason );
 		}
 		return array( $add, $remove );

--- a/includes/specials/SpecialUserrights.php
+++ b/includes/specials/SpecialUserrights.php
@@ -22,6 +22,7 @@
  */
 
 use Wikia\Service\User\Permissions\PermissionsServiceAccessor;
+use Wikia\Logger\WikiaLogger;
 
 /**
  * Special page to allow managing user group membership
@@ -71,25 +72,27 @@ class UserrightsPage extends SpecialPage {
 	}
 
 	/**
+	 * @param $globalGroups string[] List of global groups
 	 * @param $changeableGroups string[] Changeable groups
 	 * @param  $group String: the name of the group to check
 	 * @param $isself bool Are we change the same user that is logged in
 	 * @return bool Can we remove the group?
 	 */
-	public static function canRemove( $changeableGroups, $group, $isself ) {
-		// $this->changeableGroups()['remove'] doesn't work, of course. Thanks,
-		// PHP.
-		return in_array( $group, $changeableGroups['remove'] ) || ( $isself && in_array( $group, $changeableGroups['remove-self'] ) );
+	public static function canRemove( $globalGroups, $changeableGroups, $group, $isself ) {
+		return !self::isGlobalNonEditableGroup( $globalGroups, $group) &&
+			in_array( $group, $changeableGroups['remove'] ) || ( $isself && in_array( $group, $changeableGroups['remove-self'] ) );
 	}
 
 	/**
+	 * @param $globalGroups string[] List of global groups
 	 * @param $changeableGroups string[] Changeable groups
 	 * @param $group string: the name of the group to check
 	 * @param $isself bool Are we change the same user that is logged in
 	 * @return bool Can we add the group?
 	 */
-	public static function canAdd( $changeableGroups, $group, $isself ) {
-		return in_array( $group, $changeableGroups['add'] ) || ( $isself && in_array( $group, $changeableGroups['add-self'] ) );
+	public static function canAdd( $globalGroups, $changeableGroups, $group, $isself ) {
+		return !self::isGlobalNonEditableGroup( $globalGroups, $group) &&
+			in_array( $group, $changeableGroups['add'] ) || ( $isself && in_array( $group, $changeableGroups['add-self'] ) );
 	}
 
 	public function __construct() {
@@ -235,25 +238,28 @@ class UserrightsPage extends SpecialPage {
 	 * Save user groups changes in the database.
 	 *
 	 * @param $user User object
-	 * @param $add Array of groups to add
-	 * @param $remove Array of groups to remove
+	 * @param $groupsToAdd Array of groups to add
+	 * @param $groupsToRemove Array of groups to remove
 	 * @param $reason String: reason for group change
 	 * @return Array: Tuple of added, then removed groups
 	 */
-	function doSaveUserGroups( $user, $add, $remove, $reason = '' ) {
-		// Validate input set...
-		$isself = ( $user->getName() == $this->getUser()->getName() );
-		$groups = $user->getGroups();
+	function doSaveUserGroups( $user, $groupsToAdd, $groupsToRemove, $reason = '' ) {
+		$globalGroups = $this->permissionsService()->getConfiguration()->getGlobalGroups();
 		$changeable = $this->getUser()->changeableGroups();
-		$addable = array_merge( $changeable['add'], $isself ? $changeable['add-self'] : array() );
-		$removable = array_merge( $changeable['remove'], $isself ? $changeable['remove-self'] : array() );
+		$validGroupsToAdd = [];
+		$validGroupsToRemove = [];
 
-		$remove = array_unique(
-			array_intersect( (array)$remove, $removable, $groups ) );
-		$add = array_unique( array_diff(
-			array_intersect( (array)$add, $addable ),
-			$groups )
-		);
+		foreach ( $groupsToAdd as $group ) {
+			if( self::canAdd( $globalGroups, $changeable, $group, $this->isself ) ) {
+				$validGroupsToAdd[] = $group;
+			}
+		}
+
+		foreach ( $groupsToRemove as $group ) {
+			if( self::canRemove( $globalGroups, $changeable, $group, $this->isself ) ) {
+				$validGroupsToRemove[] = $group;
+			}
+		}
 
 		$oldGroups = $user->getGroups();
 		sort( $oldGroups );
@@ -262,14 +268,14 @@ class UserrightsPage extends SpecialPage {
 		$success = true;
 
 		//First add, then remove, otherwise addition may not be possible due to lack of permissions
-		if( $add ) {
-			$newGroups = array_merge( $newGroups, $add );
-			$success = $user->addGroup( $add ) && $success;
+		if( $validGroupsToAdd ) {
+			$newGroups = array_merge( $newGroups, $validGroupsToAdd );
+			$success = $user->addGroup( $validGroupsToAdd ) && $success;
 		}
 
-		if( $remove ) {
-			$newGroups = array_diff( $newGroups, $remove );
-			$success = $user->removeGroup( $remove ) && $success;
+		if( $validGroupsToRemove ) {
+			$newGroups = array_diff( $newGroups, $validGroupsToRemove );
+			$success = $user->removeGroup( $validGroupsToRemove ) && $success;
 		}
 
 		$newGroups = array_unique( $newGroups );
@@ -278,20 +284,20 @@ class UserrightsPage extends SpecialPage {
 		if( !$success ) {
 			$newGroups = $user->getGroups();
 			sort( $newGroups );
-			\Wikia\Logger\WikiaLogger::instance()->error(
-				'Error occurred while changing groups. Groups requested to add: ' . json_encode( $add )
-				. ", groups request to remove: " . json_encode( $remove ) );
+			WikiaLogger::instance()->error(
+				__METHOD__ . ' - Error occurred while changing groups',
+				[ 'groups-to-add ' => $validGroupsToAdd, 'groups-to-remove' => $validGroupsToRemove ] );
 		}
 
-		\Wikia\Logger\WikiaLogger::instance()->debug( 'Changing groups. oldGroups: ' . json_encode( $oldGroups )
-			. ', newGroups: ' . json_encode( $newGroups ) );
+		WikiaLogger::instance()->debug( __METHOD__ . ' - Changing user groups',
+			[ 'old-groups' => $oldGroups, 'new-groups' => $newGroups ] );
 
-		wfRunHooks( 'UserRights', array( &$user, $add, $remove ) );
+		wfRunHooks( 'UserRights', array( &$user, $validGroupsToAdd, $validGroupsToRemove ) );
 
 		if( $newGroups != $oldGroups ) {
 			$this->addLogEntry( $user, $oldGroups, $newGroups, $reason );
 		}
-		return array( $add, $remove );
+		return array( $validGroupsToAdd, $validGroupsToRemove );
 	}
 
 	/**
@@ -547,19 +553,16 @@ class UserrightsPage extends SpecialPage {
 		# more easily manage it.
 		$columns = array( 'unchangeable' => array(), 'changeable' => array() );
 		$changeableGroups = $this->getUser()->changeableGroups();
+		$globalGroups = $this->permissionsService()->getConfiguration()->getGlobalGroups();
 
 		foreach( $allgroups as $group ) {
 			$set = in_array( $group, $usergroups );
+			$canAdd = self::canAdd( $globalGroups, $changeableGroups, $group, $this->isself );
+			$canRemove = self::canRemove( $globalGroups, $changeableGroups, $group, $this->isself );
 			# Should the checkbox be disabled?
-			$disabled = !(
-				( $set && self::canRemove( $changeableGroups, $group, $this->isself ) ) ||
-				( !$set && self::canAdd( $changeableGroups, $group, $this->isself ) ) );
-			$disabled = $disabled || $this->isGlobalNonEditableGroup(
-					$this->permissionsService()->getConfiguration()->getGlobalGroups(), $group );
+			$disabled = !( ( $set && $canRemove ) || ( !$set && $canAdd ) );
 			# Do we need to point out that this action is irreversible?
-			$irreversible = !$disabled && (
-				( $set && !self::canAdd( $changeableGroups, $group, $this->isself ) ) ||
-				( !$set && !self::canRemove( $changeableGroups, $group, $this->isself ) ) );
+			$irreversible = !$disabled && ( ( $set && !$canAdd ) || ( !$set && !$canRemove ) );
 
 			$checkbox = array(
 				'set' => $set,

--- a/lib/Wikia/src/Service/User/Permissions/PermissionsService.php
+++ b/lib/Wikia/src/Service/User/Permissions/PermissionsService.php
@@ -77,19 +77,19 @@ interface PermissionsService
      * Adds the given user to the given group
      * @param \User $performer User that is currently logged in and is performing the operation
      * @param \User $userToChange User whose groups we're changing
-     * @param $group string Name of group
+     * @param $groups string Name of group or array with list of groups
      * @return bool True if operation was successful
      */
-    public function addToGroup( \User $performer, \User $userToChange, $group );
+    public function addToGroup( \User $performer, \User $userToChange, $groups );
 
     /**
      * Removes the given user from the given group
      * @param \User $performer User that is currently logged in and is performing the operation
      * @param \User $userToChange User whose groups we're changing
-     * @param $group string Name of group
+     * @param $groups string Name of group or array with list of groups
      * @return bool True if operation was successful
      */
-    public function removeFromGroup( \User $performer, \User $userToChange, $group );
+    public function removeFromGroup( \User $performer, \User $userToChange, $groups );
 
     /**
      * Checks whether the given user has the requested permission

--- a/lib/Wikia/src/Service/User/Permissions/PermissionsService.php
+++ b/lib/Wikia/src/Service/User/Permissions/PermissionsService.php
@@ -74,7 +74,7 @@ interface PermissionsService
     public function getChangeableGroups( \User $performer );
 
     /**
-     * Adds the given user to the given group
+     * Adds the given user to the given group(s)
      * @param \User $performer User that is currently logged in and is performing the operation
      * @param \User $userToChange User whose groups we're changing
      * @param $groups string Name of group or array with list of groups
@@ -83,7 +83,7 @@ interface PermissionsService
     public function addToGroup( \User $performer, \User $userToChange, $groups );
 
     /**
-     * Removes the given user from the given group
+     * Removes the given user from the given group(s)
      * @param \User $performer User that is currently logged in and is performing the operation
      * @param \User $userToChange User whose groups we're changing
      * @param $groups string Name of group or array with list of groups

--- a/lib/Wikia/src/Service/User/Permissions/PermissionsServiceImpl.php
+++ b/lib/Wikia/src/Service/User/Permissions/PermissionsServiceImpl.php
@@ -234,12 +234,12 @@ class PermissionsServiceImpl implements PermissionsService {
 	}
 
 	public function addToGroup( \User $performer, \User $userToChange, $groups ) {
-		$groupsList = $groups;
+		$groupList = $groups;
 		if ( !is_array( $groups ) ) {
-			$groupsList = [ $groups ];
+			$groupList = [ $groups ];
 		}
 		//First check if we can add all groups (if we add in parallel to checking, then the check may not be valid)
-		foreach ( $groupsList as $group ) {
+		foreach ( $groupList as $group ) {
 			if ( !$this->canGroupBeAdded( $performer, $userToChange, $group ) ) {
 				return false;
 			}
@@ -247,7 +247,7 @@ class PermissionsServiceImpl implements PermissionsService {
 
 		$result = true;
 		try {
-			foreach ( $groupsList as $group ) {
+			foreach ( $groupList as $group ) {
 				if ( in_array( $group, $this->permissionsConfiguration->getGlobalGroups() ) ) {
 					$result = $this->addToGlobalGroup( $userToChange, $group ) && $result;
 				} else {
@@ -295,20 +295,20 @@ class PermissionsServiceImpl implements PermissionsService {
 
 	public function removeFromGroup( \User $performer, \User $userToChange, $groups )
 	{
-		$groupsList = $groups;
+		$groupList = $groups;
 		if ( !is_array( $groups ) ) {
-			$groupsList = [ $groups ];
+			$groupList = [ $groups ];
 		}
 
 		//First check if we can remove all groups (if we remove in parallel to checking, then the check may not be valid)
-		foreach ( $groupsList as $group ) {
+		foreach ( $groupList as $group ) {
 			if ( !$this->canGroupBeRemoved( $performer, $userToChange, $group ) ) {
 				return false;
 			}
 		}
 		$result = true;
 		try {
-			foreach ( $groupsList as $group ) {
+			foreach ( $groupList as $group ) {
 				if ( in_array( $group, $this->permissionsConfiguration->getGlobalGroups() ) ) {
 					$result = $this->removeFromGlobalGroup( $userToChange, $group ) && $result;
 				} else {

--- a/lib/Wikia/src/Service/User/Permissions/PermissionsServiceImpl.php
+++ b/lib/Wikia/src/Service/User/Permissions/PermissionsServiceImpl.php
@@ -233,16 +233,26 @@ class PermissionsServiceImpl implements PermissionsService {
 		return false;
 	}
 
-	public function addToGroup( \User $performer, \User $userToChange, $group ) {
-		if ( !$this->canGroupBeAdded( $performer, $userToChange, $group ) ) {
-			return false;
+	public function addToGroup( \User $performer, \User $userToChange, $groups ) {
+		$groupsList = $groups;
+		if ( !is_array( $groups ) ) {
+			$groupsList = [ $groups ];
+		}
+		//First check if we can add all groups (if we add in parallel to checking, then the check may not be valid)
+		foreach ( $groupsList as $group ) {
+			if ( !$this->canGroupBeAdded( $performer, $userToChange, $group ) ) {
+				return false;
+			}
 		}
 
+		$result = true;
 		try {
-			if ( in_array( $group, $this->permissionsConfiguration->getGlobalGroups() ) ) {
-				$result = $this->addToGlobalGroup( $userToChange, $group );
-			} else {
-				$result = $this->addToLocalGroup( $userToChange, $group );
+			foreach ( $groupsList as $group ) {
+				if ( in_array( $group, $this->permissionsConfiguration->getGlobalGroups() ) ) {
+					$result = $this->addToGlobalGroup( $userToChange, $group ) && $result;
+				} else {
+					$result = $this->addToLocalGroup( $userToChange, $group ) && $result;
+				}
 			}
 		}
 		finally {
@@ -283,19 +293,29 @@ class PermissionsServiceImpl implements PermissionsService {
 		return true;
 	}
 
-	public function removeFromGroup( \User $performer, \User $userToChange, $group ) {
-		if ( !$this->canGroupBeRemoved( $performer, $userToChange, $group ) ) {
-			return false;
+	public function removeFromGroup( \User $performer, \User $userToChange, $groups )
+	{
+		$groupsList = $groups;
+		if ( !is_array( $groups ) ) {
+			$groupsList = [ $groups ];
 		}
 
-		try {
-			if ( in_array( $group, $this->permissionsConfiguration->getGlobalGroups() ) ) {
-				$result = $this->removeFromGlobalGroup( $userToChange, $group );
-			} else {
-				$result = $this->removeFromLocalGroup( $userToChange, $group );
+		//First check if we can remove all groups (if we remove in parallel to checking, then the check may not be valid)
+		foreach ( $groupsList as $group ) {
+			if ( !$this->canGroupBeRemoved( $performer, $userToChange, $group ) ) {
+				return false;
 			}
 		}
-		finally {
+		$result = true;
+		try {
+			foreach ( $groupsList as $group ) {
+				if ( in_array( $group, $this->permissionsConfiguration->getGlobalGroups() ) ) {
+					$result = $this->removeFromGlobalGroup( $userToChange, $group ) && $result;
+				} else {
+					$result = $this->removeFromLocalGroup( $userToChange, $group ) && $result;
+				}
+			}
+		} finally {
 			$this->invalidateCache( $userToChange );
 			$userToChange->invalidateCache();
 		}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-2011

Added possibility to add/remove list of groups instead of a single value due to an edge case that when removing rights one by one, one can lack permissions to remove the next group because of removal of a previous one. Now all validation is done first and then actual removal takes place.
