### PR TITLE
(PLATFORM-3175) Remove domain sharding from RL and AM assets

### DIFF
--- a/extensions/wikia/AssetsManager/AssetsManager.class.php
+++ b/extensions/wikia/AssetsManager/AssetsManager.class.php
@@ -220,9 +220,6 @@ class AssetsManager {
 
 		$url = $prefix . $this->getAMLocalURL( 'sass', $scssFilePath, $params );
 
-		// apply domain sharding
-		$url = wfReplaceAssetServer( $url );
-
 		wfProfileOut( __METHOD__ );
 		return $url;
 	}
@@ -426,8 +423,6 @@ class AssetsManager {
 			// in varnish (BugId: 33905)
 			$url = $this->mCommonHost . $this->getOneLocalURL($filePath, $minify);
 		}
-		// apply domain sharding
-		$url = wfReplaceAssetServer( $url );
 
 		return $url;
 	}
@@ -479,9 +474,6 @@ class AssetsManager {
 			if ( !$isEmpty ) {
 				$url = $prefix . $this->getAMLocalURL('group', $groupName, $params);
 
-				// apply domain sharding
-				$url = wfReplaceAssetServer( $url );
-
 				$URLs[] = $url;
 			}
 		} else {
@@ -496,8 +488,6 @@ class AssetsManager {
 					// in varnish (BugId: 33905)
 					$url = $this->getOneCommonURL($asset,$minify);
 				}
-				// apply domain sharding
-				$url = wfReplaceAssetServer( $url );
 
 				$URLs[] = $url;
 			}

--- a/includes/resourceloader/ResourceLoaderFileModule.php
+++ b/includes/resourceloader/ResourceLoaderFileModule.php
@@ -463,10 +463,7 @@ class ResourceLoaderFileModule extends ResourceLoaderModule {
 				return AssetsManager::getInstance()->getSassLocalURL($path,false);
 				break;
 			default:
-				$url = "{$this->remoteBasePath}/$path";;
-
-				// apply domain sharding
-				$url = wfReplaceAssetServer( $url );
+				$url = "{$this->remoteBasePath}/$path";
 
 				return $url;
 		}

--- a/includes/wikia/GlobalFunctions.php
+++ b/includes/wikia/GlobalFunctions.php
@@ -146,40 +146,6 @@ function wfReplaceImageServer( $url, $timestamp = false ) {
 }
 
 /**
- * Returns a link to the same asset after applying domain sharding
- *
- * @see wfReplaceImageServer
- * @author Władysław Bodzek
- * @param $url string URL to an asset
- * @return string URL after applying domain sharding
- */
-function wfReplaceAssetServer( $url ) {
-	global $wgImagesServers, $wgDevelEnvironment;
-
-	$matches = array();
-
-	if ( preg_match( "#^(?<a>(https?:)?//(slot[0-9]+\\.)?images)(?<b>\\.wikia\\.nocookie\\.net/.*)\$#", $url, $matches ) ) {
-		$hash = sha1( $url );
-		$inthash = ord( $hash );
-
-		$serverNo = $inthash % ( $wgImagesServers -1 );
-		$serverNo++;
-
-		$url = $matches['a'] . ( $serverNo ) . $matches['b'];
-	} elseif ( !empty( $wgDevelEnvironment ) && preg_match( '/^((https?:)?\/\/)(([a-z0-9]+)\.wikia-dev\.(pl|us|com)\/(.*))$/', $url, $matches ) ) {
-		$hash = sha1( $url );
-		$inthash = ord( $hash );
-
-		$serverNo = $inthash % ( $wgImagesServers -1 );
-		$serverNo++;
-
-		$url = "{$matches[1]}i{$serverNo}.{$matches[3]}";
-	}
-
-	return $url;
-}
-
-/**
  * 	@author Krzysztof Zmudziński <kaz3t@wikia.com>
  *	Returns array of review reason id
  */

--- a/includes/wikia/nirvana/WikiaSkin.class.php
+++ b/includes/wikia/nirvana/WikiaSkin.class.php
@@ -111,8 +111,6 @@ abstract class WikiaSkin extends SkinTemplate {
 				if ( !empty( $srcMatch[1] ) && $this->assetsManager->checkAssetUrlForSkin( $srcMatch[1], $this ) ) {
 					//fix HTML::inlineScript's expansion of ampersands in the src attribute
 					$url = str_replace( '&amp;', '&', $srcMatch[1] );
-					// apply domain sharding
-					$url = wfReplaceAssetServer($url);
 					$res[] = array( 'url' => $url, 'tag' => str_replace( '&amp;', '&', $m ) );
 				} elseif ( empty( $srcMatch[1] ) && !$this->strictAssetUrlCheck ) {
 					//only non-strict skins accept inline elements
@@ -153,8 +151,6 @@ abstract class WikiaSkin extends SkinTemplate {
 					//fix HTML::element's expansion of ampersands in the src attribute
 					// todo: do we really need this trick? I notice URLs that are not properly encoded in the head element
 					$url = str_replace( '&amp;', '&', $hrefMatch[1] );
-					// apply domain sharding
-					$url = wfReplaceAssetServer($url);
 					$res[] = array( 'url' => $url, 'tag' => str_replace( '&amp;', '&', $m ) );
 				} elseif ( empty( $hrefMatch[1] ) && !$this->strictAssetUrlCheck ) {
 					$res[] = array( 'url' => null, 'tag' => $m );

--- a/includes/wikia/resourceloader/ResourceLoaderHooks.class.php
+++ b/includes/wikia/resourceloader/ResourceLoaderHooks.class.php
@@ -270,16 +270,10 @@ class ResourceLoaderHooks {
 			$params = urlencode(http_build_query($loadQuery));
 			$url = $loadScript . "$params/$modules";
 			$url = wfExpandUrl( $url, PROTO_RELATIVE );
-
-			// apply domain sharding
-			$url = wfReplaceAssetServer( $url );
 		} else {
 			// just a copy&paste from ResourceLoader::makeLoaderURL :-(
 			$url = wfExpandUrl( wfAppendQuery( $loadScript, $query ) . '&*', PROTO_RELATIVE );
 		}
-
-		// apply domain sharding
-		$url = wfReplaceAssetServer( $url );
 
 		return false;
 	}

--- a/includes/wikia/tests/ReplaceImageServerTest.php
+++ b/includes/wikia/tests/ReplaceImageServerTest.php
@@ -91,33 +91,4 @@ class ReplaceImageServerTest extends WikiaBaseTest {
 			],
 		];
 	}
-
-	/** @dataProvider devBoxReplaceAssetServerProvider */
-	public function testDevBoxReplaceAssetServer($url, $regex) {
-		$this->mockGlobalVariable('wgDevelEnvironment', true);
-		$replacedUrl = wfReplaceAssetServer($url);
-
-		if ($regex) {
-			$this->assertEquals(true, preg_match($regex, $replacedUrl));
-		} else {
-			$this->assertEquals($url, $replacedUrl);
-		}
-	}
-
-	public function devBoxReplaceAssetServerProvider() {
-		return [
-			[
-				'http://developer.wikia-dev.com/path/to/some/file.scss',
-				'/^http:\/\/i([0-9])\.developer\.wikia-dev.com\/path\/to\/some\/file\.scss$/'
-			],
-			[
-				'https://slot1.images.wikia.nocookie.net/path/to/file.js',
-				'/^https:\/\/slot1\.images([0-9])\.wikia\.nocookie\.net\/path\/to\/file\.js$/',
-			],
-			[
-				'http://google.com/resource.js',
-				false,
-			],
-		];
-	}
 }


### PR DESCRIPTION
Remove domain sharding as part of serving the assets over HTTPS. Domain sharding is both
unnecessary over HTTP/2 and it causes issues with certificates.

/cc @Wikia/core-platform-team 