### PR TITLE
WikiaTracer: fix PHP Strict Standards: Only variables should be passed by reference

### DIFF
--- a/lib/Wikia/src/Tracer/WikiaTracer.php
+++ b/lib/Wikia/src/Tracer/WikiaTracer.php
@@ -362,7 +362,8 @@ class WikiaTracer {
 		$caller = str_replace( '{closure}', '', $caller );
 		$caller = trim( $caller, '\\:' );
 
-		return end( explode('\\', $caller ) );
+		$parts = explode('\\', $caller );
+		return end( $parts );
 	}
 
 	/**


### PR DESCRIPTION
[PLATFORM-2119](https://wikia-inc.atlassian.net/browse/PLATFORM-2119)

@wladekb 
