### PR TITLE
SUS-2580: Do not require hook handlers to always return boolean

### DIFF
--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -87,19 +87,17 @@ class Hooks {
 	 * in here than would normally be necessary.
 	 *
 	 * @param $event String: event name
-	 * @param $args Array: parameters passed to hook functions
-	 * @return Boolean True if no handler aborted the hook
+	 * @param $args array: parameters passed to hook functions
+	 * @return bool True if no handler aborted the hook
+	 * @throws FatalError if a hook handler returns string
+	 * @throws MWException if the hook handler setup for this hook is invalid
 	 */
 	public static function run( $event, $args = array() ) {
-		wfProfileIn(__METHOD__.'-hook-'.$event);
-		wfProfileIn(__METHOD__);
 		// Wikia change - begin - @author: wladek
 		// optimized hooks execution
 
 		// Return quickly in the most common case
 		if ( !isset( self::$handlers[$event] ) ) {
-			wfProfileOut(__METHOD__);
-			wfProfileOut(__METHOD__.'-hook-'.$event);
 			return true;
 		}
 
@@ -176,9 +174,7 @@ class Hooks {
 
 			if ( $closure ) {
 				$callback = $object;
-				$func = "hook-$event-closure";
 			} elseif ( isset( $object ) ) {
-				$func = get_class( $object ) . '::' . $method;
 				$callback = array( $object, $method );
 			} else {
 				$callback = $func;
@@ -207,14 +203,7 @@ class Hooks {
 			 */
 			$retval = null;
 
-			wfProfileOut(__METHOD__);
-			wfProfileIn( $func );
-
 			$retval = call_user_func_array( $callback, $hook_args );
-
-			wfProfileOut( $func );
-			wfProfileIn(__METHOD__);
-
 
 			// Process the return value.
 			if ( is_string( $retval ) ) {
@@ -226,8 +215,6 @@ class Hooks {
 			}
 		}
 
-		wfProfileOut(__METHOD__);
-		wfProfileOut(__METHOD__.'-hook-'.$event);
 		return true;
 	}
 

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -23,8 +23,6 @@
  * @file
  */
 
-class MWHookException extends MWException {}
-
 /**
  * Hooks class.
  *

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -117,7 +117,6 @@ class Hooks {
 			$data = null;
 			$have_data = false;
 			$closure = false;
-			$badhookmsg = false;
 
 			/**
 			 * $hook can be: a function, an object, an array of $function and

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -212,46 +212,19 @@ class Hooks {
 
 			wfProfileOut(__METHOD__);
 			wfProfileIn( $func );
-			try {
-				$retval = call_user_func_array( $callback, $hook_args );
-			} catch ( MWHookException $e ) {
-				$badhookmsg = $e->getMessage();
-			}
+
+			$retval = call_user_func_array( $callback, $hook_args );
+
 			wfProfileOut( $func );
 			wfProfileIn(__METHOD__);
 
 
-			/* String return is an error; false return means stop processing. */
+			// Process the return value.
 			if ( is_string( $retval ) ) {
+				// String returned means error.
 				throw new FatalError( $retval );
-			} elseif( $retval === null ) {
-				if ( $closure ) {
-					$prettyFunc = "$event closure";
-				} elseif( is_array( $callback ) ) {
-					if( is_object( $callback[0] ) ) {
-						$prettyClass = get_class( $callback[0] );
-					} else {
-						$prettyClass = strval( $callback[0] );
-					}
-					$prettyFunc = $prettyClass . '::' . strval( $callback[1] );
-				} else {
-					$prettyFunc = strval( $callback );
-				}
-				if ( $badhookmsg ) {
-					throw new MWException(
-						'Detected bug in an extension! ' .
-						"Hook $prettyFunc has invalid call signature; " . $badhookmsg
-					);
-				} else {
-					throw new MWException(
-						'Detected bug in an extension! ' .
-						"Hook $prettyFunc failed to return a value; " .
-						'should return true to continue hook processing or false to abort.'
-					);
-				}
-			} elseif ( !$retval ) {
-				wfProfileOut(__METHOD__);
-				wfProfileOut(__METHOD__.'-hook-'.$event);
+			} elseif ( $retval === false ) {
+				// False was returned. Stop processing, but no error.
 				return false;
 			}
 		}


### PR DESCRIPTION
See [feedback](https://github.com/Wikia/app/pull/13444#discussion_r131309376) by @Krinkle in #13444 
>This requirement was lifted in 2013 (release in MW 1.22) due to the common mistake where a hook is forgetting to return true/false (resulting in the implicit null return being casted to return false, which means to abort the action, and not allow any other hooks to run, either).
Given many hooks are just to allow modification to an array of some sorts (which cannot be aborted and has its return value ignored), this was removed to make the usage of those hooks more idiomatic.

This lessens the chance of some rogue hook handler causing whitepages.

https://wikia-inc.atlassian.net/browse/SUS-2580