### PR TITLE
ListusersAjax: improve DB queries profiling in getWikiUsers method

### DIFF
--- a/extensions/wikia/Listusers/SpecialListusers_ajax.php
+++ b/extensions/wikia/Listusers/SpecialListusers_ajax.php
@@ -115,10 +115,12 @@ class ListusersAjax {
 	 * @see SUS-3207
 	 */
 	private static function getWikiUsers( int $cityId ) {
+		$fname = __METHOD__;
+
 		return WikiaDataAccess::cache(
 			wfSharedMemcKey(__METHOD__, $cityId),
 			WikiaResponse::CACHE_VERY_SHORT,
-			function() use ($cityId) {
+			function() use ($cityId, $fname) {
 				global $wgSpecialsDB;
 
 				$dbr = wfGetDB( DB_SLAVE, [], $wgSpecialsDB );
@@ -128,7 +130,7 @@ class ListusersAjax {
 					[
 						'wiki_id' => $cityId,
 					],
-					__METHOD__
+					$fname
 				);
 			}
 		);


### PR DESCRIPTION
Avoid reporting `{closure}` as a caller.