### PR TITLE
Pi static method

### DIFF
--- a/extensions/wikia/PortableInfoboxBuilder/PortableInfoboxBuilderHooks.class.php
+++ b/extensions/wikia/PortableInfoboxBuilder/PortableInfoboxBuilderHooks.class.php
@@ -8,7 +8,7 @@ class PortableInfoboxBuilderHooks {
 	 *
 	 * @return true
 	 */
-	public function onTCAfterEditPageAssets() {
+	public static function onTCAfterEditPageAssets() {
 		\Wikia::addAssetsToOutput( 'portable_infobox_builder_template_classification_helper_js' );
 
 		return true;

--- a/extensions/wikia/TemplateClassification/styles/TemplateClassification.scss
+++ b/extensions/wikia/TemplateClassification/styles/TemplateClassification.scss
@@ -10,9 +10,6 @@ $tc-name-color-checked: $color-links;
 	$tc-modal-text-color: lighten($color-text, 20);
 }
 
-$tc-name-color: #000;
-$tc-modal-text-color: #000;
-
 .template-classification-type-wrapper {
 	position: relative;
 }
@@ -60,7 +57,7 @@ $tc-modal-text-color: #000;
 	}
 
 	.tc-type-name {
-		//color: $tc-name-color;
+		color: $tc-name-color;
 		font-size: 16px;
 		font-weight: bold;
 		padding-bottom: 4px;

--- a/extensions/wikia/TemplateClassification/styles/TemplateClassification.scss
+++ b/extensions/wikia/TemplateClassification/styles/TemplateClassification.scss
@@ -10,6 +10,9 @@ $tc-name-color-checked: $color-links;
 	$tc-modal-text-color: lighten($color-text, 20);
 }
 
+$tc-name-color: #000;
+$tc-modal-text-color: #000;
+
 .template-classification-type-wrapper {
 	position: relative;
 }
@@ -57,7 +60,7 @@ $tc-name-color-checked: $color-links;
 	}
 
 	.tc-type-name {
-		color: $tc-name-color;
+		//color: $tc-name-color;
 		font-size: 16px;
 		font-weight: bold;
 		padding-bottom: 4px;


### PR DESCRIPTION
Fixing the deprecation notice: 
`Deprecated: call_user_func_array() expects parameter 1 to be a valid callback, non-static method PortableInfoboxBuilderHooks::onTCAfterEditPageAssets() should not be called statically in /usr/wikia/source/app/includes/Hooks.php on line 216`

@SebastianMarzjan 
