### PR TITLE
SOC-2716 use is_numeric rather than is_int

### DIFF
--- a/extensions/wikia/Email/Controller/CategoryAddController.class.php
+++ b/extensions/wikia/Email/Controller/CategoryAddController.class.php
@@ -85,7 +85,7 @@ class CategoryAddController extends EmailController {
 	private function incrementEmailsSentCount() {
 		global $wgMemc;
 		$emailsSent = $wgMemc->get( $this->getTargetUserCacheKey() );
-		if ( !is_int( $emailsSent ) ) {
+		if ( !is_numeric( $emailsSent ) ) {
 			$wgMemc->set( $this->getTargetUserCacheKey(), 0, time() + self::THROTTLE_PERIOD );
 		}
 


### PR DESCRIPTION
Ticket: https://wikia-inc.atlassian.net/browse/SOC-2716

This PR fixes a bug with the throttling we set up for category add emails. Users have reported occasionally receiving thousands of "category add" emails indicating that a page has been added to a given category. In order to prevent this, we set-up throttling which caches the number of category add emails we send to a user. If we attempt to send too many emails in a given time period (currently 10 emails in 30 mins), we don't send subsequent emails until that time period is over.

The bug was we were using the method `is_int` to check if the value we pulled from memcache is an int. If not, we assume this is the first email being sent (memcache returns `false` when you do a get for a non-existent value), so we initialize the emailsSent count to 0, and then later increment that value by one. The problem is that the method we're using to increment, serializes the values as a string. So for the next email, we pull the value "1" from memcache, `is_int` returns false, and then we initialize to 0 again.

This fixes that by using `is_numeric`, which returns true if the value is an int, or a string representing an int.
