### PR TITLE
SUS-2537 | make Welcome Tool use a default Fandom user account

### DIFF
--- a/extensions/wikia/HAWelcome/HAWelcomeTask.php
+++ b/extensions/wikia/HAWelcome/HAWelcomeTask.php
@@ -6,10 +6,6 @@ use Wikia\Util\GlobalStateWrapper;
 class HAWelcomeTask extends BaseTask {
 	use IncludeMessagesTrait;
 
-	/** @type String The default user to send welcome messages. */
-	const DEFAULT_WELCOMER = 'Wikia';
-
-
 	/**
 	 * Default switches to enable features, explained below.
 	 *
@@ -103,7 +99,7 @@ class HAWelcomeTask extends BaseTask {
 	}
 
 	protected function getDefaultWelcomerUser() {
-		return User::newFromName( self::DEFAULT_WELCOMER );
+		return User::newFromName( Wikia::USER );
 	}
 
 	public function getUserFeatureFlags() {
@@ -265,7 +261,7 @@ class HAWelcomeTask extends BaseTask {
 		}
 
 		// This should not happen. Fall back to the default welcomer.
-		$this->senderObject = User::newFromName( HAWelcomeTask::DEFAULT_WELCOMER );
+		$this->senderObject = User::newFromName( Wikia::USER );
 		return;
 	}
 

--- a/extensions/wikia/HAWelcome/HAWelcomeTaskHookDispatcher.php
+++ b/extensions/wikia/HAWelcome/HAWelcomeTaskHookDispatcher.php
@@ -98,7 +98,7 @@ class HAWelcomeTaskHookDispatcher {
 	}
 
 	protected function currentUserIsDefaultWelcomer() {
-		return $this->currentUser->getName() == HAWelcomeTask::DEFAULT_WELCOMER;
+		return $this->currentUser->getName() == Wikia::USER;
 	}
 
 	protected function currentUserIsFounder() {

--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -86,6 +86,7 @@ class Wikia {
 	const COMMUNITY_WIKI_ID = 177; // community.wikia.com
 	const NEWSLETTER_WIKI_ID = 223496; // wikianewsletter.wikia.com
 
+	const USER = 'Fandom';
 	const BOT_USER = 'FandomBot';
 
 	const FAVICON_URL_CACHE_KEY = 'favicon-v1';


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-2537

For now it will be "Fandom" account as "FANDOM" is not yet created.