### PR TITLE
SUS-1419: Add support for 'trending' sorting param for Game Guides app requests

### DIFF
--- a/includes/wikia/services/MediaQueryService.class.php
+++ b/includes/wikia/services/MediaQueryService.class.php
@@ -13,6 +13,11 @@ class MediaQueryService extends WikiaService {
 	const SORT_RECENT_FIRST   = 'recent';
 	const SORT_POPULAR_FIRST  = 'popular';
 	const SORT_TRENDING_FIRST = 'trend';
+	/**
+	 * @var string SORT_TRENDING_FIRST_LEGACY
+	 * Legacy sorting option used by requests from Game Guides apps
+	 */
+	const SORT_TRENDING_FIRST_LEGACY = 'trending';
 
 	const DB_RECENT_COLUMN    = 'added_at';
 	const DB_POPULAR_COLUMN   = 'views_total';
@@ -427,6 +432,7 @@ class MediaQueryService extends WikiaService {
 				break;
 
 			case self::SORT_TRENDING_FIRST:
+			case self::SORT_TRENDING_FIRST_LEGACY:
 				$query->ORDER_BY( self::DB_TRENDING_COLUMN )->DESC();
 				break;
 

--- a/includes/wikia/services/MediaQueryService.class.php
+++ b/includes/wikia/services/MediaQueryService.class.php
@@ -438,7 +438,7 @@ class MediaQueryService extends WikiaService {
 
 			default:
 				throw new InvalidArgumentException( "\$sort was none of '" . self::SORT_RECENT_FIRST . "', '"
-					. self::SORT_POPULAR_FIRST . "', '" . self::SORT_TRENDING_FIRST . "'." );
+					. self::SORT_POPULAR_FIRST . "', '" . self::SORT_TRENDING_FIRST . "', '" . self::SORT_TRENDING_FIRST_LEGACY . "'." );
 				break;
 		}
 

--- a/includes/wikia/services/tests/MediaQueryServiceTest.php
+++ b/includes/wikia/services/tests/MediaQueryServiceTest.php
@@ -20,7 +20,8 @@ class MediaQueryServiceTest extends WikiaBaseTest {
 			$this->assertEquals( $e->getMessage(), "\$sort was none of '"
 				. MediaQueryService::SORT_RECENT_FIRST . "', '"
 				. MediaQueryService::SORT_POPULAR_FIRST . "', '"
-				. MediaQueryService::SORT_TRENDING_FIRST . "'."
+				. MediaQueryService::SORT_TRENDING_FIRST . "', '"
+				. MediaQueryService::SORT_TRENDING_FIRST_LEGACY . "'."
 			);
 			return;
 		}


### PR DESCRIPTION
Game Guides apps are using wrong sorting param (`trending` instead of `trend`) when contacting VideoHandler Nirvana API. Let's add support for this param.

ticket: https://wikia-inc.atlassian.net/browse/SUS-1419