### PR TITLE
DeleteBatch: add --by-id switch

### DIFF
--- a/maintenance/deleteBatch.php
+++ b/maintenance/deleteBatch.php
@@ -39,6 +39,9 @@ class DeleteBatch extends Maintenance {
 		$this->addOption( 'i', "Interval to sleep between deletions" );
 		$this->addArg( 'listfile', 'File with titles to delete, separated by newlines. ' .
 			'If not given, stdin will be used.', false );
+
+		// Wikia change
+		$this->addOption( 'by-id', 'Provided list contains article IDs instead of titles', false, false /* $withArgs */ );
 	}
 
 	public function execute() {
@@ -78,7 +81,7 @@ class DeleteBatch extends Maintenance {
 			if ( $line == '' ) {
 				continue;
 			}
-			$title = Title::newFromText( $line );
+			$title = $this->hasOption( 'by-id' ) ? Title::newFromID( $line ) : Title::newFromText( $line ); # Wikia change
 			if ( is_null( $title ) ) {
 				$this->output( "Invalid title '$line' on line $linenum\n" );
 				continue;

--- a/maintenance/deleteBatch.php
+++ b/maintenance/deleteBatch.php
@@ -41,7 +41,7 @@ class DeleteBatch extends Maintenance {
 			'If not given, stdin will be used.', false );
 
 		// Wikia change
-		$this->addOption( 'by-id', 'Provided list contains article IDs instead of titles', false, false /* $withArgs */ );
+		$this->addOption( 'by-id', 'Provided list contains article IDs instead of titles, separated by newlines', false, false /* $withArgs */ );
 	}
 
 	public function execute() {


### PR DESCRIPTION
For Top 10 Lists cleanup task ([SUS-499](https://wikia-inc.atlassian.net/browse/SUS-499)) we would like to use `maintenance/deleteBatch.php` to delete articles by the list of IDs.

@mixth-sense 