### PR TITLE
SUS-3239: Use a DESCRIBE query to determine if field exists in table

### DIFF
--- a/includes/db/DatabaseMysqlBase.php
+++ b/includes/db/DatabaseMysqlBase.php
@@ -410,6 +410,28 @@ abstract class DatabaseMysqlBase extends DatabaseBase {
 	}
 
 	/**
+	 * SUS-3239: Determines if a field exists in a given table, using a DESCRIBE query.
+	 *
+	 * @param String $table
+	 * @param String $field
+	 * @param string $fname
+	 * @return bool
+	 */
+	function fieldExists( $table, $field, $fname = 'DatabaseBase::fieldExists' ) {
+		// This handles escaping and optionally resolving the table
+		$tableName = $this->tableName( $table );
+		$res = $this->query( "DESCRIBE $tableName", __METHOD__ );
+
+		foreach ( $res as $row ) {
+			if ( $row->Field === $field ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * @param $table string
 	 * @param $field string
 	 * @return bool|MySQLField

--- a/includes/db/DatabaseMysqlBase.php
+++ b/includes/db/DatabaseMysqlBase.php
@@ -417,10 +417,14 @@ abstract class DatabaseMysqlBase extends DatabaseBase {
 	 * @param string $fname
 	 * @return bool
 	 */
-	function fieldExists( $table, $field, $fname = 'DatabaseBase::fieldExists' ) {
+	function fieldExists( $table, $field, $fname = __METHOD__ ) {
 		// This handles escaping and optionally resolving the table
 		$tableName = $this->tableName( $table );
-		$res = $this->query( "DESCRIBE $tableName", __METHOD__ );
+		$res = $this->query( "DESCRIBE $tableName", __METHOD__, true );
+
+		if ( !$res ) {
+			return false;
+		}
 
 		foreach ( $res as $row ) {
 			if ( $row->Field === $field ) {


### PR DESCRIPTION
The current implementation uses `SELECT * FROM table LIMIT 1`, which is disadvantageous:
* it will fail if the table is empty
* otherwise it will trigger a full table scan.

MySQL `DESCRIBE` will serve us better here.

https://wikia-inc.atlassian.net/browse/SUS-3239