### PR TITLE
WW-282 | change card header to div

### DIFF
--- a/extensions/wikia/CommunityPage/styles/components/_insights-module.scss
+++ b/extensions/wikia/CommunityPage/styles/components/_insights-module.scss
@@ -49,12 +49,15 @@ $module-width: 239px;
 
 		background: $color-buttons;
 		color: $color-button-text;
-		font-size: $typescale-size-minus-1;
-		font-weight: bold;
-		line-height: $typescale-size-base;
 		margin: 0 0 $content-spacing-large;
 		padding: $content-spacing-regular;
-		text-transform: uppercase;
+
+		h3 {
+			font-size: $typescale-size-minus-1;
+			font-weight: bold;
+			line-height: $typescale-size-base;
+			text-transform: uppercase;
+		}
 	}
 
 	.community-page-insights-module-header-icon {

--- a/extensions/wikia/CommunityPage/templates/insightsModule.mustache
+++ b/extensions/wikia/CommunityPage/templates/insightsModule.mustache
@@ -1,12 +1,12 @@
 <section class="community-page-insights-module" data-tracking="community-page-insights-{{type}}">
-	<h3 class="community-page-insights-module-header">
+	<div class="community-page-insights-module-header">
 		<div class="community-page-insights-module-header-icon">
 			<svg width="48" height="48">
 				<use xlink:href="/extensions/wikia/CommunityPage/images/{{{icon}}}.svg#icon"></use>
 			</svg>
 		</div>
-		{{title}}
-	</h3>
+		<h3>{{title}}</h3>
+	</div>
 	<ul class="community-page-insights-module-list reset">
 		{{#pages}}
 			<li class="community-page-insights-module-list-item">


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/WW-298

changing header of cards to divs instead of h3 in order to fix background issues on some communities

@Wikia/west-wing 
