### PR TITLE
JPN-555 Don't show users with zero contribs in top contributors module

### DIFF
--- a/extensions/wikia/CommunityPage/models/CommunityPageSpecialUsersModel.class.php
+++ b/extensions/wikia/CommunityPage/models/CommunityPageSpecialUsersModel.class.php
@@ -68,6 +68,7 @@ class CommunityPageSpecialUsersModel {
 					->FROM ( 'wikia_user_properties' )
 					->WHERE( 'wup_property' )->EQUAL_TO( 'editcountThisWeek' )
 					->AND_( 'wup_user' )->NOT_IN( $botIds )
+					->AND_( 'wup_value' )->GREATER_THAN( 0 )
 					->ORDER_BY( 'CAST(wup_value as unsigned) DESC, wup_user ASC' );
 
 				$result = $sqlData->runLoop( $db, function ( &$result, $row ) {


### PR DESCRIPTION
The query for getting top contributors did not take into account that entries can show up in the user properties table with zero entries (happens when a user logs in).
