### PR TITLE
XW-2429 | Skip costly and unnecessary operations on file pages

### DIFF
--- a/extensions/wikia/MercuryApi/MercuryApiController.class.php
+++ b/extensions/wikia/MercuryApi/MercuryApiController.class.php
@@ -411,12 +411,16 @@ class MercuryApiController extends WikiaController {
 			$title = $this->wg->Title;
 		}
 
-		$data['articleType'] = WikiaPageType::getArticleType( $title );
-		$data['adsContext'] = $this->mercuryApi->getAdsContext( $title );
-		$otherLanguages = $this->getOtherLanguages( $title );
+		// These operations slow the API response time by 50 times
+		// There is no need to perform them on the file pages as they're not supported by Mercury anyway
+		if ( $title->getNamespace() !== NS_FILE ) {
+			$data['articleType'] = WikiaPageType::getArticleType( $title );
+			$data['adsContext'] = $this->mercuryApi->getAdsContext( $title );
+			$otherLanguages = $this->getOtherLanguages( $title );
 
-		if ( !empty( $otherLanguages ) ) {
-			$data['otherLanguages'] = $otherLanguages;
+			if ( !empty( $otherLanguages ) ) {
+				$data['otherLanguages'] = $otherLanguages;
+			}
 		}
 
 		$this->response->setFormat( WikiaResponse::FORMAT_JSON );


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/XW-2429

Profiler on my devbox showed that the response time for http://concf.igor.wikia-dev.com/wikia.php?controller=MercuryApi&method=getPage&title=File:Wikia-hero-image&forceprofile=1 went from ~1s to ~0.1s. Most of this time was spent in `WikiaPageType::getArticleType()` which sends a request to Solr. We should consider getting the article type using another method but for now let's speed up the file page.

I've checked on a sandbox and the improvement is much less impressive - from ~0.16s to ~0.11s. It's possible though that the difference is much bigger when the load increases (and it was massive, see the linked ticket).

@Wikia/x-wing and @macbre as you're now _The Solr Guy_ :wink: 