### PR TITLE
SUS-1226: remove legacy EditCommentsIndex hook

### DIFF
--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -935,20 +935,6 @@ class ArticleComment {
 		CommentsIndex::addCommentInfo( $commentTitleText, $title, $parentId );
 
 		$retVal = self::doSaveAsArticle( $text, $article, $user, $metadata );
-
-		if ( $retVal->value == EditPage::AS_SUCCESS_NEW_ARTICLE ) {
-			$commentsIndex = CommentsIndex::newFromId( $article->getID() );
-			if ( empty( $commentsIndex ) ) {
-				WikiaLogger::instance()->error( 'Empty commentsIndex', [
-					'method' => __METHOD__,
-					'parentId' => $parentId,
-					'commentTitleText' => $commentTitleText,
-				] );
-			} else {
-				Hooks::run( 'EditCommentsIndex', [ $article->getTitle(), $commentsIndex ] );
-			}
-		}
-
 		$res = ArticleComment::doAfterPost( $retVal, $article, $parentId );
 
 		ArticleComment::doPurge( $title, $commentTitle );

--- a/extensions/wikia/Wall/WallMessage.class.php
+++ b/extensions/wikia/Wall/WallMessage.class.php
@@ -1524,7 +1524,6 @@ class WallMessage {
 	private function updateParentLastComment( $useMaster, CommentsIndex $commentsIndex ) {
 		$lastChildCommentId = $commentsIndex->getParentLastCommentId( $useMaster );
 		$commentsIndex->updateParentLastCommentId( $lastChildCommentId );
-		wfRunHooks( 'EditCommentsIndex', [ $this->getTitle(), $commentsIndex ] );
 	}
 
 	protected function markInProps( $prop ) {


### PR DESCRIPTION
Code related to this hook is generating lots of errors. It appears however that this hook is no longer used, as all handlers are gone:
```
$ grep -r EditCommentsIndex .
./extensions/wikia/ArticleComments/classes/ArticleComment.class.php:				Hooks::run( 'EditCommentsIndex', [ $article->getTitle(), $commentsIndex ] );
./extensions/wikia/Wall/WallMessage.class.php:		wfRunHooks( 'EditCommentsIndex', [ $this->getTitle(), $commentsIndex ] );
```
Let's get rid of it.

ticket: https://wikia-inc.atlassian.net/browse/SUS-1226