### PR TITLE
SUS-3240: DPL revision query builder refactor

### DIFF
--- a/extensions/DynamicPageList/DPLMain.php
+++ b/extensions/DynamicPageList/DPLMain.php
@@ -2183,37 +2183,37 @@ class DPLMain {
 				->tableSet( $dplTableSet );
 
 			if ( $sCreatedBy != "" ) {
-				$userArray = self::getWhereStatementForUsername( $sCreatedBy, $dbr );
+				$userArray = self::getWhereStatementForUsername( $sCreatedBy );
 				$sSqlCond_page_rev .= $dplRevisionQuerySegmentBuilder
 					->buildCreatedByQuerySegment( $userArray );
 			}
 
 			if ( $sNotCreatedBy != "" ) {
-				$userArray = self::getWhereStatementForUsername( $sNotCreatedBy, $dbr );
+				$userArray = self::getWhereStatementForUsername( $sNotCreatedBy );
 				$sSqlCond_page_rev .= $dplRevisionQuerySegmentBuilder
 					->buildNotCreatedByQuerySegment( $userArray );
 			}
 
 			if ( $sModifiedBy != "" ) {
-				$userArray = self::getWhereStatementForUsername( $sModifiedBy, $dbr );
+				$userArray = self::getWhereStatementForUsername( $sModifiedBy );
 				$sSqlCond_page_rev .= $dplRevisionQuerySegmentBuilder
 					->buildModifiedByQuerySegment( $userArray );
 			}
 
 			if ( $sNotModifiedBy != "" ) {
-				$userArray = self::getWhereStatementForUsername( $sNotModifiedBy, $dbr );
+				$userArray = self::getWhereStatementForUsername( $sNotModifiedBy );
 				$sSqlCond_page_rev .= $dplRevisionQuerySegmentBuilder
 					->buildNotModifiedByQuerySegment( $userArray );
 			}
 
 			if ( $sLastModifiedBy != "" ) {
-				$userArray = self::getWhereStatementForUsername( $sLastModifiedBy, $dbr );
+				$userArray = self::getWhereStatementForUsername( $sLastModifiedBy );
 				$sSqlCond_page_rev .= $dplRevisionQuerySegmentBuilder
 					->buildLastModifiedByQuerySegment( $userArray );
 			}
 
 			if ( $sNotLastModifiedBy != "" ) {
-				$userArray = self::getWhereStatementForUsername( $sNotLastModifiedBy, $dbr );
+				$userArray = self::getWhereStatementForUsername( $sNotLastModifiedBy );
 				$sSqlCond_page_rev .= $dplRevisionQuerySegmentBuilder
 					->buildNotLastModifiedByQuerySegment( $userArray );
 			}
@@ -3222,18 +3222,23 @@ class DPLMain {
 	}
 
 
-	// SUS-807
-	private static function getWhereStatementForUsername( $username, DatabaseBase $dbr ) {
-		$res = [];
-		if ( User::isIP( $username ) ) {
-			$res[ 'user_text' ] = $dbr->addQuotes( $username );
-		} else {
-			$userId = User::idFromName( $username );
-			if ( $userId > 0 ) {
-				$res[ 'user_id' ] = $userId;
-			}
+	/**
+	 * SUS-807: Get user name or user ID to use in lookup
+	 * It is the responsibility of callers to escape the output
+	 * @param $userName
+	 * @return array
+	 */
+	private static function getWhereStatementForUsername( $userName ) {
+		if ( User::isIP( $userName ) ) {
+			return [ 'user_text' => $userName ];
 		}
-		return $res;
+
+		$userId = User::idFromName( $userName );
+		if ( $userId > 0 ) {
+			return [ 'user_id' => $userId ];
+		}
+
+		return [];
 	}
 
 	private static function getMemcacheKey( $dplCacheId ) {

--- a/extensions/DynamicPageList/DPLMain.php
+++ b/extensions/DynamicPageList/DPLMain.php
@@ -1822,9 +1822,6 @@ class DPLMain {
         $sTemplateLinksTable = $dbr->tableName( 'templatelinks' );
         $sSqlPageLinksTable = '';
         $sSqlExternalLinksTable = '';
-        $sSqlCreationRevisionTable = '';
-        $sSqlNoCreationRevisionTable = '';
-        $sSqlChangeRevisionTable = '';
         $sSqlCond_page_pl = '';
         $sSqlCond_page_el = '';
         $sSqlCond_page_tpl = '';

--- a/extensions/DynamicPageList/DPLMain.php
+++ b/extensions/DynamicPageList/DPLMain.php
@@ -2294,7 +2294,8 @@ class DPLMain {
                                 $sSqlPage_size . $sSqlPage_touched . $sSqlRev_user .
                                 $sSqlRev_timestamp . $sSqlRev_id . $sSqlCats . $sSqlCl_timestamp .
                                 ' FROM ' . $sSqlRevisionTable . $dplRevisionQueryTables . $sSqlRCTable .
-							  $sSqlPageLinksTable . $sSqlExternalLinksTable . $sPageTable;}
+							  $sSqlPageLinksTable . $sSqlExternalLinksTable . $sPageTable;
+        }
 
         // JOIN ...
         if($sSqlClHeadTable != '' || $sSqlClTableForGC != '') {

--- a/extensions/DynamicPageList/DplRevisionQuerySegmentBuilder.php
+++ b/extensions/DynamicPageList/DplRevisionQuerySegmentBuilder.php
@@ -123,11 +123,9 @@ class DplRevisionQuerySegmentBuilder {
 			$whereStatement = "$revisionTable.rev_user = $userId";
 		}
 
-		$sqlQuerySegment = <<<SQL
+		return <<<SQL
  AND NOT EXISTS (SELECT 1 FROM $revisionTable WHERE $revisionTable.rev_page=page_id AND $whereStatement LIMIT 1)
 SQL;
-
-		return $sqlQuerySegment;
 	}
 
 	/**
@@ -150,11 +148,9 @@ SQL;
 			$userField = 'rev_user';
 		}
 
-		$sqlQuerySegment = <<<SQL
+		return <<<SQL
  AND (SELECT $userField FROM $revisionTable WHERE $revisionTable.rev_page=page_id ORDER BY $revisionTable.rev_timestamp DESC LIMIT 1) = $userNameOrId
 SQL;
-
-		return $sqlQuerySegment;
 	}
 
 	/**
@@ -177,10 +173,8 @@ SQL;
 			$userField = 'rev_user';
 		}
 
-		$sqlQuerySegment = <<<SQL
+		return <<<SQL
  AND (SELECT $userField FROM $revisionTable WHERE $revisionTable.rev_page=page_id ORDER BY $revisionTable.rev_timestamp DESC LIMIT 1) != $userNameOrId
 SQL;
-
-		return $sqlQuerySegment;
 	}
 }

--- a/extensions/DynamicPageList/DplRevisionQuerySegmentBuilder.php
+++ b/extensions/DynamicPageList/DplRevisionQuerySegmentBuilder.php
@@ -1,0 +1,186 @@
+<?php
+
+/**
+ * Constructs SQL query segments for certain constraints affecting revisions
+ */
+class DplRevisionQuerySegmentBuilder {
+	/** @var DatabaseBase $databaseConnection */
+	private $databaseConnection;
+
+	/** @var DplTableSet $dplTableSet */
+	private $dplTableSet;
+
+	public function __construct( DatabaseBase $databaseConnection ) {
+		$this->databaseConnection = $databaseConnection;
+	}
+
+	/**
+	 * Specify the {@see DplTableSet} instance that will hold the tables and aliases
+	 * added by the query segments build by this instance.
+	 *
+	 * @param DplTableSet $dplTableSet
+	 * @return DplRevisionQuerySegmentBuilder
+	 */
+	public function tableSet( DplTableSet $dplTableSet ): DplRevisionQuerySegmentBuilder {
+		$this->dplTableSet = $dplTableSet;
+		return $this;
+	}
+
+	/**
+	 * Construct an SQL query segment that will match only revisions created by the given user
+	 * @param array $userArray An array with either an user_text entry or an user_id entry
+	 * @return string the SQL query segment
+	 */
+	public function buildCreatedByQuerySegment( array $userArray ): string {
+		if ( empty( $userArray ) ) {
+			return '';
+		}
+
+		$this->dplTableSet->addTableAlias( 'revision', 'creation_rev' );
+
+		if ( isset( $userArray['user_text'] ) ) {
+			$userText = $this->databaseConnection->addQuotes( $userArray['user_text'] );
+			$sqlQuerySegment = "AND creation_rev.rev_user_text = $userText";
+		} else {
+			$userId = $this->databaseConnection->addQuotes( $userArray['user_id'] );
+			$sqlQuerySegment = "AND creation_rev.rev_user = $userId";
+		}
+
+		$sqlQuerySegment .= ' AND creation_rev.rev_page = page_id';
+		$sqlQuerySegment .= ' AND creation_rev.rev_parent_id = 0';
+
+		return " $sqlQuerySegment";
+	}
+
+	/**
+	 * Construct an SQL query segment that will match only revisions NOT created by the given user
+	 * @param array $userArray An array with either an user_text entry or an user_id entry
+	 * @return string the SQL query segment
+	 */
+	public function buildNotCreatedByQuerySegment( array $userArray ): string {
+		if ( empty( $userArray ) ) {
+			return '';
+		}
+
+		$this->dplTableSet->addTableAlias( 'revision', 'no_creation_rev' );
+
+		if ( isset( $userArray['user_text'] ) ) {
+			$userText = $this->databaseConnection->addQuotes( $userArray['user_text'] );
+			$sqlQuerySegment = "AND no_creation_rev.rev_user_text != $userText";
+		} else {
+			$userId = $this->databaseConnection->addQuotes( $userArray['user_id'] );
+			$sqlQuerySegment = "AND no_creation_rev.rev_user != $userId";
+		}
+
+		$sqlQuerySegment .= ' AND no_creation_rev.rev_page = page_id';
+		$sqlQuerySegment .= ' AND no_creation_rev.rev_parent_id = 0';
+
+		return " $sqlQuerySegment";
+	}
+
+	/**
+	 * Construct an SQL query segment that will match only revisions modified by the given user
+	 * @param array $userArray An array with either an user_text entry or an user_id entry
+	 * @return string the SQL query segment
+	 */
+	public function buildModifiedByQuerySegment( array $userArray ): string {
+		if ( empty( $userArray ) ) {
+			return '';
+		}
+
+		$this->dplTableSet->addTableAlias( 'revision', 'change_rev' );
+
+		if ( isset( $userArray['user_text'] ) ) {
+			$userText = $this->databaseConnection->addQuotes( $userArray['user_text'] );
+			$sqlQuerySegment = "AND change_rev.rev_user_text = $userText";
+		} else {
+			$userId = $this->databaseConnection->addQuotes( $userArray['user_id'] );
+			$sqlQuerySegment = "AND change_rev.rev_user = $userId";
+		}
+
+		$sqlQuerySegment .= " AND change_rev.rev_page = page_id";
+
+		return " $sqlQuerySegment";
+	}
+
+	/**
+	 * Construct an SQL query segment that will match only revisions NOT modified by the given user
+	 * @param array $userArray An array with either an user_text entry or an user_id entry
+	 * @return string the SQL query segment
+	 */
+	public function buildNotModifiedByQuerySegment( array $userArray ): string {
+		if ( empty( $userArray ) ) {
+			return '';
+		}
+
+		$revisionTable = $this->databaseConnection->tableName( 'revision' );
+
+		if ( isset( $userArray['user_text'] ) ) {
+			$userText = $this->databaseConnection->addQuotes( $userArray['user_text'] );
+			$whereStatement = "$revisionTable.rev_user_text = $userText";
+		} else {
+			$userId = $this->databaseConnection->addQuotes( $userArray['user_id'] );
+			$whereStatement = "$revisionTable.rev_user = $userId";
+		}
+
+		$sqlQuerySegment = <<<SQL
+ AND NOT EXISTS (SELECT 1 FROM $revisionTable WHERE $revisionTable.rev_page=page_id AND $whereStatement LIMIT 1)
+SQL;
+
+		return $sqlQuerySegment;
+	}
+
+	/**
+	 * Construct an SQL query segment that will match only revisions last modified by the given user
+	 * @param array $userArray An array with either an user_text entry or an user_id entry
+	 * @return string the SQL query segment
+	 */
+	public function buildLastModifiedByQuerySegment( array $userArray ): string {
+		if ( empty( $userArray ) ) {
+			return '';
+		}
+
+		$revisionTable = $this->databaseConnection->tableName( 'revision' );
+
+		if ( isset( $userArray['user_text'] ) ) {
+			$userNameOrId = $this->databaseConnection->addQuotes( $userArray['user_text'] );
+			$userField = 'rev_user_text';
+		} else {
+			$userNameOrId = $this->databaseConnection->addQuotes( $userArray['user_id'] );
+			$userField = 'rev_user';
+		}
+
+		$sqlQuerySegment = <<<SQL
+ AND (SELECT $userField FROM $revisionTable WHERE $revisionTable.rev_page=page_id ORDER BY $revisionTable.rev_timestamp DESC LIMIT 1) = $userNameOrId
+SQL;
+
+		return $sqlQuerySegment;
+	}
+
+	/**
+	 * Construct an SQL query segment that will match only revisions NOT last modified by the given user
+	 * @param array $userArray An array with either an user_text entry or an user_id entry
+	 * @return string the SQL query segment
+	 */
+	public function buildNotLastModifiedByQuerySegment( array $userArray ): string {
+		if ( empty( $userArray ) ) {
+			return '';
+		}
+
+		$revisionTable = $this->databaseConnection->tableName( 'revision' );
+
+		if ( isset( $userArray['user_text'] ) ) {
+			$userNameOrId = $this->databaseConnection->addQuotes( $userArray['user_text'] );
+			$userField = 'rev_user_text';
+		} else {
+			$userNameOrId = $this->databaseConnection->addQuotes( $userArray['user_id'] );
+			$userField = 'rev_user';
+		}
+
+		$sqlQuerySegment = <<<SQL
+ AND (SELECT $userField FROM $revisionTable WHERE $revisionTable.rev_page=page_id ORDER BY $revisionTable.rev_timestamp DESC LIMIT 1) != $userNameOrId
+SQL;
+
+		return $sqlQuerySegment;
+	}
+}

--- a/extensions/DynamicPageList/DplTableSet.php
+++ b/extensions/DynamicPageList/DplTableSet.php
@@ -17,10 +17,12 @@ class DplTableSet {
 	}
 
 	public function addTableAlias( string $tableName, string $tableAlias ) {
-		$quotedTableName = $this->databaseConnection->tableName( $tableName );
-		$quotedTableAlias = $this->databaseConnection->addQuotes( $tableAlias );
+		if ( !isset( $this->tableMap[$tableAlias] ) ) {
+			$quotedTableName = $this->databaseConnection->tableName( $tableName );
+			$quotedTableAlias = $this->databaseConnection->addQuotes( $tableAlias );
 
-		$this->tableMap[$tableAlias] = "$quotedTableName AS $quotedTableAlias";
+			$this->tableMap[$tableAlias] = "$quotedTableName AS $quotedTableAlias";
+		}
 	}
 
 	public function getTables(): string {

--- a/extensions/DynamicPageList/DplTableSet.php
+++ b/extensions/DynamicPageList/DplTableSet.php
@@ -1,0 +1,29 @@
+<?php
+
+class DplTableSet {
+	/** @var DatabaseBase $databaseConnection */
+	private $databaseConnection;
+
+	private $tableMap = [];
+
+	public function __construct( DatabaseBase $databaseConnection ) {
+		$this->databaseConnection = $databaseConnection;
+	}
+
+	public function addTable( string $tableName ) {
+		if ( !isset( $this->tableMap[$tableName] ) ) {
+			$this->tableMap[$tableName] = $this->databaseConnection->tableName( $tableName );
+		}
+	}
+
+	public function addTableAlias( string $tableName, string $tableAlias ) {
+		$quotedTableName = $this->databaseConnection->tableName( $tableName );
+		$quotedTableAlias = $this->databaseConnection->addQuotes( $tableAlias );
+
+		$this->tableMap[$tableAlias] = "$quotedTableName AS $quotedTableAlias";
+	}
+
+	public function getTables(): string {
+		return implode( ', ', $this->tableMap );
+	}
+}

--- a/extensions/DynamicPageList/DynamicPageList.php
+++ b/extensions/DynamicPageList/DynamicPageList.php
@@ -59,25 +59,28 @@ if( !defined( 'MEDIAWIKI' ) ) {
     die( 'This is not a valid entry point to MediaWiki.' );
 }
 
-$wgExtensionFunctions[]        = array( 'ExtDynamicPageList', 'setupDPL' );
-$wgHooks['LanguageGetMagic'][] = 'ExtDynamicPageList__languageGetMagic';
+$GLOBALS['wgExtensionFunctions'][] = [ 'ExtDynamicPageList', 'setupDPL' ];
+$GLOBALS['wgHooks']['LanguageGetMagic'][] = 'ExtDynamicPageList__languageGetMagic';
 
-$wgExtensionMessagesFiles['DynamicPageList'] =  dirname( __FILE__ ) . '/DynamicPageList.i18n.php';
+$GLOBALS['wgExtensionMessagesFiles']['DynamicPageList'] = __DIR__ . '/DynamicPageList.i18n.php';
 
-$DPLVersion = '2.3.0';
+$GLOBALS['DPLVersion'] = '2.3.0';
 
-$wgExtensionCredits['parserhook'][] = array(
-	'path' 				=> __FILE__,
-	'name' 				=> 'DynamicPageList (third party)',
-	'author' 			=>  '[http://de.wikipedia.org/wiki/Benutzer:Algorithmix Gero Scholz]',
-	'url' 				=> 'https://www.mediawiki.org/wiki/Extension:DynamicPageList_(third-party)',
-	'descriptionmsg' 	=> 'dpl-desc',
-  	'version' 			=> $DPLVersion
-  );
+$GLOBALS['wgExtensionCredits']['parserhook'][] = [
+	'path' => __FILE__,
+	'name' => 'DynamicPageList (third party)',
+	'author' => '[http://de.wikipedia.org/wiki/Benutzer:Algorithmix Gero Scholz]',
+	'url' => 'https://www.mediawiki.org/wiki/Extension:DynamicPageList_(third-party)',
+	'descriptionmsg' => 'dpl-desc',
+	'version' => $GLOBALS['DPLVersion'],
+];
+
+$GLOBALS['wgAutoloadClasses']['DplRevisionQuerySegmentBuilder'] = __DIR__ . '/DplRevisionQuerySegmentBuilder.php';
+$GLOBALS['wgAutoloadClasses']['DplTableSet'] = __DIR__ . '/DplTableSet.php';
 
 require_once( 'DPLSetup.php' );
 
-ExtDynamicPageList::$DPLVersion = $DPLVersion;
+ExtDynamicPageList::$DPLVersion = $GLOBALS['DPLVersion'];
 
 // use full functionality by default
 ExtDynamicPageList::setFunctionalRichness(4);

--- a/extensions/DynamicPageList/tests/DplRevisionQuerySegmentBuilderTest.php
+++ b/extensions/DynamicPageList/tests/DplRevisionQuerySegmentBuilderTest.php
@@ -1,0 +1,238 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class DplRevisionQuerySegmentBuilderTest extends TestCase {
+	const TEST_USER_ARRAY_WITH_ID = [ 'user_id' => 123 ];
+	const TEST_USER_ARRAY_WITH_NAME = [ 'user_text' => 'TestUser' ];
+
+	/** @var DatabaseBase|PHPUnit_Framework_MockObject_MockObject $databaseConnectionMock */
+	private $databaseConnectionMock;
+
+	/** @var DplTableSet|PHPUnit_Framework_MockObject_MockObject $dplTableSetMock */
+	private $dplTableSetMock;
+
+	/** @var DplRevisionQuerySegmentBuilder $dplRevisionQuerySegmentBuilder */
+	private $dplRevisionQuerySegmentBuilder;
+
+	protected function setUp() {
+		parent::setUp();
+
+		require_once __DIR__ . '/../DynamicPageList.php';
+
+		$this->databaseConnectionMock = $this->createMock( DatabaseBase::class );
+		$this->dplTableSetMock = $this->createMock( DplTableSet::class );
+
+		$this->dplRevisionQuerySegmentBuilder =
+			( new DplRevisionQuerySegmentBuilder( $this->databaseConnectionMock ) )
+				->tableSet( $this->dplTableSetMock );
+
+		$this->databaseConnectionMock->expects( $this->any() )
+			->method( 'tableName' )
+			->willReturnArgument( 0 );
+
+		$this->databaseConnectionMock->expects( $this->any() )
+			->method( 'addQuotes' )
+			->willReturnArgument( 0 );
+	}
+
+	public function testNoQuerySegmentIsBuiltForEmptyUserArray() {
+		$userArray = [];
+
+		$this->dplTableSetMock->expects( $this->never() )
+			->method( 'addTableAlias' );
+
+		$this->assertEmpty(
+			$this->dplRevisionQuerySegmentBuilder->buildCreatedByQuerySegment( $userArray )
+		);
+
+		$this->assertEmpty(
+			$this->dplRevisionQuerySegmentBuilder->buildNotCreatedByQuerySegment( $userArray )
+		);
+
+
+		$this->assertEmpty(
+			$this->dplRevisionQuerySegmentBuilder->buildModifiedByQuerySegment( $userArray )
+		);
+
+
+		$this->assertEmpty(
+			$this->dplRevisionQuerySegmentBuilder->buildNotModifiedByQuerySegment( $userArray )
+		);
+
+		$this->assertEmpty(
+			$this->dplRevisionQuerySegmentBuilder->buildLastModifiedByQuerySegment( $userArray )
+		);
+
+
+		$this->assertEmpty(
+			$this->dplRevisionQuerySegmentBuilder->buildNotLastModifiedByQuerySegment( $userArray )
+		);
+	}
+
+	public function testBuildCreatedByQuerySegmentUserId() {
+		$this->dplTableSetMock->expects( $this->once() )
+			->method( 'addTableAlias' )
+			->with( 'revision', 'creation_rev' );
+
+		$sqlQuerySegment =
+			$this->dplRevisionQuerySegmentBuilder->buildCreatedByQuerySegment( static::TEST_USER_ARRAY_WITH_ID );
+
+		$this->assertEquals(
+			' AND creation_rev.rev_user = 123 AND creation_rev.rev_page = page_id AND creation_rev.rev_parent_id = 0',
+			$sqlQuerySegment
+		);
+	}
+
+	public function testBuildCreatedByQuerySegmentUserName() {
+		$this->dplTableSetMock->expects( $this->once() )
+			->method( 'addTableAlias' )
+			->with( 'revision', 'creation_rev' );
+
+		$sqlQuerySegment =
+			$this->dplRevisionQuerySegmentBuilder->buildCreatedByQuerySegment( static::TEST_USER_ARRAY_WITH_NAME );
+
+		$this->assertEquals(
+			' AND creation_rev.rev_user_text = TestUser AND creation_rev.rev_page = page_id AND creation_rev.rev_parent_id = 0',
+			$sqlQuerySegment
+		);
+	}
+
+	public function testBuildNotCreatedByQuerySegmentUserId() {
+		$this->dplTableSetMock->expects( $this->once() )
+			->method( 'addTableAlias' )
+			->with( 'revision', 'no_creation_rev' );
+
+		$sqlQuerySegment = $this->dplRevisionQuerySegmentBuilder
+			->buildNotCreatedByQuerySegment( static::TEST_USER_ARRAY_WITH_ID );
+
+		$this->assertEquals(
+			' AND no_creation_rev.rev_user != 123 AND no_creation_rev.rev_page = page_id AND no_creation_rev.rev_parent_id = 0',
+			$sqlQuerySegment
+		);
+	}
+
+	public function testBuildNotCreatedByQuerySegmentUserName() {
+		$this->dplTableSetMock->expects( $this->once() )
+			->method( 'addTableAlias' )
+			->with( 'revision', 'no_creation_rev' );
+
+		$sqlQuerySegment = $this->dplRevisionQuerySegmentBuilder
+			->buildNotCreatedByQuerySegment( static::TEST_USER_ARRAY_WITH_NAME );
+
+		$this->assertEquals(
+			' AND no_creation_rev.rev_user_text != TestUser AND no_creation_rev.rev_page = page_id AND no_creation_rev.rev_parent_id = 0',
+			$sqlQuerySegment
+		);
+	}
+
+	public function testBuildModifiedByQuerySegmentUserId() {
+		$this->dplTableSetMock->expects( $this->once() )
+			->method( 'addTableAlias' )
+			->with( 'revision', 'change_rev' );
+
+		$sqlQuerySegment = $this->dplRevisionQuerySegmentBuilder
+			->buildModifiedByQuerySegment( static::TEST_USER_ARRAY_WITH_ID );
+
+		$this->assertEquals(
+			' AND change_rev.rev_user = 123 AND change_rev.rev_page = page_id',
+			$sqlQuerySegment
+		);
+	}
+
+
+	public function testBuildModifiedByQuerySegmentUserName() {
+		$this->dplTableSetMock->expects( $this->once() )
+			->method( 'addTableAlias' )
+			->with( 'revision', 'change_rev' );
+
+		$sqlQuerySegment = $this->dplRevisionQuerySegmentBuilder
+			->buildModifiedByQuerySegment( static::TEST_USER_ARRAY_WITH_NAME );
+
+		$this->assertEquals(
+			' AND change_rev.rev_user_text = TestUser AND change_rev.rev_page = page_id',
+			$sqlQuerySegment
+		);
+	}
+
+	public function testBuildNotModifiedByQuerySegmentUserId() {
+		$this->dplTableSetMock->expects( $this->never() )
+			->method( 'addTableAlias' );
+
+		$sqlQuerySegment = $this->dplRevisionQuerySegmentBuilder
+			->buildNotModifiedByQuerySegment( static::TEST_USER_ARRAY_WITH_ID );
+
+		$this->assertEquals(
+			' AND NOT EXISTS (SELECT 1 FROM revision WHERE revision.rev_page=page_id AND revision.rev_user = 123 LIMIT 1)',
+			$sqlQuerySegment
+		);
+	}
+
+
+	public function testBuildNotModifiedByQuerySegmentUserName() {
+		$this->dplTableSetMock->expects( $this->never() )
+			->method( 'addTableAlias' );
+
+		$sqlQuerySegment = $this->dplRevisionQuerySegmentBuilder
+			->buildNotModifiedByQuerySegment( static::TEST_USER_ARRAY_WITH_NAME );
+
+		$this->assertEquals(
+			' AND NOT EXISTS (SELECT 1 FROM revision WHERE revision.rev_page=page_id AND revision.rev_user_text = TestUser LIMIT 1)',
+			$sqlQuerySegment
+		);
+	}
+
+	public function testBuildLastModifiedByQuerySegmentUserId() {
+		$this->dplTableSetMock->expects( $this->never() )
+			->method( 'addTableAlias' );
+
+		$sqlQuerySegment = $this->dplRevisionQuerySegmentBuilder
+			->buildLastModifiedByQuerySegment( static::TEST_USER_ARRAY_WITH_ID );
+
+
+		$this->assertEquals(
+			' AND (SELECT rev_user FROM revision WHERE revision.rev_page=page_id ORDER BY revision.rev_timestamp DESC LIMIT 1) = 123',
+			$sqlQuerySegment
+		);
+	}
+
+	public function testBuildLastModifiedByQuerySegmentUserName() {
+		$this->dplTableSetMock->expects( $this->never() )
+			->method( 'addTableAlias' );
+
+		$sqlQuerySegment = $this->dplRevisionQuerySegmentBuilder
+			->buildLastModifiedByQuerySegment( static::TEST_USER_ARRAY_WITH_NAME );
+
+
+		$this->assertEquals(
+			' AND (SELECT rev_user_text FROM revision WHERE revision.rev_page=page_id ORDER BY revision.rev_timestamp DESC LIMIT 1) = TestUser',
+			$sqlQuerySegment
+		);
+	}
+
+	public function testBuildNotLastModifiedByQuerySegmentUserId() {
+		$this->dplTableSetMock->expects( $this->never() )
+			->method( 'addTableAlias' );
+
+		$sqlQuerySegment = $this->dplRevisionQuerySegmentBuilder
+			->buildNotLastModifiedByQuerySegment( static::TEST_USER_ARRAY_WITH_ID);
+
+		$this->assertEquals(
+			' AND (SELECT rev_user FROM revision WHERE revision.rev_page=page_id ORDER BY revision.rev_timestamp DESC LIMIT 1) != 123',
+			$sqlQuerySegment
+		);
+	}
+
+	public function testBuildNotLastModifiedByQuerySegmentUserName() {
+		$this->dplTableSetMock->expects( $this->never() )
+			->method( 'addTableAlias' );
+
+		$sqlQuerySegment = $this->dplRevisionQuerySegmentBuilder
+			->buildNotLastModifiedByQuerySegment( static::TEST_USER_ARRAY_WITH_NAME );
+
+		$this->assertEquals(
+			' AND (SELECT rev_user_text FROM revision WHERE revision.rev_page=page_id ORDER BY revision.rev_timestamp DESC LIMIT 1) != TestUser',
+			$sqlQuerySegment
+		);
+	}
+}

--- a/extensions/DynamicPageList/tests/DplTableSetTest.php
+++ b/extensions/DynamicPageList/tests/DplTableSetTest.php
@@ -82,4 +82,46 @@ class DplTableSetTest extends TestCase {
 			$this->dplTableSet->getTables()
 		);
 	}
+
+	public function testTableAliasIsNotAddedIfTableWithSameNameIsSet() {
+		$tables = [ 'revision', 'page' ];
+		$aliasTables = [
+			'revision' => 'my_rev',
+			'foo_bar' => 'page'
+		];
+
+		foreach ( $tables as $tableName ) {
+			$this->dplTableSet->addTable( $tableName );
+		}
+
+		foreach ( $aliasTables as $tableName => $alias ) {
+			$this->dplTableSet->addTableAlias( $tableName, $alias );
+		}
+
+		$this->assertEquals(
+			'revision, page, revision AS my_rev',
+			$this->dplTableSet->getTables()
+		);
+	}
+
+	public function testTableIsNotAddedIfTableWithSomeAliasIsSet() {
+		$aliasTables = [
+			'revision' => 'my_rev',
+			'foo_bar' => 'page'
+		];
+		$tables = [ 'revision', 'page' ];
+
+		foreach ( $aliasTables as $tableName => $alias ) {
+			$this->dplTableSet->addTableAlias( $tableName, $alias );
+		}
+
+		foreach ( $tables as $tableName ) {
+			$this->dplTableSet->addTable( $tableName );
+		}
+
+		$this->assertEquals(
+			'revision AS my_rev, foo_bar AS page, revision',
+			$this->dplTableSet->getTables()
+		);
+	}
 }

--- a/extensions/DynamicPageList/tests/DplTableSetTest.php
+++ b/extensions/DynamicPageList/tests/DplTableSetTest.php
@@ -1,0 +1,85 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class DplTableSetTest extends TestCase {
+	/** @var DatabaseBase|PHPUnit_Framework_MockObject_MockObject $databaseConnectionMock */
+	private $databaseConnectionMock;
+
+	/** @var DplTableSet $dplTableSet */
+	private $dplTableSet;
+
+	protected function setUp() {
+		parent::setUp();
+
+		require_once __DIR__ . '/../DynamicPageList.php';
+
+		$this->databaseConnectionMock = $this->createMock( DatabaseBase::class );
+		$this->dplTableSet = new DplTableSet( $this->databaseConnectionMock );
+
+		$this->databaseConnectionMock->expects( $this->any() )
+			->method( 'tableName' )
+			->willReturnArgument( 0 );
+
+		$this->databaseConnectionMock->expects( $this->any() )
+			->method( 'addQuotes' )
+			->willReturnArgument( 0 );
+	}
+
+	public function testAddTable() {
+		$tables = [ 'revision', 'page', 'user' ];
+
+		foreach ( $tables as $tableName ) {
+			$this->dplTableSet->addTable( $tableName );
+		}
+
+		$this->assertEquals( 'revision, page, user', $this->dplTableSet->getTables() );
+	}
+
+	public function testAddTableDoesNotDuplicateTables() {
+		$tables = [ 'revision', 'page', 'page' ];
+
+		foreach ( $tables as $tableName ) {
+			$this->dplTableSet->addTable( $tableName );
+		}
+
+		$this->assertEquals( 'revision, page', $this->dplTableSet->getTables() );
+	}
+
+	public function testAddTableAlias() {
+		$tables = [
+			'revision' => 'my_rev',
+			'page' => 'my_page'
+		];
+
+		foreach ( $tables as $tableName => $alias ) {
+			$this->dplTableSet->addTableAlias( $tableName, $alias );
+		}
+
+		$this->assertEquals(
+			'revision AS my_rev, page AS my_page',
+			$this->dplTableSet->getTables()
+		);
+	}
+
+	public function testAddTableAliasedAndNotAliased() {
+		$tables = [ 'revision', 'page' ];
+		$aliasTables = [
+			'revision' => 'my_rev',
+			'page' => 'my_page'
+		];
+
+		foreach ( $tables as $tableName ) {
+			$this->dplTableSet->addTable( $tableName );
+		}
+
+		foreach ( $aliasTables as $tableName => $alias ) {
+			$this->dplTableSet->addTableAlias( $tableName, $alias );
+		}
+
+		$this->assertEquals(
+			'revision, page, revision AS my_rev, page AS my_page',
+			$this->dplTableSet->getTables()
+		);
+	}
+}

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.1/phpunit.xsd"
+		xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.4/phpunit.xsd"
 		bootstrap="bootstrap.php"
 		backupGlobals="false"
 		backupStaticAttributes="false"
@@ -41,6 +41,9 @@
 		</testsuite>
 		<testsuite name="MediaWiki /includes/libs Test Suite">
 			<directory>../includes/libs/tests/</directory>
+		</testsuite>
+		<testsuite name="DPL Extension Test Suite">
+			<directory>../extensions/DynamicPageList/tests/</directory>
 		</testsuite>
 	</testsuites>
 	<groups>


### PR DESCRIPTION
Avoid a situation where using `category` and `modifiedby` params together caused database error:

```
Query: SELECT  DISTINCT `page`.page_namespace AS page_namespace,`page`.page_title AS page_title,`page`.page_id AS page_id, `page`.page_title  as sortkey FROM `revision` AS change_rev, `page` INNER JOIN `categorylinks` AS cl0 ON `page`.page_id=cl0.cl_from AND (cl0.cl_to='Individuen')  WHERE 1=1  AND `page`.page_is_redirect=0 AND 5301680 = creation_rev.rev_user AND change_rev.rev_page = page_id ORDER BY page_title ASC LIMIT 500 OFFSET 0 
Function: DPLMain:dynamicPageList
Error: 1054 Unknown column 'creation_rev.rev_user' in 'where clause' (geo-db-a-slave.query.consul)
```

Relevant functionality was extracted out of legacy file and unit tests were written.
https://wikia-inc.atlassian.net/browse/SUS-3240