### PR TITLE
(PLATFORM-3106) Remove domain sharding from Vignette URLs

### DIFF
--- a/extensions/wikia/Bucky/js/bucky_resources_timing.js
+++ b/extensions/wikia/Bucky/js/bucky_resources_timing.js
@@ -41,7 +41,7 @@ define('bucky.resourceTiming', ['jquery', 'wikia.window', 'wikia.log', 'bucky'],
 	/**
 	 * Returns the domain name from the full URL
 	 *
-	 * Only last two segments will be returned, e.g. "vignette1.wikia.nocookie.net" will give you "nocookie.net"
+	 * Only last two segments will be returned, e.g. "vignette.wikia.nocookie.net" will give you "nocookie.net"
 	 *
 	 * @param {string} url URL to get domain for
 	 * @return {string|false} domain or false when URLs in invalid

--- a/extensions/wikia/Bucky/js/spec/bucky_resources_timing.spec.js
+++ b/extensions/wikia/Bucky/js/spec/bucky_resources_timing.spec.js
@@ -19,7 +19,7 @@ describe('BuckyResourcesTiming', function () {
 		var resourcesTiming = getModule(),
 			urls = {
 				// Wikia assets
-				'http://vignette1.wikia.nocookie.net/nordycka/images/d/d7/Mykines_2.jpg/revision/latest/scale-to-width/300?cb=20141031093541&path-prefix=pl': true,
+				'http://vignette.wikia.nocookie.net/nordycka/images/d/d7/Mykines_2.jpg/revision/latest/scale-to-width/300?cb=20141031093541&path-prefix=pl': true,
 				'http://img4.wikia.nocookie.net/__cb4/nordycka/pl/images/b/bc/Wiki.png': true,
 				'http://slot1.images2.wikia.nocookie.net/__am/1418375407/sasses/foo/extensions/wikia/Qualaroo/css/Qualaroo.scss': true,
 				'http://nordycka.wikia.com/__load/-/cb%3D1418375407%26debug%3Dfalse%26lang%3Dpl%26only%3Dstyles%26skin%3Doasis/site': true,
@@ -38,7 +38,7 @@ describe('BuckyResourcesTiming', function () {
 		var resourcesTiming = getModule(),
 			urls = {
 				// Wikia assets
-				'http://vignette1.wikia.nocookie.net/nordycka/images/d/d7/Mykines_2.jpg/revision/latest/scale-to-width/300?cb=20141031093541&path-prefix=pl': 'nocookie.net',
+				'http://vignette.wikia.nocookie.net/nordycka/images/d/d7/Mykines_2.jpg/revision/latest/scale-to-width/300?cb=20141031093541&path-prefix=pl': 'nocookie.net',
 				// 3rd party assets
 				'http://edge.quantserve.com/quant-wikia.js': 'quantserve.com',
 				'http://www.google-analytics.com/ga.js': 'google-analytics.com',

--- a/extensions/wikia/Discussions/maintenance/ForumDumper.php
+++ b/extensions/wikia/Discussions/maintenance/ForumDumper.php
@@ -258,7 +258,7 @@ class ForumDumper {
 	 *     class="lzy lzyPlcHld "
 	 *     data-image-key="Joker_laughing.gif"
 	 *     data-image-name="Joker laughing.gif"
-	 *     data-src="http://vignette3.wikia.nocookie.net/wonderland-org/images/d/d0/Joker_laughing.gif/revision/latest/scale-to-width-down/200?cb=20150901041046"
+	 *     data-src="http://vignette.wikia.nocookie.net/wonderland-org/images/d/d0/Joker_laughing.gif/revision/latest/scale-to-width-down/200?cb=20150901041046"
 	 *     width="200"
 	 *     height="154"
 	 *     onload="if(typeof ImgLzy==='object'){ImgLzy.load(this)}"
@@ -267,7 +267,7 @@ class ForumDumper {
 	 * would match and update to:
 	 *
 	 *  <img
-	 *     src="http://vignette3.wikia.nocookie.net/wonderland-org/images/d/d0/Joker_laughing.gif/revision/latest/scale-to-width-down/200?cb=20150901041046"
+	 *     src="http://vignette.wikia.nocookie.net/wonderland-org/images/d/d0/Joker_laughing.gif/revision/latest/scale-to-width-down/200?cb=20150901041046"
 	 *     alt="Joker laughing"
 	 *     width="200"
 	 *     height="154"

--- a/extensions/wikia/Email/tests/EmailIntegrationTest.php
+++ b/extensions/wikia/Email/tests/EmailIntegrationTest.php
@@ -7,7 +7,7 @@
  */
 class EmailIntegrationTest extends WikiaBaseTest {
 
-	const VIGNETTE_BASE_URL_PROD = 'http://vignette<SHARD>.wikia.nocookie.net';
+	const VIGNETTE_BASE_URL_PROD = 'http://vignette.wikia.nocookie.net';
 
 	function setUp() {
 		$this->setupFile = __DIR__ . '/../Email.setup.php';

--- a/extensions/wikia/UserProfilePageV3/Masthead.class.php
+++ b/extensions/wikia/UserProfilePageV3/Masthead.class.php
@@ -245,7 +245,7 @@ class Masthead {
 				 * uploaded file, we are adding common/avatars path
 				 */
 				// avatars selected from "samples" are stored as full URLs (BAC-1105)
-				// e.g http://vignette4.wikia.nocookie.net/messaging/images/1/19/Avatar.jpg/revision/latest/scale-to-width/150?format=jpg
+				// e.g http://vignette.wikia.nocookie.net/messaging/images/1/19/Avatar.jpg/revision/latest/scale-to-width/150?format=jpg
 				// e.g http://images3.wikia.nocookie.net/__cb2/messaging/images/thumb/1/19/Avatar.jpg/150px-Avatar.jpg
 				if ( !preg_match( '/^https?:\/\//', $url ) ) {
 					$url = $wgBlogAvatarPath . rtrim( $thumb, '/' ) . $url;

--- a/includes/wikia/tests/VignetteRequestTest.php
+++ b/includes/wikia/tests/VignetteRequestTest.php
@@ -70,7 +70,6 @@ class VignetteRequestTest extends WikiaBaseTest {
 			'relative-path' => 'a/ab/filename.jpg',
 			'bucket' => 'tests',
 			'timestamp' => '123',
-			'domain-shard-count' => 2,
 		]);
 		$actual = VignetteRequest::applyLegacyThumbDefinition($generator, $legacyDefinition)->url();
 

--- a/includes/wikia/vignette/VignetteRequest.php
+++ b/includes/wikia/vignette/VignetteRequest.php
@@ -6,7 +6,7 @@ class VignetteRequest {
 
 	/**
 	 * create a UrlGenerator from a config map. $config must have the following keys: relative-path.
-	 * optionally, it can also have timestamp, is-archive, path-prefix, bucket, base-url, and domain-shard-count.
+	 * optionally, it can also have timestamp, is-archive, path-prefix, bucket, and base-url.
 	 * if the optional values aren't in the map, they'll be generated from the current wiki environment
 	 *
 	 * @param $config
@@ -47,11 +47,6 @@ class VignetteRequest {
 			$config['bucket'] = self::parseBucket( $wgUploadPath );
 		}
 
-		if ( !isset( $config['domain-shard-count'] ) ) {
-			global $wgImagesServers;
-			$config['domain-shard-count'] = $wgImagesServers;
-		}
-
 		foreach ( $requiredKeys as $key ) {
 			if ( !isset( $config[$key] ) ) {
 				\Wikia\Logger\WikiaLogger::instance()->error( "missing key", array_merge( $config, ['missing_key' => $key] ) );
@@ -65,8 +60,7 @@ class VignetteRequest {
 			->setRelativePath( $config['relative-path'] )
 			->setPathPrefix( $pathPrefix )
 			->setBucket( $config['bucket'] )
-			->setBaseUrl( $config['base-url'] )
-			->setDomainShardCount( $config['domain-shard-count'] );
+			->setBaseUrl( $config['base-url'] );
 
 		if ( $timestamp > 0 ) {
 			$config->setTimestamp( $timestamp );
@@ -145,26 +139,24 @@ class VignetteRequest {
 	 * @return bool
 	 */
 	public static function isVignetteUrl( $url ) {
-		global $wgVignetteUrl, $wgImagesServers;
-
-		$isVignetteUrl = false;
+		global $wgVignetteUrl, $wgLegacyVignetteUrl, $wgImagesServers;
 
 		$urlHost = parse_url( $url, PHP_URL_HOST );
 		$vignetteHost = parse_url( $wgVignetteUrl, PHP_URL_HOST );
 
-		if ( strpos( $wgVignetteUrl, '<SHARD>' ) === false ) {
-			$isVignetteUrl = $urlHost === $vignetteHost;
-		} else {
+		if ( $urlHost === $vignetteHost ) {
+			return true;
+		} elseif ( !empty( $wgLegacyVignetteUrl ) ) {
+			$vignetteHost = parse_url( $wgLegacyVignetteUrl, PHP_URL_HOST );
 			for ( $i = 1; $i <= $wgImagesServers; ++$i ) {
 				$candidate = str_replace( '<SHARD>', $i, $vignetteHost );
 				if ( $urlHost === $candidate ) {
-					$isVignetteUrl = true;
-					break;
+					return true;
 				}
 			}
 		}
 
-		return $isVignetteUrl;
+		return false;
 	}
 
 	/**

--- a/lib/Wikia/src/Vignette/StaticAssetsUrlGenerator.php
+++ b/lib/Wikia/src/Vignette/StaticAssetsUrlGenerator.php
@@ -23,6 +23,6 @@ class StaticAssetsUrlGenerator extends UrlGenerator {
 
 		$imagePath .= $this->modePath();
 
-		return $this->domainShard( $imagePath );
+		return $this->config->baseUrl() . '/' . $imagePath;
 	}
 }

--- a/lib/Wikia/src/Vignette/UrlConfig.php
+++ b/lib/Wikia/src/Vignette/UrlConfig.php
@@ -18,7 +18,6 @@ class UrlConfig {
 	protected $pathPrefix;
 	protected $bucket;
 	protected $baseUrl;
-	protected $domainShardCount;
 
 	public function setIsArchive($isArchive) {
 		$this->isArchive = $isArchive;
@@ -55,11 +54,6 @@ class UrlConfig {
 		return $this;
 	}
 
-	public function setDomainShardCount($domainShardCount) {
-		$this->domainShardCount = $domainShardCount;
-		return $this;
-	}
-
 	public function isArchive() {
 		return $this->isArchive;
 	}
@@ -86,9 +80,5 @@ class UrlConfig {
 
 	public function baseUrl() {
 		return $this->baseUrl;
-	}
-
-	public function domainShardCount() {
-		return $this->domainShardCount;
 	}
 }

--- a/lib/Wikia/src/Vignette/UrlGenerator.php
+++ b/lib/Wikia/src/Vignette/UrlGenerator.php
@@ -304,7 +304,7 @@ class UrlGenerator {
 			$imagePath .= empty( $queryString ) ? '' : '?'.$queryString;
 		}
 
-		return $this->domainShard( $imagePath );
+		return $this->config->baseUrl() . '/' . $imagePath;
 	}
 
 	public function config() {
@@ -384,14 +384,5 @@ class UrlGenerator {
 	protected function imageType($type) {
 		$this->imageType = $type;
 		return $this;
-	}
-
-	protected function domainShard($imagePath) {
-		// shard based on original image, so frontends can build thumb urls from originals that might be cached in the
-		// user's browser (VE, for instance)
-		$hash = ord(sha1($this->config->relativePath()));
-		$shard = 1 + ($hash % ($this->config->domainShardCount() - 1));
-
-		return str_replace('<SHARD>', $shard, $this->config->baseUrl()) . "/{$imagePath}";
 	}
 }

--- a/resources/wikia/modules/spec/thumbnailer.spec.js
+++ b/resources/wikia/modules/spec/thumbnailer.spec.js
@@ -4,13 +4,13 @@ describe('thumbnailer', function () {
 	var thumbnailer = modules['wikia.thumbnailer'](),
 		fullSizeImageUrl = 'http://img2.wikia.nocookie.net/__cb20140419225924/thelastofus/images/f/ff/Joel.png',
 		legacyThumbnailerUrl = 'http://images2.wikia.nocookie.net/__cb20111213221641/poznan/pl/images/thumb/0/06/Gzik.jpg/300px-Gzik.jpg',
-		thumbnailerUrl = 'http://vignette2.wikia.nocookie.net/arresteddevelopment/f/fb/1x08_My_Mother_the_Car_%2822%29.png/revision/latest/zoom-crop/width/240/height/240?cb=20120214071005',
+		thumbnailerUrl = 'http://vignette.wikia.nocookie.net/arresteddevelopment/f/fb/1x08_My_Mother_the_Car_%2822%29.png/revision/latest/zoom-crop/width/240/height/240?cb=20120214071005',
 		articleUrl = 'http://poznan.wikia.com/wiki/Gzik';
 
 	it('identifies thumbnails', function () {
 		expect(thumbnailer.isThumbUrl(legacyThumbnailerUrl)).toBe(true);
 		expect(thumbnailer.isThumbUrl(thumbnailerUrl)).toBe(true);
-		expect(thumbnailer.isThumbUrl(thumbnailerUrl.replace('vignette2', 'vignette-poz'))).toBe(true); // Poznań devbox
+		expect(thumbnailer.isThumbUrl(thumbnailerUrl.replace('vignette', 'vignette-poz'))).toBe(true); // Poznań devbox
 		expect(thumbnailer.isThumbUrl(fullSizeImageUrl)).toBe(false);
 		expect(thumbnailer.isThumbUrl(articleUrl)).toBe(false);
 	});
@@ -22,25 +22,25 @@ describe('thumbnailer', function () {
 
 	it('returns proper nocrop thumbnail URL', function () {
 		expect(thumbnailer.getThumbURL(legacyThumbnailerUrl, 'nocrop', 660, 330)).toBe('http://images2.wikia.nocookie.net/__cb20111213221641/poznan/pl/images/thumb/0/06/Gzik.jpg/660x330-Gzik.png');
-		expect(thumbnailer.getThumbURL(thumbnailerUrl, 'nocrop', 90, 55)).toBe('http://vignette2.wikia.nocookie.net/arresteddevelopment/f/fb/1x08_My_Mother_the_Car_%2822%29.png/revision/latest/fixed-aspect-ratio/width/90/height/55?cb=20120214071005');
+		expect(thumbnailer.getThumbURL(thumbnailerUrl, 'nocrop', 90, 55)).toBe('http://vignette.wikia.nocookie.net/arresteddevelopment/f/fb/1x08_My_Mother_the_Car_%2822%29.png/revision/latest/fixed-aspect-ratio/width/90/height/55?cb=20120214071005');
 		expect(thumbnailer.getThumbURL(fullSizeImageUrl, 'nocrop', 90, 55)).toBe('http://img2.wikia.nocookie.net/__cb20140419225924/thelastofus/images/thumb/f/ff/Joel.png/90x55-Joel.png');
 	});
 
 	it('returns proper video thumbnail URL', function () {
 		expect(thumbnailer.getThumbURL(legacyThumbnailerUrl, 'video', 660, 330)).toBe('http://images2.wikia.nocookie.net/__cb20111213221641/poznan/pl/images/thumb/0/06/Gzik.jpg/660x330-Gzik.png');
-		expect(thumbnailer.getThumbURL(thumbnailerUrl, 'video', 90, 55)).toBe('http://vignette2.wikia.nocookie.net/arresteddevelopment/f/fb/1x08_My_Mother_the_Car_%2822%29.png/revision/latest/fixed-aspect-ratio/width/90/height/55?cb=20120214071005');
+		expect(thumbnailer.getThumbURL(thumbnailerUrl, 'video', 90, 55)).toBe('http://vignette.wikia.nocookie.net/arresteddevelopment/f/fb/1x08_My_Mother_the_Car_%2822%29.png/revision/latest/fixed-aspect-ratio/width/90/height/55?cb=20120214071005');
 		expect(thumbnailer.getThumbURL(fullSizeImageUrl, 'video', 90, 55)).toBe('http://img2.wikia.nocookie.net/__cb20140419225924/thelastofus/images/thumb/f/ff/Joel.png/90x55-Joel.png');
 	});
 
 	it('returns proper image thumbnail URL', function () {
 		expect(thumbnailer.getThumbURL(legacyThumbnailerUrl, 'image', 660, 330)).toBe('http://images2.wikia.nocookie.net/__cb20111213221641/poznan/pl/images/thumb/0/06/Gzik.jpg/660x330x2-Gzik.png');
-		expect(thumbnailer.getThumbURL(thumbnailerUrl, 'image', 90, 55)).toBe('http://vignette2.wikia.nocookie.net/arresteddevelopment/f/fb/1x08_My_Mother_the_Car_%2822%29.png/revision/latest/zoom-crop/width/90/height/55?cb=20120214071005');
+		expect(thumbnailer.getThumbURL(thumbnailerUrl, 'image', 90, 55)).toBe('http://vignette.wikia.nocookie.net/arresteddevelopment/f/fb/1x08_My_Mother_the_Car_%2822%29.png/revision/latest/zoom-crop/width/90/height/55?cb=20120214071005');
 		expect(thumbnailer.getThumbURL(fullSizeImageUrl, 'image', 90, 55)).toBe('http://img2.wikia.nocookie.net/__cb20140419225924/thelastofus/images/thumb/f/ff/Joel.png/90x55x2-Joel.png');
 	});
 
 	it('returns proper full image URL', function () {
 		expect(thumbnailer.getImageURL(legacyThumbnailerUrl)).toBe('http://images2.wikia.nocookie.net/__cb20111213221641/poznan/pl/images/0/06/Gzik.jpg');
-		expect(thumbnailer.getImageURL(thumbnailerUrl)).toBe('http://vignette2.wikia.nocookie.net/arresteddevelopment/f/fb/1x08_My_Mother_the_Car_%2822%29.png/revision/latest?cb=20120214071005');
+		expect(thumbnailer.getImageURL(thumbnailerUrl)).toBe('http://vignette.wikia.nocookie.net/arresteddevelopment/f/fb/1x08_My_Mother_the_Car_%2822%29.png/revision/latest?cb=20120214071005');
 		expect(thumbnailer.getImageURL(fullSizeImageUrl)).toBe(fullSizeImageUrl);
 	});
 
@@ -49,6 +49,6 @@ describe('thumbnailer', function () {
 	});
 
 	it('test 0 height image for vignette thumbnail', function () {
-		expect(thumbnailer.getThumbURL(thumbnailerUrl, 'image', 500, 0)).toBe('http://vignette2.wikia.nocookie.net/arresteddevelopment/f/fb/1x08_My_Mother_the_Car_%2822%29.png/revision/latest/zoom-crop/width/500/height/0?cb=20120214071005');
+		expect(thumbnailer.getThumbURL(thumbnailerUrl, 'image', 500, 0)).toBe('http://vignette.wikia.nocookie.net/arresteddevelopment/f/fb/1x08_My_Mother_the_Car_%2822%29.png/revision/latest/zoom-crop/width/500/height/0?cb=20120214071005');
 	});
 });

--- a/resources/wikia/modules/thumbnailer.js
+++ b/resources/wikia/modules/thumbnailer.js
@@ -175,10 +175,10 @@
 		 * Constructs complete thumbnailer url by appending parameters to url
 		 *
 		 * URL before:
-		 * http://vignette2.wikia.nocookie.net/thelastofus/f/ff/Joel.png/revision/latest
+		 * http://vignette.wikia.nocookie.net/thelastofus/f/ff/Joel.png/revision/latest
 		 *
 		 * URL after:
-		 * http://vignette2.wikia.nocookie.net/thelastofus/f/ff/Joel.png/revision/latest/zoom-crop/width/240/height/240
+		 * http://vignette.wikia.nocookie.net/thelastofus/f/ff/Joel.png/revision/latest/zoom-crop/width/240/height/240
 		 *
 		 * @private
 		 * @param {String} url


### PR DESCRIPTION
Remove domain sharding from Vignette URL generation.

/cc @Wikia/core-platform-team 