### PR TITLE
SUS-1135 | lazy-load ArticleComment metadata

### DIFF
--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -154,6 +154,11 @@ class ArticleComment {
 	 * @return string
 	 */
 	public function getMetadata( $key, $val = '' ) {
+		// mMetadata is lazy-loaded (possibly from cache)
+		if ( !is_array( $this->mMetadata ) ) {
+			$this->parseText();
+		}
+
 		return empty( $this->mMetadata[$key] ) ? $val: $this->mMetadata[$key];
 	}
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-1135

Wall message metadata were not lazy-loaded from cache by `WallMessage::getMetaTitle` calls resulting with messages having "no title" displayed on WikiActivity.

See #11874

@TK-999 