### PR TITLE
SUS-1557: Message Wall: edits don't immediately render all wikitext content

### DIFF
--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -442,8 +442,9 @@ class ArticleComment {
 
 		$parser = ParserPool::get();
 		$parserOptions = $this->getParserOptions();
+		$user = $parserOptions->getUser();
 
-		$this->mRawtext = $parser->preSaveTransform( $this->mRawtext, $this->mTitle, $parserOptions->getUser(), $parserOptions );
+		$this->mRawtext = $parser->preSaveTransform( $this->mRawtext, $this->mTitle, $user, $parserOptions );
 
 		ParserPool::release( $parser );
 	}

--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -48,8 +48,10 @@ class ArticleComment {
 
 	protected $minRevIdFromSlave;
 
-	private $isTextLoaded = false;
 	private $isRevisionLoaded = false;
+
+	/** @var ParserOptions $mParserOptions Parser options that can be used for processing this article comment */
+	private $mParserOptions = null;
 
 	/**
 	 * @param Title $title
@@ -215,13 +217,13 @@ class ArticleComment {
 			return false;
 		}
 
-		if ( $this->isTextLoaded ) {
+		// SUS-1557: If raw comment text was already set, don't bother loading it from DB
+		if ( is_string( $this->mRawtext ) ) {
 			return true;
 		}
 
 		$this->setRawText( $this->mLastRevision->getText() );
 
-		$this->isTextLoaded = true;
 		return true;
 	}
 
@@ -374,15 +376,32 @@ class ArticleComment {
 	}
 
 	/**
+	 * Lazy-initialize and cache a ParserOptions instance that can be used to parse this article comment
+	 * @return ParserOptions
+	 */
+	private function getParserOptions(): ParserOptions {
+		if ( !( $this->mParserOptions instanceof ParserOptions ) ) {
+			$this->mParserOptions = ParserOptions::newFromContext( RequestContext::getMain() );
+
+			// VOLDEV-68: Remove broken section edit links
+			$this->mParserOptions->setEditSection( false );
+		}
+
+		return $this->mParserOptions;
+	}
+
+	/**
 	 * Parse the comment content in a lazy fashion: when either getText() or getHeadItems() is called
 	 */
 	private function parseText() {
 		wfProfileIn( __METHOD__ );
-		$this->load();
 
-		// VOLDEV-68: Remove broken section edit links
-		$opts = ParserOptions::newFromContext( RequestContext::getMain() );
-		$opts->setEditSection( false );
+		// SUS-1557: only load from DB if raw text was not set manually
+		if ( !is_string( $this->mRawtext ) ) {
+			$this->load();
+		}
+
+		$opts = $this->getParserOptions();
 
 		$data = WikiaDataAccess::cache(
 			wfMemcKey( __METHOD__, md5( $this->mRawtext . $this->mTitle->getPrefixedDBkey() ), $opts->optionsHash( ParserOptions::legacyOptions() ) ),
@@ -411,12 +430,46 @@ class ArticleComment {
 	}
 
 	/**
+	 * SUS-1557: Perform pre-save transformation on comment text
+	 * This is necessary when someone edits Wall/Forum content - we're sending back parsed user-passed text that has not passed through pre-save transformation
+	 */
+	private function transformText() {
+		// We can safely skip if mRawText is not set
+		// In that case it has to be loaded from DB, which means it has already gone through pre-save transofmration
+		if ( !is_string( $this->mRawtext ) ) {
+			return;
+		}
+
+		$parser = ParserPool::get();
+		$parserOptions = $this->getParserOptions();
+
+		$this->mRawtext = $parser->preSaveTransform( $this->mRawtext, $this->mTitle, $parserOptions->getUser(), $parserOptions );
+
+		ParserPool::release( $parser );
+	}
+
+	/**
 	 * Return HTML content of parsed comment
 	 *
 	 * @return string
 	 */
 	public function getText() {
 		if ( !is_string( $this->mText ) ) {
+			$this->parseText();
+		}
+
+		return $this->mText;
+	}
+
+	/**
+	 * Return HTML content of parsed comment, and additionally perform pre-save transformations
+	 * This is necessary if raw comment text is not fetched from DB but passed directly from user, since it skips transformation in that case
+	 *
+	 * @return string
+	 */
+	public function getTransformedParsedText(): string {
+		if ( !is_string( $this->mText ) ) {
+			$this->transformText();
 			$this->parseText();
 		}
 

--- a/extensions/wikia/ArticleComments/tests/ArticleCommentTest.php
+++ b/extensions/wikia/ArticleComments/tests/ArticleCommentTest.php
@@ -1,0 +1,51 @@
+<?php
+
+class ArticleCommentTest extends WikiaBaseTest {
+	/**
+	 * SUS-1557: Verify ArticleComment::getTransformedParsedText goes through both pre-save processing and wikitext parse
+	 * when text is not fetched from DB
+	 *
+	 * @see ArticleComment::getTransformedParsedText()
+	 */
+	public function testGetTransformedParsedText() {
+		$title = Title::makeTitle( NS_TALK, 'Piła tango' );
+		$user = new User;
+		$text = 'Grzesiek Kubiak, czyli Kuba rządził naszą podstawówką; Po lekcjach na boisku ganiał za mną z cegłówką.';
+		$parserMock = $this->getMock( Parser::class, [ 'parser', 'preSaveTransform' ] );
+		$parserOptionsMock = $this->getMock( ParserOptions::class, [ 'setEditSection', 'optionsHash' ] );
+
+		// ensure parser options do not allow "Section edit" links
+		$parserOptionsMock->expects( $this->at( 0 ) )
+			->method( 'setEditSection' )
+			->with( false );
+
+
+		$parserOptionsMock->expects( $this->at( 1 ) )
+			->method( 'getUser' )
+			->willReturn( $user );
+
+		$parserMock->expects( $this->at( 0 ) )
+			->method( 'preSaveTransform' )
+			->with( $text, $title, $user, $text )
+			->willReturnArgument( 3 );
+
+		// ensure options hash is used for memc key
+		$parserOptionsMock->expects( $this->at( 2 ) )
+			->method( 'optionsHash' )
+			->with( ParserOptions::legacyOptions() )
+			->willReturn( 'foo' );
+
+		$parserMock->expects( $this->at( 1 ) )
+			->method( 'parse' )
+			->with( $text, $title, $parserOptionsMock )
+			->willReturnArgument( 0 );
+
+		$this->mockClass( ParserOptions::class, $parserOptionsMock, 'newFromContext' );
+		$this->mockStaticMethod( ParserPool::class, 'get', $parserMock );
+		$this->mockStaticMethod( ParserPool::class, 'release', true );
+
+		$articleComment = new ArticleComment( $title );
+		$articleComment->setRawText( $text );
+		$returnText = $articleComment->getTransformedParsedText();
+	}
+}

--- a/extensions/wikia/ArticleComments/tests/CommentsIndexTest.php
+++ b/extensions/wikia/ArticleComments/tests/CommentsIndexTest.php
@@ -52,8 +52,6 @@ class CommentsIndexTest extends WikiaBaseTest {
 	}
 
 	/**
-	 * @group Slow
-	 * @slowExecutionTime 0.01076 ms
 	 * The purpose of CommentsIndex cache is avoid database queries for CommentsIndex instances that were created
 	 * during the request. So here we simulate inserting the CommentsIndex to the table and then ask for that id and
 	 * make sure it's not fetched from the database

--- a/extensions/wikia/Wall/WallMessage.class.php
+++ b/extensions/wikia/Wall/WallMessage.class.php
@@ -319,7 +319,7 @@ class WallMessage {
 
 		// parse the new / updated message
 		$articleComment->setRawText( $body );
-		$out = $articleComment->getText();
+		$out = $articleComment->getTransformedParsedText();
 
 		wfProfileOut( __METHOD__ );
 		return $out;

--- a/includes/EmailNotification.php
+++ b/includes/EmailNotification.php
@@ -585,30 +585,28 @@ class EmailNotification {
 		// its not a blog.
 		return (
 			( $this->action === ArticleComment::LOG_ACTION_COMMENT ) &&
-			( $this->title->getNamespace() != NS_BLOG_ARTICLE )
+			( defined( 'NS_BLOG_ARTICLE' ) && $this->title->inNamespace( NS_BLOG_ARTICLE ) )
 		);
 	}
 
 	private function isBlogComment() {
 		return (
 			( $this->action === ArticleComment::LOG_ACTION_COMMENT ) &&
-			( $this->title->getNamespace() == NS_BLOG_ARTICLE )
+			( defined( 'NS_BLOG_ARTICLE' ) && $this->title->inNamespace(  NS_BLOG_ARTICLE ) )
 		);
 	}
 
 	private function isUserBlogPost() {
-		$ns = $this->title->getNamespace();
 		return (
 			( $this->action === FollowHelper::LOG_ACTION_BLOG_POST ) &&
-			( $ns == NS_BLOG_ARTICLE )
+			( defined( 'NS_BLOG_ARTICLE' ) && $this->title->inNamespace( NS_BLOG_ARTICLE ) )
 		);
 	}
 
 	private function isListBlogPost() {
-		$ns = $this->title->getNamespace();
 		return (
 			( $this->action === FollowHelper::LOG_ACTION_BLOG_POST ) &&
-			( $ns == NS_BLOG_LISTING )
+			( defined( 'NS_BLOG_LISTING' ) && $this->title->inNamespace( NS_BLOG_LISTING ) )
 		);
 	}
 


### PR DESCRIPTION
Introduced `ArticleComment::getTransformedParsedText` method to run text through pre-save transform and used it in Wall

If text is not fetched from DB but provided by user (e.g. when replying to a Wall message, where parsed reply is rendered via Ajax without triggering a page refresh), the text needs
 to go through pre-save processing to expand signatures, substituted templates etc.

https://wikia-inc.atlassian.net/browse/SUS-1557