### PR TITLE
CAKE-1657 Set the title using X-Page-Title from the FC

### DIFF
--- a/extensions/wikia/ContributionPrototype/CPArticle.php
+++ b/extensions/wikia/ContributionPrototype/CPArticle.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace ContributionPrototype;
+
+class CPArticle {
+
+	private $content;
+	private $entityName;
+
+	function __construct($content, $entityName) {
+		$this->content = $content;
+		$this->entityName = $entityName;
+	}
+
+	public function getContent() {
+		return $this->content;
+	}
+
+	public function getEntityName() {
+		return $this->entityName;
+	}
+}

--- a/extensions/wikia/ContributionPrototype/CPArticle.php
+++ b/extensions/wikia/ContributionPrototype/CPArticle.php
@@ -5,18 +5,18 @@ namespace ContributionPrototype;
 class CPArticle {
 
 	private $content;
-	private $entityName;
+	private $title;
 
-	function __construct($content, $entityName) {
+	function __construct($content, $title) {
 		$this->content = $content;
-		$this->entityName = $entityName;
+		$this->title = $title;
 	}
 
 	public function getContent() {
 		return $this->content;
 	}
 
-	public function getEntityName() {
-		return $this->entityName;
+	public function getTitle() {
+		return $this->title;
 	}
 }

--- a/extensions/wikia/ContributionPrototype/CPArticleRenderer.php
+++ b/extensions/wikia/ContributionPrototype/CPArticleRenderer.php
@@ -136,6 +136,6 @@ class CPArticleRenderer {
 			return false;
 		}
 
-		return new CPArticle($response->getContent(), $response->getResponseHeader(CP_TITLE_HEADER));
+		return new CPArticle($response->getContent(), $response->getResponseHeader(self::CP_TITLE_HEADER));
 	}
 }

--- a/extensions/wikia/ContributionPrototype/CPArticleRenderer.php
+++ b/extensions/wikia/ContributionPrototype/CPArticleRenderer.php
@@ -52,15 +52,19 @@ class CPArticleRenderer {
 		}
 
 		$output->setPageTitle($title->getPrefixedText());
-		$content = $this->getArticleContent($title->getPartialURL(), $action);
+		$cpArticle = $this->getArticle($title->getPartialURL(), $action);
 		$this->addStyles($output);
-		
-		if ($content === false) {
+
+		if ($cpArticle === false) {
 			$output->addHTML("<p>We're currently experiencing some technical difficulties. Hang tight, we're working to fix these ASAP.</p>");
 			return;
 		}
 
-		$output->addHTML($content);
+		$output->addHTML($cpArticle->getContent());
+		if (!empty($cpArticle->getEntityName())) {
+			$output->setPageTitle($cpArticle->getEntityName());
+		}
+
 		$this->addScripts($output);
 	}
 
@@ -101,7 +105,7 @@ class CPArticleRenderer {
 		return "wiki/{$id}/{$slug}";
 	}
 
-	private function getArticleContent($title, $action) {
+	private function getArticle($title, $action) {
 		$internalHost = $this->publicHost;
 
 		$path = $this->getFCRequestPath($title);
@@ -131,6 +135,6 @@ class CPArticleRenderer {
 			return false;
 		}
 
-		return $response->getContent();
+		return new CPArticle($response->getContent(), $response->getResponseHeader('X-Page-Title'));
 	}
 }

--- a/extensions/wikia/ContributionPrototype/CPArticleRenderer.php
+++ b/extensions/wikia/ContributionPrototype/CPArticleRenderer.php
@@ -15,6 +15,7 @@ class CPArticleRenderer {
 	use Loggable;
 
 	const SERVICE_NAME = "structdata";
+	const CP_TITLE_HEADER = 'X-Page-Title';
 
 	/** @var string */
 	private $publicHost;
@@ -61,8 +62,8 @@ class CPArticleRenderer {
 		}
 
 		$output->addHTML($cpArticle->getContent());
-		if (!empty($cpArticle->getEntityName())) {
-			$output->setPageTitle($cpArticle->getEntityName());
+		if (!empty($cpArticle->getTitle())) {
+			$output->setPageTitle($cpArticle->getTitle());
 		}
 
 		$this->addScripts($output);
@@ -135,6 +136,6 @@ class CPArticleRenderer {
 			return false;
 		}
 
-		return new CPArticle($response->getContent(), $response->getResponseHeader('X-Page-Title'));
+		return new CPArticle($response->getContent(), $response->getResponseHeader(CP_TITLE_HEADER));
 	}
 }


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CAKE-1657

This PR changes the CP article rendering to use the title supplied by the FC to set the title. This prevents the brief display of the title with the id prefixed before it's replaced during the FC rendering.

Here we: 
  * change getArticleContent to getArticle
  * change the return type of getArticle from a string to a CPArticle object
  * use the CPArticle object to set the title and content

The changes in the FC to make this possible are here https://github.com/Wikia/sd-poc/pull/413.

@Wikia/cake 