### PR TITLE
SEO-311 Paginator refactor: Second batch of changes

### DIFF
--- a/extensions/wikia/Blogs/templates/blog-pager-ajax.tmpl.php
+++ b/extensions/wikia/Blogs/templates/blog-pager-ajax.tmpl.php
@@ -3,7 +3,7 @@
 if ($iPageCount > 1) {
 ?>
 <?
-	$pages = Paginator::newFromArray( $iTotal, $iCount, 50 );
+	$pages = Paginator::newFromCount( $iTotal, $iCount, 50 );
 	$pages->setActivePage( $iPage + 1 );
 	echo $pages->getBarHTML( '', 'BlogPaginator' );
 ?>

--- a/extensions/wikia/Blogs/templates/blog-pager-ajax.tmpl.php
+++ b/extensions/wikia/Blogs/templates/blog-pager-ajax.tmpl.php
@@ -4,7 +4,7 @@ if ($iPageCount > 1) {
 ?>
 <?
 	$pages = Paginator::newFromArray( $iTotal, $iCount, 50 );
-	$pages->setActivePage($iPage);
+	$pages->setActivePage( $iPage + 1 );
 	echo $pages->getBarHTML( '', 'BlogPaginator' );
 ?>
 <script type="text/javascript" src="<?=$wgExtensionsPath?>/wikia/Blogs/js/BlogsPager.js"></script>

--- a/extensions/wikia/Blogs/templates/blog-pager-ajax.tmpl.php
+++ b/extensions/wikia/Blogs/templates/blog-pager-ajax.tmpl.php
@@ -3,7 +3,7 @@
 if ($iPageCount > 1) {
 ?>
 <?
-	$pages = Paginator::newFromCount( $iTotal, $iCount, 50 );
+	$pages = Paginator::newFromCount( $iTotal, min( $iCount, 50 ) );
 	$pages->setActivePage( $iPage + 1 );
 	echo $pages->getBarHTML( '', 'BlogPaginator' );
 ?>

--- a/extensions/wikia/CategoryExhibition/CategoryExhibitionSection.class.php
+++ b/extensions/wikia/CategoryExhibition/CategoryExhibitionSection.class.php
@@ -223,10 +223,10 @@ class CategoryExhibitionSection {
 		$oTmpl = new EasyTemplate( dirname( __FILE__ ) . "/templates/" );
 		if( empty( $cachedContent ) ){
 			$aTmpData = $this->fetchSectionItems( $namespace, $negative );
-			$pages = Paginator::newFromArray( $aTmpData, $itemsPerPage );
+			$pages = Paginator::newFromCount( count( $aTmpData ), $itemsPerPage );
 			if ( is_array( $aTmpData ) && count( $aTmpData ) > 0 ){
 				$pages->setActivePage( $this->paginatorPosition );
-				$aTmpData = $pages->getCurrentPage();
+				$aTmpData = $pages->getCurrentPage( $aTmpData );
 				$aData = $this->getArticles( $aTmpData );
 				$oTmpl->set_vars(
 					array (

--- a/extensions/wikia/CategoryExhibition/CategoryExhibitionSection.class.php
+++ b/extensions/wikia/CategoryExhibition/CategoryExhibitionSection.class.php
@@ -225,7 +225,7 @@ class CategoryExhibitionSection {
 			$aTmpData = $this->fetchSectionItems( $namespace, $negative );
 			$pages = Paginator::newFromArray( $aTmpData, $itemsPerPage );
 			if ( is_array( $aTmpData ) && count( $aTmpData ) > 0 ){
-				$pages->setActivePage( $this->paginatorPosition - 1 );
+				$pages->setActivePage( $this->paginatorPosition );
 				$aTmpData = $pages->getCurrentPage();
 				$aData = $this->getArticles( $aTmpData );
 				$oTmpl->set_vars(

--- a/extensions/wikia/CategoryExhibition/CategoryExhibitionSection.class.php
+++ b/extensions/wikia/CategoryExhibition/CategoryExhibitionSection.class.php
@@ -225,7 +225,8 @@ class CategoryExhibitionSection {
 			$aTmpData = $this->fetchSectionItems( $namespace, $negative );
 			$pages = Paginator::newFromArray( $aTmpData, $itemsPerPage );
 			if ( is_array( $aTmpData ) && count( $aTmpData ) > 0 ){
-				$aTmpData = $pages->getPage( $this->paginatorPosition, true );
+				$pages->setActivePage( $this->paginatorPosition - 1 );
+				$aTmpData = $pages->getCurrentPage();
 				$aData = $this->getArticles( $aTmpData );
 				$oTmpl->set_vars(
 					array (

--- a/extensions/wikia/CategoryExhibition/CategoryExhibitionSectionMedia.class.php
+++ b/extensions/wikia/CategoryExhibition/CategoryExhibitionSectionMedia.class.php
@@ -18,7 +18,7 @@ class CategoryExhibitionSectionMedia extends CategoryExhibitionSection {
 			$aTmpData = $this->fetchSectionItems( array( NS_FILE ) ); // we wan't old videos
 			if ( is_array( $aTmpData ) && count( $aTmpData ) > 0 ){
 				$pages = Paginator::newFromArray( $aTmpData, $wgCategoryExhibitionMediaSectionRows * 4 );
-				$pages->setActivePage( $this->paginatorPosition - 1 );
+				$pages->setActivePage( $this->paginatorPosition );
 				$pageData = $pages->getCurrentPage();
 				$aData = array();
 				foreach( $pageData as $item ){

--- a/extensions/wikia/CategoryExhibition/CategoryExhibitionSectionMedia.class.php
+++ b/extensions/wikia/CategoryExhibition/CategoryExhibitionSectionMedia.class.php
@@ -17,9 +17,9 @@ class CategoryExhibitionSectionMedia extends CategoryExhibitionSection {
 			// grabs data for videos and images
 			$aTmpData = $this->fetchSectionItems( array( NS_FILE ) ); // we wan't old videos
 			if ( is_array( $aTmpData ) && count( $aTmpData ) > 0 ){
-				$pages = Paginator::newFromArray( $aTmpData, $wgCategoryExhibitionMediaSectionRows * 4 );
+				$pages = Paginator::newFromCount( count( $aTmpData ), $wgCategoryExhibitionMediaSectionRows * 4 );
 				$pages->setActivePage( $this->paginatorPosition );
-				$pageData = $pages->getCurrentPage();
+				$pageData = $pages->getCurrentPage( $aTmpData );
 				$aData = array();
 				foreach( $pageData as $item ){
 					$itemTitle = Title::newFromID($item['page_id']);

--- a/extensions/wikia/CategoryExhibition/CategoryExhibitionSectionMedia.class.php
+++ b/extensions/wikia/CategoryExhibition/CategoryExhibitionSectionMedia.class.php
@@ -18,7 +18,8 @@ class CategoryExhibitionSectionMedia extends CategoryExhibitionSection {
 			$aTmpData = $this->fetchSectionItems( array( NS_FILE ) ); // we wan't old videos
 			if ( is_array( $aTmpData ) && count( $aTmpData ) > 0 ){
 				$pages = Paginator::newFromArray( $aTmpData, $wgCategoryExhibitionMediaSectionRows * 4 );
-				$pageData = $pages->getPage( $this->paginatorPosition, true);
+				$pages->setActivePage( $this->paginatorPosition - 1 );
+				$pageData = $pages->getCurrentPage();
 				$aData = array();
 				foreach( $pageData as $item ){
 					$itemTitle = Title::newFromID($item['page_id']);

--- a/extensions/wikia/Crunchyroll/CrunchyrollVideo.class.php
+++ b/extensions/wikia/Crunchyroll/CrunchyrollVideo.class.php
@@ -125,7 +125,7 @@ class CrunchyrollVideo {
 			$toolbar = $cachedData['toolbar'];
 		} else {
 			$crunchyrollRSS = $this->getPaginatedRSSData();
-			$crunchyrollRSS->setActivePage( $this->currentPage - 1 );
+			$crunchyrollRSS->setActivePage( $this->currentPage );
 			$aTmpData = $crunchyrollRSS->getCurrentPage();
 			$toolbar = $this->getBarHTML();
 			$this->saveToCache(

--- a/extensions/wikia/Crunchyroll/CrunchyrollVideo.class.php
+++ b/extensions/wikia/Crunchyroll/CrunchyrollVideo.class.php
@@ -125,7 +125,8 @@ class CrunchyrollVideo {
 			$toolbar = $cachedData['toolbar'];
 		} else {
 			$crunchyrollRSS = $this->getPaginatedRSSData();
-			$aTmpData = $crunchyrollRSS->getPage( $this->currentPage, true);
+			$crunchyrollRSS->setActivePage( $this->currentPage - 1 );
+			$aTmpData = $crunchyrollRSS->getCurrentPage();
 			$toolbar = $this->getBarHTML();
 			$this->saveToCache(
 				array(

--- a/extensions/wikia/InsightsV2/helpers/InsightsPaginator.php
+++ b/extensions/wikia/InsightsV2/helpers/InsightsPaginator.php
@@ -61,7 +61,7 @@ class InsightsPaginator {
 		$params = array_merge( $this->getParams(), [ 'page' => '%s' ] );
 		$url = urldecode( InsightsHelper::getSubpageLocalUrl( $this->subpage, $params ) );
 
-		$paginator = Paginator::newFromArray( $this->getTotal(), $this->getLimit(), $this->getLimit() );
+		$paginator = Paginator::newFromCount( $this->getTotal(), $this->getLimit(), $this->getLimit() );
 		$paginator->setActivePage( $this->getPage() + 1 );
 		$paginatorBar = $paginator->getBarHTML( $url );
 

--- a/extensions/wikia/InsightsV2/helpers/InsightsPaginator.php
+++ b/extensions/wikia/InsightsV2/helpers/InsightsPaginator.php
@@ -62,7 +62,7 @@ class InsightsPaginator {
 		$url = urldecode( InsightsHelper::getSubpageLocalUrl( $this->subpage, $params ) );
 
 		$paginator = Paginator::newFromArray( $this->getTotal(), $this->getLimit(), $this->getLimit() );
-		$paginator->setActivePage( $this->getPage() );
+		$paginator->setActivePage( $this->getPage() + 1 );
 		$paginatorBar = $paginator->getBarHTML( $url );
 
 		return $paginatorBar;

--- a/extensions/wikia/InsightsV2/helpers/InsightsPaginator.php
+++ b/extensions/wikia/InsightsV2/helpers/InsightsPaginator.php
@@ -61,7 +61,7 @@ class InsightsPaginator {
 		$params = array_merge( $this->getParams(), [ 'page' => '%s' ] );
 		$url = urldecode( InsightsHelper::getSubpageLocalUrl( $this->subpage, $params ) );
 
-		$paginator = Paginator::newFromCount( $this->getTotal(), $this->getLimit(), $this->getLimit() );
+		$paginator = Paginator::newFromCount( $this->getTotal(), $this->getLimit() );
 		$paginator->setActivePage( $this->getPage() + 1 );
 		$paginatorBar = $paginator->getBarHTML( $url );
 

--- a/extensions/wikia/Paginator/Paginator.body.php
+++ b/extensions/wikia/Paginator/Paginator.body.php
@@ -124,8 +124,6 @@ class Paginator {
 	 * @return array as described above
 	 */
 	private function getBarData() {
-		// NOTE: For $this->pagesCount <= 1 will return [ 1, 1 ]
-
 		// Compute whether there's the ellipsis to the left/right of the current page
 		$leftEllipsis = ( $this->activePage > self::DISPLAYED_NEIGHBOURS + 2 );
 		$rightEllipsis = ( $this->activePage < $this->pagesCount - self::DISPLAYED_NEIGHBOURS - 1 );

--- a/extensions/wikia/Paginator/Paginator.body.php
+++ b/extensions/wikia/Paginator/Paginator.body.php
@@ -23,8 +23,8 @@ class Paginator {
 	const DISPLAYED_NEIGHBOURS = 3;
 
 	// State
-	private $itemsPerPage = 8;
-	private $pagesCount = 0;
+	private $itemsPerPage;
+	private $pagesCount;
 	private $activePage = 1;
 
 	// Deprecated state
@@ -89,31 +89,42 @@ class Paginator {
 	 * @return array
 	 */
 	public function getCurrentPage( array $data = null ) {
-		$index = $this->activePage - 1;
-
 		// deprecated case:
 		if ( is_null( $data ) ) {
 			$data = $this->data;
 		}
 
-		if ( count( $data ) > 0 ) {
-			$paginatedData = array_chunk( $data, $this->itemsPerPage );
-		} else {
-			$paginatedData = $data;
-		}
+		$paginatedData = array_chunk( $data, $this->itemsPerPage );
 
-		if ( !isset( $paginatedData[$index] ) ) {
-			return [];
+		$index = $this->activePage - 1;
+		if ( isset( $paginatedData[$index] ) ) {
+			return $paginatedData[$index];
 		}
-
-		return $paginatedData[$index];
+		return [];
 	}
 
+	/**
+	 * Get data needed to generate the paginator bar: an array specifying pages to link.
+	 *
+	 * Example:
+	 *
+	 * For page 1 of 1000, return: [1, 2, 3, 4, '', 1000]
+	 * For page 100 of 1000, return [1, '', 97, 98, 99, 100, 101, 102, 103, '', 1000]
+	 * For page 1000 of 1000, return [1, '', 997, 998, 999, 1000]
+	 *
+	 * Empty string represents the ellipsis, the first item is always 1, the last one is always
+	 * the total number of pages.
+	 *
+	 * The current page is always included and up to self::DISPLAYED_NEIGHBOURS items are returned
+	 * to the left and to the right of the current page.
+	 *
+	 * This method doesn't work very well for activePage 0 or 1, returns [1, 0] and [1, 1]
+	 * respectively.
+	 *
+	 * @return array as described above
+	 */
 	private function getBarData() {
-		if ( $this->pagesCount <= 1 ) {
-			// Just one page
-			return [ 1 ];
-		}
+		// NOTE: For $this->pagesCount <= 1 will return [ 1, 1 ]
 
 		// Compute whether there's the ellipsis to the left/right of the current page
 		$leftEllipsis = ( $this->activePage > self::DISPLAYED_NEIGHBOURS + 2 );

--- a/extensions/wikia/Paginator/Paginator.body.php
+++ b/extensions/wikia/Paginator/Paginator.body.php
@@ -106,6 +106,8 @@ class Paginator {
 	 * @param int $pageNumber
 	 */
 	public function setActivePage( $pageNumber ) {
+		$pageNumber = min( $pageNumber, $this->getPagesCount() - 1 );
+		$pageNumber = max( 0, $pageNumber );
 		$this->activePage = $pageNumber;
 	}
 

--- a/extensions/wikia/Paginator/Paginator.body.php
+++ b/extensions/wikia/Paginator/Paginator.body.php
@@ -110,27 +110,33 @@ class Paginator {
 	}
 
 	private function getBarData() {
-		$data = [];
+		if ( $this->pagesCount <= 1 ) {
+			// Just one page
+			return [ 1 ];
+		}
 
+		// Compute whether there's the ellipsis to the left/right of the current page
 		$leftEllipsis = ( $this->activePage > self::DISPLAYED_NEIGHBOURS + 2 );
 		$rightEllipsis = ( $this->activePage < $this->pagesCount - self::DISPLAYED_NEIGHBOURS - 1 );
+
+		// Compute the range of pages between the left and right ellipsis
+		// Or between the first and last page
 		$leftRangeStart = max( $this->activePage - self::DISPLAYED_NEIGHBOURS, 2 );
 		$rightRangeStart = min( $this->activePage + self::DISPLAYED_NEIGHBOURS, $this->pagesCount - 1 );
 
-		$data[] = 1;
+		$data = [ 1 ];
 
-		if ( $this->pagesCount > 1 ) {
-			if ( $leftEllipsis ) {
-				$data[] = '';
-			}
-			for ( $i = $leftRangeStart; $i <= $rightRangeStart; $i++ ) {
-				$data[] = $i;
-			}
-			if ( $rightEllipsis ) {
-				$data[] = '';
-			}
-			$data[] = $this->pagesCount;
+		if ( $leftEllipsis ) {
+			$data[] = '';
 		}
+		for ( $i = $leftRangeStart; $i <= $rightRangeStart; $i++ ) {
+			$data[] = $i;
+		}
+		if ( $rightEllipsis ) {
+			$data[] = '';
+		}
+
+		$data[] = $this->pagesCount;
 
 		return [
 			'pages' => $data,

--- a/extensions/wikia/Paginator/Paginator.body.php
+++ b/extensions/wikia/Paginator/Paginator.body.php
@@ -13,7 +13,6 @@
  *  * On the second page of paginated content rel="prev" link should point to the page without ?page=1
  *  * On any page other than the first page there should be no canonical (link rel="prev/next" is enough)
  *  * Avoid passing the same URL to getHeadItem and getBarHTML (pass to constructor instead?)
- *  * Convert the other code to use the constructor instead of newFromArray
  *  * Support for indefinite pagination? 1 ... 47 48 49 _50_ 51 52 53 ...
  */
 class Paginator {
@@ -36,18 +35,29 @@ class Paginator {
 	/**
 	 * Creates a new Pagination object.
 	 *
-	 * @param   array|integer $aData
+	 * @param int $aData
 	 * @param int $iItemsPerPage
 	 * @param int $maxItemsPerPage
 	 * @return Paginator
 	 */
-	public static function newFromArray( $aData, $iItemsPerPage = 8, $maxItemsPerPage = 48 ) {
+	public static function newFromCount( $aData, $iItemsPerPage = 8, $maxItemsPerPage = 48 ) {
 		$aConfig = [
 			'itemsPerPage' => $iItemsPerPage,
 			'maxItemsPerPage' => $maxItemsPerPage,
 		];
 
 		return new Paginator( $aData, $aConfig );
+	}
+
+	/**
+	 * @deprecated use newFromCount
+	 * @param array $aData
+	 * @param int $iItemsPerPage
+	 * @param int $maxItemsPerPage
+	 * @return Paginator
+	 */
+	public static function newFromArray( array $aData, $iItemsPerPage = 8, $maxItemsPerPage = 48 ) {
+		return self::newFromCount( $aData, $iItemsPerPage, $maxItemsPerPage );
 	}
 
 	/**
@@ -106,7 +116,26 @@ class Paginator {
 		$this->activePage = $pageNumber - 1;
 	}
 
-	public function getCurrentPage() {
+	/**
+	 * Get the current page of the passed data
+	 *
+	 * @param array|null $aData data to be paginated (if null, the data passed from newFromArray is used)
+	 * @return array
+	 */
+	public function getCurrentPage( $aData = null ) {
+		if ( is_array( $aData ) ) {
+			if ( count( $aData ) > 0 ) {
+				$aPaginatedData = array_chunk( $aData, $this->config['itemsPerPage'] );
+			} else {
+				$aPaginatedData = $aData;
+			}
+			$iPagesCount = count( $aPaginatedData );
+
+			if ( $this->activePage < $iPagesCount ) {
+				return $aPaginatedData[$this->activePage];
+			}
+			return [];
+		}
 		return $this->paginatedData[$this->activePage];
 	}
 

--- a/extensions/wikia/Paginator/Paginator.body.php
+++ b/extensions/wikia/Paginator/Paginator.body.php
@@ -14,7 +14,6 @@
  *  * On any page other than the first page there should be no canonical (link rel="prev/next" is enough)
  *  * Avoid passing the same URL to getHeadItem and getBarHTML (pass to constructor instead?)
  *  * Convert the other code to use the constructor instead of newFromArray
- *  * Convert the other code to use $total instead of array_fill( 0, $total, '' )
  *  * Support for indefinite pagination? 1 ... 47 48 49 _50_ 51 52 53 ...
  */
 class Paginator {

--- a/extensions/wikia/Paginator/Paginator.body.php
+++ b/extensions/wikia/Paginator/Paginator.body.php
@@ -64,7 +64,7 @@ class Paginator {
 		}
 
 		if ( !is_int( $dataCount ) ) {
-			throw new InvalidArgumentException( 'Paginator: need an int or array for $data' );
+			throw new InvalidArgumentException( 'Paginator: need an int for $data' );
 		}
 
 		$this->itemsPerPage = max( $itemsPerPage, self::MIN_ITEMS_PER_PAGE );

--- a/extensions/wikia/Paginator/Paginator.body.php
+++ b/extensions/wikia/Paginator/Paginator.body.php
@@ -11,8 +11,6 @@
  *
  * TODO:
  *  * setActivePage should NOT be 0-indexed
- *  * setActivePage should check for page number outside the correct range and correct it
- *  * convert uses of getPage(int, true) to setActivePage(int), getCurrentPage()
  *  * On the second page of paginated content rel="prev" link should point to the page without ?page=1
  *  * On any page other than the first page there should be no canonical (link rel="prev/next" is enough)
  *  * Avoid passing the same URL to getHeadItem and getBarHTML (pass to constructor instead?)
@@ -111,24 +109,23 @@ class Paginator {
 		$this->activePage = $pageNumber;
 	}
 
+	public function getCurrentPage() {
+		return $this->paginatedData[$this->activePage];
+	}
+
+	/**
+	 * @deprecated use setActivePage followed by getCurrentPage
+	 * @param $iPageNumber
+	 * @param bool $bSetToActive
+	 * @return bool|mixed
+	 * @throws InvalidArgumentException
+	 */
 	public function getPage( $iPageNumber, $bSetToActive = false ) {
-		$iPageNumber = (int) $iPageNumber;
-		$iPageNumber--;
-		if ( $iPageNumber < $this->pagesCount && $iPageNumber >= 0 ) {
-			if ( !empty( $bSetToActive ) ) {
-				$this->setActivePage( $iPageNumber );
-			}
-			return $this->paginatedData[$iPageNumber];
-		} elseif ( $iPageNumber < 0 ) {
-			if ( isset( $this->paginatedData[0] ) ) {
-				return $this->paginatedData[0];
-			} else {
-				return false;
-			}
-		} else {
-			$this->setActivePage( $this->pagesCount - 1 );
-			return $this->paginatedData[$this->pagesCount - 1];
+		if ( !$bSetToActive ) {
+			throw InvalidArgumentException( '$bSetActiveToActive = true not supported' );
 		}
+		$this->setActivePage( $iPageNumber - 1 );
+		return $this->getCurrentPage();
 	}
 
 	private function getBarData() {

--- a/extensions/wikia/Paginator/Paginator.body.php
+++ b/extensions/wikia/Paginator/Paginator.body.php
@@ -10,7 +10,6 @@
  * Object that allows auto pagination of array content
  *
  * TODO:
- *  * setActivePage should NOT be 0-indexed
  *  * On the second page of paginated content rel="prev" link should point to the page without ?page=1
  *  * On any page other than the first page there should be no canonical (link rel="prev/next" is enough)
  *  * Avoid passing the same URL to getHeadItem and getBarHTML (pass to constructor instead?)
@@ -98,34 +97,18 @@ class Paginator {
 	}
 
 	/**
-	 * Set the currently active page. This is 0-indexed, so you may need to
-	 * set the value to $this->getRequest()->getInt( 'page' ) - 1
+	 * Set the currently active page
 	 *
 	 * @param int $pageNumber
 	 */
 	public function setActivePage( $pageNumber ) {
-		$pageNumber = min( $pageNumber, $this->getPagesCount() - 1 );
-		$pageNumber = max( 0, $pageNumber );
-		$this->activePage = $pageNumber;
+		$pageNumber = min( $pageNumber, $this->getPagesCount() );
+		$pageNumber = max( 1, $pageNumber );
+		$this->activePage = $pageNumber - 1;
 	}
 
 	public function getCurrentPage() {
 		return $this->paginatedData[$this->activePage];
-	}
-
-	/**
-	 * @deprecated use setActivePage followed by getCurrentPage
-	 * @param $iPageNumber
-	 * @param bool $bSetToActive
-	 * @return bool|mixed
-	 * @throws InvalidArgumentException
-	 */
-	public function getPage( $iPageNumber, $bSetToActive = false ) {
-		if ( !$bSetToActive ) {
-			throw InvalidArgumentException( '$bSetActiveToActive = true not supported' );
-		}
-		$this->setActivePage( $iPageNumber - 1 );
-		return $this->getCurrentPage();
 	}
 
 	private function getBarData() {

--- a/extensions/wikia/Paginator/tests/PaginatorTest.php
+++ b/extensions/wikia/Paginator/tests/PaginatorTest.php
@@ -354,31 +354,6 @@ class PaginatorTest extends WikiaBaseTest {
 	}
 
 	/**
-	 * Test passing maxItemsPerPage param through newFromCount
-	 *
-	 * The same as above, just passing additional param $maxItemsPerPage, simulated here by
-	 * passing a big number for $itemsPerPage and then the one from data provider as $maxItemsPerPage
-	 *
-	 * This style of calling the class is used by:
-	 *
-	 *  * InsightsPaginator
-	 *  * blog-pager-ajax.tmpl
-	 *
-	 * @dataProvider dataProviderPaginator
-	 */
-	public function testMaxItemsPerPage( $itemsPerPage, $allDataString, $pageNo, $pageDataString, $expectedHtml ) {
-		$url = 'http://url/?page=%s';
-		$allData = explode( ',', $allDataString );
-		$expectedPageData = explode( ',', $pageDataString );
-		$pages = Paginator::newFromCount( count( $allData ), 1000, $itemsPerPage );
-		$pages->setActivePage( $pageNo );
-		$onePageData = $pages->getCurrentPage( $allData );
-		$html = $pages->getBarHTML( $url );
-		$this->assertEquals( $expectedPageData, $onePageData );
-		$this->assertHtmlEquals( $expectedHtml, $html );
-	}
-
-	/**
 	 * Test getHeadItem method
 	 *
 	 * Called by:

--- a/extensions/wikia/Paginator/tests/PaginatorTest.php
+++ b/extensions/wikia/Paginator/tests/PaginatorTest.php
@@ -308,7 +308,7 @@ class PaginatorTest extends WikiaBaseTest {
 	}
 
 	/**
-	 * Test the basic API of the class, style #1 of using it
+	 * Test the basic API of the class, style #1 of using it -- deprecated version
 	 *
 	 * Create an object of Paginator using Paginator::newFromArray and then set an active page
 	 * number and get the current slice of the input array using Paginator::getPage and then
@@ -328,6 +328,33 @@ class PaginatorTest extends WikiaBaseTest {
 		$expectedPageData = explode( ',', $pageDataString );
 		$pages = Paginator::newFromArray( $allData, $itemsPerPage );
 		$onePageData = $pages->getPage( $pageNo, true );
+		$html = $pages->getBarHTML( $url );
+		$this->assertEquals( $expectedPageData, $onePageData );
+		$this->assertHtmlEquals( $expectedHtml, $html );
+	}
+
+	/**
+	 * Test the basic API of the class, style #1 of using it -- updated version
+	 *
+	 * Create an object of Paginator using Paginator::newFromArray and then set an active page
+	 * number through setActivePage and get the current slice of the input array using
+	 * getCurrentPage and then generate the HTML for the pagination bar by Paginator::getBarHTML
+	 *
+	 * This style of calling the class is used by:
+	 *
+	 *  * CategoryExhibitionSection
+	 *  * CategoryExhibitionSectionMedia
+	 *  * CrunchyrollVideo
+	 *
+	 * @dataProvider dataProviderCallStyle1
+	 */
+	public function testCallStyle1Updated( $itemsPerPage, $allDataString, $pageNo, $pageDataString, $expectedHtml ) {
+		$url = 'http://url/?page=%s';
+		$allData = explode( ',', $allDataString );
+		$expectedPageData = explode( ',', $pageDataString );
+		$pages = Paginator::newFromArray( $allData, $itemsPerPage );
+		$pages->setActivePage( $pageNo - 1 );
+		$onePageData = $pages->getCurrentPage();
 		$html = $pages->getBarHTML( $url );
 		$this->assertEquals( $expectedPageData, $onePageData );
 		$this->assertHtmlEquals( $expectedHtml, $html );

--- a/extensions/wikia/Paginator/tests/PaginatorTest.php
+++ b/extensions/wikia/Paginator/tests/PaginatorTest.php
@@ -308,7 +308,7 @@ class PaginatorTest extends WikiaBaseTest {
 	}
 
 	/**
-	 * Test the basic API of the class, style #1 of using it -- updated version
+	 * Test the basic API of the class, style #1 of using it -- old version
 	 *
 	 * Create an object of Paginator using Paginator::newFromArray and then set an active page
 	 * number through setActivePage and get the current slice of the input array using
@@ -316,13 +316,11 @@ class PaginatorTest extends WikiaBaseTest {
 	 *
 	 * This style of calling the class is used by:
 	 *
-	 *  * CategoryExhibitionSection
-	 *  * CategoryExhibitionSectionMedia
 	 *  * CrunchyrollVideo
 	 *
 	 * @dataProvider dataProviderCallStyle1
 	 */
-	public function testCallStyle1Updated( $itemsPerPage, $allDataString, $pageNo, $pageDataString, $expectedHtml ) {
+	public function testCallStyle1( $itemsPerPage, $allDataString, $pageNo, $pageDataString, $expectedHtml ) {
 		$url = 'http://url/?page=%s';
 		$allData = explode( ',', $allDataString );
 		$expectedPageData = explode( ',', $pageDataString );
@@ -335,9 +333,36 @@ class PaginatorTest extends WikiaBaseTest {
 	}
 
 	/**
+	 * Test the basic API of the class, style #1 of using it - passing data length to newFromCount
+	 * and passing data to getCurrentPage
+	 *
+	 * Create an object of Paginator using Paginator::newFromCount and then set an active page
+	 * number through setActivePage and get the current slice of the input array using
+	 * getCurrentPage and then generate the HTML for the pagination bar by Paginator::getBarHTML
+	 *
+	 * This style of calling the class is used by:
+	 *
+	 *  * CategoryExhibitionSection
+	 *  * CategoryExhibitionSectionMedia
+	 *
+	 * @dataProvider dataProviderCallStyle1
+	 */
+	public function testCallStyle1Updated( $itemsPerPage, $allDataString, $pageNo, $pageDataString, $expectedHtml ) {
+		$url = 'http://url/?page=%s';
+		$allData = explode( ',', $allDataString );
+		$expectedPageData = explode( ',', $pageDataString );
+		$pages = Paginator::newFromCount( count( $allData ), $itemsPerPage );
+		$pages->setActivePage( $pageNo );
+		$onePageData = $pages->getCurrentPage( $allData );
+		$html = $pages->getBarHTML( $url );
+		$this->assertEquals( $expectedPageData, $onePageData );
+		$this->assertHtmlEquals( $expectedHtml, $html );
+	}
+
+	/**
 	 * Test the basic API of the class, style #2 of using it
 	 *
-	 * Create an object of Paginator using Paginator::newFromArray passing array
+	 * Create an object of Paginator using Paginator::newFromCount passing array
 	 * constructed by array_fill( 0, $count, '' ) and then set an active page number
 	 * using Paginator::setActivePage and then generate the HTML for the pagination
 	 * bar by Paginator::getBarHTML + generate the head item with rel="prev/next" links
@@ -356,7 +381,7 @@ class PaginatorTest extends WikiaBaseTest {
 		$url = 'http://url/?page=%s';
 		$count = count( explode( ',', $allDataString ) );
 		$allData = array_fill( 0, $count, '' );
-		$pages = Paginator::newFromArray( $allData, $itemsPerPage );
+		$pages = Paginator::newFromCount( $allData, $itemsPerPage );
 		$pages->setActivePage( $pageNo );
 		$html = $pages->getBarHTML( $url );
 		$this->assertHtmlEquals( $expectedHtml, $html );
@@ -379,7 +404,7 @@ class PaginatorTest extends WikiaBaseTest {
 		$url = 'http://url/?page=%s';
 		$count = count( explode( ',', $allDataString ) );
 		$allData = array_fill( 0, $count, '' );
-		$pages = Paginator::newFromArray( $allData, 1000, $itemsPerPage );
+		$pages = Paginator::newFromCount( $allData, 1000, $itemsPerPage );
 		$pages->setActivePage( $pageNo );
 		$html = $pages->getBarHTML( $url );
 		$this->assertHtmlEquals( $expectedHtml, $html );
@@ -388,7 +413,7 @@ class PaginatorTest extends WikiaBaseTest {
 	/**
 	 * Test the basic API of the class, style #3 of using it
 	 *
-	 * Create an object of Paginator using Paginator::newFromArray passing number of elements to
+	 * Create an object of Paginator using Paginator::newFromCount passing number of elements to
 	 * paginate through constructed by array_fill( 0, $count, '' ) and then set an active page
 	 * number using Paginator::setActivePage and then generate the HTML for the pagination
 	 * bar by Paginator::getBarHTML + generate the head item with rel="prev/next" links
@@ -404,7 +429,7 @@ class PaginatorTest extends WikiaBaseTest {
 	public function testCallStyle3( $itemsPerPage, $allDataString, $pageNo, $pageDataString, $expectedHtml ) {
 		$url = 'http://url/?page=%s';
 		$count = count( explode( ',', $allDataString ) );
-		$pages = Paginator::newFromArray( $count, $itemsPerPage );
+		$pages = Paginator::newFromCount( $count, $itemsPerPage );
 		$pages->setActivePage( $pageNo );
 		$html = $pages->getBarHTML( $url );
 		$this->assertHtmlEquals( $expectedHtml, $html );
@@ -423,7 +448,7 @@ class PaginatorTest extends WikiaBaseTest {
 	 */
 	public function testHeadItem( $count, $perPage, $activePage, $expectedHtml ) {
 		$url = 'http://url/?page=%s';
-		$pages = Paginator::newFromArray( $count, $perPage );
+		$pages = Paginator::newFromCount( $count, $perPage );
 		$pages->setActivePage( $activePage );
 		$html = $pages->getHeadItem( $url );
 		$this->assertHtmlEquals( $expectedHtml, $html, true );

--- a/extensions/wikia/Paginator/tests/PaginatorTest.php
+++ b/extensions/wikia/Paginator/tests/PaginatorTest.php
@@ -290,7 +290,7 @@ class PaginatorTest extends WikiaBaseTest {
 	}
 
 	/**
-	 * Test the basic API of the class, style #1 of using it -- deprecated
+	 * Test the deprecated API of the class
 	 *
 	 * 1. Create an object of Paginator using Paginator::newFromArray (passing the array of items)
 	 * 2. Set the active page number through Paginator::setActivePage
@@ -303,7 +303,7 @@ class PaginatorTest extends WikiaBaseTest {
 	 *
 	 * @dataProvider dataProviderPaginator
 	 */
-	public function testCallStyle1( $itemsPerPage, $allDataString, $pageNo, $pageDataString, $expectedHtml ) {
+	public function testDeprecatedApi( $itemsPerPage, $allDataString, $pageNo, $pageDataString, $expectedHtml ) {
 		$url = 'http://url/?page=%s';
 		$allData = explode( ',', $allDataString );
 		$expectedPageData = explode( ',', $pageDataString );
@@ -316,7 +316,7 @@ class PaginatorTest extends WikiaBaseTest {
 	}
 
 	/**
-	 * Test the basic API of the class, style #2 of using it:
+	 * Test the basic API of the class
 	 *
 	 * 1. Create an object of Paginator using Paginator::newFromCount (passing the number of items)
 	 * 2. Set the active page number through Paginator::setActivePage
@@ -328,31 +328,7 @@ class PaginatorTest extends WikiaBaseTest {
 	 *  * CategoryExhibitionSection
 	 *  * CategoryExhibitionSectionMedia
 	 *
-	 * @dataProvider dataProviderPaginator
-	 */
-	public function testCallStyle2( $itemsPerPage, $allDataString, $pageNo, $pageDataString, $expectedHtml ) {
-		$url = 'http://url/?page=%s';
-		$allData = explode( ',', $allDataString );
-		$expectedPageData = explode( ',', $pageDataString );
-		$pages = Paginator::newFromCount( count( $allData ), $itemsPerPage );
-		$pages->setActivePage( $pageNo );
-		$onePageData = $pages->getCurrentPage( $allData );
-		$html = $pages->getBarHTML( $url );
-		$this->assertEquals( $expectedPageData, $onePageData );
-		$this->assertHtmlEquals( $expectedHtml, $html );
-	}
-
-	/**
-	 * Test the basic API of the class, style #3 of using it
-	 *
-	 * 1. Create an object of Paginator using Paginator::newFromCount (passing the number of items)
-	 * 2. Set the active page number through Paginator::setActivePage
-	 * 3. Generate the HTML for the pagination bar by Paginator::getBarHTML
-	 *
-	 * There's no getting current slice from the class. In fact the class doesn't have the paginated
-	 * array at any point.
-	 *
-	 * This style of calling the class is used by:
+	 * The following classes use the class without getting the currentPage slice:
 	 *
 	 *  * ManageWikiaHomeController
 	 *  * UserActivity\SpecialController
@@ -365,12 +341,15 @@ class PaginatorTest extends WikiaBaseTest {
 	 *
 	 * @dataProvider dataProviderPaginator
 	 */
-	public function testCallStyle3( $itemsPerPage, $allDataString, $pageNo, $pageDataString, $expectedHtml ) {
+	public function testPaginator( $itemsPerPage, $allDataString, $pageNo, $pageDataString, $expectedHtml ) {
 		$url = 'http://url/?page=%s';
-		$count = count( explode( ',', $allDataString ) );
-		$pages = Paginator::newFromCount( $count, $itemsPerPage );
+		$allData = explode( ',', $allDataString );
+		$expectedPageData = explode( ',', $pageDataString );
+		$pages = Paginator::newFromCount( count( $allData ), $itemsPerPage );
 		$pages->setActivePage( $pageNo );
+		$onePageData = $pages->getCurrentPage( $allData );
 		$html = $pages->getBarHTML( $url );
+		$this->assertEquals( $expectedPageData, $onePageData );
 		$this->assertHtmlEquals( $expectedHtml, $html );
 	}
 
@@ -389,10 +368,13 @@ class PaginatorTest extends WikiaBaseTest {
 	 */
 	public function testMaxItemsPerPage( $itemsPerPage, $allDataString, $pageNo, $pageDataString, $expectedHtml ) {
 		$url = 'http://url/?page=%s';
-		$count = count( explode( ',', $allDataString ) );
-		$pages = Paginator::newFromCount( $count, 1000, $itemsPerPage );
+		$allData = explode( ',', $allDataString );
+		$expectedPageData = explode( ',', $pageDataString );
+		$pages = Paginator::newFromCount( count( $allData ), 1000, $itemsPerPage );
 		$pages->setActivePage( $pageNo );
+		$onePageData = $pages->getCurrentPage( $allData );
 		$html = $pages->getBarHTML( $url );
+		$this->assertEquals( $expectedPageData, $onePageData );
 		$this->assertHtmlEquals( $expectedHtml, $html );
 	}
 

--- a/extensions/wikia/Paginator/tests/PaginatorTest.php
+++ b/extensions/wikia/Paginator/tests/PaginatorTest.php
@@ -1,11 +1,5 @@
 <?php
 
-class PaginatorTestMessageMock {
-	public function escaped() {
-		return 'escaped-msg';
-	}
-}
-
 class PaginatorTest extends WikiaBaseTest {
 
 	private $alphabet = 'a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z';
@@ -190,11 +184,12 @@ class PaginatorTest extends WikiaBaseTest {
 	';
 
 	public function setUp() {
-		global $IP;
-		$this->setupFile = "$IP/extensions/wikia/Paginator/Paginator.setup.php";
+		$this->setupFile = __DIR__ . '/../Paginator.setup.php';
 		parent::setUp();
 
-		$this->mockGlobalFunction( 'wfMessage', new PaginatorTestMessageMock() );
+		$messageMock = $this->getMockBuilder( 'Message' )->disableOriginalConstructor()->getMock();
+		$messageMock->expects( $this->any() )->method( 'escaped' )->willReturn( 'escaped-msg' );
+		$this->mockGlobalFunction( 'wfMessage', $messageMock );
 	}
 
 	private function assertHtmlEquals( $expectedHtml, $actualHtml, $head = false ) {

--- a/extensions/wikia/Paginator/tests/PaginatorTest.php
+++ b/extensions/wikia/Paginator/tests/PaginatorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class MessageMock {
+class PaginatorTestMessageMock {
 	public function escaped() {
 		return 'escaped-msg';
 	}
@@ -194,7 +194,7 @@ class PaginatorTest extends WikiaBaseTest {
 		$this->setupFile = "$IP/extensions/wikia/Paginator/Paginator.setup.php";
 		parent::setUp();
 
-		$this->mockGlobalFunction( 'wfMessage', new MessageMock() );
+		$this->mockGlobalFunction( 'wfMessage', new PaginatorTestMessageMock() );
 	}
 
 	private function assertHtmlEquals( $expectedHtml, $actualHtml, $head = false ) {
@@ -308,32 +308,6 @@ class PaginatorTest extends WikiaBaseTest {
 	}
 
 	/**
-	 * Test the basic API of the class, style #1 of using it -- deprecated version
-	 *
-	 * Create an object of Paginator using Paginator::newFromArray and then set an active page
-	 * number and get the current slice of the input array using Paginator::getPage and then
-	 * generate the HTML for the pagination bar by Paginator::getBarHTML
-	 *
-	 * This style of calling the class is used by:
-	 *
-	 *  * CategoryExhibitionSection
-	 *  * CategoryExhibitionSectionMedia
-	 *  * CrunchyrollVideo
-	 *
-	 * @dataProvider dataProviderCallStyle1
-	 */
-	public function testCallStyle1( $itemsPerPage, $allDataString, $pageNo, $pageDataString, $expectedHtml ) {
-		$url = 'http://url/?page=%s';
-		$allData = explode( ',', $allDataString );
-		$expectedPageData = explode( ',', $pageDataString );
-		$pages = Paginator::newFromArray( $allData, $itemsPerPage );
-		$onePageData = $pages->getPage( $pageNo, true );
-		$html = $pages->getBarHTML( $url );
-		$this->assertEquals( $expectedPageData, $onePageData );
-		$this->assertHtmlEquals( $expectedHtml, $html );
-	}
-
-	/**
 	 * Test the basic API of the class, style #1 of using it -- updated version
 	 *
 	 * Create an object of Paginator using Paginator::newFromArray and then set an active page
@@ -353,7 +327,7 @@ class PaginatorTest extends WikiaBaseTest {
 		$allData = explode( ',', $allDataString );
 		$expectedPageData = explode( ',', $pageDataString );
 		$pages = Paginator::newFromArray( $allData, $itemsPerPage );
-		$pages->setActivePage( $pageNo - 1 );
+		$pages->setActivePage( $pageNo );
 		$onePageData = $pages->getCurrentPage();
 		$html = $pages->getBarHTML( $url );
 		$this->assertEquals( $expectedPageData, $onePageData );
@@ -383,7 +357,7 @@ class PaginatorTest extends WikiaBaseTest {
 		$count = count( explode( ',', $allDataString ) );
 		$allData = array_fill( 0, $count, '' );
 		$pages = Paginator::newFromArray( $allData, $itemsPerPage );
-		$pages->setActivePage( $pageNo - 1 );
+		$pages->setActivePage( $pageNo );
 		$html = $pages->getBarHTML( $url );
 		$this->assertHtmlEquals( $expectedHtml, $html );
 	}
@@ -406,7 +380,7 @@ class PaginatorTest extends WikiaBaseTest {
 		$count = count( explode( ',', $allDataString ) );
 		$allData = array_fill( 0, $count, '' );
 		$pages = Paginator::newFromArray( $allData, 1000, $itemsPerPage );
-		$pages->setActivePage( $pageNo - 1 );
+		$pages->setActivePage( $pageNo );
 		$html = $pages->getBarHTML( $url );
 		$this->assertHtmlEquals( $expectedHtml, $html );
 	}
@@ -431,7 +405,7 @@ class PaginatorTest extends WikiaBaseTest {
 		$url = 'http://url/?page=%s';
 		$count = count( explode( ',', $allDataString ) );
 		$pages = Paginator::newFromArray( $count, $itemsPerPage );
-		$pages->setActivePage( $pageNo - 1 );
+		$pages->setActivePage( $pageNo );
 		$html = $pages->getBarHTML( $url );
 		$this->assertHtmlEquals( $expectedHtml, $html );
 	}
@@ -450,7 +424,7 @@ class PaginatorTest extends WikiaBaseTest {
 	public function testHeadItem( $count, $perPage, $activePage, $expectedHtml ) {
 		$url = 'http://url/?page=%s';
 		$pages = Paginator::newFromArray( $count, $perPage );
-		$pages->setActivePage( $activePage - 1 );
+		$pages->setActivePage( $activePage );
 		$html = $pages->getHeadItem( $url );
 		$this->assertHtmlEquals( $expectedHtml, $html, true );
 	}

--- a/extensions/wikia/Paginator/tests/PaginatorTest.php
+++ b/extensions/wikia/Paginator/tests/PaginatorTest.php
@@ -207,7 +207,7 @@ class PaginatorTest extends WikiaBaseTest {
 		);
 	}
 
-	private function casesForStandardUse() {
+	public function dataProviderPaginator() {
 		return [
 			// Pages 1...4
 			[ 8, $this->alphabet, 1, 'a,b,c,d,e,f,g,h', $this->htmlPage1of4Selected ],
@@ -234,11 +234,7 @@ class PaginatorTest extends WikiaBaseTest {
 			// Min per-page is 4:
 			[ 3, 'a,b,c,d', 1, 'a,b,c,d', '' ],
 			[ 2, 'a,b,c,d', 1, 'a,b,c,d', '' ],
-		];
-	}
 
-	private function casesForEdgeBehavior() {
-		return [
 			// Pages beyond the last one will still display the last one
 			[ 8, $this->alphabet, 5, 'y,z', $this->htmlPage4of4Selected ],
 			[ 8, $this->alphabet, 6, 'y,z', $this->htmlPage4of4Selected ],
@@ -250,20 +246,6 @@ class PaginatorTest extends WikiaBaseTest {
 			[ 8, $this->alphabet, -2, 'a,b,c,d,e,f,g,h', $this->htmlPage1of4Selected ],
 			[ 8, $this->alphabet, -100, 'a,b,c,d,e,f,g,h', $this->htmlPage1of4Selected ],
 		];
-	}
-
-	public function dataProviderCallStyle1() {
-		return array_merge(
-			$this->casesForStandardUse(),
-			$this->casesForEdgeBehavior()
-		);
-	}
-
-	public function dataProviderCallStyle2() {
-		return array_merge(
-			$this->casesForStandardUse(),
-			$this->casesForEdgeBehavior()
-		);
 	}
 
 	public function dataProviderHeadItem() {
@@ -308,17 +290,18 @@ class PaginatorTest extends WikiaBaseTest {
 	}
 
 	/**
-	 * Test the basic API of the class, style #1 of using it -- old version
+	 * Test the basic API of the class, style #1 of using it -- deprecated
 	 *
-	 * Create an object of Paginator using Paginator::newFromArray and then set an active page
-	 * number through setActivePage and get the current slice of the input array using
-	 * getCurrentPage and then generate the HTML for the pagination bar by Paginator::getBarHTML
+	 * 1. Create an object of Paginator using Paginator::newFromArray (passing the array of items)
+	 * 2. Set the active page number through Paginator::setActivePage
+	 * 3. Get the current slice of the input array using Paginator::getCurrentPage
+	 * 4. Generate the HTML for the pagination bar by Paginator::getBarHTML
 	 *
-	 * This style of calling the class is used by:
+	 * This style of calling the class is only used by:
 	 *
 	 *  * CrunchyrollVideo
 	 *
-	 * @dataProvider dataProviderCallStyle1
+	 * @dataProvider dataProviderPaginator
 	 */
 	public function testCallStyle1( $itemsPerPage, $allDataString, $pageNo, $pageDataString, $expectedHtml ) {
 		$url = 'http://url/?page=%s';
@@ -333,21 +316,21 @@ class PaginatorTest extends WikiaBaseTest {
 	}
 
 	/**
-	 * Test the basic API of the class, style #1 of using it - passing data length to newFromCount
-	 * and passing data to getCurrentPage
+	 * Test the basic API of the class, style #2 of using it:
 	 *
-	 * Create an object of Paginator using Paginator::newFromCount and then set an active page
-	 * number through setActivePage and get the current slice of the input array using
-	 * getCurrentPage and then generate the HTML for the pagination bar by Paginator::getBarHTML
+	 * 1. Create an object of Paginator using Paginator::newFromCount (passing the number of items)
+	 * 2. Set the active page number through Paginator::setActivePage
+	 * 3. Get the current slice of the input array using Paginator::getCurrentPage (passing the array)
+	 * 4. Generate the HTML for the pagination bar by Paginator::getBarHTML
 	 *
 	 * This style of calling the class is used by:
 	 *
 	 *  * CategoryExhibitionSection
 	 *  * CategoryExhibitionSectionMedia
 	 *
-	 * @dataProvider dataProviderCallStyle1
+	 * @dataProvider dataProviderPaginator
 	 */
-	public function testCallStyle1Updated( $itemsPerPage, $allDataString, $pageNo, $pageDataString, $expectedHtml ) {
+	public function testCallStyle2( $itemsPerPage, $allDataString, $pageNo, $pageDataString, $expectedHtml ) {
 		$url = 'http://url/?page=%s';
 		$allData = explode( ',', $allDataString );
 		$expectedPageData = explode( ',', $pageDataString );
@@ -360,12 +343,14 @@ class PaginatorTest extends WikiaBaseTest {
 	}
 
 	/**
-	 * Test the basic API of the class, style #2 of using it
+	 * Test the basic API of the class, style #3 of using it
 	 *
-	 * Create an object of Paginator using Paginator::newFromCount passing array
-	 * constructed by array_fill( 0, $count, '' ) and then set an active page number
-	 * using Paginator::setActivePage and then generate the HTML for the pagination
-	 * bar by Paginator::getBarHTML + generate the head item with rel="prev/next" links
+	 * 1. Create an object of Paginator using Paginator::newFromCount (passing the number of items)
+	 * 2. Set the active page number through Paginator::setActivePage
+	 * 3. Generate the HTML for the pagination bar by Paginator::getBarHTML
+	 *
+	 * There's no getting current slice from the class. In fact the class doesn't have the paginated
+	 * array at any point.
 	 *
 	 * This style of calling the class is used by:
 	 *
@@ -374,21 +359,23 @@ class PaginatorTest extends WikiaBaseTest {
 	 *  * WhereIsExtension
 	 *  * WAMPageController
 	 *  * WDACReviewSpecialController
+	 *  * SpecialVideosHelper
+	 *  * WikiaNewFilesSpecialController
+	 *  * TemplatesSpecialController
 	 *
-	 * @dataProvider dataProviderCallStyle2
+	 * @dataProvider dataProviderPaginator
 	 */
-	public function testCallStyle2( $itemsPerPage, $allDataString, $pageNo, $pageDataString, $expectedHtml ) {
+	public function testCallStyle3( $itemsPerPage, $allDataString, $pageNo, $pageDataString, $expectedHtml ) {
 		$url = 'http://url/?page=%s';
 		$count = count( explode( ',', $allDataString ) );
-		$allData = array_fill( 0, $count, '' );
-		$pages = Paginator::newFromCount( $allData, $itemsPerPage );
+		$pages = Paginator::newFromCount( $count, $itemsPerPage );
 		$pages->setActivePage( $pageNo );
 		$html = $pages->getBarHTML( $url );
 		$this->assertHtmlEquals( $expectedHtml, $html );
 	}
 
 	/**
-	 * Test the basic API of the class, style #2 of using it + using $maxItemsPerPage param
+	 * Test passing maxItemsPerPage param through newFromCount
 	 *
 	 * The same as above, just passing additional param $maxItemsPerPage, simulated here by
 	 * passing a big number for $itemsPerPage and then the one from data provider as $maxItemsPerPage
@@ -398,38 +385,12 @@ class PaginatorTest extends WikiaBaseTest {
 	 *  * InsightsPaginator
 	 *  * blog-pager-ajax.tmpl
 	 *
-	 * @dataProvider dataProviderCallStyle2
+	 * @dataProvider dataProviderPaginator
 	 */
-	public function testCallStyle2maxItemsPerPage( $itemsPerPage, $allDataString, $pageNo, $pageDataString, $expectedHtml ) {
+	public function testMaxItemsPerPage( $itemsPerPage, $allDataString, $pageNo, $pageDataString, $expectedHtml ) {
 		$url = 'http://url/?page=%s';
 		$count = count( explode( ',', $allDataString ) );
-		$allData = array_fill( 0, $count, '' );
-		$pages = Paginator::newFromCount( $allData, 1000, $itemsPerPage );
-		$pages->setActivePage( $pageNo );
-		$html = $pages->getBarHTML( $url );
-		$this->assertHtmlEquals( $expectedHtml, $html );
-	}
-
-	/**
-	 * Test the basic API of the class, style #3 of using it
-	 *
-	 * Create an object of Paginator using Paginator::newFromCount passing number of elements to
-	 * paginate through constructed by array_fill( 0, $count, '' ) and then set an active page
-	 * number using Paginator::setActivePage and then generate the HTML for the pagination
-	 * bar by Paginator::getBarHTML + generate the head item with rel="prev/next" links
-	 *
-	 * This style of calling the class is used by:
-	 *
-	 *  * SpecialVideosHelper
-	 *  * WikiaNewFilesSpecialController
-	 *  * TemplatesSpecialController
-	 *
-	 * @dataProvider dataProviderCallStyle2
-	 */
-	public function testCallStyle3( $itemsPerPage, $allDataString, $pageNo, $pageDataString, $expectedHtml ) {
-		$url = 'http://url/?page=%s';
-		$count = count( explode( ',', $allDataString ) );
-		$pages = Paginator::newFromCount( $count, $itemsPerPage );
+		$pages = Paginator::newFromCount( $count, 1000, $itemsPerPage );
 		$pages->setActivePage( $pageNo );
 		$html = $pages->getBarHTML( $url );
 		$this->assertHtmlEquals( $expectedHtml, $html );

--- a/extensions/wikia/Paginator/tests/PaginatorTest.php
+++ b/extensions/wikia/Paginator/tests/PaginatorTest.php
@@ -261,7 +261,8 @@ class PaginatorTest extends WikiaBaseTest {
 
 	public function dataProviderCallStyle2() {
 		return array_merge(
-			$this->casesForStandardUse()
+			$this->casesForStandardUse(),
+			$this->casesForEdgeBehavior()
 		);
 	}
 
@@ -293,15 +294,16 @@ class PaginatorTest extends WikiaBaseTest {
 			[ 4, 3, 1, '' ],
 			[ 4, 2, 1, '' ],
 
-			[ 26, 8, 5, '' ],
-			[ 26, 8, 6, '' ],
-			[ 26, 8, 100, '' ],
+			// Beyond the last page:
+			[ 26, 8, 5, $this->headPage4of4Selected ],
+			[ 26, 8, 6, $this->headPage4of4Selected ],
+			[ 26, 8, 100, $this->headPage4of4Selected ],
 
 			// Page 0, -1, -2, -100 acts the same as 1
-			[ 26, 8, 0, '' ],
-			[ 26, 8, -1, '' ],
-			[ 26, 8, -2, '' ],
-			[ 26, 8, -100, '' ],
+			[ 26, 8, 0, $this->headPage1of4Selected ],
+			[ 26, 8, -1, $this->headPage1of4Selected ],
+			[ 26, 8, -2, $this->headPage1of4Selected ],
+			[ 26, 8, -100, $this->headPage1of4Selected ],
 		];
 	}
 

--- a/extensions/wikia/SpecialManageWikiaHome/ManageWikiaHomeController.class.php
+++ b/extensions/wikia/SpecialManageWikiaHome/ManageWikiaHomeController.class.php
@@ -249,7 +249,7 @@ class ManageWikiaHomeController extends WikiaSpecialPageController {
 
 		if( $count > self::WHST_WIKIS_PER_PAGE ) {
 			/** @var $paginator Paginator */
-			$paginator = Paginator::newFromArray( $count, self::WHST_WIKIS_PER_PAGE );
+			$paginator = Paginator::newFromCount( $count, self::WHST_WIKIS_PER_PAGE );
 
 			$paginator->setActivePage($currentPage);
 

--- a/extensions/wikia/SpecialManageWikiaHome/ManageWikiaHomeController.class.php
+++ b/extensions/wikia/SpecialManageWikiaHome/ManageWikiaHomeController.class.php
@@ -249,7 +249,7 @@ class ManageWikiaHomeController extends WikiaSpecialPageController {
 
 		if( $count > self::WHST_WIKIS_PER_PAGE ) {
 			/** @var $paginator Paginator */
-			$paginator = Paginator::newFromArray( array_fill( 0, $count, '' ), self::WHST_WIKIS_PER_PAGE );
+			$paginator = Paginator::newFromArray( $count, self::WHST_WIKIS_PER_PAGE );
 
 			$paginator->setActivePage($currentPage);
 

--- a/extensions/wikia/SpecialManageWikiaHome/ManageWikiaHomeController.class.php
+++ b/extensions/wikia/SpecialManageWikiaHome/ManageWikiaHomeController.class.php
@@ -251,7 +251,7 @@ class ManageWikiaHomeController extends WikiaSpecialPageController {
 			/** @var $paginator Paginator */
 			$paginator = Paginator::newFromArray( array_fill( 0, $count, '' ), self::WHST_WIKIS_PER_PAGE );
 
-			$paginator->setActivePage($currentPage - 1);
+			$paginator->setActivePage($currentPage);
 
 			$url = $this->getUrlWithAllParams($visualizationLang, $filterOptions);
 			$this->setVal('pagination', $paginator->getBarHTML($url));

--- a/extensions/wikia/SpecialVideos/SpecialVideosHelper.class.php
+++ b/extensions/wikia/SpecialVideos/SpecialVideosHelper.class.php
@@ -209,7 +209,6 @@ class SpecialVideosHelper extends WikiaModel {
 		$totalVideos = $this->getTotalVideos( $videoParams );
 
 		if ( $totalVideos > self::VIDEOS_PER_PAGE ) {
-			// Paginator::newFromArray allows array and integer param
 			$pages = Paginator::newFromCount( $totalVideos, self::VIDEOS_PER_PAGE );
 			$pages->setActivePage( $videoParams['page'] );
 

--- a/extensions/wikia/SpecialVideos/SpecialVideosHelper.class.php
+++ b/extensions/wikia/SpecialVideos/SpecialVideosHelper.class.php
@@ -211,7 +211,7 @@ class SpecialVideosHelper extends WikiaModel {
 		if ( $totalVideos > self::VIDEOS_PER_PAGE ) {
 			// Paginator::newFromArray allows array and integer param
 			$pages = Paginator::newFromArray( $totalVideos, self::VIDEOS_PER_PAGE );
-			$pages->setActivePage( $videoParams['page'] - 1 );
+			$pages->setActivePage( $videoParams['page'] );
 
 			$urlTemplate = SpecialPage::getTitleFor( 'Videos' )->escapeLocalUrl();
 			$urlTemplate .= '?page=%s';

--- a/extensions/wikia/SpecialVideos/SpecialVideosHelper.class.php
+++ b/extensions/wikia/SpecialVideos/SpecialVideosHelper.class.php
@@ -210,7 +210,7 @@ class SpecialVideosHelper extends WikiaModel {
 
 		if ( $totalVideos > self::VIDEOS_PER_PAGE ) {
 			// Paginator::newFromArray allows array and integer param
-			$pages = Paginator::newFromArray( $totalVideos, self::VIDEOS_PER_PAGE );
+			$pages = Paginator::newFromCount( $totalVideos, self::VIDEOS_PER_PAGE );
 			$pages->setActivePage( $videoParams['page'] );
 
 			$urlTemplate = SpecialPage::getTitleFor( 'Videos' )->escapeLocalUrl();

--- a/extensions/wikia/TemplateClassification/specials/TemplatesSpecialController.class.php
+++ b/extensions/wikia/TemplateClassification/specials/TemplatesSpecialController.class.php
@@ -255,7 +255,7 @@ class TemplatesSpecialController extends WikiaSpecialPageController {
 			$params['template'] = $this->templateName;
 		}
 
-		$paginator = Paginator::newFromArray( $total, self::ITEMS_PER_PAGE );
+		$paginator = Paginator::newFromCount( $total, self::ITEMS_PER_PAGE );
 		$paginator->setActivePage( $page + 1 );
 		$url = urldecode( $this->specialPage->getTitle()->getLocalUrl( $params ) );
 		$this->paginatorBar = $paginator->getBarHTML( $url );

--- a/extensions/wikia/TemplateClassification/specials/TemplatesSpecialController.class.php
+++ b/extensions/wikia/TemplateClassification/specials/TemplatesSpecialController.class.php
@@ -256,7 +256,7 @@ class TemplatesSpecialController extends WikiaSpecialPageController {
 		}
 
 		$paginator = Paginator::newFromArray( $total, self::ITEMS_PER_PAGE );
-		$paginator->setActivePage( $page );
+		$paginator->setActivePage( $page + 1 );
 		$url = urldecode( $this->specialPage->getTitle()->getLocalUrl( $params ) );
 		$this->paginatorBar = $paginator->getBarHTML( $url );
 	}

--- a/extensions/wikia/UserActivity/SpecialUserActivityController.class.php
+++ b/extensions/wikia/UserActivity/SpecialUserActivityController.class.php
@@ -82,7 +82,7 @@ class SpecialController extends \WikiaSpecialPageController {
 	private function getPagination( $total, $page, $order ) {
 		$pagination = '';
 		if ( $total > self::ITEMS_PER_PAGE ) {
-			$pages = \Paginator::newFromArray( array_fill( 0, $total, '' ), self::ITEMS_PER_PAGE );
+			$pages = \Paginator::newFromArray( $total, self::ITEMS_PER_PAGE );
 			$pages->setActivePage( $page );
 
 			$linkToSpecialPage = \SpecialPage::getTitleFor( 'UserActivity' )->escapeLocalUrl();

--- a/extensions/wikia/UserActivity/SpecialUserActivityController.class.php
+++ b/extensions/wikia/UserActivity/SpecialUserActivityController.class.php
@@ -82,7 +82,7 @@ class SpecialController extends \WikiaSpecialPageController {
 	private function getPagination( $total, $page, $order ) {
 		$pagination = '';
 		if ( $total > self::ITEMS_PER_PAGE ) {
-			$pages = \Paginator::newFromArray( $total, self::ITEMS_PER_PAGE );
+			$pages = \Paginator::newFromCount( $total, self::ITEMS_PER_PAGE );
 			$pages->setActivePage( $page );
 
 			$linkToSpecialPage = \SpecialPage::getTitleFor( 'UserActivity' )->escapeLocalUrl();

--- a/extensions/wikia/UserActivity/SpecialUserActivityController.class.php
+++ b/extensions/wikia/UserActivity/SpecialUserActivityController.class.php
@@ -83,7 +83,7 @@ class SpecialController extends \WikiaSpecialPageController {
 		$pagination = '';
 		if ( $total > self::ITEMS_PER_PAGE ) {
 			$pages = \Paginator::newFromArray( array_fill( 0, $total, '' ), self::ITEMS_PER_PAGE );
-			$pages->setActivePage( $page - 1 );
+			$pages->setActivePage( $page );
 
 			$linkToSpecialPage = \SpecialPage::getTitleFor( 'UserActivity' )->escapeLocalUrl();
 			$pagination = $pages->getBarHTML( $linkToSpecialPage.'?page=%s&order='.$order );

--- a/extensions/wikia/WAMPage/WAMPageController.class.php
+++ b/extensions/wikia/WAMPage/WAMPageController.class.php
@@ -38,7 +38,7 @@ class WAMPageController extends WikiaController
 		$total = ( empty( $this->indexWikis['wam_results_total'] ) ) ? 0 : $this->indexWikis['wam_results_total'];
 		$itemsPerPage = $this->model->getItemsPerPage();
 		if( $total > $itemsPerPage ) {
-			$paginator = Paginator::newFromArray( array_fill( 0, $total, '' ), $itemsPerPage );
+			$paginator = Paginator::newFromArray( $total, $itemsPerPage );
 			$paginator->setActivePage( $this->page );
 			$this->paginatorBar = $paginator->getBarHTML( $this->getUrlWithAllParams() );
 			$this->wg->Out->addHeadItem( 'Pagination', $paginator->getHeadItem( $this->getUrlWithAllParams() ) );

--- a/extensions/wikia/WAMPage/WAMPageController.class.php
+++ b/extensions/wikia/WAMPage/WAMPageController.class.php
@@ -38,7 +38,7 @@ class WAMPageController extends WikiaController
 		$total = ( empty( $this->indexWikis['wam_results_total'] ) ) ? 0 : $this->indexWikis['wam_results_total'];
 		$itemsPerPage = $this->model->getItemsPerPage();
 		if( $total > $itemsPerPage ) {
-			$paginator = Paginator::newFromArray( $total, $itemsPerPage );
+			$paginator = Paginator::newFromCount( $total, $itemsPerPage );
 			$paginator->setActivePage( $this->page );
 			$this->paginatorBar = $paginator->getBarHTML( $this->getUrlWithAllParams() );
 			$this->wg->Out->addHeadItem( 'Pagination', $paginator->getHeadItem( $this->getUrlWithAllParams() ) );

--- a/extensions/wikia/WAMPage/WAMPageController.class.php
+++ b/extensions/wikia/WAMPage/WAMPageController.class.php
@@ -39,7 +39,7 @@ class WAMPageController extends WikiaController
 		$itemsPerPage = $this->model->getItemsPerPage();
 		if( $total > $itemsPerPage ) {
 			$paginator = Paginator::newFromArray( array_fill( 0, $total, '' ), $itemsPerPage );
-			$paginator->setActivePage( $this->page - 1 );
+			$paginator->setActivePage( $this->page );
 			$this->paginatorBar = $paginator->getBarHTML( $this->getUrlWithAllParams() );
 			$this->wg->Out->addHeadItem( 'Pagination', $paginator->getHeadItem( $this->getUrlWithAllParams() ) );
 		}

--- a/extensions/wikia/WDACReview/WDACReviewSpecialController.class.php
+++ b/extensions/wikia/WDACReview/WDACReviewSpecialController.class.php
@@ -60,7 +60,7 @@ class WDACReviewSpecialController extends WikiaSpecialPageController {
 		$this->paginator = '';
 		if ( self::WIKIS_PER_PAGE_LIMIT < $iCount ) {
 			$oPaginator = Paginator::newFromArray( array_fill( 0, $iCount, '' ), self::WIKIS_PER_PAGE_LIMIT );
-			$oPaginator->setActivePage( $iPage - 1 );
+			$oPaginator->setActivePage( $iPage );
 
 			// And here we go! The %s will be replaced with the page number.
 			$this->paginator = $oPaginator->getBarHTML( $this->paginatorUrl );

--- a/extensions/wikia/WDACReview/WDACReviewSpecialController.class.php
+++ b/extensions/wikia/WDACReview/WDACReviewSpecialController.class.php
@@ -59,7 +59,7 @@ class WDACReviewSpecialController extends WikiaSpecialPageController {
 		$this->aCities = $helper->getCitiesForReviewList( self::WIKIS_PER_PAGE_LIMIT, $iPage-1 );
 		$this->paginator = '';
 		if ( self::WIKIS_PER_PAGE_LIMIT < $iCount ) {
-			$oPaginator = Paginator::newFromArray( $iCount, self::WIKIS_PER_PAGE_LIMIT );
+			$oPaginator = Paginator::newFromCount( $iCount, self::WIKIS_PER_PAGE_LIMIT );
 			$oPaginator->setActivePage( $iPage );
 
 			// And here we go! The %s will be replaced with the page number.

--- a/extensions/wikia/WDACReview/WDACReviewSpecialController.class.php
+++ b/extensions/wikia/WDACReview/WDACReviewSpecialController.class.php
@@ -59,7 +59,7 @@ class WDACReviewSpecialController extends WikiaSpecialPageController {
 		$this->aCities = $helper->getCitiesForReviewList( self::WIKIS_PER_PAGE_LIMIT, $iPage-1 );
 		$this->paginator = '';
 		if ( self::WIKIS_PER_PAGE_LIMIT < $iCount ) {
-			$oPaginator = Paginator::newFromArray( array_fill( 0, $iCount, '' ), self::WIKIS_PER_PAGE_LIMIT );
+			$oPaginator = Paginator::newFromArray( $iCount, self::WIKIS_PER_PAGE_LIMIT );
 			$oPaginator->setActivePage( $iPage );
 
 			// And here we go! The %s will be replaced with the page number.

--- a/extensions/wikia/WhereIsExtension/SpecialWhereIsExtension_body.php
+++ b/extensions/wikia/WhereIsExtension/SpecialWhereIsExtension_body.php
@@ -105,7 +105,7 @@ class WhereIsExtension extends SpecialPage {
                                 // the Paginator, if we need more than one page
                                 if ( self::ITEMS_PER_PAGE < $formData['count'] ) {
                                     $oPaginator = Paginator::newFromArray( array_fill( 0, $formData['count'], '' ), self::ITEMS_PER_PAGE );
-                                    $oPaginator->setActivePage( $iPage - 1 );
+                                    $oPaginator->setActivePage( $iPage );
                                     $sPager = $oPaginator->getBarHTML( sprintf( '%s?var=%s&val=%s&likeValue=%s&searchType=%s&page=%%s', $wgTitle->getFullURL(), $gVar, $gVal, $gLikeVal, $gTypeVal ) );
                                 }
                             }

--- a/extensions/wikia/WhereIsExtension/SpecialWhereIsExtension_body.php
+++ b/extensions/wikia/WhereIsExtension/SpecialWhereIsExtension_body.php
@@ -103,7 +103,7 @@ class WhereIsExtension extends SpecialPage {
                                 $formData['wikis'] = WikiFactory::getListOfWikisWithVar( $gVar, $gTypeVal, $this->values[$gVal][2], $this->values[$gVal][1], $gLikeVal, $iOffset, self::ITEMS_PER_PAGE );
 
                                 // the Paginator, if we need more than one page
-								$oPaginator = Paginator::newFromArray( $formData['count'], self::ITEMS_PER_PAGE );
+								$oPaginator = Paginator::newFromCount( $formData['count'], self::ITEMS_PER_PAGE );
 								$oPaginator->setActivePage( $iPage );
 								$sPager = $oPaginator->getBarHTML( sprintf( '%s?var=%s&val=%s&likeValue=%s&searchType=%s&page=%%s', $wgTitle->getFullURL(), $gVar, $gVal, $gLikeVal, $gTypeVal ) );
                             }

--- a/extensions/wikia/WhereIsExtension/SpecialWhereIsExtension_body.php
+++ b/extensions/wikia/WhereIsExtension/SpecialWhereIsExtension_body.php
@@ -103,11 +103,9 @@ class WhereIsExtension extends SpecialPage {
                                 $formData['wikis'] = WikiFactory::getListOfWikisWithVar( $gVar, $gTypeVal, $this->values[$gVal][2], $this->values[$gVal][1], $gLikeVal, $iOffset, self::ITEMS_PER_PAGE );
 
                                 // the Paginator, if we need more than one page
-                                if ( self::ITEMS_PER_PAGE < $formData['count'] ) {
-                                    $oPaginator = Paginator::newFromArray( array_fill( 0, $formData['count'], '' ), self::ITEMS_PER_PAGE );
-                                    $oPaginator->setActivePage( $iPage );
-                                    $sPager = $oPaginator->getBarHTML( sprintf( '%s?var=%s&val=%s&likeValue=%s&searchType=%s&page=%%s', $wgTitle->getFullURL(), $gVar, $gVal, $gLikeVal, $gTypeVal ) );
-                                }
+								$oPaginator = Paginator::newFromArray( $formData['count'], self::ITEMS_PER_PAGE );
+								$oPaginator->setActivePage( $iPage );
+								$sPager = $oPaginator->getBarHTML( sprintf( '%s?var=%s&val=%s&likeValue=%s&searchType=%s&page=%%s', $wgTitle->getFullURL(), $gVar, $gVal, $gLikeVal, $gTypeVal ) );
                             }
                         }
 		}

--- a/extensions/wikia/WhereIsExtension/SpecialWhereIsExtension_body.php
+++ b/extensions/wikia/WhereIsExtension/SpecialWhereIsExtension_body.php
@@ -102,7 +102,6 @@ class WhereIsExtension extends SpecialPage {
 					// the list
 					$formData['wikis'] = WikiFactory::getListOfWikisWithVar( $gVar, $gTypeVal, $this->values[$gVal][2], $this->values[$gVal][1], $gLikeVal, $iOffset, self::ITEMS_PER_PAGE );
 
-					// the Paginator, if we need more than one page
 					$oPaginator = Paginator::newFromCount( $formData['count'], self::ITEMS_PER_PAGE );
 					$oPaginator->setActivePage( $iPage );
 					$sPager = $oPaginator->getBarHTML( sprintf( '%s?var=%s&val=%s&likeValue=%s&searchType=%s&page=%%s', $wgTitle->getFullURL(), $gVar, $gVal, $gLikeVal, $gTypeVal ) );

--- a/extensions/wikia/WhereIsExtension/SpecialWhereIsExtension_body.php
+++ b/extensions/wikia/WhereIsExtension/SpecialWhereIsExtension_body.php
@@ -84,30 +84,30 @@ class WhereIsExtension extends SpecialPage {
 		if (!empty($gVar)) {
 			$formData['selectedVar'] = $gVar;
 
-                        // assume an empty result
-                        $formData['count'] = 0;
-                        $formData['wikis'] = array();
+			// assume an empty result
+			$formData['count'] = 0;
+			$formData['wikis'] = array();
 
-                        if ( isset( $this->values[$gVal][1] ) && isset( $this->values[$gVal][2] ) ) {
+			if ( isset( $this->values[$gVal][1] ) && isset( $this->values[$gVal][2] ) ) {
 
-                            // check how many wikis meet the conditions
-                            $formData['count'] = WikiFactory::getCountOfWikisWithVar( $gVar, $gTypeVal, $this->values[$gVal][2], $this->values[$gVal][1], $gLikeVal );
+				// check how many wikis meet the conditions
+				$formData['count'] = WikiFactory::getCountOfWikisWithVar( $gVar, $gTypeVal, $this->values[$gVal][2], $this->values[$gVal][1], $gLikeVal );
 
-                            // if there are any, get the list and create a Paginator
-                            if (0 < $formData['count'] ) {
-                                // determine the offset (from the requested page)
-                                $iPage = $wgRequest->getVal( 'page', 1 );
-                                $iOffset = ( $iPage - 1 ) * self::ITEMS_PER_PAGE;
+				// if there are any, get the list and create a Paginator
+				if ( 0 < $formData['count'] ) {
+					// determine the offset (from the requested page)
+					$iPage = $wgRequest->getVal( 'page', 1 );
+					$iOffset = ( $iPage - 1 ) * self::ITEMS_PER_PAGE;
 
-                                // the list
-                                $formData['wikis'] = WikiFactory::getListOfWikisWithVar( $gVar, $gTypeVal, $this->values[$gVal][2], $this->values[$gVal][1], $gLikeVal, $iOffset, self::ITEMS_PER_PAGE );
+					// the list
+					$formData['wikis'] = WikiFactory::getListOfWikisWithVar( $gVar, $gTypeVal, $this->values[$gVal][2], $this->values[$gVal][1], $gLikeVal, $iOffset, self::ITEMS_PER_PAGE );
 
-                                // the Paginator, if we need more than one page
-								$oPaginator = Paginator::newFromCount( $formData['count'], self::ITEMS_PER_PAGE );
-								$oPaginator->setActivePage( $iPage );
-								$sPager = $oPaginator->getBarHTML( sprintf( '%s?var=%s&val=%s&likeValue=%s&searchType=%s&page=%%s', $wgTitle->getFullURL(), $gVar, $gVal, $gLikeVal, $gTypeVal ) );
-                            }
-                        }
+					// the Paginator, if we need more than one page
+					$oPaginator = Paginator::newFromCount( $formData['count'], self::ITEMS_PER_PAGE );
+					$oPaginator->setActivePage( $iPage );
+					$sPager = $oPaginator->getBarHTML( sprintf( '%s?var=%s&val=%s&likeValue=%s&searchType=%s&page=%%s', $wgTitle->getFullURL(), $gVar, $gVal, $gLikeVal, $gTypeVal ) );
+				}
+			}
 		}
 
 		$oTmpl = new EasyTemplate(dirname( __FILE__ ) . '/templates/');

--- a/extensions/wikia/WikiaNewFiles/WikiaNewFilesSpecialController.class.php
+++ b/extensions/wikia/WikiaNewFiles/WikiaNewFilesSpecialController.class.php
@@ -50,7 +50,7 @@ class WikiaNewFilesSpecialController extends WikiaSpecialPageController {
 
 		// Pagination
 		$paginator = Paginator::newFromArray( $imageCount, self::DEFAULT_LIMIT );
-		$paginator->setActivePage( $pageNumber - 1 );
+		$paginator->setActivePage( $pageNumber );
 		$output->addHeadItem( 'Paginator', $paginator->getHeadItem( self::PAGINATOR_URL ) );
 
 		// Hook for ContentFeeds::specialNewImagesHook

--- a/extensions/wikia/WikiaNewFiles/WikiaNewFilesSpecialController.class.php
+++ b/extensions/wikia/WikiaNewFiles/WikiaNewFilesSpecialController.class.php
@@ -49,7 +49,7 @@ class WikiaNewFilesSpecialController extends WikiaSpecialPageController {
 		$imageCount = $newFilesModel->getImageCount();
 
 		// Pagination
-		$paginator = Paginator::newFromArray( $imageCount, self::DEFAULT_LIMIT );
+		$paginator = Paginator::newFromCount( $imageCount, self::DEFAULT_LIMIT );
 		$paginator->setActivePage( $pageNumber );
 		$output->addHeadItem( 'Paginator', $paginator->getHeadItem( self::PAGINATOR_URL ) );
 


### PR DESCRIPTION
Most notable is the change for how the Paginator should be called. Instead of
`Paginator::newFromArray` the preferred method is now `Paginator::newFromCount`.

The second notable change is  the way `setActivePage` method works. Previously
it used accept anything (no range validation) and the value was 0-indexed
(for first page you would pass 0, for second 1, and so on). Now the value is
checked for bounds (will default to the first page for numbers < 1 and the
last page for pages beyond the last). The expected value is now natural: you
pass 1 for the first page, 2 for second and so on. This way it's consistent
with the links `getBarHTML` method generates -- just read the `page` value
and pass it to `setActivePage`.

The code no longer checks for `maxItemsPerPage`. If the caller wants 234
items per page, `Paginator` will allow it. Previously it would cap the
items per page to 48 unless `$maxItemsPerPage` param was also passed to
`Paginator::newFromArray`.

In case the number of items per page is supplied by user, it's the
responsibility of the controller, or whoever constructs the `Paginator`
object to validate that data. Relying on the others to do your job is not
the way to go.

Lots of refactoring, rewriting, simplification happen too. All covered by
unit tests.
