### PR TITLE
XW-2256 | add missing href to create new page link

### DIFF
--- a/skins/oasis/modules/templates/PageHeader_Index.php
+++ b/skins/oasis/modules/templates/PageHeader_Index.php
@@ -32,7 +32,7 @@ if ( $runNjord ) {
 					<div class="tally"><?= $tallyMsg ?></div>
 				<? endif; ?>
 				<? // TODO remove after XW-2226 is done ?>
-				<a class="wikia-button createpage add-new-page-experiment-element">Add New Page</a>
+				<a href="/wiki/Special:CreatePage?flow=create-page-contribute-button" class="wikia-button createpage add-new-page-experiment-element">Add New Page</a>
 				<? // TODO remove end ?>
 			</div>
 		</div>
@@ -76,7 +76,7 @@ if ( $runNjord ) {
 		?>
 
 		<? // TODO remove after XW-2226 is done ?>
-		<a class="wikia-button createpage add-new-page-experiment-element"><img class="sprite new" src="<?=wfBlankImgUrl()?>"> Add New Page</a>
+		<a href="/wiki/Special:CreatePage?flow=create-page-contribute-button" class="wikia-button createpage add-new-page-experiment-element"><img class="sprite new" src="<?=wfBlankImgUrl()?>"> Add New Page</a>
 		<? // TODO remove end ?>
 		<?
 

--- a/skins/oasis/modules/templates/WikiHeader_Index.php
+++ b/skins/oasis/modules/templates/WikiHeader_Index.php
@@ -9,7 +9,7 @@
 	<? if ( $displayHeaderButtons ) : ?>
 		<div class="buttons">
 			<? // TODO remove after XW-2226 is done ?>
-			<a class="wikia-button createpage add-new-page-experiment-element">Add New Page</a>
+			<a href="/wiki/Special:CreatePage?flow=create-page-contribute-button" class="wikia-button createpage add-new-page-experiment-element">Add New Page</a>
 			<? // TODO remove end ?>
 			<?= $app->renderView( 'ContributeMenu', 'Index' ) ?>
 		</div>


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/XW-2256

Href attribute is needed when `$wgWikiaEnableNewCreatepageExt` is disabled (create new page modal is disabled). In other words `create new page link` have to open `create new page modal` or have to redirect user to special page if modal is disabled by wgVariable and in that case link requires href attribute to work.

@Wikia/x-wing 
