### PR TITLE
SUS-2528: Move legacy default styles from MediaWiki:Common.css to core

### DIFF
--- a/extensions/GlobalMessages/GlobalMessagesC.i18n.php
+++ b/extensions/GlobalMessages/GlobalMessagesC.i18n.php
@@ -103,18 +103,7 @@ Since you do not have the hideuser right, you cannot see or edit the user's bloc
 	'cant-move-user-page' => 'You do not have permission to move user pages (apart from subpages).',
 	'cant-move-to-user-page' => 'You do not have permission to move a page to a user page (except to a user subpage).',
 	'cantmove-titleprotected' => 'You cannot move a page to this location, because the new title has been protected from creation',
-	'common.css' => '/***** CSS placed here will be applied to all skins on the entire site. *****/
-
-/* Mark redirects in Special:Allpages and Special:Watchlist */
-.allpagesredirect {
-   font-style: italic;
-}
-.allpagesredirect:after {
-   color: #808080; content: " (redirect)"
-}
-.watchlistredir {
-   font-style: italic;
-}',
+	'common.css' => '/***** CSS placed here will be applied to all skins on the entire site. *****/',
 	'common.js' => '/* Any JavaScript here will be loaded for all users on every page load. */',
 	'creditspage' => 'Page credits',
 	'confirmemail' => 'Confirm email address',

--- a/resources/mediawiki.special/mediawiki.special.css
+++ b/resources/mediawiki.special/mediawiki.special.css
@@ -31,6 +31,10 @@ table.mw-allpages-table-form tr {
 	vertical-align: top;
 }
 
+.allpagesredirect {
+	font-style: italic;
+}
+
 /**** Special:Block ****/
 tr.mw-block-hideuser {
 	font-weight: bold;
@@ -271,4 +275,9 @@ td.mw-statistics-numbers {
 table.mw-userrights-groups * td,
 table.mw-userrights-groups * th {
 	padding-right: 1.5em;
+}
+
+/**** Special:WatchList ****/
+.watchlistredir {
+	font-style: italic;
 }


### PR DESCRIPTION
These styles are included in Common.css on newly created English wikis, which results in confusing `@import` behavior. In newer versions of MW, they have been moved to `mediawiki.special` module - let's do so.

https://wikia-inc.atlassian.net/browse/SUS-2528