### PR TITLE
FAN-1047 removing vertical links for non-en on fandom

### DIFF
--- a/includes/wikia/models/DesignSystemGlobalNavigationModel.class.php
+++ b/includes/wikia/models/DesignSystemGlobalNavigationModel.class.php
@@ -85,9 +85,6 @@ class DesignSystemGlobalNavigationModel extends WikiaModel {
 				]
 			];
 		} else {
-			if ( $this->product === static::PRODUCT_FANDOMS ) {
-				$data[ 'fandom_overview' ] = $this->getVerticalsSection();
-			}
 			$data[ 'wikis' ] = [
 				'links' => [
 					$this->getCommunityCentralLink()


### PR DESCRIPTION
Pointing this PR to the main x-wing branch since we're going off of this one now. 

This removes the games/movies/tv links for non-en pages. 

@Wikia/x-wing @Wikia/west-wing 
