### PR TITLE
SUS-3219 | handle duplicated IDs in User::whoAre

### DIFF
--- a/includes/User.php
+++ b/includes/User.php
@@ -604,7 +604,10 @@ class User implements JsonSerializable {
 		if ( $ids == [] ) {
 			return [];
 		}
-		elseif ( count( $ids ) === 1 ) {
+
+		$ids = array_unique( $ids, SORT_NUMERIC );
+
+		if ( count( $ids ) === 1 ) {
 			// SUS-3219 - fall back to well-cached User::whoIs when we want to resolve a single user ID
 			$userId = $ids[0];
 
@@ -614,8 +617,6 @@ class User implements JsonSerializable {
 				$userId => self::whoIs( $userId )
 			];
 		}
-
-		$ids = array_unique( $ids, SORT_NUMERIC );
 
 		$sdb = wfGetDB( $source, [], $wgExternalSharedDB );
 		$res = $sdb->select(


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3219

A follow-up of #14151

Avoid the following queries - try to satisfy them with cached data from `User::whoIs`:

```sql
SELECT /* User::whoAre Imperium42bot - 6d99b104-d5a7-4191-99bc-d51fbcbac8bc */  user_id,user_name  FROM `user`  WHERE user_id = '31674317'  
```

### Before

```
> var_dump(User::whoAre( [2, 2] ))
...
Query wikicities (DB user: wikia_maint) (7) (slave): SELECT /* User::whoAre CommandLineInc - 5ff158dd-df8d-4665-b2cd-4dc41feda793 */  user_id,user_name  FROM `user`  WHERE user_id = '2'  
...
array(2) {
  [2] =>
  string(6) "Angela"
  [0] =>
  string(26) "Użytkownik portalu FANDOM"
}
```

### After

```
> var_dump(User::whoAre( [2, 2] ))
...
memcached: get(dev-macbre-plpoznan:user:id:2)
memcached: MemCache: sock i:0; got dev-macbre-plpoznan:user:id:2
memcached: get(dev-macbre-wikicities:user_touched:v1:2)
memcached: MemCache: sock i:0; got dev-macbre-wikicities:user_touched:v1:2
User: got user 2 from cache
...
array(2) {
  [0] =>
  string(26) "Użytkownik portalu FANDOM"
  [2] =>
  string(6) "Angela"
}
```