### PR TITLE
LyricWiki: use multibyte string functions when finding first letter value

### DIFF
--- a/extensions/3rdparty/LyricWiki/Parser_LWMagicWords.php
+++ b/extensions/3rdparty/LyricWiki/Parser_LWMagicWords.php
@@ -18,8 +18,8 @@ Version 0.1	2008-02-16
 
 function findFirstLetterOf($fLetterOf)
 {
-	$fLetterOf = strtoupper(trim($fLetterOf));
-	$fLetter = strtoupper((strlen($fLetterOf) == 0)?"":substr($fLetterOf,0,1));
+	$fLetterOf = mb_strtoupper( trim( $fLetterOf ) );
+	$fLetter = mb_substr( $fLetterOf, 0, 1 );
 
 	if(is_numeric($fLetter))
 	{


### PR DESCRIPTION
Switching `strtoupper` and `substr` to their multibyte equivalents allows non-ASCII characters to be handled correctly in the fletter magic words.

----
Follow-up to #13448 
