### PR TITLE
RECIRC-164: Map discussions cityId to alias WF variable if set

### DIFF
--- a/extensions/wikia/Recirculation/RecirculationHooks.class.php
+++ b/extensions/wikia/Recirculation/RecirculationHooks.class.php
@@ -86,6 +86,12 @@ class RecirculationHooks {
 	}
 
 	static public function canShowDiscussions( $cityId ) {
+		$discussionsAlias = WikiFactory::getVarValueByName( 'wgRecirculationDiscussionsAlias', $cityId );
+
+		if ( !empty( $discussionsAlias ) ) {
+			$cityId = $discussionsAlias;
+		}
+
 		$discussionsEnabled = WikiFactory::getVarValueByName( 'wgEnableDiscussions', $cityId );
 		$recirculationDiscussionsEnabled = WikiFactory::getVarValueByName( 'wgEnableRecirculationDiscussions', $cityId );
 

--- a/extensions/wikia/Recirculation/services/DiscussionsDataService.class.php
+++ b/extensions/wikia/Recirculation/services/DiscussionsDataService.class.php
@@ -11,7 +11,13 @@ class DiscussionsDataService {
 	private $cityId;
 
 	public function __construct( $cityId ) {
-		$this->cityId = $cityId;
+		$discussionsAlias = WikiFactory::getVarValueByName( 'wgRecirculationDiscussionsAlias', $cityId );
+
+		if ( !empty( $discussionsAlias ) ) {
+			$this->cityId = $discussionsAlias;
+		} else {
+			$this->cityId = $cityId;
+		}
 	}
 
 	public function getData() {


### PR DESCRIPTION
On some communities that don't have discussions enabled, we want to be able to configure other communities discussions to be shown in the Recirculation modules
