### PR TITLE
SUS-1620 | Introduced User::touch() method to bump the getTouched() value using memcached

### DIFF
--- a/includes/User.php
+++ b/includes/User.php
@@ -2005,13 +2005,6 @@ class User implements JsonSerializable {
 	 * for reload on the next hit.
 	 */
 	public function invalidateCache() {
-		#<Wikia>
-		global $wgLogUserInvalidateCache;
-		if ( !empty( $wgLogUserInvalidateCache ) ) {
-			$e = new Exception;
-			$this->error( 'SUS-546', [ 'traceBack' => $e->getTraceAsString() ] );
-		}
-		#</Wikia>
 		if( wfReadOnly() ) {
 			return;
 		}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-1620

`User::invalidateCache` will no longer try to update `user.user_touched` on shared database which was prone to deadlocks. Instead it will just set a key in memcache (via new `User::touch` method). This will greatly reduce the number of such queries (we currently make 640k of these every day, that's 68% of **all** `UPDATE` queries on shared db master node). `invalidateCache` is usually called when an edit / upload is made (via `User::addWatch` method) or when a user is created from an auth token (`User::newFromToken` method).

`user_touched` field is still updated when `User::saveSettings` is called (e.g. preferences are saved).

`User::getTouched`  will now return the greater of these - `user_touched` field from `user` table / value stored in memcache (set via `User::touch`)

```php
macbre@dev-macbre:~$ ./eval.sh 
> $u = User::newFromName('Macbre')
Unstubbing $wgAuth on call of $wgAuth::getCanonicalName from User::newFromName

> echo $u->getName()
Macbre

> echo $u->getTouched()
Query plpoznan (DB user: wikia_maint) (10) (slave): SELECT /* User::idFromName CommandLineInc - fcfd0fd0-87fc-44e9-b349-b4a368730599 */  user_id  FROM `wikicities_c1`.`user`  WHERE user_name = 'Macbre'  LIMIT 1  
memcached: get(dev-macbre-plpoznan:user:id:119245)
memcached: MemCache: sock i:0; got dev-macbre-plpoznan:user:id:119245
memcached: get(dev-macbre-wikicities:user_touched:v1:119245)
memcached: MemCache: sock i:0; got dev-macbre-wikicities:user_touched:v1:119245
User: got user 119245 from cache
memcached: get(dev-macbre-wikicities:user-quicktouched:id:119245)
memcached: set dev-macbre-wikicities:user-quicktouched:id:119245 (STORED)
20170516115729

> $u->invalidateCache()
memcached: set dev-macbre-wikicities:user-quicktouched:id:119245 (STORED)
memcached: MemCache: delete dev-macbre-plpoznan:user:id:119245 (DELETED)
User: loading options for user 119245 from override cache.
memcached: client: serializing data as it is not scalar
memcached: client: compressing data; was 10981 bytes is now 3259 bytes
memcached: set dev-macbre-plpoznan:user:id:119245 (STORED)
User: user 119245 stored in cache
memcached: set dev-macbre-wikicities:user_touched:v1:119245 (STORED)
Shared user: updating shared user_touched
memcached: MemCache: delete GLOBAL:Wikia\Service\User\Permissions\PermissionsServiceImpl:permissions-groups:119245 (DELETED)

> echo $u->getTouched()
20170516115756

> $u->saveSettings()
User: got user 119245 from cache
User: loading options for user 119245 from override cache.
Connecting to geo-db-dev-db-master.query.consul plpoznan...
DatabaseBase::query: Writes done: UPDATE  `wikicities_c1`.`user` SET user_name = 'Macbre',user_real_name = '',user_email = 'macbre@wikia-inc.com',user_email_authenticated = '20090126130335',user_touched = '20170516115817',user_token = '96f6670ef02fea4d2b2c3ade065d9aaf',user_email_token = '1f92a97d8d27e0ca2a6fecc3bc2c57d3',user_email_token_expires = '20090711205751' WHERE user_id = '119245'
Query plpoznan (DB user: wikia_maint) (11) (master): UPDATE /* User::saveSettings CommandLineInc - fcfd0fd0-87fc-44e9-b349-b4a368730599 */  `wikicities_c1`.`user` SET user_name = 'Macbre',user_real_name = '',user_email = 'macbre@wikia-inc.com',user_email_authenticated = '20090126130335',user_touched = '20170516115817',user_token = '96f6670ef02fea4d2b2c3ade065d9aaf',user_email_token = '1f92a97d8d27e0ca2a6fecc3bc2c57d3',user_email_token_expires = '20090711205751' WHERE user_id = '119245'
...
User: user 119245 stored in cache
memcached: set dev-macbre-wikicities:user_touched:v1:119245 (STORED)
Shared user: updating shared user_touched
LBFactory_Wikia::getSectionForWiki: section c1, wiki
Query plpoznan (DB user: wikia_maint) (17) (master): UPDATE /* Title::invalidateCache CommandLineInc - fcfd0fd0-87fc-44e9-b349-b4a368730599 */  `page` SET page_touched = '20170516115812' WHERE page_namespace = '2' AND page_title = 'Macbre'
{"appname":"mediawiki","@timestamp":"2017-05-16T11:58:12.358842+00:00","@message":"Important table write - SQL UPDATE /* Title::invalidateCache CommandLineInc - fcfd0fd0-87fc-44e9-b349-b4a368730599 */  `page` SET page_touched = '20170516115812' WHERE page_namespace = '2' AND page_title = 'Macbre'","@fields":{"app_name":"mediawiki","app_version":"dev","datacenter":"poz","environment":"dev","wiki_dbname":"plpoznan","wiki_id":"5915","maintenance_file":"/usr/wikia/source/app/maintenance/eval.php","maintenance_class":"CommandLineInc","client_ip":"127.0.0.1","span_id":"79fcdc83-2905-4bd3-9835-a39d6ef6af15","trace_id":"fcfd0fd0-87fc-44e9-b349-b4a368730599"},"@exception":{"class":"Exception","message":"","code":0,"file":"/usr/wikia/source/app/includes/db/Database.php:3732","trace":["/usr/wikia/source/app/includes/db/Database.php:3673","/usr/wikia/source/app/includes/db/Database.php:977","/usr/wikia/source/app/includes/db/Database.php:1897","/usr/wikia/source/app/includes/Title.php:4467","/usr/wikia/source/app/includes/User.php:3206","/usr/wikia/source/app/maintenance/eval.php(88) : eval()'d code:1","/usr/wikia/source/app/maintenance/eval.php:88"]},"@context":{"method":"Title::invalidateCache","elapsed":0.010771989822388,"num_rows":1,"transaction_level":0,"cluster":"c1","server":"geo-db-dev-db-master.query.consul","server_role":"master","db_name":"plpoznan","db_user":"wikia_maint"}}
memcached: set dev-macbre-plpoznan:page_touched:2_Macbre (STORED)

> echo $u->getTouched()
20170516115817
```