### PR TITLE
Fix errors with VOLDEV devbox

### DIFF
--- a/extensions/ExtensionFunctions.php
+++ b/extensions/ExtensionFunctions.php
@@ -8,75 +8,21 @@ if ( !defined( 'MEDIAWIKI' ) ) {
 	exit( 1 );
 }
 
-if ( !defined( 'MW_SPECIALPAGE_VERSION' ) ) {
-	/**
-	 * Equivalent of wfCreateObject
-	 */
-	function extCreateObject( $name, $p ) {
-		$p = array_values( $p );
-		switch ( count( $p ) ) {
-			case 0:
-				return new $name;
-			case 1:
-				return new $name( $p[0] );
-			case 2:
-				return new $name( $p[0], $p[1] );
-			case 3:
-				return new $name( $p[0], $p[1], $p[2] );
-			case 4:
-				return new $name( $p[0], $p[1], $p[2], $p[3] );
-			case 5:
-				return new $name( $p[0], $p[1], $p[2], $p[3], $p[4] );
-			case 6:
-				return new $name( $p[0], $p[1], $p[2], $p[3], $p[4], $p[5] );
-			default:
-				wfDebugDieBacktrace( "Too many arguments to constructor in extCreateObject" );
-		}
+/**
+ * Add a special page
+ *
+ * @param string $file Filename containing the derived class
+ * @param string $name Name of the special page
+ * @param mixed $params Name of the class, or array containing class name and constructor params
+ * @deprecated Use $wgSpecialPages and $wgAutoloadClasses
+ */
+function extAddSpecialPage( $file, $name, $params ) {
+	global $wgSpecialPages, $wgAutoloadClasses;
+	if ( !is_array( $params ) ) {
+		$className = $params;
+	} else {
+		$className = $params[0];
 	}
-
-	class SetupSpecialPage {
-		function __construct( $file, $name, $params ) {
-			$this->file = $file;
-			$this->name = $name;
-			$this->params = $params;
-		}
-
-		function setup() {
-			global $IP;
-			require_once( "$IP/includes/SpecialPage.php" );
-			require_once( $this->file );
-			if ( !is_array( $this->params ) ) {
-				$this->params = array( $this->params );
-			}
-			$className = array_shift( $this->params );
-			$obj = extCreateObject( $className, $this->params );
-			SpecialPage::addPage( $obj );
-		}
-	}
-
-	function extAddSpecialPage( $file, $name, $params ) {
-		global $wgExtensionFunctions;
-		$setup = new SetupSpecialPage( $file, $name, $params );
-		$wgExtensionFunctions[] = array( &$setup, 'setup' );
-	}
-} else {
-	/**
-	 * Add a special page
-	 *
-	 * @param string $file Filename containing the derived class
-	 * @param string $name Name of the special page
-	 * @param mixed $params Name of the class, or array containing class name and constructor params
-	 * @deprecated Use $wgSpecialPages and $wgAutoloadClasses
-	 */
-	function extAddSpecialPage( $file, $name, $params ) {
-		global $wgSpecialPages, $wgAutoloadClasses;
-		if ( !is_array( $params ) ) {
-			$className = $params;
-		} else {
-			$className = $params[0];
-		}
-		$wgSpecialPages[$name] = $params;
-		$wgAutoloadClasses[$className] = $file;
-	}
+	$wgSpecialPages[$name] = $params;
+	$wgAutoloadClasses[$className] = $file;
 }
-

--- a/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php
+++ b/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php
@@ -389,7 +389,7 @@ class ArticleAsJson extends WikiaService {
 		return true;
 	}
 
-	public static function onShowEditLink( Parser &$this, &$showEditLink ) {
+	public static function onShowEditLink( Parser &$parser, &$showEditLink ) {
 		global $wgArticleAsJson;
 
 		//We don't have editing in this version


### PR DESCRIPTION
These two changes fix errors that prevent the VOLDEV devbox from working:
- removed deprecated version of `extAddSpecialPage` and `extCreateObject` - this branch is never run in our code since `MW_SPECIALPAGE_VERSION` is defined as 2 in Defines.php but it's mysteriously preventing our devbox from starting
- renamed unused function parameter in `ArticleAsJson` class - `$this` is not allowed

@Grunny @mixth-sense @macbre please review :)
