### PR TITLE
SUS-1648 | Category pages are displaying broken in some wikis - CSS missing

### DIFF
--- a/extensions/wikia/CategoryExhibition/css/CategoryExhibition.scss
+++ b/extensions/wikia/CategoryExhibition/css/CategoryExhibition.scss
@@ -1,7 +1,6 @@
 @import "skins/shared/mixins/box-shadow";
 @import "skins/shared/mixins/clearfix";
 @import "skins/shared/color";
-@import "extensions/wikia/TopLists/css/mixins";
 
 $color: #000; // was removed from /skins/shared/mixins/box-shadow
 
@@ -22,10 +21,6 @@ $color-inctive-button: mix($color-page, #000, 60%);
 
 @if lightness($color-page) < 80 {
 	$color: lighten($color, 20%);
-}
-
-#toplists-loading-screen {
-	@include blockInput;
 }
 
 .category-gallery-form {


### PR DESCRIPTION
As `toplists-loading-screen` ID is no longer used in the code, we can simply remove mixin import and ID styling.