### PR TITLE
AdEngine: tests for old and new url format on staging envs

### DIFF
--- a/extensions/wikia/AdEngine/js/spec/utils/AdLogicZoneParams.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/utils/AdLogicZoneParams.spec.js
@@ -98,12 +98,44 @@ describe('ext.wikia.adEngine.utils.adLogicZoneParams', function () {
 		expect(zoneParams.getHostnamePrefix()).toBe('externaltest');
 	});
 
+	it('Hostname and domain for fallout.externaltest.wikia.com', function () {
+		setUpLocation('fallout.externaltest.wikia.com');
+		var zoneParams = getModule();
+
+		expect(zoneParams.getDomain()).toBe('wikiacom');
+		expect(zoneParams.getHostnamePrefix()).toBe('externaltest');
+	});
+
 	it('Hostname and domain for showcase.gta.wikia.com', function () {
 		setUpLocation('showcase.gta.wikia.com');
 		var zoneParams = getModule();
 
 		expect(zoneParams.getDomain()).toBe('wikiacom');
 		expect(zoneParams.getHostnamePrefix()).toBe('showcase');
+	});
+
+	it('Hostname and domain for gta.showcase.wikia.com', function () {
+		setUpLocation('gta.showcase.wikia.com');
+		var zoneParams = getModule();
+
+		expect(zoneParams.getDomain()).toBe('wikiacom');
+		expect(zoneParams.getHostnamePrefix()).toBe('showcase');
+	});
+
+	it('Hostname and domain for sandbox-adeng05.gta.wikia.com', function () {
+		setUpLocation('sandbox-adeng05.gta.wikia.com');
+		var zoneParams = getModule();
+
+		expect(zoneParams.getDomain()).toBe('wikiacom');
+		expect(zoneParams.getHostnamePrefix()).toBe('sandbox-adeng05');
+	});
+
+	it('Hostname and domain for gta.sandbox-adeng05.wikia.com', function () {
+		setUpLocation('gta.sandbox-adeng05.wikia.com');
+		var zoneParams = getModule();
+
+		expect(zoneParams.getDomain()).toBe('wikiacom');
+		expect(zoneParams.getHostnamePrefix()).toBe('sandbox-adeng05');
 	});
 
 	it('Simple base params', function () {

--- a/extensions/wikia/AdEngine/js/utils/AdLogicZoneParams.js
+++ b/extensions/wikia/AdEngine/js/utils/AdLogicZoneParams.js
@@ -39,7 +39,7 @@ define('ext.wikia.adEngine.utils.adLogicZoneParams', [
 
 	function getHostnamePrefix() {
 		var lhost = hostname.toLowerCase(),
-			match = /(^|\.)(showcase|externaltest|sandbox-[^\.]+)\./.exec(lhost);
+			match = /(^|\.)(showcase|externaltest|preview|verify|stable|sandbox-[^\.]+)\./.exec(lhost);
 
 		if (match && match.length > 2) {
 			return match[2];

--- a/extensions/wikia/AdEngine/js/utils/AdLogicZoneParams.js
+++ b/extensions/wikia/AdEngine/js/utils/AdLogicZoneParams.js
@@ -39,7 +39,13 @@ define('ext.wikia.adEngine.utils.adLogicZoneParams', [
 
 	function getHostnamePrefix() {
 		var lhost = hostname.toLowerCase(),
-			pieces = lhost.split('.');
+			match = /(^|\.)(showcase|externaltest|sandbox-[^\.]+)\./.exec(lhost);
+
+		if (match && match.length > 2) {
+			return match[2];
+		}
+
+		var	pieces = lhost.split('.');
 
 		if (pieces.length) {
 			return pieces[0];

--- a/extensions/wikia/AdEngine/js/utils/AdLogicZoneParams.js
+++ b/extensions/wikia/AdEngine/js/utils/AdLogicZoneParams.js
@@ -45,7 +45,7 @@ define('ext.wikia.adEngine.utils.adLogicZoneParams', [
 			return match[2];
 		}
 
-		var	pieces = lhost.split('.');
+		var pieces = lhost.split('.');
 
 		if (pieces.length) {
 			return pieces[0];


### PR DESCRIPTION
Due to the url change for staging envs, update AdEngine code for ad targeting so it works with both formats.