### PR TITLE
SUS-3089 | use varbinary for IP addresses

### DIFF
--- a/extensions/wikia/WikiaNewtalk/wikia_newtalk.php
+++ b/extensions/wikia/WikiaNewtalk/wikia_newtalk.php
@@ -77,11 +77,20 @@ function wfSetWikiaNewtalk( WikiPage $article ): bool {
         /**
 		 * then insert
 		 */
-		$dbw->insert(
-            "shared_newtalks",
-            wfBuildNewtalkWhereCondition( $other, true ),
-            __METHOD__
-        );
+	    $dbw->insert(
+		    "shared_newtalks",
+		    // TODO: bring back wfBuildNewtalkWhereCondition for anon as well, when the migration is completed (SUS-3089)
+		    $other->isAnon()
+		    ?
+		    [
+			    'sn_wiki' => wfWikiID(),
+			    'sn_user_ip' => $other->getName(),
+			    'sn_anon_ip' => inet_pton( $other->getName() ),
+		    ]
+		    :
+		    wfBuildNewtalkWhereCondition( $other, true ),
+		    __METHOD__
+	    );
         $dbw->commit();
 		$wgMemc->delete( wfWikiaNewTalkMemcKey( $other ) );
 	}

--- a/maintenance/wikia/sql/wikicities-schema.sql
+++ b/maintenance/wikia/sql/wikicities-schema.sql
@@ -486,11 +486,13 @@ CREATE TABLE `shared_newtalks` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `sn_user_id` int(5) unsigned DEFAULT NULL,
   `sn_user_ip` varchar(255) DEFAULT '',
+  `sn_anon_ip` varbinary(16) DEFAULT NULL,
   `sn_wiki` varchar(31) DEFAULT NULL,
   `sn_date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
   KEY `idx_user_ip_wiki` (`sn_user_ip`,`sn_wiki`),
-  KEY `idx_user_id_wiki` (`sn_user_id`,`sn_wiki`)
+  KEY `idx_user_id_wiki` (`sn_user_id`,`sn_wiki`),
+  KEY `sn_user_id_sn_user_ip_sn_wiki_idx` (`sn_user_id`,`sn_user_ip`,`sn_wiki`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 --
@@ -675,4 +677,4 @@ CREATE TABLE `wikia_tasks_log` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 
--- Dump completed on 2017-10-20 14:09:30
+-- Dump completed on 2017-10-23 14:46:55


### PR DESCRIPTION
Insert both formats of IP - as a string and binary (using inet_pton)

```sql
Query wikicities (DB user: wikia_maint) (11) (master): INSERT /* wfSetWikiaNewtalk CommandLineInc - da12344b-1436-4bf7-b3cf-a62ec6249c42 */  INTO `shared_newtalks` (sn_wiki,sn_user_ip,sn_anon_ip) VALUES ('plpoznan','56.78.97.1','8Na ')

mysql@geo-db-dev-db-slave.query.consul[wikicities]>SELECT sn_user_id, sn_user_ip, INET6_NTOA(sn_anon_ip), sn_date FROM shared_newtalks  ;
+------------+---------------------+------------------------+---------------------+
| sn_user_id | sn_user_ip          | INET6_NTOA(sn_anon_ip) | sn_date             |
+------------+---------------------+------------------------+---------------------+
|       NULL | 127.0.0.1           | 127.0.0.1              | 2017-10-23 14:21:39 |
|       NULL | 56.78.97.1          | 56.78.97.1             | 2017-10-23 14:23:44 |
|     119245 |                     | NULL                   | 2017-10-23 14:24:07 |
+------------+---------------------+------------------------+---------------------+
4 rows in set, 1 warning (0.00 sec)
```

Let's wait for this being run on production, we can then rely solely on `sn_anon_ip` column and drop `sn_user_ip`.