### PR TITLE
ADEN-3187 Use SP detection in Yavli

### DIFF
--- a/extensions/wikia/AdEngine/js/AdContext.js
+++ b/extensions/wikia/AdEngine/js/AdContext.js
@@ -163,7 +163,11 @@ define('ext.wikia.adEngine.adContext', [
 			!isPageType('home')
 		);
 
-		context.opts.yavli = !noExternals && geo.isProperGeo(instantGlobals.wgAdDriverYavliCountries);
+		context.opts.yavli = !!(
+			!noExternals &&
+			geo.isProperGeo(instantGlobals.wgAdDriverYavliCountries) &&
+			isPageType('article')
+		);
 
 		// Export the context back to ads.context
 		// Only used by Lightbox.js, WikiaBar.js and AdsInContext.js

--- a/extensions/wikia/AdEngine/js/provider/yavliTag.js
+++ b/extensions/wikia/AdEngine/js/provider/yavliTag.js
@@ -1,9 +1,10 @@
 /*global define*/
 define('ext.wikia.adEngine.provider.yavliTag', [
 	'ext.wikia.adEngine.adContext',
+	'ext.wikia.aRecoveryEngine.recovery.helper',
 	'wikia.document',
 	'wikia.log'
-], function (adContext, doc, log) {
+], function (adContext, recoveryHelper, doc, log) {
 	'use strict';
 
 	var logGroup = 'ext.wikia.adEngine.provider.yavliTag';
@@ -11,15 +12,17 @@ define('ext.wikia.adEngine.provider.yavliTag', [
 	log('init', 'debug', logGroup);
 
 	function add() {
-		var context = adContext.getContext(),
-			yavli = doc.createElement('script');
+		recoveryHelper.addOnBlockingCallback(function () {
+			var context = adContext.getContext(),
+				yavli = doc.createElement('script');
 
-		yavli.async = true;
-		yavli.type = 'text/javascript';
-		yavli.src = context.opts.yavliUrl;
+			yavli.async = true;
+			yavli.type = 'text/javascript';
+			yavli.src = context.opts.yavliUrl;
 
-		log('Appending Yavli to the end of body', 'debug', logGroup);
-		doc.body.appendChild(yavli);
+			log('Appending Yavli to the end of body', 'debug', logGroup);
+			doc.body.appendChild(yavli);
+		});
 	}
 
 	return {

--- a/extensions/wikia/AdEngine/js/run/mercury.run.js
+++ b/extensions/wikia/AdEngine/js/run/mercury.run.js
@@ -1,5 +1,6 @@
 /*global require*/
 require([
+	'ext.wikia.adEngine.adContext',
 	'ext.wikia.adEngine.lookup.amazonMatch',
 	'ext.wikia.adEngine.lookup.openXBidder',
 	'ext.wikia.adEngine.lookup.rubiconFastlane',
@@ -12,6 +13,7 @@ require([
 	'wikia.instantGlobals',
 	'wikia.window'
 ], function (
+	adContext,
 	amazon,
 	oxBidder,
 	rubiconFastlane,
@@ -45,7 +47,7 @@ require([
 			oxBidder.call();
 		}
 
-		if (geo.isProperGeo(instantGlobals.wgAdDriverYavliCountries)) {
+		if (adContext.getContext().opts.yavli) {
 			yavliTag.add();
 		}
 	});


### PR DESCRIPTION
Use SourcePoint detection (ad un-blocking software) and show Yavli (Taboola-like provider) only for AdBlock users.
