### PR TITLE
MWExceptionHandler: log MW exceptions to ELK

### DIFF
--- a/includes/Exception.php
+++ b/includes/Exception.php
@@ -557,6 +557,13 @@ class MWExceptionHandler {
 		$cmdLine = MWException::isCommandLine();
 
 		if ( $e instanceof MWException ) {
+			# Wikia change - begin
+			# report MediawWiki exceptions to ELK
+			Wikia\Logger\WikiaLogger::instance()->error( __METHOD__ . ' - MediaWiki exception encountered', [
+				'exception' => $e,
+			] );
+			# Wikia change - end
+
 			try {
 				// Try and show the exception prettily, with the normal skin infrastructure
 				$e->report();


### PR DESCRIPTION
Preview returns HTTP 500 and Kibanna shows the following:

```
MediaWiki internal error.

Exception caught inside exception handler.

Set $wgShowExceptionDetails = true; at the bottom of LocalSettings.php to show detailed debugging information.
```

We need more context here - log the exception

@ludwikkazmierczak / @Grunny 
