### PR TITLE
WikiaSpecialVersion: remove handling of old deploytools

### DIFF
--- a/extensions/wikia/SpecialVersion/WikiaSpecialVersion.class.php
+++ b/extensions/wikia/SpecialVersion/WikiaSpecialVersion.class.php
@@ -15,19 +15,10 @@ class WikiaSpecialVersion extends SpecialVersion {
 		if ( file_exists( "$IP/../config" ) ) {
 			return self::getVersionFromDir("$IP/../config");
 		}
-		# transition only, remove when new deploytools are released
-		if ( file_exists("$IP/../docroot" ) ) {
-			return self::getVersionFromDir("$IP/../docroot");
-		}
 	}
 
 	public static function getVersionFromDir($dir) {
 		$filename = $dir . '/wikia.version.txt';
-		if ( file_exists( $filename ) ) {
-			return file_get_contents( $filename );
-		}
-		# transition only, remove when new deploytools are released
-		$filename = $dir . '/VERSION';
 		if ( file_exists( $filename ) ) {
 			return file_get_contents( $filename );
 		}


### PR DESCRIPTION
These checks are from 2014 and referenced directories are no longer generated by currently used deploy tools.