### PR TITLE
SEO-548 Hotfix for paragon.wiki -> paragon.wikia.com redirect

### DIFF
--- a/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
+++ b/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
@@ -431,7 +431,17 @@ class WikiFactoryLoader {
 				$url[ "path" ] = "/{$path}" . $url[ "path" ];
 			}
 
-			$target = WikiFactory::getLocalEnvURL( $url[ "scheme" ] . "://" . $host . $url[ "path" ] );
+			// Special treatment for paragon.wiki
+			// For URLs starting with upper-case letter (/Something) redirect to /wiki/Something
+			$wikiPrefix = '';
+			if ( $host == 'paragon.wikia.com' ) {
+				$firstLetter = $url['path'][1];
+				if ( strtoupper( $firstLetter ) == $firstLetter ) {
+					$wikiPrefix = '/wiki';
+				}
+			}
+
+			$target = WikiFactory::getLocalEnvURL( $url[ "scheme" ] . "://" . $host . $wikiPrefix . $url[ "path" ] );
 			$target = isset( $url[ "query" ] ) ? $target . "?" . $url[ "query" ] : $target;
 
 			$this->debug( "redirected from {$url[ "url" ]} to {$target}" );

--- a/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
+++ b/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
@@ -435,8 +435,8 @@ class WikiFactoryLoader {
 			// For URLs starting with upper-case letter (/Something) redirect to /wiki/Something
 			$wikiPrefix = '';
 			if ( $host == 'paragon.wikia.com' ) {
-				$firstLetter = $url['path'][1];
-				if ( strtoupper( $firstLetter ) == $firstLetter ) {
+				$firstLetter = substr( $url['path'], 1, 1 );
+				if ( is_string( $firstLetter ) && ctype_upper( $firstLetter ) ) {
 					$wikiPrefix = '/wiki';
 				}
 			}


### PR DESCRIPTION
Articles on paragon.wiki start with an upper-case letter, just like on Wikia. They miss the `/wiki/` prefix though.

In this pull request we're redirecting all URLs within paragon.wiki that start with an uppercase letter to /wiki/ while retaining the current behavior for everything else.

Examples:
- paragon.wiki/Heroes will redirect to paragon.wikia.com/wiki/Heroes
- paragon.wiki/robots.txt will redirect to paragon.wiki.com/robots.txt
- paragon.wiki/wiki/Category:2_point_cards will redirect to paragon.wikia.com/wiki/Category:2_point_cards
