### PR TITLE
Lua backports from the upstream

### DIFF
--- a/extensions/Scribunto/engines/LuaCommon/UstringLibrary.php
+++ b/extensions/Scribunto/engines/LuaCommon/UstringLibrary.php
@@ -140,8 +140,11 @@ class Scribunto_LuaUstringLibrary extends Scribunto_LuaLibraryBase {
 		if ( $j < 0 ) {
 			$j = $l + $j + 1;
 		}
-		$i = max( 1, min( $i, $l ) );
-		$j = max( 1, min( $j, $l ) );
+		if ( $j < $i ) {
+			return array();
+		}
+		$i = max( 1, min( $i, $l + 1 ) );
+		$j = max( 1, min( $j, $l + 1 ) );
 		$s = mb_substr( $s, $i - 1, $j - $i + 1, 'UTF-8' );
 		return unpack( 'N*', mb_convert_encoding( $s, 'UTF-32BE', 'UTF-8' ) );
 	}
@@ -205,6 +208,9 @@ class Scribunto_LuaUstringLibrary extends Scribunto_LuaLibraryBase {
 		}
 		if ( $j < 0 ) {
 			$j = $len + $j + 1;
+		}
+		if ( $j < $i ) {
+			return array( '' );
 		}
 		$i = max( 1, min( $i, $len + 1 ) );
 		$j = max( 1, min( $j, $len + 1 ) );

--- a/extensions/Scribunto/engines/LuaCommon/UstringLibrary.php
+++ b/extensions/Scribunto/engines/LuaCommon/UstringLibrary.php
@@ -81,6 +81,9 @@ class Scribunto_LuaUstringLibrary extends Scribunto_LuaLibraryBase {
 	}
 
 	private function checkString( $name, $s, $checkEncoding = true ) {
+		if ( $this->getLuaType( $s ) == 'number' ) {
+			$s = (string)$s;
+		}
 		$this->checkType( $name, 1, $s, 'string' );
 		if ( $checkEncoding && !$this->checkEncoding( $s ) ) {
 			throw new Scribunto_LuaError( "bad argument #1 to '$name' (string is not UTF-8)" );
@@ -220,6 +223,9 @@ class Scribunto_LuaUstringLibrary extends Scribunto_LuaLibraryBase {
 	}
 
 	private function checkPattern( $name, $pattern ) {
+		if ( $this->getLuaType( $pattern ) == 'number' ) {
+			$pattern = (string)$pattern;
+		}
 		$this->checkType( $name, 2, $pattern, 'string' );
 		if ( !$this->checkEncoding( $pattern ) ) {
 			throw new Scribunto_LuaError( "bad argument #2 to '$name' (string is not UTF-8)" );
@@ -545,6 +551,7 @@ class Scribunto_LuaUstringLibrary extends Scribunto_LuaLibraryBase {
 
 		switch ( $this->getLuaType( $repl ) ) {
 		case 'string':
+		case 'number':
 			$cb = function ( $m ) use ( $repl, $anypos, &$captures ) {
 				if ( $anypos ) {
 					$m = array_shift( $captures );

--- a/extensions/Scribunto/engines/LuaCommon/UstringLibrary.php
+++ b/extensions/Scribunto/engines/LuaCommon/UstringLibrary.php
@@ -465,7 +465,11 @@ class Scribunto_LuaUstringLibrary extends Scribunto_LuaLibraryBase {
 
 		if ( $plain ) {
 			$ret = mb_strpos( $s, $pattern, 0, 'UTF-8' );
-			return array( ( $ret === false ) ? null : $ret + $init );
+			if ( $ret === false ) {
+				return array( null );
+			} else {
+				return array( $ret + $init, $ret + $init + mb_strlen( $pattern ) - 1 );
+			}
 		}
 
 		list( $re, $capt ) = $this->patternToRegex( $pattern );

--- a/extensions/Scribunto/engines/LuaCommon/lualib/ustring/ustring.lua
+++ b/extensions/Scribunto/engines/LuaCommon/lualib/ustring/ustring.lua
@@ -243,8 +243,11 @@ function ustring.codepoint( s, i, j )
 	if j < 0 then
 		j = cps.len + j + 1
 	end
-	i = math.max( 1, math.min( i, cps.len ) )
-	j = math.max( 1, math.min( j, cps.len ) )
+	if j < i then
+		return -- empty result set
+	end
+	i = math.max( 1, math.min( i, cps.len + 1 ) )
+	j = math.max( 1, math.min( j, cps.len + 1 ) )
 	return unpack( cps.codepoints, i, j )
 end
 
@@ -353,6 +356,9 @@ function ustring.sub( s, i, j )
 	j = j or -1
 	if j < 0 then
 		j = cps.len + j + 1
+	end
+	if j < i then
+		return ''
 	end
 	i = math.max( 1, math.min( i, cps.len + 1 ) )
 	j = math.max( 1, math.min( j, cps.len + 1 ) )

--- a/extensions/Scribunto/engines/LuaCommon/lualib/ustring/ustring.lua
+++ b/extensions/Scribunto/engines/LuaCommon/lualib/ustring/ustring.lua
@@ -15,8 +15,8 @@ local S = {
 
 ---- Configuration ----
 -- To limit the length of strings or patterns processed, set these
-ustring.maxStringLength = inf
-ustring.maxPatternLength = inf
+ustring.maxStringLength = math.huge
+ustring.maxPatternLength = math.huge
 
 ---- Utility functions ----
 
@@ -143,7 +143,7 @@ local function utf8_explode( s )
 		i = i + 1 + trail
 	end
 
-	-- One past the end
+	-- Two past the end (for sub with empty string)
 	ret.bytepos[#ret.bytepos + 1] = l + 1
 
 	return ret

--- a/extensions/Scribunto/engines/LuaCommon/lualib/ustring/ustring.lua
+++ b/extensions/Scribunto/engines/LuaCommon/lualib/ustring/ustring.lua
@@ -33,6 +33,9 @@ local function checkType( name, argidx, arg, expecttype, nilok )
 end
 
 local function checkString( name, s )
+    if type( s ) == 'number' then
+		s = tostring( s )
+	end
 	if type( s ) ~= 'string' then
 		local msg = S.format( "bad argument #1 to '%s' (string expected, got %s)",
 			name, type( s )
@@ -48,6 +51,9 @@ local function checkString( name, s )
 end
 
 local function checkPattern( name, pattern )
+    if type( pattern ) == 'number' then
+		pattern = tostring( pattern )
+	end
 	if type( pattern ) ~= 'string' then
 		local msg = S.format( "bad argument #2 to '%s' (string expected, got %s)",
 			name, type( pattern )
@@ -893,6 +899,9 @@ function ustring.gsub( s, pattern, repl, n )
 	elseif type( repl ) == 'table' then
 		tp = 2
 	elseif type( repl ) == 'string' then
+		tp = 3
+    elseif type( repl ) == 'number' then
+		repl = tostring( repl )
 		tp = 3
 	else
 		checkType( 'gsub', 3, repl, 'function or table or string' )

--- a/extensions/Scribunto/engines/LuaCommon/lualib/ustring/ustring.lua
+++ b/extensions/Scribunto/engines/LuaCommon/lualib/ustring/ustring.lua
@@ -33,7 +33,7 @@ local function checkType( name, argidx, arg, expecttype, nilok )
 end
 
 local function checkString( name, s )
-    if type( s ) == 'number' then
+	if type( s ) == 'number' then
 		s = tostring( s )
 	end
 	if type( s ) ~= 'string' then
@@ -51,7 +51,7 @@ local function checkString( name, s )
 end
 
 local function checkPattern( name, pattern )
-    if type( pattern ) == 'number' then
+	if type( pattern ) == 'number' then
 		pattern = tostring( pattern )
 	end
 	if type( pattern ) ~= 'string' then


### PR DESCRIPTION
[PLATFORM-2331](https://wikia-inc.atlassian.net/browse/PLATFORM-2331)

More backporting from Scribuntu upstream.

Fixes

```
Błąd Lua w module „ustring.lua”, w linii 325: attempt to perform arithmetic on field '?' (a nil value).
Backtrace:
(tail call): ?
ustring.lua:325: ?
(tail call): ?
mw.text.lua:225: in function "(for generator)"
mw.text.lua:212: in function "split"
Module:Disassemble:255: in function "func"
Module:Infobox:833: in function "cleanParams"
Module:Disassemble:43: in function "chunk"
mw.lua:430: in function "chunk"
(tail call): ?
[C]: in function "xpcall"
MWServer.lua:73: in function "handleCall"
MWServer.lua:266: in function "dispatch"
MWServer.lua:33: in function "execute"
mw_main.lua:7: in main chunk
[C]: ?
```

@Grunny 
