### PR TITLE
Lyr 262

### DIFF
--- a/extensions/3rdparty/LyricWiki/Special_ArtistRedirects.body.php
+++ b/extensions/3rdparty/LyricWiki/Special_ArtistRedirects.body.php
@@ -49,13 +49,13 @@ class ArtistRedirects extends SpecialPage
 				ob_start();
 
 				$dbr = wfGetDB( DB_SLAVE );
-				$numRedirs = $dbr->selectField("page",
-					'COUNT(*) as numRedirs',
+				$numRedirs = $dbr->selectField(
+					"page",
+					"COUNT(*) as numRedirs",
 					[
 						"page_is_redirect" => 1,
-						"page-title NOT LIKE '%:%'"
-					]
-				),__METHOD__);
+						"page_title NOT LIKE '%:%'"
+					], __METHOD__);
 
 				print "View results by pages:\n";
 				print "<ul>\n";

--- a/extensions/3rdparty/LyricWiki/Special_ArtistRedirects.body.php
+++ b/extensions/3rdparty/LyricWiki/Special_ArtistRedirects.body.php
@@ -22,8 +22,6 @@ class ArtistRedirects extends SpecialPage
 	function wfArtistRedirects(){
 		global $wgOut;
 
-		$tablePrefix = "";
-
 		$wgOut->setPageTitle("Artist Redirects");
 
 		$msg = "";
@@ -50,8 +48,14 @@ class ArtistRedirects extends SpecialPage
 			if(!$content){
 				ob_start();
 
-				$queryString = "SELECT COUNT(*) as numRedirs FROM $tablePrefix"."page WHERE page_is_redirect=1 AND page_title NOT LIKE '%:%'";
-				$numRedirs = lw_simpleQuery($queryString);
+				$dbr = wfGetDB( DB_SLAVE );
+				$numRedirs = $dbr->selectField("page",
+					'COUNT(*) as numRedirs',
+					[
+						"page_is_redirect" => 1,
+						"page-title NOT LIKE '%:%'"
+					]
+				),__METHOD__);
 
 				print "View results by pages:\n";
 				print "<ul>\n";

--- a/extensions/3rdparty/LyricWiki/Special_LinksToRedirects.php
+++ b/extensions/3rdparty/LyricWiki/Special_LinksToRedirects.php
@@ -176,8 +176,15 @@ class Linkstoredirects extends SpecialPage{
 					);
 					$idToTitle = array();
 					$ids = array_unique($ids);
-					$queryString = "SELECT page_id, page_namespace, page_title FROM $TABLE_PREFIX"."page WHERE page_id IN (".implode(",", $ids).")";
-					$res2 = $dbr->query($queryString);
+
+					$res2 = $dbr->select(
+						"page",
+						array( "page_id",
+							   "page_namespace",
+							   "page_title"),
+						"page_id IN (".implode(",", $ids).")",
+						__METHOD__
+					);
 					while ($innerRow = $dbr->fetchObject($res2)) {
 						$id = $innerRow->page_id;
 						$ns = $innerRow->page_namespace;

--- a/extensions/3rdparty/LyricWiki/Special_LinksToRedirects.php
+++ b/extensions/3rdparty/LyricWiki/Special_LinksToRedirects.php
@@ -184,7 +184,9 @@ class Linkstoredirects extends SpecialPage{
 							"page_namespace",
 							"page_title"
 						],
-						"page_id" => $ids,
+						[
+							"page_id" => $ids,
+						]
 						__METHOD__
 					);
 					while ($innerRow = $dbr->fetchObject($res2)) {

--- a/extensions/3rdparty/LyricWiki/Special_LinksToRedirects.php
+++ b/extensions/3rdparty/LyricWiki/Special_LinksToRedirects.php
@@ -184,7 +184,7 @@ class Linkstoredirects extends SpecialPage{
 							"page_namespace",
 							"page_title"
 						],
-						"page_id IN (".implode(",", $ids).")",
+						"page_id" => $ids,
 						__METHOD__
 					);
 					while ($innerRow = $dbr->fetchObject($res2)) {

--- a/extensions/3rdparty/LyricWiki/Special_LinksToRedirects.php
+++ b/extensions/3rdparty/LyricWiki/Special_LinksToRedirects.php
@@ -179,9 +179,11 @@ class Linkstoredirects extends SpecialPage{
 
 					$res2 = $dbr->select(
 						"page",
-						array( "page_id",
-							   "page_namespace",
-							   "page_title"),
+						[
+							"page_id",
+							"page_namespace",
+							"page_title"
+						],
 						"page_id IN (".implode(",", $ids).")",
 						__METHOD__
 					);

--- a/extensions/3rdparty/LyricWiki/Special_LinksToRedirects.php
+++ b/extensions/3rdparty/LyricWiki/Special_LinksToRedirects.php
@@ -143,7 +143,7 @@ class Linkstoredirects extends SpecialPage{
 				while ($row = $dbr->fetchObject($res)) {
 					$totalResults++;
 					$pageId = $row->from_id;
-					$target = $row->links_to;3
+					$target = $row->links_to;
 					$allListings[] = array($pageId, $target);
 
 					// Somehow, a blank from_id can slip into the results (which messes up the query).

--- a/extensions/3rdparty/LyricWiki/Special_LinksToRedirects.php
+++ b/extensions/3rdparty/LyricWiki/Special_LinksToRedirects.php
@@ -48,8 +48,7 @@ class Linkstoredirects extends SpecialPage{
 		$CACHE_KEY = "LW_LINKS_TO_REDIRECTS";
 
 		$wgOut->setPageTitle(wfMsg('linkstoredirects'));
-
-	/*
+/*
 		// This processes any requested for removal of an item from the list.
 		if(isset($_GET['artist']) && isset($_GET['song'])){
 
@@ -88,10 +87,10 @@ class Linkstoredirects extends SpecialPage{
 				$db = &wfGetDB(DB_SLAVE)->getProperty('mConn');
 
 				print "Deleting record... ";
-				if(mysql_query("DELETE FROM lw_soap_failures WHERE request_artist='$artist' AND request_song='$song'", $db)){
+				if(mysqli_query("DELETE FROM lw_soap_failures WHERE request_artist='$artist' AND request_song='$song'", $db)){
 					print "Deleted.";
 				} else {
-					print "Failed. ".mysql_error();
+					print "Failed. ".mysqli_error($db);
 				}
 				print "<br/>Clearing the cache... ";
 				$wgMemc->delete($CACHE_KEY); // purge the entry from memcached
@@ -103,7 +102,7 @@ class Linkstoredirects extends SpecialPage{
 			print "<br/>Back to <a href='/Special:Soapfailures'>SOAP Failures</a>\n";
 			exit; // wiki system throws database-connection errors if the page is allowed to display itself.
 		} else {
-	*/
+*/
 			$msg = "";
 
 			// Allow the cache to be manually cleared.
@@ -117,8 +116,6 @@ class Linkstoredirects extends SpecialPage{
 			$content = $wgMemc->get($CACHE_KEY);
 			if(!$content){
 				ob_start();
-
-				$db = &wfGetDB(DB_SLAVE)->getProperty('mConn');
 
 				print "This page shows a list of pages which link to redirects (and which redirects they are linking to). ";
 				print "When possible, it is best to fix the source link to go directly to the page which the redirect would ";
@@ -139,106 +136,104 @@ class Linkstoredirects extends SpecialPage{
 								WHERE page_namespace=0 AND page_is_redirect=1 AND (pl.pl_title IS NOT NULL or tl_title IS NOT NULL) LIMIT $LIMIT";
 				$ids = array();
 				$allListings = array();
-				if($result = mysql_query($queryString,$db)){
-					if(($numRows = mysql_num_rows($result)) && ($numRows > 0)){
-						$totalResults = $numRows; // stored because numRows will get overwritten by the next query.
-						for($cnt=0; $cnt<$numRows; $cnt++){
-							$pageId = mysql_result($result, $cnt, "from_id");
-							$target = mysql_result($result, $cnt, "links_to");
-							$allListings[] = array($pageId, $target);
+				
+				$dbr = wfGetDB( DB_SLAVE );
+				$res = $dbr->query($queryString);
+				$totalResults = 0;
+				while ($row = $dbr->fetchObject($res)) {
+					$totalResults++;
+					$pageId = $row->from_id;
+					$target = $row->links_to;3
+					$allListings[] = array($pageId, $target);
 
-							// Somehow, a blank from_id can slip into the results (which messes up the query).
-							if($pageId != ""){
-								$ids[] = $pageId; // will uniquify later
-							}
-						}
-
-						// Find the page titles of all of the source pages by id (uniquify the id array).
-						GLOBAL $wgSitename;
-						$nsMapping = array(
-										1 => "Talk",
-										2 => "User",
-										3 => "User_talk",
-										4 => $wgSitename,
-										5 => $wgSitename."_talk",
-										6 => ":File",
-										7 => "File_talk",
-										8 => "MediaWiki",
-										9 => "MediaWiki_talk",
-										10 => ":Template",
-										11 => "Template_talk",
-										12 => "Help",
-										13 => "Help_talk",
-										14 => ":Category",
-										15 => "Category_talk"
-									);
-						$idToTitle = array();
-						$ids = array_unique($ids);
-						$queryString = "SELECT page_id, page_namespace, page_title FROM $TABLE_PREFIX"."page WHERE page_id IN (".implode(",", $ids).")";
-						if($result = mysql_query($queryString,$db)){
-							if(($numRows = mysql_num_rows($result)) && ($numRows > 0)){
-								for($cnt=0; $cnt<$numRows; $cnt++){
-									$id = mysql_result($result, $cnt, "page_id");
-									$ns = mysql_result($result, $cnt, "page_namespace");
-									$title = mysql_result($result, $cnt, "page_title");
-
-									if(isset($nsMapping[$ns])){
-										$title = $nsMapping[$ns].":$title";
-									}
-
-									$idToTitle[$id] = $title;
-								}
-							}
-						}
-
-						$missing = "";
-						print "The following source pages link to redirects:<br/>\n";
-						print "<table>\n";
-						print "<tr><th nowrap='nowrap'>Source Page</th><th>Redirect Page</th></tr>\n";
-						$index = 0;
-						foreach($allListings as $pair){
-							$fromId = $pair[0];
-							$to = $pair[1];
-
-							if(isset($idToTitle[$fromId])){
-								$from = $idToTitle[$fromId];
-
-								print "<tr".((($index % 2)==0)?"":" class='odd'")."><td>[[$from]]</td><td>[[$to]]</td></tr>\n";
-
-	/*
-		// TODO: IMPLEMENT THIS IF WE WANT TO LET SINGLE ITEMS BE CLEARED
-								$delim = "&amp;";
-								$prefix = "";
-
-								// If the short-url is in the REQUEST_URI, make sure to add the index.php?title= prefix to it.
-								if(strpos($REQUEST_URI, "index.php?title=") === false){
-									$prefix = "/index.php?title=";
-
-									// If we're adding the index.php ourselves, but the request still started with a slash, remove it because that would break the request if it came after the "title="
-									if(substr($REQUEST_URI,0,1) == "/"){
-										$REQUEST_URI = substr($REQUEST_URI, 1);
-									}
-								}
-								print "	- (report as [{{SERVER}}$prefix$REQUEST_URI$delim"."artist=".urlencode($artist)."&amp;song=".urlencode($song)." fixed])";
-								print "</td></tr>";
-	*/
-							} else {
-								$missing .= "Could not find the page_title for id $fromId which linked to <strong>[[$to]]</strong>.  Try [[Special:WhatLinksHere/$to]] instead.<br/>\n";
-							}
-							$index++;
-						}
-						print "</table><br/>\n";
-						print "$missing<br/>\n";
-						if($totalResults < $LIMIT){
-							print "There are <strong>$totalResults </strong> links to redirects left on the site.  They are all listed above.";
-						} else {
-							print "There are <strong>$totalResults </strong> links to redirects on this page but we set a limit of $LIMIT, so there are probably more.<br/>\n";
-						}
-					} else {
-						print "<em>No more links to redirects found. <strong>(Yay!)</strong></em>\n";
+					// Somehow, a blank from_id can slip into the results (which messes up the query).
+					if($pageId != ""){
+						$ids[] = $pageId; // will uniquify later
 					}
 				}
 
+				if($totalResults == 0){
+					print "<em>No more links to redirects found. <strong>(Yay!)</strong></em>\n";
+				} else {
+					// Find the page titles of all of the source pages by id (uniquify the id array).
+					GLOBAL $wgSitename;
+					$nsMapping = array(
+						1 => "Talk",
+						2 => "User",
+						3 => "User_talk",
+						4 => $wgSitename,
+						5 => $wgSitename."_talk",
+						6 => ":File",
+						7 => "File_talk",
+						8 => "MediaWiki",
+						9 => "MediaWiki_talk",
+						10 => ":Template",
+						11 => "Template_talk",
+						12 => "Help",
+						13 => "Help_talk",
+						14 => ":Category",
+						15 => "Category_talk"
+					);
+					$idToTitle = array();
+					$ids = array_unique($ids);
+					$queryString = "SELECT page_id, page_namespace, page_title FROM $TABLE_PREFIX"."page WHERE page_id IN (".implode(",", $ids).")";
+					$res2 = $dbr->query($queryString);
+					while ($innerRow = $dbr->fetchObject($res2)) {
+						$id = $innerRow->page_id;
+						$ns = $innerRow->page_namespace;
+						$title = $innerRow->page_title;
+
+						if(isset($nsMapping[$ns])){
+							$title = $nsMapping[$ns].":$title";
+						}
+
+						$idToTitle[$id] = $title;
+					}
+
+					$missing = "";
+					print "The following source pages link to redirects:<br/>\n";
+					print "<table>\n";
+					print "<tr><th nowrap='nowrap'>Source Page</th><th>Redirect Page</th></tr>\n";
+					$index = 0;
+					foreach($allListings as $pair){
+						$fromId = $pair[0];
+						$to = $pair[1];
+
+						if(isset($idToTitle[$fromId])){
+							$from = $idToTitle[$fromId];
+
+							print "<tr".((($index % 2)==0)?"":" class='odd'")."><td>[[$from]]</td><td>[[$to]]</td></tr>\n";
+
+							/*
+							// TODO: IMPLEMENT THIS IF WE WANT TO LET SINGLE ITEMS BE CLEARED
+							$delim = "&amp;";
+							$prefix = "";
+
+							// If the short-url is in the REQUEST_URI, make sure to add the index.php?title= prefix to it.
+							if(strpos($REQUEST_URI, "index.php?title=") === false){
+								$prefix = "/index.php?title=";
+
+								// If we're adding the index.php ourselves, but the request still started with a slash, remove it because that would break the request if it came after the "title="
+								if(substr($REQUEST_URI,0,1) == "/"){
+									$REQUEST_URI = substr($REQUEST_URI, 1);
+								}
+							}
+							print "	- (report as [{{SERVER}}$prefix$REQUEST_URI$delim"."artist=".urlencode($artist)."&amp;song=".urlencode($song)." fixed])";
+							print "</td></tr>";
+							*/
+						} else {
+							$missing .= "Could not find the page_title for id $fromId which linked to <strong>[[$to]]</strong>.  Try [[Special:WhatLinksHere/$to]] instead.<br/>\n";
+						}
+						$index++;
+					}
+					print "</table><br/>\n";
+					print "$missing<br/>\n";
+					if($totalResults < $LIMIT){
+						print "There are <strong>$totalResults </strong> links to redirects left on the site.  They are all listed above.";
+					} else {
+						print "There are <strong>$totalResults </strong> links to redirects on this page but we set a limit of $LIMIT, so there are probably more.<br/>\n";
+					}
+				}
 
 				$content = ob_get_clean();
 				$wgMemc->set($CACHE_KEY, $content, strtotime("+2 hour"));

--- a/extensions/3rdparty/LyricWiki/Special_MobileSearches.php
+++ b/extensions/3rdparty/LyricWiki/Special_MobileSearches.php
@@ -3,7 +3,17 @@
  * Author: Sean Colombo
  * Date: 20110305 - copied from Special:Soapfailures
  *
- * TODO: Make this and Special:Soapfailures use the same code (the only difference needed is the table-name and possibly the i18n strings).
+ * Extends the same SearchFailuresPage defined in Special_SoapFailures.
+ *
+ * This specifically shows the failed requests that come from the old
+ * LyricWiki mobile app. Since that app hasn't been updated in several
+ * years, the usage is dropping off. The main difference bewteen this
+ * and Special_SoapFailures is that these requests were typed by humans
+ * or decent music apps on phones, so the hit rate was really high, that
+ * these were good, correct titles, to real songs that we were missing.
+ * With the high signal/noise ratio, this let us find new songs very quickly
+ * and get them on the site before they were popular, so that we'd be ready
+ * when that happened.
  */
 
 if(!defined('MEDIAWIKI')) die();
@@ -20,264 +30,16 @@ $wgExtensionMessagesFiles['SpecialMobileSearches'] = dirname(__FILE__).'/Special
 require_once($IP . '/includes/SpecialPage.php');
 $wgSpecialPages['MobileSearches'] = 'MobileSearches';
 
-class MobileSearches extends SpecialPage{
+class MobileSearches extends SearchFailuresPage{
 
 	public function __construct(){
 		parent::__construct('MobileSearches');
+
+		global $wgScriptPath;
+		$this->PAGE_URL = "$wgScriptPath/Special:MobileSearches";
+		$this->CACHE_KEY_PREFIX = "LW_SOAP_FAILURES_MOBILE";
+		$this->TABLE_NAME = "lw_soap_failures_mobile";
+		$this->I18N_PREFIX = "mobilesearches";
+		$this->API_TYPE = LW_API_TYPE_MOBILE;
 	}
-
-	/**
-	 *
-	 * @param $par String subpage string, if one was specified
-	 */
-	function execute( $par ){
-		global $wgOut;
-		global $wgRequest, $wgUser, $wgMemc;
-
-		$MAX_RESULTS = 100;
-		$CACHE_KEY_PREFIX = "LW_SOAP_FAILURES_MOBILE";
-		$CACHE_KEY_DATA = wfMemcKey($CACHE_KEY_PREFIX, "data");
-		$CACHE_KEY_TIME = wfMemcKey($CACHE_KEY_PREFIX, "cachedOn");
-		$CACHE_KEY_STATS = wfMemcKey($CACHE_KEY_PREFIX, "stats");
-		$TABLE_NAME = "lw_soap_failures_mobile";
-		$wgOut->setPageTitle(wfMsg('mobilesearches'));
-
-		// This processes any requested for removal of an item from the list.
-		if(isset($_POST['artist']) && isset($_POST['song'])){
-			$artist = $_POST['artist'];
-			$song = $_POST['song'];
-			$songResult = array();
-			$failedLyrics = "Not found";
-
-			/*
-			GLOBAL $IP;
-			define('LYRICWIKI_SOAP_FUNCS_ONLY', true); // so that we can use the SOAP functions but not actually instantiate a SOAP server & process a request.
-			include_once 'server.php'; // the SOAP functions
-
-			$songResult = getSong($artist, $song);*/
-
-			// Pull in the NuSOAP code
-			$dir = dirname(__FILE__) . '/';
-			require_once($dir . 'nusoap.php');
-			// Create the client instance
-			$wsdlUrl = 'http://'.$_SERVER['SERVER_NAME'].'/server.php?wsdl&1';
-
-			// PLATFORM-1743
-			global $wgHTTPProxy;
-			list($PROXY_HOST, $PROXY_PORT) = explode(':', $wgHTTPProxy);
-
-			$client = new nusoapclient($wsdlUrl, true, $PROXY_HOST, $PROXY_PORT);
-			$err = $client->getError();
-			if ($err) {
-				echo '<h2>Constructor error</h2><pre>' . $err . '</pre>';
-			} else {
-				// Create the proxy
-				$proxy = $client->getProxy();
-				GLOBAL $LW_USERNAME,$LW_PASSWORD;
-				if(($LW_USERNAME != "") || ($LW_PASSWORD != "")){
-					$headers = "<username>$LW_USERNAME</username><password>$LW_PASSWORD</password>\n";
-					$proxy->setHeaders($headers);
-				}
-				$songResult = $proxy->getSongResult($artist, $song);
-			}
-
-			if(($songResult['lyrics'] == $failedLyrics) || ($songResult['lyrics'] == "")){
-				print "<html><head><title>Error</title></head><body>\n"; // TODO: i18n
-				print "<div style='background-color:#fcc'>Sorry, but $artist:$song song still failed.</div>\n";
-				print_r($songResult);
-			} else {
-				$artist = str_replace("'", "\\'", $artist);
-				$song = str_replace("'", "\\'", $song);
-
-				print "<html><head><title>Success</title></head><body>\n"; // TODO: i18n
-				print "Deleting record... ";
-				$dbw = &wfGetDB(DB_MASTER);
-				$dbw->delete( $TABLE_NAME,
-							array(
-								'request_artist' => $artist,
-								'request_song' => $song,
-							),
-							__METHOD__
-				);
-
-				print "<br/>Clearing the cache... ";
-
-				$wgMemc->delete($CACHE_KEY_DATA); // purge the entry from memcached
-				$wgMemc->delete($CACHE_KEY_TIME);
-				$wgMemc->delete($CACHE_KEY_STATS);
-
-				print "<div style='background-color:#cfc'>The song was retrieved successfully and ";
-				print "was removed from the failed requests list.";
-				print "</div>\n";
-			}
-			global $wgScriptPath;
-			print "<br/>Back to <a href='$wgScriptPath/Special:MobileSearches'>SOAP Failures</a>\n";
-			print "</body></html>";
-			exit; // wiki system throws database-connection errors if the page is allowed to display itself.
-		} else {
-			$wgOut->addHTML("<style type='text/css'>
-				table.mobilesearches{
-					border-collapse:collapse;
-				}
-				.mobilesearches tr.odd{background-color:#eef}
-				.mobilesearches td, .mobilesearches th{
-					border:1px solid;
-					cell-padding:0px;
-					cell-spacing:0px;
-					vertical-align:top;
-					padding:5px;
-				}</style>\n");
-
-			// Allow the cache to be manually cleared.
-			$msg = "";
-			if(isset($_GET['cache']) && $_GET['cache']=="clear"){
-				$msg.= "Forced clearing of the cache...\n";
-				$wgMemc->delete($CACHE_KEY_DATA); // purge the entry from memcached
-				$wgMemc->delete($CACHE_KEY_TIME);
-				$wgMemc->delete($CACHE_KEY_STATS);
-				unset($_GET['cache']);
-				$_SERVER['REQUEST_URI'] = str_replace("?cache=clear", "", $_SERVER['REQUEST_URI']);
-				$_SERVER['REQUEST_URI'] = str_replace("&cache=clear", "", $_SERVER['REQUEST_URI']);
-			}
-
-			$msg = ($msg==""?"":"<pre>$msg</pre>");
-			$wgOut->addWikiText($msg);
-
-			// Form for clearing a fixed song.
-			$wgOut->addHTML(wfMsg('mobilesearches-mark-as-fixed') . "
-							<form method='post'>
-								".wfMsg('mobilesearches-artist')." <input type='text' name='artist'/><br/>
-								".wfMsg('mobilesearches-song')." <input type='text' name='song'/><br/>
-								<input type='submit' name='fixed' value='".wfMsg('mobilesearches-fixed')."'/>
-							</form><br/>");
-
-			$data = $wgMemc->get($CACHE_KEY_DATA);
-			$cachedOn = $wgMemc->get($CACHE_KEY_TIME);
-			$statsHtml = $wgMemc->get($CACHE_KEY_STATS);
-			if(!$data){
-				$db = &wfGetDB(DB_SLAVE)->getProperty('mConn');
-				$queryString = "SELECT * FROM $TABLE_NAME ORDER BY numRequests DESC LIMIT $MAX_RESULTS";
-				if($result = mysql_query($queryString,$db)){
-					$data = array();
-					if(($numRows = mysql_num_rows($result)) && ($numRows > 0)){
-						for($cnt=0; $cnt<$numRows; $cnt++){
-							$row = array();
-							$row['artist'] = mysql_result($result, $cnt, "request_artist");
-							$row['song'] = mysql_result($result, $cnt, "request_song");
-							$row['numRequests'] = mysql_result($result, $cnt, "numRequests");
-							$row['lookedFor'] = mysql_result($result, $cnt, "lookedFor");
-							$row['lookedFor'] = formatLookedFor($row['lookedFor']);
-							$data[] = $row;
-						}
-					}
-				} else {
-					$wgOut->addHTML("<br/><br/><strong>Error: with query</strong><br/><em>$queryString</em><br/><strong>Error message: </strong>".mysql_error($db));
-				}
-
-				$cachedOn = date('m/d/Y \a\t g:ia');
-			}
-
-			// Stats HTML is just an unimportant feature, hackily storing HTML instead of the data - FIXME: It's BAD to cache output rather than data.
-			if(!$statsHtml){
-				// Display some hit-rate stats.
-				ob_start();
-				include_once __DIR__ . "/soap_stats.php"; // for tracking success/failure
-				print "<br/><br/><br/>";
-				print "<em>".wfMsg('mobilesearches-stats-header')."</em><br/>\n";
-				print "<table border='1px' cellpadding='5px'>\n";
-				print "\t<tr><th>".wfMsg('mobilesearches-stats-timeperiod')."</th><th>".wfMsg('mobilesearches-stats-numfound')."</th><th>".wfMsg('mobilesearches-stats-numnotfound')."</th><th>&nbsp;</th></tr>\n";
-
-				$stats = lw_soapStats_getStats(LW_TERM_DAILY, "", LW_API_TYPE_MOBILE);
-				print "\t<tr><td>".wfMsg('mobilesearches-stats-period-today')."</td><td>{$stats[LW_API_FOUND]}</td><td>{$stats[LW_API_NOT_FOUND]}</td><td>{$stats[LW_API_PERCENT_FOUND]}%</td></tr>\n";
-
-				$stats = lw_soapStats_getStats(LW_TERM_WEEKLY, "", LW_API_TYPE_MOBILE);
-				print "\t<tr><td>".wfMsg('mobilesearches-stats-period-thisweek')."</td><td>{$stats[LW_API_FOUND]}</td><td>{$stats[LW_API_NOT_FOUND]}</td><td>{$stats[LW_API_PERCENT_FOUND]}%</td></tr>\n";
-
-				$stats = lw_soapStats_getStats(LW_TERM_MONTHLY, "", LW_API_TYPE_MOBILE);
-				print "\t<tr><td>".wfMsg('mobilesearches-stats-period-thismonth')."</td><td>{$stats[LW_API_FOUND]}</td><td>{$stats[LW_API_NOT_FOUND]}</td><td>{$stats[LW_API_PERCENT_FOUND]}%</td></tr>\n";
-				print "</table>\n";
-				$statsHtml = ob_get_clean();
-			}
-
-			if($data){
-				$wgOut->addWikiText(wfMsg('mobilesearches-intro'));
-
-				$wgOut->addHTML("This page is cached every 2 hours - \n"); // TODO: i18n
-				$wgOut->addHTML("last cached: <strong>$cachedOn</strong>\n"); // TODO: i18n
-				$totFailures = 0;
-				if(!empty($data)){
-					$wgOut->addHTML("<table class='mobilesearches'>\n");
-					$wgOut->addHTML("<tr><th nowrap='nowrap'>".wfMsg('mobilesearches-header-requests')."</th><th>".wfMsg('mobilesearches-header-artist')."</th><th>".wfMsg('mobilesearches-header-song')."</th><th>".wfMsg('mobilesearches-header-looked-for')."</th><th>".wfMsg('mobilesearches-header-fixed')."</th></tr>\n");
-					$REQUEST_URI = $_SERVER['REQUEST_URI'];
-					$rowIndex=0;
-					foreach($data as $row){
-						$artist = $row['artist'];
-						$song = $row['song'];
-						$numRequests = $row['numRequests'];
-						$lookedFor = $row['lookedFor'];
-						$totFailures += $numRequests;
-						$wgOut->addHTML(utf8_encode("<tr".((($rowIndex%2)!=0)?" class='odd'":"")."><td>$numRequests</td><td>"));
-						$wgOut->addWikiText("[[$artist]]");
-						$wgOut->addHTML("</td><td>");
-						$wgOut->addWikiText("[[$artist:$song|$song]]");
-						$delim = "&amp;";
-						$prefix = "";
-
-						// If the short-url is in the REQUEST_URI, make sure to add the index.php?title= prefix to it.
-						if(strpos($REQUEST_URI, "index.php?title=") === false){
-							$prefix = "/index.php?title=";
-
-							// If we're adding the index.php ourselves, but the request still started with a slash, remove it because that would break the request if it came after the "title="
-							if(substr($REQUEST_URI,0,1) == "/"){
-								$REQUEST_URI = substr($REQUEST_URI, 1);
-							}
-						}
-						$wgOut->addHTML("</td><td>");
-						$wgOut->addWikiText("$lookedFor");
-						$wgOut->addHTML("</td><td>");
-						$wgOut->addHTML("<form action='' method='POST' target='_blank'>
-								<input type='hidden' name='artist' value=\"$artist\"/>
-								<input type='hidden' name='song' value=\"$song\"/>
-								<input type='submit' name='fixed' value='".wfMsg('mobilesearches-fixed')."'/>
-							</form>\n");
-						$wgOut->addHTML("</td>");
-						$wgOut->addHTML("</tr>\n");
-
-						$rowIndex++;
-					}
-					$wgOut->addHTML("</table>\n");
-					$wgOut->addHTML("<br/>Total of <strong id='lw_numFailures'>$totFailures</strong> requests in the top $MAX_RESULTS.  This number will increase slightly over time, but we should fight to keep it as low as possible!");
-				} else {
-					$wgOut->addHTML("<em>No results found.</em>\n");
-				}
-
-				if(!empty($data)){
-					$TWO_HOURS_IN_SECONDS = (60*60*2);
-					$wgMemc->set($CACHE_KEY_TIME, $cachedOn, $TWO_HOURS_IN_SECONDS);
-					$wgMemc->set($CACHE_KEY_STATS, $statsHtml, $TWO_HOURS_IN_SECONDS);
-
-					// We use CACHE_KEY_DATA to determine when all of these keys have expired, so it should expire a few microseconds after the other two (that's why it's below the other set()s).
-					$wgMemc->set($CACHE_KEY_DATA, $data, $TWO_HOURS_IN_SECONDS);
-				}
-			}
-
-			$wgOut->addHTML($statsHtml);
-		}
-	} // end execute
 }
-
-/**
- * Given the string of lookedFor titles, formats them into wikitext with one title (as a link) per line.
-NOTE: THIS IS ALREADY IN Special:Soapfailures.  COMBINE THEM SOON!!
- function formatLookedFor($lookedFor){
-	$titles = array_unique(explode("\n", $lookedFor));
-	$lookedFor = "";
-	foreach($titles as $pageTitle){
-		if(trim($pageTitle) != ""){
-			$pageTitle = str_replace("_", " ", $pageTitle);
-			$lookedFor .= "[[$pageTitle]]<br/>";
-		}
-	}
-	return $lookedFor;
-} // end formatLookedFor()
-*/

--- a/extensions/3rdparty/LyricWiki/Special_Soapfailures.php
+++ b/extensions/3rdparty/LyricWiki/Special_Soapfailures.php
@@ -188,11 +188,16 @@ class SearchFailuresPage extends SpecialPage{
 			$cachedOn = $wgMemc->get($this->CACHE_KEY_TIME);
 			$statsHtml = $wgMemc->get($this->CACHE_KEY_STATS);
 			if(!$data){
-				$queryString = "SELECT * FROM {$this->TABLE_NAME} ORDER BY numRequests DESC LIMIT $MAX_RESULTS";
 				$data = array();
 				$dbr = wfGetDB( DB_SLAVE );
 				try{
-					$res = $dbr->query($queryString);
+					$res = $dbr->select(
+						$this->TABLE_NAME,
+						[ "request_artist", "request_song", "numRequests", "lookedFor" ],
+						"",
+						__METHOD__,
+						[ 'ORDER BY' => 'numRequests DESC', 'LIMIT' => $MAX_RESULTS ]
+					);
 					while ($resRow = $dbr->fetchObject($res)) {
 						$row = array();
 						$row['artist'] = $resRow->request_artist;
@@ -203,7 +208,7 @@ class SearchFailuresPage extends SpecialPage{
 						$data[] = $row;
 					}
 				} catch(MWException $ex){
-					$wgOut->addHTML("<br/><br/><strong>Error: with query</strong><br/><em>$queryString</em><br/><strong>Error message: </strong>".$ex->getHtml());
+					$wgOut->addHTML("<br/><br/><strong>Error getting requests in Soapfailures. Error message: </strong>".$ex->getHtml());
 				}
 
 				$cachedOn = date('m/d/Y \a\t g:ia');

--- a/extensions/3rdparty/LyricWiki/Special_Soapfailures.php
+++ b/extensions/3rdparty/LyricWiki/Special_Soapfailures.php
@@ -119,7 +119,7 @@ class SearchFailuresPage extends SpecialPage{
 
 				print "<html><head><title>Success</title></head><body>\n"; // TODO: i18n
 				print "Deleting record... ";
-				$dbw = &wfGetDB(DB_MASTER);
+				$dbw = wfGetDB(DB_MASTER);
 				$result = $dbw->delete(
 					$this->TABLE_NAME,
 					[

--- a/extensions/3rdparty/LyricWiki/Special_Soapfailures.php
+++ b/extensions/3rdparty/LyricWiki/Special_Soapfailures.php
@@ -218,7 +218,7 @@ class SearchFailuresPage extends SpecialPage{
 						$data[] = $row;
 					}
 				} catch(MWException $ex){
-					$wgOut->addHTML("<br/><br/><strong>Error: with query</strong><br/><em>$queryString</em><br/><strong>Error message: </strong>".$ex->getHtml();
+					$wgOut->addHTML("<br/><br/><strong>Error: with query</strong><br/><em>$queryString</em><br/><strong>Error message: </strong>".$ex->getHtml());
 				}
 
 				$cachedOn = date('m/d/Y \a\t g:ia');

--- a/extensions/3rdparty/LyricWiki/Special_Soapfailures.php
+++ b/extensions/3rdparty/LyricWiki/Special_Soapfailures.php
@@ -44,27 +44,12 @@ $wgExtensionMessagesFiles['SpecialSoapFailures'] = dirname(__FILE__).'/Special_S
 require_once($IP . '/includes/SpecialPage.php');
 $wgSpecialPages['Soapfailures'] = 'Soapfailures';
 
-class Soapfailures extends SearchFailuresPage{
-
-	public function __construct(){
-		parent::__construct('Soapfailures');
-
-		global $wgScriptPath;
-		$this->PAGE_URL = "$wgScriptPath/Special:Soapfailures";
-		$this->CACHE_KEY_PREFIX = "LW_SOAP_FAILURES";
-		$this->TABLE_NAME = "lw_soap_failures";
-		$this->I18N_PREFIX = "soapfailures";
-		$this->API_TYPE = LW_API_TYPE_WEB;
-	}
-}
-
-
 class SearchFailuresPage extends SpecialPage{
 
-	private $CACHE_KEY_PREFIX;
-	private $TABLE_NAME;
-	private $I18N_PREFIX;
-	private $API_TYPE;
+	protected $CACHE_KEY_PREFIX;
+	protected $TABLE_NAME;
+	protected $I18N_PREFIX;
+	protected $API_TYPE;
 
 	public function __construct($specialPageName){
 		parent::__construct($specialPageName);
@@ -136,7 +121,7 @@ class SearchFailuresPage extends SpecialPage{
 				print "Deleting record... ";
 				$dbw = &wfGetDB(DB_MASTER);
 				$result = $dbw->delete(
-					$TABLE_NAME,
+					$this->TABLE_NAME,
 					[
 						'request_artist' => $artist,
 						'request_song' => $song,
@@ -150,9 +135,9 @@ class SearchFailuresPage extends SpecialPage{
 				}
 				print "<br/>Clearing the cache... ";
 
-				$wgMemc->delete($CACHE_KEY_DATA); // purge the entry from memcached
-				$wgMemc->delete($CACHE_KEY_TIME);
-				$wgMemc->delete($CACHE_KEY_STATS);
+				$wgMemc->delete($this->CACHE_KEY_DATA); // purge the entry from memcached
+				$wgMemc->delete($this->CACHE_KEY_TIME);
+				$wgMemc->delete($this->CACHE_KEY_STATS);
 
 				print "<div style='background-color:#cfc'>The song was retrieved successfully and ";
 				print "was removed from the failed requests list.";
@@ -180,9 +165,9 @@ class SearchFailuresPage extends SpecialPage{
 			$msg = "";
 			if(isset($_GET['cache']) && $_GET['cache']=="clear"){
 				$msg.= "Forced clearing of the cache...\n";
-				$wgMemc->delete($CACHE_KEY_DATA); // purge the entry from memcached
-				$wgMemc->delete($CACHE_KEY_TIME);
-				$wgMemc->delete($CACHE_KEY_STATS);
+				$wgMemc->delete($this->CACHE_KEY_DATA); // purge the entry from memcached
+				$wgMemc->delete($this->CACHE_KEY_TIME);
+				$wgMemc->delete($this->CACHE_KEY_STATS);
 				unset($_GET['cache']);
 				$_SERVER['REQUEST_URI'] = str_replace("?cache=clear", "", $_SERVER['REQUEST_URI']);
 				$_SERVER['REQUEST_URI'] = str_replace("&cache=clear", "", $_SERVER['REQUEST_URI']);
@@ -199,11 +184,11 @@ class SearchFailuresPage extends SpecialPage{
 								<input type='submit' name='fixed' value='".wfMsg($this->I18N_PREFIX.'-fixed')."'/>
 							</form><br/>");
 
-			$data = $wgMemc->get($CACHE_KEY_DATA);
-			$cachedOn = $wgMemc->get($CACHE_KEY_TIME);
-			$statsHtml = $wgMemc->get($CACHE_KEY_STATS);
+			$data = $wgMemc->get($this->CACHE_KEY_DATA);
+			$cachedOn = $wgMemc->get($this->CACHE_KEY_TIME);
+			$statsHtml = $wgMemc->get($this->CACHE_KEY_STATS);
 			if(!$data){
-				$queryString = "SELECT * FROM $TABLE_NAME ORDER BY numRequests DESC LIMIT $MAX_RESULTS";
+				$queryString = "SELECT * FROM {$this->TABLE_NAME} ORDER BY numRequests DESC LIMIT $MAX_RESULTS";
 				$data = array();
 				$dbr = wfGetDB( DB_SLAVE );
 				try{
@@ -329,3 +314,17 @@ class SearchFailuresPage extends SpecialPage{
 } // end class SearchFailuresPage
 
 
+
+class Soapfailures extends SearchFailuresPage{
+
+	public function __construct(){
+		parent::__construct('Soapfailures');
+
+		global $wgScriptPath;
+		$this->PAGE_URL = "$wgScriptPath/Special:Soapfailures";
+		$this->CACHE_KEY_PREFIX = "LW_SOAP_FAILURES";
+		$this->TABLE_NAME = "lw_soap_failures";
+		$this->I18N_PREFIX = "soapfailures";
+		$this->API_TYPE = LW_API_TYPE_WEB;
+	}
+}

--- a/extensions/3rdparty/LyricWiki/Special_Soapfailures.php
+++ b/extensions/3rdparty/LyricWiki/Special_Soapfailures.php
@@ -218,7 +218,7 @@ class SearchFailuresPage extends SpecialPage{
 						$data[] = $row;
 					}
 				} catch(MWException $ex){
-					$wgOut->addHTML("<br/><br/><strong>Error: with query</strong><br/><em>$queryString</em><br/><strong>Error message: </strong>".print_r($ex,true));
+					$wgOut->addHTML("<br/><br/><strong>Error: with query</strong><br/><em>$queryString</em><br/><strong>Error message: </strong>".$ex->getHtml();
 				}
 
 				$cachedOn = date('m/d/Y \a\t g:ia');

--- a/extensions/3rdparty/LyricWiki/Special_Soapfailures.php
+++ b/extensions/3rdparty/LyricWiki/Special_Soapfailures.php
@@ -7,7 +7,8 @@
  * the LyricWiki SOAP.
  *
  * The structure of this special page was just copied from Teknomunk's
- * Batch Move special page.
+ * Batch Move special page, now it has been extracted to SearchFailuresPage which
+ * is shared by SoapFailures and MobileSearches.
  *
  *DROP TABLE IF EXISTS lw_soap_failures;
  *CREATE TABLE lw_soap_failures(
@@ -26,7 +27,7 @@
  *	PRIMARY KEY (request_artist, request_song)
  *);
  *
- * TODO: Make better use of Internationalization.  There are a bunch of hardcoded strings still.
+ * TODO: Make better use of Internationalization.  There are several hardcoded strings still.
  */
 
 if(!defined('MEDIAWIKI')) die();
@@ -43,10 +44,30 @@ $wgExtensionMessagesFiles['SpecialSoapFailures'] = dirname(__FILE__).'/Special_S
 require_once($IP . '/includes/SpecialPage.php');
 $wgSpecialPages['Soapfailures'] = 'Soapfailures';
 
-class Soapfailures extends SpecialPage{
+class Soapfailures extends SearchFailuresPage{
 
 	public function __construct(){
 		parent::__construct('Soapfailures');
+
+		global $wgScriptPath;
+		$this->PAGE_URL = "$wgScriptPath/Special:Soapfailures";
+		$this->CACHE_KEY_PREFIX = "LW_SOAP_FAILURES";
+		$this->TABLE_NAME = "lw_soap_failures";
+		$this->I18N_PREFIX = "soapfailures";
+		$this->API_TYPE = LW_API_TYPE_WEB;
+	}
+}
+
+
+class SearchFailuresPage extends SpecialPage{
+
+	private $CACHE_KEY_PREFIX;
+	private $TABLE_NAME;
+	private $I18N_PREFIX;
+	private $API_TYPE;
+
+	public function __construct($specialPageName){
+		parent::__construct($specialPageName);
 	}
 
 	/**
@@ -58,12 +79,11 @@ class Soapfailures extends SpecialPage{
 		global $wgRequest, $wgUser, $wgMemc;
 
 		$MAX_RESULTS = 100;
-		$CACHE_KEY_PREFIX = "LW_SOAP_FAILURES";
-		$CACHE_KEY_DATA = wfMemcKey($CACHE_KEY_PREFIX, "data");
-		$CACHE_KEY_TIME = wfMemcKey($CACHE_KEY_PREFIX, "cachedOn");
-		$CACHE_KEY_STATS = wfMemcKey($CACHE_KEY_PREFIX, "stats");
-
-		$wgOut->setPageTitle(wfMsg('soapfailures'));
+		
+		$CACHE_KEY_DATA = wfMemcKey($this->CACHE_KEY_PREFIX, "data");
+		$CACHE_KEY_TIME = wfMemcKey($this->CACHE_KEY_PREFIX, "cachedOn");
+		$CACHE_KEY_STATS = wfMemcKey($this->CACHE_KEY_PREFIX, "stats");
+		$wgOut->setPageTitle(wfMsg($this->I18N_PREFIX));
 
 		// This processes any requested for removal of an item from the list.
 		if(isset($_POST['artist']) && isset($_POST['song'])){
@@ -109,13 +129,14 @@ class Soapfailures extends SpecialPage{
 				print '<div style="background-color:#fcc">Sorry, but ' . htmlspecialchars( $artist ) . ':' . htmlspecialchars( $song ) . " song still failed.</div>\n";
 				print_r($songResult);
 			} else {
-				$dbw = wfGetDB( DB_MASTER );
+				$artist = str_replace("'", "\\'", $artist);
+				$song = str_replace("'", "\\'", $song);
 
 				print "<html><head><title>Success</title></head><body>\n"; // TODO: i18n
 				print "Deleting record... ";
-
+				$dbw = &wfGetDB(DB_MASTER);
 				$result = $dbw->delete(
-					'lw_soap_failures',
+					$TABLE_NAME,
 					[
 						'request_artist' => $artist,
 						'request_song' => $song,
@@ -125,7 +146,7 @@ class Soapfailures extends SpecialPage{
 				if ( $result ) {
 					print "Deleted.";
 				} else {
-					print "Failed. ".mysql_error();
+					print "Failed. ";
 				}
 				print "<br/>Clearing the cache... ";
 
@@ -138,16 +159,16 @@ class Soapfailures extends SpecialPage{
 				print "</div>\n";
 			}
 			global $wgScriptPath;
-			print "<br/>Back to <a href='$wgScriptPath/Special:Soapfailures'>SOAP Failures</a>\n";
+			print "<br/>Back to <a href='{$this->PAGE_URL}'>full list of search failures</a>\n"; // TODO: i18n
 			print "</body></html>";
 			exit; // wiki system throws database-connection errors if the page is allowed to display itself.
 		} else {
 			$wgOut->addHTML("<style type='text/css'>
-				table.soapfailures{
+				table.searchfailures{
 					border-collapse:collapse;
 				}
-				.soapfailures tr.odd{background-color:#eef}
-				.soapfailures td, .soapfailures th{
+				.searchfailures tr.odd{background-color:#eef}
+				.searchfailures td, .searchfailures th{
 					border:1px solid;
 					cell-padding:0px;
 					cell-spacing:0px;
@@ -171,34 +192,33 @@ class Soapfailures extends SpecialPage{
 			$wgOut->addWikiText($msg);
 
 			// Form for clearing a fixed song.
-			$wgOut->addHTML(wfMsg('soapfailures-mark-as-fixed') . "
+			$wgOut->addHTML(wfMsg($this->I18N_PREFIX.'-mark-as-fixed') . "
 							<form method='post'>
-								".wfMsg('soapfailures-artist')." <input type='text' name='artist'/><br/>
-								".wfMsg('soapfailures-song')." <input type='text' name='song'/><br/>
-								<input type='submit' name='fixed' value='".wfMsg('soapfailures-fixed')."'/>
+								".wfMsg($this->I18N_PREFIX.'-artist')." <input type='text' name='artist'/><br/>
+								".wfMsg($this->I18N_PREFIX.'-song')." <input type='text' name='song'/><br/>
+								<input type='submit' name='fixed' value='".wfMsg($this->I18N_PREFIX.'-fixed')."'/>
 							</form><br/>");
 
 			$data = $wgMemc->get($CACHE_KEY_DATA);
 			$cachedOn = $wgMemc->get($CACHE_KEY_TIME);
 			$statsHtml = $wgMemc->get($CACHE_KEY_STATS);
 			if(!$data){
-				$db = &wfGetDB(DB_SLAVE)->getProperty('mConn');
-				$queryString = "SELECT * FROM lw_soap_failures ORDER BY numRequests DESC LIMIT $MAX_RESULTS";
-				if($result = mysql_query($queryString,$db)){
-					$data = array();
-					if(($numRows = mysql_num_rows($result)) && ($numRows > 0)){
-						for($cnt=0; $cnt<$numRows; $cnt++){
-							$row = array();
-							$row['artist'] = mysql_result($result, $cnt, "request_artist");
-							$row['song'] = mysql_result($result, $cnt, "request_song");
-							$row['numRequests'] = mysql_result($result, $cnt, "numRequests");
-							$row['lookedFor'] = mysql_result($result, $cnt, "lookedFor");
-							$row['lookedFor'] = formatLookedFor($row['lookedFor']);
-							$data[] = $row;
-						}
+				$queryString = "SELECT * FROM $TABLE_NAME ORDER BY numRequests DESC LIMIT $MAX_RESULTS";
+				$data = array();
+				$dbr = wfGetDB( DB_SLAVE );
+				try{
+					$res = $dbr->query($queryString);
+					while ($resRow = $dbr->fetchObject($res)) {
+						$row = array();
+						$row['artist'] = $resRow->request_artist;
+						$row['song'] = $resRow->request_song;
+						$row['numRequests'] = $resRow->numRequests;
+						$row['lookedFor'] = $resRow->lookedFor;
+						$row['lookedFor'] = $this->formatLookedFor($row['lookedFor']);
+						$data[] = $row;
 					}
-				} else {
-					$wgOut->addHTML("<br/><br/><strong>Error: with query</strong><br/><em>$queryString</em><br/><strong>Error message: </strong>".mysql_error($db));
+				} catch(MWException $ex){
+					$wgOut->addHTML("<br/><br/><strong>Error: with query</strong><br/><em>$queryString</em><br/><strong>Error message: </strong>".print_r($ex,true));
 				}
 
 				$cachedOn = date('m/d/Y \a\t g:ia');
@@ -210,31 +230,31 @@ class Soapfailures extends SpecialPage{
 				ob_start();
 				include_once __DIR__ . "/soap_stats.php"; // for tracking success/failure
 				print "<br/><br/><br/>";
-				print "<em>".wfMsg('soapfailures-stats-header')."</em><br/>\n";
+				print "<em>".wfMsg($this->I18N_PREFIX.'-stats-header')."</em><br/>\n";
 				print "<table border='1px' cellpadding='5px'>\n";
-				print "\t<tr><th>".wfMsg('soapfailures-stats-timeperiod')."</th><th>".wfMsg('soapfailures-stats-numfound')."</th><th>".wfMsg('soapfailures-stats-numnotfound')."</th><th>&nbsp;</th></tr>\n";
+				print "\t<tr><th>".wfMsg($this->I18N_PREFIX.'-stats-timeperiod')."</th><th>".wfMsg($this->I18N_PREFIX.'-stats-numfound')."</th><th>".wfMsg($this->I18N_PREFIX.'-stats-numnotfound')."</th><th>&nbsp;</th></tr>\n";
 
-				$stats = lw_soapStats_getStats(LW_TERM_DAILY, "", LW_API_TYPE_WEB);
-				print "\t<tr><td>".wfMsg('soapfailures-stats-period-today')."</td><td>{$stats[LW_API_FOUND]}</td><td>{$stats[LW_API_NOT_FOUND]}</td><td>{$stats[LW_API_PERCENT_FOUND]}%</td></tr>\n";
+				$stats = lw_soapStats_getStats(LW_TERM_DAILY, "", $this->API_TYPE);
+				print "\t<tr><td>".wfMsg($this->I18N_PREFIX.'-stats-period-today')."</td><td>{$stats[LW_API_FOUND]}</td><td>{$stats[LW_API_NOT_FOUND]}</td><td>{$stats[LW_API_PERCENT_FOUND]}%</td></tr>\n";
 
-				$stats = lw_soapStats_getStats(LW_TERM_WEEKLY, "", LW_API_TYPE_WEB);
-				print "\t<tr><td>".wfMsg('soapfailures-stats-period-thisweek')."</td><td>{$stats[LW_API_FOUND]}</td><td>{$stats[LW_API_NOT_FOUND]}</td><td>{$stats[LW_API_PERCENT_FOUND]}%</td></tr>\n";
+				$stats = lw_soapStats_getStats(LW_TERM_WEEKLY, "", $this->API_TYPE);
+				print "\t<tr><td>".wfMsg($this->I18N_PREFIX.'-stats-period-thisweek')."</td><td>{$stats[LW_API_FOUND]}</td><td>{$stats[LW_API_NOT_FOUND]}</td><td>{$stats[LW_API_PERCENT_FOUND]}%</td></tr>\n";
 
-				$stats = lw_soapStats_getStats(LW_TERM_MONTHLY, "", LW_API_TYPE_WEB);
-				print "\t<tr><td>".wfMsg('soapfailures-stats-period-thismonth')."</td><td>{$stats[LW_API_FOUND]}</td><td>{$stats[LW_API_NOT_FOUND]}</td><td>{$stats[LW_API_PERCENT_FOUND]}%</td></tr>\n";
+				$stats = lw_soapStats_getStats(LW_TERM_MONTHLY, "", $this->API_TYPE);
+				print "\t<tr><td>".wfMsg($this->I18N_PREFIX.'-stats-period-thismonth')."</td><td>{$stats[LW_API_FOUND]}</td><td>{$stats[LW_API_NOT_FOUND]}</td><td>{$stats[LW_API_PERCENT_FOUND]}%</td></tr>\n";
 				print "</table>\n";
 				$statsHtml = ob_get_clean();
 			}
 
 			if($data){
-				$wgOut->addWikiText(wfMsg('soapfailures-intro'));
+				$wgOut->addWikiText(wfMsg($this->I18N_PREFIX.'-intro'));
 
 				$wgOut->addHTML("This page is cached every 2 hours - \n"); // TODO: i18n
 				$wgOut->addHTML("last cached: <strong>$cachedOn</strong>\n"); // TODO: i18n
 				$totFailures = 0;
 				if(!empty($data)){
-					$wgOut->addHTML("<table class='soapfailures'>\n");
-					$wgOut->addHTML("<tr><th nowrap='nowrap'>".wfMsg('soapfailures-header-requests')."</th><th>".wfMsg('soapfailures-header-artist')."</th><th>".wfMsg('soapfailures-header-song')."</th><th>".wfMsg('soapfailures-header-looked-for')."</th><th>".wfMsg('soapfailures-header-fixed')."</th></tr>\n");
+					$wgOut->addHTML("<table class='searchfailures'>\n");
+					$wgOut->addHTML("<tr><th nowrap='nowrap'>".wfMsg($this->I18N_PREFIX.'-header-requests')."</th><th>".wfMsg($this->I18N_PREFIX.'-header-artist')."</th><th>".wfMsg($this->I18N_PREFIX.'-header-song')."</th><th>".wfMsg($this->I18N_PREFIX.'-header-looked-for')."</th><th>".wfMsg($this->I18N_PREFIX.'-header-fixed')."</th></tr>\n");
 					$REQUEST_URI = $_SERVER['REQUEST_URI'];
 					$rowIndex=0;
 					foreach($data as $row){
@@ -265,7 +285,7 @@ class Soapfailures extends SpecialPage{
 						$wgOut->addHTML("<form action='' method='POST' target='_blank'>
 								<input type='hidden' name='artist' value=\"" . Sanitizer::encodeAttribute( $artist ) . "\"/>
 								<input type='hidden' name='song' value=\"" . Sanitizer::encodeAttribute( $song ) . "\"/>
-								<input type='submit' name='fixed' value=\"" . wfMessage( 'soapfailures-fixed' )->escaped() . "\"/>
+								<input type='submit' name='fixed' value=\"" . wfMessage( $this->I18N_PREFIX.'-fixed' )->escaped() . "\"/>
 							</form>\n");
 						$wgOut->addHTML("</td>");
 						$wgOut->addHTML("</tr>\n");
@@ -291,20 +311,21 @@ class Soapfailures extends SpecialPage{
 			$wgOut->addHTML($statsHtml);
 		}
 	} // end execute()
-}
 
-/**
- * Given the string of lookedFor titles, formats them into wikitext with one title (as a link) per line.
- */
-function formatLookedFor($lookedFor){
-	$titles = array_unique(explode("\n", $lookedFor));
-	$lookedFor = "";
-	foreach($titles as $pageTitle){
-		if(trim($pageTitle) != ""){
-			$pageTitle = str_replace("_", " ", $pageTitle);
-			$lookedFor .= "[[$pageTitle]]<br/>";
+	/**
+	 * Given the string of lookedFor titles, formats them into wikitext with one title (as a link) per line.
+	 */
+	function formatLookedFor($lookedFor){
+		$titles = array_unique(explode("\n", $lookedFor));
+		$lookedFor = "";
+		foreach($titles as $pageTitle){
+			if(trim($pageTitle) != ""){
+				$pageTitle = str_replace("_", " ", $pageTitle);
+				$lookedFor .= "[[$pageTitle]]<br/>";
+			}
 		}
-	}
-	return $lookedFor;
-} // end formatLookedFor()
+		return $lookedFor;
+	} // end formatLookedFor()
+} // end class SearchFailuresPage
+
 

--- a/extensions/3rdparty/LyricWiki/extras.php
+++ b/extensions/3rdparty/LyricWiki/extras.php
@@ -75,21 +75,3 @@ function sandboxParse($wikiText)
 	// give the result
 	return $result;
 }
-
-////
-// Sends a read-only mySQL query and assumes that there will be one result.
-// Returns that result if available, empty string otherwise.
-////
-function lw_simpleQuery($queryString){
-	$retVal = "";
-	$db = wfGetDB(DB_SLAVE)->getProperty('mConn');
-
-	// TODO: use Database class instead
-	if($result = mysql_query($queryString,$db)){
-		if(($numRows = mysql_num_rows($result)) && ($numRows > 0)){
-			$row = mysql_fetch_row($result);
-			$retVal = $row[0];
-		}
-	}
-	return $retVal;
-} // end lw_simpleQuery()

--- a/extensions/3rdparty/LyricWiki/lw_spiderableBadArtists.php
+++ b/extensions/3rdparty/LyricWiki/lw_spiderableBadArtists.php
@@ -44,8 +44,8 @@ function wfSpiderableBadArtists_outputPage(&$out, &$text){
 	if(isset($_GET['virtPage'])){
 		$subTitle = $out->getSubtitle();
 		$matches = array();
-		if(0 < preg_match("/Redirected from <a href=\"[^\"]+&amp;redirect=no\" title=\"([^\"]+)\"/i", $subTitle, $matches)){
-			$redirFrom = $matches[1];
+		if(0 < preg_match("/Redirected from <a href=\"[^\"]+(&amp;|\?)redirect=no\" title=\"([^\"]+)\"/i", $subTitle, $matches)){
+			$redirFrom = $matches[2];
 			if(false === strpos($redirFrom, ":")){
 				$redirFrom = str_replace(" ", "_", $redirFrom);
 				$redirFrom = urlencode($redirFrom);

--- a/extensions/3rdparty/LyricWiki/lw_spiderableBadArtists.php
+++ b/extensions/3rdparty/LyricWiki/lw_spiderableBadArtists.php
@@ -42,7 +42,7 @@ function wfSpiderableBadArtists_outputPage(&$out, &$text){
 
 	// For "virtual pages" that the spiders can index.
 	if(isset($_GET['virtPage'])){
-		$subTitle = $out->mSubtitle;
+		$subTitle = $out->getSubtitle();
 		$matches = array();
 		if(0 < preg_match("/Redirected from <a href=\"[^\"]+&amp;redirect=no\" title=\"([^\"]+)\"/i", $subTitle, $matches)){
 			$redirFrom = $matches[1];
@@ -51,8 +51,12 @@ function wfSpiderableBadArtists_outputPage(&$out, &$text){
 				$redirFrom = urlencode($redirFrom);
 				$from = $wgTitle->mUrlform;
 				if(strtolower($from) != strtolower($redirFrom)){
-					$text = str_replace("\"/$from", "\"/$redirFrom", $text);
-					$text = str_replace("\"$from", "\"$redirFrom", $text);
+					// Replaces just the links (taking into account wgArticlePath.
+					global $wgArticlePath;
+					$fromLink = str_replace("$1", $from, $wgArticlePath);
+					$toLink = str_replace("$1", $redirFrom, $wgArticlePath);
+					$text = str_replace("\"/$fromLink", "\"/$toLink", $text);
+					$text = str_replace("\"$fromLink", "\"$toLink", $text);
 				}
 			}
 		}

--- a/extensions/3rdparty/LyricWiki/server.php
+++ b/extensions/3rdparty/LyricWiki/server.php
@@ -2478,8 +2478,8 @@ function requestStarted($funcName, $requestData){
 		if(defined('TRACK_REQUEST_RUNTIMES') && TRACK_REQUEST_RUNTIMES) {
 			$requestData = str_replace("'", "[&apos;]", $requestData);
 			
-			$dbr = wfGetDB( DB_MASTER );
-			$dbr->insert(
+			$dbw = wfGetDB( DB_MASTER );
+			$dbw->insert(
 				'apiRequests',
 				[
 					"requestedThrough" => $REQUEST_TYPE,
@@ -2489,6 +2489,7 @@ function requestStarted($funcName, $requestData){
 				],
 				__METHOD__
 			);
+			$retVal = $dbw->insertId();
 		}
 	}
 	return $retVal;

--- a/extensions/3rdparty/LyricWiki/server.php
+++ b/extensions/3rdparty/LyricWiki/server.php
@@ -65,9 +65,10 @@ if(!$SHUT_DOWN_API){
 	}
 
 	if(!$funcsOnly){
-		if(!defined('MEDIAWIKI')){
-			define( 'MEDIAWIKI', true );
-		}
+		// This causes devbox to crash because WebStart will then re-define it. Not sure what changed in core MediaWiki.
+		// if(!defined('MEDIAWIKI')){
+		//	 define( 'MEDIAWIKI', true );
+		// }
 
 		require_once $LW_PATH."includes/Defines.php";
 

--- a/extensions/3rdparty/LyricWiki/server.php
+++ b/extensions/3rdparty/LyricWiki/server.php
@@ -2483,9 +2483,9 @@ function requestStarted($funcName, $requestData){
 				'apiRequests',
 				[
 					"requestedThrough" => $REQUEST_TYPE,
-					"requestedFunction" => $dbr->addQuotes(funcName),
-					"requestData" => $dbr->addQuotes(requestData),
-					"requestTime" => "NOW()",
+					"requestedFunction" => $funcName,
+					"requestData" => $requestData,
+					"requestTime" => $dbw->timestamp( wfTimestampNow() ),
 				],
 				__METHOD__
 			);


### PR DESCRIPTION
Modernized the LyricWiki extensions not to use mysql_ anywhere. There were some chunks of commented-out code I just swapped to mysqli_ (note the "i") but in general I switched them to using MediaWiki's database objects.

Also, extracted the common code from Soap search failures and Mobile search failures to share a base-class SearchFailuresSpecialPage so that the code only needs to be maintained in one spot.

Tested these on my devbox and all looks good. Strangely, in production with current code, no data shows up... the tables appear to be there in production dbs, so hopefully when we push, these updates will make some of this visible again.

In production, Special:LinksToRedirects and Special:ArtistRedirects have regressed to basically being blank and this is likely hurting SEO. Will be good to keep an eye on LW traffic a couple of weeks after this change to see if it results in an improvement.
