### PR TITLE
AssetsManager performance fixes

### DIFF
--- a/extensions/wikia/AssetsManager/AssetsConfig.class.php
+++ b/extensions/wikia/AssetsManager/AssetsConfig.class.php
@@ -12,11 +12,15 @@ class AssetsConfig {
 
 	const JQUERY_VERSION = '1.8.2';
 
-	public static function getSiteJS( $combine ) {
+	/*
+	 * The getters below are called by resolveItemsToAssets method (when '#function_' is used in config.php)
+	 */
+
+	public static function getSiteJS() {
 		return array( Title::newFromText( '-' )->getFullURL( 'action=raw&smaxage=0&gen=js&useskin=oasis' ) );
 	}
 
-	public static function getRTEAssets( $combine ) {
+	public static function getRTEAssets() {
 		global $IP;
 		$path = "extensions/wikia/RTE";
 		$files = array(
@@ -39,7 +43,7 @@ class AssetsConfig {
 		return $files;
 	}
 
-	public static function getEPLAssets( $combine ) {
+	public static function getEPLAssets() {
 		$files = [];
 
 		if ( class_exists( 'EditPageLayoutHelper' ) ) {
@@ -163,11 +167,8 @@ class AssetsConfig {
 			} elseif ( substr ( $item, 0, 10 ) == '#function_' ) {
 				// reference to a function that returns array of URIs
 				$assets = array_merge( $assets, call_user_func( substr( $item, 10 ), $combine, $minify, $params ) );
-			} elseif ( substr ( $item, 0, 10 ) == '#external_' ) {
+			} elseif ( substr ( $item, 0, 10 ) == '#external_' || Http::isValidURI( $item ) ) {
 				// reference to a file to be fetched by the browser from external server (BugId:9522)
-				$assets[] = $item;
-			} elseif ( Http::isValidURI( $item ) ) {
-				// reference to remote file (http and https)
 				$assets[] = $item;
 			}
 		}

--- a/extensions/wikia/AssetsManager/AssetsConfig.class.php
+++ b/extensions/wikia/AssetsManager/AssetsConfig.class.php
@@ -75,7 +75,8 @@ class AssetsConfig {
 	private function load() {
 		if ( empty( self::$mConfig ) ) {
 			wfProfileIn( __METHOD__ );
-			include( 'config.php' );
+			include( __DIR__ . '/config.php' );
+
 			/* @var $config Array */
 			self::$mConfig = $config;
 

--- a/extensions/wikia/AssetsManager/AssetsConfig.class.php
+++ b/extensions/wikia/AssetsManager/AssetsConfig.class.php
@@ -80,19 +80,6 @@ class AssetsConfig {
 			self::$mConfig = $config;
 
 			wfProfileOut( __METHOD__ );
-
-			wfProfileIn( __METHOD__ . 'Groups' );
-
-			foreach ( glob ( __DIR__ . '/configGroups/*Config.php' ) as $fileName ) {
-				include( $fileName );
-				$configFileName = pathinfo( $fileName )['filename'];
-				if ( !empty ( $$configFileName ) ) {
-					$configVar = $$configFileName;
-					self::$mConfig = array_merge( self::$mConfig, $configVar );
-				}
-			}
-
-			wfProfileOut( __METHOD__ . 'Groups' );
 		}
 	}
 

--- a/extensions/wikia/AssetsManager/AssetsConfig.class.php
+++ b/extensions/wikia/AssetsManager/AssetsConfig.class.php
@@ -58,10 +58,10 @@ class AssetsConfig {
 
 		if ( !empty( $wgUseJQueryFromCDN ) && empty( $params['noexternals'] ) ) {
 			$url = $minify
-				? '#external_http://ajax.googleapis.com/ajax/libs/jquery/' . self::JQUERY_VERSION . '/jquery.min.js'
-				: '#external_http://ajax.googleapis.com/ajax/libs/jquery/' . self::JQUERY_VERSION . '/jquery.js';
+				? '#external_http://ajax.googleapis.com/ajax/libs/jquery/' . static::JQUERY_VERSION . '/jquery.min.js'
+				: '#external_http://ajax.googleapis.com/ajax/libs/jquery/' . static::JQUERY_VERSION . '/jquery.js';
 		} else {
-			$url = 'resources/jquery/jquery-' . self::JQUERY_VERSION . '.js';
+			$url = 'resources/jquery/jquery-' . static::JQUERY_VERSION . '.js';
 		}
 
 		return array( $url );
@@ -73,12 +73,12 @@ class AssetsConfig {
 	 * @author Federico "Lox" Lucignano <federico(at)wikia-inc.com>
 	 */
 	private function load() {
-		if ( empty( self::$mConfig ) ) {
+		if ( empty( static::$mConfig ) ) {
 			wfProfileIn( __METHOD__ );
 			include( __DIR__ . '/config.php' );
 
 			/* @var $config Array */
-			self::$mConfig = $config;
+			static::$mConfig = $config;
 
 			wfProfileOut( __METHOD__ );
 		}
@@ -93,7 +93,7 @@ class AssetsConfig {
 		$this->load();
 
 		if ( $this->isGroupDefined( $groupName ) ) {
-			return ( isset( self::$mConfig[$groupName]['skin'] ) ) ? self::$mConfig[$groupName]['skin'] : null;
+			return ( isset( static::$mConfig[$groupName]['skin'] ) ) ? static::$mConfig[$groupName]['skin'] : null;
 		} else {
 			// this is being called on non-defined groups programmatically, so no need to log failure
 			return null;
@@ -109,7 +109,7 @@ class AssetsConfig {
 		$this->load();
 
 		if ( $this->isGroupDefined( $groupName ) ) {
-			return self::$mConfig[$groupName]['type'];
+			return static::$mConfig[$groupName]['type'];
 		} else {
 			// this is being called on non-defined groups programmatically, so no need to log failure
 			return null;
@@ -129,7 +129,7 @@ class AssetsConfig {
 		$this->load();
 
 		if ( $this->isGroupDefined( $groupName ) ) {
-			return self::$mConfig[$groupName]['assets'];
+			return static::$mConfig[$groupName]['assets'];
 		} else {
 			throw new InvalidArgumentException("Group '{$groupName}' doesn't exist");
 		}
@@ -182,12 +182,12 @@ class AssetsConfig {
 	 * @return bool true if the group is defined
 	 */
 	public function isGroupDefined($groupName) {
-		return is_string( $groupName ) && isset( self::$mConfig[$groupName] );
+		return is_string( $groupName ) && isset( static::$mConfig[$groupName] );
 	}
 
 	public function getGroupNames() {
 		$this->load();
 
-		return array_keys( self::$mConfig );
+		return array_keys( static::$mConfig );
 	}
 }


### PR DESCRIPTION
**Save a few system calls on each page view**

`include( 'config.php' );` was making the following system calls:

```
[pid 26989] lstat("/usr/wikia/source/app/extensions/OggHandler/PEAR/File_Ogg/config.php", 0x7ffe9093fe60) = -1 ENOENT (No such file or directory)
[pid 26989] lstat("/usr/wikia/source/app/lib/composer/phpunit/php-text-template/config.php", 0x7ffe9093fe60) = -1 ENOENT (No such file or directory)
[pid 26989] lstat("/usr/wikia/source/app/lib/composer/phpunit/phpunit-mock-objects/config.php", 0x7ffe9093fe60) = -1 ENOENT (No such file or directory)
[pid 26989] lstat("/usr/wikia/source/app/lib/composer/phpunit/php-timer/config.php", 0x7ffe9093fe60) = -1 ENOENT (No such file or directory)
[pid 26989] lstat("/usr/wikia/source/app/lib/composer/phpunit/php-token-stream/config.php", 0x7ffe9093fe60) = -1 ENOENT (No such file or directory)
[pid 26989] lstat("/usr/wikia/source/app/lib/composer/phpunit/php-file-iterator/config.php", 0x7ffe9093fe60) = -1 ENOENT (No such file or directory)
[pid 26989] lstat("/usr/wikia/source/app/lib/composer/phpunit/php-code-coverage/config.php", 0x7ffe9093fe60) = -1 ENOENT (No such file or directory)
[pid 26989] lstat("/usr/wikia/source/app/lib/composer/phpunit/phpunit/config.php", 0x7ffe9093fe60) = -1 ENOENT (No such file or directory)
[pid 26989] lstat("/usr/wikia/source/app/lib/composer/symfony/yaml/config.php", 0x7ffe9093fe60) = -1 ENOENT (No such file or directory)
[pid 26989] lstat("/usr/wikia/source/app/config.php", 0x7ffe9093fe60) = -1 ENOENT (No such file or directory)
[pid 26989] lstat("/usr/wikia/source/app/includes/config.php", 0x7ffe9093fe60) = -1 ENOENT (No such file or directory)
[pid 26989] lstat("/usr/wikia/source/app/languages/config.php", 0x7ffe9093fe60) = -1 ENOENT (No such file or directory)
[pid 26989] lstat("/usr/wikia/source/app/lib/vendor/config.php", 0x7ffe9093fe60) = -1 ENOENT (No such file or directory)
[pid 26989] getcwd("/usr/wikia/source/app", 4096) = 22
[pid 26989] lstat("/usr/wikia/source/app/./config.php", 0x7ffe9093fe60) = -1 ENOENT (No such file or directory)
[pid 26989] lstat("/usr/wikia/source/app/extensions/wikia/AssetsManager/config.php", {st_mode=S_IFREG|0664, st_size=96011, ...}) = 0
[pid 26989] lstat("/usr/wikia/source/app/extensions/wikia/AssetsManager", {st_mode=S_IFDIR|0775, st_size=4096, ...}) = 0
[pid 26989] open("/usr/wikia/source/app/extensions/wikia/AssetsManager/config.php", O_RDONLY) = 28
```

and `glob` call:

```
[pid 26712] openat(AT_FDCWD, "/usr/wikia/source/app/extensions/wikia/AssetsManager/configGroups", O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
```

@mixth-sense / @sqreek / @Grunny / @wladekb / @drozdo 
