### PR TITLE
PLATFORM-2198: Strip domain from http_url_path log attribute

### DIFF
--- a/lib/Wikia/src/Tracer/WikiaTracer.php
+++ b/lib/Wikia/src/Tracer/WikiaTracer.php
@@ -128,7 +128,7 @@ class WikiaTracer {
 		}
 
 		if ( isset( $_SERVER['REQUEST_URI'] ) ) {
-			$context['http_url_path'] = $_SERVER['REQUEST_URI'];
+			$context['http_url_path'] = $this->stripDomainFromUrl($_SERVER['REQUEST_URI']);
 
 			if ( isset( $_SERVER['REQUEST_METHOD'] ) ) {
 				$context['http_method'] = $_SERVER['REQUEST_METHOD'];
@@ -160,6 +160,19 @@ class WikiaTracer {
 		}
 
 		return $this->removeNullEntries( $context );
+	}
+
+	private function stripDomainFromUrl( $url ) {
+		$matches = null;
+		if (preg_match('#^https?://[^/]+(/.*)?$#',$url,$matches)) {
+			if (isset($matches[1])) {
+				$url = $matches[1];
+			} else {
+				$url = '/';
+			}
+		}
+
+		return $url;
 	}
 
 	private function removeNullEntries( $array ) {


### PR DESCRIPTION
We are getting inconsistent values for http_url_path in the logs. This change ensures that we do not report domain in this attribute.

https://wikia-inc.atlassian.net/browse/PLATFORM-2198

/cc @macbre @mixth-sense
