### PR TITLE
(PLATFORM-3194) Migrate tag extensions to HTTPS where possible

### DIFF
--- a/extensions/wikia/ApesterTag/ApesterTagController.class.php
+++ b/extensions/wikia/ApesterTag/ApesterTagController.class.php
@@ -4,7 +4,7 @@ class ApesterTagController extends WikiaController {
 
 	const PARSER_TAG_NAME = 'apester';
 
-	const SCRIPT_SRC = 'http://static.apester.com/js/sdk/v2.0/apester-javascript-sdk.min.js';
+	const SCRIPT_SRC = 'https://static.apester.com/js/sdk/v2.0/apester-javascript-sdk.min.js';
 
 	const DATA_MEDIA_ID_ATTR = 'data-media-id';
 	const HEIGHT_ATTR = 'height';

--- a/extensions/wikia/PlaybuzzTag/PlaybuzzTagController.class.php
+++ b/extensions/wikia/PlaybuzzTag/PlaybuzzTagController.class.php
@@ -2,7 +2,7 @@
 
 class PlaybuzzTagController extends WikiaController {
 	const PARSER_TAG_NAME = 'playbuzz';
-	const PLAYBUZZ_SCRIPT_SRC = 'http://cdn.playbuzz.com/widget/feed.js';
+	const PLAYBUZZ_SCRIPT_SRC = 'https://cdn.playbuzz.com/widget/feed.js';
 
 	const DATA_ITEM_ATTR = 'data-item';
 	const DATA_COMMENTS_ATTR = 'data-comments';

--- a/extensions/wikia/PollSnackTag/PollSnackTagController.class.php
+++ b/extensions/wikia/PollSnackTag/PollSnackTagController.class.php
@@ -3,6 +3,7 @@ class PollSnackTagController extends WikiaController {
 
 	const PARSER_TAG_NAME = 'pollsnack';
 
+	// files.quizsnack.com does not yet support HTTPS, to handle in (PLATFORM-3285)
 	const TAG_SRC = 'http://files.quizsnack.com/iframe/embed.html?';
 
 	const TAG_SOURCE_ALLOWED_PARAMS_WITH_DEFAULTS = [

--- a/extensions/wikia/PolldaddyTag/templates/PolldaddyTagController_showDesktop.mustache
+++ b/extensions/wikia/PolldaddyTag/templates/PolldaddyTagController_showDesktop.mustache
@@ -1,1 +1,1 @@
-<a name="pd_a_{{id}}" style="display:inline;padding:0;margin:0;"></a><div class="PDS_Poll" id="PDI_container{{id}}"></div><script type="text/javascript" charset="utf-8" src="http://static.polldaddy.com/p/{{id}}.js"></script>
+<a name="pd_a_{{id}}" style="display:inline;padding:0;margin:0;"></a><div class="PDS_Poll" id="PDI_container{{id}}"></div><script type="text/javascript" charset="utf-8" src="https://static.polldaddy.com/p/{{id}}.js"></script>

--- a/extensions/wikia/WeiboTag/WeiboTagController.class.php
+++ b/extensions/wikia/WeiboTag/WeiboTagController.class.php
@@ -1,7 +1,7 @@
 <?php
 class WeiboTagController extends WikiaController {
 	const PARSER_TAG_NAME = 'weibo';
-	const TAG_SRC = 'http://widget.weibo.com/relationship/bulkfollow.php?';
+	const TAG_SRC = 'https://widget.weibo.com/relationship/bulkfollow.php?';
 	const TAG_SOURCE_ALLOWED_PARAMS_WITH_DEFAULTS = [
 		'color' => '',
 		'count' => '',

--- a/extensions/wikia/XBoxGamerCardTag/XBoxGamerCardTag.php
+++ b/extensions/wikia/XBoxGamerCardTag/XBoxGamerCardTag.php
@@ -57,7 +57,7 @@ function wfMakeXboxCard( $contents, $attributes, $parser ) {
 	else
 	{
 		$xbox_id_e = rawurlencode($xbox_id); #we use raw version because microsoft no longer accepts spaces as +, MUST be %20
-		$out .= "<iframe src=\"http://gamercard.xbox.com/{$xbox_id_e}.card\" scrolling=\"no\" frameBorder=\"0\" height=\"140\" width=\"204\">{$xbox_id}</iframe>";
+		$out .= "<iframe src=\"https://gamercard.xbox.com/{$xbox_id_e}.card\" scrolling=\"no\" frameBorder=\"0\" height=\"140\" width=\"204\">{$xbox_id}</iframe>";
 	}
 
 	$out .= "</div>\n";

--- a/extensions/wikia/YouTube/YouTube.php
+++ b/extensions/wikia/YouTube/YouTube.php
@@ -210,10 +210,8 @@ function wfYouTube( Parser $parser ): bool {
 	$parser->setHook( 'aovideo', 'embedArchiveOrgVideo' );
 	$parser->setHook( 'aoaudio', 'embedArchiveOrgAudio' );
 	$parser->setHook( 'wegame', 'embedWeGame' );
-	$parser->setHook( 'tangler', 'embedTangler' );
 	$parser->setHook( 'gtrailer', 'embedGametrailers' );
 	$parser->setHook( 'nicovideo', 'embedNicovideo' );
-	$parser->setHook( 'ggtube', 'embedGoGreenTube' );
 	$parser->setHook( 'cgamer', 'embedCrispyGamer' );
 	$parser->setHook( 'longtail', 'embedLongtailVideo' );
 
@@ -289,7 +287,7 @@ function embedYouTube( $input, $argv, $parser ) {
 	}
 
 	if ( !empty( $ytid ) ) {
-		$url = "http://www.youtube.com/v/{$ytid}&enablejsapi=1&version=2&playerapiid={$ytid}"; // it's not mistake, there should be &, not ?
+		$url = "https://www.youtube.com/v/{$ytid}&enablejsapi=1&version=2&playerapiid={$ytid}"; // it's not mistake, there should be &, not ?
 		return "<object type=\"application/x-shockwave-flash\" data=\"{$url}\" width=\"{$width}\" height=\"{$height}\" id=\"YT_{$ytid}\"><param name=\"movie\" value=\"{$url}\"/><param name=\"wmode\" value=\"transparent\"/><param name=\"allowScriptAccess\" value=\"always\"/></object>";
 	}
 }
@@ -327,7 +325,7 @@ function embedGoogleVideo( $input, $argv, $parser ) {
 	}
 
 	if ( !empty( $gvid ) ) {
-		$url = "http://video.google.com/googleplayer.swf?docId={$gvid}";
+		$url = "https://video.google.com/googleplayer.swf?docId={$gvid}";
 		return "<object type=\"application/x-shockwave-flash\" data=\"{$url}\" width=\"{$width}\" height=\"{$height}\"><param name=\"movie\" value=\"{$url}\"/><param name=\"wmode\" value=\"transparent\"/></object>";
 	}
 }
@@ -363,15 +361,15 @@ function embedArchiveOrgVideo( $input, $argv, $parser ) {
 	}
 
 	if ( !empty( $aovid ) ) {
-		$url = "http://www.archive.org/download/{$aovid}.flv";
-		return "<object type=\"application/x-shockwave-flash\" data=\"http://www.archive.org/flv/FlowPlayerWhite.swf\" width=\"{$width}\" height=\"{$height}\"><param name=\"movie\" value=\"http://www.archive.org/flv/FlowPlayerWhite.swf\"/><param name=\"flashvars\" value=\"config={loop: false, videoFile: '{$url}', autoPlay: false}\"/></object>";
+		$url = "https://www.archive.org/download/{$aovid}.flv";
+		return "<object type=\"application/x-shockwave-flash\" data=\"https://www.archive.org/flv/FlowPlayerWhite.swf\" width=\"{$width}\" height=\"{$height}\"><param name=\"movie\" value=\"https://www.archive.org/flv/FlowPlayerWhite.swf\"/><param name=\"flashvars\" value=\"config={loop: false, videoFile: '{$url}', autoPlay: false}\"/></object>";
 	}
 }
 
 function embedYouTube_url2aoaid( $url ) {
 	$id = $url;
 
-	if ( preg_match( '/http:\/\/www\.archive\.org\/details\/(.+)$/', $url, $preg ) ) {
+	if ( preg_match( '/https?:\/\/www\.archive\.org\/details\/(.+)$/', $url, $preg ) ) {
 		$id = $preg[1];
 	}
 
@@ -399,15 +397,15 @@ function embedArchiveOrgAudio( $input, $argv, $parser ) {
 	}
 
 	if ( !empty( $aoaid ) ) {
-		$url = urlencode( "http://www.archive.org/audio/xspf-maker.php?identifier={$aoaid}" );
-		return "<object type=\"application/x-shockwave-flash\" data=\"http://www.archive.org/audio/xspf_player.swf?playlist_url={$url}\" width=\"{$width}\" height=\"{$height}\"><param name=\"movie\" value=\"http://www.archive.org/audio/xspf_player.swf?playlist_url={$url}\"/></object>";
+		$url = urlencode( "https://www.archive.org/audio/xspf-maker.php?identifier={$aoaid}" );
+		return "<object type=\"application/x-shockwave-flash\" data=\"https://www.archive.org/audio/xspf_player.swf?playlist_url={$url}\" width=\"{$width}\" height=\"{$height}\"><param name=\"movie\" value=\"https://www.archive.org/audio/xspf_player.swf?playlist_url={$url}\"/></object>";
 	}
 }
 
 function embedYouTube_url2weid( $url ) {
 	$id = $url;
 
-	if ( preg_match( '/^http:\/\/www\.wegame\.com\/watch\/(.+)\/$/', $url, $preg ) ) {
+	if ( preg_match( '/^https?:\/\/www\.wegame\.com\/watch\/(.+)\/$/', $url, $preg ) ) {
 		$id = $preg[1];
 	}
 
@@ -435,7 +433,7 @@ function embedWeGame( $input, $argv, $parser ) {
 	}
 
 	if ( !empty( $weid ) ) {
-		return "<object type=\"application/x-shockwave-flash\" data=\"http://www.wegame.com/static/flash/player2.swf\" width=\"{$width}\" height=\"{$height}\"><param name=\"flashvars\" value=\"tag={$weid}\"/></object>";
+		return "<object type=\"application/x-shockwave-flash\" data=\"https://www.wegame.com/static/flash/player2.swf\" width=\"{$width}\" height=\"{$height}\"><param name=\"flashvars\" value=\"tag={$weid}\"/></object>";
 
 	}
 }
@@ -457,26 +455,12 @@ function embedYouTube_url2tgid( $input ) {
 	return array( $tid, $gid );
 }
 
-function embedTangler( $input, $argv, $parser ) {
-	$tid = $gid = '';
-
-	if ( !empty( $argv['tid'] ) && !empty( $argv['gid'] ) ) {
-		list( $tid, $gid ) = embedYouTube_url2tgid( "{$argv['tid']}|{$argv['gid']}" );
-	} elseif ( !empty( $input ) ) {
-		list( $tid, $gid ) = embedYouTube_url2tgid( $input );
-	}
-
-	if ( !empty( $tid ) && !empty( $gid ) ) {
-		return "<p style=\"width: 410px; height: 480px\" id=\"tangler-embed-topic-{$tid}\"></p><script type=\"text/javascript\" src=\"http://www.tangler.com/widget/embedtopic.js?id={$tid}&gId={$gid}\"></script>";
-	}
-}
-
 function embedYouTube_url2gtid( $url ) {
 	$id = $url;
 
-	if ( preg_match( '/^http:\/\/www\.gametrailers\.com\/player\/(.+)\.html$/', $url, $preg ) ) {
+	if ( preg_match( '/^https?:\/\/www\.gametrailers\.com\/player\/(.+)\.html$/', $url, $preg ) ) {
 		$id = $preg[1];
-	} elseif ( preg_match( '/^http:\/\/www\.gametrailers\.com\/remote_wrap\.php\?mid=(.+)$/', $url, $preg ) ) {
+	} elseif ( preg_match( '/^https?:\/\/www\.gametrailers\.com\/remote_wrap\.php\?mid=(.+)$/', $url, $preg ) ) {
 		$id = $preg[1];
 	}
 
@@ -504,6 +488,7 @@ function embedGametrailers( $input, $argv, $parser ) {
 	}
 
 	if ( !empty( $gtid ) ) {
+		// www.gametrailers.com does not yet support HTTPS, to handle in (PLATFORM-3284)
 		$url = "http://www.gametrailers.com/remote_wrap.php?mid={$gtid}";
 		// return "<object type=\"application/x-shockwave-flash\" width=\"{$width}\" height=\"{$height}\"><param name=\"movie\" value=\"{$url}\"/></object>";
 		// gametrailers' flash doesn't work on FF with object tag alone )-: weird, yt and gvideo are ok )-: valid xhtml no more )-:
@@ -538,45 +523,7 @@ function embedNicovideo( $input, $argv, $parser ) {
 	}
 
 	if ( !empty( $nvid ) ) {
-		$url = "http://ext.nicovideo.jp/thumb_watch/{$nvid}?w={$width}&amp;h={$height}";
-		return "<script type=\"text/javascript\" src=\"{$url}\"></script>";
-	}
-}
-
-function embedYouTube_url2ggid( $url ) {
-	$id = $url;
-
-	if ( preg_match( '/^http:\/\/www\.gogreentube\.com\/watch\.php\?v=(.+)$/', $url, $preg ) ) {
-		$id = $preg[1];
-	} elseif ( preg_match( '/^http:\/\/www\.gogreentube\.com\/embed\/(.+)$/', $url, $preg ) ) {
-		$id = $preg[1];
-	}
-
-	preg_match( '/([0-9A-Za-z]+)/', $id, $preg );
-	$id = $preg[1];
-
-	return $id;
-}
-
-function embedGoGreenTube( $input, $argv, $parser ) {
-	$ggid = '';
-	$width  = $width_max  = 432;
-	$height = $height_max = 394;
-
-	if ( !empty( $argv['ggid'] ) ) {
-		$ggid = embedYouTube_url2ggid( $argv['ggid'] );
-	} elseif ( !empty( $input ) ) {
-		$ggid = embedYouTube_url2ggid( $input );
-	}
-	if ( !empty( $argv['width'] ) && settype( $argv['width'], 'integer' ) && ( $width_max >= $argv['width'] ) ) {
-		$width = $argv['width'];
-	}
-	if ( !empty( $argv['height'] ) && settype( $argv['height'], 'integer' ) && ( $height_max >= $argv['height'] ) ) {
-		$height = $argv['height'];
-	}
-
-	if ( !empty( $ggid ) ) {
-		$url = "http://www.gogreentube.com/embed/{$ggid}";
+		$url = "https://ext.nicovideo.jp/thumb_watch/{$nvid}?w={$width}&amp;h={$height}";
 		return "<script type=\"text/javascript\" src=\"{$url}\"></script>";
 	}
 }
@@ -600,7 +547,7 @@ function embedCrispyGamer( $input, $argv, $parser ) {
 	}
 
 	if ( !empty( $cvid ) ) {
-		$url = "http://www.crispygamer.com/partners/wikia.aspx?pid=0&amp;vid={$cvid}";
+		$url = "https://www.crispygamer.com/partners/wikia.aspx?pid=0&amp;vid={$cvid}";
 		return "<script type=\"text/javascript\" src=\"{$url}\"></script>";
 	}
 }
@@ -610,6 +557,6 @@ function embedCrispyGamer( $input, $argv, $parser ) {
 function embedLongtailVideo( $input, $argv, $parser ) {
 	if ( !empty( $argv['vid'] ) ) {
 		$vid = $argv['vid'];
-		return "<script type=\"text/javascript\" src=\"http://content.bitsontherun.com/players/{$vid}-McXqFI4P.js\"></script>";
+		return "<script type=\"text/javascript\" src=\"https://content.bitsontherun.com/players/{$vid}-McXqFI4P.js\"></script>";
 	}
 }

--- a/extensions/wikia/YouTube/YouTube.php
+++ b/extensions/wikia/YouTube/YouTube.php
@@ -206,7 +206,6 @@ function wfYouTube( Parser $parser ): bool {
 		return true;
 	}
 	$parser->setHook( 'youtube', 'embedYouTube' );
-	$parser->setHook( 'gvideo',  'embedGoogleVideo' );
 	$parser->setHook( 'aovideo', 'embedArchiveOrgVideo' );
 	$parser->setHook( 'aoaudio', 'embedArchiveOrgAudio' );
 	$parser->setHook( 'wegame', 'embedWeGame' );
@@ -289,44 +288,6 @@ function embedYouTube( $input, $argv, $parser ) {
 	if ( !empty( $ytid ) ) {
 		$url = "https://www.youtube.com/v/{$ytid}&enablejsapi=1&version=2&playerapiid={$ytid}"; // it's not mistake, there should be &, not ?
 		return "<object type=\"application/x-shockwave-flash\" data=\"{$url}\" width=\"{$width}\" height=\"{$height}\" id=\"YT_{$ytid}\"><param name=\"movie\" value=\"{$url}\"/><param name=\"wmode\" value=\"transparent\"/><param name=\"allowScriptAccess\" value=\"always\"/></object>";
-	}
-}
-
-function embedYouTube_url2gvid( $url ) {
-	$id = $url;
-
-	if ( preg_match( '/^https?:\/\/video\.google\.com\/videoplay\?docid=([^&]+)(&hl=.+)?$/', $url, $preg ) ) {
-		$id = $preg[1];
-	} elseif ( preg_match( '/^https?:\/\/video\.google\.com\/googleplayer\.swf\?docId=(.+)$/', $url, $preg ) ) {
-		$id = $preg[1];
-	}
-
-	preg_match( '/([0-9-]+)/', $id, $preg );
-	$id = $preg[1];
-
-	return $id;
-}
-
-function embedGoogleVideo( $input, $argv, $parser ) {
-	$gvid   = '';
-	$width  = $width_max  = 400;
-	$height = $height_max = 326;
-
-	if ( !empty( $argv['gvid'] ) ) {
-		$gvid = embedYouTube_url2gvid( $argv['gvid'] );
-	} elseif ( !empty( $input ) ) {
-		$gvid = embedYouTube_url2gvid( $input );
-	}
-	if ( !empty( $argv['width'] ) && settype( $argv['width'], 'integer' ) && ( $width_max >= $argv['width'] ) ) {
-		$width = $argv['width'];
-	}
-	if ( !empty( $argv['height'] ) && settype( $argv['height'], 'integer' ) && ( $height_max >= $argv['height'] ) ) {
-		$height = $argv['height'];
-	}
-
-	if ( !empty( $gvid ) ) {
-		$url = "https://video.google.com/googleplayer.swf?docId={$gvid}";
-		return "<object type=\"application/x-shockwave-flash\" data=\"{$url}\" width=\"{$width}\" height=\"{$height}\"><param name=\"movie\" value=\"{$url}\"/><param name=\"wmode\" value=\"transparent\"/></object>";
 	}
 }
 


### PR DESCRIPTION
This migrates assets in tag extensions to HTTPS where possible. Two
providers in the Youtube extension were also removed as the domains no
longer resolve at all.

/cc @Wikia/core-platform-team 