### PR TITLE
The AppPromoLanding should be caching the app configs once on Wikia, …

### DIFF
--- a/extensions/wikia/AppPromoLanding/AppPromoLandingController.class.php
+++ b/extensions/wikia/AppPromoLanding/AppPromoLandingController.class.php
@@ -222,7 +222,7 @@ class AppPromoLandingController extends WikiaController {
 	static private function getAllAppConfigs(){
 		// Pull in the app-configuration (has data for all apps)
 		$appConfig = [];
-		$memcKey = wfMemcKey( static::$CACHE_KEY, static::$CACHE_KEY_VERSION );
+		$memcKey = wfSharedMemcKey( static::$CACHE_KEY, static::$CACHE_KEY_VERSION );
 		$response = F::app()->wg->memc->get( $memcKey );
 		if ( empty( $response ) ){
 			$req = MWHttpRequest::factory( static::APP_CONFIG_SERVICE_URL, [ 'noProxy' => true ] );


### PR DESCRIPTION
…not once per wiki. This will drastically decrease the number of hits to that API.
