### PR TITLE
SUS-846: Fix search suggestions for custom namespaces

### DIFF
--- a/extensions/wikia/LinkSuggest/LinkSuggest.class.php
+++ b/extensions/wikia/LinkSuggest/LinkSuggest.class.php
@@ -329,7 +329,7 @@ class LinkSuggest {
 		global $wgLinkSuggestLimit;
 		while(($row = $db->fetchObject($res)) && count($results) < $wgLinkSuggestLimit ) {
 
-			if (strtolower($row->page_title) == $query) {
+			if ( is_null( $exactMatchRow ) && strtolower($row->page_title) == $query) {
 				$exactMatchRow = $row;
 				continue;
 			}

--- a/extensions/wikia/LinkSuggest/LinkSuggest.class.php
+++ b/extensions/wikia/LinkSuggest/LinkSuggest.class.php
@@ -329,7 +329,8 @@ class LinkSuggest {
 		global $wgLinkSuggestLimit;
 		while(($row = $db->fetchObject($res)) && count($results) < $wgLinkSuggestLimit ) {
 
-			if ( is_null( $exactMatchRow ) && strtolower($row->page_title) == $query) {
+			// SUS-846: Ensure we only have one exact match, to prevent overwriting it and losing the suggestion
+			if ( is_null( $exactMatchRow ) && strtolower( $row->page_title ) == $query ) {
 				$exactMatchRow = $row;
 				continue;
 			}


### PR DESCRIPTION
If a search is performed for an all-lowercase string and there are two matching titles (one in main namespace, other in a custom content namespace), only the content namespace result is displayed in search suggestions. Let's make it consistent

ticket: https://wikia-inc.atlassian.net/browse/SUS-846