### PR TITLE
WW-89: Checking if data returned from cache is an array

### DIFF
--- a/extensions/wikia/InsightsV2/helpers/InsightsCache.php
+++ b/extensions/wikia/InsightsV2/helpers/InsightsCache.php
@@ -18,7 +18,7 @@ class InsightsCache {
 
 	public function get( $params ) {
 		$data = $this->memc->get( $this->getMemcKey( $params ) );
-		return is_array($data) ? $data : [];
+		return is_array( $data ) ? $data : [];
 	}
 
 	public function set( $params, $data, $ttl = self::INSIGHTS_MEMC_TTL ) {
@@ -83,7 +83,7 @@ class InsightsCache {
 
 		foreach ( $sorting as $type => $item ) {
 			$sortingArray = $this->get( $type );
-			if ( is_array( $sortingArray ) ) {
+			if ( !empty( $sortingArray ) ) {
 				$key = array_search( $articleId, $sortingArray );
 
 				if ( $key !== false && $key !== null ) {

--- a/extensions/wikia/InsightsV2/helpers/InsightsCache.php
+++ b/extensions/wikia/InsightsV2/helpers/InsightsCache.php
@@ -17,7 +17,8 @@ class InsightsCache {
 	}
 
 	public function get( $params ) {
-		return $this->memc->get( $this->getMemcKey( $params ) );
+		$data = $this->memc->get( $this->getMemcKey( $params ) );
+		return is_array($data) ? $data : [];
 	}
 
 	public function set( $params, $data, $ttl = self::INSIGHTS_MEMC_TTL ) {


### PR DESCRIPTION
Ticket: https://wikia-inc.atlassian.net/browse/WW-89

Error was occurred because "get" method from cache returns false if there is no data for given key.

@Wikia/west-wing 
