### PR TITLE
XW-2087 | Support language code fallbacks in DesignSystem links

### DIFF
--- a/includes/wikia/models/DesignSystemSharedLinks.class.php
+++ b/includes/wikia/models/DesignSystemSharedLinks.class.php
@@ -26,7 +26,28 @@ class DesignSystemSharedLinks {
 	 * @return string full URL, in case of lang specific URL missing, default one is returned
 	 */
 	public function getHref( $name, $lang ) {
+		if ( !isset( $this->hrefs[ $lang ] ) ) {
+			$lang = $this->getLangFallback( $lang );
+		}
+
 		return $this->hrefs[ $lang ][ $name ] ?? $this->hrefs[ 'default' ][ $name ];
+	}
+
+	private function getLangFallback( $lang ) {
+		if ( isset( $this->hrefs[ $lang ] ) ) {
+			return $lang;
+		}
+
+		$fallbacks = Language::getFallbacksFor( $lang );
+		foreach ( $fallbacks as $fallbackCode ) {
+			// All languages fallback to en, but we use that for English-specific
+			// URLs, so we want to fallback only to default, rather than en
+			if ( $fallbackCode !== 'en' && isset( $this->hrefs[ $fallbackCode ] ) ) {
+				return $fallbackCode;
+			}
+		}
+
+		return 'default';
 	}
 
 	private $hrefs = [

--- a/includes/wikia/models/DesignSystemSharedLinks.class.php
+++ b/includes/wikia/models/DesignSystemSharedLinks.class.php
@@ -26,14 +26,12 @@ class DesignSystemSharedLinks {
 	 * @return string full URL, in case of lang specific URL missing, default one is returned
 	 */
 	public function getHref( $name, $lang ) {
-		if ( !isset( $this->hrefs[ $lang ] ) ) {
-			$lang = $this->getLangFallback( $lang );
-		}
+		$lang = $this->getLangWithFallback( $lang );
 
 		return $this->hrefs[ $lang ][ $name ] ?? $this->hrefs[ 'default' ][ $name ];
 	}
 
-	private function getLangFallback( $lang ) {
+	private function getLangWithFallback( $lang ) {
 		if ( isset( $this->hrefs[ $lang ] ) ) {
 			return $lang;
 		}

--- a/includes/wikia/models/tests/DesignSystemSharedLinksTest.php
+++ b/includes/wikia/models/tests/DesignSystemSharedLinksTest.php
@@ -73,6 +73,46 @@ class DesignSystemSharedLinksTest extends WikiaBaseTest {
 				],
 				'http://www.wikia.com'
 			],
+			[
+				'pt',
+				[
+					'en' => [
+						'create-new-wiki' => 'http://www.wikia.com'
+					],
+					'default' => [
+						'create-new-wiki' => null
+					],
+					'pt-br' => [
+						'create-new-wiki' => 'http://pt-br.wikia.com'
+					],
+				],
+				'http://pt-br.wikia.com'
+			],
+			[
+				'pt',
+				[
+					'en' => [
+						'create-new-wiki' => 'http://www.wikia.com'
+					],
+					'default' => [
+						'create-new-wiki' => null
+					],
+					'pt-br' => [ ],
+				],
+				null
+			],
+			[
+				'pt',
+				[
+					'en' => [
+						'create-new-wiki' => 'http://www.wikia.com'
+					],
+					'default' => [
+						'create-new-wiki' => null
+					],
+				],
+				null
+			],
 		];
 	}
 }


### PR DESCRIPTION
Support language code fallbacks in DesignSystem links so that if you provide
the language code pt for Portuguese, we will return the links defined for
Brazilian Portuguese before falling back to default.

/cc @Wikia/x-wing 
