### PR TITLE
SUS-1215 Be more forgiving of older blocks

### DIFF
--- a/extensions/wikia/PhalanxII/PhalanxSpecialController.class.php
+++ b/extensions/wikia/PhalanxII/PhalanxSpecialController.class.php
@@ -106,7 +106,7 @@ class PhalanxSpecialController extends WikiaSpecialPageController {
 
 		// VSTF should not be allowed to block emails in Phalanx
 		$showEmailBlock = $this->wg->User->isAllowed( 'phalanxemailblock' );
-		$blockTypes  = Phalanx::getAllTypeNames();
+		$blockTypes  = Phalanx::getSupportedTypeNames();
 
 		$typeSections = [
 			'page-edition' => [
@@ -264,7 +264,7 @@ class PhalanxSpecialController extends WikiaSpecialPageController {
 		$listing = '';
 		$noMatches = true;
 
-		foreach ( Phalanx::getAllTypeNames() as $blockType ) {
+		foreach ( Phalanx::getSupportedTypeNames() as $blockType ) {
 			$res = $service->match( $blockType, $blockText );
 
 			if ( empty( $res ) ) {
@@ -383,7 +383,7 @@ class PhalanxSpecialController extends WikiaSpecialPageController {
 		$block = $this->request->getVal( 'block' );
 
 		if ( $token == $this->getToken() ) {
-			foreach ( Phalanx::getAllTypeNames() as $type => $typeName ) {
+			foreach ( Phalanx::getSupportedTypeNames() as $type => $typeName ) {
 				$blocks = $this->service->match( $type, $block );
 				if ( !empty( $blocks ) ) {
 					$result[$type] = $blocks;

--- a/extensions/wikia/PhalanxII/classes/Phalanx.class.php
+++ b/extensions/wikia/PhalanxII/classes/Phalanx.class.php
@@ -317,10 +317,10 @@ class Phalanx extends WikiaModel implements ArrayAccess {
 		$log->addEntry(
 			$action,
 			$title,
-			wfMsgExt(
-				'phalanx-rule-log-details', [ 'parsemag', 'content' ],
+			wfMessage(
+				'phalanx-rule-log-details',
 				$this->data['text'], $types, $this->data['reason']
-			)
+			)->inContentLanguage()->escaped()
 		);
 	}
 }

--- a/extensions/wikia/PhalanxII/classes/PhalanxStatsPager.class.php
+++ b/extensions/wikia/PhalanxII/classes/PhalanxStatsPager.class.php
@@ -45,17 +45,28 @@ class PhalanxStatsPager extends PhalanxPager {
 	}
 
 	function formatRow( $row ) {
-		$type = implode( ", ", Phalanx::getTypeNames( $row->ps_blocker_hit ?? $row->ps_blocker_type ) );
+		$blocker = $row->ps_blocker_hit ?: $row->ps_blocker_type;
+		$type = implode( ', ', Phalanx::getTypeNames( $blocker ) );
 		$username = $row->ps_blocked_user;
 		$timestamp = $this->getLanguage()->timeanddate( $row->ps_timestamp );
-		$oWiki = WikiFactory::getWikiByID( $row->ps_wiki_id );
-		$url = $row->ps_referrer ?? '';
-		$url = ( empty( $url ) && isset( $oWiki ) ) ? $oWiki->city_url : $url;
+
+		$url = $row->ps_referrer ?: '';
+		if ( empty( $url ) ) {
+			$wiki = WikiFactory::getWikiByID( $row->ps_wiki_id );
+			if ( $wiki ) {
+				$url = $wiki->city_url;
+			}
+		}
 
 		// SUS-184: Render usernames containing spaces correctly
 		$encUserName = str_replace( ' ', '_', $username );
 
-		$specialContributionsURL = GlobalTitle::newFromText( 'Contributions', NS_SPECIAL, $row->ps_wiki_id )->getFullURL();
+		$specialContributions = GlobalTitle::newFromText(
+			'Contributions',
+			NS_SPECIAL,
+			$row->ps_wiki_id
+		);
+		$specialContributionsURL = $specialContributions->getFullURL();
 
 		if ( !empty( $specialContributionsURL ) ) {
 			$username = '[' . $specialContributionsURL . '/' . $encUserName . ' ' . $username . ']';

--- a/extensions/wikia/PhalanxII/classes/PhalanxStatsPager.class.php
+++ b/extensions/wikia/PhalanxII/classes/PhalanxStatsPager.class.php
@@ -66,9 +66,9 @@ class PhalanxStatsPager extends PhalanxPager {
 			NS_SPECIAL,
 			$row->ps_wiki_id
 		);
-		$specialContributionsURL = $specialContributions->getFullURL();
 
-		if ( !empty( $specialContributionsURL ) ) {
+		if ( $specialContributions->getServer() ) {
+			$specialContributionsURL = $specialContributions->getFullURL();
 			$username = '[' . $specialContributionsURL . '/' . $encUserName . ' ' . $username . ']';
 		}
 

--- a/extensions/wikia/PhalanxII/hooks/PhalanxHooks.class.php
+++ b/extensions/wikia/PhalanxII/hooks/PhalanxHooks.class.php
@@ -68,7 +68,7 @@ class PhalanxHooks extends WikiaObject {
 		}
 
 		// get type ID -> type mapping
-		$types = Phalanx::getAllTypeNames();
+		$types = Phalanx::getSupportedTypeNames();
 		$ret = $model->match( $types[$typeId] );
 
 		// pass matching block details

--- a/extensions/wikia/PhalanxII/schema.sql
+++ b/extensions/wikia/PhalanxII/schema.sql
@@ -23,11 +23,15 @@ CREATE TABLE IF NOT EXISTS `phalanx` (
   `p_reason` tinyblob NOT NULL,
 -- language to which the block applies - just for Answers for legacy reasons
   `p_lang` varchar(10),
+-- internal comments for each block (BAC-534)
+  `p_comment` tinyblob NOT NULL,
   PRIMARY KEY (`p_id`),
   KEY (`p_ip_hex`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `phalanx_stats` (
+-- unique ID for stats row
+  `ps_id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT,
 -- foreign key to phalanx.p_id
   `ps_blocker_id` int(6) unsigned NOT NULL,
 -- type of match
@@ -38,8 +42,11 @@ CREATE TABLE IF NOT EXISTS `phalanx_stats` (
   `ps_blocked_user` varchar(255) binary NOT NULL default '',
 -- wiki_id where block matched
   `ps_wiki_id` int(9) NOT NULL,
+-- The block type that matched
+  `ps_blocker_hit` SMALLINT(1) UNSIGNED NOT NULL,
+-- Referring page (if any)
+  `ps_referrer` VARCHAR(150),
   KEY `ps_blocker_id_idx` (`ps_blocker_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- internal comments for each block (BAC-534)
-ALTER TABLE `phalanx` ADD `p_comment` tinyblob NOT NULL;
+

--- a/extensions/wikia/UserRenameTool/RenameUserHelper.class.php
+++ b/extensions/wikia/UserRenameTool/RenameUserHelper.class.php
@@ -163,7 +163,7 @@ class RenameUserHelper {
 
 		$blockFound = false;
 
-		foreach ( Phalanx::getAllTypeNames() as $blockType ) {
+		foreach ( Phalanx::getSupportedTypeNames() as $blockType ) {
 			$res = $service->match( $blockType, $text );
 
 			if ( !empty( $res ) ) {


### PR DESCRIPTION
Older blocks may not have the ps_blocker_hit column set in the phalanx_stats table. Existing code was using the null coalescing operator to check both ps_blocker_hit then ps_blocker_type.  However as this value is sometimes zero as well as null, this did not do the right thing. Also add back in an old block for stats display purposes, but hide it for block creation.

https://wikia-inc.atlassian.net/browse/SUS-1215

Note that this PR builds on the PR for SUS-1278 (incorrectly checked in to the branch SOC-1278 but will stay there now, sorry :/).  The PR for that is https://github.com/Wikia/app/pull/11832

@nmonterroso @TK-999 