### PR TITLE
VideoService: by-pass the RepoGroup process cache (SUS-1195)

### DIFF
--- a/includes/wikia/services/VideoService.class.php
+++ b/includes/wikia/services/VideoService.class.php
@@ -56,7 +56,9 @@ class VideoService extends WikiaModel {
 					return wfMessage( 'videohandler-non-premium' )->parse();
 				}
 				list($videoTitle, $videoPageId, $videoProvider) = $this->addVideoVideoHandlers( $url );
-				$file = RepoGroup::singleton()->findFile( $videoTitle );
+
+				// SUS-1195: by-pass the RepoGroup process cache
+				$file = WikiaFileHelper::getFileFromTitle( $videoTitle, true /* by-pass the cache */ );
 			}
 
 			if ( !( $file instanceof File ) ) {


### PR DESCRIPTION
One more fix for #11692 - clear process cache inside `RepoGroup` class

@mixth-sense / @TK-999 
