### PR TITLE
SUS-3246: Prevent manually crafted SemanticDrilldown queries from causing DB error

### DIFF
--- a/extensions/SemanticDrilldown/includes/SD_Filter.php
+++ b/extensions/SemanticDrilldown/includes/SD_Filter.php
@@ -184,10 +184,6 @@ class SDFilter {
 	public function loadDBStructureInformation() {
 		global $smwgDefaultStore;
 
-		\Wikia\Logger\WikiaLogger::instance()->info( 'SUS-3246 - Loading property information', [
-			'property_type' => $this->property_type
-		] );
-
 		if ( $smwgDefaultStore === 'SMWSQLStore3' || $smwgDefaultStore === 'SMWSparqlStore' ) {
 			if ( $this->property_type === 'page' ) {
 				$this->db_table_name = 'smw_di_wikipage';

--- a/extensions/SemanticDrilldown/tests/TemporaryTableManagerTest.php
+++ b/extensions/SemanticDrilldown/tests/TemporaryTableManagerTest.php
@@ -1,0 +1,106 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class TemporaryTableManagerTest extends TestCase {
+	/** @var DatabaseBase|PHPUnit_Framework_MockObject_MockObject */
+	private $databaseConnectionMock;
+
+	/** @var TemporaryTableManager $temporaryTableManager */
+	private $temporaryTableManager;
+
+	protected function setUp() {
+		parent::setUp();
+		require_once __DIR__ . '/../includes/TemporaryTableManager.php';
+
+		$this->databaseConnectionMock = $this->createMock( DatabaseMysqli::class );
+
+		$this->temporaryTableManager = new TemporaryTableManager( $this->databaseConnectionMock );
+	}
+
+	/**
+	 * @dataProvider sqlProvider
+	 * @param string $sqlQuery
+	 */
+	public function testTransactionStateAndFlagsAreNotManipulatedWhenDboTrxIsNotSet( $sqlQuery ) {
+		$this->databaseConnectionMock->expects( $this->any() )
+			->method( 'getFlag' )
+			->with( DBO_TRX )
+			->willReturn( false );
+
+		$this->databaseConnectionMock->expects( $this->once() )
+			->method( 'query' )
+			->with( $sqlQuery, $this->anything() );
+
+		$this->databaseConnectionMock->expects( $this->never() )
+			->method( 'commit' );
+		$this->databaseConnectionMock->expects( $this->never() )
+			->method( 'setFlag' );
+
+		$this->temporaryTableManager->queryWithAutoCommit( $sqlQuery );
+	}
+
+	/**
+	 * @dataProvider sqlProvider
+	 * @param string $sqlQuery
+	 */
+	public function testDboTrxFlagIsPreservedButCommitIsNotCalledIfDboTrxIsSetWithNoOpenTransaction(
+		$sqlQuery
+	) {
+		$this->databaseConnectionMock->expects( $this->any() )
+			->method( 'getFlag' )
+			->with( DBO_TRX )
+			->willReturn( true );
+		$this->databaseConnectionMock->expects( $this->any() )
+			->method( 'trxLevel' )
+			->willReturn( false );
+
+		$this->databaseConnectionMock->expects( $this->once() )
+			->method( 'query' )
+			->with( $sqlQuery, $this->anything() );
+
+		$this->databaseConnectionMock->expects( $this->never() )
+			->method( 'commit' );
+		$this->databaseConnectionMock->expects( $this->once() )
+			->method( 'setFlag' )
+			->with( DBO_TRX );
+
+		$this->temporaryTableManager->queryWithAutoCommit( $sqlQuery );
+	}
+
+	/**
+	 * @dataProvider sqlProvider
+	 * @param string $sqlQuery
+	 */
+	public function testDboTrxFlagIsPreservedAndCommitIsCalledIfDboTrxIsSetWithOpenTransaction(
+		$sqlQuery
+	) {
+		$this->databaseConnectionMock->expects( $this->any() )
+			->method( 'getFlag' )
+			->with( DBO_TRX )
+			->willReturn( true );
+		$this->databaseConnectionMock->expects( $this->any() )
+			->method( 'trxLevel' )
+			->willReturn( true );
+
+		$this->databaseConnectionMock->expects( $this->once() )
+			->method( 'query' )
+			->with( $sqlQuery, $this->anything() );
+
+		$this->databaseConnectionMock->expects( $this->once() )
+			->method( 'commit' );
+		$this->databaseConnectionMock->expects( $this->once() )
+			->method( 'setFlag' )
+			->with( DBO_TRX );
+
+		$this->temporaryTableManager->queryWithAutoCommit( $sqlQuery );
+	}
+
+	public function sqlProvider() {
+		return array(
+			array( 'CREATE TEMPORARY TABLE semantic_drilldown_values ( id INT NOT NULL )' ),
+			array( 'CREATE INDEX id_index ON semantic_drilldown_values ( id )' ),
+			array( 'INSERT INTO semantic_drilldown_values SELECT ids.smw_id AS id\n' ),
+		);
+	}
+}

--- a/includes/db/Database.php
+++ b/includes/db/Database.php
@@ -839,6 +839,9 @@ abstract class DatabaseBase implements DatabaseType {
 	 * @return bool Whether $sql is SQL for TEMPORARY table operation
 	 */
 	protected function registerTempTableOperation( $sql ) {
+		// SUS-3246: Trim the SQL query to avoid manually crafted queries not matching
+		$sql = ltrim( $sql );
+
 		if ( preg_match(
 			'/^CREATE\s+TEMPORARY\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?[`"\']?(\w+)[`"\']?/i',
 			$sql,

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -45,6 +45,9 @@
 		<testsuite name="DPL Extension Test Suite">
 			<directory>../extensions/DynamicPageList/tests/</directory>
 		</testsuite>
+		<testsuite name="Semantic Drilldown Test Suite">
+			<directory>../extensions/SemanticDrilldown/tests/</directory>
+		</testsuite>
 	</testsuites>
 	<groups>
 		<exclude>


### PR DESCRIPTION
Semantic Drilldown SQL queries are constructed via _konkatenacja kalinskiego_, so they do not match regexes that determine if they are temporary table operations, causing the query to fail on read-only slave databases. By trimming the SQL query before match, we can eliminate this issue.

https://wikia-inc.atlassian.net/browse/SUS-3246