### PR TITLE
Remove $wgHttpOnlyBlacklist

### DIFF
--- a/includes/DefaultSettings.php
+++ b/includes/DefaultSettings.php
@@ -3762,17 +3762,6 @@ $wgCookiePrefix = false;
  */
 $wgCookieHttpOnly = true;
 
-/**
- * If the requesting browser matches a regex in this blacklist, we won't
- * send it cookies with HttpOnly mode, even if $wgCookieHttpOnly is on.
- */
-$wgHttpOnlyBlacklist = array(
-	// Internet Explorer for Mac; sometimes the cookies work, sometimes
-	// they don't. It's difficult to predict, as combinations of path
-	// and expiration options affect its parsing.
-	'/^Mozilla\/4\.0 \(compatible; MSIE \d+\.\d+; Mac_PowerPC\)/',
-);
-
 /** A list of cookies that vary the cache (for use by extensions) */
 $wgCacheVaryCookies = array();
 

--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -3404,23 +3404,6 @@ function wfCreateObject( $name, $p ) {
 }
 
 /**
- * @return bool
- */
-function wfHttpOnlySafe() {
-	global $wgHttpOnlyBlacklist;
-
-	if( isset( $_SERVER['HTTP_USER_AGENT'] ) ) {
-		foreach( $wgHttpOnlyBlacklist as $regex ) {
-			if( preg_match( $regex, $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-		}
-	}
-
-	return true;
-}
-
-/**
  * Check if there is sufficent entropy in php's built-in session generation
  * PHP's built-in session entropy is enabled if:
  * - entropy_file is set or you're on Windows with php 5.3.3+
@@ -3499,7 +3482,6 @@ function wfSetupSession( $sessionId = false ) {
 		# hasn't already been set to the desired value (that causes errors)
 		ini_set( 'session.save_handler', $wgSessionHandler );
 	}
-	$httpOnlySafe = wfHttpOnlySafe() && $wgCookieHttpOnly;
 	wfDebugLog( 'cookie',
 		'session_set_cookie_params: "' . implode( '", "',
 			array(
@@ -3507,8 +3489,8 @@ function wfSetupSession( $sessionId = false ) {
 				$wgCookiePath,
 				$wgCookieDomain,
 				$wgCookieSecure,
-				$httpOnlySafe ) ) . '"' );
-	session_set_cookie_params( 0, $wgCookiePath, $wgCookieDomain, $wgCookieSecure, $httpOnlySafe );
+				$wgCookieHttpOnly  ) ) . '"' );
+	session_set_cookie_params( 0, $wgCookiePath, $wgCookieDomain, $wgCookieSecure, $wgCookieHttpOnly  );
 	session_cache_limiter( 'private, must-revalidate' );
 	if ( $sessionId ) {
 		session_id( $sessionId );

--- a/includes/WebResponse.php
+++ b/includes/WebResponse.php
@@ -60,7 +60,6 @@ class WebResponse implements \Wikia\HTTP\Response {
 		if( $domain === null ) {
 			$domain = $wgCookieDomain;
 		}
-		$httpOnlySafe = wfHttpOnlySafe() && $wgCookieHttpOnly;
 		wfDebugLog( 'cookie',
 			'setcookie: "' . implode( '", "',
 				array(
@@ -70,14 +69,14 @@ class WebResponse implements \Wikia\HTTP\Response {
 					$wgCookiePath,
 					$domain,
 					$wgCookieSecure,
-					$httpOnlySafe ) ) . '"' );
+					$wgCookieHttpOnly ) ) . '"' );
 		setcookie( $prefix . $name,
 			$value,
 			$expire,
 			$wgCookiePath,
 			$domain,
 			$wgCookieSecure,
-			$httpOnlySafe );
+			$wgCookieHttpOnly );
 	}
 }
 


### PR DESCRIPTION
[PLATFORM-2269](https://wikia-inc.atlassian.net/browse/PLATFORM-2269)

This hack was added in https://github.com/wikimedia/mediawiki/commit/6b16f44 to support IE for Mac.
That browser is no longer supported, and no additional user-agent
strings have been added in WMF configuration.

Backporting https://github.com/wikimedia/mediawiki/commit/00b7f76aaf2037cbb084b4f80b5ec3c9e2a7a88a from MW 1.23 - all cookies set by backend will now **ALWAYS** be set as `HttpOnly`.

@wladekb / @Grunny 
