### PR TITLE
VideoHandler::getVideoList - set a proper surrogate key

### DIFF
--- a/extensions/wikia/VideoHandlers/VideoHandlerController.class.php
+++ b/extensions/wikia/VideoHandlers/VideoHandlerController.class.php
@@ -411,7 +411,7 @@ class VideoHandlerController extends WikiaController {
 	 */
 	public static function getVideoListSurrogateKey() {
 		global $wgCachePrefix;
-		return implode( '-', [ $wgCachePrefix, __CLASS__, 'getVideoList' ] );
+		return implode( '-', [ $wgCachePrefix ?: wfWikiID(), __CLASS__, 'getVideoList' ] );
 	}
 
 	protected function getVideoListParams() {


### PR DESCRIPTION
[PLATFORM-2063](https://wikia-inc.atlassian.net/browse/PLATFORM-2063)

Use `wfWikiId()` as `$wgCachePrefix` defaults to false on production. This caused the surrogate key to be same across all wikis - instead of purging responses for a single wiki (on video upload), we're purging them for all wikis.

Fixes performance regression caused by #9663 ([SUS-81](https://wikia-inc.atlassian.net/browse/SUS-81))

```
< X-Surrogate-Key: -VideoHandlerController-getVideoList
< Surrogate-Key: -VideoHandlerController-getVideoList
```

``` php
Eval for plpoznan...
> echo wfWikiID()
plpoznan
> echo $wgCachePrefix ?: wfWikiID()
plpoznan
```

@Wikia/sustaining-engineering-team 
