### PR TITLE
PLATFORM-2385: decrease HTTP timeout

### DIFF
--- a/includes/DefaultSettings.php
+++ b/includes/DefaultSettings.php
@@ -5360,8 +5360,13 @@ $wgShellLocale = 'en_US.utf8';
 
 /**
  * Timeout for HTTP requests done internally
+ *
+ * Let's use different values when running a maintenance script (that includes Wikia Tasks)
+ * and when serving HTTP request
+ *
+ * @see PLATFORM-2385
  */
-$wgHTTPTimeout = 25;
+$wgHTTPTimeout = defined( 'RUN_MAINTENANCE_IF_MAIN' ) ? 25 : 5; # Wikia change
 
 /**
  * Timeout for Asynchronous (background) HTTP requests

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1177,6 +1177,7 @@ $wgPhalanxService = true;
 $wgPhalanxBaseUrl = "phalanx.service.consul:4666";
 $wgPhalanxServiceOptions = [
 	'noProxy' => true, # PLATFORM-1744: do not use the default HTTP proxy (defined in $wgHTTPProxy) for Phalanx requests
+	'timeout' => 1 # [sec] PLATFORM-2385 / SUS-890: prevent Phalanx slowness from affecting the site performance
 ];
 
 /**


### PR DESCRIPTION
[PLATFORM-2385](https://wikia-inc.atlassian.net/browse/PLATFORM-2385)
-   `wgHTTPTimeout`: set the HTTP timeout to 5 seconds for HTTP requests, keep the current value (25 seconds) for maintenance scripts and Wikia Tasks
- set the timeout for Phalanx requests to 1 second (only 0,2% of Phalanx requests are slower than this value) - [SUS-890](https://wikia-inc.atlassian.net/browse/SUS-890)

@mixth-sense / @wladekb / @Grunny 
