### PR TITLE
RECIRC-96: Be explicit when using `.outerWidth()`

### DIFF
--- a/extensions/wikia/Recirculation/js/views/incontent.js
+++ b/extensions/wikia/Recirculation/js/views/incontent.js
@@ -29,6 +29,10 @@ define('ext.wikia.recirculation.views.incontent', [
 			return element.offsetWidth === width;
 		}).first();
 
+		if (firstSuitableSection.length === 0) {
+			return false;
+		}
+
 		return firstSuitableSection;
 	}
 

--- a/extensions/wikia/Recirculation/js/views/incontent.js
+++ b/extensions/wikia/Recirculation/js/views/incontent.js
@@ -24,7 +24,7 @@ define('ext.wikia.recirculation.views.incontent', [
 		}
 
 		// The idea is to show links above the first section under an infobox
-		width = $container.outerWidth();
+		width = $container.outerWidth(false);
 		firstSuitableSection = sections.filter(function(index, element) {
 			return element.offsetWidth === width;
 		}).first();


### PR DESCRIPTION
the version of jQuery UI that we use on some communities breaks the `.outerWidth()` functionality of jQuery objects when called without a parameter, causing it to return an object instead of the actual width. Adding `false` is a quick fix until we decide to upgrade jQuery UI.

Fixed in version 1.8.22 of jQuery UI:
http://stackoverflow.com/a/13805897
