### PR TITLE
SUS-3081: do not insert user name to logging table

### DIFF
--- a/includes/logging/LogPage.php
+++ b/includes/logging/LogPage.php
@@ -85,33 +85,38 @@ class LogPage {
 
 	/**
 	 * @return bool|int|null
+	 * @throws MWException if this log entry would be attributed to anon user
 	 */
 	protected function saveContent() {
 		global $wgLogRestrictions;
 
+		// SUS-3222: All log entries should be attributed to registered users
+		if ( $this->doer->isAnon() ) {
+			$mwException = new MWException( 'Log entries must be attributed to registered users' );
+
+			\Wikia\Logger\WikiaLogger::instance()
+				->warning( 'SUS-3222 - Anon user log entry', [ 'exception' => $mwException ] );
+
+			throw $mwException;
+		}
+
 		$dbw = wfGetDB( DB_MASTER );
 		$log_id = $dbw->nextSequenceValue( 'logging_log_id_seq' );
 
-		// SUS-3222: All log entries should be attributed to registered users
-		if ( $this->doer->isAnon() ) {
-			\Wikia\Logger\WikiaLogger::instance()
-				->warning( 'SUS-3222 - Anon user log entry' );
-		}
-
 		$this->timestamp = $now = wfTimestampNow();
-		$data = array(
+		$data = [
 			'log_id' => $log_id,
 			'log_type' => $this->type,
 			'log_action' => $this->action,
 			'log_timestamp' => $dbw->timestamp( $now ),
 			'log_user' => $this->doer->getId(),
-			'log_user_text' => $this->doer->getName(),
 			'log_namespace' => $this->target->getNamespace(),
 			'log_title' => $this->target->getDBkey(),
 			'log_page' => $this->target->getArticleId(),
 			'log_comment' => $this->comment,
 			'log_params' => $this->params
-		);
+		];
+
 		$dbw->insert( 'logging', $data, __METHOD__ );
 		$newId = !is_null( $log_id ) ? $log_id : $dbw->insertId();
 

--- a/tests/unit/includes/logging/ManualLogEntryTest.php
+++ b/tests/unit/includes/logging/ManualLogEntryTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class ManualLogEntryTest extends TestCase {
+	const LOG_TYPE = 'test_type';
+	const LOG_SUBTYPE = 'test_subtype';
+
+	/** @var User|PHPUnit_Framework_MockObject_MockObject $userMock */
+	private $userMock;
+
+	/** @var ManualLogEntry $manualLogEntry */
+	private $manualLogEntry;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->userMock = $this->createMock( User::class );
+		$this->manualLogEntry = new ManualLogEntry( static::LOG_TYPE, static::LOG_SUBTYPE );
+	}
+
+	public function testLogTypeSubtype() {
+		$this->assertEquals( static::LOG_TYPE, $this->manualLogEntry->getType() );
+		$this->assertEquals( static::LOG_SUBTYPE, $this->manualLogEntry->getSubtype() );
+	}
+
+	public function testLogEntryCannotBeSavedWithAnonUserAsAuthor() {
+		$this->expectException( MWException::class );
+		$this->expectExceptionMessage( 'Log entries must be attributed to registered users' );
+
+		$this->userMock->expects( $this->any() )
+			->method( 'isAnon' )
+			->willReturn( true );
+
+		$this->manualLogEntry->setPerformer( $this->userMock );
+		$this->manualLogEntry->insert();
+	}
+}


### PR DESCRIPTION
* do not insert value for `log_user_text` column (rely on `default ''`)
* treat inserting log entry with anon author as error - such entries are always broken

https://wikia-inc.atlassian.net/browse/SUS-3081