### PR TITLE
MAIN-8472 Make namespaces aliases mergeable

### DIFF
--- a/includes/LocalisationCache.php
+++ b/includes/LocalisationCache.php
@@ -99,7 +99,7 @@ class LocalisationCache {
 	 */
 	static public $mergeableMapKeys = array( 'messages', 'namespaceNames', 'mathNames',
 		'dateFormats', 'defaultUserOptionOverrides', 'imageFiles',
-		'preloadedMessages',
+		'preloadedMessages', 'namespaceAliases',
 	);
 
 	/**
@@ -601,7 +601,7 @@ class LocalisationCache {
 			if ( $coreData['fallbackSequence'][$len - 1] !== 'en' ) {
 				$coreData['fallbackSequence'][] = 'en';
 			}
-			
+
 			# Load the fallback localisation item by item and merge it
 			foreach ( $coreData['fallbackSequence'] as $fbCode ) {
 				# Load the secondary localisation from the source file to
@@ -616,7 +616,7 @@ class LocalisationCache {
 				$fbData = $this->readPHPFile( $fbFilename, 'core' );
 
 				wfDebug( __METHOD__.": got fallback localisation for $fbCode from source\n" );
-                        
+
 				foreach ( self::$allKeys as $key ) {
 					if ( !isset( $fbData[$key] ) ) {
 						continue;


### PR DESCRIPTION
Fixed in MediaWiki 1.28:
https://github.com/wikimedia/mediawiki/commit/ea9fcc1e4d3b572199d82c426024e3e5efe23879

The problem is:

If you have some namespace aliases defined in "core" and in extensions
MediaWiki (prior to 1.28) will just overwrite the "core" settings with
the extension ones.

Fixed in 1.28 to let both "core" and extensions define the aliases and
handle that by merging the arrays instead of overwriting.