### PR TITLE
WW-95 | forcing login for anons on CP if wiki has anon edits disabled

### DIFF
--- a/extensions/wikia/CommunityPage/CommunityPage.setup.php
+++ b/extensions/wikia/CommunityPage/CommunityPage.setup.php
@@ -17,6 +17,7 @@ $wgAutoloadClasses['CommunityPageEntryPointController'] = $IP . '/skins/oasis/mo
 
 /* helpers */
 $wgAutoloadClasses['WikiTopic'] = __DIR__ . '/helpers/WikiTopic.php';
+$wgAutoloadClasses['LinkHelper'] = __DIR__ . '/helpers/LinkHelper.php';
 
 /* hooks */
 $wgAutoloadClasses['CommunityPageSpecialHooks'] =  __DIR__ . '/CommunityPageSpecialHooks.class.php';

--- a/extensions/wikia/CommunityPage/helpers/LinkHelper.php
+++ b/extensions/wikia/CommunityPage/helpers/LinkHelper.php
@@ -1,23 +1,22 @@
 <?php
 
 class LinkHelper {
-	public static function forceLoginLink( Title $title, $edit=true ) {
+	static $WITH_EDIT_MODE = true;
+	static $WITHOUT_EDIT_MODE = false;
+
+	public static function forceLoginLink( Title $title, $editMode ) {
 		global $wgUser, $wgDisableAnonymousEditing;
 
 		if ( $wgDisableAnonymousEditing && !$wgUser->isLoggedIn() ) {
 			return SpecialPage::getTitleFor( 'SignUp' )->getFullURL(
 				[
 					'returnto' => $title->getEscapedText(),
-					'returntoquery' => $edit ? urlencode( static::getEditorParam() ) : '',
+					'returntoquery' => $editMode ? urlencode( static::getEditorParam() ) : '',
 					'type' => 'login'
 				]);
 		}
 
-		return $edit ? static::getEditUrl( $title->getFullURL() ) : $title->getFullURL();
-	}
-
-	public static function getEditUrl( $articleUrl ) {
-		return $articleUrl . '?' . static::getEditorParam();
+		return $editMode ?  $title->getFullURL() . '?' . static::getEditorParam() : $title->getFullURL();
 	}
 
 	private static function getEditorParam() {

--- a/extensions/wikia/CommunityPage/helpers/LinkHelper.php
+++ b/extensions/wikia/CommunityPage/helpers/LinkHelper.php
@@ -5,8 +5,8 @@ class LinkHelper {
 	const WITHOUT_EDIT_MODE = false;
 
 	/**
-	 * Returns url to Special:SignUp with redirect to given article if current wiki has disabled anon edits and current
-	 * user is anon. Otherwise link to given article is returned
+	 * If current user is NOT logged in and wiki has disabled edditing by anon, this function returns link to force login
+	 * modal - after login user will be redirected to provided article. Otherwise url to given article is returned.
 	 *
 	 * @param Title $title
 	 * @param $editMode - if $WITH_EDIT_MODE then action=edit or veaction=edit is added to link (depending on which

--- a/extensions/wikia/CommunityPage/helpers/LinkHelper.php
+++ b/extensions/wikia/CommunityPage/helpers/LinkHelper.php
@@ -24,7 +24,7 @@ class LinkHelper {
 		if ( EditorPreference::isVisualEditorPrimary() ) {
 			return 'veaction=edit';
 		}
-		
+
 		return 'action=edit';
 	}
 }

--- a/extensions/wikia/CommunityPage/helpers/LinkHelper.php
+++ b/extensions/wikia/CommunityPage/helpers/LinkHelper.php
@@ -4,6 +4,15 @@ class LinkHelper {
 	static $WITH_EDIT_MODE = true;
 	static $WITHOUT_EDIT_MODE = false;
 
+	/**
+	 * Returns url to Special:SignUp with redirect to given article if current wiki has disabled anon edits and current
+	 * user is anon. Otherwise link to given article is returned
+	 *
+	 * @param Title $title
+	 * @param $editMode - if $WITH_EDIT_MODE then action=edit or veaction=edit is added to link (depending on which
+	 * editor is primary).
+	 * @return String - the url
+	 */
 	public static function forceLoginLink( Title $title, $editMode ) {
 		global $wgUser, $wgDisableAnonymousEditing;
 

--- a/extensions/wikia/CommunityPage/helpers/LinkHelper.php
+++ b/extensions/wikia/CommunityPage/helpers/LinkHelper.php
@@ -8,7 +8,7 @@ class LinkHelper {
 			return SpecialPage::getTitleFor( 'SignUp' )->getFullURL(
 				[
 					'returnto' => $title->getEscapedText(),
-					'returntoquery' => $edit ? urlencode( self::getEditorParam() ) : '',
+					'returntoquery' => $edit ? urlencode( static::getEditorParam() ) : '',
 					'type' => 'login'
 				]);
 		}
@@ -24,6 +24,7 @@ class LinkHelper {
 		if ( EditorPreference::isVisualEditorPrimary() ) {
 			return 'veaction=edit';
 		}
+		
 		return 'action=edit';
 	}
 }

--- a/extensions/wikia/CommunityPage/helpers/LinkHelper.php
+++ b/extensions/wikia/CommunityPage/helpers/LinkHelper.php
@@ -1,8 +1,8 @@
 <?php
 
 class LinkHelper {
-	static $WITH_EDIT_MODE = true;
-	static $WITHOUT_EDIT_MODE = false;
+	const WITH_EDIT_MODE = true;
+	const WITHOUT_EDIT_MODE = false;
 
 	/**
 	 * Returns url to Special:SignUp with redirect to given article if current wiki has disabled anon edits and current
@@ -17,7 +17,7 @@ class LinkHelper {
 		global $wgUser, $wgDisableAnonymousEditing;
 
 		if ( $wgDisableAnonymousEditing && !$wgUser->isLoggedIn() ) {
-			return SpecialPage::getTitleFor( 'SignUp' )->getFullURL(
+			return SpecialPage::getTitleFor( 'SignUp' )->getLocalURL(
 				[
 					'returnto' => $title->getEscapedText(),
 					'returntoquery' => $editMode ? urlencode( static::getEditorParam() ) : '',
@@ -25,7 +25,7 @@ class LinkHelper {
 				]);
 		}
 
-		return $editMode ?  $title->getFullURL() . '?' . static::getEditorParam() : $title->getFullURL();
+		return $editMode ?  $title->getLocalURL() . '?' . static::getEditorParam() : $title->getLocalURL();
 	}
 
 	private static function getEditorParam() {

--- a/extensions/wikia/CommunityPage/helpers/LinkHelper.php
+++ b/extensions/wikia/CommunityPage/helpers/LinkHelper.php
@@ -1,0 +1,33 @@
+<?php
+
+class LinkHelper {
+	public static function getEditUrl( Title $article ) {
+		global $wgUser, $wgDisableAnonymousEditing;
+
+		if ( $wgDisableAnonymousEditing ) {
+			 if ( $wgUser->isLoggedIn() ) {
+				 return static::editUrl( $article->getFullURL() );
+			 } else {
+			 	return SpecialPage::getTitleFor( 'SignUp' )->getFullURL(
+			 		$query2=[
+			 			'returnto' => $article->getEscapedText(),
+						'returntoquery' => self::getEditorParam(),
+						'type' => 'login'
+				]);
+			 }
+		} else {
+			return static::editUrl( $article->getFullURL() );
+		}
+	}
+
+	private static function editUrl( $articleUrl ) {
+		return $articleUrl . '?'. static::getEditorParam();
+	}
+
+	private static function getEditorParam() {
+		if ( EditorPreference::isVisualEditorPrimary() ) {
+			return 'veaction=edit';
+		}
+		return 'action=edit';
+	}
+}

--- a/extensions/wikia/CommunityPage/helpers/LinkHelper.php
+++ b/extensions/wikia/CommunityPage/helpers/LinkHelper.php
@@ -1,26 +1,22 @@
 <?php
 
 class LinkHelper {
-	public static function getEditUrl( Title $article ) {
+	public static function forceLoginLink(Title $title, $edit=true ) {
 		global $wgUser, $wgDisableAnonymousEditing;
 
-		if ( $wgDisableAnonymousEditing ) {
-			 if ( $wgUser->isLoggedIn() ) {
-				 return static::editUrl( $article->getFullURL() );
-			 } else {
-			 	return SpecialPage::getTitleFor( 'SignUp' )->getFullURL(
-			 		$query2=[
-			 			'returnto' => $article->getEscapedText(),
-						'returntoquery' => self::getEditorParam(),
-						'type' => 'login'
+		if ( $wgDisableAnonymousEditing && !$wgUser->isLoggedIn() ) {
+			return SpecialPage::getTitleFor( 'SignUp' )->getFullURL(
+				$query2=[
+					'returnto' => $title->getEscapedText(),
+					'returntoquery' => $edit ? self::getEditorParam() : '',
+					'type' => 'login'
 				]);
-			 }
-		} else {
-			return static::editUrl( $article->getFullURL() );
 		}
+
+		return $edit ? static::getEditUrl( $title->getFullURL() ) : $title->getFullURL();
 	}
 
-	private static function editUrl( $articleUrl ) {
+	public static function getEditUrl( $articleUrl ) {
 		return $articleUrl . '?'. static::getEditorParam();
 	}
 

--- a/extensions/wikia/CommunityPage/helpers/LinkHelper.php
+++ b/extensions/wikia/CommunityPage/helpers/LinkHelper.php
@@ -1,12 +1,12 @@
 <?php
 
 class LinkHelper {
-	public static function forceLoginLink(Title $title, $edit=true ) {
+	public static function forceLoginLink( Title $title, $edit=true ) {
 		global $wgUser, $wgDisableAnonymousEditing;
 
 		if ( $wgDisableAnonymousEditing && !$wgUser->isLoggedIn() ) {
 			return SpecialPage::getTitleFor( 'SignUp' )->getFullURL(
-				$query=[
+				[
 					'returnto' => $title->getEscapedText(),
 					'returntoquery' => $edit ? urlencode( self::getEditorParam() ) : '',
 					'type' => 'login'
@@ -17,7 +17,7 @@ class LinkHelper {
 	}
 
 	public static function getEditUrl( $articleUrl ) {
-		return $articleUrl . '?'. static::getEditorParam();
+		return $articleUrl . '?' . static::getEditorParam();
 	}
 
 	private static function getEditorParam() {

--- a/extensions/wikia/CommunityPage/helpers/LinkHelper.php
+++ b/extensions/wikia/CommunityPage/helpers/LinkHelper.php
@@ -6,9 +6,9 @@ class LinkHelper {
 
 		if ( $wgDisableAnonymousEditing && !$wgUser->isLoggedIn() ) {
 			return SpecialPage::getTitleFor( 'SignUp' )->getFullURL(
-				$query2=[
+				$query=[
 					'returnto' => $title->getEscapedText(),
-					'returntoquery' => $edit ? self::getEditorParam() : '',
+					'returntoquery' => $edit ? urlencode( self::getEditorParam() ) : '',
 					'type' => 'login'
 				]);
 		}

--- a/extensions/wikia/CommunityPage/models/CommunityPageDefaultCardsModel.class.php
+++ b/extensions/wikia/CommunityPage/models/CommunityPageDefaultCardsModel.class.php
@@ -15,7 +15,7 @@ class CommunityPageDefaultCardsModel {
 				'title' => wfMessage( 'communitypage-cards-create-page' )->text(),
 				'description' => wfMessage( 'communitypage-cards-create-page-description' )->text(),
 				'icon' => 'create-page',
-				'actionlink' => LinkHelper::forceLoginLink( SpecialPage::getTitleFor( 'CreatePage' ), false ),
+				'actionlink' => LinkHelper::forceLoginLink( SpecialPage::getTitleFor( 'CreatePage' ), LinkHelper::$WITHOUT_EDIT_MODE ),
 				'actiontext' => wfMessage( 'communitypage-cards-create-page' )->text()
 			]
 		], 0, $modulesLimit );

--- a/extensions/wikia/CommunityPage/models/CommunityPageDefaultCardsModel.class.php
+++ b/extensions/wikia/CommunityPage/models/CommunityPageDefaultCardsModel.class.php
@@ -15,7 +15,7 @@ class CommunityPageDefaultCardsModel {
 				'title' => wfMessage( 'communitypage-cards-create-page' )->text(),
 				'description' => wfMessage( 'communitypage-cards-create-page-description' )->text(),
 				'icon' => 'create-page',
-				'actionlink' => LinkHelper::forceLoginLink( SpecialPage::getTitleFor( 'CreatePage' ), LinkHelper::$WITHOUT_EDIT_MODE ),
+				'actionlink' => LinkHelper::forceLoginLink( SpecialPage::getTitleFor( 'CreatePage' ), LinkHelper::WITHOUT_EDIT_MODE ),
 				'actiontext' => wfMessage( 'communitypage-cards-create-page' )->text()
 			]
 		], 0, $modulesLimit );

--- a/extensions/wikia/CommunityPage/models/CommunityPageDefaultCardsModel.class.php
+++ b/extensions/wikia/CommunityPage/models/CommunityPageDefaultCardsModel.class.php
@@ -15,7 +15,7 @@ class CommunityPageDefaultCardsModel {
 				'title' => wfMessage( 'communitypage-cards-create-page' )->text(),
 				'description' => wfMessage( 'communitypage-cards-create-page-description' )->text(),
 				'icon' => 'create-page',
-				'actionlink' => LinkHelper::forceLoginLink(SpecialPage::getTitleFor( 'CreatePage' ), $edit=false),
+				'actionlink' => LinkHelper::forceLoginLink( SpecialPage::getTitleFor( 'CreatePage' ), false ),
 				'actiontext' => wfMessage( 'communitypage-cards-create-page' )->text()
 			]
 		], 0, $modulesLimit );

--- a/extensions/wikia/CommunityPage/models/CommunityPageDefaultCardsModel.class.php
+++ b/extensions/wikia/CommunityPage/models/CommunityPageDefaultCardsModel.class.php
@@ -15,7 +15,7 @@ class CommunityPageDefaultCardsModel {
 				'title' => wfMessage( 'communitypage-cards-create-page' )->text(),
 				'description' => wfMessage( 'communitypage-cards-create-page-description' )->text(),
 				'icon' => 'create-page',
-				'actionlink' => SpecialPage::getTitleFor( 'CreatePage' )->getLocalURL(),
+				'actionlink' => LinkHelper::forceLoginLink(SpecialPage::getTitleFor( 'CreatePage' ), $edit=false),
 				'actiontext' => wfMessage( 'communitypage-cards-create-page' )->text()
 			]
 		], 0, $modulesLimit );

--- a/extensions/wikia/CommunityPage/models/CommunityPageShortPagesCardModel.class.php
+++ b/extensions/wikia/CommunityPage/models/CommunityPageShortPagesCardModel.class.php
@@ -45,15 +45,8 @@ class CommunityPageShortPagesCardModel {
 			'link' => [
 				'text' => $title->getText(),
 				'articleurl' => $title->getFullURL(),
-				'editlink' => $this->getEditUrl( $title->getFullURL() )
+				'editlink' => LinkHelper::getEditUrl( $title )
 			]
 		];
-	}
-
-	private function getEditUrl( $articleUrl ) {
-		if ( EditorPreference::isVisualEditorPrimary() ) {
-			return $articleUrl . '?veaction=edit';
-		}
-		return $articleUrl . '?action=edit';
 	}
 }

--- a/extensions/wikia/CommunityPage/models/CommunityPageShortPagesCardModel.class.php
+++ b/extensions/wikia/CommunityPage/models/CommunityPageShortPagesCardModel.class.php
@@ -45,7 +45,7 @@ class CommunityPageShortPagesCardModel {
 			'link' => [
 				'text' => $title->getText(),
 				'articleurl' => $title->getFullURL(),
-				'editlink' => LinkHelper::forceLoginLink( $title, LinkHelper::$WITH_EDIT_MODE )
+				'editlink' => LinkHelper::forceLoginLink( $title, LinkHelper::WITH_EDIT_MODE )
 			]
 		];
 	}

--- a/extensions/wikia/CommunityPage/models/CommunityPageShortPagesCardModel.class.php
+++ b/extensions/wikia/CommunityPage/models/CommunityPageShortPagesCardModel.class.php
@@ -45,7 +45,7 @@ class CommunityPageShortPagesCardModel {
 			'link' => [
 				'text' => $title->getText(),
 				'articleurl' => $title->getFullURL(),
-				'editlink' => LinkHelper::getEditUrl( $title )
+				'editlink' => LinkHelper::forceLoginLink( $title )
 			]
 		];
 	}

--- a/extensions/wikia/CommunityPage/models/CommunityPageShortPagesCardModel.class.php
+++ b/extensions/wikia/CommunityPage/models/CommunityPageShortPagesCardModel.class.php
@@ -45,7 +45,7 @@ class CommunityPageShortPagesCardModel {
 			'link' => [
 				'text' => $title->getText(),
 				'articleurl' => $title->getFullURL(),
-				'editlink' => LinkHelper::forceLoginLink( $title )
+				'editlink' => LinkHelper::forceLoginLink( $title, LinkHelper::$WITH_EDIT_MODE )
 			]
 		];
 	}

--- a/extensions/wikia/CommunityPage/models/CommunityPageSpecialInsightsModel.class.php
+++ b/extensions/wikia/CommunityPage/models/CommunityPageSpecialInsightsModel.class.php
@@ -79,7 +79,7 @@ class CommunityPageSpecialInsightsModel {
 	private function addEditLinks( $insightsPages ) {
 		foreach ( $insightsPages[ 'pages' ] as $key => $insight ) {
 			$insightsPages[ 'pages' ][ $key ][ 'link' ][ 'editlink' ]
-				= LinkHelper::forceLoginLink( Title::newFromText( $insight[ 'link' ][ 'title' ] ) );
+				= LinkHelper::forceLoginLink( Title::newFromText( $insight[ 'link' ][ 'title' ] ), LinkHelper::$WITH_EDIT_MODE );
 		}
 		return $insightsPages;
 	}

--- a/extensions/wikia/CommunityPage/models/CommunityPageSpecialInsightsModel.class.php
+++ b/extensions/wikia/CommunityPage/models/CommunityPageSpecialInsightsModel.class.php
@@ -79,15 +79,8 @@ class CommunityPageSpecialInsightsModel {
 	private function addEditLinks( $insightsPages ) {
 		foreach ( $insightsPages[ 'pages' ] as $key => $insight ) {
 			$insightsPages[ 'pages' ][ $key ][ 'link' ][ 'editlink' ]
-				= $this->getEditUrl( $insight[ 'link' ][ 'articleurl' ] );
+				= LinkHelper::forceLoginLink( Title::newFromText( $insight[ 'link' ][ 'title' ] ) );
 		}
 		return $insightsPages;
-	}
-
-	private function getEditUrl( $articleUrl ) {
-		if ( EditorPreference::isVisualEditorPrimary() ) {
-			return $articleUrl . '?veaction=edit';
-		}
-		return $articleUrl . '?action=edit';
 	}
 }

--- a/extensions/wikia/CommunityPage/models/CommunityPageSpecialInsightsModel.class.php
+++ b/extensions/wikia/CommunityPage/models/CommunityPageSpecialInsightsModel.class.php
@@ -79,7 +79,7 @@ class CommunityPageSpecialInsightsModel {
 	private function addEditLinks( $insightsPages ) {
 		foreach ( $insightsPages[ 'pages' ] as $key => $insight ) {
 			$insightsPages[ 'pages' ][ $key ][ 'link' ][ 'editlink' ]
-				= LinkHelper::forceLoginLink( Title::newFromText( $insight[ 'link' ][ 'title' ] ), LinkHelper::$WITH_EDIT_MODE );
+				= LinkHelper::forceLoginLink( Title::newFromText( $insight[ 'link' ][ 'title' ] ), LinkHelper::WITH_EDIT_MODE );
 		}
 		return $insightsPages;
 	}

--- a/extensions/wikia/CommunityPage/tests/LinkHelperTest.php
+++ b/extensions/wikia/CommunityPage/tests/LinkHelperTest.php
@@ -8,7 +8,7 @@ class LinkHelperTest extends WikiaBaseTest {
 	const ANNOON_EDITS_FORBIDDEN = true;
 
 	const ARTICLE_NAME = 'test_article';
-	const ARTiCLE_LOCAL_URL = '/wiki/test_article';
+	const ARTICLE_LOCAL_URL = '/wiki/test_article';
 	const ARTICLE_LOCAL_EDIT_URL = '/wiki/test_article?veaction=edit';
 	const SIGNUP_URL_WITH_EDIT = '/wiki/Special:SignUp?returnto=test_article&returntoquery=veaction%253Dedit&type=login';
 	const SIGNUP_URL_WITHOUT_EDIT = '/wiki/Special:SignUp?returnto=test_article&type=login';

--- a/extensions/wikia/CommunityPage/tests/LinkHelperTest.php
+++ b/extensions/wikia/CommunityPage/tests/LinkHelperTest.php
@@ -7,29 +7,23 @@ class LinkHelperTest extends WikiaBaseTest {
 	const ANNON_EDITS_ALLOWED = false;
 	const ANNOON_EDITS_FORBIDDEN = true;
 
-	const ARTICLE_NAME = 'test_article';
-	const ARTICLE_LOCAL_URL = '/wiki/test_article';
-	const ARTICLE_LOCAL_EDIT_URL = '/wiki/test_article?veaction=edit';
-	const SIGNUP_URL_WITH_EDIT = '/wiki/Special:SignUp?returnto=test_article&returntoquery=veaction%253Dedit&type=login';
-	const SIGNUP_URL_WITHOUT_EDIT = '/wiki/Special:SignUp?returnto=test_article&type=login';
+	const ARTICLE_NAME = 'Test_article';
+	const ARTICLE_LOCAL_URL = '/wiki/Test_article';
+	const ARTICLE_LOCAL_EDIT_URL = '/wiki/Test_article?veaction=edit';
+	const SIGNUP_URL_WITH_EDIT = '/wiki/Special:SignUp?returnto=Test+article&returntoquery=veaction%253Dedit&type=login';
+	const SIGNUP_URL_WITHOUT_EDIT = '/wiki/Special:SignUp?returnto=Test+article&type=login';
 
 	/**
 	 * @dataProvider forceLoginLinkTestCases
 	 */
 	public function testForceLoginLink( $user, $editMode, $disableAnonEdits, $expectedLink ) {
-		$mockTitle = $this->getMock( 'Title', [ 'getEscapedText', 'getLocalURL' ] );
-		$mockTitle->expects( $this->any() )
-			->method( 'getEscapedText' )
-			->willReturn( static::ARTICLE_NAME );
-		$mockTitle->expects( $this->any() )
-			->method( 'getLocalURL' )
-			->willReturn( static::ARTICLE_LOCAL_URL );
+		$title = Title::newFromText('test_article');
 
 		$this->mockGlobalVariable( 'wgDisableAnonymousEditing', $disableAnonEdits );
 		$this->mockGlobalVariable( 'wgUser', $user );
 		$this->mockGlobalVariable( 'wgVisualEditorNeverPrimary', false );
 
-		$this->assertEquals( $expectedLink, LinkHelper::forceLoginLink( $mockTitle, $editMode ) );
+		$this->assertEquals( $expectedLink, LinkHelper::forceLoginLink( $title, $editMode ) );
 	}
 
 	public function forceLoginLinkTestCases() {

--- a/extensions/wikia/CommunityPage/tests/LinkHelperTest.php
+++ b/extensions/wikia/CommunityPage/tests/LinkHelperTest.php
@@ -1,5 +1,5 @@
 <?php
-
+require_once( $IP . '/extensions/wikia/CommunityPage/helpers/LinkHelper.php' );
 
 class LinkHelperTest extends WikiaBaseTest {
 	const ANON = false;

--- a/extensions/wikia/CommunityPage/tests/LinkHelperTest.php
+++ b/extensions/wikia/CommunityPage/tests/LinkHelperTest.php
@@ -1,0 +1,57 @@
+<?php
+
+
+class LinkHelperTest extends WikiaBaseTest {
+	const ANON = false;
+	const LOGGED_IN = true;
+	const ANNON_EDITS_ALLOWED = false;
+	const ANNOON_EDITS_FORBIDDEN = true;
+
+	const ARTICLE_NAME = 'test_article';
+	const ARTiCLE_LOCAL_URL = '/wiki/test_article';
+	const ARTICLE_LOCAL_EDIT_URL = '/wiki/test_article?veaction=edit';
+	const SIGNUP_URL_WITH_EDIT = '/wiki/Special:SignUp?returnto=test_article&returntoquery=veaction%253Dedit&type=login';
+	const SIGNUP_URL_WITHOUT_EDIT = '/wiki/Special:SignUp?returnto=test_article&type=login';
+
+	/**
+	 * @dataProvider forceLoginLinkTestCases
+	 */
+	public function testForceLoginLink( $user, $editMode, $disableAnonEdits, $expectedLink ) {
+		$mockTitle = $this->getMock( 'Title', [ 'getEscapedText', 'getLocalURL' ] );
+		$mockTitle->expects( $this->any() )
+			->method( 'getEscapedText' )
+			->willReturn( static::ARTICLE_NAME );
+		$mockTitle->expects( $this->any() )
+			->method( 'getLocalURL' )
+			->willReturn( static::ARTiCLE_LOCAL_URL );
+
+		$this->mockGlobalVariable( 'wgDisableAnonymousEditing', $disableAnonEdits );
+		$this->mockGlobalVariable( 'wgUser', $user );
+		$this->mockGlobalVariable( 'wgVisualEditorNeverPrimary', false );
+
+		$this->assertEquals( $expectedLink, LinkHelper::forceLoginLink( $mockTitle, $editMode ) );
+	}
+
+	public function forceLoginLinkTestCases() {
+		return [
+			[ $this->getUser( static::ANON ), LinkHelper::WITH_EDIT_MODE, static::ANNON_EDITS_ALLOWED, static::ARTICLE_LOCAL_EDIT_URL ],
+			[ $this->getUser( static::ANON ), LinkHelper::WITH_EDIT_MODE, static::ANNOON_EDITS_FORBIDDEN, static::SIGNUP_URL_WITH_EDIT ],
+			[ $this->getUser( static::ANON ), LinkHelper::WITHOUT_EDIT_MODE, static::ANNON_EDITS_ALLOWED, static::ARTiCLE_LOCAL_URL ],
+			[ $this->getUser( static::ANON ), LinkHelper::WITHOUT_EDIT_MODE, static::ANNOON_EDITS_FORBIDDEN, static::SIGNUP_URL_WITHOUT_EDIT ],
+
+			[ $this->getUser( static::LOGGED_IN ), LinkHelper::WITH_EDIT_MODE, static::ANNON_EDITS_ALLOWED, static::ARTICLE_LOCAL_EDIT_URL ],
+			[ $this->getUser( static::LOGGED_IN ), LinkHelper::WITH_EDIT_MODE, static::ANNOON_EDITS_FORBIDDEN, static::ARTICLE_LOCAL_EDIT_URL ],
+			[ $this->getUser( static::LOGGED_IN ), LinkHelper::WITHOUT_EDIT_MODE, static::ANNON_EDITS_ALLOWED, static::ARTiCLE_LOCAL_URL ],
+			[ $this->getUser( static::LOGGED_IN ), LinkHelper::WITHOUT_EDIT_MODE, static::ANNOON_EDITS_FORBIDDEN, static::ARTiCLE_LOCAL_URL ]
+		];
+	}
+
+	private function getUser( $loggedIn ) {
+		$mockUser = $this->getMock( 'User', [ 'isLoggedIn' ] );
+		$mockUser->expects( $this->any() )
+			->method( 'isLoggedIn' )
+			->willReturn( $loggedIn );
+
+		return $mockUser;
+	}
+}

--- a/extensions/wikia/CommunityPage/tests/LinkHelperTest.php
+++ b/extensions/wikia/CommunityPage/tests/LinkHelperTest.php
@@ -23,7 +23,7 @@ class LinkHelperTest extends WikiaBaseTest {
 			->willReturn( static::ARTICLE_NAME );
 		$mockTitle->expects( $this->any() )
 			->method( 'getLocalURL' )
-			->willReturn( static::ARTiCLE_LOCAL_URL );
+			->willReturn( static::ARTICLE_LOCAL_URL );
 
 		$this->mockGlobalVariable( 'wgDisableAnonymousEditing', $disableAnonEdits );
 		$this->mockGlobalVariable( 'wgUser', $user );
@@ -36,13 +36,13 @@ class LinkHelperTest extends WikiaBaseTest {
 		return [
 			[ $this->getUser( static::ANON ), LinkHelper::WITH_EDIT_MODE, static::ANNON_EDITS_ALLOWED, static::ARTICLE_LOCAL_EDIT_URL ],
 			[ $this->getUser( static::ANON ), LinkHelper::WITH_EDIT_MODE, static::ANNOON_EDITS_FORBIDDEN, static::SIGNUP_URL_WITH_EDIT ],
-			[ $this->getUser( static::ANON ), LinkHelper::WITHOUT_EDIT_MODE, static::ANNON_EDITS_ALLOWED, static::ARTiCLE_LOCAL_URL ],
+			[ $this->getUser( static::ANON ), LinkHelper::WITHOUT_EDIT_MODE, static::ANNON_EDITS_ALLOWED, static::ARTICLE_LOCAL_URL ],
 			[ $this->getUser( static::ANON ), LinkHelper::WITHOUT_EDIT_MODE, static::ANNOON_EDITS_FORBIDDEN, static::SIGNUP_URL_WITHOUT_EDIT ],
 
 			[ $this->getUser( static::LOGGED_IN ), LinkHelper::WITH_EDIT_MODE, static::ANNON_EDITS_ALLOWED, static::ARTICLE_LOCAL_EDIT_URL ],
 			[ $this->getUser( static::LOGGED_IN ), LinkHelper::WITH_EDIT_MODE, static::ANNOON_EDITS_FORBIDDEN, static::ARTICLE_LOCAL_EDIT_URL ],
-			[ $this->getUser( static::LOGGED_IN ), LinkHelper::WITHOUT_EDIT_MODE, static::ANNON_EDITS_ALLOWED, static::ARTiCLE_LOCAL_URL ],
-			[ $this->getUser( static::LOGGED_IN ), LinkHelper::WITHOUT_EDIT_MODE, static::ANNOON_EDITS_FORBIDDEN, static::ARTiCLE_LOCAL_URL ]
+			[ $this->getUser( static::LOGGED_IN ), LinkHelper::WITHOUT_EDIT_MODE, static::ANNON_EDITS_ALLOWED, static::ARTICLE_LOCAL_URL ],
+			[ $this->getUser( static::LOGGED_IN ), LinkHelper::WITHOUT_EDIT_MODE, static::ANNOON_EDITS_FORBIDDEN, static::ARTICLE_LOCAL_URL ]
 		];
 	}
 

--- a/extensions/wikia/UserLogin/UserLogin.setup.php
+++ b/extensions/wikia/UserLogin/UserLogin.setup.php
@@ -72,6 +72,6 @@ $wgSpecialPages['Signup'] = 'Signup';
 // redirects from Signup to UserLogin or UserSignup
 class Signup extends SpecialRedirectToSpecial {
 	function __construct() {
-		parent::__construct( 'Signup', 'UserLogin', false, array( 'returnto', 'type' ) );
+		parent::__construct( 'Signup', 'UserLogin', false, array( 'returnto', 'returntoquery', 'type' ) );
 	}
 }


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/WW-95

For wikis with disabled anon edits, if anon clicks on edit/create link on community page, the login modal shows.

@bkoval Additionally adding missing query parameter while redirecting from Special:Signup to Special:UserLogin

@Wikia/west-wing  
