### PR TITLE
WW-11: Run method after required modules are loaded

### DIFF
--- a/resources/wikia/wikia.wikibits.js
+++ b/resources/wikia/wikia.wikibits.js
@@ -181,8 +181,10 @@ var importNotifications = (function() {
 window.importArticle = window.importArticles = importArticle;
 window.importNotifications = importNotifications;
 
-require(['wikia.importScript', 'wikia.window'], function(importScript, window){
-	window.importWikiaScriptPages = importScript.importWikiaScriptPages;
-});
+window.importWikiaScriptPages = function(articles) {
+	require(['wikia.importScript'], function(importScript){
+		importScript.importWikiaScriptPages(articles);
+	});
+}
 
 })( this, jQuery );


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/WW-11

This error is really hard to reproduce and it happens rarely. After small investigation and observation I assumed that `importWikiaScriptPages` is not defined because it's used before depended modules are loaded. So lets wait for them ;)
