### PR TITLE
SEO-496 Fixed AdEngine2ContextService tests 

### DIFF
--- a/extensions/wikia/AdEngine/tests/AdEngine2ContextServiceTest.php
+++ b/extensions/wikia/AdEngine/tests/AdEngine2ContextServiceTest.php
@@ -86,13 +86,6 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 			],
 			[
 				'titleMockType' => 'article',
-				'flags' => ['wgAdDriverUseMonetizationService', 'wgEnableMonetizationModuleExt'],
-				'expectedOpts' => [],
-				'expectedTargeting' => [ 'newWikiCategories' => [ 'test' ] ],
-				'expectedProviders' => ['monetizationService' => true]
-			],
-			[
-				'titleMockType' => 'article',
 				'flags' => ['wgAdDriverWikiIsTop1000'],
 				'expectedOpts' => [],
 				'expectedTargeting' => [ 'newWikiCategories' => [ 'test' ], 'wikiIsTop1000' => true ]


### PR DESCRIPTION
Fixed test after disabling monetization service.
