### PR TITLE
MAIN-10068

### DIFF
--- a/extensions/wikia/PhalanxII/templates/PhalanxSpecial_main.php
+++ b/extensions/wikia/PhalanxII/templates/PhalanxSpecial_main.php
@@ -45,7 +45,7 @@
 							</label>
 
 							<label for="wpPhalanxFormatExact">
-								<input type="checkbox" name="wpPhalanxFormatExact" value="1" <? if ( !empty( $data['exact'] ) ): ?>checked="checked" <? endif; ?>/>
+								<input type="checkbox" name="wpPhalanxFormatExact" value="1" checked="checked" />
 								<?= wfMessage( 'phalanx-format-exact' )->escaped() ?>
 							</label>
 						</div>

--- a/extensions/wikia/SpecialContact2/SpecialContact.i18n.php
+++ b/extensions/wikia/SpecialContact2/SpecialContact.i18n.php
@@ -73,7 +73,7 @@ If there\'s an active user community on the wiki you wish to adopt, please start
 *Have you confirmed your email address?
 *Are you trying to log in via Facebook Connect? Be sure to follow the steps [[Help:Facebook_Connect|here]].
 *Not able to create an account? It may be that you are not eligible for an account at this time. See the [[homepage:Terms of Use#Membership|Terms of Use]] for more details.
-*Lost your password? You can request a new password [[Special:Signup|here]] Once there, enter your username, and click the "new password" button. You will then receive an email with a new temporary password. You can use this to sign in and update your password to one of your choice.
+*Lost your password? You can request a new password [[Special:Signup|here]]. Once there, enter your username, and click the "forgot password" button. You will then receive an email to your registered email address with a link to securely set a new password
 
 If you have done all of these and are still having an issue - please send us a detailed report below. We will get back to you as soon as possible to help fix the problem.
 


### PR DESCRIPTION
More often than not, for user block it makes sense to use the EXACT attribute as opposed to not, so let's default check it to avoid user error.