### PR TITLE
GenderCache - fix OOM on devbox / sandbox

### DIFF
--- a/includes/cache/GenderCache.php
+++ b/includes/cache/GenderCache.php
@@ -135,7 +135,7 @@ class GenderCache {
 		global $wgExternalSharedDB;
 		$dbr = wfGetDB( DB_SLAVE, [], $wgExternalSharedDB );
 
-		$table = [ '`user`', '`user_properties`' ];
+		$table = [ '`user`', 'user_properties' ];
 		$fields = [ 'user_name', 'up_value' ];
 		$conds = [ 'user_name' => $userNames ];
 		$joins = [


### PR DESCRIPTION
Because of backticks used in the list of tables JOIN conditions were not included in the query. This caused `PHP Fatal Error: Allowed memory size of 536870912 bytes exhausted (tried to allocate 4096 bytes) in /usr/wikia/slot1/19981/src/includes/db/DatabaseMysqli.php on line 44`.

The "broken" query tried to fetch all rows from user_properties table on shared DB.

```sql
Query wikicities (DB user: wikia_mw2) (18) (slave): SELECT /* GenderCache::getGenderOfUsersFromDB/Skin::preloadExistence Macbre - 39014284-2ad6-453d-ac0f-ddb866a268e3 */  user_name,up_value  FROM `user`,`user_properties`   WHERE user_name = 'Macbre'
```

Query after a fix:

```sql
Query wikicities (DB user: wikia_mw2) (17) (slave): SELECT /* GenderCache::getGenderOfUsersFromDB/Skin::preloadExistence Macbre - 475dc732-52da-4c95-8575-36854d42e1d8 */  user_name,up_value  FROM `user` LEFT JOIN `user_properties` ON ((user_id = up_user) AND up_property = 'gender')  WHERE user_name = 'Macbre'  
```

See #13912