### PR TITLE
RECIRC-159: Include FANDOM_TOPIC items in IMPACT_FOOTER scroller

### DIFF
--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -151,6 +151,7 @@ $config['recirculation_js'] = array(
 		'//extensions/wikia/Recirculation/js/views/scroller.js',
 		'//extensions/wikia/Recirculation/js/views/impactFooter.js',
 		'//extensions/wikia/Recirculation/js/experiments/placement.js',
+		'//extensions/wikia/Recirculation/js/experiments/placement/impactFooter.js',
 		'//extensions/wikia/Recirculation/js/scrolldepth.js',
 		'//extensions/wikia/Recirculation/js/libs/perfect-scrollbar.js',
 	),

--- a/extensions/wikia/Recirculation/RecirculationApiController.class.php
+++ b/extensions/wikia/Recirculation/RecirculationApiController.class.php
@@ -67,7 +67,7 @@ class RecirculationApiController extends WikiaApiController {
 		];
 
 		$discussionsData = [];
-		if ( RecirculationHooks::canShowDiscussions() ) {
+		if ( RecirculationHooks::canShowDiscussions( $cityId ) ) {
 			$discussionsDataService = new DiscussionsDataService( $cityId );
 			$discussionsData = $discussionsDataService->getData();
 			$discussionsData['title'] = wfMessage( 'recirculation-discussion-title' )->plain();

--- a/extensions/wikia/Recirculation/RecirculationController.class.php
+++ b/extensions/wikia/Recirculation/RecirculationController.class.php
@@ -38,7 +38,7 @@ class RecirculationController extends WikiaController {
 			throw new InvalidParameterApiException( 'cityId' );
 		}
 
-		if ( RecirculationHooks::canShowDiscussions() ) {
+		if ( RecirculationHooks::canShowDiscussions( $cityId ) ) {
 			$discussionsDataService = new DiscussionsDataService( $cityId );
 			$posts = $discussionsDataService->getPosts();
 

--- a/extensions/wikia/Recirculation/RecirculationHooks.class.php
+++ b/extensions/wikia/Recirculation/RecirculationHooks.class.php
@@ -46,7 +46,7 @@ class RecirculationHooks {
 	 * @return bool
 	 */
 	public static function onOasisSkinAssetGroups( &$jsAssets ) {
-		global $wgWikiaEnvironment, $wgNoExternals, $wgRecirculationTestGroup;
+		global $wgWikiaEnvironment, $wgNoExternals, $wgRecirculationTestGroup, $wgCityId;
 
 		// We only want to track this on production
 		if ( ( $wgWikiaEnvironment === WIKIA_ENV_PROD ) && empty( $wgNoExternals ) && !empty( $wgRecirculationTestGroup ) ) {
@@ -56,7 +56,7 @@ class RecirculationHooks {
 		if ( self::isCorrectPageType() ) {
 			$jsAssets[] = 'recirculation_js';
 
-			if ( self::canShowDiscussions() ) {
+			if ( self::canShowDiscussions( $wgCityId ) ) {
 				$jsAssets[] = 'recirculation_discussions_js';
 			}
 		}
@@ -85,9 +85,11 @@ class RecirculationHooks {
 		}
 	}
 
-	static public function canShowDiscussions() {
-		$wg = F::app()->wg;
-		if ( !empty( $wg->EnableDiscussions ) && !empty( $wg->EnableRecirculationDiscussions ) ) {
+	static public function canShowDiscussions( $cityId ) {
+		$discussionsEnabled = WikiFactory::getVarValueByName( 'wgEnableDiscussions', $cityId );
+		$recirculationDiscussionsEnabled = WikiFactory::getVarValueByName( 'wgEnableRecirculationDiscussions', $cityId );
+
+		if ( !empty( $discussionsEnabled ) && !empty( $recirculationDiscussionsEnabled ) ) {
 			return true;
 		} else {
 			return false;

--- a/extensions/wikia/Recirculation/js/experiments/placement.js
+++ b/extensions/wikia/Recirculation/js/experiments/placement.js
@@ -19,6 +19,7 @@ require([
 	'ext.wikia.recirculation.helpers.cakeRelatedContent',
 	'ext.wikia.recirculation.helpers.curatedContent',
 	'ext.wikia.recirculation.helpers.googleMatch',
+	'ext.wikia.recirculation.experiments.placement.IMPACT_FOOTER',
 	'ext.wikia.adEngine.taboolaHelper',
 	require.optional('videosmodule.controllers.rail')
 ], function(
@@ -41,6 +42,7 @@ require([
 	cakeHelper,
 	curatedHelper,
 	googleMatchHelper,
+	impactFooterExperiment,
 	taboolaHelper,
 	videosModule
 ) {
@@ -171,7 +173,7 @@ require([
 			isRail = true;
 			break;
 		case 'IMPACT_FOOTER':
-			renderImpactFooter();
+			impactFooterExperiment.run(experimentName);
 			return;
 		default:
 			return;
@@ -309,38 +311,6 @@ require([
 				tracker.trackVerboseClick(experimentName, label);
 			});
 		});
-	}
-
-	function renderImpactFooter() {
-		var curated = curatedHelper(),
-			fView = impactFooterView(),
-			rView = railView(),
-			sView = scrollerView();
-
-		contentLinksHelper({
-			count: 6,
-			extra: 6
-		}).loadData()
-			.then(sView.render)
-			.then(sView.setupTracking(experimentName));
-
-		dataHelper({}).loadData()
-			.then(function(data) {
-				var fandomData = {
-					title: data.fandom.title,
-					items: data.fandom.items.splice(0,5)
-				};
-
-				fView.render(data)
-					.then(fView.setupTracking(experimentName));
-
-				utils.afterRailLoads(function() {
-					curated.injectContent(fandomData)
-						.then(rView.render)
-						.then(rView.setupTracking)
-						.then(curatedHelper.setupTracking);
-				});
-			});
 	}
 
 	function renderLiftigniterFandom(waitToFetch) {

--- a/extensions/wikia/Recirculation/js/experiments/placement.js
+++ b/extensions/wikia/Recirculation/js/experiments/placement.js
@@ -178,19 +178,9 @@ require([
 	}
 
 	if (isRail) {
-		afterRailLoads(runRailExperiment);
+		utils.afterRailLoads(runRailExperiment);
 	} else {
 		runExperiment();
-	}
-
-	function afterRailLoads(callback) {
-		var $rail = $('#WikiaRail');
-
-		if ($rail.find('.loading').exists()) {
-			$rail.one('afterLoad.rail', callback);
-		} else {
-			callback();
-		}
 	}
 
 	function runExperiment() {
@@ -223,7 +213,7 @@ require([
 		}
 
 		errorHandled = true;
-		afterRailLoads(function() {
+		utils.afterRailLoads(function() {
 			var rail = railView();
 
 			fandomHelper({
@@ -280,7 +270,7 @@ require([
 				}
 			});
 
-		afterRailLoads(function() {
+		utils.afterRailLoads(function() {
 			var rail = railView();
 
 			lateralHelper({
@@ -303,7 +293,7 @@ require([
 	}
 
 	function renderTaboola() {
-		afterRailLoads(function() {
+		utils.afterRailLoads(function() {
 			taboolaHelper.initializeWidget({
 				mode: 'thumbnails-rr2',
 				container: railContainerId,
@@ -344,7 +334,7 @@ require([
 				fView.render(data)
 					.then(fView.setupTracking(experimentName));
 
-				afterRailLoads(function() {
+				utils.afterRailLoads(function() {
 					curated.injectContent(fandomData)
 						.then(rView.render)
 						.then(rView.setupTracking)

--- a/extensions/wikia/Recirculation/js/experiments/placement/impactFooter.js
+++ b/extensions/wikia/Recirculation/js/experiments/placement/impactFooter.js
@@ -1,0 +1,65 @@
+/*global define*/
+define('ext.wikia.recirculation.experiments.placement.IMPACT_FOOTER', [
+	'jquery',
+	'ext.wikia.recirculation.utils',
+	'ext.wikia.recirculation.helpers.contentLinks',
+	'ext.wikia.recirculation.helpers.data',
+	'ext.wikia.recirculation.views.rail',
+	'ext.wikia.recirculation.views.scroller',
+	'ext.wikia.recirculation.views.impactFooter'
+], function ($, utils, ContentLinks, DataHelper, RailView, ScrollerView, ImpactFooterView) {
+
+	function run(experimentName) {
+		var scrollerView = ScrollerView();
+
+		ContentLinksHelper({
+			count: 6,
+			extra: 6
+		}).loadData()
+			.then(scrollerView.render)
+			.then(scrollerView.setupTracking(experimentName));
+
+		return DataHelper({}).loadData()
+			.then(formatData)
+			.then(renderImpactFooter(experimentName))
+			.then(utils.waitForRail)
+			.then(renderRail(experimentName));
+	}
+
+	function formatData(data) {
+		var railData = {
+			title: data.fandom.title,
+			items: data.fandom.items.splice(0,5)
+		};
+
+		return {
+			rail: railData,
+			footer: data
+		};
+	}
+
+	function renderImpactFooter(experimentName) {
+		return function(data) {
+			var view = ImpactFooterView();
+
+			view.render(data.footer)
+				.then(view.setupTracking(experimentName));
+
+			return data;
+		}
+	}
+
+	function renderRail(experimentName) {
+		return function(data) {
+			var view = RailView();
+
+			return view.render(data.fandom)
+				.then(view.setupTracking(experimentName));
+		}
+	}
+
+	return {
+		run: run
+	}
+
+});

--- a/extensions/wikia/Recirculation/js/helpers/FandomHelper.js
+++ b/extensions/wikia/Recirculation/js/helpers/FandomHelper.js
@@ -10,7 +10,8 @@ define('ext.wikia.recirculation.helpers.fandom', [
 	return function(config) {
 		var defaults = {
 				limit: 3,
-				type: 'recent_popular'
+				type: 'recent_popular',
+				ignoreError: false
 			},
 			options = $.extend({}, defaults, config);
 
@@ -32,7 +33,15 @@ define('ext.wikia.recirculation.helpers.fandom', [
 					if (data.items && data.items.length >= options.limit ) {
 						deferred.resolve(data);
 					} else {
-						deferred.reject('Recirculation widget not shown - Not enough items returned from Fandom API');
+
+						if (options.ignoreError) {
+							deferred.resolve({
+								title: data.title,
+								items: []
+							});
+						} else {
+							deferred.reject('Recirculation widget not shown - Not enough items returned from Fandom API');
+						}
 					}
 				}
 			});

--- a/extensions/wikia/Recirculation/js/utils.js
+++ b/extensions/wikia/Recirculation/js/utils.js
@@ -1,9 +1,10 @@
 /*global define*/
 define('ext.wikia.recirculation.utils', [
+	'jquery',
 	'wikia.loader',
 	'wikia.cache',
 	'wikia.mustache'
-], function (loader, cache, Mustache) {
+], function ($, loader, cache, Mustache) {
 	'use strict';
 
 	/**
@@ -73,10 +74,38 @@ define('ext.wikia.recirculation.utils', [
 		return items;
 	}
 
+	function afterRailLoads(callback) {
+		var $rail = $('#WikiaRail');
+
+		if ($rail.find('.loading').exists()) {
+			$rail.one('afterLoad.rail', callback);
+		} else {
+			callback();
+		}
+	}
+
+	function waitForRail() {
+		var $rail = $('#WikiaRail'),
+			deferred = $.Deferred(),
+			args = arguments;
+
+		if ($rail.find('.loading').exists()) {
+			$rail.one('afterLoad.rail', function() {
+				deferred.resolve(args);
+			});
+		} else {
+			deferred.resolve(args);
+		}
+
+		return deferred.promise();
+	}
+
 	return {
 		buildLabel: buildLabel,
 		loadTemplate: loadTemplate,
 		renderTemplate: renderTemplate,
-		addUtmTracking: addUtmTracking
+		addUtmTracking: addUtmTracking,
+		afterRailLoads: afterRailLoads,
+		waitForRail: waitForRail
 	};
 });

--- a/extensions/wikia/Recirculation/js/utils.js
+++ b/extensions/wikia/Recirculation/js/utils.js
@@ -91,10 +91,10 @@ define('ext.wikia.recirculation.utils', [
 
 		if ($rail.find('.loading').exists()) {
 			$rail.one('afterLoad.rail', function() {
-				deferred.resolve(args);
+				deferred.resolve.apply(null, args);
 			});
 		} else {
-			deferred.resolve(args);
+			deferred.resolve.apply(null, args);
 		}
 
 		return deferred.promise();

--- a/extensions/wikia/Recirculation/js/utils.js
+++ b/extensions/wikia/Recirculation/js/utils.js
@@ -87,7 +87,7 @@ define('ext.wikia.recirculation.utils', [
 	function waitForRail() {
 		var $rail = $('#WikiaRail'),
 			deferred = $.Deferred(),
-			args = arguments;
+			args = Array.prototype.slice.call(arguments);
 
 		if ($rail.find('.loading').exists()) {
 			$rail.one('afterLoad.rail', function() {


### PR DESCRIPTION
This change also starts the process of moving placement experiments into their own files in hopes of cleaning up the `placement.js` and making new groups easier to add
