### PR TITLE
SUS-2766: Cleanup Phalanx after Kubernetes migration

### DIFF
--- a/extensions/wikia/PhalanxII/PhalanxSpecialController.class.php
+++ b/extensions/wikia/PhalanxII/PhalanxSpecialController.class.php
@@ -239,7 +239,7 @@ class PhalanxSpecialController extends WikiaSpecialPageController {
 			'reason'     => $request->getText( 'wpPhalanxReason' ),
 			'comment'    => $request->getText( 'wpPhalanxComment' ),
 			'lang'       => $request->getVal( 'wpPhalanxLanguages', null ),
-			'type'       => $request->getArray( 'wpPhalanxType' ),
+			'type'       => (array) $request->getArray( 'wpPhalanxType' ),
 			'multitext'  => $request->getText( 'wpPhalanxFilterBulk' ),
 			'expire'     => $expire
 		];

--- a/extensions/wikia/PhalanxII/classes/Phalanx.class.php
+++ b/extensions/wikia/PhalanxII/classes/Phalanx.class.php
@@ -80,11 +80,14 @@ class Phalanx extends WikiaModel implements ArrayAccess {
 	 * @param $blockId int
 	 * @return Phalanx
 	 */
-	public static function newFromId( $blockId ) {
+	public static function newFromId( $blockId ): Phalanx {
 		$instance = new Phalanx( $blockId );
 
 		// read data from database
-		$instance->load();
+		if ( !empty( $blockId ) ) {
+			$instance->load();
+		}
+
 		return $instance;
 	}
 

--- a/extensions/wikia/PhalanxII/hooks/PhalanxHooks.class.php
+++ b/extensions/wikia/PhalanxII/hooks/PhalanxHooks.class.php
@@ -203,13 +203,13 @@ class PhalanxHooks extends WikiaObject {
 		$id = $phalanx->delete();
 		if ( $id ) {
 			$service = Injector::getInjector()->get( PhalanxService::class );
-			$ret = $service->reload( [ $id ] );
-		} else {
-			$ret = false;
+			$service->reload( [ $id ] );
+
+			return true;
 		}
 
 		wfProfileOut( __METHOD__ );
-		return $ret;
+		return false;
 	}
 
 	/**

--- a/extensions/wikia/PhalanxII/models/PhalanxModel.php
+++ b/extensions/wikia/PhalanxII/models/PhalanxModel.php
@@ -1,5 +1,7 @@
 <?php
 
+use Wikia\DependencyInjection\Injector;
+
 /**
  * @method PhalanxModel setBlock( $block )
  * @method object getBlock
@@ -31,7 +33,7 @@ abstract class PhalanxModel extends WikiaObject {
 		parent::__construct();
 
 		$this->user = $this->wg->user;
-		$this->service = new PhalanxService();
+		$this->service = Injector::getInjector()->get( PhalanxService::class );
 		$this->ip = $this->wg->request->getIp();
 	}
 

--- a/extensions/wikia/PhalanxII/services/PhalanxService.class.php
+++ b/extensions/wikia/PhalanxII/services/PhalanxService.class.php
@@ -2,6 +2,8 @@
 
 use Wikia\Service\Gateway\ConsulUrlProvider;
 use Wikia\Rabbit\ConnectionBase;
+use Wikia\Service\Gateway\KubernetesUrlProvider;
+use Wikia\Service\Gateway\UrlProvider;
 
 /**
  * @method PhalanxService setLimit( int $limit )
@@ -16,6 +18,9 @@ class PhalanxService {
 	/** @var User */
 	private $user = null;
 
+	/** @var UrlProvider $urlProvider */
+	private $urlProvider;
+
 	const RES_OK = 'ok';
 	const RES_FAILURE = 'failure';
 	const RES_STATUS = 'PHALANX ALIVE';
@@ -29,13 +34,12 @@ class PhalanxService {
 	const PHALANX_SERVICE_TRY_USLEEP = 20000;
 
 	/**
-	 * @var int PHALANX_SERVICE_RELOAD_TIMEOUT
-	 * SUS-964: Give Phalanx /reload requests more time to succeed (25 seconds, the old default
-	 * for $wgHttpTimeout)
-	 * This does not affect site performance - /reload requests are sent only upon
-	 * saving/modifying a block.
+	 * @Inject
+	 * @param KubernetesUrlProvider $urlProvider
 	 */
-	const PHALANX_SERVICE_RELOAD_TIMEOUT = 25;
+	public function __construct( KubernetesUrlProvider $urlProvider ) {
+		$this->urlProvider = $urlProvider;
+	}
 
 	protected function getLoggerContext() {
 		return [
@@ -115,32 +119,14 @@ class PhalanxService {
 	}
 
 	/**
-	 * service for reload function
-	 *
-	 * @example curl "http://localhost:8080/reload?changed=1,2,3"
-	 *
-	 * @param array $changed -- list of rules to reload, default empty array so reload all
-	 *
-	 * @return int|mixed
+	 * Instruct Phalanx nodes to load a set of rules (identified by ID) from the database
+	 * @param int[] $changed -- list of rules to reload
 	 */
 	public function reload( $changed = [] ) {
-		wfProfileIn( __METHOD__ );
-
-		$params = is_array( $changed ) && sizeof( $changed )
-			? [ "changed" => implode( ",", $changed ) ]
-			: [];
-
-		$result = $this->sendToPhalanxDaemon( "reload", $params );
-		$this->sendToPhalanxQueue( $changed );
-		wfProfileOut( __METHOD__ );
-		return $result;
-	}
-
-	private function sendToPhalanxQueue( $changed ) {
 		global $wgPhalanxQueue;
 
 		$rabbitConnection = new ConnectionBase( $wgPhalanxQueue );
-		$rabbitConnection->publish ( self::ROUTING_KEY, implode( ",", $changed ) );
+		$rabbitConnection->publish( self::ROUTING_KEY, implode( ",", $changed ) );
 	}
 
 	/**
@@ -155,19 +141,6 @@ class PhalanxService {
 	public function validate( $regex ) {
 		wfProfileIn( __METHOD__ );
 		$result = $this->sendToPhalanxDaemon( "validate", [ "regex" => $regex ] );
-		wfProfileOut( __METHOD__ );
-		return $result;
-	}
-
-	/**
-	 * service for stats method
-	 *
-	 * @example curl "http://localhost:8080/stats"
-	 *
-	 */
-	public function stats() {
-		wfProfileIn( __METHOD__ );
-		$result = $this->sendToPhalanxDaemon( "stats", [] );
 		wfProfileOut( __METHOD__ );
 		return $result;
 	}
@@ -233,22 +206,14 @@ class PhalanxService {
 				}
 			}
 
-			// SUS-964: Give reload requests more time to succeed
-			// Reload requests are only sent upon saving/modifying a block,
-			// so using a higher value here won't affect site performance
-			if ( $action === 'reload' ) {
-				$options['timeout'] = static::PHALANX_SERVICE_RELOAD_TIMEOUT;
-			}
-
 			$options["postData"] = implode( "&", $postData );
-			wfDebug( __METHOD__ . ": calling $url with POST data " . $options["postData"] . "\n" );
-			wfDebug( __METHOD__ . ": " . json_encode( $parameters ) . "\n" );
+
 			$requestTime = microtime( true );
 
 			// BAC-1332 - some of the phalanx service calls are breaking and we're not sure why
 			// it's better to do the retry than maintain the PHP fallback for that
+			$url = $this->getPhalanxUrl( $action );
 			while ( $tries <= self::PHALANX_SERVICE_TRIES_LIMIT ) {
-				$url = $this->getPhalanxUrl( $action );
 				$response = Http::post( $url, $options );
 				if ( false !== $response ) {
 					break;
@@ -332,14 +297,13 @@ class PhalanxService {
 	}
 
 	private function getPhalanxUrl( $action ) {
-		global $wgConsulUrl, $wgConsulServiceTag, $wgPhalanxServiceUrl;
+		global $wgPhalanxServiceUrl;
 
 		if ( !empty( $wgPhalanxServiceUrl ) ) {
 			// e.g. "localhost:4666"
 			$baseurl = $wgPhalanxServiceUrl;
 		} else {
-			$baseurl = ( new ConsulUrlProvider( $wgConsulUrl, $wgConsulServiceTag ) )
-				->getUrl( 'phalanx' );
+			$baseurl = $this->urlProvider->getUrl( 'phalanx' );
 		}
 
 		return sprintf( "http://%s/%s", $baseurl, $action != "status" ? $action : "" );

--- a/extensions/wikia/PhalanxII/tests/PhalanxModelTest.php
+++ b/extensions/wikia/PhalanxII/tests/PhalanxModelTest.php
@@ -58,6 +58,7 @@ class PhalanxModelTest extends WikiaBaseTest {
 	private function setUpService( $block ) {
 		$phalanxServiceMock =
 			$this->getMockBuilder( PhalanxService::class )
+				->disableOriginalConstructor()
 				->setMethods( [ 'match' ] )
 				->getMock();
 

--- a/extensions/wikia/PhalanxII/tests/PhalanxServiceTest.php
+++ b/extensions/wikia/PhalanxII/tests/PhalanxServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Wikia\DependencyInjection\Injector;
+
 /**
  * @category Wikia
  * @group Integration
@@ -13,7 +15,7 @@ class PhalanxServiceTest extends WikiaBaseTest {
 		$this->setupFile =  __DIR__ . '/../Phalanx_setup.php';
 		parent::setUp();
 
-		$this->service = new PhalanxService();
+		$this->service = Injector::getInjector()->get( PhalanxService::class );
 		if ( !$this->service->status() ) {
 			// Skip test if phalanx service is not available
 			$this->markTestSkipped( "Can't connect to phalanx service" );
@@ -86,11 +88,4 @@ class PhalanxServiceTest extends WikiaBaseTest {
 		$this->assertEquals( 0, $ret, "Invalid regex" );
 
 	}
-
-	public function testPhalanxServiceStats() {
-		$ret = $this->service->stats( );
-		// check for known strings
-		$this->assertRegexp( "/email|wiki_creation|summary/", $ret );
-	}
-
 }


### PR DESCRIPTION
* no need to call `/reload` anymore - rule synchronization is handled by 🐇 
* use k8s url instead of consul

https://wikia-inc.atlassian.net/browse/SUS-2766