### PR TITLE
cake-1585 - rewrite Title urls with the text rather than the db key

### DIFF
--- a/extensions/wikia/ContributionPrototype/ContributionPrototype.setup.php
+++ b/extensions/wikia/ContributionPrototype/ContributionPrototype.setup.php
@@ -61,3 +61,11 @@ $wgHooks['MakeGlobalVariablesScript'][] = function(&$vars, OutputPage $outputPag
 
 	return true;
 };
+
+$wgHooks['GetLocalURL'][] = function(Title $title, &$url) {
+	if ($title->getNamespace() === NS_MAIN) {
+		$url = str_replace(urldecode($title->getPrefixedDBkey()), rawurlencode($title->getText()), $url);
+	}
+
+	return true;
+};


### PR DESCRIPTION
@Wikia/cake 
https://wikia-inc.atlassian.net/browse/CAKE-1585

This fixes both `Special:Random` redirects, navigation links, and possibly other places that generate links to pages from the `Title` objects.

There's a 3 hour cache on the wiki nav, so we'd have to wait for that once this code is pushed out.