### PR TITLE
checkPerClusterReadOnlyFlag | Reston has wgDBReadOnly = true, leave early

### DIFF
--- a/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
+++ b/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
@@ -890,6 +890,12 @@ class WikiFactoryLoader {
 	 * @return bool if true is returned, the caller should set $wgReadOnly flag
 	 */
 	public static function checkPerClusterReadOnlyFlag( string $cluster ) : bool {
+		// we're already in DB read-only mode (are we in Reston DC?), leave early
+		global $wgDBReadOnly;
+		if ( $wgDBReadOnly === true ) {
+			return false;
+		}
+
 		$readOnlyCluster = WikiFactory::getVarValueByName( 'wgReadOnlyCluster', Wikia::COMMUNITY_WIKI_ID );
 		return $readOnlyCluster === $cluster;
 	}


### PR DESCRIPTION
It's set in [CommonSettings.php for RES](https://github.com/Wikia/config/blob/dev/CommonSettings.php#L2458)

Avoid the following:

```php
PHP Fatal Error: Uncaught Error: Call to a member function get() on null in /usr/wikia/slot1/19192/src/includes/wikia/WikiaDataAccess.class.php:91
Stack trace:
0 /usr/wikia/slot1/19192/src/includes/wikia/WikiaDataAccess.class.php(55): WikiaDataAccess::cacheWithOptions('wikicities:wiki...', Object(Closure), Array)
1 /usr/wikia/slot1/19192/src/extensions/wikia/WikiFactory/WikiFactory.php(2133): WikiaDataAccess::cache('wikicities:wiki...', 86400, Object(Closure), 0)
2 /usr/wikia/slot1/19192/src/extensions/wikia/WikiFactory/WikiFactory.php(1064): WikiFactory::loadVariableFromDB(false, 'wgReadOnlyClust...', 177, false)
3 /usr/wikia/slot1/19192/src/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php(893): WikiFactory::getVarValueByName('wgReadOnlyClust...', 177)
4 /usr/wikia/slot1/19192/config/LocalSettings.php(133): WikiFactoryLoader::checkPerClusterReadOnlyFlag('c1')
5 /usr/wikia/slot1/19192/src/LocalSettings.php(4): require('/usr/wikia/slot...')
6 /usr/wikia/slot1/19192/src/includes/WebStart.php(145): require_once('/usr/wikia/slot...')
7 /usr/wikia/slot1/19192/src/wikia.php(13): require('/usr/wikia/slot...')
8 {main}
  thrown in /usr/wikia/slot1/19192/src/includes/wikia/WikiaDataAccess.class.php on line 91
```