### PR TITLE
SUS-3079: Create rc_ip_bin column for Recent Changes

### DIFF
--- a/includes/wikia/WikiaUpdater.php
+++ b/includes/wikia/WikiaUpdater.php
@@ -36,6 +36,7 @@ class WikiaUpdater {
 			# fields
 			array( 'addField', 'watchlist', 'wl_wikia_addedtimestamp', $dir . 'patch-watchlist-improvements.sql', true ),
 			array( 'modifyField', 'recentchanges', 'rc_ip', $dir . 'patch-rc_ip-varbinary.sql', true ),
+			array( 'addField', 'recentchanges', 'rc_ip_bin',$dir . 'patch-rc_ip_bin.sql', true ), // SUS-3079
 
 			# indexes
 			array( 'addIndex', 'archive', 'page_revision', $dir. 'patch-index-archive-page_revision.sql', true ),

--- a/maintenance/archives/wikia/patch-populate-rc_ip_bin.sql
+++ b/maintenance/archives/wikia/patch-populate-rc_ip_bin.sql
@@ -1,0 +1,4 @@
+-- SUS-3079: Populate rc_ip_bin column
+
+UPDATE /*$wgDBPrefix*/recentchanges
+  SET rc_ip_bin = IFNULL(INET6_ATON(rc_ip), '') WHERE rc_user = 0 AND rc_ip_bin = '';

--- a/maintenance/archives/wikia/patch-populate-rc_ip_bin.sql
+++ b/maintenance/archives/wikia/patch-populate-rc_ip_bin.sql
@@ -1,4 +1,4 @@
 -- SUS-3079: Populate rc_ip_bin column
 
 UPDATE /*$wgDBPrefix*/recentchanges
-  SET rc_ip_bin = IFNULL(INET6_ATON(rc_ip), '') WHERE rc_user = 0 AND rc_ip_bin = '';
+  SET rc_ip_bin = IFNULL(INET6_ATON(rc_ip), '') WHERE rc_ip_bin = '';

--- a/maintenance/archives/wikia/patch-rc_ip_bin.sql
+++ b/maintenance/archives/wikia/patch-rc_ip_bin.sql
@@ -1,0 +1,6 @@
+-- SUS-3079: Create rc_ip_bin column and index for recentchanges table
+
+ALTER TABLE /*$wgDBPrefix*/recentchanges
+  ADD rc_ip_bin VARBINARY(16) NULL DEFAULT NULL;
+
+CREATE INDEX /*i*/rc_ip_bin ON /*_*/recentchanges (rc_ip_bin);

--- a/maintenance/archives/wikia/patch-rc_ip_bin.sql
+++ b/maintenance/archives/wikia/patch-rc_ip_bin.sql
@@ -1,6 +1,6 @@
 -- SUS-3079: Create rc_ip_bin column and index for recentchanges table
 
 ALTER TABLE /*$wgDBPrefix*/recentchanges
-  ADD rc_ip_bin VARBINARY(16) NULL DEFAULT NULL;
+  ADD rc_ip_bin VARBINARY(16) NOT NULL DEFAULT '';
 
 CREATE INDEX /*i*/rc_ip_bin ON /*_*/recentchanges (rc_ip_bin);

--- a/maintenance/tables.sql
+++ b/maintenance/tables.sql
@@ -1017,7 +1017,7 @@ CREATE TABLE /*_*/recentchanges (
   rc_ip varbinary(40) NOT NULL default '',
 
   -- SUS-3079: IP address the edit was made from, in binary format
-  rc_ip_bin VARBINARY(16) NULL DEFAULT NULL,
+  rc_ip_bin VARBINARY(16) NOT NULL DEFAULT '',
 
   -- Text length in characters before
   -- and after the edit

--- a/maintenance/tables.sql
+++ b/maintenance/tables.sql
@@ -1016,6 +1016,9 @@ CREATE TABLE /*_*/recentchanges (
   -- $wgPutIPinRC option is enabled.
   rc_ip varbinary(40) NOT NULL default '',
 
+  -- SUS-3079: IP address the edit was made from, in binary format
+  rc_ip_bin VARBINARY(16) NULL DEFAULT NULL,
+
   -- Text length in characters before
   -- and after the edit
   rc_old_len int,
@@ -1039,6 +1042,7 @@ CREATE INDEX /*i*/rc_namespace_title ON /*_*/recentchanges (rc_namespace, rc_tit
 CREATE INDEX /*i*/rc_cur_id ON /*_*/recentchanges (rc_cur_id);
 CREATE INDEX /*i*/new_name_timestamp ON /*_*/recentchanges (rc_new,rc_namespace,rc_timestamp);
 CREATE INDEX /*i*/rc_ip ON /*_*/recentchanges (rc_ip);
+CREATE INDEX /*i*/rc_ip_bin ON /*_*/recentchanges (rc_ip_bin);
 CREATE INDEX /*i*/rc_ns_usertext ON /*_*/recentchanges (rc_namespace, rc_user_text);
 CREATE INDEX /*i*/rc_user_text ON /*_*/recentchanges (rc_user_text, rc_timestamp);
 


### PR DESCRIPTION
Introduce `rc_ip_bin` column for `recentchanges` tables to store IP address in binary format. This column will replace `rc_ip` and `rc_user_text`.

https://wikia-inc.atlassian.net/browse/SUS-3079