### PR TITLE
XW-3227 | border color in attribution changed

### DIFF
--- a/extensions/wikia/ArticleVideo/styles/video-attribution.scss
+++ b/extensions/wikia/ArticleVideo/styles/video-attribution.scss
@@ -6,7 +6,7 @@
 	@include align-items(center);
 	@include flexbox();
 	@include justify-content(center);
-	border-bottom: 1px solid rgba($color-text, .5);
+	border-bottom: 1px solid $color-page-border;
 	padding: 6px;
 }
 


### PR DESCRIPTION
Border color change in featured video attribution

@Wikia/x-wing 