### PR TITLE
MWMemcached: do not report NOT_STORED responses as errors

### DIFF
--- a/includes/objectcache/MemcachedClient.php
+++ b/includes/objectcache/MemcachedClient.php
@@ -1247,14 +1247,17 @@ class MWMemcached {
 
 		// Wikia change - begin
 		// @author macbre (PLATFORM-774)
-		$this->error( __METHOD__ . ' - MemcachedClient: store failed - ' . $line, [
-			'cmd'       => $cmd,
-			'key'       => $key,
-			'normalized_key' => Wikia\Memcached\MemcachedStats::normalizeKey( $key ), # for easier grouping in Kibana
-			'val_size'  => strlen( $val ),
-			'exception' => new Exception( $line ),
-			'host'      => $host,
-		] );
+		// "NOT_STORED" response is not the indicator of an error (PLATFORM-2268)
+		if ( $line !== 'NOT_STORED' ) {
+			$this->error( __METHOD__ . ' - MemcachedClient: store failed - ' . $line, [
+				'cmd' => $cmd,
+				'key' => $key,
+				'normalized_key' => Wikia\Memcached\MemcachedStats::normalizeKey( $key ), # for easier grouping in Kibana
+				'val_size' => strlen( $val ),
+				'exception' => new Exception( $line ),
+				'host' => $host,
+			] );
+		}
 		// Wikia change - end
 		return false;
 	}


### PR DESCRIPTION
[PLATFORM-2268](https://wikia-inc.atlassian.net/browse/PLATFORM-2268) / [memcache protocol documentaion](https://github.com/memcached/memcached/blob/master/doc/protocol.txt) says:

```
After sending the command line and the data block the client awaits
the reply, which may be:

...

- "NOT_STORED\r\n" to indicate the data was not stored, but not
because of an error. This normally means that the
condition for an "add" or a "replace" command wasn't met.

...

  "add" means "store this data, but only if the server *doesn't* already
  hold data for this key".
```

@wladekb / @artursitarski 
