### PR TITLE
XW-1429 | Move the first infobox to the top of article content

### DIFF
--- a/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php
+++ b/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php
@@ -394,6 +394,8 @@ class ArticleAsJson extends WikiaService {
 				self::linkifyMediaCaption( $parser, $media );
 			}
 
+			wfRunHooks( 'ArticleAsJsonBeforeEncode', [ &$text ] );
+
 			$text = json_encode(
 				[
 					'content' => $text,

--- a/extensions/wikia/PortableInfobox/PortableInfobox.setup.php
+++ b/extensions/wikia/PortableInfobox/PortableInfobox.setup.php
@@ -82,6 +82,7 @@ $wgHooks[ 'ArticlePurge' ][] = 'PortableInfoboxHooks::onArticlePurge';
 $wgHooks[ 'ArticleSave' ][] = 'PortableInfoboxHooks::onArticleSave';
 $wgHooks[ 'BacklinksPurge' ][] = 'PortableInfoboxHooks::onBacklinksPurge';
 $wgHooks[ 'ArticleInsertComplete' ][] = 'PortableInfoboxHooks::onArticleInsertComplete';
+$wgHooks[ 'ArticleAsJsonBeforeEncode' ][] = 'PortableInfoboxHooks::onArticleAsJsonBeforeEncode';
 
 // special pages
 $wgSpecialPages[ 'AllInfoboxes' ] = 'AllinfoboxesQueryPage';

--- a/extensions/wikia/PortableInfobox/PortableInfoboxHooks.class.php
+++ b/extensions/wikia/PortableInfobox/PortableInfoboxHooks.class.php
@@ -136,4 +136,10 @@ class PortableInfoboxHooks {
 
 		return true;
 	}
+	
+	public static function onArticleAsJsonBeforeEncode( &$text ) {
+		PortableInfoboxParserTagController::getInstance()->moveFirstMarkerToTop( $text );
+
+		return true;
+	}
 }

--- a/extensions/wikia/PortableInfobox/controllers/PortableInfoboxParserTagController.class.php
+++ b/extensions/wikia/PortableInfobox/controllers/PortableInfoboxParserTagController.class.php
@@ -133,7 +133,23 @@ class PortableInfoboxParserTagController extends WikiaController {
 	public function moveFirstMarkerToTop( &$text ) {
 		if ( !empty( $this->markers ) ) {
 			$firstMarker = array_keys( $this->markers )[0];
-			$text = $firstMarker . str_replace( $firstMarker, '', $text );
+
+			// Skip if the first marker is already at the top
+			if ( strpos( $text, $firstMarker ) !== 0 ) {
+				$firstMarkerWithFollowingWhitespace = '';
+
+				$text = preg_replace_callback(
+					'/(' . $firstMarker . ')\s*/',
+					function ( $matches ) use ( &$firstMarkerWithFollowingWhitespace ) {
+						$firstMarkerWithFollowingWhitespace = $matches[0];
+						return '';
+					},
+					$text,
+					1
+				);
+
+				$text = $firstMarkerWithFollowingWhitespace . $text;
+			}
 		}
 	}
 

--- a/extensions/wikia/PortableInfobox/controllers/PortableInfoboxParserTagController.class.php
+++ b/extensions/wikia/PortableInfobox/controllers/PortableInfoboxParserTagController.class.php
@@ -136,19 +136,9 @@ class PortableInfoboxParserTagController extends WikiaController {
 
 			// Skip if the first marker is already at the top
 			if ( strpos( $text, $firstMarker ) !== 0 ) {
-				$firstMarkerWithFollowingWhitespace = '';
-
-				$text = preg_replace_callback(
-					'/(' . $firstMarker . ')\s*/',
-					function ( $matches ) use ( &$firstMarkerWithFollowingWhitespace ) {
-						$firstMarkerWithFollowingWhitespace = $matches[0];
-						return '';
-					},
-					$text,
-					1
-				);
-
-				$text = $firstMarkerWithFollowingWhitespace . $text;
+				// Remove first marker and the following whitespace
+				$text = preg_replace( '/' . $firstMarker . '\s*/', '', $text, 1 );
+				$text = $firstMarker . ' ' . $text;
 			}
 		}
 	}

--- a/extensions/wikia/PortableInfobox/controllers/PortableInfoboxParserTagController.class.php
+++ b/extensions/wikia/PortableInfobox/controllers/PortableInfoboxParserTagController.class.php
@@ -10,12 +10,12 @@ class PortableInfoboxParserTagController extends WikiaController {
 	const INFOBOX_LAYOUT_PREFIX = 'pi-layout-';
 
 	private $markerNumber = 0;
-	private $markers = [ ];
 	private $supportedLayouts = [
 		'default',
 		'stacked'
 	];
 
+	protected $markers = [ ];
 	protected static $instance;
 
 	/**

--- a/extensions/wikia/PortableInfobox/controllers/PortableInfoboxParserTagController.class.php
+++ b/extensions/wikia/PortableInfobox/controllers/PortableInfoboxParserTagController.class.php
@@ -100,7 +100,6 @@ class PortableInfoboxParserTagController extends WikiaController {
 	 * @returns String $html
 	 */
 	public function renderInfobox( $text, $params, $parser, $frame ) {
-		global $wgArticleAsJson;
 		$this->markerNumber++;
 		$markup = '<' . self::PARSER_TAG_NAME . '>' . $text . '</' . self::PARSER_TAG_NAME . '>';
 
@@ -114,11 +113,6 @@ class PortableInfoboxParserTagController extends WikiaController {
 			return $this->handleError( wfMessage( 'portable-infobox-xml-parse-error-infobox-tag-attribute-unsupported', [ $e->getMessage() ] )->escaped() );
 		}
 
-		if ( $wgArticleAsJson ) {
-			// (wgArticleAsJson == true) it means that we need to encode output for use inside JSON
-			$renderedValue = trim( json_encode( $renderedValue ), '"' );
-		}
-
 		$marker = $parser->uniqPrefix() . "-" . self::PARSER_TAG_NAME . "-{$this->markerNumber}\x7f-QINU";
 		$this->markers[ $marker ] = $renderedValue;
 
@@ -126,7 +120,19 @@ class PortableInfoboxParserTagController extends WikiaController {
 	}
 
 	public function replaceMarkers( $text ) {
-		return strtr( $text, $this->markers );
+		wfProfileIn( __METHOD__ );
+
+		global $wgArticleAsJson;
+
+		if ( !empty( $wgArticleAsJson ) && !empty( $this->markers ) ) {
+			$text = $this->moveFirstInfoboxToTop( $text );
+		}
+
+		$articleWithMarkersReplaced = strtr( $text, $this->markers );
+
+		wfProfileOut( __METHOD__ );
+
+		return $articleWithMarkersReplaced;
 	}
 
 	protected function saveToParserOutput( \ParserOutput $parserOutput, Nodes\NodeInfobox $raw ) {
@@ -178,5 +184,22 @@ class PortableInfoboxParserTagController extends WikiaController {
 		}
 
 		return self::INFOBOX_LAYOUT_PREFIX . self::DEFAULT_LAYOUT_NAME;
+	}
+
+	private function moveFirstInfoboxToTop( $article ) {
+		$articleDecoded = json_decode( $article );
+
+		if ( !empty( $articleDecoded->content ) ) {
+			$firstMarker = array_keys( $this->markers )[0];
+			$firstInfobox = $this->markers[$firstMarker];
+
+			// Remove the first marker
+			$this->markers[$firstMarker] = '';
+
+			// Put the first infobox in the beginning of article content
+			$articleDecoded->content = $firstInfobox . $articleDecoded->content;
+		}
+
+		return json_encode( $articleDecoded );
 	}
 }

--- a/extensions/wikia/PortableInfobox/tests/PortableInfoboxParserTagControllerTest.php
+++ b/extensions/wikia/PortableInfobox/tests/PortableInfoboxParserTagControllerTest.php
@@ -241,4 +241,63 @@ class PortableInfoboxParserTagControllerTest extends WikiaBaseTest {
 			  [ 'abc' => 'minus one', '0' => 'zero', '1' => 'one', '2' => 'two', '3' => 'three' ] ],
 		];
 	}
+
+	/**
+	 * @dataProvider moveFirstMarkerToTopDataProvider
+	 */
+	public function testMoveFirstMarkerToTop( $markers, $text, $expected ) {
+		$this->controller->markers = $markers;
+		$this->controller->moveFirstMarkerToTop( $text );
+		$this->assertEquals( $expected, $text );
+	}
+
+	public function moveFirstMarkerToTopDataProvider() {
+		return [
+			[
+				'markers' => [
+					'infobox-1' => '1',
+					'infobox-2' => '2',
+				],
+				'text' => 'infobox-1 some text infobox-2',
+				'expected' => 'infobox-1 some text infobox-2',
+				'message' => 'first infobox already at the top'
+			],
+			[
+				'markers' => [
+					'infobox-1' => '1',
+					'infobox-2' => '2',
+				],
+				'text' => 'some text infobox-1 infobox-2',
+				'expected' => 'infobox-1 some text infobox-2',
+				'message' => 'first infobox below text'
+			],
+			[
+				'markers' => [
+					'infobox-1' => '1'
+				],
+				'text' => 'nospaceinfobox-1',
+				'expected' => 'infobox-1nospace',
+				'message' => 'no space between elements'
+			],
+			[
+				'markers' => [
+					'infobox-1' => '1',
+					'infobox-2' => '2',
+				],
+				'text' => 'some text
+						   some more
+						   infobox-1
+						   more text
+						   infobox-2
+						   and some more',
+				'expected' => 'infobox-1
+						   some text
+						   some more
+						   more text
+						   infobox-2
+						   and some more',
+				'message' => 'multiple lines'
+			],
+		];
+	}
 }

--- a/extensions/wikia/PortableInfobox/tests/PortableInfoboxParserTagControllerTest.php
+++ b/extensions/wikia/PortableInfobox/tests/PortableInfoboxParserTagControllerTest.php
@@ -276,8 +276,8 @@ class PortableInfoboxParserTagControllerTest extends WikiaBaseTest {
 					'infobox-1' => '1'
 				],
 				'text' => 'nospaceinfobox-1',
-				'expected' => 'infobox-1nospace',
-				'message' => 'no space between elements'
+				'expected' => 'infobox-1 nospace',
+				'message' => 'no space between input elements'
 			],
 			[
 				'markers' => [
@@ -290,8 +290,7 @@ class PortableInfoboxParserTagControllerTest extends WikiaBaseTest {
 						   more text
 						   infobox-2
 						   and some more',
-				'expected' => 'infobox-1
-						   some text
+				'expected' => 'infobox-1 some text
 						   some more
 						   more text
 						   infobox-2


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/XW-1429

We want to have the first infobox at the top of article in Mercury.

@idradm @SebastianMarzjan please let me know how you like the approach. If it's ok then I'll add some tests.

/cc @Wikia/x-wing 
