### PR TITLE
(SEC-71) Fix support for PHP's taint extension

### DIFF
--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -61,20 +61,15 @@ if( !function_exists( 'mb_strrpos' ) ) {
 
 
 // Support for Wietse Venema's taint feature
-if ( !function_exists( 'istainted' ) ) {
+if ( !function_exists( 'is_tainted' ) ) {
 	/** @codeCoverageIgnore */
-	function istainted( $var ) {
-		return 0;
+	function is_tainted( $var ) {
+		return false;
 	}
 	/** @codeCoverageIgnore */
 	function taint( $var, $level = 0 ) {}
 	/** @codeCoverageIgnore */
 	function untaint( $var, $level = 0 ) {}
-	define( 'TC_HTML', 1 );
-	define( 'TC_SHELL', 1 );
-	define( 'TC_MYSQL', 1 );
-	define( 'TC_PCRE', 1 );
-	define( 'TC_SELF', 1 );
 }
 
 /** Wikia change begin - backport hash_equals from MW 1.24 **/
@@ -297,7 +292,7 @@ function wfObjectToArray( $objOrArray, $recursive = true ) {
 function wfArrayMap( $function, $input ) {
 	$ret = array_map( $function, $input );
 	foreach ( $ret as $key => $value ) {
-		$taint = istainted( $input[$key] );
+		$taint = is_tainted( $input[$key] );
 		if ( $taint ) {
 			taint( $ret[$key], $taint );
 		}

--- a/includes/db/Database.php
+++ b/includes/db/Database.php
@@ -970,7 +970,7 @@ abstract class DatabaseBase implements DatabaseType {
 			wfDebug( "Query {$this->mDBname} (DB user: {$DBuser}) ($cnt) ($master): $sqlx\n" );
 		}
 
-		if ( istainted( $sql ) & TC_MYSQL ) {
+		if ( is_tainted( $sql ) ) {
 			throw new MWException( 'Tainted query found' );
 		}
 

--- a/includes/wikia/nirvana/WikiaRequest.class.php
+++ b/includes/wikia/nirvana/WikiaRequest.class.php
@@ -59,6 +59,7 @@ class WikiaRequest implements Wikia\Interfaces\IRequest {
 			return $this->params[$key];
 		}
 
+		taint( $default );
 		return $default;
 	}
 
@@ -273,7 +274,7 @@ class WikiaRequest implements Wikia\Interfaces\IRequest {
 	public function setSessionData( $key, $data ) {
 		$_SESSION[$key] = $data;
 	}
-	
+
 	/*
 	 * Get data from $_SERVER['SCRIPT_URL'], which is original path of the request, before mod_rewrite changed it.
 	 * Please be aware how our URL rewrites work before you think about using this.


### PR DESCRIPTION
MediaWiki had some experimental support for the initial taint feature
proposal, which isn't compatible with the newer PHP extension for this
purpose. This fixes the support so there aren't conflicts and makes
WikiaRequest match WebRequest in tainting default values when the
extension is enabled.

/cc @macbre @wladekb 
