### PR TITLE
XW-4099 | Do not hide controls on onScroll transition

### DIFF
--- a/extensions/wikia/ArticleVideo/scripts/featured-video.jwplayer.on-scroll.js
+++ b/extensions/wikia/ArticleVideo/scripts/featured-video.jwplayer.on-scroll.js
@@ -17,7 +17,7 @@ define('wikia.articleVideo.featuredVideo.jwplayer.onScroll', ['wikia.onScroll', 
 			collapsingDisabled = false;
 			videoCollapsed = true;
 			$featuredVideo.addClass('is-collapsed-ready');
-			playerInstance.setControls(false);
+
 			$playerContainer.css({
 				'bottom': viewportHeight - videoOffset.top - videoHeight + $(window).scrollTop(),
 				'right': viewportWidth - videoOffset.left - videoWidth,
@@ -79,7 +79,6 @@ define('wikia.articleVideo.featuredVideo.jwplayer.onScroll', ['wikia.onScroll', 
 		function onVideoResized(event) {
 			if (event.propertyName === 'width') {
 				playerInstance.resize();
-				playerInstance.setControls(true);
 			}
 		}
 


### PR DESCRIPTION
@Wikia/x-wing 

This would not hide controls when transitioning from full video to the onscroll box. The intention of hiding was to make transition look smoother, but it's not tragic, whereas switching off controls sometimes results in a bug, where mouse cursor is not visible over the video.