### PR TITLE
ADEN-4322 Stop indexing part of our content

### DIFF
--- a/skins/oasis/modules/templates/Body_Index.php
+++ b/skins/oasis/modules/templates/Body_Index.php
@@ -95,7 +95,8 @@
 						<br />
 						<h3><?= wfMessage('arecovery-blocked-message-part-one')->escaped() ?>
 							<br /><br />
-							<?= wfMessage('arecovery-blocked-message-part-two')->escaped() ?></h3>
+							<?= wfMessage('arecovery-blocked-message-part-two')->escaped() ?>
+						</h3>
 					</div>
 				<?php } ?>
 				<div id="WikiaArticle" class="WikiaArticle">

--- a/skins/oasis/modules/templates/Body_Index.php
+++ b/skins/oasis/modules/templates/Body_Index.php
@@ -90,6 +90,7 @@
 					<div id="contentSub"><?= $subtitle ?></div>
 				<?php } ?>
 				<?php if ( ARecoveryModule::isLockEnabled() ) { ?>
+					<!--googleoff: all-->
 					<div id="WikiaArticleMsg">
 						<h2><?= wfMessage('arecovery-blocked-message-headline')->escaped() ?></h2>
 						<br />
@@ -98,6 +99,7 @@
 							<?= wfMessage('arecovery-blocked-message-part-two')->escaped() ?>
 						</h3>
 					</div>
+					<!--googleon: all-->
 				<?php } ?>
 				<div id="WikiaArticle" class="WikiaArticle">
 					<div class="home-top-right-ads">


### PR DESCRIPTION
https://perishablepress.com/tell-google-to-not-index-certain-parts-of-your-page/

In order not to display the message addressed to users who use ad blocking software in Google Search results, we added `googleoff` and `googleon` tags.

//cc @gabrys @saipetch 