### PR TITLE
SEO-538 Fix old XML sitemaps

### DIFF
--- a/extensions/wikia/Sitemap/SpecialSitemap_body.php
+++ b/extensions/wikia/Sitemap/SpecialSitemap_body.php
@@ -71,12 +71,13 @@ class SitemapPage extends UnlistedSpecialPage {
 	public function execute( $subpage ) {
 		global $wgMemc, $wgRequest, $wgOut, $wgEnableSitemapXmlExt, $wgSitemapXmlExposeInRobots;
 
+		$showIndex = strpos( $subpage, '-index.xml' ) !== false;
 		$isNewSitemapDefault = !empty( $wgEnableSitemapXmlExt ) && !empty( $wgSitemapXmlExposeInRobots );
 
 		$forceOldSitemap = strpos( $subpage, '-oldsitemapxml-' ) !== false;
 		$forceNewSitemap = strpos( $subpage, '-newsitemapxml-' ) !== false;
 
-		if ( ( $isNewSitemapDefault && !$forceOldSitemap ) || $forceNewSitemap ) {
+		if ( ( $showIndex && $isNewSitemapDefault && !$forceOldSitemap ) || $forceNewSitemap ) {
 			if ( empty( $wgEnableSitemapXmlExt ) ) {
 				$this->print404();
 				return;


### PR DESCRIPTION
The logic implemented in previous commits marked SEO-538 was to chose the "default" XML sitemap: old or new.

That logic should have been applied only to sitemap indexes and unfortunately was applied to both the index and the single sitemap pages.

This fix makes the new/old decision based on wg vars only for sitemap-(*sitemapxml-)index.xml, while the URL itself defines the new/old sitemap logic for single sitemap pages (as used to be the case).