### PR TITLE
XW-2650 | HTML title for Mercury file pages is consistent with desktop

### DIFF
--- a/extensions/wikia/MercuryApi/MercuryApiController.class.php
+++ b/extensions/wikia/MercuryApi/MercuryApiController.class.php
@@ -357,6 +357,7 @@ class MercuryApiController extends WikiaController {
 
 				if ( $article instanceof Article) {
 					$articleData = MercuryApiArticleHandler::getArticleJson( $this->request, $article );
+					$displayTitle = $articleData['displayTitle'];
 					$data['categories'] = $articleData['categories'];
 					$data['details'] = MercuryApiArticleHandler::getArticleDetails( $article );
 				} else {
@@ -384,10 +385,8 @@ class MercuryApiController extends WikiaController {
 						$data['article'] = $articleData;
 
 						if ( !$title->isContentPage() ) {
-							// This does two things:
-							// - gets displayTitle from parser function {{DISPLAYTITLE:displayTitle}}
-							// - removes the namespace prefix from it
-							$displayTitle = Title::newFromText( $data['article']['displayTitle'] )->getText();
+							// Remove the namespace prefix from display title
+							$displayTitle = Title::newFromText( $displayTitle )->getText();
 							$data['article']['displayTitle'] = $displayTitle;
 						}
 					}

--- a/extensions/wikia/MercuryApi/MercuryApiController.class.php
+++ b/extensions/wikia/MercuryApi/MercuryApiController.class.php
@@ -346,6 +346,7 @@ class MercuryApiController extends WikiaController {
 
 				// getPage is cached (see the bottom of the method body) so there is no need for additional caching here
 				$article = Article::newFromID( $title->getArticleId() );
+				$displayTitle = null;
 
 				if ( $title->isRedirect() ) {
 					list( $title, $article, $data ) = $this->handleRedirect( $title, $article, $data );
@@ -366,8 +367,10 @@ class MercuryApiController extends WikiaController {
 					 */
 					$data['details'] = MercuryApiCategoryHandler::getCategoryMockedDetails( $title );
 				}
+
 				$data['articleType'] = WikiaPageType::getArticleType( $title );
 				$data['adsContext'] = $this->mercuryApi->getAdsContext( $title );
+
 				$otherLanguages = $this->getOtherLanguages( $title );
 
 				if ( !empty( $otherLanguages ) ) {
@@ -384,8 +387,8 @@ class MercuryApiController extends WikiaController {
 							// This does two things:
 							// - gets displayTitle from parser function {{DISPLAYTITLE:displayTitle}}
 							// - removes the namespace prefix from it
-							$data['article']['displayTitle'] =
-								Title::newFromText( $data['article']['displayTitle'] )->getText();
+							$displayTitle = Title::newFromText( $data['article']['displayTitle'] )->getText();
+							$data['article']['displayTitle'] = $displayTitle;
 						}
 					}
 
@@ -410,6 +413,8 @@ class MercuryApiController extends WikiaController {
 							);
 					}
 				}
+
+				$data['htmlTitle'] = $this->mercuryApi->getHtmlTitleForPage( $title, $displayTitle );
 			}
 		} catch ( WikiaHttpException $exception ) {
 			$this->response->setCode( $exception->getCode() );

--- a/extensions/wikia/MercuryApi/MercuryApiController.class.php
+++ b/extensions/wikia/MercuryApi/MercuryApiController.class.php
@@ -371,6 +371,8 @@ class MercuryApiController extends WikiaController {
 
 				$data['articleType'] = WikiaPageType::getArticleType( $title );
 				$data['adsContext'] = $this->mercuryApi->getAdsContext( $title );
+				// Set it before we remove the namespace from $displayTitle
+				$data['htmlTitle'] = $this->mercuryApi->getHtmlTitleForPage( $title, $displayTitle );
 
 				$otherLanguages = $this->getOtherLanguages( $title );
 
@@ -412,8 +414,6 @@ class MercuryApiController extends WikiaController {
 							);
 					}
 				}
-
-				$data['htmlTitle'] = $this->mercuryApi->getHtmlTitleForPage( $title, $displayTitle );
 			}
 		} catch ( WikiaHttpException $exception ) {
 			$this->response->setCode( $exception->getCode() );

--- a/extensions/wikia/MercuryApi/models/MercuryApi.class.php
+++ b/extensions/wikia/MercuryApi/models/MercuryApi.class.php
@@ -316,13 +316,9 @@ class MercuryApi {
 	 * @return string
 	 */
 	public function getHtmlTitleForPage( Title $title, $displayTitle ) {
-		global $wgContLang;
-
 		if ( $title->isMainPage() ) {
 			return '';
 		}
-
-		$namespaces = $wgContLang->getNamespaces();
 
 		if ( $title->inNamespace( NS_FILE ) ) {
 			$file = WikiaFileHelper::getFileFromTitle( $title );
@@ -332,9 +328,7 @@ class MercuryApi {
 		}
 
 		if ( empty( $htmlTitle ) ) {
-			$namespace = $namespaces[$title->getNamespace()];
-			$prefix = !empty( $namespace ) ? $namespace . ':' : '';
-			$htmlTitle = $prefix . $title->getText();
+			$htmlTitle = $title->getPrefixedText();
 		}
 
 		return $htmlTitle;

--- a/extensions/wikia/MercuryApi/models/MercuryApi.class.php
+++ b/extensions/wikia/MercuryApi/models/MercuryApi.class.php
@@ -318,6 +318,10 @@ class MercuryApi {
 	public function getHtmlTitleForPage( Title $title, $displayTitle ) {
 		global $wgContLang;
 
+		if ( $title->isMainPage() ) {
+			return '';
+		}
+
 		$namespaces = $wgContLang->getNamespaces();
 
 		if ( $title->inNamespace( NS_FILE ) ) {

--- a/extensions/wikia/MercuryApi/models/MercuryApi.class.php
+++ b/extensions/wikia/MercuryApi/models/MercuryApi.class.php
@@ -310,6 +310,33 @@ class MercuryApi {
 	}
 
 	/**
+	 * @param Title $title
+	 * @param string|null $displayTitle
+	 *
+	 * @return string
+	 */
+	public function getHtmlTitleForPage( Title $title, $displayTitle ) {
+		global $wgContLang;
+
+		$namespaces = $wgContLang->getNamespaces();
+
+		if ( $title->inNamespace( NS_FILE ) ) {
+			$file = WikiaFileHelper::getFileFromTitle( $title );
+			$htmlTitle = SEOTweaksHooksHelper::getTitleForFilePage( $title, $file );
+		} else {
+			$htmlTitle = $displayTitle;
+		}
+
+		if ( empty( $htmlTitle ) ) {
+			$namespace = $namespaces[$title->getNamespace()];
+			$prefix = !empty( $namespace ) ? $namespace . ':' : '';
+			$htmlTitle = $prefix . $title->getText();
+		}
+
+		return $htmlTitle;
+	}
+
+	/**
 	 * CuratedContent API returns data in a different format than we need.
 	 * Let's clean it up!
 	 *

--- a/extensions/wikia/SEOTweaks/SEOTweaksHooksHelper.class.php
+++ b/extensions/wikia/SEOTweaks/SEOTweaksHooksHelper.class.php
@@ -60,9 +60,9 @@ class SEOTweaksHooksHelper {
 		$newTitle = null;
 
 		if ( ( new WikiaFileHelper )->isFileTypeVideo( $file ) ) {
-			$newTitle = wfMsg( 'seotweaks-video' ) . ' - ' . $title->getBaseText();
+			$newTitle = wfMessage( 'seotweaks-video' )->escaped() . ' - ' . $title->getBaseText();
 		} elseif ( $file instanceof LocalFile && $file->getHandler() instanceof BitmapHandler ) {
-			$newTitle = wfMsg( 'seotweaks-image' ) . ' - ' . $title->getBaseText();
+			$newTitle = wfMessage( 'seotweaks-image' )->escaped() . ' - ' . $title->getBaseText();
 		}
 
 		return $newTitle;

--- a/extensions/wikia/SEOTweaks/SEOTweaksHooksHelper.class.php
+++ b/extensions/wikia/SEOTweaks/SEOTweaksHooksHelper.class.php
@@ -36,29 +36,36 @@ class SEOTweaksHooksHelper {
 	 * @return bool
 	 */
 	static function onImagePageAfterImageLinks( $imgPage, $html ) {
-		$file = $imgPage->getDisplayedFile(); /* @var $file LocalRepo */
+		$file = $imgPage->getDisplayedFile(); /* @var $file WikiaLocalFile */
 		$title = $imgPage->getTitle();  /* @var $title Title */
-		$newTitle = '';
 
 		if ( !empty( $file ) && !empty( $title ) && !F::app()->checkSkin('monobook') ) {
-
-			if ( (new WikiaFileHelper)->isFileTypeVideo( $file ) ) {
-
-				$newTitle = wfMsg('seotweaks-video') . ' - ' . $title->getBaseText();
-			} else {
-
-				// It's not Video so lets check if it is Image
-				if ( $file instanceof LocalFile && $file->getHandler() instanceof BitmapHandler ) {
-
-					$newTitle = wfMsg('seotweaks-image') . ' - ' . $title->getBaseText();
-				}
-			}
+			$newTitle = self::getTitleForFilePage( $title, $file );
 
 			if ( !empty( $newTitle ) ) {
 				F::app()->wg->Out->setPageTitle( $newTitle );
 			}
 		}
+
 		return true;
+	}
+
+	/**
+	 * @param Title $title
+	 * @param File $file
+	 *
+	 * @return null|string
+	 */
+	public static function getTitleForFilePage( Title $title, File $file ) {
+		$newTitle = null;
+
+		if ( ( new WikiaFileHelper )->isFileTypeVideo( $file ) ) {
+			$newTitle = wfMsg( 'seotweaks-video' ) . ' - ' . $title->getBaseText();
+		} elseif ( $file instanceof LocalFile && $file->getHandler() instanceof BitmapHandler ) {
+			$newTitle = wfMsg( 'seotweaks-image' ) . ' - ' . $title->getBaseText();
+		}
+
+		return $newTitle;
 	}
 
 	/**


### PR DESCRIPTION
* https://wikia-inc.atlassian.net/browse/XW-2650
* https://github.com/Wikia/mercury/pull/3062

Mercury will use `Image - Kerm.jpg | Muppet Wiki | Fandom powered by Wikia` instead of `File:Kerm.jpg | Muppet Wiki | Fandom powered by Wikia` for the HTML title. Same for videos.

/cc @gabrys 