### PR TITLE
SUS-2904 | InitStats should not call SiteStatsInit::views() 

### DIFF
--- a/includes/SiteStatsUpdate.php
+++ b/includes/SiteStatsUpdate.php
@@ -107,7 +107,7 @@ class SiteStatsUpdate implements DeferrableUpdate {
 		SiteStats::invalidateCache(); // Wikia change
 	}
 	/**
-	 * @param IDatabase $dbw
+	 * @param DatabaseBase $dbw
 	 * @return bool|mixed
 	 */
 	public static function cacheUpdate( $dbw ) {

--- a/maintenance/initStats.php
+++ b/maintenance/initStats.php
@@ -30,7 +30,6 @@ class InitStats extends Maintenance {
 		parent::__construct();
 		$this->mDescription = "Re-initialise the site statistics tables";
 		$this->addOption( 'update', 'Update the existing statistics' );
-		$this->addOption( 'noviews', "Don't update the page view counter" );
 		$this->addOption( 'active', 'Also update active users count' );
 		$this->addOption( 'use-master', 'Count using the master database' );
 	}
@@ -54,12 +53,6 @@ class InitStats extends Maintenance {
 
 		$image = $counter->files();
 		$this->output( "{$image}\n" );
-
-		if ( !$this->hasOption( 'noviews' ) ) {
-			$this->output( "Counting total page views..." );
-			$views = $counter->views();
-			$this->output( "{$views}\n" );
-		}
 
 		if ( $this->hasOption( 'active' ) ) {
 			$this->output( "Counting active users..." );


### PR DESCRIPTION
This methods was removed as a part of SUS-2651 (see #13628).

https://wikia-inc.atlassian.net/browse/SUS-2904