### PR TITLE
(SUS-907) Make use of PHP tasks to update ImageReview data

### DIFF
--- a/extensions/wikia/ImageReview/ImageReview.setup.php
+++ b/extensions/wikia/ImageReview/ImageReview.setup.php
@@ -27,8 +27,6 @@ $dir = dirname(__FILE__) . '/';
 $app = F::app();
 
 // classes
-$wgAutoloadClasses['Wikia\\Tasks\\Tasks\\ImageReviewTask'] = "{$dir}ImageReviewTask.class.php";
-
 $wgAutoloadClasses['ImageReviewSpecialController'] =  $dir . 'ImageReviewSpecialController.class.php';
 $wgAutoloadClasses['ImageReviewHelperBase'] =  $dir . 'ImageReviewHelperBase.class.php';
 $wgAutoloadClasses['ImageReviewHelper'] =  $dir . 'ImageReviewHelper.class.php';

--- a/extensions/wikia/ImageReview/ImageReviewEvents.setup.php
+++ b/extensions/wikia/ImageReview/ImageReviewEvents.setup.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Event handling hooks to update ImageReview data when files are uploaded,
+ * deleted and restored.
+ */
+
+$wgAutoloadClasses['ImageReviewEventsHooks'] = __DIR__ . '/ImageReviewEventsHooks.class.php';
+
+$wgHooks['UploadComplete'][] = 'ImageReviewEventsHooks::onUploadComplete';
+$wgHooks['FileRevertComplete'][] = 'ImageReviewEventsHooks::onFileRevertComplete';
+$wgHooks['ArticleDeleteComplete'][] = 'ImageReviewEventsHooks::onArticleDeleteComplete';
+$wgHooks['ArticleUndelete'][] = 'ImageReviewEventsHooks::onArticleUndelete';

--- a/extensions/wikia/ImageReview/ImageReviewEventsHooks.class.php
+++ b/extensions/wikia/ImageReview/ImageReviewEventsHooks.class.php
@@ -1,0 +1,83 @@
+<?php
+
+use \Wikia\Logger\WikiaLogger;
+use \Wikia\Tasks\Tasks\ImageReviewTask;
+
+class ImageReviewEventsHooks {
+	public static function onUploadComplete( UploadBase $form ) {
+		static::createAddTask( $form->getTitle() );
+
+		return true;
+	}
+
+	public static function onFileRevertComplete( Page $page ) {
+		static::createAddTask( $page->getTitle() );
+
+		return true;
+	}
+
+	public static function onArticleUndelete( Title $title, $created, $comment ) {
+		if ( static::isFileForReview( $title ) ) {
+			static::createAddTask( $title );
+		}
+
+		return true;
+	}
+
+	public static function onArticleDeleteComplete( Page $page, User $user, $reason, $articleId ) {
+		global $wgCityId;
+
+		$title = $page->getTitle();
+
+		if ( static::isFileForReview( $title ) ) {
+			WikiaLogger::instance()->debug(
+				'Image Review - Adding delete task',
+				[
+					'method' => __METHOD__,
+					'title' => $title->getPrefixedText(),
+				]
+			);
+
+			$task = new ImageReviewTask();
+			$task->call( 'deleteFromQueue', [ [
+				'wiki_id' => $wgCityId,
+				'page_id' => $articleId,
+			] ] );
+			$task->prioritize();
+			$task->queue();
+		}
+		return true;
+	}
+
+	private static function isFileForReview( $title ) {
+		if ( $title->inNamespace( NS_FILE ) ) {
+			$localFile = wfLocalFile( $title );
+			return ( $localFile instanceof File );
+		}
+
+		return false;
+	}
+
+	private static function createAddTask( Title $title ) {
+		global $wgCityId;
+
+		if ( !preg_match( '/.(png|bmp|gif|jpg|ico|svg|jpeg)$/', $title->getPrefixedText() ) ) {
+			return;
+		}
+
+		WikiaLogger::instance()->debug(
+			'Image Review - Adding task',
+			[
+				'method' => __METHOD__,
+				'title' => $title->getPrefixedText(),
+			]
+		);
+
+		$task = new ImageReviewTask();
+		$task->call( 'addToQueue' );
+		$task->wikiId( $wgCityId );
+		$task->title( $title );
+		$task->prioritize();
+		$task->queue();
+	}
+}

--- a/includes/actions/RevertAction.php
+++ b/includes/actions/RevertAction.php
@@ -113,6 +113,9 @@ class RevertFileAction extends FormAction {
 	}
 
 	public function onSuccess() {
+		// Wikia change - Add hook for a successful file revert
+		wfRunHooks( 'FileRevertComplete', [ $this->page ] );
+		// Wikia change - end
 		$timestamp = $this->oldFile->getTimestamp();
 		$this->getOutput()->addHTML( wfMsgExt( 'filerevert-success', 'parse', $this->getTitle()->getText(),
 			$this->getLanguage()->date( $timestamp, true ),
@@ -126,7 +129,7 @@ class RevertFileAction extends FormAction {
 	protected function getPageTitle() {
 		return wfMsg( 'filerevert', $this->getTitle()->getText() );
 	}
-	
+
 	protected function getDescription() {
 		$this->getOutput()->addBacklinkSubtitle( $this->getTitle() );
 		return '';

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1909,3 +1909,5 @@ $wgReviveSpotlightsCountries = null;
  * It should be always included even if recovery is disabled as we use Recovery classes outside the module
  */
 include_once("$IP/extensions/wikia/ARecoveryEngine/ARecoveryEngine.setup.php");
+
+require_once "$IP/extensions/wikia/ImageReview/ImageReviewEvents.setup.php";

--- a/includes/wikia/tasks/Tasks/ImageReviewTask.class.php
+++ b/includes/wikia/tasks/Tasks/ImageReviewTask.class.php
@@ -111,23 +111,16 @@ class ImageReviewTask extends BaseTask {
 	public function addToQueue() {
 		global $wgExternalDatawareDB;
 		$title = $this->getTitle();
-		$file = wfLocalFile( $title );
 		$wikiId = $this->getWikiId();
-
 		$latestRevId = $title->getLatestRevID( \Title::GAID_FOR_UPDATE );
-		// Get from master to make sure it is the latest data
-		$revisionTimestamp = \Revision::newFromId( $latestRevId, \Revision::READ_LATEST )->getTimestamp();
-
-		$userId = $file->getUser( 'id' );
-		$top200 = $this->isTop200( $wikiId ) ? 1 : 0;
 
 		$imageData = [
 			'wiki_id' => $wikiId,
 			'page_id' => $title->getArticleID(),
 			'revision_id' => $latestRevId,
-			'user_id' => $userId,
-			'last_edited' => $revisionTimestamp,
-			'top_200' => $top200,
+			'user_id' => wfLocalFile( $title )->getUser( 'id' ),
+			'last_edited' => \Revision::newFromId( $latestRevId, \Revision::READ_LATEST )->getTimestamp(),
+			'top_200' => $this->isTop200( $wikiId ) ? 1 : 0,
 			'state' => \ImageReviewStatuses::STATE_UNREVIEWED,
 		];
 
@@ -146,15 +139,9 @@ class ImageReviewTask extends BaseTask {
 		);
 
 		if ( $result ) {
-			$this->info(
-				'Image Review - Added uploaded file',
-				$imageData
-			);
+			$this->info( 'Image Review - Added uploaded file', $imageData );
 		} else {
-			$this->error(
-				'Image Review - Failed to add uploaded file',
-				$imageData
-			);
+			$this->error( 'Image Review - Failed to add uploaded file', $imageData );
 		}
 
 		return $result;

--- a/includes/wikia/tasks/Tasks/ImageReviewTask.class.php
+++ b/includes/wikia/tasks/Tasks/ImageReviewTask.class.php
@@ -108,6 +108,75 @@ class ImageReviewTask extends BaseTask {
 		}
 	}
 
+	public function addToQueue() {
+		global $wgExternalDatawareDB;
+		$title = $this->getTitle();
+		$file = wfLocalFile( $title );
+		$wikiId = $this->getWikiId();
+
+		$latestRevId = $title->getLatestRevID( \Title::GAID_FOR_UPDATE );
+		// Get from master to make sure it is the latest data
+		$revisionTimestamp = \Revision::newFromId( $latestRevId, \Revision::READ_LATEST )->getTimestamp();
+
+		$userId = $file->getUser( 'id' );
+		$top200 = $this->isTop200( $wikiId ) ? 1 : 0;
+
+		$imageData = [
+			'wiki_id' => $wikiId,
+			'page_id' => $title->getArticleID(),
+			'revision_id' => $latestRevId,
+			'user_id' => $userId,
+			'last_edited' => $revisionTimestamp,
+			'top_200' => $top200,
+			'state' => \ImageReviewStatuses::STATE_UNREVIEWED,
+		];
+
+		$dbw = wfGetDB( DB_MASTER, [], $wgExternalDatawareDB );
+		$result = $dbw->upsert(
+			'image_review',
+			$imageData,
+			[],
+			[
+				'last_edited = values(last_edited)',
+				'revision_id = values(revision_id)',
+				'state = values(state)',
+				'user_id = values(user_id)',
+			],
+			__METHOD__
+		);
+
+		if ( $result ) {
+			$this->info(
+				'Image Review - Added uploaded file',
+				$imageData
+			);
+		} else {
+			$this->error(
+				'Image Review - Failed to add uploaded file',
+				$imageData
+			);
+		}
+
+		return $result;
+	}
+
+	private function isTop200( $wikiId ) {
+		global $wgExternalDatawareDB;
+		$dbr = wfGetDB( DB_SLAVE, [], $wgExternalDatawareDB );
+
+		$result = $dbr->selectRow(
+			'image_review',
+			[ 'top_200' ],
+			[
+				'wiki_id' => $wikiId,
+				'top_200' => 1,
+			],
+			__METHOD__
+		);
+
+		return $result !== false;
+	}
+
 	private function sendNotification() {
 		global $wgFlowerUrl;
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-907

Make use of PHP tasks to update ImageReview data which can be used instead of
our Scribe backend.

This also adds functionality to make sure that images are reviewed when a file is reverted.
It implements removing images from the queue upon their deletion per [SUS-761](https://wikia-inc.atlassian.net/browse/SUS-761) as well.

The use of Scribe will be removed in a separate PR once this is reviewed and if we do want
to use this approach.
