### PR TITLE
JPN-436 Update designs of the Insights module

### DIFF
--- a/extensions/wikia/CommunityPage/styles/components/_insights-module.scss
+++ b/extensions/wikia/CommunityPage/styles/components/_insights-module.scss
@@ -12,10 +12,6 @@
 		margin: 0 0 12px;
 	}
 
-	.community-page-insights-module-full-list-link {
-		float: right;
-	}
-
 	.community-page-insights-module-description {
 		clear: both;
 	}
@@ -29,10 +25,6 @@
 		border-bottom: 1px solid $color-page-border-subtle;
 		font-size: 14px;
 		padding: 20px;
-	}
-
-	.community-page-insights-module-list-item:first-child {
-		border-top: 1px solid $color-page-border-subtle;
 	}
 
 	.community-page-insights-module-inline-data {

--- a/extensions/wikia/CommunityPage/templates/insightsModule.mustache
+++ b/extensions/wikia/CommunityPage/templates/insightsModule.mustache
@@ -1,7 +1,7 @@
 <section class="community-page-insights-module">
 	<h3 class="community-page-insights-module-header">{{title}}</h3>
-	<a class="community-page-insights-module-full-list-link" href="{{fulllistlink}}">{{insightsModules.messages.fulllist}} &rarr;</a>
 	<p class="community-page-insights-module-description">{{description}}</p>
+	<a class="community-page-insights-module-full-list-link" href="{{fulllistlink}}">{{insightsModules.messages.fulllist}} &rarr;</a>
 	<ul class="community-page-insights-module-list">
 		{{#pages}}
 			<li class="community-page-insights-module-list-item">


### PR DESCRIPTION
Having the "View full list" link on the right made it hard to recognize which module it belongs to for more than 2 of them.

This PR puts it between a description and a list. Also, the top border of the first item on a list is removed.

@Wikia/spitfires @perjg @d34th4ck3r 
