### PR TITLE
CE-3604 Look for cookie truthness instead of value

### DIFF
--- a/extensions/wikia/SpitfiresContributionExperiments/scripts/experiments-tracker.js
+++ b/extensions/wikia/SpitfiresContributionExperiments/scripts/experiments-tracker.js
@@ -45,9 +45,9 @@ define('ext.wikia.spitfires.experiments.tracker', [
 	}
 
 	function getUserStatus() {
-		if (cookies.get('newlyregistered') === 1) {
+		if (cookies.get('newlyregistered')) {
 			return 'newlyregistered';
-		} else if (cookies.get('userwithoutedit') === 1) {
+		} else if (cookies.get('userwithoutedit')) {
 			return 'userwithoutedit';
 		} else {
 			return 'userStatusNaN';


### PR DESCRIPTION
Cookies are stored as strings, I think it's better to check for it's pressence instead.

@Wikia/spitfires 
