### PR TITLE
SEO-624 Update English noarticletext to work with any wiki language

### DIFF
--- a/extensions/GlobalMessages/GlobalMessagesN.i18n.php
+++ b/extensions/GlobalMessages/GlobalMessagesN.i18n.php
@@ -64,18 +64,15 @@ It may have been moved or deleted while you were viewing the page.',
 	'newarticle' => '(New)',
 	'newarticletext' => '<div style="margin-top: 0px;" class="emptymwmsg mediawiki_newarticletext"></div>',
 	'newarticletextanon' => '{{int:newarticletext}}',
-	'noarticletext' => '{{#ifeq:{{NAMESPACE}}|Category||=== \'\'\'Article {{FULLPAGENAME}} was not found\'\'\' ===
+	'noarticletext' => '{{#ifeq:{{NAMESPACE}}||
+=== \'\'\'Article {{FULLPAGENAME}} was not found\'\'\' ===
 
 What do you want to do?
 
 * Search existing articles for <span class="plainlinks">[{{fullurl:Special:Search|search={{urlencode:{{PAGENAME}}}}}} {{PAGENAME}}]</span>
-* Create article <span class="plainlinks">[{{fullurl:{{FULLPAGENAME}}|action=create}} {{FULLPAGENAME}}]</span>}}',
-	'noarticletext-nopermission' => '=== \'\'\'Article {{FULLPAGENAME}} was not found\'\'\' ===
-
-What do you want to do?
-
-* Search existing articles for <span class="plainlinks">[{{fullurl:Special:Search|search={{urlencode:{{PAGENAME}}}}}} {{PAGENAME}}]</span>
-* Create article <span class="plainlinks">[{{fullurl:{{FULLPAGENAME}}|action=create}} {{FULLPAGENAME}}]</span>',
+* Create article <span class="plainlinks">[{{fullurl:{{FULLPAGENAME}}|action=create}} {{FULLPAGENAME}}]</span>
+}}',
+	'noarticletext-nopermission' => '{{int:noarticletext}}',
 	'noarticletextanon' => '{{int:noarticletext}}',
 	'note' => '\'\'\'Note:\'\'\'',
 	'nonunicodebrowser' => '\'\'\'Warning: Your browser is not unicode compliant.\'\'\'


### PR DESCRIPTION
The "logic" (unfortunately coded within the translation layer) for the `noarticletext` message was as follows:

* Show nothing if `Namespace = Category` (this doesn't work for non-English languages, as they have their own names for the category namespace)
* Show the "Article not found" text otherwise

Now the logic is as follows:

* Show nothing if `Namespace is empty` (this **does** work for non-English languages)
* Show the "Article not found" text otherwise

This message will need to be translated to other languages, so for now to test it you can visit a page like that:

http://de.gta.wikia.com/Category:NoSuchCategory?uselang=en <- shows the message - production
http://stable.de.gta.wikia.com/Category:NoSuchCategory?uselang=en <- doesn't show the message - updated code.

Once the message is translated (and that needs to wait for MAIN-9346 first), the same "logic" should work without `?uselang=en`.