### PR TITLE
SUS-3221 | Client::isConsulAddress - handle Consul geo queries

### DIFF
--- a/lib/Wikia/src/Consul/Client.php
+++ b/lib/Wikia/src/Consul/Client.php
@@ -10,12 +10,13 @@
 namespace Wikia\Consul;
 
 use SensioLabs\Consul\ServiceFactory;
+use Wikia\Logger\Loggable;
 use Wikia\Logger\WikiaLogger;
 use Wikia\Util\Assert;
 
 class Client {
 
-	use \Wikia\Logger\Loggable;
+	use Loggable;
 
 	protected $logger;
 
@@ -74,10 +75,10 @@ class Client {
 	 * Example: Wikia\Consul\Catalog::isConsulAddress( 'slave.db-smw.service.consul' )
 	 *
 	 * @param $address
-	 * @preturn bool true if the given address is a consul one
+	 * @return bool true if the given address is a consul one
 	 */
 	static function isConsulAddress( $address ) {
-		return endsWith( $address, '.service.consul' );
+		return endsWith( $address, '.consul' );
 	}
 
 	/**

--- a/lib/Wikia/tests/Consul/ClientTest.php
+++ b/lib/Wikia/tests/Consul/ClientTest.php
@@ -10,6 +10,7 @@ class ConsulClientTest extends WikiaBaseTest {
 	function testIsConsulAddress() {
 		$this->assertTrue( Client::isConsulAddress( 'slave.db-smw.service.consul' ) );
 		$this->assertTrue( Client::isConsulAddress( 'master.db-a.service.consul' ) );
+		$this->assertTrue( Client::isConsulAddress( 'geo-db-sharedb-master.query.consul' ) );
 
 		$this->assertFalse( Client::isConsulAddress( 'statsdb-s9' ) );
 	}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3221

```sql
SHOW /* DatabaseMysqlBase::getLagFromSlaveStatus  - fdfa9466-a6ad-49ac-97ff-b1db13d19da6 */ SLAVE STATUS
```

This query is performed **~3.8 mm times a day on `wikicities` shared database**. Let's rely on Consul health-checks here as we used to, but stopped after introducing Consul's queries.