### PR TITLE
PLATFORM-2359: fix sandbox detection when not running using Apache module

### DIFF
--- a/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
+++ b/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
@@ -685,13 +685,13 @@ class WikiFactoryLoader {
 				}
 
 				if ($key == 'wgServer') {
-					$headers = Wikia::getAllHeaders();
-					if (array_key_exists('X-Original-Host', $headers) &&
-					    !empty($headers['X-Original-Host'])) {
+					if ( !empty( $_SERVER['HTTP_X_ORIGINAL_HOST'] ) ) {
 						global $wgConf;
-						$tValue = 'http://'.$headers['X-Original-Host'];
-						$wgConf->localVHosts = array_merge($wgConf->localVHosts,
-										   array( $headers['X-Original-Host'] ));
+
+						$stagingServer = $_SERVER['HTTP_X_ORIGINAL_HOST'];
+
+						$tValue = 'http://'.$stagingServer;
+						$wgConf->localVHosts = array_merge( $wgConf->localVHosts, [ $stagingServer ] );
 					}
 				}
 

--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -1338,15 +1338,6 @@ class Wikia {
 		return $params;
 	}
 
-	static public function getAllHeaders() {
-		if ( function_exists( 'getallheaders' ) ) {
-			$headers = getallheaders();
-		} else {
-			$headers = $_SERVER;
-		}
-		return $headers;
-	}
-
 	static public function isUnsubscribed( $to, $body, $subject ) {
 		# Hook moved from SpecialUnsubscribe extension
 		#if this opt is set, fake their conf status to OFF, and stop here.


### PR DESCRIPTION
[PLATFORM-2359](https://wikia-inc.atlassian.net/browse/PLATFORM-2359)

Previously `getallheaders()` function was used that only exists when PHP is run under Apache module. It returns headers names as they arrived to the server. When this function is not present, `$_SERVER` is used which normalizes headers names to uppercase and adds HTTP prefix.

```
staging-fpm:
'HTTP_X_STAGING' => sandbox-fpm

staging-s2
'X-Staging' => sandbox-s2
```

To make it consistent for both Apache module and fpm let's use `$_SERVER` in both cases.

Additionally, remove `Wikia::getAllHeaders()` as it was used only by WikiFactoryLoader.

@artursitarski / @wladekb 
