### PR TITLE
IRIS-4131 pass necessary data to Special:Leaderboard

### DIFF
--- a/extensions/wikia/AchievementsII/modules/templates/LatestEarnedBadges_ListBadges.php
+++ b/extensions/wikia/AchievementsII/modules/templates/LatestEarnedBadges_ListBadges.php
@@ -18,8 +18,8 @@ foreach ($badges as $item) {
 
 	if ($displayMode == 'LatestBadges') {
 		$info = wfMsg('achievements-recent-info',
-			$item['user']->getUserPage()->getLocalURL(),
-			$item['user']->getName(),
+			$item['user']['profileUrl'],
+			$item['user']['userName'],
 			$badge_name,
 			$item['badge']->getGiveFor(),
 			wfTimeFormatAgo($item['date'])

--- a/extensions/wikia/AchievementsII/services/AchRankingService.class.php
+++ b/extensions/wikia/AchievementsII/services/AchRankingService.class.php
@@ -165,7 +165,7 @@ class AchRankingService {
 
 			if ( $user && AchAwardingService::canEarnBadges( $user ) ) {
 				$badges[] = [
-					'user' => $this->extractNeededUserData( $user ),
+					'user' => $this->getUsernameAndProfileUrl( $user ),
 					'badge' => new AchBadge( $row->badge_type_id, $row->badge_lap, $row->badge_level ),
 					'date' => $row->date
 				];
@@ -180,12 +180,12 @@ class AchRankingService {
 	}
 
 	/**
-	 * Extract only the info we need from the user object.
+	 * Get the user's profileUrl and username.
 	 *
 	 * Previously we were passing the entire user object, but
 	 * that was exposing private user data. See MAIN-9412.
 	 */
-	private function extractNeededUserData( User $user ) : array {
+	private function getUsernameAndProfileUrl( User $user ) : array {
 		return [
 			'profileUrl' => $user->getUserPage()->getLocalURL(),
 			'userName' => $user->getName()

--- a/extensions/wikia/AchievementsII/services/AchRankingService.class.php
+++ b/extensions/wikia/AchievementsII/services/AchRankingService.class.php
@@ -163,8 +163,12 @@ class AchRankingService {
 		while(($row = $dbr->fetchObject($res)) && (count($badges) <= $limit)) {
 			$user = User::newFromId($row->user_id);
 
-			if( $user && AchAwardingService::canEarnBadges( $user ) ) {
-				$badges[] = array('badge' => new AchBadge($row->badge_type_id, $row->badge_lap, $row->badge_level), 'date' => $row->date);
+			if ( $user && AchAwardingService::canEarnBadges( $user ) ) {
+				$badges[] = [
+					'user' => $this->extractNeededUserData( $user ),
+					'badge' => new AchBadge( $row->badge_type_id, $row->badge_lap, $row->badge_level ),
+					'date' => $row->date
+				];
 			}
 		}
 
@@ -173,5 +177,18 @@ class AchRankingService {
 		wfProfileOut(__METHOD__);
 
 		return $badges;
+	}
+
+	/**
+	 * Extract only the info we need from the user object.
+	 *
+	 * Previously we were passing the entire user object, but
+	 * that was exposing private user data. See MAIN-9412.
+	 */
+	private function extractNeededUserData( User $user ) : array {
+		return [
+			'profileUrl' => $user->getUserPage()->getLocalURL(),
+			'userName' => $user->getName()
+		];
 	}
 }


### PR DESCRIPTION
Ticket: https://wikia-inc.atlassian.net/browse/IRIS-4131

This ticket fixes a 500 which is getting thrown for all requests to `wikia.php?controller=LatestEarnedBadgesController&format=json`. That endpoint is used to render the right rail for Special:LeaderBoard.

The problem was that back in December a p1 was raised in which private user data was being exposed through that endpoint. The fix we took at the time was to just completely remove the user objects which were being passed to the template. That had the unintended side-effect of breaking that endpoint which would call methods on the expected userObjects.

The fix is to pass the necessary data to the template, but not only what we need. That allows the right rail to render, but doesn't expose private user data:

```
james-s:~  jamessutterfield$ curl -s 'http://sandbox-s1.dontstarve.wikia.com/wikia.php?controller=LatestEarnedBadgesController&format=json' | jq 'map(.[0])'
[
  {
    "user": {
      "profileUrl": "/wiki/User:Alarsin",
      "userName": "Alarsin"
    },
    "badge": {},
    "date": "2017-03-16 01:52:01"
  }
]
```