### PR TITLE
luastandalone: bump memory limit because of PLATFORM-2331 - take two

### DIFF
--- a/extensions/Scribunto/Scribunto.php
+++ b/extensions/Scribunto/Scribunto.php
@@ -146,7 +146,7 @@ $wgScribuntoEngineConf = array(
 
 		// The location of the Lua binary, or null to use the bundled binary.
 		'luaPath' => null,
-		'memoryLimit' => 150 * 1024 * 1024,
+		'memoryLimit' => 250 * 1024 * 1024,
 		'cpuLimit' => 7,
 		'allowEnvFuncs' => false,
 	),


### PR DESCRIPTION
Bump to 250 MB - this is a followup of #10885

@Grunny 
