### PR TITLE
SUS-1625 | ignore warnings reported by "identify" binary and focus on errors

### DIFF
--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -1982,7 +1982,15 @@ class Wikia {
 		$output = wfShellExec("identify -regard-warnings {$imageFile} 2>&1", $retVal);
 		wfDebug("Exit code #{$retVal}\n{$output}\n");
 
-		$isValid = ($retVal === 0);
+		/**
+		 * Let's ignore warnings reported by "identify" binary and focus on errors, examples:
+		 *
+		 * identify: Ignoring attempt to set negative chromaticity value `/tmp/Gree.png' @ warning/png.c/MagickPNGWarningHandler/1671.
+		 * identify.im6: no decode delegate for this image format `/tmp/UploadTestExwn06' @ error/constitute.c/ReadImage/544.
+		 *
+		 * @see SUS-1625
+		 */
+		$isValid = strpos( $output, ' @ error/' ) === false; /* no errors reported */
 
 		if (!$isValid) {
 			Wikia\Logger\WikiaLogger::instance()->warning( __METHOD__ . ' failed', [

--- a/includes/wikia/tests/UploadVerifyFileTest.php
+++ b/includes/wikia/tests/UploadVerifyFileTest.php
@@ -48,6 +48,7 @@ class UploadVerifyFile extends WikiaBaseTest {
 				'uploadContent' => base64_decode('R0lGODlhAQABAIABAAAAAP///yH5BAEAAAEALAAAAAABAAEAQAICTAEAOw%3D%3D'), // blank 1x1 gif
 			),
 			// invalid image
+			// identify.im6: no decode delegate for this image format `/tmp/UploadTestBUg4ue' @ error/constitute.c/ReadImage/544
 			array(
 				'mime' => 'image/gif',
 				'expectedReturnVal' => false,


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-1625

## Examples

```
identify.im6: no decode delegate for this image format `/tmp/UploadTestExwn06' @ error/constitute.c/ReadImage/544.
identify: Ignoring attempt to set negative chromaticity value `/tmp/Gree.png' @ warning/png.c/MagickPNGWarningHandler/1671.
```

Out of 80 failed validations in the last 24h, only 28 were the actual decoding errors (the first case). The rest was perfectly fine.