### PR TITLE
IRIS-4082 make embeddable-discussions-threads position relative

### DIFF
--- a/extensions/wikia/EmbeddableDiscussions/styles/EmbeddableDiscussions.scss
+++ b/extensions/wikia/EmbeddableDiscussions/styles/EmbeddableDiscussions.scss
@@ -250,7 +250,7 @@ $text-overlay-value: 40%;
 	.embeddable-discussions-threads {
 		clear: both;
 		padding-top: 14px;
-		position: relative;;
+		position: relative;
 	}
 
 	.embeddable-discussions-threads-columns {

--- a/extensions/wikia/EmbeddableDiscussions/styles/EmbeddableDiscussions.scss
+++ b/extensions/wikia/EmbeddableDiscussions/styles/EmbeddableDiscussions.scss
@@ -250,6 +250,7 @@ $text-overlay-value: 40%;
 	.embeddable-discussions-threads {
 		clear: both;
 		padding-top: 14px;
+		position: relative;;
 	}
 
 	.embeddable-discussions-threads-columns {


### PR DESCRIPTION
Ticket: https://wikia-inc.atlassian.net/browse/IRIS-4082

Embeddable Discussions is using our wikia.throbber library to display a modal with a loading icon when we make the async request to fetch the discussion threads. That throbber expects a parent div to have a `position: relative` property in order to calculate what space the modal should fill. Embeddable Discussions was lacking that `position: relative` which was leading to the loading modal taking up the entire article space. The fix is to add that CSS property.