### PR TITLE
SOC-1892 Authorize an internal request using a Schwartz token

### DIFF
--- a/includes/WebRequest.php
+++ b/includes/WebRequest.php
@@ -1134,6 +1134,23 @@ HTML;
 	public function isWikiaInternalRequest() {
 		return $this->getHeader( self::WIKIA_INTERNAL_REQUEST_HEADER ) !== false;
 	}
+
+	const WIKIA_INTERNAL_AUTHORIZED_REQUEST_HEADER = 'X-Wikia-Schwartz';
+
+	/**
+	 * Use X-Wikia-Schwartz to authorize an internal request using a Schwartz token,
+	 * e.g. was sent via Http::get() helper or made by DC warmer
+	 *
+	 * @see SOC-1892
+	 *
+	 * @return bool
+	 */
+	public function isWikiaInternalAuthorizedRequest() {
+		global $wgSchwartzToken;
+
+		return $this->getHeader( self::WIKIA_INTERNAL_AUTHORIZED_REQUEST_HEADER ) ===
+			$wgSchwartzToken;
+	}
 }
 
 /**

--- a/includes/WebRequest.php
+++ b/includes/WebRequest.php
@@ -1146,10 +1146,10 @@ HTML;
 	 * @return bool
 	 */
 	public function isWikiaInternalAuthorizedRequest() {
-		global $wgSchwartzToken;
+		global $wgTheSchwartzSecretToken;
 
 		return $this->getHeader( self::WIKIA_INTERNAL_AUTHORIZED_REQUEST_HEADER ) ===
-			$wgSchwartzToken;
+			$wgTheSchwartzSecretToken;
 	}
 }
 

--- a/includes/wikia/nirvana/WikiaApp.class.php
+++ b/includes/wikia/nirvana/WikiaApp.class.php
@@ -603,9 +603,12 @@ class WikiaApp {
 	 * @param string $controllerName The name of the controller, without the 'Controller' or 'Model' suffix
 	 * @param string $methodName The name of the Controller method to call
 	 * @param array $params An array with the parameters to pass to the specified method
+	 * @param bool $internal
 	 * @param int $exceptionMode exception mode
-	 *
 	 * @return WikiaResponse a response object with the data produced by the method call
+	 * @throws WikiaDispatchedException
+	 * @throws WikiaException
+	 * @throws WikiaHttpException
 	 */
 	public function sendRequest( $controllerName = null, $methodName = null, $params = array(), $internal = true,
 								 $exceptionMode = null ) {
@@ -632,6 +635,10 @@ class WikiaApp {
 		}
 
 		$request = new WikiaRequest($params);
+
+		if ( false === $internal ) {
+			$internal = F::app()->wg->Request->isWikiaInternalAuthorizedRequest();
+		}
 
 		$request->setInternal( $internal );
 


### PR DESCRIPTION
Right now the Email controller can only be called within MediaWiki or when there is a current user available who is an admin.

The notification service will use a Schwartz header to authorize itself to the Email service.

See SOC-1892 for more details and discussion.
