### PR TITLE
SEO-479 Allow caching of <bloglist> tags if there's no pagination

### DIFF
--- a/extensions/wikia/Blogs/BlogTemplate.php
+++ b/extensions/wikia/Blogs/BlogTemplate.php
@@ -1159,14 +1159,15 @@ class BlogTemplateClass {
 								$sPager = $aPager['body'];
 							}
 
-							if ( $sPager ) {
-								/**
-								 * Don't cache the tag if there's pagination.
-								 * We rely on Varnish caching for anonymous users and bots.
-								 **/
-								if ( ( $parser instanceof Parser ) && ( $parser->mOutput instanceof ParserOutput ) ) {
-									$parser->mOutput->updateCacheExpiry( -1 );
-								}
+							/**
+							 * Don't cache the tag if there's pagination.
+							 * We rely on Varnish caching for anonymous users and bots.
+							 **/
+							if ( $sPager &&
+								$parser instanceof Parser &&
+								$parser->mOutput instanceof ParserOutput
+							) {
+								$parser->mOutput->updateCacheExpiry( -1 );
 							}
 
 							if ( F::app()->checkSkin( 'oasis' ) ) {

--- a/extensions/wikia/Blogs/BlogTemplate.php
+++ b/extensions/wikia/Blogs/BlogTemplate.php
@@ -948,13 +948,13 @@ class BlogTemplateClass {
 		global $wgExtensionsPath, $wgStylePath, $wgRequest;
 
 		/**
-		 * Don't cache the tag. This makes the pagination work.
-		 * We rely on Varnish caching for anonymous users and bots.
-		 **/
+		 * Because this parser tag contains elements of interface we need to
+		 * inform parser to vary parser cache key by user lang option
+		 */
 
 		/* @var $parser Parser */
 		if ( ( $parser instanceof Parser ) && ( $parser->mOutput instanceof ParserOutput ) ) {
-			$parser->mOutput->updateCacheExpiry( -1 );
+			$parser->mOutput->recordOption( 'userlang' );
 		}
 
 		$result = "";
@@ -1158,6 +1158,17 @@ class BlogTemplateClass {
 								$wgOut->addHeadItem( 'Paginator', $aPager['head'] );
 								$sPager = $aPager['body'];
 							}
+
+							if ( $sPager ) {
+								/**
+								 * Don't cache the tag if there's pagination.
+								 * We rely on Varnish caching for anonymous users and bots.
+								 **/
+								if ( ( $parser instanceof Parser ) && ( $parser->mOutput instanceof ParserOutput ) ) {
+									$parser->mOutput->updateCacheExpiry( -1 );
+								}
+							}
+
 							if ( F::app()->checkSkin( 'oasis' ) ) {
 								wfRunHooks( 'BlogsRenderBlogArticlePage', array( &$result, $aResult, self::$aOptions, $sPager ) );
 							} else {


### PR DESCRIPTION
The only reason to disable caching on blog lists was because there's no
easy way to make it work with pagination.

When there's no pagination, we can let the Parser Cache cache the
rendered pages.
