### PR TITLE
MAIN-9790: remove deleted ImageLazyLoad tests from karma config

### DIFF
--- a/tests/karma/js-unit.conf.js
+++ b/tests/karma/js-unit.conf.js
@@ -171,12 +171,6 @@ module.exports = function (config) {
 			'extensions/3rdparty/LyricWiki/LyricFind/js/modules/LyricFind.Tracker.js',
 			'extensions/3rdparty/LyricWiki/LyricFind/js/spec/*.spec.js',
 
-			// ImageLazyLoad
-			'resources/wikia/libraries/jquery/throttle-debounce/jquery.throttle-debounce.js', // $.throttle
-			'extensions/wikia/ImageLazyLoad/js/ImgLzy.module.js',
-			'extensions/wikia/ImageLazyLoad/js/ImageLazyLoad.js',
-			'extensions/wikia/ImageLazyLoad/spec/*.spec.js',
-
 			// Thumbnails
 			'extensions/wikia/Thumbnails/scripts/templates.mustache.js',
 			'extensions/wikia/Thumbnails/scripts/views/titleThumbnail.js',


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/MAIN-9790