### PR TITLE
SOC-2268 don't log all attributeservice exceptions as errors

### DIFF
--- a/lib/Wikia/src/Service/User/Attributes/AttributeKeyValueService.php
+++ b/lib/Wikia/src/Service/User/Attributes/AttributeKeyValueService.php
@@ -109,7 +109,7 @@ class AttributeKeyValueService implements AttributeService {
 		if ( $e instanceof PersistenceException ) {
 			$this->error( $msg, $context );
 		} else {
-			$this->info( $msg, $context );
+			$this->warning( $msg, $context );
 		}
 	}
 

--- a/lib/Wikia/src/Service/User/Attributes/AttributeKeyValueService.php
+++ b/lib/Wikia/src/Service/User/Attributes/AttributeKeyValueService.php
@@ -7,6 +7,7 @@ use Wikia\Logger\Loggable;
 use Wikia\Persistence\User\Attributes\AttributePersistence;
 use Wikia\Util\WikiaProfiler;
 use Wikia\Service\User\Attributes;
+use Wikia\Service\PersistenceException;
 
 class AttributeKeyValueService implements AttributeService {
 
@@ -105,7 +106,7 @@ class AttributeKeyValueService implements AttributeService {
 	 */
 	private function logException( $userId, \Exception $e, $msg ) {
 		$context = [ 'user' => $userId, 'exception' => $e ];
-		if ( is_a( $e, 'Wikia\Service\PersistenceException' ) ) {
+		if ( $e instanceof PersistenceException ) {
 			$this->error( $msg, $context );
 		} else {
 			$this->info( $msg, $context );

--- a/lib/Wikia/src/Service/User/Attributes/AttributeKeyValueService.php
+++ b/lib/Wikia/src/Service/User/Attributes/AttributeKeyValueService.php
@@ -97,9 +97,9 @@ class AttributeKeyValueService implements AttributeService {
 	 * Log any exceptions thrown when contacting the attribute service. There are 4 possible exceptions
 	 * which can be thrown, and which this method can expect to receive: PersistenceException, ForbiddenException,
 	 * NotFoundException, and UnauthorizedException. Log PersistenceExceptions at error level, and all others
-	 * at info. PersistenceExceptions indicate a problem was encountered contacting the service, or that we received
+	 * at warning. PersistenceExceptions indicate a problem was encountered contacting the service, or that we received
 	 * an unexpected HTTP response like a 500. The other exceptions indicate a resources wasn't found, or that the
-	 * request was refused which is not an error.
+	 * request was refused.
 	 * @param $userId
 	 * @param \Exception $e
 	 * @param $msg

--- a/lib/Wikia/src/Service/User/Attributes/AttributeKeyValueService.php
+++ b/lib/Wikia/src/Service/User/Attributes/AttributeKeyValueService.php
@@ -47,7 +47,7 @@ class AttributeKeyValueService implements AttributeService {
 
 			return $ret;
 		} catch ( \Exception $e ) {
-			$this->logError( $userId, $e, "USER_ATTRIBUTES error saving to service" );
+			$this->logException( $userId, $e, "USER_ATTRIBUTES failure saving to service" );
 			return false;
 		}
 	}
@@ -66,7 +66,7 @@ class AttributeKeyValueService implements AttributeService {
 		try {
 			$attributeArray = $this->persistenceAdapter->getAttributes( $userId );
 		} catch ( \Exception $e ) {
-			$this->logError( $userId, $e, "USER_ATTRIBUTES error getting from service" );
+			$this->logException( $userId, $e, "USER_ATTRIBUTES failure getting from service" );
 		}
 
 		return $attributeArray;
@@ -87,16 +87,29 @@ class AttributeKeyValueService implements AttributeService {
 			$ret = $this->persistenceAdapter->deleteAttribute( $userId, $attribute );
 			return $ret;
 		} catch ( \Exception $e ) {
-			$this->logError( $userId, $e, "USER_ATTRIBUTES error deleting from service" );
+			$this->logException( $userId, $e, "USER_ATTRIBUTES failure deleting from service" );
 			return false;
 		}
 	}
 
-	private function logError( $userId, \Exception $e, $msg ) {
-		$this->error( $msg , [
-			'user' => $userId,
-			'exception' => $e
-		] );
+	/**
+	 * Log any exceptions thrown when contacting the attribute service. There are 4 possible exceptions
+	 * which can be thrown, and which this method can expect to receive: PersistenceException, ForbiddenException,
+	 * NotFoundException, and UnauthorizedException. Log PersistenceExceptions at error level, and all others
+	 * at info. PersistenceExceptions indicate a problem was encountered contacting the service, or that we received
+	 * an unexpected HTTP response like a 500. The other exceptions indicate a resources wasn't found, or that the
+	 * request was refused which is not an error.
+	 * @param $userId
+	 * @param \Exception $e
+	 * @param $msg
+	 */
+	private function logException( $userId, \Exception $e, $msg ) {
+		$context = [ 'user' => $userId, 'exception' => $e ];
+		if ( is_a( $e, 'Wikia\Service\PersistenceException' ) ) {
+			$this->error( $msg, $context );
+		} else {
+			$this->info( $msg, $context );
+		}
 	}
 
 	protected function getLoggerContext() {

--- a/lib/Wikia/src/Service/User/Attributes/UserAttributes.php
+++ b/lib/Wikia/src/Service/User/Attributes/UserAttributes.php
@@ -13,6 +13,10 @@ class UserAttributes {
 	const DEFAULT_ATTRIBUTES = "user_attributes_default_attributes";
 	const CACHE_PROVIDER = "user_attributes_cache_provider";
 
+	// Attributes which the service returns, but treats as immutable and therefore we
+	// shouldn't attempt to save as the service will return a 403.
+	const READ_ONLY_ATTRIBUTES = [ 'username' ];
+
 	/** @var CacheProvider */
 	private $cache;
 
@@ -114,6 +118,10 @@ class UserAttributes {
 		// Ticket: SOC-1482
 		$savedAttributes = [];
 		foreach( $attributes as $name => $value ) {
+			if ( $this->isReadOnlyAttribute( $name ) ) {
+				continue;
+			}
+
 			if ( $this->attributeShouldBeSaved( $name, $value ) ) {
 				$this->setInService( $userId, new Attribute( $name, $value ) );
 				$savedAttributes[$name] = $value;
@@ -126,6 +134,10 @@ class UserAttributes {
 		}
 
 		$this->setInMemcache( $userId, $savedAttributes );
+	}
+
+	private function isReadOnlyAttribute( $name ) {
+		return in_array( $name, self::READ_ONLY_ATTRIBUTES );
 	}
 
 	private function logIfBadAvatarVal( $value, $userId ) {


### PR DESCRIPTION
Ticket: https://wikia-inc.atlassian.net/browse/SOC-2268

As part of SOC-2123 I added additional logging to the AttributeKeyValueService.php. All of that logging was set at the error level, which is incorrect. There are some cases where exceptions are thrown which don't indicate an error. Some of these include when MW tries to GET a non-existent attribute, or an unauthenticated user tries to save an attribute.

This PR updates that logging so we only log `PersistenceExceptions` at error, since those indicate an error actually contacting the service, everything else has been downgraded to info.
