### PR TITLE
 MAIN-10932 - LyricWiki: Support using a template preload when creating category namespace pages

### DIFF
--- a/extensions/3rdparty/LyricWiki/Parser_LWMagicWords.php
+++ b/extensions/3rdparty/LyricWiki/Parser_LWMagicWords.php
@@ -142,7 +142,12 @@ function getLyricWikiVariables()
 		$titleStr = $wgTitle->getFullText();
 
 		$ns = $wgTitle->getNamespace();
-		if(($ns != NS_MAIN) && ($ns  != NS_TALK))
+		if($ns == NS_CATEGORY)
+		{
+			//set pagetype for category namespace so template preload in Templates.php can run there.
+			$lwVars["pagetype"] = "category";
+		}
+		elseif(($ns != NS_MAIN) && ($ns != NS_TALK))
 		{
 			//pages outside of the main namespace & talk shouldn't have music-related templates.
 			$lwVars["pagetype"] = "none";

--- a/extensions/3rdparty/LyricWiki/Templates.php
+++ b/extensions/3rdparty/LyricWiki/Templates.php
@@ -63,9 +63,9 @@ function lw_templatePreload(&$textbox, Title &$title)
 
 	$titleStr = $title->getText();
 
-	// only use templates in the main namespace
+	// only use templates in the main and category namespace
 	$ns = $title->getNamespace();
-	if(($ns != NS_MAIN) && ($ns != NS_TALK)){
+	if(($ns != NS_MAIN) && ($ns != NS_TALK) && ($ns != NS_CATEGORY)){
 		return true;
 	}
 

--- a/extensions/3rdparty/LyricWiki/Templates.php
+++ b/extensions/3rdparty/LyricWiki/Templates.php
@@ -106,7 +106,7 @@ function lw_templatePreload(&$textbox, Title &$title)
 		$template = wfMsgForContentNoTrans("lwtemp-{$pageType}-template");
 
 		// only display a template if the template actually exists
-		if( $template != "<{$pageType}Template>" and $template != "&lt;{$pageType}Template&gt;" )
+		if( $template != "&lt;lwtemp-{$pageType}-template&gt;" )
 		{
 			$textbox = $template;
 			$lwVars = getLyricWikiVariables();


### PR DESCRIPTION
The new page template preload extension is currently limited to running on the main/talk namespaces. Having it available in the category namespace too would be convenient. I've also fixed the existence check.

----
Note that I've kept the existing code style for consistency with the rest of the file and simplicity of the changes - if you'd like me to follow code conventions instead, just let me know!

Ticket: MAIN-10932