### PR TITLE
Add ability to override solr host for KV queries

### DIFF
--- a/includes/wikia/services/ArticleService.class.php
+++ b/includes/wikia/services/ArticleService.class.php
@@ -274,6 +274,8 @@ class ArticleService extends WikiaObject {
 	public function getTextFromSolr()
 	{
 		global $wgSolrHost, $wgSolrKvHost;
+		$oldWgSolrHost = $wgSolrHost; // store the value to restore it later to not affect sites like special search
+
 		if (isset($wgSolrKvHost)) {
 			$wgSolrHost = $wgSolrKvHost;
 		}
@@ -285,6 +287,7 @@ class ArticleService extends WikiaObject {
 		$htmlField = Wikia\Search\Utilities::field( 'html' );
 
 		$document = $service->getResult();
+		$wgSolrHost = $oldWgSolrHost;
 
 		$text = '';
 		if ( $document !== null ) {
@@ -310,6 +313,8 @@ class ArticleService extends WikiaObject {
 			return '';
 		}
 		global $wgSolrHost, $wgSolrKvHost;
+		$oldWgSolrHost = $wgSolrHost; // store the value to restore it later to not affect sites like special search
+
 		if (isset($wgSolrKvHost)) {
 			$wgSolrHost = $wgSolrKvHost;
 		}
@@ -317,6 +322,7 @@ class ArticleService extends WikiaObject {
 		$service = new SolrDocumentService();
 		$service->setArticleId( $this->article->getId() );
 		$document = $service->getResult();
+		$wgSolrHost = $oldWgSolrHost;
 
 		$text = '';
 		if ( $document !== null ) {

--- a/includes/wikia/services/ArticleService.class.php
+++ b/includes/wikia/services/ArticleService.class.php
@@ -272,6 +272,8 @@ class ArticleService extends WikiaObject {
 	 * @return string The plain text as stored in solr. Will be empty if we don't have a result.
 	 */
 	public function getTextFromSolr() {
+		global $wgSolrHost, $wgSolrKvHost;
+		$wgSolrHost = $wgSolrKvHost;
 		$service = new SolrDocumentService();
 		// note that this will use wgArticleId without an article
 		if ( $this->article ) {
@@ -304,6 +306,8 @@ class ArticleService extends WikiaObject {
 		if ( !($this->article instanceof Article ) ) {
 			return '';
 		}
+		global $wgSolrHost, $wgSolrKvHost;
+		$wgSolrHost = $wgSolrKvHost;
 
 		$service = new SolrDocumentService();
 		$service->setArticleId( $this->article->getId() );

--- a/includes/wikia/services/ArticleService.class.php
+++ b/includes/wikia/services/ArticleService.class.php
@@ -271,9 +271,12 @@ class ArticleService extends WikiaObject {
 	 *
 	 * @return string The plain text as stored in solr. Will be empty if we don't have a result.
 	 */
-	public function getTextFromSolr() {
+	public function getTextFromSolr()
+	{
 		global $wgSolrHost, $wgSolrKvHost;
-		$wgSolrHost = $wgSolrKvHost;
+		if (isset($wgSolrKvHost)) {
+			$wgSolrHost = $wgSolrKvHost;
+		}
 		$service = new SolrDocumentService();
 		// note that this will use wgArticleId without an article
 		if ( $this->article ) {
@@ -307,7 +310,9 @@ class ArticleService extends WikiaObject {
 			return '';
 		}
 		global $wgSolrHost, $wgSolrKvHost;
-		$wgSolrHost = $wgSolrKvHost;
+		if (isset($wgSolrKvHost)) {
+			$wgSolrHost = $wgSolrKvHost;
+		}
 
 		$service = new SolrDocumentService();
 		$service->setArticleId( $this->article->getId() );


### PR DESCRIPTION
This allows solr hostname used in KV queries (outside special:search) to be overriden separately.
