### PR TITLE
PLATFORM-2273: simplify/refactor comscore category override code

### DIFF
--- a/extensions/wikia/AnalyticsEngine/AnalyticsProviderComscore.php
+++ b/extensions/wikia/AnalyticsEngine/AnalyticsProviderComscore.php
@@ -1,7 +1,7 @@
 <?php
 
 class AnalyticsProviderComscore implements iAnalyticsProvider {
-	
+
 	private static $COMSCORE_KEYWORD_KEYNAME = 'comscorekw';
 	private static $PARTNER_ID = 6177433;
 
@@ -43,6 +43,12 @@ class AnalyticsProviderComscore implements iAnalyticsProvider {
 		global $wgCityId;
 
 		$verticalName = HubService::getVerticalNameForComscore( $wgCityId );
+
+		$categoryOverride = HubService::getComscoreCategoryOverride( $wgCityId );
+		if ( $categoryOverride ) {
+			$verticalName = $categoryOverride['short'];
+		}
+
 		if ( !$verticalName ) {
 			\Wikia\Logger\WikiaLogger::instance()->error( 'Vertical not set for comscore', [
 				'cityId' => $wgCityId,
@@ -56,7 +62,7 @@ class AnalyticsProviderComscore implements iAnalyticsProvider {
 
 	private function getC7ParamAndValue() {
 		global $wgRequest;
-		
+
 		$requestUrl = $wgRequest->getFullRequestURL();
 		$c7Value = $this->getC7Value();
 		if ($c7Value) {

--- a/includes/wikia/services/HubService.class.php
+++ b/includes/wikia/services/HubService.class.php
@@ -64,31 +64,22 @@ class HubService extends Service {
 	}
 
 	/**
-	 * Get canonical (legacy) vertical name for given cityId.
-	 * For corporate homepages (actual and hub-based) return 'fandom'.
-	 * For Lifestyle and Gaming return their names.
+	 * Get comscore vertical name for given cityId.
+	 * For Lifestyle and Gaming and etc return their names.
 	 * For Other return 'lifestyle'.
-	 * For rest of values return Entertainment.
 	 *
 	 * @param integer $cityId
 	 *
 	 * @return string
 	 */
 	public static function getVerticalNameForComscore( $cityId ) {
-		global $wgDisableWAMOnHubs;
 
-		if ( WikiaPageType::isWikiaHomePage() || WikiaPageType::isWikiaHub() && $wgDisableWAMOnHubs ) {
-			return 'fandom';
-		}
+		$vertical = WikiFactoryHub::getInstance()->getWikiVertical( $cityId )['short'];
 
-		switch ( WikiFactoryHub::getInstance()->getVerticalId( $cityId ) ) {
-			case WikiFactoryHub::VERTICAL_ID_VIDEO_GAMES:
-				return 'gaming';
-			case WikiFactoryHub::VERTICAL_ID_LIFESTYLE:
-			case WikiFactoryHub::VERTICAL_ID_OTHER:
-				return 'lifestyle';
-			default:
-				return 'entertainment';
+		if ( $vertical == "other" ) {
+			return "lifestyle";
+		} else {
+			return $vertical;
 		}
 	}
 

--- a/includes/wikia/services/tests/HubServiceTest.php
+++ b/includes/wikia/services/tests/HubServiceTest.php
@@ -4,23 +4,13 @@ class HubServiceTest extends WikiaBaseTest {
 
 	/**
 	 * @dataProvider getVerticalNameForComscoreDataProvider
-	 * @param boolean $wgDisableWAMOnHubsMock
-	 * @param boolean $isWikiaHomePageValueMock
-	 * @param boolean $isWikiaHubValueMock
 	 * @param integer $verticalIdMock
 	 * @param string $expectedVerticalName
 	 */
 	public function testGetVerticalNameForComscore(
-		$isWikiaHomePageValueMock,
-		$isWikiaHubValueMock,
-		$wgDisableWAMOnHubsMock,
 		$verticalIdMock,
 		$expectedVerticalName
 	) {
-		$this->mockGlobalVariable( 'wgDisableWAMOnHubs', $wgDisableWAMOnHubsMock );
-
-		$this->mockStaticMethod( 'WikiaPageType', 'isWikiaHomePage', $isWikiaHomePageValueMock );
-		$this->mockStaticMethod( 'WikiaPageType', 'isWikiaHub', $isWikiaHubValueMock );
 
 		$wikiFactoryHubMock = $this->getMock( 'WikiFactoryHub', [ 'getVerticalId' ] );
 
@@ -35,59 +25,13 @@ class HubServiceTest extends WikiaBaseTest {
 
 	public function getVerticalNameForComscoreDataProvider() {
 		return [
-			// actual corporate hompages
-			'actual corporate hompage — e.g. www.wikia.com (on 2015-11-26)' =>
-				[ true, false, false, WikiFactoryHub::VERTICAL_ID_LIFESTYLE, 'fandom' ],
-			'actual corporate hompage — e.g. pl.wikia.com' =>
-				[ true, false, false, WikiFactoryHub::VERTICAL_ID_OTHER, 'fandom' ],
 
-			// hypothetical cases
-			'actual cororate hompage — hypothetical case, vertical: books' =>
-				[ true, true, true, WikiFactoryHub::VERTICAL_ID_BOOKS, 'fandom' ],
-			'actual cororate hompage — hypothetical case, vertical: comics' =>
-				[ true, false, true, WikiFactoryHub::VERTICAL_ID_COMICS, 'fandom' ],
-			'actual cororate hompage — hypothetical case, vertical: movies' =>
-				[ true, true, false, WikiFactoryHub::VERTICAL_ID_MOVIES, 'fandom' ],
+			// special business rules for vertical->comscore mapping
+			'comscore mapping — vertical: lifestyle' =>
+				[ WikiFactoryHub::VERTICAL_ID_LIFESTYLE, 'lifestyle' ],
+			'comscore mapping — vertical: other' =>
+				[ WikiFactoryHub::VERTICAL_ID_OTHER, 'lifestyle' ],
 
-			// hub-based corporate homepages
-			'hub-based corporate homepage — e.g. pt-br.wikia.com' =>
-				[ false, true, true, WikiFactoryHub::VERTICAL_ID_OTHER, 'fandom' ],
-
-			// hub-based corporate homepages — hypothetical case
-			'hub-based corporate homepage — hypothetical case' =>
-				[ false, true, true, WikiFactoryHub::VERTICAL_ID_LIFESTYLE, 'fandom' ],
-
-			// corporate hubs
-			'corporate hub — e.g. gryhub.wikia.com' =>
-				[ false, true, false, WikiFactoryHub::VERTICAL_ID_VIDEO_GAMES, 'gaming' ],
-			'corporate hub — e.g. lifestylehub.wikia.com' =>
-				[ false, true, false, WikiFactoryHub::VERTICAL_ID_LIFESTYLE, 'lifestyle' ],
-			'corporate hub — e.g. tvhub.wikia.com' =>
-				[ false, true, false, WikiFactoryHub::VERTICAL_ID_TV, 'entertainment' ],
-
-			// corporate hubs — hypothetical case
-			'corporate hub — hypothetical case' =>
-				[ false, true, false, WikiFactoryHub::VERTICAL_ID_OTHER, 'lifestyle' ],
-
-			// usual wiki(a)s
-			'usual wiki(a) — vertical: games' =>
-				[ false, false, false, WikiFactoryHub::VERTICAL_ID_VIDEO_GAMES, 'gaming' ],
-			'usual wiki(a) — vertical: lifestyle' =>
-				[ false, false, false, WikiFactoryHub::VERTICAL_ID_LIFESTYLE, 'lifestyle' ],
-			'usual wiki(a) — vertical: other' =>
-				[ false, false, false, WikiFactoryHub::VERTICAL_ID_OTHER, 'lifestyle' ],
-			'usual wiki(a) — vertical: music' =>
-				[ false, false, false, WikiFactoryHub::VERTICAL_ID_MUSIC, 'entertainment' ],
-
-			// usual wiki(a)s — hypothetical cases
-			'usual wiki(a) — hypothetical case, vertical: games' =>
-				[ false, false, true, WikiFactoryHub::VERTICAL_ID_VIDEO_GAMES, 'gaming' ],
-			'usual wiki(a) — hypothetical case, vertical: lifestyle' =>
-				[ false, false, true, WikiFactoryHub::VERTICAL_ID_LIFESTYLE, 'lifestyle' ],
-			'usual wiki(a) — hypothetical case, vertical: other' =>
-				[ false, false, true, WikiFactoryHub::VERTICAL_ID_OTHER, 'lifestyle' ],
-			'usual wiki(a) — hypothetical case, vertical: music' =>
-				[ false, false, true, WikiFactoryHub::VERTICAL_ID_MUSIC, 'entertainment' ],
 		];
 	}
 }


### PR DESCRIPTION
Original comscore categories used the "old" 3 major hubs (gaming/entertainment/lifestyle).  Now we are using the "new" vertical in comscore, only mapping "other" to lifestyle.

There was some override code which allowed a Tag to change the comscore category but it was inside a private method of the HubService class and it wasn't used for this vertical->category mapping, only for the legacy category->category mapping.   I refactored this code to make it a little more obvious and now it is called in both places.  
