### PR TITLE
WallRelatedPages::getMessagesRelatedArticleIds - one does not simply call wfGetDB() twice

### DIFF
--- a/extensions/wikia/Wall/WallRelatedPages.class.php
+++ b/extensions/wikia/Wall/WallRelatedPages.class.php
@@ -115,12 +115,12 @@ class WallRelatedPages extends WikiaModel {
 	 * @param array $messageId
 	 */
 
-	function getMessagesRelatedArticleIds( $messageIds, $orderBy = 'order_index', $db = DB_SLAVE ) {
+	function getMessagesRelatedArticleIds( $messageIds, $orderBy = 'order_index', $dbType = DB_SLAVE ) {
 		wfProfileIn( __METHOD__ );
 		$pageIds = [ ];
 
 		// Loading from cache
-		$db = wfGetDB( $db );
+		$db = wfGetDB( $dbType );
 
 		if ( ! $db->tableExists( 'wall_related_pages' ) && wfReadOnly() ) {
 			wfProfileOut( __METHOD__ );
@@ -128,7 +128,7 @@ class WallRelatedPages extends WikiaModel {
 		}
 
 		if ( $this->createTable() ) {
-			$db = wfGetDB( $db );
+			$db = wfGetDB( $dbType );
 		}
 
 		$result = $db->select(

--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -3620,7 +3620,7 @@ function wfSplitWikiID( $wiki ) {
  *
  * @return DatabaseMysqli
  */
-function &wfGetDB( $db, $groups = array(), $wiki = false ) {
+function &wfGetDB( int $db, $groups = array(), $wiki = false ) {
 	// wikia change begin -- SMW DB separation project, @author Krzysztof Krzyżaniak (eloy)
 	global $smwgUseExternalDB, $wgDBname;
 	if( $smwgUseExternalDB === true ) {


### PR DESCRIPTION
Prevent `PHP Notice: Object of class DatabaseMysqli could not be converted to int in /usr/wikia/slot1/13783/src/includes/db/LoadBalancer.php on line 491`

followed by

```
Unexpected non-MediaWiki exception encountered, of type "Error"
Error: Call to a member function setLBInfo() on null in /usr/wikia/slot1/13783/src/includes/db/LoadBalancer.php:745
```

Causes `ForumBoardTests` to fail on staging.

Force `wfGetDB`'s `$db`  argument to be int (PHP7 feature), to catch other cases where Database class instance is passed there - f193ce2

``` php
> wfGetDB(DB_SLAVE)
LoadBalancer::getReaderIndex: Using reader #1: slave.db-dev-db.service.consul...
Connecting to slave.db-dev-db.service.consul plpoznan...

> wfGetDB('foo')
Unexpected non-MediaWiki exception encountered, of type "TypeError"
TypeError: Argument 1 passed to wfGetDB() must be of the type integer, string given, called in maintenance/eval.php(88) : eval()'d code on line 1 and defined in includes/GlobalFunctions.php:3623
```

@mixth-sense / @sqreek / @TK-999 
