### PR TITLE
MAIN-11012: in SMW HookRegistry correct namespace

### DIFF
--- a/extensions/SemanticMediaWiki/src/MediaWiki/Hooks/HookRegistry.php
+++ b/extensions/SemanticMediaWiki/src/MediaWiki/Hooks/HookRegistry.php
@@ -4,8 +4,13 @@ namespace SMW\MediaWiki\Hooks;
 
 use Hooks;
 use Onoi\HttpRequest\HttpRequestFactory;
+use OutputPage;
 use Parser;
 use ParserHooks\HookRegistrant;
+use ParserOutput;
+use ResourceLoader;
+use Revision;
+use Skin;
 use SMW\ApplicationFactory;
 use SMW\DeferredRequestDispatchManager;
 use SMW\NamespaceManager;
@@ -13,6 +18,9 @@ use SMW\ParserFunctions\DocumentationParserFunction;
 use SMW\ParserFunctions\InfoParserFunction;
 use SMW\PermissionPthValidator;
 use SMW\SQLStore\QueryDependencyLinksStoreFactory;
+use Title;
+use User;
+use WikiPage;
 
 /**
  * @license GNU GPL v2+


### PR DESCRIPTION
Just patching this in app as we will be upgrading SMW anyways in https://github.com/Wikia/app/pull/13514
