### PR TITLE
SUS-536 In Chat: change date string stored in chat ban logs

### DIFF
--- a/extensions/wikia/Chat2/Chat.class.php
+++ b/extensions/wikia/Chat2/Chat.class.php
@@ -119,7 +119,7 @@ class Chat {
 			}
 
 			$options = array_flip( ChatBanTimeOptions::newDefault()->get() );
-            $timeLabel = $options[ $time ];
+			$timeLabel = $options[ $time ];
 			$endOn = time() + $time;
 
 			$subjectChatUser->ban( $adminUser->getId(), $endOn, $reason );

--- a/extensions/wikia/Chat2/Chat.class.php
+++ b/extensions/wikia/Chat2/Chat.class.php
@@ -118,7 +118,8 @@ class Chat {
 				$action = self::BAN_CHANGE;
 			}
 
-			$timeLabel = self::getTimeLabel( $time );
+			$options = array_flip( ChatBanTimeOptions::newDefault()->get() );
+            $timeLabel = $options[ $time ];
 			$endOn = time() + $time;
 
 			$subjectChatUser->ban( $adminUser->getId(), $endOn, $reason );
@@ -139,7 +140,7 @@ class Chat {
 		Chat::addLogEntry(
 			$subjectUser,
 			$adminUser,
-			[ $adminUser->getId(), $subjectUser->getId(), $timeLabel, $endOn ],
+			[ $adminUser->getId(), $subjectUser->getId(), $timeLabel, $endOn, $time ],
 			'ban' . $action,
 			$reason
 		);


### PR DESCRIPTION
[SUS-536](https://wikia-inc.atlassian.net/browse/SUS-536)
I've changed chat ban duration string to be more 'human readable' :) 
@mixth-sense @sqreek 
