### PR TITLE
cake-1148 - adding _kruxTags to global context

### DIFF
--- a/extensions/wikia/Recirculation/js/trackers/liftigniter.js
+++ b/extensions/wikia/Recirculation/js/trackers/liftigniter.js
@@ -35,6 +35,10 @@ function getLiftIgniterGlobalContext() {
         }
     }
 
+    if (localStorage.kxallsegs) {
+        context['_kruxTags'] = localStorage.kxallsegs.split(',');
+    }
+
     return context;
 }
 


### PR DESCRIPTION
@Wikia/cake 
https://wikia-inc.atlassian.net/browse/CAKE-1148

Adding krux tags to LI global context. This is assuming the plan we've sent to LI is the path forward. Changes on the `site-attribute` side will come separately.