### PR TITLE
PLATFORM-2779: Remove private objects from CNW log entries

### DIFF
--- a/extensions/wikia/CreateNewWiki/tasks/TaskContext.php
+++ b/extensions/wikia/CreateNewWiki/tasks/TaskContext.php
@@ -71,8 +71,29 @@ class TaskContext {
 		] );
 	}
 
-	public function getAllProperties() {
-		return get_object_vars( $this );
+	/**
+	 * @return string[][]
+	 */
+	public function getLoggerContext() {
+		$context = [
+			'dbName'        => $this->dbName,
+			'language'      => $this->language,
+			'cityId'        => $this->cityId,
+			'wikiName'      => $this->wikiName,
+			'siteName'      => $this->siteName,
+			'url'           => $this->url,
+			'domain'        => $this->domain,
+			'inputDomain'   => $this->inputDomain,
+			'inputWikiName' => $this->inputWikiName,
+			'vertical'      => $this->vertical,
+			'categories'    => $this->categories,
+		];
+		if ( $this->founder instanceof User ) {
+			$context['founderName'] = $this->founder->getName();
+			$context['founderId'] = $this->founder->getId();
+		}
+
+		return $context;
 	}
 
 	public function getInputWikiName() {

--- a/extensions/wikia/CreateNewWiki/tasks/TaskHelper.php
+++ b/extensions/wikia/CreateNewWiki/tasks/TaskHelper.php
@@ -58,7 +58,7 @@ class TaskHelper {
 	 * @return string[][]
 	 */
 	public static function getLoggerContext( TaskContext $taskContext, $additionalValues = [] ) {
-		$context = $taskContext->getAllProperties();
+		$context = $taskContext->getLoggerContext();
 
 		$context = array_merge( $context, $additionalValues );
 

--- a/extensions/wikia/CreateNewWiki/tests/tasks/CreateDatabaseTest.php
+++ b/extensions/wikia/CreateNewWiki/tests/tasks/CreateDatabaseTest.php
@@ -96,7 +96,7 @@ class CreateDatabaseTest extends \WikiaBaseTest {
 		$result = $task->prepare();
 
 		//then
-		$taskContextData = $taskContext->getAllProperties();
+		$taskContextData = $taskContext->getLoggerContext();
 		foreach ($taskContextExpected as $key => $value) {
 			$this->assertEquals( $value, $taskContextData[ $key ] );
 		}
@@ -120,7 +120,7 @@ class CreateDatabaseTest extends \WikiaBaseTest {
 		$result = $task->prepare();
 
 		//then
-		$taskContextData = $taskContext->getAllProperties();
+		$taskContextData = $taskContext->getLoggerContext();
 		$this->assertEquals( true, $result->isOk());
 		//We expect that the db name will have the original name + some suffix i.e. textWiki123
 		$this->assertNotEquals( $taskContextExpected[ 'dbName' ], $taskContextData[ 'dbName' ] );
@@ -144,7 +144,7 @@ class CreateDatabaseTest extends \WikiaBaseTest {
 		$result = $task->prepare();
 
 		//then
-		$taskContextData = $taskContext->getAllProperties();
+		$taskContextData = $taskContext->getLoggerContext();
 		$this->assertEquals( true, $result->isOk());
 		//We expect that the db name will have the original name + some suffix i.e. textWiki123
 		$this->assertNotEquals( $taskContextExpected[ 'dbName' ], $taskContextData[ 'dbName' ] );


### PR DESCRIPTION
I noticed this when looking for serialized user objects. CNW logged to ELK the whole founder user object and also fields like sharedDBW (which is a mysql connection object).