### PR TITLE
SUS-2974 | log SQL queries to a separate ES index - 'mediawiki-sql'

### DIFF
--- a/includes/db/Database.php
+++ b/includes/db/Database.php
@@ -3753,6 +3753,7 @@ abstract class DatabaseBase implements DatabaseType {
 	 * @param string $sql the query
 	 * @param ResultWrapper|mysqli_result|bool $ret database results
 	 * @param string $fname the name of the function that made this query
+	 * @param float $elapsedTime time (in seconds) it took the query to complete
 	 * @param bool $isMaster is this against the master
 	 * @return void
 	 */
@@ -3797,11 +3798,12 @@ abstract class DatabaseBase implements DatabaseType {
 			'exception'   => new Exception(), // log the backtrace
 		];
 
+		/* @var WebRequest $wgRequest */
 		if ( $wgRequest && $wgRequest->getVal( 'action' ) == 'delete' ) {
 			$this->getWikiaLogger()->info( "SQL (action=delete) {$sql}", $context );
 		}
 
-		// SUS-2974 | log SQL logs to a separate ES index 'mediawiki-sql'
+		// SUS-2974 | send SQL logs to a separate ES index 'mediawiki-sql'
 		if ( $this->getSampler()->shouldSample() ) {
 			$this->getWikiaLogger()->defaultLogger( 'mediawiki-sql' )->info( $sql, $context );
 		}

--- a/includes/db/Database.php
+++ b/includes/db/Database.php
@@ -3801,8 +3801,9 @@ abstract class DatabaseBase implements DatabaseType {
 			$this->getWikiaLogger()->info( "SQL (action=delete) {$sql}", $context );
 		}
 
+		// SUS-2974 | log SQL logs to a separate ES index 'mediawiki-sql'
 		if ( $this->getSampler()->shouldSample() ) {
-			$this->getWikiaLogger()->info( "SQL {$sql}", $context );
+			$this->getWikiaLogger()->defaultLogger( 'mediawiki-sql' )->info( $sql, $context );
 		}
 
 		if ( $this->isWriteQuery($sql) &&

--- a/lib/Wikia/src/Logger/LogstashFormatter.php
+++ b/lib/Wikia/src/Logger/LogstashFormatter.php
@@ -12,15 +12,19 @@ use Exception;
 
 
 class LogstashFormatter extends \Monolog\Formatter\LogstashFormatter {
-	public function __construct()
-	{
-		// prevent "Undefined variable: applicationName" notice
-		parent::__construct(null);
+
+	const APPNAME = 'mediawiki';
+
+	/**
+	 * @param string $appname
+	 */
+	public function __construct($appname = self::APPNAME) {
+		parent::__construct($appname);
 	}
 
 	protected function formatV0(array $record) {
 		$message = array(
-			'appname' => 'mediawiki',
+			'appname' => $this->applicationName,
 			'@timestamp' => $record['datetime'],
 			'@message' => $record['message'],
 		);

--- a/lib/Wikia/src/Logger/SyslogHandler.php
+++ b/lib/Wikia/src/Logger/SyslogHandler.php
@@ -4,7 +4,7 @@ namespace Wikia\Logger;
 class SyslogHandler extends \Monolog\Handler\SyslogHandler {
 
 	protected function getDefaultFormatter() {
-		return new LogstashFormatter();
+		return new LogstashFormatter($this->ident);
 	}
 
 }

--- a/lib/Wikia/src/Logger/WikiaLogger.php
+++ b/lib/Wikia/src/Logger/WikiaLogger.php
@@ -14,14 +14,13 @@ class WikiaLogger implements LoggerInterface {
 	/** @var \Psr\Log\LoggerInterface */
 	private $logger;
 
-	/** @var SyslogHandler */
-	private $syslogHandler;
-
 	/** @var WebProcessor */
 	private $webProcessor;
 
 	/** @var StatusProcessor */
 	private $statusProcessor;
+
+	const SYSLOG_IDENT = 'mediawiki';
 
 	/** private to enforce singleton */
 	private function __construct() {
@@ -185,34 +184,21 @@ class WikiaLogger implements LoggerInterface {
 	}
 
 	/**
+	 * Return an instance of syslog logger handler with logstash formatter registered.
+	 *
+	 * appname field will be set to the value provided by $ident argument.
+	 *
+	 * @param string $ident
 	 * @return SyslogHandler
 	 */
-	public function getSyslogHandler() {
-		if ($this->syslogHandler == null) {
-			// SUS-2966 | We do not want debug logs to be reported on production (info level will be the lowest logged)
-			// $level is the minimum logging level at which this handler will be triggered
-			global $wgWikiaEnvironment;
-			$level = ( $wgWikiaEnvironment === WIKIA_ENV_PROD ) ? Logger::INFO : Logger::DEBUG;
+	static public function getSyslogHandler($ident) {
+		// SUS-2966 | We do not want debug logs to be reported on production (info level will be the lowest logged)
+		// $level is the minimum logging level at which this handler will be triggered
+		global $wgWikiaEnvironment;
+		$level = ( $wgWikiaEnvironment === WIKIA_ENV_PROD ) ? Logger::INFO : Logger::DEBUG;
 
-			// all logs from WikiaLogger will have 'program' set to 'mediawiki'
-			$this->syslogHandler = new SyslogHandler('mediawiki', LOG_USER /* $facility */, $level);
-		}
-
-		return $this->syslogHandler;
-	}
-
-	/**
-	 * Set the SyslogHandler. Throws an exception of the logger has already been initialized.
-	 *
-	 * @param SyslogHandler $handler
-	 * @throws \InvalidArgumentException
-	 */
-	public function setSyslogHandler(SyslogHandler $handler) {
-		if (isset($this->logger)) {
-			throw new \InvalidArgumentException("Error, \$this->logger has been initialized.");
-		}
-
-		$this->syslogHandler = $handler;
+		// SUS-2974 | all logs from WikiaLogger will have 'program' and 'appname' set to provided $ident value
+		return new SyslogHandler($ident, LOG_USER /* $facility */, $level);
 	}
 
 	/**
@@ -254,12 +240,13 @@ class WikiaLogger implements LoggerInterface {
 	/**
 	 * Creates the default logger.
 	 *
+	 * @param string $ident
 	 * @return Logger
 	 */
-	public function defaultLogger() {
+	public function defaultLogger($ident = self::SYSLOG_IDENT) {
 		return new Logger(
 			'default',
-			[$this->getSyslogHandler()],
+			[self::getSyslogHandler($ident)],
 			[$this->getWebProcessor(), $this->getStatusProcessor()]
 		);
 	}

--- a/lib/Wikia/tests/Logger/WikiaLoggerTest.php
+++ b/lib/Wikia/tests/Logger/WikiaLoggerTest.php
@@ -13,7 +13,7 @@ class WikiaLoggerTest extends TestCase {
 	function testInstance() {
 		$logger = WikiaLogger::instance();
 		$this->assertTrue($logger instanceof WikiaLogger);
-		$this->assertTrue($logger->getSyslogHandler() instanceof SyslogHandler);
+		$this->assertTrue(WikiaLogger::getSyslogHandler('foo-test') instanceof SyslogHandler);
 		$this->assertTrue($logger->getWebProcessor() instanceof WebProcessor);
 	}
 

--- a/lib/Wikia/tests/Logger/WikiaLoggerTest.php
+++ b/lib/Wikia/tests/Logger/WikiaLoggerTest.php
@@ -12,9 +12,9 @@ class WikiaLoggerTest extends TestCase {
 
 	function testInstance() {
 		$logger = WikiaLogger::instance();
-		$this->assertTrue($logger instanceof WikiaLogger);
-		$this->assertTrue(WikiaLogger::getSyslogHandler('foo-test') instanceof SyslogHandler);
-		$this->assertTrue($logger->getWebProcessor() instanceof WebProcessor);
+		$this->assertInstanceOf( WikiaLogger::class,$logger );
+		$this->assertInstanceOf( SyslogHandler::class, WikiaLogger::getSyslogHandler('foo-test') );
+		$this->assertInstanceOf( WebProcessor::class, $logger->getWebProcessor() );
 	}
 
 	function testLogger() {

--- a/tests/unit/includes/db/DatabaseBaseTest.php
+++ b/tests/unit/includes/db/DatabaseBaseTest.php
@@ -40,7 +40,7 @@ class DatabaseBaseTest extends \PHPUnit\Framework\TestCase {
 
 		$wikiaLoggerMock->expects( $this->once() )
 			->method( 'defaultLogger' )
-			->will( $this->returnValue( $wikiaLoggerMock ) );
+			->willReturnSelf();
 
 		$return = 'a value';
 		$databaseBaseTesterMock = $this->getMockBuilder( DatabaseBaseTester::class )

--- a/tests/unit/includes/db/DatabaseBaseTest.php
+++ b/tests/unit/includes/db/DatabaseBaseTest.php
@@ -38,6 +38,10 @@ class DatabaseBaseTest extends \PHPUnit\Framework\TestCase {
 			->method( 'info' )
 			->will( $this->returnValue( true ) );
 
+		$wikiaLoggerMock->expects( $this->once() )
+			->method( 'defaultLogger' )
+			->will( $this->returnValue( $wikiaLoggerMock ) );
+
 		$return = 'a value';
 		$databaseBaseTesterMock = $this->getMockBuilder( DatabaseBaseTester::class )
 			->setMethods( [ 'doQuery', 'getWikiaLogger', 'resultObject' ] )


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-2974

`SQL` prefix in messages has been removed. Sampling will be kept at 1% (for now).

### An example entry

```
{
  "_index": "logstash-mediawiki-sql-2017.10.11",
  "_type": "logs",
...
    "@message": "SELECT /* WikiFactoryLoader::execute::tagsdb TaskRunnerMaintenance - 22805cf7-b615-4b67-8f27-e748d7357a6c */  id,name  FROM `city_tag`,`city_tag_map`  WHERE (city_tag.id = city_tag_map.tag_id) AND (city_id = 5915)  ",
    "@timestamp": "2017-10-11T14:31:16.385Z",
    "appname": "mediawiki-sql",
    "@source_host": "dev-macbre",
    "facility": "user-level"
  }
```

Non-SQL logs are still sent to `logstash-mediawiki-2017.10.11` index.
