### PR TITLE
ADEN-5917 | Move ooyala tracking to ooyala-player and add line item id

### DIFF
--- a/extensions/wikia/ArticleVideo/scripts/article-featured-video.js
+++ b/extensions/wikia/ArticleVideo/scripts/article-featured-video.js
@@ -387,7 +387,6 @@ require([
 					label: 'recommended-video-depth-' + recommendedVideoDepth
 				});
 
-
 				ooyalaVideoController.updateAdSet(ooyalaAdSetProvider.get(recommendedVideoDepth + 1, correlator, {
 					contentSourceId: videoData.dfpContentSourceId,
 					videoId: nextVideoId

--- a/extensions/wikia/ArticleVideo/scripts/article-featured-video.js
+++ b/extensions/wikia/ArticleVideo/scripts/article-featured-video.js
@@ -11,7 +11,6 @@ require([
 	'wikia.articleVideo.trackingQueue',
 	'wikia.articleVideo.ooyalaService',
 	require.optional('ext.wikia.adEngine.lookup.a9'),
-	require.optional('ext.wikia.adEngine.video.player.ooyala.ooyalaTracker'),
 	require.optional('ext.wikia.adEngine.video.ooyalaAdSetProvider')
 ], function (
 	window,
@@ -26,7 +25,6 @@ require([
 	TrackingQueue,
 	ooyalaService,
 	a9,
-	playerTracker,
 	ooyalaAdSetProvider
 ) {
 
@@ -45,10 +43,6 @@ require([
 			collapsingDisabled = false,
 			playTime = -1,
 			percentagePlayTime = -1,
-			playerTrackerParams = {
-				adProduct: 'featured-video-preroll',
-				slotName: 'FEATURED'
-			},
 			trackingQueue = new TrackingQueue({
 				category: 'article-video',
 				trackingMethod: 'analytics'
@@ -85,12 +79,16 @@ require([
 					}
 				},
 				options = {
-					pcode: window.wgOoyalaParams.ooyalaPCode,
-					playerBrandingId: window.wgOoyalaParams.ooyalaPlayerBrandingId,
-					videoId: videoId,
+					adTrackingParams: {
+						adProduct: 'featured-video-preroll',
+						slotName: 'FEATURED'
+					},
 					autoplay: autoplayOnLoad,
 					inlineSkinConfig: inlineSkinConfig,
-					recommendedLabel: recommendedLabel
+					pcode: window.wgOoyalaParams.ooyalaPCode,
+					playerBrandingId: window.wgOoyalaParams.ooyalaPlayerBrandingId,
+					recommendedLabel: recommendedLabel,
+					videoId: videoId
 				};
 
 			if (ooyalaAdSetProvider.canShowAds()) {
@@ -110,7 +108,7 @@ require([
 				}
 
 			} else {
-				playerTrackerParams.adProduct = 'featured-video-no-preroll';
+				options.adTrackingParams.adProduct = 'featured-video-no-preroll';
 				initPlayerWithTracking(options, onCreate);
 			}
 
@@ -118,10 +116,6 @@ require([
 		}
 
 		function initPlayerWithTracking(options, onCreate) {
-			if (playerTracker) {
-				playerTracker.track(playerTrackerParams, 'init');
-			}
-
 			ooyalaVideoController = OoyalaPlayer.initHTML5Player(ooyalaVideoElementId, options, onCreate);
 		}
 
@@ -264,10 +258,6 @@ require([
 		initVideo(function (player) {
 			$video.addClass('ready-to-play');
 
-			if (playerTracker) {
-				playerTracker.register(player, playerTrackerParams);
-			}
-
 			player.mb.subscribe(window.OO.EVENTS.INITIAL_PLAY, 'featured-video', function () {
 				initialPlayTriggered = true;
 
@@ -396,6 +386,7 @@ require([
 					action: tracker.ACTIONS.VIEW,
 					label: 'recommended-video-depth-' + recommendedVideoDepth
 				});
+
 
 				ooyalaVideoController.updateAdSet(ooyalaAdSetProvider.get(recommendedVideoDepth + 1, correlator, {
 					contentSourceId: videoData.dfpContentSourceId,

--- a/extensions/wikia/ArticleVideo/scripts/ooyala-player.js
+++ b/extensions/wikia/ArticleVideo/scripts/ooyala-player.js
@@ -205,8 +205,6 @@ define('ooyala-player', [
 			params.replayAds = options.replayAds || false;
 		}
 
-
-
 		html5Player = new OoyalaHTML5Player(document.getElementById(videoElementId), params, onCreate, options.inlineSkinConfig);
 		html5Player.setUpPlayer();
 


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/ADEN-5917

## Description

Passing value by reference isn't easy to understand, although we don't have access to `player` object inside `onAdRequestSuccess()` method (when we call this method `player` is not instantiated). So there is no easy way to update tracking on a player from that method. That's why I decided to go with reference magic.

Tracing events after we get ad response contains `line_item_id` and `creative_id`:
* started
* completed
* content_started
* content_completed

Events triggered before ad response don't contain that info.