### PR TITLE
Fixes to WAM UI

### DIFF
--- a/extensions/wikia/WAM/controllers/api/WAMApiController.class.php
+++ b/extensions/wikia/WAM/controllers/api/WAMApiController.class.php
@@ -110,7 +110,8 @@ class WAMApiController extends WikiaApiController {
 			[
 				'wam_index' => $wamIndex[ 'wam_index' ],
 				'wam_results_total' => $wamIndex[ 'wam_results_total' ],
-				'wam_index_date' => $wamIndex[ 'wam_index_date' ]
+				'wam_index_date' => $wamIndex[ 'wam_index_date' ],
+                'wam_actual_date' => $options['currentTimestamp']
 			],
 			[ 'urlFields' => [ 'avatarUrl', 'userPageUrl', 'userContributionsUrl' ] ],
 			self::WAM_RESPONSE_CACHE_VALIDITY

--- a/extensions/wikia/WAM/controllers/api/WAMApiController.class.php
+++ b/extensions/wikia/WAM/controllers/api/WAMApiController.class.php
@@ -111,7 +111,7 @@ class WAMApiController extends WikiaApiController {
 				'wam_index' => $wamIndex[ 'wam_index' ],
 				'wam_results_total' => $wamIndex[ 'wam_results_total' ],
 				'wam_index_date' => $wamIndex[ 'wam_index_date' ],
-                'wam_actual_date' => $options['currentTimestamp']
+				'wam_actual_date' => $options[ 'currentTimestamp' ]
 			],
 			[ 'urlFields' => [ 'avatarUrl', 'userPageUrl', 'userContributionsUrl' ] ],
 			self::WAM_RESPONSE_CACHE_VALIDITY

--- a/extensions/wikia/WAMPage/WAMPageController.class.php
+++ b/extensions/wikia/WAMPage/WAMPageController.class.php
@@ -38,6 +38,8 @@ class WAMPageController extends WikiaController
 		$this->indexWikis = $this->model->getIndexWikis( $this->getIndexParams() );
 
 		$total = ( empty( $this->indexWikis['wam_results_total'] ) ) ? 0 : $this->indexWikis['wam_results_total'];
+        $this->selectedDate = $this->indexWikis['wam_actual_date'];
+
 		$itemsPerPage = $this->model->getItemsPerPage();
 		if( $total > $itemsPerPage ) {
 			$paginator = new Paginator( $total, $itemsPerPage, $this->getUrlForPagination() );
@@ -78,26 +80,21 @@ class WAMPageController extends WikiaController
 			]
 		);
 
-		if (!empty($this->selectedDate)) {
-			$timestamp = $this->selectedDate;
+        $timestamp = $this->selectedDate;
 
-			if (!empty($filterMinMaxDates['min_date'])) {
-				$dateValidator = new WikiaValidatorCompare(['expression' => WikiaValidatorCompare::GREATER_THAN_EQUAL]);
-				if (!$dateValidator->isValid([$timestamp, $filterMinMaxDates['min_date']])) {
-					$this->selectedDate = null;
-				}
-			}
+        if (!empty($filterMinMaxDates['min_date'])) {
+            $dateValidator = new WikiaValidatorCompare(['expression' => WikiaValidatorCompare::GREATER_THAN_EQUAL]);
+            if (!$dateValidator->isValid([$timestamp, $filterMinMaxDates['min_date']])) {
+                $this->selectedDate = null;
+            }
+        }
 
-			if (!empty($filterMinMaxDates['max_date'])) {
-				$dateValidator = new WikiaValidatorCompare(['expression' => WikiaValidatorCompare::LESS_THAN_EQUAL]);
-				if (!$dateValidator->isValid([$timestamp, $filterMinMaxDates['max_date']])) {
-					$this->selectedDate = null;
-				}
-			}
-		} else {
-			// DE-1673 default to two days ago because we might not have data for today
-			$this->selectedDate = strtotime( '00:00 -2 day');
-		}
+        if (!empty($filterMinMaxDates['max_date'])) {
+            $dateValidator = new WikiaValidatorCompare(['expression' => WikiaValidatorCompare::LESS_THAN_EQUAL]);
+            if (!$dateValidator->isValid([$timestamp, $filterMinMaxDates['max_date']])) {
+                $this->selectedDate = null;
+            }
+        }
 
 		$this->filterLanguages = $this->model->getWAMLanguages( $this->selectedDate );
 

--- a/extensions/wikia/WAMPage/WAMPageController.class.php
+++ b/extensions/wikia/WAMPage/WAMPageController.class.php
@@ -142,27 +142,6 @@ class WAMPageController extends WikiaController
 		return $url;
 	}
 
-	private function redirectIfUnknownTab($currentTabIndex, $title) {
-		// we don't check here if $title is instance of Title
-		// because this method is called after this check and isWAMPage() check
-
-		if( $title->isSubpage() && !$currentTabIndex ) {
-			$this->wg->Out->redirect($this->model->getWAMSubpageUrl($title), 301);
-		}
-	}
-
-	private function redirectIfFirstTab($tabIndex, $subpageText) {
-		// we don't check here if $title is instance of Title
-		// because this method is called after this check and isWAMPage() check
-
-		$isFirstTab = ($tabIndex === WAMPageModel::TAB_INDEX_TOP_WIKIS && !empty($subpageText));
-		$mainWAMPageUrl = $this->model->getWAMMainPageUrl($this->filterParams);
-
-		if( $isFirstTab && !empty($mainWAMPageUrl) ) {
-			$this->wg->Out->redirect($mainWAMPageUrl, 301);
-		}
-	}
-
 	private function redirectIfMisspelledWamMainPage($title) {
 		// we don't check here if $title is instance of Title
 		// because this method is called after this check and isWAMPage() check

--- a/extensions/wikia/WAMPage/WAMPageController.class.php
+++ b/extensions/wikia/WAMPage/WAMPageController.class.php
@@ -38,7 +38,7 @@ class WAMPageController extends WikiaController
 		$this->indexWikis = $this->model->getIndexWikis( $this->getIndexParams() );
 
 		$total = ( empty( $this->indexWikis['wam_results_total'] ) ) ? 0 : $this->indexWikis['wam_results_total'];
-        $this->selectedDate = $this->indexWikis['wam_actual_date'];
+		$this->selectedDate = $this->indexWikis['wam_actual_date'];
 
 		$itemsPerPage = $this->model->getItemsPerPage();
 		if( $total > $itemsPerPage ) {
@@ -80,21 +80,21 @@ class WAMPageController extends WikiaController
 			]
 		);
 
-        $timestamp = $this->selectedDate;
+		$timestamp = $this->selectedDate;
 
-        if (!empty($filterMinMaxDates['min_date'])) {
-            $dateValidator = new WikiaValidatorCompare(['expression' => WikiaValidatorCompare::GREATER_THAN_EQUAL]);
-            if (!$dateValidator->isValid([$timestamp, $filterMinMaxDates['min_date']])) {
-                $this->selectedDate = null;
-            }
-        }
+		if (!empty($filterMinMaxDates['min_date'])) {
+			$dateValidator = new WikiaValidatorCompare(['expression' => WikiaValidatorCompare::GREATER_THAN_EQUAL]);
+			if (!$dateValidator->isValid([$timestamp, $filterMinMaxDates['min_date']])) {
+				$this->selectedDate = null;
+			}
+		}
 
-        if (!empty($filterMinMaxDates['max_date'])) {
-            $dateValidator = new WikiaValidatorCompare(['expression' => WikiaValidatorCompare::LESS_THAN_EQUAL]);
-            if (!$dateValidator->isValid([$timestamp, $filterMinMaxDates['max_date']])) {
-                $this->selectedDate = null;
-            }
-        }
+		if (!empty($filterMinMaxDates['max_date'])) {
+			$dateValidator = new WikiaValidatorCompare(['expression' => WikiaValidatorCompare::LESS_THAN_EQUAL]);
+			if (!$dateValidator->isValid([$timestamp, $filterMinMaxDates['max_date']])) {
+				$this->selectedDate = null;
+			}
+		}
 
 		$this->filterLanguages = $this->model->getWAMLanguages( $this->selectedDate );
 

--- a/extensions/wikia/WAMPage/js/WAMPage.js
+++ b/extensions/wikia/WAMPage/js/WAMPage.js
@@ -59,20 +59,20 @@ WAMPage.prototype = {
 					maxDate = new Date(window.wamFilterMinMaxDates.max_date * 1000);
 
 				var filterWam = function () {
-                    var $date = $('#WamFilterDate'),
-                        timestamp = parseInt($date.val(), 10);
-                    //Conversion to second epoch, which is necessary if date hasn't changed as internally ms are stored
-                    if (timestamp > 9999999999) {
-                        timestamp = timestamp / 1000;
-                    }
-                    $date.val(timestamp - new Date().getTimezoneOffset() * 60);
-                    WAMPage.trackClick('WamPage', Wikia.Tracker.ACTIONS.CLICK, 'wam-search-filter-change',
-                        null, {
-                            lang: wgContentLanguage,
-                            filter: 'date'
-                        });
-                    WAMPage.filterWamIndex($date);
-                };
+					var $date = $('#WamFilterDate'),
+						timestamp = parseInt($date.val(), 10);
+					//Conversion to second epoch, which is necessary if date hasn't changed as internally ms are stored
+					if (timestamp > 9999999999) {
+						timestamp = timestamp / 1000;
+					}
+					$date.val(timestamp - new Date().getTimezoneOffset() * 60);
+					WAMPage.trackClick('WamPage', Wikia.Tracker.ACTIONS.CLICK, 'wam-search-filter-change',
+						null, {
+							lang: wgContentLanguage,
+							filter: 'date'
+						});
+					WAMPage.filterWamIndex($date);
+				};
 
 				minDate.setMinutes(minDate.getMinutes() + minDate.getTimezoneOffset());
 				maxDate.setMinutes(maxDate.getMinutes() + maxDate.getTimezoneOffset());

--- a/extensions/wikia/WAMPage/js/WAMPage.js
+++ b/extensions/wikia/WAMPage/js/WAMPage.js
@@ -58,6 +58,22 @@ WAMPage.prototype = {
 				var minDate = new Date(window.wamFilterMinMaxDates.min_date * 1000),
 					maxDate = new Date(window.wamFilterMinMaxDates.max_date * 1000);
 
+				var filterWam = function () {
+                    var $date = $('#WamFilterDate'),
+                        timestamp = parseInt($date.val(), 10);
+                    //Conversion to second epoch, which is necessary if date hasn't changed as internally ms are stored
+                    if (timestamp > 9999999999) {
+                        timestamp = timestamp / 1000;
+                    }
+                    $date.val(timestamp - new Date().getTimezoneOffset() * 60);
+                    WAMPage.trackClick('WamPage', Wikia.Tracker.ACTIONS.CLICK, 'wam-search-filter-change',
+                        null, {
+                            lang: wgContentLanguage,
+                            filter: 'date'
+                        });
+                    WAMPage.filterWamIndex($date);
+                };
+
 				minDate.setMinutes(minDate.getMinutes() + minDate.getTimezoneOffset());
 				maxDate.setMinutes(maxDate.getMinutes() + maxDate.getTimezoneOffset());
 
@@ -69,18 +85,8 @@ WAMPage.prototype = {
 					altField: '#WamFilterDate',
 					altFormat: '@',
 					dateFormat: window.wamFilterDateFormat,
-					onSelect: $.proxy(function () {
-						var $date = $('#WamFilterDate'),
-							timestamp = parseInt($date.val(), 10),
-							currentTimezoneOffset = (new Date(timestamp)).getTimezoneOffset();
-						$date.val((timestamp / 1000) - currentTimezoneOffset * 60);
-						WAMPage.trackClick('WamPage', Wikia.Tracker.ACTIONS.CLICK, 'wam-search-filter-change',
-							null, {
-								lang: wgContentLanguage,
-								filter: 'date'
-							});
-						WAMPage.filterWamIndex($date);
-					}, this)
+					onClose: $.proxy(filterWam, this),
+					onSelect: $.proxy(filterWam, this)
 				});
 			}, this)
 		);

--- a/extensions/wikia/WAMPage/models/WAMPageModel.class.php
+++ b/extensions/wikia/WAMPage/models/WAMPageModel.class.php
@@ -110,16 +110,6 @@ class WAMPageModel extends WikiaModel {
 		$aDates = $this->app->sendRequest( 'WAMApi', 'getMinMaxWamIndexDate' )->getData();
 		if ( isset( $aDates['min_max_dates'] ) ) {
 			$aDates = $aDates['min_max_dates'];
-
-			// Add 1 to min_date, because we don't have older data
-			if ( !empty( $aDates['min_date'] ) ) {
-				$aDates['min_date'] += 60 * 60 * 24;
-			}
-
-			// Subtract 1 from max_date because we don't have future data
-			if ( !empty( $aDates['max_date'] ) ) {
-				$aDates['max_date'] -= 60 * 60 * 24;
-			}
 		} else {
 			$aDates = [
 				'min_date' => null,


### PR DESCRIPTION
Yet another attempt to improve WAMs UI. Few fixes:
- Currently when entering a different date and clicking somewhere the UI used timestamp in miliseconds instead of expected one in seconds which resulted in redirect to page with default date. Fixed that to properly interpret the timestamp
- Added setting of current date in the selector to what we actually got from the Api. This should help knowing what one is looking at in case of selecting a value out of range or when backend is missing newest data.
- Removed fallback to data from two days before, as after last fixes when there is no date or it is out of range we simply take the most recent value.

@macbre @Grunny @TK-999 
