### PR TITLE
Chat: fix a notice introduced in #10243

### DIFF
--- a/extensions/wikia/Chat2/Chat.class.php
+++ b/extensions/wikia/Chat2/Chat.class.php
@@ -185,7 +185,7 @@ class Chat {
 	protected static function getTimeLabel( $time ) {
 		global $wgContLang;
 
-		return $wgContLang->formatTimePeriod( $time . [ 'noabbrevs' => true ] );
+		return $wgContLang->formatTimePeriod( $time , [ 'noabbrevs' => true ] );
 	}
 
 	private static function getUserNamesFromIds( $userIds ) {


### PR DESCRIPTION
`Notice: Array to string conversion in /extensions/wikia/Chat2/Chat.class.php on line 188`

@Wikia/sustaining-engineering-team 
