### PR TITLE
Fix namespace error in GlobalShortcuts

### DIFF
--- a/extensions/wikia/GlobalShortcuts/GlobalShortcuts.hooks.php
+++ b/extensions/wikia/GlobalShortcuts/GlobalShortcuts.hooks.php
@@ -47,7 +47,7 @@ class Hooks {
 		$helper->addCurrentPageActions( $actions, $shortcuts );
 		$helper->addSpecialPageActions( $actions, $shortcuts );
 
-		Hooks::run( 'PageGetActions', [ &$actions, &$shortcuts ] );
+		\Hooks::run( 'PageGetActions', [ &$actions, &$shortcuts ] );
 		$vars['wgWikiaPageActions'] = $actions;
 		$vars['wgWikiaShortcutKeys'] = $shortcuts;
 


### PR DESCRIPTION
Fixes the error:

    Error: Call to undefined method Wikia\GlobalShortcuts\Hooks::run() in
    extensions/wikia/GlobalShortcuts/GlobalShortcuts.hooks.php:50

/cc @macbre @TK-999 