### PR TITLE
XW-3137 | ArticleAsJson skip not existing media objects

### DIFF
--- a/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php
+++ b/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php
@@ -230,6 +230,10 @@ class ArticleAsJson extends WikiaService {
 				);
 				$details['context'] = self::MEDIA_CONTEXT_GALLERY_IMAGE;
 
+				if ( $details['exists'] === false ) {
+					continue;
+				}
+
 				$caption = $image['caption'];
 
 				if ( !empty( $caption ) ) {

--- a/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php
+++ b/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php
@@ -302,6 +302,14 @@ class ArticleAsJson extends WikiaService {
 
 			$details = self::getMediaDetailWithSizeFallback( $title, self::$mediaDetailConfig );
 
+			if ( $details['exists'] === false ) {
+				// Skip media when it doesn't exist
+
+				$res = '';
+
+				return false;
+			}
+
 			//information for mobile skins how they should display small icons
 			$details['context'] = self::isIconImage( $details, $handlerParams ) ? self::MEDIA_CONTEXT_ICON :
 				self::MEDIA_CONTEXT_ARTICLE_IMAGE;


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/XW-3137

In articleAsJson not existing media doesn't provide any value. We just skip them in output `context` and `media` array.

Ping @Wikia/x-wing 