### PR TITLE
Cake 1229 - don't remove footer ad when recirc is present

### DIFF
--- a/extensions/wikia/Recirculation/js/utils.js
+++ b/extensions/wikia/Recirculation/js/utils.js
@@ -23,7 +23,12 @@ define('ext.wikia.recirculation.utils', [
 				footerState.loading = true;
 				return renderTemplate('footer-index-container.mustache', {})
 					.then(function($html) {
-						$('#WikiaFooter').html($html);
+						$('#WikiaFooter')
+							.find('#BOTTOM_LEADERBOARD')
+							.siblings()
+							.remove()
+							.end()
+							.after($html);
 						footerState.cleared = true;
 						footerState.pending.forEach(function(d) {
 							d.resolve();

--- a/extensions/wikia/Recirculation/js/utils.js
+++ b/extensions/wikia/Recirculation/js/utils.js
@@ -28,7 +28,8 @@ define('ext.wikia.recirculation.utils', [
 							.siblings()
 							.remove()
 							.end()
-							.after($html);
+							.end()
+							.append($html);
 						footerState.cleared = true;
 						footerState.pending.forEach(function(d) {
 							d.resolve();


### PR DESCRIPTION
@Wikia/cake 
https://wikia-inc.atlassian.net/browse/CAKE-1229

instead of replacing the contents of `WikiaFooter` with the recirc content, remove the sibling elements of the ad spot `BOTTOM_LEADERBOARD` and then add the recirc content to the end of `WikiaFooter`