### PR TITLE
SUS-2700: Semantic Drilldown - Use same database connection for temporary tables

### DIFF
--- a/extensions/SemanticDrilldown/SemanticDrilldown.php
+++ b/extensions/SemanticDrilldown/SemanticDrilldown.php
@@ -57,6 +57,7 @@ $wgAutoloadClasses['SDFilterValue'] = $sdgIP . '/includes/SD_FilterValue.php';
 $wgAutoloadClasses['SDAppliedFilter'] = $sdgIP . '/includes/SD_AppliedFilter.php';
 $wgAutoloadClasses['SDPageSchemas'] = $sdgIP . '/includes/SD_PageSchemas.php';
 $wgAutoloadClasses['SDParserFunctions'] = $sdgIP . '/includes/SD_ParserFunctions.php';
+$wgAutoloadClasses['TemporaryTableManager'] = "$sdgIP/includes/TemporaryTableManager.php";
 
 $wgHooks['smwInitProperties'][] = 'sdfInitProperties';
 $wgHooks['AdminLinks'][] = 'SDUtils::addToAdminLinks';

--- a/extensions/SemanticDrilldown/includes/SD_Filter.php
+++ b/extensions/SemanticDrilldown/includes/SD_Filter.php
@@ -325,7 +325,6 @@ END;
 				$date_string = SDUtils::monthToString( $row[1] ) . ' ' . $row[2] . ', ' . $row[0];
 				$possible_dates[$date_string] = $row[3];
 			} elseif ( $this->getTimePeriod() == 'month' ) {
-				global $sdgMonthValues;
 				$date_string = SDUtils::monthToString( $row[1] ) . ' ' . $row[0];
 				$possible_dates[$date_string] = $row[2];
 			} elseif ( $this->getTimePeriod() == 'year' ) {
@@ -403,7 +402,6 @@ END;
 		$smw_ids = $dbr->tableName( SDUtils::getIDsTableName() );
 		$valuesTable = $dbr->tableName( $this->getTableName() );
 		$value_field = $this->getValueField();
-		$property_field = 'p_id';
 		$query_property = $this->escaped_property;
 
 		$sql = <<<END
@@ -417,7 +415,9 @@ END;
 			$sql .= "	JOIN $smw_ids o_ids ON $valuesTable.o_id = o_ids.smw_id\n";
 		}
 		$sql .= "	WHERE p_ids.smw_title = '$query_property'";
-		$dbr->query( $sql );
+
+		$temporaryTableManager = new TemporaryTableManager( $dbr );
+		$temporaryTableManager->queryWithAutoCommit( $sql, __METHOD__ );
 	}
 
 	/**
@@ -425,9 +425,11 @@ END;
 	 */
 	function dropTempTable() {
 		$dbr = wfGetDB( DB_SLAVE, 'smw' );
+		$temporaryTableManager = new TemporaryTableManager( $dbr );
+
 		// DROP TEMPORARY TABLE would be marginally safer, but it's
 		// not supported on all RDBMS's.
 		$sql = "DROP TABLE semantic_drilldown_filter_values";
-		$dbr->query( $sql );
+		$temporaryTableManager->queryWithAutoCommit( $sql, __METHOD__ );
 	}
 }

--- a/extensions/SemanticDrilldown/includes/TemporaryTableManager.php
+++ b/extensions/SemanticDrilldown/includes/TemporaryTableManager.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Class TemporaryTableManager helps execute temporary table operations in auto-commit mode
+ */
+class TemporaryTableManager {
+	/** @var DatabaseBase $databaseConnection */
+	private $databaseConnection;
+
+	/**
+	 * TemporaryTableManager constructor.
+	 * @param DatabaseBase $databaseConnection the DB connection to execute queries against
+	 */
+	public function __construct( $databaseConnection ) {
+		$this->databaseConnection = $databaseConnection;
+	}
+
+	/**
+	 * Execute the given SQL query against the database in auto-commit mode.
+	 * If a transaction was already open (via DBO_TRX flag), it is committed.
+	 *
+	 * @param string $sqlQuery SQL query to execute
+	 * @param string $method method name to log for query, defaults to this method
+	 */
+	public function queryWithAutoCommit( $sqlQuery, $method = __METHOD__ ) {
+		$wasAutoTrx = $this->databaseConnection->getFlag( DBO_TRX );
+		$this->databaseConnection->clearFlag( DBO_TRX );
+
+		// If a transaction was automatically started on first query, make sure we commit it
+		if ( $wasAutoTrx && $this->databaseConnection->trxLevel() ) {
+			$this->databaseConnection->commit( __METHOD__ );
+		}
+
+		$this->databaseConnection->query( $sqlQuery, $method );
+
+		if ( $wasAutoTrx ) {
+			$this->databaseConnection->setFlag( DBO_TRX );
+		}
+	}
+}

--- a/extensions/SemanticDrilldown/specials/SD_BrowseData.php
+++ b/extensions/SemanticDrilldown/specials/SD_BrowseData.php
@@ -1,7 +1,5 @@
 <?php
 
-use SMW\ApplicationFactory;
-
 /**
  * Displays an interface to let the user drill down through all data on
  * the wiki, using categories and custom-defined filters that have
@@ -22,7 +20,7 @@ class SDBrowseData extends IncludableSpecialPage {
 
 	function execute( $query ) {
 		global $wgRequest, $wgOut, $wgTitle;
-		global $sdgScriptPath, $sdgContLang, $sdgNumResultsPerPage;
+		global $sdgScriptPath, $sdgNumResultsPerPage;
 
 		if ( $wgTitle->getNamespace() != NS_SPECIAL ) {
 			global $wgParser;
@@ -207,21 +205,17 @@ class SDBrowseDataPage extends QueryPage {
 	 * all remaining filters
 	 */
 	function createTempTable( $category, $subcategory, $subcategories, $applied_filters ) {
-		$applicationFactory = ApplicationFactory::getInstance();
+		$databaseConnection = wfGetDB( DB_SLAVE, 'smw' );
+		$temporaryTableManager = new TemporaryTableManager( $databaseConnection );
 
-		$mwCollaboratorFactory = $applicationFactory->newMwCollaboratorFactory();
-		$queryEngineDatabaseConnectionProvider = $mwCollaboratorFactory->newQueryEngineDatabaseConnectionProvider();
-
-		$databaseConnection = $queryEngineDatabaseConnectionProvider->getConnection();
-
-		$databaseConnection->queryWithAutoCommit( 'CREATE TEMPORARY TABLE semantic_drilldown_values ( id INT NOT NULL )', __METHOD__ );
-		$databaseConnection->queryWithAutoCommit( 'CREATE INDEX id_index ON semantic_drilldown_values ( id )', __METHOD__ );
+		$temporaryTableManager->queryWithAutoCommit( 'CREATE TEMPORARY TABLE semantic_drilldown_values ( id INT NOT NULL )', __METHOD__ );
+		$temporaryTableManager->queryWithAutoCommit( 'CREATE INDEX id_index ON semantic_drilldown_values ( id )', __METHOD__ );
 
 		$sqlQuery = 'INSERT INTO semantic_drilldown_values SELECT ids.smw_id AS id' . PHP_EOL;
 		$sqlQuery .= $this->getSQLFromClause( $category, $subcategory, $subcategories,
 			$applied_filters );
 
-		$databaseConnection->queryWithAutoCommit( $sqlQuery, __METHOD__ );
+		$temporaryTableManager->queryWithAutoCommit( $sqlQuery, __METHOD__ );
 	}
 
 	/**


### PR DESCRIPTION
Multiple calls to `wfGetDB( DB_SLAVE )` during the course of one request will always return the same object, unless the underlying connection or load balancer is manually destroyed. However SMW DAO layer uses different load balancer. So let's only use `wfGetDB` in Semantic Drilldown when dealing with temporary tables, else we end up with weird database errors.

https://wikia-inc.atlassian.net/browse/SUS-2700
refs https://phabricator.wikimedia.org/T174908