### PR TITLE
SUS-3116: Avoid drunk PHP situation in EditPage 🍻

### DIFF
--- a/includes/EditPage.php
+++ b/includes/EditPage.php
@@ -2641,17 +2641,22 @@ HTML
 			'ORDER BY' => 'log_timestamp DESC'
 		] );
 
-		// Quick paranoid permission checks...
-		if( is_object( $data ) ) {
-			if( $data->log_deleted & LogPage::DELETED_USER )
-				$data->user_name = wfMsgHtml( 'rev-deleted-user' );
-			if( $data->log_deleted & LogPage::DELETED_COMMENT )
-				$data->log_comment = wfMsgHtml( 'rev-deleted-comment' );
+		if ( !$data ) {
+			return false;
 		}
 
-		// SUS-2779
-		$user = User::newFromId($data->log_user);
-		$data->user_name = $user->getName();
+		// Quick paranoid permission checks...
+		if ( $data->log_deleted & LogPage::DELETED_USER ) {
+			$data->user_name = wfMessage( 'rev-deleted-user' )->escaped();
+		} else {
+			// SUS-2779: use username lookup
+			$user = User::newFromId( $data->log_user );
+			$data->user_name = $user->getName();
+		}
+
+		if ( $data->log_deleted & LogPage::DELETED_COMMENT ) {
+			$data->log_comment = wfMessage( 'rev-deleted-comment' )->escaped();
+		}
 
 		return $data;
 	}


### PR DESCRIPTION
```php
<?php
$res = false;

$res->bar = 5;

var_dump( $res );
```
results in:
>**Warning**:  Creating default object from empty value in **[...][...]** on line **4**
object(stdClass)#1 (1) {
  ["bar"]=>
  int(5)
}

and we do not want that to happen.
https://wikia-inc.atlassian.net/browse/SUS-3116
