### PR TITLE
cake-1079 - adding "sponsored" indicator on right rail

### DIFF
--- a/extensions/wikia/Recirculation/js/helpers/LiftigniterHelper.js
+++ b/extensions/wikia/Recirculation/js/helpers/LiftigniterHelper.js
@@ -56,7 +56,6 @@ define('ext.wikia.recirculation.helpers.liftigniter', [
 					}
 
 					item.meta = options.widget;
-					// item.sponsor = "Hulu";
 
 					item.index = index;
 					items.push(item);

--- a/extensions/wikia/Recirculation/js/helpers/LiftigniterHelper.js
+++ b/extensions/wikia/Recirculation/js/helpers/LiftigniterHelper.js
@@ -56,6 +56,7 @@ define('ext.wikia.recirculation.helpers.liftigniter', [
 					}
 
 					item.meta = options.widget;
+					// item.sponsor = "Hulu";
 
 					item.index = index;
 					items.push(item);

--- a/extensions/wikia/Recirculation/js/helpers/LiftigniterHelper.js
+++ b/extensions/wikia/Recirculation/js/helpers/LiftigniterHelper.js
@@ -56,7 +56,7 @@ define('ext.wikia.recirculation.helpers.liftigniter', [
 					}
 
 					item.meta = options.widget;
-					// item.sponsor = "Hulu";
+					item.sponsor = "Hulu";
 
 					item.index = index;
 					items.push(item);

--- a/extensions/wikia/Recirculation/js/helpers/LiftigniterHelper.js
+++ b/extensions/wikia/Recirculation/js/helpers/LiftigniterHelper.js
@@ -56,7 +56,7 @@ define('ext.wikia.recirculation.helpers.liftigniter', [
 					}
 
 					item.meta = options.widget;
-					item.sponsor = "Hulu";
+					// item.sponsor = "Hulu";
 
 					item.index = index;
 					items.push(item);

--- a/extensions/wikia/Recirculation/styles/rail.scss
+++ b/extensions/wikia/Recirculation/styles/rail.scss
@@ -2,6 +2,10 @@
 @import 'skins/shared/mixins/transform';
 
 .WikiaRail .recirculation-rail {
+	.recirculation-sponsored-footer {
+		font-size: 12px !important;
+	}
+
 	.item {
 		margin-bottom: 15px;
 	}

--- a/extensions/wikia/Recirculation/styles/recirculation.scss
+++ b/extensions/wikia/Recirculation/styles/recirculation.scss
@@ -24,6 +24,25 @@
 
 .recirculation-unit {
 
+	.recirculation-sponsored-header {
+		position: absolute;
+		background: #666666;
+		z-index: 1;
+		padding: 6px 12px;
+		font-size: 12px;
+		font-family: "Helvetica Neue", sans-serif;
+		color: white;
+	}
+
+	.recirculation-sponsored-footer {
+		opacity: 0.35;
+		font-size: 10px;
+		font-family: "Helvetica Neue", sans-serif;
+		padding-top: 5px;
+		text-transform: uppercase;
+		font-weight: bold;
+	}
+
 	.rail-item.is-video,
 	.item.is-video {
 		.image-thumbnail,

--- a/extensions/wikia/Recirculation/templates/client/rail.mustache
+++ b/extensions/wikia/Recirculation/templates/client/rail.mustache
@@ -10,6 +10,11 @@
 				{{#meta}} data-meta="{{meta}}" {{/meta}}
 			>
 				<a href="{{url}}">
+				    {{#sponsor}}
+                    <div class="recirculation-sponsored-header">
+                        Sponsored
+                    </div>
+                    {{/sponsor}}
 					<div class="image image-thumbnail placeholder-thumbnail fluid small">
 						{{#thumbnail}}
 							<img src="{{thumbnail}}" alt="{{title}}" itemprop="thumbnail">
@@ -18,6 +23,11 @@
 					<div class="title" title="{{title}}">{{title}}</div>
 					<div class="metadata">{{author}} &middot; <time class="timeago" datetime="{{pub_date}}">{{pub_date}}</time></div>
 				</a>
+				{{#sponsor}}
+                <div class="recirculation-sponsored-footer">
+                    Sponsored by {{sponsor}}
+                </div>
+                {{/sponsor}}
 			</li>
 		{{/items}}
 	</ul>

--- a/extensions/wikia/Recirculation/templates/client/rail.mustache
+++ b/extensions/wikia/Recirculation/templates/client/rail.mustache
@@ -1,34 +1,34 @@
 <section class="recirculation-rail module recirculation-unit">
-	<h2>{{title}}</h2>
-	<ul class="thumbnails">
-		{{#items}}
-			<li class="item item-{{source}}{{#isVideo}} is-video{{/isVideo}}"
-				data-flag="{{flag}}"
-				data-index="{{index}}"
-				data-source="{{source}}"
-				{{#id}} data-id="{{id}}" {{/id}}
-				{{#meta}} data-meta="{{meta}}" {{/meta}}
-			>
-				<a href="{{url}}">
-				    {{#sponsor}}
-                    <div class="recirculation-sponsored-header">
-                        Sponsored
-                    </div>
-                    {{/sponsor}}
-					<div class="image image-thumbnail placeholder-thumbnail fluid small">
-						{{#thumbnail}}
-							<img src="{{thumbnail}}" alt="{{title}}" itemprop="thumbnail">
-						{{/thumbnail}}
-					</div>
-					<div class="title" title="{{title}}">{{title}}</div>
-					<div class="metadata">{{author}} &middot; <time class="timeago" datetime="{{pub_date}}">{{pub_date}}</time></div>
-				</a>
-				{{#sponsor}}
-                <div class="recirculation-sponsored-footer">
-                    Sponsored by {{sponsor}}
-                </div>
-                {{/sponsor}}
-			</li>
-		{{/items}}
-	</ul>
+  <h2>{{title}}</h2>
+  <ul class="thumbnails">
+    {{#items}}
+      <li class="item item-{{source}}{{#isVideo}} is-video{{/isVideo}}"
+          data-flag="{{flag}}"
+          data-index="{{index}}"
+          data-source="{{source}}"
+        {{#id}} data-id="{{id}}" {{/id}}
+        {{#meta}} data-meta="{{meta}}" {{/meta}}
+      >
+        <a href="{{url}}">
+          {{#sponsor}}
+            <div class="recirculation-sponsored-header">
+              Sponsored
+            </div>
+          {{/sponsor}}
+          <div class="image image-thumbnail placeholder-thumbnail fluid small">
+            {{#thumbnail}}
+              <img src="{{thumbnail}}" alt="{{title}}" itemprop="thumbnail">
+            {{/thumbnail}}
+          </div>
+          <div class="title" title="{{title}}">{{title}}</div>
+          <div class="metadata">{{author}} &middot; <time class="timeago" datetime="{{pub_date}}">{{pub_date}}</time></div>
+        </a>
+        {{#sponsor}}
+          <div class="recirculation-sponsored-footer">
+            Sponsored by {{sponsor}}
+          </div>
+        {{/sponsor}}
+      </li>
+    {{/items}}
+  </ul>
 </section>

--- a/extensions/wikia/Recirculation/templates/client/rail.mustache
+++ b/extensions/wikia/Recirculation/templates/client/rail.mustache
@@ -10,11 +10,11 @@
         {{#meta}} data-meta="{{meta}}" {{/meta}}
       >
         <a href="{{url}}">
-          {{#sponsor}}
+          {{#presented_by}}
             <div class="recirculation-sponsored-header">
               Sponsored
             </div>
-          {{/sponsor}}
+          {{/presented_by}}
           <div class="image image-thumbnail placeholder-thumbnail fluid small">
             {{#thumbnail}}
               <img src="{{thumbnail}}" alt="{{title}}" itemprop="thumbnail">
@@ -23,11 +23,11 @@
           <div class="title" title="{{title}}">{{title}}</div>
           <div class="metadata">{{author}} &middot; <time class="timeago" datetime="{{pub_date}}">{{pub_date}}</time></div>
         </a>
-        {{#sponsor}}
+        {{#presented_by}}
           <div class="recirculation-sponsored-footer">
-            Sponsored by {{sponsor}}
+            Sponsored by {{presented_by}}
           </div>
-        {{/sponsor}}
+        {{/presented_by}}
       </li>
     {{/items}}
   </ul>


### PR DESCRIPTION
@Wikia/cake 
https://wikia-inc.atlassian.net/browse/CAKE-1079

Adding sponsored indicator on the right rail. Since we send this as `presented_by` I'm assuming it will come back that way. If that's not true we can change this afterwards.

The result is:

![image](https://cloud.githubusercontent.com/assets/325800/21733901/a06c973e-d415-11e6-903b-3f9ff1a8adaf.png)
