### PR TITLE
SUS-2767 | stop supporting "counter" ordering method

### DIFF
--- a/extensions/DynamicPageList/DPLMain.php
+++ b/extensions/DynamicPageList/DPLMain.php
@@ -143,7 +143,7 @@ class DPLMain {
 			ExtDynamicPageList::$options['allowcachedresults']['default'] = 'true';
 		}
 		else {
-			ExtDynamicPageList::$options['ordermethod'] = array('default' => 'titlewithoutnamespace', 'counter', 'size', 'category', 'sortkey',
+			ExtDynamicPageList::$options['ordermethod'] = array('default' => 'titlewithoutnamespace', 'size', 'category', 'sortkey',
                                         'category,firstedit',  'category,lastedit', 'category,pagetouched', 'category,sortkey',
                                         'categoryadd', 'firstedit', 'lastedit', 'pagetouched', 'pagesel',
                                         'title', 'titlewithoutnamespace', 'user', 'user,firstedit', 'user,lastedit','none');


### PR DESCRIPTION
DPL syntax to reproduce this issue:

```
{{#dpl:
|namespace = 0
|ordermethod=counter
|userdateformat=Y-m-d
}}
```

Fixes a regression caused by #13628