### PR TITLE
SUS-660 (Chat) remove urldecode from username comparison

### DIFF
--- a/extensions/wikia/Chat2/ChatAjax.class.php
+++ b/extensions/wikia/Chat2/ChatAjax.class.php
@@ -45,7 +45,7 @@ class ChatAjax {
 		}
 
 		$user = User::newFromId( $data['user_id'] );
-		if ( empty( $user ) || !$user->isLoggedIn() || $user->getName() != urldecode( $wgRequest->getVal( 'name', '' ) ) ) {
+		if ( empty( $user ) || !$user->isLoggedIn() || $user->getName() != $wgRequest->getVal( 'name', '' ) ) {
 			wfProfileOut( __METHOD__ );
 
 			return [ 'errorMsg' => self::ERROR_USER_NOT_FOUND ];

--- a/extensions/wikia/Chat2/ChatAjax.class.php
+++ b/extensions/wikia/Chat2/ChatAjax.class.php
@@ -45,7 +45,10 @@ class ChatAjax {
 		}
 
 		$user = User::newFromId( $data['user_id'] );
-		if ( empty( $user ) || !$user->isLoggedIn() || $user->getName() != $wgRequest->getVal( 'name', '' ) ) {
+		if ( empty( $user ) ||
+			 !$user->isLoggedIn() ||
+			 $user->getName() != $wgRequest->getVal( 'name', '' )
+			) {
 			wfProfileOut( __METHOD__ );
 
 			return [ 'errorMsg' => self::ERROR_USER_NOT_FOUND ];


### PR DESCRIPTION
@mixth-sense @TK-999 
[SUS-660 Users with "+" in their name can no longer load chat](https://wikia-inc.atlassian.net/browse/SUS-660)
Since user names reach this point in decoded form, I've removed urldecode, which was replacing '+' with space.
