### PR TITLE
SUS-1900 | ResourceLoader: Serve exceptions with a proper HTTP error code

### DIFF
--- a/includes/libs/HttpStatus.php
+++ b/includes/libs/HttpStatus.php
@@ -5,13 +5,10 @@
 class HttpStatus {
 
 	/**
-	 * Get the message associed with the HTTP response code $code
+	 * Get the message associated with an HTTP response status code
 	 *
-	 * Replace OutputPage::getStatusMessage( $code )
-	 *
-	 * @param $code Integer: status code
-	 * @return String or null: message or null if $code is not in the list of
-	 *         messages
+	 * @param int $code Status code
+	 * @return string|null Message, or null if $code is not known
 	 */
 	public static function getMessage( $code ) {
 		static $statusMessage = array(
@@ -65,4 +62,26 @@ class HttpStatus {
 		return isset( $statusMessage[$code] ) ? $statusMessage[$code] : null;
 	}
 
+	/**
+	 * Output an HTTP status code header
+	 *
+	 * @since 1.26
+	 * @param int $code Status code
+	 * @return bool
+	 */
+	public static function header( $code ) {
+		static $version = null;
+		$message = self::getMessage( $code );
+		if ( $message === null ) {
+			trigger_error( "Unknown HTTP status code $code", E_USER_WARNING );
+			return false;
+		}
+
+		if ( $version === null ) {
+			$version = isset( $_SERVER['SERVER_PROTOCOL'] ) && $_SERVER['SERVER_PROTOCOL'] === 'HTTP/1.0' ? '1.0' : '1.1';
+		}
+
+		header( "HTTP/$version $code $message" );
+		return true;
+	}
 }

--- a/includes/resourceloader/ResourceLoader.php
+++ b/includes/resourceloader/ResourceLoader.php
@@ -519,7 +519,9 @@ class ResourceLoader {
 		wfProfileOut( __METHOD__.'-getModifiedTime' );
 
 		// Send content type and cache related headers
-		$this->sendResponseHeaders( $context, $mtime );
+		if ( $errors === '' ) {
+			$this->sendResponseHeaders($context, $mtime);
+		}
 
 		// If there's an If-Modified-Since header, respond with a 304 appropriately
 		if ( $this->tryRespondLastModified( $context, $mtime ) ) {

--- a/includes/resourceloader/ResourceLoader.php
+++ b/includes/resourceloader/ResourceLoader.php
@@ -723,6 +723,11 @@ class ResourceLoader {
 			'exception' => $e
 		] );
 
+		// SUS-1900: emit a proper HTTP error code indicating that something went wrong
+		HttpStatus::header( 500 );
+		header( "X-MediaWiki-Exception: 1" );
+		header( "Content-Type: text/plain; charset=utf-8" );
+
 		if ( $wgShowExceptionDetails ) {
 			return $this->makeComment( $e->__toString() );
 		} else {


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-1900

* serve responses with exception reports with `HTTP 500` response code and set `X-MediaWiki-Exception` header (be consistent with `index.php` MediaWiki responses with exception report)
* [backport MW change](https://github.com/wikimedia/mediawiki/commit/7b835dd12649b7c474d4c9f42875a8a2b23eb032) - introduce `HttpStats::header` method