### PR TITLE
Aden 3908

### DIFF
--- a/extensions/wikia/AdEngine/js/lookup/rubicon/rubiconFastlane.js
+++ b/extensions/wikia/AdEngine/js/lookup/rubicon/rubiconFastlane.js
@@ -211,9 +211,6 @@ define('ext.wikia.adEngine.lookup.rubicon.rubiconFastlane', [
 		if (parameters[rubiconTierKey] && typeof parameters[rubiconTierKey].sort === 'function') {
 			parameters[rubiconTierKey].sort(compareTiers);
 		}
-		if (parameters[rubiconTierKey] && parameters[rubiconTierKey].length > 0) {
-			parameters.bid = 'Rxx';
-		}
 
 		log(['getSlotParams', slotName, parameters], 'debug', logGroup);
 		return parameters;

--- a/extensions/wikia/AdEngine/js/lookup/services.js
+++ b/extensions/wikia/AdEngine/js/lookup/services.js
@@ -25,13 +25,38 @@ define('ext.wikia.adEngine.lookup.services', [
 			rubiconFastlane,
 			prebid,
 			rubiconVulcan
-		];
+		],
+		bidIndex = {
+			'rubicon_fastlane': {
+				'pos': 0,
+				'char': 'R'
+			},
+			'ox_bidder': {
+				'pos': 1,
+				'char': 'O'
+			},
+			'amazon': {
+				'pos': 2,
+				'char': 'A'
+			},
+			'rubicon_vulcan': {
+				'pos': 3,
+				'char': 'V'
+			},
+			'prebid': {
+				'pos': 4,
+				'char': 'P'
+			}
+		},
+		bidMarker = ['x','x','x','x','x'];
+
 
 	function addParameters(providerName, slotName, slotTargeting) {
 		var params = {};
 		if (!Object.keys) {
 			return;
 		}
+
 		bidders.forEach(function (bidder) {
 			if (bidder && bidder.wasCalled()) {
 				params = bidder.getSlotParams(slotName);
@@ -39,8 +64,22 @@ define('ext.wikia.adEngine.lookup.services', [
 				Object.keys(params).forEach(function (key) {
 					slotTargeting[key] = params[key];
 				});
+				if (bidder.hasResponse()) {
+					bidMarker = appendBidderMarker(bidder.getName(), bidMarker);
+				}
 			}
 		});
+		slotTargeting.bid = bidMarker.join('');
+	}
+
+	function appendBidderMarker(bidderName, bidMarker) {
+		var bidder;
+		if (!bidIndex[bidderName]) {
+			return bidMarker;
+		}
+		bidder = bidIndex[bidderName];
+		bidMarker[bidder.pos] = bidder.char;
+		return bidMarker;
 	}
 
 	function extendSlotTargeting(slotName, slotTargeting, providerName) {

--- a/extensions/wikia/AdEngine/js/lookup/services.js
+++ b/extensions/wikia/AdEngine/js/lookup/services.js
@@ -28,24 +28,24 @@ define('ext.wikia.adEngine.lookup.services', [
 		],
 		bidIndex = {
 			'rubicon_fastlane': {
-				'pos': 0,
-				'char': 'R'
+				pos: 0,
+				char: 'R'
 			},
 			'ox_bidder': {
-				'pos': 1,
-				'char': 'O'
+				pos: 1,
+				char: 'O'
 			},
-			'amazon': {
-				'pos': 2,
-				'char': 'A'
+			amazon: {
+				pos: 2,
+				char: 'A'
 			},
 			'rubicon_vulcan': {
-				'pos': 3,
-				'char': 'V'
+				pos: 3,
+				char: 'V'
 			},
-			'prebid': {
-				'pos': 4,
-				'char': 'P'
+			prebid: {
+				pos: 4,
+				char: 'P'
 			}
 		},
 		bidMarker = ['x','x','x','x','x'];
@@ -65,14 +65,14 @@ define('ext.wikia.adEngine.lookup.services', [
 					slotTargeting[key] = params[key];
 				});
 				if (bidder.hasResponse()) {
-					bidMarker = appendBidderMarker(bidder.getName(), bidMarker);
+					bidMarker = updateBidderMarker(bidder.getName(), bidMarker);
 				}
 			}
 		});
 		slotTargeting.bid = bidMarker.join('');
 	}
 
-	function appendBidderMarker(bidderName, bidMarker) {
+	function updateBidderMarker(bidderName, bidMarker) {
 		var bidder;
 		if (!bidIndex[bidderName]) {
 			return bidMarker;

--- a/extensions/wikia/AdEngine/js/spec/lookup/rubicon/rubiconFastlane.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/lookup/rubicon/rubiconFastlane.spec.js
@@ -222,7 +222,6 @@ describe('ext.wikia.adEngine.lookup.rubicon.rubiconFastlane', function () {
 		rubiconFastlane.call();
 
 		expect(rubiconFastlane.getSlotParams('MOBILE_TOP_LEADERBOARD')).toEqual({
-			'bid': 'Rxx',
 			'rpfl_7450': ['15_tier0000', '43_tier0000', '44_tier0000', '67_tierNONE']
 		});
 	});
@@ -235,7 +234,6 @@ describe('ext.wikia.adEngine.lookup.rubicon.rubiconFastlane', function () {
 		rubiconFastlane.call();
 
 		expect(rubiconFastlane.getSlotParams('INCONTENT_BOXAD_1')).toEqual({
-			'bid': 'Rxx',
 			'rpfl_7450': ['8_tier0100', '9_tierNONE', '10_tierNONE', '15_tier0010', '54_tier0050']
 		});
 	});

--- a/extensions/wikia/AdEngine/js/spec/lookup/services.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/lookup/services.spec.js
@@ -12,13 +12,38 @@ describe('Method ext.wikia.adEngine.lookup.services', function () {
 		amazon: {
 			trackState: noop,
 			wasCalled: noop,
-			getSlotParams: noop
+			getSlotParams: noop,
+			getName: function () { return 'amazon'; },
+			hasResponse: function () { return true; }
+		},
+		fastlane: {
+			trackState: noop,
+			wasCalled: noop,
+			getSlotParams: noop,
+			getName: function() { return 'rubicon_fastlane'; },
+			hasResponse: function () { return true; }
 		},
 		log: noop,
 		oxBidder: {
 			trackState: noop,
 			wasCalled: noop,
-			getSlotParams: noop
+			getSlotParams: noop,
+			getName: function () { return 'ox_bidder'; },
+			hasResponse: function () { return true; }
+		},
+		prebid: {
+			trackState: noop,
+			wasCalled: noop,
+			getSlotParams: noop,
+			getName: function () { return 'prebid'; },
+			hasResponse: function () { return true; }
+		},
+		vulcan: {
+			trackState: noop,
+			wasCalled: noop,
+			getSlotParams: noop,
+			getName: function () { return 'rubicon_vulcan'; },
+			hasResponse: function () { return true; }
 		},
 		window: {}
 	};
@@ -31,7 +56,8 @@ describe('Method ext.wikia.adEngine.lookup.services', function () {
 			slotTargetingMock = {a: 'b'},
 			expectedSlotTargeting = {
 				a: 'b',
-				amznslots: ['a1x6p5', 'a3x2p9', 'a7x9p5']
+				amznslots: ['a1x6p5', 'a3x2p9', 'a7x9p5'],
+				bid: 'xxAxx'
 			};
 
 		spyOn(mocks.amazon, 'trackState');
@@ -48,11 +74,12 @@ describe('Method ext.wikia.adEngine.lookup.services', function () {
 			mocks.log,
 			undefined,
 			mocks.oxBidder
-		),
-		slotTargetingMock = {a: 'b'},
+			),
+			slotTargetingMock = {a: 'b'},
 			expectedSlotTargeting = {
 				a: 'b',
-				oxslots: ['ox1x6p5', 'ox3x2p9', 'ox7x9p5']
+				oxslots: ['ox1x6p5', 'ox3x2p9', 'ox7x9p5'],
+				bid: 'xOxxx'
 			};
 
 		spyOn(mocks.oxBidder, 'trackState');
@@ -63,4 +90,97 @@ describe('Method ext.wikia.adEngine.lookup.services', function () {
 		expect(slotTargetingMock).toEqual(expectedSlotTargeting);
 		expect(mocks.oxBidder.trackState).toHaveBeenCalled();
 	});
+
+	it('extends slot targeting for RubiconFastlane', function () {
+		var lookup = modules['ext.wikia.adEngine.lookup.services'](
+			mocks.log,
+			undefined,
+			mocks.fastlane
+			),
+			slotTargetingMock = {a: 'b'},
+			expectedSlotTargeting = {
+				a: 'b',
+				flslots: ['fa1s', 'fa2s', 'fa3s'],
+				bid: 'Rxxxx'
+			};
+
+		spyOn(mocks.fastlane, 'trackState');
+		spyOn(mocks.fastlane, 'wasCalled').and.returnValue(true);
+		spyOn(mocks.fastlane, 'getSlotParams').and.returnValue({flslots: ['fa1s', 'fa2s', 'fa3s']});
+
+		lookup.extendSlotTargeting('TOP_LEADERBOARD', slotTargetingMock, 'DirectGpt');
+		expect(slotTargetingMock).toEqual(expectedSlotTargeting);
+		expect(mocks.fastlane.trackState).toHaveBeenCalled();
+	});
+
+	it('extends slot targeting for Prebid.js', function () {
+		var lookup = modules['ext.wikia.adEngine.lookup.services'](
+			mocks.log,
+			undefined,
+			mocks.prebid
+			),
+			slotTargetingMock = {a: 'b'},
+			expectedSlotTargeting = {
+				a: 'b',
+				prebidslots: ['pa1s', 'pa2s', 'pa3s'],
+				bid: 'xxxxP'
+			};
+
+		spyOn(mocks.prebid, 'trackState');
+		spyOn(mocks.prebid, 'wasCalled').and.returnValue(true);
+		spyOn(mocks.prebid, 'getSlotParams').and.returnValue({prebidslots: ['pa1s', 'pa2s', 'pa3s']});
+
+		lookup.extendSlotTargeting('TOP_LEADERBOARD', slotTargetingMock, 'DirectGpt');
+		expect(slotTargetingMock).toEqual(expectedSlotTargeting);
+		expect(mocks.prebid.trackState).toHaveBeenCalled();
+	});
+
+	it('extends slot targeting for Rubicon Vulcan', function () {
+		var lookup = modules['ext.wikia.adEngine.lookup.services'](
+			mocks.log,
+			undefined,
+			mocks.vulcan
+			),
+			slotTargetingMock = {a: 'b'},
+			expectedSlotTargeting = {
+				a: 'b',
+				vulcanslots: ['va1s', 'va2s', 'va3s'],
+				bid: 'xxxVx'
+			};
+
+		spyOn(mocks.vulcan, 'trackState');
+		spyOn(mocks.vulcan, 'wasCalled').and.returnValue(true);
+		spyOn(mocks.vulcan, 'getSlotParams').and.returnValue({vulcanslots: ['va1s', 'va2s', 'va3s']});
+
+		lookup.extendSlotTargeting('TOP_LEADERBOARD', slotTargetingMock, 'DirectGpt');
+		expect(slotTargetingMock).toEqual(expectedSlotTargeting);
+		expect(mocks.vulcan.trackState).toHaveBeenCalled();
+	});
+
+	it('correctly mark all bid slots', function () {
+		var lookup = modules['ext.wikia.adEngine.lookup.services'](
+			mocks.log,
+			mocks.prebid,
+			mocks.amazon,
+			mocks.oxBidder,
+			mocks.fastlane,
+			mocks.vulcan
+			),
+			slotTargetingMock = {a: 'b'},
+			expectedSlotTargeting = {
+				a: 'b',
+				slots: ['va1s', 'va2s', 'va3s'],
+				bid: 'ROAVP'
+			},
+			testedProviders = [mocks.vulcan, mocks.amazon, mocks.prebid, mocks.oxBidder, mocks.fastlane];
+
+		testedProviders.forEach(function(provider) {
+			spyOn(provider, 'wasCalled').and.returnValue(true);
+			spyOn(provider, 'getSlotParams').and.returnValue({slots: ['va1s', 'va2s', 'va3s']});
+		});
+
+		lookup.extendSlotTargeting('TOP_LEADERBOARD', slotTargetingMock, 'DirectGpt');
+		expect(slotTargetingMock).toEqual(expectedSlotTargeting);
+	});
+
 });


### PR DESCRIPTION
Mark bidders responses in data-gpt-slot-params. 

R - Rubicon Fastlane
O - OpenX Bidder
A - Amazon Match
V - Vulcan
P - Prebid.js
x - bidder disabled or didn't respond
Examples:
xxxxx - all bidders disabled
RxxVx - Rubicon & Vulcan responded
