### PR TITLE
SUS-793 Replace cityId with a hash generated from cityId and hostname.

### DIFF
--- a/extensions/wikia/Chat2/ChatAjax.class.php
+++ b/extensions/wikia/Chat2/ChatAjax.class.php
@@ -82,7 +82,8 @@ class ChatAjax {
 		if ( $res['canChat'] ) {
 			$roomId = $wgRequest->getVal( 'roomId' );
 			$cityIdFromRoom = ChatServerApiClient::getCityIdFromRoomId( $roomId );
-			if ( $wgCityId !== $cityIdFromRoom ) {
+            $cityIdHash = md5($wgCityId.$wgServer);
+			if ( $cityIdHash !== $cityIdFromRoom ) {
 				$res['canChat'] = false; // don't let the user chat in the room they requested.
 				$res['errorMsg'] = wfMessage( 'chat-room-is-not-on-this-wiki' )->text();
 			}

--- a/extensions/wikia/Chat2/ChatAjax.class.php
+++ b/extensions/wikia/Chat2/ChatAjax.class.php
@@ -82,7 +82,7 @@ class ChatAjax {
 		if ( $res['canChat'] ) {
 			$roomId = $wgRequest->getVal( 'roomId' );
 			$cityIdFromRoom = ChatServerApiClient::getCityIdFromRoomId( $roomId );
-            $cityIdHash = md5($wgCityId.$wgServer);
+			$cityIdHash = md5($wgCityId.$wgServer);
 			if ( $cityIdHash !== $cityIdFromRoom ) {
 				$res['canChat'] = false; // don't let the user chat in the room they requested.
 				$res['errorMsg'] = wfMessage( 'chat-room-is-not-on-this-wiki' )->text();


### PR DESCRIPTION
[SUS-793](https://wikia-inc.atlassian.net/browse/SUS-793)  **DO NOT MERGE**

So... Currently room IDs are generated based on wiki ID and stored permanently in redis together with the host name, witch is then used to make API calls. This is fine on production, but causes some issues on other environments. 
For instance when someone uses chat on sandbox-sus1 and then someone another will run it on same wiki, but other environment, let's say, sandbox-s7 it won't work, because chat server will still make API calls to sandbox-sus1.

To fix that we've replaced cityId with a hash generated from cityId and host name. 

This change is related to [chat@SUS-793](https://github.com/Wikia/chat/pull/32)
