### PR TITLE
SUS-2571 | update the memcache when User::setNewtalk() is called

### DIFF
--- a/includes/User.php
+++ b/includes/User.php
@@ -1814,6 +1814,16 @@ class User implements JsonSerializable {
 	 * @return Bool True if the user has new messages
 	 */
 	public function getNewtalk() {
+		# Wikia change - begin
+		# leave early, don't check it for our varnish ip addresses
+		global $wgSquidServers, $wgSquidServersNoPurge;
+		if( in_array( $this->getName(), $wgSquidServers ) ||
+			in_array( $this->getName(), $wgSquidServersNoPurge )
+		) {
+			return false;
+		}
+		# Wikia change - end
+
 		$this->load();
 
 		# Load the newtalk status if it is unloaded (mNewtalk=-1)
@@ -1823,14 +1833,6 @@ class User implements JsonSerializable {
 			# Check memcached separately for anons, who have no
 			# entire User object stored in there.
 			if( !$this->mId ) {
-				# hack: don't check it for our varnish ip addresses
-				global $wgSquidServers, $wgSquidServersNoPurge;
-				if( in_array( $this->getName(), $wgSquidServers ) ||
-					in_array( $this->getName(), $wgSquidServersNoPurge )
-				) {
-					return $this->mNewtalk;
-				}
-
 				global $wgMemc;
 				$key = wfMemcKey( 'newtalk', 'ip', $this->getName() );
 				$newtalk = $wgMemc->get( $key );


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-2571

This way we avoid subsequent database query to a master. Instead, we just get the updated value from the memcache.

## Cache miss

```
> $u = User::newFromName('Macbre'); var_dump( $u->getNewtalk() );
...
memcached: get(dev-macbre-plpoznan:user:id:119245)
memcached: MemCache: sock i:0; got dev-macbre-plpoznan:user:id:119245
memcached: get(dev-macbre-wikicities:user_touched:v1:119245)
memcached: MemCache: sock i:0; got dev-macbre-wikicities:user_touched:v1:119245
User: got user 119245 from cache

memcached: get(dev-macbre-plpoznan:newtalk:user:119245)
Query plpoznan (DB user: wikia_maint) (11) (slave): SELECT /* User::checkNewtalk CommandLineInc - a562a3b7-2989-4663-a2b2-30c0dacfc0b3 */  user_id  FROM `user_newtalk`  WHERE user_id = '119245'  LIMIT 1  

memcached: set dev-macbre-plpoznan:newtalk:user:119245 (STORED)

/usr/wikia/source/deploytools/18879/src/maintenance/eval.php(88) : eval()'d code:1:
bool(false)
```

## Update the new talk state

```
> $u = User::newFromName('Macbre'); $u->setNewtalk( true ); var_dump( $u->getNewtalk() );
...
DatabaseBase::query: Writes done: INSERT IGNORE INTO `user_newtalk` (user_id) VALUES ('119245')
Query plpoznan (DB user: wikia_maint) (10) (master): INSERT /* User::updateNewtalk CommandLineInc - e065dd1b-cc5d-4cdf-8abf-f9043e0626ee */ IGNORE INTO `user_newtalk` (user_id) VALUES ('119245')
User::updateNewtalk: set on (user_id, 119245)

memcached: set dev-macbre-plpoznan:newtalk:user:119245 (STORED)
memcached: set dev-macbre-wikicities:user-quicktouched:id:119245 (STORED)
memcached: MemCache: delete dev-macbre-plpoznan:user:id:119245 (DELETED)
...
/usr/wikia/source/deploytools/18879/src/maintenance/eval.php(88) : eval()'d code:1:
bool(true)
```

## The numbers

This change should remove a great part of **146,618 queries** that we make daily from `User::getNewtalk` method to database master nodes (out of 2,4 mm that we make daily when handling GET requests).