### PR TITLE
SUS-2950 | greatly improve caching in WikiFactory::getCategories

### DIFF
--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -2756,9 +2756,9 @@ class WikiFactory {
 	 * @deprecated
 	 */
 
-	static public function getCategory ( $city_id ) {
+	static public function getCategory ( int $city_id ) {
 		// return deprecated category list
-		$categories = static::getCategories( $city_id, true );
+		$categories = self::getCategories( $city_id, true );
 		return !empty($categories) ? $categories[0] : 0;
 	}
 
@@ -2766,13 +2766,12 @@ class WikiFactory {
 	/**
 	 * get new category id and name for $city_id
 	 *
-	 * @param integer	$city_id		wikia identifier in city_list
-	 *
+	 * @param int	$city_id		wikia identifier in city_list
+	 * @param bool $deprecated
 	 * @return array of stdClass ($row->cat_id $row->cat_name) or empty array
 	 *
 	 */
-
-	static public function getCategories( $city_id, $deprecated = false ) {
+	static private function getCategories( int $city_id, $deprecated = false ) {
 		global $wgRunningUnitTests, $wgNoDBUnits;
 
 		$aCategories = [];
@@ -2803,7 +2802,7 @@ class WikiFactory {
 		$memkey = sprintf("%s:%d", __METHOD__, intval($city_id));
 		$cached = $oMemc->get($memkey);
 
-		if ( empty($cached) ) {
+		if ( !is_array($cached) ) {
 			$dbr = static::db( DB_SLAVE );
 
 			$oRes = $dbr->select(
@@ -2818,10 +2817,11 @@ class WikiFactory {
 				$aOptions
 			);
 
+			$aCategories = [];
 			while ( $oRow = $dbr->fetchObject( $oRes ) ) {
 				$aCategories[] = $oRow;
 			}
-			$oMemc->set($memkey, $aCategories, 60*60*24);
+			$oMemc->set( $memkey, $aCategories, WikiaResponse::CACHE_LONG );
 		} else {
 			$aCategories = $cached;
 		}


### PR DESCRIPTION
Due to the way cache miss was checked (caching was added here 7 years ago) we were incorrectly assuming miss when the database query returned no rows (and that's what happens in 97.6% of cases).

This resulted in **42 mm queries to shared DB daily** (over 40% of all SELECT queries hitting shared database cluster).

https://wikia-inc.atlassian.net/browse/SUS-2950

## Example

### Cache miss

```sql
> var_dump( WikiFactory::getCategory( 5 ) )
memcached: get(WikiFactory::getCategories:5)
...
Query wikicities (DB user: wikia_maint) (8) (slave): SELECT /* WikiFactory::getCategories CommandLineInc - 6b9e7605-ef69-49de-8ba1-a4c8fc49cf3c */  city_cats.cat_id as cat_id,city_cats.cat_name as cat_name  FROM `city_cat_mapping`,`city_cats`  WHERE city_id = '5' AND (city_cats.cat_id = city_cat_mapping.cat_id) AND (city_cats.cat_deprecated = 1)  LIMIT 1  
memcached: client: serializing data as it is not scalar
memcached: set WikiFactory::getCategories:5 (STORED)
...
int(0)
```

### Cache hit (even on empty results set)

```sql
> var_dump( WikiFactory::getCategory( 5 ) )
memcached: get(WikiFactory::getCategories:5)
memcached: MemCache: sock i:0; got WikiFactory::getCategories:5
...
int(0)
```

It did work correctly (before this fix) in rare cases:

```
>  var_dump( WikiFactory::getCategory( 831 ) )
memcached: get(WikiFactory::getCategories:831)
memcached: MemCache: sock i:0; got WikiFactory::getCategories:831
object(stdClass)#288 (2) {
  ["cat_id"]=>
  string(1) "3"
  ["cat_name"]=>
  string(13) "Entertainment"
}
```