### PR TITLE
MAIN-7675 Disable MW Group JS because of security risk

### DIFF
--- a/includes/resourceloader/ResourceLoaderUserGroupsModule.php
+++ b/includes/resourceloader/ResourceLoaderUserGroupsModule.php
@@ -39,7 +39,9 @@ class ResourceLoaderUserGroupsModule extends ResourceLoaderWikiModule {
 					if ( in_array( $group, array( '*', 'user' ) ) ) {
 						continue;
 					}
-					$pages["MediaWiki:Group-$group.js"] = array( 'type' => 'script' );
+					// MAIN-7675 - Disable group JS because it bypasses JS review process.
+					// This can be re-enabled if integrated with JS review.
+					//$pages["MediaWiki:Group-$group.js"] = array( 'type' => 'script' );
 					$pages["MediaWiki:Group-$group.css"] = array( 'type' => 'style' );
 				}
 				return $pages;


### PR DESCRIPTION
See a description of MediaWiki Group JS (and CSS) here: https://www.mediawiki.org/wiki/Manual:User_group_CSS_and_Javascript

This should be disabled for now as a security risk. The group JS can possibly be re-enabled later if it can be integrated with our wiki JS review.
