### PR TITLE
SUS-2245: add assertions in Chat's PHP client

### DIFF
--- a/extensions/wikia/Chat2/Chat.class.php
+++ b/extensions/wikia/Chat2/Chat.class.php
@@ -58,14 +58,14 @@ class Chat {
 	 *
 	 * The key is then used by ChatAjax::getUserInfo() to load the info back from memcached.
 	 *
-	 * @return string
+	 * @return null|string
 	 */
 	public static function getSessionKey() {
 		self::info( __METHOD__ . ': Method called' );
 		$wg = F::app()->wg;
 
 		if ( !$wg->User->isLoggedIn() ) {
-			return '';
+			return null;
 		}
 		$key = 'Chat::cookies::' . sha1( $wg->User->getId() . "_" . microtime() . '_' . mt_rand() );
 		$wg->Memc->set( $key, [

--- a/extensions/wikia/Chat2/ChatController.class.php
+++ b/extensions/wikia/Chat2/ChatController.class.php
@@ -39,8 +39,7 @@ class ChatController extends WikiaController {
 		try {
 			Assert::true( is_int( $this->roomId ), 'We could not contact Chat\'s backend to get a valid roomId' );
 			Assert::true( is_string( $this->chatkey ), 'We were not able to generate a valid session key for Chat' );
-		}
-		catch( AssertionException $ex ) {
+		} catch ( AssertionException $ex ) {
 			$this->errorMsg = $ex->getMessage();
 			$this->overrideTemplate( 'error' );
 

--- a/extensions/wikia/Chat2/ChatController.class.php
+++ b/extensions/wikia/Chat2/ChatController.class.php
@@ -1,5 +1,8 @@
 <?php
 
+use Wikia\Util\Assert;
+use Wikia\Util\AssertionException;
+
 class ChatController extends WikiaController {
 
 	const CHAT_WORDMARK_WIDTH = 115;
@@ -22,15 +25,29 @@ class ChatController extends WikiaController {
 		$this->username = $wgUser->getName();
 		$this->avatarUrl = AvatarService::getAvatarUrl( $this->username, ChatController::CHAT_AVATAR_DIMENSION );
 
-		// Find the chat for this wiki (or create it, if it isn't there yet).
-		$this->roomId = ChatServerApiClient::getPublicRoomId();
 
 		// we overwrite here data from redis since it causes a bug DAR-1532
 		$pageTitle = new WikiaHtmlTitle();
 		$pageTitle->setParts( [ wfMessage( 'chat' ) ] );
 		$this->pageTitle = $pageTitle->getTitle();
 
+		// Find the chat for this wiki (or create it, if it isn't there yet).
+		$this->roomId = ChatServerApiClient::getPublicRoomId();
 		$this->chatkey = Chat::getSessionKey();
+
+		// SUS-2245: add assertions in Chat code
+		try {
+			Assert::true( is_int( $this->roomId ), 'We could not contact Chat\'s backend to get a valid roomId' );
+			Assert::true( is_string( $this->chatkey ), 'We were not able to generate a valid session key for Chat' );
+		}
+		catch( AssertionException $ex ) {
+			$this->errorMsg = $ex->getMessage();
+			$this->overrideTemplate( 'error' );
+
+			// set a proper HTTP response code
+			$this->getResponse()->setCode( 500 );
+			return;
+		}
 
 		// Set the hostname of the node server that the page will connect to.
 		$chathost = ChatConfig::getPublicHost();

--- a/extensions/wikia/Chat2/ChatServerApiClient.class.php
+++ b/extensions/wikia/Chat2/ChatServerApiClient.class.php
@@ -100,7 +100,7 @@ class ChatServerApiClient {
 		] );
 
 		if ( isset( $roomData->roomId ) ) {
-			$roomId = $roomData->roomId;
+			$roomId = intval( $roomData->roomId );
 			Chat::info( __METHOD__ . ': Method called', [
 				'roomId' => $roomId,
 			] );

--- a/extensions/wikia/Chat2/templates/ChatController_error.php
+++ b/extensions/wikia/Chat2/templates/ChatController_error.php
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+<head>
+	<title><?= $pageTitle ?></title>
+	<link rel="shortcut icon" href="<?= $wg->Favicon ?>">
+
+	<link rel="stylesheet" href="<?= AssetsManager::getInstance()->getSassCommonURL( '/extensions/wikia/Chat2/css/Chat.scss' )?>">
+</head>
+<body>
+	<section id="WikiaPage" class="WikiaPage">
+		<h1><?= htmlspecialchars( $errorMsg) ?></h1>
+	</section>
+</body>


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-2245

Assert that:

* `roomId` is an integer
* `key` used by Chat's session is a string

If the assertion fails, emit an error message and set `Special:Chat` response code to HTTP 500 to clearly show that something's wrong with Chat's backend.