### PR TITLE
SUS-3459 | Revision - rev_user_text can now be an empty string

### DIFF
--- a/includes/Revision.php
+++ b/includes/Revision.php
@@ -664,7 +664,7 @@ class Revision implements IDBAccessObject {
 	 * @return String
 	 */
 	public function getRawUserText() {
-		if ( $this->mUserText === null ) {
+		if ( $this->mUserText === null || $this->mUserText === '' /* SUS-3459 */ ) {
 			$this->mUserText = User::whoIs( $this->mUser ); // load on demand
 			if ( $this->mUserText === false ) {
 				# This shouldn't happen, but it can if the wiki was recovered


### PR DESCRIPTION
That means that we should use `user_id` from `rev_user` column to properly resolve a user name.

https://wikia-inc.atlassian.net/browse/SUS-3459

This method is used by `Linker::revUserTools` that is used on Special:NewPages to render contributor link.