### PR TITLE
XW-3139 | Disable importing scripts when user JS is not allowed

### DIFF
--- a/extensions/wikia/ContentReview/ContentReview.hooks.php
+++ b/extensions/wikia/ContentReview/ContentReview.hooks.php
@@ -123,9 +123,9 @@ class Hooks {
 	 * @throws \MWException
 	 */
 	public function onSkinAfterBottomScripts( $skin, &$bottomScripts ) {
-		global $wgUseSiteJs;
+		global $wgOut, $wgUseSiteJs;
 
-		if ( !empty( $wgUseSiteJs ) ) {
+		if ( !empty( $wgUseSiteJs ) && $wgOut->isUserJsAllowed() ) {
 			$bottomScripts .= ( new ImportJS() )->getImportScripts();
 		}
 

--- a/extensions/wikia/ContentReview/ContentReview.hooks.php
+++ b/extensions/wikia/ContentReview/ContentReview.hooks.php
@@ -117,15 +117,15 @@ class Hooks {
 	/**
 	 * Add script to load safe imports
 	 *
-	 * @param $skin
+	 * @param \Skin $skin
 	 * @param String $bottomScripts
 	 * @return bool
 	 * @throws \MWException
 	 */
 	public function onSkinAfterBottomScripts( $skin, &$bottomScripts ) {
-		global $wgOut, $wgUseSiteJs;
+		global $wgUseSiteJs;
 
-		if ( !empty( $wgUseSiteJs ) && $wgOut->isUserJsAllowed() ) {
+		if ( !empty( $wgUseSiteJs ) && $skin->getOutput()->isUserJsAllowed() ) {
 			$bottomScripts .= ( new ImportJS() )->getImportScripts();
 		}
 


### PR DESCRIPTION
## Links
* https://wikia-inc.atlassian.net/browse/XW-3139

## Description
Disallow use of ImportJS on pages like Special:Preferences.
It's a quick fix, I'll leave the refactoring suggested by @TK-999 to SUS.

## Reviewers
@Grunny @TK-999 @kvas-damian 