### PR TITLE
ADEN-4963 Add _sp_.config to detection script

### DIFF
--- a/extensions/wikia/AdEngine/js/SourcePointDetection.js
+++ b/extensions/wikia/AdEngine/js/SourcePointDetection.js
@@ -71,6 +71,10 @@ define('ext.wikia.adEngine.sourcePointDetection', [
 		win.ads.runtime = win.ads.runtime || {};
 		win.ads.runtime.sp = win.ads.runtime.sp || {};
 
+		win._sp_ = win._sp_ || {};
+		win._sp_.config = win._sp_.config || {};
+		win._sp_.config.account_id = win._sp_.config.account_id || 106;
+
 		doc.addEventListener('sp.blocking', function () {
 			win.ads.runtime.sp.blocking = true;
 			trackStatusOnce('yes');


### PR DESCRIPTION
`_sp_.config` is mandatory after recent update. Config is duplicated in https://github.com/Wikia/app/blob/dev/extensions/wikia/ARecoveryEngine/templates/ARecoveryEngineApiController_getBootstrap.mustache#L10 but proposed changes applies to oasis and mercury.