### PR TITLE
WW-634: Prepare page header prototype to release

### DIFF
--- a/extensions/wikia/RWEPageHeader/RWEPageHeaderController.class.php
+++ b/extensions/wikia/RWEPageHeader/RWEPageHeaderController.class.php
@@ -3,6 +3,8 @@
 class RWEPageHeaderController extends WikiaController {
 
 	public function index() {
+		OasisController::addBodyClass( 'rwe-page-header-experiment' );
+
 		$this->searchModel = $this->getSearchData();
 		$this->discussTabLink = $this->getDiscussTabLink();
 	}

--- a/extensions/wikia/RWEPageHeader/scripts/rwe-page-header.js
+++ b/extensions/wikia/RWEPageHeader/scripts/rwe-page-header.js
@@ -1,7 +1,8 @@
 require(['wikia.window', 'jquery', 'wikia.tracker'], function (window, $, tracker) {
 	'use strict';
 
-	var track = function (data) {
+	var experimentName = 'PAGE_HEADER_RDPS_EXPERIMENT',
+		track = function (data) {
 		tracker.track(window.Object.assign({
 			action: tracker.ACTIONS.CLICK,
 			category: 'rwe-page-header',
@@ -74,9 +75,13 @@ require(['wikia.window', 'jquery', 'wikia.tracker'], function (window, $, tracke
 	}
 
 	$(function () {
-		addWordmarkTracking();
-		initReadDropdown();
-		moveBannerNotifications();
-		openChatWindowOnClick();
+		var experimentGroup = window.Wikia.AbTest.getGroup(experimentName);
+
+		if (experimentGroup === 'TEST_1' || experimentName === 'TEST_2') {
+			addWordmarkTracking();
+			initReadDropdown();
+			moveBannerNotifications();
+			openChatWindowOnClick();
+		}
 	});
 });

--- a/extensions/wikia/RWEPageHeader/scripts/rwe-page-header.js
+++ b/extensions/wikia/RWEPageHeader/scripts/rwe-page-header.js
@@ -83,7 +83,7 @@ require(['wikia.window', 'jquery', 'wikia.tracker'], function (window, $, tracke
 	$(function () {
 		var experimentGroup = window.Wikia.AbTest.getGroup(experimentName);
 
-		if (experimentGroup === 'TEST_1' || experimentName === 'TEST_2') {
+		if (experimentGroup === 'RDPS_HEADER_1' || experimentName === 'RDPS_HEADER_2') {
 			addWordmarkTracking();
 			initReadDropdown();
 			moveBannerNotifications();

--- a/extensions/wikia/RWEPageHeader/styles/index.scss
+++ b/extensions/wikia/RWEPageHeader/styles/index.scss
@@ -6,10 +6,6 @@
 @import 'skins/oasis/css/core/breakpoints-variables';
 @import 'skins/oasis/css/core/layout';
 
-.WikiaPageHeader .header-container {
-	border: 0;
-}
-
 .WikiaPage:before {
 	border-top: $content-spacing-large solid $color-buttons;
 	content: '.';
@@ -20,17 +16,8 @@
 	z-index: -2;
 }
 
-.WikiaPage {
-	margin-top: $content-spacing-great-minus;
-}
-
-.WikiHeader {
+.RWEPageHeader {
 	display: none;
-}
-
-.banner-notifications-wrapper {
-	position: relative;
-	z-index: 30;
 }
 
 @media #{$breakpoint-small-only} {

--- a/skins/oasis/modules/templates/Body_Index.php
+++ b/skins/oasis/modules/templates/Body_Index.php
@@ -37,10 +37,11 @@
 				echo $app->renderView( 'WikiHeader', 'Index' );
 			}
 		?>
-		<!--TODO: show it only if extension enabled -->
-		<div class="RWEPageHeader">
-			<?= $app->renderView( 'RWEPageHeader', 'index') ?>
-		</div>
+		<?php if ( !empty( $wg->EnablePageHeaderExperiment ) && empty( $wg->SuppressWikiHeader ) ): ?>
+			<div class="RWEPageHeader">
+				<?= $app->renderView( 'RWEPageHeader', 'index') ?>
+			</div>
+		<?php endif ?>
 
 		<?php
 			if ( !empty( $wg->EnableWikiAnswers ) ) {


### PR DESCRIPTION
Some styles moved to AB test styles:
* Original:
`.rwe-page-header-experiment .WikiaPage:before { display: none; }`
* Test:
```
.rwe-page-header-experiment #WikiHeader { display: none; }
.rwe-page-header-experiment .RWEPageHeader { display: block; }
.rwe-page-header-experiment .WikiaPage { margin-top: 32px; }
.rwe-page-header-experiment .WikiaPageHeader .header-container { border: 0; }
.rwe-page-header-experiment .banner-notifications-wrapper {
	position: relative;
	z-index: 30;
}
```

To force one of the group on devbox add to url:
`?AbTest.PAGE_HEADER_RDPS_EXPERIMENT=ORIGINAL_1` or
`?AbTest.PAGE_HEADER_RDPS_EXPERIMENT=RDPS_HEADER_1`

@Wikia/west-wing 