### PR TITLE
SUS-1175: As a VSTF, I would like to be able to clear user masthead content with a single click

### DIFF
--- a/extensions/wikia/UserProfilePageV3/UserIdentityBox.class.php
+++ b/extensions/wikia/UserProfilePageV3/UserIdentityBox.class.php
@@ -1,6 +1,6 @@
 <?php
 
-class UserIdentityBox {
+class UserIdentityBox extends WikiaObject {
 	const CACHE_VERSION = 2;
 
 	/**
@@ -44,10 +44,9 @@ class UserIdentityBox {
 	 * @param User $user core user object
 	 */
 	public function __construct( User $user ) {
-		global $wgTitle;
-
+		parent::__construct();
 		$this->user = $user;
-		$this->title = $wgTitle;
+		$this->title = $this->wg->Title;
 		$this->favWikisModel = $this->getFavoriteWikisModel();
 
 		if ( is_null( $this->title ) ) {
@@ -77,7 +76,6 @@ class UserIdentityBox {
 
 	protected function getUserData( $dataType ) {
 		wfProfileIn( __METHOD__ );
-		global $wgCityId, $wgLang;
 
 		$userName = $this->user->getName();
 		$userId = $this->user->getId();
@@ -91,7 +89,7 @@ class UserIdentityBox {
 
 			$this->getUserTags( $data );
 		} else {
-			$wikiId = $wgCityId;
+			$wikiId = $this->wg->CityId;
 
 			if ( empty( $this->userStats ) ) {
 				/** @var $userStatsService UserStatsService */
@@ -114,7 +112,7 @@ class UserIdentityBox {
 
 			$data = $this->getInternationalizedRegistrationDate( $wikiId, $data );
 			if ( !empty( $data['edits'] ) ) {
-				$data['edits'] = $wgLang->formatNum( $data['edits'] );
+				$data['edits'] = $this->wg->Lang->formatNum( $data['edits'] );
 			}
 
 			// other data operations
@@ -156,11 +154,10 @@ class UserIdentityBox {
 	}
 
 	protected function internationalizeRegistrationDate( $data ) {
-		global $wgLang;
 		wfProfileIn( __METHOD__ );
 
 		if ( !empty( $data['registration'] ) ) {
-			$data['registration'] = $wgLang->date( $data['registration'] );
+			$data['registration'] = $this->wg->Lang->date( $data['registration'] );
 		}
 		wfProfileOut( __METHOD__ );
 		return $data;
@@ -389,10 +386,8 @@ class UserIdentityBox {
 	 * @return string Parsed HTML string
 	 */
 	public function doParserFilter( $text ) {
-		global $wgParser;
-
 		$text = str_replace( '*', '&asterix;', $text );
-		$text = $wgParser->parse( $text, $this->user->getUserPage(), new ParserOptions( $this->user ) )->getText();
+		$text = ParserPool::parse( $text, $this->user->getUserPage(), new ParserOptions( $this->user ) )->getText();
 		$text = str_replace( '&amp;asterix;', '*', $text );
 		// Encoding problems in user masthead (CONN-131)
 		$text = str_replace( '&#160;', ' ', $text );
@@ -426,8 +421,6 @@ class UserIdentityBox {
 	 * @return array
 	 */
 	private function saveMemcUserIdentityData( $data ) {
-		global $wgMemc;
-
 		foreach ( array( 'location', 'occupation', 'gender', 'birthday', 'website', 'twitter', 'fbPage', 'realName', 'topWikis', 'hideEditsWikis' ) as $property ) {
 			if ( is_object( $data ) && isset( $data->$property ) ) {
 				$memcData[$property] = $data->$property;
@@ -469,7 +462,7 @@ class UserIdentityBox {
 			}
 		}
 
-		$wgMemc->set( $this->getMemcUserIdentityDataKey(), $memcData, self::CACHE_TTL );
+		$this->wg->Memc->set( $this->getMemcUserIdentityDataKey(), $memcData, self::CACHE_TTL );
 
 		return $memcData;
 	}
@@ -537,8 +530,6 @@ class UserIdentityBox {
 	 * @return bool
 	 */
 	public function shouldDisplayFullMasthead() {
-		global $wgCityId;
-
 		$userId = $this->user->getId();
 		if ( empty( $this->userStats ) ) {
 			/** @var $userStatsService UserStatsService */
@@ -550,7 +541,7 @@ class UserIdentityBox {
 		$iEdits = is_null( $iEdits ) ? 0 : intval( $iEdits );
 
 		$hasUserEverEditedMastheadBefore = $this->hasUserEverEditedMasthead();
-		$hasUserEditedMastheadBeforeOnThisWiki = $this->hasUserEditedMastheadBefore( $wgCityId );
+		$hasUserEditedMastheadBeforeOnThisWiki = $this->hasUserEditedMastheadBefore( $this->wg->CityId );
 
 		if ( $hasUserEditedMastheadBeforeOnThisWiki || ( $iEdits > 0 && $hasUserEverEditedMastheadBefore ) ) {
 			return true;
@@ -560,12 +551,18 @@ class UserIdentityBox {
 	}
 
 	/**
-	 * Blanks user profile data
+	 * Blanks user profile data and disables the user's account
 	 * @author grunny
 	 */
 	public function resetUserProfile() {
-		global $wgMemc;
+		Wikia::invalidateUser( $this->user );
+		$this->clearMastheadContents();
+	}
 
+	/**
+	 * Removes all content from user profile masthead and deletes user avatar
+	 */
+	public function clearMastheadContents() {
 		foreach ( $this->optionsArray as $option ) {
 			if ( $option === 'gender' || $option === 'birthday' ) {
 				$option = self::USER_PROPERTIES_PREFIX . $option;
@@ -573,14 +570,16 @@ class UserIdentityBox {
 			$this->user->setGlobalAttribute( $option, null );
 		}
 
-		Wikia::invalidateUser( $this->user );
-		$this->user->saveSettings();
-		$wgMemc->delete( $this->getMemcUserIdentityDataKey() );
+		$this->user->setRealName( null );
 
 		// Delete both the avatar from the user's attributes (above),
 		// as well as from disk.
 		$avatarService = new UserAvatarsService( $this->user->getId() );
 		$avatarService->remove();
+
+		$this->user->saveSettings();
+
+		$this->wg->Memc->delete( $this->getMemcUserIdentityDataKey() );
 	}
 
 	/**
@@ -610,12 +609,10 @@ class UserIdentityBox {
 	 * @return boolean
 	 */
 	public function hideWiki( $wikiId ) {
-		global $wgMemc;
-
 		$result = $this->getFavoriteWikisModel()->hideWiki( $wikiId );
 
 		if ( $result ) {
-			$memcData = $wgMemc->get( $this->getMemcUserIdentityDataKey() );
+			$memcData = $this->wg->Memc->get( $this->getMemcUserIdentityDataKey() );
 			$memcData['topWikis'] = empty( $memcData['topWikis'] ) ? [] : $memcData['topWikis'];
 			$this->saveMemcUserIdentityData( $memcData );
 		}

--- a/extensions/wikia/UserProfilePageV3/UserIdentityBox.class.php
+++ b/extensions/wikia/UserProfilePageV3/UserIdentityBox.class.php
@@ -543,11 +543,7 @@ class UserIdentityBox extends WikiaObject {
 		$hasUserEverEditedMastheadBefore = $this->hasUserEverEditedMasthead();
 		$hasUserEditedMastheadBeforeOnThisWiki = $this->hasUserEditedMastheadBefore( $this->wg->CityId );
 
-		if ( $hasUserEditedMastheadBeforeOnThisWiki || ( $iEdits > 0 && $hasUserEverEditedMastheadBefore ) ) {
-			return true;
-		} else {
-			return false;
-		}
+		return ( $hasUserEditedMastheadBeforeOnThisWiki || ( $iEdits > 0 && $hasUserEverEditedMastheadBefore ) );
 	}
 
 	/**

--- a/extensions/wikia/UserProfilePageV3/UserProfilePage.i18n.php
+++ b/extensions/wikia/UserProfilePageV3/UserProfilePage.i18n.php
@@ -88,6 +88,10 @@ $messages['en'] = [
 	'user-identity-box-avatar-error-cantwrite' => 'Error: Could not write to temporary directory',
 	'user-identity-box-avatar-error-size' => 'Error: Avatar file is too big (max {{PLURAL:$1|$1|$1}}KB)',
 	'user-identity-box-avatar-error' => 'Error: There was internal error while saving avatar',
+	'user-identity-box-clear' => 'Clear profile contents',
+	'user-identity-box-clear-confirmation' => 'Are you sure you want to clear profile contents',
+	'user-identity-box-clear-success' => 'Successfully deleted user profile contents',
+	'user-identity-box-clear-notarget' => 'The specified user could not be found',
 	'userprofilepage-lightbox-about-me-cancel' => 'Cancel',
 	'userprofilepage-lightbox-about-me-save' => 'Save, I\'m Done',
 	'user-identity-box-saving-error' => 'Saving user data failed - your data should be a plain text',
@@ -125,6 +129,7 @@ $messages['en'] = [
 	'right-editprofilev3' => 'Edit other user\'s profile data',
 	'right-deleteprofilev3' => 'Delete user pages',
 	'right-renameprofilev3' => 'Move user pages',
+	'right-clearuserprofile' => 'Clear the contents of an user\'s profile masthead in one click',
 ];
 
 $messages['qqq'] = [
@@ -271,6 +276,19 @@ Parameters:
 	'user-identity-remove-fail' => 'Error message, general error message during avatar picture removal.',
 	'user-identity-avatars-maintenance' => 'Info message that avatars are currently under maintenance and can\'t be modified right now.',
 	'userprofilepage-edit-modal-error' => 'General error message for user profile page.',
+	'right-council' => '{{doc-right}}',
+	'right-voldev' => '{{doc-right}}',
+	'right-authenticated' => '{{doc-right}}',
+	'right-removeavatar' => '{{doc-right}}',
+	'right-loggedin' => '{{doc-right}}',
+	'right-editprofilev3' => '{{doc-right}}',
+	'right-deleteprofilev3' => '{{doc-right}}',
+	'right-renameprofilev3' => '{{doc-right}}',
+	'right-clearuserprofile' => '{{doc-right}}',
+	'user-identity-box-clear' => 'Label for link which clears user profile page contents in one click',
+	'user-identity-box-clear-confirmation' => 'Confirmation message displayed after user clicks clear profile contents link on user profile page',
+	'user-identity-box-clear-success' => 'Success confirmation message shown as banner notification when the contents of the user profile page were successfully cleared',
+	'user-identity-box-clear-notarget' => 'Error message shown as banner notification when the contents of the user profile page could not be cleared because the target was invalid',
 ];
 
 $messages['ar'] = [

--- a/extensions/wikia/UserProfilePageV3/UserProfilePage.setup.php
+++ b/extensions/wikia/UserProfilePageV3/UserProfilePage.setup.php
@@ -75,17 +75,24 @@ $wgHooks['ArticleSaveComplete'][] = 'Masthead::userMastheadInvalidateCache';
  */
 $wgExtensionMessagesFiles['UserProfilePageV3'] = $dir . '/UserProfilePage.i18n.php';
 
-// register messages package for JS
-JSMessages::registerPackage( 'UserProfilePageV3', array(
-	'userprofilepage-edit-modal-header',
-	'user-identity-box-avatar-cancel',
-	'user-identity-box-avatar-save',
-	'userprofilepage-closing-popup-header',
-	'userprofilepage-closing-popup-save-and-quit',
-	'userprofilepage-closing-popup-discard-and-quit',
-	'userprofilepage-closing-popup-cancel',
-	'userprofilepage-edit-modal-error'
-) );
+$wgResourceModules['ext.UserProfilePage.Lightbox'] = [
+	'styles' => 'css/UserProfilePage_modal.scss',
+	'messages' => [
+		'userprofilepage-edit-modal-header',
+		'user-identity-box-avatar-cancel',
+		'user-identity-box-avatar-save',
+		'userprofilepage-closing-popup-header',
+		'userprofilepage-closing-popup-save-and-quit',
+		'userprofilepage-closing-popup-discard-and-quit',
+		'userprofilepage-closing-popup-cancel',
+		'userprofilepage-edit-modal-error',
+		'oasis-generic-error'
+	],
+	'dependencies' => [ 'mediawiki.jqueryMsg' ],
+	'localBasePath' => __DIR__,
+	'remoteExtPath' => 'wikia'
+];
+
 /**
  * extension related configuration
  */

--- a/extensions/wikia/UserProfilePageV3/UserProfilePageController.class.php
+++ b/extensions/wikia/UserProfilePageV3/UserProfilePageController.class.php
@@ -1048,7 +1048,7 @@ class UserProfilePageController extends WikiaController {
 		}
 
 		$targetUser = User::newFromName( $this->request->getVal( 'target' ) );
-		if ( $targetUser->getId() !== 0 ) {
+		if ( $targetUser && $targetUser->getId() !== 0 ) {
 			$userIdentityBox = new UserIdentityBox( $targetUser );
 			$userIdentityBox->clearMastheadContents();
 

--- a/extensions/wikia/UserProfilePageV3/css/UserProfilePage.scss
+++ b/extensions/wikia/UserProfilePageV3/css/UserProfilePage.scss
@@ -101,7 +101,7 @@ $color-user-profile-gradient-bottom: desaturate(darken($color-menu-highlight, 5%
 		position: relative;
 
 		&:hover {
-			#userIdentityBoxEdit {
+			.user-identity-box-edit {
 				display: block;
 			}
 		}
@@ -276,18 +276,20 @@ $color-user-profile-gradient-bottom: desaturate(darken($color-menu-highlight, 5%
 			padding-bottom: 10px;
 		}
 
-		#userIdentityBoxEdit {
+		.user-identity-box-edit {
 			display: block;
 		}
 	}
 }
 
-#userIdentityBoxEdit {
+.user-identity-box-edit {
+	cursor: pointer;
 	display: none;
 	margin-top: 10px;
 	position: absolute;
 	right: 10px;
-	img {
+	list-style: none;
+	svg {
 		position: relative;
 		top: 2px;
 	}

--- a/extensions/wikia/UserProfilePageV3/js/UserProfilePage.js
+++ b/extensions/wikia/UserProfilePageV3/js/UserProfilePage.js
@@ -54,6 +54,14 @@ require(
 				});
 			});
 
+			$('#userIdentityBoxClear').click(function (event) {
+				event.preventDefault();
+				UserProfilePage.clearMastheadContents(
+					$(event.target).attr('data-name'),
+					$(event.target).attr('data-confirm')
+				);
+			});
+
 			// for touch devices (without hover state) make sure that Edit is always
 			// visible
 			if (window.Wikia.isTouchScreen()) {
@@ -622,6 +630,30 @@ require(
 					} else {
 						UserProfilePage.error(data.error);
 					}
+				});
+			}
+		},
+
+		/**
+		 * Clear all contents from user profile (including user avatar)
+		 * @param {string} targetUser Name of target user
+		 * @param {string} confirmationMessage Confirmation message to display
+		 */
+		clearMastheadContents: function (targetUser, confirmationMessage) {
+			var confirmClear = window.confirm(confirmationMessage)
+			if (confirmClear) {
+				nirvana.sendRequest({
+					controller: 'UserProfilePage',
+					method: 'clearMastheadContents',
+					type: 'POST',
+					data: {
+						target: targetUser,
+						token: mw.user.tokens.get('editToken')
+					}
+				}).done(function (res) {
+					window.location.reload();
+				}).fail(function (res) {
+					new BannerNotification(res.error, 'error').show();
 				});
 			}
 		}

--- a/extensions/wikia/UserProfilePageV3/js/UserProfilePage.js
+++ b/extensions/wikia/UserProfilePageV3/js/UserProfilePage.js
@@ -109,7 +109,7 @@ require(
 									title: mw.message('userprofilepage-edit-modal-header').escaped(),
 									buttons: [{
 										vars: {
-											value: mw.message('user-identity-box-avatar-save').escaped(),
+											value: mw.message('user-identity-box-avatar-save').text(),
 											classes: ['normal', 'primary'],
 											data: [{
 												key: 'event',
@@ -118,7 +118,7 @@ require(
 										}
 									}, {
 										vars: {
-											value: mw.message('user-identity-box-avatar-cancel').escaped(),
+											value: mw.message('user-identity-box-avatar-cancel').text(),
 											data: [{
 												key: 'event',
 												value: 'close'

--- a/extensions/wikia/UserProfilePageV3/js/UserProfilePage.js
+++ b/extensions/wikia/UserProfilePageV3/js/UserProfilePage.js
@@ -1,94 +1,92 @@
-var UserProfilePage = {
-	// TODO: use $.nirvana.getJSON instead
-	ajaxEntryPoint: '/wikia.php?controller=UserProfilePage&format=json',
-	questions: [],
-	currQuestionIndex: 0,
-	modal: null,
-	newAvatar: false,
-	closingPopup: null,
-	userId: null,
-	wasDataChanged: false,
-	forceRedirect: false,
-	reloadUrl: false,
-	bucky: window.Bucky('UserProfilePage'),
-	bannerNotification: null,
+require(
+	['jquery', 'mw', 'wikia.nirvana', 'wikia.window', 'wikia.tracker', 'bucky', 'BannerNotification', 'wikia.ui.factory'],
+	function ($, mw, nirvana, window, tracker, bucky, BannerNotification, uiFactory) {
+	'use strict';
 
-	// reference to modal UI component
-	modalComponent: {},
+	var UserProfilePage = {
+		questions: [],
+		currQuestionIndex: 0,
+		modal: null,
+		newAvatar: false,
+		closingPopup: null,
+		userId: null,
+		wasDataChanged: false,
+		forceRedirect: false,
+		reloadUrl: false,
+		bucky: bucky('UserProfilePage'),
+		bannerNotification: null,
 
-	init: function () {
-		'use strict';
+		// reference to modal UI component
+		modalComponent: {},
 
-		var $userIdentityBoxEdit = $('#userIdentityBoxEdit');
-		UserProfilePage.userId = $('#user').val();
-		UserProfilePage.reloadUrl = $('#reloadUrl').val();
-		require(['BannerNotification'], function (BannerNotification) {
+		init: function () {
+			var $userIdentityBoxEdit = $('#userIdentityBoxEdit');
+			UserProfilePage.userId = $('#user').val();
+			UserProfilePage.reloadUrl = $('#reloadUrl').val();
 			UserProfilePage.bannerNotification = new BannerNotification().setType('error');
-		});
 
-		if (UserProfilePage.reloadUrl === '' || UserProfilePage.reloadUrl === false) {
-			UserProfilePage.reloadUrl = window.wgScript + '?title=' + window.wgPageName;
-		}
+			if (UserProfilePage.reloadUrl === '' || UserProfilePage.reloadUrl === false) {
+				UserProfilePage.reloadUrl = mw.config.get('wgScript') + '?title=' + mw.config.get('wgPageName');
+			}
 
-		$userIdentityBoxEdit.click(function (event) {
-			event.preventDefault();
-			UserProfilePage.renderLightbox('about');
-		});
-
-		$('#UserAvatarRemove').click(function (event) {
-			event.preventDefault();
-			UserProfilePage.removeAvatar($(event.target).attr('data-name'),
-				$(event.target).attr('data-confirm'));
-		});
-
-		$('#userAvatarEdit').click(function (event) {
-			event.preventDefault();
-			UserProfilePage.renderLightbox('avatar');
-		});
-
-		$('#discussionAllPostsByUser').click(function (event) {
-			Wikia.Tracker.track({
-				action: Wikia.Tracker.ACTIONS.CLICK_LINK_TEXT,
-				browserEvent: event,
-				href: $(event.target).attr('href'),
-				label: 'discussion-all-posts-by-user'
+			$userIdentityBoxEdit.click(function (event) {
+				event.preventDefault();
+				UserProfilePage.renderLightbox('about');
 			});
-		});
 
-		// for touch devices (without hover state) make sure that Edit is always
-		// visible
-		if (Wikia.isTouchScreen()) {
-			$userIdentityBoxEdit.show();
-		}
-	},
+			$('#UserAvatarRemove').click(function (event) {
+				event.preventDefault();
+				UserProfilePage.removeAvatar($(event.target).attr('data-name'),
+					$(event.target).attr('data-confirm'));
+			});
 
-	renderLightbox: function (tabName) {
-		'use strict';
+			$('#userAvatarEdit').click(function (event) {
+				event.preventDefault();
+				UserProfilePage.renderLightbox('avatar');
+			});
 
-		if (!UserProfilePage.isLightboxGenerating) {
-			// Start profiling
-			UserProfilePage.bucky.timer.start('renderLightboxSuccess');
-			UserProfilePage.bucky.timer.start('renderLightboxFail');
+			$('#discussionAllPostsByUser').click(function (event) {
+				tracker.track({
+					action: tracker.ACTIONS.CLICK_LINK_TEXT,
+					browserEvent: event,
+					href: $(event.target).attr('href'),
+					label: 'discussion-all-posts-by-user'
+				});
+			});
 
-			//if lightbox is generating we don't want to let user open second one
-			UserProfilePage.isLightboxGenerating = true;
-			UserProfilePage.newAvatar = false;
+			// for touch devices (without hover state) make sure that Edit is always
+			// visible
+			if (window.Wikia.isTouchScreen()) {
+				$userIdentityBoxEdit.show();
+			}
+		},
 
-			$.when(
-				$.getJSON(this.ajaxEntryPoint, {
-					method: 'getLightboxData',
-					tab: tabName,
-					userId: UserProfilePage.userId,
-					rand: Math.floor(Math.random() * 100001) // is cache buster really needed here?
-				}),
-				$.getMessages(['UserProfilePageV3']),
-				$.getResources([
-					$.getSassCommonURL('/extensions/wikia/UserProfilePageV3/css/UserProfilePage_modal.scss')
-				])
-			).done(function (getJSONResponse) {
-				var data = getJSONResponse[0];
+		renderLightbox: function (tabName) {
+			if (!UserProfilePage.isLightboxGenerating) {
+				// Start profiling
+				UserProfilePage.bucky.timer.start('renderLightboxSuccess');
+				UserProfilePage.bucky.timer.start('renderLightboxFail');
 
-				require(['wikia.ui.factory'], function (uiFactory) {
+				//if lightbox is generating we don't want to let user open second one
+				UserProfilePage.isLightboxGenerating = true;
+				UserProfilePage.newAvatar = false;
+
+				$.when(
+					// TODO: this should probably be refactored as mustache template
+					nirvana.sendRequest({
+						controller: 'UserProfilePage',
+						method: 'getLightboxData',
+						type: 'GET',
+						data: {
+							tab: tabName,
+							userId: UserProfilePage.userId,
+							rand: Math.floor(Math.random() * 100001) // is cache buster really needed here?
+						}
+					}),
+					mw.loader.using('ext.UserProfilePage.Lightbox')
+				).done(function (getJSONResponse) {
+					var data = getJSONResponse[0];
+
 					uiFactory.init(['modal']).then(function (modal) {
 
 						// set reference to modal UI component for easy creation of confirmation modal
@@ -100,10 +98,10 @@ var UserProfilePage = {
 									id: id,
 									content: data.body,
 									size: 'medium',
-									title: $.msg('userprofilepage-edit-modal-header'),
+									title: mw.message('userprofilepage-edit-modal-header').escaped(),
 									buttons: [{
 										vars: {
-											value: $.msg('user-identity-box-avatar-save'),
+											value: mw.message('user-identity-box-avatar-save').escaped(),
 											classes: ['normal', 'primary'],
 											data: [{
 												key: 'event',
@@ -112,7 +110,7 @@ var UserProfilePage = {
 										}
 									}, {
 										vars: {
-											value: $.msg('user-identity-box-avatar-cancel'),
+											value: mw.message('user-identity-box-avatar-cancel').escaped(),
 											data: [{
 												key: 'event',
 												value: 'close'
@@ -131,10 +129,8 @@ var UserProfilePage = {
 							UserProfilePage.registerAboutMeHandlers(modal);
 
 							// attach handlers to modal events
-							editProfileModal.bind('beforeClose',
-								$.proxy(UserProfilePage.beforeClose, UserProfilePage));
-							editProfileModal.bind('save',
-								$.proxy(UserProfilePage.saveUserData, UserProfilePage));
+							editProfileModal.bind('beforeClose', UserProfilePage.beforeClose.bind(UserProfilePage));
+							editProfileModal.bind('save', UserProfilePage.saveUserData.bind(UserProfilePage));
 
 							// adding handler for tab switching
 							tab.click(function (event) {
@@ -156,29 +152,27 @@ var UserProfilePage = {
 							UserProfilePage.bucky.timer.stop('renderLightboxSuccess');
 						});
 					});
-				});
-			}).fail(function (data) {
+				}).fail(function (data) {
 
-				console.log(data);
+					window.console.log(data);
 
-				var message = '',
-					response = '';
+					var message = '',
+						response = '';
 
-				if (data.responseText) {
-					response = JSON.parse(data.responseText);
-					message = response.exception.message;
-				} else {
-					message = data.error;
-				}
+					if (data.responseText) {
+						response = JSON.parse(data.responseText);
+						message = response.exception.message;
+					} else {
+						message = data.error;
+					}
 
-				require(['wikia.ui.factory'], function (uiFactory) {
 					uiFactory.init(['modal']).then(function (modal) {
 						var modalConfig = {
 							vars: {
 								id: 'UPPModalError',
 								content: message,
 								size: 'small',
-								title: $.msg('userprofilepage-edit-modal-error')
+								title: mw.message('userprofilepage-edit-modal-error').escaped()
 							}
 						};
 
@@ -187,222 +181,207 @@ var UserProfilePage = {
 							UserProfilePage.bucky.timer.stop('renderLightboxFail');
 						});
 					});
+
+					UserProfilePage.isLightboxGenerating = false;
 				});
-
-				UserProfilePage.isLightboxGenerating = false;
-			});
-		}
-	},
-
-	/**
-	 * Checks if anything data was changes before closing modal and if true opens confirmation modal.
-	 * Rejected promise stops execution other event handlers in the queue
-	 *
-	 * @returns {promise|*}
-	 */
-
-	beforeClose: function () {
-		'use strict';
-
-		var deferred = new $.Deferred();
-
-		if (UserProfilePage.wasDataChanged === true) {
-			if ($('#UPPLightboxCloseWrapper').length === 0) {
-				setTimeout(function () {
-					UserProfilePage.displayClosingPopup();
-				}, 50);
 			}
-			deferred.reject();
-		} else {
-			deferred.resolve();
-		}
+		},
 
-		return deferred.promise();
-	},
+		/**
+		 * Checks if anything data was changes before closing modal and if true opens confirmation modal.
+		 * Rejected promise stops execution other event handlers in the queue
+		 *
+		 * @returns {promise|*}
+		 */
 
-	switchTab: function (tab) {
-		'use strict';
+		beforeClose: function () {
+			var deferred = new $.Deferred();
 
-		// Move 'selected' class to the right tab
-		var tabs = tab.closest('ul'),
-			tabName = tab.data('tab');
-
-		tabs.children('li').each(function () {
-			$(this).removeClass('selected');
-		});
-		tab.addClass('selected');
-
-		// Show correct tab content
-		$('.tab-content > li').each(function () {
-			var currentItem = $(this);
-			if (currentItem.attr('class') === tabName) {
-				currentItem.show();
-			} else {
-				currentItem.hide();
-			}
-		});
-	},
-
-	/**
-	 * Register handlers related to the Avatar tab of the user edit modal.
-	 * @param {object} modal UI component modal
-	 */
-	registerAvatarHandlers: function (modal) {
-		'use strict';
-
-		var $avatarUploadInput = modal.find('#UPPLightboxAvatar'),
-			$avatarUploadButton = modal.find('#UPPLightboxAvatarUpload'),
-			$avatarForm = modal.find('#usersAvatar'),
-			$sampleAvatars = modal.find('.sample-avatars');
-
-		// VOLDEV-83: Fix confusing file upload interface
-		$avatarUploadButton.on('click', function () {
-			$avatarUploadInput.click();
-		});
-
-		$avatarUploadInput.change(function () {
-			UserProfilePage.saveAvatarAIM($avatarForm);
-		});
-
-		$sampleAvatars.on('click', 'img', function (event) {
-			UserProfilePage.sampleAvatarChecked($(event.target));
-		});
-	},
-
-	sampleAvatarChecked: function (img) {
-		'use strict';
-
-		var image = $(img),
-			$modal = UserProfilePage.modal.$element,
-			avatarImg = $modal.find('img.avatar');
-
-		$modal.find('img.avatar').hide();
-		$modal.startThrobbing();
-
-		UserProfilePage.newAvatar = {
-			file: image.attr('class'),
-			source: 'sample',
-			userId: UserProfilePage.userId
-		};
-		UserProfilePage.wasDataChanged = true;
-
-		avatarImg.attr('src', image.attr('src'));
-		$modal.stopThrobbing();
-		avatarImg.show();
-	},
-
-	saveAvatarAIM: function (form) {
-		'use strict';
-
-		UserProfilePage.bucky.timer.start('saveAvatarAIMSuccess');
-		UserProfilePage.bucky.timer.start('saveAvatarAIMFail');
-		var $modal = UserProfilePage.modal.$element;
-
-		$.AIM.submit(form, {
-			onStart: function () {
-				$modal.startThrobbing();
-			},
-			onComplete: function (response) {
-				try {
-					response = JSON.parse(response);
-					var avatarImg = $modal.find('img.avatar');
-					if (response.result.success === true) {
-						avatarImg.attr('src', response.result.avatar);
-						UserProfilePage.newAvatar = {
-							file: response.result.avatar,
-							source: 'uploaded',
-							userId: UserProfilePage.userId
-						};
-						UserProfilePage.wasDataChanged = true;
-						UserProfilePage.bannerNotification.hide();
-					} else {
-						if (typeof (response.result.error) !== 'undefined') {
-							UserProfilePage.error(response.result.error);
-						}
-					}
-					$modal.stopThrobbing();
-
-					if (typeof (form[0]) !== 'undefined') {
-						form[0].reset();
-						UserProfilePage.bucky.timer.stop('saveAvatarAIMSuccess');
-					}
-				} catch (e) {
-					$modal.stopThrobbing();
-					form[0].reset();
-					UserProfilePage.bucky.timer.stop('saveAvatarAIMFail');
+			if (UserProfilePage.wasDataChanged === true) {
+				if ($('#UPPLightboxCloseWrapper').length === 0) {
+					setTimeout(function () {
+						UserProfilePage.displayClosingPopup();
+					}, 50);
 				}
+				deferred.reject();
+			} else {
+				deferred.resolve();
 			}
-		});
 
-		//unbind original html element handler to avoid loops
-		form.onsubmit = null;
+			return deferred.promise();
+		},
 
-		$(form).submit();
-	},
+		switchTab: function (tab) {
+			// Move 'selected' class to the right tab
+			var tabs = tab.closest('ul'),
+				tabName = tab.data('tab');
 
-	/**
-	 * Register handlers related to the About Me tab of the user edit modal.
-	 * @param {object} modal UI component modal
-	 */
-	registerAboutMeHandlers: function (modal) {
-		'use strict';
-
-		var $monthSelectBox = modal.find('#userBDayMonth'),
-			$daySelectBox = modal.find('#userBDayDay'),
-			$formFields = modal.find('input[type="text"], select'),
-
-			change = function () {
-				UserProfilePage.wasDataChanged = true;
-			};
-
-		$monthSelectBox.change(function () {
-			UserProfilePage.refillBDayDaySelectbox({
-				month: $monthSelectBox,
-				day: $daySelectBox
+			tabs.children('li').each(function () {
+				$(this).removeClass('selected');
 			});
-		});
+			tab.addClass('selected');
 
-		$('.favorite-wikis').on('click', '.delete', function () {
-			UserProfilePage.hideFavWiki($(this).closest('li').data('wiki-id'));
-		});
+			// Show correct tab content
+			$('.tab-content > li').each(function () {
+				var currentItem = $(this);
+				if (currentItem.attr('class') === tabName) {
+					currentItem.show();
+				} else {
+					currentItem.hide();
+				}
+			});
+		},
 
-		modal.find('.favorite-wikis-refresh').click(function (event) {
-			event.preventDefault();
-			UserProfilePage.refreshFavWikis();
-		});
+		/**
+		 * Register handlers related to the Avatar tab of the user edit modal.
+		 * @param {object} modal UI component modal
+		 */
+		registerAvatarHandlers: function (modal) {
+			var $avatarUploadInput = modal.find('#UPPLightboxAvatar'),
+				$avatarUploadButton = modal.find('#UPPLightboxAvatarUpload'),
+				$avatarForm = modal.find('#usersAvatar'),
+				$sampleAvatars = modal.find('.sample-avatars');
 
-		$formFields.change(change);
-		$formFields.keypress(change);
+			// VOLDEV-83: Fix confusing file upload interface
+			$avatarUploadButton.on('click', function () {
+				$avatarUploadInput.click();
+			});
 
-		UserProfilePage.toggleJoinMoreWikis();
-	},
+			$avatarUploadInput.change(function () {
+				UserProfilePage.saveAvatarAIM($avatarForm);
+			});
 
-	saveUserData: function () {
-		'use strict';
+			$sampleAvatars.on('click', 'img', function (event) {
+				UserProfilePage.sampleAvatarChecked($(event.target));
+			});
+		},
 
-		UserProfilePage.bucky.timer.start('saveUserDataSuccess');
-		UserProfilePage.bucky.timer.start('saveUserDataFail');
+		sampleAvatarChecked: function (img) {
+			var image = $(img),
+				$modal = UserProfilePage.modal.$element,
+				avatarImg = $modal.find('img.avatar');
 
-		var userData = UserProfilePage.getFormData(),
-			saveButton = $('button[data-event=save]');
+			$modal.find('img.avatar').hide();
+			$modal.startThrobbing();
 
-		//prevent from multiple clicks on 'save' button
-		saveButton.prop('disabled', true);
+			UserProfilePage.newAvatar = {
+				file: image.attr('class'),
+				source: 'sample',
+				userId: UserProfilePage.userId
+			};
+			UserProfilePage.wasDataChanged = true;
 
-		if (UserProfilePage.newAvatar) {
-			userData.avatarData = UserProfilePage.newAvatar;
-		}
+			avatarImg.attr('src', image.attr('src'));
+			$modal.stopThrobbing();
+			avatarImg.show();
+		},
 
-		$.ajax({
-			type: 'POST',
-			url: this.ajaxEntryPoint + '&method=saveUserData',
-			dataType: 'json',
-			data: {
-				'userId': UserProfilePage.userId,
-				'data': JSON.stringify(userData),
-				'token': window.mw.user.tokens.get('editToken')
-			},
-			success: function (data) {
+		saveAvatarAIM: function (form) {
+			UserProfilePage.bucky.timer.start('saveAvatarAIMSuccess');
+			UserProfilePage.bucky.timer.start('saveAvatarAIMFail');
+			var $modal = UserProfilePage.modal.$element;
+
+			$.AIM.submit(form, {
+				onStart: function () {
+					$modal.startThrobbing();
+				},
+				onComplete: function (response) {
+					try {
+						response = JSON.parse(response);
+						var avatarImg = $modal.find('img.avatar');
+						if (response.result.success === true) {
+							avatarImg.attr('src', response.result.avatar);
+							UserProfilePage.newAvatar = {
+								file: response.result.avatar,
+								source: 'uploaded',
+								userId: UserProfilePage.userId
+							};
+							UserProfilePage.wasDataChanged = true;
+							UserProfilePage.bannerNotification.hide();
+						} else {
+							if (typeof (response.result.error) !== 'undefined') {
+								UserProfilePage.error(response.result.error);
+							}
+						}
+						$modal.stopThrobbing();
+
+						if (typeof (form[0]) !== 'undefined') {
+							form[0].reset();
+							UserProfilePage.bucky.timer.stop('saveAvatarAIMSuccess');
+						}
+					} catch (e) {
+						$modal.stopThrobbing();
+						form[0].reset();
+						UserProfilePage.bucky.timer.stop('saveAvatarAIMFail');
+					}
+				}
+			});
+
+			//unbind original html element handler to avoid loops
+			form.onsubmit = null;
+
+			$(form).submit();
+		},
+
+		/**
+		 * Register handlers related to the About Me tab of the user edit modal.
+		 * @param {object} modal UI component modal
+		 */
+		registerAboutMeHandlers: function (modal) {
+			var $monthSelectBox = modal.find('#userBDayMonth'),
+				$daySelectBox = modal.find('#userBDayDay'),
+				$formFields = modal.find('input[type="text"], select'),
+
+				change = function () {
+					UserProfilePage.wasDataChanged = true;
+				};
+
+			$monthSelectBox.change(function () {
+				UserProfilePage.refillBDayDaySelectbox({
+					month: $monthSelectBox,
+					day: $daySelectBox
+				});
+			});
+
+			$('.favorite-wikis').on('click', '.delete', function () {
+				UserProfilePage.hideFavWiki($(this).closest('li').data('wiki-id'));
+			});
+
+			modal.find('.favorite-wikis-refresh').click(function (event) {
+				event.preventDefault();
+				UserProfilePage.refreshFavWikis();
+			});
+
+			$formFields.change(change);
+			$formFields.keypress(change);
+
+			UserProfilePage.toggleJoinMoreWikis();
+		},
+
+		saveUserData: function () {
+			UserProfilePage.bucky.timer.start('saveUserDataSuccess');
+			UserProfilePage.bucky.timer.start('saveUserDataFail');
+
+			var userData = UserProfilePage.getFormData(),
+				saveButton = $('button[data-event=save]');
+
+			//prevent from multiple clicks on 'save' button
+			saveButton.prop('disabled', true);
+
+			if (UserProfilePage.newAvatar) {
+				userData.avatarData = UserProfilePage.newAvatar;
+			}
+
+			nirvana.sendRequest({
+				controller: 'UserProfilePage',
+				method: 'saveUserData',
+				type: 'POST',
+				data: {
+					'userId': UserProfilePage.userId,
+					'data': JSON.stringify(userData),
+					'token': window.mw.user.tokens.get('editToken')
+				}
+			}).then(function (data) {
 				if (data.status === 'error') {
 					UserProfilePage.error(data.errMsg);
 					UserProfilePage.bucky.timer.stop('saveUserDataFail');
@@ -414,248 +393,239 @@ var UserProfilePage = {
 					UserProfilePage.bucky.flush();
 					window.location = UserProfilePage.reloadUrl;
 				}
-			},
-			error: UserProfilePage.error,
-			complete: function () {
+			}).fail(
+				UserProfilePage.error
+			).done(function () {
 				saveButton.prop('disabled', false);
-			}
-		});
-	},
-
-	/**
-	 * Hnadle error states after ajax requests
-	 * @param {string} [msg] Optional error message to display. Otherwise, default message will be used.
-	 */
-	error: function (msg) {
-		'use strict';
-
-		if (typeof msg !== 'string') {
-			msg = $.msg('oasis-generic-error');
-		}
-
-		UserProfilePage.bannerNotification.setContent(msg).show();
-	},
-
-	getFormData: function () {
-		'use strict';
-
-		var userData = {
-				name: null,
-				location: null,
-				occupation: null,
-				gender: null,
-				website: null,
-				twitter: null,
-				fbPage: null,
-				year: null,
-				month: null,
-				day: null
-			},
-			i,
-			userDataItem;
-
-		for (i in userData) {
-			userDataItem = $(document.userData[i]).val();
-			if (typeof (userDataItem) !== 'undefined') {
-				userData[i] = userDataItem;
-			}
-		}
-
-		userData.hideEditsWikis = document.userData.hideEditsWikis.checked ? 1 : 0;
-
-		return userData;
-	},
-
-	refillBDayDaySelectbox: function (selectboxes) {
-		'use strict';
-
-		selectboxes.day.html('');
-		var options = '',
-			daysInMonth = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
-			selectedMonth = selectboxes.month.val(),
-			i;
-
-		for (i = 1; i <= daysInMonth[selectedMonth - 1]; i++) {
-			options += '<option value="' + i + '">' + i + '</option>';
-		}
-		options = '<option value="0">--</option>' + options;
-
-		selectboxes.day.html(options);
-	},
-
-	hideFavWiki: function (wikiId) {
-		'use strict';
-
-		var $modal = UserProfilePage.modal.$element;
-
-		if (wikiId >= 0) {
-			$modal.find('.favorite-wikis [data-wiki-id="' + wikiId + '"]')
-				.fadeOut('fast', function () {
-					$(this).remove();
-					$.postJSON(UserProfilePage.ajaxEntryPoint, {
-						method: 'onHideWiki',
-						userId: UserProfilePage.userId,
-						wikiId: wikiId,
-						cb: window.wgStyleVersion
-					}, function (data) {
-						if (data.result.success === true) {
-							// add the next wiki
-							$.each(data.result.wikis, function (index, value) {
-								if ($modal.find('.favorite-wikis [data-wiki-id="' + value.id + '"]').length === 0) {
-									//found the wiki to add. now do it.
-									$modal.find('.join-more-wikis')
-										.before('<li data-wiki-id="' + value.id + '"><span>' + value.wikiName +
-											'</span> <img src="' + window.wgBlankImgUrl +
-											'" class="sprite-small delete"></li>');
-
-								}
-							});
-							UserProfilePage.toggleJoinMoreWikis();
-						}
-					});
-				});
-		} else {
-			// basically it shouldn't happen but i imagine it can happen during development
-			$().log('Unexpected error wikiId <= 0');
-		}
-	},
-
-	refreshFavWikis: function () {
-		'use strict';
-
-		$.postJSON(this.ajaxEntryPoint, {
-			method: 'onRefreshFavWikis',
-			userId: UserProfilePage.userId,
-			cb: window.wgStyleVersion
-		}, function (data) {
-			if (data.result.success === true) {
-				var favWikisList = UserProfilePage.modal.$element.find('.favorite-wikis'),
-					favWikis = '',
-					i;
-
-				// empty the list
-				favWikisList.children().not('.join-more-wikis').remove();
-
-				// add items
-				for (i in data.result.wikis) {
-					favWikis += '<li data-wiki-id="' + data.result.wikis[i].id + '"><span>' +
-						data.result.wikis[i].wikiName + '</span> <img src="' + window.wgBlankImgUrl +
-						'" class="sprite-small delete"></li>';
-				}
-				favWikisList.prepend(favWikis);
-
-				UserProfilePage.toggleJoinMoreWikis();
-			}
-		});
-	},
-
-	toggleJoinMoreWikis: function () {
-		'use strict';
-
-		var $modal = UserProfilePage.modal.$element,
-			minNumOfJoinedWikis = 4,
-			joinMoreWikis = $modal.find('.join-more-wikis');
-		if ($modal.find('.favorite-wikis').children().not('.join-more-wikis').length === minNumOfJoinedWikis) {
-			joinMoreWikis.hide();
-		} else {
-			joinMoreWikis.show();
-		}
-	},
-
-	/**
-	 * Display confirmation modal when trying to close edit profile modal with unsaved changes
-	 */
-
-	displayClosingPopup: function () {
-		'use strict';
-
-		$.getJSON(this.ajaxEntryPoint, {
-			method: 'getClosingModal',
-			userId: UserProfilePage.userId,
-			rand: Math.floor(Math.random() * 100001)
-		}, function (data) {
-			var id = $(data.body).attr('id') + 'Wrapper',
-				modalConfig = {
-					vars: {
-						id: id,
-						content: data.body,
-						size: 'medium',
-						title: $.msg('userprofilepage-closing-popup-header'),
-						buttons: [{
-							vars: {
-								value: $.msg('userprofilepage-closing-popup-save-and-quit'),
-								classes: ['normal', 'primary'],
-								data: [{
-									key: 'event',
-									value: 'save'
-								}]
-							}
-						}, {
-							vars: {
-								value: $.msg('userprofilepage-closing-popup-discard-and-quit'),
-								data: [{
-									key: 'event',
-									value: 'quit'
-								}]
-							}
-						}, {
-							vars: {
-								value: $.msg('userprofilepage-closing-popup-cancel'),
-								data: [{
-									key: 'event',
-									value: 'close'
-								}]
-							}
-						}]
-					}
-				};
-
-			UserProfilePage.modalComponent.createComponent(modalConfig, function (confirmationModal) {
-
-				// attaching handlers to button events
-				confirmationModal.bind('save', function () {
-					confirmationModal.trigger('close');
-					UserProfilePage.saveUserData();
-				});
-				confirmationModal.bind('quit', function () {
-					UserProfilePage.wasDataChanged = false;
-					UserProfilePage.modal.trigger('close');
-					confirmationModal.trigger('close');
-				});
-
-				confirmationModal.show();
-
 			});
-		});
-	},
+		},
 
-	removeAvatar: function (name, question) {
-		'use strict';
+		/**
+		 * Hnadle error states after ajax requests
+		 * @param {string} [msg] Optional error message to display. Otherwise, default message will be used.
+		 */
+		error: function (msg) {
+			if (typeof msg !== 'string') {
+				msg = mw.message('oasis-generic-error');
+			}
 
-		var answer = window.confirm(question);
+			UserProfilePage.bannerNotification.setContent(msg).show();
+		},
 
-		if (answer) {
-			$.nirvana.sendRequest({
-				controller: 'UserProfilePage',
-				method: 'removeavatar',
-				format: 'json',
-				data: {
-					avUser: name,
-					token: mw.user.tokens.get('editToken')
+		getFormData: function () {
+			var userData = {
+					name: null,
+					location: null,
+					occupation: null,
+					gender: null,
+					website: null,
+					twitter: null,
+					fbPage: null,
+					year: null,
+					month: null,
+					day: null
 				},
-				callback: function (data) {
+				i,
+				userDataItem;
+
+			for (i in userData) {
+				userDataItem = $(document.userData[i]).val();
+				if (typeof (userDataItem) !== 'undefined') {
+					userData[i] = userDataItem;
+				}
+			}
+
+			userData.hideEditsWikis = document.userData.hideEditsWikis.checked ? 1 : 0;
+
+			return userData;
+		},
+
+		refillBDayDaySelectbox: function (selectboxes) {
+			selectboxes.day.html('');
+			var options = '',
+				daysInMonth = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
+				selectedMonth = selectboxes.month.val(),
+				i;
+
+			for (i = 1; i <= daysInMonth[selectedMonth - 1]; i++) {
+				options += '<option value="' + i + '">' + i + '</option>';
+			}
+			options = '<option value="0">--</option>' + options;
+
+			selectboxes.day.html(options);
+		},
+
+		hideFavWiki: function (wikiId) {
+			var $modal = UserProfilePage.modal.$element;
+
+			if (wikiId >= 0) {
+				$modal.find('.favorite-wikis [data-wiki-id="' + wikiId + '"]')
+					.fadeOut('fast', function () {
+						$(this).remove();
+						nirvana.sendRequest({
+							controller: 'UserProfilePage',
+							method: 'onHideWiki',
+							type: 'POST',
+							data: {
+								userId: UserProfilePage.userId,
+								wikiId: wikiId,
+								cb: window.wgStyleVersion
+							}
+						}).then(function (data) {
+							if (data.result.success === true) {
+								// add the next wiki
+								data.result.wikis.forEach(function(wiki) {
+									if ($modal.find('.favorite-wikis [data-wiki-id="' + wiki.id + '"]').length === 0) {
+										//found the wiki to add. now do it.
+										$modal.find('.join-more-wikis')
+											.before('<li data-wiki-id="' + wiki.id + '"><span>' + wiki.wikiName +
+												'</span> <img src="' + window.wgBlankImgUrl +
+												'" class="sprite-small delete"></li>');
+
+									}
+								});
+								UserProfilePage.toggleJoinMoreWikis();
+							}
+						});
+					});
+			} else {
+				// basically it shouldn't happen but i imagine it can happen during development
+				$().log('Unexpected error wikiId <= 0');
+			}
+		},
+
+		refreshFavWikis: function () {
+			nirvana.sendRequest({
+				controller: 'UserProfilePage',
+				method: 'onRefreshFavWikis',
+				type: 'POST',
+				data: {
+					userId: UserProfilePage.userId,
+					cb: mw.config.get('wgStyleVersion')
+				}
+			}).then(function (data) {
+				if (data.result.success === true) {
+					var favWikisList = UserProfilePage.modal.$element.find('.favorite-wikis'),
+						favWikis = '';
+
+					// empty the list
+					favWikisList.children().not('.join-more-wikis').remove();
+
+					// add items
+					data.result.wikis.forEach(function(wiki) {
+						favWikis += '<li data-wiki-id="' + wiki.id + '"><span>' +
+							wiki.wikiName + '</span> <img src="' + mw.config.get('wgBlankImgUrl') +
+							'" class="sprite-small delete"></li>';
+					});
+					favWikisList.prepend(favWikis);
+
+					UserProfilePage.toggleJoinMoreWikis();
+				}
+			});
+		},
+
+		toggleJoinMoreWikis: function () {
+			var $modal = UserProfilePage.modal.$element,
+				minNumOfJoinedWikis = 4,
+				joinMoreWikis = $modal.find('.join-more-wikis');
+			if ($modal.find('.favorite-wikis').children().not('.join-more-wikis').length === minNumOfJoinedWikis) {
+				joinMoreWikis.hide();
+			} else {
+				joinMoreWikis.show();
+			}
+		},
+
+		/**
+		 * Display confirmation modal when trying to close edit profile modal with unsaved changes
+		 */
+
+		displayClosingPopup: function () {
+			nirvana.sendRequest({
+				controller: 'UserProfilePage',
+				method: 'getClosingModal',
+				type: 'GET',
+				data: {
+					userId: UserProfilePage.userId,
+					rand: Math.floor(Math.random() * 100001)
+				}
+			}).then(function (data) {
+				var id = $(data.body).attr('id') + 'Wrapper',
+					modalConfig = {
+						vars: {
+							id: id,
+							content: data.body,
+							size: 'medium',
+							title: mw.message('userprofilepage-closing-popup-header').escaped(),
+							buttons: [{
+								vars: {
+									value: mw.message('userprofilepage-closing-popup-save-and-quit').escaped(),
+									classes: ['normal', 'primary'],
+									data: [{
+										key: 'event',
+										value: 'save'
+									}]
+								}
+							}, {
+								vars: {
+									value: mw.message('userprofilepage-closing-popup-discard-and-quit').escaped(),
+									data: [{
+										key: 'event',
+										value: 'quit'
+									}]
+								}
+							}, {
+								vars: {
+									value: mw.message('userprofilepage-closing-popup-cancel').escaped(),
+									data: [{
+										key: 'event',
+										value: 'close'
+									}]
+								}
+							}]
+						}
+					};
+
+				UserProfilePage.modalComponent.createComponent(modalConfig, function (confirmationModal) {
+
+					// attaching handlers to button events
+					confirmationModal.bind('save', function () {
+						confirmationModal.trigger('close');
+						UserProfilePage.saveUserData();
+					});
+					confirmationModal.bind('quit', function () {
+						UserProfilePage.wasDataChanged = false;
+						UserProfilePage.modal.trigger('close');
+						confirmationModal.trigger('close');
+					});
+
+					confirmationModal.show();
+
+				});
+			});
+		},
+
+		removeAvatar: function (name, question) {
+			var answer = window.confirm(question);
+
+			if (answer) {
+				nirvana.sendRequest({
+					controller: 'UserProfilePage',
+					method: 'removeavatar',
+					type: 'POST',
+					data: {
+						avUser: name,
+						token: mw.user.tokens.get('editToken')
+					}
+				}).then(function (data) {
 					if (data.status === 'ok') {
 						window.location.reload();
 					} else {
 						UserProfilePage.error(data.error);
 					}
-				}
-			});
+				});
+			}
 		}
-	}
-};
+	};
 
-$(function () {
-	'use strict';
-	UserProfilePage.init();
+	$(UserProfilePage.init);
 });

--- a/extensions/wikia/UserProfilePageV3/js/UserProfilePage.js
+++ b/extensions/wikia/UserProfilePageV3/js/UserProfilePage.js
@@ -651,7 +651,7 @@ require(
 				}).done(function () {
 					window.location.reload();
 				}).fail(function (res) {
-					new BannerNotification(res.error, 'error').show();
+					new BannerNotification(JSON.parse(res.responseText).error, 'error').show();
 				});
 			}
 		}

--- a/extensions/wikia/UserProfilePageV3/js/UserProfilePage.js
+++ b/extensions/wikia/UserProfilePageV3/js/UserProfilePage.js
@@ -164,8 +164,7 @@ require(
 
 					window.console.log(data);
 
-					var message = '',
-						response = '';
+					var message, response;
 
 					if (data.responseText) {
 						response = JSON.parse(data.responseText);
@@ -433,15 +432,14 @@ require(
 					month: null,
 					day: null
 				},
-				i,
 				userDataItem;
 
-			for (i in userData) {
-				userDataItem = $(document.userData[i]).val();
+			Object.getOwnPropertyNames(userData).forEach(function (userDataItemKey) {
+				userDataItem = $(document.userData[userDataItemKey]).val();
 				if (typeof (userDataItem) !== 'undefined') {
-					userData[i] = userDataItem;
+					userData[userDataItemKey] = userDataItem;
 				}
-			}
+			});
 
 			userData.hideEditsWikis = document.userData.hideEditsWikis.checked ? 1 : 0;
 
@@ -640,7 +638,7 @@ require(
 		 * @param {string} confirmationMessage Confirmation message to display
 		 */
 		clearMastheadContents: function (targetUser, confirmationMessage) {
-			var confirmClear = window.confirm(confirmationMessage)
+			var confirmClear = window.confirm(confirmationMessage);
 			if (confirmClear) {
 				nirvana.sendRequest({
 					controller: 'UserProfilePage',
@@ -650,7 +648,7 @@ require(
 						target: targetUser,
 						token: mw.user.tokens.get('editToken')
 					}
-				}).done(function (res) {
+				}).done(function () {
 					window.location.reload();
 				}).fail(function (res) {
 					new BannerNotification(res.error, 'error').show();

--- a/extensions/wikia/UserProfilePageV3/templates/UserProfilePage_renderUserIdentityBox.php
+++ b/extensions/wikia/UserProfilePageV3/templates/UserProfilePage_renderUserIdentityBox.php
@@ -35,10 +35,25 @@
 		</hgroup>
 
 		<? if ( $canEditProfile ): ?>
-			<span id="userIdentityBoxEdit">
-				<img src="<?= $wgBlankImgUrl ?>" class="sprite edit-pencil">
-				<a href="#"><?= wfMessage( 'user-identity-box-edit' )->escaped(); ?></a>
-			</span>
+			<ul class="user-identity-box-edit">
+				<li>
+					<?= DesignSystemHelper::getSvg( 'wds-icons-pencil', 'wds-icon-tiny' ); ?>
+					<a id="userIdentityBoxEdit" href="#"><?= wfMessage( 'user-identity-box-edit' )->escaped(); ?></a>
+				</li>
+				<? if ( $canClearProfile && !$user[ 'showZeroStates' ] ): ?>
+					<li>
+						<?= DesignSystemHelper::getSvg( 'wds-icons-trash', 'wds-icon-tiny' ); ?>
+						<a
+							id="userIdentityBoxClear"
+							href="#"
+							data-name="<?= Sanitizer::encodeAttribute( $user['name'] ); ?>"
+							data-confirm="<?= wfMessage( 'user-identity-box-clear-confirmation' )->escaped(); ?>"
+						>
+							<?= wfMessage( 'user-identity-box-clear' )->escaped(); ?>
+						</a>
+					</li>
+				<? endif; ?>
+			</ul>
 			<input type="hidden" id="user" value="<?= $user['id']; ?>"/>
 		<? endif; ?>
 		<div class="masthead-info-lower">

--- a/extensions/wikia/UserProfilePageV3/tests/UserIdentityBoxTest.php
+++ b/extensions/wikia/UserProfilePageV3/tests/UserIdentityBoxTest.php
@@ -31,6 +31,29 @@ class UserIdentityBoxTest extends WikiaBaseTest {
 		$this->assertEquals($expectedResult, $userIdentityBox->checkIfDisplayZeroStates($data));
 	}
 
+	public function testClearMastheadContents() {
+		/** @var PHPUnit_Framework_MockObject_MockObject|User $userMock */
+		$userMock = $this->getMockBuilder( User::class )
+			->setMethods( [ 'saveSettings' ] )
+			->getMock();
+
+		$userMock->expects( $this->once() )
+			->method( 'saveSettings' )
+			->with();
+
+		$userIdentityBox = new UserIdentityBox( $userMock );
+		$userIdentityBox->clearMastheadContents();
+
+		foreach ( $userIdentityBox->optionsArray as $option ) {
+			if ( $option === 'gender' || $option === 'birthday' ) {
+				$option = UserIdentityBox::USER_PROPERTIES_PREFIX . $option;
+			}
+			$this->assertEquals( null, $userMock->getGlobalAttribute( $option ), 'clearMastheadContents should reset all user profile attributes' );
+		}
+
+		$this->assertEquals( null, $userMock->getRealName(), 'clearMastheadContents should reset user\'s real name' );
+	}
+
 	/**
 	 * @brief data provider for UserIdentityBoxTest::testCheckIfDisplayZeroStates()
 	 *

--- a/lib/Wikia/src/Service/User/Permissions/PermissionsConfigurationImpl.php
+++ b/lib/Wikia/src/Service/User/Permissions/PermissionsConfigurationImpl.php
@@ -255,6 +255,7 @@ class PermissionsConfigurationImpl implements PermissionsConfiguration {
 		'hideblockername',
 		'fancontributor-staff',
 		'fancontributor-contributor',
+		'clearuserprofile',
 	];
 
 	public function __construct() {


### PR DESCRIPTION
This change contains functionality for VSTF and Staff members so that they can clear the contents of the user profile page masthead with a single click.

Config PR: https://github.com/Wikia/config/pull/1978

Ticket & QA notes: https://wikia-inc.atlassian.net/browse/SUS-1175
