### PR TITLE
CAKE-2335: Adds Origin to the Vary header when setting CORS headers

### DIFF
--- a/extensions/wikia/MercuryApi/MercuryApiController.class.php
+++ b/extensions/wikia/MercuryApi/MercuryApiController.class.php
@@ -191,6 +191,11 @@ class MercuryApiController extends WikiaController {
 	 *
 	 */
 	public function getWikiVariables() {
+		(new CrossOriginResourceSharingHeaderHelper())
+		  ->allowWhitelistedOrigins()
+		  ->setAllowMethod( [ 'GET' ] )
+		  ->setHeaders($this->response);
+
 		$wikiVariables = $this->prepareWikiVariables();
 
 		$this->response->setVal( 'data', $wikiVariables );

--- a/includes/wikia/helpers/CrossOriginResourceSharingHeaderHelper.php
+++ b/includes/wikia/helpers/CrossOriginResourceSharingHeaderHelper.php
@@ -11,6 +11,7 @@ class CrossOriginResourceSharingHeaderHelper {
 	const ALLOW_ORIGIN_HEADER_NAME = 'Access-Control-Allow-Origin';
 	const ALLOW_METHOD_HEADER_NAME = 'Access-Control-Allow-Method';
 	const ALLOW_CREDENTIALS_HEADER_NAME = 'Access-Control-Allow-Credentials';
+	const VARY_HEADER_VALUE = 'Origin';
 	const HEADER_DELIMETER = ',';
 
 	const PROD_ORIGINS = ['.wikia.com'];
@@ -85,6 +86,13 @@ class CrossOriginResourceSharingHeaderHelper {
 			foreach ( $this->whitelistOrigins as $origin ) {
 				if ( preg_match( '/' . $origin . '$/', $requestOrigin ) ) {
 					$this->setResponseHeader( $response, self::ALLOW_ORIGIN_HEADER_NAME, $requestOrigin );
+
+					// If we're setting Access-Control-Allow-Origin to something non-"*", then we also have to set Vary: Origin
+					// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin#CORS_and_caching
+
+					// We can't just set the Vary header here, though, because it'll get clobbered in WikiaResponse::SendHeaders
+					// So, instead, we have to add the vary header to the output.
+					RequestContext::getMain()->getOutput()->addVaryHeader(self::VARY_HEADER_VALUE);
 					break;
 				}
 			}


### PR DESCRIPTION
This ensures that the `Vary` header has `Origin` in it whenever `Access-Control-Allow-Origin` is set to a non-`*` value, as per https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin#CORS_and_caching

This should (in theory) correct the CORS issues we were having with anon users and the global header / footer.  While I see the correct header behavior locally using cURL, I can't fully test it without pushing it to dev.

@Wikia/cake 