### PR TITLE
MAIN-9965 bump WallThread cache version (release)

### DIFF
--- a/extensions/wikia/Wall/WallThread.class.php
+++ b/extensions/wikia/Wall/WallThread.class.php
@@ -129,7 +129,7 @@ class WallThread {
 	}
 
 	private function getThreadKey() {
-		return  wfMemcKey( __CLASS__, '-thread-key-v17-', $this->mThreadId );
+		return  wfMemcKey( __CLASS__, '-thread-key-v18-', $this->mThreadId );
 	}
 
 	private function getCache() {


### PR DESCRIPTION
Force invalidate cached instances of WallMessage which try to call nonexistent methods.

see #12554 