### PR TITLE
SUS-1308 - lookup phalanx using the prodTesting tag in production

### DIFF
--- a/extensions/wikia/PhalanxII/services/PhalanxService.class.php
+++ b/extensions/wikia/PhalanxII/services/PhalanxService.class.php
@@ -331,13 +331,14 @@ class PhalanxService extends Service {
 	}
 
 	private function getPhalanxUrl( $action ) {
-		global $wgConsulUrl, $wgConsulServiceTag, $wgPhalanxServiceUrl;
+		global $wgConsulUrl, $wgConsulServiceTag, $wgPhalanxServiceUrl, $wgWikiaEnvironment;
 
 		if ( !empty( $wgPhalanxServiceUrl ) ) {
 			// e.g. "localhost:4666"
 			$baseurl = $wgPhalanxServiceUrl;
 		} else {
-			$baseurl = ( new ConsulUrlProvider( $wgConsulUrl, $wgConsulServiceTag ) )
+			$tag = $wgWikiaEnvironment == WIKIA_ENV_PROD ? "prodTesting" : $wgConsulServiceTag;
+			$baseurl = ( new ConsulUrlProvider( $wgConsulUrl, $tag ) )
 				->getUrl( 'phalanx' );
 		}
 


### PR DESCRIPTION
@mixth-sense @macbre @garthwebb 
https://wikia-inc.atlassian.net/browse/SUS-1308

Change Phalanx client to resolve Phalanx using the `prodTesting` tag when in production. This will force usage of the Phalanx instances running in marathon. 

Note that this is meant to be temporary, and this code should be removed after phalanx has the `prod` tag in marathon.