### PR TITLE
SUS-3083 | CheckUser::addLogEntry inserts user ID and user name pair into the database

### DIFF
--- a/extensions/CheckUser/CheckUser_body.php
+++ b/extensions/CheckUser/CheckUser_body.php
@@ -1335,7 +1335,7 @@ class CheckUser extends SpecialPage {
 				'cul_id' => $cul_id,
 				'cul_timestamp' => $dbw->timestamp(),
 				'cul_user' => $wgUser->getID(),
-				'cul_user_text' => $wgUser->getName(),
+				'cul_user_text' => $wgUser->isAnon() ? $wgUser->getName() : '', // SUS-3083
 				'cul_reason' => $reason,
 				'cul_type' => $logType,
 				'cul_target_id' => $targetID,
@@ -1347,4 +1347,3 @@ class CheckUser extends SpecialPage {
 		return true;
 	}
 }
-

--- a/extensions/CheckUser/cu_log_import.inc
+++ b/extensions/CheckUser/cu_log_import.inc
@@ -34,6 +34,10 @@ function import_cu_log_line( $line ) {
 	}
 }
 
+/**
+ * @param DatabaseBase $db
+ * @param $log
+ */
 function import_cu_log( $db, $log ) {
 	global $wgDBname;
 
@@ -71,7 +75,7 @@ function import_cu_log( $db, $log ) {
 					'cul_id' => $db->nextSequenceValue( 'cu_log_cul_id_seq' ),
 					'cul_timestamp' => $db->timestamp( $data['timestamp'] ),
 					'cul_user' => $user->getID(),
-					'cul_user_text' => $user->getName(),
+					'cul_user_text' => $user->isAnon() ? $user->getName() : '', // SUS-3083
 					'cul_reason' => $data['reason'],
 					'cul_type' => $data['type'],
 					'cul_target_id' => $targetID,

--- a/maintenance/wikia/removeRedundantUserNames.php
+++ b/maintenance/wikia/removeRedundantUserNames.php
@@ -26,6 +26,7 @@ class RemoveRedundantUserNames extends Maintenance {
 	// set username_column to "" in rows where userid_column value is non-zero
 	const TABLES = [
 		[ 'table' => 'archive', 'userid_column' => 'ar_user', 'username_column' => 'ar_user_text' ],
+		[ 'table' => 'cu_log', 'userid_column' => 'cul_user', 'username_column' => 'cul_user_text' ],
 		[ 'table' => 'filearchive', 'userid_column' => 'fa_user', 'username_column' => 'fa_user_text' ],
 		[ 'table' => 'image', 'userid_column' => 'img_user', 'username_column' => 'img_user_text' ],
 		[ 'table' => 'ipblocks', 'userid_column' => 'ipb_by', 'username_column' => 'ipb_by_text' ],


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3083

`cu_log` table has duplicated data - it keeps both user ID and user name as a text. Set `cul_user_text` column only for anons, i.e. keep their IP addresses there.

### Some stats

```sql
CheckUser::addLogEntry 0.60% [ap] db:local | INSERT INTO `cu_log` (cul_id,cul_timestamp,cul_user,cul_user_text,cul_reason,cul_type,cul_target_id,cul_target_text,cul_target_hex,cul_range_start,cul_range_end) VALUES (NULL,X,X,X,X,X,X,X,X,X,X)

-- SQL dump

  -- User who performed the action
  cul_user int unsigned not null,
  cul_user_text varchar(255) binary not null,

-- Muppet wiki stats / there are no entries for anons

mysql@geo-db-a-slave.query.consul[muppet]>select count(*) from cu_log where cul_user = 0;
+----------+
| count(*) |
+----------+
|        0 |
+----------+
1 row in set (0.00 sec)

mysql@geo-db-a-slave.query.consul[muppet]>select count(*) from cu_log where cul_user > 0;
+----------+
| count(*) |
+----------+
|     1830 |
+----------+
1 row in set (0.01 sec)
```

`removeRedundantUserNames.php` script has been updated as well.

```
macbre@dev-macbre:~/app/maintenance/wikia$ SERVER_DBNAME=muppet php removeRedundantUserNames.php --dry-run
Processing archive table ... 52906 rows updated
Processing cu_log table ... 1807 rows updated
Processing filearchive table ... 16452 rows updated
Processing image table ...^C
```