### PR TITLE
WikiaCorporateModel | use a hardcoded list of corporate wikis for different languages

### DIFF
--- a/extensions/wikia/CityVisualization/models/CityVisualization.class.php
+++ b/extensions/wikia/CityVisualization/models/CityVisualization.class.php
@@ -865,17 +865,9 @@ class CityVisualization extends WikiaModel {
 	 * @desc Returns an array of wikis with visualization
 	 * @return array
 	 */
-	public function getVisualizationWikisData() {
+	private function getVisualizationWikisData() {
 		$corporateSites = $this->getCorporateSitesList();
 		return $this->getWikiaHomePageHelper()->cleanWikisDataArray($corporateSites);
-	}
-
-	/**
-	 * @desc Returns an array of wikis' ids
-	 * @return array
-	 */
-	public function getVisualizationWikisIds() {
-		return array_keys($this->getCorporateSitesList());
 	}
 
 	/**

--- a/includes/wikia/models/WikiaCorporateModel.class.php
+++ b/includes/wikia/models/WikiaCorporateModel.class.php
@@ -16,12 +16,11 @@ class WikiaCorporateModel extends WikiaModel {
 	 * Get corporate wikiId by content lang
 	 *
 	 * @param string $lang
-	 * @return int
-	 * @throws WikiaException
+	 * @return int|false
 	 */
 	public function getCorporateWikiIdByLang($lang) {
 		if (!isset(self::LANG_TO_WIKI_ID[$lang])) {
-			throw new WikiaException('Corporate Wiki not defined for this lang');
+			return false;
 		}
 
 		return self::LANG_TO_WIKI_ID[$lang];

--- a/includes/wikia/models/WikiaCorporateModel.class.php
+++ b/includes/wikia/models/WikiaCorporateModel.class.php
@@ -1,31 +1,29 @@
 <?php
 
-class WikiaCorporateModel extends WikiaModel
-{
+class WikiaCorporateModel extends WikiaModel {
+
+	// taken from wgEnableWikiaHomePageExt
+	const LANG_TO_WIKI_ID = [
+		'en' => Wikia::CORPORATE_WIKI_ID,
+		'de' => 111264,
+		'fr' => 208826,
+		'pl' => 435095,
+		'es' => 637291,
+		'ja' => 875569,
+	];
+
 	/**
 	 * Get corporate wikiId by content lang
 	 *
-	 * @param $lang
-	 *
+	 * @param string $lang
 	 * @return int
-	 *
-	 * @throws Exception
+	 * @throws WikiaException
 	 */
 	public function getCorporateWikiIdByLang($lang) {
-		$visualizationData = $this->getVisualizationData();
-		if (!isset($visualizationData[$lang]['wikiId'])) {
-			throw new Exception('Corporate Wiki not defined for this lang');
+		if (!isset(self::LANG_TO_WIKI_ID[$lang])) {
+			throw new WikiaException('Corporate Wiki not defined for this lang');
 		}
 
-		return $visualizationData[$lang]['wikiId'];
-	}
-
-	/**
-	 * get data about corporate wikis
-	 * @return array
-	 */
-	protected function getVisualizationData() {
-		$visualizationModel = new CityVisualization();
-		return $visualizationModel->getVisualizationWikisData();
+		return self::LANG_TO_WIKI_ID[$lang];
 	}
 }

--- a/includes/wikia/services/WikiDetailsService.class.php
+++ b/includes/wikia/services/WikiDetailsService.class.php
@@ -113,16 +113,14 @@ class WikiDetailsService extends WikiService {
 	 * @param string $imageName
 	 * @param string $lang
 	 * @param int $wikiId
-	 * @return GlobalFile|null
+	 * @return GlobalFile
 	 */
 	protected function findGlobalFileImage( $imageName, $lang, $wikiId ) {
 		//try to find image on lang specific corporate wiki
-		$f = null;
-		$visualizationModel = new CityVisualization();
-		$cityList = $visualizationModel->getVisualizationWikisData();
+		$cityId = ( new WikiaCorporateModel )->getCorporateWikiIdByLang( $lang );
 
-		if ( isset( $cityList[ $lang ] ) ) {
-			$f = GlobalFile::newFromText( $imageName, $cityList[ $lang ][ 'wikiId' ] );
+		if ( $cityId !== false ) {
+			$f = GlobalFile::newFromText( $imageName, $cityId );
 		} else {
 			//if image wasn't found, try to find it on wiki itself
 			$promoImage = ( new PromoImage( PromoImage::MAIN ) )->setCityId( $wikiId );


### PR DESCRIPTION
This used to be handled by `wgEnableWikiaHomePageExt` WikiFactory variable which will be removed.

```php
extensions/wikia/CityVisualization/models/CityVisualization.class.php
24:	const WIKIA_HOME_PAGE_WF_VAR_NAME = 'wgEnableWikiaHomePageExt';
1015:				$wikiFactoryVarId = WikiFactory::getVarIdByName(self::WIKIA_HOME_PAGE_WF_VAR_NAME);
```

## Example

```php
> var_dump( (new WikiaCorporateModel)->getCorporateWikiIdByLang('en') )
int(80433)

> var_dump( (new WikiaCorporateModel)->getCorporateWikiIdByLang('pl') )
int(435095)

> echo $wgDBname
plpoznan

> var_dump( (new WikiaLogoHelper)->getMainCorpPageURL() )
string(29) "http://pl.macbre.wikia-dev.pl"
```

https://wikia-inc.atlassian.net/browse/SUS-1276