### PR TITLE
Avoid master queries in Revision::newFromTitle(..., Revision::READ_NORMAL)

### DIFF
--- a/includes/Revision.php
+++ b/includes/Revision.php
@@ -62,7 +62,7 @@ class Revision implements IDBAccessObject {
 	 * @param $flags Integer Bitfield (optional)
 	 * @return Revision or null
 	 */
-	public static function newFromTitle( $title, $id = 0, $flags = null ) {
+	public static function newFromTitle( $title, $id = 0, $flags = 0 ) {
 		$conds = array(
 			'page_namespace' => $title->getNamespace(),
 			'page_title' 	 => $title->getDBkey()
@@ -70,13 +70,13 @@ class Revision implements IDBAccessObject {
 		if ( $id ) {
 			// Use the specified ID
 			$conds['rev_id'] = $id;
+			return self::newFromConds( $conds, (int)$flags );
 		} else {
 			// Use a join to get the latest revision
 			$conds[] = 'rev_id=page_latest';
-			// Callers assume this will be up-to-date
-			$flags = is_int( $flags ) ? $flags : self::READ_LATEST; // b/c
+			$db = wfGetDB( ( $flags & self::READ_LATEST ) ? DB_MASTER : DB_SLAVE );
+			return self::loadFromConds( $db, $conds, $flags );
 		}
-		return self::newFromConds( $conds, (int)$flags );
 	}
 
 	/**


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-2583

`Revision::fetchFromConds` is responsible for ~13% of 3.3mm queries every day that hit master database when handling GET requests.

The fallback to master makes sense in `Revision::newFromId()`, since a revision ID known to exist by some other means might be present in the master but not in the slave. But it doesn't make sense for `Revision::newFromTitle()`, where by far the most common cause of this case being hit is the page being nonexistent.

Backporting https://github.com/wikimedia/mediawiki/commit/e6b1baf240b8323ab092ce9be85050bf63336049 from MW 1.22