### PR TITLE
Minor spelling fix that fixes desc

### DIFF
--- a/extensions/wikia/Piggyback/Piggyback.i18n.php
+++ b/extensions/wikia/Piggyback/Piggyback.i18n.php
@@ -3,7 +3,7 @@
 $messages = [];
 
 $messages['en'] = [
-	'piggybac-desc' => 'Allows logging on as another user',
+	'piggyback-desc' => 'Allows logging on as another user',
 	'piggyback' => 'Piggyback',
 	'piggyback-otherusername' => 'Other username:',
 	'piggyback-nosuchuser' => 'There is no user by the name "$1".


### PR DESCRIPTION
The piggyback desc is presented by the code piggyback-desc but the one in the github and live server ii8n file is piggybac-desc. This fixes this issue.