### PR TITLE
SUS-544 | Use template instead of replacing main page's content

### DIFF
--- a/extensions/wikia/CreateNewWiki/tests/FinishCreateWikiControllerTest.php
+++ b/extensions/wikia/CreateNewWiki/tests/FinishCreateWikiControllerTest.php
@@ -1,0 +1,82 @@
+<?php
+
+class FinishCreateWikiControllerTest extends WikiaBaseTest {
+
+	public function setUp() {
+		$this->setupFile = dirname(__FILE__) . '/../CreateNewWiki_setup.php';
+		parent::setUp();
+	}
+
+	/**
+	 * @dataProvider editSiteDescriptionTemplateDataProvider
+	 *
+	 * @param $description
+	 * @param $templateExists
+	 * @param $shouldEdit
+	 */
+	public function testEditSiteDescriptionTemplate( $description, $templateExists, $shouldEdit ) {
+		$titleMock = $this->getMockBuilder( 'Title' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'getArticleID', 'exists' ] )
+			->getMock();
+
+		$titleMock->expects( $this->any() )
+			->method( 'getArticleID' )
+			->willReturn( 1 );
+
+		$titleMock->expects( $this->any() )
+			->method( 'exists' )
+			->willReturn( $templateExists );
+
+		$this->getStaticMethodMock( 'Title', 'newFromText' )
+			->expects( $this->any() )
+			->method( 'newFromText' )
+			->will( $this->returnValue( $titleMock ) );
+
+		$articleMock = $this->getMockBuilder( 'Article' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'doEdit' ] )
+			->getMock();
+
+		if ( $shouldEdit ) {
+			$articleMock->expects( $this->once() )
+				->method( 'doEdit' )
+				->with( $this->equalTo( $description ) );
+		} else {
+			$articleMock->expects( $this->never() )
+				->method( 'doEdit' );
+		}
+
+		$this->getStaticMethodMock( 'Article', 'newFromID' )
+			->expects( $this->any() )
+			->method( 'newFromID' )
+			->will( $this->returnValue( $articleMock ) );
+
+		$controller = new FinishCreateWikiController();
+		$controller->params['wikiDescription'] = $description;
+		
+		$method = new ReflectionMethod( 'FinishCreateWikiController', 'editSiteDescriptionTemplate' );
+		$method->setAccessible( true );
+		$method->invoke( $controller );
+	}
+
+	public function editSiteDescriptionTemplateDataProvider() {
+		return [
+			[
+				'description' => 'This is description of my new wiki',
+				'templateExists' => true,
+				'shouldEdit' => true,
+			],
+			[
+				'description' => null,
+				'templateExists' => true,
+				'shouldEdit' => false
+			],
+			[
+				'description' => 'This is description of my new wiki',
+				'templateExists' => false,
+				'shouldEdit' => false
+			]
+		];
+	}
+}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-544
### Wiki description

Instead of blindly replacing the first section of main page with a site description let's use a new template - `Template:SiteDescription`. This way the ComDev will be able to put it wherever they please instead of being limited by some obscure, hardcoded rules which weren't communicated anywhere else but in the code itself.
### Wiki name

This PR also removes logic which was replacing `Wiki` word in the first section's header to `$wgSitename`. I've checked all starters and only two of them still depends on it:
- http://starter.wikia.com/wiki/Main_Page?action=raw
- http://de.starter.wikia.com/wiki/Hauptseite?action=raw

All other starters either:
- use another structure or wording so the replacement doesn't work anyway
- use `{{SITENAME}}` which is preferable way to achieve the effect
### Non-code changes

Before we can merge it we should:
- create `Template:SiteDescription` on every starter
- optionally put a default description there (if we don't do that, we will show description only if user provided it)
- edit main pages in starters to include `Template:SiteDescription`
### Reviewers

@mixth-sense 
