### PR TITLE
Toggle 2 more dis vars during CNW

### DIFF
--- a/extensions/wikia/CreateNewWiki/tasks/EnableDiscussionsTask.php
+++ b/extensions/wikia/CreateNewWiki/tasks/EnableDiscussionsTask.php
@@ -38,6 +38,8 @@ class EnableDiscussionsTask extends Task {
 			->setEnableDiscussionsNav( true )
 			->setEnableForums( false )
 			->setArchiveWikiForums( true )
+			->setEnableRecircDiscussions( true )
+			->setEnableDisCountInProfile( true )
 			->save();
 	}
 

--- a/extensions/wikia/Discussions/DiscussionsVarToggler.class.php
+++ b/extensions/wikia/Discussions/DiscussionsVarToggler.class.php
@@ -7,6 +7,8 @@ class DiscussionsVarToggler {
 	const ENABLE_DISCUSSIONS = 'wgEnableDiscussions';
 	const ENABLE_FORUMS = 'wgEnableForumExt';
 	const ARCHIVE_WIKI_FORUMS = 'wgArchiveWikiForums';
+	const ENABLE_DIS_COUNT_IN_PROFILE = 'wgEnableDiscussionPostsCountInUserIdentityBox';
+	const ENABLE_RECIRC_DISCUSSIONS = 'wgEnableRecirculationDiscussions';
 
 	private $discussionsVarMap;
 	private $cityId;
@@ -17,7 +19,9 @@ class DiscussionsVarToggler {
 			self::ENABLE_DISCUSSIONS => null,
 			self::ENABLE_DISCUSSIONS_NAV => null,
 			self::ENABLE_FORUMS => null,
-			self::ARCHIVE_WIKI_FORUMS => null
+			self::ARCHIVE_WIKI_FORUMS => null,
+			self::ENABLE_DIS_COUNT_IN_PROFILE => null,
+			self::ENABLE_RECIRC_DISCUSSIONS => null
 		];
 	}
 
@@ -38,6 +42,16 @@ class DiscussionsVarToggler {
 
 	public function setArchiveWikiForums( bool $val ) : DiscussionsVarToggler {
 		$this->discussionsVarMap[self::ARCHIVE_WIKI_FORUMS] = $val;
+		return $this;
+	}
+
+	public function setEnableDisCountInProfile( bool $val ) : DiscussionsVarToggler {
+		$this->discussionsVarMap[self::ENABLE_DIS_COUNT_IN_PROFILE] = $val;
+		return $this;
+	}
+
+	public function setEnableRecircDiscussions( bool $val ) : DiscussionsVarToggler {
+		$this->discussionsVarMap[self::ENABLE_RECIRC_DISCUSSIONS] = $val;
 		return $this;
 	}
 


### PR DESCRIPTION
Cristina has requested that we toggle 2 more Discussions related wg vars during CNW, `$wgEnableDiscussionPostsCountInUserIdentityBox` and `$wgEnableRecirculationDiscussions`.

`$wgEnableDiscussionPostsCountInUserIdentityBox` should go away following SOC-3082, but we're going to enable it for now until that ticket hits production.

cc @sactage 
