### PR TITLE
added  parameter in callApi function SER-343

### DIFF
--- a/lib/Wikia/src/Service/Swagger/ApiClient.php
+++ b/lib/Wikia/src/Service/Swagger/ApiClient.php
@@ -24,7 +24,7 @@ class ApiClient extends \Swagger\Client\ApiClient {
 		$this->serviceName = $serviceName;
 	}
 
-	public function callApi($resourcePath, $method, $queryParams, $postData, $headerParams, $responseType=null) {
+	public function callApi($resourcePath, $method, $queryParams, $postData, $headerParams, $responseType=null, $endpointPath=null) {
 		$start = microtime(true);
 		$response = $exception = null;
 		$code = 200;
@@ -33,7 +33,7 @@ class ApiClient extends \Swagger\Client\ApiClient {
 		WikiaTracer::instance()->setRequestHeaders( $headerParams, true );
 
 		try {
-			$response = parent::callApi($resourcePath, $method, $queryParams, $postData, $headerParams, $responseType);
+			$response = parent::callApi($resourcePath, $method, $queryParams, $postData, $headerParams, $responseType, $endpointPath);
 		} catch (ApiException $e) {
 			$exception = $e;
 			$code = $e->getCode();


### PR DESCRIPTION
Added  parameter in callApi function (it was added only in overridden method). Another solution is to remove $endpointPath parameter from parent method (it's unused), but it was added 19 days ago, so I suppose it'll be used it the future.  
