### PR TITLE
SUS-1697: Don't let robots index api.php

### DIFF
--- a/includes/api/ApiFormatBase.php
+++ b/includes/api/ApiFormatBase.php
@@ -155,6 +155,8 @@ abstract class ApiFormatBase extends ApiBase {
 <!DOCTYPE HTML>
 <html>
 <head>
+	<!-- SUS-1697: robots have no reason to index this page -->
+	<meta name="robots" content="noindex,nofollow" />
 <?php if ( $this->mUnescapeAmps ) {
 ?>	<title>MediaWiki API</title>
 <?php } else {


### PR DESCRIPTION
It's very annoying to try to filter out bot noise when determining if some endpoint is still in use.

https://wikia-inc.atlassian.net/browse/SUS-1697