### PR TITLE
XW-3823: Disabling memcache in NavigationTest

### DIFF
--- a/extensions/wikia/CommunityHeader/tests/NavigationTest.php
+++ b/extensions/wikia/CommunityHeader/tests/NavigationTest.php
@@ -7,6 +7,13 @@ use \Wikia\CommunityHeader\Navigation;
 class NavigationTest extends WikiaBaseTest {
 	const WIKI_ID = 147;
 	const DOMAIN =  "http://starwars.wikia.com";
+
+
+	protected function setUp() {
+		parent::setUp();
+		$this->disableMemCache();
+	}
+
 	/**
 	 * @dataProvider exploreItemsProvider
 	 *


### PR DESCRIPTION
So GlobalTitle tries to load the `mServer` from memcache https://github.com/Wikia/app/blob/56373dd143cb52343ae9d620246834b15c2fe144/includes/wikia/GlobalTitle.php#L195 and if it succeeds, it is not fetched from globals. Disabling the memcache in this test so the mocked value is always used.