### PR TITLE
SUS-2977 | remove wgSharedDB checks

### DIFF
--- a/extensions/wikia/CreateNewWiki/tasks/CreateTables.php
+++ b/extensions/wikia/CreateNewWiki/tasks/CreateTables.php
@@ -52,12 +52,6 @@ class CreateTables extends Task {
 	}
 
 	public function run() {
-		global $wgSharedDB;
-		$tmpSharedDB = $wgSharedDB;
-		//This is needed because otherwise the underlying tableName() function treats the "user" table as a shared table
-		//and adds a DB prefix which causes the table to be created in a wikicities_x DB instead of the newly created one
-		$wgSharedDB = $this->taskContext->getDBname();
-
 		$dbw = wfGetDB( DB_MASTER, [ ], $this->taskContext->getDBname() );
 		$this->taskContext->setWikiDBW( $dbw );
 
@@ -69,7 +63,6 @@ class CreateTables extends Task {
 				return TaskResult::createForError( "Failed to run sql script " . $file );
 			}
 		}
-		$wgSharedDB = $tmpSharedDB;
 
 		//Add stats entry
 		$this->taskContext->getWikiDBW()->insert( "site_stats", [ "ss_row_id" => "1" ], __METHOD__ );

--- a/extensions/wikia/EditPageLayout/EditPageLayoutAjax.class.php
+++ b/extensions/wikia/EditPageLayout/EditPageLayoutAjax.class.php
@@ -158,18 +158,6 @@ class EditPageLayoutAjax {
 		if ($wgUser->isLoggedIn()) {
 			$wgUser->setGlobalPreference($name, $value);
 			$wgUser->saveSettings();
-
-			// commit changes to local db
-			$dbw = wfGetDB( DB_MASTER );
-			$dbw->commit();
-
-			// commit changes to shared db
-			global $wgExternalSharedDB, $wgSharedDB;
-			if( isset( $wgSharedDB ) ) {
-				$dbw = wfGetDB( DB_MASTER, array(), $wgExternalSharedDB );
-				$dbw->commit();
-			}
-
 			return true;
 		} else {
 			return false;

--- a/extensions/wikia/SiteWideMessages/SpecialSiteWideMessages.php
+++ b/extensions/wikia/SiteWideMessages/SpecialSiteWideMessages.php
@@ -57,16 +57,12 @@ $wgResourceModules['ext.siteWideMessages.anon'] = array(
  *
  */
 function SiteWideMessagesInit() {
-	global $wgSharedDB, $wgDontWantShared;
-	//Include files ONLY when SharedDB is defined and desired.
-	if (isset($wgSharedDB) && empty($wgDontWantShared)) {
-		global $wgHooks;
-		$wgHooks['WikiFactoryPublicStatusChange'][] = 'SiteWideMessagesPublicStatusChange';
-		$wgHooks['SiteNoticeAfter'][] = 'SiteWideMessagesSiteNoticeAfter';
+	global $wgHooks;
+	$wgHooks['WikiFactoryPublicStatusChange'][] = 'SiteWideMessagesPublicStatusChange';
+	$wgHooks['SiteNoticeAfter'][] = 'SiteWideMessagesSiteNoticeAfter';
 
-		// macbre: notifications for Oasis
-		$wgHooks['SkinTemplateOutputPageBeforeExec'][] = 'SiteWideMessagesAddNotifications';
-	}
+	// macbre: notifications for Oasis
+	$wgHooks['SkinTemplateOutputPageBeforeExec'][] = 'SiteWideMessagesAddNotifications';
 }
 
 /**


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-2977

* remove `wgSharedDB` checks, it now default to null
* `wgDontWantShared` removed as well - there was no default value set nor in the code nor in config, WikiFactory has this variable defined, but it's not set on any wiki (variable has been removed from a database)
* CreateNewWikis' `CreateTables` class no longer needs to "mock" `wgSharedDB` to force creation of previously shared table (`user`) on a local wiki database (we're considering removing per-wiki `user` tables)