### PR TITLE
CAKE - recirc incontent template fixes

### DIFF
--- a/extensions/wikia/Recirculation/templates/client/incontent.mustache
+++ b/extensions/wikia/Recirculation/templates/client/incontent.mustache
@@ -3,7 +3,14 @@
 
 	<div class="items">
 		{{#items}}
-		<div class="item" data-index="{{index}}" data-source="{{source}}">
+		<div
+		    data-flag="{{flag}}"
+		    class="item item-{{source}}{{#isVideo}} is-video{{/isVideo}}"
+		    data-index="{{index}}"
+		    data-source="{{source}}"
+		    {{#id}} data-id="{{id}}" {{/id}}
+		    {{#meta}} data-meta="{{meta}}" {{/meta}}
+		>
 			<a title="{{title}}" href="{{url}}">
 				<div class="thumbnail"><img src="{{thumbnail}}" alt="{{title}}"></div>
 				<h4>{{title}}</h4>


### PR DESCRIPTION
@Wikia/cake 

Adding the missing `data-*` tags for the `incontent` template. Without these, we aren't getting correct tracking information in LiftIgniter. ~~With these, however, there seems to be a race-condition that's introduced with the tracking for the second experiment being set up before it's correctly rendered. @gbenson-wikia says that this is OK for now.~~

The race condition mentioned above was an issue with the way we were defining our experiments. From the [docs](https://liftigniter.readme.io/docs/pregister), we can call `register` multiple times, but only call `fetch` once.