### PR TITLE
SUS-1508: Limiting the number of results returned by list=wkdomains

### DIFF
--- a/extensions/wikia/WikiaApi/WikiaApiQueryDomains.php
+++ b/extensions/wikia/WikiaApi/WikiaApiQueryDomains.php
@@ -14,14 +14,14 @@ class WikiaApiQueryDomains extends ApiQueryBase {
 	/**
 	 * constructor
 	 */
-	public function __construct($query, $moduleName) {
+	public function __construct( $query, $moduleName ) {
 		$this->defLimit = 1000;
-		parent :: __construct($query, $moduleName, "wk");
+		parent :: __construct( $query, $moduleName, 'wk' );
 	}
 
 	protected function getDB() {
 		global $wgExternalSharedDB;
-		return wfGetDB(DB_SLAVE, array(), $wgExternalSharedDB);
+		return wfGetDB( DB_SLAVE, [], $wgExternalSharedDB );
 	}
 
 	/**
@@ -37,34 +37,43 @@ class WikiaApiQueryDomains extends ApiQueryBase {
 		 */
 		$db = $this->getDB();
 		$activeonly = false;
-		if( isset($active) ) {
+		if( isset( $active ) ) {
 			$activeonly = true;
 		}
 
 		/**
 		 * query builder
 		 */
-		$this->addTables(array('city_list'));
+		$this->addTables( [ 'city_list' ] );
 
-		if ($activeonly) $this->addWhereFld('city_public', 1);
-		if ($wikia) $this->addWhereFld('city_id', $wikia);
+		if ( $activeonly ) {
+			$this->addWhereFld( 'city_public', 1 );
+		}
 
-		if (empty($wikia)) {
-			if ( !empty($to) ) {
-				if ($to && is_int($to)) {
-					$this->addWhere('city_id <= '.intval($to));	
+		if ( $wikia ) {
+			$this->addWhereFld( 'city_id', $wikia );
+		}
+
+		if ( empty( $wikia ) ) {
+			if ( !empty( $to ) ) {
+				if ( $to && is_int( $to ) ) {
+					$to = intval( $to );
+					$this->addWhere( 'city_id <= ' . $to );	
 				}
 			}
 
-			if ( !empty($from) ) {
-				if ($from && is_int($from)) $this->addWhere('city_id >= '.intval($from));
+			if ( !empty( $from ) ) {
+				if ( $from && is_int( $from ) ) {
+					$from = intval( $from );
+					$this->addWhere( 'city_id >= ' . $from );
+				}
 			}
 		}
 
 		if ( !empty( $lang ) ) {
 			if ( !Language::isValidBuiltInCode( $lang ) ) {
 				// FIXME add proper error msg
-				$this->dieUsageMsg( array( 'invalidtitle', $lang ) );
+				$this->dieUsageMsg( [ 'invalidtitle', $lang ] );
 			}
 
 			$this->addWhereFld( 'city_lang', $lang );
@@ -74,40 +83,40 @@ class WikiaApiQueryDomains extends ApiQueryBase {
 			/**
 			 * query builder
 			 */
-			$this->addFields(array('count(*) as cnt'));
-			$data = array();
-			$res = $this->select(__METHOD__);
-			if ($row = $db->fetchObject($res)) {
+			$this->addFields( [ 'count(*) as cnt' ] );
+			$data = [];
+			$res = $this->select( __METHOD__ );
+			if ( $row = $db->fetchObject( $res ) ) {
 				$data['count'] = $row->cnt;
 				ApiResult :: setContent( $data, $row->cnt );
 			}
-			$db->freeResult($res);
+			$db->freeResult( $res );
 		} else {
-			$this->addFields(array('city_id', 'city_url', 'city_lang'));
-			$this->addOption( "ORDER BY ", "city_id" );
+			$this->addFields( [ 'city_id', 'city_url', 'city_lang' ] );
+			$this->addOption( 'ORDER BY ', 'city_id' );
 			$this->addOption( 'LIMIT', $this->defLimit );
 
 			#--- result builder
-			$data = array();
-			$res = $this->select(__METHOD__);
-			while ($row = $db->fetchObject($res)) {
+			$data = [];
+			$res = $this->select( __METHOD__ );
+			while ( $row = $db->fetchObject( $res ) ) {
 				$domain = $row->city_url;
-				$domain =  preg_replace('/^http:\/\//', '', $domain);
-				$domain =  preg_replace('/\/$/',        '', $domain);
-				if ($domain) {
-					$data[$row->city_id] = array(
-						"id"		=> $row->city_id,
-						"domain"	=> $domain,
-						"lang"   => $row->city_lang,
-					);
-					ApiResult :: setContent( $data[$row->city_id], $domain );
+				$domain =  preg_replace( '/^http:\/\//', '', $domain );
+				$domain =  preg_replace( '/\/$/',        '', $domain );
+				if ( $domain ) {
+					$data[ $row->city_id ] = [
+						'id'		=> $row->city_id,
+						'domain'	=> $domain,
+						'lang'		=> $row->city_lang,
+					];
+					ApiResult :: setContent( $data[ $row->city_id ], $domain );
 				}
 			}
-			$db->freeResult($res);
+			$db->freeResult( $res );
 		}
 
-		$this->getResult()->setIndexedTagName($data, 'variable');
-		$this->getResult()->addValue('query', $this->getModuleName(), $data);
+		$this->getResult()->setIndexedTagName( $data, 'variable' );
+		$this->getResult()->addValue( 'query', $this->getModuleName(), $data );
 	}
 
 	public function getVersion() {
@@ -122,53 +131,53 @@ class WikiaApiQueryDomains extends ApiQueryBase {
 	}
 
 	public function getAllowedParams() {
-		return array (
-			"wikia" => array(
+		return [
+			'wikia' => [
 				ApiBase :: PARAM_TYPE => 'integer'
-			),
-			"active" => array(
-				ApiBase :: PARAM_TYPE => "integer",
+			],
+			'active' => [
+				ApiBase :: PARAM_TYPE => 'integer',
 				ApiBase :: PARAM_MAX => 1,
 				ApiBase :: PARAM_MIN => 0,
-			),
-			"from" => array(
-				ApiBase :: PARAM_TYPE => "integer",
+			],
+			'from' => [
+				ApiBase :: PARAM_TYPE => 'integer',
 				ApiBase :: PARAM_MIN => 1,
 				ApiBase :: PARAM_DFLT => 1,
-			),
-			"to" => array(
-				ApiBase :: PARAM_TYPE => "integer",
+			],
+			'to' => [
+				ApiBase :: PARAM_TYPE => 'integer',
 				ApiBase :: PARAM_MIN => 1,
 				ApiBase :: PARAM_DFLT => $this->defLimit,
-			),
-			"countonly" => array(
-				ApiBase :: PARAM_TYPE => "integer",
+			],
+			'countonly' => [
+				ApiBase :: PARAM_TYPE => 'integer',
 				ApiBase :: PARAM_MIN => 1,
-			),
-			"lang" => null,
-		);
+			],
+			'lang' => null,
+		];
 	}
 
 	public function getParamDescription() {
-		return array (
-			"wikia" => "Identifier in Wiki Factory",
-			"active" => "Get only active domains [optional]",
-			"from" => "Begin of range - identifier in Wiki Factory",
-			"to" => "end of range - identifier in Wiki Factory",
-			"lang" => "Wiki language",
-			"countonly" => "return only number of Wikis"
-		);
+		return [
+			'wikia' => 'Identifier in Wiki Factory',
+			'active' => 'Get only active domains [optional]',
+			'from' => 'Begin of range - identifier in Wiki Factory',
+			'to' => 'end of range - identifier in Wiki Factory',
+			'lang' => 'Wiki language',
+			'countonly' => 'return only number of Wikis'
+		];
 	}
 
 	public function getExamples() {
-		return array (
-			"api.php?action=query&list=wkdomains",
-			"api.php?action=query&list=wkdomains&wkactive=1",
-			"api.php?action=query&list=wkdomains&wkwikia=177",
-			"api.php?action=query&list=wkdomains&wkfrom=100&wkto=150",
-			"api.php?action=query&list=wkdomains&wkfrom=10000&wkto=15000&wklang=de",
-			"api.php?action=query&list=wkdomains&wkcountonly=1",
-			"api.php?action=query&list=wkdomains&wkactive=1&wkcountonly=1",
-		);
+		return [
+			'api.php?action=query&list=wkdomains',
+			'api.php?action=query&list=wkdomains&wkactive=1',
+			'api.php?action=query&list=wkdomains&wkwikia=177',
+			'api.php?action=query&list=wkdomains&wkfrom=100&wkto=150',
+			'api.php?action=query&list=wkdomains&wkfrom=10000&wkto=15000&wklang=de',
+			'api.php?action=query&list=wkdomains&wkcountonly=1',
+			'api.php?action=query&list=wkdomains&wkactive=1&wkcountonly=1',
+		];
 	}
 };

--- a/extensions/wikia/WikiaApi/WikiaApiQueryDomains.php
+++ b/extensions/wikia/WikiaApi/WikiaApiQueryDomains.php
@@ -85,6 +85,7 @@ class WikiaApiQueryDomains extends ApiQueryBase {
 		} else {
 			$this->addFields(array('city_id', 'city_url', 'city_lang'));
 			$this->addOption( "ORDER BY ", "city_id" );
+			$this->addOption( 'LIMIT', $this->defLimit );
 
 			#--- result builder
 			$data = array();
@@ -114,7 +115,10 @@ class WikiaApiQueryDomains extends ApiQueryBase {
 	}
 
 	public function getDescription() {
-		return "Get domains handled by Wikia";
+		return [
+			'Get domains handled by Fandom',
+			"This API returns a maximum of {$this->defLimit} results"
+		];
 	}
 
 	public function getAllowedParams() {


### PR DESCRIPTION
API for returning wiki domains can theoretically return an infinite amount of wiki domains (actually, it can return max. 8MiB of data) which could lead to possible API abuse. This pull request should fix that.
Also done some formatting on the file.

Support ticket: [#317255](https://support.wikia-inc.com/hc/en-us/requests/317255)
Bug ticket: [SUS-1508](https://wikia-inc.atlassian.net/browse/SUS-1508)
Examples: [500.000 wikis](http://c.wikia.com/api.php?action=query&list=wkdomains&wkfrom=1&wkto=500000&format=json), [1.000.000 wikis - API error](http://community.wikia.com/api.php?action=query&list=wkdomains&wkfrom=1&wkto=1000000&format=json)

Fixed in #12627, closing