### PR TITLE
SUS-2977 | do not call ExternalUser_Wikia::initFromCond

### DIFF
--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -35,10 +35,6 @@ $wgHooks['BeforeInitialize']         [] = "Wikia::onBeforeInitializeMemcachePurg
 $wgHooks['SkinTemplateOutputPageBeforeExec'][] = "Wikia::onSkinTemplateOutputPageBeforeExec";
 $wgHooks['UploadVerifyFile']         [] = 'Wikia::onUploadVerifyFile';
 
-# User hooks
-$wgHooks['UserNameLoadFromId']       [] = "Wikia::onUserNameLoadFromId";
-$wgHooks['UserLoadFromDatabase']     [] = "Wikia::onUserLoadFromDatabase";
-
 # Swift file backend
 $wgHooks['AfterSetupLocalFileRepo']  [] = "Wikia::onAfterSetupLocalFileRepo";
 $wgHooks['BeforeRenderTimeline']     [] = "Wikia::onBeforeRenderTimeline";
@@ -1492,40 +1488,6 @@ class Wikia {
 		}
 
 		return $isValid;
-	}
-
-	/*
-	 * @param $user_name String
-	 * @param $s ResultWrapper
-	 * @param $bUserObject boolean Return instance of User if true; StdClass (row) otherwise.
-	 */
-	public static function onUserNameLoadFromId( $user_name, &$s, $bUserObject = false ) {
-		global $wgExternalAuthType;
-		if ( $wgExternalAuthType ) {
-			$mExtUser = ExternalUser::newFromName( $user_name );
-			if ( is_object( $mExtUser ) && ( 0 != $mExtUser->getId() ) ) {
-				$s = $mExtUser->getLocalUser( $bUserObject );
-			}
-		}
-
-		return true;
-	}
-
-	/**
-	 * @param $user User
-	 * @param $s ResultWrapper
-	 */
-	public static function onUserLoadFromDatabase( $user, &$s ) {
-		/* wikia change */
-		global $wgExternalAuthType;
-		if ( $wgExternalAuthType ) {
-			$mExtUser = ExternalUser::newFromId( $user->mId );
-			if ( is_object( $mExtUser ) && ( 0 != $mExtUser->getId() ) ) {
-				$s = $mExtUser->getLocalUser( false );
-			}
-		}
-
-		return true;
 	}
 
 	/**


### PR DESCRIPTION
Internally it queries `wikicities.user`, it's already performed by `User` class.

This code is no longer called after https://github.com/Wikia/config/pull/2314 (`$wgExternalAuthType` is now set to null).

**Save ~5.8 mm queries a day to shared DB:**

```sql
SELECT /* ExternalUser_Wikia::initFromCond Redride' s OG - b1fcbaca-e625-4c41-b382-a32235cb81c4 */  *  FROM `user`  WHERE user_id = '1121346'  LIMIT 1  
```