### PR TITLE
SUS-3219 | User::whoAre - fall back to well-cached User::whoIs when we want to resolve a single user ID

### DIFF
--- a/includes/User.php
+++ b/includes/User.php
@@ -592,15 +592,29 @@ class User implements JsonSerializable {
 	}
 
 	/**
+	 * Return user ID to user name mapping
 	 *
-	 * @param $ids Array User IDs
-	 * @return Array User ID to User name mapping
+	 * Please note that this method is NOT cached!
+	 *
+	 * @param array $ids User IDs
+	 * @param int $source DB_SLAVE / DB_MASTER
+	 * @return array User ID to User name mapping
 	 */
-	public static function whoAre( Array $ids, $source = DB_SLAVE ): Array {
+	public static function whoAre( Array $ids, $source = DB_SLAVE ): array {
 		global $wgExternalSharedDB;
 
 		if ( $ids == [] ) {
 			return [];
+		}
+		else if ( count( $ids ) === 1 ) {
+			// SUS-3219 - fall back to well-cached User::whoIs when we want to resolve a single user ID
+			$userId = $ids[0];
+
+			return [
+				// Add the name used to indicate anonymous users.
+				0 => wfMessage( 'oasis-anon-user' )->escaped(),
+				$userId => self::whoIs( $userId )
+			];
 		}
 
 		$ids = array_unique( $ids, SORT_NUMERIC );

--- a/includes/User.php
+++ b/includes/User.php
@@ -606,7 +606,7 @@ class User implements JsonSerializable {
 		if ( $ids == [] ) {
 			return [];
 		}
-		else if ( count( $ids ) === 1 ) {
+		elseif ( count( $ids ) === 1 ) {
 			// SUS-3219 - fall back to well-cached User::whoIs when we want to resolve a single user ID
 			$userId = $ids[0];
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3219

`User::whoAre` is responsible for 15% of all queries that hit shared db cluster - **12.8 mm a day**.

These queries come from `ApiQueryLogEvents` class:

```sql
SELECT /* User::whoAre Imperium42bot - 460493ef-80b6-4a15-93aa-8980b0346892 */  user_id,user_name  FROM `user`  WHERE user_id = '33039255' 
```

### After a fix

```sql
> var_dump( User::whoAre( [2, 5] ) )
LoadBalancer::openForeignConnection: reusing connection 1/wikicities
Query wikicities (DB user: wikia_maint) (46) (slave): SELECT /* User::whoAre CommandLineInc - 832ebb01-eba5-4fae-8b63-3485b35e64ef */  user_id,user_name  FROM `user`  WHERE user_id IN ('2','5')   
array(3) {
  [2] =>
  string(6) "Angela"
  [5] =>
  string(8) "Hemanshu"
  [0] =>
  string(26) "Użytkownik portalu FANDOM"
}

--

> var_dump( User::whoAre( [2] ) )
User: got user 2 from cache
array(2) {
  [0] =>
  string(26) "Użytkownik portalu FANDOM"
  [2] =>
  string(6) "Angela"
}
```

Calling this method with a single ID will use well-cached `User::whoIs`.