### PR TITLE
SUS-1522: In Phalanx allow internal requests to look up different user from session user

### DIFF
--- a/extensions/wikia/PhalanxII/models/PhalanxContentModel.php
+++ b/extensions/wikia/PhalanxII/models/PhalanxContentModel.php
@@ -18,11 +18,13 @@ class PhalanxContentModel extends PhalanxModel {
 	 *
 	 * @return bool
 	 */
-	public function isOk() {
+	public function isOk(): bool {
+		global $wgUser;
+
 		return (
-			$this->wg->User->isAllowed( 'phalanxexempt' ) ||
 			!( $this->title instanceof Title ) ||
-			$this->isWikiaInternalRequest()
+			$this->isWikiaInternalRequest() ||
+			$wgUser->isAllowed( 'phalanxexempt' )
 		);
 	}
 

--- a/extensions/wikia/PhalanxII/models/PhalanxModel.php
+++ b/extensions/wikia/PhalanxII/models/PhalanxModel.php
@@ -12,15 +12,17 @@
  */
 abstract class PhalanxModel extends WikiaObject {
 	/** @var string $text */
-	public $text = null;
+	protected $text = null;
+
 	/** @var null|object $block Information about the current block that was triggered */
-	public $block = null;
+	protected $block = null;
 
 	/* @var User */
-	public $user = null;
+	protected $user = null;
+
 	/* @var PhalanxService */
 	private $service = null;
-	public $ip = null;
+	protected $ip = null;
 
 	protected $shouldLogInStats = true;
 
@@ -92,14 +94,19 @@ abstract class PhalanxModel extends WikiaObject {
 
 	/**
 	 * Skip calls to Phalanx service if this method returns true
+	 * We must skip check if and only if:
+	 * - user has 'phalanxexempt' right (staff/VSTF/helper)
+	 * - this is an internal request looking up a different user from session user (user-permissions service)
 	 *
-	 * @return bool
+	 * @return bool whether to skip call to Phalanx service
 	 */
-	public function isOk() {
+	public function isOk(): bool {
+		global $wgUser;
+
 		return (
-			( ( $this->user instanceof User ) && ( $this->user->getName() == $this->wg->User->getName() && $this->wg->User->isAllowed( 'phalanxexempt' ) ) ) ||
-			( ( $this->user instanceof User ) && $this->user->isAllowed( 'phalanxexempt' ) ) ||
-			$this->isWikiaInternalRequest()
+			// SUS-1522: Permit user-permissions service to look up Phalanx blocks for different users
+			( $this->isWikiaInternalRequest() && $this->user->equals( $wgUser ) ) ||
+			$this->user->isAllowed( 'phalanxexempt' )
 		);
 	}
 

--- a/extensions/wikia/PhalanxII/models/PhalanxModel.php
+++ b/extensions/wikia/PhalanxII/models/PhalanxModel.php
@@ -96,7 +96,7 @@ abstract class PhalanxModel extends WikiaObject {
 	 * Skip calls to Phalanx service if this method returns true
 	 * We must skip check if and only if:
 	 * - user has 'phalanxexempt' right (staff/VSTF/helper)
-	 * - this is an internal request looking up a different user from session user (user-permissions service)
+	 * - this is an internal request (except if it's looking up different user, e.g. user-permissions service)
 	 *
 	 * @return bool whether to skip call to Phalanx service
 	 */

--- a/extensions/wikia/PhalanxII/tests/PhalanxModelTest.php
+++ b/extensions/wikia/PhalanxII/tests/PhalanxModelTest.php
@@ -233,11 +233,10 @@ class PhalanxModelTest extends WikiaBaseTest {
 			->with( $this->equalTo( 'phalanxexempt' ) )
 			->willReturn( false );
 
-		if ( $isSelfCheck ) {
-			$userMock->expects( $this->once() )
+
+		$userMock->expects( $this->any() )
 				->method( 'getName' )
-				->willReturn( $this->app->wg->User->getName() );
-		}
+				->willReturn( $isSelfCheck ? $this->app->wg->User->getName() : 'TestDifferentUserName' );
 
 		$requestMock = $this->getMock( WebRequest::class, [ 'isWikiaInternalRequest', 'getIp' ] );
 		$requestMock->expects( $this->exactly( 3 ) )


### PR DESCRIPTION
Allow internal requests to look up user block info in Phalanx for different users

ticket: https://wikia-inc.atlassian.net/browse/SUS-1522