### PR TITLE
XW-2394 | VE allow insert tools only in linear selection

### DIFF
--- a/extensions/VisualEditor/wikia/modules/ve/ui/ve.ui.WikiaCommandRegistry.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/ve.ui.WikiaCommandRegistry.js
@@ -81,10 +81,7 @@ ve.ui.commandRegistry.register(
 ve.ui.commandRegistry.register(
 	new ve.ui.Command(
 		'wikiaInfobox', 'window', 'open',
-		{
-			args: ['wikiaInfobox'],
-			supportedSelections: ['linear']
-		}
+		{ args: ['wikiaInfobox'] }
 	)
 );
 

--- a/extensions/VisualEditor/wikia/modules/ve/ui/ve.ui.WikiaCommandRegistry.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/ve.ui.WikiaCommandRegistry.js
@@ -21,56 +21,80 @@ ve.ui.commandRegistry.register(
 ve.ui.commandRegistry.register(
 	new ve.ui.Command(
 		'wikiaMediaInsert', 'window', 'open',
-		{ args: ['wikiaMediaInsert'] }
+		{
+			args: ['wikiaMediaInsert'],
+			supportedSelections: ['linear']
+		}
 	)
 );
 
 ve.ui.commandRegistry.register(
 	new ve.ui.Command(
 		'wikiaImageInsert', 'window', 'open',
-		{ args: ['wikiaImageInsert'] }
+		{
+			args: ['wikiaImageInsert'],
+			supportedSelections: ['linear']
+		}
 	)
 );
 
 ve.ui.commandRegistry.register(
 	new ve.ui.Command(
 		'wikiaVideoInsert', 'window', 'open',
-		{ args: ['wikiaVideoInsert'] }
+		{
+			args: ['wikiaVideoInsert'],
+			supportedSelections: ['linear']
+		}
 	)
 );
 
 ve.ui.commandRegistry.register(
 	new ve.ui.Command(
 		'wikiaSingleMedia', 'window', 'open',
-		{ args: ['wikiaSingleMedia'] }
+		{
+			args: ['wikiaSingleMedia'],
+			supportedSelections: ['linear']
+		}
 	)
 );
 
 ve.ui.commandRegistry.register(
 	new ve.ui.Command(
 		'wikiaMapInsert', 'window', 'open',
-		{ args: ['wikiaMapInsert'] }
+		{
+			args: ['wikiaMapInsert'],
+			supportedSelections: ['linear']
+		}
 	)
 );
 
 ve.ui.commandRegistry.register(
 	new ve.ui.Command(
 		'wikiaInfoboxInsert', 'window', 'open',
-		{ args: ['wikiaInfoboxInsert'] }
+		{
+			args: ['wikiaInfoboxInsert'],
+			supportedSelections: ['linear']
+		}
 	)
 );
 
 ve.ui.commandRegistry.register(
 	new ve.ui.Command(
 		'wikiaInfobox', 'window', 'open',
-		{ args: ['wikiaInfobox'] }
+		{
+			args: ['wikiaInfobox'],
+			supportedSelections: ['linear']
+		}
 	)
 );
 
 ve.ui.commandRegistry.register(
 	new ve.ui.Command(
 		'wikiaTemplateInsert', 'window', 'open',
-		{ args: ['wikiaTemplateInsert'] }
+		{
+			args: ['wikiaTemplateInsert'],
+			supportedSelections: ['linear']
+		}
 	)
 );
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/XW-2394

Inserting new content in null and table selection isn't very intuitive. For null selection it can replace content that isn't highlighted. For table selection inserting media or templates doesn't have much sense as user can select multiple cells.
Having that said we decided to limit insert tools only to linear selection.

Ping @Wikia/x-wing 