### PR TITLE
FAN-1855 Reduce user attributes cache TTL to test removal of caching

### DIFF
--- a/lib/Wikia/src/Service/User/Attributes/UserAttributes.php
+++ b/lib/Wikia/src/Service/User/Attributes/UserAttributes.php
@@ -29,7 +29,7 @@ class UserAttributes {
 	/** @var string[string] */
 	private $defaultAttributes;
 
-	const CACHE_TTL = 300; // 5 minute
+	const CACHE_TTL = 120; // 2 minutes
 
 	/**
 	 * @Inject({


### PR DESCRIPTION
This reduction of cache TTL for User Attributes is to see how the load on the UA service changes without caching on the Mediawiki side. The eventual goal is to remove caching of user attributes in memcache in MW completely, so that user avatar changes on other platforms are able to propagate immediately to MW.