### PR TITLE
WW-166 | Switching PortabilityDashboardExtension to use portability_db instead of dataware

### DIFF
--- a/extensions/wikia/PortabilityDashboard/PortabilityDashboardModel.class.php
+++ b/extensions/wikia/PortabilityDashboard/PortabilityDashboardModel.class.php
@@ -194,8 +194,8 @@ class PortabilityDashboardModel {
 	 * @return DatabaseMysqli|null
 	 */
 	private function connect( $type = DB_SLAVE ) {
-		global $wgExternalDatawareDB;
-		return wfGetDB( $type, array(), $wgExternalDatawareDB );
+		global $wgPortabilityDB;
+		return wfGetDB( $type, array(), $wgPortabilityDB );
 	}
 
 	/**

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -768,6 +768,7 @@ $wgSwiftSyncDB = 'swift_sync';
 $wgSharedKeyPrefix = "wikicities"; // default value for shared key prefix, @see wfSharedMemcKey
 $wgWikiaMailerDB = 'wikia_mailer';
 $wgRevisionUpvotesDB = 'revision_upvotes';
+$wgPortabilityDB = 'portability_db';
 $wgForceMasterDatabase = false;  // true only during wiki creation process
 
 $wgAutoloadClasses['LBFactory_Wikia'] = "$IP/includes/wikia/LBFactory_Wikia.php";


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/WW-166

Using portability_db instead of dataware in portability dashboard ext.

**Merge together with https://github.com/Wikia/config/pull/1934**

//cc @Wikia/west-wing 
