### PR TITLE
SUS-1777: Avoid potential error on RecentChanges

### DIFF
--- a/extensions/wikia/Wall/WallHelper.class.php
+++ b/extensions/wikia/Wall/WallHelper.class.php
@@ -587,7 +587,7 @@ class WallHelper {
 			// change in NS_USER_WALL namespace mean that wall page was created (bugid:95249)
 			$title = Title::makeTitle( NS_USER_WALL, $row->page_title );
 
-			$out = [
+			return [
 				'articleTitle' => $title->getPrefixedText(),
 				'articleFullUrl' => $title->getFullUrl(),
 				'articleTitleVal' => '',
@@ -599,8 +599,6 @@ class WallHelper {
 				'isThread' => true,
 				'isNew' => $isNew
 			];
-
-			return $out;
 		}
 
 		$wm = WallMessage::newFromId( $objTitle->getArticleId() );
@@ -634,7 +632,7 @@ class WallHelper {
 
 		$title = Title::makeTitle( NS_USER_WALL_MESSAGE, $articleId );
 
-		$out = [
+		return [
 			'articleTitle' => $title->getPrefixedText(),
 			'articleFullUrl' => $wm->getMessagePageUrl(),
 			'articleTitleVal' => $articleTitleTxt,
@@ -646,7 +644,5 @@ class WallHelper {
 			'isThread' => $wm->isMain(),
 			'isNew' => $isNew
 		];
-
-		return $out;
 	}
 }

--- a/extensions/wikia/Wall/WallHelper.class.php
+++ b/extensions/wikia/Wall/WallHelper.class.php
@@ -560,7 +560,7 @@ class WallHelper {
 	 */
 	public static function getWallTitleData( $rc = null, $row = null ) {
 		if ( is_object( $row ) ) {
-			$objTitle = Title::newFromText( $row->page_title, $row->page_namespace );
+			$objTitle = Title::makeTitle( $row->page_namespace, $row->page_title );
 			$userText = !empty( $row->rev_user_text ) ? $row->rev_user_text : '';
 
 			$isNew = ( !empty( $row->page_is_new ) && $row->page_is_new === '1' ) ? true : false;
@@ -583,18 +583,16 @@ class WallHelper {
 		}
 
 		// SUS-1777: Don't bother trying to load Wall Message if this is the Wall itself
-		if ( $row->page_namespace === NS_USER_WALL ) {
+		if ( $objTitle->inNamespace( NS_USER_WALL ) ) {
 			// change in NS_USER_WALL namespace mean that wall page was created (bugid:95249)
-			$title = Title::makeTitle( NS_USER_WALL, $row->page_title );
-
 			return [
-				'articleTitle' => $title->getPrefixedText(),
-				'articleFullUrl' => $title->getFullUrl(),
+				'articleTitle' => $objTitle->getPrefixedText(),
+				'articleFullUrl' => $objTitle->getFullUrl(),
 				'articleTitleVal' => '',
 				'articleTitleTxt' => wfMessage(  'wall-recentchanges-wall-created-title' )->text(),
-				'wallTitleTxt' => $title->getPrefixedText(),
-				'wallPageFullUrl' =>  $title->getFullUrl(),
-				'wallPageName' => $row->page_title,
+				'wallTitleTxt' => $objTitle->getPrefixedText(),
+				'wallPageFullUrl' =>  $objTitle->getFullUrl(),
+				'wallPageName' => $objTitle->getText(),
 				'actionUser' => $userText,
 				'isThread' => true,
 				'isNew' => $isNew

--- a/extensions/wikia/Wall/WallMessage.class.php
+++ b/extensions/wikia/Wall/WallMessage.class.php
@@ -667,7 +667,7 @@ class WallMessage {
 
 		$postFix = $this->getPageUrlPostFix();
 		$postFix = empty( $postFix ) ? "" : ( '#' . $postFix );
-		$title = Title::newFromText( $id, NS_USER_WALL_MESSAGE );
+		$title = Title::makeTitle( NS_USER_WALL_MESSAGE, $id );
 
 		$this->messagePageUrl = [ ];
 


### PR DESCRIPTION
Don't bother trying to load comments index info if this is the Wall itself, there won't be any. Also swapped a few `Title::newFromText` calls to more efficient `makeTitle` where it made sense to do so.

https://wikia-inc.atlassian.net/browse/SUS-1777