### PR TITLE
SEO-380 Special:AllPages and Special:Images no longer allowed in robots.txt

### DIFF
--- a/extensions/wikia/RobotsTxt/classes/WikiaRobots.class.php
+++ b/extensions/wikia/RobotsTxt/classes/WikiaRobots.class.php
@@ -150,7 +150,11 @@ class WikiaRobots {
 	 * @param PathBuilder $pathBuilder
 	 */
 	public function __construct( PathBuilder $pathBuilder ) {
-		global $wgRequest, $wgRobotsTxtCustomRules, $wgWikiaEnvironment;
+		global $wgAllowSpecialImagesInRobots,
+			   $wgEnableLocalSitemap,
+			   $wgRequest,
+			   $wgRobotsTxtCustomRules,
+			   $wgWikiaEnvironment;
 
 		$this->pathBuilder = $pathBuilder;
 		$this->accessAllowed = ( $wgWikiaEnvironment === WIKIA_ENV_PROD || $wgRequest->getBool( 'forcerobots' ) );

--- a/extensions/wikia/RobotsTxt/tests/WikiaRobotsTest.php
+++ b/extensions/wikia/RobotsTxt/tests/WikiaRobotsTest.php
@@ -259,4 +259,34 @@ class WikiaRobotsTest extends WikiaBaseTest {
 		$this->assertTrue( $this->isSpecialPageAllowed( $robotsTxtMock, 'MyPage1' ) );
 		$this->assertTrue( $this->isSpecialPageAllowed( $robotsTxtMock, 'MyPage2' ) );
 	}
+
+	public function testLocalSitemapAllowed() {
+		$this->mockGlobalVariable( 'wgWikiaEnvironment', WIKIA_ENV_PROD );
+		$this->mockGlobalVariable( 'wgEnableLocalSitemap', true );
+		$this->mockGlobalVariable( 'wgAllowSpecialImagesInRobots', false );
+
+		$robotsTxtMock = $this->getRobotsTxtMock();
+		$pathBuilderMock = $this->getPathBuilderMock();
+
+		$wikiaRobots = new WikiaRobots( $pathBuilderMock );
+		$wikiaRobots->configureRobotsBuilder( $robotsTxtMock );
+
+		$this->assertTrue( $this->isSpecialPageAllowed( $robotsTxtMock, 'Allpages' ) );
+		$this->assertFalse( $this->isSpecialPageAllowed( $robotsTxtMock, 'Images' ) );
+	}
+
+	public function testSpecialImagesAllowed() {
+		$this->mockGlobalVariable( 'wgWikiaEnvironment', WIKIA_ENV_PROD );
+		$this->mockGlobalVariable( 'wgEnableLocalSitemap', false );
+		$this->mockGlobalVariable( 'wgAllowSpecialImagesInRobots', true );
+
+		$robotsTxtMock = $this->getRobotsTxtMock();
+		$pathBuilderMock = $this->getPathBuilderMock();
+
+		$wikiaRobots = new WikiaRobots( $pathBuilderMock );
+		$wikiaRobots->configureRobotsBuilder( $robotsTxtMock );
+
+		$this->assertFalse( $this->isSpecialPageAllowed( $robotsTxtMock, 'Allpages' ) );
+		$this->assertTrue( $this->isSpecialPageAllowed( $robotsTxtMock, 'Images' ) );
+	}
 }


### PR DESCRIPTION
While working on SEO-351 we broke the robots.txt rules for allowing
Special:AllPages (the local sitemap) and Special:Images.

Fixed them now and added the unit tests around the trigger variables.
