### PR TITLE
Get rid of magic_quotes

### DIFF
--- a/lib/vendor/Mail2/mime.php
+++ b/lib/vendor/Mail2/mime.php
@@ -474,14 +474,7 @@ class Mail_mime
             return $this->_raiseError('File is not readable: ' . $file_name);
         }
 
-        // Temporarily reset magic_quotes_runtime and read file contents
-        if ($magic_quote_setting = get_magic_quotes_runtime()) {
-            @ini_set('magic_quotes_runtime', 0);
-        }
         $cont = file_get_contents($file_name);
-        if ($magic_quote_setting) {
-            @ini_set('magic_quotes_runtime', $magic_quote_setting);
-        }
 
         return $cont;
     }
@@ -761,11 +754,6 @@ class Mail_mime
             return $this->_raiseError('File is not writable: ' . $filename);
         }
 
-        // Temporarily reset magic_quotes_runtime and read file contents
-        if ($magic_quote_setting = get_magic_quotes_runtime()) {
-            @ini_set('magic_quotes_runtime', 0);
-        }
-
         if (!($fh = fopen($filename, 'ab'))) {
             return $this->_raiseError('Unable to open file: ' . $filename);
         }
@@ -777,10 +765,6 @@ class Mail_mime
         }
 
         fclose($fh);
-
-        if ($magic_quote_setting) {
-            @ini_set('magic_quotes_runtime', $magic_quote_setting);
-        }
 
         // Write the rest of the message into file
         $res = $this->get($params, $filename);
@@ -804,11 +788,6 @@ class Mail_mime
         // Check state of file and raise an error properly
         if (file_exists($filename) && !is_writable($filename)) {
             return $this->_raiseError('File is not writable: ' . $filename);
-        }
-
-        // Temporarily reset magic_quotes_runtime and read file contents
-        if ($magic_quote_setting = get_magic_quotes_runtime()) {
-            @ini_set('magic_quotes_runtime', 0);
         }
 
         if (!($fh = fopen($filename, 'ab'))) {

--- a/lib/vendor/Mail2/mimePart.php
+++ b/lib/vendor/Mail2/mimePart.php
@@ -329,14 +329,7 @@ class Mail_mimePart
         } else if ($this->_body) {
             $encoded['body'] = $this->_getEncodedData($this->_body, $this->_encoding);
         } else if ($this->_body_file) {
-            // Temporarily reset magic_quotes_runtime for file reads and writes
-            if ($magic_quote_setting = get_magic_quotes_runtime()) {
-                @ini_set('magic_quotes_runtime', 0);
-            }
             $body = $this->_getEncodedDataFromFile($this->_body_file, $this->_encoding);
-            if ($magic_quote_setting) {
-                @ini_set('magic_quotes_runtime', $magic_quote_setting);
-            }
 
             if ($this->_isError($body)) {
                 return $body;
@@ -377,18 +370,9 @@ class Mail_mimePart
             return $err;
         }
 
-        // Temporarily reset magic_quotes_runtime for file reads and writes
-        if ($magic_quote_setting = get_magic_quotes_runtime()) {
-            @ini_set('magic_quotes_runtime', 0);
-        }
-
         $res = $this->_encodePartToFile($fh, $boundary, $skip_head);
 
         fclose($fh);
-
-        if ($magic_quote_setting) {
-            @ini_set('magic_quotes_runtime', $magic_quote_setting);
-        }
 
         return $this->_isError($res) ? $res : $this->_headers;
     }

--- a/lib/vendor/PEAR/Registry.php
+++ b/lib/vendor/PEAR/Registry.php
@@ -995,8 +995,7 @@ class PEAR_Registry extends PEAR
         if ($fp === null) {
             return null;
         }
-        $rt = get_magic_quotes_runtime();
-        set_magic_quotes_runtime(0);
+
         clearstatcache();
         if (function_exists('file_get_contents')) {
             $this->_closePackageFile($fp);
@@ -1005,7 +1004,6 @@ class PEAR_Registry extends PEAR
             $data = fread($fp, filesize($this->_packageFileName($package, $channel)));
             $this->_closePackageFile($fp);
         }
-        set_magic_quotes_runtime($rt);
         $data = unserialize($data);
         if ($key === null) {
             return $data;
@@ -1037,8 +1035,6 @@ class PEAR_Registry extends PEAR
         if ($fp === null) {
             return null;
         }
-        $rt = get_magic_quotes_runtime();
-        set_magic_quotes_runtime(0);
         clearstatcache();
         if (function_exists('file_get_contents')) {
             $this->_closeChannelFile($fp);
@@ -1047,7 +1043,6 @@ class PEAR_Registry extends PEAR
             $data = fread($fp, filesize($this->_channelFileName($channel)));
             $this->_closeChannelFile($fp);
         }
-        set_magic_quotes_runtime($rt);
         $data = unserialize($data);
         return $data;
     }


### PR DESCRIPTION
[PLATFORM-2154](https://wikia-inc.atlassian.net/browse/PLATFORM-2154)
- `set_magic_quotes_runtime` - this function was DEPRECATED in PHP 5.3.0, and REMOVED as of PHP 7.0.0.
- `magic_quotes_runtime` - this feature has been DEPRECATED as of PHP 5.3.0 and REMOVED as of PHP 5.4.0.

@harnash 
