### PR TITLE
SMWUpdateJob: catch exceptions from the parser

### DIFF
--- a/extensions/wikia/SemanticMediaWiki/includes/jobs/SMW_UpdateJob.php
+++ b/extensions/wikia/SemanticMediaWiki/includes/jobs/SMW_UpdateJob.php
@@ -56,7 +56,21 @@ class SMWUpdateJob extends Job {
 
 		wfProfileIn( __METHOD__ . '-parse' );
 		$options = new ParserOptions();
-		$output = $wgParser->parse( $revision->getText(), $this->title, $options, true, true, $revision->getID() );
+
+		# Wikia change
+		try {
+			$output = $wgParser->parse( $revision->getText(), $this->title, $options, true, true, $revision->getID() );
+		}
+		catch( \Exception $e ) {
+			Wikia\Logger\WikiaLogger::instance()->error( __METHOD__, [
+				'exception' => $e,
+				'title' => $this->title->getPrefixedDBkey()
+			] );
+
+			wfProfileOut( __METHOD__ . '-parse' );
+			wfProfileOut( 'SMWUpdateJob::run (SMW)' );
+			return false;
+		}
 
 		wfProfileOut( __METHOD__ . '-parse' );
 		wfProfileIn( __METHOD__ . '-update' );


### PR DESCRIPTION
Avoid breaking the SMW storage migration due to parser exceptions.

```
Unexpected non-MediaWiki exception encountered, of type "Wikia\Util\AssertionException"
exception 'Wikia\Util\AssertionException' with message 'Parser::mSubstWords should be an instance of MagicWordArray' in /home/macbre/app/lib/Wikia/src/Util/Assert.php:25
Stack trace:
#0 /home/macbre/app/includes/parser/Parser.php(3397): Wikia\Util\Assert::true(false, 'Parser::mSubstW...', Array)
#1 /home/macbre/app/includes/parser/Preprocessor_DOM.php(1189): Parser->braceSubstitution(Array, Object(PPFrame_DOM))
#2 /home/macbre/app/includes/parser/Parser.php(3280): PPFrame_DOM->expand(Object(PPNode_DOM), 0)
#3 /home/macbre/app/includes/parser/Parser.php(1205): Parser->replaceVariables('Es gibt {{PLURA...')
#4 /home/macbre/app/includes/parser/Parser.php(536): Parser->internalParse('Es gibt {{PLURA...', false, false)
#5 /home/macbre/app/extensions/DynamicPageList/DPL.php(1244): Parser->recursiveTagParse('Es gibt {{PLURA...')
#6 /home/macbre/app/extensions/DynamicPageList/DPL.php(182): DPL->msgExt('categoryarticle...', Array, 1)
#7 /home/macbre/app/extensions/DynamicPageList/DPL.php(131): DPL->formatCount(1)
#8 /home/macbre/app/extensions/DynamicPageList/DPLMain.php(2831): DPL->__construct(Array, true, 1, 1, 0, '', Array, 'category', Object(DPLListMode), Object(DPLListMode), 'true', false, false, NULL, Array, Array, Array, false, Object(Parser), Object(DPLLogger), Array, NULL, '.default', Array, false, '0', '', '')
#9 /home/macbre/app/extensions/DynamicPageList/DPLSetup.php(1324): DPLMain::dynamicPageList('\n  ordermethod=...', Array, Object(Parser), Array, 'tag')
#10 /home/macbre/app/extensions/DynamicPageList/DPLSetup.php(1310): ExtDynamicPageList::executeTag('\n  ordermethod=...', Array, Object(Parser))
#11 [internal function]: ExtDynamicPageList::dplTag('\n  ordermethod=...', Array, Object(Parser), Object(PPFrame_DOM))
#12 /home/macbre/app/includes/parser/Parser.php(4180): call_user_func_array(Array, Array)
#13 /home/macbre/app/includes/parser/Preprocessor_DOM.php(1298): Parser->extensionSubstitution(Array, Object(PPFrame_DOM))
#14 /home/macbre/app/includes/parser/Parser.php(3280): PPFrame_DOM->expand(Object(PPNode_DOM), 0)
#15 /home/macbre/app/includes/parser/Parser.php(1205): Parser->replaceVariables('<dpl>\n  orderme...')
#16 /home/macbre/app/includes/parser/Parser.php(371): Parser->internalParse('<dpl>\n  orderme...')
#17 /home/macbre/app/extensions/wikia/SemanticMediaWiki/includes/jobs/SMW_UpdateJob.php(59): Parser->parse('<dpl>\n  orderme...', Object(Title), Object(ParserOptions), true, true, 11216)
#18 /home/macbre/app/includes/wikia/tasks/Tasks/JobWrapperTask.class.php(43): SMWUpdateJob->run()
#19 /home/macbre/app/extensions/wikia/SemanticMediaWiki/includes/storage/SQLStore/SMW_SQLStore3_SetupHandlers.php(473): Wikia\Tasks\Tasks\JobWrapperTask->wrap('SMWUpdateJob')
#20 /home/macbre/app/extensions/wikia/SemanticMediaWiki/includes/storage/SQLStore/SMW_SQLStore3.php(406): SMWSQLStore3SetupHandlers->refreshData('3785', 1, false, false)
#21 /home/macbre/app/extensions/wikia/SemanticMediaWiki/maintenance/SMW_refreshData.php(147): SMWSQLStore3->refreshData('3785', 1, false, false)
```

@mixth-sense 
