### PR TITLE
(XW-1761) Fix notice in MercuryApi when scheme values aren't set

### DIFF
--- a/extensions/wikia/MercuryApi/MercuryApiController.class.php
+++ b/extensions/wikia/MercuryApi/MercuryApiController.class.php
@@ -44,8 +44,8 @@ class MercuryApiController extends WikiaController {
 			];
 
 			$smartBannerConfig[ 'appScheme' ] = [
-				'ios' => $meta[ 'ios-scheme' ],
-				'android' => $meta[ 'android-scheme' ]
+				'ios' => $meta[ 'ios-scheme' ] ?? null,
+				'android' => $meta[ 'android-scheme' ] ?? null,
 			];
 
 			return $smartBannerConfig;


### PR DESCRIPTION
Fixes the PHP notice:

```
PHP Notice: Undefined index: android-scheme in extensions/wikia/
MercuryApi/MercuryApiController.class.php on line 48
```

/cc @Wikia/x-wing 
