### PR TITLE
JPN-432 Fix issue where modal tab could get stuck in 'loading' state

### DIFF
--- a/extensions/wikia/CommunityPage/scripts/ext.communityPage.js
+++ b/extensions/wikia/CommunityPage/scripts/ext.communityPage.js
@@ -143,10 +143,6 @@ require([
 	}
 
 	function switchCommunityModalTab(tabToActivate) {
-		if (tabToActivate === activeTab) {
-			return;
-		}
-
 		getModalNavHtml().then(function (navHtml) {
 			// Switch highlight to new tab
 			var loading = mustache.render(templates.modalLoadingScreen, {


### PR DESCRIPTION
Deleted redundant leftover code from before modal loading refactor.

This caused a bug where the tab would be stuck in loading state when invoking the modal a second time.
