### PR TITLE
SUS-2050 | CategoryViewer: use CategoryRefreshCountsTask

### DIFF
--- a/includes/Category.php
+++ b/includes/Category.php
@@ -81,9 +81,9 @@ class Category {
 	/**
 	 * Factory function.
 	 *
-	 * @param $name Array: A category name (no "Category:" prefix).  It need
+	 * @param $name string: A category name (no "Category:" prefix).  It need
 	 *   not be normalized, with spaces replaced by underscores.
-	 * @return mixed Category, or false on a totally invalid name
+	 * @return self|false Category, or false on a totally invalid name
 	 */
 	public static function newFromName( $name ) {
 		$cat = new self();

--- a/includes/CategoryViewer.php
+++ b/includes/CategoryViewer.php
@@ -699,7 +699,16 @@ class CategoryViewer extends ContextSource {
 			# to refresh the incorrect category table entry -- which should be
 			# quick due to the small number of entries.
 			$totalcnt = $rescnt;
-			$this->cat->refreshCounts();
+
+			// Wikia change - begin
+			// @see SUS-2050
+			global $wgCityId;
+
+			$task = new \Wikia\Tasks\Tasks\CategoryRefreshCountsTask();
+			$task->wikiId( $wgCityId );
+			$task->call( 'refresh', $this->cat->getName() );
+			$task->queue();
+			// Wikia change - end
 		} else {
 			# Case 3: hopeless.  Don't give a total count at all.
 			return wfMessage( "category-$type-count-limited" )->numParams( $rescnt )->parseAsBlock();

--- a/includes/wikia/tasks/Tasks/CategoryRefreshCountsTask.class.php
+++ b/includes/wikia/tasks/Tasks/CategoryRefreshCountsTask.class.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Wikia\Tasks\Tasks;
+
+class CategoryRefreshCountsTask extends BaseTask {
+
+	/**
+	 * Refresh the counts for a given category
+	 *
+	 * An offline version of Category::refreshCounts
+	 *
+	 * @see SUS-2050
+	 *
+	 * @param string $categoryName
+	 * @return bool
+	 */
+	public function refresh( string $categoryName ) {
+		$category = \Category::newFromName( $categoryName );
+		return $category->refreshCounts();
+	}
+
+}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-2050

Move heavy queries (and prone to database deadlocks) from `Category::refreshCounts` to an offline task.