### PR TITLE
SUS-1542 | Fixing caching issues on closing/reopening threads on wall

### DIFF
--- a/extensions/wikia/Wall/WallExternalController.class.php
+++ b/extensions/wikia/Wall/WallExternalController.class.php
@@ -355,7 +355,7 @@ class WallExternalController extends WikiaController {
 		if ( $isDeleteOrRemove ) {
 			$this->response->setVal( 'html', $this->app->renderView( 'WallController', 'messageRemoved', [ 'showundo' => true , 'comment' => $mw ] ) );
 			$mw->getLastActionReason();
-			$mw->purgeSquid();
+			$mw->invalidateCache();
 			$this->response->setVal( 'deleteInfoBox', 'INFO BOX' );
 		}
 
@@ -391,17 +391,13 @@ class WallExternalController extends WikiaController {
 			case 'close':
 				if ( $mw->canArchive( $this->wg->User ) ) {
 					$result = $mw->archive( $this->wg->User, $reason );
-					$mw->getWall()->getTitle()->invalidateCache();
-					wfWaitForSlaves();
-					$mw->purgeSquid();
+					$mw->invalidateCache();
 				}
 				break;
 			case 'open':
 				if ( $mw->canReopen( $this->wg->User ) ) {
 					$result = $mw->reopen( $this->wg->User );
-					$mw->getWall()->getTitle()->invalidateCache();
-					wfWaitForSlaves();
-					$mw->purgeSquid();
+					$mw->invalidateCache();
 				}
 				break;
 			default:
@@ -456,7 +452,7 @@ class WallExternalController extends WikiaController {
 
 		) {
 			$mw->restore( $this->wg->User );
-			$mw->purgeSquid();
+			$mw->invalidateCache();
 			$this->response->setVal( 'status', true );
 			return true;
 		}
@@ -486,7 +482,7 @@ class WallExternalController extends WikiaController {
 			}
 
 			$mw->restore( $this->wg->User, $reason );
-			$mw->purgeSquid();
+			$mw->invalidateCache();
 
 			$this->response->setVal( 'buttons', $this->app->renderView( 'WallController', 'messageButtons', [ 'comment' => $mw ] ) );
 			$this->response->setVal( 'status', true );

--- a/extensions/wikia/Wall/WallExternalController.class.php
+++ b/extensions/wikia/Wall/WallExternalController.class.php
@@ -391,12 +391,16 @@ class WallExternalController extends WikiaController {
 			case 'close':
 				if ( $mw->canArchive( $this->wg->User ) ) {
 					$result = $mw->archive( $this->wg->User, $reason );
+					$mw->getWall()->getTitle()->invalidateCache();
+					wfWaitForSlaves();
 					$mw->purgeSquid();
 				}
 				break;
 			case 'open':
 				if ( $mw->canReopen( $this->wg->User ) ) {
 					$result = $mw->reopen( $this->wg->User );
+					$mw->getWall()->getTitle()->invalidateCache();
+					wfWaitForSlaves();
 					$mw->purgeSquid();
 				}
 				break;

--- a/extensions/wikia/Wall/WallMessage.class.php
+++ b/extensions/wikia/Wall/WallMessage.class.php
@@ -1683,9 +1683,8 @@ class WallMessage {
 	 * The flow then goes to TitleGetSquidURLs hook which cleans the list of URLs in Wall and Forum
 	 */
 	public function purgeSquid() {
-		$title = Title::newFromID( $this->getId() );
-		if ( $title instanceof Title ) {
-			$title->purgeSquid();
+		if ( $this->title instanceof Title ) {
+			$this->title->purgeSquid();
 		}
 	}
 

--- a/extensions/wikia/Wall/WallMessage.class.php
+++ b/extensions/wikia/Wall/WallMessage.class.php
@@ -1679,11 +1679,13 @@ class WallMessage {
 	}
 
 	/**
-	 * @desc calls purgeSquid() on $title instance
+	 * @desc calls purgeSquid() on $title instance and invalidateCache() on Wall's title instance
 	 * The flow then goes to TitleGetSquidURLs hook which cleans the list of URLs in Wall and Forum
 	 */
-	public function purgeSquid() {
+	public function invalidateCache() {
 		if ( $this->title instanceof Title ) {
+			$this->getWall()->getTitle()->invalidateCache();
+			wfWaitForSlaves();
 			$this->title->purgeSquid();
 		}
 	}

--- a/extensions/wikia/Wall/WallMessage.class.php
+++ b/extensions/wikia/Wall/WallMessage.class.php
@@ -1679,7 +1679,7 @@ class WallMessage {
 	}
 
 	/**
-	 * @desc Creates wall message title (a board, a thread, a message) instance and calls purgeSquid() on it
+	 * @desc calls purgeSquid() on $title instance
 	 * The flow then goes to TitleGetSquidURLs hook which cleans the list of URLs in Wall and Forum
 	 */
 	public function purgeSquid() {


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-1542

Invalidating cache for wall after closing/reopening thread, so the message about closing the thread will be visible right after closing the thread (or disapear when reopening).