### PR TITLE
MAIN-11309: fix for tabbers in preview

### DIFF
--- a/extensions/3rdparty/tabber/tabber.js
+++ b/extensions/3rdparty/tabber/tabber.js
@@ -537,7 +537,7 @@ function tabberAutomaticOnLoad(tabberArgs)
 	if (!tabberArgs) { tabberArgs = {}; }
 	/* Taken from: http://simon.incutio.com/archive/2004/05/26/addLoadEvent */
 
-	$(function() {
+	mw.hook('wikipage.content').add(function () {
 		tabberAutomatic(tabberArgs);
 	});
 
@@ -550,7 +550,7 @@ function tabberAutomaticOnLoad(tabberArgs)
 /* Run tabberAutomaticOnload() unless the "manualStartup" option was specified */
 if (typeof tabberOptions == 'undefined') {
 
-	tabberAutomaticOnLoad();
+	$(tabberAutomaticOnLoad);
 
 } else {
 

--- a/extensions/3rdparty/tabber/tabber.js
+++ b/extensions/3rdparty/tabber/tabber.js
@@ -553,7 +553,9 @@ if (typeof tabberOptions == 'undefined') {
 } else {
 
 	if (!tabberOptions['manualStartup']) {
-		tabberAutomaticOnLoad(tabberOptions);
+		$(function(){
+			tabberAutomaticOnLoad(tabberOptions);
+		});
 	}
 
 }

--- a/extensions/3rdparty/tabber/tabber.js
+++ b/extensions/3rdparty/tabber/tabber.js
@@ -531,12 +531,10 @@ function tabberAutomatic(tabberArgs)
 
 function tabberAutomaticOnLoad(tabberArgs)
 {
-	/* This function adds tabberAutomatic to the window.onload event,
-	 so it will run after the document has finished loading.
-	 */
-	if (!tabberArgs) { tabberArgs = {}; }
-	/* Taken from: http://simon.incutio.com/archive/2004/05/26/addLoadEvent */
 
+	if (!tabberArgs) { tabberArgs = {}; }
+
+	// Wikia change - init tabbers every time wikitext is added to the page
 	mw.hook('wikipage.content').add(function () {
 		tabberAutomatic(tabberArgs);
 	});


### PR DESCRIPTION
Legacy editor wasn't prepared for parser tag extensions with RL modules.

https://wikia-inc.atlassian.net/browse/MAIN-11309