### PR TITLE
DatabaseBase: log if we're within DB transaction

### DIFF
--- a/includes/db/Database.php
+++ b/includes/db/Database.php
@@ -3744,6 +3744,7 @@ abstract class DatabaseBase implements DatabaseType {
 			'method'      => $fname,
 			'elapsed'     => $elapsedTime,
 			'num_rows'    => $num_rows,
+			'transaction_level' => $this->mTrxLevel, # either 0 or 1
 			'cluster'     => $wgDBcluster,
 			'server'      => $this->mServer,
 			'server_role' => $isMaster ? 'master' : 'slave',


### PR DESCRIPTION
Make debugging issues like [PLATFORM-2118](https://wikia-inc.atlassian.net/browse/PLATFORM-2118) a bit easier by logging `transaction_level` field stating it the query was performed within a transaction or not.

@wladekb / @drozdo 
