### PR TITLE
SUS-1123: update not a valid Wiki URL handling

### DIFF
--- a/extensions/wikia/NotAValidWikia/NotAValidWikiaHooks.class.php
+++ b/extensions/wikia/NotAValidWikia/NotAValidWikiaHooks.class.php
@@ -7,7 +7,12 @@ class NotAValidWikiaHooks {
 	 * @return boolean
 	 */
 	public static function onArticleFromTitle( &$title, &$article ) {
-		if ( $title instanceof Title && $title->getDBkey() === 'Not_a_valid_Wikia' && !$title->isTalkPage() ) {
+		global $wgNotAValidWikia;
+
+		// http://community.wikia.com/wiki/Community_Central:Not_a_valid_community -> Community_Central:Not_a_valid_community
+		$notAValidWikiaArticleName = array_pop( explode( '/', $wgNotAValidWikia ) );
+
+		if ( $title instanceof Title && $title->getPrefixedDBkey() === $notAValidWikiaArticleName && !$title->isTalkPage() ) {
 			$article = new NotAValidWikiaArticle( $title );
 		}
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-1123

`NotAValidWikia` extension should set meta tag for indexing bots to skip `Not_a_valid_Wikia` page. It does not work currently, fix it as we're changing the URL:

```
$ curl -s 'http://community.wikia.com/wiki/Not_a_valid_Wikia?from=foobar123781612.wikia.com' | grep robots
<meta name="robots" content="noindex,nofollow" />
```

@TK-999 / @Grunny / @gabrys 
