### PR TITLE
Ser-959 In context translations

### DIFF
--- a/includes/DefaultSettings.php
+++ b/includes/DefaultSettings.php
@@ -1893,6 +1893,7 @@ $wgDummyLanguageCodes = array(
 	'be-x-old' => 'be-tarask',
 	'bh' => 'bho',
 	'fiu-vro' => 'vro',
+	'lol' => 'lol', # Used for In Context Translations
 	'no' => 'nb',
 	'qqq' => 'qqq', # Used for message documentation.
 	'qqx' => 'qqx', # Used for viewing message keys.

--- a/languages/messages/MessagesLol.php
+++ b/languages/messages/MessagesLol.php
@@ -1,0 +1,8 @@
+<?php
+/** Lol - Dummy lang for in context translations
+ *
+ * @ingroup Language
+ * @file
+ *
+ * @author JCellary
+ */

--- a/skins/oasis/modules/templates/Body_Index.php
+++ b/skins/oasis/modules/templates/Body_Index.php
@@ -7,6 +7,14 @@
 /** @var $isEditPage bool */
 ?>
 
+<? if ( !empty( $wg->InContextTranslationsProject ) ): ?>
+	<script type="text/javascript">
+		var _jipt = [];
+		_jipt.push(['project', '<?= $wg->InContextTranslationsProject ?>' ]);
+	</script>
+	<script type="text/javascript" src="//cdn.crowdin.com/jipt/jipt.js"></script>
+<? endif; ?>
+
 <? if ( $displayHeader ): ?>
 	<h2><?= wfMessage( 'oasis-global-page-header' )->escaped(); ?></h2>
 <? endif; ?>

--- a/skins/oasis/modules/templates/Body_Index.php
+++ b/skins/oasis/modules/templates/Body_Index.php
@@ -9,8 +9,7 @@
 
 <? if ( !empty( $wg->InContextTranslationsProject ) ): ?>
 	<script type="text/javascript">
-		var _jipt = [];
-		_jipt.push(['project', '<?= $wg->InContextTranslationsProject ?>' ]);
+		var _jipt = [['project', '<?= addslashes($wg->InContextTranslationsProject) ?>' ]];
 	</script>
 	<script type="text/javascript" src="//cdn.crowdin.com/jipt/jipt.js"></script>
 <? endif; ?>


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SER-959

Added extra dummy language "lol" to dev and sandbox environments. It will be used on sandbox-i18n-XX machines to perform in context translations. Translators will choose it as their default language in their user preferences and then edit translations on page. Normal users on production will not be able to see/select it.

Also added a script from crowdin: https://crowdin.com/project/ext-wikia-Contact/settings#in-context which controls in context translations. I'm not sure if Body_Index.php is the best place to put it, so I'm open to suggestions :) Bare in mind however, that the $wg->InContextTranslationsProject variable will only ever be set on the i18n sandboxes, so this part will never be on our production environment.

Setting of crowdin project on a visual qa sandbox will be done by a jenkins job running a script added in https://github.com/Wikia/chef-repo/pull/13650

Connected to https://github.com/Wikia/config/pull/2114 and https://github.com/Wikia/chef-repo/pull/13650

@macbre @Grunny 