### PR TITLE
SEO-361 More debugging/logging around the <meta name="description" content=" " /> issue

### DIFF
--- a/extensions/wikia/ArticleMetaDescription/ArticleMetaDescription.php
+++ b/extensions/wikia/ArticleMetaDescription/ArticleMetaDescription.php
@@ -69,9 +69,24 @@ function wfArticleMetaDescription( &$out, &$text ) {
 		$article = new Article( $wg->Title );
 		$articleService = new ArticleService( $article );
 		$description = $articleService->getTextSnippet( $DESC_LENGTH );
+		/* extra logging - remove later */
+		if ( $description === ' ' ) {
+			$out->addMeta( 'debug-description', 'SPACE-SNIPPET' );
+		}
+		/* end of extra logging */
 	} else {
 		// MediaWiki:Description message found, use it
 		$description = $sMessage;
+		/* extra logging - remove later */
+		if ( $description === ' ' ) {
+			$out->addMeta( 'debug-description', 'SPACE-MESSAGE' );
+			\Wikia\Logger\WikiaLogger::instance()->warning( 'Meta description containing just a space', [
+				'variant' => 'wfMessage( \'Description\' )->text()',
+				'title' => $wg->Title,
+				'ex' => new Exception(),
+			] );
+		}
+		/* end of extra logging */
 	}
 
 	if ( !empty( $description ) ) {

--- a/includes/OutputPage.php
+++ b/includes/OutputPage.php
@@ -309,16 +309,6 @@ class OutputPage extends ContextSource {
 	 * @param $val String tag value
 	 */
 	function addMeta( $name, $val ) {
-		/** Wikia change begin: SEO-361: Investigate <meta name="description" content=" " /> */
-		if ( $name === 'description' && $val === ' ' ) {
-			array_push( $this->mMetatags, array( 'debug-description', 'SPACE' ) );
-			\Wikia\Logger\WikiaLogger::instance()->warning(
-				'Meta description containing just a space', [
-					'ex' => new Exception(),
-				]
-			);
-		}
-		/** Wikia change end */
 		array_push( $this->mMetatags, array( $name, $val ) );
 	}
 

--- a/includes/wikia/services/ArticleService.class.php
+++ b/includes/wikia/services/ArticleService.class.php
@@ -153,6 +153,18 @@ class ArticleService extends WikiaObject {
 		$length = $this->adjustTextSnippetLength( $text, $length, $breakLimit );
 		$snippet = wfShortenText( $text, $length, $useContentLanguage = true );
 
+		/* extra logging - remove later */
+		if ( $snippet === ' ' ) {
+			\Wikia\Logger\WikiaLogger::instance()->warning( 'Meta description containing just a space', [
+				'variant' => '$articleService->getTextSnippet',
+				'id' => $id,
+				'text' => $text,
+				'length' => $length,
+				'snippet' => $snippet,
+				'ex' => new Exception(),
+			] );
+		}
+		/* end of extra logging */
 		return $snippet;
 	}
 
@@ -171,11 +183,27 @@ class ArticleService extends WikiaObject {
 					$content = '';
 					if ( !$this->wg->DevelEnvironment && !empty( $this->wg->SolrMaster ) ) {
 						$content = $service->getTextFromSolr();
+						/* extra logging - remove later */
+						if ( $content === ' ' ) {
+							\Wikia\Logger\WikiaLogger::instance()->warning( 'Meta description containing just a space', [
+								'variant' => '$articleService->getTextFromSolr',
+								'ex' => new Exception(),
+							] );
+						}
+						/* end of extra logging */
 					}
 
 					if ( $content === '' ) {
 						// back-off is to use mediawiki
 						$content = $service->getUncachedSnippetFromArticle();
+						/* extra logging - remove later */
+						if ( $content === ' ' ) {
+							\Wikia\Logger\WikiaLogger::instance()->warning( 'Meta description containing just a space', [
+								'variant' => '$articleService->getUncachedSnippetFromArticle',
+								'ex' => new Exception(),
+							] );
+						}
+						/* end of extra logging */
 					}
 
 					return $content;


### PR DESCRIPTION
Dashboard with the logs: https://kibana.wikia-inc.com/#/dashboard/elasticsearch/Meta%20description%20containing%20just%20a%20space

We figured where to start debugging the issue, not it's time to go deeper. For each case where description is set to just a space, one of the following warnings should be logged:

```
        \Wikia\Logger\WikiaLogger::instance()->warning( 'Meta description containing just a space', [
            'variant' => 'wfMessage( \'Description\' )->text()',
            'title' => $wg->Title,
            'ex' => new Exception(),
        ] );
```

,

```
        \Wikia\Logger\WikiaLogger::instance()->warning( 'Meta description containing just a space', [
            'variant' => '$articleService->getTextSnippet',
            'id' => $id,
            'text' => $text,
            'length' => $length,
            'snippet' => $snippet,
            'ex' => new Exception(),
        ] );
```

,

```
                        \Wikia\Logger\WikiaLogger::instance()->warning( 'Meta description containing just a space', [
                            'variant' => '$articleService->getTextFromSolr',
                            'ex' => new Exception(),
                        ] );
```

OR

```
                        \Wikia\Logger\WikiaLogger::instance()->warning( 'Meta description containing just a space', [
                            'variant' => '$articleService->getUncachedSnippetFromArticle',
                            'ex' => new Exception(),
                        ] );
```

This will reveal where precisely the problem occurs.

(Note this issue isn't easily reproducible, seems to appear randomly and very rarely, that's why we need to debug it on production).
