### PR TITLE
MAIN-10932 - LyricWiki: Support Cyrillic, Greek, and more Latin letters in fletter magic words

### DIFF
--- a/extensions/3rdparty/LyricWiki/Parser_LWMagicWords.php
+++ b/extensions/3rdparty/LyricWiki/Parser_LWMagicWords.php
@@ -25,14 +25,13 @@ function findFirstLetterOf($fLetterOf)
 	{
 		return "0-9";
 	}
-	else if(($fLetter < "A") || ($fLetter > "Z"))
+	if(preg_match("/^[A-ZÀ-ÖØ-ÞĀ-ŽΆ-ΩА-Я]$/u", $fLetter))
 	{
-		return "Symbol";
-	}
-	else
-	{
+		// Covers Latin, accented/extended Latin (3 sets), Greek, and Cyrillic letters.
+		// Rest can be set when creating wiki page to avoid this becoming complicated.
 		return $fLetter;
 	}
+	return "Symbol";
 }
 
 function LyricWikiVariableDefaults()


### PR DESCRIPTION
Currently, the `artistfletter`/`albumfletter`/`songfletter` magic words support the English alphabet only. Anything else defaults to 'Symbol' and needs to be set manually in a template on the page. This change would reduce the number of cases where that'd be needed.

----
Note that I've kept the existing code style for consistency with the rest of the file and simplicity of the changes - if you'd like me to follow code conventions instead, just let me know!

Ticket: MAIN-10932