### PR TITLE
Increase the cache ttl for the cake recirculation module

### DIFF
--- a/extensions/wikia/Recirculation/RecirculationApiController.class.php
+++ b/extensions/wikia/Recirculation/RecirculationApiController.class.php
@@ -59,7 +59,7 @@ class RecirculationApiController extends WikiaApiController {
 		$ignore = trim( $this->request->getVal( 'ignore' ) );
 		$namespaceId = trim( $this->request->getVal( 'namespaceId' ) );
 
-		$this->response->setCacheValidity( WikiaResponse::CACHE_VERY_SHORT );
+		$this->response->setCacheValidity( WikiaResponse::CACHE_SHORT );
 		$this->response->setData( [
 				'title' => wfMessage( 'recirculation-fandom-subtitle' )->plain(),
 				'items' => ( new CakeRelatedContentService() )->getContentRelatedTo(


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CAKE-170

Increased the `maxage` from 5 minutes to 3 hours. Five minutes seems too short while a day seems too long. We don't have a mechanism for invalidating the cache and it's possible that content could be updated within that time frame. Having the module be stale for a few hours is not likely to affect the performance significantly IMO.

@Wikia/cake 
