### PR TITLE
SUS-3090 | shared_newtalks database keeps archive notifications from 2007

### DIFF
--- a/extensions/wikia/WikiaNewtalk/maintenance/cleanupWikiaSharedTalk.php
+++ b/extensions/wikia/WikiaNewtalk/maintenance/cleanupWikiaSharedTalk.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Script that removes wikicities.shared_newtalks entries that are older than 90 days
+ *
+ * @see SUS-3090
+ * @author macbre
+ * @file
+ * @ingroup Maintenance
+ */
+
+require_once( __DIR__ . '/../../../../maintenance/commandLine.inc' );
+
+$db = wfGetDB( DB_MASTER, [], $wgExternalSharedDB );
+$rows = 0;
+
+do {
+
+	// delete entries older than 90 days in small batches
+	$db->query( 'DELETE FROM shared_newtalks WHERE sn_date < NOW() - INTERVAL 90 DAY LIMIT 500', __FILE__ );
+	$affectedRows = $db->affectedRows();
+
+	$rows +=  $affectedRows;
+
+	wfWaitForSlaves( $db->getDBname() );
+
+} while ( $affectedRows > 0 );
+
+echo sprintf( "%s: dropped %d rows from shared_newtalks\n", date( 'r' ), $rows );


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3090

Let's periodically remove entries older than 90 days:

```sql
mysql@geo-db-sharedb-slave.query.consul[wikicities]>select count(*) from shared_newtalks where sn_date < NOW() - INTERVAL 90 DAY;
+----------+
| count(*) |
+----------+
|   989199 |
+----------+
1 row in set (1.57 sec)

mysql@geo-db-sharedb-slave.query.consul[wikicities]>select count(*) from shared_newtalks;
+----------+
| count(*) |
+----------+
|  1004981 |
+----------+
1 row in set (0.15 sec)
```

Run the following query until affected rows drop to zero:

```sql
DELETE FROM shared_newtalks WHERE sn_date < NOW() - INTERVAL 90 DAY LIMIT 500
```