### PR TITLE
(DAT-4579) Remove action=render from the TabView tab links

### DIFF
--- a/extensions/wikia/TabView/TabView.php
+++ b/extensions/wikia/TabView/TabView.php
@@ -62,7 +62,7 @@ function tabviewRender($input, $params, $parser ) {
 		if(isset($onetab[0]) && strpos($onetab[0], '<') === false && strpos($onetab[0], '>') === false) {
 			$titleObj = Title::newFromText($onetab[0]);
 			if(is_object($titleObj) && $titleObj->exists()) {
-				$url = $titleObj->getLocalURL('action=render');
+				$url = $titleObj->getLocalURL();
 				$text = $titleObj->getFullText();
 				if(isset($onetab[1]) && strpos($onetab[1], '<') === false && strpos($onetab[1], '>') === false) {
 					if($onetab[1] != '') {

--- a/extensions/wikia/TabView/js/TabView.js
+++ b/extensions/wikia/TabView/js/TabView.js
@@ -128,7 +128,7 @@ window.TabViewClass = $.createClass(Object, {
 
 			containerSelector.startThrobbing();
 
-			$.get(tabUrl, function (html) {
+			$.get(tabUrl, {action: 'render'}, function (html) {
 				containerSelector.html(html).data('loaded', true).stopThrobbing();
 
 				// fire event when new article comment is/will be added to DOM


### PR DESCRIPTION
The TabView tab links include action=render which leads to a strange
experience when clicking the links in Mercury and if you open the tab
link in a new tab. This removes action=render from the link URL and
instead adds it to the AJAX request when loading the tab content.

/cc @Wikia/x-wing 
