### PR TITLE
PLATFORM-2353: Make FandomBot create Template:Extension DPL

### DIFF
--- a/extensions/DynamicPageList/DPLSetup.php
+++ b/extensions/DynamicPageList/DPLSetup.php
@@ -1231,7 +1231,7 @@ class ExtDynamicPageList {
 
 		if ( !defined( "MW_UPDATER" ) ) {
 			// make sure page "Template:Extension DPL" exists
-			$user = User::newFromName( 'FandomBot' );
+			$user = User::newFromName( Wikia::BOT_USER );
 			$title = Title::newFromText( 'Template:Extension DPL' );
 			if ( !$title->exists() ) {
 				$article = new Article( $title );

--- a/extensions/DynamicPageList/DPLSetup.php
+++ b/extensions/DynamicPageList/DPLSetup.php
@@ -1230,17 +1230,16 @@ class ExtDynamicPageList {
         }
 
 		if ( !defined( "MW_UPDATER" ) ) {
-		// make sure page "Template:Extension DPL" exists
-        $title = Title::newFromText('Template:Extension DPL');
-		global $wgUser;
-		if (!$title->exists() && $wgUser->isAllowed('edit')) {
-			$article = new Article($title);
-			$article->doEdit( "<noinclude>This page was automatically created. It serves as an anchor page for ".
-							  "all '''[[Special:WhatLinksHere/Template:Extension_DPL|invocations]]''' ".
-							  "of [http://mediawiki.org/wiki/Extension:DynamicPageList Extension:DynamicPageList (DPL)].</noinclude>",
-							  $title, EDIT_NEW | EDIT_FORCE_BOT );
-			die(header('Location: '.Title::newFromText('Template:Extension DPL')->getFullURL()));
-		}
+			// make sure page "Template:Extension DPL" exists
+			$user = User::newFromName( 'FandomBot' );
+			$title = Title::newFromText( 'Template:Extension DPL' );
+			if ( !$title->exists() ) {
+				$article = new Article( $title );
+				$article->doEdit( "<noinclude>This page was automatically created. It serves as an anchor page for ".
+								  "all '''[[Special:WhatLinksHere/Template:Extension DPL|invocations]]''' ".
+								  "of [[mw:Extension:DynamicPageList|Extension:DynamicPageList (DPL)]].</noinclude>",
+								  $title, EDIT_NEW | EDIT_FORCE_BOT, false, $user );
+			}
 		}
         require_once( 'DPLVariables.php' );
 	}


### PR DESCRIPTION
[Template:Extension DPL](http://c.wikia.com/wiki/Template:Extension_DPL) often gets created by the first user that refreshed the wiki page. That probably shouldn't be happening so this PR should make FandomBot create it instead.

Support ticket: [#316320](https://support.wikia-inc.com/hc/en-us/requests/316320)
Bug ticket: [PLATFORM-2353](https://wikia-inc.atlassian.net/browse/PLATFORM-2353)