### PR TITLE
SUS-2162: Get rid of legacy messaging wiki hack from MessageCache

### DIFF
--- a/includes/cache/MessageCache.php
+++ b/includes/cache/MessageCache.php
@@ -650,19 +650,6 @@ class MessageCache {
 		}
 
 		# wikia change start
-		// Inline DefaultMessages check, it's getting called hundreds of times during a single request
-		// and uses time-consuming Hooks mechanism
-		if ( $message === false ) {
-			global $wgDefaultMessagesCache;
-			if ( is_object( $wgDefaultMessagesCache ) ) {
-				$dmcKey = $uckey;
-				if ( $langcode !== 'en' && strpos( $dmcKey, '/' ) === false ) {
-					$dmcKey .= '/' . $langcode;
-				}
-				$message = $wgDefaultMessagesCache->get( $dmcKey, $langcode, $useDB );
-			}
-		}
-
 		# Try the extension array
 		if ( $message === false && isset( $this->mExtensionMessages[$langcode][$lckey] ) ) {
 			$message = $this->mExtensionMessages[$langcode][$lckey];


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-2162

Partially reverts 359a82952ed311913bad13929375c6e998044777 and removed the last mentions of `$wgDefaultMessagesCache` which was used for handling i18n strings stored on messaging.wikia.com.