### PR TITLE
XW-3290 | User avatars in chat rail module redirect to user profile page

### DIFF
--- a/extensions/wikia/Chat2/ChatWidget.class.php
+++ b/extensions/wikia/Chat2/ChatWidget.class.php
@@ -44,7 +44,7 @@ class ChatWidget {
 			[
 				'username' => User::isIp( $wgUser->getName() )
 					? wfMessage( 'oasis-anon-user' )->escaped() : $wgUser->getName(),
-				'userProfileUrl' => $wgUser->getUserPage()->getLinkURL(),
+				'profileUrl' => $wgUser->getUserPage()->getLinkURL(),
 				'avatarUrl' => $myAvatarUrl,
 			],
 		];

--- a/extensions/wikia/Chat2/templates/widgetUserElement.mustache
+++ b/extensions/wikia/Chat2/templates/widgetUserElement.mustache
@@ -1,5 +1,5 @@
 {{#viewedUsersInfo}}
-	<a href="{{userProfileUrl}}"
+	<a href="{{profileUrl}}"
 	   class="wds-avatar-stack__avatar{{#hasUsers}} chatter{{/hasUsers}}"{{^hasUsers}}
 	   title="{{username}}"{{/hasUsers}}>
 		<img class="wds-avatar" src="{{avatarUrl}}"/>

--- a/extensions/wikia/Chat2/tests/ChatWidgetTest.php
+++ b/extensions/wikia/Chat2/tests/ChatWidgetTest.php
@@ -190,7 +190,7 @@ class ChatWidgetTest extends WikiaBaseTest {
 					'viewedUsersInfo' => [
 						[
 							'username' => 'testUsername',
-							'userProfileUrl' => '/wiki/User:testUsername',
+							'profileUrl' => '/wiki/User:testUsername',
 							'avatarUrl' => 'www.image.com',
 						],
 					],
@@ -218,7 +218,7 @@ class ChatWidgetTest extends WikiaBaseTest {
 					'viewedUsersInfo' => [
 						[
 							'username' => 'testUsername',
-							'userProfileUrl' => '/wiki/User:testUsername',
+							'profileUrl' => '/wiki/User:testUsername',
 							'avatarUrl' => 'www.image.com',
 						],
 					],
@@ -246,7 +246,7 @@ class ChatWidgetTest extends WikiaBaseTest {
 					'viewedUsersInfo' => [
 						[
 							'username' => 'testUsername',
-							'userProfileUrl' => '/wiki/User:testUsername',
+							'profileUrl' => '/wiki/User:testUsername',
 							'avatarUrl' => 'www.image.com',
 						],
 					],


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/XW-3290

Wrongly typed variable name in template caused avatar link to lead to currently viewed page instead of user profile page. `$usersInfo` passed to `getViewedUsersInfo()` has `profileUrl` and not `userProfileUrl`, see https://github.com/Wikia/app/blob/a2ce058e13dc943c1769e56dea2add446371c691/extensions/wikia/Chat2/ChatWidget.class.php#L214.

@Wikia/x-wing 