### PR TITLE
Fix cache poisioning from externaltest and showcase

### DIFF
--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -1234,7 +1234,7 @@ class WikiFactory {
 		}
 
 		// strip env-specific pre- and suffixes for staging environment
-		$server = preg_replace( '/^(stable|preview|verify|sandbox-[a-z0-9]+)\./', '', $server );
+		$server = preg_replace( '/^(externaltest|preview|sandbox-[a-z0-9]+|showcase|stable|verify)\./', '', $server );
 		if ( !empty( $wgDevDomain ) ) {
 			$server = str_replace( ".{$wgDevDomain}", '', $server );
 		}


### PR DESCRIPTION
Here's what happens before this change:

* externaltest and showcase are routed to production apaches
* there is an internal API request for the data for global navigation for the current wiki, like this: http://muppet.wikia.com/wikia.php?controller=DesignSystemApiController&method=getAllElements&product=wikis&id=831&lang=en
* even though it's not clear from the code, the code that generates the links for the nav behaves differently depending on whether you request it from the same wiki or from another, namely:
  * http://muppet.wikia.com/wikia.php?controller=DesignSystemApiController&method=getAllElements&product=wikis&id=831&lang=en -- will request `$wgServer` from global variables -- this is extracted from `$_SERVER['HTTP_HOST']` <- may be poisoned by externaltest-like scenarios
  * vs http://gta.wikia.com/wikia.php?controller=DesignSystemApiController&method=getAllElements&product=wikis&id=831&lang=en -- will request `$wgServer` from the database -- always the correct `muppet.wikia.com` no matter what
* `$wgServer` is sanitized in `getLocalEnvURL` method by removing the env prefix -- this is only meaningful when reading the `$wgServer` from the global variable, not from the DB
* `externaltest` and `showcase` are not stripped from the URL (this is what this PR changes)
* data is cached in memcached under production key for 3 hours (externaltest and showcase are not separate environments)
* next time the data is requested even on production, the cached values with `externaltest` in them are returned