### PR TITLE
AMP-8 | use <amp-img> instead of <img>

### DIFF
--- a/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php
+++ b/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php
@@ -23,6 +23,10 @@ class ArticleAsJson {
 	const MEDIA_THUMBNAIL_TEMPLATE = 'extensions/wikia/ArticleAsJson/templates/media-thumbnail.mustache';
 	const MEDIA_GALLERY_TEMPLATE = 'extensions/wikia/ArticleAsJson/templates/media-gallery.mustache';
 
+	const MEDIA_ICON_TEMPLATE_AMP = 'extensions/wikia/ArticleAsJson/templates/media-icon-amp.mustache';
+	const MEDIA_THUMBNAIL_TEMPLATE_AMP = 'extensions/wikia/ArticleAsJson/templates/media-thumbnail-amp.mustache';
+	const MEDIA_GALLERY_TEMPLATE_AMP = 'extensions/wikia/ArticleAsJson/templates/media-gallery-amp.mustache';
+
 	private static function renderIcon( $media ) {
 		$scaledSize = self::scaleIconSize( $media['height'], $media['width'] );
 
@@ -53,9 +57,11 @@ class ArticleAsJson {
 	}
 
 	private static function renderImage( $media, $id ) {
+		$template = self::isAmp() ? self::MEDIA_THUMBNAIL_TEMPLATE_AMP : self::MEDIA_THUMBNAIL_TEMPLATE;
+
 		return self::removeNewLines(
 			\MustacheService::getInstance()->render(
-				self::MEDIA_THUMBNAIL_TEMPLATE,
+				$template,
 				[
 					'mediaAttrs' => json_encode( [ 'ref' => $id ] ),
 					'media' => $media,
@@ -600,5 +606,11 @@ class ArticleAsJson {
 		}
 
 		return $mediaDetail;
+	}
+
+	private static function isAmp(): bool {
+		global $wgArticleAsJsonIsAmp;
+
+		return (bool) $wgArticleAsJsonIsAmp;
 	}
 }

--- a/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php
+++ b/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php
@@ -28,6 +28,7 @@ class ArticleAsJson {
 	const MEDIA_GALLERY_TEMPLATE_AMP = 'extensions/wikia/ArticleAsJson/templates/media-gallery-amp.mustache';
 
 	private static function renderIcon( $media ) {
+		$template = self::isAmp() ? self::MEDIA_ICON_TEMPLATE_AMP : self::MEDIA_ICON_TEMPLATE;
 		$scaledSize = self::scaleIconSize( $media['height'], $media['width'] );
 
 		try {
@@ -43,7 +44,7 @@ class ArticleAsJson {
 
 		return self::removeNewLines(
 			\MustacheService::getInstance()->render(
-				self::MEDIA_ICON_TEMPLATE,
+				$template,
 				[
 					'url' => $thumbUrl,
 					'height' => $scaledSize['height'],
@@ -90,9 +91,11 @@ class ArticleAsJson {
 	}
 
 	private static function renderGallery( $media, $id, $hasLinkedImages ) {
+		$template = self::isAmp() ? self::MEDIA_GALLERY_TEMPLATE_AMP : self::MEDIA_GALLERY_TEMPLATE;
+
 		return self::removeNewLines(
 			\MustacheService::getInstance()->render(
-				self::MEDIA_GALLERY_TEMPLATE,
+				$template,
 				[
 					'galleryAttrs' => json_encode( [ 'ref' => $id ] ),
 					/**

--- a/extensions/wikia/ArticleAsJson/templates/media-gallery-amp.mustache
+++ b/extensions/wikia/ArticleAsJson/templates/media-gallery-amp.mustache
@@ -1,0 +1,5 @@
+<div class="article-media-gallery">
+	{{#media}}
+		{{> media-thumbnail-amp}}
+	{{/media}}
+</div>

--- a/extensions/wikia/ArticleAsJson/templates/media-icon-amp.mustache
+++ b/extensions/wikia/ArticleAsJson/templates/media-icon-amp.mustache
@@ -1,0 +1,8 @@
+<a href="{{href}}"{{#caption}} title="{{caption}}"{{/caption}}>
+	<amp-img class="article-media-icon"
+			 alt="{{title}}"
+			 src="{{url}}"
+			 width="{{width}}"
+			 height="{{height}}">
+	</amp-img>
+</a>

--- a/extensions/wikia/ArticleAsJson/templates/media-thumbnail-amp.mustache
+++ b/extensions/wikia/ArticleAsJson/templates/media-thumbnail-amp.mustache
@@ -6,8 +6,13 @@
 				 height="{{height}}"
 				 layout="responsive"
 		>
-		{{! TODO use srcset + Vignette thumbnails, see https://www.ampproject.org/docs/guides/responsive/art_direction}}
+		{{!--
+			TODO AMP-10
+			use srcset + Vignette thumbnails, see https://www.ampproject.org/docs/guides/responsive/art_direction
+		--}}
 		</amp-img>
 	</a>
-	{{#caption}}<figcaption>{{{caption}}}</figcaption>{{/caption}}
+	{{#caption}}
+		<figcaption>{{{caption}}}</figcaption>
+	{{/caption}}
 </figure>

--- a/extensions/wikia/ArticleAsJson/templates/media-thumbnail-amp.mustache
+++ b/extensions/wikia/ArticleAsJson/templates/media-thumbnail-amp.mustache
@@ -1,0 +1,13 @@
+<figure class="article-media-thumbnail">
+	<a href="{{href}}">
+		<amp-img alt="{{title}}"
+				 src="{{url}}"
+				 width="{{width}}"
+				 height="{{height}}"
+				 layout="responsive"
+		>
+		{{! TODO use srcset + Vignette thumbnails, see https://www.ampproject.org/docs/guides/responsive/art_direction}}
+		</amp-img>
+	</a>
+	{{#caption}}<figcaption>{{{caption}}}</figcaption>{{/caption}}
+</figure>

--- a/extensions/wikia/MercuryApi/handlers/MercuryApiArticleHandler.class.php
+++ b/extensions/wikia/MercuryApi/handlers/MercuryApiArticleHandler.class.php
@@ -83,6 +83,7 @@ class MercuryApiArticleHandler {
 	public static function getArticleJson( WikiaRequest $request, Article $article ) {
 		$redirect = $request->getVal( 'redirect' );
 		$sections = $request->getVal( 'sections', '' );
+		$isAmp = $request->getVal( 'isAmp', false );
 
 		return F::app()->sendRequest(
 			'ArticlesApi',
@@ -90,7 +91,8 @@ class MercuryApiArticleHandler {
 			[
 				'id' => $article->getID(),
 				'redirect' => $redirect,
-				'sections' => $sections
+				'sections' => $sections,
+				'isAmp' => $isAmp
 			]
 		)->getData();
 	}

--- a/includes/wikia/api/ArticlesApiController.class.php
+++ b/includes/wikia/api/ArticlesApiController.class.php
@@ -61,6 +61,7 @@ class ArticlesApiController extends WikiaApiController {
 	const SIMPLE_JSON_VARNISH_CACHE_EXPIRATION = 86400; // 24 hours
 	const SIMPLE_JSON_ARTICLE_ID_PARAMETER_NAME = "id";
 	const SIMPLE_JSON_ARTICLE_TITLE_PARAMETER_NAME = "title";
+	const SIMPLE_JSON_ARTICLE_AMP_PARAMETER_NAME = "isAmp";
 
 	/**
 	 * @var CrossOriginResourceSharingHeaderHelper
@@ -939,6 +940,7 @@ class ArticlesApiController extends WikiaApiController {
 		$articleId = $this->getRequest()->getInt( self::SIMPLE_JSON_ARTICLE_ID_PARAMETER_NAME, NULL );
 		$articleTitle = $this->getRequest()->getVal( self::SIMPLE_JSON_ARTICLE_TITLE_PARAMETER_NAME, NULL );
 		$redirect = $this->request->getVal( 'redirect' );
+		$isAmp = $this->request->getBool( self::SIMPLE_JSON_ARTICLE_AMP_PARAMETER_NAME, false );
 
 		if ( !empty( $articleId ) && !empty( $articleTitle ) ) {
 			throw new BadRequestApiException( 'Can\'t use id and title in the same request' );
@@ -983,14 +985,22 @@ class ArticlesApiController extends WikiaApiController {
 		global $wgArticleAsJson;
 		$wgArticleAsJson = true;
 
+		global $wgArticleAsJsonIsAmp;
+
+		if ( $isAmp === true ) {
+			$wgArticleAsJsonIsAmp = true;
+		}
+
 		$parsedArticle = $article->getParserOutput();
 
 		if ( $parsedArticle instanceof ParserOutput ) {
 			$articleContent = json_decode( $parsedArticle->getText() );
 			$content = $articleContent->content;
 			$wgArticleAsJson = false;
+			$wgArticleAsJsonIsAmp = false;
 		} else {
 			$wgArticleAsJson = false;
+			$wgArticleAsJsonIsAmp = false;
 			throw new ArticleAsJsonParserException( 'Parser is currently not available' );
 		}
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/AMP-8

http://muppet.wikia.com/wikia.php?controller=MercuryApi&method=getPage&title=Kermit&isAmp=1 will return `<amp-img>` instead of `<img>` for galleries, single images, and small icons. Doesn't apply to Portable Infoboxes.

@themech 