### PR TITLE
Decouple test context logging from WikiaBaseTest

### DIFF
--- a/includes/wikia/tests/core/WikiaBaseTest.class.php
+++ b/includes/wikia/tests/core/WikiaBaseTest.class.php
@@ -43,40 +43,7 @@ abstract class WikiaBaseTest extends TestCase {
 	private $mockProxy = null;
 	private $mockMessageCacheGet = null;
 
-	private static $testRunTime = 0;
 	private static $numberSlowTests = 0;
-
-	/**
-	 * Print out currently run test
-	 */
-	public static function setUpBeforeClass() {
-		global $wgAnnotateTestSpeed;
-
-		error_reporting(E_ALL);
-		$testClass = get_called_class();
-		echo "\nRunning '{$testClass}'...";
-
-		self::$testRunTime = microtime( true );
-		self::$numberSlowTests = 0;
-
-		if ($wgAnnotateTestSpeed) {
-			WikiaTestSpeedAnnotator::initialize();
-		}
-	}
-
-	/**
-	 * Print out time it took to run all tests from current test class
-	 */
-	public static function tearDownAfterClass() {
-		global $wgAnnotateTestSpeed;
-
-		$time = round( ( microtime( true ) - self::$testRunTime ) * 1000, 2 );
-		echo "done in {$time} ms [" . self::$numberSlowTests . ' slow tests]';
-
-		if ($wgAnnotateTestSpeed) {
-			WikiaTestSpeedAnnotator::execute();
-		}
-	}
 
 	protected function setUp() {
 		$this->startTime = microtime(true);
@@ -500,29 +467,6 @@ abstract class WikiaBaseTest extends TestCase {
 		}
 
 		return $this->callOriginalMethod( MessageCache::singleton(), 'get', func_get_args() );
-	}
-
-	/**
-	 * Mark this test as skipped. Puts extra information in the logs.
-	 *
-	 * @param string $message
-	 */
-	public static function markTestSkipped($message = '') {
-		$backtrace = wfDebugBacktrace(3);
-		$entry = $backtrace[1];
-
-		Wikia::log(wfFormatStackFrame($entry), false, "marked as skipped - $message");
-        parent::markTestSkipped($message);
-    }
-
-	/**
-	 * Mark this test as incomplete. Puts extra information in the logs.
-	 *
-	 * @param string $message
-	 */
-	public static function markTestIncomplete($message = '') {
-		Wikia::log(__METHOD__, '', $message);
-		parent::markTestIncomplete($message);
 	}
 
 	/**

--- a/tests/WikiaTestContextPrinter.php
+++ b/tests/WikiaTestContextPrinter.php
@@ -1,0 +1,100 @@
+<?php
+
+use PHPUnit\Framework\BaseTestListener;
+use PHPUnit\Framework\Test;
+use PHPUnit\Framework\TestSuite;
+
+class WikiaTestContextPrinter extends BaseTestListener {
+	/** @var string $currentTestSuiteName */
+	private $currentTestSuiteName;
+
+	/** @var int $testCount */
+	private $testCount = 0;
+
+	/** @var int $skippedTestCount */
+	private $skippedTestCount;
+
+	/** @var int $incompleteTestCount */
+	private $incompleteTestCount;
+
+	/** @var int $executionTime */
+	private $executionTime = 0;
+
+	/**
+	 * If the new test suite is a test class, reset statistics and output class name info.
+	 *
+	 * @param TestSuite $testSuite
+	 */
+	public function startTestSuite( TestSuite $testSuite ) {
+		$testSuiteName = $testSuite->getName();
+		$tryAutoloadClass = false;
+
+		// Generic test suites cannot be mapped to classes
+		if ( class_exists( $testSuiteName, $tryAutoloadClass ) ) {
+			echo "\nRunning $testSuiteName ";
+
+			$this->currentTestSuiteName = $testSuiteName;
+
+			$this->testCount = 0;
+			$this->skippedTestCount = 0;
+			$this->incompleteTestCount = 0;
+			$this->executionTime = 0;
+		}
+	}
+
+	/**
+	 * Increment the count of tests in the current test class.
+	 *
+	 * @param Test $test
+	 */
+	public function startTest( Test $test ) {
+		$this->testCount++;
+	}
+
+	/**
+	 * Increment the count of incomplete tests in the current test class.
+	 *
+	 * @param Test $test
+	 * @param Exception $e
+	 * @param float $time
+	 */
+	public function addIncompleteTest( Test $test, Exception $e, $time ) {
+		$this->incompleteTestCount++;
+	}
+
+	/**
+	 * Increment the count of skipped tests in the current test class.
+	 *
+	 * @param Test $test
+	 * @param Exception $e
+	 * @param float $time
+	 */
+	public function addSkippedTest( Test $test, Exception $e, $time ) {
+		$this->skippedTestCount++;
+	}
+
+	public function endTest( Test $test, $time ) {
+		$this->executionTime += $time;
+	}
+
+	/**
+	 * Output execution time and test statistics for the test class that finished execution.
+	 *
+	 * @param TestSuite $testSuite
+	 */
+	public function endTestSuite( TestSuite $testSuite ) {
+		if ( $testSuite->getName() === $this->currentTestSuiteName ) {
+			// Convert execution time to milliseconds from seconds
+			$this->executionTime *= 1000;
+
+			echo
+				sprintf(
+				'done in %.2f ms [%d tests/%d skipped/%d incomplete]',
+					$this->executionTime,
+					$this->testCount,
+					$this->skippedTestCount,
+					$this->incompleteTestCount
+				);
+		}
+	}
+}

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,75 +1,52 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="bootstrap.php"
-		 backupGlobals="false"
-		 backupStaticAttributes="false"
-		 colors="false"
-		 convertErrorsToExceptions="true"
-		 convertNoticesToExceptions="true"
-		 convertWarningsToExceptions="true"
-		 stopOnFailure="false"
-		 syntaxCheck="true"
-		 processIsolation="false">
-	<testsuite name="Wikia Test Suite">
-		<directory>./unit/</directory>
-	</testsuite>
-	<testsuite name="Wikia Lib Test Suite">
-		<directory>../lib/Wikia/tests/</directory>
-	</testsuite>
-	<testsuite name="Wikia Includes Test Suite">
-		<directory>../includes/wikia/</directory>
-	</testsuite>
-	<testsuite name="Wikia ResourceLoader Test Suite">
-		<directory>../includes/resourceloader/wikia/</directory>
-	</testsuite>
-	<testsuite name="Wikia Extensions Test Suite">
-		<directory>../extensions/wikia/</directory>
-		<exclude>../extensions/wikia/SemanticMediaWiki/</exclude>
-	</testsuite>
-	<testsuite name="Wikia Maintenance Test Suite">
-		<directory>../maintenance/wikia/tests/</directory>
-	</testsuite>
-	<testsuite name="Wikia Search Test Suite">
-		<directory>../extensions/wikia/Search/classes/Test</directory>
-		<directory>../extensions/wikia/GameGuides/tests/GameGuidesModelTest.php</directory>
-		<directory>../extensions/w3rdparty/LyricWiki/tests/ServerTest.php</directory>
-	</testsuite>
-	<testsuite name="LyricFind Test Suite">
-		<directory>../extensions/3rdparty/LyricWiki/LyricFind/tests/</directory>
-	</testsuite>
-	<!-- DO NOT run MW tests. These tests are dropping db tables, including users -->
-	<!--
-	 <testsuite name="MediaWiki Test Suite">
-		<directory>../maintenance/tests/</directory>
-	 </testsuite>
-	 -->
+<phpunit
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.1/phpunit.xsd"
+		bootstrap="bootstrap.php"
+		backupGlobals="false"
+		backupStaticAttributes="false"
+		colors="true"
+		convertErrorsToExceptions="true"
+		convertNoticesToExceptions="true"
+		convertWarningsToExceptions="true"
+		stopOnFailure="false"
+		processIsolation="false">
+	<testsuites>
+		<testsuite name="Wikia Test Suite">
+			<directory>./unit/</directory>
+		</testsuite>
+		<testsuite name="Wikia Lib Test Suite">
+			<directory>../lib/Wikia/tests/</directory>
+		</testsuite>
+		<testsuite name="Wikia Includes Test Suite">
+			<directory>../includes/wikia/</directory>
+		</testsuite>
+		<testsuite name="Wikia ResourceLoader Test Suite">
+			<directory>../includes/resourceloader/wikia/</directory>
+		</testsuite>
+		<testsuite name="Wikia Extensions Test Suite">
+			<directory>../extensions/wikia/</directory>
+			<exclude>../extensions/wikia/SemanticMediaWiki/</exclude>
+		</testsuite>
+		<testsuite name="Wikia Maintenance Test Suite">
+			<directory>../maintenance/wikia/tests/</directory>
+		</testsuite>
+		<testsuite name="Wikia Search Test Suite">
+			<directory>../extensions/wikia/Search/classes/Test</directory>
+			<directory>../extensions/wikia/GameGuides/tests/GameGuidesModelTest.php</directory>
+			<directory>../extensions/w3rdparty/LyricWiki/tests/ServerTest.php</directory>
+		</testsuite>
+		<testsuite name="LyricFind Test Suite">
+			<directory>../extensions/3rdparty/LyricWiki/LyricFind/tests/</directory>
+		</testsuite>
+	</testsuites>
 	<groups>
 		<exclude>
 			<group>Broken</group>
 			<group>Stub</group>
 		</exclude>
 	</groups>
-	<filter>
-		<!-- Exclude the following from code coverage reports -->
-		<blacklist>
-			<directory>../bin</directory>
-			<directory>../config</directory>
-			<directory>../docs</directory>
-			<directory>../images</directory>
-			<directory>../languages</directory>
-			<directory>../lib/composer</directory>
-			<directory>../lib/vendor</directory>
-			<directory>../maintenance</directory>
-			<directory>../math</directory>
-			<directory>../resources</directory>
-			<directory>../serialized</directory>
-			<directory>../static</directory>
-			<directory>../t</directory>
-			<directory>../tests</directory>
-			<directory suffix=".i18n.php">../extensions</directory>
-			<directory suffix=".alias.php">../extensions</directory>
-			<directory suffix=".aliases.php">../extensions</directory>
-			<directory suffix=".setup.php">../extensions</directory>
-			<directory suffix="_setup.php">../extensions</directory>
-		</blacklist>
-	</filter>
+	<listeners>
+		<listener class="WikiaTestContextPrinter" file="WikiaTestContextPrinter.php" />
+	</listeners>
 </phpunit>


### PR DESCRIPTION
This allows us to log information about tests without having to extend `WikiaBaseTest` class - so we can directly extend `TestCase` if we don't need monkey patching.