### PR TITLE
SUS-2981 | cache User::idFromName results for not existing users

### DIFF
--- a/includes/User.php
+++ b/includes/User.php
@@ -672,7 +672,8 @@ class User implements JsonSerializable {
 		}
 
 		if ( isset( self::$idCacheByName[$name] ) ) {
-			return (int) self::$idCacheByName[$name];
+			// SUS-2981 - return NULL when a user is not found
+			return ( (int) self::$idCacheByName[$name] ) ?: null;
 		}
 
 		// SUS-2945 | this method makes ~32mm queries every day
@@ -683,7 +684,8 @@ class User implements JsonSerializable {
 		$cachedId = $wgMemc->get( $key );
 
 		if ( is_numeric( $cachedId ) ) {
-			return (int) self::$idCacheByName[$name] = $cachedId;
+			// SUS-2981 - return NULL when a user is not found
+			return ( (int) self::$idCacheByName[$name] = $cachedId ) ?: null;
 		}
 
 		// not in cache, query the database
@@ -696,13 +698,14 @@ class User implements JsonSerializable {
 		}
 
 		if ( $s === false ) {
-			$result = null;
+			// SUS-2981 - set cached value to zero when a user is not found, setting a memcache entry to NULL makes no sense
+			$result = 0;
 		} else {
-			$result = (int) $s->user_id;
-
-			// SUS-2945 - only store when there's a match
-			$wgMemc->set( $key, $result, WikiaResponse::CACHE_LONG );
+			$result = (int)$s->user_id;
 		}
+
+		// SUS-2981 - cache even when a given user is not found (set cache entry to 0)
+		$wgMemc->set( $key, $result, WikiaResponse::CACHE_LONG );
 
 		self::$idCacheByName[$name] = $result;
 
@@ -710,7 +713,7 @@ class User implements JsonSerializable {
 			self::$idCacheByName = array();
 		}
 
-		return $result;
+		return $result ?: null;
 	}
 
 	/**


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-2981

88% of calls to this method return no rows (635k queries daily vs 724k queries overall from this method).

### Existing user

```sql
> var_dump( User::idFromName( 'Pyrabot' ) )
memcached: get(dev-macbre-wikicities:user:name:Pyrabot)
LBFactory_Wikia::getSectionForWiki: section central, wiki wikicities
LoadBalancer::getReaderIndex: Using reader #1: geo-db-dev-db-slave.query.consul...
Connecting to geo-db-dev-db-slave.query.consul wikicities...
LoadBalancer::openForeignConnection: opened new connection for 1/wikicities
LoadBalancer::reuseConnection: freed connection 1/wikicities
LoadBalancer::openForeignConnection: reusing free connection 1/wikicities
Query wikicities (DB user: wikia_maint) (7) (slave): SELECT /* User::idFromName CommandLineInc - e28a2115-ee69-4795-8d47-bd0639784326 */  user_id  FROM `user`  WHERE user_name = 'Pyrabot'  LIMIT 1  
memcached: set dev-macbre-wikicities:user:name:Pyrabot (STORED)
/usr/wikia/source/deploytools/18879/src/maintenance/eval.php(88) : eval()'d code:1:
int(5059646)

> var_dump( User::idFromName( 'Pyrabot' ) )
/usr/wikia/source/deploytools/18879/src/maintenance/eval.php(88) : eval()'d code:1:
int(5059646)

--

> var_dump( User::idFromName( 'Pyrabot' ) )
memcached: get(dev-macbre-wikicities:user:name:Pyrabot)
memcached: MemCache: sock i:0; got dev-macbre-wikicities:user:name:Pyrabot
/usr/wikia/source/deploytools/18879/src/maintenance/eval.php(88) : eval()'d code:1:
int(5059646)
```

### Not existing user

```sql
> var_dump( User::idFromName( 'MacbreAAA' ) )
memcached: get(dev-macbre-wikicities:user:name:MacbreAAA)
LBFactory_Wikia::getSectionForWiki: section central, wiki wikicities
LoadBalancer::getReaderIndex: Using reader #1: geo-db-dev-db-slave.query.consul...
Connecting to geo-db-dev-db-slave.query.consul wikicities...
LoadBalancer::openForeignConnection: opened new connection for 1/wikicities
LoadBalancer::reuseConnection: freed connection 1/wikicities
LoadBalancer::openForeignConnection: reusing free connection 1/wikicities
Query wikicities (DB user: wikia_maint) (7) (slave): SELECT /* User::idFromName CommandLineInc - 69387999-85cb-4195-bd51-e4df922437ed */  user_id  FROM `user`  WHERE user_name = 'MacbreAAA'  LIMIT 1  
memcached: set dev-macbre-wikicities:user:name:MacbreAAA (STORED)
/usr/wikia/source/deploytools/18879/src/maintenance/eval.php(88) : eval()'d code:1:
NULL

> var_dump( User::idFromName( 'MacbreAAA' ) )
/usr/wikia/source/deploytools/18879/src/maintenance/eval.php(88) : eval()'d code:1:
NULL

--

> var_dump( User::idFromName( 'MacbreAAA' ) )
memcached: get(dev-macbre-wikicities:user:name:MacbreAAA)
memcached: MemCache: sock i:0; got dev-macbre-wikicities:user:name:MacbreAAA
/usr/wikia/source/deploytools/18879/src/maintenance/eval.php(88) : eval()'d code:1:
NULL
```