### PR TITLE
SUS-1623 | Special:Images redirects to Special:ListFiles on Italian wikis due to aliases conflict

### DIFF
--- a/extensions/wikia/WikiaNewFiles/WikiaNewFiles.alias.php
+++ b/extensions/wikia/WikiaNewFiles/WikiaNewFiles.alias.php
@@ -25,7 +25,7 @@ $specialPageAliases['fr'] = [
 ];
 
 $specialPageAliases['it'] = [
-	'Images' => [ 'Immagini' ],
+	'Images' => [ 'UltimeImmagini' ],
 ];
 
 $specialPageAliases['ja'] = [


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-1623

Let's use _UltimeImmagini_ as an alias for Wikia's custom Special:Images to resolve conflict with _Immagini_ set as an alias for MediaWiki-core Special:Listfiles