### PR TITLE
FAN-1665 Resize Fandom images in recirculation modules

### DIFF
--- a/extensions/wikia/Recirculation/js/helpers/LiftigniterHelper.js
+++ b/extensions/wikia/Recirculation/js/helpers/LiftigniterHelper.js
@@ -58,10 +58,12 @@ define('ext.wikia.recirculation.helpers.liftigniter', [
 					item.meta = options.widget;
 					item.index = index;
 
-                    if (item.source === 'wiki') {
-                        item.isWiki = true;
-                        item.thumbnail = thumbnailer.getThumbURL(item.thumbnail, 'image', options.width, options.height);
-                    }
+					if (item.source === 'wiki') {
+						item.isWiki = true;
+					}
+					if (thumbnailer.isThumbUrl(item.thumbnail)) {
+						item.thumbnail = thumbnailer.getThumbURL(item.thumbnail, 'image', options.width, options.height);
+					}
 
 					items.push(item);
 				}

--- a/extensions/wikia/Recirculation/styles/impact-footer.scss
+++ b/extensions/wikia/Recirculation/styles/impact-footer.scss
@@ -25,7 +25,7 @@ $recirculation-impact-footer-color-feature-overlay: rgba(0, 0, 0, .75);
 	img {
 		background: $color-page;
 		display: block;
-		max-width: 100%;
+		width: 100%;
 	}
 
 	.items {

--- a/resources/wikia/modules/thumbnailer.js
+++ b/resources/wikia/modules/thumbnailer.js
@@ -17,7 +17,9 @@
 		var extRegExp = /\.(jpg|jpeg|gif|bmp|png|svg)$/i,
 			imagePath = '/images/',
 			legacyThumbnailerPath = '/images/thumb/',
-			thumbnailerBaseURLRegex = /(.*\/revision\/\w+).*/;
+			// [0-9a-f-]{36} is to match UUIDs like in
+			// https://vignette.wikia.nocookie.net/ff8b7617-46fa-4efb-ac2f-ff98edf04bcf
+			thumbnailerBaseURLRegex = new RegExp('(.*/revision/\\w+|.*/[0-9a-f-]{36}).*');
 
 		/**
 		 * Converts the URL of a full size image or of a thumbnail into one of a thumbnail of


### PR DESCRIPTION
Ported from https://github.com/Wikia/app/pull/12436

Now that the Fandom images are served by Vignette we can request resized version of them instead of requesting super huge images and rescaling in the client (like it used to be).

To do so I needed to update `isThumbUrl` function to recognize the UUID Vignette URLs.

Also we don't need the `?from=recirc` URL params added to the images requested from the recirculation module so I'm removing them now.