### PR TITLE
CAKE-900 In-line the design system sprite for the contribution prototype embedding

### DIFF
--- a/extensions/wikia/ContributionPrototype/CPArticleRenderer.php
+++ b/extensions/wikia/ContributionPrototype/CPArticleRenderer.php
@@ -71,6 +71,12 @@ class CPArticleRenderer {
 	private function addScripts(OutputPage $output) {
 		$output->addScript("<script src=\"{$this->publicHost}/public/assets/vendor.dll.js\"></script>");
 		$output->addScript("<script src=\"{$this->publicHost}/public/assets/app.js\"></script>");
+
+		// This is not the intended use of renderSvg but it conveniently does what we want because
+		// the sprite is stored alongside the individual SVGs. The alternative would be to provide
+		// a "correct" mechanism for loading the sprite via the DesignSystem directly (lazy?). Note
+		// that this in-lines the whole thing into the page.
+		$output->addHTML(\DesignSystemHelper::renderSvg('sprite'));
 	}
 
 	private function getArticleContent($title) {


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CAKE-900

In-line the design system sprite for the CP article views. Direct sprite loading/inlining is not currently provided by the DS so are leveraging `renderSvg` to slurp in the contents of `sprite.svg` and dump it onto the page.

The work we are doing for [CAKE-83](https://wikia-inc.atlassian.net/browse/CAKE-83) is experimental so I think this is ok as a short term solution.

/cc @Wikia/cake @vforge 