### PR TITLE
cake-2132/2133 - add api call to receive email definition and wrapper task to send email

### DIFF
--- a/extensions/wikia/FandomCreatorEmail/Api/SendEmailController.php
+++ b/extensions/wikia/FandomCreatorEmail/Api/SendEmailController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace FandomCreatorEmail\Api;
+
+use FandomCreatorEmail\Controller\ContentUpdatedController;
+use FandomCreatorEmail\SendEmailTask;
+use WikiaApiController;
+
+class SendEmailController extends WikiaApiController {
+
+	public function allowsExternalRequests() {
+		return false;
+	}
+
+	public function contentUpdated() {
+		$task = SendEmailTask::from($this->request, ContentUpdatedController::class);
+		$taskId = $task->queue();
+		$this->setResponseData(['taskId' => $taskId]);
+	}
+}

--- a/extensions/wikia/FandomCreatorEmail/Api/SendEmailController.php
+++ b/extensions/wikia/FandomCreatorEmail/Api/SendEmailController.php
@@ -13,8 +13,8 @@ class SendEmailController extends WikiaApiController {
 	}
 
 	public function contentUpdated() {
-		$task = SendEmailTask::from($this->request, ContentUpdatedController::class);
+		$task = SendEmailTask::from( $this->request, ContentUpdatedController::class );
 		$taskId = $task->queue();
-		$this->setResponseData(['taskId' => $taskId]);
+		$this->setResponseData( ['taskId' => $taskId] );
 	}
 }

--- a/extensions/wikia/FandomCreatorEmail/FandomCreatorEmail.setup.php
+++ b/extensions/wikia/FandomCreatorEmail/FandomCreatorEmail.setup.php
@@ -1,5 +1,17 @@
 <?php
+spl_autoload_register(function($class) {
+	$prefix = 'FandomCreatorEmail\\';
+	$len = strlen($prefix);
+	if (strncmp($prefix, $class, $len) !== 0) {
+		return;
+	}
 
-$wgAutoloadClasses['FandomCreatorEmail\MagicWordWrapper'] = __DIR__ . '/MagicWordWrapper.php';
-$wgAutoloadClasses['FandomCreatorEmail\FandomCreatorEmailController'] = __DIR__ . '/FandomCreatorEmailController.php';
+	$file = __DIR__.'/'.str_replace('\\', '/', substr($class, $len)).'.php';
+	if (file_exists($file)) {
+		require $file;
+	}
+});
+
+// WikiaDispatcher looks for classes in this array and doesn't utilize the autoloader :|
+$wgAutoloadClasses['FandomCreatorEmail\Api\SendEmailController'] = __DIR__ . '/Api/SendEmailController.php';
 $wgAutoloadClasses['FandomCreatorEmail\Controller\ContentUpdatedController'] = __DIR__ . '/Controller/ContentUpdatedController.php';

--- a/extensions/wikia/FandomCreatorEmail/FandomCreatorEmail.setup.php
+++ b/extensions/wikia/FandomCreatorEmail/FandomCreatorEmail.setup.php
@@ -1,16 +1,16 @@
 <?php
-spl_autoload_register(function($class) {
+spl_autoload_register( function( $class ) {
 	$prefix = 'FandomCreatorEmail\\';
-	$len = strlen($prefix);
-	if (strncmp($prefix, $class, $len) !== 0) {
+	$len = strlen( $prefix );
+	if ( strncmp( $prefix, $class, $len ) !== 0 ) {
 		return;
 	}
 
-	$file = __DIR__.'/'.str_replace('\\', '/', substr($class, $len)).'.php';
-	if (file_exists($file)) {
+	$file = __DIR__ . '/' . str_replace( '\\', '/', substr( $class, $len ) ) . '.php';
+	if ( file_exists( $file ) ) {
 		require $file;
 	}
-});
+} );
 
 // WikiaDispatcher looks for classes in this array and doesn't utilize the autoloader :|
 $wgAutoloadClasses['FandomCreatorEmail\Api\SendEmailController'] = __DIR__ . '/Api/SendEmailController.php';

--- a/extensions/wikia/FandomCreatorEmail/SendEmailTask.php
+++ b/extensions/wikia/FandomCreatorEmail/SendEmailTask.php
@@ -7,26 +7,26 @@ use WikiaRequest;
 
 class SendEmailTask extends BaseTask {
 
-	public function sendEmails(string $emailController, string $method, array $params, array $targetUserIds) {
-		foreach ($targetUserIds as $targetUserId) {
-			$emailParams = array_merge([
+	public function sendEmails( string $emailController, string $method, array $params, array $targetUserIds ) {
+		foreach ( $targetUserIds as $targetUserId ) {
+			$emailParams = array_merge( [
 					'targetUserId' => $targetUserId,
-			], (array) $params);
+			], (array) $params );
 
-			\F::app()->sendRequest($emailController, $method, $emailParams);
+			\F::app()->sendRequest( $emailController, $method, $emailParams );
 		}
 	}
 
-	public static function from(WikiaRequest $controller, string $emailController):SendEmailTask {
+	public static function from( WikiaRequest $controller, string $emailController ): SendEmailTask {
 		$allParams = $controller->getParams();
 		$targetUserIds = $allParams['targetUserIds'];
 
-		unset($allParams['targetUserIds']);
-		unset($allParams['controller']);
-		unset($allParams['method']);
+		unset( $allParams['targetUserIds'] );
+		unset( $allParams['controller'] );
+		unset( $allParams['method'] );
 
 		$task = new SendEmailTask();
-		$task->call('sendEmails', $emailController, 'handle', $allParams, $targetUserIds);
+		$task->call( 'sendEmails', $emailController, 'handle', $allParams, $targetUserIds );
 		return $task;
 	}
 }

--- a/extensions/wikia/FandomCreatorEmail/SendEmailTask.php
+++ b/extensions/wikia/FandomCreatorEmail/SendEmailTask.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace FandomCreatorEmail;
+
+use Wikia\Tasks\Tasks\BaseTask;
+use WikiaRequest;
+
+class SendEmailTask extends BaseTask {
+
+	public function sendEmails(string $emailController, string $method, array $params, array $targetUserIds) {
+		foreach ($targetUserIds as $targetUserId) {
+			$emailParams = array_merge([
+					'targetUserId' => $targetUserId,
+			], (array) $params);
+
+			\F::app()->sendRequest($emailController, $method, $emailParams);
+		}
+	}
+
+	public static function from(WikiaRequest $controller, string $emailController):SendEmailTask {
+		$allParams = $controller->getParams();
+		$targetUserIds = $allParams['targetUserIds'];
+
+		unset($allParams['targetUserIds']);
+		unset($allParams['controller']);
+		unset($allParams['method']);
+
+		$task = new SendEmailTask();
+		$task->call('sendEmails', $emailController, 'handle', $allParams, $targetUserIds);
+		return $task;
+	}
+}

--- a/includes/wikia/nirvana/WikiaController.class.php
+++ b/includes/wikia/nirvana/WikiaController.class.php
@@ -12,7 +12,7 @@
  */
 abstract class WikiaController extends WikiaDispatchableObject {
 
-	final public function allowsExternalRequests(){
+	public function allowsExternalRequests(){
 		return true;
 	}
 


### PR DESCRIPTION
@Wikia/cake 
https://wikia-inc.atlassian.net/browse/CAKE-2132
https://wikia-inc.atlassian.net/browse/CAKE-2133

This changeset covers adding an internal-only API that will be called from the CGS with inputs required to send the content updated email as well as a wrapper task that MW will use to send the emails through the async queue.

Some notes:
- I _could_ have made `SendEmailController` receive the controller class as an input rather than having a specific `contentUpdated` method - think something like `SendEmailController.sendEmail` where `emailController` is another input param. This would have made this API more general, but I didn't want to have the CGS know the internal class names for the email controller. The CGS already has enough of the internals with having to know the controller name for the api including the namespace. I could be easily swayed on this if someone else thinks it should be made more generic so we hopefully don't have to touch this code if we want to add more emails.
- `SendEmailTask` _is_ generic, so we shouldn't have to add any more functionality in the future if we want to send other emails from the FC/CGS.
- Batching is explicitly not included in the api/task. I could see the argument being made here so that the CGS doesn't manage the size of an email (it should maybe be handled by the "email service"?) but from a practical perspective it's easier for us to change/deploy code from the CGS side, so I think it's better to have the batching logic there.