### PR TITLE
XW-3992 | Always fall back in wikitext field

### DIFF
--- a/includes/wikia/models/DesignSystemCommunityHeaderModel.class.php
+++ b/includes/wikia/models/DesignSystemCommunityHeaderModel.class.php
@@ -133,8 +133,7 @@ class DesignSystemCommunityHeaderModel extends WikiaModel {
 				$localNavData = ApiService::foreignCall( WikiFactory::getWikiByID( $this->productInstanceId )->city_dbname, [
 					'controller' => 'NavigationApi',
 					'method' => 'getData',
-					'uselang' => $this->langCode,
-					'wikitext' => $wikitext
+					'uselang' => $this->langCode
 				], ApiService::WIKIA )[ 'navigation' ][ 'wiki' ];
 			}
 


### PR DESCRIPTION
Instead of passing (sometimes malformed) wikitext of nav as a param, let's allow MW to fetch it from DB.