### PR TITLE
PLATFORM-2369: increase Lua memory limit to 350 MB

### DIFF
--- a/extensions/Scribunto/Scribunto.php
+++ b/extensions/Scribunto/Scribunto.php
@@ -146,7 +146,7 @@ $wgScribuntoEngineConf = array(
 
 		// The location of the Lua binary, or null to use the bundled binary.
 		'luaPath' => null,
-		'memoryLimit' => 250 * 1024 * 1024,
+		'memoryLimit' => 350 * 1024 * 1024,
 		'cpuLimit' => 7,
 		'allowEnvFuncs' => false,
 	),


### PR DESCRIPTION
[PLATFORM-2369](https://wikia-inc.atlassian.net/browse/PLATFORM-2369)

Some wikis are still having problems with Lua-powered templates not rendering due to `out of memory` errors. Let's bump it once more by 100 MB - a follow-up of #10892

@Grunny 
