### PR TITLE
SEO-366 Test: Small-Scale, Highly Relevant Crosslinks

### DIFF
--- a/extensions/wikia/SeoCrossLink/SeoCrossLink.setup.php
+++ b/extensions/wikia/SeoCrossLink/SeoCrossLink.setup.php
@@ -2,5 +2,6 @@
 
 // Autoload
 $wgAutoloadClasses['Wikia\SeoCrossLink\CrossLinkHooks'] =  __DIR__ . '/classes/CrossLinkHooks.class.php';
+$wgAutoloadClasses['Wikia\SeoCrossLink\CrossLinkInserter'] =  __DIR__ . '/classes/CrossLinkInserter.class.php';
 
 $wgHooks['OutputPageBeforeHTML'][] = 'Wikia\SeoCrossLink\CrossLinkHooks::onOutputPageBeforeHTML';

--- a/extensions/wikia/SeoCrossLink/SeoCrossLink.setup.php
+++ b/extensions/wikia/SeoCrossLink/SeoCrossLink.setup.php
@@ -1,0 +1,6 @@
+<?php
+
+// Autoload
+$wgAutoloadClasses['Wikia\SeoCrossLink\CrossLinkHooks'] =  __DIR__ . '/classes/CrossLinkHooks.class.php';
+
+$wgHooks['OutputPageBeforeHTML'][] = 'Wikia\SeoCrossLink\CrossLinkHooks::onOutputPageBeforeHTML';

--- a/extensions/wikia/SeoCrossLink/classes/CrossLinkHooks.class.php
+++ b/extensions/wikia/SeoCrossLink/classes/CrossLinkHooks.class.php
@@ -7,9 +7,7 @@ class CrossLinkHooks {
 		$user = $out->getUser();
 		$lang = $out->getLanguage();
 
-		if ( $user && $user->isAnon()
-			&& $lang && $lang->getCode() === 'en'
-		) {
+		if ( $user && $user->isAnon() && $lang && $lang->getCode() === 'en' ) {
 			$inserter = new CrossLinkInserter();
 			$text = $inserter->insertCrossLinks( $text );
 		}

--- a/extensions/wikia/SeoCrossLink/classes/CrossLinkHooks.class.php
+++ b/extensions/wikia/SeoCrossLink/classes/CrossLinkHooks.class.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Wikia\SeoCrossLink;
+
+class CrossLinkHooks {
+	public static function onOutputPageBeforeHTML( \OutputPage $out, &$text ) {
+		$user = $out->getUser();
+		$lang = $out->getLanguage();
+
+		if ( $user && $user->isAnon()
+			&& $lang && $lang->getCode() === 'en'
+		) {
+			$inserter = new CrossLinkInserter();
+			$text = $inserter->insertCrossLinks( $text );
+		}
+
+		return true;
+	}
+}

--- a/extensions/wikia/SeoCrossLink/classes/CrossLinkInserter.class.php
+++ b/extensions/wikia/SeoCrossLink/classes/CrossLinkInserter.class.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Wikia\SeoCrossLink;
+
+use Wikia\Logger\WikiaLogger;
+
+class CrossLinkInserter {
+	const FIRST_CHARACTERS_TO_FIND_THE_HOT_WORD_IN = 20000;
+
+	const HOT_WORDS = [
+		[ 'Mojito', 'http://cocktails.wikia.com/wiki/Mojito', 'cocktails' ],
+		[ 'Mojitos', 'http://cocktails.wikia.com/wiki/Mojito', 'cocktails' ],
+		[ 'Gruyère', 'http://cheese.wikia.com/wiki/Gruy%C3%A8re', 'cheese' ],
+		[ 'Gruyere', 'http://cheese.wikia.com/wiki/Gruy%C3%A8re', 'cheese' ],
+		[ 'Sushi', 'http://japaneserecipes.wikia.com/wiki/Sushi', 'japaneserecipes' ],
+		[ 'Pilsner', 'http://beer.wikia.com/wiki/Pilsner', 'beer' ],
+		[ 'Frappuccino', 'http://coffee.wikia.com/wiki/Frappuccino', 'coffee' ],
+		[ 'Wolverine', 'http://marvel.wikia.com/wiki/James_Howlett_%28Earth-616%29', 'enmarveldatabase' ],
+		[ 'Maserati', 'http://automobile.wikia.com/wiki/Maserati', 'automobile' ],
+		[ 'Green tea', 'http://tea.wikia.com/wiki/Green_tea', 'tea' ],
+		[ 'AK-47', 'http://guns.wikia.com/wiki/Kalashnikov_rifle', 'guns' ],
+		[ 'AK 47', 'http://guns.wikia.com/wiki/Kalashnikov_rifle', 'guns' ],
+		[ 'AK47', 'http://guns.wikia.com/wiki/Kalashnikov_rifle', 'guns' ],
+	];
+
+	public function insertCrossLinks( $text ) {
+		global $wgDBname;
+
+		$firstPart = mb_substr( $text, 0, self::FIRST_CHARACTERS_TO_FIND_THE_HOT_WORD_IN );
+
+		$urlsAlreadyLinked = [];
+
+		foreach ( self::HOT_WORDS as $line ) {
+			list( $hotWord, $targetUrl, $targetDbName ) = $line;
+
+			// Only link once to a given URL
+			if ( in_array( $targetUrl, $urlsAlreadyLinked ) ) {
+				continue;
+			}
+
+			// Don't do internal links
+			if ( $targetDbName === $wgDBname ) {
+				continue;
+			}
+
+			// Early exit before doing heavy regular expressions
+			if ( mb_stripos( $firstPart, $hotWord ) === false ) {
+				continue;
+			}
+
+			// Regex time: find the occurrence of the word after opening of <p>, <li>, <td>, <div>
+			// <span>, <b>, <i>, <string>, or <em> tag without any other HTML between the opening
+			// and the word. A closing </br> tag will do too
+			$regex = ':<(li|td|p|div|span|b|i|strong|em|/br)( [^<>]*)?>([^<>]*?)(\b' .
+				preg_quote( $hotWord ) . '\b):i';
+
+			$replacement = sprintf(
+				'<\1\2>\3<a class="external extiw" href="%s">\4</a>',
+				htmlspecialchars( $targetUrl )
+			);
+
+			$m = [];
+			if ( preg_match( $regex, $firstPart, $m ) ) {
+				// Only replace the first matched appearance of the word
+				$firstPart = preg_replace( $regex, $replacement, $firstPart, 1 );
+				$urlsAlreadyLinked[] = $targetUrl;
+				WikiaLogger::instance()->info( __CLASS__ . ' ' . $targetUrl );
+			}
+		}
+
+		if ( count( $urlsAlreadyLinked ) === 0 ) {
+			// Didn't replace anything, just exit
+			return $text;
+		}
+
+		$remainder = mb_substr( $text, self::FIRST_CHARACTERS_TO_FIND_THE_HOT_WORD_IN );
+
+		return $firstPart . $remainder;
+	}
+}

--- a/extensions/wikia/SeoCrossLink/classes/CrossLinkInserter.class.php
+++ b/extensions/wikia/SeoCrossLink/classes/CrossLinkInserter.class.php
@@ -51,13 +51,8 @@ class CrossLinkInserter {
 			// Regex time: find the occurrence of the word after opening of <p>, <li>, <td>, <div>
 			// <span>, <b>, <i>, <string>, or <em> tag without any other HTML between the opening
 			// and the word. A closing </br> tag will do too
-			$regex = ':<(li|td|p|div|span|b|i|strong|em|/br)( [^<>]*)?>([^<>]*?)(\b' .
-				preg_quote( $hotWord ) . '\b):i';
-
-			$replacement = sprintf(
-				'<\1\2>\3<a class="external extiw" href="%s">\4</a>',
-				htmlspecialchars( $targetUrl )
-			);
+			$regex = ':<(li|td|p|div|span|b|i|strong|em|/br)( [^<>]*)?>([^<>]*?)(\b' . preg_quote( $hotWord ) . '\b):i';
+			$replacement = '<\1\2>\3<a class="external" href="' . htmlspecialchars( $targetUrl ) . '">\4</a>';
 
 			$m = [];
 			if ( preg_match( $regex, $firstPart, $m ) ) {

--- a/extensions/wikia/SeoCrossLink/classes/CrossLinkInserter.class.php
+++ b/extensions/wikia/SeoCrossLink/classes/CrossLinkInserter.class.php
@@ -5,7 +5,10 @@ namespace Wikia\SeoCrossLink;
 use Wikia\Logger\WikiaLogger;
 
 class CrossLinkInserter {
-	const FIRST_CHARACTERS_TO_FIND_THE_HOT_WORD_IN = 20000;
+	/**
+	 * Hot words will be only searched within this many first characters of the content
+	 */
+	const CHARACTER_LIMIT = 20000;
 
 	const HOT_WORDS = [
 		[ 'Mojito', 'http://cocktails.wikia.com/wiki/Mojito', 'cocktails' ],
@@ -26,7 +29,7 @@ class CrossLinkInserter {
 	public function insertCrossLinks( $text ) {
 		global $wgDBname;
 
-		$firstPart = mb_substr( $text, 0, self::FIRST_CHARACTERS_TO_FIND_THE_HOT_WORD_IN );
+		$firstPart = mb_substr( $text, 0, self::CHARACTER_LIMIT );
 
 		$urlsAlreadyLinked = [];
 
@@ -54,8 +57,7 @@ class CrossLinkInserter {
 			$regex = ':<(li|td|p|div|span|b|i|strong|em|/br)( [^<>]*)?>([^<>]*?)(\b' . preg_quote( $hotWord ) . '\b):i';
 			$replacement = '<\1\2>\3<a class="external" href="' . htmlspecialchars( $targetUrl ) . '">\4</a>';
 
-			$m = [];
-			if ( preg_match( $regex, $firstPart, $m ) ) {
+			if ( preg_match( $regex, $firstPart ) ) {
 				// Only replace the first matched appearance of the word
 				$firstPart = preg_replace( $regex, $replacement, $firstPart, 1 );
 				$urlsAlreadyLinked[] = $targetUrl;
@@ -68,7 +70,7 @@ class CrossLinkInserter {
 			return $text;
 		}
 
-		$remainder = mb_substr( $text, self::FIRST_CHARACTERS_TO_FIND_THE_HOT_WORD_IN );
+		$remainder = mb_substr( $text, self::CHARACTER_LIMIT );
 
 		return $firstPart . $remainder;
 	}


### PR DESCRIPTION
This extension replaces selected words with links to manually selected Wikia articles on other wikis.

It's only supposed to run on English wikis for anonymous users. The links mimic the regular external links.
We're not tricking users into thinking they go to the next article on the same wiki.
