### PR TITLE
Enable local RL links everywhere

### DIFF
--- a/includes/DefaultSettings.php
+++ b/includes/DefaultSettings.php
@@ -5516,7 +5516,7 @@ $wgDBtestpassword = '';
 /**
  * When enabled, RL will output links without the server part.
  */
-$wgEnableLocalResourceLoaderLinks = false;
+$wgEnableLocalResourceLoaderLinks = true;
 
 /**
  * For really cool vim folding this needs to be at the end:


### PR DESCRIPTION
It has beed enabled for some time on preview/verify and selected production wikis and didn't cause any issues