### PR TITLE
SUS-2948: In Theme Designer fix middle background color

### DIFF
--- a/extensions/wikia/ThemeDesigner/ThemeDesignerHelper.class.php
+++ b/extensions/wikia/ThemeDesigner/ThemeDesignerHelper.class.php
@@ -65,6 +65,7 @@ class ThemeDesignerHelper {
 	public static function getColorVars() {
 		return [
 			'color-body' => '#BACDD8',
+			'color-body-middle' => '#BACDD8',
 			'color-page' => '#FFF',
 			'color-community-header' => '#006CB0',
 			'color-buttons' => '#006CB0',

--- a/extensions/wikia/ThemeDesigner/ThemeSettings.class.php
+++ b/extensions/wikia/ThemeDesigner/ThemeSettings.class.php
@@ -64,6 +64,7 @@ class ThemeSettings {
 		// colors
 		$this->defaultSettings = $wgOasisThemes[$themeName];
 		$this->defaultSettings['theme'] = $themeName;
+		$this->defaultSettings['color-body-middle'] = $this->defaultSettings['color-body'];
 
 		// wordmark
 		$this->defaultSettings['wordmark-text'] = $wgSitename;


### PR DESCRIPTION
Define `color-body-middle` as known settings property.

https://wikia-inc.atlassian.net/browse/SUS-2948