### PR TITLE
IRIS-4908 | Stop parsing thread title for email subject

### DIFF
--- a/extensions/wikia/Email/Controller/ForumController.class.php
+++ b/extensions/wikia/Email/Controller/ForumController.class.php
@@ -154,7 +154,7 @@ class ReplyForumController extends ForumController {
 
 	public function getSubject() {
 		return $this->getMessage( $this->getSubjectKey() )
-			// No need to encode HTML entities in subject
+			// We should not encode HTML entities in the subject
 			->rawParams( $this->titleText )
 			->text();
 	}

--- a/extensions/wikia/Email/Controller/ForumController.class.php
+++ b/extensions/wikia/Email/Controller/ForumController.class.php
@@ -153,7 +153,10 @@ class ReplyForumController extends ForumController {
 	}
 
 	public function getSubject() {
-		return $this->getMessage( $this->getSubjectKey(), $this->titleText )->text();
+		return $this->getMessage( $this->getSubjectKey() )
+			// No need to encode HTML entities in subject
+			->rawParams( $this->titleText )
+			->text();
 	}
 
 	protected function getSummary() {

--- a/extensions/wikia/Email/Controller/WallMessageController.class.php
+++ b/extensions/wikia/Email/Controller/WallMessageController.class.php
@@ -178,7 +178,10 @@ class OwnWallMessageController extends WallMessageController {
 	 * @return string
 	 */
 	protected function getSubject() {
-		return $this->getMessage( 'emailext-wallmessage-owned-subject', $this->titleText )->text();
+		return $this->getMessage( 'emailext-wallmessage-owned-subject' )
+			// We should not encode HTML entities in the subject
+			->rawParams( $this->titleText )
+			->text();
 	}
 }
 
@@ -210,7 +213,10 @@ class ReplyWallMessageController extends WallMessageController {
 	 * @return string
 	 */
 	protected function getSubject() {
-		return $this->getMessage( 'emailext-wallmessage-reply-subject', $this->titleText )->parse();
+		return $this->getMessage( 'emailext-wallmessage-reply-subject' )
+			// We should not encode HTML entities in the subject
+			->rawParams( $this->titleText )
+			->text();
 	}
 
 	protected function getFooterMessages() {
@@ -263,10 +269,11 @@ class FollowedWallMessageController extends WallMessageController {
 	 * @return string
 	 */
 	protected function getSubject() {
-		return $this->getMessage( 'emailext-wallmessage-following-subject',
-			$this->wallUserName,
-			$this->titleText
-		)->text();
+		return $this->getMessage( 'emailext-wallmessage-following-subject' )
+			// We should not encode HTML entities in the subject
+			->rawParams( $this->wallUserName )
+			->rawParams( $this->titleText )
+			->text();
 	}
 
 	protected function getFooterMessages() {


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/IRIS-4908

We don't want thread titles which use `{{TemplateName}}` to be parsed. There is no need to escape HTML entities in an email subject, so we can use `rawParams`.

/cc @slayful @Grunny