### PR TITLE
SUS-1422: Have Semantic Forms connect to dedicated SMW cluster

### DIFF
--- a/extensions/SemanticForms/includes/SF_AutocompleteAPI.php
+++ b/extensions/SemanticForms/includes/SF_AutocompleteAPI.php
@@ -150,7 +150,7 @@ class SFAutocompleteAPI extends ApiBase {
 		global $smwgDefaultStore;
 
 		$values = array();
-		$db = wfGetDB( DB_SLAVE );
+		$db = wfGetDB( DB_SLAVE, 'smw' );
 		$sqlOptions = array();
 		$sqlOptions['LIMIT'] = $sfgMaxAutocompleteValues;
 


### PR DESCRIPTION
We use dedicated cluster for Semantic MediaWiki tables. However some queries made by Semantic Forms extension do not have connection groups properly set. As such they try to connect to local wiki database instead of SMW cluster, where the SMW tables do not exist. This error can be prevented by making sure proper group is used when acquiring a connection.

https://wikia-inc.atlassian.net/browse/SUS-1422