### PR TITLE
SUS-3466: Truncate revision summaries on insert

### DIFF
--- a/includes/Revision.php
+++ b/includes/Revision.php
@@ -21,6 +21,11 @@ class Revision implements IDBAccessObject {
 	protected $mTitle;
 	protected $mCurrent;
 
+	/**
+	 * SUS-3466: Maximum possible length of revision summary in bytes.
+	 */
+	const REVISION_SUMMARY_MAX_LENGTH = 255;
+
 	// Revision deletion constants
 	const DELETED_TEXT = 1;
 	const DELETED_COMMENT = 2;
@@ -1006,7 +1011,8 @@ class Revision implements IDBAccessObject {
 			$this->mTextId = $dbw->insertId();
 		}
 
-		if ( $this->mComment === null ) $this->mComment = "";
+		// SUS-3466: Truncate edit summaries before insert to prevent database error
+		$this->mComment = substr( $this->mComment ?? '', 0, static::REVISION_SUMMARY_MAX_LENGTH );
 
 		# Record the edit in revisions
 		$rev_id = isset( $this->mId )


### PR DESCRIPTION
Avoid SQL strict mode error: `1406: Data too long for column 'rev_comment' at row 1` by truncating input to the maximum allowable length before save.

https://wikia-inc.atlassian.net/browse/SUS-3466