### PR TITLE
SUS-3066 | tag_summary per-wiki table no longer needed

### DIFF
--- a/includes/wikia/WikiaUpdater.php
+++ b/includes/wikia/WikiaUpdater.php
@@ -64,6 +64,7 @@ class WikiaUpdater {
 			array( 'WikiaUpdater::do_transcache_update' ),
 			array( 'dropField', 'interwiki', 'iw_api', $dir . 'patch-drop-iw_api.sql', true ),
 			array( 'dropField', 'interwiki', 'iw_wikiid', $dir . 'patch-drop-wikiid.sql', true ),
+			array( 'WikiaUpdater::do_drop_table', 'tag_summary' ), // SUS-3066
 		);
 
 		if ( $wgDBname === $wgExternalSharedDB ) {

--- a/maintenance/tables.sql
+++ b/maintenance/tables.sql
@@ -1345,25 +1345,6 @@ CREATE UNIQUE INDEX /*i*/change_tag_rev_tag ON /*_*/change_tag (ct_rev_id,ct_tag
 CREATE INDEX /*i*/change_tag_tag_id ON /*_*/change_tag (ct_tag,ct_rc_id,ct_rev_id,ct_log_id);
 
 
--- Rollup table to pull a LIST of tags simply without ugly GROUP_CONCAT
--- that only works on MySQL 4.1+
-CREATE TABLE /*_*/tag_summary (
-  ts_id int unsigned NOT NULL PRIMARY KEY AUTO_INCREMENT,
-  -- RCID for the change
-  ts_rc_id int NULL,
-  -- LOGID for the change
-  ts_log_id int NULL,
-  -- REVID for the change
-  ts_rev_id int NULL,
-  -- Comma-separated list of tags
-  ts_tags blob NOT NULL
-) /*$wgDBTableOptions*/;
-
-CREATE UNIQUE INDEX /*i*/tag_summary_rc_id ON /*_*/tag_summary (ts_rc_id);
-CREATE UNIQUE INDEX /*i*/tag_summary_log_id ON /*_*/tag_summary (ts_log_id);
-CREATE UNIQUE INDEX /*i*/tag_summary_rev_id ON /*_*/tag_summary (ts_rev_id);
-
-
 CREATE TABLE /*_*/valid_tag (
   vt_tag varchar(255) NOT NULL PRIMARY KEY
 ) /*$wgDBTableOptions*/;


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3066

* remove it from maintenance/tables.sql schema used when creating new wikis
* add an entry in WikiaUpdater to remove the table when update.php is run

Only these queries are run for this table:

```sql
$ query_digest --table tag_summary --simple --last-24h
...
2017-10-19 07:25:44 query_digest                        INFO     Processing 15 queries from the last 24 hour(s)...
2017-10-19 07:25:44 query_digest                        INFO     Got 2 kinds of queries
Query digest for "tag_summary" table, found 15 queries
DatabaseBase::sourceFile( /usr/wikia/slot1/20116/src/maintenance/tables.sql ) 86.67% [ap] db:codenamewikisteam | CREATE UNIQUE INDEX tag_summary_rc_id ON `tag_summary` (ts_rc_id)
DatabaseBase::sourceFile( /usr/wikia/slot1/20056/src/maintenance/tables.sql ) 13.33% [ap] db:et2ilmasoda | CREATE TABLE `tag_summary` ( ts_id int unsigned NOT NULL PRIMARY KEY AUTO_INCREMENT, ts_rc_id int NULL, ts_log_id int NULL, ts_rev_id int NULL, ts_tags blob NOT NULL ) ENGINE=InnoDB
```

`update.php` removes the table:

```
macbre@sandbox-s2:~$ run_maintenance --db macbre --script="update,php --quick"
...
Checking wikia tag_summary table...
...dropping tag_summary table... ok
```