### PR TITLE
PLATFORM-2303: Fix fatal error in feed provider/renderer

### DIFF
--- a/extensions/wikia/MyHome/data/DataFeedProvider.php
+++ b/extensions/wikia/MyHome/data/DataFeedProvider.php
@@ -425,6 +425,10 @@ class DataFeedProvider {
 					}
 
 					$imageInfo = self::getThumb($imageName);
+					if (!$imageInfo) {
+						continue;
+					}
+					
 					if ($imageClass === 'image' && !$hideimages) {
 						$item['new_images'][] = $imageInfo;
 					} elseif ($imageClass === 'video' && !$hidevideos) {

--- a/extensions/wikia/MyHome/renderers/FeedRenderer.php
+++ b/extensions/wikia/MyHome/renderers/FeedRenderer.php
@@ -685,6 +685,10 @@ class FeedRenderer {
 			$popupTitle = $wg->Lang->getNsText($namespace) . ':' . $item['name'];
 
 			$titleObj = Title::newFromText($item['name'], NS_FILE);
+			if (!$titleObj) {
+				continue;
+			}
+			
 			$fileName = $titleObj->getText(); // Pass display version of title to Lightbox
 
 			// wrapper for thumbnail


### PR DESCRIPTION
This change should fix the fatal error:

```
PHP Fatal Error: Call to a member function getText() on null in /extensions/wikia/MyHome/renderers/FeedRenderer.php on line 688
```

https://wikia-inc.atlassian.net/browse/PLATFORM-2303

/cc @macbre @garthwebb 
