### PR TITLE
ArticleComment: always return a bool from loadRevisionsAndAuthor()

### DIFF
--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -249,6 +249,7 @@ class ArticleComment {
 		$this->mUser->setName( $this->mFirstRevision->getUserText() );
 
 		$this->isRevisionLoaded = true;
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
Fix a regression caused by #10664 - users were not able to edit their own comments.

@ludwikkazmierczak / @wladekb 
