### PR TITLE
SEO-337 Don't show MediaWiki redirects on local HTML sitemap

### DIFF
--- a/extensions/wikia/LocalSitemapPage/LocalSitemapSpecialPage.class.php
+++ b/extensions/wikia/LocalSitemapPage/LocalSitemapSpecialPage.class.php
@@ -9,18 +9,24 @@
  *  * No forms and prev/next links
  *  * Better format of the from A to B links
  *  * Use alternative from/to params to overcome ?from robot.txt block
+ *  * Hide MediaWiki redirects
  *
  */
 class LocalSitemapSpecialPage extends SpecialAllpages {
+	/**
+	 * Setting this flag causes the Special:AllPages to skip over redirects when displaying the list of pages.
+	 * It has a matching Wikia change in SpecialAllpages class. Note it only works when including() returns true.
+	 *
+	 * @var bool
+	 */
+	public $skipRedirects = true;
 
 	/**
 	 * Generate chunks as the page was included. This removes the UI around the lists.
 	 *
-	 * @return bool
+	 * @var bool
 	 */
-	public function including() {
-		return true;
-	}
+	protected $mIncluding = true;
 
 	/**
 	 * Use alternative line format for "from A to B" links

--- a/includes/specials/SpecialAllpages.php
+++ b/includes/specials/SpecialAllpages.php
@@ -337,6 +337,11 @@ class SpecialAllpages extends IncludableSpecialPage {
 			if( $res->numRows() > 0 ) {
 				$out = Xml::openElement( 'table', array( 'class' => 'mw-allpages-table-chunk' ) );
 				while( ( $n < $this->maxPerPage ) && ( $s = $res->fetchObject() ) ) {
+					/** Wikia change begin, @see LocalSitemapSpecialPage */
+					if ( $s->page_is_redirect && isset( $this->skipRedirects ) && $this->including() ) {
+						continue;
+					}
+					/* Wikia change end */
 					$t = Title::newFromRow( $s );
 					if( $t ) {
 						$link = ( $s->page_is_redirect ? '<div class="allpagesredirect">' : '' ) .


### PR DESCRIPTION
Testing notes:

The local HTML sitemap is available on all wikis under `/wiki/Local_Sitemap`.

The code is based on Special:AllPages with a bunch of modifications. The
code will now make the list skip over redirects (known bug: this can
potentially produce an empty page, if only redirects were about to be
shown).

Original Special:AllPages should be unaffected.