### PR TITLE
SUS-3215 | GenderCache - do not perform queries for IP addresses

### DIFF
--- a/includes/cache/GenderCache.php
+++ b/includes/cache/GenderCache.php
@@ -116,6 +116,9 @@ class GenderCache {
 			if ( isset( $this->cache[$name] ) ) {
 				// Skip users whose gender setting we already know
 				unset( $users[$index] );
+			} elseif ( !User::isValidUserName( $name ) ) {
+				// SUS-3215 - do not perform queries for IP addresses
+				unset( $users[$index] );
 			} else {
 				$users[$index] = $name;
 				// For existing users, this value will be overwritten by the correct value


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3215

Filter-out IP addresses from a list of "users" to check:

```
> var_dump( (GenderCache::singleton())->doQuery(['Macbre', '66.249.79.67']) );
User::isValidUserName: '66.249.79.67' invalid due to empty, IP, slash, colon, length, or lowercase
...
Query wikicities (DB user: wikia_maint) (8) (slave): SELECT /* GenderCache::getGenderOfUsersFromDB CommandLineInc - 8719e47c-b765-4279-a5f3-010079562bf5 */  user_name,up_value  FROM `user` LEFT JOIN `user_properties` ON ((user_id = up_user) AND up_property = 'gender')  WHERE user_name = 'Macbre'  
/usr/wikia/source/deploytools/18879/src/maintenance/eval.php(88) : eval()'d code:1:

> var_dump( (GenderCache::singleton())->doQuery(['66.249.79.67']) );
User::isValidUserName: '66.249.79.67' invalid due to empty, IP, slash, colon, length, or lowercase
...
NULL
```

Avoid the following queries:

```sql
SELECT /* GenderCache::getGenderOfUsersFromDB/Skin::preloadExistence 66.249.79.67 - 2e074b55-02bb-43fa-b996-031ca00d8024 */  user_name,up_value  FROM `user` LEFT JOIN `user_properties` ON ((user_id = up_user) AND up_property = 'gender')  WHERE user_name = '66.249.79.67'
```