### PR TITLE
WW-256 | Preventing messages to be escaped twice in CommunityPage

### DIFF
--- a/extensions/wikia/CommunityPage/CommunityPageSpecialController.class.php
+++ b/extensions/wikia/CommunityPage/CommunityPageSpecialController.class.php
@@ -22,7 +22,7 @@ class CommunityPageSpecialController extends WikiaSpecialPageController {
 
 	public function index() {
 		$this->specialPage->setHeaders();
-		$this->getOutput()->setPageTitle( $this->msg( 'communitypage-title' )->plain() );
+		$this->getOutput()->setPageTitle( $this->msg( 'communitypage-title' )->text() );
 		$this->addAssets();
 
 		$this->wg->SuppressPageHeader = true;
@@ -33,11 +33,11 @@ class CommunityPageSpecialController extends WikiaSpecialPageController {
 
 		$this->response->setValues( [
 			'heroImageUrl' => $this->getHeroImageUrl(),
-			'inviteFriendsText' => $this->msg( 'communitypage-invite-friends' )->plain(),
+			'inviteFriendsText' => $this->msg( 'communitypage-invite-friends' )->text(),
 			'headerWelcomeMsg' => $this->msg( 'communitypage-tasks-header-welcome' )->parse(),
 			'adminWelcomeMsg' => $this->msg( 'communitypage-admin-welcome-message' )->text(),
-			'pageListEmptyText' => $this->msg( 'communitypage-page-list-empty' )->plain(),
-			'pageTitle' => $this->msg( 'communitypage-title' )->plain(),
+			'pageListEmptyText' => $this->msg( 'communitypage-page-list-empty' )->text(),
+			'pageTitle' => $this->msg( 'communitypage-title' )->text(),
 			'topContributors' => $this->sendRequest(
 				'CommunityPageSpecialController',
 				'getTopContributorsData',
@@ -83,25 +83,25 @@ class CommunityPageSpecialController extends WikiaSpecialPageController {
 		$login = Html::element(
 			'a',
 			[ 'href' => 'https://www.wikia.com/signin?' . $query ],
-			$this->msg( 'communitypage-anon-login' )->plain()
+			$this->msg( 'communitypage-anon-login' )->text()
 		);
 
 		$register = Html::element(
 			'a',
 			[ 'href' => 'https://www.wikia.com/register?' . $query ],
-			$this->msg( 'communitypage-anon-register' )->plain()
+			$this->msg( 'communitypage-anon-register' )->text()
 		);
 
 		$anonText = $this->msg( 'communitypage-anon-contrib-header' )->rawParams( $login, $register )->escaped();
 
 		$this->response->setData( [
-			'admin' => $this->msg( 'communitypage-admin' )->plain(),
-			'topContribsHeaderText' => $this->msg( 'communitypage-top-contributors-week' )->plain(),
-			'yourRankText' => $this->msg( 'communitypage-user-rank' )->plain(),
+			'admin' => $this->msg( 'communitypage-admin' )->text(),
+			'topContribsHeaderText' => $this->msg( 'communitypage-top-contributors-week' )->text(),
+			'yourRankText' => $this->msg( 'communitypage-user-rank' )->text(),
 			'userContributionsText' => $this->msg( 'communitypage-user-contributions' )
 				->numParams( $this->getLanguage()->formatNum( $currentUserContributionCount ) )
 				->text(),
-			'noContribsText' => $this->msg( 'communitypage-no-contributions' )->plain(),
+			'noContribsText' => $this->msg( 'communitypage-no-contributions' )->text(),
 			'contributors' => $topContributorsDetails,
 			'userAvatar' => AvatarService::renderAvatar(
 				$this->getUser()->getName(),
@@ -131,10 +131,10 @@ class CommunityPageSpecialController extends WikiaSpecialPageController {
 			);
 
 		$templateMessages = [
-			'topAdminsHeaderText' => $this->msg( 'communitypage-admins' )->plain(),
-			'otherAdmins' => $this->msg( 'communitypage-other-admins' )->plain(),
-			'noAdminText' => $this->msg( 'communitypage-no-admins' )->plain(),
-			'noAdminContactText' => $this->msg( 'communitypage-no-admins-contact' )->plain(),
+			'topAdminsHeaderText' => $this->msg( 'communitypage-admins' )->text(),
+			'otherAdmins' => $this->msg( 'communitypage-other-admins' )->text(),
+			'noAdminText' => $this->msg( 'communitypage-no-admins' )->text(),
+			'noAdminContactText' => $this->msg( 'communitypage-no-admins-contact' )->text(),
 			'noAdminHref' => $this->msg( 'communitypage-communitycentral-link' )->inContentLanguage()->text(),
 		];
 		$this->response->setData( array_merge( $templateMessages, $topAdminsTemplateData ) );
@@ -150,12 +150,12 @@ class CommunityPageSpecialController extends WikiaSpecialPageController {
 		$allAdminsDetails = $this->getContributorsDetails( $allAdminsDetails );
 
 		$this->response->setData( [
-			'topAdminsHeaderText' => $this->msg( 'communitypage-admins' )->plain(),
-			'allAdminsLegend' => $this->msg( 'communitypage-modal-tab-all-contribution-header' )->plain(),
+			'topAdminsHeaderText' => $this->msg( 'communitypage-admins' )->text(),
+			'allAdminsLegend' => $this->msg( 'communitypage-modal-tab-all-contribution-header' )->text(),
 			'allAdminsList' => $allAdminsDetails,
 			'allAdminsCount' => $this->getLanguage()->formatNum( count( $allAdminsDetails ) ),
-			'noAdminText' => $this->msg( 'communitypage-no-admins' )->plain(),
-			'noAdminContactText' => $this->msg( 'communitypage-no-admins-contact' )->plain(),
+			'noAdminText' => $this->msg( 'communitypage-no-admins' )->text(),
+			'noAdminContactText' => $this->msg( 'communitypage-no-admins-contact' )->text(),
 			'noAdminHref' => $this->msg( 'communitypage-communitycentral-link' )->inContentLanguage()->text(),
 		] );
 	}
@@ -168,8 +168,8 @@ class CommunityPageSpecialController extends WikiaSpecialPageController {
 		$recentlyJoined = $this->usersModel->getRecentlyJoinedUsers();
 
 		$this->response->setData( [
-			'allMembers' => $this->msg( 'communitypage-view-all-members' )->plain(),
-			'recentlyJoinedHeaderText' => $this->msg( 'communitypage-recently-joined' )->plain(),
+			'allMembers' => $this->msg( 'communitypage-view-all-members' )->text(),
+			'recentlyJoinedHeaderText' => $this->msg( 'communitypage-recently-joined' )->text(),
 			'members' => $recentlyJoined,
 			'haveNewMembers' => count( $recentlyJoined ) > 0,
 		] );
@@ -188,16 +188,16 @@ class CommunityPageSpecialController extends WikiaSpecialPageController {
 		$membersCount = $this->usersModel->getMemberCount();
 
 		$this->response->setData( [
-			'allMembersHeaderText' => $this->msg( 'communitypage-all-members' )->plain(),
-			'allContributorsLegend' => $this->msg( 'communitypage-modal-tab-all-contribution-header' )->plain(),
-			'admin' => $this->msg( 'communitypage-admin' )->plain(),
-			'joinedText' => $this->msg( 'communitypage-joined' )->plain(),
-			'noMembersText' => $this->msg( 'communitypage-no-members' )->plain(),
+			'allMembersHeaderText' => $this->msg( 'communitypage-all-members' )->text(),
+			'allContributorsLegend' => $this->msg( 'communitypage-modal-tab-all-contribution-header' )->text(),
+			'admin' => $this->msg( 'communitypage-admin' )->text(),
+			'joinedText' => $this->msg( 'communitypage-joined' )->text(),
+			'noMembersText' => $this->msg( 'communitypage-no-members' )->text(),
 			'members' => $allMembers,
 			'membersCount' => $this->getLanguage()->formatNum( $membersCount ),
 			'haveMoreMembers' => $membersCount >= CommunityPageSpecialUsersModel::ALL_CONTRIBUTORS_MODAL_LIMIT,
 			'moreMembersLink' => $moreMembers->getCanonicalURL(),
-			'moreMembersText' => $this->msg( 'communitypage-view-more' )->plain(),
+			'moreMembersText' => $this->msg( 'communitypage-view-more' )->text(),
 		] );
 	}
 
@@ -225,20 +225,20 @@ class CommunityPageSpecialController extends WikiaSpecialPageController {
 		$memberCount = $this->usersModel->getMemberCount();
 
 		$this->response->setData( [
-			'allText' => $this->msg( 'communitypage-modal-tab-all' )->plain(),
+			'allText' => $this->msg( 'communitypage-modal-tab-all' )->text(),
 			'allCount' => $this->getLanguage()->formatNum( $memberCount ),
-			'adminsText' => $this->msg( 'communitypage-modal-tab-admins' )->plain(),
+			'adminsText' => $this->msg( 'communitypage-modal-tab-admins' )->text(),
 			'allAdminsCount' => $this->getLanguage()->formatNum( count( $this->usersModel->getAllAdmins() ) ),
-			'leaderboardText' => $this->msg( 'communitypage-top-contributors-week' )->plain(),
+			'leaderboardText' => $this->msg( 'communitypage-top-contributors-week' )->text(),
 		] );
 	}
 
 	public function getFirstTimeEditorModalData() {
 		$this->response->setData( [
-			'headingText' => $this->msg( 'communitypage-first-edit-heading' )->plain(),
-			'subheadingText' => $this->msg( 'communitypage-first-edit-subheading' )->plain(),
-			'getStartedText' => $this->msg( 'communitypage-first-edit-get-started' )->plain(),
-			'maybeLaterText' => $this->msg( 'communitypage-first-edit-maybe-later' )->plain(),
+			'headingText' => $this->msg( 'communitypage-first-edit-heading' )->text(),
+			'subheadingText' => $this->msg( 'communitypage-first-edit-subheading' )->text(),
+			'getStartedText' => $this->msg( 'communitypage-first-edit-get-started' )->text(),
+			'maybeLaterText' => $this->msg( 'communitypage-first-edit-maybe-later' )->text(),
 			'getStartedLink' => $this->getTitle()->getCanonicalURL(),
 		] );
 	}
@@ -279,7 +279,7 @@ class CommunityPageSpecialController extends WikiaSpecialPageController {
 			$count += 1;
 
 			if ( User::isIp( $userName ) ) {
-				$userName = $this->msg( 'oasis-anon-user' )->plain();
+				$userName = $this->msg( 'oasis-anon-user' )->text();
 			}
 
 			return [
@@ -366,10 +366,10 @@ class CommunityPageSpecialController extends WikiaSpecialPageController {
 		return array_merge( $data, [
 			'showEditLink' => $user->isAllowed( 'editinterface' ),
 			'isZeroState' => !$data[ 'haveContent' ],
-			'heading' => $this->msg( 'communitypage-todo-module-heading' )->plain(),
-			'editList' => $this->msg( 'communitypage-todo-module-edit-list' )->plain(),
-			'description' => $this->msg( 'communitypage-todo-module-description' )->plain(),
-			'zeroStateText' => $this->msg( 'communitypage-todo-module-zero-state' )->plain(),
+			'heading' => $this->msg( 'communitypage-todo-module-heading' )->text(),
+			'editList' => $this->msg( 'communitypage-todo-module-edit-list' )->text(),
+			'description' => $this->msg( 'communitypage-todo-module-description' )->text(),
+			'zeroStateText' => $this->msg( 'communitypage-todo-module-zero-state' )->text(),
 		] );
 	}
 }

--- a/extensions/wikia/CommunityPage/CommunityPageSpecialController.class.php
+++ b/extensions/wikia/CommunityPage/CommunityPageSpecialController.class.php
@@ -34,7 +34,7 @@ class CommunityPageSpecialController extends WikiaSpecialPageController {
 		$this->response->setValues( [
 			'heroImageUrl' => $this->getHeroImageUrl(),
 			'inviteFriendsText' => $this->msg( 'communitypage-invite-friends' )->text(),
-			'headerWelcomeMsg' => $this->msg( 'communitypage-tasks-header-welcome' )->parse(),
+			'headerWelcomeMsg' => $this->msg( 'communitypage-tasks-header-welcome' )->plain(),
 			'adminWelcomeMsg' => $this->msg( 'communitypage-admin-welcome-message' )->text(),
 			'pageListEmptyText' => $this->msg( 'communitypage-page-list-empty' )->text(),
 			'pageTitle' => $this->msg( 'communitypage-title' )->text(),
@@ -369,7 +369,7 @@ class CommunityPageSpecialController extends WikiaSpecialPageController {
 			'heading' => $this->msg( 'communitypage-todo-module-heading' )->text(),
 			'editList' => $this->msg( 'communitypage-todo-module-edit-list' )->text(),
 			'description' => $this->msg( 'communitypage-todo-module-description' )->text(),
-			'zeroStateText' => $this->msg( 'communitypage-todo-module-zero-state' )->text(),
+			'zeroStateText' => $this->msg( 'communitypage-todo-module-zero-state' )->plain(),
 		] );
 	}
 }

--- a/extensions/wikia/CommunityPage/models/CommunityPageSpecialHelpModel.class.php
+++ b/extensions/wikia/CommunityPage/models/CommunityPageSpecialHelpModel.class.php
@@ -3,10 +3,10 @@
 class CommunityPageSpecialHelpModel {
 	public function getData() {
 		return [
-			'title' => wfMessage( 'communitypage-help-module-title' )->plain(),
-			'editPage' => wfMessage( 'communitypage-help-edit-page' )->plain(),
-			'addLinks' => wfMessage( 'communitypage-help-add-link' )->plain(),
-			'addNewPage' => wfMessage( 'communitypage-help-add-new-page' )->plain(),
+			'title' => wfMessage( 'communitypage-help-module-title' )->text(),
+			'editPage' => wfMessage( 'communitypage-help-edit-page' )->text(),
+			'addLinks' => wfMessage( 'communitypage-help-add-link' )->text(),
+			'addNewPage' => wfMessage( 'communitypage-help-add-new-page' )->text(),
 			'editPageLink' => $this->getHelpPageLink( 'communitypage-help-module-edit-page-name' ),
 			'addLinksPageLink' => $this->getHelpPageLink( 'communitypage-help-module-add-link-name' ),
 			'addNewPageLink' => $this->getHelpPageLink( 'communitypage-help-module-new-page-name' )

--- a/extensions/wikia/CommunityPage/models/CommunityPageSpecialInsightsModel.class.php
+++ b/extensions/wikia/CommunityPage/models/CommunityPageSpecialInsightsModel.class.php
@@ -174,7 +174,7 @@ class CommunityPageSpecialInsightsModel {
 		$userName = $metadata['lastRevision']['username'];
 
 		if ( User::isIp( $userName ) ) {
-			$userName = wfMessage( 'oasis-anon-user' )->plain();
+			$userName = wfMessage( 'oasis-anon-user' )->text();
 		}
 
 		return wfMessage( 'communitypage-lastrevision' )->rawParams(

--- a/extensions/wikia/CommunityPage/models/CommunityPageSpecialRecentActivityModel.class.php
+++ b/extensions/wikia/CommunityPage/models/CommunityPageSpecialRecentActivityModel.class.php
@@ -14,7 +14,7 @@ class CommunityPageSpecialRecentActivityModel {
 			$userName = $activity['user_name'];
 
 			if ( User::isIp( $userName ) ) {
-				$userName = wfMessage( 'oasis-anon-user' )->plain();
+				$userName = wfMessage( 'oasis-anon-user' )->text();
 			}
 
 			$changeTypeString = $this->getChangeTypeMessage( $activity['changetype'] );
@@ -22,7 +22,7 @@ class CommunityPageSpecialRecentActivityModel {
 			$pageLink = $this->getPageLink( $activity['page_title'], $activity['page_url'] );
 
 			$changeMessage = wfMessage( 'communitypage-activity',
-				$userProfileLink, $changeTypeString, $pageLink )->plain();
+				$userProfileLink, $changeTypeString, $pageLink )->text();
 
 			$recentActivity[] = [
 				'timeAgo' => $activity['time_ago'],
@@ -37,8 +37,8 @@ class CommunityPageSpecialRecentActivityModel {
 		$title = SpecialPage::getTitleFor( 'WikiActivity' );
 
 		return [
-			'activityHeading' => wfMessage( 'communitypage-recent-activity-header' )->plain(),
-			'moreActivityText' => wfMessage( 'communitypage-recent-activity' )->plain(),
+			'activityHeading' => wfMessage( 'communitypage-recent-activity-header' )->text(),
+			'moreActivityText' => wfMessage( 'communitypage-recent-activity' )->text(),
 			'moreActivityLink' => $title->getCanonicalURL(),
 			'activity' => $recentActivity,
 		];

--- a/extensions/wikia/CommunityPage/models/CommunityPageSpecialRecentActivityModel.class.php
+++ b/extensions/wikia/CommunityPage/models/CommunityPageSpecialRecentActivityModel.class.php
@@ -14,7 +14,7 @@ class CommunityPageSpecialRecentActivityModel {
 			$userName = $activity['user_name'];
 
 			if ( User::isIp( $userName ) ) {
-				$userName = wfMessage( 'oasis-anon-user' )->text();
+				$userName = wfMessage( 'oasis-anon-user' )->plain();
 			}
 
 			$changeTypeString = $this->getChangeTypeMessage( $activity['changetype'] );
@@ -22,7 +22,7 @@ class CommunityPageSpecialRecentActivityModel {
 			$pageLink = $this->getPageLink( $activity['page_title'], $activity['page_url'] );
 
 			$changeMessage = wfMessage( 'communitypage-activity',
-				$userProfileLink, $changeTypeString, $pageLink )->text();
+				$userProfileLink, $changeTypeString, $pageLink )->plain();
 
 			$recentActivity[] = [
 				'timeAgo' => $activity['time_ago'],
@@ -37,8 +37,8 @@ class CommunityPageSpecialRecentActivityModel {
 		$title = SpecialPage::getTitleFor( 'WikiActivity' );
 
 		return [
-			'activityHeading' => wfMessage( 'communitypage-recent-activity-header' )->text(),
-			'moreActivityText' => wfMessage( 'communitypage-recent-activity' )->text(),
+			'activityHeading' => wfMessage( 'communitypage-recent-activity-header' )->plain(),
+			'moreActivityText' => wfMessage( 'communitypage-recent-activity' )->plain(),
 			'moreActivityLink' => $title->getCanonicalURL(),
 			'activity' => $recentActivity,
 		];

--- a/extensions/wikia/CommunityPage/models/CommunityPageSpecialUsersModel.class.php
+++ b/extensions/wikia/CommunityPage/models/CommunityPageSpecialUsersModel.class.php
@@ -427,7 +427,7 @@ class CommunityPageSpecialUsersModel {
 			$avatar = AvatarService::renderAvatar( $userName, AvatarService::AVATAR_SIZE_SMALL_PLUS );
 
 			if ( User::isIp( $userName ) ) {
-				$userName = wfMessage( 'oasis-anon-user' )->plain();
+				$userName = wfMessage( 'oasis-anon-user' )->text();
 			}
 
 			return [


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/WW-256

Messages where escaped twice (wfMessage(..)->plain() and at mustache level) and that caused displaying things like {code}
Brak edycji w tym tygodniu! Bądź {{GENDER:|pierwszy|pierwsza!}}
{code}

@Wikia/west-wing 
