### PR TITLE
SUS-2656 | Some file pages are giving 500 error

### DIFF
--- a/extensions/wikia/ImageReview/ImageReviewImageStatus.php
+++ b/extensions/wikia/ImageReview/ImageReviewImageStatus.php
@@ -50,7 +50,7 @@ function efImageReviewDisplayStatus( ImagePage $imagePage, &$html ) {
 			 * If the file is a local one and is older than 1 hour - send it to ImageReview
 			 * since it's probably been restored, and is not just a fresh file.
 			 */
-			$lastTouched = new DateTime( $imagePage->getRevisionFetched()->getTimestamp() );
+			$lastTouched = new DateTime( $imagePage->getPage()->getTouched() );
 			$now = new DateTime();
 			$file = $imagePage->getDisplayedFile();
 			if ( $file instanceof WikiaLocalFile && $lastTouched < $now->modify( '-1 hour' ) ) {


### PR DESCRIPTION
Prevent https://wikia-inc.atlassian.net/browse/SUS-2656

```
/usr/wikia/slot1/19292/src/extensions/wikia/ImageReview/ImageReviewImageStatus.php:53
Call to a member function getTimestamp() on null
/usr/wikia/slot1/19292/src/includes/Hooks.php:206, /usr/wikia/slot1/19292/src/includes/ImagePage.php:210, /usr/wikia/slot1/19292/src/extensions/wikia/FilePage/FilePageTabbed.php:87, /usr/wikia/slot1/19292/src/includes/ImagePage.php:141, /usr/wikia/slot1/19292/src/includes/actions/ViewAction.php:40, /usr/wikia/slot1/19292/src/includes/Wiki.php:528, /usr/wikia/slot1/19292/src/includes/Wiki.php:307, /usr/wikia/slot1/19292/src/includes/Wiki.php:667, /usr/wikia/slot1/19292/src/includes/Wiki.php:547, /usr/wikia/slot1/19292/src/index.php:58
```