### PR TITLE
XW-3232 | Render partial JSON when there is encode error

### DIFF
--- a/includes/wikia/nirvana/WikiaView.class.php
+++ b/includes/wikia/nirvana/WikiaView.class.php
@@ -351,7 +351,15 @@ class WikiaView {
 			$output = $this->response->getData();
 		}
 
-		return json_encode( $output );
+		$json = json_encode( $output, JSON_PARTIAL_OUTPUT_ON_ERROR );
+
+		if ( json_last_error() !== JSON_ERROR_NONE ) {
+			WikiaLogger::instance()->error( 'Partial JSON output rendered because of json_encode error', [
+				'error_msg' => json_last_error_msg()
+			] );
+		}
+
+		return $json;
 	}
 
 	protected function renderJsonp() {


### PR DESCRIPTION
Return partial JSON instead of a blank page, when there is issue with e.g. encoding.
Log the errors so we don't ignore the fact that there is a broken data somewhere.

@kvas-damian @hakubo 