### PR TITLE
SUS-673 in ChatWidget fix missing message about page type

### DIFF
--- a/extensions/wikia/Chat2/ChatWidget.class.php
+++ b/extensions/wikia/Chat2/ChatWidget.class.php
@@ -189,6 +189,13 @@ class ChatWidget {
 					$profileUrlNs = !empty( $wgEnableWallExt ) ? NS_USER_WALL : NS_USER_TALK;
 					$chatter['profileUrl'] = Title::makeTitle( $profileUrlNs, $chatter['username'] )->getFullURL();
 					$chatter['contribsUrl'] = SpecialPage::getTitleFor( 'Contributions', $chatter['username'] )->getFullURL();
+					if (empty( $wgEnableWallExt )){
+						$chatter['profileType'] = 'talk-page';
+						$chatter['profileTypeMsg'] = 'chat-user-menu-talk-page';
+					} else {
+						$chatter['profileType'] = 'message-wall';
+						$chatter['profileTypeMsg'] = 'chat-user-menu-message-wall';
+					}
 				}
 
 				return $chatter;

--- a/extensions/wikia/Chat2/templates/widgetUserElement.mustache
+++ b/extensions/wikia/Chat2/templates/widgetUserElement.mustache
@@ -15,7 +15,7 @@
 				<li class="profilepage {{profileType}}">
 					<a href="{{profileUrl}}">
 						<span class="icon">&nbsp;</span>
-						<span class="label" data-msg-id="chat-user-menu-{{profileType}}"></span>
+						<span class="label" data-msg-id="{{profileTypeMsg}}"></span>
 					</a>
 				</li>
 				<li class="contribs">


### PR DESCRIPTION
[SUS-673](https://wikia-inc.atlassian.net/browse/SUS-673)
Missing message when hovering on user avatar in chat widget was caused by missing variable 'profileType'. I've added profileType to getUserInfo method together with new variable profileTypeMsg to avoid concatenation on template. Both variables are wrapped in a conditional to determine wether Talk Page or Message Wall should be displayed.

@mixth-sense @sqreek 
