### PR TITLE
ST-78 Use community central globals instead of wiki-specific globals

### DIFF
--- a/extensions/wikia/Search/WikiaSearchController.class.php
+++ b/extensions/wikia/Search/WikiaSearchController.class.php
@@ -653,6 +653,17 @@ class WikiaSearchController extends WikiaSpecialPageController {
 		$this->addRightRailModules( $searchConfig );
 	}
 
+	// ST-78: temporary code to use globals from community central because we can't
+	// deploy config during code freeze
+	protected function getCentralVariableValue( $variableName ) {
+		$variable =
+			WikiFactory::getVarByName( $variableName, WikiFactory::COMMUNITY_CENTRAL,
+				true  // ignore cached value
+			);
+
+		return unserialize( $variable->cv_value );
+	}
+
 	protected function addRightRailModules( Wikia\Search\Config $searchConfig ) {
 		global $wgLang, $wgEnableFandomStoriesOnSearchResultPage;
 
@@ -675,12 +686,8 @@ class WikiaSearchController extends WikiaSpecialPageController {
 
 			// ST-78: temporary code to use globals from community central because we can't
 			// deploy config during code freeze
-			$enableSearchLoggingVariable = WikiFactory::getVarByName(
-				self::ENABLE_FANDOM_STORIES_SEARCH_LOGGING,
-				WikiFactory::COMMUNITY_CENTRAL,
-				true
-			);
-			$enableSearchLogging = unserialize( $enableSearchLoggingVariable->cv_value );
+			$enableSearchLogging =
+				$this->getCentralVariableValue( self::ENABLE_FANDOM_STORIES_SEARCH_LOGGING );
 			if ( $enableSearchLogging ) {
 				WikiaLogger::instance()->info( __METHOD__ . ' - Querying Fandom Stories', [
 					'query' => $query,
@@ -691,12 +698,8 @@ class WikiaSearchController extends WikiaSpecialPageController {
 
 			// ST-78: temporary code to use globals from community central because we can't
 			// deploy config during code freeze
-			$disableResultsCachingVariable = WikiFactory::getVarByName(
-				self::DISABLE_FANDOM_STORIES_SEARCH_RESULTS_CACHING,
-				WikiFactory::COMMUNITY_CENTRAL,
-				true
-			);
-			$disableResultsCaching = unserialize( $disableResultsCachingVariable->cv_value );
+			$disableResultsCaching =
+				$this->getCentralVariableValue( self::DISABLE_FANDOM_STORIES_SEARCH_RESULTS_CACHING );
 			if ( !$disableResultsCaching ) {
 				$fandomStories =
 					\WikiaDataAccess::cache( wfSharedMemcKey( static::FANDOM_STORIES_MEMC_KEY,
@@ -738,21 +741,8 @@ class WikiaSearchController extends WikiaSpecialPageController {
 
 		// ST-78: temporary code to use globals from community central because we can't
 		// deploy config during code freeze
-		$enableShadowingVariable = WikiFactory::getVarByName(
-				self::ENABLE_SEARCH_REQUEST_SHADOWING,
-				WikiFactory::COMMUNITY_CENTRAL,
-				true
-			);
-
-		$enableShadowing = unserialize( $enableShadowingVariable->cv_value );
-
-		$samplingRateVariable = WikiFactory::getVarByName(
-				self::SEARCH_REQUEST_SAMPLING_RATE,
-				WikiFactory::COMMUNITY_CENTRAL,
-				true
-			);
-
-		$samplingRate = unserialize( $samplingRateVariable->cv_value ) ?: 0;
+		$enableShadowing = $this->getCentralVariableValue( self::ENABLE_SEARCH_REQUEST_SHADOWING );
+		$samplingRate = $this->getCentralVariableValue( self::SEARCH_REQUEST_SAMPLING_RATE ) ?: 0;
 
 		return function () use (
 			$query, $enableShadowing, $samplingRate


### PR DESCRIPTION
This PR hold temporary code put in place because of the upcoming code freeze.  The search team needs to enable search request shadowing and sampling at various sampling rates over the next month to ensure that the production search service can handle expected capacity.  However, we won't be able to deploy config with new values for the variables involved, so we needed a way to change these variables for 260K wikis during code freeze.
- We tagged the wikis in question, but setting variables by tag does not work for large numbers of wikis
- It's possible to use SQL inserts/updates against the DB to change variables, but this isn't the best option
- Taking Mix's advice, we plan to use globals from community central for all wikis, allowing us to use WikiFactory to change the values for a single wiki and have all wikis use those values
This code will be removed once code freeze is over.

- [x] Remove global declarations for variables no longer used per wiki
- [x] Get variables from Community Central wiki ignoring cache and querying the DB each time
- [x] Test in dev

@jogura @mixth-sense @macbre 