### PR TITLE
SUS-2988 | adding maintenance/wikia/pushUploadsToImageReview.php

### DIFF
--- a/extensions/wikia/ImageReview/ImageReviewEvents.setup.php
+++ b/extensions/wikia/ImageReview/ImageReviewEvents.setup.php
@@ -6,6 +6,7 @@
 
 $wgAutoloadClasses['ImageReviewEventsHooks'] = __DIR__ . '/ImageReviewEventsHooks.class.php';
 
+$wgHooks['FileUpload'][] = 'ImageReviewEventsHooks::onFileUpload';
 $wgHooks['UploadComplete'][] = 'ImageReviewEventsHooks::onUploadComplete';
 $wgHooks['FileRevertComplete'][] = 'ImageReviewEventsHooks::onFileRevertComplete';
 $wgHooks['ArticleDeleteComplete'][] = 'ImageReviewEventsHooks::onArticleDeleteComplete';

--- a/extensions/wikia/ImageReview/ImageReviewEventsHooks.class.php
+++ b/extensions/wikia/ImageReview/ImageReviewEventsHooks.class.php
@@ -101,12 +101,12 @@ class ImageReviewEventsHooks {
 	 *
 	 * @see SUS-2988
 	 *
-	 * @param int $pageId
+	 * @param Title $title Title object of an image to be pushed to the queue
 	 * @param int $revisionId
 	 * @param int $userId
 	 */
-	public static function requeueImageUpload( int $pageId, int $revisionId, int $userId ) {
-		self::actionCreate( Title::newFromID( $pageId ), $revisionId, 'created', $userId );
+	public static function requeueImageUpload( Title $title, int $revisionId, int $userId ) {
+		self::actionCreate( $title, $revisionId, 'created', $userId );
 	}
 
 	private static function isFileForReview( Title $title ) {

--- a/extensions/wikia/ImageReview/ImageReviewEventsHooks.class.php
+++ b/extensions/wikia/ImageReview/ImageReviewEventsHooks.class.php
@@ -109,7 +109,11 @@ class ImageReviewEventsHooks {
 		self::actionCreate( $title, $revisionId, 'created', $userId );
 	}
 
-	private static function isFileForReview( Title $title ) {
+	/**
+	 * @param Title $title
+	 * @return bool
+	 */
+	public static function isFileForReview( Title $title ) : bool {
 		if ( $title->inNamespace( NS_FILE ) ) {
 			$localFile = wfLocalFile( $title );
 

--- a/maintenance/wikia/pushUploadsToImageReview.php
+++ b/maintenance/wikia/pushUploadsToImageReview.php
@@ -68,9 +68,9 @@ class PushUploadsToImageReview extends Maintenance {
 		$pushed = 0;
 
 		// logging
-		global $wgDBName;
+		global $wgDBname;
 		$this->output( $db->lastQuery() . "\n");
-		$this->output( "{$wgDBName} - {$count} uploads will be checked\n");
+		$this->output( "{$wgDBname} - {$count} uploads will be checked\n");
 
 		foreach($res as $row) {
 			$title = Title::newFromRow($row);
@@ -90,7 +90,7 @@ class PushUploadsToImageReview extends Maintenance {
 			}
 		}
 
-		$this->output( "{$wgDBName} - {$pushed} uploads were pushed\n");
+		$this->output( "{$wgDBname} - {$pushed} uploads were pushed\n");
 
 		WikiaLogger::instance()->info( __CLASS__, [ 'uploads_pushed' => $pushed ] );
 	}

--- a/maintenance/wikia/pushUploadsToImageReview.php
+++ b/maintenance/wikia/pushUploadsToImageReview.php
@@ -65,14 +65,22 @@ class PushUploadsToImageReview extends Maintenance {
 		);
 
 		$count = $db->affectedRows();
+		$pushed = 0;
 
 		// logging
 		global $wgDBName;
 		$this->output( "\n" . $db->lastQuery() );
-		$this->output( "\n{$wgDBName} - {$count} upload(s) will be checked ");
+		$this->output( "\n{$wgDBName} - {$count} uploads will be checked ");
 
 		foreach($res as $row) {
 			$title = Title::newFromRow($row);
+
+			// skipping as this is not an image
+			if (!ImageReviewEventsHooks::isFileForReview($title)) {
+				continue;
+			}
+
+			$pushed++;
 
 			if ($this->isDryRun === false) {
 				ImageReviewEventsHooks::requeueImageUpload($title, $row->rev_id, $row->rev_user);
@@ -82,9 +90,9 @@ class PushUploadsToImageReview extends Maintenance {
 			}
 		}
 
-		$this->output( "\nDone!" );
+		$this->output( "\n{$wgDBName} - {$pushed} uploads were pushed");
 
-		WikiaLogger::instance()->info( __CLASS__, [ 'uploads_pushed' => $count ] );
+		WikiaLogger::instance()->info( __CLASS__, [ 'uploads_pushed' => $pushed ] );
 	}
 }
 

--- a/maintenance/wikia/pushUploadsToImageReview.php
+++ b/maintenance/wikia/pushUploadsToImageReview.php
@@ -67,9 +67,12 @@ class PushUploadsToImageReview extends Maintenance {
 		$count = $db->affectedRows();
 		$pushed = 0;
 
+		if ($this->isDryRun === true) {
+			$this->output($db->lastQuery() . "\n");
+		}
+
 		// logging
 		global $wgDBname;
-		$this->output( $db->lastQuery() . "\n");
 		$this->output( "{$wgDBname} - {$count} uploads will be checked\n");
 
 		foreach($res as $row) {

--- a/maintenance/wikia/pushUploadsToImageReview.php
+++ b/maintenance/wikia/pushUploadsToImageReview.php
@@ -69,8 +69,8 @@ class PushUploadsToImageReview extends Maintenance {
 
 		// logging
 		global $wgDBName;
-		$this->output( "\n" . $db->lastQuery() );
-		$this->output( "\n{$wgDBName} - {$count} uploads will be checked ");
+		$this->output( $db->lastQuery() . "\n");
+		$this->output( "{$wgDBName} - {$count} uploads will be checked\n");
 
 		foreach($res as $row) {
 			$title = Title::newFromRow($row);
@@ -86,11 +86,11 @@ class PushUploadsToImageReview extends Maintenance {
 				ImageReviewEventsHooks::requeueImageUpload($title, $row->rev_id, $row->rev_user);
 			}
 			else {
-				$this->output("\n * would push {$row->page_title}, but running in dry-run mode" );
+				$this->output("* would push {$row->page_title} (rev #{$row->rev_id}), but running in dry-run mode\n" );
 			}
 		}
 
-		$this->output( "\n{$wgDBName} - {$pushed} uploads were pushed");
+		$this->output( "{$wgDBName} - {$pushed} uploads were pushed\n");
 
 		WikiaLogger::instance()->info( __CLASS__, [ 'uploads_pushed' => $pushed ] );
 	}

--- a/maintenance/wikia/pushUploadsToImageReview.php
+++ b/maintenance/wikia/pushUploadsToImageReview.php
@@ -1,0 +1,92 @@
+<?php
+
+use \Wikia\Logger\WikiaLogger;
+
+/**
+ * Script that pushes image uploads for a given to image review queue
+ *
+ * @see SUS-2988
+ *
+ * @author Macbre
+ * @ingroup Maintenance
+ */
+
+require_once( __DIR__ . '/../Maintenance.php' );
+
+/**
+ * Maintenance script class
+ */
+class PushUploadsToImageReview extends Maintenance {
+
+	// perform push for uploads performed between these two timestamp
+	const TIMESTAMP_FROM = '2017-08-31';
+	const TIMESTAMP_TO = '2017-10-13';
+
+	private $isDryRun = false;
+
+	/**
+	 * Set script options
+	 */
+	public function __construct() {
+		parent::__construct();
+
+		$this->addOption( 'dry-run', 'Don\'t perform any operations' );
+		$this->mDescription = 'This script pushes image uploads for a given to image review queue';
+	}
+
+	public function execute() {
+		$this->isDryRun = $this->hasOption( 'dry-run' );
+
+		// timestamps
+		$timestampFrom = strtotime(self::TIMESTAMP_FROM);
+		$timestampTo = strtotime(self::TIMESTAMP_TO);
+
+		// fetch uploads to handle
+		// select rev_id, page_id, rev_user, rev_timestamp, page_title from revision, page where revision.rev_page = page.page_id and page_namespace = 6
+		$db = $this->getDB(DB_SLAVE);
+
+		$res = $db->select(
+			['page', 'revision'],
+			[
+				'page_id',
+				'page_title',
+				'page_namespace',
+				'rev_id',
+				'rev_user',
+				'rev_timestamp',
+			],
+			[
+				'revision.rev_page = page.page_id',
+				'page_namespace' => NS_FILE,
+				sprintf('rev_timestamp > "%s"', $db->timestamp($timestampFrom)),
+				sprintf('rev_timestamp < "%s"', $db->timestamp($timestampTo))
+			],
+			__METHOD__
+		);
+
+		$count = $db->affectedRows();
+
+		// logging
+		global $wgDBName;
+		$this->output( "\n" . $db->lastQuery() );
+		$this->output( "\n{$wgDBName} - {$count} upload(s) will be checked ");
+
+		foreach($res as $row) {
+			$title = Title::newFromRow($row);
+
+			if ($this->isDryRun === false) {
+				ImageReviewEventsHooks::requeueImageUpload($title, $row->rev_id, $row->rev_user);
+			}
+			else {
+				$this->output("\n * would push {$row->page_title}, but running in dry-run mode" );
+			}
+		}
+
+		$this->output( "\nDone!" );
+
+		WikiaLogger::instance()->info( __CLASS__, [ 'uploads_pushed' => $count ] );
+	}
+}
+
+$maintClass = PushUploadsToImageReview::class;
+require_once( RUN_MAINTENANCE_IF_MAIN );


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-2988

Introduce the script that will push image uploads to image review queue.

```
macbre@cron-s1:~/app/maintenance/wikia$ SERVER_ID=831 php pushUploadsToImageReview.php 
SELECT  page_id,page_title,page_namespace,rev_id,rev_user,rev_timestamp  FROM `page`,`revision`  WHERE (revision.rev_page = page.page_id) AND page_namespace = '6' AND (rev_timestamp > "20170831000000") AND (rev_timestamp < "20171013000000")  
muppet - 788 uploads will be checked
muppet - 719 uploads were pushed
```

Log the following events:

* `ImageReviewEventsHooks::actionCreate` - push to image review queue
* `ImageReviewEventsHooks::onFileUpload` - image upload on the MW core level

`@context.file_name` field will be reported in both cases. This should allow us to identify all not handled upload scenarios.