### PR TITLE
ImageReviewEventsHooks: log uploads and image review queue pushes

### DIFF
--- a/extensions/wikia/ImageReview/ImageReviewEvents.setup.php
+++ b/extensions/wikia/ImageReview/ImageReviewEvents.setup.php
@@ -6,6 +6,7 @@
 
 $wgAutoloadClasses['ImageReviewEventsHooks'] = __DIR__ . '/ImageReviewEventsHooks.class.php';
 
+$wgHooks['FileUpload'][] = 'ImageReviewEventsHooks::onFileUpload';
 $wgHooks['UploadComplete'][] = 'ImageReviewEventsHooks::onUploadComplete';
 $wgHooks['FileRevertComplete'][] = 'ImageReviewEventsHooks::onFileRevertComplete';
 $wgHooks['ArticleDeleteComplete'][] = 'ImageReviewEventsHooks::onArticleDeleteComplete';

--- a/extensions/wikia/ImageReview/ImageReviewEventsHooks.class.php
+++ b/extensions/wikia/ImageReview/ImageReviewEventsHooks.class.php
@@ -2,7 +2,6 @@
 
 use Wikia\Logger\WikiaLogger;
 use Wikia\Rabbit\ConnectionBase;
-use Wikia\Tasks\Tasks\ImageReviewTask;
 
 class ImageReviewEventsHooks {
 	const ROUTING_KEY = 'image-review.mw-context.on-upload';
@@ -13,6 +12,27 @@ class ImageReviewEventsHooks {
 		$title = Title::newFromID( $form->getTitle()->getArticleID() );
 
 		self::actionCreate( $title ?? $form->getTitle() );
+
+		return true;
+	}
+
+	/**
+	 * Report all uploads
+	 *
+	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/FileUpload
+	 * @see SUS-2988
+	 *
+	 * @param LocalFile $file
+	 * @return bool
+	 */
+	public static function onFileUpload( LocalFile $file ) {
+		// SUS-2988 | log uploads and image review pushes
+		WikiaLogger::instance()->info(
+			__METHOD__,
+			[
+				'file_name' => $file->getTitle()->getPrefixedDBkey()
+			]
+		);
 
 		return true;
 	}
@@ -133,6 +153,14 @@ class ImageReviewEventsHooks {
 			];
 
 			$rabbitConnection->publish( self::ROUTING_KEY, $data );
+
+			// SUS-2988 | log uploads and image review pushes
+			WikiaLogger::instance()->info(
+				__METHOD__,
+				[
+					'file_name' => $title->getPrefixedDBkey()
+				]
+			);
 		}
 	}
 


### PR DESCRIPTION
Partial backport of #13980.

Log the following events:

* `ImageReviewEventsHooks::actionCreate` - push to image review queue
* `ImageReviewEventsHooks::onFileUpload` - image upload on the MW core level

`@context.file_name` field will be reported in both cases. This should allow us to identify all not handled upload scenarios.

https://kibana5.wikia-inc.com/goto/b32cbf963b15d23a9b9afcce32bd6701