### PR TITLE
SUS-1017: Give Phalanx reload requests more time to succeed

### DIFF
--- a/extensions/wikia/PhalanxII/services/PhalanxService.class.php
+++ b/extensions/wikia/PhalanxII/services/PhalanxService.class.php
@@ -21,6 +21,13 @@ class PhalanxService extends Service {
 	const PHALANX_SERVICE_TRIES_LIMIT = 3; // number of retries for phalanx POST requests
 	const PHALANX_SERVICE_TRY_USLEEP = 20000; // delay between retries - 0.2s
 
+	/**
+	 * @var int PHALANX_SERVICE_RELOAD_TIMEOUT
+	 * SUS-964: Give Phalanx /reload requests more time to succeed (25 seconds, the old default for $wgHttpTimeout)
+	 * This does not affect site performance - /reload requests are sent only upon saving/modifying a block.
+	 */
+	const PHALANX_SERVICE_RELOAD_TIMEOUT = 25;
+
 	protected function getLoggerContext() {
 		return [
 			'class' => __CLASS__
@@ -202,6 +209,13 @@ class PhalanxService extends Service {
 					}
 					$loggerPostParams[ $key ] = substr( json_encode( $values ), 0, self::PHALANX_LOG_PARAM_LENGTH_LIMIT );
 				}
+			}
+
+			// SUS-964: Give reload requests more time to succeed
+			// Reload requests are only sent upon saving/modifying a block,
+			// so using a higher value here won't affect site performance
+			if ( $action === 'reload' ) {
+				$options['timeout'] = static::PHALANX_SERVICE_RELOAD_TIMEOUT;
 			}
 
 			$options["postData"] = implode( "&", $postData );


### PR DESCRIPTION
In #11186 we're setting a default timeout value of 1 second for all internal requests made to Phalanx service. However, this is causing all reload requests (sent upon saving a block) to time out and fail - this
is producing an error message and also causes MediaWiki to send 4 reload requests for each save, exacerbating the existing performance issues. It is safe to increase HTTP timeout value for reload requests, since they're only sent when a block is saved, so they do not affect site performance.

Relevant tickets:
- https://wikia-inc.atlassian.net/browse/PLATFORM-2385
- https://wikia-inc.atlassian.net/browse/SUS-890
- https://wikia-inc.atlassian.net/browse/SUS-964
- https://wikia-inc.atlassian.net/browse/SUS-1017

@macbre @mixth-sense
