### PR TITLE
PLATFORM-2367: stable env was unstable

### DIFF
--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -1231,6 +1231,8 @@ class WikiFactory {
 				return 'http://preview.' . $server . '.wikia.com'.$address;
 			case WIKIA_ENV_VERIFY:
 				return 'http://verify.' . $server . '.wikia.com'.$address;
+			case WIKIA_ENV_STABLE:
+				return 'http://stable.' . $server . '.wikia.com'.$address;
 			case WIKIA_ENV_STAGING:
 			case WIKIA_ENV_PROD:
 				return sprintf( 'http://%s.%s%s', $server, $wgWikiaBaseDomain, $address ) ;

--- a/extensions/wikia/WikiFactory/tests/WikiFactoryTest.php
+++ b/extensions/wikia/WikiFactory/tests/WikiFactoryTest.php
@@ -123,6 +123,11 @@ class WikiFactoryTest extends WikiaBaseTest {
 				'expected' => 'http://verify.muppet.wikia.com/wiki/Muppet'
 			],
 			[
+				'env' => WIKIA_ENV_STABLE,
+				'url' => 'http://muppet.wikia.com/wiki/Muppet',
+				'expected' => 'http://stable.muppet.wikia.com/wiki/Muppet'
+			],
+			[
 				'env' => WIKIA_ENV_DEV,
 				'url' => 'http://muppet.wikia.com/wiki',
 				'expected' => 'http://muppet.' . self::MOCK_DEV_NAME . '.wikia-dev.com/wiki'

--- a/includes/Exception.php
+++ b/includes/Exception.php
@@ -233,6 +233,7 @@ class MWException extends Exception {
 
 		if ( !headers_sent() ) {
 			header( 'HTTP/1.0 500 Internal Server Error' );
+			header( "X-MediaWiki-Exception: 1" ); // Wikia change - @author macbre (BAC-1199)
 			header( 'Content-type: text/html; charset=UTF-8' );
 			/* Don't cache error pages!  They cause no end of trouble... */
 			header( 'Cache-control: none' );
@@ -638,10 +639,13 @@ class MWExceptionHandler {
 		# @author macbre
 		# don't emit anything to the client in production mode
 		header('HTTP/1.0 500 Internal Error');
+		header( "X-MediaWiki-Exception: 1" ); // Wikia change - @author macbre (BAC-1199)
 
 		global $wgDevelEnvironment;
 		if (empty($wgDevelEnvironment)) {
-			Wikia::log(__METHOD__, false, $message);
+			Wikia\Logger\WikiaLogger::instance()->error( __METHOD__, [
+				'exception' => new Exception( $message )
+			] );
 			die(1);
 		}
 		# Wikia change - end

--- a/includes/wikia/tests/core/WikiaBaseTest.class.php
+++ b/includes/wikia/tests/core/WikiaBaseTest.class.php
@@ -544,6 +544,12 @@ abstract class WikiaBaseTest extends PHPUnit_Framework_TestCase {
 		$this->mockGlobalVariable( 'wgWikiaEnvironment', WIKIA_ENV_VERIFY );
 	}
 
+	protected function mockStableEnv() {
+		$this->mockGlobalVariable( 'wgDevelEnvironment', false );
+		$this->mockGlobalVariable( 'wgStagingEnvironment', true );
+		$this->mockGlobalVariable( 'wgWikiaEnvironment', WIKIA_ENV_STABLE );
+	}
+
 	protected function mockSandboxEnv() {
 		$this->mockGlobalVariable( 'wgDevelEnvironment', false );
 		$this->mockGlobalVariable( 'wgStagingEnvironment', false );
@@ -587,6 +593,9 @@ abstract class WikiaBaseTest extends PHPUnit_Framework_TestCase {
 				break;
 			case WIKIA_ENV_DEV:
 				$this->mockDevEnv();
+				break;
+			case WIKIA_ENV_STABLE:
+				$this->mockStableEnv();
 				break;
 		}
 	}


### PR DESCRIPTION
- add `X-MediaWiki-Exception: 1` response header when MediaWiki explicitly returns HTTP 500
- try to log an exception in `MWExceptionHandler::escapeEchoAndDie`

@drozdo / @artursitarski / @wladekb 
