### PR TITLE
ADEN-3406 SP Firefox fix

### DIFF
--- a/extensions/wikia/AssetsManager/AssetsManager.class.php
+++ b/extensions/wikia/AssetsManager/AssetsManager.class.php
@@ -352,13 +352,13 @@ class AssetsManager {
 		}
 	}
 
-	public function getSassesUrl($sassList) {
-		if (!is_array($sassList)) {
+	public function getSassesUrl( $sassList, $params = null ) {
+		if ( !is_array( $sassList ) ) {
 			$sassList = [$sassList];
 		}
 
-		$url = $this->getSassCommonURL(implode(',', $sassList));
-		$url =  str_replace(['/sass/', 'type=sass'], ['/sasses/', 'type=sasses'], $url);
+		$url = $this->getSassCommonURL( implode( ',', $sassList ), null, $params );
+		$url = str_replace( ['/sass/', 'type=sass'], ['/sasses/', 'type=sasses'], $url );
 
 		return $url;
 	}

--- a/extensions/wikia/AssetsManager/AssetsManagerServer.class.php
+++ b/extensions/wikia/AssetsManager/AssetsManagerServer.class.php
@@ -107,7 +107,7 @@ class AssetsManagerServer {
 			$headers['X-Pass-Cache-Control'] = 'public, max-age=' . $cacheDuration['client'];
 		}
 
-		if ($type === 'saas' || $type === 'sasses') {
+		if ( $type === 'sasses' && strpos( $request->getRequestURL(), urlencode( 'crossorigin=anonymous' ) ) !== false ) {
 			header( 'Access-Control-Allow-Origin: *' );
 		}
 

--- a/extensions/wikia/AssetsManager/AssetsManagerServer.class.php
+++ b/extensions/wikia/AssetsManager/AssetsManagerServer.class.php
@@ -107,6 +107,10 @@ class AssetsManagerServer {
 			$headers['X-Pass-Cache-Control'] = 'public, max-age=' . $cacheDuration['client'];
 		}
 
+		if ($type === 'saas' || $type === 'sasses') {
+			header( 'Access-Control-Allow-Origin: *' );
+		}
+
 		$headers['Last-Modified'] = gmdate('D, d M Y H:i:s \G\M\T');
 
 		foreach($headers as $k => $v) {

--- a/includes/Html.php
+++ b/includes/Html.php
@@ -627,16 +627,22 @@ class Html {
 	 *
 	 * @param $url string
 	 * @param $media mixed A media type string, like 'screen'
+	 * @param $crossorigin Configure the CORS requests for the fetched data
 	 * @return string Raw HTML
 	 */
-	public static function linkedStyle( $url, $media = 'all' ) {
-		return self::element( 'link', array(
+	public static function linkedStyle( $url, $media = 'all', $crossorigin = null ) {
+		$attribs = array(
 			'rel' => 'stylesheet',
 			'href' => $url,
 			'type' => 'text/css',
 			'media' => $media,
-			'crossorigin' => 'anonymous',
-		) );
+		);
+
+		if ( $crossorigin !== null ) {
+			$attribs['crossorigin'] = $crossorigin;
+		}
+
+		return self::element( 'link', $attribs );
 	}
 
 	/**

--- a/includes/Html.php
+++ b/includes/Html.php
@@ -635,6 +635,7 @@ class Html {
 			'href' => $url,
 			'type' => 'text/css',
 			'media' => $media,
+			'crossorigin' => 'anonymous',
 		) );
 	}
 

--- a/includes/wikia/nirvana/WikiaSkin.class.php
+++ b/includes/wikia/nirvana/WikiaSkin.class.php
@@ -276,7 +276,9 @@ abstract class WikiaSkin extends SkinTemplate {
 		$sassFiles = $this->assetsManager->getSassFilePath($sassFiles);
 
 		// get a single URL to fetch all the required SASS files
-		$sassFilesUrl = $this->assetsManager->getSassesUrl($sassFiles);
+		$sassParams = SassUtil::getSassSettings();
+		$sassParams['crossorigin'] = 'anonymous';
+		$sassFilesUrl = $this->assetsManager->getSassesUrl( $sassFiles, $sassParams );
 
 		// recovery unlock css
 		$unlockUrl = ARecoveryUnlockCSS::getUnlockCSSUrl();
@@ -284,7 +286,7 @@ abstract class WikiaSkin extends SkinTemplate {
 		wfDebug( sprintf( "%s: combined %d SASS files\n", __METHOD__, count($sassFiles) ) );
 
 		wfProfileOut(__METHOD__);
-		return Html::linkedStyle($sassFilesUrl) . Html::linkedStyle($unlockUrl) . implode('', $cssLinks);
+		return Html::linkedStyle( $sassFilesUrl, 'all', 'anonymous' ) . Html::linkedStyle( $unlockUrl ) . implode( '', $cssLinks );
 	}
 
 	/*


### PR DESCRIPTION
Recovered ads are placed in divs without styles.

Fix:
- add the crossorigin=“anonymous” attribute to CSS link element 
- return the proper CORS header for CSS link element

CC: @macbre 
