### PR TITLE
SUS-2939 | move queries performed by User::loadFromDatabase to a shared cluster

### DIFF
--- a/includes/User.php
+++ b/includes/User.php
@@ -1107,13 +1107,16 @@ class User implements JsonSerializable {
 			return false;
 		}
 
-		$dbr = wfGetDB( DB_MASTER );
+		// SUS-2339 - query wikicities.user table instead of per-cluster copy
+		// `user` - backticks prevent adding `wikicities_cX` prefix to the table name
+		global $wgExternalSharedDB;
+		$dbr = wfGetDB( DB_MASTER, [],  $wgExternalSharedDB );
 		if ( !is_object( $dbr ) ) {
 			$this->loadDefaults();
 			return false;
 		}
 
-		$s = $dbr->selectRow( 'user', '*', array( 'user_id' => $this->mId ), __METHOD__ );
+		$s = $dbr->selectRow( '`user`', '*', array( 'user_id' => $this->mId ), __METHOD__ );
 		Hooks::run( 'UserLoadFromDatabase', array( $this, &$s ) );
 
 		if ( $s !== false ) {


### PR DESCRIPTION
As a part of our work on UserRenameTool refactoring let's get rid of dependency on per-cluster copies of user table. First, let's query `wikicities.user` when `User::loadFromDatabase` is called - **it's ~2.5mm queries daily**.

https://wikia-inc.atlassian.net/browse/SUS-2939

## Example

```sql
> echo User::whoIs(30)
...
Query wikicities (DB user: wikia_maint) (12) (master): SELECT /* User::loadFromDatabase CommandLineInc - 6c80a79f-40aa-44fd-87bc-daba0b6c2389 */  *  FROM `user`  WHERE user_id = '30'  LIMIT 1  
...
```