### PR TITLE
[SUS-415] Automatically include all i18n files in LocalisationCache rebuild script. 

### DIFF
--- a/maintenance/rebuildLocalisationCache.php
+++ b/maintenance/rebuildLocalisationCache.php
@@ -157,7 +157,11 @@ class RebuildLocalisationCache extends Maintenance {
 		exit( $exitcode );
 	}
 
-	public function includeAllMessagesFiles() {
+	/**
+	 * Helper function to include all localisation files to localisation cache rebuild process.
+	 * It looks for i18n and alias files from whole code directory and registers them in global array.
+	 */
+	private function includeAllMessagesFiles() {
 		global $wgExtensionMessagesFiles;
 
 		$directory = new RecursiveDirectoryIterator('/usr/wikia/source/app/');

--- a/maintenance/rebuildLocalisationCache.php
+++ b/maintenance/rebuildLocalisationCache.php
@@ -31,6 +31,11 @@
 require_once( dirname( __FILE__ ) . '/Maintenance.php' );
 
 class RebuildLocalisationCache extends Maintenance {
+
+	const I18N_FILE_EXTENSION = ".i18n.php";
+	const PHP_FILE_EXTENSION = ".php";
+	const LOCALISATION_FILE_REGEX = "/^.+\.(i18n|aliases|alias).php$/i";
+
 	public function __construct() {
 		parent::__construct();
 		$this->mDescription = "Rebuild the localisation cache";
@@ -157,15 +162,15 @@ class RebuildLocalisationCache extends Maintenance {
 
 		$directory = new RecursiveDirectoryIterator('/usr/wikia/source/app/');
 		$iterator = new RecursiveIteratorIterator($directory);
-		$files = new RegexIterator($iterator, '/^.+\.(i18n|aliases|alias).php$/i', RecursiveRegexIterator::GET_MATCH);
+		$files = new RegexIterator($iterator, self::LOCALISATION_FILE_REGEX, RecursiveRegexIterator::GET_MATCH);
 
 		foreach ($files as $filepath) {
 			if (!isset($filepath[0])) continue;
 
-			if (strpos($filepath[0], '.i18n.php') !== false ) {
-				$wgExtensionMessagesFiles[basename($filepath[0], ".i18n.php")] = $filepath[0];
+			if (strpos($filepath[0], self::I18N_FILE_EXTENSION) !== false ) {
+				$wgExtensionMessagesFiles[basename($filepath[0], self::I18N_FILE_EXTENSION)] = $filepath[0];
 			} else {
-				$wgExtensionMessagesFiles[basename($filepath[0], ".php")] = $filepath[0];
+				$wgExtensionMessagesFiles[basename($filepath[0], self::PHP_FILE_EXTENSION)] = $filepath[0];
 			}
 		}
 	}

--- a/maintenance/rebuildLocalisationCache.php
+++ b/maintenance/rebuildLocalisationCache.php
@@ -173,10 +173,11 @@ class RebuildLocalisationCache extends Maintenance {
 			if (!isset($filepath[0])) continue;
 
 			if (strpos($filepath[0], self::I18N_FILE_EXTENSION) !== false ) {
-				$wgExtensionMessagesFiles[basename($filepath[0], self::I18N_FILE_EXTENSION)] = $filepath[0];
+				$key = basename($filepath[0], self::I18N_FILE_EXTENSION);
 			} else {
-				$wgExtensionMessagesFiles[basename($filepath[0], self::PHP_FILE_EXTENSION)] = $filepath[0];
+				$key = basename($filepath[0], self::PHP_FILE_EXTENSION);
 			}
+			$wgExtensionMessagesFiles[$key] = $filepath[0];
 		}
 	}
 

--- a/maintenance/rebuildLocalisationCache.php
+++ b/maintenance/rebuildLocalisationCache.php
@@ -49,6 +49,8 @@ class RebuildLocalisationCache extends Maintenance {
 	public function execute() {
 		global $wgLocalisationCacheConf;
 
+		$this->includeAllMessagesFiles();
+
 		// Wikia change begin
 		global $wgCacheDirectory;
 		$wgCacheDirectory = $this->getOption( 'cache-dir', $wgCacheDirectory );
@@ -148,6 +150,24 @@ class RebuildLocalisationCache extends Maintenance {
 		}
 
 		exit( $exitcode );
+	}
+
+	public function includeAllMessagesFiles() {
+		global $wgExtensionMessagesFiles;
+
+		$directory = new RecursiveDirectoryIterator('/usr/wikia/source/app/');
+		$iterator = new RecursiveIteratorIterator($directory);
+		$files = new RegexIterator($iterator, '/^.+\.(i18n|aliases|alias).php$/i', RecursiveRegexIterator::GET_MATCH);
+
+		foreach ($files as $filepath) {
+			if (!isset($filepath[0])) continue;
+
+			if (strpos($filepath[0], '.i18n.php') !== false ) {
+				$wgExtensionMessagesFiles[basename($filepath[0], ".i18n.php")] = $filepath[0];
+			} else {
+				$wgExtensionMessagesFiles[basename($filepath[0], ".php")] = $filepath[0];
+			}
+		}
 	}
 
 	/**

--- a/maintenance/rebuildLocalisationCache.php
+++ b/maintenance/rebuildLocalisationCache.php
@@ -163,8 +163,9 @@ class RebuildLocalisationCache extends Maintenance {
 	 */
 	private function includeAllMessagesFiles() {
 		global $wgExtensionMessagesFiles;
+		global $IP;
 
-		$directory = new RecursiveDirectoryIterator('/usr/wikia/source/app/');
+		$directory = new RecursiveDirectoryIterator($IP);
 		$iterator = new RecursiveIteratorIterator($directory);
 		$files = new RegexIterator($iterator, self::LOCALISATION_FILE_REGEX, RecursiveRegexIterator::GET_MATCH);
 

--- a/maintenance/rebuildLocalisationCache.php
+++ b/maintenance/rebuildLocalisationCache.php
@@ -169,15 +169,13 @@ class RebuildLocalisationCache extends Maintenance {
 		$iterator = new RecursiveIteratorIterator($directory);
 		$files = new RegexIterator($iterator, self::LOCALISATION_FILE_REGEX, RecursiveRegexIterator::GET_MATCH);
 
-		foreach ($files as $filepath) {
-			if (!isset($filepath[0])) continue;
-
-			if (strpos($filepath[0], self::I18N_FILE_EXTENSION) !== false ) {
-				$key = basename($filepath[0], self::I18N_FILE_EXTENSION);
+		foreach ($files as $file) {
+			if (strpos($file[0], self::I18N_FILE_EXTENSION) !== false ) {
+				$key = basename($file[0], self::I18N_FILE_EXTENSION);
 			} else {
-				$key = basename($filepath[0], self::PHP_FILE_EXTENSION);
+				$key = basename($file[0], self::PHP_FILE_EXTENSION);
 			}
-			$wgExtensionMessagesFiles[$key] = $filepath[0];
+			$wgExtensionMessagesFiles[$key] = $file[0];
 		}
 	}
 

--- a/maintenance/rebuildLocalisationCache.php
+++ b/maintenance/rebuildLocalisationCache.php
@@ -28,7 +28,7 @@
  * @ingroup Maintenance
  */
 
-require_once( dirname( __FILE__ ) . '/Maintenance.php' );
+require_once( __DIR__ . '/Maintenance.php' );
 
 class RebuildLocalisationCache extends Maintenance {
 
@@ -162,8 +162,7 @@ class RebuildLocalisationCache extends Maintenance {
 	 * It looks for i18n and alias files from whole code directory and registers them in global array.
 	 */
 	private function includeAllMessagesFiles() {
-		global $wgExtensionMessagesFiles;
-		global $IP;
+		global $wgExtensionMessagesFiles, $IP;
 
 		$directory = new RecursiveDirectoryIterator($IP);
 		$iterator = new RecursiveIteratorIterator($directory);


### PR DESCRIPTION
We should include all localisation files (i18n & aliases) in LocalisationCache rebuild process, this will alow us to build cache file that contains all the messages keys and we will be able to remove manual includes like here :  https://github.com/Wikia/config/blob/dev/CommonExtensions.php#L122

https://wikia-inc.atlassian.net/browse/SUS-415

/cc @mixth-sense 
