### PR TITLE
CAKE-1694 If title's partial url is empty redirect to Home

### DIFF
--- a/extensions/wikia/ContributionPrototype/CPArticleRenderer.php
+++ b/extensions/wikia/ContributionPrototype/CPArticleRenderer.php
@@ -52,6 +52,10 @@ class CPArticleRenderer {
 	 * @param OutputPage $output
 	 */
 	public function render(Title $title, OutputPage $output, $action='view') {
+		if ( $title->getPartialURL() == '' ) {
+			$output->redirect( '/wiki/Home' );
+		}
+
 		$output->setPageTitle($title->getPrefixedText());
 		$content = $this->getArticleContent($title->getPartialURL(), $action);
 		


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CAKE-1694

In the contribution prototype renderer, if the location is '/' then the title's partial URL will be empty. In that case we know we are in the wrong place so redirect the client to '/wiki/Home'. In this instance the redirect (302) will happen before anything is rendered which is what we want.

@Wikia/cake 