### PR TITLE
SUS-2757: Delete watchlist entries when a Forum Thread is deleted

### DIFF
--- a/extensions/wikia/Forum/Forum.setup.php
+++ b/extensions/wikia/Forum/Forum.setup.php
@@ -28,6 +28,7 @@ $wgAutoloadClasses['ForumPostInfo'] =  $dir . 'ForumPostInfo.class.php' ;
 $wgAutoloadClasses['ForumHelper'] =  $dir . 'ForumHelper.class.php' ;
 $wgAutoloadClasses['ForumExternalController'] =  $dir . 'ForumExternalController.class.php' ;
 $wgAutoloadClasses['RelatedForumDiscussionController'] =  $dir . 'RelatedForumDiscussionController.class.php' ;
+$wgAutoloadClasses['ThreadWatchlistDeleteUpdate'] = $dir . 'ThreadWatchlistDeleteUpdate.php';
 
 // i18n mapping
 $wgExtensionMessagesFiles['Forum'] = $dir . 'Forum.i18n.php' ;

--- a/extensions/wikia/Forum/ForumHooksHelper.class.php
+++ b/extensions/wikia/Forum/ForumHooksHelper.class.php
@@ -463,9 +463,15 @@ class ForumHooksHelper {
 	 * @return bool always true to continue hook processing
 	 */
 	static public function onArticleDeleteComplete( Page $page, User $user, string $reason, int $id ): bool {
-		if ( $page->getTitle()->inNamespace( NS_WIKIA_FORUM_BOARD_THREAD ) ) {
+		$pageTitle = $page->getTitle();
+
+		if ( $pageTitle->inNamespace( NS_WIKIA_FORUM_BOARD_THREAD ) ) {
 			$wallHistory = new WallHistory();
 			WikiaDataAccess::cachePurge( $wallHistory->getLastPostsMemcKey() );
+
+			// SUS-2757: After the main transaction is closed, delete watchlist entries for thread
+			$threadWatchlistDeleteUpdate = new ThreadWatchlistDeleteUpdate( $pageTitle );
+			DeferredUpdates::addUpdate( $threadWatchlistDeleteUpdate );
 		}
 
 		return true;

--- a/extensions/wikia/Forum/ThreadWatchlistDeleteUpdate.php
+++ b/extensions/wikia/Forum/ThreadWatchlistDeleteUpdate.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Class ThreadWatchlistDeleteUpdate removes watchlist entries for a Forum Thread when it is deleted
+ * @link https://wikia-inc.atlassian.net/browse/SUS-2757
+ */
+class ThreadWatchlistDeleteUpdate implements DeferrableUpdate {
+	/** @var Title $threadTitle */
+	private $threadTitle;
+
+	public function __construct( Title $threadTitle ) {
+		$this->threadTitle = $threadTitle;
+	}
+
+	/**
+	 * Perform the actual work
+	 */
+	function doUpdate() {
+		$dbw = wfGetDB( DB_MASTER );
+
+		$dbw->delete( 'watchlist',  [
+			'wl_namespace' => [ NS_WIKIA_FORUM_BOARD, NS_WIKIA_FORUM_BOARD_THREAD ],
+			'wl_title' => $this->threadTitle->getDBkey(),
+		], __METHOD__ );
+	}
+}

--- a/includes/wikia/nirvana/WikiaApp.class.php
+++ b/includes/wikia/nirvana/WikiaApp.class.php
@@ -719,6 +719,9 @@ class WikiaApp {
 			 */
 			$factory = wfGetLBFactory();
 			$factory->commitMasterChanges();  // commits only if writes were done on connection
+
+			// SUS-2757: Execute any deferred updates
+			DeferredUpdates::doUpdates( 'commit' );
 		}
 	}
 }


### PR DESCRIPTION
When a Forum Thread is deleted, any watchlist entries that correspond to it are will be invalid. Let's delete them as well when the thread is deleted so they don't cause errors elsewhere.

https://wikia-inc.atlassian.net/browse/SUS-2757