### PR TITLE
LOC-932: Update founder welcome staff user list (i.e. MediaWiki:Staffsigs)

### DIFF
--- a/extensions/GlobalMessages/GlobalMessagesS.i18n.php
+++ b/extensions/GlobalMessages/GlobalMessagesS.i18n.php
@@ -290,15 +290,14 @@ If you think this is wrong, please contact us [[w:c:vstf:Report:Spam filter prob
 ** BertH
 * es
 ** Luchofigo85
-** Bola
+** Vpinas
 * fr
-** Wyz
 ** Hypsoline
 * it
 ** Leviathan_89
 ** Cresh.
 * ja
-** Charicocco
+** Kuro0222
 * ko
 ** Miri-Nae
 * nl
@@ -313,7 +312,6 @@ If you think this is wrong, please contact us [[w:c:vstf:Report:Spam filter prob
 ** Macherie ana
 * ru
 ** Kuzura
-** Wildream
 ** vlazovskiy
 * vi
 ** KhangND


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/LOC-932

```
Formerly this list lived in http://messaging.wikia.com/wiki/MediaWiki:Staffsigs and was managed there.
Please update the list in CrowdIN (assuming it resides there now).
For JA:
Change Charicocco to Kuro0222
For RU:
Remove Wildream
For FR:
Remove Wyz
For ES:
Change Bola to Vpinas
```

`Staffsigs` i18n string can not be translated via Crowdin, because the code (`Wikia::staffForLang`) uses English version of the message.

**For now**: update the message in the code.

**The solution for the future** :tm:: use WikiFactory variable instead of a message

@mixth-sense / @TK-999 
