### PR TITLE
RECIRC-189: Switch to using wfShortenText for better multibyte support

### DIFF
--- a/extensions/wikia/Recirculation/js/discussions.js
+++ b/extensions/wikia/Recirculation/js/discussions.js
@@ -38,7 +38,7 @@ require([
 
 			$('.discussion-thread').click(function () {
 				var slot = $(this).index() + 1,
-					label = 'discussions-tile=slot-' + slot;
+					label = 'discussions-tile=slot-' + slot + '=discussions';
 				tracker.trackVerboseClick(experimentName, label);
 				window.location = $(this).data('link');
 			});

--- a/extensions/wikia/Recirculation/services/DiscussionsDataService.class.php
+++ b/extensions/wikia/Recirculation/services/DiscussionsDataService.class.php
@@ -89,7 +89,7 @@ class DiscussionsDataService {
 		$post = [];
 		$post['author'] = $rawPost['createdBy']['name'];
 		$post['authorAvatar'] = $rawPost['createdBy']['avatarUrl'];
-		$post['content'] = $wgContLang->truncate($rawPost['_embedded']['firstPost'][0]['rawContent'], 120);
+		$post['content'] = wfShortenText($rawPost['_embedded']['firstPost'][0]['rawContent'], 120);
 		$post['upvoteCount'] = $rawPost['upvoteCount'];
 		$post['commentCount'] = $rawPost['postCount'];
 		$post['createdAt'] = wfTimestamp( TS_ISO_8601, $rawPost['creationDate']['epochSecond'] );


### PR DESCRIPTION
[RECIRC-189](https://wikia-inc.atlassian.net/browse/RECIRC-189)
Multibyte characters are getting corrupted when attempting to truncate them. Fix the issue by switching to wfShortenText which has better multibyte character support.
