### PR TITLE
JPN-570 Fix community page overlay for Firefox

### DIFF
--- a/extensions/wikia/CommunityPage/styles/components/_header.scss
+++ b/extensions/wikia/CommunityPage/styles/components/_header.scss
@@ -28,6 +28,7 @@ $hero-image-height: 200px;
 		left: 0;
 		position: absolute;
 		right: 0;
+		top: 0;
 		z-index: 0;
 	}
 


### PR DESCRIPTION
top: 0; is needed for correct placement in Firefox.

@Wikia/spitfires @d34th4ck3r 
