### PR TITLE
SUS-2564 | cache local user groups in PermissionsServiceImpl

### DIFF
--- a/lib/Wikia/src/Service/User/Permissions/PermissionsServiceImpl.php
+++ b/lib/Wikia/src/Service/User/Permissions/PermissionsServiceImpl.php
@@ -56,7 +56,7 @@ class PermissionsServiceImpl implements PermissionsService {
 	 * @param int $userId
 	 * @return string memcache key
 	 */
-	static public function getMemcKey( $userId ) {
+	static private function getGlobalMemcKey( int $userId ) : string {
 		return implode( ':', [ 'GLOBAL', __CLASS__, 'permissions-groups', $userId ] );
 	}
 
@@ -66,7 +66,7 @@ class PermissionsServiceImpl implements PermissionsService {
 	 * @param int $userId
 	 * @return string memcache key
 	 */
-	static public function getLocalMemcKey( int $userId ) : string {
+	static private function getLocalMemcKey( int $userId ) : string {
 		return wfMemcKey(__CLASS__, 'permissions-local-groups', $userId );
 	}
 
@@ -156,7 +156,7 @@ class PermissionsServiceImpl implements PermissionsService {
 		return $permissions;
 	}
 
-	private function loadLocalGroups( $userId ) {
+	private function loadLocalGroups( int $userId ) {
 		if ( !empty( $userId ) && !isset( $this->localExplicitUserGroups[ $userId ] ) ) {
 
 			$fname = __METHOD__;
@@ -192,7 +192,7 @@ class PermissionsServiceImpl implements PermissionsService {
 
 			$fname = __METHOD__;
 			$globalGroups = \WikiaDataAccess::cache(
-				self::getMemcKey( $userId ),
+				self::getGlobalMemcKey( $userId ),
 				\WikiaResponse::CACHE_LONG,
 				function() use ( $userId, $fname ) {
 					$dbr = self::getSharedDB( DB_MASTER );
@@ -443,7 +443,7 @@ class PermissionsServiceImpl implements PermissionsService {
 
 	public function invalidateCache( \User $user ) {
 		$this->invalidateGroupsAndPermissions( $user->getId() );
-		\WikiaDataAccess::cachePurge( self::getMemcKey( $user->getId() ) );
+		\WikiaDataAccess::cachePurge( self::getGlobalMemcKey( $user->getId() ) );
 		\WikiaDataAccess::cachePurge( self::getLocalMemcKey( $user->getId() ) );
 	}
 }

--- a/lib/Wikia/tests/Service/User/UserPermissionsIntegrationTest.php
+++ b/lib/Wikia/tests/Service/User/UserPermissionsIntegrationTest.php
@@ -2,8 +2,6 @@
 
 namespace Wikia\Service\User\Permissions;
 
-use Wikia\Service\User\Permissions\PermissionsServiceAccessor;
-
 class UserPermissionsIntegrationTest extends \WikiaBaseTest {
 	use PermissionsServiceAccessor;
 
@@ -43,12 +41,12 @@ class UserPermissionsIntegrationTest extends \WikiaBaseTest {
 		$this->staffUser = \User::newFromId( $this->staffUserId );
 		$this->anonUser = \User::newFromId( 0 );
 
+		$this->disableMemCache();
+
 		parent::setUp();
 	}
 
 	function testShouldReturnExplicitGroups() {
-		\WikiaDataAccess::cachePurge( PermissionsServiceImpl::getMemcKey( $this->staffUserId ) );
-
 		$groups = $this->permissionsService()->getExplicitGroups( $this->staffUser );
 		$this->assertContains("staff", $groups);
 		$this->assertContains("bureaucrat", $groups);


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-2564

## Query

```sql
SELECT /* Wikia\\Service\\User\\Permissions\\PermissionsServiceImpl::loadLocalGroups Tzaflidisp - 97ca8f71-d483-4d98-bb95-16883634b3fc */  ug_group  FROM `user_groups`  WHERE ug_user = '123'
```

## The numbers

This query was explicitly made on master database node. Let's keep it that way, but add a cache around it (as we do for shared user groups).

This method is responsible for 21% of master node queries when GET requests is handled / over **780 k** in the last 24h.