### PR TITLE
SUS-1275 | Custom404PageBestMatchingPageFinder: we're fine with querying the main namespace only

### DIFF
--- a/extensions/wikia/Custom404Page/Custom404PageHooks.class.php
+++ b/extensions/wikia/Custom404Page/Custom404PageHooks.class.php
@@ -21,7 +21,8 @@ class Custom404PageHooks {
 
 		$title = $article->getTitle();
 
-		if ( $article->getOldID() || !$title || !$title->isContentPage() ) {
+		// SUS-1275: handle NS_MAIN pages only, we do not want to query solr with all available namespaces
+		if ( $article->getOldID() || !$title || !$title->inNamespace( NS_MAIN ) ) {
 			// MW will treat those cases specially, don't try to direct users to other pages
 			return true;
 		}


### PR DESCRIPTION
As discussed in https://wikia-inc.atlassian.net/browse/SUS-1275 we're fine with querying just the main namespace on 404 pages.

@mixth-sense / @bkoval / @gabrys 