### PR TITLE
ADEN-3972 Fix high impact templates and remove not needed variables

### DIFF
--- a/extensions/wikia/AdEngine/AdEngine2Hooks.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2Hooks.class.php
@@ -51,8 +51,6 @@ class AdEngine2Hooks {
 		$vars[] = 'wgAdDriverIncontentPlayerSlotCountries';
 		$vars[] = 'wgAdDriverIndexExchangeBidderCountries';
 		$vars[] = 'wgAdDriverKruxCountries';
-		$vars[] = 'wgAdDriverMobileTransitionInterstitialCountries';
-		$vars[] = 'wgAdDriverMobileFloorAdhesionCountries';
 		$vars[] = 'wgAdDriverOpenXBidderCountries';
 		$vars[] = 'wgAdDriverOpenXBidderCountriesRemnant';
 		$vars[] = 'wgAdDriverOverridePrefootersCountries';

--- a/extensions/wikia/AdEngine/js/template/floorAdhesion.js
+++ b/extensions/wikia/AdEngine/js/template/floorAdhesion.js
@@ -9,11 +9,11 @@ define('ext.wikia.adEngine.template.floorAdhesion', [
 	'use strict';
 
 	var logGroup = 'ext.wikia.adEngine.template.floorAdhesion',
-		slotName = 'INVISIBLE_HIGH_IMPACT_2',
-		wrapper = doc.getElementById('InvisibleHighImpactWrapper');
+		slotName = 'INVISIBLE_HIGH_IMPACT_2';
 
 	function show() {
-		var skin = adContext.getContext().targeting.skin;
+		var skin = adContext.getContext().targeting.skin,
+			wrapper = doc.getElementById('InvisibleHighImpactWrapper');
 
 		wrapper.querySelector('.close').addEventListener('click', function (event) {
 			event.preventDefault();

--- a/extensions/wikia/AdEngine/js/template/interstitial.js
+++ b/extensions/wikia/AdEngine/js/template/interstitial.js
@@ -7,10 +7,11 @@ define('ext.wikia.adEngine.template.interstitial', [
 	'use strict';
 
 	var logGroup = 'ext.wikia.adEngine.template.interstitial',
-		slotName = 'INVISIBLE_HIGH_IMPACT_2',
-		wrapper = doc.getElementById('InvisibleHighImpactWrapper');
+		slotName = 'INVISIBLE_HIGH_IMPACT_2';
 
 	function show() {
+		var wrapper = doc.getElementById('InvisibleHighImpactWrapper');
+
 		wrapper.querySelector('.close').addEventListener('click', function (event) {
 			event.preventDefault();
 


### PR DESCRIPTION
`#InvisibleHighImpactWrapper` node is created on each pageview on Mercury so we need to get fresh selector on each show
