### PR TITLE
SUS-1565 | get rid of an assert on $page instance

### DIFF
--- a/extensions/wikia/Search/classes/MediaWikiService.php
+++ b/extensions/wikia/Search/classes/MediaWikiService.php
@@ -1094,7 +1094,7 @@ class MediaWikiService {
 	 *
 	 * @param int $pageId
 	 *
-	 * @return \Article
+	 * @return \Article|null
 	 */
 	protected function getPageFromPageId( $pageId ) {
 
@@ -1214,16 +1214,13 @@ class MediaWikiService {
 	 *
 	 * @param int $pageId
 	 *
-	 * @return \Title
+	 * @return \Title|null
 	 */
 	protected function getTitleFromPageId( $pageId ) {
 
 		if ( !isset( static::$pageIdsToTitles[$pageId] ) ) {
 			$page = $this->getPageFromPageId( $pageId );
-
-			\Wikia\Util\Assert::true( $page instanceof \Article, __METHOD__ . ' - Invalid article ID' ); // SUS-1403
-
-			static::$pageIdsToTitles[$pageId] = $page->getTitle();
+			static::$pageIdsToTitles[$pageId] = $page instanceof \Article ? $page->getTitle() : null;
 		}
 
 		return static::$pageIdsToTitles[$pageId];


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-1565

It's going to happen due to the way search master - slave replication is configured. We may sometimes get the "outdated" ID of an article from Solr that has been deleted on a wiki. This "problem" has been reported ~300 times in the last 48h. There's no user impact because of them.

Calls to this method are wrapped in try / catch block with "result is probably stale/deleted" comments