### PR TITLE
SUS-2733 | CuratedContentController::extendItemsWithImages - keep continuous keys in the returned array so that it can be JSON-encoded as an array rather than an object

### DIFF
--- a/extensions/wikia/CuratedContent/CuratedContentController.class.php
+++ b/extensions/wikia/CuratedContent/CuratedContentController.class.php
@@ -461,8 +461,9 @@ class CuratedContentController extends WikiaController {
 		}, [ ] );
 	}
 
-	private function extendItemsWithImages( array $items ) {
-		return array_map( [ $this, 'extendWithImageData' ], $items );
+	private function extendItemsWithImages( array $items ) : array {
+		// SUS-2733 | keep continuous keys in the returned array so that it can be JSON-encoded as an array rather than an object
+		return array_values( array_map( [ $this, 'extendWithImageData' ], $items ) );
 	}
 
 	private function extendWithImageData( $item ) {


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-2733

Following request:

http://mario.wikia.com/wikia.php?controller=CuratedContent&method=getList

returns `items` field which should be a list but it's an object. For other communities the response is correct:

http://de.teenwolf.wikia.com/wikia.php?controller=CuratedContent&method=getList
http://cocktails.wikia.com/wikia.php?controller=CuratedContent&method=getList
http://ru.elderscrolls.wikia.com/wikia.php?controller=CuratedContent&method=getList