### PR TITLE
SOC-2386 | Fix duplicated comments

### DIFF
--- a/extensions/wikia/ArticleComments/classes/ArticleCommentsAjax.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleCommentsAjax.class.php
@@ -196,8 +196,6 @@ class ArticleCommentsAjax {
 			'parentId' => $parentId,
 		] );
 
-		$response = ArticleComment::doPost( self::getConvertedContent( $wgRequest->getVal( 'wpArticleComment' ) ), $wgUser, $title, $parentId );
-
 		if ( $response === false ) {
 			return $result;
 		}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SOC-2386

remove duplicated `ArticleComment::doPost()` line
