### PR TITLE
PLATFORM-2351: Make Special:Wanted* not register redlinks on JS/CSS/Lua pages

### DIFF
--- a/includes/parser/Parser.php
+++ b/includes/parser/Parser.php
@@ -5443,7 +5443,7 @@ class Parser {
 		$shouldAddTrackingCategory = true;
 		wfRunHooks( 'ParserShouldAddTrackingCategory', array( $this, $title, $file, &$shouldAddTrackingCategory ) );
 
-		if ( !$file && $shouldAddTrackingCategory ) {
+		if ( !$file && $this->mTitle->isWikitextPage() && $shouldAddTrackingCategory ) {
 		# wikia end
 
 			$this->addTrackingCategory( 'broken-file-category' );

--- a/includes/specials/SpecialWantedcategories.php
+++ b/includes/specials/SpecialWantedcategories.php
@@ -35,17 +35,30 @@ class WantedCategoriesPage extends WantedQueryPage {
 	}
 
 	function getQueryInfo() {
-		return array (
-			'tables' => array ( 'categorylinks', 'page' ),
-			'fields' => array ( "'" . NS_CATEGORY . "' AS namespace",
-					'cl_to AS title',
-					'COUNT(*) AS value' ),
-			'conds' => array ( 'page_title IS NULL' ),
-			'options' => array ( 'GROUP BY' => 'cl_to' ),
-			'join_conds' => array ( 'page' => array ( 'LEFT JOIN',
-				array ( 'page_title = cl_to',
-					'page_namespace' => NS_CATEGORY ) ) )
-		);
+		return [
+			'tables' => [
+				'categorylinks',
+				'pg1' => 'page',
+				'pg2' => 'page'
+			],
+			'fields' => [
+				'namespace' => NS_CATEGORY,
+				'title' => 'cl_to',
+				'value' => 'COUNT(*)'
+			],
+			'conds' => [
+				'pg1.page_title IS NULL',
+				"NOT (RIGHT(pg2.page_title, 3) = '.js' OR RIGHT(pg2.page_title, 4) = '.css' OR pg2.page_namespace = '" . NS_MODULE . "')"
+			],
+			'options' => [ 'GROUP BY' => 'cl_to' ],
+			'join_conds' => [
+				'pg1' => [ 'LEFT JOIN', [
+					'pg1.page_title = cl_to',
+					'pg1.page_namespace' => NS_CATEGORY
+				] ],
+				'pg2' => [ 'LEFT JOIN', 'pg2.page_id = cl_from' ]
+			]
+		];
 	}
 
 	/**

--- a/includes/specials/SpecialWantedfiles.php
+++ b/includes/specials/SpecialWantedfiles.php
@@ -72,19 +72,34 @@ class WantedFilesPage extends WantedQueryPage {
 	}
 
 	function getQueryInfo() {
-		$queryInfo = array (
-			'tables' => array ( 'imagelinks', 'image' ),
-			'fields' => array ( "'" . NS_FILE . "' AS namespace",
-					'il_to AS title',
-					'COUNT(*) AS value' ),
-			'conds' => array ( 'img_name IS NULL' ),
-			'options' => array ( 'GROUP BY' => 'il_to' ),
-			'join_conds' => array ( 'image' =>
-				array ( 'LEFT JOIN',
-					array ( 'il_to = img_name' )
-				)
-			)
-		);
+		$queryInfo = [
+            'tables' => [
+                'imagelinks',
+                'pg1' => 'page',
+                'pg2' => 'page',
+                'image'
+            ],
+            'fields' => [
+                'namespace' => NS_FILE,
+                'title' => 'il_to',
+                'value' => 'COUNT(*)'
+            ],
+            'conds' => [
+                'img_name' => null,
+				"NOT (RIGHT(pg2.page_title, 3) = '.js' OR RIGHT(pg2.page_title, 4) = '.css' OR pg2.page_namespace = '" . NS_MODULE . "')"
+            ],
+            'options' => [ 'GROUP BY' => 'il_to' ],
+            'join_conds' => [
+                'image' => [ 'LEFT JOIN',
+                    'il_to = img_name'
+                ],
+                'pg1' => [ 'LEFT JOIN', [
+                    'il_to = pg1.page_title',
+                    'pg1.page_namespace' => NS_FILE,
+                ] ],
+                'pg2' => [ 'LEFT JOIN', 'pg2.page_id = il_from' ]
+			]
+		];
 		
 		wfRunHooks( 'WantedFiles::getQueryInfo', array( &$queryInfo ) ); 
 		

--- a/includes/specials/SpecialWantedfiles.php
+++ b/includes/specials/SpecialWantedfiles.php
@@ -73,31 +73,31 @@ class WantedFilesPage extends WantedQueryPage {
 
 	function getQueryInfo() {
 		$queryInfo = [
-            'tables' => [
-                'imagelinks',
-                'pg1' => 'page',
-                'pg2' => 'page',
-                'image'
-            ],
-            'fields' => [
-                'namespace' => NS_FILE,
-                'title' => 'il_to',
-                'value' => 'COUNT(*)'
-            ],
-            'conds' => [
-                'img_name' => null,
+			'tables' => [
+				'imagelinks',
+				'pg1' => 'page',
+				'pg2' => 'page',
+				'image'
+			],
+			'fields' => [
+				'namespace' => NS_FILE,
+				'title' => 'il_to',
+				'value' => 'COUNT(*)'
+			],
+			'conds' => [
+				'img_name' => null,
 				"NOT (RIGHT(pg2.page_title, 3) = '.js' OR RIGHT(pg2.page_title, 4) = '.css' OR pg2.page_namespace = '" . NS_MODULE . "')"
-            ],
-            'options' => [ 'GROUP BY' => 'il_to' ],
-            'join_conds' => [
-                'image' => [ 'LEFT JOIN',
-                    'il_to = img_name'
-                ],
-                'pg1' => [ 'LEFT JOIN', [
-                    'il_to = pg1.page_title',
-                    'pg1.page_namespace' => NS_FILE,
-                ] ],
-                'pg2' => [ 'LEFT JOIN', 'pg2.page_id = il_from' ]
+			],
+			'options' => [ 'GROUP BY' => 'il_to' ],
+			'join_conds' => [
+				'image' => [ 'LEFT JOIN',
+					'il_to = img_name'
+				],
+				'pg1' => [ 'LEFT JOIN', [
+					'il_to = pg1.page_title',
+					'pg1.page_namespace' => NS_FILE,
+				] ],
+				'pg2' => [ 'LEFT JOIN', 'pg2.page_id = il_from' ]
 			]
 		];
 		

--- a/includes/specials/SpecialWantedpages.php
+++ b/includes/specials/SpecialWantedpages.php
@@ -53,37 +53,40 @@ class WantedPagesPage extends WantedQueryPage {
 	function getQueryInfo() {
 		global $wgWantedPagesThreshold;
 		$count = $wgWantedPagesThreshold - 1;
-		$query = array(
-			'tables' => array(
+		$query = [
+			'tables' => [
 				'pagelinks',
 				'pg1' => 'page',
 				'pg2' => 'page'
-			),
-			'fields' => array(
-				'pl_namespace AS namespace',
-				'pl_title AS title',
-				'COUNT(*) AS value'
-			),
-			'conds' => array(
+			],
+			'fields' => [
+				'namespace' => 'pl_namespace',
+				'title' => 'pl_title',
+				'value' => 'COUNT(*)'
+			],
+			'conds' => [
 				'pg1.page_namespace IS NULL',
-				"pl_namespace NOT IN ( '" . NS_USER .
-					"', '" . NS_USER_TALK . "' )",
-				"pg2.page_namespace != '" . NS_MEDIAWIKI . "'"
-			),
-			'options' => array(
-				'HAVING' => "COUNT(*) > $count",
-				'GROUP BY' => 'pl_namespace, pl_title'
-			),
-			'join_conds' => array(
-				'pg1' => array(
-					'LEFT JOIN', array(
+				"pl_namespace NOT IN ( '" . NS_USER . "', '" . NS_USER_TALK . "' )",
+				"pg2.page_namespace != '" . NS_MEDIAWIKI . "'",
+				"NOT (RIGHT(pg2.page_title, 3) = '.js' OR RIGHT(pg2.page_title, 4) = '.css' OR pg2.page_namespace = '" . NS_MODULE . "')"
+			],
+			'options' => [
+				'HAVING' => [
+					"COUNT(*) > $count",
+					"COUNT(*) > SUM(pg2.page_is_redirect)"
+				],
+				'GROUP BY' => [ 'pl_namespace', 'pl_title' ]
+			],
+			'join_conds' => [
+				'pg1' => [
+					'LEFT JOIN', [
 						'pg1.page_namespace = pl_namespace',
 						'pg1.page_title = pl_title'
-					)
-				),
-				'pg2' => array( 'LEFT JOIN', 'pg2.page_id = pl_from' )
-			)
-		);
+					]
+				],
+				'pg2' => [ 'LEFT JOIN', 'pg2.page_id = pl_from' ]
+			]
+		];
 		// Replacement for the WantedPages::getSQL hook
 		wfRunHooks( 'WantedPages::getQueryInfo', array( &$this, &$query ) );
 		return $query;

--- a/includes/specials/SpecialWantedtemplates.php
+++ b/includes/specials/SpecialWantedtemplates.php
@@ -40,10 +40,10 @@ class WantedTemplatesPage extends WantedQueryPage {
 	function getQueryInfo() {
 		return [
 			'tables' => [
-			    'templatelinks',
-                'pg1' => 'page',
-                'pg2' => 'page'
-            ],
+				'templatelinks',
+				'pg1' => 'page',
+				'pg2' => 'page'
+			],
 			'fields' => [
 				'namespace' => 'tl_namespace',
 				'title' => 'tl_title',
@@ -56,12 +56,12 @@ class WantedTemplatesPage extends WantedQueryPage {
 			],
 			'options' => [ 'GROUP BY' => [ 'tl_namespace', 'tl_title' ] ],
 			'join_conds' => [
-			    'pg1' => [ 'LEFT JOIN', [
-			        'pg1.page_namespace = tl_namespace',
+				'pg1' => [ 'LEFT JOIN', [
+					'pg1.page_namespace = tl_namespace',
 					'pg1.page_title = tl_title'
-                ] ],
-                'pg2' => [ 'LEFT JOIN', 'pg2.page_id = tl_from' ]
-            ]
+				] ],
+				'pg2' => [ 'LEFT JOIN', 'pg2.page_id = tl_from' ]
+			]
 		];
 	}
 }

--- a/includes/specials/SpecialWantedtemplates.php
+++ b/includes/specials/SpecialWantedtemplates.php
@@ -38,18 +38,30 @@ class WantedTemplatesPage extends WantedQueryPage {
 	}
 
 	function getQueryInfo() {
-		return array (
-			'tables' => array ( 'templatelinks', 'page' ),
-			'fields' => array ( 'tl_namespace AS namespace',
-					'tl_title AS title',
-					'COUNT(*) AS value' ),
-			'conds' => array ( 'page_title IS NULL',
-					'tl_namespace' => NS_TEMPLATE ),
-			'options' => array (
-				'GROUP BY' => 'tl_namespace, tl_title' ),
-			'join_conds' => array ( 'page' => array ( 'LEFT JOIN',
-					array ( 'page_namespace = tl_namespace',
-						'page_title = tl_title' ) ) )
-		);
+		return [
+			'tables' => [
+			    'templatelinks',
+                'pg1' => 'page',
+                'pg2' => 'page'
+            ],
+			'fields' => [
+				'namespace' => 'tl_namespace',
+				'title' => 'tl_title',
+				'value' => 'COUNT(*)'
+			],
+			'conds' => [
+				'pg1.page_title IS NULL',
+				'tl_namespace' => NS_TEMPLATE,
+				"NOT (RIGHT(pg2.page_title, 3) = '.js' OR RIGHT(pg2.page_title, 4) = '.css' OR pg2.page_namespace = '" . NS_MODULE . "')"
+			],
+			'options' => [ 'GROUP BY' => [ 'tl_namespace', 'tl_title' ] ],
+			'join_conds' => [
+			    'pg1' => [ 'LEFT JOIN', [
+			        'pg1.page_namespace = tl_namespace',
+					'pg1.page_title = tl_title'
+                ] ],
+                'pg2' => [ 'LEFT JOIN', 'pg2.page_id = tl_from' ]
+            ]
+		];
 	}
 }


### PR DESCRIPTION
[WantedPages](http://c.wikia.com/wiki/Special:WantedPages), [WantedTemplates](http://c.wikia.com/wiki/Special:WantedTemplates), [WantedFiles](http://c.wikia.com/wiki/Special:WantedFiles) and [WantedCategories](http://c.wikia.com/wiki/Special:WantedCategories) are registering a redlink even when it appears on pages whose content isn't wikitext. This happens on newer MediaWiki versions too, but since it's not supposed to be working like that on Wikia, this pull request fixes that. It also prevents non-wikitext pages from being added into [Pages with broken file links](http://c.wikia.com/wiki/Category:Pages_with_broken_file_links) category.

Changes were tested on MediaWiki 1.28, so if something breaks, it's most likely due to incompatibilities between versions.

Support ticket: [#320236](https://support.wikia-inc.com/hc/en-us/requests/320236)
Bug ticket: [PLATFORM-2351](https://wikia-inc.atlassian.net/browse/PLATFORM-2351)