### PR TITLE
SUS-1188 - Phalanx: log when EditFilter block is applied

### DIFF
--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -827,7 +827,7 @@ class ArticleComment {
 
 		// SUS-1188
 		if ( !$status->isOK() ) {
-			WikiaLogger::instance()->error( __METHOD__ . ' - failed', [
+			WikiaLogger::instance()->error( __METHOD__ . ' - failed SUS-1188', [
 				'hook_error' => (string) $editPage->hookError,
 				'edit_status' => $status,
 				'edit_result' => (array) $result,

--- a/extensions/wikia/PhalanxII/hooks/PhalanxContentBlock.class.php
+++ b/extensions/wikia/PhalanxII/hooks/PhalanxContentBlock.class.php
@@ -20,13 +20,15 @@ class PhalanxContentBlock extends WikiaObject {
 	 * @param $summary
 	 * @return bool
 	 */
-	static public function editFilter( $editPage, $text, $section, &$hookError, $summary ) {
+	static public function editFilter( EditPage $editPage, $text, $section, &$hookError, $summary ) {
 		wfProfileIn( __METHOD__ );
 		list( $contentIsBlocked, $errorMessage ) = self::checkContentFromEditPage( $editPage );
 
 		if ( $contentIsBlocked ) {
 			// we found block
 			$editPage->spamPageWithContent( $errorMessage );
+
+			Wikia\Logger\WikiaLogger::instance()->warning( __METHOD__ . ' - block applied SUS-1188', [ 'title' => $editPage->getTitle()->getPrefixedDBkey(), 'error_message' => $errorMessage ] );
 		}
 
 		wfProfileOut( __METHOD__ );

--- a/extensions/wikia/PhalanxII/hooks/PhalanxTitleBlock.class.php
+++ b/extensions/wikia/PhalanxII/hooks/PhalanxTitleBlock.class.php
@@ -19,7 +19,7 @@ class PhalanxTitleBlock extends WikiaObject {
 	 * @param EditPage $editPage -- edit page instance
 	 * @static
 	 */
-	static public function editFilter( $editPage, $text, $section, &$hookError, $summary ) {
+	static public function editFilter( EditPage $editPage, $text, $section, &$hookError, $summary ) {
 		wfProfileIn( __METHOD__ );
 
 		$title = $editPage->getTitle();
@@ -36,6 +36,10 @@ class PhalanxTitleBlock extends WikiaObject {
 		 * pass to check title method
 		 */
 		$ret = PhalanxTitleBlock::checkTitle( $title );
+
+		if ( $ret === false ) {
+			Wikia\Logger\WikiaLogger::instance()->warning( __METHOD__ . ' - block applied SUS-1188', [ 'title' => $title->getPrefixedDBkey() ] );
+		}
 
 		wfProfileOut( __METHOD__ );
 		return $ret;


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-1188

`EditFilter` hook prevent certain Message Wall edits, let's add more logging in Phalanx methods that are bound to this hook.

@TK-999 / @Grunny 
