### PR TITLE
Fix warning when  is null

### DIFF
--- a/extensions/wikia/SASS/SassUtil.php
+++ b/extensions/wikia/SASS/SassUtil.php
@@ -140,7 +140,7 @@ class SassUtil {
 		wfProfileIn(__METHOD__);
 		static $cb = null;
 
-		if (is_null($cb)) {
+		if (is_null($cb) && is_array($wgOasisThemeSettingsHistory)) {
 			$currentSettings = end($wgOasisThemeSettingsHistory);
 			if (!empty($currentSettings['revision'])) {
 				$cb = $currentSettings['revision'];


### PR DESCRIPTION
Fix warning:
`Warning: end() expects parameter 1 to be array, boolean given in /usr/wikia/source/app/extensions/wikia/SASS/SassUtil.php on line 144`

On some dev wikis `$wgOasisThemeSettingsHistory` is null - it causes warning to appear.

/cc @macbre
