### PR TITLE
cake-480 - callbacks for tracking events

### DIFF
--- a/extensions/wikia/EditPageLayout/js/plugins/PageControls.js
+++ b/extensions/wikia/EditPageLayout/js/plugins/PageControls.js
@@ -120,16 +120,18 @@
 					isDirty: (typeof this.editor.plugins.leaveconfirm === 'undefined' || this.editor.plugins.leaveconfirm.isDirty()) ? 'yes' : 'no'
 				});
 			}
+
+			this.editform.off('submit');
 			this.editor.track({
 				action: Wikia.Tracker.ACTIONS.SUBMIT,
-				label: 'publish'
+				label: 'publish',
+				callbacks: {
+					timeout: 5000,
+					complete: this.proxy(function() {
+						this.editform.submit();
+					})
+				}
 			});
-
-			// prevent submitting immediately so we can track this event
-			this.editform.off('submit');
-			setTimeout(this.proxy(function () {
-				this.editform.submit();
-			}), 100);
 
 			// block "Publish" button
 			$('#wpSave').attr('disabled', true);


### PR DESCRIPTION
@Wikia/cake 
https://wikia-inc.atlassian.net/browse/CAKE-480

adding `callbacks` field to the `data` passed to the tracking library, with a timeout. This allows us to hold page changes until after tracking has been completed instead of adding an arbitrary delay on those refreshes.
