### PR TITLE
release-463-SUS-1403 | Remove page id from StaleResultException message

### DIFF
--- a/extensions/wikia/Search/classes/MediaWikiService.php
+++ b/extensions/wikia/Search/classes/MediaWikiService.php
@@ -907,7 +907,7 @@ class MediaWikiService
 		$page = \Article::newFromID( $pageId );
 
 		if ( $page === null ) {
-			throw new StaleResultException( (string)$pageId );
+			throw new StaleResultException();
 		}
 
 		$redirectTarget = null;

--- a/extensions/wikia/Search/classes/MediaWikiService.php
+++ b/extensions/wikia/Search/classes/MediaWikiService.php
@@ -907,7 +907,11 @@ class MediaWikiService
 		$page = \Article::newFromID( $pageId );
 
 		if ( $page === null ) {
-			throw new StaleResultException();
+			throw new StaleResultException(
+				'MediaWikiService::getPageFromPageId $page is null', 0, null, [
+					'page_id' => (string) $pageId
+				]
+			);
 		}
 
 		$redirectTarget = null;

--- a/includes/wikia/nirvana/WikiaException.php
+++ b/includes/wikia/nirvana/WikiaException.php
@@ -53,22 +53,26 @@ abstract class WikiaBaseException extends MWException {
  * @link http://pl2.php.net/manual/en/class.exception.php
  */
 class WikiaException extends WikiaBaseException {
-	public function __construct($message = '', $code = 0, Exception $previous = null) {
+	public function __construct( $message = '', $code = 0, Exception $previous = null, $extraContext = [] ) {
 		global $wgRunningUnitTests;
 		parent::__construct( $message, $code, $previous );
 
-		if (!$wgRunningUnitTests) {
-			$exceptionClass = get_class($this);
+		if ( !$wgRunningUnitTests ) {
+			$exceptionClass = get_class( $this );
 
 			// log on devboxes to /tmp/debug.log
-			wfDebug($exceptionClass . ": {$message}\n");
-			wfDebug($this->getTraceAsString());
+			wfDebug( $exceptionClass . ": {$message}\n" );
+			wfDebug( $this->getTraceAsString() );
 
-			WikiaLogger::instance()->error($exceptionClass, [
-				'err' => $message,
-				'errno' => $code,
-				'exception' => $previous instanceof Exception ? $previous : $this,
-			]);
+			WikiaLogger::instance()->error(
+				$exceptionClass,
+				[
+					'err' => $message,
+					'errno' => $code,
+					'exception' => $previous instanceof Exception ? $previous : $this,
+					'extra_context' => $extraContext
+				]
+			);
 		}
 	}
 }

--- a/includes/wikia/nirvana/WikiaException.php
+++ b/includes/wikia/nirvana/WikiaException.php
@@ -53,7 +53,7 @@ abstract class WikiaBaseException extends MWException {
  * @link http://pl2.php.net/manual/en/class.exception.php
  */
 class WikiaException extends WikiaBaseException {
-	public function __construct( $message = '', $code = 0, Exception $previous = null, $extraContext = [] ) {
+	public function __construct( $message = '', $code = 0, Exception $previous = null, array $extraContext = [] ) {
 		global $wgRunningUnitTests;
 		parent::__construct( $message, $code, $previous );
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-1403

We have a flood of duplicated error reporter tickets. Let's generalize the message and pass the page id in the context instead.

https://github.com/Wikia/app/pull/12052