### PR TITLE
PLATFORM-2466 Set tracer flag if sjc-backend is unhealthy

### DIFF
--- a/lib/Wikia/src/Tracer/WikiaTracer.php
+++ b/lib/Wikia/src/Tracer/WikiaTracer.php
@@ -12,6 +12,8 @@ class WikiaTracer {
 	const PARENT_SPAN_ID_HEADER_NAME = 'X-Parent-Span-Id';
 	const CLIENT_IP_HEADER_NAME = 'X-Client-Ip';
 	const SHIELDS_HEADER_NAME = 'X-SJC-shields-healthy';
+	const SHIELDS_HEADER_STATUS_HEALTHY = '1';
+	const SHIELDS_HEADER_STATUS_UNHEALTHY  = '0';
 	const CLIENT_BEACON_ID_HEADER_NAME = 'X-Client-Beacon-Id';
 	const CLIENT_DEVICE_ID_HEADER_NAME = 'X-Client-Device-Id';
 	const CLIENT_USER_ID = 'X-User-Id';
@@ -32,7 +34,7 @@ class WikiaTracer {
 	const SERVER_SERVER_NAME = 'SERVER_NAME';
 
 	private $traceId;
-	private $sjcShields;
+	private $sjcShieldsHealthStatus;
 	private $parentSpanId;
 	private $clientIp;
 	private $clientBeaconId;
@@ -51,7 +53,9 @@ class WikiaTracer {
 		$this->traceId = $this->validateId( $this->getTraceEntry( self::TRACE_ID_HEADER_NAME ) )
 			?: $this->validateId( $this->getTraceEntry( self::LEGACY_TRACE_ID_HEADER_NAME ) )
 			?: self::generateId();
-		$this->sjcShields = $this->getTraceEntry( self::SHIELDS_HEADER_NAME );
+
+		$this->sjcShieldsHealthStatus = $this->getSjcShieldsStatus();
+
 		$this->spanId = self::generateId();
 		$this->parentSpanId = $this->getTraceEntry( self::PARENT_SPAN_ID_HEADER_NAME );
 
@@ -87,15 +91,15 @@ class WikiaTracer {
 		$serverHeaderName = 'HTTP_' . $entryName;
 		$envName = self::ENV_VARIABLES_PREFIX . $entryName;
 
-		if ( isset( $_SERVER[$serverHeaderName] ) && $_SERVER[$serverHeaderName] !== '' ) {
-			return $_SERVER[$serverHeaderName];
+		if ( isset( $_SERVER[ $serverHeaderName ] ) && $_SERVER[ $serverHeaderName ] !== '' ) {
+			return $_SERVER[ $serverHeaderName ];
 		}
-		else if ( isset( $_ENV[$envName] ) && $_ENV[$envName] !== '' ) {
-			return $_ENV[$envName];
+
+		if ( isset( $_ENV[ $envName ] ) && $_ENV[ $envName ] !== '' ) {
+			return $_ENV[ $envName ];
 		}
-		else {
-			return null;
-		}
+
+		return null;
 	}
 
 	private function updateContext() {
@@ -109,7 +113,7 @@ class WikiaTracer {
 				'span_id' => $this->spanId,
 				'parent_span_id' => $this->parentSpanId,
 				'trace_id' => $this->traceId,
-				'sjc_shields' => $this->sjcShields,
+				'sjc_shields_unhealthy' => $this->sjcShieldsHealthStatus,
 			] )
 		);
 		if ( $this->contextSource->getContext() !== $newContext ) {
@@ -310,7 +314,7 @@ class WikiaTracer {
 			self::LEGACY_TRACE_ID_HEADER_NAME => $this->traceId,
 			// pass the current span ID to the subrequest, it will be logged as parent_span_id there
 			self::PARENT_SPAN_ID_HEADER_NAME => $this->spanId,
-			self::SHIELDS_HEADER_NAME => $this->sjcShields,
+			self::SHIELDS_HEADER_NAME => $this->sjcShieldsHealthStatus,
 		] );
 	}
 
@@ -451,5 +455,16 @@ class WikiaTracer {
 		array_unshift( $path, sprintf( "%s %s %d %.6f", self::APPLICATION_NAME, wfHostname(), (int) $wgRequestTime, microtime( true ) - $wgRequestTime ) );
 
 		return sprintf( "(%s)", join( ' ', $path ) );
+	}
+
+	/**
+	 * Set the flag ONLY if backend is unhealthy (i.e. 0)
+	 * If the backend is healthy, remove it from stack (set to null, trimmed later by removeNullEntries
+	 * @see removeNullEntries
+	 */
+	private function getSjcShieldsStatus() {
+		return $this->getTraceEntry( self::SHIELDS_HEADER_NAME ) === self::SHIELDS_HEADER_STATUS_UNHEALTHY
+			? 1
+			: null;
 	}
 }


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-2466

- [x] If there is no header sent, lets just not include it in logs (It's sent only from SJC datacenter)	
- [x] Log only when header says backend is unhealthy

//cc
@Grunny @themech 