### PR TITLE
ADEN-3509 Fix collapsed BOTTOM_LEADERBOARD

### DIFF
--- a/extensions/wikia/AdEngine/AdEngine2Controller.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2Controller.class.php
@@ -53,6 +53,7 @@ class AdEngine2Controller extends WikiaController {
 	public function ad() {
 		$this->includeLabel = $this->request->getVal('includeLabel');
 		$this->onLoad = $this->request->getVal('onLoad');
+		$this->addToAdQueue = $this->request->getVal('addToAdQueue', true);
 		$this->pageTypes = $this->request->getVal('pageTypes');
 		$this->slotName = $this->request->getVal('slotName');
 		$this->showAd = AdEngine2Service::shouldShowAd($this->pageTypes);

--- a/extensions/wikia/AdEngine/templates/AdEngine2_Ad.php
+++ b/extensions/wikia/AdEngine/templates/AdEngine2_Ad.php
@@ -1,22 +1,22 @@
 <?php if ($showAd): ?>
-<!-- BEGIN SLOTNAME: <?= htmlspecialchars( $slotName ) ?> -->
-<div id="<?= htmlspecialchars( $slotName ) ?>" class="wikia-ad noprint default-height">
+	<!-- BEGIN SLOTNAME: <?= htmlspecialchars( $slotName ) ?> -->
+	<div id="<?= htmlspecialchars( $slotName ) ?>" class="wikia-ad noprint default-height">
 	<? if ($includeLabel): ?>
 		<label class="wikia-ad-label"><?= wfMessage( 'adengine-advertisement' )->escaped() ?></label>
 	<? endif; ?>
-<? if ($addToAdQueue): ?>
-<script>
-	<? if ($onLoad) { ?>
-		wgAfterContentAndJS.push(function () {
-			window.adslots2.push(<?= json_encode([$slotName]) ?>);
-		});
-	<? } else { ?>
-		window.adslots2.push(<?= json_encode([$slotName]) ?>);
-	<? } ?>
-</script>
-<? endif; ?>
-</div>
-<!-- END SLOTNAME: <?= htmlspecialchars($slotName) ?> -->
+	<? if ($addToAdQueue): ?>
+		<script>
+			<? if ($onLoad) { ?>
+				wgAfterContentAndJS.push(function () {
+					window.adslots2.push(<?= json_encode([$slotName]) ?>);
+				});
+			<? } else { ?>
+				window.adslots2.push(<?= json_encode([$slotName]) ?>);
+			<? } ?>
+		</script>
+	<? endif; ?>
+	</div>
+	<!-- END SLOTNAME: <?= htmlspecialchars($slotName) ?> -->
 <?php else: ?>
 <!-- NO AD <?= htmlspecialchars($slotName) ?> (levels: <?= htmlspecialchars(json_encode($pageTypes)) ?>) -->
 <?php endif; ?>

--- a/extensions/wikia/AdEngine/templates/AdEngine2_Ad.php
+++ b/extensions/wikia/AdEngine/templates/AdEngine2_Ad.php
@@ -4,6 +4,7 @@
 	<? if ($includeLabel): ?>
 		<label class="wikia-ad-label"><?= wfMessage( 'adengine-advertisement' )->escaped() ?></label>
 	<? endif; ?>
+<? if ($addToAdQueue): ?>
 <script>
 	<? if ($onLoad) { ?>
 		wgAfterContentAndJS.push(function () {
@@ -13,6 +14,7 @@
 		window.adslots2.push(<?= json_encode([$slotName]) ?>);
 	<? } ?>
 </script>
+<? endif; ?>
 </div>
 <!-- END SLOTNAME: <?= htmlspecialchars($slotName) ?> -->
 <?php else: ?>

--- a/skins/oasis/modules/AdController.class.php
+++ b/skins/oasis/modules/AdController.class.php
@@ -7,6 +7,7 @@ class AdController extends WikiaController {
 		$this->pageTypes = $this->request->getVal('pageTypes');
 		$this->includeLabel = $this->request->getVal('includeLabel');
 		$this->onLoad = $this->request->getVal('onLoad');
+		$this->addToAdQueue = $this->request->getVal('addToAdQueue');
 	}
 
 	public function executeConfig() {

--- a/skins/oasis/modules/templates/Ad_Index.php
+++ b/skins/oasis/modules/templates/Ad_Index.php
@@ -3,5 +3,11 @@
 echo F::app()->renderView(
 	'AdEngine2',
 	'Ad',
-	[ 'slotName' => $slotName, 'pageTypes' => $pageTypes, 'includeLabel' => $includeLabel, 'onLoad' => $onLoad ]
+	[
+		'slotName' => $slotName,
+		'pageTypes' => $pageTypes,
+		'includeLabel' => $includeLabel,
+		'onLoad' => $onLoad,
+		'addToAdQueue' => $addToAdQueue
+	]
 );

--- a/skins/oasis/modules/templates/Footer_Index.php
+++ b/skins/oasis/modules/templates/Footer_Index.php
@@ -1,5 +1,5 @@
 <footer id="WikiaFooter" class="WikiaFooter <?= $showToolbar ? '' : 'notoolbar' ?>">
-	<?= F::app()->renderView('Ad', 'Index', ['slotName' => 'BOTTOM_LEADERBOARD', 'pageTypes' => ['homepage_logged', 'corporate', 'search', 'all_ads']]); ?>
+	<?= F::app()->renderView('Ad', 'Index', ['slotName' => 'BOTTOM_LEADERBOARD', 'pageTypes' => ['homepage_logged', 'corporate', 'search', 'all_ads'], 'addToAdQueue' => false]); ?>
 	<?php if( $showToolbar ): ?>
 		<div class="toolbar">
 			<?= F::app()->renderView('Notifications', 'Index'); ?>

--- a/skins/oasis/modules/templates/Footer_Index.php
+++ b/skins/oasis/modules/templates/Footer_Index.php
@@ -1,5 +1,5 @@
 <footer id="WikiaFooter" class="WikiaFooter <?= $showToolbar ? '' : 'notoolbar' ?>">
-	<div id="BOTTOM_LEADERBOARD"></div>
+	<?= F::app()->renderView('Ad', 'Index', ['slotName' => 'BOTTOM_LEADERBOARD', 'pageTypes' => ['homepage_logged', 'search', 'all_ads']]); ?>
 	<?php if( $showToolbar ): ?>
 		<div class="toolbar">
 			<?= F::app()->renderView('Notifications', 'Index'); ?>

--- a/skins/oasis/modules/templates/Footer_Index.php
+++ b/skins/oasis/modules/templates/Footer_Index.php
@@ -1,5 +1,5 @@
 <footer id="WikiaFooter" class="WikiaFooter <?= $showToolbar ? '' : 'notoolbar' ?>">
-	<?= F::app()->renderView('Ad', 'Index', ['slotName' => 'BOTTOM_LEADERBOARD', 'pageTypes' => ['homepage_logged', 'search', 'all_ads']]); ?>
+	<?= F::app()->renderView('Ad', 'Index', ['slotName' => 'BOTTOM_LEADERBOARD', 'pageTypes' => ['homepage_logged', 'corporate', 'search', 'all_ads']]); ?>
 	<?php if( $showToolbar ): ?>
 		<div class="toolbar">
 			<?= F::app()->renderView('Notifications', 'Index'); ?>


### PR DESCRIPTION
New slot, when collapsed, did not have `wikia-ad` class and was adding empty space at the bottom of our pages. Using the regular method to generate slots helped but also expanding current functionality to make it possible for a slot not to push slot to the ad queue right away.
