### PR TITLE
SUS-932: log when WikiaDispatchableObject::setTokenMismatchError is called

### DIFF
--- a/includes/wikia/nirvana/WikiaDispatchableObject.class.php
+++ b/includes/wikia/nirvana/WikiaDispatchableObject.class.php
@@ -215,6 +215,11 @@ abstract class WikiaDispatchableObject extends WikiaObject {
 	}
 
 	protected function setTokenMismatchError() {
+		// SUS-932: log cases when there's a token mismatch
+		Wikia\Logger\WikiaLogger::instance()->error( __METHOD__, [
+			'exception' => new BadRequestException()
+		] );
+
 		$this->response->setValues( [
 			'status' => 'error',
 			'errormsg' => wfMessage( 'sessionfailure' )->escaped(),


### PR DESCRIPTION
This method is used by `MessageWall`, `Forum` and `UserProfilePage`.

https://wikia-inc.atlassian.net/browse/SUS-932

@TK-999 / @mixth-sense 