### PR TITLE
SOC-3151 Bust ETags after removing a user's avatar

### DIFF
--- a/extensions/wikia/UserProfilePageV3/UserProfilePageController.class.php
+++ b/extensions/wikia/UserProfilePageV3/UserProfilePageController.class.php
@@ -1009,6 +1009,7 @@ class UserProfilePageController extends WikiaController {
 				$avatar = Masthead::newFromUser( $avUser );
 				if ( $avatar->removeFile( true ) ) {
 					$this->clearAttributeCache( $avUser->getId() );
+					$this->bustETagForCurrentUser();
 					$this->setVal( 'status', 'ok' );
 					wfProfileOut( __METHOD__ );
 					return true;
@@ -1020,6 +1021,15 @@ class UserProfilePageController extends WikiaController {
 
 		wfProfileOut( __METHOD__ );
 		return true;
+	}
+
+	/**
+	 * Call invalidateCache on the current user which updates the user's user_touched value.
+	 * That value is used when constructing ETag so we end up cache busting any pages this user
+	 * has saved locally.
+	 */
+	private function bustETagForCurrentUser() {
+		$this->app->wg->User->invalidateCache();
 	}
 
 	/**

--- a/extensions/wikia/UserProfilePageV3/UserProfilePageController.class.php
+++ b/extensions/wikia/UserProfilePageV3/UserProfilePageController.class.php
@@ -1026,7 +1026,6 @@ class UserProfilePageController extends WikiaController {
 		$this->clearAttributeCache( $user->getId() );
 		$this->bustETagsForUserPage( $user );
 		$this->bustETagsForAllPagesIfNecessary( $user );
-
 	}
 
 	/**
@@ -1038,10 +1037,11 @@ class UserProfilePageController extends WikiaController {
 	}
 
 	/**
-	 * Call invalidateCache for the current user if it's the current user whose avatar we've removed.
-	 * This is because the global header (which contains the avatar) is cached along with the page, so
-	 * any article pages which the user has in browser cache contain the stale avatar value. invalidateCache
-	 * updates the user's last_touched value which is used when validating ETags.
+	 * Call invalidateCache for the current user if the user is removing their own avatar. This is necessary
+	 * because the global header (which contains the avatar) is cached along with the page, so any article page
+	 * the user has in browser cache will contain their stale avatar value. invalidateCache updates the
+	 * user's last_touched value which is used when validating ETags, effectively busting all pages the user
+	 * has in their browser cache.
 	 */
 	private function bustETagsForAllPagesIfNecessary( User $user ) {
 		if ( $this->wg->User->getId() == $user->getId() ) {

--- a/extensions/wikia/UserProfilePageV3/UserProfilePageController.class.php
+++ b/extensions/wikia/UserProfilePageV3/UserProfilePageController.class.php
@@ -1078,6 +1078,7 @@ class UserProfilePageController extends WikiaController {
 		if ( $targetUser && $targetUser->getId() !== 0 ) {
 			$userIdentityBox = new UserIdentityBox( $targetUser );
 			$userIdentityBox->clearMastheadContents();
+			$this->clearCaches( $targetUser );
 
 			$this->response->setVal( 'success', wfMessage( 'user-identity-box-clear-success' )->escaped() );
 			BannerNotificationsController::addConfirmation( wfMessage( 'user-identity-box-clear-success' )->escaped() );


### PR DESCRIPTION
Ticket: https://wikia-inc.atlassian.net/browse/SOC-3151

This PR solves a bug where when a staff user removed an avatar (either their own or someone else's), the page would reload, but the old avatar value would still be showing.

The problem had to do with browser cache. Logged in user's don't get any pages from Varnish (our intermediate HTTP cache), however they _are_ allowed to use browser cache. Each of our responses comes with an `ETag` the client can use on subsequent requests. If the `ETag` matches, our servers return a 304 and the browser can just use the value it has in cache. That's what was happening here. After removing the avatar, the js was reloading the page, which was getting a 304 from the server, so the browser was using the stale version from cache.

This PR makes sure that all `ETag`s are invalidated for the profile page after removing the avatar. Additionally, if the user is deleting their own avatar, this PR also invalidates all of that user's `ETag`s since the avatar is also stored in the global nav which is present on all pages. So if the user deletes their own avatar, then browsed to an article page they had in cache, they would see the stale avatar value if we don't invalidate all their `ETag`s.
