### PR TITLE
Amp-4: Enable AMP experiment for selected articles

### DIFF
--- a/extensions/wikia/GoogleAmp/GoogleAmp.setup.php
+++ b/extensions/wikia/GoogleAmp/GoogleAmp.setup.php
@@ -10,3 +10,4 @@ $wgAutoloadClasses['GoogleAmpHelper'] =  $dir . 'GoogleAmpHelper.class.php';
 
 // hooks
 $wgHooks['BeforePageDisplay'][] = 'GoogleAmpHelper::onBeforePageDisplay';
+$wgHooks['MercuryPageData'][] = 'GoogleAmpHelper::onMercuryPageData';

--- a/extensions/wikia/GoogleAmp/GoogleAmp.setup.php
+++ b/extensions/wikia/GoogleAmp/GoogleAmp.setup.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Google AMP
+ */
+
+$dir = dirname(__FILE__) . '/';
+
+// classes
+$wgAutoloadClasses['GoogleAmpHelper'] =  $dir . 'GoogleAmpHelper.class.php';
+
+// hooks
+$wgHooks['BeforePageDisplay'][] = 'GoogleAmpHelper::onBeforePageDisplay';

--- a/extensions/wikia/GoogleAmp/GoogleAmpHelper.class.php
+++ b/extensions/wikia/GoogleAmp/GoogleAmpHelper.class.php
@@ -37,8 +37,8 @@ class GoogleAmpHelper {
 		if ( preg_match( $serverRegex, $wikiServer, $groups ) !== 1 ) {
 			return null;
 		}
-		$wikiServer = $groups[1];
-		$article = $title->getPrefixedDBkey();
+		$wikiServer = rawurlencode( $groups[1] );
+		$article = rawurlencode( $title->getPrefixedDBkey() );
 
 		return str_replace( '{WIKI}', $wikiServer, str_replace( '{ARTICLE}', $article, $wgGoogleAmpAddress ) );
 	}

--- a/extensions/wikia/GoogleAmp/GoogleAmpHelper.class.php
+++ b/extensions/wikia/GoogleAmp/GoogleAmpHelper.class.php
@@ -2,80 +2,80 @@
 
 class GoogleAmpHelper {
 
-    /**
-     * Checks whether AMP version is enabled for a given title.
-     *
-     * @param Title $title
-     * @return bool
-     */
-    static public function isAmpEnabled( Title $title ): bool {
-        global $wgGoogleAmpNamespaces, $wgGoogleAmpArticleBlacklist;
+	/**
+	 * Checks whether AMP version is enabled for a given title.
+	 *
+	 * @param Title $title
+	 * @return bool
+	 */
+	static public function isAmpEnabled( Title $title ): bool {
+		global $wgGoogleAmpNamespaces, $wgGoogleAmpArticleBlacklist;
 
-        if ( in_array( $title->getNamespace(), $wgGoogleAmpNamespaces ) ) {
-            if ( !in_array( $title->getPrefixedDBkey(), $wgGoogleAmpArticleBlacklist ) ) {
-                return true;
-            }
-        }
-        return false;
-    }
+		if ( in_array( $title->getNamespace(), $wgGoogleAmpNamespaces ) ) {
+			if ( !in_array( $title->getPrefixedDBkey(), $wgGoogleAmpArticleBlacklist ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
 
-    /**
-     * If Amp is enabled for a given title, return Amp article address.
-     *
-     * @param Title $title
-     * @return string|null
-     */
-    static public function getAmpAddress( Title $title ) {
-        global $wgServer, $wgGoogleAmpAddress;
+	/**
+	 * If Amp is enabled for a given title, return Amp article address.
+	 *
+	 * @param Title $title
+	 * @return string|null
+	 */
+	static public function getAmpAddress( Title $title ) {
+		global $wgServer, $wgGoogleAmpAddress;
 
-        if ( !self::isAmpEnabled( $title ) ) {
-            return null;
-        }
+		if ( !self::isAmpEnabled( $title ) ) {
+			return null;
+		}
 
-        $wikiServer = WikiFactory::getLocalEnvURL( $wgServer, WIKIA_ENV_PROD );
-        $serverRegex = '/^https?:\/\/(.+)\.wikia\.com/';
-        if ( preg_match( $serverRegex, $wikiServer, $groups ) !== 1 ) {
-            return null;
-        }
-        $wikiServer = $groups[1];
-        $article = $title->getPrefixedDBkey();
+		$wikiServer = WikiFactory::getLocalEnvURL( $wgServer, WIKIA_ENV_PROD );
+		$serverRegex = '/^https?:\/\/(.+)\.wikia\.com/';
+		if ( preg_match( $serverRegex, $wikiServer, $groups ) !== 1 ) {
+			return null;
+		}
+		$wikiServer = $groups[1];
+		$article = $title->getPrefixedDBkey();
 
-        return str_replace( '{WIKI}', $wikiServer, str_replace( '{ARTICLE}', $article, $wgGoogleAmpAddress ) );
-    }
+		return str_replace( '{WIKI}', $wikiServer, str_replace( '{ARTICLE}', $article, $wgGoogleAmpAddress ) );
+	}
 
-    /**
-     * Adds Amp article data
-     *
-     * @param Title $title
-     * @param $data Mercury article data to be returned
-     * @return bool
-     */
-    static public function onMercuryPageData( Title $title, &$data ): bool {
-        $ampAddress = self::getAmpAddress( $title );
-        if ( $ampAddress ) {
-            $data['amphtml'] = $ampAddress;
-        }
-        return true;
-    }
+	/**
+	 * Adds Amp article data
+	 *
+	 * @param Title $title
+	 * @param $data Mercury article data to be returned
+	 * @return bool
+	 */
+	static public function onMercuryPageData( Title $title, &$data ): bool {
+		$ampAddress = self::getAmpAddress( $title );
+		if ( $ampAddress ) {
+			$data['amphtml'] = $ampAddress;
+		}
+		return true;
+	}
 
-    /**
-     * Add Amp rel link to page header.
-     *
-     * @param OutputPage $out
-     * @param Skin $skin
-     * @return bool
-     */
-    static public function onBeforePageDisplay( OutputPage $out, Skin $skin ): bool {
-        $title = $out->getTitle();
-        if ( $title ) {
-            $ampArticle = self::getAmpAddress( $title );
-            if ( $ampArticle ) {
-                $out->addLink( [
-                    'rel' => 'amphtml',
-                    'href' => $ampArticle
-                ] );
-            }
-        }
-        return true;
-    }
+	/**
+	 * Add Amp rel link to page header.
+	 *
+	 * @param OutputPage $out
+	 * @param Skin $skin
+	 * @return bool
+	 */
+	static public function onBeforePageDisplay( OutputPage $out, Skin $skin ): bool {
+		$title = $out->getTitle();
+		if ( $title ) {
+			$ampArticle = self::getAmpAddress( $title );
+			if ( $ampArticle ) {
+				$out->addLink( [
+					'rel' => 'amphtml',
+					'href' => $ampArticle
+				] );
+			}
+		}
+		return true;
+	}
 }

--- a/extensions/wikia/GoogleAmp/GoogleAmpHelper.class.php
+++ b/extensions/wikia/GoogleAmp/GoogleAmpHelper.class.php
@@ -1,6 +1,30 @@
 <?php
 
 class GoogleAmpHelper {
+
+    static public function isAmpEnabled ( Title $title): bool {
+        global $wgEnableGoogleAmp, $wgGoogleAmpArticles;
+        return true;
+    }
+
+    static public function getAmpAddress( Title $title ) {
+        global $wgServer, $wgGoogleAmpAddress;
+
+        if ( !self::isAmpEnabled( $title) ) {
+            return null;
+        }
+
+        $wikiServer = WikiFactory::getLocalEnvURL($wgServer, WIKIA_ENV_PROD);
+        $serverRegex = '/^https?:\/\/(.+)\.wikia\.com/';
+        if ( preg_match( $serverRegex, $wikiServer, $groups ) !== 1 ) {
+            return null;
+        }
+        $wikiServer = $groups[1];
+        $article = $title->getPrefixedDBkey();
+
+        return str_replace( '{WIKI}', $wikiServer, str_replace( '{ARTICLE}', $article, $wgGoogleAmpAddress));;
+    }
+
     /**
      * Attempts to recover a URL that was truncated by an external service (e.g. /wiki/Wanted! --> /wiki/Wanted)
      * @param Article $article
@@ -9,20 +33,16 @@ class GoogleAmpHelper {
      * @return bool
      */
     static public function onBeforePageDisplay( OutputPage $out, Skin $skin ): bool {
-
         $title = $out->getTitle();
-        $isMainpage = $title->isMainPage();
-        if ( $isMainpage ) {
-            //$meta["og:type"] = "website";
-            //$meta["og:title"] = $wgSitename;
-        } else {
-            $out->addLink( [
-                'rel' => 'alternate',
-                'href' => 'http://example.com',
-                'hreflang' => 'en-us'
-            ] );
+        if ( $title ) {
+            $ampArticle = self::getAmpAddress( $title );
+            if ( $ampArticle ) {
+                $out->addLink( [
+                    'rel' => 'amphtml',
+                    'href' => $ampArticle
+                ] );
+            }
         }
-
         return true;
     }
 }

--- a/extensions/wikia/GoogleAmp/GoogleAmpHelper.class.php
+++ b/extensions/wikia/GoogleAmp/GoogleAmpHelper.class.php
@@ -11,10 +11,10 @@ class GoogleAmpHelper {
 	static public function isAmpEnabled( Title $title ): bool {
 		global $wgGoogleAmpNamespaces, $wgGoogleAmpArticleBlacklist;
 
-		if ( $title->exists() && in_array( $title->getNamespace(), $wgGoogleAmpNamespaces ) ) {
-			if ( !in_array( $title->getPrefixedDBkey(), $wgGoogleAmpArticleBlacklist ) ) {
+		if ( $title->exists() &&
+			in_array( $title->getNamespace(), $wgGoogleAmpNamespaces ) &&
+			!in_array( $title->getPrefixedDBkey(), $wgGoogleAmpArticleBlacklist ) ) {
 				return true;
-			}
 		}
 		return false;
 	}

--- a/extensions/wikia/GoogleAmp/GoogleAmpHelper.class.php
+++ b/extensions/wikia/GoogleAmp/GoogleAmpHelper.class.php
@@ -1,0 +1,28 @@
+<?php
+
+class GoogleAmpHelper {
+    /**
+     * Attempts to recover a URL that was truncated by an external service (e.g. /wiki/Wanted! --> /wiki/Wanted)
+     * @param Article $article
+     * @param bool $outputDone
+     * @param bool $pcache
+     * @return bool
+     */
+    static public function onBeforePageDisplay( OutputPage $out, Skin $skin ): bool {
+
+        $title = $out->getTitle();
+        $isMainpage = $title->isMainPage();
+        if ( $isMainpage ) {
+            //$meta["og:type"] = "website";
+            //$meta["og:title"] = $wgSitename;
+        } else {
+            $out->addLink( [
+                'rel' => 'alternate',
+                'href' => 'http://example.com',
+                'hreflang' => 'en-us'
+            ] );
+        }
+
+        return true;
+    }
+}

--- a/extensions/wikia/GoogleAmp/GoogleAmpHelper.class.php
+++ b/extensions/wikia/GoogleAmp/GoogleAmpHelper.class.php
@@ -11,7 +11,7 @@ class GoogleAmpHelper {
 	static public function isAmpEnabled( Title $title ): bool {
 		global $wgGoogleAmpNamespaces, $wgGoogleAmpArticleBlacklist;
 
-		if ( in_array( $title->getNamespace(), $wgGoogleAmpNamespaces ) ) {
+		if ( $title->exists() && in_array( $title->getNamespace(), $wgGoogleAmpNamespaces ) ) {
 			if ( !in_array( $title->getPrefixedDBkey(), $wgGoogleAmpArticleBlacklist ) ) {
 				return true;
 			}

--- a/extensions/wikia/GoogleAmp/GoogleAmpHelper.class.php
+++ b/extensions/wikia/GoogleAmp/GoogleAmpHelper.class.php
@@ -2,27 +2,37 @@
 
 class GoogleAmpHelper {
 
-    static public function isAmpEnabled ( Title $title): bool {
-        global $wgEnableGoogleAmp, $wgGoogleAmpNamespaces, $wgGoogleAmpArticleBlacklist;
+    /**
+     * Checks whether AMP version is enabled for a given title.
+     *
+     * @param Title $title
+     * @return bool
+     */
+    static public function isAmpEnabled( Title $title ): bool {
+        global $wgGoogleAmpNamespaces, $wgGoogleAmpArticleBlacklist;
 
-        if ( $wgEnableGoogleAmp ) {
-            if ( in_array( $title->getNamespace(), $wgGoogleAmpNamespaces ) ) {
-                if ( !in_array( $title->getPrefixedDBkey(), $wgGoogleAmpArticleBlacklist ) ) {
-                    return true;
-                }
+        if ( in_array( $title->getNamespace(), $wgGoogleAmpNamespaces ) ) {
+            if ( !in_array( $title->getPrefixedDBkey(), $wgGoogleAmpArticleBlacklist ) ) {
+                return true;
             }
         }
         return false;
     }
 
+    /**
+     * If Amp is enabled for a given title, return Amp article address.
+     *
+     * @param Title $title
+     * @return string|null
+     */
     static public function getAmpAddress( Title $title ) {
         global $wgServer, $wgGoogleAmpAddress;
 
-        if ( !self::isAmpEnabled( $title) ) {
+        if ( !self::isAmpEnabled( $title ) ) {
             return null;
         }
 
-        $wikiServer = WikiFactory::getLocalEnvURL($wgServer, WIKIA_ENV_PROD);
+        $wikiServer = WikiFactory::getLocalEnvURL( $wgServer, WIKIA_ENV_PROD );
         $serverRegex = '/^https?:\/\/(.+)\.wikia\.com/';
         if ( preg_match( $serverRegex, $wikiServer, $groups ) !== 1 ) {
             return null;
@@ -30,9 +40,16 @@ class GoogleAmpHelper {
         $wikiServer = $groups[1];
         $article = $title->getPrefixedDBkey();
 
-        return str_replace( '{WIKI}', $wikiServer, str_replace( '{ARTICLE}', $article, $wgGoogleAmpAddress));;
+        return str_replace( '{WIKI}', $wikiServer, str_replace( '{ARTICLE}', $article, $wgGoogleAmpAddress ) );
     }
 
+    /**
+     * Adds Amp article data
+     *
+     * @param Title $title
+     * @param $data Mercury article data to be returned
+     * @return bool
+     */
     static public function onMercuryPageData( Title $title, &$data ): bool {
         $ampAddress = self::getAmpAddress( $title );
         if ( $ampAddress ) {
@@ -42,10 +59,10 @@ class GoogleAmpHelper {
     }
 
     /**
-     * Attempts to recover a URL that was truncated by an external service (e.g. /wiki/Wanted! --> /wiki/Wanted)
-     * @param Article $article
-     * @param bool $outputDone
-     * @param bool $pcache
+     * Add Amp rel link to page header.
+     *
+     * @param OutputPage $out
+     * @param Skin $skin
      * @return bool
      */
     static public function onBeforePageDisplay( OutputPage $out, Skin $skin ): bool {

--- a/extensions/wikia/GoogleAmp/GoogleAmpHelper.class.php
+++ b/extensions/wikia/GoogleAmp/GoogleAmpHelper.class.php
@@ -3,8 +3,16 @@
 class GoogleAmpHelper {
 
     static public function isAmpEnabled ( Title $title): bool {
-        global $wgEnableGoogleAmp, $wgGoogleAmpArticles;
-        return true;
+        global $wgEnableGoogleAmp, $wgGoogleAmpNamespaces, $wgGoogleAmpArticleBlacklist;
+
+        if ( $wgEnableGoogleAmp ) {
+            if ( in_array( $title->getNamespace(), $wgGoogleAmpNamespaces ) ) {
+                if ( !in_array( $title->getPrefixedDBkey(), $wgGoogleAmpArticleBlacklist ) ) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     static public function getAmpAddress( Title $title ) {
@@ -23,6 +31,14 @@ class GoogleAmpHelper {
         $article = $title->getPrefixedDBkey();
 
         return str_replace( '{WIKI}', $wikiServer, str_replace( '{ARTICLE}', $article, $wgGoogleAmpAddress));;
+    }
+
+    static public function onMercuryPageData( Title $title, &$data ): bool {
+        $ampAddress = self::getAmpAddress( $title );
+        if ( $ampAddress ) {
+            $data['amphtml'] = $ampAddress;
+        }
+        return true;
     }
 
     /**

--- a/extensions/wikia/MercuryApi/MercuryApiController.class.php
+++ b/extensions/wikia/MercuryApi/MercuryApiController.class.php
@@ -420,6 +420,8 @@ class MercuryApiController extends WikiaController {
 					}
 				}
 			}
+
+            \Hooks::run( 'MercuryPageData', [ $title, &$data ] );
 		} catch ( WikiaHttpException $exception ) {
 			$this->response->setCode( $exception->getCode() );
 

--- a/extensions/wikia/MercuryApi/MercuryApiController.class.php
+++ b/extensions/wikia/MercuryApi/MercuryApiController.class.php
@@ -421,7 +421,7 @@ class MercuryApiController extends WikiaController {
 				}
 			}
 
-            \Hooks::run( 'MercuryPageData', [ $title, &$data ] );
+ 			\Hooks::run( 'MercuryPageData', [ $title, &$data ] );
 		} catch ( WikiaHttpException $exception ) {
 			$this->response->setCode( $exception->getCode() );
 

--- a/extensions/wikia/MercuryApi/MercuryApiController.class.php
+++ b/extensions/wikia/MercuryApi/MercuryApiController.class.php
@@ -421,7 +421,7 @@ class MercuryApiController extends WikiaController {
 				}
 			}
 
- 			\Hooks::run( 'MercuryPageData', [ $title, &$data ] );
+			\Hooks::run( 'MercuryPageData', [ $title, &$data ] );
 		} catch ( WikiaHttpException $exception ) {
 			$this->response->setCode( $exception->getCode() );
 


### PR DESCRIPTION
AMP experiment can be enabled through WF variables added in https://github.com/Wikia/config/pull/2254. When enabled for a given article, the `<link rel="amphtml"` is added to page header (per https://www.ampproject.org/docs/guides/discovery). Additionally Amp article address is returned through the Mercury API so the same header can be returned in mobile wiki