### PR TITLE
SUS-1642 | Improve schema of wall_notification table

### DIFF
--- a/extensions/wikia/Wall/sql/wall_notification.sql
+++ b/extensions/wikia/Wall/sql/wall_notification.sql
@@ -1,21 +1,15 @@
-CREATE TABLE wall_notification (
-	id INT(11) NOT NULL AUTO_INCREMENT,
-	user_id INT(11) NOT NULL,
-	wiki_id INT(11),
-	is_read INT(11) NOT NULL,
-	is_reply INT(11) NOT NULL,
-	is_hidden INT(11) NOT NULL DEFAULT 0,
-	author_id INT(11) NOT NULL,
-	unique_id INT(11) NOT NULL,
-	entity_key  CHAR(30) NOT NULL,
-	notif_type INT(11) DEFAULT 0,
-	KEY `user` (user_id,wiki_id),
-	KEY `user_wiki_unique` (user_id,wiki_id,unique_id),
-	PRIMARY KEY (id)
+CREATE TABLE `wall_notification` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) NOT NULL,
+  `wiki_id` int(11) NOT NULL,
+  `is_read` tinyint(1) NOT NULL,
+  `is_reply` tinyint(1) NOT NULL,
+  `author_id` int(11) NOT NULL,
+  `unique_id` int(11) NOT NULL,
+  `entity_key` char(30) NOT NULL,
+  `is_hidden` tinyint(1) NOT NULL,
+  `notifyeveryone` tinyint(1) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `unique_id` (`unique_id`),
+  KEY `user_wiki_unique` (`user_id`,`wiki_id`,`unique_id`)
 ) ENGINE=InnoDB;
-
-
-// ALTER TABLE wall_notification MODIFY unique_id INT(11) NOT NULL;
-// ALTER TABLE wall_notification ADD is_hidden INT(11) NOT NULL DEFAULT 0;
-// ALTER TABLE wall_notification ADD KEY `user_wiki_unique` (user_id,wiki_id,unique_id);
-// alter table wall_notification add notifyeveryone  INT(1) NOT NULL DEFAULT 0;


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-1642

* remove redundant `user` index (as it's already covered by `user_wiki_unique`)
* change `int(11)` column what have either 0 or 1 as a value to `tinyint`

Performed the table cleanup, removed 61 out of 67 mm of rows. Its size dropped from 14 to 0,7 GB (**95% size reduction**).

The production database has been altered.