### PR TITLE
WikiaRobotsTest: require classes via autoload entries in setup file

### DIFF
--- a/extensions/wikia/RobotsTxt/RobotsTxt.setup.php
+++ b/extensions/wikia/RobotsTxt/RobotsTxt.setup.php
@@ -4,3 +4,6 @@
 $wgAutoloadClasses['Wikia\RobotsTxt\RobotsTxt'] =  __DIR__ . '/classes/RobotsTxt.class.php';
 $wgAutoloadClasses['Wikia\RobotsTxt\PathBuilder'] =  __DIR__ . '/classes/PathBuilder.class.php';
 $wgAutoloadClasses['Wikia\RobotsTxt\WikiaRobots'] =  __DIR__ . '/classes/WikiaRobots.class.php';
+
+// for unit tests
+$wgAutoloadClasses['RobotsTxtMock'] =  __DIR__ . '/tests/RobotsTxtMock.php';

--- a/extensions/wikia/RobotsTxt/tests/WikiaRobotsTest.php
+++ b/extensions/wikia/RobotsTxt/tests/WikiaRobotsTest.php
@@ -2,8 +2,6 @@
 
 use Wikia\RobotsTxt\WikiaRobots;
 
-require_once( __DIR__ . '/RobotsTxtMock.php' );
-
 class WikiaRobotsTest extends WikiaBaseTest {
 	public function setUp() {
 		global $IP;


### PR DESCRIPTION
Avoid race condition when the `RobotsTxtMock` class is required by the unit test class before the extension's setup file is included.

@gabrys / @harnash 
