### PR TITLE
SUS-1507: Use "A Fandom User" as image alt text for anon avatars

### DIFF
--- a/includes/wikia/services/AvatarService.class.php
+++ b/includes/wikia/services/AvatarService.class.php
@@ -181,7 +181,7 @@ class AvatarService extends Service {
 			'width' => $avatarSize,
 			'height' => $avatarSize,
 			'class' => 'avatar',
-			'alt' => IP::isIPAddress( $userName ) ? wfMessage( 'oasis-anon-user' )->inContentLanguage()->text() : $userName,
+			'alt' => IP::isIPAddress( $userName ) ? wfMessage( 'oasis-anon-user' )->text() : $userName,
 		) );
 
 		wfProfileOut( __METHOD__ );

--- a/includes/wikia/services/AvatarService.class.php
+++ b/includes/wikia/services/AvatarService.class.php
@@ -157,6 +157,9 @@ class AvatarService extends Service {
 
 	/**
 	 * Render avatar
+	 * @param string $userName
+	 * @param int $avatarSize
+	 * @return string rendered avatar <img /> tag
 	 */
 	static function renderAvatar( $userName, $avatarSize = 20 ) {
 		wfProfileIn( __METHOD__ );
@@ -178,7 +181,7 @@ class AvatarService extends Service {
 			'width' => $avatarSize,
 			'height' => $avatarSize,
 			'class' => 'avatar',
-			'alt' => $userName,
+			'alt' => IP::isIPAddress( $userName ) ? wfMessage( 'oasis-anon-user' )->inContentLanguage()->text() : $userName,
 		) );
 
 		wfProfileOut( __METHOD__ );

--- a/includes/wikia/services/tests/AvatarServiceTest.php
+++ b/includes/wikia/services/tests/AvatarServiceTest.php
@@ -160,6 +160,35 @@ class AvatarServiceTest extends WikiaBaseTest {
 	}
 
 	/**
+	 * SUS-1507: Verify that default avatar for anon users has "A Fandom User" message as alt text
+	 */
+	public function testAltTextForAnonAvatarsUsesMediaWikiMessage() {
+		$messageMock = $this->getMockBuilder( Message::class )
+			->setMethods( [ 'text' ] )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$messageMock->expects( $this->once() )
+			->method( 'text' )
+			->willReturn( 'A Fandom User' );
+
+		$this->getGlobalFunctionMock( 'wfMessage' )
+			->expects( $this->once() )
+			->method( 'wfMessage' )
+			->with( 'oasis-anon-user' )
+			->willReturn( $messageMock );
+
+		$this->mockGlobalFunction( 'getMessageForContentAsArray', [] );
+
+		$avatarTag = AvatarService::renderAvatar( '8.8.8.8', 20 );
+
+		$this->assertEquals(
+			'<img src="' . AvatarService::getDefaultAvatar( 20 ) . '" width="20" height="20" class="avatar" alt="A Fandom User" />',
+			$avatarTag
+		);
+	}
+
+	/**
 	 * @dataProvider getVignetteUrlDataProvider
 	 */
 	function testGetVignetteUrl( $userAttr, $width, $expectedUrl ) {


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-1507