### PR TITLE
SUS-1290: In Autopromote skip edit count lookup if edit count condition is 0

### DIFF
--- a/includes/Autopromote.php
+++ b/includes/Autopromote.php
@@ -116,7 +116,11 @@ class Autopromote {
 				}
 				return false;
 			case APCOND_EDITCOUNT:
-				if ( !empty($wgEnableEditCountLocal) ) {
+				// Wikia change
+				// SUS-1290: If edit count condition is 0 skip edit count lookup
+				if ( $cond[1] === 0 ) {
+					return true;
+				} elseif ( !empty($wgEnableEditCountLocal) ) {
 					return $user->getEditCountLocal() >= $cond[1];
 				} else {
 					return $user->getEditCount() >= $cond[1];


### PR DESCRIPTION
Currently we perform edit count lookup in Autopromote even if 0 edits are required. Let's check for this case and skip it.

ticket: https://wikia-inc.atlassian.net/browse/SUS-1290