### PR TITLE
SUS-3096 | drop redundant indices on wall_related_pages table + make schema consistent

### DIFF
--- a/extensions/wikia/Wall/sql/wall_related_pages.sql
+++ b/extensions/wikia/Wall/sql/wall_related_pages.sql
@@ -4,7 +4,6 @@ CREATE TABLE `wall_related_pages` (
   `order_index` int(10) unsigned NOT NULL,
   `add_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   `last_update` timestamp,
-  KEY `comment_id_idx` (`comment_id`),
-  KEY `page_id_idx` (`page_id`, `last_update`),
-  unique key unique_key (`comment_id`, `page_id`)
+  UNIQUE KEY `unique_key` (`comment_id`,`page_id`),
+  KEY `page_id_idx` (`page_id`,`last_update`)
 ) ENGINE=InnoDB;

--- a/includes/installer/MysqlUpdater.php
+++ b/includes/installer/MysqlUpdater.php
@@ -138,8 +138,8 @@ class MysqlUpdater extends DatabaseUpdater {
 			// 1.15
 			array( 'doUniquePlTlIl' ),
 			array( 'addTable', 'change_tag',                        'patch-change_tag.sql' ),
-			array( 'addTable', 'tag_summary',                       'patch-change_tag.sql' ),
-			array( 'addTable', 'valid_tag',                         'patch-change_tag.sql' ),
+			#array( 'addTable', 'tag_summary',                       'patch-change_tag.sql' ), # SUS-3066
+			#array( 'addTable', 'valid_tag',                         'patch-change_tag.sql' ), # SUS-3066
 
 			// 1.16
 			array( 'addTable', 'user_properties',                   'patch-user_properties.sql' ),

--- a/includes/wikia/WikiaUpdater.php
+++ b/includes/wikia/WikiaUpdater.php
@@ -43,6 +43,8 @@ class WikiaUpdater {
 			# indexes drop
 			array( 'dropIndex', 'ach_user_badges', 'id',  $dir . 'patch-ach-user-badges-drop-id.sql', true ), // SUS-3097
 			array( 'dropIndex', 'ach_user_badges', 'notified_id',  $dir . 'patch-ach-user-badges-drop-notified_id.sql', true ), // SUS-3097
+			array( 'dropIndex', 'wall_related_pages', 'comment_id_idx',  $dir . 'patch-wall_related_pages-drop-comment_id_idx.sql', true ), // SUS-3096
+			array( 'dropIndex', 'wall_related_pages', 'page_id_idx_2',  $dir . 'patch-wall_related_pages-drop-page_id_idx_2.sql', true ), // SUS-3096
 
 			# functions
 			array( 'WikiaUpdater::do_page_vote_unique_update' ),

--- a/maintenance/archives/patch-change_tag.sql
+++ b/maintenance/archives/patch-change_tag.sql
@@ -15,17 +15,7 @@ CREATE UNIQUE INDEX /*i*/change_tag_rev_tag ON /*_*/change_tag (ct_rev_id,ct_tag
 CREATE INDEX /*i*/change_tag_tag_id ON /*_*/change_tag (ct_tag,ct_rc_id,ct_rev_id,ct_log_id);
 
 -- Rollup table to pull a LIST of tags simply without ugly GROUP_CONCAT that only works on MySQL 4.1+
-CREATE TABLE /*_*/tag_summary (
-	ts_rc_id int NULL,
-	ts_log_id int NULL,
-	ts_rev_id int NULL,
-	ts_tags BLOB NOT NULL
-) /*$wgDBTableOptions*/;
-
-CREATE UNIQUE INDEX /*i*/tag_summary_rc_id ON /*_*/tag_summary (ts_rc_id);
-CREATE UNIQUE INDEX /*i*/tag_summary_log_id ON /*_*/tag_summary (ts_log_id);
-CREATE UNIQUE INDEX /*i*/tag_summary_rev_id ON /*_*/tag_summary (ts_rev_id);
-
+-- Wikia: tag_summary table was removed as a part of SUS-3066
 
 CREATE TABLE /*_*/valid_tag (
 	vt_tag varchar(255) NOT NULL PRIMARY KEY

--- a/maintenance/archives/wikia/patch-wall_related_pages-drop-comment_id_idx.sql
+++ b/maintenance/archives/wikia/patch-wall_related_pages-drop-comment_id_idx.sql
@@ -1,0 +1,2 @@
+ALTER TABLE /*$wgDBprefix*/wall_related_pages DROP KEY comment_id_idx;
+OPTIMIZE TABLE /*$wgDBprefix*/wall_related_pages;

--- a/maintenance/archives/wikia/patch-wall_related_pages-drop-page_id_idx_2.sql
+++ b/maintenance/archives/wikia/patch-wall_related_pages-drop-page_id_idx_2.sql
@@ -1,0 +1,3 @@
+ALTER TABLE /*$wgDBprefix*/wall_related_pages DROP KEY page_id_idx;
+ALTER TABLE /*$wgDBprefix*/wall_related_pages RENAME INDEX page_id_idx_2 TO page_id_idx;
+OPTIMIZE TABLE /*$wgDBprefix*/wall_related_pages;


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3096

Run the schema update on production for `glee` database: **the index size dropped by 67%** (overall table size **by 28.5%**).

This table weights **18,589 GB** across all clusters.


### Schema before

```sql
CREATE TABLE `wall_related_pages` (
  `comment_id` int(10) unsigned NOT NULL,
  `page_id` int(10) unsigned NOT NULL,
  `order_index` int(10) unsigned NOT NULL,
  `add_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
  `last_update` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',
  UNIQUE KEY `unique_key` (`comment_id`,`page_id`),
  KEY `comment_id_idx` (`comment_id`),
  KEY `page_id_idx` (`page_id`),
  KEY `page_id_idx_2` (`page_id`,`last_update`)
) ENGINE=InnoDB DEFAULT CHARSET=latin1
```

```
macbre@dev-macbre:~/app/maintenance$ SERVER_ID=5915 php update.php --quick
...
Dropping comment_id_idx index from table wall_related_pages... done.
Dropping page_id_idx_2 index from table wall_related_pages... done.
...
```

### Schema after
```sql
CREATE TABLE `wall_related_pages` (
  `comment_id` int(10) unsigned NOT NULL,
  `page_id` int(10) unsigned NOT NULL,
  `order_index` int(10) unsigned NOT NULL,
  `add_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
  `last_update` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',
  UNIQUE KEY `unique_key` (`comment_id`,`page_id`),
  KEY `page_id_idx` (`page_id`,`last_update`)
) ENGINE=InnoDB DEFAULT CHARSET=latin1
```

### `index-digest` reports

```
redundant_indices → table affected: wall_related_pages

✗ "comment_id_idx" index can be removed as redundant (covered by "unique_key")

  - redundant: KEY comment_id_idx (comment_id)
  - covered_by: UNIQUE KEY unique_key (comment_id, page_id)
  - schema: CREATE TABLE `wall_related_pages` (
      `comment_id` int(10) unsigned NOT NULL,
      `page_id` int(10) unsigned NOT NULL,
      `order_index` int(10) unsigned NOT NULL,
      `add_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
      `last_update` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',
      UNIQUE KEY `unique_key` (`comment_id`,`page_id`),
      KEY `comment_id_idx` (`comment_id`),
      KEY `page_id_idx` (`page_id`),
      KEY `page_id_idx_2` (`page_id`,`last_update`)
    ) ENGINE=InnoDB DEFAULT CHARSET=latin1
  - table_data_size_mb: 0.0625
  - table_index_size_mb: 0.046875

------------------------------------------------------------
redundant_indices → table affected: wall_related_pages

✗ "page_id_idx" index can be removed as redundant (covered by "page_id_idx_2")

  - redundant: KEY page_id_idx (page_id)
  - covered_by: KEY page_id_idx_2 (page_id, last_update)
  - schema: CREATE TABLE `wall_related_pages` (
      `comment_id` int(10) unsigned NOT NULL,
      `page_id` int(10) unsigned NOT NULL,
      `order_index` int(10) unsigned NOT NULL,
      `add_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
      `last_update` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',
      UNIQUE KEY `unique_key` (`comment_id`,`page_id`),
      KEY `comment_id_idx` (`comment_id`),
      KEY `page_id_idx` (`page_id`),
      KEY `page_id_idx_2` (`page_id`,`last_update`)
    ) ENGINE=InnoDB DEFAULT CHARSET=latin1
  - table_data_size_mb: 0.0625
  - table_index_size_mb: 0.046875
```
