### PR TITLE
WW-634: Hide top bar if experiment is disabled

### DIFF
--- a/extensions/wikia/RWEPageHeader/styles/index.scss
+++ b/extensions/wikia/RWEPageHeader/styles/index.scss
@@ -9,6 +9,7 @@
 .WikiaPage:before {
 	border-top: $content-spacing-large solid $color-buttons;
 	content: '.';
+	display: none;
 	left: -1px;
 	position: absolute;
 	right: -1px;


### PR DESCRIPTION
It's safer to disable article top bar and display it via Ab test framework styles

@Wikia/west-wing 