### PR TITLE
SUS-2765: Direct all traffic to Phalanx@Kubernetes

### DIFF
--- a/extensions/wikia/PhalanxII/models/PhalanxModel.php
+++ b/extensions/wikia/PhalanxII/models/PhalanxModel.php
@@ -1,7 +1,5 @@
 <?php
 
-use Wikia\DependencyInjection\Injector;
-
 /**
  * @method PhalanxModel setBlock( $block )
  * @method object getBlock
@@ -33,7 +31,7 @@ abstract class PhalanxModel extends WikiaObject {
 		parent::__construct();
 
 		$this->user = $this->wg->user;
-		$this->service = Injector::getInjector()->get( PhalanxService::class );
+		$this->service = new PhalanxService();
 		$this->ip = $this->wg->request->getIp();
 	}
 

--- a/extensions/wikia/PhalanxII/services/PhalanxService.class.php
+++ b/extensions/wikia/PhalanxII/services/PhalanxService.class.php
@@ -207,11 +207,10 @@ class PhalanxService {
 			// SUS-2759: pass on content language code to the service
 			$parameters[ 'lang' ] = $wgLanguageCode;
 
-			if ( ( $action == "match" || $action == "check" ) ) {
-				if ( !is_null( $this->user ) ) {
-					$parameters[ 'user' ][] = $this->user->getName();
-				}
+			if ( ( $action == "match" || $action == "check" ) && !empty( $this->user ) ) {
+				$parameters[ 'user' ][] = $this->user->getName();
 			}
+
 			if ( $action == "match" && $this->limit != 1 ) {
 				$parameters['limit'] = $this->limit;
 			}

--- a/extensions/wikia/PhalanxII/tests/PhalanxModelTest.php
+++ b/extensions/wikia/PhalanxII/tests/PhalanxModelTest.php
@@ -1,7 +1,5 @@
 <?php
 
-use Wikia\Service\Gateway\KubernetesUrlProvider;
-
 class PhalanxModelTest extends WikiaBaseTest {
 	const VALID_USERNAME = 'WikiaTest';
 	const VALID_EMAIL = 'moli@wikia-inc.com';
@@ -58,12 +56,8 @@ class PhalanxModelTest extends WikiaBaseTest {
 	 * @return PhalanxService|PHPUnit_Framework_MockObject_MockObject
 	 */
 	private function setUpService( $block ) {
-		$urlProvider = $this->getMockBuilder( KubernetesUrlProvider::class )
-			->setConstructorArgs([ WIKIA_ENV_DEV, 'sjc' ])
-			->getMock();
 		$phalanxServiceMock =
 			$this->getMockBuilder( PhalanxService::class )
-				->setConstructorArgs( [ $urlProvider ] )
 				->setMethods( [ 'match' ] )
 				->getMock();
 

--- a/extensions/wikia/PhalanxII/tests/PhalanxServiceTest.php
+++ b/extensions/wikia/PhalanxII/tests/PhalanxServiceTest.php
@@ -1,7 +1,5 @@
 <?php
 
-use Wikia\DependencyInjection\Injector;
-
 /**
  * @category Wikia
  * @group Integration
@@ -9,39 +7,20 @@ use Wikia\DependencyInjection\Injector;
 class PhalanxServiceTest extends WikiaBaseTest {
 
 	/* @var PhalanxService */
-	public $service;
+	private $service;
 
-	/**
-	 * setup tests
-	 */
 	public function setUp() {
-		$this->setupFile =  dirname( __FILE__ ) . '/../Phalanx_setup.php';
+		$this->setupFile =  __DIR__ . '/../Phalanx_setup.php';
 		parent::setUp();
-		$this->checkPhalanxAlive();
-	}
 
-	public function checkPhalanxAlive( ) {
-		$this->service = Injector::getInjector()->get( PhalanxService::class );
+		$this->service = new PhalanxService();
 		if ( !$this->service->status() ) {
 			// Skip test if phalanx service is not available
-			throw new Exception( "Can't connect to phalanx service" );
-		}
-	}
-
-
-	/**
-	 * check for defined methods in service
-	 */
-	public function testPhalanxServiceMethod() {
-		error_log( __CLASS__ . '::' . __FUNCTION__ );
-		$this->service = Injector::getInjector()->get( PhalanxService::class );
-		foreach ( array( "check", "match", "status", "reload", "validate", "stats" ) as $method ) {
-			$this->assertEquals( true, method_exists( $this->service, $method ), "Method '$method' doesnt exist in PhalanxService" );
+			$this->markTestSkipped( "Can't connect to phalanx service" );
 		}
 	}
 
 	public function testPhalanxServiceCheck() {
-		error_log( __CLASS__ . '::' . __FUNCTION__ );
 		$ret = $this->service->check( "content", "hello world" );
 		$this->assertEquals( $ret, 1 );
 
@@ -100,7 +79,6 @@ class PhalanxServiceTest extends WikiaBaseTest {
 	}
 
 	public function testPhalanxServiceValidate() {
-
 		$ret = $this->service->validate( '^alamakota$' );
 		$this->assertEquals( 1, $ret, "Valid regex" );
 


### PR DESCRIPTION
Stop shadowing Phalanx calls to Kubernetes. Kubernetes instances will be registered in Consul which will allow us to gradually scale down our Mesos/Marathon deployment. After that is complete, we can ditch Consul here completely.

https://wikia-inc.atlassian.net/browse/SUS-2765