### PR TITLE
SUS-2148 | add fandom interwiki

### DIFF
--- a/maintenance/wikia/city_interwiki_links.sql
+++ b/maintenance/wikia/city_interwiki_links.sql
@@ -589,4 +589,5 @@ REPLACE INTO interwiki (iw_prefix, iw_url, iw_local, iw_trans) VALUES
 ("wowwiki","http://www.wowwiki.com/$1",0,0),
 ("wikimoon","http://wikimoon.org/index.php?title=$1",0,0),
 ("homepage","http://www.wikia.com/$1",1,0),
-("wikiavideo","http://video.wikia.com/wiki/Video:$1",1,1);
+("wikiavideo","http://video.wikia.com/wiki/Video:$1",1,1),
+("fandom","http://fandom.wikia.com/articles/$1",1,0);


### PR DESCRIPTION
Example: `[[fandom:the-most-mad-max-moments-from-the-maze-runner-the-death-cure-trailer|The Most Mad Max Moments From the 'Maze Runner: The Death Cure' Trailer]]`
Will link to: http://fandom.wikia.com/articles/the-most-mad-max-moments-from-the-maze-runner-the-death-cure-trailer

https://wikia-inc.atlassian.net/browse/SUS-2148

See #13824 for syncing interwiki list with the one from Community Central.