### PR TITLE
SUS-1595: Fix contributions link in Special:ChatBanList

### DIFF
--- a/extensions/wikia/Chat2/ChatBanListSpecial_helper.php
+++ b/extensions/wikia/Chat2/ChatBanListSpecial_helper.php
@@ -197,22 +197,20 @@ class ChatBanData extends WikiaModel
 	private function getUserLinks( $user ) {
 
 		$userIsBlocked = $this->wg->User->isBlocked( true, false );
-		$oEncUserName = urlencode( $user->getName() );
+		$username = $user->getName();
 		$links = [
 			0 => "",
 			1 => Linker::link(
-				Title::newFromText( 'Contributions', NS_SPECIAL ),
-				$this->wg->Lang->ucfirst( wfMsg( 'contribslink' ) ),
-				[],
-				[ 'target' => $oEncUserName]
+				SpecialPage::getSafeTitleFor( 'Contributions', $username ),
+				$this->wg->Lang->ucfirst( wfMsg( 'contribslink' ) )
 			),
 		];
 
 		if ( !empty( $this->wg->EnableWallExt ) ) {
-			$oUTitle = Title::newFromText( $user->getName(), NS_USER_WALL );
+			$oUTitle = Title::newFromText( $username, NS_USER_WALL );
 			$msg = 'wall-message-wall-shorten';
 		} else {
-			$oUTitle = Title::newFromText( $user->getName(), NS_USER_TALK );
+			$oUTitle = Title::newFromText( $username, NS_USER_TALK );
 			$msg = 'talkpagelinktext';
 		}
 
@@ -222,15 +220,14 @@ class ChatBanData extends WikiaModel
 
 		if ( $this->wg->User->isAllowed( 'block' ) && ( !$userIsBlocked ) ) {
 			$links[] = Linker::link(
-				Title::newFromText( "BlockIP/{$user->getName()}", NS_SPECIAL ),
+				SpecialPage::getSafeTitleFor( 'Block', $username ),
 				$this->wg->Lang->ucfirst( wfMsg( 'blocklink' ) )
 			);
 		}
 		if ( $this->wg->User->isAllowed( 'userrights' ) && ( !$userIsBlocked ) ) {
 			$links[] = Linker::link(
-				Title::newFromText( 'UserRights', NS_SPECIAL ),
-				$this->wg->Lang->ucfirst( wfMsg( 'listgrouprights-rights' ) ),
-				"user={$oEncUserName}"
+				SpecialPage::getSafeTitleFor( 'UserRights', $username ),
+				$this->wg->Lang->ucfirst( wfMsg( 'listgrouprights-rights' ) )
 			);
 		}
 

--- a/extensions/wikia/Chat2/ChatBanListSpecial_helper.php
+++ b/extensions/wikia/Chat2/ChatBanListSpecial_helper.php
@@ -203,6 +203,7 @@ class ChatBanData extends WikiaModel
 			1 => Linker::link(
 				Title::newFromText( 'Contributions', NS_SPECIAL ),
 				$this->wg->Lang->ucfirst( wfMsg( 'contribslink' ) ),
+				[],
 				[ 'target' => $oEncUserName]
 			),
 		];


### PR DESCRIPTION
[Special:ChatBanList](http://c.wikia.com/wiki/Special:ChatBanList) is displaying a link to `Special:Contributions` instead of `Special:Contributions/Username` or `Special:Contributions?target=Username`. That happens because parameters are wrongly passed to the `Linker::link` method, and this pull request is supposed to fix that.

Support ticket: [#317255](https://support.wikia-inc.com/hc/en-us/requests/317255)
Bug ticket: [SUS-1595](https://wikia-inc.atlassian.net/browse/SUS-1595)