### PR TITLE
WallHistory: remove type hinting

### DIFF
--- a/extensions/wikia/Wall/WallHistory.class.php
+++ b/extensions/wikia/Wall/WallHistory.class.php
@@ -23,7 +23,7 @@ class WallHistory extends WikiaModel {
 	 * @param WallNotificationAdminEntity $feed
 	 * @param User $user
 	 */
-	public function add( int $type, WallNotificationAdminEntity $feed, User $user ) {
+	public function add( int $type, $feed, User $user ) {
 
 		switch( $type ) {
 			case WH_EDIT:
@@ -92,7 +92,7 @@ class WallHistory extends WikiaModel {
 	 * @param WallNotificationEntity $feed
 	 * @param User $user
 	 */
-	private function addNewOrEdit( int $action, WallNotificationAdminEntity $feed, User $user ) {
+	private function addNewOrEdit( int $action, $feed, User $user ) {
 
 		$data = $feed->data;
 
@@ -115,7 +115,7 @@ class WallHistory extends WikiaModel {
 	 * @param int $action
 	 * @param WallNotificationAdminEntity $feed
 	 */
-	private function addStatChangeAction( int $action, WallNotificationAdminEntity $feed ) {
+	private function addStatChangeAction( int $action, $feed ) {
 
 		$data = $feed->data;
 		$title = Title::newFromID( $data->message_id );


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-1736

```
Unexpected non-MediaWiki exception encountered, of type "TypeError"
TypeError: Argument 2 passed to WallHistory::add() must be an instance of WallNotificationAdminEntity, instance of WallNotificationEntity given, called in /usr/wikia/slot1/16503/src/extensions/wikia/Wall/WallHelper.class.php on line 492 and defined in /usr/wikia/slot1/16503/src/extensions/wikia/Wall/WallHistory.class.php:26

Stack trace:

0 /usr/wikia/slot1/16503/src/extensions/wikia/Wall/WallHelper.class.php(492): WallHistory->add(1, Object(WallNotificationEntity), Object(User))
1 /usr/wikia/slot1/16503/src/extensions/wikia/Wall/builders/WallMessageBuilder.class.php(168): WallHelper::sendNotification(Object(Revision))
2 /usr/wikia/slot1/16503/src/extensions/wikia/Wall/builders/WallMessageBuilder.class.php(250): WallMessageBuilder->notifyIfNeeded()
3 /usr/wikia/slot1/16503/src/extensions/wikia/Wall/WallExternalController.class.php(709): WallMessageBuilder->build()
4 /usr/wikia/slot1/16503/src/includes/wikia/nirvana/WikiaDispatcher.class.php(214): WallExternalController->replyToMessage(Array)
5 /usr/wikia/slot1/16503/src/includes/wikia/nirvana/WikiaApp.class.php(647): WikiaDispatcher->dispatch(Object(WikiaApp), Object(WikiaRequest))
6 /usr/wikia/slot1/16503/src/includes/wikia/nirvana/WikiaApp.class.php(663): WikiaApp->sendRequest(NULL, NULL, Array, false, NULL)
7 /usr/wikia/slot1/16503/src/wikia.php(48): WikiaApp->sendExternalRequest(NULL, NULL, NULL)
8 {main}
```