### PR TITLE
PLATFORM-2373: fix bad var reference

### DIFF
--- a/includes/wikia/services/HubService.class.php
+++ b/includes/wikia/services/HubService.class.php
@@ -149,7 +149,7 @@ class HubService extends Service {
 		if ( $comscoreCategoryOverride ) {
 			$category = WikiFactoryHub::getInstance()->getCategoryByName( $comscoreCategoryOverride );
 			if ( $category ) {
-				$categoryId = $comscoreCategoryOverride['id'];
+				$categoryId = $category['id'];
 			}
 		}
 


### PR DESCRIPTION
@macbre 

WikiFactoryHub::getInstance()->getCategoryByName() returns null or an array with "id" key.
