### PR TITLE
CAKE-1080 Explicitly set the request fields for liftigniter 

### DIFF
--- a/extensions/wikia/Recirculation/js/helpers/LiftigniterHelper.js
+++ b/extensions/wikia/Recirculation/js/helpers/LiftigniterHelper.js
@@ -34,6 +34,7 @@ define('ext.wikia.recirculation.helpers.liftigniter', [
 
 			// Callback renders and injects results into the placeholder.
 			w.$p('register', registerOptions);
+			w.$p("setRequestFields", ["rank", "thumbnail", "title", "url", "presented_by"]);
 
 			if (options.flush) {
 				w.$p('fetch');

--- a/extensions/wikia/Recirculation/js/helpers/LiftigniterHelper.js
+++ b/extensions/wikia/Recirculation/js/helpers/LiftigniterHelper.js
@@ -34,7 +34,7 @@ define('ext.wikia.recirculation.helpers.liftigniter', [
 
 			// Callback renders and injects results into the placeholder.
 			w.$p('register', registerOptions);
-			w.$p("setRequestFields", ["rank", "thumbnail", "title", "url", "presented_by"]);
+			w.$p("setRequestFields", ["rank", "thumbnail", "title", "url", "presented_by", "author"]);
 
 			if (options.flush) {
 				w.$p('fetch');


### PR DESCRIPTION
Explicitly set the request fields for LI and include the "presented_by" field for the sponsored presentation. See PRs #12181, #12182 for the related UI changes.

https://wikia-inc.atlassian.net/browse/CAKE-1080
https://wikia-inc.atlassian.net/browse/CAKE-1079

@Wikia/cake 

