### PR TITLE
SUS-3206 | Remove JOIN to wikicities_cX.user in User::idForName

### DIFF
--- a/includes/User.php
+++ b/includes/User.php
@@ -3228,14 +3228,18 @@ class User implements JsonSerializable {
 
 	/**
 	 * If only this user's username is known, and it exists, return the user ID.
+	 *
+	 * @param boolean $fromMaster
 	 * @return Int
 	 */
 	public function idForName( $fromMaster = false ) {
 		$s = trim( $this->getName() );
 		if ( $s === '' ) return 0;
 
-		$dbr = ( $fromMaster ) ? wfGetDB( DB_MASTER ) : wfGetDB( DB_SLAVE );
-		$id = $dbr->selectField( 'user', 'user_id', array( 'user_name' => $s ), __METHOD__ );
+		global $wgExternalSharedDB;
+		$dbr = wfGetDB( $fromMaster ? DB_MASTER : DB_SLAVE, [], $wgExternalSharedDB );
+
+		$id = $dbr->selectField( '`user`', 'user_id', array( 'user_name' => $s ), __METHOD__ );
 		if ( $id === false ) {
 			$id = 0;
 		}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3206

This is The Last Join :tm: with per-cluster `user` table copy.

## Before

```sql
SELECT /* User::idForName Kuzura - 5056eebf-e1b5-4ff6-8e53-61de2c2c4d72 */  user_id  FROM `wikicities_c1`.`user`  WHERE user_name = 'Kagehirin'  LIMIT 1  
```
> MediaWiki logged only three queries in the last 24h.

## After the fix

```sql
> $u = User::newFromName('Macbre')

> echo $u->idForName()
...
Query wikicities (DB user: wikia_maint) (8) (slave): SELECT /* User::idForName CommandLineInc - f74cfeaa-da22-429b-b002-aea15b47b91d */  user_id  FROM `user`  WHERE user_name = 'Macbre'  LIMIT 1
119245
```