### PR TITLE
SUS-2420 set From: address on email sent by discussion alert cron

### DIFF
--- a/maintenance/wikia/discussion-alerts.php
+++ b/maintenance/wikia/discussion-alerts.php
@@ -129,5 +129,4 @@ doMail( 'community@wikia.com', $body );
 function doMail($address, $body) {
 	$header = "From: $address\r\n";
 	mail( $address, 'Discussions alert', $body, $header );
-
 }

--- a/maintenance/wikia/discussion-alerts.php
+++ b/maintenance/wikia/discussion-alerts.php
@@ -122,6 +122,12 @@ foreach ( $queries as $query ) {
 
 $body .= "\nThis is the end of the list.  If you can't read this line, please tell TOR.  Oh... wait...\n";
 
-// send the e-mail
-mail( 'tor@wikia-inc.com', 'Discussions alert', $body );
-mail( 'community@wikia.com', 'Discussion alerts', $body );
+
+doMail( 'tor@wikia-inc.com', $body );
+doMail( 'community@wikia.com', $body );
+
+function doMail($address, $body) {
+	$header = "From: $address\r\n";
+	mail( $address, 'Discussions alert', $body, $header );
+
+}


### PR DESCRIPTION
This cron job is sending with a default `From` of `root@wikia.com` which is resulting in unecessary spam to the ops team

This is an addition to #13311