### PR TITLE
Sus 953 Performance monitoring for using user_id instead username

### DIFF
--- a/extensions/wikia/Editcount/SpecialEditcount_body.php
+++ b/extensions/wikia/Editcount/SpecialEditcount_body.php
@@ -1,4 +1,6 @@
 <?php
+use Wikia\Util\PerformanceProfilers\UsernameUseProfiler;
+
 if (!defined('MEDIAWIKI')) die();
 
 class Editcount extends SpecialPage {
@@ -169,6 +171,7 @@ class Editcount extends SpecialPage {
 	 */
 	function editsArchived( $uid ) {
 		global $wgMemc;
+		$usernameUseProfiler = new UsernameUseProfiler( __CLASS__, __METHOD__ );
 		$key = wfMemcKey( 'archivedCount', $uid );
 		$arcount = $wgMemc->get($key);
 
@@ -186,6 +189,7 @@ class Editcount extends SpecialPage {
 
 			$wgMemc->set( $key, $arcount, self::CACHE_TIME );
 		}
+		$usernameUseProfiler->end();
 
 		return $arcount;
 	}

--- a/extensions/wikia/VideoHandlers/filerepo/WikiaNoArticleLocalFile.class.php
+++ b/extensions/wikia/VideoHandlers/filerepo/WikiaNoArticleLocalFile.class.php
@@ -5,6 +5,8 @@
  * Works as interface, logic should go to WikiaLocalFileShared
  */
 
+use Wikia\Util\PerformanceProfilers\UsernameUseProfiler;
+
 class WikiaNoArticleLocalFile extends WikiaLocalFile {
 	
 	/**
@@ -75,6 +77,7 @@ class WikiaNoArticleLocalFile extends WikiaLocalFile {
 		);
 
 		if( $dbw->affectedRows() == 0 ) {
+			$usernameUseProfiler = new UsernameUseProfiler( __CLASS__, __METHOD__ );
 			$reupload = true;
 
 			# Collision, this is an update of a file
@@ -119,6 +122,7 @@ class WikiaNoArticleLocalFile extends WikiaLocalFile {
 					'img_name' => $this->getName()
 				), __METHOD__
 			);
+			$usernameUseProfiler->end();
 		} else {
 			# This is a new file
 			# Update the image count

--- a/includes/Block.php
+++ b/includes/Block.php
@@ -1,4 +1,6 @@
 <?php
+use Wikia\Util\PerformanceProfilers\UsernameUseProfiler;
+
 /**
  * Blocks and bans object
  *
@@ -353,6 +355,7 @@ class Block {
 	 * @param $row ResultWrapper: a row from the ipblocks table
 	 */
 	protected function initFromRow( $row ) {
+		$usernameUseProfiler = new UsernameUseProfiler( __CLASS__, __METHOD__ );
 		$this->setTarget( $row->ipb_address );
 		if ( $row->ipb_by ) { // local user
 			$this->setBlocker( User::newFromID( $row->ipb_by ) );
@@ -380,6 +383,7 @@ class Block {
 		$this->prevents( 'createaccount', $row->ipb_create_account );
 		$this->prevents( 'sendemail', $row->ipb_block_email );
 		$this->prevents( 'editownusertalk', !$row->ipb_allow_usertalk );
+		$usernameUseProfiler->end();
 	}
 
 	/**

--- a/includes/Revision.php
+++ b/includes/Revision.php
@@ -1,4 +1,5 @@
 <?php
+use Wikia\Util\PerformanceProfilers\UsernameUseProfiler;
 
 /**
  * @todo document
@@ -115,6 +116,7 @@ class Revision implements IDBAccessObject {
 	 * @return Revision
 	 */
 	public static function newFromArchiveRow( $row, $overrides = array() ) {
+		$usernameUseProfiler = new UsernameUseProfiler( __CLASS__, __METHOD__ );
 		$attribs = $overrides + array(
 			'page'       => isset( $row->ar_page_id ) ? $row->ar_page_id : null,
 			'id'         => isset( $row->ar_rev_id ) ? $row->ar_rev_id : null,
@@ -135,6 +137,7 @@ class Revision implements IDBAccessObject {
 				throw new MWException( 'Unable to load text from archive row (possibly bug 22624)' );
 			}
 		}
+		$usernameUseProfiler->end();
 		return new self( $attribs );
 	}
 

--- a/includes/api/ApiQueryAllUsers.php
+++ b/includes/api/ApiQueryAllUsers.php
@@ -23,6 +23,7 @@
  *
  * @file
  */
+use Wikia\Util\PerformanceProfilers\UsernameUseProfiler;
 
 /**
  * Query module to enumerate all registered users.
@@ -35,6 +36,7 @@ class ApiQueryAllUsers extends ApiQueryBase {
 	}
 
 	public function execute() {
+		$usernameUseProfiler = new UsernameUseProfiler( __CLASS__, __METHOD__ );
 		$db = $this->getDB();
 		$params = $this->extractRequestParams();
 
@@ -275,6 +277,7 @@ class ApiQueryAllUsers extends ApiQueryBase {
 		}
 
 		$result->setIndexedTagName_internal( array( 'query', $this->getModuleName() ), 'u' );
+		$usernameUseProfiler->end();
 	}
 
 	public function getCacheMode( $params ) {

--- a/includes/api/ApiQueryBase.php
+++ b/includes/api/ApiQueryBase.php
@@ -23,6 +23,7 @@
  *
  * @file
  */
+use Wikia\Util\PerformanceProfilers\UsernameUseProfiler;
 
 /**
  * This is a base class for all Query modules.
@@ -508,6 +509,7 @@ abstract class ApiQueryBase extends ApiBase {
 	 * @return void
 	 */
 	public function showHiddenUsersAddBlockInfo( $showBlockInfo ) {
+		$usernameUseProfiler = new UsernameUseProfiler( __CLASS__, __METHOD__ );
 		$userCanViewHiddenUsers = $this->getUser()->isAllowed( 'hideuser' );
 
 		if ( $showBlockInfo || !$userCanViewHiddenUsers ) {
@@ -527,6 +529,7 @@ abstract class ApiQueryBase extends ApiBase {
 				$this->addWhere( 'ipb_deleted = 0 OR ipb_deleted IS NULL' );
 			}
 		}
+		$usernameUseProfiler->end();
 	}
 
 	/**

--- a/includes/api/ApiQueryBlocks.php
+++ b/includes/api/ApiQueryBlocks.php
@@ -23,6 +23,7 @@
  *
  * @file
  */
+use Wikia\Util\PerformanceProfilers\UsernameUseProfiler;
 
 /**
  * Query module to enumerate all user blocks
@@ -42,6 +43,7 @@ class ApiQueryBlocks extends ApiQueryBase {
 
 	public function execute() {
 		global $wgContLang;
+		$usernameUseProfiler = new UsernameUseProfiler( __CLASS__, __METHOD__ );
 
 		$params = $this->extractRequestParams();
 		$this->requireMaxOneParameter( $params, 'users', 'ip' );
@@ -209,6 +211,7 @@ class ApiQueryBlocks extends ApiQueryBase {
 			}
 		}
 		$result->setIndexedTagName_internal( array( 'query', $this->getModuleName() ), 'block' );
+		$usernameUseProfiler->end();
 	}
 
 	protected function prepareUsername( $user ) {

--- a/includes/api/ApiQueryDeletedrevs.php
+++ b/includes/api/ApiQueryDeletedrevs.php
@@ -23,6 +23,7 @@
  *
  * @file
  */
+use Wikia\Util\PerformanceProfilers\UsernameUseProfiler;
 
 /**
  * Query module to enumerate all deleted revisions.
@@ -41,6 +42,7 @@ class ApiQueryDeletedrevs extends ApiQueryBase {
 		if ( !$user->isAllowed( 'deletedhistory' ) ) {
 			$this->dieUsage( 'You don\'t have permission to view deleted revision information', 'permissiondenied' );
 		}
+		$usernameUseProfiler = new UsernameUseProfiler( __CLASS__, __METHOD__ );
 
 		$db = $this->getDB();
 		$params = $this->extractRequestParams( false );
@@ -278,6 +280,7 @@ class ApiQueryDeletedrevs extends ApiQueryBase {
 			}
 		}
 		$result->setIndexedTagName_internal( array( 'query', $this->getModuleName() ), 'page' );
+		$usernameUseProfiler->end();
 	}
 
 	public function getAllowedParams() {

--- a/includes/filerepo/file/ArchivedFile.php
+++ b/includes/filerepo/file/ArchivedFile.php
@@ -5,6 +5,7 @@
  * @file
  * @ingroup FileAbstraction
  */
+use Wikia\Util\PerformanceProfilers\UsernameUseProfiler;
 
 /**
  * Class representing a row of the 'filearchive' table
@@ -117,6 +118,8 @@ class ArchivedFile {
 		}
 
 		if( !$this->title || $this->title->getNamespace() == NS_FILE ) {
+			$usernameUseProfiler = new UsernameUseProfiler( __CLASS__, __METHOD__ );
+
 			$dbr = wfGetDB( DB_SLAVE );
 			$res = $dbr->select( 'filearchive',
 				array(
@@ -163,20 +166,11 @@ class ArchivedFile {
 			$this->media_type = $row->fa_media_type;
 			$this->description = $row->fa_description;
 			$this->user = $row->fa_user;
-			/**
-			 * Check, how often is this code executed. Scope: the following if block.
-			 *
-			 * @author Mix
-			 * @see SUS-810
-			 */
-			Wikia\Logger\WikiaLogger::instance()->debugSampled(
-				0.01,
-				'SUS-810',
-				[ 'method' => __METHOD__, 'exception' => new Exception() ]
-			);
 			$this->user_text = $row->fa_user_text;
 			$this->timestamp = $row->fa_timestamp;
 			$this->deleted = $row->fa_deleted;
+
+			$usernameUseProfiler->end();
 		} else {
 			throw new MWException( 'This title does not correspond to an image page.' );
 		}
@@ -194,6 +188,8 @@ class ArchivedFile {
 	 * @return ArchivedFile
 	 */
 	public static function newFromRow( $row ) {
+		$usernameUseProfiler = new UsernameUseProfiler( __CLASS__, __METHOD__ );
+
 		$file = new ArchivedFile( Title::makeTitle( NS_FILE, $row->fa_name ) );
 
 		$file->id = intval($row->fa_id);
@@ -213,6 +209,8 @@ class ArchivedFile {
 		$file->user_text = $row->fa_user_text;
 		$file->timestamp = $row->fa_timestamp;
 		$file->deleted = $row->fa_deleted;
+
+		$usernameUseProfiler->end();
 
 		return $file;
 	}

--- a/includes/filerepo/file/LocalFile.php
+++ b/includes/filerepo/file/LocalFile.php
@@ -5,6 +5,7 @@
  * @file
  * @ingroup FileAbstraction
  */
+use Wikia\Util\PerformanceProfilers\UsernameUseProfiler;
 
 /**
  * Bump this number when serialized cache records may be incompatible.
@@ -1061,6 +1062,7 @@ class LocalFile extends File {
 				#throw new MWException( "Empty oi_archive_name. Database and storage out of sync?" );
 				Wikia::logBacktrace(__METHOD__ . "::oi_archive_name - [{$this->getName()}]"); // Wikia change (BAC-1068)
 			}
+			$usernameUseProfiler = new UsernameUseProfiler( __CLASS__, __METHOD__ );
 			$reupload = true;
 			# Collision, this is an update of a file
 			# Insert previous contents into oldimage
@@ -1106,6 +1108,8 @@ class LocalFile extends File {
 				array( 'img_name' => $this->getName() ),
 				__METHOD__
 			);
+
+			$usernameUseProfiler->end();
 		}
 
 		$descTitle = $this->getTitle();
@@ -1980,6 +1984,7 @@ class LocalFileRestoreBatch {
 	 */
 	function execute() {
 		global $wgLang;
+		$usernameUseProfiler = new UsernameUseProfiler( __CLASS__, __METHOD__ );
 
 		if ( !$this->all && !$this->ids ) {
 			// Do nothing
@@ -2200,7 +2205,7 @@ class LocalFileRestoreBatch {
 		}
 
 		$this->file->unlock();
-
+		$usernameUseProfiler->end();
 		return $status;
 	}
 

--- a/includes/revisiondelete/RevisionDeleteUser.php
+++ b/includes/revisiondelete/RevisionDeleteUser.php
@@ -1,4 +1,6 @@
 <?php
+use Wikia\Util\PerformanceProfilers\UsernameUseProfiler;
+
 /**
  * Backend functions for suppressing and unsuppressing all references to a given user,
  * used when blocking with HideUser enabled.  This was spun out of SpecialBlockip.php
@@ -34,6 +36,7 @@ class RevisionDeleteUser {
 	 * @return bool
 	 */
 	private static function setUsernameBitfields( $name, $userId, $op, $dbw ) {
+		$usernameUseProfiler = new UsernameUseProfiler( __CLASS__, __METHOD__ );
 		if( $op !== '|' && $op !== '&' ){
 			return false; // sanity check
 		}
@@ -108,17 +111,6 @@ class RevisionDeleteUser {
 			array( 'oi_user_text' => $name ),
 			__METHOD__
 		);
-		/**
-		 * Check, how often is this code executed. Scope: the following if block.
-		 *
-		 * @author Mix
-		 * @see SUS-810
-		 */
-		Wikia\Logger\WikiaLogger::instance()->debugSampled(
-			0.01,
-			'SUS-810',
-			[ 'method' => __METHOD__, 'exception' => new Exception() ]
-		);
 		# Hide name from deleted images
 		$dbw->update(
 			'filearchive',
@@ -127,6 +119,7 @@ class RevisionDeleteUser {
 			__METHOD__
 		);
 		# Done!
+		$usernameUseProfiler->end();
 		return true;
 	}
 

--- a/includes/specials/SpecialBlockList.php
+++ b/includes/specials/SpecialBlockList.php
@@ -20,6 +20,7 @@
  * @file
  * @ingroup SpecialPage
  */
+use Wikia\Util\PerformanceProfilers\UsernameUseProfiler;
 
 /**
  * A special page that lists existing blocks
@@ -243,6 +244,7 @@ class BlockListPager extends TablePager {
 	}
 
 	function formatValue( $name, $value ) {
+		$usernameUseProfiler = new UsernameUseProfiler( __CLASS__, __METHOD__ );
 		static $msg = null;
 		if ( $msg === null ) {
 			$msg = array(
@@ -359,7 +361,7 @@ class BlockListPager extends TablePager {
 				$formatted = "Unable to format $name";
 				break;
 		}
-
+		$usernameUseProfiler->end();
 		return $formatted;
 	}
 

--- a/includes/specials/SpecialDeletedContributions.php
+++ b/includes/specials/SpecialDeletedContributions.php
@@ -20,6 +20,7 @@
  * @file
  * @ingroup SpecialPage
  */
+use Wikia\Util\PerformanceProfilers\UsernameUseProfiler;
 
 /**
  * Implements Special:DeletedContributions to display archived revisions
@@ -133,7 +134,7 @@ class DeletedContribsPager extends IndexPager {
 	 */
 	function formatRow( $row ) {
 		wfProfileIn( __METHOD__ );
-
+		$usernameUseProfiler = new UsernameUseProfiler( __CLASS__, __METHOD__ );
 		$rev = new Revision( array(
 				'id'         => $row->ar_rev_id,
 				'comment'    => $row->ar_comment,
@@ -229,7 +230,7 @@ class DeletedContribsPager extends IndexPager {
 		}
 
 		$ret = Html::rawElement( 'li', array(), $ret ) . "\n";
-
+		$usernameUseProfiler->end();
 		wfProfileOut( __METHOD__ );
 		return $ret;
 	}

--- a/includes/specials/SpecialUndelete.php
+++ b/includes/specials/SpecialUndelete.php
@@ -20,6 +20,7 @@
  * @file
  * @ingroup SpecialPage
  */
+use Wikia\Util\PerformanceProfilers\UsernameUseProfiler;
 
 /**
  * Used to show archived pages and eventually restore them.
@@ -1086,6 +1087,7 @@ class SpecialUndelete extends SpecialPage {
 	}
 
 	private function showHistory() {
+		$usernameUseProfiler = new UsernameUseProfiler( __CLASS__, __METHOD__ );
 		$out = $this->getOutput();
 		if( $this->mAllowed ) {
 			$out->addModules( 'mediawiki.special.undelete' );
@@ -1135,17 +1137,6 @@ class SpecialUndelete extends SpecialPage {
 		if( $haveFiles ) {
 			$batch = new LinkBatch();
 			foreach ( $files as $row ) {
-				/**
-				 * Check, how often is this code executed. Scope: the following if block.
-				 *
-				 * @author Mix
-				 * @see SUS-810
-				 */
-				Wikia\Logger\WikiaLogger::instance()->debugSampled(
-					0.01,
-					'SUS-810',
-					[ 'method' => __METHOD__, 'exception' => new Exception() ]
-				);
 				$batch->addObj( Title::makeTitleSafe( NS_USER, $row->fa_user_text ) );
 				$batch->addObj( Title::makeTitleSafe( NS_USER_TALK, $row->fa_user_text ) );
 			}
@@ -1249,7 +1240,7 @@ class SpecialUndelete extends SpecialPage {
 			$misc .= Xml::closeElement( 'form' );
 			$out->addHTML( $misc );
 		}
-
+		$usernameUseProfiler->end();
 		return true;
 	}
 

--- a/includes/wikia/services/UserStatsService.class.php
+++ b/includes/wikia/services/UserStatsService.class.php
@@ -1,6 +1,7 @@
 <?php
 
 use Wikia\Logger\WikiaLogger;
+use Wikia\Util\PerformanceProfilers\UsernameUseProfiler;
 
 class UserStatsService extends WikiaModel {
 
@@ -160,6 +161,7 @@ class UserStatsService extends WikiaModel {
 	 * @return Int Number of edits
 	 */
 	public function calculateEditCountWiki( $flags = 0 ) {
+		$usernameUseProfiler = new UsernameUseProfiler( __CLASS__, __METHOD__ );
 		if ( !$this->validateUser() ) {
 			return 0;
 		}
@@ -179,6 +181,7 @@ class UserStatsService extends WikiaModel {
 		);
 
 		$this->setUserStat( 'editcount', $editCount );
+		$usernameUseProfiler->end();
 		return $editCount;
 	}
 
@@ -207,6 +210,7 @@ class UserStatsService extends WikiaModel {
 		if ( !$this->validateUser() ) {
 			return 0;
 		}
+		$usernameUseProfiler = new UsernameUseProfiler( __CLASS__, __METHOD__ );
 
 		$dbr = $this->getDatabase( $flags );
 
@@ -229,6 +233,7 @@ class UserStatsService extends WikiaModel {
 		);
 
 		$this->setUserStat( 'editcountThisWeek', $editCount );
+		$usernameUseProfiler->end();
 		return $editCount;
 	}
 

--- a/lib/Wikia/src/Util/PerformanceProfilers/UsernameUseProfiler.php
+++ b/lib/Wikia/src/Util/PerformanceProfilers/UsernameUseProfiler.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Wikia\Util\PerformanceProfilers;
+
+
+use Wikia\Util\WikiaProfiler;
+
+/**
+ * Class UsernameUseProfiler
+ * This is helper class for provide information about how performance will change
+ * if we load username from id instead using username from table with denormalized form.
+ * See https://wikia-inc.atlassian.net/browse/SUS-953
+ * See
+ * @package Wikia\Util\PerformanceProfilers
+ */
+class UsernameUseProfiler {
+	use WikiaProfiler;
+
+	/**
+	 * @var string
+	 */
+	private $class;
+	/**
+	 * @var string
+	 */
+	private $method;
+
+	/**
+	 * @var integer
+	 */
+	private $startTime;
+
+	/**
+	 * @var float
+	 */
+	private $sampling;
+
+	const EVENT_USERNAME_FROM_ID = 'username_from_id';
+
+
+	/**
+	 * UsernameUseProfiler constructor.
+	 * @param $class string
+	 * @param $method string
+	 * @param $sampling float
+	 */
+	public function __construct( $class, $method, $sampling = 0.01 ) {
+		$this->class = $class;
+		$this->method = $method;
+		$this->sampling = $sampling;
+		$this->start();
+	}
+
+	public function start() {
+		$this->startTime = $this->startProfile();
+	}
+
+	public function end( $context = [] ) {
+		$context[ 'class' ] = $this->class;
+		$context[ 'method' ] = $this->method;
+
+		$this->endProfile(
+			static::EVENT_USERNAME_FROM_ID,
+			$this->startTime,
+			$context,
+			$this->sampling
+		);
+	}
+}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-953
https://wikia-inc.atlassian.net/browse/SUS-825

We want to start using one place for getting username.
This PR introduce monitoring for selected tables where username is keep with userid value.

Tables: filearchive, oldimage, ipblocks, archive

@mixth-sense 
