### PR TITLE
Fixed php notice in achievements 2

### DIFF
--- a/extensions/wikia/AchievementsII/Ach_setup.php
+++ b/extensions/wikia/AchievementsII/Ach_setup.php
@@ -164,7 +164,7 @@ function Ach_GetHTMLAfterBody($skin, &$html) {
 	global $wgOut, $wgTitle, $wgUser;
 
 	if($wgUser->isLoggedIn() && !($wgUser->getGlobalPreference( 'hidepersonalachievements' ))) {
-		if ($wgTitle->getNamespace() == NS_SPECIAL && array_shift(SpecialPageFactory::resolveAlias($wgTitle->getDBkey())) == 'MyHome') {
+		if( $skin->getTitle()->isSpecial( 'MyHome' ) ) {
 			$awardingService = new AchAwardingService();
 			$awardingService->awardCustomNotInTrackBadge($wgUser, BADGE_WELCOME);
 		}

--- a/extensions/wikia/AchievementsII/Ach_setup.php
+++ b/extensions/wikia/AchievementsII/Ach_setup.php
@@ -161,7 +161,7 @@ function Ach_ArticleSaveComplete(	&$article, &$user, $text,
 function Ach_GetHTMLAfterBody($skin, &$html) {
 	wfProfileIn(__METHOD__);
 
-	global $wgOut, $wgTitle, $wgUser;
+	global $wgOut, $wgUser;
 
 	if($wgUser->isLoggedIn() && !($wgUser->getGlobalPreference( 'hidepersonalachievements' ))) {
 		if( $skin->getTitle()->isSpecial( 'MyHome' ) ) {


### PR DESCRIPTION
This contains the same change as in https://github.com/Wikia/app/pull/11358, but without reformatting of code which greatly decreased the transparency of that change.

The change is to remove an error generated on my dev box due to a PHP notice. The notice is: Only variables should be passed by reference

@wladekb 
