### PR TITLE
SUS-3475 Use background task to update city_list table

### DIFF
--- a/extensions/wikia/CityList/CityList.setup.php
+++ b/extensions/wikia/CityList/CityList.setup.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Handle updating shared city_list table
+ */
+
+$GLOBALS['wgAutoloadClasses']['UpdateCityListTask'] = __DIR__ . '/UpdateCityListTask.php';
+
+function wfScheduleCityListUpdateTask() {
+	global $wgCityId;
+
+	$user = RequestContext::getMain()->getUser();
+	$timestamp = wfTimestampNow();
+
+	$task = ( new UpdateCityListTask() )->wikiId( $wgCityId );
+
+	$task->call( 'updateLastTimestamp', $timestamp );
+	$task->call( 'checkIfWikiIsStillAdoptable', $user->getId() );
+
+	$task->queue();
+}
+
+$GLOBALS['wgHooks']['ArticleSaveComplete'][] = 'wfScheduleCityListUpdateTask';
+$GLOBALS['wgHooks']['ArticleDeleteComplete'][] = 'wfScheduleCityListUpdateTask';
+$GLOBALS['wgHooks']['ArticleUndelete'][] = 'wfScheduleCityListUpdateTask';
+$GLOBALS['wgHooks']['TitleMoveComplete'][] = 'wfScheduleCityListUpdateTask';

--- a/extensions/wikia/CityList/UpdateCityListTask.php
+++ b/extensions/wikia/CityList/UpdateCityListTask.php
@@ -34,7 +34,7 @@ class UpdateCityListTask extends BaseTask {
 
 		$user = User::newFromId( $userId );
 
-		if ( in_array( 'sysop', $user->getGroups() ) || $this->getTotalEditsOnWiki() >= 1000 ) {
+		if ( in_array( 'sysop', $user->getGroups() ) || SiteStats::edits() >= 1000 ) {
 			$dbw = $this->getSharedDatabaseMaster();
 			$flags = $wiki->city_flags &~ WikiFactory::FLAG_ADOPTABLE;
 
@@ -45,12 +45,6 @@ class UpdateCityListTask extends BaseTask {
 				__METHOD__
 			);
 		}
-	}
-
-	private function getTotalEditsOnWiki() {
-		$dbr = wfGetDB( DB_SLAVE );
-
-		return $dbr->selectField( 'site_stats', 'ss_total_edits', [], __METHOD__ );
 	}
 
 	private function getSharedDatabaseMaster() {

--- a/extensions/wikia/CityList/UpdateCityListTask.php
+++ b/extensions/wikia/CityList/UpdateCityListTask.php
@@ -1,0 +1,64 @@
+<?php
+
+use Wikia\Tasks\Tasks\BaseTask;
+
+class UpdateCityListTask extends BaseTask {
+	private $sharedDatabaseMaster;
+
+	/**
+	 * @param string $timestamp MW timestamp of current time
+	 */
+	public function updateLastTimestamp( string $timestamp ) {
+		$dbw = $this->getSharedDatabaseMaster();
+
+		$dbw->update(
+			'city_list',
+			[ 'city_last_timestamp' => $timestamp ],
+			[ 'city_id' => $this->getWikiId() ],
+			__METHOD__
+		);
+	}
+
+	/**
+	 * Mark the wiki unavailable for adoption if it was up for adoption,
+	 * and the user who made an action was an admin or there were more than 1,000 edits made on wiki.
+	 * @param int $userId
+	 */
+	public function checkIfWikiIsStillAdoptable( int $userId ) {
+		$cityId = $this->getWikiId();
+		$wiki = WikiFactory::getWikiByID( $cityId );
+
+		if ( !$wiki || !( $wiki->city_flags & WikiFactory::FLAG_ADOPTABLE ) ) {
+			return;
+		}
+
+		$user = User::newFromId( $userId );
+
+		if ( in_array( 'sysop', $user->getGroups() ) || $this->getTotalEditsOnWiki() >= 1000 ) {
+			$dbw = $this->getSharedDatabaseMaster();
+			$flags = $wiki->city_flags &~ WikiFactory::FLAG_ADOPTABLE;
+
+			$dbw->update(
+				'city_list',
+				[ 'city_flags' => $flags ],
+				[ 'city_id' => $cityId ],
+				__METHOD__
+			);
+		}
+	}
+
+	private function getTotalEditsOnWiki() {
+		$dbr = wfGetDB( DB_SLAVE );
+
+		return $dbr->selectField( 'site_stats', 'ss_total_edits', [], __METHOD__ );
+	}
+
+	private function getSharedDatabaseMaster() {
+		if ( !$this->sharedDatabaseMaster ) {
+			global $wgExternalSharedDB;
+			$this->sharedDatabaseMaster = wfGetDB( DB_MASTER, [], $wgExternalSharedDB );
+		}
+
+		return $this->sharedDatabaseMaster;
+	}
+}

--- a/extensions/wikia/CityList/tests/UpdateCityListTaskIntegrationTest.php
+++ b/extensions/wikia/CityList/tests/UpdateCityListTaskIntegrationTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * @group Integration
+ */
+class UpdateCityListTaskIntegrationTest extends WikiaDatabaseTest {
+	const ADOPTABLE_WIKI_ID = 1;
+	const NON_ADOPTABLE_WIKI_ID = 2;
+
+	const ADMIN_USER_ID = 1;
+	const NOT_ADMIN_USER_ID = 2;
+
+	/** @var UpdateCityListTask $updateCityListTask */
+	private $updateCityListTask;
+
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		require_once __DIR__ . '/../CityList.setup.php';
+
+		static::loadSchemaFile( __DIR__ . '/fixtures/city-list.sql' );
+	}
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->updateCityListTask = new UpdateCityListTask();
+	}
+
+	public function testTimestampIsUpdated() {
+		$this->updateCityListTask->wikiId( static::ADOPTABLE_WIKI_ID )
+			->updateLastTimestamp( '20171201000000' );
+
+		$queryTable = $this->getConnection()->createQueryTable(
+			'city_list', 'SELECT city_id, city_last_timestamp FROM city_list'
+		);
+
+		$expectedTable = $this->createYamlDataSet( __DIR__ . '/fixtures/state_updated_timestamp.yaml' )
+			->getTable( 'city_list' );
+
+		$this->assertTablesEqual( $expectedTable, $queryTable );
+	}
+
+	/**
+	 * @dataProvider provideUserIds
+	 * @param int $userId
+	 */
+	public function testWikiIsNotAdoptableWhenItHasOverThousandEdits( int $userId ) {
+		$this->updateCityListTask->wikiId( static::ADOPTABLE_WIKI_ID )
+			->checkIfWikiIsStillAdoptable( $userId );
+
+		$queryTable = $this->getConnection()->createQueryTable(
+			'city_list', 'SELECT city_id, city_flags FROM city_list'
+		);
+
+		$expectedTable = $this->createYamlDataSet( __DIR__ . '/fixtures/state_no_wiki_is_adoptable.yaml' )
+			->getTable( 'city_list' );
+
+		$this->assertTablesEqual( $expectedTable, $queryTable );
+	}
+
+	public function provideUserIds(): Generator {
+		yield [ static::ADMIN_USER_ID ];
+		yield [ static::NOT_ADMIN_USER_ID ];
+		yield [ 0 ];
+	}
+
+	protected function getDataSet() {
+		return $this->createYamlDataSet( __DIR__ . '/fixtures/state_initial.yaml' );
+	}
+}

--- a/extensions/wikia/CityList/tests/fixtures/city-list.sql
+++ b/extensions/wikia/CityList/tests/fixtures/city-list.sql
@@ -1,0 +1,42 @@
+DROP TABLE IF EXISTS `city_list`;
+CREATE TABLE `city_list` (
+  `city_id` int NOT NULL PRIMARY KEY AUTOINCREMENT,
+  `city_path` varchar(255) NOT NULL DEFAULT '/home/wikicities/cities/notreal',
+  `city_dbname` varchar(64) NOT NULL DEFAULT 'notreal',
+  `city_sitename` varchar(255) NOT NULL DEFAULT 'wikicities',
+  `city_url` varchar(255) NOT NULL DEFAULT 'http://notreal.wikicities.com/',
+  `city_created` datetime DEFAULT NULL,
+  `city_founding_user` int(5) DEFAULT NULL,
+  `city_adult` tinyint(1) DEFAULT '0',
+  `city_public` int(1) NOT NULL DEFAULT '1',
+  `city_additional` text,
+  `city_description` text,
+  `city_title` varchar(255) DEFAULT NULL,
+  `city_founding_email` varchar(255) DEFAULT NULL,
+  `city_lang` varchar(8) NOT NULL DEFAULT 'en',
+  `city_special_config` text,
+  `city_umbrella` varchar(255) DEFAULT NULL,
+  `city_ip` varchar(256) NOT NULL DEFAULT '/usr/wikia/source/wiki',
+  `city_google_analytics` varchar(100) DEFAULT '',
+  `city_google_search` varchar(100) DEFAULT '',
+  `city_google_maps` varchar(100) DEFAULT '',
+  `city_indexed_rev` int unsigned NOT NULL DEFAULT '1',
+  `city_lastdump_timestamp` varchar(14) DEFAULT '19700101000000',
+  `city_factory_timestamp` varchar(14) DEFAULT '19700101000000',
+  `city_useshared` tinyint(1) DEFAULT '1',
+  `ad_cat` char(4) NOT NULL DEFAULT '',
+  `city_flags` int unsigned NOT NULL DEFAULT '0',
+  `city_cluster` varchar(255) DEFAULT NULL,
+  `city_last_timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `city_vertical` int(11) NOT NULL DEFAULT '0',
+  `city_founding_ip_bin` varbinary(16) DEFAULT NULL
+);
+
+CREATE UNIQUE INDEX `urlidx` ON `city_list` (`city_url`);
+CREATE UNIQUE INDEX `city_dbname_idx` ON `city_list` (`city_dbname`);
+CREATE INDEX `titleidx` ON `city_list` (`city_title`);
+CREATE INDEX `city_flags` ON `city_list` (`city_flags`);
+CREATE INDEX `city_created` ON `city_list` (`city_created`,`city_lang`);
+CREATE INDEX `city_founding_user_inx` ON `city_list` (`city_founding_user`);
+CREATE INDEX `city_cluster` ON `city_list`(`city_cluster`);
+CREATE INDEX `city_founding_ip_bin` ON `city_list` (`city_founding_ip_bin`);

--- a/extensions/wikia/CityList/tests/fixtures/state_initial.yaml
+++ b/extensions/wikia/CityList/tests/fixtures/state_initial.yaml
@@ -1,0 +1,48 @@
+city_list:
+  -
+    city_id: 1
+    city_dbname: test1
+    city_url: http://test1.wikicities.com/
+    city_flags: 64
+    city_last_timestamp: 20110101000000
+  -
+    city_id: 2
+    city_dbname: test2
+    city_url: http://test2.wikicities.com/
+    city_flags: 0
+    city_last_timestamp: 20110101000000
+user:
+  -
+    user_id: 1
+    user_name: 'AdminUser'
+    user_real_name: ''
+    user_email: 'kossuth.lajos@lajoskossuth.hu'
+    user_touched: '20110101000000'
+    user_token: 'loremipsum'
+    user_email_authenticated: '20101102000000'
+    user_email_token: 'dolorsitamet'
+    user_email_token_expires: '20120301120000'
+    user_registration: '20090604060000'
+    user_editcount: 2500
+    user_birthdate:
+  -
+    user_id: 2
+    user_name: 'NotAdminUser'
+    user_real_name: ''
+    user_email: 'ferenc.jozsef@kuk.hu'
+    user_touched: '20110101000000'
+    user_token: 'loremipsum'
+    user_email_authenticated: '20101102000000'
+    user_email_token: 'dolorsitamet'
+    user_email_token_expires: '20120301120000'
+    user_registration: '20090604060000'
+    user_editcount: 1000
+    user_birthdate:
+user_groups:
+  -
+    ug_user: 1
+    ug_group: sysop
+site_stats:
+  -
+    ss_row_id: 1
+    ss_total_edits: 2000

--- a/extensions/wikia/CityList/tests/fixtures/state_no_wiki_is_adoptable.yaml
+++ b/extensions/wikia/CityList/tests/fixtures/state_no_wiki_is_adoptable.yaml
@@ -1,0 +1,7 @@
+city_list:
+  -
+    city_id: 1
+    city_flags: 0
+  -
+    city_id: 2
+    city_flags: 0

--- a/extensions/wikia/CityList/tests/fixtures/state_updated_timestamp.yaml
+++ b/extensions/wikia/CityList/tests/fixtures/state_updated_timestamp.yaml
@@ -1,0 +1,7 @@
+city_list:
+  -
+    city_id: 1
+    city_last_timestamp: 20171201000000
+  -
+    city_id: 2
+    city_last_timestamp: 20110101000000

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1899,3 +1899,6 @@ require_once "$IP/extensions/wikia/FacebookTags/FacebookTags.setup.php";
 
 // SUS-2956: Include MultiLookup extension
 require_once "$IP/extensions/wikia/SpecialMultipleLookup/SpecialMultipleLookup.php";
+
+// SUS-3475: Extension to update shared city_list table
+require_once "$IP/extensions/wikia/CityList/CityList.setup.php";

--- a/includes/wikia/tests/core/WikiaDatabaseTest.php
+++ b/includes/wikia/tests/core/WikiaDatabaseTest.php
@@ -38,12 +38,12 @@ abstract class WikiaDatabaseTest extends TestCase {
 
 		// init core MW schema
 		$schemaFile = self::$db->getSchemaPath();
-		self::$db->sourceFile( $schemaFile );
+		static::loadSchemaFile( $schemaFile );
 
 		// SUS-3071: add shared db tables
 		global $IP;
-		self::$db->sourceFile( "$IP/tests/fixtures/user.sql" );
-		self::$db->sourceFile( "$IP/tests/fixtures/user_properties.sql" );
+		static::loadSchemaFile( "$IP/tests/fixtures/user.sql" );
+		static::loadSchemaFile( "$IP/tests/fixtures/user_properties.sql" );
 	}
 
 	protected function setUp() {
@@ -93,5 +93,9 @@ abstract class WikiaDatabaseTest extends TestCase {
 
 	protected function createYamlDataSet( string $fileName ): IDataSet {
 		return new YamlDataSet( $fileName );
+	}
+
+	protected static function loadSchemaFile( string $schemaFile ) {
+		self::$db->sourceFile( $schemaFile );
 	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,3 +5,6 @@ $wgRunningUnitTests = true;
 $wgDevelEnvironment = true;
 
 require_once __DIR__ . '/../maintenance/commandLine.inc';
+
+$wgWikiFactoryCacheType = CACHE_NONE;
+$wgMemc = new EmptyBagOStuff();


### PR DESCRIPTION
Replace legacy script with background task that will bump `wikicities`.`city_list`.`city_last_timestamp` when page edit/delete/undelete/move occurs, and also verify adoptability status.

https://wikia-inc.atlassian.net/browse/SUS-3475