### PR TITLE
SUS-1954 | AbuseFilter - set an email to an empty string (instead of null)

### DIFF
--- a/extensions/AbuseFilter/AbuseFilter.hooks.php
+++ b/extensions/AbuseFilter/AbuseFilter.hooks.php
@@ -238,7 +238,7 @@ class AbuseFilterHooks {
 			} else {
 				// Sorry dude, we need this account.
 				$user->setPassword( null );
-				$user->setEmail( null );
+				$user->setEmail( '' );
 				$user->saveSettings();
 			}
 			$updater->insertUpdateRow( 'create abusefilter-blocker-user' );


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-1954

Otherwise `"SQL ERROR: Column 'user_email' cannot be null"` is raised when update.php is run