### PR TITLE
EditPage: report hook name on hookaborted

### DIFF
--- a/includes/EditPage.php
+++ b/includes/EditPage.php
@@ -1108,6 +1108,7 @@ class EditPage {
 
 		if ( !wfRunHooks( 'EditPage::attemptSave', array( $this ) ) ) {
 			wfDebug( "Hook 'EditPage::attemptSave' aborted article saving\n" );
+			$result['hookaborted'] = 'EditPage::attemptSave'; // Wikia change - SUS-1188
 			$status->fatal( 'hookaborted' );
 			$status->value = self::AS_HOOK_ERROR;
 			wfProfileOut( __METHOD__ . '-checks' );
@@ -1154,6 +1155,7 @@ class EditPage {
 		}
 		if ( !wfRunHooks( 'EditFilter', array( $this, $this->textbox1, $this->section, &$this->hookError, $this->summary ) ) ) {
 			# Error messages etc. could be handled within the hook...
+			$result['hookaborted'] = 'EditFilter'; // Wikia change - SUS-1188
 			$status->fatal( 'hookaborted' );
 			$status->value = self::AS_HOOK_ERROR;
 			wfProfileOut( __METHOD__ . '-checks' );
@@ -1161,6 +1163,7 @@ class EditPage {
 			return $status;
 		} elseif ( $this->hookError != '' ) {
 			# ...or the hook could be expecting us to produce an error
+			$result['hookaborted'] = 'EditFilter'; // Wikia change - SUS-1188
 			$status->fatal( 'hookaborted' );
 			$status->value = self::AS_HOOK_ERROR_EXPECTED;
 			wfProfileOut( __METHOD__ . '-checks' );
@@ -1254,12 +1257,14 @@ class EditPage {
 			// Run post-section-merge edit filter
 			if ( !wfRunHooks( 'EditFilterMerged', array( $this, $this->textbox1, &$this->hookError, $this->summary ) ) ) {
 				# Error messages etc. could be handled within the hook...
+				$result['hookaborted'] = 'EditFilterMerged'; // Wikia change - SUS-1188
 				$status->fatal( 'hookaborted' );
 				$status->value = self::AS_HOOK_ERROR;
 				wfProfileOut( __METHOD__ );
 				return $status;
 			} elseif ( $this->hookError != '' ) {
 				# ...or the hook could be expecting us to produce an error
+				$result['hookaborted'] = 'EditFilterMerged'; // Wikia change - SUS-1188
 				$status->fatal( 'hookaborted' );
 				$status->value = self::AS_HOOK_ERROR_EXPECTED;
 				wfProfileOut( __METHOD__ );
@@ -1377,12 +1382,14 @@ class EditPage {
 			// Run post-section-merge edit filter
 			if ( !wfRunHooks( 'EditFilterMerged', array( $this, $text, &$this->hookError, $this->summary ) ) ) {
 				# Error messages etc. could be handled within the hook...
+				$result['hookaborted'] = 'EditFilterMerged'; // Wikia change - SUS-1188
 				$status->fatal( 'hookaborted' );
 				$status->value = self::AS_HOOK_ERROR;
 				wfProfileOut( __METHOD__ );
 				return $status;
 			} elseif ( $this->hookError != '' ) {
 				# ...or the hook could be expecting us to produce an error
+				$result['hookaborted'] = 'EditFilterMerged'; // Wikia change - SUS-1188
 				$status->fatal( 'hookaborted' );
 				$status->value = self::AS_HOOK_ERROR_EXPECTED;
 				wfProfileOut( __METHOD__ );


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-1188

Add hook name to `$result` array when any of three hooks triggered in `EditPage::internalAttemptSave` prevents an edit. It will be logged by #11668.

@TK-999 / @Grunny 
