### PR TITLE
SUS-1015 | Add cache in User::whoIs

### DIFF
--- a/includes/User.php
+++ b/includes/User.php
@@ -582,8 +582,8 @@ class User implements JsonSerializable {
 	 * @return String|false The corresponding username
 	 */
 	public static function whoIs( $id ) {
-		$dbr = wfGetDB( DB_SLAVE );
-		return $dbr->selectField( 'user', 'user_name', array( 'user_id' => $id ), __METHOD__ );
+		// Wikia change - @see SUS-1015
+		return self::newFromId( $id )->getName();
 	}
 
 	/**


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-1015

Caching was added in MW1.20 by https://github.com/wikimedia/mediawiki/commit/1b7045e341f898a45e6831ba04406a97c4802cda

Simply use `User::newFromId` which handles caching internally. `User::whoIs` method **makes ~20 mm DB queries every 24h**. Caching here sounds like a pretty interesting option :smile: 

## Example

```sql
> echo User::newFromId(1)->getName()
memcached: get(dev-macbre-plpoznan:user:id:1)
memcached: MemCache: sock i:0; got dev-macbre-plpoznan:user:id:1
memcached: get(dev-macbre-wikicities:user_touched:v1:1)
memcached: MemCache: sock i:0; got dev-macbre-wikicities:user_touched:v1:1
User: got user 1 from cache
W-Jasonr

> echo User::whoIs(1)
Connecting to geo-db-dev-db-slave.query.consul plpoznan...
Query plpoznan (DB user: wikia_maint) (9) (slave): SHOW /* DatabaseMysqlBase::getLagFromSlaveStatus CommandLineInc - 8aeeebef-3146-4e51-8664-778d8887fe7d */ SLAVE STATUS
memcached: client: serializing data as it is not scalar
memcached: set dev-macbre-wikicities:db:lag_times:geo-db-dev-db-master.query.consul (STORED)
LoadBalancer::getReaderIndex: Using reader #1: geo-db-dev-db-slave.query.consul...
Query plpoznan (DB user: wikia_maint) (10) (slave): SELECT /* User::whoIs CommandLineInc - 8aeeebef-3146-4e51-8664-778d8887fe7d */  user_name  FROM `wikicities_c1`.`user`  WHERE user_id = '1'  LIMIT 1  
W-Jasonr
```

### After a fix

```sql
> echo User::whoIs(1)
memcached: get(dev-macbre-plpoznan:user:id:1)
memcached: MemCache: sock i:0; got dev-macbre-plpoznan:user:id:1
memcached: get(dev-macbre-wikicities:user_touched:v1:1)
memcached: MemCache: sock i:0; got dev-macbre-wikicities:user_touched:v1:1
User: got user 1 from cache
W-Jasonr
```