### PR TITLE
SOC-2185 save/delete requested-closure-date as both a preference and …

### DIFF
--- a/extensions/wikia/CloseMyAccount/CloseMyAccountHelper.class.php
+++ b/extensions/wikia/CloseMyAccount/CloseMyAccountHelper.class.php
@@ -25,7 +25,12 @@ class CloseMyAccountHelper {
 		}
 
 		$user->setGlobalFlag( 'requested-closure', true );
+
+		// Temporarily save requested-closure-date as both an attribute and a preference. This
+		// will be changed to just a preference once we complete the migration. See SOC-2185
 		$user->setGlobalAttribute( 'requested-closure-date', wfTimestamp( TS_DB ) );
+		$user->setGlobalPreference( 'requested-closure-date', wfTimestamp( TS_DB ) );
+
 		$user->saveSettings();
 
 		$this->track( $user, 'request-closure' );
@@ -82,7 +87,13 @@ class CloseMyAccountHelper {
 		}
 
 		$user->setGlobalFlag( 'requested-closure', null );
+
+		// requested-closure-date is temporarily being stored as both an attribute and a preference.
+		// Make sure to delete from both places. This will be changed to just a preference once the
+		// migration is complete. See SOC-2185
 		$user->setGlobalAttribute( 'requested-closure-date', null );
+		$user->setGlobalPreference( 'requested-closure-date', null );
+
 		$user->saveSettings();
 
 		$this->track( $user, 'account-reactivated' );

--- a/extensions/wikia/CloseMyAccount/maintenance/CloseMyAccountMaintenance.php
+++ b/extensions/wikia/CloseMyAccount/maintenance/CloseMyAccountMaintenance.php
@@ -73,7 +73,12 @@ class CloseMyAccountMaintenance extends Maintenance {
 
 				// Cleanup
 				$userObj->setGlobalFlag( 'requested-closure', null );
+
+				// requested-closure-date is temporarily being stored as both an attribute and a preference.
+				// Make sure to delete from both places. This will be changed to just a preference once the
+				// migration is complete. See SOC-2185
 				$userObj->setGlobalAttribute( 'requested-closure-date', null );
+				$userObj->setGlobalPreference( 'requested-closure-date', null );
 
 				$userObj->saveSettings();
 


### PR DESCRIPTION
Ticket: https://wikia-inc.atlassian.net/browse/SOC-2185

In preparation for migrating `requested-closure-date` to the user preference service, we need to start writing/deleting it from the service. This ensure that when we migrate the existing values from the `user_properties` table, new values will be added and deleted from both places so they'll be consistent. Note that we're not writing over `requested-closure`. The plan is to get rid of this redundant data after the migration since we can assume `requested-closure` == `true` if we have a value for  `requested-closure-date`.
