### PR TITLE
Fixed the issue with Tabview link in Special:Version

### DIFF
--- a/extensions/wikia/TabView/TabView.php
+++ b/extensions/wikia/TabView/TabView.php
@@ -18,7 +18,7 @@ $wgExtensionCredits['parserhook'][] = array(
 	'name' => 'TabView',
 	'author' => array('Inez Korczynski', 'Maciej Brencz'),
 	'description' => 'Gives an easy way of combining pages into one page with a tab for each sub-page.',
-	'url' => 'http://help.wikia.com/wiki/Tabview',
+	'url' => 'http://community.wikia.com/wiki/Help:Tab_view',
 );
 
 $wgHooks['ParserFirstCallInit'][] = 'wfSetupTabView';


### PR DESCRIPTION
Fixed the issue where Tabview link in Special:Version was pointing to a [non-existent page](http://c.wikia.com/wiki/Tabview). This bug has been [reported](http://c.wikia.com/wiki/Talk:Tabview) back in 2013 but seems like no ticket has been created then. Creating a pull request suggested by @Kirkburn in a [support ticket](https://support.wikia-inc.com/hc/en-us/requests/302591) (note: the support ticket has a bit more things than just the bug report)
