### PR TITLE
JPN-458: Display header image from specific location

### DIFF
--- a/extensions/wikia/CommunityPage/CommunityPageSpecialController.class.php
+++ b/extensions/wikia/CommunityPage/CommunityPageSpecialController.class.php
@@ -279,7 +279,7 @@ class CommunityPageSpecialController extends WikiaSpecialPageController {
 		$heroImage = Title::newFromText( self::COMMUNITY_PAGE_HERO_IMAGE, NS_FILE );
 		if ( $heroImage instanceof Title && $heroImage->exists() ) {
 			$heroImageFile = wfFindFile( $heroImage );
-			if ( !empty( $heroImageFile ) ) {
+			if ( $heroImageFile instanceof File ) {
 				$heroImageUrl = $heroImageFile->getUrl();
 			}
 		}

--- a/extensions/wikia/CommunityPage/CommunityPageSpecialController.class.php
+++ b/extensions/wikia/CommunityPage/CommunityPageSpecialController.class.php
@@ -29,9 +29,6 @@ class CommunityPageSpecialController extends WikiaSpecialPageController {
 		// remove user styles and js
 		$this->getOutput()->disallowUserJs();
 
-
-
-
 		$this->response->setValues( [
 			'heroImageUrl' => $this->getHeroImageUrl(),
 			'inviteFriendsText' => $this->msg( 'communitypage-invite-friends' )->plain(),

--- a/extensions/wikia/CommunityPage/CommunityPageSpecialController.class.php
+++ b/extensions/wikia/CommunityPage/CommunityPageSpecialController.class.php
@@ -2,6 +2,8 @@
 
 class CommunityPageSpecialController extends WikiaSpecialPageController {
 	const DEFAULT_TEMPLATE_ENGINE = \WikiaResponse::TEMPLATE_ENGINE_MUSTACHE;
+	const COMMUNITY_PAGE_HERO_IMAGE = 'Community-Page-Header.jpg';
+
 	private $usersModel;
 	private $wikiModel;
 	private $userTotalContributionCount;
@@ -27,7 +29,11 @@ class CommunityPageSpecialController extends WikiaSpecialPageController {
 		// remove user styles and js
 		$this->getOutput()->disallowUserJs();
 
+
+
+
 		$this->response->setValues( [
+			'heroImageUrl' => $this->getHeroImageUrl(),
 			'inviteFriendsText' => $this->msg( 'communitypage-invite-friends' )->plain(),
 			'headerWelcomeMsg' => $this->msg( 'communitypage-tasks-header-welcome' )->plain(),
 			'adminWelcomeMsg' => $this->msg( 'communitypage-admin-welcome-message' )->text(),
@@ -269,5 +275,18 @@ class CommunityPageSpecialController extends WikiaSpecialPageController {
 				'isAdmin' => $contributor['isAdmin'],
 			];
 		} , $contributors );
+	}
+
+	private function getHeroImageUrl() {
+		$heroImageUrl = '';
+		$heroImage = Title::newFromText( self::COMMUNITY_PAGE_HERO_IMAGE, NS_FILE );
+		if ( $heroImage instanceof Title && $heroImage->exists() ) {
+			$heroImageFile = wfFindFile( $heroImage );
+			if ( !empty( $heroImageFile ) ) {
+				$heroImageUrl = $heroImageFile->getUrl();
+			}
+		}
+
+		return $heroImageUrl;
 	}
 }

--- a/extensions/wikia/CommunityPage/styles/components/_header.scss
+++ b/extensions/wikia/CommunityPage/styles/components/_header.scss
@@ -3,7 +3,7 @@
 .community-page-header {
 	@include flexbox();
 	align-items: center;
-	background-image: url('/extensions/wikia/WAMPage/images/hero.jpg'); /* inline */
+	background-color: $color-links;
 	height: 250px;
 	justify-content: center;
 	text-align: center;

--- a/extensions/wikia/CommunityPage/templates/pageHeader.mustache
+++ b/extensions/wikia/CommunityPage/templates/pageHeader.mustache
@@ -1,4 +1,4 @@
-<div class="community-page-header">
+<div class="community-page-header" {{#heroImageUrl}}style="background-image: url({{heroImageUrl}});"{{/heroImageUrl}}>
 	<div class="community-page-header-content">
 		<h1>
 			{{headerWelcomeMsg}}


### PR DESCRIPTION
Display header image on Community Page got from "Community-Page-Header.jpg" location. If image does not exist callback to link color.
