### PR TITLE
PLATFORM-2759: Temporarily remove devbox logs from proxy.php as it crashes the script

### DIFF
--- a/extensions/wikia/Tasks/proxy/proxy.php
+++ b/extensions/wikia/Tasks/proxy/proxy.php
@@ -34,6 +34,11 @@ foreach($traceEnv as $key => $val) {
 
 $command = "{$env}php {$script} --wiki_id={$wikiId} --task_id={$taskId} --task_list={$list} --call_order={$order} --created_by={$createdBy} --created_at={$createdAt}";
 
+// @todo (PLATFORM-2759): For a long-term fix, initialize the MW stack here, remove the shell_exec and execute the
+//                        TaskRunnerMaintenance directly. For now I'm removing the lines below as the composer/autoload.php
+//                        fails to load some classes without MW and the whole script crashed on devboxes.
+/*
+ *
 // can't use globals here, this doesn't execute within mediawiki
 if ( getenv( 'WIKIA_ENVIRONMENT' ) == 'dev' ) {
 	require_once( __DIR__ . '/../../../../lib/Wikia/autoload.php' );
@@ -44,5 +49,6 @@ if ( getenv( 'WIKIA_ENVIRONMENT' ) == 'dev' ) {
 		'data' => $_POST,
 	] );
 }
+*/
 
 echo shell_exec( $command );

--- a/extensions/wikia/Tasks/proxy/proxy.php
+++ b/extensions/wikia/Tasks/proxy/proxy.php
@@ -38,7 +38,6 @@ $command = "{$env}php {$script} --wiki_id={$wikiId} --task_id={$taskId} --task_l
 //                        TaskRunnerMaintenance directly. For now I'm removing the lines below as the composer autoload
 //                        fails to load some classes without MW and the whole script crashed on devboxes.
 /*
- *
 // can't use globals here, this doesn't execute within mediawiki
 if ( getenv( 'WIKIA_ENVIRONMENT' ) == 'dev' ) {
 	require_once( __DIR__ . '/../../../../lib/Wikia/autoload.php' );

--- a/extensions/wikia/Tasks/proxy/proxy.php
+++ b/extensions/wikia/Tasks/proxy/proxy.php
@@ -35,7 +35,7 @@ foreach($traceEnv as $key => $val) {
 $command = "{$env}php {$script} --wiki_id={$wikiId} --task_id={$taskId} --task_list={$list} --call_order={$order} --created_by={$createdBy} --created_at={$createdAt}";
 
 // @todo (PLATFORM-2759): For a long-term fix, initialize the MW stack here, remove the shell_exec and execute the
-//                        TaskRunnerMaintenance directly. For now I'm removing the lines below as the composer/autoload.php
+//                        TaskRunnerMaintenance directly. For now I'm removing the lines below as the composer autoload
 //                        fails to load some classes without MW and the whole script crashed on devboxes.
 /*
  *


### PR DESCRIPTION
Quick fix so tasks start working on devboxes again. For the nicer long-term script details, please refer to Jira ticket.