### PR TITLE
StaffLogger::log - make sure int value is inserted into database

### DIFF
--- a/extensions/wikia/StaffLog/StaffLog.events.php
+++ b/extensions/wikia/StaffLog/StaffLog.events.php
@@ -1,6 +1,6 @@
 <?php
 class StaffLogger {
-	static public function log($type, $action, $userId, $userName, $userdstId, $userNamedst, $comment = "") {
+	static public function log(string $type, string $action, int $userId, string $userName, int $userdstId, string $userNamedst, $comment = "") {
 		global $wgSitename,$wgCityId,$wgExternalDatawareDB;
 		$dbw =  wfGetDB( DB_MASTER, array(), $wgExternalDatawareDB );
 		$now = wfTimestampNow();
@@ -70,7 +70,7 @@ class StaffLogger {
 			$reason
 		)->inLanguage( 'en' )->text();
 		// sadly, $type and $action have 10-character limit, hence 'wikifactor' and 'pubstatus'.
-		self::log( 'wikifactor', 'pubstatus', $wgUser->getID(), $wgUser->getName(), '', '',  $comment );
+		self::log( 'wikifactor', 'pubstatus', $wgUser->getID(), $wgUser->getName(), 0, '',  $comment );
 		return true;
 	}
 }


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3212

Avoid the following:

```
A database query syntax error has occurred. This may indicate a bug in the software. The last attempted database query was:

    (SQL query hidden)

from within function "StaffLogger::log". Database returned error "1366: Incorrect integer value: '' for column 'slog_userdst' at row 1 (geo-db-archive-master.query.consul)".
```