### PR TITLE
SUS-691: show $smwgDefaultStore on Special:Version

### DIFF
--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -1085,7 +1085,7 @@ class Wikia {
 	 * add entries to software info
 	 */
 	static public function softwareInfo( &$software ) {
-		global $wgCityId, $wgDBcluster, $wgWikiaDatacenter, $wgLocalFileRepo, $smwgDefaultStore;
+		global $wgCityId, $wgDBcluster, $wgWikiaDatacenter, $wgLocalFileRepo, $smwgDefaultStore, $wgEnableSemanticMediaWikiExt;
 
 		$info = [];
 
@@ -1101,7 +1101,7 @@ class Wikia {
 		if( !empty( $wgWikiaDatacenter ) ) {
 			$info[] = "dc: $wgWikiaDatacenter";
 		}
-		if( !empty( $smwgDefaultStore ) ) {
+		if( !empty( $wgEnableSemanticMediaWikiExt ) ) {
 			$info[] = "smw_store: $smwgDefaultStore";
 		}
 

--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -1104,7 +1104,6 @@ class Wikia {
 		if( !empty( $smwgDefaultStore ) ) {
 			$info[] = "smw_store: $smwgDefaultStore";
 		}
-		$info[] = "file_repo: {$wgLocalFileRepo['backend']}";
 
 		$software[ "Internals" ] = join(', ', $info);
 

--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -1087,26 +1087,26 @@ class Wikia {
 	static public function softwareInfo( &$software ) {
 		global $wgCityId, $wgDBcluster, $wgWikiaDatacenter, $wgLocalFileRepo, $smwgDefaultStore;
 
-		$info = '';
+		$info = [];
 
 		if( !empty( $wgCityId ) ) {
-			$info .= "city_id: {$wgCityId}";
+			$info[] = "city_id: {$wgCityId}";
 		}
 		if( empty( $wgDBcluster ) ) {
-			$info .= ", cluster: c1";
+			$info[] = "cluster: c1";
 		}
 		else {
-			$info .= ", cluster: $wgDBcluster";
+			$info[] = "cluster: $wgDBcluster";
 		}
 		if( !empty( $wgWikiaDatacenter ) ) {
-			$info .= ", dc: $wgWikiaDatacenter";
+			$info[] = "dc: $wgWikiaDatacenter";
 		}
 		if( !empty( $smwgDefaultStore ) ) {
-			$info .= ", smw_store: $smwgDefaultStore";
+			$info[] = "smw_store: $smwgDefaultStore";
 		}
-		$info .= ", file_repo: {$wgLocalFileRepo['backend']}";
+		$info[] = "file_repo: {$wgLocalFileRepo['backend']}";
 
-		$software[ "Internals" ] = $info;
+		$software[ "Internals" ] = join(', ', $info);
 
 		/**
 		 * obligatory hook return value

--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -1085,10 +1085,12 @@ class Wikia {
 	 * add entries to software info
 	 */
 	static public function softwareInfo( &$software ) {
-		global $wgCityId, $wgDBcluster, $wgWikiaDatacenter, $wgLocalFileRepo;
+		global $wgCityId, $wgDBcluster, $wgWikiaDatacenter, $wgLocalFileRepo, $smwgDefaultStore;
+
+		$info = '';
 
 		if( !empty( $wgCityId ) ) {
-			$info = "city_id: {$wgCityId}";
+			$info .= "city_id: {$wgCityId}";
 		}
 		if( empty( $wgDBcluster ) ) {
 			$info .= ", cluster: c1";
@@ -1098,6 +1100,9 @@ class Wikia {
 		}
 		if( !empty( $wgWikiaDatacenter ) ) {
 			$info .= ", dc: $wgWikiaDatacenter";
+		}
+		if( !empty( $smwgDefaultStore ) ) {
+			$info .= ", smw_store: $smwgDefaultStore";
 		}
 		$info .= ", file_repo: {$wgLocalFileRepo['backend']}";
 

--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -1105,7 +1105,7 @@ class Wikia {
 			$info[] = "smw_store: $smwgDefaultStore";
 		}
 
-		$software[ "Internals" ] = join(', ', $info);
+		$software[ "Internals" ] = join( ', ', $info );
 
 		/**
 		 * obligatory hook return value


### PR DESCRIPTION
[SUS-691](https://wikia-inc.atlassian.net/browse/SUS-691)

As we prepare to migrate all SMW-powered wikis to the new storage, let's show the value of `$smwgDefaultStore` on [Special:Version](http://transformers-legends.macbre.wikia-dev.com/wiki/Special:Version)

@mixth-sense / @Wikia/sustaining-engineering-team 
