### PR TITLE
SUS-1313: improve Wall metadata handling

### DIFF
--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -138,10 +138,12 @@ class ArticleComment {
 	 * @param mixed $val
 	 */
 	public function setMetadata( $key, $val ) {
+		$this->loadMetadata();
 		$this->mMetadata[$key] = $val;
 	}
 
 	public function removeMetadata( $key ) {
+		$this->loadMetadata();
 		unset( $this->mMetadata[$key] );
 	}
 
@@ -154,12 +156,16 @@ class ArticleComment {
 	 * @return string
 	 */
 	public function getMetadata( $key, $val = '' ) {
+		$this->loadMetadata();
+		return empty( $this->mMetadata[$key] ) ? $val: $this->mMetadata[$key];
+	}
+
+	private function loadMetadata() {
 		// mMetadata is lazy-loaded (possibly from cache)
 		if ( !is_array( $this->mMetadata ) ) {
+			wfDebug(__METHOD__ . " - lazy-loading\n");
 			$this->parseText();
 		}
-
-		return empty( $this->mMetadata[$key] ) ? $val: $this->mMetadata[$key];
 	}
 
 	/**

--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -24,7 +24,7 @@ class ArticleComment {
 	public $mNamespace;
 
 	/** @var array */
-	public $mMetadata;
+	private $mMetadata;
 
 	private $mText = false; // parsed HTML
 	private $mRawtext; // wikitext

--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -163,7 +163,7 @@ class ArticleComment {
 	/**
 	 * @return array
 	 */
-	public function getAllMedata() {
+	public function getAllMetadata() {
 		$this->loadMetadata();
 		return $this->mMetadata;
 	}

--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -160,10 +160,18 @@ class ArticleComment {
 		return empty( $this->mMetadata[$key] ) ? $val: $this->mMetadata[$key];
 	}
 
+	/**
+	 * @return array
+	 */
+	public function getAllMedata() {
+		$this->loadMetadata();
+		return $this->mMetadata;
+	}
+
 	private function loadMetadata() {
 		// mMetadata is lazy-loaded (possibly from cache)
 		if ( !is_array( $this->mMetadata ) ) {
-			wfDebug(__METHOD__ . " - lazy-loading\n");
+			wfDebug(__METHOD__ . " - lazy-loading...\n");
 			$this->parseText();
 		}
 	}

--- a/extensions/wikia/Wall/WallHelper.class.php
+++ b/extensions/wikia/Wall/WallHelper.class.php
@@ -158,12 +158,11 @@ class WallHelper {
 				$item['wall-msg'] = wfMessage( 'wall-wiki-activity-on', $item['wall-title'], $item['wall-owner'] )->parse();
 			} else {
 			// child
+				/* @var WallMessage $parent */
 				$parent->load();
 
 				if ( !in_array( true, [ $parent->isRemove(), $parent->isAdminDelete() ] ) ) {
-					$title = wfMessage( 'wall-no-title' )->escaped(); // in case metadata does not include title field
-					if ( isset( $parent->mMetadata['title'] ) ) $title = $wmessage->getMetaTitle();
-					$this->mapParentData( $item, $parent, $title );
+					$this->mapParentData( $item, $parent );
 					$res['title'] = 'message-wall-thread-#' . $parent->getTitle()->getArticleID();
 					$item['wall-msg'] = wfMessage( 'wall-wiki-activity-on', $item['wall-title'], $item['wall-owner'] )->parse();
 				} else {
@@ -186,13 +185,11 @@ class WallHelper {
 	 * @brief Copies parent's informations to child item
 	 *
 	 * @param array $item a referance to an array with wall comment informations
-	 * @param ArticleComment $parent parent comment
-	 * @param Title $title title object instance
+	 * @param WallMessage $parent parent comment
 	 *
-	 * @author Andrzej 'nAndy' Åukaszewski
+	 * @author Andrzej 'nAndy' Łukaszewski
 	 */
-
-	private function mapParentData( &$item, $parent, $title ) {
+	private function mapParentData( Array &$item, WallMessage $parent ) {
 		wfProfileIn( __METHOD__ );
 
 		$metaTitle = $parent->getMetaTitle();

--- a/extensions/wikia/Wall/WallMessage.class.php
+++ b/extensions/wikia/Wall/WallMessage.class.php
@@ -329,7 +329,7 @@ class WallMessage {
 		wfProfileIn( __METHOD__ );
 		$body = $this->getArticleComment()->getRawText();
 
-		wfDebug( __METHOD__ . json_encode( $this->getArticleComment()->getAllMedata() ) . "\n" );
+		wfDebug( __METHOD__ . json_encode( $this->getArticleComment()->getAllMetadata() ) . "\n" );
 
 		$out = $this->doSaveComment( $body, $user, $summary, $force, true );
 		wfProfileOut( __METHOD__ );

--- a/extensions/wikia/Wall/WallMessage.class.php
+++ b/extensions/wikia/Wall/WallMessage.class.php
@@ -325,13 +325,12 @@ class WallMessage {
 		return $out;
 	}
 
-	public function doSaveMetadata( $user, $summary = '', $force = false ) {
+	protected function doSaveMetadata( $user, $summary = '', $force = false ) {
 		wfProfileIn( __METHOD__ );
-		// @todo: as getRawText overwrites the metadata, we have to make a copy of it
-		// this is done only to quickly fix case 102384, this whole thing should be refactored
-		$metadataCopy = $this->getArticleComment()->mMetadata;
-		$body = $this->getRawText( true );
-		$this->getArticleComment()->mMetadata = $metadataCopy;
+		$body = $this->getArticleComment()->getRawText();
+
+		wfDebug( __METHOD__ . json_encode( $this->getArticleComment()->getAllMedata() ) . "\n" );
+
 		$out = $this->doSaveComment( $body, $user, $summary, $force, true );
 		wfProfileOut( __METHOD__ );
 		return $out;
@@ -556,6 +555,7 @@ class WallMessage {
 	public function setNotifyEveryone( $notifyEveryone ) {
 		if ( $this->isMain() ) {
 			if ( !$this->isAllowedNotifyEveryone() ) {
+				wfDebug( __METHOD__ . " - is not allowed to notify everyone\n" );
 				return false;
 			}
 			$app = F::App();


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-1313

* lazy-load metadata when calling `ArticleComments` methods (introduce a private `loadMetadata` method)
* WallMessage: call `doSaveMetadata` method from `ArticleComment` instance that uses cached value and does not overwrite the existing metadata + make `ArticleComment::mMetadata` a private field
* WallHelper: `mapParentData` does not need the third argument - remove it and do not calculate its value in the caller

@mixth-sense / @TK-999 