### PR TITLE
JPN-650 Make sure wikipage.content hook fires when switching out of m…

### DIFF
--- a/extensions/wikia/EditPreview/js/preview.js
+++ b/extensions/wikia/EditPreview/js/preview.js
@@ -35,7 +35,8 @@ define('wikia.preview', [
 		previewTypes, //List of available preview options
 		currentTypeName, //Currently used preview type
 		editPageOptions, //options passed from EditPageLayout
-		previewLoaded; //a flag indicating that preview has been loaded
+		previewLoaded, //a flag indicating that preview has been loaded
+		previousType; // the previous preview type loaded if any
 
 	// show dialog for preview / show changes and scale it to fit viewport's height
 	function renderDialog(title, options, callback) {
@@ -140,7 +141,13 @@ define('wikia.preview', [
 
 				// fire event when new article comment is/will be added to DOM
 				mw.hook('wikipage.content').fire($article);
+			} else if (previousType === previewTypes.mobile.name) {
+				// always fire event when switching out of mobile preview
+				mw.hook('wikipage.content').fire($article);
 			}
+
+			previousType = type;
+
 			//If current view is different skin, pass it to getPreviewContent
 		}, previewTypes[currentTypeName].skin);
 	}


### PR DESCRIPTION
…obile preview in classic editor

Steps to reproduce:
Open classic editor
Click on mobile preview
Wait until the Mercury preview is loaded
Select Desktop from the top drop-down
Expected result: wikipage.content hook should fire as the view switches between Mercury and Oasis, and the DOM is reloaded.
Actual result: wikipage.content does not fire. It only fires on the first load of the Preview dialog.
This will affect any dynamically rendered element that relies on the wikipage.content hook to trigger JS.

@d34th4ck3r @Grunny @garthwebb 
