### PR TITLE
CAKE-2028 Add CORS support to the DesignSystemApiController

### DIFF
--- a/includes/wikia/api/DesignSystemApiController.class.php
+++ b/includes/wikia/api/DesignSystemApiController.class.php
@@ -11,7 +11,8 @@ class DesignSystemApiController extends WikiaApiController {
 	public function __construct() {
 		parent::__construct();
 		$this->cors = new CrossOriginResourceSharingHeaderHelper();
-		$this->cors->setAllowOrigin( [ '*' ] );
+		$this->cors->readConfig();
+		$this->cors->setAllowCredentials( true );
 	}
 
 	public function getFooter() {

--- a/includes/wikia/api/DesignSystemApiController.class.php
+++ b/includes/wikia/api/DesignSystemApiController.class.php
@@ -6,6 +6,14 @@ class DesignSystemApiController extends WikiaApiController {
 	const PARAM_LANG = 'lang';
 	const PRODUCT_WIKIS = 'wikis';
 
+	protected $cors;
+
+	public function __construct() {
+		parent::__construct();
+		$this->cors = new CrossOriginResourceSharingHeaderHelper();
+		$this->cors->setAllowOrigin( [ '*' ] );
+	}
+
 	public function getFooter() {
 		$params = $this->getRequestParameters();
 		$footerModel = new DesignSystemGlobalFooterModel(
@@ -14,6 +22,7 @@ class DesignSystemApiController extends WikiaApiController {
 			$params[static::PARAM_LANG]
 		);
 
+		$this->cors->setHeaders( $this->response );
 		$this->setResponseData( $footerModel->getData() );
 		$this->response->setCacheValidity( WikiaResponse::CACHE_VERY_SHORT );
 	}
@@ -26,6 +35,7 @@ class DesignSystemApiController extends WikiaApiController {
 			$params[static::PARAM_LANG]
 		);
 
+		$this->cors->setHeaders( $this->response );
 		$this->setResponseData( $navigationModel->getData() );
 		$this->addCachingHeaders();
 	}
@@ -36,6 +46,7 @@ class DesignSystemApiController extends WikiaApiController {
 			$params[static::PARAM_ID]
 		);
 
+		$this->cors->setHeaders( $this->response );
 		$this->setResponseData( $communityHeaderModel->getData() );
 		$this->response->setCacheValidity( WikiaResponse::CACHE_VERY_SHORT );
 	}
@@ -64,6 +75,7 @@ class DesignSystemApiController extends WikiaApiController {
 			$params[static::PARAM_ID]
 		);
 
+		$this->cors->setHeaders( $this->response );
 		$this->setResponseData(
 			[
 				'global-footer' => $footerModel->getData(),

--- a/includes/wikia/helpers/CrossOriginResourceSharingHeaderHelper.php
+++ b/includes/wikia/helpers/CrossOriginResourceSharingHeaderHelper.php
@@ -10,6 +10,7 @@
 class CrossOriginResourceSharingHeaderHelper {
 	const ALLOW_ORIGIN_HEADER_NAME = 'Access-Control-Allow-Origin';
 	const ALLOW_METHOD_HEADER_NAME = 'Access-Control-Allow-Method';
+	const ALLOW_CREDENTIALS_HEADER_NAME = 'Access-Control-Allow-Credentials';
 	const HEADER_DELIMETER = ',';
 
 	protected $allowValues = [];
@@ -35,6 +36,16 @@ class CrossOriginResourceSharingHeaderHelper {
 	}
 
 	/**
+	 * @param boolean $value
+	 * @return $this
+	 */
+	public function setAllowCredentials( $value ) {
+		$this->allowValues[self::ALLOW_CREDENTIALS_HEADER_NAME] = (boolean)$value ? 'true' : 'false';
+
+		return $this;
+	}
+
+	/**
 	 * This method sets all configured CORS related headers
 	 *
 	 * @param WikiaResponse $response response object to set headers to
@@ -50,11 +61,17 @@ class CrossOriginResourceSharingHeaderHelper {
 					$response->removeHeader( $headerName );
 
 					foreach ( $headers as $header ) {
-						$valuesToSet = array_merge( $valuesToSet, explode( self::HEADER_DELIMETER, $header['value'] ) );
+						if ( strpos( $header['value'], self::HEADER_DELIMETER ) !== false ) {
+							$valuesToSet = array_merge( $valuesToSet, explode( self::HEADER_DELIMETER, $header['value'] ) );
+						}
 					}
 				}
 
-				$response->setHeader( $headerName, implode( self::HEADER_DELIMETER, $valuesToSet ) );
+				if ( is_array( $valuesToSet ) ) {
+					$response->setHeader( $headerName, implode( self::HEADER_DELIMETER, $valuesToSet ) );
+				} else {
+					$response->setHeader( $headerName, $valuesToSet );
+				}
 			}
 		}
 

--- a/includes/wikia/helpers/CrossOriginResourceSharingHeaderHelper.php
+++ b/includes/wikia/helpers/CrossOriginResourceSharingHeaderHelper.php
@@ -61,21 +61,31 @@ class CrossOriginResourceSharingHeaderHelper {
 					$response->removeHeader( $headerName );
 
 					foreach ( $headers as $header ) {
-						if ( strpos( $header['value'], self::HEADER_DELIMETER ) !== false ) {
-							$valuesToSet = array_merge( $valuesToSet, explode( self::HEADER_DELIMETER, $header['value'] ) );
-						}
+						$valuesToSet = $this->mergeValues( $valuesToSet, $header['value'] );
 					}
 				}
 
-				if ( is_array( $valuesToSet ) ) {
-					$response->setHeader( $headerName, implode( self::HEADER_DELIMETER, $valuesToSet ) );
-				} else {
-					$response->setHeader( $headerName, $valuesToSet );
-				}
+				$this->setResponseHeader( $response, $headerName, $valuesToSet );
 			}
 		}
 
 		return $this;
+	}
+
+	private function mergeValues( $mergeTo, $headerValue ) {
+		if ( is_array( $mergeTo ) && strpos( $headerValue, self::HEADER_DELIMETER ) !== false ) {
+			return array_merge( $mergeTo, explode( self::HEADER_DELIMETER, $headerValue ) );
+		}
+
+		return $mergeTo;
+	}
+
+	private function setResponseHeader( WikiaResponse $response, $headerName, $values ) {
+		if ( is_array( $values ) ) {
+			$response->setHeader( $headerName, implode( self::HEADER_DELIMETER, $values ) );
+		} else {
+			$response->setHeader( $headerName, $values );
+		}
 	}
 
 	/**

--- a/includes/wikia/helpers/tests/CrossOriginResourceSharingHeaderHelperTest.php
+++ b/includes/wikia/helpers/tests/CrossOriginResourceSharingHeaderHelperTest.php
@@ -51,8 +51,30 @@ class CrossOriginResourceSharingHeaderHelperTest extends BaseTest {
 		$this->assertEquals( $headers[0]['value'], 'a,b,t,t,m,p' );
 	}
 
-	public function testShouldProperlyReadCORSConfigFromGlobal()
-	{
+	public function testShouldProperlySetAllowCredentialsHeaderToTrue() {
+		$dummyResponse = new WikiaResponse( "tmp" );
+
+		$cors = new CrossOriginResourceSharingHeaderHelper();
+		$cors->setAllowCredentials( true )->setHeaders( $dummyResponse );
+
+		$headers = $dummyResponse->getHeader( CrossOriginResourceSharingHeaderHelper::ALLOW_CREDENTIALS_HEADER_NAME );
+
+		$this->assertEquals( $headers[0]['value'], 'true' );
+	}
+
+	public function testShouldProperlySetAllowCredentialsHeaderToFalse() {
+		$dummyResponse = new WikiaResponse( "tmp" );
+
+		$cors = new CrossOriginResourceSharingHeaderHelper();
+		$cors->setAllowCredentials( false )->setHeaders( $dummyResponse );
+
+		$headers = $dummyResponse->getHeader( CrossOriginResourceSharingHeaderHelper::ALLOW_CREDENTIALS_HEADER_NAME );
+
+		$this->assertEquals( $headers[0]['value'], 'false' );
+
+	}
+
+	public function testShouldProperlyReadCORSConfigFromGlobal() {
 		global $wgCORSAllowOrigin;
 		$wgCORSAllowOrigin = [ "a", "b", "c" ];
 		$dummyResponse = new WikiaResponse( "tmp" );


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CAKE-2028
https://wikia-inc.atlassian.net/browse/CAKE-2033

Add `Access-Control-Allow-Origin:*` to all design system API requests. We are adding requests to these APIs in the header and footer web components in the [`fandom-global-elements`](https://github.com/Wikia/fandom-global-elements). Some of these requests will be coming from *.wikia.com and *.wikia-dev.us as we roll out support for the header and footer. Without the `Access-Control-Allow-Origin` header the browser won't propagate the response up and the request will error out.

Since this is public information and there are no state changes taking place I think this should be ok. If we are concerned about abuse we can follow this up with domain whitelisting.

@Wikia/cake @vforge 

 