### PR TITLE
SUS-1634 | make wgDBcluster consistent

### DIFF
--- a/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
+++ b/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
@@ -628,7 +628,7 @@ class WikiFactoryLoader {
 
 		# take some WF variables values from city_list
 		$this->mVariables["wgDBname"] = $this->mCityDB;
-		$this->mVariables["wgDBCluster"] = $this->mCityCluster;
+		$this->mVariables["wgDBcluster"] = $this->mCityCluster;
 
 		// @author macbre
 		Hooks::run( 'WikiFactory::executeBeforeTransferToGlobals', [ $this ] );

--- a/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
+++ b/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
@@ -311,7 +311,8 @@ class WikiFactoryLoader {
 						"host" => $host,
 						"active" => $oRow->city_public,
 						"time" =>  $oRow->city_factory_timestamp,
-						"db" => $this->mCityDB
+						"db" => $this->mCityDB,
+						"cluster" => $oRow->city_cluster,
 					);
 				}
 			}
@@ -331,7 +332,8 @@ class WikiFactoryLoader {
 						"city_factory_timestamp",
 						"city_domain",
 						"city_url",
-						"city_dbname"
+						"city_dbname",
+						"city_cluster"
 					),
 					array(
 						"city_domains.city_id = city_list.city_id",
@@ -349,13 +351,15 @@ class WikiFactoryLoader {
 						$this->mIsWikiaActive = $oRow->city_public;
 						$this->mCityHost = $host;
 						$this->mCityDB   = $oRow->city_dbname;
+						$this->mCityCluster = $oRow->city_cluster;
 						$this->mTimestamp = $oRow->city_factory_timestamp;
 						$this->mDomain = array(
 							"id"     => $oRow->city_id,
 							"host"   => $host,
 							"active" => $oRow->city_public,
 							"time"   => $oRow->city_factory_timestamp,
-							"db"     => $oRow->city_dbname
+							"db"     => $oRow->city_dbname,
+							"cluster" => $oRow->city_cluster,
 						);
 					}
 				}
@@ -382,6 +386,7 @@ class WikiFactoryLoader {
 			$this->mIsWikiaActive = $this->mDomain["active"];
 			$this->mTimestamp = isset( $this->mDomain["time"] ) ? $this->mDomain["time"] : null;
 			$this->mCityDB = isset( $this->mDomain[ "db" ] ) ? $this->mDomain[ "db" ] : false;
+			$this->mCityCluster = $this->mDomain["cluster"];
 		}
 
 

--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -1619,7 +1619,7 @@ class WikiFactory {
 	 */
 	static public function getDomainKey( $domain ) {
 		$domainHash = static::getDomainHash($domain);
-		return "wikifactory:domains:by_domain_hash:{$domainHash}";
+		return "wikifactory:domains:by_domain_hash:{$domainHash}:v2";
 	}
 
 	/**

--- a/maintenance/wikia/alterTable.php
+++ b/maintenance/wikia/alterTable.php
@@ -12,9 +12,9 @@ class AlterTableMaintenance extends Maintenance {
 	const ALTER_QUERY = 'ALTER TABLE page_wikia_props DROP PRIMARY KEY, ADD INDEX page_id (`page_id`), ADD INDEX propname (`propname`)';
 
 	public function execute() {
-		global $wgDBname, $wgDBCluster;
+		global $wgDBname, $wgDBcluster;
 
-		$this->output("Altering indices on {$wgDBname} ({$wgDBCluster})...");
+		$this->output("Altering indices on {$wgDBname} ({$wgDBcluster})...");
 		$dbw = $this->getDB( DB_MASTER );
 
 		$then = microtime( true );
@@ -25,7 +25,7 @@ class AlterTableMaintenance extends Maintenance {
 		wfWaitForSlaves();
 
 		Wikia\Logger\WikiaLogger::instance()->info( __METHOD__, [
-			'cluster' => $wgDBCluster,
+			'cluster' => $wgDBcluster,
 			'took' => round($took, 6),
 		] );
 

--- a/maintenance/wikia/cleanPageWikiaProps.php
+++ b/maintenance/wikia/cleanPageWikiaProps.php
@@ -18,9 +18,9 @@ class CleanPageWikiaPropsMaintenance extends Maintenance {
 	const TABLE_NAME = 'page_wikia_props';
 
 	public function execute() {
-		global $wgDBname, $wgDBCluster;
+		global $wgDBname, $wgDBcluster;
 
-		$this->output("Cleaning up page_wikia_props on {$wgDBname} ({$wgDBCluster})...");
+		$this->output("Cleaning up page_wikia_props on {$wgDBname} ({$wgDBcluster})...");
 		$dbw = $this->getDB( DB_MASTER );
 
 		$then = microtime( true );
@@ -44,7 +44,7 @@ class CleanPageWikiaPropsMaintenance extends Maintenance {
 		wfWaitForSlaves();
 
 		Wikia\Logger\WikiaLogger::instance()->info( __METHOD__, [
-			'cluster' => $wgDBCluster,
+			'cluster' => $wgDBcluster,
 			'took' => round($took, 6),
 		] );
 

--- a/maintenance/wikia/deleteLocalGroup.php
+++ b/maintenance/wikia/deleteLocalGroup.php
@@ -21,7 +21,7 @@ class DeleteLocalGroupMaintenance extends Maintenance {
 	}
 
 	public function execute() {
-		global $wgDBname, $wgDBCluster;
+		global $wgDBname, $wgDBcluster;
 
 		$group = $this->getOption( "group" );
 		$delete = $this->getOption( "delete", false );
@@ -31,7 +31,7 @@ class DeleteLocalGroupMaintenance extends Maintenance {
 
 		$then = microtime( true );
 		if ( !$delete ) {
-			$this->output( "Getting entries count for group on {$wgDBname} ({$wgDBCluster})\n" );
+			$this->output( "Getting entries count for group on {$wgDBname} ({$wgDBcluster})\n" );
 			$dbw = $this->getDB( DB_SLAVE );
 
 			$count = $dbw->selectField(
@@ -43,7 +43,7 @@ class DeleteLocalGroupMaintenance extends Maintenance {
 
 			$this->output( "Row count: " . $count . "\n" );
 		} else {
-			$this->output( "Deleting group on {$wgDBname} ({$wgDBCluster})\n" );
+			$this->output( "Deleting group on {$wgDBname} ({$wgDBcluster})\n" );
 			$dbw = $this->getDB( DB_MASTER );
 			$dbw->begin();
 			$dbw->delete(
@@ -56,7 +56,7 @@ class DeleteLocalGroupMaintenance extends Maintenance {
 		$took = microtime( true ) - $then;
 
 		Wikia\Logger\WikiaLogger::instance()->info( __METHOD__, [
-			'cluster' => $wgDBCluster,
+			'cluster' => $wgDBcluster,
 			'took' => round( $took, 6 ),
 		] );
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-1634

In `WikiFactoryLoader` class read `city_cluster` from `city_list` table and store it in the cache.

Avoid throwing `PHP Fatal Error: Uncaught TypeError: Argument 1 passed to WikiFactoryLoader::checkPerClusterReadOnlyFlag() must be of the type string, null given, called in /usr/wikia/slot1/19129/config/LocalSettings.php on line 133 and defined in /usr/wikia/slot1/19129/src/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php:887`