### PR TITLE
SUS-1271: fix a fatal in SF_FormStart caused by a call to MW1.21 API

### DIFF
--- a/extensions/SemanticForms/specials/SF_FormStart.php
+++ b/extensions/SemanticForms/specials/SF_FormStart.php
@@ -133,7 +133,7 @@ END;
 		if ( $page_title->exists() ) {
 			// It exists - see if page is a redirect; if
 			// it is, edit the target page instead.
-			$content = WikiPage::factory( $page_title )->getContent();
+			$content = WikiPage::factory( $page_title ); # Wikia change - SUS-1271 / use MW1.19 compatible call
 			if ( $content && $content->getRedirectTarget() ) {
 				$page_title = $content->getRedirectTarget();
 				$page_name = SFUtils::titleURLString( $page_title );


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-1271

Due to [a call to a method introduce in MediaWiki 1.21](https://doc.wikimedia.org/mediawiki-core/master/php/classWikiPage.html#a23408530f80d9cf37b3f8712529835d2) we're getting the following error:

```
Unexpected non-MediaWiki exception encountered, of type "Error"
Error: Call to undefined method WikiPage::getContent() in /usr/wikia/slot1/14902/src/extensions/SemanticForms/specials/SF_FormStart.php:136
Stack trace:
#0 /usr/wikia/slot1/14902/src/extensions/SemanticForms/specials/SF_FormStart.php(80): SFFormStart->doRedirect('Character', 'Infobox:Naruto_...', NULL)
#1 /usr/wikia/slot1/14902/src/includes/SpecialPageFactory.php(480): SFFormStart->execute(NULL)
#2 /usr/wikia/slot1/14902/src/includes/Wiki.php(292): SpecialPageFactory::executePath(Object(Title), Object(RequestContext))
#3 /usr/wikia/slot1/14902/src/includes/Wiki.php(667): MediaWiki->performRequest()
#4 /usr/wikia/slot1/14902/src/includes/Wiki.php(547): MediaWiki->main()
#5 /usr/wikia/slot1/14902/src/index.php(58): MediaWiki->run()
#6 {main}
````

@mixth-sense / @TK-999 