### PR TITLE
IRIS-4440 - rename logo images for email

### DIFF
--- a/extensions/wikia/Email/EmailImageHelper.class.php
+++ b/extensions/wikia/Email/EmailImageHelper.class.php
@@ -18,11 +18,11 @@ class ImageHelper {
 			'extension' => 'png'
 		],
 		'FandomLogoHeader' => [
-			'name' => 'Hero-Logo-2x',
+			'name' => 'Hero-Logo-v3',
 			'extension' => 'png'
 		],
 		'FandomLogoFooter' => [
-			'name' => 'Footer-logo-2x',
+			'name' => 'Footer-logo-v3',
 			'extension' => 'png'
 		],
 		'Wikia' => [


### PR DESCRIPTION
In order to get the new logo in transactional emails we need to rename uploaded files, not only in Wikia Newsletter but also in the code.