### PR TITLE
IRIS-4048 | old notifications (wall messages) will now use the note icon

### DIFF
--- a/extensions/wikia/DesignSystem/services/templates/DesignSystemGlobalNavigationWallNotifications_index.php
+++ b/extensions/wikia/DesignSystem/services/templates/DesignSystemGlobalNavigationWallNotifications_index.php
@@ -4,7 +4,7 @@
 			<div class="wds-global-navigation__notifications-menu-counter notifications-count"></div>
 		</div>
 		<?= DesignSystemHelper::renderSvg(
-			'wds-icons-bell',
+			'wds-icons-note',
 			'wds-icon wds-icon-small',
 			wfMessage( 'global-navigation-notifications-title' )->escaped()
 		) ?>

--- a/includes/wikia/models/DesignSystemGlobalNavigationModel.class.php
+++ b/includes/wikia/models/DesignSystemGlobalNavigationModel.class.php
@@ -323,10 +323,10 @@ class DesignSystemGlobalNavigationModel extends WikiaModel {
 			'header' => [
 				'type' => 'line-image',
 				// 'image' is deprecated, use 'image-data' instead
-				'image' => 'wds-icons-bell',
+				'image' => 'wds-icons-note',
 				'image-data' => [
 					'type' => 'wds-svg',
-					'name' => 'wds-icons-bell',
+					'name' => 'wds-icons-note',
 				],
 				'title' => [
 					'type' => 'translatable-text',


### PR DESCRIPTION
We'll be adding On Site Notifications widget which will be using the bell icon.
We want to replace the icon so that users get used to it and do not mix it up with new notifications when they get deployed.

https://wikia-inc.atlassian.net/browse/IRIS-4048