### PR TITLE
(XW-2046) Support the user's go search preference by default

### DIFF
--- a/extensions/wikia/Search/WikiaSearchController.class.php
+++ b/extensions/wikia/Search/WikiaSearchController.class.php
@@ -565,11 +565,15 @@ class WikiaSearchController extends WikiaSpecialPageController {
 	 * @return bool
 	 */
 	private function useGoSearch() {
-		$default = $this->getUser()->getGlobalPreference( 'enableGoSearch' ) ? '0' : 'Search';
-		// Support for Monobook's "Go" button and functionality
-		$fulltext = $this->getVal( 'fulltext', $this->getVal( 'go', $default ) );
+		$fulltext = $this->getVal( 'fulltext' );
 
-		return $fulltext === '0' || $fulltext === 'Go';
+		// For backwards compatibility ?fulltext=0 means use Go search
+		// and if fulltext is set and not equal to 0, it means that the
+		// user is trying to manually go to search and override their preference
+		// such as with Monobook's "Search" button
+		return $fulltext === '0' ||
+			$this->getVal( 'go' ) !== null ||
+			( $fulltext === null && $this->getUser()->getGlobalPreference( 'enableGoSearch' ) );
 	}
 
 	/**

--- a/extensions/wikia/Search/classes/Test/Controller/SearchControllerTest.php
+++ b/extensions/wikia/Search/classes/Test/Controller/SearchControllerTest.php
@@ -182,14 +182,13 @@ class SearchControllerTest extends Wikia\Search\Test\BaseTest {
 	 * @covers WikiaSearchController::handleArticleMatchTracking
 	 */
 	public function testArticleMatchTrackingWithMatch() {
-		$mockController = $this->searchController->setMethods( [ 'getVal', 'getUser' ] )->getMock();
+		$mockController = $this->searchController->setMethods( [ 'getVal' ] )->getMock();
 		$searchConfig = $this->getMock( 'Wikia\Search\Config', [ 'getQuery', 'getPage', 'hasArticleMatch', 'getArticleMatch' ] );
 		$mockQuery = $this->getMock( 'Wikia\Search\Query', [ 'getSanitizedQuery' ] );
 		$mockTitle = $this->getMockBuilder( 'Title' )
 		                  ->disableOriginalConstructor()
 		                  ->setMethods( [ 'getFullUrl' ] )
 		                  ->getMock();
-		$mockUser = $this->getMock( 'User', [ 'getGlobalPreference' ] );
 		$mockResponse = $this->getMock( 'WikiaResponse', [ 'redirect' ], [ 'html' ] );
 		$mockMatch = $this->getMockBuilder( 'Wikia\Search\Match\Article' )
 		                  ->disableOriginalConstructor()
@@ -232,18 +231,10 @@ class SearchControllerTest extends Wikia\Search\Test\BaseTest {
 			->expects( $this->any() )
 			->method( 'hasArticleMatch' )
 			->will( $this->returnValue( true ) );
-		$mockUser
-			->expects( $this->once() )
-			->method( 'getGlobalPreference' )
-			->will( $this->returnValue( false ) );
 		$mockController
 			->expects( $this->any() )
 			->method( 'getVal' )
 			->will( $this->returnValue( '0' ) );
-		$mockController
-			->expects( $this->once() )
-			->method( 'getUser' )
-			->will( $this->returnValue( $mockUser ) );
 		$mockRunHooks
 			->expects( $this->once() )
 			->method( 'wfRunHooks' );
@@ -342,14 +333,13 @@ class SearchControllerTest extends Wikia\Search\Test\BaseTest {
 	 * @covers WikiaSearchController::handleArticleMatchTracking
 	 */
 	public function testHandleArticleMatchTrackingWithoutGoSearch() {
-		$mockController = $this->searchController->setMethods( [ 'getVal', 'getUser' ] )->getMock();
+		$mockController = $this->searchController->setMethods( [ 'getVal' ] )->getMock();
 		$searchConfig = $this->getMock( 'Wikia\Search\Config', [ 'getQuery', 'getPage', 'hasArticleMatch', 'getArticleMatch' ] );
 		$mockQuery = $this->getMock( 'Wikia\Search\Query', [ 'getSanitizedQuery' ] );
 		$mockTitle = $this->getMockBuilder( 'Title' )
 		                  ->disableOriginalConstructor()
 		                  ->setMethods( [ 'getFullUrl' ] )
 		                  ->getMock();
-		$mockUser = $this->getMock( 'User', [ 'getGlobalPreference' ] );
 		$mockMatch = $this->getMockBuilder( 'Wikia\Search\Match\Article' )
 		                  ->disableOriginalConstructor()
 		                  ->setMethods( [ 'getId' ] )
@@ -395,18 +385,10 @@ class SearchControllerTest extends Wikia\Search\Test\BaseTest {
 			->expects( $this->any() )
 			->method( 'hasArticleMatch' )
 			->will( $this->returnValue( true ) );
-		$mockUser
-			->expects( $this->once() )
-			->method( 'getGlobalPreference' )
-			->will( $this->returnValue( false ) );
 		$mockController
 			->expects( $this->any() )
 			->method( 'getVal' )
 			->will( $this->returnValue( 'Search' ) );
-		$mockController
-			->expects( $this->once() )
-			->method( 'getUser' )
-			->will( $this->returnValue( $mockUser ) );
 
 		$responserefl = new ReflectionProperty( 'WikiaSearchController', 'response' );
 		$responserefl->setAccessible( true );

--- a/extensions/wikia/Search/classes/Test/Controller/SearchControllerTest.php
+++ b/extensions/wikia/Search/classes/Test/Controller/SearchControllerTest.php
@@ -182,21 +182,22 @@ class SearchControllerTest extends Wikia\Search\Test\BaseTest {
 	 * @covers WikiaSearchController::handleArticleMatchTracking
 	 */
 	public function testArticleMatchTrackingWithMatch() {
-		$mockController = $this->searchController->setMethods( array( 'getVal' ) )->getMock();
-		$searchConfig = $this->getMock( 'Wikia\Search\Config', array( 'getQuery', 'getPage', 'hasArticleMatch', 'getArticleMatch' ) );
-		$mockQuery = $this->getMock( 'Wikia\Search\Query', array( 'getSanitizedQuery' ) );
+		$mockController = $this->searchController->setMethods( [ 'getVal', 'getUser' ] )->getMock();
+		$searchConfig = $this->getMock( 'Wikia\Search\Config', [ 'getQuery', 'getPage', 'hasArticleMatch', 'getArticleMatch' ] );
+		$mockQuery = $this->getMock( 'Wikia\Search\Query', [ 'getSanitizedQuery' ] );
 		$mockTitle = $this->getMockBuilder( 'Title' )
 		                  ->disableOriginalConstructor()
-		                  ->setMethods( array( 'getFullUrl' ) )
+		                  ->setMethods( [ 'getFullUrl' ] )
 		                  ->getMock();
-		$mockResponse = $this->getMock( 'WikiaResponse', array( 'redirect' ), array( 'html' ) );
+		$mockUser = $this->getMock( 'User', [ 'getGlobalPreference' ] );
+		$mockResponse = $this->getMock( 'WikiaResponse', [ 'redirect' ], [ 'html' ] );
 		$mockMatch = $this->getMockBuilder( 'Wikia\Search\Match\Article' )
 		                  ->disableOriginalConstructor()
-		                  ->setMethods( array( 'getId' ) )
+		                  ->setMethods( [ 'getId' ] )
 		                  ->getMock();
 		$mockArticle = $this->getMockBuilder( 'Article' )
 		                    ->disableOriginalConstructor()
-		                    ->setMethods( array( 'getTitle' ) )
+		                    ->setMethods( [ 'getTitle' ] )
 		                    ->getMock();
 		$mockRunHooks = $this->getGlobalFunctionMock( 'wfRunHooks' );
 
@@ -204,62 +205,57 @@ class SearchControllerTest extends Wikia\Search\Test\BaseTest {
 		$redirectUrl = 'http://foo.wikia.com/Wiki/foo';
 
 		$searchConfig
-			->expects	( $this->any() )
-			->method	( 'getPage' )
-			->will		( $this->returnValue( 1 ) )
-		;
+			->expects( $this->any() )
+			->method( 'getPage' )
+			->will( $this->returnValue( 1 ) );
 		$searchConfig
 		    ->expects( $this->any() )
-		    ->method ( 'getQuery' )
-		    ->will   ( $this->returnValue( $mockQuery ) )
-	    ;
+		    ->method( 'getQuery' )
+		    ->will( $this->returnValue( $mockQuery ) );
 		$mockQuery
 		    ->expects( $this->once() )
-		    ->method ( 'getSanitizedQuery' )
-		    ->will   ( $this->returnValue( 'foo' ) )
-		;
+		    ->method( 'getSanitizedQuery' )
+		    ->will( $this->returnValue( 'foo' ) );
 		$searchConfig
 		    ->expects( $this->any() )
-		    ->method ( 'getArticleMatch' )
-		    ->will   ( $this->returnValue( $mockMatch) )
-		;
+		    ->method( 'getArticleMatch' )
+		    ->will( $this->returnValue( $mockMatch) );
 		$mockMatch
 		    ->expects( $this->once() )
-		    ->method ( 'getId' )
-		    ->will   ( $this->returnValue( 123 ) )
-		;
+		    ->method( 'getId' )
+		    ->will( $this->returnValue( 123 ) );
 		$mockArticle
 		    ->expects( $this->once() )
-		    ->method ( 'getTitle' )
-		    ->will   ( $this->returnValue( $mockTitle ) )
-		;
+		    ->method( 'getTitle' )
+		    ->will( $this->returnValue( $mockTitle ) );
 		$searchConfig
-			->expects	( $this->any() )
-			->method	( 'hasArticleMatch' )
-			->will		( $this->returnValue( true ) )
-		;
+			->expects( $this->any() )
+			->method( 'hasArticleMatch' )
+			->will( $this->returnValue( true ) );
+		$mockUser
+			->expects( $this->once() )
+			->method( 'getGlobalPreference' )
+			->will( $this->returnValue( false ) );
 		$mockController
-			->expects	( $this->once() )
-			->method	( 'getVal' )
-			->with		( 'fulltext', '0' )
-			->will		( $this->returnValue( '0' ) )
-		;
+			->expects( $this->any() )
+			->method( 'getVal' )
+			->will( $this->returnValue( '0' ) );
+		$mockController
+			->expects( $this->once() )
+			->method( 'getUser' )
+			->will( $this->returnValue( $mockUser ) );
 		$mockRunHooks
-		    ->expects( $this->once() )
-		    ->method ( 'wfRunHooks' )
-		    ->with   ( 'SpecialSearchIsgomatch', array( $mockTitle, $originalQuery ) )
-		;
+			->expects( $this->once() )
+			->method( 'wfRunHooks' );
 		$mockTitle
-			->expects	( $this->any() )
-			->method	( 'getFullURL' )
-			->will		( $this->returnValue( $redirectUrl ) )
-		;
+			->expects( $this->any() )
+			->method( 'getFullURL' )
+			->will( $this->returnValue( $redirectUrl ) );
 		$mockResponse
-			->expects	( $this->once() )
-			->method	( 'redirect' )
-			->with      ( $redirectUrl )
-			->will		( $this->returnValue( true ) )
-		;
+			->expects( $this->once() )
+			->method( 'redirect' )
+			->with( $redirectUrl )
+			->will( $this->returnValue( true ) );
 
 		$responserefl = new ReflectionProperty( 'WikiaSearchController', 'response' );
 		$responserefl->setAccessible( true );
@@ -346,71 +342,71 @@ class SearchControllerTest extends Wikia\Search\Test\BaseTest {
 	 * @covers WikiaSearchController::handleArticleMatchTracking
 	 */
 	public function testHandleArticleMatchTrackingWithoutGoSearch() {
-		$mockController = $this->searchController->setMethods( array( 'getVal' ) )->getMock();
-		$searchConfig = $this->getMock( 'Wikia\Search\Config', array( 'getQuery', 'getPage', 'hasArticleMatch', 'getArticleMatch' ) );
-		$mockQuery = $this->getMock( 'Wikia\Search\Query', array( 'getSanitizedQuery' ) );
+		$mockController = $this->searchController->setMethods( [ 'getVal', 'getUser' ] )->getMock();
+		$searchConfig = $this->getMock( 'Wikia\Search\Config', [ 'getQuery', 'getPage', 'hasArticleMatch', 'getArticleMatch' ] );
+		$mockQuery = $this->getMock( 'Wikia\Search\Query', [ 'getSanitizedQuery' ] );
 		$mockTitle = $this->getMockBuilder( 'Title' )
 		                  ->disableOriginalConstructor()
-		                  ->setMethods( array( 'getFullUrl' ) )
+		                  ->setMethods( [ 'getFullUrl' ] )
 		                  ->getMock();
+		$mockUser = $this->getMock( 'User', [ 'getGlobalPreference' ] );
 		$mockMatch = $this->getMockBuilder( 'Wikia\Search\Match\Article' )
 		                  ->disableOriginalConstructor()
-		                  ->setMethods( array( 'getId' ) )
+		                  ->setMethods( [ 'getId' ] )
 		                  ->getMock();
 		$mockArticle = $this->getMockBuilder( 'Article' )
 		                    ->disableOriginalConstructor()
-		                    ->setMethods( array( 'getTitle' ) )
+		                    ->setMethods( [ 'getTitle' ] )
 		                    ->getMock();
-		$mockResponse = $this->getMock( 'WikiaResponse', array( 'redirect' ), array( 'html' ) );
+		$mockResponse = $this->getMock( 'WikiaResponse', [ 'redirect' ], [ 'html' ] );
 		$mockWrapper = $this->getMockBuilder( 'WikiaFunctionWrapper' )
 		                    ->disableOriginalConstructor()
-		                    ->setMethods( array( 'RunHooks' ) )
+		                    ->setMethods( [ 'RunHooks' ] )
 		                    ->getMock();
 
 		$originalQuery = 'foo';
 		$redirectUrl = 'http://foo.wikia.com/Wiki/foo';
 
 		$searchConfig
-		    ->expects( $this->once() )
-		    ->method ( 'getArticleMatch' )
-		    ->will   ( $this->returnValue( $mockMatch ) )
-		;
+			->expects( $this->once() )
+			->method( 'getArticleMatch' )
+			->will( $this->returnValue( $mockMatch ) );
 		$mockMatch
-		    ->expects( $this->once() )
-		    ->method ( 'getId' )
-		    ->will   ( $this->returnValue( 123 ) )
-		;
+			->expects( $this->once() )
+			->method( 'getId' )
+			->will( $this->returnValue( 123 ) );
 		$mockArticle
-		    ->expects( $this->once() )
-		    ->method ( 'getTitle' )
-		    ->will   ( $this->returnValue( $mockTitle ) )
-		;
+			->expects( $this->once() )
+			->method( 'getTitle' )
+			->will( $this->returnValue( $mockTitle ) );
 		$searchConfig
-			->expects	( $this->any() )
-			->method	( 'getPage' )
-			->will		( $this->returnValue( 1 ) )
-		;
+			->expects( $this->any() )
+			->method( 'getPage' )
+			->will( $this->returnValue( 1 ) );
 		$searchConfig
-		    ->expects( $this->any() )
-		    ->method ( 'getQuery' )
-		    ->will   ( $this->returnValue( $mockQuery ) )
-		;
+			->expects( $this->any() )
+			->method( 'getQuery' )
+			->will( $this->returnValue( $mockQuery ) );
 		$mockQuery
-		    ->expects( $this->once() )
-		    ->method ( 'getSanitizedQuery' )
-		    ->will   ( $this->returnValue( $originalQuery ) )
-		;
+			->expects( $this->once() )
+			->method( 'getSanitizedQuery' )
+			->will( $this->returnValue( $originalQuery ) );
 		$searchConfig
-			->expects	( $this->any() )
-			->method	( 'hasArticleMatch' )
-			->will		( $this->returnValue( true ) )
-		;
+			->expects( $this->any() )
+			->method( 'hasArticleMatch' )
+			->will( $this->returnValue( true ) );
+		$mockUser
+			->expects( $this->once() )
+			->method( 'getGlobalPreference' )
+			->will( $this->returnValue( false ) );
 		$mockController
-			->expects	( $this->once() )
-			->method	( 'getVal' )
-			->with		( 'fulltext', '0' )
-			->will		( $this->returnValue( 'search' ) )
-		;
+			->expects( $this->any() )
+			->method( 'getVal' )
+			->will( $this->returnValue( 'Search' ) );
+		$mockController
+			->expects( $this->once() )
+			->method( 'getUser' )
+			->will( $this->returnValue( $mockUser ) );
 
 		$responserefl = new ReflectionProperty( 'WikiaSearchController', 'response' );
 		$responserefl->setAccessible( true );


### PR DESCRIPTION
This supports both the user preference and has backwards compatibility for
Monobook's "Go" button and "go" URL parameter on search.
