### PR TITLE
SUS-296 | We do not want debug logs to be reported on production

### DIFF
--- a/lib/Wikia/src/Logger/SyslogHandler.php
+++ b/lib/Wikia/src/Logger/SyslogHandler.php
@@ -3,9 +3,8 @@ namespace Wikia\Logger;
 
 class SyslogHandler extends \Monolog\Handler\SyslogHandler {
 
-	// all logs go to ELK by default
 	protected function getDefaultFormatter() {
-		return new LogstashFormatter(null);
+		return new LogstashFormatter();
 	}
 
 }

--- a/lib/Wikia/src/Logger/WikiaLogger.php
+++ b/lib/Wikia/src/Logger/WikiaLogger.php
@@ -189,8 +189,13 @@ class WikiaLogger implements LoggerInterface {
 	 */
 	public function getSyslogHandler() {
 		if ($this->syslogHandler == null) {
+			// SUS-2966 | We do not want debug logs to be reported on production (info level will be the lowest logged)
+			// $level is the minimum logging level at which this handler will be triggered
+			global $wgWikiaEnvironment;
+			$level = ( $wgWikiaEnvironment === WIKIA_ENV_PROD ) ? Logger::INFO : Logger::DEBUG;
+
 			// all logs from WikiaLogger will have 'program' set to 'mediawiki'
-			$this->syslogHandler = new SyslogHandler('mediawiki');
+			$this->syslogHandler = new SyslogHandler('mediawiki', LOG_USER /* $facility */, $level);
 		}
 
 		return $this->syslogHandler;


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-2966

`Logger::INFO` level will be the lowest logged on production.

### Some statistics

Out of 675,674,771 entries in MediaWiki log in the last 24h 389,972,032 are logged at the `debug` level (~**58%**).