### PR TITLE
CAKE-1967 Change the api subdomain to query for LI

### DIFF
--- a/extensions/wikia/Recirculation/js/trackers/liftigniter.js
+++ b/extensions/wikia/Recirculation/js/trackers/liftigniter.js
@@ -48,10 +48,10 @@ $p("init", "l9ehhrb6mtv75bp2", {
             queryServer: "//query.fandommetrics.com"
         },
         activity: {
-            activityServer: "//api.fandommetrics.com"
+            activityServer: "//query.fandommetrics.com"
         },
         inventory: {
-            inventoryServer: "//api.fandommetrics.com"
+            inventoryServer: "//query.fandommetrics.com"
         },
         globalCtx: getLiftIgniterGlobalContext()
     }


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CAKE-1967

The `api` domain started 404'ing for some requests. LI asked us to change these to `query`.

Ops already setup the DNS:

```
[damon@dev-damon app]$ dig query.fandommetrics.com +short
query.petametrics.com.
35.190.14.224
```

@Wikia/cake @frankfarmer 