### PR TITLE
SOC-3743 Fix encoding and escaping issues during migration

### DIFF
--- a/extensions/wikia/Discussions/maintenance/ForumDumper.php
+++ b/extensions/wikia/Discussions/maintenance/ForumDumper.php
@@ -20,8 +20,6 @@ class ForumDumper {
 	// MySQL to fail the insert.
 	const MAX_CONTENT_SIZE = 65520;
 
-	const REGEXP_MATCH_TITLE = '/<ac_metadata.*title="([^"]*)".*>.*<\/ac_metadata>/';
-
 	// A very loose interpretation of markup favoring false positives for markup.  Match
 	// alphanumerics, anything in a basic URL and punctuation.  If any character in the text
 	// doesn't match, assume there is wiki text and parse it.
@@ -74,25 +72,14 @@ class ForumDumper {
 		"timestamp",
 	];
 
+	const FORUM_NAMEPSACES = [
+		NS_WIKIA_FORUM_BOARD,
+		NS_WIKIA_FORUM_BOARD_THREAD
+	];
+
 	private $pages = [];
 	private $revisions = [];
 	private $votes = [];
-
-	private $dummyTitle;
-	private $parserOptions;
-
-	public function __construct() {
-		$this->dummyTitle = \Title::newFromText( "Dummy" );
-		$this->parserOptions = new \ParserOptions();
-		$this->parserOptions->setEditSection( false );
-	}
-
-	private function getForumNamespaces() {
-		return [
-			NS_WIKIA_FORUM_BOARD,
-			NS_WIKIA_FORUM_BOARD_THREAD
-		];
-	}
 
 	public function addPage( $id, $data ) {
 		$this->pages[$id] = $data;
@@ -116,7 +103,7 @@ class ForumDumper {
 			->SELECT_ALL()
 			->FROM( self::TABLE_PAGE )
 			->LEFT_JOIN( self::TABLE_COMMENTS )->ON( 'page_id', 'comment_id' )
-			->WHERE( 'page_namespace' )->IN( $this->getForumNamespaces() )
+			->WHERE( 'page_namespace' )->IN( self::FORUM_NAMEPSACES )
 			->runLoop( $dbh, function ( &$pages, $row ) {
 				$this->addPage( $row->page_id, [
 						"page_id" => $row->page_id,
@@ -159,12 +146,11 @@ class ForumDumper {
 			->JOIN( self::TABLE_TEXT )->ON( 'rev_text_id', 'old_id' )
 			->WHERE( 'rev_page' )->IN( $pageIds )
 			->runLoop( $dbh, function ( &$revisions, $row ) {
-				$textId = $row->old_text;
-				list( $parsedText, $plainText, $title ) = $this->getTextAndTitle( $textId );
+				list( $parsedText, $plainText, $title ) = $this->getTextAndTitle( $row->rev_page );
 
 				$pages = $this->getPages();
 				$curPage = $pages[$row->rev_page];
-				
+
 				$this->addRevision( [
 					"revision_id" => $row->rev_id,
 					"page_id" => $row->rev_page,
@@ -188,62 +174,42 @@ class ForumDumper {
 	}
 
 	public function getTextAndTitle( $textId ) {
-		$rawText = $this->getRawText( $textId );
+		$articleComment = \ArticleComment::newFromId( $textId );
+		$articleComment->load();
+
+		$rawText = $this->getRawText( $articleComment );
+		$title = $articleComment->getMetadata( 'title', '' );
+		$parsedText = $this->getParsedText( $rawText, $articleComment );
+
+		// Truncate the strings if they are too big
+		if ( strlen( $parsedText ) > self::MAX_CONTENT_SIZE ) {
+			$parsedText = substr( $parsedText, 0, self::MAX_CONTENT_SIZE );
+		}
+		if ( strlen( $rawText ) > self::MAX_CONTENT_SIZE ) {
+			$rawText = substr( $rawText, 0, self::MAX_CONTENT_SIZE );
+		}
+
+		return [ $parsedText, $rawText, $title ];
+	}
+
+	private function getRawText( \ArticleComment $articleComment ) {
+		$rawText = strip_tags( $articleComment->getRawText() );
 
 		// There are some bogus characters in our data.  Strip them out
-		$rawText = filter_var(
+		return filter_var(
 			$rawText,
 			FILTER_UNSAFE_RAW,
 			FILTER_FLAG_STRIP_LOW|FILTER_FLAG_STRIP_HIGH
 		);
-
-		// The title is included within the text as an ac_metadata tag
-		$title = $this->getTitle( $rawText );
-
-		// Parse the wiki text
-		$parsedText = $this->getParsedText( $rawText );
-
-		// Get a plain text version as well
-		$plainText = trim( strip_tags( $parsedText ) );
-
-		// Truncate the strings if they are too big
-		if ( strlen($parsedText) > self::MAX_CONTENT_SIZE ) {
-			$parsedText = substr( $parsedText, 0, self::MAX_CONTENT_SIZE );
-		}
-		if ( strlen($plainText) > self::MAX_CONTENT_SIZE ) {
-			$plainText = substr( $plainText, 0, self::MAX_CONTENT_SIZE );
-		}
-
-		return [ $parsedText, $plainText, $title ];
 	}
 
-	private function getRawText( $textId ) {
-		$text = \ExternalStore::fetchFromURL( $textId );
-		return gzinflate( $text );
-	}
-
-	private function getParsedText( $wikiText ) {
+	private function getParsedText( $wikiText, \ArticleComment $articleComment ) {
 		// If this text appears not to have any markup, just return the text as is.
 		if ( !preg_match( self::REGEXP_MATCH_HAS_MARKUP, $wikiText ) ) {
 			return $wikiText;
 		}
 
-		$parserOut = \F::app()->wg->Parser->parse(
-			$wikiText,
-			$this->dummyTitle,
-			$this->parserOptions
-		);
-		return $parserOut->getText();
-	}
-
-	private function getTitle( $text ) {
-		$title = '';
-
-		if ( preg_match( self::REGEXP_MATCH_TITLE, $text, $matches ) ) {
-			$title = $matches[1];
-		}
-
-		return $title;
+		return $articleComment->getText();
 	}
 
 	public function getContributorType( $row ) {
@@ -269,7 +235,6 @@ class ForumDumper {
 
 		$pageIds = array_keys( $this->getPages() );
 
-		$dumper = $this;
 		$dbh = wfGetDB( DB_SLAVE );
 		( new \WikiaSQL() )
 			->SELECT_ALL()

--- a/extensions/wikia/Discussions/maintenance/ForumDumper.php
+++ b/extensions/wikia/Discussions/maintenance/ForumDumper.php
@@ -204,7 +204,7 @@ class ForumDumper {
 		$parsedText = $this->getParsedText( $rawText );
 
 		// Get a plain text version as well
-		$plainText = strip_tags( $parsedText );
+		$plainText = trim( strip_tags( $parsedText ) );
 
 		// Truncate the strings if they are too big
 		if ( strlen($parsedText) > self::MAX_CONTENT_SIZE ) {

--- a/extensions/wikia/Discussions/maintenance/dumpForumData.php
+++ b/extensions/wikia/Discussions/maintenance/dumpForumData.php
@@ -29,19 +29,24 @@ class DumpForumData extends Maintenance {
 		}
 		$this->dumper = new Discussions\ForumDumper();
 
+		$this->setConnectinoEncoding();
 		$this->clearImportTables();
 		$this->dumpPages();
 		$this->dumpRevisions();
 		$this->dumpVotes();
 	}
 
-	public function clearImportTables() {
+	private function setConnectinoEncoding() {
+		fwrite( $this->fh, "SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci;" );
+	}
+
+	private function clearImportTables() {
 		fwrite( $this->fh, "DELETE FROM import_page;\n" );
 		fwrite( $this->fh, "DELETE FROM import_revision;\n" );
 		fwrite( $this->fh, "DELETE FROM import_vote;\n" );
 	}
 
-	public function dumpPages() {
+	private function dumpPages() {
 		$pages = $this->dumper->getPages();
 
 		foreach ( $pages as $id => $data ) {
@@ -55,7 +60,7 @@ class DumpForumData extends Maintenance {
 		}
 	}
 
-	public function dumpRevisions() {
+	private function dumpRevisions() {
 		$revisions = $this->dumper->getRevisions();
 
 		foreach ( $revisions as $data ) {
@@ -68,7 +73,7 @@ class DumpForumData extends Maintenance {
 		}
 	}
 
-	public function dumpVotes() {
+	private function dumpVotes() {
 		$votes = $this->dumper->getVotes();
 
 		foreach ( $votes as $data ) {


### PR DESCRIPTION
Ticket: https://wikia-inc.atlassian.net/browse/SOC-3743

This PR doesn't address the main purpose of SOC-3743 (adding board descriptions as forum descriptions), but fixes some issues I found when testing the migration script.

Specifically, this PR makes use of the `ArticleComment` class to extract the title, raw_content, and parsed_content for each Forum Thread that we're migrating. Additionally, we're now explicitly setting the connection parameters as UTF-8 when we're loading the data which is dumped from MW into Discussions. Beforehand the `character_set_client` was being set as Latin-1 (at least on my dev-box), which was leading to encoding issues.

The reason for using `ArticleComment` to extract the title and content can be seen from the screenshots below. By manually extracting that data as we were before, some escaped characters (like quotation marks) where being migrating in their escaped form. Using the APIs provided by the `ArticleComment` class fixes that and prevents us from having to duplicate logic it already implements.

**Before the fix**
<img width="561" alt="screen shot 2017-01-11 at 4 00 06 pm" src="https://cloud.githubusercontent.com/assets/1657792/21905237/920281ea-d8bb-11e6-854c-eb1b8a8cab93.png">
<img width="567" alt="screen shot 2017-01-11 at 3 59 51 pm" src="https://cloud.githubusercontent.com/assets/1657792/21905267/ab8dde2a-d8bb-11e6-8950-c6a9a02014c7.png">

**After the fix**:
![screen shot 2017-01-12 at 11 39 54 am 1](https://cloud.githubusercontent.com/assets/1657792/21905339/e98d85c2-d8bb-11e6-92af-250731790c6e.png)
![screen shot 2017-01-12 at 11 40 05 am](https://cloud.githubusercontent.com/assets/1657792/21905345/f054f35e-d8bb-11e6-975e-3a6f3e79ac1e.png)

###### //cc
@garthwebb 