### PR TITLE
PLATFORM-2227: cache WikiaNewFilesModel::getImageCount SQL query

### DIFF
--- a/extensions/wikia/WikiaNewFiles/WikiaNewFiles_setup.php
+++ b/extensions/wikia/WikiaNewFiles/WikiaNewFiles_setup.php
@@ -32,3 +32,7 @@ $wgSpecialPages['Images'] = 'WikiaNewFilesSpecialController';
 // Redirect from the old special page (Special:NewFiles)
 $wgSpecialPages['Newimages'] = 'WikiaNewFilesSpecialController';
 
+// invalidate image count cache on each image related operation
+$wgHooks['UploadComplete'][] = 'WikiaNewFilesModel::onFileOperation';
+$wgHooks['FileDeleteComplete'][] = 'WikiaNewFilesModel::onFileOperation';
+$wgHooks['FileUndeleteComplete'][] = 'WikiaNewFilesModel::onFileOperation';

--- a/includes/wikia/WikiaDataAccess.class.php
+++ b/includes/wikia/WikiaDataAccess.class.php
@@ -49,7 +49,7 @@ class WikiaDataAccess {
 	 * @author Piotr Bablok <pbablok@wikia-inc.com>
 	 * @author Jakub Olek <jolek@wikia-inc.com>
 	 */
-	static function cache( $key, $cacheTTL, $getData, $command = self::USE_CACHE ) {
+	static function cache( $key, $cacheTTL, callable $getData, $command = self::USE_CACHE ) {
 		return self::cacheWithOptions( $key, $getData, [
 			'command' => $command,
 			'cacheTTL' => $cacheTTL,


### PR DESCRIPTION
[PLATFORM-2227](https://wikia-inc.atlassian.net/browse/PLATFORM-2227)
- cache it for 24h
- invalidate it on each image related operation

This query is run 240k times a day on prod with the slowest ones taking more than 100 ms (with 16% of all queries being run for `yugioh` wiki).

@wladekb / @drozdo 

FYI, @gabrys and @garthwebb (per extension credits)
