### PR TITLE
SUS-3257: Truncate cuc_action_text value before insert

### DIFF
--- a/extensions/CheckUser/CheckUser.hooks.php
+++ b/extensions/CheckUser/CheckUser.hooks.php
@@ -34,7 +34,7 @@ class CheckUserHooks {
 		}
 
 		// SUS-3257: Make sure the text fits into the database
-		$actionTextTrim = substr( $actionText, 0, static::ACTION_TEXT_MAX_LENGTH );
+		$actionTextTrim = mb_substr( $actionText, 0, static::ACTION_TEXT_MAX_LENGTH );
 
 		$dbw = wfGetDB( DB_MASTER );
 		$cuc_id = $dbw->nextSequenceValue( 'cu_changes_cu_id_seq' );

--- a/extensions/CheckUser/CheckUser.hooks.php
+++ b/extensions/CheckUser/CheckUser.hooks.php
@@ -1,5 +1,7 @@
 <?php
 class CheckUserHooks {
+	const ACTION_TEXT_MAX_LENGTH = 255;
+
 	/**
 	 * Hook function for RecentChange_save
 	 * Saves user data into the cu_changes table
@@ -31,6 +33,9 @@ class CheckUserHooks {
 			$actionText = '';
 		}
 
+		// SUS-3257: Make sure the text fits into the database
+		$actionTextTrim = substr( $actionText, 0, static::ACTION_TEXT_MAX_LENGTH );
+
 		$dbw = wfGetDB( DB_MASTER );
 		$cuc_id = $dbw->nextSequenceValue( 'cu_changes_cu_id_seq' );
 		$rcRow = array(
@@ -40,7 +45,7 @@ class CheckUserHooks {
 			'cuc_minor'      => $rc_minor,
 			'cuc_user'       => $rc_user,
 			// 'cuc_user_text'  => $user->isAnon() ? $rc_user_text : '', // SUS-3080 - this column is redundant
-			'cuc_actiontext' => $actionText,
+			'cuc_actiontext' => $actionTextTrim,
 			'cuc_comment'    => $rc_comment,
 			'cuc_this_oldid' => $rc_this_oldid,
 			'cuc_last_oldid' => $rc_last_oldid,


### PR DESCRIPTION
Avoid the following:
```
Query: INSERT  INTO `cu_changes` (cuc_id,cuc_namespace,cuc_title,cuc_minor,cuc_user,cuc_actiontext,cuc_comment,cuc_this_oldid,cuc_last_oldid,cuc_type,cuc_timestamp,cuc_ip,cuc_ip_hex,cuc_xff,cuc_xff_hex,cuc_agent,cuc_page_id) VALUES (NULL,'0','If_I_use_Starlight_Road_to_Special_Summon_Stardust_Dragon,then_use_Assault_Mode_Activate_on_it,_Can_the_Stardust_Dragon/Assault_Mode_I_special_Summoned_Use_its_Ablilty_to_Summon_Stardust_Dragon_once_its_Destroyed','0','63030','Jacce changed protection level for &quot;[[If I use Starlight Road to Special Summon Stardust Dragon,then use Assault Mode Activate on it, Can the Stardust Dragon/Assault Mode I special Summoned Use its Ablilty to Summon Stardust Dragon once its Destroyed]]&quot; ‎[create=autoconfirmed] (expires 12:53, February 16, 2018 (UTC))','','0','0','3','20171116125324','148.136.141.173','94888DAD','',NULL,'Mozilla/5.0 (Windows NT 6.1; rv:56.0) Gecko/20100101 Firefox/56.0','0')
Function: CheckUserHooks::updateCheckUserData
Error: 1406 Data too long for column 'cuc_actiontext' at row 1 (geo-db-b-master.query.consul)
```
https://wikia-inc.atlassian.net/browse/SUS-3257