### PR TITLE
SUS-1853: fix a fatal when visiting Special:Preferences

### DIFF
--- a/includes/Preferences.php
+++ b/includes/Preferences.php
@@ -85,10 +85,14 @@ class Preferences {
 			}
 		}
 
+		## Make sure that form fields have their parent set. See SUS-1853
+		$dummyForm = new HTMLForm( array(), $context );
+
 		## Prod in defaults from the user
 		foreach ( $defaultPreferences as $name => &$info ) {
 			$prefFromUser = self::getUserProperty( $name, $info, $user );
 			$field = HTMLForm::loadInputFromParameters( $name, $info ); // For validation
+			$field->mParent = $dummyForm; // SUS-1853
 			$defaultOptions = User::getDefaultOptions();
 			$globalDefault = isset( $defaultOptions[$name] )
 				? $defaultOptions[$name]


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-1853

Backport https://github.com/wikimedia/mediawiki/commit/307eee22b6cfc8354e9fb746a3fb9cfe9c9dc041

The error is `Fatal error: Call to a member function msg() on a non-object at includes/Preferences.php on line 1207.`

The problem is that fields created in `Preferences::getPreferences()` for
validation don't have their parent set and thus an error occurs when the
validation fails since they want to use their parent to get a Message
object.

This commit adds a dummy parent object to these fields to fix the error.