### PR TITLE
PLATFORM-2125: WikiaLocalFileShared::__get - add an assert

### DIFF
--- a/includes/filerepo/file/File.php
+++ b/includes/filerepo/file/File.php
@@ -80,6 +80,9 @@ abstract class File implements UrlGeneratorInterface {
 
 	var $lastError, $redirected, $redirectedTitle;
 
+	/** @var Title */
+	protected $redirectTitle;
+
 	/**
 	 * @var FSFile|false
 	 */


### PR DESCRIPTION
[PLATFORM-2125](https://wikia-inc.atlassian.net/browse/PLATFORM-2125)

Add `redirectTitle` field to `File` class and get rid of `PHP Notice: Undefined property: WikiaLocalFileShared::$redirectTitle in /extensions/wikia/VideoHandlers/filerepo/WikiaForeignDBFile.class.php on line 64`

This backports https://github.com/wikimedia/mediawiki/commit/68f50015c77bc1db7387e2c8c3633972d0c252af partially

@wladekb 
