### PR TITLE
SUS-1854: remove "mainpage" translation for "no" language

### DIFF
--- a/extensions/GlobalMessages/GlobalMessagesM.i18n.php
+++ b/extensions/GlobalMessages/GlobalMessagesM.i18n.php
@@ -24445,7 +24445,6 @@ $messages['no'] = [
 	'moredotdotdot' => 'Meir …',
 	'mypage' => 'Sida mi',
 	'mytalk' => 'Diskusjonssida mi',
-	'mainpage' => 'Hovudside',
 	'mainpage-description' => 'Hovudside',
 	'missing-article' => 'Databasen burde ha funne sida «$1» $2, men det gjorde han ikkje.
 


### PR DESCRIPTION
"no" should act as an alias for Bokmål (nb) - let's simply remove translation and allow fallback to be applied

https://wikia-inc.atlassian.net/browse/SUS-1854