### PR TITLE
SUS-1446 | WikiaSearchIndexer - do not return data for documents that should not be indexed

### DIFF
--- a/extensions/wikia/Search/classes/IndexService/AbstractService.php
+++ b/extensions/wikia/Search/classes/IndexService/AbstractService.php
@@ -121,7 +121,8 @@ abstract class AbstractService {
 				continue;
 			}
 
-			if ( !$this->getService()->pageIdExists( $pageId ) ) {
+			// page was either delete or should not be indexed (SUS-1446)
+			if ( !$this->getService()->pageIdExists( $pageId ) || !$this->getService()->pageIdCanBeIndexed( $pageId ) ) {
 				$documents[] = [ "delete" => [ "id" => $currentId ] ];
 				continue;
 			}

--- a/extensions/wikia/Search/classes/MediaWikiService.php
+++ b/extensions/wikia/Search/classes/MediaWikiService.php
@@ -386,6 +386,24 @@ class MediaWikiService {
 	}
 
 	/**
+	 * Determines whether given page can be indexed
+	 *
+	 * @param int $pageId
+	 *
+	 * @return boolean
+	 */
+	public function pageIdCanBeIndexed( $pageId ) {
+		try {
+			return \Wikia\IndexingPipeline\PipelineEventProducer::canIndex(
+				$this->getPageFromPageId( $pageId )->getTitle()
+			);
+		} catch ( \Throwable $e ) {
+			# catch "Error: Call to a member function exists() on null"
+			return false;
+		}
+	}
+
+	/**
 	 * Provides redirect title text for canonical pages
 	 *
 	 * @param int $pageId

--- a/extensions/wikia/Search/classes/Test/IndexService/AbstractServiceTest.php
+++ b/extensions/wikia/Search/classes/Test/IndexService/AbstractServiceTest.php
@@ -116,7 +116,7 @@ class AbstractServiceTest extends BaseTest
 		
 		$mwservice = $this->getMockBuilder( '\Wikia\Search\MediaWikiService' )
 		                  ->disableOriginalConstructor()
-		                  ->setMethods( array( 'pageIdExists' ) )
+		                  ->setMethods( array( 'pageIdExists', 'pageIdCanBeIndexed' ) )
 		                  ->getMock();
 		
 		$executeResponse = array( 'foo' => 'bar' );
@@ -125,6 +125,12 @@ class AbstractServiceTest extends BaseTest
 		$mwservice
 		    ->expects( $this->at( 0 ) )
 		    ->method ( 'pageIdExists' )
+		    ->with   ( 234 )
+		    ->will   ( $this->returnValue( true ) )
+		;
+		$mwservice
+		    ->expects( $this->any() )
+		    ->method ( 'pageIdCanBeIndexed' )
 		    ->with   ( 234 )
 		    ->will   ( $this->returnValue( true ) )
 		;
@@ -169,7 +175,7 @@ class AbstractServiceTest extends BaseTest
 		
 		$mwservice = $this->getMockBuilder( '\Wikia\Search\MediaWikiService' )
 		                  ->disableOriginalConstructor()
-		                  ->setMethods( array( 'pageIdExists' ) )
+		                  ->setMethods( array( 'pageIdExists', 'pageIdCanBeIndexed' ) )
 		                  ->getMock();
 		
 		$service->setPageIds( array( 456 ) );
@@ -183,6 +189,12 @@ class AbstractServiceTest extends BaseTest
 		    ->method ( 'pageIdExists' )
 		    ->with   ( 456 )
 		    ->will   ( $this->returnValue( true ) )
+		;
+		$mwservice
+			->expects( $this->any() )
+			->method ( 'pageIdCanBeIndexed' )
+			->with   ( 456 )
+			->will   ( $this->returnValue( true ) )
 		;
 		$service
 		    ->expects( $this->any() )


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-1446

Apparently https://github.com/Wikia/app/pull/12217 was not enough to stop indexing Wall messages, Forum posts and article comments.

As Python indexer uses Scribe events stream we cannot add filtering at that level. Instead, let's return `delete` information when Python indexer asks MediaWiki for article metadata via `WikiaSearchIndexer` Nirvana controller.

@sqreek / @mixth-sense / @TK-999 / @idradm 