### PR TITLE
load liftigniter tracker in environments besides prod

### DIFF
--- a/extensions/wikia/Recirculation/RecirculationHooks.class.php
+++ b/extensions/wikia/Recirculation/RecirculationHooks.class.php
@@ -46,10 +46,9 @@ class RecirculationHooks {
 	 * @return bool
 	 */
 	public static function onOasisSkinAssetGroups( &$jsAssets ) {
-		global $wgWikiaEnvironment, $wgNoExternals;
+		global $wgNoExternals;
 
-		// Only track on prod
-		if ( ( $wgWikiaEnvironment === WIKIA_ENV_PROD ) && empty( $wgNoExternals ) ) {
+		if ( empty( $wgNoExternals ) ) {
 			$jsAssets[] = 'recirculation_liftigniter_tracker';
 		}
 


### PR DESCRIPTION
@Wikia/cake 

This will count pageviews on dev, but they should be a drop in the bucket compared to the traffic we get in prod, so it's probably OK.