### PR TITLE
PLATFORM-2039: set task_runner.php time limit to 60 minutes

### DIFF
--- a/maintenance/wikia/task_runner.php
+++ b/maintenance/wikia/task_runner.php
@@ -1,5 +1,5 @@
 <?php
-set_time_limit( 0 );
+set_time_limit( 3600 ); // PLATFORM-2039
 $wgCommandLineSilentMode = true; // suppress output from Wikia::log calls
 
 require_once( dirname( __FILE__ ) . '/../Maintenance.php' );


### PR DESCRIPTION
[PLATFORM-2039](https://wikia-inc.atlassian.net/browse/PLATFORM-2039)

Sometimes the task processes are running for 30 hours without any activity. Let's set the time limit in `task_runner.php`.

@artursitarski / @wladekb 
