### PR TITLE
CE-3851 Wrap words in right rail entrypoint module

### DIFF
--- a/extensions/wikia/CommunityPage/styles/entrypoint/EntryPoint.scss
+++ b/extensions/wikia/CommunityPage/styles/entrypoint/EntryPoint.scss
@@ -1,8 +1,6 @@
 @import 'skins/shared/color';
-@import 'skins/shared/mixins/flexbox';
 @import 'skins/oasis/css/core/breakpoints-variables';
-
-@import '../components/_variables';
+@import '../components/variables';
 
 $background-color-dark: #1a1a1a;
 $background-color-light: #f6f6f6;
@@ -23,12 +21,20 @@ $logo-url: $logo-url-light;
 .WikiaRail {
 	.module {
 		position: relative;
+
+		&.community-page-entry-point-module {
+			padding-top: 40px;
+		}
 	}
 }
 
 .community-page-entry-point-module {
+	font-family: $community-page-font-family;
+	font-size: 16px;
+	line-height: 21px;
 	margin-top: 20px;
 	position: relative;
+	text-align: center;
 
 	.community-page-entry-point-logo {
 		background-image: url($logo-url); /* inline */
@@ -38,16 +44,6 @@ $logo-url: $logo-url-light;
 		top: 0;
 		transform: translate(-50%, -40%);
 		width: 30px;
-	}
-
-	.community-page-entry-point-container {
-		@include align-items(center);
-		@include flexbox();
-		@include flex-direction(column);
-
-		font-size: 14px;
-		font-family: $community-page-font-family;
-		padding-top: 5px;
 	}
 
 	.community-page-entry-point-button {
@@ -84,10 +80,6 @@ $logo-url: $logo-url-light;
 	}
 
 	.community-page-entry-point-description {
-		font-size: 16px;
-		padding-top: 15px;
-		text-align: center;
-		word-wrap: break-word;
 		white-space: pre-line; // Respect linebreaks
 
 		b {

--- a/skins/oasis/modules/templates/CommunityPageEntryPointController_Index.php
+++ b/skins/oasis/modules/templates/CommunityPageEntryPointController_Index.php
@@ -3,10 +3,6 @@
 	<div class="community-page-entry-point-new">
 		<?= wfMessage( 'communitypage-new' )->escaped() ?>
 	</div>
-	<div class="community-page-entry-point-container">
-		<div class="community-page-entry-point-description"><?= wfMessage( 'communitypage-help-us-grow' )->parse() ?></div>
-		<div>
-			<a href="<?= SpecialPage::getTitleFor( 'Community' )->getLocalURL(); ?>" class="community-page-entry-point-button"><?= wfMessage( 'communitypage-entry-button' )->escaped() ?></a>
-		</div>
-	</div>
+	<div class="community-page-entry-point-description"><?= wfMessage( 'communitypage-help-us-grow' )->parse() ?></div>
+	<a href="<?= SpecialPage::getTitleFor( 'Community' )->getLocalURL(); ?>" class="community-page-entry-point-button"><?= wfMessage( 'communitypage-entry-button' )->escaped() ?></a>
 </section>


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CE-3851
## Description

`word-wrap: break-word` wasn't working properly for the entry point module and it turned out that flexbox is breaking it. Fix could be to add width on flexbox element then longer words start to be wrapped properly.

Although instead I decided to simplify stylling here and remove flex stylling which also fixed word wrapping.

@Wikia/spitfires 
