### PR TITLE
MigrateImagesBetweenSwiftDC: do not emit confusing log messages

### DIFF
--- a/maintenance/wikia/migrateImagesBetweenSwiftDC.php
+++ b/maintenance/wikia/migrateImagesBetweenSwiftDC.php
@@ -312,10 +312,10 @@ class MigrateImagesBetweenSwiftDC extends Maintenance {
 				$result = null;
 			}
 		} else {
-			$this->output( "\tImage still exists in source DC \n" );
+			$this->output( "\tNew version of the file exists in source DC \n" );
 			$this->imageSyncQueueItem->setError( self::ERROR_FILE_EXISTS_IN_SOURCE_DC );
 
-			$this->getLogger()->error( 'MigrateImagesBetweenSwiftDC: file still exists in source DC' , $this->getLoggerContext());
+			$this->getLogger()->info( 'MigrateImagesBetweenSwiftDC: new version of the file exists in source DC' , $this->getLoggerContext());
 
 			$result = null;
 		}


### PR DESCRIPTION
[PLATFORM-2235](https://wikia-inc.atlassian.net/browse/PLATFORM-2235)

Because of asynchronous nature of the image sync images re-uploads cause this error to be reported (which is a false positive). During the re-upload we perform three operations:
- file move to archive
- file delete of the previous version
- store of the new version under the same name as the previous version

Synchronization of the 2nd step usually takes place when the 3rd step is already completed in the source datacenter - hence the error. However, it does not impact the sync process as then we perform the synchronization of the 3rd step sync - new version is uploaded to the secondary DC.

As we do have logging of Swift / DFS operations failures in MediaWiki client and we only perform sync when the operation is successful, I'm going to remove the error log as it's simply misleading.

```
2016-08-12_09:20:29.39567 Fetching 50000 images to sync ...
2016-08-12_09:20:29.39831 Run move operation: (record: 5621237)
2016-08-12_09:20:29.39833       Source: mwstore://swift-backend/pokemon/nl/images/9/9c/Rhyhorn_Ronde.png
2016-08-12_09:20:29.39833       Destination: mwstore://swift-backend/pokemon/nl/images/archive/9/9c/20160812092028!Rhyhorn_Ronde.png
2016-08-12_09:20:29.39835       Move image mwstore://swift-backend/pokemon/nl/images/9/9c/Rhyhorn_Ronde.png to mwstore://swift-backend/pokemon/nl/images/archive/9/9c/20160812092028!Rhyhorn_Ronde.png
2016-08-12_09:20:29.46500       Remote file: /archive/9/9c/20160812092028!Rhyhorn_Ronde.png (Swift: prod.dfs.service.sjc.consul ) 
2016-08-12_09:20:30.03550       Connect to dest Swift server: prod.dfs.service.res.consul 
2016-08-12_09:20:30.62034       Record moved to archive
2016-08-12_09:20:30.62035 
2016-08-12_09:20:30.62048 Run delete operation: (record: 5621238)
2016-08-12_09:20:30.62048       Source: mwstore://swift-backend/pokemon/nl/images/9/9c/Rhyhorn_Ronde.png
2016-08-12_09:20:30.62049       Destination: mwstore://swift-backend/pokemon/nl/images/9/9c/Rhyhorn_Ronde.png
2016-08-12_09:20:30.62049       Delete mwstore://swift-backend/pokemon/nl/images/9/9c/Rhyhorn_Ronde.png image
2016-08-12_09:20:30.62050       Remote file: /9/9c/Rhyhorn_Ronde.png (Swift: prod.dfs.service.sjc.consul ) 
2016-08-12_09:20:30.62407       Image still exists in source DC 
2016-08-12_09:20:30.62498       Record moved to archive
2016-08-12_09:20:30.62498 
2016-08-12_09:20:30.62511 Run store operation: (record: 5621239)
2016-08-12_09:20:30.62512       Source: /tmp/phpl4ntRe
2016-08-12_09:20:30.62512       Destination: mwstore://swift-backend/pokemon/nl/images/9/9c/Rhyhorn_Ronde.png
2016-08-12_09:20:30.62512       Store new image into mwstore://swift-backend/pokemon/nl/images/9/9c/Rhyhorn_Ronde.png
2016-08-12_09:20:30.62512       Remote file: /9/9c/Rhyhorn_Ronde.png (Swift: prod.dfs.service.sjc.consul ) 
2016-08-12_09:20:30.69168       Connect to dest Swift server: prod.dfs.service.res.consul 
2016-08-12_09:20:31.03502       Record moved to archive
```

@mixth-sense 
