### PR TITLE
RECIRC 181: Highlight new stories in recirculation

### DIFF
--- a/extensions/wikia/Recirculation/RecirculationApiController.class.php
+++ b/extensions/wikia/Recirculation/RecirculationApiController.class.php
@@ -1,7 +1,7 @@
 <?php
 
 class RecirculationApiController extends WikiaApiController {
-	const ALLOWED_TYPES = ['recent_popular', 'vertical', 'community', 'curated', 'e3', 'hero', 'category'];
+	const ALLOWED_TYPES = ['recent_popular', 'vertical', 'community', 'curated', 'hero', 'category', 'latest'];
 	const FANDOM_LIMIT = 5;
 
 	/**
@@ -27,7 +27,7 @@ class RecirculationApiController extends WikiaApiController {
 
 		if ( $type === 'curated' ) {
 			$dataService = new CuratedContentService();
-		} elseif ( $type === 'hero' || $type === 'category' ) {
+		} elseif ( $type === 'hero' || $type === 'category' || $type === 'latest' ) {
 			$dataService = new FandomDataService( $cityId, $type );
 		} else {
 			$dataService = new ParselyDataService( $cityId );

--- a/extensions/wikia/Recirculation/js/experiments/placement/fandomTopic.js
+++ b/extensions/wikia/Recirculation/js/experiments/placement/fandomTopic.js
@@ -16,18 +16,19 @@ define('ext.wikia.recirculation.experiments.placement.FANDOM_TOPIC', [
 
 	function loadData() {
 		var popular = FandomHelper({
-			    type: 'community',
-			    fill: true,
-				limit: 15
+				type: 'community',
+				fill: true,
+				limit: 10
 			}).loadData(),
 			recent = FandomHelper({
 				type: 'latest',
-				limit: 1
+				limit: 1,
+				ignoreError: true
 			}).loadData();
 
 		return $.when(popular, recent)
 			.then(function(popularData, recentData) {
-				var items = utils.ditherResults(popularData.items, 2),
+				var items = utils.ditherResults(popularData.items, 2).slice(0,5),
 					mostRecent = recentData.items[0];
 
 				if (mostRecent && items.every(isNot(mostRecent))) {

--- a/extensions/wikia/Recirculation/js/experiments/placement/impactFooter.js
+++ b/extensions/wikia/Recirculation/js/experiments/placement/impactFooter.js
@@ -2,13 +2,14 @@
 define('ext.wikia.recirculation.experiments.placement.IMPACT_FOOTER', [
 	'jquery',
 	'underscore',
+	'ext.wikia.recirculation.utils',
 	'ext.wikia.recirculation.helpers.contentLinks',
 	'ext.wikia.recirculation.helpers.fandom',
 	'ext.wikia.recirculation.helpers.data',
 	'ext.wikia.recirculation.views.rail',
 	'ext.wikia.recirculation.views.scroller',
 	'ext.wikia.recirculation.views.impactFooter'
-], function ($, _, ContentLinks, FandomHelper, DataHelper, RailView, ScrollerView, ImpactFooterView) {
+], function ($, _, utils, ContentLinks, FandomHelper, DataHelper, RailView, ScrollerView, ImpactFooterView) {
 
 	function run(experimentName) {
 		var scrollerView = ScrollerView(),

--- a/extensions/wikia/Recirculation/js/helpers/FandomHelper.js
+++ b/extensions/wikia/Recirculation/js/helpers/FandomHelper.js
@@ -65,8 +65,20 @@ define('ext.wikia.recirculation.helpers.fandom', [
 
 			return {
 				title: data.title,
-				items: items
+				items: items.sort(sortItem)
 			};
+		}
+
+		function sortItem(a, b) {
+			if (a.type === 'recent_popular' && b.type !== 'recent_popular') {
+				return 1;
+			}
+
+			if (b.type === 'recent_popular' && a.type !== 'recent_popular') {
+				return -1;
+			}
+
+			return b.isVideo - a.isVideo;
 		}
 
 		return {

--- a/extensions/wikia/Recirculation/services/FandomDataService.class.php
+++ b/extensions/wikia/Recirculation/services/FandomDataService.class.php
@@ -79,6 +79,7 @@ class FandomDataService {
 	private function buildUrl( $type, $options ) {
 		switch ( $type ) {
 			case 'latest':
+				$options['after'] = new DateTime()->modify( '-24 hours' )->format( DateTime::ATOM );
 				$endpoint = 'posts';
 				break;
 			default:

--- a/extensions/wikia/Recirculation/services/FandomDataService.class.php
+++ b/extensions/wikia/Recirculation/services/FandomDataService.class.php
@@ -18,11 +18,11 @@ class FandomDataService {
 		$this->options = [
 			'_embed' => 1,
 			'per_page' => self::FANDOM_PER_PAGE,
-			'filter' => ['orderby' => 'menu_order'],
+			'filter' => [],
 			'context' => 'embed'
 		];
 
-		if ( $type === 'category' ) {
+		if ( $type === 'category' || $type === 'latest' ) {
 			$this->setupCategories( $ignoreTopic );
 		} else {
 			$this->setupVerticalCategory( $vertical );
@@ -51,35 +51,15 @@ class FandomDataService {
 		return $data;
 	}
 
-	private function categoryApiRequest( $tag ) {
-		$options = [
-			'search' => $tag,
-			'orderby' => 'count',
-			'order' => 'desc',
-			'per_page' => 1,
-		];
-
-		$url = self::API_BASE . 'categories?' . http_build_query( $options );
-
-		$data = ExternalHttp::get( $url );
-		$data = json_decode( $data, true );
-
-		if ( is_array( $data ) && count( $data ) > 0 ) {
-			return $data[0]['id'];
-		} else {
-			return 0;
-		}
-	}
-
 	/**
 	 * Make an API request to parsely to gather posts
 	 *
 	 * @return an array of posts
 	 */
-	private function apiRequest() {
+	private function apiRequest( $type ) {
 		$options = [];
 
-		$url = $this->buildUrl( $this->options );
+		$url = $this->buildUrl( $type, $this->options );
 		$data = ExternalHttp::get( $url );
 
 		$data = json_decode( $data, true );
@@ -96,10 +76,18 @@ class FandomDataService {
 	 * @param array $options
 	 * @return string
 	 */
-	private function buildUrl( $options ) {
-		$url = self::API_BASE . 'hero_unit?' . http_build_query( $options );
+	private function buildUrl( $type, $options ) {
+		switch ( $type ) {
+			case 'latest':
+				$endpoint = 'posts';
+				break;
+			default:
+				$options['filter']['orderby'] = 'menu_order';
+				$endpoint = 'hero_unit';
+				break;
+		}
 
-		return $url;
+		return self::API_BASE . $endpoint . '?' . http_build_query( $options );
 	}
 
 	private function formatPosts( $data ) {
@@ -108,7 +96,7 @@ class FandomDataService {
 		foreach ($data as $key => $post) {
 			if ($this->postHasImage( $post ) && count( $posts ) < self::LIMIT ) {
 				$posts[] = new RecirculationContent( [
-					'url' => $post['upstream_content_link'],
+					'url' => empty($post['upstream_content_link']) ? $post['link'] : $post['upstream_content_link'],
 					'index' => $key,
 					'thumbnail' => $post['_embedded']['wp:featuredmedia'][0]['media_details']['sizes']['thumbnail']['source_url'],
 					'title' => html_entity_decode( $post['title']['rendered'] ),
@@ -137,9 +125,6 @@ class FandomDataService {
 	}
 
 	private function setupCategories( $ignoreTopic ) {
-		// Hard coding in the SDCC category for now, eventually we will want to pass this in from JS
-		$this->options['categories'] = 4435;
-
 		$topicId = $this->getTopicCategoryId();
 
 		if ( !empty( $topicId ) && empty( $ignoreTopic ) ) {
@@ -170,6 +155,26 @@ class FandomDataService {
 		);
 
 		return $data;
+	}
+
+	private function categoryApiRequest( $tag ) {
+		$options = [
+			'search' => $tag,
+			'orderby' => 'count',
+			'order' => 'desc',
+			'per_page' => 1,
+		];
+
+		$url = self::API_BASE . 'categories?' . http_build_query( $options );
+
+		$data = ExternalHttp::get( $url );
+		$data = json_decode( $data, true );
+
+		if ( is_array( $data ) && count( $data ) > 0 ) {
+			return $data[0]['id'];
+		} else {
+			return 0;
+		}
 	}
 
 	private function postHasImage( $post ) {

--- a/extensions/wikia/Recirculation/services/FandomDataService.class.php
+++ b/extensions/wikia/Recirculation/services/FandomDataService.class.php
@@ -79,7 +79,8 @@ class FandomDataService {
 	private function buildUrl( $type, $options ) {
 		switch ( $type ) {
 			case 'latest':
-				$options['after'] = new DateTime()->modify( '-24 hours' )->format( DateTime::ATOM );
+				$date = (new \DateTime())->modify( '-24 hours' );
+				$options['after'] = $date->format( DateTime::ATOM );
 				$endpoint = 'posts';
 				break;
 			default:

--- a/extensions/wikia/Recirculation/services/ParselyDataService.class.php
+++ b/extensions/wikia/Recirculation/services/ParselyDataService.class.php
@@ -87,7 +87,7 @@ class ParselyDataService {
 		$posts = json_decode( $data, true );
 
 		if ( isset( $posts['data'] ) && is_array( $posts['data'] ) ) {
-			return $this->dedupePosts( $posts['data'], $count );
+			return $this->dedupePosts( $posts['data'], $count, $type );
 		} else {
 			return [];
 		}
@@ -120,7 +120,7 @@ class ParselyDataService {
 	 * @param array $rawPosts
 	 * @return array
 	 */
-	private function dedupePosts( $rawPosts, $count ) {
+	private function dedupePosts( $rawPosts, $count, $type ) {
 		$posts = [];
 		$postIds = [];
 
@@ -134,6 +134,7 @@ class ParselyDataService {
 				$postIds[] = $metadata['postID'];
 				$post['source'] = 'fandom';
 				$post['isVideo'] = $metadata['isVideo'] ?? null;
+				$post['type'] = $type;
 				$posts[] = $post;
 			}
 		}


### PR DESCRIPTION
For the FANDOM_TOPIC tests, we want stories published within the past 24 hours floated to the top. This helps keep the right rail fresh and also makes sure that time sensitive mosts aren't completely overlooked. In this change we also add extra weight to video posts.
