### PR TITLE
PLATORM-1736 - 	FSFile: log when sha1_file fails

### DIFF
--- a/includes/filerepo/backend/FSFile.php
+++ b/includes/filerepo/backend/FSFile.php
@@ -193,6 +193,14 @@ class FSFile {
 		if ( $hash !== false ) {
 			$hash = wfBaseConvert( $hash, 16, 36, 31 );
 		}
+		else {
+			\Wikia\Logger\WikiaLogger::instance()->warning( __METHOD__ . ' - sha1_file failed',
+				[
+					'local_path' => $this->path,
+					'file_exists_bool' => file_exists( $this->path )
+				]
+			);
+		}
 
 		wfProfileOut( __METHOD__ );
 		return $hash;

--- a/includes/filerepo/backend/SwiftFileBackend.php
+++ b/includes/filerepo/backend/SwiftFileBackend.php
@@ -6,6 +6,8 @@
  * @author Aaron Schulz
  */
 
+use Wikia\Logger\WikiaLogger;
+
 /**
  * Class for an OpenStack Swift based file backend.
  *
@@ -571,7 +573,15 @@ class SwiftFileBackend extends FileBackendStore {
 			return true; //nothing to do
 		}
 		wfProfileIn( __METHOD__ );
-		trigger_error( "$path was not stored with SHA-1 metadata.", E_USER_WARNING );
+
+		WikiaLogger::instance()->warning(
+			__METHOD__ . ' - file was not stored with SHA-1 metadata',
+			[
+				'path' => $path,
+				'object' => $obj->container->name
+			]
+		);
+
 		$status = Status::newGood();
 		$scopeLockS = $this->getScopedFileLocks( array( $path ), LockManager::LOCK_UW, $status );
 		if ( $status->isOK() ) {
@@ -586,7 +596,15 @@ class SwiftFileBackend extends FileBackendStore {
 				}
 			}
 		}
-		trigger_error( "Unable to set SHA-1 metadata for $path", E_USER_WARNING );
+
+		WikiaLogger::instance()->warning(
+			__METHOD__ . ' - unable to set SHA-1 metadata',
+			[
+				'path' => $path,
+				'object' => $obj->container->name
+			]
+		);
+
 		$obj->setMetadataValues( array( 'Sha1base36' => false ) );
 		wfProfileOut( __METHOD__ );
 		return false; // failed


### PR DESCRIPTION
[PLATFORM-1736](https://wikia-inc.atlassian.net/browse/PLATFORM-1736)

Let's debug `PHP Warning: mwstore://swift-backend/X was not stored with SHA-1 metadata` reported by `SwiftFileBackend`. It's most likely caused by failing `sha1_file` (a local file is missing?).

@wladekb 
