### PR TITLE
SUS-1276 | CityVisualization - remove dependency on wgEnableWikiaHomePageExt

### DIFF
--- a/extensions/wikia/CityVisualization/classes/WikiGetDataForVisualizationHelper.class.php
+++ b/extensions/wikia/CityVisualization/classes/WikiGetDataForVisualizationHelper.class.php
@@ -2,10 +2,10 @@
 
 class WikiGetDataForVisualizationHelper implements WikiGetDataHelper {
 	public function getMemcKey($wikiId, $langCode) {
-		/** @var $visualization CityVisualization */
 		$visualization = new CityVisualization();
+		$model = new WikiaCorporateModel();
 
-		return $visualization->getWikiDataCacheKey($visualization->getTargetWikiId($langCode), $wikiId, $langCode);
+		return $visualization->getWikiDataCacheKey($model->getCorporateWikiIdByLang($langCode), $wikiId, $langCode);
 	}
 
 	public function getImages($wikiId, $langCode, $wikiRow) {

--- a/extensions/wikia/CityVisualization/helpers/WikiaHomePageHelper.class.php
+++ b/extensions/wikia/CityVisualization/helpers/WikiaHomePageHelper.class.php
@@ -309,25 +309,4 @@ class WikiaHomePageHelper extends WikiaModel {
 			return self::REMIX_IMG_SMALL_WIDTH;
 		}
 	}
-
-	/**
-	 * @param Array $sites lists of wikis from WikiFactory::getListOfWikisWithVar()
-	 * @return array
-	 */
-	public function cleanWikisDataArray($sites) {
-		$results = array();
-
-		foreach( $sites as $wikiId => $wiki ) {
-			$results[$wiki['l']] = [
-				'wikiId' => $wikiId,
-				'url' => $wiki['u'],
-				'db' => $wiki['d'],
-				'lang' => $wiki['l'],
-				'wikiTitle' => $wiki['t'],
-			];
-		}
-
-		return $results;
-	}
-
 }

--- a/extensions/wikia/CityVisualization/models/CityVisualization.class.php
+++ b/extensions/wikia/CityVisualization/models/CityVisualization.class.php
@@ -6,7 +6,6 @@
  */
 class CityVisualization extends WikiaModel {
 	const CITY_VISUALIZATION_MEMC_VERSION = 'v0.80';
-	const CITY_VISUALIZATION_CORPORATE_PAGE_LIST_MEMC_VERSION = 'v1.09';
 	const WIKI_STANDARD_BATCH_SIZE_MULTIPLIER = 100;
 
 	const CITY_VISUALIZATION_TABLE_NAME = 'city_visualization';
@@ -17,11 +16,6 @@ class CityVisualization extends WikiaModel {
 	const PROMOTED_SLOTS = 3;
 	const PROMOTED_ARRAY_KEY = 'promoted';
 	const DEMOTED_ARRAY_KEY = 'demoted';
-
-	/**
-	 * @const String name of variable in city_variables table which enables WikiaHomePage extension
-	 */
-	const WIKIA_HOME_PAGE_WF_VAR_NAME = 'wgEnableWikiaHomePageExt';
 
 	protected $verticalMap = array(
 		WikiFactoryHub::CATEGORY_ID_LIFESTYLE => 'lifestyle',
@@ -431,40 +425,16 @@ class CityVisualization extends WikiaModel {
 		return (($wikiFlags & WikisModel::FLAG_PROMOTED) == WikisModel::FLAG_PROMOTED);
 	}
 
+	/**
+	 * Given the language code returns ID of a corresponding corporate wiki
+	 *
+	 * @param string $langCode
+	 * @return int|false
+	 *
+	 * @deprecated use WikiaCorporateModel::getCorporateWikiIdByLang instead
+	 */
 	public function getTargetWikiId($langCode) {
-		$corporateSites = $this->getVisualizationWikisData();
-		return ( isset($corporateSites[$langCode]['wikiId']) ) ? $corporateSites[$langCode]['wikiId'] : false;
-	}
-
-	/**
-	 * @desc Returns an array of wikis with visualization
-	 * @return array
-	 */
-	private function getVisualizationWikisData() {
-		$corporateSites = $this->getCorporateSitesList();
-		return $this->getWikiaHomePageHelper()->cleanWikisDataArray($corporateSites);
-	}
-
-	/**
-	 * @desc Gets id of wgEnableWikiaHomePageExt variable and then loads and returns list of corporate sites
-	 * @return array
-	 */
-	protected function getCorporateSitesList() {
-		return WikiaDataAccess::cache(
-			wfSharedMemcKey('corporate_pages_list', self::CITY_VISUALIZATION_CORPORATE_PAGE_LIST_MEMC_VERSION),
-			WikiaResponse::CACHE_STANDARD,
-			function() {
-				// loads list of corporate sites (sites which have $wgEnableWikiaHomePageExt WF variable set to true)
-				$wikiFactoryVarId = WikiFactory::getVarIdByName(self::WIKIA_HOME_PAGE_WF_VAR_NAME);
-
-				if (is_int($wikiFactoryVarId)) {
-					return WikiFactory::getListOfWikisWithVar($wikiFactoryVarId, 'bool', '=', true);
-				}
-				else {
-					return [];
-				}
-			}
-		);
+		return (new WikiaCorporateModel)->getCorporateWikiIdByLang($langCode);
 	}
 
 	/**

--- a/extensions/wikia/CityVisualization/models/CityVisualization.class.php
+++ b/extensions/wikia/CityVisualization/models/CityVisualization.class.php
@@ -426,18 +426,6 @@ class CityVisualization extends WikiaModel {
 	}
 
 	/**
-	 * Given the language code returns ID of a corresponding corporate wiki
-	 *
-	 * @param string $langCode
-	 * @return int|false
-	 *
-	 * @deprecated use WikiaCorporateModel::getCorporateWikiIdByLang instead
-	 */
-	public function getTargetWikiId($langCode) {
-		return (new WikiaCorporateModel)->getCorporateWikiIdByLang($langCode);
-	}
-
-	/**
 	 * @return Array An array where the keys are three main hubs ids (integers) and values are string representation of English names
 	 */
 	private function getVerticalMap() {

--- a/extensions/wikia/Search/classes/Result/ResultHelper.php
+++ b/extensions/wikia/Search/classes/Result/ResultHelper.php
@@ -35,7 +35,7 @@ class ResultHelper {
 			$imageFileName =
 				PromoImage::fromPathname( $result['image_s'] )->ensureCityIdIsSet( $result['id'] )->getPathname();
 			$imageURL = ImagesService::getImageSrcByTitle(
-				( new \CityVisualization )->getTargetWikiId( $result['lang_s'] ),
+				( new \WikiaCorporateModel )->getCorporateWikiIdByLang( $result['lang_s'] ),
 				$imageFileName,
 				$imageSizes['width'],
 				$imageSizes['height']

--- a/includes/wikia/services/WikiService.class.php
+++ b/includes/wikia/services/WikiService.class.php
@@ -575,6 +575,7 @@ class WikiService extends WikiaModel {
 	public function getWikiDescription( Array $wikiIds, $imgWidth = 250, $imgHeight = null ) {
 
 		$wikiDetails = $this->getDetails( $wikiIds );
+		$corpModel = new WikiaCorporateModel();
 
 		foreach ( $wikiDetails as $wikiId => $wikiData ) {
 			if ( empty( $wikiData['desc']) ) {
@@ -582,7 +583,7 @@ class WikiService extends WikiaModel {
 			}
 			$wikiDetails[ $wikiId ]['image_wiki_id'] = null;
 			if ( !empty( $wikiData['image'] ) ) {
-				$wikiDetails[ $wikiId ]['image_wiki_id'] = $this->getCityVisualizationObject()->getTargetWikiId( $wikiData['lang'] );
+				$wikiDetails[ $wikiId ]['image_wiki_id'] = $corpModel->getCorporateWikiIdByLang( $wikiData['lang'] );
 
 				$imageUrl = $this->getImageSrcByTitle( $wikiDetails[ $wikiId ]['image_wiki_id'], $wikiData['image'], $imgWidth, $imgHeight);
 				$wikiDetails[ $wikiId ]['image_url'] = $imageUrl;
@@ -592,17 +593,6 @@ class WikiService extends WikiaModel {
 		}
 
 		return $wikiDetails;
-	}
-
-	public function setCityVisualizationObject( $cityVisualizationObject ) {
-		$this->cityVisualizationObject = $cityVisualizationObject;
-	}
-
-	public function getCityVisualizationObject() {
-		if ( empty( $this->cityVisualizationObject ) ) {
-			$this->cityVisualizationObject = new CityVisualization();
-		}
-		return $this->cityVisualizationObject;
 	}
 
 	/**

--- a/includes/wikia/services/tests/WikiServiceTests.php
+++ b/includes/wikia/services/tests/WikiServiceTests.php
@@ -16,6 +16,7 @@ class WikiServiceTests extends WikiaBaseTest {
 			->expects( $this->never() )
 			->method( 'wfMessage' );
 
+		/* @var WikiService $wikiService */
 		$wikiService = $this->getMock('WikiService', array( 'getDetails', 'getImageSrcByTitle' ));
 		$wikiService->expects($this->exactly(1))
 			->method('getDetails')
@@ -44,7 +45,6 @@ class WikiServiceTests extends WikiaBaseTest {
 			->will($this->returnValueMap([
 				[ 69, $image13, $imgSize, null, $image13Url ],
 				[ 69, $image42, $imgSize, null, $image42Url ]]));
-		$wikiService->setCityVisualizationObject($this->mockCityVisualisationObject( 69, 2 ));
 
 		$result = $wikiService->getWikiDescription( $ids, $imgSize );
 
@@ -73,6 +73,7 @@ class WikiServiceTests extends WikiaBaseTest {
 			->with( 'wikiasearch2-crosswiki-description', 'wiki42' )
 			->will( $this->returnValue( $MessageMock ) );
 
+		/* @var WikiService $wikiService */
 		$wikiService = $this->getMock('WikiService', array( 'getDetails','getImageSrcByTitle' ));
 		$wikiService->expects($this->exactly(1))
 			->method('getDetails')
@@ -100,7 +101,6 @@ class WikiServiceTests extends WikiaBaseTest {
 			->method('getImageSrcByTitle')
 			->will($this->returnValueMap([
 				[ 69, $image42, $imgSize, null, $image42Url ]]));
-		$wikiService->setCityVisualizationObject($this->mockCityVisualisationObject( 69, 1 ));
 
 		$result = $wikiService->getWikiDescription( $ids, $imgSize );
 


### PR DESCRIPTION
Get rid of `WikiFactory::getVarIdByName(self::WIKIA_HOME_PAGE_WF_VAR_NAME)`. Use `WikiaCorporateModel::getCorporateWikiIdByLang` instead.

https://wikia-inc.atlassian.net/browse/SUS-1276

And now we can finally get rid of `wgEnableWikiaHomePageExt` variable from WikiFactory.