### PR TITLE
XW-2572 | Portable infoboxes: support for 'row-items' attribute in <group> and 'span' and 'layout' in <data>

### DIFF
--- a/extensions/wikia/PortableInfobox/services/Parser/Nodes/NodeData.php
+++ b/extensions/wikia/PortableInfobox/services/Parser/Nodes/NodeData.php
@@ -2,15 +2,34 @@
 namespace Wikia\PortableInfobox\Parser\Nodes;
 
 class NodeData extends Node {
+	const SPAN_ATTR_NAME = 'span';
+	const SPAN_DEFAULT_VALUE = 1;
+
+	const LAYOUT_ATTR_NAME = 'layout';
+	const LAYOUT_DEFAULT_VALUE = 'default';
 
 	public function getData() {
 		if ( !isset( $this->data ) ) {
 			$this->data = [
 				'label' => $this->getInnerValue( $this->xmlNode->{self::LABEL_TAG_NAME} ),
-				'value' => $this->getValueWithDefault( $this->xmlNode )
+				'value' => $this->getValueWithDefault( $this->xmlNode ),
+				'span' => $this->getSpan(),
+				'layout' => $this->getLayout()
 			];
 		}
 
 		return $this->data;
+	}
+
+	protected function getSpan() {
+		$span = $this->getXmlAttribute( $this->xmlNode, self::SPAN_ATTR_NAME );
+
+		return ( isset( $span ) && ctype_digit( $span ) ) ? $span : self::SPAN_DEFAULT_VALUE;
+	}
+
+	protected function getLayout() {
+		$layout = $this->getXmlAttribute( $this->xmlNode, self::LAYOUT_ATTR_NAME );
+
+		return ( isset( $layout ) && $layout == self::LAYOUT_DEFAULT_VALUE ) ? $layout : null;
 	}
 }

--- a/extensions/wikia/PortableInfobox/services/Parser/Nodes/NodeData.php
+++ b/extensions/wikia/PortableInfobox/services/Parser/Nodes/NodeData.php
@@ -24,7 +24,7 @@ class NodeData extends Node {
 	protected function getSpan() {
 		$span = $this->getXmlAttribute( $this->xmlNode, self::SPAN_ATTR_NAME );
 
-		return ( isset( $span ) && ctype_digit( $span ) ) ? $span : self::SPAN_DEFAULT_VALUE;
+		return ( isset( $span ) && ctype_digit( $span ) ) ? intval( $span ) : self::SPAN_DEFAULT_VALUE;
 	}
 
 	protected function getLayout() {

--- a/extensions/wikia/PortableInfobox/services/Parser/Nodes/NodeGroup.php
+++ b/extensions/wikia/PortableInfobox/services/Parser/Nodes/NodeGroup.php
@@ -107,6 +107,6 @@ class NodeGroup extends Node {
 	protected function getRowItems() {
 		$rowItems = $this->getXmlAttribute( $this->xmlNode, self::ROW_ITEMS_ATTR_NAME );
 
-		return ( isset( $rowItems ) && ctype_digit( $rowItems ) ) ? $rowItems : null;
+		return ( isset( $rowItems ) && ctype_digit( $rowItems ) ) ? intval( $rowItems ) : null;
 	}
 }

--- a/extensions/wikia/PortableInfobox/services/Parser/Nodes/NodeGroup.php
+++ b/extensions/wikia/PortableInfobox/services/Parser/Nodes/NodeGroup.php
@@ -11,6 +11,7 @@ class NodeGroup extends Node {
 	const COLLAPSE_ATTR_NAME = 'collapse';
 	const COLLAPSE_OPEN_OPTION = 'open';
 	const COLLAPSE_CLOSED_OPTION = 'closed';
+	const ROW_ITEMS_ATTR_NAME = 'row-items';
 
 	private $supportedGroupLayouts = [
 		self::LAYOUT_DEFAULT_OPTION,
@@ -32,7 +33,8 @@ class NodeGroup extends Node {
 			$this->data = [
 				'value' => $this->getDataForChildren(),
 				'layout' => $this->getLayout(),
-				'collapse' => $this->getCollapse()
+				'collapse' => $this->getCollapse(),
+				'row-items' => $this->getRowItems()
 			];
 		}
 
@@ -54,7 +56,8 @@ class NodeGroup extends Node {
 			'data' => [
 				'value' => $value,
 				'layout' => $this->getLayout(),
-				'collapse' => $this->getCollapse()
+				'collapse' => $this->getCollapse(),
+				'row-items' => $this->getRowItems()
 			],
 		];
 	}
@@ -99,5 +102,11 @@ class NodeGroup extends Node {
 
 		return ( isset( $layout ) && in_array( $layout, $this->supportedGroupLayouts ) ) ? $layout
 			: self::LAYOUT_DEFAULT_OPTION;
+	}
+
+	protected function getRowItems() {
+		$rowItems = $this->getXmlAttribute( $this->xmlNode, self::ROW_ITEMS_ATTR_NAME );
+
+		return ( isset( $rowItems ) && ctype_digit( $rowItems ) ) ? $rowItems : null;
 	}
 }

--- a/extensions/wikia/PortableInfobox/tests/PortableInfoboxDataServiceTest.php
+++ b/extensions/wikia/PortableInfobox/tests/PortableInfoboxDataServiceTest.php
@@ -53,7 +53,7 @@ class PortableInfoboxDataServiceTest extends WikiaBaseTest {
 			->save( $infoboxNode )
 			->getData();
 
-		$this->assertEquals( [ [ 'data' => [ [ 'type' => 'data', 'data' => [ 'label' => null, 'value' => 1 ] ] ],
+		$this->assertEquals( [ [ 'data' => [ [ 'type' => 'data', 'data' => [ 'label' => null, 'value' => 1, 'layout' => null, 'span' => 1 ] ] ],
 								 'sources' => [ 'test', 'test2' ] ] ], $result );
 	}
 

--- a/extensions/wikia/PortableInfobox/tests/nodes/NodeDataTest.php
+++ b/extensions/wikia/PortableInfobox/tests/nodes/NodeDataTest.php
@@ -168,25 +168,30 @@ class NodeDataTest extends WikiaBaseTest {
 
 	public function dataProvider() {
 		return [
-			[ '<data source="test"></data>', [ 'test' => 'test' ], [ 'value' => 'test', 'label' => '' ] ],
-			[ '<data source="test"><default>def</default></data>', [ ], [ 'value' => 'def', 'label' => '' ] ],
+			[ '<data source="test"></data>', [ 'test' => 'test' ], [ 'value' => 'test', 'label' => '', 'span' => 1, 'layout' => null ] ],
+			[ '<data source="test" span="2"></data>', [ 'test' => 'test' ], [ 'value' => 'test', 'label' => '', 'span' => '2', 'layout' => null ] ],
+			[ '<data source="test" span="2.2"></data>', [ 'test' => 'test' ], [ 'value' => 'test', 'label' => '', 'span' => 1, 'layout' => null ] ],
+			[ '<data source="test" span="non_numeric_span"></data>', [ 'test' => 'test' ], [ 'value' => 'test', 'label' => '', 'span' => 1, 'layout' => null ] ],
+			[ '<data source="test" layout="wrong layout"></data>', [ 'test' => 'test' ], [ 'value' => 'test', 'label' => '', 'span' => 1, 'layout' => null ] ],
+			[ '<data source="test" layout="default"></data>', [ 'test' => 'test' ], [ 'value' => 'test', 'label' => '', 'span' => 1, 'layout' => 'default' ] ],
+			[ '<data source="test"><default>def</default></data>', [ ], [ 'value' => 'def', 'label' => '', 'span' => 1, 'layout' => null ] ],
 			[ '<data source="test"><label>l</label><default>def</default></data>', [ ],
-			  [ 'value' => 'def', 'label' => 'l' ] ],
+			  [ 'value' => 'def', 'label' => 'l', 'span' => 1, 'layout' => null ] ],
 			[ '<data source="test"><label source="l">jjj</label><default>def</default></data>', [ 'l' => 1 ],
-			  [ 'value' => 'def', 'label' => 'jjj' ] ],
+			  [ 'value' => 'def', 'label' => 'jjj', 'span' => 1, 'layout' => null ] ],
 			[ '<data source="test"><label source="l" /><default>def</default></data>', [ 'l' => 1 ],
-			  [ 'value' => 'def', 'label' => '' ] ],
+			  [ 'value' => 'def', 'label' => '', 'span' => 1, 'layout' => null ] ],
 			[ '<data source="test"><label>l</label><default>def</default></data>', [ 'test' => 1 ],
-			  [ 'value' => 1, 'label' => 'l' ] ],
-			[ '<data></data>', [ ], [ 'label' => '', 'value' => null ] ],
+			  [ 'value' => 1, 'label' => 'l', 'span' => 1, 'layout' => null ] ],
+			[ '<data></data>', [ ], [ 'label' => '', 'value' => null, 'span' => 1, 'layout' => null ] ],
 			[ '<data source="test"><label>l</label><format>{{{test}}}%</format><default>def</default></data>', [ 'test' => 1 ],
-			  [ 'value' => '{{{test}}}%', 'label' => 'l' ] ],
+			  [ 'value' => '{{{test}}}%', 'label' => 'l', 'span' => 1, 'layout' => null ] ],
 			[ '<data source="test"><label>l</label><format>{{{not_defined_var}}}%</format><default>def</default></data>', [ 'test' => 1 ],
-				[ 'value' => '{{{not_defined_var}}}%', 'label' => 'l' ] ],
+				[ 'value' => '{{{not_defined_var}}}%', 'label' => 'l', 'span' => 1, 'layout' => null ] ],
 			[ '<data source="test"><label>l</label><format>{{{test}}}%</format><default>def</default></data>', [ ],
-				[ 'value' => 'def', 'label' => 'l' ] ],
+				[ 'value' => 'def', 'label' => 'l', 'span' => 1, 'layout' => null ] ],
 			[ '<data source="test"><format>{{{test}}}%</format></data>', [ 'test' => 0 ],
-				[ 'value' => '{{{test}}}%', 'label' => '' ] ],
+				[ 'value' => '{{{test}}}%', 'label' => '', 'span' => 1, 'layout' => null ] ],
 		];
 	}
 
@@ -208,8 +213,28 @@ class NodeDataTest extends WikiaBaseTest {
 		return [
 			[ '<data source="test"></data>',
 				[ 'test' => 'test' ],
-				[ 'type' => 'data', 'data' => [ 'value' => 'test', 'label' => '' ] ]
-			]
+				[ 'type' => 'data', 'data' => [ 'value' => 'test', 'label' => '', 'span' => 1, 'layout' => null ] ]
+			],
+			[ '<data source="test" layout="default"></data>',
+				[ 'test' => 'test' ],
+				[ 'type' => 'data', 'data' => [ 'value' => 'test', 'label' => '', 'span' => 1, 'layout' => 'default' ] ]
+			],
+			[ '<data source="test" layout="wrong_layout"></data>',
+				[ 'test' => 'test' ],
+				[ 'type' => 'data', 'data' => [ 'value' => 'test', 'label' => '', 'span' => 1, 'layout' => null ] ]
+			],
+			[ '<data source="test" span="2"></data>',
+				[ 'test' => 'test' ],
+				[ 'type' => 'data', 'data' => [ 'value' => 'test', 'label' => '', 'span' => '2', 'layout' => null ] ]
+			],
+			[ '<data source="test" span="2.2"></data>',
+				[ 'test' => 'test' ],
+				[ 'type' => 'data', 'data' => [ 'value' => 'test', 'label' => '', 'span' => 1, 'layout' => null ] ]
+			],
+			[ '<data source="test" span="non numeric span"></data>',
+				[ 'test' => 'test' ],
+				[ 'type' => 'data', 'data' => [ 'value' => 'test', 'label' => '', 'span' => 1, 'layout' => null ] ]
+			],
 		];
 	}
 

--- a/extensions/wikia/PortableInfobox/tests/nodes/NodeGroupTest.php
+++ b/extensions/wikia/PortableInfobox/tests/nodes/NodeGroupTest.php
@@ -29,6 +29,31 @@ class NodeGroupTest extends WikiaBaseTest {
 
 	/**
 	 * @covers       \Wikia\PortableInfobox\Parser\Nodes\NodeGroup::getData
+	 * @covers       \Wikia\PortableInfobox\Parser\Nodes\NodeGroup::getRenderData
+	 * @dataProvider groupNodeRowItemsTestProvider
+	 *
+	 * @param $markup
+	 * @param $expected
+	 */
+	public function testNodeGroupRowItems( $markup, $expected ) {
+		$node = \Wikia\PortableInfobox\Parser\Nodes\NodeFactory::newFromXML( $markup );
+		$this->assertEquals( $expected, $node->getData()[ 'row-items' ] );
+		$this->assertEquals( $expected, $node->getRenderData()[ 'data' ][ 'row-items' ] );
+	}
+
+	public function groupNodeRowItemsTestProvider() {
+		return [
+			[ '<group></group>', null ],
+			[ '<group row-items="not a number"></group>', null ],
+			[ '<group row-items="5.5"></group>', null ],
+			[ '<group row-items="5"></group>', '5' ],
+			[ '<group row-items="50"></group>', '50' ],
+		];
+	}
+
+
+	/**
+	 * @covers       \Wikia\PortableInfobox\Parser\Nodes\NodeGroup::getData
 	 * @dataProvider groupNodeTestProvider
 	 *
 	 * @param $markup
@@ -56,7 +81,8 @@ class NodeGroupTest extends WikiaBaseTest {
 						  'source' => [ 'elem3' ] ]
 					],
 				'layout' => 'default',
-				'collapse' => null
+				'collapse' => null,
+				'row-items' => null
 			  ] ],
 			[ '<group layout="horizontal"><data source="elem1"><label>l1</label><default>def1</default></data><data source="elem2">
 				<label>l2</label><default>def2</default></data><data source="elem3"><label>l2</label></data></group>',
@@ -71,7 +97,8 @@ class NodeGroupTest extends WikiaBaseTest {
 						  'source' => [ 'elem3' ] ],
 					],
 				'layout' => 'horizontal',
-				'collapse' => null
+				'collapse' => null,
+				'row-items' => null
 			  ] ],
 			[ '<group  layout="loool"><data source="elem1"><label>l1</label><default>def1</default></data><data source="elem2">
 				<label>l2</label><default>def2</default></data><data source="elem3"><label>l2</label></data></group>',
@@ -86,7 +113,8 @@ class NodeGroupTest extends WikiaBaseTest {
 						  'source' => [ 'elem3' ] ],
 					],
 				'layout' => 'default',
-				'collapse' => null
+				'collapse' => null,
+				'row-items' => null
 			  ] ],
 			[ '<group show="incomplete"><header>h</header><data source="1"/><data source="2"/></group>',
 			  [ '1' => 'one', '2' => 'two' ],
@@ -98,7 +126,8 @@ class NodeGroupTest extends WikiaBaseTest {
 					'source' => [ '2' ] ],
 			  ],
 				'layout' => 'default',
-				'collapse' => null
+				'collapse' => null,
+				'row-items' => null
 			  ] ],
 			[ '<group show="incomplete"><header>h</header><data source="1"/><data source="2"/></group>',
 			  [ '1' => 'one' ],
@@ -110,7 +139,9 @@ class NodeGroupTest extends WikiaBaseTest {
 					'source' => [ '2' ] ]
 			  ],
 				'layout' => 'default',
-				'collapse' => null
+				'collapse' => null,
+				'row-items' => null
+
 			  ] ],
 			[ '<group show="incomplete"><header>h</header><data source="1"/><data source="2"/></group>', [ ],
 			  [ 'value' => [
@@ -121,7 +152,8 @@ class NodeGroupTest extends WikiaBaseTest {
 					'source' => [ '2' ] ],
 			  ],
 				'layout' => 'default',
-				'collapse' => null
+				'collapse' => null,
+				'row-items' => null
 			  ] ]
 		];
 	}

--- a/extensions/wikia/PortableInfobox/tests/nodes/NodeGroupTest.php
+++ b/extensions/wikia/PortableInfobox/tests/nodes/NodeGroupTest.php
@@ -73,11 +73,11 @@ class NodeGroupTest extends WikiaBaseTest {
 			  [ 'elem1' => 1, 'elem2' => 2 ],
 			  [ 'value' =>
 					[
-						[ 'type' => 'data', 'isEmpty' => false, 'data' => [ 'label' => 'l1', 'value' => 1 ],
+						[ 'type' => 'data', 'isEmpty' => false, 'data' => [ 'label' => 'l1', 'value' => 1, 'span' => 1, 'layout' => null ],
 						  'source' => [ 'elem1' ] ],
-						[ 'type' => 'data', 'isEmpty' => false, 'data' => [ 'label' => 'l2', 'value' => 2 ],
+						[ 'type' => 'data', 'isEmpty' => false, 'data' => [ 'label' => 'l2', 'value' => 2, 'span' => 1, 'layout' => null ],
 						  'source' => [ 'elem2' ] ],
-						[ 'type' => 'data', 'isEmpty' => true, 'data' => [ 'label' => 'l2', 'value' => null ],
+						[ 'type' => 'data', 'isEmpty' => true, 'data' => [ 'label' => 'l2', 'value' => null, 'span' => 1, 'layout' => null ],
 						  'source' => [ 'elem3' ] ]
 					],
 				'layout' => 'default',
@@ -89,11 +89,11 @@ class NodeGroupTest extends WikiaBaseTest {
 			  [ 'elem1' => 1, 'elem2' => 2 ],
 			  [ 'value' =>
 					[
-						[ 'type' => 'data', 'isEmpty' => false, 'data' => [ 'label' => 'l1', 'value' => 1 ],
+						[ 'type' => 'data', 'isEmpty' => false, 'data' => [ 'label' => 'l1', 'value' => 1, 'span' => 1, 'layout' => null ],
 						  'source' => [ 'elem1' ] ],
-						[ 'type' => 'data', 'isEmpty' => false, 'data' => [ 'label' => 'l2', 'value' => 2 ],
+						[ 'type' => 'data', 'isEmpty' => false, 'data' => [ 'label' => 'l2', 'value' => 2, 'span' => 1, 'layout' => null ],
 						  'source' => [ 'elem2' ] ],
-						[ 'type' => 'data', 'isEmpty' => true, 'data' => [ 'label' => 'l2', 'value' => null ],
+						[ 'type' => 'data', 'isEmpty' => true, 'data' => [ 'label' => 'l2', 'value' => null, 'span' => 1, 'layout' => null ],
 						  'source' => [ 'elem3' ] ],
 					],
 				'layout' => 'horizontal',
@@ -105,11 +105,11 @@ class NodeGroupTest extends WikiaBaseTest {
 			  [ 'elem1' => 1, 'elem2' => 2 ],
 			  [ 'value' =>
 					[
-						[ 'type' => 'data', 'isEmpty' => false, 'data' => [ 'label' => 'l1', 'value' => 1 ],
+						[ 'type' => 'data', 'isEmpty' => false, 'data' => [ 'label' => 'l1', 'value' => 1, 'span' => 1, 'layout' => null ],
 						  'source' => [ 'elem1' ] ],
-						[ 'type' => 'data', 'isEmpty' => false, 'data' => [ 'label' => 'l2', 'value' => 2 ],
+						[ 'type' => 'data', 'isEmpty' => false, 'data' => [ 'label' => 'l2', 'value' => 2, 'span' => 1, 'layout' => null ],
 						  'source' => [ 'elem2' ] ],
-						[ 'type' => 'data', 'isEmpty' => true, 'data' => [ 'label' => 'l2', 'value' => null ],
+						[ 'type' => 'data', 'isEmpty' => true, 'data' => [ 'label' => 'l2', 'value' => null, 'span' => 1, 'layout' => null ],
 						  'source' => [ 'elem3' ] ],
 					],
 				'layout' => 'default',
@@ -120,9 +120,9 @@ class NodeGroupTest extends WikiaBaseTest {
 			  [ '1' => 'one', '2' => 'two' ],
 			  [ 'value' => [
 				  [ 'type' => 'header', 'data' => [ 'value' => 'h' ], 'isEmpty' => false, 'source' => [ ] ],
-				  [ 'type' => 'data', 'data' => [ 'value' => 'one', 'label' => '' ], 'isEmpty' => false,
+				  [ 'type' => 'data', 'data' => [ 'value' => 'one', 'label' => '', 'span' => 1, 'layout' => null ], 'isEmpty' => false,
 					'source' => [ '1' ] ],
-				  [ 'type' => 'data', 'data' => [ 'value' => 'two', 'label' => '' ], 'isEmpty' => false,
+				  [ 'type' => 'data', 'data' => [ 'value' => 'two', 'label' => '', 'span' => 1, 'layout' => null ], 'isEmpty' => false,
 					'source' => [ '2' ] ],
 			  ],
 				'layout' => 'default',
@@ -133,9 +133,9 @@ class NodeGroupTest extends WikiaBaseTest {
 			  [ '1' => 'one' ],
 			  [ 'value' => [
 				  [ 'type' => 'header', 'data' => [ 'value' => 'h' ], 'isEmpty' => false, 'source' => [ ] ],
-				  [ 'type' => 'data', 'data' => [ 'value' => 'one', 'label' => '' ], 'isEmpty' => false,
+				  [ 'type' => 'data', 'data' => [ 'value' => 'one', 'label' => '', 'span' => 1, 'layout' => null ], 'isEmpty' => false,
 					'source' => [ '1' ] ],
-				  [ 'type' => 'data', 'data' => [ 'value' => null, 'label' => '' ], 'isEmpty' => true,
+				  [ 'type' => 'data', 'data' => [ 'value' => null, 'label' => '', 'span' => 1, 'layout' => null ], 'isEmpty' => true,
 					'source' => [ '2' ] ]
 			  ],
 				'layout' => 'default',
@@ -146,9 +146,9 @@ class NodeGroupTest extends WikiaBaseTest {
 			[ '<group show="incomplete"><header>h</header><data source="1"/><data source="2"/></group>', [ ],
 			  [ 'value' => [
 				  [ 'type' => 'header', 'data' => [ 'value' => 'h' ], 'isEmpty' => false, 'source' => [ ] ],
-				  [ 'type' => 'data', 'data' => [ 'value' => null, 'label' => '' ], 'isEmpty' => true,
+				  [ 'type' => 'data', 'data' => [ 'value' => null, 'label' => '', 'span' => 1, 'layout' => null ], 'isEmpty' => true,
 					'source' => [ '1' ] ],
-				  [ 'type' => 'data', 'data' => [ 'value' => null, 'label' => '' ], 'isEmpty' => true,
+				  [ 'type' => 'data', 'data' => [ 'value' => null, 'label' => '', 'span' => 1, 'layout' => null ], 'isEmpty' => true,
 					'source' => [ '2' ] ],
 			  ],
 				'layout' => 'default',


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/XW-2572
https://wikia-inc.atlassian.net/browse/XW-2569

Portable infoboxes: support for 'row-items' attribute in <group> and 'span' and 'layout' in <data>

//cc @idradm @latata 