### PR TITLE
SEO-557 Unify sitemap generation time reporting and fix stale sitemaps

### DIFF
--- a/extensions/wikia/Sitemap/SpecialSitemap_body.php
+++ b/extensions/wikia/Sitemap/SpecialSitemap_body.php
@@ -250,7 +250,7 @@ class SitemapPage extends UnlistedSpecialPage {
 				return gzencode( str_replace( 'http://localhost/', 'http://' . $_SERVER['SERVER_NAME'] . '/', gzdecode( $namespaceSitemap ) ) );
 			}
 		}
-		$startTime = microtime( true );
+		$start = microtime( true ) * 1000;
 
 		$dbr = wfGetDB( DB_SLAVE, 'vslow' );
 
@@ -306,8 +306,8 @@ class SitemapPage extends UnlistedSpecialPage {
 			$out .= $entry;
 		}
 		$out .= "</urlset>\n";
-		$endTime = microtime( true );
-		$out .= "<!-- Generating time: " . ( $endTime - $startTime ) . " sec - " . date( 'Y-m-d H:i:s' ) . " -->\n";
+		$out .= sprintf( '<!-- Generation time: %dms -->' . PHP_EOL, ( microtime( true ) * 1000 - $start ) );
+		$out .= sprintf( '<!-- Generation date: %s -->' . PHP_EOL, wfTimestamp( TS_ISO_8601 ) );
 
 		return gzencode( $out );
 	}

--- a/extensions/wikia/Sitemap/SpecialSitemap_body.php
+++ b/extensions/wikia/Sitemap/SpecialSitemap_body.php
@@ -313,6 +313,14 @@ class SitemapPage extends UnlistedSpecialPage {
 	}
 
 	private function generateNamespaceFromDb() {
+		// Sitemaps are ONLY saved to database for NS_6 and only if wgEnableVideoSitemaps is true.
+		// If you turn that var ON you're putting the pre-cached sitemaps into the db.
+		// If you then turn the var back OFF you're serving the outdated sitemaps.
+		// SEO-557
+		if ( !F::app()->wg->EnableVideoSitemaps ) {
+			return null;
+		}
+
 		$dbr = wfGetDB( DB_SLAVE );
 		if ( $dbr->tableExists( self::BLOBS_TABLE_NAME ) ) {
 			$sitemapContent = $dbr->selectField(

--- a/extensions/wikia/SitemapXml/SpecialSitemapXmlController.class.php
+++ b/extensions/wikia/SitemapXml/SpecialSitemapXmlController.class.php
@@ -60,6 +60,7 @@ class SpecialSitemapXmlController extends WikiaSpecialPageController {
 
 		echo '</urlset>' . PHP_EOL;
 		echo sprintf( '<!-- Generation time: %dms -->' . PHP_EOL, microtime( true ) * 1000 - $start );
+		echo sprintf( '<!-- Generation date: %s -->' . PHP_EOL, wfTimestamp( TS_ISO_8601 ) );
 	}
 
 	private function getIso8601Timestamp( $touched ) {


### PR DESCRIPTION
Both new sitemaps (/wiki/Special:SitemapXml) and old sitemaps
(/sitemap-_-NS__-*.xml.gz) will report the time to generate and
generation date in an XML comment at the end of the file like that:

```
<!-- Generation time: 1227ms -->
<!-- Generation date: 2016-09-29T19:18:30Z -->
```

Because of the bug in how the video sitemaps are handled, after
disabling them, the code still served the sitemaps saved before
(from back when video sitemaps were enabled). eb796b2 fixes it
by only reading the cached sitemaps from database if video
sitemaps are enabled.
