### PR TITLE
SUS-2775: Remove legacy JobQueue scribe emitter

### DIFF
--- a/includes/job/JobQueue.php
+++ b/includes/job/JobQueue.php
@@ -263,7 +263,6 @@ abstract class Job {
 				$dbw->begin();
 				$dbw->insert( 'job', $rows, __METHOD__, 'IGNORE' );
 				$dbw->commit();
-				Wikia::informJobQueue( count( $rows ) );
 				$rows = array();
 			}
 		}
@@ -271,7 +270,6 @@ abstract class Job {
 			$dbw->begin();
 			$dbw->insert( 'job', $rows, __METHOD__, 'IGNORE' );
 			$dbw->commit();
-			Wikia::informJobQueue( count( $rows ) );
 		}
 		wfIncrStats( 'job-insert', count( $jobs ) );
 	}
@@ -295,13 +293,11 @@ abstract class Job {
 			$rows[] = $job->insertFields();
 			if ( count( $rows ) >= 500 ) {
 				$dbw->insert( 'job', $rows, __METHOD__, 'IGNORE' );
-				Wikia::informJobQueue( count( $rows ) );
 				$rows = array();
 			}
 		}
 		if ( $rows ) { // last chunk
 			$dbw->insert( 'job', $rows, __METHOD__, 'IGNORE' );
-			Wikia::informJobQueue( count( $rows ) );
 		}
 		wfIncrStats( 'job-insert', count( $jobs ) );
 	}
@@ -343,7 +339,6 @@ abstract class Job {
 			}
 		}
 		wfIncrStats( 'job-insert' );
-		Wikia::informJobQueue();
 		return $dbw->insert( 'job', $fields, __METHOD__ );
 	}
 

--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -1302,46 +1302,6 @@ class Wikia {
 	}
 
 	/**
-	 * informJobQueue
-	 * Send information to the backend script what job was added
-	 *
-	 * @static
-	 * @access public
-	 *
-	 * @param Integer count of job params
-	 *
-	 * @author Piotr Molski (MoLi)
-	 * @return true
-	 */
-	static public function informJobQueue( /*Integer*/ $job_count = 1 ) {
-		global $wgCityId, $wgDBname, $wgEnableScribeReport;
-
-		if ( empty( $wgEnableScribeReport ) ) {
-			return true;
-		}
-
-		$params = array(
-			'dbname'	=> $wgDBname,
-			'wiki_id'	=> $wgCityId,
-			'jobs'		=> $job_count
-		);
-
-		try {
-			$message = array(
-				'method' => 'jobqueue',
-				'params' => $params
-			);
-			$data = json_encode( $message );
-			WScribeClient::singleton('trigger')->send($data);
-		}
-		catch( TException $e ) {
-			Wikia::log( __METHOD__, 'scribeClient exception', $e->getMessage() );
-		}
-
-		return true;
-	}
-
-	/**
 	 * get_const_values
 	 * Returns some stats values from const_values table
 	 *


### PR DESCRIPTION
Instead of JobQueue we now use celery workers + rabbit. There has been no traffic via this scribe hook according to Kibana.

https://wikia-inc.atlassian.net/browse/SUS-2775