### PR TITLE
FAN-1527 | Remove FC permissions

### DIFF
--- a/extensions/GlobalMessages/GlobalMessagesG.i18n.php
+++ b/extensions/GlobalMessages/GlobalMessagesG.i18n.php
@@ -73,10 +73,6 @@ $messages['en'] = [
 	'grouppage-voldev' => 'w:c:dev:Volunteer_Developers',
 	'group-content-moderator' => 'Content Moderators',
 	'group-content-moderator-member' => 'Content Moderator',
-	'group-fancontributor-contributor' => 'Fan Contributors',
-	'group-fancontributor-contributor-member' => 'Fan Contributor',
-	'group-fancontributor-staff' => 'Fan Contributor Staff',
-	'group-fancontributor-staff-member' => 'Fan Contributor Staff',
 ];
 
 $messages['qqq'] = [

--- a/includes/wikia/models/DesignSystemGlobalNavigationModel.class.php
+++ b/includes/wikia/models/DesignSystemGlobalNavigationModel.class.php
@@ -214,7 +214,7 @@ class DesignSystemGlobalNavigationModel extends WikiaModel {
 	}
 
 	private function hasAuthorProfile( $user ) {
-		return sizeof( preg_grep( "/^fancontributor-/", $user->getGroups() ) ) > 0;
+		return intval( $user->getGlobalAttribute( 'wordpressId', 0 ), 10 ) > 0;
 	}
 
 	private function getLoggedInUserData( $user ) {

--- a/lib/Wikia/src/Service/User/Permissions/PermissionsConfigurationImpl.php
+++ b/lib/Wikia/src/Service/User/Permissions/PermissionsConfigurationImpl.php
@@ -36,8 +36,6 @@ class PermissionsConfigurationImpl implements PermissionsConfiguration {
 		'vanguard',
 		'voldev',
 		'vstf',
-		'fancontributor-staff',
-		'fancontributor-contributor',
 	];
 
 	private $implicitGroups = [
@@ -252,8 +250,6 @@ class PermissionsConfigurationImpl implements PermissionsConfiguration {
 		'createclass',
 		'first-edit-dialog-exempt',
 		'hideblockername',
-		'fancontributor-staff',
-		'fancontributor-contributor',
 		'clearuserprofile',
 		'smw-patternedit',
 	];
@@ -408,11 +404,8 @@ class PermissionsConfigurationImpl implements PermissionsConfiguration {
 		$this->groupsRemovableByGroup['bureaucrat'] = [ 'rollback', 'sysop', 'bot', 'content-moderator' ];
 		$this->groupsSelfRemovableByGroup['bureaucrat'] = [ 'bureaucrat' ];
 
-		$this->groupsAddableByGroup['staff'] = [ 'rollback', 'bot', 'sysop', 'bureaucrat', 'content-moderator', 'chatmoderator', 'threadmoderator', 'fancontributor-staff', 'fancontributor-contributor' ];
-		$this->groupsRemovableByGroup['staff'] = [ 'rollback', 'bot', 'sysop', 'bureaucrat', 'content-moderator', 'chatmoderator', 'threadmoderator', 'fancontributor-staff', 'fancontributor-contributor' ];
-
-		$this->groupsSelfAddableByGroup['fancontributor-staff'] = [ 'fancontributor-contributor' ];
-		$this->groupsSelfRemovableByGroup['fancontributor-staff'] = [ 'fancontributor-staff', 'fancontributor-contributor' ];
+		$this->groupsAddableByGroup['staff'] = [ 'rollback', 'bot', 'sysop', 'bureaucrat', 'content-moderator', 'chatmoderator', 'threadmoderator' ];
+		$this->groupsRemovableByGroup['staff'] = [ 'rollback', 'bot', 'sysop', 'bureaucrat', 'content-moderator', 'chatmoderator', 'threadmoderator' ];
 
 		$this->groupsAddableByGroup['helper'] = [ 'rollback', 'bot', 'sysop', 'bureaucrat', 'content-moderator', 'chatmoderator', 'threadmoderator' ];
 		$this->groupsRemovableByGroup['helper'] = [ 'rollback', 'bot', 'sysop', 'bureaucrat', 'content-moderator', 'chatmoderator', 'threadmoderator' ];


### PR DESCRIPTION
- remove fc permissions
- DS api should rely on presence of `wordpressId` user attribute and not permission
- there should be no changes to the output of the DS api if you have the wordpressId (and you had the permission before that):  `/api/v1/design-system/fandoms/1/en/navigation`