### PR TITLE
ST-103 Use New Search API

### DIFF
--- a/extensions/wikia/Search/classes/Services/ESFandomSearchService.php
+++ b/extensions/wikia/Search/classes/Services/ESFandomSearchService.php
@@ -42,7 +42,7 @@ class ESFandomSearchService extends AbstractSearchService {
 		$consulUrl = $this->getConsulUrl();
 
 		$response = \Http::post(
-			"http://$consulUrl/fandom",
+			"http://$consulUrl/fandom/search",
 			[
 				'noProxy' => true,
 				'postData' => "queryTerms=$query",


### PR DESCRIPTION
Use the new fandom story Search API for retrieving fandom story search results. The service behavior is identical to the previous API but was changed to align with RESTful practices.

@jimmordino 