### PR TITLE
PHPUnit 6.4.2 -> 6.4.3

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2627,16 +2627,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.4.2",
+            "version": "6.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "ae6e2e062ff55263c7b04374c190aca45872b26a"
+                "reference": "06b28548fd2b4a20c3cd6e247dc86331a7d4db13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/ae6e2e062ff55263c7b04374c190aca45872b26a",
-                "reference": "ae6e2e062ff55263c7b04374c190aca45872b26a",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/06b28548fd2b4a20c3cd6e247dc86331a7d4db13",
+                "reference": "06b28548fd2b4a20c3cd6e247dc86331a7d4db13",
                 "shasum": ""
             },
             "require": {
@@ -2707,7 +2707,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-10-15T06:16:19+00:00"
+            "time": "2017-10-16T13:18:59+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",

--- a/lib/composer/composer/installed.json
+++ b/lib/composer/composer/installed.json
@@ -4547,17 +4547,17 @@
     },
     {
         "name": "phpunit/phpunit",
-        "version": "6.4.2",
-        "version_normalized": "6.4.2.0",
+        "version": "6.4.3",
+        "version_normalized": "6.4.3.0",
         "source": {
             "type": "git",
             "url": "https://github.com/sebastianbergmann/phpunit.git",
-            "reference": "ae6e2e062ff55263c7b04374c190aca45872b26a"
+            "reference": "06b28548fd2b4a20c3cd6e247dc86331a7d4db13"
         },
         "dist": {
             "type": "zip",
-            "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/ae6e2e062ff55263c7b04374c190aca45872b26a",
-            "reference": "ae6e2e062ff55263c7b04374c190aca45872b26a",
+            "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/06b28548fd2b4a20c3cd6e247dc86331a7d4db13",
+            "reference": "06b28548fd2b4a20c3cd6e247dc86331a7d4db13",
             "shasum": ""
         },
         "require": {
@@ -4596,7 +4596,7 @@
             "ext-xdebug": "*",
             "phpunit/php-invoker": "^1.1"
         },
-        "time": "2017-10-15T06:16:19+00:00",
+        "time": "2017-10-16T13:18:59+00:00",
         "bin": [
             "phpunit"
         ],

--- a/lib/composer/phpunit/phpunit/ChangeLog-6.4.md
+++ b/lib/composer/phpunit/phpunit/ChangeLog-6.4.md
@@ -2,6 +2,12 @@
 
 All notable changes of the PHPUnit 6.4 release series are documented in this file using the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
+## [6.4.3] - 2017-10-16
+
+### Fixed
+
+* Fixed [#2811](https://github.com/sebastianbergmann/phpunit/issues/2811): `expectExceptionMessage()` does not work without `expectException()`
+
 ## [6.4.2] - 2017-10-15
 
 ### Fixed
@@ -38,6 +44,7 @@ All notable changes of the PHPUnit 6.4 release series are documented in this fil
 
 * Fixed [#2750](https://github.com/sebastianbergmann/phpunit/issues/2750): Useless call to `array_map()`
 
+[6.4.3]: https://github.com/sebastianbergmann/phpunit/compare/6.4.2...6.4.3
 [6.4.2]: https://github.com/sebastianbergmann/phpunit/compare/6.4.1...6.4.2
 [6.4.1]: https://github.com/sebastianbergmann/phpunit/compare/6.4.0...6.4.1
 [6.4.0]: https://github.com/sebastianbergmann/phpunit/compare/6.3...6.4.0

--- a/lib/composer/phpunit/phpunit/src/Framework/TestCase.php
+++ b/lib/composer/phpunit/phpunit/src/Framework/TestCase.php
@@ -1069,33 +1069,15 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
 
         try {
             $testResult = $method->invokeArgs($this, $testArguments);
-        } catch (Throwable $_e) {
-            $e = $_e;
+        } catch (Throwable $t) {
+            $exception = $t;
         }
 
-        if (isset($e)) {
-            $checkException = false;
-
-            if (!($e instanceof SkippedTestError) && \is_string($this->expectedException)) {
-                $checkException = true;
-
-                if ($e instanceof Exception) {
-                    $checkException = false;
-                }
-
-                $reflector = new ReflectionClass($this->expectedException);
-
-                if ($this->expectedException === 'PHPUnit\Framework\Exception' ||
-                    $this->expectedException === '\PHPUnit\Framework\Exception' ||
-                    $reflector->isSubclassOf('PHPUnit\Framework\Exception')) {
-                    $checkException = true;
-                }
-            }
-
-            if ($checkException) {
+        if (isset($exception)) {
+            if ($this->checkExceptionExpectations($exception)) {
                 if ($this->expectedException !== null) {
                     $this->assertThat(
-                        $e,
+                        $exception,
                         new ExceptionConstraint(
                             $this->expectedException
                         )
@@ -1104,7 +1086,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
 
                 if ($this->expectedExceptionMessage !== null) {
                     $this->assertThat(
-                        $e,
+                        $exception,
                         new ExceptionMessage(
                             $this->expectedExceptionMessage
                         )
@@ -1113,7 +1095,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
 
                 if ($this->expectedExceptionMessageRegExp !== null) {
                     $this->assertThat(
-                        $e,
+                        $exception,
                         new ExceptionMessageRegularExpression(
                             $this->expectedExceptionMessageRegExp
                         )
@@ -1122,7 +1104,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
 
                 if ($this->expectedExceptionCode !== null) {
                     $this->assertThat(
-                        $e,
+                        $exception,
                         new ExceptionCode(
                             $this->expectedExceptionCode
                         )
@@ -1132,7 +1114,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
                 return;
             }
 
-            throw $e;
+            throw $exception;
         }
 
         if ($this->expectedException !== null) {
@@ -2508,5 +2490,30 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
         }
 
         $this->locale = [];
+    }
+
+    private function checkExceptionExpectations(Throwable $throwable): bool
+    {
+        $result = false;
+
+        if ($this->expectedException !== null || $this->expectedExceptionCode !== null || $this->expectedExceptionMessage !== null || $this->expectedExceptionMessageRegExp !== null) {
+            $result = true;
+        }
+
+        if ($throwable instanceof Exception) {
+            $result = false;
+        }
+
+        if (\is_string($this->expectedException)) {
+            $reflector = new ReflectionClass($this->expectedException);
+
+            if ($this->expectedException === 'PHPUnit\Framework\Exception' ||
+                $this->expectedException === '\PHPUnit\Framework\Exception' ||
+                $reflector->isSubclassOf('PHPUnit\Framework\Exception')) {
+                $result = true;
+            }
+        }
+
+        return $result;
     }
 }

--- a/lib/composer/phpunit/phpunit/src/Runner/Version.php
+++ b/lib/composer/phpunit/phpunit/src/Runner/Version.php
@@ -32,7 +32,7 @@ class Version
         }
 
         if (self::$version === null) {
-            $version       = new VersionId('6.4.2', \dirname(\dirname(__DIR__)));
+            $version       = new VersionId('6.4.3', \dirname(\dirname(__DIR__)));
             self::$version = $version->getVersion();
         }
 

--- a/lib/composer/phpunit/phpunit/tests/Regression/GitHub/2811.phpt
+++ b/lib/composer/phpunit/phpunit/tests/Regression/GitHub/2811.phpt
@@ -1,0 +1,20 @@
+--TEST--
+GH-2811: expectExceptionMessage() does not work without expectException()
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = 'Issue2811Test';
+$_SERVER['argv'][3] = __DIR__ . '/2811/Issue2811Test.php';
+
+require __DIR__ . '/../../bootstrap.php';
+
+PHPUnit\TextUI\Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+OK (1 test, 1 assertion)

--- a/lib/composer/phpunit/phpunit/tests/Regression/GitHub/2811/Issue2811Test.php
+++ b/lib/composer/phpunit/phpunit/tests/Regression/GitHub/2811/Issue2811Test.php
@@ -1,0 +1,10 @@
+<?php
+class Issue2811Test extends PHPUnit\Framework\TestCase
+{
+    public function testOne()
+    {
+        $this->expectExceptionMessage('hello');
+
+        throw new \Exception('hello');
+    }
+}


### PR DESCRIPTION
[Changelog](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.4.md#643---2017-10-16)
```
$ composer update phpunit/phpunit
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 0 installs, 1 update, 0 removals
  - Updating phpunit/phpunit (6.4.2 => 6.4.3): Downloading (100%)
Writing lock file
Generating optimized autoload files
```