### PR TITLE
SOC-2187 Maintenance script to migrate requested-closure-date values to preference service

### DIFF
--- a/extensions/wikia/CloseMyAccount/maintenance/MigrateReqCloseDateToPermService.php
+++ b/extensions/wikia/CloseMyAccount/maintenance/MigrateReqCloseDateToPermService.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Migrate requested-closure-date values from the user_properties table
+ * to the permissions service. Note, this does not delete those values
+ * from the user_properties table, that will be done separately.
+ *
+ * This is a one time script.
+ * See SOC-2187
+ */
+
+require_once __DIR__ . '/../../../../maintenance/Maintenance.php';
+
+class MigrateReqCloseDateToPermService extends Maintenance {
+
+	private $isDryRun = true;
+	private $totalUsersMigrated = 0;
+
+	public function __construct() {
+		parent::__construct();
+		$this->addOption( 'dry-run', "Don't perform any operations [default]" );
+	}
+
+	public function execute() {
+		$this->isDryRun = $this->getOption( 'dry-run', true );
+
+		if ( $this->isDryRun ) {
+			$this->output( "Running in dry-run mode!" );
+		}
+
+		foreach ( $this->getUsersToMigrate() as $user ) {
+			$this->migrateUser( $user );
+		}
+
+		$this->printResults();
+	}
+
+	private function getUsersToMigrate() {
+		global $wgExternalSharedDB;
+		$db = wfGetDB( DB_SLAVE, [], $wgExternalSharedDB );
+		return ( new WikiaSQL() )
+			->SELECT( 'up_user', 'up_value' )
+			->FROM( 'user_properties' )
+			->WHERE( 'up_property' )->EQUAL_TO( 'requested-closure-date' )
+			->runLoop( $db, function( &$result, $row ) {
+				$result[] = [
+					'userId' => $row->up_user,
+					'requestedClosureDate' => $row->up_value
+				];
+			} );
+	}
+
+	private function migrateUser( array $userArray ) {
+		$this->logUserMigration( $userArray );
+		$user = User::newFromId( $userArray['userId'] );
+		$user->setGlobalPreference( 'requested-closure-date', $userArray['requestedClosureDate'] );
+		if ( !$this->isDryRun ) {
+			$user->saveSettings();
+		}
+
+		$this->totalUsersMigrated++;
+	}
+
+	private function logUserMigration( array $userArray ) {
+		$this->output(
+			sprintf( "Migrating user %d with requested-closure-date value %s...",
+				$userArray['userId'],
+				$userArray['requestedClosureDate']
+			)
+		);
+	}
+
+	private function printResults() {
+		$this->output( "Done!" );
+		$this->output( sprintf( "Total users migrated: %d", $this->totalUsersMigrated ) );
+	}
+
+	protected function output( $msg ) {
+		parent::output( $msg . "\n" );
+	}
+}
+
+$maintClass = "MigrateReqCloseDateToPermService";
+require_once( RUN_MAINTENANCE_IF_MAIN );

--- a/extensions/wikia/CloseMyAccount/maintenance/MigrateReqCloseDateToPermService.php
+++ b/extensions/wikia/CloseMyAccount/maintenance/MigrateReqCloseDateToPermService.php
@@ -12,18 +12,18 @@ require_once __DIR__ . '/../../../../maintenance/Maintenance.php';
 
 class MigrateReqCloseDateToPermService extends Maintenance {
 
-	private $isDryRun = true;
+	private $force;
 	private $totalUsersMigrated = 0;
 
 	public function __construct() {
 		parent::__construct();
-		$this->addOption( 'dry-run', "Don't perform any operations [default]" );
+		$this->addOption( 'force', "Actually perform migration, script defaults to test mode" );
 	}
 
 	public function execute() {
-		$this->isDryRun = $this->getOption( 'dry-run', true );
+		$this->force = $this->hasOption( 'force' );
 
-		if ( $this->isDryRun ) {
+		if ( !$this->force ) {
 			$this->output( "Running in dry-run mode!" );
 		}
 
@@ -53,7 +53,7 @@ class MigrateReqCloseDateToPermService extends Maintenance {
 		$this->logUserMigration( $userArray );
 		$user = User::newFromId( $userArray['userId'] );
 		$user->setGlobalPreference( 'requested-closure-date', $userArray['requestedClosureDate'] );
-		if ( !$this->isDryRun ) {
+		if ( $this->force ) {
 			$user->saveSettings();
 		}
 


### PR DESCRIPTION
Ticket: https://wikia-inc.atlassian.net/browse/SOC-2187

This PR creates a maintenance script to migrate all the values for `requested-closure-date` from the user_properties table to the user preference service. Note this doesn't actually delete those values from the `user_properties` table, it just makes sure the values are in both places. The work to clean up and delete those values from the `user_properties` table will be done separately.
