### PR TITLE
SUS-2743: Use GROUP_CONCAT on change_tags table instead of JOIN with tag_summary

### DIFF
--- a/includes/actions/HistoryAction.php
+++ b/includes/actions/HistoryAction.php
@@ -351,25 +351,22 @@ class HistoryPager extends ReverseChronologicalPager {
 	}
 
 	function getQueryInfo() {
-		$queryInfo = array(
-			'tables'  => array( 'revision', 'user' ),
-			'fields'  => array_merge( Revision::selectFields(), Revision::selectUserFields() ),
-			'conds'   => array_merge(
-				array( 'rev_page' => $this->getWikiPage()->getId() ),
-				$this->conds ),
-			'options' => array( 'USE INDEX' => array( 'revision' => 'page_timestamp' ) ),
-			'join_conds' => array(
-				'user'        => Revision::userJoinCond(),
-				'tag_summary' => array( 'LEFT JOIN', 'ts_rev_id=rev_id' ) ),
-		);
-		ChangeTags::modifyDisplayQuery(
-			$queryInfo['tables'],
-			$queryInfo['fields'],
-			$queryInfo['conds'],
-			$queryInfo['join_conds'],
-			$queryInfo['options'],
-			$this->tagFilter
-		);
+		$queryInfo = [
+			'tables' => [ 'revision', 'user' ],
+			'fields' => array_merge( Revision::selectFields(), Revision::selectUserFields() ),
+			'conds' => array_merge( [ 'rev_page' => $this->getWikiPage()->getId() ], $this->conds ),
+			'options' => [
+				'USE INDEX' => [ 'revision' => 'page_timestamp' ]
+			],
+			'join_conds' => [
+				'user' => Revision::userJoinCond(),
+			],
+		];
+
+		ChangeTags::modifyDisplayQuery( $queryInfo['tables'], $queryInfo['fields'],
+			$queryInfo['conds'], $queryInfo['join_conds'], $queryInfo['options'],
+			$this->tagFilter );
+
 		Hooks::run( 'PageHistoryPager::getQueryInfo', [ $this, &$queryInfo ] );
 
 		return $queryInfo;

--- a/includes/api/ApiQueryLogEvents.php
+++ b/includes/api/ApiQueryLogEvents.php
@@ -87,9 +87,8 @@ class ApiQueryLogEvents extends ApiQueryBase {
 		$this->addFieldsIf( 'log_params', $this->fld_details );
 
 		if ( $this->fld_tags ) {
-			$this->addTables( 'tag_summary' );
-			$this->addJoinConds( array( 'tag_summary' => array( 'LEFT JOIN', 'log_id=ts_log_id' ) ) );
-			$this->addFields( 'ts_tags' );
+			$tsTags = ChangeTags::buildTsTagsGroupConcatField( 'log_id' );
+			$this->addFields( $tsTags );
 		}
 
 		if ( !is_null( $params['tag'] ) ) {

--- a/includes/api/ApiQueryRecentChanges.php
+++ b/includes/api/ApiQueryRecentChanges.php
@@ -245,7 +245,9 @@ class ApiQueryRecentChanges extends ApiQueryGeneratorBase {
 		if ( $this->fld_tags ) {
 			$tsTags = ChangeTags::buildTsTagsGroupConcatField( 'rc_id' );
 			$this->addFields( $tsTags );
-		} elseif ( !is_null( $params['tag'] ) ) {
+		}
+
+		if ( !is_null( $params['tag'] ) ) {
 			$this->addTables( 'change_tag' );
 			$this->addJoinConds( array( 'change_tag' => array( 'INNER JOIN', array( 'rc_id=ct_rc_id' ) ) ) );
 			$this->addWhereFld( 'ct_tag' , $params['tag'] );

--- a/includes/api/ApiQueryRecentChanges.php
+++ b/includes/api/ApiQueryRecentChanges.php
@@ -243,9 +243,14 @@ class ApiQueryRecentChanges extends ApiQueryGeneratorBase {
 		}
 
 		if ( $this->fld_tags ) {
-			$this->addTables( 'tag_summary' );
-			$this->addJoinConds( array( 'tag_summary' => array( 'LEFT JOIN', array( 'rc_id=ts_rc_id' ) ) ) );
-			$this->addFields( 'ts_tags' );
+			$tsTags = ChangeTags::buildTsTagsGroupConcatField( 'rc_id' );
+			$this->addFields( $tsTags );
+		} elseif ( !is_null( $params['tag'] ) ) {
+			$this->addTables( 'change_tag' );
+			$this->addJoinConds( array( 'change_tag' => array( 'INNER JOIN', array( 'rc_id=ct_rc_id' ) ) ) );
+			$this->addWhereFld( 'ct_tag' , $params['tag'] );
+			global $wgOldChangeTagsIndex;
+			$index['change_tag'] = $wgOldChangeTagsIndex ? 'ct_tag' : 'change_tag_tag_id';
 		}
 
 		if ( $params['toponly'] || $showRedirects ) {
@@ -256,14 +261,6 @@ class ApiQueryRecentChanges extends ApiQueryGeneratorBase {
 			if ( $params['toponly'] ) {
 				$this->addWhere( 'rc_this_oldid = page_latest' );
 			}
-		}
-
-		if ( !is_null( $params['tag'] ) ) {
-			$this->addTables( 'change_tag' );
-			$this->addJoinConds( array( 'change_tag' => array( 'INNER JOIN', array( 'rc_id=ct_rc_id' ) ) ) );
-			$this->addWhereFld( 'ct_tag' , $params['tag'] );
-			global $wgOldChangeTagsIndex;
-			$index['change_tag'] = $wgOldChangeTagsIndex ? 'ct_tag' : 'change_tag_tag_id';
 		}
 
 		$this->token = $params['token'];

--- a/includes/api/ApiQueryRevisions.php
+++ b/includes/api/ApiQueryRevisions.php
@@ -178,7 +178,9 @@ class ApiQueryRevisions extends ApiQueryBase {
 			$this->fld_tags = true;
 			$tsTags = ChangeTags::buildTsTagsGroupConcatField( 'rev_id' );
 			$this->addFields( $tsTags );
-		} elseif ( !is_null( $params['tag'] ) ) {
+		}
+
+		if ( !is_null( $params['tag'] ) ) {
 			$this->addTables( 'change_tag' );
 			$this->addJoinConds( array( 'change_tag' => array( 'INNER JOIN', array( 'rev_id=ct_rev_id' ) ) ) );
 			$this->addWhereFld( 'ct_tag' , $params['tag'] );

--- a/includes/api/ApiQueryRevisions.php
+++ b/includes/api/ApiQueryRevisions.php
@@ -176,12 +176,9 @@ class ApiQueryRevisions extends ApiQueryBase {
 
 		if ( isset( $prop['tags'] ) ) {
 			$this->fld_tags = true;
-			$this->addTables( 'tag_summary' );
-			$this->addJoinConds( array( 'tag_summary' => array( 'LEFT JOIN', array( 'rev_id=ts_rev_id' ) ) ) );
-			$this->addFields( 'ts_tags' );
-		}
-
-		if ( !is_null( $params['tag'] ) ) {
+			$tsTags = ChangeTags::buildTsTagsGroupConcatField( 'rev_id' );
+			$this->addFields( $tsTags );
+		} elseif ( !is_null( $params['tag'] ) ) {
 			$this->addTables( 'change_tag' );
 			$this->addJoinConds( array( 'change_tag' => array( 'INNER JOIN', array( 'rev_id=ct_rev_id' ) ) ) );
 			$this->addWhereFld( 'ct_tag' , $params['tag'] );

--- a/includes/api/ApiQueryUserContributions.php
+++ b/includes/api/ApiQueryUserContributions.php
@@ -249,9 +249,8 @@ class ApiQueryContributions extends ApiQueryBase {
 		$this->addFieldsIf( 'rc_patrolled', $this->fld_patrolled );
 
 		if ( $this->fld_tags ) {
-			$this->addTables( 'tag_summary' );
-			$this->addJoinConds( array( 'tag_summary' => array( 'LEFT JOIN', array( 'rev_id=ts_rev_id' ) ) ) );
-			$this->addFields( 'ts_tags' );
+			$tsTags = ChangeTags::buildTsTagsGroupConcatField( 'rev_id' );
+			$this->addFields( $tsTags );
 		}
 
 		if ( isset( $this->params['tag'] ) ) {


### PR DESCRIPTION
Follow-up to https://github.com/Wikia/app/pull/13733 . The only remaining consumers appear to be rather obscure APIs. Let's replace JOINs with GROUP_CONCAT subquery on change_tags table whose indexes have better cardinality.

## Query execution plans
```
mysql@geo-db-dev-db-slave.query.consul[muppet]>explain SELECT /* ApiQueryRecentChanges::run TK-test - e6b2778c-ccbd-404b-babf-7e7fb39177eb */  rc_timestamp,rc_namespace,rc_title,rc_cur_id,rc_type,rc_moved_to_ns,rc_moved_to_title,rc_deleted,rc_user,rc_user_text,ts_tags  FROM `recentchanges` FORCE INDEX (rc_timestamp) LEFT JOIN `tag_summary` ON ((rc_id=ts_rc_id))  WHERE rc_deleted = '0'  ORDER BY rc_timestamp DESC LIMIT 11;
+----+-------------+---------------+------------+-------+-------------------+-------------------+---------+----------------------------+------+----------+-------------+
| id | select_type | table         | partitions | type  | possible_keys     | key               | key_len | ref                        | rows | filtered | Extra       |
+----+-------------+---------------+------------+-------+-------------------+-------------------+---------+----------------------------+------+----------+-------------+
|  1 | SIMPLE      | recentchanges | NULL       | index | NULL              | rc_timestamp      | 16      | NULL                       |   10 |    10.00 | Using where |
|  1 | SIMPLE      | tag_summary   | NULL       | ref   | tag_summary_rc_id | tag_summary_rc_id | 5       | muppet.recentchanges.rc_id |    1 |   100.00 | NULL        |
+----+-------------+---------------+------------+-------+-------------------+-------------------+---------+----------------------------+------+----------+-------------+
2 rows in set, 1 warning (0.00 sec)

mysql@geo-db-dev-db-slave.query.consul[noreply]>explain SELECT /* ApiQueryRecentChanges::run TK-test - ebb65022-4895-4b7b-9cf0-3f501e90b3d6 */  rc_timestamp,rc_namespace,rc_title,rc_cur_id,rc_type,rc_moved_to_ns,rc_moved_to_title,rc_deleted,rc_user,rc_user_text,(SELECT  GROUP_CONCAT(ct_tag SEPARATOR ',')  FROM `change_tag`  WHERE ct_rc_id=rc_id  ) AS ts_tags  FROM `recentchanges`   WHERE rc_deleted = '0'  ORDER BY rc_timestamp DESC LIMIT 11;
+----+--------------------+---------------+------------+-------+-------------------+-------------------+---------+-----------------------------+------+----------+-------------+
| id | select_type        | table         | partitions | type  | possible_keys     | key               | key_len | ref                         | rows | filtered | Extra       |
+----+--------------------+---------------+------------+-------+-------------------+-------------------+---------+-----------------------------+------+----------+-------------+
|  1 | PRIMARY            | recentchanges | NULL       | index | NULL              | rc_timestamp      | 16      | NULL                        |   11 |    10.00 | Using where |
|  2 | DEPENDENT SUBQUERY | change_tag    | NULL       | ref   | change_tag_rc_tag | change_tag_rc_tag | 5       | noreply.recentchanges.rc_id |    1 |   100.00 | Using index |
+----+--------------------+---------------+------------+-------+-------------------+-------------------+---------+-----------------------------+------+----------+-------------+
2 rows in set, 2 warnings (0.00 sec)
```

https://wikia-inc.atlassian.net/browse/SUS-2743
https://phabricator.wikimedia.org/T55577