### PR TITLE
SEO-218 Update Not_a_valid_Wikia page

### DIFF
--- a/extensions/wikia/InterwikiDispatcher/SpecialInterwikiDispatcher_body.php
+++ b/extensions/wikia/InterwikiDispatcher/SpecialInterwikiDispatcher_body.php
@@ -38,6 +38,9 @@ class InterwikiDispatcher extends UnlistedSpecialPage {
 		$art = $wgRequest->getText('article');
 
 		if (!empty($wikia)) {
+			// The code in NotAValidWikiaArticle.class.php will drop the ".interwiki" pseudo-TLD
+			// When constructing the search query
+			$redirect .= '?from=' . rawurlencode( $wikia . '.interwiki' );
 			$iCityId = self::isWikiExists($wikia);
 			if ($iCityId) {	//wiki exists
 				$redirect = self::getCityUrl($iCityId);

--- a/extensions/wikia/NotAValidWikia/NotAValidWikia.i18n.php
+++ b/extensions/wikia/NotAValidWikia/NotAValidWikia.i18n.php
@@ -1,0 +1,26 @@
+<?php
+/**
+* Internationalisation file for the NotAValidWikia extension.
+*
+* @addtogroup Languages
+*/
+
+$messages = array();
+
+$messages['en'] = array(
+	'not-a-valid-wikia' => ' 
+<div class="center" style="padding: 1em 0; font-weight:bold; font-size:120%; margin-bottom:1em">This is not the wiki you\'re looking for! We didn\'t recognize the URL you provided. Head over to search and find the wiki of your dreams [{{fullurl:homepage:Special:Search|search={{urlencode:$1}}}} here].</div>
+
+{| style="margin: 1em auto 0; font-weight: bold; text-align: center" cellpadding="7" cellspacing="5"
+!colspan="3" style="font-size: 120%"|Looking for help on Wikia?
+|-
+|[[Help:Contents|Explore our Help pages]]
+|
+|[[Special:Forum|Ask questions in the Forum]]
+|-
+|[[homepage:Special:CreateWiki|Start your own wiki]]
+|
+|[[Blog:Wikia Staff Blog|Read the latest Wikia news]]
+|}
+',
+);

--- a/extensions/wikia/NotAValidWikia/NotAValidWikia.i18n.php
+++ b/extensions/wikia/NotAValidWikia/NotAValidWikia.i18n.php
@@ -5,9 +5,9 @@
 * @addtogroup Languages
 */
 
-$messages = array();
+$messages = [];
 
-$messages['en'] = array(
+$messages['en'] = [
 	'not-a-valid-wikia' => ' 
 <div class="center" style="padding: 1em 0; font-weight:bold; font-size:120%; margin-bottom:1em">This is not the wiki you\'re looking for! We didn\'t recognize the URL you provided. Head over to search and find the wiki of your dreams [{{fullurl:homepage:Special:Search|search={{urlencode:$1}}}} here].</div>
 
@@ -23,4 +23,11 @@ $messages['en'] = array(
 |[[Blog:Wikia Staff Blog|Read the latest Wikia news]]
 |}
 ',
-);
+];
+
+$messages['qqq'] = [
+	'not-a-valid-wikia' => 'Wiki text displayed when user got redirected from a domain that does not
+		correspond to any known wiki. The intent of the page is to encourage user to stay at Wikia
+		and search for other exciting content. $1 is replaced with the search query based on the
+		originally entered domain.',
+];

--- a/extensions/wikia/NotAValidWikia/NotAValidWikia.setup.php
+++ b/extensions/wikia/NotAValidWikia/NotAValidWikia.setup.php
@@ -1,0 +1,10 @@
+<?php
+
+// autoload
+$wgAutoloadClasses['NotAValidWikiaArticle'] =  __DIR__ . '/NotAValidWikiaArticle.class.php';
+
+// i18n mapping
+$wgExtensionMessagesFiles['NotAValidWikia'] = __DIR__ . '/NotAValidWikia.i18n.php';
+
+// hooks
+$wgHooks['ArticleFromTitle'][] = 'NotAValidWikiaArticle::onArticleFromTitle';

--- a/extensions/wikia/NotAValidWikia/NotAValidWikia.setup.php
+++ b/extensions/wikia/NotAValidWikia/NotAValidWikia.setup.php
@@ -2,9 +2,10 @@
 
 // autoload
 $wgAutoloadClasses['NotAValidWikiaArticle'] =  __DIR__ . '/NotAValidWikiaArticle.class.php';
+$wgAutoloadClasses['NotAValidWikiaHooks'] =  __DIR__ . '/NotAValidWikiaHooks.class.php';
 
 // i18n mapping
 $wgExtensionMessagesFiles['NotAValidWikia'] = __DIR__ . '/NotAValidWikia.i18n.php';
 
 // hooks
-$wgHooks['ArticleFromTitle'][] = 'NotAValidWikiaArticle::onArticleFromTitle';
+$wgHooks['ArticleFromTitle'][] = 'NotAValidWikiaHooks::onArticleFromTitle';

--- a/extensions/wikia/NotAValidWikia/NotAValidWikiaArticle.class.php
+++ b/extensions/wikia/NotAValidWikia/NotAValidWikiaArticle.class.php
@@ -35,5 +35,8 @@ class NotAValidWikiaArticle extends Article {
 
 		// Pass to the message
 		$wgOut->addWikiMsg( 'not-a-valid-wikia', $searchQuery );
+
+		// Don't index this page
+		$wgOut->setRobotPolicy( 'noindex,nofollow' );
 	}
 }

--- a/extensions/wikia/NotAValidWikia/NotAValidWikiaArticle.class.php
+++ b/extensions/wikia/NotAValidWikia/NotAValidWikiaArticle.class.php
@@ -12,13 +12,13 @@ class NotAValidWikiaArticle extends Article {
 
 		// Extract the interesting part from the domain
 		$interestingPart = preg_replace(
-			'/^(www\.)?(.*?)(\.org|\.com|\.gov|\.net|\.edu|\.co|\.or)?(\.[a-z]+)$/',
+			'/^(www\.)?(.*?)(\.co|\.com|\.me|\.net|\.org)?(\.[a-z]+)$/',
 			'\2',
 			$fromDomain
 		);
 
 		// Replace any non-alpha part with space
-		$searchQuery = trim( preg_replace( '/[\W ]+/', ' ', $interestingPart ) );
+		$searchQuery = trim( preg_replace( '/\W+/', ' ', $interestingPart ) );
 
 		// Pass to the message
 		$wgOut->addWikiMsg( 'not-a-valid-wikia', $searchQuery );

--- a/extensions/wikia/NotAValidWikia/NotAValidWikiaArticle.class.php
+++ b/extensions/wikia/NotAValidWikia/NotAValidWikiaArticle.class.php
@@ -25,7 +25,7 @@ class NotAValidWikiaArticle extends Article {
 
 		// Extract the interesting part from the domain
 		$interestingPart = preg_replace(
-			'/^(www\.)?(.*)(\.org|\.com|\.gov|\.net|\.edu|\.co|\.or)?(\.[a-z]+)$/',
+			'/^(www\.)?(.*?)(\.org|\.com|\.gov|\.net|\.edu|\.co|\.or)?(\.[a-z]+)$/',
 			'\2',
 			$fromDomain
 		);

--- a/extensions/wikia/NotAValidWikia/NotAValidWikiaArticle.class.php
+++ b/extensions/wikia/NotAValidWikia/NotAValidWikiaArticle.class.php
@@ -1,19 +1,6 @@
 <?php
 
 class NotAValidWikiaArticle extends Article {
-	/**
-	 * @param Title $title
-	 * @param Article $article
-	 * @return boolean
-	 */
-	public static function onArticleFromTitle( &$title, &$article ) {
-		if ( $title->getDBkey() == 'Not_a_valid_Wikia' ) {
-			$article = new self( $title );
-		}
-
-		return true;
-	}
-
 	public function view() {
 		global $wgRequest, $wgOut;
 

--- a/extensions/wikia/NotAValidWikia/NotAValidWikiaArticle.class.php
+++ b/extensions/wikia/NotAValidWikia/NotAValidWikiaArticle.class.php
@@ -1,0 +1,39 @@
+<?php
+
+class NotAValidWikiaArticle extends Article {
+	/**
+	 * @param Title $title
+	 * @param Article $article
+	 * @return boolean
+	 */
+	public static function onArticleFromTitle( &$title, &$article ) {
+		if ( $title->getDBkey() == 'Not_a_valid_Wikia' ) {
+			$article = new self( $title );
+		}
+
+		return true;
+	}
+
+	public function view() {
+		global $wgRequest, $wgOut;
+
+		$wgOut->setPageTitle( $this->getTitle()->getText() );
+
+		// Construct the search query from the from param
+		// (which is the domain we're redirected from)
+		$fromDomain = $wgRequest->getVal( 'from' );
+
+		// Extract the interesting part from the domain
+		$interestingPart = preg_replace(
+			'/^(www\.)?(.*)(\.org|\.com|\.gov|\.net|\.edu|\.co|\.or)?(\.[a-z]+)$/',
+			'\2',
+			$fromDomain
+		);
+
+		// Replace any non-alpha part with space
+		$searchQuery = trim( preg_replace( '/[\W ]+/', ' ', $interestingPart ) );
+
+		// Pass to the message
+		$wgOut->addWikiMsg( 'not-a-valid-wikia', $searchQuery );
+	}
+}

--- a/extensions/wikia/NotAValidWikia/NotAValidWikiaHooks.class.php
+++ b/extensions/wikia/NotAValidWikia/NotAValidWikiaHooks.class.php
@@ -1,0 +1,16 @@
+<?php
+
+class NotAValidWikiaHooks {
+	/**
+	 * @param Title $title
+	 * @param Article $article
+	 * @return boolean
+	 */
+	public static function onArticleFromTitle( &$title, &$article ) {
+		if ( $title instanceof Title && $title->getDBkey() == 'Not_a_valid_Wikia' ) {
+			$article = new NotAValidWikiaArticle( $title );
+		}
+
+		return true;
+	}
+}

--- a/extensions/wikia/NotAValidWikia/NotAValidWikiaHooks.class.php
+++ b/extensions/wikia/NotAValidWikia/NotAValidWikiaHooks.class.php
@@ -7,7 +7,7 @@ class NotAValidWikiaHooks {
 	 * @return boolean
 	 */
 	public static function onArticleFromTitle( &$title, &$article ) {
-		if ( $title instanceof Title && $title->getDBkey() == 'Not_a_valid_Wikia' ) {
+		if ( $title instanceof Title && $title->getDBkey() === 'Not_a_valid_Wikia' ) {
 			$article = new NotAValidWikiaArticle( $title );
 		}
 

--- a/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
+++ b/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
@@ -450,14 +450,15 @@ class WikiFactoryLoader {
 		if( empty( $this->mWikiID ) || $this->mIsWikiaActive == -1 ) {
 			if( ! $this->mCommandLine ) {
 				global $wgNotAValidWikia;
-				$this->debug( "redirected to {$wgNotAValidWikia}, {$this->mWikiID} {$this->mIsWikiaActive}" );
+				$redirect = $wgNotAValidWikia . '?from=' . rawurlencode( $this->mServerName );
+				$this->debug( "redirected to {$redirect}, {$this->mWikiID} {$this->mIsWikiaActive}" );
 				if( $this->mIsWikiaActive < 0 ) {
 					header( "X-Redirected-By-WF: MarkedForClosing" );
 				}
 				else {
 					header( "X-Redirected-By-WF: NotAValidWikia" );
 				}
-				header("Location: $wgNotAValidWikia");
+				header( "Location: $redirect" );
 				wfProfileOut( __METHOD__ );
 				exit(0);
 			}
@@ -479,7 +480,7 @@ class WikiFactoryLoader {
 					);
 				}
 				else {
-					$redirect = $wgNotAValidWikia;
+					$redirect = $wgNotAValidWikia . '?from=' . rawurlencode( $this->mServerName );
 				}
 				$this->debug( "disabled and not commandline, redirected to {$redirect}, {$this->mWikiID} {$this->mIsWikiaActive}" );
 				header( "X-Redirected-By-WF: Dump" );


### PR DESCRIPTION
Building a custom handler for the article.

We'll enable NotAValidWikia extension on community and the code will
take it from there.

The content of the page remains a message. I'm using another label
though to allow easy transition between old and new. The old version
uses 'not_a_valid_Wikia' message, the new uses 'not-a-valid-wikia'
message (dashes and all lowercase).

There's no need for translations as of now, because you're always taken
to the English community anyway (we may want to support different
languages based on a guess from the domain name or user browser setting).

The ?from param is used to construct the query for the search page.
We're removing the last part from the domain plus optionally the second
last part if it's one of org, com, co, and similar ones. We're dropping
the leading "www" too.

The page will need to be removed from community, so the correct (404)
HTTP status is returned.
