### PR TITLE
SEO-406 Make video-enabled XML sitemaps generate faster

### DIFF
--- a/extensions/wikia/Sitemap/SpecialSitemap_body.php
+++ b/extensions/wikia/Sitemap/SpecialSitemap_body.php
@@ -525,16 +525,16 @@ class SitemapPage extends UnlistedSpecialPage {
 
 			$numResults = $response->getResultsFound();
 
-			if ( $numResults >= self::SOLR_LIMIT ) {
+			if ( $numResults > self::SOLR_LIMIT ) {
 				$alwaysReturnTrue = true;
 				return true;
 			}
 
 			$limit = Wikia\Search\Config::MAX_RESULTS_PER_PAGE;
 
-			for ( $page = 0; $page < $numResults / $limit; $page++ ) {
+			for ( $start = 0; $start < $numResults; $start += $limit ) {
 				$config->setLimit( $limit );
-				$config->setStart( $page * $limit );
+				$config->setStart( $start );
 				$query = $queryServiceFactory->getFromConfig( $config );
 				$response = $query->search();
 

--- a/includes/wikia/services/MediaQueryService.class.php
+++ b/includes/wikia/services/MediaQueryService.class.php
@@ -232,7 +232,7 @@ class MediaQueryService extends WikiaService {
 				}
 				$this->mediaCache[ $media->getDBKey() ] = array(
 					'title' => $media->getText(),
-					'desc' => $length > 0 ? $articleService->getTextSnippet( $length ) : '',
+					'desc' => ( $length > 0 ? $articleService->getTextSnippet( $length ) : '' ),
 					'type' => ( $isVideo ? self::MEDIA_TYPE_VIDEO : self::MEDIA_TYPE_IMAGE ),
 					'meta' => ( $videoHandler ? array_merge( $videoHandler->getVideoMetadata(true), $videoHandler->getEmbedSrcData() ) : array() ),
 					'thumbUrl' => ( !empty($thumb) ? $thumb->getUrl() : false

--- a/includes/wikia/services/MediaQueryService.class.php
+++ b/includes/wikia/services/MediaQueryService.class.php
@@ -216,7 +216,9 @@ class MediaQueryService extends WikiaService {
 	private function getMediaDataFromCache( Title $media, $length = 256 ) {
 		wfProfileIn(__METHOD__);
 
-		if ( !isset($this->mediaCache[ $media->getDBKey() ] ) ) {
+		$cacheKey = $media->getDBkey() . ':' . $length;
+
+		if ( !isset($this->mediaCache[ $cacheKey ] ) ) {
 			$file = wfFindFile( $media );
 			if ( !empty( $file ) && $file->canRender() ) {
 				$articleService = new ArticleService( $media );
@@ -230,7 +232,7 @@ class MediaQueryService extends WikiaService {
 				else {
 					$videoHandler = false;
 				}
-				$this->mediaCache[ $media->getDBKey() ] = array(
+				$this->mediaCache[ $cacheKey ] = array(
 					'title' => $media->getText(),
 					'desc' => ( $length > 0 ? $articleService->getTextSnippet( $length ) : '' ),
 					'type' => ( $isVideo ? self::MEDIA_TYPE_VIDEO : self::MEDIA_TYPE_IMAGE ),
@@ -239,12 +241,12 @@ class MediaQueryService extends WikiaService {
 				));
 			}
 			else {
-				$this->mediaCache[ $media->getDBKey() ] = false;
+				$this->mediaCache[ $cacheKey ] = false;
 			}
 		}
 
 		wfProfileOut(__METHOD__);
-		return $this->mediaCache[ $media->getDBKey() ];
+		return $this->mediaCache[ $cacheKey ];
 	}
 
 	/**

--- a/includes/wikia/services/MediaQueryService.class.php
+++ b/includes/wikia/services/MediaQueryService.class.php
@@ -232,7 +232,7 @@ class MediaQueryService extends WikiaService {
 				}
 				$this->mediaCache[ $media->getDBKey() ] = array(
 					'title' => $media->getText(),
-					'desc' => $articleService->getTextSnippet( $length ),
+					'desc' => $length > 0 ? $articleService->getTextSnippet( $length ) : '',
 					'type' => ( $isVideo ? self::MEDIA_TYPE_VIDEO : self::MEDIA_TYPE_IMAGE ),
 					'meta' => ( $videoHandler ? array_merge( $videoHandler->getVideoMetadata(true), $videoHandler->getEmbedSrcData() ) : array() ),
 					'thumbUrl' => ( !empty($thumb) ? $thumb->getUrl() : false


### PR DESCRIPTION
In order to generate the sitemaps with enhanced information for videos
we query Solr to get the snippet of the article for each of the file
page that contains a video. Turns out most of the video pages don't have
the content, so the code queries Solr for no good reason, Solr responds
with an empty respons and the code falls back to parsing (empty) wiki
text.

In this pull request, we're first querying Solr to get ALL the pages in
NS_FILE that are indexed in Solr and then only expect a snippet from
those that are indexed. This reduces the time to generate the sitemap to
one tenth of the original time for some wikis (callofduty).
