### PR TITLE
SUS-1556 | do not check tables existence on each request

### DIFF
--- a/extensions/wikia/ArticleComments/classes/CommentsIndex.class.php
+++ b/extensions/wikia/ArticleComments/classes/CommentsIndex.class.php
@@ -213,8 +213,6 @@ class CommentsIndex extends WikiaModel {
 		wfProfileIn( __METHOD__ );
 
 		if ( !wfReadOnly() && !empty( $this->commentId ) ) {
-			$this->createTableCommentsIndex();
-
 			$db = $this->dbw ? $this->dbw : wfGetDB( DB_MASTER );
 
 			$updateValue['last_touched'] = $db->timestamp();
@@ -247,8 +245,6 @@ class CommentsIndex extends WikiaModel {
 
 		wfProfileIn( __METHOD__ );
 
-
-		$this->createTableCommentsIndex();
 		$db = $this->dbw ? $this->dbw : wfGetDB( DB_MASTER );
 		$timestamp = $db->timestamp();
 		if ( empty( $this->createdAt ) ) {
@@ -293,24 +289,6 @@ class CommentsIndex extends WikiaModel {
 		// if $dbw was passed, this is a part of some outside transaction, so we don't commit anything yet
 		if ( is_null( $this->dbw ) ) {
 			$db->commit();
-		}
-
-		wfProfileOut( __METHOD__ );
-	}
-
-	/**
-	 * create comments_index table if not exists
-	 */
-	public function createTableCommentsIndex() {
-		wfProfileIn( __METHOD__ );
-
-		if ( !wfReadOnly() ) {
-			$db = $this->dbw ? $this->dbw : wfGetDB( DB_MASTER );
-
-			if ( !$db->tableExists( 'comments_index' ) ) {
-				$source = dirname( __FILE__ ) . "/../patch-create-comments_index.sql";
-				$db->sourceFile( $source );
-			}
 		}
 
 		wfProfileOut( __METHOD__ );

--- a/extensions/wikia/CreateNewWiki/tasks/CreateTables.php
+++ b/extensions/wikia/CreateNewWiki/tasks/CreateTables.php
@@ -24,10 +24,14 @@ class CreateTables extends Task {
 			"{$IP}/maintenance/archives/wikia/patch-create-blog_listing_relation.sql",
 			"{$IP}/maintenance/archives/wikia/patch-create-page_vote.sql",
 			"{$IP}/maintenance/archives/wikia/patch-create-page_visited.sql",
+
 			//article comments list use by wall/forum
 			"{$IP}/extensions/wikia/ArticleComments/patch-create-comments_index.sql",
-			//wall history table
+
+			//wall tables (SUS-1556)
 			"{$IP}/extensions/wikia/Wall/sql/wall_history_local.sql",
+			"{$IP}/extensions/wikia/Wall/sql/wall_related_pages.sql",
+
 			"{$IP}/extensions/wikia/VideoHandlers/sql/video_info.sql",
 			"{$IP}/maintenance/wikia/wikia_user_properties.sql",
 		];

--- a/extensions/wikia/Forum/Forum.setup.php
+++ b/extensions/wikia/Forum/Forum.setup.php
@@ -49,7 +49,6 @@ $wgHooks['WallHistoryHeader'][] = 'ForumHooksHelper::onWallHistoryHeader';
 
 $wgHooks['WallHeader'][] = 'ForumHooksHelper::onWallHeader';
 $wgHooks['WallNewMessage'][] = 'ForumHooksHelper::onWallNewMessage';
-$wgHooks['ArticleInsertComplete'][] = 'ForumHooksHelper::onArticleInsertComplete';
 $wgHooks['WallBeforeRenderThread'][] = 'ForumHooksHelper::onWallBeforeRenderThread';
 $wgHooks['AfterBuildNewMessageAndPost'][] = 'ForumHooksHelper::onAfterBuildNewMessageAndPost';
 $wgHooks['WallMessageDeleted'][] = 'ForumHooksHelper::onWallMessageDeleted';

--- a/extensions/wikia/Forum/ForumHooksHelper.class.php
+++ b/extensions/wikia/Forum/ForumHooksHelper.class.php
@@ -222,29 +222,6 @@ class ForumHooksHelper {
 	}
 
 	/**
-	 * Hook: add comments_index table when adding board
-	 * @param Article $article
-	 * @param $user
-	 * @param $text
-	 * @param $summary
-	 * @param $minoredit
-	 * @param $watchthis
-	 * @param $sectionanchor
-	 * @param $flags
-	 * @param $revision
-	 * @return bool
-	 */
-	static public function onArticleInsertComplete( &$article, &$user, $text, $summary, $minoredit, $watchthis, $sectionanchor, &$flags, $revision ) {
-		$title = $article->getTitle();
-		if ( $title->getNamespace() == NS_WIKIA_FORUM_BOARD ) {
-			$commentsIndex = ( new CommentsIndex );
-			$commentsIndex->createTableCommentsIndex();
-		}
-
-		return true;
-	}
-
-	/**
 	 * clear the caches
 	 * @param WallMessage $mw
 	 * @return bool

--- a/extensions/wikia/Wall/WallHooksHelper.class.php
+++ b/extensions/wikia/Wall/WallHooksHelper.class.php
@@ -2075,7 +2075,7 @@ class WallHooksHelper {
 	}
 
 	/**
-	 * Adds necessary tables if Wall or Forum has just been enabled in Special:WikiFeatures
+	 * Purge wiki navigation cache when disabling/enabling Forum and Wall
 	 *
 	 * @param String $name
 	 * @param String $val
@@ -2085,15 +2085,6 @@ class WallHooksHelper {
 	public static function onAfterToggleFeature( $name, $val ) {
 		global $IP;
 		if ( $name == 'wgEnableWallExt' || $name == 'wgEnableForumExt' ) {
-			$db = wfGetDB( DB_MASTER );
-			if ( !$db->tableExists( 'wall_history' ) ) {
-				$db->sourceFile( $IP . "/extensions/wikia/Wall/sql/wall_history_local.sql" );
-			}
-
-			if ( !$db->tableExists( 'wall_related_pages' ) ) {
-				$db->sourceFile( $IP . "/extensions/wikia/Wall/sql/wall_related_pages.sql" );
-			}
-
 			$nm = new NavigationModel();
 			$nm->clearMemc( NavigationModel::WIKIA_GLOBAL_VARIABLE );
 		}

--- a/extensions/wikia/Wall/WallRelatedPages.class.php
+++ b/extensions/wikia/Wall/WallRelatedPages.class.php
@@ -47,8 +47,6 @@ class WallRelatedPages extends WikiaModel {
 		wfProfileIn( __METHOD__ );
 		$db = wfGetDB( DB_MASTER );
 
-		$this->createTable();
-
 		$db->begin();
 		$db->delete( 'wall_related_pages', [
 			'comment_id' => $messageId
@@ -121,15 +119,6 @@ class WallRelatedPages extends WikiaModel {
 
 		// Loading from cache
 		$db = wfGetDB( $dbType );
-
-		if ( ! $db->tableExists( 'wall_related_pages' ) && wfReadOnly() ) {
-			wfProfileOut( __METHOD__ );
-			return [ ];
-		}
-
-		if ( $this->createTable() ) {
-			$db = wfGetDB( $dbType );
-		}
 
 		$result = $db->select(
 			[ 'wall_related_pages' ],
@@ -262,15 +251,6 @@ class WallRelatedPages extends WikiaModel {
 
 		// Loading from cache
 		$db = wfGetDB( DB_SLAVE );
-
-	    if ( ! $db->tableExists( 'wall_related_pages' ) && wfReadOnly() ) {
-			wfProfileOut( __METHOD__ );
-			return [ ];
-		}
-
-		if ( $this->createTable() ) {
-			$db = wfGetDB( DB_MASTER );
-		}
 
 		// Loading from cache
 		$result = $db->select(

--- a/extensions/wikia/Wall/WallRelatedPages.class.php
+++ b/extensions/wikia/Wall/WallRelatedPages.class.php
@@ -3,26 +3,6 @@
 class WallRelatedPages extends WikiaModel {
 
 	/**
-	 * Create table if it dosen't exists
-	 */
-	function createTable() {
-		wfProfileIn( __METHOD__ );
-		$dir = dirname( __FILE__ );
-
-		if ( !wfReadOnly() ) {
-			$db = wfGetDB( DB_MASTER );
-			if ( !$db->tableExists( 'wall_related_pages' ) ) {
-				$db->sourceFile( $dir . '/sql/wall_related_pages.sql' );
-				wfProfileOut( __METHOD__ );
-				return true;
-			}
-		}
-
-		wfProfileOut( __METHOD__ );
-		return false;
-	}
-
-	/**
 	 * set last update use for ordering on aritcle page
 	 *
 	 */


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-1556

Instead rely on CreateNewWiki creating these tables (Wall is enabled site-wide because Forum extension is).

* `comments_index` existence was checked ~80k times a day
* `wall_related_pages` existence was checked ~10mm times a day