### PR TITLE
(PLATFORM-3294) Make Lua variable mw.site.server protocol-relative

### DIFF
--- a/extensions/Scribunto/engines/LuaCommon/SiteLibrary.php
+++ b/extensions/Scribunto/engines/LuaCommon/SiteLibrary.php
@@ -17,7 +17,7 @@ class Scribunto_LuaSiteLibrary extends Scribunto_LuaLibraryBase {
 		);
 		$info = array(
 			'siteName' => $GLOBALS['wgSitename'],
-			'server' => $GLOBALS['wgServer'],
+			'server' => wfProtocolUrlToRelative( $GLOBALS['wgServer'] ),
 			'scriptPath' => $GLOBALS['wgScriptPath'],
 			'stylePath' => $GLOBALS['wgStylePath'],
 			'currentVersion' => SpecialVersion::getVersion(),


### PR DESCRIPTION
Make Lua variable mw.site.server protocol-relative so that it is not cached
with the wrong protocol if the page is parsed over HTTP or HTTPS and then
viewed over the other.