### PR TITLE
SUS-1719 | bring back the call to ArticleComment::newFromId that adds small delay allowing slaves to catch up

### DIFF
--- a/extensions/wikia/Wall/WallMessage.class.php
+++ b/extensions/wikia/Wall/WallMessage.class.php
@@ -1511,7 +1511,7 @@ class WallMessage {
 	}
 
 	protected function getPropCacheKey() {
-		return wfMemcKey( __CLASS__, __METHOD__, $this->cityId, $this->getId(), 'v5' );
+		return wfMemcKey( __CLASS__, __METHOD__, $this->cityId, $this->getId(), 'v6' );
 	}
 
 	private function getCache() {

--- a/extensions/wikia/Wall/builders/WallMessageBuilder.class.php
+++ b/extensions/wikia/Wall/builders/WallMessageBuilder.class.php
@@ -99,7 +99,12 @@ class WallMessageBuilder extends WallBuilder {
 
 		/** @var Article $article */
 		list( $status, $article ) = $result;
-		$this->newMessage = WallMessage::newFromTitle( $article->getTitle() );
+
+		// SUS-1719: this call has a nice side-effect, it first queries DB_SLAVE and then - as a fallback - DB_MASTER
+		// TODO: consider improving handling of slave lag (wfWaitForSlaves / update the cache instead of invalidating it)
+		$ac = ArticleComment::newFromId( $article->getID() );
+
+		$this->newMessage = new WallMessage( $ac->getTitle(), $ac );
 
 		return $this;
 	}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-1719

Yes, it is an ugly hack (backport of code removed as a part of #12424) and we first want to check whether it solves the issue on sandbox.

**TODO**: consider improving handling of slave lag - `wfWaitForSlaves` / update the cache instead of invalidating it...