### PR TITLE
SUS-2979 | LookupUser - remove a join between user and user_properties + rely on User::whoAre()

### DIFF
--- a/extensions/wikia/LookupUser/LookupUser.body.php
+++ b/extensions/wikia/LookupUser/LookupUser.body.php
@@ -165,26 +165,27 @@ EOT
 			}
 
 			// Check for disabled accounts where we kept the email
-			$dRows = $dbr->select(
-				[ '`user`', 'user_properties' ],
-				[ 'user_name' ],
+			$userIds = $dbr->selectFieldValues(
+				'user_properties',
+				'up_user',
 				[
-					'user_id = up_user',
 					'up_property' => 'disabled-user-email',
 					'up_value' => $target,
 				],
 				__METHOD__
 			);
 
-			/** @var stdClass $row */
-			foreach ( $dRows as $row ) {
+			foreach ( User::whoAre( $userIds ) as $user_id => $user_name ) {
+				// User::whoAre return an entry for anons (under '0' key), skip it here
+				if ( $user_id === 0 ) continue;
+
 				if ( $loop === 0 ) {
-					$userTarget = $oRow->user_name;
+					$userTarget = $user_name;
 				}
-				if ( !empty( $emailUser ) && ( $emailUser == $row->user_name ) ) {
+				if ( !empty( $emailUser ) && ( $emailUser == $user_name ) ) {
 					$userTarget = $emailUser;
 				}
-				$aUsers[] = $row->user_name;
+				$aUsers[] = $user_name;
 				$loop++;
 			}
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-2979

### Before the fix

```sql
SELECT /* LookupUserPage::showInfo foo - 5a0a6d09-4d47-4362-8a2a-3149affeda53 */  user_name  FROM `user`,`user_properties`  WHERE (user_id = up_user) AND up_property = 'disabled-user-email' AND up_value = 'XXX@gmail.com'
```

### After the fix

```sql
mysql@geo-db-sharedb-slave.query.consul[wikicities]>explain SELECT /* LookupUserPage::showInfo foo - 5a0a6d09-4d47-4362-8a2a-3149affeda53 */  up_user  FROM `user_properties`  WHERE up_property = 'disabled-user-email' AND up_value = 'XXX@gmail.com'  ;
+----+-------------+-----------------+------------+------+--------------------------+--------------------------+---------+-------+--------+----------+------------------------------------+
| id | select_type | table           | partitions | type | possible_keys            | key                      | key_len | ref   | rows   | filtered | Extra                              |
+----+-------------+-----------------+------------+------+--------------------------+--------------------------+---------+-------+--------+----------+------------------------------------+
|  1 | SIMPLE      | user_properties | NULL       | ref  | user_properties_property | user_properties_property | 258     | const | 189312 |    10.00 | Using index condition; Using where |
+----+-------------+-----------------+------------+------+--------------------------+--------------------------+---------+-------+--------+----------+------------------------------------+
1 row in set, 1 warning (0.00 sec)
```