### PR TITLE
XW-1478 | Don't render infobox hero module on Mercury

### DIFF
--- a/extensions/wikia/PortableInfobox/services/Helpers/PortableInfoboxDataBag.php
+++ b/extensions/wikia/PortableInfobox/services/Helpers/PortableInfoboxDataBag.php
@@ -9,6 +9,7 @@ namespace Wikia\PortableInfobox\Helpers;
 class PortableInfoboxDataBag {
 	private static $instance = null;
 	private $galleries = [ ];
+	private $firstInfoboxAlredyRendered = false;
 
 	private function __construct() {
 	}
@@ -36,5 +37,19 @@ class PortableInfoboxDataBag {
 		}
 
 		return null;
+	}
+
+	/**
+	 * @return boolean
+	 */
+	public function isFirstInfoboxAlredyRendered() {
+		return $this->firstInfoboxAlredyRendered;
+	}
+
+	/**
+	 * @param boolean $firstInfoboxAlredyRendered
+	 */
+	public function setFirstInfoboxAlredyRendered( $firstInfoboxAlredyRendered ) {
+		$this->firstInfoboxAlredyRendered = $firstInfoboxAlredyRendered;
 	}
 }

--- a/extensions/wikia/PortableInfobox/services/PortableInfoboxRenderService.class.php
+++ b/extensions/wikia/PortableInfobox/services/PortableInfoboxRenderService.class.php
@@ -54,6 +54,7 @@ class PortableInfoboxRenderService extends WikiaService {
 		wfProfileIn( __METHOD__ );
 
 		$helper = new PortableInfoboxRenderServiceHelper();
+		$dataBag = \Wikia\PortableInfobox\Helpers\PortableInfoboxDataBag::getInstance();
 		$infoboxHtmlContent = '';
 		$heroData = [ ];
 
@@ -87,7 +88,8 @@ class PortableInfoboxRenderService extends WikiaService {
 			}
 		}
 
-		if ( !empty( $heroData ) ) {
+		// In Mercury SPA content of the first infobox's hero module is already rendered in the article header.
+		if ( !empty( $heroData ) && !( $helper->isMercury() && empty( $dataBag->isFirstInfoboxAlredyRendered() ) ) ) {
 			$infoboxHtmlContent = $this->renderInfoboxHero( $heroData ) . $infoboxHtmlContent;
 		}
 
@@ -102,7 +104,7 @@ class PortableInfoboxRenderService extends WikiaService {
 			$output = '';
 		}
 
-		\Wikia\PortableInfobox\Helpers\PortableInfoboxDataBag::getInstance()->setFirstInfoboxAlredyRendered( true );
+		$dataBag->setFirstInfoboxAlredyRendered( true );
 
 		wfProfileOut( __METHOD__ );
 
@@ -168,9 +170,7 @@ class PortableInfoboxRenderService extends WikiaService {
 
 			if ( !$helper->isMercury() ) {
 				$markup = $this->renderItem( 'hero-mobile-wikiamobile', $data );
-			} elseif (
-				\Wikia\PortableInfobox\Helpers\PortableInfoboxDataBag::getInstance()->isFirstInfoboxAlredyRendered()
-			) {
+			} else {
 				$markup = $this->renderItem( 'hero-mobile', $data );
 			}
 		} else {
@@ -217,6 +217,7 @@ class PortableInfoboxRenderService extends WikiaService {
 				} else {
 					$data = $helper->extendImageCollectionData( $images );
 				}
+
 				$templateName = 'image-collection';
 			}
 

--- a/extensions/wikia/PortableInfobox/services/PortableInfoboxRenderService.class.php
+++ b/extensions/wikia/PortableInfobox/services/PortableInfoboxRenderService.class.php
@@ -102,6 +102,8 @@ class PortableInfoboxRenderService extends WikiaService {
 			$output = '';
 		}
 
+		\Wikia\PortableInfobox\Helpers\PortableInfoboxDataBag::getInstance()->setFirstInfoboxAlredyRendered( true );
+
 		wfProfileOut( __METHOD__ );
 
 		return $output;
@@ -166,7 +168,9 @@ class PortableInfoboxRenderService extends WikiaService {
 
 			if ( !$helper->isMercury() ) {
 				$markup = $this->renderItem( 'hero-mobile-wikiamobile', $data );
-			} else {
+			} elseif (
+				\Wikia\PortableInfobox\Helpers\PortableInfoboxDataBag::getInstance()->isFirstInfoboxAlredyRendered()
+			) {
 				$markup = $this->renderItem( 'hero-mobile', $data );
 			}
 		} else {
@@ -213,7 +217,6 @@ class PortableInfoboxRenderService extends WikiaService {
 				} else {
 					$data = $helper->extendImageCollectionData( $images );
 				}
-				
 				$templateName = 'image-collection';
 			}
 


### PR DESCRIPTION
…as it is now rendered in the article header.

⚠️  Release one release before https://github.com/Wikia/mercury/pull/2488 —app change should be on our servers and in cache before the removal of CSS rules hiding the hero image and title. One downside of this is that if an infobox has two or more `pi-title`s in it, the second will be hidden.

https://wikia-inc.atlassian.net/browse/XW-1478

@Wikia/x-wing @Wikia/west-wing 
