### PR TITLE
Fix error in getHref for keys that don't exist in default language

### DIFF
--- a/includes/wikia/models/DesignSystemSharedLinks.class.php
+++ b/includes/wikia/models/DesignSystemSharedLinks.class.php
@@ -28,7 +28,7 @@ class DesignSystemSharedLinks {
 	public function getHref( $name, $lang ) {
 		$lang = $this->getLangWithFallback( $lang );
 
-		return $this->hrefs[ $lang ][ $name ] ?? $this->hrefs[ 'default' ][ $name ];
+		return $this->hrefs[ $lang ][ $name ] ?? $this->hrefs[ 'default' ][ $name ] ?? NULL;
 	}
 
 	private function getLangWithFallback( $lang ) {


### PR DESCRIPTION
Fix error introduced in  https://github.com/Wikia/app/commit/0430a9809dccf363dd3cd9d8456f89ad00f1cbed