### PR TITLE
SUS-3244 Use int instead of tinyint for abuse_filter_log.afl_namespace

### DIFF
--- a/extensions/AbuseFilter/AbuseFilter.hooks.php
+++ b/extensions/AbuseFilter/AbuseFilter.hooks.php
@@ -210,6 +210,7 @@ class AbuseFilterHooks {
 			$updater->addExtensionUpdate( array( 'addField', 'abuse_filter', 'af_global', "$dir/db_patches/patch-global_filters.sql", true ) );
 			if ( $updater->getDB()->getType() == 'mysql' ) {
 				$updater->addExtensionUpdate( array( 'addIndex', 'abuse_filter_log', 'filter_timestamp', "$dir/db_patches/patch-fix-indexes.sql", true ) );
+				$updater->addExtensionUpdate( array( 'modifyField', 'abuse_filter_log', 'afl_namespace', "$dir/db_patches/patch-afl-namespace_int.sql", true ) );
 			} else {
 				$updater->addExtensionUpdate( array( 'addIndex', 'abuse_filter_log', 'afl_filter_timestamp', "$dir/db_patches/patch-fix-indexes.sqlite.sql", true ) );
 			}

--- a/extensions/AbuseFilter/abusefilter.tables.pg.sql
+++ b/extensions/AbuseFilter/abusefilter.tables.pg.sql
@@ -46,7 +46,7 @@ CREATE TABLE abuse_filter_log (
     afl_actions    TEXT         NOT NULL,
     afl_var_dump   TEXT         NOT NULL,
     afl_timestamp  TIMESTAMPTZ  NOT NULL,
-    afl_namespace  SMALLINT     NOT NULL,
+    afl_namespace  INTEGER      NOT NULL,
     afl_title      TEXT         NOT NULL,
 	afl_wiki       TEXT             NULL,
 	afl_deleted    SMALLINT         NULL

--- a/extensions/AbuseFilter/abusefilter.tables.sql
+++ b/extensions/AbuseFilter/abusefilter.tables.sql
@@ -39,7 +39,7 @@ CREATE TABLE /*$wgDBprefix*/abuse_filter_log (
 	afl_actions varbinary(255) not null,
 	afl_var_dump BLOB NOT NULL,
 	afl_timestamp binary(14) NOT NULL,
-	afl_namespace tinyint NOT NULL,
+	afl_namespace int NOT NULL,
 	afl_title varchar(255) binary NOT NULL,
 	afl_wiki varchar(64) binary NULL,
 	afl_deleted tinyint(1) NOT NULL DEFAULT 0,

--- a/extensions/AbuseFilter/abusefilter.tables.sqlite.sql
+++ b/extensions/AbuseFilter/abusefilter.tables.sqlite.sql
@@ -37,7 +37,7 @@ CREATE TABLE /*$wgDBprefix*/abuse_filter_log (
 	afl_actions varbinary(255) not null,
 	afl_var_dump BLOB NOT NULL,
 	afl_timestamp binary(14) NOT NULL,
-	afl_namespace tinyint NOT NULL,
+	afl_namespace int NOT NULL,
 	afl_title varchar(255) binary NOT NULL,
 	afl_wiki varchar(64) binary NULL,
 	afl_deleted tinyint(1) NOT NULL DEFAULT 0,

--- a/extensions/AbuseFilter/db_patches/patch-afl-namespace_int.sql
+++ b/extensions/AbuseFilter/db_patches/patch-afl-namespace_int.sql
@@ -1,0 +1,1 @@
+ALTER TABLE /*_*/abuse_filter_log MODIFY afl_namespace INT NOT NULL;


### PR DESCRIPTION
Port of https://github.com/wikimedia/mediawiki-extensions-AbuseFilter/commit/03f18d2578667bd861962b92241f4841925dfdf7 to avoid truncation or DB error (in case of SQL strict mode operation, as is default on MySQL >= 5.7) when inserting large custom namespace values into `abuse_filter_log.afl_namespace`.

https://wikia-inc.atlassian.net/browse/SUS-3244