### PR TITLE
SUS-1325: introduce exception class for stale results

### DIFF
--- a/extensions/wikia/Search/classes/MediaWikiService.php
+++ b/extensions/wikia/Search/classes/MediaWikiService.php
@@ -907,7 +907,7 @@ class MediaWikiService
 		$page = \Article::newFromID( $pageId );
 
 		if ( $page === null ) {
-			throw new StaleResultException( $pageId );
+			throw new StaleResultException( (string)$pageId );
 		}
 
 		$redirectTarget = null;

--- a/extensions/wikia/Search/classes/MediaWikiService.php
+++ b/extensions/wikia/Search/classes/MediaWikiService.php
@@ -476,10 +476,7 @@ class MediaWikiService
 				$articleMatch = new \Wikia\Search\Match\Article( $title->getArticleId(), $this, $term );
 			} catch ( StaleResultException $staleResultException ) {
 				\Wikia\Logger\WikiaLogger::instance()->warning( 'SUS-1306 - Invalid article ID', [
-					'exception' => $staleResultException,
-					'articleId' => $articleId,
-					'ns' => $title->getNamespace(),
-					'titleText' => $title->getPrefixedText()
+					'exception' => $staleResultException
 				] );
 			}
 		}
@@ -910,7 +907,7 @@ class MediaWikiService
 		$page = \Article::newFromID( $pageId );
 
 		if ( $page === null ) {
-			throw new StaleResultException();
+			throw new StaleResultException( $pageId );
 		}
 
 		$redirectTarget = null;

--- a/extensions/wikia/Search/classes/MediaWikiService.php
+++ b/extensions/wikia/Search/classes/MediaWikiService.php
@@ -4,6 +4,7 @@
  * @author relwell
  */
 namespace Wikia\Search;
+use Wikia\Search\Result\StaleResultException;
 
 /**
  * Encapsulates MediaWiki functionalities.
@@ -470,12 +471,12 @@ class MediaWikiService
 		$title = $searchEngine->getNearMatch( $term );
 		$articleId = ( $title !== null ) ? $title->getArticleId() : 0;
 		if ( ( $articleId > 0 ) && ( in_array( $title->getNamespace(), $namespaces ) ) ) {
-			$page = $this->getPageFromPageId( $articleId );
-			if ( $page instanceof \Article ) {
+			try {
+				$page = $this->getPageFromPageId( $articleId );
 				$articleMatch = new \Wikia\Search\Match\Article( $title->getArticleId(), $this, $term );
-			} else {
+			} catch ( StaleResultException $staleResultException ) {
 				\Wikia\Logger\WikiaLogger::instance()->warning( 'SUS-1306 - Invalid article ID', [
-					'exception' => new \BadTitleError(),
+					'exception' => $staleResultException,
 					'articleId' => $articleId,
 					'ns' => $title->getNamespace(),
 					'titleText' => $title->getPrefixedText()
@@ -898,7 +899,7 @@ class MediaWikiService
 	 * Standard interface for this class's services to access a page
 	 * @param int $pageId
 	 * @return \Article
-	 * @throws \Exception
+	 * @throws StaleResultException if page id does not belong to a valid article
 	 */
 	protected function getPageFromPageId( $pageId ) {
 		wfProfileIn( __METHOD__ );
@@ -909,7 +910,7 @@ class MediaWikiService
 		$page = \Article::newFromID( $pageId );
 
 		if ( $page === null ) {
-			return null;
+			throw new StaleResultException();
 		}
 
 		$redirectTarget = null;

--- a/extensions/wikia/Search/classes/Result/StaleResultException.php
+++ b/extensions/wikia/Search/classes/Result/StaleResultException.php
@@ -1,0 +1,4 @@
+<?php
+namespace Wikia\Search\Result;
+
+class StaleResultException extends \WikiaBaseException {}

--- a/extensions/wikia/Search/classes/Result/StaleResultException.php
+++ b/extensions/wikia/Search/classes/Result/StaleResultException.php
@@ -1,4 +1,4 @@
 <?php
 namespace Wikia\Search\Result;
 
-class StaleResultException extends \WikiaBaseException {}
+class StaleResultException extends \WikiaException {}

--- a/extensions/wikia/Search/classes/Test/MediaWikiServiceTest.php
+++ b/extensions/wikia/Search/classes/Test/MediaWikiServiceTest.php
@@ -7,6 +7,8 @@ namespace Wikia\Search\Test;
 use Wikia\Search\MediaWikiService;
 use \ReflectionProperty;
 use \ReflectionMethod;
+use Wikia\Search\Result\StaleResultException;
+
 /**
  * Tests the methods found in \Wikia\Search\MediaWikiService
  * @author relwell
@@ -1167,13 +1169,14 @@ class MediaWikiServiceTest extends BaseTest
 	 * @slowExecutionTime 0.14926 ms
 	 * @covers \Wikia\Search\MediaWikiService::getPageFromPageId
 	 */
-	public function testGetPageFromPageIdReturnsNullIfInvalid() {
+	public function testGetPageFromPageIdThrowsExceptionIfInvalid() {
 		$service = new MediaWikiService();
 
 		$method = new ReflectionMethod( MediaWikiService::class, 'getPageFromPageId' );
 		$method->setAccessible( true );
 
-		$this->assertNull( $method->invoke( $service, 0 ), 'MediaWikiService::getPageFromPageId returns null for invalid id' );
+		$this->setExpectedException( StaleResultException::class );
+		$method->invoke( $service, 0 );
 	}
 
 	/**


### PR DESCRIPTION
Remain consistent in handling invalid cases - introduce an unique exception for the edge case where a stale page id is passed to search service

ticket: https://wikia-inc.atlassian.net/browse/SUS-1325