### PR TITLE
SUS-1203: logging in ConsulUrlProvider, sending requests to different phalanx instances while retry

### DIFF
--- a/extensions/wikia/PhalanxII/services/PhalanxService.class.php
+++ b/extensions/wikia/PhalanxII/services/PhalanxService.class.php
@@ -154,11 +154,9 @@ class PhalanxService extends Service {
 	 * @return integer|mixed data of blocks applied or numeric value (0 - block applied, 1 - no block applied)
 	 */
 	private function sendToPhalanxDaemon( $action, $parameters ) {
-		$urlProvider = Injector::getInjector()->get(ConsulUrlProvider::class);
-		$baseurl = $urlProvider->getUrl( 'phalanx' );
 		$options = F::app()->wg->PhalanxServiceOptions;
 
-		$url = sprintf( "http://%s/%s", $baseurl, $action != "status" ? $action : "" );
+		$url = $this->getPhalanxUrl($action);
 		$requestTime = 0;
 		$loggerPostParams = [];
 		$tries = 1;
@@ -229,6 +227,7 @@ class PhalanxService extends Service {
 			// BAC-1332 - some of the phalanx service calls are breaking and we're not sure why
 			// it's better to do the retry than maintain the PHP fallback for that
 			while ( $tries <= self::PHALANX_SERVICE_TRIES_LIMIT ) {
+				$url = $this->getPhalanxUrl($action);
 				$response = Http::post( $url, $options );
 				if ( false !== $response) {
 					break;
@@ -309,4 +308,10 @@ class PhalanxService extends Service {
 		}
 		return $res;
 	}
+
+	private function getPhalanxUrl($action) {
+		$baseurl = Injector::getInjector()->get(ConsulUrlProvider::class)->getUrl('phalanx');
+		return sprintf( "http://%s/%s", $baseurl, $action != "status" ? $action : "" );
+	}
+
 };

--- a/extensions/wikia/PhalanxII/services/PhalanxService.class.php
+++ b/extensions/wikia/PhalanxII/services/PhalanxService.class.php
@@ -1,5 +1,4 @@
 <?php
-use Wikia\DependencyInjection\Injector;
 use Wikia\Service\Gateway\ConsulUrlProvider;
 
 /**
@@ -310,7 +309,8 @@ class PhalanxService extends Service {
 	}
 
 	private function getPhalanxUrl($action) {
-		$baseurl = Injector::getInjector()->get(ConsulUrlProvider::class)->getUrl('phalanx');
+		global $wgConsulUrl, $wgConsulServiceTag;
+		$baseurl = ( new Wikia\Service\Gateway\ConsulUrlProvider( $wgConsulUrl, $wgConsulServiceTag ) )->getUrl( 'phalanx' );
 		return sprintf( "http://%s/%s", $baseurl, $action != "status" ? $action : "" );
 	}
 

--- a/extensions/wikia/PhalanxII/services/PhalanxService.class.php
+++ b/extensions/wikia/PhalanxII/services/PhalanxService.class.php
@@ -155,7 +155,7 @@ class PhalanxService extends Service {
 	private function sendToPhalanxDaemon( $action, $parameters ) {
 		$options = F::app()->wg->PhalanxServiceOptions;
 
-		$url = $this->getPhalanxUrl($action);
+		$url = $this->getPhalanxUrl( $action );
 		$requestTime = 0;
 		$loggerPostParams = [];
 		$tries = 1;
@@ -226,7 +226,7 @@ class PhalanxService extends Service {
 			// BAC-1332 - some of the phalanx service calls are breaking and we're not sure why
 			// it's better to do the retry than maintain the PHP fallback for that
 			while ( $tries <= self::PHALANX_SERVICE_TRIES_LIMIT ) {
-				$url = $this->getPhalanxUrl($action);
+				$url = $this->getPhalanxUrl( $action );
 				$response = Http::post( $url, $options );
 				if ( false !== $response) {
 					break;
@@ -308,9 +308,10 @@ class PhalanxService extends Service {
 		return $res;
 	}
 
-	private function getPhalanxUrl($action) {
+	private function getPhalanxUrl( $action ) {
 		global $wgConsulUrl, $wgConsulServiceTag;
-		$baseurl = ( new Wikia\Service\Gateway\ConsulUrlProvider( $wgConsulUrl, $wgConsulServiceTag ) )->getUrl( 'phalanx' );
+		
+		$baseurl = ( new ConsulUrlProvider( $wgConsulUrl, $wgConsulServiceTag ) )->getUrl( 'phalanx' );
 		return sprintf( "http://%s/%s", $baseurl, $action != "status" ? $action : "" );
 	}
 

--- a/lib/Wikia/src/Service/Gateway/ConsulUrlProvider.php
+++ b/lib/Wikia/src/Service/Gateway/ConsulUrlProvider.php
@@ -60,7 +60,7 @@ class ConsulUrlProvider implements UrlProvider {
 		}
 
 		if (empty($this->cache[$serviceName])) {
-			WikiaLogger::instance()->warning("Empty URL returned from ConsulUrlProvider", ["service_name" => $serviceName, "service_tag" => $this->serviceTag]);
+			WikiaLogger::instance()->warning(__METHOD__ . " Empty URL returned from ConsulUrlProvider", ["service_name" => $serviceName, "service_tag" => $this->serviceTag]);
 			return "";
 		}
 

--- a/lib/Wikia/src/Service/Gateway/ConsulUrlProvider.php
+++ b/lib/Wikia/src/Service/Gateway/ConsulUrlProvider.php
@@ -4,6 +4,7 @@ namespace Wikia\Service\Gateway;
 
 
 use Http;
+use Wikia\Logger\WikiaLogger;
 
 class ConsulUrlProvider implements UrlProvider {
 	const BASE_URL = "consul_url_provider_base_url";
@@ -59,6 +60,7 @@ class ConsulUrlProvider implements UrlProvider {
 		}
 
 		if (empty($this->cache[$serviceName])) {
+			WikiaLogger::instance()->warning("Empty URL returned from ConsulUrlProvider", ["service_name" => $serviceName, "service_tag" => $this->serviceTag]);
 			return "";
 		}
 


### PR DESCRIPTION
After releasing https://github.com/Wikia/app/pull/11719, it turned out that sometimes url to phalanx instance is not returned from consul. This pull request introduces fetching phalanx address from consul every time when there is a need to send request to phalanx. Additionally logging in ConsulUrlProvider is added

//cc @macbre @mixth-sense 
