### PR TITLE
(MAIN-9750) Handle email changes when confirming an email

### DIFF
--- a/extensions/wikia/UserLogin/EmailConfirmationController.class.php
+++ b/extensions/wikia/UserLogin/EmailConfirmationController.class.php
@@ -36,8 +36,12 @@ class EmailConfirmationController extends WikiaController {
 	 * @param $user
 	 */
 	private function confirmEmail( User $user ) {
+		$optionNewEmail = $user->getNewEmail();
+		if ( !empty( $optionNewEmail ) ) {
+			$user->setEmail( $optionNewEmail );
+		}
 		$user->confirmEmail();
+		$user->clearNewEmail();
 		$user->saveSettings();
-		wfRunHooks( 'ConfirmEmailComplete', [ &$user ] );
 	}
 }


### PR DESCRIPTION
When changing an email, we also need to set the new email as the main
email when confirming the address.

Also, remove the duplicate ConfirmEmailComplete hook as it is called
within User::confirmEmail.