### PR TITLE
SUS-2944 | ApiQueryCheckUser - use cuc_user and cuc_user_text columns to get username / IP address for anons

### DIFF
--- a/extensions/CheckUser/api/ApiQueryCheckUser.php
+++ b/extensions/CheckUser/api/ApiQueryCheckUser.php
@@ -45,7 +45,7 @@ class ApiQueryCheckUser extends ApiQueryBase {
 				}
 
 				$this->addFields( array( 'cuc_timestamp', 'cuc_ip', 'cuc_xff' ) );
-				$this->addWhereFld( 'cuc_user_text', $target );
+				$this->addWhereFld( 'cuc_user', $user_id ); // SUS-2944
 				$res = $this->select( __METHOD__ );
 				$result = $this->getResult();
 
@@ -95,12 +95,12 @@ class ApiQueryCheckUser extends ApiQueryBase {
 					if ( !$user_id ) {
 						$this->dieUsage( 'Target user does not exists', 'nosuchuser' );
 					}
-					$this->addWhereFld( 'cuc_user_text', $target );
+					$this->addWhereFld( 'cuc_user', $user_id ); // SUS-2944
 					$log_type = array( 'useredits', 'user' );
 				}
 
 				$this->addFields( array( 
-					'cuc_namespace', 'cuc_title', 'cuc_user_text', 'cuc_actiontext',
+					'cuc_namespace', 'cuc_title', 'cuc_user', 'cuc_user_text', 'cuc_actiontext',
 					'cuc_comment', 'cuc_minor', 'cuc_timestamp', 'cuc_ip', 'cuc_xff', 'cuc_agent' 
 				) );
 
@@ -113,7 +113,7 @@ class ApiQueryCheckUser extends ApiQueryBase {
 						'timestamp' => wfTimestamp( TS_ISO_8601, $row->cuc_timestamp ),
 						'ns'        => intval( $row->cuc_namespace ),
 						'title'     => $row->cuc_title,
-						'user'      => $row->cuc_user_text,
+						'user'      => User::getUsername( $row->cuc_user, $row->cuc_user_text ), // SUS-2944
 						'ip'        => $row->cuc_ip,
 						'agent'     => $row->cuc_agent,
 					);
@@ -152,14 +152,14 @@ class ApiQueryCheckUser extends ApiQueryBase {
 				}
 
 				$this->addFields( array( 
-					'cuc_user_text', 'cuc_timestamp', 'cuc_ip', 'cuc_agent' ) );
+					'cuc_user', 'cuc_user_text', 'cuc_timestamp', 'cuc_ip', 'cuc_agent' ) );
 
 				$res = $this->select( __METHOD__ );
 				$result = $this->getResult();
 
 				$users = array();
 				foreach ( $res as $row ) {
-					$user = $row->cuc_user_text;
+					$user = User::getUsername( $row->cuc_user, $row->cuc_user_text ); // SUS-2944
 					$ip = $row->cuc_ip;
 					$agent = $row->cuc_agent;
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-2944

## `ApiQueryCheckUser`

http://poznan.macbre.wikia-dev.pl/api.php?action=query&list=checkuser&curequest=userips&cutarget=Macbre

```
Query plpoznan (DB user: wikia_mw2) (11) (slave): SELECT /* ApiQueryCheckUser::execute Macbre - 0efa6d47-9b97-4687-8292-72bd2b82d8c9 */  cuc_timestamp,cuc_ip,cuc_xff  FROM `cu_changes`  WHERE (cuc_timestamp > '20170920085229') AND cuc_user = '119245'  ORDER BY cuc_timestamp DESC LIMIT 1001  
```

http://poznan.macbre.wikia-dev.pl/api.php?action=query&list=checkuser&curequest=ipusers&cutarget=2001:978:3500:BEEF:0:0:0:102F

```
Query plpoznan (DB user: wikia_mw2) (10) (slave): SELECT /* ApiQueryCheckUser::execute Macbre - d100d6c1-eae7-42fc-a06a-95867c4ff1f7 */  cuc_user,cuc_user_text,cuc_timestamp,cuc_ip,cuc_agent  FROM `cu_changes`  WHERE (cuc_timestamp > '20170920085338') AND cuc_ip_hex = 'v6-200109783500BEEF000000000000102F'  ORDER BY cuc_timestamp DESC LIMIT 1001  
```