### PR TITLE
(PLATFORM-2391) Fail silently on bad titles due to cache

### DIFF
--- a/extensions/wikia/PageShare/PageShareController.class.php
+++ b/extensions/wikia/PageShare/PageShareController.class.php
@@ -13,6 +13,14 @@ class PageShareController extends WikiaController {
 		$requestlang = $this->getVal( 'lang' );
 		$title = $this->getVal( 'title' );
 		$titleObject = Title::newFromText( $title );
+
+		// Fail silently on bad titles to avoid floods of exceptions
+		// from requests to cached pages (PLATFORM-2391)
+		$modalTitle = '';
+		if ( $titleObject instanceof Title ) {
+			$modalTitle = $titleObject->getText();
+		}
+
 		$lang = PageShareHelper::getLangForPageShare( $requestlang );
 
 		$renderedSocialIcons = \MustacheService::getInstance()->render(
@@ -21,7 +29,7 @@ class PageShareController extends WikiaController {
 		);
 
 		$this->setVal( 'socialIcons', $renderedSocialIcons );
-		$this->setVal( 'modalTitle', wfMessage( 'page-share-modal-title' )->params( $titleObject->getText() )->text() );
+		$this->setVal( 'modalTitle', wfMessage( 'page-share-modal-title' )->params( $modalTitle )->text() );
 		$this->response->setCacheValidity( WikiaResponse::CACHE_STANDARD );
 	}
 


### PR DESCRIPTION
This controller used to be requested on all page loads without a title
parameter. We're getting a large number of requests to this controller
from cached pages from Googlebot which is giving us thousands of the
following error every hour:

    Error: Call to a member function getText() on null in /extensions/
    wikia/PageShare/PageShareController.class.php:24

So, to avoid unnecessary exceptions, let's fail silently on a bad title
parameter and just set the modal title to an empty string for now.