### PR TITLE
SUS-3221 | ApiMain::checkMaxLag - Consul health checks make sure that we only have healthy slaves serving traffic

### DIFF
--- a/extensions/wikia/WikiaApi/WikiaApiQuery.php
+++ b/extensions/wikia/WikiaApi/WikiaApiQuery.php
@@ -18,7 +18,8 @@ define ('WIKIA_API_QUERY_MIN_OFFSET',	0);
 define ('WIKIA_API_QUERY_CTIME',	5 * 60 * 3);
 define ('WIKIA_API_QUERY_MIN_CTIME',	5);
 
-define ('WIKIA_API_QUERY_DBNAME',	$wgDBname);
+global $wgDBName;
+define ('WIKIA_API_QUERY_DBNAME',	$wgDBName);
 
 define ('COOKIE_EXPR',	15552000);
 

--- a/includes/api/ApiMain.php
+++ b/includes/api/ApiMain.php
@@ -631,10 +631,13 @@ class ApiMain extends ApiBase {
 	/**
 	 * Check the max lag if necessary
 	 * @param $module ApiBase object: Api module being used
-	 * @param $params Array an array containing the request parameters.
+	 * @param $params array an array containing the request parameters.
 	 * @return boolean True on success, false should exit immediately
 	 */
 	protected function checkMaxLag( $module, $params ) {
+		# Wikia change - SUS-3221 | Consul health checks make sure that we only have healthy slaves serving traffic
+		return true;
+		/**
 		if ( $module->shouldCheckMaxlag() && isset( $params['maxlag'] ) ) {
 			// Check for maxlag
 			global $wgShowHostnames;
@@ -655,6 +658,7 @@ class ApiMain extends ApiBase {
 			}
 		}
 		return true;
+		**/
 	}
 
 	/**


### PR DESCRIPTION
Save a few queries:

```sql
SHOW /* DatabaseMysqlBase::getLagFromSlaveStatus  - fdfa9466-a6ad-49ac-97ff-b1db13d19da6 */ SLAVE STATUS
```

A follow-up of #14153