### PR TITLE
PLATFORM-2911: Use format=webp when looking for webp thumbnails

### DIFF
--- a/maintenance/wikia/purgeWebPThumbs.php
+++ b/maintenance/wikia/purgeWebPThumbs.php
@@ -21,7 +21,7 @@ class PurgeWebPThumbs extends Maintenance {
 	const LIST_LIMIT = 1000;
 
 	const THUMB_SUFFIX = '.webp';
-	#const THUMB_SUFFIX = '.png';
+	const FORMAT_WEBP_MARKER = '[format=webp]';
 
 	// remove thumbnails generated during given period
 	const TIMESTAMP_FROM = '2014-06-09 09:00:00';
@@ -105,7 +105,7 @@ class PurgeWebPThumbs extends Maintenance {
 			foreach($thumbs as $thumb) {
 				$name = $thumb->name;
 
-				if (endsWith($name, self::THUMB_SUFFIX)) {
+				if (endsWith($name, self::THUMB_SUFFIX) || (FALSE !== strpos($name, self::FORMAT_WEBP_MARKER))) {
 					$name = substr($name, strlen($this->storage->getPathPrefix())); // remove path prefix from thumb path
 
 					// check the timestamp


### PR DESCRIPTION
This is how Vignette stores the webp thumbnails created from jpg/png:

```
vignette.util.thumbnail - Calling thumbnailer args=["/Users/mech/Projects/vignette/bin/thumbnail" "--in" "/tmp/vignette/d0b1a493-83c4-40e0-a1b5-3ba10b30c609.jpg" "--out" "webp:/tmp/vignette/muppet_thumb_aec71452-cdd2-4413-9e01-9559eae134a5" "--width" "131" "--mode" "scale-to-width-down" "--height" ":auto"]
vignette.storage.s3 - s3 putobject bucket=muppet, path=images/thumb/f/fe/804581_6f3.jpg/131px-autopx-scale-to-width-down[format=webp]-804581_6f3.jpg
```