### PR TITLE
Fix variableInterpolation for PHP7

### DIFF
--- a/extensions/Maps/includes/Maps_Geocoders.php
+++ b/extensions/Maps/includes/Maps_Geocoders.php
@@ -316,8 +316,9 @@ final class MapsGeocoders {
 	protected static function getGeocoderInstance( $geocoderIdentifier ) {
 		if ( !array_key_exists( $geocoderIdentifier, self::$geocoders ) ) {
 			if ( array_key_exists( $geocoderIdentifier, self::$registeredGeocoders ) ) {
-				$geocoder = new self::$registeredGeocoders[$geocoderIdentifier]( $geocoderIdentifier );
-				
+				$className = self::$registeredGeocoders[$geocoderIdentifier];
+				$geocoder = new $className( $geocoderIdentifier );
+
 				//if ( $service instanceof iMappingService ) {
 					self::$geocoders[$geocoderIdentifier] = $geocoder;
 				//}

--- a/extensions/Maps/includes/Maps_Layers.php
+++ b/extensions/Maps/includes/Maps_Layers.php
@@ -45,7 +45,8 @@ class MapsLayers {
 		self::initializeLayers();
 		
 		if ( self::hasLayer( $type ) ) {
-			return new self::$classes[$type]( $properties );
+			$className = self::$classes[$type];
+			return new $className( $properties );
 		}
 		else {
 			throw new exception( "There is no layer class for layer of type $type." );

--- a/extensions/Maps/includes/Maps_MappingServices.php
+++ b/extensions/Maps/includes/Maps_MappingServices.php
@@ -89,7 +89,8 @@ final class MapsMappingServices {
 	public static function getServiceInstance( $serviceIdentifier ) {
 		if ( !array_key_exists( $serviceIdentifier, self::$services ) ) {
 			if ( array_key_exists( $serviceIdentifier, self::$registeredServices ) ) {
-				$service = new self::$registeredServices[$serviceIdentifier]( $serviceIdentifier );
+				$className = self::$registeredServices[$serviceIdentifier];
+				$service = new $className( $serviceIdentifier );
 				
 				if ( $service instanceof iMappingService ) {
 					self::$services[$serviceIdentifier] = $service;

--- a/extensions/SpamBlacklist/BaseBlacklist.php
+++ b/extensions/SpamBlacklist/BaseBlacklist.php
@@ -103,7 +103,8 @@ abstract class BaseBlacklist {
 				$wgBlacklistSettings[$type] = array();
 			}
 
-			self::$instances[$type] = new self::$blacklistTypes[$type]( $wgBlacklistSettings[$type] );
+			$className = self::$blacklistTypes[$type];
+			self::$instances[$type] = new $className( $wgBlacklistSettings[$type] );
 		}
 
 		return self::$instances[$type];

--- a/extensions/wikia/SemanticMediaWiki/includes/SMW_DataValueFactory.php
+++ b/extensions/wikia/SemanticMediaWiki/includes/SMW_DataValueFactory.php
@@ -94,7 +94,8 @@ class SMWDataValueFactory {
 		self::initDatatypes();
 
 		if ( array_key_exists( $typeId, self::$mTypeClasses ) ) {
-			$result = new self::$mTypeClasses[$typeId]( $typeId );
+			$className = self::$mTypeClasses[$typeId];
+			$result = new $className( $typeId );
 		} else {
 			return new SMWErrorValue( $typeId,
 				wfMessage( 'smw_unknowntype', $typeId )->inContentLanguage()->text(),


### PR DESCRIPTION
[`php7mar`](https://github.com/Alexia/php7mar) reported `variableInterpolation` in these places. Let's use a temporary variable to make code easier to read.
