### PR TITLE
PLATFORM-2318: Use proper index in WikiaApiQueryLastEditors

### DIFF
--- a/extensions/wikia/WikiaApi/WikiaApiQueryLastEditors.php
+++ b/extensions/wikia/WikiaApi/WikiaApiQueryLastEditors.php
@@ -79,6 +79,7 @@ class WikiaApiQueryLastEditors extends ApiQueryBase {
 			__METHOD__,
 			array(
 				'ORDER BY' => 'rev_timestamp DESC',
+				'USE INDEX' => 'for_wikia_api_last_editors_idx',
 				'LIMIT'	=> $this->params['limit'],
 				'OFFSET' => $this->params['offset']
 			)


### PR DESCRIPTION
Force the dedicated index to be used. Mysql is sometimes smart enough to choose other ones.

https://wikia-inc.atlassian.net/browse/PLATFORM-2318

/cc @macbre @drozdo 
