### PR TITLE
SUS-2988 | ImageReviewEventsHooks - log LocalFile instance class

### DIFF
--- a/extensions/wikia/ImageReview/ImageReviewEventsHooks.class.php
+++ b/extensions/wikia/ImageReview/ImageReviewEventsHooks.class.php
@@ -31,7 +31,8 @@ class ImageReviewEventsHooks {
 			__METHOD__,
 			[
 				'file_name' => $file->getTitle()->getPrefixedDBkey(),
-				'caller' => wfGetCallerClassMethod( [ __CLASS__, UploadBase::class, LocalFile::class, Hooks::class ] )
+				'caller' => wfGetCallerClassMethod( [ __CLASS__, UploadBase::class, LocalFile::class, Hooks::class ] ),
+				'file_class' => get_class( $file ),
 			]
 		);
 


### PR DESCRIPTION
Want to detect uploads of "temporary" files in WikiaMiniUpload

```
"@context": {
      "caller": "WikiaPhotoGalleryUpload:uploadImage",
      "file_name": "Plik:Kociur.png",
      "file_class": "LocalFile"
    },
    "tags": [
      "json"
    ],
    "@message": "ImageReviewEventsHooks::onFileUpload",
```