### PR TITLE
XW-1910 Fix value returned by WikiFactory::getHostById() on sandboxes

### DIFF
--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -541,11 +541,11 @@ class WikiFactory {
 	 * @return string
 	 */
 	public static function getHostById( $cityId ) {
-		global $wgDevelEnvironment;
+		global $wgWikiaEnvironment;
 
 		$hostName = \WikiFactory::getVarValueByName( 'wgServer', $cityId );
 
-		if ( !empty( $wgDevelEnvironment ) ) {
+		if ( $wgWikiaEnvironment != WIKIA_ENV_PROD ) {
 			$hostName = \WikiFactory::getLocalEnvURL( $hostName );
 		}
 

--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -541,13 +541,8 @@ class WikiFactory {
 	 * @return string
 	 */
 	public static function getHostById( $cityId ) {
-		global $wgDevelEnvironment;
-
 		$hostName = \WikiFactory::getVarValueByName( 'wgServer', $cityId );
-
-		if ( !empty( $wgDevelEnvironment ) ) {
-			$hostName = \WikiFactory::getLocalEnvURL( $hostName );
-		}
+		$hostName = \WikiFactory::getLocalEnvURL( $hostName );
 
 		return rtrim( $hostName, '/' );
 	}
@@ -1209,6 +1204,7 @@ class WikiFactory {
 	 * (preview/verify/sandbox).wikiname.wikia.com
 	 * en.wikiname.developer.wikia-dev.com
 	 * wikiname.developer.wikia-dev.com
+	 * @TODO MAIN-7994 support custom domains
 	 * @access public
 	 * @author pbablok@wikia
 	 * @static

--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -1204,7 +1204,6 @@ class WikiFactory {
 	 * (preview/verify/sandbox).wikiname.wikia.com
 	 * en.wikiname.developer.wikia-dev.com
 	 * wikiname.developer.wikia-dev.com
-	 * @TODO MAIN-7994 support custom domains
 	 * @access public
 	 * @author pbablok@wikia
 	 * @static

--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -541,8 +541,13 @@ class WikiFactory {
 	 * @return string
 	 */
 	public static function getHostById( $cityId ) {
+		global $wgDevelEnvironment;
+
 		$hostName = \WikiFactory::getVarValueByName( 'wgServer', $cityId );
-		$hostName = \WikiFactory::getLocalEnvURL( $hostName );
+
+		if ( !empty( $wgDevelEnvironment ) ) {
+			$hostName = \WikiFactory::getLocalEnvURL( $hostName );
+		}
 
 		return rtrim( $hostName, '/' );
 	}
@@ -1204,7 +1209,6 @@ class WikiFactory {
 	 * (preview/verify/sandbox).wikiname.wikia.com
 	 * en.wikiname.developer.wikia-dev.com
 	 * wikiname.developer.wikia-dev.com
-	 * @TODO MAIN-7994 support custom domains
 	 * @access public
 	 * @author pbablok@wikia
 	 * @static

--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -541,13 +541,8 @@ class WikiFactory {
 	 * @return string
 	 */
 	public static function getHostById( $cityId ) {
-		global $wgWikiaEnvironment;
-
 		$hostName = \WikiFactory::getVarValueByName( 'wgServer', $cityId );
-
-		if ( $wgWikiaEnvironment != WIKIA_ENV_PROD ) {
-			$hostName = \WikiFactory::getLocalEnvURL( $hostName );
-		}
+		$hostName = \WikiFactory::getLocalEnvURL( $hostName );
 
 		return rtrim( $hostName, '/' );
 	}

--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -542,9 +542,27 @@ class WikiFactory {
 	 */
 	public static function getHostById( $cityId ) {
 		$hostName = \WikiFactory::getVarValueByName( 'wgServer', $cityId );
-		$hostName = \WikiFactory::getLocalEnvURL( $hostName );
+		$hostName = \WikiFactory::fixURLForNonProductionEnv( $hostName );
 
 		return rtrim( $hostName, '/' );
+	}
+
+	/**
+	 * Calls WikiFactory::getLocalEnvURL only on non-production host names
+	 * @TODO MAIN-7994 remove this method when WikiFactory::getLocalEnvURL supports custom domains
+	 *
+	 * @param string $hostName
+	 *
+	 * @return string
+	 */
+	public static function fixURLForNonProductionEnv( $hostName ) {
+		global $wgWikiaEnvironment;
+
+		if ( $wgWikiaEnvironment != WIKIA_ENV_PROD ) {
+			$hostName = \WikiFactory::getLocalEnvURL( $hostName );
+		}
+
+		return $hostName;
 	}
 
 	/**
@@ -1204,6 +1222,7 @@ class WikiFactory {
 	 * (preview/verify/sandbox).wikiname.wikia.com
 	 * en.wikiname.developer.wikia-dev.com
 	 * wikiname.developer.wikia-dev.com
+	 * @TODO MAIN-7994 support custom domains
 	 * @access public
 	 * @author pbablok@wikia
 	 * @static

--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -542,27 +542,9 @@ class WikiFactory {
 	 */
 	public static function getHostById( $cityId ) {
 		$hostName = \WikiFactory::getVarValueByName( 'wgServer', $cityId );
-		$hostName = \WikiFactory::fixURLForNonProductionEnv( $hostName );
+		$hostName = \WikiFactory::getLocalEnvURL( $hostName );
 
 		return rtrim( $hostName, '/' );
-	}
-
-	/**
-	 * Calls WikiFactory::getLocalEnvURL only on non-production host names
-	 * @TODO MAIN-7994 remove this method when WikiFactory::getLocalEnvURL supports custom domains
-	 *
-	 * @param string $hostName
-	 *
-	 * @return string
-	 */
-	public static function fixURLForNonProductionEnv( $hostName ) {
-		global $wgWikiaEnvironment;
-
-		if ( $wgWikiaEnvironment != WIKIA_ENV_PROD ) {
-			$hostName = \WikiFactory::getLocalEnvURL( $hostName );
-		}
-
-		return $hostName;
 	}
 
 	/**

--- a/extensions/wikia/WikiFactory/tests/WikiFactoryTest.php
+++ b/extensions/wikia/WikiFactory/tests/WikiFactoryTest.php
@@ -225,9 +225,19 @@ class WikiFactoryTest extends WikiaBaseTest {
 
 	public function testGetHostById() {
 		$this->mockStaticMethod( 'WikiFactory', 'getVarValueByName', 1 );
-		$this->mockStaticMethod( 'WikiFactory', 'getLocalEnvURL', 'test_host/' );
+		$this->mockStaticMethod( 'WikiFactory', 'fixURLForNonProductionEnv', 'test_host/' );
 
 		$this->assertEquals( 'test_host', WikiFactory::getHostById( 2 ) );
+	}
+
+	public function testFixURLForNonProductionEnv() {
+		$this->mockStaticMethod( 'WikiFactory', 'getLocalEnvURL', 'test_host_processed' );
+
+		$this->mockEnvironment( WIKIA_ENV_PROD );
+		$this->assertEquals( 'test_host', WikiFactory::fixURLForNonProductionEnv( 'test_host' ) );
+
+		$this->mockEnvironment( WIKIA_ENV_SANDBOX );
+		$this->assertEquals( 'test_host_processed', WikiFactory::fixURLForNonProductionEnv( 'test_host' ) );
 	}
 
 	public function testRenderValueOfVariableWithoutValue() {

--- a/extensions/wikia/WikiFactory/tests/WikiFactoryTest.php
+++ b/extensions/wikia/WikiFactory/tests/WikiFactoryTest.php
@@ -223,6 +223,13 @@ class WikiFactoryTest extends WikiaBaseTest {
 		];
 	}
 
+	public function testGetHostById() {
+		$this->mockStaticMethod( 'WikiFactory', 'getVarValueByName', 1 );
+		$this->mockStaticMethod( 'WikiFactory', 'getLocalEnvURL', 'test_host/' );
+
+		$this->assertEquals( 'test_host', WikiFactory::getHostById( 2 ) );
+	}
+
 	public function testRenderValueOfVariableWithoutValue() {
 		$variable = new stdClass();
 

--- a/extensions/wikia/WikiFactory/tests/WikiFactoryTest.php
+++ b/extensions/wikia/WikiFactory/tests/WikiFactoryTest.php
@@ -186,7 +186,25 @@ class WikiFactoryTest extends WikiaBaseTest {
 				'forcedEnv' => WIKIA_ENV_DEV,
 				'url' => 'http://gta.wikia.com/',
 				'expected' => 'http://preview.gta.wikia.com'
-			]
+			],
+			[
+				'env' => WIKIA_ENV_PROD,
+				'forcedEnv' => null,
+				'url' => 'http://gta.wikia.com/',
+				'expected' => 'http://gta.wikia.com'
+			],
+			[
+				'env' => WIKIA_ENV_PROD,
+				'forcedEnv' => null,
+				'url' => 'http://muupet.wikia.com/wiki/test/test/test',
+				'expected' => 'http://muupet.wikia.com/wiki/test/test/test'
+			],
+			[
+				'env' => WIKIA_ENV_DEV,
+				'forcedEnv' => WIKIA_ENV_PROD,
+				'url' => 'http://gta.wikia.com/',
+				'expected' => 'http://gta.wikia.com'
+			],
 		];
 	}
 
@@ -225,19 +243,9 @@ class WikiFactoryTest extends WikiaBaseTest {
 
 	public function testGetHostById() {
 		$this->mockStaticMethod( 'WikiFactory', 'getVarValueByName', 1 );
-		$this->mockStaticMethod( 'WikiFactory', 'fixURLForNonProductionEnv', 'test_host/' );
+		$this->mockStaticMethod( 'WikiFactory', 'getLocalEnvURL', 'test_host/' );
 
 		$this->assertEquals( 'test_host', WikiFactory::getHostById( 2 ) );
-	}
-
-	public function testFixURLForNonProductionEnv() {
-		$this->mockStaticMethod( 'WikiFactory', 'getLocalEnvURL', 'test_host_processed' );
-
-		$this->mockEnvironment( WIKIA_ENV_PROD );
-		$this->assertEquals( 'test_host', WikiFactory::fixURLForNonProductionEnv( 'test_host' ) );
-
-		$this->mockEnvironment( WIKIA_ENV_SANDBOX );
-		$this->assertEquals( 'test_host_processed', WikiFactory::fixURLForNonProductionEnv( 'test_host' ) );
 	}
 
 	public function testRenderValueOfVariableWithoutValue() {

--- a/includes/wikia/GlobalTitle.php
+++ b/includes/wikia/GlobalTitle.php
@@ -680,7 +680,7 @@ class GlobalTitle extends Title {
 		 */
 		$server = WikiFactory::getVarValueByName( "wgServer", $this->mCityId );
 		if ( $server ) {
-			$this->mServer = self::normalizeEnvURL( $server );
+			$this->mServer = WikiFactory::getLocalEnvURL( $server );
 			return $server;
 		}
 
@@ -698,27 +698,11 @@ class GlobalTitle extends Title {
 
 		if ( $city ) {
 			$server = rtrim( $city->city_url, "/" );
-			$this->mServer = self::normalizeEnvURL( $server );
+			$this->mServer = WikiFactory::getLocalEnvURL( $server );
 			return $server;
 		}
 
 		return false;
-	}
-
-	/**
-	 *
-	 * Normalizes URL passed to this method to generate environment-specific paths
-	 *
-	 * @param $server
-	 * @return string
-	 */
-	private static function normalizeEnvURL( $server ) {
-		global $wgWikiaEnvironment;
-		if ( $wgWikiaEnvironment != WIKIA_ENV_PROD ) {
-			return WikiFactory::getLocalEnvURL( $server );
-		}
-
-		return $server;
 	}
 
 	/**

--- a/includes/wikia/GlobalTitle.php
+++ b/includes/wikia/GlobalTitle.php
@@ -680,7 +680,7 @@ class GlobalTitle extends Title {
 		 */
 		$server = WikiFactory::getVarValueByName( "wgServer", $this->mCityId );
 		if ( $server ) {
-			$this->mServer = WikiFactory::getLocalEnvURL( $server );
+			$this->mServer = self::normalizeEnvURL( $server );
 			return $server;
 		}
 
@@ -698,11 +698,23 @@ class GlobalTitle extends Title {
 
 		if ( $city ) {
 			$server = rtrim( $city->city_url, "/" );
-			$this->mServer = WikiFactory::getLocalEnvURL( $server );
+			$this->mServer = self::normalizeEnvURL( $server );
 			return $server;
 		}
 
 		return false;
+	}
+
+	/**
+	 *
+	 * Normalizes URL passed to this method to generate environment-specific paths
+	 *
+	 * @param $server
+	 * @return string
+	 */
+	private static function normalizeEnvURL( $server ) {
+		// TODO MAIN-7994 use WikiFactory::getLocalEnvURL when it supports custom domains
+		return \WikiFactory::fixURLForNonProductionEnv( $server );
 	}
 
 	/**

--- a/includes/wikia/GlobalTitle.php
+++ b/includes/wikia/GlobalTitle.php
@@ -81,7 +81,7 @@ class GlobalTitle extends Title {
 
 		return $title;
 	}
-	
+
 	/**
 	 * @desc Create a new Title for the Main Page
 	 *
@@ -680,7 +680,7 @@ class GlobalTitle extends Title {
 		 */
 		$server = WikiFactory::getVarValueByName( "wgServer", $this->mCityId );
 		if ( $server ) {
-			$this->mServer = self::normalizeEnvURL( $server );
+			$this->mServer = \WikiFactory::getLocalEnvURL( $server );
 			return $server;
 		}
 
@@ -698,23 +698,11 @@ class GlobalTitle extends Title {
 
 		if ( $city ) {
 			$server = rtrim( $city->city_url, "/" );
-			$this->mServer = self::normalizeEnvURL( $server );
+			$this->mServer = \WikiFactory::getLocalEnvURL( $server );
 			return $server;
 		}
 
 		return false;
-	}
-
-	/**
-	 *
-	 * Normalizes URL passed to this method to generate environment-specific paths
-	 *
-	 * @param $server
-	 * @return string
-	 */
-	private static function normalizeEnvURL( $server ) {
-		// TODO MAIN-7994 use WikiFactory::getLocalEnvURL when it supports custom domains
-		return \WikiFactory::fixURLForNonProductionEnv( $server );
 	}
 
 	/**

--- a/includes/wikia/tests/GlobalTitleTest.php
+++ b/includes/wikia/tests/GlobalTitleTest.php
@@ -14,11 +14,9 @@ class GlobalTitleTest extends WikiaBaseTest {
 			->willReturnMap( [
 				// basically all tests where GlobalTitle::load() is executed
 				[ 'wgServer', 177, 'http://community.wikia.com' ],
-				[ 'wgServer', 113, 'http://en.memory-alpha.org' ],
-				[ 'wgServer', 490, 'http://www.wowwiki.com' ],
+				[ 'wgServer', 113, 'http://memory-alpha.wikia.com' ],
+				[ 'wgServer', 490, 'http://wowwiki.wikia.com' ],
 				[ 'wgServer', 1686, 'http://spolecznosc.wikia.com' ],
-				/** @see testUrlsMainNSonWoW **/
-				[ 'wgArticlePath', 490, '/$1' ],
 				[ 'wgExtraNamespacesLocal', 490, [ 116 => 'Portal' ] ],
 			] );
 	}
@@ -51,7 +49,7 @@ class GlobalTitleTest extends WikiaBaseTest {
 		$this->mockProdEnv();
 
 		$title = GlobalTitle::newFromText( "Timeline", NS_MAIN, 113 ); # memory-alpha
-		$expectedUrl = "http://en.memory-alpha.org/wiki/Timeline";
+		$expectedUrl = "http://memory-alpha.wikia.com/wiki/Timeline";
 		$this->assertEquals( $expectedUrl, $title->getFullURL() );
 	}
 
@@ -59,7 +57,7 @@ class GlobalTitleTest extends WikiaBaseTest {
 		$this->mockProdEnv();
 
 		$title = GlobalTitle::newFromText( "Main", 116, 490); # wowwiki
-		$expectedUrl = "http://www.wowwiki.com/Portal:Main";
+		$expectedUrl = "http://wowwiki.wikia.com/wiki/Portal:Main";
 		$this->assertEquals( $expectedUrl, $title->getFullURL() );
 	}
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/XW-1910

To fix the Search Suggestions URL returned by the Design System API on sandboxes we had to change `WikiFactory::getHostById()`. It was only checking if the environment is a devbox and treating all the other envs like production. Now it checks if it's not production.

The same logic is in [`GlobalTitle::normalizeEnvURL()`](https://github.com/Wikia/app/blob/dev/includes/wikia/GlobalTitle.php#L715-L722).

/cc @Wikia/x-wing @sebastianmarzjan @macbre 
