### PR TITLE
SEO-361: Investigate <meta name="description" content=" " />

### DIFF
--- a/includes/OutputPage.php
+++ b/includes/OutputPage.php
@@ -309,6 +309,16 @@ class OutputPage extends ContextSource {
 	 * @param $val String tag value
 	 */
 	function addMeta( $name, $val ) {
+		/** Wikia change begin: SEO-361: Investigate <meta name="description" content=" " /> */
+		if ( $name === 'description' && $val === ' ' ) {
+			array_push( $this->mMetatags, array( 'debug-description', 'SPACE' ) );
+			\Wikia\Logger\WikiaLogger::instance()->warning(
+				'Meta description containing just a space', [
+					'ex' => new Exception(),
+				]
+			);
+		}
+		/** Wikia change end */
 		array_push( $this->mMetatags, array( $name, $val ) );
 	}
 


### PR DESCRIPTION
First step: make sure we know how the " " description is set.

We do that by emitting another meta tag when `<meta name="description" content=" " />` is about to be emitted. When the situation happens again we can inspect the meta tags and if both are there: bingo, the broken meta tag was added through `addMeta`. Additionally we log the warning message when this happens, so we can get a stacktrace and estimate the scale of the issue.

If `<meta name="description" content=" " />` is found live without `<meta name="debug-description" content="SPACE" />` the tag is added through a different call.

Next steps: after confirming the issue and estimating the scope of the problem add the proper amount of logging in the process of generating the params passed to the `addMeta` call.
