### PR TITLE
SUS-624 | Wait for slaves before importing wiki

### DIFF
--- a/extensions/wikia/CreateNewWiki/maintenance/importStarter.php
+++ b/extensions/wikia/CreateNewWiki/maintenance/importStarter.php
@@ -71,6 +71,9 @@ class ImportStarter extends Maintenance {
 		$pagesCnt = 0;
 		$then = microtime(true);
 
+		// WikiImporter uses methods which in turn use slaves
+		wfWaitForSlaves();
+
 		// perform the import in a transaction
 		$dbw = wfGetDB( DB_MASTER );
 		$dbw->begin( __METHOD__ );


### PR DESCRIPTION
`WikiImporter` uses methods which in turn use slaves, e.g. [Title::getTitleProtection()](https://github.com/Wikia/app/blob/d06204608c4d001e177fb31510059dce9d494d55/includes/Title.php#L2423) which was intermittently causing error:

```
Query: SELECT  *  FROM `protected_titles`  WHERE pt_namespace = '0' AND pt_title = 'Accueil'  
Function: Title::getTitleProtection
Error: 1146 Table 'frqatestwiki1465385389971.protected_titles' doesn't exist (slave.db-g.service.consul)
```

Let's wait for slaves before doing the import.

@mixth-sense @macbre @ludwikkazmierczak
