### PR TITLE
upping cake related content limit to 5

### DIFF
--- a/extensions/wikia/Recirculation/js/helpers/CakeRelatedContentHelper.js
+++ b/extensions/wikia/Recirculation/js/helpers/CakeRelatedContentHelper.js
@@ -3,7 +3,7 @@ define('ext.wikia.recirculation.helpers.cakeRelatedContent', [
     'wikia.nirvana'
 ], function($, nirvana) {
     var options = {
-        limit: 3
+        limit: 5
     };
 
     function loadData() {

--- a/extensions/wikia/Recirculation/services/CakeRelatedContentService.php
+++ b/extensions/wikia/Recirculation/services/CakeRelatedContentService.php
@@ -19,6 +19,8 @@ class CakeRelatedContentService {
 	 * @return RecirculationContent[]
 	 */
 	public function getContentRelatedTo($title, $limit=5, $ignore=null) {
+		global $wgContLang;
+
 		$api = $this->relatedContentApi();
 		
 		try {
@@ -53,11 +55,14 @@ class CakeRelatedContentService {
 					if (!empty($item)) {
 						/** @var RelatedContent $item */
 						$content = $item->getContent();
+						$title = $content->getContentType() == "Discussion Thread" ?
+								$wgContLang->truncate($content->getTitle(), 105) : $content->getTitle();
+
 						$items[] = new RecirculationContent(
 								count($items),
 								$content->getUrl(),
 								$content->getImage(),
-								$content->getTitle(),
+								$title,
 								"",
 								"");
 					}

--- a/extensions/wikia/Recirculation/services/CakeRelatedContentService.php
+++ b/extensions/wikia/Recirculation/services/CakeRelatedContentService.php
@@ -18,7 +18,7 @@ class CakeRelatedContentService {
 	 * @param $ignore
 	 * @return RecirculationContent[]
 	 */
-	public function getContentRelatedTo($title, $limit=3, $ignore=null) {
+	public function getContentRelatedTo($title, $limit=5, $ignore=null) {
 		$api = $this->relatedContentApi();
 		
 		try {

--- a/extensions/wikia/Recirculation/services/CakeRelatedContentService.php
+++ b/extensions/wikia/Recirculation/services/CakeRelatedContentService.php
@@ -12,6 +12,7 @@ class CakeRelatedContentService {
 	use Loggable;
 	
 	const SERVICE_NAME = "content-entity";
+	const DISCUSSION_THREAD_TITLE_MAX_LENGTH = 105;
 
 	/**
 	 * @param $title
@@ -56,7 +57,10 @@ class CakeRelatedContentService {
 						/** @var RelatedContent $item */
 						$content = $item->getContent();
 						$title = $content->getContentType() == "Discussion Thread" ?
-								$wgContLang->truncate($content->getTitle(), 105) : $content->getTitle();
+								$wgContLang->truncate(
+										$content->getTitle(),
+										self::DISCUSSION_THREAD_TITLE_MAX_LENGTH) :
+								$content->getTitle();
 
 						$items[] = new RecirculationContent(
 								count($items),


### PR DESCRIPTION
@Wikia/cake @pauloslund 
https://wikia-inc.atlassian.net/browse/CAKE-155

Change the cake related content to show 5 related items. Also prepend `[Discussions]` to discussion threads
