### PR TITLE
SUS-3045 | ImageReviewEventsHooks - rely solely on FileUpload hook

### DIFF
--- a/extensions/VisualEditor/wikia/ApiAddMediaPermanent.php
+++ b/extensions/VisualEditor/wikia/ApiAddMediaPermanent.php
@@ -38,10 +38,6 @@ class ApiAddMediaPermanent extends ApiAddMedia {
 			}
 			$file = new LocalFile( $title, RepoGroup::singleton()->getLocalRepo() );
 			$file->upload( $tempFile->getPath(), '', $pageText ? $pageText : '' );
-
-			// Wikia change - notify extension when file is added via VisualEditor
-			// Standard FileUpload hook is not fired for these uploads
-			Hooks::run( 'VisualEditorAddMedia', [ $file->getTitle() ] );
 		}
 
 		return [

--- a/extensions/wikia/AchievementsII/services/AchImageUploadService.class.php
+++ b/extensions/wikia/AchievementsII/services/AchImageUploadService.class.php
@@ -232,9 +232,6 @@ class AchImageUploadService {
 		);
 		$file->upload( $badgeFile, '/* comment */', '/* page text */' );
 
-		// SUS-3048 | push an upload to image review queue
-		Hooks::run( 'AchievementsImageUpload', [ $file->getTitle() ] );
-
 		return $file;
 	}
 

--- a/extensions/wikia/ImageReview/ImageReviewEvents.setup.php
+++ b/extensions/wikia/ImageReview/ImageReviewEvents.setup.php
@@ -6,8 +6,9 @@
 
 $wgAutoloadClasses['ImageReviewEventsHooks'] = __DIR__ . '/ImageReviewEventsHooks.class.php';
 
+// SUS-3045 | Push all uploads to image review queue
 $wgHooks['FileUpload'][] = 'ImageReviewEventsHooks::onFileUpload';
-$wgHooks['UploadComplete'][] = 'ImageReviewEventsHooks::onUploadComplete';
+
 $wgHooks['FileRevertComplete'][] = 'ImageReviewEventsHooks::onFileRevertComplete';
 $wgHooks['ArticleDeleteComplete'][] = 'ImageReviewEventsHooks::onArticleDeleteComplete';
 $wgHooks['ArticleUndelete'][] = 'ImageReviewEventsHooks::onArticleUndelete';

--- a/extensions/wikia/ImageReview/ImageReviewEvents.setup.php
+++ b/extensions/wikia/ImageReview/ImageReviewEvents.setup.php
@@ -15,13 +15,5 @@ $wgHooks['OldFileDeleteComplete'][] = 'ImageReviewEventsHooks::onOldFileDeleteCo
 $wgHooks['OldImageRevisionVisibilityChange'][] = 'ImageReviewEventsHooks::onOldImageRevisionVisibilityChange';
 $wgHooks['CloseWikiPurgeSharedData'][] = 'ImageReviewEventsHooks::onCloseWikiPurgeSharedData';
 
-// SUS-2988 | bind to custom hooks and add these uploads to image review queue
-// TODO: refactor to use a generic upload handling (SUS-3045)
-$wgHooks['AchievementsImageUpload'][] = 'ImageReviewEventsHooks::addTitleToTheQueue';
-$wgHooks['ThemeDesignerSaveImage'][] = 'ImageReviewEventsHooks::addTitleToTheQueue';
-$wgHooks['VisualEditorAddMedia'][] = 'ImageReviewEventsHooks::addTitleToTheQueue';
-$wgHooks['WikiaMiniUploadInsertImage'][] = 'ImageReviewEventsHooks::addTitleToTheQueue';
-$wgHooks['WikiaPhotoGalleryUpload'][] = 'ImageReviewEventsHooks::addTitleToTheQueue';
-
 // Image Review information on file pages
 $wgHooks['ImagePageAfterImageLinks'][] = 'ImageReviewEventsHooks::onImagePageAfterImageLinks';

--- a/extensions/wikia/ImageReview/ImageReviewEventsHooks.class.php
+++ b/extensions/wikia/ImageReview/ImageReviewEventsHooks.class.php
@@ -47,21 +47,16 @@ class ImageReviewEventsHooks {
 		return true;
 	}
 
-	public static function onUploadComplete( UploadBase $form ) {
-		// $form->getTitle() returns Title object with not updated latestRevisionId when uploading new revision
-		// of the file
-		$title = Title::newFromID( $form->getTitle()->getArticleID() );
-
-		self::actionCreate( $title ?? $form->getTitle() );
-
-		return true;
-	}
-
 	/**
-	 * Report all uploads
+	 * Push all uploads to image review queue.
+	 *
+	 * This binds to FileUpload hook and handles all uploads instead of custom hooks introduced on-per feature basis.
+	 *
+	 * self::actionCreate is still going to perform a check if uploaded file is an image that should pass the review.
 	 *
 	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/FileUpload
 	 * @see SUS-2988
+	 * @see SUS-3045
 	 *
 	 * @param LocalFile $file
 	 * @return bool
@@ -76,6 +71,8 @@ class ImageReviewEventsHooks {
 				'file_class' => get_class( $file ),
 			]
 		);
+
+		self::actionCreate( $file->getTitle() );
 
 		return true;
 	}

--- a/extensions/wikia/ThemeDesigner/ThemeSettings.class.php
+++ b/extensions/wikia/ThemeDesigner/ThemeSettings.class.php
@@ -243,9 +243,6 @@ class ThemeSettings {
 			$callback();
 		}
 
-		// SUS-3044 | push an upload to image review queue
-		Hooks::run( 'ThemeDesignerSaveImage', [ $file->getTitle() ] );
-
 		$file->repo->forceMaster();
 
 		/* @var OldLocalFile[] $history */

--- a/extensions/wikia/WikiaMiniUpload/WikiaMiniUpload_body.php
+++ b/extensions/wikia/WikiaMiniUpload/WikiaMiniUpload_body.php
@@ -508,10 +508,6 @@ class WikiaMiniUpload {
 						$file_mwname->delete('');
 						$this->tempFileClearInfo( $tempid );
 						$newFile = false;
-
-						// SUS-3042 | push an upload to image review queue
-						Hooks::run( 'WikiaMiniUploadInsertImage', [ $file_name->getTitle() ] );
-
 					} else if ( $type == 'existing' ) {
 						$file = wfFindFile( Title::newFromText( $name, 6 ) );
 
@@ -589,9 +585,6 @@ class WikiaMiniUpload {
 					$file->upload($temp_file->getPath(), '', $caption);
 					$temp_file->delete('');
 					$this->tempFileClearInfo( $tempid );
-
-					// SUS-3042 | push an upload to image review queue
-					Hooks::run( 'WikiaMiniUploadInsertImage', [ $file->getTitle() ] );
 				}
 
 				if ( $wgUser->getGLobalPreference( 'watchdefault' ) || ( $newFile && $wgUser->getGlobalPreference( 'watchcreations' ) ) ) {

--- a/extensions/wikia/WikiaPhotoGallery/WikiaPhotoGalleryUpload.class.php
+++ b/extensions/wikia/WikiaPhotoGallery/WikiaPhotoGalleryUpload.class.php
@@ -102,9 +102,6 @@ class WikiaPhotoGalleryUpload extends WikiaTempFilesUpload{
 				// perform upload
 				$result = $imageFile->upload( $imagePath, '' /* comment */, '' /* page text */);
 
-				// SUS-3043 | push an upload to image review queue
-				Hooks::run( 'WikiaPhotoGalleryUpload', [ $imageFile->getTitle() ] );
-
 				$this->log( __METHOD__, !empty( $result->ok ) ? 'upload successful' : 'upload failed' );
 
 				$ret = array(


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3045

Remove all custom upload hooks introduced by P2 fixes and use [`FileUpload`](https://www.mediawiki.org/wiki/Manual:Hooks/FileUpload) hook only.