### PR TITLE
PLATFORM-2366: [PHP-FPM] Verify Apache-related PHP functions calls

### DIFF
--- a/extensions/wikia/SkinChooser/SkinChooser.class.php
+++ b/extensions/wikia/SkinChooser/SkinChooser.class.php
@@ -193,9 +193,9 @@ class SkinChooser {
 		 * @author eloy, requested by artur
 		 */
 		if ( is_null( $useskin ) ) {
-			if ( !empty( $_SERVER['HTTP_X_SKIN'] ) ) {
-				$skinFromHeader = $_SERVER['HTTP_X_SKIN'];
+			$skinFromHeader = $request->getHeader( 'X-Skin' );
 
+			if ( $skinFromHeader !== false ) {
 				if ( in_array( $skinFromHeader, array( 'monobook', 'oasis', 'wikia', 'wikiamobile', 'uncyclopedia' ) ) ) {
 					$skin = Skin::newFromKey( $skinFromHeader );
 				// X-Skin header fallback for Mercury which is actually not a MediaWiki skin but a separate application

--- a/extensions/wikia/SkinChooser/SkinChooser.class.php
+++ b/extensions/wikia/SkinChooser/SkinChooser.class.php
@@ -192,14 +192,14 @@ class SkinChooser {
 		 * check headers sent by varnish, if X-Skin is send force skin unless there is useskin param in url
 		 * @author eloy, requested by artur
 		 */
-		if ( is_null( $useskin ) && function_exists( 'apache_request_headers' ) ) {
-			$headers = apache_request_headers();
+		if ( is_null( $useskin ) ) {
+			if ( !empty( $_SERVER['HTTP_X_SKIN'] ) ) {
+				$skinFromHeader = $_SERVER['HTTP_X_SKIN'];
 
-			if ( isset( $headers[ 'X-Skin' ] ) ) {
-				if ( in_array( $headers[ 'X-Skin' ], array( 'monobook', 'oasis', 'wikia', 'wikiamobile', 'uncyclopedia' ) ) ) {
-					$skin = Skin::newFromKey( $headers[ 'X-Skin' ] );
+				if ( in_array( $skinFromHeader, array( 'monobook', 'oasis', 'wikia', 'wikiamobile', 'uncyclopedia' ) ) ) {
+					$skin = Skin::newFromKey( $skinFromHeader );
 				// X-Skin header fallback for Mercury which is actually not a MediaWiki skin but a separate application
-				} elseif ( $headers[ 'X-Skin' ] === 'mercury') {
+				} elseif ( $skinFromHeader === 'mercury') {
 					$skin = Skin::newFromKey( 'wikiamobile' );
 				}
 				wfProfileOut( __METHOD__ );

--- a/extensions/wikia/SkinChooser/tests/SkinChooserTest.php
+++ b/extensions/wikia/SkinChooser/tests/SkinChooserTest.php
@@ -1,0 +1,47 @@
+<?php
+
+class SkinChooserTest extends WikiaBaseTest {
+
+	function setUp() {
+		parent::setUp();
+		$this->mockGlobalVariable('wgDefaultSkin', 'oasis');
+	}
+
+	/**
+	 * @param string||false $headerValue
+	 * @param string $expectedSkinClass
+	 *
+	 * @dataProvider onGetSkinProvider
+	 */
+	function testOnGetSkin( $headerValue, $expectedSkinClass ) {
+		$context = $this->mockClassWithMethods( 'RequestContext', [
+			'getRequest' => $this->mockClassWithMethods( 'WebRequest', [
+				'getHeader' => $headerValue
+			] ),
+			'getUser' => $this->mockClassWithMethods( 'User', [
+				'isLoggedIn' => false
+			] )
+		] );
+
+		SkinChooser::onGetSkin( $context, $skin );
+
+		if ($expectedSkinClass !== null) {
+			$this->assertInstanceOf( $expectedSkinClass, $skin );
+		}
+		else {
+			$this->assertNull( $skin );
+		}
+	}
+
+	function onGetSkinProvider() {
+		return [
+			[ 'dynks', null ], # SkinChooser logic leaves early when X-Skin is set to an unknown skin (and returns no skin instance)
+			[ false, SkinOasis::class ], # use $wgDefaultSkin (for anons)
+			[ 'monobook', SkinMonoBook::class ],
+			[ 'oasis', SkinOasis::class ],
+			[ 'wikia', SkinOasis::class ],
+			[ 'uncyclopedia', SkinUncyclopedia::class ],
+			[ 'mercury', SkinWikiaMobile::class ],
+		];
+	}
+}

--- a/extensions/wikia/Tasks/proxy/proxy.php
+++ b/extensions/wikia/Tasks/proxy/proxy.php
@@ -3,8 +3,7 @@ set_time_limit( 0 );
 ini_set('display_errors', 0);
 
 # SEC-21: make sure that this is called internally
-$headers = apache_request_headers();
-if ( empty( $headers['X-Wikia-Internal-Request'] ) ) {
+if ( empty( $_SERVER['HTTP_X_WIKIA_INTERNAL_REQUEST'] ) ) {
 	$ip = isset( $_SERVER['REMOTE_ADDR'] ) ? $_SERVER['REMOTE_ADDR'] : null;
 	trigger_error( "X-Wikia-Internal-Request header is missing (request from {$ip})", E_USER_WARNING );
 

--- a/includes/wikia/transaction/tests/TransactionIsCacheableTest.php
+++ b/includes/wikia/transaction/tests/TransactionIsCacheableTest.php
@@ -8,8 +8,8 @@ class TransactionIsCacheableTest extends WikiaBaseTest {
 	/**
 	 * @dataProvider isCacheableDataProvider
 	 */
-	public function testIsCacheable( $header, $expected ) {
-		$this->assertEquals( $expected, Transaction::isCacheable( $header ? [ 'Cache-Control: ' . $header ] : [] ) );
+	public function testIsCacheable( $headerValue, $expected ) {
+		$this->assertEquals( $expected, Transaction::isCacheable( $headerValue ? [ 'Cache-Control: ' . $headerValue ] : [] ) );
 	}
 
 	public function isCacheableDataProvider() {

--- a/includes/wikia/transaction/tests/TransactionIsCacheableTest.php
+++ b/includes/wikia/transaction/tests/TransactionIsCacheableTest.php
@@ -1,12 +1,15 @@
 <?php
 
+/**
+ * @group Transaction
+ */
 class TransactionIsCacheableTest extends WikiaBaseTest {
 
 	/**
 	 * @dataProvider isCacheableDataProvider
 	 */
 	public function testIsCacheable( $header, $expected ) {
-		$this->assertEquals( $expected, Transaction::isCacheable( ['Cache-Control' => $header] ) );
+		$this->assertEquals( $expected, Transaction::isCacheable( $header ? [ 'Cache-Control: ' . $header ] : [] ) );
 	}
 
 	public function isCacheableDataProvider() {


### PR DESCRIPTION
[PLATFORM-2366](https://wikia-inc.atlassian.net/browse/PLATFORM-2366)

As we're giving fpm a try let's rely on `$_SERVER` or MediaWiki's `RequestContext` instead of Apache functions.

``` php
$ ack-grep apache_ --php
includes/wikia/transaction/Transaction.php
274:        if ( function_exists( 'apache_response_headers' ) ) {
275:            $isCacheable = self::isCacheable( apache_response_headers() );

extensions/wikia/SkinChooser/SkinChooser.class.php
195:        if ( is_null( $useskin ) && function_exists( 'apache_request_headers' ) ) {
196:            $headers = apache_request_headers();

extensions/wikia/Tasks/proxy/proxy.php
6:$headers = apache_request_headers();
```

@artursitarski / @wladekb 
