### PR TITLE
JPN-355 Filter out Admin and Anon from Community page experiment

### DIFF
--- a/extensions/wikia/CommunityPageExperiment/CommunityPageExperimentHelper.class.php
+++ b/extensions/wikia/CommunityPageExperiment/CommunityPageExperimentHelper.class.php
@@ -51,13 +51,10 @@ class CommunityPageExperimentHelper {
 		}
 
 		// Filter out blocked and anon admins
-		foreach ( $adminIds as $key => $adminId ) {
+		$adminIds = array_filter( $adminIds, function ( $adminId ) {
 			$admin = User::newFromId( $adminId );
-
-			if ( $admin->isBlocked() || $admin->isAnon() ) {
-				unset( $adminIds[$key] );
-			}
-		}
+			return !$admin->isBlocked() && !$admin->isAnon();
+		} );
 
 		$numAdmins = count( $adminIds );
 		if ( $numAdmins < $num ) {

--- a/extensions/wikia/CommunityPageExperiment/CommunityPageExperimentHelper.class.php
+++ b/extensions/wikia/CommunityPageExperiment/CommunityPageExperimentHelper.class.php
@@ -49,9 +49,23 @@ class CommunityPageExperimentHelper {
 		if ( empty( $adminIds ) ) {
 			return [];
 		}
+
+		// Filter out blocked and anon admins
+		foreach ( $adminIds as $key => $adminId ) {
+			$admin = User::newFromId( $adminId );
+
+			if ( $admin->isBlocked() || $admin->isAnon() ) {
+				unset( $adminIds[$key] );
+			}
+		}
+
 		$numAdmins = count( $adminIds );
 		if ( $numAdmins < $num ) {
 			$num = $numAdmins;
+		}
+
+		if ( $num == 0 ) {
+			return [];
 		}
 
 		$randomAdminIds = array_rand( $adminIds, $num );


### PR DESCRIPTION
getRandomAdmins was not filtering out blocked and anon admins. Added extra filtering to make sure that   they're filtered out before randomizing.
