### PR TITLE
move html for guidelines section back into chat module

### DIFF
--- a/extensions/wikia/Chat2/templates/widget.mustache
+++ b/extensions/wikia/Chat2/templates/widget.mustache
@@ -32,10 +32,10 @@
 			</div>
 		</div>
 	</div>
+	{{#guidelinesText}}
+		<span class="more">{{{guidelinesText}}}</span>
+	{{/guidelinesText}}
 </section>
-{{#guidelinesText}}
-	<span class="more">{{{guidelinesText}}}</span>
-{{/guidelinesText}}
 {{#fromParserTag}}
 	<script language="javascript" type="text/javascript">if ( typeof ChatWidget!=="undefined" ) ChatWidget.init();</script>
 	<a class="ChatMonobookWidget" href="{{linkToSpecialChat}}">{{joinChatText}}></a>


### PR DESCRIPTION
fromParserTag was outside the module before @dianafa changes 
so I am leaving it there
