### PR TITLE
SEO-376 Expose HTML title object through getWikiVariables call

### DIFF
--- a/extensions/wikia/MercuryApi/MercuryApiController.class.php
+++ b/extensions/wikia/MercuryApi/MercuryApiController.class.php
@@ -201,6 +201,12 @@ class MercuryApiController extends WikiaController {
 			$wikiVariables[ 'specialRobotPolicy' ] = $robotPolicy;
 		}
 
+		$htmlTitle = new WikiaHtmlTitle();
+		$wikiVariables[ 'htmlTitle' ] = [
+			'separator' => $htmlTitle->getSeparator(),
+			'parts' => $htmlTitle->getAllParts(),
+		];
+
 		return $wikiVariables;
 	}
 

--- a/includes/wikia/WikiaHtmlTitle.class.php
+++ b/includes/wikia/WikiaHtmlTitle.class.php
@@ -16,9 +16,6 @@ class WikiaHtmlTitle {
 	/** @var array - Configurable parts of the title */
 	private $parts = [];
 
-	/** @var array - Environment like dev-rychu, sandbox-s4, etc */
-	private $environment;
-
 	/** @var Message|null - The site name to include in the title */
 	private $siteName;
 
@@ -26,12 +23,6 @@ class WikiaHtmlTitle {
 	private $brandName;
 
 	public function __construct() {
-		global $wgWikiaEnvironment, $wgEnableHostnameInHtmlTitle;
-
-		if ( $wgWikiaEnvironment !== WIKIA_ENV_PROD && $wgEnableHostnameInHtmlTitle ) {
-			$this->environment = wfHostname();
-		}
-
 		$this->brandName = wfMessage( 'wikia-pagetitle-brand' );
 		$this->siteName = wfMessage( 'wikia-pagetitle-sitename' );
 
@@ -72,7 +63,6 @@ class WikiaHtmlTitle {
 	 */
 	public function getAllParts() {
 		$parts = array_merge(
-			[$this->environment],
 			$this->parts,
 			[$this->siteName, $this->brandName]
 		);


### PR DESCRIPTION
In order for Mercury-based apps (CMP first?) to build the HTML titles
consistent with the other pages on Wikia, we're exporting an object
called `htmlTitle` in `MercuryApiController::getWikiVariables`.

The format of the object is:

```
"htmlTitle": {
    "separator": " - ",
    "parts": ["Xyz Wiki", "Wikia"]
}
```

Mercury-based apps need to read the parts, prepend any additional ones
(required unless it's the main page of the wiki) and then construct the
string by joining with the given separator.

The result HTML titles will be like:
- Kermit the Frog - Muppet Wiki - Wikia
- Quick question - Discussions - Fallout Wiki - Wikia
- Future Films - Wookiepedia - Wikia

Titles structured like that are recommended by SEO team. They serve a
number of purposes:
- Cute titles for search results
- Increase brand awareness (always seeing "Wikia" for our pages)
- Page titles are generally more unique this way
- Page title exhibits the relationship between the specific page, the
  area, the wiki and Wikia, for example "Quick question" is a part of
  "Discussions" which is a part of "Fallout Wiki" which is a part of
  "Wikia"

Also based on the result of the recent engineering survey, the environment part of the HTML title is removed.
