### PR TITLE
(CE-3844) Refactor fix for PI and parser tag fix

### DIFF
--- a/extensions/wikia/PortableInfobox/PortableInfoboxHooks.class.php
+++ b/extensions/wikia/PortableInfobox/PortableInfoboxHooks.class.php
@@ -136,9 +136,12 @@ class PortableInfoboxHooks {
 
 		return true;
 	}
-	
+
 	public static function onArticleAsJsonBeforeEncode( &$text ) {
-		PortableInfoboxParserTagController::getInstance()->moveFirstMarkerToTop( $text );
+		$tagController = PortableInfoboxParserTagController::getInstance();
+		$tagController->moveFirstMarkerToTop( $text );
+
+		$text = $tagController->replaceMarkers( $text );
 
 		return true;
 	}

--- a/extensions/wikia/PortableInfobox/controllers/PortableInfoboxParserTagController.class.php
+++ b/extensions/wikia/PortableInfobox/controllers/PortableInfoboxParserTagController.class.php
@@ -50,7 +50,10 @@ class PortableInfoboxParserTagController extends WikiaController {
 	 * @return string
 	 */
 	public static function replaceInfoboxMarkers( &$parser, &$text ) {
-		$text = static::getInstance()->replaceMarkers( $text );
+		global $wgArticleAsJson;
+		if ( !$wgArticleAsJson ) {
+			$text = static::getInstance()->replaceMarkers( $text );
+		}
 
 		return true;
 	}
@@ -138,20 +141,7 @@ class PortableInfoboxParserTagController extends WikiaController {
 	}
 
 	public function replaceMarkers( $text ) {
-		global $wgArticleAsJson;
-		if ( $wgArticleAsJson ) {
-			$contentArray = json_decode( $text, true );
-			if ( is_array( $contentArray ) && isset( $contentArray['content'] ) ) {
-				$text = strtr( $contentArray['content'], $this->markers );
-				$contentArray['content'] = $text;
-				$text = json_encode( $contentArray );
-			} else {
-				$text = strtr( $text, $this->markers );
-			}
-		} else {
-			$text = strtr( $text, $this->markers );
-		}
-		return $text;
+		return strtr( $text, $this->markers );
 	}
 
 	protected function saveToParserOutput( \ParserOutput $parserOutput, Nodes\NodeInfobox $raw ) {

--- a/extensions/wikia/PortableInfobox/controllers/PortableInfoboxParserTagController.class.php
+++ b/extensions/wikia/PortableInfobox/controllers/PortableInfoboxParserTagController.class.php
@@ -51,6 +51,7 @@ class PortableInfoboxParserTagController extends WikiaController {
 	 */
 	public static function replaceInfoboxMarkers( &$parser, &$text ) {
 		global $wgArticleAsJson;
+		// The replacements for ArticleAsJson are handled in PortableInfoboxHooks::onArticleAsJsonBeforeEncode
 		if ( !$wgArticleAsJson ) {
 			$text = static::getInstance()->replaceMarkers( $text );
 		}


### PR DESCRIPTION
A security fix from MW core added quotes to the Parser's strip tag
markers in order to prevent an XSS vulnerability. When this was deployed
PIs and our Wikia tag extensions broke in Mercury because ArticlesAsJson
JSON encodes the parser output in the ParserAfterTidy, but then PI and
the tag extensions were manually replacing the Parser tag strip markers
on the already JSON encoded string within their own ParserAfterTidy methods
(which were always run after the ArticlesAsJson method). This meant that the
strip marker had the quote escaped with a backslash in the encoded string,
so the string replacements failed.

This change follows [the previous quick and dirty fix](https://github.com/Wikia/app/pull/10701) by moving the replacements
in PI and the tag extensions to just before ArticlesAsJson encodes the output.
This also removes the need from before the fix in #10701 to JSON encode the
parser output of the tags that will be replaced into the text.

/cc @Wikia/west-wing @rogatty 
