### PR TITLE
SUS-2628: Allow Phalanx to be synchronised using RabbitMQ queue

### DIFF
--- a/extensions/wikia/PhalanxII/services/PhalanxService.class.php
+++ b/extensions/wikia/PhalanxII/services/PhalanxService.class.php
@@ -131,9 +131,9 @@ class PhalanxService {
 			: [];
 
 		$result = $this->sendToPhalanxDaemon( "reload", $params );
-		$queue_result = $this->sendToPhalanxQueue( $changed );
+		$this->sendToPhalanxQueue( $changed );
 		wfProfileOut( __METHOD__ );
-		return $result && $queue_result;
+		return $result;
 	}
 
 	private function sendToPhalanxQueue( $changed ) {
@@ -143,7 +143,6 @@ class PhalanxService {
 		$rabbitConnection = new ConnectionBase( $wgPhalanxQueue );
 		$rabbitConnection->publish ( self::ROUTING_KEY, implode( ",", $changed ) );
 		wfProfileOut( __METHOD__ );
-		return true;
 	}
 
 	/**

--- a/extensions/wikia/PhalanxII/services/PhalanxService.class.php
+++ b/extensions/wikia/PhalanxII/services/PhalanxService.class.php
@@ -137,12 +137,10 @@ class PhalanxService {
 	}
 
 	private function sendToPhalanxQueue( $changed ) {
-		wfProfileIn( __METHOD__ );
 		global $wgPhalanxQueue;
 
 		$rabbitConnection = new ConnectionBase( $wgPhalanxQueue );
 		$rabbitConnection->publish ( self::ROUTING_KEY, implode( ",", $changed ) );
-		wfProfileOut( __METHOD__ );
 	}
 
 	/**

--- a/extensions/wikia/PhalanxII/services/PhalanxService.class.php
+++ b/extensions/wikia/PhalanxII/services/PhalanxService.class.php
@@ -1,6 +1,7 @@
 <?php
 
 use Wikia\Service\Gateway\ConsulUrlProvider;
+use Wikia\Rabbit\ConnectionBase;
 
 /**
  * @method PhalanxService setLimit( int $limit )
@@ -19,6 +20,7 @@ class PhalanxService {
 	const RES_FAILURE = 'failure';
 	const RES_STATUS = 'PHALANX ALIVE';
 	const PHALANX_LOG_PARAM_LENGTH_LIMIT = 64;
+	const ROUTING_KEY = 'onUpdate';
 
 	// number of retries for phalanx POST requests
 	const PHALANX_SERVICE_TRIES_LIMIT = 3;
@@ -129,8 +131,19 @@ class PhalanxService {
 			: [];
 
 		$result = $this->sendToPhalanxDaemon( "reload", $params );
+		$queue_result = $this->sendToPhalanxQueue( $changed );
 		wfProfileOut( __METHOD__ );
-		return $result;
+		return $result && $queue_result;
+	}
+
+	private function sendToPhalanxQueue( $changed ) {
+		wfProfileIn( __METHOD__ );
+		global $wgPhalanxQueue;
+
+		$rabbitConnection = new ConnectionBase( $wgPhalanxQueue );
+		$rabbitConnection->publish ( self::ROUTING_KEY, implode( ",", $changed ) );
+		wfProfileOut( __METHOD__ );
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
This will send notification to both clusters - Mesos (old) via plain HTTP request and Kubernetes (new) via RabbitMQ queue.

There is companion PR in config repo: https://github.com/Wikia/config/pull/2260

ping: @Wikia/sus 