### PR TITLE
RECIRC-181: Properly use $type in FandomDataService

### DIFF
--- a/extensions/wikia/Recirculation/services/FandomDataService.class.php
+++ b/extensions/wikia/Recirculation/services/FandomDataService.class.php
@@ -43,8 +43,8 @@ class FandomDataService {
 		$data = WikiaDataAccess::cache(
 			$memcKey,
 			self::MCACHE_TIME,
-			function() {
-				return $this->apiRequest();
+			function() use ( $type ) {
+				return $this->apiRequest( $type );
 			}
 		);
 
@@ -80,7 +80,8 @@ class FandomDataService {
 		switch ( $type ) {
 			case 'latest':
 				$date = (new \DateTime())->modify( '-24 hours' );
-				$options['after'] = $date->format( DateTime::ATOM );
+				$options['after'] = $date->format( 'Y-m-d\TH:i:s' );
+				$options['per_page'] = 1;
 				$endpoint = 'posts';
 				break;
 			default:


### PR DESCRIPTION
`$type` is required to determine which endpoint to hit and needs to be passed into the apiRequest
