### PR TITLE
SUS-2700: Use auto-commit mode for Semantic Drilldown temporary tables

### DIFF
--- a/extensions/SemanticDrilldown/specials/SD_BrowseData.php
+++ b/extensions/SemanticDrilldown/specials/SD_BrowseData.php
@@ -1,4 +1,7 @@
 <?php
+
+use SMW\ApplicationFactory;
+
 /**
  * Displays an interface to let the user drill down through all data on
  * the wiki, using categories and custom-defined filters that have
@@ -149,10 +152,6 @@ class SDBrowseDataPage extends QueryPage {
 		$this->offset = $offset;
 		$this->limit = $limit;
 
-		$dbr = wfGetDB( DB_SLAVE );
-		$categorylinks = $dbr->tableName( 'categorylinks' );
-		$page = $dbr->tableName( 'page' );
-		$cat_ns = NS_CATEGORY;
 		if ( $this->subcategory ) {
 			$actual_cat = str_replace( ' ', '_', $this->subcategory );
 		} else {
@@ -208,14 +207,20 @@ class SDBrowseDataPage extends QueryPage {
 	 * all remaining filters
 	 */
 	function createTempTable( $category, $subcategory, $subcategories, $applied_filters ) {
-		$dbr = wfGetDB( DB_SLAVE, 'smw' );
-		$sql1 = "CREATE TEMPORARY TABLE semantic_drilldown_values ( id INT NOT NULL )";
-		$dbr->query( $sql1 );
-		$sql2 = "CREATE INDEX id_index ON semantic_drilldown_values ( id )";
-		$dbr->query( $sql2 );
-		$sql3 = "INSERT INTO semantic_drilldown_values SELECT ids.smw_id AS id\n";
-		$sql3 .= $this->getSQLFromClause( $category, $subcategory, $subcategories, $applied_filters );
-		$dbr->query( $sql3 );
+		$applicationFactory = ApplicationFactory::getInstance();
+
+		$mwCollaboratorFactory = $applicationFactory->newMwCollaboratorFactory();
+		$queryEngineDatabaseConnectionProvider = $mwCollaboratorFactory->newQueryEngineDatabaseConnectionProvider();
+
+		$databaseConnection = $queryEngineDatabaseConnectionProvider->getConnection();
+
+		$databaseConnection->queryWithAutoCommit( 'CREATE TEMPORARY TABLE semantic_drilldown_values ( id INT NOT NULL )', __METHOD__ );
+		$databaseConnection->queryWithAutoCommit( 'CREATE INDEX id_index ON semantic_drilldown_values ( id )', __METHOD__ );
+		$databaseConnection->queryWithAutoCommit( 'INSERT INTO semantic_drilldown_values SELECT ids.smw_id AS id\n', __METHOD__ );
+
+		$sqlQuery = $this->getSQLFromClause( $category, $subcategory, $subcategories, $applied_filters );
+
+		$databaseConnection->queryWithAutoCommit( $sqlQuery, __METHOD__ );
 	}
 
 	/**
@@ -239,8 +244,6 @@ class SDBrowseDataPage extends QueryPage {
 	 * subcategory's child subcategories, to ensure completeness.
 	 */
 	function getSQLFromClauseForCategory( $subcategory, $child_subcategories ) {
-		global $smwgDefaultStore;
-
 		$dbr = wfGetDB( DB_SLAVE );
 		$smwIDs = $dbr->tableName( SDUtils::getIDsTableName() );
 		$smwCategoryInstances = $dbr->tableName( SDUtils::getCategoryInstancesTableName() );


### PR DESCRIPTION
Avoid the following error with MySQL 5.7:
```
A database error has occurred.  Did you forget to run maintenance/update.php after upgrading?  See: https://www.mediawiki.org/wiki/Manual:Upgrading#Run_the_update_script
Query: CREATE TEMPORARY TABLE semantic_drilldown_values ( id INT NOT NULL )
Function: SDBrowseDataPage:createTempTable
Error: 1787 Statement violates GTID consistency: CREATE TEMPORARY TABLE and DROP TEMPORARY TABLE can only be executed outside transactional context.  These statements are also not allowed in a function or trigger because functions and triggers are also considered to be multi-statement transactions. (geo-db-smw-slave.query.consul)
```
See: https://dev.mysql.com/doc/refman/5.7/en/replication-gtids-restrictions.html

https://wikia-inc.atlassian.net/browse/SUS-2700
