### PR TITLE
SUS-2988 | ImageReviewEventsHooks - introduce isFileForReview method

### DIFF
--- a/extensions/wikia/ImageReview/ImageReviewEventsHooks.class.php
+++ b/extensions/wikia/ImageReview/ImageReviewEventsHooks.class.php
@@ -96,7 +96,20 @@ class ImageReviewEventsHooks {
 		return true;
 	}
 
-	private static function isFileForReview( $title ) {
+	/**
+	 * Push given image upload to the queue. This method is used by the re-queueing script.
+	 *
+	 * @see SUS-2988
+	 *
+	 * @param int $pageId
+	 * @param int $revisionId
+	 * @param int $userId
+	 */
+	public static function requeueImageUpload( int $pageId, int $revisionId, int $userId ) {
+		self::actionCreate( Title::newFromID( $pageId ), $revisionId, 'created', $userId );
+	}
+
+	private static function isFileForReview( Title $title ) {
 		if ( $title->inNamespace( NS_FILE ) ) {
 			$localFile = wfLocalFile( $title );
 
@@ -106,7 +119,13 @@ class ImageReviewEventsHooks {
 		return false;
 	}
 
-	private static function actionCreate( Title $title, $revisionId = null, $action = 'created' ) {
+	/**
+	 * @param Title $title
+	 * @param int $revisionId
+	 * @param string $action
+	 * @param int $userId allow user ID that makes an upload to be forced (instead of taken from the RequestContext)
+	 */
+	private static function actionCreate( Title $title, $revisionId = null, $action = 'created', $userId = null ) {
 		if ( self::isFileForReview( $title ) ) {
 			global $wgImageReview, $wgCityId;
 
@@ -123,7 +142,7 @@ class ImageReviewEventsHooks {
 						'revision' => $revisionId,
 					]
 				),
-				'userId' => RequestContext::getMain()->getUser()->getId(),
+				'userId' => $userId ?? RequestContext::getMain()->getUser()->getId(),
 				'wikiId' => $wgCityId,
 				'pageId' => $articleId,
 				'revisionId' => $revisionId,


### PR DESCRIPTION
This method will be used by the re-queueing script and will take data from this query:

```sql
mysql@geo-db-a-slave.query.consul[plpoznan]>select rev_id, page_id, rev_user, rev_timestamp, page_title from revision, page where revision.rev_page = page.page_id and page_namespace = 6 order by 1 desc limit 8;
+--------+---------+----------+----------------+----------------------------------------------+
| rev_id | page_id | rev_user | rev_timestamp  | page_title                                   |
+--------+---------+----------+----------------+----------------------------------------------+
| 114714 |   32619 |  5059646 | 20170930141743 | Ikarus_260.04                                |
| 114704 |   32616 |   119245 | 20170930085843 | DAF_MB200.jpg                                |
| 114703 |   32616 |  5059646 | 20170930085759 | DAF_MB200.jpg                                |
| 114702 |   32614 |   119245 | 20170929173944 | Ulica_Paderewskiego_-_tory_tramwajowe.jpg    |
| 114701 |   32615 |   119245 | 20170929173406 | Neony_-_lata_70-te.ogv                       |
| 114700 |   32615 |  5059646 | 20170929173306 | Neony_-_lata_70-te.ogv                       |
| 114698 |   32614 |   119245 | 20170929172619 | Ulica_Paderewskiego_-_tory_tramwajowe.jpg    |
| 114697 |   32614 |   119245 | 20170929172602 | Ulica_Paderewskiego_-_tory_tramwajowe.jpg    |
+--------+---------+----------+----------------+----------------------------------------------+
```

https://wikia-inc.atlassian.net/browse/SUS-2988