### PR TITLE
PHP 7.2 - get rid of count( $dracula )

### DIFF
--- a/includes/api/ApiOptions.php
+++ b/includes/api/ApiOptions.php
@@ -58,7 +58,7 @@ class ApiOptions extends ApiBase {
 		}
 
 		$changes = array();
-		if ( count( $params['change'] ) ) {
+		if ( $params['change'] ) {
 			foreach ( $params['change'] as $entry ) {
 				$array = explode( '=', $entry, 2 );
 				$changes[$array[0]] = isset( $array[1] ) ? $array[1] : null;

--- a/includes/api/ApiQueryAllpages.php
+++ b/includes/api/ApiQueryAllpages.php
@@ -106,12 +106,12 @@ class ApiQueryAllpages extends ApiQueryGeneratorBase {
 		}
 
 		// Page protection filtering
-		if ( count( $params['prtype'] ) || $params['prexpiry'] != 'all' ) {
+		if ( $params['prtype'] || $params['prexpiry'] != 'all' ) {
 			$this->addTables( 'page_restrictions' );
 			$this->addWhere( 'page_id=pr_page' );
 			$this->addWhere( 'pr_expiry>' . $db->addQuotes( $db->timestamp() ) );
 
-			if ( count( $params['prtype'] ) ) {
+			if ( $params['prtype'] ) {
 				$this->addWhereFld( 'pr_type', $params['prtype'] );
 
 				if ( isset( $params['prlevel'] ) ) {

--- a/includes/api/ApiQueryCategoryMembers.php
+++ b/includes/api/ApiQueryCategoryMembers.php
@@ -102,7 +102,7 @@ class ApiQueryCategoryMembers extends ApiQueryGeneratorBase {
 		global $wgMiserMode;
 		$miser_ns = array();
 		if ( $wgMiserMode ) {
-			$miser_ns = $params['namespace'];
+			$miser_ns = $params['namespace'] ?: [];
 		} else {
 			$this->addWhereFld( 'page_namespace', $params['namespace'] );
 		}

--- a/includes/api/ApiQueryExtLinksUsage.php
+++ b/includes/api/ApiQueryExtLinksUsage.php
@@ -62,7 +62,7 @@ class ApiQueryExtLinksUsage extends ApiQueryGeneratorBase {
 		global $wgMiserMode;
 		$miser_ns = array();
 		if ( $wgMiserMode ) {
-			$miser_ns = $params['namespace'];
+			$miser_ns = $params['namespace'] ?: [];
 		} else {
 			$this->addWhereFld( 'page_namespace', $params['namespace'] );
 		}

--- a/includes/api/ApiQueryLinks.php
+++ b/includes/api/ApiQueryLinks.php
@@ -138,7 +138,7 @@ class ApiQueryLinks extends ApiQueryGeneratorBase {
 		if ( count( $this->getPageSet()->getGoodTitles() ) != 1 ) {
 			$order[] = $this->prefix . '_from' . $dir;
 		}
-		if ( count( $params['namespace'] ) != 1 ) {
+		if ( $params['namespace'] && count( $params['namespace'] ) != 1 ) {
 			$order[] = $this->prefix . '_namespace' . $dir;
 		}
 


### PR DESCRIPTION
Port of https://github.com/wikimedia/mediawiki/commit/847bc2b8d7756c36551a768f5cf0d36bc50705b6 to address `count`-related changes in PHP 7.2: http://php.net/manual/en/migration72.incompatible.php

