### PR TITLE
XW-2158 | install Wikia/design-system#0.14.4

### DIFF
--- a/extensions/wikia/DesignSystem/bower.json
+++ b/extensions/wikia/DesignSystem/bower.json
@@ -3,6 +3,6 @@
   "private": true,
 
   "dependencies": {
-    "design-system": "Wikia/design-system#XW-2158"
+    "design-system": "Wikia/design-system#0.14.4"
   }
 }

--- a/extensions/wikia/DesignSystem/bower_components/design-system/.bower.json
+++ b/extensions/wikia/DesignSystem/bower_components/design-system/.bower.json
@@ -11,13 +11,14 @@
     "reference-page/"
   ],
   "homepage": "https://github.com/Wikia/design-system",
-  "_release": "ad708ed64c",
+  "version": "0.14.4",
+  "_release": "0.14.4",
   "_resolution": {
-    "type": "branch",
-    "branch": "XW-2158",
-    "commit": "ad708ed64c70a35345e9a074221a6e999ec65722"
+    "type": "version",
+    "tag": "0.14.4",
+    "commit": "1ba67745d664e3ba454184ec4ebdccb15f7a02b0"
   },
   "_source": "git://github.com/Wikia/design-system.git",
-  "_target": "XW-2158",
+  "_target": "0.14.4",
   "_originalSource": "Wikia/design-system"
 }

--- a/extensions/wikia/DesignSystem/bower_components/design-system/package.json
+++ b/extensions/wikia/DesignSystem/bower_components/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "design-system",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "description": "Design System developed for Wikia",
   "scripts": {
     "build": "gulp",


### PR DESCRIPTION
https://github.com/Wikia/app/pull/11532 had a brach XW-2158 set as a source of Design System code. Branch changes were merged and are released now.

@Wikia/x-wing 
