### PR TITLE
SUS-1879: Bring back Nirvana endpoint for cross-wiki notifications

### DIFF
--- a/extensions/wikia/WallNotifications/WallNotificationControllerBase.class.php
+++ b/extensions/wikia/WallNotifications/WallNotificationControllerBase.class.php
@@ -116,7 +116,7 @@ abstract class WallNotificationControllerBase extends WikiaService {
 		// array) instead of the most recent so that they start reading where the left off. See bugid 64560.
 		$oldestEntity = end( $notify[ 'grouped' ] );
 		$url = empty( $oldestEntity->data->url ) ? '' : $oldestEntity->data->url;
-		$title = $this->shortenTitle( $data->thread_title );
+		$title = $this->shortenTitle( $data->thread_title ?? '' );
 		$this->response->setVal( 'url', $this->fixNotificationURL( $url ) );
 		$this->response->setVal( 'authors', array_reverse( $authors ) );
 		$this->response->setVal( 'title', $title );
@@ -167,7 +167,7 @@ abstract class WallNotificationControllerBase extends WikiaService {
 		$this->response->setVal( 'msg', $msg );
 		$this->response->setVal( 'authors', $authors );
 		$this->response->setVal( 'iso_timestamp', wfTimestamp( TS_ISO_8601, $data->timestamp ) );
-		$this->response->setVal( 'title', $this->shortenTitle( $data->title ) );
+		$this->response->setVal( 'title', $this->shortenTitle( $data->title ?? '' ) );
 	}
 
 	protected function getNotificationMessage( $isMain, $data, $authors, $userCount, $myName ) {

--- a/extensions/wikia/WallNotifications/WallNotificationEntity.class.php
+++ b/extensions/wikia/WallNotifications/WallNotificationEntity.class.php
@@ -139,7 +139,7 @@ class WallNotificationEntity {
 	public function loadDataFromRevIdOnWiki( $revId, $wikiId, $useMasterDB = false ) {
 		$dbName = WikiFactory::IDtoDB( $wikiId );
 		$params = [
-			'controller' => 'WallNotifications',
+			'controller' => 'WallNotificationsExternalController',
 			'method' => 'getEntityData',
 			'revId' => $revId,
 			'useMasterDB' => $useMasterDB,

--- a/extensions/wikia/WallNotifications/WallNotificationsExternalController.class.php
+++ b/extensions/wikia/WallNotifications/WallNotificationsExternalController.class.php
@@ -132,4 +132,34 @@ class WallNotificationsExternalController extends WikiaController {
 		$this->response->setCachePolicy( WikiaResponse::CACHE_PRIVATE );
 		$this->response->setCacheValidity( WikiaResponse::CACHE_DISABLED );
 	}
+
+	/**
+	 * Requested by Wall Notifications for cross-wiki notifications
+	 * @see WallNotificationEntity::loadDataFromRevIdOnWiki()
+	 */
+	public function getEntityData() {
+		$this->response->setFormat( WikiaResponse::FORMAT_JSON );
+
+		$revId = $this->getVal( 'revId' );
+		$useMasterDB = $this->getVal( 'useMasterDB', false );
+
+		$wn = new WallNotificationEntity();
+		if ( $wn->loadDataFromRevId( $revId, $useMasterDB ) ) {
+			$this->response->setCacheValidity( WikiaResponse::CACHE_SHORT );
+
+			$this->response->setData( [
+				'data' => $wn->data,
+				'parentTitleDbKey' => $wn->parentTitleDbKey,
+				'msgText' => $wn->msgText,
+				'threadTitleFull' => $wn->threadTitleFull,
+				'status' => 'ok',
+			] );
+
+			return;
+		}
+
+		$this->response->setData( [
+			'status' => 'error'
+		] );
+	}
 }

--- a/extensions/wikia/WallNotifications/WallNotificationsExternalController.class.php
+++ b/extensions/wikia/WallNotifications/WallNotificationsExternalController.class.php
@@ -138,6 +138,7 @@ class WallNotificationsExternalController extends WikiaController {
 	 * @see WallNotificationEntity::loadDataFromRevIdOnWiki()
 	 */
 	public function getEntityData() {
+		$this->response->setCacheValidity( WikiaResponse::CACHE_DISABLED );
 		$this->response->setFormat( WikiaResponse::FORMAT_JSON );
 
 		$revId = $this->getVal( 'revId' );
@@ -145,8 +146,6 @@ class WallNotificationsExternalController extends WikiaController {
 
 		$wn = new WallNotificationEntity();
 		if ( $wn->loadDataFromRevId( $revId, $useMasterDB ) ) {
-			$this->response->setCacheValidity( WikiaResponse::CACHE_SHORT );
-
 			$this->response->setData( [
 				'data' => $wn->data,
 				'parentTitleDbKey' => $wn->parentTitleDbKey,

--- a/extensions/wikia/WallNotifications/WallNotificationsExternalController.class.php
+++ b/extensions/wikia/WallNotifications/WallNotificationsExternalController.class.php
@@ -138,6 +138,7 @@ class WallNotificationsExternalController extends WikiaController {
 	 * @see WallNotificationEntity::loadDataFromRevIdOnWiki()
 	 */
 	public function getEntityData() {
+		// SUS-1879: Disable cache - this endpoint is only requested internally
 		$this->response->setCacheValidity( WikiaResponse::CACHE_DISABLED );
 		$this->response->setFormat( WikiaResponse::FORMAT_JSON );
 


### PR DESCRIPTION
It was removed mistakenly.

https://wikia-inc.atlassian.net/browse/SUS-1879