### PR TITLE
PLATFORM-2779: fixing the call to SpecialEditWatchlist::clearWatchlist 

### DIFF
--- a/includes/specials/SpecialEditWatchlist.php
+++ b/includes/specials/SpecialEditWatchlist.php
@@ -331,7 +331,7 @@ class SpecialEditWatchlist extends UnlistedSpecialPage {
 			__METHOD__
 		);
 
-		wfRunHooks( 'SpecialEditWatchlist::clearWatchlist', array ( $user ) );
+		wfRunHooks( 'SpecialEditWatchlist::clearWatchlist', array ( $user->getId() ) );
 	}
 
 	/**


### PR DESCRIPTION
The listener expects userId, not the whole object: https://github.com/Wikia/app/blob/b03df0a89ed672697e9c130d529bf1eb25f49cda/extensions/wikia/GlobalWatchlist/GlobalWatchlistHooks.class.php#L115. I noticed this while browsing logs of serialized user objects