### PR TITLE
ST-310 - Handle Multi-Byte (MB) Query Strings better

### DIFF
--- a/extensions/wikia/LinkSuggest/LinkSuggest.class.php
+++ b/extensions/wikia/LinkSuggest/LinkSuggest.class.php
@@ -1,6 +1,6 @@
 <?php
 
-use \Wikia\Measurements\Time as T;
+use Wikia\Measurements\Time as T;
 
 /**
  * LinkSuggest main class
@@ -66,7 +66,8 @@ class LinkSuggest {
 			$key = wfMemcKey( __METHOD__, md5( $query.'_'.$request->getText('format').$request->getText('nospecial', '') ) );
 		}
 
-		if (strlen($query) < 3) {
+		// use mb_strlen to test string length accurately
+		if ( mb_strlen( $query ) < 3 ) {
 			// enforce minimum character limit on server side
 			$out = self::getEmptyResponse($request->getText('format'));
 		} else if ($cached = $wgMemc->get($key)) {
@@ -172,19 +173,42 @@ class LinkSuggest {
 			 * It uses fact that page titles can't start with lowercase letter.
 			 */
 			$pageTitlePrefilter = "";
-			if( strlen($queryLower) >= 2 ) {
-				$pageTitlePrefilter = "(
-							( convert(binary convert(page_title using latin1) using utf8) " . $db->buildLike(strtoupper($queryLower[0]) . strtolower($queryLower[1]) , $db->anyString() ) . " ) OR
-							( convert(binary convert(page_title using latin1) using utf8) " . $db->buildLike(strtoupper($queryLower[0]) . strtoupper($queryLower[1]) , $db->anyString() ) . " ) ) AND ";
-			} else if( strlen($queryLower) >= 1 ) {
-				$pageTitlePrefilter = "( page_title " . $db->buildLike(strtoupper($queryLower[0]) , $db->anyString() ) . " ) AND ";
+
+			// use mb_substring to get the first & second chars
+			// in case of multi-byte
+			$firstChar = mb_substr($queryLower, 0, 1);
+			$secondChar = mb_substr($queryLower, 1, 1);
+
+			if( mb_strlen( $queryLower ) >= 2 ) {
+				if ( LinkSuggest::containsMultibyteCharacters( $firstChar . $secondChar ) ) {
+					$pageTitlePrefilter = "(
+						( convert(binary convert(page_title using latin1) using utf8) LIKE convert(binary convert('" . strtoupper( $firstChar ) . strtolower( $secondChar ) . "%' using latin1) using utf8)) ) OR
+						( convert(binary convert(page_title using latin1) using utf8) LIKE convert(binary convert('" . strtoupper( $firstChar ) . strtoupper( $secondChar )  . "%' using latin1) using utf8) ) AND ";
+				} else {
+					$pageTitlePrefilter = "(
+						( convert(binary convert(page_title using latin1) using utf8) " . $db->buildLike( strtoupper( $firstChar ) . strtolower( $secondChar ) , $db->anyString() ) . " ) OR
+						( convert(binary convert(page_title using latin1) using utf8) " . $db->buildLike( strtoupper( $firstChar ) . strtoupper( $secondChar ) , $db->anyString() ) . " ) ) AND ";
+				}
+			} else if( mb_strlen($queryLower) >= 1 ) {
+				if ( LinkSuggest::containsMultibyteCharacters( $firstChar ) ) {
+					$pageTitlePrefilter = "( convert(binary convert(page_title using latin1) using utf8) LIKE convert(binary convert('" . $firstChar . "'% ) AND ";
+				} else {
+					$pageTitlePrefilter = "( convert(binary convert(page_title using latin1) using utf8) " . $db->buildLike(strtoupper( $firstChar ) , $db->anyString() ) . " ) AND ";
+				}
 			}
+
+			if ( LinkSuggest::containsMultibyteCharacters( $queryLower ) ) {
+				$pageTitleLikeClause = "convert(binary convert('{$queryLower}%' using latin1) using utf8)";
+			} else {
+				$pageTitleLikeClause = "'{$queryLower}%'";
+			}
+
 			// TODO: use $db->select helper method
 			$sql = "SELECT page_len, page_id, page_title, rd_title, page_namespace, rd_namespace, page_is_redirect
 						FROM page
 						LEFT JOIN redirect ON page_is_redirect = 1 AND page_id = rd_from
 						LEFT JOIN querycache ON qc_title = page_title AND qc_type = 'BrokenRedirects'
-						WHERE  {$pageTitlePrefilter} {$pageNamespaceClause} (convert(binary convert(page_title using latin1) using utf8) LIKE convert(binary convert('{$queryLower}%' using latin1) using utf8))
+						WHERE  {$pageTitlePrefilter} {$pageNamespaceClause} (convert(binary convert(page_title using latin1) using utf8) LIKE {$pageTitleLikeClause} )
 							AND qc_type IS NULL
 						LIMIT ".($wgLinkSuggestLimit * 3); // we fetch 3 times more results to leave out redirects to the same page
 
@@ -275,6 +299,17 @@ class LinkSuggest {
 
 		wfProfileOut(__METHOD__);
 		return $out;
+	}
+
+	/**
+	 * helper function to determine if given string contains multibyte characters
+	 *
+	 * @param String $string
+	 *
+	 * @return bool
+	 */
+	static function containsMultibyteCharacters( $string ) {
+		return mb_strlen ( $string ) != strlen( $string );
 	}
 
 	/**

--- a/extensions/wikia/LinkSuggest/LinkSuggest.class.php
+++ b/extensions/wikia/LinkSuggest/LinkSuggest.class.php
@@ -182,8 +182,8 @@ class LinkSuggest {
 			if( mb_strlen( $queryLower ) >= 2 ) {
 				if ( LinkSuggest::containsMultibyteCharacters( $firstChar . $secondChar ) ) {
 					$pageTitlePrefilter = "(
-						( convert(binary convert(page_title using latin1) using utf8) LIKE convert(binary convert('" . strtoupper( $firstChar ) . strtolower( $secondChar ) . "%' using latin1) using utf8)) ) OR
-						( convert(binary convert(page_title using latin1) using utf8) LIKE convert(binary convert('" . strtoupper( $firstChar ) . strtoupper( $secondChar )  . "%' using latin1) using utf8) ) AND ";
+						( convert(binary convert(page_title using latin1) using utf8) LIKE convert(binary '" . strtoupper( $firstChar ) . strtolower( $secondChar ) . "%' using utf8)) ) OR
+						( convert(binary convert(page_title using latin1) using utf8) LIKE convert(binary '" . strtoupper( $firstChar ) . strtoupper( $secondChar )  . "%' using utf8) ) AND ";
 				} else {
 					$pageTitlePrefilter = "(
 						( convert(binary convert(page_title using latin1) using utf8) " . $db->buildLike( strtoupper( $firstChar ) . strtolower( $secondChar ) , $db->anyString() ) . " ) OR
@@ -191,14 +191,14 @@ class LinkSuggest {
 				}
 			} else if( mb_strlen($queryLower) >= 1 ) {
 				if ( LinkSuggest::containsMultibyteCharacters( $firstChar ) ) {
-					$pageTitlePrefilter = "( convert(binary convert(page_title using latin1) using utf8) LIKE convert(binary convert('" . $firstChar . "%' using latin1) using utf8) ) AND ";
+					$pageTitlePrefilter = "( convert(binary convert(page_title using latin1) using utf8) LIKE convert(binary '" . $firstChar . "%' using utf8) ) AND ";
 				} else {
 					$pageTitlePrefilter = "( convert(binary convert(page_title using latin1) using utf8) " . $db->buildLike(strtoupper( $firstChar ) , $db->anyString() ) . " ) AND ";
 				}
 			}
 
 			if ( LinkSuggest::containsMultibyteCharacters( $queryLower ) ) {
-				$pageTitleLikeClause = "convert(binary convert('{$queryLower}%' using latin1) using utf8)";
+				$pageTitleLikeClause = "convert(binary '{$queryLower}%' using utf8)";
 			} else {
 				$pageTitleLikeClause = "'{$queryLower}%'";
 			}

--- a/extensions/wikia/LinkSuggest/LinkSuggest.class.php
+++ b/extensions/wikia/LinkSuggest/LinkSuggest.class.php
@@ -191,7 +191,7 @@ class LinkSuggest {
 				}
 			} else if( mb_strlen($queryLower) >= 1 ) {
 				if ( LinkSuggest::containsMultibyteCharacters( $firstChar ) ) {
-					$pageTitlePrefilter = "( convert(binary convert(page_title using latin1) using utf8) LIKE convert(binary convert('" . $firstChar . "'% ) AND ";
+					$pageTitlePrefilter = "( convert(binary convert(page_title using latin1) using utf8) LIKE convert(binary convert('" . $firstChar . "%' using latin1) using utf8) ) AND ";
 				} else {
 					$pageTitlePrefilter = "( convert(binary convert(page_title using latin1) using utf8) " . $db->buildLike(strtoupper( $firstChar ) , $db->anyString() ) . " ) AND ";
 				}


### PR DESCRIPTION
Multibyte characters cause problems with the non mb_* string utilities which causes the SQL passed to be incorrect.

Use the mb_* versions of the string utilities to get accurate string
length and substrings.

Have two versions of the query depending on if MB chars are detected in the
query string.

/cc
@garthwebb 