### PR TITLE
SUS-1221: Log DB exceptions thrown by User::edits and UserStatsService::getStats

### DIFF
--- a/includes/User.php
+++ b/includes/User.php
@@ -915,12 +915,27 @@ class User {
 				array( 'rev_user' => $uid ),
 				__METHOD__
 			);
-			$dbw->update(
-				'user',
-				array( 'user_editcount' => $count ),
-				array( 'user_id' => $uid ),
-				__METHOD__
-			);
+
+			// Wikia change - begin
+			try {
+				$dbw->update(
+					'user',
+					[ 'user_editcount' => $count ],
+					[ 'user_id' => $uid ],
+					__METHOD__
+				);
+			} catch ( DBQueryError $dbQueryError ) {
+				// Wikia change
+				// SUS-1221: Some of these UPDATE queries are failing
+				// If this happens let's log exception details to try to identify root cause
+				Wikia\Logger\WikiaLogger::instance()->error( 'SUS-1221 - User::edits failed', [
+					'exception' => $dbQueryError,
+					'userId' => $uid,
+					'editCount' => $count
+				] );
+			}
+			// Wikia change - end
+
 		} else {
 			$count = $field;
 		}


### PR DESCRIPTION
These two methods have lately been throwing DB exceptions which among others can prevent the Rail from loading. Let's catch them and log details to try and identify the root cause.

ticket: https://wikia-inc.atlassian.net/browse/SUS-1221

@macbre 