### PR TITLE
XW-4179 | show controls on vpaid ads

### DIFF
--- a/extensions/wikia/ArticleVideo/scripts/featured-video.jwplayer.instant.js
+++ b/extensions/wikia/ArticleVideo/scripts/featured-video.jwplayer.instant.js
@@ -64,7 +64,8 @@ require([
 		playerInstance.setup({
 			advertising: {
 				autoplayadsmuted: willAutoplay,
-				client: 'googima'
+				client: 'googima',
+				vpaidcontrols: true
 			},
 			autostart: willAutoplay && !document.hidden,
 			description: videoDetails.description,

--- a/extensions/wikia/ArticleVideo/styles/jwplayer-overrides.scss
+++ b/extensions/wikia/ArticleVideo/styles/jwplayer-overrides.scss
@@ -49,10 +49,10 @@
 	&.jw-flag-user-inactive.jw-state-buffering {
 		&.jw-flag-ads-vpaid-controls:not(:hover):not(.jw-flag-media-audio):not(.jw-flag-audio-player):not(.jw-flag-casting) {
 			.jw-controlbar {
-				visibility: hidden;
-				pointer-events: none;
 				opacity: 0;
+				pointer-events: none;
 				transition-delay: 0s, 250ms;
+				visibility: hidden;
 			}
 
 			.jw-controls-backdrop {

--- a/extensions/wikia/ArticleVideo/styles/jwplayer-overrides.scss
+++ b/extensions/wikia/ArticleVideo/styles/jwplayer-overrides.scss
@@ -41,6 +41,25 @@
 			display: none !important;
 		}
 	}
+
+	// hides controls on vpaid ads when player is not hovered
+	&.jw-flag-ads-vpaid,
+	&.jw-flag-autostart,
+	&.jw-flag-user-inactive.jw-state-playing,
+	&.jw-flag-user-inactive.jw-state-buffering {
+		&.jw-flag-ads-vpaid-controls:not(:hover):not(.jw-flag-media-audio):not(.jw-flag-audio-player):not(.jw-flag-casting) {
+			.jw-controlbar {
+				visibility: hidden;
+				pointer-events: none;
+				opacity: 0;
+				transition-delay: 0s, 250ms;
+			}
+
+			.jw-controls-backdrop {
+				opacity: 0;
+			}
+		}
+	}
 }
 
 // if both .is-collapsed & is-collapsed-ready are added it means animation is in progress and we do not want to show title and controls


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/XW-4179
@Wikia/x-wing

Waiting for decision, if we want to show controls on vpaid ads. 
If the VPAID creative has built-in controls, showing the controls may be redundant