### PR TITLE
Revert "SUS-2779 Replace in-cluster users table JOINs with external database "

### DIFF
--- a/includes/EditPage.php
+++ b/includes/EditPage.php
@@ -2621,26 +2621,26 @@ HTML
 
 	protected function getLastDelete() {
 		$dbr = wfGetDB( DB_SLAVE );
-		$data = $dbr->selectRow( [ 'logging' ], [
-			'log_type',
-			'log_action',
-			'log_timestamp',
-			'log_user',
-			'log_namespace',
-			'log_title',
-			'log_comment',
-			'log_params',
-			'log_deleted',
-		], [
-			'log_namespace' => $this->mTitle->getNamespace(),
-			'log_title' => $this->mTitle->getDBkey(),
-			'log_type' => 'delete',
-			'log_action' => 'delete',
-		], __METHOD__, [
-			'LIMIT' => 1,
-			'ORDER BY' => 'log_timestamp DESC'
-		] );
-
+		$data = $dbr->selectRow(
+			array( 'logging', 'user' ),
+			array( 'log_type',
+				   'log_action',
+				   'log_timestamp',
+				   'log_user',
+				   'log_namespace',
+				   'log_title',
+				   'log_comment',
+				   'log_params',
+				   'log_deleted',
+				   'user_name' ),
+			array( 'log_namespace' => $this->mTitle->getNamespace(),
+				   'log_title' => $this->mTitle->getDBkey(),
+				   'log_type' => 'delete',
+				   'log_action' => 'delete',
+				   'user_id=log_user' ),
+			__METHOD__,
+			array( 'LIMIT' => 1, 'ORDER BY' => 'log_timestamp DESC' )
+		);
 		// Quick paranoid permission checks...
 		if( is_object( $data ) ) {
 			if( $data->log_deleted & LogPage::DELETED_USER )
@@ -2648,11 +2648,6 @@ HTML
 			if( $data->log_deleted & LogPage::DELETED_COMMENT )
 				$data->log_comment = wfMsgHtml( 'rev-deleted-comment' );
 		}
-
-		// SUS-2779
-		$user = User::newFromId($data->log_user);
-		$data->user_name = $user->getName();
-
 		return $data;
 	}
 

--- a/includes/api/ApiQueryLogEvents.php
+++ b/includes/api/ApiQueryLogEvents.php
@@ -63,12 +63,14 @@ class ApiQueryLogEvents extends ApiQueryBase {
 		}
 
 		// Order is significant here
-		$this->addTables( array( 'logging', 'page' ) );
+		$this->addTables( array( 'logging', 'user', 'page' ) );
 		$this->addOption( 'STRAIGHT_JOIN' );
-		// SUS-2779
 		$this->addJoinConds( array(
+			'user' => array( 'JOIN',
+				'user_id=log_user' ),
 			'page' => array( 'LEFT JOIN',
-				array(	'log_namespace=page_namespace', 'log_title=page_title' ) ) ) );
+				array(	'log_namespace=page_namespace',
+					'log_title=page_title' ) ) ) );
 
 		$this->addFields( array(
 			'log_type',
@@ -78,7 +80,8 @@ class ApiQueryLogEvents extends ApiQueryBase {
 		) );
 
 		$this->addFieldsIf( array( 'log_id', 'page_id' ), $this->fld_ids );
-		$this->addFieldsIf( array( 'log_user' ), $this->fld_user );
+		$this->addFieldsIf( array( 'log_user', 'user_name' ), $this->fld_user );
+		$this->addFieldsIf( 'user_id', $this->fld_userid );
 		$this->addFieldsIf( array( 'log_namespace', 'log_title' ), $this->fld_title || $this->fld_parsedcomment );
 		$this->addFieldsIf( 'log_comment', $this->fld_comment || $this->fld_parsedcomment );
 		$this->addFieldsIf( 'log_params', $this->fld_details );
@@ -153,32 +156,11 @@ class ApiQueryLogEvents extends ApiQueryBase {
 		$count = 0;
 		$res = $this->select( __METHOD__ );
 		$result = $this->getResult();
-
-		// SUS-2779
-		$userIds = $this->getFieldFromResults( $res, 'log_user' );
-		$userNames = $this->getIndexedUserNames( $userIds );
-
 		foreach ( $res as $row ) {
 			if ( ++ $count > $limit ) {
 				// We've reached the one extra which shows that there are additional pages to be had. Stop here...
 				$this->setContinueEnumParameter( 'start', wfTimestamp( TS_ISO_8601, $row->log_timestamp ) );
 				break;
-			}
-
-			// SUS-2779
-			if ( $this->fld_userid ) {
-				$row->user_id = $row->log_user;
-			}
-
-			if ( $this->fld_user ) {
-				if ( isset( $userNames[$row->log_user] ) ) {
-					$row->user_name = $userNames[$row->log_user];
-				} else {
-					$row->user_name = 'unknown';
-					\Wikia\Logger\WikiaLogger::instance()
-						->warning( "User not found by a given ID",
-							[ 'user_id' => $row->log_user ] );
-				}
 			}
 
 			$vals = $this->extractRowInfo( $row );
@@ -485,34 +467,5 @@ class ApiQueryLogEvents extends ApiQueryBase {
 
 	public function getVersion() {
 		return __CLASS__ . ': $Id$';
-	}
-
-	private function getIndexedUserNames( $userIds ) {
-		global $wgExternalSharedDB;
-		if ( count( $userIds ) === 0 ) {
-			return [];
-		}
-
-		$db = wfGetDB( DB_SLAVE, [], $wgExternalSharedDB );
-		$conditions = [ 'user_id' => array_unique( $userIds ) ];
-		$dbResults = $db->select( '`user`', [ 'user_id', 'user_name' ], $conditions, __METHOD__ );
-
-		$results = [];
-		foreach ( $dbResults as $row ) {
-			$results[$row->user_id] = $row->user_name;
-		}
-
-		return $results;
-	}
-
-	private function getFieldFromResults( $res, $fieldName ) {
-		$userIds = [];
-		foreach ( $res as $row ) {
-			if ( isset($row->{ $fieldName }) ) {
-				$userIds[] = $row->{ $fieldName };
-			}
-		}
-
-		return $userIds;
 	}
 }

--- a/includes/cache/GenderCache.php
+++ b/includes/cache/GenderCache.php
@@ -92,26 +92,13 @@ class GenderCache {
 
 	/**
 	 * Preloads genders for given list of users.
-	 * @param $users array|String: userNames
+	 * @param $users List|String: usernames
 	 * @param $caller String: the calling method
 	 */
 	public function doQuery( $users, $caller = '' ) {
 		$default = $this->getDefault();
 
-		// SUS-2779
-		$users = $this->filterListOfUsers($users, $default);
-
-		if ( count( $users ) === 0 ) {
-			return;
-		}
-
-		foreach ( $this->getGenderOfUsersFromDB($users, $caller) as $row ) {
-			$this->cache[$row->user_name] = $row->up_value ? $row->up_value : $default;
-		}
-	}
-
-	private function filterListOfUsers( $users, $default ) {
-		foreach ( (array)$users as $index => $value ) {
+		foreach ( (array) $users as $index => $value ) {
 			$name = strtr( $value, '_', ' ' );
 			if ( isset( $this->cache[$name] ) ) {
 				// Skip users whose gender setting we already know
@@ -123,32 +110,26 @@ class GenderCache {
 			}
 		}
 
-		return $users;
-	}
+		if ( count( $users ) === 0 ) {
+			return;
+		}
 
-	/**
-	 * @param $userNames
-	 * @param $caller
-	 * @return ResultWrapper
-	 */
-	private function getGenderOfUsersFromDB( $userNames, $caller ): ResultWrapper {
-		global $wgExternalSharedDB;
-		$dbr = wfGetDB( DB_SLAVE, [], $wgExternalSharedDB );
-
-		$table = [ '`user`', '`user_properties`' ];
-		$fields = [ 'user_name', 'up_value' ];
-		$conds = [ 'user_name' => $userNames ];
-		$joins = [
-			'user_properties' => [
-				'LEFT JOIN', [ 'user_id = up_user', 'up_property' => 'gender' ],
-			],
-		];
+		$dbr = wfGetDB( DB_SLAVE );
+		$table = array( 'user', 'user_properties' );
+		$fields = array( 'user_name', 'up_value' );
+		$conds = array( 'user_name' => $users );
+		$joins = array( 'user_properties' =>
+			array( 'LEFT JOIN', array( 'user_id = up_user', 'up_property' => 'gender' ) ) );
 
 		$comment = __METHOD__;
 		if ( strval( $caller ) !== '' ) {
 			$comment .= "/$caller";
 		}
+		$res = $dbr->select( $table, $fields, $conds, $comment, $joins, $joins );
 
-		return $dbr->select( $table, $fields, $conds, $comment, $joins, $joins );
+		foreach ( $res as $row ) {
+			$this->cache[$row->user_name] = $row->up_value ? $row->up_value : $default;
+		}
 	}
+
 }

--- a/includes/logging/LogEntry.php
+++ b/includes/logging/LogEntry.php
@@ -118,22 +118,27 @@ class DatabaseLogEntry extends LogEntryBase {
 	 * @return array
 	 */
 	public static function getSelectQueryData() {
-		// SUS-2779
-		$tables = [ 'logging' ];
-		$fields = [
+		$tables = array( 'logging', 'user' );
+		$fields = array(
 			'log_id', 'log_type', 'log_action', 'log_timestamp',
 			'log_user', 'log_user_text',
 			'log_namespace', 'log_title', // unused log_page
-			'log_comment', 'log_params', 'log_deleted'
-		];
+			'log_comment', 'log_params', 'log_deleted',
+			'user_id', 'user_name', 'user_editcount',
+		);
 
-		return [
+		$joins = array(
+			// IP's don't have an entry in user table
+			'user' => array( 'LEFT JOIN', 'log_user=user_id' ),
+		);
+
+		return array(
 			'tables' => $tables,
 			'fields' => $fields,
-			'conds'  => [],
-			'options' => [],
-			'join_conds' => []
-		];
+			'conds'  => array(),
+			'options' => array(),
+			'join_conds' => $joins,
+		);
 	}
 
 	/**

--- a/includes/logging/LogPager.php
+++ b/includes/logging/LogPager.php
@@ -30,7 +30,6 @@ class LogPager extends ReverseChronologicalPager {
 	private $types = array(), $performer = '', $title = '', $pattern = '';
 	private $typeCGI = '';
 	public $mLogEventsList;
-	private $usersData = [];
 
 	/**
 	 * Constructor
@@ -277,18 +276,11 @@ class LogPager extends ReverseChronologicalPager {
 	}
 
 	public function getStartBody() {
-		$userIds = $this->getFieldFromResults($this->mResult, 'log_user');
-		$this->usersData = $this->parseUsersData( $this->getUserData( $userIds ) );
-
 		wfProfileIn( __METHOD__ );
 		# Do a link batch query
 		if( $this->getNumRows() > 0 ) {
 			$lb = new LinkBatch;
 			foreach ( $this->mResult as $row ) {
-
-				// SUS-2779
-				$this->joinUserDataToLogRow($row, $this->usersData);
-
 				$lb->add( $row->log_namespace, $row->log_title );
 				$lb->addObj( Title::makeTitleSafe( NS_USER, $row->user_name ) );
 				$lb->addObj( Title::makeTitleSafe( NS_USER_TALK, $row->user_name ) );
@@ -304,68 +296,7 @@ class LogPager extends ReverseChronologicalPager {
 		return '';
 	}
 
-	/**
-	 * @param $row
-	 * @param $userNames
-	 */
-	private function joinUserDataToLogRow( $row, $userNames ) {
-		$row->user_id = $row->log_user;
-
-		if ( isset( $userNames[$row->user_id] ) ) {
-			$row->user_name = $userNames[$row->user_id]->user_name;
-			$row->user_text = $row->user_name;
-			$row->user_editcount = $userNames[$row->user_id]->user_editcount;
-		} else {
-			\Wikia\Logger\WikiaLogger::instance()
-				->warning( "User with id {$row->log_user} was not found" );
-			$row->user_name = 'unknown';
-			$row->user_editcount = 0;
-		}
-
-		$row->log_user_text = $row->user_name;
-	}
-
-	private function getUserData( $userIds ) {
-		global $wgExternalSharedDB;
-
-		if (count($userIds) === 0) {
-			return [];
-		}
-
-		$fields = [ 'user_id', 'user_name', 'user_editcount' ];
-		$conditions = [ 'user_id' => array_unique( $userIds ) ];
-		$db = wfGetDB( DB_SLAVE, [], $wgExternalSharedDB );
-		return $db->select( '`user`', $fields, $conditions );
-	}
-
-	private function getFieldFromResults( $res, $fieldName ) {
-		$userIds = [];
-		foreach ( $res as $row ) {
-			if ( isset($row->{ $fieldName }) ) {
-				$userIds[] = $row->{ $fieldName };
-			}
-		}
-
-		return $userIds;
-	}
-
-	/**
-	 * @param $dbResults
-	 * @return array
-	 */
-	private function parseUsersData( $dbResults ): array {
-		$results = [];
-
-		foreach ( $dbResults as $row ) {
-			$results[$row->user_id] = $row;
-		}
-
-		return $results;
-	}
-
 	public function formatRow( $row ) {
-		// SUS-2779
-		$this->joinUserDataToLogRow( $row, $this->usersData );
 		return $this->mLogEventsList->logLine( $row );
 	}
 


### PR DESCRIPTION
Reverts Wikia/app#13912

Seems to cause `PHP Fatal Error: Allowed memory size of 536870912 bytes exhausted (tried to allocate 4096 bytes) in /usr/wikia/slot1/19981/src/includes/db/DatabaseMysqli.php on line 44` on devbox and sandbox.

The full trace:

```

1 | 0.0000 | 365384 | {main}( ) | .../index.php:0
-- | -- | -- | -- | --
2 | 0.0753 | 4475584 | MediaWiki->run( ) | .../index.php:58
3 | 0.0753 | 4475608 | MediaWiki->main( ) | .../Wiki.php:547
4 | 0.1850 | 6232504 | MediaWiki->finalCleanup( ) | .../Wiki.php:668
5 | 0.1850 | 6232504 | OutputPage->output( ) | .../Wiki.php:448
6 | 0.2009 | 6578880 | SkinTemplate->outputPage( ) | .../OutputPage.php:2133
7 | 0.2009 | 6579048 | WikiaSkin->initPage( ) | .../SkinTemplate.php:162
8 | 1.4827 | 7454728 | Skin->initPage( ) | .../WikiaSkin.class.php:344
9 | 1.4827 | 7454728 | Skin->preloadExistence( ) | .../Skin.php:205
10 | 1.4829 | 7458360 | LinkBatch->execute( ) | .../Skin.php:230
11 | 1.4829 | 7458384 | LinkBatch->executeInto( ) | .../LinkBatch.php:94
12 | 1.4837 | 7475624 | LinkBatch->doGenderQuery( ) | .../LinkBatch.php:107
13 | 1.4838 | 7476856 | GenderCache->doLinkBatch( ) | .../LinkBatch.php:193
14 | 1.4838 | 7477608 | GenderCache->doQuery( ) | .../GenderCache.php:90
15 | 1.4838 | 7477984 | GenderCache->getGenderOfUsersFromDB( ) | .../GenderCache.php:108
16 | 1.4839 | 7478456 | DatabaseBase->select( ) | .../GenderCache.php:152
17 | 1.4839 | 7478584 | DatabaseBase->query( ) | .../Database.php:1564
18 | 1.4840 | 7479320 | DatabaseBase->executeAndProfileQuery( ) | .../Database.php:1019
19 | 1.4840 | 7479320 | DatabaseMysqli->doQuery( ) | .../Database.php:3736
20 | 1.4840 | 7479320 | query ( ) | .../DatabaseMysqli.php:44
```