### PR TITLE
IRIS-4357 Prefer the non-deleted content when there is more than one comment

### DIFF
--- a/extensions/wikia/Discussions/maintenance/ForumDumper.php
+++ b/extensions/wikia/Discussions/maintenance/ForumDumper.php
@@ -84,6 +84,13 @@ class ForumDumper {
 	private $votes = [];
 
 	public function addPage( $id, $data ) {
+		// There are cases when the page appears twice; one marked as deleted in comments_index
+		// and one where its not marked deleted in comments_index.  This might represent a move.
+		// If this is the case, prefer the un-deleted version.
+		if ( !empty( $this->pages[$id] ) && $data["deleted_ind"] == 1 ) {
+			return;
+		}
+
 		$this->pages[$id] = $data;
 	}
 


### PR DESCRIPTION
This is an edge case in Forums.  Its not clear how comments get in this state and not many are.  Its likely it happens when someone moves a thread to be a comment of another thread.

Ticket: https://wikia-inc.atlassian.net/browse/IRIS-4357