### PR TITLE
DAT-4057 | dataTables bug

### DIFF
--- a/includes/wikia/parser/templatetypes/handlers/DataTables.class.php
+++ b/includes/wikia/parser/templatetypes/handlers/DataTables.class.php
@@ -18,7 +18,7 @@ class DataTables {
 			// marks wikitext tables, omits {{{{{|subst:}}} cases by checking if there is only one '{' before '|'
 			if ( preg_match_all( "/^(.*[^\\{])?\\{\\|(.*)/\n", $wikitext, $wikiTables ) ) {
 				for ( $i = 0; $i < count( $wikiTables[ 0 ] ); $i++ ) {
-					$wikitext = static::markTable( $wikitext, $wikiTables[ 0 ][ $i ], $wikiTables[ 2 ][ $i ], '{|' );
+					$wikitext = static::markTable( $wikitext, $wikiTables[ 0 ][ $i ], $wikiTables[ 2 ][ $i ], $wikiTables[1][$i].'{|' );
 				}
 			}
 			// marks html tables

--- a/includes/wikia/parser/templatetypes/tests/DataTablesTest.php
+++ b/includes/wikia/parser/templatetypes/tests/DataTablesTest.php
@@ -60,6 +60,32 @@ class DataTablesTest extends WikiaBaseTest {
 		return [
 			[ "", "" ],
 			[
+				'<includeonly><onlyinclude>{| class="myClass va-table va-table-center"
+! {{icon|pistol|big|tooltip=Weapon name}}
+! {{Icon|damage|big|tooltip=Weapon damage}}
+! {{Icon|merchant|big|tooltip=Weapon value}}
+! {{icon|rarity|big|Tooltip=Weapon rarity}}
+
+|-
+| [[Rusty BB gun]]
+| 0-1
+| 10
+| {{common}}
+|}</onlyinclude></includeonly>',
+				'<includeonly><onlyinclude>{| data-portable="false" class="myClass va-table va-table-center"
+! {{icon|pistol|big|tooltip=Weapon name}}
+! {{Icon|damage|big|tooltip=Weapon damage}}
+! {{Icon|merchant|big|tooltip=Weapon value}}
+! {{icon|rarity|big|Tooltip=Weapon rarity}}
+
+|-
+| [[Rusty BB gun]]
+| 0-1
+| 10
+| {{common}}
+|}</onlyinclude></includeonly>'
+			],
+			[
 				'{| class="va-table va-table-center"
 ! {{icon|pistol|big|tooltip=Weapon name}}
 ! {{Icon|damage|big|tooltip=Weapon damage}}
@@ -114,6 +140,15 @@ class DataTablesTest extends WikiaBaseTest {
 |}',
 			  '{| data-portable="false" class="va-table va-table-center"
 |}' ],
+			[
+				'<includeonly><onlyinclude>
+					<table><tr><td>sth</td><td>sth2</td></tr></table>
+				</onlyinclude></includeonly>',
+
+				'<includeonly><onlyinclude>
+					<table data-portable="false"><tr><td>sth</td><td>sth2</td></tr></table>
+				</onlyinclude></includeonly>'
+			],
 			[ '<table></table>', '<table data-portable="false"></table>' ],
 			[ '{| class="va-table va-table-center"
 ! {{icon|pistol|big|tooltip=Weapon name}}


### PR DESCRIPTION
Fixing issue with </onlyinclude> and </includeonly> tags visible on some articles on mercury, when transcluded template contains table surrounded by <onlyinclude></onlyinclude> or <includeonly></includeonly>
