### PR TITLE
SUS-3266: ListusersData::updateUserGroups - stop updating user_name column

### DIFF
--- a/extensions/wikia/Listusers/SpecialListusers_helper.php
+++ b/extensions/wikia/Listusers/SpecialListusers_helper.php
@@ -466,7 +466,6 @@ class ListusersData {
 				array(
 					"wiki_id"        => $this->mCityId,
 					"user_id"        => $user_id,
-					"user_name"  	 => '', # TODO: SUS-3204 - insert either user ID or user name
 					"edits"			 => $edits,
 					"editdate"		 => $editdate,
 					"last_revision"  => intval($lastrev),


### PR DESCRIPTION
```sql
REPLACE /* ListusersData::updateUserGroups */ INTO `events_local_users` (wiki_id,user_id,user_name,edits,editdate,last_revision,cnt_groups,single_group,all_groups) VALUES ('84587','26024564','','0','0000-00-00 00:00:00','0','1','sysop','sysop')

--

  `user_name` varchar(255) NOT NULL DEFAULT '',
```

We can safely remove this column from a `REPLACE` statement.

https://wikia-inc.atlassian.net/browse/SUS-3266