### PR TITLE
PLATFORM-3070: fixing problem when MW returns too long HTTP header

### DIFF
--- a/includes/WebResponse.php
+++ b/includes/WebResponse.php
@@ -27,7 +27,8 @@
  */
 class WebResponse implements \Wikia\HTTP\Response {
 
-	const NO_COOKIE_PREFIX = '';
+	const NO_COOKIE_PREFIX  = '';
+	const MAX_HEADER_LENGTH = 4096;
 
 	/**
 	 * Output a HTTP header, wrapper for PHP's
@@ -37,6 +38,11 @@ class WebResponse implements \Wikia\HTTP\Response {
 	 * @param $http_response_code null|int Forces the HTTP response code to the specified value.
 	 */
 	public function header( $string, $replace = true, $http_response_code = null ) {
+		// PLATFORM-3070: In case of extremely long headers we should trim them to avoid problems with Fastly or other clients
+		if ( strlen( $string ) > self::MAX_HEADER_LENGTH ) {
+			$string = substr( $string, 0, self::MAX_HEADER_LENGTH );
+		}
+
 		header( $string, $replace, $http_response_code );
 	}
 


### PR DESCRIPTION
When adding headers we should at least make sure we do not exceed 4kB length which is sane value for a header. Too long headers will make Fastly unhappy and return 5xx errors to the client.

ping: @macbre @Wikia/core-platform-team 