### PR TITLE
embedded CMS styling fixes

### DIFF
--- a/extensions/wikia/ContributionPrototype/styles/ContributionPrototype.scss
+++ b/extensions/wikia/ContributionPrototype/styles/ContributionPrototype.scss
@@ -6,9 +6,13 @@ body {
   overflow-y: visible !important;
 }
 
-#app button, .desktop_modal_dialog button {
+#app button, .desktop_modal_dialog button, .quill_toolbar_popover button {
   height: auto;
   background-image: none;
+}
+
+.quill_toolbar_popover button h2 {
+  line-height: 20px !important;
 }
 
 #WikiaPageHeader {

--- a/extensions/wikia/ContributionPrototype/styles/ContributionPrototype.scss
+++ b/extensions/wikia/ContributionPrototype/styles/ContributionPrototype.scss
@@ -11,8 +11,12 @@ body {
   background-image: none;
 }
 
-.quill_toolbar_popover button h2 {
-  line-height: 20px !important;
+.quill_toolbar_popover button {
+  color: black;
+
+  h2 {
+    line-height: 20px !important;
+  }
 }
 
 #WikiaPageHeader {
@@ -36,7 +40,7 @@ body {
     fill: black;
   }
 
-  .dropdown {
+  .dropdown, .controls {
     > button {
       color: black;
 


### PR DESCRIPTION
@Wikia/cake

Fixing CMS styling since the latest changes have changed some of the element orderings/classnames.