### PR TITLE
SUS-723 | Comments_index table cleanup

### DIFF
--- a/extensions/wikia/Wall/maintenance/CleanupCommentsIndex.php
+++ b/extensions/wikia/Wall/maintenance/CleanupCommentsIndex.php
@@ -3,8 +3,15 @@ require_once( __DIR__ . '/../../../../maintenance/Maintenance.php' );
 
 class CleanupCommentsIndex extends Maintenance {
 
+	public function __construct() {
+		parent::__construct();
+
+		$this->addOption( 'dry-run', 'only checks how many rows is affected' );
+	}
 
 	public function execute() {
+		global $wgDBname;
+
 		$db = wfGetDB( DB_MASTER );
 
 		$ids = $db->selectFieldValues(
@@ -20,11 +27,13 @@ class CleanupCommentsIndex extends Maintenance {
 			}, $ids);
 
 			\Wikia\Logger\WikiaLogger::instance()->info(
-				"CleanupCommentsIndex: " . count( $ids ) . " rows affected",
+				"{$wgDBname}: " . count( $ids ) . " rows affected",
 				[ "rows_count" => count( $ids ) ]
 			);
 
-			$db->delete( 'comments_index',  "comment_id in (" . implode( ',', $ids ) . ")");
+			if ( !$this->hasOption('dry-run') ) {
+				$db->delete( 'comments_index', "comment_id in (" . implode( ',', $ids ) . ")" );
+			}
 		}
 	}
 }

--- a/extensions/wikia/Wall/maintenance/CleanupCommentsIndex.php
+++ b/extensions/wikia/Wall/maintenance/CleanupCommentsIndex.php
@@ -33,8 +33,11 @@ class CleanupCommentsIndex extends Maintenance {
 
 			$this->output( "{$wgDBname}: " . count( $ids ) . " rows affected\n" );
 
-			if ( !$this->hasOption('dry-run') ) {
-				$db->delete( 'comments_index', "comment_id in (" . implode( ',', $ids ) . ")" );
+			if ( !$this->hasOption('dry-run') && !empty( $ids ) ) {
+				$db->delete(
+					'comments_index',
+					[ "comment_id" => $ids ]
+				);
 			}
 		}
 	}

--- a/extensions/wikia/Wall/maintenance/CleanupCommentsIndex.php
+++ b/extensions/wikia/Wall/maintenance/CleanupCommentsIndex.php
@@ -17,7 +17,7 @@ class CleanupCommentsIndex extends Maintenance {
 		$ids = $db->selectFieldValues(
 			[ 'page', 'comments_index' ],
 			'comment_id',
-			[ 'page_id=comment_id', 'page_namespace not in (1,500,501,1200,1201,2000,2001)' ],
+			[ 'page_id=comment_id', 'page_namespace not in (500,501,1200,1201,2000,2001)' ],
 			__METHOD__
 		);
 

--- a/extensions/wikia/Wall/maintenance/CleanupCommentsIndex.php
+++ b/extensions/wikia/Wall/maintenance/CleanupCommentsIndex.php
@@ -31,6 +31,8 @@ class CleanupCommentsIndex extends Maintenance {
 				[ "rows_count" => count( $ids ) ]
 			);
 
+			$this->output( "{$wgDBname}: " . count( $ids ) . " rows affected\n" );
+
 			if ( !$this->hasOption('dry-run') ) {
 				$db->delete( 'comments_index', "comment_id in (" . implode( ',', $ids ) . ")" );
 			}

--- a/extensions/wikia/Wall/maintenance/CleanupCommentsIndex.php
+++ b/extensions/wikia/Wall/maintenance/CleanupCommentsIndex.php
@@ -5,8 +5,6 @@ class CleanupCommentsIndex extends Maintenance {
 
 
 	public function execute() {
-		global $wgDBName;
-
 		$db = wfGetDB( DB_MASTER );
 
 		$ids = $db->selectFieldValues(
@@ -22,8 +20,8 @@ class CleanupCommentsIndex extends Maintenance {
 			}, $ids);
 
 			\Wikia\Logger\WikiaLogger::instance()->info(
-				$wgDBName . ":" . count( $ids ) . "rows affected",
-				[ "rows_count" => count( $ids ),  "dbname" => $wgDBName ]
+				"CleanupCommentsIndex: " . count( $ids ) . " rows affected",
+				[ "rows_count" => count( $ids ) ]
 			);
 
 			$db->delete( 'comments_index',  "comment_id in (" . implode( ',', $ids ) . ")");

--- a/extensions/wikia/Wall/maintenance/CleanupCommentsIndex.php
+++ b/extensions/wikia/Wall/maintenance/CleanupCommentsIndex.php
@@ -1,0 +1,26 @@
+<?php
+require_once( getenv( 'MW_INSTALL_PATH' ) !== false ? getenv( 'MW_INSTALL_PATH' ) . '/maintenance/Maintenance.php' : dirname( __FILE__ ) . '/../../../../maintenance/Maintenance.php' );
+
+class CleanupCommentsIndex extends Maintenance {
+
+
+	public function execute() {
+		$getIdsQuery = "select page_id from page, comments_index where page_id=comment_id and page_namespace not in (1,500,501,1200,1201,2000,2001)";
+
+		$db = wfGetDB( DB_MASTER );
+
+		$ids = [];
+
+		$result = $db->query( $getIdsQuery );
+		while ( $row = $db->fetchRow( $result ) ) {
+			$ids[] = intval( $row['page_id'] );
+		};
+
+		$deleteQuery = "DELETE FROM comments_index WHERE comment_id in (" . implode( ',', $ids ) . ")";
+
+		$db->query( $deleteQuery );
+	}
+}
+
+$maintClass = 'CleanupCommentsIndex';
+require_once( RUN_MAINTENANCE_IF_MAIN );


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-1683
https://wikia-inc.atlassian.net/browse/SUS-723

maintenance script for removing broken entries (those which comment_id corresponds to a page with namespace not related to forum/wall) from comments_index table