### PR TITLE
SUS-3098 | ach_custom_badges - KEY id (id) index can be removed as redundant

### DIFF
--- a/extensions/wikia/AchievementsII/schema_local.sql
+++ b/extensions/wikia/AchievementsII/schema_local.sql
@@ -45,7 +45,6 @@ CREATE TABLE IF NOT EXISTS `ach_custom_badges` (
 	`badge_tracking_url` VARCHAR(255) DEFAULT NULL,
 	`hover_tracking_url` VARCHAR(255) DEFAULT NULL,
 	`click_tracking_url` VARCHAR(255) DEFAULT NULL,
-	KEY `id` (`id`),
 	KEY `type` (`type`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 

--- a/includes/wikia/WikiaUpdater.php
+++ b/includes/wikia/WikiaUpdater.php
@@ -43,6 +43,7 @@ class WikiaUpdater {
 			# indexes drop
 			array( 'dropIndex', 'ach_user_badges', 'id',  $dir . 'patch-ach-user-badges-drop-id.sql', true ), // SUS-3097
 			array( 'dropIndex', 'ach_user_badges', 'notified_id',  $dir . 'patch-ach-user-badges-drop-notified_id.sql', true ), // SUS-3097
+			array( 'dropIndex', 'ach_custom_badges', 'id',  $dir . 'patch-ach_custom_badges-drop-id.sql', true ), // SUS-3098
 			array( 'dropIndex', 'wall_related_pages', 'comment_id_idx',  $dir . 'patch-wall_related_pages-drop-comment_id_idx.sql', true ), // SUS-3096
 			array( 'dropIndex', 'wall_related_pages', 'page_id_idx_2',  $dir . 'patch-wall_related_pages-drop-page_id_idx_2.sql', true ), // SUS-3096
 

--- a/maintenance/archives/wikia/patch-ach_custom_badges-drop-id.sql
+++ b/maintenance/archives/wikia/patch-ach_custom_badges-drop-id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE /*$wgDBprefix*/ach_custom_badges DROP KEY id;
+OPTIMIZE TABLE /*$wgDBprefix*/ach_custom_badges;


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3098

Dropped the index for `glee` database: Index size dropped by 50%, **table size overall - 33%**.

This table weights **12,103 GB** across all clusters.

### Schema before

```sql
CREATE TABLE `ach_custom_badges` (
  `id` int(10) NOT NULL AUTO_INCREMENT,
  `cat` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
  `enabled` tinyint(1) NOT NULL DEFAULT '0',
  `type` tinyint(1) NOT NULL,
  `sponsored` tinyint(1) NOT NULL DEFAULT '0',
  `badge_tracking_url` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
  `hover_tracking_url` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
  `click_tracking_url` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
  PRIMARY KEY (`id`),
  KEY `id` (`id`),
  KEY `type` (`type`)
) ENGINE=InnoDB
```

### Schema after

```sql
CREATE TABLE `ach_custom_badges` (
  `id` int(10) NOT NULL AUTO_INCREMENT,
  `cat` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
  `enabled` tinyint(1) NOT NULL DEFAULT '0',
  `type` tinyint(1) NOT NULL,
  `sponsored` tinyint(1) NOT NULL DEFAULT '0',
  `badge_tracking_url` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
  `hover_tracking_url` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
  `click_tracking_url` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
  PRIMARY KEY (`id`),
  KEY `type` (`type`)
) ENGINE=InnoDB
```

### `index-digest` says

```
redundant_indices → table affected: ach_custom_badges

✗ "id" index can be removed as redundant (covered by "PRIMARY")

  - redundant: KEY id (id)
  - covered_by: PRIMARY KEY (id)
  - schema: CREATE TABLE `ach_custom_badges` (
      `id` int(10) NOT NULL AUTO_INCREMENT,
      `cat` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
      `enabled` tinyint(1) NOT NULL DEFAULT '0',
      `type` tinyint(1) NOT NULL,
      `sponsored` tinyint(1) NOT NULL DEFAULT '0',
      `badge_tracking_url` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
      `hover_tracking_url` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
      `click_tracking_url` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
      PRIMARY KEY (`id`),
      KEY `id` (`id`),
      KEY `type` (`type`)
    ) ENGINE=InnoDB AUTO_INCREMENT=5028 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci
  - table_data_size_mb: 0.015625
  - table_index_size_mb: 0.03125
```