### PR TITLE
(MAIN-7726) Only load site RL module in VE if site JS is enabled

### DIFF
--- a/extensions/VisualEditor/modules/ve-mw/init/targets/ve.init.mw.ViewPageTarget.js
+++ b/extensions/VisualEditor/modules/ve-mw/init/targets/ve.init.mw.ViewPageTarget.js
@@ -273,6 +273,7 @@ ve.init.mw.ViewPageTarget.prototype.activate = function () {
 
 		this.saveScrollPosition();
 
+		// Only ensure site JS is loaded if it is enabled (SEC-73)
 		if ( mw.config.get( 'wgUseSiteJs' ) ) {
 			extraModules[extraModules.length] = 'site';
 		}

--- a/extensions/VisualEditor/modules/ve-mw/init/targets/ve.init.mw.ViewPageTarget.js
+++ b/extensions/VisualEditor/modules/ve-mw/init/targets/ve.init.mw.ViewPageTarget.js
@@ -253,6 +253,7 @@ ve.init.mw.ViewPageTarget.prototype.setupLocalNoticeMessages = function () {
  * @return {jQuery.Promise}
  */
 ve.init.mw.ViewPageTarget.prototype.activate = function () {
+	var extraModules = [ 'user' ];
 	if ( !this.active && !this.activating ) {
 		this.activating = true;
 		this.activatingDeferred = $.Deferred();
@@ -272,7 +273,11 @@ ve.init.mw.ViewPageTarget.prototype.activate = function () {
 
 		this.saveScrollPosition();
 
-		this.load( [ 'site', 'user' ] );
+		if ( mw.config.get( 'wgUseSiteJs' ) ) {
+			extraModules[extraModules.length] = 'site';
+		}
+
+		this.load( extraModules );
 	}
 	return this.activatingDeferred.promise();
 };

--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -2521,6 +2521,10 @@ class Wikia {
 			$vars['wgWikiDirectedAtChildrenByFounder'] = $wgWikiDirectedAtChildrenByFounder;
 		}
 
+		if ( self::isUsingSafeJs() ) {
+			$vars['wgUseSiteJs'] = true;
+		}
+
 		return true;
 	}
 


### PR DESCRIPTION
This adds a JS variable for wgUseSiteJs which is only set and true if
both wgUseSiteJs and wgEnableContentReviewExt are true. We can then use
this in VE to decide whether or not to also load the site JS RL module
when initialising the editor.
