### PR TITLE
SUS-2957 | remove wgExtensionMessagesFiles global

### DIFF
--- a/extensions/3rdparty/LyricWiki/BetterLyricWikiTextSnippets.php
+++ b/extensions/3rdparty/LyricWiki/BetterLyricWikiTextSnippets.php
@@ -22,7 +22,6 @@ $wgExtensionCredits['other'][] = array(
 $dir = dirname(__FILE__);
 
 // Internalization
-$wgExtensionMessagesFiles['BetterLyricWikiTextSnippets'] = $dir . '/BetterLyricWikiTextSnippets.i18n.php';
 
 // Hooks
 $wgHooks['ArticleService::getTextSnippet::beforeStripping'][] = 'efLyricWikiGetTextSnippet';

--- a/extensions/3rdparty/LyricWiki/Hook_PreventBlanking.php
+++ b/extensions/3rdparty/LyricWiki/Hook_PreventBlanking.php
@@ -3,7 +3,6 @@
 require_once 'extras.php';
 
 $wgHooks['EditFilter'][] = 'stopBlanking';
-$wgExtensionMessagesFiles["PreventBlanking"] = "$LW/Hook_PreventBlanking.i18n.php";
 
 function stopBlanking($editor, $text, $section, &$error )
 {

--- a/extensions/3rdparty/LyricWiki/ImageServing_LyricWiki.php
+++ b/extensions/3rdparty/LyricWiki/ImageServing_LyricWiki.php
@@ -19,7 +19,6 @@ $wgExtensionCredits['other'][] = array(
 );
 
 $dir = dirname( __FILE__ );
-$wgExtensionMessagesFiles['ImageServing_LyricWiki'] = $dir . '/ImageServing_LyricWiki.i18n.php';
 
 $wgHooks['ImageServing::fallbackOnNoResults'][] = 'lw_ImageServingFallback';
 

--- a/extensions/3rdparty/LyricWiki/LyricFind/LyricFind.setup.php
+++ b/extensions/3rdparty/LyricWiki/LyricFind/LyricFind.setup.php
@@ -16,7 +16,6 @@ $dir = __DIR__;
 
 // common code
 $wgAutoloadClasses['LyricFindHooks'] =  $dir . '/LyricFindHooks.class.php';
-$wgExtensionMessagesFiles['LyricFind'] = $dir . '/LyricFind.i18n.php';
 
 // LyricFind page views tracking
 $wgAutoloadClasses['LyricFindController'] =  $dir . '/LyricFindController.class.php';

--- a/extensions/3rdparty/LyricWiki/SongOfTheDay/Special_SOTD.php
+++ b/extensions/3rdparty/LyricWiki/SongOfTheDay/Special_SOTD.php
@@ -17,4 +17,3 @@ $wgExtensionCredits['specialpage'][] = array(
 $dir = dirname(__FILE__) . '/';
 $wgAutoloadClasses['SOTD'] = $dir . 'Special_SOTD.body.php';
 $wgSpecialPages['SOTD'] = 'SOTD';
-$wgExtensionMessagesFiles['SOTD'] = $dir . 'Special_SOTD.i18n.php';

--- a/extensions/3rdparty/LyricWiki/Special_ArtistRedirects.php
+++ b/extensions/3rdparty/LyricWiki/Special_ArtistRedirects.php
@@ -20,6 +20,5 @@ $wgExtensionCredits["specialpage"][] = array(
 );
 $dir = dirname(__FILE__) . '/';
 $wgAutoloadClasses['ArtistRedirects'] = $dir . 'Special_ArtistRedirects.body.php'; # Tell MediaWiki to load the extension body.
-$wgExtensionMessagesFiles['ArtistRedirects'] = $dir . 'Special_ArtistRedirects.i18n.php';
 $wgSpecialPages['ArtistRedirects'] = 'ArtistRedirects'; # Let MediaWiki know about your new special page.
 

--- a/extensions/3rdparty/LyricWiki/Special_BatchMove.php
+++ b/extensions/3rdparty/LyricWiki/Special_BatchMove.php
@@ -40,7 +40,6 @@ if(!defined('MEDIAWIKI')) die();
 require_once "extras.php";
 
 $dir = dirname(__FILE__) . '/';
-$wgExtensionMessagesFiles['BatchMove'] = $dir.'Special_BatchMove.i18n.php';
 
 $wgExtensionCredits['specialpage'][] = array(
 	'name' => 'Batch Move',

--- a/extensions/3rdparty/LyricWiki/Special_GoogleSearch.php
+++ b/extensions/3rdparty/LyricWiki/Special_GoogleSearch.php
@@ -29,6 +29,5 @@ EOT;
 $dir = dirname(__FILE__) . '/';
 
 $wgAutoloadClasses['GoogleSearchResults'] = $dir . 'Special_GoogleSearch.body.php'; # Tell MediaWiki to load the extension body.
-$wgExtensionMessagesFiles['GoogleSearchResults'] = $dir . 'Special_GoogleSearch.i18n.php';
 $wgSpecialPages['GoogleSearchResults'] = 'GoogleSearchResults'; # Let MediaWiki know about your new special page.
 

--- a/extensions/3rdparty/LyricWiki/Special_LinksToRedirects.php
+++ b/extensions/3rdparty/LyricWiki/Special_LinksToRedirects.php
@@ -24,7 +24,6 @@ $wgExtensionCredits['specialpage'][] = array(
 	'description' => 'Special page showing all links which point to redirects',
 	'version' => '0.1.1',
 );
-$wgExtensionMessagesFiles['LinksToRedirects'] = dirname(__FILE__).'/Special_LinksToRedirects.i18n.php';
 
 require_once($IP . '/includes/SpecialPage.php');
 $wgSpecialPages['Linkstoredirects'] = 'Linkstoredirects';

--- a/extensions/3rdparty/LyricWiki/Special_MobileSearches.php
+++ b/extensions/3rdparty/LyricWiki/Special_MobileSearches.php
@@ -25,7 +25,6 @@ $wgExtensionCredits['specialpage'][] = array(
 	'description' => 'Info on searches from the LyricWiki Android and iPhone apps',
 	'version' => '1.2',
 );
-$wgExtensionMessagesFiles['SpecialMobileSearches'] = dirname(__FILE__).'/Special_MobileSearches.i18n.php';
 
 require_once($IP . '/includes/SpecialPage.php');
 $wgSpecialPages['MobileSearches'] = 'MobileSearches';

--- a/extensions/3rdparty/LyricWiki/Special_SendToAFriend.php
+++ b/extensions/3rdparty/LyricWiki/Special_SendToAFriend.php
@@ -102,6 +102,5 @@ EOT;
 $dir = dirname(__FILE__) . '/';
 
 $wgAutoloadClasses['SendToAFriend'] = $dir . 'Special_SendToAFriend.body.php'; # Tell MediaWiki to load the extension body.
-$wgExtensionMessagesFiles['SendToAFriend'] = $dir . 'Special_SendToAFriend.i18n.php';
 $wgSpecialPages['SendToAFriend'] = 'SendToAFriend'; # Let MediaWiki know about your new special page.
 

--- a/extensions/3rdparty/LyricWiki/Special_Soapfailures.php
+++ b/extensions/3rdparty/LyricWiki/Special_Soapfailures.php
@@ -39,7 +39,6 @@ $wgExtensionCredits['specialpage'][] = array(
 	'description' => 'SOAP Failures Log special page',
 	'version' => '1.2',
 );
-$wgExtensionMessagesFiles['SpecialSoapFailures'] = dirname(__FILE__).'/Special_Soapfailures.i18n.php';
 
 require_once($IP . '/includes/SpecialPage.php');
 $wgSpecialPages['Soapfailures'] = 'Soapfailures';

--- a/extensions/3rdparty/LyricWiki/Special_WatchlistFeed.php
+++ b/extensions/3rdparty/LyricWiki/Special_WatchlistFeed.php
@@ -42,7 +42,6 @@ EOT;
 $dir = dirname(__FILE__) . '/';
 
 $wgAutoloadClasses['WatchlistFeed'] = $dir . 'Special_WatchlistFeed.body.php';
-$wgExtensionMessagesFiles['WatchlistFeed'] = $dir . 'Special_WatchlistFeed.i18n.php';
 $wgSpecialPages['WatchlistFeed'] = 'WatchlistFeed';
 
 # default options

--- a/extensions/3rdparty/LyricWiki/Special_Wikify.php
+++ b/extensions/3rdparty/LyricWiki/Special_Wikify.php
@@ -46,5 +46,4 @@ if(isset($wgScriptPath)){
 $dir = dirname(__FILE__) . '/';
 
 $wgAutoloadClasses['Wikify'] = $dir . 'Special_Wikify.body.php'; # Tell MediaWiki to load the extension body.
-$wgExtensionMessagesFiles['Wikify'] = $dir . 'Special_Wikify.i18n.php';
 $wgSpecialPages['Wikify'] = 'Wikify'; # Let MediaWiki know about your new special page.

--- a/extensions/3rdparty/LyricWiki/Tag_XML.php
+++ b/extensions/3rdparty/LyricWiki/Tag_XML.php
@@ -56,7 +56,6 @@ require_once 'extras.php';
 
 $dir = dirname(__FILE__) . '/';
 $wgHooks['ParserFirstCallInit'][] = "wfXMLFormatter";
-$wgExtensionMessagesFiles['XMLParser'] = $dir . 'Tag_XML.i18n.php';
 
 if(isset($wgScriptPath))
 {

--- a/extensions/3rdparty/LyricWiki/Templates.php
+++ b/extensions/3rdparty/LyricWiki/Templates.php
@@ -51,7 +51,6 @@ require_once 'Parser_LWMagicWords.php';
 require_once 'extras.php';
 
 $dir = dirname(__FILE__) . '/';
-$wgExtensionMessagesFiles['lwTemplates'] = $dir.'Templates.i18n.php';
 $wgHooks['EditFormPreloadText'][] = array('lw_templatePreload');
 
 /**

--- a/extensions/3rdparty/RSHighscores/RSHighscores.php
+++ b/extensions/3rdparty/RSHighscores/RSHighscores.php
@@ -28,8 +28,6 @@ $wgExtensionCredits['parserhook'][] = array(
 
 $wgAutoloadClasses['RSHiscores'] = __DIR__ . '/RSHighscores.body.php';
 
-$wgExtensionMessagesFiles['RSHiscores'] = __DIR__ . '/RSHighscores.i18n.php';
-$wgExtensionMessagesFiles['RSHiscoresMagic'] = __DIR__ . '/RSHighscores.i18n.magic.php';
 
 $wgHooks['ParserFirstCallInit'][] = 'RSHiscores::register';
 

--- a/extensions/3rdparty/RSS/rss.php
+++ b/extensions/3rdparty/RSS/rss.php
@@ -32,7 +32,6 @@ $wgExtensionCredits['parserhook'][] = array(
 
 define('MAGPIE_OUTPUT_ENCODING', 'UTF-8');
 
-$wgExtensionMessagesFiles['rss'] = dirname(__FILE__) . '/rss.i18n.php';
 
 #change this according to your magpie installation!
 require_once(dirname(__FILE__) . '/magpierss/rss_fetch.inc');

--- a/extensions/3rdparty/Spoiler/Spoiler.php
+++ b/extensions/3rdparty/Spoiler/Spoiler.php
@@ -12,7 +12,6 @@
 # Modified February 2007 by Patrick Delancy for use in TibiaWiki ( http://tibia.erig.net/ )
 
 $wgHooks['ParserFirstCallInit'][] = "wfSpoilerExtension";
-$wgExtensionMessagesFiles['SpoilerExtension'] = dirname(__FILE__) . '/Spoiler.i18n.php';
 $wgHooks['OutputPageBeforeHTML'][] = 'spoilerParserHook' ;
 
 /**

--- a/extensions/AbuseFilter/AbuseFilter.php
+++ b/extensions/AbuseFilter/AbuseFilter.php
@@ -24,8 +24,6 @@ $wgExtensionCredits[version_compare($wgVersion, '1.17alpha', '>=') ? 'antispam' 
 );
 
 $dir = dirname( __FILE__ );
-$wgExtensionMessagesFiles['AbuseFilter'] =  "$dir/AbuseFilter.i18n.php";
-$wgExtensionMessagesFiles['AbuseFilterAliases'] = "$dir/AbuseFilter.alias.php";
 
 $wgAutoloadClasses['AbuseFilter'] = "$dir/AbuseFilter.class.php";
 $wgAutoloadClasses['AbuseFilterParser'] = "$dir/AbuseFilter.parser.php";

--- a/extensions/AntiBot/AntiBot.php
+++ b/extensions/AntiBot/AntiBot.php
@@ -41,7 +41,6 @@ $wgExtensionCredits[version_compare($wgVersion, '1.17alpha', '>=') ? 'antispam' 
 	'author' => 'Tim Starling',
 	'descriptionmsg' => 'antibot-desc',
 );
-$wgExtensionMessagesFiles['AntiBot'] =  dirname( __FILE__ ) . '/AntiBot.i18n.php';
 
 /**
  * A map of payload types to callbacks

--- a/extensions/AntiSpoof/AntiSpoof.php
+++ b/extensions/AntiSpoof/AntiSpoof.php
@@ -23,7 +23,6 @@ $wgAntiSpoofAccounts = true;
 
 $dir = dirname( __FILE__ );
 
-$wgExtensionMessagesFiles['AntiSpoof'] = "$dir/AntiSpoof.i18n.php";
 
 $wgAutoloadClasses['AntiSpoof'] = "$dir/AntiSpoof_body.php";
 $wgAutoloadClasses['AntiSpoofHooks'] = "$dir/AntiSpoofHooks.php";

--- a/extensions/ApiExplorer/SpecialApiExplorer.php
+++ b/extensions/ApiExplorer/SpecialApiExplorer.php
@@ -24,8 +24,6 @@ $wgExtensionCredits['specialpage'][] = array(
 );
 
 $dir = dirname( __FILE__ ) . '/';
-$wgExtensionMessagesFiles['ApiExplorer'] = $dir . 'ApiExplorer.i18n.php';
-$wgExtensionMessagesFiles['ApiExplorerAlias'] = $dir . 'ApiExplorer.alias.php';
 
 /**
  * @ingroup SpecialPage

--- a/extensions/Arrays/Arrays.php
+++ b/extensions/Arrays/Arrays.php
@@ -29,8 +29,6 @@ $wgExtensionCredits['parserhook'][] = array(
 	'version'        => ExtArrays::VERSION
 );
 
-$wgExtensionMessagesFiles['Arrays'     ] = ExtArrays::getDir() . '/Arrays.i18n.php';
-$wgExtensionMessagesFiles['ArraysMagic'] = ExtArrays::getDir() . '/Arrays.i18n.magic.php';
 
 // hooks registration:
 $wgHooks['ParserFirstCallInit'][] = 'ExtArrays::init';

--- a/extensions/Autoincrement/Autoincrement.php
+++ b/extensions/Autoincrement/Autoincrement.php
@@ -21,8 +21,6 @@ $wgExtensionCredits['variable'][] = array(
 );
 
 $dir = dirname( __FILE__ ) . '/';
-$wgExtensionMessagesFiles['Autoincrement'] = $dir . 'Autoincrement.i18n.php';
-$wgExtensionMessagesFiles['AutoincrementMagic'] = $dir . 'Autoincrement.i18n.magic.php';
 
 class Autoincrement {
 	var $mCount;

--- a/extensions/CategoryTree/CategoryTree.php
+++ b/extensions/CategoryTree/CategoryTree.php
@@ -117,10 +117,6 @@ $wgExtensionCredits['specialpage'][] = $wgExtensionCredits['parserhook'][] = arr
  */
 $dir = dirname( __FILE__ ) . '/';
 
-if ( $wgUseAjax && $wgCategoryTreeAllowTag ) {
-	$wgExtensionMessagesFiles['CategoryTreeMagic'] = $dir . 'CategoryTree.i18n.magic.php';
-}
-
 $wgAutoloadClasses['CategoryTreePage'] = $dir . 'CategoryTreePage.php';
 $wgAutoloadClasses['CategoryTree'] = $dir . 'CategoryTreeFunctions.php';
 $wgAutoloadClasses['CategoryTreeCategoryPage'] = $dir . 'CategoryPageSubclass.php';

--- a/extensions/CategoryTree/CategoryTree.php
+++ b/extensions/CategoryTree/CategoryTree.php
@@ -99,7 +99,6 @@ $wgCategoryTreePageCategoryOptions['namespaces'] = false;
 $wgCategoryTreePageCategoryOptions['depth'] = 0;
 # $wgCategoryTreePageCategoryOptions['class'] = 'CategoryTreeInlineNode';
 
-$wgExtensionMessagesFiles['CategoryTreeAlias'] = dirname( __FILE__ ) . '/CategoryTree.alias.php';
 
 /**
  * Register extension setup hook and credits
@@ -122,7 +121,6 @@ if ( $wgUseAjax && $wgCategoryTreeAllowTag ) {
 	$wgExtensionMessagesFiles['CategoryTreeMagic'] = $dir . 'CategoryTree.i18n.magic.php';
 }
 
-$wgExtensionMessagesFiles['CategoryTree'] = $dir . 'CategoryTree.i18n.php';
 $wgAutoloadClasses['CategoryTreePage'] = $dir . 'CategoryTreePage.php';
 $wgAutoloadClasses['CategoryTree'] = $dir . 'CategoryTreeFunctions.php';
 $wgAutoloadClasses['CategoryTreeCategoryPage'] = $dir . 'CategoryPageSubclass.php';

--- a/extensions/CharInsert/CharInsert.php
+++ b/extensions/CharInsert/CharInsert.php
@@ -42,7 +42,6 @@ $wgExtensionCredits['parserhook'][] = array(
 );
 
 $dir = dirname(__FILE__) . '/';
-$wgExtensionMessagesFiles['CharInsert'] = $dir . 'CharInsert.i18n.php';
 
 function setupSpecialChars( Parser $parser ): bool {
 	$parser->setHook( 'charinsert', 'charInsert' );

--- a/extensions/CheckUser/CheckUser.php
+++ b/extensions/CheckUser/CheckUser.php
@@ -20,8 +20,6 @@ if ( !defined( 'MEDIAWIKI' ) ) {
 
 # Internationalisation files
 $dir = dirname( __FILE__ ) . '/';
-$wgExtensionMessagesFiles['CheckUser'] = $dir . 'CheckUser.i18n.php';
-$wgExtensionMessagesFiles['CheckUserAliases'] = $dir . 'CheckUser.alias.php';
 
 // Extension credits that will show up on Special:Version
 $wgExtensionCredits['specialpage'][] = array(

--- a/extensions/Cite/Cite.php
+++ b/extensions/Cite/Cite.php
@@ -30,7 +30,6 @@ $wgExtensionCredits['parserhook'][] = array(
 );
 $wgParserTestFiles[] = dirname( __FILE__ ) . "/citeParserTests.txt";
 $wgParserTestFiles[] = dirname( __FILE__ ) . "/citeCatTreeParserTests.txt";
-$wgExtensionMessagesFiles['Cite'] = dirname( __FILE__ ) . "/Cite.i18n.php";
 $wgAutoloadClasses['Cite'] = dirname( __FILE__ ) . "/Cite_body.php";
 $wgSpecialPageGroups['Cite'] = 'pagetools';
 

--- a/extensions/ConfirmEdit/Asirra.php
+++ b/extensions/ConfirmEdit/Asirra.php
@@ -29,7 +29,6 @@ require_once( "$dir/ConfirmEdit.php" );
 $dir = dirname( __FILE__ ) . '/';
 
 $wgCaptchaClass = 'Asirra';
-$wgExtensionMessagesFiles['Asirra'] = "$dir/Asirra.i18n.php";
 $wgAutoloadClasses['Asirra'] = "$dir/Asirra.class.php";
 
 $wgResourceModules['ext.confirmedit.asirra'] = array(

--- a/extensions/ConfirmEdit/ConfirmEdit.php
+++ b/extensions/ConfirmEdit/ConfirmEdit.php
@@ -159,8 +159,6 @@ $wgCaptchaRegexes = array();
 $wgSpecialPages['Captcha'] = 'CaptchaSpecialPage';
 
 $wgConfirmEditIP = dirname( __FILE__ );
-$wgExtensionMessagesFiles['ConfirmEdit'] = "$wgConfirmEditIP/ConfirmEdit.i18n.php";
-$wgExtensionMessagesFiles['ConfirmEditAlias'] = "$wgConfirmEditIP/ConfirmEdit.alias.php";
 
 $wgHooks['EditFilterMerged'][] = 'ConfirmEditHooks::confirmEditMerged';
 $wgHooks['UserCreateForm'][] = 'ConfirmEditHooks::injectUserCreate';

--- a/extensions/ConfirmEdit/FancyCaptcha.php
+++ b/extensions/ConfirmEdit/FancyCaptcha.php
@@ -49,5 +49,4 @@ $wgCaptchaSecret = "CHANGE_THIS_SECRET!";
  */
 $wgCaptchaDeleteOnSolve = false;
 
-$wgExtensionMessagesFiles['FancyCaptcha'] = dirname( __FILE__ ) . '/FancyCaptcha.i18n.php';
 $wgAutoloadClasses['FancyCaptcha'] = dirname( __FILE__ ) . '/FancyCaptcha.class.php';

--- a/extensions/ConfirmEdit/QuestyCaptcha.php
+++ b/extensions/ConfirmEdit/QuestyCaptcha.php
@@ -41,5 +41,4 @@ $wgCaptchaQuestions = array();
 // You can also provide several acceptable answers to a given question (the answers shall be in lowercase):
 // $wgCaptchaQuestions[] = array( 'question' => "2 + 2 ?", 'answer' => array( '4', 'four' ) );
 
-$wgExtensionMessagesFiles['QuestyCaptcha'] = dirname( __FILE__ ) . '/QuestyCaptcha.i18n.php';
 $wgAutoloadClasses['QuestyCaptcha'] = dirname( __FILE__ ) . '/QuestyCaptcha.class.php';

--- a/extensions/ConfirmEdit/ReCaptcha.php
+++ b/extensions/ConfirmEdit/ReCaptcha.php
@@ -17,7 +17,6 @@ $wgCaptchaClass = 'ReCaptcha';
 
 $dir = dirname( __FILE__ );
 
-$wgExtensionMessagesFiles['ReCaptcha'] = $dir . '/ReCaptcha.i18n.php';
 
 $wgAutoloadClasses['ReCaptcha'] = $dir . '/ReCaptcha.class.php';
 

--- a/extensions/CreateBox/CreateBox.php
+++ b/extensions/CreateBox/CreateBox.php
@@ -44,7 +44,6 @@ $wgExtensionCredits['parserhook'][] = array(
 );
 
 $dir = dirname( __FILE__ ) . '/';
-$wgExtensionMessagesFiles['CreateBox'] = $dir . 'CreateBox.i18n.php';
 
 function wfCreateBox( $parser ) {
 	$parser->setHook( 'createbox', 'acMakeBox' );

--- a/extensions/DPLforum/DPLforum.php
+++ b/extensions/DPLforum/DPLforum.php
@@ -51,9 +51,6 @@ $wgHooks['CanonicalNamespaces'][] = 'wfDPLforumCanonicalNamespaces';
 
 // Set up i18n and autoload the main class
 $dir = dirname( __FILE__ ) . '/';
-$wgExtensionMessagesFiles['DPLforum'] = $dir . 'DPLforum.i18n.php';
-$wgExtensionMessagesFiles['DPLforumMagic'] = $dir . 'DPLforum.i18n.magic.php';
-$wgExtensionMessagesFiles['DPLforumNamespaces'] = $dir . 'DPLforum.namespaces.php';
 $wgAutoloadClasses['DPLForum'] = $dir . 'DPLforum_body.php';
 
 function wfDPLinit( Parser $parser ): bool {

--- a/extensions/DismissableSiteNotice/DismissableSiteNotice.php
+++ b/extensions/DismissableSiteNotice/DismissableSiteNotice.php
@@ -8,7 +8,6 @@ $wgExtensionCredits['other'][] = array(
 	'url' => 'https://www.mediawiki.org/wiki/Extension:DismissableSiteNotice',
 );
 
-$wgExtensionMessagesFiles['DismissableSiteNotice'] = dirname(__FILE__) . '/DismissableSiteNotice.i18n.php';
 
 function wfDismissableSiteNotice( &$notice ) {
 	global $wgMajorSiteNoticeID, $wgUser;

--- a/extensions/DynamicPageList/DynamicPageList.php
+++ b/extensions/DynamicPageList/DynamicPageList.php
@@ -62,7 +62,6 @@ if( !defined( 'MEDIAWIKI' ) ) {
 $wgExtensionFunctions[]        = array( 'ExtDynamicPageList', 'setupDPL' );
 $wgHooks['LanguageGetMagic'][] = 'ExtDynamicPageList__languageGetMagic';
 
-$wgExtensionMessagesFiles['DynamicPageList'] =  dirname( __FILE__ ) . '/DynamicPageList.i18n.php';
 
 $DPLVersion = '2.3.0';
 

--- a/extensions/DynamicPageList/DynamicPageListMigration.php
+++ b/extensions/DynamicPageList/DynamicPageListMigration.php
@@ -58,7 +58,6 @@ $wgExtensionCredits['parserhook'][] = array(
 require_once( 'DPLSetup.php' );
 
 $wgMessagesDirs['DynamicPageList'] = __DIR__ . '/i18n';
-$wgExtensionMessagesFiles['DynamicPageList'] = dirname(__FILE__).'/DynamicPageList.i18n.php';
 
 ExtDynamicPageList::$DPLVersion = $DPLVersion;
 

--- a/extensions/ExpandTemplates/ExpandTemplates.php
+++ b/extensions/ExpandTemplates/ExpandTemplates.php
@@ -18,7 +18,5 @@ $wgExtensionCredits['specialpage'][] = array(
 
 $dir = dirname(__FILE__) . '/';
 $wgAutoloadClasses['ExpandTemplates'] = $dir . 'ExpandTemplates_body.php';
-$wgExtensionMessagesFiles['ExpandTemplates'] = $dir . 'ExpandTemplates.i18n.php';
-$wgExtensionMessagesFiles['ExpandTemplatesAlias'] = $dir . 'ExpandTemplates.alias.php';
 $wgSpecialPages['ExpandTemplates'] = 'ExpandTemplates';
 $wgSpecialPageGroups['ExpandTemplates'] = 'wiki';

--- a/extensions/FormatNum/FormatNum.php
+++ b/extensions/FormatNum/FormatNum.php
@@ -22,8 +22,6 @@ $wgExtensionCredits['parserhook'][] = array (
 $dir = dirname( __FILE__ ) . '/';
 
 // Internationalization
-$wgExtensionMessagesFiles['FormatNum'] = $dir . 'FormatNum.i18n.php';
-$wgExtensionMessagesFiles['FormatNumMagic'] = $dir . 'FormatNum.i18n.magic.php';
 
 # Define a setup function
 $wgHooks['ParserFirstCallInit'][] = 'efFormatNumParserFunction_Setup';

--- a/extensions/Gadgets/Gadgets.php
+++ b/extensions/Gadgets/Gadgets.php
@@ -36,8 +36,6 @@ $wgHooks['ResourceLoaderRegisterModules'][] = 'GadgetHooks::registerModules';
 $wgHooks['UnitTestsList'][]                 = 'GadgetHooks::unitTestsList';
 
 $dir = dirname( __FILE__ ) . '/';
-$wgExtensionMessagesFiles['Gadgets'] = $dir . 'Gadgets.i18n.php';
-$wgExtensionMessagesFiles['GadgetsAlias'] = $dir . 'Gadgets.alias.php';
 
 $wgAutoloadClasses['ApiQueryGadgetCategories'] = $dir . 'ApiQueryGadgetCategories.php';
 $wgAutoloadClasses['ApiQueryGadgets'] = $dir . 'ApiQueryGadgets.php';

--- a/extensions/GlobalUsage/GlobalUsage.php
+++ b/extensions/GlobalUsage/GlobalUsage.php
@@ -45,8 +45,6 @@ $wgExtensionCredits['specialpage'][] = array(
 );
 
 // Internationlization files
-$wgExtensionMessagesFiles['GlobalUsage'] = $dir . 'GlobalUsage.i18n.php';
-$wgExtensionMessagesFiles['GlobalUsageAliases'] = $dir . 'GlobalUsage.alias.php';
 
 // Special page classes
 $wgAutoloadClasses['GlobalUsage'] = $dir . 'GlobalUsage_body.php';

--- a/extensions/ImageMap/ImageMap.php
+++ b/extensions/ImageMap/ImageMap.php
@@ -1,7 +1,6 @@
 <?php
 
 $dir = dirname(__FILE__) . '/';
-$wgExtensionMessagesFiles['ImageMap'] = $dir . 'ImageMap.i18n.php';
 $wgAutoloadClasses['ImageMap'] = $dir . 'ImageMap_body.php';
 $wgHooks['ParserFirstCallInit'][] = 'wfSetupImageMap';
 

--- a/extensions/InputBox/InputBox.php
+++ b/extensions/InputBox/InputBox.php
@@ -43,7 +43,6 @@ $wgExtensionCredits['parserhook'][] = array(
 $dir = dirname( __FILE__ ) . '/';
 
 // Internationalization
-$wgExtensionMessagesFiles['InputBox'] = $dir . 'InputBox.i18n.php';
 
 // Register auto load for the special page class
 $wgAutoloadClasses['InputBoxHooks'] = $dir . 'InputBox.hooks.php';

--- a/extensions/LabeledSectionTransclusion/lst.php
+++ b/extensions/LabeledSectionTransclusion/lst.php
@@ -34,7 +34,6 @@ $wgExtensionCredits['parserhook'][] = array(
 	'descriptionmsg' => 'lst-desc',
 );
 $wgParserTestFiles[] = dirname( __FILE__ ) . "/lstParserTests.txt";
-$wgExtensionMessagesFiles['LabeledSectionTransclusion'] = dirname( __FILE__ ) . '/lst.i18n.php';
 
 // Local settings variable
 // Must be set now to avoid injection via register_globals

--- a/extensions/Loops/Loops.php
+++ b/extensions/Loops/Loops.php
@@ -28,8 +28,6 @@ $wgExtensionCredits['parserhook'][] = array(
 );
 
 // language files:
-$wgExtensionMessagesFiles['Loops'     ] = ExtLoops::getDir() . '/Loops.i18n.php';
-$wgExtensionMessagesFiles['LoopsMagic'] = ExtLoops::getDir() . '/Loops.i18n.magic.php';
 
 // hooks registration:
 $wgHooks['ParserFirstCallInit'][] = 'ExtLoops::init';

--- a/extensions/Math/Math.php
+++ b/extensions/Math/Math.php
@@ -113,7 +113,6 @@ $dir = dirname( __FILE__ ) . '/';
 $wgAutoloadClasses['MathHooks'] = $dir . 'Math.hooks.php';
 $wgAutoloadClasses['MathRenderer'] = $dir . 'Math.body.php';
 
-$wgExtensionMessagesFiles['Math'] = $dir . 'Math.i18n.php';
 
 $wgParserTestFiles[] = $dir . 'mathParserTests.txt';
 

--- a/extensions/MultiUpload/MultiUpload.php
+++ b/extensions/MultiUpload/MultiUpload.php
@@ -30,8 +30,6 @@ $wgExtensionCredits['specialpage'][] = array(
 $dir = dirname( __FILE__ ) . '/';
 $wgAutoloadClasses['MultipleUpload'] = $dir . 'MultiUpload.body.php';
 $wgAutoloadClasses['MultipleUploadForm'] = $dir . 'MultiUpload.body.php';
-$wgExtensionMessagesFiles['MultiUpload'] = $dir . 'MultiUpload.i18n.php';
-$wgExtensionMessagesFiles['MultiUploadAlias'] = $dir . 'MultiUpload.alias.php';
 $wgSpecialPages['MultipleUpload'] = 'MultipleUpload';
 $wgSpecialPageGroups['MultipleUpload'] = 'media';
 

--- a/extensions/NewestPages/NewestPages.php
+++ b/extensions/NewestPages/NewestPages.php
@@ -25,7 +25,5 @@ $wgExtensionCredits['specialpage'][] = array(
 $wgNewestPagesLimit = 50;
 
 $dir = dirname(__FILE__) . '/';
-$wgExtensionMessagesFiles['NewestPages'] = $dir . 'NewestPages.i18n.php';
-$wgExtensionMessagesFiles['NewestPagesAlias'] = $dir . 'NewestPages.alias.php';
 $wgAutoloadClasses['NewestPages'] = $dir . 'NewestPages.page.php';
 $wgSpecialPages['NewestPages'] = 'NewestPages';

--- a/extensions/Nuke/Nuke.php
+++ b/extensions/Nuke/Nuke.php
@@ -8,8 +8,6 @@ define( 'Nuke_VERSION', '1.1.4' );
 
 $dir = dirname(__FILE__) . '/';
 
-$wgExtensionMessagesFiles['Nuke'] = $dir . 'Nuke.i18n.php';
-$wgExtensionMessagesFiles['NukeAlias'] = $dir . 'Nuke.alias.php';
 
 $wgExtensionCredits['specialpage'][] = array(
 	'path'           => __FILE__,

--- a/extensions/OggHandler/OggHandler.php
+++ b/extensions/OggHandler/OggHandler.php
@@ -22,8 +22,6 @@ if ( !in_array( 'oga', $wgFileExtensions ) ) {
 // Bump this when updating OggPlayer.js to help update caches
 $wgOggScriptVersion = '12';
 
-$wgExtensionMessagesFiles['OggHandler'] = "$oggDir/OggHandler.i18n.php";
-$wgExtensionMessagesFiles['OggHandlerMagic'] = "$oggDir/OggHandler.i18n.magic.php";
 $wgParserOutputHooks['OggHandler'] = array( 'OggHandler', 'outputHook' );
 
 $wgHooks['ExtractThumbParameters'][] = 'OggHandler::onExtractThumbParameters';

--- a/extensions/OpenGraphMeta/OpenGraphMeta.php
+++ b/extensions/OpenGraphMeta/OpenGraphMeta.php
@@ -33,8 +33,6 @@ $wgExtensionCredits['parserhook'][] = array (
 );
 
 $dir = dirname( __FILE__ );
-$wgExtensionMessagesFiles['OpenGraphMetaMagic'] = $dir . '/OpenGraphMeta.magic.php';
-$wgExtensionMessagesFiles['OpenGraphMeta'] = $dir . '/OpenGraphMeta.i18n.php';
 
 $wgHooks['ParserFirstCallInit'][] = 'efOpenGraphMetaParserInit';
 function efOpenGraphMetaParserInit( Parser $parser ) {

--- a/extensions/ParserFunctions/ParserFunctions.php
+++ b/extensions/ParserFunctions/ParserFunctions.php
@@ -69,8 +69,6 @@ $wgAutoloadClasses['ExprError'] = dirname( __FILE__ ) . '/Expr.php';
 $wgAutoloadClasses['Scribunto_LuaParserFunctionsLibrary'] = __DIR__ . '/ParserFunctions.library.php';
 // end wikia change
 
-$wgExtensionMessagesFiles['ParserFunctions'] = dirname( __FILE__ ) . '/ParserFunctions.i18n.php';
-$wgExtensionMessagesFiles['ParserFunctionsMagic'] = dirname( __FILE__ ) . '/ParserFunctions.i18n.magic.php';
 
 $wgParserTestFiles[] = dirname( __FILE__ ) . "/funcsParserTests.txt";
 $wgParserTestFiles[] = dirname( __FILE__ ) . "/stringFunctionTests.txt";

--- a/extensions/Poem/Poem.php
+++ b/extensions/Poem/Poem.php
@@ -27,7 +27,6 @@ $wgExtensionCredits['parserhook'][] = array(
 	'descriptionmsg' => 'poem-desc',
 );
 $wgParserTestFiles[] = dirname( __FILE__ ) . "/poemParserTests.txt";
-$wgExtensionMessagesFiles['Poem'] =  dirname(__FILE__) . '/Poem.i18n.php';
 
 function wfPoemExtension( Parser $parser ): bool {
 	$parser->setHook( 'poem', 'wfRenderPoemTag' );

--- a/extensions/PoolCounter/PoolCounterClient.php
+++ b/extensions/PoolCounter/PoolCounterClient.php
@@ -43,4 +43,3 @@ $dir = dirname( __FILE__ ) . '/';
 $wgAutoloadClasses['PoolCounter_ConnectionManager']
 	= $wgAutoloadClasses['PoolCounter_Client']
 	= $dir . 'PoolCounterClient_body.php';
-$wgExtensionMessagesFiles['PoolCounterClient'] = $dir . 'PoolCounterClient.i18n.php';

--- a/extensions/RandomImage/RandomImage.php
+++ b/extensions/RandomImage/RandomImage.php
@@ -23,7 +23,6 @@ $wgExtensionCredits['parserhook'][] = array(
 	'url'            => 'https://www.mediawiki.org/wiki/Extension:RandomImage',
 	'descriptionmsg' => 'randomimage-desc',
 );
-$wgExtensionMessagesFiles['RandomImage'] = dirname(__FILE__) . '/RandomImage.i18n.php';
 $wgHooks['ParserAfterStrip'][] = 'RandomImage::stripHook';
 $wgHooks['ParserFirstCallInit'][] = 'efRandomImage';
 

--- a/extensions/RandomInCategory/RandomInCategory.php
+++ b/extensions/RandomInCategory/RandomInCategory.php
@@ -23,8 +23,6 @@ $wgExtensionCredits['specialpage'][] = array(
 );
 
 $dir = dirname(__FILE__) . '/';
-$wgExtensionMessagesFiles['RandomInCategory'] = $dir . 'RandomInCategory.i18n.php';
-$wgExtensionMessagesFiles['RandomInCategoryAlias'] = $dir . 'RandomInCategory.alias.php';
 
 $wgSpecialPages['RandomInCategory'] = 'RandomPageInCategory';
 $wgAutoloadClasses['RandomPageInCategory'] = $dir . 'RandomInCategory.body.php';

--- a/extensions/RegexFun/RegexFun.php
+++ b/extensions/RegexFun/RegexFun.php
@@ -31,8 +31,6 @@ $wgExtensionCredits['parserhook'][] = array(
 );
 
 // language files:
-$wgExtensionMessagesFiles['RegexFun'     ] = ExtRegexFun::getDir() . '/RegexFun.i18n.php';
-$wgExtensionMessagesFiles['RegexFunMagic'] = ExtRegexFun::getDir() . '/RegexFun.i18n.magic.php';
 
 // hooks registration:
 $wgHooks['ParserFirstCallInit'][] = 'ExtRegexFun::init';

--- a/extensions/Scribunto/Scribunto.php
+++ b/extensions/Scribunto/Scribunto.php
@@ -32,9 +32,6 @@ $wgExtensionCredits['parserhook']['Scribunto'] = array(
 );
 
 $dir = dirname(__FILE__) . '/';
-$wgExtensionMessagesFiles['Scribunto'] = $dir . 'Scribunto.i18n.php';
-$wgExtensionMessagesFiles['ScribuntoMagic'] = $dir . 'Scribunto.magic.php';
-$wgExtensionMessagesFiles['ScribuntoNamespaces'] = $dir . 'Scribunto.namespaces.php';
 
 $wgAutoloadClasses['ScribuntoEngineBase'] = $dir.'common/Base.php';
 $wgAutoloadClasses['ScribuntoModuleBase'] = $dir.'common/Base.php';

--- a/extensions/SemanticDrilldown/SemanticDrilldown.php
+++ b/extensions/SemanticDrilldown/SemanticDrilldown.php
@@ -42,9 +42,6 @@ $sdgIP = dirname( __FILE__ );
 require_once( $sdgIP . '/languages/SD_Language.php' );
 
 $wgMessagesDirs['SemanticDrilldown'] = __DIR__ . '/i18n';
-$wgExtensionMessagesFiles['SemanticDrilldown'] = $sdgIP . '/languages/SD_Messages.php';
-$wgExtensionMessagesFiles['SemanticDrilldownAlias'] = $sdgIP . '/languages/SD_Aliases.php';
-$wgExtensionMessagesFiles['SemanticDrilldownMagic'] = $sdgIP . '/languages/SemanticDrilldown.i18n.magic.php';
 
 // register all special pages and other classes
 $wgSpecialPages['BrowseData'] = 'SDBrowseData';

--- a/extensions/SemanticMaps/SemanticMaps.php
+++ b/extensions/SemanticMaps/SemanticMaps.php
@@ -97,7 +97,6 @@ require_once 'SM_Settings.php';
 	# OpenLayers API
 	include_once $smgDir . 'includes/services/OpenLayers/SM_OpenLayers.php';
 
-$wgExtensionMessagesFiles['SemanticMaps'] = $smgDir . 'SemanticMaps.i18n.php';
 
 $incDir = __DIR__ . '/includes/';
 

--- a/extensions/SemanticResultFormats/SemanticResultFormats.php
+++ b/extensions/SemanticResultFormats/SemanticResultFormats.php
@@ -54,8 +54,6 @@ define( 'SRF_VERSION', '1.8' );
 // Initialize the formats later on, so the $srfgFormats setting can be manipulated in LocalSettings.
 $wgExtensionFunctions[] = 'srffInitFormats';
 
-$wgExtensionMessagesFiles['SemanticResultFormats'] = dirname( __FILE__ ) . '/SemanticResultFormats.i18n.php';
-$wgExtensionMessagesFiles['SemanticResultFormatsMagic'] = dirname( __FILE__ ) . '/SemanticResultFormats.i18n.magic.php';
 
 $srfgScriptPath = ( $wgExtensionAssetsPath === false ? $wgScriptPath . '/extensions' : $wgExtensionAssetsPath ) . '/SemanticResultFormats';
 $srfgIP = dirname( __FILE__ );

--- a/extensions/SpamBlacklist/SpamBlacklist.php
+++ b/extensions/SpamBlacklist/SpamBlacklist.php
@@ -16,7 +16,6 @@ $wgExtensionCredits[version_compare($wgVersion, '1.17alpha', '>=') ? 'antispam' 
 );
 
 $dir = dirname(__FILE__) . '/';
-$wgExtensionMessagesFiles['SpamBlackList'] = $dir . 'SpamBlacklist.i18n.php';
 
 /**
  * Array of settings for blacklist classes

--- a/extensions/SwiftCloudFiles/SwiftCloudFiles.php
+++ b/extensions/SwiftCloudFiles/SwiftCloudFiles.php
@@ -13,4 +13,3 @@ $wgAutoloadClasses['CF_Authentication'] =
 	$wgAutoloadClasses['CF_Container'] =
 	$wgAutoloadClasses['CF_Object'] = dirname( __FILE__ ) . '/php-cloudfiles-1.7.10/cloudfiles.php';
 
-$wgExtensionMessagesFiles['SwiftCloudFiles'] = dirname( __FILE__ ) . '/SwiftCloudFiles.i18n.php';

--- a/extensions/SyntaxHighlight_GeSHi/SyntaxHighlight_GeSHi.php
+++ b/extensions/SyntaxHighlight_GeSHi/SyntaxHighlight_GeSHi.php
@@ -50,7 +50,6 @@ $wgExtensionCredits['parserhook']['SyntaxHighlight_GeSHi'] = array(
 
 $wgSyntaxHighlightDefaultLang = null; //Change this in LocalSettings.php
 $dir = dirname(__FILE__) . '/';
-$wgExtensionMessagesFiles['SyntaxHighlight_GeSHi'] = $dir . 'SyntaxHighlight_GeSHi.i18n.php';
 $wgAutoloadClasses['SyntaxHighlight_GeSHi'] = $dir . 'SyntaxHighlight_GeSHi.class.php';
 $wgHooks['ShowRawCssJs'][] = 'SyntaxHighlight_GeSHi::viewHook';
 $wgHooks['ParserFirstCallInit'][] = 'efSyntaxHighlight_GeSHiSetup';

--- a/extensions/TitleBlacklist/TitleBlacklist.php
+++ b/extensions/TitleBlacklist/TitleBlacklist.php
@@ -17,7 +17,6 @@ $wgExtensionCredits[version_compare($wgVersion, '1.17alpha', '>=') ? 'antispam' 
 	'descriptionmsg' => 'titleblacklist-desc',
 );
 
-$wgExtensionMessagesFiles['TitleBlacklist'] = dirname( __FILE__ ) . '/TitleBlacklist.i18n.php';
 $wgAutoloadClasses['TitleBlacklist']      = dirname( __FILE__ ) . '/TitleBlacklist.list.php';
 $wgAutoloadClasses['TitleBlacklistHooks'] = dirname( __FILE__ ) . '/TitleBlacklist.hooks.php';
 

--- a/extensions/TorBlock/TorBlock.php
+++ b/extensions/TorBlock/TorBlock.php
@@ -25,7 +25,6 @@ $wgExtensionCredits[version_compare($wgVersion, '1.17alpha', '>=') ? 'antispam' 
 	'url'            => 'https://www.mediawiki.org/wiki/Extension:TorBlock',
 );
 
-$wgExtensionMessagesFiles['TorBlock'] =  "$dir/TorBlock.i18n.php";
 $wgAutoloadClasses[ 'TorBlock' ] = "$dir/TorBlock.class.php";
 
 $wgHooks['getUserPermissionsErrorsExpensive'][] = 'TorBlock::onGetUserPermissionsErrorsExpensive';

--- a/extensions/Variables/Variables.php
+++ b/extensions/Variables/Variables.php
@@ -31,8 +31,6 @@ $wgExtensionCredits['parserhook'][] = array(
 );
 
 // language files:
-$wgExtensionMessagesFiles['Variables'     ] = ExtVariables::getDir() . '/Variables.i18n.php';
-$wgExtensionMessagesFiles['VariablesMagic'] = ExtVariables::getDir() . '/Variables.i18n.magic.php';
 
 // hooks registration:
 $wgHooks['ParserFirstCallInit'     ][] = 'ExtVariables::init';

--- a/extensions/VisualEditor/VisualEditor.php
+++ b/extensions/VisualEditor/VisualEditor.php
@@ -43,7 +43,6 @@ $wgAutoloadClasses['VisualEditorHooks'] = $dir . 'VisualEditor.hooks.php';
 $wgAutoloadClasses['VisualEditorDataModule'] = $dir . 'VisualEditorDataModule.php';
 $wgAutoloadClasses['VisualEditorViewPageTargetInitModule'] =
 	$dir . 'VisualEditorViewPageTargetInitModule.php';
-$wgExtensionMessagesFiles['VisualEditor'] = $dir . 'VisualEditor.i18n.php';
 $wgMessagesDirs['VisualEditor'] = array(
 	__DIR__ . '/lib/ve/i18n',
 	__DIR__ . '/modules/ve-mw/i18n',

--- a/extensions/VisualEditor/wikia/VisualEditor.php
+++ b/extensions/VisualEditor/wikia/VisualEditor.php
@@ -257,7 +257,6 @@ $wgVisualEditorPluginModules[] = 'ext.visualEditor.wikia.core';
 
 /* Messages */
 
-$wgExtensionMessagesFiles['VisualEditorWikia'] = $dir . 'VisualEditor.i18n.php';
 
 /* Hooks */
 

--- a/extensions/cldr/cldr.php
+++ b/extensions/cldr/cldr.php
@@ -20,7 +20,6 @@ $wgExtensionCredits['other'][] = array(
 );
 
 $dir = dirname( __FILE__ ) . '/';
-$wgExtensionMessagesFiles['cldr'] = $dir . 'cldr.i18n.php';
 $wgAutoloadClasses['CldrNames'] = $dir . 'CldrNames.php';
 $wgAutoloadClasses['LanguageNames'] = $dir . 'LanguageNames.body.php';
 $wgAutoloadClasses['CountryNames'] = $dir . 'CountryNames.body.php';

--- a/extensions/timeline/Timeline.php
+++ b/extensions/timeline/Timeline.php
@@ -45,7 +45,6 @@ $wgTimelineSettings->perlCommand = "/usr/bin/perl";
 $wgTimelineSettings->timelineFile = dirname(__FILE__)."/EasyTimeline.pl";
 
 $wgHooks['ParserFirstCallInit'][] = 'wfTimelineExtension';
-$wgExtensionMessagesFiles['Timeline'] = dirname(__FILE__) . '/Timeline.i18n.php';
 
 /**
  * @param $parser Parser

--- a/extensions/wikia/ARecoveryEngine/ARecoveryEngine.setup.php
+++ b/extensions/wikia/ARecoveryEngine/ARecoveryEngine.setup.php
@@ -24,4 +24,3 @@ $wgAutoloadClasses['ResourceLoaderAdEngineInstartLogicModule'] = __DIR__ . '/Res
 $wgHooks['InstantGlobalsGetVariables'][] = 'ARecoveryEngineHooks::onInstantGlobalsGetVariables';
 
 // i18n
-$wgExtensionMessagesFiles['ARecoveryEngine'] = __DIR__ . '/ARecoveryEngine.i18n.php';

--- a/extensions/wikia/AbTesting/AbTesting.setup.php
+++ b/extensions/wikia/AbTesting/AbTesting.setup.php
@@ -46,7 +46,6 @@ $wgAutoloadClasses['AbTestingController'] = "{$dir}/AbTestingController.class.ph
 /**
  * message files
  */
-$wgExtensionMessagesFiles['AbTesting'] = "{$dir}/AbTesting.i18n.php";
 
 // Embed the experiment/treatment config in the head scripts.
 $wgHooks['WikiaSkinTopScripts'][] =  'AbTesting::onWikiaSkinTopScripts';

--- a/extensions/wikia/AbuseFilterBypass/AbuseFilterBypass.php
+++ b/extensions/wikia/AbuseFilterBypass/AbuseFilterBypass.php
@@ -29,5 +29,4 @@ $wgAutoloadClasses[ 'AbuseFilterBypass' ] = "{$dir}/AbuseFilterBypass.class.php"
 $wgHooks[ 'AbuseFilterShouldFilter' ][ ] = 'AbuseFilterBypass::onBypassCheck';
 
 //i18n
-$wgExtensionMessagesFiles[ 'AbuseFilterBypass' ] = $dir . '/i18n/AbuseFilterBypass.i18n.php';
 

--- a/extensions/wikia/AchievementsII/Ach_setup.php
+++ b/extensions/wikia/AchievementsII/Ach_setup.php
@@ -85,8 +85,6 @@ $wgAutoloadClasses[ 'UploadAchievementsFromFile' ] = "{$dir}UploadAchievementsFr
 $wgAutoloadClasses[ 'WikiaPhotoGalleryUpload' ] = "{$dir}../WikiaPhotoGallery/WikiaPhotoGalleryUpload.class.php";
 
 // I18N
-$wgExtensionMessagesFiles['AchievementsII'] = $dir.'AchievementsII.i18n.php';
-$wgExtensionMessagesFiles['AchievementsIIAliases'] = $dir.'AchievementsII.alias.php' ;
 
 // Michał Roszka (Mix) <michal@wikia-inc.com>
 // BugId:10474

--- a/extensions/wikia/AdEngine/AdEngine2.setup.php
+++ b/extensions/wikia/AdEngine/AdEngine2.setup.php
@@ -32,7 +32,6 @@ $wgHooks['WikiaSkinTopScripts'][] = 'AdEngine2Hooks::onWikiaSkinTopScripts';
 $wgHooks['WikiaSkinTopModules'][] = 'AdEngine2Hooks::onWikiaSkinTopModules';
 
 // i18n
-$wgExtensionMessagesFiles['AdEngine'] = __DIR__ . '/AdEngine.i18n.php';
 $wgExtensionFunctions[] = function() {
 	JSMessages::registerPackage( 'AdEngine', [
 		'adengine-*'

--- a/extensions/wikia/AdminDashboard/AdminDashboard.setup.php
+++ b/extensions/wikia/AdminDashboard/AdminDashboard.setup.php
@@ -23,9 +23,6 @@ $wgAutoloadClasses['QuickStatsController'] =  __DIR__ . '/QuickStatsController.c
 $wgHooks['BeforeToolbarMenu'][] = 'AdminDashboardLogic::onBeforeToolbarMenu';
 
 // i18n mapping
-$wgExtensionMessagesFiles['AdminDashboard'] = __DIR__ . '/AdminDashboard.i18n.php';
-$wgExtensionMessagesFiles['QuickStats'] = __DIR__ . '/QuickStats.i18n.php';
-$wgExtensionMessagesFiles['AdminDashboardAliases'] = __DIR__ . '/AdminDashboard.alias.php';
 
 // special pages
 $wgSpecialPages[ 'AdminDashboard'] = 'AdminDashboardSpecialPageController';

--- a/extensions/wikia/AjaxPoll/AjaxPoll.php
+++ b/extensions/wikia/AjaxPoll/AjaxPoll.php
@@ -27,7 +27,6 @@ $wgExtensionCredits['parserhook'][] = array(
 );
 
 $wgHooks['ParserFirstCallInit'][] = "wfAjaxPollTag";
-$wgExtensionMessagesFiles["AjaxPoll"] = __DIR__ . '/AjaxPoll.i18n.php';
 
 /**
  * helper file

--- a/extensions/wikia/AnalyticsEngine/AnalyticsEngine.setup.php
+++ b/extensions/wikia/AnalyticsEngine/AnalyticsEngine.setup.php
@@ -7,7 +7,6 @@ $wgExtensionCredits['other'][] = array(
 );
 
 //i18n
-$wgExtensionMessagesFiles['AnalyticsEngine'] = __DIR__ . '/i18n/AnalyticsEngine.i18n.php';
 
 // autoloaded classes
 $wgAutoloadClasses['iAnalyticsProvider'] = __DIR__ . '/iAnalyticsProvider.php';

--- a/extensions/wikia/Answers/Answers.php
+++ b/extensions/wikia/Answers/Answers.php
@@ -27,7 +27,6 @@ $wgExtensionCredits[ 'other' ][ ] = array(
 require_once( dirname(__FILE__) . "/AnswersClass.php");
 require_once( dirname(__FILE__) . "/AttributionCache.class.php");
 
-$wgExtensionMessagesFiles['Answers'] = dirname( __FILE__ ) . '/Answers.i18n.php';
 
 if(empty($wgAnswerHelperIDs)) {
 	$wgAnswerHelperIDs = array( 0 /* anonymous */, 1172427 /* Wikia User */ );

--- a/extensions/wikia/Answers/SpecialGetQuestionWidget.php
+++ b/extensions/wikia/Answers/SpecialGetQuestionWidget.php
@@ -1,6 +1,6 @@
 <?php
 
-$wgExtensionMessagesFiles ['GetQuestionWidget'] = dirname(__FILE__) . '/GetQuestionWidget.i18n.php' ; 
+
 
 class GetQuestionWidget extends UnlistedSpecialPage {
 

--- a/extensions/wikia/AntiSpamInput/AntiSpamInput.php
+++ b/extensions/wikia/AntiSpamInput/AntiSpamInput.php
@@ -28,7 +28,6 @@ $wgExtensionCredits['other'][] = array(
     'descriptionmsg' => 'antispaminput-msg',
 	'url' => 'https://github.com/Wikia/app/tree/dev/extensions/wikia/AntiSpamInput'
 );
-$wgExtensionMessagesFiles['AntiSpamInput'] = dirname(__FILE__) . '/AntiSpamInput.i18n.php';
 
 function wfAntiSpamInputInit () {
 	global $wgHooks;

--- a/extensions/wikia/ApesterTag/ApesterTag.setup.php
+++ b/extensions/wikia/ApesterTag/ApesterTag.setup.php
@@ -15,4 +15,3 @@ $wgAutoloadClasses['ApesterTagController'] =  __DIR__ . '/ApesterTagController.c
 $wgHooks['ParserFirstCallInit'][] = 'ApesterTagController::onParserFirstCallInit';
 
 // i18n
-$wgExtensionMessagesFiles['ApesterTag'] = __DIR__ . '/ApesterTag.i18n.php';

--- a/extensions/wikia/ApiDocs/ApiDocs.setup.php
+++ b/extensions/wikia/ApiDocs/ApiDocs.setup.php
@@ -15,7 +15,6 @@ $dir = __DIR__ . '/';
 $app = F::app();
 
 //i18n
-$wgExtensionMessagesFiles['ApiDocs'] = $dir . 'i18n/ApiDocs.i18n.php';
 
 $wgAutoloadClasses['ApiDocsController'] = "{$dir}ApiDocsController.class.php";
 $wgAutoloadClasses['DocsApiController'] = "{$dir}DocsApiController.class.php";

--- a/extensions/wikia/AppPromoLanding/AppPromoLanding_setup.php
+++ b/extensions/wikia/AppPromoLanding/AppPromoLanding_setup.php
@@ -17,7 +17,6 @@ $dir = __DIR__ . '/';
 $wgAutoloadClasses['AppPromoLandingController'] = $dir . 'AppPromoLandingController.class.php';
 
 // i18n mapping
-$wgExtensionMessagesFiles['AppPromoLanding'] = $dir . 'AppPromoLanding.i18n.php';
 
 // setup functions
 //$wgExtensionFunctions[] = 'AppPromoLandingController::setupAppPromoLanding';

--- a/extensions/wikia/ArticleAsJson/ArticleAsJson.setup.php
+++ b/extensions/wikia/ArticleAsJson/ArticleAsJson.setup.php
@@ -10,7 +10,6 @@ $wgExtensionCredits['other'][] = array(
 $dir = dirname(__FILE__) . '/';
 
 //i18n
-$wgExtensionMessagesFiles['ArticleAsJson'] = $dir . 'ArticleAsJson.i18n.php';
 
 //classes
 $wgAutoloadClasses['ArticleAsJson'] =  $dir . 'ArticleAsJson.class.php';

--- a/extensions/wikia/ArticleComments/ArticleComments_setup.php
+++ b/extensions/wikia/ArticleComments/ArticleComments_setup.php
@@ -40,7 +40,6 @@ $wgAutoloadClasses['ArticleCommentsAjax'] = __DIR__ . '/classes/ArticleCommentsA
 $wgAutoloadClasses['ArticleCommentsController'] = __DIR__ . '/modules/ArticleCommentsController.class.php';
 $wgAutoloadClasses['ArticleCommentsHooks'] = __DIR__ . '/ArticleCommentsHooks.class.php';
 
-$wgExtensionMessagesFiles['ArticleComments'] = __DIR__ . '/ArticleComments.i18n.php';
 
 if (!empty($wgEnableWallEngine) || !empty($wgEnableArticleCommentsExt) || !empty($wgEnableBlogArticles)) {
 

--- a/extensions/wikia/ArticleMetaDescription/ArticleMetaDescription.php
+++ b/extensions/wikia/ArticleMetaDescription/ArticleMetaDescription.php
@@ -26,7 +26,6 @@ $wgExtensionCredits['other'][] = [
 ];
 
 //i18n
-$wgExtensionMessagesFiles['ArticleMetaDescription'] = __DIR__ . '/ArticleMetaDescription.i18n.php';
 
 $wgHooks['OutputPageBeforeHTML'][] = 'wfArticleMetaDescription';
 

--- a/extensions/wikia/ArticleSummary/ArticleSummary.setup.php
+++ b/extensions/wikia/ArticleSummary/ArticleSummary.setup.php
@@ -19,5 +19,4 @@ $dir = dirname( __FILE__ );
 $wgAutoloadClasses['ArticleSummaryController'] =  $dir.'/ArticleSummaryController.class.php';
 
 //i18n
-$wgExtensionMessagesFiles['ArticleSummary'] = __DIR__  . '/ArticleSummary.i18n.php';
 

--- a/extensions/wikia/ArticleVideo/ArticleVideo.setup.php
+++ b/extensions/wikia/ArticleVideo/ArticleVideo.setup.php
@@ -1,5 +1,4 @@
 <?php
-$wgExtensionMessagesFiles['ArticleVideo'] = __DIR__ . '/ArticleVideo.i18n.php';
 $wgAutoloadClasses['ArticleVideoContext'] = __DIR__ . '/ArticleVideoContext.class.php';
 $wgAutoloadClasses['ArticleVideoHooks'] = __DIR__ . '/ArticleVideo.hooks.php';
 $wgAutoloadClasses['ArticleVideoController'] = __DIR__ . '/ArticleVideoController.class.php';

--- a/extensions/wikia/ArticlesAsResources/ArticlesAsResources.setup.php
+++ b/extensions/wikia/ArticlesAsResources/ArticlesAsResources.setup.php
@@ -53,5 +53,4 @@ $wgAutoloadClasses['ArticlesAsResources'] =  $dir . '/ArticlesAsResources.class.
 $wgHooks['ResourceLoaderBeforeRespond'][] = 'ArticlesAsResources::onResourceLoaderBeforeRespond';
 
 //i18n
-$wgExtensionMessagesFiles['ArticlesAsResources'] = $dir . '/ArticlesAsResources.i18n.php';
 

--- a/extensions/wikia/AssetsManager/AssetsManager_setup.php
+++ b/extensions/wikia/AssetsManager/AssetsManager_setup.php
@@ -18,7 +18,6 @@ $wgExtensionCredits['other'][] = array(
 );
 
 //i18n
-$wgExtensionMessagesFiles['AssetsManager'] = __DIR__ . '/i18n/AssetsManager.i18n.php';
 
 $wgAutoloadClasses['AssetsManagerBaseBuilder'] = __DIR__ . '/builders/AssetsManagerBaseBuilder.class.php';
 $wgAutoloadClasses['AssetsManagerOneBuilder'] = __DIR__ . '/builders/AssetsManagerOneBuilder.class.php';

--- a/extensions/wikia/AuthModal/AuthModal.setup.php
+++ b/extensions/wikia/AuthModal/AuthModal.setup.php
@@ -8,4 +8,3 @@ $wgHooks['BeforePageDisplay'][] = 'AuthModalHooks::onBeforePageDisplay';
 /**
  * i18n
  */
-$wgExtensionMessagesFiles['AuthModal'] = $dir . 'AuthModal.i18n.php';

--- a/extensions/wikia/AutoFollow/AutoFollow.setup.php
+++ b/extensions/wikia/AutoFollow/AutoFollow.setup.php
@@ -25,7 +25,6 @@ $wgExtensionCredits['other'][] = [
 	'url'               => 'https://github.com/Wikia/app/tree/dev/extensions/wikia/AutoFollow/',
 ];
 
-$wgExtensionMessagesFiles['AutoFollow'] = __DIR__ . '/AutoFollow.i18n.php';
 
 $wgAutoloadClasses['Wikia\AutoFollow\AutoFollowHooks'] = __DIR__ . '/AutoFollow.hooks.php';
 $wgAutoloadClasses['Wikia\AutoFollow\AutoFollowTask'] = __DIR__ . '/AutoFollowTask.class.php';

--- a/extensions/wikia/AutoMainpageFixer/AutoMainpageFixer.php
+++ b/extensions/wikia/AutoMainpageFixer/AutoMainpageFixer.php
@@ -15,7 +15,6 @@ $wgExtensionCredits['parserhook'][] = array(
 );
 
 //i18n
-$wgExtensionMessagesFiles['AutoMainpageFixer'] = __DIR__ . '/AutoMainpageFixer.i18n.php';
 
 $wgHooks['TitleMoveComplete'][] = 'fnAutoMWMainpageFixer';
 

--- a/extensions/wikia/AutoPageCreate/AutoPageCreate.php
+++ b/extensions/wikia/AutoPageCreate/AutoPageCreate.php
@@ -15,7 +15,6 @@ $wgExtensionCredits[ 'other' ][ ] = array(
 	'url' => 'https://github.com/Wikia/app/tree/dev/extensions/wikia/AutoPageCreate',
 );
 
-$wgExtensionMessagesFiles['AutoPageCreate'] = dirname(__FILE__) . '/AutoPageCreate.i18n.php';
 $wgExtensionFunctions[] = 'wfAutoPageCreateInit';
 
 function wfAutoPageCreateInit() {

--- a/extensions/wikia/AutomaticWikiAdoption/AutomaticWikiAdoption_setup.php
+++ b/extensions/wikia/AutomaticWikiAdoption/AutomaticWikiAdoption_setup.php
@@ -30,7 +30,6 @@ $wgExtensionCredits['other'][] = array(
 $dir = dirname(__FILE__);
 
 $wgExtensionFunctions[] = 'AutomaticWikiAdoptionInit';
-$wgExtensionMessagesFiles['AutomaticWikiAdoption'] = "$dir/AutomaticWikiAdoption.i18n.php";
 $wgAutoloadClasses['AutomaticWikiAdoptionAjax'] = "$dir/AutomaticWikiAdoptionAjax.class.php";
 $wgAutoloadClasses['AutomaticWikiAdoptionHelper'] = "$dir/AutomaticWikiAdoptionHelper.class.php";
 $wgAutoloadClasses['AutomaticWikiAdoptionController'] = "$dir/AutomaticWikiAdoptionController.class.php";

--- a/extensions/wikia/BannerNotifications/BannerNotifications.setup.php
+++ b/extensions/wikia/BannerNotifications/BannerNotifications.setup.php
@@ -35,7 +35,6 @@ $wgHooks['BeforePageDisplay'][] = 'BannerNotificationsController::onBeforePageDi
 /**
  * i18n
  */
-$wgExtensionMessagesFiles['BannerNotification'] = $dir . 'BannerNotifications.i18n.php';
 
 /**
  * ResourceLoader module

--- a/extensions/wikia/Blogs/Blogs.php
+++ b/extensions/wikia/Blogs/Blogs.php
@@ -52,9 +52,6 @@ $wgAPIModules[ "blogs" ] = "WikiaApiBlogs";
 /**
  * messages file
  */
-$wgExtensionMessagesFiles['Blogs'] = __DIR__ . '/Blogs.i18n.php';
-$wgExtensionMessagesFiles['BlogsAliases'] = __DIR__ . '/Blogs.alias.php';
-$wgExtensionMessagesFiles['BlogsMagic'] = __DIR__ . '/Blogs.i18n.magic.php';
 
 // special pages
 $wgAutoloadClasses['CreateBlogListingPage'] = __DIR__ . '/SpecialCreateBlogListingPage.php';

--- a/extensions/wikia/Bucky/Bucky.setup.php
+++ b/extensions/wikia/Bucky/Bucky.setup.php
@@ -19,4 +19,3 @@ $wgAutoloadClasses['Bucky'] =  $dir . 'Bucky.class.php';
 $wgHooks['MakeGlobalVariablesScript'][] = 'Bucky::onMakeGlobalVariablesScript';
 
 //i18n
-$wgExtensionMessagesFiles['Bucky'] = $dir . 'Bucky.i18n.php';

--- a/extensions/wikia/CanonicalHref/CanonicalHref.php
+++ b/extensions/wikia/CanonicalHref/CanonicalHref.php
@@ -17,7 +17,6 @@ $wgExtensionCredits['specialpage'][] = array(
 );
 
 //i18n
-$wgExtensionMessagesFiles['CanonicalHref'] = __DIR__ . '/CanonicalHref.i18n.php';
 
 $wgHooks['BeforePageDisplay'][] = 'wfCanonicalHref';
 /**

--- a/extensions/wikia/Captcha/Captcha.setup.php
+++ b/extensions/wikia/Captcha/Captcha.setup.php
@@ -93,7 +93,6 @@ $wgCaptchaWhitelist = false;
 $wgCaptchaRegexes = [];
 
 $dir = dirname( __FILE__ );
-$wgExtensionMessagesFiles['Captcha'] = "$dir/Captcha.i18n.php";
 
 // Captcha Hooks
 $wgHooks['EditFilterMerged'][] = 'Captcha\Hooks::confirmEditMerged';

--- a/extensions/wikia/CategoryBlueLinks/CategoryBlueLinks.php
+++ b/extensions/wikia/CategoryBlueLinks/CategoryBlueLinks.php
@@ -26,7 +26,6 @@ $wgExtensionCredits['other'][] = array(
 );
 
 //i18n
-$wgExtensionMessagesFiles['CategoryBlueLinks'] = __DIR__ . '/CategoryBlueLinks.i18n.php';
 
 $wgHooks['LinkBegin'][] = 'efCategoryBlueLinks';
 

--- a/extensions/wikia/CategoryExhibition/CategoryExhibition_setup.php
+++ b/extensions/wikia/CategoryExhibition/CategoryExhibition_setup.php
@@ -33,7 +33,6 @@ $wgAutoloadClasses[ 'CategoryPageII' ] = __DIR__ . '/CategoryPageII.php';
 $wgAutoloadClasses[ 'CategoryUrlParams' ] = __DIR__ . '/CategoryUrlParams.class.php';
 
 // Internalization
-$wgExtensionMessagesFiles[ 'CategoryPageII' ] = __DIR__ . '/i18n/CategoryExhibition.i18n.php';
 
 // Hooks
 define('CATEXHIBITION_DISABLED', 'CATEXHIBITION_DISABLED');

--- a/extensions/wikia/CategoryGalleries/CategoryGalleries.php
+++ b/extensions/wikia/CategoryGalleries/CategoryGalleries.php
@@ -26,7 +26,6 @@ $wgAutoloadClasses[ 'CategoryGallery' ] = $dir . '/CategoryGallery.class.php';
 $wgAutoloadClasses[ 'CategoryGalleriesHelper' ] = $dir . '/CategoryGalleriesHelper.class.php';
 
 // Internalization
-$wgExtensionMessagesFiles['CategoryGalleries'] = $dir . '/CategoryGalleries.i18n.php';
 
 // Set up hooks for embedding gallery into category page
 $wgHooks['CategoryPageView'][] = 'CategoryGalleriesHelper::onCategoryPageView';

--- a/extensions/wikia/CategorySelect/CategorySelect.setup.php
+++ b/extensions/wikia/CategorySelect/CategorySelect.setup.php
@@ -32,7 +32,6 @@ $wgHooks['GetPreferences'][] = 'CategorySelectHooksHelper::onGetPreferences';
 $wgHooks['MediaWikiPerformAction'][] = 'CategorySelectHooksHelper::onMediaWikiPerformAction';
 
 // Messages
-$wgExtensionMessagesFiles['CategorySelect'] = $dir . 'CategorySelect.i18n.php' ;
 
 JSMessages::registerPackage( 'CategorySelect', array(
 	'categoryselect-button-save',

--- a/extensions/wikia/Chat2/Chat_setup.php
+++ b/extensions/wikia/Chat2/Chat_setup.php
@@ -39,9 +39,6 @@ $wgSpecialPages['Chat'] = 'SpecialChat';
 $wgSpecialPages['ChatBanList'] = 'ChatBanListSpecialController';
 
 // i18n
-$wgExtensionMessagesFiles['Chat'] = $dir . '/Chat.i18n.php';
-$wgExtensionMessagesFiles['ChatAliases'] = $dir . '/Chat.aliases.php';
-$wgExtensionMessagesFiles['ChatDefaultEmoticons'] = $dir . '/ChatDefaultEmoticons.i18n.php';
 
 // hooks
 $wgHooks['GetRailModuleList'][] = 'ChatHooks::onGetRailModuleList';

--- a/extensions/wikia/CloseMyAccount/CloseMyAccount.setup.php
+++ b/extensions/wikia/CloseMyAccount/CloseMyAccount.setup.php
@@ -22,8 +22,6 @@ $wgAutoloadClasses['CloseMyAccountSpecialController'] =  __DIR__ . '/CloseMyAcco
 $wgAutoloadClasses['CloseMyAccountHooks'] =  __DIR__ . '/CloseMyAccountHooks.class.php';
 $wgAutoloadClasses['CloseMyAccountHelper'] =  __DIR__ . '/CloseMyAccountHelper.class.php';
 
-$wgExtensionMessagesFiles['CloseMyAccount'] = __DIR__ . '/CloseMyAccount.i18n.php' ;
-$wgExtensionMessagesFiles['CloseMyAccountAliases'] = __DIR__ . '/CloseMyAccount.aliases.php';
 
 $wgSpecialPages['CloseMyAccount'] = 'CloseMyAccountSpecialController';
 $wgSpecialPageGroups['CloseMyAccount'] = 'wikia';

--- a/extensions/wikia/CommentCSV/CommentCSV.php
+++ b/extensions/wikia/CommentCSV/CommentCSV.php
@@ -29,7 +29,6 @@ $wgExtensionCredits['other'][] = array(
 $dir = dirname(__FILE__) . '/';
 
 //i18n
-$wgExtensionMessagesFiles['CommentCSV'] = $dir . 'CommentCSV.i18n.php';
 
 $wgAutoloadClasses['CommentCSV'] = $dir . '/CommentCSV.class.php';
 

--- a/extensions/wikia/CommunityMessages/CommunityMessages_setup.php
+++ b/extensions/wikia/CommunityMessages/CommunityMessages_setup.php
@@ -29,7 +29,6 @@ $wgExtensionCredits['other'][] = array(
 );
 
 $wgExtensionFunctions[] = 'CommunityMessagesInit';
-$wgExtensionMessagesFiles['CommunityMessages'] = dirname( __FILE__ ) . '/CommunityMessages.i18n.php';
 $wgAutoloadClasses['CommunityMessages'] = "$IP/extensions/wikia/CommunityMessages/CommunityMessages.class.php";
 $wgAutoloadClasses['CommunityMessagesAjax'] = "$IP/extensions/wikia/CommunityMessages/CommunityMessagesAjax.class.php";
 

--- a/extensions/wikia/CommunityPage/CommunityPage.setup.php
+++ b/extensions/wikia/CommunityPage/CommunityPage.setup.php
@@ -28,7 +28,6 @@ $wgHooks['UserRights'][] = 'CommunityPageSpecialHooks::onUserRights';
 $wgHooks['ResourceLoaderGetConfigVars'][] = 'CommunityPageSpecialHooks::onResourceLoaderGetConfigVars';
 
 /* i18n */
-$wgExtensionMessagesFiles['CommunityPage'] = __DIR__ . '/CommunityPage.i18n.php';
 
 /* messages exported to JS */
 JSMessages::registerPackage( 'CommunityPageSpecial', [

--- a/extensions/wikia/ContentFeeds/ContentFeeds.php
+++ b/extensions/wikia/ContentFeeds/ContentFeeds.php
@@ -21,7 +21,6 @@ $wgExtensionCredits['specialpage'][] = array(
  * setup functions
  */
 $wgExtensionFunctions[] = 'wfContentFeedsInit';
-$wgExtensionMessagesFiles['ContentFeeds'] = dirname(__FILE__) . '/ContentFeeds.i18n.php';
 
 function wfContentFeedsInit() {
 	global $wgHooks, $wgAutoloadClasses;

--- a/extensions/wikia/ContentReview/ContentReview.setup.php
+++ b/extensions/wikia/ContentReview/ContentReview.setup.php
@@ -77,8 +77,6 @@ $wgAutoloadClasses['ContentReviewModuleController'] = $IP . '/skins/oasis/module
 /**
  * Messages
  */
-$wgExtensionMessagesFiles['ContentReview'] = __DIR__ . '/ContentReview.i18n.php';
-$wgExtensionMessagesFiles['ContentReviewInternal'] = __DIR__ . '/ContentReviewInternal.i18n.php';
 
 JSMessages::registerPackage( 'ContentReviewModule', [
 	'content-review-module-*'

--- a/extensions/wikia/ContentWarning/ContentWarning.setup.php
+++ b/extensions/wikia/ContentWarning/ContentWarning.setup.php
@@ -19,7 +19,6 @@ $wgAutoloadClasses['ContentWarningController'] =  $dir . 'ContentWarningControll
 $wgAutoloadClasses['ContentWarningHooks'] =  $dir . 'ContentWarningHooks.class.php';
 
 // i18n mapping
-$wgExtensionMessagesFiles['ContentWarning'] = $dir . 'ContentWarning.i18n.php';
 
 // Hooks
 $wgHooks['GetHTMLAfterBody'][] = 'ContentWarningHooks::onGetHTMLAfterBody';

--- a/extensions/wikia/CookiePolicy/CookiePolicy.setup.php
+++ b/extensions/wikia/CookiePolicy/CookiePolicy.setup.php
@@ -14,7 +14,6 @@ $wgExtensionCredits['other'][] = array(
 	'url' => 'https://github.com/Wikia/app/tree/dev/extensions/wikia/CookiePolicy/',
 );
 
-$wgExtensionMessagesFiles['CookiePolicy'] = __DIR__ . '/CookiePolicy.i18n.php';
 
 $wgAutoloadClasses['Wikia\CookiePolicy\CookiePolicyHooks'] = __DIR__ . '/CookiePolicy.hooks.php';
 

--- a/extensions/wikia/CoppaTool/CoppaTool.setup.php
+++ b/extensions/wikia/CoppaTool/CoppaTool.setup.php
@@ -19,7 +19,6 @@ $wgExtensionCredits['specialpage'][] = [
 $wgAutoloadClasses['CoppaToolSpecialController'] =  __DIR__ . '/CoppaToolSpecialController.class.php';
 $wgAutoloadClasses['CoppaToolController'] =  __DIR__ . '/CoppaToolController.class.php';
 
-$wgExtensionMessagesFiles['CoppaTool'] = __DIR__ . '/CoppaTool.i18n.php' ;
 
 $wgSpecialPages['CoppaTool'] = 'CoppaToolSpecialController';
 $wgSpecialPageGroups['CoppaTool'] = 'wikia';

--- a/extensions/wikia/CreateNewWiki/CreateNewWiki_setup.php
+++ b/extensions/wikia/CreateNewWiki/CreateNewWiki_setup.php
@@ -47,9 +47,6 @@ $wgAutoloadClasses['CreateNewWikiController'] = $dir . 'CreateNewWikiController.
 $wgSpecialPages['CreateNewWiki'] = 'SpecialCreateNewWiki';
 
 // i18n mapping
-$wgExtensionMessagesFiles['CreateWikiChecks'] = $dir . 'CreateWikiChecks.i18n.php';
-$wgExtensionMessagesFiles['CreateNewWiki'] = $dir . 'CreateNewWiki.i18n.php';
-$wgExtensionMessagesFiles['CreateNewWikiAlias'] = $dir . 'CreateNewWiki.alias.php';
 
 // setup functions
 $wgExtensionFunctions[] = 'CreateNewWikiController::setupCreateNewWiki';

--- a/extensions/wikia/CreateNewWiki/FinishCreateWiki_setup.php
+++ b/extensions/wikia/CreateNewWiki/FinishCreateWiki_setup.php
@@ -16,4 +16,3 @@ $wgAutoloadClasses['SpecialFinishCreate'] = $dir . 'SpecialFinishCreate.class.ph
 $wgSpecialPages['FinishCreate'] = 'SpecialFinishCreate';
 
 // i18n mapping
-$wgExtensionMessagesFiles['CreateNewWiki'] = $dir . 'CreateNewWiki.i18n.php';

--- a/extensions/wikia/CreateNewWiki/WikiaApiCreatorReminderEmail.php
+++ b/extensions/wikia/CreateNewWiki/WikiaApiCreatorReminderEmail.php
@@ -28,8 +28,7 @@ class WikiaApiCreatorReminderEmail extends ApiBase {
 	 */
 	public function execute() {
 
-		global $wgTheSchwartzSecretToken, $wgCityId, $wgServer,
-			$wgExtensionMessagesFiles;
+		global $wgTheSchwartzSecretToken, $wgCityId, $wgServer;
 
 		$params = $this->extractRequestParams();
 		$status = 0;

--- a/extensions/wikia/CreatePage/CreatePage.php
+++ b/extensions/wikia/CreatePage/CreatePage.php
@@ -23,11 +23,9 @@ define( 'CREATEPAGE_DIALOG_SIDE_PADDING', 10 );
 /**
  * messages file
  */
-$wgExtensionMessagesFiles['CreatePage'] = dirname( __FILE__ ) . '/CreatePage.i18n.php';
 /**
  * Aliases
  */
-$wgExtensionMessagesFiles['CreatePageAliases'] = __DIR__ . '/CreatePage.aliases.php';
 
 /**
  * Special page

--- a/extensions/wikia/CuratedContent/CuratedContent.setup.php
+++ b/extensions/wikia/CuratedContent/CuratedContent.setup.php
@@ -25,8 +25,6 @@ $wgAutoloadClasses['CuratedContentHooks'] =  __DIR__ . '/CuratedContentHooks.cla
 /**
  * message files
  */
-$wgExtensionMessagesFiles['CuratedContent'] = __DIR__ . '/CuratedContent.i18n.php';
-$wgExtensionMessagesFiles['CuratedContentAlias'] = __DIR__ . '/CuratedContent.alias.php';
 
 JSMessages::registerPackage( 'CuratedContentMsg', [
 	'wikiacuratedcontent-content-duplicate-entry',

--- a/extensions/wikia/Custom404Page/Custom404Page.setup.php
+++ b/extensions/wikia/Custom404Page/Custom404Page.setup.php
@@ -8,4 +8,3 @@ $wgAutoloadClasses['Custom404PageHooks'] =  __DIR__ . '/Custom404PageHooks.class
 $wgHooks['BeforeDisplayNoArticleText'][] = 'Custom404PageHooks::onBeforeDisplayNoArticleText';
 
 // Messages
-$wgExtensionMessagesFiles['Custom404Page'] = __DIR__ . '/Custom404Page.i18n.php';

--- a/extensions/wikia/DMCARequest/DMCARequest.setup.php
+++ b/extensions/wikia/DMCARequest/DMCARequest.setup.php
@@ -24,7 +24,6 @@ $wgAutoloadClasses['DMCARequestSpecialController'] =  __DIR__ . '/DMCARequestSpe
 $wgAutoloadClasses['DMCARequestManagementSpecialController'] =  __DIR__ . '/DMCARequestManagementSpecialController.class.php';
 $wgAutoloadClasses['DMCARequest\ChillingEffectsClient'] =  __DIR__ . '/ChillingEffectsClient.class.php';
 
-$wgExtensionMessagesFiles['DMCARequest'] = __DIR__ . '/DMCARequest.i18n.php' ;
 
 $wgSpecialPages['DMCARequest'] = 'DMCARequestSpecialController';
 $wgSpecialPages['DMCARequestManagement'] = 'DMCARequestManagementSpecialController';

--- a/extensions/wikia/DataProvider/DataProvider.php
+++ b/extensions/wikia/DataProvider/DataProvider.php
@@ -25,7 +25,6 @@ $wgExtensionCredits['other'][] = array(
 );
 
 // i18n
-$wgExtensionMessagesFiles['DataProvider'] = __DIR__ . '/DataProvider.i18n.php';
 
 class DataProvider {
 	private $skin;

--- a/extensions/wikia/DesignSystem/DesignSystem.setup.php
+++ b/extensions/wikia/DesignSystem/DesignSystem.setup.php
@@ -11,7 +11,6 @@ $wgExtensionCredits['api'][] = [
 ];
 
 // i18n
-$wgExtensionMessagesFiles['DesignSystem'] = __DIR__ . '/DesignSystem.i18n.php';
 
 // services
 $wgAutoloadClasses[ 'DesignSystemGlobalFooterService' ] = __DIR__ . '/services/DesignSystemGlobalFooterService.class.php';

--- a/extensions/wikia/Development/SpecialDevBoxPanel/Special_DevBoxPanel.php
+++ b/extensions/wikia/Development/SpecialDevBoxPanel/Special_DevBoxPanel.php
@@ -29,7 +29,6 @@ $wgSpecialPageGroups['DevBoxPanel'] = 'wikia';
 
 // Hooks
 $dir = __DIR__ . '/';
-$wgExtensionMessagesFiles['DevBoxPanel'] = $dir.'Special_DevBoxPanel.i18n.php';
 
 if (!empty($wgRunningUnitTests) && $wgNoDBUnits) {
 	Language::$dataCache = new FakeCache();

--- a/extensions/wikia/Development/SpecialListIncludedFiles/Special_ListIncludedFiles.php
+++ b/extensions/wikia/Development/SpecialListIncludedFiles/Special_ListIncludedFiles.php
@@ -6,7 +6,6 @@
  * Mainly intended for dev use... not because it's private, just because it's not too useful to anyone else.
  */
 $dir = dirname(__FILE__) . '/';
-$wgExtensionMessagesFiles['listincludedfiles'] = $dir . 'Special_ListIncludedFiles.i18n.php';
 
 require_once($IP . '/includes/SpecialPage.php');
 $wgSpecialPages['ListIncludedFiles'] = 'ListIncludedFiles';

--- a/extensions/wikia/Discussions/Discussions.setup.php
+++ b/extensions/wikia/Discussions/Discussions.setup.php
@@ -51,8 +51,6 @@ if ( !empty( $wgEnableDiscussions ) && empty( $wgEnableForumExt ) ) {
 }
 
 // message files
-$wgExtensionMessagesFiles['SpecialDiscussions'] = $dir . 'i18n/SpecialDiscussions.i18n.php';
-$wgExtensionMessagesFiles['StaffWelcomePost'] = $dir . 'i18n/StaffWelcomePost.i18n.php';
 
 // permissions
 $wgAvailableRights[] = 'specialdiscussions';

--- a/extensions/wikia/EditAccount/FlagClosedAccounts.php
+++ b/extensions/wikia/EditAccount/FlagClosedAccounts.php
@@ -22,7 +22,6 @@ define( 'CLOSED_ACCOUNT_FLAG', 'Account Disabled' );
 
 $wgHooks['SpecialContributionsBeforeMainOutput'][] = 'efFlagClosedAccounts';
 
-$wgExtensionMessagesFiles['EditAccount'] = dirname( __FILE__ ) . '/SpecialEditAccount.i18n.php';
 
 function efFlagClosedAccounts( $id ) {
 	global $wgOut;

--- a/extensions/wikia/EditAccount/SpecialEditAccount.php
+++ b/extensions/wikia/EditAccount/SpecialEditAccount.php
@@ -38,7 +38,6 @@ $wgLogActions['editaccnt/closeaccnt'] = 'editaccount-log-entry-close';
 $wgLogRestrictions['editaccnt'] = 'editaccount';
 
 // Set up the new special page
-$wgExtensionMessagesFiles['EditAccount'] = __DIR__ . '/SpecialEditAccount.i18n.php';
 $wgAutoloadClasses['EditAccount'] = __DIR__ . '/SpecialEditAccount_body.php';
 $wgSpecialPages['EditAccount'] = 'EditAccount';
 $wgSpecialPageGroups['EditAccount'] = 'users';

--- a/extensions/wikia/EditPageLayout/EditPageLayout_setup.php
+++ b/extensions/wikia/EditPageLayout/EditPageLayout_setup.php
@@ -57,7 +57,6 @@ $wgHooks['GetPreferences'][] = 'EditPageLayoutHooks::onGetPreferences';
 $wgHooks['LogEventsListShowLogExtract'][] = 'EditPageLayoutHooks::onLogEventsListShowLogExtract';
 
 // messages
-$wgExtensionMessagesFiles['EditPageLayout'] = $dir . '/EditPageLayout.i18n.php';
 
 // add class to autoloader and register handler for it
 $wgAutoloadClasses['EditorUserPropertiesHandler'] = "$dir/models/EditorUserPropertiesHandler.class.php";

--- a/extensions/wikia/EditPreview/EditPreview.setup.php
+++ b/extensions/wikia/EditPreview/EditPreview.setup.php
@@ -20,4 +20,3 @@ $wgExtensionCredits['editpreview'][] = [
 ];
 
 // messages
-$wgExtensionMessagesFiles[ 'EditPreview' ] = __DIR__ . '/EditPreview.i18n.php';

--- a/extensions/wikia/Editcount/SpecialEditcount.php
+++ b/extensions/wikia/Editcount/SpecialEditcount.php
@@ -26,5 +26,3 @@ $wgAutoloadClasses['Editcount'] = $dir . '/SpecialEditcount_body.php';
 $wgSpecialPages['Editcount'] = 'Editcount';
 $wgSpecialPageGroups['Editcount'] = 'users';
 
-$wgExtensionMessagesFiles['Editcount'] = $dir . '/SpecialEditcount.i18n.php';
-$wgExtensionMessagesFiles['EditcountAliases'] = __DIR__ . '/SpecialEditcount.aliases.php';

--- a/extensions/wikia/EditorPreference/EditorPreference.php
+++ b/extensions/wikia/EditorPreference/EditorPreference.php
@@ -17,7 +17,6 @@ $dir = dirname(__FILE__) . '/';
 $wgAutoloadClasses['EditorPreference'] = $dir . 'EditorPreference.class.php';
 
 // i18n
-$wgExtensionMessagesFiles['EditorPreference'] = $dir . 'EditorPreference.i18n.php';
 
 // Hooks
 $wgHooks['EditingPreferencesBefore'][] = 'EditorPreference::onEditingPreferencesBefore';

--- a/extensions/wikia/Email/Email.setup.php
+++ b/extensions/wikia/Email/Email.setup.php
@@ -89,24 +89,4 @@ $wgSpecialPages[ 'SendEmail' ] =  'Email\SpecialSendEmailController';
 /**
  * messages
  */
-$wgExtensionMessagesFiles['Email'] = $dir . 'Email.i18n.php';
-$wgExtensionMessagesFiles['EmailWatchedPage'] = $dir . 'i18n/WatchedPage.i18n.php';
-$wgExtensionMessagesFiles['EmailWatchedPageRestored'] = $dir . 'i18n/WatchedPageRestored.i18n.php';
-$wgExtensionMessagesFiles['EmailComment'] = $dir . 'i18n/Comment.i18n.php';
-$wgExtensionMessagesFiles['EmailBlogPost'] = $dir . 'i18n/BlogPost.i18n.php';
-$wgExtensionMessagesFiles['EmailForum'] = $dir . 'i18n/Forum.i18n.php';
-$wgExtensionMessagesFiles['EmailWallMessage'] = $dir . 'i18n/WallMessage.i18n.php';
-$wgExtensionMessagesFiles['EmailWeeklyDigest'] = $dir . 'i18n/WeeklyDigest.i18n.php';
-$wgExtensionMessagesFiles['EmailFounder'] = $dir . 'i18n/Founder.i18n.php';
-$wgExtensionMessagesFiles['EmailFacebookDisconnect'] = $dir . 'i18n/FacebookDisconnect.i18n.php';
-$wgExtensionMessagesFiles['EmailConfirmation'] = $dir . 'i18n/EmailConfirmation.i18n.php';
-$wgExtensionMessagesFiles['EmailFounderDigest'] = $dir . 'i18n/FounderDigest.i18n.php';
-$wgExtensionMessagesFiles['ReactivateAccount'] = $dir . 'i18n/ReactivateAccount.i18n.php';
-$wgExtensionMessagesFiles['EmailCategoryAdd'] = $dir . 'i18n/CategoryAdd.i18n.php';
-$wgExtensionMessagesFiles['EmailWelcome'] = $dir . 'i18n/Welcome.i18n.php';
-$wgExtensionMessagesFiles['SpecialSendEmail'] = $dir . 'i18n/specialSendEmail.i18n.php';
-$wgExtensionMessagesFiles['ForgotPassword'] = $dir . 'i18n/ForgotPassword.i18n.php';
-$wgExtensionMessagesFiles['UserRightsChanged'] = $dir . 'i18n/UserRightsChanged.i18n.php';
-$wgExtensionMessagesFiles['EmailUserNameChange'] = $dir . 'i18n/UserNameChange.i18n.php';
-$wgExtensionMessagesFiles['EmailDiscussions'] = $dir . 'i18n/Discussion.i18n.php';
 

--- a/extensions/wikia/EmbeddableDiscussions/EmbeddableDiscussions.setup.php
+++ b/extensions/wikia/EmbeddableDiscussions/EmbeddableDiscussions.setup.php
@@ -19,7 +19,6 @@ $wgHooks['ParserFirstCallInit'][] = 'EmbeddableDiscussionsController::onParserFi
 $wgHooks['BeforePageDisplay'][] = 'EmbeddableDiscussionsController::onBeforePageDisplay';
 
 // i18n
-$wgExtensionMessagesFiles['EmbeddableDiscussions'] = __DIR__ . '/EmbeddableDiscussions.i18n.php';
 
 // messages exported to JS
 JSMessages::registerPackage( 'EmbeddableDiscussions', [

--- a/extensions/wikia/FacebookPreferences/FacebookPreferences.setup.php
+++ b/extensions/wikia/FacebookPreferences/FacebookPreferences.setup.php
@@ -6,7 +6,6 @@ $wgExtensionCredits['other'][] = [
 	'url' => 'https://github.com/Wikia/app/tree/dev/extensions/wikia/FacebookPreferences',
 ];
 
-$wgExtensionMessagesFiles['FacebookPreferences'] = __DIR__ . '/FacebookPreferences.i18n.php';
 
 $wgAutoloadClasses['FacebookService'] = __DIR__ . '/FacebookService.php';
 $wgAutoloadClasses['FacebookApiFactory'] = __DIR__ . '/FacebookApiFactory.php';

--- a/extensions/wikia/FacebookTags/FacebookTags.setup.php
+++ b/extensions/wikia/FacebookTags/FacebookTags.setup.php
@@ -6,7 +6,6 @@ $wgExtensionCredits['parserhook'][] = [
 	'url' => 'https://github.com/Wikia/app/tree/dev/extensions/wikia/FacebookTags',
 ];
 
-$wgExtensionMessagesFiles['FacebookTags'] = __DIR__ . '/FacebookTags.i18n.php';
 
 $wgAutoloadClasses['FacebookTagConstants'] = __DIR__ . '/FacebookTagConstants.php';
 $wgAutoloadClasses['FacebookTagParser'] = __DIR__ . '/FacebookTagParser.php';

--- a/extensions/wikia/FilePage/FilePage.setup.php
+++ b/extensions/wikia/FilePage/FilePage.setup.php
@@ -34,7 +34,6 @@ $wgAutoloadClasses[ 'FilePageHelper' ] = $dir . 'FilePageHelper.class.php';
 $wgAutoloadClasses[ 'FilePageController' ] = $dir . 'FilePageController.class.php';
 
 // i18n mapping
-$wgExtensionMessagesFiles['FilePage'] = $dir . 'FilePage.i18n.php' ;
 
 // hooks
 $wgHooks['ArticleFromTitle'][] = 'FilePageHooks::onArticleFromTitle';

--- a/extensions/wikia/FirstContributions/FirstContributions.setup.php
+++ b/extensions/wikia/FirstContributions/FirstContributions.setup.php
@@ -8,7 +8,6 @@ $wgExtensionCredits['api'][] = [
 	'url' => 'https://github.com/Wikia/app/tree/dev/extensions/wikia/FirstContributions',
 ];
 
-$wgExtensionMessagesFiles['FirstContributions'] = __DIR__ . '/FirstContributions.i18n.php';
 
 $wgAutoloadClasses['ApiQueryFirstContributions'] = __DIR__ . '/api/ApiQueryFirstContributions.php';
 

--- a/extensions/wikia/FliteTag/FliteTag.setup.php
+++ b/extensions/wikia/FliteTag/FliteTag.setup.php
@@ -14,4 +14,3 @@ $wgAutoloadClasses['FliteTagController'] =  __DIR__ . '/FliteTagController.class
 $wgHooks['ParserFirstCallInit'][] = 'FliteTagController::onParserFirstCallInit';
 
 // i18n
-$wgExtensionMessagesFiles['FliteTag'] = __DIR__ . '/FliteTag.i18n.php';

--- a/extensions/wikia/Follow/Follow.php
+++ b/extensions/wikia/Follow/Follow.php
@@ -16,8 +16,6 @@ $wgAutoloadClasses['FollowHelper']  = $dir . 'FollowHelper.class.php';
 $wgAutoloadClasses['FollowedPages']  = $dir . 'FollowedPagesSpecial.php';
 $wgAutoloadClasses['FollowModel'] = $dir . 'FollowModel.class.php';
 $wgAutoloadClasses['FollowEmailTask'] = $dir . 'FollowEmailTask.class.php';
-$wgExtensionMessagesFiles['Follow'] = $dir . 'Follow.i18n.php';
-$wgExtensionMessagesFiles['FollowAliases'] = $dir . 'Follow.alias.php';
 
 /* Hooks setup */
 if ( !empty($wgEnableWikiaFollowedPages) && $wgEnableWikiaFollowedPages ) {

--- a/extensions/wikia/Forum/Forum.setup.php
+++ b/extensions/wikia/Forum/Forum.setup.php
@@ -31,8 +31,6 @@ $wgAutoloadClasses['RelatedForumDiscussionController'] =  $dir . 'RelatedForumDi
 $wgAutoloadClasses['ThreadWatchlistDeleteUpdate'] = $dir . 'ThreadWatchlistDeleteUpdate.php';
 
 // i18n mapping
-$wgExtensionMessagesFiles['Forum'] = $dir . 'Forum.i18n.php' ;
-$wgExtensionMessagesFiles['ForumAliases'] = $dir . 'Forum.alias.php';
 
 // special pages
 $wgSpecialPages['Forum'] =  'ForumSpecialController';

--- a/extensions/wikia/Forum/ForumDisabled.setup.php
+++ b/extensions/wikia/Forum/ForumDisabled.setup.php
@@ -21,4 +21,3 @@ $wgAutoloadClasses[ 'ForumNotificationPlugin'] =  $dir . 'ForumNotificationPlugi
 
 $wgHooks['NotificationGetNotificationMessage'][] = 'ForumNotificationPlugin::onGetNotificationMessage';
 
-$wgExtensionMessagesFiles['Forum'] = $dir . 'Forum.i18n.php' ;

--- a/extensions/wikia/FounderEmails/FounderEmails.php
+++ b/extensions/wikia/FounderEmails/FounderEmails.php
@@ -19,7 +19,6 @@ $wgExtensionCredits['specialpage'][] = array(
 /**
  * messages file
  */
-$wgExtensionMessagesFiles['FounderEmails'] = dirname( __FILE__ ) . '/FounderEmails.i18n.php';
 
 /**
  * extension config

--- a/extensions/wikia/FounderProgressBar/FounderProgressBar.setup.php
+++ b/extensions/wikia/FounderProgressBar/FounderProgressBar.setup.php
@@ -14,7 +14,6 @@ $wgAutoloadClasses['FounderProgressBarController'] =  $dir . '/FounderProgressBa
 $wgAutoloadClasses['FounderProgressBarHooks'] =  $dir . '/FounderProgressBarHooks.class.php';
 
 // I18N
-$wgExtensionMessagesFiles['FounderProgressBar'] = $dir . '/FounderProgressBar.i18n.php';
 
 // Hooks
 $wgHooks[ 'ArticleSaveComplete' ][] = 'FounderProgressBarHooks::onArticleSaveComplete';

--- a/extensions/wikia/GameGuides/GameGuides_setup.php
+++ b/extensions/wikia/GameGuides/GameGuides_setup.php
@@ -24,7 +24,6 @@ $wgAutoloadClasses['GameGuidesModel'] =  "{$dir}/GameGuidesModel.class.php" ;
 /**
  * message files
  */
-$wgExtensionMessagesFiles['GameGuides'] = "{$dir}/GameGuides.i18n.php";
 
 
 //Special Page to preview page in GameGuide style

--- a/extensions/wikia/GlobalCSSJS/GlobalCSSJS.php
+++ b/extensions/wikia/GlobalCSSJS/GlobalCSSJS.php
@@ -13,7 +13,6 @@ $wgExtensionCredits['other'][] = array(
   );
   
   //i18n
-$wgExtensionMessagesFiles['GlobalCSSJS'] = __DIR__ . '/GlobalCSSJS.i18n.php';
 
 /**
  * Adds custom user CSS and JavaScript to a page

--- a/extensions/wikia/GlobalShortcuts/GlobalShortcuts.setup.php
+++ b/extensions/wikia/GlobalShortcuts/GlobalShortcuts.setup.php
@@ -40,7 +40,6 @@ $wgAutoloadClasses['Wikia\GlobalShortcuts\Helper'] = __DIR__ . '/GlobalShortcuts
 /**
  * Messages
  */
-$wgExtensionMessagesFiles['GlobalShortcuts'] = __DIR__ . '/GlobalShortcuts.i18n.php';
 
 JSMessages::registerPackage( 'GlobalShortcuts', [
 	'global-shortcuts-caption-*',

--- a/extensions/wikia/GoogleAnalyticsSampling/GoogleAnalyticsSampling.setup.php
+++ b/extensions/wikia/GoogleAnalyticsSampling/GoogleAnalyticsSampling.setup.php
@@ -21,7 +21,6 @@ $wgExtensionCredits[ 'other' ][ ] = array(
 $dir = dirname(__FILE__);
 
 //i18n
-$wgExtensionMessagesFiles['GoogleAnalyticsSampling'] = $dir . '/GoogleAnalyticsSampling.i18n.php';
 
 // WikiaApp
 $app = F::app();

--- a/extensions/wikia/GoogleDocs/GoogleDocs.php
+++ b/extensions/wikia/GoogleDocs/GoogleDocs.php
@@ -26,7 +26,6 @@ $wgExtensionCredits['parserhook'][] = [
 ];
 
 //i18n
-$wgExtensionMessagesFiles['GoogleDocs4MW'] = __DIR__ . '/GoogleDocs.i18n.php';
 
 function wfGoogleDocs( Parser $parser ) {
 	$parser->setHook( 'googlespreadsheet', 'renderGoogleSpreadsheet' );

--- a/extensions/wikia/GoogleFormTag/GoogleFormTag.setup.php
+++ b/extensions/wikia/GoogleFormTag/GoogleFormTag.setup.php
@@ -15,4 +15,3 @@ $wgAutoloadClasses['GoogleFormTagController'] = __DIR__ . '/GoogleFormTagControl
 $wgHooks['ParserFirstCallInit'][] = 'GoogleFormTagController::onParserFirstCallInit';
 
 // i18n
-$wgExtensionMessagesFiles['GoogleFormTag'] = __DIR__ . '/GoogleFormTag.i18n.php';

--- a/extensions/wikia/HAWelcome/HAWelcome.setup.php
+++ b/extensions/wikia/HAWelcome/HAWelcome.setup.php
@@ -42,7 +42,6 @@ $wgExtensionCredits['other'][] = array(
 	'url'               => 'https://github.com/Wikia/app/tree/dev/extensions/wikia/HAWelcome/'
 );
 
-$wgExtensionMessagesFiles[ 'HAWelcome' ] = $dir . '/HAWelcome.i18n.php';
 
 $wgAutoloadClasses['HAWelcomeHooks'] =  $dir . 'HAWelcomeHooks.php' ;
 $wgAutoloadClasses['HAWelcomeTask'] =  $dir . 'HAWelcomeTask.php' ;

--- a/extensions/wikia/ImageLazyLoad/ImageLazyLoad.setup.php
+++ b/extensions/wikia/ImageLazyLoad/ImageLazyLoad.setup.php
@@ -13,7 +13,6 @@ $wgExtensionCredits[ 'other' ][ ] = array(
 $dir = dirname(__FILE__) . '/';
 
 //i18n
-$wgExtensionMessagesFiles['ImageLazyLoad'] = $dir . 'i18n/ImageLazyLoad.i18n.php';
 
 $wgAutoloadClasses[ 'ImageLazyLoad'] =  $dir . 'ImageLazyLoad.class.php' ;
 

--- a/extensions/wikia/ImagePlaceholder/ImagePlaceholder_setup.php
+++ b/extensions/wikia/ImagePlaceholder/ImagePlaceholder_setup.php
@@ -34,7 +34,6 @@ $wgExtensionFunctions[] = 'ImagePlaceholder_init';
 /**
  * message files
  */
-$wgExtensionMessagesFiles['ImagePlaceholder'] = $dir . 'ImagePlaceholder.i18n.php';
 
 JSMessages::registerPackage('ImagePlaceholder', array('imgplc-*'));
 JSMessages::enqueuePackage('ImagePlaceholder', JSMessages::EXTERNAL);

--- a/extensions/wikia/ImageReview/CoppaImageReview.setup.php
+++ b/extensions/wikia/ImageReview/CoppaImageReview.setup.php
@@ -25,4 +25,3 @@ $wgAutoloadClasses['CoppaImageReviewSpecialController'] =  __DIR__ . '/modules/C
 $wgAutoloadClasses['CoppaImageReviewHelper'] =  __DIR__ . '/modules/CoppaImageReview/CoppaImageReviewHelper.class.php';
 $wgSpecialPages['CoppaImageReview'] = 'CoppaImageReviewSpecialController';
 
-$wgExtensionMessagesFiles['CoppaImageReview'] = __DIR__ . '/modules/CoppaImageReview/CoppaImageReview.i18n.php';

--- a/extensions/wikia/ImageReview/ImageReview.setup.php
+++ b/extensions/wikia/ImageReview/ImageReview.setup.php
@@ -40,4 +40,3 @@ $wgSpecialPages['ImageReview'] = 'ImageReviewSpecialController';
 $wgExtensionFunctions[] = 'ImageReviewHooks::setupHooks';
 
 // i18n
-$wgExtensionMessagesFiles['ImageReview'] = $dir . 'ImageReview.i18n.php';

--- a/extensions/wikia/ImageServing/Test/ImageServingTest.setup.php
+++ b/extensions/wikia/ImageServing/Test/ImageServingTest.setup.php
@@ -20,6 +20,4 @@ $wgExtensionCredits['specialpage'][] = array(
 $dir = dirname(__FILE__) . '/';
 
 $wgAutoloadClasses['ImageServingTest'] = $dir . 'ImageServingTest_body.php'; # Tell MediaWiki to load the extension body.
-$wgExtensionMessagesFiles['ImageServingTest'] = $dir . 'ImageServingTest.i18n.php';
-$wgExtensionMessagesFiles['ImageServingTestAliases'] = $dir . 'ImageServingTest.alias.php';
 $wgSpecialPages['ImageServingTest'] = 'ImageServingTest'; # Let MediaWiki know about your new special page.

--- a/extensions/wikia/ImageServing/imageServing.setup.php
+++ b/extensions/wikia/ImageServing/imageServing.setup.php
@@ -42,7 +42,6 @@ if (isset($wgHooks['BeforeParserrenderImageGallery'])) {
 }
 
 // i18n
-$wgExtensionMessagesFiles['ImageServing'] = $dir . 'ImageServing.i18n.php';
 
 /* Adds imageCrop api to lists */
 $wgAutoloadClasses[ "WikiaApiCroppedImage"         ] = "{$dir}/api/WikiaApiCroppedImage.php";

--- a/extensions/wikia/ImageSizeInfoFunctions/ImageSizeInfoFunctions.php
+++ b/extensions/wikia/ImageSizeInfoFunctions/ImageSizeInfoFunctions.php
@@ -32,4 +32,3 @@ $wgAutoloadClasses['ExtImageSizeInfoFunctionsHooks'] = dirname( __FILE__ ) . '/I
 
 $wgHooks['ParserFirstCallInit'][] = 'ExtImageSizeInfoFunctionsHooks::parserFirstCallInit';
 
-$wgExtensionMessagesFiles['ImageSizeInfoFunctions'] =  dirname( __FILE__ ) . '/ImageSizeInfoFunctions.i18n.php';

--- a/extensions/wikia/IndexingPipeline/IndexingPipeline.setup.php
+++ b/extensions/wikia/IndexingPipeline/IndexingPipeline.setup.php
@@ -10,7 +10,6 @@ $wgExtensionCredits[ 'other' ][] = [
 $dir = dirname( __FILE__ );
 
 //i18n
-$wgExtensionMessagesFiles[ 'IndexingPipeline' ] = $dir . '/IndexingPipeline.i18n.php';
 
 $wgAutoloadClasses[ 'Wikia\IndexingPipeline\PipelineEventProducer' ] = $dir . '/PipelineEventProducer.class.php';
 $wgAutoloadClasses[ 'Wikia\IndexingPipeline\MySQLMetricEventProducer' ] = $dir . '/MySQLMetricEventProducer.class.php';

--- a/extensions/wikia/InfoboxBuilder/InfoboxBuilder.php
+++ b/extensions/wikia/InfoboxBuilder/InfoboxBuilder.php
@@ -45,8 +45,6 @@ $wgHooks['EditPageLayoutExecute'][]       = '\InfoboxBuilder\InfoboxBuilderHooks
 /**
  * I18n files
  */
-$wgExtensionMessagesFiles['InfoboxBuilder']      = __DIR__ . '/InfoboxBuilder.i18n.php';
-$wgExtensionMessagesFiles['InfoboxBuilderMagic'] = __DIR__ . '/InfoboxBuilder.magic.i18n.php';
 
 /**
  * Register SCSS with the default theme for an infobox

--- a/extensions/wikia/InsightsBlogpostRedirect/InsightsBlogpostRedirect.setup.php
+++ b/extensions/wikia/InsightsBlogpostRedirect/InsightsBlogpostRedirect.setup.php
@@ -25,4 +25,3 @@ $wgAutoloadClasses['InsightsBlogpostRedirectController'] = $dir . 'InsightsBlogp
 $wgSpecialPages['Insights'] = 'InsightsBlogpostRedirectController';
 
 //message files
-$wgExtensionMessagesFiles['InsightsBlogpostRedirect'] = $dir . 'InsightsBlogpostRedirect.i18n.php';

--- a/extensions/wikia/InsightsV2/InsightsV2.setup.php
+++ b/extensions/wikia/InsightsV2/InsightsV2.setup.php
@@ -95,5 +95,3 @@ $wgExtensionFunctions[] = 'InsightsHooks::init';
 /**
  * Message files
  */
-$wgExtensionMessagesFiles['Insights'] = $dir . 'Insights.i18n.php';
-$wgExtensionMessagesFiles['InsightsAliases'] = $dir . 'Insights.alias.php';

--- a/extensions/wikia/InstantGlobals/InstantGlobals.setup.php
+++ b/extensions/wikia/InstantGlobals/InstantGlobals.setup.php
@@ -38,7 +38,6 @@ $wgAutoloadClasses['InstantGlobalsModule'] = "{$dir}/InstantGlobalsModule.class.
 $wgWikiaApiControllers['InstantGlobalsApiController'] = $dir . 'InstantGlobalsApiController.class.php';
 
 // i18n
-$wgExtensionMessagesFiles['InstantGlobals'] = $dir . '/InstantGlobals.i18n.php';
 
 /**
  * hooks

--- a/extensions/wikia/InterwikiDispatcher/SpecialInterwikiDispatcher.php
+++ b/extensions/wikia/InterwikiDispatcher/SpecialInterwikiDispatcher.php
@@ -28,8 +28,6 @@ $wgExtensionCredits['specialpage'][] = array(
 	'url' => 'https://github.com/Wikia/app/tree/dev/extensions/wikia/InterwikiDispatcher'
 );
 
-$wgExtensionMessagesFiles['SpecialInterwikiDispatcher'] = dirname(__FILE__) . '/SpecialInterwikiDispatcher.i18n.php';
-$wgExtensionMessagesFiles['SpecialInterwikiDispatcherAliases'] = dirname(__FILE__) . '/SpecialInterwikiDispatcher.alias.php';
 
 //Register hook
 $wgHooks['GetFullURL'][] = 'InterwikiDispatcher::getInterWikiaURLHook';

--- a/extensions/wikia/JSMessages/JSMessages_setup.php
+++ b/extensions/wikia/JSMessages/JSMessages_setup.php
@@ -20,7 +20,6 @@ $wgExtensionCredits['other'][] = array(
 $dir = dirname(__FILE__);
 
 //i18n
-$wgExtensionMessagesFiles['JSMessages'] = $dir . '/JSMessages.i18n.php';
 
 // classes
 $wgAutoloadClasses['JSMessages'] =  $dir . '/JSMessages.class.php';

--- a/extensions/wikia/JSSnippets/JSSnippets_setup.php
+++ b/extensions/wikia/JSSnippets/JSSnippets_setup.php
@@ -26,7 +26,6 @@ $wgExtensionCredits[ 'other' ][ ] = array(
 $dir = dirname(__FILE__);
 
 //i18n
-$wgExtensionMessagesFiles['JSSnippets'] = $dir . '/JSSnippets.i18n.php';
 
 // classes
 $wgAutoloadClasses['JSSnippets'] =  $dir . '/JSSnippets.class.php';

--- a/extensions/wikia/JSVariables/JSVariables.php
+++ b/extensions/wikia/JSVariables/JSVariables.php
@@ -11,7 +11,6 @@ $wgExtensionCredits[ 'other' ][ ] = array(
 );
 
 //i18n
-$wgExtensionMessagesFiles[ 'JSVariables' ] = __DIR__ . '/JSVariables.i18n.php';
 
 $wgHooks['MakeGlobalVariablesScript'][] = 'wfMakeGlobalVariablesScript';
 $wgHooks['WikiaSkinTopScripts'][] = 'wfJSVariablesTopScripts';

--- a/extensions/wikia/JsonFormat/JsonFormat.setup.php
+++ b/extensions/wikia/JsonFormat/JsonFormat.setup.php
@@ -11,7 +11,6 @@ $dir = dirname(__FILE__);
 $app = F::app();
 
 //i18n
-$wgExtensionMessagesFiles['JsonFormat'] =                       $dir . '/i18n/JsonFormat.i18n.php';
 
 $wgAutoloadClasses[ 'Wikia\JsonFormat\HtmlParser' ] =           $dir . "/HtmlParser.php";
 $wgAutoloadClasses[ 'JsonFormatService' ] =                     $dir . "/JsonFormatService.php";

--- a/extensions/wikia/Lightbox/Lightbox.setup.php
+++ b/extensions/wikia/Lightbox/Lightbox.setup.php
@@ -31,7 +31,6 @@ $wgHooks['MakeGlobalVariablesScript'][] = 'LightboxHooks::onMakeGlobalVariablesS
 $wgHooks['GetHTMLAfterBody'][] = 'LightboxHooks::onGetHTMLAfterBody';
 
 // i18n mapping
-$wgExtensionMessagesFiles['Lightbox'] = $dir . 'Lightbox.i18n.php';
 
 JSMessages::registerPackage('Lightbox', array(
 	'lightbox-carousel-more-items',

--- a/extensions/wikia/LinkSuggest/LinkSuggest.php
+++ b/extensions/wikia/LinkSuggest/LinkSuggest.php
@@ -49,7 +49,6 @@ $wgAutoloadClasses['LinkSuggestLoader'] = __DIR__ . '/LinkSuggestLoader.class.ph
 $wgAutoloadClasses['LinkSuggestHooks'] = __DIR__ . '/LinkSuggestHooks.class.php';
 
 // i18n
-$wgExtensionMessagesFiles['LinkSuggest'] = __DIR__ . '/LinkSuggest.i18n.php';
 
 // hooks
 $wgHooks['GetPreferences'][] = 'LinkSuggestHooks::onGetPreferences' ;

--- a/extensions/wikia/LinkToMobileApp/LinkToMobileApp.php
+++ b/extensions/wikia/LinkToMobileApp/LinkToMobileApp.php
@@ -30,7 +30,6 @@ $wgExtensionCredits['specialpage'][] = array(
 );
 
 //i18n
-$wgExtensionMessagesFiles['LinkToMobileApp'] = __DIR__ . '/LinkToMobileApp.i18n.php';
 
 $wgHooks['BeforePageDisplay'][] = 'efLinkToMobileApp';
 

--- a/extensions/wikia/Listusers/SpecialListusers.php
+++ b/extensions/wikia/Listusers/SpecialListusers.php
@@ -22,8 +22,6 @@ $wgExtensionCredits['specialpage'][] = array(
 /**
  * Messages
  */
-$wgExtensionMessagesFiles['Listusers'] = __DIR__ . '/SpecialListusers.i18n.php';
-$wgExtensionMessagesFiles['ListusersAlias'] = __DIR__ . '/SpecialListusers.alias.php';
 
 /**
  * Helpers

--- a/extensions/wikia/LocalSitemapPage/LocalSitemapPage.setup.php
+++ b/extensions/wikia/LocalSitemapPage/LocalSitemapPage.setup.php
@@ -7,7 +7,6 @@ $wgAutoloadClasses['LocalSitemapPageHooks'] = __DIR__ . '/LocalSitemapPageHooks.
 $wgAutoloadClasses['LocalSitemapSpecialPage'] = __DIR__ . '/LocalSitemapSpecialPage.class.php';
 
 // i18n mapping
-$wgExtensionMessagesFiles['LocalSitemapPage'] = __DIR__ . '/LocalSitemapPage.i18n.php';
 
 // hooks
 $wgHooks['ArticleFromTitle'][] = 'LocalSitemapPageHooks::onArticleFromTitle';

--- a/extensions/wikia/LookupContribs/LookupContribs.php
+++ b/extensions/wikia/LookupContribs/LookupContribs.php
@@ -26,7 +26,6 @@ $wgSpecialPageGroups['LookupContribs'] = 'users';
 /**
  * i18n
  */
-$wgExtensionMessagesFiles["SpecialLookupContribs"] = $dir . 'SpecialLookupContribs.i18n.php';
 
 /**
  * hooks

--- a/extensions/wikia/LookupUser/LookupUser.php
+++ b/extensions/wikia/LookupUser/LookupUser.php
@@ -28,7 +28,6 @@ $wgExtensionCredits['specialpage'][] = array(
 
 // Set up the new special page
 $dir = dirname( __FILE__ ) . '/';
-$wgExtensionAliasesFiles['LookupUser'] = $dir . 'LookupUser.alias.php';
 $wgAutoloadClasses['LookupUserPage'] = $dir . 'LookupUser.body.php';
 $wgSpecialPages['LookupUser'] = 'LookupUserPage';
 // Special page group for MW 1.13+

--- a/extensions/wikia/LookupUser/LookupUser.php
+++ b/extensions/wikia/LookupUser/LookupUser.php
@@ -28,7 +28,6 @@ $wgExtensionCredits['specialpage'][] = array(
 
 // Set up the new special page
 $dir = dirname( __FILE__ ) . '/';
-$wgExtensionMessagesFiles['LookupUser'] = $dir . 'LookupUser.i18n.php';
 $wgExtensionAliasesFiles['LookupUser'] = $dir . 'LookupUser.alias.php';
 $wgAutoloadClasses['LookupUserPage'] = $dir . 'LookupUser.body.php';
 $wgSpecialPages['LookupUser'] = 'LookupUserPage';

--- a/extensions/wikia/MainPageTag/MainPageTag.php
+++ b/extensions/wikia/MainPageTag/MainPageTag.php
@@ -19,7 +19,6 @@ $wgExtensionCredits[ 'other' ][ ] = array(
 );
 
 //i18n
-$wgExtensionMessagesFiles['MainPageTag'] = __DIR__ . '/MainPageTag.i18n.php';
 
 $wgHooks['ParserFirstCallInit'][] = 'wfMainPageTag';
 

--- a/extensions/wikia/MediaGallery/MediaGallery.setup.php
+++ b/extensions/wikia/MediaGallery/MediaGallery.setup.php
@@ -33,7 +33,6 @@ $wgHooks['MakeGlobalVariablesScript'][] = 'MediaGalleryHooks::onMakeGlobalVariab
 $wgHooks['WikiFeatures::afterToggleFeature'][] = 'MediaGalleryHooks::afterToggleFeature';
 
 // i18n mapping
-$wgExtensionMessagesFiles['MediaGallery'] = $dir . 'MediaGallery.i18n.php';
 
 JSMessages::registerPackage('MediaGallery', array(
 	'mediagallery-show-more',

--- a/extensions/wikia/MercuryApi/MercuryApi.setup.php
+++ b/extensions/wikia/MercuryApi/MercuryApi.setup.php
@@ -17,7 +17,6 @@ $wgExtensionCredits['api'][] = [
 ];
 
 // i18n
-$wgExtensionMessagesFiles['MercuryApi'] = $dir . 'MercuryApi.i18n.php';
 
 // Load needed classes
 $wgAutoloadClasses['MercuryApiController'] = $dir . 'MercuryApiController.class.php';

--- a/extensions/wikia/MiniEditor/MiniEditor.setup.php
+++ b/extensions/wikia/MiniEditor/MiniEditor.setup.php
@@ -32,4 +32,3 @@ $wgSpecialPages['MiniEditorDemo'] = 'MiniEditorSpecialController';
 /**
  * Message files
  */
-$wgExtensionMessagesFiles['MiniEditor'] = $dir . 'MiniEditor.i18n.php';

--- a/extensions/wikia/MostPopularCategories/SpecialMostPopularCategories.php
+++ b/extensions/wikia/MostPopularCategories/SpecialMostPopularCategories.php
@@ -28,10 +28,8 @@ $wgExtensionCredits['specialpage'][] = array(
 $wgHooks['wgQueryPages'][] = 'wfSetupMostPopularCategories';
 $wgExtensionFunctions[] = 'wfSetupMostPopularCategories';
 #--- messages file
-$wgExtensionMessagesFiles["Mostpopularcategories"] = dirname(__FILE__) . '/SpecialMostPopularCategories.i18n.php';
 
 // aliases
-$wgExtensionMessagesFiles['MostpopularcategoriesAliases'] = __DIR__ . '/SpecialMostPopularCategories.aliases.php';
 
 if ( !function_exists( 'extAddSpecialPage' ) ) {
     require_once( "$IP/extensions/ExtensionFunctions.php" );

--- a/extensions/wikia/MultiTasks/SpecialMultiDelete.php
+++ b/extensions/wikia/MultiTasks/SpecialMultiDelete.php
@@ -20,8 +20,6 @@ $wgExtensionCredits['specialpage'][] = array(
 	'url' => 'https://github.com/Wikia/app/tree/dev/extensions/wikia/MultiTasks'
 );
 
-$wgExtensionMessagesFiles["Multidelete"] = dirname(__FILE__) . '/MultiTasks.i18n.php';
-$wgExtensionMessagesFiles['MultideleteAliases'] = __DIR__ . '/MultiTasks.aliases.php';
 
 extAddSpecialPage( dirname(__FILE__) . '/SpecialMultiDelete_body.php', 'Multidelete', 'Multidelete' );
 

--- a/extensions/wikia/MultiTasks/SpecialMultiWikiEdit.php
+++ b/extensions/wikia/MultiTasks/SpecialMultiWikiEdit.php
@@ -21,8 +21,6 @@ $wgExtensionCredits['specialpage'][] = array(
 	"url" => "https://github.com/Wikia/app/tree/dev/extensions/wikia/MultiTasks"
 );
 
-$wgExtensionMessagesFiles["Multiwikiedit"] = dirname(__FILE__) . '/MultiTasks.i18n.php';
-$wgExtensionMessagesFiles['MultiwikieditAliases'] = __DIR__ . '/MultiTasks.aliases.php';
 
 require_once( $IP . "/extensions/wikia/TaskManager/BatchTask.php" );
 

--- a/extensions/wikia/MultiTasks/SpecialMultiWikiFinder.php
+++ b/extensions/wikia/MultiTasks/SpecialMultiWikiFinder.php
@@ -26,8 +26,6 @@ $wgExtensionCredits['specialpage'][] = array(
 );
 
 #--- messages file
-$wgExtensionMessagesFiles["Multiwikifinder"] = dirname(__FILE__) . '/MultiTasks.i18n.php';
-$wgExtensionMessagesFiles['MultiwikifinderAliases'] = __DIR__ . '/MultiTasks.aliases.php';
 
 if ( !function_exists( 'extAddSpecialPage' ) ) {
     require_once ( "$IP/extensions/ExtensionFunctions.php" );

--- a/extensions/wikia/MyHome/MyHome.php
+++ b/extensions/wikia/MyHome/MyHome.php
@@ -36,7 +36,6 @@ if((!empty($wgEnableAchievementsInActivityFeed)) && (!empty($wgEnableAchievement
 }
 
 // i18n
-$wgExtensionMessagesFiles['MyHome'] = $dir . 'MyHome.i18n.php';
 
 if (!empty($wgEnableActivityFeedApiFeed)) {
 	$wgAutoloadClasses["ApiQueryActivityFeed"] = $dir . "ApiQueryActivityFeed.php";

--- a/extensions/wikia/MyHome/SpecialMyHome.php
+++ b/extensions/wikia/MyHome/SpecialMyHome.php
@@ -13,7 +13,6 @@ $dir = dirname(__FILE__) . '/';
 $wgAutoloadClasses['SpecialWikiActivity'] = $dir.'SpecialWikiActivity.class.php';
 $wgSpecialPages['WikiActivity'] = 'SpecialWikiActivity';
 $wgSpecialPageGroups['WikiActivity'] = 'changes';
-$wgExtensionMessagesFiles['WikiActivityAliases'] = "$dir/SpecialWikiActivity.alias.php";
 
 // hooks
 $wgHooks['InitialQueriesMainPage'][] = 'MyHome::getInitialMainPage';

--- a/extensions/wikia/NotAValidWikia/NotAValidWikia.setup.php
+++ b/extensions/wikia/NotAValidWikia/NotAValidWikia.setup.php
@@ -5,7 +5,6 @@ $wgAutoloadClasses['NotAValidWikiaArticle'] =  __DIR__ . '/NotAValidWikiaArticle
 $wgAutoloadClasses['NotAValidWikiaHooks'] =  __DIR__ . '/NotAValidWikiaHooks.class.php';
 
 // i18n mapping
-$wgExtensionMessagesFiles['NotAValidWikia'] = __DIR__ . '/NotAValidWikia.i18n.php';
 
 // hooks
 $wgHooks['ArticleFromTitle'][] = 'NotAValidWikiaHooks::onArticleFromTitle';

--- a/extensions/wikia/Oasis/Oasis_setup.php
+++ b/extensions/wikia/Oasis/Oasis_setup.php
@@ -16,7 +16,6 @@ $wgExtensionCredits['other'][] = [
 ];
 
 // Messages
-$wgExtensionMessagesFiles['Oasis'] = __DIR__ . '/Oasis.i18n.php';
 
 $wgExtensionFunctions[] = 'wfOasisSetup';
 

--- a/extensions/wikia/OpenGraphMetaCustomizations/OpenGraphMetaCustomizations.setup.php
+++ b/extensions/wikia/OpenGraphMetaCustomizations/OpenGraphMetaCustomizations.setup.php
@@ -18,7 +18,6 @@ $wgExtensionCredits['other'][] = array(
 	'url' => 'https://github.com/Wikia/app/tree/dev/extensions/wikia/OpenGraphMetaCustomizations'
 );
 
-$wgExtensionMessagesFiles['OpenGraphMetaCustomizations'] = __DIR__ . '/OpenGraphMetaCustomizations.i18n.php';
 
 $wgHooks['ParserAfterTidy'][] = 'egOgmcParserAfterTidy';
 

--- a/extensions/wikia/Optimizely/Optimizely.setup.php
+++ b/extensions/wikia/Optimizely/Optimizely.setup.php
@@ -17,7 +17,6 @@ $wgExtensionCredits[ 'other' ][] = array(
 );
 
 //i18n
-$wgExtensionMessagesFiles['Optimizely'] = $dir . 'Optimizely.i18n.php';
 
 // classes
 $wgAutoloadClasses[ 'Optimizely' ] =  $dir . 'Optimizely.class.php';

--- a/extensions/wikia/PageHeader/PageHeader.setup.php
+++ b/extensions/wikia/PageHeader/PageHeader.setup.php
@@ -20,4 +20,3 @@ $wgHooks['BeforePageDisplay'][] = 'Wikia\PageHeader\Hooks::onBeforePageDisplay';
 $wgHooks['EditPage::showEditForm:initial'][] = 'Wikia\PageHeader\Hooks::onEditPageRender';
 
 // i18n
-$wgExtensionMessagesFiles[ 'PageHeader' ] = $dir . 'PageHeader.i18n.php';

--- a/extensions/wikia/PageShare/PageShare.setup.php
+++ b/extensions/wikia/PageShare/PageShare.setup.php
@@ -14,7 +14,6 @@ $wgExtensionCredits[ 'specialpage' ][] = [
 
 
 //i18n
-$wgExtensionMessagesFiles['PageShare'] = __DIR__ . '/PageShare.i18n.php';
 
 // controller classes
 $wgAutoloadClasses[ 'PageShareController' ] =  __DIR__ . '/PageShareController.class.php';

--- a/extensions/wikia/Paginator/Paginator.setup.php
+++ b/extensions/wikia/Paginator/Paginator.setup.php
@@ -11,4 +11,3 @@ $wgAutoloadClasses['Wikia\Paginator\Paginator'] = __DIR__ . '/classes/Paginator.
 $wgAutoloadClasses['Wikia\Paginator\UrlGenerator'] = __DIR__ . '/classes/UrlGenerator.class.php';
 $wgAutoloadClasses['Wikia\Paginator\Validator'] = __DIR__ . '/classes/Validator.class.php';
 
-$wgExtensionMessagesFiles['Paginator'] = __DIR__ . '/i18n/Paginator.i18n.php';

--- a/extensions/wikia/PaidAssetDrop/PaidAssetDrop.setup.php
+++ b/extensions/wikia/PaidAssetDrop/PaidAssetDrop.setup.php
@@ -17,4 +17,3 @@ $wgHooks['WikiaSkinTopScripts'][] = 'PaidAssetDropHooks::onWikiaSkinTopScripts';
 $wgHooks['InstantGlobalsGetVariables'][] = 'PaidAssetDropHooks::onInstantGlobalsGetVariables';
 
 // i18n
-$wgExtensionMessagesFiles['PaidAssetDrop'] = __DIR__ . '/PaidAssetDrop.i18n.php';

--- a/extensions/wikia/PartnerFeed/PartnerFeed.setup.php
+++ b/extensions/wikia/PartnerFeed/PartnerFeed.setup.php
@@ -25,8 +25,6 @@ $wgAutoloadClasses['PartnerRSSFeed']	= $dir . 'PartnerFeed.class.php';
 $wgAutoloadClasses['PartnerAtomFeed']	= $dir . 'PartnerFeed.class.php';
 $wgAutoloadClasses['PartnerFeed']	= $dir . 'PartnerFeed.body.php';
 
-$wgExtensionMessagesFiles['PartnerFeed'] = $dir . 'PartnerFeed.i18n.php';
-$wgExtensionMessagesFiles['PartnerFeedAliases'] = $dir. 'PartnerFeed.aliases.php';
 
 $wgSpecialPages['PartnerFeed']		= 'PartnerFeed';
 $wgSpecialPageGroups['PartnerFeed']	= 'wikia';

--- a/extensions/wikia/PhalanxII/Phalanx_setup.php
+++ b/extensions/wikia/PhalanxII/Phalanx_setup.php
@@ -101,7 +101,6 @@ foreach ( $phalanxhooks as $class => $hooks ) {
 /**
  * messages
  */
-$wgExtensionMessagesFiles['Phalanx'] = $dir . 'Phalanx.i18n.php';
 
 /*
  * globals, rights etc

--- a/extensions/wikia/Piggyback/Piggyback.php
+++ b/extensions/wikia/Piggyback/Piggyback.php
@@ -25,8 +25,6 @@ $wgAutoloadClasses['Piggyback'] = $dir . 'Piggyback_body.php'; # Tell MediaWiki 
 $wgAutoloadClasses['PBLoginForm']  = $dir . 'Piggyback_body.php'; # Tell MediaWiki to load the extension body.
 $wgAutoloadClasses['PBHooks']  = $dir . 'Piggyback_body.php';
 
-$wgExtensionMessagesFiles['Piggyback'] = $dir . 'Piggyback.i18n.php';
-$wgExtensionMessagesFiles['PiggybackAliases'] = $dir . 'Piggyback.alias.php';
 
 $wgSpecialPages['Piggyback'] = 'Piggyback'; # Let MediaWiki know about your new special page.
 

--- a/extensions/wikia/Places/Places.setup.php
+++ b/extensions/wikia/Places/Places.setup.php
@@ -76,8 +76,6 @@ $wgAPIModules['places'] = 'WikiaApiPlaces';
 /**
  * messages
  */
-$wgExtensionMessagesFiles['Places'] = $dir . '/Places.i18n.php';
-$wgExtensionMessagesFiles['PlacesAliases'] = $dir . '/Places.alias.php';
 
 JSMessages::registerPackage('Places', array(
 	'places-toolbar-button-*',

--- a/extensions/wikia/PlaybuzzTag/PlaybuzzTag.setup.php
+++ b/extensions/wikia/PlaybuzzTag/PlaybuzzTag.setup.php
@@ -15,4 +15,3 @@ $wgAutoloadClasses['PlaybuzzTagController'] =  __DIR__ . '/PlaybuzzTagController
 $wgHooks['ParserFirstCallInit'][] = 'PlaybuzzTagController::onParserFirstCallInit';
 
 // i18n
-$wgExtensionMessagesFiles['PlaybuzzTag'] = __DIR__ . '/PlaybuzzTag.i18n.php';

--- a/extensions/wikia/PollSnackTag/PollSnackTag.setup.php
+++ b/extensions/wikia/PollSnackTag/PollSnackTag.setup.php
@@ -16,4 +16,3 @@ $wgAutoloadClasses['PollSnackTagValidator'] =  __DIR__ . '/PollSnackTagValidator
 $wgHooks['ParserFirstCallInit'][] = 'PollSnackTagController::onParserFirstCallInit';
 
 // i18n
-$wgExtensionMessagesFiles['PollSnackTag'] = __DIR__ . '/PollSnackTag.i18n.php';

--- a/extensions/wikia/PolldaddyTag/PolldaddyTag.setup.php
+++ b/extensions/wikia/PolldaddyTag/PolldaddyTag.setup.php
@@ -17,4 +17,3 @@ $wgHooks['ParserFirstCallInit'][] = 'PolldaddyTagController::onParserFirstCallIn
 $wgHooks['WikiaMobileAssetsPackages'][] = 'PolldaddyTagController::onWikiaMobileAssetsPackages';
 
 // i18n
-$wgExtensionMessagesFiles['PolldaddyTag'] = __DIR__ . '/PolldaddyTag.i18n.php';

--- a/extensions/wikia/PortabilityDashboard/PortabilityDashboard.setup.php
+++ b/extensions/wikia/PortabilityDashboard/PortabilityDashboard.setup.php
@@ -6,4 +6,3 @@ $wgAutoloadClasses[ 'SpecialPortabilityDashboardController' ] = __DIR__ . '/Spec
 $wgSpecialPages[ 'PortabilityDashboard' ] = 'SpecialPortabilityDashboardController';
 $wgSpecialPageGroups[ 'PortabilityDashboard' ] = 'wikia';
 
-$wgExtensionMessagesFiles[ 'PortabilityDashboard' ] = __DIR__ . '/PortabilityDashboard.i18n.php';

--- a/extensions/wikia/PortableInfobox/PortableInfobox.setup.php
+++ b/extensions/wikia/PortableInfobox/PortableInfobox.setup.php
@@ -91,7 +91,6 @@ $wgSpecialPages[ 'AllInfoboxes' ] = 'AllinfoboxesQueryPage';
 $wgSpecialPageGroups[ 'AllInfoboxes' ] = 'wikia';
 
 // i18n mapping
-$wgExtensionMessagesFiles[ 'PortableInfobox' ] = $dir . 'PortableInfobox.i18n.php';
 
 // MW API
 $wgAPIModules[ 'infobox' ] = 'ApiPortableInfobox';

--- a/extensions/wikia/PortableInfoboxBuilder/PortableInfoboxBuilder.setup.php
+++ b/extensions/wikia/PortableInfoboxBuilder/PortableInfoboxBuilder.setup.php
@@ -39,4 +39,3 @@ $wgHooks[ 'CustomEditor' ][] = 'PortableInfoboxBuilderHooks::onCustomEditor';
 $wgHooks[ 'TemplateClassificationHooks::afterEditPageAssets' ][] = 'PortableInfoboxBuilderHooks::onTCAfterEditPageAssets';
 
 // i18n mapping
-$wgExtensionMessagesFiles[ 'PortableInfoboxBuilder' ] = $dir . 'PortableInfoboxBuilder.i18n.php';

--- a/extensions/wikia/PowerUser/PowerUser.setup.php
+++ b/extensions/wikia/PowerUser/PowerUser.setup.php
@@ -23,7 +23,6 @@ $wgExtensionCredits['other'][] = [
 	'url'               => 'https://github.com/Wikia/app/tree/dev/extensions/wikia/PowerUser/',
 ];
 
-$wgExtensionMessagesFiles['PowerUser'] = __DIR__ . '/PowerUser.i18n.php';
 
 $wgAutoloadClasses['Wikia\PowerUser\PowerUser'] = __DIR__ . '/PowerUser.class.php';
 $wgAutoloadClasses['Wikia\PowerUser\PowerUserHooks'] = __DIR__ . '/PowerUser.hooks.php';

--- a/extensions/wikia/Qualaroo/Qualaroo.setup.php
+++ b/extensions/wikia/Qualaroo/Qualaroo.setup.php
@@ -18,7 +18,6 @@ $wgExtensionCredits['other'][] = array(
 $wgAutoloadClasses['QualarooHooks'] = $dir . 'QualarooHooks.class.php';
 
 //i18n
-$wgExtensionMessagesFiles['Qualaroo'] = $dir . 'Qualaroo.i18n.php';
 
 // hooks
 $wgHooks['OasisSkinAssetGroupsBlocking'][] = 'QualarooHooks::onOasisSkinAssetGroupsBlocking';

--- a/extensions/wikia/QuickTools/QuickTools.setup.php
+++ b/extensions/wikia/QuickTools/QuickTools.setup.php
@@ -24,7 +24,6 @@ $wgAutoloadClasses[ 'QuickToolsHelper'] =  __DIR__ . '/QuickToolsHelper.class.ph
 $wgAutoloadClasses[ 'QuickToolsHooksHelper'] =  __DIR__ . '/QuickToolsHooksHelper.class.php';
 
 // i18n
-$wgExtensionMessagesFiles['QuickTools'] = __DIR__ . '/QuickTools.i18n.php';
 
 // Resource Loader modules
 $qtResourceTemplate = array(

--- a/extensions/wikia/RTE/RTE_setup.php
+++ b/extensions/wikia/RTE/RTE_setup.php
@@ -44,7 +44,6 @@ $wgHooks['LinkEnd'][] = 'RTELinkerHooks::onLinkEnd';
 $wgHooks['LinkerMakeExternalLink'][] = 'RTELinkerHooks::onLinkerMakeExternalLink';
 
 // i18n
-$wgExtensionMessagesFiles['RTE'] = __DIR__ . '/i18n/RTE.i18n.php';
 
 // Ajax dispatcher
 $wgAjaxExportList[] = 'RTEAjax';

--- a/extensions/wikia/RandomWiki/SpecialRandomWiki.php
+++ b/extensions/wikia/RandomWiki/SpecialRandomWiki.php
@@ -44,4 +44,3 @@ $wgSpecialPages['RandomWiki'] = 'RandomWiki';
 $wgSpecialPageGroups['RandomWiki'] = 'redirects';
 
 // i18n
-$wgExtensionMessagesFiles['RandomWiki'] = $dir . 'SpecialRandomWiki.i18n.php';

--- a/extensions/wikia/Recirculation/Recirculation.setup.php
+++ b/extensions/wikia/Recirculation/Recirculation.setup.php
@@ -26,7 +26,6 @@ $wgHooks['OasisSkinAssetGroups'][] = 'RecirculationHooks::onOasisSkinAssetGroups
 $wgHooks['BeforePageDisplay'][] = 'RecirculationHooks::onBeforePageDisplay';
 
 // i18n
-$wgExtensionMessagesFiles['Recirculation'] = __DIR__ . '/Recirculation.i18n.php';
 
 JSMessages::registerPackage('Recirculation', [
 	'recirculation-*',

--- a/extensions/wikia/RelatedPages/RelatedPages.php
+++ b/extensions/wikia/RelatedPages/RelatedPages.php
@@ -27,6 +27,5 @@ $wgHooks['WikiaMobileAssetsPackages'][] = 'RelatedPages::onWikiaMobileAssetsPack
 $wgAutoloadClasses['RelatedPages'] = $dir . 'RelatedPages.class.php';
 
 // messages
-$wgExtensionMessagesFiles['RelatedPages'] = $dir . 'RelatedPages.i18n.php';
 JSMessages::registerPackage( 'RelatedPages', [ 'wikiarelatedpages-heading' ] );
 JSMessages::registerPackage( 'RelatedPagesInContent', [ 'wikiamobile-related-article' , 'wikiamobile-people-also-read'] );

--- a/extensions/wikia/SEOTweaks/SEOTweaks.setup.php
+++ b/extensions/wikia/SEOTweaks/SEOTweaks.setup.php
@@ -22,4 +22,3 @@ $wgHooks['OpenGraphMetaHeaders'][] = 'SEOTweaksHooksHelper::onOpenGraphMetaHeade
 $wgHooks['ShowMissingArticle'][] = 'SEOTweaksHooksHelper::onShowMissingArticle';
 
 // messages
-$wgExtensionMessagesFiles['SEOTweaks'] = $dir . 'SEOTweaks.i18n.php';

--- a/extensions/wikia/Search/WikiaSearch.setup.php
+++ b/extensions/wikia/Search/WikiaSearch.setup.php
@@ -59,7 +59,6 @@ $wgWikiaApiControllers['SearchApiController'] = $dir . 'SearchApiController.clas
 /**
  * message files
  */
-$wgExtensionMessagesFiles['WikiaSearch'] = $dir . 'WikiaSearch.i18n.php';
 
 /**
  * preference settings

--- a/extensions/wikia/SharedHelp/CentralHelpSearch.php
+++ b/extensions/wikia/SharedHelp/CentralHelpSearch.php
@@ -26,7 +26,6 @@ $wgExtensionCredits['parserhook'][] = array(
 	'descriptionmsg' => 'centralhelpsearch-desc',
 );
 
-$wgExtensionMessagesFiles['CentralHelpSearch'] = __DIR__ . '/CentralHelpSearch.i18n.php';
 
 $wgHooks['ParserFirstCallInit'][] = 'efCentralHelpSearchSetup';
 

--- a/extensions/wikia/SharedHelp/SharedHelp.php
+++ b/extensions/wikia/SharedHelp/SharedHelp.php
@@ -20,7 +20,6 @@ $wgExtensionCredits['other'][] = array(
 	'url' => 'https://github.com/Wikia/app/tree/dev/extensions/wikia/SharedHelp'
 );
 
-$wgExtensionMessagesFiles['SharedHelp'] =  dirname( __FILE__ ) . '/SharedHelp.i18n.php';
 
 $wgHooks['OutputPageBeforeHTML'][] = 'SharedHelpHook';
 $wgHooks['EditPage::showEditForm:initial'][] = 'SharedHelpEditPageHook';

--- a/extensions/wikia/SiteWideMessages/SpecialSiteWideMessages.php
+++ b/extensions/wikia/SiteWideMessages/SpecialSiteWideMessages.php
@@ -35,7 +35,6 @@ $wgExtensionCredits['specialpage'][] = array(
 );
 
 $wgExtensionFunctions[] = 'SiteWideMessagesInit';
-$wgExtensionMessagesFiles['SpecialSiteWideMessages'] = dirname(__FILE__) . '/SpecialSiteWideMessages.i18n.php';
 $wgAjaxExportList[] = 'SiteWideMessagesAjaxDismiss';
 
 if ( empty( $wgSWMSupportedLanguages ) ) $wgSWMSupportedLanguages = array( 'en' );

--- a/extensions/wikia/Sitemap/SpecialSitemap.php
+++ b/extensions/wikia/Sitemap/SpecialSitemap.php
@@ -38,8 +38,6 @@ $wgExtensionCredits['specialpage'][] = array(
  * Set up the new special page
  */
 $dir = dirname( __FILE__ ) . '/';
-$wgExtensionMessagesFiles['Sitemap'] = $dir . 'Sitemap.i18n.php';
-$wgExtensionMessagesFiles['SitemapAlias'] = $dir . 'Sitemap.alias.php';
 $wgAutoloadClasses['SitemapPage'] = $dir . 'SpecialSitemap_body.php';
 $wgSpecialPages['Sitemap'] = 'SitemapPage';
 $wgSpecialPageGroups['Sitemap'] = 'wikia';

--- a/extensions/wikia/SitemapPage/SitemapPage.setup.php
+++ b/extensions/wikia/SitemapPage/SitemapPage.setup.php
@@ -22,7 +22,6 @@ $wgAutoloadClasses['SitemapPageArticle'] = $dir . 'SitemapPageArticle.class.php'
 $wgAutoloadClasses['SitemapPageHooks'] = $dir . 'SitemapPageHooks.class.php';
 
 // i18n mapping
-$wgExtensionMessagesFiles['SitemapPage'] = $dir . 'SitemapPage.i18n.php';
 
 // hooks
 $wgHooks['ArticleFromTitle'][] = 'SitemapPageHooks::onArticleFromTitle';

--- a/extensions/wikia/SkinChooser/SkinChooser.php
+++ b/extensions/wikia/SkinChooser/SkinChooser.php
@@ -18,7 +18,6 @@ $dir = dirname(__FILE__) . '/';
 $wgAutoloadClasses['SkinChooser'] = $dir . 'SkinChooser.class.php';
 
 // i18n
-$wgExtensionMessagesFiles['SkinChooser'] = $dir . 'SkinChooser.i18n.php';
 
 // register hooks
 $wgHooks['GetPreferences'][] = 'SkinChooser::onGetPreferences';

--- a/extensions/wikia/SoundCloudTag/SoundCloudTag.setup.php
+++ b/extensions/wikia/SoundCloudTag/SoundCloudTag.setup.php
@@ -16,4 +16,3 @@ $wgAutoloadClasses['SoundCloudTagController'] =  __DIR__ . '/SoundCloudTagContro
 $wgHooks['ParserFirstCallInit'][] = 'SoundCloudTagController::onParserFirstCallInit';
 
 // i18n
-$wgExtensionMessagesFiles['SoundCloudTag'] = __DIR__ . '/SoundCloudTag.i18n.php';

--- a/extensions/wikia/SpecialCategoryIntersection/SpecialCategoryIntersection.php
+++ b/extensions/wikia/SpecialCategoryIntersection/SpecialCategoryIntersection.php
@@ -16,7 +16,6 @@
 if ( !defined( 'MEDIAWIKI' ) ) die();
 
 $wgSpecialPages[ "CategoryIntersection" ] = "SpecialCategoryIntersection";
-$wgExtensionMessagesFiles['CategoryIntersection'] = dirname( __FILE__ ) . '/SpecialCategoryIntersection.i18n.php';
 $wgExtensionCredits['specialpage'][] = array(
 	'name' => 'CategoryIntersection',
 	'url' => 'https://github.com/Wikia/app/tree/dev/extensions/wikia/SpecialCategoryIntersection', // TODO: Update with a link to appropriate extension info page (such as MediaWiki.org) if this extension gets committed upstream.

--- a/extensions/wikia/SpecialContact2/SpecialContact.php
+++ b/extensions/wikia/SpecialContact2/SpecialContact.php
@@ -20,8 +20,6 @@ require_once('UserMailer.php');
 
 $dir = dirname(__FILE__) . '/';
 $wgAutoloadClasses['ContactForm'] = $dir . 'SpecialContact.body.php'; # Tell MediaWiki to load the extension body.
-$wgExtensionMessagesFiles['ContactForm2'] = $dir . 'SpecialContact.i18n.php';
-$wgExtensionMessagesFiles['ContactForm2Aliases']  = $dir . 'SpecialContact.alias.php';
 
 #$wgSpecialPages['ContactForm'] = 'ContactForm'; # Let MediaWiki know about your new special page.
 extAddSpecialPage( $dir . 'SpecialContact.body.php', 'Contact', 'ContactForm' );

--- a/extensions/wikia/SpecialDiscussionsLog/SpecialDiscussionsLog.setup.php
+++ b/extensions/wikia/SpecialDiscussionsLog/SpecialDiscussionsLog.setup.php
@@ -28,7 +28,6 @@ $wgHooks['ContributionsToolLinks'][] = 'SpecialDiscussionsLogHooks::onContributi
 $wgSpecialPages['DiscussionsLog'] = 'SpecialDiscussionsLogController';
 
 // message files
-$wgExtensionMessagesFiles['SpecialDiscussionsLog'] = $dir . 'SpecialDiscussionsLog.i18n.php';
 
 // permissions
 $wgAvailableRights[] = 'specialdiscussionslog';

--- a/extensions/wikia/SpecialInterwikiEdit/SpecialInterwikiEdit.php
+++ b/extensions/wikia/SpecialInterwikiEdit/SpecialInterwikiEdit.php
@@ -29,7 +29,6 @@ $wgExtensionCredits[ 'specialpage' ][ ] = array(
 	'url' => 'https://github.com/Wikia/app/tree/dev/extensions/wikia/SpecialInterwikiEdit',
 );
 
-$wgExtensionMessagesFiles['SpecialInterwikiEdit'] = dirname(__FILE__) . '/SpecialInterwikiEdit.i18n.php';
 $wgSpecialPageGroups['InterwikiEdit'] = 'wiki';
 
 require_once($IP . '/includes/SpecialPage.php');

--- a/extensions/wikia/SpecialMultipleLookup/SpecialMultipleLookup.php
+++ b/extensions/wikia/SpecialMultipleLookup/SpecialMultipleLookup.php
@@ -20,8 +20,6 @@ $wgExtensionCredits['specialpage'][] = array(
 );
 define( "MULTILOOKUP_NO_CACHE", false );
 define( "ML_TEST", 0 );
-$wgExtensionMessagesFiles["MultiLookup"] = dirname( __FILE__ ) . '/SpecialMultipleLookup.i18n.php';
-$wgExtensionMessagesFiles['MultiLookupAliases'] = __DIR__ . '/SpecialMultipleLookup.aliases.php';
 require_once( dirname( __FILE__ ) . '/SpecialMultipleLookup_helper.php' );
 require_once( dirname( __FILE__ ) . '/SpecialMultipleLookup_ajax.php' );
 require_once( dirname( __FILE__ ) . '/SpecialMultipleLookup_hooks.php' );

--- a/extensions/wikia/SpecialNewWikis/SpecialNewWikis.php
+++ b/extensions/wikia/SpecialNewWikis/SpecialNewWikis.php
@@ -26,7 +26,6 @@ $wgExtensionCredits['specialpage'][] = array(
 );
 
 #--- messages file
-$wgExtensionMessagesFiles["Newwikis"] = __DIR__ . '/SpecialNewWikis.i18n.php';
 
 #--- special pages
 $wgSpecialPageGroups['Newwikis'] = 'highuse';

--- a/extensions/wikia/SpecialProtectSite/SpecialProtectSite.php
+++ b/extensions/wikia/SpecialProtectSite/SpecialProtectSite.php
@@ -31,8 +31,6 @@ $wgExtensionCredits['specialpage'][] = array(
 	'url'			 => 'https://github.com/Wikia/app/tree/dev/extensions/wikia/SpecialProtectSite'
 );
 
-$wgExtensionMessagesFiles['SpecialProtectSite'] = $dir . '/SpecialProtectSite.i18n.php';
-$wgExtensionMessagesFiles['SpecialProtectSiteAliases'] = __DIR__ . '/SpecialProtectSite.aliases.php';
 
 /* Add this Special page to the Special page listing array */
 $wgSpecialPages['Protectsite'] = 'ProtectsiteForm';

--- a/extensions/wikia/SpecialUnlockdb/SpecialUnlockdb.setup.php
+++ b/extensions/wikia/SpecialUnlockdb/SpecialUnlockdb.setup.php
@@ -14,7 +14,6 @@ $wgExtensionCredits['specialpage'][] = array(
 $dir = dirname(__FILE__).'/';
 
 //i18n
-$wgExtensionMessagesFiles['SpecialUnlockdb'] = $dir . 'SpecialUnlockdb.i18n.php';
 
 $wgAutoloadClasses['WikiaSpecialUnlockdb'] = $dir . 'SpecialUnlockdb.class.php';
 $wgSpecialPages['Unlockdb'] = 'WikiaSpecialUnlockdb';

--- a/extensions/wikia/SpecialUnsubscribe/Unsubscribe.php
+++ b/extensions/wikia/SpecialUnsubscribe/Unsubscribe.php
@@ -31,8 +31,6 @@ $wgExtensionCredits['specialpage'][] = array(
 
 // Set up the new special page
 $dir = dirname(__FILE__) . '/';
-$wgExtensionMessagesFiles['Unsubscribe'] = $dir . 'Unsubscribe.i18n.php';
-$wgExtensionMessagesFiles['UnsubscribeAliases'] = $dir . 'Unsubscribe.alias.php';
 
 $wgAutoloadClasses['UnsubscribePage'] = $dir . 'Unsubscribe.body.php';
 $wgSpecialPages['Unsubscribe'] = 'UnsubscribePage';

--- a/extensions/wikia/SpecialUnusedVideos/SpecialUnusedVideos.setup.php
+++ b/extensions/wikia/SpecialUnusedVideos/SpecialUnusedVideos.setup.php
@@ -21,8 +21,6 @@ $wgAutoloadClasses[ 'SpecialUnusedVideosHooks'] =  $dir.'SpecialUnusedVideosHook
 $wgHooks['wgQueryPages'][] = 'SpecialUnusedVideosHooks::registerUnusedVideos';
 
 // i18n mapping
-$wgExtensionMessagesFiles['SpecialUnusedVideos'] = $dir.'SpecialUnusedVideos.i18n.php' ;
-$wgExtensionMessagesFiles['SpecialUnusedVideosAliases'] = $dir.'SpecialUnusedVideos.alias.php' ;
 
 // special pages
 $wgSpecialPages[ 'UnusedVideos' ] =  'SpecialUnusedVideos';

--- a/extensions/wikia/SpecialVersion/WikiaSpecialVersion.setup.php
+++ b/extensions/wikia/SpecialVersion/WikiaSpecialVersion.setup.php
@@ -22,7 +22,6 @@ $wgSpecialPages['Version'] = 'WikiaSpecialVersionController';
 /**
  * message files
  */
-$wgExtensionMessagesFiles['WikiaSpecialVersion'] = $dir . 'WikiaSpecialVersion.i18n.php' ;
 
 $wgExtensionCredits['other'][] = array(
 	'name'				=> 'Wikia Special:Version',

--- a/extensions/wikia/SpecialVideos/SpecialVideos.setup.php
+++ b/extensions/wikia/SpecialVideos/SpecialVideos.setup.php
@@ -20,8 +20,6 @@ $wgAutoloadClasses['SpecialVideosHelper'] = $dir . 'SpecialVideosHelper.class.ph
 $wgAutoloadClasses['SpecialVideosHooks'] = $dir . 'SpecialVideosHooks.class.php';
 
 // i18n mapping
-$wgExtensionMessagesFiles['SpecialVideos'] = $dir . 'SpecialVideos.i18n.php';
-$wgExtensionMessagesFiles['SpecialVideosAliases'] = $dir . 'SpecialVideos.alias.php';
 
 // special pages
 $wgSpecialPages['Videos'] = 'SpecialVideosSpecialController';

--- a/extensions/wikia/SpecialWithoutimages/SpecialWithoutimages.php
+++ b/extensions/wikia/SpecialWithoutimages/SpecialWithoutimages.php
@@ -18,8 +18,6 @@ $wgAutoloadClasses['SpecialWithoutimages'] = $dir . 'SpecialWithoutimages.class.
 $wgAutoloadClasses['WithoutimagesPage'] = $dir . 'WithoutimagesPage.class.php';
 
 // i18n
-$wgExtensionMessagesFiles['Withoutimages'] = $dir . 'SpecialWithoutimages.i18n.php';
-$wgExtensionMessagesFiles['WithoutimagesAliases'] = $dir . 'SpecialWithoutimages.alias.php';
 
 // special page
 $wgSpecialPages['Withoutimages'] = 'SpecialWithoutimages';

--- a/extensions/wikia/SponsorshipDashboard/SponsorshipDashboard_setup.php
+++ b/extensions/wikia/SponsorshipDashboard/SponsorshipDashboard_setup.php
@@ -24,7 +24,6 @@ $dir = dirname(__FILE__) . '/';
 
 require_once( $dir . '/SponsorshipDashboard_autoload.php' );
 
-$wgExtensionMessagesFiles['SponsorshipDashboard'] = $dir . 'SponsorshipDashboard.i18n.php';
 
 $wgAjaxExportList[] = 'SponsorshipDashboardAjax';
 

--- a/extensions/wikia/SpotifyTag/SpotifyTag.setup.php
+++ b/extensions/wikia/SpotifyTag/SpotifyTag.setup.php
@@ -16,4 +16,3 @@ $wgAutoloadClasses['SpotifyTagValidator'] =  __DIR__ . '/SpotifyTagValidator.cla
 $wgHooks['ParserFirstCallInit'][] = 'SpotifyTagController::onParserFirstCallInit';
 
 // i18n
-$wgExtensionMessagesFiles['SpotifyTag'] = __DIR__ . '/SpotifyTag.i18n.php';

--- a/extensions/wikia/StaffLog/StaffLog.php
+++ b/extensions/wikia/StaffLog/StaffLog.php
@@ -20,8 +20,6 @@ $dir = __DIR__ . '/';
 
 $wgAutoloadClasses['StaffLog'] = $dir . 'StaffLog_body.php'; # Tell MediaWiki to load the extension body.
 $wgAutoloadClasses['StaffLogger'] = $dir . 'StaffLog.events.php';
-$wgExtensionMessagesFiles['StaffLog'] = $dir . 'StaffLog.i18n.php';
-$wgExtensionMessagesFiles['StaffLogAliases'] = $dir . 'StaffLog.alias.php';
 
 if ( !empty( $wgEnableStaffLogSpecialPage ) ) {
 	$wgSpecialPages['StaffLog'] = 'StaffLog'; # Let MediaWiki know about your new special page.

--- a/extensions/wikia/StaffPowers/StaffPowers.php
+++ b/extensions/wikia/StaffPowers/StaffPowers.php
@@ -13,7 +13,6 @@ $wgExtensionCredits[ 'other' ][ ] = array(
 	'url' => 'https://github.com/Wikia/app/tree/dev/extensions/wikia/StaffPowers',
 );
 
-$wgExtensionMessagesFiles['StaffPowers'] = dirname(__FILE__) . '/StaffPowers.i18n.php';
 
 // Power: unblockableness
 $wgHooks['BlockIp'][] = 'efPowersMakeUnblockable';

--- a/extensions/wikia/TOC/TOC.setup.php
+++ b/extensions/wikia/TOC/TOC.setup.php
@@ -19,7 +19,6 @@ $wgExtensionCredits['other'][] = array(
 );
 
 //i18n
-$wgExtensionMessagesFiles['TOC'] = $dir . 'TOC.i18n.php';
 
 // register classes
 $wgAutoloadClasses['TOCController'] =  $dir . 'TOCController.class.php';

--- a/extensions/wikia/TagsReport/SpecialTagsReport.php
+++ b/extensions/wikia/TagsReport/SpecialTagsReport.php
@@ -17,8 +17,6 @@ $wgExtensionCredits['specialpage'][] = array(
 	"url" => "https://github.com/Wikia/app/tree/dev/extensions/wikia/TagsReport"
 );
 
-$wgExtensionMessagesFiles["TagsReport"] = __DIR__ . '/SpecialTagsReport.i18n.php';
-$wgExtensionMessagesFiles['TagsReportAliases'] = __DIR__ . '/SpecialTagsReport.aliases.php';
 
 extAddSpecialPage( __DIR__ . '/SpecialTagsReport_body.php', 'TagsReport', 'TagsReportPage' );
 $wgSpecialPageGroups['TagsReport'] = 'maintenance';

--- a/extensions/wikia/TaskManager/SpecialTaskManager.php
+++ b/extensions/wikia/TaskManager/SpecialTaskManager.php
@@ -36,12 +36,10 @@ extAddBatchTask( $dir ."/Tasks/UpdateSpecialPagesTask.php", "update_special_page
 /**
  * message file
  */
-$wgExtensionMessagesFiles[ $sSpecialPage ] = $dir . "/Special{$sSpecialPage}.i18n.php";
 
 /**
  * aliases file
  */
-$wgExtensionMessagesFiles[ $sSpecialPage . 'Aliases' ] = $dir . "/Special{$sSpecialPage}.aliases.php";
 
 extAddSpecialPage( $dir . "/Special{$sSpecialPage}_body.php", $sSpecialPage, "{$sSpecialPage}Page" );
 $wgSpecialPageGroups[$sSpecialPage] = 'wikia';

--- a/extensions/wikia/TaskManager/Tasks/LocalMaintenanceTask.php
+++ b/extensions/wikia/TaskManager/Tasks/LocalMaintenanceTask.php
@@ -46,8 +46,7 @@ class LocalMaintenanceTask extends BatchTask {
 	 * @return boolean - status of operation
 	 */
 	public function execute( $params = null ) {
-		global $IP, $wgWikiaLocalSettingsPath, $wgWikiaAdminSettingsPath,
-			$wgExtensionMessagesFiles;
+		global $IP, $wgWikiaLocalSettingsPath, $wgWikiaAdminSettingsPath;
 
 		$this->mTaskID = $params->task_id;
 		$this->mParams = unserialize( $params->task_arguments );

--- a/extensions/wikia/TaskManager/Tasks/SWMSendToGroupTask.php
+++ b/extensions/wikia/TaskManager/Tasks/SWMSendToGroupTask.php
@@ -21,7 +21,6 @@ if (!defined('MSG_STATUS_UNSEEN')) {
 }
 
 #--- messages file
-$wgExtensionMessagesFiles['SWMSendToGroupTask'] = dirname(__FILE__) . '/SWMSendToGroupWikiTask/SWMSendToGroupTask.i18n.php';
 
 class SWMSendToGroupTask extends BatchTask {
 	public $mType, $mVisible, $mParams, $mFounder, $mStaff;

--- a/extensions/wikia/Tasks/Tasks.setup.php
+++ b/extensions/wikia/Tasks/Tasks.setup.php
@@ -20,4 +20,3 @@ $wgAutoloadClasses['TasksSpecialController'] = "$dir/TasksSpecialController.clas
 
 $wgSpecialPages['Tasks'] = 'TasksSpecialController';
 
-$wgExtensionMessagesFiles['Tasks'] = "$dir/Tasks.i18n.php";

--- a/extensions/wikia/TemplateClassification/TemplateClassification.setup.php
+++ b/extensions/wikia/TemplateClassification/TemplateClassification.setup.php
@@ -77,7 +77,6 @@ $wgAutoloadClasses['Wikia\TemplateClassification\TemplateBulkClassificationTask'
 /**
  * Messages
  */
-$wgExtensionMessagesFiles['TemplateClassification'] = __DIR__ . '/TemplateClassification.i18n.php';
 
 JSMessages::registerPackage( 'TemplateClassificationModal', [
 	'template-classification-edit-modal-*',

--- a/extensions/wikia/TemplateDraft/TemplateDraft.setup.php
+++ b/extensions/wikia/TemplateDraft/TemplateDraft.setup.php
@@ -19,7 +19,6 @@ $wgExtensionCredits['other'][] = [
 /**
  * Messages
  */
-$wgExtensionMessagesFiles['TemplateDraft'] = __DIR__ . '/TemplateDraft.i18n.php';
 
 /**
  * Controllers

--- a/extensions/wikia/ThemeDesigner/ThemeDesigner_setup.php
+++ b/extensions/wikia/ThemeDesigner/ThemeDesigner_setup.php
@@ -23,8 +23,6 @@ $wgSpecialPages['ThemeDesigner'] = 'SpecialThemeDesigner';
 $wgSpecialPages['ThemeDesignerPreview'] = 'SpecialThemeDesignerPreview';
 
 // i18n
-$wgExtensionMessagesFiles['ThemeDesigner'] = "$dir/ThemeDesigner.i18n.php";
-$wgExtensionMessagesFiles['ThemeDesignerAliases'] = "$dir/ThemeDesigner.alias.php";
 
 JSMessages::registerPackage( 'ThemeDesigner', [
 	'themedesigner-wordmark-preview-error'

--- a/extensions/wikia/Thumbnails/Thumbnails.setup.php
+++ b/extensions/wikia/Thumbnails/Thumbnails.setup.php
@@ -25,4 +25,3 @@ $wgAutoloadClasses['ThumbnailHelper'] = $dir . 'ThumbnailHelper.class.php';
 $wgHooks['BeforePageDisplay'][] = 'ThumbnailHooks::onBeforePageDisplay';
 
 // i18n mapping
-$wgExtensionMessagesFiles['Thumbnails'] = $dir . 'Thumbnails.i18n.php' ;

--- a/extensions/wikia/TimeAgoMessaging/TimeAgoMessaging_setup.php
+++ b/extensions/wikia/TimeAgoMessaging/TimeAgoMessaging_setup.php
@@ -25,7 +25,6 @@ $wgExtensionCredits['other'][] = array(
 $dir = dirname(__FILE__);
 
 // i18n
-$wgExtensionMessagesFiles['TimeAgoMessaging'] = "{$dir}/TimeAgoMessaging.i18n.php";
 
 // hooks
 $wgHooks['MakeGlobalVariablesScript'][] = 'TimeAgoMessaging::onMakeGlobalVariablesScript';

--- a/extensions/wikia/TwitterCards/TwitterCards.setup.php
+++ b/extensions/wikia/TwitterCards/TwitterCards.setup.php
@@ -20,4 +20,3 @@ $wgAutoloadClasses['TwitterCardsHooks'] = $dir . 'TwitterCardsHooks.class.php';
 $wgHooks['BeforePageDisplay'][] = 'TwitterCardsHooks::onBeforePageDisplay';
 
 // i18n mapping
-$wgExtensionMessagesFiles['TwitterCards'] = $dir . 'TwitterCards.i18n.php';

--- a/extensions/wikia/TwitterTag/TwitterTag.setup.php
+++ b/extensions/wikia/TwitterTag/TwitterTag.setup.php
@@ -14,7 +14,6 @@ $wgExtensionCredits['parserTag'][] = [
 
 $wgAutoloadClasses['TwitterTagController'] = __DIR__ . '/TwitterTagController.class.php';
 
-$wgExtensionMessagesFiles['TwitterTag'] = __DIR__ . '/TwitterTag.i18n.php';
 
 $wgHooks['ParserFirstCallInit'][] = 'TwitterTagController::onParserFirstCallInit';
 

--- a/extensions/wikia/UserActivity/UserActivity.setup.php
+++ b/extensions/wikia/UserActivity/UserActivity.setup.php
@@ -37,4 +37,3 @@ $wgSpecialPages['UserActivity'] = 'UserActivity\SpecialController';
 /**
  * messages
  */
-$wgExtensionMessagesFiles['UserActivity'] = $dir . 'UserActivity.i18n.php';

--- a/extensions/wikia/UserLogin/UserLogin.setup.php
+++ b/extensions/wikia/UserLogin/UserLogin.setup.php
@@ -45,10 +45,6 @@ $wgHooks['BeforePageDisplay'][] = "EmailConfirmationHooks::onBeforePageDisplay";
 
 
 // i18n mapping
-$wgExtensionMessagesFiles['UserLogin'] = $dir . 'UserLogin.i18n.php';
-$wgExtensionMessagesFiles['UserSignup'] = $dir . 'UserSignup.i18n.php';
-$wgExtensionMessagesFiles['UserSignupAliases'] = $dir . 'UserSignup.alias.php';
-$wgExtensionMessagesFiles['WikiaConfirmEmail'] = $dir . 'WikiaConfirmEmail.i18n.php';
 
 JSMessages::registerPackage( 'UserLogin', ['userlogin-login-*'] );
 

--- a/extensions/wikia/UserPageRedirects/UserPageRedirects.setup.php
+++ b/extensions/wikia/UserPageRedirects/UserPageRedirects.setup.php
@@ -13,7 +13,6 @@ $wgExtensionCredits['specialpage'][] = array(
 $dir = dirname(__FILE__) . '/';
 
 //i18n
-$wgExtensionMessagesFiles['UserPageRedirects'] = $dir . 'UserPageRedirects.i18n.php';
 
 $wgAutoloadClasses['UserPageRedirectsHelper']  = $dir . 'UserPageRedirectsHelper.class.php';
 $wgHooks['ArticleFromTitle'][] = 'UserPageRedirectsHelper::ArticleFromTitle';

--- a/extensions/wikia/UserPreferencesV2/UserPreferencesV2.setup.php
+++ b/extensions/wikia/UserPreferencesV2/UserPreferencesV2.setup.php
@@ -37,4 +37,3 @@ $wgHooks['UserGetDefaultOptions'][] = 'UserPreferencesV2::onUserGetDefaultOption
 /**
  * messages
  */
-$wgExtensionMessagesFiles['UserPreferencesV2'] = __DIR__ . '/UserPreferencesV2.i18n.php';

--- a/extensions/wikia/UserProfilePageV3/UserProfilePage.setup.php
+++ b/extensions/wikia/UserProfilePageV3/UserProfilePage.setup.php
@@ -73,7 +73,6 @@ $wgHooks['ArticleSaveComplete'][] = 'Masthead::userMastheadInvalidateCache';
 /**
  * messages
  */
-$wgExtensionMessagesFiles['UserProfilePageV3'] = $dir . '/UserProfilePage.i18n.php';
 
 $wgResourceModules['ext.UserProfilePage.Lightbox'] = [
 	'styles' => 'css/UserProfilePage_modal.scss',

--- a/extensions/wikia/UserRenameTool/SpecialRenameuser.php
+++ b/extensions/wikia/UserRenameTool/SpecialRenameuser.php
@@ -37,8 +37,6 @@ $wgSpecialPageGroups['UserRenameTool'] = 'users';
 
 
 // internationalization files
-$wgExtensionMessagesFiles['UserRenameTool'] = $dir . 'SpecialRenameuser.i18n.php';
-$wgExtensionMessagesFiles['UserRenameToolAliases'] = $dir . 'SpecialRenameuser.alias.php';
 
 // classes
 $wgAutoloadClasses['SpecialRenameuser'] = dirname( __FILE__ ) . '/SpecialRenameuser_body.php';

--- a/extensions/wikia/UserTools/UserTools.setup.php
+++ b/extensions/wikia/UserTools/UserTools.setup.php
@@ -17,5 +17,4 @@ $wgExtensionCredits['specialpage'][] =
 	];
 
 $wgAutoloadClasses['UserToolsController'] = __DIR__ . '/UserToolsController.class.php';
-$wgExtensionMessagesFiles['UserTools'] = __DIR__ . '/UserTools.i18n.php';
 

--- a/extensions/wikia/VKTag/VKTag.setup.php
+++ b/extensions/wikia/VKTag/VKTag.setup.php
@@ -16,7 +16,6 @@ $wgAutoloadClasses['VKTagValidator'] =  __DIR__ . '/VKTagValidator.class.php';
 $wgHooks['ParserFirstCallInit'][] = 'VKTagController::onParserFirstCallInit';
 
 // i18n
-$wgExtensionMessagesFiles['VKTag'] = __DIR__ . '/VKTag.i18n.php';
 
 $wgResourceModules['ext.wikia.VKTag'] = [
 	'skinScripts' => [

--- a/extensions/wikia/VideoEmbedTool/VideoEmbedTool_setup.php
+++ b/extensions/wikia/VideoEmbedTool/VideoEmbedTool_setup.php
@@ -30,11 +30,8 @@ if ( !function_exists( 'extAddSpecialPage' ) ) {
     require( "$IP/extensions/ExtensionFunctions.php" );
 }
 
-$wgExtensionMessagesFiles['WikiaVideoAdd'] = dirname(__FILE__) . '/WikiaVideoAdd.i18n.php';
-$wgExtensionMessagesFiles['WikiaVideoAddAliases'] = dirname(__FILE__) . '/WikiaVideoAdd.alias.php';
 extAddSpecialPage( dirname(__FILE__) . '/WikiaVideoAdd_body.php', 'WikiaVideoAdd', 'WikiaVideoAddForm' );
 
-$wgExtensionMessagesFiles['VideoEmbedTool'] = $dir.'/VideoEmbedTool.i18n.php';
 $wgHooks['EditPage::showEditForm:initial2'][] = 'VETSetup';
 
 JSMessages::registerPackage('VideoEmbedTool', array(

--- a/extensions/wikia/VideoHandlers/VideoHandlers.setup.php
+++ b/extensions/wikia/VideoHandlers/VideoHandlers.setup.php
@@ -84,7 +84,6 @@ $wgAutoloadClasses[ 'VideoInfoHooksHelper'] =  $dir . '/videoInfo/VideoInfoHooks
 /**
  * messages
  */
-$wgExtensionMessagesFiles['VideoHandlers'] = "$dir/VideoHandlers.i18n.php";
 
 /**
  * hooks

--- a/extensions/wikia/VideoPageTool/VideoPageTool.setup.php
+++ b/extensions/wikia/VideoPageTool/VideoPageTool.setup.php
@@ -32,7 +32,6 @@ $wgAutoloadClasses['VideoHomePageArticle']    =  $dir . 'model/VideoHomePageArti
 $wgAutoloadClasses['VideoHomePagePage']       =  $dir . 'model/VideoHomePagePage.class.php';
 
 // i18n mapping
-$wgExtensionMessagesFiles['VideoPageTool'] = $dir.'VideoPageTool.i18n.php';
 
 // special pages
 $wgSpecialPages['VideoPageAdmin'] = 'VideoPageAdminSpecialController';

--- a/extensions/wikia/VideosModule/VideosModule.setup.php
+++ b/extensions/wikia/VideosModule/VideosModule.setup.php
@@ -49,7 +49,6 @@ $wgHooks['OutputPageBeforeHTML'][] = 'VideosModuleHooks::onOutputPageBeforeHTML'
 /**
  * messages
  */
-$wgExtensionMessagesFiles['VideosModule'] = $dir . 'VideosModule.i18n.php';
 
 // register messages package for JS
 JSMessages::registerPackage( 'VideosModule', array(

--- a/extensions/wikia/WAM/WAM.setup.php
+++ b/extensions/wikia/WAM/WAM.setup.php
@@ -25,4 +25,3 @@ $wgExtensionCredits['other'][] = array(
 );
 
 //i18n
-$wgExtensionMessagesFiles['WAM'] = $dir . 'WAM.i18n.php';

--- a/extensions/wikia/WAMPage/WAMPage.setup.php
+++ b/extensions/wikia/WAMPage/WAMPage.setup.php
@@ -34,4 +34,3 @@ $wgHooks['LinkBegin'][] = 'WAMPageHooks::onLinkBegin';
 $wgHooks['WikiaCanonicalHref'][] = 'WAMPageHooks::onWikiaCanonicalHref';
 
 // i18n
-$wgExtensionMessagesFiles['WAMPage'] = $dir . 'WAMPage.i18n.php' ;

--- a/extensions/wikia/WDACReview/WDACReview.setup.php
+++ b/extensions/wikia/WDACReview/WDACReview.setup.php
@@ -26,4 +26,3 @@ $wgAutoloadClasses['WDACReviewHelper'] =  $dir . 'WDACReviewHelper.class.php';
 $wgSpecialPages['WDACReview'] = 'WDACReviewSpecialController';
 
 // i18n
-$wgExtensionMessagesFiles['WDACReview'] = $dir . 'WDACReview.i18n.php';

--- a/extensions/wikia/Wall/Wall.setup.php
+++ b/extensions/wikia/Wall/Wall.setup.php
@@ -54,7 +54,6 @@ $wgAutoloadClasses['InappropriateContentException'] = __DIR__ . '/exceptions/Ina
 $wgAutoloadClasses['WallBuilderException'] = __DIR__ . '/exceptions/WallBuilderException.class.php';
 $wgAutoloadClasses['WallBuilderGenericException'] = __DIR__ . '/exceptions/WallBuilderGenericException.class.php';
 
-$wgExtensionMessagesFiles['Wall'] = $dir . '/Wall.i18n.php';
 
 $wgHooks['ArticleViewHeader'][] = 'WallHooksHelper::onArticleViewHeader';
 $wgHooks['SkinTemplateTabs'][] = 'WallHooksHelper::onSkinTemplateTabs';

--- a/extensions/wikia/Wall/WallDisabled.setup.php
+++ b/extensions/wikia/Wall/WallDisabled.setup.php
@@ -19,7 +19,6 @@ $wgExtensionCredits['specialpage'][] = [
 
 $dir = dirname( __FILE__ );
 
-$wgExtensionMessagesFiles['Wall'] = $dir . '/Wall.i18n.php';
 $wgAutoloadClasses['WallDisabledHooksHelper'] =  $dir . '/WallDisabledHooksHelper.class.php';
 
 // don't let others edit wall messages after turning wall on and off

--- a/extensions/wikia/WallNotifications/WallNotifications.setup.php
+++ b/extensions/wikia/WallNotifications/WallNotifications.setup.php
@@ -7,7 +7,6 @@ $wgExtensionCredits[ 'other' ][ ] = [
 ];
 
 // i18n
-$wgExtensionMessagesFiles['WallNotifications'] = __DIR__ . '/i18n/WallNotifications.i18n.php';
 
 $wgAutoloadClasses['WallNotifications'] =  __DIR__ . '/WallNotifications.class.php';
 

--- a/extensions/wikia/WeiboTag/WeiboTag.setup.php
+++ b/extensions/wikia/WeiboTag/WeiboTag.setup.php
@@ -15,4 +15,3 @@ $wgAutoloadClasses['WeiboTagValidator'] =  __DIR__ . '/WeiboTagValidator.class.p
 $wgHooks['ParserFirstCallInit'][] = 'WeiboTagController::onParserFirstCallInit';
 
 // i18n
-$wgExtensionMessagesFiles['WeiboTag'] = __DIR__ . '/WeiboTag.i18n.php';

--- a/extensions/wikia/WhereIsExtension/SpecialWhereIsExtension.php
+++ b/extensions/wikia/WhereIsExtension/SpecialWhereIsExtension.php
@@ -29,7 +29,6 @@ $wgExtensionCredits[ 'specialpage' ][ ] = array(
 	'url' => 'https://github.com/Wikia/app/tree/dev/extensions/wikia/WhereIsExtension',
 );
 
-$wgExtensionMessagesFiles['WhereIsExtension'] = dirname(__FILE__) . '/SpecialWhereIsExtension.i18n.php';
 
 //Register special page
 if (!function_exists('extAddSpecialPage')) {

--- a/extensions/wikia/WidgetFramework/WidgetFramework.php
+++ b/extensions/wikia/WidgetFramework/WidgetFramework.php
@@ -17,4 +17,3 @@ $wgExtensionCredits['specialpage'][] = array(
 $wgAutoloadClasses["ReorderWidgets"] = "$IP/extensions/wikia/WidgetFramework/ReorderWidgets.php";
 $wgAutoloadClasses["WidgetFramework"] = "$IP/extensions/wikia/WidgetFramework/WidgetFramework.class.php";
 
-$wgExtensionMessagesFiles['WidgetFramework'] = dirname(__FILE__) . '/WidgetFramework.i18n.php';

--- a/extensions/wikia/WidgetFramework/Widgets/WidgetAnswers/WidgetAnswers.php
+++ b/extensions/wikia/WidgetFramework/Widgets/WidgetAnswers/WidgetAnswers.php
@@ -40,12 +40,6 @@ function WidgetAnswers($id, $params) {
 		return '';
 	}
 
-	global $wgExtensionMessagesFiles;
-	if( empty( $wgExtensionMessagesFiles['Answers'] ) ) {
-		global $IP;
-		$wgExtensionMessagesFiles['Answers'] = "$IP/../answers/Answers.i18n.php";
-	}
-
 	// This HTML for the Ask a Question is used for both logged in and logged out users
 	// but in different place - top or the bottom of the widget
 	$ask_a_question = htmlspecialchars(wfMsgForContent("ask_a_question-widget"));

--- a/extensions/wikia/WidgetTag/WidgetTag.php
+++ b/extensions/wikia/WidgetTag/WidgetTag.php
@@ -21,7 +21,6 @@ $wgHooks['ParserFirstCallInit'][] = 'efWidgetTagSetup';
 $wgAutoloadClasses['WidgetTagRenderer'] = dirname(__FILE__) . '/WidgetTagRenderer.class.php';
 
 //i18n
-$wgExtensionMessagesFiles['WidgetTag'] = __DIR__ . '/WidgetTag.i18n.php';
 
 /**
  * Setup parser hook

--- a/extensions/wikia/WikiAnswers/WikiAnswers.php
+++ b/extensions/wikia/WikiAnswers/WikiAnswers.php
@@ -7,7 +7,6 @@ $wgDefaultSkin = 'oasis';
 $wgAutoloadClasses['WikiAnswersController'] = dirname( __FILE__ ) . '/WikiAnswersController.class.php';
 
 // i18n
-$wgExtensionMessagesFiles['WikiAnswers'] = dirname( __FILE__ ) . '/WikiAnswers.i18n.php';
 
 // add CSS
 $wgHooks['BeforePageDisplay'][] = 'wfWikiAnswersAddStyle';

--- a/extensions/wikia/WikiFactory/Dumps/DumpsOnDemand.php
+++ b/extensions/wikia/WikiFactory/Dumps/DumpsOnDemand.php
@@ -6,7 +6,6 @@
  * @author Michał ‘Mix’ Roszka <mix@wikia-inc.com>
  */
 $wgHooks[ "CustomSpecialStatistics" ][] = "DumpsOnDemand::customSpecialStatistics";
-$wgExtensionMessagesFiles[ "DumpsOnDemand" ] =  __DIR__ . '/DumpsOnDemand.i18n.php';
 
 class DumpsOnDemand {
 

--- a/extensions/wikia/WikiFactory/Reporter/SpecialWikiFactoryReporter.php
+++ b/extensions/wikia/WikiFactory/Reporter/SpecialWikiFactoryReporter.php
@@ -15,7 +15,6 @@ $wgExtensionCredits['specialpage'][] = array
     'author'      => '[http://www.wikia.com/wiki/User:Ppiotr Przemek Piotrowski (Nef)]'
 );
 
-$wgExtensionMessagesFiles['WikiFactoryReporter'] = dirname(__FILE__) . '/SpecialWikiFactoryReporter.i18n.php';
 
 extAddSpecialPage(dirname(__FILE__) . '/SpecialWikiFactoryReporter_body.php', 'WikiFactoryReporter', 'WikiFactoryReporter');
 

--- a/extensions/wikia/WikiFactory/SpecialWikiFactory.php
+++ b/extensions/wikia/WikiFactory/SpecialWikiFactory.php
@@ -26,7 +26,6 @@ $dir = dirname( __FILE__ );
 /**
  * messages file
  */
-$wgExtensionMessagesFiles["WikiFactory"] =  $dir . '/SpecialWikiFactory.i18n.php';
 
 /**
  * helper file

--- a/extensions/wikia/WikiFeatures/WikiFeatures.setup.php
+++ b/extensions/wikia/WikiFeatures/WikiFeatures.setup.php
@@ -29,8 +29,6 @@ $wgAutoloadClasses['WikiFeaturesHelper'] =  $dir . 'WikiFeaturesHelper.class.php
 $wgAutoloadClasses['WikiaLabsSpecialController'] =  $dir . 'WikiaLabsSpecialController.class.php';
 
 // i18n mapping
-$wgExtensionMessagesFiles['WikiFeatures'] = $dir . 'WikiFeatures.i18n.php';
-$wgExtensionMessagesFiles['WikiFeaturesAliases'] = $dir . 'WikiFeatures.alias.php' ;
 
 // special pages
 $wgSpecialPages['WikiFeatures'] = 'WikiFeaturesSpecialController';

--- a/extensions/wikia/WikiaBar/WikiaBar.setup.php
+++ b/extensions/wikia/WikiaBar/WikiaBar.setup.php
@@ -44,4 +44,3 @@ $wgHooks['WikiFactoryChanged'][] = 'WikiaBarHooks::onWikiFactoryVarChanged';
 $wgHooks['WikiFactoryVarSave::AfterErrorDetection'][] = 'WikiaBarHooks::onWFAfterErrorDetection';
 
 // i18n mapping
-$wgExtensionMessagesFiles['WikiaBar'] = $dir . 'WikiaBar.i18n.php';

--- a/extensions/wikia/WikiaInYourLang/WikiaInYourLang.setup.php
+++ b/extensions/wikia/WikiaInYourLang/WikiaInYourLang.setup.php
@@ -25,7 +25,6 @@ $wgExtensionCredits['other'][] = array(
 	'url'               => 'https://github.com/Wikia/app/tree/dev/extensions/wikia/WikiaInYourLang/',
 );
 
-$wgExtensionMessagesFiles['WikiaInYourLang'] = __DIR__ . '/WikiaInYourLang.i18n.php';
 
 $wgAutoloadClasses['Wikia\WikiaInYourLang\WikiaInYourLangHooks'] = __DIR__ . '/WikiaInYourLang.hooks.php';
 $wgAutoloadClasses['WikiaInYourLangController'] = __DIR__ . '/WikiaInYourLangController.class.php';

--- a/extensions/wikia/WikiaIrcGateway/WikiaIrcGateway.php
+++ b/extensions/wikia/WikiaIrcGateway/WikiaIrcGateway.php
@@ -25,7 +25,6 @@ $wgExtensionCredits['parserhook'][] = array(
 	'url' => 'https://github.com/Wikia/app/tree/dev/extensions/wikia/WikiaIrcGateway'
 );
 
-$wgExtensionMessagesFiles['WikiaIrcGateway'] = dirname( __FILE__ ) . '/WikiaIrcGateway.i18n.php';
 $wgHooks['ParserFirstCallInit'][] = "wfWikiaIrcGateway";
 
 /**

--- a/extensions/wikia/WikiaMiniUpload/WikiaMiniUpload_setup.php
+++ b/extensions/wikia/WikiaMiniUpload/WikiaMiniUpload_setup.php
@@ -19,7 +19,6 @@ $wgExtensionCredits['other'][] = array(
 
 $dir = dirname(__FILE__).'/';
 
-$wgExtensionMessagesFiles['WikiaMiniUpload'] = $dir.'/WikiaMiniUpload.i18n.php';
 $wgHooks['EditPage::showEditForm:initial2'][] = 'WMUSetup';
 
 function WMUSetup( EditPage $editform ): bool {

--- a/extensions/wikia/WikiaMobile/WikiaMobile.setup.php
+++ b/extensions/wikia/WikiaMobile/WikiaMobile.setup.php
@@ -74,7 +74,6 @@ $wgAutoloadClasses['WikiaMobileController'] = "{$dir}/WikiaMobileController.clas
 /**
  * message files
  */
-$wgExtensionMessagesFiles['WikiaMobile'] = "{$dir}/WikiaMobile.i18n.php";
 
 // initialize i18ns
 JSMessages::registerPackage( 'WkMbl', [

--- a/extensions/wikia/WikiaNewFiles/WikiaNewFiles_setup.php
+++ b/extensions/wikia/WikiaNewFiles/WikiaNewFiles_setup.php
@@ -18,8 +18,6 @@ $wgExtensionCredits['specialpage'][] = array(
 );
 
 // Translations
-$wgExtensionMessagesFiles['WikiaNewFiles'] =  __DIR__ . '/WikiaNewFiles.i18n.php';
-$wgExtensionMessagesFiles['WikiaNewFilesAliases'] = __DIR__ . '/WikiaNewFiles.alias.php';
 
 // Autoloaded classes
 $wgAutoloadClasses['WikiaNewFilesSpecialController'] = __DIR__ . '/WikiaNewFilesSpecialController.class.php';

--- a/extensions/wikia/WikiaPhotoGallery/WikiaPhotoGallery_setup.php
+++ b/extensions/wikia/WikiaPhotoGallery/WikiaPhotoGallery_setup.php
@@ -52,7 +52,6 @@ $wgHooks['EditPage::importFormData'][] = 'WikiaPhotoGalleryHelper::onImportFormD
 $wgHooks[ 'PageRenderingHash' ][] = 'WikiaPhotoGalleryHelper::addMediaGalleryCacheKey';
 
 // i18n
-$wgExtensionMessagesFiles['WikiaPhotoGallery'] = $dir.'/WikiaPhotoGallery.i18n.php';
 
 // Ajax dispatcher
 $wgAjaxExportList[] = 'WikiaPhotoGalleryAjax';

--- a/extensions/wikia/WikiaRSS/WikiaRss.setup.php
+++ b/extensions/wikia/WikiaRSS/WikiaRss.setup.php
@@ -30,4 +30,3 @@ $wgAutoloadClasses['WikiaRssExternalController'] =  $dir . '/WikiaRssExternalCon
 $wgHooks['ParserFirstCallInit'][] = 'WikiaRssHooks::onParserFirstCallInit';
 
 //messages
-$wgExtensionMessagesFiles['WikiaRss'] = $dir . '/WikiaRss.i18n.php';

--- a/extensions/wikia/WikiaRecentChangesBlockHandler/WikiaRecentChangesBlockHandler.setup.php
+++ b/extensions/wikia/WikiaRecentChangesBlockHandler/WikiaRecentChangesBlockHandler.setup.php
@@ -16,7 +16,6 @@ $wgExtensionCredits['other'][] = array(
 );
 
 //i18n
-$wgExtensionMessagesFiles['WikiaRecentChangesBlockHandler'] = $dir . 'WikiaRecentChangesBlockHandler.i18n.php';
 
 //classes
 $wgAutoloadClasses['WikiaRecentChangesBlockHandler'] =  $dir.'WikiaRecentChangesBlockHandler.php';

--- a/extensions/wikia/WikiaStats/WikiaStats.setup.php
+++ b/extensions/wikia/WikiaStats/WikiaStats.setup.php
@@ -14,4 +14,3 @@ $wgExtensionCredits['specialpage'][] = array(
 $wgAutoloadClasses['WikiaStatsController'] =  $dir . 'WikiaStatsController.class.php';
 $wgAutoloadClasses['WikiaStatsModel'] =  $dir . 'WikiaStatsModel.class.php';
 
-$wgExtensionMessagesFiles['WikiaStats'] = $dir . 'WikiaStats.i18n.php';

--- a/extensions/wikia/WikiaStyleGuide/WikiaStyleGuideElements.setup.php
+++ b/extensions/wikia/WikiaStyleGuide/WikiaStyleGuideElements.setup.php
@@ -15,7 +15,6 @@ $wgAutoloadClasses['WikiaStyleGuideTooltipIconController'] =  $dir . 'WikiaStyle
 $wgAutoloadClasses['WikiaStyleGuideFormHelper'] =  $dir . 'WikiaStyleGuideFormHelper.class.php';
 
 // i18n
-$wgExtensionMessagesFiles['WikiaStyleGuideElements'] = $dir . 'WikiaStyleGuideElements.i18n.php';
 
 // js messages registration
 JSMessages::registerPackage('WikiaStyleGuideDropdown', array('wikiastyleguide-dropdown-*'));

--- a/extensions/wikia/WikiaWantedQueryPage/WikiaWantedQueryPage.setup.php
+++ b/extensions/wikia/WikiaWantedQueryPage/WikiaWantedQueryPage.setup.php
@@ -22,7 +22,6 @@ $dir = dirname( __FILE__ );
 $wgAutoloadClasses[ 'WantedPagesPageWikia'] = 		$dir . '/WantedPagesPageWikia.class.php' ;
 $wgAutoloadClasses[ 'WantedFilesPageWikia'] = 		$dir . '/WantedFilesPageWikia.class.php' ;
 
-$wgExtensionMessagesFiles['WantedFilesPageWikia'] = $dir . '/WikiaWantedQueryPage.i18n.php';
 /**
  * Overwrite MediaWiki Special:WantedPages with Wikia version
  */

--- a/extensions/wikia/YouTube/YouTube.php
+++ b/extensions/wikia/YouTube/YouTube.php
@@ -57,7 +57,6 @@ $wgExtensionCredits['parserhook'][] = array
 );
 
 // i18n
-$wgExtensionMessagesFiles['YouTube'] = __DIR__ . '/YouTube.i18n.php';
 
 // Define the tallest a video can be to qualify as audio only
 define( 'AUDIO_ONLY_HEIGHT', 30 );

--- a/extensions/wikihiero/wikihiero.php
+++ b/extensions/wikihiero/wikihiero.php
@@ -38,8 +38,6 @@ $wgExtensionCredits['parserhook'][] = array(
 
 $dir = dirname( __FILE__ );
 
-$wgExtensionMessagesFiles['Wikihiero'] = "$dir/wikihiero.i18n.php";
-$wgExtensionMessagesFiles['HieroglyphsAlias'] = "$dir/wikihiero.alias.php";
 
 $wgAutoloadClasses['WikiHiero'] = "$dir/wikihiero.body.php";
 $wgAutoloadClasses['SpecialHieroglyphs'] = "$dir/SpecialHieroglyphs.php";

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -156,7 +156,6 @@ $wgAutoloadClasses['MoviesApiController'] = "{$IP}/includes/wikia/api/MoviesApiC
 $wgAutoloadClasses['InfoboxApiController'] = "{$IP}/includes/wikia/api/InfoboxApiController.class.php";
 $wgAutoloadClasses['LogEventsApiController'] = "{$IP}/includes/wikia/api/LogEventsApiController.class.php";
 $wgAutoloadClasses['TemplateClassificationApiController'] = "{$IP}/includes/wikia/api/TemplateClassificationApiController.class.php";
-$wgExtensionMessagesFiles['WikiaApi'] = "{$IP}/includes/wikia/api/WikiaApi.i18n.php";
 
 $wgWikiaApiControllers['DiscoverApiController'] = "{$IP}/includes/wikia/api/DiscoverApiController.class.php";
 $wgWikiaApiControllers['DesignSystemApiController'] = "{$IP}/includes/wikia/api/DesignSystemApiController.class.php";

--- a/includes/wikia/nirvana/WikiaApp.class.php
+++ b/includes/wikia/nirvana/WikiaApp.class.php
@@ -464,26 +464,6 @@ class WikiaApp {
 	}
 
 	/**
-	 * register extension message file
-	 * @param string $name
-	 * @param string $filePath
-	 * @deprecated
-	 */
-	public function registerExtensionMessageFile( $name, $filePath ) {
-		$this->wg->set( 'wgExtensionMessagesFiles', $filePath, $name );
-	}
-
-	/**
-	 * register extension alias file
-	 * @param string $name
-	 * @param string $filePath
-	 * @deprecated
-	 */
-	public function registerExtensionAliasFile( $name, $filePath ) {
-		$this->wg->set( 'wgExtensionAliasesFiles', $filePath, $name );
-	}
-
-	/**
 	 * register special page
 	 * @param string $name special page name
 	 * @param string $className class name

--- a/includes/wikia/tests/WikiaAppTest.php
+++ b/includes/wikia/tests/WikiaAppTest.php
@@ -48,30 +48,6 @@ class WikiaAppTest extends TestCase {
 		$this->application->registerExtensionFunction($function);
 	}
 
-	public function testRegisteringExtensionMessageFileProxiesToMediaWikiRegistry() {
-		$path = 'filepath';
-		$name = 'name';
-
-		$registry = $this->createMock( WikiaGlobalRegistry::class );
-		$registry->expects($this->once())
-		         ->method('set')
-		         ->with($this->equalTo('wgExtensionMessagesFiles'), $this->equalTo($path), $this->equalTo($name));
-		$this->application->setGlobalRegistry($registry);
-		$this->application->registerExtensionMessageFile($name, $path);
-	}
-
-	public function testRegisteringExtensionAliasFileProxiesToMediaWikiRegistry() {
-		$path = 'filepath';
-		$name = 'name';
-
-		$registry = $this->createMock( WikiaGlobalRegistry::class );
-		$registry->expects($this->once())
-		         ->method('set')
-		         ->with($this->equalTo('wgExtensionAliasesFiles'), $this->equalTo($path), $this->equalTo($name));
-		$this->application->setGlobalRegistry($registry);
-		$this->application->registerExtensionAliasFile($name, $path);
-	}
-
 	public function testRegisteringSpecialPageProxiesToMediaWikiRegistry() {
 		$name = 'name';
 		$class = 'SpecialPageClass';

--- a/maintenance/wikia/AutomaticWikiAdoptionGatherData.php
+++ b/maintenance/wikia/AutomaticWikiAdoptionGatherData.php
@@ -25,8 +25,7 @@ if (isset($options['help'])) {
 		  --maxwiki			maximum wiki id\n\n");
 }
 
-$wgExtensionMessagesFiles['AutomaticWikiAdoption'] = $GLOBALS['IP'] . '/extensions/wikia/AutomaticWikiAdoption/AutomaticWikiAdoption.i18n.php';
-require_once( $GLOBALS['IP'].'/extensions/wikia/AutomaticWikiAdoption/maintenance/AutomaticWikiAdoptionGatherData.php' );
+require_once( __DIR__.'/../../extensions/wikia/AutomaticWikiAdoption/maintenance/AutomaticWikiAdoptionGatherData.php' );
 
 $maintenance = new AutomaticWikiAdoptionGatherData();
 $maintenance->run($options);


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-2957

`wgExtensionMessagesFiles` is now taken from the list of files by `RebuildLocalisationCache` script.