### PR TITLE
SUS-1629 | Chat-live2 i18n message does not update

### DIFF
--- a/extensions/wikia/Chat2/ChatWidget.class.php
+++ b/extensions/wikia/Chat2/ChatWidget.class.php
@@ -71,6 +71,7 @@ class ChatWidget {
 		return [
 			'blankImgUrl' => $wgBlankImgUrl,
 			'buttonText' => wfMessage( $buttonMessage )->text(),
+			'chatLiveText' => wfMessage( 'chat-live2' )->text(),
 			'buttonIcon' => DesignSystemHelper::renderSvg( 'wds-icons-reply-tiny' ),
 			'guidelinesText' => $guidelinesText->exists() ? $guidelinesText->parse() : null,
 			'fromParserTag' => $fromParserTag,

--- a/extensions/wikia/Chat2/Chat_setup.php
+++ b/extensions/wikia/Chat2/Chat_setup.php
@@ -97,7 +97,6 @@ $wgResourceModules['ext.Chat2.ChatWidget'] = [
 		'chat-user-menu-message-wall',
 		'chat-user-menu-talk-page',
 		'chat-user-menu-contribs',
-		'chat-live2',
 		'chat-edit-count',
 		'chat-member-since',
 	],

--- a/extensions/wikia/Chat2/templates/widget.mustache
+++ b/extensions/wikia/Chat2/templates/widget.mustache
@@ -5,7 +5,7 @@
 		{{#hasUsers}} chat-room-active{{/hasUsers}}
 		{{^hasUsers}} chat-room-empty{{/hasUsers}}">
 		<h2 class="chat-headline">
-			<span class="chat-live" data-msg-id="chat-live2"></span>
+			<span class="chat-live">{{chatLiveText}}</span>
 		</h2>
 		<div class="chat-details">
 			<div class="avatars">

--- a/extensions/wikia/Chat2/tests/ChatWidgetTest.php
+++ b/extensions/wikia/Chat2/tests/ChatWidgetTest.php
@@ -124,6 +124,7 @@ class ChatWidgetTest extends WikiaBaseTest {
 					'viewedUsersInfo' => [ 'User1', 'User2' ],
 					'moreUsersCount' => null,
 					'hasUsers' => true,
+					'chatLiveText' => 'message',
 				]
 			],
 			'user from rail without message wall (null)' => [
@@ -146,6 +147,7 @@ class ChatWidgetTest extends WikiaBaseTest {
 					'viewedUsersInfo' => [ 'User1', 'User2' ],
 					'moreUsersCount' => null,
 					'hasUsers' => true,
+					'chatLiveText' => 'message',
 				]
 			],
 			'user from rail without message wall (false)' => [
@@ -168,6 +170,7 @@ class ChatWidgetTest extends WikiaBaseTest {
 					'viewedUsersInfo' => [ 'User1', 'User2' ],
 					'moreUsersCount' => null,
 					'hasUsers' => true,
+					'chatLiveText' => 'message',
 				]
 			],
 			'anon from parser tag with message wall' => [
@@ -196,6 +199,7 @@ class ChatWidgetTest extends WikiaBaseTest {
 					],
 					'moreUsersCount' => null,
 					'hasUsers' => false,
+					'chatLiveText' => 'message',
 				]
 			],
 			'anon from parser tag with no users' => [
@@ -224,6 +228,7 @@ class ChatWidgetTest extends WikiaBaseTest {
 					],
 					'moreUsersCount' => null,
 					'hasUsers' => false,
+					'chatLiveText' => 'message',
 				]
 			],
 			'user from parser tag with no users' => [
@@ -252,6 +257,7 @@ class ChatWidgetTest extends WikiaBaseTest {
 					],
 					'moreUsersCount' => null,
 					'hasUsers' => false,
+					'chatLiveText' => 'message',
 				]
 			]
 		];


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-1629

ChatWidget: pass `chatLiveText` to mustache template instead of relying on ResourceLoader messages. `chat-live2` was the only message used in this template that was filled by JS code.