### PR TITLE
PLATFORM-410: Add explicit lock before updating category counts

### DIFF
--- a/includes/WikiPage.php
+++ b/includes/WikiPage.php
@@ -2850,6 +2850,14 @@ class WikiPage extends Page implements IDBAccessObject {
 			return;
 		}
 
+		// Wikia change - begin - @author: wladek
+		// PLATFORM-410: Attempt to lower the chance of deadlocks
+		sort( $insertCats );
+		foreach ( $insertCats as $cat ) {
+			$dbw->selectRow( 'category', 'cat_id', [ 'cat_title' => $cat ], __METHOD__, [ 'FOR UPDATE' ] );
+		}
+		// Wikia change - end
+
 		$insertRows = array();
 
 		foreach ( $insertCats as $cat ) {


### PR DESCRIPTION
This is a change that is an attempt to lower the chance of deadlocks when multiple concurrent requests try to affect the same category. Let's see if that helps!

https://wikia-inc.atlassian.net/browse/PLATFORM-410

/cc @macbre @jcellary @owend 
