### PR TITLE
SUS-1804 | make RefreshCategoryCountsTask work when the list of categories to remove is empty

### DIFF
--- a/includes/wikia/tasks/Tasks/RefreshCategoryCountsTask.class.php
+++ b/includes/wikia/tasks/Tasks/RefreshCategoryCountsTask.class.php
@@ -107,7 +107,9 @@ class RefreshCategoryCountsTask extends BaseTask {
 			}
 		}
 
-		$this->db->delete( 'category', [ 'cat_title' => $entriesToDelete ], __METHOD__ );
+		if ( !empty( $entriesToDelete ) ) {
+			$this->db->delete( 'category', [ 'cat_title' => $entriesToDelete ], __METHOD__ );
+		}
 	}
 
 	/**
@@ -144,7 +146,7 @@ class RefreshCategoryCountsTask extends BaseTask {
 	 * @param string $catName
 	 * @return array|object
 	 */
-	private function getContentCounts( string $catName ): array {
+	private function getContentCounts( string $catName ) {
 		$cond1 = $this->db->conditional( 'page_namespace=' . NS_CATEGORY, 1, 'NULL' );
 		$cond2 = $this->db->conditional( 'page_namespace=' . NS_FILE, 1, 'NULL' );
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-1804

Avoid `DatabaseBase::makeList: empty input` and `TypeError: Return value of Wikia\Tasks\Tasks\RefreshCategoryCountsTask::getContentCounts() must be of the type array, object returned in RefreshCategoryCountsTask.class.php:159`