### PR TITLE
SUS-1253: Fix unicode errors in Search

### DIFF
--- a/extensions/wikia/Search/WikiaSearchController.class.php
+++ b/extensions/wikia/Search/WikiaSearchController.class.php
@@ -525,7 +525,11 @@ class WikiaSearchController extends WikiaSpecialPageController {
 	 * @return \Wikia\Search\Config
 	 */
 	protected function getSearchConfigFromRequest() {
-		$request = $this->getRequest();
+		global $wgRequest;
+
+		// Use WebRequest instead of Nirvana request
+		// Nirvana request does not process certain Unicode stuff correctly which causes HTTP 500
+		$request = $wgRequest;
 		$searchConfig = new Wikia\Search\Config();
 		$resultsPerPage = $this->isCorporateWiki() ? self::INTERWIKI_RESULTS_PER_PAGE : self::RESULTS_PER_PAGE;
 		$resultsPerPage = empty( $this->wg->SearchResultsPerPage ) ? $resultsPerPage : $this->wg->SearchResultsPerPage;
@@ -533,12 +537,12 @@ class WikiaSearchController extends WikiaSpecialPageController {
 			->setQuery                   ( $request->getVal( 'query', $request->getVal( 'search' ) ) )
 			->setCityId                  ( $this->wg->CityId )
 			->setLimit                   ( $request->getInt( 'limit', $resultsPerPage ) )
-			->setPage                    ( $request->getVal( 'page', 1) )
+			->setPage                    ( $request->getInt( 'page', 1 ) )
 			->setRank                    ( $request->getVal( 'rank', 'default' ) )
-			->setHub                     ( $request->getVal( 'hub', false ) )
+			->setHub                     ( $request->getBool( 'hub', false ) )
 			->setInterWiki               ( $this->isCorporateWiki() )
-			->setVideoSearch             ( $request->getVal( 'videoSearch', false ) )
-			->setFilterQueriesFromCodes  ( $request->getVal( 'filters', array() ) )
+			->setVideoSearch             ( $request->getBool( 'videoSearch', false ) )
+			->setFilterQueriesFromCodes  ( $request->getArray( 'filters', [] ) )
 			->setBoostGroup              ( $request->getVal( 'ab' ) );
 
 		if ( $this->isCorporateWiki() ) {

--- a/extensions/wikia/Search/classes/Services/FandomSearchService.php
+++ b/extensions/wikia/Search/classes/Services/FandomSearchService.php
@@ -9,11 +9,14 @@ class FandomSearchService extends EntitySearchService {
 		return 'fandom';
 	}
 
-	protected function prepareQuery( $query ) {
+	protected function prepareQuery( string $phrase ) {
 		$select = $this->getSelect();
 
-		$phrase = $this->sanitizeQuery( $query );
-		$select->setQuery( 'title:' . $phrase . ' excerpt_t:' . $phrase . ' content_t:' . $phrase );
+		// escape query text properly to prevent HTTP 500 errors
+		$queryText = 'title:%P1% excerpt_t:%P1% content_t:%P1%';
+		$params = [ $phrase ];
+
+		$select->setQuery( $queryText, $params );
 		$select->clearFields()->addFields( [ 'title', 'url', 'image_s', 'excerpt_t', 'vertical_s' ] );
 		$select->setRows( static::RESULTS_COUNT );
 

--- a/extensions/wikia/Search/templates/WikiaSearch_mediadata.php
+++ b/extensions/wikia/Search/templates/WikiaSearch_mediadata.php
@@ -1,5 +1,5 @@
 <?php if ( isset($mediaData['items']) && sizeof($mediaData['items']) != 0 ): ?>
-	<h1><a href="<?= $mediaData['videoUrl'] ?>" class="video-addon-seach-video"><?= wfMessage( 'wikiasearch2-video-results', $query ) ?></a></h1>
+	<h1><a href="<?= $mediaData['videoUrl'] ?>" class="video-addon-seach-video"><?= wfMessage( 'wikiasearch2-video-results', $query )->escaped(); ?></a></h1>
 	<ul>
 		<?php foreach ( $mediaData['items'] as $fileDatum ): ?><li><?= $fileDatum["thumbnail"] ?></li><? endforeach; ?>
 	</ul>


### PR DESCRIPTION
Let's use `WebRequest` instead of Nirvana framework to ensure search config passed via URL parameters is properly decoded.

Additionally fixed an AssertionException in search template due to incorrect message usage

ticket: https://wikia-inc.atlassian.net/browse/SUS-1253