### PR TITLE
SUS-688: introduce SMW transactions in NewRelic and xhprof

### DIFF
--- a/extensions/wikia/SemanticMediaWiki/includes/SMW_GlobalFunctions.php
+++ b/extensions/wikia/SemanticMediaWiki/includes/SMW_GlobalFunctions.php
@@ -284,6 +284,8 @@ function &smwfGetStore() {
 
 	if ( is_null( $smwgMasterStore ) ) {
 		$smwgMasterStore = new $smwgDefaultStore();
+
+		wfRunHooks( 'AfterSmwfGetStore', [ $smwgMasterStore ] ); # Wikia change / @macbre
 	}
 
 	return $smwgMasterStore;

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -277,6 +277,7 @@ $wgAutoloadClasses[ 'TransactionClassifier'           ] = "$IP/includes/wikia/tr
 $wgAutoloadClasses[ 'TransactionTraceNewrelic'        ] = "$IP/includes/wikia/transaction/TransactionTraceNewrelic.php";
 $wgAutoloadClasses[ 'TransactionTraceScribe'          ] = "$IP/includes/wikia/transaction/TransactionTraceScribe.php";
 $wgHooks          [ 'ArticleViewAddParserOutput'      ][] = 'Transaction::onArticleViewAddParserOutput';
+$wgHooks          [ 'AfterSmwfGetStore'               ][] = 'Transaction::onAfterSmwfGetStore';
 $wgHooks          [ 'RestInPeace'                     ][] = 'Transaction::onRestInPeace';
 $wgHooks          [ 'RestInPeace'                     ][] = 'ScribePurge::onRestInPeace';
 $wgHooks          [ 'RestInPeace'                     ][] = 'CeleryPurge::onRestInPeace';

--- a/includes/wikia/transaction/Transaction.php
+++ b/includes/wikia/transaction/Transaction.php
@@ -39,6 +39,7 @@ class Transaction {
 	const PARAM_API_LIST = 'api_list';
 	const PARAM_WIKI = 'wiki';
 	const PARAM_DPL = 'dpl';
+	const PARAM_SEMANTIC_MEDIAWIKI = 'semantic_mediawiki';
 	const PARAM_AB_PERFORMANCE_TEST = 'perf_test';
 	const PARAM_MAINTENANCE_SCRIPT = 'maintenance_script';
 
@@ -210,6 +211,17 @@ class Transaction {
 
 		Transaction::setAttribute( Transaction::PARAM_SIZE_CATEGORY, $sizeCategory );
 
+		return true;
+	}
+
+	/**
+	 * Mark SemanticMediaWiki requests (they will always call smwfGetStore() function)
+	 *
+	 * @param SMWStore $store
+	 * @return bool
+	 */
+	public static function onAfterSmwfGetStore( $store ) {
+		self::setAttribute( self::PARAM_SEMANTIC_MEDIAWIKI, true );
 		return true;
 	}
 

--- a/includes/wikia/transaction/TransactionClassifier.php
+++ b/includes/wikia/transaction/TransactionClassifier.php
@@ -30,6 +30,14 @@ class TransactionClassifier {
 	const NS_BLOG_LISTING = 502;
 	const NS_BLOG_LISTING_TALK = 503;
 
+	// copied from extensions/wikia/SemanticMediaWiki/includes/SMW_Setup.php to use a constant below
+	// NOTE: this assumes $smwgNamespaceIndex is set to 300 (set in CommonExtensions.php)
+	// while not being dependant on SMW extension inclusion
+	const SMW_NS_PROPERTY = 302;
+	const SMW_NS_TYPE = 304;
+	const SF_NS_FORM = 306;
+	const SMW_NS_CONCEPT = 308;
+
 	protected static $FILTER_ARTICLE_ACTIONS = array(
 		'view',
 		'edit',
@@ -90,6 +98,11 @@ class TransactionClassifier {
 		self::NS_BLOG_ARTICLE_TALK => 'blog',
 		self::NS_BLOG_LISTING => 'blog',
 		self::NS_BLOG_LISTING_TALK => 'blog',
+
+		self::SMW_NS_PROPERTY => 'semantic_mediawiki',
+		self::SMW_NS_TYPE => 'semantic_mediawiki',
+		self::SMW_NS_CONCEPT => 'semantic_mediawiki',
+		self::SF_NS_FORM => 'semantic_form',
 	);
 
 	protected static $MAP_PARSER_CACHED_USED = array(

--- a/includes/wikia/transaction/TransactionClassifier.php
+++ b/includes/wikia/transaction/TransactionClassifier.php
@@ -118,6 +118,10 @@ class TransactionClassifier {
 		true => 'dpl',
 	);
 
+	protected static $MAP_SEMANTIC_MEDIAWIKI = array(
+		true => 'semantic_mediawiki',
+	);
+
 	protected $dependencies = array( Transaction::PARAM_ENTRY_POINT );
 	protected $attributes = array();
 	protected $nameParts = null;
@@ -218,6 +222,9 @@ class TransactionClassifier {
 
 		// add "DPL was used" information
 		$this->addByMap( Transaction::PARAM_DPL, self::$MAP_DPL );
+
+		// add "SMW was used" information
+		$this->addByMap( Transaction::PARAM_SEMANTIC_MEDIAWIKI, self::$MAP_SEMANTIC_MEDIAWIKI );
 
 		// add size category
 		if ( $this->add( Transaction::PARAM_SIZE_CATEGORY ) === null ) {

--- a/includes/wikia/transaction/tests/TransactionClassifierTest.php
+++ b/includes/wikia/transaction/tests/TransactionClassifierTest.php
@@ -199,6 +199,35 @@ class TransactionClassifierTest extends WikiaBaseTest {
 				],
 				'expectedName' => 'page/blog'
 			],
+			# SemanticMediaWiki
+			[
+				'attributes' => [
+					Transaction::PARAM_ENTRY_POINT => Transaction::ENTRY_POINT_PAGE,
+					Transaction::PARAM_NAMESPACE => TransactionClassifier::SMW_NS_CONCEPT,
+				],
+				'expectedName' => 'page/semantic_mediawiki'
+			],
+			[
+				'attributes' => [
+					Transaction::PARAM_ENTRY_POINT => Transaction::ENTRY_POINT_PAGE,
+					Transaction::PARAM_NAMESPACE => TransactionClassifier::SMW_NS_PROPERTY,
+				],
+				'expectedName' => 'page/semantic_mediawiki'
+			],
+			[
+				'attributes' => [
+					Transaction::PARAM_ENTRY_POINT => Transaction::ENTRY_POINT_PAGE,
+					Transaction::PARAM_NAMESPACE => TransactionClassifier::SMW_NS_TYPE,
+				],
+				'expectedName' => 'page/semantic_mediawiki'
+			],
+			[
+				'attributes' => [
+					Transaction::PARAM_ENTRY_POINT => Transaction::ENTRY_POINT_PAGE,
+					Transaction::PARAM_NAMESPACE => TransactionClassifier::SF_NS_FORM,
+				],
+				'expectedName' => 'page/semantic_form'
+			],
 			# special pages
 			[
 				'attributes' => [

--- a/includes/wikia/transaction/tests/TransactionClassifierTest.php
+++ b/includes/wikia/transaction/tests/TransactionClassifierTest.php
@@ -82,6 +82,17 @@ class TransactionClassifierTest extends WikiaBaseTest {
 			],
 			[
 				'attributes' => [
+					Transaction::PARAM_ENTRY_POINT => Transaction::ENTRY_POINT_PAGE,
+					Transaction::PARAM_NAMESPACE => NS_MAIN,
+					Transaction::PARAM_ACTION => TransactionClassifier::ACTION_VIEW,
+					Transaction::PARAM_SKIN => 'foo-skin',
+					Transaction::PARAM_PARSER_CACHE_USED => true,
+					Transaction::PARAM_SEMANTIC_MEDIAWIKI => true
+				],
+				'expectedName' => 'page/main/view/foo-skin/no_parser/semantic_mediawiki'
+			],
+			[
+				'attributes' => [
 					Transaction::PARAM_ENTRY_POINT => Transaction::ENTRY_POINT_NIRVANA,
 					Transaction::PARAM_CONTROLLER => 'SearchSuggestionsApi',
 				],


### PR DESCRIPTION
[SUS-688](https://wikia-inc.atlassian.net/browse/SUS-688)

**Measure your changes**.

Introduce SemanticMediaWiki-specific transactions in NewRelic and in xhprof profiler reports:
- `page/semantic_mediawiki` - will be set for pages in Property, Type and Concept namespaces
- `page/semantic_form` - will be set for SemanticForm pages
- `page/main/view/oasis/.../semantic_mediawiki` - for articles rendered using SMW

One SMW core change was made - `AfterSmwfGetStore` hook was added in `smwfGetStore` function.

```
LoadBalancer::getReaderIndex: no loads for group smw
TransactionTrace: notification: ["onAttributeChange","semantic_mediawiki",true]
TransactionTrace: notification: ["onTypeChange","page\/main\/view\/oasis\/no_parser\/semantic_mediawiki\/average"]
LoadBalancer::getReaderIndex: no loads for group smw
Query transformerslegends (DB user: wikia_mw2) (21) (slave): SELECT /* SMWSQLStore2::getSMWPageIDandSort Macbre - 2694e255-acda-416d-ad44-5a002281dbdc */  smw_id,smw_iw,smw_sortkey  FROM `smw_ids`  WHERE smw_title='Acid_Storm' AND smw_namespace='0' AND (smw_iw='' OR smw_iw=':smw-redi') AND smw_subobject=''  LIMIT 1  
```

@mixth-sense / @Wikia/sustaining-engineering-team 
