### PR TITLE
DatabaseUpdater::dropIndex - check if table exists before trying to drop an index

### DIFF
--- a/includes/installer/DatabaseUpdater.php
+++ b/includes/installer/DatabaseUpdater.php
@@ -500,7 +500,11 @@ abstract class DatabaseUpdater {
 	 * @param $fullpath Boolean: Whether to treat $patch path as a relative or not
 	 */
 	protected function dropIndex( $table, $index, $patch, $fullpath = false ) {
-		if ( $this->db->indexExists( $table, $index, __METHOD__ ) ) {
+		# Wikia - prevent "SHOW INDEX FROM" from reporting DB error when a table does not exist
+		if ( !$this->db->tableExists( $table, __METHOD__ ) ) {
+			$this->output( "...$table table doesn't exist.\n" );
+		}
+		elseif ( $this->db->indexExists( $table, $index, __METHOD__ ) ) {
 			$this->output( "Dropping $index index from table $table... " );
 			$this->applyPatch( $patch, $fullpath );
 			$this->output( "done.\n" );


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3209

Prevent the following:

```sql
Table 'foobar.ach_user_badges' doesn't exist (geo-db-f-master.query.consul)

Query: SHOW INDEX FROM `ach_user_badges`
Function: DatabaseUpdater::dropIndex
```