### PR TITLE
Revert "Merge pull request #13580 from Wikia/SUS-1393"

### DIFF
--- a/extensions/GlobalMessages/GlobalMessagesF.i18n.php
+++ b/extensions/GlobalMessages/GlobalMessagesF.i18n.php
@@ -13,7 +13,6 @@ $messages['en'] = array(
 	'feed-unavailable' => 'Syndication feeds are not available',
 	'feed-atom' => 'Atom',
 	'feed-rss' => 'RSS',
-	'file-resolution-exceeded' => 'Provided image resolution ($1 megapixels) exceeds maximum allowed resolution of $2 megapixels for $3 MIME type.',
 	'fileappenderrorread' => 'Could not read "$1" during append.',
 	'fileappenderror' => 'Could not append "$1" to "$2".',
 	'filecopyerror' => 'Could not copy file "$1" to "$2".',
@@ -216,7 +215,6 @@ $messages['qqq'] = array(
 	'feed-unavailable' => 'This message is displayed when a user tries to use an RSS or Atom feed on a wiki where such feeds have been disabled.',
 	'feed-atom' => '{{optional}}',
 	'feed-rss' => '{{optional}}',
-	'file-resolution-exceeded' => 'Error displayed when user tries to upload image with too high resolution',
 	'fileappenderrorread' => '"Append" is a computer procedure, explained on [http://en.wikipedia.org/wiki/Append Wikipedia].
 
 $1 is a filename, I think.',

--- a/extensions/GlobalMessages/crowdin-global-f.conf
+++ b/extensions/GlobalMessages/crowdin-global-f.conf
@@ -1,5 +1,4 @@
 [crowdin.project]
-product_person="mike.holmes"
 projectid="ext-GlobalMessages-F"
 format="mediawiki"
 source.file="GlobalMessagesF.i18n.php"

--- a/includes/DefaultSettings.php
+++ b/includes/DefaultSettings.php
@@ -724,9 +724,9 @@ $wgAllowTitlesInSVG = false;
  * JPEGs with ImageMagick, and when using the VipsScaler extension.
  *
  * The default is 50 MB if decompressed to RGBA form, which corresponds to
- * 12.5 million pixels or 3500x3500. - changed to 60MP: SUS-1393
+ * 12.5 million pixels or 3500x3500.
  */
-$wgMaxImageArea = 6e7;
+$wgMaxImageArea = 1.25e7;
 /**
  * Force thumbnailing of animated GIFs above this size to a single
  * frame instead of an animated thumbnail.  As of MW 1.17 this limit

--- a/includes/upload/UploadBase.php
+++ b/includes/upload/UploadBase.php
@@ -231,8 +231,6 @@ abstract class UploadBase {
 	 * @return mixed self::OK or else an array with error information
 	 */
 	public function verifyUpload() {
-		global $wgMaxImageArea;
-
 		/**
 		 * If there was no filename or a zero size given, give up quick.
 		 */
@@ -250,25 +248,6 @@ abstract class UploadBase {
 				'max' => $maxSize,
 			);
 		}
-
-		// Wikia change - check if image resolution does not exceed wgMaxImageArea - @author: ryba
-		$imgInfo = getimagesize($this->mUpload->getTempName());
-		$imgWidth = $imgInfo[0];
-		$imgHeight = $imgInfo[1];
-		$mime = $imgInfo['mime'];
-		$imageResolution = $imgHeight * $imgWidth;
-		if ( $imageResolution > $wgMaxImageArea ) {
-			return [
-				'status' => self::VERIFICATION_ERROR,
-				'details' => [
-					'file-resolution-exceeded',
-					round( $imageResolution / 1000000, 2 ),
-					round( $wgMaxImageArea / 1000000, 2 ),
-					$mime
-				]
-			];
-		}
-		// Wikia change - end
 
 		/**
 		 * Look at the contents of the file; if we can recognize the

--- a/skins/oasis/modules/UploadPhotosController.class.php
+++ b/skins/oasis/modules/UploadPhotosController.class.php
@@ -147,13 +147,7 @@ class UploadPhotosController extends WikiaController {
 				break;
 
 			case UploadBase::VERIFICATION_ERROR:
-				$message = wfMessage( array_shift( $details['details'] ) );
-
-				if ( count( $details['details'] ) > 1 ) {
-					$message->numParams( $details['details'] );
-				}
-
-				$msg = $message->escaped();
+				$msg = wfMessage($details['details'][0])->escaped();
 				break;
 
 			case UploadBase::UPLOAD_VERIFICATION_ERROR:


### PR DESCRIPTION
This reverts commit d650274fb4889bdfe37dffec6651fe8dbd1d9990, reversing
changes made to d06480e7592b0e3fc6dd5c4439b72f654bc5cdf1.

Reverts #13580 that caused the following:

```
Unexpected non-MediaWiki exception encountered, of type "Error"
Error: Call to a member function getTempName() on null in /usr/wikia/slot1/19216/src/includes/upload/UploadBase.php:255
Stack trace:
0 /usr/wikia/slot1/19216/src/includes/upload/UploadFromUrl.php(202): UploadBase->verifyUpload()
1 /usr/wikia/slot1/19216/src/extensions/wikia/VideoHandlers/VideoFileUploader.class.php(334): UploadFromUrl->verifyUpload()
2 /usr/wikia/slot1/19216/src/extensions/wikia/VideoHandlers/VideoFileUploader.class.php(282): VideoFileUploader->uploadThumbnailFromUrl('https://i.ytimg...')
3 /usr/wikia/slot1/19216/src/extensions/wikia/VideoHandlers/VideoFileUploader.class.php(94): VideoFileUploader->uploadBestThumbnail('https://i.ytimg...')
4 /usr/wikia/slot1/19216/src/extensions/wikia/VideoEmbedTool/VideoEmbedTool_body.php(363): VideoFileUploader->upload(NULL)
5 /usr/wikia/slot1/19216/src/extensions/wikia/VideoEmbedTool/VideoEmbedTool_body.php(239): VideoEmbedTool->uploadVideoAsFile('youtube', 'iRvI4c9VsW8', 'Hamradun - Snep...', NULL)
6 /usr/wikia/slot1/19216/src/extensions/wikia/VideoEmbedTool/VideoEmbedTool_setup.php(98): VideoEmbedTool->insertFinalVideo()
7 /usr/wikia/slot1/19216/src/includes/AjaxDispatcher.php(118): VET()
8 /usr/wikia/slot1/19216/src/includes/Wiki.php(629): AjaxDispatcher->performAction()
9 /usr/wikia/slot1/19216/src/includes/Wiki.php(547): MediaWiki->main()
10 /usr/wikia/slot1/19216/src/index.php(58): MediaWiki->run()
11 {main}
```