### PR TITLE
CAKE-1629: Forward the UA to the node server, for proper pre-rendering

### DIFF
--- a/extensions/wikia/ContributionPrototype/CPArticleRenderer.php
+++ b/extensions/wikia/ContributionPrototype/CPArticleRenderer.php
@@ -98,6 +98,7 @@ class CPArticleRenderer {
 				'GET',
 				"{$internalHost}/{$path}",
 				[
+                    'userAgent' => $_SERVER['HTTP_USER_AGENT'],
 					'noProxy' => true,
 					'returnInstance' => true,
 					'followRedirects'=> true,

--- a/extensions/wikia/ContributionPrototype/CPArticleRenderer.php
+++ b/extensions/wikia/ContributionPrototype/CPArticleRenderer.php
@@ -98,7 +98,7 @@ class CPArticleRenderer {
 				'GET',
 				"{$internalHost}/{$path}",
 				[
-                    'userAgent' => $_SERVER['HTTP_USER_AGENT'],
+					'userAgent' => $_SERVER['HTTP_USER_AGENT'],
 					'noProxy' => true,
 					'returnInstance' => true,
 					'followRedirects'=> true,


### PR DESCRIPTION
@Wikia/cake 