### PR TITLE
SUS-2974 | LogstashFormatter - remove the $IP part to make backtrace a bit smaller

### DIFF
--- a/lib/Wikia/src/Logger/LogstashFormatter.php
+++ b/lib/Wikia/src/Logger/LogstashFormatter.php
@@ -51,10 +51,22 @@ class LogstashFormatter extends \Monolog\Formatter\LogstashFormatter {
 	}
 
 	/**
+	 * Remove the $IP-prefix (/usr/wikia/slot1/NNN/src) to make backtrace entries a bit smaller
+	 *
+	 * @see SUS-2974
+	 * @param string $path
+	 * @return string
+	 */
+	public static function normalizePath( string $path ) : string {
+		global $IP;
+		return str_replace( $IP, '', $path );
+	}
+
+	/**
 	 * @param Exception}Throwable $e
 	 * @return array
 	 */
-	protected function normalizeException($e) {
+	public function normalizeException($e) {
 		if (!$e instanceof Exception && !$e instanceof \Throwable) {
 			throw new \InvalidArgumentException('Exception/Throwable expected, got '.gettype($e).' / '.get_class($e));
 		}
@@ -63,13 +75,13 @@ class LogstashFormatter extends \Monolog\Formatter\LogstashFormatter {
 			'class' => get_class($e),
 			'message' => $e->getMessage(),
 			'code' => $e->getCode(),
-			'file' => $e->getFile().':'.$e->getLine(),
+			'file' => self::normalizePath( $e->getFile() ).':'.$e->getLine(),
 		);
 
 		$trace = $e->getTrace();
 		foreach ($trace as $frame) {
 			if (isset($frame['file'])) {
-				$data['trace'][] = $frame['file'].':'.$frame['line'];
+				$data['trace'][] = self::normalizePath( $frame['file'] ).':'.$frame['line'];
 			} else {
 				// prevent huge json blobs from preventing message parsing (because of split message) and flooding file logs
 				if (isset($frame['args'])) {

--- a/lib/Wikia/src/Tracer/WikiaTracer.php
+++ b/lib/Wikia/src/Tracer/WikiaTracer.php
@@ -3,6 +3,7 @@
 namespace Wikia\Tracer;
 
 use Wikia\Logger\ContextSource;
+use Wikia\Logger\LogstashFormatter;
 
 class WikiaTracer {
 
@@ -179,7 +180,7 @@ class WikiaTracer {
 		// add some context for maintenance scripts
 		if ( defined( 'RUN_MAINTENANCE_IF_MAIN' ) ) {
 			if ( isset( $_SERVER['SCRIPT_FILENAME'] ) ) {
-				$context['maintenance_file'] = realpath( $_SERVER['SCRIPT_FILENAME'] );
+				$context['maintenance_file'] = LogstashFormatter::normalizePath( realpath( $_SERVER['SCRIPT_FILENAME'] ) );
 			}
 
 			if ( !empty( $maintClass ) ) {

--- a/lib/Wikia/tests/Logger/LogstashFormatterTest.php
+++ b/lib/Wikia/tests/Logger/LogstashFormatterTest.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Wikia\Logger\LogstashFormatter tests
+ */
+
+use Wikia\Logger\LogstashFormatter;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group WikiaLogger
+ */
+class LogstashFormatterTest extends TestCase {
+
+	function testNormalizePath() {
+		global $IP;
+		$this->assertEquals( '/foo/bar', LogstashFormatter::normalizePath( $IP . '/foo/bar') );
+		$this->assertEquals( '/lib/Wikia/tests/Logger/LogstashFormatterTest.php', LogstashFormatter::normalizePath( __FILE__ ) );
+	}
+
+	function testNormalizeException() {
+		global $IP;
+		$ex = new Exception();
+
+		$handler = new LogstashFormatter('test');
+		$data = $handler->normalizeException($ex);
+
+		$this->assertFalse( startsWith( $data['trace'][1], $IP ) );
+		$this->assertTrue( startsWith( $data['trace'][1], '/lib' ) );
+
+		$this->assertFalse( startsWith( $data['file'], $IP ) );
+		$this->assertTrue( startsWith( $data['file'], '/lib' ) );
+	}
+}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-2974

This will allow us to increase sampling of DB queries log to 10%.

## Example

```
> Wikia\Logger\WikiaLogger::instance()->error('SUS-2974 test')
{"appname":"eval.php","@timestamp":"2017-11-20T11:02:26.757129+00:00","@message":"SUS-2974 test","@fields":{"app_name":"mediawiki","app_version":"2d4f9fe480270bd1bbca0e4e768e01c995226c06","datacenter":"poz","environment":"dev","wiki_dbname":"plpoznan","wiki_id":"5915","maintenance_file":"/maintenance/eval.php","maintenance_class":"CommandLineInc","client_ip":"127.0.0.1","span_id":"05053626-6db0-42bd-8594-b0f260b54a87","trace_id":"b42a41d9-77a5-4c7d-be5a-475a2d23d343"},"@exception":{"class":"Exception","message":"","code":0,"file":"/lib/Wikia/src/Logger/WikiaLogger.php:170","trace":["/lib/Wikia/src/Logger/WikiaLogger.php:147","/maintenance/eval.php(88) : eval()'d code:1","/maintenance/eval.php:88"]},"@context":[]}
```