### PR TITLE
SUS-3471 | stop creating `job` table for new wikis

### DIFF
--- a/includes/installer/MysqlUpdater.php
+++ b/includes/installer/MysqlUpdater.php
@@ -73,7 +73,7 @@ class MysqlUpdater extends DatabaseUpdater {
 			#array( 'addField', 'user',            'user_registration', 'patch-user_registration.sql' ),
 			array( 'doTemplatelinksUpdate' ),
 			array( 'addTable', 'externallinks',                       'patch-externallinks.sql' ),
-			array( 'addTable', 'job',                                 'patch-job.sql' ),
+			#array( 'addTable', 'job',                                 'patch-job.sql' ),
 			array( 'addField', 'site_stats',      'ss_images',        'patch-ss_images.sql' ),
 			array( 'addTable', 'langlinks',                           'patch-langlinks.sql' ),
 			array( 'addTable', 'querycache_info',                     'patch-querycacheinfo.sql' ),
@@ -181,7 +181,7 @@ class MysqlUpdater extends DatabaseUpdater {
 			array( 'addIndex', 'page', 'page_redirect_namespace_len', 'patch-page_redirect_namespace_len.sql' ),
 			array( 'modifyField', 'user_groups', 'ug_group', 'patch-ug_group-length-increase.sql' ),
 			array( 'addField',	'uploadstash',	'us_chunk_inx',		'patch-uploadstash_chunk.sql' ),
-			array( 'addfield', 'job',           'job_timestamp',    'patch-jobs-add-timestamp.sql' ),
+			#array( 'addfield', 'job',           'job_timestamp',    'patch-jobs-add-timestamp.sql' ),
 			array( 'modifyField', 'user_former_groups', 'ufg_group', 'patch-ufg_group-length-increase.sql' ),
 
 			// backports

--- a/maintenance/tables.sql
+++ b/maintenance/tables.sql
@@ -1073,33 +1073,6 @@ CREATE TABLE /*_*/log_search (
 CREATE UNIQUE INDEX /*i*/ls_field_val ON /*_*/log_search (ls_field,ls_value,ls_log_id);
 CREATE INDEX /*i*/ls_log_id ON /*_*/log_search (ls_log_id);
 
-
--- Jobs performed by parallel apache threads or a command-line daemon
-CREATE TABLE /*_*/job (
-  job_id int unsigned NOT NULL PRIMARY KEY AUTO_INCREMENT,
-
-  -- Command name
-  -- Limited to 60 to prevent key length overflow
-  job_cmd varbinary(60) NOT NULL default '',
-
-  -- Namespace and title to act on
-  -- Should be 0 and '' if the command does not operate on a title
-  job_namespace int NOT NULL,
-  job_title varchar(255) binary NOT NULL,
-
-  -- Timestamp of when the job was inserted
-  -- NULL for jobs added before addition of the timestamp
-  job_timestamp varbinary(14) NULL default NULL,
-
-  -- Any other parameters to the command
-  -- Stored as a PHP serialized array, or an empty string if there are no parameters
-  job_params blob NOT NULL
-) /*$wgDBTableOptions*/;
-
-CREATE INDEX /*i*/job_cmd ON /*_*/job (job_cmd, job_namespace, job_title, job_params(128));
-CREATE INDEX /*i*/job_timestamp ON /*_*/job(job_timestamp);
-
-
 -- Details of updates to cached special pages
 CREATE TABLE /*_*/querycache_info (
   -- Special page name


### PR DESCRIPTION
This table is no longer used since July 2014. We switched from MediaWiki job scheduling to RabbitMQ + Celery.

```sql
mysql@geo-db-a-slave.query.consul[uncyclo]>select count(*), max(job_timestamp) from job;
+----------+--------------------+
| count(*) | max(job_timestamp) |
+----------+--------------------+
|       85 | 20140728221815     |
+----------+--------------------+
```

https://wikia-inc.atlassian.net/browse/SUS-3471