### PR TITLE
[SUS-795] Added log type for user rename globally

### DIFF
--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1901,6 +1901,11 @@ $wgEnableFliteTagExt = false;
 $wgARecoveryEngineCustomLog = null;
 
 /**
+ * Allow filter logs by renamed user globally
+ */
+$wgLogTypes[] = 'renameuser';
+
+/**
  * Protect Piggyback logs even if the extension is disabled
  */
 $wgLogRestrictions['piggyback'] = 'piggyback';


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-795

**Summary:**
To allow filtering logs by the user renamed action, we need to add this type global as currently it's only being added when `UserRenameTool` extension is enabled so only on http://community.wikia.com

**Details:**
Functionality for filtering logs is based on `$wgLogTypes` global array, and we have some dafault values for https://github.com/Wikia/app/blob/b03df0a89ed672697e9c130d529bf1eb25f49cda/includes/DefaultSettings.php#L4807 this array, but in general every extension can introduce it's own type that is added with the extension only if it's enabled on given wiki.

Since UserRenameTool is enabled only http://community.wikia.com, that's the only wiki that supports 'renameuser' filter type : https://github.com/Wikia/app/blob/b03df0a89ed672697e9c130d529bf1eb25f49cda/extensions/wikia/UserRenameTool/SpecialRenameuser.php#L58
Considering that we if we want to keep that that extension only enabled on that single wiki we need to move the type to some common global config. : 3f586de

I'm still not sure where to move the translations for that type/field since it's displayed as translated string in select dialogs, let me know what would be a good place for that.

/cc @mixth-sense @macbre 
