### PR TITLE
SUS-1284 | WikiaHomePageController - prevent InvalidParameterApiException

### DIFF
--- a/extensions/wikia/WikiaHomePage/WikiaHomePageController.class.php
+++ b/extensions/wikia/WikiaHomePage/WikiaHomePageController.class.php
@@ -118,7 +118,7 @@ class WikiaHomePageController extends WikiaController {
 				$hubsV3List = $this->getHubsV3List( $langCode );
 
 				foreach( $hubsSlots['hub_slot'] as $slot => $hubId ) {
-					if( !empty( $hubId ) ) {
+					if( !empty( $hubId ) && !empty( $hubsV3List[$hubId] ) ) {
 						$hubSlot[ $slot ] = $this->prepareHubV3Slot( $hubsV3List[$hubId], $slot );
 					}
 				}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-1284

`PHP Notice: Undefined offset in WikiaHomePageController.class.php on line 122` was reported followed by `InvalidParameterApiException`

@TK-999 / @sqreek 