### PR TITLE
(PLATFORM-3303) Unset default values for shared uploads

### DIFF
--- a/includes/DefaultSettings.php
+++ b/includes/DefaultSettings.php
@@ -423,11 +423,11 @@ $wgUpdateCompatibleMetadata = false;
  */
 $wgUseSharedUploads = false;
 /** Full path on the web server where shared uploads can be found */
-$wgSharedUploadPath = "http://commons.wikimedia.org/shared/images";
+$wgSharedUploadPath = null;
 /** Fetch commons image description pages and display them on the local wiki? */
 $wgFetchCommonsDescriptions = false;
 /** Path on the file system where shared uploads can be found. */
-$wgSharedUploadDirectory = "/var/www/wiki3/images";
+$wgSharedUploadDirectory = null;
 /** DB name with metadata about shared directory. Set this to false if the uploads do not come from a wiki. */
 $wgSharedUploadDBname = false;
 /** Optional table prefix used in database. */


### PR DESCRIPTION
Unset the default values for wgSharedUploadPath and wgSharedUploadDirectory
since they don't work.

This was done in later versions of MW in https://github.com/wikimedia/mediawiki/commit/6df8fce796f.