### PR TITLE
Platform 2521 - Implement HTTP retries in Helios PHP client.

### DIFF
--- a/lib/Wikia/src/Service/Helios/HeliosClientImpl.php
+++ b/lib/Wikia/src/Service/Helios/HeliosClientImpl.php
@@ -16,6 +16,16 @@ class HeliosClientImpl implements HeliosClient
 	const BASE_URI = "helios_base_uri";
 	const SCHWARTZ_TOKEN = "schwartz_token";
 	const SCHWARTZ_HEADER_NAME = 'THE-SCHWARTZ';
+
+	// Timeout (in seconds) of the Helios HTTP requests.
+	const HELIOS_REQUEST_TIMEOUT_SEC = 2;
+
+	// Maximum number of Helios HTTP connection attempts.
+	const HELIOS_REQUEST_TRIES = 2;
+
+	// Delay for Helios HTTP connection retries.
+	const HELIOS_REQUEST_RETRY_DELAY_SEC = 1;
+
 	protected $baseUri;
 	protected $status;
 	protected $schwartzToken;
@@ -69,7 +79,7 @@ class HeliosClientImpl implements HeliosClient
 		// Request options pre-processing.
 		$options = [
 			'method'          => 'GET',
-			'timeout'         => 5,
+			'timeout'         => self::HELIOS_REQUEST_TIMEOUT_SEC,
 			'postData'        => $postData,
 			'noProxy'         => true,
 			'followRedirects' => false,
@@ -92,11 +102,36 @@ class HeliosClientImpl implements HeliosClient
 		global $wgContLang;
 		$wrapper = new GlobalStateWrapper( [ 'wgLang' => $wgContLang ] );
 
-		// Request execution.
-		/** @var \MWHttpRequest $request */
-		$request = $wrapper->wrap( function() use ( $options, $uri ) {
-			return \Http::request( $options['method'], $uri, $options );
-		} );
+		/*
+		 * We have self::HELIOS_REQUEST_RETRIES tries to receive an HTTP response from Helios.
+		 * One thing to keep in mind is that Helios address resolution is done by AuthModule
+		 * using Consul at the beginning of the request, so the retry will hit the same
+		 * Helios instance.
+		 */
+		$retry_cnt = 1;
+		while( true ) {
+
+			// Request execution.
+			/** @var \MWHttpRequest $request */
+			$request = $wrapper->wrap( function() use ( $options, $uri ) {
+				return \Http::request( $options['method'], $uri, $options );
+			} );
+
+			/*
+			 * $request->getStatus returns 200 when we failed to make http connection, so
+			 * we use the internal status object to check for http connection errors.
+			 * The general idea here is that we will make extra requests when if fail
+			 * to receive an HTTP response from Helios.
+			 */
+
+			if ( $retry_cnt < self::HELIOS_REQUEST_TRIES ||
+				( !$request->status->hasMessage( 'http-timed-out' ) &&
+				  !$request->status->hasMessage( 'http-curl-error' ) ) ) {
+				break;
+			}
+			$retry_cnt += 1;
+			sleep( self::HELIOS_REQUEST_RETRY_DELAY_SEC );
+		}
 
 		$this->status = $request->getStatus();
 		return $this->processResponseOutput( $request );
@@ -112,8 +147,11 @@ class HeliosClientImpl implements HeliosClient
 
 		if ( !$output ) {
 			$data = [];
-			$data[ "response" ] = $response;
-			$data["status_code"] = $request->getStatus();
+			$data[ 'response' ] = $response;
+			$data[ 'status_code' ] = $request->getStatus();
+			if ( !$request->status->isOK() ) {
+				$data[ 'status_errors' ] = $request->status->getErrorsArray();
+			}
 			throw new ClientException ( 'Invalid Helios response.', 0, null, $data );
 		}
 

--- a/lib/Wikia/src/Service/Helios/HeliosClientImpl.php
+++ b/lib/Wikia/src/Service/Helios/HeliosClientImpl.php
@@ -124,7 +124,7 @@ class HeliosClientImpl implements HeliosClient
 			 * to receive an HTTP response from Helios.
 			 */
 
-			if ( $retry_cnt < self::HELIOS_REQUEST_TRIES ||
+			if ( $retry_cnt >= self::HELIOS_REQUEST_TRIES ||
 				( !$request->status->hasMessage( 'http-timed-out' ) &&
 				  !$request->status->hasMessage( 'http-curl-error' ) ) ) {
 				break;

--- a/lib/Wikia/src/Service/Helios/HeliosClientImpl.php
+++ b/lib/Wikia/src/Service/Helios/HeliosClientImpl.php
@@ -120,7 +120,7 @@ class HeliosClientImpl implements HeliosClient
 			/*
 			 * $request->getStatus returns 200 when we failed to make http connection, so
 			 * we use the internal status object to check for http connection errors.
-			 * The general idea here is that we will make extra requests when if fail
+			 * The general idea here is that we will make extra requests if we fail
 			 * to receive an HTTP response from Helios.
 			 */
 

--- a/lib/Wikia/src/Service/Helios/HeliosClientImpl.php
+++ b/lib/Wikia/src/Service/Helios/HeliosClientImpl.php
@@ -108,12 +108,12 @@ class HeliosClientImpl implements HeliosClient
 		 * using Consul at the beginning of the request, so the retry will hit the same
 		 * Helios instance.
 		 */
-		$retry_cnt = 1;
-		while( true ) {
+		$retryCnt = 1;
+		while ( true ) {
 
 			// Request execution.
 			/** @var \MWHttpRequest $request */
-			$request = $wrapper->wrap( function() use ( $options, $uri ) {
+			$request = $wrapper->wrap( function () use ( $options, $uri ) {
 				return \Http::request( $options['method'], $uri, $options );
 			} );
 
@@ -124,16 +124,18 @@ class HeliosClientImpl implements HeliosClient
 			 * to receive an HTTP response from Helios.
 			 */
 
-			if ( $retry_cnt >= self::HELIOS_REQUEST_TRIES ||
+			if ( $retryCnt >= self::HELIOS_REQUEST_TRIES ||
 				( !$request->status->hasMessage( 'http-timed-out' ) &&
-				  !$request->status->hasMessage( 'http-curl-error' ) ) ) {
+					!$request->status->hasMessage( 'http-curl-error' ) )
+			) {
 				break;
 			}
-			$retry_cnt += 1;
+			$retryCnt += 1;
 			sleep( self::HELIOS_REQUEST_RETRY_DELAY_SEC );
 		}
 
 		$this->status = $request->getStatus();
+
 		return $this->processResponseOutput( $request );
 	}
 
@@ -147,10 +149,10 @@ class HeliosClientImpl implements HeliosClient
 
 		if ( !$output ) {
 			$data = [];
-			$data[ 'response' ] = $response;
-			$data[ 'status_code' ] = $request->getStatus();
+			$data['response'] = $response;
+			$data['status_code'] = $request->getStatus();
 			if ( !$request->status->isOK() ) {
-				$data[ 'status_errors' ] = $request->status->getErrorsArray();
+				$data['status_errors'] = $request->status->getErrorsArray();
 			}
 			throw new ClientException ( 'Invalid Helios response.', 0, null, $data );
 		}

--- a/lib/Wikia/tests/Service/Helios/HeliosClientTest.php
+++ b/lib/Wikia/tests/Service/Helios/HeliosClientTest.php
@@ -34,6 +34,8 @@ class HeliosClientTest extends \WikiaBaseTest {
 			->method( 'getContent' )
 			->willReturn( null );
 
+		$requestMock->status = $this->getMock( 'stdClass', [ 'isOK', 'getErrorsArray' ]);
+
 		$this->mockStaticMethod( '\Http', 'request', $requestMock );
 
 		$client = new HeliosClientImpl( 'http://example.com', 'id', 'secret' );

--- a/lib/Wikia/tests/Service/Helios/HeliosClientTest.php
+++ b/lib/Wikia/tests/Service/Helios/HeliosClientTest.php
@@ -31,7 +31,7 @@ class HeliosClientTest extends \WikiaBaseTest {
 			->method( 'getContent' )
 			->willReturn( null );
 
-		$requestMock->status = $this->getMock( 'staClass', [ 'isOK', 'getErrorsArray', 'hasMessage' ] );
+		$requestMock->status = $this->getMock( '\Status', [ 'isOK', 'getErrorsArray', 'hasMessage' ] );
 
 		$this->mockStaticMethod( '\Http', 'request', $requestMock );
 
@@ -47,7 +47,7 @@ class HeliosClientTest extends \WikiaBaseTest {
 			->method( 'getContent' )
 			->willReturn( '{}' );
 
-		$requestMock->status = $this->getMock( 'stdClass', [ 'isOK', 'getErrorsArray', 'hasMessage' ] );
+		$requestMock->status = $this->getMock( '\Status', [ 'isOK', 'getErrorsArray', 'hasMessage' ] );
 		$requestMock->status->expects( $this->any() )->method( 'hasMessage' )->willReturn( false );
 
 		// With no error message, we expect no retries, hence \Http::request should be called only once.
@@ -70,7 +70,7 @@ class HeliosClientTest extends \WikiaBaseTest {
 			->method( 'getContent' )
 			->willReturn( '{}' );
 
-		$requestMock->status = $this->getMock( 'stdClass', [ 'isOK', 'getErrorsArray', 'hasMessage' ] );
+		$requestMock->status = $this->getMock( '\Status', [ 'isOK', 'getErrorsArray', 'hasMessage' ] );
 		$requestMock->status->expects( $this->any() )->method( 'hasMessage' )->willReturn( true );
 
 		// Retries are base on status->hasMessage value, so we expect two calls to \Http::request here.

--- a/lib/Wikia/tests/Service/Helios/HeliosClientTest.php
+++ b/lib/Wikia/tests/Service/Helios/HeliosClientTest.php
@@ -7,15 +7,13 @@ use Wikia\Service\Helios\HeliosClientImpl;
 
 class HeliosClientTest extends \WikiaBaseTest {
 
-	public function setUp()
-	{
+	public function setUp() {
 
 		parent::setUp();
 	}
 
-	public function testCannotMakeRequests()
-	{
-		$this->setExpectedException('Wikia\Util\AssertionException');
+	public function testCannotMakeRequests() {
+		$this->setExpectedException( 'Wikia\Util\AssertionException' );
 
 		$this->mockStaticMethod( '\MWHttpRequest', 'canMakeRequests', false );
 
@@ -23,9 +21,8 @@ class HeliosClientTest extends \WikiaBaseTest {
 		$client->request( 'resource', [], [], [] );
 	}
 
-	public function testInvalidResponse()
-	{
-		$this->setExpectedException('Wikia\Service\Helios\ClientException','Invalid Helios response.');
+	public function testInvalidResponse() {
+		$this->setExpectedException( 'Wikia\Service\Helios\ClientException', 'Invalid Helios response.' );
 
 		$this->mockStaticMethod( '\MWHttpRequest', 'canMakeRequests', true );
 
@@ -34,7 +31,7 @@ class HeliosClientTest extends \WikiaBaseTest {
 			->method( 'getContent' )
 			->willReturn( null );
 
-		$requestMock->status = $this->getMock( 'stdClass', [ 'isOK', 'getErrorsArray', 'hasMessage' ]);
+		$requestMock->status = $this->getMock( 'staClass', [ 'isOK', 'getErrorsArray', 'hasMessage' ] );
 
 		$this->mockStaticMethod( '\Http', 'request', $requestMock );
 
@@ -42,8 +39,7 @@ class HeliosClientTest extends \WikiaBaseTest {
 		$client->request( 'resource', [], [], [] );
 	}
 
-	public function testSuccess()
-	{
+	public function testSuccess() {
 		$this->mockStaticMethod( '\MWHttpRequest', 'canMakeRequests', true );
 
 		$requestMock = $this->getMock( '\CurlHttpRequest', [ 'execute', 'getContent' ], [ 'http://example.com' ], '', false );
@@ -51,7 +47,7 @@ class HeliosClientTest extends \WikiaBaseTest {
 			->method( 'getContent' )
 			->willReturn( '{}' );
 
-		$requestMock->status = $this->getMock( 'stdClass', [ 'isOK', 'getErrorsArray', 'hasMessage' ]);
+		$requestMock->status = $this->getMock( 'stdClass', [ 'isOK', 'getErrorsArray', 'hasMessage' ] );
 		$requestMock->status->expects( $this->any() )->method( 'hasMessage' )->willReturn( false );
 
 		// With no error message, we expect no retries, hence \Http::request should be called only once.
@@ -63,10 +59,9 @@ class HeliosClientTest extends \WikiaBaseTest {
 		$this->assertInternalType( 'object', $client->request( 'resource', [], [], [] ) );
 	}
 
-	public function testRetry()
-	{
+	public function testRetry() {
 		// To reduce the unit test time, mock the 'sleep' method called between retries.
-		$this->mockGlobalFunction( 'sleep', null);
+		$this->mockGlobalFunction( 'sleep', null );
 
 		$this->mockStaticMethod( '\MWHttpRequest', 'canMakeRequests', true );
 
@@ -75,7 +70,7 @@ class HeliosClientTest extends \WikiaBaseTest {
 			->method( 'getContent' )
 			->willReturn( '{}' );
 
-		$requestMock->status = $this->getMock( 'stdClass', [ 'isOK', 'getErrorsArray', 'hasMessage' ]);
+		$requestMock->status = $this->getMock( 'stdClass', [ 'isOK', 'getErrorsArray', 'hasMessage' ] );
 		$requestMock->status->expects( $this->any() )->method( 'hasMessage' )->willReturn( true );
 
 		// Retries are base on status->hasMessage value, so we expect two calls to \Http::request here.

--- a/lib/Wikia/tests/Service/Helios/HeliosClientTest.php
+++ b/lib/Wikia/tests/Service/Helios/HeliosClientTest.php
@@ -34,7 +34,7 @@ class HeliosClientTest extends \WikiaBaseTest {
 			->method( 'getContent' )
 			->willReturn( null );
 
-		$requestMock->status = $this->getMock( 'stdClass', [ 'isOK', 'getErrorsArray' ]);
+		$requestMock->status = $this->getMock( 'stdClass', [ 'isOK', 'getErrorsArray', 'hasMessage' ]);
 
 		$this->mockStaticMethod( '\Http', 'request', $requestMock );
 
@@ -51,10 +51,40 @@ class HeliosClientTest extends \WikiaBaseTest {
 			->method( 'getContent' )
 			->willReturn( '{}' );
 
-		$this->mockStaticMethod( '\Http', 'request', $requestMock );
+		$requestMock->status = $this->getMock( 'stdClass', [ 'isOK', 'getErrorsArray', 'hasMessage' ]);
+		$requestMock->status->expects( $this->any() )->method( 'hasMessage' )->willReturn( false );
+
+		// With no error message, we expect no retries, hence \Http::request should be called only once.
+		$this->getStaticMethodMock( '\Http', 'request' )->expects( $this->once() )
+			->method( 'request' )
+			->willReturn( $requestMock );
 
 		$client = new HeliosClientImpl( 'http://example.com', 'id', 'secret' );
 		$this->assertInternalType( 'object', $client->request( 'resource', [], [], [] ) );
+	}
+
+	public function testRetry()
+	{
+		// To reduce the unit test time, mock the 'sleep' method called between retries.
+		$this->mockGlobalFunction( 'sleep', null);
+
+		$this->mockStaticMethod( '\MWHttpRequest', 'canMakeRequests', true );
+
+		$requestMock = $this->getMock( '\CurlHttpRequest', [ 'execute', 'getContent' ], [ 'http://example.com' ], '', false );
+		$requestMock->expects( $this->once() )
+			->method( 'getContent' )
+			->willReturn( '{}' );
+
+		$requestMock->status = $this->getMock( 'stdClass', [ 'isOK', 'getErrorsArray', 'hasMessage' ]);
+		$requestMock->status->expects( $this->any() )->method( 'hasMessage' )->willReturn( true );
+
+		// Retries are base on status->hasMessage value, so we expect two calls to \Http::request here.
+		$this->getStaticMethodMock( '\Http', 'request' )->expects( $this->exactly( 2 ) )
+			->method( 'request' )
+			->willReturn( $requestMock );
+
+		$client = new HeliosClientImpl( 'http://example.com', 'id', 'secret' );
+		$client->request( 'resource', [], [], [] );
 	}
 
 }


### PR DESCRIPTION
As there will be no PHP fallback for authentication, we are adding retries in Helios PHP client to try to avoid failures caused by network issues.