### PR TITLE
WW-110: Clear descendant header internal cache

### DIFF
--- a/extensions/wikia/JsonFormat/tests/JsonFormatTest.php
+++ b/extensions/wikia/JsonFormat/tests/JsonFormatTest.php
@@ -53,7 +53,6 @@ class JsonFormatTest extends WikiaBaseTest {
 	 * @dataProvider StructureProvider
 	 */
 	public function testStructureMatchingWithLazyLoad( $wikiText, $expectedStructure = null ) {
-		$this->markTestSkipped( "Skipping temporarly because of https://wikia-inc.atlassian.net/browse/MAIN-7626" );
 		$this->setThumbnailImageHooks( false );
 		$output = $this->getParsedOutput( $wikiText );
 

--- a/extensions/wikia/JsonFormat/util/DomHelper.php
+++ b/extensions/wikia/JsonFormat/util/DomHelper.php
@@ -126,4 +126,8 @@ class DomHelper {
 		return trim( $text );
 	}
 
+	public static function cleanDescendantHeaderInternalCache() {
+		self::$hasDescendantHeaderInternalCache = [];
+	}
+
 }

--- a/extensions/wikia/JsonFormat/visitors/DivContainingHeadersVisitor.php
+++ b/extensions/wikia/JsonFormat/visitors/DivContainingHeadersVisitor.php
@@ -5,6 +5,12 @@
 
 
 class DivContainingHeadersVisitor extends DOMNodeVisitorBase {
+
+	function __construct( IDOMNodeVisitor $childrenVisitor, JsonFormatBuilder $jsonFormatTraversingState )	{
+		parent::__construct( $childrenVisitor, $jsonFormatTraversingState );
+		DomHelper::cleanDescendantHeaderInternalCache();
+	}
+
 	/**
 	 * @param DOMNode $currentNode
 	 * @return bool


### PR DESCRIPTION
The problem with failing `JsonFormatTest` is because of caching descendant header in `div` element (https://github.com/Wikia/app/blob/dev/extensions/wikia/JsonFormat/util/DomHelper.php#L9).

`spl_object_hash` method (https://github.com/Wikia/app/blob/dev/extensions/wikia/JsonFormat/util/DomHelper.php#L79) creates `cacheId` and store proper value in `$hasDescendantHeaderInternalCache`, but when connected object is destroyed, proper value is not removed and the same hash may be used for other object (http://php.net/manual/en/function.spl-object-hash.php#refsect1-function.spl-object-hash-notes). 

Test `testStructureMatching` populates `$hasDescendantHeaderInternalCache` with data and then `testStructureMatchingWithLazyLoad` test uses the same data. So it sometimes happened that hash created by `spl_object_hash()` in second test already existed, but the value was different (https://github.com/Wikia/app/blob/dev/extensions/wikia/JsonFormat/visitors/DivContainingHeadersVisitor.php#L16) that we expected (in our case instead of `true` we got `false`). 

That's why JSON output returned by `HtmlParser` (https://github.com/Wikia/app/blob/dev/extensions/wikia/JsonFormat/tests/JsonFormatTest.php#L162) was wrong.

The branch I was able to reproduce failing `JsonFormatTest` is `SUS-762_image_review_cleaner` by running `./php-contractual-responsibilities`

cc @Wikia/west-wing 
