### PR TITLE
VOLDEV-186: Whitelist Gadget-* to make the gadget extension usable

### DIFF
--- a/extensions/3rdparty/Verbatim/Verbatim.php
+++ b/extensions/3rdparty/Verbatim/Verbatim.php
@@ -31,6 +31,8 @@ function renderVerbatim( $input ) {
 		|| startsWith( $formattedInput, Wikia::CUSTOM_INTERFACE_PREFIX, /* $case = */ false )
 		|| startsWith( $formattedInput, Wikia::EDITNOTICE_INTERFACE_PREFIX, /* $case = */ false )
 		|| startsWith( $formattedInput, Wikia::TAG_INTERFACE_PREFIX, /* $case = */ false )
+		|| startsWith( $formattedInput, Wikia::GADGETS_INTERFACE_PREFIX, /* $case = */ false )
+		|| startsWith( $formattedInput, Wikia::GADGET_INTERFACE_PREFIX, /* $case = */ false )
 	) {
 		// Do not allow transclusion into Verbatim tags
 		return '';

--- a/extensions/Gadgets/Gadgets_body.php
+++ b/extensions/Gadgets/Gadgets_body.php
@@ -87,7 +87,10 @@ class GadgetHooks {
 			}
 
 			if ( $section !== '' ) {
-				$section = wfMsgExt( "gadget-section-$section", 'parseinline' );
+				// begin wikia change
+				// wfMsg cleanup
+				$section = wfMessage( "gadget-section-$section" )->parse();
+				// end wikia change
 
 				if ( count ( $available ) ) {
 					$options[$section] = $available;
@@ -103,7 +106,10 @@ class GadgetHooks {
 				'label' => '&#160;',
 				'default' => Xml::tags( 'tr', array(),
 					Xml::tags( 'td', array( 'colspan' => 2 ),
-						wfMsgExt( 'gadgets-prefstext', 'parse' ) ) ),
+						// begin wikia change
+						// wfMsg cleanup
+						wfMessage( 'gadgets-prefstext' )->parse() ) ),
+						// end wikia change
 				'section' => 'gadgets',
 				'raw' => 1,
 				'rawrow' => 1,

--- a/extensions/Gadgets/SpecialGadgets.php
+++ b/extensions/Gadgets/SpecialGadgets.php
@@ -39,7 +39,10 @@ class SpecialGadgets extends SpecialPage {
 		global $wgOut, $wgUser, $wgLang, $wgContLang;
 
 		$this->setHeaders();
-		$wgOut->setPagetitle( wfMsg( "gadgets-title" ) );
+		// begin wikia change
+		// wfMsg cleanup
+		$wgOut->setPagetitle( wfMessage( 'gadgets-title' )->escaped() );
+		// end wikia change
 		$wgOut->addWikiMsg( 'gadgets-pagetext' );
 
 		$gadgets = Gadget::loadStructuredList();
@@ -52,7 +55,6 @@ class SpecialGadgets extends SpecialPage {
 
 		$listOpen = false;
 
-		$msgOpt = array( 'parseinline', 'parsemag' );
 		$editInterfaceAllowed = $wgUser->isAllowed( 'editinterface' );
 
 		foreach ( $gadgets as $section => $entries ) {
@@ -60,14 +62,20 @@ class SpecialGadgets extends SpecialPage {
 				$t = Title::makeTitleSafe( NS_MEDIAWIKI, "Gadget-section-$section$lang" );
 				if ( $editInterfaceAllowed ) {
 					$lnkTarget = $t
-						? Linker::link( $t, wfMsgHTML( 'edit' ), array(), array( 'action' => 'edit' ) )
+						// begin wikia change
+						// wfMsg cleanup
+						? Linker::link( $t, wfMessage( 'edit' )->escaped(), array(), array( 'action' => 'edit' ) )
+						// end wikia change
 						: htmlspecialchars( $section );
 					$lnk =  "&#160; &#160; [$lnkTarget]";
 				} else {
 					$lnk = '';
 				}
 
-				$ttext = wfMsgExt( "gadget-section-$section", $msgOpt );
+				// begin wikia change
+				// wfMsg cleanup
+				$ttext = wfMessage( "gadget-section-$section" )->parse();
+				// end wikia change
 
 				if ( $listOpen ) {
 					$wgOut->addHTML( Xml::closeElement( 'ul' ) . "\n" );
@@ -89,23 +97,32 @@ class SpecialGadgets extends SpecialPage {
 
 				$links = array();
 				if ( $editInterfaceAllowed ) {
-					$links[] = Linker::link( $t, wfMsgHTML( 'edit' ), array(), array( 'action' => 'edit' ) );
+					// begin wikia change
+					// wfMsg cleanup
+					$links[] = Linker::link( $t, wfMessage( 'edit' )->escaped(), array(), array( 'action' => 'edit' ) );
+					// end wikia change
 				}
 
-				$links[] = Linker::link( $this->getTitle( "export/{$gadget->getName()}" ), wfMsgHtml( 'gadgets-export' ) );
+				// begin wikia change
+				// wfMsg cleanup
+				$links[] = Linker::link( $this->getTitle( "export/{$gadget->getName()}" ), wfMessage( 'gadgets-export' )->escaped() );
 
-				$ttext = wfMsgExt( "gadget-{$gadget->getName()}", $msgOpt );
+				$ttext = wfMessage( "gadget-{$gadget->getName()}" )->parse();
+				// end wikia change
 
 				if ( !$listOpen ) {
 					$listOpen = true;
 					$wgOut->addHTML( Xml::openElement( 'ul' ) );
 				}
 
-				$lnk = '&#160;&#160;' . wfMsg( 'parentheses', $wgLang->pipeList( $links ) );
+				// begin wikia change
+				// wfMsg cleanup
+				$lnk = '&#160;&#160;' . wfMessage( 'parentheses', $wgLang->pipeList( $links ) )->plain();
 				$wgOut->addHTML( Xml::openElement( 'li' ) .
 						$ttext . $lnk . "<br />" .
-						wfMsgHTML( 'gadgets-uses' ) . wfMsg( 'colon-separator' )
+						wfMessage( 'gadgets-uses' )->escaped() . wfMessage( 'colon-separator' )->escaped()
 				);
+				// end wikia change
 
 				$lnk = array();
 				foreach ( $gadget->getScriptsAndStyles() as $codePage ) {
@@ -175,7 +192,10 @@ class SpecialGadgets extends SpecialPage {
 		 */
 		$g = $gadgets[$gadget];
 		$this->setHeaders();
-		$wgOut->setPagetitle( wfMsg( "gadgets-export-title" ) );
+		// begin wikia change
+		// wfMsg cleanup
+		$wgOut->setPagetitle( wfMessage( 'gadgets-export-title' )->escaped() );
+		// end wikia change
 		$wgOut->addWikiMsg( 'gadgets-export-text', $gadget, $g->getDefinition() );
 
 		$exportList = "MediaWiki:gadget-$gadget\n";
@@ -188,7 +208,10 @@ class SpecialGadgets extends SpecialPage {
 			. Html::hidden( 'pages', $exportList )
 			. Html::hidden( 'wpDownload', '1' )
 			. Html::hidden( 'templates', '1' )
-			. Xml::submitButton( wfMsg( 'gadgets-export-download' ) )
+			// begin wikia change
+			// wfMsg cleanup
+			. Xml::submitButton( wfMessage( 'gadgets-export-download' )->escaped() )
+			// end wikia change
 			. Html::closeElement( 'form' )
 		);
 	}

--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -94,11 +94,14 @@ class Wikia {
 	const CUSTOM_INTERFACE_PREFIX = 'custom-';
 	const EDITNOTICE_INTERFACE_PREFIX = 'editnotice-';
 	const TAG_INTERFACE_PREFIX = 'tag-';
+	// one for the extension messages, one for the user messages
+	const GADGETS_INTERFACE_PREFIX = 'gadgets-';
+	const GADGET_INTERFACE_PREFIX = 'gadget-';
 
 	const DEFAULT_FAVICON_FILE = '/skins/common/images/favicon.ico';
 	const DEFAULT_WIKI_LOGO_FILE = '/skins/common/images/wiki.png';
 
-	private static $vars = array();
+	private static $vars = [];
 	private static $cachedLinker;
 
 	public static function setVar($key, $value) {
@@ -2421,6 +2424,8 @@ class Wikia {
 			|| startsWith( lcfirst( $title->getDBKey() ), self::CUSTOM_INTERFACE_PREFIX )
 			|| startsWith( lcfirst( $title->getDBKey() ), self::EDITNOTICE_INTERFACE_PREFIX )
 			|| startsWith( lcfirst( $title->getDBKey() ), self::TAG_INTERFACE_PREFIX )
+			|| startsWith( lcfirst( $title->getDBKey() ), self::GADGETS_INTERFACE_PREFIX )
+			|| startsWith( lcfirst( $title->getDBKey() ), self::GADGET_INTERFACE_PREFIX )
 		) {
 			return $wgUser->isAllowed( 'editinterface' );
 		}


### PR DESCRIPTION
Also whitelists Gadgets-*, which applies to messages defined by the extension itself, thus allowing users to alter gadgets-definition as well.

@Grunny