### PR TITLE
XW-3992 | Let MW fall back when fetching navigation wikitext

### DIFF
--- a/includes/wikia/api/NavigationApiController.class.php
+++ b/includes/wikia/api/NavigationApiController.class.php
@@ -17,12 +17,8 @@ class NavigationApiController extends WikiaApiController {
 
 	public function getData() {
 		$model = new NavigationModel();
-		$wikitext = $this->request->getVal( 'wikitext' );
-		if ( !empty($wikitext) ) {
-			$nav = $model->getFormattedWiki( NavigationModel::WIKI_LOCAL_MESSAGE, $wikitext );
-		} else {
-			$nav = $model->getFormattedWiki();
-		}
+
+		$nav = $model->getFormattedWiki( NavigationModel::WIKI_LOCAL_MESSAGE );
 
 		$this->setResponseData(
 			[ 'navigation' => $nav ],

--- a/includes/wikia/models/DesignSystemCommunityHeaderModel.class.php
+++ b/includes/wikia/models/DesignSystemCommunityHeaderModel.class.php
@@ -133,8 +133,7 @@ class DesignSystemCommunityHeaderModel extends WikiaModel {
 				$localNavData = ApiService::foreignCall( WikiFactory::getWikiByID( $this->productInstanceId )->city_dbname, [
 					'controller' => 'NavigationApi',
 					'method' => 'getData',
-					'uselang' => $this->langCode,
-					'wikitext' => $wikitext
+					'uselang' => $this->langCode
 				], ApiService::WIKIA )[ 'navigation' ][ 'wiki' ];
 			}
 


### PR DESCRIPTION
Instead of passing (sometimes malformed) wikitext of nav as a param, let's allow MW to fetch it from DB.