### PR TITLE
XW-2961 | Fix fetching pageviews for Insights/popularpages

### DIFF
--- a/extensions/wikia/InsightsV2/helpers/InsightsPageViews.php
+++ b/extensions/wikia/InsightsV2/helpers/InsightsPageViews.php
@@ -99,7 +99,7 @@ class InsightsPageViews {
 	 * @return array An array with dates of the last four Sundays
 	 */
 	private function getLastFourTimeIds() {
-		$lastTimeId = ( new DateTime() )->modify( 'last Sunday' );
+		$lastTimeId = new DateTime( DataMartService::findLastRollupsDate( DataMartService::PERIOD_ID_WEEKLY ) );
 		$format = 'Y-m-d H:i:s';
 		return [
 			$lastTimeId->modify( '-1 week' )->format( $format ),


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/XW-3153

DataMart have `timeId` set at 1AM so we don't hit right data
`|         2 | 2017-04-16 01:00:00 |   26337 |         2002 |          0 |         9 |`
The fix checks what is last available `timeId`

@Wikia/x-wing 