### PR TITLE
SUS-3097 | ach_user_badges - remove redundant "id" and not used "notified_id" indices

### DIFF
--- a/includes/wikia/WikiaUpdater.php
+++ b/includes/wikia/WikiaUpdater.php
@@ -40,6 +40,10 @@ class WikiaUpdater {
 			# indexes
 			array( 'addIndex', 'archive', 'page_revision', $dir. 'patch-index-archive-page_revision.sql', true ),
 
+			# indexes drop
+			array( 'dropIndex', 'ach_user_badges', 'id',  $dir . 'patch-ach-user-badges-drop-id.sql', true ), // SUS-3097
+			array( 'dropIndex', 'ach_user_badges', 'notified_id',  $dir . 'patch-ach-user-badges-drop-notified_id.sql', true ), // SUS-3097
+
 			# functions
 			array( 'WikiaUpdater::do_page_vote_unique_update' ),
 			array( 'WikiaUpdater::do_page_wikia_props_update' ),

--- a/maintenance/archives/wikia/patch-ach-user-badges-drop-id.sql
+++ b/maintenance/archives/wikia/patch-ach-user-badges-drop-id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE /*$wgDBprefix*/ach_user_badges DROP KEY id;

--- a/maintenance/archives/wikia/patch-ach-user-badges-drop-notified_id.sql
+++ b/maintenance/archives/wikia/patch-ach-user-badges-drop-notified_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE /*$wgDBprefix*/ach_user_badges DROP KEY notified_id;
+OPTIMIZE TABLE /*$wgDBprefix*/ach_user_badges;


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3097

Make `update.php` drop redundant and not used indices on `ach_user_badges` per-wiki tables.

```
macbre@dev-macbre:~/app/maintenance$ SERVER_ID=26337 php update.php --quick
...
Dropping id index from table ach_user_badges... done.
Dropping notified_id index from table ach_user_badges... done.
...
```

## Index improvements suggestions

```
redundant_indices → table affected: ach_user_badges

✗ "id" index can be removed as redundant (covered by "user_badge")

  - redundant: KEY id (user_id)
  - covered_by: KEY user_badge (user_id, badge_type_id, badge_lap)

------------------------------------------------------------

not_used_indices → table affected: ach_user_badges

✗ "notified_id" index was not used by provided queries

  - not_used_index: KEY notified_id (user_id, notified)
```

## Cleanup stats

```sql
-- before
mysql@geo-db-c-slave.query.consul[glee]>SELECT ENGINE, TABLE_ROWS, DATA_LENGTH/1024/1024 as data_mb, INDEX_LENGTH/1024/1024 as index_mb FROM information_schema.TABLES WHERE TABLE_SCHEMA='glee' AND TABLE_NAME='ach_user_badges';
+--------+------------+------------+-------------+
| ENGINE | TABLE_ROWS | data_mb    | index_mb    |
+--------+------------+------------+-------------+
| InnoDB |      89776 | 4.51562500 | 22.09375000 |
+--------+------------+------------+-------------+
1 row in set (0.00 sec)

-- after
mysql@geo-db-c-master.query.consul[glee]>SELECT ENGINE, TABLE_ROWS, DATA_LENGTH/1024/1024 as data_mb, INDEX_LENGTH/1024/1024 as index_mb FROM information_schema.TABLES WHERE TABLE_SCHEMA='glee' AND TABLE_NAME='ach_user_badges';
+--------+------------+------------+-------------+
| ENGINE | TABLE_ROWS | data_mb    | index_mb    |
+--------+------------+------------+-------------+
| InnoDB |      89714 | 4.51562500 | 16.06250000 |
+--------+------------+------------+-------------+
1 row in set (0.00 sec)
```

Index size dropped from 22 to 16 MiB (27%).

## Possible improvements

For c3 cluster:

```sql
mysql@geo-db-c-slave.query.consul[glee]>SELECT COUNT(*) as cnt, SUM(TABLE_ROWS), SUM(DATA_LENGTH/1024/1024) as data_mb, SUM(INDEX_LENGTH/1024/1024) as index_mb FROM information_schema.TABLES WHERE TABLE_NAME='ach_user_badges';
+-------+-----------------+--------------+---------------+
| cnt   | SUM(TABLE_ROWS) | data_mb      | index_mb      |
+-------+-----------------+--------------+---------------+
| 50230 |         2563121 | 909.37500000 | 5143.45312500 |
+-------+-----------------+--------------+---------------+
1 row in set (57.99 sec)
```

**`ach_user_badges` tables across all clusters weight  ~33.31 GiB**