### PR TITLE
MAIN-10932 - LyricWiki: Fix links to project/blog namespaces on Special:Linkstoredirects

### DIFF
--- a/extensions/3rdparty/LyricWiki/Special_LinksToRedirects.php
+++ b/extensions/3rdparty/LyricWiki/Special_LinksToRedirects.php
@@ -161,8 +161,8 @@ class Linkstoredirects extends SpecialPage{
 						1 => "Talk",
 						2 => "User",
 						3 => "User_talk",
-						4 => $wgSitename,
-						5 => $wgSitename."_talk",
+						4 => "Project",
+						5 => "Project_talk",
 						6 => ":File",
 						7 => "File_talk",
 						8 => "MediaWiki",
@@ -172,7 +172,9 @@ class Linkstoredirects extends SpecialPage{
 						12 => "Help",
 						13 => "Help_talk",
 						14 => ":Category",
-						15 => "Category_talk"
+						15 => "Category_talk",
+						500 => "User_blog",
+						501 => "User_blog_comment"
 					);
 					$idToTitle = array();
 					$ids = array_unique($ids);


### PR DESCRIPTION
See http://lyrics.wikia.com/wiki/Special:Linkstoredirects - there's a number of broken links there due to the special page code assuming `$wgSitename` for the project namespace, and due to the blog/blog comment namespaces being missing. 

----
Ticket: MAIN-10932