### PR TITLE
IRIS-5113 | Enable possibility to submit a post with OG or Image only.

### DIFF
--- a/extensions/wikia/MercuryApi/models/MercuryApi.class.php
+++ b/extensions/wikia/MercuryApi/models/MercuryApi.class.php
@@ -121,7 +121,7 @@ class MercuryApi {
 		       $wgDisableMobileSectionEditor, $wgEnableCommunityData, $wgEnableDiscussions,
 		       $wgEnableDiscussionsImageUpload, $wgDiscussionColorOverride, $wgEnableNewAuth,
 		       $wgLanguageCode, $wgSitename, $wgWikiDirectedAtChildrenByFounder,
-		       $wgWikiDirectedAtChildrenByStaff, $wgCdnRootUrl, $wgEnableFandomAppSmartBanner;
+		       $wgWikiDirectedAtChildrenByStaff, $wgCdnRootUrl, $wgEnableFandomAppSmartBanner, $wgEnableDiscussionsPostsWithoutText;
 
 		$enableFAsmartBannerCommunity = WikiFactory::getVarValueByName( 'wgEnableFandomAppSmartBanner', WikiFactory::COMMUNITY_CENTRAL );
 
@@ -138,6 +138,7 @@ class MercuryApi {
 			'enableCommunityData' => $wgEnableCommunityData,
 			'enableDiscussions' => $wgEnableDiscussions,
 			'enableDiscussionsImageUpload' => $wgEnableDiscussionsImageUpload,
+			'enableDiscussionsPostsWithoutText' => $wgEnableDiscussionsPostsWithoutText,
 			'enableFandomAppSmartBanner' => !empty( $enableFAsmartBannerCommunity ),
 			'enableNewAuth' => $wgEnableNewAuth,
 			'favicon' => Wikia::getFaviconFullUrl(),


### PR DESCRIPTION
###### [Ticket](https://wikia-inc.atlassian.net/browse/IRIS-5113)

###### This PR makes a change in **discussion**.

###### Change Description:

Discussions now allow users to create and edit posts w/o content if OG image or Content Image has been provided.

##### Acceptance Criteria

h2. AC:
- either a resource or integration test
- let Mobile Apps [iOS&Android] test out a sample response w/o content on the older version - apps should not crash, at worst they should not display those posts and replies