### PR TITLE
SUS-3042 | WikiaMiniUpload uploads are not pushed to image review queue

### DIFF
--- a/extensions/wikia/ImageReview/ImageReviewEvents.setup.php
+++ b/extensions/wikia/ImageReview/ImageReviewEvents.setup.php
@@ -18,3 +18,4 @@ $wgHooks['CloseWikiPurgeSharedData'][] = 'ImageReviewEventsHooks::onCloseWikiPur
 // SUS-2988 | bind to custom hooks and add these uploads to image review queue
 $wgHooks['ThemeDesignerSaveImage'][] = 'ImageReviewEventsHooks::addTitleToTheQueue';
 $wgHooks['VisualEditorAddMedia'][] = 'ImageReviewEventsHooks::addTitleToTheQueue';
+$wgHooks['WikiaMiniUploadInsertImage'][] = 'ImageReviewEventsHooks::addTitleToTheQueue';

--- a/extensions/wikia/ImageReview/ImageReviewEventsHooks.class.php
+++ b/extensions/wikia/ImageReview/ImageReviewEventsHooks.class.php
@@ -31,7 +31,7 @@ class ImageReviewEventsHooks {
 			__METHOD__,
 			[
 				'file_name' => $file->getTitle()->getPrefixedDBkey(),
-				'caller' => wfGetCallerClassMethod( [ __CLASS__, UploadBase::class, LocalFile::class ] )
+				'caller' => wfGetCallerClassMethod( [ __CLASS__, UploadBase::class, LocalFile::class, Hooks::class ] )
 			]
 		);
 
@@ -189,7 +189,7 @@ class ImageReviewEventsHooks {
 				__METHOD__,
 				[
 					'file_name' => $title->getPrefixedDBkey(),
-					'caller' => wfGetCallerClassMethod( [ __CLASS__, UploadBase::class, LocalFile::class ] )
+					'caller' => wfGetCallerClassMethod( [ __CLASS__, UploadBase::class, LocalFile::class, Hooks::class ] )
 				]
 			);
 		}

--- a/extensions/wikia/WikiaMiniUpload/WikiaMiniUpload_body.php
+++ b/extensions/wikia/WikiaMiniUpload/WikiaMiniUpload_body.php
@@ -429,6 +429,7 @@ class WikiaMiniUpload {
 	 * @return bool|String
 	 */
 	function insertImage() {
+		/* @var WebRequest $wgRequest */
 		global $wgRequest, $wgUser, $wgContLang;
 
 		$this->assertValidRequest();
@@ -507,6 +508,10 @@ class WikiaMiniUpload {
 						$file_mwname->delete('');
 						$this->tempFileClearInfo( $tempid );
 						$newFile = false;
+
+						// SUS-3042 | push an upload to image review queue
+						Hooks::run( 'WikiaMiniUploadInsertImage', [ $file_name->getTitle() ] );
+
 					} else if ( $type == 'existing' ) {
 						$file = wfFindFile( Title::newFromText( $name, 6 ) );
 
@@ -584,6 +589,9 @@ class WikiaMiniUpload {
 					$file->upload($temp_file->getPath(), '', $caption);
 					$temp_file->delete('');
 					$this->tempFileClearInfo( $tempid );
+
+					// SUS-3042 | push an upload to image review queue
+					Hooks::run( 'WikiaMiniUploadInsertImage', [ $file->getTitle() ] );
 				}
 
 				if ( $wgUser->getGLobalPreference( 'watchdefault' ) || ( $newFile && $wgUser->getGlobalPreference( 'watchcreations' ) ) ) {


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3042

Works fine on sandbox-s2:

```
    "@context": {
      "file_name": "Plik:17545525_263633060762743_556901697057478716_o.jpg",
      "caller": "WikiaMiniUpload:insertImage"
    },
    "tags": [
      "json"
    ],
    "@message": "ImageReviewEventsHooks::actionCreate",
    "@timestamp": "2017-10-13T13:26:21.506Z",
    "appname": "mediawiki",
    "@source_host": "sandbox-s2",
```