### PR TITLE
SUS-3063 | Log all cases where Database::tableName returns wikicities_cX.user

### DIFF
--- a/includes/db/Database.php
+++ b/includes/db/Database.php
@@ -2201,6 +2201,12 @@ abstract class DatabaseBase implements DatabaseType {
 		 && in_array( $table, $wgSharedTables ) ) { # A shared table is selected
 			$database = $wgSharedDB;
 			$prefix   = isset( $wgSharedPrefix ) ? $wgSharedPrefix : $prefix;
+
+			// SUS-3063 | Log all cases where Database::tableName returns wikicities_cX.user
+			WikiaLogger::instance()->warning( __METHOD__ . '::addSharedPrefix', [
+				'table_name' => $table,
+				'caller' => wfGetCallerClassMethod( [ __CLASS__, DatabaseMysqlBase::class, DatabaseMysqli::class ]  ),
+			] );
 		}
 
 		# Quote the $database and $table and apply the prefix if not quoted.


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3065

Avoid bugs like #14029

## Example log entry

```json
{"appname":"eval.php","@timestamp":"2017-10-18T13:00:17.307377+00:00","@message":"DatabaseBase::tableName::addSharedPrefix","@fields":{"app_name":"mediawiki","app_version":"SUS-3063","datacenter":"sjc","environment":"prod","wiki_dbname":"wikia","wiki_id":"177","maintenance_file":"/home/macbre/app/maintenance/eval.php","maintenance_class":"CommandLineInc","client_ip":"127.0.0.1","span_id":"3aa3a38e-f090-4b8b-885a-6263f53e986a","trace_id":"d8493ada-dfdf-4e6d-9057-3654ac196e5e"},"@exception":{"class":"Exception","message":"","code":0,"file":"/home/macbre/app/lib/Wikia/src/Logger/WikiaLogger.php:170","trace":["/home/macbre/app/lib/Wikia/src/Logger/WikiaLogger.php:142","/home/macbre/app/includes/db/Database.php:2208","/home/macbre/app/maintenance/eval.php(88) : eval()'d code:1","/home/macbre/app/maintenance/eval.php:88"]},"@context":{"table_name":"user","caller":""}}
```