### PR TITLE
PLATFORM-410: Skip INSERT IGNORE if category row exists

### DIFF
--- a/includes/WikiPage.php
+++ b/includes/WikiPage.php
@@ -2859,16 +2859,16 @@ class WikiPage extends Page implements IDBAccessObject {
 				$missingCats[] = $cat;
 			}
 		}
-		$insertCats = $missingCats;
 
-		if ( $insertCats ) {
-			$insertRows = array();
-			foreach ( $insertCats as $cat ) {
-				$insertRows[] = array(
-					'cat_id' => $dbw->nextSequenceValue( 'category_cat_id_seq' ),
-					'cat_title' => $cat
-				);
-			}
+		$insertRows = array();
+		foreach ( $missingCats as $cat ) {
+			$insertRows[] = array(
+				'cat_id' => $dbw->nextSequenceValue( 'category_cat_id_seq' ),
+				'cat_title' => $cat
+			);
+		}
+
+		if ( !empty( $insertRows ) ) {
 			$dbw->insert( 'category', $insertRows, __METHOD__, 'IGNORE' );
 		}
 		// Wikia change - end

--- a/includes/WikiPage.php
+++ b/includes/WikiPage.php
@@ -2853,20 +2853,25 @@ class WikiPage extends Page implements IDBAccessObject {
 		// Wikia change - begin - @author: wladek
 		// PLATFORM-410: Attempt to lower the chance of deadlocks
 		sort( $insertCats );
+		$missingCats = [];
 		foreach ( $insertCats as $cat ) {
-			$dbw->selectRow( 'category', 'cat_id', [ 'cat_title' => $cat ], __METHOD__, [ 'FOR UPDATE' ] );
+			if ( !$dbw->selectRow( 'category', 'cat_id', [ 'cat_title' => $cat ], __METHOD__, [ 'FOR UPDATE' ] ) ) {
+				$missingCats[] = $cat;
+			}
+		}
+		$insertCats = $missingCats;
+
+		if ( $insertCats ) {
+			$insertRows = array();
+			foreach ( $insertCats as $cat ) {
+				$insertRows[] = array(
+					'cat_id' => $dbw->nextSequenceValue( 'category_cat_id_seq' ),
+					'cat_title' => $cat
+				);
+			}
+			$dbw->insert( 'category', $insertRows, __METHOD__, 'IGNORE' );
 		}
 		// Wikia change - end
-
-		$insertRows = array();
-
-		foreach ( $insertCats as $cat ) {
-			$insertRows[] = array(
-				'cat_id' => $dbw->nextSequenceValue( 'category_cat_id_seq' ),
-				'cat_title' => $cat
-			);
-		}
-		$dbw->insert( 'category', $insertRows, __METHOD__, 'IGNORE' );
 
 		$addFields    = array( 'cat_pages = cat_pages + 1' );
 		$removeFields = array( 'cat_pages = cat_pages - 1' );


### PR DESCRIPTION
This is another attempt to lower the change of deadlocks in `WikiPage::updateCategoryCounts`. Rows from `category` table are never deleted by mediawiki so this should be totally safe to skip INSERT to this table when you are sure the row existed a few milliseconds ago.

/cc @owend @macbre
