### PR TITLE
XW-2866  | Make sure when we json_encode we serialize parts to array not an object

### DIFF
--- a/extensions/wikia/MercuryApi/MercuryApiController.class.php
+++ b/extensions/wikia/MercuryApi/MercuryApiController.class.php
@@ -180,7 +180,7 @@ class MercuryApiController extends WikiaController {
 		$htmlTitle = new WikiaHtmlTitle();
 		$wikiVariables['htmlTitle'] = [
 			'separator' => $htmlTitle->getSeparator(),
-			'parts' => $htmlTitle->getAllParts(),
+			'parts' => array_values( $htmlTitle->getAllParts() ),
 		];
 
 		return $wikiVariables;

--- a/includes/wikia/WikiaHtmlTitle.class.php
+++ b/includes/wikia/WikiaHtmlTitle.class.php
@@ -68,9 +68,11 @@ class WikiaHtmlTitle {
 			if ( $part instanceof Message ) {
 				return $part->inContentLanguage()->text();
 			}
+
 			if ( is_string( $part ) ) {
 				return $part;
 			}
+
 			return null;
 		}, $parts );
 


### PR DESCRIPTION
As when we have an array like this
[1 => 'a part']
this gets serialized to an object not an array

This can happen for example on corporate pages