### PR TITLE
XW-1368 | Remove /api/mercury from purged URLs

### DIFF
--- a/extensions/wikia/MercuryApi/MercuryApiHooks.class.php
+++ b/extensions/wikia/MercuryApi/MercuryApiHooks.class.php
@@ -110,17 +110,17 @@ class MercuryApiHooks {
 		WikiaDataAccess::cachePurge( MercuryApiMainPageHandler::curatedContentDataMemcKey() );
 
 		foreach ( $sections as $section ) {
-			if ( !empty( $section['featured'] ) ) {
+			$sectionLabel = $section['label'];
+
+			if ( empty( $sectionLabel ) || !empty( $section['featured'] ) ) {
 				continue;
 			}
 
-			$sectionTitle = $section['title'];
-
-			WikiaDataAccess::cachePurge( MercuryApiMainPageHandler::curatedContentDataMemcKey( $sectionTitle ) );
+			WikiaDataAccess::cachePurge( MercuryApiMainPageHandler::curatedContentDataMemcKey( $sectionLabel ) );
 
 			// Request from browser to MediaWiki
-			$encodedTitle = self::encodeURIQueryParam( $sectionTitle );
-			$urls[] = MercuryApiController::getUrl( 'getCuratedContentSection', [ 'section' => $encodedTitle ] );
+			$encodedTitle = self::encodeURIQueryParam( $sectionLabel );
+			$urls[] = MercuryApiController::getUrl( 'getCuratedContentSection' ) . '&section=' . $encodedTitle;
 		}
 
 		( new SquidUpdate( array_unique( $urls ) ) )->doUpdate();


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/XW-1368

Since https://github.com/Wikia/mercury/pull/2363 we no longer call `/api/mercury` URLs, instead we use MediaWiki's `/wikia.php` directly. No need to purge those old URLs.

/cc @Wikia/x-wing 
