### PR TITLE
SUS-2768 | bring back Category::refreshCounts

### DIFF
--- a/includes/Category.php
+++ b/includes/Category.php
@@ -251,4 +251,23 @@ class Category {
 		}
 		return $this-> { $key } ;
 	}
+
+	/**
+	 * Refresh the counts for this category synchronously.
+	 *
+	 * @return bool True on success, false on failure
+	 *
+	 * @deprecated Please use an async task instead
+	 * @see https://github.com/Wikia/app/pull/12600/files
+	 */
+	public function refreshCounts() {
+		if ( wfReadOnly() ) {
+			return false;
+		}
+
+		$task = new \Wikia\Tasks\Tasks\RefreshCategoryCountsTask();
+		$task->refreshCounts( $this->mName );
+
+		return true;
+	}
 }


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-2768

This method will run `RefreshCategoryCountsTask` synchronously and fix `Error: Call to undefined method Category::refreshCounts` when update.php runs (fixes a regression introduced by #12600)

Works fine on cron-s1 now:

```
macbre@cron-s1:~/app/maintenance$ SERVER_ID=1626447 php update.php 
...
Populating category table, printing progress markers. For large databases, you
may want to hit Ctrl-C and do this manually with maintenance/
populateCategory.php.
Category population complete.
Done populating category table.
...
```