### PR TITLE
	DPLMain::getSubcategories - properly escape category name

### DIFF
--- a/extensions/DynamicPageList/DPLMain.php
+++ b/extensions/DynamicPageList/DPLMain.php
@@ -3074,8 +3074,8 @@ class DPLMain {
         $dbr =& wfGetDB( DB_SLAVE );
         $cats=$cat;
         $res = $dbr->query("SELECT DISTINCT page_title FROM ".$dbr->tableName('page')." INNER JOIN "
-                .$dbr->tableName('categorylinks')." AS cl0 ON ".$sPageTable.".page_id = cl0.cl_from AND cl0.cl_to='"
-               .str_replace(' ','_',$cat)."'"." WHERE page_namespace='14'");
+                .$dbr->tableName('categorylinks')." AS cl0 ON ".$sPageTable.".page_id = cl0.cl_from AND cl0.cl_to="
+               . $dbr->addQuotes(str_replace(' ','_',$cat))." WHERE page_namespace='14'"); # Wikia change - PLATFORM-2422
         foreach ($res as $row) {
 			if ($depth>1) {
 				$cats .= '|'. self::getSubcategories($row->page_title,$sPageTable,$depth -1) ;

--- a/extensions/DynamicPageList/DPLMain.php
+++ b/extensions/DynamicPageList/DPLMain.php
@@ -3075,7 +3075,7 @@ class DPLMain {
         $cats=$cat;
         $res = $dbr->query("SELECT DISTINCT page_title FROM ".$dbr->tableName('page')." INNER JOIN "
                 .$dbr->tableName('categorylinks')." AS cl0 ON ".$sPageTable.".page_id = cl0.cl_from AND cl0.cl_to="
-               . $dbr->addQuotes(str_replace(' ','_',$cat))." WHERE page_namespace='14'"); # Wikia change - PLATFORM-2422
+               . $dbr->addQuotes(str_replace(' ','_',$cat))." WHERE page_namespace=".NS_CATEGORY); # Wikia change - PLATFORM-2422
         foreach ($res as $row) {
 			if ($depth>1) {
 				$cats .= '|'. self::getSubcategories($row->page_title,$sPageTable,$depth -1) ;


### PR DESCRIPTION
[PLATFORM-2422](https://wikia-inc.atlassian.net/browse/PLATFORM-2422)

[Wikitext](http://semeb.com/dpldemo/index.php?title=DPL:Manual_-_DPL_parameters:_Criteria_for_page_selection#category) to reproduce this issue:

```
<dpl>
category=**"foo"bar's
</dpl>
```

Removed hardcoded value for category namespace (use a const instead).

@wladekb / @Grunny 
