### PR TITLE
XW-2944 | import scss fix, file renamed

### DIFF
--- a/skins/oasis/css/core/ads.scss
+++ b/skins/oasis/css/core/ads.scss
@@ -11,7 +11,7 @@
 @import 'ads-in-content';
 @import 'ads-interstitial';
 @import 'ads-invisible-high-impact';
-@import '../../../../extensions/wikia/ArticleVideo/styles/article-video';
+@import '../../../../extensions/wikia/ArticleVideo/styles/article-featured-video';
 @import '../../../../extensions/wikia/WikiaBar/css/WikiaBar';
 
 $wikia-top-ads-index: 2;


### PR DESCRIPTION
We renamed `article-video.scss` to `article-featured-video.scss`. Merging XW-2836 broke that import.

https://wikia-inc.atlassian.net/browse/XW-2944

@weronika  @jsutterfield @Wikia/adeng 