### PR TITLE
SUS-2563 | ArticleComment - do not force Title::isNewPage to use master

### DIFF
--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -602,7 +602,7 @@ class ArticleComment {
 			$links['edit'] = '#comment' . $commentId;
 		}
 
-		if ( !$this->mTitle->isNewPage( Title::GAID_FOR_UPDATE ) ) {
+		if ( !$this->mTitle->isNewPage() ) {
 			$buttons[] = Linker::linkKnown(
 				$title,
 				wfMessage( 'article-comments-history' )->escaped(),

--- a/extensions/wikia/Blogs/templates/comment.tmpl.php
+++ b/extensions/wikia/Blogs/templates/comment.tmpl.php
@@ -1,6 +1,10 @@
 <!-- s:<?= __FILE__ ?> -->
 <div class="blog-comment">
 <?php
+    /* @var $comment mixed */
+    /* @var $canToggle boolean */
+    /* @var $canDelete boolean */
+    /* @var $canEdit boolean */
 	if( ! $comment[ "hidden" ] ):
 ?>
 	<a name="<?php echo isset( $comment["anchor"][2] ) ? $comment["anchor"][2] : "" ?>"></a>

--- a/includes/Title.php
+++ b/includes/Title.php
@@ -4184,13 +4184,10 @@ class Title {
 	/**
 	 * Check if this is a new page
 	 *
-	 * Wikia change, add possibility to use master - used in ArticleComment;
-	 * Wikia change: @author: Marooned
-	 *
 	 * @return bool
 	 */
-	public function isNewPage( $flags = 0 ) {
-		$dbr = ($flags & self::GAID_FOR_UPDATE) ? wfGetDB( DB_MASTER ) : wfGetDB( DB_SLAVE );
+	public function isNewPage() {
+		$dbr = wfGetDB( DB_SLAVE );
 
 		return (bool)$dbr->selectField( 'page', 'page_is_new', $this->pageCond(), __METHOD__ );
 	}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-2565

## A query

```sql
SELECT /* Title::isNewPage 88.131.26.98 - 2f34c415-5f23-4b67-93e9-6c76c22945a2 */  page_is_new  FROM `page`  WHERE page_id = '13140'  LIMIT 1 
```

## The numbers

16% of all queries made explicitly to a master database node when handling GET requests come from this method (add 12% for `BEGIN` statement that starts the transaction). Let's just rely on slave data.

For the last 24h the numbers look as follows:

* Database queries to the master when handling GET request: **2.3 mm**
* Queries from `Title::isNewPage` with `use a master` flag set: **392,5 k**