### PR TITLE
SUS-563 | Use $wgSitename instead of wfMsgForContent( 'mainpage' )

### DIFF
--- a/extensions/wikia/CreateNewWiki/FinishCreateWikiController.class.php
+++ b/extensions/wikia/CreateNewWiki/FinishCreateWikiController.class.php
@@ -71,9 +71,10 @@ class FinishCreateWikiController extends WikiaController {
 		$this->skipRendering();
 		$this->LoadState();
 
-		$mainPage = wfMsgForContent( 'mainpage' );
+		$mainPageTitleText = $wgSitename;
 
 		// SUS-563 debug
+		$mainPageMessageContent = wfMsgForContent( 'mainpage' );
 		$mediawikiMainPageArticleText = '';
 		$mediawikiMainPageTitle = Title::newFromText('Mainpage', NS_MEDIAWIKI);
 
@@ -94,8 +95,8 @@ class FinishCreateWikiController extends WikiaController {
 			[
 				'mediawikiMainPageArticleText' => $mediawikiMainPageArticleText,
 				'wgSitename' => $wgSitename,
-				'mainPageMessage' => $mainPage,
-				'suspicious' => ( $mainPage !== $wgSitename )
+				'mainPageMessage' => $mainPageMessageContent,
+				'suspicious' => ( $mainPageMessageContent !== $wgSitename )
 			]
 		);
 		// SUS-563 debug end
@@ -108,7 +109,7 @@ class FinishCreateWikiController extends WikiaController {
 
 		// set description on main page
 		if(!empty($this->params['wikiDescription'])) {
-			$mainTitle = Title::newFromText( $mainPage );
+			$mainTitle = Title::newFromText( $mainPageTitleText );
 			$mainId = $mainTitle->getArticleID();
 			$mainArticle = Article::newFromID( $mainId );
 
@@ -120,7 +121,7 @@ class FinishCreateWikiController extends WikiaController {
 				}
 
 				$mainArticle->doEdit( $newMainPageText, '' );
-				$this->initHeroModule( $mainPage );
+				$this->initHeroModule( $mainPageTitleText );
 			}
 		}
 
@@ -128,7 +129,7 @@ class FinishCreateWikiController extends WikiaController {
 
 		$this->clearState();
 
-		$wgOut->redirect($mainPage.'?wiki-welcome=1');
+		$wgOut->redirect( $mainPageTitleText . '?wiki-welcome=1' );
 	}
 
 	/**


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-563

There is a race condition that sometimes causes `wfMsgForContent( 'mainpage' )` to have the initial value of e.g. "Main Page" (depends on wiki language) instead of site name. New value is set in `CreateNewWikiTask::moveMainPage()` to `$wgSitename` but there seems to be some caching issue and it's not always propagated when we need it. Instead of depending on cache let's use the global directly.

@mixth-sense @ludwikkazmierczak 
