### PR TITLE
luastandalone: bump memory limit because of PLATFORM-2331

### DIFF
--- a/extensions/Scribunto/Scribunto.php
+++ b/extensions/Scribunto/Scribunto.php
@@ -146,7 +146,7 @@ $wgScribuntoEngineConf = array(
 
 		// The location of the Lua binary, or null to use the bundled binary.
 		'luaPath' => null,
-		'memoryLimit' => 50 * 1024 * 1024,
+		'memoryLimit' => 150 * 1024 * 1024,
 		'cpuLimit' => 7,
 		'allowEnvFuncs' => false,
 	),


### PR DESCRIPTION
`Lua error: not enough memory.` - 70% of all errors reported

@Grunny 
