### PR TITLE
Http request: log X-Served-By header to help debug problems with slow internal HTTP requests

### DIFF
--- a/includes/HttpFunctions.php
+++ b/includes/HttpFunctions.php
@@ -87,6 +87,7 @@ class Http {
 
 			$params = [
 				'statusCode' => $req->getStatus(),
+				'served-by' => $req->getResponseHeader('x-served-by') ?: '',
 				'reqMethod' => $method,
 				'reqUrl' => $url,
 				'caller' => $caller,


### PR DESCRIPTION
[SUS-890](https://wikia-inc.atlassian.net/browse/SUS-890)

Add `served-by` context field when logging HTTP requests.

``` json
{
  "@timestamp": "2016-08-23T10:30:26.878125+00:00",
  "@message": "Http request",
  "@fields": {
    "app_name": "mediawiki",
    "app_version": "dev",
    "datacenter": "poz",
    "environment": "dev",
    "wiki_dbname": "plpoznan",
    "wiki_id": "5915",
    "maintenance_file": "/usr/wikia/source/app/maintenance/eval.php",
    "maintenance_class": "CommandLineInc",
    "client_ip": "127.0.0.1",
    "span_id": "82c33b03-9694-4c47-9bb2-a899dbf3b057",
    "trace_id": "690bee79-4e5a-42d8-b1da-6b662e547680"
  },
  "@context": {
    "statusCode": 200,
    "served-by": "dev-phalanx-p1",
    "reqMethod": "POST",
    "reqUrl": "http://dev.phalanx.service.consul:4666/validate",
    "caller": "PhalanxService:sendToPhalanxDaemon",
    "isOk": true,
    "isExternal": false,
    "requestTimeMS": 5,
    "backendTimeMS": 0
  }
}
```

@mixth-sense 
