### PR TITLE
CE-3697 Prepare a Japanese version of the experiment

### DIFF
--- a/extensions/wikia/PotentialMemberPageExperiments/Hooks.class.php
+++ b/extensions/wikia/PotentialMemberPageExperiments/Hooks.class.php
@@ -22,7 +22,8 @@ class Hooks extends \ContextSource {
 
 		return !$user->isLoggedIn() &&
 			$title->inNamespace( NS_MAIN ) &&
-			$title->getPageLanguage()->getCode() === 'en' && // getPageLanguage returns wgContLang for NS_MAIN pages
+			// Title::getPageLanguage() returns wgContLang for NS_MAIN pages
+			in_array( $title->getPageLanguage()->getCode(), [ 'en', 'ja' ] ) &&
 			!$title->isMainPage() &&
 			$this->getRequest()->getVal( 'action', 'view' ) === 'view';
 	}

--- a/extensions/wikia/PotentialMemberPageExperiments/PotentialMemberPageExperiments.i18n.php
+++ b/extensions/wikia/PotentialMemberPageExperiments/PotentialMemberPageExperiments.i18n.php
@@ -24,7 +24,7 @@ $messages['qqq'] = [
  * Japanese - ja
  */
 $messages['ja'] = [
-	'pmp-entry-point-message' => 'このコミュニティはあなたのようなファンによって創られています。',
+	'pmp-entry-point-message' => 'このコミュニティは<strong>あなたのようなファンによって創られています</strong>。',
 	'pmp-entry-point-button' => 'コミュニティを助ける',
 	'pmp-entry-point-button-url' => 'http://ja.community.wikia.com/wiki/%E5%88%9D%E3%82%81%E3%81%A6%E3%81%AE%E6%8A%95%E7%A8%BF%E3%82%92%E3%81%99%E3%82%8B',
 ];

--- a/extensions/wikia/PotentialMemberPageExperiments/PotentialMemberPageExperiments.i18n.php
+++ b/extensions/wikia/PotentialMemberPageExperiments/PotentialMemberPageExperiments.i18n.php
@@ -1,0 +1,30 @@
+<?php
+
+$messages = [];
+
+/**
+ * English - en
+ */
+$messages['en'] = [
+	'pmp-entry-point-message' => 'This wiki is <strong>built by</strong> fans like <strong>you</strong>',
+	'pmp-entry-point-button' => 'Help out',
+	'pmp-entry-point-button-url' => 'http://community.wikia.com/wiki/Tips_on_Getting_Started',
+];
+
+/**
+ * Documentation - qqq
+ */
+$messages['qqq'] = [
+	'pmp-entry-point-message' => 'A message shown next to an entry point to the Potential Member Page.',
+	'pmp-entry-point-button' => 'Text of the button being an entry point to the Potential Member Page',
+	'pmp-entry-point-button-url' => 'A URL of the Potential Member Page',
+];
+
+/**
+ * Japanese - ja
+ */
+$messages['ja'] = [
+	'pmp-entry-point-message' => 'このコミュニティはあなたのようなファンによって創られています。',
+	'pmp-entry-point-button' => 'コミュニティを助ける',
+	'pmp-entry-point-button-url' => 'http://ja.community.wikia.com/wiki/%E5%88%9D%E3%82%81%E3%81%A6%E3%81%AE%E6%8A%95%E7%A8%BF%E3%82%92%E3%81%99%E3%82%8B',
+];

--- a/extensions/wikia/PotentialMemberPageExperiments/PotentialMemberPageExperiments.setup.php
+++ b/extensions/wikia/PotentialMemberPageExperiments/PotentialMemberPageExperiments.setup.php
@@ -5,3 +5,12 @@
  */
 $wgAutoloadClasses['Wikia\PotentialMemberPageExperiments\Hooks'] = __DIR__ . '/Hooks.class.php';
 $wgExtensionFunctions[] = 'Wikia\PotentialMemberPageExperiments\Hooks::register';
+
+/**
+ * Messages
+ */
+$wgExtensionMessagesFiles['PotentialMemberPageExperiment'] = __DIR__ . '/PotentialMemberPageExperiments.i18n.php';
+
+JSMessages::registerPackage( 'PotentialMemberPageEntryPoint', [
+	'pmp-entry-point-*'
+] );

--- a/extensions/wikia/PotentialMemberPageExperiments/scripts/entry-point-experiment.js
+++ b/extensions/wikia/PotentialMemberPageExperiments/scripts/entry-point-experiment.js
@@ -12,8 +12,13 @@ require([
 	var $banner,
 		bannerBottomOffset,
 		bannerOffset,
+		contentLanguage = mw.config.get('wgContentLanguage'),
 		dismissCookieName = 'pmp-entry-point-dismissed',
-		experimentGroup = abTest.getGroup('POTENTIAL_MEMBER_PAGE_ENTRY_POINTS'),
+		experimentGroup, // To be set based on contentLanguage
+		experimentNames = {
+			en: 'POTENTIAL_MEMBER_PAGE_ENTRY_POINTS',
+			ja: 'POTENTIAL_MEMBER_PAGE_ENTRY_POINTS_JA'
+		},
 		experiments = {
 			TOP: {
 				type: 'top',
@@ -50,15 +55,22 @@ require([
 				}
 			}
 		},
-		track = tracker.buildTrackingFunction({
-			category: 'potential-member-experiment',
-			trackingMethod: 'analytics'
-		}),
+		track,
 		viewabilityCounter = 0,
 		viewabilityInterval;
 
 	function init() {
-		if ($.cookie(dismissCookieName) || !experimentEnabled()) {
+		if ($.cookie(dismissCookieName) || !experimentNames.hasOwnProperty(contentLanguage)) {
+			return;
+		}
+
+		experimentGroup = abTest.getGroup(experimentNames[contentLanguage]);
+		track = tracker.buildTrackingFunction({
+			category: 'potential-member-page-experiment-' + contentLanguage,
+			trackingMethod: 'analytics'
+		});
+
+		if (!experimentEnabled()) {
 			return;
 		}
 
@@ -66,6 +78,7 @@ require([
 			loader({
 				type: loader.MULTI,
 				resources: {
+					messages: 'PotentialMemberPageEntryPoint',
 					mustache: '/extensions/wikia/PotentialMemberPageExperiments/templates/PMPEntryPoint.mustache',
 					styles: '/extensions/wikia/PotentialMemberPageExperiments/styles/entry-point-experiment.scss'
 				}
@@ -74,15 +87,26 @@ require([
 	}
 
 	function experimentEnabled() {
+		experimentGroup = abTest.getGroup(experimentNames[contentLanguage]);
 		return experiments.hasOwnProperty(experimentGroup);
 	}
 
 	function setupExperiment(resources) {
-		var experiment = experiments[experimentGroup];
+		var experiment = experiments[experimentGroup],
+			templateData;
 
 		loader.processStyle(resources.styles);
+		mw.messages.set(resources.messages);
 
-		$banner = $(mustache.render(resources.mustache[0], { bannerType: experiment.type }))
+		templateData = {
+			bannerType: experiment.type,
+			language: contentLanguage,
+			messageText: mw.message('pmp-entry-point-message').plain(),
+			buttonText: mw.message('pmp-entry-point-button').escaped(),
+			buttonUrl: mw.message('pmp-entry-point-button-url').plain()
+		};
+
+		$banner = $(mustache.render(resources.mustache[0], templateData))
 			.on('mousedown touchstart', '.pmp-entry-point-button', onEntryPointClick)
 			.on('click', '.pmp-entry-point-close', close);
 

--- a/extensions/wikia/PotentialMemberPageExperiments/scripts/entry-point-experiment.js
+++ b/extensions/wikia/PotentialMemberPageExperiments/scripts/entry-point-experiment.js
@@ -87,7 +87,6 @@ require([
 	}
 
 	function experimentEnabled() {
-		experimentGroup = abTest.getGroup(experimentNames[contentLanguage]);
 		return experiments.hasOwnProperty(experimentGroup);
 	}
 
@@ -102,7 +101,7 @@ require([
 			bannerType: experiment.type,
 			language: contentLanguage,
 			messageText: mw.message('pmp-entry-point-message').plain(),
-			buttonText: mw.message('pmp-entry-point-button').escaped(),
+			buttonText: mw.message('pmp-entry-point-button').plain(),
 			buttonUrl: mw.message('pmp-entry-point-button-url').plain()
 		};
 

--- a/extensions/wikia/PotentialMemberPageExperiments/styles/entry-point-experiment.scss
+++ b/extensions/wikia/PotentialMemberPageExperiments/styles/entry-point-experiment.scss
@@ -67,7 +67,9 @@ $close-button-background: $close-dark-icon;
 
 	&:hover {
 		background: $color-blue-darken;
+		color: $color-white;
 		text-decoration: none;
+		text-shadow: none;
 	}
 }
 
@@ -133,6 +135,19 @@ $close-button-background: $close-dark-icon;
 			padding-top: 16px;
 			width: 122px;
 		}
+
+		&.pmp-entry-point-ja {
+			p.pmp-entry-point-message {
+				font-size: 36px;
+				line-height: 48px;
+				padding-top: 65px;
+				width: 575px;
+			}
+
+			.pmp-entry-point-button {
+				width: 140px;
+			}
+		}
 	}
 }
 
@@ -145,6 +160,13 @@ $close-button-background: $close-dark-icon;
 		p.pmp-entry-point-message {
 			padding-top: 50px;
 			width: 270px;
+		}
+
+		&.pmp-entry-point-ja {
+			p.pmp-entry-point-message {
+				font-size: 20px;
+				width: 320px;
+			}
 		}
 	}
 }

--- a/extensions/wikia/PotentialMemberPageExperiments/templates/PMPEntryPoint.mustache
+++ b/extensions/wikia/PotentialMemberPageExperiments/templates/PMPEntryPoint.mustache
@@ -1,7 +1,7 @@
-<div class="pmp-entry-point pmp-entry-point-{{bannerType}}">
+<div class="pmp-entry-point pmp-entry-point-{{bannerType}} pmp-entry-point-{{language}}">
     <span class="pmp-entry-point-close"></span>
-    <p class="pmp-entry-point-message">This wiki is <strong>built by</strong> fans like <strong>you</strong></p>
+    <p class="pmp-entry-point-message">{{{messageText}}}</p>
     <div>
-        <a href="http://community.wikia.com/wiki/Tips_on_Getting_Started" class="pmp-entry-point-button">Help out</a>
+        <a href="{{buttonUrl}}" class="pmp-entry-point-button">{{buttonText}}</a>
     </div>
 </div>


### PR DESCRIPTION
### Links
- https://wikia-inc.atlassian.net/browse/CE-3697
### Description

This PR prepares the Potential Member Page Entry Points experiment to be run in different languages. A new experiment for Japanese has been created.

It's ready to be run on one GA slot by including a language code in the tracking category: `potential-member-page-experiment-{langCode}`.
### Reviewers

@Wikia/spitfires 
