### PR TITLE
JPN-552 Add transparent black background for light theme

### DIFF
--- a/extensions/wikia/CommunityPage/styles/components/_header.scss
+++ b/extensions/wikia/CommunityPage/styles/components/_header.scss
@@ -3,15 +3,18 @@
 
 $hero-image-pattern: '/extensions/wikia/CommunityPage/images/hero_image_pattern.png';
 $hero-image-height: 200px;
+$hero-image-background: rgba(0,0,0,0.35);
 
 @if $is-dark-wiki {
 	$hero-image-pattern: '/extensions/wikia/CommunityPage/images/hero_image_pattern_dark.png';
+	$hero-image-background: rgba(0,0,0,0);
 }
 
 .community-page-header {
 	@include flexbox();
 	align-items: center;
 	background: url($hero-image-pattern);
+	background-color: $hero-image-background;
 	height: $hero-image-height;
 	justify-content: center;
 	text-align: center;


### PR DESCRIPTION
JPN-552 Add transparent black background for light theme default community page image. Left dark theme default image alone, as it already looks good with white text.

@Wikia/spitfires @d34th4ck3r 
