### PR TITLE
XW-2755 | Fix geshi syntax highlighting for CSS

### DIFF
--- a/extensions/SyntaxHighlight_GeSHi/geshi/solarized-dark/css.php
+++ b/extensions/SyntaxHighlight_GeSHi/geshi/solarized-dark/css.php
@@ -208,8 +208,7 @@ $language_data = array (
         //note: & is needed for &gt; (i.e. > )
         2 => '(?<!\\\\):(?!\d)[a-zA-Z0-9\-]+\b(?:\s*(?=[\{\.#a-zA-Z,:+*&](.|\n)|<\|))',
         //Measurements
-        3 => '(em|ex|pt|px|cm|in|%)',
-        4 => '',
+        3 => '(em|ex|pt|px|cm|in|%)'
         ),
     'STRICT_MODE_APPLIES' => GESHI_NEVER,
     'SCRIPT_DELIMITERS' => array(

--- a/extensions/SyntaxHighlight_GeSHi/geshi/solarized-light/css.php
+++ b/extensions/SyntaxHighlight_GeSHi/geshi/solarized-light/css.php
@@ -209,8 +209,7 @@ $language_data = array (
         //note: & is needed for &gt; (i.e. > )
         2 => '(?<!\\\\):(?!\d)[a-zA-Z0-9\-]+\b(?:\s*(?=[\{\.#a-zA-Z,:+*&](.|\n)|<\|))',
         //Measurements
-        3 => '(em|ex|pt|px|cm|in|%)',
-        4 => '',
+        3 => '(em|ex|pt|px|cm|in|%)'
         ),
     'STRICT_MODE_APPLIES' => GESHI_NEVER,
     'SCRIPT_DELIMITERS' => array(


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/XW-2755

Geshi uses different logic for regexing CSS and JS. We initially it's the same and we applied the same fix in  https://github.com/Wikia/app/pull/12329 . Unfortunately this change breaks CSS syntax highlighting. 
CSS highlighter requires the same number of elements in `REGEXPS` and `STYLES->REGEXPS` arrays ( https://github.com/Wikia/app/blob/56db4bedee54e1c71849291eddf21e70eff8fa11/extensions/SyntaxHighlight_GeSHi/geshi/geshi.php#L3623-L3625 ). This PR reverts previous change.