### PR TITLE
DE-2674 WAM - Added setting of current timestamp if out of range

### DIFF
--- a/extensions/wikia/WAM/controllers/api/WAMApiController.class.php
+++ b/extensions/wikia/WAM/controllers/api/WAMApiController.class.php
@@ -200,19 +200,22 @@ class WAMApiController extends WikiaApiController {
 			$options['currentTimestamp'] = $wamDates['max_date'];
 			$options['previousTimestamp'] = $options['currentTimestamp'] - 60 * 60 * 24;
 		} else {
-			if($options['currentTimestamp'] > $wamDates['max_date'] || $options['currentTimestamp'] < $wamDates['min_date']) {
+			if($options['currentTimestamp'] > $wamDates['max_date']) {
+				$options['currentTimestamp'] = $wamDates['max_date'];
 
-				if ( time() > $options['currentTimestamp'] ) {
-					// SUS-1235: let us know that something is wrong with WAM data
-					// and make sure that the requested date is not in The Future
-					$this->critical( __METHOD__ . " - current timestamp out of range", [
-						'wam_last_entry_date' => wfTimestamp( TS_DB, $wamDates['max_date'] ), // e.g. 2016-11-01 00:00:00
-						'wam_requested_entry_date' => wfTimestamp( TS_DB, $options['currentTimestamp'] ),
-						'exception' => new Exception(),
-					] );
-				}
+				$this->warning( __METHOD__ . " - current timestamp over maximum", [
+					'wam_last_entry_date' => wfTimestamp( TS_DB, $wamDates['max_date'] ), // e.g. 2016-11-01 00:00:00
+					'wam_requested_entry_date' => wfTimestamp( TS_DB, $options['currentTimestamp'] ),
+					'exception' => new Exception(),
+				] );
+			} else if($options['currentTimestamp'] < $wamDates['min_date']) {
+				$options['currentTimestamp'] = $wamDates['min_date'];
 
-				throw new OutOfRangeApiException('currentTimestamp', $wamDates['min_date'], $wamDates['max_date']);
+				$this->warning( __METHOD__ . " - current timestamp below minimum", [
+					'wam_last_entry_date' => wfTimestamp( TS_DB, $wamDates['max_date'] ), // e.g. 2016-11-01 00:00:00
+					'wam_requested_entry_date' => wfTimestamp( TS_DB, $options['currentTimestamp'] ),
+					'exception' => new Exception(),
+				] );
 			}
 
 			if(empty($options['previousTimestamp'])) {

--- a/extensions/wikia/WAM/controllers/api/WAMApiController.class.php
+++ b/extensions/wikia/WAM/controllers/api/WAMApiController.class.php
@@ -212,7 +212,7 @@ class WAMApiController extends WikiaApiController {
 				$options['currentTimestamp'] = $wamDates['min_date'];
 
 				$this->warning( __METHOD__ . " - current timestamp below minimum", [
-					'wam_last_entry_date' => wfTimestamp( TS_DB, $wamDates['max_date'] ), // e.g. 2016-11-01 00:00:00
+					'wam_first_entry_date' => wfTimestamp( TS_DB, $wamDates['min_date'] ), // e.g. 2016-11-01 00:00:00
 					'wam_requested_entry_date' => wfTimestamp( TS_DB, $options['currentTimestamp'] ),
 					'exception' => new Exception(),
 				] );


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/DE-2674

Simple fix to set the current display time stamp of WAM to max available date, when we're missing part of the data, to show what we have, instead of giving white page.