### PR TITLE
FAN-1285 Point non-English visitors to fandom.wikia.com when searching

### DIFF
--- a/includes/wikia/models/DesignSystemGlobalNavigationModel.class.php
+++ b/includes/wikia/models/DesignSystemGlobalNavigationModel.class.php
@@ -119,7 +119,7 @@ class DesignSystemGlobalNavigationModel extends WikiaModel {
 		$isCorporatePage = WikiaPageType::isCorporatePage( $this->productInstanceId );
 
 		if ( $this->product === static::PRODUCT_FANDOMS && $this->lang === static::DEFAULT_LANG ) {
-			$searchUrl = '/';
+			$searchUrl = 'http://fandom.wikia.com/';
 			$searchPlaceholderKey = 'global-navigation-search-placeholder-fandom';
 			$searchParamName = 's';
 		} else {
@@ -150,7 +150,12 @@ class DesignSystemGlobalNavigationModel extends WikiaModel {
 			]
 		];
 
-		if ( $this->product !== static::PRODUCT_FANDOMS && !$isCorporatePage ) {
+		if ( $this->product === static::PRODUCT_FANDOMS || $isCorporatePage ) {
+			$search['hiddenFields'] = [
+				'resultsLang' => $this->lang,
+				'uselang' => $this->lang,
+			];
+		} else {
 			$search['suggestions'] = [
 				'url' => WikiFactory::getHostById( $this->productInstanceId ) . '/index.php?action=ajax&rs=getLinkSuggest&format=json',
 				'param-name' => 'query',
@@ -390,10 +395,7 @@ class DesignSystemGlobalNavigationModel extends WikiaModel {
 	}
 
 	private function getCorporatePageSearchUrl() {
-		return GlobalTitle::newFromText( 'Search', NS_SPECIAL, WikiService::WIKIAGLOBAL_CITY_ID )->getFullURL( [
-			'fulltext' => 'Search',
-			'resultsLang' => $this->lang
-		] );
+		return GlobalTitle::newFromText( 'Search', NS_SPECIAL, WikiService::WIKIAGLOBAL_CITY_ID )->getFullURL();
 	}
 
 	private function getCommunityCentralLink() {

--- a/includes/wikia/models/DesignSystemSharedLinks.class.php
+++ b/includes/wikia/models/DesignSystemSharedLinks.class.php
@@ -83,7 +83,7 @@ class DesignSystemSharedLinks {
 			'media-kit-contact' => null,
 			'app-store' => 'https://itunes.apple.com/developer/wikia-inc./id422467077',
 			'google-play' => 'https://play.google.com/store/apps/developer?id=Fandom+powered+by+Wikia',
-			'fandom-logo' => 'http://fandom.wikia.com',
+			'fandom-logo' => 'http://fandom.wikia.com/',
 			'games' => 'http://fandom.wikia.com/topics/games',
 			'movies' => 'http://fandom.wikia.com/topics/movies',
 			'tv' => 'http://fandom.wikia.com/topics/tv',


### PR DESCRIPTION
The other change makes the logo point to `/` on non-production environments.