### PR TITLE
(DAT-4494) Quick fix Portable Infobox rendering

### DIFF
--- a/extensions/wikia/PortableInfobox/controllers/PortableInfoboxParserTagController.class.php
+++ b/extensions/wikia/PortableInfobox/controllers/PortableInfoboxParserTagController.class.php
@@ -119,7 +119,7 @@ class PortableInfoboxParserTagController extends WikiaController {
 			$renderedValue = trim( json_encode( $renderedValue ), '"' );
 		}
 
-		$marker = $parser->uniqPrefix() . "-" . self::PARSER_TAG_NAME . "-{$this->markerNumber}\x7f-QINU";
+		$marker = $parser->uniqPrefix() . "-" . self::PARSER_TAG_NAME . "-{$this->markerNumber}" . Parser::MARKER_SUFFIX;
 		$this->markers[ $marker ] = $renderedValue;
 
 		return [ $marker, 'markerType' => 'nowiki' ];

--- a/extensions/wikia/PortableInfobox/controllers/PortableInfoboxParserTagController.class.php
+++ b/extensions/wikia/PortableInfobox/controllers/PortableInfoboxParserTagController.class.php
@@ -100,7 +100,6 @@ class PortableInfoboxParserTagController extends WikiaController {
 	 * @returns String $html
 	 */
 	public function renderInfobox( $text, $params, $parser, $frame ) {
-		global $wgArticleAsJson;
 		$this->markerNumber++;
 		$markup = '<' . self::PARSER_TAG_NAME . '>' . $text . '</' . self::PARSER_TAG_NAME . '>';
 
@@ -112,11 +111,6 @@ class PortableInfoboxParserTagController extends WikiaController {
 			return $this->handleXmlParseError( $e->getErrors(), $text );
 		} catch ( \Wikia\PortableInfobox\Helpers\InvalidInfoboxParamsException $e ) {
 			return $this->handleError( wfMessage( 'portable-infobox-xml-parse-error-infobox-tag-attribute-unsupported', [ $e->getMessage() ] )->escaped() );
-		}
-
-		if ( $wgArticleAsJson ) {
-			// (wgArticleAsJson == true) it means that we need to encode output for use inside JSON
-			$renderedValue = trim( json_encode( $renderedValue ), '"' );
 		}
 
 		$marker = $parser->uniqPrefix() . "-" . self::PARSER_TAG_NAME . "-{$this->markerNumber}" . Parser::MARKER_SUFFIX;

--- a/extensions/wikia/PortableInfobox/controllers/PortableInfoboxParserTagController.class.php
+++ b/extensions/wikia/PortableInfobox/controllers/PortableInfoboxParserTagController.class.php
@@ -141,12 +141,15 @@ class PortableInfoboxParserTagController extends WikiaController {
 		global $wgArticleAsJson;
 		if ( $wgArticleAsJson ) {
 			$contentArray = json_decode( $text, true );
-			$text = $contentArray['content'];
-		}
-		$text = strtr( $text, $this->markers );
-		if ( $wgArticleAsJson ) {
-			$contentArray['content'] = $text;
-			$text = json_encode( $contentArray );
+			if ( is_array( $contentArray ) && isset( $contentArray['content'] ) ) {
+				$text = strtr( $contentArray['content'], $this->markers );
+				$contentArray['content'] = $text;
+				$text = json_encode( $contentArray );
+			} else {
+				$text = strtr( $text, $this->markers );
+			}
+		} else {
+			$text = strtr( $text, $this->markers );
 		}
 		return $text;
 	}

--- a/extensions/wikia/PortableInfobox/controllers/PortableInfoboxParserTagController.class.php
+++ b/extensions/wikia/PortableInfobox/controllers/PortableInfoboxParserTagController.class.php
@@ -144,7 +144,17 @@ class PortableInfoboxParserTagController extends WikiaController {
 	}
 
 	public function replaceMarkers( $text ) {
-		return strtr( $text, $this->markers );
+		global $wgArticleAsJson;
+		if ( $wgArticleAsJson ) {
+			$contentArray = json_decode( $text, true );
+			$text = $contentArray['content'];
+		}
+		$text = strtr( $text, $this->markers );
+		if ( $wgArticleAsJson ) {
+			$contentArray['content'] = $text;
+			$text = json_encode( $contentArray );
+		}
+		return $text;
 	}
 
 	protected function saveToParserOutput( \ParserOutput $parserOutput, Nodes\NodeInfobox $raw ) {

--- a/extensions/wikia/PortableInfobox/services/Parser/Nodes/NodeImage.php
+++ b/extensions/wikia/PortableInfobox/services/Parser/Nodes/NodeImage.php
@@ -10,7 +10,7 @@ class NodeImage extends Node {
 	const MEDIA_TYPE_VIDEO = 'VIDEO';
 
 	public static function getMarkers( $value, $ext ) {
-		if ( preg_match_all('/\x7fUNIQ[A-Z0-9]*-' . $ext . '-[A-F0-9]{8}-QINU\x7f/is', $value, $out ) ) {
+		if ( preg_match_all('/\x7f\'"`UNIQ[A-Z0-9]*-' . $ext . '-[A-F0-9]{8}-QINU`"\'\x7f/is', $value, $out ) ) {
 			return $out[0];
 		} else {
 			return [];

--- a/extensions/wikia/PortableInfobox/tests/nodes/NodeImageTest.php
+++ b/extensions/wikia/PortableInfobox/tests/nodes/NodeImageTest.php
@@ -49,13 +49,13 @@ class NodeImageTest extends WikiaBaseTest {
 		return [
 			[
 				'TABBER',
-				"<div>\x7fUNIQ123456789-tAbBeR-12345678-QINU\x7f</div>",
-				[ "\x7fUNIQ123456789-tAbBeR-12345678-QINU\x7f" ]
+				"<div>\x7f'\"`UNIQ123456789-tAbBeR-12345678-QINU`\"'\x7f</div>",
+				[ "\x7f'\"`UNIQ123456789-tAbBeR-12345678-QINU`\"'\x7f" ]
 			],
 			[
 				'GALLERY',
-				"\x7fUNIQ123456789-tAbBeR-12345678-QINU\x7f<center>\x7fUNIQabcd-gAlLeRy-12345678-QINU\x7f</center>\x7fUNIQabcd-gAlLeRy-87654321-QINU\x7f",
-				[ "\x7fUNIQabcd-gAlLeRy-12345678-QINU\x7f", "\x7fUNIQabcd-gAlLeRy-87654321-QINU\x7f" ]
+				"\x7f'\"`UNIQ123456789-tAbBeR-12345678-QINU`\"'\x7f<center>\x7f'\"`UNIQabcd-gAlLeRy-12345678-QINU`\"'\x7f</center>\x7f'\"`UNIQabcd-gAlLeRy-87654321-QINU`\"'\x7f",
+				[ "\x7f'\"`UNIQabcd-gAlLeRy-12345678-QINU`\"'\x7f", "\x7f'\"`UNIQabcd-gAlLeRy-87654321-QINU`\"'\x7f" ]
 			]
 		];
 	}

--- a/includes/parser/Parser.php
+++ b/includes/parser/Parser.php
@@ -97,6 +97,7 @@ class Parser {
 
 	# Marker Suffix needs to be accessible staticly.
 	const MARKER_SUFFIX = "-QINU`\"'\x7f";
+	const MARKER_PREFIX = "\x7f'\"`UNIQ";
 
 	# Persistent:
 	var $mTagHooks = array();
@@ -297,7 +298,7 @@ class Parser {
 		 */
 		# $this->mUniqPrefix = "\x07UNIQ" . Parser::getRandomString();
 		# Changed to \x7f to allow XML double-parsing -- TS
-		$this->mUniqPrefix = "\x7f'\"`UNIQ" . self::getRandomString();
+		$this->mUniqPrefix = self::MARKER_PREFIX . self::getRandomString();
 		$this->mStripState = new StripState( $this->mUniqPrefix );
 
 

--- a/includes/wikia/nirvana/WikiaParserTagController.class.php
+++ b/includes/wikia/nirvana/WikiaParserTagController.class.php
@@ -69,7 +69,20 @@ abstract class WikiaParserTagController extends WikiaController {
 	}
 
 	public final function onParserAfterTidy( Parser &$parser, &$text ) {
-		$text = strtr( $text, $this->getMarkers() );
+		$markers = $this->getMarkers();
+		if ( $this->wg->ArticleAsJson ) {
+			$contentArray = json_decode( $text, true );
+			if ( is_array( $contentArray ) && isset( $contentArray['content'] ) ) {
+				$text = strtr( $contentArray['content'], $this->markers );
+				$contentArray['content'] = $text;
+				$text = json_encode( $contentArray );
+			} else {
+				$text = strtr( $text, $markers );
+			}
+		} else {
+			$text = strtr( $text, $markers );
+		}
+		$text = strtr( $text, $markers );
 		return true;
 	}
 
@@ -136,7 +149,7 @@ abstract class WikiaParserTagController extends WikiaController {
 			 *
 			 * I've chosen b) and if you think about anything which is better don't hesitate to let me know, please :)
 			 */
-			$this->markers[$markerId] = trim( json_encode( $output->toString() ), "\"" );
+			$this->markers[$markerId] = $output->toString();
 		} else {
 			$this->markers[$markerId] = $output;
 		}


### PR DESCRIPTION
After the MW security release, the format of the UNIQ parser markers was changed
and the way PIs replace them broke.

In Mercury, this is because the JSON encoding was encoding and escaping the quote
in the unique prefix and then the replace was being done on the JSON encoded string.

This is a quick and ugly fix to get PIs working again on Mercury, but needs to be refactored
with more time (in particular the quick and dirty fix for `PortableInfoboxParserTagController`
when `wgArticleAsJson` is true).

/cc @rogatty 
