### PR TITLE
RECIRC-18: Filter Fandom by relevant vertical

### DIFF
--- a/extensions/wikia/Recirculation/RecirculationApiController.class.php
+++ b/extensions/wikia/Recirculation/RecirculationApiController.class.php
@@ -1,7 +1,7 @@
 <?php
 
 class RecirculationApiController extends WikiaApiController {
-	const ALLOWED_TYPES = ['popular', 'shares', 'recent_popular'];
+	const ALLOWED_TYPES = ['popular', 'shares', 'recent_popular', 'vertical', 'community'];
 
 	public function getFandomPosts() {
 		$type = $this->request->getVal( 'type' );

--- a/extensions/wikia/Recirculation/js/experiments/placement.js
+++ b/extensions/wikia/Recirculation/js/experiments/placement.js
@@ -98,6 +98,20 @@ require([
 			helper = fandomHelper();
 			view = footerView();
 			break;
+		case 'FANDOM_GENRE':
+			helper = fandomHelper({
+				type: 'vertical'
+			});
+			view = railView();
+			isRail = true;
+			break;
+		case 'FANDOM_TOPIC':
+			helper = fandomHelper({
+				type: 'community'
+			});
+			view = railView();
+			isRail = true;
+			break;
 		case 'LINKS_RAIL':
 			helper = contentLinksHelper();
 			view = railView();

--- a/extensions/wikia/Recirculation/js/helpers/FandomHelper.js
+++ b/extensions/wikia/Recirculation/js/helpers/FandomHelper.js
@@ -6,7 +6,8 @@ define('ext.wikia.recirculation.helpers.fandom', [
 	'wikia.mustache'
 ], function ($, abTest, nirvana, Mustache) {
 	var options = {
-		limit: 3
+		limit: 3,
+		type: 'recent_popular'
 	};
 
 	function loadData() {
@@ -18,10 +19,15 @@ define('ext.wikia.recirculation.helpers.fandom', [
 			format: 'json',
 			type: 'get',
 			data: {
-				type: 'recent_popular'
+				type: options.type
 			},
 			callback: function(data) {
-				deferred.resolve(formatData(data));
+				data = formatData(data);
+				if (data.items && data.items.length >= options.limit ) {
+					deferred.resolve(data);
+				} else {
+					deferred.reject('Recirculation widget not shown - Not enough items returned from Fandom API');
+				}
 			}
 		});
 


### PR DESCRIPTION
Currently using hard coded tag map arrays for the experiment. If the variation performs well we will want to update this to something more manageable.
