### PR TITLE
MAIN-10869: Remove $watchers dictionary from Elasticsearch logs

### DIFF
--- a/extensions/wikia/Follow/FollowEmailTask.class.php
+++ b/extensions/wikia/Follow/FollowEmailTask.class.php
@@ -44,7 +44,14 @@ class FollowEmailTask extends BaseTask {
 		} else {
 			$msg = 'WatchlistLogs: Sending other watchlist updates';
 		}
+		// MAIN-10869 - don't use dynamic keys (titles) as key names
+		// Convert $watchers to a flat array before logging.
+		$flat_watchers = [];
+		foreach( $watchers as $title => $users ) {
+			$flat_watchers[] = $title;
+			$flat_watchers = array_merge( $flat_watchers, $users );
+		}
 
-		$this->info( $msg, [ 'watchers' => $watchers, 'action' => $action ] );
+		$this->info( $msg, [ 'watchers' => $flat_watchers, 'action' => $action ] );
 	}
 }

--- a/extensions/wikia/Follow/FollowEmailTask.class.php
+++ b/extensions/wikia/Follow/FollowEmailTask.class.php
@@ -19,7 +19,7 @@ class FollowEmailTask extends BaseTask {
 
 		$targetUser = User::newFromId( $userId );
 
-		$this->logWatchers( $watchers, $action );
+		$this->logAction( $action );
 
 		foreach ( $watchers as $titleText => $followingUsers ) {
 			$title = Title::makeTitle( $namespace, $titleText );
@@ -36,7 +36,7 @@ class FollowEmailTask extends BaseTask {
 		}
 	}
 
-	private function logWatchers( $watchers, $action ) {
+	private function logAction( $action ) {
 		if ( $action == FollowHelper::LOG_ACTION_BLOG_POST ) {
 			$msg = 'WatchlistLogs: Sending bloglisting watchlist updates';
 		} elseif ( $action == FollowHelper::LOG_ACTION_CATEGORY_ADD ) {
@@ -44,14 +44,7 @@ class FollowEmailTask extends BaseTask {
 		} else {
 			$msg = 'WatchlistLogs: Sending other watchlist updates';
 		}
-		// MAIN-10869 - don't use dynamic keys (titles) as key names
-		// Convert $watchers to a flat array before logging.
-		$flatWatchers = [];
-		foreach( $watchers as $title => $users ) {
-            $flatWatchers[] = $title;
-            $flatWatchers = array_merge( $flatWatchers, $users );
-		}
 
-		$this->info( $msg, [ 'watchers' => $flatWatchers, 'action' => $action ] );
+		$this->info( $msg, [ 'action' => $action ] );
 	}
 }

--- a/extensions/wikia/Follow/FollowEmailTask.class.php
+++ b/extensions/wikia/Follow/FollowEmailTask.class.php
@@ -46,12 +46,12 @@ class FollowEmailTask extends BaseTask {
 		}
 		// MAIN-10869 - don't use dynamic keys (titles) as key names
 		// Convert $watchers to a flat array before logging.
-		$flat_watchers = [];
+		$flatWatchers = [];
 		foreach( $watchers as $title => $users ) {
-			$flat_watchers[] = $title;
-			$flat_watchers = array_merge( $flat_watchers, $users );
+            $flatWatchers[] = $title;
+            $flatWatchers = array_merge( $flatWatchers, $users );
 		}
 
-		$this->info( $msg, [ 'watchers' => $flat_watchers, 'action' => $action ] );
+		$this->info( $msg, [ 'watchers' => $flatWatchers, 'action' => $action ] );
 	}
 }


### PR DESCRIPTION
During the task run the title and user login are logged to elk by the `EmailNotification` class, so we can remove this dict that created dynamic fields in ELK.