### PR TITLE
VOLDEV-138: Show proper error message for anonymous users if they cannot comment

### DIFF
--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -1629,9 +1629,9 @@ class ArticleComment {
 		if ( $isBlog ) {
 			$props = BlogArticle::getProps( $title->getArticleID() );
 			$commentingEnabled = isset( $props[ 'commenting' ] ) ? (bool) $props[ 'commenting' ] : true;
-			return ( $user->isAllowed( 'commentcreate' ) && $commentingEnabled );
+			return ( $user->isAllowedAll( 'commentcreate', 'edit' ) && $commentingEnabled );
 		} else {
-			return ( $user->isAllowed( 'commentcreate' ) && ArticleCommentInit::ArticleCommentCheckTitle( $title ) );
+			return ( $user->isAllowedAll( 'commentcreate', 'edit' ) && ArticleCommentInit::ArticleCommentCheckTitle( $title ) );
 		}
 	}
 }

--- a/extensions/wikia/ArticleComments/classes/ArticleCommentList.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleCommentList.class.php
@@ -387,8 +387,7 @@ class ArticleCommentList {
 		$wg = F::app()->wg;
 
 		// $isSysop = in_array('sysop', $groups) || in_array('staff', $groups);
-
-		$canEdit = ArticleComment::userCanCommentOn( $this->mTitle );
+		
 		$isBlocked = $wg->User->isBlocked();
 
 		$isReadOnly = wfReadOnly();
@@ -412,7 +411,6 @@ class ArticleCommentList {
 		return [
 			'avatar' => AvatarService::renderAvatar( $wg->User->getName(), 50 ),
 			'userurl' => AvatarService::getUrl( $wg->User->getName() ),
-			'canEdit' => $canEdit,
 			'commentListRaw' => $comments,
 			'commentingAllowed' => ArticleComment::userCanCommentOn( $this->mTitle ),
 			'commentsPerPage' => $this->mMaxPerPage,
@@ -425,7 +423,7 @@ class ArticleCommentList {
 			'pagination' => $pagination,
 			'reason' => $isBlocked ? $this->blockedPage() : '',
 			'stylePath' => $wg->StylePath,
-			'title' => $this->mTitle
+			'title' => $this->mTitle,
 		];
 	} // end getData();
 

--- a/extensions/wikia/ArticleComments/modules/templates/ArticleCommentsController_Content.php
+++ b/extensions/wikia/ArticleComments/modules/templates/ArticleCommentsController_Content.php
@@ -1,9 +1,9 @@
 <ul class="controls">
-	<li id="article-comments-counter-recent"><?= wfMessage( 'oasis-comments-showing-most-recent', count( $commentListRaw ) )->escaped() ?></li>
+	<li id="article-comments-counter-recent"><?= wfMessage( 'oasis-comments-showing-most-recent' )->numParams( count( $commentListRaw ) )->escaped() ?></li>
 </ul>
-<h1 id="article-comments-counter-header"><?= wfMessage( 'oasis-comments-header', $wg->Lang->FormatNum( $countCommentsNested ) )->parse() ?></h1>
+<h1 id="article-comments-counter-header"><?= wfMessage( 'oasis-comments-header' )->numParams( $countCommentsNested )->parse() ?></h1>
 <div id="article-comments" class="article-comments">
-	<? if ( !$isBlocked && $canEdit && $commentingAllowed ): ?>
+	<? if ( !$isBlocked && $commentingAllowed ): ?>
 		<? if ( $isMiniEditorEnabled ): ?>
 			<?= $app->renderView( 'MiniEditorController', 'Setup' ) ?>
 		<? endif ?>
@@ -47,7 +47,9 @@
 		<p><?= wfMessage( 'article-comments-comment-cannot-add' )->escaped() ?></p>
 		<p><?= $reason ?></p>
 	<? elseif ( !$commentingAllowed ): ?>
-		<p class="no-comments-allowed"><?= wfMessage( 'article-comments-comment-cannot-add' )->escaped() ?> </p>
+		<p class="no-comments-allowed">
+			<?= $isAnon ? wfMessage( 'article-comments-login' )->parse() : wfMessage( 'article-comments-comment-cannot-add' )->escaped() ?>
+		</p>
 	<? endif ?>
 	<? if ( $countComments ): ?>
 		<div class="article-comments-pagination upper-pagination"><?= $pagination ?></div>


### PR DESCRIPTION
@garthwebb @kvas-damian 
Per Bert Hall's testing, this change ensures that anonymous users are shown proper error messages if they are not allowed to comment.

The major change introduced is that creating a new comment now requires the generic 'edit' permission, along with 'commentcreate', to ensure expected behavior on wikias with anonymous editing disabled. The user, however, does _not_ have to be able to edit the specific page they are commenting on (on e.g. blog articles, this would not be feasible).
https://wikia-inc.atlassian.net/browse/VOLDEV-138
https://wikia-inc.atlassian.net/browse/SOC-1627
