### PR TITLE
WallHelper | fix a fatal error

### DIFF
--- a/extensions/wikia/Wall/WallHelper.class.php
+++ b/extensions/wikia/Wall/WallHelper.class.php
@@ -562,7 +562,7 @@ class WallHelper {
 		if ( is_object( $row ) ) {
 			// row from the revision table
 			$objTitle = Title::makeTitle( $row->page_namespace, $row->page_title );
-			$userText = User::getUsername( $row->rev_user, $row->rev_user_text ) ?: '';
+			$userText = isset( $row->rev_user ) ? User::getUsername( $row->rev_user, $row->rev_user_text ) : '';
 
 			$isNew = ( !empty( $row->page_is_new ) && $row->page_is_new === '1' ) ? true : false;
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/MAIN-11594

```
PHP Notice: Undefined property: stdClass::$rev_user in /usr/wikia/slot1/19955/src/extensions/wikia/Wall/WallHelper.class.php on line 565

Argument 1 passed to User::getUsername() must be of the type integer, null given, called in /usr/wikia/slot1/19955/src/extensions/wikia/Wall/WallHelper.class.php on line 565
```