### PR TITLE
RECIRC 188: Fix issue with in-content module causing large whitespace gaps

### DIFF
--- a/extensions/wikia/Recirculation/js/views/incontent.js
+++ b/extensions/wikia/Recirculation/js/views/incontent.js
@@ -36,20 +36,39 @@ define('ext.wikia.recirculation.views.incontent', [
 		return firstSuitableSection;
 	}
 
-	function render(data) {
-		var deferred = $.Deferred(),
-			section = findSuitableSection();
+	function waitForToc() {
+		var $toc = $('#toc'),
+			deferred = $.Deferred(),
+			args = Array.prototype.slice.call(arguments);
 
-		if (!section) {
-			return deferred.reject('Recirculation in-content widget not shown - Not enough sections in article');
+		if ($toc.length === 0 || $toc.data('loaded') === true || !$toc.hasClass( 'show' )) {
+			deferred.resolve.apply(null, args);
+		} else {
+			$toc.one('afterLoad.toc', function() {
+				deferred.resolve.apply(null, args);
+			});
 		}
+
+		return deferred.promise();
+	}
+
+	function render(data) {
+		var deferred = $.Deferred();
 
 		data.items = utils.addUtmTracking(data.items, 'incontent');
 
-		utils.renderTemplate('incontent.mustache', data).then(function($html) {
-			section.before($html);
-			deferred.resolve($html);
-		});
+		utils.renderTemplate('incontent.mustache', data)
+			.then(waitForToc)
+			.then(function($html) {
+				var section = findSuitableSection();
+
+				if (!section) {
+					return deferred.reject('Recirculation in-content widget not shown - Not enough sections in article');
+				}
+
+				section.before($html);
+				deferred.resolve($html);
+			});
 
 		return deferred.promise();
 	}

--- a/extensions/wikia/TOC/js/tocWikiaArticle.js
+++ b/extensions/wikia/TOC/js/tocWikiaArticle.js
@@ -112,7 +112,8 @@ require( ['jquery', 'wikia.toc', 'wikia.mustache'], function( $, toc, mustache )
 	 */
 
 	function renderTOC( $target ) {
-		var $container = $target.parents( '#toc' ).children( 'ol' ),
+		var $tocContainer = $target.parents( '#toc' ),
+			$container = $tocContainer.children( 'ol' ),
 			$contentContainer = getContentContainer( $target ),
 			$headers = $contentContainer.find( 'h1, h2, h3, h4, h5, h6' ),
 			data = toc.getData( $headers, createTOCSection, getHeader );
@@ -121,6 +122,7 @@ require( ['jquery', 'wikia.toc', 'wikia.mustache'], function( $, toc, mustache )
 
 		loadTemplate().done( function( template ) {
 			$container.append( mustache.render( template, data ) );
+			$tocContainer.trigger('afterLoad.toc').data('loaded', true);
 
 			setHasTOC( $target, true );
 		} );

--- a/extensions/wikia/TOC/templates/TOC_index.mustache
+++ b/extensions/wikia/TOC/templates/TOC_index.mustache
@@ -1,1 +1,1 @@
-<nav id="toc" class="toc"><div id="toctitle"><h2>{{tocHeader}}</h2><span class="toctoggle">[<a href="#" class="internal" id="togglelink" data-show="{{show}}" data-hide="{{hide}}">{{show}}</a>]</span></div><ol></ol></nav>
+<nav id="toc" class="toc" data-loaded="false"><div id="toctitle"><h2>{{tocHeader}}</h2><span class="toctoggle">[<a href="#" class="internal" id="togglelink" data-show="{{show}}" data-hide="{{hide}}">{{show}}</a>]</span></div><ol></ol></nav>


### PR DESCRIPTION
[RECIRC-188](https://wikia-inc.atlassian.net/browse/RECIRC-188)
The incontent module clears floats so it's causing all content below it to get pushed down the page. This is problematic when the Table of Contents is really long as it causes large whitespace issues. The fix is to wait for the Table of Contents to load before looking for a suitable section  to render the module in to
