### PR TITLE
Wikia::getProps - pollutes stdout when run by the command line script

### DIFF
--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -1145,13 +1145,10 @@ class Wikia {
 	/**
 	 * get properties for page
 	 * FIXME: maybe it should be cached?
-	 * @static
-	 * @access public
-	 * @param page_id
-	 * @param oneProp if you just want one property, this will return the value only, not an array
-	 * @return Array
+	 * @param $page_id int
+	 * @param $oneProp string if you just want one property, this will return the value only, not an array
+	 * @return mixed
 	 */
-
 	static public function getProps( $page_id, $oneProp = null ) {
 		wfProfileIn( __METHOD__ );
 		$return = array();
@@ -1174,7 +1171,7 @@ class Wikia {
 		);
 		while( $row = $dbr->fetchObject( $res ) ) {
 			$return[ $row->pp_propname ] = $row->pp_value;
-			Wikia::log( __METHOD__, "get", "id: {$page_id}, key: {$row->pp_propname}, value: {$row->pp_value}" );
+			wfDebug( __METHOD__ . " id: {$page_id}, key: {$row->pp_propname}, value: {$row->pp_value}\n" );
 		}
 		$dbr->freeResult( $res );
 		wfProfileOut( __METHOD__ );


### PR DESCRIPTION
For instance:

```
Wikia::getProps-get:darkstalkers/4674: id: 6098, key: infoboxes, value: 
Wikia::getProps-get:glee/26337: id: 2555196, key: infoboxes, value: [{"parser_tag_version":2,"data":[{"type":"title","data":{"value":"Infobox single\/pi"}}],"metadata":[{"type":"title","sources":{"name":{"label":"","primary":true}}},{"type":"image","sources":{"image":{"label":"","primary":true}}},{"type":"data","sources":{"album":{"label":"Album:","primary":true}}},{"type":"data","sources":{"released":{"label":"Released:","primary":true}}},{"type":"data","sources":{"by":{"label":"By:","primary":true}}},{"type":"data","sources":{"sung by":{"label":"Sung by:","primary":true}}},{"type":"data","sources":{"solos":{"label":"Solos:","primary":true}}},{"type":"data","sources":{"place":{"label":"Place:","primary":true}}},{"type":"data","sources":{"episode":{"label":"Episode:","primary":true}}},{"type":"group","metadata":[{"type":"header","sources":[]},{"type":"image","sources":{"track":{"label":"","primary":true}}}]}]}]
```

Let's just log via `wfDebug` and skip echo'ing messages to stdout.