### PR TITLE
SUS-3114: Support GlobalTitle in internal Linker cache

### DIFF
--- a/includes/Linker.php
+++ b/includes/Linker.php
@@ -180,10 +180,12 @@ class Linker {
 		// method call for the rest of this request
 		static $linkCache = array();
 		$key = serialize( array( $target->getDBkey(), $target->getNamespace(), $target->getFragment(), $target->getInterwiki(), $html, $customAttribs, $query, $options ) );
+		// SUS-3114: Support GlobalTitle links, else they are incorrectly cached
+		$wikiId = $target instanceof GlobalTitle ? $target->getCityId() : $GLOBALS['wgCityId'];
 
-		if ( array_key_exists($key, $linkCache) ) {
+		if ( isset( $linkCache[$wikiId][$key] ) ) {
 			wfProfileOut( __METHOD__ );
-			return $linkCache[$key];
+			return $linkCache[$wikiId][$key];
 		}
 		/* Wikia change - end */
 
@@ -248,7 +250,7 @@ class Linker {
 		}
 
 		/* Wikia change begin - @author: garth */
-		$linkCache[$key] = $ret;
+		$linkCache[$wikiId][$key] = $ret;
 		/* Wikia change - end */
 
 		wfProfileOut( __METHOD__ );


### PR DESCRIPTION
The internal `Linker` cache does not vary on target `wgCityId` if the target is a `GlobalTitle`.
So if you have code like 

```php
$title = GlobalTitle::newFromText( "Contributions/$user", NS_SPECIAL, $cityId );
$link = Linker::linkKnown( $title, htmlspecialchars( $user ) );
```
and call it several times with different `$cityId`, all links will point to the first wiki.

https://wikia-inc.atlassian.net/browse/SUS-3114