### PR TITLE
SEO-428 Fix i18n for Paginator

### DIFF
--- a/extensions/wikia/Paginator/Paginator.setup.php
+++ b/extensions/wikia/Paginator/Paginator.setup.php
@@ -11,4 +11,4 @@ $wgAutoloadClasses['Wikia\Paginator\Paginator'] = __DIR__ . '/classes/Paginator.
 $wgAutoloadClasses['Wikia\Paginator\UrlGenerator'] = __DIR__ . '/classes/UrlGenerator.class.php';
 $wgAutoloadClasses['Wikia\Paginator\Validator'] = __DIR__ . '/classes/Validator.class.php';
 
-$wgExtensionMessagesFiles['Paginator'] = $dir . 'i18n/Paginator.i18n.php';
+$wgExtensionMessagesFiles['Paginator'] = __DIR__ . '/i18n/Paginator.i18n.php';


### PR DESCRIPTION
Fixes PHP Warning: include(/extensions/wikia/TopListsi18n/Paginator.i18n.php): failed to open stream: No such file or directory in /includes/LocalisationCache.php on line 461
