### PR TITLE
AjaxResponse: add extra response headers

### DIFF
--- a/includes/AjaxResponse.php
+++ b/includes/AjaxResponse.php
@@ -134,6 +134,8 @@ class AjaxResponse {
 		if ( $this->mVary ) {
 			header ( "Vary: " . $this->mVary );
 		}
+
+		wfRunHooks( 'AjaxResponseSendHeadersAfter' ); # Wikia change
 	}
 
 	/**

--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -57,6 +57,7 @@ $wgHooks['BeforeSendCacheControl']    [] = 'Wikia::onBeforeSendCacheControl';
 $wgHooks['ResourceLoaderAfterRespond'][] = 'Wikia::onResourceLoaderAfterRespond';
 $wgHooks['NirvanaAfterRespond']       [] = 'Wikia::onNirvanaAfterRespond';
 $wgHooks['ApiMainBeforeSendCacheHeaders'][] = 'Wikia::onApiMainBeforeSendCacheHeaders';
+$wgHooks['AjaxResponseSendHeadersAfter'][] = 'Wikia::onAjaxResponseSendHeadersAfter';
 
 # don't purge all variants of articles in Chinese - BAC-1278
 $wgHooks['TitleGetLangVariants'][] = 'Wikia::onTitleGetLangVariants';
@@ -2306,6 +2307,17 @@ class Wikia {
 	 */
 	static function onApiMainBeforeSendCacheHeaders( WebResponse $response ) {
 		self::addExtraHeaders( $response );
+		return true;
+	}
+
+	/**
+	 * Add X-Served-By and X-Backend-Response-Time response headers to index.php?action=ajax (MW ajax requests dispatcher)
+	 *
+	 * @return bool
+	 * @author macbre
+	 */
+	static function onAjaxResponseSendHeadersAfter() {
+		self::addExtraHeaders( F::app()->wg->Request->response() );
 		return true;
 	}
 


### PR DESCRIPTION
- introduced `AjaxResponseSendHeadersAfter` hook

Add our standard set of response headers (introduced in #2587):

```
macbre@dell:~$ curl -svo /dev/null 'http://poznan.macbre.wikia-dev.com/index.php?action=ajax&rs=RTEAjax&method=wiki2html&wikitext=*foo' 2>&1 | grep "X-"
< X-Content-Type-Options: nosniff
< X-Backend-Response-Time: 0.088
< X-Trace-Id: f22498bb-5b4c-4489-ae88-e47f1fcbb124
< X-Span-Id: 9a3a5829-ef4c-47b2-96cd-118605b2d937
< X-Backend: dev_macbre
< X-Cacheable: NO:Not-Cacheable
< X-Served-By: dev-macbre, cache-fra1227-FRA
< X-Cache: ORIGIN, MISS
< X-Cache-Hits: ORIGIN, 0
< X-Timer: S1464615932.749476,VS0,VE132
```

@wladekb 
