### PR TITLE
ADEN | add tracking for bidders ASAP

### DIFF
--- a/extensions/wikia/AdEngine/js/AdInfoTracker.js
+++ b/extensions/wikia/AdEngine/js/AdInfoTracker.js
@@ -71,7 +71,7 @@ define('ext.wikia.adEngine.adInfoTracker',  [
 			'bidder_2': slotPrices.appnexus || '',
 			'bidder_3': slotPrices.fastlane || '',
 			'bidder_4': slotPrices.vulcan || '',
-			'bidder_5': '',
+			'bidder_5': slotPrices.fastlane_private || '',
 			'bidder_6': '',
 			'bidder_7': '',
 			'product_chosen': '',

--- a/extensions/wikia/AdEngine/js/lookup/prebid/adaptersPerformanceTracker.js
+++ b/extensions/wikia/AdEngine/js/lookup/prebid/adaptersPerformanceTracker.js
@@ -83,7 +83,7 @@ define('ext.wikia.adEngine.lookup.prebid.adaptersPerformanceTracker', [
 		if (bid.getStatusCode() === responseErrorCode) {
 			return [emptyResponseMsg, bucket].join(';');
 		}
-		return [bid.getSize(), bid.pbMg, bucket].join(';');
+		return [bid.getSize(), bid.pbAg, bucket].join(';');
 	}
 
 

--- a/extensions/wikia/AdEngine/js/lookup/prebid/adaptersPricesTracker.js
+++ b/extensions/wikia/AdEngine/js/lookup/prebid/adaptersPricesTracker.js
@@ -1,8 +1,11 @@
 define('ext.wikia.adEngine.lookup.prebid.adaptersPricesTracker', [
 	'ext.wikia.adEngine.lookup.prebid.adaptersRegistry',
-	'ext.wikia.adEngine.wrappers.prebid'
-], function (adaptersRegistry, prebid) {
+	'ext.wikia.adEngine.wrappers.prebid',
+	'wikia.log'
+], function (adaptersRegistry, prebid, log) {
 	'use strict';
+
+	var logGroup = 'ext.wikia.adEngine.lookup.prebid.adaptersPricesTracker';
 
 	function getSlotBestPrice(slotName) {
 		var prebidCmd = prebid.get(),
@@ -10,15 +13,17 @@ define('ext.wikia.adEngine.lookup.prebid.adaptersPricesTracker', [
 			bestPrices = {};
 
 		adaptersRegistry.getAdapters().forEach(function(adapter) {
-			bestPrices[adapter.getName()] = undefined;
+			bestPrices[adapter.getName()] = 0;
 		});
 
-		slotBids.forEach(function(bid) {
-			bestPrices[bid.bidderCode] = Math.max(bestPrices[bid.bidderCode], bid.pbMg) || 0;
+		log(['getSlotBestPrices slotBids', slotName, slotBids], 'debug', logGroup);
 
-			if (typeof bestPrices[bid.bidderCode] !== 'undefined') {
-				bestPrices[bid.bidderCode] = (bestPrices[bid.bidderCode] / 100).toFixed(2).toString();
-			}
+		slotBids.forEach(function(bid) {
+			var priceFromBidder = parseFloat(bid.pbAg || 0),
+				currentBestPrice = Math.max(bestPrices[bid.bidderCode], priceFromBidder) || 0;
+
+			bestPrices[bid.bidderCode] = (currentBestPrice).toFixed(2).toString();
+			log(['getSlotBestPrices best price for slot', slotName, bid.bidderCode, bestPrices[bid.bidderCode]], 'debug', logGroup);
 		});
 
 		return bestPrices;

--- a/extensions/wikia/AdEngine/js/lookup/rubicon/rubiconFastlane.js
+++ b/extensions/wikia/AdEngine/js/lookup/rubicon/rubiconFastlane.js
@@ -12,6 +12,7 @@ define('ext.wikia.adEngine.lookup.rubicon.rubiconFastlane', [
 	'use strict';
 
 	var bestPrices = {},
+		bestPricesPrivate = {},
 		config = {
 			oasis: {
 				TOP_LEADERBOARD: {
@@ -176,20 +177,26 @@ define('ext.wikia.adEngine.lookup.rubicon.rubiconFastlane', [
 
 	function saveBestPrice(slotName, tiers) {
 		tiers.forEach(function (tier) {
-			bestPrices[slotName] = Math.max(rubiconTier.parsePrice(tier), bestPrices[slotName] || 0);
+			bestPrices[slotName] = Math.max(rubiconTier.parseOpenMarketPrice(tier), bestPrices[slotName] || 0);
+			bestPricesPrivate[slotName] = Math.max(rubiconTier.parsePrivatePrice(tier), bestPricesPrivate[slotName] || 0);
 		});
 	}
 
 	function getBestSlotPrice(slotName) {
+		return {
+			fastlane: getBestPriceString(bestPrices[slotName]),
+			fastlane_private: getBestPriceString(bestPricesPrivate[slotName])
+		};
+	}
+
+	function getBestPriceString(bestPriceForSlot) {
 		var price;
 
-		if (typeof bestPrices[slotName] !== 'undefined') {
-			price = (bestPrices[slotName] / 100).toFixed(2).toString();
+		if (typeof bestPriceForSlot !== 'undefined') {
+			price = (bestPriceForSlot / 100).toFixed(2).toString();
 		}
 
-		return {
-			fastlane: price
-		};
+		return price;
 	}
 
 	function getSlotParams(slotName) {

--- a/extensions/wikia/AdEngine/js/lookup/rubicon/rubiconTier.js
+++ b/extensions/wikia/AdEngine/js/lookup/rubicon/rubiconTier.js
@@ -4,7 +4,8 @@ define('ext.wikia.adEngine.lookup.rubicon.rubiconTier', [
 ], function (math) {
 	'use strict';
 
-	var cpmBuckets = [
+	var privateTierSuffix = 'deals',
+		cpmBuckets = [
 		{
 			maxValue: 4,
 			bucket: 1
@@ -38,8 +39,20 @@ define('ext.wikia.adEngine.lookup.rubicon.rubiconTier', [
 		return sizeId + '_tier' + math.leftPad(tier, 4);
 	}
 
-	function parsePrice(tier) {
-		var matches = /^\d+_tier(\d+)/g.exec(tier);
+	function parseOpenMarketPrice(tier) {
+		if (tier.indexOf(privateTierSuffix) === -1) {
+			var matches = /^\d+_tier(\d+)/g.exec(tier);
+
+			if (matches && matches[1]) {
+				return parseInt(matches[1], 10);
+			}
+		}
+
+		return 0;
+	}
+
+	function parsePrivatePrice(tier) {
+		var matches = new RegExp('^\\d+_tier(\\d+)' + privateTierSuffix,'g').exec(tier);
 
 		if (matches && matches[1]) {
 			return parseInt(matches[1], 10);
@@ -50,6 +63,7 @@ define('ext.wikia.adEngine.lookup.rubicon.rubiconTier', [
 
 	return {
 		create: create,
-		parsePrice: parsePrice
+		parseOpenMarketPrice: parseOpenMarketPrice,
+		parsePrivatePrice: parsePrivatePrice
 	};
 });

--- a/extensions/wikia/AdEngine/js/lookup/rubicon/rubiconVulcan.js
+++ b/extensions/wikia/AdEngine/js/lookup/rubicon/rubiconVulcan.js
@@ -105,7 +105,7 @@ define('ext.wikia.adEngine.lookup.rubicon.rubiconVulcan', [
 			price;
 
 		if (priceMap[slotName]) {
-			cpm = rubiconTier.parsePrice(priceMap[slotName]) / 100;
+			cpm = rubiconTier.parseOpenMarketPrice(priceMap[slotName]) / 100;
 			price = cpm.toFixed(2).toString();
 		}
 

--- a/extensions/wikia/AdEngine/js/spec/lookup/prebid/adaptersPerformanceTracker.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/lookup/prebid/adaptersPerformanceTracker.spec.js
@@ -92,7 +92,7 @@ describe('ext.wikia.adEngine.lookup.prebid.adaptersPerformanceTracker', function
 			},
 			correctIndexExchangeBid: {
 				bidder: 'indexExchange',
-				pbMg: '1.00',
+				pbAg: '1.00',
 				getStatusCode: function () {
 					return 1;
 				},
@@ -102,7 +102,7 @@ describe('ext.wikia.adEngine.lookup.prebid.adaptersPerformanceTracker', function
 			},
 			correctAppNexusBid: {
 				bidder: 'appnexus',
-				pbMg: '0.00',
+				pbAg: '0.00',
 				getStatusCode: function () {
 					return 1;
 				},
@@ -113,7 +113,7 @@ describe('ext.wikia.adEngine.lookup.prebid.adaptersPerformanceTracker', function
 			completeAppNexusBid: {
 				bidder: 'appnexus',
 				complete: true,
-				pbMg: '5.00',
+				pbAg: '5.00',
 				getStatusCode: function () {
 					return 1;
 				},

--- a/extensions/wikia/AdEngine/js/spec/lookup/rubicon/rubiconFastlane.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/lookup/rubicon/rubiconFastlane.spec.js
@@ -77,7 +77,10 @@ describe('ext.wikia.adEngine.lookup.rubicon.rubiconFastlane', function () {
 				}
 			},
 			rubiconTier: {
-				parsePrice: function () {
+				parseOpenMarketPrice: function () {
+					return 0;
+				},
+				parsePrivatePrice: function () {
 					return 0;
 				}
 			},

--- a/extensions/wikia/AdEngine/js/spec/lookup/rubicon/rubiconTier.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/lookup/rubicon/rubiconTier.spec.js
@@ -68,7 +68,7 @@ describe('ext.wikia.adEngine.lookup.rubicon.rubiconTier', function () {
 		});
 	});
 
-	it('Get price from ', function () {
+	it('Get open market price from ', function () {
 		var testCases = [
 			{
 				tier: '203_tier1600',
@@ -81,11 +81,48 @@ describe('ext.wikia.adEngine.lookup.rubicon.rubiconTier', function () {
 			{
 				tier: '15_tier0015',
 				price: 15
+			},
+			{
+				tier: '15_tier0015NONE',
+				price: 15
+			},
+			{
+				tier: '15_tier0015deals',
+				price: 0
 			}
 		];
 
 		testCases.forEach(function (testCase) {
-			expect(rubiconTier.parsePrice(testCase.tier)).toEqual(testCase.price);
+			expect(rubiconTier.parseOpenMarketPrice(testCase.tier)).toEqual(testCase.price);
+		});
+	});
+
+	it('Get private price from ', function () {
+		var testCases = [
+			{
+				tier: '203_tier1600',
+				price: 0
+			},
+			{
+				tier: '15_tier0000',
+				price: 0
+			},
+			{
+				tier: '15_tier0015deals',
+				price: 15
+			},
+			{
+				tier: '15_tier0000deals',
+				price: 0
+			},
+			{
+				tier: '15_tier0015something',
+				price: 0
+			}
+		];
+
+		testCases.forEach(function (testCase) {
+			expect(rubiconTier.parsePrivatePrice(testCase.tier)).toEqual(testCase.price);
 		});
 	});
 });

--- a/extensions/wikia/AdEngine/js/spec/lookup/rubicon/rubiconVulcan.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/lookup/rubicon/rubiconVulcan.spec.js
@@ -70,7 +70,7 @@ describe('ext.wikia.adEngine.lookup.rubicon.rubiconVulcan', function () {
 				create: function () {
 					return '203_tier1600';
 				},
-				parsePrice: function () {
+				parseOpenMarketPrice: function () {
 					return 0;
 				}
 			},


### PR DESCRIPTION
In order to collect data about our header bidding partners we would like to release it as soon as possible. 