### PR TITLE
FAN-1646 Be able to distinguish /wp-content/ requests coming from Recirculation

### DIFF
--- a/extensions/wikia/Recirculation/templates/client/impactFooter.mustache
+++ b/extensions/wikia/Recirculation/templates/client/impactFooter.mustache
@@ -16,7 +16,7 @@
           {{/presented_by}}
           <div class="thumbnail placeholder-thumbnail">
             {{#thumbnail}}
-              <img src="{{thumbnail}}" alt="{{title}}">
+              <img src="{{thumbnail}}?from=recirc-footer" alt="{{title}}">
             {{/thumbnail}}
           </div>
           <div class="recirc-footer-title-container">

--- a/extensions/wikia/Recirculation/templates/client/rail.mustache
+++ b/extensions/wikia/Recirculation/templates/client/rail.mustache
@@ -17,7 +17,7 @@
           {{/presented_by}}
           <div class="image image-thumbnail placeholder-thumbnail fluid small">
             {{#thumbnail}}
-              <img src="{{thumbnail}}" alt="{{title}}" itemprop="thumbnail">
+              <img src="{{thumbnail}}?from=recirc-rail" alt="{{title}}" itemprop="thumbnail">
             {{/thumbnail}}
           </div>
           <div class="title" title="{{title}}">{{title}}</div>


### PR DESCRIPTION
We're in the middle of moving all WordPress images to Vignette. All articles now have updated image URLs, but the rate at which images are requested from WordPress dropped by only about 10%.

To confirm the hypothesis most of the remaining images are coming from Recirculation module, I want to add a query param to the requested URL so that we can filter them in Kibana.

(I tested this on sandbox-s1)