### PR TITLE
WW-171 Support blocks in Contribution Appreciation experiment

### DIFF
--- a/extensions/wikia/ContributionAppreciation/ContributionAppreciationController.class.php
+++ b/extensions/wikia/ContributionAppreciation/ContributionAppreciationController.class.php
@@ -13,7 +13,7 @@ class ContributionAppreciationController extends WikiaController {
 		$revisionId = $this->request->getInt( 'revision' );
 		$revision = Revision::newFromId( $revisionId );
 
-		if ( $revision ) {
+		if ( $revision && !$wgUser->isBlocked() ) {
 			$id = ( new RevisionUpvotesService() )->addUpvote(
 				$wgCityId,
 				$revision->getPage(),
@@ -170,8 +170,10 @@ class ContributionAppreciationController extends WikiaController {
 	private static function shouldDisplayAppreciation() {
 		global $wgUser, $wgLang, $wgEnableCommunityPageExt;
 
-		// we want to run it only for english users
+		// we want to run it only for a subset of users: logged in, not blocked,
+		// using languages supported in experiment
 		return $wgUser->isLoggedIn() &&
+			!$wgUser->isBlocked() &&
 			self::isSuportedAppreciationLang( $wgLang->getCode() ) &&
 			!empty( $wgEnableCommunityPageExt );
 	}


### PR DESCRIPTION
- Check user block status before displaying call to action
- Ensure request to appreciation is made by a non-blocked user
