### PR TITLE
SUS-2680 | MediaWiki:Block shows an English text on RecentChanges page if admin rollbacks edit

### DIFF
--- a/includes/WikiPage.php
+++ b/includes/WikiPage.php
@@ -2463,9 +2463,9 @@ class WikiPage extends Page implements IDBAccessObject {
 		$target = Revision::newFromId( $s->rev_id );
 		if ( empty( $summary ) ) {
 			if ( $from == '' ) { // no public user name
-				$summary = wfMsgForContent( 'revertpage-nouser' );
+				$summary = wfMessage( 'revertpage-nouser' );
 			} else {
-				$summary = wfMsgForContent( 'revertpage' );
+				$summary = wfMessage( 'revertpage' );
 			}
 		}
 
@@ -2483,7 +2483,15 @@ class WikiPage extends Page implements IDBAccessObject {
 			$wgContLang->timeanddate( wfTimestamp( TS_MW, $s->rev_timestamp ) ),
 			$current->getId(), $wgContLang->timeanddate( $current->getTimestamp() )
 		);
-		$summary = wfMsgReplaceArgs( $summary, $args );
+
+		if ( $summary instanceof Message ) {
+			$summary = $summary->params( $args )->inContentLanguage()->text();
+		} else {
+			$summary = wfMsgReplaceArgs( $summary, $args );
+		}
+
+		// Trim spaces on user supplied text
+		$summary = trim( $summary );
 
 		# Save
 		$flags = EDIT_UPDATE;


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-2680

Let's use content language when generating rollback summary message. This can't be localized using user language settings as the generated summary is stored in `recentchanges` table in `rc_comment` column. 

Partially backporting https://github.com/wikimedia/mediawiki/commit/475a1daa03da8308f7356ebf01026fc1843d9b95#diff-c2d3a4adc1db4ce7005da86c0e73080dR2421 from MW 1.20

Replace some occurrences of wfMsg* by alternatives. Undeprecated wfMsgReplaceArgs.

## An example

![sus-2680](https://user-images.githubusercontent.com/1929317/30110631-063005ec-930b-11e7-95c5-cf87aa4cb91a.png)
