### PR TITLE
SUS-2595 | invalidate Special:RecentChanges (and feeds) on article edit

### DIFF
--- a/includes/Title.php
+++ b/includes/Title.php
@@ -3458,10 +3458,10 @@ class Title {
 
 
 	/**
-	 * Get a list of URLs to purge from the Squid cache when this
+	 * Get a list of URLs to purge from the CDN cache when this
 	 * page changes
 	 *
-	 * @return Array of String the URLs
+	 * @return string[] Array of String the URLs
 	 */
 	public function getSquidURLs() {
 		global $wgContLang;

--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -1188,6 +1188,13 @@ class Wikia {
 			}
 		}
 
+		// purge Special:RecentChanges too (SUS-2595)
+		$rcTitle = SpecialPage::getTitleFor('RecentChanges');
+
+		$urls[] = $rcTitle->getInternalURL();
+		$urls[] = $rcTitle->getInternalURL('feed=rss');
+		$urls[] = $rcTitle->getInternalURL('feed=atom');
+
 		wfProfileOut(__METHOD__);
 		return true;
 	}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-2595

Since 7fc7cf8 (March 2009) these are cached for 24 hours. However, at some point we removed the code that was adding these URLs to the list of entries to be invalidated in CDN cache on article edit

## An example

```php
> WikiPage::factory( Title::newFromText('Gzik') )->doPurge()
...
Purging backtrace: eval/WikiPage::doPurge/SquidUpdate::doUpdate/SquidUpdate::purge/CeleryPurge::purge
Purging URL http://poznan.macbre.wikia-dev.pl/wiki/Gzik from  via Celery
Purging URL http://poznan.macbre.wikia-dev.pl/wiki/Gzik?action=history from  via Celery
Purging URL http://poznan.macbre.wikia-dev.pl/wiki/Specjalna:Ostatnie_zmiany from  via Celery
Purging URL http://poznan.macbre.wikia-dev.pl/wiki/Specjalna:Ostatnie_zmiany?feed=rss from  via Celery
Purging URL http://poznan.macbre.wikia-dev.pl/wiki/Specjalna:Ostatnie_zmiany?feed=atom from  via Celery
Purging URL http://poznan.macbre.wikia-dev.pl/wikia.php?controller=GameGuides&method=getPage&page=Gzik from  via Celery
Purging URL http://poznan.macbre.wikia-dev.pl/wikia.php?controller=MercuryApi&method=getArticle&title=Gzik from  via Celery
Purging URL http://poznan.macbre.wikia-dev.pl/wikia.php?controller=MercuryApi&method=getPage&title=Gzik from  via Celery
```