### PR TITLE
SUS-2391: In VideoPageTool reference BannerNotification instance correctly

### DIFF
--- a/extensions/wikia/VideoPageTool/scripts/admin/views/featured.js
+++ b/extensions/wikia/VideoPageTool/scripts/admin/views/featured.js
@@ -13,7 +13,6 @@ define('videopageadmin.views.featured', [
 		initialize: function () {
 			EditBaseView.prototype.initialize.call(this, arguments);
 			this.$fieldsToValidate = this.$el.find('.description, .display-title, .video-key, .alt-thumb');
-			this.bannerNotification = new BannerNotification().setType('error');
 
 			_.bindAll(this, 'initAddVideo', 'initValidator', 'clearForm');
 
@@ -109,7 +108,10 @@ define('videopageadmin.views.featured', [
 								// close VET modal
 								vet.close();
 							} else {
-								bannerNotification.setContent(json.msg).show();
+								new BannerNotification()
+									.setType('error')
+									.setContent(json.msg)
+									.show();
 							}
 						}
 					});


### PR DESCRIPTION
Ensure that error message is correctly displayed to user when the video they are trying to add is not licensed.

https://wikia-inc.atlassian.net/browse/SUS-2391

![Task failed successfully](http://i1.kym-cdn.com/photos/images/facebook/000/918/810/a22.jpg)