### PR TITLE
CSRFDetector: introduce markHttpMethodAccepted method to improve handling of "internal" GET requests

### DIFF
--- a/extensions/wikia/Chat2/ChatAjax.class.php
+++ b/extensions/wikia/Chat2/ChatAjax.class.php
@@ -262,6 +262,8 @@ class ChatAjax {
 	private static function authenticateServer() {
 		global $wgRequest;
 
+		\Wikia\Security\CSRFDetector::markRequestAsSecure( __METHOD__ );
+
 		return \Wikia\Security\Utils::matchToken( ChatConfig::getSecretToken(), $wgRequest->getVal( 'token' ) );
 	}
 

--- a/extensions/wikia/Chat2/ChatAjax.class.php
+++ b/extensions/wikia/Chat2/ChatAjax.class.php
@@ -257,14 +257,20 @@ class ChatAjax {
 	}
 
 	/**
+	 * When token matches accept internal GET requests, i.e. do not report them as CSRF errors (PLATFORM-2207)
+	 *
 	 * @return bool
 	 */
 	private static function authenticateServer() {
 		global $wgRequest;
 
-		\Wikia\Security\CSRFDetector::markHttpMethodAccepted( __METHOD__ );
+		$tokenMatched = \Wikia\Security\Utils::matchToken( ChatConfig::getSecretToken(), $wgRequest->getVal( 'token' ) );
 
-		return \Wikia\Security\Utils::matchToken( ChatConfig::getSecretToken(), $wgRequest->getVal( 'token' ) );
+		if ( $tokenMatched ) {
+			\Wikia\Security\CSRFDetector::markHttpMethodAccepted( __METHOD__ );
+		}
+
+		return $tokenMatched;
 	}
 
 	private static function authenticateServerOrUser() {

--- a/extensions/wikia/Chat2/ChatAjax.class.php
+++ b/extensions/wikia/Chat2/ChatAjax.class.php
@@ -262,9 +262,7 @@ class ChatAjax {
 	private static function authenticateServer() {
 		global $wgRequest;
 
-		\Wikia\Security\CSRFDetector::markHttpMethodAccepted( __METHOD__ );
-
-		return \Wikia\Security\Utils::matchToken( ChatConfig::getSecretToken(), $wgRequest->getVal( 'token' ) );
+		return \Wikia\Security\Utils::matchSecretToken( ChatConfig::getSecretToken(), $wgRequest->getVal( 'token' ) );
 	}
 
 	private static function authenticateServerOrUser() {

--- a/extensions/wikia/Chat2/ChatAjax.class.php
+++ b/extensions/wikia/Chat2/ChatAjax.class.php
@@ -257,20 +257,14 @@ class ChatAjax {
 	}
 
 	/**
-	 * When token matches accept internal GET requests, i.e. do not report them as CSRF errors (PLATFORM-2207)
-	 *
 	 * @return bool
 	 */
 	private static function authenticateServer() {
 		global $wgRequest;
 
-		$tokenMatched = \Wikia\Security\Utils::matchToken( ChatConfig::getSecretToken(), $wgRequest->getVal( 'token' ) );
+		\Wikia\Security\CSRFDetector::markHttpMethodAccepted( __METHOD__ );
 
-		if ( $tokenMatched ) {
-			\Wikia\Security\CSRFDetector::markHttpMethodAccepted( __METHOD__ );
-		}
-
-		return $tokenMatched;
+		return \Wikia\Security\Utils::matchToken( ChatConfig::getSecretToken(), $wgRequest->getVal( 'token' ) );
 	}
 
 	private static function authenticateServerOrUser() {

--- a/extensions/wikia/Chat2/ChatAjax.class.php
+++ b/extensions/wikia/Chat2/ChatAjax.class.php
@@ -262,7 +262,7 @@ class ChatAjax {
 	private static function authenticateServer() {
 		global $wgRequest;
 
-		\Wikia\Security\CSRFDetector::markRequestAsSecure( __METHOD__ );
+		\Wikia\Security\CSRFDetector::markHttpMethodAccepted( __METHOD__ );
 
 		return \Wikia\Security\Utils::matchToken( ChatConfig::getSecretToken(), $wgRequest->getVal( 'token' ) );
 	}

--- a/extensions/wikia/Security/classes/CSRFDetector.class.php
+++ b/extensions/wikia/Security/classes/CSRFDetector.class.php
@@ -40,8 +40,8 @@ class CSRFDetector {
 	 *
 	 * @see PLATFORM-2207
 	 */
-	public static function markRequestAsSecure( $caller ) {
-		wfDebug( __METHOD__ . ": {$caller} marked the current request as a secure one\n" );
+	public static function markHttpMethodAccepted( $caller ) {
+		wfDebug( __METHOD__ . ": {$caller} accepted the current GET request to skip CSRF check\n" );
 
 		// make assertEditTokenAndMethodWereChecked() method think that we checked the request method
 		self::$requestWasPostedCalled = true;

--- a/extensions/wikia/Security/classes/CSRFDetector.class.php
+++ b/extensions/wikia/Security/classes/CSRFDetector.class.php
@@ -36,6 +36,18 @@ class CSRFDetector {
 	}
 
 	/**
+	 * In some cases we consider GET requests to be secure when they're provided with a secret token
+	 *
+	 * @see PLATFORM-2207
+	 */
+	public static function markRequestAsSecure( $caller ) {
+		wfDebug( __METHOD__ . ": {$caller} marked the current request as a secure one\n" );
+
+		// make assertEditTokenAndMethodWereChecked() method think that we checked the request method
+		self::$requestWasPostedCalled = true;
+	}
+
+	/**
 	 * Bind to hooks, actions that triggered them will be checked against token and HTTP method validation
 	 *
 	 * Called via $wgExtensionFunctions

--- a/extensions/wikia/Security/classes/Utils.class.php
+++ b/extensions/wikia/Security/classes/Utils.class.php
@@ -19,4 +19,23 @@ class Utils {
 		// It is important to provide the user-supplied string as the second parameter, rather than the first.
 		return hash_equals( $expectedValue, $value );
 	}
+
+	/**
+	 * Call the above method and assert that the HTTP request method is secure (even if it's GET)
+	 *
+	 * @see PLATFORM-2207
+	 *
+	 * @param string $expectedValue expected token value
+	 * @param string $value token value from the request
+	 * @return boolean
+	 */
+	public static function matchSecretToken( $expectedValue, $value ) {
+		$matches = self::matchToken( $expectedValue, $value );
+
+		if ( $matches ) {
+			\Wikia\Security\CSRFDetector::markHttpMethodAccepted( __METHOD__ );
+		}
+
+		return $matches;
+	}
 }


### PR DESCRIPTION
In some cases we consider GET requests to be secure when they're provided with a secret token (see [PLATFORM-2207](https://wikia-inc.atlassian.net/browse/PLATFORM-2207) for an example) - simply call `\Wikia\Security\CSRFDetector::markHttpMethodAccepted` to mark such requests as secure ones and avoid reporting CSRF errors for them.

@wladekb / @Wikia/sustaining-engineering-team (per code ownership)
