### PR TITLE
MAIN-10932 - LyricWiki: Move SOTD extension CSS loading into execute function to prevent it being loaded on every page

### DIFF
--- a/extensions/3rdparty/LyricWiki/SongOfTheDay/Special_SOTD.body.php
+++ b/extensions/3rdparty/LyricWiki/SongOfTheDay/Special_SOTD.body.php
@@ -11,8 +11,7 @@ class SOTD extends SpecialPage
 	function __construct()
 	{
 		parent::__construct( 'SOTD' );
-		global $errors, $errorlist, $wgOut;
-		$wgOut->addStyle(AssetsManager::getInstance()->getOneCommonURL('extensions/3rdparty/LyricWiki/SongOfTheDay/Special_SOTD.css'));
+		global $errors, $errorlist;
 		$errors = array ( 'set' => false );
 		$errorlist = '';
 	}
@@ -196,6 +195,9 @@ class SOTD extends SpecialPage
 		$action = $wgRequest->getText('action');
 		$mode = $wgRequest->getText('mode');
 		$pagename = $this->getTitle()->getPrefixedText();
+
+		$wgOut->addStyle(AssetsManager::getInstance()->getOneCommonURL('extensions/3rdparty/LyricWiki/SongOfTheDay/Special_SOTD.css'));
+
 		if ( $par == 'Admin' )
 		{	# Admin mode subpage
 			if ( $canModify )


### PR DESCRIPTION
Currently, the SongOfTheDay extension CSS is being loaded on every page on the wiki, causing a few style issues. Moving the `$wgOut->addStyle` call from __construct into the execute function should hopefully stop that from happening.

----
Note that I've kept the existing code style for consistency with the rest of the file and simplicity of the changes - if you'd like me to follow code conventions instead, just let me know!

Ticket: MAIN-10932