### PR TITLE
DAT-4077 | fixing issues with navigation templates on mercury

### DIFF
--- a/includes/wikia/parser/templatetypes/handlers/NavigationTemplate.class.php
+++ b/includes/wikia/parser/templatetypes/handlers/NavigationTemplate.class.php
@@ -8,7 +8,7 @@ class NavigationTemplate {
 		'p',
 	];
 
-	public static $mark = 'NAVUNIQ';
+	const MARK = 'NAVUNIQ';
 
 	/**
 	 * @desc If a block element div, table or p is found in a template's text, return an empty
@@ -30,7 +30,7 @@ class NavigationTemplate {
 
 	private static function process( $html ) {
 		$blockElemRegex = '/<(' . implode( '|', self::$blockLevelElements ) . ')[>\s]+/i';
-		$markerRegex = "/\x7f".self::$mark.".+?\x7f/s";
+		$markerRegex = "/\x7f".self::MARK.".+?\x7f/s";
 
 		//getting markers of each navigation template
 		preg_match_all($markerRegex, $html, $markers);
@@ -59,7 +59,7 @@ class NavigationTemplate {
 	 */
 	private static function mark( $text ) {
 		// marking each template with unique marker to be able to handle nested navigation templates
-		$marker = "\x7f".self::$mark."_".uniqid()."\x7f";
+		$marker = "\x7f".self::MARK."_".uniqid()."\x7f";
 		return sprintf( "%s%s%s", $marker, $text, $marker );
 	}
 }

--- a/includes/wikia/parser/templatetypes/handlers/NavigationTemplate.class.php
+++ b/includes/wikia/parser/templatetypes/handlers/NavigationTemplate.class.php
@@ -33,14 +33,14 @@ class NavigationTemplate {
 		$markerRegex = "/\x7f".self::MARK.".+?\x7f/s";
 
 		//getting markers of each navigation template
-		preg_match_all($markerRegex, $html, $markers);
-		foreach ( array_unique($markers[ 0 ]) as $marker ) {
+		preg_match_all( $markerRegex, $html, $markers );
+		foreach ( array_unique( $markers[ 0 ] ) as $marker ) {
 			$replacementRegex = '/'.$marker.".*?".$marker.'/s';
-			preg_match_all($replacementRegex, $html, $navTemplates);
+			preg_match_all( $replacementRegex, $html, $navTemplates );
 
 			//multiple invocations of the same template can occur, replacing each of them
-			foreach($navTemplates[0] as $navTemplate) {
-				$replacement = str_replace($marker, '', $navTemplate);
+			foreach( $navTemplates[ 0 ] as $navTemplate ) {
+				$replacement = str_replace( $marker, '', $navTemplate );
 
 				if ( preg_match( $blockElemRegex, $navTemplate ) ) {
 					$replacement = '';

--- a/includes/wikia/parser/templatetypes/handlers/NavigationTemplate.class.php
+++ b/includes/wikia/parser/templatetypes/handlers/NavigationTemplate.class.php
@@ -34,7 +34,7 @@ class NavigationTemplate {
 
 		//getting markers of each navigation template
 		preg_match_all($markerRegex, $html, $markers);
-		foreach ( $markers[ 0 ] as $marker ) {
+		foreach ( array_unique($markers[ 0 ]) as $marker ) {
 			$replacementRegex = '/'.$marker.".*?".$marker.'/s';
 			preg_match_all($replacementRegex, $html, $navTemplates);
 

--- a/includes/wikia/parser/templatetypes/handlers/NavigationTemplate.class.php
+++ b/includes/wikia/parser/templatetypes/handlers/NavigationTemplate.class.php
@@ -18,7 +18,7 @@ class NavigationTemplate {
 	 * @return string
 	 */
 	public static function handle( $text ) {
-		return !empty( $text ) ? self::mark( $text ) : $text;
+		return !empty($text) ? self::mark( $text ) : $text;
 	}
 
 	public static function resolve( &$html ) {
@@ -30,16 +30,16 @@ class NavigationTemplate {
 
 	private static function process( $html ) {
 		$blockElemRegex = '/<(' . implode( '|', self::$blockLevelElements ) . ')[>\s]+/i';
-		$markerRegex = "/\x7f".self::MARK.".+?\x7f/s";
+		$markerRegex = "/\x7f" . self::MARK . ".+?\x7f/s";
 
 		//getting markers of each navigation template
 		preg_match_all( $markerRegex, $html, $markers );
 		foreach ( array_unique( $markers[ 0 ] ) as $marker ) {
-			$replacementRegex = '/'.$marker.".*?".$marker.'/s';
+			$replacementRegex = '/' . $marker . ".*?" . $marker . '/s';
 			preg_match_all( $replacementRegex, $html, $navTemplates );
 
 			//multiple invocations of the same template can occur, replacing each of them
-			foreach( $navTemplates[ 0 ] as $navTemplate ) {
+			foreach ( $navTemplates[ 0 ] as $navTemplate ) {
 				$replacement = str_replace( $marker, '', $navTemplate );
 
 				if ( preg_match( $blockElemRegex, $navTemplate ) ) {
@@ -59,7 +59,7 @@ class NavigationTemplate {
 	 */
 	private static function mark( $text ) {
 		// marking each template with unique marker to be able to handle nested navigation templates
-		$marker = "\x7f".self::MARK."_".uniqid()."\x7f";
+		$marker = "\x7f" . self::MARK . "_" . uniqid() . "\x7f";
 		return sprintf( "%s%s%s", $marker, $text, $marker );
 	}
 }

--- a/includes/wikia/parser/templatetypes/handlers/NavigationTemplate.class.php
+++ b/includes/wikia/parser/templatetypes/handlers/NavigationTemplate.class.php
@@ -32,11 +32,13 @@ class NavigationTemplate {
 		$blockElemRegex = '/<(' . implode( '|', self::$blockLevelElements ) . ')[>\s]+/i';
 		$markerRegex = "/\x7f".self::$mark.".+?\x7f/s";
 
+		//getting markers of each navigation template
 		preg_match_all($markerRegex, $html, $markers);
 		foreach ( $markers[ 0 ] as $marker ) {
 			$replacementRegex = '/'.$marker.".*?".$marker.'/s';
 			preg_match_all($replacementRegex, $html, $navTemplates);
 
+			//multiple invocations of the same template can occur, replacing each of them
 			foreach($navTemplates[0] as $navTemplate) {
 				$replacement = str_replace($marker, '', $navTemplate);
 
@@ -56,6 +58,7 @@ class NavigationTemplate {
 	 * @return string
 	 */
 	private static function mark( $text ) {
+		// marking each template with unique marker to be able to handle nested navigation templates
 		$marker = "\x7f".self::$mark."_".uniqid()."\x7f";
 		return sprintf( "%s%s%s", $marker, $text, $marker );
 	}

--- a/includes/wikia/parser/templatetypes/handlers/NavigationTemplate.class.php
+++ b/includes/wikia/parser/templatetypes/handlers/NavigationTemplate.class.php
@@ -29,20 +29,20 @@ class NavigationTemplate {
 	}
 
 	private static function process( $html ) {
-		$markerRegex = "/<(\x7f" . self::MARK . ".+\x7f)>/sU";
+		$markerRegex = "/(<|&lt;)(\x7f" . self::MARK . ".+\x7f)(>|&gt;)/sU";
 
 		//getting unique markers of each navigation template
 		preg_match_all( $markerRegex, $html, $markers );
 
-		foreach ( array_unique( $markers[ 1 ] ) as $marker ) {
+		foreach ( array_unique( $markers[ 2 ] ) as $marker ) {
 			// matches block elements in between start and end marker tags
 			// <marker>(not </marker>)...(block element)...</marker>
-			$html = preg_replace( '/<' . $marker . '>' .
-								  '((?!<\\/' . $marker . '>).)*' .
-								  '<(' . implode( '|', self::$blockLevelElements ) . ')[>\s]+.*' .
-								  '<\\/' . $marker . '>/isU', '', $html );
+			$html = preg_replace( '/(<|&lt;)' . $marker . '(>|&gt;)' .
+								  '((?!(<|&lt;)\\/' . $marker . '(>|&gt;)).)*' .
+								  '(<|&lt;)(' . implode( '|', self::$blockLevelElements ) . ')[(>|&gt;)\s]+.*' .
+								  '(<|&lt;)\\/' . $marker . '(>|&gt;)/isU', '', $html );
 			// remove just the marker tags
-			$html = preg_replace( '/<\\/?' . $marker . '>/sU', '', $html );
+			$html = preg_replace( '/(<|&lt;)\\/?' . $marker . '(>|&gt;)/sU', '', $html );
 		}
 
 		return $html;

--- a/includes/wikia/parser/templatetypes/tests/NavigationTemplateTest.php
+++ b/includes/wikia/parser/templatetypes/tests/NavigationTemplateTest.php
@@ -8,14 +8,14 @@ class NavigationTemplateTest extends WikiaBaseTest {
 	public function testMarkNavigationElements( $content, $expected, $message ) {
 		$marked = NavigationTemplate::handle( $content );
 
-		$this->assertEquals( preg_match($markerRegex = "/<\x7f".NavigationTemplate::MARK.".+?\x7f>/s", $marked), $expected, $message );
+		$this->assertEquals( $expected, preg_match( $markerRegex = "/<\x7f" . NavigationTemplate::MARK . ".+?\x7f>/s", $marked ), $message );
 	}
 
 	public function markedTemplateContentProvider() {
 		return [
 			[ '', 0, 'Empty content was marked' ],
 			[ '1', 1, 'Numbers should be marked' ],
-			[ '{{#invoke: Eras|main}}', 1,  'Wikitext should be marked' ],
+			[ '{{#invoke: Eras|main}}', 1, 'Wikitext should be marked' ],
 		];
 	}
 

--- a/includes/wikia/parser/templatetypes/tests/NavigationTemplateTest.php
+++ b/includes/wikia/parser/templatetypes/tests/NavigationTemplateTest.php
@@ -99,6 +99,11 @@ class NavigationTemplateTest extends WikiaBaseTest {
 				"Single nav template with block should be removed"
 			],
 			[
+				"&lt;\x7fNAVUNIQ_342\x7f&gt;akjsdlkjflk <div>asdf</div>kasjdlfkjdks ksdjlafkj&lt;/\x7fNAVUNIQ_342\x7f&gt; test",
+				" test",
+				"Single nav template with block should be removed, even when encoded"
+			],
+			[
 				"<\x7fNAVUNIQ_342\x7f>asdf</\x7fNAVUNIQ_342\x7f> test",
 				"asdf test",
 				"Single inline element should be left"

--- a/includes/wikia/parser/templatetypes/tests/NavigationTemplateTest.php
+++ b/includes/wikia/parser/templatetypes/tests/NavigationTemplateTest.php
@@ -5,11 +5,11 @@ class NavigationTemplateTest extends WikiaBaseTest {
 	/**
 	 * @dataProvider markedTemplateContentProvider
 	 */
-	public function testMarkNavigationElements( $content, $expected, $message ) {
-		$marked = NavigationTemplate::handle( $content );
-
-		$this->assertEquals( preg_match($markerRegex = "/\x7f".NavigationTemplate::MARK.".+?\x7f/s", $marked), $expected, $message );
-	}
+//	public function testMarkNavigationElements( $content, $expected, $message ) {
+//		$marked = NavigationTemplate::handle( $content );
+//
+//		$this->assertEquals( preg_match($markerRegex = "/\x7f".NavigationTemplate::MARK.".+?\x7f/s", $marked), $expected, $message );
+//	}
 
 	public function markedTemplateContentProvider() {
 		return [
@@ -24,12 +24,12 @@ class NavigationTemplateTest extends WikiaBaseTest {
 	 * @param $templateText
 	 * @dataProvider getNavigationTemplates
 	 */
-	public function testHideNavigationWithBlockElements( $templateText, $expectedOutput, $message ) {
-		$output = NavigationTemplate::handle( $templateText );
-		NavigationTemplate::resolve( $output );
-
-		$this->assertSame( $expectedOutput, $output, $message );
-	}
+//	public function testHideNavigationWithBlockElements( $templateText, $expectedOutput, $message ) {
+//		$output = NavigationTemplate::handle( $templateText );
+//		NavigationTemplate::resolve( $output );
+//
+//		$this->assertSame( $expectedOutput, $output, $message );
+//	}
 
 	public function getNavigationTemplates() {
 		return [
@@ -89,45 +89,45 @@ class NavigationTemplateTest extends WikiaBaseTest {
 		return [
 			[ "", "", "Empty html should be correctly processed" ],
 			[
-				"\x7fNAVUNIQ_342\x7fakjsdlkjflk <div>asdf</div>kasjdlfkjdks ksdjlafkj\x7fNAVUNIQ_342\x7fNAVUNIQ aksdjlfkj alksjdldf\nlkjsdl \x7fNAVUNIQ_343\x7fd\x7fNAVUNIQ_343\x7f",
+				"<\x7fNAVUNIQ_342\x7f>fakjsdlkjflk <div>asdf</div>kasjdlfkjdks ksdjlafkj</\x7fNAVUNIQ_342\x7f>NAVUNIQ aksdjlfkj alksjdldf\nlkjsdl <\x7fNAVUNIQ_343\x7f>d</\x7fNAVUNIQ_343\x7f>",
 				"NAVUNIQ aksdjlfkj alksjdldf\nlkjsdl d",
 				"If block element in navigation template it should be removed"
 			],
 			[
-				"\x7fNAVUNIQ_342\x7fakjsdlkjflk <div>asdf</div>kasjdlfkjdks ksdjlafkj\x7fNAVUNIQ_342\x7f test",
+				"<\x7fNAVUNIQ_342\x7f>akjsdlkjflk <div>asdf</div>kasjdlfkjdks ksdjlafkj</\x7fNAVUNIQ_342\x7f> test",
 				" test",
 				"Single nav template with block should be removed"
 			],
 			[
-				"\x7fNAVUNIQ_342\x7fasdf\x7fNAVUNIQ_342\x7f test",
+				"<\x7fNAVUNIQ_342\x7f>asdf</\x7fNAVUNIQ_342\x7f> test",
 				"asdf test",
 				"Single inline element should be left"
 			],
 			[
-				"\x7fNAVUNIQ_342\x7f<div>some content \x7fNAVUNIQ_343\x7f <p>nested template</p> \x7fNAVUNIQ_343\x7f \x7fNAVUNIQ_344\x7f <p>nested template</p> \x7fNAVUNIQ_344\x7f</div>\x7fNAVUNIQ_342\x7f",
+				"<\x7fNAVUNIQ_342\x7f><div>some content <\x7fNAVUNIQ_343\x7f> <p>nested template</p> </\x7fNAVUNIQ_343\x7f> <\x7fNAVUNIQ_344\x7f> <p>nested template</p> </\x7fNAVUNIQ_344\x7f></div></\x7fNAVUNIQ_342\x7f>",
 				"",
 				"nested templates with block element and one nested template without block elements, everything should be removed"
 			],
 			[
-				"\x7fNAVUNIQ_342\x7f<div>some content \x7fNAVUNIQ_343\x7f <p>nested template</p> \x7fNAVUNIQ_343\x7f \x7fNAVUNIQ_344\x7f nested template \x7fNAVUNIQ_344\x7f</div>\x7fNAVUNIQ_342\x7f",
+				"<\x7fNAVUNIQ_342\x7f><div>some content <\x7fNAVUNIQ_343\x7f> <p>nested template</p> </\x7fNAVUNIQ_343\x7f> <\x7fNAVUNIQ_344\x7f> nested template </\x7fNAVUNIQ_344\x7f></div></\x7fNAVUNIQ_342\x7f>",
 
 				"",
 				"nested templates with block elements, everything should be removed"
 			],
 			[
-				"\x7fNAVUNIQ_342\x7f<a>some content \x7fNAVUNIQ_343\x7f <a>nested template</a> \x7fNAVUNIQ_346\x7f <a>nested nested template</a>\x7fNAVUNIQ_347\x7f <a>nested nested nested template</a>\x7fNAVUNIQ_348\x7f <a>nested nested nested template</a> \x7fNAVUNIQ_348\x7f \x7fNAVUNIQ_347\x7f \x7fNAVUNIQ_346\x7f \x7fNAVUNIQ_343\x7f \x7fNAVUNIQ_344\x7f <a>nested template</a> \x7fNAVUNIQ_344\x7f</a>\x7fNAVUNIQ_342\x7f",
+				"<\x7fNAVUNIQ_342\x7f><a>some content <\x7fNAVUNIQ_343\x7f> <a>nested template</a> <\x7fNAVUNIQ_346\x7f> <a>nested nested template</a><\x7fNAVUNIQ_347\x7f> <a>nested nested nested template</a><\x7fNAVUNIQ_348\x7f> <a>nested nested nested template</a> </\x7fNAVUNIQ_348\x7f> </\x7fNAVUNIQ_347\x7f> </\x7fNAVUNIQ_346\x7f> </\x7fNAVUNIQ_343\x7f> <\x7fNAVUNIQ_344\x7f> <a>nested template</a> </\x7fNAVUNIQ_344\x7f></a></\x7fNAVUNIQ_342\x7f>",
 
 				"<a>some content  <a>nested template</a>  <a>nested nested template</a> <a>nested nested nested template</a> <a>nested nested nested template</a>      <a>nested template</a> </a>",
 				"nested templates without block elements, nothing should be removed if there is no block element"
 			],
 			[
-				"\x7fNAVUNIQ_342\x7f<a>some content \x7fNAVUNIQ_343\x7f <a>nested template</a> \x7fNAVUNIQ_346\x7f <a>nested nested template</a>\x7fNAVUNIQ_347\x7f <p>nested nested nested template</p>\x7fNAVUNIQ_348\x7f <a>nested nested nested template</a> \x7fNAVUNIQ_348\x7f \x7fNAVUNIQ_347\x7f \x7fNAVUNIQ_346\x7f \x7fNAVUNIQ_343\x7f \x7fNAVUNIQ_344\x7f <a>nested template</a> \x7fNAVUNIQ_344\x7f</a>\x7fNAVUNIQ_342\x7f",
+				"<\x7fNAVUNIQ_342\x7f><a>some content <\x7fNAVUNIQ_343\x7f> <a>nested template</a> <\x7fNAVUNIQ_346\x7f> <a>nested nested template</a><\x7fNAVUNIQ_347\x7f> <p>nested nested nested template</p><\x7fNAVUNIQ_348\x7f> <a>nested nested nested template</a> </\x7fNAVUNIQ_348\x7f> </\x7fNAVUNIQ_347\x7f> </\x7fNAVUNIQ_346\x7f> </\x7fNAVUNIQ_343\x7f> <\x7fNAVUNIQ_344\x7f> <a>nested template</a> </\x7fNAVUNIQ_344\x7f></a></\x7fNAVUNIQ_342\x7f>",
 
 				"",
 				"block element within the most inner template, everything should be removed"
 			],
 			[
-				"\x7fNAVUNIQ_342\x7f <a>something</a> \x7fNAVUNIQ_342\x7f\x7fNAVUNIQ_343\x7f<p>something2</p>\x7fNAVUNIQ_343\x7f\x7fNAVUNIQ_342\x7fsomething\x7fNAVUNIQ_342\x7f\x7fNAVUNIQ_343\x7f<div>something2</div>\x7fNAVUNIQ_343\x7f",
+				"<\x7fNAVUNIQ_342\x7f> <a>something</a> </\x7fNAVUNIQ_342\x7f><\x7fNAVUNIQ_343\x7f><p>something2</p></\x7fNAVUNIQ_343\x7f><\x7fNAVUNIQ_342\x7f>something</\x7fNAVUNIQ_342\x7f><\x7fNAVUNIQ_343\x7f><div>something2</div></\x7fNAVUNIQ_343\x7f>",
 				" <a>something</a> something",
 				"multiple invocations of the same template, those with block elements should be removed"
 			]

--- a/includes/wikia/parser/templatetypes/tests/NavigationTemplateTest.php
+++ b/includes/wikia/parser/templatetypes/tests/NavigationTemplateTest.php
@@ -5,11 +5,11 @@ class NavigationTemplateTest extends WikiaBaseTest {
 	/**
 	 * @dataProvider markedTemplateContentProvider
 	 */
-//	public function testMarkNavigationElements( $content, $expected, $message ) {
-//		$marked = NavigationTemplate::handle( $content );
-//
-//		$this->assertEquals( preg_match($markerRegex = "/\x7f".NavigationTemplate::MARK.".+?\x7f/s", $marked), $expected, $message );
-//	}
+	public function testMarkNavigationElements( $content, $expected, $message ) {
+		$marked = NavigationTemplate::handle( $content );
+
+		$this->assertEquals( preg_match($markerRegex = "/\x7f".NavigationTemplate::MARK.".+?\x7f/s", $marked), $expected, $message );
+	}
 
 	public function markedTemplateContentProvider() {
 		return [
@@ -24,12 +24,12 @@ class NavigationTemplateTest extends WikiaBaseTest {
 	 * @param $templateText
 	 * @dataProvider getNavigationTemplates
 	 */
-//	public function testHideNavigationWithBlockElements( $templateText, $expectedOutput, $message ) {
-//		$output = NavigationTemplate::handle( $templateText );
-//		NavigationTemplate::resolve( $output );
-//
-//		$this->assertSame( $expectedOutput, $output, $message );
-//	}
+	public function testHideNavigationWithBlockElements( $templateText, $expectedOutput, $message ) {
+		$output = NavigationTemplate::handle( $templateText );
+		NavigationTemplate::resolve( $output );
+
+		$this->assertSame( $expectedOutput, $output, $message );
+	}
 
 	public function getNavigationTemplates() {
 		return [

--- a/includes/wikia/parser/templatetypes/tests/NavigationTemplateTest.php
+++ b/includes/wikia/parser/templatetypes/tests/NavigationTemplateTest.php
@@ -8,7 +8,7 @@ class NavigationTemplateTest extends WikiaBaseTest {
 	public function testMarkNavigationElements( $content, $expected, $message ) {
 		$marked = NavigationTemplate::handle( $content );
 
-		$this->assertEquals( preg_match($markerRegex = "/\x7f".NavigationTemplate::$mark.".+?\x7f/s", $marked), $expected, $message );
+		$this->assertEquals( preg_match($markerRegex = "/\x7f".NavigationTemplate::MARK.".+?\x7f/s", $marked), $expected, $message );
 	}
 
 	public function markedTemplateContentProvider() {

--- a/includes/wikia/parser/templatetypes/tests/NavigationTemplateTest.php
+++ b/includes/wikia/parser/templatetypes/tests/NavigationTemplateTest.php
@@ -8,7 +8,7 @@ class NavigationTemplateTest extends WikiaBaseTest {
 	public function testMarkNavigationElements( $content, $expected, $message ) {
 		$marked = NavigationTemplate::handle( $content );
 
-		$this->assertEquals( preg_match($markerRegex = "/\x7f".NavigationTemplate::MARK.".+?\x7f/s", $marked), $expected, $message );
+		$this->assertEquals( preg_match($markerRegex = "/<\x7f".NavigationTemplate::MARK.".+?\x7f>/s", $marked), $expected, $message );
 	}
 
 	public function markedTemplateContentProvider() {


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/DAT-4077

handling nested navigation templates, 
hiding on mercury whole structure of nested navigation templates if even single block element is present within this structure.
