### PR TITLE
SUS-1225: fix article comments permissions checks

### DIFF
--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -1589,7 +1589,7 @@ class ArticleComment {
 	 * @param Title $title
 	 * @param User $user
 	 * @param string $action
-	 * @param mixed $result False if user is not allowed to perform this action, true otherwise
+	 * @param bool|null $result False if user is not allowed to perform this action, true otherwise
 	 * @return bool False to abort checking hooks if action is forbidden, true otherwise
 	 */
 	static public function userCan( Title $title, User $user, string $action, &$result ): bool {
@@ -1607,7 +1607,6 @@ class ArticleComment {
 		$comment = static::newFromTitle( $title );
 		$isBlog = ( $wgEnableBlogArticles && static::isBlog( $title ) );
 
-		$result = true;
 		switch ( $action ) {
 			// Creating article comments requires 'commentcreate' permission
 			// For blogs, additionally check if the owner has enabled commenting+
@@ -1632,10 +1631,10 @@ class ArticleComment {
 				);
 				break;
 			default:
-				$result = true;
+				// we have no opinion
 		}
 
-		return $result;
+		return is_null( $result ) ? true : $result;
 	}
 
 	/**

--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -1589,62 +1589,53 @@ class ArticleComment {
 	 * @param Title $title
 	 * @param User $user
 	 * @param string $action
-	 * @param bool $result Whether $user can perform $action on $title
-	 * @return bool Whether to continue checking hooks
+	 * @param mixed $result False if user is not allowed to perform this action, true otherwise
+	 * @return bool False to abort checking hooks if action is forbidden, true otherwise
 	 */
-	static public function userCan( Title &$title, User &$user, $action, &$result ) {
-		$wg = F::app()->wg;
-		$commentsNS = $wg->ArticleCommentsNamespaces;
+	static public function userCan( Title $title, User $user, string $action, &$result ): bool {
+		global $wgArticleCommentsNamespaces, $wgEnableBlogArticles;
 		$ns = $title->getNamespace();
 
 		// Only handle article and blog comments
-		if ( !in_array( MWNamespace::getSubject( $ns ), $commentsNS ) ||
-			!ArticleComment::isTitleComment( $title ) ) {
+		if (
+			( MWNamespace::isTalk( $ns ) && !in_array( MWNamespace::getSubject( $ns ), $wgArticleCommentsNamespaces ) ) ||
+			!static::isTitleComment( $title )
+		) {
 			return true;
 		}
 
-		wfProfileIn( __METHOD__ );
+		$comment = static::newFromTitle( $title );
+		$isBlog = ( $wgEnableBlogArticles && static::isBlog( $title ) );
 
-		$comment = ArticleComment::newFromTitle( $title );
-		$isBlog = ( $wg->EnableBlogArticles && ArticleComment::isBlog( $title ) );
-
+		$result = true;
 		switch ( $action ) {
 			// Creating article comments requires 'commentcreate' permission
 			// For blogs, additionally check if the owner has enabled commenting+
 			case 'create':
 				// We have to check these permissions on the parent article
-				// due to the chicken-and-egg problem inherent in the design
-				$result = self::userCanCommentOn( $comment->getArticleTitle(), $user );
-				$return = false;
+				// (blog article owner could have disabled commenting)
+				$result = static::userCanCommentOn( $comment->getArticleTitle(), $user );
 				break;
 			// Article and blog comments can only be edited by their author,
 			// or an user with 'commentedit' permission
 			case 'edit':
-				// Prepopulate the object with revision data
-				// required by ArticleComment::isAuthor
 				$result = ( $comment->isAuthor( $user ) || $user->isAllowed( 'commentedit' ) );
-				$return = false;
 				break;
-
 			case 'move':
 			case 'move-target':
 				$result = $user->isAllowed( 'commentmove' );
-				$return = false;
 				break;
-
 			case 'delete':
 			case 'undelete':
 				$result = ( ArticleComment::isTitleComment( $title ) &&
 					( $user->isAllowed( 'commentdelete' ) || $isBlog && $user->isAllowed( 'blog-comments-delete' ) )
 				);
-				$return = false;
 				break;
 			default:
-				$result = $return = true;
+				$result = true;
 		}
 
-		wfProfileOut( __METHOD__ );
-		return $return;
+		return $result;
 	}
 
 	/**
@@ -1657,16 +1648,11 @@ class ArticleComment {
 	 * @return bool Whether $user can add a comment to $title
 	 */
 	static public function userCanCommentOn( Title $title, User $user = null ) {
-		$wg = F::app()->wg;
-		if ( !( $user instanceof User ) ) {
-			$user = $wg->User;
-		}
+		global $wgUser, $wgEnableBlogArticles;
 
-		if ( wfReadOnly() ) {
-			return false;
-		}
+		$user = $user ?? $wgUser;
 
-		$isBlog = ( $wg->EnableBlogArticles && ArticleComment::isBlog( $title ) );
+		$isBlog = ( $wgEnableBlogArticles && ArticleComment::isBlog( $title ) );
 		if ( $isBlog ) {
 			$props = BlogArticle::getProps( $title->getArticleID() );
 			$commentingEnabled = isset( $props[ 'commenting' ] ) ? (bool) $props[ 'commenting' ] : true;

--- a/extensions/wikia/ArticleComments/classes/ArticleCommentsAjax.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleCommentsAjax.class.php
@@ -28,7 +28,7 @@ class ArticleCommentsAjax {
 	 * @return String -- json-ized array
 	 */
 	static public function axSave() {
-		global $wgRequest, $wgUser, $wgTitle;
+		global $wgRequest, $wgUser;
 
 		$articleId = $wgRequest->getVal( 'article', false );
 		$commentId = $wgRequest->getVal( 'id', false );
@@ -49,11 +49,6 @@ class ArticleCommentsAjax {
 			return $errorResult;
 		}
 
-		// Return with error if we can't comment on the current title (wgTitle)
-		if ( !ArticleComment::userCanCommentOn( $wgTitle ) ) {
-			return $errorResult;
-		}
-
 		// Return with error if we can't create a new article comment
 		$comment = ArticleComment::newFromId( $commentId );
 		if ( empty( $comment ) ) {
@@ -62,11 +57,6 @@ class ArticleCommentsAjax {
 
 		// Return with error if we can't load the data for this comment
 		if ( !$comment->load( true ) ) {
-			return $errorResult;
-		}
-
-		// Return with error if we can't edit this comment
-		if ( !$comment->getTitle()->userCan( 'edit' ) ) {
 			return $errorResult;
 		}
 
@@ -117,10 +107,6 @@ class ArticleCommentsAjax {
 			return $result;
 		}
 
-		if ( !$comment->getTitle()->userCan( 'edit' ) ) {
-			return $result;
-		}
-
 		$result['error'] = 0;
 		$result['show'] = true;
 		$result['text'] = $comment->editPage();
@@ -155,17 +141,13 @@ class ArticleCommentsAjax {
 			return $result;
 		}
 
-		$canComment = ArticleComment::userCanCommentOn( $title );
+		$vars = [
+			'commentId' => $commentId,
+			'isMiniEditorEnabled' => ArticleComment::isMiniEditorEnabled(),
+			'stylePath' => $wgStylePath
+		];
 
-		if ( $canComment == true ) {
-			$vars = [
-				'commentId' => $commentId,
-				'isMiniEditorEnabled' => ArticleComment::isMiniEditorEnabled(),
-				'stylePath' => $wgStylePath
-			];
-
-			$result['html'] = F::app()->getView( 'ArticleComments', 'Reply', $vars )->render();
-		}
+		$result['html'] = F::app()->getView( 'ArticleComments', 'Reply', $vars )->render();
 
 		return $result;
 	}
@@ -192,7 +174,7 @@ class ArticleCommentsAjax {
 
 		$title = Title::newFromID( $articleId );
 
-		if ( !$title || !ArticleComment::userCanCommentOn( $title, $wgUser ) ) {
+		if ( !$title ) {
 			return $result;
 		}
 


### PR DESCRIPTION
AC permissions checks are run for parent pages of comments too, causing error.
- make sure only AC namespace is affected
- don't run permissions checks twice (core `EditPage` checks permissions and read-only state)

ticket: https://wikia-inc.atlassian.net/browse/SUS-1225