### PR TITLE
MAIN-9681: Don't send popular wikis if hidden

### DIFF
--- a/extensions/wikia/UserProfilePageV3/UserIdentityBox.class.php
+++ b/extensions/wikia/UserProfilePageV3/UserIdentityBox.class.php
@@ -585,7 +585,11 @@ class UserIdentityBox extends WikiaObject {
 	 * @return array
 	 */
 	public function getTopWikis( $refreshHidden = false ) {
-		return $this->getFavoriteWikisModel()->getTopWikis( $refreshHidden );
+		if ( $this->user->getGlobalPreference( 'hideEditsWikis' ) ) {
+			return [];
+		} else {
+			return $this->getFavoriteWikisModel()->getTopWikis( $refreshHidden );
+		}
 	}
 
 	/**


### PR DESCRIPTION
**Warning:** This change is untested. Please test it, and sorry if it breaks

The API returns information about wikis the user recently edited on, even if the user has hidden them from their masthead. This change makes a check if that preference is set and returns an empty array if so.

Support ticket: [#316786](http://support.wikia-inc.com/hc/requests/316786)
Bug ticket: [MAIN-9681](https://wikia-inc.atlassian.net/browse/MAIN-9681)
Examples: [API call](http://c.wikia.com/wikia.php?controller=UserProfilePage&method=renderUserIdentityBox&title=User:Count_of_Howard&format=json), [script for unhiding user wikis](http://kocka.wikia.com/wiki/User:KockaAdmiralac/UnhideUserWikis.javascript?action=raw)