### PR TITLE
Platform-2779: Make the user field private so the object is not serialized to logs

### DIFF
--- a/includes/parser/ParserOptions.php
+++ b/includes/parser/ParserOptions.php
@@ -158,7 +158,7 @@ class ParserOptions {
 	 * @var User 
 	 * Stored user object
 	 */
-	var $mUser;
+	private $mUser;
 	
 	/**
 	 * Parsing the page for a "preview" operation?


### PR DESCRIPTION
Making the user object private will prevent it from being serialized to logs in https://github.com/Wikia/app/blob/b03df0a89ed672697e9c130d529bf1eb25f49cda/includes/wikia/services/ArticleService.class.php#L230. Also I think it should be private in the first place as there is a getter for it.