### PR TITLE
PLATFORM-2391: Prevent calling getTalk() on NS_MEDIA titles

### DIFF
--- a/includes/Skin.php
+++ b/includes/Skin.php
@@ -217,7 +217,7 @@ abstract class Skin extends ContextSource {
 		$titles = array( $user->getUserPage(), $user->getTalkPage() );
 
 		// Other tab link
-		if ( $this->getTitle()->isSpecialPage() ) {
+		if ( $this->getTitle()->isSpecialPage() || $this->getTitle()->getNamespace() == NS_MEDIA ) {
 			// nothing
 		} elseif ( $this->getTitle()->isTalkPage() ) {
 			$titles[] = $this->getTitle()->getSubjectPage();


### PR DESCRIPTION
We have been getting an exception during Mediawiki initialization when title was in NS_MEDIA namespace. This should fix the issue.

/cc @macbre 
