### PR TITLE
SUS-1712: If a board has the same name as a user, user should not get notifications for every post to that board

### DIFF
--- a/extensions/wikia/WallNotifications/WallNotifications.class.php
+++ b/extensions/wikia/WallNotifications/WallNotifications.class.php
@@ -377,7 +377,11 @@ class WallNotifications {
 		}
 
 		// FB:#11089
-		$users[$notifData->wall_userid] = $notifData->wall_userid;
+		// SUS-1712: Users should not be notified about messages a board that is the same as their
+		// user name unless they are explicitly following it
+		if ( $notifData->article_title_ns === NS_USER_WALL ) {
+			$users[$notifData->wall_userid] = $notifData->wall_userid;
+		}
 
 		if ( !empty( $users[$notifData->msg_author_id] ) ) {
 			unset( $users[$notifData->msg_author_id] );

--- a/extensions/wikia/WallNotifications/tests/WallNotificationsTest.php
+++ b/extensions/wikia/WallNotifications/tests/WallNotificationsTest.php
@@ -27,13 +27,16 @@ class WallNotificationsTest extends WikiaBaseTest {
 	 */
 	public function testNotifyEveryoneForMainThread() {
 		/** @var PHPUnit_Framework_MockObject_MockObject|WallNotifications $wn */
-		$wn = $this->getMock( 'WallNotifications', [ 'sendEmails', 'addNotificationLinks' ] );
+		$wn = $this->getMockBuilder( WallNotifications::class )
+			->setMethods( [ 'sendEmails', 'addNotificationLinks' ] )
+			->getMock();
 
 		/** @var WallNotificationEntity $notification */
-		$notification = $this->getMock( 'WallNotificationEntity', [ 'isMain' ] );
+		$notification = $this->createMock( WallNotificationEntity::class );
 
 		$notification->data = new StdClass();
 
+		$notification->data->article_title_ns = NS_USER_WALL;
 		$notification->data->wall_userid = '123';
 		$notification->data->msg_author_id = '567';
 		$notification->data->wall_username = 'LoremIpsum';


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-1712