### PR TITLE
prevent global block check in Special:UserLookup

### DIFF
--- a/extensions/wikia/LookupUser/LookupUser.body.php
+++ b/extensions/wikia/LookupUser/LookupUser.body.php
@@ -407,7 +407,7 @@ EOT
 			return json_encode( [ 'success' => false ] );
 		}
 
-		$apiUrl = $wiki->city_url . 'api.php?action=query&list=users&ususers=' . urlencode( $userName ) . '&usprop=blockinfo|groups|editcount&format=json';
+		$apiUrl = $wiki->city_url . 'api.php?action=query&list=users&ususers=' . urlencode( $userName ) . '&usprop=localblockinfo|groups|editcount&format=json';
 
 		$cachedData = $wgMemc->get( LookupUserPage::getUserLookupMemcKey( $userName, $wikiId ) );
 		if ( !empty( $cachedData ) ) {

--- a/extensions/wikia/PhalanxII/hooks/PhalanxHooks.class.php
+++ b/extensions/wikia/PhalanxII/hooks/PhalanxHooks.class.php
@@ -250,7 +250,7 @@ class PhalanxHooks extends WikiaObject {
 	 * @return bool true
 	 */
 	static public function onGetBlockedStatus( User $user, $shouldLogBlockInStats=false, $global=true ) {
-		if (!$global) {
+		if ( ! $global ) {
 			return true;
 		}
 

--- a/extensions/wikia/PhalanxII/hooks/PhalanxHooks.class.php
+++ b/extensions/wikia/PhalanxII/hooks/PhalanxHooks.class.php
@@ -249,7 +249,11 @@ class PhalanxHooks extends WikiaObject {
 	 * @param User $user
 	 * @return bool true
 	 */
-	static public function onGetBlockedStatus( User $user ) {
+	static public function onGetBlockedStatus( User $user, $shouldLogBlockInStats=false, $global=true ) {
+		if (!$global) {
+			return true;
+		}
+
 		global $wgRequest, $wgClientIPHeader;
 
 		// get the client IP using Fastly-generated request header

--- a/extensions/wikia/PhalanxII/hooks/PhalanxUserBlock.class.php
+++ b/extensions/wikia/PhalanxII/hooks/PhalanxUserBlock.class.php
@@ -27,7 +27,7 @@ class PhalanxUserBlock extends WikiaObject {
 	 * @return bool
 	 */
 	static public function blockCheck( User $user, $shouldLogBlockInStats = true, $global = true ) {
-		if (!$global) {
+		if ( ! $global ) {
 			return true;
 		}
 

--- a/extensions/wikia/PhalanxII/hooks/PhalanxUserBlock.class.php
+++ b/extensions/wikia/PhalanxII/hooks/PhalanxUserBlock.class.php
@@ -26,7 +26,11 @@ class PhalanxUserBlock extends WikiaObject {
 	 *
 	 * @return bool
 	 */
-	static public function blockCheck( User $user, $shouldLogBlockInStats = true ) {
+	static public function blockCheck( User $user, $shouldLogBlockInStats = true, $global = true ) {
+		if (!$global) {
+			return true;
+		}
+
 		wfProfileIn( __METHOD__ );
 
 		$phalanxModel = new PhalanxUserModel( $user );

--- a/includes/User.php
+++ b/includes/User.php
@@ -1356,7 +1356,7 @@ class User {
 	 *                    done against master.
 	 * @param $shouldLogBlockInStats Bool flag that decides whether to log or not in PhalanxStats
 	 */
-	private function getBlockedStatus( $bFromSlave = true, $shouldLogBlockInStats = true ) {
+	private function getBlockedStatus( $bFromSlave = true, $shouldLogBlockInStats = true, $global = true ) {
 	/* Wikia change end */
 		global $wgProxyWhitelist, $wgUser;
 
@@ -1419,7 +1419,7 @@ class User {
 
 		# Extensions
 		/* Wikia change begin - SUS-92 */
-		wfRunHooks( 'GetBlockedStatus', array( &$this, $shouldLogBlockInStats ) );
+		wfRunHooks( 'GetBlockedStatus', array( &$this, $shouldLogBlockInStats, $global ) );
 		/* Wikia change end */
 
 		if ( !empty($this->mBlockedby) ) {
@@ -1656,8 +1656,9 @@ class User {
 	 *
 	 * @return Bool True if blocked, false otherwise
 	 */
-	public function isBlocked( $bFromSlave = true, $shouldLogBlockInStats = true ) { // hacked from false due to horrible probs on site
-		return $this->getBlock( $bFromSlave, $shouldLogBlockInStats ) instanceof Block && $this->getBlock()->prevents( 'edit' );
+	public function isBlocked( $bFromSlave = true, $shouldLogBlockInStats = true, $global = true ) { // hacked from false due to horrible probs on site
+		$block = $this->getBlock( $bFromSlave, $shouldLogBlockInStats, $global );
+		return $block instanceof Block && $block->prevents( 'edit' );
 	}
 
 	/**
@@ -1668,8 +1669,8 @@ class User {
 	 *
 	 * @return Block|null
 	 */
-	public function getBlock( $bFromSlave = true, $shouldLogBlockInStats = true ){
-		$this->getBlockedStatus( $bFromSlave, $shouldLogBlockInStats );
+	public function getBlock( $bFromSlave = true, $shouldLogBlockInStats = true, $global = true ){
+		$this->getBlockedStatus( $bFromSlave, $shouldLogBlockInStats, $global );
 		return $this->mBlock instanceof Block ? $this->mBlock : null;
 	}
 	/* Wikia change end */

--- a/includes/api/ApiQueryUsers.php
+++ b/includes/api/ApiQueryUsers.php
@@ -160,8 +160,8 @@ class ApiQueryUsers extends ApiQueryBase {
 				}
 
 				/* Wikia change begin - SUS-92 */
-				if ( isset( $this->prop['blockinfo'] ) || isset($this->prop['localblockinfo']) ) {
-					$isGlobalBlockCheck = !isset($this->prop['localblockinfo']);
+				if ( isset( $this->prop['blockinfo'] ) || isset( $this->prop['localblockinfo'] ) ) {
+					$isGlobalBlockCheck = !isset( $this->prop['localblockinfo'] );
 					$isBlocked = $user->isBlocked( true, false, $isGlobalBlockCheck );
 					
 					if ($isBlocked) {

--- a/includes/api/ApiQueryUsers.php
+++ b/includes/api/ApiQueryUsers.php
@@ -158,15 +158,20 @@ class ApiQueryUsers extends ApiQueryBase {
 				if ( $row->ipb_deleted ) {
 					$data[$name]['hidden'] = '';
 				}
+
 				/* Wikia change begin - SUS-92 */
-				if ( isset( $this->prop['blockinfo'] ) && $user->isBlocked( true, false ) ) {
-					$blockInfo = $user->getBlock( true, false );
-				/* Wikia change end */
+				if ( isset( $this->prop['blockinfo'] ) || isset($this->prop['localblockinfo']) ) {
+					$isGlobalBlockCheck = !isset($this->prop['localblockinfo']);
+					$isBlocked = $user->isBlocked( true, false, $isGlobalBlockCheck );
 					
-					$data[$name]['blockedby'] = $blockInfo->getByName();
-					$data[$name]['blockreason'] = $blockInfo->mReason;
-					$data[$name]['blockexpiry'] = $blockInfo->getExpiry();
+					if ($isBlocked) {
+						$blockInfo = $user->getBlock( true, false, $isGlobalBlockCheck );
+						$data[$name]['blockedby'] = $blockInfo->getByName();
+						$data[$name]['blockreason'] = $blockInfo->mReason;
+						$data[$name]['blockexpiry'] = $blockInfo->getExpiry();
+					}
 				}
+				/* Wikia change end */
 
 				if ( isset( $this->prop['emailable'] ) && $user->canReceiveEmail() ) {
 					$data[$name]['emailable'] = '';
@@ -274,6 +279,7 @@ class ApiQueryUsers extends ApiQueryBase {
 				ApiBase::PARAM_ISMULTI => true,
 				ApiBase::PARAM_TYPE => array(
 					'blockinfo',
+					'localblockinfo',
 					'groups',
 					'implicitgroups',
 					'rights',


### PR DESCRIPTION
@mixth-sense 
https://wikia-inc.atlassian.net/browse/SUS-598

Add the `localblockinfo` property to `ApiQueryUsers` and using that on `Special:UserLookup` to prevent Phalanx blocks from overwriting local blocks in the UI.
