### PR TITLE
SUS-2624 | Update sender name for transactional emails

### DIFF
--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1050,7 +1050,7 @@ $wgHooks['ArticleDelete'][] = 'ArticlesUsingMediaQuery::onArticleDelete';
 /**
  * Password reminder name
  */
-$wgPasswordSenderName = 'Fandom';
+$wgPasswordSenderName = Wikia::USER;
 
 /**
  * Defines the mapping for per-skin Common.js/css


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-2624

Use `Wikia::USER` const set to `FANDOM` - we'll have one place less to remember of in case of a next rebranding

See #11535 for a previous change (to Fandom)