### PR TITLE
XW-1925 | Fix support for links in zh-hk and other Chinese variants

### DIFF
--- a/includes/wikia/models/DesignSystemSharedLinks.class.php
+++ b/includes/wikia/models/DesignSystemSharedLinks.class.php
@@ -261,7 +261,7 @@ class DesignSystemSharedLinks {
 			'user-signin' => 'https://www.wikia.com/signin?uselang=ru',
 			'user-register' => 'https://www.wikia.com/register?uselang=ru',
 		],
-		'zh' => [
+		'zh-hans' => [
 			'fan-communities' => 'http://zh.wikia.com/wiki/Wikia%E4%B8%AD%E6%96%87',
 			'fandom-logo' => 'http://zh.wikia.com',
 			'terms-of-use' => 'http://zh.wikia.com/wiki/%E4%BD%BF%E7%94%A8%E6%9D%A1%E6%AC%BE',
@@ -277,7 +277,7 @@ class DesignSystemSharedLinks {
 			'user-signin' => 'https://www.wikia.com/signin?uselang=zh',
 			'user-register' => 'https://www.wikia.com/register?uselang=zh',
 		],
-		'zh-tw' => [
+		'zh-hant' => [
 			'fan-communities' => 'http://zh-tw.wikia.com/wiki/Wikia%E4%B8%AD%E6%96%87',
 			'fandom-logo' => 'http://zh-tw.wikia.com',
 			'contact' => 'http://zh-tw.wikia.com/wiki/%E7%89%B9%E6%AE%8A:Contact',


### PR DESCRIPTION
By changing the array keys to zh-hans and zh-hant we allow all of MediaWiki's
fallbacks for Chinese language codes to work for links in the DesignSystem API.

/cc @Wikia/x-wing 
