### PR TITLE
MAIN-10932 - LyricWiki: Add 'songsubpage' magic word for use in the template preload

### DIFF
--- a/extensions/3rdparty/LyricWiki/Parser_LWMagicWords.php
+++ b/extensions/3rdparty/LyricWiki/Parser_LWMagicWords.php
@@ -52,6 +52,7 @@ function LyricWikiVariableDefaults()
 	$lwVars["albumfletter"] = "ALBUMFLETTER";
 	$lwVars["song"] = "SONG";
 	$lwVars["songfletter"] = "SONGFLETTER";
+	$lwVars["songsubpage"] = "SONGSUBPAGE";
 	$lwVars["artistsortname"] = "ARTISTSORTNAME";
 	return $lwVars;
 }
@@ -103,6 +104,10 @@ function parseLyricWikiTitle($titleStr,&$lwVars)
 		$song = $lwVars["song"];
 		$lwVars["artistfletter"] = findFirstLetterOf($lwVars["artist"]);
 		$lwVars["songfletter"] = findFirstLetterOf($lwVars["song"]);
+		if( 0 < preg_match("/^.+\/(.+)$/",$lwVars["song"],$m2) )
+		{
+			$lwVars["songsubpage"] = trim($m2[1]);
+		}
 	}
 	else
 	{


### PR DESCRIPTION
A `songsubpage` magic word would allow simplifying the new page template preload for translated song pages. Their page names are of the form `Artist:Song Name/languagecode`.

----
Note that I've kept the existing code style for consistency with the rest of the file and simplicity of the changes - if you'd like me to follow code conventions instead, just let me know!

Ticket: MAIN-10932