### PR TITLE
(MAIN-10111) Fix JS error in Safari 9

### DIFF
--- a/extensions/wikia/DesignSystem/scripts/DesignSystemGlobalNavigationOnSiteNotifications.view.js
+++ b/extensions/wikia/DesignSystem/scripts/DesignSystemGlobalNavigationOnSiteNotifications.view.js
@@ -76,7 +76,7 @@ define('ext.wikia.design-system.on-site-notifications.view', [
 			};
 
 			this.onMouseWheel = function (event) {
-				const delta = -event.originalEvent.wheelDelta || event.originalEvent.detail,
+				var delta = -event.originalEvent.wheelDelta || event.originalEvent.detail,
 					scrollTop = this.scrollTop;
 				if ((delta < 0 && scrollTop === 0)
 					|| (delta > 0 && this.scrollHeight - this.clientHeight - scrollTop === 0)) {


### PR DESCRIPTION
Don't use ES6 syntax in order to fix the error:

    SyntaxError: Unexpected keyword 'const'. Const declarations are
    not supported in strict mode. VMundefined
    DesignSystemGlobalNavigationOnSiteNotifications.view.js:79