### PR TITLE
Pass archived page id to ArticleUndelete hook.

### DIFF
--- a/includes/specials/SpecialUndelete.php
+++ b/includes/specials/SpecialUndelete.php
@@ -516,6 +516,7 @@ class PageArchive {
 
 		$ret->seek( $rev_count - 1 ); // move to last
 		$row = $ret->fetchObject(); // get newest archived rev
+		$oldPageId = (int)$row->ar_page_id; // pass this to ArticleUndelete hook
 		$ret->seek( 0 ); // move back
 
 		if( $makepage ) {
@@ -621,7 +622,7 @@ class PageArchive {
 			$article->doEditUpdates( $revision, $user, array( 'created' => $created, 'oldcountable' => $oldcountable ) );
 		}
 
-		wfRunHooks( 'ArticleUndelete', array( &$this->title, $created, $comment ) );
+		wfRunHooks( 'ArticleUndelete', array( &$this->title, $created, $comment, $oldPageId ) );
 
 		if( $this->title->getNamespace() == NS_FILE ) {
 			// Wikia change begin @author Scott Rabin (srabin@wikia-inc.com)


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-1688

Backported https://github.com/wikimedia/mediawiki/commit/1fb9118c7cdc54cf4e4f2af727bf37f32c69319b from MW 1.24

Needed for instrumentation of PageRestoration schema

Rationale:  By the time the hook runs, there is no longer record
of the previous page id.

Change-Id: If87a73e47def7a4404858f374780c3f1cf4d69b5
See: https://meta.wikimedia.org/wiki/Schema:PageRestoration
Needed by: Id40347ec268658dc854e4ab2dd38570b19db1477