### PR TITLE
SUS-1195: make sure the file cache is up to date shortly after the video upload

### DIFF
--- a/extensions/wikia/SpecialVideos/SpecialVideosHelper.class.php
+++ b/extensions/wikia/SpecialVideos/SpecialVideosHelper.class.php
@@ -130,7 +130,7 @@ class SpecialVideosHelper extends WikiaModel {
 		wfProfileIn( __METHOD__ );
 
 		$mediaService = new MediaQueryService();
-		if ( $videoParams['sort'] == 'premium' ) {
+		if ( !empty( $videoParams['sort'] ) && $videoParams['sort'] == 'premium' ) {
 			$totalVideos = $mediaService->getTotalPremiumVideos();
 		} else if ( !empty( $videoParams['category'] ) ) {
 			$totalVideos = $mediaService->getTotalVideosByCategory( $videoParams['category'] );

--- a/extensions/wikia/VideoHandlers/VideoFileUploader.class.php
+++ b/extensions/wikia/VideoHandlers/VideoFileUploader.class.php
@@ -182,6 +182,11 @@ class VideoFileUploader {
 
 		wfRunHooks('AfterVideoFileUploaderUpload', array($file, $result));
 
+		// SUS-1195: make sure the file cache is up to date shortly after the video upload
+		if ( $result->isOK() ) {
+			$file->saveToCache();
+		}
+
 		return $result;
 	}
 

--- a/extensions/wikia/VideoHandlers/VideoFileUploader.class.php
+++ b/extensions/wikia/VideoHandlers/VideoFileUploader.class.php
@@ -66,8 +66,10 @@ class VideoFileUploader {
 			'wpUploadFileURL' => $urlFrom
 		);
 
+		$request = new FauxRequest( $data, true );
+
 		$upload = (new UploadFromUrl); /* @var $upload UploadFromUrl */
-		$upload->initializeFromRequest( new FauxRequest( $data, true ) );
+		$upload->initializeFromRequest( $request );
 		wfProfileOut( __METHOD__ );
 		return $upload;
 	}


### PR DESCRIPTION
See https://wikia-inc.atlassian.net/browse/SUS-1195
## Problem

Video upload via UI pop-up ends up with an error logged to ELK:

``` json
{
    "url": "https://www.youtube.com/watch?v=tOzJHO3q_9w",
    "title": "[object] (Title: File:Https://www.youtube.com/watch?v=tOzJHO3q 9w)",
    "videoTitle": "[object] (Title: File:Dash 8 Air Iceland take off in Greenland !!)",
    "videoPageId": 435145,
    "videoProvider": null,
    "wgIsGhostVideo": null
},
```

The video is correctly uploaded, but the process cache claims that it does not exist:

```
> var_dump( wfFindFile( Title::newFromId(435145) ) )
Query mediawiki119cleanup4 (DB user: wikia_maint) (72) (slave): SELECT /* Title::newFromID CommandLineInc - 1cc0d57f-f91f-495e-a207-3c5624159e3c */  *  FROM `page`  WHERE page_id = '435145'  LIMIT 1  
bool(false)
```
## Solution

Make sure the file cache of newly uploaded video is always up to date by explicitly setting the memcache entry shortly after the successful upload,

And fix two PHP notices that make devbox users pretty annoyed :smile: 

@TK-999 / @mixth-sense / @bulaszenko 
