### PR TITLE
MAIN-10932 - LyricWiki: Update lyricbox styling to match current wiki style

### DIFF
--- a/extensions/3rdparty/LyricWiki/Gracenote/Tag_GracenoteLyrics.php
+++ b/extensions/3rdparty/LyricWiki/Gracenote/Tag_GracenoteLyrics.php
@@ -146,9 +146,9 @@ function gracenoteLyricsTagCss(OutputPage $out)
 .lyricbox
 {
 	padding: 1em;
-	border: 1px solid silver;
-	color: black;
-	background-color: #ffffcc;
+	border: 1px solid #ccc;
+	color: #3a3a3a;
+	background-color: #f8f8f8;
 }
 DOC
 ;

--- a/extensions/3rdparty/LyricWiki/LyricFind/css/lyricbox.css
+++ b/extensions/3rdparty/LyricWiki/LyricFind/css/lyricbox.css
@@ -20,9 +20,9 @@
 
 .lyricbox {
 	padding: 1em;
-	border: 1px solid silver;
-	color: black;
-	background-color: #FFC;
+	border: 1px solid #ccc;
+	color: #3a3a3a;
+	background-color: #f8f8f8;
 }
 
 .rtMatcher a {

--- a/extensions/3rdparty/LyricWiki/Tag_Lyric.php
+++ b/extensions/3rdparty/LyricWiki/Tag_Lyric.php
@@ -77,10 +77,10 @@ function lyricTagCss($out)
 	$css = <<<DOC
 .lyricbox
 {
-	padding: 1em 1em 0;
-	border: 1px solid silver;
-	color: black;
-	background-color: #ffffcc;
+	padding: 1em;
+	border: 1px solid #ccc;
+	color: #3a3a3a;
+	background-color: #f8f8f8;
 }
 .lyricsbreak{
 	clear:both;


### PR DESCRIPTION
The default tag styling is currently being overridden in the wiki Common.css page using `!important`, but it seems better to update it in the parser code instead. 

----
Ticket: MAIN-10932