### PR TITLE
MAIN-7924 updating global nav api params

### DIFF
--- a/includes/wikia/api/DesignSystemApiController.class.php
+++ b/includes/wikia/api/DesignSystemApiController.class.php
@@ -22,7 +22,11 @@ class DesignSystemApiController extends WikiaApiController {
 		$params = $this->getRequestParameters();
 
 		$this->setResponseData(
-			( new DesignSystemGlobalNavigationModel( $params[ 'wikiId' ], $params[ 'lang' ] ) )->getData() );
+			( new DesignSystemGlobalNavigationModel(
+				$params[static::PARAM_PRODUCT],
+				$params[static::PARAM_ID],
+				$params[static::PARAM_LANG]
+			) )->getData() );
 
 		$this->addCachingHeaders();
 	}


### PR DESCRIPTION
Looks like a merge error caused some out of date code to crop up. This should fix that.

Link to api tests changes: https://github.com/Wikia/api-tests/pull/215

@Wikia/west-wing @Wikia/x-wing 
