### PR TITLE
PLATFORM-2331: fix Lua errors

### DIFF
--- a/extensions/Scribunto/engines/LuaCommon/LuaCommon.php
+++ b/extensions/Scribunto/engines/LuaCommon/LuaCommon.php
@@ -58,8 +58,23 @@ abstract class Scribunto_LuaEngine extends ScribuntoEngineBase {
 		return new Scribunto_LuaModule( $this, $text, $chunkName );
 	}
 
+	/**
+	 * @param string $message
+	 * @param array $params
+	 * @return Scribunto_LuaError
+	 */
 	public function newLuaError( $message, $params = array() ) {
-		return new Scribunto_LuaError( $message, $this->getDefaultExceptionParams() + $params );
+		// Wikia change - begin
+		$ex = new Scribunto_LuaError( $message, $this->getDefaultExceptionParams() + $params );
+
+		Wikia\Logger\WikiaLogger::instance()->error( __METHOD__, [
+			'exception' => $ex,
+			'lua_message' => $ex->getLuaMessage(),
+			'lua_params' => $params,
+		] );
+		// Wikia change - end
+
+		return $ex;
 	}
 
 	public function destroy() {

--- a/extensions/Scribunto/engines/LuaCommon/SiteLibrary.php
+++ b/extensions/Scribunto/engines/LuaCommon/SiteLibrary.php
@@ -57,7 +57,7 @@ class Scribunto_LuaSiteLibrary extends Scribunto_LuaLibraryBase {
 
 			$aliases = array_merge( $wgNamespaceAliases, $wgContLang->getNamespaceAliases() );
 			foreach ( $aliases as $title => $ns ) {
-				if ( !isset( $namespacesByName[$title] ) ) {
+				if ( !isset( $namespacesByName[$title] ) && isset( $namespaces[$ns] ) ) {
 					$ct = count( $namespaces[$ns]['aliases'] );
 					$namespaces[$ns]['aliases'][$ct+1] = $title;
 					$namespacesByName[$title] = $ns;


### PR DESCRIPTION
[PLATFORM-2331](https://wikia-inc.atlassian.net/browse/PLATFORM-2331)
- log Lua errors to ELK with more context

``` json
{
"@message": "Scribunto_LuaEngine::newLuaError",
"@context": {
      "lua_message": "table index is nil",
      "lua_params": {
        "module": "mw.site.lua",
        "line": "33",
        "trace": [
          {
            "short_src": "(tail call)",
            "what": "tail",
            "currentline": -1,
            "namewhat": "",
            "linedefined": -1,
            "name": ""
          }
         ]
    }
}
```

This PR does not fix all cases, but let's start :)

@Grunny / @sactage 
