### PR TITLE
MAIN-9729 add protocol to discussions internal URL

### DIFF
--- a/extensions/wikia/Recirculation/services/DiscussionsDataService.class.php
+++ b/extensions/wikia/Recirculation/services/DiscussionsDataService.class.php
@@ -83,7 +83,7 @@ class DiscussionsDataService {
 		$endpoint = $this->cityId . '/threads';
 
 		$url = $this->buildUrl( $endpoint, $options );
-		$data = Http::get( $url );
+		$data = Http::get( $url, 'default', [ 'noProxy' => true ] );
 
 		return json_decode( $data, true );
 	}
@@ -108,7 +108,7 @@ class DiscussionsDataService {
 	private function getDiscussionsApiUrl() {
 		global $wgConsulServiceTag, $wgConsulUrl;
 
-		return ( new ConsulUrlProvider( $wgConsulUrl,
+		return "http://" . ( new ConsulUrlProvider( $wgConsulUrl,
 			$wgConsulServiceTag ) )->getUrl( 'discussion' );
 	}
 


### PR DESCRIPTION
Ticket: https://wikia-inc.atlassian.net/browse/MAIN-9729

This PR fixes a bug that was leading to the Discussion Recirculation module not being rendered on wikis where it's enabled.

The issue stemmed from us changing the way we were generating the URL to get content. Beforehand, we were using an external URL (eg, "http://services.wikia.com/discussion"). As part of SOC-3874, we updated to using the Consul library to get an internal address (eg, "10.1.0.2:3153"). The problem is that the Consul library doesn't prepend the protocol, it just gives us the IP and port leading to URLs like this , "10.1.0.2:3153", which were failing when we tried to make the request.

The fix is to prepend the host and port we get from the Consul library with the protocol ("http://").