### PR TITLE
ADEN-6110 Fix outstream on Safari

### DIFF
--- a/extensions/wikia/AdEngine/js/video/player/ui/dynamicReveal.js
+++ b/extensions/wikia/AdEngine/js/video/player/ui/dynamicReveal.js
@@ -16,7 +16,7 @@ define('ext.wikia.adEngine.video.player.ui.dynamicReveal', [
 		if (params.isDynamic) {
 			slot = doc.getElementById(params.slotName);
 
-			video.addEventListener('start', function () {
+			video.addEventListener('loaded', function () {
 				if (!slotExpanded) {
 					slotTweaker.expand(params.slotName);
 					slotExpanded = true;


### PR DESCRIPTION
It turns out that event `started` is not fired until video player is visible on Safari 11