### PR TITLE
[CAKE-500] Fixed article title for cake related content recirculation test

### DIFF
--- a/extensions/wikia/Recirculation/js/helpers/CakeRelatedContentHelper.js
+++ b/extensions/wikia/Recirculation/js/helpers/CakeRelatedContentHelper.js
@@ -8,11 +8,7 @@ define('ext.wikia.recirculation.helpers.cakeRelatedContent', [
 
     function loadData() {
         var deferred = $.Deferred(),
-            currentArticle = window.location.pathname.replace('_', ' ');
-
-        if (currentArticle.startsWith('/wiki/')) {
-            currentArticle =  currentArticle.split('/wiki/')[1];
-        }
+            articleTitle = window.wgTitle;
 
         nirvana.sendRequest({
             controller: 'RecirculationApi',
@@ -20,7 +16,7 @@ define('ext.wikia.recirculation.helpers.cakeRelatedContent', [
             format: 'json',
             type: 'get',
             data: {
-                relatedTo: currentArticle,
+                relatedTo: articleTitle,
                 ignore: window.location.pathname,
                 limit: options.limit
             },


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CAKE-500

Getting article title from global variable to pass for related content api request. 

`window.wgTitle` is properly denormalized so we will avoid any further issues with url encoding when passing it as entity name in request for related content.

// @Wikia/cake 
