### PR TITLE
Updated the way that we parse wikitext inside of the Lyrics tag to a …

### DIFF
--- a/extensions/3rdparty/LyricWiki/Tag_Lyric.php
+++ b/extensions/3rdparty/LyricWiki/Tag_Lyric.php
@@ -92,7 +92,7 @@ DOC
 	return true;
 }
 
-function renderLyricTag($input, $argv, $parser)
+function renderLyricTag( $input, array $argv, Parser $parser, PPFrame $frame )
 {
 	wfProfileIn( __METHOD__ );
 
@@ -108,7 +108,7 @@ function renderLyricTag($input, $argv, $parser)
 	}
 
 	#parse embedded wikitext
-	$transform = $parser->parse($transform, $parser->mTitle, $parser->mOptions, false, false)->getText();
+	$transform = $parser->recursiveTagParse( $transform, $frame );
 
 	$retVal = "";
 	$retVal.= gracenote_getNoscriptTag();


### PR DESCRIPTION
…more modern approach (available since 1.16) and that fixes the issue with MercuryApi::getPage's call to ArticleAsJson not understanding that this is a single tag and not an article. The undesired side-effect of the old code is that the parser thought this was an article and so it was outputting '{content:' at the beginning (eg: treating the tag like an article that needed to be encoded as JSON when wgArticleAsJson was true).
