### PR TITLE
PLATFORM-2235:improve migrateImagesBetweenSwiftDC

### DIFF
--- a/extensions/wikia/SwiftSync/SwiftSync.setup.php
+++ b/extensions/wikia/SwiftSync/SwiftSync.setup.php
@@ -19,4 +19,3 @@ $wgAutoloadClasses[ 'Wikia\\SwiftSync\\ImageSync'     ] = $dir . "classes/ImageS
 $wgHooks[ 'SwiftFileBackend::doStoreInternal'     ][] = 'Wikia\SwiftSync\Hooks::doStoreInternal';
 $wgHooks[ 'SwiftFileBackend::doCopyInternal'      ][] = 'Wikia\SwiftSync\Hooks::doCopyInternal';
 $wgHooks[ 'SwiftFileBackend::doDeleteInternal'    ][] = 'Wikia\SwiftSync\Hooks::doDeleteInternal';
-$wgHooks[ 'Masthead::AvatarSavedToSwift'          ][] = 'Wikia\SwiftSync\Hooks::SyncFiletoDC';

--- a/extensions/wikia/SwiftSync/classes/Hooks.php
+++ b/extensions/wikia/SwiftSync/classes/Hooks.php
@@ -13,21 +13,24 @@ namespace Wikia\SwiftSync;
 class Hooks {
 
 	/* save image into local repo */
-	public static function doStoreInternal( $params, \Status $status ) {
+	public static function doStoreInternal( array $params, \Status $status ) {
 
-		Queue::newFromParams( $params )->add();
-
-		return true;
-	}
-
-	public static function doCopyInternal( $params, \Status $status ) {
-
-		Queue::newFromParams( $params )->add();
+		if ( $status->isGood() ) {
+			Queue::newFromParams( $params )->add();
+		}
 
 		return true;
 	}
 
-	public static function doDeleteInternal( $params, \Status $status ) {
+	public static function doCopyInternal( array $params, \Status $status ) {
+
+		if ( $status->isGood() ) {
+			Queue::newFromParams( $params )->add();
+		}
+		return true;
+	}
+
+	public static function doDeleteInternal( array $params, \Status $status ) {
 
 		if ( !empty( $params['src'] ) && ( strpos( $params['src'], '/images/thumb' ) !== false ) ) {
 			return true;
@@ -37,8 +40,9 @@ class Hooks {
 			$params['op'] = 'delete';
 		}
 
-		Queue::newFromParams( $params )->add();
-
+		if ( $status->isGood() ) {
+			Queue::newFromParams( $params )->add();
+		}
 		return true;
 	}
 

--- a/extensions/wikia/SwiftSync/classes/Hooks.php
+++ b/extensions/wikia/SwiftSync/classes/Hooks.php
@@ -45,16 +45,4 @@ class Hooks {
 		}
 		return true;
 	}
-
-	public static function SyncFileToDC( $source, $dest) {
-
-		Queue::newFromParams( [
-			'city_id' => 0,
-			'op' => 'store',
-			'src' => $source,
-			'dst' => $dest
-		] )->add();
-
-		return true;
-	}
 }

--- a/extensions/wikia/SwiftSync/classes/Queue.class.php
+++ b/extensions/wikia/SwiftSync/classes/Queue.class.php
@@ -149,9 +149,9 @@ class Queue {
 		return wfGetDB( ( empty( $master ) ) ? DB_SLAVE : DB_MASTER, array(), $wgSwiftSyncDB );
 	}
 
-	/* 
+	/**
 	 * Save information about uploaded image in database 
-	 * @return Boolean True/False
+	 * @return int|false ID of added row or false on error
 	 */ 
 	public function add() {
 		wfProfileIn( __METHOD__ );
@@ -179,10 +179,23 @@ class Queue {
 			], 
 			__METHOD__ 
 		);
+
+		$id = $dbw->insertId();
 		$dbw->commit();
-		
+
+		WikiaLogger::instance()->info( __METHOD__, [
+			'id'      => (string) $id,
+			'action'  => $this->action,
+			'city_id' => (string) $this->city_id,
+			'src'     => $this->src,
+			'dst'     => $this->dst,
+			'@root'   => [
+				'tags' => [ 'SwiftSync' ]
+			]
+		] );
+
 		wfProfileOut( __METHOD__ );
-		return true;
+		return $id;
 	}
 	
 	/* 

--- a/maintenance/wikia/migrateImagesBetweenSwiftDC.php
+++ b/maintenance/wikia/migrateImagesBetweenSwiftDC.php
@@ -55,6 +55,9 @@ class MigrateImagesBetweenSwiftDC extends Maintenance {
 			'city_id' => $this->imageSyncQueueItem->city_id,
 			'src'     => $this->imageSyncQueueItem->src,
 			'dst'     => $this->imageSyncQueueItem->dst,
+			'@root'   => [
+				'tags' => [ 'SwiftSync' ]
+			]
 		];
 	}
 


### PR DESCRIPTION
[PLATFORM-2235](https://wikia-inc.atlassian.net/browse/PLATFORM-2235)

Part of delete operations fail to propagate to Reston DFS nodes. Let's add logging of all pushes to the images sync queue from the app and check that we're actually syncing a successful Swift operation.

Tag log messages with `SwiftSync` to be able to easily correlate pushes and queue consumption.

@wladekb 
