### PR TITLE
XW-2277 | Replace image links in PI on Monobook with File page URLs

### DIFF
--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -2466,6 +2466,14 @@ $config['portable_infobox_js'] = [
 	],
 ];
 
+$config['portable_infobox_monobook_js'] = [
+	'type' => AssetsManager::TYPE_JS,
+	'skin' => [ 'monobook' ],
+	'assets' => [
+		'//extensions/wikia/PortableInfobox/js/PortableInfoboxMonobook.js',
+	],
+];
+
 $config['portable_infobox_scss'] = [
 	'type' => AssetsManager::TYPE_SCSS,
 	'skin' => [ 'oasis' ],

--- a/extensions/wikia/PortableInfobox/PortableInfoboxHooks.class.php
+++ b/extensions/wikia/PortableInfobox/PortableInfoboxHooks.class.php
@@ -9,6 +9,7 @@ class PortableInfoboxHooks {
 		Wikia::addAssetsToOutput( 'portable_infobox_js' );
 		if ( F::app()->checkSkin( 'monobook', $skin ) ) {
 			Wikia::addAssetsToOutput( 'portable_infobox_monobook_scss' );
+			Wikia::addAssetsToOutput( 'portable_infobox_monobook_js' );
 		} else {
 			Wikia::addAssetsToOutput( 'portable_infobox_scss' );
 			if ( !empty( $wgEnablePortableInfoboxEuropaTheme ) ) {

--- a/extensions/wikia/PortableInfobox/js/PortableInfoboxMonobook.js
+++ b/extensions/wikia/PortableInfobox/js/PortableInfoboxMonobook.js
@@ -1,13 +1,14 @@
-(function () {
+(function (window) {
 	'use strict';
 
 	var ImageLink = {
 		init: function ($content) {
 			$content.find('.portable-infobox .pi-image > a.image').on('click', function () {
 				var $anchor = $(this),
-					fileName = $anchor.children('.pi-image-thumbnail').data('image-key');
+					fileName = $anchor.children('.pi-image-thumbnail').data('image-key'),
+					href = window.wgArticlePath.replace(/\$1/, 'File:' + encodeURIComponent(fileName));
 
-				$anchor.attr('href', '/wiki/File:' + encodeURIComponent(fileName));
+				$anchor.attr('href', href);
 			});
 		}
 	};
@@ -15,4 +16,4 @@
 	mw.hook('wikipage.content').add(function ($content) {
 		ImageLink.init($content);
 	});
-})();
+})(window);

--- a/extensions/wikia/PortableInfobox/js/PortableInfoboxMonobook.js
+++ b/extensions/wikia/PortableInfobox/js/PortableInfoboxMonobook.js
@@ -5,10 +5,12 @@
 		init: function ($content) {
 			$content.find('.portable-infobox .pi-image > a.image').on('click', function () {
 				var $anchor = $(this),
-					fileName = $anchor.children('.pi-image-thumbnail').data('image-key'),
-					href = window.wgArticlePath.replace(/\$1/, 'File:' + fileName);
+					fileName = $anchor.find('img[data-image-key]').data('image-key');
 
-				$anchor.attr('href', href);
+				// If users create markup manually and there is no data-image-key then cancel the change
+				if (fileName) {
+					$anchor.attr('href', window.wgArticlePath.replace(/\$1/, 'File:' + fileName));
+				}
 			});
 		}
 	};

--- a/extensions/wikia/PortableInfobox/js/PortableInfoboxMonobook.js
+++ b/extensions/wikia/PortableInfobox/js/PortableInfoboxMonobook.js
@@ -3,9 +3,7 @@
 
 	var ImageLink = {
 		init: function ($content) {
-			var $anchors = $content.find('.portable-infobox .pi-image > a.image');
-
-			$anchors.each(function () {
+			$content.find('.portable-infobox .pi-image > a.image').on('click', function () {
 				var $anchor = $(this),
 					fileName = $anchor.children('.pi-image-thumbnail').data('image-key');
 

--- a/extensions/wikia/PortableInfobox/js/PortableInfoboxMonobook.js
+++ b/extensions/wikia/PortableInfobox/js/PortableInfoboxMonobook.js
@@ -6,7 +6,7 @@
 			$content.find('.portable-infobox .pi-image > a.image').on('click', function () {
 				var $anchor = $(this),
 					fileName = $anchor.children('.pi-image-thumbnail').data('image-key'),
-					href = window.wgArticlePath.replace(/\$1/, 'File:' + encodeURIComponent(fileName));
+					href = window.wgArticlePath.replace(/\$1/, 'File:' + fileName);
 
 				$anchor.attr('href', href);
 			});

--- a/extensions/wikia/PortableInfobox/js/PortableInfoboxMonobook.js
+++ b/extensions/wikia/PortableInfobox/js/PortableInfoboxMonobook.js
@@ -1,0 +1,20 @@
+(function () {
+	'use strict';
+
+	var ImageLink = {
+		init: function ($content) {
+			var $anchors = $content.find('.portable-infobox .pi-image > a.image');
+
+			$anchors.each(function () {
+				var $anchor = $(this),
+					fileName = $anchor.children('.pi-image-thumbnail').data('image-key');
+
+				$anchor.attr('href', '/wiki/File:' + encodeURIComponent(fileName));
+			});
+		}
+	};
+
+	mw.hook('wikipage.content').add(function ($content) {
+		ImageLink.init($content);
+	});
+})();


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/XW-2277

A similar solution to the one from http://starwars.wikia.com/wiki/MediaWiki:Monobook.js. Instead of replacing links when the page is ready we replace them on click. Google does the same on its SRP.

@Wikia/x-wing 