### PR TITLE
Mail_mimePart: PHP7 compatibility

### DIFF
--- a/lib/vendor/Mail2/mimePart.php
+++ b/lib/vendor/Mail2/mimePart.php
@@ -162,7 +162,7 @@ class Mail_mimePart
     *
     * @access public
     */
-    function Mail_mimePart($body = '', $params = array())
+    function __construct($body = '', $params = array())
     {
         if (!empty($params['eol'])) {
             $this->_eol = $params['eol'];


### PR DESCRIPTION
`Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP; Mail_mimePart has a deprecated constructor`

@wladekb 
