### PR TITLE
SUS-1766: Special:Block should load mediawiki.special.block.js

### DIFF
--- a/includes/specials/SpecialBlock.php
+++ b/includes/specials/SpecialBlock.php
@@ -311,6 +311,8 @@ class SpecialBlock extends FormSpecialPage {
 	 * Add header elements like block log entries, etc.
 	 */
 	protected function preText(){
+		$this->getOutput()->addModules( 'mediawiki.special.block' );
+
 		$text = $this->msg( 'blockiptext' )->parse();
 
 		$otherBlockMessages = array();


### PR DESCRIPTION
Special:Block is showing checkboxes that apply only to IP blocks when
blocking usernames, and vice versa. The code to hide these checkboxes
already exists in `resources/mediawiki.special/mediawiki.special.block.js`,
but it's not being loaded.

JIRA: https://wikia-inc.atlassian.net/browse/SUS-1766
Backported from upstream https://phabricator.wikimedia.org/T37893