### PR TITLE
SUS-3263 | FavoriteWikisModel - use DataMartService::PERIOD_ID_MONTHLY rollups

### DIFF
--- a/extensions/wikia/UserProfilePageV3/models/FavoriteWikisModel.class.php
+++ b/extensions/wikia/UserProfilePageV3/models/FavoriteWikisModel.class.php
@@ -13,7 +13,7 @@ class FavoriteWikisModel extends WikiaModel {
 	 */
 	const MAX_FAV_WIKIS = 4;
 
-	const CACHE_VERSION = '2';
+	const CACHE_VERSION = '3';
 
 	// 3600 == 60 * 60 == 1 hr
 	const SAVED_WIKIS_TTL = 3600;
@@ -50,7 +50,7 @@ class FavoriteWikisModel extends WikiaModel {
 
 		$dbr = wfGetDB(DB_SLAVE, [], $wgDWStatsDB );
 		$where = [
-			'period_id' => DataMartService::PERIOD_ID_WEEKLY,
+			'period_id' => DataMartService::PERIOD_ID_MONTHLY,
 			'time_id >= NOW() - INTERVAL 90 DAY', // process only recent 90 days
 			'user_id' => $this->user->getId(),
 		];


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3263 / extends #14274

### Queries
```sql
mysql@geo-db-dataware-slave.query.consul[statsdb]>select wiki_id, sum(edits + creates) as edits from rollup_wiki_user_events where period_id = 2 and user_id = 119245 and time_id >= NOW() - INTERVAL 90 DAY group by wiki_id order by edits desc;
+---------+-------+
| wiki_id | edits |
+---------+-------+
| 1474483 |    65 |
|    5915 |    57 |
|     177 |     4 |
| 1618258 |     3 |
|  203236 |     2 |
| 1031256 |     2 |
| 1558829 |     2 |
| 1652920 |     1 |
+---------+-------+
8 rows in set (0.00 sec)

-- with monthly rollups

mysql@geo-db-dataware-slave.query.consul[statsdb]>select wiki_id, sum(edits + creates) as edits from rollup_wiki_user_events where period_id = 3 and user_id = 119245 and time_id >= NOW() - INTERVAL 90 DAY group by wiki_id order by edits desc;
+---------+-------+
| wiki_id | edits |
+---------+-------+
|    5915 |    29 |
| 1474483 |     6 |
|     177 |     4 |
| 1031256 |     2 |
| 1558829 |     2 |
| 1652920 |     1 |
+---------+-------+
6 rows in set (0.00 sec)
```