### PR TITLE
cake-1794 - fix tracking for recirc footer items

### DIFF
--- a/extensions/wikia/Recirculation/templates/client/footer.mustache
+++ b/extensions/wikia/Recirculation/templates/client/footer.mustache
@@ -3,7 +3,7 @@
 
   <div class="items">
     {{#items}}
-      <div class="item" data-index="{{index}}" data-source="{{source}}">
+      <div class="item" data-index="{{index}}" data-source="{{source}}" {{#meta}}data-meta="{{meta}}"{{/meta}}>
         <a title="{{title}}" href="{{url}}">
           <div class="thumbnail">
             {{#isWiki}}


### PR DESCRIPTION
@Wikia/cake 
https://wikia-inc.atlassian.net/browse/CAKE-1794

looks like tracking uses the `data-meta` attribute in recirc items to set up its tracking. This wasn't set in the footer template, so tracking wasn't working for items in that module.