### PR TITLE
Improve VE handling of permissions & read-only mode

### DIFF
--- a/extensions/VisualEditor/ApiVisualEditor.php
+++ b/extensions/VisualEditor/ApiVisualEditor.php
@@ -371,26 +371,18 @@ class ApiVisualEditor extends ApiBase {
 				RequestContext::getMain()->setTitle( $page );
 				// Wikia change
 				$notices = array();
-				$anoneditwarning = false;
 				$anoneditwarningMessage = $this->msg( 'VisualEditor-anoneditwarning' );
+
 				if ( $user->isAnon() && $anoneditwarningMessage->exists() ) {
 					$notices[] = $anoneditwarningMessage->parseAsBlock();
-					$anoneditwarning = true;
 				}
-				/*
-				$notices = $page->getEditNotices();
-				if ( $user->isAnon() ) {
-					$notices[] = $this->msg(
-						'anoneditwarning',
-						// Log-in link
-						'{{fullurl:Special:UserLogin|returnto={{FULLPAGENAMEE}}}}',
-						// Sign-up link
-						'{{fullurl:Special:UserLogin/signup|returnto={{FULLPAGENAMEE}}}}'
-					)->parseAsBlock();
-				}
-				*/
+
 				if ( $parsed && $parsed['restoring'] ) {
 					$notices[] = $this->msg( 'editingold' )->parseAsBlock();
+				}
+
+				if ( wfReadOnly() ) {
+					$notices[] = $this->msg( 'readonlywarning', wfReadOnlyReason() );
 				}
 
 				// Creating new page
@@ -467,19 +459,6 @@ class ApiVisualEditor extends ApiBase {
 					// Some upstream code is deleted from here, more information:
 					// https://github.com/Wikia/app/commit/d54b481d3f6e5b092b212a2c98b2cb5452bee26c
 					// https://github.com/Wikia/app/commit/681e7437078206460f7c0cb1837095e656d8ba85
-				}
-
-				if ( class_exists( 'GlobalBlocking' ) ) {
-					$error = GlobalBlocking::getUserBlockErrors(
-						$user,
-						$this->getRequest()->getIP()
-					);
-					if ( count( $error ) ) {
-						$notices[] = call_user_func_array(
-							array( $this, 'msg' ),
-							$error
-						)->parseAsBlock();
-					}
 				}
 
 				// HACK: Build a fake EditPage so we can get checkboxes from it
@@ -670,7 +649,7 @@ class ApiVisualEditor extends ApiBase {
 	}
 
 	public function isWriteMode() {
-		return true;
+		return false;
 	}
 
 	/**

--- a/extensions/VisualEditor/ApiVisualEditorEdit.php
+++ b/extensions/VisualEditor/ApiVisualEditorEdit.php
@@ -10,8 +10,9 @@
 
 class ApiVisualEditorEdit extends ApiVisualEditor {
 
-	public function __construct( ApiMain $main, $name /*, Config $config */ ) {
-		parent::__construct( $main, $name, $config );
+	public function __construct( ApiMain $main, $name ) {
+		parent::__construct( $main, $name );
+		$main->setShouldCheckWriteApiPermission( false );
 	}
 
 	protected function saveWikitext( $title, $wikitext, $params ) {
@@ -47,6 +48,7 @@ class ApiVisualEditorEdit extends ApiVisualEditor {
 			true // enable write
 		);
 
+		$api->setShouldCheckWriteApiPermission( false );
 		$api->execute();
 
 		return $api->getResultData();

--- a/extensions/VisualEditor/modules/ve-mw/init/targets/ve.init.mw.ViewPageTarget.js
+++ b/extensions/VisualEditor/modules/ve-mw/init/targets/ve.init.mw.ViewPageTarget.js
@@ -82,6 +82,7 @@ ve.init.mw.ViewPageTarget = function VeInitMwViewPageTarget() {
 		saveErrorAbuseFilter: 'onSaveErrorAbuseFilter',
 		saveErrorNewUser: 'onSaveErrorNewUser',
 		saveErrorCaptcha: 'onSaveErrorCaptcha',
+		saveErrorReadOnly: 'onSaveErrorReadOnly',
 		saveErrorUnknown: 'onSaveErrorUnknown',
 		saveErrorPageDeleted: 'onSaveErrorPageDeleted',
 		loadError: 'onLoadError',
@@ -762,6 +763,17 @@ ve.init.mw.ViewPageTarget.prototype.onSaveErrorUnknown = function ( editApi, dat
 		) ),
 		false // prevents reapply
 	);
+};
+
+/**
+ * Update save dialog message if database is in read-only state
+ *
+ * @method
+ * @param {Object} editApi
+ * @param {Object} data
+ */
+ve.init.mw.ViewPageTarget.prototype.onSaveErrorReadOnly = function ( editApi, data ) {
+	this.showSaveError( $( $.parseHTML( mw.message( 'readonlywarning', data.error.readonlyreason ).parse() ) ), true, true );
 };
 
 /**

--- a/extensions/VisualEditor/modules/ve-mw/init/ve.init.mw.Target.js
+++ b/extensions/VisualEditor/modules/ve-mw/init/ve.init.mw.Target.js
@@ -136,6 +136,13 @@ OO.inheritClass( ve.init.mw.Target, ve.init.Target );
  */
 
 /**
+ * @event saveErrorReadOnly
+ * Fired when the user tries to save page but the database is locked
+ * @param {Object} editApi
+ * @param {Object} data API response data
+ */
+
+/**
  * @event saveErrorUnknown
  * Fired for any other type of save error
  * @param {Object} editApi
@@ -692,6 +699,8 @@ ve.init.mw.Target.prototype.onSaveError = function ( doc, saveData, jqXHR, statu
 		return;
 	} else if ( data.error && data.error.code === 'pagedeleted' ) {
 		this.emit( 'saveErrorPageDeleted' );
+	} else if ( data.error && data.error.code === 'readonly' ) {
+		this.emit( 'saveErrorReadOnly' );
 	}
 
 	// Handle captcha

--- a/includes/api/ApiMain.php
+++ b/includes/api/ApiMain.php
@@ -136,6 +136,12 @@ class ApiMain extends ApiBase {
 	private $mCacheControl = array();
 
 	/**
+	 * Wikia change - fix visualeditor api permissions
+	 * @var bool $shouldCheckWriteApiPermission
+	 */
+	private $shouldCheckWriteApiPermission = true;
+
+	/**
 	 * Constructs an instance of ApiMain that utilizes the module and format specified by $request.
 	 *
 	 * @param $context IContextSource|WebRequest - if this is an instance of FauxRequest, errors are thrown and no printing occurs
@@ -652,6 +658,13 @@ class ApiMain extends ApiBase {
 	}
 
 	/**
+	 * @param bool $shouldCheckWriteApiPermission
+	 */
+	public function setShouldCheckWriteApiPermission( bool $shouldCheckWriteApiPermission ) {
+		$this->shouldCheckWriteApiPermission = $shouldCheckWriteApiPermission;
+	}
+
+	/**
 	 * Check for sufficient permissions to execute
 	 * @param $module ApiBase An Api module
 	 */
@@ -671,7 +684,7 @@ class ApiMain extends ApiBase {
 			if ( !$this->mEnableWrite ) {
 				$this->dieUsageMsg( 'writedisabled' );
 			}
-			if ( !$user->isAllowed( 'writeapi' ) ) {
+			if ( $this->shouldCheckWriteApiPermission && !$user->isAllowed( 'writeapi' ) ) {
 				$this->dieUsageMsg( 'writerequired' );
 			}
 			if ( wfReadOnly() ) {


### PR DESCRIPTION
* Port https://github.com/wikimedia/mediawiki-extensions-VisualEditor/commit/d2a9aefba707544779be5dc209efd0417b60ea34 from upstream - `ApiVisualEditor` is not write mode
* make `ApiVisualEditorEdit` act like everyone was allowed `writeapi` (hack)