### PR TITLE
ST-122 Look up renamed fandom-search-service

### DIFF
--- a/extensions/wikia/Search/classes/Services/ESFandomSearchService.php
+++ b/extensions/wikia/Search/classes/Services/ESFandomSearchService.php
@@ -30,7 +30,7 @@ class ESFandomSearchService extends AbstractSearchService {
 		global $wgConsulServiceTag, $wgConsulUrl;
 
 		return ( new ConsulUrlProvider( $wgConsulUrl,
-			$wgConsulServiceTag ) )->getUrl( 'fandom-search' );
+			$wgConsulServiceTag ) )->getUrl( 'fandom-search-service' );
 	}
 
 	protected function prepareQuery( string $query ) {


### PR DESCRIPTION
With the restructuring of the fandom search service pandora directory the service used to find fandom news and stories is now called ```fandom-search-service```.  This PR changes the code that looks up this service to use the new name.

NOTE: This code should not be merged until the service is deployed under the new name in production.

@jogura 