### PR TITLE
SUS-3421 | ChangesList::insertUserRelatedLinks - use either rc_user or rc_user_text for handling logged-in / anon entries in recentchanges table

### DIFF
--- a/extensions/wikia/Wall/WallHelper.class.php
+++ b/extensions/wikia/Wall/WallHelper.class.php
@@ -554,7 +554,7 @@ class WallHelper {
 	}
 
 	/**
-	 * @param RecentChange $rc or a row from revison table
+	 * @param RCCacheEntry $rc or a row from revison table
 	 * @param array $row [ page_title, page_namespace, rev_user_text?, page_is_new?, rev_parent_id? ]
 	 * @return array|bool
 	 */

--- a/includes/ChangesList.php
+++ b/includes/ChangesList.php
@@ -361,9 +361,14 @@ class ChangesList extends ContextSource {
 		if( $this->isDeleted( $rc, Revision::DELETED_USER ) ) {
 			$s .= ' <span class="history-deleted">' . wfMsgHtml( 'rev-deleted-user' ) . '</span>';
 		} else {
-			$s .= $this->getLanguage()->getDirMark() . Linker::userLink( $rc->mAttribs['rc_user'],
-				$rc->mAttribs['rc_user_text'] );
-			$s .= Linker::userToolLinks( $rc->mAttribs['rc_user'], $rc->mAttribs['rc_user_text'] );
+			# Wikia change - SUS-3241
+			# use either rc_user or rc_user_text for handling logged-in / anon entries in recentchanges table
+			$userId = (int) $rc->getAttribute('rc_user');
+			$userName = (string) User::getUsername( $userId, $rc->getAttribute( 'rc_user_text' ) );
+
+			$s .= $this->getLanguage()->getDirMark() . Linker::userLink( $userId, $userName );
+			$s .= Linker::userToolLinks( $userId, $userName );
+			# Wikia change - end
 		}
 	}
 
@@ -787,6 +792,12 @@ class EnhancedChangesList extends ChangesList {
 		return $ret;
 	}
 
+	/**
+	 * @param RecentChange $rc
+	 * @param $unpatrolled
+	 * @param $counter
+	 * @return array|bool|Object
+	 */
 	public function lineLinksCache($rc, $unpatrolled, $counter) {
 		wfProfileIn( __METHOD__ );
 		global $wgMemc;
@@ -808,8 +819,14 @@ class EnhancedChangesList extends ChangesList {
 			$out['userlink'] = ' <span class="history-deleted">' . wfMsgHtml( 'rev-deleted-user' ) . '</span>';
 			$out['usertalklink'] = null;
 		} else {
-			$out['userlink'] = Linker::userLink( $rc->mAttribs['rc_user'], $rc->mAttribs['rc_user_text'] );
-			$out['usertalklink'] = Linker::userToolLinks( $rc->mAttribs['rc_user'], $rc->mAttribs['rc_user_text'] );
+			# Wikia change - SUS-3241
+			# use either rc_user or rc_user_text for handling logged-in / anon entries in recentchanges table
+			$userId = (int) $rc->getAttribute('rc_user');
+			$userName = (string) User::getUsername( $userId, $rc->getAttribute( 'rc_user_text' ) );
+
+			$out['userlink'] = Linker::userLink( $userId, $userName );
+			$out['usertalklink'] = Linker::userToolLinks( $userId, $userName );
+			# Wikia change - end
 		}
 		
 		$out['clink'] = Linker::linkKnown( $rc->getTitle() );

--- a/includes/ChangesList.php
+++ b/includes/ChangesList.php
@@ -802,7 +802,7 @@ class EnhancedChangesList extends ChangesList {
 		wfProfileIn( __METHOD__ );
 		global $wgMemc;
 
-		$memcKey = wfMemcKey( __METHOD__, $rc->mAttribs['rc_id'], $unpatrolled, $this->getLanguage()->getCode(), $counter);
+		$memcKey = wfMemcKey( __METHOD__, $rc->mAttribs['rc_id'], $unpatrolled, $this->getLanguage()->getCode(), $counter, 'v2');
 		$out = $wgMemc->get($memcKey);
 		if(!empty($out)) {
 			// wikia change start (BAC-492)

--- a/includes/specials/SpecialRecentchanges.php
+++ b/includes/specials/SpecialRecentchanges.php
@@ -214,6 +214,8 @@ class SpecialRecentChanges extends IncludableSpecialPage {
 		// wikia change end
 		if( $feedFormat ) {
 			list( $changesFeed, $formatter ) = $this->getFeedObject( $feedFormat );
+			/* @var ChangesFeed $changesFeed */
+			/* @var ChannelFeed $formatter */
 			$changesFeed->execute( $formatter, $rows, $lastmod, $opts );
 		} else {
 			$this->webOutput( $rows, $opts );


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3241

Compare http://sandbox-s2.nordycka.wikia.com/wiki/Specjalna:Ostatnie_zmiany vs http://nordycka.wikia.com/wiki/Specjalna:Ostatnie_zmiany

![sus-3210 - recent changes](https://user-images.githubusercontent.com/1929317/32658709-97e3af8c-c61b-11e7-85ac-19d85c23f014.png)
