### PR TITLE
Revert "Revert "ADEN-5009 Fix vpaid styles""

### DIFF
--- a/extensions/wikia/AdEngine/js/template/porvata.js
+++ b/extensions/wikia/AdEngine/js/template/porvata.js
@@ -76,12 +76,16 @@ define('ext.wikia.adEngine.template.porvata', [
 
 	function getVideoContainer(slotName) {
 		var container = doc.createElement('div'),
+			displayWrapper = doc.createElement('div'),
 			providerContainer = doc.querySelector('#' + slotName + ' > .provider-container');
 
-		container.classList.add('vpaid-container');
+		container.classList.add('video-overlay');
+		displayWrapper.classList.add('video-display-wrapper');
+
+		container.appendChild(displayWrapper);
 		providerContainer.appendChild(container);
 
-		return container;
+		return displayWrapper;
 	}
 
 	function isVpaid(contentType) {
@@ -129,7 +133,7 @@ define('ext.wikia.adEngine.template.porvata', [
 				});
 
 				video.addEventListener('allAdsCompleted', function () {
-					DOMElementTweaker.hide(videoPlayer);
+					DOMElementTweaker.hide(params.container);
 				});
 			}
 

--- a/extensions/wikia/AdEngine/js/video/player/porvata/porvataPlayerFactory.js
+++ b/extensions/wikia/AdEngine/js/video/player/porvata/porvataPlayerFactory.js
@@ -12,7 +12,6 @@ define('ext.wikia.adEngine.video.player.porvata.porvataPlayerFactory', [
 	function prepareVideoAdContainer(videoAdContainer, videoSettings) {
 		DOMElementTweaker.hide(videoAdContainer);
 		videoAdContainer.classList.add(videoPlayerClassName);
-		videoAdContainer.style.position = 'relative';
 
 		if (videoSettings.isAutoPlay()) {
 			videoAdContainer.classList.add(autoPlayClassName);

--- a/extensions/wikia/AdEngine/js/video/uapVideo.js
+++ b/extensions/wikia/AdEngine/js/video/uapVideo.js
@@ -42,6 +42,7 @@ define('ext.wikia.adEngine.video.uapVideo', [
 
 		return porvata.inject(videoSettings)
 			.then(function (video) {
+				video.container.style.position = 'relative';
 				if (mercuryListener) {
 					mercuryListener.onPageChange(function () {
 						video.destroy();

--- a/skins/oasis/css/core/ads.scss
+++ b/skins/oasis/css/core/ads.scss
@@ -41,6 +41,7 @@ $video-control-pause-shadow-animation-duration: 1s;
 $video-control-pause-shadow-animation-function: ease;
 
 $vpaid-z-index: 10;
+$video-interactive-area-z-index: $vpaid-z-index + 1;
 
 @mixin absolute-fill() {
 	height: 100%;
@@ -131,25 +132,23 @@ $vpaid-z-index: 10;
 		}
 	}
 
-	.vpaid-container {
+	.video-overlay {
 		@include absolute-fill();
+	}
 
-		video, & > div {
+	.video-display-wrapper {
+		background: #000;
+		height: 100%;
+		position: relative;
+		width: 100%;
+
+		video, &.vpaid-enabled > div {
 			@include absolute-fill();
 		}
 
-		// Node elements created by IMA library
-		& > div {
-			pointer-events: none;
-
-			video {
-				pointer-events: auto;
-			}
-		}
-
 		&.vpaid-enabled video {
-			 z-index: $vpaid-z-index;
-		 }
+			z-index: $vpaid-z-index;
+		}
 
 		.video-player {
 			background: #000;
@@ -671,7 +670,7 @@ body > a > img[src$="noad.gif"] {
 	left: 0;
 	position: absolute;
 	top: 0;
-	z-index: 1;
+	z-index: $video-interactive-area-z-index;
 
 	img {
 		padding: 7px;
@@ -683,6 +682,7 @@ body > a > img[src$="noad.gif"] {
 	left: 0;
 	position: absolute;
 	width: 100%;
+	z-index: $video-interactive-area-z-index;
 
 	.control-bar {
 		padding: 0 $video-control-bar-padding;
@@ -797,6 +797,7 @@ body > a > img[src$="noad.gif"] {
 	top: 0;
 	visibility: hidden;
 	width: $video-control-panel-item-size;
+	z-index: $video-interactive-area-z-index;
 
 	svg {
 		fill: $video-control-panel-default-color;


### PR DESCRIPTION
Revert of revert because those changes have to wait for release of new styles on mobile.

> It turns out that we should not override IMA's inline styles because some vpaids are styled base on those defaults. Instead of overriding IMA properties everywhere we can adjust styles for UAP units only and keep defaults for all standalone players.