### PR TITLE
SUS-3111 | rely on msg_recipient_user_id (instead of msg_recipient_name column)

### DIFF
--- a/extensions/wikia/SiteWideMessages/SpecialSiteWideMessages.php
+++ b/extensions/wikia/SiteWideMessages/SpecialSiteWideMessages.php
@@ -176,13 +176,3 @@ function SiteWideMessagesPublicStatusChange($city_public, $city_id, $reason = ''
 	}
 	return true;
 }
-
-$wgHooks['UserRename::Global'][] = "SiteWideMessagesUserRenameGlobal";
-
-function SiteWideMessagesUserRenameGlobal( $dbw, $uid, $oldusername, $newusername, $process, &$tasks ) {
-	$tasks[] = array(
-		'table' => 'messages_text',
-		'username_column' => 'msg_recipient_name',
-	);
-	return true;
-}

--- a/extensions/wikia/SiteWideMessages/SpecialSiteWideMessages_body.php
+++ b/extensions/wikia/SiteWideMessages/SpecialSiteWideMessages_body.php
@@ -1480,13 +1480,13 @@ class SiteWideMessagesPager extends TablePager {
 
 	#--- isFieldSortable-----------------------------------------------------
 	function isFieldSortable( $field ) {
-		static $sortable = array( 'msg_id', 'msg_sender', 'msg_removed', 'msg_date', 'msg_expire', 'msg_wiki_name', 'msg_group_name', 'msg_text', 'msg_lang', 'msg_hub_id' );
+		static $sortable = array( 'msg_id', 'msg_removed', 'msg_date', 'msg_expire', 'msg_wiki_name', 'msg_group_name', 'msg_text', 'msg_lang', 'msg_hub_id' );
 		return in_array( $field, $sortable );
 	}
 
 	#--- formatValue --------------------------------------------------------
 	function formatValue( $field, $value ) {
-		global $wgStylePath, $wgTitle;
+		global $wgTitle;
 
 		switch ($field) {
 			case 'msg_expire':
@@ -1497,10 +1497,20 @@ class SiteWideMessagesPager extends TablePager {
 				$sRetval = $value ? wfMsg('swm-yes') : wfMsg('swm-no');
 				break;
 
-			case 'msg_recipient_name':
-				$sRetval = $value ?
-					( $value === MSG_RECIPIENT_ANON ? ('<i>' . wfMsg( 'swm-label-mode-users-anon' ) . '</i>') : htmlspecialchars( $value ) ) :
-					( '<i>' . wfMsg('swm-label-mode-users-all') . '</i>' );
+			case 'msg_sender_id':
+				$sRetval = htmlspecialchars( User::whoIs( $value ) );
+				break;
+
+			case 'msg_recipient_id':
+				if ( is_null( $value ) ) {
+					$sRetval = '<i>' . wfMsg('swm-label-mode-users-all') . '</i>';
+				}
+				elseif ( $value === 0 ) {
+					$sRetval = '<i>' . wfMsg( 'swm-label-mode-users-anon' ) . '</i>';
+				}
+				else {
+					$sRetval = htmlspecialchars( User::whoIs( $value ) );
+				}
 				break;
 
 			case 'msg_wiki_name':
@@ -1569,8 +1579,8 @@ class SiteWideMessagesPager extends TablePager {
 	#--- getQueryInfo -------------------------------------------------------
 	function getQueryInfo() {
 		return array(
-			'tables' => MSG_TEXT_DB . ' LEFT JOIN user ON msg_sender_id = user_id',
-			'fields' => array('msg_id', 'user_name AS msg_sender', 'msg_text', 'msg_removed', 'msg_expire', 'msg_date', 'msg_group_name', 'msg_wiki_name', 'msg_lang', 'msg_hub_id')
+			'tables' => MSG_TEXT_DB,
+			'fields' => array('msg_id', 'msg_sender_id', 'msg_text', 'msg_removed', 'msg_expire', 'msg_date', 'msg_group_name', 'msg_wiki_name', 'msg_lang', 'msg_hub_id')
 		);
 	}
 

--- a/extensions/wikia/SiteWideMessages/SpecialSiteWideMessages_body.php
+++ b/extensions/wikia/SiteWideMessages/SpecialSiteWideMessages_body.php
@@ -1466,7 +1466,7 @@ class SiteWideMessagesPager extends TablePager {
 			$this->mFieldNames['msg_sender_id']      = wfMsg('swm-list-table-sender');
 			$this->mFieldNames['msg_wiki_name']      = wfMsg('swm-list-table-wiki');
 			$this->mFieldNames['msg_hub_id']         = wfMsg( 'swm-list-table-hub' );
-			$this->mFieldNames['msg_recipient_id']   = wfMsg('swm-list-table-recipient');
+			$this->mFieldNames['msg_recipient_user_id'] = wfMsg('swm-list-table-recipient');
 			$this->mFieldNames['msg_group_name']     = wfMsg('swm-list-table-group');
 			$this->mFieldNames['msg_expire']         = wfMsg('swm-list-table-expire');
 			$this->mFieldNames['msg_removed']        = wfMsg('swm-list-table-removed');
@@ -1501,7 +1501,7 @@ class SiteWideMessagesPager extends TablePager {
 				$sRetval = htmlspecialchars( User::whoIs( $value ) );
 				break;
 
-			case 'msg_recipient_id':
+			case 'msg_recipient_user_id':
 				if ( is_null( $value ) ) {
 					$sRetval = '<i>' . wfMsg('swm-label-mode-users-all') . '</i>';
 				}
@@ -1580,7 +1580,7 @@ class SiteWideMessagesPager extends TablePager {
 	function getQueryInfo() {
 		return array(
 			'tables' => MSG_TEXT_DB,
-			'fields' => array('msg_id', 'msg_sender_id', 'msg_recipient_id', 'msg_text', 'msg_removed', 'msg_expire', 'msg_date', 'msg_group_name', 'msg_wiki_name', 'msg_lang', 'msg_hub_id')
+			'fields' => array('msg_id', 'msg_sender_id', 'msg_recipient_user_id', 'msg_text', 'msg_removed', 'msg_expire', 'msg_date', 'msg_group_name', 'msg_wiki_name', 'msg_lang', 'msg_hub_id')
 		);
 	}
 

--- a/extensions/wikia/SiteWideMessages/SpecialSiteWideMessages_body.php
+++ b/extensions/wikia/SiteWideMessages/SpecialSiteWideMessages_body.php
@@ -1013,7 +1013,7 @@ class SiteWideMessages extends SpecialPage {
 			$messages[$i]['msg_expire'] = $oMsg->msg_expire;
 			$messages[$i]['msg_date'] = $oMsg->msg_date;
 			$messages[$i]['msg_recipient_user_id'] = $oMsg->msg_recipient_user_id; # SUS-3111
-			$messages[$i]['msg_recipient_name'] = User::getUsername( $oMsg->msg_recipient_user_id, $oMsg->msg_recipient_name); # SUS-3111
+			$messages[$i]['msg_recipient_name'] = ( $oMsg->msg_recipient_user_id > 0 ) ? User::whoIs( $oMsg->msg_recipient_user_id ) : false; # SUS-3111
 			$messages[$i]['msg_group_name'] = $oMsg->msg_group_name;
 			$messages[$i]['msg_wiki_name'] = $oMsg->msg_wiki_name;
 			$i++;

--- a/extensions/wikia/SiteWideMessages/SpecialSiteWideMessages_body.php
+++ b/extensions/wikia/SiteWideMessages/SpecialSiteWideMessages_body.php
@@ -1463,10 +1463,10 @@ class SiteWideMessagesPager extends TablePager {
 		if ( !$this->mFieldNames ) {
 			$this->mFieldNames = array();
 			$this->mFieldNames['msg_id']             = wfMsg('swm-list-table-id');
-			$this->mFieldNames['msg_sender']         = wfMsg('swm-list-table-sender');
+			$this->mFieldNames['msg_sender_id']      = wfMsg('swm-list-table-sender');
 			$this->mFieldNames['msg_wiki_name']      = wfMsg('swm-list-table-wiki');
 			$this->mFieldNames['msg_hub_id']         = wfMsg( 'swm-list-table-hub' );
-			$this->mFieldNames['msg_recipient_name'] = wfMsg('swm-list-table-recipient');
+			$this->mFieldNames['msg_recipient_id']   = wfMsg('swm-list-table-recipient');
 			$this->mFieldNames['msg_group_name']     = wfMsg('swm-list-table-group');
 			$this->mFieldNames['msg_expire']         = wfMsg('swm-list-table-expire');
 			$this->mFieldNames['msg_removed']        = wfMsg('swm-list-table-removed');

--- a/extensions/wikia/SiteWideMessages/SpecialSiteWideMessages_body.php
+++ b/extensions/wikia/SiteWideMessages/SpecialSiteWideMessages_body.php
@@ -1580,7 +1580,7 @@ class SiteWideMessagesPager extends TablePager {
 	function getQueryInfo() {
 		return array(
 			'tables' => MSG_TEXT_DB,
-			'fields' => array('msg_id', 'msg_sender_id', 'msg_text', 'msg_removed', 'msg_expire', 'msg_date', 'msg_group_name', 'msg_wiki_name', 'msg_lang', 'msg_hub_id')
+			'fields' => array('msg_id', 'msg_sender_id', 'msg_recipient_id', 'msg_text', 'msg_removed', 'msg_expire', 'msg_date', 'msg_group_name', 'msg_wiki_name', 'msg_lang', 'msg_hub_id')
 		);
 	}
 

--- a/extensions/wikia/SiteWideMessages/SpecialSiteWideMessages_body.php
+++ b/extensions/wikia/SiteWideMessages/SpecialSiteWideMessages_body.php
@@ -1040,11 +1040,16 @@ class SiteWideMessages extends SpecialPage {
 		return $dbResult;
 	}
 
-	//Static functions (used in hooks)
+	/**
+	 * Static functions (used in hooks)
+	 *
+	 * @param User $user
+	 * @param bool $filter_seen
+	 * @return array
+	 */
 	static function getAllUserMessagesId($user, $filter_seen = true) {
-		global $wgCityId, $wgLanguageCode;
-		global $wgExternalSharedDB ;
-		$localCityId = isset($wgCityId) ? $wgCityId : 0;
+		global $wgCityId, $wgExternalSharedDB;
+		$localCityId = $wgCityId;
 		$DB = wfGetDB( DB_SLAVE, array(), $wgExternalSharedDB );
 
 		//step 1 of 3: get all active messages sent to *all*
@@ -1079,7 +1084,7 @@ class SiteWideMessages extends SpecialPage {
 				  'SELECT msg_id AS id'
 				. ' FROM ' . MSG_STATUS_DB
 				. ' WHERE msg_id IN (' . implode(',', array_keys($tmpMsg)) . ')'
-				. ' AND msg_recipient_id = ' . $DB->AddQuotes($user->GetID())
+				. ' AND msg_recipient_id = ' . $DB->AddQuotes($user->getId())
 				. ' AND msg_status IN (' . join(',', $status) . ')'
 				. ';'
 				, __METHOD__
@@ -1104,7 +1109,7 @@ class SiteWideMessages extends SpecialPage {
 			. ' FROM ' . MSG_TEXT_DB
 			. ' LEFT JOIN ' . MSG_STATUS_DB . ' USING (msg_id)'
 			. ' WHERE msg_mode = ' . MSG_MODE_SELECTED
-			. ' AND msg_recipient_id = ' . $DB->AddQuotes($user->GetID())
+			. ' AND msg_recipient_id = ' . $DB->AddQuotes($user->getId())
 			. ' AND msg_status IN (' . join(',', $status) . ')'
 			. ' AND (msg_expire IS NULL OR msg_expire > ' . $DB->AddQuotes(date('Y-m-d H:i:s')) . ')'
 			. ' AND msg_removed = ' . MSG_REMOVED_NO
@@ -1125,13 +1130,12 @@ class SiteWideMessages extends SpecialPage {
 		//sort from newer to older
 		krsort($tmpMsg);
 
-		$messages = array();
 		$IDs = array();
 		foreach ($tmpMsg as $tmpMsgId => $tmpMsgData) {
 			$IDs['id'][] = $tmpMsgId;
 			$IDs['wiki'][] = $tmpMsgData['wiki_id'];
 		}
-		wfDebug(basename(__FILE__) . ' || ' . __METHOD__ . " || userID={$user->GetID()}, result=" . ($dbResult ? 'true':'false') . "\n");
+		wfDebug(basename(__FILE__) . ' || ' . __METHOD__ . " || userID={$user->getId()}, result=" . ($dbResult ? 'true':'false') . "\n");
 
 		return $IDs;
 	}

--- a/extensions/wikia/SiteWideMessages/SpecialSiteWideMessages_body.php
+++ b/extensions/wikia/SiteWideMessages/SpecialSiteWideMessages_body.php
@@ -1480,7 +1480,7 @@ class SiteWideMessagesPager extends TablePager {
 
 	#--- isFieldSortable-----------------------------------------------------
 	function isFieldSortable( $field ) {
-		static $sortable = array( 'msg_id', 'msg_sender', 'msg_removed', 'msg_date', 'msg_expire', 'msg_wiki_name', 'msg_group_name', 'msg_recipient_name', 'msg_text', 'msg_lang', 'msg_hub_id' );
+		static $sortable = array( 'msg_id', 'msg_sender', 'msg_removed', 'msg_date', 'msg_expire', 'msg_wiki_name', 'msg_group_name', 'msg_text', 'msg_lang', 'msg_hub_id' );
 		return in_array( $field, $sortable );
 	}
 

--- a/extensions/wikia/SiteWideMessages/SpecialSiteWideMessages_body.php
+++ b/extensions/wikia/SiteWideMessages/SpecialSiteWideMessages_body.php
@@ -535,13 +535,12 @@ class SiteWideMessages extends SpecialPage {
 
 			$dbResult = (boolean)$DB->Query (
 				  'INSERT INTO ' . MSG_TEXT_DB
-				. ' (msg_sender_id, msg_text, msg_mode, msg_expire, msg_recipient_name, msg_recipient_user_id, msg_group_name, msg_wiki_name, msg_hub_id, msg_lang, msg_cluster_id)'
+				. ' (msg_sender_id, msg_text, msg_mode, msg_expire, msg_recipient_user_id, msg_group_name, msg_wiki_name, msg_hub_id, msg_lang, msg_cluster_id)'
 				. ' VALUES ('
 				. $DB->AddQuotes($mSender->GetID()). ', '
 				. $DB->AddQuotes($mText) . ', '
 				. ($sendToAll ? MSG_MODE_ALL : MSG_MODE_SELECTED) . ', '
 				. $DB->AddQuotes($mExpire) . ', '
-				. $DB->AddQuotes($mRecipientName) . ', '
 				. $recipientUserId . ', ' # SUS-3111
 				. $DB->AddQuotes($mGroupName) . ', '
 				. $DB->AddQuotes($mWikiName) . ', '
@@ -996,7 +995,7 @@ class SiteWideMessages extends SpecialPage {
 		$DB = wfGetDB( DB_SLAVE, array(), $wgExternalSharedDB );
 
 		$dbResult = $DB->Query (
-			  'SELECT msg_id, user_name, msg_text, msg_removed, msg_expire, msg_date, msg_recipient_name, msg_recipient_user_id, msg_group_name, msg_wiki_name'
+			  'SELECT msg_id, user_name, msg_text, msg_removed, msg_expire, msg_date, msg_recipient_user_id, msg_group_name, msg_wiki_name'
 			. ' FROM ' . MSG_TEXT_DB
 			. ' LEFT JOIN user ON msg_sender_id = user_id'
 			. ' ORDER BY msg_id DESC'
@@ -1292,7 +1291,7 @@ class SiteWideMessages extends SpecialPage {
 				' LEFT JOIN ' . MSG_STATUS_DB . ' USING (msg_id)' .
 				' WHERE msg_mode = ' . MSG_MODE_SELECTED .
 				' AND msg_recipient_id = 0' .
-				' AND msg_recipient_name = ' . $dbr->addQuotes( MSG_RECIPIENT_ANON ) .
+				' AND msg_recipient_user_id = 0' . # message is for all anons
 				' AND msg_status IN (' . MSG_STATUS_UNSEEN . ', ' . MSG_STATUS_SEEN . ')' .
 				' AND (msg_expire IS NULL OR msg_expire > ' . $dbr->addQuotes( date( 'Y-m-d H:i:s' ) ) . ')' .
 				' AND msg_removed = ' . MSG_REMOVED_NO .
@@ -1567,7 +1566,7 @@ class SiteWideMessagesPager extends TablePager {
 	function getQueryInfo() {
 		return array(
 			'tables' => MSG_TEXT_DB . ' LEFT JOIN user ON msg_sender_id = user_id',
-			'fields' => array('msg_id', 'user_name AS msg_sender', 'msg_text', 'msg_removed', 'msg_expire', 'msg_date', 'msg_recipient_name', 'msg_group_name', 'msg_wiki_name', 'msg_lang', 'msg_hub_id')
+			'fields' => array('msg_id', 'user_name AS msg_sender', 'msg_text', 'msg_removed', 'msg_expire', 'msg_date', 'msg_group_name', 'msg_wiki_name', 'msg_lang', 'msg_hub_id')
 		);
 	}
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3111

A follow-up of #14089.

* `msg_recipient_name` defaults to NULL, we can safely skip this column in INSERT queries.
* `msg_recipient_user_id` is populated since #14089, now it's time to start using it in SELECT queries.

```sql
  -- ...
  `msg_recipient_name` varchar(255) DEFAULT NULL,
  `msg_recipient_user_id` int(5) unsigned DEFAULT NULL,
  -- ...
```