### PR TITLE
SUS-932: MemcacheSync: log calls to get and set methods to find which memcache operation causes OOM errors

### DIFF
--- a/extensions/wikia/WallNotifications/WallNotifications.class.php
+++ b/extensions/wikia/WallNotifications/WallNotifications.class.php
@@ -720,7 +720,12 @@ class WallNotifications {
 		$this->getDB( true )->delete( 'wall_notification' , $where, __METHOD__ );
 	}
 
-	protected function addNotificationLinkInternal( $userId, $wikiId, $notification ) {
+	/**
+	 * @param int $userId
+	 * @param int $wikiId
+	 * @param array $notification
+	 */
+	protected function addNotificationLinkInternal( $userId, $wikiId, Array $notification ) {
 		if ( $userId < 1 ) {
 			return;
 		}
@@ -1028,19 +1033,26 @@ class WallNotifications {
 		return $out;
 	}
 
-	public function storeInDB( $userId, $wikiId, $notification ) {
+	/**
+	 * @param int $userId
+	 * @param int $wikiId
+	 * @param array $notification
+	 */
+	private function storeInDB( $userId, $wikiId, Array $notification ) {
 		$notification['is_read'] = 0;
 		$notification['is_hidden'] = 0;
 		$notification['user_id'] = $userId;
 		$notification['wiki_id'] = $wikiId;
 
+		$dbw = $this->getDB( true );
+
+		$dbw->insert( 'wall_notification', $notification, __METHOD__ );
+		$dbw->commit();
+
 		WikiaLogger::instance()->info( 'New Wall Notification created', [
 			'wikiId' => $wikiId,
 			'userId' => $userId
 		] );
-
-		$this->getDB( true )->insert( 'wall_notification', $notification, __METHOD__ );
-		$this->getDB( true )->commit();
 	}
 
 	protected function getCache( $userId, $wikiId ) {

--- a/includes/wikia/MemcacheSync.class.php
+++ b/includes/wikia/MemcacheSync.class.php
@@ -9,6 +9,9 @@
  */
 
 class MemcacheSync{
+
+	use Wikia\Logger\Loggable;
+
 	/** @var MemcachedPhpBagOStuff */
 	var $memc = null;
 	var $key;
@@ -22,6 +25,12 @@ class MemcacheSync{
 		$this->key = $key;
 		$this->lockKey = wfSharedMemcKey('MemcacheSyncLock', $key);
 		$this->instance = uniqid ('', true);
+	}
+
+	protected function getLoggerContext() {
+		return [
+			'key' => $this->key,
+		];
 	}
 
 	function lock($time = 5) {
@@ -50,12 +59,14 @@ class MemcacheSync{
 		return $this->memc->get($this->lockKey, false);
 	}
 
-	function get($val = null) {
-		return $this->memc->get($this->key, $val);
+	function get() {
+		$this->debug( __METHOD__, [ 'exception' => new Exception() ] );
+		return $this->memc->get($this->key);
 	}
 
 	function set($val, $time = 0) {
 		if($this->isMy()) {
+			$this->debug( __METHOD__, [ 'exception' => new Exception() ] );
 			$this->memc->set($this->key, $val, $time);
 			return true;
 		} else {
@@ -64,10 +75,12 @@ class MemcacheSync{
 	}
 
 	function delete() {
+		$this->debug( __METHOD__, [ 'exception' => new Exception() ] );
 		$this->memc->delete($this->key);
 	}
 
 	protected function randomSleep( $max = 20 ) {
+		$this->debug( __METHOD__, [ 'exception' => new Exception() ] );
 		usleep( rand( 1, $max*1000 ) );
 	}
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-932

```
PHP Fatal Error: Allowed memory size of 536870912 bytes exhausted (tried to allocate 24576 bytes) in /usr/wikia/slot1/15083/src/includes/objectcache/MemcachedClient.php on line 1117
```

Additionally 	make `WallNotifications::storeInDB` a private method + type hinting

@mixth-sense 