### PR TITLE
ADEN-3639 do not allow google bot to index this controller method

### DIFF
--- a/extensions/wikia/ARecoveryEngine/ARecoveryEngineApiController.class.php
+++ b/extensions/wikia/ARecoveryEngine/ARecoveryEngineApiController.class.php
@@ -34,7 +34,6 @@ class ARecoveryEngineApiController extends WikiaController {
 			->warning( 'AdBlock Interference',
 				[ 'action' => $this->request->getVal('kind') ]
 			);
-		$this->response->setHeader('X-Robots-Tag', 'noindex,noarchive'); //ADEN-3930
 		$this->response->setContentType( 'text/javascript; charset=utf-8' );
 		$this->response->setBody( 'var arecoveryEngineLogInfoStatus=1;' );
 		$this->response->setCacheValidity( self::MAX_EVENT_INTERVAL );

--- a/extensions/wikia/ARecoveryEngine/ARecoveryEngineApiController.class.php
+++ b/extensions/wikia/ARecoveryEngine/ARecoveryEngineApiController.class.php
@@ -34,6 +34,7 @@ class ARecoveryEngineApiController extends WikiaController {
 			->warning( 'AdBlock Interference',
 				[ 'action' => $this->request->getVal('kind') ]
 			);
+		$this->response->setHeader('X-Robots-Tag', 'noindex,noarchive'); //ADEN-3930
 		$this->response->setContentType( 'text/javascript; charset=utf-8' );
 		$this->response->setBody( 'var arecoveryEngineLogInfoStatus=1;' );
 		$this->response->setCacheValidity( self::MAX_EVENT_INTERVAL );

--- a/extensions/wikia/RobotsTxt/classes/WikiaRobots.class.php
+++ b/extensions/wikia/RobotsTxt/classes/WikiaRobots.class.php
@@ -74,6 +74,8 @@ class WikiaRobots {
 	private $blockedPaths = [
 		'/d/u/', // User pages for discussions
 		'/fandom?p=', // Fandom old URLs
+		'/wikia.php?controller=ARecoveryEngineApi', // logging for ad-recovery (ADEN-3930)
+		'/api/v1/ARecoveryEngine' // logging for ad-recovery (ADEN-3930)
 	];
 
 	/**


### PR DESCRIPTION
For details please see ADEN-3639. 
This change prevents Google Bot accessing our logging endpoint 
/wikia.php?controller=ARecoveryEngineApi&method=getLogInfo&kind=css-display-none

As this is tricky change, I'd like to ask SEO team for CR (CC: @gabrys )
