### PR TITLE
SUS-1634 | support setting read-only mode via WikiFactory

### DIFF
--- a/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
+++ b/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
@@ -51,6 +51,8 @@ class WikiFactoryLoader {
 
 	private $mDBhandler, $mDBname;
 
+	const PER_CLUSTER_READ_ONLY_MODE_REASON = 'This cluster is running in read-only mode.';
+
 	/**
 	 * __construct
 	 *
@@ -867,5 +869,23 @@ class WikiFactoryLoader {
 		if( !empty( $this->mDebug ) ) {
 			error_log("wikifactory: {$message}");
 		}
+	}
+
+	/**
+	 * Check the value of "wgReadOnlyCluster" WikiFactory variable defined for community.wikia.com
+	 * that controls which DB cluster is in read-only mode.
+	 *
+	 * @author macbre
+	 * @see SUS-1634
+	 *
+	 * An example:
+	 * $wgReadOnlyCluster = "c1"; // this will turn on read-only mode on all c1 wikis
+	 *
+	 * @param string $cluster
+	 * @return bool if true is returned, the caller should set $wgReadOnly flag
+	 */
+	public static function checkPerClusterReadOnlyFlag( string $cluster ) : bool {
+		$readOnlyCluster = WikiFactory::getVarValueByName( 'wgReadOnlyCluster', Wikia::COMMUNITY_WIKI_ID );
+		return $readOnlyCluster === $cluster;
 	}
 }

--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -870,6 +870,16 @@ class WikiFactory {
 		$bStatus = false;
 		wfProfileIn( __METHOD__ );
 
+		// SUS-1634 added per-cluster control of database read-only mode. It sets $wgReadOnly global variable
+		// than affects read-only checks that take place before queries are made to other database clusters.
+		// This ugly hack makes removing wgReadOnlyCluster value possible when it was used to put A cluster into read-only mode.
+		global $wgReadOnly, $wgDBReadOnly;
+		if ( $wgReadOnly === WikiFactoryLoader::PER_CLUSTER_READ_ONLY_MODE_REASON ) {
+			$wgReadOnly = false;
+			$wgDBReadOnly = false;
+			wfDebug( __METHOD__ . " - removed read-only flag triggered by wgReadOnlyCluster variable\n" );
+		}
+
 		$variable = static::getVarById( $variable_id, $wiki );
 		$dbw = static::db( DB_MASTER );
 		$dbw->begin();


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-1634

Let's [introduce `wgReadOnlyCluster` WikiFactory variable](http://community.wikia.com/wiki/Special:WikiFactory/177/variables/wgReadOnlyCluster) that will be used to quickly (i.e. without the need to make two time-consuming app pushes) put given database cluster in read-only mode when master nodes are switched. 

## Example

Setting `wgReadOnlyCluster` value to `c1` will put all wikis on A cluster in read-only mode. Note: this solution handles only one wiki cluster (c1 - c7) at a time.