### PR TITLE
SUS-1799 | get rid of Wikia::ignoreUser method

### DIFF
--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -20,7 +20,6 @@ $wgHooks['UserRights']               [] = "Wikia::notifyUserOnRightsChange";
 $wgHooks['SetupAfterCache']          [] = "Wikia::setupAfterCache";
 $wgHooks['ComposeMail']              [] = "Wikia::ComposeMail";
 $wgHooks['SoftwareInfo']             [] = "Wikia::softwareInfo";
-$wgHooks['AddNewAccount']            [] = "Wikia::ignoreUser";
 $wgHooks['ComposeMail']              [] = "Wikia::isUnsubscribed";
 $wgHooks['AllowNotifyOnPageChange']  [] = "Wikia::allowNotifyOnPageChange";
 $wgHooks['AfterInitialize']          [] = "Wikia::onAfterInitialize";
@@ -1222,26 +1221,6 @@ class Wikia {
 		wfProfileOut( __METHOD__ );
 	}
 
-	/**
-	 * ignoreUser
-	 * @author tor
-	 *
-	 * marks a user as ignored for the purposes of stats counting, used to ignore test accounts
-	 * hooked up to AddNewAccount
-	 */
-	static public function ignoreUser( $user, $byEmail = false ) {
-		global $wgExternalDatawareDB;
-
-		if ( ( $user instanceof User ) && ( 0 === strpos( $user->getName(), 'WikiaTestAccount' ) ) ) {
-			if( !wfReadOnly() ){ // Change to wgReadOnlyDbMode if we implement that
-				$dbw = wfGetDB( DB_MASTER, array(), $wgExternalDatawareDB );
-
-				$dbw->insert( 'ignored_users', array( 'user_id' => $user->getId() ), __METHOD__, "IGNORE" );
-			}
-		}
-
-		return true;
-	}
 	/**
 	 * build user authentication key
 	 * @static


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-1799

We no longer use WikiaTestAccount prefix for test accounts (the last one was created in May 2012)

Introduced by 0fcd41cb370887b9c4f2b9df494fd4fef107eaa0 in Feb 2011

Thanks to this change `stats.ignored_users` table can be removed.