### PR TITLE
SUS-2945 | add caching in User::idFromName

### DIFF
--- a/includes/User.php
+++ b/includes/User.php
@@ -425,7 +425,7 @@ class User implements JsonSerializable {
 	}
 
 	private static function getCacheKeyByName( string $name ) : string {
-		return wfMemcKey( 'user', 'name', $name );
+		return wfSharedMemcKey( 'user', 'name', $name );
 	}
 
 	/** @name newFrom*() static factory methods */
@@ -615,7 +615,7 @@ class User implements JsonSerializable {
 		}
 
 		if ( isset( self::$idCacheByName[$name] ) ) {
-			return self::$idCacheByName[$name];
+			return (int) self::$idCacheByName[$name];
 		}
 
 		// SUS-2945 | this method makes ~32mm queries every day
@@ -626,7 +626,7 @@ class User implements JsonSerializable {
 		$cachedId = $wgMemc->get( $key );
 
 		if ( is_numeric( $cachedId ) ) {
-			return self::$idCacheByName[$name] = $cachedId;
+			return (int) self::$idCacheByName[$name] = $cachedId;
 		}
 
 		// not in cache, query the database

--- a/includes/User.php
+++ b/includes/User.php
@@ -630,8 +630,9 @@ class User implements JsonSerializable {
 		}
 
 		// not in cache, query the database
-		$dbr = wfGetDB( DB_SLAVE );
-		$s = $dbr->selectRow( 'user', array( 'user_id' ), array( 'user_name' => $nt->getText() ), __METHOD__ );
+		global $wgExternalSharedDB; // SUS-2945 - let's use wikicities.user instead of per-cluster copy
+		$dbr = wfGetDB( DB_SLAVE, [], $wgExternalSharedDB );
+		$s = $dbr->selectRow( '`user`', array( 'user_id' ), array( 'user_name' => $nt->getText() ), __METHOD__ );
 
 		if ( $s === false ) {
 			$user_name = $nt->getText();

--- a/includes/User.php
+++ b/includes/User.php
@@ -625,7 +625,7 @@ class User implements JsonSerializable {
 		$key = self::getCacheKeyByName( $name );
 		$cachedId = $wgMemc->get( $key );
 
-		if ( is_int( $cachedId ) ) {
+		if ( is_numeric( $cachedId ) ) {
 			return self::$idCacheByName[$name] = $cachedId;
 		}
 
@@ -642,12 +642,12 @@ class User implements JsonSerializable {
 			$result = null;
 		} else {
 			$result = (int) $s->user_id;
+
+			// SUS-2945 - only store when there's a match
+			$wgMemc->set( $key, $result, WikiaResponse::CACHE_LONG );
 		}
 
 		self::$idCacheByName[$name] = $result;
-
-		// SUS-2945
-		$wgMemc->set( $key, $result, WikiaResponse::CACHE_LONG );
 
 		if ( count( self::$idCacheByName ) > 1000 ) {
 			self::$idCacheByName = array();


### PR DESCRIPTION
#This method makes **~32mm database queries daily**.

* add a cache in `User::idFromName`
* invalidate it when `User::clearSharedCache` is called
* set it when `User::saveToCache` is called to increase hit ratio
* use `wikicities.user` table instead of per-cluster copy of `user` table (7e7be9a / see SUS-2779)

https://wikia-inc.atlassian.net/browse/SUS-2945

## Cold cache

```sql
> var_dump( User::idFromName('Pyrabot') )
memcached: get(dev-macbre-wikicities:user:name:Pyrabot)
Connecting to geo-db-dev-db-slave.query.consul wikicities...
...
Query wikicities (DB user: wikia_maint) (10) (slave): SELECT /* User::idFromName CommandLineInc - b2d050c2-8eaa-42d3-830d-32f313cf3410 */  user_id  FROM `user`  WHERE user_name = 'Pyrabot'  LIMIT 1  
memcached: set dev-macbre-wikicities:user:name:Pyrabot (STORED)
/usr/wikia/source/deploytools/18879/src/maintenance/eval.php(88) : eval()'d code:1:
int(5059646)
```

## Warm cache

```sql
> var_dump( User::idFromName('Pyrabot') )
memcached: get(dev-macbre-wikicities:user:name:Pyrabot)
memcached: MemCache: sock i:0; got dev-macbre-wikicities:user:name:Pyrabot
/usr/wikia/source/deploytools/18879/src/maintenance/eval.php(88) : eval()'d code:1:
int(5059646)
```