### PR TITLE
SUS-2218 | Change the default MediaWiki thousands separator for Italian from a "space" to a "dot"

### DIFF
--- a/languages/messages/MessagesIt.php
+++ b/languages/messages/MessagesIt.php
@@ -86,7 +86,9 @@ $namespaceAliases = array(
 	'Discussioni_immagine' => NS_FILE_TALK,
 );
 
-$separatorTransformTable = array( ',' => "\xc2\xa0", '.' => ',' );
+// SUS-2218 | Change the default MediaWiki thousands separator for Italian from a "space" to a "dot"
+// e.g. 12345 will be rendered as 12.345 (instead of 12 345)
+$separatorTransformTable = array( ',' => '.', '.' => ',' );
 
 $dateFormats = array(
 	'mdy time' => 'H:i',


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-2218

## An example

![sus-2218](https://user-images.githubusercontent.com/1929317/30064957-a95484cc-9253-11e7-8040-6fe5f0a7404c.png)
