### PR TITLE
PLATFORM-2393: add a default value for an i18n message in Masthead::getDefaultAvatars

### DIFF
--- a/extensions/wikia/UserProfilePageV3/Masthead.class.php
+++ b/extensions/wikia/UserProfilePageV3/Masthead.class.php
@@ -127,7 +127,7 @@ class Masthead {
 		if ( is_array( $images ) ) {
 			foreach ( $images as $image ) {
 				$hash = FileRepo::getHashPathForLevel( $image, 2 );
-				$this->mDefaultAvatars[] = self::DEFAULT_PATH . $thumb . $hash . $image;
+				$this->mDefaultAvatars[] = static::DEFAULT_PATH . $thumb . $hash . $image;
 			}
 		}
 
@@ -215,7 +215,7 @@ class Masthead {
 		 * default avatar, path from messaging.wikia.com
 		 */
 		$hash = FileRepo::getHashPathForLevel( $avatar, 2 );
-		return self::DEFAULT_PATH . $hash . $avatar;
+		return static::DEFAULT_PATH . $hash . $avatar;
 	}
 
 	/**
@@ -252,7 +252,7 @@ class Masthead {
 				/**
 				 * default avatar, path from messaging.wikia.com
 				 */
-				$url = self::getDefaultAvatarUrl( $url );
+				$url = static::getDefaultAvatarUrl( $url );
 			}
 		} else {
 			$defaults = $this->getDefaultAvatars( trim( $thumb, "/" ) . "/" );

--- a/extensions/wikia/UserProfilePageV3/Masthead.class.php
+++ b/extensions/wikia/UserProfilePageV3/Masthead.class.php
@@ -7,6 +7,8 @@ class Masthead {
 	 */
 	const DEFAULT_PATH = 'http://images.wikia.com/messaging/images/';
 
+	const DEFAULT_AVATAR_FILENAME = 'Avatar.jpg';
+
 	/**
 	 * path to file, relative
 	 */
@@ -122,7 +124,7 @@ class Masthead {
 		wfProfileIn( __METHOD__ );
 
 		$this->mDefaultAvatars = array();
-		$images = getMessageForContentAsArray( 'blog-avatar-defaults' ) ?: ['Avatar.jpg']; // PLATFORM-2393: add a default value
+		$images = getMessageForContentAsArray( 'blog-avatar-defaults' ) ?: [ static::DEFAULT_AVATAR_FILENAME ]; // PLATFORM-2393: add a default value
 
 		if ( is_array( $images ) ) {
 			foreach ( $images as $image ) {

--- a/extensions/wikia/UserProfilePageV3/Masthead.class.php
+++ b/extensions/wikia/UserProfilePageV3/Masthead.class.php
@@ -518,10 +518,6 @@ class Masthead {
 		wfProfileOut( __METHOD__ );
 	}
 
-	private function getThumbPath( $dir ) {
-		return str_replace( "/avatars/", "/avatars/thumb/", $dir );
-	}
-
 	/**
 	 * While this is technically downloading the URL, the function's purpose is to be similar
 	 * to uploadFile, but instead of having the file come from the user's computer, it comes

--- a/extensions/wikia/UserProfilePageV3/Masthead.class.php
+++ b/extensions/wikia/UserProfilePageV3/Masthead.class.php
@@ -122,7 +122,7 @@ class Masthead {
 		wfProfileIn( __METHOD__ );
 
 		$this->mDefaultAvatars = array();
-		$images = getMessageForContentAsArray( 'blog-avatar-defaults' );
+		$images = getMessageForContentAsArray( 'blog-avatar-defaults' ) ?: ['Avatar.jpg']; // PLATFORM-2393: add a default value
 
 		if ( is_array( $images ) ) {
 			foreach ( $images as $image ) {


### PR DESCRIPTION
Prevent `VignetteRequest.php:58 - missing key 'relative-path'`" exception when the messages cache is outdated.

@nandy-andy / @wladekb / @mixth-sense 
