### PR TITLE
SUS-1768 | report exceptions in MWExceptionHandler as the first thing

### DIFF
--- a/includes/Exception.php
+++ b/includes/Exception.php
@@ -562,13 +562,14 @@ class MWExceptionHandler {
 
 		$cmdLine = MWException::isCommandLine();
 
+		# Wikia change - begin
+		# @see PLATFORM-2008 - report non-MediawWiki exceptions to ELK
+		Wikia\Logger\WikiaLogger::instance()->error( __METHOD__, [
+			'exception' => $e,
+		] );
+		# Wikia change - end
+
 		if ( $e instanceof MWException ) {
-			# Wikia change - begin
-			# report MediawWiki exceptions to ELK
-			Wikia\Logger\WikiaLogger::instance()->error( __METHOD__ . ' - MediaWiki exception encountered', [
-				'exception' => $e,
-			] );
-			# Wikia change - end
 
 			try {
 				// Try and show the exception prettily, with the normal skin infrastructure
@@ -609,13 +610,6 @@ class MWExceptionHandler {
 			} else {
 				self::escapeEchoAndDie( $message );
 			}
-
-			# Wikia change - begin
-			# @see PLATFORM-2008 - report non-MediawWiki exceptions to ELK
-			Wikia\Logger\WikiaLogger::instance()->error( __METHOD__ . ' - unexpected non-MediaWiki exception encountered', [
-				'exception' => $e,
-			] );
-			# Wikia change - end
 		}
 	}
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-1768

Let's move ELK logging of exceptions handled by `MWExceptionHandler::report` to the top of this method. Jira Reporter change will follow to improve normalization of such exceptions so that we can report all of them properly grouped.

@TK-999 