### PR TITLE
XW-2653 | Link video thumbnails to file pages on Mercury

### DIFF
--- a/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php
+++ b/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php
@@ -45,7 +45,7 @@ class ArticleAsJson extends WikiaService {
 					'height' => $scaledSize['height'],
 					'width' => $scaledSize['width'],
 					'title' => $media['title'],
-					'link' => $media['link'] ?? '',
+					'href' => $media['href'],
 					'caption' => $media['caption'] ?? ''
 				]
 			)
@@ -65,7 +65,7 @@ class ArticleAsJson extends WikiaService {
 					'title' => $media['title'],
 					'fileUrl' => $media['fileUrl'],
 					'caption' => $media['caption'] ?? '',
-					'link' => $media['link'],
+					'href' => $media['href'],
 					'isLinkedByUser' => $media['isLinkedByUser'],
 					/**
 					 * data-ref has to be set for now because it's read in
@@ -154,10 +154,12 @@ class ArticleAsJson extends WikiaService {
 		];
 
 		if ( is_string( $link ) && $link !== '' && $media['type'] === 'image' ) {
+			// TODO remove after XW-2653 is released
 			$media['link'] = $link;
+			$media['href'] = $link;
 			$media['isLinkedByUser'] = true;
 		} else {
-			$media['link'] = $media['type'] === 'image' ? $media['url'] : $media['fileUrl'];
+			$media['href'] = $media['type'] === 'image' ? $media['url'] : $media['fileUrl'];
 			$media['isLinkedByUser'] = false;
 		}
 

--- a/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php
+++ b/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php
@@ -153,13 +153,15 @@ class ArticleAsJson extends WikiaService {
 			'user' => $details['userName']
 		];
 
+		// Only images are allowed to be linked by user
 		if ( is_string( $link ) && $link !== '' && $media['type'] === 'image' ) {
 			// TODO remove after XW-2653 is released
 			$media['link'] = $link;
 			$media['href'] = $link;
 			$media['isLinkedByUser'] = true;
 		} else {
-			$media['href'] = $media['type'] === 'image' ? $media['url'] : $media['fileUrl'];
+			// There is no easy way to link directly to a video, so we link to its file page
+			$media['href'] = $media['type'] === 'video' ? $media['fileUrl'] : $media['url'];
 			$media['isLinkedByUser'] = false;
 		}
 

--- a/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php
+++ b/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php
@@ -65,7 +65,8 @@ class ArticleAsJson extends WikiaService {
 					'title' => $media['title'],
 					'fileUrl' => $media['fileUrl'],
 					'caption' => $media['caption'] ?? '',
-					'link' => $media['link'] ?? '',
+					'link' => $media['link'],
+					'isLinkedByUser' => $media['isLinkedByUser'],
 					/**
 					 * data-ref has to be set for now because it's read in
 					 * extensions/wikia/PortableInfobox/services/Parser/Nodes/NodeImage.php:getGalleryData
@@ -125,7 +126,7 @@ class ArticleAsJson extends WikiaService {
 				array_filter(
 					$media,
 					function ( $item ) {
-						return isset( $item['link'] );
+						return $item['isLinkedByUser'];
 					}
 				)
 			) ) {
@@ -152,8 +153,12 @@ class ArticleAsJson extends WikiaService {
 			'user' => $details['userName']
 		];
 
-		if ( is_string( $link ) && $link !== '' ) {
+		if ( is_string( $link ) && $link !== '' && $media['type'] === 'image' ) {
 			$media['link'] = $link;
+			$media['isLinkedByUser'] = true;
+		} else {
+			$media['link'] = $media['type'] === 'image' ? $media['url'] : $media['fileUrl'];
+			$media['isLinkedByUser'] = false;
 		}
 
 		if ( !empty( $details['width'] ) ) {

--- a/extensions/wikia/ArticleAsJson/templates/media-icon.mustache
+++ b/extensions/wikia/ArticleAsJson/templates/media-icon.mustache
@@ -1,5 +1,4 @@
-{{#link}}
-<a href="{{link}}"{{#caption}} title="{{caption}}"{{/caption}}>
+<a href="{{href}}"{{#caption}} title="{{caption}}"{{/caption}}>
 	<img class="article-media-icon"
 		src="data:image/svg+xml;charset=utf-8,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' viewBox%3D'0 0 {{width}} {{height}}'%2F%3E"
 		data-src="{{url}}"
@@ -7,13 +6,3 @@
 		{{#width}} width="{{width}}"{{/width}}
 		{{#height}} height="{{height}}"{{/height}}>
 </a>
-{{/link}}
-{{^link}}
-	<img class="article-media-icon"
-		src="data:image/svg+xml;charset=utf-8,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' viewBox%3D'0 0 {{width}} {{height}}'%2F%3E"
-		data-src="{{url}}"
-		alt="{{title}}"
-		{{#caption}} title="{{caption}}"{{/caption}}
-		{{#width}} width="{{width}}"{{/width}}
-		{{#height}} height="{{height}}"{{/height}}>
-{{/link}}

--- a/extensions/wikia/ArticleAsJson/templates/media-thumbnail.mustache
+++ b/extensions/wikia/ArticleAsJson/templates/media-thumbnail.mustache
@@ -1,5 +1,5 @@
 <figure class="article-media-thumbnail"{{#mediaAttrs}} data-component="article-media-thumbnail" data-attrs="{{mediaAttrs}}"{{/mediaAttrs}} data-ref="{{ref}}">
-	<a href="{{link}}">
+	<a href="{{href}}">
 		<img class="article-media-placeholder"
 			src="data:image/svg+xml;charset=utf-8,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' viewBox%3D'0 0 {{width}} {{height}}'%2F%3E"
 			alt="{{title}}"

--- a/extensions/wikia/ArticleAsJson/templates/media-thumbnail.mustache
+++ b/extensions/wikia/ArticleAsJson/templates/media-thumbnail.mustache
@@ -1,5 +1,5 @@
 <figure class="article-media-thumbnail"{{#mediaAttrs}} data-component="article-media-thumbnail" data-attrs="{{mediaAttrs}}"{{/mediaAttrs}} data-ref="{{ref}}">
-	<a href="{{#link}}{{link}}{{/link}}{{^link}}{{url}}{{/link}}">
+	<a href="{{link}}">
 		<img class="article-media-placeholder"
 			src="data:image/svg+xml;charset=utf-8,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' viewBox%3D'0 0 {{width}} {{height}}'%2F%3E"
 			alt="{{title}}"


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/XW-2653
* https://github.com/Wikia/mercury/pull/3066

## Description

Every thumbnail is now linked to something:
- if it's an image and user provided a link, then use it and flag the thumbnail with `isLinkedByUser`
- if above is not true:
  - if it's a video link to a file page
  - if it's not a video link to the Vignette URL (yes, it supports audio etc.)

## Reviewers

@Wikia/x-wing 