### PR TITLE
ADEN-3511 TOP_BUTTON_WIDE fix

### DIFF
--- a/extensions/wikia/AdEngine/js/provider/directGpt.js
+++ b/extensions/wikia/AdEngine/js/provider/directGpt.js
@@ -53,7 +53,7 @@ define('ext.wikia.adEngine.provider.directGpt', [
 		{
 			beforeSuccess: function (slotName) {
 				slotTweaker.removeDefaultHeight(slotName);
-				if (slotTweaker.isUniversalAdPackageLoaded()) {
+				if (!slotTweaker.isUniversalAdPackageLoaded()) {
 					slotTweaker.removeTopButtonIfNeeded(slotName);
 					slotTweaker.adjustLeaderboardSize(slotName);
 				}

--- a/extensions/wikia/AdEngine/js/provider/remnantGpt.js
+++ b/extensions/wikia/AdEngine/js/provider/remnantGpt.js
@@ -35,7 +35,7 @@ define('ext.wikia.adEngine.provider.remnantGpt', [
 		{
 			beforeSuccess: function (slotName) {
 				slotTweaker.removeDefaultHeight(slotName);
-				if (slotTweaker.isUniversalAdPackageLoaded()) {
+				if (!slotTweaker.isUniversalAdPackageLoaded()) {
 					slotTweaker.removeTopButtonIfNeeded(slotName);
 					slotTweaker.adjustLeaderboardSize(slotName);
 				}


### PR DESCRIPTION
While working on Fan Takeover we made a mistake in the condition and disabled `TOP_BUTTON_WIDE`. The changes in this PR fix it.
