### PR TITLE
SUS-2627 | emit a proper HTTP error code when handling POST request when in read-only mode

### DIFF
--- a/includes/WebStart.php
+++ b/includes/WebStart.php
@@ -197,6 +197,11 @@ if(wfReadOnly() && is_object($wgRequest) && $wgRequest->wasPosted()) {
 		( strpos(strtolower($_SERVER['SCRIPT_URL']), 'api.php') === false )
 	) {
 
+		// SUS-2627: emit a proper HTTP error code indicating that something went wrong
+		HttpStatus::header( 500 );
+		header( "X-MediaWiki-ReadOnly: 1" );
+		header( "Content-Type: text/html; charset=utf-8" );
+
 $js = <<<EOD
 <script type="text/javascript">
 var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");

--- a/includes/WebStart.php
+++ b/includes/WebStart.php
@@ -198,7 +198,8 @@ if(wfReadOnly() && is_object($wgRequest) && $wgRequest->wasPosted()) {
 	) {
 
 		// SUS-2627: emit a proper HTTP error code indicating that something went wrong
-		HttpStatus::header( 500 );
+		// RFC says "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server. "
+		HttpStatus::header( 503 );
 		header( "X-MediaWiki-ReadOnly: 1" );
 		header( "Content-Type: text/html; charset=utf-8" );
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-2627

HTTP 200 OK response is not the best one for the errors. Let's respond with HTTP 500 (and set `X-MediaWiki-ReadOnly: 1` header ) when POST request is made to either `wikia.php` or a legacy `action=ajax` endpoint.

## An example

```
$ curl -svo /dev/null 'http://community.macbre.wikia-dev.pl/index.php' -d 'action=ajax&rs=axWFactorySaveVariable'
> POST /index.php HTTP/1.1
< HTTP/1.1 503 Service Unavailable
< Server: Apache
< X-Content-Type-Options: nosniff
< X-MediaWiki-ReadOnly: 1
< Content-Type: text/html; charset=utf-8
< Age: 0
< X-Backend: dev_macbre
```