### PR TITLE
SUS-3111 | add msg_recipient_user_id column to messages_text table

### DIFF
--- a/extensions/wikia/SiteWideMessages/SpecialSiteWideMessages_body.php
+++ b/extensions/wikia/SiteWideMessages/SpecialSiteWideMessages_body.php
@@ -513,13 +513,14 @@ class SiteWideMessages extends SpecialPage {
 			$DB = wfGetDB( DB_MASTER, array(), $wgExternalSharedDB );
 			$dbResult = (boolean)$DB->Query (
 				  'INSERT INTO ' . MSG_TEXT_DB
-				. ' (msg_sender_id, msg_text, msg_mode, msg_expire, msg_recipient_name, msg_group_name, msg_wiki_name, msg_hub_id, msg_lang, msg_cluster_id)'
+				. ' (msg_sender_id, msg_text, msg_mode, msg_expire, msg_recipient_name, msg_recipient_user_id, msg_group_name, msg_wiki_name, msg_hub_id, msg_lang, msg_cluster_id)'
 				. ' VALUES ('
 				. $DB->AddQuotes($mSender->GetID()). ', '
 				. $DB->AddQuotes($mText) . ', '
 				. ($sendToAll ? MSG_MODE_ALL : MSG_MODE_SELECTED) . ', '
 				. $DB->AddQuotes($mExpire) . ', '
 				. $DB->AddQuotes($mRecipientName) . ', '
+				. ( User::idFromName($mRecipientName) ?: 'NULL' ) . ', ' # SUS-3111
 				. $DB->AddQuotes($mGroupName) . ', '
 				. $DB->AddQuotes($mWikiName) . ', '
 				. $DB->AddQuotes($mHubId) . ' , '
@@ -973,7 +974,7 @@ class SiteWideMessages extends SpecialPage {
 		$DB = wfGetDB( DB_SLAVE, array(), $wgExternalSharedDB );
 
 		$dbResult = $DB->Query (
-			  'SELECT msg_id, user_name, msg_text, msg_removed, msg_expire, msg_date, msg_recipient_name, msg_group_name, msg_wiki_name'
+			  'SELECT msg_id, user_name, msg_text, msg_removed, msg_expire, msg_date, msg_recipient_name, msg_recipient_user_id, msg_group_name, msg_wiki_name'
 			. ' FROM ' . MSG_TEXT_DB
 			. ' LEFT JOIN user ON msg_sender_id = user_id'
 			. ' ORDER BY msg_id DESC'
@@ -990,7 +991,8 @@ class SiteWideMessages extends SpecialPage {
 			$messages[$i]['msg_removed'] = $oMsg->msg_removed;
 			$messages[$i]['msg_expire'] = $oMsg->msg_expire;
 			$messages[$i]['msg_date'] = $oMsg->msg_date;
-			$messages[$i]['msg_recipient_name'] = $oMsg->msg_recipient_name;
+			$messages[$i]['msg_recipient_user_id'] = $oMsg->msg_recipient_user_id; # SUS-3111
+			$messages[$i]['msg_recipient_name'] = User::getUsername( $oMsg->msg_recipient_user_id, $oMsg->msg_recipient_name); # SUS-3111
 			$messages[$i]['msg_group_name'] = $oMsg->msg_group_name;
 			$messages[$i]['msg_wiki_name'] = $oMsg->msg_wiki_name;
 			$i++;

--- a/extensions/wikia/SiteWideMessages/SpecialSiteWideMessages_body.php
+++ b/extensions/wikia/SiteWideMessages/SpecialSiteWideMessages_body.php
@@ -520,11 +520,11 @@ class SiteWideMessages extends SpecialPage {
 			$DB = wfGetDB( DB_MASTER, array(), $wgExternalSharedDB );
 
 			// SUS-3111
-			if ($mRecipientName === MSG_RECIPIENT_ANON) {
+			if ( $mRecipientName === MSG_RECIPIENT_ANON ) {
 				// the message is for anons
 				$recipientUserId = 0;
 			}
-			else if ($mSendModeUsers === 'USER') {
+			elseif ( $mSendModeUsers === 'USER' ) {
 				// the message is for a specific user
 				$recipientUserId = User::idFromName( $mRecipientName );
 			}

--- a/maintenance/wikia/sql/wikicities-schema.sql
+++ b/maintenance/wikia/sql/wikicities-schema.sql
@@ -381,6 +381,7 @@ CREATE TABLE `messages_text` (
   `msg_expire` datetime DEFAULT NULL,
   `msg_date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   `msg_recipient_name` varchar(255) DEFAULT NULL,
+  `msg_recipient_user_id` int(5) unsigned DEFAULT NULL,
   `msg_group_name` varchar(255) DEFAULT NULL,
   `msg_wiki_name` varchar(255) DEFAULT NULL,
   `msg_hub_id` int(9) DEFAULT NULL,
@@ -485,12 +486,11 @@ DROP TABLE IF EXISTS `shared_newtalks`;
 CREATE TABLE `shared_newtalks` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `sn_user_id` int(5) unsigned DEFAULT NULL,
-  `sn_user_ip` varchar(255) DEFAULT '',
   `sn_anon_ip` varbinary(16) DEFAULT NULL,
   `sn_wiki` varchar(31) DEFAULT NULL,
   `sn_date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
-  KEY `idx_user_ip_wiki` (`sn_user_ip`,`sn_wiki`),
+  KEY `idx_user_ip_wiki` (`sn_wiki`),
   KEY `idx_user_id_wiki` (`sn_user_id`,`sn_wiki`),
   KEY `idx_anon_ip_wiki` (`sn_anon_ip`,`sn_wiki`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
@@ -677,4 +677,4 @@ CREATE TABLE `wikia_tasks_log` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 
--- Dump completed on 2017-10-24 14:37:30
+-- Dump completed on 2017-10-26 11:27:23


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3111

For now insert both `msg_recipient_user_id` and `msg_recipient_name` values. When names are migrated to IDs, drop the latter one.

`msg_recipient_user_id` can be either:

* NULL - the message is for all users
* 0 - the message is for anons
* integer value - ID of the user that should receive this message