### PR TITLE
SUS-548: more debug logging in migration scripts

### DIFF
--- a/extensions/wikia/CuratedContent/maintenance/HeroImageToCuratedContentMigrator.php
+++ b/extensions/wikia/CuratedContent/maintenance/HeroImageToCuratedContentMigrator.php
@@ -14,7 +14,7 @@ class HeroImageToCuratedContentMigrator extends Maintenance {
 	}
 
 	function execute() {
-		global $wgCityId;
+		global $wgCityId, $wgDBname;
 		$dryRun = $this->hasOption('dry-run');
 
 		$commData = new CommunityDataService($wgCityId);
@@ -43,6 +43,7 @@ class HeroImageToCuratedContentMigrator extends Maintenance {
 			$this->output("\ncurated content after migration:\n".json_encode($curatedData)."\n");
 		} else {
 			$commData->setCuratedContent($curatedData, "migrating data from Hero Module");
+			$this->output("{$wgDBname}: hero image data has been migrated\n");
 		}
 	}
 }

--- a/extensions/wikia/CuratedContent/maintenance/SpecialPromoteToCuratedContent.php
+++ b/extensions/wikia/CuratedContent/maintenance/SpecialPromoteToCuratedContent.php
@@ -110,6 +110,8 @@ class SpecialPromoteToCuratedContentMigrator extends Maintenance {
 		}
 		$this->output( "\n" );
 		$this->output( "Done\n" );
+
+		$this->output("{$wgDBname}: Special:Promote data has been migrated\n");
 	}
 
 	/**

--- a/extensions/wikia/CuratedContent/maintenance/SpecialPromoteToCuratedContent.php
+++ b/extensions/wikia/CuratedContent/maintenance/SpecialPromoteToCuratedContent.php
@@ -158,9 +158,9 @@ class SpecialPromoteToCuratedContentMigrator extends Maintenance {
 		$uploadOptions->name = $imageName;
 		$uploadOptions->comment = wfMessage( 'wikiacuratedcontent-image-upload-comment' )->inContentLanguage()->escaped();
 		$uploadOptions->description = wfMessage( 'wikiacuratedcontent-image-upload-description' )->inContentLanguage()->escaped();
-		$wikiaBotUser = User::newFromName( 'WikiaBot' );
+		$botUser = User::newFromName( 'FandomBot' );
 
-		$result = ImagesService::uploadImageFromUrl( $imageUrl, $uploadOptions, $wikiaBotUser );
+		$result = ImagesService::uploadImageFromUrl( $imageUrl, $uploadOptions, $botUser );
 		return $result;
 	}
 }


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-548

Log successful migration of HeroImage and Special:Promote data to ease grepping through logs emitted when these scripts are run via `run_maintenance` helper.

And use `FandomBot` user to upload promote images (instead of `WikiaBot`).

@TK-999 