### PR TITLE
XW-2119 | fix default link to Facebook

### DIFF
--- a/includes/wikia/models/DesignSystemSharedLinks.class.php
+++ b/includes/wikia/models/DesignSystemSharedLinks.class.php
@@ -193,6 +193,7 @@ class DesignSystemSharedLinks {
 			'wam' => 'http://ja.wikia.com/WAM?langCode=ja',
 			'help' => 'http://ja.community.wikia.com/wiki/%E3%83%98%E3%83%AB%E3%83%97:%E3%82%B3%E3%83%B3%E3%83%86%E3%83%B3%E3%83%84',
 			'media-kit' => 'http://www.wikia.com/mediakit?uselang=ja',
+			'social-facebook' => 'https://www.facebook.com/WikiaJapan',
 			'social-twitter' => 'https://twitter.com/wikiajapan',
 			'app-store' => 'https://itunes.apple.com/jp/artist/wikia-inc./id422467077',
 			'google-play' => 'https://play.google.com/store/apps/developer?id=Wikia,+Inc.&hl=ja',

--- a/includes/wikia/models/DesignSystemSharedLinks.class.php
+++ b/includes/wikia/models/DesignSystemSharedLinks.class.php
@@ -193,7 +193,6 @@ class DesignSystemSharedLinks {
 			'wam' => 'http://ja.wikia.com/WAM?langCode=ja',
 			'help' => 'http://ja.community.wikia.com/wiki/%E3%83%98%E3%83%AB%E3%83%97:%E3%82%B3%E3%83%B3%E3%83%86%E3%83%B3%E3%83%84',
 			'media-kit' => 'http://www.wikia.com/mediakit?uselang=ja',
-			'social-facebook' => 'https://www.facebook.com/WikiaJapan',
 			'social-twitter' => 'https://twitter.com/wikiajapan',
 			'app-store' => 'https://itunes.apple.com/jp/artist/wikia-inc./id422467077',
 			'google-play' => 'https://play.google.com/store/apps/developer?id=Wikia,+Inc.&hl=ja',

--- a/includes/wikia/models/DesignSystemSharedLinks.class.php
+++ b/includes/wikia/models/DesignSystemSharedLinks.class.php
@@ -70,7 +70,7 @@ class DesignSystemSharedLinks {
 			'help' => 'http://community.wikia.com/wiki/Help:Contents',
 			'media-kit' => 'http://www.wikia.com/mediakit',
 			'media-kit-contact' => 'http://www.wikia.com/mediakit/contact',
-			'social-facebook' => 'https://www.facebook.com/wikia',
+			'social-facebook' => 'https://www.facebook.com/getfandom',
 			'social-twitter' => 'https://twitter.com/wikia',
 			'social-reddit' => null,
 			'social-youtube' => 'https://www.youtube.com/user/wikia',
@@ -111,7 +111,6 @@ class DesignSystemSharedLinks {
 		],
 		'en' => [
 			'fan-contributor' => 'http://fandom.wikia.com/fan-contributor',
-			'social-facebook' => 'https://www.facebook.com/getfandom',
 			'social-twitter' => 'https://twitter.com/getfandom',
 			'social-reddit' => 'https://www.reddit.com/r/wikia',
 			'social-youtube' => 'https://www.youtube.com/channel/UC988qTQImTjO7lUdPfYabgQ',


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/XW-2119
PR to `release-444`: https://github.com/Wikia/app/pull/11458

https://www.facebook.com/wikia is not a valid address.

@Wikia/x-wing 
