### PR TITLE
CAKE-1460: Removes MW-specific styling for MW+CP integration

### DIFF
--- a/extensions/wikia/ContributionPrototype/styles/ContributionPrototype.scss
+++ b/extensions/wikia/ContributionPrototype/styles/ContributionPrototype.scss
@@ -27,7 +27,6 @@ body {
   display: flex;
   align-items: center;
   margin-bottom: 10px;
-  background: #030f1d;
 
   h2 {
     flex-grow: 1;
@@ -53,8 +52,6 @@ body {
     }
 
     button {
-      color: black;
-
       > i {
         font-style: normal;
       }
@@ -82,32 +79,6 @@ body {
     height: auto;
     position: relative;
     top: -10px;
-    color: white;
-  }
-
-  .wds-button:hover {
-    color: #D5D4D4;
-  }
-}
-
-.ql-editor, .wikia_color-app_background, .wikia_color-card_background {
-  background-color: #030f1d;
-  color: #D5D4D4;
-}
-
-.wikia_color-headers, h1, h2, h3 {
-  color: #D5D4D4 !important;
-}
-
-.expandable_infobox {
-  background-color: #13202d !important;
-  border: none !important;
-
-  +.expander_button {
-    border-top: none;
-    border-left: 1px solid #D5D4D4;
-    border-right: 1px solid #D5D4D4;
-    border-bottom: 1px solid #D5D4D4;
   }
 }
 
@@ -119,18 +90,8 @@ body {
   margin-top: 0;
 }
 
-.dialog_body {
-  input, .entity_autosuggest {
-    background-color: white;
-  }
-}
-
 .article.ql-editor {
   border: 1px solid rgba(0,0,0,0);  /* work around a bizarre webkit bug that was causing a white bar to appear at the bottom of this element */
-}
-
-.cms_article_header > .wds-button {
-  border-color: transparent;
 }
 
 i.fa {
@@ -139,23 +100,6 @@ i.fa {
 
 .WikiHeader > nav.WikiNav .subnav-2 {
   width: 729px !important;
-}
-
-.infobox_section_header {
-  background-color: #40787e !important;
-}
-
-.editable_infobox {
-  background-color: white;
-}
-
-.footnotes {
-  background-color: transparent !important;
-  border: none !important;
-}
-
-.view_entity {
-  background-color: #030f1d !important;
 }
 
 .table_of_contents {


### PR DESCRIPTION
Layout styling was left alone - this intentionally only addressed the colors.  There's some additional styling work that'll be required to get this polished up, but that's outside the scope of this ticket.

@Wikia/cake 