### PR TITLE
SEO-169 XML sitemap generation without USE INDEX PRIMARY

### DIFF
--- a/extensions/wikia/SitemapXml/SpecialSitemapXmlController.class.php
+++ b/extensions/wikia/SitemapXml/SpecialSitemapXmlController.class.php
@@ -116,7 +116,6 @@ class SpecialSitemapXmlController extends WikiaSpecialPageController {
 			__METHOD__,
 			[
 				'ORDER BY' => 'page_id',
-				'USE INDEX' => 'PRIMARY',
 				'LIMIT' => 15000,
 			]
 		);


### PR DESCRIPTION
Early tests show the DB query is much much quicker without this
'optimization'.
