### PR TITLE
ApiQueryUsers: kill a notice

### DIFF
--- a/includes/api/ApiQueryUsers.php
+++ b/includes/api/ApiQueryUsers.php
@@ -155,7 +155,7 @@ class ApiQueryUsers extends ApiQueryBase {
 				if ( isset( $this->prop['rights'] ) ) {
 					$data[$name]['rights'] = $user->getRights();
 				}
-				if ( $row->ipb_deleted ) {
+				if ( isset( $row->ipb_deleted ) /* Wikia change */ && $row->ipb_deleted ) {
 					$data[$name]['hidden'] = '';
 				}
 


### PR DESCRIPTION
[PLATFORM-2329](https://wikia-inc.atlassian.net/browse/PLATFORM-2329)

Kill a notice:

```
PHP Notice: Undefined property: stdClass::$ipb_deleted in /usr/wikia/source/app/includes/api/ApiQueryUsers.php on line 158
```

@wladekb 
