### PR TITLE
ChatUserTest: fix the unit tests

### DIFF
--- a/extensions/wikia/Chat2/tests/ChatUserTest.php
+++ b/extensions/wikia/Chat2/tests/ChatUserTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class ChatUserText extends WikiaBaseTest {
+class ChatUserTest extends WikiaBaseTest {
 
 	const MOCK_USER_ID = 142;
 	const MOCK_WIKI_ID = 189;

--- a/extensions/wikia/Chat2/tests/ChatUserTest.php
+++ b/extensions/wikia/Chat2/tests/ChatUserTest.php
@@ -33,9 +33,7 @@ class ChatUserText extends WikiaBaseTest {
 	}
 
 	private function mockDatabaseRow( $result ) {
-		$databaseMock = $this->getMockBuilder( 'Database' )
-			->disableOriginalConstructor()
-			->getMock();
+		$databaseMock = $this->getDatabaseMock(['selectRow']);
 
 		$databaseMock
 			->expects( $result !== null ? $this->once() : $this->never() )


### PR DESCRIPTION
```
08:31:43 Running 'ChatUserText'...
08:31:43 Fatal error: Call to undefined method Mock_Database_204d7f89::selectRow() in /var/lib/jenkins/workspace/phpUnit_trunkUnit/app/extensions/wikia/Chat2/ChatUser.class.php on line 151
```

Relates to #10303 - `Database` class was removed.

@Wikia/sustaining-engineering-team 
