### PR TITLE
SUS-912 Changed regexp to include more whitespaces

### DIFF
--- a/maintenance/wikia/WikiaMaps/removeImapTags.php
+++ b/maintenance/wikia/WikiaMaps/removeImapTags.php
@@ -18,6 +18,8 @@ class RemoveImapTags extends Maintenance {
 	private $mapsClientConfig;
 	private $slaveDBConfig;
 
+	private $imapSearchRegexp = "/<imap\s+map\-id\=[\'\"]?(\d{1,})[\'\"]?\s*(>\s*<\s*\/\s*imap|\/)\s*>/";
+
 
 	public function __construct() {
 		parent::__construct();
@@ -70,9 +72,8 @@ class RemoveImapTags extends Maintenance {
 		if ( $article instanceof Article && $article->getID() ) {
 			$results = null;
 			$articleContent = $article->getContent();
-			$imapSearchRegexp = "/<imap.*map\-id\=['\"](\d{1,})['\"].*(<\/imap|\/)>/";
 
-			$noOfFoundTags = preg_match_all($imapSearchRegexp, $articleContent, $results);
+			$noOfFoundTags = preg_match_all($this->imapSearchRegexp, $articleContent, $results);
 
 			if( $noOfFoundTags === 0 ) {
 				return false;

--- a/maintenance/wikia/WikiaMaps/removeImapTags.php
+++ b/maintenance/wikia/WikiaMaps/removeImapTags.php
@@ -35,7 +35,7 @@ class RemoveImapTags extends Maintenance {
 	}
 
 	static public function isDryRun() {
-		return self::$dryRun;
+		return static::$dryRun;
 	}
 
 	static public function isNaturalNumber( $int ) {
@@ -111,7 +111,7 @@ class RemoveImapTags extends Maintenance {
 			$newContent = str_replace( $stringWithTagToRemove, "", $oldContent );
 
 			$this->output( sprintf( 'Trying to edit article #%d', $articleId ) . PHP_EOL );
-			if( !self::isDryRun() ) {
+			if( !static::isDryRun() ) {
 				$result = $article->doEdit(
 					$newContent,
 					wfMessage(
@@ -138,7 +138,7 @@ class RemoveImapTags extends Maintenance {
 	}
 
 	public function isValidTilesSetId( $tilesSetId ) {
-		if ( !self::isNaturalNumber( $tilesSetId ) ) {
+		if ( !static::isNaturalNumber( $tilesSetId ) ) {
 			return false;
 		}
 
@@ -158,12 +158,12 @@ class RemoveImapTags extends Maintenance {
 		$this->slaveDBConfig = $this->app->wg->IntMapFullConfig['db']['prod']['slave'][0];
 		$this->maps = new WikiaMaps( $this->mapsClientConfig );
 
-		self::$dryRun = $this->hasOption( 'dry-run' );
+		static::$dryRun = $this->hasOption( 'dry-run' );
 
 		$cityId = $this->app->wg->CityId;
 		$tilesSetId = $this->getOption( 'tiles-set-id' );
 
-		if ( self::isDryRun() ) {
+		if ( static::isDryRun() ) {
 			$this->output( 'Mode: test run' . PHP_EOL );
 		} else {
 			$this->output( 'Mode: normal run' . PHP_EOL );
@@ -173,7 +173,7 @@ class RemoveImapTags extends Maintenance {
 			$this->error( 'Invalid tiles-set-id. Try again.' . PHP_EOL, 1 );
 		}
 
-		$mapsUsingTheTileset = self::getMapsIdsUsingTileset( $cityId, $tilesSetId );
+		$mapsUsingTheTileset = static::getMapsIdsUsingTileset( $cityId, $tilesSetId );
 		$mapsUsingTheTilesetCount = count($mapsUsingTheTileset);
 		$this->output( sprintf( "Found %d maps using the tiles's set #%d", $mapsUsingTheTilesetCount, $tilesSetId ) . PHP_EOL );
 
@@ -181,7 +181,7 @@ class RemoveImapTags extends Maintenance {
 			$this->output( 'No maps found.' . PHP_EOL );
 		}
 
-		$articlesUsingImap = self::getArticlesIdsUsingImap( $cityId );
+		$articlesUsingImap = static::getArticlesIdsUsingImap( $cityId );
 		$articlesUsingImapCount = count( $articlesUsingImap );
 		$this->output( sprintf( "Found %d articles using <imap/>", $articlesUsingImapCount ) . PHP_EOL );
 

--- a/maintenance/wikia/WikiaMaps/removeImapTags.php
+++ b/maintenance/wikia/WikiaMaps/removeImapTags.php
@@ -18,7 +18,7 @@ class RemoveImapTags extends Maintenance {
 	private $mapsClientConfig;
 	private $slaveDBConfig;
 
-	private $imapSearchRegexp = "/<imap\s+map\-id\=[\'\"]?(\d{1,})[\'\"]?\s*(>\s*<\s*\/\s*imap|\/)\s*>/";
+	private $imapSearchRegexp = "/<imap\s+.*map\-id\s*\=\s*[\'\"]?(\d{1,})[\'\"]?\s*.*(>\s*<\s*\/\s*imap|\/)\s*>/";
 
 
 	public function __construct() {

--- a/maintenance/wikia/tests/removeImapTagsTest.php
+++ b/maintenance/wikia/tests/removeImapTagsTest.php
@@ -57,11 +57,13 @@ class RemoveImapTagsTests extends WikiaBaseTest {
 			],
 			[
 				pageContent => "<imap map-id=\"10\" ></imap >",
-				expectedResult => false
+				expectedResult => true,
+				mapId => 10
 			],
 			[
-				pageContent => "<imap map-id=\"11\" ></ imap> ",
-				expectedResult => false
+				pageContent => "<imap map-id=\"11\" ></ imap>",
+				expectedResult => true,
+				mapId => 11
 			],
 			[
 				pageContent => "<imap map-id=\"12\" ><imap> ",
@@ -79,6 +81,16 @@ class RemoveImapTagsTests extends WikiaBaseTest {
 				pageContent => "<imap></imap>",
 				expectedResult => false
 			],
+			[
+				pageContent => "<imap map-id=16/> </imap>",
+				expectedResult => true,
+				mapId => 16
+			],
+			[
+				pageContent => "<imap map-id=17 /></imap>",
+				expectedResult => true,
+				mapId => 17
+			],
 		];
 
 		foreach( $testCases as $testCase ) {
@@ -95,7 +107,7 @@ class RemoveImapTagsTests extends WikiaBaseTest {
 				$this->assertEquals( $testCase['mapId'], $foundTagsMapIds[0] );
 				$this->assertTrue( $actualResult );
 			} else {
-				$this->assertFalse( $actualResult );
+				$this->assertFalse( $actualResult, $testCase['pageContent'] );
 			}
 
 		}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-912

After running script to remove maps we noticed the regexp searching for imap tags does not include some edge cases. Extended the regexp to include whitespaces and id's without quotation mark. Tested using https://regex101.com/
