### PR TITLE
SUS-1078: Skip rendering template when handling a block save POST request

### DIFF
--- a/extensions/wikia/PhalanxII/PhalanxSpecialController.class.php
+++ b/extensions/wikia/PhalanxII/PhalanxSpecialController.class.php
@@ -85,6 +85,7 @@ class PhalanxSpecialController extends WikiaSpecialPageController {
 
 			// SUS-1078: Don't render template when handling a POST request (block save) to prevent warnings
 			// We will be redirected back to Special:Phalanx anyways
+			$this->skipRendering();
 			return false;
 		}
 

--- a/extensions/wikia/PhalanxII/PhalanxSpecialController.class.php
+++ b/extensions/wikia/PhalanxII/PhalanxSpecialController.class.php
@@ -82,7 +82,10 @@ class PhalanxSpecialController extends WikiaSpecialPageController {
 			$this->wg->Out->redirect($this->title->getFullURL());
 
 			wfProfileOut( __METHOD__ );
-			return;
+
+			// SUS-1078: Don't render template when handling a POST request (block save) to prevent warnings
+			// We will be redirected back to Special:Phalanx anyways
+			return false;
 		}
 
 		/* set pager */


### PR DESCRIPTION
Currently, Phalanx generates PHP warnings every time a block is saved,
because it still tries to render its Nirvana template without enough
data before redirecting the user. We should just skip rendering - we get
redirected back to Phalanx main anyways.

Ticket: https://wikia-inc.atlassian.net/browse/SUS-1078

@macbre @mixth-sense
