### PR TITLE
SUS-1594: AsyncTaskList - $wgUser might not yet be initialized, fallback to IP

### DIFF
--- a/includes/wikia/tasks/AsyncTaskList.class.php
+++ b/includes/wikia/tasks/AsyncTaskList.class.php
@@ -14,6 +14,7 @@ use PhpAmqpLib\Connection\AMQPConnection;
 use PhpAmqpLib\Message\AMQPMessage;
 use PhpAmqpLib\Exception\AMQPRuntimeException;
 use PhpAmqpLib\Exception\AMQPExceptionInterface;
+use User;
 use Wikia\Logger\WikiaLogger;
 use Wikia\Tasks\Queues\ParsoidPurgePriorityQueue;
 use Wikia\Tasks\Queues\ParsoidPurgeQueue;
@@ -284,12 +285,14 @@ class AsyncTaskList {
 	 * @throws AMQPExceptionInterface
 	 */
 	public function queue( AMQPChannel $channel = null, $priority = null ) {
-		global $wgUser;
-
 		$this->initializeWorkId();
 
 		if ( $this->createdBy == null ) {
-			$this->createdBy( $wgUser );
+			global $wgUser, $wgRequest;
+
+			// SUS-1594: $wgUser might not yet be initialized
+			$user = $wgUser ?? User::newFromName( $wgRequest->getIP() );
+			$this->createdBy( $user );
 		}
 
 		if ( is_string( $priority ) ) {


### PR DESCRIPTION
Background task added in https://github.com/Wikia/app/pull/12983 sometimes gets called before `$wgUser` global is initialized which breaks the task queue - provide a sane default for this scenario.

https://wikia-inc.atlassian.net/browse/SUS-1594