### PR TITLE
SUS-1219: Fix founder user not getting welcome message from staff (release)

### DIFF
--- a/extensions/wikia/PhalanxII/hooks/PhalanxContentBlock.class.php
+++ b/extensions/wikia/PhalanxII/hooks/PhalanxContentBlock.class.php
@@ -79,7 +79,8 @@ class PhalanxContentBlock extends WikiaObject {
 			return [ $contentIsBlocked, $errorMessage ];
 		}
 
-		$title = RequestContext::getMain()->getTitle();
+		// SUS-1219: fallback to editpage title if wgTitle is null
+		$title = $editPage->getContextTitle() ?? $editPage->getTitle();
 
 		$phalanxModel = new PhalanxContentModel( $title );
 


### PR DESCRIPTION
In Phalanx fall back to edit page title if wgTitle is null
ticket: https://wikia-inc.atlassian.net/browse/SUS-1219
dev PR was #11769 