### PR TITLE
SOC-1408 use batches for migration script

### DIFF
--- a/lib/Wikia/src/Service/User/Attributes/maintenance/cleanupMigratedAttributes.php
+++ b/lib/Wikia/src/Service/User/Attributes/maintenance/cleanupMigratedAttributes.php
@@ -73,7 +73,6 @@ class CleanupMigratedAttributes extends Maintenance {
                 ->run( $db );
 
             $rowsRemaining = $db->affectedRows() > 0;
-            $db->commit();
 
             sleep( 2 );
         }


### PR DESCRIPTION
As I was preparing to use the migration script which cleans up old values from the `wikicities.user_properties` table, I realized the original approach didn't scale with the amount of data we have in production. I decided to update the script to run in batches and only delete one attribute at a time, rather than trying to do all at once. I also added a sleep between each delete cycle to reduce the amount of replication lag. See [this SO post](http://stackoverflow.com/questions/1318972/deleting-millions-of-rows-in-mysql#answer-1318975).

Can you take another look @armonr?

Also, /cc @drozdo and @frankfarmer. Please let me know if either of you foresee any problems with this new approach. Here's the original PR for additional context: https://github.com/Wikia/app/pull/10875
