### PR TITLE
PLATFORM-2233: use a "classic" MemCache client on devboxes and in Reston

### DIFF
--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1058,7 +1058,18 @@ $wgMaxLevelThreeNavElements = 10;
 /**
  * Memcached class name
  */
-$wgMemCachedClass = 'MemcacheMoxiCluster';
+
+/**
+ * PLATFORM-2233 - use a classic memcache client on devboxes and in Reston
+ * Devbox's LocalSettings.php is too late as wgMemc is initialized earlier
+ * FIXME: This is temporary code - will be removed after the full switch to twemproxy
+ */
+if ( $wgWikiaDatacenter === WIKIA_DC_RES || $wgWikiaEnvironment === WIKIA_ENV_DEV ) {
+	$wgMemCachedClass = 'MemCachedClientforWiki';
+}
+else {
+	$wgMemCachedClass = 'MemcacheMoxiCluster';
+}
 
 /**
  * Extra configuration options for memcached when using libmemcached/pecl-memcached


### PR DESCRIPTION
[PLATFORM-2233](https://wikia-inc.atlassian.net/browse/PLATFORM-2233)

Do not use Moxi on devboxes and in Reston, but instead connect directly to [Twitter's memcache proxy](https://github.com/twitter/twemproxy). See https://github.com/Wikia/config/pull/1792

@wladekb / @artursitarski 
