### PR TITLE
ADEN-3774 Rmoved unexisting file from AM config

### DIFF
--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -46,7 +46,6 @@ $config['adengine2_desktop_js'] = array(
 		'//extensions/wikia/AdEngine/js/AdEngine2.js',
 		'//extensions/wikia/AdEngine/js/AdEngineRunner.js',
 		'//extensions/wikia/AdEngine/js/AdLogicDartSubdomain.js',
-		'//extensions/wikia/AdEngine/js/AdLogicHighValueCountry.js',
 		'//extensions/wikia/AdEngine/js/AdLogicPageDimensions.js',
 		'//extensions/wikia/AdEngine/js/AdLogicPageParams.js',
 		'//extensions/wikia/AdEngine/js/AdLogicPageViewCounter.js',


### PR DESCRIPTION
[While cleaning up Liftium code](https://github.com/Wikia/app/pull/11010) we removed `AdLogicHighValueCountry.js` file which we missed in AssetManager config. It resulted in PHP warning and the change in this PR fixes it.
