### PR TITLE
SUS-3119: Rely on user ID instead of rev_user_text in Special:Templates

### DIFF
--- a/extensions/wikia/TemplateClassification/specials/TemplatesSpecialController.class.php
+++ b/extensions/wikia/TemplateClassification/specials/TemplatesSpecialController.class.php
@@ -224,17 +224,13 @@ class TemplatesSpecialController extends WikiaSpecialPageController {
 
 		if ( $revision instanceof Revision ) {
 			$data['timestamp'] = $this->wg->Lang->date( $revision->getTimestamp() );
+			
+			// SUS-3119: Determine user name of registered users based on user ID
+			$userId = $revision->getUser();
+			$userName = User::getUsername( $userId, $revision->getUserText() );
 
-			$user = $revision->getUserText();
-
-			if ( $revision->getUser() ) {
-				$userpage = Title::newFromText( $user, NS_USER )->getFullURL();
-			} else {
-				$userpage = SpecialPage::getTitleFor( 'Contributions', $user )->getFullUrl();
-			}
-
-			$data['username'] = $user;
-			$data['userpage'] = $userpage;
+			$data['username'] = $userName;
+			$data['userpage'] = Linker::userLink( $userId, $userName );
 		}
 
 		return $data;


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3119