### PR TITLE
SUS-2147 | expire-ipblocks script refactoring

### DIFF
--- a/includes/Block.php
+++ b/includes/Block.php
@@ -963,10 +963,16 @@ class Block {
 	 * Purge expired blocks from the ipblocks table
 	 */
 	public static function purgeExpired() {
+		global $wgCityId;
+
 		if ( !wfReadOnly() ) {
-			$dbw = wfGetDB( DB_MASTER );
-			$dbw->delete( 'ipblocks',
-				array( 'ipb_expiry < ' . $dbw->addQuotes( $dbw->timestamp() ) ), __METHOD__ );
+			// Wikia change - begin
+			// @see SUS-2147
+			$task = new Wikia\Tasks\Tasks\BlockPurgeExpiredTask();
+			$task->wikiId( $wgCityId );
+			$task->call( 'purgeExpired' );
+			$task->queue();
+			// Wikia change - end
 		}
 	}
 

--- a/includes/wikia/tasks/Tasks/BlockPurgeExpiredTask.class.php
+++ b/includes/wikia/tasks/Tasks/BlockPurgeExpiredTask.class.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * An offline version of Block::purgeExpired method
+ *
+ * @see SUS-2147
+ */
+
+namespace Wikia\Tasks\Tasks;
+
+class BlockPurgeExpiredTask extends BaseTask {
+
+	/**
+	 * Purge expired blocks from the ipblocks table
+	 *
+	 * @return bool
+	 */
+	public function purgeExpired() {
+		if ( !wfReadOnly() ) {
+			$dbw = wfGetDB( DB_MASTER );
+			$dbw->delete( 'ipblocks',
+				array( 'ipb_expiry < ' . $dbw->addQuotes( $dbw->timestamp() ) ), __METHOD__ );
+
+			$this->info( __METHOD__, [
+				'num_rows' => (int) $dbw->affectedRows()
+			] );
+		}
+		return true;
+	}
+}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-2147

Introduce `Wikia\Tasks\Tasks\BlockPurgeExpiredTask::purgeExpired()` Celery task to handle expired IP blocks deletes in MediaWiki app.

This task will be scheduled every time `Block::purgeExpired()` method is called - delete will be handled offline instead of during the end-user request.

This change allows us to get rid of [`expire-ipblocks`](https://github.com/Wikia/backend/blob/c33db19fb011508549d1bd28d6c9935cd1b41e7e/bin/expire-ipblocks) backend script (from 2012) that scans ALL public wikis every 20 minutes (resulting in ~25 mm of `USE` queries daily and just handful of `DELETE` queries).