### PR TITLE
Fix notices in NavigationTest

### DIFF
--- a/extensions/wikia/CommunityHeader/tests/NavigationTest.php
+++ b/extensions/wikia/CommunityHeader/tests/NavigationTest.php
@@ -18,7 +18,7 @@ class NavigationTest extends WikiaBaseTest {
 			'WikiFactory',
 			'getVarValueByName',
 			function ( $variable/*, $id*/ ) use ( $globals ) {
-				return $globals[$variable];
+				return $globals[$variable] ?? $GLOBALS[$variable] ?? false;
 			}
 		);
 
@@ -41,7 +41,7 @@ class NavigationTest extends WikiaBaseTest {
 			function ( $variable/*, $id*/ ) use ( $globals ) {
 				$globals['wgServer'] = self::DOMAIN;
 
-				return $globals[$variable];
+				return $globals[$variable] ?? $GLOBALS[$variable] ?? false;
 			}
 		);
 


### PR DESCRIPTION
`NavigationTest` is outputting ugly PHP notices in logs.