### PR TITLE
SUS-760: Add only valid images to image review queue

### DIFF
--- a/extensions/wikia/ImageReview/ImageReviewImageStatus.php
+++ b/extensions/wikia/ImageReview/ImageReviewImageStatus.php
@@ -59,7 +59,7 @@ function efImageReviewDisplayStatus( ImagePage $imagePage, &$html ) {
 			if ( $file instanceof WikiaLocalFile && $lastTouched < $now->modify( '-1 hour' ) ) {
 				$scribeEventProducer = new ScribeEventProducer( 'edit' );
 				$user = User::newFromName( $file->getUser() );
-				if ( $scribeEventProducer->buildEditPackage( $imagePage, $user, null, null, $file ) ) {
+				if ( $scribeEventProducer->buildEditPackage( $imagePage, $user, null, $file ) ) {
 					$logParams = [
 						'cityId' => $wgCityId,
 						'pageId' => $imagePage->getID(),

--- a/extensions/wikia/ImageReview/ImageReviewTask.class.php
+++ b/extensions/wikia/ImageReview/ImageReviewTask.class.php
@@ -10,6 +10,7 @@ namespace Wikia\Tasks\Tasks;
 use \Wikia\Logger\WikiaLogger;
 
 class ImageReviewTask extends BaseTask {
+
 	public function delete( $pageList, $suppress = false ) {
 		global $IP;
 

--- a/extensions/wikia/Scribe/ScribeEventProducer.class.php
+++ b/extensions/wikia/Scribe/ScribeEventProducer.class.php
@@ -109,7 +109,10 @@ class ScribeEventProducer {
 		$this->setMediaLinks( $oPage );
 		$this->setTotalWords( str_word_count( $rev_text ) );
 
-		if ( $oLocalFile instanceof File ) {
+		if ( $bIsNewWiki && $oTitle->getNamespace() === NS_FILE ) {
+			$this->setImageApproved( true );
+			$this->setIsImageForReview( true );
+		} elseif ( $oLocalFile instanceof File ) {
 			$this->setMediaType( $oLocalFile );
 			$this->setIsImageForReview( ImagesService::isLocalImage( $oTitle ) );
 			if ( $bIsNewWiki ) {
@@ -401,8 +404,8 @@ class ScribeEventProducer {
 	 * @param  string $sLogMessage  A log message
 	 * @return void
 	 */
-	private function log() {
-		WikiaLogger::instance()->info( 'ImageReviewLog', [
+	private function logSendScribeMessage() {
+		WikiaLogger::instance()->info( 'SendScribeMessage', [
 			'method' => __METHOD__,
 			'params' => $this->mParams,
 		] );
@@ -413,7 +416,7 @@ class ScribeEventProducer {
 		try {
 			$data = json_encode($this->mParams);
 			WScribeClient::singleton( $this->mKey )->send( $data );
-			$this->log();
+			$this->logSendScribeMessage();
 		}
 		catch( TException $e ) {
 			Wikia::log( __METHOD__, 'scribeClient exception', $e->getMessage() );

--- a/extensions/wikia/Scribe/ScribeEventProducer.class.php
+++ b/extensions/wikia/Scribe/ScribeEventProducer.class.php
@@ -49,7 +49,7 @@ class ScribeEventProducer {
 		$this->setCategory();
 	}
 
-	public function buildEditPackage( $oPage, $oUser, $oRevision = null, $oLocalFile = null, $bIsNewWiki = false ) {
+	public function buildEditPackage( $oPage, $oUser, $oRevision = null, $oLocalFile = null ) {
 		wfProfileIn( __METHOD__ );
 
 		if ( !is_object( $oPage ) ) {
@@ -109,10 +109,7 @@ class ScribeEventProducer {
 		$this->setMediaLinks( $oPage );
 		$this->setTotalWords( str_word_count( $rev_text ) );
 
-		if ( $bIsNewWiki && $oTitle->getNamespace() === NS_FILE ) {
-			$this->setImageApproved( true );
-			$this->setIsImageForReview( true );
-		} elseif ( $oLocalFile instanceof File ) {
+		if ( $oLocalFile instanceof File ) {
 			$this->setMediaType( $oLocalFile );
 			$this->setIsImageForReview( ImagesService::isLocalImage( $oTitle ) );
 		} else {

--- a/extensions/wikia/Scribe/ScribeEventProducer.class.php
+++ b/extensions/wikia/Scribe/ScribeEventProducer.class.php
@@ -115,9 +115,6 @@ class ScribeEventProducer {
 		} elseif ( $oLocalFile instanceof File ) {
 			$this->setMediaType( $oLocalFile );
 			$this->setIsImageForReview( ImagesService::isLocalImage( $oTitle ) );
-			if ( $bIsNewWiki ) {
-				$this->setImageApproved( true );
-			}
 		} else {
 			$this->setIsImageForReview( false );
 		}

--- a/extensions/wikia/Scribe/ScribeEventProducer.class.php
+++ b/extensions/wikia/Scribe/ScribeEventProducer.class.php
@@ -7,33 +7,33 @@ class ScribeEventProducer {
 	private $mParams, $mKey, $mEventType;
 
 	const
-		EDIT_CATEGORY 		    = 'log_edit',
-		CREATEPAGE_CATEGORY		= 'log_create',
-		UNDELETE_CATEGORY	    = 'log_undelete',
-		DELETE_CATEGORY		    = 'log_delete';
+		EDIT_CATEGORY       = 'log_edit',
+		CREATEPAGE_CATEGORY = 'log_create',
+		UNDELETE_CATEGORY   = 'log_undelete',
+		DELETE_CATEGORY     = 'log_delete';
 
 	const
-		EDIT_CATEGORY_INT			= 1,
-		CREATEPAGE_CATEGORY_INT		= 2,
-		DELETE_CATEGORY_INT			= 3,
-		UNDELETE_CATEGORY_INT		= 4;
+		EDIT_CATEGORY_INT       = 1,
+		CREATEPAGE_CATEGORY_INT = 2,
+		DELETE_CATEGORY_INT     = 3,
+		UNDELETE_CATEGORY_INT   = 4;
 
 	function __construct( $key, $archive = 0 ) {
 		$this->app = F::app();
 		switch ( $key ) {
-			case 'edit' 		:
+			case 'edit':
 				$this->mKey = self::EDIT_CATEGORY;
 				$this->mEventType = self::EDIT_CATEGORY_INT;
 				break;
-			case 'create' 		:
+			case 'create':
 				$this->mKey = self::CREATEPAGE_CATEGORY;
 				$this->mEventType = self::CREATEPAGE_CATEGORY_INT;
 				break;
-			case 'delete' 		:
+			case 'delete':
 				$this->mKey = self::DELETE_CATEGORY;
 				$this->mEventType = self::DELETE_CATEGORY_INT;
 				break;
-			case 'undelete'		:
+			case 'undelete':
 				$this->mKey = self::UNDELETE_CATEGORY;
 				$this->mEventType = self::UNDELETE_CATEGORY_INT;
 				break;
@@ -329,16 +329,16 @@ class ScribeEventProducer {
 			$mediaType = $oLocalFile->getMediaType();
 
 			switch ( $mediaType ) {
-				case MEDIATYPE_BITMAP		: $mediaTypeCode = 1; break;
-				case MEDIATYPE_DRAWING		: $mediaTypeCode = 2; break;
-				case MEDIATYPE_AUDIO		: $mediaTypeCode = 3; break;
-				case MEDIATYPE_VIDEO		: $mediaTypeCode = 4; break;
-				case MEDIATYPE_MULTIMEDIA	: $mediaTypeCode = 5; break;
-				case MEDIATYPE_OFFICE		: $mediaTypeCode = 6; break;
-				case MEDIATYPE_TEXT			: $mediaTypeCode = 7; break;
-				case MEDIATYPE_EXECUTABLE	: $mediaTypeCode = 8; break;
-				case MEDIATYPE_ARCHIVE		: $mediaTypeCode = 9; break;
-				default 					: $mediaTypeCode = 1; break;
+				case MEDIATYPE_BITMAP:     $mediaTypeCode = 1; break;
+				case MEDIATYPE_DRAWING:    $mediaTypeCode = 2; break;
+				case MEDIATYPE_AUDIO:      $mediaTypeCode = 3; break;
+				case MEDIATYPE_VIDEO:      $mediaTypeCode = 4; break;
+				case MEDIATYPE_MULTIMEDIA: $mediaTypeCode = 5; break;
+				case MEDIATYPE_OFFICE:     $mediaTypeCode = 6; break;
+				case MEDIATYPE_TEXT:       $mediaTypeCode = 7; break;
+				case MEDIATYPE_EXECUTABLE: $mediaTypeCode = 8; break;
+				case MEDIATYPE_ARCHIVE:    $mediaTypeCode = 9; break;
+				default:                   $mediaTypeCode = 1; break;
 			}
 		}
 

--- a/extensions/wikia/Scribe/ScribeEventProducerController.class.php
+++ b/extensions/wikia/Scribe/ScribeEventProducerController.class.php
@@ -23,7 +23,7 @@ class ScribeEventProducerController {
 		$oLocalFile = $oForm->getLocalFile();
 
 		$oScribeProducer = new ScribeEventProducer( 'edit' );
-		if ( $oScribeProducer->buildEditPackage( self::$oPage, self::$oUser, self::$oRevision, null, $oLocalFile ) ) {
+		if ( $oScribeProducer->buildEditPackage( self::$oPage, self::$oUser, self::$oRevision, $oLocalFile ) ) {
 			$oScribeProducer->sendLog();
 		}
 
@@ -77,7 +77,7 @@ class ScribeEventProducerController {
 					self::$oRevision = $oRevision;
 				}
 
-				if ( $oScribeProducer->buildEditPackage( $oPage, $oUser, $oRevision, $revision_id ) ) {
+				if ( $oScribeProducer->buildEditPackage( $oPage, $oUser, $oRevision ) ) {
 					$oScribeProducer->sendLog();
 				}
 			}

--- a/includes/wikia/services/ImagesService.class.php
+++ b/includes/wikia/services/ImagesService.class.php
@@ -462,4 +462,29 @@ class ImagesService extends Service {
 			'errors' => $errors,
 		);
 	}
+
+	/**
+	 * Check if given title is a local image
+	 *
+	 * @param Title $title
+	 * @return bool
+	 */
+	public static function isLocalImage( Title $title ) {
+		$allowedTypes = [
+			MEDIATYPE_BITMAP,
+			MEDIATYPE_DRAWING,
+		];
+
+		$localFile = RepoGroup::singleton()->getLocalRepo()->newFile( $title );
+
+		if ( $title->inNamespaces( NS_IMAGE, NS_FILE )
+			&& in_array( $localFile->getMediaType(), $allowedTypes )
+			&& !$title->isRedirect()
+			&& $localFile instanceof LocalFile
+			&& $localFile->exists()
+		) {
+			return true;
+		}
+		return false;
+	}
 }

--- a/includes/wikia/tasks/Tasks/CreateNewWikiTask.class.php
+++ b/includes/wikia/tasks/Tasks/CreateNewWikiTask.class.php
@@ -447,10 +447,11 @@ class CreateNewWikiTask extends BaseTask {
 						$key = ( isset( $pages[ $row->page_id ] ) ) ? 'edit' : 'create';
 						$scribeProducer = new \ScribeEventProducer( $key, 0 );
 						if ( is_object( $scribeProducer ) ) {
-							if ( $scribeProducer->buildEditPackage( $article, $user, $revision, null, true ) ) {
+							if ( $scribeProducer->buildEditPackage( $article, $user, $revision ) ) {
 								// SUS-760 Autoapprove all images (creations and edits) while creating a wiki.
 								if ( $article->getTitle()->getNamespace() == NS_FILE ) {
 									$scribeProducer->setImageApproved( true );
+									$scribeProducer->setIsImageForReview( true );
 								}
 								$scribeProducer->sendLog();
 							}

--- a/includes/wikia/tasks/Tasks/CreateNewWikiTask.class.php
+++ b/includes/wikia/tasks/Tasks/CreateNewWikiTask.class.php
@@ -448,6 +448,10 @@ class CreateNewWikiTask extends BaseTask {
 						$scribeProducer = new \ScribeEventProducer( $key, 0 );
 						if ( is_object( $scribeProducer ) ) {
 							if ( $scribeProducer->buildEditPackage( $article, $user, $revision, null, true ) ) {
+								// SUS-760 Autoapprove all images (creations and edits) while creating a wiki.
+								if ( $article->getTitle()->getNamespace() == NS_FILE ) {
+									$scribeProducer->setImageApproved( true );
+								}
 								$scribeProducer->sendLog();
 							}
 						}

--- a/includes/wikia/tasks/Tasks/CreateNewWikiTask.class.php
+++ b/includes/wikia/tasks/Tasks/CreateNewWikiTask.class.php
@@ -448,10 +448,9 @@ class CreateNewWikiTask extends BaseTask {
 						$scribeProducer = new \ScribeEventProducer( $key, 0 );
 						if ( is_object( $scribeProducer ) ) {
 							if ( $scribeProducer->buildEditPackage( $article, $user, $revision ) ) {
-								// SUS-760 Autoapprove all images (creations and edits) while creating a wiki.
-								if ( $article->getTitle()->getNamespace() == NS_FILE ) {
-									$scribeProducer->setImageApproved( true );
-									$scribeProducer->setIsImageForReview( true );
+								// SUS-760 Do not send images images (creations and edits) for review while creating a wiki.
+								if ( $article->getTitle()->inNamespaces( NS_FILE, NS_IMAGE ) ) {
+									$scribeProducer->setIsImageForReview( false );
 								}
 								$scribeProducer->sendLog();
 							}

--- a/includes/wikia/tasks/Tasks/CreateNewWikiTask.class.php
+++ b/includes/wikia/tasks/Tasks/CreateNewWikiTask.class.php
@@ -447,7 +447,7 @@ class CreateNewWikiTask extends BaseTask {
 						$key = ( isset( $pages[ $row->page_id ] ) ) ? 'edit' : 'create';
 						$scribeProducer = new \ScribeEventProducer( $key, 0 );
 						if ( is_object( $scribeProducer ) ) {
-							if ( $scribeProducer->buildEditPackage( $article, $user, $revision ) ) {
+							if ( $scribeProducer->buildEditPackage( $article, $user, $revision, null, true ) ) {
 								$scribeProducer->sendLog();
 							}
 						}

--- a/maintenance/wikia/updateImageReview.php
+++ b/maintenance/wikia/updateImageReview.php
@@ -168,20 +168,20 @@ class UpdateImageReview extends Maintenance {
 	private function updateDatawareFile( $dbw, $top200, $localFile, $imageReviewFile ) {
 		global $wgCityId;
 
-		$action = $imageReviewFile ? "Updating image_review:" : "Adding to image_review:";
-		$this->output( "{$action} {$localFile->page_textual_title}...\n" );
-
-		if ( $this->debug ) {
-			$this->output( "  * local file: " . json_encode( $localFile ) . "\n" );
-			$this->output( "  * image_review: " . json_encode( $imageReviewFile ) . "\n" );
-		}
-
 		if ( $this->dryRun ) {
 			return;
 		}
 
 		$title = Title::newFromID( $localFile->page_id );
 		if ( ImagesService::isLocalImage( $title ) ) {
+			$action = $imageReviewFile ? "Updating image_review:" : "Adding to image_review:";
+			$this->output( "{$action} {$localFile->page_textual_title}...\n" );
+
+			if ( $this->debug ) {
+				$this->output( "  * local file: " . json_encode( $localFile ) . "\n" );
+				$this->output( "  * image_review: " . json_encode( $imageReviewFile ) . "\n" );
+			}
+
 			$dbw->replace(
 				'image_review',
 				[
@@ -198,6 +198,12 @@ class UpdateImageReview extends Maintenance {
 				],
 				__METHOD__
 			);
+
+			\Wikia\Logger\WikiaLogger::instance()->info( 'Add image to review queue', [
+				'method' => __METHOD__,
+				'wiki_id' => $wgCityId,
+				'page_id' => $localFile->page_id
+			] );
 
 			return true;
 		}


### PR DESCRIPTION
We are excluding from image review queue pages from File namespace (NS_FILE):
- from newly created wiki
- which are not images
- which don't exists
- which are redirects

@harnash @mixth-sense @wladekb 
