### PR TITLE
Changes Modil to play nicer with the AMD standard, while still issuing a warning for sub-ideal practices.

### DIFF
--- a/resources/wikia/libraries/modil/modil.js
+++ b/resources/wikia/libraries/modil/modil.js
@@ -135,6 +135,8 @@
 	 * @throws {Error} If dependencies is not undefined but not an array
 	 */
 	define = function (id, dependencies, definition, defMock) {
+		var warning;
+
 		if (typeof id !== strType) {
 			// Slide all the args over by one to make room for the id
 			defMock = definition;
@@ -145,7 +147,7 @@
 			id = 'module_' + (new Date()).getTime() + '_' + Math.random();
 
 			// Let the developer know there's a potential problem
-			var warning = "Module id missing or not a string; assigning temporary id (" + id + "). "
+			warning = "Module id missing or not a string; assigning temporary id (" + id + "). "
 				+ (new Error().stack||'').replace(/\n/g, ' / ');
 
 			if (console.warn) {

--- a/resources/wikia/libraries/modil/modil.js
+++ b/resources/wikia/libraries/modil/modil.js
@@ -121,17 +121,18 @@
 	 *
 	 * @public
 	 *
+	 * @example define(function () { return {hello: 'World'}; });
+     * @example define(['dep1', 'dep2'], function (dep1, dep2) { ... });
 	 * @example define('mymod', function () { return {hello: 'World'}; });
 	 * @example define('mymod', ['dep1', 'dep2'], function (dep1, dep2) { ... });
 	 *
-	 * @param {String} id The identificator for the new module
+	 * @param {String} id [Optional] The identificator for the new module
 	 * @param {Array} dependencies [Optional] A list of module id's which
 	 * the new module depends on
 	 * @param {Object} definition The definition for the module
 	 *
-	 * @throws {Error} If id is not passed or undefined
-	 * @throws {Error} If id doesn't have a definition
-	 * @throws {Error} If dependenices is not undefined but not an array
+	 * @throws {Error} If called without a definition
+	 * @throws {Error} If dependencies is not undefined but not an array
 	 */
 	define = function (id, dependencies, definition, defMock) {
 		if (typeof id !== strType) {

--- a/resources/wikia/libraries/modil/modil.js
+++ b/resources/wikia/libraries/modil/modil.js
@@ -122,7 +122,7 @@
 	 * @public
 	 *
 	 * @example define(function () { return {hello: 'World'}; });
-     * @example define(['dep1', 'dep2'], function (dep1, dep2) { ... });
+	 * @example define(['dep1', 'dep2'], function (dep1, dep2) { ... });
 	 * @example define('mymod', function () { return {hello: 'World'}; });
 	 * @example define('mymod', ['dep1', 'dep2'], function (dep1, dep2) { ... });
 	 *
@@ -148,7 +148,7 @@
 			var warning = "Module id missing or not a string; assigning temporary id (" + id + "). "
 				+ (new Error().stack||'').replace(/\n/g, ' / ');
 
-			if( console.warn ) {
+			if (console.warn) {
 				console.warn(warning);
 			} else if(console.log) {
 				console.log(warning);

--- a/resources/wikia/libraries/modil/modil.js
+++ b/resources/wikia/libraries/modil/modil.js
@@ -135,18 +135,18 @@
 	 */
 	define = function (id, dependencies, definition, defMock) {
 		if (typeof id !== strType) {
-            // Give it a temporary module name
-            id = 'module_' + (new Date()).getTime() + '_' + Math.random();
+			// Give it a temporary module name
+			id = 'module_' + (new Date()).getTime() + '_' + Math.random();
 
-            // Let the developer know there's a potential problem
-            var warning = "Module id missing or not a string; assigning temporary id (" + id + "). "
-                + (new Error().stack||'').replace(/\n/g, ' / ');
+			// Let the developer know there's a potential problem
+			var warning = "Module id missing or not a string; assigning temporary id (" + id + "). "
+				+ (new Error().stack||'').replace(/\n/g, ' / ');
 
 			if( console.warn ) {
-                console.warn(warning);
-            } else if(console.log) {
-                console.log(warning);
-            }
+				console.warn(warning);
+			} else if(console.log) {
+				console.log(warning);
+			}
 		}
 
 		//no dependencies array, it's actually the definition

--- a/resources/wikia/libraries/modil/modil.js
+++ b/resources/wikia/libraries/modil/modil.js
@@ -135,7 +135,18 @@
 	 */
 	define = function (id, dependencies, definition, defMock) {
 		if (typeof id !== strType) {
-			throw "Module id missing or not a string. " + (new Error().stack||'').replace(/\n/g, ' / ');
+            // Give it a temporary module name
+            id = 'module_' + (new Date()).getTime() + '_' + Math.random();
+
+            // Let the developer know there's a potential problem
+            var warning = "Module id missing or not a string; assigning temporary id (" + id + "). "
+                + (new Error().stack||'').replace(/\n/g, ' / ');
+
+			if( console.warn ) {
+                console.warn(warning);
+            } else if(console.log) {
+                console.log(warning);
+            }
 		}
 
 		//no dependencies array, it's actually the definition

--- a/resources/wikia/libraries/modil/modil.js
+++ b/resources/wikia/libraries/modil/modil.js
@@ -135,6 +135,11 @@
 	 */
 	define = function (id, dependencies, definition, defMock) {
 		if (typeof id !== strType) {
+			// Slide all the args over by one to make room for the id
+			defMock = definition;
+			definition = dependencies;
+			dependencies = id;
+
 			// Give it a temporary module name
 			id = 'module_' + (new Date()).getTime() + '_' + Math.random();
 


### PR DESCRIPTION
Specifically, the AMD standard permits the first argument to be omitted.  These changes update Modil to permit this case, and emits a console warning when encountered (instead of throwing an Error).
