### PR TITLE
SUS-688 - TransactionClassifier: report SemanticMediaWiki special pages

### DIFF
--- a/includes/wikia/transaction/TransactionClassifier.php
+++ b/includes/wikia/transaction/TransactionClassifier.php
@@ -57,6 +57,20 @@ class TransactionClassifier {
 		'Newimages',
 		'Videos',
 		'Contributions',
+		// SMW-specific special pages
+		'Ask',
+		'Browse',
+		'ExportRDF',
+		'PageProperty',
+		'Properties',
+		'QueryCreator',
+		'SearchByProperty',
+		'SemanticStatistics',
+		'SMWAdmin',
+		'Types',
+		'UnusedProperties',
+		'URIResolver',
+		'WantedProperties',
 	);
 
 	protected static $FILTER_AJAX_FUNCTIONS = array(

--- a/includes/wikia/transaction/tests/TransactionClassifierTest.php
+++ b/includes/wikia/transaction/tests/TransactionClassifierTest.php
@@ -250,6 +250,13 @@ class TransactionClassifierTest extends WikiaBaseTest {
 			[
 				'attributes' => [
 					Transaction::PARAM_ENTRY_POINT => Transaction::ENTRY_POINT_SPECIAL_PAGE,
+					Transaction::PARAM_SPECIAL_PAGE_NAME => 'Browse',
+				],
+				'expectedName' => 'special_page/Browse'
+			],
+			[
+				'attributes' => [
+					Transaction::PARAM_ENTRY_POINT => Transaction::ENTRY_POINT_SPECIAL_PAGE,
 					Transaction::PARAM_SPECIAL_PAGE_NAME => 'foo',
 				],
 				'expectedName' => 'special_page/other'


### PR DESCRIPTION
[SUS-688](https://wikia-inc.atlassian.net/browse/SUS-688)

```
TransactionTrace: notification: ["onTypeChange","special_page\/Browse"]
TransactionTrace: notification: ["onAttributeChange","semantic_mediawiki",true]
```

@mixth-sense 
