### PR TITLE
Platform-2547 fix the cronjob SwiftFileBackend errors

### DIFF
--- a/includes/filerepo/backend/FileBackend.php
+++ b/includes/filerepo/backend/FileBackend.php
@@ -1136,13 +1136,16 @@ abstract class FileBackendStore extends FileBackend {
 		}
 		$latest = !empty( $params['latest'] );
 		if ( isset( $this->cache[$path]['stat'] ) ) {
+			$stat = $this->cache[$path]['stat'];
 			// If we want the latest data, check that this cached
 			// value was in fact fetched with the latest available data.
-			if ( !$latest || !empty( $this->cache[$path]['stat']['latest'] ) ) {
-				wfProfileOut( __METHOD__ );
-				return $this->cache[$path]['stat'];
-			} elseif ( in_array( $this->cache[$path]['stat'], array( 'NOT_EXIST', 'NOT_EXIST_LATEST' ) ) ) {
-				if ( !$latest || $this->cache[$path]['stat'] === 'NOT_EXIST_LATEST' ) {
+			if ( is_array( $stat ) ) {
+				if ( !$latest || $stat['latest'] ) {
+					wfProfileOut( __METHOD__ );
+					return $stat;
+				}
+			} elseif ( in_array( $stat, array( 'NOT_EXIST', 'NOT_EXIST_LATEST' ) ) ) {
+				if ( !$latest || $stat === 'NOT_EXIST_LATEST' ) {
 					wfProfileOut( __METHOD__ );
 					return false;
 				}

--- a/includes/upload/UploadStash.php
+++ b/includes/upload/UploadStash.php
@@ -104,6 +104,7 @@ class UploadStash {
 			}
 
 			// create $this->files[$key]
+
 			$this->initFile( $key );
 
 			// fetch fileprops
@@ -113,7 +114,7 @@ class UploadStash {
 
 		if ( ! $this->files[$key]->exists() ) {
 			wfDebug( __METHOD__ . " tried to get file at $key, but it doesn't exist\n" );
-			throw new UploadStashBadPathException( "path doesn't exist" );
+			throw new UploadStashFileDoesntExistException( "path doesn't exist" );
 		}
 
 		if ( !$noAuth ) {
@@ -453,7 +454,6 @@ class UploadStash {
 		}
 
 		$this->fileMetadata[$key] = (array)$row;
-
 		return true;
 	}
 
@@ -512,7 +512,6 @@ class UploadStashFile extends UnregisteredLocalFile {
 				throw new UploadStashFileNotFoundException( 'cannot find path, or not a plain file' );
 			}
 		}
-
 		parent::__construct( false, $repo, $path, false );
 
 		$this->name = basename( $this->path );
@@ -631,7 +630,7 @@ class UploadStashFile extends UnregisteredLocalFile {
 	 * @return Status: success
 	 */
 	public function remove() {
-		if ( !$this->repo->fileExists( $this->path, FileRepo::FILES_ONLY ) ) {
+		if ( !$this->exists() ) {
 			// Maybe the file's already been removed? This could totally happen in UploadBase.
 			return true;
 		}
@@ -648,6 +647,7 @@ class UploadStashFile extends UnregisteredLocalFile {
 class UploadStashNotAvailableException extends MWException {};
 class UploadStashFileNotFoundException extends MWException {};
 class UploadStashBadPathException extends MWException {};
+class UploadStashFileDoesntExistException extends UploadStashBadPathException {};
 class UploadStashFileException extends MWException {};
 class UploadStashZeroLengthFileException extends MWException {};
 class UploadStashNotLoggedInException extends MWException {};

--- a/maintenance/cleanupUploadStash.php
+++ b/maintenance/cleanupUploadStash.php
@@ -67,10 +67,17 @@ class UploadStashCleanup extends Maintenance {
 		// UploadStash's own methods means it's less likely to fall accidentally
 		// out-of-date someday
 		$stash = new UploadStash( $repo );
-
 		foreach( $keys as $key ) {
 			try {
-				$stash->getFile( $key, true );
+				try {
+					$stash->getFile( $key, true );
+				} catch ( UploadStashFileDoesntExistException $ex ) {
+					/*
+					 * When the metadata is there but the file itself doesn't exist, it is safe
+					 * to proceed - the removeFileNoAuth method will remove the db entry and skip
+					 * the physical file removal.
+					 */
+				}
 				$stash->removeFileNoAuth( $key );
 			} catch ( UploadStashBadPathException $ex ) {
 				$this->output( "Failed removing stashed upload with key: $key\n"  );


### PR DESCRIPTION
While cleaning up the uploadstash table, we were logging exception when the physical file didn't exist anymore and ignored that db entry, so the list of abandoned entries (and logged exceptions) keeps growing over time. In this change I'm detecting the non-existing files and removing the db entry for those.