### PR TITLE
Removed duplicated user name in blog subtitle

### DIFF
--- a/extensions/wikia/PageHeader/Subtitle.class.php
+++ b/extensions/wikia/PageHeader/Subtitle.class.php
@@ -263,7 +263,7 @@ class Subtitle {
 
 		$userBlogPageUrl = AvatarService::getUrl( $userName, NS_BLOG_ARTICLE );
 		$namespaceText = $language->getFormattedNsText( $this->title->getNamespace() );
-		$userBlogPageText = $namespaceText . ':' . $userName;
+		$userBlogPageText = $namespaceText;
 
 		$pageStatsService = new PageStatsService( $this->title->getArticleId() );
 		$pageCreatedDate = $language->date( $pageStatsService->getFirstRevisionTimestamp() );


### PR DESCRIPTION
Is already displayed in the first item quite after the avatar as user page link text.