### PR TITLE
forward the x-wikia-community header to the CP for backend rendering

### DIFF
--- a/extensions/wikia/ContributionPrototype/CPArticleRenderer.php
+++ b/extensions/wikia/ContributionPrototype/CPArticleRenderer.php
@@ -85,6 +85,9 @@ class CPArticleRenderer {
 					'noProxy' => true,
 					'returnInstance' => true,
 					'followRedirects'=> true,
+					'headers' => [
+						'X-Wikia-Community' => $this->dbName,
+					]
 				]
 		);
 


### PR DESCRIPTION
@Wikia/cake 
See Wikia/sd-poc#16

Send the `x-wikia-community` header when requesting content form the CP
