### PR TITLE
JPN-538 	Add linebreak before wiki name

### DIFF
--- a/extensions/wikia/CommunityPage/styles/entrypoint/EntryPoint.scss
+++ b/extensions/wikia/CommunityPage/styles/entrypoint/EntryPoint.scss
@@ -88,5 +88,12 @@ $logo-url: $logo-url-light;
 		padding-top: 15px;
 		text-align: center;
 		word-break: break-all;
+		white-space: pre-line; // Respect linebreaks
+
+		b {
+			font-size: 18px;
+			&:before { content: '\A'; } // Add a linebreak before bolded text
+		}
+
 	}
 }

--- a/extensions/wikia/CommunityPage/styles/entrypoint/EntryPoint.scss
+++ b/extensions/wikia/CommunityPage/styles/entrypoint/EntryPoint.scss
@@ -76,11 +76,11 @@ $logo-url: $logo-url-light;
 		height: 17px;
 		left: 0;
 		line-height: 17px;
+		padding: 0 9px;
 		position: absolute;
 		text-align: center;
 		text-transform: uppercase;
 		top: 0;
-		width: 41px;
 	}
 
 	.community-page-entry-point-description {

--- a/skins/oasis/modules/templates/CommunityPageEntryPointController_Index.php
+++ b/skins/oasis/modules/templates/CommunityPageEntryPointController_Index.php
@@ -4,9 +4,7 @@
 		<?= wfMessage( 'communitypage-new' )->escaped() ?>
 	</div>
 	<div class="community-page-entry-point-container">
-		<div class="community-page-entry-point-description">
-			<?= wfMessage( 'communitypage-help-us-grow' )->parse() ?>
-		</div>
+		<div class="community-page-entry-point-description"><?= wfMessage( 'communitypage-help-us-grow' )->parse() ?></div>
 		<div>
 			<a href="<?= SpecialPage::getTitleFor( 'Community' )->getLocalURL(); ?>" class="community-page-entry-point-button"><?= wfMessage( 'communitypage-entry-button' )->escaped() ?></a>
 		</div>


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/JPN-538

Going with simpler approach than one proposed here https://github.com/Wikia/app/pull/10506
Tradeoff is that it breaks the line always that will be confirmed with product owners whether is sufficient or we should proceed with above one.

@Wikia/spitfires @perjg 
