### PR TITLE
XW-2607 | increasing cache validity to 24h for RecirculationApiController::getFandomPosts

### DIFF
--- a/extensions/wikia/Recirculation/RecirculationApiController.class.php
+++ b/extensions/wikia/Recirculation/RecirculationApiController.class.php
@@ -40,7 +40,7 @@ class RecirculationApiController extends WikiaApiController {
 			$posts = array_slice( array_merge( $posts, $ds->getPosts( 'recent_popular', $limit ) ), 0, $limit );
 		}
 
-		$this->response->setCacheValidity( WikiaResponse::CACHE_VERY_SHORT );
+		$this->response->setCacheValidity( WikiaResponse::CACHE_STANDARD );
 		$this->response->setData( [
 			'title' => $title,
 			'posts' => $posts,


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/XW-2607

Increasing as this will improve our score in page speed test:
https://developers.google.com/speed/pagespeed/insights/?url=starwars.wikia.com%2Fwiki%2FAnakin%3Fnoexternals%3D1&tab=mobile

//cc @Wikia/x-wing @Wikia/cake 