### PR TITLE
SUS-2616: Better handling of Category::refreshCounts

### DIFF
--- a/includes/Category.php
+++ b/includes/Category.php
@@ -80,13 +80,6 @@ class Category {
 		# and should not be kept, and 2) we *probably* don't have to scan many
 		# rows to obtain the correct figure, so let's risk a one-time recount.
 		if ( $this->mPages < 0 || $this->mSubcats < 0 || $this->mFiles < 0 ) {
-			\Wikia\Logger\WikiaLogger::instance()->error( 'SUS-1782 - Negative count in category table', [
-				'categoryTitle' => $this->mName,
-				'totalCount' => $this->mPages,
-				'subCategoryCount' => $this->mSubcats,
-				'filesCount' => $this->mFiles,
-			] );
-
 			// SUS-1782: Schedule a background task to update the bogus data
 			$task = new \Wikia\Tasks\Tasks\RefreshCategoryCountsTask();
 			$task->call( 'refreshCounts', $this->mName );
@@ -222,7 +215,7 @@ class Category {
 	 * @param $limit integer
 	 * @param $offset string
 	 * //Wikia Change - Jakub Olek - PHP Lint Helpers
-	 * @return Title[] object for category members.
+	 * @return TitleArray object for category members.
 	 * //Wikia Change End
 	 */
 	public function getMembers( $limit = false, $offset = '' ) {

--- a/includes/wikia/tasks/Tasks/RefreshCategoryCountsTask.class.php
+++ b/includes/wikia/tasks/Tasks/RefreshCategoryCountsTask.class.php
@@ -84,7 +84,11 @@ class RefreshCategoryCountsTask extends BaseTask {
 		}
 
 		// Batch load titles for empty categories for performance
-		$categoryTitles = $this->getCategoryTitles( array_keys( $emptyCategories ) );
+		$categoryTitles = [];
+		if ( !empty( $emptyCategories ) ) {
+			$categoryTitles = $this->getCategoryTitles( array_keys( $emptyCategories ) );
+		}
+
 		$entriesToDelete = [];
 
 		foreach ( $emptyCategories as $catName => $row ) {


### PR DESCRIPTION
* if there are no empty categories there is nothing to load
* possible bogus category count is fixed by refresh task

https://wikia-inc.atlassian.net/browse/SUS-2616