### PR TITLE
SUS-3249 | Wikia\Consul\Client::getNodesFromConsulQuery - added support for Consul queries

### DIFF
--- a/extensions/wikia/CreateNewWiki/maintenance/importStarter.php
+++ b/extensions/wikia/CreateNewWiki/maintenance/importStarter.php
@@ -71,6 +71,7 @@ class ImportStarter extends Maintenance {
 	 *
 	 * @param resource $contentDumpStream stream with XML dump
 	 * @param resource $sqlDumpStream stream with SQL tables dump
+	 * @throws CreateWikiException
 	 */
 	private function importDump($contentDumpStream, $sqlDumpStream) {
 		$pagesCnt = 0;

--- a/lib/Wikia/src/Consul/Client.php
+++ b/lib/Wikia/src/Consul/Client.php
@@ -4,11 +4,14 @@
  * A helper class that uses sensiolabs/consul-php-sdk for getting the list of service nodes
  *
  * @see PLATFORM-1489
+ * @see SUS-3249 - added support for Consul queries
  * @see https://www.consul.io/docs/agent/http/health.html#health_service
+ * @see https://www.consul.io/api/query.html
  */
 
 namespace Wikia\Consul;
 
+use SensioLabs\Consul\Client as ConsulClient;
 use SensioLabs\Consul\ServiceFactory;
 use Wikia\Logger\Loggable;
 use Wikia\Logger\WikiaLogger;
@@ -42,7 +45,7 @@ class Client {
 	 * @param string $tag
 	 * @return array list of IP addresses with ports ie. 127.0.0.1:1234
 	 */
-	function getNodes( $service, $tag ) {
+	function getNodes( string $service, string $tag ) : array {
 		$resp = $this->api->service( $service, [ 'tag' => $tag, 'passing' => true ] )->json();
 
 		$nodes = array_map(
@@ -57,38 +60,125 @@ class Client {
 	}
 
 	/**
+	 * Returns IP addresses (with ports) of given service healthy nodes
+	 *
+	 * $catalog->getNodes( 'db-a', 'slave' )
+	 * $catalog->getNodes( 'chat-private', 'prod' )
+	 *
+	 * $ curl 'http://127.0.0.1:8500/v1/query/geo-db-a-slave/execute?pretty=&passing='
+	 *
+	 * @param string $query
+	 * @return array list of IP addresses with ports ie. 127.0.0.1:1234
+	 */
+	private function getNodesFromConsulQuery( string $query ) : array {
+		$consulClient = new ConsulClient();
+		$resp = $consulClient->get(
+			sprintf( '/v1/query/%s/execute?passing=', $query )
+		)->json();
+
+		$nodes = array_map(
+			function( $item ) {
+				return $item[ 'Node' ][ 'Address' ] . ':' . $item[ 'Service' ][ 'Port' ];
+			},
+			$resp['Nodes']
+		);
+
+		wfDebug( __METHOD__ .sprintf( ": got nodes for '%s' query: %s\n", $query, join(', ', $nodes) ) );
+		return $nodes;
+	}
+
+	/**
 	 * Helper method for getting IP addresses of all nodes hidden behind consul
 	 *
-	 * $catalog->getNodesFromHostname( 'slave.db-smw.service.consul' )
+	 * $consul->getNodesFromHostname( 'slave.db-smw.service.consul' )
+	 * $consul->getNodesFromHostname( 'geo-db-g-slave.query.consul' )
 	 *
 	 * @param string $hostname
 	 * @return array list of IP addresses
+	 * @throws \Exception
 	 */
-	function getNodesFromHostname( $hostname ) {
+	function getNodesFromHostname( string $hostname ) {
 		Assert::true( self::isConsulAddress( $hostname ), __METHOD__ . ' should get a Consul address', $this->getLoggerContext() );
 
-		list( $tag, $service ) = explode( '.', $hostname );
-		return $this->getNodes( $service, $tag );
+		if ( self::isConsulQuery($hostname) ) {
+			// e.g. geo-db-g-slave.query.consul
+			$query = self::parseConsulQuery( $hostname );
+			return $this->getNodesFromConsulQuery( $query );
+		}
+		elseif ( self::isConsulServiceAddress( $hostname ) ) {
+			// e.g. slave.db-g.service.consul
+			list( $tag, $service ) = self::parseConsulServiceAddress( $hostname);
+			return $this->getNodes( $service, $tag );
+		}
+		else {
+			throw new \Exception( __METHOD__ . " - {$hostname} is neither consul query nor consul service address" );
+		}
 	}
 
 	/**
 	 * Example: Wikia\Consul\Client::isConsulAddress( 'slave.db-smw.service.consul' )
 	 *
-	 * @param $address
+	 * @param string $address
 	 * @return bool true if the given address is a consul one
 	 */
-	static function isConsulAddress( $address ) {
+	static function isConsulAddress( string $address ) : bool {
 		return endsWith( $address, '.consul' );
+	}
+
+	/**
+	 * Example: Wikia\Consul\Client::isConsulServiceAddress( 'slave.db-smw.service.consul' )
+	 *
+	 * @param string $address
+	 * @return bool true if the given address is a consul service one
+	 */
+	static function isConsulServiceAddress( string $address ) : bool {
+		return endsWith( $address, '.service.consul' );
+	}
+
+	/**
+	 * Returns a service and tag part from consul address.
+	 *
+	 * Example: 'slave.db-smw.service.consul' => ['slave', 'db-smw']
+	 *
+	 * @param string $address
+	 * @return string[]|false
+	 */
+	static function parseConsulServiceAddress( string $address ) {
+		if ( self::isConsulServiceAddress( $address ) ) {
+			list( $tag, $service ) = explode( '.', $address, 3 );
+			return [ $tag, $service ];
+		}
+		else {
+			return false;
+		}
 	}
 
 	/**
 	 * Example: Wikia\Consul\Client::isConsulQuery( 'geo-db-g-slave.query.consul' )
 	 *
-	 * @param $address
+	 * @see https://www.consul.io/api/query.html
+	 *
+	 * @param string $address
 	 * @return bool true if the given address is a consul query
 	 */
-	static function isConsulQuery( $address ) {
+	static function isConsulQuery( string $address ) : bool {
 		return endsWith( $address, '.query.consul' );
+	}
+
+	/**
+	 * Returns a query from consul address.
+	 *
+	 * It basically returns the first part of the dot-separated domain
+	 *
+	 * Example: 'geo-db-g-slave.query.consul' => 'geo-db-g-slave'
+	 *
+	 * @param string $address
+	 * @return string|false
+	 */
+	static function parseConsulQuery( string $address ) {
+		return self::isConsulQuery( $address )
+			? strtok( $address, '.' )
+			: false;
 	}
 
 	/**

--- a/lib/Wikia/src/Consul/Client.php
+++ b/lib/Wikia/src/Consul/Client.php
@@ -72,13 +72,23 @@ class Client {
 	}
 
 	/**
-	 * Example: Wikia\Consul\Catalog::isConsulAddress( 'slave.db-smw.service.consul' )
+	 * Example: Wikia\Consul\Client::isConsulAddress( 'slave.db-smw.service.consul' )
 	 *
 	 * @param $address
 	 * @return bool true if the given address is a consul one
 	 */
 	static function isConsulAddress( $address ) {
 		return endsWith( $address, '.consul' );
+	}
+
+	/**
+	 * Example: Wikia\Consul\Client::isConsulQuery( 'geo-db-g-slave.query.consul' )
+	 *
+	 * @param $address
+	 * @return bool true if the given address is a consul query
+	 */
+	static function isConsulQuery( $address ) {
+		return endsWith( $address, '.query.consul' );
 	}
 
 	/**

--- a/lib/Wikia/src/Consul/Client.php
+++ b/lib/Wikia/src/Consul/Client.php
@@ -62,8 +62,7 @@ class Client {
 	/**
 	 * Returns IP addresses (with ports) of given service healthy nodes
 	 *
-	 * $catalog->getNodes( 'db-a', 'slave' )
-	 * $catalog->getNodes( 'chat-private', 'prod' )
+	 * $catalog->getNodesFromConsulQuery( 'geo-db-dev-db-slave' )
 	 *
 	 * $ curl 'http://127.0.0.1:8500/v1/query/geo-db-a-slave/execute?pretty=&passing='
 	 *

--- a/lib/Wikia/tests/Consul/ClientTest.php
+++ b/lib/Wikia/tests/Consul/ClientTest.php
@@ -14,4 +14,13 @@ class ConsulClientTest extends WikiaBaseTest {
 
 		$this->assertFalse( Client::isConsulAddress( 'statsdb-s9' ) );
 	}
+
+	function testIsConsulQuery() {
+		$this->assertTrue( Client::isConsulQuery( 'geo-db-sharedb-master.query.consul' ) );
+		$this->assertTrue( Client::isConsulQuery( 'geo-db-g-slave.query.consul' ) );
+
+		$this->assertFalse( Client::isConsulQuery( 'slave.db-smw.service.consul' ) );
+		$this->assertFalse( Client::isConsulQuery( 'master.db-a.service.consul' ) );
+		$this->assertFalse( Client::isConsulQuery( 'statsdb-s9' ) );
+	}
 }

--- a/lib/Wikia/tests/Consul/ClientTest.php
+++ b/lib/Wikia/tests/Consul/ClientTest.php
@@ -5,6 +5,9 @@
 
 use Wikia\Consul\Client;
 
+/**
+ * @group Consul
+ */
 class ConsulClientTest extends WikiaBaseTest {
 
 	function testIsConsulAddress() {
@@ -15,6 +18,16 @@ class ConsulClientTest extends WikiaBaseTest {
 		$this->assertFalse( Client::isConsulAddress( 'statsdb-s9' ) );
 	}
 
+	function testIsConsulServiceAddress() {
+		$this->assertTrue( Client::isConsulServiceAddress( 'master.db-a.service.consul' ) );
+		$this->assertTrue( Client::isConsulServiceAddress( 'slave.db-smw.service.consul' ) );
+
+		$this->assertFalse( Client::isConsulServiceAddress( 'geo-db-sharedb-master.query.consul' ) );
+		$this->assertFalse( Client::isConsulServiceAddress( 'geo-db-g-slave.query.consul' ) );
+
+		$this->assertFalse( Client::isConsulServiceAddress( 'statsdb-s9' ) );
+	}
+
 	function testIsConsulQuery() {
 		$this->assertTrue( Client::isConsulQuery( 'geo-db-sharedb-master.query.consul' ) );
 		$this->assertTrue( Client::isConsulQuery( 'geo-db-g-slave.query.consul' ) );
@@ -22,5 +35,27 @@ class ConsulClientTest extends WikiaBaseTest {
 		$this->assertFalse( Client::isConsulQuery( 'slave.db-smw.service.consul' ) );
 		$this->assertFalse( Client::isConsulQuery( 'master.db-a.service.consul' ) );
 		$this->assertFalse( Client::isConsulQuery( 'statsdb-s9' ) );
+	}
+
+	function testParseConsulQuery() {
+		$this->assertEquals(
+			'geo-db-sharedb-master',
+			Client::parseConsulQuery( 'geo-db-sharedb-master.query.consul') );
+
+		$this->assertFalse( Client::parseConsulQuery( 'slave.db-smw.service.consul') );
+		$this->assertFalse( Client::parseConsulQuery( 'statsdb-s9') );
+	}
+
+	function testParseConsulServiceAddress() {
+		$this->assertEquals(
+			[ 'slave', 'db-smw' ],
+			Client::parseConsulServiceAddress( 'slave.db-smw.service.consul') );
+
+		$this->assertEquals(
+			[ 'master', 'db-a' ],
+			Client::parseConsulServiceAddress( 'master.db-a.service.consul') );
+
+		$this->assertFalse( Client::parseConsulServiceAddress( 'geo-db-sharedb-master.query.consul') );
+		$this->assertFalse( Client::parseConsulServiceAddress( 'statsdb-s9') );
 	}
 }


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3249

Consul queries (e.g. `geo-db-dev-db-slave.query.consul`) were not correctly handled by `wfWaitForSlaves` - we failed to correctly ask Consul to give us IP addresses and ports of all nodes behind the query. Hence, we did not actually wait for slaves to catch up that lead to CreateWiki  intermittently failing to fully set up new wikis.

This fix introduces support for Consul queries (and keeps support for Consul service URLs) with improved unit tests coverage.

### Before the fix

```sql
Wikia\Consul\Client::getNodes: got nodes for 'query' service ('geo-db-a-slave' tag): 
Connecting to geo-db-a-master.query.consul wikia...
Query wikia (DB user: wikia_maint) (1) (master): SHOW /* DatabaseBase::getMasterPos CommandLineInc - ebd6b93e-9615-49ab-b96b-863257515cc4 */ MASTER STATUS
Connecting to geo-db-a-slave.query.consul wikia...
LoadBalancer::doWait: Waiting for slave #1 (geo-db-a-slave.query.consul) to catch up...
DatabaseBase::commit: skipped [DatabaseMysqlBase::masterPosWait]
LoadBalancer::doWait: Done
```

The code was waiting for just a single slave node.

### After the fix

```sql
> wfWaitForSlaves()
Wikia\Consul\Client::getNodesFromConsulQuery: got nodes for 'geo-db-dev-db-slave' query: 10.x.x.x:3306, 10.y.y.y:3306
Connecting to geo-db-dev-db-master.query.consul plpoznan...
Query plpoznan (DB user: wikia_maint) (7) (master): SHOW /* DatabaseBase::getMasterPos CommandLineInc - 3b1abdd7-8cb7-45eb-9afd-315ad0305207 */ MASTER STATUS
Connecting to 10.x.x.x plpoznan...
LoadBalancer::doWait: Waiting for slave #1 (10.x.x.x) to catch up...
DatabaseBase::commit: skipped [DatabaseMysqlBase::masterPosWait]
LoadBalancer::doWait: Done
Connecting to 10.y.y.y plpoznan...
LoadBalancer::doWait: Waiting for slave #2 (10.y.y.y) to catch up...
DatabaseBase::commit: skipped [DatabaseMysqlBase::masterPosWait]
LoadBalancer::doWait: Done
```