### PR TITLE
WikiaSpecialVersion: fix " Non-static method should not be called statically

### DIFF
--- a/extensions/wikia/SpecialVersion/WikiaSpecialVersionController.class.php
+++ b/extensions/wikia/SpecialVersion/WikiaSpecialVersionController.class.php
@@ -30,18 +30,18 @@ class WikiaSpecialVersionController extends WikiaSpecialPageController {
 		$this->specialPage->setHeaders();
 
 		$softwareListPrepped = array();
-		foreach ( $this->version->getSoftwareList() as $key => $val ) {
+		foreach ( WikiaSpecialVersion::getSoftwareList() as $key => $val ) {
 			$softwareListPrepped[$this->wg->Parser->parse( $key, $title, $popts )->getText()] = $this->wg->Parser->parse( $val, $title, $popts )->getText();
 		}
 
-		$this->setVal( 'copyRightAndAuthorList', $this->wg->Parser->parse( $this->version->getCopyrightAndAuthorList(), $title, $popts )->getText() );
-		$this->setVal( 'softwareInformation', $this->wg->Parser->parse( $this->version->softwareInformation(), $title, $popts )->getText() );
+		$this->setVal( 'copyRightAndAuthorList', $this->wg->Parser->parse( WikiaSpecialVersion::getCopyrightAndAuthorList(), $title, $popts )->getText() );
+		$this->setVal( 'softwareInformation', $this->wg->Parser->parse( WikiaSpecialVersion::softwareInformation(), $title, $popts )->getText() );
 		$this->setVal( 'extensionCredit', $this->wg->Parser->parse( $this->version->getExtensionCredits(), $title, $popts )->getText() );
 		$this->setVal( 'ip', str_replace( '--', ' - ', htmlspecialchars( $this->getContext()->getRequest()->getIP() ) ) );
 		$this->setVal( 'wikiaCodeMessage', wfMessage( 'wikia-version-code' )->escaped() );
-		$this->setVal( 'wikiaCodeVersion', $this->version->getWikiaCodeVersion() );
+		$this->setVal( 'wikiaCodeVersion', WikiaSpecialVersion::getWikiaCodeVersion() );
 		$this->setVal( 'wikiaConfigMessage', wfMessage( 'wikia-version-config' )->escaped() );
-		$this->setVal( 'wikiaConfigVersion', $this->version->getWikiaConfigVersion() );
+		$this->setVal( 'wikiaConfigVersion', WikiaSpecialVersion::getWikiaConfigVersion() );
 		$this->setVal( 'versionLicenseMessage', wfMessage( 'version-license' )->escaped() );
 		$this->setVal( 'versionLicenseInfoMessage', wfMessage( 'version-license-info' )->parse() );
 		$this->setVal( 'versionSoftwareMessage', wfMessage( 'version-software' )->escaped() );


### PR DESCRIPTION
```
Deprecated: Non-static method WikiaSpecialVersion::getGitBranch() should not be called statically in /usr/wikia/source/app/extensions/wikia/SpecialVersion/WikiaSpecialVersion.class.php on line 34
```

@harnash 
