### PR TITLE
SUS-2573: Prevent ImageServing::getUrl from throwing fatal error

### DIFF
--- a/extensions/wikia/ImageServing/ImageServingController.class.php
+++ b/extensions/wikia/ImageServing/ImageServingController.class.php
@@ -98,6 +98,7 @@ class ImageServingController extends WikiaController {
 		}
 
 		$this->response->setHeader( 'Location', $url );
+		$this->skipRendering();
 	}
 
 	private function isOldImageRevision( $db, $revisionTimestamp, $fileName ): bool {


### PR DESCRIPTION
`ImageServing::getUrl` method only serves to redirect the requestor to a correct vignette URL. As such there is no corresponding PHP template and the Nirvana framework will die with error while attempting to find and render it.

https://wikia-inc.atlassian.net/browse/SUS-2573