### PR TITLE
PLATFORM-2400: make WF redirects work on staging

### DIFF
--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -1246,6 +1246,7 @@ class WikiFactory {
 
 		$server = str_replace( '.' . $devbox . '.wikia-dev.com', '', $server );
 		$server = str_replace( static::WIKIA_TOP_DOMAIN, '', $server );
+		$server = str_replace( '.' . $wgWikiaBaseDomain, '', $server ); // PLATFORM-2400: make WF redirects work on staging
 
 		// determine the environment we want to get url for
 		$environment = (

--- a/extensions/wikia/WikiFactory/tests/WikiFactoryTest.php
+++ b/extensions/wikia/WikiFactory/tests/WikiFactoryTest.php
@@ -162,6 +162,13 @@ class WikiFactoryTest extends WikiaBaseTest {
 				'url' => 'http://gta.wikia.com/wiki/test/test/test',
 				'expected' => 'http://gta.wikia-staging.com/wiki/test/test/test'
 			],
+			// @see PLATFORM-2400
+			[
+				'env' => WIKIA_ENV_STAGING,
+				'forcedEnv' => null,
+				'url' => 'http://gta.wikia-staging.com/wiki/test/test/test',
+				'expected' => 'http://gta.wikia-staging.com/wiki/test/test/test'
+			],
 			[
 				'env' => WIKIA_ENV_DEV,
 				'forcedEnv' => null,


### PR DESCRIPTION
[PLATFORM-2400](https://wikia-inc.atlassian.net/browse/PLATFORM-2400)

Currently I get the following:

```
$ curl -v 'http://www.requests.wikia-staging.com' 2>&1 | grep 'Location'
< Location: http://community.wikia-staging.com.wikia-staging.com
```

One staging is enough.

@wladekb 
