### PR TITLE
JPN-556 Use smaller font size for community page heading in Japanese

### DIFF
--- a/extensions/wikia/CommunityPage/CommunityPageSpecialController.class.php
+++ b/extensions/wikia/CommunityPage/CommunityPageSpecialController.class.php
@@ -33,7 +33,7 @@ class CommunityPageSpecialController extends WikiaSpecialPageController {
 		$this->response->setValues( [
 			'heroImageUrl' => $this->getHeroImageUrl(),
 			'inviteFriendsText' => $this->msg( 'communitypage-invite-friends' )->plain(),
-			'headerWelcomeMsg' => $this->msg( 'communitypage-tasks-header-welcome' )->text(),
+			'headerWelcomeMsg' => $this->msg( 'communitypage-tasks-header-welcome' )->parse(),
 			'adminWelcomeMsg' => $this->msg( 'communitypage-admin-welcome-message' )->text(),
 			'pageListEmptyText' => $this->msg( 'communitypage-page-list-empty' )->plain(),
 			'pageTitle' => $this->msg( 'communitypage-title' )->plain(),

--- a/extensions/wikia/CommunityPage/styles/components/_header.scss
+++ b/extensions/wikia/CommunityPage/styles/components/_header.scss
@@ -29,6 +29,10 @@ $hero-image-pattern: '/extensions/wikia/CommunityPage/images/hero_image_pattern.
 		font-weight: bold;
 		line-height: 48px;
 	}
+
+	h1.community-page-heading:lang(ja) {
+		font-size: 24px;
+	}
 }
 
 .community-page-admin-welcome-message {

--- a/extensions/wikia/CommunityPage/templates/pageHeader.mustache
+++ b/extensions/wikia/CommunityPage/templates/pageHeader.mustache
@@ -1,6 +1,6 @@
 <div class="community-page-header {{#heroImageUrl}}community-page-header-cover" style="background-image: url({{heroImageUrl}});{{/heroImageUrl}}">
 	<div class="community-page-header-content">
-		<h1 class="community-page-heading">{{headerWelcomeMsg}}</h1>
+		<h1 class="community-page-heading">{{{headerWelcomeMsg}}}</h1>
 	</div>
 </div>
 <div class="community-page-admin-welcome-message">


### PR DESCRIPTION
Also Parse community page header as wikitext.

When you set your language preference to Japanese and load a community page, the welcome text should show in 24px font size, for any other language it should be 36px.
