### PR TITLE
SEO-267 Replace the category pagination with the standard one

### DIFF
--- a/extensions/wikia/Blogs/BlogArticle.php
+++ b/extensions/wikia/Blogs/BlogArticle.php
@@ -372,9 +372,9 @@ class BlogArticle extends Article {
 			$r = "<div id=\"mw-pages\">\n";
 			$r .= '<h2>' . wfMsg( "blog-header", $ti ) . "</h2>\n";
 			$r .= $countmsg;
-			$r .= $catView->getSectionPagingLinks( 'page' );
+			$r .= $catView->getSectionPagingLinksExt( 'page' );
 			$r .= $catView->formatList( array_values( $catView->blogs ), $catView->blogs_start_char );
-			$r .= $catView->getSectionPagingLinks( 'page' );
+			$r .= $catView->getSectionPagingLinksExt( 'page' );
 			$r .= "\n</div>";
 		}
 		$output = $r;

--- a/extensions/wikia/Blogs/BlogArticle.php
+++ b/extensions/wikia/Blogs/BlogArticle.php
@@ -351,11 +351,13 @@ class BlogArticle extends Article {
 	 * static methods used in Hooks
 	 */
 	static public function getOtherSection( &$catView, &$output ) {
-		wfProfileIn( __METHOD__ );
+		global $wgEnableCategoryPaginationExt;
+		if ( $wgEnableCategoryPaginationExt ) {
+			return true;
+		}
 
 		/* @var $catView CategoryViewer */
 		if ( !isset( $catView->blogs ) ) {
-			wfProfileOut( __METHOD__ );
 			return true;
 		}
 		$ti = htmlspecialchars( $catView->title->getText() );
@@ -370,14 +372,13 @@ class BlogArticle extends Article {
 			$r = "<div id=\"mw-pages\">\n";
 			$r .= '<h2>' . wfMsg( "blog-header", $ti ) . "</h2>\n";
 			$r .= $countmsg;
-			$r .= $catView->getSectionPagingLinksExt( 'page' );
+			$r .= $catView->getSectionPagingLinks( 'page' );
 			$r .= $catView->formatList( array_values( $catView->blogs ), $catView->blogs_start_char );
-			$r .= $catView->getSectionPagingLinksExt( 'page' );
+			$r .= $catView->getSectionPagingLinks( 'page' );
 			$r .= "\n</div>";
 		}
 		$output = $r;
 
-		wfProfileOut( __METHOD__ );
 		return true;
 	}
 
@@ -479,6 +480,10 @@ class BlogArticle extends Article {
 	 * @internal param $CategoryViewer
 	 */
 	static public function addCategoryPage( &$catView, &$title, &$row, $sortkey ) {
+		global $wgEnableCategoryPaginationExt;
+		if ( $wgEnableCategoryPaginationExt ) {
+			return true;
+		}
 		if ( in_array( $row->page_namespace, array( NS_BLOG_ARTICLE, NS_BLOG_LISTING ) ) ) {
 			/**
 			 * initialize CategoryView->blogs array

--- a/extensions/wikia/CategoryPagination/CategoryPagination.setup.php
+++ b/extensions/wikia/CategoryPagination/CategoryPagination.setup.php
@@ -7,3 +7,4 @@ $wgAutoloadClasses[ 'CategoryPaginationHooks' ] = __DIR__ . '/CategoryPagination
 
 // Hooks
 $wgHooks['ArticleFromTitle'][] = 'CategoryPaginationHooks::onArticleFromTitle';
+$wgHooks['CategoryViewerGetSectionPagingLinks'][] = 'CategoryPaginationHooks::onCategoryViewerGetSectionPagingLinks';

--- a/extensions/wikia/CategoryPagination/CategoryPagination.setup.php
+++ b/extensions/wikia/CategoryPagination/CategoryPagination.setup.php
@@ -1,0 +1,9 @@
+<?php
+
+// Autoload Category Page classes
+$wgAutoloadClasses[ 'CategoryPaginationPage' ] = __DIR__ . '/CategoryPaginationPage.class.php';
+$wgAutoloadClasses[ 'CategoryPaginationViewer' ] = __DIR__ . '/CategoryPaginationViewer.class.php';
+$wgAutoloadClasses[ 'CategoryPaginationHooks' ] = __DIR__ . '/CategoryPaginationHooks.class.php';
+
+// Hooks
+$wgHooks['ArticleFromTitle'][] = 'CategoryPaginationHooks::onArticleFromTitle';

--- a/extensions/wikia/CategoryPagination/CategoryPaginationHooks.class.php
+++ b/extensions/wikia/CategoryPagination/CategoryPaginationHooks.class.php
@@ -13,7 +13,7 @@ class CategoryPaginationHooks {
 		$app = F::app();
 
 		// Only do anything with category pages on Oasis
-		if ( !$app->checkSkin( 'oasis' ) || $title->getNamespace() != NS_CATEGORY ) {
+		if ( !$app->checkSkin( 'oasis' ) || !$title || $title->getNamespace() != NS_CATEGORY ) {
 			return true;
 		}
 
@@ -27,5 +27,16 @@ class CategoryPaginationHooks {
 		$article = new CategoryPaginationPage( $title );
 
 		return true;
+	}
+
+	static public function onCategoryViewerGetSectionPagingLinks( $catViewer, $type, $position, &$r ) {
+		if ( !( $catViewer instanceof CategoryPaginationViewer ) ) {
+			return true;
+		}
+		$r = '';
+		if ( $position === 'bottom' ) {
+			$r = $catViewer->getPaginator( $type )->getBarHTML();
+		}
+		return false;
 	}
 }

--- a/extensions/wikia/CategoryPagination/CategoryPaginationHooks.class.php
+++ b/extensions/wikia/CategoryPagination/CategoryPaginationHooks.class.php
@@ -9,7 +9,7 @@ class CategoryPaginationHooks {
 	 * @param Article $article
 	 * @return bool
 	 */
-	static public function onArticleFromTitle( &$title, &$article ) {
+	public static function onArticleFromTitle( &$title, &$article ) {
 		$app = F::app();
 
 		// Only do anything with category pages on Oasis
@@ -29,7 +29,7 @@ class CategoryPaginationHooks {
 		return true;
 	}
 
-	static public function onCategoryViewerGetSectionPagingLinks( $catViewer, $type, $position, &$r ) {
+	public static function onCategoryViewerGetSectionPagingLinks( $catViewer, $type, $position, &$r ) {
 		if ( !( $catViewer instanceof CategoryPaginationViewer ) ) {
 			return true;
 		}

--- a/extensions/wikia/CategoryPagination/CategoryPaginationHooks.class.php
+++ b/extensions/wikia/CategoryPagination/CategoryPaginationHooks.class.php
@@ -37,6 +37,6 @@ class CategoryPaginationHooks {
 		if ( $position === 'bottom' ) {
 			$r = $catViewer->getPaginator( $type )->getBarHTML();
 		}
-		return false;
+		return true;
 	}
 }

--- a/extensions/wikia/CategoryPagination/CategoryPaginationHooks.class.php
+++ b/extensions/wikia/CategoryPagination/CategoryPaginationHooks.class.php
@@ -1,6 +1,8 @@
 <?php
 
 class CategoryPaginationHooks {
+	const PARAMS_DISABLING_PAGINATION = [ 'from', 'pagefrom', 'pageuntil' ];
+
 	/**
 	 * @static
 	 * @param Title $title
@@ -8,14 +10,18 @@ class CategoryPaginationHooks {
 	 * @return bool
 	 */
 	static public function onArticleFromTitle( &$title, &$article ) {
-		// Only touch category pages on Oasis
-		if ( !F::app()->checkSkin( 'oasis' ) || $title->getNamespace() != NS_CATEGORY ) {
+		$app = F::app();
+
+		// Only do anything with category pages on Oasis
+		if ( !$app->checkSkin( 'oasis' ) || $title->getNamespace() != NS_CATEGORY ) {
 			return true;
 		}
 
 		// New pagination doesn't support the from param (yet)
-		if ( F::app()->wg->Request->getVal( 'from' ) ) {
-			return true;
+		foreach ( self::PARAMS_DISABLING_PAGINATION as $param ) {
+			if ( $app->wg->Request->getVal( $param ) ) {
+				return true;
+			}
 		}
 
 		$article = new CategoryPaginationPage( $title );

--- a/extensions/wikia/CategoryPagination/CategoryPaginationHooks.class.php
+++ b/extensions/wikia/CategoryPagination/CategoryPaginationHooks.class.php
@@ -1,0 +1,25 @@
+<?php
+
+class CategoryPaginationHooks {
+	/**
+	 * @static
+	 * @param Title $title
+	 * @param Article $article
+	 * @return bool
+	 */
+	static public function onArticleFromTitle( &$title, &$article ) {
+		// Only touch category pages on Oasis
+		if ( !F::app()->checkSkin( 'oasis' ) || $title->getNamespace() != NS_CATEGORY ) {
+			return true;
+		}
+
+		// New pagination doesn't support the from param (yet)
+		if ( F::app()->wg->Request->getVal( 'from' ) ) {
+			return true;
+		}
+
+		$article = new CategoryPaginationPage( $title );
+
+		return true;
+	}
+}

--- a/extensions/wikia/CategoryPagination/CategoryPaginationPage.class.php
+++ b/extensions/wikia/CategoryPagination/CategoryPaginationPage.class.php
@@ -1,0 +1,15 @@
+<?php
+
+class CategoryPaginationPage extends CategoryPage {
+	public function closeShowCategory() {
+		$request = $this->getContext()->getRequest();
+		$page = $request->getInt( 'page', 0 );
+		$page = max( 1, $page );
+		$viewer = new CategoryPaginationViewer(
+			$this->getContext()->getTitle(),
+			$this->getContext(),
+			$page
+		);
+		$this->getContext()->getOutput()->addHTML( $viewer->getHTML() );
+	}
+}

--- a/extensions/wikia/CategoryPagination/CategoryPaginationViewer.class.php
+++ b/extensions/wikia/CategoryPagination/CategoryPaginationViewer.class.php
@@ -1,0 +1,106 @@
+<?php
+
+use Wikia\Paginator\Paginator;
+
+class CategoryPaginationViewer extends CategoryViewer {
+	private $page;
+	private $counts;
+	/** @var Paginator[] */
+	private $paginators = [];
+
+	public function __construct( $title, IContextSource $context, $page ) {
+		parent::__construct( $title, $context );
+
+		$this->page = $page;
+
+		$cat = Category::newFromTitle( $this->title );
+		$this->counts = [
+			'file' => $cat->getFileCount(),
+			'subcat' => $cat->getSubcatCount(),
+			'page' => $cat->getPageCount() - $cat->getFileCount() - $cat->getSubcatCount(),
+		];
+
+		$url = $this->title->getLocalURL();
+
+		foreach ( array_keys( $this->from ) as $type ) {
+			$this->from[$type] = $this->getActualFrom( $type, $page );
+			$this->paginators[$type] = new Paginator( $this->counts[$type], $this->limit, $url );
+			$this->paginators[$type]->setActivePage( $this->page );
+		}
+
+		$context->getOutput()->addHeadItem( 'Paginator', $this->getPaginationHeadItem() );
+	}
+
+	private function getPaginationHeadItem() {
+		$numPages = -1;
+		$maxPaginator = null;
+		foreach ( $this->paginators as $paginator ) {
+			if ( $paginator->getPagesCount() > $numPages ) {
+				$numPages = $paginator->getPagesCount();
+				$maxPaginator = $paginator;
+			}
+		}
+		if ( $maxPaginator ) {
+			return $maxPaginator->getHeadItem();
+		}
+		return '';
+	}
+
+	/**
+	 * Select the first page matching given type and page number and return the human-readable
+	 * sort key associated with it
+	 *
+	 * This value is passed to the original CategoryViewer code as the $this->from member.
+	 * The DB is called, but the query uses the proper index and therefor is super fast (< 10ms),
+	 * so there's no need to cache.
+	 */
+	private function getActualFrom( $type, $page ) {
+		$dbr = wfGetDB( DB_SLAVE, 'category' );
+
+		// if beyond the last page, show the last page instead
+		$totalPages = ceil( $this->counts[$type] / $this->limit );
+		if ( $page > $totalPages && $totalPages >= 1 ) {
+			$page = $totalPages;
+		}
+
+		$conditions = [
+			'cl_to' => $this->title->getDBkey(),
+			'cl_type' => $type,
+		];
+
+		$res = $dbr->select(
+			[ 'page', 'categorylinks' ],
+			[ 'page.*', 'cl_sortkey_prefix' ],
+			$conditions,
+			__METHOD__,
+			[
+				'USE INDEX' => array( 'categorylinks' => 'cl_sortkey' ),
+				'LIMIT' => 1,
+				'OFFSET' => ( $page - 1 ) * $this->limit,
+				'ORDER BY' => 'cl_sortkey',
+			],
+			[ 'categorylinks' => [ 'INNER JOIN', 'cl_from = page_id' ] ]
+		);
+		$row = $res->fetchObject();
+
+		if ( $row ) {
+			$title = Title::newFromRow( $row );
+			$humanSortKey = $title->getCategorySortkey( $row->cl_sortkey_prefix );
+			return $humanSortKey;
+		}
+
+		return null;
+	}
+
+	public function getSectionPagingLinks( $type ) {
+		// This method is called twice. Once for the pagination at the top of the section
+		// and the second time for the pagination at the bottom. We only want to output
+		// the pagination at the bottom: the second time this method is called for given type
+
+		static $wasCalled = [];
+		if ( isset( $wasCalled[$type] ) ) {
+			return $this->paginators[$type]->getBarHTML();
+		}
+		$wasCalled[$type] = true;
+	}
+}

--- a/extensions/wikia/CategoryPagination/CategoryPaginationViewer.class.php
+++ b/extensions/wikia/CategoryPagination/CategoryPaginationViewer.class.php
@@ -92,15 +92,12 @@ class CategoryPaginationViewer extends CategoryViewer {
 		return null;
 	}
 
-	public function getSectionPagingLinks( $type ) {
-		// This method is called twice. Once for the pagination at the top of the section
-		// and the second time for the pagination at the bottom. We only want to output
-		// the pagination at the bottom: the second time this method is called for given type
-
-		static $wasCalled = [];
-		if ( isset( $wasCalled[$type] ) ) {
-			return $this->paginators[$type]->getBarHTML();
-		}
-		$wasCalled[$type] = true;
+	/**
+	 * Get the paginator object for given section
+	 * @param string $type: page, subcat or file
+	 * @return Paginator
+	 */
+	public function getPaginator( $type ) {
+		return $this->paginators[$type];
 	}
 }

--- a/extensions/wikia/RobotsTxt/classes/WikiaRobots.class.php
+++ b/extensions/wikia/RobotsTxt/classes/WikiaRobots.class.php
@@ -83,6 +83,7 @@ class WikiaRobots {
 	private $blockedParams = [
 		'action',
 		'feed',
+		'from', // user-supplied legacy MW pagination
 		'oldid',
 		'printable',
 		'redirect',

--- a/includes/CategoryViewer.php
+++ b/includes/CategoryViewer.php
@@ -93,8 +93,8 @@ class CategoryViewer extends ContextSource {
 			$this->getPagesSection() .
 			$this->getImageSection() .
 		# <Wikia>
-			$this->getOtherSection(); 
-		# </Wikia>	
+			$this->getOtherSection();
+		# </Wikia>
 
 		if ( $r == '' ) {
 			// If there is no category content to display, only
@@ -320,7 +320,7 @@ class CategoryViewer extends ContextSource {
 					$humanSortkey = $title->getCategorySortkey( $row->cl_sortkey_prefix );
 				}
 
-				if ( ++$count > $this->limit 
+				if ( ++$count > $this->limit
 					/* Wikia change begin - @author: Federico "Lox" Lucignano */
 					/* allow getting all the items in a category */
 					&& is_integer( $this->limit )
@@ -357,7 +357,7 @@ class CategoryViewer extends ContextSource {
 		/* Category Galleries hook */
 		wfRunHooks('CategoryPage::getCategoryTop',array($this,&$r));
 		/* Wikia change end */
-				
+
 		$r .= $this->getCategoryBottom();
 		return $r === ''
 			? $r
@@ -449,19 +449,6 @@ class CategoryViewer extends ContextSource {
 	}
 	/* </Wikia> */
 
-	/* <Wikia> */
-	/**
-	* Get paging links using private function getSectionPagingLinks
-	*
-	* @param $type String same like in getSectionPagingLinks function
-	* @return String: HTML output, possibly empty if there are no other pages
-	*/
-	public function getSectionPagingLinksExt( $type ) {
-		$paginationLinks = $this->getSectionPagingLinks( $type );
-		return $paginationLinks;
-	}
-	/* </Wikia> */
-	
 	/**
 	 * Get the paging links for a section (subcats/pages/files), to go at the top and bottom
 	 * of the output.
@@ -469,7 +456,9 @@ class CategoryViewer extends ContextSource {
 	 * @param $type String: 'page', 'subcat', or 'file'
 	 * @return String: HTML output, possibly empty if there are no other pages
 	 */
-	private function getSectionPagingLinks( $type ) {
+	/* Wikia change: private -> public */
+	public function getSectionPagingLinks( $type ) {
+	/* Wikia change end */
 		if ( $this->until[$type] !== null ) {
 			return $this->pagingLinks( $this->nextPage[$type], $this->until[$type], $type );
 		} elseif ( $this->nextPage[$type] !== null || $this->from[$type] !== null ) {
@@ -721,7 +710,7 @@ class CategoryViewer extends ContextSource {
 		}
 		return wfMessage( "category-$type-count" )->numParams( $rescnt, $totalcnt )->parseAsBlock();
 	}
-	
+
 	/**
 	 * getter for private $cat variable, used in Hooks
 	 *

--- a/includes/CategoryViewer.php
+++ b/includes/CategoryViewer.php
@@ -379,9 +379,11 @@ class CategoryViewer extends ContextSource {
 			$r .= "<div id=\"mw-subcategories\">\n";
 			$r .= '<h2>' . wfMsg( 'subcategories' ) . "</h2>\n";
 			$r .= $countmsg;
-			$r .= $this->getSectionPagingLinks( 'subcat' );
+			/* Wikia change: $position param: top/bottom */
+			$r .= $this->getSectionPagingLinks( 'subcat', 'top' );
 			$r .= $this->formatList( $this->children, $this->children_start_char );
-			$r .= $this->getSectionPagingLinks( 'subcat' );
+			$r .= $this->getSectionPagingLinks( 'subcat', 'bottom' );
+			/* Wikia change end */
 			$r .= "\n</div>";
 		}
 		return $r;
@@ -408,9 +410,11 @@ class CategoryViewer extends ContextSource {
 			$r = "<div id=\"mw-pages\">\n";
 			$r .= '<h2>' . wfMsg( 'category_header', $ti ) . "</h2>\n";
 			$r .= $countmsg;
-			$r .= $this->getSectionPagingLinks( 'page' );
+			/* Wikia change: $position param: top/bottom */
+			$r .= $this->getSectionPagingLinks( 'page', 'top' );
 			$r .= $this->formatList( $this->articles, $this->articles_start_char );
-			$r .= $this->getSectionPagingLinks( 'page' );
+			$r .= $this->getSectionPagingLinks( 'page', 'bottom' );
+			/* Wikia change end */
 			$r .= "\n</div>";
 		}
 		return $r;
@@ -429,13 +433,15 @@ class CategoryViewer extends ContextSource {
 			$r .= "<div id=\"mw-category-media\">\n";
 			$r .= '<h2>' . wfMsg( 'category-media-header', htmlspecialchars( $this->title->getText() ) ) . "</h2>\n";
 			$r .= $countmsg;
-			$r .= $this->getSectionPagingLinks( 'file' );
+			/* Wikia change: $position param: top/bottom */
+			$r .= $this->getSectionPagingLinks( 'file', 'top' );
 			if ( $this->showGallery ) {
 				$r .= $this->gallery->toHTML();
 			} else {
 				$r .= $this->formatList( $this->imgsNoGallery, $this->imgsNoGallery_start_char );
 			}
-			$r .= $this->getSectionPagingLinks( 'file' );
+			$r .= $this->getSectionPagingLinks( 'file', 'bottom' );
+			/* Wikia change end */
 			$r .= "\n</div>";
 		}
 		return $r;
@@ -449,16 +455,32 @@ class CategoryViewer extends ContextSource {
 	}
 	/* </Wikia> */
 
+	/* <Wikia> */
+	/**
+	* Get paging links using private function getSectionPagingLinks
+	*
+	* @param $type String same like in getSectionPagingLinks function
+	* @return String: HTML output, possibly empty if there are no other pages
+	*/
+	public function getSectionPagingLinksExt( $type ) {
+		$paginationLinks = $this->getSectionPagingLinks( $type );
+		return $paginationLinks;
+	}
+	/* </Wikia> */
+
 	/**
 	 * Get the paging links for a section (subcats/pages/files), to go at the top and bottom
 	 * of the output.
 	 *
 	 * @param $type String: 'page', 'subcat', or 'file'
+	 * @param $position
 	 * @return String: HTML output, possibly empty if there are no other pages
 	 */
-	/* Wikia change: private -> public */
-	public function getSectionPagingLinks( $type ) {
-	/* Wikia change end */
+	private function getSectionPagingLinks( $type, $position = null ) {
+		$r = '';
+		if ( !wfRunHooks( 'CategoryViewerGetSectionPagingLinks', [ $this, $type, $position, &$r ] ) ) {
+			return $r;
+		}
 		if ( $this->until[$type] !== null ) {
 			return $this->pagingLinks( $this->nextPage[$type], $this->until[$type], $type );
 		} elseif ( $this->nextPage[$type] !== null || $this->from[$type] !== null ) {

--- a/includes/CategoryViewer.php
+++ b/includes/CategoryViewer.php
@@ -477,17 +477,17 @@ class CategoryViewer extends ContextSource {
 	 * @return String: HTML output, possibly empty if there are no other pages
 	 */
 	private function getSectionPagingLinks( $type, $position = null ) {
-		$r = '';
-		if ( !wfRunHooks( 'CategoryViewerGetSectionPagingLinks', [ $this, $type, $position, &$r ] ) ) {
-			return $r;
-		}
+		/* Wikia change: introduced a hook to override the pagination HTML */
 		if ( $this->until[$type] !== null ) {
-			return $this->pagingLinks( $this->nextPage[$type], $this->until[$type], $type );
+			$r = $this->pagingLinks( $this->nextPage[$type], $this->until[$type], $type );
 		} elseif ( $this->nextPage[$type] !== null || $this->from[$type] !== null ) {
-			return $this->pagingLinks( $this->from[$type], $this->nextPage[$type], $type );
+			$r = $this->pagingLinks( $this->from[$type], $this->nextPage[$type], $type );
 		} else {
-			return '';
+			$r = '';
 		}
+		wfRunHooks( 'CategoryViewerGetSectionPagingLinks', [ $this, $type, $position, &$r ] );
+		return $r;
+		/* Wikia change end */
 	}
 
 	/**


### PR DESCRIPTION
The extension replaces the next-200, previous-200 links with the
standard pager. The new mode is not enabled if there's a "from" param
present in the URL.
