### PR TITLE
SEO-311 Paginator refactor: rel="canonical/next/prev" update

### DIFF
--- a/extensions/wikia/Blogs/templates/blog-pager-ajax.tmpl.php
+++ b/extensions/wikia/Blogs/templates/blog-pager-ajax.tmpl.php
@@ -3,9 +3,9 @@
 if ($iPageCount > 1) {
 ?>
 <?
-	$pages = Paginator::newFromCount( $iTotal, min( $iCount, 50 ) );
+	$pages = new Wikia\Paginator\Paginator( $iTotal, min( $iCount, 50 ), '' );
 	$pages->setActivePage( $iPage + 1 );
-	echo $pages->getBarHTML( '', 'BlogPaginator' );
+	echo $pages->getBarHTML( 'BlogPaginator' );
 ?>
 <script type="text/javascript" src="<?=$wgExtensionsPath?>/wikia/Blogs/js/BlogsPager.js"></script>
 <? } ?>

--- a/extensions/wikia/CanonicalHref/CanonicalHref.php
+++ b/extensions/wikia/CanonicalHref/CanonicalHref.php
@@ -26,9 +26,14 @@ $wgHooks['BeforePageDisplay'][] = 'wfCanonicalHref';
  * @return bool
  */
 function wfCanonicalHref(&$out, &$sk) {
-	global $wgTitle;
+	global $wgTitle, $wgRequest;
 
 	if ( !($wgTitle instanceof Title) ) {
+		return true;
+	}
+
+	// No canonical on pages with pagination -- they should have the link rel="next/prev" instead
+	if ( $wgRequest->getVal( 'page' ) ) {
 		return true;
 	}
 

--- a/extensions/wikia/CategoryExhibition/CategoryExhibitionSection.class.php
+++ b/extensions/wikia/CategoryExhibition/CategoryExhibitionSection.class.php
@@ -231,13 +231,12 @@ class CategoryExhibitionSection {
 				$pages->setActivePage( $this->paginatorPosition );
 				$aTmpData = $pages->getCurrentPage( $aTmpData );
 				$aData = $this->getArticles( $aTmpData );
-				$oTmpl->set_vars(
-					array (
-						'data'		=> $aData,
-						'category'	=> $this->categoryTitle->getText(),
-						'paginator'	=> $pages->getBarHTML()
-					)
-				);
+				$oTmpl->set_vars( [
+					'data' => $aData,
+					'category' => $this->categoryTitle->getText(),
+					'paginator' => $pages->getBarHTML(),
+					'paginatorHead' => $pages->getHeadItem(),
+				] );
 				$this->saveToCache( $oTmpl->mVars );
 				return $oTmpl;
 			} else {

--- a/extensions/wikia/CategoryExhibition/CategoryExhibitionSection.class.php
+++ b/extensions/wikia/CategoryExhibition/CategoryExhibitionSection.class.php
@@ -1,4 +1,5 @@
 <?php
+use Wikia\Paginator\Paginator;
 
 /**
  * Main Category Gallery class
@@ -223,7 +224,9 @@ class CategoryExhibitionSection {
 		$oTmpl = new EasyTemplate( dirname( __FILE__ ) . "/templates/" );
 		if( empty( $cachedContent ) ){
 			$aTmpData = $this->fetchSectionItems( $namespace, $negative );
-			$pages = Paginator::newFromCount( count( $aTmpData ), $itemsPerPage );
+			$pages = new Paginator( count( $aTmpData ), $itemsPerPage, $this->sUrl, [
+				'paramName' => $this->urlParameter
+			] );
 			if ( is_array( $aTmpData ) && count( $aTmpData ) > 0 ){
 				$pages->setActivePage( $this->paginatorPosition );
 				$aTmpData = $pages->getCurrentPage( $aTmpData );
@@ -232,7 +235,7 @@ class CategoryExhibitionSection {
 					array (
 						'data'		=> $aData,
 						'category'	=> $this->categoryTitle->getText(),
-						'paginator'	=> $pages->getBarHTML( $this->sUrl )
+						'paginator'	=> $pages->getBarHTML()
 					)
 				);
 				$this->saveToCache( $oTmpl->mVars );
@@ -400,20 +403,9 @@ class CategoryExhibitionSection {
 			$paginatorPosition = (int)$reqValues[ $variableName ];
 			unset( $reqValues[ $variableName ] );
 		};
-		$return = array();
-		foreach( $reqValues AS $key => $value ) {
-			$return[] = urlencode( $key ) . '=' . urlencode( $value );
-		}
 
-		$url = $wgTitle->getFullURL().'?'.implode( '&', $return );
-		if ( count($return) > 0 ){
-			$url.= '&'.$variableName.'=%s';
-		} else {
-			$url.= '?'.$variableName.'=%s';
-		}
-		$this->sUrl = $url;
+		$this->sUrl = $wgTitle->getFullURL( $reqValues );
 		$this->paginatorPosition = $paginatorPosition;
-		return array( 'url' => $url, 'position' => $paginatorPosition );
 	}
 
 	/**

--- a/extensions/wikia/CategoryExhibition/CategoryExhibitionSection.class.php
+++ b/extensions/wikia/CategoryExhibition/CategoryExhibitionSection.class.php
@@ -235,7 +235,7 @@ class CategoryExhibitionSection {
 					'data' => $aData,
 					'category' => $this->categoryTitle->getText(),
 					'paginator' => $pages->getBarHTML(),
-					'paginatorHead' => $pages->getHeadItem(),
+					'headLinks' => $pages->getHeadItem(),
 				] );
 				$this->saveToCache( $oTmpl->mVars );
 				return $oTmpl;

--- a/extensions/wikia/CategoryExhibition/CategoryExhibitionSectionMedia.class.php
+++ b/extensions/wikia/CategoryExhibition/CategoryExhibitionSectionMedia.class.php
@@ -1,4 +1,5 @@
 <?php
+use Wikia\Paginator\Paginator;
 
 /**
  * Main Category Gallery class
@@ -17,7 +18,12 @@ class CategoryExhibitionSectionMedia extends CategoryExhibitionSection {
 			// grabs data for videos and images
 			$aTmpData = $this->fetchSectionItems( array( NS_FILE ) ); // we wan't old videos
 			if ( is_array( $aTmpData ) && count( $aTmpData ) > 0 ){
-				$pages = Paginator::newFromCount( count( $aTmpData ), $wgCategoryExhibitionMediaSectionRows * 4 );
+				$pages = new Paginator(
+					count( $aTmpData ),
+					$wgCategoryExhibitionMediaSectionRows * 4,
+					$this->sUrl,
+					[ 'paramName' => $this->urlParameter ]
+				);
 				$pages->setActivePage( $this->paginatorPosition );
 				$pageData = $pages->getCurrentPage( $aTmpData );
 				$aData = array();
@@ -83,7 +89,7 @@ class CategoryExhibitionSectionMedia extends CategoryExhibitionSection {
 				$aContent = array (
 						'data'		=> $aData,
 						'category'	=> $this->categoryTitle->getText(),
-						'paginator'	=> $pages->getBarHTML( $this->sUrl )
+						'paginator'	=> $pages->getBarHTML()
 					);
 				$this->saveToCache( $aContent );
 			} else {

--- a/extensions/wikia/CategoryExhibition/CategoryExhibitionSectionPages.class.php
+++ b/extensions/wikia/CategoryExhibition/CategoryExhibitionSectionPages.class.php
@@ -9,14 +9,15 @@ class CategoryExhibitionSectionPages extends CategoryExhibitionSection {
 	public $templateName = 'page';
 
 	public function getSectionHTML(){
-		global $wgCategoryExhibitionPagesSectionRows, $wgContentNamespaces;
+		global $wgCategoryExhibitionPagesSectionRows, $wgOut;
 		$this->loadPaginationVars();
 		$oTmpl = $this->getTemplateForNameSpace( $this->getExcludes(), $wgCategoryExhibitionPagesSectionRows * 4, true );
+		$wgOut->addHeadItem( 'Paginator', $oTmpl->mVars['paginatorHead'] );
 		return $this->executeTemplate( $oTmpl );
 	}
 
 	public function getSectionAxHTML( $paginatorPosition, $sUrl ){
-		global $wgCategoryExhibitionPagesSectionRows, $wgContentNamespaces;
+		global $wgCategoryExhibitionPagesSectionRows;
 		$this->loadPaginationVars();
 		$this->isFromAjax = true;
 		$this->paginatorPosition = $paginatorPosition;

--- a/extensions/wikia/CategoryExhibition/CategoryExhibitionSectionPages.class.php
+++ b/extensions/wikia/CategoryExhibition/CategoryExhibitionSectionPages.class.php
@@ -12,7 +12,7 @@ class CategoryExhibitionSectionPages extends CategoryExhibitionSection {
 		global $wgCategoryExhibitionPagesSectionRows, $wgOut;
 		$this->loadPaginationVars();
 		$oTmpl = $this->getTemplateForNameSpace( $this->getExcludes(), $wgCategoryExhibitionPagesSectionRows * 4, true );
-		$wgOut->addHeadItem( 'Paginator', $oTmpl->mVars['paginatorHead'] );
+		$wgOut->addHeadItem( 'Paginator', $oTmpl->mVars['headLinks'] );
 		return $this->executeTemplate( $oTmpl );
 	}
 

--- a/extensions/wikia/InsightsV2/helpers/InsightsPaginator.php
+++ b/extensions/wikia/InsightsV2/helpers/InsightsPaginator.php
@@ -64,7 +64,7 @@ class InsightsPaginator {
 	 * Prepare pagination
 	 */
 	public function getPagination() {
-		$url = urldecode( InsightsHelper::getSubpageLocalUrl( $this->subpage, $this->getParams() ) );
+		$url = InsightsHelper::getSubpageLocalUrl( $this->subpage, $this->getParams() );
 
 		$paginator = new Paginator( $this->getTotal(), $this->getLimit(), $url );
 		$paginator->setActivePage( $this->getPage() );

--- a/extensions/wikia/InsightsV2/helpers/InsightsPaginator.php
+++ b/extensions/wikia/InsightsV2/helpers/InsightsPaginator.php
@@ -20,8 +20,9 @@ class InsightsPaginator {
 		$this->subpage = $subpage;
 		if ( isset( $params['page'] ) ) {
 			$this->page = $params['page'];
+			unset( $params['page'] );
 		}
-		$this->params = $this->filterParams( $params );
+		$this->params = $params;
 		$this->total = ( new InsightsCountService() )->getCount( $this->subpage );
 
 		$this->preparePaginationParams();
@@ -83,11 +84,5 @@ class InsightsPaginator {
 		}
 
 		$this->offset = ( $this->page - 1 ) * $this->limit;
-	}
-
-	private function filterParams( $params ) {
-		unset( $params['page'] );
-
-		return $params;
 	}
 }

--- a/extensions/wikia/InsightsV2/helpers/InsightsPaginator.php
+++ b/extensions/wikia/InsightsV2/helpers/InsightsPaginator.php
@@ -1,5 +1,7 @@
 <?php
 
+use Wikia\Paginator\Paginator;
+
 class InsightsPaginator {
 	const INSIGHTS_LIST_MAX_LIMIT = 100;
 
@@ -58,12 +60,12 @@ class InsightsPaginator {
 	 * Prepare pagination
 	 */
 	public function getPagination() {
-		$params = array_merge( $this->getParams(), [ 'page' => '%s' ] );
+		$params = array_merge( $this->getParams() );
 		$url = urldecode( InsightsHelper::getSubpageLocalUrl( $this->subpage, $params ) );
 
-		$paginator = Paginator::newFromCount( $this->getTotal(), $this->getLimit() );
+		$paginator = new Paginator( $this->getTotal(), $this->getLimit(), $url );
 		$paginator->setActivePage( $this->getPage() + 1 );
-		$paginatorBar = $paginator->getBarHTML( $url );
+		$paginatorBar = $paginator->getBarHTML();
 
 		return $paginatorBar;
 	}

--- a/extensions/wikia/InsightsV2/tests/InsightsPaginatorTest.php
+++ b/extensions/wikia/InsightsV2/tests/InsightsPaginatorTest.php
@@ -1,0 +1,66 @@
+<?php
+
+
+class InsightsPaginatorTest extends WikiaBaseTest {
+
+	public function setUp() {
+		$this->setupFile = __DIR__ . '/../InsightsV2.setup.php';
+		parent::setUp();
+	}
+
+	/**
+	 * @dataProvider providerRemovingCurrentPageParam
+	 */
+	public function testRemovingCurrentPageParam( $params, $expectedParams ) {
+		$paginator = new InsightsPaginator( 'mytestinsightssubpage', $params );
+
+		$this->assertEquals( $expectedParams, $paginator->getParams() );
+	}
+
+	/**
+	 * @dataProvider providerCurrentPage
+	 */
+	public function testCurrentPage( $params, $expectedPageNumber ) {
+		$paginator = new InsightsPaginator( 'mytestinsightssubpage', $params );
+
+		$this->assertEquals( $expectedPageNumber, $paginator->getPage() );
+	}
+
+	/**
+	 * @dataProvider providerOffset
+	 */
+	public function testOffset( $params, $expectedOffset ) {
+		$paginator = new InsightsPaginator( 'mytestinsightssubpage', $params );
+
+		$this->assertEquals( $expectedOffset, $paginator->getOffset() );
+	}
+
+	public function providerRemovingCurrentPageParam() {
+		return [
+			[ [], [] ],
+			[ [ 'page' => 2 ], [] ],
+			[ [ 'page' => 2, 'someOtherParam' => 'abc' ], [ 'someOtherParam' => 'abc' ] ],
+			[ [ 'someOtherParam' => 'abc' ], [ 'someOtherParam' => 'abc' ] ]
+		];
+	}
+
+	public function providerCurrentPage() {
+		return [
+			[ [], 1 ],
+			[ [ 'page' => 1 ], 1 ],
+			[ [ 'page' => 2 ], 2 ],
+			[ [ 'page' => 2, 'someOtherParam' => 'abc' ], 2 ],
+			[ [ 'someOtherParam' => 'abc' ], 1 ]
+		];
+	}
+
+	public function providerOffset() {
+		return [
+			[ [], 0 ],
+			[ [ 'page' => 2 ], 1 * InsightsPaginator::INSIGHTS_LIST_MAX_LIMIT ],
+			[ [ 'page' => 3 ], 2 * InsightsPaginator::INSIGHTS_LIST_MAX_LIMIT ],
+			[ [ 'limit' => 30 ], 0 ],
+			[ [ 'page' => 3, 'limit' => 30 ], 2 * 30 ],
+		];
+	}
+}

--- a/extensions/wikia/Paginator/Paginator.setup.php
+++ b/extensions/wikia/Paginator/Paginator.setup.php
@@ -1,13 +1,13 @@
 <?php
 
-$wgExtensionCredits[ 'other' ][] = array(
+$wgExtensionCredits['other'][] = [
 	'name' => 'Paginator',
 	'author' => 'Jakub Kurcek',
 	'descriptionmsg' => 'paginator-desc',
 	'url' => 'https://github.com/Wikia/app/tree/dev/extensions/wikia/Paginator',
-);
+];
 
-$wgAutoloadClasses['Wikia\Paginator\Paginator']	= __DIR__ . '/classes/Paginator.class.php';
+$wgAutoloadClasses['Wikia\Paginator\Paginator'] = __DIR__ . '/classes/Paginator.class.php';
 $wgAutoloadClasses['Wikia\Paginator\UrlGenerator'] = __DIR__ . '/classes/UrlGenerator.class.php';
 $wgAutoloadClasses['Wikia\Paginator\Validator'] = __DIR__ . '/classes/Validator.class.php';
 

--- a/extensions/wikia/Paginator/Paginator.setup.php
+++ b/extensions/wikia/Paginator/Paginator.setup.php
@@ -1,17 +1,5 @@
 <?php
-if ( !defined('MEDIAWIKI') ) {
-	echo "This is a MediaWiki extension.\n";
-	exit(1);
-}
-/**
- *
- * @package MediaWiki
- * @subpackage Pagination
- * @author Jakub Kurcek
- *
- * To use this extension $wgEnablePaginatorExt = true
- */
- 
+
 $wgExtensionCredits[ 'other' ][ ] = array(
 	'name' => 'Paginator',
 	'author' => 'Jakub Kurcek',
@@ -19,7 +7,8 @@ $wgExtensionCredits[ 'other' ][ ] = array(
 	'url' => 'https://github.com/Wikia/app/tree/dev/extensions/wikia/Paginator',
 );
 
-$dir = dirname(__FILE__) . '/';
-$wgAutoloadClasses['Paginator']	= $dir . 'Paginator.body.php';
-$wgExtensionMessagesFiles['Paginator'] = $dir . 'i18n/Paginator.i18n.php';
+$wgAutoloadClasses['Wikia\Paginator\Paginator']	= __DIR__ . '/classes/Paginator.class.php';
+$wgAutoloadClasses['Wikia\Paginator\UrlGenerator'] = __DIR__ . '/classes/UrlGenerator.class.php';
+$wgAutoloadClasses['Wikia\Paginator\Validator'] = __DIR__ . '/classes/Validator.class.php';
 
+$wgExtensionMessagesFiles['Paginator'] = $dir . 'i18n/Paginator.i18n.php';

--- a/extensions/wikia/Paginator/Paginator.setup.php
+++ b/extensions/wikia/Paginator/Paginator.setup.php
@@ -1,6 +1,6 @@
 <?php
 
-$wgExtensionCredits[ 'other' ][ ] = array(
+$wgExtensionCredits[ 'other' ][] = array(
 	'name' => 'Paginator',
 	'author' => 'Jakub Kurcek',
 	'descriptionmsg' => 'paginator-desc',

--- a/extensions/wikia/Paginator/classes/Paginator.class.php
+++ b/extensions/wikia/Paginator/classes/Paginator.class.php
@@ -1,5 +1,11 @@
 <?php
 
+namespace Wikia\Paginator;
+
+use EasyTemplate;
+use Html;
+use InvalidArgumentException;
+
 /**
  *
  * @package MediaWiki
@@ -10,12 +16,8 @@
  * Object that allows auto pagination of array content
  *
  * TODO:
- *  * On the second page of paginated content rel="prev" link should point to the page without ?page=1
  *  * On any page other than the first page there should be no canonical (link rel="prev/next" is enough)
- *  * Avoid passing the same URL to getHeadItem and getBarHTML (pass to constructor instead?)
  *  * Support for indefinite pagination? 1 ... 47 48 49 _50_ 51 52 53 ...
- *  * Move template to mustache
- *  * No checking for min items per page
  */
 class Paginator {
 
@@ -26,45 +28,28 @@ class Paginator {
 	private $itemsPerPage;
 	private $pagesCount;
 	private $activePage = 1;
-
-	// Deprecated state
-	private $data = [];
+	private $url;
+	private $paramName = 'page';
 
 	/**
-	 * Creates a new Pagination object.
+	 * Paginator constructor
 	 *
-	 * @param int $count number of items to paginate through
-	 * @param int $itemsPerPage number of items to display per page (capped to between 4 and 48)
-	 * @return Paginator
-	 */
-	public static function newFromCount( $count, $itemsPerPage ) {
-		return new Paginator( $count, $itemsPerPage );
-	}
-
-	/**
-	 * @deprecated use newFromCount (only used by CrunchyRoll)
-	 * @param array $data
-	 * @param int $itemsPerPage
-	 * @return Paginator
-	 */
-	public static function newFromArray( array $data, $itemsPerPage ) {
-		$self = self::newFromCount( count( $data ), $itemsPerPage );
-		$self->data = $data;
-		return $self;
-	}
-
-	/**
-	 * Paginator constructor.
 	 * @param int $dataCount number of data to paginate or the data to paginate
-	 * @param int $itemsPerPage number of items to display per page (capped to between 4 and 48)
+	 * @param int $itemsPerPage number of items to display per page
+	 * @param string $url URL to be paginated
+	 * @param mixed[] $options {
+	 * @type string $paramName the name of the URL param to store the page number (defaults to "page")
+	 * }
 	 */
-	private function __construct( $dataCount, $itemsPerPage ) {
-		if ( !is_numeric( $itemsPerPage ) ) {
-			throw new InvalidArgumentException( 'Paginator: need an int for $itemsPerPage' );
+	public function __construct( $dataCount, $itemsPerPage, $url = '', array $options = [] ) {
+		if ( !Validator::isNonNegativeInteger( $dataCount ) ) {
+			throw new InvalidArgumentException( 'Paginator: Expected a non-negative integer for dataCount' );
 		}
-
-		if ( !is_numeric( $dataCount ) ) {
-			throw new InvalidArgumentException( 'Paginator: need an int for $data' );
+		if ( !Validator::isPositiveInteger( $itemsPerPage ) ) {
+			throw new InvalidArgumentException( 'Paginator: Expected a positive integer for itemsPerPage' );
+		}
+		if ( !is_string( $url ) ) {
+			throw new InvalidArgumentException( 'Paginator: Expected a string for url' );
 		}
 
 		$itemsPerPage = intval( $itemsPerPage );
@@ -72,6 +57,14 @@ class Paginator {
 
 		$this->itemsPerPage = max( $itemsPerPage, self::MIN_ITEMS_PER_PAGE );
 		$this->pagesCount = ceil( $dataCount / $this->itemsPerPage );
+		$this->url = $url;
+
+		if ( isset( $options['paramName'] ) ) {
+			if ( !is_string( $options['paramName'] ) ) {
+				throw new InvalidArgumentException( 'Paginator: Expected a string for options.paramName' );
+			}
+			$this->paramName = $options['paramName'];
+		}
 	}
 
 	/**
@@ -88,15 +81,10 @@ class Paginator {
 	/**
 	 * Get the current page of the passed data
 	 *
-	 * @param array|null $data data to be paginated (DEPRECATED: if null, the data passed from newFromArray is used)
+	 * @param array $data data to be paginated
 	 * @return array
 	 */
-	public function getCurrentPage( array $data = null ) {
-		// deprecated case:
-		if ( is_null( $data ) ) {
-			$data = $this->data;
-		}
-
+	public function getCurrentPage( array $data ) {
 		$paginatedData = array_chunk( $data, $this->itemsPerPage );
 
 		$index = $this->activePage - 1;
@@ -104,6 +92,15 @@ class Paginator {
 			return $paginatedData[$index];
 		}
 		return [];
+	}
+
+	/**
+	 * Used by SpecialVideosHelper
+	 *
+	 * @return int
+	 */
+	public function getPagesCount() {
+		return $this->pagesCount;
 	}
 
 	/**
@@ -126,7 +123,9 @@ class Paginator {
 	 *
 	 * @return array as described above
 	 */
-	private function getBarData() {
+	private function getBarData( $url, $pageParam ) {
+		$urlGenerator = new UrlGenerator( $url, $pageParam, $this->pagesCount );
+
 		// Compute whether there's the ellipsis to the left/right of the current page
 		$leftEllipsis = ( $this->activePage > self::DISPLAYED_NEIGHBOURS + 2 );
 		$rightEllipsis = ( $this->activePage < $this->pagesCount - self::DISPLAYED_NEIGHBOURS - 1 );
@@ -137,62 +136,63 @@ class Paginator {
 		$rightRangeStart = min( $this->activePage + self::DISPLAYED_NEIGHBOURS, $this->pagesCount - 1 );
 
 		$data = [ 1 ];
+		$urls = [ 1 => $urlGenerator->getUrlForPage( 1 ) ];
 
 		if ( $leftEllipsis ) {
 			$data[] = '';
 		}
 		for ( $i = $leftRangeStart; $i <= $rightRangeStart; $i++ ) {
 			$data[] = $i;
+			$urls[$i] = $urlGenerator->getUrlForPage( $i );
 		}
 		if ( $rightEllipsis ) {
 			$data[] = '';
 		}
 
 		$data[] = $this->pagesCount;
+		$urls[$this->pagesCount] = $urlGenerator->getUrlForPage( $this->pagesCount );
 
 		return [
 			'pages' => $data,
-			'currentPage' => $this->activePage
+			'currentPage' => $this->activePage,
+			'urls' => $urls,
 		];
 	}
 
-	public function getBarHTML( $url, $paginatorId = false ) {
+	/**
+	 * Get the Paginator HTML
+	 *
+	 * @param string $paginatorId
+	 * @return string
+	 */
+	public function getBarHTML( $paginatorId = null ) {
 		if ( $this->pagesCount <= 1 ) {
 			return '';
 		}
 
-		$data = $this->getBarData();
+		$data = $this->getBarData( $this->url, $this->paramName );
 		$data['paginatorId'] = strip_tags( trim( stripslashes( $paginatorId ) ) );
-		$data['url'] = $url;
 
-		$template = new EasyTemplate( __DIR__ . '/templates/' );
+		$template = new EasyTemplate( __DIR__ . '/../templates/' );
 		$template->set_vars( $data );
 		return $template->render( 'paginator' );
 	}
 
 	/**
-	 * Used by SpecialVideosHelper
-	 *
-	 * @return int
-	 */
-	public function getPagesCount() {
-		return $this->pagesCount;
-	}
-
-	/**
 	 * Get HTML to put to HTML <head> to allow search engines to identify next and previous pages
 	 *
-	 * @param $url the URL template. We'll replace '%s' with the page number
 	 * @return string
 	 */
-	public function getHeadItem( $url ) {
+	public function getHeadItem() {
 		$links = '';
+
+		$urlGenerator = new UrlGenerator( $this->url, $this->paramName, $this->pagesCount );
 
 		// Has a previous page?
 		if ( $this->activePage > 1 ) {
 			$links .= "\t" . Html::element( 'link', [
 					'rel' => 'prev',
-					'href' => str_replace( '%s', $this->activePage - 1, $url )
+					'href' => $urlGenerator->getUrlForPage( $this->activePage - 1 ),
 				] ) . PHP_EOL;
 		}
 
@@ -200,10 +200,11 @@ class Paginator {
 		if ( $this->activePage < $this->pagesCount ) {
 			$links .= "\t" . Html::element( 'link', [
 					'rel' => 'next',
-					'href' => str_replace( '%s', $this->activePage + 1, $url )
+					'href' => $urlGenerator->getUrlForPage( $this->activePage + 1 ),
 				] ) . PHP_EOL;
 		}
 
 		return $links;
 	}
+
 }

--- a/extensions/wikia/Paginator/classes/Paginator.class.php
+++ b/extensions/wikia/Paginator/classes/Paginator.class.php
@@ -16,8 +16,7 @@ use InvalidArgumentException;
  * Object that allows auto pagination of array content
  *
  * TODO:
- *  * On any page other than the first page there should be no canonical (link rel="prev/next" is enough)
- *  * Support for indefinite pagination? 1 ... 47 48 49 _50_ 51 52 53 ...
+ *  * Support for indefinite pagination? 1 ... 47 48 49 _50_ 51 52 53 ... (for search)
  */
 class Paginator {
 

--- a/extensions/wikia/Paginator/classes/UrlGenerator.class.php
+++ b/extensions/wikia/Paginator/classes/UrlGenerator.class.php
@@ -21,7 +21,7 @@ class UrlGenerator {
 	 */
 	private $pagesCount;
 
-	public function __construct( $url, $pageParam, $pagesCount, $usePage1 = false ) {
+	public function __construct( $url, $pageParam, $pagesCount ) {
 		if ( !is_string( $url ) ) {
 			throw new InvalidArgumentException( 'Expected a string for url' );
 		}
@@ -35,7 +35,6 @@ class UrlGenerator {
 		$this->url = $url;
 		$this->pageParam = $pageParam;
 		$this->pagesCount = intval( $pagesCount );
-		$this->usePage1 = $usePage1;
 	}
 
 	public function getUrlForPage( $pageNumber ) {
@@ -44,7 +43,7 @@ class UrlGenerator {
 		}
 
 		// Page #1 is always OK no matter how many pages there are
-		if ( !$this->usePage1 && ( $pageNumber == 1 ) ) {
+		if ( $pageNumber == 1 ) {
 			return $this->url;
 		}
 
@@ -52,7 +51,7 @@ class UrlGenerator {
 			throw new InvalidArgumentException( 'No such page available' );
 		}
 
-		if ( strchr( $this->url, '?' ) > -1 ) {
+		if ( strpos( $this->url, '?' ) !== false ) {
 			return sprintf( '%s&%s=%d', $this->url, $this->pageParam, $pageNumber );
 		}
 

--- a/extensions/wikia/Paginator/classes/UrlGenerator.class.php
+++ b/extensions/wikia/Paginator/classes/UrlGenerator.class.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Wikia\Paginator;
+
+use InvalidArgumentException;
+
+class UrlGenerator {
+
+	/**
+	 * @var string Base URL for the pagination
+	 */
+	private $url;
+
+	/**
+	 * @var string URL param name to store the page number
+	 */
+	private $pageParam;
+
+	/**
+	 * @var null|int Total number of pages (for validation purposes)
+	 */
+	private $pagesCount;
+
+	public function __construct( $url, $pageParam, $pagesCount, $usePage1 = false ) {
+		if ( !is_string( $url ) ) {
+			throw new InvalidArgumentException( 'Expected a string for url' );
+		}
+		if ( !is_string( $pageParam ) ) {
+			throw new InvalidArgumentException( 'Expected a string for pageParam' );
+		}
+		if ( !is_null( $pagesCount ) && !Validator::isNonNegativeInteger( $pagesCount ) ) {
+			throw new InvalidArgumentException( 'Expected a non-negative integer for pagesCount' );
+		}
+
+		$this->url = $url;
+		$this->pageParam = $pageParam;
+		$this->pagesCount = intval( $pagesCount );
+		$this->usePage1 = $usePage1;
+	}
+
+	public function getUrlForPage( $pageNumber ) {
+		if ( !Validator::isPositiveInteger( $pageNumber ) ) {
+			throw new InvalidArgumentException( 'Expected a positive integer for pageNumber' );
+		}
+
+		// Page #1 is always OK no matter how many pages there are
+		if ( !$this->usePage1 && ( $pageNumber == 1 ) ) {
+			return $this->url;
+		}
+
+		if ( $pageNumber > $this->pagesCount ) {
+			throw new InvalidArgumentException( 'No such page available' );
+		}
+
+		if ( strchr( $this->url, '?' ) > -1 ) {
+			return sprintf( '%s&%s=%d', $this->url, $this->pageParam, $pageNumber );
+		}
+
+		return sprintf( '%s?%s=%d', $this->url, $this->pageParam, $pageNumber );
+	}
+}

--- a/extensions/wikia/Paginator/classes/UrlGenerator.class.php
+++ b/extensions/wikia/Paginator/classes/UrlGenerator.class.php
@@ -28,7 +28,7 @@ class UrlGenerator {
 		if ( !is_string( $pageParam ) ) {
 			throw new InvalidArgumentException( 'Expected a string for pageParam' );
 		}
-		if ( !is_null( $pagesCount ) && !Validator::isNonNegativeInteger( $pagesCount ) ) {
+		if ( !Validator::isNonNegativeInteger( $pagesCount ) ) {
 			throw new InvalidArgumentException( 'Expected a non-negative integer for pagesCount' );
 		}
 

--- a/extensions/wikia/Paginator/classes/Validator.class.php
+++ b/extensions/wikia/Paginator/classes/Validator.class.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Wikia\Paginator;
+
+class Validator {
+	public static function isInteger( $value ) {
+		return is_numeric( $value ) && ( intval( $value ) == $value );
+	}
+
+	public static function isPositiveInteger( $value ) {
+		return self::isInteger( $value ) && $value > 0;
+	}
+
+	public static function isNonNegativeInteger( $value ) {
+		return self::isInteger( $value ) && $value >= 0;
+	}
+}

--- a/extensions/wikia/Paginator/templates/paginator.tmpl.php
+++ b/extensions/wikia/Paginator/templates/paginator.tmpl.php
@@ -4,7 +4,7 @@
 	<? foreach($pages as $page ): ?>
 		<? if ($i === 1): ?>
 			<? if($page < $currentPage): ?>
-				<li><a href="<?= Sanitizer::encodeAttribute( str_replace( '%s', ( $currentPage - 1 ), $url ) ); ?>" data-back="true" data-page="<?= $currentPage - 1; ?>" class="paginator-prev button secondary"><span><?= wfMessage( 'paginator-back' )->escaped(); ?></span></a></li>
+				<li><a href="<?= Sanitizer::encodeAttribute( $urls[$currentPage - 1] ); ?>" data-back="true" data-page="<?= $currentPage - 1; ?>" class="paginator-prev button secondary"><span><?= wfMessage( 'paginator-back' )->escaped(); ?></span></a></li>
 			<? else: ?>
 				<li><span class="paginator-prev disabled"><span><?= wfMessage( 'paginator-back' )->escaped(); ?></span></span></li>
 			<? endif; ?>
@@ -12,11 +12,11 @@
 		<? if ( $page === '' ): ?>
 			<li><span class="paginator-spacer">...</span></li>
 		<? else: ?>
-			<li><a href="<?= Sanitizer::encodeAttribute( str_replace( '%s', $page, $url ) ); ?>" <? if( $currentPage > $page ) echo 'data-back="true"'; ?>  data-page="<?= Sanitizer::encodeAttribute( $page ); ?>" class="paginator-page<? if ( $page == $currentPage ) echo ' active'; ?>" ><?= htmlspecialchars( $page ); ?></a></li>
+			<li><a href="<?= Sanitizer::encodeAttribute( $urls[$page] ); ?>" <? if( $currentPage > $page ) echo 'data-back="true"'; ?>  data-page="<?= Sanitizer::encodeAttribute( $page ); ?>" class="paginator-page<? if ( $page == $currentPage ) echo ' active'; ?>" ><?= htmlspecialchars( $page ); ?></a></li>
 		<? endif; ?>
 		<? if ($i === count($pages)): ?>
 			<? if($page > $currentPage): ?>
-				<li><a href="<?= Sanitizer::encodeAttribute( str_replace( '%s', ( $currentPage + 1 ), $url ) ); ?>" data-page="<?=$currentPage + 1; ?>" class="paginator-next button secondary"><span><?= wfMessage( 'paginator-next' )->escaped(); ?></span></a></li>
+				<li><a href="<?= Sanitizer::encodeAttribute( $urls[$currentPage + 1] ); ?>" data-page="<?=$currentPage + 1; ?>" class="paginator-next button secondary"><span><?= wfMessage( 'paginator-next' )->escaped(); ?></span></a></li>
 			<? else: ?>
 				<li><span class="paginator-next disabled"><span><?= wfMessage( 'paginator-next' )->escaped(); ?></span></span></li>
 			<? endif; ?>

--- a/extensions/wikia/Paginator/tests/PaginatorTest.php
+++ b/extensions/wikia/Paginator/tests/PaginatorTest.php
@@ -289,8 +289,8 @@ class PaginatorTest extends WikiaBaseTest {
 	/**
 	 * Test the basic API of the class
 	 *
-	 * 1. Create an object of Paginator using new Paginator( (passing the number of items)
-	 * 2. Set the active page number through Paginator::setActivePage
+	 * 1. Create an object of Paginator using new Paginator()
+	 * 2. Set the active page number through Paginator::setActivePage()
 	 * 3. Get the current slice of the input array using Paginator::getCurrentPage (passing the array)
 	 * 4. Generate the HTML for the pagination bar by Paginator::getBarHTML
 	 *

--- a/extensions/wikia/Paginator/tests/PaginatorTest.php
+++ b/extensions/wikia/Paginator/tests/PaginatorTest.php
@@ -1,8 +1,8 @@
 <?php
 
-use Wikia\Paginator\Paginator;
+namespace Wikia\Paginator;
 
-class PaginatorTest extends WikiaBaseTest {
+class PaginatorTest extends \WikiaBaseTest {
 
 	private $alphabet = 'a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z';
 
@@ -194,16 +194,6 @@ class PaginatorTest extends WikiaBaseTest {
 		$this->mockGlobalFunction( 'wfMessage', $messageMock );
 	}
 
-	private function assertHtmlEquals( $expectedHtml, $actualHtml, $head = false ) {
-		if ( !$head && $expectedHtml ) {
-			$expectedHtml = "<div class=\"wikia-paginator\">\n<ul>$expectedHtml</ul>\n</div>";
-		}
-		$this->assertEquals(
-			array_map( 'trim', explode( "\n", str_replace( '" >', '">', preg_replace( '/ {2,}/', ' ', trim( $expectedHtml ) ) ) ) ),
-			array_map( 'trim', explode( "\n", str_replace( '" >', '">', preg_replace( '/ {2,}/', ' ', trim( $actualHtml ) ) ) ) )
-		);
-	}
-
 	public function dataProviderPaginator() {
 		return [
 			// Pages 1...4
@@ -322,6 +312,16 @@ class PaginatorTest extends WikiaBaseTest {
 		$html = $pages->getBarHTML();
 		$this->assertEquals( $expectedPageData, $onePageData );
 		$this->assertHtmlEquals( $expectedHtml, $html );
+	}
+
+	private function assertHtmlEquals( $expectedHtml, $actualHtml, $head = false ) {
+		if ( !$head && $expectedHtml ) {
+			$expectedHtml = "<div class=\"wikia-paginator\">\n<ul>$expectedHtml</ul>\n</div>";
+		}
+		$this->assertEquals(
+			array_map( 'trim', explode( "\n", str_replace( '" >', '">', preg_replace( '/ {2,}/', ' ', trim( $expectedHtml ) ) ) ) ),
+			array_map( 'trim', explode( "\n", str_replace( '" >', '">', preg_replace( '/ {2,}/', ' ', trim( $actualHtml ) ) ) ) )
+		);
 	}
 
 	/**

--- a/extensions/wikia/Paginator/tests/PaginatorTest.php
+++ b/extensions/wikia/Paginator/tests/PaginatorTest.php
@@ -1,186 +1,188 @@
 <?php
 
+use Wikia\Paginator\Paginator;
+
 class PaginatorTest extends WikiaBaseTest {
 
 	private $alphabet = 'a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z';
 
 	private $htmlPage1of4Selected = '
 		<li><span class="paginator-prev disabled"><span>escaped-msg</span></span></li>
-		<li><a href="http://url/?page=1" data-page="1" class="paginator-page active">1</a></li>
-		<li><a href="http://url/?page=2" data-page="2" class="paginator-page">2</a></li>
-		<li><a href="http://url/?page=3" data-page="3" class="paginator-page">3</a></li>
-		<li><a href="http://url/?page=4" data-page="4" class="paginator-page">4</a></li>
-		<li><a href="http://url/?page=2" data-page="2" class="paginator-next button secondary"><span>escaped-msg</span></a></li>
+		<li><a href="http://url/path?sort=desc" data-page="1" class="paginator-page active">1</a></li>
+		<li><a href="http://url/path?sort=desc&amp;page=2" data-page="2" class="paginator-page">2</a></li>
+		<li><a href="http://url/path?sort=desc&amp;page=3" data-page="3" class="paginator-page">3</a></li>
+		<li><a href="http://url/path?sort=desc&amp;page=4" data-page="4" class="paginator-page">4</a></li>
+		<li><a href="http://url/path?sort=desc&amp;page=2" data-page="2" class="paginator-next button secondary"><span>escaped-msg</span></a></li>
 	';
 
 	private $headPage1of4Selected = '
-		<link rel="next" href="http://url/?page=2" />
+		<link rel="next" href="http://url/path?sort=desc&amp;page=2" />
 	';
 
 	private $htmlPage2of4Selected = '
-		<li><a href="http://url/?page=1" data-back="true" data-page="1" class="paginator-prev button secondary"><span>escaped-msg</span></a></li>
-		<li><a href="http://url/?page=1" data-back="true" data-page="1" class="paginator-page">1</a></li>
-		<li><a href="http://url/?page=2" data-page="2" class="paginator-page active">2</a></li>
-		<li><a href="http://url/?page=3" data-page="3" class="paginator-page">3</a></li>
-		<li><a href="http://url/?page=4" data-page="4" class="paginator-page">4</a></li>
-		<li><a href="http://url/?page=3" data-page="3" class="paginator-next button secondary"><span>escaped-msg</span></a></li>
+		<li><a href="http://url/path?sort=desc" data-back="true" data-page="1" class="paginator-prev button secondary"><span>escaped-msg</span></a></li>
+		<li><a href="http://url/path?sort=desc" data-back="true" data-page="1" class="paginator-page">1</a></li>
+		<li><a href="http://url/path?sort=desc&amp;page=2" data-page="2" class="paginator-page active">2</a></li>
+		<li><a href="http://url/path?sort=desc&amp;page=3" data-page="3" class="paginator-page">3</a></li>
+		<li><a href="http://url/path?sort=desc&amp;page=4" data-page="4" class="paginator-page">4</a></li>
+		<li><a href="http://url/path?sort=desc&amp;page=3" data-page="3" class="paginator-next button secondary"><span>escaped-msg</span></a></li>
 	';
 
 	private $headPage2of4Selected = '
-		<link rel="prev" href="http://url/?page=1" />
-		<link rel="next" href="http://url/?page=3" />
+		<link rel="prev" href="http://url/path?sort=desc" />
+		<link rel="next" href="http://url/path?sort=desc&amp;page=3" />
 	';
 
 	private $htmlPage3of4Selected = '
-		<li><a href="http://url/?page=2" data-back="true" data-page="2" class="paginator-prev button secondary"><span>escaped-msg</span></a></li>
-		<li><a href="http://url/?page=1" data-back="true" data-page="1" class="paginator-page">1</a></li>
-		<li><a href="http://url/?page=2" data-back="true" data-page="2" class="paginator-page">2</a></li>
-		<li><a href="http://url/?page=3" data-page="3" class="paginator-page active">3</a></li>
-		<li><a href="http://url/?page=4" data-page="4" class="paginator-page">4</a></li>
-		<li><a href="http://url/?page=4" data-page="4" class="paginator-next button secondary"><span>escaped-msg</span></a></li>
+		<li><a href="http://url/path?sort=desc&amp;page=2" data-back="true" data-page="2" class="paginator-prev button secondary"><span>escaped-msg</span></a></li>
+		<li><a href="http://url/path?sort=desc" data-back="true" data-page="1" class="paginator-page">1</a></li>
+		<li><a href="http://url/path?sort=desc&amp;page=2" data-back="true" data-page="2" class="paginator-page">2</a></li>
+		<li><a href="http://url/path?sort=desc&amp;page=3" data-page="3" class="paginator-page active">3</a></li>
+		<li><a href="http://url/path?sort=desc&amp;page=4" data-page="4" class="paginator-page">4</a></li>
+		<li><a href="http://url/path?sort=desc&amp;page=4" data-page="4" class="paginator-next button secondary"><span>escaped-msg</span></a></li>
 	';
 
 	private $headPage3of4Selected = '
-		<link rel="prev" href="http://url/?page=2" />
-		<link rel="next" href="http://url/?page=4" />
+		<link rel="prev" href="http://url/path?sort=desc&amp;page=2" />
+		<link rel="next" href="http://url/path?sort=desc&amp;page=4" />
 	';
 
 	private $htmlPage4of4Selected = '
-		<li><a href="http://url/?page=3" data-back="true" data-page="3" class="paginator-prev button secondary"><span>escaped-msg</span></a></li>
-		<li><a href="http://url/?page=1" data-back="true" data-page="1" class="paginator-page">1</a></li>
-		<li><a href="http://url/?page=2" data-back="true" data-page="2" class="paginator-page">2</a></li>
-		<li><a href="http://url/?page=3" data-back="true" data-page="3" class="paginator-page">3</a></li>
-		<li><a href="http://url/?page=4" data-page="4" class="paginator-page active">4</a></li>
+		<li><a href="http://url/path?sort=desc&amp;page=3" data-back="true" data-page="3" class="paginator-prev button secondary"><span>escaped-msg</span></a></li>
+		<li><a href="http://url/path?sort=desc" data-back="true" data-page="1" class="paginator-page">1</a></li>
+		<li><a href="http://url/path?sort=desc&amp;page=2" data-back="true" data-page="2" class="paginator-page">2</a></li>
+		<li><a href="http://url/path?sort=desc&amp;page=3" data-back="true" data-page="3" class="paginator-page">3</a></li>
+		<li><a href="http://url/path?sort=desc&amp;page=4" data-page="4" class="paginator-page active">4</a></li>
 		<li><span class="paginator-next disabled"><span>escaped-msg</span></span></li>
 	';
 
 	private $headPage4of4Selected = '
-		<link rel="prev" href="http://url/?page=3" />
+		<link rel="prev" href="http://url/path?sort=desc&amp;page=3" />
 	';
 
 	private $alphabet2 = 'a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z';
 
 	private $htmlPage1of13Selected = '
 				<li><span class="paginator-prev disabled"><span>escaped-msg</span></span></li>
-				<li><a href="http://url/?page=1" data-page="1" class="paginator-page active">1</a></li>
-				<li><a href="http://url/?page=2" data-page="2" class="paginator-page">2</a></li>
-				<li><a href="http://url/?page=3" data-page="3" class="paginator-page">3</a></li>
-				<li><a href="http://url/?page=4" data-page="4" class="paginator-page">4</a></li>
+				<li><a href="http://url/path?sort=desc" data-page="1" class="paginator-page active">1</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=2" data-page="2" class="paginator-page">2</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=3" data-page="3" class="paginator-page">3</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=4" data-page="4" class="paginator-page">4</a></li>
 				<li><span class="paginator-spacer">...</span></li>
-				<li><a href="http://url/?page=13" data-page="13" class="paginator-page">13</a></li>
-				<li><a href="http://url/?page=2" data-page="2" class="paginator-next button secondary"><span>escaped-msg</span></a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=13" data-page="13" class="paginator-page">13</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=2" data-page="2" class="paginator-next button secondary"><span>escaped-msg</span></a></li>
 			';
 
 	private $headPage1of13Selected = '
-		<link rel="next" href="http://url/?page=2" />
+		<link rel="next" href="http://url/path?sort=desc&amp;page=2" />
 	';
 
 	private $htmlPage2of13Selected = '
-				<li><a href="http://url/?page=1" data-back="true" data-page="1" class="paginator-prev button secondary"><span>escaped-msg</span></a></li>
-				<li><a href="http://url/?page=1" data-back="true" data-page="1" class="paginator-page">1</a></li>
-				<li><a href="http://url/?page=2" data-page="2" class="paginator-page active">2</a></li>
-				<li><a href="http://url/?page=3" data-page="3" class="paginator-page">3</a></li>
-				<li><a href="http://url/?page=4" data-page="4" class="paginator-page">4</a></li>
-				<li><a href="http://url/?page=5" data-page="5" class="paginator-page">5</a></li>
+				<li><a href="http://url/path?sort=desc" data-back="true" data-page="1" class="paginator-prev button secondary"><span>escaped-msg</span></a></li>
+				<li><a href="http://url/path?sort=desc" data-back="true" data-page="1" class="paginator-page">1</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=2" data-page="2" class="paginator-page active">2</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=3" data-page="3" class="paginator-page">3</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=4" data-page="4" class="paginator-page">4</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=5" data-page="5" class="paginator-page">5</a></li>
 				<li><span class="paginator-spacer">...</span></li>
-				<li><a href="http://url/?page=13" data-page="13" class="paginator-page">13</a></li>
-				<li><a href="http://url/?page=3" data-page="3" class="paginator-next button secondary"><span>escaped-msg</span></a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=13" data-page="13" class="paginator-page">13</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=3" data-page="3" class="paginator-next button secondary"><span>escaped-msg</span></a></li>
 			';
 
 	private $headPage2of13Selected = '
-		<link rel="prev" href="http://url/?page=1" />
-		<link rel="next" href="http://url/?page=3" />
+		<link rel="prev" href="http://url/path?sort=desc" />
+		<link rel="next" href="http://url/path?sort=desc&amp;page=3" />
 	';
 
 	private $htmlPage4of13Selected = '
-				<li><a href="http://url/?page=3" data-back="true" data-page="3" class="paginator-prev button secondary"><span>escaped-msg</span></a></li>
-				<li><a href="http://url/?page=1" data-back="true" data-page="1" class="paginator-page">1</a></li>
-				<li><a href="http://url/?page=2" data-back="true" data-page="2" class="paginator-page">2</a></li>
-				<li><a href="http://url/?page=3" data-back="true" data-page="3" class="paginator-page">3</a></li>
-				<li><a href="http://url/?page=4" data-page="4" class="paginator-page active">4</a></li>
-				<li><a href="http://url/?page=5" data-page="5" class="paginator-page">5</a></li>
-				<li><a href="http://url/?page=6" data-page="6" class="paginator-page">6</a></li>
-				<li><a href="http://url/?page=7" data-page="7" class="paginator-page">7</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=3" data-back="true" data-page="3" class="paginator-prev button secondary"><span>escaped-msg</span></a></li>
+				<li><a href="http://url/path?sort=desc" data-back="true" data-page="1" class="paginator-page">1</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=2" data-back="true" data-page="2" class="paginator-page">2</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=3" data-back="true" data-page="3" class="paginator-page">3</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=4" data-page="4" class="paginator-page active">4</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=5" data-page="5" class="paginator-page">5</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=6" data-page="6" class="paginator-page">6</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=7" data-page="7" class="paginator-page">7</a></li>
 				<li><span class="paginator-spacer">...</span></li>
-				<li><a href="http://url/?page=13" data-page="13" class="paginator-page">13</a></li>
-				<li><a href="http://url/?page=5" data-page="5" class="paginator-next button secondary"><span>escaped-msg</span></a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=13" data-page="13" class="paginator-page">13</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=5" data-page="5" class="paginator-next button secondary"><span>escaped-msg</span></a></li>
 			';
 
 	private $headPage4of13Selected = '
-		<link rel="prev" href="http://url/?page=3" />
-		<link rel="next" href="http://url/?page=5" />
+		<link rel="prev" href="http://url/path?sort=desc&amp;page=3" />
+		<link rel="next" href="http://url/path?sort=desc&amp;page=5" />
 	';
 
 	private $htmlPage7of13Selected = '
-				<li><a href="http://url/?page=6" data-back="true" data-page="6" class="paginator-prev button secondary"><span>escaped-msg</span></a></li>
-				<li><a href="http://url/?page=1" data-back="true" data-page="1" class="paginator-page">1</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=6" data-back="true" data-page="6" class="paginator-prev button secondary"><span>escaped-msg</span></a></li>
+				<li><a href="http://url/path?sort=desc" data-back="true" data-page="1" class="paginator-page">1</a></li>
 				<li><span class="paginator-spacer">...</span></li>
-				<li><a href="http://url/?page=4" data-back="true" data-page="4" class="paginator-page">4</a></li>
-				<li><a href="http://url/?page=5" data-back="true" data-page="5" class="paginator-page">5</a></li>
-				<li><a href="http://url/?page=6" data-back="true" data-page="6" class="paginator-page">6</a></li>
-				<li><a href="http://url/?page=7" data-page="7" class="paginator-page active">7</a></li>
-				<li><a href="http://url/?page=8" data-page="8" class="paginator-page">8</a></li>
-				<li><a href="http://url/?page=9" data-page="9" class="paginator-page">9</a></li>
-				<li><a href="http://url/?page=10" data-page="10" class="paginator-page">10</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=4" data-back="true" data-page="4" class="paginator-page">4</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=5" data-back="true" data-page="5" class="paginator-page">5</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=6" data-back="true" data-page="6" class="paginator-page">6</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=7" data-page="7" class="paginator-page active">7</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=8" data-page="8" class="paginator-page">8</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=9" data-page="9" class="paginator-page">9</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=10" data-page="10" class="paginator-page">10</a></li>
 				<li><span class="paginator-spacer">...</span></li>
-				<li><a href="http://url/?page=13" data-page="13" class="paginator-page">13</a></li>
-				<li><a href="http://url/?page=8" data-page="8" class="paginator-next button secondary"><span>escaped-msg</span></a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=13" data-page="13" class="paginator-page">13</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=8" data-page="8" class="paginator-next button secondary"><span>escaped-msg</span></a></li>
 			';
 
 	private $headPage7of13Selected = '
-		<link rel="prev" href="http://url/?page=6" />
-		<link rel="next" href="http://url/?page=8" />
+		<link rel="prev" href="http://url/path?sort=desc&amp;page=6" />
+		<link rel="next" href="http://url/path?sort=desc&amp;page=8" />
 	';
 
 	private $htmlPage10of13Selected = '
-				<li><a href="http://url/?page=9" data-back="true" data-page="9" class="paginator-prev button secondary"><span>escaped-msg</span></a></li>
-				<li><a href="http://url/?page=1" data-back="true" data-page="1" class="paginator-page">1</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=9" data-back="true" data-page="9" class="paginator-prev button secondary"><span>escaped-msg</span></a></li>
+				<li><a href="http://url/path?sort=desc" data-back="true" data-page="1" class="paginator-page">1</a></li>
 				<li><span class="paginator-spacer">...</span></li>
-				<li><a href="http://url/?page=7" data-back="true" data-page="7" class="paginator-page">7</a></li>
-				<li><a href="http://url/?page=8" data-back="true" data-page="8" class="paginator-page">8</a></li>
-				<li><a href="http://url/?page=9" data-back="true" data-page="9" class="paginator-page">9</a></li>
-				<li><a href="http://url/?page=10" data-page="10" class="paginator-page active">10</a></li>
-				<li><a href="http://url/?page=11" data-page="11" class="paginator-page">11</a></li>
-				<li><a href="http://url/?page=12" data-page="12" class="paginator-page">12</a></li>
-				<li><a href="http://url/?page=13" data-page="13" class="paginator-page">13</a></li>
-				<li><a href="http://url/?page=11" data-page="11" class="paginator-next button secondary"><span>escaped-msg</span></a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=7" data-back="true" data-page="7" class="paginator-page">7</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=8" data-back="true" data-page="8" class="paginator-page">8</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=9" data-back="true" data-page="9" class="paginator-page">9</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=10" data-page="10" class="paginator-page active">10</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=11" data-page="11" class="paginator-page">11</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=12" data-page="12" class="paginator-page">12</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=13" data-page="13" class="paginator-page">13</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=11" data-page="11" class="paginator-next button secondary"><span>escaped-msg</span></a></li>
 			';
 
 	private $headPage10of13Selected = '
-		<link rel="prev" href="http://url/?page=9" />
-		<link rel="next" href="http://url/?page=11" />
+		<link rel="prev" href="http://url/path?sort=desc&amp;page=9" />
+		<link rel="next" href="http://url/path?sort=desc&amp;page=11" />
 	';
 
 	private $htmlPage12of13Selected = '
-				<li><a href="http://url/?page=11" data-back="true" data-page="11" class="paginator-prev button secondary"><span>escaped-msg</span></a></li>
-				<li><a href="http://url/?page=1" data-back="true" data-page="1" class="paginator-page">1</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=11" data-back="true" data-page="11" class="paginator-prev button secondary"><span>escaped-msg</span></a></li>
+				<li><a href="http://url/path?sort=desc" data-back="true" data-page="1" class="paginator-page">1</a></li>
 				<li><span class="paginator-spacer">...</span></li>
-				<li><a href="http://url/?page=9" data-back="true" data-page="9" class="paginator-page">9</a></li>
-				<li><a href="http://url/?page=10" data-back="true" data-page="10" class="paginator-page">10</a></li>
-				<li><a href="http://url/?page=11" data-back="true" data-page="11" class="paginator-page">11</a></li>
-				<li><a href="http://url/?page=12" data-page="12" class="paginator-page active">12</a></li>
-				<li><a href="http://url/?page=13" data-page="13" class="paginator-page">13</a></li>
-				<li><a href="http://url/?page=13" data-page="13" class="paginator-next button secondary"><span>escaped-msg</span></a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=9" data-back="true" data-page="9" class="paginator-page">9</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=10" data-back="true" data-page="10" class="paginator-page">10</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=11" data-back="true" data-page="11" class="paginator-page">11</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=12" data-page="12" class="paginator-page active">12</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=13" data-page="13" class="paginator-page">13</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=13" data-page="13" class="paginator-next button secondary"><span>escaped-msg</span></a></li>
 			';
 
 	private $headPage12of13Selected = '
-		<link rel="prev" href="http://url/?page=11" />
-		<link rel="next" href="http://url/?page=13" />
+		<link rel="prev" href="http://url/path?sort=desc&amp;page=11" />
+		<link rel="next" href="http://url/path?sort=desc&amp;page=13" />
 	';
 
 	private $htmlPage13of13Selected = '
-				<li><a href="http://url/?page=12" data-back="true" data-page="12" class="paginator-prev button secondary"><span>escaped-msg</span></a></li>
-				<li><a href="http://url/?page=1" data-back="true" data-page="1" class="paginator-page">1</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=12" data-back="true" data-page="12" class="paginator-prev button secondary"><span>escaped-msg</span></a></li>
+				<li><a href="http://url/path?sort=desc" data-back="true" data-page="1" class="paginator-page">1</a></li>
 				<li><span class="paginator-spacer">...</span></li>
-				<li><a href="http://url/?page=10" data-back="true" data-page="10" class="paginator-page">10</a></li>
-				<li><a href="http://url/?page=11" data-back="true" data-page="11" class="paginator-page">11</a></li>
-				<li><a href="http://url/?page=12" data-back="true" data-page="12" class="paginator-page">12</a></li>
-				<li><a href="http://url/?page=13" data-page="13" class="paginator-page active">13</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=10" data-back="true" data-page="10" class="paginator-page">10</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=11" data-back="true" data-page="11" class="paginator-page">11</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=12" data-back="true" data-page="12" class="paginator-page">12</a></li>
+				<li><a href="http://url/path?sort=desc&amp;page=13" data-page="13" class="paginator-page active">13</a></li>
 				<li><span class="paginator-next disabled"><span>escaped-msg</span></span></li>
 			';
 
 	private $headPage13of13Selected = '
-		<link rel="prev" href="http://url/?page=12" />
+		<link rel="prev" href="http://url/path?sort=desc&amp;page=12" />
 	';
 
 	public function setUp() {
@@ -285,35 +287,9 @@ class PaginatorTest extends WikiaBaseTest {
 	}
 
 	/**
-	 * Test the deprecated API of the class
-	 *
-	 * 1. Create an object of Paginator using Paginator::newFromArray (passing the array of items)
-	 * 2. Set the active page number through Paginator::setActivePage
-	 * 3. Get the current slice of the input array using Paginator::getCurrentPage
-	 * 4. Generate the HTML for the pagination bar by Paginator::getBarHTML
-	 *
-	 * This style of calling the class is only used by:
-	 *
-	 *  * CrunchyrollVideo
-	 *
-	 * @dataProvider dataProviderPaginator
-	 */
-	public function testDeprecatedApi( $itemsPerPage, $allDataString, $pageNo, $pageDataString, $expectedHtml ) {
-		$url = 'http://url/?page=%s';
-		$allData = explode( ',', $allDataString );
-		$expectedPageData = explode( ',', $pageDataString );
-		$pages = Paginator::newFromArray( $allData, $itemsPerPage );
-		$pages->setActivePage( $pageNo );
-		$onePageData = $pages->getCurrentPage();
-		$html = $pages->getBarHTML( $url );
-		$this->assertEquals( $expectedPageData, $onePageData );
-		$this->assertHtmlEquals( $expectedHtml, $html );
-	}
-
-	/**
 	 * Test the basic API of the class
 	 *
-	 * 1. Create an object of Paginator using Paginator::newFromCount (passing the number of items)
+	 * 1. Create an object of Paginator using new Paginator( (passing the number of items)
 	 * 2. Set the active page number through Paginator::setActivePage
 	 * 3. Get the current slice of the input array using Paginator::getCurrentPage (passing the array)
 	 * 4. Generate the HTML for the pagination bar by Paginator::getBarHTML
@@ -337,13 +313,13 @@ class PaginatorTest extends WikiaBaseTest {
 	 * @dataProvider dataProviderPaginator
 	 */
 	public function testPaginator( $itemsPerPage, $allDataString, $pageNo, $pageDataString, $expectedHtml ) {
-		$url = 'http://url/?page=%s';
+		$url = 'http://url/path?sort=desc';
 		$allData = explode( ',', $allDataString );
 		$expectedPageData = explode( ',', $pageDataString );
-		$pages = Paginator::newFromCount( count( $allData ), $itemsPerPage );
+		$pages = new Paginator( count( $allData ), $itemsPerPage, $url );
 		$pages->setActivePage( $pageNo );
 		$onePageData = $pages->getCurrentPage( $allData );
-		$html = $pages->getBarHTML( $url );
+		$html = $pages->getBarHTML();
 		$this->assertEquals( $expectedPageData, $onePageData );
 		$this->assertHtmlEquals( $expectedHtml, $html );
 	}
@@ -354,13 +330,13 @@ class PaginatorTest extends WikiaBaseTest {
 	 * @dataProvider dataProviderPaginator
 	 */
 	public function testPaginatorStrings( $itemsPerPage, $allDataString, $pageNo, $pageDataString, $expectedHtml ) {
-		$url = 'http://url/?page=%s';
+		$url = 'http://url/path?sort=desc';
 		$allData = explode( ',', $allDataString );
 		$expectedPageData = explode( ',', $pageDataString );
-		$pages = Paginator::newFromCount( (string) count( $allData ), (string) $itemsPerPage );
+		$pages = new Paginator( (string) count( $allData ), (string) $itemsPerPage, $url );
 		$pages->setActivePage( $pageNo );
 		$onePageData = $pages->getCurrentPage( $allData );
-		$html = $pages->getBarHTML( $url );
+		$html = $pages->getBarHTML();
 		$this->assertEquals( $expectedPageData, $onePageData );
 		$this->assertHtmlEquals( $expectedHtml, $html );
 	}
@@ -377,10 +353,32 @@ class PaginatorTest extends WikiaBaseTest {
 	 * @dataProvider dataProviderHeadItem
 	 */
 	public function testHeadItem( $count, $perPage, $activePage, $expectedHtml ) {
-		$url = 'http://url/?page=%s';
-		$pages = Paginator::newFromCount( $count, $perPage );
+		$url = 'http://url/path?sort=desc';
+		$pages = new Paginator( $count, $perPage, $url );
 		$pages->setActivePage( $activePage );
-		$html = $pages->getHeadItem( $url );
+		$html = $pages->getHeadItem();
 		$this->assertHtmlEquals( $expectedHtml, $html, true );
+	}
+
+	/**
+	 * Custom URL param for passing page number
+	 */
+	public function testPaginatorPassUrlParam() {
+		$pages = new Paginator( 20, 5, 'http://url/path?sort=desc', [
+			'paramName' => 'customParamName'
+		] );
+		$pages->setActivePage( 2 );
+		$this->assertHtmlEquals( '
+			<li><a href="http://url/path?sort=desc" data-back="true" data-page="1" class="paginator-prev button secondary"><span>escaped-msg</span></a></li>
+			<li><a href="http://url/path?sort=desc" data-back="true" data-page="1" class="paginator-page">1</a></li>
+			<li><a href="http://url/path?sort=desc&amp;customParamName=2" data-page="2" class="paginator-page active">2</a></li>
+			<li><a href="http://url/path?sort=desc&amp;customParamName=3" data-page="3" class="paginator-page">3</a></li>
+			<li><a href="http://url/path?sort=desc&amp;customParamName=4" data-page="4" class="paginator-page">4</a></li>
+			<li><a href="http://url/path?sort=desc&amp;customParamName=3" data-page="3" class="paginator-next button secondary"><span>escaped-msg</span></a></li>
+		', $pages->getBarHTML() );
+		$this->assertHtmlEquals( '
+			<link rel="prev" href="http://url/path?sort=desc" />
+			<link rel="next" href="http://url/path?sort=desc&amp;customParamName=3" />
+		', $pages->getHeadItem(), true );
 	}
 }

--- a/extensions/wikia/Paginator/tests/PaginatorUrlGeneratorTest.php
+++ b/extensions/wikia/Paginator/tests/PaginatorUrlGeneratorTest.php
@@ -1,0 +1,99 @@
+<?php
+
+use Wikia\Paginator\UrlGenerator;
+
+class PaginatorUrlGeneratorTest extends WikiaBaseTest {
+	public function dataProviderGetUrlForPage() {
+		return [
+			// Invalid pageUrlParam number
+			[ '', 'pageUrlParam', 1, 'a', null, 'InvalidArgumentException' ],
+			[ '', 'pageUrlParam', 1, [], null,  'InvalidArgumentException' ],
+			[ '', 'pageUrlParam', 1, 2, null, 'InvalidArgumentException' ],
+
+			// Empty URL
+			[ '', 'pageUrlParam', 0, 1, '' ],
+			[ '', 'pageUrlParam', 1, 1, '' ],
+			[ '', 'pageUrlParam', 2, 1, '' ],
+			[ '', 'pageUrlParam', 2, 2, '?pageUrlParam=2' ],
+			[ '', 'pageUrlParam', 10, 1, '' ],
+			[ '', 'pageUrlParam', 10, 5, '?pageUrlParam=5' ],
+			[ '', 'pageUrlParam', 10, 10, '?pageUrlParam=10' ],
+
+			// Full URL
+			[ 'http://wikia.com/WAM', 'pageUrlParam', 0, 1, 'http://wikia.com/WAM' ],
+			[ 'http://wikia.com/WAM', 'pageUrlParam', 1, 1, 'http://wikia.com/WAM' ],
+			[ 'http://wikia.com/WAM', 'pageUrlParam', 2, 1, 'http://wikia.com/WAM' ],
+			[ 'http://wikia.com/WAM', 'pageUrlParam', 2, 2, 'http://wikia.com/WAM?pageUrlParam=2' ],
+			[ 'http://wikia.com/WAM', 'pageUrlParam', 10, 1, 'http://wikia.com/WAM' ],
+			[ 'http://wikia.com/WAM', 'pageUrlParam', 10, 5, 'http://wikia.com/WAM?pageUrlParam=5' ],
+			[ 'http://wikia.com/WAM', 'pageUrlParam', 10, 10, 'http://wikia.com/WAM?pageUrlParam=10' ],
+
+			// Partial URL
+			[ '/WAM', 'pageUrlParam', 0, 1, '/WAM' ],
+			[ '/WAM', 'pageUrlParam', 1, 1, '/WAM' ],
+			[ '/WAM', 'pageUrlParam', 2, 1, '/WAM' ],
+			[ '/WAM', 'pageUrlParam', 2, 2, '/WAM?pageUrlParam=2' ],
+			[ '/WAM', 'pageUrlParam', 10, 1, '/WAM' ],
+			[ '/WAM', 'pageUrlParam', 10, 5, '/WAM?pageUrlParam=5' ],
+			[ '/WAM', 'pageUrlParam', 10, 10, '/WAM?pageUrlParam=10' ],
+
+			// Partial URL with one param
+			[ '/WAM?sort=desc', 'pageUrlParam', 0, 1, '/WAM?sort=desc' ],
+			[ '/WAM?sort=desc', 'pageUrlParam', 1, 1, '/WAM?sort=desc' ],
+			[ '/WAM?sort=desc', 'pageUrlParam', 2, 1, '/WAM?sort=desc' ],
+			[ '/WAM?sort=desc', 'pageUrlParam', 2, 2, '/WAM?sort=desc&pageUrlParam=2' ],
+			[ '/WAM?sort=desc', 'pageUrlParam', 10, 1, '/WAM?sort=desc' ],
+			[ '/WAM?sort=desc', 'pageUrlParam', 10, 5, '/WAM?sort=desc&pageUrlParam=5' ],
+			[ '/WAM?sort=desc', 'pageUrlParam', 10, 10, '/WAM?sort=desc&pageUrlParam=10' ],
+
+			// Partial URL with two params
+			[ '/WAM?sort=desc&hub=tv', 'pageUrlParam', 0, 1, '/WAM?sort=desc&hub=tv' ],
+			[ '/WAM?sort=desc&hub=tv', 'pageUrlParam', 1, 1, '/WAM?sort=desc&hub=tv' ],
+			[ '/WAM?sort=desc&hub=tv', 'pageUrlParam', 2, 1, '/WAM?sort=desc&hub=tv' ],
+			[ '/WAM?sort=desc&hub=tv', 'pageUrlParam', 2, 2, '/WAM?sort=desc&hub=tv&pageUrlParam=2' ],
+			[ '/WAM?sort=desc&hub=tv', 'pageUrlParam', 10, 1, '/WAM?sort=desc&hub=tv' ],
+			[ '/WAM?sort=desc&hub=tv', 'pageUrlParam', 10, 5, '/WAM?sort=desc&hub=tv&pageUrlParam=5' ],
+			[ '/WAM?sort=desc&hub=tv', 'pageUrlParam', 10, 10, '/WAM?sort=desc&hub=tv&pageUrlParam=10' ],
+
+			// Empty URL with one param
+			[ '?sort=desc', 'pageUrlParam', 0, 1, '?sort=desc' ],
+			[ '?sort=desc', 'pageUrlParam', 1, 1, '?sort=desc' ],
+			[ '?sort=desc', 'pageUrlParam', 2, 1, '?sort=desc' ],
+			[ '?sort=desc', 'pageUrlParam', 2, 2, '?sort=desc&pageUrlParam=2' ],
+			[ '?sort=desc', 'pageUrlParam', 10, 1, '?sort=desc' ],
+			[ '?sort=desc', 'pageUrlParam', 10, 5, '?sort=desc&pageUrlParam=5' ],
+			[ '?sort=desc', 'pageUrlParam', 10, 10, '?sort=desc&pageUrlParam=10' ],
+
+			// Empty URL with two params
+			[ '?sort=desc&hub=tv', 'pageUrlParam', 0, 1, '?sort=desc&hub=tv' ],
+			[ '?sort=desc&hub=tv', 'pageUrlParam', 1, 1, '?sort=desc&hub=tv' ],
+			[ '?sort=desc&hub=tv', 'pageUrlParam', 2, 1, '?sort=desc&hub=tv' ],
+			[ '?sort=desc&hub=tv', 'pageUrlParam', 2, 2, '?sort=desc&hub=tv&pageUrlParam=2' ],
+			[ '?sort=desc&hub=tv', 'pageUrlParam', 10, 1, '?sort=desc&hub=tv' ],
+			[ '?sort=desc&hub=tv', 'pageUrlParam', 10, 5, '?sort=desc&hub=tv&pageUrlParam=5' ],
+			[ '?sort=desc&hub=tv', 'pageUrlParam', 10, 10, '?sort=desc&hub=tv&pageUrlParam=10' ],
+
+			// Special case: 0 items in total, requesting first pageUrlParam
+		];
+	}
+
+	/**
+	 * @param $url
+	 * @param $pageParam
+	 * @param $pagesCount
+	 * @param $pageNumber
+	 * @param $expectedUrl
+	 * @param $exceptionClass
+	 *
+	 * @dataProvider dataProviderGetUrlForPage
+	 */
+	public function testGetUrlForPage( $url, $pageParam, $pagesCount, $pageNumber, $expectedUrl, $exceptionClass = null ) {
+		$urlGenerator = new UrlGenerator( $url, $pageParam, $pagesCount );
+		if ( $exceptionClass ) {
+			$this->setExpectedException( $exceptionClass );
+			$urlGenerator->getUrlForPage( $pageNumber );
+		} else {
+			$this->assertEquals( $expectedUrl, $urlGenerator->getUrlForPage( $pageNumber ) );
+		}
+	}
+}

--- a/extensions/wikia/Paginator/tests/UrlGeneratorTest.php
+++ b/extensions/wikia/Paginator/tests/UrlGeneratorTest.php
@@ -5,10 +5,11 @@ namespace Wikia\Paginator;
 class UrlGeneratorTest extends \WikiaBaseTest {
 	public function dataProviderGetUrlForPage() {
 		return [
-			// Invalid pageUrlParam number
+			// Invalid page number
 			[ '', 'pageUrlParam', 1, 'a', null, 'InvalidArgumentException' ],
 			[ '', 'pageUrlParam', 1, [], null, 'InvalidArgumentException' ],
 			[ '', 'pageUrlParam', 1, 2, null, 'InvalidArgumentException' ],
+			[ '', 'pageUrlParam', 1, null, null, 'InvalidArgumentException' ],
 
 			// Empty URL
 			[ '', 'pageUrlParam', 0, 1, '' ],

--- a/extensions/wikia/Paginator/tests/UrlGeneratorTest.php
+++ b/extensions/wikia/Paginator/tests/UrlGeneratorTest.php
@@ -2,7 +2,7 @@
 
 use Wikia\Paginator\UrlGenerator;
 
-class PaginatorUrlGeneratorTest extends WikiaBaseTest {
+class UrlGeneratorTest extends WikiaBaseTest {
 	public function dataProviderGetUrlForPage() {
 		return [
 			// Invalid pageUrlParam number

--- a/extensions/wikia/Paginator/tests/UrlGeneratorTest.php
+++ b/extensions/wikia/Paginator/tests/UrlGeneratorTest.php
@@ -1,13 +1,13 @@
 <?php
 
-use Wikia\Paginator\UrlGenerator;
+namespace Wikia\Paginator;
 
-class UrlGeneratorTest extends WikiaBaseTest {
+class UrlGeneratorTest extends \WikiaBaseTest {
 	public function dataProviderGetUrlForPage() {
 		return [
 			// Invalid pageUrlParam number
 			[ '', 'pageUrlParam', 1, 'a', null, 'InvalidArgumentException' ],
-			[ '', 'pageUrlParam', 1, [], null,  'InvalidArgumentException' ],
+			[ '', 'pageUrlParam', 1, [], null, 'InvalidArgumentException' ],
 			[ '', 'pageUrlParam', 1, 2, null, 'InvalidArgumentException' ],
 
 			// Empty URL

--- a/extensions/wikia/SpecialManageWikiaHome/ManageWikiaHomeController.class.php
+++ b/extensions/wikia/SpecialManageWikiaHome/ManageWikiaHomeController.class.php
@@ -1,4 +1,6 @@
 <?php
+use Wikia\Paginator\Paginator;
+
 class ManageWikiaHomeController extends WikiaSpecialPageController {
 	const WHST_VISUALIZATION_LANG_VAR_NAME = 'vl';
 	const WHST_WIKIS_PER_PAGE = 25;
@@ -248,13 +250,11 @@ class ManageWikiaHomeController extends WikiaSpecialPageController {
 		$this->verticals = $this->helper->getWikiVerticals();
 
 		if( $count > self::WHST_WIKIS_PER_PAGE ) {
-			/** @var $paginator Paginator */
-			$paginator = Paginator::newFromCount( $count, self::WHST_WIKIS_PER_PAGE );
-
-			$paginator->setActivePage($currentPage);
-
 			$url = $this->getUrlWithAllParams($visualizationLang, $filterOptions);
-			$this->setVal('pagination', $paginator->getBarHTML($url));
+			/** @var $paginator Paginator */
+			$paginator = new Paginator( $count, self::WHST_WIKIS_PER_PAGE, $url );
+			$paginator->setActivePage($currentPage);
+			$this->setVal('pagination', $paginator->getBarHTML());
 		}
 
 		wfProfileOut(__METHOD__);
@@ -632,7 +632,6 @@ class ManageWikiaHomeController extends WikiaSpecialPageController {
 				'wiki-blocked-filter' => isset($filterParams['wiki-blocked-filter']) ? $filterParams['wiki-blocked-filter'] : 0,
 				'wiki-promoted-filter' => isset($filterParams['wiki-promoted-filter']) ? $filterParams['wiki-promoted-filter'] : 0,
 				'wiki-official-filter' => isset($filterParams['wiki-official-filter']) ? $filterParams['wiki-official-filter'] : 0,
-				'page' => '%s',
 				'vl' => $lang
 			];
 

--- a/extensions/wikia/SpecialVideos/SpecialVideosHelper.class.php
+++ b/extensions/wikia/SpecialVideos/SpecialVideosHelper.class.php
@@ -1,4 +1,5 @@
 <?php
+use Wikia\Paginator\Paginator;
 
 /**
  * SpecialVideos Helper
@@ -209,19 +210,19 @@ class SpecialVideosHelper extends WikiaModel {
 		$totalVideos = $this->getTotalVideos( $videoParams );
 
 		if ( $totalVideos > self::VIDEOS_PER_PAGE ) {
-			$pages = Paginator::newFromCount( $totalVideos, self::VIDEOS_PER_PAGE );
-			$pages->setActivePage( $videoParams['page'] );
-
-			$urlTemplate = SpecialPage::getTitleFor( 'Videos' )->escapeLocalUrl();
-			$urlTemplate .= '?page=%s';
+			$urlParams = [];
 			foreach( [ 'sort', 'category', 'provider'] as $key ) {
 				if ( !empty( $videoParams[$key] ) ) {
-					$urlTemplate .= "&$key=" . urlencode( $videoParams[$key] );
+					$urlParams[$key] = $videoParams[$key];
 				}
 			}
+			$url = SpecialPage::getTitleFor( 'Videos' )->escapeLocalUrl( $urlParams );
 
-			$body = $pages->getBarHTML( $urlTemplate );
-			$head = $pages->getHeadItem( $urlTemplate );
+			$pages = new Paginator( $totalVideos, self::VIDEOS_PER_PAGE, $url );
+			$pages->setActivePage( $videoParams['page'] );
+
+			$body = $pages->getBarHTML();
+			$head = $pages->getHeadItem();
 
 			// check if we're on the last page
 			if ( $videoParams['page'] < $pages->getPagesCount() ) {

--- a/extensions/wikia/TemplateClassification/specials/TemplatesSpecialController.class.php
+++ b/extensions/wikia/TemplateClassification/specials/TemplatesSpecialController.class.php
@@ -1,5 +1,7 @@
 <?php
 
+use Wikia\Paginator\Paginator;
+
 class TemplatesSpecialController extends WikiaSpecialPageController {
 
 	const ITEMS_PER_PAGE = 20;
@@ -245,7 +247,7 @@ class TemplatesSpecialController extends WikiaSpecialPageController {
 	 * @param int $page
 	 */
 	private function preparePagination( $total, $page ) {
-		$params = [ 'page' => '%s' ];
+		$params = [];
 
 		if ( $this->type ) {
 			$params['type'] = $this->type;
@@ -254,11 +256,11 @@ class TemplatesSpecialController extends WikiaSpecialPageController {
 		if ( $this->templateName ) {
 			$params['template'] = $this->templateName;
 		}
-
-		$paginator = Paginator::newFromCount( $total, self::ITEMS_PER_PAGE );
-		$paginator->setActivePage( $page + 1 );
 		$url = urldecode( $this->specialPage->getTitle()->getLocalUrl( $params ) );
-		$this->paginatorBar = $paginator->getBarHTML( $url );
+
+		$paginator = new Paginator( $total, self::ITEMS_PER_PAGE, $url );
+		$paginator->setActivePage( $page + 1 );
+		$this->paginatorBar = $paginator->getBarHTML();
 	}
 
 	/**

--- a/extensions/wikia/TemplateClassification/specials/TemplatesSpecialController.class.php
+++ b/extensions/wikia/TemplateClassification/specials/TemplatesSpecialController.class.php
@@ -256,7 +256,7 @@ class TemplatesSpecialController extends WikiaSpecialPageController {
 		if ( $this->templateName ) {
 			$params['template'] = $this->templateName;
 		}
-		$url = urldecode( $this->specialPage->getTitle()->getLocalUrl( $params ) );
+		$url = $this->specialPage->getTitle()->getLocalUrl( $params );
 
 		$paginator = new Paginator( $total, self::ITEMS_PER_PAGE, $url );
 		$paginator->setActivePage( $page + 1 );

--- a/extensions/wikia/UserActivity/SpecialUserActivityController.class.php
+++ b/extensions/wikia/UserActivity/SpecialUserActivityController.class.php
@@ -80,15 +80,13 @@ class SpecialController extends \WikiaSpecialPageController {
 	}
 
 	private function getPagination( $total, $page, $order ) {
-		$pagination = '';
-		if ( $total > self::ITEMS_PER_PAGE ) {
-			$pages = \Paginator::newFromCount( $total, self::ITEMS_PER_PAGE );
-			$pages->setActivePage( $page );
+		$url = \SpecialPage::getTitleFor( 'UserActivity' )->escapeLocalUrl( [
+			'order' => $order
+		]);
 
-			$linkToSpecialPage = \SpecialPage::getTitleFor( 'UserActivity' )->escapeLocalUrl();
-			$pagination = $pages->getBarHTML( $linkToSpecialPage.'?page=%s&order='.$order );
-		}
+		$pages = new \Wikia\Paginator\Paginator( $total, self::ITEMS_PER_PAGE, $url );
+		$pages->setActivePage( $page );
 
-		return $pagination;
+		return $pages->getBarHTML();
 	}
 }

--- a/extensions/wikia/WAMPage/WAMPageController.class.php
+++ b/extensions/wikia/WAMPage/WAMPageController.class.php
@@ -1,5 +1,7 @@
 <?php
 
+use Wikia\Paginator\Paginator;
+
 class WAMPageController extends WikiaController
 {
 	const DEFAULT_LANG_CODE = 'en';
@@ -38,10 +40,10 @@ class WAMPageController extends WikiaController
 		$total = ( empty( $this->indexWikis['wam_results_total'] ) ) ? 0 : $this->indexWikis['wam_results_total'];
 		$itemsPerPage = $this->model->getItemsPerPage();
 		if( $total > $itemsPerPage ) {
-			$paginator = Paginator::newFromCount( $total, $itemsPerPage );
+			$paginator = new Paginator( $total, $itemsPerPage, $this->getUrlForPagination() );
 			$paginator->setActivePage( $this->page );
-			$this->paginatorBar = $paginator->getBarHTML( $this->getUrlWithAllParams() );
-			$this->wg->Out->addHeadItem( 'Pagination', $paginator->getHeadItem( $this->getUrlWithAllParams() ) );
+			$this->paginatorBar = $paginator->getBarHTML();
+			$this->wg->Out->addHeadItem( 'Pagination', $paginator->getHeadItem() );
 		}
 	}
 
@@ -116,24 +118,20 @@ class WAMPageController extends WikiaController
 	}
 
 	protected function getIndexParams($forPaginator = false) {
-		if( $forPaginator ) {
-			$page = '%s';
-		} else {
-			$page = $this->page;
-		}
-
 		$indexParams = [
 			'searchPhrase' => $this->searchPhrase,
 			'verticalId' => Sanitizer::encodeAttribute( $this->selectedVerticalId ),
 			'langCode' => $this->selectedLangCode,
-			'date' => isset($this->selectedDate) ? $this->selectedDate : null,
-			'page' => Sanitizer::encodeAttribute( $page ),
+			'date' => isset( $this->selectedDate ) ? $this->selectedDate : null,
 		];
+		if ( !$forPaginator ) {
+			$indexParams['page'] = Sanitizer::encodeAttribute( $this->page );
+		}
 
 		return $indexParams;
 	}
 
-	protected function getUrlWithAllParams() {
+	protected function getUrlForPagination() {
 		$url = '#';
 		$title = $this->wg->Title;
 		if( $title instanceof Title ) {

--- a/extensions/wikia/WDACReview/WDACReviewSpecialController.class.php
+++ b/extensions/wikia/WDACReview/WDACReviewSpecialController.class.php
@@ -1,5 +1,7 @@
 <?php
 
+use Wikia\Paginator\Paginator;
+
 class WDACReviewSpecialController extends WikiaSpecialPageController {
 
 	const FLAG_APPROVE = 1;
@@ -38,9 +40,10 @@ class WDACReviewSpecialController extends WikiaSpecialPageController {
 		$helper = $this->getHelper();
 
 		$this->baseUrl = $this->specialPage->getTitle()->getFullUrl();
-		$this->paginatorUrl = urldecode( $this->specialPage->getTitle()->getFullUrl( array('page'=>"%s") ) );
 		$this->toolName = $this->getToolName();
 		$this->submitUrl = $this->baseUrl;
+
+		$paginatorUrl = urldecode( $this->specialPage->getTitle()->getFullUrl() );
 
 		if( $this->wg->request->wasPosted() ) {
 			$data = $this->wg->request->getValues();
@@ -57,14 +60,10 @@ class WDACReviewSpecialController extends WikiaSpecialPageController {
 		$iPage = $this->wg->request->getVal( 'page', 1 );
 		$iCount = $helper->getCountWikisForReview();
 		$this->aCities = $helper->getCitiesForReviewList( self::WIKIS_PER_PAGE_LIMIT, $iPage-1 );
-		$this->paginator = '';
-		if ( self::WIKIS_PER_PAGE_LIMIT < $iCount ) {
-			$oPaginator = Paginator::newFromCount( $iCount, self::WIKIS_PER_PAGE_LIMIT );
-			$oPaginator->setActivePage( $iPage );
 
-			// And here we go! The %s will be replaced with the page number.
-			$this->paginator = $oPaginator->getBarHTML( $this->paginatorUrl );
-		}
+		$oPaginator = new Paginator( $iCount, self::WIKIS_PER_PAGE_LIMIT, $paginatorUrl );
+		$oPaginator->setActivePage( $iPage );
+		$this->paginator = $oPaginator->getBarHTML();
 	}
 
 

--- a/extensions/wikia/WDACReview/WDACReviewSpecialController.class.php
+++ b/extensions/wikia/WDACReview/WDACReviewSpecialController.class.php
@@ -43,7 +43,7 @@ class WDACReviewSpecialController extends WikiaSpecialPageController {
 		$this->toolName = $this->getToolName();
 		$this->submitUrl = $this->baseUrl;
 
-		$paginatorUrl = urldecode( $this->specialPage->getTitle()->getFullUrl() );
+		$paginatorUrl = $this->specialPage->getTitle()->getFullUrl();
 
 		if( $this->wg->request->wasPosted() ) {
 			$data = $this->wg->request->getValues();

--- a/extensions/wikia/WhereIsExtension/SpecialWhereIsExtension_body.php
+++ b/extensions/wikia/WhereIsExtension/SpecialWhereIsExtension_body.php
@@ -17,6 +17,8 @@
  *     require_once("$IP/extensions/wikia/WhereIsExtension/SpecialWhereIsExtension.php");
  */
 
+use Wikia\Paginator\Paginator;
+
 if (!defined('MEDIAWIKI')) {
 	echo "This is MediaWiki extension named WhereIsExtension.\n";
 	exit(1) ;
@@ -102,9 +104,10 @@ class WhereIsExtension extends SpecialPage {
 					// the list
 					$formData['wikis'] = WikiFactory::getListOfWikisWithVar( $gVar, $gTypeVal, $this->values[$gVal][2], $this->values[$gVal][1], $gLikeVal, $iOffset, self::ITEMS_PER_PAGE );
 
-					$oPaginator = Paginator::newFromCount( $formData['count'], self::ITEMS_PER_PAGE );
+					$url = sprintf( '%s?var=%s&val=%s&likeValue=%s&searchType=%s', $wgTitle->getFullURL(), $gVar, $gVal, $gLikeVal, $gTypeVal );
+					$oPaginator = new Paginator( $formData['count'], self::ITEMS_PER_PAGE, $url );
 					$oPaginator->setActivePage( $iPage );
-					$sPager = $oPaginator->getBarHTML( sprintf( '%s?var=%s&val=%s&likeValue=%s&searchType=%s&page=%%s', $wgTitle->getFullURL(), $gVar, $gVal, $gLikeVal, $gTypeVal ) );
+					$sPager = $oPaginator->getBarHTML();
 				}
 			}
 		}

--- a/extensions/wikia/WikiaNewFiles/WikiaNewFilesSpecialController.class.php
+++ b/extensions/wikia/WikiaNewFiles/WikiaNewFilesSpecialController.class.php
@@ -49,7 +49,8 @@ class WikiaNewFilesSpecialController extends WikiaSpecialPageController {
 		$imageCount = $newFilesModel->getImageCount();
 
 		// Pagination
-		$paginator = new Paginator( $imageCount, self::DEFAULT_LIMIT, '' );
+		$url = $this->specialPage->getFullTitle()->getFullURL();
+		$paginator = new Paginator( $imageCount, self::DEFAULT_LIMIT, $url );
 		$paginator->setActivePage( $pageNumber );
 		$output->addHeadItem( 'Paginator', $paginator->getHeadItem() );
 

--- a/extensions/wikia/WikiaNewFiles/WikiaNewFilesSpecialController.class.php
+++ b/extensions/wikia/WikiaNewFiles/WikiaNewFilesSpecialController.class.php
@@ -1,4 +1,5 @@
 <?php
+use Wikia\Paginator\Paginator;
 
 /**
  * @ingroup SpecialPage
@@ -6,7 +7,6 @@
 class WikiaNewFilesSpecialController extends WikiaSpecialPageController {
 	const DEFAULT_LIMIT = 48;
 	const PAGE_PARAM = 'page';
-	const PAGINATOR_URL = '?page=%s';
 
 	public function __construct() {
 		parent::__construct( 'Images', '', false );
@@ -49,9 +49,9 @@ class WikiaNewFilesSpecialController extends WikiaSpecialPageController {
 		$imageCount = $newFilesModel->getImageCount();
 
 		// Pagination
-		$paginator = Paginator::newFromCount( $imageCount, self::DEFAULT_LIMIT );
+		$paginator = new Paginator( $imageCount, self::DEFAULT_LIMIT, '' );
 		$paginator->setActivePage( $pageNumber );
-		$output->addHeadItem( 'Paginator', $paginator->getHeadItem( self::PAGINATOR_URL ) );
+		$output->addHeadItem( 'Paginator', $paginator->getHeadItem() );
 
 		// Hook for ContentFeeds::specialNewImagesHook
 		wfRunHooks( 'SpecialNewImages::beforeDisplay', array( $images ) );
@@ -65,7 +65,7 @@ class WikiaNewFilesSpecialController extends WikiaSpecialPageController {
 			'gallery' => $gallery,
 			'noImages' => !$imageCount,
 			'emptyPage' => count( $images ) === 0,
-			'pagination' => $paginator->getBarHTML( self::PAGINATOR_URL ),
+			'pagination' => $paginator->getBarHTML(),
 		] );
 	}
 }


### PR DESCRIPTION
- `<link rel="canonical">` not emitted when there's "page" URL param
- `<link rel="next/prev">` emitted for category pages of exhibition type pointing to the next/previous page of PAGES in the category
- `<link rel="prev">` now points to the original URL rather than ?page=1
- The API of Paginator object changed and now you need to pass the URL in the constructor
- The URL for pagination is no longer a template: you specify the URL "base" and optionally the URL param (defaults to "page") to update when navigation through pages
- Paginator was moved to `Wikia\Paginator` PHP namespace
