### PR TITLE
SUS-3222: Ensure all log events are attributed to registered users

### DIFF
--- a/extensions/wikia/TemplateClassification/TemplateBulkClassificationTask.class.php
+++ b/extensions/wikia/TemplateClassification/TemplateBulkClassificationTask.class.php
@@ -9,7 +9,19 @@ class TemplateBulkClassificationTask extends BaseTask {
 	public function classifyTemplates( $templates, $templateType, $userId, $category ) {
 		$wikiId = $this->getWikiId();
 
+		$user = \User::newFromId( $userId );
+		if ( !$user ) {
+			$this->error( 'Template Bulk Classification - Invalid user', [
+				'userId' => $userId
+			] );
+			return;
+		}
+
+		$context = new \DerivativeContext( \RequestContext::getMain() );
+		$context->setUser( $user );
+
 		$utcs = new \UserTemplateClassificationService();
+		$utcs->setContext( $context );
 		$errors = $utcs->classifyMultipleTemplates( $wikiId, $templates, $templateType, $userId );
 
 		$this->logResults( $wikiId, $templates, $templateType, $userId, $category, $errors );

--- a/extensions/wikia/TemplateClassification/TemplateClassification.hooks.php
+++ b/extensions/wikia/TemplateClassification/TemplateClassification.hooks.php
@@ -51,6 +51,7 @@ class Hooks {
 		if ( empty( $typeNew )
 			 || $typeNew === \TemplateClassificationService::NOT_AVAILABLE
 			 || $typeNew === $typeCurrent
+			 || $user->isAnon()
 		) {
 			return true;
 		}

--- a/extensions/wikia/TemplateClassification/services/UserTemplateClassificationService.class.php
+++ b/extensions/wikia/TemplateClassification/services/UserTemplateClassificationService.class.php
@@ -9,6 +9,13 @@ class UserTemplateClassificationService extends TemplateClassificationService {
 	const CLASSIFY_TEMPLATE_EXCEPTION_MESSAGE = 'Bad request. Template type %s is not valid.';
 	const CLASSIFY_TEMPLATE_EXCEPTION_CODE = 400;
 
+	/** @var Logger $logger */
+	private $logger;
+
+	public function __construct() {
+		$this->logger = new Logger();
+	}
+
 	/**
 	 * Allowed types of templates stored in an array to make a validation process easier.
 	 *
@@ -42,6 +49,11 @@ class UserTemplateClassificationService extends TemplateClassificationService {
 		self::TEMPLATE_INFOBOX,
 		self::TEMPLATE_CUSTOM_INFOBOX,
 	];
+
+	public function setContext( IContextSource $context ) {
+		parent::setContext( $context );
+		$this->logger->setContext( $context );
+	}
 
 	/**
 	 * Fallback to the Unclassified string if a received type is not supported by
@@ -105,7 +117,7 @@ class UserTemplateClassificationService extends TemplateClassificationService {
 
 		parent::classifyTemplate( $wikiId, $pageId, $templateType, $origin, $provider );
 
-		( new Logger() )->logClassificationChange( $pageId, $templateType, $oldType );
+		$this->logger->logClassificationChange( $pageId, $templateType, $oldType );
 
 		$title = Title::newFromID( $pageId );
 		if ( $title instanceof Title ) {

--- a/includes/logging/LogEntry.php
+++ b/includes/logging/LogEntry.php
@@ -417,6 +417,12 @@ class ManualLogEntry extends LogEntryBase {
 		# Truncate for whole multibyte characters.
 		$comment = $wgContLang->truncate( $this->getComment(), 255 );
 
+		// SUS-3222: All log entries should be attributed to registered users
+		if ( $this->getPerformer()->isAnon() ) {
+			\Wikia\Logger\WikiaLogger::instance()
+				->warning( 'SUS-3222 - Anon user log entry' );
+		}
+
 		$data = array(
 			'log_id' => $id,
 			'log_type' => $this->getType(),

--- a/includes/logging/LogPage.php
+++ b/includes/logging/LogPage.php
@@ -92,6 +92,12 @@ class LogPage {
 		$dbw = wfGetDB( DB_MASTER );
 		$log_id = $dbw->nextSequenceValue( 'logging_log_id_seq' );
 
+		// SUS-3222: All log entries should be attributed to registered users
+		if ( $this->doer->isAnon() ) {
+			\Wikia\Logger\WikiaLogger::instance()
+				->warning( 'SUS-3222 - Anon user log entry' );
+		}
+
 		$this->timestamp = $now = wfTimestampNow();
 		$data = array(
 			'log_id' => $log_id,

--- a/includes/wikia/services/TemplateClassificationService.class.php
+++ b/includes/wikia/services/TemplateClassificationService.class.php
@@ -6,7 +6,7 @@ use Swagger\Client\TemplateClassification\Storage\Models\TemplateTypeProvider;
 use Wikia\DependencyInjection\Injector;
 use Wikia\Service\Swagger\ApiProvider;
 
-class TemplateClassificationService {
+class TemplateClassificationService extends ContextSource {
 
 	const SERVICE_NAME = 'template-classification-storage';
 

--- a/maintenance/wikia/deleteImageRevision.php
+++ b/maintenance/wikia/deleteImageRevision.php
@@ -19,6 +19,11 @@ class DeleteImageRevision extends Maintenance {
 
 
 	public function execute() {
+		global $wgUser;
+
+		// SUS-3222: Delete as official bot
+		$wgUser = User::newFromName( Wikia::BOT_USER, false );
+
 		$pageId = intval( $this->getOption( self::PAGE_ID_OPTION ) );
 		$revisionId = intval( $this->getOption( self::REVISION_ID_OPTION ) );
 		$reason = wfMessage( 'imagereview-reason' )->inContentLanguage()->plain();


### PR DESCRIPTION
MediaWiki does not support attributing log events to anonymous users. Let's make sure that all new log events are attributed to registered users going forward.

https://wikia-inc.atlassian.net/browse/SUS-3222