### PR TITLE
PLATFORM-2163 - magpierss: use PHP5-style constructors

### DIFF
--- a/extensions/3rdparty/RSS/magpierss/rss_cache.inc
+++ b/extensions/3rdparty/RSS/magpierss/rss_cache.inc
@@ -21,7 +21,7 @@ class RSSCache {
     var $MAX_AGE    = 3600;         // when are files stale, default one hour
     var $ERROR      = "";           // accumulate error messages
     
-    function RSSCache ($base='', $age='') {
+    function __construct($base='', $age='') {
         if ( $base ) {
             $this->BASE_CACHE = $base;
         }
@@ -199,5 +199,3 @@ class RSSCache {
     }
 
 }
-
-?>

--- a/extensions/3rdparty/RSS/magpierss/rss_parse.inc
+++ b/extensions/3rdparty/RSS/magpierss/rss_parse.inc
@@ -91,7 +91,7 @@ class MagpieRSS {
      *                                  source encoding. (caveat emptor)
      *
      */
-    function MagpieRSS ($source, $output_encoding='ISO-8859-1',
+    function __construct($source, $output_encoding='ISO-8859-1',
                         $input_encoding=null, $detect_encoding=true)
     {
         # if PHP xml isn't compiled in, die
@@ -608,5 +608,3 @@ if (!function_exists('array_change_key_case')) {
 	}
 
 }
-
-?>


### PR DESCRIPTION
Did not include `*.inc` files in the initial run of `php7mar` for [PLATFORM-2163](https://wikia-inc.atlassian.net/browse/PLATFORM-2163).

@harnash 
