### PR TITLE
MAIN-7212: Track.php should use ExternalHttp

### DIFF
--- a/extensions/wikia/Track/Track.php
+++ b/extensions/wikia/Track/Track.php
@@ -95,7 +95,7 @@ SCRIPT1;
 		$param['caller'] = "$class::$func:$line";
 
 		$url = Track::getURL('special', urlencode($event_type), $param, false);
-		if (Http::get($url) !== false) {
+		if (ExternalHttp::get($url) !== false) {
 			wfProfileOut(__METHOD__);
 			return true;
 		} else {


### PR DESCRIPTION
@macbre  Just FYI, I already merged this to release-412 for tomorrow's release.
