### PR TITLE
SUS-2245: when Chat re-connections limit is reached reload the page

### DIFF
--- a/extensions/wikia/Chat2/ChatController.class.php
+++ b/extensions/wikia/Chat2/ChatController.class.php
@@ -6,6 +6,13 @@ class ChatController extends WikiaController {
 	const CHAT_WORDMARK_HEIGHT = 30;
 	const CHAT_AVATAR_DIMENSION = 41;
 
+	/**
+	 * @see SUS-2245
+	 *
+	 * Do not try more than given amount of re-connections. When limit is reached, reload the page.
+	 */
+	const SOCKET_IO_RECONNECT_MAX_TRIES = 4;
+
 	public function executeIndex() {
 		global $wgUser, $wgFavicon, $wgOut, $wgHooks, $wgWikiaBaseDomain, $wgWikiaNocookieDomain;
 
@@ -101,6 +108,7 @@ class ChatController extends WikiaController {
 
 		$vars['wgChatKey'] = $this->chatkey;
 		$vars['wgChatRoomId'] = $this->roomId;
+		$vars['wgChatReconnectMaxTries'] = self::SOCKET_IO_RECONNECT_MAX_TRIES;
 
 		$vars['wgChatHost'] = $this->chatServerHost;
 		$vars['wgChatPort'] = $this->chatServerPort;


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-2245

Recent chat load problems were caused by "cached" socket.io 1.4.5 clients unable to properly talk to just deployed server running socket.io 2.0.3.

This change introduces the client reload when a certain amount of re-connection retries is reached. This will make sure that the client is up to date shortly after the app release (the recent Chat problems were caused by #13124).

Currently the Chat client sends dozens of small, handshake requests every second when `socket.io` versions do not match. The server sets new io cookie on each of these requests. Four re-connection tries equal ~500 HTTP requests sent to chat's backend and that equals :fire: on production.