### PR TITLE
PLATFORM-2531 log User::crypt calls on production

### DIFF
--- a/includes/User.php
+++ b/includes/User.php
@@ -4191,7 +4191,18 @@ class User {
 	 */
 	public static function crypt( $password, $salt = false ) {
 		global $wgPasswordSalt;
-
+		// Wikia change - begin
+		// @see PLATFORM-2502 comparing new passwords in PHP code.
+		// @todo mech remove after the new password hashing is implemented (PLATFORM-2530).
+		Wikia\Logger\WikiaLogger::instance()->debug(
+			'NEW_HASHING crypt called in PHP',
+			[
+				'wgPasswordSalt' => $wgPasswordSalt,
+				'caller' => wfGetCaller(),
+				'exception' => new Exception()
+			]
+		);
+ 		// Wikia change - end
 		$hash = '';
 		if( !wfRunHooks( 'UserCryptPassword', array( &$password, &$salt, &$wgPasswordSalt, &$hash ) ) ) {
 			return $hash;


### PR DESCRIPTION
Similarly to https://github.com/Wikia/app/pull/11647, I want to track down all the places where passwords are still generated in PHP. Later on, based on the logs, I'll change those places to use Helios.
