### PR TITLE
SUS-1196: Purge "Forum Activity" rail module if thread is deleted via Nuke / Quick Tools

### DIFF
--- a/extensions/wikia/Forum/Forum.setup.php
+++ b/extensions/wikia/Forum/Forum.setup.php
@@ -85,6 +85,9 @@ $wgHooks['LinkBegin'][] = 'ForumHooksHelper::onLinkBegin';
 $wgHooks['TitleGetSquidURLs'][] = 'ForumHooksHelper::onTitleGetSquidURLs';
 $wgHooks['ArticleCommentGetSquidURLs'][] = 'ForumHooksHelper::onArticleCommentGetSquidURLs';
 
+// SUS-1196: Invalidate "Forum Activity" rail module when deleting a thread via Nuke / Quick Tools
+$wgHooks['ArticleDeleteComplete'][] = 'ForumHooksHelper::onArticleDeleteComplete';
+
 include ( $dir . '/Forum.namespace.setup.php' );
 
 // add this namespace to list of wall namespaces

--- a/extensions/wikia/Forum/ForumHooksHelper.class.php
+++ b/extensions/wikia/Forum/ForumHooksHelper.class.php
@@ -513,4 +513,23 @@ class ForumHooksHelper {
 		return true;
 	}
 
+	/**
+	 * SUS-1196: Invalidate "Forum Activity" rail module cache if thread is deleted via Nuke / Quick Tools
+	 * @param Article|WikiPage|Page $page
+	 * @param User $user
+	 * @param string $reason
+	 * @param int $id
+	 * @return bool always true to continue hook processing
+	 */
+	static public function onArticleDeleteComplete( Page $page, User $user, string $reason, int $id ): bool {
+		global $wgCityId;
+
+		if ( $page->getTitle()->inNamespace( NS_WIKIA_FORUM_BOARD_THREAD ) ) {
+			$wallHistory = new WallHistory( $wgCityId );
+			WikiaDataAccess::cachePurge( $wallHistory->getLastPostsMemcKey() );
+		}
+
+		return true;
+	}
+
 }

--- a/extensions/wikia/Forum/ForumHooksHelper.class.php
+++ b/extensions/wikia/Forum/ForumHooksHelper.class.php
@@ -522,10 +522,8 @@ class ForumHooksHelper {
 	 * @return bool always true to continue hook processing
 	 */
 	static public function onArticleDeleteComplete( Page $page, User $user, string $reason, int $id ): bool {
-		global $wgCityId;
-
 		if ( $page->getTitle()->inNamespace( NS_WIKIA_FORUM_BOARD_THREAD ) ) {
-			$wallHistory = new WallHistory( $wgCityId );
+			$wallHistory = new WallHistory();
 			WikiaDataAccess::cachePurge( $wallHistory->getLastPostsMemcKey() );
 		}
 


### PR DESCRIPTION
Introduced new `ArticleDeleteComplete` hook handler to purge wall history memcache when a thread is deleted via Nuke or Quick Tools.

ticket & QA notes: https://wikia-inc.atlassian.net/browse/SUS-1196

@mixth-sense / @macbre 
