### PR TITLE
SUS-1466 | LightboxLoader: use analytics as trackingMethod

### DIFF
--- a/extensions/wikia/Lightbox/scripts/LightboxLoader.js
+++ b/extensions/wikia/Lightbox/scripts/LightboxLoader.js
@@ -398,12 +398,12 @@
 		inlineVideoTrackingTimeout: 0,
 		// @param data - any extra params we want to pass to internal tracking
 		// Don't add willy nilly though... check with Jonathan.
-		track: function (action, label, value, data, method) {
+		track: function (action, label, value, data) {
 			Wikia.Tracker.track({
 				action: action,
 				category: 'lightbox',
 				label: label || '',
-				trackingMethod: method || 'both',
+				trackingMethod: 'analytics',
 				value: value || 0
 			}, data);
 		},


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-1466

`both` is no longer a correct value for `trackingMethod`. Use `analytics` instead. Checked on my devbox - requests to GA are sent.