### PR TITLE
Add Page button

### DIFF
--- a/extensions/wikia/ContributionPrototype/styles/ContributionPrototype.scss
+++ b/extensions/wikia/ContributionPrototype/styles/ContributionPrototype.scss
@@ -76,13 +76,14 @@ body {
   top: 89px !important;
 }
 
-#WikiHeader .buttons .contribute {
-  > .drop > .chevron {
-    vertical-align: middle !important;
-  }
-
-  .WikiaMenuElement a {
+#WikiHeader .buttons {
+  .wds-button {
+    background-image: none;
     height: auto;
+    position: relative;
+    top: -10px;
+    color: white;
+    border-color: white;
   }
 }
 

--- a/extensions/wikia/ContributionPrototype/styles/ContributionPrototype.scss
+++ b/extensions/wikia/ContributionPrototype/styles/ContributionPrototype.scss
@@ -83,7 +83,10 @@ body {
     position: relative;
     top: -10px;
     color: white;
-    border-color: white;
+  }
+
+  .wds-button:hover {
+    color: #D5D4D4;
   }
 }
 

--- a/skins/oasis/modules/WikiHeaderController.class.php
+++ b/skins/oasis/modules/WikiHeaderController.class.php
@@ -41,7 +41,9 @@ class WikiHeaderController extends WikiaController {
 
 		$this->displaySearch = $this->wg->Title->isSpecial( 'AdminDashboard' );
 		$this->setVal( 'displayHeader', !$this->wg->HideNavigationHeaders );
+
 		$this->displayHeaderButtons = !WikiaPageType::isWikiaHubMain();
+		$this->useAddPageButton = $this->wg->EnableContributionPrototypeViewing;
 
 		$this->hiddenLinks = [
 			'watchlist' => SpecialPage::getTitleFor( 'Watchlist' )->getLocalURL(),

--- a/skins/oasis/modules/templates/WikiHeader_Index.php
+++ b/skins/oasis/modules/templates/WikiHeader_Index.php
@@ -8,7 +8,16 @@
 	</nav>
 	<? if ( $displayHeaderButtons ) : ?>
 		<div class="buttons">
-			<?= $app->renderView( 'ContributeMenu', 'Index' ) ?>
+      <? if ($useAddPageButton) { ?>
+        <button id="add-page" class="wds-button wds-is-squished wds-is-secondary">
+          <svg class="wds-icon wds-icon-tiny">
+            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#wds-icons-plus" />
+          </svg>
+          <span>Add Page</span>
+        </button>
+      <? } else { ?>
+				<?= $app->renderView('ContributeMenu', 'Index'); ?>
+      <? } ?>
 		</div>
 	<? endif ?>
 	<div class="hiddenLinks">


### PR DESCRIPTION
@Wikia/cake 

When using the embedded CP, change the contribute button to instead be an "Add Page" button. See Wikia/sd-poc#183 for the CP changes to bind to the new button.