### PR TITLE
cake-546 - overtake the history action as well

### DIFF
--- a/extensions/wikia/ContributionPrototype/CPHistoryAction.php
+++ b/extensions/wikia/ContributionPrototype/CPHistoryAction.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace ContributionPrototype;
+
+use FormlessAction;
+use HistoryAction;
+
+class CPHistoryAction extends FormlessAction {
+
+	public function getName() {
+		return 'history';
+	}
+
+	public function requiresWrite() {
+		return false;
+	}
+
+	public function requiresUnblock() {
+		return false;
+	}
+
+	public function onView() {
+		return null;
+	}
+
+	public function show() {
+		switch ($this->page->getTitle()->getNamespace()) {
+			case NS_MAIN:
+				Utils::getRenderer()->render($this->page->getTitle()->getPartialURL(), $this->getOutput(), 'history');
+				break;
+			default:
+				$this->fallback();
+				break;
+		}
+	}
+
+	private function fallback() {
+		$action = new HistoryAction($this->page, $this->context);
+		$action->show();
+	}
+}

--- a/extensions/wikia/ContributionPrototype/ContributionPrototype.setup.php
+++ b/extensions/wikia/ContributionPrototype/ContributionPrototype.setup.php
@@ -14,6 +14,7 @@ spl_autoload_register(function($class) {
 
 $wgActions['view'] = ContributionPrototype\CPViewAction::class;
 $wgActions['edit'] = ContributionPrototype\CPEditAction::class;
+$wgActions['history'] = ContributionPrototype\CPHistoryAction::class;
 
 // titles in the name mainspace shouldn't be force capitalized
 $wgCapitalLinkOverrides = [NS_MAIN => false];


### PR DESCRIPTION
@Wikia/cake 
https://wikia-inc.atlassian.net/browse/CAKE-546

See Wikia/sd-poc#314 for the changes on the CMS side to display history when embedded in MW