### PR TITLE
SUS-2576 | Forum/Wall - set response code to HTTP 410 Gone for deleted wall messages and forum threads

### DIFF
--- a/extensions/wikia/Wall/WallHooksHelper.class.php
+++ b/extensions/wikia/Wall/WallHooksHelper.class.php
@@ -93,6 +93,11 @@ class WallHooksHelper {
 			$showDeleted = ( $wallMessage->canViewDeletedMessage( $app->wg->User )
 				&& $app->wg->Request->getVal( 'show' ) == '1' );
 
+			// SUS-2576: set response code to HTTP 410 Gone for deleted wall messages and forum threads
+			if ( $wallMessage->isRemove() ) {
+				$app->wg->Out->setStatusCode( 410 );
+			}
+
 			if ( $isDeleted ) {
 				$app->wg->Out->setStatusCode( 404 );
 			}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-2576

## Examples

```
$ curl -svo /dev/null 'http://poznan.macbre.wikia-dev.pl/wiki/W%C4%85tek:32433' 2>&1 | grep HTTP
> GET /wiki/W%C4%85tek:32433 HTTP/1.1
< HTTP/1.1 410 Gone

--

$ curl -svo /dev/null 'http://poznan.macbre.wikia-dev.pl/wiki/W%C4%85tek:32432' 2>&1 | grep HTTP
> GET /wiki/W%C4%85tek:32432 HTTP/1.1
< HTTP/1.1 200 OK
```