### PR TITLE
User::whoIsReal - use cache

### DIFF
--- a/includes/User.php
+++ b/includes/User.php
@@ -637,8 +637,8 @@ class User implements JsonSerializable {
 	 * @return String|false The corresponding user's real name
 	 */
 	public static function whoIsReal( $id ) {
-		$dbr = wfGetDB( DB_SLAVE );
-		return $dbr->selectField( 'user', 'user_real_name', array( 'user_id' => $id ), __METHOD__ );
+		// Wikia change - @see SUS-1015
+		return self::newFromId( $id )->getRealName();
 	}
 
 	/**


### PR DESCRIPTION
### Before

```sql
> echo User::whoIsReal( 119245 )
Query wikia (DB user: wikia_maint) (3) (slave): SELECT /* User::whoIsReal CommandLineInc - c362de7b-e11a-4fe0-9121-c8fbe143f420 */  user_real_name  FROM `wikicities_c1`.`user`  WHERE user_id = '119245'  LIMIT 1
```

### After

Using cache when calling `User::newFromId`:

```
> echo User::whoIsReal( 119245 )
memcached: get(dev-macbre-plpoznan:user:id:119245)
memcached: MemCache: sock i:0; got dev-macbre-plpoznan:user:id:119245
memcached: get(dev-macbre-wikicities:user_touched:v1:119245)
memcached: MemCache: sock i:0; got dev-macbre-wikicities:user_touched:v1:119245
User: got user 119245 from cache
```