### PR TITLE
Cake 645 - prevent related content lookups for non-articles

### DIFF
--- a/extensions/wikia/Recirculation/RecirculationApiController.class.php
+++ b/extensions/wikia/Recirculation/RecirculationApiController.class.php
@@ -57,11 +57,12 @@ class RecirculationApiController extends WikiaApiController {
 
 		$limit = trim( $this->request->getVal( 'limit' ) );
 		$ignore = trim( $this->request->getVal( 'ignore' ) );
+		$namespaceId = trim( $this->request->getVal( 'namespaceId' ) );
 
 		$this->response->setCacheValidity( WikiaResponse::CACHE_VERY_SHORT );
 		$this->response->setData( [
 				'title' => wfMessage( 'recirculation-fandom-subtitle' )->plain(),
-				'items' => ( new CakeRelatedContentService() )->getContentRelatedTo( $target, $this->wg->sitename, $limit, $ignore ),
+				'items' => ( new CakeRelatedContentService() )->getContentRelatedTo( $target, $namespaceId, $this->wg->sitename, $limit, $ignore ),
 		] );
 	}
 

--- a/extensions/wikia/Recirculation/RecirculationApiController.class.php
+++ b/extensions/wikia/Recirculation/RecirculationApiController.class.php
@@ -65,8 +65,8 @@ class RecirculationApiController extends WikiaApiController {
 				'items' => ( new CakeRelatedContentService() )->getContentRelatedTo(
 						$target,
 						$namespaceId,
-						$this->wg->sitename,
 						$this->wg->cityId,
+						$this->wg->sitename,
 						$limit,
 						$ignore
 				),

--- a/extensions/wikia/Recirculation/RecirculationApiController.class.php
+++ b/extensions/wikia/Recirculation/RecirculationApiController.class.php
@@ -62,7 +62,14 @@ class RecirculationApiController extends WikiaApiController {
 		$this->response->setCacheValidity( WikiaResponse::CACHE_VERY_SHORT );
 		$this->response->setData( [
 				'title' => wfMessage( 'recirculation-fandom-subtitle' )->plain(),
-				'items' => ( new CakeRelatedContentService() )->getContentRelatedTo( $target, $namespaceId, $this->wg->sitename, $limit, $ignore ),
+				'items' => ( new CakeRelatedContentService() )->getContentRelatedTo(
+						$target,
+						$namespaceId,
+						$this->wg->sitename,
+						$this->wg->cityId,
+						$limit,
+						$ignore
+				),
 		] );
 	}
 

--- a/extensions/wikia/Recirculation/js/helpers/CakeRelatedContentHelper.js
+++ b/extensions/wikia/Recirculation/js/helpers/CakeRelatedContentHelper.js
@@ -21,6 +21,7 @@ define('ext.wikia.recirculation.helpers.cakeRelatedContent', [
             type: 'get',
             data: {
                 relatedTo: articleTitle,
+                namespaceId: w.wgNamespaceNumber,
                 ignore: w.location.pathname,
                 limit: options.limit
             },

--- a/extensions/wikia/Recirculation/services/CakeRelatedContentService.php
+++ b/extensions/wikia/Recirculation/services/CakeRelatedContentService.php
@@ -28,15 +28,14 @@ class CakeRelatedContentService {
 	public function getContentRelatedTo($title, $namespaceId, $wikiId, $universeName = null, $limit = 5, $ignore = null ) {
 		$items = [];
 
-		if ( !$this->onValidWiki($wikiId) || !$this->onValidPage( $title ) ) {
+		if ( !$this->onValidWiki($wikiId) || !$this->onValidPage( $title ) || !$this->isValidNamespace($namespaceId) ) {
 			return $items;
 		}
 
 		$api = $this->relatedContentApi();
-		$entityName = $this->isValidNamespace($namespaceId) ? $title : $universeName;
 
 		try {
-			$filteredRelatedContent = $api->getRelatedContentFromEntityName( $entityName, $universeName, $limit + 1, "true" );
+			$filteredRelatedContent = $api->getRelatedContentFromEntityName( $title, $universeName, $limit + 1, "true" );
 			if ( is_null( $filteredRelatedContent ) ) {
 				$this->warning( "getRelatedContentFromEntityName failed to retrieve recommendations", [
 						"title" => $title,

--- a/extensions/wikia/Recirculation/services/CakeRelatedContentService.php
+++ b/extensions/wikia/Recirculation/services/CakeRelatedContentService.php
@@ -21,10 +21,10 @@ class CakeRelatedContentService {
 	 * @param $ignore
 	 * @return RecirculationContent[]
 	 */
-	public function getContentRelatedTo( $title, $universeName = null, $limit = 5, $ignore = null ) {
+	public function getContentRelatedTo( $title, $namespaceId, $universeName = null, $limit = 5, $ignore = null ) {
 		$items = [];
 
-		if ( !$this->onValidWiki() || !$this->onValidPage( $title ) ) {
+		if ( !$this->onValidWiki() || !$this->onValidPage( $title ) || !$this->isValidNamespace($namespaceId) ) {
 			return $items;
 		}
 
@@ -187,11 +187,18 @@ class CakeRelatedContentService {
 						2237,   // dc
 						2233,   // marvel
 						208733, // darksouls
+						1706, 	// elderscrolls
+						1071836,// overwatch
+						509,		// harrypotter
 				]
 		);
 	}
 
 	private function onValidPage( $title ) {
 		return $title != "Main Page";
+	}
+
+	private function isValidNamespace($namespaceId) {
+		return $namespaceId == NS_MAIN;
 	}
 }

--- a/extensions/wikia/Recirculation/services/CakeRelatedContentService.php
+++ b/extensions/wikia/Recirculation/services/CakeRelatedContentService.php
@@ -18,20 +18,25 @@ class CakeRelatedContentService {
 
 	/**
 	 * @param $title
-	 * @param $ignore
+	 * @param $namespaceId
+	 * @param $wikiId
+	 * @param null $universeName
+	 * @param int $limit
+	 * @param null $ignore
 	 * @return RecirculationContent[]
 	 */
-	public function getContentRelatedTo( $title, $namespaceId, $universeName = null, $limit = 5, $ignore = null ) {
+	public function getContentRelatedTo($title, $namespaceId, $wikiId, $universeName = null, $limit = 5, $ignore = null ) {
 		$items = [];
 
-		if ( !$this->onValidWiki() || !$this->onValidPage( $title ) || !$this->isValidNamespace($namespaceId) ) {
+		if ( !$this->onValidWiki($wikiId) || !$this->onValidPage( $title ) ) {
 			return $items;
 		}
 
 		$api = $this->relatedContentApi();
+		$entityName = $this->isValidNamespace($namespaceId) ? $title : $universeName;
 
 		try {
-			$filteredRelatedContent = $api->getRelatedContentFromEntityName( $title, $universeName, $limit + 1, "true" );
+			$filteredRelatedContent = $api->getRelatedContentFromEntityName( $entityName, $universeName, $limit + 1, "true" );
 			if ( is_null( $filteredRelatedContent ) ) {
 				$this->warning( "getRelatedContentFromEntityName failed to retrieve recommendations", [
 						"title" => $title,
@@ -175,11 +180,9 @@ class CakeRelatedContentService {
 		}
 	}
 
-	private function onValidWiki() {
-		global $wgCityId;
-
+	private function onValidWiki($wikiId) {
 		return in_array(
-				$wgCityId,
+				$wikiId,
 				[
 						147,    // starwars
 						130814, // gameofthrones


### PR DESCRIPTION
@Wikia/cake 
https://wikia-inc.atlassian.net/browse/CAKE-645

pass the article namespace id and don't look up related content on non-`0` namespaces. Also passing in the `wikiId` explicitly instead of relying on the global and updating our list of supported communities.
