### PR TITLE
SUS-2517: Increase uselessly low IPv6 range block limit

### DIFF
--- a/includes/DefaultSettings.php
+++ b/includes/DefaultSettings.php
@@ -3344,12 +3344,19 @@ $wgSysopEmailBans = true;
  * Limits on the possible sizes of range blocks.
  *
  * CIDR notation is hard to understand, it's easy to mistakenly assume that a
- * /1 is a small range and a /31 is a large range. Setting this to half the
- * number of bits avoids such errors.
+ * /1 is a small range and a /31 is a large range. For IPv4, setting a limit of
+ * half the number of bits avoids such errors, and allows entire ISPs to be
+ * blocked using a small number of range blocks.
+ *
+ * For IPv6, RFC 3177 recommends that a /48 be allocated to every residential
+ * customer, so range blocks larger than /64 (half the number of bits) will
+ * plainly be required. RFC 4692 implies that a very large ISP may be
+ * allocated a /19 if a generous HD-Ratio of 0.8 is used, so we will use that
+ * as our limit. As of 2012, blocking the whole world would require a /4 range.
  */
 $wgBlockCIDRLimit = array(
 	'IPv4' => 16, # Blocks larger than a /16 (64k addresses) will not be allowed
-	'IPv6' => 64, # 2^64 = ~1.8x10^19 addresses
+	'IPv6' => 19,
 );
 
 /**


### PR DESCRIPTION
Port of https://gerrit.wikimedia.org/r/#/c/11260/
>For IPv6, RFC 3177 recommends that a /48 be allocated to every residential customer, so range blocks larger than /64 (half the number of bits) will plainly be required. RFC 4692 implies that a very large ISP may be allocated a /19 if a generous HD-Ratio of 0.8 is used, so we will use that as our limit. As of 2012, blocking the whole world would require a /4 range.

https://wikia-inc.atlassian.net/browse/SUS-2517