### PR TITLE
FinishCreateWikiController: fix a PHP fatal

### DIFF
--- a/extensions/wikia/CreateNewWiki/FinishCreateWikiController.class.php
+++ b/extensions/wikia/CreateNewWiki/FinishCreateWikiController.class.php
@@ -71,8 +71,6 @@ class FinishCreateWikiController extends WikiaController {
 		$this->skipRendering();
 		$this->LoadState();
 
-		$mainPageTitleText = $wgSitename;
-
 		// SUS-563 debug
 		$mainPageMessageContent = wfMsgForContent( 'mainpage' );
 		$mediawikiMainPageArticleText = '';
@@ -109,7 +107,9 @@ class FinishCreateWikiController extends WikiaController {
 
 		// set description on main page
 		if(!empty($this->params['wikiDescription'])) {
-			$mainTitle = Title::newFromText( $mainPageTitleText );
+			global $wgSitename;
+
+			$mainTitle = Title::newFromText( $wgSitename );
 			$mainId = $mainTitle->getArticleID();
 			$mainArticle = Article::newFromID( $mainId );
 


### PR DESCRIPTION
`Error: Call to a member function getArticleID() on null in extensions/wikia/CreateNewWiki/FinishCreateWikiController.class.php:113`

https://wikia-inc.atlassian.net/browse/MAIN-8613

@mixth-sense 