### PR TITLE
cake-1080 - add sponsored indicator for impact footer items

### DIFF
--- a/extensions/wikia/Recirculation/styles/impact-footer.scss
+++ b/extensions/wikia/Recirculation/styles/impact-footer.scss
@@ -62,7 +62,7 @@ $recirculation-impact-footer-color-feature-overlay: rgba(0, 0, 0, .75);
 
 	}
 
-	.title_pretext {
+	.title_pretext, .recirculation-sponsored-header {
 		display: none;
 	}
 
@@ -73,6 +73,10 @@ $recirculation-impact-footer-color-feature-overlay: rgba(0, 0, 0, .75);
 	.item:nth-of-type(1),
 	.item:nth-of-type(6) {
 		width: 49.5%;
+
+		.recirculation-sponsored-header {
+			display: block;
+		}
 
 		.recirc-footer-title-container {
 			background-color: $recirculation-impact-footer-color-feature-overlay;

--- a/extensions/wikia/Recirculation/styles/impact-footer.scss
+++ b/extensions/wikia/Recirculation/styles/impact-footer.scss
@@ -62,6 +62,10 @@ $recirculation-impact-footer-color-feature-overlay: rgba(0, 0, 0, .75);
 
 	}
 
+	.title_pretext {
+		display: none;
+	}
+
 	.item:nth-of-type(n+6) {
 		width: 32.5%;
 	}
@@ -70,25 +74,40 @@ $recirculation-impact-footer-color-feature-overlay: rgba(0, 0, 0, .75);
 	.item:nth-of-type(6) {
 		width: 49.5%;
 
-		h4 {
+		.recirc-footer-title-container {
 			background-color: $recirculation-impact-footer-color-feature-overlay;
 			bottom: 0;
 			color: $color-white;
-			font-size: 24px;
 			left: 0;
-			line-height: 28px;
 			min-height: 70px;
-			padding: 10px;
+			padding: 15px;
 			position: absolute;
 			right: 0;
-		}
 
-		h4::before {
-			content: attr(data-tag);
-			display: block;
-			font-size: 12px;
-			font-style: italic;
-			line-height: 14px;
+			.title_pretext {
+				display: flex;
+				color: #CCC;
+				line-height: 14px;
+
+				.featured-fandom-subtitle {
+					flex-grow: 1;
+					font-size: 12px;
+					font-style: italic;
+				}
+
+				.recirculation-sponsored-footer {
+					flex-grow: 1;
+					text-align: right;
+					font-size: 10px;
+					padding: 0;
+				}
+			}
+
+			h4 {
+				padding-top: 5px;
+				font-size: 24px;
+				line-height: 28px;
+			}
 		}
 
 		.thumbnail {

--- a/extensions/wikia/Recirculation/templates/client/impactFooter.mustache
+++ b/extensions/wikia/Recirculation/templates/client/impactFooter.mustache
@@ -9,12 +9,29 @@
 				{{#meta}} data-meta="{{meta}}" {{/meta}}
 			>
 				<a title="{{title}}" href="{{url}}" class="track-items">
+          {{#presented_by}}
+            <div class="recirculation-sponsored-header">
+              Sponsored
+            </div>
+          {{/presented_by}}
 					<div class="thumbnail placeholder-thumbnail">
 						{{#thumbnail}}
 							<img src="{{thumbnail}}" alt="{{title}}">
 						{{/thumbnail}}
 					</div>
-					<h4 data-tag="{{i18n.featuredFandomSubtitle}}">{{title}}</h4>
+          <div class="recirc-footer-title-container">
+            <div class="title_pretext">
+              <div class="featured-fandom-subtitle">
+                {{i18n.featuredFandomSubtitle}}
+              </div>
+              {{#presented_by}}
+                <div class="recirculation-sponsored-footer">
+                  Sponsored by {{presented_by}}
+                </div>
+              {{/presented_by}}
+            </div>
+            <h4>{{title}}</h4>
+          </div>
 				</a>
 			</div>
 		{{/items}}

--- a/extensions/wikia/Recirculation/templates/client/impactFooter.mustache
+++ b/extensions/wikia/Recirculation/templates/client/impactFooter.mustache
@@ -1,24 +1,24 @@
 <section class="recirculation-impact-footer recirculation-unit">
-	<h2>{{i18n.title}}</h2>
-	<div class="items">
-		{{#items}}
-			<div class="item item-{{source}}{{#isVideo}} is-video{{/isVideo}}"
-				data-index="{{index}}"
-				data-source="{{source}}"
-				{{#id}} data-id="{{id}}" {{/id}}
-				{{#meta}} data-meta="{{meta}}" {{/meta}}
-			>
-				<a title="{{title}}" href="{{url}}" class="track-items">
+  <h2>{{i18n.title}}</h2>
+  <div class="items">
+    {{#items}}
+      <div class="item item-{{source}}{{#isVideo}} is-video{{/isVideo}}"
+           data-index="{{index}}"
+           data-source="{{source}}"
+        {{#id}} data-id="{{id}}" {{/id}}
+        {{#meta}} data-meta="{{meta}}" {{/meta}}
+      >
+        <a title="{{title}}" href="{{url}}" class="track-items">
           {{#presented_by}}
             <div class="recirculation-sponsored-header">
               Sponsored
             </div>
           {{/presented_by}}
-					<div class="thumbnail placeholder-thumbnail">
-						{{#thumbnail}}
-							<img src="{{thumbnail}}" alt="{{title}}">
-						{{/thumbnail}}
-					</div>
+          <div class="thumbnail placeholder-thumbnail">
+            {{#thumbnail}}
+              <img src="{{thumbnail}}" alt="{{title}}">
+            {{/thumbnail}}
+          </div>
           <div class="recirc-footer-title-container">
             <div class="title_pretext">
               <div class="featured-fandom-subtitle">
@@ -32,44 +32,44 @@
             </div>
             <h4>{{title}}</h4>
           </div>
-				</a>
-			</div>
-		{{/items}}
-	</div>
+        </a>
+      </div>
+    {{/items}}
+  </div>
 
-{{#discussions}}
-<div class="discussion-module">
-	<div class="discussion-header">
-		<div class="discussion-header-alpha">
-			<h3>{{i18n.discussionsTitle}}</h3>
-			<a href="{{discussionsUrl}}">{{i18n.discussionsLinkText}} <svg xmlns="http://www.w3.org/2000/svg" width="16" height="12" viewBox="0 0 16 12"><path class="arrow-path" fill-rule="evenodd" fill="#FFFFFF" d="m9.96924,0l-1.04453,1.04453l4.17812,4.17813l-13.10283,0l0,1.49218l13.10283,0l-4.17812,4.17813l1.04453,1.04453l5.96875,-5.96875l-5.96875,-5.96875z" /></svg></a>
-		</div>
-	</div>
+  {{#discussions}}
+    <div class="discussion-module">
+      <div class="discussion-header">
+        <div class="discussion-header-alpha">
+          <h3>{{i18n.discussionsTitle}}</h3>
+          <a href="{{discussionsUrl}}">{{i18n.discussionsLinkText}} <svg xmlns="http://www.w3.org/2000/svg" width="16" height="12" viewBox="0 0 16 12"><path class="arrow-path" fill-rule="evenodd" fill="#FFFFFF" d="m9.96924,0l-1.04453,1.04453l4.17812,4.17813l-13.10283,0l0,1.49218l13.10283,0l-4.17812,4.17813l1.04453,1.04453l5.96875,-5.96875l-5.96875,-5.96875z" /></svg></a>
+        </div>
+      </div>
 
-	<ul class="discussion-threads">
-		{{#posts}}
-		  <li class="discussion-thread" data-index="{{index}}" data-source="{{source}}"><a class="track-discussions" href="{{url}}">
-			<div class="discussion-author">
-				<img src="{{meta.authorAvatarUrl}}" class="discussion-author-avatar" />
-				<h4>{{author}}</h4>
-				<span class="subtext">&#183; <time class="discussion-timestamp" datetime="{{pub_date}}"></time></span>
-			</div>
-			<p class="discussion-content">{{title}}</p>
-			<div class="discussion-meta">
-				<div class="discussion-upvotes-container">
-					<span class="subtext">{{meta.upvoteCount}} {{i18n.discussionsUpvotes}}</span>
-				</div>
-				<div class="discussion-comments-container">
-					<span class="subtext">{{meta.postCount}} {{i18n.discussionsReplies}}</span>
-				</div>
-			</div>
-		  </a></li>
-		{{/posts}}
-	</ul>
+      <ul class="discussion-threads">
+        {{#posts}}
+          <li class="discussion-thread" data-index="{{index}}" data-source="{{source}}"><a class="track-discussions" href="{{url}}">
+            <div class="discussion-author">
+              <img src="{{meta.authorAvatarUrl}}" class="discussion-author-avatar" />
+              <h4>{{author}}</h4>
+              <span class="subtext">&#183; <time class="discussion-timestamp" datetime="{{pub_date}}"></time></span>
+            </div>
+            <p class="discussion-content">{{title}}</p>
+            <div class="discussion-meta">
+              <div class="discussion-upvotes-container">
+                <span class="subtext">{{meta.upvoteCount}} {{i18n.discussionsUpvotes}}</span>
+              </div>
+              <div class="discussion-comments-container">
+                <span class="subtext">{{meta.postCount}} {{i18n.discussionsReplies}}</span>
+              </div>
+            </div>
+          </a></li>
+        {{/posts}}
+      </ul>
 
-	<div class="discussion-footer">
-		<a href="{{discussionsUrl}}" class="button discussion-new">{{i18n.discussionsNew}}</a>
-	</div>
-</div>
-{{/discussions}}
+      <div class="discussion-footer">
+        <a href="{{discussionsUrl}}" class="button discussion-new">{{i18n.discussionsNew}}</a>
+      </div>
+    </div>
+  {{/discussions}}
 </section>


### PR DESCRIPTION
@Wikia/cake 
https://wikia-inc.atlassian.net/browse/CAKE-1080

Adding "sponsored" indicator for impact footer elements. The output looks like:

![image](https://cloud.githubusercontent.com/assets/325800/21736771/ec0a2dfc-d427-11e6-8a01-2a1a0594a884.png)
