### PR TITLE
Video: send video playback events to GA as well

### DIFF
--- a/extensions/wikia/VideoHandlers/js/VideoBootstrap.js
+++ b/extensions/wikia/VideoHandlers/js/VideoBootstrap.js
@@ -115,7 +115,7 @@ define( 'wikia.videoBootstrap', [
 				action: action,
 				category: 'video-player-stats',
 				label: this.provider,
-				trackingMethod: 'internal',
+				trackingMethod: 'analytics', // send to both GA and our internal tracker
 				value: 0
 			}, {
 				title: this.title,


### PR DESCRIPTION
`statsdb.rollup_wiki_video_views` is an unreliable source of stats