### PR TITLE
PLATFORM-2226 Related Pages performance improvements and cleanup

### DIFF
--- a/extensions/wikia/RelatedPages/RelatedPages.class.php
+++ b/extensions/wikia/RelatedPages/RelatedPages.class.php
@@ -144,7 +144,7 @@ class RelatedPages {
 					}
 
 					// limit * 2 - get more pages (some can be filtered out - RT #72703)
-					$pages = $this->getPagesForCategories( $articleId, self::LIMIT_MAX * 2, $categories );
+					$pages = $this->getPagesForCategories( $articleId, $categories );
 
 					$this->afterGet( $pages, self::LIMIT_MAX );
 				}
@@ -183,14 +183,14 @@ class RelatedPages {
 	/**
 	 * get pages that belong to a list of categories
 	 * @author Owen
+	 * @author Macbre
 	 *
 	 * @param int $articleId
-	 * @param int $limit
 	 * @param array $categories
 	 * @return array
 	 * @throws DBUnexpectedError|MWException
 	 */
-	protected function getPagesForCategories( $articleId, $limit, Array $categories ) {
+	protected function getPagesForCategories( $articleId, Array $categories ) {
 		if ( empty( $categories ) ) {
 			return [];
 		}
@@ -204,11 +204,8 @@ class RelatedPages {
 		$pages = WikiaDataAccess::cache(
 			wfMemcKey( __METHOD__, 'categories', md5( serialize( $categories ) ) ),
 			WikiaResponse::CACHE_STANDARD,
-			function() use ( $categories, $fname, $limit ) {
+			function() use ( $categories, $fname ) {
 				$dbr = wfGetDB( DB_SLAVE );
-
-				# sanitize query parameters
-				$limit = intval( $limit );
 
 				/**
 				 * SELECT count(page_id) as c, cl_from AS page_id, page_namespace, page_title, page_is_redirect, page_len, page_latest
@@ -241,7 +238,7 @@ class RelatedPages {
 					[
 						'GROUP BY' => 'page.page_id',
 						'ORDER BY' => 'c DESC',
-						'LIMIT' => $limit,
+						'LIMIT' => self::LIMIT_MAX * 2,
 					],
 					[
 						'page' => [

--- a/extensions/wikia/RelatedPages/RelatedPages.class.php
+++ b/extensions/wikia/RelatedPages/RelatedPages.class.php
@@ -13,15 +13,6 @@ class RelatedPages {
 
 	const LIMIT_MAX = 10;
 
-	/**
-	 * Limit the number of results taken from categorylinks and improve the performance on big wikis
-	 * by making the temporary table much smaller
-	 *
-	 * @author macbre
-	 * @see PLATFORM-1591
-	 */
-	const CATEGORY_LINKS_LIMIT = 100000;
-
 	protected function __construct() {
 	}
 

--- a/extensions/wikia/RelatedPages/RelatedPages.class.php
+++ b/extensions/wikia/RelatedPages/RelatedPages.class.php
@@ -208,7 +208,6 @@ class RelatedPages {
 				$dbr = wfGetDB( DB_SLAVE );
 
 				# sanitize query parameters
-				$articleId = intval( $articleId );
 				$limit = intval( $limit );
 
 				/**
@@ -273,6 +272,8 @@ class RelatedPages {
 		);
 
 		// filter out the page we want to get related pages for
+		$articleId = intval( $articleId );
+
 		if ( array_key_exists( $articleId, $pages ) ) {
 			unset( $pages[ $articleId ] );
 		}

--- a/extensions/wikia/RelatedPages/RelatedPages.class.php
+++ b/extensions/wikia/RelatedPages/RelatedPages.class.php
@@ -202,7 +202,7 @@ class RelatedPages {
 		sort( $categories );
 
 		$pages = WikiaDataAccess::cache(
-			wfMemcKey( __METHOD__, 'categories', md5( serialize( $category ) ) ),
+			wfMemcKey( __METHOD__, 'categories', md5( serialize( $categories ) ) ),
 			WikiaResponse::CACHE_STANDARD,
 			function() use ( $categories, $fname, $limit ) {
 				$dbr = wfGetDB( DB_SLAVE );

--- a/extensions/wikia/RelatedPages/RelatedPages.class.php
+++ b/extensions/wikia/RelatedPages/RelatedPages.class.php
@@ -134,7 +134,6 @@ class RelatedPages {
 						$categories = array_slice( $categories, 0, $this->categoriesLimit );
 					}
 
-					// limit * 2 - get more pages (some can be filtered out - RT #72703)
 					$pages = $this->getPagesForCategories( $articleId, $categories );
 
 					$this->afterGet( $pages, self::LIMIT_MAX );
@@ -205,7 +204,7 @@ class RelatedPages {
 				 * 		AND page_is_redirect = 0)
 				 * GROUP BY page.page_id
 				 * ORDER BY c desc
-				 * LIMIT 20;
+				 * LIMIT 11;
 				 *
 				 * @see PLATFORM-2226
 				 */
@@ -229,7 +228,7 @@ class RelatedPages {
 					[
 						'GROUP BY' => 'page.page_id',
 						'ORDER BY' => 'c DESC',
-						'LIMIT' => self::LIMIT_MAX * 2,
+						'LIMIT' => self::LIMIT_MAX + 1, # +1 as we get the current page (i.e. $articleId) as well
 					],
 					[
 						'page' => [


### PR DESCRIPTION
[PLATFORM-2226](https://wikia-inc.atlassian.net/browse/PLATFORM-2226)

Improve the way `RelatedPages::getPagesForCategories` method caches query results:
- the previous version of the code used only the article ID to generate the memcache key
- the query performed was quite heavy and the filtering was performed inside the query
- get rid of subquery (as suggested and implemented by @drozdo)

This code introduces caching by the list of categories to get the best matching articles. The current article (i.e. the one we get related pages for) is filtered out from the results (got from either database or memcache) on app level. The cached results can then be reused by other API calls.

Expected results: improve hit ratio and hence less heavy DB queries from `RelatedPages`.

Queries before:

``` sql
SELECT page_id, count(*) c FROM ( SELECT  cl_from AS page_id  FROM `categorylinks` JOIN `page` ON (
(page_id = cl_from AND page_namespace = 0))  WHERE (cl_to IN ( 'Gwara','Tradycja','Kuchnia_regionalna','Potrawy','Gzik' ))  LIMIT 100000   ) i WHERE page_id != 1963 GROUP BY page_id ORDER BY c desc LIMIT 20

+----+-------------+---------------+--------+---------------------------------+--------------+---------+--------------------------------+------+----------------------------------------------+
| id | select_type | table         | type   | possible_keys                   | key          | key_len | ref                            | rows | Extra                                        |
+----+-------------+---------------+--------+---------------------------------+--------------+---------+--------------------------------+------+----------------------------------------------+
|  1 | PRIMARY     | <derived2>    | ALL    | NULL                            | NULL         | NULL    | NULL                           |  111 | Using where; Using temporary; Using filesort |
|  2 | DERIVED     | categorylinks | range  | cl_from,cl_timestamp,cl_sortkey | cl_timestamp | 257     | NULL                           |  111 | Using where; Using index                     |
|  2 | DERIVED     | page          | eq_ref | PRIMARY,name_title              | PRIMARY      | 4       | plpoznan.categorylinks.cl_from |    1 | Using where                                  |
+----+-------------+---------------+--------+---------------------------------+--------------+---------+--------------------------------+------+----------------------------------------------+
```

and after (thanks @drozdo):

``` sql
SELECT /* RelatedPages::getPagesForCategories Macbre - 40c99228-84d0-4899-9139-8dac747b5fc5 */  count(page_id) AS c,page_id,page_namespace,page_title,page_is_redirect,page_len,page_latest  FROM `categorylinks` JOIN `page` ON ((page_id = cl_from) AND (page_namespace = 0))  WHERE cl_to IN ('Gwara','Gzik','Kuchnia_regionalna','Potrawy','Tradycja')  AND page_is_redirect = '0'  GROUP BY page.page_id ORDER BY c DESC LIMIT 11;

+----+-------------+---------------+--------+---------------------------------------------------------------------+--------------+---------+--------------------------------+------+-----------------------------------------------------------+
| id | select_type | table         | type   | possible_keys                                                       | key          | key_len | ref                            | rows | Extra                                                     |
+----+-------------+---------------+--------+---------------------------------------------------------------------+--------------+---------+--------------------------------+------+-----------------------------------------------------------+
|  1 | SIMPLE      | categorylinks | range  | cl_from,cl_timestamp,cl_sortkey                                     | cl_timestamp | 257     | NULL                           |  111 | Using where; Using index; Using temporary; Using filesort |
|  1 | SIMPLE      | page          | eq_ref | PRIMARY,name_title,page_random,page_len,page_redirect_namespace_len | PRIMARY      | 4       | plpoznan.categorylinks.cl_from |    1 | Using where                                               |
+----+-------------+---------------+--------+---------------------------------------------------------------------+--------------+---------+--------------------------------+------+-----------------------------------------------------------+
```

The results set order is a bit different, however the results are still correct.([examples in the ticket](https://wikia-inc.atlassian.net/browse/PLATFORM-2213)).

@wladekb / @drozdo 
