### PR TITLE
SUS-3263 | FavoriteWikisModel - use rollup_wiki_user_events instead of events_local_users

### DIFF
--- a/extensions/wikia/UserProfilePageV3/models/FavoriteWikisModel.class.php
+++ b/extensions/wikia/UserProfilePageV3/models/FavoriteWikisModel.class.php
@@ -50,7 +50,7 @@ class FavoriteWikisModel extends WikiaModel {
 
 		$dbr = wfGetDB(DB_SLAVE, [], $wgDWStatsDB );
 		$where = [
-			'period_id' => 2, // weekly roll-ups
+			'period_id' => DataMartService::PERIOD_ID_WEEKLY,
 			'time_id >= NOW() - INTERVAL 90 DAY', // process only recent 90 days
 			'user_id' => $this->user->getId(),
 		];

--- a/extensions/wikia/UserProfilePageV3/models/FavoriteWikisModel.class.php
+++ b/extensions/wikia/UserProfilePageV3/models/FavoriteWikisModel.class.php
@@ -238,13 +238,14 @@ class FavoriteWikisModel extends WikiaModel {
 		return $mastheadEditsWikis;
 	}
 
+	/**
+	 * @return array
+	 */
 	private function getEditsWikis() {
 		global $wgMemc;
 
 		$mastheadEditsWikis = $wgMemc->get( $this->getMemcMastheadEditsWikisKey() );
-		$mastheadEditsWikis = is_array( $mastheadEditsWikis ) ? $mastheadEditsWikis : [];
-
-		return $mastheadEditsWikis;
+		return is_array( $mastheadEditsWikis ) ? $mastheadEditsWikis : [];
 	}
 
 	/**

--- a/extensions/wikia/UserProfilePageV3/models/FavoriteWikisModel.class.php
+++ b/extensions/wikia/UserProfilePageV3/models/FavoriteWikisModel.class.php
@@ -69,7 +69,7 @@ class FavoriteWikisModel extends WikiaModel {
 			'rollup_wiki_user_events',
 			[
 				'wiki_id',
-				'SUM(created + edits) AS edits',
+				'SUM(creates + edits) AS edits',
 			],
 			$where,
 			__METHOD__,

--- a/extensions/wikia/UserProfilePageV3/models/FavoriteWikisModel.class.php
+++ b/extensions/wikia/UserProfilePageV3/models/FavoriteWikisModel.class.php
@@ -69,13 +69,14 @@ class FavoriteWikisModel extends WikiaModel {
 			'rollup_wiki_user_events',
 			[
 				'wiki_id',
-				'edits',
+				'SUM(created + edits) AS edits',
 			],
 			$where,
 			__METHOD__,
 			[
 				'LIMIT' => $limit,
-				'ORDER BY' => 'edits'
+				'ORDER BY' => 'edits DESC',
+				'GROUP BY' => 'wiki_id'
 			]
 		);
 
@@ -92,16 +93,20 @@ class FavoriteWikisModel extends WikiaModel {
 		return $wikis;
 	}
 
+	/**
+	 * @param object $row
+	 * @return array|false
+	 */
 	private function getTopWikiDataFromRow( $row ) {
-		$wikiId = $row->wiki_id;
+		$wikiId = (int) $row->wiki_id;
 		$wikiTitle = GlobalTitle::newFromText( $this->user->getName(), NS_USER_TALK, $wikiId );
+		$wikiName = WikiFactory::getVarValueByName( 'wgSitename', $wikiId );
 
-		if ( empty( $wikiTitle ) ) {
+		if ( empty( $wikiTitle ) || empty ($wikiName ) ) {
 			return false;
 		}
 
-		$editCount = $row->edits;
-		$wikiName = WikiFactory::getVarValueByName( 'wgSitename', $wikiId );
+		$editCount = (int) $row->edits;
 		$wikiUrl = $wikiTitle->getFullUrl();
 
 		return [

--- a/extensions/wikia/UserProfilePageV3/models/FavoriteWikisModel.class.php
+++ b/extensions/wikia/UserProfilePageV3/models/FavoriteWikisModel.class.php
@@ -291,7 +291,7 @@ class FavoriteWikisModel extends WikiaModel {
 	 *
 	 * @param Integer $wikiId
 	 *
-	 * @return array
+	 * @return bool
 	 */
 	public function hideWiki( $wikiId ) {
 		global $wgExternalSharedDB, $wgMemc;


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3263

Let's use `rollup_wiki_user_events` from Data Engineering instead of `events_local_users`. We want to get rid of all cross-wiki use cases of the latter table.

The functional difference will be that **only the activity from the recent 90 days will be taken into account (instead of since The Beginning Of The Known Universe).**

### New query

```sql
mysql@geo-db-dataware-slave.query.consul[statsdb]>select wiki_id, sum(edits + creates) as edits from rollup_wiki_user_events where period_id = 2 and user_id = 119245 and time_id >= NOW() - INTERVAL 90 DAY group by wiki_id order by edits desc;
+---------+-------+
| wiki_id | edits |
+---------+-------+
| 1474483 |    69 |
|    5915 |    54 |
|  203236 |     6 |
|     177 |     4 |
| 1618258 |     3 |
| 1031256 |     2 |
| 1558829 |     2 |
| 1652920 |     1 |
+---------+-------+
8 rows in set (0.00 sec)
```
![sus-3263](https://user-images.githubusercontent.com/1929317/33133907-88a0708c-cf9e-11e7-9ae6-6cfd892019f7.png)

```sql
mysql@geo-db-dataware-slave.query.consul[statsdb]>explain select wiki_id, sum(edits + creates) as edits from rollup_wiki_user_events where period_id = 2 and user_id = 119245 and time_id >= NOW() - INTERVAL 90 DAY group by wiki_id order by edits desc;
+----+-------------+-------------------------+-------+--------------------------+------------------+---------+------+------+----------------------------------------------+
| id | select_type | table                   | type  | possible_keys            | key              | key_len | ref  | rows | Extra                                        |
+----+-------------+-------------------------+-------+--------------------------+------------------+---------+------+------+----------------------------------------------+
|  1 | SIMPLE      | rollup_wiki_user_events | range | PRIMARY,period_user_time | period_user_time | 11      | NULL |   23 | Using where; Using temporary; Using filesort |
+----+-------------+-------------------------+-------+--------------------------+------------------+---------+------+------+----------------------------------------------+
1 row in set (0.00 sec)

-- temporary and filesort on 23 rows is not a big deal
```