### PR TITLE
Adjust distance between admin avatars

### DIFF
--- a/extensions/wikia/CommunityPage/styles/components/_admins-module.scss
+++ b/extensions/wikia/CommunityPage/styles/components/_admins-module.scss
@@ -1,7 +1,8 @@
 @import 'extensions/wikia/DesignSystem/bower_components/design-system/base/typography';
 
 $admins-module-icon-size: 48px;
-$admins-module-margin: 20px;
+$admins-module-item-margin: 10px;
+$admins-module-item-width: 80px;
 $admins-module-text-padding-top: 14px;
 $admins-module-text-padding-bottom: 30px;
 
@@ -9,11 +10,17 @@ $admins-module-text-padding-bottom: 30px;
 	text-align: center;
 
 	.admins {
-		@include flexbox();
-		@include justify-content(space-between);
-
 		font-size: $typescale-size-minus-2;
-		margin: 0 $admins-module-margin;
+
+		.community-page-admin-item {
+			display: inline-block;
+			vertical-align: top;
+			width: $admins-module-item-width;
+
+			&:first-child {
+				margin-right: $admins-module-item-margin;
+			}
+		}
 	}
 
 	.admins-text {

--- a/extensions/wikia/CommunityPage/templates/topAdmins.mustache
+++ b/extensions/wikia/CommunityPage/templates/topAdmins.mustache
@@ -1,14 +1,14 @@
 <div class="community-page-module-section-title">{{topAdminsHeaderText}}</div>
-<ul class="admins reset">
+<div class="admins reset">
 	{{#topAdminsList}}
-		<li class="community-page-admin-item">
+		<div class="community-page-admin-item">
 			<div class="avatar-container">
 				<a data-tracking="top-admins-user-avatar" href="{{profilePage}}">{{{avatar}}}</a>
 			</div>
 			<div class="community-page-contributor-details">
 				<a data-tracking="top-admins-user" href="{{profilePage}}">{{userName}}</a>
 			</div>
-		</li>
+		</div>
 	{{/topAdminsList}}
 	{{^topAdminsList}}
 		<div class="community-page-zero">
@@ -16,7 +16,7 @@
 			<a href="{{noAdminHref}}">{{noAdminContactText}}</a>
 		</div>
 	{{/topAdminsList}}
-</ul>
+</div>
 <div class="admins-text">{{adminsText}}</div>
 {{#haveOtherAdmins}}
 	<a id="openModalTopAdmins" class="admins-view-all" data-tracking="view-all-admins" href="">{{otherAdmins}}</a>


### PR DESCRIPTION
Also `ul` replaced with `div` because there are some wikis which have `margin-left: Zpx !important` set for `ul` element in their custom css.

@Wikia/west-wing 
