### PR TITLE
SUS-1923 | remove page_edits and page_status columns

### DIFF
--- a/extensions/wikia/MultiTasks/SpecialMultiWikiFinder_body.php
+++ b/extensions/wikia/MultiTasks/SpecialMultiWikiFinder_body.php
@@ -124,7 +124,6 @@ class MultiwikifinderPage {
 				array(
 					'page_title'		=> mb_strtolower($this->mPageTitle),
 					'page_namespace' 	=> $this->mPageNS,
-					'page_status'		=> 0
 				),
 				__METHOD__,
 				array(

--- a/maintenance/wikia/updateDatawarePages.php
+++ b/maintenance/wikia/updateDatawarePages.php
@@ -105,7 +105,6 @@ class UpdateDatawarePages extends Maintenance {
 			'pages',
 			[
 				'page_id',
-				'page_status',
 				'page_latest',
 				'page_title',
 				'page_namespace',
@@ -204,7 +203,6 @@ class UpdateDatawarePages extends Maintenance {
 				'page_id' => $localPage->page_id,
 				'page_namespace' => $localPage->page_namespace,
 				'page_title' => $localPage->page_title,
-				'page_status' => 0,
 				'page_is_content' => $localPage->page_is_content,
 				'page_is_redirect' => $localPage->page_is_redirect,
 				'page_latest' => $localPage->page_latest,

--- a/maintenance/wikia/updateDatawarePages.php
+++ b/maintenance/wikia/updateDatawarePages.php
@@ -48,7 +48,6 @@ class UpdateDatawarePages extends Maintenance {
 				'page_latest',
 				'page_title',
 				'page_namespace',
-				'count(rev_id) as page_edits',
 				'max(rev_timestamp) as page_last_edited',
 				'rev_user'
 			],
@@ -67,7 +66,6 @@ class UpdateDatawarePages extends Maintenance {
 		/** @var stdClass $row */
 		foreach ( $res as $row ) {
 			$row->page_latest = intval( $row->page_latest );
-			$row->page_edits = intval( $row->page_edits );
 			$row->page_is_redirect = intval( $row->page_is_redirect );
 			$row->page_is_content = intval( in_array( $row->page_namespace, $wgContentNamespaces ) );
 			$row->page_last_edited = $row->page_last_edited ? wfTimestamp( TS_DB, $row->page_last_edited ) : null;
@@ -113,7 +111,6 @@ class UpdateDatawarePages extends Maintenance {
 				'page_namespace',
 				'page_is_redirect',
 				'page_is_content',
-				'page_edits',
 				'page_last_edited'
 			],
 			[
@@ -210,7 +207,6 @@ class UpdateDatawarePages extends Maintenance {
 				'page_status' => 0,
 				'page_is_content' => $localPage->page_is_content,
 				'page_is_redirect' => $localPage->page_is_redirect,
-				'page_edits' => $localPage->page_edits,
 				'page_latest' => $localPage->page_latest,
 				'page_last_edited' => $localPage->page_last_edited,
 			],


### PR DESCRIPTION
These columns are not queried by MW app nor backend (except the update script that takes the currently existing `dataware.page` row and updates it with data from a local per-wiki `page` table entry).

No need to keep them up to date. We'll perform 'ALTER` query once this hits production.