### PR TITLE
SUS-1397 | Shared images: if source community is removed, it breaks destination communities, needs fallback

### DIFF
--- a/includes/filerepo/RepoGroup.php
+++ b/includes/filerepo/RepoGroup.php
@@ -159,7 +159,22 @@ class RepoGroup {
 
 		# Check the foreign repos
 		foreach ( $this->foreignRepos as $repo ) {
-			$image = $repo->findFile( $title, $options );
+
+			// Wikia change - begin
+			$image = false;
+
+			try {
+				$image = $repo->findFile( $title, $options );
+			}
+			catch( DBError $e ) {
+				// gracefully handle "Unknown database 'foobar'" errors (SUS-1397)
+				\Wikia\Logger\WikiaLogger::instance()->error( __METHOD__, [
+					'exception' => $e,
+					'repo_name' => $repo->getName()
+				] );
+			}
+			// Wikia change - end
+
 			if ( $image ) {
 				/* Wikia changes begin */
 				// check if the foreign repo allows local repo file blocking


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-1397

Catch `DBError` exceptions when trying to connect to `ForeignDBViaLBRepo`