### PR TITLE
SUS-1403 | do not report stalled articles in Solr index

### DIFF
--- a/extensions/wikia/Search/WikiaSearchIndexerController.class.php
+++ b/extensions/wikia/Search/WikiaSearchIndexerController.class.php
@@ -48,6 +48,7 @@ class WikiaSearchIndexerController extends WikiaController
 		$serviceName = 'Wikia\Search\IndexService\\' . $this->getVal( 'service', 'DefaultContent' );
 		$ids = explode( '|', $this->getVal( 'ids', '' ) );
 		if ( class_exists( $serviceName ) ) {
+			/* @var Wikia\Search\IndexService\AbstractService $service */
 			$service = new $serviceName( $ids );
 			$ids = $this->getVal( 'ids' );
 			if ( !empty( $ids ) ) {

--- a/extensions/wikia/Search/classes/MediaWikiService.php
+++ b/extensions/wikia/Search/classes/MediaWikiService.php
@@ -1098,11 +1098,7 @@ class MediaWikiService {
 		$page = \Article::newFromID( $pageId );
 
 		if ( $page === null ) {
-			throw new StaleResultException(
-				'MediaWikiService::getPageFromPageId $page is null', 0, null, [
-					'page_id' => (string) $pageId
-				]
-			);
+			throw new StaleResultException( (string)$pageId );
 		}
 
 		$redirectTarget = null;

--- a/extensions/wikia/Search/classes/MediaWikiService.php
+++ b/extensions/wikia/Search/classes/MediaWikiService.php
@@ -1202,6 +1202,9 @@ class MediaWikiService {
 
 		if ( !isset( static::$pageIdsToTitles[$pageId] ) ) {
 			$page = $this->getPageFromPageId( $pageId );
+
+			\Wikia\Util\Assert::true( $page instanceof \Article, __METHOD__ . ' - Invalid article ID' ); // SUS-1403
+
 			static::$pageIdsToTitles[$pageId] = $page->getTitle();
 		}
 

--- a/extensions/wikia/Search/classes/MediaWikiService.php
+++ b/extensions/wikia/Search/classes/MediaWikiService.php
@@ -379,7 +379,8 @@ class MediaWikiService {
 	public function pageIdExists( $pageId ) {
 		try {
 			return $this->getPageFromPageId( $pageId )->exists();
-		} catch ( \Exception $e ) {
+		} catch ( \Throwable $e ) {
+			# catch "Error: Call to a member function exists() on null"
 			return false;
 		}
 	}

--- a/extensions/wikia/Search/classes/MediaWikiService.php
+++ b/extensions/wikia/Search/classes/MediaWikiService.php
@@ -1076,7 +1076,6 @@ class MediaWikiService {
 	 * @param int $pageId
 	 *
 	 * @return \Article
-	 * @throws \Exception
 	 */
 	protected function getPageFromPageId( $pageId ) {
 

--- a/extensions/wikia/Search/classes/MediaWikiService.php
+++ b/extensions/wikia/Search/classes/MediaWikiService.php
@@ -561,10 +561,8 @@ class MediaWikiService {
 		$title = $searchEngine->getNearMatch( $term );
 		$articleId = ( $title !== null ) ? $title->getArticleId() : 0;
 		if ( ( $articleId > 0 ) && ( in_array( $title->getNamespace(), $namespaces ) ) ) {
-			$page = $this->getPageFromPageId( $articleId );
-			if ( $page instanceof \Article ) {
-				$articleMatch = new \Wikia\Search\Match\Article( $title->getArticleId(), $this, $term );
-			}
+			$this->getPageFromPageId( $articleId );
+			$articleMatch = new \Wikia\Search\Match\Article( $title->getArticleId(), $this ,$term);
 		}
 
 		return $articleMatch;

--- a/extensions/wikia/Search/classes/Result/StaleResultException.php
+++ b/extensions/wikia/Search/classes/Result/StaleResultException.php
@@ -1,5 +1,0 @@
-<?php
-namespace Wikia\Search\Result;
-
-class StaleResultException extends \WikiaException {
-}

--- a/extensions/wikia/Search/classes/Test/MediaWikiServiceTest.php
+++ b/extensions/wikia/Search/classes/Test/MediaWikiServiceTest.php
@@ -1167,13 +1167,16 @@ class MediaWikiServiceTest extends BaseTest
 	 * @slowExecutionTime 0.14926 ms
 	 * @covers \Wikia\Search\MediaWikiService::getPageFromPageId
 	 */
-	public function testGetPageFromPageIdReturnsNullIfInvalid() {
-		$service = new MediaWikiService();
+	public function testGetPageFromPageIdRetunrsNull() {
+		$this->mockClass( 'Article', null, 'newFromID' );
+		$get = new ReflectionMethod( '\Wikia\Search\MediaWikiService', 'getPageFromPageId' );
+		$get->setAccessible( true );
 
-		$method = new ReflectionMethod( MediaWikiService::class, 'getPageFromPageId' );
-		$method->setAccessible( true );
-
-		$this->assertNull( $method->invoke( $service, 0 ), 'MediaWikiService::getPageFromPageId returns null for invalid id' );
+		$this->assertEquals(
+			null,
+			$get->invoke( (new MediaWikiService), $this->pageId ),
+			'\Wikia\Search\MediaWikiService::getPageFromPageId should return null when provided a nonexistent page id'
+		);
 	}
 
 	/**

--- a/extensions/wikia/Search/classes/Test/MediaWikiServiceTest.php
+++ b/extensions/wikia/Search/classes/Test/MediaWikiServiceTest.php
@@ -7,8 +7,6 @@ namespace Wikia\Search\Test;
 use Wikia\Search\MediaWikiService;
 use \ReflectionProperty;
 use \ReflectionMethod;
-use Wikia\Search\Result\StaleResultException;
-
 /**
  * Tests the methods found in \Wikia\Search\MediaWikiService
  * @author relwell
@@ -1169,14 +1167,13 @@ class MediaWikiServiceTest extends BaseTest
 	 * @slowExecutionTime 0.14926 ms
 	 * @covers \Wikia\Search\MediaWikiService::getPageFromPageId
 	 */
-	public function testGetPageFromPageIdThrowsExceptionIfInvalid() {
+	public function testGetPageFromPageIdReturnsNullIfInvalid() {
 		$service = new MediaWikiService();
 
 		$method = new ReflectionMethod( MediaWikiService::class, 'getPageFromPageId' );
 		$method->setAccessible( true );
 
-		$this->setExpectedException( StaleResultException::class );
-		$method->invoke( $service, 0 );
+		$this->assertNull( $method->invoke( $service, 0 ), 'MediaWikiService::getPageFromPageId returns null for invalid id' );
 	}
 
 	/**

--- a/extensions/wikia/Search/classes/Test/MediaWikiServiceTest.php
+++ b/extensions/wikia/Search/classes/Test/MediaWikiServiceTest.php
@@ -1181,6 +1181,20 @@ class MediaWikiServiceTest extends BaseTest
 
 	/**
 	 * @group Slow
+	 * @slowExecutionTime 0.14926 ms
+	 * @covers \Wikia\Search\MediaWikiService::getPageFromPageId
+	 */
+	public function testPageIdExistsForNotExistingArticle() {
+		$this->mockClass( 'Article', null, 'newFromID' );
+
+		$this->assertFalse(
+			(new MediaWikiService)->pageIdExists(0),
+			'\Wikia\Search\MediaWikiService::pageIdExists should return false when provided a nonexistent page id'
+		);
+	}
+
+	/**
+	 * @group Slow
 	 * @slowExecutionTime 0.16001 ms
 	 * @covers \Wikia\Search\MediaWikiService::getPageFromPageId
 	 */

--- a/includes/wikia/nirvana/WikiaException.php
+++ b/includes/wikia/nirvana/WikiaException.php
@@ -53,26 +53,22 @@ abstract class WikiaBaseException extends MWException {
  * @link http://pl2.php.net/manual/en/class.exception.php
  */
 class WikiaException extends WikiaBaseException {
-	public function __construct( $message = '', $code = 0, Exception $previous = null, array $extraContext = [] ) {
+	public function __construct($message = '', $code = 0, Exception $previous = null) {
 		global $wgRunningUnitTests;
 		parent::__construct( $message, $code, $previous );
 
-		if ( !$wgRunningUnitTests ) {
-			$exceptionClass = get_class( $this );
+		if (!$wgRunningUnitTests) {
+			$exceptionClass = get_class($this);
 
 			// log on devboxes to /tmp/debug.log
-			wfDebug( $exceptionClass . ": {$message}\n" );
-			wfDebug( $this->getTraceAsString() );
+			wfDebug($exceptionClass . ": {$message}\n");
+			wfDebug($this->getTraceAsString());
 
-			WikiaLogger::instance()->error(
-				$exceptionClass,
-				[
-					'err' => $message,
-					'errno' => $code,
-					'exception' => $previous instanceof Exception ? $previous : $this,
-					'extra_context' => $extraContext
-				]
-			);
+			WikiaLogger::instance()->error($exceptionClass, [
+				'err' => $message,
+				'errno' => $code,
+				'exception' => $previous instanceof Exception ? $previous : $this,
+			]);
 		}
 	}
 }


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-1403

Given the architecture of our Solr and indexing pipeline (slaves replication taking place every 3 hours) reporting stale article IDs (i.e. deleted articles) in the index does not really make sense.

`WikiaSearchIndexer` triggers  `StaleResultException` exceptions by default when handling requests from Python worker that processes deletes. Only a few exceptions were reported from Special:Search for delete articles (documents were still in the index, but they were already deleted on a wiki).