### PR TITLE
SUS-3388 | introduce ext/wikia/PhalanxII/maintenance/cleanupPhalanxStats.php

### DIFF
--- a/extensions/wikia/PhalanxII/maintenance/cleanupPhalanxStats.php
+++ b/extensions/wikia/PhalanxII/maintenance/cleanupPhalanxStats.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Script that removes specials.phalanx_stats entries that are older than 365 days
+ *
+ * @see SUS-3388
+ * @author macbre
+ * @file
+ * @ingroup Maintenance
+ */
+
+require_once( __DIR__ . '/../../../../maintenance/commandLine.inc' );
+
+$db = wfGetDB( DB_MASTER, [], $wgSpecialsDB );
+$rows = 0;
+
+do {
+
+	// delete entries older than 365 days in small batches
+	// ps_timestamp has MediaWiki-formatted timestamps, e.g. 20170101000000
+	$db->query( 'DELETE FROM phalanx_stats WHERE ps_timestamp < NOW() - INTERVAL 365 DAY LIMIT 5000', __FILE__ );
+	$affectedRows = $db->affectedRows();
+
+	$rows +=  $affectedRows;
+
+	wfWaitForSlaves( $db->getDBname() );
+
+	echo '.';
+
+} while ( $affectedRows > 0 );
+
+echo sprintf( "\n%s: dropped %d rows from phalanx_stats\n", date( 'r' ), $rows );


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3388

Script that removes `specials.phalanx_stats` entries that are older than 365 days

Currently out of 100+ mm rows in this table, **97 mm are older than a year**.

Chef pull request to follow.


### Queries

The oldest entry seems to be from [A.D. 512](https://en.wikipedia.org/wiki/512) :smile: 

```sql
mysql@geo-db-specials-master.query.consul[specials]>SELECT ps_timestamp FROM phalanx_stats LIMIT 2;
+----------------+
| ps_timestamp   |
+----------------+
| 05121945072460 |
| 20140709200538 |
+----------------+
2 rows in set (0.00 sec)
```

```sql
mysql@geo-db-specials-slave.query.consul[specials]>SELECT COUNT(*) FROM phalanx_stats WHERE ps_timestamp < NOW() - INTERVAL 365 DAY;
+----------+
| COUNT(*) |
+----------+
| 97577143 |
+----------+
1 row in set, 1 warning (33.11 sec)

--

mysql@geo-db-specials-master.query.consul[specials]>select count(*) from phalanx_stats ;
+-----------+
| count(*)  |
+-----------+
| 106264492 |
+-----------+
1 row in set (14.36 sec)
```

`DELETE`s will take place in batches of 5000 rows followed by `wfWaitForSlaves` call.

```sql
mysql@geo-db-specials-master.query.consul[specials]>DELETE FROM phalanx_stats WHERE ps_timestamp < NOW() - INTERVAL 365 DAY LIMIT 5000;
Query OK, 5000 rows affected (0.05 sec)
```