### PR TITLE
PLATFORM-2331: Expose PPFrame::getTitle to Lua

### DIFF
--- a/extensions/Scribunto/engines/LuaCommon/LuaCommon.php
+++ b/extensions/Scribunto/engines/LuaCommon/LuaCommon.php
@@ -106,6 +106,7 @@ abstract class Scribunto_LuaEngine extends ScribuntoEngineBase {
 			'expandTemplate',
 			'preprocess',
 			'incrementExpensiveFunctionCount',
+			'getFrameTitle',
 		);
 
 		$lib = array();
@@ -396,6 +397,14 @@ abstract class Scribunto_LuaEngine extends ScribuntoEngineBase {
 	function parentFrameExists() {
 		$frame = $this->getFrameById( 'parent' );
 		return array( $frame !== false );
+	}
+
+	/**
+	 * Handler for getTitle()
+	 */
+	function getFrameTitle( $frameId ) {
+		$frame = $this->getFrameById( $frameId );
+		return array( $frame->getTitle()->getPrefixedText() );
 	}
 
 	/**

--- a/extensions/Scribunto/engines/LuaCommon/lualib/mw.lua
+++ b/extensions/Scribunto/engines/LuaCommon/lualib/mw.lua
@@ -408,6 +408,11 @@ local function newFrame( frameId )
 			)
 	end
 
+	function frame:getTitle()
+		checkSelf( self, 'getTitle' )
+		return php.getFrameTitle( frameId )
+	end
+
 	-- For backwards compat
 	function frame:argumentPairs()
 		checkSelf( self, 'argumentPairs' )


### PR DESCRIPTION
This field already exists in PHP with exactly the content requested in
bug 47089, so we may as well expose it on the frame object.

Backporting https://github.com/wikimedia/mediawiki-extensions-Scribunto/commit/0763e2229279487bcfd6caefe9c427458fb0a8d5

Fixes the most common Lua error: `attempt to call method 'getTitle' (a nil value).`

``` lua
function cs1.citation(frame)
    local pframe = frame:getParent()
    local validation, utilities, identifiers, metadata;
```

``` lua
    if nil ~= string.find (frame:getTitle(), 'sandbox', 1, true) then           -- did the {{#invoke:}} use sandbox version?
            local parent = frame:getParent()
            if not parent then
                fargs = frame.args
            else
                local title = parent:getTitle():gsub('/sandbox$', '')
```

@Grunny 
