### PR TITLE
WikiFactory/Close/maintenance.php: remove entries from city_variables as well

### DIFF
--- a/extensions/wikia/WikiFactory/Close/maintenance.php
+++ b/extensions/wikia/WikiFactory/Close/maintenance.php
@@ -225,6 +225,14 @@ class CloseWikiMaintenance {
 					),
 					__METHOD__
 				);
+				// SUS-2374
+				$dbw->delete(
+					"city_variables",
+					array(
+						"cv_city_id" => $row->city_id
+					),
+					__METHOD__
+				);
 				$this->log( "{$row->city_id} removed from WikiFactory tables" );
 
 				$this->cleanupSharedData( intval( $row->city_id ) );


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-2374

`WikiFactory::copyToArchive( $row->city_id )` called above copies `city_variables` rows to archive cluster, we can safely delete these rows from shared DB.

Right now out of 22 mm rows in `city_variables`, 9 mm are those for deleted wikis.