### PR TITLE
PLATFORM-2246: do not fetch all articles in the category as there can be tens of thousands of them

### DIFF
--- a/extensions/wikia/CategoryGalleries/services/CategoryService.class.php
+++ b/extensions/wikia/CategoryGalleries/services/CategoryService.class.php
@@ -114,7 +114,10 @@
 					'page_namespace' => $namespace,
 				),
 				__METHOD__,
-				array(),
+				array(
+					// PLATFORM-2246: do not fetch all articles in the category as there can be tens of thousands of them
+					'LIMIT' => 5000
+				),
 				array( 'categorylinks'  => array( 'INNER JOIN', 'cl_from = page_id' ) )
 			);
 


### PR DESCRIPTION
[PLATFORM-2246](https://wikia-inc.atlassian.net/browse/PLATFORM-2246)

In some cases even 2 mm rows!

Results are then passed to datamart query to sort them by pageviews and displayed on [category pages](http://colors.wikia.com/wiki/Category:Colors).

``` php
$service = new CategoryService('Ulice'); $service->getTopArticles( 8 );
```

``` sql
Query plpoznan (DB user: xxx) (8) (slave): SELECT /* CategoryService::fetchTopArticlesInfo CommandLineInc - 14997ab6-ec8b-4ccf-9a0b-5c643a3a4fa8 */  page_id,page_title,page_namespace  FROM `page` INNER JOIN `categorylinks` ON ((cl_from = page_id))  WHERE cl_to = 'Pomniki' AND page_namespace = '0'  

Query statsdb_mart (DB user: xxx) (9) (slave): SELECT /* DataMartService:doGetTopArticlesByPageview CommandLineInc - 14997ab6-ec8b-4ccf-9a0b-5c643a3a4fa8 */ namespace_id, article_id, pageviews as pv   FROM rollup_wiki_article_pageviews   WHERE time_id = ( CURDATE() - INTERVAL DAYOFWEEK(CURDATE()) - 1 DAY  )   AND period_id = '2'   AND wiki_id = '5915'   AND article_id IN ( '46', '1397', '3147', '3835', '5032', '12306', '12419', '13834', '15042', '31', '17166', '17243', '17362', '17392', '17440', '20184', '21736', '25337', '25673', '25714', '
```

@drozdo 
