### PR TITLE
SUS-2741: Changed use of tag_summary to use change_tag with GROUP_CONCAT()

### DIFF
--- a/includes/ChangeTags.php
+++ b/includes/ChangeTags.php
@@ -176,10 +176,10 @@ class ChangeTags {
 			throw new MWException( 'Unable to determine appropriate JOIN condition for tagging.' );
 		}
 
-		// JOIN on tag_summary
-		$tables[] = 'tag_summary';
-		$join_conds['tag_summary'] = array( 'LEFT JOIN', "ts_$join_cond=$join_cond" );
-		$fields[] = 'ts_tags';
+		// SUS-2741: ported from MW 1.23, adjusted for compatibility
+		$fields[] = wfGetDB( DB_SLAVE )->buildGroupConcatField(
+			',', 'change_tag', 'ct_tag', "ct_$join_cond=$join_cond"
+		) . ' AS ts_tags';
 
 		if( $wgUseTagFilter && $filter_tag ) {
 			// Somebody wants to filter on a tag.

--- a/includes/db/Database.php
+++ b/includes/db/Database.php
@@ -2074,6 +2074,38 @@ abstract class DatabaseBase implements DatabaseType {
 	}
 
 	/**
+	 * Build a concatenation list to feed into a SQL query
+	 * @param array $stringList list of raw SQL expressions; caller is responsible for any quoting
+	 * @return String
+	 */
+	public function buildConcat( $stringList ) {
+		return 'CONCAT(' . implode( ',', $stringList ) . ')';
+	}
+
+	/**
+	 * Build a GROUP_CONCAT or equivalent statement for a query.
+	 *
+	 * This is useful for combining a field for several rows into a single string.
+	 * NULL values will not appear in the output, duplicated values will appear,
+	 * and the resulting delimiter-separated values have no defined sort order.
+	 * Code using the results may need to use the PHP unique() or sort() methods.
+	 *
+	 * @param string $delim Glue to bind the results together
+	 * @param string|array $table Table name
+	 * @param string $field Field name
+	 * @param string|array $conds Conditions
+	 * @param string|array $join_conds Join conditions
+	 * @return String SQL text
+	 * @since 1.23
+	 */
+	public function buildGroupConcatField(
+		$delim, $table, $field, $conds = '', $join_conds = array()
+	) {
+		$fld = "GROUP_CONCAT($field SEPARATOR " . $this->addQuotes( $delim ) . ')';
+		return '(' . $this->selectSQLText( $table, $fld, $conds, null, array(), $join_conds ) . ')';
+	}
+
+	/**
 	 * Change the current database
 	 *
 	 * @todo Explain what exactly will fail if this is not overridden.
@@ -3563,15 +3595,6 @@ abstract class DatabaseBase implements DatabaseType {
 	 */
 	protected function indexNameCallback( $matches ) {
 		return $this->indexName( $matches[1] );
-	}
-
-	/**
-	 * Build a concatenation list to feed into a SQL query
-	 * @param $stringList Array: list of raw SQL expressions; caller is responsible for any quoting
-	 * @return String
-	 */
-	function buildConcat( $stringList ) {
-		return 'CONCAT(' . implode( ',', $stringList ) . ')';
 	}
 
 	/**

--- a/includes/db/DatabaseOracle.php
+++ b/includes/db/DatabaseOracle.php
@@ -1315,6 +1315,13 @@ class DatabaseOracle extends DatabaseBase {
 		return $this->mServer;
 	}
 
+	public function buildGroupConcatField(
+		$delim, $table, $field, $conds = '', $join_conds = array()
+	) {
+		$fld = "LISTAGG($field," . $this->addQuotes( $delim ) . ") WITHIN GROUP (ORDER BY $field)";
+		return '(' . $this->selectSQLText( $table, $fld, $conds, null, array(), $join_conds ) . ')';
+	}
+
 	public function getSearchEngine() {
 		return 'SearchOracle';
 	}

--- a/includes/db/DatabasePostgres.php
+++ b/includes/db/DatabasePostgres.php
@@ -1003,6 +1003,13 @@ SQL;
 		return implode( ' || ', $stringList );
 	}
 
+	public function buildGroupConcatField(
+		$delimiter, $table, $field, $conds = '', $options = array(), $join_conds = array()
+	) {
+		$fld = "array_to_string(array_agg($field)," . $this->addQuotes( $delimiter ) . ')';
+		return '(' . $this->selectSQLText( $table, $fld, $conds, null, array(), $join_conds ) . ')';
+	}
+
 	public function getSearchEngine() {
 		return 'SearchPostgres';
 	}

--- a/includes/db/DatabaseSqlite.php
+++ b/includes/db/DatabaseSqlite.php
@@ -787,6 +787,13 @@ class DatabaseSqlite extends DatabaseBase {
 		return '(' . implode( ') || (', $stringList ) . ')';
 	}
 
+	public function buildGroupConcatField(
+		$delim, $table, $field, $conds = '', $join_conds = array()
+	) {
+		$fld = "group_concat($field," . $this->addQuotes( $delim ) . ')';
+		return '(' . $this->selectSQLText( $table, $fld, $conds, null, array(), $join_conds ) . ')';
+	}
+
 	/**
 	 * @throws MWException
 	 * @param $oldName


### PR DESCRIPTION
Port of [r95584](https://gerrit.wikimedia.org/r/#/c/95584/) from upstream. More context in [T55577](https://phabricator.wikimedia.org/T55577) (including `EXPLAIN`s).

This helps avoid suboptimal execution plans involving full table scan on `tag_summary` table.

https://wikia-inc.atlassian.net/browse/SUS-2741

## Comparison of execution plans
```
explain SELECT /* IndexPager::reallyDoQuery (LogPager) QuimeraMC - 9c5ad490-b7d0-45ea-a3ec-574664ff2c5d */  log_id,log_type,log_action,log_timestamp,log_user,log_user_text,log_namespace,log_title,log_comment,log_params,log_deleted,user_id,user_name,user_editcount,ts_tags  FROM `logging` LEFT JOIN `wikicities_c3`.`user` ON ((log_user=user_id)) LEFT JOIN `tag_summary` ON ((ts_log_id=log_id))  WHERE (log_type NOT IN ('suppress','piggyback','chatconnect','editaccnt','phalanx','phalanxemail','StaffLog')) AND log_type = 'newusers'  ORDER BY log_timestamp DESC LIMIT 51;
+----+-------------+-------------+------------+--------+-----------------------+-----------+---------+--------------------------------+--------+----------+--------------------------------------------------------+
| id | select_type | table       | partitions | type   | possible_keys         | key       | key_len | ref                            | rows   | filtered | Extra                                                  |
+----+-------------+-------------+------------+--------+-----------------------+-----------+---------+--------------------------------+--------+----------+--------------------------------------------------------+
|  1 | SIMPLE      | logging     | NULL       | ref    | type_time,type_action | type_time | 34      | const                          |  31864 |   100.00 | Using index condition; Using temporary; Using filesort |
|  1 | SIMPLE      | user        | NULL       | eq_ref | PRIMARY               | PRIMARY   | 4       | escreepypasta.logging.log_user |      1 |   100.00 | NULL                                                   |
|  1 | SIMPLE      | tag_summary | NULL       | ALL    | tag_summary_log_id    | NULL      | NULL    | NULL                           | 120093 |   100.00 | Using where; Using join buffer (Block Nested Loop)     |
+----+-------------+-------------+------------+--------+-----------------------+-----------+---------+--------------------------------+--------+----------+--------------------------------------------------------+
3 rows in set, 1 warning (0.07 sec)

explain SELECT /* IndexPager::reallyDoQuery (LogPager) QuimeraMC - 9c5ad490-b7d0-45ea-a3ec-574664ff2c5d */  log_id,log_type,log_action,log_timestamp,log_user,log_user_text,log_namespace,log_title,log_comment,log_params,log_deleted,user_id,user_name,user_editcount,(SELECT  GROUP_CONCAT(ct_tag SEPARATOR ',')  FROM `change_tag`  WHERE ct_log_id=log_id  ) AS ts_tags  FROM `logging` LEFT JOIN `wikicities_c3`.`user` ON ((log_user=user_id))  WHERE (log_type NOT IN ('suppress','piggyback','chatconnect','editaccnt','phalanx','phalanxemail','StaffLog')) AND log_type = 'newusers'  ORDER BY log_timestamp DESC LIMIT 51;
+----+--------------------+------------+------------+--------+-----------------------+--------------------+---------+--------------------------------+--------+----------+--------------------------+
| id | select_type        | table      | partitions | type   | possible_keys         | key                | key_len | ref                            | rows   | filtered | Extra                    |
+----+--------------------+------------+------------+--------+-----------------------+--------------------+---------+--------------------------------+--------+----------+--------------------------+
|  1 | PRIMARY            | logging    | NULL       | ref    | type_time,type_action | type_time          | 34      | const                          |  31864 |   100.00 | Using where              |
|  1 | PRIMARY            | user       | NULL       | eq_ref | PRIMARY               | PRIMARY            | 4       | escreepypasta.logging.log_user |      1 |   100.00 | NULL                     |
|  2 | DEPENDENT SUBQUERY | change_tag | NULL       | ref    | change_tag_log_tag    | change_tag_log_tag | 5       | escreepypasta.logging.log_id   | 152306 |   100.00 | Using where; Using index |
+----+--------------------+------------+------------+--------+-----------------------+--------------------+---------+--------------------------------+--------+----------+--------------------------+
3 rows in set, 2 warnings (0.07 sec)
```