### PR TITLE
SUS-3440 Rollback - query rev_user_text only for anons

### DIFF
--- a/includes/WikiPage.php
+++ b/includes/WikiPage.php
@@ -2373,10 +2373,9 @@ class WikiPage extends Page implements IDBAccessObject {
 		$s = $dbw->selectRow( 'revision',
 			array( 'rev_id', 'rev_timestamp', 'rev_deleted' ),
 			array( 'rev_page' => $current->getPage(),
-				"rev_user != {$user} OR rev_user_text != {$user_text}"
+				"rev_user != {$user} OR (rev_user = 0 AND rev_user_text != {$user_text})"
 			), __METHOD__,
-			array( 'USE INDEX' => 'page_timestamp',
-				'ORDER BY' => 'rev_timestamp DESC' )
+			array( 'ORDER BY' => 'rev_timestamp DESC' )
 			);
 		if ( $s === false ) {
 			# No one else ever edited this page


### PR DESCRIPTION
As `rev_user_text` field is empty for registered users, we should only query it for anons, otherwise it will falsely match latest revision.

https://wikia-inc.atlassian.net/browse/SUS-3440