### PR TITLE
(PLATFORM-3294) Make SERVER magic word protocol-relative

### DIFF
--- a/includes/parser/Parser.php
+++ b/includes/parser/Parser.php
@@ -3146,10 +3146,10 @@ class Parser {
 			case 'sitename':
 				return $wgSitename;
 			case 'server':
-				return $wgServer;
+				return wfProtocolUrlToRelative( $wgServer );
 			case 'servername':
 				$serverParts = wfParseUrl( $wgServer );
-				return $serverParts && isset( $serverParts['host'] ) ? $serverParts['host'] : $wgServer;
+				return $serverParts && isset( $serverParts['host'] ) ? $serverParts['host'] : wfProtocolUrlToRelative( $wgServer );
 			case 'scriptpath':
 				return $wgScriptPath;
 			case 'stylepath':


### PR DESCRIPTION
Make SERVER magic word protocol-relative so that it is not cached with
the wrong protocol if the page is parsed over HTTP or HTTPS and then viewed
over the other.