### PR TITLE
WikiaLogger: pass errors to PHP native handling

### DIFF
--- a/lib/Wikia/src/Logger/WikiaLogger.php
+++ b/lib/Wikia/src/Logger/WikiaLogger.php
@@ -91,7 +91,15 @@ class WikiaLogger implements LoggerInterface {
 			exit(1);
 		}
 
-		return true;
+		/**
+		 * It is important to remember that the standard PHP error handler is completely bypassed
+		 * for the error types specified by error_typesunless the callback function returns FALSE
+		 *
+		 * Return false will make it possible for XDebug to display an orange box with an error on devboxes
+		 *
+		 * @see PLATFORM-2377
+		 */
+		return false;
 	}
 
 	/**

--- a/lib/Wikia/tests/Logger/WikiaLoggerTest.php
+++ b/lib/Wikia/tests/Logger/WikiaLoggerTest.php
@@ -41,7 +41,7 @@ class WikiaLoggerTest extends PHPUnit_Framework_TestCase {
 			->will($this->returnValue(E_NOTICE));
 
 		$wikiaLoggerMock->setLogger($loggerMock);
-		$this->assertTrue($wikiaLoggerMock->onError(E_NOTICE, 'foo', __FILE__, __LINE__, 'here'));
+		$this->assertFalse($wikiaLoggerMock->onError(E_NOTICE, 'foo', __FILE__, __LINE__, 'here'));
 	}
 
 }


### PR DESCRIPTION
[PLATFORM-2377](https://wikia-inc.atlassian.net/browse/PLATFORM-2377)

Return false in `WikiaLogger::onError` error handler by to pass the error to PHP internals - this allows XDebug to print out a shiny orange box.

@gabrys / @mixth-sense 
