### PR TITLE
PLATFORM-3274: use WikiFactory::getLocalEnvURL everywhere

### DIFF
--- a/extensions/wikia/Search/classes/Services/EntitySearchService.php
+++ b/extensions/wikia/Search/classes/Services/EntitySearchService.php
@@ -232,7 +232,7 @@ class EntitySearchService extends AbstractSearchService {
 	}
 
 	public function replaceHostUrl( $url ) {
-	    return WikiFactory::getLocalEnvURL( $url );
+		return WikiFactory::getLocalEnvURL( $url );
 	}
 
 }

--- a/extensions/wikia/Search/classes/Services/EntitySearchService.php
+++ b/extensions/wikia/Search/classes/Services/EntitySearchService.php
@@ -232,15 +232,7 @@ class EntitySearchService extends AbstractSearchService {
 	}
 
 	public function replaceHostUrl( $url ) {
-		global $wgStagingEnvironment, $wgDevelEnvironment;
-		if ( $wgStagingEnvironment || $wgDevelEnvironment ) {
-			return preg_replace_callback( self::WIKIA_URL_REGEXP, [ $this, 'replaceHost' ], $url );
-		}
-
-		return $url;
+	    return WikiFactory::getLocalEnvURL( $url );
 	}
 
-	protected function replaceHost( $details ) {
-		return $details[1] . WikiFactory::getCurrentStagingHost( $details[4], $details[3] );
-	}
 }

--- a/extensions/wikia/Search/classes/Test/Services/MovieEntitySearchServiceTest.php
+++ b/extensions/wikia/Search/classes/Test/Services/MovieEntitySearchServiceTest.php
@@ -8,10 +8,10 @@ class MovieEntitySearchServiceTest extends BaseTest {
 
 	/** @test */
 	public function shouldReturnCorrectArticleFormat() {
-		$this->getStaticMethodMock( '\WikiFactory', 'getCurrentStagingHost' )
+		$this->getStaticMethodMock( '\WikiFactory', 'getLocalEnvURL' )
 			->expects( $this->any() )
-			->method( 'getCurrentStagingHost' )
-			->will( $this->returnCallback( [ $this, 'mock_getCurrentStagingHost' ] ) );
+			->method( 'getLocalEnvURL' )
+			->will( $this->returnCallback( [ $this, 'mock_getLocalEnvURL' ] ) );
 
 		$mock = $this->getSolariumMock();
 		$mock->expects( $this->once() )
@@ -32,9 +32,9 @@ class MovieEntitySearchServiceTest extends BaseTest {
 		], $res );
 	}
 
-	public function mock_getCurrentStagingHost($arg1, $arg2)
+	public function mock_getLocalEnvURL($arg1, $arg2)
 	{
-		return 'newhost';
+	    return preg_replace('/https?:\/\/[^\/]+/', 'http://newhost', $arg1, 1);
 	}
 
 	private function getSolariumMock() {

--- a/extensions/wikia/Search/classes/Test/Services/MovieEntitySearchServiceTest.php
+++ b/extensions/wikia/Search/classes/Test/Services/MovieEntitySearchServiceTest.php
@@ -34,7 +34,7 @@ class MovieEntitySearchServiceTest extends BaseTest {
 
 	public function mock_getLocalEnvURL($arg1, $arg2)
 	{
-	    return preg_replace('/https?:\/\/[^\/]+/', 'http://newhost', $arg1, 1);
+		return preg_replace('/https?:\/\/[^\/]+/', 'http://newhost', $arg1, 1);
 	}
 
 	private function getSolariumMock() {

--- a/extensions/wikia/Search/classes/Test/Services/SeriesEntitySearchServiceTest.php
+++ b/extensions/wikia/Search/classes/Test/Services/SeriesEntitySearchServiceTest.php
@@ -8,10 +8,10 @@ class SeriesEntitySearchServiceTest extends BaseTest {
 
 	/** @test */
 	public function shouldReturnCorrectFormat() {
-		$this->getStaticMethodMock( '\WikiFactory', 'getCurrentStagingHost' )
+		$this->getStaticMethodMock( '\WikiFactory', 'getLocalEnvURL' )
 			->expects( $this->any() )
-			->method( 'getCurrentStagingHost' )
-			->will( $this->returnCallback( [ $this, 'mock_getCurrentStagingHost' ] ) );
+			->method( 'getLocalEnvURL' )
+			->will( $this->returnCallback( [ $this, 'mock_getLocalEnvURL' ] ) );
 
 		$mock = $this->getSolariumMock();
 		$mock->expects( $this->once() )
@@ -32,9 +32,9 @@ class SeriesEntitySearchServiceTest extends BaseTest {
 		], $res );
 	}
 
-	public function mock_getCurrentStagingHost($arg1, $arg2)
+	public function mock_getLocalEnvURL($arg1, $arg2)
 	{
-		return 'newhost';
+        return preg_replace('/https?:\/\/[^\/]+/', 'http://newhost', $arg1, 1);
 	}
 
 	private function getSolariumMock() {

--- a/extensions/wikia/Search/classes/Test/Services/SeriesEntitySearchServiceTest.php
+++ b/extensions/wikia/Search/classes/Test/Services/SeriesEntitySearchServiceTest.php
@@ -34,7 +34,7 @@ class SeriesEntitySearchServiceTest extends BaseTest {
 
 	public function mock_getLocalEnvURL($arg1, $arg2)
 	{
-        return preg_replace('/https?:\/\/[^\/]+/', 'http://newhost', $arg1, 1);
+		return preg_replace('/https?:\/\/[^\/]+/', 'http://newhost', $arg1, 1);
 	}
 
 	private function getSolariumMock() {

--- a/extensions/wikia/WallNotifications/WallNotificationControllerBase.class.php
+++ b/extensions/wikia/WallNotifications/WallNotificationControllerBase.class.php
@@ -123,7 +123,7 @@ abstract class WallNotificationControllerBase extends WikiaService {
 		$oldestEntity = end( $notify[ 'grouped' ] );
 		$url = empty( $oldestEntity->data->url ) ? '' : $oldestEntity->data->url;
 		$title = $this->shortenTitle( $data->thread_title ?? '' );
-		$this->response->setVal( 'url', $this->fixNotificationURL( $url ) );
+		$this->response->setVal( 'url', WikiFactory::getLocalEnvURL( $url ) );
 		$this->response->setVal( 'authors', array_reverse( $authors ) );
 		$this->response->setVal( 'title', $title );
 		$this->response->setVal( 'iso_timestamp', wfTimestamp( TS_ISO_8601, $data->timestamp ) );
@@ -169,7 +169,7 @@ abstract class WallNotificationControllerBase extends WikiaService {
 			}
 		}
 
-		$this->response->setVal( 'url', $this->fixNotificationURL( $data->url ) );
+		$this->response->setVal( 'url', WikiFactory::getLocalEnvURL( $data->url ) );
 		$this->response->setVal( 'msg', $msg );
 		$this->response->setVal( 'authors', $authors );
 		$this->response->setVal( 'iso_timestamp', wfTimestamp( TS_ISO_8601, $data->timestamp ) );
@@ -224,29 +224,6 @@ abstract class WallNotificationControllerBase extends WikiaService {
 		}
 		$msg = wfMessage( $msgid, $params )->text();
 		return $msg;
-	}
-
-	protected function fixNotificationURL( $url ) {
-		global $wgStagingList;
-		$hostOn = getHostPrefix();
-
-		$hosts = $wgStagingList;
-		foreach ( $hosts as $host ) {
-			$prefix = 'http://' . $host . '.';
-			if ( strpos( $url, $prefix ) !== false ) {
-				if ( empty( $hostOn ) ) {
-					return str_replace( $prefix, 'http://', $url );
-				} else {
-					return str_replace( $prefix, 'http://' . $hostOn . '.', $url );
-				}
-			}
-		}
-
-		if ( !empty( $hostOn ) ) {
-			return str_replace( 'http://', 'http://' . $hostOn . '.', $url );
-		}
-
-		return $url;
 	}
 
 	/**

--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -1166,36 +1166,6 @@ class WikiFactory {
 		return isset( $oRow->city_dbname ) ? $oRow->city_dbname : false;
 	}
 
-
-	/**
-	 * Convert given host to current environment (devbox or sandbox).
-	 * @param string $dbName
-	 * @param string $default if on main wikia
-	 * @param string $host for testing
-	 * @return string changed host or $default
-	 */
-	public static function getCurrentStagingHost( $dbName='', $default='', $host = null) {
-		global $wgStagingList, $wgDevDomain;
-
-		if ( $host === null ) {
-			$host = gethostname();
-		}
-
-		if ( preg_match( '/^(demo-[a-z0-9]+)-[s|r][0-9]+$/i', $host, $m ) ) {
-			return ( $dbName ? $dbName : 'www' )  . '.' . $m[ 1 ] . static::WIKIA_TOP_DOMAIN;
-		}
-
-		if ( in_array( $host, $wgStagingList ) ) {
-			return ( $dbName ? $dbName : 'www' ) . '.' . $host . static::WIKIA_TOP_DOMAIN;
-		}
-
-		if ( preg_match( '/^dev-([a-z0-9]+)$/i', $host ) ) {
-			return "{$dbName}.{$wgDevDomain}";
-		}
-
-		return $default;
-	}
-
 	/**
 	 * getLocalEnvURL
 	 *

--- a/extensions/wikia/WikiFactory/tests/WikiFactoryTest.php
+++ b/extensions/wikia/WikiFactory/tests/WikiFactoryTest.php
@@ -3,18 +3,10 @@
 class WikiFactoryTest extends WikiaBaseTest {
 
 	private $serverName = null;
-	/**
-	 * Only for holding original values
-	 * @var array
-	 */
-	private $org_StagingList;
 
 	public function setUp() {
 		parent::setUp();
 
-		global $wgStagingList;
-		$this->org_StagingList = $wgStagingList;
-		$wgStagingList = ['teststagging'];
 		if ( isset($_SERVER['SERVER_NAME'] ) ) {
 			$this->serverName = $_SERVER['SERVER_NAME'];
 		}
@@ -23,23 +15,9 @@ class WikiFactoryTest extends WikiaBaseTest {
 	public function tearDown() {
 		parent::tearDown();
 
-		global $wgStagingList;
-		$wgStagingList = $this->org_StagingList;
 		if ( !empty($this->serverName) ) {
 			$_SERVER['SERVER_NAME'] = $this->serverName;
 		}
-	}
-
-	public function testGetCurrentStagingHostSandbox()
-	{
-		$this->assertEquals('muppet.teststagging.wikia.com',
-			WikiFactory::getCurrentStagingHost('muppet','http://www.muppet.wikia.com/', 'teststagging'));
-	}
-
-	public function testGetCurrentStagingHostDevbox() {
-		$this->mockGlobalVariable( 'wgDevDomain', 'mydevbox.wikia-dev.com' );
-		$this->assertEquals('muppet.mydevbox.wikia-dev.com',
-			WikiFactory::getCurrentStagingHost('muppet','http://www.muppet.wikia.com/', 'dev-mydevbox'));
 	}
 
 	/**
@@ -52,77 +30,11 @@ class WikiFactoryTest extends WikiaBaseTest {
 	}
 
 	/**
-	 * @dataProvider getCurrentStagingHostDataProvider
-	 */
-	public function testGetCurrentStagingHost($host, $dbName, $devDomain, $expHost) {
-		$default = 'defaulthost';
-		$this->mockGlobalVariable('wgStagingList', ['preview',
-			'verify',
-			'sandbox-s1',
-			'sandbox-s2',
-			'sandbox-s3',
-			'sandbox-s4',
-			'sandbox-s5',
-			'sandbox-sony',
-			'externaltest',
-			'sandbox-qa01',
-			'sandbox-qa02',
-			'sandbox-qa03',
-			'sandbox-qa04',
-			'demo-sony',
-		] );
-		$this->mockGlobalVariable( 'wgDevDomain', $devDomain );
-
-		$this->assertEquals($expHost, WikiFactory::getCurrentStagingHost($dbName, $default, $host));
-	}
-
-	/**
 	 * @dataProvider prepareUrlToParseDataProvider
 	 */
 	public function testPrepareUrlToParse( $url, $expected ) {
 		$url = WikiFactory::prepareUrlToParse( $url );
 		$this->assertEquals( $expected, $url );
-	}
-
-	public function getCurrentStagingHostDataProvider() {
-		return [
-			[
-				'demo-sony-s1',
-				'muppet',
-				'',
-				'muppet.demo-sony.wikia.com'
-			],
-			[
-				'demo-sony-s2',
-				'muppet',
-				'',
-				'muppet.demo-sony.wikia.com'
-			],
-			[
-				'preview',
-				'muppet',
-				'',
-				'muppet.preview.wikia.com'
-			],
-			[
-				'verify',
-				'muppet',
-				'',
-				'muppet.verify.wikia.com',
-			],
-			[
-				'dev-test',
-				'muppet',
-				'test.wikia-dev.com',
-				'muppet.test.wikia-dev.com',
-			],
-			[
-				'sandbox-s3',
-				'muppet',
-				'',
-				'muppet.sandbox-s3.wikia.com'
-			]
-		];
 	}
 
 	public function getLocalEnvURLDataProvider() {

--- a/includes/wikia/GlobalFunctions.php
+++ b/includes/wikia/GlobalFunctions.php
@@ -1361,28 +1361,6 @@ function wfGetBeaconId() {
 }
 
 /**
- * Allow to find what staging machine we are on
- *
- * @author Tomasz Odrobny <tomek@wikia-inc.com>
- */
-function getHostPrefix() {
-	global $wgStagingList, $wgServer;
-	static $cache;
-	if ( !empty( $cache ) ) {
-		return $cache;
-	}
-	$hosts = $wgStagingList;
-	foreach ( $hosts as $host ) {
-		$prefix = 'http://' . $host . '.';
-		if ( strpos( $wgServer, $prefix )  !== false ) {
-			$cache = $host;
-			return  $host;
-		}
-	}
-	return null;
-}
-
-/**
  * Defines error handler to log backtrace for PHP (catchable) fatal errors
  *
  * @author Maciej Brencz <macbre@wikia-inc.com>


### PR DESCRIPTION
Get rid of custom implementations and use WikiFactory::getLocalEnvURL. 

Config cleanup: https://github.com/Wikia/config/pull/2313

FYI: @Wikia/sus 