### PR TITLE
Introduce CURLOPT_TIMEOUT of 5s to Solr client

### DIFF
--- a/lib/vendor/Solarium/Client/Adapter/Curl.php
+++ b/lib/vendor/Solarium/Client/Adapter/Curl.php
@@ -153,7 +153,7 @@ class Solarium_Client_Adapter_Curl extends Solarium_Client_Adapter
         curl_setopt($handler, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($handler, CURLOPT_FOLLOWLOCATION, true);
         curl_setopt($handler, CURLOPT_TIMEOUT, $options['timeout']);
-		curl_setopt($handler, CURLOPT_CONNECTTIMEOUT, $options['timeout']);
+        curl_setopt($handler, CURLOPT_CONNECTTIMEOUT, $options['timeout']);
         
         if ( $proxy = $this->getOption('proxy') ) {
         	curl_setopt($handler, CURLOPT_PROXY, $proxy);

--- a/lib/vendor/Solarium/Client/Adapter/Curl.php
+++ b/lib/vendor/Solarium/Client/Adapter/Curl.php
@@ -152,7 +152,8 @@ class Solarium_Client_Adapter_Curl extends Solarium_Client_Adapter
         curl_setopt($handler, CURLOPT_URL, $uri);
         curl_setopt($handler, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($handler, CURLOPT_FOLLOWLOCATION, true);
-        curl_setopt($handler, CURLOPT_CONNECTTIMEOUT, $options['timeout']);
+        curl_setopt($handler, CURLOPT_TIMEOUT, $options['timeout']);
+		curl_setopt($handler, CURLOPT_CONNECTTIMEOUT, $options['timeout']);
         
         if ( $proxy = $this->getOption('proxy') ) {
         	curl_setopt($handler, CURLOPT_PROXY, $proxy);


### PR DESCRIPTION
Default TIMEOUT is indefinite  - 5 seconds is the max request time suggestion we pass to Solr (but its only suggestion so solr requests can last longer - a lot longer)

/cc: @owend @idradm @mixth-sense @ljagiello 
