### PR TITLE
SUS-2695: Support operations on temporary tables in read-only mode

### DIFF
--- a/includes/db/Database.php
+++ b/includes/db/Database.php
@@ -915,7 +915,7 @@ abstract class DatabaseBase implements DatabaseType {
 
 		$this->mLastQuery = $sql;
 		$is_writeable = $this->isWriteQuery( $sql );
-		$isNonTempWrite = !$this->registerTempTableOperation( $sql );
+		$isTemporaryTableOperation = $this->registerTempTableOperation( $sql );
 
 		if ( !$this->mDoneWrites && $is_writeable ) {
 			# Set a flag indicating that writes have been done
@@ -925,7 +925,7 @@ abstract class DatabaseBase implements DatabaseType {
 
 		# <Wikia>
 		global $wgDBReadOnly, $wgReadOnly;
-		if ( $is_writeable && $isNonTempWrite && $wgDBReadOnly ) {
+		if ( $is_writeable && !$isTemporaryTableOperation && $wgDBReadOnly ) {
 			if ( !Profiler::instance()->isStub() ) {
 				wfProfileOut( $queryProf );
 				wfProfileOut( $totalProf );


### PR DESCRIPTION
Port a helper method from upstream to determine if the SQL query to be executed deals with temporary tables, and use it to allow the query to be executed irrespective of global read-only state - MySQL supports operations on temporary tables even in read-only mode.

We already use slaves for such operations in SJC via our custom [QueryEngineDatabaseConnectionProvider](https://github.com/Wikia/SemanticMediaWiki/blob/2.4.2_Wikia/src/MediaWiki/QueryEngineDatabaseConnectionProvider.php) class.

https://wikia-inc.atlassian.net/browse/SUS-2695