### PR TITLE
WikiaApiQueryAllUsers: filter by wiki_id as well

### DIFF
--- a/extensions/wikia/WikiaApi/WikiaApiQueryAllUsers.php
+++ b/extensions/wikia/WikiaApi/WikiaApiQueryAllUsers.php
@@ -269,6 +269,7 @@ class WikiaApiQueryAllUsers extends ApiQueryBase {
 		
 		# table
 		$this->addTables('events_local_users');
+		$this->addWhere( 'wiki_id = ' . intval($wgCityId) );
 		$this->addWhere( 'user_is_closed = 0' );
 		
 		# limit
@@ -288,7 +289,6 @@ class WikiaApiQueryAllUsers extends ApiQueryBase {
 			$this->addWhere( 'user_name' . $db->buildLike( $this->keyToTitle( $params['prefix'] ), $db->anyString() ) );
 
 		if ( !is_null($params['group']) ) {
-			$this->addWhere( 'wiki_id = ' . intval($wgCityId) );			
 			$this->addWhere( 'all_groups' . $db->buildLike( $db->anyString(), $params['group'], $db->anyString() ) );
 		}
 


### PR DESCRIPTION
[PLATFORM-2424](https://wikia-inc.atlassian.net/browse/PLATFORM-2424)

Let's filter by `wiki_id` when making `/api.php?action=query&format=json&list=allusers&aulocal=10` requests to avoid filesort on 300mm+ rows..

``` sql
mysql@slave.db-specials.service.consul[specials]>explain SELECT /* WikiaApiQueryAllUsers::local_users 10.8.34.20 - 0e1f0669-2b1b-4849-a6c3-2ff351febd17 */  user_id, user_name, cnt_groups, edits as user_editcount, all_groups, user_is_blocked  FROM `events_local_users`  WHERE (user_is_closed = 0)  ORDER BY user_name LIMIT 10;
+----+-------------+--------------------+------+---------------+------+---------+------+-----------+-----------------------------+
| id | select_type | table              | type | possible_keys | key  | key_len | ref  | rows      | Extra                       |
+----+-------------+--------------------+------+---------------+------+---------+------+-----------+-----------------------------+
|  1 | SIMPLE      | events_local_users | ALL  | NULL          | NULL | NULL    | NULL | 312829425 | Using where; Using filesort |
+----+-------------+--------------------+------+---------------+------+---------+------+-----------+-----------------------------+
```

After the fix:

``` sql
mysql@slave.db-specials.service.consul[specials]>explain SELECT /* WikiaApiQueryAllUsers::local_users 10.8.34.20 - 0e1f0669-2b1b-4849-a6c3-2ff351febd17 */  user_id, user_name, cnt_groups, edits as user_editcount, all_groups, user_is_blocked  FROM `events_local_users`  WHERE (wiki_id = 147) AND  (user_is_closed = 0)  ORDER BY user_name LIMIT 10;
+----+-------------+--------------------+-------+-----------------+---------+---------+------+--------+-----------------------------+
| id | select_type | table              | type  | possible_keys   | key     | key_len | ref  | rows   | Extra                       |
+----+-------------+--------------------+-------+-----------------+---------+---------+------+--------+-----------------------------+
|  1 | SIMPLE      | events_local_users | range | PRIMARY,wiki_id | PRIMARY | 4       | NULL | 103426 | Using where; Using filesort |
+----+-------------+--------------------+-------+-----------------+---------+---------+------+--------+-----------------------------+
```

@mixth-sense / @wladekb / @drozdo / @ludwikkazmierczak 
