### PR TITLE
CreateNewWiki / ImportStarterDataTest: assert bz2 PHP extension is there

### DIFF
--- a/extensions/wikia/CreateNewWiki/tests/tasks/ImportStarterDataTest.php
+++ b/extensions/wikia/CreateNewWiki/tests/tasks/ImportStarterDataTest.php
@@ -19,6 +19,14 @@ class ImportStarterDataTest extends \WikiaBaseTest {
 	}
 
 	/**
+	 * @see PLATFORM-2224
+	 * @group Infrastructure
+	 */
+	public function testDependencies() {
+		$this->assertTrue( extension_loaded( 'bz2' ), 'bz2 extension should be loaded for XML dumps decompression' );
+	}
+
+	/**
 	 * @dataProvider checkDataProvider
 	 * @param $return
 	 * @param $expected


### PR DESCRIPTION
[PLATFORM-2224](https://wikia-inc.atlassian.net/browse/PLATFORM-2224)

Wuthout `bz2` extension we cannot decompress XML dumps.

```
Maintenance script ImportStarter was interrupted by unhandled exception.

PHP Warning: stream_filter_append(): unable to locate filter "bzip2.decompress" in /usr/wikia/slot1/11735/src/extensions/wikia/CreateNewWiki/maintenance/importStarter.php on line 59
```

@mixth-sense / @artursitarski 
