### PR TITLE
PLATFORM-2369: increase luastandalone "cpuLimit" to 15 seconds

### DIFF
--- a/extensions/Scribunto/Scribunto.php
+++ b/extensions/Scribunto/Scribunto.php
@@ -147,7 +147,7 @@ $wgScribuntoEngineConf = array(
 		// The location of the Lua binary, or null to use the bundled binary.
 		'luaPath' => null,
 		'memoryLimit' => 350 * 1024 * 1024,
-		'cpuLimit' => 7,
+		'cpuLimit' => 15, # the CPU time limit in seconds (enforced using ulimit)
 		'allowEnvFuncs' => false,
 	),
 );


### PR DESCRIPTION
We already increased the memory limit for luastandalone. Let's do the same with the time limit to allow the most complex articles to be rendered successfully.

```
cpuLimit 
  Specify the CPU time limit in seconds for the standalone interpreter on Linux (enforced using ulimit).
```

@Grunny 
