### PR TITLE
SUS-1473 | Click tracking for Wall Notifications

### DIFF
--- a/extensions/wikia/DesignSystem/scripts/DesignSystemGlobalNavigationNotifications.js
+++ b/extensions/wikia/DesignSystem/scripts/DesignSystemGlobalNavigationNotifications.js
@@ -1,6 +1,6 @@
 require(
-	['jquery', 'wikia.window', 'wikia.nirvana'],
-	function($, window, nirvana) {
+	['jquery', 'wikia.window', 'wikia.nirvana', 'wikia.tracker'],
+	function($, window, nirvana, tracker) {
 		'use strict';
 
 		var WallNotifications = {
@@ -49,6 +49,9 @@ require(
 				this.$wallNotifications.add($('#pt-wall-notifications'))
 					.on('click', '.notifications-markasread', this.markAllAsReadAllWikis.bind(this));
 
+				this.$wallNotifications.on('click', 'a', function(ev) {
+					WallNotifications.track('notification');
+				});
 
 				$(window).on('resize', $.throttle(50, function () {
 					WallNotifications.setNotificationsHeight();
@@ -179,6 +182,7 @@ require(
 
 			markAllAsReadAllWikis: function () {
 				this.markAllAsReadRequest('FORCE');
+				this.track('mark-all-as-read');
 				return false;
 			},
 
@@ -211,6 +215,8 @@ require(
 			},
 
 			wikiClick: function (e) {
+				this.track('wiki');
+
 				var wikiEl = $(e.target).closest('.notifications-for-wiki'),
 					wikiId = parseInt(wikiEl.data('wiki-id'), 10);
 
@@ -369,9 +375,19 @@ require(
 			},
 
 			onNotificationsOpen: function () {
-				WallNotifications.$wallNotifications.addClass('show');
-				WallNotifications.setNotificationsHeight();
-			}
+				this.$wallNotifications.addClass('show');
+				this.setNotificationsHeight();
+				this.track('open');
+			},
+
+			track: function (label) {
+				tracker.track({
+					action: 'click',
+					category: 'notifications',
+					label: label,
+					trackingMethod: 'analytics'
+				});
+			},
 		};
 
 		$(function () {


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-1473

Track when notification's dropdown is open, notifications are clicked or marked as read.

```
Wikia.Tracker:  trackingevent notifications/click/open/ [analytics track]
Wikia.Tracker:  trackingevent notifications/click/notification/ [analytics track]
```

@mixth-sense / @TK-999 / @rogatty 