### PR TITLE
XW-3963 | Hiding controls we dont want

### DIFF
--- a/extensions/wikia/ArticleVideo/styles/jwplayer-overrides.scss
+++ b/extensions/wikia/ArticleVideo/styles/jwplayer-overrides.scss
@@ -1,0 +1,10 @@
+.featured-video {
+	.jw-button-container {
+		.jw-icon-rewind,
+		.jw-icon-next,
+		.jw-settings-sharing,
+		.jw-related-btn {
+			display: none;
+		}
+	}
+}

--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -2690,6 +2690,7 @@ $config['jwplayer_scss'] = [
 	'skin' => [ 'oasis' ],
 	'assets' => [
 		'//extensions/wikia/ArticleVideo/styles/jwplayer.scss',
+		'//extensions/wikia/ArticleVideo/styles/jwplayer-overrides.scss',
 		'//extensions/wikia/ArticleVideo/styles/video-feedback.scss',
 		'//extensions/wikia/ArticleVideo/styles/video-attribution.scss'
 	],


### PR DESCRIPTION
@Wikia/x-wing 

This hides controls for:

- Rewinding
- Next item
- Discovering (related items)
- Sharing