### PR TITLE
SEO-456 Use /wiki/Local_Sitemap as the local HTML sitemap

### DIFF
--- a/extensions/wikia/GlobalFooter/GlobalFooterController.class.php
+++ b/extensions/wikia/GlobalFooter/GlobalFooterController.class.php
@@ -9,7 +9,6 @@ class GlobalFooterController extends WikiaController {
 	const MESSAGE_KEY_GLOBAL_FOOTER_LINKS = 'shared-Oasis-footer-wikia-links';
 	const MEMC_EXPIRY = 3600;
 	const SITEMAP_GLOBAL = 'http://www.wikia.com/Sitemap';
-	const SITEMAP_LOCAL = 'Special:AllPages';
 
 	public function index() {
 		Wikia::addAssetsToOutput( 'global_footer_scss' );
@@ -111,9 +110,9 @@ class GlobalFooterController extends WikiaController {
 
 		// Don't link to local sitemap on corporate sites and community.wikia.com (controlled via WikiFactory)
 		if ( $this->wg->EnableLocalSitemapPageExt ) {
-			$sitemapLinks[] = parseItem(
-				'*' . self::SITEMAP_LOCAL . '|' . wfMessage( 'global-footer-local-sitemap' )->escaped()
-			);
+			$link = LocalSitemapPageHelper::getLocalSitemapArticleDBkey();
+			$label = wfMessage( 'global-footer-local-sitemap' )->escaped();
+			$sitemapLinks[] = parseItem( '*' . $link . '|' . $label );
 		}
 
 		return $sitemapLinks;

--- a/extensions/wikia/GlobalFooter/GlobalFooterController.class.php
+++ b/extensions/wikia/GlobalFooter/GlobalFooterController.class.php
@@ -110,7 +110,7 @@ class GlobalFooterController extends WikiaController {
 		);
 
 		// Don't link to local sitemap on corporate sites and community.wikia.com (controlled via WikiFactory)
-		if ( $this->wg->EnableLocalSitemap ) {
+		if ( $this->wg->EnableLocalSitemapPageExt ) {
 			$sitemapLinks[] = parseItem(
 				'*' . self::SITEMAP_LOCAL . '|' . wfMessage( 'global-footer-local-sitemap' )->escaped()
 			);

--- a/extensions/wikia/LocalSitemapPage/LocalSitemapPage.i18n.php
+++ b/extensions/wikia/LocalSitemapPage/LocalSitemapPage.i18n.php
@@ -1,0 +1,55 @@
+<?php
+
+$messages = [];
+
+$messages['en'] = [
+	'local-sitemap-page-header' => 'Local Sitemap',
+];
+
+$messages['qqq'] = [
+	'local-sitemap-page-header' => 'Label of link pointing to local sitemap',
+];
+
+$messages['de'] = [
+	'local-sitemap-page-header' => 'Lokale Sitemap',
+];
+
+$messages['es'] = [
+	'local-sitemap-page-header' => 'Mapa del sitio local',
+];
+
+$messages['fr'] = [
+	'local-sitemap-page-header' => 'Plan du site - Local',
+];
+
+$messages['it'] = [
+	'local-sitemap-page-header' => 'Mappa del sito locale',
+];
+
+$messages['ja'] = [
+	'local-sitemap-page-header' => 'コミュニティ・サイトマップ',
+];
+
+$messages['nl'] = [
+	'local-sitemap-page-header' => 'Local Sitemap',
+];
+
+$messages['pl'] = [
+	'local-sitemap-page-header' => 'Lokalna Mapa Strony',
+];
+
+$messages['pt'] = [
+	'local-sitemap-page-header' => 'Mapa do site local',
+];
+
+$messages['ru'] = [
+	'local-sitemap-page-header' => 'Локальная карта сайта',
+];
+
+$messages['zh-hans'] = [
+	'local-sitemap-page-header' => '本地网站地图',
+];
+
+$messages['zh-hant'] = [
+	'local-sitemap-page-header' => '本地網站地圖',
+];

--- a/extensions/wikia/LocalSitemapPage/LocalSitemapPage.setup.php
+++ b/extensions/wikia/LocalSitemapPage/LocalSitemapPage.setup.php
@@ -2,6 +2,7 @@
 
 // autoload
 $wgAutoloadClasses['LocalSitemapPageArticle'] = __DIR__ . '/LocalSitemapPageArticle.class.php';
+$wgAutoloadClasses['LocalSitemapPageHelper'] = __DIR__ . '/LocalSitemapPageHelper.class.php';
 $wgAutoloadClasses['LocalSitemapPageHooks'] = __DIR__ . '/LocalSitemapPageHooks.class.php';
 $wgAutoloadClasses['LocalSitemapSpecialPage'] = __DIR__ . '/LocalSitemapSpecialPage.class.php';
 

--- a/extensions/wikia/LocalSitemapPage/LocalSitemapPage.setup.php
+++ b/extensions/wikia/LocalSitemapPage/LocalSitemapPage.setup.php
@@ -5,6 +5,9 @@ $wgAutoloadClasses['LocalSitemapPageArticle'] = __DIR__ . '/LocalSitemapPageArti
 $wgAutoloadClasses['LocalSitemapPageHooks'] = __DIR__ . '/LocalSitemapPageHooks.class.php';
 $wgAutoloadClasses['LocalSitemapSpecialPage'] = __DIR__ . '/LocalSitemapSpecialPage.class.php';
 
+// i18n mapping
+$wgExtensionMessagesFiles['LocalSitemapPage'] = __DIR__ . '/LocalSitemapPage.i18n.php';
+
 // hooks
 $wgHooks['ArticleFromTitle'][] = 'LocalSitemapPageHooks::onArticleFromTitle';
 $wgHooks['PageHeaderPageTypePrepared'][] = 'LocalSitemapPageHooks::onPageHeaderPageTypePrepared';

--- a/extensions/wikia/LocalSitemapPage/LocalSitemapPage.setup.php
+++ b/extensions/wikia/LocalSitemapPage/LocalSitemapPage.setup.php
@@ -1,0 +1,10 @@
+<?php
+
+// autoload
+$wgAutoloadClasses['LocalSitemapPageArticle'] = __DIR__ . '/LocalSitemapPageArticle.class.php';
+$wgAutoloadClasses['LocalSitemapPageHooks'] = __DIR__ . '/LocalSitemapPageHooks.class.php';
+$wgAutoloadClasses['LocalSitemapSpecialPage'] = __DIR__ . '/LocalSitemapSpecialPage.class.php';
+
+// hooks
+$wgHooks['ArticleFromTitle'][] = 'LocalSitemapPageHooks::onArticleFromTitle';
+$wgHooks['PageHeaderPageTypePrepared'][] = 'LocalSitemapPageHooks::onPageHeaderPageTypePrepared';

--- a/extensions/wikia/LocalSitemapPage/LocalSitemapPageArticle.class.php
+++ b/extensions/wikia/LocalSitemapPage/LocalSitemapPageArticle.class.php
@@ -2,7 +2,7 @@
 
 class LocalSitemapPageArticle extends Article {
 	public function view() {
-		$sap = new LocalSitemapSpecialPage();
-		$sap->execute( null );
+		$page = new LocalSitemapSpecialPage();
+		$page->execute( null );
 	}
 }

--- a/extensions/wikia/LocalSitemapPage/LocalSitemapPageArticle.class.php
+++ b/extensions/wikia/LocalSitemapPage/LocalSitemapPageArticle.class.php
@@ -1,0 +1,8 @@
+<?php
+
+class LocalSitemapPageArticle extends Article {
+	public function view() {
+		$sap = new LocalSitemapSpecialPage();
+		$sap->execute( null );
+	}
+}

--- a/extensions/wikia/LocalSitemapPage/LocalSitemapPageHelper.class.php
+++ b/extensions/wikia/LocalSitemapPage/LocalSitemapPageHelper.class.php
@@ -1,0 +1,21 @@
+<?php
+
+class LocalSitemapPageHelper {
+	const LOCAL_SITEMAP_PAGE_DBKEY = 'Local_Sitemap';
+
+	/**
+	 * Whether the page is the one we want to convert to the local sitemap
+	 * @param Title $title
+	 * @return bool
+	 */
+	public static function isLocalSitemap( $title ) {
+		return ( $title
+			&& $title->getNamespace() === NS_MAIN
+			&& $title->getDBkey() === self::LOCAL_SITEMAP_PAGE_DBKEY
+		);
+	}
+
+	public static function getLocalSitemapArticleDBkey() {
+		return self::LOCAL_SITEMAP_PAGE_DBKEY;
+	}
+}

--- a/extensions/wikia/LocalSitemapPage/LocalSitemapPageHooks.class.php
+++ b/extensions/wikia/LocalSitemapPage/LocalSitemapPageHooks.class.php
@@ -3,22 +3,9 @@
  * Local Sitemap Page Hooks
  */
 class LocalSitemapPageHooks {
-	const LOCAL_SITEMAP_PAGE_DBKEY = 'Local_Sitemap';
-
-	/**
-	 * Whether the page is the one we want to convert to the local sitemap
-	 * @param Title $title
-	 * @return bool
-	 */
-	private static function isLocalSitemap( $title ) {
-		return ( $title
-			&& $title->getNamespace() === NS_MAIN
-			&& $title->getDBkey() === self::LOCAL_SITEMAP_PAGE_DBKEY
-		);
-	}
 
 	public static function onArticleFromTitle( &$title, &$article ) {
-		if ( self::isLocalSitemap( $title ) ) {
+		if ( LocalSitemapPageHelper::isLocalSitemap( $title ) ) {
 			F::app()->wg->SuppressRail = true;
 			$article = new LocalSitemapPageArticle( $title );
 		}
@@ -30,7 +17,7 @@ class LocalSitemapPageHooks {
 	 * Don't display "talk" and "create" buttons on Local Sitemap
 	 */
 	public static function onPageHeaderPageTypePrepared( $pageHeaderController, $title ) {
-		if ( self::isLocalSitemap( $title ) ) {
+		if ( LocalSitemapPageHelper::isLocalSitemap( $title ) ) {
 			$pageHeaderController->comments = false;
 			$pageHeaderController->action = false;
 		}

--- a/extensions/wikia/LocalSitemapPage/LocalSitemapPageHooks.class.php
+++ b/extensions/wikia/LocalSitemapPage/LocalSitemapPageHooks.class.php
@@ -3,12 +3,17 @@
  * Local Sitemap Page Hooks
  */
 class LocalSitemapPageHooks {
-	const LOCAL_SITEMAP_PAGE_TITLE = 'Local Sitemap';
+	const LOCAL_SITEMAP_PAGE_DBKEY = 'Local_Sitemap';
 
+	/**
+	 * Whether the page is the one we want to convert to the local sitemap
+	 * @param Title $title
+	 * @return bool
+	 */
 	private static function isLocalSitemap( $title ) {
 		return ( $title
 			&& $title->getNamespace() === NS_MAIN
-			&& $title->getText() === self::LOCAL_SITEMAP_PAGE_TITLE
+			&& $title->getDBkey() === self::LOCAL_SITEMAP_PAGE_DBKEY
 		);
 	}
 
@@ -21,11 +26,12 @@ class LocalSitemapPageHooks {
 	}
 
 	/**
-	 * Don't display "talk" button on Local Sitemap
+	 * Don't display "talk" and "create" buttons on Local Sitemap
 	 */
 	public static function onPageHeaderPageTypePrepared( $pageHeaderController, $title ) {
 		if ( self::isLocalSitemap( $title ) ) {
 			$pageHeaderController->comments = false;
+			$pageHeaderController->action = false;
 		}
 		return true;
 	}

--- a/extensions/wikia/LocalSitemapPage/LocalSitemapPageHooks.class.php
+++ b/extensions/wikia/LocalSitemapPage/LocalSitemapPageHooks.class.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Local Sitemap Page Hooks
+ */
+class LocalSitemapPageHooks {
+	const LOCAL_SITEMAP_PAGE_TITLE = 'Local Sitemap';
+
+	private static function isLocalSitemap( $title ) {
+		return ( $title
+			&& $title->getNamespace() === NS_MAIN
+			&& $title->getText() === self::LOCAL_SITEMAP_PAGE_TITLE
+		);
+	}
+
+	public static function onArticleFromTitle( &$title, &$article ) {
+		if ( self::isLocalSitemap( $title ) ) {
+			$article = new LocalSitemapPageArticle( $title );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Don't display "talk" button on Local Sitemap
+	 */
+	public static function onPageHeaderPageTypePrepared( $pageHeaderController, $title ) {
+		if ( self::isLocalSitemap( $title ) ) {
+			$pageHeaderController->comments = false;
+		}
+		return true;
+	}
+}

--- a/extensions/wikia/LocalSitemapPage/LocalSitemapPageHooks.class.php
+++ b/extensions/wikia/LocalSitemapPage/LocalSitemapPageHooks.class.php
@@ -19,6 +19,7 @@ class LocalSitemapPageHooks {
 
 	public static function onArticleFromTitle( &$title, &$article ) {
 		if ( self::isLocalSitemap( $title ) ) {
+			F::app()->wg->SuppressRail = true;
 			$article = new LocalSitemapPageArticle( $title );
 		}
 

--- a/extensions/wikia/LocalSitemapPage/LocalSitemapSpecialPage.class.php
+++ b/extensions/wikia/LocalSitemapPage/LocalSitemapSpecialPage.class.php
@@ -40,8 +40,8 @@ class LocalSitemapSpecialPage extends SpecialAllpages {
 		$outpointf = $wgContLang->truncate( $outpointf, $this->maxPageLength );
 
 		$link = '?' . http_build_query( [
-				'pagefrom' => $inpoint,
-				'pageto' => $outpoint,
+				'namefrom' => $inpoint,
+				'nameto' => $outpoint,
 			] );
 
 		$out = '<div class="local-sitemap-line"><a href="' . htmlspecialchars( $link ) . '"><span>';
@@ -66,8 +66,8 @@ class LocalSitemapSpecialPage extends SpecialAllpages {
 			$out->mSquidMaxage = WikiaResponse::CACHE_VERY_SHORT;
 		}
 
-		$from = $request->getVal( 'pagefrom', null );
-		$to = $request->getVal( 'pageto', null );
+		$from = $request->getVal( 'namefrom', null );
+		$to = $request->getVal( 'nameto', null );
 
 		$this->showToplevel( NS_MAIN, $from, $to );
 	}

--- a/extensions/wikia/LocalSitemapPage/LocalSitemapSpecialPage.class.php
+++ b/extensions/wikia/LocalSitemapPage/LocalSitemapSpecialPage.class.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Class LocalSitemapSpecialPage
+ *
+ * This class represents all the modifications to the Special:AllPages required
+ * to use it as the local HTML sitemap:
+ *
+ *  * Allow the page to be cached for a short time for anonymous users
+ *  * No forms and prev/next links
+ *  * Better format of the from A to B links
+ *  * Use alternative from/to params to overcome ?from robot.txt block
+ *
+ */
+class LocalSitemapSpecialPage extends SpecialAllpages {
+
+	/**
+	 * Generate chunks as the page was included. This removes the UI around the lists.
+	 *
+	 * @return bool
+	 */
+	public function including() {
+		return true;
+	}
+
+	/**
+	 * Use alternative line format for "from A to B" links
+	 *
+	 * @param String $inpoint
+	 * @param String $outpoint
+	 * @return string
+	 */
+	public function showline( $inpoint, $outpoint ) {
+		global $wgContLang;
+		$inpointf = htmlspecialchars( str_replace( '_', ' ', $inpoint ) );
+		$outpointf = htmlspecialchars( str_replace( '_', ' ', $outpoint ) );
+
+		// Don't let the length runaway
+		$inpointf = $wgContLang->truncate( $inpointf, $this->maxPageLength );
+		$outpointf = $wgContLang->truncate( $outpointf, $this->maxPageLength );
+
+		$link = '?' . http_build_query( [
+				'pagefrom' => $inpoint,
+				'pageto' => $outpoint,
+			] );
+
+		$out = '<div class="local-sitemap-line"><a href="' . htmlspecialchars( $link ) . '"><span>';
+		$out .= $this->msg( 'alphaindexline' )->rawParams(
+			'</span>' . $inpointf . '<span>',
+			'</span>' . $outpointf . '<span>'
+		)->escaped();
+		$out .= '</span></a></div>';
+		return $out;
+	}
+
+	public function execute( $par ) {
+		$request = $this->getRequest();
+		$out = $this->getOutput();
+		$user = $this->getUser();
+
+		// TODO: migrate to own i18n files after the new global footer release
+		$out->setPageTitle( wfMessage( 'global-footer-local-sitemap' ) );
+		$out->setRobotPolicy( 'noindex,follow' );
+
+		if ( $user && !$user->isLoggedIn() ) {
+			$out->mSquidMaxage = WikiaResponse::CACHE_VERY_SHORT;
+		}
+
+		$from = $request->getVal( 'pagefrom', null );
+		$to = $request->getVal( 'pageto', null );
+
+		$this->showToplevel( NS_MAIN, $from, $to );
+	}
+}

--- a/extensions/wikia/LocalSitemapPage/LocalSitemapSpecialPage.class.php
+++ b/extensions/wikia/LocalSitemapPage/LocalSitemapSpecialPage.class.php
@@ -6,7 +6,6 @@
  * This class represents all the modifications to the Special:AllPages required
  * to use it as the local HTML sitemap:
  *
- *  * Allow the page to be cached for a short time for anonymous users
  *  * No forms and prev/next links
  *  * Better format of the from A to B links
  *  * Use alternative from/to params to overcome ?from robot.txt block

--- a/extensions/wikia/LocalSitemapPage/LocalSitemapSpecialPage.class.php
+++ b/extensions/wikia/LocalSitemapPage/LocalSitemapSpecialPage.class.php
@@ -56,15 +56,9 @@ class LocalSitemapSpecialPage extends SpecialAllpages {
 	public function execute( $par ) {
 		$request = $this->getRequest();
 		$out = $this->getOutput();
-		$user = $this->getUser();
 
-		// TODO: migrate to own i18n files after the new global footer release
-		$out->setPageTitle( wfMessage( 'global-footer-local-sitemap' ) );
+		$out->setPageTitle( wfMessage( 'local-sitemap-page-header' ) );
 		$out->setRobotPolicy( 'noindex,follow' );
-
-		if ( $user && !$user->isLoggedIn() ) {
-			$out->mSquidMaxage = WikiaResponse::CACHE_VERY_SHORT;
-		}
 
 		$from = $request->getVal( 'namefrom', null );
 		$to = $request->getVal( 'nameto', null );

--- a/extensions/wikia/RobotsTxt/classes/WikiaRobots.class.php
+++ b/extensions/wikia/RobotsTxt/classes/WikiaRobots.class.php
@@ -113,7 +113,6 @@ class WikiaRobots {
 	 */
 	public function __construct( PathBuilder $pathBuilder ) {
 		global $wgAllowSpecialImagesInRobots,
-			   $wgEnableLocalSitemap,
 			   $wgRequest,
 			   $wgRobotsTxtCustomRules,
 			   $wgWikiaEnvironment;
@@ -126,10 +125,6 @@ class WikiaRobots {
 			foreach ( (array) $wgRobotsTxtCustomRules['allowSpecialPage'] as $page ) {
 				$this->allowedSpecialPages[$page] = 'allow';
 			}
-		}
-
-		if ( !empty( $wgEnableLocalSitemap ) ) {
-			$this->allowedSpecialPages['Allpages'] = 'allow';
 		}
 
 		if ( !empty( $wgAllowSpecialImagesInRobots ) ) {

--- a/extensions/wikia/RobotsTxt/tests/WikiaRobotsTest.php
+++ b/extensions/wikia/RobotsTxt/tests/WikiaRobotsTest.php
@@ -258,24 +258,8 @@ class WikiaRobotsTest extends WikiaBaseTest {
 		$this->assertTrue( $this->isSpecialPageAllowed( $robotsTxtMock, 'MyPage2' ) );
 	}
 
-	public function testLocalSitemapAllowed() {
-		$this->mockGlobalVariable( 'wgWikiaEnvironment', WIKIA_ENV_PROD );
-		$this->mockGlobalVariable( 'wgEnableLocalSitemap', true );
-		$this->mockGlobalVariable( 'wgAllowSpecialImagesInRobots', false );
-
-		$robotsTxtMock = $this->getRobotsTxtMock();
-		$pathBuilderMock = $this->getPathBuilderMock();
-
-		$wikiaRobots = new WikiaRobots( $pathBuilderMock );
-		$wikiaRobots->configureRobotsBuilder( $robotsTxtMock );
-
-		$this->assertTrue( $this->isSpecialPageAllowed( $robotsTxtMock, 'Allpages' ) );
-		$this->assertFalse( $this->isSpecialPageAllowed( $robotsTxtMock, 'Images' ) );
-	}
-
 	public function testSpecialImagesAllowed() {
 		$this->mockGlobalVariable( 'wgWikiaEnvironment', WIKIA_ENV_PROD );
-		$this->mockGlobalVariable( 'wgEnableLocalSitemap', false );
 		$this->mockGlobalVariable( 'wgAllowSpecialImagesInRobots', true );
 
 		$robotsTxtMock = $this->getRobotsTxtMock();
@@ -284,7 +268,8 @@ class WikiaRobotsTest extends WikiaBaseTest {
 		$wikiaRobots = new WikiaRobots( $pathBuilderMock );
 		$wikiaRobots->configureRobotsBuilder( $robotsTxtMock );
 
-		$this->assertFalse( $this->isSpecialPageAllowed( $robotsTxtMock, 'Allpages' ) );
 		$this->assertTrue( $this->isSpecialPageAllowed( $robotsTxtMock, 'Images' ) );
+		$this->assertFalse( $this->isSpecialPageAllowed( $robotsTxtMock, 'MyPage1' ) );
+		$this->assertFalse( $this->isSpecialPageAllowed( $robotsTxtMock, 'MyPage2' ) );
 	}
 }

--- a/extensions/wikia/SitemapPage/SitemapPageController.class.php
+++ b/extensions/wikia/SitemapPage/SitemapPageController.class.php
@@ -20,8 +20,8 @@ class SitemapPageController extends WikiaController {
 			return true;
 		}
 
-		$from = $this->getVal( 'from', '' );
-		$to = $this->getVal( 'to', '' );
+		$from = $this->getVal( 'dbfrom', '' );
+		$to = $this->getVal( 'dbto', '' );
 
 		$sitemapPage = new SitemapPageModel();
 		$this->wikis = $sitemapPage->getWikiListTopLevel( $level, $from, $to );
@@ -34,8 +34,8 @@ class SitemapPageController extends WikiaController {
 	 * Show list of wikis
 	 */
 	public function showList() {
-		$from = $this->getVal( 'from', '' );
-		$to = $this->getVal( 'to', '' );
+		$from = $this->getVal( 'dbfrom', '' );
+		$to = $this->getVal( 'dbto', '' );
 
 		$sitemapPage = new SitemapPageModel();
 		$this->wikis = $sitemapPage->getWikiList( $from, $to );

--- a/extensions/wikia/SitemapPage/SitemapPageController.class.php
+++ b/extensions/wikia/SitemapPage/SitemapPageController.class.php
@@ -20,8 +20,8 @@ class SitemapPageController extends WikiaController {
 			return true;
 		}
 
-		$from = $this->getVal( 'dbfrom', '' );
-		$to = $this->getVal( 'dbto', '' );
+		$from = $this->getVal( 'namefrom', '' );
+		$to = $this->getVal( 'nameto', '' );
 
 		$sitemapPage = new SitemapPageModel();
 		$this->wikis = $sitemapPage->getWikiListTopLevel( $level, $from, $to );
@@ -34,8 +34,8 @@ class SitemapPageController extends WikiaController {
 	 * Show list of wikis
 	 */
 	public function showList() {
-		$from = $this->getVal( 'dbfrom', '' );
-		$to = $this->getVal( 'dbto', '' );
+		$from = $this->getVal( 'namefrom', '' );
+		$to = $this->getVal( 'nameto', '' );
 
 		$sitemapPage = new SitemapPageModel();
 		$this->wikis = $sitemapPage->getWikiList( $from, $to );

--- a/extensions/wikia/SitemapPage/templates/SitemapPage_index.php
+++ b/extensions/wikia/SitemapPage/templates/SitemapPage_index.php
@@ -5,7 +5,7 @@
 		while ( count( $wikis ) > 0 ) {
 			$from = array_shift( $wikis );
 			$to = array_shift( $wikis );
-			$url = $wg->Title->getLocalURL( "level=$level&dbfrom=$from[dbname]&dbto=$to[dbname]" );
+			$url = $wg->Title->getLocalURL( "level=$level&namefrom=$from[dbname]&nameto=$to[dbname]" );
 			?>
 			<span>
 			<a class="title" href="<?= $url ?>">

--- a/extensions/wikia/SitemapPage/templates/SitemapPage_index.php
+++ b/extensions/wikia/SitemapPage/templates/SitemapPage_index.php
@@ -5,7 +5,7 @@
 		while ( count( $wikis ) > 0 ) {
 			$from = array_shift( $wikis );
 			$to = array_shift( $wikis );
-			$url = $wg->Title->getLocalURL( "level=$level&from=$from[dbname]&to=$to[dbname]" );
+			$url = $wg->Title->getLocalURL( "level=$level&dbfrom=$from[dbname]&dbto=$to[dbname]" );
 			?>
 			<span>
 			<a class="title" href="<?= $url ?>">

--- a/includes/specials/SpecialAllpages.php
+++ b/includes/specials/SpecialAllpages.php
@@ -63,19 +63,6 @@ class SpecialAllpages extends IncludableSpecialPage {
 		$out = $this->getOutput();
 
 		$this->setHeaders();
-
-		/* Wikia change begin - @author: rychu */
-		// SEO-6: Remove the nofollow attribute from Special:AllPages
-		// SEO-256: Use Special:Allpages as local sitemaps
-		global $wgEnableLocalSitemap;
-		if ( !empty( $wgEnableLocalSitemap ) ) {
-			if ( $this->getUser() && !$this->getUser()->isLoggedIn() ) {
-				$out->setRobotPolicy( 'noindex,follow' );
-				$out->mSquidMaxage = WikiaResponse::CACHE_VERY_SHORT;
-			}
-		}
-		/* Wikia change end */
-
 		$this->outputHeader();
 		$out->allowClickjacking();
 
@@ -296,20 +283,6 @@ class SpecialAllpages extends IncludableSpecialPage {
 		$special = $this->getTitle();
 		$link = htmlspecialchars( $special->getLocalUrl( $queryparams . 'from=' . urlencode($inpoint) . '&to=' . urlencode($outpoint) ) );
 
-		/* Wikia change begin - @author: rychu */
-		// SEO-256: Use Special:Allpages as local sitemaps
-		global $wgEnableLocalSitemap;
-		if ( !empty( $wgEnableLocalSitemap ) ) {
-			$out = '<div><a href="' . $link . '"><span>';
-			$out .= $this->msg( 'alphaindexline' )->rawParams(
-				'</span>' . $inpointf . '<span>',
-				'</span>' . $outpointf . '<span>'
-			)->escaped();
-			$out .= '</span></a></div>';
-			return $out;
-		}
-		/* Wikia change end */
-
 		$out = $this->msg( 'alphaindexline' )->rawParams(
 			"<a href=\"$link\">$inpointf</a></td><td>",
 			"</td><td><a href=\"$link\">$outpointf</a>"
@@ -452,10 +425,7 @@ class SpecialAllpages extends IncludableSpecialPage {
 				$prevLink = Linker::linkKnown(
 					$self,
 					$this->msg( 'prevpage', $pt )->escaped(),
-					/* Wikia change begin - @author: rychu */
-					// SEO-256: Use Special:Allpages as local sitemaps
-					array( 'rel' => 'nofollow' ),
-					/* Wikia change end */
+					array(),
 					$query
 				);
 				$out2 = $this->getLanguage()->pipeList( array( $out2, $prevLink ) );
@@ -472,10 +442,7 @@ class SpecialAllpages extends IncludableSpecialPage {
 				$nextLink = Linker::linkKnown(
 					$self,
 					$this->msg( 'nextpage', $t->getText() )->escaped(),
-					/* Wikia change begin - @author: rychu */
-					// SEO-256: Use Special:Allpages as local sitemaps
-					array( 'rel' => 'nofollow' ),
-					/* Wikia change end */
+					array(),
 					$query
 				);
 				$out2 = $this->getLanguage()->pipeList( array( $out2, $nextLink ) );

--- a/skins/oasis/css/core/body.scss
+++ b/skins/oasis/css/core/body.scss
@@ -76,9 +76,7 @@ a {
 	color: $color-text;
 }
 
-// Customization for Special:Allpages
-.mw-special-Allpages {
-	#mw-content-text a span {
-		color: $color-text;
-	}
+// Customization for Local_Sitemap
+.local-sitemap-line a span {
+	color: $color-text;
 }


### PR DESCRIPTION
Also change the from/to params in local and global params to avoid being
blocking in robots.txt (?from param is blocked to avoid duplicate
content in category pages).

All the customizations of Special:AllPages are now moved to
LocalSitemapSpecialPage class (a subclass of SpecialAllpages), meaning
users get the original MW page in /wiki/Special:AllPages and bots get the
tweaked one in /wiki/Local_Sitemap.
