### PR TITLE
SUS-639 Un-stifle on-site event notifications for all following users

### DIFF
--- a/extensions/wikia/WallNotifications/WallNotifications.class.php
+++ b/extensions/wikia/WallNotifications/WallNotifications.class.php
@@ -770,10 +770,10 @@ class WallNotifications {
 		// The code will call this method twice for the same notification at times.  Rather than unwind this terrible
 		// mess of logic and state, just make sure we don't add the same notification twice.
 		static $seen = [];
-		if ( !empty( $seen[$entityKey] ) ) {
+		if ( !empty( $seen[$entityKey][$userId] ) ) {
 			return;
 		}
-		$seen[$entityKey] = true;
+		$seen[$entityKey][$userId] = true;
 
 		// Add the new $uniqueId and keep track of the index of the new ID in $notificationIndex.  This end/key/reset
 		// nonsense is required because of how PHP handles arrays.  Since we unset elements from this array later
@@ -850,12 +850,13 @@ class WallNotifications {
 
 		foreach ( $data['relation'][ $uniqueId ]['list'] as $rel ) {
 			if ( $rel['authorId'] == $authorId ) {
-				$found = true;
 
 				// Check the $entityKey here to make sure we're not removing an entry we just added
 				if ( $rel['entityKey'] != $entityKey ) {
 					continue;
 				}
+
+				$found = true;
 
 				// keep track of removed elements - we will remove them from db
 				// table after we are done updating in-memory structures

--- a/extensions/wikia/WallNotifications/tests/WallNotificationsTest.php
+++ b/extensions/wikia/WallNotifications/tests/WallNotificationsTest.php
@@ -80,8 +80,10 @@ class WallNotificationsTest extends WikiaBaseTest {
 
 	public function someDataProvider() {
 		$tests = [ ];
+		$relationListItem = [ 'entityKey' => '404_101', 'authorId' => 6600, 'isReply' => false ];
+		$firstUniqueId = 4444;
+		$secondUniqueId = 5555;
 
-		$uniqueId = 5555;
 		$entityKey = '505_212';
 		$authorId = 6666;
 		$isReply = false;
@@ -89,7 +91,7 @@ class WallNotificationsTest extends WikiaBaseTest {
 		$notifyeveryone = false;
 
 		$notificationData = [
-			'unique_id' => $uniqueId,
+			'unique_id' => $secondUniqueId,
 			'entity_key' => $entityKey,
 			'is_reply' => $isReply,
 			'author_id' => $authorId,
@@ -99,12 +101,12 @@ class WallNotificationsTest extends WikiaBaseTest {
 
 		$dataS = [
 			'notification' => [
-				0 => 4444
+				0 => $firstUniqueId
 			],
 			'relation' => [
-				4444 => [
+				$firstUniqueId => [
 					'read' => true,
-					'list' => [ [ 'entityKey' => '404_101', 'authorId' => 6600, 'isReply' => false ] ],
+					'list' => [ $relationListItem ],
 					'last' => 0,
 					'count' => 1,
 					'notifyeveryone' => 0
@@ -115,18 +117,18 @@ class WallNotificationsTest extends WikiaBaseTest {
 
 		$dataF = [
 			'notification' => [
-				0 => 4444,
-				1 => $uniqueId
+				0 => $firstUniqueId,
+				1 => $secondUniqueId
 			],
 			'relation' => [
-				4444 => [
+				$firstUniqueId => [
 					'read' => true,
-					'list' => [ 0 => [ 'entityKey' => '404_101', 'authorId' => 6600, 'isReply' => false ] ],
+					'list' => [ 0 => $relationListItem ],
 					'last' => 0,
 					'count' => 1,
 					'notifyeveryone' => 0
 				],
-				$uniqueId => [
+				$secondUniqueId => [
 					'read' => $read,
 					'list' => [ 0 => [ 'entityKey' => $entityKey, 'authorId' => $authorId, 'isReply' => $isReply ] ],
 					'last' => 1,
@@ -143,18 +145,18 @@ class WallNotificationsTest extends WikiaBaseTest {
 
 		$dataF = [
 			'notification' => [
-				0 => 4444,
-				2 => $uniqueId
+				0 => $firstUniqueId,
+				2 => $secondUniqueId
 			],
 			'relation' => [
-				4444 => [
+				$firstUniqueId => [
 					'read' => true,
-					'list' => [ 0 => [ 'entityKey' => '404_101', 'authorId' => 6600, 'isReply' => false ] ],
+					'list' => [ 0 => $relationListItem ],
 					'last' => 0,
 					'count' => 1,
 					'notifyeveryone' => 0
 				],
-				$uniqueId => [
+				$secondUniqueId => [
 					'read' => $read,
 					'list' => [ 0 => [ 'entityKey' => $entityKey, 'authorId' => $authorId, 'isReply' => $isReply ] ],
 					'last' => 2,
@@ -177,18 +179,18 @@ class WallNotificationsTest extends WikiaBaseTest {
 
 		$dataF = [
 			'notification' => [
-				0 => 4444,
-				2 => $uniqueId
+				0 => $firstUniqueId,
+				2 => $secondUniqueId
 			],
 			'relation' => [
-				4444 => [
+				$firstUniqueId => [
 					'read' => true,
-					'list' => [ 0 => [ 'entityKey' => '404_101', 'authorId' => 6600, 'isReply' => false ] ],
+					'list' => [ 0 => $relationListItem ],
 					'last' => 0,
 					'count' => 1,
 					'notifyeveryone' => 0
 				],
-				$uniqueId => [
+				$secondUniqueId => [
 					'read' => $read,
 					'list' => [
 						0 => [ 'entityKey' => $entityKey,  'authorId' => $authorId,  'isReply' => $isReply ],
@@ -214,18 +216,18 @@ class WallNotificationsTest extends WikiaBaseTest {
 
 		$dataF = [
 			'notification' => [
-				0 => 4444,
-				3 => $uniqueId
+				0 => $firstUniqueId,
+				3 => $secondUniqueId
 			],
 			'relation' => [
-				4444 => [
+				$firstUniqueId => [
 					'read' => true,
-					'list' => [ 0 => [ 'entityKey' => '404_101', 'authorId' => 6600, 'isReply' => false ] ],
+					'list' => [ 0 => $relationListItem ],
 					'last' => 0,
 					'count' => 1,
 					'notifyeveryone' => 0
 				],
-				$uniqueId => [
+				$secondUniqueId => [
 					'read' => $read,
 					'list' => [
 						0 => [ 'entityKey' => $entityKey,  'authorId' => $authorId,  'isReply' => $isReply ],
@@ -252,18 +254,18 @@ class WallNotificationsTest extends WikiaBaseTest {
 
 		$dataF = [
 			'notification' => [
-				0 => 4444,
-				4 => $uniqueId
+				0 => $firstUniqueId,
+				4 => $secondUniqueId
 			],
 			'relation' => [
-				4444 => [
+				$firstUniqueId => [
 					'read' => true,
-					'list' => [ 0 => [ 'entityKey' => '404_101', 'authorId' => 6600, 'isReply' => false ] ],
+					'list' => [ 0 => $relationListItem ],
 					'last' => 0,
 					'count' => 1,
 					'notifyeveryone' => 0
 				],
-				$uniqueId => [
+				$secondUniqueId => [
 					'read' => $read,
 					'list' => [
 						0 => [ 'entityKey' => $entityKey2, 'authorId' => $authorId2, 'isReply' => $isReply ],
@@ -287,18 +289,18 @@ class WallNotificationsTest extends WikiaBaseTest {
 
 		$dataF = [
 			'notification' => [
-				0 => 4444,
-				5 => $uniqueId
+				0 => $firstUniqueId,
+				5 => $secondUniqueId
 			],
 			'relation' => [
-				4444 => [
+				$firstUniqueId => [
 					'read' => true,
-					'list' => [ 0 => [ 'entityKey' => '404_101', 'authorId' => 6600, 'isReply' => false ] ],
+					'list' => [ 0 => $relationListItem ],
 					'last' => 0,
 					'count' => 1,
 					'notifyeveryone' => 0
 				],
-				$uniqueId => [
+				$secondUniqueId => [
 					'read' => $read,
 					'list' => [
 						0 => [ 'entityKey' => $entityKey2, 'authorId' => $authorId2, 'isReply' => $isReply ],
@@ -321,8 +323,14 @@ class WallNotificationsTest extends WikiaBaseTest {
 
 		return $tests;
 	}
+
 	/**
 	 * @dataProvider someDataProvider
+	 * @param $userId
+	 * @param $wikiId
+	 * @param $notificationData
+	 * @param $dataS
+	 * @param $dataF
 	 */
 	public function testAddNotificationToData($userId, $wikiId, $notificationData, $dataS, $dataF) {
 		$wn = new testWallNotifications();

--- a/extensions/wikia/WallNotifications/tests/WallNotificationsTest.php
+++ b/extensions/wikia/WallNotifications/tests/WallNotificationsTest.php
@@ -11,6 +11,13 @@ class testWallNotifications extends WallNotifications {
 
 class WallNotificationsTest extends WikiaBaseTest {
 
+	const ENTITY_KEY_102 = '404_102';
+	const ENTITY_KEY_103 = '404_103';
+	const ENTITY_KEY_104 = '404_104';
+	const ENTITY_KEY_105 = '404_105';
+	const ENTITY_KEY_106 = '404_106';
+	const ENTITY_KEY_212 = '505_212';
+
 	public function setUp() {
 		parent::setUp();
 	}
@@ -84,7 +91,7 @@ class WallNotificationsTest extends WikiaBaseTest {
 		$firstUniqueId = 4444;
 		$secondUniqueId = 5555;
 
-		$entityKey = '505_212';
+		$entityKey0 = self::ENTITY_KEY_212;
 		$authorId = 6666;
 		$isReply = false;
 		$read = false;
@@ -92,7 +99,7 @@ class WallNotificationsTest extends WikiaBaseTest {
 
 		$notificationData = [
 			'unique_id' => $secondUniqueId,
-			'entity_key' => $entityKey,
+			'entity_key' => $entityKey0,
 			'is_reply' => $isReply,
 			'author_id' => $authorId,
 			'is_read' => $read,
@@ -114,7 +121,6 @@ class WallNotificationsTest extends WikiaBaseTest {
 			]
 		];
 
-
 		$dataF = [
 			'notification' => [
 				0 => $firstUniqueId,
@@ -130,7 +136,7 @@ class WallNotificationsTest extends WikiaBaseTest {
 				],
 				$secondUniqueId => [
 					'read' => $read,
-					'list' => [ 0 => [ 'entityKey' => $entityKey, 'authorId' => $authorId, 'isReply' => $isReply ] ],
+					'list' => [ 0 => [ 'entityKey' => $entityKey0, 'authorId' => $authorId, 'isReply' => $isReply ] ],
 					'last' => 1,
 					'count' => 1,
 					'notifyeveryone' => $notifyeveryone
@@ -141,41 +147,10 @@ class WallNotificationsTest extends WikiaBaseTest {
 		// Data Set #0
 		$tests[] = [ null, null, $notificationData, $dataS, $dataF ];
 
+		$entityKey10 = self::ENTITY_KEY_212;
+		$entityKey11 = self::ENTITY_KEY_102;
+
 		$dataS = $dataF;
-
-		$dataF = [
-			'notification' => [
-				0 => $firstUniqueId,
-				2 => $secondUniqueId
-			],
-			'relation' => [
-				$firstUniqueId => [
-					'read' => true,
-					'list' => [ 0 => $relationListItem ],
-					'last' => 0,
-					'count' => 1,
-					'notifyeveryone' => 0
-				],
-				$secondUniqueId => [
-					'read' => $read,
-					'list' => [ 0 => [ 'entityKey' => $entityKey, 'authorId' => $authorId, 'isReply' => $isReply ] ],
-					'last' => 2,
-					'count' => 1,
-					'notifyeveryone' => $notifyeveryone
-				]
-			]
-		];
-
-		$entityKey = '404_102';
-
-		$notificationData['entity_key'] = $entityKey;
-
-		// Data Set #1
-		$tests[] = [ null, null, $notificationData, $dataS, $dataF ];
-
-		$authorId2 = 7777;
-		$entityKey  = '505_212';
-		$entityKey2 = '404_103';
 
 		$dataF = [
 			'notification' => [
@@ -193,8 +168,8 @@ class WallNotificationsTest extends WikiaBaseTest {
 				$secondUniqueId => [
 					'read' => $read,
 					'list' => [
-						0 => [ 'entityKey' => $entityKey,  'authorId' => $authorId,  'isReply' => $isReply ],
-						1 => [ 'entityKey' => $entityKey2, 'authorId' => $authorId2, 'isReply' => $isReply ]
+						0 => [ 'entityKey' => $entityKey10, 'authorId' => $authorId, 'isReply' => $isReply ],
+						1 => [ 'entityKey' => $entityKey11, 'authorId' => $authorId, 'isReply' => $isReply ],
 					],
 					'last' => 2,
 					'count' => 2,
@@ -203,7 +178,42 @@ class WallNotificationsTest extends WikiaBaseTest {
 			]
 		];
 
-		$notificationData['entity_key'] = $entityKey2;
+		$notificationData['entity_key'] = $entityKey11;
+
+		// Data Set #1
+		$tests[] = [ null, null, $notificationData, $dataS, $dataF ];
+
+		$authorId2 = 7777;
+		$entityKey20 = self::ENTITY_KEY_212;
+		$entityKey21 = self::ENTITY_KEY_103;
+
+		$dataF = [
+			'notification' => [
+				0 => $firstUniqueId,
+				2 => $secondUniqueId
+			],
+			'relation' => [
+				$firstUniqueId => [
+					'read' => true,
+					'list' => [ 0 => $relationListItem ],
+					'last' => 0,
+					'count' => 1,
+					'notifyeveryone' => 0
+				],
+				$secondUniqueId => [
+					'read' => $read,
+					'list' => [
+						0 => [ 'entityKey' => $entityKey20,  'authorId' => $authorId,  'isReply' => $isReply ],
+						1 => [ 'entityKey' => $entityKey21, 'authorId' => $authorId2, 'isReply' => $isReply ],
+					],
+					'last' => 2,
+					'count' => 2,
+					'notifyeveryone' => $notifyeveryone
+				]
+			]
+		];
+
+		$notificationData['entity_key'] = $entityKey21;
 		$notificationData['author_id'] = $authorId2;
 
 		// Data Set #2
@@ -212,7 +222,9 @@ class WallNotificationsTest extends WikiaBaseTest {
 		$dataS = $dataF;
 
 		$authorId3 = 7778;
-		$entityKey3 = '404_104';
+		$entityKey30 = self::ENTITY_KEY_212;
+		$entityKey31 = self::ENTITY_KEY_103;
+		$entityKey32 = self::ENTITY_KEY_104;
 
 		$dataF = [
 			'notification' => [
@@ -230,9 +242,9 @@ class WallNotificationsTest extends WikiaBaseTest {
 				$secondUniqueId => [
 					'read' => $read,
 					'list' => [
-						0 => [ 'entityKey' => $entityKey,  'authorId' => $authorId,  'isReply' => $isReply ],
-						1 => [ 'entityKey' => $entityKey2, 'authorId' => $authorId2, 'isReply' => $isReply ],
-						2 => [ 'entityKey' => $entityKey3, 'authorId' => $authorId3, 'isReply' => $isReply ]
+						0 => [ 'entityKey' => $entityKey30, 'authorId' => $authorId, 'isReply' => $isReply ],
+						1 => [ 'entityKey' => $entityKey31, 'authorId' => $authorId2, 'isReply' => $isReply ],
+						2 => [ 'entityKey' => $entityKey32, 'authorId' => $authorId3, 'isReply' => $isReply ],
 					],
 					'last' => 3,
 					'count' => 3,
@@ -241,7 +253,7 @@ class WallNotificationsTest extends WikiaBaseTest {
 			]
 		];
 
-		$notificationData['entity_key'] = $entityKey3;
+		$notificationData['entity_key'] = $entityKey32;
 		$notificationData['author_id'] = $authorId3;
 
 		// Data Set #3
@@ -250,7 +262,9 @@ class WallNotificationsTest extends WikiaBaseTest {
 		$dataS = $dataF;
 
 		$authorId4 = 7779;
-		$entityKey4 = '404_105';
+		$entityKey40 = self::ENTITY_KEY_103;
+		$entityKey41 = self::ENTITY_KEY_104;
+		$entityKey42 = self::ENTITY_KEY_105;
 
 		$dataF = [
 			'notification' => [
@@ -268,9 +282,9 @@ class WallNotificationsTest extends WikiaBaseTest {
 				$secondUniqueId => [
 					'read' => $read,
 					'list' => [
-						0 => [ 'entityKey' => $entityKey2, 'authorId' => $authorId2, 'isReply' => $isReply ],
-						1 => [ 'entityKey' => $entityKey3, 'authorId' => $authorId3, 'isReply' => $isReply ],
-						2 => [ 'entityKey' => $entityKey4, 'authorId' => $authorId4, 'isReply' => $isReply ]
+						0 => [ 'entityKey' => $entityKey40, 'authorId' => $authorId2, 'isReply' => $isReply ],
+						1 => [ 'entityKey' => $entityKey41, 'authorId' => $authorId3, 'isReply' => $isReply ],
+						2 => [ 'entityKey' => $entityKey42, 'authorId' => $authorId4, 'isReply' => $isReply ],
 					],
 					'last' => 4,
 					'count' => 4,
@@ -279,13 +293,17 @@ class WallNotificationsTest extends WikiaBaseTest {
 			]
 		];
 
-		$notificationData['entity_key'] = $entityKey4;
+		$notificationData['entity_key'] = $entityKey42;
 		$notificationData['author_id'] = $authorId4;
 
 		// Data Set #4
 		$tests[] = [ null, null, $notificationData, $dataS, $dataF ];
 
 		$dataS = $dataF;
+
+		$entityKey50 = self::ENTITY_KEY_104;
+		$entityKey51 = self::ENTITY_KEY_105;
+		$entityKey52 = self::ENTITY_KEY_106;
 
 		$dataF = [
 			'notification' => [
@@ -303,20 +321,18 @@ class WallNotificationsTest extends WikiaBaseTest {
 				$secondUniqueId => [
 					'read' => $read,
 					'list' => [
-						0 => [ 'entityKey' => $entityKey2, 'authorId' => $authorId2, 'isReply' => $isReply ],
-						1 => [ 'entityKey' => $entityKey3, 'authorId' => $authorId3, 'isReply' => $isReply ],
-						2 => [ 'entityKey' => $entityKey4, 'authorId' => $authorId4, 'isReply' => $isReply ]
+						0 => [ 'entityKey' => $entityKey50, 'authorId' => $authorId3, 'isReply' => $isReply ],
+						1 => [ 'entityKey' => $entityKey51, 'authorId' => $authorId4, 'isReply' => $isReply ],
+						2 => [ 'entityKey' => $entityKey52, 'authorId' => $authorId4, 'isReply' => $isReply ],
 					],
 					'last' => 5,
-					'count' => 4,
+					'count' => 5,
 					'notifyeveryone' => $notifyeveryone
 				]
 			]
 		];
 
-		$entityKey5 = '404_106';
-
-		$notificationData['entity_key'] = $entityKey5;
+		$notificationData['entity_key'] = $entityKey52;
 
 		// Data Set #5
 		$tests[] = [ null, null, $notificationData, $dataS, $dataF ];


### PR DESCRIPTION
This aims to fix two issues:
1. On each event being followed by multiple users, only the first follower probing for notifications 'wins' in getting the notification. The rest of the followers will not because the marker had no user id factored in it.
2. On multiple events by same author, the found flag is raised prematurely which can cause more notification entities removed than necessary

/CC @mixth-sense @garthwebb 
