### PR TITLE
SUS-533 | SMW : move action=formedit to edit button dropdown in Oasis

### DIFF
--- a/skins/oasis/modules/PageHeaderController.class.php
+++ b/skins/oasis/modules/PageHeaderController.class.php
@@ -80,12 +80,7 @@ class PageHeaderController extends WikiaController {
 
 			$this->actionImage = MenuButtonController::ADD_ICON;
 			$this->actionName = 'addtopic';
-		} // "Edit with form" (SMW)
-		else if ( isset( $this->content_actions['formedit'] ) ) {
-			$this->action = $this->content_actions['formedit'];
-			$this->actionImage = MenuButtonController::EDIT_ICON;
-			$this->actionName = 'form-edit';
-		} // ve-edit
+		}  // ve-edit
 		else if ( isset( $this->content_actions['ve-edit'] ) && $this->content_actions['ve-edit']['main'] ) {
 			$this->action = $this->content_actions['ve-edit'];
 			$this->actionImage = MenuButtonController::EDIT_ICON;
@@ -124,6 +119,9 @@ class PageHeaderController extends WikiaController {
 			} else {
 				array_push( $editActions, 've-edit' );
 			}
+		}
+		if ( isset( $this->content_actions['formedit'] ) ) {
+			array_push( $editActions, 'formedit' ); // SUS-533
 		}
 
 		// items to be added to "edit" dropdown


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-533

Do not use `action=formedit` as the default action for the edit button in Oasis. Instead add it to the edit button dropdown.

@timmyquivy / @mixth-sense / @TK-999 