### PR TITLE
[CAKE-481] Enity related content and impact footer integration

### DIFF
--- a/extensions/wikia/Recirculation/services/CakeRelatedContentService.php
+++ b/extensions/wikia/Recirculation/services/CakeRelatedContentService.php
@@ -146,7 +146,7 @@ class CakeRelatedContentService {
 
 		if ($content->getContentType() == "Discussion Thread") {
 			return $wgContLang->truncate(
-					"[Discussions] {$content->getTitle()}",
+					$content->getTitle(),
 					self::DISCUSSION_THREAD_TITLE_MAX_LENGTH);
 		}
 

--- a/extensions/wikia/Recirculation/services/CakeRelatedContentService.php
+++ b/extensions/wikia/Recirculation/services/CakeRelatedContentService.php
@@ -105,6 +105,7 @@ class CakeRelatedContentService {
 								'thumbnail' => $content->getImage(),
 								'title' => $this->formatTitle($content),
 								'publishDate' => $content->getModified(),
+								'author' => $this->getAuthor($content->getContentMetadata()),
 								'isVideo' => false,
 								'meta' => $content->getContentMetadata(),
 								'source' => $this->getRecirculationContentType($content->getContentType()),
@@ -150,6 +151,15 @@ class CakeRelatedContentService {
 		}
 
 		return $content->getTitle();
+	}
+
+	private function getAuthor($metadata) {
+		if (array_key_exists("authorName", $metadata)) {
+			return $metadata["authorName"];
+		} else {
+			return "";
+		}
+
 	}
 
 	private function getRecirculationContentType($contentType) {

--- a/extensions/wikia/Recirculation/services/CakeRelatedContentService.php
+++ b/extensions/wikia/Recirculation/services/CakeRelatedContentService.php
@@ -104,6 +104,10 @@ class CakeRelatedContentService {
 								'url' => $content->getUrl(),
 								'thumbnail' => $content->getImage(),
 								'title' => $this->formatTitle($content),
+								'publishDate' => $content->getModified(),
+								'isVideo' => false,
+								'meta' => $content->getContentMetadata(),
+								'source' => $this->getRecirculationContentType($content->getContentType()),
 							] );
 					}
 
@@ -146,6 +150,20 @@ class CakeRelatedContentService {
 		}
 
 		return $content->getTitle();
+	}
+
+	private function getRecirculationContentType($contentType) {
+		switch ($contentType) {
+			case "Discussion Thread":
+				return "discussions";
+			case "Fandom Article":
+				return "fandom";
+			case "Wiki Article":
+				return "wiki";
+			default:
+				return "undefined";
+		}
+
 	}
 
 	private function onValidWiki() {


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CAKE-481

Adjusted the data produced by `CakeRelatedContentService/getContentRelatedTo` so we can use it as data source for impact footer.

//cc @Wikia/cake @pauloslund 
