### PR TITLE
PLATFORM-3198: Migrate VideoHandler wrappers to HTTPS

### DIFF
--- a/extensions/wikia/VideoHandlers/VideoFileUploader.class.php
+++ b/extensions/wikia/VideoHandlers/VideoFileUploader.class.php
@@ -283,7 +283,7 @@ class VideoFileUploader {
 
 		// If uploading the actual thumbnail fails, load a default thumbnail
 		if ( empty($upload) ) {
-			$upload = $this->uploadThumbnailFromUrl( LegacyVideoApiWrapper::$THUMBNAIL_URL );
+			$upload = $this->uploadThumbnailFromUrl( LegacyVideoApiWrapper::getLegacyThumbnailUrl() );
 			$this->scheduleJob( $delayIndex );
 		}
 

--- a/extensions/wikia/VideoHandlers/apiwrappers/AnyclipApiWrapper.class.php
+++ b/extensions/wikia/VideoHandlers/apiwrappers/AnyclipApiWrapper.class.php
@@ -3,7 +3,7 @@
 class AnyclipApiWrapper extends ApiWrapper {
 
 	protected $ingestion = true;
-
+	// HTTPS-note: not switching to https, as apis.anyclip.com doesn't seem to work at all.
 	protected static $API_URL = 'http://apis.anyclip.com/api/clip/$1/';
 	protected static $CACHE_KEY = 'anyclipapi';
 	protected static $CACHE_KEY_VERSION = 0.2;

--- a/extensions/wikia/VideoHandlers/apiwrappers/ApiWrapper.class.php
+++ b/extensions/wikia/VideoHandlers/apiwrappers/ApiWrapper.class.php
@@ -900,8 +900,7 @@ abstract class IngestionApiWrapper extends PseudoApiWrapper {
  * those are only used by video migration scripts and serve no other purpose
  */
 abstract class LegacyVideoApiWrapper extends PseudoApiWrapper {
-	//@todo change this url
-	static $THUMBNAIL_URL = 'http://community.wikia.com/extensions/wikia/VideoHandlers/images/NoThumbnailBg.png';
+	static $THUMBNAIL_PATH = '/extensions/wikia/VideoHandlers/images/NoThumbnailBg.png';
 
 	public function __construct($videoId, array $overrideMetadata=array()) {
 
@@ -927,7 +926,12 @@ abstract class LegacyVideoApiWrapper extends PseudoApiWrapper {
 	}
 
 	public function getThumbnailUrl() {
-		return self::$THUMBNAIL_URL;
+		return self::getLegacyThumbnailUrl();
+	}
+
+	public static function getLegacyThumbnailUrl() {
+		global $wgCdnStylePath;
+		return $wgCdnStylePath . self::$THUMBNAIL_PATH;
 	}
 
 }

--- a/extensions/wikia/VideoHandlers/apiwrappers/ApiWrapper.class.php
+++ b/extensions/wikia/VideoHandlers/apiwrappers/ApiWrapper.class.php
@@ -930,8 +930,8 @@ abstract class LegacyVideoApiWrapper extends PseudoApiWrapper {
 	}
 
 	public static function getLegacyThumbnailUrl() {
-		global $wgCdnStylePath;
-		return $wgCdnStylePath . self::$THUMBNAIL_PATH;
+		global $wgResourceBasePath;
+		return $wgResourceBasePath . self::$THUMBNAIL_PATH;
 	}
 
 }

--- a/extensions/wikia/VideoHandlers/apiwrappers/FiveminApiWrapper.class.php
+++ b/extensions/wikia/VideoHandlers/apiwrappers/FiveminApiWrapper.class.php
@@ -3,7 +3,7 @@
 class FiveminApiWrapper extends ApiWrapper {
 
 	protected static $RESPONSE_FORMAT = self::RESPONSE_FORMAT_XML;
-	protected static $API_URL = 'http://api.5min.com/video/$1/info.xml?thumbnail_sizes=true';
+	protected static $API_URL = 'https://api.5min.com/video/$1/info.xml?thumbnail_sizes=true';
 	protected static $CACHE_KEY = 'fiveminapi';
 	protected static $aspectRatio = 1.3636;	// 480 x 352
 

--- a/extensions/wikia/VideoHandlers/apiwrappers/HuluApiWrapper.class.php
+++ b/extensions/wikia/VideoHandlers/apiwrappers/HuluApiWrapper.class.php
@@ -2,8 +2,8 @@
 
 class HuluApiWrapper extends ApiWrapper {
 
-	protected static $API_URL = 'http://www.hulu.com/api/oembed.json?url=';
-	protected static $WATCH_URL = 'http://www.hulu.com/watch/$1';
+	protected static $API_URL = 'https://www.hulu.com/api/oembed.json?url=';
+	protected static $WATCH_URL = 'https://www.hulu.com/watch/$1';
 	protected static $CACHE_KEY = 'huluapi';
 	protected static $aspectRatio = 1.7777778;
 

--- a/extensions/wikia/VideoHandlers/apiwrappers/MovieclipsApiWrapper.class.php
+++ b/extensions/wikia/VideoHandlers/apiwrappers/MovieclipsApiWrapper.class.php
@@ -3,6 +3,7 @@
 class MovieclipsApiWrapper extends ApiWrapper {
 	
 	protected static $RESPONSE_FORMAT = self::RESPONSE_FORMAT_XML;
+	// HTTPS-note: api.movieclips.com doesn't seem to work over https
 	protected static $API_URL = 'http://api.movieclips.com/v2/videos/$1';
 	protected static $CACHE_KEY = 'movieclipsapi';
 	protected static $MOVIECLIPS_XMLNS = 'http://api.movieclips.com/schemas/2010';

--- a/extensions/wikia/VideoHandlers/apiwrappers/PrototypeApiWrapper.class.php
+++ b/extensions/wikia/VideoHandlers/apiwrappers/PrototypeApiWrapper.class.php
@@ -20,7 +20,7 @@ class PrototypeApiWrapper extends ApiWrapper{
 	}
 
 	function getThumbnailUrl( ){
-		return 'http://img.youtube.com/vi/FRKUuSnEDkU/0.jpg';
+		return 'https://img.youtube.com/vi/FRKUuSnEDkU/0.jpg';
 	}
 	
 	protected function getInterfaceObject() {

--- a/extensions/wikia/VideoHandlers/apiwrappers/ScreenplayApiWrapper.class.php
+++ b/extensions/wikia/VideoHandlers/apiwrappers/ScreenplayApiWrapper.class.php
@@ -18,8 +18,8 @@ class ScreenplayApiWrapper extends IngestionApiWrapper {
 
 	protected static $CACHE_KEY = 'screenplayapi';
 	protected static $aspectRatio = 1.7777778;
-	protected static $THUMBNAIL_URL_TEMPLATE = 'http://www.totaleclips.com/Player/Bounce.aspx?eclipid=$1&bitrateid=$2&vendorid=$3&type=$4';
-	protected static $ASSET_URL = 'http://$2:$3@www.totaleclips.com/api/v1/assets?vendorid=$1&eclipid=$4';
+	protected static $THUMBNAIL_URL_TEMPLATE = 'https://www.totaleclips.com/Player/Bounce.aspx?eclipid=$1&bitrateid=$2&vendorid=$3&type=$4';
+	protected static $ASSET_URL = 'https://$2:$3@www.totaleclips.com/api/v1/assets?vendorid=$1&eclipid=$4';
 
 	public function getDescription() {
 		return '';	//  no description from provider

--- a/extensions/wikia/VideoHandlers/apiwrappers/TwitchtvApiWrapper.class.php
+++ b/extensions/wikia/VideoHandlers/apiwrappers/TwitchtvApiWrapper.class.php
@@ -53,7 +53,7 @@ class TwitchtvApiWrapper extends ApiWrapper {
 	}
 
 	public function getThumbnailUrl() {
-		$thumb = LegacyVideoApiWrapper::$THUMBNAIL_URL;
+		$thumb = LegacyVideoApiWrapper::getLegacyThumbnailUrl();
 
 		$url = str_replace( '$2', 'streams', static::$API_URL );
 		$url = str_replace( '$1', $this->videoId, $url );

--- a/extensions/wikia/VideoHandlers/apiwrappers/UstreamApiWrapper.class.php
+++ b/extensions/wikia/VideoHandlers/apiwrappers/UstreamApiWrapper.class.php
@@ -2,8 +2,8 @@
 
 class UstreamApiWrapper extends ApiWrapper {
 
-	protected static $API_URL = 'http://api.ustream.tv/json/video/$1/getInfo';
-	protected static $WATCH_URL = 'http://www.ustream.tv/recorded/$1';
+	protected static $API_URL = 'https://api.ustream.tv/json/video/$1/getInfo';
+	protected static $WATCH_URL = 'https://www.ustream.tv/recorded/$1';
 	protected static $CACHE_KEY = 'ustreamapi';
 	protected static $aspectRatio = 1.7777778;
 

--- a/extensions/wikia/VideoHandlers/apiwrappers/UstreamApiWrapper.class.php
+++ b/extensions/wikia/VideoHandlers/apiwrappers/UstreamApiWrapper.class.php
@@ -2,8 +2,9 @@
 
 class UstreamApiWrapper extends ApiWrapper {
 
-	protected static $API_URL = 'https://api.ustream.tv/json/video/$1/getInfo';
-	protected static $WATCH_URL = 'https://www.ustream.tv/recorded/$1';
+	// HTTPS-note - https://ustream.tv redirects to http
+	protected static $API_URL = 'http://api.ustream.tv/json/video/$1/getInfo';
+	protected static $WATCH_URL = 'http://www.ustream.tv/recorded/$1';
 	protected static $CACHE_KEY = 'ustreamapi';
 	protected static $aspectRatio = 1.7777778;
 

--- a/extensions/wikia/VideoHandlers/apiwrappers/ViddlerApiWrapper.class.php
+++ b/extensions/wikia/VideoHandlers/apiwrappers/ViddlerApiWrapper.class.php
@@ -2,9 +2,9 @@
 
 class ViddlerApiWrapper extends ApiWrapper {
 	protected static $RESPONSE_FORMAT = self::RESPONSE_FORMAT_PHP;
-	protected static $API_URL = 'http://api.viddler.com/api/v2/viddler.videos.getDetails.php?add_embed_code=1&url=';
-	public static $WATCH_URL = 'http://www.viddler.com/v/$1';
-	public static $MAIN_URL = 'http://www.viddler.com/';
+	protected static $API_URL = 'https://api.viddler.com/api/v2/viddler.videos.getDetails.php?add_embed_code=1&url=';
+	public static $WATCH_URL = 'https://www.viddler.com/v/$1';
+	public static $MAIN_URL = 'https://www.viddler.com/';
 	protected static $CACHE_KEY = 'viddlerapi';
 	protected static $aspectRatio = 1.56160458;
 

--- a/extensions/wikia/VideoHandlers/apiwrappers/VimeoApiWrapper.class.php
+++ b/extensions/wikia/VideoHandlers/apiwrappers/VimeoApiWrapper.class.php
@@ -2,7 +2,7 @@
 
 class VimeoApiWrapper extends ApiWrapper {
 
-	protected static $API_URL = 'http://vimeo.com/api/v2/video/$1.json';
+	protected static $API_URL = 'https://vimeo.com/api/v2/video/$1.json';
 	protected static $CACHE_KEY = 'Vimeoapi';
 	protected static $aspectRatio = 1.7777778;
 

--- a/extensions/wikia/VideoHandlers/feedingesters/CrunchyrollFeedIngester.class.php
+++ b/extensions/wikia/VideoHandlers/feedingesters/CrunchyrollFeedIngester.class.php
@@ -6,7 +6,7 @@
 class CrunchyrollFeedIngester extends VideoFeedIngester {
 	protected static $API_WRAPPER = 'CrunchyrollApiWrapper';
 	protected static $PROVIDER = 'crunchyroll';
-	protected static $FEED_URL = 'http://www.crunchyroll.com/syndication/feed?type=series';
+	protected static $FEED_URL = 'https://www.crunchyroll.com/syndication/feed?type=series';
 
 	/**
 	 * Contains desired series titles and Ids

--- a/extensions/wikia/VideoHandlers/feedingesters/IgnFeedIngester.class.php
+++ b/extensions/wikia/VideoHandlers/feedingesters/IgnFeedIngester.class.php
@@ -6,7 +6,7 @@
 class IgnFeedIngester extends VideoFeedIngester {
 	protected static $API_WRAPPER = 'IgnApiWrapper';
 	protected static $PROVIDER = 'ign';
-	protected static $FEED_URL = 'http://apis.ign.com/partners/v3/wikia?fromDate=$1&toDate=$2&app_id=$3&app_key=$4';
+	protected static $FEED_URL = 'https://apis.ign.com/partners/v3/wikia?fromDate=$1&toDate=$2&app_id=$3&app_key=$4';
 	protected static $CLIP_FILTER = [
 		'*' => [
 			'/IGN Daily/i',

--- a/extensions/wikia/VideoHandlers/feedingesters/IvaFeedIngester.class.php
+++ b/extensions/wikia/VideoHandlers/feedingesters/IvaFeedIngester.class.php
@@ -6,6 +6,7 @@
 class IvaFeedIngester extends RemoteAssetFeedIngester {
 	protected static $API_WRAPPER = 'IvaApiWrapper';
 	protected static $PROVIDER = 'iva';
+	// HTTPS-note - https://api.internetvideoarchive.com doesn't seem to work.
 	protected static $FEED_URL = 'http://api.internetvideoarchive.com/1.0/DataService/EntertainmentPrograms?$top=$1&$skip=$2&$filter=$3&$expand=$4&$format=json&developerid=$5';
 	protected static $FEED_URL_ASSET = 'http://api.internetvideoarchive.com/1.0/DataService/VideoAssets()?$top=$1&$skip=$2&$filter=$3&$expand=$4&$format=json&developerid=$5';
 	protected static $ASSET_URL = 'http://www.videodetective.net/video.mp4?cmd=6&fmt=4&customerid=$1&videokbrate=$4&publishedid=$2&e=$3';

--- a/extensions/wikia/VideoHandlers/feedingesters/ScreenplayFeedIngester.class.php
+++ b/extensions/wikia/VideoHandlers/feedingesters/ScreenplayFeedIngester.class.php
@@ -6,7 +6,7 @@ class ScreenplayFeedIngester extends RemoteAssetFeedIngester {
 
 	protected static $API_WRAPPER = 'ScreenplayApiWrapper';
 	protected static $PROVIDER = 'screenplay';
-	protected static $FEED_URL = 'http://$2:$3@www.totaleclips.com/api/v1/assets?vendorid=$1&group_by_title=1&date_added=$4&date_added_end=$5&bitrateID=$6';
+	protected static $FEED_URL = 'https://$2:$3@www.totaleclips.com/api/v1/assets?vendorid=$1&group_by_title=1&date_added=$4&date_added_end=$5&bitrateID=$6';
 
 	protected static $FORMAT_ID_THUMBNAIL = 9;
 	protected static $FORMAT_ID_VIDEO = 20;

--- a/extensions/wikia/VideoHandlers/handlers/CrunchyrollVideoHandler.class.php
+++ b/extensions/wikia/VideoHandlers/handlers/CrunchyrollVideoHandler.class.php
@@ -10,8 +10,8 @@ class CrunchyrollVideoHandler extends VideoHandler {
 	 */
 
 	protected $apiName = 'CrunchyrollApiWrapper';
-	protected static $urlTemplate = "http://www.crunchyroll.com/affiliate_iframeplayer?aff=$2&media_id=$1&video_format=106&video_quality=60";
-	protected static $providerHomeUrl = 'http://www.crunchyroll.com/';
+	protected static $urlTemplate = "https://www.crunchyroll.com/affiliate_iframeplayer?aff=$2&media_id=$1&video_format=106&video_quality=60";
+	protected static $providerHomeUrl = 'https://www.crunchyroll.com/';
 
 	/**
 	 * @inheritdoc

--- a/extensions/wikia/VideoHandlers/handlers/DailymotionVideoHandler.class.php
+++ b/extensions/wikia/VideoHandlers/handlers/DailymotionVideoHandler.class.php
@@ -3,9 +3,9 @@
 class DailymotionVideoHandler extends VideoHandler {
 
 	protected $apiName = 'DailymotionApiWrapper';
-	protected static $urlTemplate = 'http://www.dailymotion.com/embed/video/$1';
-	protected static $providerDetailUrlTemplate = 'http://www.dailymotion.com/video/$1';
-	protected static $providerHomeUrl = 'http://www.dailymotion.com/';
+	protected static $urlTemplate = 'https://www.dailymotion.com/embed/video/$1';
+	protected static $providerDetailUrlTemplate = 'https://www.dailymotion.com/video/$1';
+	protected static $providerHomeUrl = 'https://www.dailymotion.com/';
 	protected static $autoplayParam = "autoPlay";
 	protected static $autoplayValue = "1";
 

--- a/extensions/wikia/VideoHandlers/handlers/FiveminVideoHandler.class.php
+++ b/extensions/wikia/VideoHandlers/handlers/FiveminVideoHandler.class.php
@@ -3,9 +3,9 @@
 class FiveminVideoHandler extends VideoHandler {
 
 	protected $apiName = 'FiveminApiWrapper';
-	protected static $urlTemplate = 'http://www.5min.com/Embeded/$1';
-	protected static $providerDetailUrlTemplate = 'http://www.5min.com/Video/$1';
-	protected static $providerHomeUrl = 'http://www.5min.com/';
+	protected static $urlTemplate = 'https://www.5min.com/Embeded/$1';
+	protected static $providerDetailUrlTemplate = 'https://www.5min.com/Video/$1';
+	protected static $providerHomeUrl = 'https://www.5min.com/';
 	protected static $autoplayParam = "autostart";
 	protected static $autoplayValue = "true";
 

--- a/extensions/wikia/VideoHandlers/handlers/GametrailersVideoHandler.class.php
+++ b/extensions/wikia/VideoHandlers/handlers/GametrailersVideoHandler.class.php
@@ -2,9 +2,10 @@
 
 class GametrailersVideoHandler extends VideoHandler {
 	protected $apiName = 'GametrailersApiWrapper';
-	protected static $urlTemplate = 'https://media.mtvnservices.com/mgid:moses:video:gametrailers.com:$1';
-	protected static $providerDetailUrlTemplate = 'https://www.gametrailers.com/video/play/$1';
-	protected static $providerHomeUrl = 'https://www.gametrailers.com/';
+	// HTTPS-note - www.gametrailers.com does not yet support HTTPS, to handle in (PLATFORM-3284)
+	protected static $urlTemplate = 'http://media.mtvnservices.com/mgid:moses:video:gametrailers.com:$1';
+	protected static $providerDetailUrlTemplate = 'http://www.gametrailers.com/video/play/$1';
+	protected static $providerHomeUrl = 'http://www.gametrailers.com/';
 	protected static $autoplayParam = "autoplay";
 	protected static $autoplayValue = "true";
 

--- a/extensions/wikia/VideoHandlers/handlers/GametrailersVideoHandler.class.php
+++ b/extensions/wikia/VideoHandlers/handlers/GametrailersVideoHandler.class.php
@@ -2,9 +2,9 @@
 
 class GametrailersVideoHandler extends VideoHandler {
 	protected $apiName = 'GametrailersApiWrapper';
-	protected static $urlTemplate = 'http://media.mtvnservices.com/mgid:moses:video:gametrailers.com:$1';
-	protected static $providerDetailUrlTemplate = 'http://www.gametrailers.com/video/play/$1';
-	protected static $providerHomeUrl = 'http://www.gametrailers.com/';
+	protected static $urlTemplate = 'https://media.mtvnservices.com/mgid:moses:video:gametrailers.com:$1';
+	protected static $providerDetailUrlTemplate = 'https://www.gametrailers.com/video/play/$1';
+	protected static $providerHomeUrl = 'https://www.gametrailers.com/';
 	protected static $autoplayParam = "autoplay";
 	protected static $autoplayValue = "true";
 

--- a/extensions/wikia/VideoHandlers/handlers/HuluVideoHandler.class.php
+++ b/extensions/wikia/VideoHandlers/handlers/HuluVideoHandler.class.php
@@ -3,9 +3,9 @@
 class HuluVideoHandler extends VideoHandler {
 
 	protected $apiName = 'HuluApiWrapper';
-	protected static $urlTemplate = 'http://www.hulu.com/embed/$1';
-	protected static $providerDetailUrlTemplate = 'http://www.hulu.com/watch/$1';
-	protected static $providerHomeUrl = 'http://www.hulu.com/';
+	protected static $urlTemplate = 'https://www.hulu.com/embed/$1';
+	protected static $providerDetailUrlTemplate = 'https://www.hulu.com/watch/$1';
+	protected static $providerHomeUrl = 'https://www.hulu.com/';
 	protected static $autoplayParam = "";
 	protected static $autoplayValue = "";
 

--- a/extensions/wikia/VideoHandlers/handlers/IgnVideoHandler.class.php
+++ b/extensions/wikia/VideoHandlers/handlers/IgnVideoHandler.class.php
@@ -4,9 +4,9 @@ class IgnVideoHandler extends VideoHandler {
 
 	protected $apiName = 'IgnApiWrapper';
 	protected static $urlTemplate = '';
-	protected static $providerDetailUrlTemplate = 'http://www.ign.com/watch?v=$1';
-	protected static $providerPlayerUrl = 'http://widgets.ign.com/video/embed/content.html';
-	protected static $providerHomeUrl = 'http://www.ign.com/';
+	protected static $providerDetailUrlTemplate = 'https://www.ign.com/watch?v=$1';
+	protected static $providerPlayerUrl = 'https://widgets.ign.com/video/embed/content.html';
+	protected static $providerHomeUrl = 'https://www.ign.com/';
 	protected static $autoplayParam = 'autoplay';
 	protected static $autoplayValue = 'true';
 	protected static $playerVersion = '4';

--- a/extensions/wikia/VideoHandlers/handlers/MakerstudiosVideoHandler.class.php
+++ b/extensions/wikia/VideoHandlers/handlers/MakerstudiosVideoHandler.class.php
@@ -3,8 +3,8 @@
 class MakerstudiosVideoHandler extends VideoHandler {
 
 	protected $apiName = 'MakerstudiosWrapper';
-	protected static $urlTemplate = 'http://www.maker.tv/player/$1';
-	protected static $providerHomeUrl = 'http://www.makerstudios.com/';
+	protected static $urlTemplate = 'https://www.maker.tv/player/$1';
+	protected static $providerHomeUrl = 'https://www.makerstudios.com/';
 
 	public function getEmbed( $width, array $options = [] ) {
 		$height =  $this->getHeight( $width );

--- a/extensions/wikia/VideoHandlers/handlers/SouthparkstudiosVideoHandler.class.php
+++ b/extensions/wikia/VideoHandlers/handlers/SouthparkstudiosVideoHandler.class.php
@@ -3,6 +3,7 @@
 class SouthparkstudiosVideoHandler extends VideoHandler {
 	protected $apiName = 'SouthparkstudiosApiWrapper';
 	protected static $urlTemplate = 'http://media.mtvnservices.com/mgid:cms:item:southparkstudios.com:$1';
+	// HTTPS-note - opposite to http://www.southparkstudios.com/clips/104202, I cannot get the https version to work.
 	protected static $providerDetailUrlTemplate = 'http://www.southparkstudios.com/clips/$1';
 	protected static $providerHomeUrl = 'http://www.southparkstudios.com/';
 	protected static $autoplayParam = "autoPlay";

--- a/extensions/wikia/VideoHandlers/handlers/TwitchtvVideoHandler.class.php
+++ b/extensions/wikia/VideoHandlers/handlers/TwitchtvVideoHandler.class.php
@@ -3,9 +3,9 @@
 class TwitchtvVideoHandler extends VideoHandler {
 
 	protected $apiName = 'TwitchtvApiWrapper';
-	protected static $urlTemplate = 'http://www.twitch.tv/widgets/live_embed_player.swf?channel=$1';
-	protected static $providerDetailUrlTemplate = 'http://www.twitch.tv/$1';
-	protected static $providerHomeUrl = 'http://www.twitch.tv';
+	protected static $urlTemplate = 'https://www.twitch.tv/widgets/live_embed_player.swf?channel=$1';
+	protected static $providerDetailUrlTemplate = 'https://www.twitch.tv/$1';
+	protected static $providerHomeUrl = 'https://www.twitch.tv';
 
 	public function getEmbed( $width, array $options = [] ) {
 		$autoplay = !empty( $options['autoplay'] );
@@ -19,7 +19,7 @@ class TwitchtvVideoHandler extends VideoHandler {
 	<param name="allowFullScreen" value="true" />
 	<param name="allowScriptAccess" value="always" />
 	<param name="allowNetworking" value="all" />
-	<param name="movie" value="http://www.twitch.tv/widgets/live_embed_player.swf" />
+	<param name="movie" value="https://www.twitch.tv/widgets/live_embed_player.swf" />
 	<param name="flashvars" value="hostname=www.twitch.tv&channel={$this->videoId}&auto_play={$autoplayStr}&start_volume=25" />
 </object>
 EOT;

--- a/extensions/wikia/VideoHandlers/handlers/UstreamVideoHandler.class.php
+++ b/extensions/wikia/VideoHandlers/handlers/UstreamVideoHandler.class.php
@@ -4,6 +4,7 @@ class UstreamVideoHandler extends VideoHandler {
 
 	protected $apiName = 'UstreamApiWrapper';
 	protected static $urlTemplate = 'http://www.ustream.tv/embed/recorded/$1?v=3&wmode=direct';
+	// HTTPS-note - https://www.ustream.tv/recorded/44762993 redirects to http.
 	protected static $providerDetailUrlTemplate = 'http://www.ustream.tv/recorded/$1';
 	protected static $providerHomeUrl = 'http://www.ustream.tv/';
 

--- a/extensions/wikia/VideoHandlers/handlers/ViddlerVideoHandler.class.php
+++ b/extensions/wikia/VideoHandlers/handlers/ViddlerVideoHandler.class.php
@@ -2,9 +2,9 @@
 
 class ViddlerVideoHandler extends VideoHandler {
 	protected $apiName = 'ViddlerApiWrapper';
-	protected static $urlTemplate = 'http://www.viddler.com/player/$1/';
-	protected static $providerDetailUrlTemplate = 'http://www.viddler.com/v/$1';
-	protected static $providerHomeUrl = 'http://www.viddler.com/';
+	protected static $urlTemplate = 'https://www.viddler.com/player/$1/';
+	protected static $providerDetailUrlTemplate = 'https://www.viddler.com/v/$1';
+	protected static $providerHomeUrl = 'https://www.viddler.com/';
 	protected static $autoplayParam = "autoplay";
 	protected static $autoplayValue = "t";
 

--- a/extensions/wikia/VideoHandlers/handlers/VimeoVideoHandler.class.php
+++ b/extensions/wikia/VideoHandlers/handlers/VimeoVideoHandler.class.php
@@ -3,10 +3,10 @@
 class VimeoVideoHandler extends VideoHandler {
 
 	protected $apiName = 'VimeoApiWrapper';
-	protected $googleSitemapCustomVideoUrl = 'http://vimeo.com/moogaloop.swf?clip_id=$1';
-	protected static $urlTemplate = 'http://player.vimeo.com/video/$1';
-	protected static $providerDetailUrlTemplate = 'http://vimeo.com/$1';
-	protected static $providerHomeUrl = 'http://vimeo.com/';
+	protected $googleSitemapCustomVideoUrl = 'https://vimeo.com/moogaloop.swf?clip_id=$1';
+	protected static $urlTemplate = 'https://player.vimeo.com/video/$1';
+	protected static $providerDetailUrlTemplate = 'https://vimeo.com/$1';
+	protected static $providerHomeUrl = 'https://vimeo.com/';
 	protected static $autoplayParam = "autoplay";
 	protected static $autoplayValue = "1";
 

--- a/extensions/wikia/VideoHandlers/handlers/YoukuVideoHandler.class.php
+++ b/extensions/wikia/VideoHandlers/handlers/YoukuVideoHandler.class.php
@@ -3,9 +3,9 @@
 class YoukuVideoHandler extends VideoHandler {
 
 	protected $apiName = 'YoukuApiWrapper';
-	protected static $urlTemplate = 'http://player.youku.com/embed/$1';
-	protected static $providerDetailUrlTemplate = "http://v.youku.com/v_show/id_$1.html";
-	protected static $providerHomeUrl = 'http://www.youku.com/';
+	protected static $urlTemplate = 'https://player.youku.com/embed/$1';
+	protected static $providerDetailUrlTemplate = "https://v.youku.com/v_show/id_$1.html";
+	protected static $providerHomeUrl = 'https://www.youku.com/';
 
 	public function getEmbed( $width, array $options = [] ) {
 		$height =  $this->getHeight( $width );

--- a/extensions/wikia/VideoHandlers/handlers/YoutubeVideoHandler.class.php
+++ b/extensions/wikia/VideoHandlers/handlers/YoutubeVideoHandler.class.php
@@ -3,9 +3,9 @@
 class YoutubeVideoHandler extends VideoHandler {
 
 	protected $apiName = 'YoutubeApiWrapper';
-	protected static $urlTemplate = 'http://www.youtube.com/embed/$1';
-	protected static $providerDetailUrlTemplate = 'http://www.youtube.com/watch?v=$1';
-	protected static $providerHomeUrl = 'http://www.youtube.com/';
+	protected static $urlTemplate = 'https://www.youtube.com/embed/$1';
+	protected static $providerDetailUrlTemplate = 'https://www.youtube.com/watch?v=$1';
+	protected static $providerHomeUrl = 'https://www.youtube.com/';
 	protected static $autoplayParam = "autoplay";
 	protected static $autoplayValue = "1";
 


### PR DESCRIPTION
Switching video providers urls to https, at least these which seem to work over secure protocol.
Also migrated legacy thumbnail url from `http://community.wikia.com/extensions/wikia/VideoHandlers/images/NoThumbnailBg.png` to something like `https://slot1-images.wikia.nocookie.net/__cb1510840026/common/extensions/wikia/VideoHandlers/images/NoThumbnailBg.png`.