### PR TITLE
SUS-929 Use new config variable to tell if map is protected

### DIFF
--- a/extensions/wikia/WikiaMaps/controllers/WikiaMapsBaseController.class.php
+++ b/extensions/wikia/WikiaMaps/controllers/WikiaMapsBaseController.class.php
@@ -217,10 +217,6 @@ class WikiaMapsBaseController extends WikiaController {
 	 * @return bool
 	 */
 	protected function shouldDisableProtectedMapEdit( $mapId ) {
-		$IntMapConfig = $this->wg->IntMapConfig;
-
-		return array_key_exists( 'protectedMaps', $IntMapConfig ) &&
-			array_key_exists($mapId, $IntMapConfig[ 'protectedMaps' ]) &&
-			$this->wg->User->isStaff() === false;
+		return in_array($mapId, $this->wg->IntMapProtectedMaps) && $this->wg->User->isStaff() === false;
 	}
 }


### PR DESCRIPTION
Used a new variable added in https://github.com/Wikia/config/pull/1919 to store protected maps ids and make it impossible to add pins to a protected map via client API.

More: https://wikia-inc.atlassian.net/browse/SUS-929
