### PR TITLE
FAN-1113 Allow redirect to URL when logging out on Fandom Stories

### DIFF
--- a/includes/specials/SpecialUserlogout.php
+++ b/includes/specials/SpecialUserlogout.php
@@ -92,6 +92,14 @@ class SpecialUserlogout extends UnlistedSpecialPage {
 			}
 		}
 
-		$out->returnToMain(false, $mReturnTo, $mReturnToQuery);
+		if (
+			empty( $mReturnTo ) &&
+			empty( $mReturnToQuery ) &&
+			$redirectUrl = $this->getRequest()->getVal( 'redirect' )
+		) {
+			$out->redirect( $redirectUrl );
+		} else {
+			$out->returnToMain(false, $mReturnTo, $mReturnToQuery);
+		}
 	}
 }

--- a/includes/specials/SpecialUserlogout.php
+++ b/includes/specials/SpecialUserlogout.php
@@ -112,12 +112,6 @@ class SpecialUserlogout extends UnlistedSpecialPage {
 	 */
 	protected function isValidRedirectUrl( $url ) {
 		$hostname = parse_url( $url, PHP_URL_HOST );
-
-		if ( $hostname === 'wikia.com' || $hostname === 'fandom.com' ) {
-			return true;
-		}
-
-		return substr( $hostname, -strlen( '.wikia.com' ) ) === '.wikia.com' ||
-				substr( $hostname, -strlen( '.fandom.com' ) ) === '.fandom.com';
+		return preg_match( '/(\.|^)(wikia|fandom)\.com$/', $hostname );
 	}
 }

--- a/includes/specials/SpecialUserlogout.php
+++ b/includes/specials/SpecialUserlogout.php
@@ -92,14 +92,32 @@ class SpecialUserlogout extends UnlistedSpecialPage {
 			}
 		}
 
-		if (
-			empty( $mReturnTo ) &&
-			empty( $mReturnToQuery ) &&
-			$redirectUrl = $this->getRequest()->getVal( 'redirect' )
-		) {
-			$out->redirect( $redirectUrl );
-		} else {
-			$out->returnToMain(false, $mReturnTo, $mReturnToQuery);
+		if ( empty( $mReturnTo ) && empty( $mReturnToQuery ) ) {
+			$redirectUrl = $this->getRequest()->getVal( 'redirect' );
+
+			if ( $redirectUrl && $this->isValidRedirectUrl( $redirectUrl ) ) {
+				$out->redirect( $redirectUrl );
+				return;
+			}
 		}
+
+		$out->returnToMain( false, $mReturnTo, $mReturnToQuery );
+	}
+
+	/**
+	 * Verifies that a log-out redirect URL is for a Wikia/Fandom domain
+	 *
+	 * @param string $url
+	 * @return boolean True if the URL can be used for a redirect
+	 */
+	protected function isValidRedirectUrl( $url ) {
+		$hostname = parse_url( $url, PHP_URL_HOST );
+
+		if ( $hostname === 'wikia.com' || $hostname === 'fandom.com' ) {
+			return true;
+		}
+
+		return substr( $hostname, -strlen( '.wikia.com' ) ) === '.wikia.com' ||
+				substr( $hostname, -strlen( '.fandom.com' ) ) === '.fandom.com';
 	}
 }

--- a/includes/wikia/models/DesignSystemGlobalNavigationModel.class.php
+++ b/includes/wikia/models/DesignSystemGlobalNavigationModel.class.php
@@ -234,7 +234,7 @@ class DesignSystemGlobalNavigationModel extends WikiaModel {
 				'type' => 'translatable-text',
 				'key' => 'global-navigation-user-sign-out'
 			],
-			'param-name' => 'returnto',
+			'param-name' => $this->product === static::PRODUCT_FANDOMS ? 'redirect' : 'returnto',
 			'tracking_label' => 'account.sign-out',
 		];
 


### PR DESCRIPTION
Currently the log-out page does not allow redirection to a specific URL. This is needed on Fandom Stories, where redirecting to a wiki page makes no sense.

This change adds a check for a "redirect" query parameter on the log-out page, and specifies "redirect" as the parameter for log-out links in the global nav for Fandom Stories.

See https://github.com/Wikia/upstream/pull/745 for the accompanying changes to Wikia/upstream.
