### PR TITLE
Fix variables interpolation for PHP7

### DIFF
--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -3358,7 +3358,6 @@ class WikiFactory {
 	 * @return string
 	 */
 	static public function renderValueOnCommunity( $name, $type ) {
-		global $$name;
 		global $preWFValues;
 
 		$value = "";
@@ -3366,9 +3365,9 @@ class WikiFactory {
 		if( isset( $preWFValues[$name] ) ) {
 			// was modified, spit out saved default
 			$value = self::parseValue( $preWFValues[$name], $type );
-		} elseif( isset( $$name ) ) {
+		} elseif( isset( $GLOBALS[$name] ) ) {
 			// was not modified, spit out actual value
-			$value = self::parseValue( $$name, $type );
+			$value = self::parseValue( $GLOBALS[$name], $type );
 		}
 		return htmlspecialchars( $value );
 	}

--- a/includes/wikia/nirvana/WikiaDispatcher.class.php
+++ b/includes/wikia/nirvana/WikiaDispatcher.class.php
@@ -52,7 +52,7 @@ class WikiaDispatcher {
 			if ( isset( $route['after'] ) ) $callNext = $route['after'];
 		}
 		// global var routing should probably only be for controllers and methods
-		if (isset( $route['global'] ) && isset( $app->wg->$route['global'] ) ) {
+		if (isset( $route['global'] ) && isset( $app->wg->{$route['global']} ) ) {
 			if ( isset( $route['controller'] ) ) $response->setControllerName( $route['controller'] );
 			if ( isset( $route['method'] ) ) $response->setMethodName( $route['method'] );
 			if ( isset( $route['after'] ) ) $callNext = $route['after'];


### PR DESCRIPTION
[PLATFORM-2156](https://wikia-inc.atlassian.net/browse/PLATFORM-2156)

https://wiki.php.net/rfc/uniform_variable_syntax

``` php
                        // old meaning            // new meaning
$$foo['bar']['baz']     ${$foo['bar']['baz']}     ($$foo)['bar']['baz']
$foo->$bar['baz']       $foo->{$bar['baz']}       ($foo->$bar)['baz']
$foo->$bar['baz']()     $foo->{$bar['baz']}()     ($foo->$bar)['baz']()
Foo::$bar['baz']()      Foo::{$bar['baz']}()      (Foo::$bar)['baz']()


global $$foo->bar;
// instead use:
global ${$foo->bar};
```

@harnash 
