### PR TITLE
SUS-3109: Provide a way to query for users that are members of some group(s)

### DIFF
--- a/includes/api/wikia/ApiQueryUserGroupMembers.php
+++ b/includes/api/wikia/ApiQueryUserGroupMembers.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * SUS-3109: API module to get users who are members of some user group
+ */
+class ApiQueryUserGroupMembers extends ApiQueryBase {
+	use \Wikia\Service\User\Permissions\PermissionsServiceAccessor;
+
+	public function __construct( ApiBase $query, $moduleName ) {
+		parent::__construct( $query, $moduleName, 'gm' );
+	}
+
+	public function execute() {
+		$params = $this->extractRequestParams();
+
+		if ( empty( $params['groups'] ) ) {
+			$this->dieUsageMsg( [ 'missingparam', 'groups' ] );
+		}
+
+		$groupMembers = $this->permissionsService()->getUsersInGroups( $params['groups'] );
+		ksort( $groupMembers );
+		$userNames = User::whoAre( array_keys( $groupMembers ) );
+
+		$result = $this->getResult();
+		$count = 0;
+
+		foreach ( $groupMembers as $userId => $userGroups ) {
+			// If the offset param is set, we must display only results that come after it
+			if ( !empty( $params['offset'] ) && $userId < $params['offset'] ) {
+				continue;
+			}
+
+			$count++;
+			if ( $count > $params['limit'] ) {
+				$this->setContinueEnumParameter( 'offset', $userId );
+				break;
+			}
+
+			$row = [
+				'userid' => $userId,
+				'name' => $userNames[$userId],
+				'groups' => $userGroups
+			];
+
+			$result->setIndexedTagName( $row['groups'], 'g' );
+
+			if ( !$result->addValue( 'users', null, $row ) ) {
+				$this->setContinueEnumParameter( 'offset', $userId );
+				break;
+			}
+		}
+
+		$result->setIndexedTagName_internal( 'users', 'user' );
+	}
+
+	protected function getAllowedParams() {
+		return [
+			'groups' => [
+				ApiBase::PARAM_REQUIRED => true,
+				ApiBase::PARAM_ISMULTI => true,
+			],
+			'offset' => [
+				ApiBase::PARAM_TYPE => 'integer',
+			],
+			'limit' => [
+				ApiBase::PARAM_DFLT => 10,
+				ApiBase::PARAM_TYPE => 'limit',
+				ApiBase::PARAM_MIN => 1,
+				ApiBase::PARAM_MAX => ApiBase::LIMIT_BIG1,
+				ApiBase::PARAM_MAX2 => ApiBase::LIMIT_BIG2,
+			],
+		];
+	}
+
+	public function getCacheMode( $params ) {
+		return 'anon-public user-private';
+	}
+
+	protected function getParamDescription() {
+		return [
+			'groups' => 'List of user groups whose members to get',
+			'offset' => 'Optional offset user ID parameter for paging',
+			'limit' => 'Maximum number of results to return'
+		];
+	}
+
+	public function getExamples() {
+		return [
+			'api.php?action=query&list=groupmembers&gmgroups=vstf|staff&gmlimit=15',
+			'api.php?action=query&list=groupmembers&gmgroups=sysop&gmoffset=999&',
+		];
+	}
+
+	protected function getDescription() {
+		return 'Get users who are members of one of the given group(s).';
+	}
+
+	public function getVersion() {
+		return __CLASS__ . '-v1';
+	}
+}

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -496,6 +496,7 @@ $wgAutoloadClasses[ "WikiFactoryTags"               ] = "$IP/extensions/wikia/Wi
 $wgAutoloadClasses[ "WikiaApiQueryAllUsers"         ] = "$IP/extensions/wikia/WikiaApi/WikiaApiQueryAllUsers.php";
 $wgAutoloadClasses[ "ApiFetchBlob"                  ] = "$IP/includes/api/wikia/ApiFetchBlob.php";
 $wgAutoloadClasses[ "ApiLicenses"                   ] = "$IP/includes/wikia/api/ApiLicenses.php";
+$wgAutoloadClasses['ApiQueryUserGroupMembers'] = "$IP/includes/api/wikia/ApiQueryUserGroupMembers.php";
 
 /**
  * validators
@@ -538,7 +539,7 @@ $wgAutoloadClasses['GlobalVarConfig'] = $IP . '/includes/config/GlobalVarConfig.
 global $wgAPIListModules;
 $wgAPIListModules[ "wkdomains"    ] = "WikiaApiQueryDomains";
 $wgAPIListModules[ "wkpoppages"   ] = "WikiaApiQueryPopularPages";
-
+$wgAPIListModules['groupmembers'] = 'ApiQueryUserGroupMembers';
 
 /**
  * registered API methods

--- a/lib/Wikia/src/Service/User/Permissions/PermissionsService.php
+++ b/lib/Wikia/src/Service/User/Permissions/PermissionsService.php
@@ -63,7 +63,7 @@ interface PermissionsService
      */
     public function getPermissions( \User $user );
 
-	public function getUsersInGroups( array $groups ): \UserArray;
+	public function getUsersInGroups( array $groups ): array;
 
     /**
      * Returns an array of groups that this user can add and remove

--- a/lib/Wikia/src/Service/User/Permissions/PermissionsService.php
+++ b/lib/Wikia/src/Service/User/Permissions/PermissionsService.php
@@ -63,6 +63,8 @@ interface PermissionsService
      */
     public function getPermissions( \User $user );
 
+	public function getUsersInGroups( array $groups ): \UserArray;
+
     /**
      * Returns an array of groups that this user can add and remove
      * @param \User $userPerformingChange


### PR DESCRIPTION
`events_local_users` sucks in many ways. Instead of using it and `WikiaApiQueryAllUsers` class, provide a way for clients to easily query for user group members. Then the relevant functionality can be gone from `WikiaApiQueryAllUsers`.

https://wikia-inc.atlassian.net/browse/SUS-3109

## Sample output
```
{"users":[{"userid":8,"name":"Sannse","groups":["staff"]},{"userid":13,"name":"Jimbo Wales","groups":["staff"]},{"userid":10370,"name":"Toughpigs","groups":["staff"]},{"userid":11001,"name":"Merrystar","groups":["staff"]},{"userid":11536,"name":"Grunny","groups":["staff"]},{"userid":20251,"name":"Gil","groups":["staff"]},{"userid":20644,"name":"Brandon Rhea","groups":["staff"]},{"userid":22224,"name":"DaNASCAT","groups":["staff"]},{"userid":22439,"name":"Wikia","groups":["staff"]},{"userid":22460,"name":"Sulfur","groups":["vstf"]},{"userid":23865,"name":"TOR","groups":["staff","vstf"]},{"userid":38903,"name":"BillK","groups":["staff"]},{"userid":51098,"name":"Eloy.wikia","groups":["staff"]},{"userid":51654,"name":"Inez","groups":["staff"]},{"userid":52915,"name":"Deltaneos","groups":["vstf"]}],"query-continue":{"groupmembers":{"gmoffset":60069}}}
```