### PR TITLE
SUS-3368 | Refactor WikiService::getTopEditors to use datamart roll-ups instead of events_local_users

### DIFF
--- a/extensions/wikia/DataProvider/DataProvider.php
+++ b/extensions/wikia/DataProvider/DataProvider.php
@@ -396,7 +396,7 @@ class DataProvider {
 			global $wgCityId;
 
 			// SUS-3248 | use WikiService::getTopEditors
-			$usersAndEdits = (new WikiService)->getTopEditors( $wgCityId, self::TOP_USERS_MAX_LIMIT, true );
+			$usersAndEdits = (new WikiService)->getTopEditors( $wgCityId, self::TOP_USERS_MAX_LIMIT );
 
 			$results = [];
 			foreach ( $usersAndEdits as $userId => $editsCount ) {

--- a/includes/User.php
+++ b/includes/User.php
@@ -4528,6 +4528,16 @@ class User implements JsonSerializable {
 	}
 
 	/**
+	 * Whether this user is a bot (either globally or on this wiki) or not
+	 * @return bool
+	 */
+	public function isBot() {
+		return self::permissionsService()->isInGroup( $this, 'bot' )
+			||
+			self::permissionsService()->isInGroup( $this, 'bot-global' );
+	}
+
+	/**
 	 * Get the localized descriptive name for a group, if it exists
 	 *
 	 * @param $group String Internal group name

--- a/includes/wikia/api/WikisApiController.class.php
+++ b/includes/wikia/api/WikisApiController.class.php
@@ -237,7 +237,7 @@ class WikisApiController extends WikiaApiController {
 				//get data providers
 				$wikiObj = WikiFactory::getWikiByID( $wikiId );
 				$wikiStats = $service->getSiteStats( $wikiId );
-				$topUsers = $service->getTopEditors( $wikiId, static::DEFAULT_TOP_EDITORS_NUMBER, true );
+				$topUsers = $service->getTopEditors( $wikiId, static::DEFAULT_TOP_EDITORS_NUMBER );
 
 				$wikiInfo = array(
 					'id' => (int) $wikiId,

--- a/includes/wikia/services/WikiDetailsService.class.php
+++ b/includes/wikia/services/WikiDetailsService.class.php
@@ -177,7 +177,7 @@ class WikiDetailsService extends WikiService {
 	 */
 	protected function getFromService( $id ) {
 		$wikiStats = $this->getSiteStats( $id );
-		$topUsers = $this->getTopEditors( $id, static::DEFAULT_TOP_EDITORS_NUMBER, true );
+		$topUsers = $this->getTopEditors( $id, static::DEFAULT_TOP_EDITORS_NUMBER );
 		$modelData = $this->getDetails( [ $id ] );
 
 		//filter out flags

--- a/includes/wikia/services/WikiService.class.php
+++ b/includes/wikia/services/WikiService.class.php
@@ -15,7 +15,7 @@ class WikiService extends WikiaModel {
 	const WAM_DEFAULT_ITEM_LIMIT_PER_PAGE = 20;
 	const IMAGE_HEIGHT_KEEP_ASPECT_RATIO = -1;
 	const TOPUSER_CACHE_VALID = 10800;
-	const TOPUSER_LIMIT = 150;
+	const TOPUSER_LIMIT = 10;
 
 	const CACHE_VERSION = '5';
 	const MAX_WIKI_RESULTS = 300;

--- a/includes/wikia/services/WikiService.class.php
+++ b/includes/wikia/services/WikiService.class.php
@@ -300,7 +300,7 @@ class WikiService extends WikiaModel {
 					)
 				);
 
-				foreach($result as $row) {
+				foreach( $result as $row ) {
 					if ( User::newFromId( $row->user_id )->isBot() === false ) {
 						$topEditors[$row->user_id] = intval( $row->edits );
 					}

--- a/includes/wikia/services/WikiService.class.php
+++ b/includes/wikia/services/WikiService.class.php
@@ -269,10 +269,9 @@ class WikiService extends WikiaModel {
 	 *
 	 * @return array topEditors [ array( user_id => edits ) ]
 	 */
-	public function getTopEditors( $wikiId = 0, $limit = 30 ) {
+	public function getTopEditors( int $wikiId , int $limit ) {
 		wfProfileIn( __METHOD__ );
 
-		$wikiId = ( empty($wikiId) ) ? $this->wg->CityId : $wikiId ;
 		$fname = __METHOD__;
 
 		$topEditors = WikiaDataAccess::cache(

--- a/includes/wikia/services/WikiService.class.php
+++ b/includes/wikia/services/WikiService.class.php
@@ -275,7 +275,7 @@ class WikiService extends WikiaModel {
 		$fname = __METHOD__;
 
 		$topEditors = WikiaDataAccess::cache(
-			wfSharedMemcKey( 'wiki_top_editors:v2', $wikiId ),
+			wfSharedMemcKey( 'wiki_top_editors:v1', $wikiId ),
 			static::TOPUSER_CACHE_VALID,
 			function() use ( $wikiId, $fname ) {
 				global $wgDWStatsDB;
@@ -295,6 +295,7 @@ class WikiService extends WikiaModel {
 					$fname,
 					array(
 						'ORDER BY' => 'edits DESC',
+						'GROUP BY' => 'user_id',
 						'LIMIT' => static::TOPUSER_LIMIT,
 					)
 				);

--- a/includes/wikia/services/WikiService.class.php
+++ b/includes/wikia/services/WikiService.class.php
@@ -262,43 +262,46 @@ class WikiService extends WikiaModel {
 	}
 
 	/**
-	 * get list of top editors
+	 * get list of top editors (bots excluded)
 	 *
 	 * @param integer $wikiId
 	 * @param integer $limit
-	 * @param bool    $excludeBots
 	 *
 	 * @return array topEditors [ array( user_id => edits ) ]
 	 */
-	public function getTopEditors( $wikiId = 0, $limit = 30, $excludeBots = false ) {
+	public function getTopEditors( $wikiId = 0, $limit = 30 ) {
 		wfProfileIn( __METHOD__ );
 
 		$wikiId = ( empty($wikiId) ) ? $this->wg->CityId : $wikiId ;
 		$fname = __METHOD__;
 
 		$topEditors = WikiaDataAccess::cache(
-			wfSharedMemcKey( 'wiki_top_editors', $wikiId, $excludeBots ),
+			wfSharedMemcKey( 'wiki_top_editors:v2', $wikiId ),
 			static::TOPUSER_CACHE_VALID,
-			function() use ( $wikiId, $excludeBots, $fname ) {
-				global $wgSpecialsDB;
+			function() use ( $wikiId, $fname ) {
+				global $wgDWStatsDB;
 				$topEditors = array();
 
-				$db = wfGetDB( DB_SLAVE, array(), $wgSpecialsDB );
+				$db = wfGetDB( DB_SLAVE, array(), $wgDWStatsDB );
 
 				$result = $db->select(
-					array( 'events_local_users' ),
-					array( 'user_id', 'edits', 'all_groups' ),
-					array( 'wiki_id' => $wikiId, 'edits != 0' ),
+					array( 'rollup_wiki_user_events' ),
+					array( 'user_id', 'SUM(edits + creates) as edits' ),
+					array(
+						'period_id' => DataMartService::PERIOD_ID_WEEKLY,
+						'wiki_id' => $wikiId,
+						'time_id >= NOW() - INTERVAL 365 DAY', # SUS-3368 | use last year data only
+						'user_id > 0', # skip anons
+					),
 					$fname,
 					array(
-						'ORDER BY' => 'edits desc',
+						'ORDER BY' => 'edits DESC',
 						'LIMIT' => static::TOPUSER_LIMIT,
-						'USE INDEX' => 'PRIMARY', # mysql in Reston wants to use a different key (PLATFORM-1648)
 					)
 				);
 
-				while( $row = $db->fetchObject($result) ) {
-					if (!($excludeBots && $this->isBotGroup($row->all_groups))) {
+				foreach($result as $row) {
+					if ( User::newFromId( $row->user_id )->isBot() === false ) {
 						$topEditors[$row->user_id] = intval( $row->edits );
 					}
 				}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3368

Instead of using `events_local_users` get the top wiki contributors since its first edit, let's rely on `rollup_wiki_user_events` data and use only the last year.

### Queries

```sql
SELECT /* WikiService::getTopEditors CommandLineInc - fcaf6bb3-85dc-4798-bb63-a39ac6d0a91a */  user_id,SUM(edits + creates) as edits  FROM `rollup_wiki_user_events`  WHERE period_id = '2' AND wiki_id = '5915' AND (time_id >= NOW() - INTERVAL 365 DAY) AND (user_id > 0)  GROUP BY user_id ORDER BY edits DESC LIMIT 10

--

mysql@geo-db-dataware-slave.query.consul[statsdb]>explain SELECT /* WikiService::getTopEditors CommandLineInc - fcaf6bb3-85dc-4798-bb63-a39ac6d0a91a */  user_id,SUM(edits + creates) as edits  FROM `rollup_wiki_user_events`  WHERE period_id = '2' AND wiki_id = '5915' AND (time_id >= NOW() - INTERVAL 365 DAY) AND (user_id > 0)  GROUP BY user_id ORDER BY edits DESC LIMIT 10;
+----+-------------+-------------------------+-------+-------------------------------------------+------------------+---------+------+------+----------------------------------------------+
| id | select_type | table                   | type  | possible_keys                             | key              | key_len | ref  | rows | Extra                                        |
+----+-------------+-------------------------+-------+-------------------------------------------+------------------+---------+------+------+----------------------------------------------+
|  1 | SIMPLE      | rollup_wiki_user_events | range | PRIMARY,period_user_time,period_wiki_time | period_wiki_time | 11      | NULL |  127 | Using where; Using temporary; Using filesort |
+----+-------------+-------------------------+-------+-------------------------------------------+------------------+---------+------+------+----------------------------------------------+
1 row in set (0.00 sec)
```