### PR TITLE
SUS-2979 | GenderCache::getGenderOfUsersFromDB - remove join between user and user_properties tables

### DIFF
--- a/includes/cache/GenderCache.php
+++ b/includes/cache/GenderCache.php
@@ -105,8 +105,9 @@ class GenderCache {
 			return;
 		}
 
-		foreach ( $this->getGenderOfUsersFromDB($users, $caller) as $row ) {
-			$this->cache[$row->user_name] = $row->up_value ? $row->up_value : $default;
+		// Wikia change - SUS-2979
+		foreach ( $this->getGenderOfUsersFromDB($users, $caller) as $user_name => $value ) {
+			$this->cache[$user_name] = $value ?: $default;
 		}
 	}
 
@@ -132,26 +133,42 @@ class GenderCache {
 	/**
 	 * @param $userNames
 	 * @param $caller
-	 * @return ResultWrapper
+	 * @return array user_name => gender hash
 	 */
-	private function getGenderOfUsersFromDB( $userNames, $caller ): ResultWrapper {
+	private function getGenderOfUsersFromDB( $userNames, $caller ): array {
 		global $wgExternalSharedDB;
 		$dbr = wfGetDB( DB_SLAVE, [], $wgExternalSharedDB );
 
-		$table = [ '`user`', 'user_properties' ];
-		$fields = [ 'user_name', 'up_value' ];
-		$conds = [ 'user_name' => $userNames ];
-		$joins = [
-			'user_properties' => [
-				'LEFT JOIN', [ 'user_id = up_user', 'up_property' => 'gender' ],
-			],
-		];
+		// Wikia change - SUS-2979
+		if ( is_string( $userNames ) ) {
+			$userNames = [ $userNames ];
+		}
+
+		// map user IDs to user names
+		// in 97% of cases this method is called with a single user name provided
+		// use heavily cached User::idFromName to get it
+		$userIdsToNames = [];
+		foreach($userNames as $userName) {
+			$userIdsToNames[User::idFromName( $userName )] = $userName;
+		}
+
+		$table = 'user_properties';
+		$fields = [ 'up_user', 'up_value' ];
+		$conds = [ 'up_user' => array_keys( $userIdsToNames ), 'up_property' => 'gender' ];
 
 		$comment = __METHOD__;
 		if ( strval( $caller ) !== '' ) {
 			$comment .= "/$caller";
 		}
 
-		return $dbr->select( $table, $fields, $conds, $comment, $joins, $joins );
+		$ret = [];
+		$res = $dbr->select( $table, $fields, $conds, $comment );
+
+		foreach( $res as $row ) {
+			// map user IDs back to user names
+			$ret[ $userIdsToNames[$row->up_user] ] = $row->up_value;
+		}
+
+		return $ret;
 	}
 }


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-2979

### Before the fix

```sql
> var_dump( GenderCache::singleton()->getGenderOf('Macbre') );
Query wikicities (DB user: wikia_maint) (7) (slave): SELECT /* GenderCache::getGenderOfUsersFromDB CommandLineInc - 62437861-5d24-4187-b22b-c8bfb39a1e20 */  user_name,up_value  FROM `user` LEFT JOIN `user_properties` ON ((user_id = up_user) AND up_property = 'gender')  WHERE user_name = 'Macbre'  

string(7) "unknown"
```

### After the fix

In **97%** of cases this method is called with a single user name provided, use heavily cached `User::idFromName` to get user ID.

```sql
> var_dump( GenderCache::singleton()->doQuery(['Macbre', 'Angela']) );
...
memcached: get(dev-macbre-wikicities:user:name:Macbre)
memcached: MemCache: sock i:0; got dev-macbre-wikicities:user:name:Macbre
memcached: get(dev-macbre-wikicities:user:name:Angela)
memcached: MemCache: sock i:0; got dev-macbre-wikicities:user:name:Angela
...
Query wikicities (DB user: wikia_maint) (7) (slave): SELECT /* GenderCache::getGenderOfUsersFromDB CommandLineInc - 73d175df-fe0b-4d40-8c71-737d08b5a312 */  up_user,up_value  FROM `user_properties`  WHERE up_user IN ('119245','2')  AND up_property = 'gender'  

> var_dump( GenderCache::singleton() )
/usr/wikia/source/deploytools/18879/src/maintenance/eval.php(88) : eval()'d code:1:
class GenderCache#291 (4) {
  protected $cache =>
  array(2) {
    'Macbre' =>
    string(7) "unknown"
    'Angela' =>
    string(6) "female"
  }
...
}

--

> var_dump( GenderCache::singleton()->getGenderOf('Macbre') );
string(7) "unknown"

> var_dump( GenderCache::singleton()->getGenderOf('Angela') );
string(6) "female"
```