### PR TITLE
fix monobook fatal

### DIFF
--- a/extensions/wikia/Wall/WallHooksHelper.class.php
+++ b/extensions/wikia/Wall/WallHooksHelper.class.php
@@ -1936,10 +1936,11 @@ class WallHooksHelper {
 	 * @access public
 	 * @author Sactage
 	 *
-	 * @param Skin $skin
-	 * @return boolean
+	 * @param QuickTemplate $quickTemplate
+	 * @return bool
 	 */
-	static public function onBuildMonobookToolbox( Skin $skin ) {
+	static public function onBuildMonobookToolbox( QuickTemplate $quickTemplate ): bool {
+		$skin = $quickTemplate->getSkin();
 		$title = $skin->getTitle();
 		$curUser = $skin->getUser();
 


### PR DESCRIPTION
```Unexpected non-MediaWiki exception encountered, of type "TypeError" TypeError: Argument 1 passed to WallHooksHelper::onBuildMonobookToolbox() must be an instance of Skin, instance of MonoBookTemplate given in /usr/wikia/source/deploytools/18879/src/extensions/wikia/Wall/WallHooksHelper.class.php:1942```