### PR TITLE
RECIRC 236: Add Liftigniter as a data provider for RECIRCULATION_MIX test

### DIFF
--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -147,6 +147,7 @@ $config['recirculation_js'] = [
 		'//extensions/wikia/Recirculation/js/helpers/DiscussionsHelper.js',
 		'//extensions/wikia/Recirculation/js/helpers/CakeRelatedContentHelper.js',
 		'//extensions/wikia/Recirculation/js/helpers/CuratedContentHelper.js',
+		'//extensions/wikia/Recirculation/js/helpers/LiftigniterHelper.js',
 		'//extensions/wikia/Recirculation/js/views/incontent.js',
 		'//extensions/wikia/Recirculation/js/views/rail.js',
 		'//extensions/wikia/Recirculation/js/views/footer.js',

--- a/extensions/wikia/Recirculation/js/experiments/mix.js
+++ b/extensions/wikia/Recirculation/js/experiments/mix.js
@@ -4,6 +4,7 @@ require([
 	'wikia.log',
 	'ext.wikia.recirculation.utils',
 	'ext.wikia.recirculation.discussions',
+	'ext.wikia.recirculation.helpers.liftigniter',
 	require.optional('videosmodule.controllers.rail')
 ], function (
 	$,
@@ -11,6 +12,7 @@ require([
 	log,
 	utils,
 	discussions,
+	liftigniter,
 	videosModule
 ) {
 	/**
@@ -22,7 +24,7 @@ require([
 	 *  var recircExperiment = [
 	 *  	{
 	 *  		id: 'unique identifier - only used if you want to use data across multiple views',
-	 *  		sorce: 'the id you want to use for data - only used if you want to use data across multiple views',
+	 *  		source: 'the id you want to use for data - only used if you want to use data across multiple views',
 	 *  		placement: 'name of the view',
 	 *  		helper: 'name of the helper',
 	 *  		options: {
@@ -37,8 +39,10 @@ require([
 	var recircExperiment = w.recircExperiment || false,
 		experimentName = 'RECIRCULATION_MIX',
 		logGroup = 'ext.wikia.recirculation.experiments.mix',
-		views = {},
-		saved = {};
+		views = {}, // Each view holds an array of promises used to gather data for that view
+		saved = {}, // Saved data to be used across multiple views
+		completed = [], // An array of promises to keep track of which views have completed rendering
+		liftigniterHelpers = {};
 
 	if (!recircExperiment || w.wgContentLanguage !== 'en') {
 		if (videosModule) {
@@ -58,17 +62,31 @@ require([
 		}
 
 		if (experiment.helper) {
-			var helperString = 'ext.wikia.recirculation.helpers.' + experiment.helper;
-
-			require([helperString], function (helper) {
-				helper(experiment.options).loadData()
+			if (experiment.helper === 'liftigniter') {
+				// Liftigniter works differently than the other helpers in that it doesn't actually do anything until
+				// 'fetch' is called. Because fetch can only be called once per page, we need to make sure to use
+				// `loadData` before it is called at the bottom of this script.
+				liftigniterHelpers[experiment.id] = liftigniter(experiment.options);
+				liftigniterHelpers[experiment.id].loadData()
 					.done(function (data) {
 						deferred.resolve(data);
 					})
 					.fail(function (err) {
 						deferred.reject(err);
 					});
-			});
+			} else {
+				var helperString = 'ext.wikia.recirculation.helpers.' + experiment.helper;
+
+				require([helperString], function (helper) {
+					helper(experiment.options).loadData()
+						.done(function (data) {
+							deferred.resolve(data);
+						})
+						.fail(function (err) {
+							deferred.reject(err);
+						});
+				});
+			}
 		}
 
 		if (experiment.source && saved[experiment.source]) {
@@ -87,12 +105,15 @@ require([
 		views[experiment.placement].push(deferred);
 	});
 
-	$.each(views, function (key, value) {
-		var viewString = 'ext.wikia.recirculation.views.' + key;
+	$.each(views, function (key, promises) {
+		var viewString = 'ext.wikia.recirculation.views.' + key,
+			deferred = $.Deferred();
+
+		completed.push(deferred);
 
 		log('Initializing View: ' + key, 'info', logGroup);
 		require([viewString], function (viewFactory) {
-			$.when.apply($, value)
+			$.when.apply($, promises)
 				.done(function () {
 					var view = viewFactory(),
 						args = Array.prototype.slice.call(arguments),
@@ -118,9 +139,12 @@ require([
 					data.items = utils.ditherResults(data.items, 4);
 
 					view.render(data)
-						.then(view.setupTracking(experimentName));
+						.then(view.setupTracking(experimentName))
+						.then(deferred.resolve);
 				})
-				.fail(handleError(key));
+				.fail(handleError(key), function() {
+					deferred.reject(key);
+				});
 		});
 	});
 

--- a/extensions/wikia/Recirculation/js/experiments/mix.js
+++ b/extensions/wikia/Recirculation/js/experiments/mix.js
@@ -142,13 +142,29 @@ require([
 						.then(view.setupTracking(experimentName))
 						.then(deferred.resolve);
 				})
-				.fail(handleError(key), function() {
+				.fail(handleError(key), function () {
 					deferred.reject(key);
 				});
 		});
 	});
 
-	function handleError(placement) {
+	$.when.apply($, completed)
+		.done(function () {
+			log('Finished rendering recirculation', 'info', logGroup);
+
+			$.each(liftigniterHelpers, function (key, helper) {
+				helper.setupTracking();
+			});
+		})
+		.fail(function (placement) {
+			log('Error running recirc at: ' + placement, 'info', logGroup);
+		});
+
+	if (w.$p && Object.keys(liftigniterHelpers).length > 0) {
+		w.$p('fetch');
+	}
+
+	function handleError (placement) {
 		return function (errorMessage) {
 			log(errorMessage, 'info', logGroup);
 

--- a/extensions/wikia/Recirculation/js/helpers/LiftigniterHelper.js
+++ b/extensions/wikia/Recirculation/js/helpers/LiftigniterHelper.js
@@ -1,0 +1,87 @@
+define('ext.wikia.recirculation.helpers.liftigniter', [
+	'jquery',
+	'wikia.window',
+	'wikia.thumbnailer'
+], function ($, w, thumbnailer) {
+	'use strict';
+
+	var helper = function (config) {
+		var defaults = {
+				max: 5,
+				width: 320,
+				height: 180
+			},
+			options = $.extend({}, defaults, config);
+
+		function loadData() {
+			var deferred = $.Deferred(),
+				registerOptions = {
+					max: options.max * 2, // We want to load twice as many because we filter based on thumbnails
+					widget: options.widget,
+					callback: function (response) {
+						deferred.resolve(formatData(response));
+					}
+				};
+
+			if (!w.$p) {
+				return deferred.reject('Liftigniter library not found').promise();
+			}
+
+			if (options.opts) {
+				registerOptions.opts = options.opts;
+			}
+
+			// Callback renders and injects results into the placeholder.
+			w.$p('register', registerOptions);
+
+			return deferred.promise();
+		}
+
+		function formatData(data) {
+			var items = [],
+				title = '';
+
+			$.each(data.items, function (index, item) {
+				if (items.length < options.max && item.thumbnail) {
+					item.source = options.source;
+
+					if (item.source === 'wiki') {
+						item.thumbnail = thumbnailer
+							.getThumbURL(item.thumbnail, 'image', options.width, options.height);
+					}
+
+					item.meta = options.widget;
+
+					item.index = index;
+					items.push(item);
+				}
+			});
+
+			return {
+				title: title,
+				items: items
+			};
+		}
+
+		function setupTracking() {
+			var elements = $('.recirculation-unit .item[data-meta="' + options.widget + '"]').get(),
+				trackOptions = {
+					elements: elements,
+					name: options.widget,
+					source: 'LI'
+				};
+
+			if (options.opts) {
+				trackOptions.opts = options.opts;
+			}
+			w.$p('track', trackOptions);
+		}
+
+		return {
+			setupTracking: setupTracking,
+			loadData: loadData
+		};
+	};
+
+	return helper;
+});

--- a/extensions/wikia/Recirculation/js/helpers/LiftigniterHelper.js
+++ b/extensions/wikia/Recirculation/js/helpers/LiftigniterHelper.js
@@ -9,7 +9,8 @@ define('ext.wikia.recirculation.helpers.liftigniter', [
 		var defaults = {
 				max: 5,
 				width: 320,
-				height: 180
+				height: 180,
+				flush: false
 			},
 			options = $.extend({}, defaults, config);
 
@@ -33,6 +34,10 @@ define('ext.wikia.recirculation.helpers.liftigniter', [
 
 			// Callback renders and injects results into the placeholder.
 			w.$p('register', registerOptions);
+
+			if (options.flush) {
+				w.$p('fetch');
+			}
 
 			return deferred.promise();
 		}

--- a/extensions/wikia/Recirculation/js/views/rail.js
+++ b/extensions/wikia/Recirculation/js/views/rail.js
@@ -16,7 +16,7 @@ define('ext.wikia.recirculation.views.rail', [
 		return curated.injectContent(data)
 			.then(renderTemplate('rail.mustache'))
 			.then(utils.waitForRail)
-			.then(function($html) {
+			.then(function ($html) {
 				if (options.before) {
 					$html = options.before($html);
 				}
@@ -29,17 +29,18 @@ define('ext.wikia.recirculation.views.rail', [
 	}
 
 	function renderTemplate(templateName) {
-		return function(data) {
+		return function (data) {
+			data.title = data.title || $.msg('recirculation-fandom-title');
 			data.items = data.items.slice(0, 5);
 			return utils.renderTemplate(templateName, data);
 		};
 	}
 
 	function setupTracking(experimentName) {
-		return function($html) {
+		return function ($html) {
 			tracker.trackVerboseImpression(experimentName, 'rail');
 
-			$html.on('mousedown', 'a', function() {
+			$html.on('mousedown', 'a', function () {
 				tracker.trackVerboseClick(experimentName, utils.buildLabel(this, 'rail'));
 			});
 
@@ -47,7 +48,7 @@ define('ext.wikia.recirculation.views.rail', [
 		};
 	}
 
-	return function(config) {
+	return function (config) {
 		$.extend(options, config);
 
 		return {

--- a/extensions/wikia/Recirculation/js/views/scroller.js
+++ b/extensions/wikia/Recirculation/js/views/scroller.js
@@ -15,7 +15,9 @@ define('ext.wikia.recirculation.views.scroller', [
 			return deferred.reject('Recirculation scroller widget not shown - Not enough sections in article');
 		}
 
-		utils.renderTemplate('scroller.mustache', data).then(function($html) {
+		data.title = data.title || $.msg('recirculation-incontent-title');
+
+		utils.renderTemplate('scroller.mustache', data).then(function ($html) {
 			section.before($html);
 
 			var scroller = $html.find('.items-container').perfectScrollbar({
@@ -23,7 +25,7 @@ define('ext.wikia.recirculation.views.scroller', [
 				}),
 				scrollAmount = $html.find('.item').outerWidth(true) * 3;
 
-			$html.find('.scroller-arrow').click(function() {
+			$html.find('.scroller-arrow').click(function () {
 				var direction = $(this).data('direction'),
 					currentScrollLeft = scroller.scrollLeft(),
 					scroll;
@@ -40,7 +42,6 @@ define('ext.wikia.recirculation.views.scroller', [
 				scroller.perfectScrollbar('update');
 			});
 
-
 			deferred.resolve($html);
 		});
 
@@ -48,16 +49,16 @@ define('ext.wikia.recirculation.views.scroller', [
 	}
 
 	function setupTracking(experimentName) {
-		return function($html) {
+		return function ($html) {
 			tracker.trackVerboseImpression(experimentName, 'scroller');
 
-			$html.on('mousedown', 'a', function() {
+			$html.on('mousedown', 'a', function () {
 				tracker.trackVerboseClick(experimentName, utils.buildLabel(this, 'scroller'));
 			});
 		};
 	}
 
-	return function() {
+	return function () {
 		return {
 			render: render,
 			setupTracking: setupTracking

--- a/extensions/wikia/Recirculation/styles/rail.scss
+++ b/extensions/wikia/Recirculation/styles/rail.scss
@@ -2,7 +2,7 @@
 @import 'skins/shared/mixins/transform';
 
 .WikiaRail .recirculation-rail {
-	.rail-item {
+	.item {
 		margin-bottom: 15px;
 	}
 

--- a/extensions/wikia/Recirculation/templates/client/impactFooter.mustache
+++ b/extensions/wikia/Recirculation/templates/client/impactFooter.mustache
@@ -2,7 +2,12 @@
 	<h2>{{i18n.title}}</h2>
 	<div class="items">
 		{{#items}}
-			<div class="item item-{{source}}{{#isVideo}} is-video{{/isVideo}}" data-index="{{index}}" data-source="{{source}}">
+			<div class="item item-{{source}}{{#isVideo}} is-video{{/isVideo}}"
+				data-index="{{index}}"
+				data-source="{{source}}"
+				{{#id}} data-id="{{id}}" {{/id}}
+				{{#meta}} data-meta="{{meta}}" {{/meta}}
+			>
 				<a title="{{title}}" href="{{url}}" class="track-items">
 					<div class="thumbnail placeholder-thumbnail">
 						{{#thumbnail}}

--- a/extensions/wikia/Recirculation/templates/client/rail.mustache
+++ b/extensions/wikia/Recirculation/templates/client/rail.mustache
@@ -2,7 +2,13 @@
 	<h2>{{title}}</h2>
 	<ul class="thumbnails">
 		{{#items}}
-			<li class="rail-item {{classes}} item-{{source}}{{#isVideo}} is-video{{/isVideo}}" {{#id}} data-id="{{id}}" {{/id}} data-flag="{{flag}}" data-index="{{index}}" data-source="{{source}}">
+			<li class="item item-{{source}}{{#isVideo}} is-video{{/isVideo}}"
+				data-flag="{{flag}}"
+				data-index="{{index}}"
+				data-source="{{source}}"
+				{{#id}} data-id="{{id}}" {{/id}}
+				{{#meta}} data-meta="{{meta}}" {{/meta}}
+			>
 				<a href="{{url}}">
 					<div class="image image-thumbnail placeholder-thumbnail fluid small">
 						{{#thumbnail}}

--- a/extensions/wikia/Recirculation/templates/client/scroller.mustache
+++ b/extensions/wikia/Recirculation/templates/client/scroller.mustache
@@ -4,7 +4,12 @@
 	<div class="items-container">
 		<div class="items">
 			{{#items}}
-			<div class="item {{#isVideo}} is-video{{/isVideo}}" data-index="{{index}}" data-source="{{source}}">
+			<div class="item item-{{source}}{{#isVideo}} is-video{{/isVideo}}"
+				data-index="{{index}}"
+				data-source="{{source}}"
+				{{#id}} data-id="{{id}}" {{/id}}
+				{{#meta}} data-meta="{{meta}}" {{/meta}}
+			>
 				<a title="{{title}}" href="{{url}}">
 					<div class="thumbnail placeholder-thumbnail">
 						{{#thumbnail}}


### PR DESCRIPTION
Going forward Liftigniter will be our primary data provider for recirculation. Since we want to do a staged roll-out, we are using our RECIRCULATION_MIX test so we can measure performance as we go against our established controls.

Example configuration:

```js
var recircExperiment = [
	// The first two configurations are setting up the actual helpers. `fandom` 
	// loads data and places it directly in the rail and `wiki` just loads data 
	// to be used later. In the context of the code, these first two
	// configurations are what actually call `loadData` on the liftigniter
	// helper and register the API calls
	{
		id: 'fandom',
		placement: 'rail',
		helper: 'liftigniter',
		options: {
			max: 12,
			widget: 'fandom-rec',
			source: 'fandom',
			opts: {
				resultType:'cross-domain',
				domainType:'fandom.wikia.com'
			}
		}
	},
	{
		id: 'wiki',
		helper: 'liftigniter',
		options: {
			max: 17,
			widget: 'in-wiki',
			source: 'wiki'
		}
	},
	// The next three configurations are just placing the data that was already 
	// loaded. Two of them are for placing `wiki` data in the scroller and
	// impactFooter and the other one is just for placing `fandom` data in
	// the impactFooter
	{
		source: 'wiki',
		placement: 'scroller',
		options: {
			limit: 12
		}
	},
	{
		source: 'wiki',
		placement: 'impactFooter',
		options: {
			offset: 12,
		}
	},
	{
		source: 'fandom',
		placement: 'impactFooter',
		options: {
			offset: 5,
		}
	}
];
```