### PR TITLE
SOC-2672 | Making calls to AuthModal global and synchronous

### DIFF
--- a/extensions/wikia/AuthModal/js/AuthModal.js
+++ b/extensions/wikia/AuthModal/js/AuthModal.js
@@ -1,4 +1,4 @@
-define('AuthModal', ['jquery', 'wikia.window'], function ($, window) {
+require(['jquery', 'wikia.window'], function ($, window) {
 	'use strict';
 
 	var authPopUpWindow,
@@ -8,7 +8,7 @@ define('AuthModal', ['jquery', 'wikia.window'], function ($, window) {
 		popUpName = 'WikiaAuthWindow',
 		track = getTrackingFunction();
 
-	function initPostMessageListener (onAuthSuccess) {
+	function initPostMessageListener(onAuthSuccess) {
 		$(window).on('message.authPopUpWindow', function (event) {
 			var e = event.originalEvent;
 
@@ -47,7 +47,7 @@ define('AuthModal', ['jquery', 'wikia.window'], function ($, window) {
 		});
 	}
 
-	function close (event) {
+	function close(event) {
 		if (event) {
 			event.preventDefault();
 		}
@@ -76,7 +76,7 @@ define('AuthModal', ['jquery', 'wikia.window'], function ($, window) {
 		return 'width=' + popUpWindowWidth + ',height=' + popUpWindowHeight + ',top=' + popUpWindowTop + ',left=' + popUpWindowLeft;
 	}
 
-	function getTrackingFunction () {
+	function getTrackingFunction() {
 		if (track) {
 			return track;
 		}
@@ -88,7 +88,7 @@ define('AuthModal', ['jquery', 'wikia.window'], function ($, window) {
 		return track;
 	}
 
-	function loadPopUpPage (url, forceLogin) {
+	function loadPopUpPage(url, forceLogin) {
 		var src = buildPopUpUrl(url, {'forceLogin': (forceLogin ? 1 : 0)});
 
 		authPopUpWindow = window.open(src, popUpName, getPopUpWindowSpecs());
@@ -98,7 +98,7 @@ define('AuthModal', ['jquery', 'wikia.window'], function ($, window) {
 		}
 	}
 
-	return {
+	window.wikiaAuthModal = {
 		/**
 		 * @desc launches the new auth modal if wgEnableNewAuthModal is set to true. If not, then the old UserLoginModal
 		 * is loaded.
@@ -145,6 +145,7 @@ define('AuthModal', ['jquery', 'wikia.window'], function ($, window) {
 				});
 			}
 		},
+
 		close: close
 	};
 });

--- a/extensions/wikia/Chat2/js/ChatWidget.js
+++ b/extensions/wikia/Chat2/js/ChatWidget.js
@@ -210,13 +210,11 @@ var ChatWidget = {
 		if (window.wgUserName) {
 			window.open(linkToSpecialChat, 'wikiachat', window.wgWikiaChatWindowFeatures);
 		} else {
-			require(['AuthModal'], function (authModal) {
-				authModal.load({
-					forceLogin: true,
-					url: '/signin?redirect=' + encodeURIComponent(window.location.href),
-					origin: 'chat',
-					onAuthSuccess: ChatWidget.onSuccessfulLogin
-				});
+			window.wikiaAuthModal.load({
+				forceLogin: true,
+				url: '/signin?redirect=' + encodeURIComponent(window.location.href),
+				origin: 'chat',
+				onAuthSuccess: ChatWidget.onSuccessfulLogin
 			});
 		}
 	},

--- a/extensions/wikia/CommunityPageExperiment/modules/ext.communityPageExperiment.js
+++ b/extensions/wikia/CommunityPageExperiment/modules/ext.communityPageExperiment.js
@@ -28,16 +28,14 @@ require([
 		// Hack to always use the new auth modal
 		win.wgEnableNewAuthModal = true;
 
-		require(['AuthModal'], function (authModal) {
-			authModal.load({
-				forceLogin: true,
-				url: event.currentTarget.href,
-				origin: 'community-page',
-				onAuthSuccess: function () {
-					cache.set('communityPageSignedUp', true, cache.CACHE_LONG);
-					win.location.reload();
-				}
-			});
+		win.wikiaAuthModal.load({
+			forceLogin: true,
+			url: event.currentTarget.href,
+			origin: 'community-page',
+			onAuthSuccess: function () {
+				cache.set('communityPageSignedUp', true, cache.CACHE_LONG);
+				win.location.reload();
+			}
 		});
 	}
 

--- a/extensions/wikia/GlobalNavigation/scripts/GlobalNavigationAccountNavigation.js
+++ b/extensions/wikia/GlobalNavigation/scripts/GlobalNavigationAccountNavigation.js
@@ -55,12 +55,10 @@ require([
 	}
 
 	function authModalOpen(url) {
-		require(['AuthModal'], function (authModal) {
-			authModal.load({
-				url: url,
-				origin: 'global-nav',
-				onAuthSuccess: onAuthSuccess.bind({url: url})
-			});
+		window.wikiaAuthModal.load({
+			url: url,
+			origin: 'global-nav',
+			onAuthSuccess: onAuthSuccess.bind({url: url})
 		});
 	}
 

--- a/extensions/wikia/Lightbox/scripts/Lightbox.js
+++ b/extensions/wikia/Lightbox/scripts/Lightbox.js
@@ -1106,17 +1106,15 @@
 				if (window.wgUserName) {
 					doShareEmail(addresses);
 				} else {
-					require(['AuthModal'], function (authModal) {
-						authModal.load({
-							forceLogin: true,
-							url: '/signin?redirect=' + encodeURIComponent(window.location.href),
-							origin: 'image-lightbox',
-							onAuthSuccess: function () {
-								doShareEmail(addresses);
-								// see VID-473 - Reload page on lightbox close
-								LightboxLoader.reloadOnClose = true;
-							}
-						});
+					window.wikiaAuthModal.load({
+						forceLogin: true,
+						url: '/signin?redirect=' + encodeURIComponent(window.location.href),
+						origin: 'image-lightbox',
+						onAuthSuccess: function () {
+							doShareEmail(addresses);
+							// see VID-473 - Reload page on lightbox close
+							LightboxLoader.reloadOnClose = true;
+						}
 					});
 				}
 			});

--- a/extensions/wikia/UserLogin/js/UserLogin.js
+++ b/extensions/wikia/UserLogin/js/UserLogin.js
@@ -14,17 +14,15 @@
 		rteForceLogin: function () {
 			//prevent onbeforeunload from being called when user is loging in
 			window.onbeforeunload = function () {};
-			require(['AuthModal'], function (authModal) {
-				authModal.load({
-					forceLogin: true,
-					origin: 'editor',
-					url: '/signin?redirect=' + encodeURIComponent(window.location.href),
-					onAuthSuccess: function () {
-						if (window.WikiaEditor) {
-							WikiaEditor.reloadEditor();
-						}
+			window.wikiAuthModal.load({
+				forceLogin: true,
+				origin: 'editor',
+				url: '/signin?redirect=' + encodeURIComponent(window.location.href),
+				onAuthSuccess: function () {
+					if (window.WikiaEditor) {
+						WikiaEditor.reloadEditor();
 					}
-				});
+				}
 			});
 		},
 
@@ -32,12 +30,10 @@
 			if (window.wgUserName === null) {
 				//prevent onbeforeunload from being called when user is logging in
 				window.onbeforeunload = function () {};
-				require(['AuthModal'], function (authModal) {
-					authModal.load({
-						forceLogin: true,
-						origin: 'editor',
-						url: '/signin?redirect=' + encodeURIComponent(window.location.href),
-					});
+				window.wikiaAuthModal.load({
+					forceLogin: true,
+					origin: 'editor',
+					url: '/signin?redirect=' + encodeURIComponent(window.location.href),
 				});
 				return true;
 			}

--- a/extensions/wikia/VideoEmbedTool/js/VET_Loader.js
+++ b/extensions/wikia/VideoEmbedTool/js/VET_Loader.js
@@ -84,16 +84,14 @@
 			return;
 		} else if (window.wgUserName === null && !window.UserLogin.forceLoggedIn) {
 			// handle login on article page
-			require(['AuthModal'], function (authModal) {
-				authModal.load({
-					forceLogin: true,
-					url: '/signin?redirect=' + encodeURIComponent(window.location.href),
-					origin: 'vet',
-					onAuthSuccess: function () {
-						window.UserLogin.forceLoggedIn = true;
-						vetLoader.load(options);
-					}
-				});
+			window.wikiaAuthModal.load({
+				forceLogin: true,
+				url: '/signin?redirect=' + encodeURIComponent(window.location.href),
+				origin: 'vet',
+				onAuthSuccess: function () {
+					window.UserLogin.forceLoggedIn = true;
+					vetLoader.load(options);
+				}
 			});
 			$elem.stopThrobbing();
 			return;

--- a/extensions/wikia/Wall/js/Wall.js
+++ b/extensions/wikia/Wall/js/Wall.js
@@ -302,18 +302,16 @@
 		vote: function (e) {
 			e.preventDefault();
 			if (!window.wgUserName) {
-				require(['AuthModal'], function (authModal) {
-					authModal.load({
-						forceLogin: true,
-						url: '/signin?redirect=' + encodeURIComponent(window.location.href),
-						origin: 'wall-and-forum',
-						onAuthSuccess: this.proxy(function () {
-							this.voteBase(e, function () {
-								window.location.reload();
-							});
-						})
-					});
-				}.bind(this));
+				window.wikiaAuthModal.load({
+					forceLogin: true,
+					url: '/signin?redirect=' + encodeURIComponent(window.location.href),
+					origin: 'wall-and-forum',
+					onAuthSuccess: this.proxy(function () {
+						this.voteBase(e, function () {
+							window.location.reload();
+						});
+					}.bind(this))
+				});
 			} else {
 				this.voteBase(e, this.proxy(function (target, data, dir) {
 					var votes = target.closest('li.message').find('.votes:first'),

--- a/extensions/wikia/Wall/js/Wall.js
+++ b/extensions/wikia/Wall/js/Wall.js
@@ -306,11 +306,11 @@
 					forceLogin: true,
 					url: '/signin?redirect=' + encodeURIComponent(window.location.href),
 					origin: 'wall-and-forum',
-					onAuthSuccess: this.proxy(function () {
+					onAuthSuccess: function () {
 						this.voteBase(e, function () {
 							window.location.reload();
 						});
-					}.bind(this))
+					}.bind(this)
 				});
 			} else {
 				this.voteBase(e, this.proxy(function (target, data, dir) {

--- a/extensions/wikia/Wall/js/WallMessageForm.js
+++ b/extensions/wikia/Wall/js/WallMessageForm.js
@@ -87,17 +87,15 @@
 
 		loginBeforeSubmit: function (action) {
 			if (window.wgDisableAnonymousEditing && !window.wgUserName) {
-				require(['AuthModal'], function (authModal) {
-					authModal.load({
-						forceLogin: true,
-						url: '/signin?redirect=' + encodeURIComponent(window.location.href),
-						origin: 'wall-and-forum',
-						onAuthSuccess: this.proxy(function () {
-							action(false);
-							return true;
-						})
-					});
-				}.bind(this));
+				window.wikiaAuthModal.load({
+					forceLogin: true,
+					url: '/signin?redirect=' + encodeURIComponent(window.location.href),
+					origin: 'wall-and-forum',
+					onAuthSuccess: function () {
+						action(false);
+						return true;
+					}
+				});
 			} else {
 				action(true);
 				return true;

--- a/extensions/wikia/WikiaHubsV3/js/WikiaHubsV3Modals.js
+++ b/extensions/wikia/WikiaHubsV3/js/WikiaHubsV3Modals.js
@@ -9,16 +9,14 @@
 				if (window.wgUserName) {
 					SuggestModalWikiaHubsV3.suggestArticle();
 				} else {
-					require(['AuthModal'], function (authModal) {
-						authModal.load({
-							forceLogin: true,
-							url: '/signin?redirect=' + encodeURIComponent(window.location.href),
-							origin: 'wikia-hubs',
-							onAuthSuccess: function () {
-								window.UserLogin.forceLoggedIn = true;
-								SuggestModalWikiaHubsV3.suggestArticle();
-							}
-						});
+					window.wikiaAuthModal.load({
+						forceLogin: true,
+						url: '/signin?redirect=' + encodeURIComponent(window.location.href),
+						origin: 'wikia-hubs',
+						onAuthSuccess: function () {
+							window.UserLogin.forceLoggedIn = true;
+							SuggestModalWikiaHubsV3.suggestArticle();
+						}
 					});
 				}
 			});

--- a/extensions/wikia/WikiaMaps/js/WikiaMapsUtils.js
+++ b/extensions/wikia/WikiaMaps/js/WikiaMapsUtils.js
@@ -280,16 +280,14 @@ define(
 		 * @param {function} onLoggedIn - callback function to be called after login
 		 */
 		function showForceLoginModal(origin, onLoggedIn) {
-			require(['AuthModal'], function (authModal) {
-				authModal.load({
-					forceLogin: true,
-					origin: origin,
-					url: '/signin?redirect=' + encodeURIComponent(w.location.href),
-					onAuthSuccess: function () {
-						w.UserLogin.forceLoggedIn = true;
-						onLoggedIn();
-					}
-				});
+			window.wikiaAuthModal.load({
+				forceLogin: true,
+				origin: origin,
+				url: '/signin?redirect=' + encodeURIComponent(w.location.href),
+				onAuthSuccess: function () {
+					w.UserLogin.forceLoggedIn = true;
+					onLoggedIn();
+				}
 			});
 		}
 

--- a/extensions/wikia/WikiaNewFiles/scripts/uploadPhotosDialog.js
+++ b/extensions/wikia/WikiaNewFiles/scripts/uploadPhotosDialog.js
@@ -14,17 +14,15 @@ var UploadPhotos = {
 	loginBeforeShowDialog: function(evt) {
 		var UserLoginModal = window.UserLoginModal;
 		if (( wgUserName == null ) && ( !UserLogin.forceLoggedIn )) {
-			require(['AuthModal'], function (authModal) {
-				authModal.load({
-					forceLogin: true,
-					url: '/signin?redirect=' + encodeURIComponent(window.location.href),
-					origin: 'latest-photos',
-					onAuthSuccess: $.proxy(function() {
-						UserLogin.forceLoggedIn = true;
-						this.showDialog(evt);
-					}, this)
-				});
-			}.bind(this));
+			authModal.load({
+				forceLogin: true,
+				url: '/signin?redirect=' + encodeURIComponent(window.location.href),
+				origin: 'latest-photos',
+				onAuthSuccess: $.proxy(function() {
+					UserLogin.forceLoggedIn = true;
+					this.showDialog(evt);
+				}, this)
+			});
 		}
 		else {
 			this.showDialog(evt);

--- a/extensions/wikia/WikiaNewFiles/scripts/uploadPhotosDialog.js
+++ b/extensions/wikia/WikiaNewFiles/scripts/uploadPhotosDialog.js
@@ -14,7 +14,7 @@ var UploadPhotos = {
 	loginBeforeShowDialog: function(evt) {
 		var UserLoginModal = window.UserLoginModal;
 		if (( wgUserName == null ) && ( !UserLogin.forceLoggedIn )) {
-			authModal.load({
+			window.wikiaAuthModal.load({
 				forceLogin: true,
 				url: '/signin?redirect=' + encodeURIComponent(window.location.href),
 				origin: 'latest-photos',


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SOC-2672

@kvas-damian @rafalkalinski We need to eliminate require() from authmodal as it makes clicks opening popups run in asynchronous code. This means that sometimes browsers might guess it's a malicious popup.
