### PR TITLE
SUS-2178 | no need to pass $this by a reference

### DIFF
--- a/docs/hooks.txt
+++ b/docs/hooks.txt
@@ -211,9 +211,9 @@ related to a particular event, like so:
 		# ...
 		function protect() {
 			global $wgUser;
-			if (wfRunHooks('ArticleProtect', array(&$this, &$wgUser))) {
+			if (wfRunHooks('ArticleProtect', array($this, &$wgUser))) {
 				# protect the article
-				wfRunHooks('ArticleProtectComplete', array(&$this, &$wgUser));
+				wfRunHooks('ArticleProtectComplete', array($this, &$wgUser));
 			}
 		}
 	}

--- a/extensions/3rdparty/ArrayExtension/ArrayExtension.php
+++ b/extensions/3rdparty/ArrayExtension/ArrayExtension.php
@@ -142,7 +142,7 @@ class ArrayExtension {
 * http://us2.php.net/manual/en/book.pcre.php
 * see also: http://us2.php.net/manual/en/function.preg-split.php
 */
-    function arraydefine( &$parser, $arrayid, $value='', $delimiter = '/\s*,\s*/', $options = '') {
+    function arraydefine( $parser, $arrayid, $value='', $delimiter = '/\s*,\s*/', $options = '') {
         if (!isset($arrayid))
 	   return '';
 
@@ -206,7 +206,7 @@ class ArrayExtension {
 *    {{#arrayprint:b|<br/>|@@@|{{f.tag{{f.print.vbar}}prop{{f.print.vbar}}@@@}} }}   -- embed template function
 *    {{#arrayprint:b|<br/>|@@@|[[name::@@@]]}}   -- make SMW links
 */
-    function arrayprint( &$parser, $arrayid , $delimiter = ', ', $search='@@@@', $subject='@@@@', $frame=null) {
+    function arrayprint( $parser, $arrayid , $delimiter = ', ', $search='@@@@', $subject='@@@@', $frame=null) {
 	$ret = $this->validate_array_by_arrayid($arrayid);
 	if (true!==$ret){
 	   return $ret;
@@ -240,7 +240,7 @@ class ArrayExtension {
 * usage
 *   {{#arrayindex:arrayid|index}}
 */
-    function arrayindex( &$parser, $arrayid , $index , $options='') {
+    function arrayindex( $parser, $arrayid , $index , $options='') {
 	// now parse the options, and do posterior process on the created array
 	$ary_option = $this->parse_options($options);
 
@@ -265,7 +265,7 @@ class ArrayExtension {
 *
 *  See: http://www.php.net/manual/en/function.count.php
 */
-    function arraysize( &$parser, $arrayid) {
+    function arraysize( $parser, $arrayid) {
  	$ret = $this->validate_array_by_arrayid($arrayid);
 	if (true!==$ret){
 	   return '';
@@ -287,7 +287,7 @@ class ArrayExtension {
 *   See: http://www.php.net/manual/en/function.array-search.php
 *   note it is extended to support regular expression match and index
 */
-    function arraysearch( &$parser, $arrayid, $needle, $index=0, $yes=null, $no=null) {
+    function arraysearch( $parser, $arrayid, $needle, $index=0, $yes=null, $no=null) {
  	$ret = $this->validate_array_by_arrayid($arrayid);
 	if (true!==$ret){
 		$ret = -1;
@@ -355,7 +355,7 @@ class ArrayExtension {
 *    {{#arrayreset:}}
 *    {{#arrayreset:arrayid1,arrayid2,...arrayidn}}
 */
-   function arrayreset( &$parser, $arrayids) {
+   function arrayreset( $parser, $arrayids) {
         if (!$this->is_non_empty($arrayids)){
 	    //reset all
 	    $this->mArrayExtension = array();
@@ -380,7 +380,7 @@ class ArrayExtension {
 *
 *   see: http://www.php.net/manual/en/function.array-unique.php
 */
-    function arrayunique( &$parser, $arrayid ) {
+    function arrayunique( $parser, $arrayid ) {
 	$ret = $this->validate_array_by_arrayid($arrayid);
 	if (true!==$ret){
 	   return '';
@@ -411,7 +411,7 @@ class ArrayExtension {
 *          http://www.php.net/manual/en/function.shuffle.php
 *          http://us3.php.net/manual/en/function.array-reverse.php
 */
-    function arraysort( &$parser, $arrayid , $sort = 'none') {
+    function arraysort( $parser, $arrayid , $sort = 'none') {
 	$ret = $this->validate_array_by_arrayid($arrayid);
 	if (true!==$ret){
 	   return '';
@@ -442,7 +442,7 @@ class ArrayExtension {
 *  merge values two arrayes identified by arrayid1 and arrayid2 into a new array identified by arrayid_new.
 *  this merge differs from array_merge of php because it merges values.
 */
-    function arraymerge( &$parser, $arrayid_new, $arrayid1, $arrayid2='' ) {
+    function arraymerge( $parser, $arrayid_new, $arrayid1, $arrayid2='' ) {
         if (!isset($arrayid_new) )
 	   return '';
 
@@ -481,7 +481,7 @@ class ArrayExtension {
 *    extract a slice from an  array
 *    see: http://www.php.net/manual/en/function.array-slice.php
 */
-    function arrayslice( &$parser, $arrayid_new , $arrayid , $offset, $length='') {
+    function arrayslice( $parser, $arrayid_new , $arrayid , $offset, $length='') {
         if (!isset($arrayid_new) )
 	   return '';
 
@@ -519,7 +519,7 @@ class ArrayExtension {
 *    {{#arrayintersect:arrayid_new|arrayid1|arrayid2}}
 *   See: http://www.php.net/manual/en/function.array-intersect.php
 */
-    function arrayintersect( &$parser, $arrayid_new , $arrayid1 , $arrayid2 ) {
+    function arrayintersect( $parser, $arrayid_new , $arrayid1 , $arrayid2 ) {
         if (!isset($arrayid_new) )
 	   return '';
 
@@ -547,7 +547,7 @@ class ArrayExtension {
 *    similar to arraymerge, this union works on values.
 */
 
-    function arrayunion( &$parser, $arrayid_new , $arrayid1 , $arrayid2 ) {
+    function arrayunion( $parser, $arrayid_new , $arrayid1 , $arrayid2 ) {
         if (!isset($arrayid_new) )
 	   return '';
 
@@ -575,7 +575,7 @@ class ArrayExtension {
 *    see: http://www.php.net/manual/en/function.array-diff.php
 */
 
-    function arraydiff( &$parser, $arrayid_new , $arrayid1 , $arrayid2 ) {
+    function arraydiff( $parser, $arrayid_new , $arrayid1 , $arrayid2 ) {
         if (!isset($arrayid_new) )
 	   return '';
 

--- a/extensions/3rdparty/DynamicFunctions/DynamicFunctions.php
+++ b/extensions/3rdparty/DynamicFunctions/DynamicFunctions.php
@@ -66,7 +66,7 @@ class ExtDynamicFunctions
 	 * @param Parser $parser
 	 * @return bool
 	 */
-    function arg( &$parser, $name = '', $default = '' )
+    function arg( $parser, $name = '', $default = '' )
     {
         global $wgRequest;
         $parser->disableCache();
@@ -77,7 +77,7 @@ class ExtDynamicFunctions
 	 * @param Parser $parser
 	 * @return bool
 	 */
-    function ip( &$parser )
+    function ip( $parser )
     {
         $parser->disableCache();
         return wfGetIP();
@@ -87,7 +87,7 @@ class ExtDynamicFunctions
 	 * @param Parser $parser
 	 * @return bool
 	 */
-    function rand( &$parser, $a = 0, $b = 1 )
+    function rand( $parser, $a = 0, $b = 1 )
     {
         $parser->disableCache();
         return mt_rand( intval($a), intval($b) );
@@ -97,7 +97,7 @@ class ExtDynamicFunctions
 	 * @param Parser $parser
 	 * @return bool
 	 */
-    function skin( &$parser )
+    function skin( $parser )
     {
         global $wgUser, $wgRequest;
         $parser->disableCache();

--- a/extensions/3rdparty/HasCategory/HasCategory.php
+++ b/extensions/3rdparty/HasCategory/HasCategory.php
@@ -61,9 +61,9 @@ class ExtensionHasCategory {
 	function RegisterParser( &$parser ) {
 		if ( defined( get_class( $parser ) . '::SFH_OBJECT_ARGS' ) ) {
 			// These functions accept DOM-style arguments
-			$parser->setFunctionHook( 'ifhascat', array( &$this, 'IfhascatPfObj' ), SFH_OBJECT_ARGS );
+			$parser->setFunctionHook( 'ifhascat', array( $this, 'IfhascatPfObj' ), SFH_OBJECT_ARGS );
 		} else {
-			$parser->setFunctionHook( 'ifhascat', array( &$this, 'IfhascatPf' ) );
+			$parser->setFunctionHook( 'ifhascat', array( $this, 'IfhascatPf' ) );
 		}
 
 		return true;

--- a/extensions/3rdparty/HasCategory/HasCategory.php
+++ b/extensions/3rdparty/HasCategory/HasCategory.php
@@ -58,7 +58,7 @@ class ExtensionHasCategory {
 	 *
 	 * @param Parser $parser
 	 */
-	function RegisterParser( &$parser ) {
+	function RegisterParser( $parser ) {
 		if ( defined( get_class( $parser ) . '::SFH_OBJECT_ARGS' ) ) {
 			// These functions accept DOM-style arguments
 			$parser->setFunctionHook( 'ifhascat', array( $this, 'IfhascatPfObj' ), SFH_OBJECT_ARGS );
@@ -75,7 +75,7 @@ class ExtensionHasCategory {
 	 * @param Parser $parser
 	 * @param PPFrame $frame
 	 */
-	function IfhascatPfObj( &$parser, $frame, $args ) {
+	function IfhascatPfObj( $parser, $frame, $args ) {
 		$page     = isset($args[0]) ? trim($frame->expand($args[0])) : '';
 		$category = isset($args[1]) ? trim($frame->expand($args[1])) : '';
 		$then     = isset($args[2]) ? trim($frame->expand($args[2])) : '1';
@@ -94,7 +94,7 @@ class ExtensionHasCategory {
 	 * Here we find out whether the page is really contained in the category.
 	 * If yes return $then (default: 1) else return $else (default: 0).
 	 */
-	function IfhascatPf( &$parser, $page = '', $category = '', $then = '1', $else = '0' ) {
+	function IfhascatPf( $parser, $page = '', $category = '', $then = '1', $else = '0' ) {
 		// Connect to the database
 		$dbr = wfGetDB( DB_SLAVE );
 

--- a/extensions/3rdparty/LyricWiki/Gracenote/Tag_GracenoteLyrics.php
+++ b/extensions/3rdparty/LyricWiki/Gracenote/Tag_GracenoteLyrics.php
@@ -131,7 +131,7 @@ if(isset($wgScriptPath))
 }
 
 #Install extension
-function gracenoteLyricsTag( Parser &$parser)
+function gracenoteLyricsTag( Parser $parser)
 {
   #install hook on the element <gracenotelyrics>
   $parser->setHook("gracenotelyrics", "renderGracenoteLyricsTag");

--- a/extensions/3rdparty/LyricWiki/Parser_LWMagicWords.php
+++ b/extensions/3rdparty/LyricWiki/Parser_LWMagicWords.php
@@ -173,7 +173,7 @@ function wfLyricWikiMagicWords(&$aWikiWords, $langID)
 #---------------------------------------------------
 
 $wgHooks['ParserGetVariableValueSwitch'][] = 'wfLyricWikiVariableSwitch';
-function wfLyricWikiVariableSwitch(&$parser, &$cache, &$magicWordId, &$ret)
+function wfLyricWikiVariableSwitch($parser, &$cache, &$magicWordId, &$ret)
 {
 	$lwVars = getLyricWikiVariables();
 
@@ -202,7 +202,7 @@ function wfLyricWikiDeclareVarIds(&$magicWordIds)
 	return true;
 }
 
-function wfLyricWikiSterilizeTitle( &$parser, $title = '' )
+function wfLyricWikiSterilizeTitle( $parser, $title = '' )
 {
 	$lwVars = Array();
 

--- a/extensions/3rdparty/RSHighscores/RSHighscores.body.php
+++ b/extensions/3rdparty/RSHighscores/RSHighscores.body.php
@@ -10,7 +10,7 @@ class RSHiscores {
 	 * @param $parser Parser
 	 * @return bool
 	 */
-	public static function register( &$parser ) {
+	public static function register( $parser ) {
 		$parser->setFunctionHook( 'hs', 'RSHiscores::renderHiscores' );
 		return true;
 	}
@@ -113,7 +113,7 @@ class RSHiscores {
 	 * @param int $type Index representing the requested type of data for the given skill.
 	 * @return string
 	 */
-	public static function renderHiscores( &$parser, $hs = 'rs3', $player = '', $skill = -1, $type = 1 ) {
+	public static function renderHiscores( $parser, $hs = 'rs3', $player = '', $skill = -1, $type = 1 ) {
 		global $wgRSLimit;
 
 		if ( $hs != 'rs3' && $hs != 'osrs' ) {

--- a/extensions/3rdparty/SimpleCalendar/SimpleCalendar.php
+++ b/extensions/3rdparty/SimpleCalendar/SimpleCalendar.php
@@ -37,7 +37,7 @@ function wfSetupSimpleCalendar( $parser ) {
  * @param Parser $parser
  * @return string
  */
-function wfRenderCalendar(&$parser) {
+function wfRenderCalendar($parser) {
 	$parser->disableCache();
 	$argv = array();
 	foreach (func_get_args() as $arg) if (!is_object($arg)) {

--- a/extensions/3rdparty/Spoiler/Spoiler.php
+++ b/extensions/3rdparty/Spoiler/Spoiler.php
@@ -74,7 +74,7 @@ function wfSpoilerJavaScript() {
 				"</script>\n";
 }
 
-function spoilerParserHook( &$parser , &$text ) {
+function spoilerParserHook( $parser , &$text ) {
 	$text = wfSpoilerJavaScript() . $text;
 	return true;
 }

--- a/extensions/3rdparty/tabber/tabber.php
+++ b/extensions/3rdparty/tabber/tabber.php
@@ -16,7 +16,7 @@ $wgHooks['ParserFirstCallInit'][] = 'wfTabber';
  * @param Parser $parser
  * @return bool
  */
-function wfTabber(&$parser) {
+function wfTabber($parser) {
 	$parser->setHook( 'tabber', 'renderTabber' );
 	return true;
 }

--- a/extensions/Arrays/Arrays.php
+++ b/extensions/Arrays/Arrays.php
@@ -745,7 +745,7 @@ class ExtArrays {
 	 *    {{#arraymerge:arrayid_new |array1 |array2 |... |array n}}
 	 *    See: http://www.php.net/manual/en/function.array-merge.php
 	 */
-	static function pfObj_arraymerge( &$parser, $frame, $args) {
+	static function pfObj_arraymerge( $parser, $frame, $args) {
 		self::get( $parser )->multiArrayOperation( $frame, $args, __FUNCTION__, false );
 		return '';
 	}
@@ -761,7 +761,7 @@ class ExtArrays {
 	 *    Set operation, {red, white} = {red, white} union {red}
 	 *    Similar to arraymerge but with unique values. This union works on values.
 	 */
-	static function pfObj_arrayunion( &$parser, $frame, $args) {
+	static function pfObj_arrayunion( $parser, $frame, $args) {
 		self::get( $parser )->multiArrayOperation( $frame, $args, __FUNCTION__, false );
 		return '';
 	}
@@ -777,7 +777,7 @@ class ExtArrays {
 	 *    Set operation, {red} = {red, white} intersect {red,black}
 	 *    See: http://www.php.net/manual/en/function.array-intersect.php
 	 */
-	static function pfObj_arrayintersect( &$parser, $frame, $args) {
+	static function pfObj_arrayintersect( $parser, $frame, $args) {
 		self::get( $parser )->multiArrayOperation( $frame, $args, __FUNCTION__, false );
 		return '';
 	}
@@ -794,7 +794,7 @@ class ExtArrays {
 	 *    Set operation, {white} = {red, white} - {red}
 	 *    See: http://www.php.net/manual/en/function.array-diff.php
 	 */
-	static function pfObj_arraydiff( &$parser, $frame, $args) {
+	static function pfObj_arraydiff( $parser, $frame, $args) {
 		self::get( $parser )->multiArrayOperation( $frame, $args, __FUNCTION__, false );
 		return '';
 	}

--- a/extensions/Arrays/Arrays.php
+++ b/extensions/Arrays/Arrays.php
@@ -78,7 +78,7 @@ class ExtArrays {
 	 *
 	 * @since 2.0
 	 */
-	public static function init( Parser &$parser ) {
+	public static function init( Parser $parser ) {
 		global $egArraysCompatibilityMode;
 		/*
 		 * store for arrays per Parser object. This will solve several bugs related to
@@ -117,7 +117,7 @@ class ExtArrays {
 
 		return true;
 	}
-	private static function initFunction( Parser &$parser, $name, $flags = 0 ) {
+	private static function initFunction( Parser $parser, $name, $flags = 0 ) {
 		// all parser functions with prefix:
 		$prefix = ( $flags & SFH_OBJECT_ARGS ) ? 'pfObj_' : 'pf_';
 		$functionCallback = array( __CLASS__, $prefix . $name );
@@ -159,7 +159,7 @@ class ExtArrays {
 	* see also: http://us2.php.net/manual/en/function.preg-split.php
 	*/
 	static function pf_arraydefine(
-			Parser &$parser,
+			Parser $parser,
 			$arrayId,
 			$value = null,
 			$delimiter = '/\s*,\s*/',
@@ -278,7 +278,7 @@ class ExtArrays {
 	*    {{#arrayprint:b|<br/>|@@@|{{f.tag{{f.print.vbar}}prop{{f.print.vbar}}@@@}} }}   -- embed template function
 	*    {{#arrayprint:b|<br/>|@@@|[[name::@@@]]}}   -- make SMW links
 	*/
-	static function pfObj_arrayprint( Parser &$parser, PPFrame $frame, $args ) {
+	static function pfObj_arrayprint( Parser $parser, PPFrame $frame, $args ) {
 		global $egArraysCompatibilityMode, $egArraysExpansionEscapeTemplates;
 		
 		// Get Parameters
@@ -382,7 +382,7 @@ class ExtArrays {
 	* usage:
 	*   {{#arrayindex:arrayid|index}}
 	*/
-	static function pfObj_arrayindex( Parser &$parser, PPFrame $frame, $args ) {
+	static function pfObj_arrayindex( Parser $parser, PPFrame $frame, $args ) {
 		global $egArraysCompatibilityMode;
 
 		// Get Parameters
@@ -427,7 +427,7 @@ class ExtArrays {
 	*
 	*   See: http://www.php.net/manual/en/function.count.php
 	*/
-	static function pf_arraysize( Parser &$parser, $arrayId ) {
+	static function pf_arraysize( Parser $parser, $arrayId ) {
 		$store = self::get( $parser );
 
 		if( ! $store->arrayExists( $arrayId ) ) {
@@ -449,7 +449,7 @@ class ExtArrays {
 	*   See: http://www.php.net/manual/en/function.array-search.php
 	*   note it is extended to support regular expression match and index
 	*/
-	static function pfObj_arraysearch( Parser &$parser, PPFrame $frame, $args ) {
+	static function pfObj_arraysearch( Parser $parser, PPFrame $frame, $args ) {
 		// Get Parameters
 		$arrayId = trim( $frame->expand( $args[0] ) );
 		$index = isset( $args[2] ) ? trim( $frame->expand( $args[2] ) ) : 0;
@@ -510,7 +510,7 @@ class ExtArrays {
 	* "needle" can be a regular expression or a string search value. If "needle" is a regular expression, "transform" can contain
 	* "$n" where "n" stands for a number to access a variable from the regex result.
 	*/
-	static function pfObj_arraysearcharray( Parser &$parser, PPFrame $frame, $args ) {
+	static function pfObj_arraysearcharray( Parser $parser, PPFrame $frame, $args ) {
 		$store = self::get( $parser );
 		
 		// get first two parameters
@@ -609,7 +609,7 @@ class ExtArrays {
 	*    extract a slice from an  array
 	*    see: http://www.php.net/manual/en/function.array-slice.php
 	*/
-	static function pf_arrayslice( Parser &$parser, $arrayId_new, $arrayId = null , $offset = 0, $length = null ) {
+	static function pf_arrayslice( Parser $parser, $arrayId_new, $arrayId = null , $offset = 0, $length = null ) {
 		$store = self::get( $parser );
 		if( $arrayId === null ) {
 			global $egArraysCompatibilityMode;
@@ -652,7 +652,7 @@ class ExtArrays {
 	*    {{#arrayreset:}}
 	*    {{#arrayreset:arrayid1,arrayid2,...arrayidn}}
 	*/
-	static function pfObj_arrayreset( Parser &$parser, PPFrame $frame, $args) {
+	static function pfObj_arrayreset( Parser $parser, PPFrame $frame, $args) {
 		global $egArraysCompatibilityMode;
 
 		if( $egArraysCompatibilityMode && count( $args ) == 1 ) {
@@ -690,7 +690,7 @@ class ExtArrays {
 	 *
 	 *   see: http://www.php.net/manual/en/function.array-unique.php
 	 */
-	static function pf_arrayunique( Parser &$parser, $arrayId ) {
+	static function pf_arrayunique( Parser $parser, $arrayId ) {
 		$store = self::get( $parser );
 
 		if( $store->arrayExists( $arrayId ) ) {
@@ -717,7 +717,7 @@ class ExtArrays {
 	 *        http://www.php.net/manual/en/function.shuffle.php
 	 *        http://us3.php.net/manual/en/function.array-reverse.php
 	 */
-	static function pf_arraysort( Parser &$parser, $arrayId , $sort = 'none' ) {
+	static function pf_arraysort( Parser $parser, $arrayId , $sort = 'none' ) {
 		$store = self::get( $parser );
 
 		$array = $store->getArray( $arrayId );
@@ -1015,7 +1015,7 @@ class ExtArrays {
 	# Used Hooks #
 	##############
 
-	static function onParserClearState( Parser &$parser ) {
+	static function onParserClearState( Parser $parser ) {
 		// remove all arrays to avoid conflicts with job queue or Special:Import or SMW semantic updates
 		$parser->mExtArrays = new self();
 		return true;
@@ -1038,11 +1038,11 @@ class ExtArrays {
 	 *
 	 * @since 2.0
 	 *
-	 * @param Parser &$parser
+	 * @param Parser $parser
 	 *
 	 * @return ExtArrays by reference so we still have the right object after 'ParserClearState'
 	 */
-	public static function &get( Parser &$parser ) {
+	public static function &get( Parser $parser ) {
 		return $parser->mExtArrays;
 	}
 

--- a/extensions/Autoincrement/Autoincrement.php
+++ b/extensions/Autoincrement/Autoincrement.php
@@ -42,7 +42,7 @@ class Autoincrement {
 		return true;
 	}
 
-	function wfAutoincrementHookSwitch( &$parser, &$varCache, &$index, &$ret ) {
+	function wfAutoincrementHookSwitch( $parser, &$varCache, &$index, &$ret ) {
 		if ( $index === 'autoincrement' )
 			$ret = ++$this->mCount; // No formatNum() just like url autonumbering
 

--- a/extensions/CharInsert/CharInsert.php
+++ b/extensions/CharInsert/CharInsert.php
@@ -44,7 +44,7 @@ $wgExtensionCredits['parserhook'][] = array(
 $dir = dirname(__FILE__) . '/';
 $wgExtensionMessagesFiles['CharInsert'] = $dir . 'CharInsert.i18n.php';
 
-function setupSpecialChars( &$parser ) {
+function setupSpecialChars( $parser ) {
 	$parser->setHook( 'charinsert', 'charInsert' );
 	return true;
 }

--- a/extensions/Cite/Cite_body.php
+++ b/extensions/Cite/Cite_body.php
@@ -1034,7 +1034,7 @@ class Cite {
 	 *
 	 * @return bool
 	 */
-	function clearState( &$parser ) {
+	function clearState( $parser ) {
 		if ( $parser->extCite !== $this ) {
 			return $parser->extCite->clearState( $parser );
 		}
@@ -1065,7 +1065,7 @@ class Cite {
 	 *
 	 * @return bool
 	 */
-	function checkRefsNoReferences( &$parser, &$text ) {
+	function checkRefsNoReferences( $parser, &$text ) {
 		if ( $parser->extCite !== $this ) {
 			return $parser->extCite->checkRefsNoReferences( $parser, $text );
 		}

--- a/extensions/Cite/SpecialCite_body.php
+++ b/extensions/Cite/SpecialCite_body.php
@@ -161,7 +161,7 @@ class CiteOutput {
 		return false;
 	}
 
-	function timestamp( &$parser, &$ts ) {
+	function timestamp( $parser, &$ts ) {
 		if ( isset( $parser->mTagHooks['citation'] ) ) {
 			$ts = wfTimestamp( TS_UNIX, $this->mArticle->getTimestamp() );
 		}

--- a/extensions/ConfirmEdit/Captcha.php
+++ b/extensions/ConfirmEdit/Captcha.php
@@ -305,7 +305,7 @@ class SimpleCaptcha {
 				$newLinks = $this->findLinks( $editPage, $newtext );
 			}
 
-			$unknownLinks = array_filter( $newLinks, array( &$this, 'filterLink' ) );
+			$unknownLinks = array_filter( $newLinks, array( $this, 'filterLink' ) );
 			$addedLinks = array_diff( $unknownLinks, $oldLinks );
 			$numLinks = count( $addedLinks );
 
@@ -475,13 +475,13 @@ class SimpleCaptcha {
 		
 		#<Wikia>
 		$result = null;                                                                                                                                                                  
-		if( !wfRunHooks( 'ConfirmEdit::onConfirmEdit', array( &$this, &$editPage, $newtext, $section, $merged, &$result ) ) ) {                                                          
+		if( !wfRunHooks( 'ConfirmEdit::onConfirmEdit', array( $this, &$editPage, $newtext, $section, $merged, &$result ) ) ) {
 			return $result;                                                                                                                                                          
 		}
 		#</Wikia>
                 
 		if ( !$this->doConfirmEdit( $editPage, $newtext, $section, $merged ) ) {
-			$editPage->showEditForm( array( &$this, 'editCallback' ) );
+			$editPage->showEditForm( array( $this, 'editCallback' ) );
 			return false;
 		}
 		return true;

--- a/extensions/DPLforum/DPLforum.php
+++ b/extensions/DPLforum/DPLforum.php
@@ -56,7 +56,7 @@ $wgExtensionMessagesFiles['DPLforumMagic'] = $dir . 'DPLforum.i18n.magic.php';
 $wgExtensionMessagesFiles['DPLforumNamespaces'] = $dir . 'DPLforum.namespaces.php';
 $wgAutoloadClasses['DPLForum'] = $dir . 'DPLforum_body.php';
 
-function wfDPLinit( &$parser ) {
+function wfDPLinit( $parser ) {
 	$parser->setHook( 'forum', 'parseForum' );
 	$parser->setFunctionHook( 'forumlink', array( new DPLForum(), 'link' ) );
 	return true;

--- a/extensions/DPLforum/DPLforum_body.php
+++ b/extensions/DPLforum/DPLforum_body.php
@@ -63,7 +63,7 @@ class DPLForum {
 	var $sCreationDateFormat;
 	var $sLastEditFormat;
 
-	function cat( &$parser, $name ) {
+	function cat( $parser, $name ) {
 		$cats = array();
 		if ( preg_match_all( "/^\s*$name\s*=\s*(.*)/mi", $this->sInput, $matches ) ) {
 			foreach ( $matches[1] as $cat ) {
@@ -90,7 +90,7 @@ class DPLForum {
 		return $value;
 	}
 
-	function link( &$parser, $count, $page = '', $text = '' ) {
+	function link( $parser, $count, $page = '', $text = '' ) {
 		$count = intval( $count );
 		if ( $count < 1 ) {
 			return '';

--- a/extensions/DynamicPageList/DPLSetup.php
+++ b/extensions/DynamicPageList/DPLSetup.php
@@ -427,10 +427,10 @@ function ExtDynamicPageList__languageGetMagic( &$magicWords, $langCode ) 	{
 	return ExtDynamicPageList::languageGetMagic( $magicWords, $langCode ); 
 }
 
-function ExtDynamicPageList__endReset( &$parser, $text ) 					{ 
+function ExtDynamicPageList__endReset( $parser, $text ) 					{
 	return ExtDynamicPageList::endReset( $parser, $text ); 
 }
-function ExtDynamicPageList__endEliminate( &$parser, $text )			 	{ 
+function ExtDynamicPageList__endEliminate( $parser, $text )			 	{
 	return ExtDynamicPageList::endEliminate( $parser, $text ); 
 }
 
@@ -1350,7 +1350,7 @@ class ExtDynamicPageList {
 
 
     //------------------------------------------------------------------------------------- ENTRY parser FUNCTION #dpl
-    public static function dplParserFunction(&$parser) {
+    public static function dplParserFunction($parser) {
 
 		// late loading of php modules, only if needed
 		self::loadModules();
@@ -1391,7 +1391,7 @@ class ExtDynamicPageList {
 
     }
 
-    public static function dplNumParserFunction(&$parser, $text='') {
+    public static function dplNumParserFunction($parser, $text='') {
         $num = str_replace('&#160;',' ',$text);
         $num = str_replace('&nbsp;',' ',$text);
 		$num = preg_replace('/([0-9])([.])([0-9][0-9]?[^0-9,])/','\1,\3',$num);
@@ -1409,7 +1409,7 @@ class ExtDynamicPageList {
 		return $num;
     } 
 
-    public static function dplVarParserFunction(&$parser, $cmd) {
+    public static function dplVarParserFunction($parser, $cmd) {
 		$args = func_get_args();
         if      ($cmd=='set')     return DPLVariables::setVar($args);
         else if ($cmd=='default') return DPLVariables::setVarDefault($args);
@@ -1425,7 +1425,7 @@ class ExtDynamicPageList {
         return false;
     }
 
-    public static function dplReplaceParserFunction(&$parser, $text, $pat, $repl='') {
+    public static function dplReplaceParserFunction($parser, $text, $pat, $repl='') {
 		if ($text=='' || $pat=='') return '';
         # convert \n to a real newline character
         $repl = str_replace('\n',"\n",$repl);
@@ -1436,12 +1436,12 @@ class ExtDynamicPageList {
         return preg_replace ( $pat, $repl, $text );
     } 
 
-    public static function dplChapterParserFunction(&$parser, $text='', $heading=' ', $maxLength = -1, $page = '?page?', $link = 'default', $trim=false ) {
+    public static function dplChapterParserFunction($parser, $text='', $heading=' ', $maxLength = -1, $page = '?page?', $link = 'default', $trim=false ) {
         $output = DPLInclude::extractHeadingFromText($parser, $page, '?title?', $text, $heading, '', $sectionHeading, true, $maxLength, $link, $trim);
         return $output[0];
     } 
 
-    public static function dplMatrixParserFunction(&$parser, $name, $yes, $no, $flip, $matrix ) {
+    public static function dplMatrixParserFunction($parser, $name, $yes, $no, $flip, $matrix ) {
         $lines = explode("\n",$matrix);
         $m = array();
         $sources = array();
@@ -1533,7 +1533,7 @@ class ExtDynamicPageList {
     } 
 
 // reset everything; some categories may have been fixed, however via  fixcategory=
-    public static function endReset( &$parser, $text ) {
+    public static function endReset( $parser, $text ) {
         if (!self::$createdLinks['resetdone']) {
             self::$createdLinks['resetdone'] = true;
 			foreach ($parser->mOutput->mCategories as $key => $val) {
@@ -1550,7 +1550,7 @@ class ExtDynamicPageList {
         return true;
     }
 
-    public static function endEliminate( &$parser, &$text ) {
+    public static function endEliminate( $parser, &$text ) {
 
         // called during the final output phase; removes links created by DPL
         if (isset(self::$createdLinks)) {

--- a/extensions/HeaderTabs/HeaderTabs_body.jq.php
+++ b/extensions/HeaderTabs/HeaderTabs_body.jq.php
@@ -17,7 +17,7 @@ class HeaderTabs {
 		return '<div id="nomoretabs"></div>';
 	}
 
-	public static function replaceFirstLevelHeaders( &$parser, &$text ) {
+	public static function replaceFirstLevelHeaders( $parser, &$text ) {
 		global $htRenderSingleTab, $htAutomaticNamespaces, $htDefaultFirstTab, $htDisableDefaultToc, $htGenerateTabTocs, $htStyle, $htEditTabLink;
 		global $htTabIndexes;
 
@@ -290,7 +290,7 @@ class HeaderTabs {
 		return true;
 	}
 
-	public static function renderSwitchTabLink( &$parser, $tabName, $linkText, $anotherTarget = '' ) {
+	public static function renderSwitchTabLink( $parser, $tabName, $linkText, $anotherTarget = '' ) {
 		// The cache unfortunately needs to be disabled for the
 		// Javascript for such links to work.
 		$parser->disableCache();

--- a/extensions/HeaderTabs/HeaderTabs_body.yui.php
+++ b/extensions/HeaderTabs/HeaderTabs_body.yui.php
@@ -27,7 +27,7 @@ class HeaderTabs {
 		return '<div id="nomoretabs"></div>';
 	}
 
-	public static function replaceFirstLevelHeaders( &$parser, &$text ) {
+	public static function replaceFirstLevelHeaders( $parser, &$text ) {
 		global $htUseHistory, $htScriptPath, $wgVersion;
 
 		$aboveandbelow = explode( '<div id="nomoretabs"></div>', $text, 2 );
@@ -129,7 +129,7 @@ class HeaderTabs {
 		return true;
 	}
 
-	public static function renderSwitchTabLink( &$parser, $tabName, $linkText, $anotherTarget = '' ) {
+	public static function renderSwitchTabLink( $parser, $tabName, $linkText, $anotherTarget = '' ) {
 		$tabTitle = Title::newFromText( $tabName );
 		$tabKey = $tabTitle->getDBkey();
 		$sanitizedLinkText = $parser->recursiveTagParse( $linkText );

--- a/extensions/ImageMap/ImageMap.php
+++ b/extensions/ImageMap/ImageMap.php
@@ -17,7 +17,7 @@ $wgExtensionCredits['parserhook']['ImageMap'] = array(
  * @param $parser Parser
  * @return bool
  */
-function wfSetupImageMap( &$parser ) {
+function wfSetupImageMap( $parser ) {
 	$parser->setHook( 'imagemap', array( 'ImageMap', 'render' ) );
 	return true;
 }

--- a/extensions/InputBox/InputBox.hooks.php
+++ b/extensions/InputBox/InputBox.hooks.php
@@ -12,7 +12,7 @@ class InputBoxHooks {
 	/* Functions */
 
 	// Initialization
-	public static function register( &$parser ) {
+	public static function register( $parser ) {
 		// Register the hook with the parser
 		$parser->setHook( 'inputbox', array( 'InputBoxHooks', 'render' ) );
 

--- a/extensions/Loops/Loops.php
+++ b/extensions/Loops/Loops.php
@@ -77,7 +77,7 @@ class ExtLoops {
 	* 
 	* @since 0.4
 	*/
-	public static function init( Parser &$parser ) {
+	public static function init( Parser $parser ) {
 		
 		if( ! class_exists( 'ExtVariables' ) ) {
 			/*
@@ -104,7 +104,7 @@ class ExtLoops {
 		
 		return true;
 	}
-	private static function initFunction( Parser &$parser, $name ) {
+	private static function initFunction( Parser $parser, $name ) {
 		global $egLoopsEnabledFunctions;
 		
 		// don't register parser function if disabled by configuration:
@@ -121,18 +121,18 @@ class ExtLoops {
 	# Parser Functions #
 	####################
 
-	public static function pfObj_while( Parser &$parser, $frame, $args ) {
+	public static function pfObj_while( Parser $parser, $frame, $args ) {
 		return self::perform_while( $parser, $frame, $args, false );
 	}
 	
-	public static function pfObj_dowhile( Parser &$parser, $frame, $args ) {
+	public static function pfObj_dowhile( Parser $parser, $frame, $args ) {
 		return self::perform_while( $parser, $frame, $args, true );
 	}
 	
 	/**
 	 * Generic function handling '#while' and '#dowhile' as one
 	 */
-	protected static function perform_while( Parser &$parser, $frame, $args, $dowhile = false ) {
+	protected static function perform_while( Parser $parser, $frame, $args, $dowhile = false ) {
 		// #(do)while: | condition | code
 		$rawCond = isset( $args[1] ) ? $args[1] : ''; // unexpanded condition
 		$rawCode = isset( $args[2] ) ? $args[2] : ''; // unexpanded loop code
@@ -159,7 +159,7 @@ class ExtLoops {
 		return $output;
 	}
 	
-	public static function pfObj_loop( Parser &$parser, PPFrame $frame, $args ) {
+	public static function pfObj_loop( Parser $parser, PPFrame $frame, $args ) {
 		// #loop: var | start | count | code
 		$varName  = isset( $args[0] ) ?      trim( $frame->expand( $args[0] ) ) : '';
 		$startVal = isset( $args[1] ) ? (int)trim( $frame->expand( $args[1] ) ) : 0;
@@ -195,7 +195,7 @@ class ExtLoops {
 	/**
 	 * #forargs: filter | keyVarName | valVarName | code
 	 */
-	public static function pfObj_forargs( Parser &$parser, $frame, $args ) {		
+	public static function pfObj_forargs( Parser $parser, $frame, $args ) {
 		// The first arg is already expanded, but this is a good habit to have...
 		$filter = array_shift( $args );
 		$filter = $filter !== null ? trim( $frame->expand( $filter ) ) : '';
@@ -213,7 +213,7 @@ class ExtLoops {
 	 * or (since 0.4 for more consistency)
 	 * #fornumargs: | keyVarName | valVarName | code
 	 */
-	public static function pfObj_fornumargs( Parser &$parser, $frame, $args ) {
+	public static function pfObj_fornumargs( Parser $parser, $frame, $args ) {
 		/*
 		 * get numeric arguments, don't use PPFrame::getNumberedArguments because it would
 		 * return explicitely numbered arguments only.
@@ -239,7 +239,7 @@ class ExtLoops {
 	/**
 	 * Generic function handling '#forargs' and '#fornumargs' as one
 	 */
-	protected static function perform_forargs( Parser &$parser, PPFrame $frame, array $funcArgs, array $templateArgs, $prefix = '' ) {
+	protected static function perform_forargs( Parser $parser, PPFrame $frame, array $funcArgs, array $templateArgs, $prefix = '' ) {
 		// if not called within template instance:
 		if( !( $frame->isTemplate() ) ) {
 			return '';
@@ -288,7 +288,7 @@ class ExtLoops {
 	 * @param string $varName
 	 * @param string $varValue
 	 */
-	private static function setVariable( Parser &$parser, $varName, $varValue ) {
+	private static function setVariable( Parser $parser, $varName, $varValue ) {
 		global $wgExtVariables;
 		
 		static $newVersion = null;
@@ -320,7 +320,7 @@ class ExtLoops {
 	 * @param Parser $parser
 	 * @return int
 	 */
-	public static function getLoopsCount( Parser &$parser ) {
+	public static function getLoopsCount( Parser $parser ) {
 		return $parser->mExtLoopsCounter;
 	}
 	
@@ -333,7 +333,7 @@ class ExtLoops {
 	 * @param Parser $parser
 	 * @return bool 
 	 */
-	public static function maxLoopsPerformed( Parser &$parser ) {
+	public static function maxLoopsPerformed( Parser $parser ) {
 		$count = $parser->mExtLoopsCounter;
 		return $count > -1 && $count >= self::$maxLoops;
 	}
@@ -344,7 +344,7 @@ class ExtLoops {
 	 * 
 	 * @return false|int
 	 */
-	protected static function incrCounter( Parser &$parser ) {
+	protected static function incrCounter( Parser $parser ) {
 		if( self::maxLoopsPerformed( $parser ) ) {
 			return false;
 		}
@@ -366,7 +366,7 @@ class ExtLoops {
 	# Hooks handling #
 	##################
 	
-	public static function onParserClearState( Parser &$parser ) {
+	public static function onParserClearState( Parser $parser ) {
 		// reset loops counter since the parser process finished one page
 		$parser->mExtLoopsCounter = 0;
 		return true;

--- a/extensions/Maps/Maps.hooks.php
+++ b/extensions/Maps/Maps.hooks.php
@@ -134,12 +134,12 @@ final class MapsHooks {
 	 *
 	 * @since 3.0
 	 *
-	 * @param Parser &$parser
-	 * @param string &$text
+	 * @param Parser $parser
+	 * @param string $text
 	 *
 	 * @return true
 	 */
-	public static function onParserAfterTidy( Parser &$parser, &$text ) {
+	public static function onParserAfterTidy( Parser $parser, &$text ) {
 
 		$title = $parser->getTitle();
 
@@ -211,7 +211,7 @@ final class MapsHooks {
 	 *
 	 * @return true
 	 */
-	public static function onParserClearState( Parser &$parser ) {
+	public static function onParserClearState( Parser $parser ) {
 		$parser->getOutput()->mExtMapsLayers = null;
 		return true;
 	}

--- a/extensions/Maps/Maps.php
+++ b/extensions/Maps/Maps.php
@@ -99,42 +99,42 @@ call_user_func( function() {
 	// Parser hooks
 
 	// Required for #coordinates.
-	$GLOBALS['wgHooks']['ParserFirstCallInit'][] = function( Parser &$parser ) {
+	$GLOBALS['wgHooks']['ParserFirstCallInit'][] = function( Parser $parser ) {
 		$instance = new MapsCoordinates();
 		return $instance->init( $parser );
 	};
 
-	$GLOBALS['wgHooks']['ParserFirstCallInit'][] = function( Parser &$parser ) {
+	$GLOBALS['wgHooks']['ParserFirstCallInit'][] = function( Parser $parser ) {
 		$instance = new MapsDisplayMap();
 		return $instance->init( $parser );
 	};
 
-	$GLOBALS['wgHooks']['ParserFirstCallInit'][] = function( Parser &$parser ) {
+	$GLOBALS['wgHooks']['ParserFirstCallInit'][] = function( Parser $parser ) {
 		$instance = new MapsDistance();
 		return $instance->init( $parser );
 	};
 
-	$GLOBALS['wgHooks']['ParserFirstCallInit'][] = function( Parser &$parser ) {
+	$GLOBALS['wgHooks']['ParserFirstCallInit'][] = function( Parser $parser ) {
 		$instance = new MapsFinddestination();
 		return $instance->init( $parser );
 	};
 
-	$GLOBALS['wgHooks']['ParserFirstCallInit'][] = function( Parser &$parser ) {
+	$GLOBALS['wgHooks']['ParserFirstCallInit'][] = function( Parser $parser ) {
 		$instance = new MapsGeocode();
 		return $instance->init( $parser );
 	};
 
-	$GLOBALS['wgHooks']['ParserFirstCallInit'][] = function( Parser &$parser ) {
+	$GLOBALS['wgHooks']['ParserFirstCallInit'][] = function( Parser $parser ) {
 		$instance = new MapsGeodistance();
 		return $instance->init( $parser );
 	};
 
-	$GLOBALS['wgHooks']['ParserFirstCallInit'][] = function( Parser &$parser ) {
+	$GLOBALS['wgHooks']['ParserFirstCallInit'][] = function( Parser $parser ) {
 		$instance = new MapsMapsDoc();
 		return $instance->init( $parser );
 	};
 
-	$GLOBALS['wgHooks']['ParserFirstCallInit'][] = function( Parser &$parser ) {
+	$GLOBALS['wgHooks']['ParserFirstCallInit'][] = function( Parser $parser ) {
 		$instance = new MapsLayerDefinition();
 		return $instance->init( $parser );
 	};

--- a/extensions/Maps/includes/Maps_Layer.php
+++ b/extensions/Maps/includes/Maps_Layer.php
@@ -274,7 +274,7 @@ abstract class MapsLayer {
 	 *
 	 * @return array
 	 */
-	public function getPropertiesHtmlRepresentation( &$parser ) {
+	public function getPropertiesHtmlRepresentation( $parser ) {
 		$this->validate(); // make sure properties are available!
 		$transformed = array();
 		foreach( $this->properties as $property => $value ) {

--- a/extensions/Maps/includes/Maps_LayerPage.php
+++ b/extensions/Maps/includes/Maps_LayerPage.php
@@ -35,7 +35,7 @@ class MapsLayerPage extends Article {
 			return parent::view();
 		}
 
-		if( !Hooks::run( 'MapsLayerPageView', array( &$this ) ) ) {
+		if( !Hooks::run( 'MapsLayerPageView', array( $this ) ) ) {
 			return;
 		}
 

--- a/extensions/Maps/includes/Maps_MappingService.php
+++ b/extensions/Maps/includes/Maps_MappingService.php
@@ -102,7 +102,7 @@ abstract class MapsMappingService implements iMappingService {
 	 *
 	 * @since 0.6.3
 	 */
-	public final function addDependencies( &$parserOrOut ) {
+	public final function addDependencies( $parserOrOut ) {
 		$dependencies = $this->getDependencyHtml();
 
 		// Only add a head item when there are dependencies.

--- a/extensions/Maps/includes/iMappingService.php
+++ b/extensions/Maps/includes/iMappingService.php
@@ -26,7 +26,7 @@ interface iMappingService {
 	 * 
 	 * @param mixed $parserOrOut
 	 */
-	public function addDependencies( &$parserOrOut );
+	public function addDependencies( $parserOrOut );
 	
 	/**
 	 * Adds service-specific parameter definitions to the provided parameter list.

--- a/extensions/Maps/tests/phpunit/parserhooks/ParserHookTest.php
+++ b/extensions/Maps/tests/phpunit/parserhooks/ParserHookTest.php
@@ -45,7 +45,7 @@ abstract class ParserHookTest extends \PHPUnit_Framework_TestCase {
 
 		$renderResult = call_user_func_array(
 			array( $parserHook, 'renderFunction' ),
-			array_merge( array( &$parser ), $parameters )
+			array_merge( array( $parser ), $parameters )
 		);
 
 		if ( is_string( $renderResult ) ) {

--- a/extensions/Math/Math.body.php
+++ b/extensions/Math/Math.body.php
@@ -158,7 +158,7 @@ class MathRenderer {
 				$this->hash = substr( $contents, 1, 32 );
 			}
 
-			wfRunHooks( 'MathAfterTexvc', array( &$this, &$errmsg ) );
+			wfRunHooks( 'MathAfterTexvc', array( $this, &$errmsg ) );
 
 			if ( $errmsg ) {
 				return $errmsg;

--- a/extensions/Math/Math.hooks.php
+++ b/extensions/Math/Math.hooks.php
@@ -147,7 +147,7 @@ class MathHooks {
 	 * @param Parser $parser
 	 * @return bool
 	 */
-	static function onParserTestParser( &$parser ) {
+	static function onParserTestParser( $parser ) {
 		global $wgMathPath;
 		$wgMathPath = '/images/math';
 		return true;

--- a/extensions/NumberFormat/NumberFormat.php
+++ b/extensions/NumberFormat/NumberFormat.php
@@ -27,7 +27,7 @@ function number_format_Setup( Parser $parser )	 {
 
 class NumberFormart {
 
-	public static function number_format_Render( &$parser ) {
+	public static function number_format_Render( $parser ) {
 		wfProfileIn(__METHOD__);
 		// {{#number_format:number|decimals|dec_point|thousands_sep}}
 

--- a/extensions/ParserFunctions/ParserFunctions_body.php
+++ b/extensions/ParserFunctions/ParserFunctions_body.php
@@ -901,7 +901,7 @@ class ExtParserFunctions {
 	 * Returns count($chars).
 	 * copied from StringFunctions by eloy
 	 */
-	static protected function mwSplit( &$parser, $str, &$chars ) {
+	static protected function mwSplit( $parser, $str, &$chars ) {
 		# Get marker prefix & suffix
 		$prefix = preg_quote( $parser->mUniqPrefix, '/' );
 		if ( defined( 'Parser::MARKER_SUFFIX' ) ) {
@@ -926,7 +926,7 @@ class ExtParserFunctions {
 	 *
 	 * copied from StringFunctions by eloy
 	 */
-	static function runPad( &$parser, $inStr = '', $inLen = 0, $inWith = '', $inDirection = '' ) {
+	static function runPad( $parser, $inStr = '', $inLen = 0, $inWith = '', $inDirection = '' ) {
 		global $wgPFStringLengthLimit;
 
 		# direction

--- a/extensions/Poem/Poem.php
+++ b/extensions/Poem/Poem.php
@@ -29,7 +29,7 @@ $wgExtensionCredits['parserhook'][] = array(
 $wgParserTestFiles[] = dirname( __FILE__ ) . "/poemParserTests.txt";
 $wgExtensionMessagesFiles['Poem'] =  dirname(__FILE__) . '/Poem.i18n.php';
 
-function wfPoemExtension( &$parser ) {
+function wfPoemExtension( $parser ) {
 	$parser->setHook( 'poem', 'wfRenderPoemTag' );
 	return true;
 }

--- a/extensions/RandomImage/RandomImage.php
+++ b/extensions/RandomImage/RandomImage.php
@@ -43,7 +43,7 @@ $wgRandomImageStrict = !$wgMiserMode;
 /**
  * Hook setup
  */
-function efRandomImage(&$parser) {
+function efRandomImage($parser) {
 	$parser->setHook( 'randomimage', 'RandomImage::renderHook' );
 	return true;
 }

--- a/extensions/RegexFun/RegexFun.php
+++ b/extensions/RegexFun/RegexFun.php
@@ -452,7 +452,7 @@ class ExtRegexFun {
 	 * 
 	* @return String result of all matching text parts separated by a string
 	*/
-	public static function pf_regexall( &$parser , $subject = '' , $pattern = '' , $separator = ', ' , $offset = 0 , $length = '' ) {
+	public static function pf_regexall( $parser , $subject = '' , $pattern = '' , $separator = ', ' , $offset = 0 , $length = '' ) {
 		// check whether limit exceeded:
 		if( self::limitExceeded( $parser ) ) {
 			return self::msgLimitExceeded();
@@ -596,7 +596,7 @@ class ExtRegexFun {
 	 * 
 	 * @return String Returns the quoted string
 	 */
-	public static function pf_regexquote( &$parser, $str = null, $delimiter = '/' ) {		
+	public static function pf_regexquote( $parser, $str = null, $delimiter = '/' ) {
 		if( $str === null ) {
 			return '';
 		}		
@@ -685,7 +685,7 @@ class ExtRegexFun {
 		self::setLastSubject( $frame, $subject );
 	}
 	
-	public static function onParserClearState( &$parser ) {
+	public static function onParserClearState( $parser ) {
 		//cleanup to avoid conflicts with job queue or Special:Import
 		/*
 		$parser->mExtRegexFun = array();

--- a/extensions/RegexFun/RegexFun.php
+++ b/extensions/RegexFun/RegexFun.php
@@ -62,7 +62,7 @@ class ExtRegexFun {
 	/**
 	 * Sets up parser functions
 	 */
-	public static function init( Parser &$parser ) {
+	public static function init( Parser $parser ) {
 		self::initFunction( $parser, 'regex', SFH_OBJECT_ARGS );
 		self::initFunction( $parser, 'regex_var', SFH_OBJECT_ARGS );
 		self::initFunction( $parser, 'regexquote' );
@@ -70,7 +70,7 @@ class ExtRegexFun {
 		
 		return true;		
 	}	
-	private static function initFunction( Parser &$parser, $name, $flags = 0 ) {		
+	private static function initFunction( Parser $parser, $name, $flags = 0 ) {
 		global $egRegexFunDisabledFunctions;
 		
 		// only register function if not disabled by configuration
@@ -195,7 +195,7 @@ class ExtRegexFun {
 		return false;
 	}
 	
-	private static function limitHandler( Parser &$parser ) {		
+	private static function limitHandler( Parser $parser ) {
 		// is the limit exceeded for this parsers parse() process?
 		if( self::limitExceeded( $parser ) ) {
 			return false;
@@ -255,8 +255,8 @@ class ExtRegexFun {
 	 * 
 	 * @return String Result of replacing pattern with replacement in string, or matching text if replacement was omitted
 	 */
-    //public static function pf_regex( Parser &$parser, $subject = '', $pattern = '', $replacement = null, $limit = -1 ) {		
-	public static function pfObj_regex( Parser &$parser, PPFrame $frame, array $args ) {
+    //public static function pf_regex( Parser $parser, $subject = '', $pattern = '', $replacement = null, $limit = -1 ) {
+	public static function pfObj_regex( Parser $parser, PPFrame $frame, array $args ) {
 		// Get Parameters
 		$subject     = isset( $args[0] ) ? trim( $frame->expand( $args[0] ) ) : '';
 		$pattern     = isset( $args[1] ) ? trim( $frame->expand( $args[1] ) ) : '';
@@ -496,7 +496,7 @@ class ExtRegexFun {
 	 * @param $index Integer index of the last match which should be returnd or a string containing $n as indexes to be replaced
 	 * @param $defaultVal Integer default value which will be returned when the result with the given index doesn't exist or is a void string
 	 */
-	public static function pfObj_regex_var( Parser &$parser, PPFrame $frame, array $args ) {		
+	public static function pfObj_regex_var( Parser $parser, PPFrame $frame, array $args ) {
 		$index      = isset( $args[0] ) ? trim( $frame->expand( $args[0] ) ) : 0;
 		$defaultVal = isset( $args[1] ) ? trim( $frame->expand( $args[1] ) ) : '';
 		
@@ -704,7 +704,7 @@ class ExtRegexFun {
 	 * 
 	 * @return boolean
 	 */
-	public static function limitExceeded( Parser &$parser ) {		
+	public static function limitExceeded( Parser $parser ) {
 		global $egRegexFunMaxRegexPerParse;
 		return (
 			$egRegexFunMaxRegexPerParse !== -1
@@ -712,14 +712,14 @@ class ExtRegexFun {
 		);
 	}
 	
-	public static function getLimitCount( Parser &$parser ) {
+	public static function getLimitCount( Parser $parser ) {
 		if( isset( $parser->mExtRegexFun['counter'] ) ) {
 			return $parser->mExtRegexFun['counter'];
 		}
 		return 0;
 	}
 	
-	private static function increaseRegexCount( Parser &$parser ) {
+	private static function increaseRegexCount( Parser $parser ) {
 		$parser->mExtRegexFun['counter']++;		
 	}
 	

--- a/extensions/Scribunto/common/Hooks.php
+++ b/extensions/Scribunto/common/Hooks.php
@@ -29,7 +29,7 @@ class ScribuntoHooks {
 	 * @param $parser Parser
 	 * @return bool
 	 */
-	public static function setupParserHook( &$parser ) {
+	public static function setupParserHook( $parser ) {
 		$parser->setFunctionHook( 'invoke', 'ScribuntoHooks::invokeHook', SFH_OBJECT_ARGS );
 		return true;
 	}
@@ -40,7 +40,7 @@ class ScribuntoHooks {
 	 * @param $parser Parser
 	 * @return bool
 	 */
-	public static function clearState( &$parser ) {
+	public static function clearState( $parser ) {
 		Scribunto::resetParserEngine( $parser );
 		return true;
 	}
@@ -66,7 +66,7 @@ class ScribuntoHooks {
 	 * @throws ScribuntoException
 	 * @return string
 	 */
-	public static function invokeHook( &$parser, $frame, $args ) {
+	public static function invokeHook( $parser, $frame, $args ) {
 		if ( !@constant( get_class( $frame ) . '::SUPPORTS_INDEX_OFFSET' ) ) {
 			throw new MWException(
 				'Scribunto needs MediaWiki 1.20 or later (Preprocessor::SUPPORTS_INDEX_OFFSET)' );

--- a/extensions/SemanticDrilldown/includes/SD_ParserFunctions.php
+++ b/extensions/SemanticDrilldown/includes/SD_ParserFunctions.php
@@ -21,13 +21,13 @@
 
 class SDParserFunctions {
 
-	static function registerFunctions( &$parser ) {
+	static function registerFunctions( $parser ) {
 		$parser->setFunctionHook( 'drilldowninfo', array( 'SDParserFunctions', 'renderDrilldownInfo' ) );
 		$parser->setFunctionHook( 'drilldownlink', array( 'SDParserFunctions', 'renderDrilldownLink' ) );
 		return true;
 	}
 
-	static function renderDrilldownInfo( &$parser ) {
+	static function renderDrilldownInfo( $parser ) {
 		$curTitle = $parser->getTitle();
 		if ( $curTitle->getNamespace() != NS_CATEGORY ) {
 			return '<div class="error">Error: #drilldowninfo can only be called in category pages.</div>';
@@ -149,7 +149,7 @@ class SDParserFunctions {
 	}
 
 
-	static function renderDrilldownLink( &$parser ) {
+	static function renderDrilldownLink( $parser ) {
 		$params = func_get_args();
 		array_shift( $params );
 

--- a/extensions/SemanticDrilldown/includes/SD_Utils.php
+++ b/extensions/SemanticDrilldown/includes/SD_Utils.php
@@ -423,7 +423,7 @@ class SDUtils {
 	 * Set values in the page_props table based on the presence of the
 	 * 'HIDEFROMDRILLDOWN' and 'SHOWINDRILLDOWN' magic words in a page
 	 */
-	static function handleShowAndHide( &$parser, &$text ) {
+	static function handleShowAndHide( $parser, &$text ) {
 		global $wgOut, $wgAction;
 		$mw_hide = MagicWord::get( 'MAG_HIDEFROMDRILLDOWN' );
 		if ( $mw_hide->matchAndRemove( $text ) ) {

--- a/extensions/SemanticForms/includes/SF_Hooks.php
+++ b/extensions/SemanticForms/includes/SF_Hooks.php
@@ -162,7 +162,7 @@ class SFHooks {
 		return true;
 	}
 
-	static function registerFunctions( &$parser ) {
+	static function registerFunctions( $parser ) {
 		$parser->setFunctionHook( 'default_form', array( 'SFParserFunctions', 'renderDefaultForm' ) );
 		$parser->setFunctionHook( 'forminput', array( 'SFParserFunctions', 'renderFormInput' ) );
 		$parser->setFunctionHook( 'formlink', array( 'SFParserFunctions', 'renderFormLink' ) );

--- a/extensions/SemanticForms/includes/SF_ParserFunctions.php
+++ b/extensions/SemanticForms/includes/SF_ParserFunctions.php
@@ -154,7 +154,7 @@ class SFParserFunctions {
 	// only gets added to the page once
 	static $num_autocompletion_inputs = 0;
 
-	static function renderDefaultform( &$parser ) {
+	static function renderDefaultform( $parser ) {
 		$curTitle = $parser->getTitle();
 
 		$params = func_get_args();
@@ -185,7 +185,7 @@ class SFParserFunctions {
 		// It's not a category - display nothing.
 	}
 
-	static function renderFormLink ( &$parser ) {
+	static function renderFormLink ( $parser ) {
 		$params = func_get_args();
 		array_shift( $params ); // We don't need the parser.
 
@@ -194,7 +194,7 @@ class SFParserFunctions {
 		return $parser->insertStripItem( self::createFormLink( $parser, $params, 'formlink' ), $parser->mStripState );
 	}
 
-	static function renderFormRedLink ( &$parser ) {
+	static function renderFormRedLink ( $parser ) {
 		$params = func_get_args();
 		array_shift( $params ); // We don't need the parser.
 
@@ -203,7 +203,7 @@ class SFParserFunctions {
 		return $parser->insertStripItem( self::createFormLink( $parser, $params, 'formredlink' ), $parser->mStripState );
 	}
 
-	static function renderQueryFormLink ( &$parser ) {
+	static function renderQueryFormLink ( $parser ) {
 		$params = func_get_args();
 		array_shift( $params ); // We don't need the parser.
 
@@ -212,7 +212,7 @@ class SFParserFunctions {
 		return $parser->insertStripItem( self::createFormLink( $parser, $params, 'queryformlink' ), $parser->mStripState );
 	}
 
-	static function renderFormInput( &$parser ) {
+	static function renderFormInput( $parser ) {
 		$params = func_get_args();
 		array_shift( $params ); // don't need the parser
 
@@ -391,7 +391,7 @@ class SFParserFunctions {
 	/**
 	 * {{#arraymap:value|delimiter|var|formula|new_delimiter}}
 	 */
-	static function renderArrayMap( &$parser, $frame, $args ) {
+	static function renderArrayMap( $parser, $frame, $args ) {
 		// Set variables.
 		$value = isset( $args[0] ) ? trim( $frame->expand( $args[0] ) ) : '';
 		$delimiter = isset( $args[1] ) ? trim( $frame->expand( $args[1] ) ) : ',';
@@ -429,7 +429,7 @@ class SFParserFunctions {
 	/**
 	 * {{#arraymaptemplate:value|template|delimiter|new_delimiter}}
 	 */
-	static function renderArrayMapTemplate( &$parser, $frame, $args ) {
+	static function renderArrayMapTemplate( $parser, $frame, $args ) {
 		// Set variables.
 		$value = isset( $args[0] ) ? trim( $frame->expand( $args[0] ) ) : '';
 		$template = isset( $args[1] ) ? trim( $frame->expand( $args[1] ) ) : '';
@@ -465,7 +465,7 @@ class SFParserFunctions {
 	}
 
 
-	static function renderAutoEdit( &$parser ) {
+	static function renderAutoEdit( $parser ) {
 		$parser->getOutput()->addModules( 'ext.semanticforms.autoedit' );
 
 		// Set defaults.
@@ -601,7 +601,7 @@ class SFParserFunctions {
 		return $parser->insertStripItem( $output, $parser->mStripState );
 	}
 
-	static function createFormLink( &$parser, $params, $parserFunctionName ) {
+	static function createFormLink( $parser, $params, $parserFunctionName ) {
 		// Set defaults.
 		$inFormName = $inLinkStr = $inExistingPageLinkStr = $inLinkType =
 			$inTooltip = $inQueryStr = $inTargetName = '';
@@ -765,7 +765,7 @@ class SFParserFunctions {
 		return $str;
 	}
 
-	static function loadScriptsForPopupForm( &$parser ) {
+	static function loadScriptsForPopupForm( $parser ) {
 		$parser->getOutput()->addModules( 'ext.semanticforms.popupformedit' );
 		return true;
 	}

--- a/extensions/SemanticForms/includes/SF_Template.php
+++ b/extensions/SemanticForms/includes/SF_Template.php
@@ -344,7 +344,7 @@ class SFTemplate {
 	 * extension.
 	 */
 	public function createText() {
-		Hooks::run( 'SFCreateTemplateText', array( &$this ) );
+		Hooks::run( 'SFCreateTemplateText', array( $this ) );
 		$templateHeader = wfMessage( 'sf_template_docu', $this->mTemplateName )->inContentLanguage()->text();
 		$text = <<<END
 <noinclude>

--- a/extensions/SemanticForms/specials/SF_UploadWindow.php
+++ b/extensions/SemanticForms/specials/SF_UploadWindow.php
@@ -151,7 +151,7 @@ class SFUploadWindow extends UnlistedSpecialPage {
 			$this->processUpload();
 		} else {
 			# Backwards compatibility hook
-			if( !Hooks::run( 'UploadForm:initial', array( &$this ) ) ) {
+			if( !Hooks::run( 'UploadForm:initial', array( $this ) ) ) {
 				wfDebug( "Hook 'UploadForm:initial' broke output of the upload form" );
 				return;
 			}
@@ -327,7 +327,7 @@ class SFUploadWindow extends UnlistedSpecialPage {
 		if ( !$status->isOK() )
 			return $this->showUploadForm( $this->getUploadForm( $this->getOutput()->parse( $status->getWikiText() ) ) );
 
-		if( !Hooks::run( 'UploadForm:BeforeProcessing', array( &$this ) ) ) {
+		if( !Hooks::run( 'UploadForm:BeforeProcessing', array( $this ) ) ) {
 			wfDebug( "Hook 'UploadForm:BeforeProcessing' broke processing the file.\n" );
 			// This code path is deprecated. If you want to break upload processing
 			// do so by hooking into the appropriate hooks in UploadBase::verifyUpload
@@ -428,7 +428,7 @@ END;
 		print $output;
 		$img = null; // @todo: added to avoid passing a ref to null - should this be defined somewhere?
 
-		Hooks::run( 'SpecialUploadComplete', array( &$this ) );
+		Hooks::run( 'SpecialUploadComplete', array( $this ) );
 	}
 
 	/**

--- a/extensions/SemanticMediaWiki/src/MediaWiki/Hooks/HookRegistry.php
+++ b/extensions/SemanticMediaWiki/src/MediaWiki/Hooks/HookRegistry.php
@@ -116,7 +116,7 @@ class HookRegistry {
 		 *
 		 * @see https://www.mediawiki.org/wiki/Manual:Hooks/ParserAfterTidy
 		 */
-		$this->handlers['ParserAfterTidy'] = function ( &$parser, &$text ) {
+		$this->handlers['ParserAfterTidy'] = function ( $parser, &$text ) {
 
 			$parserAfterTidy = new ParserAfterTidy(
 				$parser,
@@ -194,7 +194,7 @@ class HookRegistry {
 		 *
 		 * @see https://www.mediawiki.org/wiki/Manual:Hooks/InternalParseBeforeLinks
 		 */
-		$this->handlers['InternalParseBeforeLinks'] = function ( &$parser, &$text ) {
+		$this->handlers['InternalParseBeforeLinks'] = function ( $parser, &$text ) {
 
 			$internalParseBeforeLinks = new InternalParseBeforeLinks(
 				$parser,
@@ -545,7 +545,7 @@ class HookRegistry {
 		/**
 		 * @see https://www.mediawiki.org/wiki/Manual:Hooks/ParserFirstCallInit
 		 */
-		$this->handlers['ParserFirstCallInit'] = function ( &$parser ) use( $applicationFactory ) {
+		$this->handlers['ParserFirstCallInit'] = function ( $parser ) use( $applicationFactory ) {
 
 			$parserFunctionFactory = $applicationFactory->newParserFunctionFactory( $parser );
 

--- a/extensions/SemanticMediaWiki/src/MediaWiki/Hooks/InternalParseBeforeLinks.php
+++ b/extensions/SemanticMediaWiki/src/MediaWiki/Hooks/InternalParseBeforeLinks.php
@@ -47,7 +47,7 @@ class InternalParseBeforeLinks {
 	 * @param Parser $parser
 	 * @param string $text
 	 */
-	public function __construct( Parser &$parser, &$text ) {
+	public function __construct( Parser $parser, &$text ) {
 		$this->parser = $parser;
 		$this->text =& $text;
 		$this->applicationFactory = ApplicationFactory::getInstance();

--- a/extensions/SemanticMediaWiki/src/MediaWiki/Hooks/LinksUpdateConstructed.php
+++ b/extensions/SemanticMediaWiki/src/MediaWiki/Hooks/LinksUpdateConstructed.php
@@ -90,7 +90,7 @@ class LinksUpdateConstructed {
 	 * @note Parsing is expensive but it is more expensive to loose data or to
 	 * expect that an external process adheres the object contract
 	 */
-	private function updateEmptySemanticData( &$parserData, $title ) {
+	private function updateEmptySemanticData( $parserData, $title ) {
 
 		wfDebug( __METHOD__ . ' Empty SemanticData : ' . $title->getPrefixedDBkey() . "\n" );
 

--- a/extensions/SemanticMediaWiki/src/MediaWiki/Hooks/ParserAfterTidy.php
+++ b/extensions/SemanticMediaWiki/src/MediaWiki/Hooks/ParserAfterTidy.php
@@ -39,7 +39,7 @@ class ParserAfterTidy {
 	 * @param Parser $parser
 	 * @param string $text
 	 */
-	public function __construct( Parser &$parser, &$text ) {
+	public function __construct( Parser $parser, &$text ) {
 		$this->parser = $parser;
 		$this->text =& $text;
 	}

--- a/extensions/SemanticMediaWiki/tests/phpunit/Unit/MediaWiki/Hooks/HookRegistryTest.php
+++ b/extensions/SemanticMediaWiki/tests/phpunit/Unit/MediaWiki/Hooks/HookRegistryTest.php
@@ -312,7 +312,7 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertThatHookIsExcutable(
 			$instance->getHandlerFor( $handler ),
-			array( &$parser, &$text )
+			array( $parser, &$text )
 		);
 	}
 
@@ -836,7 +836,7 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertThatHookIsExcutable(
 			$instance->getHandlerFor( $handler ),
-			array( &$parser )
+			array( $parser )
 		);
 	}
 

--- a/extensions/SemanticResultFormats/SemanticResultFormats.parser.php
+++ b/extensions/SemanticResultFormats/SemanticResultFormats.parser.php
@@ -33,20 +33,20 @@
  */
 class SRFParserFunctions {
 
-	static function registerFunctions( &$parser ) {
+	static function registerFunctions( $parser ) {
 		$parser->setFunctionHook( 'calendarstartdate', array( 'SRFParserFunctions', 'runCalendarStartDate' ) );
 		$parser->setFunctionHook( 'calendarenddate', array( 'SRFParserFunctions', 'runCalendarEndDate' ) );
 		return true;
 	}
 
-	static function runCalendarStartDate( &$parser, $calendar_type = 'month', $calendar_start_day = null, $calendar_days = 7, $default_year = null, $default_month = null, $default_day = null ) {
+	static function runCalendarStartDate( $parser, $calendar_type = 'month', $calendar_start_day = null, $calendar_days = 7, $default_year = null, $default_month = null, $default_day = null ) {
 		if ( $calendar_type == '' ) $calendar_type = 'month';
 		list( $lower_date, $upper_date, $query_date ) =
 			SRFParserFunctions::getBoundaryDates( $calendar_type, $calendar_start_day, $calendar_days, $default_year, $default_month, $default_day );
 		return date( "Y", $lower_date ) . '-' . date( "m", $lower_date ) . '-' . date( "d", $lower_date );
 	}
 
-	static function runCalendarEndDate( &$parser, $calendar_type = 'month', $calendar_start_day = null, $calendar_days = 7, $default_year = null, $default_month = null, $default_day = null ) {
+	static function runCalendarEndDate( $parser, $calendar_type = 'month', $calendar_start_day = null, $calendar_days = 7, $default_year = null, $default_month = null, $default_day = null ) {
 		if ( $calendar_type == '' ) $calendar_type = 'month';
 		list( $lower_date, $upper_date, $query_date ) =
 			SRFParserFunctions::getBoundaryDates( $calendar_type, $calendar_start_day, $calendar_days, $default_year, $default_month, $default_day );

--- a/extensions/SwiftCloudFiles/php-cloudfiles-1.7.10/cloudfiles_http.php
+++ b/extensions/SwiftCloudFiles/php-cloudfiles-1.7.10/cloudfiles_http.php
@@ -229,7 +229,7 @@ class CF_Http
 		curl_setopt( $curl_ch, CURLOPT_HTTPHEADER, $headers );
 		curl_setopt( $curl_ch, CURLOPT_USERAGENT, USER_AGENT );
 		curl_setopt( $curl_ch, CURLOPT_RETURNTRANSFER, TRUE );
-		curl_setopt( $curl_ch, CURLOPT_HEADERFUNCTION, array( &$this, '_auth_hdr_cb' ) );
+		curl_setopt( $curl_ch, CURLOPT_HEADERFUNCTION, array( $this, '_auth_hdr_cb' ) );
 		curl_setopt( $curl_ch, CURLOPT_CONNECTTIMEOUT, 10 );
 		curl_setopt( $curl_ch, CURLOPT_TIMEOUT, 10 );
 		curl_setopt( $curl_ch, CURLOPT_URL, $url );
@@ -1319,15 +1319,15 @@ class CF_Http
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
         curl_setopt($ch, CURLOPT_MAXREDIRS, 4);
         curl_setopt($ch, CURLOPT_HEADER, 0);
-        curl_setopt($ch, CURLOPT_HEADERFUNCTION, array(&$this, '_header_cb'));
+        curl_setopt($ch, CURLOPT_HEADERFUNCTION, array($this, '_header_cb'));
 
         if ($conn_type == "GET_CALL") {
-            curl_setopt($ch, CURLOPT_WRITEFUNCTION, array(&$this, '_write_cb'));
+            curl_setopt($ch, CURLOPT_WRITEFUNCTION, array($this, '_write_cb'));
         }
 
         if ($conn_type == "PUT_OBJ") {
             curl_setopt($ch, CURLOPT_PUT, 1);
-            curl_setopt($ch, CURLOPT_READFUNCTION, array(&$this, '_read_cb'));
+            curl_setopt($ch, CURLOPT_READFUNCTION, array($this, '_read_cb'));
 	    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         }
         if ($conn_type == "HEAD") {

--- a/extensions/SyntaxHighlight_GeSHi/SyntaxHighlight_GeSHi.php
+++ b/extensions/SyntaxHighlight_GeSHi/SyntaxHighlight_GeSHi.php
@@ -64,7 +64,7 @@ $wgResourceModules['ext.geshi.local'] = array( 'class' => 'HighlightGeSHilocal' 
  *
  * @param $parser Parser
  */
-function efSyntaxHighlight_GeSHiSetup( &$parser ) {
+function efSyntaxHighlight_GeSHiSetup( $parser ) {
 	$parser->setHook( 'source', array( 'SyntaxHighlight_GeSHi', 'parserHook' ) );
 	$parser->setHook( 'syntaxhighlight', array( 'SyntaxHighlight_GeSHi', 'parserHook' ) );
 	return true;

--- a/extensions/Validator/src/legacy/ParserHook.php
+++ b/extensions/Validator/src/legacy/ParserHook.php
@@ -168,7 +168,7 @@ abstract class ParserHook {
 	 *
 	 * @return true
 	 */
-	public function init( Parser &$parser ) {
+	public function init( Parser $parser ) {
 		$className = get_class( $this );
 		$first = true;
 
@@ -281,12 +281,12 @@ abstract class ParserHook {
 	 *
 	 * @since 0.4
 	 *
-	 * @param Parser &$parser
+	 * @param Parser $parser
 	 * ... further arguments ...
 	 *
 	 * @return array
 	 */
-	public function renderFunction( Parser &$parser /*, n args */ ) {
+	public function renderFunction( Parser $parser /*, n args */ ) {
 		$args = func_get_args();
 		
 		$this->parser = array_shift( $args );
@@ -314,12 +314,12 @@ abstract class ParserHook {
 	 *
 	 * @since 0.4.13
 	 * 
-	 * @param Parser &$parser
+	 * @param Parser $parser
 	 * @param PPFrame $frame
 	 * @param type $args
 	 * @return array 
 	 */
-	public function renderFunctionObj( Parser &$parser, PPFrame $frame, $args ) {		
+	public function renderFunctionObj( Parser $parser, PPFrame $frame, $args ) {
 		$this->frame = $frame;
 		
 		// create non-object args for old style 'renderFunction()'
@@ -599,13 +599,13 @@ class ParserHookCaller {
 		return $obj->{$this->method}( $input, $args, $parser, $frame );
 	}
 	
-	public function runFunctionHook( Parser &$parser /*, n args */ ) {
+	public function runFunctionHook( Parser $parser /*, n args */ ) {
 		$args = func_get_args();
 		$args[0] = &$parser; // with '&' becaus call_user_func_array is being used
 		return call_user_func_array( array( new $this->class(), $this->method ), $args );
 	}
 	
-	public function runFunctionHookObj( Parser &$parser, PPFrame $frame, array $args ) {
+	public function runFunctionHookObj( Parser $parser, PPFrame $frame, array $args ) {
 		$obj = new $this->class();		
 		return $obj->{$this->method}( $parser, $frame, $args );
 	}

--- a/extensions/Validator/src/legacy/ParserHook.php
+++ b/extensions/Validator/src/legacy/ParserHook.php
@@ -323,7 +323,7 @@ abstract class ParserHook {
 		$this->frame = $frame;
 		
 		// create non-object args for old style 'renderFunction()'
-		$oldStyleArgs = array( &$parser );
+		$oldStyleArgs = array( $parser );
 		
 		foreach( $args as $arg ) {
 			$oldStyleArgs[] = trim( $frame->expand( $arg ) );

--- a/extensions/Variables/Variables.php
+++ b/extensions/Variables/Variables.php
@@ -94,7 +94,7 @@ class ExtVariables {
 	 * 
 	 * @since 1.4
 	 */
-	public static function init( Parser &$parser ) {
+	public static function init( Parser $parser ) {
 		
 		/*
 		 * store for variables per parser object. This will solve several bugs related to
@@ -112,7 +112,7 @@ class ExtVariables {
 		
 		return true;
 	}
-	private static function initFunction( Parser &$parser, $name, $functionCallback = null, $flags = 0 ) {
+	private static function initFunction( Parser $parser, $name, $functionCallback = null, $flags = 0 ) {
 		if( $functionCallback === null ) {
 			// prefix parser functions with 'pf_'
 			$functionCallback = array( __CLASS__, 'pf_' . $name );
@@ -146,7 +146,7 @@ class ExtVariables {
 	# Parser Functions #
 	####################
 	
-    static function pf_varexists( Parser &$parser, $varName = '', $exists=true, $noexists=false ) {
+    static function pf_varexists( Parser $parser, $varName = '', $exists=true, $noexists=false ) {
         if( self::get( $parser )->varExists( $varName ) ) {
 			return $exists;
 		} else {
@@ -154,17 +154,17 @@ class ExtVariables {
 		}
     }
 	
-    static function pf_vardefine( Parser &$parser, $varName = '', $value = '' ) {
+    static function pf_vardefine( Parser $parser, $varName = '', $value = '' ) {
         self::get( $parser )->setVarValue( $varName, $value );
         return '';
     }
  
-    static function pf_vardefineecho( Parser &$parser, $varName = '', $value = '' ) {
+    static function pf_vardefineecho( Parser $parser, $varName = '', $value = '' ) {
         self::get( $parser )->setVarValue( $varName, $value );
         return $value;
     }
 		
-    static function pfObj_var( Parser &$parser, $frame, $args) {
+    static function pfObj_var( Parser $parser, $frame, $args) {
 		$varName = trim( $frame->expand( $args[0] ) ); // first argument expanded already but lets do this anyway
 		$varVal = self::get( $parser )->getVarValue( $varName, null );
 		
@@ -177,7 +177,7 @@ class ExtVariables {
 		return $varVal;
     }
 	
-	static function pf_var_final( Parser &$parser, $varName, $defaultVal = '' ) {
+	static function pf_var_final( Parser $parser, $varName, $defaultVal = '' ) {
 		$varStore = self::get( $parser );
 		
 		return self::get( $parser )->requestFinalizedVar( $parser, $varName, $defaultVal );
@@ -188,7 +188,7 @@ class ExtVariables {
 	# Used Hooks #
 	##############
 	
-	static function onInternalParseBeforeLinks( Parser &$parser, &$text ) {
+	static function onInternalParseBeforeLinks( Parser $parser, &$text ) {
 		
 		$varStore = self::get( $parser );
 		
@@ -241,7 +241,7 @@ class ExtVariables {
 	 * for example during import of several pages or job queue is running for multiple pages. In these cases variables
 	 * would become some kind of superglobals, being passed from one page to the other.
 	 */
-	static function onParserClearState( Parser &$parser ) {
+	static function onParserClearState( Parser $parser ) {
 		/**
 		 * MessageCaches Parser clone will mess things up if we don't reset the entire object.
 		 * Only resetting the array would unset it in the original object as well! This instead
@@ -284,11 +284,11 @@ class ExtVariables {
 	 * to a certain Parser object. Each parser has its own store which will be reset after
 	 * a parsing process [Parser::parse()] has finished.
 	 * 
-	 * @param Parser &$parser
+	 * @param Parser $parser
 	 * 
 	 * @return ExtVariables by reference so we still have the right object after 'ParserClearState'
 	 */
-	public static function &get( Parser &$parser ) {
+	public static function &get( Parser $parser ) {
 		return $parser->mExtVariables;
 	}
 	
@@ -355,7 +355,7 @@ class ExtVariables {
 	 *
 	 * @return string strip-item
 	 */
-	function requestFinalizedVar( Parser &$parser, $varName, $defaultVal = '' ) {
+	function requestFinalizedVar( Parser $parser, $varName, $defaultVal = '' ) {
 		if( $this->mFinalizedVarsStripState === null ) {
 			$this->mFinalizedVarsStripState = new StripState( $parser->mUniqPrefix );
 		}

--- a/extensions/VisualEditor/VisualEditor.hooks.php
+++ b/extensions/VisualEditor/VisualEditor.hooks.php
@@ -450,7 +450,7 @@ class VisualEditorHooks {
 	 * @param ResourceLoader $resourceLoader
 	 * @return boolean true
 	 */
-	public static function onResourceLoaderRegisterModules( ResourceLoader &$resourceLoader ) {
+	public static function onResourceLoaderRegisterModules( ResourceLoader $resourceLoader ) {
 		global $wgResourceModules;
 
 		$veResourceTemplate = ConfigFactory::getDefaultInstance()

--- a/extensions/timeline/Timeline.php
+++ b/extensions/timeline/Timeline.php
@@ -51,7 +51,7 @@ $wgExtensionMessagesFiles['Timeline'] = dirname(__FILE__) . '/Timeline.i18n.php'
  * @param $parser Parser
  * @return bool
  */
-function wfTimelineExtension( &$parser ) {
+function wfTimelineExtension( $parser ) {
 	$parser->setHook( 'timeline', 'wfRenderTimeline' );
 	return true;
 }

--- a/extensions/wikia/Answers/Answers.php
+++ b/extensions/wikia/Answers/Answers.php
@@ -605,7 +605,7 @@ class CategoryWithAds extends CategoryViewer{
 			} elseif( $this->showGallery && $title->getNamespace() == NS_FILE ) {
 				$this->addImage( $title, $x->cl_sortkey, $x->page_len, $x->page_is_redirect );
 			} else {
-				if( wfRunHooks( "CategoryViewer::addPage", array( &$this, &$title, &$x, $x->cl_sortkey ) ) ) {
+				if( wfRunHooks( "CategoryViewer::addPage", array( $this, &$title, &$x, $x->cl_sortkey ) ) ) {
 					$this->addPage( $title, $x->cl_sortkey, $x->page_len, $x->page_is_redirect );
 				}
 			}

--- a/extensions/wikia/AppPromoLanding/AppPromoLandingController.class.php
+++ b/extensions/wikia/AppPromoLanding/AppPromoLandingController.class.php
@@ -275,7 +275,7 @@ class AppPromoLandingController extends WikiaController {
 	 * to be done by a specific Oasis module.  However, instead of being located inside of
 	 * a special page, we are doing this by stealing the "Community_App" article title.
 	 */
-	public static function onOutputPageBeforeHTML( OutputPage &$out, &$text ) {
+	public static function onOutputPageBeforeHTML( OutputPage $out, &$text ) {
 		$title = $out->getTitle();
 		$origTitle = $title->getDBkey();
 

--- a/extensions/wikia/ArchiveWikiForum/ArchiveWikiForumHooks.class.php
+++ b/extensions/wikia/ArchiveWikiForum/ArchiveWikiForumHooks.class.php
@@ -57,7 +57,7 @@ class ArchiveWikiForumHooks {
      * @param $result
      * @return bool
      */
-    public static function onGetUserPermissionsErrors( Title &$title, User &$user, $action, &$result ) {
+    public static function onGetUserPermissionsErrors( Title $title, User $user, $action, &$result ) {
         if ( $action == 'read' ) {
             return true;
         }

--- a/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php
+++ b/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php
@@ -350,7 +350,7 @@ class ArticleAsJson extends WikiaService {
 		return true;
 	}
 
-	public static function onParserAfterTidy( Parser &$parser, &$text ) {
+	public static function onParserAfterTidy( Parser $parser, &$text ) {
 		global $wgArticleAsJson;
 
 		wfProfileIn( __METHOD__ );
@@ -411,7 +411,7 @@ class ArticleAsJson extends WikiaService {
 		return true;
 	}
 
-	public static function onShowEditLink( Parser &$parser, &$showEditLink ) {
+	public static function onShowEditLink( Parser $parser, &$showEditLink ) {
 		global $wgArticleAsJson;
 
 		//We don't have editing in this version

--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -1700,7 +1700,7 @@ class ArticleComment {
 	 * @param bool $result Whether $user can perform $action on $title
 	 * @return bool Whether to continue checking hooks
 	 */
-	static public function userCan( Title &$title, User &$user, $action, &$result ) {
+	static public function userCan( Title $title, User $user, $action, &$result ) {
 		$wg = F::app()->wg;
 		$commentsNS = $wg->ArticleCommentsNamespaces;
 		$ns = $title->getNamespace();

--- a/extensions/wikia/ArticleMetaDescription/ArticleMetaDescription.php
+++ b/extensions/wikia/ArticleMetaDescription/ArticleMetaDescription.php
@@ -35,7 +35,7 @@ $wgHooks['OutputPageBeforeHTML'][] = 'wfArticleMetaDescription';
  * @param string $text
  * @return bool
  */
-function wfArticleMetaDescription( &$out, &$text ) {
+function wfArticleMetaDescription( OutputPage $out, &$text ) {
 	wfProfileIn( __METHOD__ );
 
 	$wg = F::app()->wg;

--- a/extensions/wikia/Blogs/BlogsHelper.class.php
+++ b/extensions/wikia/Blogs/BlogsHelper.class.php
@@ -42,9 +42,9 @@ class BlogsHelper {
 	 * The method checks for usage of the bloglist tag and sets the page_props
 	 * accordingly.
 	 *
-	 * @param $oParser Object The Parser instance being used.
+	 * @param $oParser Parser The Parser instance being used.
 	 * @param $sText String The new content.
-	 * @param $oStringState Object The StripState instance being used.
+	 * @param $oStripState StripState The StripState instance being used.
 	 *
 	 * @return Boolean True so the calling function would continue.
 	 *
@@ -54,7 +54,7 @@ class BlogsHelper {
 	 * @see grep -r 'BugId:25123' *
 	 * @see doc/hooks.txt
 	 */
-	public static function OnParserBeforeInternalParse( &$oParser, &$sText, &$oStripState ) {
+	public static function OnParserBeforeInternalParse( Parser $oParser, &$sText, &$oStripState ) {
 		wfProfileIn( __METHOD__ );
 		// The name of the bloglist tag is defined in a constant.
 		$sRegExp = sprintf( '/<%s[^>]*>(.*)<\/%s>/siU', BLOGTPL_TAG, BLOGTPL_TAG );

--- a/extensions/wikia/Blogs/SpecialCreateBlogListingPage.php
+++ b/extensions/wikia/Blogs/SpecialCreateBlogListingPage.php
@@ -25,7 +25,7 @@ class CreateBlogListingPage extends SpecialPage {
 	public function execute( $par ) {
 		global $wgOut, $wgUser, $wgRequest, $wgTitle;
 
-		wfRunHooks( 'beforeBlogListingForm', array( &$this, $wgRequest->getVal( 'article' ) ) );
+		wfRunHooks( 'beforeBlogListingForm', array( $this, $wgRequest->getVal( 'article' ) ) );
 
 		if ( !$wgUser->isLoggedIn() ) {
 			$wgOut->showErrorPage( 'create-blog-no-login', 'create-blog-login-required', array( wfGetReturntoParam() ) );

--- a/extensions/wikia/Captcha/Captcha.class.php
+++ b/extensions/wikia/Captcha/Captcha.class.php
@@ -248,7 +248,7 @@ class Handler extends \WikiaObject {
 				$newLinks = $this->findLinks( $editPage, $newText );
 			}
 
-			$unknownLinks = array_filter( $newLinks, [ &$this, 'filterLink' ] );
+			$unknownLinks = array_filter( $newLinks, [ $this, 'filterLink' ] );
 			$addedLinks = array_diff( $unknownLinks, $oldLinks );
 			$numLinks = count( $addedLinks );
 
@@ -429,13 +429,13 @@ class Handler extends \WikiaObject {
 		}
 
 		$result = null;
-		$hookParams = [ &$this, &$editPage, $newText, $section, $merged, &$result ];
+		$hookParams = [ $this, &$editPage, $newText, $section, $merged, &$result ];
 		if ( !wfRunHooks( 'ConfirmEdit::onConfirmEdit', $hookParams ) ) {
 			return $result;
 		}
 
 		if ( !$this->doConfirmEdit( $editPage, $newText, $section, $merged ) ) {
-			$editPage->showEditForm( [ &$this, 'editCallback' ] );
+			$editPage->showEditForm( [ $this, 'editCallback' ] );
 			return false;
 		}
 		return true;

--- a/extensions/wikia/CategoryExhibition/CategoryExhibitionHooks.class.php
+++ b/extensions/wikia/CategoryExhibition/CategoryExhibitionHooks.class.php
@@ -75,7 +75,7 @@ class CategoryExhibitionHooks {
 	/**
 	 * Hook entry for removing the magic words from displayed text
 	 */
-	static public function onInternalParseBeforeLinks( &$parser, &$text, &$strip_state ) {
+	static public function onInternalParseBeforeLinks( $parser, &$text, &$strip_state ) {
 		global $wgRTEParserEnabled;
 		if ( empty( $wgRTEParserEnabled ) ) {
 			MagicWord::get( 'CATEXHIBITION_DISABLED' )->matchAndRemove( $text );

--- a/extensions/wikia/CategoryGalleries/CategoryGalleriesHelper.class.php
+++ b/extensions/wikia/CategoryGalleries/CategoryGalleriesHelper.class.php
@@ -62,7 +62,7 @@
 		/**
 		 * Hook entry for removing the magic words from displayed text
 		 */
-		static public function onInternalParseBeforeLinks(&$parser, &$text, &$strip_state) {
+		static public function onInternalParseBeforeLinks($parser, &$text, &$strip_state) {
 			global $wgRTEParserEnabled;
 			if (empty($wgRTEParserEnabled)) {
 				MagicWord::get('CATGALLERY_ENABLED')->matchAndRemove($text);

--- a/extensions/wikia/CategoryPagination/CategoryPaginationViewer.class.php
+++ b/extensions/wikia/CategoryPagination/CategoryPaginationViewer.class.php
@@ -65,7 +65,7 @@ class CategoryPaginationViewer extends CategoryViewer {
 		 * @see answerCategoryOtherSection
 		 */
 		$answersSection = '';
-		wfRunHooks( 'CategoryViewer::getOtherSection', [ &$this, &$answersSection ] );
+		wfRunHooks( 'CategoryViewer::getOtherSection', [ $this, &$answersSection ] );
 
 		/**
 		 * Hook for category galleries to add the top pages at the top
@@ -115,7 +115,7 @@ class CategoryPaginationViewer extends CategoryViewer {
 		// Get pages
 		$this->processSection( self::TYPE_PAGE, function ( $title, $humanSortkey, $row ) {
 			/** @see answerAddCategoryPage */
-			if ( wfRunHooks( 'CategoryViewer::addPage', array( &$this, &$title, &$row, $humanSortkey ) ) ) {
+			if ( wfRunHooks( 'CategoryViewer::addPage', array( $this, &$title, &$row, $humanSortkey ) ) ) {
 				$this->addPage( $title, $humanSortkey, $row->page_len, $row->page_is_redirect );
 				return true;
 			}

--- a/extensions/wikia/Chat2/ChatWidget.class.php
+++ b/extensions/wikia/Chat2/ChatWidget.class.php
@@ -24,7 +24,7 @@ class ChatWidget {
 	/**
 	 * @brief This function set parseTag hook
 	 */
-	public static function onParserFirstCallInit( Parser &$parser ) {
+	public static function onParserFirstCallInit( Parser $parser ) {
 		wfProfileIn( __METHOD__ );
 		$parser->setHook( CHAT_TAG, [ __CLASS__, "parseTag" ] );
 		wfProfileOut( __METHOD__ );

--- a/extensions/wikia/CommentsOnly/CommentsOnly.php
+++ b/extensions/wikia/CommentsOnly/CommentsOnly.php
@@ -79,7 +79,7 @@ function wfCOCategorySelectArticlePage() {
 	return !wfCOCheck();
 }
 
-function wfCOQuestionBox(Parser &$parser) {
+function wfCOQuestionBox(Parser $parser) {
 	$parser->setHook('questionbox', 'wfCOQuestionBoxRender');
 	return true;
 }

--- a/extensions/wikia/Comteam/ForumIndexProtector.php
+++ b/extensions/wikia/Comteam/ForumIndexProtector.php
@@ -15,7 +15,7 @@ $wgExtensionCredits['other'][] = array(
 
 $wgHooks['getUserPermissionsErrors'][] = 'fnForumIndexProtector';
 
-function fnForumIndexProtector( Title &$title, User &$user, $action, &$result) {
+function fnForumIndexProtector( Title $title, User $user, $action, &$result) {
 
 	if( $user->isLoggedIn() ) {
 		#this doesnt apply to logged in users, bail, but keep going

--- a/extensions/wikia/ContentFeeds/ContentFeeds.php
+++ b/extensions/wikia/ContentFeeds/ContentFeeds.php
@@ -46,7 +46,7 @@ function wfContentFeedsInit() {
 	 */
 	//$wgAjaxExportList[] = '';
 
-function wfContentFeedsInitParserHooks( Parser &$parser ) {
+function wfContentFeedsInitParserHooks( Parser $parser ) {
 
 	$parser->setHook( 'mostvisited', 'ContentFeeds::mostVisitedParserHook' );
 	$parser->setHook( 'wikitweets', 'ContentFeeds::wikiTweetsParserHook' );

--- a/extensions/wikia/EditPageLayout/EditPageLayout.class.php
+++ b/extensions/wikia/EditPageLayout/EditPageLayout.class.php
@@ -486,7 +486,7 @@ class EditPageLayout extends EditPage {
 	 * If you want to use another entry point to this function, be careful.
 	 */
 	protected function showConflict() {
-		if ( wfRunHooks( 'EditPageBeforeConflictDiff', array( &$this, &$this->out ) ) ) {
+		if ( wfRunHooks( 'EditPageBeforeConflictDiff', array( $this, &$this->out ) ) ) {
 			// diff
 			$this->out->addHtml('<div id="diff">');
 			$this->out->wrapWikiMsg( '<h2>$1</h2>', 'editpagelayout-diff-header' );

--- a/extensions/wikia/Forum/ForumHooksHelper.class.php
+++ b/extensions/wikia/Forum/ForumHooksHelper.class.php
@@ -162,7 +162,7 @@ class ForumHooksHelper {
 	 * @param $result
 	 * @return bool
 	 */
-	static public function getUserPermissionsErrors( &$title, &$user, $action, &$result ) {
+	static public function getUserPermissionsErrors( Title $title, $user, $action, &$result ) {
 		$result = null;
 
 		if ( Forum::$allowToEditBoard == true ) {

--- a/extensions/wikia/Forum/ForumHooksHelper.class.php
+++ b/extensions/wikia/Forum/ForumHooksHelper.class.php
@@ -381,8 +381,11 @@ class ForumHooksHelper {
 
 	/**
 	 * Create a tag for including the Forum Activity Module on pages
+	 *
+	 * @param Parser $parser
+	 * @return bool
 	 */
-	static public function onParserFirstCallInit( Parser &$parser ) {
+	static public function onParserFirstCallInit( Parser $parser ) {
 		$parser->setHook( 'wikiaforum', [ __CLASS__, 'parseForumActivityTag' ] );
 		return true;
 	}

--- a/extensions/wikia/ImageLazyLoad/ImageLazyLoad.class.php
+++ b/extensions/wikia/ImageLazyLoad/ImageLazyLoad.class.php
@@ -90,7 +90,7 @@ class ImageLazyLoad  {
 
 	}
 
-	public static function onParserClearState( &$parser ) {
+	public static function onParserClearState( $parser ) {
 		if ( !empty( $parser->lazyLoadedImagesCount ) ) {
 			$parser->lazyLoadedImagesCount = 0;
 		}

--- a/extensions/wikia/ImageServing/FakeImageGalleryImageServing.class.php
+++ b/extensions/wikia/ImageServing/FakeImageGalleryImageServing.class.php
@@ -40,7 +40,7 @@ class FakeImageGalleryImageServing extends ImageGallery {
 
 		# Give extensions a chance to select the file revision for us
 		$time = $descQuery = false;
-		wfRunHooks( 'BeforeGalleryFindFile', array( &$this, &$nt, &$time, &$descQuery ) );
+		wfRunHooks( 'BeforeGalleryFindFile', array( $this, &$nt, &$time, &$descQuery ) );
 
 		# Render image thumbnail
 		$img = wfFindFile( $nt, array('time' => $time) );

--- a/extensions/wikia/ImageServing/imageServing.class.php
+++ b/extensions/wikia/ImageServing/imageServing.class.php
@@ -180,7 +180,7 @@ class ImageServing {
 
 			if( empty( $out ) ) {
 				// Hook for finding fallback images if there were no matches. - NOTE: should this fallback any time (count($out) < $limit)? Seems like overkill.
-				wfRunHooks( 'ImageServing::fallbackOnNoResults', array( &$this, $limit, &$out ) );
+				wfRunHooks( 'ImageServing::fallbackOnNoResults', array( $this, $limit, &$out ) );
 			}
 
 			// apply limiting

--- a/extensions/wikia/ImageSizeInfoFunctions/ImageSizeInfoFunctions.hooks.php
+++ b/extensions/wikia/ImageSizeInfoFunctions/ImageSizeInfoFunctions.hooks.php
@@ -6,7 +6,7 @@
 
 class ExtImageSizeInfoFunctionsHooks {
 
-	static public function parserFirstCallInit( Parser &$parser ) {
+	static public function parserFirstCallInit( Parser $parser ) {
 		$parser->setFunctionHook( 'imgw', array( 'ExtImageSizeInfoFunctionsHooks', 'imageWidth' ) );
 		$parser->setFunctionHook( 'imgh', array( 'ExtImageSizeInfoFunctionsHooks', 'imageHeight' ) );
 		return true;

--- a/extensions/wikia/InterwikiDispatcher/SpecialInterwikiDispatcher_body.php
+++ b/extensions/wikia/InterwikiDispatcher/SpecialInterwikiDispatcher_body.php
@@ -127,7 +127,7 @@ class InterwikiDispatcher extends UnlistedSpecialPage {
 	 *
 	 * @return string, url if could convert, empty string otherwise
 	 */
-	public static function getInterWikiaURL( Title &$title ): string {
+	public static function getInterWikiaURL( Title $title ): string {
 		$url = '';
 
 		if ( self::isSupportedPrefix( $title->mInterwiki ) ) {
@@ -183,7 +183,7 @@ class InterwikiDispatcher extends UnlistedSpecialPage {
 	 *
 	 * @return bool
 	 */
-	public static function getInterWikiaURLHook( Title &$title, &$url, $query ) {
+	public static function getInterWikiaURLHook( Title $title, &$url, $query ) {
 		$interwikiUrl = self::getInterWikiaURL( $title );
 		$url = empty( $interwikiUrl ) ? $url : $interwikiUrl;
 

--- a/extensions/wikia/LandingPagesAsContent/LandingPagesParser.class.php
+++ b/extensions/wikia/LandingPagesAsContent/LandingPagesParser.class.php
@@ -20,7 +20,7 @@ class LandingPagesParser {
 		return true;
 	}
 
-	static public function onInternalParseBeforeLinksHook( &$parser, &$text, &$strip_state ) {
+	static public function onInternalParseBeforeLinksHook( $parser, &$text, &$strip_state ) {
 		global $wgLandingPagesAsContentMagicWords, $wgRTEParserEnabled;
 		if ( empty( $wgRTEParserEnabled ) ) {
 			$magicWords = array_keys( $wgLandingPagesAsContentMagicWords );

--- a/extensions/wikia/LatestPhotos/LatestPhotosHooks.class.php
+++ b/extensions/wikia/LatestPhotos/LatestPhotosHooks.class.php
@@ -13,7 +13,7 @@ class LatestPhotosHooks {
 		return true;
 	}
 
-	public static function onImageRenameCompleated( &$this , &$ot , &$nt ){
+	public static function onImageRenameCompleated( $this , &$ot , &$nt ){
 		global $wgMemc;
 		if ( $nt->getNamespace() == NS_FILE ) {
 			wfDebug(__METHOD__ . ": photo renamed\n");

--- a/extensions/wikia/MainPageTag/MainPageTag.php
+++ b/extensions/wikia/MainPageTag/MainPageTag.php
@@ -38,7 +38,7 @@ $wgMainPageTag_count = 0;
  * Set hooks for each of the three parser tags
  * @param Parser $parser reference to MediaWiki Parser object
  */
-function wfMainPageTag( &$parser ) {
+function wfMainPageTag( $parser ) {
 	$parser->setHook( 'mainpage-rightcolumn-start', 'wfMainPageTag_rcs' );
 	$parser->setHook( 'mainpage-leftcolumn-start', 'wfMainPageTag_lcs' );
 	$parser->setHook( 'mainpage-endcolumn', 'wfMainPageTag_ec' );

--- a/extensions/wikia/MobileContent/MobileContentParser.class.php
+++ b/extensions/wikia/MobileContent/MobileContentParser.class.php
@@ -6,7 +6,7 @@ class MobileContentParser {
 	 * @param Parser $parser
 	 * @return bool
 	 */
-	public static function onParserFirstCallInit( &$parser ) {
+	public static function onParserFirstCallInit( $parser ) {
 		$parser->setHook( 'mobile', 'MobileContentParser::displayContent' );
 		$parser->setHook( 'nomobile', 'MobileContentParser::hideContent' );
 		return true;

--- a/extensions/wikia/PortableInfobox/controllers/PortableInfoboxParserTagController.class.php
+++ b/extensions/wikia/PortableInfobox/controllers/PortableInfoboxParserTagController.class.php
@@ -53,7 +53,7 @@ class PortableInfoboxParserTagController extends WikiaController {
 	 *
 	 * @return string
 	 */
-	public static function replaceInfoboxMarkers( &$parser, &$text ) {
+	public static function replaceInfoboxMarkers( $parser, &$text ) {
 		global $wgArticleAsJson;
 		// The replacements for ArticleAsJson are handled in PortableInfoboxHooks::onArticleAsJsonBeforeEncode
 		if ( !$wgArticleAsJson ) {

--- a/extensions/wikia/QuickCreate/QuickCreate.php
+++ b/extensions/wikia/QuickCreate/QuickCreate.php
@@ -18,7 +18,7 @@ $wgExtensionMessagesFiles['QuickCreate'] = dirname(__FILE__) . '/QuickCreate.i18
 
 $wgHooks['ParserFirstCallInit'][] = 'wfQuickCreate';
 
-function wfQuickCreate( &$parser ) {
+function wfQuickCreate( $parser ) {
 	$parser->setHook( 'quickcreate', 'wfQuickCreateButton' );
 	return true;
 }

--- a/extensions/wikia/RTE/RTE.class.php
+++ b/extensions/wikia/RTE/RTE.class.php
@@ -95,7 +95,7 @@ class RTE {
 	 *
 	 * @author Inez KorczyDski, Macbre
 	 */
-	public static function init( &$form ) {
+	public static function init( EditPage $form ) {
 		global $wgOut, $wgHooks, $wgAllInOne, $wgRequest;
 
 		wfProfileIn(__METHOD__);
@@ -150,7 +150,7 @@ class RTE {
 	/**
 	 * Parse wikitext of edited article, so CK can be provided with HTML
 	 */
-	public static function init2( &$form, OutputPage &$out ) {
+	public static function init2( EditPage $form, OutputPage $out ) {
 		wfProfileIn(__METHOD__);
 
 		// add hidden edit form field

--- a/extensions/wikia/RTE/RTEMagicWord.class.php
+++ b/extensions/wikia/RTE/RTEMagicWord.class.php
@@ -19,7 +19,7 @@ class RTEMagicWord {
 		return true;
 	}
 
-	public static function remove(&$parser, &$text, &$strip_state) {
+	public static function remove($parser, &$text, &$strip_state) {
 		MagicWord::get('MAG_NOWYSIWYG')->matchAndRemove($text);
 		return true;
 	}

--- a/extensions/wikia/SharedHelp/CentralHelpSearch.php
+++ b/extensions/wikia/SharedHelp/CentralHelpSearch.php
@@ -36,7 +36,7 @@ $wgHooks['ParserFirstCallInit'][] = 'efCentralHelpSearchSetup';
  * @param Parser $parser
  * @return bool
  */
-function efCentralHelpSearchSetup( Parser &$parser ) {
+function efCentralHelpSearchSetup( Parser $parser ) {
 	$parser->setHook( 'centralhelpsearch', 'efCreateSearchForm' );
 
 	return true;

--- a/extensions/wikia/SharedHelp/SharedHelp.php
+++ b/extensions/wikia/SharedHelp/SharedHelp.php
@@ -546,7 +546,7 @@ function efSharedHelpGetMagicWord(&$magicWords, $langCode) {
 	return true;
 }
 
-function efSharedHelpRemoveMagicWord(&$parser, &$text, &$strip_state) {
+function efSharedHelpRemoveMagicWord($parser, &$text, &$strip_state) {
 	$found = MagicWord::get('MAG_NOSHAREDHELP')->matchAndRemove($text);
 	if ( $found ) {
 		$text .= NOSHAREDHELP_MARKER;

--- a/extensions/wikia/SharedHelp/SharedHelp.php
+++ b/extensions/wikia/SharedHelp/SharedHelp.php
@@ -126,7 +126,7 @@ class SharedHttp {
  * @param $text
  * @return bool
  */
-function SharedHelpHook(&$out, &$text) {
+function SharedHelpHook(OutputPage $out, &$text) {
 	global $wgTitle, $wgOut, $wgMemc, $wgCityId, $wgHelpWikiId, $wgContLang, $wgLanguageCode, $wgArticlePath;
 
 	/* Insurance that hook will be called only once #BugId:  */
@@ -358,7 +358,7 @@ function SharedHelpHook(&$out, &$text) {
 	return true;
 }
 
-function SharedHelpEditPageHook(&$editpage) {
+function SharedHelpEditPageHook(EditPage $editpage) {
 	global $wgTitle, $wgCityId, $wgHelpWikiId;
 
 	// do not show this message on the help wiki

--- a/extensions/wikia/StaffSig/StaffSig.php
+++ b/extensions/wikia/StaffSig/StaffSig.php
@@ -13,7 +13,7 @@ $wgHooks['ParserFirstCallInit'][] = 'wfSigSetup';
  * @param Parser $parser
  * @return bool
  */
-function wfSigSetup(&$parser) {
+function wfSigSetup($parser) {
 	$parser->setHook( 'staff', 'wfMakeStaffSignature' );
 	$parser->setHook( 'helper', 'wfMakeHelperSignature' );
 	return true;

--- a/extensions/wikia/StoriesLinkTag/StoriesLinkTagController.class.php
+++ b/extensions/wikia/StoriesLinkTag/StoriesLinkTagController.class.php
@@ -74,7 +74,7 @@ class StoriesLinkTagController extends WikiaController {
 	 * @param string $text
 	 * @return bool
 	 */
-	public static function onParserAfterTidy( Parser &$parser, &$text ) {
+	public static function onParserAfterTidy( Parser $parser, &$text ) {
 		if ( empty( F::app()->wg->ArticleAsJson ) ) {
 			$text = static::getInstance()->replaceMarkers( $text );
 		}

--- a/extensions/wikia/VideoHandlers/VideoHandlerHooks.class.php
+++ b/extensions/wikia/VideoHandlers/VideoHandlerHooks.class.php
@@ -80,7 +80,7 @@ class VideoHandlerHooks {
 	 * @param Parser $parser
 	 * @return bool
 	 */
-	static public function initParserHook( &$parser ) {
+	static public function initParserHook( $parser ) {
 		$parser->setHook( 'videogallery', [ 'CoreTagHooks', 'gallery' ] );
 		return true;
 	}
@@ -138,7 +138,7 @@ class VideoHandlerHooks {
 		return false;
 	}
 
-	static public function convertOldInterwikiToNewInterwiki( &$parser, &$text ) {
+	static public function convertOldInterwikiToNewInterwiki( $parser, &$text ) {
 		global $wgRTEParserEnabled;
 		if ( $wgRTEParserEnabled ) {
 			return true;

--- a/extensions/wikia/WallNotifications/WallNotificationControllerBase.class.php
+++ b/extensions/wikia/WallNotifications/WallNotificationControllerBase.class.php
@@ -91,7 +91,7 @@ abstract class WallNotificationControllerBase extends WikiaService {
 
 		$msg = "";
 		wfRunHooks( 'NotificationGetNotificationMessage', [
-			&$this, &$msg, $firstEntity->isMain(), $data, $authors, $userCount, $wg->User->getName()
+			$this, &$msg, $firstEntity->isMain(), $data, $authors, $userCount, $wg->User->getName()
 		] );
 
 		if ( empty( $msg ) ) {

--- a/extensions/wikia/WidgetTag/WidgetTag.php
+++ b/extensions/wikia/WidgetTag/WidgetTag.php
@@ -41,7 +41,7 @@ function efWidgetTagRender( $input, $args, $parser ) {
 	return $widgetTagRenderer->renderTag( $input, $args, $parser );
 }
 
-function efWidgetTagReplaceMarkers(&$parser, &$text) {
+function efWidgetTagReplaceMarkers($parser, &$text) {
 	$widgetTagRenderer = WidgetTagRenderer::getInstance();
 	$text = $widgetTagRenderer->replaceMarkers($text);
 	return true;

--- a/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
+++ b/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
@@ -236,7 +236,7 @@ class WikiFactoryLoader {
 		 *
 		 * @author Sean Colombo
 		 */
-		if( !wfRunHooks( 'WikiFactory::execute', array( &$this ) ) ) {
+		if( !wfRunHooks( 'WikiFactory::execute', array( $this ) ) ) {
 			wfProfileOut(__METHOD__);
 			return $this->mWikiID;
 		}
@@ -637,7 +637,7 @@ class WikiFactoryLoader {
 		$this->mVariables["wgDBCluster"] = $this->mCityCluster;
 
 		// @author macbre
-		wfRunHooks( 'WikiFactory::executeBeforeTransferToGlobals', array( &$this ) );
+		wfRunHooks( 'WikiFactory::executeBeforeTransferToGlobals', array( $this ) );
 
 		/**
 		 * transfer configuration variables from database to GLOBALS
@@ -746,7 +746,7 @@ class WikiFactoryLoader {
 			}
 		}
 
-		wfRunHooks( 'WikiFactory::onExecuteComplete', array( &$this ) );
+		wfRunHooks( 'WikiFactory::onExecuteComplete', array( $this ) );
 
 		wfProfileOut( __METHOD__ );
 

--- a/extensions/wikia/WikiaHomePage/WikiaHomePageController.class.php
+++ b/extensions/wikia/WikiaHomePage/WikiaHomePageController.class.php
@@ -697,7 +697,7 @@ class WikiaHomePageController extends WikiaController {
 		return true;
 	}
 
-	public static function onOutputPageBeforeHTML(OutputPage &$out, &$text) {
+	public static function onOutputPageBeforeHTML(OutputPage $out, &$text) {
 		Wikia\Logger\WikiaLogger::instance()->debug( 'SUS-1276', [ 'method' => __METHOD__ ] );
 		if (WikiaPageType::isMainPage() && !(F::app()->checkSkin('wikiamobile'))) {
 			$text = '';

--- a/extensions/wikia/WikiaMobile/WikiaMobileHooks.class.php
+++ b/extensions/wikia/WikiaMobile/WikiaMobileHooks.class.php
@@ -17,7 +17,7 @@ class WikiaMobileHooks {
 	 * @param $strip_state
 	 * @return bool
 	 */
-	static public function onParserBeforeStrip( &$parser, &$text, &$strip_state ) {
+	static public function onParserBeforeStrip( $parser, &$text, &$strip_state ) {
 		global $wgWikiaMobileDisableMediaGrouping;
 		wfProfileIn( __METHOD__ );
 
@@ -118,7 +118,7 @@ class WikiaMobileHooks {
 	 * @param $text String
 	 * @return bool
 	 */
-	static public function onParserAfterTidy( &$parser, &$text ){
+	static public function onParserAfterTidy( $parser, &$text ){
 		wfProfileIn( __METHOD__ );
 
 		if ( F::app()->checkSkin( 'wikiamobile' ) ) {

--- a/extensions/wikia/WikiaPhotoGallery/WikiaPhotoGallery.class.php
+++ b/extensions/wikia/WikiaPhotoGallery/WikiaPhotoGallery.class.php
@@ -166,7 +166,7 @@ class WikiaPhotoGallery extends ImageGallery {
 	 *
 	 * @param $parser Parser
 	 */
-	public function recordParserOption( &$parser ) {
+	public function recordParserOption( $parser ) {
 		if ( $this->mType == self::WIKIA_PHOTO_SLIDER ) {
 			/**
 			 * because slider tag contains elements of interface we need to
@@ -383,7 +383,7 @@ class WikiaPhotoGallery extends ImageGallery {
 	/**
 	 * Parse content of <gallery> tag (add images with captions and links provided)
 	 */
-	public function parse( &$parser = null ) {
+	public function parse( $parser = null ) {
 		wfProfileIn( __METHOD__ );
 
 		// use images passed inside <gallery> tag

--- a/extensions/wikia/WikiaPhotoGallery/WikiaPhotoGallery.class.php
+++ b/extensions/wikia/WikiaPhotoGallery/WikiaPhotoGallery.class.php
@@ -1204,7 +1204,7 @@ class WikiaPhotoGallery extends ImageGallery {
 
 				# Give extensions a chance to select the file revision for us
 				$time = $descQuery = false;
-				wfRunHooks( 'BeforeGalleryFindFile', array( &$this, &$nt, &$time, &$descQuery ) );
+				wfRunHooks( 'BeforeGalleryFindFile', array( $this, &$nt, &$time, &$descQuery ) );
 
 				$img = wfFindFile( $nt, $time );
 
@@ -1465,7 +1465,7 @@ class WikiaPhotoGallery extends ImageGallery {
 			// parse link (RT #142515)
 			$linkAttribs = $this->parseLink( $nt->getLocalUrl(), $nt->getText(), $link );
 
-			wfRunHooks( 'BeforeGalleryFindFile', array( &$this, &$nt, &$time, &$descQuery ) );
+			wfRunHooks( 'BeforeGalleryFindFile', array( $this, &$nt, &$time, &$descQuery ) );
 
 			$file = wfFindFile( $nt, $time );
 			if ( $file instanceof File && ( $nt->getNamespace() == NS_FILE ) ) {
@@ -1767,7 +1767,7 @@ class WikiaPhotoGallery extends ImageGallery {
 
 		// Give extensions a chance to select the file revision for us
 		$time = $descQuery = false;
-		wfRunHooks( 'BeforeGalleryFindFile', array( &$this, &$nt, &$time, &$descQuery ) );
+		wfRunHooks( 'BeforeGalleryFindFile', array( $this, &$nt, &$time, &$descQuery ) );
 
 		// Render image thumbnail
 		$img = wfFindFile( $nt, $time );

--- a/extensions/wikia/WikiaPhotoGallery/WikiaPhotoGalleryHelper.class.php
+++ b/extensions/wikia/WikiaPhotoGallery/WikiaPhotoGalleryHelper.class.php
@@ -63,7 +63,7 @@ class WikiaPhotoGalleryHelper {
 	/**
 	 * Allow this extension to use its own "parser" for <gallery> tag content
 	 */
-	static public function beforeRenderImageGallery(&$parser, &$ig) {
+	static public function beforeRenderImageGallery($parser, &$ig) {
 		$ig->parse($parser);
 		// by returning false we're telling MW parser to return gallery's HTML immediatelly
 		return false;
@@ -184,7 +184,7 @@ class WikiaPhotoGalleryHelper {
 	/**
 	 * Parse given link and return link tag attributes
 	 */
-	static public function parseLink(&$parser, $url, $text, $link) {
+	static public function parseLink($parser, $url, $text, $link) {
 		// fallback: link to image page + lightbox
 		$linkAttribs = array(
 			'class' => 'image lightbox',

--- a/extensions/wikia/WikiaWhiteList/WikiaWhiteList.php
+++ b/extensions/wikia/WikiaWhiteList/WikiaWhiteList.php
@@ -20,7 +20,7 @@ define ('CLASS_PARSE_WHITELIST', '/class\s*?=\s*?"%s\s*?(%s)"/');
 
 // Register hooks
 $wgHooks['ParserAfterTidy'][] = 'wfParserWhiteList' ;
-function wfParserWhiteList ( &$out, &$text) { 
+function wfParserWhiteList ( Parser $parser, &$text) {
 	$text = wfWhiteListRemoveNoFollowLinks($text);
 	return true;
 }

--- a/extensions/wikia/XBoxGamerCardTag/XBoxGamerCardTag.php
+++ b/extensions/wikia/XBoxGamerCardTag/XBoxGamerCardTag.php
@@ -15,7 +15,7 @@ $wgHooks['ParserFirstCallInit'][] = 'wfXBCardTagSetup';
  * @param Parser $parser
  * @return bool
  */
-function wfXBCardTagSetup(&$parser) {
+function wfXBCardTagSetup($parser) {
 	$parser->setHook( 'xboxcard', 'wfMakeXboxCard' );
 	return true;
 }

--- a/extensions/wikihiero/wikihiero.php
+++ b/extensions/wikihiero/wikihiero.php
@@ -78,7 +78,7 @@ $wgCompiledFiles[] = MWInit::extCompiledPath( 'wikihiero/data/tables.php' );
  * @param $parser Parser
  * @return bool
  */
-function wfRegisterWikiHiero( &$parser ) {
+function wfRegisterWikiHiero( $parser ) {
 	$parser->setHook( 'hiero', 'WikiHiero::parserHook' );
 	return true;
 }

--- a/includes/Article.php
+++ b/includes/Article.php
@@ -350,7 +350,7 @@ class Article extends Page {
 		$this->mContent = $this->mRevision->getText( Revision::FOR_THIS_USER ); // Loads if user is allowed
 		$this->mRevIdFetched = $this->mRevision->getId();
 
-		wfRunHooks( 'ArticleAfterFetchContent', array( &$this, &$this->mContent ) );
+		wfRunHooks( 'ArticleAfterFetchContent', array( $this, &$this->mContent ) );
 
 		wfProfileOut( __METHOD__ );
 
@@ -509,7 +509,7 @@ class Article extends Page {
 		while ( !$outputDone && ++$pass ) {
 			switch( $pass ) {
 				case 1:
-					wfRunHooks( 'ArticleViewHeader', array( &$this, &$outputDone, &$useParserCache ) );
+					wfRunHooks( 'ArticleViewHeader', array( $this, &$outputDone, &$useParserCache ) );
 					break;
 				case 2:
 					# Early abort if the page doesn't exist
@@ -519,7 +519,7 @@ class Article extends Page {
 						wfProfileOut( __METHOD__ );
 						/* Wikia change begin - @author: Marcin, #BugId: 30436 */
 							$text = '';
-							if (wfRunHooks('ArticleNonExistentPage', array( &$this, $wgOut, &$text))) {
+							if (wfRunHooks('ArticleNonExistentPage', array( $this, $wgOut, &$text))) {
 								$this->mParserOutput = $wgParser->parse(
 									$text,
 									$this->getTitle(),
@@ -905,7 +905,7 @@ class Article extends Page {
 		if ( isset( $this->mRedirectedFrom ) ) {
 			// This is an internally redirected page view.
 			// We'll need a backlink to the source page for navigation.
-			if ( wfRunHooks( 'ArticleViewRedirect', array( &$this ) ) ) {
+			if ( wfRunHooks( 'ArticleViewRedirect', array( $this ) ) ) {
 				# start wikia change
 				global $wgWikiaUseNoFollow;
 				$redirAttribs = array();
@@ -1165,7 +1165,7 @@ class Article extends Page {
 	public function setOldSubtitle( $oldid = 0 ) {
 		global $wgLang, $wgOut, $wgUser, $wgRequest;
 
-		if ( !wfRunHooks( 'DisplayOldSubtitle', array( &$this, &$oldid ) ) ) {
+		if ( !wfRunHooks( 'DisplayOldSubtitle', array( $this, &$oldid ) ) ) {
 			return;
 		}
 
@@ -1348,7 +1348,7 @@ class Article extends Page {
 	 */
 	public function protect() {
 		# Wikia change @author nAndy
-		wfRunHooks( 'BeforePageProtect', array(&$this) );
+		wfRunHooks( 'BeforePageProtect', array($this) );
 		# End of Wikia change
 		$form = new ProtectionForm( $this );
 		$form->execute();
@@ -1359,7 +1359,7 @@ class Article extends Page {
 	 */
 	public function unprotect() {
 		# Wikia change @author nAndy
-		wfRunHooks( 'BeforePageUnprotect', array(&$this) );
+		wfRunHooks( 'BeforePageUnprotect', array($this) );
 		# End of Wikia change
 		$this->protect();
 	}
@@ -1371,7 +1371,7 @@ class Article extends Page {
 		global $wgOut, $wgRequest, $wgLang;
 
 		# Wikia change @author nAndy
-		wfRunHooks( 'BeforePageDelete', array(&$this) );
+		wfRunHooks( 'BeforePageDelete', array($this) );
 		# End of Wikia change
 
 		# This code desperately needs to be totally rewritten
@@ -1383,7 +1383,7 @@ class Article extends Page {
 		$permission_errors = $title->getUserPermissionsErrors( 'delete', $user );
 
 		# Wikia change @author nAndy (DAR-1133)
-		wfRunHooks( 'BeforeDeletePermissionErrors', [ &$this, &$title, &$user, &$permission_errors ] );
+		wfRunHooks( 'BeforeDeletePermissionErrors', [ $this, &$title, &$user, &$permission_errors ] );
 		# End of Wikia change
 
 		if ( count( $permission_errors ) ) {
@@ -1663,7 +1663,7 @@ class Article extends Page {
 				&& !$this->mRedirectedFrom && !$this->getTitle()->isRedirect();
 			// Extension may have reason to disable file caching on some pages.
 			if ( $cacheable ) {
-				$cacheable = wfRunHooks( 'IsFileCacheable', array( &$this ) );
+				$cacheable = wfRunHooks( 'IsFileCacheable', array( $this ) );
 			}
 		}
 

--- a/includes/Block.php
+++ b/includes/Block.php
@@ -638,7 +638,7 @@ class Block {
 		}
 
 		# Allow hooks to cancel the autoblock.
-		if ( !wfRunHooks( 'AbortAutoblock', array( $autoblockIP, &$this ) ) ) {
+		if ( !wfRunHooks( 'AbortAutoblock', array( $autoblockIP, $this ) ) ) {
 			wfDebug( "Autoblock aborted by hook.\n" );
 			return false;
 		}

--- a/includes/CategoryPage.php
+++ b/includes/CategoryPage.php
@@ -48,7 +48,7 @@ class CategoryPage extends Article {
 			return;
 		}
 
-		if ( !wfRunHooks( 'CategoryPageView', array( &$this ) ) ) {
+		if ( !wfRunHooks( 'CategoryPageView', array( $this ) ) ) {
 			return;
 		}
 

--- a/includes/CategoryViewer.php
+++ b/includes/CategoryViewer.php
@@ -337,7 +337,7 @@ class CategoryViewer extends ContextSource {
 					$this->addImage( $title, $humanSortkey, $row->page_len, $row->page_is_redirect );
 				} else {
 					# <Wikia>
-					if( wfRunHooks( "CategoryViewer::addPage", array( &$this, &$title, &$row, $humanSortkey ) ) ) {
+					if( wfRunHooks( "CategoryViewer::addPage", array( $this, &$title, &$row, $humanSortkey ) ) ) {
 						$this->addPage( $title, $humanSortkey, $row->page_len, $row->page_is_redirect );
 					}
 					# </Wikia>
@@ -442,7 +442,7 @@ class CategoryViewer extends ContextSource {
 	/* <Wikia> */
 	function getOtherSection() {
 		$r = "";
-		wfRunHooks( "CategoryViewer::getOtherSection", array( &$this, &$r ) );
+		wfRunHooks( "CategoryViewer::getOtherSection", array( $this, &$r ) );
 		return $r;
 	}
 	/* </Wikia> */

--- a/includes/EditPage.php
+++ b/includes/EditPage.php
@@ -722,7 +722,7 @@ class EditPage {
 			$this->section === 'new' ? 'MediaWiki:addsection-editintro' : '' );
 
 		// Allow extensions to modify form data
-		wfRunHooks( 'EditPage::importFormData', array( &$this, $request ) );
+		wfRunHooks( 'EditPage::importFormData', array( $this, $request ) );
 
 		wfProfileOut( __METHOD__ );
 	}
@@ -874,7 +874,7 @@ class EditPage {
 		}
 
 		# <Wikia>
-		wfRunHooks( 'EditPage::getContent::end', array( &$this, &$text ) );
+		wfRunHooks( 'EditPage::getContent::end', array( $this, &$text ) );
 		# </Wikia>
 
 		wfProfileOut( __METHOD__ );
@@ -1786,7 +1786,7 @@ class EditPage {
 			$previewOutput = $this->getPreviewText();
 		}
 
-		wfRunHooks( 'EditPage::showEditForm:initial', array( &$this ) );
+		wfRunHooks( 'EditPage::showEditForm:initial', array( $this ) );
 
 		$this->setHeaders();
 
@@ -1802,7 +1802,7 @@ class EditPage {
 		}
 
 		// wikia change begin
-		wfRunHooks( 'EditPage::showEditForm:initial2', array( &$this ) ) ;
+		wfRunHooks( 'EditPage::showEditForm:initial2', array( $this ) ) ;
 		// wikia change end
 
 		$wgOut->addHTML( $this->editFormTextTop );
@@ -1832,7 +1832,7 @@ class EditPage {
 			call_user_func_array( $formCallback, array( &$wgOut ) );
 		}
 
-		wfRunHooks( 'EditPage::showEditForm:fields', array( &$this, &$wgOut ) );
+		wfRunHooks( 'EditPage::showEditForm:fields', array( $this, &$wgOut ) );
 
 		// Put these up at the top to ensure they aren't lost on early form submission
 		$this->showFormBeforeText();
@@ -1878,14 +1878,14 @@ class EditPage {
 		}
 
 		// wikia change begin
-		wfRunHooks ('EditForm:BeforeDisplayingTextbox', array (&$this, &$hidden /* TODO: remove? */) ) ;
+		wfRunHooks ('EditForm:BeforeDisplayingTextbox', array ($this, &$hidden /* TODO: remove? */) ) ;
 		// wikia change end
 
 		$wgOut->addHTML( $this->editFormTextBeforeContent );
 
 		/* Wikia change begin - @author: Marooned */
 		/* add possibility to add visible fields inside <form> but before toolbar - used in CreatePage  */
-		wfRunHooks( 'EditPage::showEditForm:beforeToolbar', array( &$this, &$wgOut ) );
+		wfRunHooks( 'EditPage::showEditForm:beforeToolbar', array( $this, &$wgOut ) );
 		/* Wikia change end */
 
 		/* Wikia change begin - @author: kflorence (BugId:40705) */
@@ -1910,7 +1910,7 @@ class EditPage {
 		}
 
 		// wikia change begin
-		wfRunHooks ('EditForm:AfterDisplayingTextbox', array (&$this, &$hidden /* TODO: remove? */) ) ;
+		wfRunHooks ('EditForm:AfterDisplayingTextbox', array ($this, &$hidden /* TODO: remove? */) ) ;
 
 		$rows = intval($wgUser->getGlobalPreference( 'rows' ));
 		$cols = intval($wgUser->getGlobalPreference( 'cols' ));
@@ -1945,7 +1945,7 @@ class EditPage {
 		# </Wikia>
 
 		# <Wikia>
-		if ( wfRunHooks( 'EditPage::CategoryBox', array( &$this ) ) ) {
+		if ( wfRunHooks( 'EditPage::CategoryBox', array( $this ) ) ) {
 			$wgOut->addHTML( Html::rawElement( 'div', array( 'class' => 'hiddencats' ),
 				Linker::formatHiddenCategories( $this->mArticle->getHiddenCategories() ) ) );
 		}
@@ -2081,7 +2081,7 @@ class EditPage {
 					if ( !$revision->isCurrent() ) {
 						/* Wikia change begin - @author: Marooned */
 						/* Add new hook and condition to allow alternate message to be displayed when editing old revision */
-						if ( wfRunHooks( 'EditPage::showEditForm:oldRevisionNotice', array( &$this ) ) ) {
+						if ( wfRunHooks( 'EditPage::showEditForm:oldRevisionNotice', array( $this ) ) ) {
 							$this->mArticle->setOldSubtitle( $revision->getId() );
 							$wgOut->addWikiMsg( 'editingold' );
 						}
@@ -2531,7 +2531,7 @@ HTML
 			array( 'minor' => $this->minoredit, 'watch' => $this->watchthis ) );
 
 		// wikia change begin, @author eloy
-		wfRunHooks ( 'EditPage::showEditForm:checkboxes', array ( &$this, &$checkboxes ) ) ;
+		wfRunHooks ( 'EditPage::showEditForm:checkboxes', array ( $this, &$checkboxes ) ) ;
 		// wikia change end
 
 		$wgOut->addHTML( "<div class='editCheckboxes'>" . implode( $checkboxes, "\n" ) . "</div>\n" );
@@ -2556,7 +2556,7 @@ HTML
 	 */
 	protected function showConflict() {
 		global $wgOut;
-		if ( wfRunHooks( 'EditPageBeforeConflictDiff', array( &$this, &$wgOut ) ) ) {
+		if ( wfRunHooks( 'EditPageBeforeConflictDiff', array( $this, &$wgOut ) ) ) {
 			$wgOut->wrapWikiMsg( '<h2>$1</h2>', "yourdiff" );
 
 			$de = new DifferenceEngine( $this->mArticle->getContext() );
@@ -3033,7 +3033,7 @@ HTML
 				Xml::expandAttributes( array( 'title' => Linker::titleAttrib( 'watch', 'withaccess' ) ) ) .
 				">{$watchLabel}</label>";
 		}
-		wfRunHooks( 'EditPageBeforeEditChecks', array( &$this, &$checkboxes, &$tabindex ) );
+		wfRunHooks( 'EditPageBeforeEditChecks', array( $this, &$checkboxes, &$tabindex ) );
 		return $checkboxes;
 	}
 
@@ -3083,7 +3083,7 @@ HTML
 		);
 		$buttons['diff'] = Xml::element( 'input', $temp, '' );
 
-		wfRunHooks( 'EditPageBeforeEditButtons', array( &$this, &$buttons, &$tabindex ) );
+		wfRunHooks( 'EditPageBeforeEditButtons', array( $this, &$buttons, &$tabindex ) );
 		return $buttons;
 	}
 
@@ -3161,7 +3161,7 @@ HTML
 		$wgOut->prepareErrorPage( wfMessage( 'nosuchsectiontitle' ) );
 
 		$res = wfMsgExt( 'nosuchsectiontext', 'parse', $this->section );
-		wfRunHooks( 'EditPageNoSuchSection', array( &$this, &$res ) );
+		wfRunHooks( 'EditPageNoSuchSection', array( $this, &$res ) );
 		$wgOut->addHTML( $res );
 
 		$wgOut->returnToMain( false, $this->mTitle );

--- a/includes/Export.php
+++ b/includes/Export.php
@@ -559,7 +559,7 @@ class XmlDumpWriter {
 				"" ) . "\n";
 		}
 
-		wfRunHooks( 'XmlDumpWriterWriteRevision', array( &$this, &$out, $row, $text ) );
+		wfRunHooks( 'XmlDumpWriterWriteRevision', array( $this, &$out, $row, $text ) );
 
 		$out .= "    </revision>\n";
 

--- a/includes/ImagePage.php
+++ b/includes/ImagePage.php
@@ -372,7 +372,7 @@ class ImagePage extends Article {
 
 			$longDesc = wfMessage( 'parentheses', $this->displayImg->getLongDesc() )->escaped();
 
-			wfRunHooks( 'ImageOpenShowImageInlineBefore', array( &$this, &$wgOut ) );
+			wfRunHooks( 'ImageOpenShowImageInlineBefore', array( $this, &$wgOut ) );
 
 			if ( $this->displayImg->allowInlineDisplay() ) {
 				# image

--- a/includes/LinksUpdate.php
+++ b/includes/LinksUpdate.php
@@ -103,7 +103,7 @@ class LinksUpdate {
 
 		$this->mRecursive = $recursive;
 
-		wfRunHooks( 'LinksUpdateConstructed', array( &$this ) );
+		wfRunHooks( 'LinksUpdateConstructed', array( $this ) );
 	}
 
 	/**
@@ -112,13 +112,13 @@ class LinksUpdate {
 	public function doUpdate() {
 		global $wgUseDumbLinkUpdate;
 
-		wfRunHooks( 'LinksUpdate', array( &$this ) );
+		wfRunHooks( 'LinksUpdate', array( $this ) );
 		if ( $wgUseDumbLinkUpdate ) {
 			$this->doDumbUpdate();
 		} else {
 			$this->doIncrementalUpdate();
 		}
-		wfRunHooks( 'LinksUpdateComplete', array( &$this ) );
+		wfRunHooks( 'LinksUpdateComplete', array( $this ) );
 	}
 
 	protected function doIncrementalUpdate() {

--- a/includes/MagicWord.php
+++ b/includes/MagicWord.php
@@ -456,7 +456,7 @@ class MagicWord {
 	 */
 	function matchAndRemove( &$text ) {
 		$this->mFound = false;
-		$text = preg_replace_callback( $this->getRegex(), array( &$this, 'pregRemoveAndRecord' ), $text );
+		$text = preg_replace_callback( $this->getRegex(), array( $this, 'pregRemoveAndRecord' ), $text );
 		return $this->mFound;
 	}
 
@@ -466,7 +466,7 @@ class MagicWord {
 	 */
 	function matchStartAndRemove( &$text ) {
 		$this->mFound = false;
-		$text = preg_replace_callback( $this->getRegexStart(), array( &$this, 'pregRemoveAndRecord' ), $text );
+		$text = preg_replace_callback( $this->getRegexStart(), array( $this, 'pregRemoveAndRecord' ), $text );
 		return $this->mFound;
 	}
 

--- a/includes/OutputPage.php
+++ b/includes/OutputPage.php
@@ -1221,7 +1221,7 @@ class OutputPage extends ContextSource {
 		}
 
 		# Add the remaining categories to the skin
-		if ( wfRunHooks( 'OutputPageMakeCategoryLinks', array( &$this, $categories, &$this->mCategoryLinks ) ) ) {
+		if ( wfRunHooks( 'OutputPageMakeCategoryLinks', array( $this, $categories, &$this->mCategoryLinks ) ) ) {
 			foreach ( $categories as $category => $type ) {
 				$origcategory = $category;
 				$title = Title::makeTitleSafe( NS_CATEGORY, $category );
@@ -1641,7 +1641,7 @@ class OutputPage extends ContextSource {
 			}
 		}
 
-		wfRunHooks( 'OutputPageParserOutput', array( &$this, $parserOutput ) );
+		wfRunHooks( 'OutputPageParserOutput', array( $this, $parserOutput ) );
 	}
 
 	/**
@@ -1653,7 +1653,7 @@ class OutputPage extends ContextSource {
 		$this->addParserOutputNoText( $parserOutput );
 		$text = $parserOutput->getText();
 
-		wfRunHooks( 'OutputPageBeforeHTML', array( &$this, &$text ) );
+		wfRunHooks( 'OutputPageBeforeHTML', array( $this, &$text ) );
 
 		$this->addHTML( $text );
 	}
@@ -2127,14 +2127,14 @@ class OutputPage extends ContextSource {
 
 			// Hook that allows last minute changes to the output page, e.g.
 			// adding of CSS or Javascript by extensions.
-			wfRunHooks( 'BeforePageDisplay', array( &$this, &$sk ) );
+			wfRunHooks( 'BeforePageDisplay', array( $this, &$sk ) );
 
 			wfProfileIn( 'Output-skin' );
 			$sk->outputPage();
 			wfProfileOut( 'Output-skin' );
 		}
 
-		wfRunHooks( 'BeforeSendCacheControl', array( &$this ) ); // Wikia change
+		wfRunHooks( 'BeforeSendCacheControl', array( $this ) ); // Wikia change
 
 		$this->sendCacheControl();
 		ob_end_flush();
@@ -2635,7 +2635,7 @@ $templates
 
 			$this->addModules( 'mediawiki.legacy.ajax' );
 
-			wfRunHooks( 'AjaxAddScript', array( &$this ) );
+			wfRunHooks( 'AjaxAddScript', array( $this ) );
 
 
 			if( $wgAjaxWatch && $this->getUser()->isLoggedIn() ) {

--- a/includes/RecentChange.php
+++ b/includes/RecentChange.php
@@ -207,7 +207,7 @@ class RecentChange {
 
 		/* Wikia change begin - @author: Macbre */
 		/* Wysiwyg: add extra data before row is added */
-		wfRunHooks( 'RecentChange_beforeSave', array( &$this ) );
+		wfRunHooks( 'RecentChange_beforeSave', array( $this ) );
 		/* Wikia change end */
 
 		# Insert new row
@@ -217,7 +217,7 @@ class RecentChange {
 		$this->mAttribs['rc_id'] = $dbw->insertId();
 
 		# Notify extensions
-		wfRunHooks( 'RecentChange_save', array( &$this ) );
+		wfRunHooks( 'RecentChange_save', array( $this ) );
 
 		# Notify external application via UDP
 		if ( !$noudp ) {

--- a/includes/Revision.php
+++ b/includes/Revision.php
@@ -1062,7 +1062,7 @@ class Revision implements IDBAccessObject {
 
 		$this->mId = !is_null( $rev_id ) ? $rev_id : $dbw->insertId();
 
-		wfRunHooks( 'RevisionInsertComplete', array( &$this, $data, $flags ) );
+		wfRunHooks( 'RevisionInsertComplete', array( $this, $data, $flags ) );
 
 		wfProfileOut( __METHOD__ );
 		return $this->mId;

--- a/includes/Skin.php
+++ b/includes/Skin.php
@@ -1572,7 +1572,7 @@ abstract class Skin extends ContextSource {
 			$attribs = " title=\"$attribs\"";
 		}
 		$result = null;
-		wfRunHooks( 'EditSectionLink', array( &$this, $nt, $section, $attribs, $link, &$result, $lang ) );
+		wfRunHooks( 'EditSectionLink', array( $this, $nt, $section, $attribs, $link, &$result, $lang ) );
 		if ( !is_null( $result ) ) {
 			# For reverse compatibility, add the brackets *after* the hook is
 			# run, and even add them to hook-provided text.  (This is the main

--- a/includes/SkinTemplate.php
+++ b/includes/SkinTemplate.php
@@ -547,7 +547,7 @@ class SkinTemplate extends Skin {
 		$tpl->set( 'reporttime', wfReportTime() );
 
 		// original version by hansm
-		if( !wfRunHooks( 'SkinTemplateOutputPageBeforeExec', array( &$this, &$tpl ) ) ) {
+		if( !wfRunHooks( 'SkinTemplateOutputPageBeforeExec', array( $this, &$tpl ) ) ) {
 			wfDebug( __METHOD__ . ": Hook SkinTemplateOutputPageBeforeExec broke outputPage execution!\n" );
 		}
 
@@ -792,7 +792,7 @@ class SkinTemplate extends Skin {
 		}
 
 		$result = array();
-		if( !wfRunHooks( 'SkinTemplateTabAction', array( &$this,
+		if( !wfRunHooks( 'SkinTemplateTabAction', array( $this,
 				$title, $message, $selected, $checkEdit,
 				&$classes, &$query, &$text, &$result ) ) ) {
 			return $result;
@@ -886,7 +886,7 @@ class SkinTemplate extends Skin {
 		$userCanRead = $title->quickUserCan( 'read', $user );
 
 		$preventActiveTabs = false;
-		wfRunHooks( 'SkinTemplatePreventOtherActiveTabs', array( &$this, &$preventActiveTabs ) );
+		wfRunHooks( 'SkinTemplatePreventOtherActiveTabs', array( $this, &$preventActiveTabs ) );
 
 		// Checks if page is some kind of content
 		if( $title->canExist() ) {
@@ -1055,7 +1055,7 @@ class SkinTemplate extends Skin {
 				}
 			}
 
-			wfRunHooks( 'SkinTemplateNavigation', array( &$this, &$content_navigation ) );
+			wfRunHooks( 'SkinTemplateNavigation', array( $this, &$content_navigation ) );
 
 			if ( $userCanRead && !$wgDisableLangConversion ) {
 				$pageLang = $title->getPageLanguage();
@@ -1095,11 +1095,11 @@ class SkinTemplate extends Skin {
 			);
 
 			wfRunHooks( 'SkinTemplateNavigation::SpecialPage',
-				array( &$this, &$content_navigation ) );
+				array( $this, &$content_navigation ) );
 		}
 
 		// Equiv to SkinTemplateContentActions
-		wfRunHooks( 'SkinTemplateNavigation::Universal', array( &$this,  &$content_navigation ) );
+		wfRunHooks( 'SkinTemplateNavigation::Universal', array( $this,  &$content_navigation ) );
 
 		// Setup xml ids and tooltip info
 		foreach ( $content_navigation as $section => &$links ) {
@@ -1246,7 +1246,7 @@ class SkinTemplate extends Skin {
 
 			// Use the copy of revision ID in case this undocumented, shady hook tries to mess with internals
 			wfRunHooks( 'SkinTemplateBuildNavUrlsNav_urlsAfterPermalink',
-				array( &$this, &$nav_urls, &$revid, &$revid ) );
+				array( $this, &$nav_urls, &$revid, &$revid ) );
 		}
 
 		if ( $out->isArticleRelated() ) {
@@ -1511,7 +1511,7 @@ abstract class BaseTemplate extends QuickTemplate {
 				$toolbox['permalink']['id'] = 't-permalink';
 			}
 		}
-		wfRunHooks( 'BaseTemplateToolbox', array( &$this, &$toolbox ) );
+		wfRunHooks( 'BaseTemplateToolbox', array( $this, &$toolbox ) );
 		wfProfileOut( __METHOD__ );
 		return $toolbox;
 	}
@@ -1621,7 +1621,7 @@ abstract class BaseTemplate extends QuickTemplate {
 			ob_start();
 			// We pass an extra 'true' at the end so extensions using BaseTemplateToolbox
 			// can abort and avoid outputting double toolbox links
-			wfRunHooks( 'SkinTemplateToolboxEnd', array( &$this, true ) );
+			wfRunHooks( 'SkinTemplateToolboxEnd', array( $this, true ) );
 			$hookContents = ob_get_contents();
 			ob_end_clean();
 			if ( !trim( $hookContents ) ) {

--- a/includes/StringUtils.php
+++ b/includes/StringUtils.php
@@ -208,7 +208,7 @@ class StringUtils {
  */
 class Replacer {
 	function cb() {
-		return array( &$this, 'replace' );
+		return array( $this, 'replace' );
 	}
 }
 

--- a/includes/Title.php
+++ b/includes/Title.php
@@ -1415,7 +1415,7 @@ class Title {
 		# Finally, add the fragment.
 		$url .= $this->getFragmentForURL();
 
-		wfRunHooks( 'GetFullURL', array( &$this, &$url, $query ) );
+		wfRunHooks( 'GetFullURL', array( $this, &$url, $query ) );
 		return $url;
 	}
 
@@ -1456,7 +1456,7 @@ class Title {
 			$dbkey = wfUrlencode( $this->getPrefixedDBkey() );
 			if ( $query == '' ) {
 				$url = str_replace( '$1', $dbkey, $wgArticlePath );
-				wfRunHooks( 'GetLocalURL::Article', array( &$this, &$url ) );
+				wfRunHooks( 'GetLocalURL::Article', array( $this, &$url ) );
 			} else {
 				global $wgVariantArticlePath, $wgActionPaths;
 				$url = false;
@@ -1508,7 +1508,7 @@ class Title {
 				}
 			}
 
-			wfRunHooks( 'GetLocalURL::Internal', array( &$this, &$url, $query ) );
+			wfRunHooks( 'GetLocalURL::Internal', array( $this, &$url, $query ) );
 
 			// @todo FIXME: This causes breakage in various places when we
 			// actually expected a local URL and end up with dupe prefixes.
@@ -1516,7 +1516,7 @@ class Title {
 				$url = $wgServer . $url;
 			}
 		}
-		wfRunHooks( 'GetLocalURL', array( &$this, &$url, $query ) );
+		wfRunHooks( 'GetLocalURL', array( $this, &$url, $query ) );
 		return $url;
 	}
 
@@ -1595,7 +1595,7 @@ class Title {
 		$query = self::fixUrlQueryArgs( $query, $query2 );
 		$server = $wgInternalServer !== false ? $wgInternalServer : $wgServer;
 		$url = wfExpandUrl( $server . $this->getLocalURL( $query ), PROTO_HTTP );
-		wfRunHooks( 'GetInternalURL', array( &$this, &$url, $query ) );
+		wfRunHooks( 'GetInternalURL', array( $this, &$url, $query ) );
 		return $url;
 	}
 
@@ -1615,7 +1615,7 @@ class Title {
 	public function getCanonicalURL( $query = '', $query2 = false ) {
 		$query = self::fixUrlQueryArgs( $query, $query2 );
 		$url = wfExpandUrl( $this->getLocalURL( $query ) . $this->getFragmentForURL(), PROTO_CANONICAL );
-		wfRunHooks( 'GetCanonicalURL', array( &$this, &$url, $query ) );
+		wfRunHooks( 'GetCanonicalURL', array( $this, &$url, $query ) );
 		return $url;
 	}
 
@@ -1844,16 +1844,16 @@ class Title {
 	private function checkPermissionHooks( $action, $user, $errors, $doExpensiveQueries, $short ) {
 		// Use getUserPermissionsErrors instead
 		$result = '';
-		if ( !wfRunHooks( 'userCan', array( &$this, &$user, $action, &$result ) ) ) {
+		if ( !wfRunHooks( 'userCan', array( $this, &$user, $action, &$result ) ) ) {
 			return $result ? array() : array( array( 'badaccess-group0' ) );
 		}
 		// Check getUserPermissionsErrors hook
-		if ( !wfRunHooks( 'getUserPermissionsErrors', array( &$this, &$user, $action, &$result ) ) ) {
+		if ( !wfRunHooks( 'getUserPermissionsErrors', array( $this, &$user, $action, &$result ) ) ) {
 			$errors = $this->resultToError( $errors, $result );
 		}
 		// Check getUserPermissionsErrorsExpensive hook
 		if ( $doExpensiveQueries && !( $short && count( $errors ) > 0 ) &&
-			 !wfRunHooks( 'getUserPermissionsErrorsExpensive', array( &$this, &$user, $action, &$result ) ) ) {
+			 !wfRunHooks( 'getUserPermissionsErrorsExpensive', array( $this, &$user, $action, &$result ) ) ) {
 			$errors = $this->resultToError( $errors, $result );
 		}
 
@@ -3758,7 +3758,7 @@ class Title {
 
 		$dbw->commit();
 
-		wfRunHooks( 'TitleMoveComplete', array( &$this, &$nt, &$wgUser, $pageid, $redirid ) );
+		wfRunHooks( 'TitleMoveComplete', array( $this, &$nt, &$wgUser, $pageid, $redirid ) );
 		return true;
 	}
 

--- a/includes/User.php
+++ b/includes/User.php
@@ -1361,7 +1361,7 @@ class User implements JsonSerializable {
 
 		# Extensions
 		/* Wikia change begin - SUS-92 */
-		wfRunHooks( 'GetBlockedStatus', array( &$this, $shouldLogBlockInStats, $global ) );
+		wfRunHooks( 'GetBlockedStatus', array( $this, $shouldLogBlockInStats, $global ) );
 		/* Wikia change end */
 
 		if ( !empty($this->mBlockedby) ) {
@@ -1516,7 +1516,7 @@ class User implements JsonSerializable {
 	public function pingLimiter( $action = 'edit' ) {
 		# Call the 'PingLimiter' hook
 		$result = false;
-		if( !wfRunHooks( 'PingLimiter', array( &$this, $action, $result ) ) ) {
+		if( !wfRunHooks( 'PingLimiter', array( $this, $action, $result ) ) ) {
 			return $result;
 		}
 
@@ -1702,7 +1702,7 @@ class User implements JsonSerializable {
 			$ip = $this->getRequest()->getIP();
 		}
 		$blocked = false;
-		wfRunHooks( 'UserIsBlockedGlobally', array( &$this, $ip, &$blocked ) );
+		wfRunHooks( 'UserIsBlockedGlobally', array( $this, $ip, &$blocked ) );
 		$this->mBlockedGlobally = (bool)$blocked;
 		return $this->mBlockedGlobally;
 	}
@@ -1856,7 +1856,7 @@ class User implements JsonSerializable {
 	 */
 	public function getNewMessageLinks() {
 		$talks = array();
-		wfRunHooks( 'UserRetrieveNewTalks', array( &$this, &$talks) );
+		wfRunHooks( 'UserRetrieveNewTalks', array( $this, &$talks) );
 
 		/* Wikia change begin - @author: XXX */
 		if( $this->getNewtalk() ) {
@@ -3132,7 +3132,7 @@ class User implements JsonSerializable {
 	 * Log this user out.
 	 */
 	public function logout() {
-		if ( wfRunHooks( 'UserLogout', array( &$this ) ) ) {
+		if ( wfRunHooks( 'UserLogout', array( $this ) ) ) {
 			$this->doLogout();
 		}
 	}
@@ -3659,7 +3659,7 @@ class User implements JsonSerializable {
 		}
 
 		$priority = 0;
-		wfRunHooks( 'UserSendConfirmationMail' , array( &$this, &$args, &$priority, &$url, $token, $ip_arg, $type ) );
+		wfRunHooks( 'UserSendConfirmationMail' , array( $this, &$args, &$priority, &$url, $token, $ip_arg, $type ) );
 
 		$emailController = $this->getEmailController( $mailtype );
 		if ( !empty( $emailController ) ) {
@@ -3928,7 +3928,7 @@ class User implements JsonSerializable {
 			return false;
 		}
 		$canSend = $this->isEmailConfirmed();
-		wfRunHooks( 'UserCanSendEmail', array( &$this, &$canSend ) );
+		wfRunHooks( 'UserCanSendEmail', array( $this, &$canSend ) );
 		return $canSend;
 	}
 
@@ -3955,7 +3955,7 @@ class User implements JsonSerializable {
 		global $wgEmailAuthentication;
 		$this->load();
 		$confirmed = true;
-		if ( wfRunHooks( 'EmailConfirmed', array( &$this, &$confirmed ) ) ) {
+		if ( wfRunHooks( 'EmailConfirmed', array( $this, &$confirmed ) ) ) {
 			if( $this->isAnon() ) {
 				return false;
 			}

--- a/includes/WikiPage.php
+++ b/includes/WikiPage.php
@@ -247,11 +247,11 @@ class WikiPage extends Page implements IDBAccessObject {
 	protected function pageData( $dbr, $conditions, $options = array() ) {
 		$fields = self::selectFields();
 
-		wfRunHooks( 'ArticlePageDataBefore', array( &$this, &$fields ) );
+		wfRunHooks( 'ArticlePageDataBefore', array( $this, &$fields ) );
 
 		$row = $dbr->selectRow( 'page', $fields, $conditions, __METHOD__, $options );
 
-		wfRunHooks( 'ArticlePageDataAfter', array( &$this, &$row ) );
+		wfRunHooks( 'ArticlePageDataAfter', array( $this, &$row ) );
 
 		return $row;
 	}
@@ -990,7 +990,7 @@ class WikiPage extends Page implements IDBAccessObject {
 	public function doPurge() {
 		global $wgUseSquid;
 
-		if( !wfRunHooks( 'ArticlePurge', array( &$this ) ) ){
+		if( !wfRunHooks( 'ArticlePurge', array( $this ) ) ){
 			return false;
 		}
 
@@ -1376,7 +1376,7 @@ class WikiPage extends Page implements IDBAccessObject {
 
 		$flags = $this->checkFlags( $flags );
 
-		if ( !wfRunHooks( 'ArticleSave', array( &$this, &$user, &$text, &$summary,
+		if ( !wfRunHooks( 'ArticleSave', array( $this, &$user, &$text, &$summary,
 			$flags & EDIT_MINOR, null, null, &$flags, &$status ) ) )
 		{
 			wfDebug( __METHOD__ . ": ArticleSave hook aborted save!\n" );
@@ -1588,7 +1588,7 @@ class WikiPage extends Page implements IDBAccessObject {
 			# Update links, etc.
 			$this->doEditUpdates( $revision, $user, array( 'created' => true ) );
 
-			wfRunHooks( 'ArticleInsertComplete', array( &$this, &$user, $text, $summary,
+			wfRunHooks( 'ArticleInsertComplete', array( $this, &$user, $text, $summary,
 				$flags & EDIT_MINOR, null, null, &$flags, $revision ) );
 		}
 
@@ -1600,7 +1600,7 @@ class WikiPage extends Page implements IDBAccessObject {
 		// Return the new revision (or null) to the caller
 		$status->value['revision'] = $revision;
 
-		wfRunHooks( 'ArticleSaveComplete', array( &$this, &$user, $text, $summary,
+		wfRunHooks( 'ArticleSaveComplete', array( $this, &$user, $text, $summary,
 			$flags & EDIT_MINOR, null, null, &$flags, $revision, &$status, $baseRevId ) );
 
 		wfProfileOut( __METHOD__ );
@@ -1701,9 +1701,9 @@ class WikiPage extends Page implements IDBAccessObject {
 		$u = new LinksUpdate( $this->mTitle, $editInfo->output );
 		$u->doUpdate();
 
-		wfRunHooks( 'ArticleEditUpdates', array( &$this, &$editInfo, $options['changed'] ) );
+		wfRunHooks( 'ArticleEditUpdates', array( $this, &$editInfo, $options['changed'] ) );
 
-		if ( wfRunHooks( 'ArticleEditUpdatesDeleteFromRecentchanges', array( &$this ) ) ) {
+		if ( wfRunHooks( 'ArticleEditUpdatesDeleteFromRecentchanges', array( $this ) ) ) {
 			if ( 0 == mt_rand( 0, 99 ) ) {
 				// Flush old entries from the `recentchanges` table
 				// Wikia: use a job backported from MediaWiki 1.25 (@see PLATFORM-965)
@@ -1745,7 +1745,7 @@ class WikiPage extends Page implements IDBAccessObject {
 			&& $shortTitle != $user->getTitleKey()
 			&& !( $revision->isMinor() && $user->isAllowed( 'nominornewtalk' ) )
 		) {
-			if ( wfRunHooks( 'ArticleEditUpdateNewTalk', array( &$this ) ) ) {
+			if ( wfRunHooks( 'ArticleEditUpdateNewTalk', array( $this ) ) ) {
 				$other = User::newFromName( $shortTitle, false );
 				if ( !$other ) {
 					wfDebug( __METHOD__ . ": invalid username\n" );
@@ -1907,7 +1907,7 @@ class WikiPage extends Page implements IDBAccessObject {
 		$protectDescription = trim( $protectDescription );
 
 		if ( $id ) { # Protection of existing page
-			if ( !wfRunHooks( 'ArticleProtect', array( &$this, &$user, $limit, $reason ) ) ) {
+			if ( !wfRunHooks( 'ArticleProtect', array( $this, &$user, $limit, $reason ) ) ) {
 				return Status::newGood();
 			}
 
@@ -1967,7 +1967,7 @@ class WikiPage extends Page implements IDBAccessObject {
 			);
 
 			wfRunHooks( 'NewRevisionFromEditComplete', array( $this, $nullRevision, $latest, $user ) );
-			wfRunHooks( 'ArticleProtectComplete', array( &$this, &$user, $limit, $reason ) );
+			wfRunHooks( 'ArticleProtectComplete', array( $this, &$user, $limit, $reason ) );
 		} else { # Protection of non-existing page (also known as "title protection")
 			# Cascade protection is meaningless in this case
 			$cascade = false;
@@ -2084,7 +2084,7 @@ class WikiPage extends Page implements IDBAccessObject {
 		}
 
 		$user = is_null( $user ) ? $wgUser : $user;
-		if ( ! wfRunHooks( 'ArticleDelete', array( &$this, &$user, &$reason, &$error ) ) ) {
+		if ( ! wfRunHooks( 'ArticleDelete', array( $this, &$user, &$reason, &$error ) ) ) {
 			return WikiPage::DELETE_HOOK_ABORTED;
 		}
 
@@ -2204,7 +2204,7 @@ class WikiPage extends Page implements IDBAccessObject {
 		$hookAddedLogEntry = false;
 
 		# @todo mediawiki merge 1.19: $log doesn't exist there
-		wfRunHooks('ArticleDoDeleteArticleBeforeLogEntry', array(&$this, &$logtype, $this->mTitle, $reason, &$hookAddedLogEntry));
+		wfRunHooks('ArticleDoDeleteArticleBeforeLogEntry', array($this, &$logtype, $this->mTitle, $reason, &$hookAddedLogEntry));
 		if( !$hookAddedLogEntry ) {
 			# if hook above didn't log anything log it as default
 
@@ -2248,7 +2248,7 @@ class WikiPage extends Page implements IDBAccessObject {
 			$dbw->commit();
 		}
 
-		wfRunHooks( 'ArticleDeleteComplete', array( &$this, &$user, $reason, $id ) );
+		wfRunHooks( 'ArticleDeleteComplete', array( $this, &$user, $reason, $id ) );
 		return WikiPage::DELETE_SUCCESS;
 	}
 
@@ -2828,7 +2828,7 @@ class WikiPage extends Page implements IDBAccessObject {
 		global $wgSkipCountForCategories;
 
 		/* Used by CategoryService */
-		wfRunHooks( 'ArticleUpdateCategoryCounts', array( &$this, $added, $deleted ));
+		wfRunHooks( 'ArticleUpdateCategoryCounts', array( $this, $added, $deleted ));
 
 		if( is_array( $wgSkipCountForCategories ) ) {
 			$added = array_diff( $added, $wgSkipCountForCategories );

--- a/includes/actions/HistoryAction.php
+++ b/includes/actions/HistoryAction.php
@@ -370,7 +370,7 @@ class HistoryPager extends ReverseChronologicalPager {
 			$queryInfo['options'],
 			$this->tagFilter
 		);
-		wfRunHooks( 'PageHistoryPager::getQueryInfo', array( &$this, &$queryInfo ) );
+		wfRunHooks( 'PageHistoryPager::getQueryInfo', array( $this, &$queryInfo ) );
 		return $queryInfo;
 	}
 

--- a/includes/actions/RawAction.php
+++ b/includes/actions/RawAction.php
@@ -113,7 +113,7 @@ class RawAction extends FormlessAction {
 			$response->header( 'HTTP/1.x 404 Not Found' );
 		}
 
-		if ( !wfRunHooks( 'RawPageViewBeforeOutput', array( &$this, &$text ) ) ) {
+		if ( !wfRunHooks( 'RawPageViewBeforeOutput', array( $this, &$text ) ) ) {
 			wfDebug( __METHOD__ . ": RawPageViewBeforeOutput hook broke raw page output.\n" );
 		}
 

--- a/includes/api/ApiBase.php
+++ b/includes/api/ApiBase.php
@@ -558,7 +558,7 @@ abstract class ApiBase extends ContextSource {
 	 */
 	public function getFinalParams() {
 		$params = $this->getAllowedParams();
-		wfRunHooks( 'APIGetAllowedParams', array( &$this, &$params ) );
+		wfRunHooks( 'APIGetAllowedParams', array( $this, &$params ) );
 		return $params;
 	}
 
@@ -570,7 +570,7 @@ abstract class ApiBase extends ContextSource {
 	 */
 	public function getFinalParamDescription() {
 		$desc = $this->getParamDescription();
-		wfRunHooks( 'APIGetParamDescription', array( &$this, &$desc ) );
+		wfRunHooks( 'APIGetParamDescription', array( $this, &$desc ) );
 		return $desc;
 	}
 
@@ -582,7 +582,7 @@ abstract class ApiBase extends ContextSource {
 	 */
 	public function getFinalDescription() {
 		$desc = $this->getDescription();
-		wfRunHooks( 'APIGetDescription', array( &$this, &$desc ) );
+		wfRunHooks( 'APIGetDescription', array( $this, &$desc ) );
 		return $desc;
 	}
 

--- a/includes/api/ApiQuerySiteinfo.php
+++ b/includes/api/ApiQuerySiteinfo.php
@@ -97,7 +97,7 @@ class ApiQuerySiteinfo extends ApiQueryBase {
 					$fit = $this->appendProtocols( $p );
 					break;
 				default:
-					wfRunHooks( 'UseExternalQuerySiteInfo', array(&$this) );
+					wfRunHooks( 'UseExternalQuerySiteInfo', array($this) );
 					if ( !isset($this->noErrors) ) {
 						ApiBase :: dieDebug( __METHOD__, "Unknown prop=$p" );
 					}

--- a/includes/db/Database.php
+++ b/includes/db/Database.php
@@ -1130,7 +1130,7 @@ abstract class DatabaseBase implements DatabaseType {
 		$this->preparedArgs =& $args;
 
 		return preg_replace_callback( '/(\\\\[?!&]|[?!&])/',
-			array( &$this, 'fillPreparedArg' ), $preparedQuery );
+			array( $this, 'fillPreparedArg' ), $preparedQuery );
 	}
 
 	/**
@@ -2745,7 +2745,7 @@ abstract class DatabaseBase implements DatabaseType {
 		list( $startOpts, $useIndex, $tailOpts ) = $this->makeSelectOptions( $selectOptions );
 
 		if ( is_array( $srcTable ) ) {
-			$srcTable =  implode( ',', array_map( array( &$this, 'tableName' ), $srcTable ) );
+			$srcTable =  implode( ',', array_map( array( $this, 'tableName' ), $srcTable ) );
 		} else {
 			$srcTable = $this->tableName( $srcTable );
 		}

--- a/includes/db/DatabaseOracle.php
+++ b/includes/db/DatabaseOracle.php
@@ -617,7 +617,7 @@ class DatabaseOracle extends DatabaseBase {
 		}
 		list( $startOpts, $useIndex, $tailOpts ) = $this->makeSelectOptions( $selectOptions );
 		if ( is_array( $srcTable ) ) {
-			$srcTable =  implode( ',', array_map( array( &$this, 'tableName' ), $srcTable ) );
+			$srcTable =  implode( ',', array_map( array( $this, 'tableName' ), $srcTable ) );
 		} else {
 			$srcTable = $this->tableName( $srcTable );
 		}
@@ -884,7 +884,7 @@ class DatabaseOracle extends DatabaseBase {
 	private function fieldInfoMulti( $table, $field ) {
 		$field = strtoupper( $field );
 		if ( is_array( $table ) ) {
-			$table = array_map( array( &$this, 'tableNameInternal' ), $table );
+			$table = array_map( array( $this, 'tableNameInternal' ), $table );
 			$tableWhere = 'IN (';
 			foreach( $table as &$singleTable ) {
 				$singleTable = $this->removeIdentifierQuotes($singleTable);

--- a/includes/db/DatabasePostgres.php
+++ b/includes/db/DatabasePostgres.php
@@ -572,7 +572,7 @@ class DatabasePostgres extends DatabaseBase {
 		}
 		list( $startOpts, $useIndex, $tailOpts ) = $this->makeSelectOptions( $selectOptions );
 		if( is_array( $srcTable ) ) {
-			$srcTable = implode( ',', array_map( array( &$this, 'tableName' ), $srcTable ) );
+			$srcTable = implode( ',', array_map( array( $this, 'tableName' ), $srcTable ) );
 		} else {
 			$srcTable = $this->tableName( $srcTable );
 		}

--- a/includes/diff/DifferenceEngine.php
+++ b/includes/diff/DifferenceEngine.php
@@ -670,7 +670,7 @@ class DifferenceEngine extends ContextSource {
 		$difftext = $this->generateDiffBody( $this->mOldtext, $this->mNewtext );
 
 		// Save to cache for 7 days
-		if ( !wfRunHooks( 'AbortDiffCache', array( &$this ) ) ) {
+		if ( !wfRunHooks( 'AbortDiffCache', array( $this ) ) ) {
 			wfIncrStats( 'diff_uncacheable' );
 		} elseif ( $key !== false && $difftext !== false ) {
 			wfIncrStats( 'diff_cache_miss' );
@@ -820,7 +820,7 @@ class DifferenceEngine extends ContextSource {
 	 */
 	function localiseLineNumbers( $text ) {
 		return preg_replace_callback( '/<!--LINE (\d+)-->/',
-		array( &$this, 'localiseLineNumbersCb' ), $text );
+		array( $this, 'localiseLineNumbersCb' ), $text );
 	}
 
 	function localiseLineNumbersCb( $matches ) {

--- a/includes/filerepo/file/LocalFile.php
+++ b/includes/filerepo/file/LocalFile.php
@@ -840,7 +840,7 @@ class LocalFile extends File {
 		$opts['ORDER BY'] = "oi_timestamp $order";
 		$opts['USE INDEX'] = array( 'oldimage' => 'oi_name_timestamp' );
 
-		wfRunHooks( 'LocalFile::getHistory', array( &$this, &$tables, &$fields,
+		wfRunHooks( 'LocalFile::getHistory', array( $this, &$tables, &$fields,
 			&$conds, &$opts, &$join_conds ) );
 
 		$res = $dbr->select( $tables, $fields, $conds, __METHOD__, $opts, $join_conds );

--- a/includes/parser/DateFormatter.php
+++ b/includes/parser/DateFormatter.php
@@ -164,7 +164,7 @@ class DateFormatter
 			
 			// Another horrible hack
 			$this->mLinked = $linked;
-			$text = preg_replace_callback( $regex, array( &$this, 'replace' ), $text );
+			$text = preg_replace_callback( $regex, array( $this, 'replace' ), $text );
 			unset($this->mLinked);
 		}
 		return $text;

--- a/includes/parser/LinkHolderArray.php
+++ b/includes/parser/LinkHolderArray.php
@@ -570,7 +570,7 @@ class LinkHolderArray {
 
 		$text = preg_replace_callback(
 			'/<!--(LINK|IWLINK) (.*?)-->/',
-			array( &$this, 'replaceTextCallback' ),
+			array( $this, 'replaceTextCallback' ),
 			$text );
 
 		wfProfileOut( __METHOD__ );

--- a/includes/parser/Parser.php
+++ b/includes/parser/Parser.php
@@ -256,7 +256,7 @@ class Parser {
 		CoreTagHooks::register( $this );
 		$this->initialiseVariables();
 
-		wfRunHooks( 'ParserFirstCallInit', array( &$this ) );
+		wfRunHooks( 'ParserFirstCallInit', array( $this ) );
 		wfProfileOut( __METHOD__ );
 	}
 
@@ -321,7 +321,7 @@ class Parser {
 			$this->mPreprocessor = null;
 		}
 
-		wfRunHooks( 'ParserClearState', array( &$this ) );
+		wfRunHooks( 'ParserClearState', array( $this ) );
 		wfProfileOut( __METHOD__ );
 	}
 
@@ -364,9 +364,9 @@ class Parser {
 			$this->mRevisionUser = null;
 		}
 
-		wfRunHooks( 'ParserBeforeStrip', array( &$this, &$text, &$this->mStripState ) );
+		wfRunHooks( 'ParserBeforeStrip', array( $this, &$text, &$this->mStripState ) );
 		# No more strip!
-		wfRunHooks( 'ParserAfterStrip', array( &$this, &$text, &$this->mStripState ) );
+		wfRunHooks( 'ParserAfterStrip', array( $this, &$text, &$this->mStripState ) );
 		$text = $this->internalParse( $text );
 
 		$text = $this->mStripState->unstripGeneral( $text );
@@ -437,7 +437,7 @@ class Parser {
 
 		$text = $this->mStripState->unstripNoWiki( $text );
 
-		wfRunHooks( 'ParserBeforeTidy', array( &$this, &$text ) );
+		wfRunHooks( 'ParserBeforeTidy', array( $this, &$text ) );
 
 		$text = $this->mStripState->unstripGeneral( $text );
 
@@ -477,7 +477,7 @@ class Parser {
 			$this->limitationWarn( 'expensive-parserfunction', $this->mExpensiveFunctionCount, $wgExpensiveParserFunctionLimit );
 		}
 
-		wfRunHooks( 'ParserAfterTidy', array( &$this, &$text ) );
+		wfRunHooks( 'ParserAfterTidy', array( $this, &$text ) );
 
 		// Wikia change begin - @author: wladek
 		$this->recordPerformanceStats( $wikitextSize, strlen($text) );
@@ -529,8 +529,8 @@ class Parser {
 	 */
 	function recursiveTagParse( $text, $frame=false ) {
 		wfProfileIn( __METHOD__ );
-		wfRunHooks( 'ParserBeforeStrip', array( &$this, &$text, &$this->mStripState ) );
-		wfRunHooks( 'ParserAfterStrip', array( &$this, &$text, &$this->mStripState ) );
+		wfRunHooks( 'ParserBeforeStrip', array( $this, &$text, &$this->mStripState ) );
+		wfRunHooks( 'ParserAfterStrip', array( $this, &$text, &$this->mStripState ) );
 		$text = $this->internalParse( $text, false, $frame );
 		wfProfileOut( __METHOD__ );
 		return $text;
@@ -546,8 +546,8 @@ class Parser {
 		if ( $revid !== null ) {
 			$this->mRevisionId = $revid;
 		}
-		wfRunHooks( 'ParserBeforeStrip', array( &$this, &$text, &$this->mStripState ) );
-		wfRunHooks( 'ParserAfterStrip', array( &$this, &$text, &$this->mStripState ) );
+		wfRunHooks( 'ParserBeforeStrip', array( $this, &$text, &$this->mStripState ) );
+		wfRunHooks( 'ParserAfterStrip', array( $this, &$text, &$this->mStripState ) );
 		$text = $this->replaceVariables( $text );
 		$text = $this->mStripState->unstripBoth( $text );
 		wfProfileOut( __METHOD__ );
@@ -1182,7 +1182,7 @@ class Parser {
 		$origText = $text;
 
 		# Hook to suspend the parser in this state
-		if ( !wfRunHooks( 'ParserBeforeInternalParse', array( &$this, &$text, &$this->mStripState ) ) ) {
+		if ( !wfRunHooks( 'ParserBeforeInternalParse', array( $this, &$text, &$this->mStripState ) ) ) {
 			wfProfileOut( __METHOD__ );
 			return $text ;
 		}
@@ -1203,8 +1203,8 @@ class Parser {
 			$text = $this->replaceVariables( $text );
 		}
 
-		$text = Sanitizer::removeHTMLtags( $text, [ &$this, 'attributeStripCallback' ] );
-		wfRunHooks( 'InternalParseBeforeLinks', array( &$this, &$text, &$this->mStripState ) );
+		$text = Sanitizer::removeHTMLtags( $text, [ $this, 'attributeStripCallback' ] );
+		wfRunHooks( 'InternalParseBeforeLinks', array( $this, &$text, &$this->mStripState ) );
 
 		# Tables need to come after variable replacement for things to work
 		# properly; putting them before other transformations should keep
@@ -1262,7 +1262,7 @@ class Parser {
 					(?: [0-9]  [\ \-]? ){9} # 9 digits with opt. delimiters
 					[0-9Xx]                 # check digit
 					\b)
-			)!xu', array( &$this, 'magicLinkCallback' ), $text );
+			)!xu', array( $this, 'magicLinkCallback' ), $text );
 
 		if ( preg_last_error() !== 0 ) {
 			\Wikia\Logger\WikiaLogger::instance()->error( 'PCRE error', [ 'preg_last_error' => preg_last_error() ] );
@@ -2867,14 +2867,14 @@ class Parser {
 		 * Some of these require message or data lookups and can be
 		 * expensive to check many times.
 		 */
-		if ( wfRunHooks( 'ParserGetVariableValueVarCache', array( &$this, &$this->mVarCache ) ) ) {
+		if ( wfRunHooks( 'ParserGetVariableValueVarCache', array( $this, &$this->mVarCache ) ) ) {
 			if ( isset( $this->mVarCache[$index] ) ) {
 				return $this->mVarCache[$index];
 			}
 		}
 
 		$ts = wfTimestamp( TS_UNIX, $this->mOptions->getTimestamp() );
-		wfRunHooks( 'ParserGetVariableValueTs', array( &$this, &$ts ) );
+		wfRunHooks( 'ParserGetVariableValueTs', array( $this, &$ts ) );
 
 		# Use the time zone
 		global $wgLocaltimezone;
@@ -3157,7 +3157,7 @@ class Parser {
 				return $wgLanguageCode;
 			default:
 				$ret = null;
-				if ( wfRunHooks( 'ParserGetVariableValueSwitch', array( &$this, &$this->mVarCache, &$index, &$ret, &$frame ) ) ) {
+				if ( wfRunHooks( 'ParserGetVariableValueSwitch', array( $this, &$this->mVarCache, &$index, &$ret, &$frame ) ) ) {
 					return $ret;
 				} else {
 					return null;
@@ -3481,7 +3481,7 @@ class Parser {
 				if ( $function ) {
 					wfProfileIn( __METHOD__ . '-pfunc-' . $function );
 					list( $callback, $flags ) = $this->mFunctionHooks[$function];
-					$initialArgs = array( &$this );
+					$initialArgs = array( $this );
 					$funcArgs = array( trim( substr( $part1, $colonPos + 1 ) ) );
 					if ( $flags & SFH_OBJECT_ARGS ) {
 						# Add a frame parameter, and pass the arguments as an array
@@ -3752,7 +3752,7 @@ class Parser {
 		}
 
 		# wikia start
-		wfRunHooks( 'Parser::endBraceSubstitution', array( $originalTitle, &$ret['text'], &$this ) );
+		wfRunHooks( 'Parser::endBraceSubstitution', array( $originalTitle, &$ret['text'], $this ) );
 		# wikia end
 
 		wfProfileOut( __METHOD__ );
@@ -4177,7 +4177,7 @@ class Parser {
 					throw new MWException( "Tag hook for $name is not callable\n" );
 				}
 
-				$output = call_user_func_array( $callback, array( &$this, $frame, $content, $attributes ) );
+				$output = call_user_func_array( $callback, array( $this, $frame, $content, $attributes ) );
 			} else {
 				$output = '<span class="error">Invalid tag extension name: ' .
 					htmlspecialchars( $name ) . '</span>';
@@ -4374,7 +4374,7 @@ class Parser {
 
 		/* Wikia change begin - @author: Macbre */
 		/* Allow extensions to force section edit link (RT #79897)*/
-		wfRunHooks('Parser::showEditLink', array(&$this, &$showEditLink));
+		wfRunHooks('Parser::showEditLink', array($this, &$showEditLink));
 		/* Wikia change end */
 
 		if ( $showEditLink ) {
@@ -4412,7 +4412,7 @@ class Parser {
 
 		/* Wikia change begin - @author: nAndy/Rafal */
 		/* Allow extensions to force not generating mediawiki TOC */
-		wfRunHooks('Parser::disableMWTOC', [ &$this, &$enoughToc ]);
+		wfRunHooks('Parser::disableMWTOC', [ $this, &$enoughToc ]);
 		/* Wikia change end */
 
 		# headline counter
@@ -5258,7 +5258,7 @@ class Parser {
 
 		/* Wikia change begin */
 		/* Allow extensions to use their own "parser" for <gallery> tag content */
-		if ( !wfRunHooks( 'BeforeParserrenderImageGallery', array( &$this, &$ig ) ) ) {
+		if ( !wfRunHooks( 'BeforeParserrenderImageGallery', array( $this, &$ig ) ) ) {
 			wfRunHooks( 'AfterParserParseImageGallery', [ $marker, $ig ] );
 			return $ig->toHTML();
 		}
@@ -5423,7 +5423,7 @@ class Parser {
 			'horizAlign' => array(), 'vertAlign' => array() );
 
 		# wikia start
-		if (!wfRunHooks( 'BeforeParserMakeImageLinkObjOptions', array( &$this, &$title, &$parts, &$params, &$time, &$descQuery, $options ) ) ) {
+		if (!wfRunHooks( 'BeforeParserMakeImageLinkObjOptions', array( $this, &$title, &$parts, &$params, &$time, &$descQuery, $options ) ) ) {
 			$ret = Linker::makeImageLink2( $title, $file, $params['frame'], $params['handler'], $time, $descQuery );
 			return $ret;
 		}

--- a/includes/parser/ParserOutput.php
+++ b/includes/parser/ParserOutput.php
@@ -188,7 +188,7 @@ class ParserOutput extends CacheTime {
 	function getText() {
 		if ( $this->mEditSectionTokens ) {
 			return preg_replace_callback( ParserOutput::EDITSECTION_REGEX,
-				array( &$this, 'replaceEditSectionLinksCallback' ), $this->mText );
+				array( $this, 'replaceEditSectionLinksCallback' ), $this->mText );
 		}
 		return preg_replace( ParserOutput::EDITSECTION_REGEX, '', $this->mText );
 	}

--- a/includes/parser/Parser_LinkHooks.php
+++ b/includes/parser/Parser_LinkHooks.php
@@ -59,7 +59,7 @@ class Parser_LinkHooks extends Parser {
 		CoreLinkFunctions::register( $this );
 		$this->initialiseVariables();
 
-		wfRunHooks( 'ParserFirstCallInit', array( &$this ) );
+		wfRunHooks( 'ParserFirstCallInit', array( $this ) );
 		wfProfileOut( __METHOD__ );
 	}
 
@@ -138,7 +138,7 @@ class Parser_LinkHooks extends Parser {
 		
 		$offset = 0;
 		$offsetStack = array();
-		$markers = new LinkMarkerReplacer( $this, $holders, array( &$this, 'replaceInternalLinksCallback' ) );
+		$markers = new LinkMarkerReplacer( $this, $holders, array( $this, 'replaceInternalLinksCallback' ) );
 		while( true ) {
 			$startBracketOffset = strpos( $s, '[[', $offset );
 			$endBracketOffset   = strpos( $s, ']]', $offset );
@@ -292,7 +292,7 @@ class LinkMarkerReplacer {
 	}
 	
 	function expand( $string ) {
-		return StringUtils::delimiterReplaceCallback( "<!-- LINKMARKER ", " -->", array( &$this, 'callback' ), $string );
+		return StringUtils::delimiterReplaceCallback( "<!-- LINKMARKER ", " -->", array( $this, 'callback' ), $string );
 	}
 	
 	function callback( $m ) {

--- a/includes/parser/Tidy.php
+++ b/includes/parser/Tidy.php
@@ -42,7 +42,7 @@ class MWTidyWrapper {
 		$this->mMarkerIndex = 0;
 
 		$wrappedtext = preg_replace_callback( ParserOutput::EDITSECTION_REGEX,
-			array( &$this, 'replaceEditSectionLinksCallback' ), $text );
+			array( $this, 'replaceEditSectionLinksCallback' ), $text );
 
 		$wrappedtext = '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"'.
 			' "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html>'.

--- a/includes/profiler/Profiler.php
+++ b/includes/profiler/Profiler.php
@@ -221,7 +221,7 @@ class Profiler {
 	 * Returns a tree of function call instead of a list of functions
 	 */
 	function getCallTree() {
-		return implode( '', array_map( array( &$this, 'getCallTreeLine' ), $this->remapCallTree( $this->mStack ) ) );
+		return implode( '', array_map( array( $this, 'getCallTreeLine' ), $this->remapCallTree( $this->mStack ) ) );
 	}
 
 	/**

--- a/includes/resourceloader/ResourceLoader.php
+++ b/includes/resourceloader/ResourceLoader.php
@@ -236,7 +236,7 @@ class ResourceLoader {
 		$this->setSourceForStaticModules('common');
 		// Wikia - change end
 		// Register extension modules
-		wfRunHooks( 'ResourceLoaderRegisterModules', array( &$this ) );
+		wfRunHooks( 'ResourceLoaderRegisterModules', array( $this ) );
 		$this->register( $wgResourceModules );
 
 		if ( $wgEnableJavaScriptTest === true ) {
@@ -316,7 +316,7 @@ class ResourceLoader {
 		$testModules = array();
 		$testModules['qunit'] = include( "$IP/tests/qunit/QUnitTestResources.php" );
 		// Get other test suites (e.g. from extensions)
-		wfRunHooks( 'ResourceLoaderTestModules', array( &$testModules, &$this ) );
+		wfRunHooks( 'ResourceLoaderTestModules', array( &$testModules, $this ) );
 
 		// Add the testrunner (which configures QUnit) to the dependencies.
 		// Since it must be ready before any of the test suites are executed.

--- a/includes/specials/SpecialConfirmemail.php
+++ b/includes/specials/SpecialConfirmemail.php
@@ -67,7 +67,7 @@ class EmailConfirmation extends UnlistedSpecialPage {
 			if( $this->getUser()->isLoggedIn() ) {
 				/* Wikia change - begin */
 				$show = true;
-				wfRunHooks( 'ConfirmEmailShowRequestForm', array( &$this, &$show ) );
+				wfRunHooks( 'ConfirmEmailShowRequestForm', array( $this, &$show ) );
 				if ( $show ) {
 					if( Sanitizer::validateEmail( $this->getUser()->getEmail() ) ) {
 						$this->showRequestForm();

--- a/includes/specials/SpecialContributions.php
+++ b/includes/specials/SpecialContributions.php
@@ -623,7 +623,7 @@ class ContribsPager extends ReverseChronologicalPager {
 			$this->tagFilter
 		);
 
-		wfRunHooks( 'ContribsPager::getQueryInfo', array( &$this, &$queryInfo ) );
+		wfRunHooks( 'ContribsPager::getQueryInfo', array( $this, &$queryInfo ) );
 		return $queryInfo;
 	}
 
@@ -871,7 +871,7 @@ class ContribsPager extends ReverseChronologicalPager {
 		$ret .= " $tagSummary";
 
 		// Let extensions add data
-		wfRunHooks( 'ContributionsLineEnding', array( &$this, &$ret, $row ) );
+		wfRunHooks( 'ContributionsLineEnding', array( $this, &$ret, $row ) );
 
 		$classes = implode( ' ', $classes );
 		$ret = "<li class=\"$classes\">$ret</li>\n";

--- a/includes/specials/SpecialListredirects.php
+++ b/includes/specials/SpecialListredirects.php
@@ -57,7 +57,7 @@ class ListredirectsPage extends QueryPage {
 					'p2.page_title=rd_title' ) ) )
 		);
 
-		wfRunHooks( 'ListredirectsPage::getQueryInfo', array( &$this, &$query ) );
+		wfRunHooks( 'ListredirectsPage::getQueryInfo', array( $this, &$query ) );
 		return $query;
 	}
 

--- a/includes/specials/SpecialMovepage.php
+++ b/includes/specials/SpecialMovepage.php
@@ -415,7 +415,7 @@ class MovePageForm extends UnlistedSpecialPage {
 		$ot = $this->oldTitle;
 		$nt = $this->newTitle;
 
-		if( ! wfRunHooks( 'SpecialMovepageBeforeMove', array(&$this))) {
+		if( ! wfRunHooks( 'SpecialMovepageBeforeMove', array($this))) {
 			return;
 		}
 
@@ -493,7 +493,7 @@ class MovePageForm extends UnlistedSpecialPage {
 			DoubleRedirectJob::fixRedirects( 'move', $ot, $nt );
 		}
 
-		wfRunHooks( 'SpecialMovepageAfterMove', array( &$this, &$ot, &$nt ) );
+		wfRunHooks( 'SpecialMovepageAfterMove', array( $this, &$ot, &$nt ) );
 
 		$out = $this->getOutput();
 		$out->setPagetitle( wfMsg( 'pagemovedsub' ) );

--- a/includes/specials/SpecialNewpages.php
+++ b/includes/specials/SpecialNewpages.php
@@ -521,7 +521,7 @@ class NewPagesPager extends ReverseChronologicalPager {
 		$join_conds = array( 'page' => array( 'INNER JOIN', 'page_id=rc_cur_id' ) );
 
 		wfRunHooks( 'SpecialNewpagesConditions',
-			array( &$this, $this->opts, &$conds, &$tables, &$fields, &$join_conds ) );
+			array( $this, $this->opts, &$conds, &$tables, &$fields, &$join_conds ) );
 
 		$info = array(
 			'tables' 	 => $tables,

--- a/includes/specials/SpecialPreferences.php
+++ b/includes/specials/SpecialPreferences.php
@@ -53,7 +53,7 @@ class SpecialPreferences extends SpecialPage {
 
 		/* Wikia change begin - @author: macbre */
 		/* Enable custom notifications handling */
-		wfRunHooks('SpecialPreferencesOnRender', array(&$this));
+		wfRunHooks('SpecialPreferencesOnRender', array($this));
 		/* Wikia change end */
 
 		if ( $this->getRequest()->getCheck( 'success' ) ) {

--- a/includes/specials/SpecialStatistics.php
+++ b/includes/specials/SpecialStatistics.php
@@ -101,7 +101,7 @@ class SpecialStatistics extends SpecialPage {
 		$text .= Xml::closeElement( 'table' );
 
 		#<Wikia>
-		wfRunHooks( "CustomSpecialStatistics", array( &$this, &$text ) );
+		wfRunHooks( "CustomSpecialStatistics", array( $this, &$text ) );
 		#</Wikia>
 
 		# Customizable footer

--- a/includes/specials/SpecialUndelete.php
+++ b/includes/specials/SpecialUndelete.php
@@ -385,7 +385,7 @@ class PageArchive {
 
 		/* Wikia change begin - @author: Andrzej 'nAndy' Lukaszewski */
 		$hookAddedLogEntry = false;
-		wfRunHooks('PageArchiveUndeleteBeforeLogEntry', array(&$this, &$log, &$this->title, $reason, &$hookAddedLogEntry));
+		wfRunHooks('PageArchiveUndeleteBeforeLogEntry', array($this, &$log, &$this->title, $reason, &$hookAddedLogEntry));
 		if( !$hookAddedLogEntry ) {
 			//if hook above didn't log anything log it as default
 			$log->addEntry( 'restore', $this->title, $reason );

--- a/includes/specials/SpecialUpload.php
+++ b/includes/specials/SpecialUpload.php
@@ -173,7 +173,7 @@ class SpecialUpload extends SpecialPage {
 			$this->processUpload();
 		} else {
 			# Backwards compatibility hook
-			if( !wfRunHooks( 'UploadForm:initial', array( &$this ) ) ) {
+			if( !wfRunHooks( 'UploadForm:initial', array( $this ) ) ) {
 				wfDebug( "Hook 'UploadForm:initial' broke output of the upload form" );
 				return;
 			}
@@ -391,7 +391,7 @@ class SpecialUpload extends SpecialPage {
 			return;
 		}
 
-		if( !wfRunHooks( 'UploadForm:BeforeProcessing', array( &$this ) ) ) {
+		if( !wfRunHooks( 'UploadForm:BeforeProcessing', array( $this ) ) ) {
 			wfDebug( "Hook 'UploadForm:BeforeProcessing' broke processing the file.\n" );
 			// This code path is deprecated. If you want to break upload processing
 			// do so by hooking into the appropriate hooks in UploadBase::verifyUpload
@@ -450,7 +450,7 @@ class SpecialUpload extends SpecialPage {
 
 		// Success, redirect to description page
 		$this->mUploadSuccessful = true;
-		wfRunHooks( 'SpecialUploadComplete', array( &$this ) );
+		wfRunHooks( 'SpecialUploadComplete', array( $this ) );
 		$this->getOutput()->redirect( $this->mLocalFile->getTitle()->getFullURL() );
 	}
 

--- a/includes/specials/SpecialVersion.php
+++ b/includes/specials/SpecialVersion.php
@@ -294,7 +294,7 @@ class SpecialVersion extends SpecialPage {
 		/**
 		 * @deprecated as of 1.17, use hook ExtensionTypes instead.
 		 */
-		wfRunHooks( 'SpecialVersionExtensionTypes', array( &$this, &$extensionTypes ) );
+		wfRunHooks( 'SpecialVersionExtensionTypes', array( $this, &$extensionTypes ) );
 
 		$out = Xml::element( 'h2', array( 'id' => 'mw-version-ext' ), wfMessage( 'version-extensions' )->plain() ) .
 			Xml::openElement( 'table', array( 'class' => 'wikitable', 'id' => 'sv-ext' ) );

--- a/includes/specials/SpecialWantedpages.php
+++ b/includes/specials/SpecialWantedpages.php
@@ -85,7 +85,7 @@ class WantedPagesPage extends WantedQueryPage {
 			)
 		);
 		// Replacement for the WantedPages::getSQL hook
-		wfRunHooks( 'WantedPages::getQueryInfo', array( &$this, &$query ) );
+		wfRunHooks( 'WantedPages::getQueryInfo', array( $this, &$query ) );
 		return $query;
 	}
 }

--- a/includes/upload/UploadBase.php
+++ b/includes/upload/UploadBase.php
@@ -633,7 +633,7 @@ abstract class UploadBase {
 				$user->addWatch( $this->getLocalFile()->getTitle() );
 			}
 
-			wfRunHooks( 'UploadComplete', array( &$this ) );
+			wfRunHooks( 'UploadComplete', array( $this ) );
 		}
 
 		return $status;

--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -2335,7 +2335,7 @@ class Wikia {
 	 * usually return true to allow processing other hooks
 	 * return false stops permissions processing and we are totally decided (nothing later can override)
 	 */
-	static function canEditInterfaceWhitelist ( &$title, &$wgUser, $action, &$result ) {
+	static function canEditInterfaceWhitelist ( Title $title, User $wgUser, $action, &$result ) {
 		global $wgEditInterfaceWhitelist;
 
 		// Allowed actions at this point

--- a/includes/wikia/nirvana/WikiaParserTagController.class.php
+++ b/includes/wikia/nirvana/WikiaParserTagController.class.php
@@ -69,7 +69,7 @@ abstract class WikiaParserTagController extends WikiaController {
 		return $markerId;
 	}
 
-	public final function onParserAfterTidy( Parser &$parser, &$text ) {
+	public final function onParserAfterTidy( Parser $parser, &$text ) {
 		if ( !$this->wg->ArticleAsJson ) {
 			$text = $this->replaceMarkers( $text );
 		}

--- a/includes/wikia/parser/templatetypes/TemplateTypesParser.class.php
+++ b/includes/wikia/parser/templatetypes/TemplateTypesParser.class.php
@@ -112,10 +112,11 @@ class TemplateTypesParser {
 	 *
 	 * @param string $templateTitle
 	 * @param string $templateWikitext
+	 * @param Parser $parser
 	 *
 	 * @return bool
 	 */
-	public static function onEndBraceSubstitution( $templateTitle, &$templateWikitext, &$parser ) {
+	public static function onEndBraceSubstitution( $templateTitle, &$templateWikitext, Parser $parser ) {
 		global $wgEnableContextLinkTemplateParsing, $wgEnableInfoIconTemplateParsing, $wgEnableNavigationTemplateParsing;
 		wfProfileIn( __METHOD__ );
 

--- a/languages/Language.php
+++ b/languages/Language.php
@@ -3775,7 +3775,7 @@ class Language {
 		# such as action=raw much more expensive than they need to be.
 		# This will hopefully cover most cases.
 		$talk = preg_replace_callback( '/{{grammar:(.*?)\|(.*?)}}/i',
-			array( &$this, 'replaceGrammarInNamespace' ), $talk );
+			array( $this, 'replaceGrammarInNamespace' ), $talk );
 		return str_replace( ' ', '_', $talk );
 	}
 

--- a/lib/composer/mediawiki/parser-hooks/src/FunctionRunner.php
+++ b/lib/composer/mediawiki/parser-hooks/src/FunctionRunner.php
@@ -42,7 +42,7 @@ class FunctionRunner extends Runner {
 	 *
 	 * @return array
 	 */
-	public function run( Parser &$parser, array $arguments, PPFrame $frame ) {
+	public function run( Parser $parser, array $arguments, PPFrame $frame ) {
 		$resultText = $this->handler->handle(
 			$parser,
 			$this->getProcessedParams( $this->getExpandedParams( $arguments, $frame ) )

--- a/lib/composer/mediawiki/parser-hooks/src/HookRegistrant.php
+++ b/lib/composer/mediawiki/parser-hooks/src/HookRegistrant.php
@@ -28,7 +28,7 @@ class HookRegistrant {
 	 *
 	 * @param Parser $parser
 	 */
-	public function __construct( Parser &$parser ) {
+	public function __construct( Parser $parser ) {
 		$this->parser = $parser;
 	}
 

--- a/lib/composer/mediawiki/parser-hooks/src/HookRunner.php
+++ b/lib/composer/mediawiki/parser-hooks/src/HookRunner.php
@@ -53,7 +53,7 @@ class HookRunner extends Runner {
 	 *
 	 * @return mixed
 	 */
-	public function run( $text, array $arguments, Parser &$parser, PPFrame $frame ) {
+	public function run( $text, array $arguments, Parser $parser, PPFrame $frame ) {
 		$this->parser = $parser;
 		$this->frame = $frame;
 

--- a/lib/vendor/Mail2/mock.php
+++ b/lib/vendor/Mail2/mock.php
@@ -122,7 +122,7 @@ class Mail2_mock extends Mail2 {
     {
         if ($this->_preSendCallback) {
             call_user_func_array($this->_preSendCallback,
-                                 array(&$this, $recipients, $headers, $body));
+                                 array($this, $recipients, $headers, $body));
         }
 
         $entry = array('recipients' => $recipients, 'headers' => $headers, 'body' => $body);
@@ -130,7 +130,7 @@ class Mail2_mock extends Mail2 {
 
         if ($this->_postSendCallback) {
             call_user_func_array($this->_postSendCallback,
-                                 array(&$this, $recipients, $headers, $body));
+                                 array($this, $recipients, $headers, $body));
         }
 
         return true;

--- a/lib/vendor/Net/SMTP2.php
+++ b/lib/vendor/Net/SMTP2.php
@@ -227,7 +227,7 @@ class Net_SMTP2
         if ($this->_debug) {
             if ($this->_debug_handler) {
                 call_user_func_array($this->_debug_handler,
-                                     array(&$this, $message));
+                                     array($this, $message));
             } else {
                 echo "DEBUG: $message\n";
             }

--- a/lib/vendor/PEAR.php
+++ b/lib/vendor/PEAR.php
@@ -177,7 +177,7 @@ class PEAR
             $destructor = "_$classname";
             if (method_exists($this, $destructor)) {
                 global $_PEAR_destructor_object_list;
-                $_PEAR_destructor_object_list[] = &$this;
+                $_PEAR_destructor_object_list[] = $this;
                 if (!isset($GLOBALS['_PEAR_SHUTDOWN_REGISTERED'])) {
                     register_shutdown_function("_PEAR_call_destructors");
                     $GLOBALS['_PEAR_SHUTDOWN_REGISTERED'] = true;

--- a/lib/vendor/PEAR/Builder.php
+++ b/lib/vendor/PEAR/Builder.php
@@ -106,7 +106,7 @@ class PEAR_Builder extends PEAR_Common
         $command = 'msdev '.$dsp.' /MAKE "'.$info['package']. ' - Release"';
 
         $this->current_callback = $callback;
-        $err = $this->_runCommand($command, array(&$this, 'msdevCallback'));
+        $err = $this->_runCommand($command, array($this, 'msdevCallback'));
         if (PEAR::isError($err)) {
             return $err;
         }
@@ -270,7 +270,7 @@ class PEAR_Builder extends PEAR_Common
         $this->log(2, "building in $dir");
         $this->current_callback = $callback;
         putenv('PATH=' . $this->config->get('bin_dir') . ':' . getenv('PATH'));
-        $err = $this->_runCommand("phpize", array(&$this, 'phpizeCallback'));
+        $err = $this->_runCommand("phpize", array($this, 'phpizeCallback'));
         if (PEAR::isError($err)) {
             return $err;
         }

--- a/lib/vendor/PEAR/Command/Build.php
+++ b/lib/vendor/PEAR/Command/Build.php
@@ -82,7 +82,7 @@ Builds one or more extensions contained in a package.'
         }
         $builder = new PEAR_Builder($this->ui);
         $this->debug = $this->config->get('verbose');
-        $err = $builder->build($params[0], array(&$this, 'buildCallback'));
+        $err = $builder->build($params[0], array($this, 'buildCallback'));
         if (PEAR::isError($err)) {
             return $err;
         }

--- a/lib/vendor/PEAR/Command/Channels.php
+++ b/lib/vendor/PEAR/Command/Channels.php
@@ -164,7 +164,7 @@ Initialize a Channel from its server and creates the local channel.xml.
     {
         $reg = &$this->config->getRegistry();
         $registered = $reg->getChannels();
-        usort($registered, array(&$this, '_sortchannels'));
+        usort($registered, array($this, '_sortchannels'));
         $i = $j = 0;
         $data = array(
             'caption' => 'Registered Channels:',

--- a/lib/vendor/PEAR/Command/Registry.php
+++ b/lib/vendor/PEAR/Command/Registry.php
@@ -140,7 +140,7 @@ installed package.'
             $channel = $this->config->get('default_channel');
         }
         $installed = $reg->packageInfo(null, null, $channel);
-        usort($installed, array(&$this, '_sortinfo'));
+        usort($installed, array($this, '_sortinfo'));
         $i = $j = 0;
         $data = array(
             'caption' => 'Installed packages, channel ' .

--- a/lib/vendor/PEAR/Config.php
+++ b/lib/vendor/PEAR/Config.php
@@ -607,7 +607,7 @@ class PEAR_Config extends PEAR
         $this->_registry['default'] = new PEAR_Registry($this->configuration['default']['php_dir']);
         $this->_registry['default']->setConfig($this);
         $this->_regInitialized['default'] = false;
-        //$GLOBALS['_PEAR_Config_instance'] = &$this;
+        //$GLOBALS['_PEAR_Config_instance'] = $this;
     }
 
     // }}}

--- a/lib/vendor/PEAR/Downloader.php
+++ b/lib/vendor/PEAR/Downloader.php
@@ -197,7 +197,7 @@ class PEAR_Downloader extends PEAR_Common
     {
         $this->log(1, 'Attempting to discover channel "' . $channel . '"...');
         PEAR::pushErrorHandling(PEAR_ERROR_RETURN);
-        $callback = $this->ui ? array(&$this, '_downloadCallback') : null;
+        $callback = $this->ui ? array($this, '_downloadCallback') : null;
         if (!class_exists('System')) {
             require_once 'System.php';
         }
@@ -1240,7 +1240,7 @@ class PEAR_Downloader extends PEAR_Common
             $this->_getDepTreeDP($packages[$i], $packages, $deps, $checked);
             $this->_depTree[$package->getChannel()][$package->getPackage()] = $deps;
         }
-        usort($packages, array(&$this, '_sortInstall'));
+        usort($packages, array($this, '_sortInstall'));
     }
 
     function _dependsOn($a, $b)

--- a/lib/vendor/PEAR/ErrorStack.php
+++ b/lib/vendor/PEAR/ErrorStack.php
@@ -331,7 +331,7 @@ class PEAR_ErrorStack {
     function setMessageCallback($msgCallback)
     {
         if (!$msgCallback) {
-            $this->_msgCallback = array(&$this, 'getErrorMessage');
+            $this->_msgCallback = array($this, 'getErrorMessage');
         } else {
             if (is_callable($msgCallback)) {
                 $this->_msgCallback = $msgCallback;
@@ -383,7 +383,7 @@ class PEAR_ErrorStack {
             return $this->_contextCallback = false;
         }
         if (!$contextCallback) {
-            $this->_contextCallback = array(&$this, 'getFileLine');
+            $this->_contextCallback = array($this, 'getFileLine');
         } else {
             if (is_callable($contextCallback)) {
                 $this->_contextCallback = $contextCallback;
@@ -534,7 +534,7 @@ class PEAR_ErrorStack {
         // set up the error message, if necessary
         if ($this->_msgCallback) {
             $msg = call_user_func_array($this->_msgCallback,
-                                        array(&$this, $err));
+                                        array($this, $err));
             $err['message'] = $msg;
         }        
         $push = $log = true;

--- a/lib/vendor/PEAR/Installer.php
+++ b/lib/vendor/PEAR/Installer.php
@@ -1311,7 +1311,7 @@ class PEAR_Installer extends PEAR_Downloader
         $this->log(1, "$this->source_files source files, building");
         $bob = new PEAR_Builder($this->ui);
         $bob->debug = $this->debug;
-        $built = $bob->build($filelist, array(&$this, '_buildCallback'));
+        $built = $bob->build($filelist, array($this, '_buildCallback'));
         if (PEAR::isError($built)) {
             $this->rollbackFileTransaction();
             $this->configSet('default_channel', $savechannel);
@@ -1524,7 +1524,7 @@ class PEAR_Installer extends PEAR_Downloader
         if (PEAR::isError($this->_dependencyDB)) {
             return $this->_dependencyDB;
         }
-        usort($packages, array(&$this, '_sortUninstall'));
+        usort($packages, array($this, '_sortUninstall'));
     }
 
     function _sortUninstall($a, $b)

--- a/lib/vendor/PEAR/Registry.php
+++ b/lib/vendor/PEAR/Registry.php
@@ -987,7 +987,7 @@ class PEAR_Registry extends PEAR
             if (!count($ps)) {
                 return array();
             }
-            return array_map(array(&$this, '_packageInfo'),
+            return array_map(array($this, '_packageInfo'),
                              $ps, array_fill(0, count($ps), null),
                              array_fill(0, count($ps), $channel));
         }

--- a/lib/vendor/PEAR/Remote.php
+++ b/lib/vendor/PEAR/Remote.php
@@ -183,7 +183,7 @@ class PEAR_Remote extends PEAR
             return $this->cache['content'];
         }
         if (extension_loaded("xmlrpc")) {
-            $result = call_user_func_array(array(&$this, 'call_epi'), $args);
+            $result = call_user_func_array(array($this, 'call_epi'), $args);
             if (!PEAR::isError($result)) {
                 $this->saveCache($_args, $result);
             }

--- a/lib/vendor/PEAR/Task/Common.php
+++ b/lib/vendor/PEAR/Task/Common.php
@@ -102,7 +102,7 @@ class PEAR_Task_Common
         $this->logger = &$logger;
         $this->installphase = $phase;
         if ($this->type == 'multiple') {
-            $GLOBALS['_PEAR_TASK_POSTINSTANCES'][get_class($this)][] = &$this;
+            $GLOBALS['_PEAR_TASK_POSTINSTANCES'][get_class($this)][] = $this;
         }
     }
 

--- a/lib/vendor/SimplePie/test/unit_test/unit_test.php
+++ b/lib/vendor/SimplePie/test/unit_test/unit_test.php
@@ -90,7 +90,7 @@ class Unit_Test
 				}
 			}
 			closedir($dh);
-			usort($files, array(&$this, 'sort_files'));
+			usort($files, array($this, 'sort_files'));
 			foreach ($files as $file)
 			{
 				if (is_dir($file))

--- a/maintenance/cleanupTitles.php
+++ b/maintenance/cleanupTitles.php
@@ -76,7 +76,7 @@ class TitleCleanup extends TableCleanup {
 	protected function moveIllegalPage( $row ) {
 		$legal = 'A-Za-z0-9_/\\\\-';
 		$legalized = preg_replace_callback( "!([^$legal])!",
-			array( &$this, 'hexChar' ),
+			array( $this, 'hexChar' ),
 			$row->page_title );
 		if ( $legalized == '.' ) $legalized = '(dot)';
 		if ( $legalized == '_' ) $legalized = '(space)';

--- a/maintenance/dumpIterator.php
+++ b/maintenance/dumpIterator.php
@@ -66,7 +66,7 @@ abstract class DumpIterator extends Maintenance {
 		$importer = new WikiImporter( $source );
 
 		$importer->setRevisionCallback(
-			array( &$this, 'handleRevision' ) );
+			array( $this, 'handleRevision' ) );
 
 		$this->from = $this->getOption( 'from', null );
 		$this->count = 0;

--- a/maintenance/dumpTextPass.php
+++ b/maintenance/dumpTextPass.php
@@ -269,8 +269,8 @@ class TextPassDumper extends BackupDumper {
 		$parser = xml_parser_create( "UTF-8" );
 		xml_parser_set_option( $parser, XML_OPTION_CASE_FOLDING, false );
 
-		xml_set_element_handler( $parser, array( &$this, 'startElement' ), array( &$this, 'endElement' ) );
-		xml_set_character_data_handler( $parser, array( &$this, 'characterData' ) );
+		xml_set_element_handler( $parser, array( $this, 'startElement' ), array( $this, 'endElement' ) );
+		xml_set_character_data_handler( $parser, array( $this, 'characterData' ) );
 
 		$offset = 0; // for context extraction on error reporting
 		$bufferSize = 512 * 1024;

--- a/maintenance/importDump.php
+++ b/maintenance/importDump.php
@@ -261,13 +261,13 @@ TEXT;
 		if ( $this->hasOption( 'no-updates' ) ) {
 			$importer->setNoUpdates( true );
 		}
-		$importer->setPageCallback( array( &$this, 'reportPage' ) );
+		$importer->setPageCallback( array( $this, 'reportPage' ) );
 		$this->importCallback =  $importer->setRevisionCallback(
-			array( &$this, 'handleRevision' ) );
+			array( $this, 'handleRevision' ) );
 		$this->uploadCallback = $importer->setUploadCallback(
-			array( &$this, 'handleUpload' ) );
+			array( $this, 'handleUpload' ) );
 		$this->logItemCallback = $importer->setLogItemCallback(
-			array( &$this, 'handleLogItem' ) );
+			array( $this, 'handleLogItem' ) );
 		if ( $this->uploads ) {
 			$importer->setImportUploads( true );
 		}

--- a/maintenance/renderDump.php
+++ b/maintenance/renderDump.php
@@ -58,7 +58,7 @@ class DumpRenderer extends Maintenance {
 		$importer = new WikiImporter( $source );
 
 		$importer->setRevisionCallback(
-			array( &$this, 'handleRevision' ) );
+			array( $this, 'handleRevision' ) );
 
 		$importer->doImport();
 

--- a/maintenance/storage/checkStorage.php
+++ b/maintenance/storage/checkStorage.php
@@ -434,7 +434,7 @@ class CheckStorage {
 
 		$source = new ImportStreamSource( $file );
 		$importer = new WikiImporter( $source );
-		$importer->setRevisionCallback( array( &$this, 'importRevision' ) );
+		$importer->setRevisionCallback( array( $this, 'importRevision' ) );
 		$importer->doImport();
 	}
 

--- a/maintenance/upgrade1_5.php
+++ b/maintenance/upgrade1_5.php
@@ -695,7 +695,7 @@ END;
 			'user_email_token'         => MW_UPGRADE_NULL,
 			'user_email_token_expires' => MW_UPGRADE_NULL );
 		$this->copyTable( 'user', $tabledef, $fields,
-			array( &$this, 'userCallback' ) );
+			array( $this, 'userCallback' ) );
 	}
 
 	function userCallback( $row, $copy ) {
@@ -742,7 +742,7 @@ END;
 			'img_user_text'   => MW_UPGRADE_ENCODE,
 			'img_timestamp'   => MW_UPGRADE_COPY );
 		$this->copyTable( 'image', $tabledef, $fields,
-			array( &$this, 'imageCallback' ) );
+			array( $this, 'imageCallback' ) );
 	}
 
 	function imageCallback( $row, $copy ) {
@@ -875,7 +875,7 @@ END;
 			'oi_user_text'    => MW_UPGRADE_ENCODE,
 			'oi_timestamp'    => MW_UPGRADE_COPY );
 		$this->copyTable( 'oldimage', $tabledef, $fields,
-			array( &$this, 'oldimageCallback' ) );
+			array( $this, 'oldimageCallback' ) );
 	}
 
 	function oldimageCallback( $row, $copy ) {

--- a/maintenance/wiki2rss.php
+++ b/maintenance/wiki2rss.php
@@ -197,9 +197,9 @@ class BackupReader {
 		$source = new ImportStreamSource( $handle );
 		$importer = new WikiImporter( $source );
 
-		$importer->setPageCallback( array( &$this, 'reportPage' ) );
+		$importer->setPageCallback( array( $this, 'reportPage' ) );
 		$this->importCallback =  $importer->setRevisionCallback(
-			array( &$this, 'handleRevision' ) );
+			array( $this, 'handleRevision' ) );
 
 		return $importer->doImport();
 	}

--- a/skins/LyricsMinimal.php
+++ b/skins/LyricsMinimal.php
@@ -71,7 +71,7 @@ class SkinLyricsMinimal extends SkinTemplate {
 		$this->template  = 'LyricsMinimalTemplate';
 
 		// Function addVariables will be called to populate all needed data to render skin
-		$wgHooks['SkinTemplateOutputPageBeforeExec'][] = array(&$this, 'addVariables');
+		$wgHooks['SkinTemplateOutputPageBeforeExec'][] = array($this, 'addVariables');
 
 		wfProfileOut(__METHOD__);
 	}

--- a/skins/MonoBook.php
+++ b/skins/MonoBook.php
@@ -312,8 +312,8 @@ echo $footerEnd;
 
 <?php
 		}
-		wfRunHooks( 'MonoBookTemplateToolboxEnd', array( &$this ) );
-		wfRunHooks( 'SkinTemplateToolboxEnd', array( &$this, true ) );
+		wfRunHooks( 'MonoBookTemplateToolboxEnd', array( $this ) );
+		wfRunHooks( 'SkinTemplateToolboxEnd', array( $this, true ) );
 ?>
 			</ul>
 		</div>

--- a/skins/oasis/modules/ContentDisplayController.class.php
+++ b/skins/oasis/modules/ContentDisplayController.class.php
@@ -9,7 +9,7 @@ class ContentDisplayController extends WikiaController {
 	/**
 	 * Show section edit link for anons (RT #79897)
 	 */
-	static function onShowEditLink(&$parser, &$showEditLink) {
+	static function onShowEditLink($parser, &$showEditLink) {
 		global $wgUser;
 		wfProfileIn(__METHOD__);
 

--- a/skins/oasis/modules/PageHeaderController.class.php
+++ b/skins/oasis/modules/PageHeaderController.class.php
@@ -506,7 +506,7 @@ class PageHeaderController extends WikiaController {
 			$this->comments = $service->getCommentsCount();
 		}
 
-		wfRunHooks( 'PageHeaderEditPage', [ &$this, $ns, $isPreview, $isShowChanges, $isDiff, $isEdit, $isHistory ] );
+		wfRunHooks( 'PageHeaderEditPage', [ $this, $ns, $isPreview, $isShowChanges, $isDiff, $isEdit, $isHistory ] );
 		wfProfileOut( __METHOD__ );
 	}
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-2178

Objects are passed by the reference since PHP5. There's no need to make it explicit via `&$this` syntax and it makes PHP 7.1 complain.

https://bugs.php.net/bug.php?id=73751

https://3v4l.org/vMc1N contains the sample code where `&$this` as part of the callback invocation:

```php
Hooks::run( 'foo', array( &$this, &$var ) );
```

causes a "Warning: Parameter 1 to {closure}() expected to be a reference, value given" on 7.1.0.

Running the provided sample code on 5.3.0 - 5.6.25, hhvm-3.10.0 - 3.12.0, 7.0.0 - 7.0.10 works as expected.

Re-declaring $this will pass on 7.1.0 and 5.3.0 - 5.6.25, hhvm-3.10.0 - 3.12.0, 7.0.0 - 7.0.10.