### PR TITLE
Add appname: mediawiki to all logs

### DIFF
--- a/lib/Wikia/src/Logger/LogstashFormatter.php
+++ b/lib/Wikia/src/Logger/LogstashFormatter.php
@@ -20,6 +20,7 @@ class LogstashFormatter extends \Monolog\Formatter\LogstashFormatter {
 
 	protected function formatV0(array $record) {
 		$message = array(
+			'appname' => 'mediawiki',
 			'@timestamp' => $record['datetime'],
 			'@message' => $record['message'],
 		);


### PR DESCRIPTION
We are now starting to use "appname" as a unified property to determine the service/application that sent the log. This makes mediawiki compliant with this assumption.

/cc @macbre @owend 
