### PR TITLE
ADEN-5353 | Add rubicon_fastlane to bidder_won in kikimora

### DIFF
--- a/extensions/wikia/AdEngine/js/AdInfoTrackerHelper.js
+++ b/extensions/wikia/AdEngine/js/AdInfoTrackerHelper.js
@@ -81,7 +81,9 @@ define('ext.wikia.adEngine.adInfoTrackerHelper',  [
 	}
 
 	function getBidderWon(slotParams, realSlotPrices) {
-		var slotPricesKeys = Object.keys(realSlotPrices),
+		var slotPricesKeys = Object.keys(realSlotPrices).filter(function(key) {
+				return parseFloat(realSlotPrices[key]) > 0;
+			}),
 			highestPrice = Math.max.apply(
 				null,
 				slotPricesKeys.map(function(key) { return parseFloat(realSlotPrices[key]); })

--- a/extensions/wikia/AdEngine/js/AdInfoTrackerHelper.js
+++ b/extensions/wikia/AdEngine/js/AdInfoTrackerHelper.js
@@ -50,7 +50,7 @@ define('ext.wikia.adEngine.adInfoTrackerHelper',  [
 			'kv_ref': pageParams.ref || '',
 			'kv_top': pageParams.top || '',
 			'kv_ah': pageParams.ah || '',
-			'bidder_won': getBidderWon(realSlotPrices),
+			'bidder_won': getBidderWon(slotParams, realSlotPrices),
 			'bidder_1': transformBidderPrice('indexExchange', realSlotPrices, slotPricesIgnoringTimeout),
 			'bidder_2': transformBidderPrice('appnexus', realSlotPrices, slotPricesIgnoringTimeout),
 			'bidder_3': transformBidderPrice('fastlane', realSlotPrices, slotPricesIgnoringTimeout),
@@ -80,15 +80,37 @@ define('ext.wikia.adEngine.adInfoTrackerHelper',  [
 		return '';
 	}
 
-	function getBidderWon(realSlotPrices) {
-		var realSlotPricesKeys = Object.keys(realSlotPrices).filter(function(key) {
-				return parseFloat(realSlotPrices[key]) > 0;
-			}),
-			highestPriceBidder = realSlotPricesKeys.length === 0 ? null : realSlotPricesKeys.reduce(function(a, b) {
-				return parseFloat(realSlotPrices[a]) > parseFloat(realSlotPrices[b]) ? a : b;
-			});
+	function getBidderWon(slotParams, realSlotPrices) {
+		var slotPricesKeys = Object.keys(realSlotPrices),
+			highestPrice = Math.max.apply(
+				null,
+				slotPricesKeys.map(function(key) { return parseFloat(realSlotPrices[key]); })
+			),
+			highestPriceBidders = [];
 
-		return highestPriceBidder || '';
+		slotPricesKeys.forEach(function(key) {
+			if (parseFloat(realSlotPrices[key]) === highestPrice) {
+				highestPriceBidders.push(key);
+			}
+		});
+
+		// In case of a tie in prebid bidders prebid.js picks the fastest bidder.
+		// In case of a tie with prebid and rubiconFastlane we promote prebid
+		if (slotParams.hb_bidder && highestPriceBidders.indexOf(slotParams.hb_bidder) >= 0) {
+			return slotParams.hb_bidder;
+		}
+
+		if (slotParams.rpfl_7450) {
+			if (highestPriceBidders.indexOf('fastlane') >= 0) {
+				return 'fastlane';
+			}
+
+			if (highestPriceBidders.indexOf('fastlane_private') >= 0) {
+				return 'fastlane_private'
+			}
+		}
+
+		return '';
 	}
 
 	function generateUUID() {

--- a/extensions/wikia/AdEngine/js/AdInfoTrackerHelper.js
+++ b/extensions/wikia/AdEngine/js/AdInfoTrackerHelper.js
@@ -50,7 +50,7 @@ define('ext.wikia.adEngine.adInfoTrackerHelper',  [
 			'kv_ref': pageParams.ref || '',
 			'kv_top': pageParams.top || '',
 			'kv_ah': pageParams.ah || '',
-			'bidder_won': slotParams.hb_bidder || '',
+			'bidder_won': getBidderWon(slotParams, realSlotPrices),
 			'bidder_1': transformBidderPrice('indexExchange', realSlotPrices, slotPricesIgnoringTimeout),
 			'bidder_2': transformBidderPrice('appnexus', realSlotPrices, slotPricesIgnoringTimeout),
 			'bidder_3': transformBidderPrice('fastlane', realSlotPrices, slotPricesIgnoringTimeout),
@@ -75,6 +75,24 @@ define('ext.wikia.adEngine.adInfoTrackerHelper',  [
 
 		if (slotPricesIgnoringTimeout[bidderName]) {
 			return slotPricesIgnoringTimeout[bidderName] + 'not_used';
+		}
+
+		return '';
+	}
+
+	function getBidderWon(slotParams, realSlotPrices) {
+		var realSlotPricesKeys = Object.keys(realSlotPrices),
+			highestPriceBidder = realSlotPricesKeys.length === 0 ? null : realSlotPricesKeys.reduce(function(a, b) {
+				return parseFloat(realSlotPrices[a]) > parseFloat(realSlotPrices[b]) ? a : b;
+		});
+
+		// We need to check targeting because it's possible that bids won't be used for targeting
+		if (slotParams.hb_bidder && highestPriceBidder === slotParams.hb_bidder) {
+			return slotParams.hb_bidder;
+		}
+
+		if (slotParams.rpfl_7450 && ['fastlane', 'fastlane_private'].indexOf(highestPriceBidder) >= 0) {
+			return highestPriceBidder;
 		}
 
 		return '';

--- a/extensions/wikia/AdEngine/js/AdInfoTrackerHelper.js
+++ b/extensions/wikia/AdEngine/js/AdInfoTrackerHelper.js
@@ -81,7 +81,9 @@ define('ext.wikia.adEngine.adInfoTrackerHelper',  [
 	}
 
 	function getBidderWon(realSlotPrices) {
-		var realSlotPricesKeys = Object.keys(realSlotPrices),
+		var realSlotPricesKeys = Object.keys(realSlotPrices).filter(function(key) {
+				return parseFloat(realSlotPrices[key]) > 0;
+			}),
 			highestPriceBidder = realSlotPricesKeys.length === 0 ? null : realSlotPricesKeys.reduce(function(a, b) {
 				return parseFloat(realSlotPrices[a]) > parseFloat(realSlotPrices[b]) ? a : b;
 			});

--- a/extensions/wikia/AdEngine/js/AdInfoTrackerHelper.js
+++ b/extensions/wikia/AdEngine/js/AdInfoTrackerHelper.js
@@ -50,7 +50,7 @@ define('ext.wikia.adEngine.adInfoTrackerHelper',  [
 			'kv_ref': pageParams.ref || '',
 			'kv_top': pageParams.top || '',
 			'kv_ah': pageParams.ah || '',
-			'bidder_won': getBidderWon(slotParams, realSlotPrices),
+			'bidder_won': getBidderWon(realSlotPrices),
 			'bidder_1': transformBidderPrice('indexExchange', realSlotPrices, slotPricesIgnoringTimeout),
 			'bidder_2': transformBidderPrice('appnexus', realSlotPrices, slotPricesIgnoringTimeout),
 			'bidder_3': transformBidderPrice('fastlane', realSlotPrices, slotPricesIgnoringTimeout),
@@ -80,7 +80,7 @@ define('ext.wikia.adEngine.adInfoTrackerHelper',  [
 		return '';
 	}
 
-	function getBidderWon(slotParams, realSlotPrices) {
+	function getBidderWon(realSlotPrices) {
 		var realSlotPricesKeys = Object.keys(realSlotPrices),
 			highestPriceBidder = realSlotPricesKeys.length === 0 ? null : realSlotPricesKeys.reduce(function(a, b) {
 				return parseFloat(realSlotPrices[a]) > parseFloat(realSlotPrices[b]) ? a : b;

--- a/extensions/wikia/AdEngine/js/AdInfoTrackerHelper.js
+++ b/extensions/wikia/AdEngine/js/AdInfoTrackerHelper.js
@@ -84,23 +84,14 @@ define('ext.wikia.adEngine.adInfoTrackerHelper',  [
 		var realSlotPricesKeys = Object.keys(realSlotPrices),
 			highestPriceBidder = realSlotPricesKeys.length === 0 ? null : realSlotPricesKeys.reduce(function(a, b) {
 				return parseFloat(realSlotPrices[a]) > parseFloat(realSlotPrices[b]) ? a : b;
-		});
+			});
 
-		// We need to check targeting because it's possible that bids won't be used for targeting
-		if (slotParams.hb_bidder && highestPriceBidder === slotParams.hb_bidder) {
-			return slotParams.hb_bidder;
-		}
-
-		if (slotParams.rpfl_7450 && ['fastlane', 'fastlane_private'].indexOf(highestPriceBidder) >= 0) {
-			return highestPriceBidder;
-		}
-
-		return '';
+		return highestPriceBidder || '';
 	}
 
 	function generateUUID() {
 		return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-			var r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
+			var r = Math.random() * 16 | 0, v = c === 'x' ? r : (r & 0x3 | 0x8);
 			return v.toString(16);
 		});
 	}

--- a/extensions/wikia/AdEngine/js/lookup/rubicon/rubiconFastlane.js
+++ b/extensions/wikia/AdEngine/js/lookup/rubicon/rubiconFastlane.js
@@ -174,6 +174,18 @@ define('ext.wikia.adEngine.lookup.rubicon.rubiconFastlane', [
 		});
 	}
 
+	function handleFloorPrice(floorPrice, slotName, parameters) {
+		if (
+			typeof floorPrice !== 'undefined' &&
+			parameters[rubiconTierKey] && typeof parameters[rubiconTierKey].map === 'function' &&
+			bestPrices[slotName] <= floorPrice && bestPricesPrivate[slotName] <= floorPrice
+		) {
+			parameters[rubiconTierKey] = parameters[rubiconTierKey].map(function (tier) {
+				return tier.replace(/tier\d+/, 'tierPREBID');
+			});
+		}
+	}
+
 	function saveBestPrice(slotName, tiers) {
 		tiers.forEach(function (tier) {
 			bestPrices[slotName] = Math.max(rubiconTier.parseOpenMarketPrice(tier), bestPrices[slotName] || 0);
@@ -213,16 +225,7 @@ define('ext.wikia.adEngine.lookup.rubicon.rubiconFastlane', [
 			}
 		});
 
-		if (
-			typeof floorPrice !== 'undefined' &&
-			bestPrices[slotName] <= floorPrice && bestPricesPrivate[slotName] <= floorPrice
-		) {
-			if (parameters[rubiconTierKey] && typeof parameters[rubiconTierKey].map === 'function') {
-				parameters[rubiconTierKey] = parameters[rubiconTierKey].map(function(tier) {
-					return tier.replace(/tier\d+/, 'tierPREBID');
-				});
-			}
-		}
+		handleFloorPrice(floorPrice, slotName, parameters);
 
 		fillInWithMissingTiers(slotName, parameters);
 		if (parameters[rubiconTierKey] && typeof parameters[rubiconTierKey].sort === 'function') {

--- a/extensions/wikia/AdEngine/js/lookup/rubicon/rubiconFastlane.js
+++ b/extensions/wikia/AdEngine/js/lookup/rubicon/rubiconFastlane.js
@@ -198,7 +198,7 @@ define('ext.wikia.adEngine.lookup.rubicon.rubiconFastlane', [
 		return price;
 	}
 
-	function getSlotParams(slotName) {
+	function getSlotParams(slotName, floorPrice) {
 		var targeting,
 			parameters = {};
 
@@ -212,6 +212,18 @@ define('ext.wikia.adEngine.lookup.rubicon.rubiconFastlane', [
 				parameters[params.key] = params.values;
 			}
 		});
+
+		if (
+			typeof floorPrice !== 'undefined' &&
+			bestPrices[slotName] <= floorPrice && bestPricesPrivate[slotName] <= floorPrice
+		) {
+			if (parameters[rubiconTierKey] && typeof parameters[rubiconTierKey].map === 'function') {
+				parameters[rubiconTierKey] = parameters[rubiconTierKey].map(function(tier) {
+					return tier.replace(/tier\d+/, 'tierPREBID');
+				});
+			}
+		}
+
 		fillInWithMissingTiers(slotName, parameters);
 		if (parameters[rubiconTierKey] && typeof parameters[rubiconTierKey].sort === 'function') {
 			parameters[rubiconTierKey].sort(compareTiers);

--- a/extensions/wikia/AdEngine/js/spec/AdInfoTrackerHelper.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/AdInfoTrackerHelper.spec.js
@@ -165,4 +165,78 @@ describe('ext.wikia.adEngine.adInfoTrackerHelper', function () {
 		expect(data.kv_top).toBe('top');
 		expect(data.kv_ah).toBe('ah');
 	});
+
+	it('prepareData correctly calculates bidder_won for no bidders', function () {
+		var data,
+			slot = getTopLeaderboardSlotWithPageParams(fakeJSONString);
+
+		slot.container.firstChild.dataset.gptSlotParams = fakeJSONString;
+		slot.container.firstChild.dataset.gptCreativeSize = fakeJSONString;
+
+		data = getModule().prepareData(slot);
+
+		expect(data.bidder_won).toBe('');
+	});
+
+	it('prepareData correctly calculates bidder_won for bidders', function () {
+		var data,
+			slot = getTopLeaderboardSlotWithPageParams(fakeJSONString);
+
+		slot.container.firstChild.dataset.gptSlotParams = JSON.stringify({foo: 1, rpfl_7450: 1});
+		slot.container.firstChild.dataset.gptCreativeSize = fakeJSONString;
+
+		mocks.lookupServices.getDfpSlotPrices = function() {
+			return {
+				fastlane_private: '2.50',
+				openx: '1.30',
+				rubicon: '0.75'
+			};
+		};
+
+		data = getModule().prepareData(slot);
+
+		expect(data.bidder_won).toBe('fastlane_private');
+	});
+
+	it('prepareData correctly calculates bidder_won for bidders', function () {
+		var data,
+			slot = getTopLeaderboardSlotWithPageParams(fakeJSONString);
+
+		slot.container.firstChild.dataset.gptSlotParams = JSON.stringify({foo: 1, hb_bidder: 'openx'});
+		slot.container.firstChild.dataset.gptCreativeSize = fakeJSONString;
+
+		mocks.lookupServices.getDfpSlotPrices = function() {
+			return {
+				fastlane_private: '2.50',
+				openx: '3.30',
+				rubicon: '0.75'
+			};
+		};
+
+		data = getModule().prepareData(slot);
+
+
+		expect(data.bidder_won).toBe('openx');
+	});
+
+	it('prepareData correctly calculates bidder_won when bids aren\'t used for targeting', function () {
+		var data,
+			slot = getTopLeaderboardSlotWithPageParams(fakeJSONString);
+
+		slot.container.firstChild.dataset.gptSlotParams = JSON.stringify(fakeJSONString);
+		slot.container.firstChild.dataset.gptCreativeSize = fakeJSONString;
+
+		mocks.lookupServices.getDfpSlotPrices = function() {
+			return {
+				fastlane_private: '2.50',
+				openx: '3.30',
+				rubicon: '0.75'
+			};
+		};
+
+		data = getModule().prepareData(slot);
+
+
+		expect(data.bidder_won).toBe('');
+	});
 });

--- a/extensions/wikia/AdEngine/js/spec/AdInfoTrackerHelper.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/AdInfoTrackerHelper.spec.js
@@ -182,7 +182,7 @@ describe('ext.wikia.adEngine.adInfoTrackerHelper', function () {
 		var data,
 			slot = getTopLeaderboardSlotWithPageParams(fakeJSONString);
 
-		slot.container.firstChild.dataset.gptSlotParams = JSON.stringify(fakeJSONString);
+		slot.container.firstChild.dataset.gptSlotParams = JSON.stringify({foo: 1, rpfl_7450: 1});
 		slot.container.firstChild.dataset.gptCreativeSize = fakeJSONString;
 
 		mocks.lookupServices.getDfpSlotPrices = function() {
@@ -202,7 +202,7 @@ describe('ext.wikia.adEngine.adInfoTrackerHelper', function () {
 		var data,
 			slot = getTopLeaderboardSlotWithPageParams(fakeJSONString);
 
-		slot.container.firstChild.dataset.gptSlotParams = JSON.stringify(fakeJSONString);
+		slot.container.firstChild.dataset.gptSlotParams = JSON.stringify({foo: 1, hb_bidder: 'openx'});
 		slot.container.firstChild.dataset.gptCreativeSize = fakeJSONString;
 
 		mocks.lookupServices.getDfpSlotPrices = function() {
@@ -217,5 +217,26 @@ describe('ext.wikia.adEngine.adInfoTrackerHelper', function () {
 
 
 		expect(data.bidder_won).toBe('openx');
+	});
+
+	it('prepareData correctly calculates bidder_won for bidders - tie (we promote prebid.js)', function () {
+		var data,
+			slot = getTopLeaderboardSlotWithPageParams(fakeJSONString);
+
+		slot.container.firstChild.dataset.gptSlotParams = JSON.stringify({foo: 1, hb_bidder: 'rubicon', rpfl_7450: 1});
+		slot.container.firstChild.dataset.gptCreativeSize = fakeJSONString;
+
+		mocks.lookupServices.getDfpSlotPrices = function() {
+			return {
+				fastlane_private: '2.60',
+				openx: '2.60',
+				rubicon: '2.60'
+			};
+		};
+
+		data = getModule().prepareData(slot);
+
+
+		expect(data.bidder_won).toBe('rubicon');
 	});
 });

--- a/extensions/wikia/AdEngine/js/spec/AdInfoTrackerHelper.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/AdInfoTrackerHelper.spec.js
@@ -178,11 +178,11 @@ describe('ext.wikia.adEngine.adInfoTrackerHelper', function () {
 		expect(data.bidder_won).toBe('');
 	});
 
-	it('prepareData correctly calculates bidder_won for bidders', function () {
+	it('prepareData correctly calculates bidder_won for bidders - fastlane_private', function () {
 		var data,
 			slot = getTopLeaderboardSlotWithPageParams(fakeJSONString);
 
-		slot.container.firstChild.dataset.gptSlotParams = JSON.stringify({foo: 1, rpfl_7450: 1});
+		slot.container.firstChild.dataset.gptSlotParams = JSON.stringify(fakeJSONString);
 		slot.container.firstChild.dataset.gptCreativeSize = fakeJSONString;
 
 		mocks.lookupServices.getDfpSlotPrices = function() {
@@ -198,28 +198,7 @@ describe('ext.wikia.adEngine.adInfoTrackerHelper', function () {
 		expect(data.bidder_won).toBe('fastlane_private');
 	});
 
-	it('prepareData correctly calculates bidder_won for bidders', function () {
-		var data,
-			slot = getTopLeaderboardSlotWithPageParams(fakeJSONString);
-
-		slot.container.firstChild.dataset.gptSlotParams = JSON.stringify({foo: 1, hb_bidder: 'openx'});
-		slot.container.firstChild.dataset.gptCreativeSize = fakeJSONString;
-
-		mocks.lookupServices.getDfpSlotPrices = function() {
-			return {
-				fastlane_private: '2.50',
-				openx: '3.30',
-				rubicon: '0.75'
-			};
-		};
-
-		data = getModule().prepareData(slot);
-
-
-		expect(data.bidder_won).toBe('openx');
-	});
-
-	it('prepareData correctly calculates bidder_won when bids aren\'t used for targeting', function () {
+	it('prepareData correctly calculates bidder_won for bidders - openx', function () {
 		var data,
 			slot = getTopLeaderboardSlotWithPageParams(fakeJSONString);
 
@@ -237,6 +216,6 @@ describe('ext.wikia.adEngine.adInfoTrackerHelper', function () {
 		data = getModule().prepareData(slot);
 
 
-		expect(data.bidder_won).toBe('');
+		expect(data.bidder_won).toBe('openx');
 	});
 });

--- a/extensions/wikia/AdEngine/js/spec/lookup/services.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/lookup/services.spec.js
@@ -35,6 +35,7 @@ describe('Method ext.wikia.adEngine.lookup.services', function () {
 			trackState: noop,
 			wasCalled: noop,
 			getSlotParams: noop,
+			getBestSlotPrice: function() { return { aol: '0.00' }; },
 			getName: function () { return 'prebid'; },
 			hasResponse: function () { return true; }
 		},
@@ -44,6 +45,7 @@ describe('Method ext.wikia.adEngine.lookup.services', function () {
 	it('extends slot targeting for Amazon', function () {
 		var lookup = modules['ext.wikia.adEngine.lookup.services'](
 				mocks.log,
+				undefined,
 				mocks.amazon
 			),
 			slotTargetingMock = {a: 'b'},
@@ -109,7 +111,6 @@ describe('Method ext.wikia.adEngine.lookup.services', function () {
 	it('extends slot targeting for Prebid.js', function () {
 		var lookup = modules['ext.wikia.adEngine.lookup.services'](
 			mocks.log,
-			undefined,
 			mocks.prebid
 			),
 			slotTargetingMock = {a: 'b'},


### PR DESCRIPTION
So far we're using `hb_bidder` param from GPT targeting. Unfortunately this parameter is not always the right value. It's possible that `fastlane` or `fastlane_private` has higher bid that will be used by DFP.

In case of a tie we promote prebid.js and fastlane targeting isn't sent to DFP

@Wikia/adeng 