### PR TITLE
SUS-1283: fix WallNotificationEntityTest i18n usage

### DIFF
--- a/extensions/wikia/WallNotifications/tests/WallNotificationEntityTest.php
+++ b/extensions/wikia/WallNotifications/tests/WallNotificationEntityTest.php
@@ -1,6 +1,7 @@
 <?php
 
 class WallNotificationEntityTest extends WikiaBaseTest {
+	const A_FANDOM_USER = 'A Fandom user';
 
 	public function setUp() {
 		$this->setupFile = __DIR__ . '/../WallNotifications.setup.php';
@@ -43,10 +44,16 @@ class WallNotificationEntityTest extends WikiaBaseTest {
 			->method( 'set' )
 			->with( WallNotificationEntity::getMemcKey( $params['id'] ), $params['data'] );
 
+		$messageMock = $this->getMock( Message::class, [ 'escaped' ] );
+		$messageMock->expects( $this->any() )
+			->method( 'escaped' )
+			->willReturn( static::A_FANDOM_USER );
+
 		$this->mockClass( User::class, $userMock, 'newFromID' );
 		$this->mockGlobalVariable( 'wgMemc', $cacheMock );
 		$this->mockGlobalVariable( 'wgCityId', $params['wgCityId'] );
 		$this->mockGlobalVariable( 'wgSitename', $params['wgSitename'] );
+		$this->mockGlobalFunction( 'wfMessage', $messageMock );
 	}
 
 	private function setupWallMessageMocks( array $params ) {
@@ -337,7 +344,7 @@ class WallNotificationEntityTest extends WikiaBaseTest {
 				'parent_page_id' => '2147',
 				'msg_author_id' => 0,
 				'msg_author_username' => '65.19.148.1',
-				'msg_author_displayname' => wfMessage( 'oasis-anon-user' )->escaped(),
+				'msg_author_displayname' => static::A_FANDOM_USER,
 				'wall_username' => 'Garthwebb',
 				'wall_userid' => '2035791',
 				'wall_displayname' => 'Garthwebb',
@@ -413,7 +420,7 @@ class WallNotificationEntityTest extends WikiaBaseTest {
 				'parent_page_id' => '2147',
 				'msg_author_id' => '0',
 				'msg_author_username' => '65.19.148.1',
-				'msg_author_displayname' => wfMessage( 'oasis-anon-user' )->escaped(),
+				'msg_author_displayname' => static::A_FANDOM_USER,
 				'wall_username' => 'Garthwebb',
 				'wall_userid' => '2035791',
 				'wall_displayname' => 'Garthwebb',
@@ -573,7 +580,7 @@ class WallNotificationEntityTest extends WikiaBaseTest {
 				'thread_title' => "Hey hey I'm anon",
 				'notifyeveryone' => '',
 				'reason' => '',
-				'parent_displayname' => wfMessage( 'oasis-anon-user' )->escaped(),
+				'parent_displayname' => static::A_FANDOM_USER,
 				'parent_user_id' => '0',
 				'url' => 'http://garth.garth.wikia-dev.com/wiki/Thread:2726#2',
 			],

--- a/extensions/wikia/WallNotifications/tests/WallNotificationEntityTest.php
+++ b/extensions/wikia/WallNotifications/tests/WallNotificationEntityTest.php
@@ -84,42 +84,51 @@ class WallNotificationEntityTest extends WikiaBaseTest {
 			->getMock();
 		$wallMessageCounter = 0;
 
-		$wallMessageMock->expects( $this->at( $wallMessageCounter++ ) )
+		$wallMessageMock->expects( $this->at( $wallMessageCounter ) )
 			->method( 'load' );
+		$wallMessageCounter++;
 
-		$wallMessageMock->expects( $this->at( $wallMessageCounter++ ) )
+		$wallMessageMock->expects( $this->at( $wallMessageCounter ) )
 			->method( 'getWallOwner' )
 			->willReturn( $wallOwnerMock );
+		$wallMessageCounter++;
 
-		$wallMessageMock->expects( $this->at( $wallMessageCounter++ ) )
+		$wallMessageMock->expects( $this->at( $wallMessageCounter ) )
 			->method( 'getArticleTitle' )
 			->willReturn( $articleTitleMock );
+		$wallMessageCounter++;
 
-		$wallMessageMock->expects( $this->at( $wallMessageCounter++ ) )
+		$wallMessageMock->expects( $this->at( $wallMessageCounter ) )
 			->method( 'getText' )
 			->willReturn( $params['wallMessage']['text'] );
+		$wallMessageCounter++;
 
-		$wallMessageMock->expects( $this->at( $wallMessageCounter++ ) )
+		$wallMessageMock->expects( $this->at( $wallMessageCounter ) )
 			->method( 'getTitle' )
 			->willReturn( $titleMock );
+		$wallMessageCounter++;
 
-		$wallMessageMock->expects( $this->at( $wallMessageCounter++ ) )
+		$wallMessageMock->expects( $this->at( $wallMessageCounter ) )
 			->method( 'getMessagePageUrl' )
 			->willReturn( $params['wallMessage']['messagePageUrl'] );
+		$wallMessageCounter++;
 
-		$wallMessageMock->expects( $this->at( $wallMessageCounter++ ) )
+		$wallMessageMock->expects( $this->at( $wallMessageCounter ) )
 			->method( 'getNotifyeveryone' )
 			->willReturn( $params['wallMessage']['notifyeveryone'] );
+		$wallMessageCounter++;
 
 		$isEdited = $params['wallMessage']['isEdited'];
-		$wallMessageMock->expects( $this->at( $wallMessageCounter++ ) )
+		$wallMessageMock->expects( $this->at( $wallMessageCounter ) )
 			->method( 'isEdited' )
 			->willReturn( $isEdited );
+		$wallMessageCounter++;
 
 		if ( $isEdited ) {
-			$wallMessageMock->expects( $this->at( $wallMessageCounter++ ) )
+			$wallMessageMock->expects( $this->at( $wallMessageCounter ) )
 				->method( 'getLastEditSummary' )
 				->willReturn( $params['wallMessage']['lastEditSummary'] );
+			$wallMessageCounter++;
 		}
 
 		if ( !empty( $params['parentWallMessage']['id'] ) ) {
@@ -129,9 +138,10 @@ class WallNotificationEntityTest extends WikiaBaseTest {
 				->method( 'getTopParentObj' )
 				->willReturn( $parentWallMessageMock );
 		} else {
-			$wallMessageMock->expects( $this->at( $wallMessageCounter++ ) )
+			$wallMessageMock->expects( $this->at( $wallMessageCounter ) )
 				->method( 'getTopParentObj' )
 				->willReturn( null );
+			$wallMessageCounter++;
 
 			$wallMessageMock->expects( $this->at( $wallMessageCounter ) )
 				->method( 'getMetaTitle' )
@@ -250,20 +260,24 @@ class WallNotificationEntityTest extends WikiaBaseTest {
 		$parentWallMessageCounter = 0;
 
 
-		$parentWallMessageMock->expects( $this->at( $parentWallMessageCounter++ ) )
+		$parentWallMessageMock->expects( $this->at( $parentWallMessageCounter ) )
 			->method( 'load' );
+		$parentWallMessageCounter++;
 
-		$parentWallMessageMock->expects( $this->at( $parentWallMessageCounter++ ) )
+		$parentWallMessageMock->expects( $this->at( $parentWallMessageCounter ) )
 			->method( 'getTitle' )
 			->willReturn( $parentTitleMock );
+		$parentWallMessageCounter++;
 
-		$parentWallMessageMock->expects( $this->at( $parentWallMessageCounter++ ) )
+		$parentWallMessageMock->expects( $this->at( $parentWallMessageCounter ) )
 			->method( 'getMetaTitle' )
 			->willReturn( $params['parentWallMessage']['metaTitle'] );
+		$parentWallMessageCounter++;
 
-		$parentWallMessageMock->expects( $this->at( $parentWallMessageCounter++ ) )
+		$parentWallMessageMock->expects( $this->at( $parentWallMessageCounter ) )
 			->method( 'getUser' )
 			->willReturn( $parentUserMock );
+		$parentWallMessageCounter++;
 
 		$parentWallMessageMock->expects( $this->at( $parentWallMessageCounter ) )
 			->method( 'getId' )

--- a/extensions/wikia/WallNotifications/tests/WallNotificationEntityTest.php
+++ b/extensions/wikia/WallNotifications/tests/WallNotificationEntityTest.php
@@ -11,6 +11,8 @@ class WallNotificationEntityTest extends WikiaBaseTest {
 	 * Given a revision, verify that wall notification data is properly populated
 	 *
 	 * @see WallNotificationEntity::createFromRev()
+	 * @group Slow
+	 * @slowExecutionTime 0.01071 ms
 	 * @dataProvider loadDataFromRevDataProvider
 	 * @param array $params
 	 */

--- a/extensions/wikia/WallNotifications/tests/WallNotificationEntityTest.php
+++ b/extensions/wikia/WallNotifications/tests/WallNotificationEntityTest.php
@@ -1,24 +1,27 @@
 <?php
 
-/**
- * Class WallNotificationEntityTest
- */
 class WallNotificationEntityTest extends WikiaBaseTest {
 
+	public function setUp() {
+		$this->setupFile = __DIR__ . '/../WallNotifications.setup.php';
+		parent::setUp();
+	}
+
 	/**
-	 * @param $params
+	 * Given a revision, verify that wall notification data is properly populated
 	 *
+	 * @see WallNotificationEntity::createFromRev()
 	 * @dataProvider loadDataFromRevDataProvider
+	 * @param array $params
 	 */
-	public function testLoadDataFromRev( $params ) {
-		F::app()->wg->Sitename = $params['wgSitename'];
-		F::app()->wg->CityId = $params['wgCityId'];
+	public function testCreateFromRev( array $params ) {
+		$this->setupEnvironmentMocks( $params );
+		$this->setupWallMessageMocks( $params );
+		$revisionMock = $this->getRevisionMock( $params );
 
-		$rev = $this->getRevisionMock( $params );
-		$entity = $this->getEntityMock( $rev, $params );
+		$entity = WallNotificationEntity::createFromRev( $revisionMock );
 
-		$entity->loadDataFromRev( $rev );
-
+		$this->assertInstanceOf( WallNotificationEntity::class, $entity, 'WallNotificationEntity::createFromRev must return instance of WallNotificationEntity if given valid revision' );
 		$this->assertEquals( $entity->id, $params['id'], 'Testing "id" matches' );
 		$this->assertEquals( $entity->data, $params['data'], 'Member "data" matches' );
 		$this->assertEquals( $entity->parentTitleDbKey, $params['parentTitleDbKey'], 'Testing "parentTitleDbKey" matches' );
@@ -27,40 +30,31 @@ class WallNotificationEntityTest extends WikiaBaseTest {
 	}
 
 	/**
-	 * @param Revision $rev
 	 * @param array $params
-	 *
-	 * @return PHPUnit_Framework_MockObject_MockObject|WallNotificationEntity
 	 */
-	private function getEntityMock( Revision $rev, array $params ) {
-		$wm = $this->getWallMessageMock( $params );
+	private function setupEnvironmentMocks( array $params ) {
+		$userMock = $this->getMock( User::class, [ 'getName' ] );
+		$userMock->expects( $this->once() )
+			->method( 'getName' )
+			->willReturn( $params['user']['userName'] );
 
-		$entity = $this->getMockBuilder( 'WallNotificationEntity' )
-			->setMethods( [
-				'getUserName',
-				'getWallMessageFromRev',
-			] )
-			->disableOriginalConstructor()
-			->getMock();
+		$cacheMock = $this->getMockForAbstractClass( BagOStuff::class );
+		$cacheMock->expects( $this->once() )
+			->method( 'set' )
+			->with( WallNotificationEntity::getMemcKey( $params['id'] ), $params['data'] );
 
-		$entity->expects( $this->once() )
-			->method( 'getUserName' )
-			->willReturn( $params['entity']['userName'] );
-		$entity->expects( $this->once() )
-			->method( 'getWallMessageFromRev' )
-			->with( $this->equalTo( $rev ) )
-			->willReturn( $wm );
-
-		return $entity;
+		$this->mockClass( User::class, $userMock, 'newFromID' );
+		$this->mockGlobalVariable( 'wgMemc', $cacheMock );
+		$this->mockGlobalVariable( 'wgCityId', $params['wgCityId'] );
+		$this->mockGlobalVariable( 'wgSitename', $params['wgSitename'] );
 	}
 
-	private function getWallMessageMock( array $params ) {
-		$wallOwner = $this->getWallOwnerMock( $params );
-		$articleTitle = $this->getArticleTitleMock( $params );
-		$title = $this->getTitleMock( $params );
-		$parentWm = $this->getParentWallMessageMock( $params );
+	private function setupWallMessageMocks( array $params ) {
+		$wallOwnerMock = $this->getWallOwnerMock( $params );
+		$articleTitleMock = $this->getArticleTitleMock( $params );
+		$titleMock = $this->getTitleMock( $params );
 
-		$wm = $this->getMockBuilder( 'WallMessage' )
+		$wallMessageMock = $this->getMockBuilder( WallMessage::class )
 			->setMethods( [
 				'getWallOwner',
 				'getArticleTitle',
@@ -72,42 +66,67 @@ class WallNotificationEntityTest extends WikiaBaseTest {
 				'isEdited',
 				'getLastEditSummary',
 				'getMetaTitle',
+				'load'
 			] )
 			->disableOriginalConstructor()
 			->getMock();
+		$wallMessageCounter = 0;
 
-		$wm->expects( $this->once() )
+		$wallMessageMock->expects( $this->at( $wallMessageCounter++ ) )
+			->method( 'load' );
+
+		$wallMessageMock->expects( $this->at( $wallMessageCounter++ ) )
 			->method( 'getWallOwner' )
-			->willReturn( $wallOwner );
-		$wm->expects( $this->once() )
+			->willReturn( $wallOwnerMock );
+
+		$wallMessageMock->expects( $this->at( $wallMessageCounter++ ) )
 			->method( 'getArticleTitle' )
-			->willReturn( $articleTitle );
-		$wm->expects( $this->once() )
-			->method( 'getTitle' )
-			->willReturn( $title );
-		$wm->expects( $this->once() )
-			->method( 'getTopParentObj' )
-			->willReturn( $parentWm );
-		$wm->expects( $this->once() )
+			->willReturn( $articleTitleMock );
+
+		$wallMessageMock->expects( $this->at( $wallMessageCounter++ ) )
 			->method( 'getText' )
 			->willReturn( $params['wallMessage']['text'] );
-		$wm->expects( $this->once() )
+
+		$wallMessageMock->expects( $this->at( $wallMessageCounter++ ) )
+			->method( 'getTitle' )
+			->willReturn( $titleMock );
+
+		$wallMessageMock->expects( $this->at( $wallMessageCounter++ ) )
 			->method( 'getMessagePageUrl' )
 			->willReturn( $params['wallMessage']['messagePageUrl'] );
-		$wm->expects( $this->once() )
+
+		$wallMessageMock->expects( $this->at( $wallMessageCounter++ ) )
 			->method( 'getNotifyeveryone' )
 			->willReturn( $params['wallMessage']['notifyeveryone'] );
-		$wm->expects( $this->once() )
-			->method( 'isEdited' )
-			->willReturn( $params['wallMessage']['isEdited'] );
-		$wm->expects( $this->any() )
-			->method( 'getLastEditSummary' )
-			->willReturn( $params['wallMessage']['lastEditSummary'] );
-		$wm->expects( $this->any() )
-			->method( 'getMetaTitle' )
-			->willReturn( $params['wallMessage']['metaTitle'] );
 
-		return $wm;
+		$isEdited = $params['wallMessage']['isEdited'];
+		$wallMessageMock->expects( $this->at( $wallMessageCounter++ ) )
+			->method( 'isEdited' )
+			->willReturn( $isEdited );
+
+		if ( $isEdited ) {
+			$wallMessageMock->expects( $this->at( $wallMessageCounter++ ) )
+				->method( 'getLastEditSummary' )
+				->willReturn( $params['wallMessage']['lastEditSummary'] );
+		}
+
+		if ( !empty( $params['parentWallMessage']['id'] ) ) {
+			$parentWallMessageMock = $this->getParentWallMessageMock( $params );
+
+			$wallMessageMock->expects( $this->at( $wallMessageCounter++ ) )
+				->method( 'getTopParentObj' )
+				->willReturn( $parentWallMessageMock );
+		} else {
+			$wallMessageMock->expects( $this->at( $wallMessageCounter++ ) )
+				->method( 'getTopParentObj' )
+				->willReturn( null );
+
+			$wallMessageMock->expects( $this->at( $wallMessageCounter++ ) )
+				->method( 'getMetaTitle' )
+				->willReturn( $params['wallMessage']['metaTitle'] );
+		}
+
+		$this->mockClass( WallMessage::class, $wallMessageMock, 'newFromTitle' );
 	}
 
 	/**
@@ -115,7 +134,7 @@ class WallNotificationEntityTest extends WikiaBaseTest {
 	 *
 	 * @return PHPUnit_Framework_MockObject_MockObject|Revision
 	 */
-	private function getRevisionMock( array $params ) {
+	private function getRevisionMock( array $params ): PHPUnit_Framework_MockObject_MockObject {
 		$rev = $this->getMockBuilder( 'Revision' )
 			->setMethods( [
 				'getId',
@@ -138,7 +157,7 @@ class WallNotificationEntityTest extends WikiaBaseTest {
 		return $rev;
 	}
 
-	private function getWallOwnerMock( array $params ) {
+	private function getWallOwnerMock( array $params ): PHPUnit_Framework_MockObject_MockObject {
 		$wallOwner = $this->getMockBuilder( 'User' )
 			->setMethods( [
 				'getId',
@@ -157,7 +176,7 @@ class WallNotificationEntityTest extends WikiaBaseTest {
 		return $wallOwner;
 	}
 
-	private function getArticleTitleMock( array $params ) {
+	private function getArticleTitleMock( array $params ): PHPUnit_Framework_MockObject_MockObject {
 		$articleTitle = $this->getMockBuilder( 'Title' )
 			->setMethods( [
 				'exists',
@@ -188,13 +207,8 @@ class WallNotificationEntityTest extends WikiaBaseTest {
 		return $articleTitle;
 	}
 
-	private function getTitleMock( array $params ) {
-		$title = $this->getMockBuilder( 'Title' )
-			->setMethods( [
-				'getArticleId',
-			] )
-			->disableOriginalConstructor()
-			->getMock();
+	private function getTitleMock( array $params ): PHPUnit_Framework_MockObject_MockObject {
+		$title = $this->getMock( Title::class, [ 'getArticleId' ] );
 
 		$title->expects( $this->once() )
 			->method( 'getArticleId' )
@@ -203,15 +217,11 @@ class WallNotificationEntityTest extends WikiaBaseTest {
 		return $title;
 	}
 
-	private function getParentWallMessageMock( array $params ) {
-		if ( empty( $params['parentWallMessage']['id'] ) ) {
-			return null;
-		}
+	private function getParentWallMessageMock( array $params ): PHPUnit_Framework_MockObject_MockObject {
+		$parentTitleMock = $this->getParentTitleMock( $params );
+		$parentUserMock = $this->getParentUserMock( $params );
 
-		$parentTitle = $this->getParentTitleMock( $params );
-		$parentUser = $this->getParentUserMock( $params );
-
-		$parentWm = $this->getMockBuilder( 'WallMessage' )
+		$parentWallMessageMock = $this->getMockBuilder( 'WallMessage' )
 			->setMethods( [
 				'load', // should do nothing
 				'getTitle',
@@ -221,60 +231,59 @@ class WallNotificationEntityTest extends WikiaBaseTest {
 			] )
 			->disableOriginalConstructor()
 			->getMock();
+		$parentWallMessageCounter = 0;
 
-		$parentWm->expects( $this->once() )
+
+		$parentWallMessageMock->expects( $this->at( $parentWallMessageCounter++ ) )
 			->method( 'load' );
-		$parentWm->expects( $this->once() )
+
+		$parentWallMessageMock->expects( $this->at( $parentWallMessageCounter++ ) )
 			->method( 'getTitle' )
-			->willReturn( $parentTitle );
-		$parentWm->expects( $this->any() )
+			->willReturn( $parentTitleMock );
+
+		$parentWallMessageMock->expects( $this->at( $parentWallMessageCounter++ ) )
 			->method( 'getMetaTitle' )
 			->willReturn( $params['parentWallMessage']['metaTitle'] );
-		$parentWm->expects( $this->once() )
+
+		$parentWallMessageMock->expects( $this->at( $parentWallMessageCounter++ ) )
+			->method( 'getUser' )
+			->willReturn( $parentUserMock );
+
+		$parentWallMessageMock->expects( $this->at( $parentWallMessageCounter++ ) )
 			->method( 'getId' )
 			->willReturn( $params['parentWallMessage']['id'] );
-		$parentWm->expects( $this->once() )
-			->method( 'getUser' )
-			->willReturn( $parentUser );
 
-		return $parentWm;
+		return $parentWallMessageMock;
 	}
 
-	private function getParentTitleMock( array $params ) {
-		$parentTitle = $this->getMockBuilder( 'Title' )
-			->setMethods( [
-				'getDBkey',
-			] )
-			->disableOriginalConstructor()
-			->getMock();
+	private function getParentTitleMock( array $params ): PHPUnit_Framework_MockObject_MockObject {
+		$parentTitleMock = $this->getMock( Title::class, [ 'getDBkey' ] );
 
-		$parentTitle->expects( $this->once() )
+		$parentTitleMock->expects( $this->once() )
 			->method( 'getDBkey' )
 			->willReturn( $params['parentTitle']['dbKey'] );
 
-		return $parentTitle;
+		return $parentTitleMock;
 	}
 
-	private function getParentUserMock( array $params ) {
-		$parentTitle = $this->getMockBuilder( 'User' )
-			->setMethods( [
-				'getId',
-				'getName',
-			] )
+	private function getParentUserMock( array $params ): PHPUnit_Framework_MockObject_MockObject {
+		$parentUserMock = $this->getMockBuilder( User::class )
+			->setMethods( [ 'getId', 'getName' ] )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$parentTitle->expects( $this->once() )
-			->method( 'getId' )
-			->willReturn( $params['parentUser']['id'] );
-		$parentTitle->expects( $this->once() )
+		$parentUserMock->expects( $this->once() )
 			->method( 'getName' )
 			->willReturn( $params['parentUser']['name'] );
 
-		return $parentTitle;
+		$parentUserMock->expects( $this->once() )
+			->method( 'getId' )
+			->willReturn( $params['parentUser']['id'] );
+
+		return $parentUserMock;
 	}
 
-	public function loadDataFromRevDataProvider() {
+	public function loadDataFromRevDataProvider(): array {
 		$anonTopic = [
 			'revision' => [
 				'id' => '5330',
@@ -312,7 +321,7 @@ class WallNotificationEntityTest extends WikiaBaseTest {
 			],
 			'parentUser' => [
 			],
-			'entity' => [
+			'user' => [
 				'userName' => '65.19.148.1',
 			],
 			'data' => (object) [
@@ -328,7 +337,7 @@ class WallNotificationEntityTest extends WikiaBaseTest {
 				'parent_page_id' => '2147',
 				'msg_author_id' => 0,
 				'msg_author_username' => '65.19.148.1',
-				'msg_author_displayname' => 'A Wikia contributor',
+				'msg_author_displayname' => wfMessage( 'oasis-anon-user' )->escaped(),
 				'wall_username' => 'Garthwebb',
 				'wall_userid' => '2035791',
 				'wall_displayname' => 'Garthwebb',
@@ -388,7 +397,7 @@ class WallNotificationEntityTest extends WikiaBaseTest {
 				'id' => '23911114',
 				'name' => 'GarthTest800',
 			],
-			'entity' => [
+			'user' => [
 				'userName' => '65.19.148.1',
 			],
 			'data' => (object) [
@@ -404,7 +413,7 @@ class WallNotificationEntityTest extends WikiaBaseTest {
 				'parent_page_id' => '2147',
 				'msg_author_id' => '0',
 				'msg_author_username' => '65.19.148.1',
-				'msg_author_displayname' => 'A Wikia contributor',
+				'msg_author_displayname' => wfMessage( 'oasis-anon-user' )->escaped(),
 				'wall_username' => 'Garthwebb',
 				'wall_userid' => '2035791',
 				'wall_displayname' => 'Garthwebb',
@@ -463,7 +472,7 @@ class WallNotificationEntityTest extends WikiaBaseTest {
 			],
 			'parentUser' => [
 			],
-			'entity' => [
+			'user' => [
 				'userName' => 'GarthTest400',
 			],
 			'data' => (object) [
@@ -539,7 +548,7 @@ class WallNotificationEntityTest extends WikiaBaseTest {
 				'id' => '0',
 				'name' => '65.19.148.1',
 			],
-			'entity' => [
+			'user' => [
 				'userName' => 'GarthTest400',
 			],
 			'data' => (object) [
@@ -564,7 +573,7 @@ class WallNotificationEntityTest extends WikiaBaseTest {
 				'thread_title' => "Hey hey I'm anon",
 				'notifyeveryone' => '',
 				'reason' => '',
-				'parent_displayname' => 'A Wikia contributor',
+				'parent_displayname' => wfMessage( 'oasis-anon-user' )->escaped(),
 				'parent_user_id' => '0',
 				'url' => 'http://garth.garth.wikia-dev.com/wiki/Thread:2726#2',
 			],

--- a/extensions/wikia/WallNotifications/tests/WallNotificationEntityTest.php
+++ b/extensions/wikia/WallNotifications/tests/WallNotificationEntityTest.php
@@ -46,7 +46,10 @@ class WallNotificationEntityTest extends WikiaBaseTest {
 			->method( 'set' )
 			->with( WallNotificationEntity::getMemcKey( $params['id'] ), $params['data'] );
 
-		$messageMock = $this->getMock( Message::class, [ 'escaped' ] );
+		$messageMock = $this->getMockBuilder( Message::class )
+			->disableOriginalConstructor()
+			->setMethods( [ 'escaped' ] )
+			->getMock();
 		$messageMock->expects( $this->any() )
 			->method( 'escaped' )
 			->willReturn( static::A_FANDOM_USER );
@@ -149,6 +152,7 @@ class WallNotificationEntityTest extends WikiaBaseTest {
 				'getId',
 				'getUser',
 				'getTimestamp',
+				'getTitle'
 			] )
 			->disableOriginalConstructor()
 			->getMock();
@@ -162,6 +166,9 @@ class WallNotificationEntityTest extends WikiaBaseTest {
 		$rev->expects( $this->once() )
 			->method( 'getTimestamp' )
 			->willReturn( $params['revision']['timestamp'] );
+		$rev->expects( $this->once() )
+			->method( 'getTitle' )
+			->willReturn( new Title() );
 
 		return $rev;
 	}

--- a/extensions/wikia/WallNotifications/tests/WallNotificationEntityTest.php
+++ b/extensions/wikia/WallNotifications/tests/WallNotificationEntityTest.php
@@ -125,7 +125,7 @@ class WallNotificationEntityTest extends WikiaBaseTest {
 		if ( !empty( $params['parentWallMessage']['id'] ) ) {
 			$parentWallMessageMock = $this->getParentWallMessageMock( $params );
 
-			$wallMessageMock->expects( $this->at( $wallMessageCounter++ ) )
+			$wallMessageMock->expects( $this->at( $wallMessageCounter ) )
 				->method( 'getTopParentObj' )
 				->willReturn( $parentWallMessageMock );
 		} else {
@@ -133,7 +133,7 @@ class WallNotificationEntityTest extends WikiaBaseTest {
 				->method( 'getTopParentObj' )
 				->willReturn( null );
 
-			$wallMessageMock->expects( $this->at( $wallMessageCounter++ ) )
+			$wallMessageMock->expects( $this->at( $wallMessageCounter ) )
 				->method( 'getMetaTitle' )
 				->willReturn( $params['wallMessage']['metaTitle'] );
 		}
@@ -265,7 +265,7 @@ class WallNotificationEntityTest extends WikiaBaseTest {
 			->method( 'getUser' )
 			->willReturn( $parentUserMock );
 
-		$parentWallMessageMock->expects( $this->at( $parentWallMessageCounter++ ) )
+		$parentWallMessageMock->expects( $this->at( $parentWallMessageCounter ) )
 			->method( 'getId' )
 			->willReturn( $params['parentWallMessage']['id'] );
 


### PR DESCRIPTION
- don't mock the SUT
- don't hardcode i18n expecteds
- add some extra expectations and mock memcache

https://wikia-inc.atlassian.net/browse/SUS-1283