### PR TITLE
IRIS-5114 | Ignore reason field 

### DIFF
--- a/extensions/wikia/Discussions/maintenance/WallHistoryFinder.php
+++ b/extensions/wikia/Discussions/maintenance/WallHistoryFinder.php
@@ -10,7 +10,6 @@ class WallHistoryFinder {
 		'comment_id',
 		'deleted_or_removed',
 		'event_date',
-		'reason',
 		'action',
 		'is_reply',
 		'post_user_id',


### PR DESCRIPTION
The field can often contains malformed data and is not used in the migration process.