### PR TITLE
SUS-1400 | log failed deletes in Indexer class

### DIFF
--- a/extensions/wikia/Search/classes/Indexer.php
+++ b/extensions/wikia/Search/classes/Indexer.php
@@ -193,7 +193,7 @@ class Indexer {
 	 *
 	 * @param int $wid
 	 *
-	 * @return \Solarium_Result_Update|null|true
+	 * @return \Solarium_Result_Update|false
 	 */
 	public function deleteWikiDocs( $wid ) {
 		$updateHandler = $this->getClient()->createUpdate();
@@ -204,9 +204,14 @@ class Indexer {
 			return $this->getClient()->update( $updateHandler );
 		} catch ( \Exception $e ) {
 			$this->getLogger()->log( __METHOD__, 'Delete: ' . $query, $e );
-		}
 
-		return true;
+			\Wikia\Logger\WikiaLogger::instance()->critical( __METHOD__, [
+				'exception' => $e,
+				'query' => $query
+			] );
+
+			return false;
+		}
 	}
 
 	/**


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-1400

Let's log cases when delete by `wid` query fails.

According to Solr index the freshest wiki that is affected by this issue (documents being indexed from deleted wikis) was last edited in March 2014:

```sql
+--------------------------+
| max(city_last_timestamp) |
+--------------------------+
| 2014-03-12 02:45:50      |
+--------------------------+
1 row in set (0.00 sec)

                city_id: 913929
              city_path: slot1
            city_dbname: newzealandpunkrock
```

@mixth-sense / @sqreek / @TK-999 