### PR TITLE
SwiftSync: ignore id when moving rows from image_sync to image_sync_done

### DIFF
--- a/extensions/wikia/SwiftSync/classes/Queue.class.php
+++ b/extensions/wikia/SwiftSync/classes/Queue.class.php
@@ -203,15 +203,15 @@ class Queue {
 		}
 		
 		$dbw = self::getDB( true );
-		$dbw->begin();
-		$query = "INSERT INTO %s (id, city_id, img_action, img_src, img_dest, img_added, img_sync, img_error) ";
-		$query .= "SELECT id, city_id, img_action, img_src, img_dest, img_added, img_sync, %s FROM %s WHERE id = %d ";
-		$dbw->query( 
+		$dbw->begin( __METHOD__ );
+		$query = "INSERT INTO %s (city_id, img_action, img_src, img_dest, img_added, img_sync, img_error) ";
+		$query .= "SELECT city_id, img_action, img_src, img_dest, img_added, img_sync, %s FROM %s WHERE id = %d ";
+		$dbw->query(
 			sprintf( $query, self::getArchTable(), $this->error, self::getTable(), $this->id ),
 			__METHOD__ 
 		);
 		$dbw->delete( self::getTable(), [ 'id' => $this->id ], __METHOD__ );
-		$dbw->commit();
+		$dbw->commit( __METHOD__ );
 		
 		wfProfileOut( __METHOD__ );
 		return true;

--- a/extensions/wikia/SwiftSync/sql/swift_sync.sql
+++ b/extensions/wikia/SwiftSync/sql/swift_sync.sql
@@ -11,7 +11,7 @@ CREATE TABLE `image_sync` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 CREATE TABLE `image_sync_done` (
-	  `id` int(8) unsigned NOT NULL,
+	  `id` int(8) NOT NULL AUTO_INCREMENT
 	  `city_id` int(8) unsigned NOT NULL,
 	  `img_action` varchar(32) NOT NULL,
 	  `img_src` blob,

--- a/maintenance/wikia/sql/swift_sync-schema.sql
+++ b/maintenance/wikia/sql/swift_sync-schema.sql
@@ -43,7 +43,7 @@ DROP TABLE IF EXISTS `image_sync_done`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `image_sync_done` (
-  `id` int(8) unsigned NOT NULL,
+  `id` int(8) NOT NULL AUTO_INCREMENT
   `city_id` int(8) unsigned NOT NULL,
   `img_action` varchar(32) NOT NULL,
   `img_src` blob,


### PR DESCRIPTION
`auto_increment` for `image_sync` is initialized to 1 on mysql restart causing `Error: 1062 Duplicate entry '1' for key 'PRIMARY'` when moving rows from `image_sync` to `image_sync_done` table - https://dev.mysql.com/doc/refman/5.6/en/innodb-auto-increment-handling.html#innodb-auto-increment-initialization

``` sql
mysql@master.db-statsdb.service.consul[swift_sync]>ALTER TABLE image_sync_done MODIFY COLUMN id INT(8) auto_increment;
Query OK, 43299987 rows affected (8 min 50.95 sec)
Records: 43299987  Duplicates: 0  Warnings: 0
```

@mixth-sense / @drozdo 
