### PR TITLE
SUS-3222: Migration to drop logging.log_user_text field

### DIFF
--- a/includes/logging/LogEntry.php
+++ b/includes/logging/LogEntry.php
@@ -122,7 +122,7 @@ class DatabaseLogEntry extends LogEntryBase {
 		$tables = [ 'logging' ];
 		$fields = [
 			'log_id', 'log_type', 'log_action', 'log_timestamp',
-			'log_user', 'log_user_text',
+			'log_user',
 			'log_namespace', 'log_title', // unused log_page
 			'log_comment', 'log_params', 'log_deleted'
 		];
@@ -211,17 +211,8 @@ class DatabaseLogEntry extends LogEntryBase {
 	}
 
 	public function getPerformer() {
-		$userId = (int) $this->row->log_user;
-		if ( $userId !== 0 ) { // logged-in users
-			if ( isset( $this->row->user_name ) ) {
-				return User::newFromRow( $this->row );
-			} else {
-				return User::newFromId( $userId );
-			}
-		} else { // IP users
-			$userText = $this->row->log_user_text;
-			return User::newFromName( $userText, false );
-		}
+		// SUS-3222: All log entries are attributed to registered users
+		return User::newFromId( $this->row->log_user );
 	}
 
 	public function getTarget() {

--- a/maintenance/tables.sql
+++ b/maintenance/tables.sql
@@ -1148,9 +1148,6 @@ CREATE TABLE /*_*/logging (
   -- The user who performed this action; key to user_id
   log_user int unsigned NOT NULL default 0,
 
-  -- Name of the user who performed this action
-  log_user_text varchar(255) binary NOT NULL default '',
-
   -- Key to the page affected. Where a user is the target,
   -- this will point to the user page.
   log_namespace int NOT NULL default 0,

--- a/maintenance/wikia/removeRedundantUserNames.php
+++ b/maintenance/wikia/removeRedundantUserNames.php
@@ -33,7 +33,6 @@ class RemoveRedundantUserNames extends Maintenance {
 		[ 'table' => 'oldimage', 'userid_column' => 'oi_user', 'username_column' => 'oi_user_text' ],
 		[ 'table' => 'recentchanges', 'userid_column' => 'rc_user', 'username_column' => 'rc_user_text' ],
 		[ 'table' => 'revision', 'userid_column' => 'rev_user', 'username_column' => 'rev_user_text' ],
-		[ 'table' => 'logging', 'userid_column' => 'log_user', 'username_column' => 'log_user_text' ],
 	];
 
 	const UPDATE_BATCH = 500;


### PR DESCRIPTION
Remove final references to `logging.log_user_text` field and create migration to remove it for good

https://wikia-inc.atlassian.net/browse/SUS-3222