### PR TITLE
WikisApiController: fix default values handling

### DIFF
--- a/includes/wikia/api/WikisApiController.class.php
+++ b/includes/wikia/api/WikisApiController.class.php
@@ -20,7 +20,7 @@ class WikisApiController extends WikiaApiController {
 	const LANGUAGES_LIMIT = 10;
 	const DEFAULT_TOP_EDITORS_NUMBER = 10;
 	const DEFAULT_WIDTH = 250;
-	const DEFAULT_HEIGHT = null;
+	const DEFAULT_HEIGHT = 140;
 	const DEFAULT_SNIPPET_LENGTH = null;
 	const CACHE_VERSION = 3;
 	const WORDMARK = 'Wiki-wordmark.png';
@@ -293,9 +293,9 @@ class WikisApiController extends WikiaApiController {
 
 	protected function getDetailsParams() {
 		return [
-			'imageWidth' => $this->request->getVal( 'width', null ),
-			'imageHeight' => $this->request->getVal( 'height', null ),
-			'length' => $this->request->getVal( 'snippet', static::DEFAULT_SNIPPET_LENGTH )
+			'imageWidth' => $this->request->getInt( 'width' ) ?: static::DEFAULT_WIDTH,
+			'imageHeight' => $this->request->getInt( 'height' ) ?:  static::DEFAULT_HEIGHT,
+			'length' => $this->request->getInt( 'snippet' ) ?: static::DEFAULT_SNIPPET_LENGTH,
 		];
 	}
 

--- a/includes/wikia/api/WikisApiController.class.php
+++ b/includes/wikia/api/WikisApiController.class.php
@@ -25,7 +25,6 @@ class WikisApiController extends WikiaApiController {
 	const CACHE_VERSION = 3;
 	const WORDMARK = 'Wiki-wordmark.png';
 	const MAX_WIKIS = 250;
-	private static $flagsBlacklist = array( 'blocked', 'promoted' );
 
 	private $keys;
 	private $service;


### PR DESCRIPTION
[PLATFORM-2427](https://wikia-inc.atlassian.net/browse/PLATFORM-2427)

`WikisApiController` did not have a default value for thumbnail height and was not handling zero value for width (passed by the old mobile apps). This caused incorrect URLs to be returned for images.
- fix default values handling (by using a default when zero is passed for either width or height)
- actually define a default for height (by using 1,7 ratio calculated based on other requests from mobile apps)

These changes will be applied to `getDetails` method

@wladekb / @aniaMu 
