### PR TITLE
SUS-1521 | report a proper DB query caller in WallThread::getLastMessage

### DIFF
--- a/extensions/wikia/Wall/WallThread.class.php
+++ b/extensions/wikia/Wall/WallThread.class.php
@@ -191,10 +191,16 @@ class WallThread {
 		WikiaDataAccess::cachePurge( $key );
 	}
 
+	/**
+	 * TODO: used by ForumController::boardThread() method only. Move it there?
+	 *
+	 * @return null|WallMessage
+	 */
 	public function getLastMessage() {
 		$key = wfMemcKey( __CLASS__, '-thread-lastreply-key', $this->mThreadId );
+		$fname = __METHOD__;
 
-		$data = WikiaDataAccess::cache( $key, 30 * 24 * 60 * 60, function() {
+		$data = WikiaDataAccess::cache( $key, 30 * 24 * 60 * 60, function() use ( $fname ) {
 			$db = wfGetDB( DB_SLAVE );
 			$row = $db->selectRow(
 				[ 'comments_index' ],
@@ -205,7 +211,7 @@ class WallThread {
 						'deleted' => 0,
 						'removed' => 0
 				],
-				__METHOD__
+				$fname
 			);
 			return $row;
 		} );


### PR DESCRIPTION
I'll move `ForumController::boardThread` (see inline code comment) as a part of SUS-1521 refactoring. Here I just want to improve reporting of database queries.