### PR TITLE
WW-364: Fix non active placeholder position

### DIFF
--- a/extensions/wikia/CreateNewWiki/js/WikiBuilder.js
+++ b/extensions/wikia/CreateNewWiki/js/WikiBuilder.js
@@ -313,7 +313,7 @@ define('ext.createNewWiki.builder', ['ext.createNewWiki.helper', 'wikia.tracker'
 	function onWikiNameBlur(e) {
 		if (e.target.value.trim().length === 0) {
 			wikiNameLabel.removeClass('active');
-			if (!wikiDomain.val().length) {
+			if (!wikiDomain.val().trim().length) {
 				wikiDomainLabel.removeClass('active');
 			}
 		}

--- a/extensions/wikia/CreateNewWiki/js/WikiBuilder.js
+++ b/extensions/wikia/CreateNewWiki/js/WikiBuilder.js
@@ -313,7 +313,9 @@ define('ext.createNewWiki.builder', ['ext.createNewWiki.helper', 'wikia.tracker'
 	function onWikiNameBlur(e) {
 		if (e.target.value.trim().length === 0) {
 			wikiNameLabel.removeClass('active');
-			wikiDomainLabel.removeClass('active');
+			if (!wikiDomain.val().length) {
+				wikiDomainLabel.removeClass('active');
+			}
 		}
 	}
 


### PR DESCRIPTION
After click outside the input fields, when wiki name input was active and domain input was filled, domain label hovers text in input field.