### PR TITLE
SUS-1219: Fix founders not receiving welcome message

### DIFF
--- a/extensions/wikia/PhalanxII/hooks/PhalanxContentBlock.class.php
+++ b/extensions/wikia/PhalanxII/hooks/PhalanxContentBlock.class.php
@@ -79,7 +79,8 @@ class PhalanxContentBlock extends WikiaObject {
 			return [ $contentIsBlocked, $errorMessage ];
 		}
 
-		$title = RequestContext::getMain()->getTitle();
+		// SUS-1219: fallback to editpage title if wgTitle is null
+		$title = $editPage->getContextTitle() ?? $editPage->getTitle();
 
 		$phalanxModel = new PhalanxContentModel( $title );
 

--- a/extensions/wikia/PhalanxII/models/PhalanxContentModel.php
+++ b/extensions/wikia/PhalanxII/models/PhalanxContentModel.php
@@ -8,7 +8,7 @@ class PhalanxContentModel extends PhalanxModel {
 	/**
 	 * @param Title $title
 	 */
-	public function __construct( Title $title ) {
+	public function __construct( $title ) {
 		parent::__construct();
 		$this->title = $title;
 	}

--- a/extensions/wikia/PhalanxII/models/PhalanxContentModel.php
+++ b/extensions/wikia/PhalanxII/models/PhalanxContentModel.php
@@ -8,7 +8,7 @@ class PhalanxContentModel extends PhalanxModel {
 	/**
 	 * @param Title $title
 	 */
-	public function __construct( $title ) {
+	public function __construct( Title $title ) {
 		parent::__construct();
 		$this->title = $title;
 	}


### PR DESCRIPTION
In Phalanx fall back to edit page title if wgTitle is not set to avoid exception

ticket: https://wikia-inc.atlassian.net/browse/SUS-1219

@macbre / @mixth-sense 