### PR TITLE
SUS-2978 | User::getUsername - fallback for user accounts is no longer needed

### DIFF
--- a/includes/User.php
+++ b/includes/User.php
@@ -4615,25 +4615,13 @@ class User implements JsonSerializable {
 	 * @return string
 	 */
 	public static function getUsername( int $userId, string $name ) : string {
-		if ( !empty( $userId ) ) {
-			$dbName = static::whoIs( $userId );
-
-			// we currently have 500k mismatches logged every 24h
-			// cache added in User::whoIs should improve the situation here as we'll use the shared user storage
-			// instead of per-cluster copy
-			if( $dbName !== $name ) {
-				WikiaLogger::instance()->warning( "Default name different than lookup", [
-					"user_id" => $userId,
-					// SUS-2008, always log username_db as string
-					"username_db" => $dbName ?: '',
-					"username_default" => $name,
-				] );
-			}
-
-			return $dbName ?: $name;
-		}
-		// this covers anons ($userId = 0), just fall back to the second method argument
-		return $name;
+		return ( $userId > 0 )
+			?
+			// logged-in - get the username by user ID
+			static::whoIs( $userId )
+			:
+			// anons - return the second argument - an IP address
+			$name;
 	}
 
 	/**

--- a/includes/wikia/tests/UserTest.php
+++ b/includes/wikia/tests/UserTest.php
@@ -207,9 +207,9 @@ class UserTest extends WikiaBaseTest {
 		$this->assertEquals( 'NameFromUserTable', User::getUsername( 123, 'notFromUserTableName' ) );
 	}
 
-	public function testGetUsernameShouldReturnDefaultValueIfUserIsNotFound() {
+	public function testGetUsernameShouldReturnFalseIfUserIsNotFound() {
 		$this->mockStaticMethod( 'User', 'whoIs', false );
-		$this->assertEquals( 'someName', User::getUsername( 123, 'someName' ) );
+		$this->assertEquals( false, User::getUsername( 123, 'someName' ) );
 	}
 
 	public function testNewFromTokenAuthorizationGranted() {


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-2978

We plan to remove redundant data in the database and store either (user ID, empty string) or (0, IP address) in (`user_id`, `user_name`) columns. Hence, let's remove the fallback and logging of mismatches that were caused by unfinished user rename processes.

### Examples

```
> echo User::getUserName( 2, '127.0.0.1' );
User: got user 2 from cache
Angela
> echo User::getUserName( 0, '127.0.0.1' )
127.0.0.1
```