### PR TITLE
SUS-2650 | invalidate file page on image review status change

### DIFF
--- a/extensions/wikia/ImageReview/ImageReviewHelper.class.php
+++ b/extensions/wikia/ImageReview/ImageReviewHelper.class.php
@@ -1,5 +1,6 @@
 <?php
 
+use \Wikia\Tasks\Tasks\ImageReviewTask;
 use \Wikia\Logger\WikiaLogger;
 
 /**
@@ -51,6 +52,12 @@ class ImageReviewHelper extends ImageReviewHelperBase {
 				'review_state' => $image['state'],
 				'reviewer_id' => $this->user_id
 			);
+
+			// SUS-2650: invalidate file page of reviewed image
+			$task = new ImageReviewTask();
+			$task->call( 'invalidateFilePage', (int) $image['pageId'] );
+			$task->wikiId( $image['wiki_id'] );
+			$task->queue();
 		}
 
 		$db = $this->getDatawareDB( DB_MASTER );

--- a/includes/wikia/tasks/Tasks/ImageReviewTask.class.php
+++ b/includes/wikia/tasks/Tasks/ImageReviewTask.class.php
@@ -189,6 +189,23 @@ class ImageReviewTask extends BaseTask {
 		return $result;
 	}
 
+	/**
+	 * Invalidates provided file page (use page ID) by bumping page_touched entry in `page` table
+	 * and purging CDN cache.
+	 *
+	 * This task is queued when image review status changes to reflect this change on the file page.
+	 *
+	 * @see SUS-2650
+	 *
+	 * @param int $pageId
+	 */
+	public function invalidateFilePage( int $pageId ) {
+		$title = \Title::newFromId( $pageId );
+
+		$title->invalidateCache();
+		$title->purgeSquid();
+	}
+
 	private function isTop200( $wikiId ) {
 		global $wgExternalDatawareDB;
 		$dbr = wfGetDB( DB_SLAVE, [], $wgExternalDatawareDB );

--- a/includes/wikia/tasks/Tasks/ImageReviewTask.class.php
+++ b/includes/wikia/tasks/Tasks/ImageReviewTask.class.php
@@ -122,6 +122,12 @@ class ImageReviewTask extends BaseTask {
 			$key = wfForeignMemcKey( $cityId, 'image-review', $pageId, $revisionId );
 
 			WikiaDataAccess::cachePurge( $key );
+
+			// SUS-2650: invalidate file page of reviewed image
+			$task = new ImageReviewTask();
+			$task->call( 'invalidateFilePage', (int) $pageId );
+			$task->wikiId( $cityId );
+			$task->queue();
 		}
 	}
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-2650

Introduce `ImageReviewTask::invalidateFilePage` method that invalidates provided file page (use page ID) by bumping `page_touched` entry in `page` table and purging CDN cache.

This task will be queued when image review status changes to reflect this change on the file page.

## An example

```
$ curl -svo /dev/null 'http://poznan.macbre.wikia-dev.pl/wiki/Plik:Gzik.jpg' 2>&1 | grep -E 'ETag|Last-Modified|Age:'
< ETag: "20170724130617-1503480947"
< Last-Modified: Mon, 24 Jul 2017 13:06:17 GMT
< Age: 0
```

Let's queue a task:

```php
$task = new \Wikia\Tasks\Tasks\ImageReviewTask();
$task->call( 'invalidateFilePage', 1962 /* pageId */ );
$task->wikiId( 5915 );
$task->queue();
```

```
$ curl -svo /dev/null 'http://poznan.macbre.wikia-dev.pl/wiki/Plik:Gzik.jpg' 2>&1 | grep -E 'ETag|Last-Modified|Age:'
< ETag: "20170823093619-1503480983"
< Last-Modified: Wed, 23 Aug 2017 09:36:19 GMT
< Age: 0
```

Task execution log:

```sql
Query plpoznan (DB user: wikia_tasks) (10) (master): UPDATE /* Title::invalidateCache TaskRunnerMaintenance - b4506d3b-2c65-4b64-bbbb-989e0f1b80c4 */  `page` SET page_touched = '20170823093619' WHERE page_id = '
1962'
Purging backtrace: require/TaskRunnerMaintenance::execute/TaskRunner::run/Wikia\Tasks\Tasks\BaseTask::execute/call_user_func_array/Wikia\Tasks\Tasks\ImageReviewTask::invalidateFilePage/Title::purgeSquid/SquidUpd
ate::doUpdate/SquidUpdate::purge/CeleryPurge::purge
Purging URL http://localhost/wiki/Plik:Gzik.jpg from Wikia\Tasks\Tasks\ImageReviewTask:invalidateFilePage via Celery
Purging URL http://localhost/wiki/Plik:Gzik.jpg?action=history from Wikia\Tasks\Tasks\ImageReviewTask:invalidateFilePage via Celery
Purging URL http://localhost/wiki/Specjalna:Ostatnie_zmiany from Wikia\Tasks\Tasks\ImageReviewTask:invalidateFilePage via Celery
Purging URL http://localhost/wiki/Specjalna:Ostatnie_zmiany?feed=rss from Wikia\Tasks\Tasks\ImageReviewTask:invalidateFilePage via Celery
Purging URL http://localhost/wiki/Specjalna:Ostatnie_zmiany?feed=atom from Wikia\Tasks\Tasks\ImageReviewTask:invalidateFilePage via Celery
```