### PR TITLE
SUS-1275 Add tracking of impressions for custom 404 pages

### DIFF
--- a/extensions/wikia/Custom404Page/scripts/Custom404Page.tracking.js
+++ b/extensions/wikia/Custom404Page/scripts/Custom404Page.tracking.js
@@ -11,6 +11,11 @@ require([
     });
 
     $(function () {
+        track({
+            action: tracker.ACTIONS.IMPRESSION,
+            label: 'alternative-suggestion-present'
+        });
+
         $('.noarticletext').on('click', '.alternative-suggestion', function(event) {
             track({
                 action: tracker.ACTIONS.CLICK,


### PR DESCRIPTION
Track impressions too, to be able to determine CTR on the found links as well as how many of those we actually serve.

//cc @mixth-sense @gabrys 