### PR TITLE
SUS-1306: handle invalid article IDs in Search transparently

### DIFF
--- a/extensions/wikia/Search/classes/MediaWikiService.php
+++ b/extensions/wikia/Search/classes/MediaWikiService.php
@@ -474,7 +474,7 @@ class MediaWikiService
 			if ( $page instanceof \Article ) {
 				$articleMatch = new \Wikia\Search\Match\Article( $title->getArticleId(), $this, $term );
 			} else {
-				\Wikia\Logger\WikiaLogger::instance()->info( 'SUS-1306 - Invalid article ID', [
+				\Wikia\Logger\WikiaLogger::instance()->warning( 'SUS-1306 - Invalid article ID', [
 					'exception' => new \BadTitleError(),
 					'articleId' => $articleId,
 					'ns' => $title->getNamespace(),

--- a/extensions/wikia/Search/classes/MediaWikiService.php
+++ b/extensions/wikia/Search/classes/MediaWikiService.php
@@ -4,6 +4,7 @@
  * @author relwell
  */
 namespace Wikia\Search;
+
 /**
  * Encapsulates MediaWiki functionalities.
  * This will allow us to abstract our behavior away from MediaWiki if we want.
@@ -469,8 +470,17 @@ class MediaWikiService
 		$title = $searchEngine->getNearMatch( $term );
 		$articleId = ( $title !== null ) ? $title->getArticleId() : 0;
 		if ( ( $articleId > 0 ) && ( in_array( $title->getNamespace(), $namespaces ) ) ) {
-			$this->getPageFromPageId( $articleId );
-			$articleMatch = new \Wikia\Search\Match\Article( $title->getArticleId(), $this ,$term);
+			$page = $this->getPageFromPageId( $articleId );
+			if ( $page instanceof \Article ) {
+				$articleMatch = new \Wikia\Search\Match\Article( $title->getArticleId(), $this, $term );
+			} else {
+				\Wikia\Logger\WikiaLogger::instance()->info( 'SUS-1306 - Invalid article ID', [
+					'exception' => new \BadTitleError(),
+					'articleId' => $articleId,
+					'ns' => $title->getNamespace(),
+					'titleText' => $title->getPrefixedText()
+				] );
+			}
 		}
 		return $articleMatch;
 	}
@@ -899,7 +909,7 @@ class MediaWikiService
 		$page = \Article::newFromID( $pageId );
 
 		if ( $page === null ) {
-			throw new \Exception( 'Invalid Article ID' );
+			return null;
 		}
 
 		$redirectTarget = null;

--- a/extensions/wikia/Search/classes/Test/MediaWikiServiceTest.php
+++ b/extensions/wikia/Search/classes/Test/MediaWikiServiceTest.php
@@ -1167,19 +1167,13 @@ class MediaWikiServiceTest extends BaseTest
 	 * @slowExecutionTime 0.14926 ms
 	 * @covers \Wikia\Search\MediaWikiService::getPageFromPageId
 	 */
-	public function testGetPageFromPageIdThrowsException() {
-		$this->mockClass( 'Article', null, 'newFromID' );
-		$get = new ReflectionMethod( '\Wikia\Search\MediaWikiService', 'getPageFromPageId' );
-		$get->setAccessible( true );
-		try {
-			$get->invoke( (new MediaWikiService), $this->pageId );
-		} catch ( \Exception $e ) {}
+	public function testGetPageFromPageIdReturnsNullIfInvalid() {
+		$service = new MediaWikiService();
 
-		$this->assertInstanceOf(
-				'\Exception',
-				$e,
-				'\Wikia\Search\MediaWikiService::getPageFromPageId should throw an exception when provided a nonexistent page id'
-		);
+		$method = new ReflectionMethod( MediaWikiService::class, 'getPageFromPageId' );
+		$method->setAccessible( true );
+
+		$this->assertNull( $method->invoke( $service, 0 ), 'MediaWikiService::getPageFromPageId returns null for invalid id' );
 	}
 
 	/**


### PR DESCRIPTION
Currently we throw exception if we encounter an invalid article ID in Search. Let's handle this case transparently and log more details to ELK to find out more about how this can happen.