### PR TITLE
SUS-1305 | SMWAdmin: we do not use job DB table for handling tasks queue

### DIFF
--- a/extensions/SemanticMediaWiki/includes/specials/SMW_SpecialSMWAdmin.php
+++ b/extensions/SemanticMediaWiki/includes/specials/SMW_SpecialSMWAdmin.php
@@ -74,18 +74,16 @@ class SMWAdmin extends SpecialPage {
 
 		$this->messageBuilder = $this->htmlFormRenderer->getMessageBuilder();
 
-		/**
-		$jobQueueLookup = $mwCollaboratorFactory->newJobQueueLookup( $this->getStore()->getConnection( 'mw.db' ) );
-		$row = $jobQueueLookup->selectJobRowFor( 'SMW\RefreshJob' );
-
-		if ( $row !== false ) { // similar to Job::pop_type, but without deleting the job
-			$title = Title::makeTitleSafe( $row->job_namespace, $row->job_title );
-			$blob = (string)$row->job_params !== '' ? unserialize( $row->job_params ) : false;
-			$refreshjob = Job::factory( $row->job_cmd, $title, $blob, $row->job_id );
-		} else {
-			$refreshjob = null;
-		}
-		**/
+		#$jobQueueLookup = $mwCollaboratorFactory->newJobQueueLookup( $this->getStore()->getConnection( 'mw.db' ) );
+		#$row = $jobQueueLookup->selectJobRowFor( 'SMW\RefreshJob' );
+		#
+		#if ( $row !== false ) { // similar to Job::pop_type, but without deleting the job
+		#	$title = Title::makeTitleSafe( $row->job_namespace, $row->job_title );
+		#	$blob = (string)$row->job_params !== '' ? unserialize( $row->job_params ) : false;
+		#	$refreshjob = Job::factory( $row->job_cmd, $title, $blob, $row->job_id );
+		#} else {
+		#	$refreshjob = null;
+		#}
 		$refreshjob = null; // Wikia change - we do not use job DB table for handling tasks queue (SUS-1305)
 
 		/**** Execute actions if any ****/

--- a/extensions/SemanticMediaWiki/includes/specials/SMW_SpecialSMWAdmin.php
+++ b/extensions/SemanticMediaWiki/includes/specials/SMW_SpecialSMWAdmin.php
@@ -74,6 +74,7 @@ class SMWAdmin extends SpecialPage {
 
 		$this->messageBuilder = $this->htmlFormRenderer->getMessageBuilder();
 
+		/**
 		$jobQueueLookup = $mwCollaboratorFactory->newJobQueueLookup( $this->getStore()->getConnection( 'mw.db' ) );
 		$row = $jobQueueLookup->selectJobRowFor( 'SMW\RefreshJob' );
 
@@ -84,6 +85,8 @@ class SMWAdmin extends SpecialPage {
 		} else {
 			$refreshjob = null;
 		}
+		**/
+		$refreshjob = null; // Wikia change - we do not use job DB table for handling tasks queue (SUS-1305)
 
 		/**** Execute actions if any ****/
 		switch ( $this->getRequest()->getText( 'action' ) ) {


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-1305

`$this->getStore()->getConnection( 'mw.db' )` returns connection to SMW cluster where there's no `job` table that is used by vanilla MediaWiki for handling tasks queue. We do not use so simply skip this piece of code.

@mixth-sense 