### PR TITLE
SUS-3443 | PhalanxStatsPager - resolve user name using user ID

### DIFF
--- a/extensions/wikia/PhalanxII/classes/PhalanxStatsPager.class.php
+++ b/extensions/wikia/PhalanxII/classes/PhalanxStatsPager.class.php
@@ -9,7 +9,7 @@ class PhalanxStatsPager extends PhalanxPager {
 	public function __construct( int $id ) {
 		parent::__construct();
 
-		$this->id = (int) $id;
+		$this->id = $id;
 		$this->mDb = $this->getDatabase( DB_SLAVE );
 
 		if ( !empty( $this->pInx ) ) {

--- a/extensions/wikia/PhalanxII/classes/PhalanxStatsPager.class.php
+++ b/extensions/wikia/PhalanxII/classes/PhalanxStatsPager.class.php
@@ -3,7 +3,10 @@ class PhalanxStatsPager extends PhalanxPager {
 	public $qCond = 'ps_blocker_id';
 	public $pInx = 'blockId';
 
-	public function __construct( $id ) {
+	protected $id;
+	public $mDb;
+
+	public function __construct( int $id ) {
 		parent::__construct();
 
 		$this->id = (int) $id;
@@ -47,8 +50,10 @@ class PhalanxStatsPager extends PhalanxPager {
 	function formatRow( $row ) {
 		$blocker = $row->ps_blocker_hit ?: $row->ps_blocker_type;
 		$type = implode( ', ', Phalanx::getTypeNames( $blocker ) );
-		$username = $row->ps_blocked_user;
 		$timestamp = $this->getLanguage()->timeanddate( $row->ps_timestamp );
+
+		// SUS-3443: we either store (user ID, "") or (0, IP address) pair
+		$username = User::getUsername( (int) $row->ps_blocked_user_id, $row->ps_blocked_user );
 
 		$url = $row->ps_referrer ?: '';
 		if ( empty( $url ) ) {


### PR DESCRIPTION
`ps_blocked_user` will store IP addresses for anons.

https://wikia-inc.atlassian.net/browse/SUS-3443

This change can go live before the data migration, as the code will fallback to a full user name kept in `ps_blocked_user` when `ps_blocked_user_id` is zero (or `NULL` as we cast the data to `int` before passing it to `User::getUsername`).