### PR TITLE
SUS-2971 | DumpsOnDemand: set value of dump_user_id column instead of dump_user_name

### DIFF
--- a/extensions/wikia/WikiFactory/Dumps/DumpsOnDemand.php
+++ b/extensions/wikia/WikiFactory/Dumps/DumpsOnDemand.php
@@ -131,13 +131,13 @@ class DumpsOnDemand {
 				return null;
 			}
 
-			$aData = array(
+			$aData = [
 				'dump_wiki_id'	  => $iCityId,
 				'dump_wiki_dbname'  => $oWiki->city_dbname,
 				'dump_wiki_url'	 => $oWiki->city_url,
-				'dump_user_name'	=> $wgUser->getName(),
+				'dump_user_id' => $wgUser->getId(),
 				'dump_requested'	=> wfTimestampNow()
-			);
+			];
 
 			if ( $bHidden ) {
 				$aData['dump_hidden'] = 'Y';

--- a/maintenance/wikia/sql/wikicities-schema.sql
+++ b/maintenance/wikia/sql/wikicities-schema.sql
@@ -291,7 +291,8 @@ CREATE TABLE `dumps` (
   `dump_wiki_id` int(9) NOT NULL,
   `dump_wiki_dbname` varchar(64) NOT NULL,
   `dump_wiki_url` varchar(255) NOT NULL,
-  `dump_user_name` varchar(255) NOT NULL,
+  `dump_user_id` int(9) DEFAULT '0',
+  `dump_user_name` varchar(255) DEFAULT NULL,
   `dump_hidden` enum('N','Y') DEFAULT 'N',
   `dump_closed` enum('N','Y') DEFAULT 'N',
   `dump_requested` datetime NOT NULL,
@@ -674,4 +675,4 @@ CREATE TABLE `wikia_tasks_log` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 
--- Dump completed on 2017-10-06 12:23:07
+-- Dump completed on 2017-10-09  8:44:58


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-2971

Next steps when this goes live:

* migrate rows to keep user ID instead of user name
* drop `dump_user_name` column