### PR TITLE
XW-2782 | MercuryApi fix errors when SEOTweaks extension isn't enabled

### DIFF
--- a/extensions/wikia/MercuryApi/models/MercuryApi.class.php
+++ b/extensions/wikia/MercuryApi/models/MercuryApi.class.php
@@ -326,7 +326,11 @@ class MercuryApi {
 			return '';
 		}
 
-		if ( $title->inNamespace( NS_FILE ) ) {
+		if ( class_exists( 'SEOTweaksHooksHelper' ) && $title->inNamespace( NS_FILE ) ) {
+			/*
+			 * Only run this code if SEOTweaks extension is enabled.
+			 * We don't use $wg variable because there are multiple switches enabling this extension
+			 */
 			$file = WikiaFileHelper::getFileFromTitle( $title );
 			$htmlTitle = SEOTweaksHooksHelper::getTitleForFilePage( $title, $file );
 		} else {


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/XW-2782

SEOTweaks extension isn't enabled on all wikis. We try to use it in MercuryApi and we end up with  `Class not found` exception. This simple check makes a deal here.

Ping @Wikia/x-wing 