### PR TITLE
MAIN-11034: in Special:Images avoid whitepage

### DIFF
--- a/extensions/wikia/WikiaNewFiles/WikiaNewFilesSpecialController.class.php
+++ b/extensions/wikia/WikiaNewFiles/WikiaNewFilesSpecialController.class.php
@@ -42,7 +42,6 @@ class WikiaNewFilesSpecialController extends WikiaSpecialPageController {
 
 		// Construct gallery
 		$gallery = new WikiaNewFilesGallery( $this->specialPage->getSkin() );
-		$gallery->setParser( new Parser() );
 		$gallery->addImages( $images );
 
 		// View

--- a/extensions/wikia/WikiaPhotoGallery/WikiaPhotoGalleryHelper.class.php
+++ b/extensions/wikia/WikiaPhotoGallery/WikiaPhotoGalleryHelper.class.php
@@ -187,7 +187,7 @@ class WikiaPhotoGalleryHelper {
 	/**
 	 * Parse given link and return link tag attributes
 	 */
-	static public function parseLink( Parser $parser, $url, $text, $link ) {
+	static public function parseLink( $parser, $url, $text, $link ) {
 		// fallback: link to image page + lightbox
 		$linkAttribs = array(
 			'class' => 'image lightbox',
@@ -195,8 +195,13 @@ class WikiaPhotoGalleryHelper {
 			'title' => $text,
 		);
 
+		// MAIN-11034: $parser can be empty here, just return
+		if ( !( $parser instanceof Parser ) ) {
+			return $linkAttribs;
+		}
+
 		// detect internal / external links (|links= param)
-		if ($link != '') {
+		if ( $link != '' ) {
 			$chars = Parser::EXT_LINK_URL_CLASS;
 			$prots = $parser->mUrlProtocols;
 


### PR DESCRIPTION
This code expects that it will receive a `Parser` instance, but `$parser` may be `false` here. However, passing in a fresh `Parser` will cause different areas of the page to fail. I added a failsafe to return early if the parser is not present.

https://wikia-inc.atlassian.net/browse/MAIN-11034