### PR TITLE
SUS-1276 | get rid of wgDisableWAMOnHubs

### DIFF
--- a/extensions/wikia/WikiaHubsServices/models/EditHubModel.class.php
+++ b/extensions/wikia/WikiaHubsServices/models/EditHubModel.class.php
@@ -40,11 +40,7 @@ class EditHubModel extends WikiaModel {
 			WikiaHubsModulePopularvideosService::MODULE_ID => 'popular-videos'
 		];
 
-		if ($this->wg->DisableWAMOnHubs) {
-			$this->nonEditableModules[WikiaHubsModuleWikiastatsService::MODULE_ID] = 'wikia-stats';
-		} else {
-			$this->nonEditableModules[WikiaHubsModuleWAMService::MODULE_ID] = 'wam';
-		}
+		$this->nonEditableModules[WikiaHubsModuleWAMService::MODULE_ID] = 'wam';
 
 		$this->modules = $this->editableModules + $this->nonEditableModules;
 


### PR DESCRIPTION
This variable is set on five wikis and all of them already have a new Fandom-style main pages

https://wikia-inc.atlassian.net/browse/SUS-1276