### PR TITLE
Auth | Check for presence of an object

### DIFF
--- a/extensions/wikia/AuthModal/js/AuthModal.js
+++ b/extensions/wikia/AuthModal/js/AuthModal.js
@@ -28,7 +28,7 @@ define('AuthModal', ['jquery', 'wikia.window'], function ($, window) {
 				closeTrackTimeoutId = setTimeout(function () {
 					var trackParams;
 
-					if (!authPopUpWindow.closed) {
+					if (authPopUpWindow && !authPopUpWindow.closed) {
 						return;
 					}
 


### PR DESCRIPTION
@kvas-damian This is sometimes throwing a js error just before redirecting to the standalone auth page.
