### PR TITLE
ADEN-5160 | Featured Video: Disable ads on replay

### DIFF
--- a/extensions/wikia/ArticleVideo/scripts/ooyala-player.js
+++ b/extensions/wikia/ArticleVideo/scripts/ooyala-player.js
@@ -129,6 +129,7 @@ define('ooyala-player', function () {
 				],
 				useGoogleCountdown: true
 			};
+			params.replayAds = false;
 		}
 
 		html5Player = new OoyalaHTML5Player(document.getElementById(videoElementId), params, onCreate);


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/ADEN-5160

There is a bug in html5-skin that doesn't hide end screen on video replay when we provide vastUrl that doesn't have any ads targeted. As a short term fix we decided to disable ads on replay.