### PR TITLE
Revert "VOLDEV-122 Backporting getTitle() to mw.lua (#7495)"

### DIFF
--- a/extensions/Scribunto/engines/LuaCommon/LuaCommon.php
+++ b/extensions/Scribunto/engines/LuaCommon/LuaCommon.php
@@ -398,15 +398,6 @@ abstract class Scribunto_LuaEngine extends ScribuntoEngineBase {
 		$frame = $this->getFrameById( 'parent' );
 		return array( $frame !== false );
 	}
-	
-	/**
-	 * Handler for getTitle()
-	 * VOLDEV-122 Backporting https://gerrit.wikimedia.org/r/#/c/99797/2
-	 */
-	function getFrameTitle( $frameId ) {
-		$frame = $this->getFrameById( $frameId );
-		return array( $frame->getTitle()->getPrefixedText() );
-	}
 
 	/**
 	 * Handler for getTitle()

--- a/extensions/Scribunto/engines/LuaCommon/lualib/mw.lua
+++ b/extensions/Scribunto/engines/LuaCommon/lualib/mw.lua
@@ -407,13 +407,6 @@ local function newFrame( frameId )
 			end
 			)
 	end
-	
-	-- VOLDEV-122
-	-- Backporting https://gerrit.wikimedia.org/r/#/c/99797/2
-	function frame:getTitle()
-		checkSelf( self, 'getTitle' )
-		return php.getFrameTitle( frameId )
-	end
 
 	function frame:getTitle()
 		checkSelf( self, 'getTitle' )

--- a/extensions/Scribunto/tests/engines/LuaCommon/luaParserTests.txt
+++ b/extensions/Scribunto/tests/engines/LuaCommon/luaParserTests.txt
@@ -133,10 +133,6 @@ function p.null( frame )
 	return '\0'
 end
 
-function p.getFrameTitle( frame )
-	return frame:getTitle()
-end
-
 return p
 !! endarticle
 
@@ -364,14 +360,5 @@ Scribunto: ASCII null
 {{#invoke:test|null}}
 !! result
 <p>�
-</p>
-!! end
-
-!! test
-Scribunto: frame:getTitle
-!! input
-{{#invoke:test|getFrameTitle}}
-!! result
-<p>Module:Test
 </p>
 !! end


### PR DESCRIPTION
This reverts commit 12dfb305df56aaf435b123eea305d3e979e07efb. Was already backported by Platform.