### PR TITLE
Feature branch

### DIFF
--- a/extensions/wikia/Blogs/templates/blog-post-page.tmpl.php
+++ b/extensions/wikia/Blogs/templates/blog-post-page.tmpl.php
@@ -40,7 +40,7 @@ if (!empty($aRows)) {
 		?>
 		<div class="wk_blogs_comments">
 			<ul class="links">
-			<?php $commentTitle = clone $oTitle; $commentTitle->setFragment('#comments'); ?>
+			<?php $commentTitle = clone $oTitle; $commentTitle->setFragment('#WikiaArticleComments'); ?>
 				<li class="blog-comment"><img src="<?= $wgBlankImgUrl ?>" border="0" class="sprite talk" /> <?= $skin->makeLinkObj($commentTitle, wfMsg('blog-nbrcomments', intval($aRow['comments']))) ?></li>
 				<?php if (!empty($isVoting)) { ?>
 				<li class="wk_star_list"><?= $aRow['votes']?></li>


### PR DESCRIPTION
Attempted to correct the Monobook comment section anchor for Blog Listing Pages. Previously the anchor was set to #comments when it should be #WikiaArticleComments