### PR TITLE
SOC-409 Fix failing unit test 

### DIFF
--- a/extensions/wikia/Email/tests/CategoryAddControllerTest.php
+++ b/extensions/wikia/Email/tests/CategoryAddControllerTest.php
@@ -46,7 +46,7 @@ class CategoryAddControllerTest extends WikiaBaseTest {
 			[ 'language', null, false, 'en' ]
 		];
 
-		$mockUser = $this->getMock( 'User', [ 'getEmail', 'getGlobalPreference', 'isBlocked' ] );
+		$mockUser = $this->getMock( 'User', [ 'getEmail', 'getGlobalPreference', 'isBlocked', 'isEmailConfirmed' ] );
 		$mockUser->expects( $this->any() )
 			->method( 'getEmail' )
 			->will( $this->returnValue( 'some.email@example.com' ) );
@@ -56,6 +56,9 @@ class CategoryAddControllerTest extends WikiaBaseTest {
 		$mockUser->expects( $this->any() )
 			->method( 'isBlocked' )
 			->will( $this->returnValue( false ) );
+		$mockUser->expects( $this->any() )
+			->method( 'isEmailConfirmed' )
+			->will( $this->returnValue( true ) );
 
 		$this->mockGlobalVariable( 'wgUser', $mockUser );
 	}

--- a/extensions/wikia/Email/tests/EmailIntegrationTest.php
+++ b/extensions/wikia/Email/tests/EmailIntegrationTest.php
@@ -12,6 +12,7 @@ class EmailIntegrationTest extends WikiaBaseTest {
 	function setUp() {
 		$this->setupFile = __DIR__ . '/../Email.setup.php';
 		parent::setUp();
+		require_once( __DIR__ . '/../../../../includes/HttpFunctions.php' );
 	}
 
 	/**


### PR DESCRIPTION
It seems like dev branch is failing after adding new condition to EmailController::assertCanEmail
https://github.com/Wikia/app/pull/10113

Also added require for HTTP class for integration test that is failing when running test only for email extension.

@Wikia/spitfires @kvas-damian @jsutterfield @armonr 
