### PR TITLE
ImageServingDriverCategoryNS::addTopArticlesFromCategory - improve cache hit ratio

### DIFF
--- a/extensions/wikia/ImageServing/drivers/ImageServingDriverCategoryNS.class.php
+++ b/extensions/wikia/ImageServing/drivers/ImageServingDriverCategoryNS.class.php
@@ -28,9 +28,9 @@ class ImageServingDriverCategoryNS extends ImageServingDriverMainNS {
 
 	protected function addTopArticlesFromCategory( $categoryId, &$articleCategories ) {
 
-		$key = wfMemcKey("ImageServingCategoryNSTopArticles", $categoryId);
+		$key = wfMemcKey(__METHOD__, $categoryId);
 		$cachedPageIds = $this->memc->get($key);
-		if (!empty($cachedPageIds)) {
+		if (is_array($cachedPageIds)) {
 			foreach ($cachedPageIds as $page_id) {
 				if ( empty( $articleCategories[$page_id] ) ) {
 					$articleCategories[$page_id] = array();
@@ -76,13 +76,15 @@ class ImageServingDriverCategoryNS extends ImageServingDriverMainNS {
 			$options
 		);
 
+		$cachedPageIds = [];
+
 		while ( $row = $this->db->fetchRow( $res ) ) {
 			if ( empty( $articleCategories[$row['page_id']] ) ) {
 				$articleCategories[$row['page_id']] = array();
 			}
 			$articleCategories[$row['page_id']][] = $categoryId;
-			$cachedPageIds[] = $row['page_id'];
+			$cachedPageIds[] = intval( $row['page_id'] );
 		}
-		$this->memc->set($key, $cachedPageIds, 86400);
+		$this->memc->set($key, $cachedPageIds, WikiaResponse::CACHE_STANDARD);
 	}
 }


### PR DESCRIPTION
[PLATFORM-2228](https://wikia-inc.atlassian.net/browse/PLATFORM-2228)

Treat an empty array got from cache as a hit (~15% of all gets). Queries made daily - 3 mm

@wladekb / @drozdo 
