### PR TITLE
(PLATFORM-2851) Make Nirvana cache private for logged-in users

### DIFF
--- a/extensions/wikia/AssetsManager/AssetsManagerController.class.php
+++ b/extensions/wikia/AssetsManager/AssetsManagerController.class.php
@@ -150,6 +150,7 @@ class AssetsManagerController extends WikiaController {
 			wfProfileOut( $profileId );
 		}
 
+		$this->response->setCachePolicy( WikiaResponse::CACHE_PUBLIC );
 		$this->response->setCacheValidity( WikiaResponse::CACHE_LONG );
 
 		$this->response->setFormat( 'json' );
@@ -230,6 +231,7 @@ class AssetsManagerController extends WikiaController {
 	public function getStyleVersion() {
 		wfProfileIn( __METHOD__ );
 		$this->response->setVal( 'styleVersion', $this->app->wg->StyleVersion );
+		$this->response->setCachePolicy( WikiaResponse::CACHE_PUBLIC );
 		$this->response->setCacheValidity( WikiaResponse::CACHE_SHORT );
 		$this->response->setFormat( 'json' );
 		wfProfileOut( __METHOD__ );

--- a/extensions/wikia/JSMessages/JSMessagesController.class.php
+++ b/extensions/wikia/JSMessages/JSMessagesController.class.php
@@ -26,6 +26,7 @@ class JSMessagesController extends WikiaController {
 
 		// cache it well :)
 		if ( !$this->request->isInternal() ) {
+			$this->response->setCachePolicy( WikiaResponse::CACHE_PUBLIC );
 			$this->response->setCacheValidity(self::CACHE_TIME);
 
 			$this->response->setContentType('text/javascript; charset=utf-8');

--- a/extensions/wikia/Lightbox/LightboxController.class.php
+++ b/extensions/wikia/Lightbox/LightboxController.class.php
@@ -24,6 +24,7 @@ class LightboxController extends WikiaController {
 	 */
 	public function lightboxModalContent() {
 		// set cache control to 1 day
+		$this->response->setCachePolicy( WikiaResponse::CACHE_PUBLIC );
 		$this->response->setCacheValidity( WikiaResponse::CACHE_STANDARD );
 	}
 
@@ -35,6 +36,7 @@ class LightboxController extends WikiaController {
 		}
 
 		// set cache control to 1 day
+		$this->response->setCachePolicy( WikiaResponse::CACHE_PUBLIC );
 		$this->response->setCacheValidity( WikiaResponse::CACHE_STANDARD );
 	}
 

--- a/extensions/wikia/Optimizely/OptimizelyController.class.php
+++ b/extensions/wikia/Optimizely/OptimizelyController.class.php
@@ -18,7 +18,7 @@ class OptimizelyController extends WikiaController {
 			$this->code = '';
 		}
 
-		$response->setVaryOnCookie( false );
+		$response->setCachePolicy( WikiaResponse::CACHE_PUBLIC );
 		$response->setCacheValidity( WikiaResponse::CACHE_VERY_SHORT );
 	}
 }

--- a/extensions/wikia/RTE/RTEController.class.php
+++ b/extensions/wikia/RTE/RTEController.class.php
@@ -12,6 +12,7 @@ class RTEController extends WikiaController {
 		$requestedCb = $this->request->getVal('cb');
 		$key = $currentCb == $requestedCb ? 'versioned' : 'unversioned';
 
+		$this->response->setCachePolicy( WikiaResponse::CACHE_PUBLIC );
 		$this->response->setCacheValidity($wgResourceLoaderMaxage[$key]['server']. $wgResourceLoaderMaxage[$key]['client']);
 	}
 

--- a/extensions/wikia/WikiaInYourLang/WikiaInYourLangController.class.php
+++ b/extensions/wikia/WikiaInYourLang/WikiaInYourLangController.class.php
@@ -95,6 +95,7 @@ class WikiaInYourLangController extends WikiaController {
 		/**
 		 * Cache the response for a day
 		 */
+		$this->response->setCachePolicy( WikiaResponse::CACHE_PUBLIC );
 		$this->response->setCacheValidity( WikiaResponse::CACHE_STANDARD );
 
 		wfProfileOut( __METHOD__ );

--- a/extensions/wikia/WikiaRSS/WikiaRssExternalController.class.php
+++ b/extensions/wikia/WikiaRSS/WikiaRssExternalController.class.php
@@ -11,6 +11,7 @@ class WikiaRssExternalController extends WikiaController {
 		$this->response->setVal( 'status', false );
 		$options = $this->request->getVal( 'options', false );
 
+		$this->response->setCachePolicy( WikiaResponse::CACHE_PUBLIC );
 		$this->response->setCacheValidity( self::CACHE_TIME ); //cache it on varnish for 1h
 
 		//somehow empty arrays are lost

--- a/includes/wikia/nirvana/WikiaResponse.class.php
+++ b/includes/wikia/nirvana/WikiaResponse.class.php
@@ -302,15 +302,21 @@ class WikiaResponse {
 	 *
 	 * @param string $policy caching policy (either private or public)
 	 */
-	public function setCachePolicy($policy) {
-		if ( in_array( $policy, [
+	public function setCachePolicy( $policy ) {
+		if ( !in_array( $policy, [
 				self::CACHE_PRIVATE,
 				self::CACHE_PUBLIC,
 				self::CACHE_ANON_PUBLIC_USER_PRIVATE,
 			] )
 		) {
-			$this->cachingPolicy = $policy;
+			\Wikia\Logger\WikiaLogger::instance()->error( 'Invalid cache policy provided', [
+				'policy' => $policy,
+				'exception' => new Exception(),
+			] );
+			return;
 		}
+
+		$this->cachingPolicy = $policy;
 	}
 
 	/**

--- a/includes/wikia/nirvana/WikiaResponse.class.php
+++ b/includes/wikia/nirvana/WikiaResponse.class.php
@@ -50,13 +50,14 @@ class WikiaResponse {
 	const CACHE_SHORT = 10800; // 3 hours
 	const CACHE_VERY_SHORT = 300; // 5 minutes
 
+	const CACHE_PRIVATE = 'private';
+	const CACHE_PUBLIC = 'public';
+	const CACHE_ANON_PUBLIC_USER_PRIVATE = 'anon-public-user-private';
+
 	/**
 	 * Caching policy
 	 */
-	private $cachingPolicy = 'public';
-
-	const CACHE_PRIVATE = 'private';
-	const CACHE_PUBLIC = 'public';
+	private $cachingPolicy = self::CACHE_ANON_PUBLIC_USER_PRIVATE;
 
 	/**
 	 * View object
@@ -82,8 +83,6 @@ class WikiaResponse {
 	 * @var bool
 	 */
 	protected $isCaching = false;
-
-	protected $varyOnCookie = true;
 
 	/**
 	 * constructor
@@ -304,7 +303,14 @@ class WikiaResponse {
 	 * @param string $policy caching policy (either private or public)
 	 */
 	public function setCachePolicy($policy) {
-		$this->cachingPolicy = $policy === self::CACHE_PRIVATE ? self::CACHE_PRIVATE : self::CACHE_PUBLIC;
+		if ( in_array( $policy, [
+				self::CACHE_PRIVATE,
+				self::CACHE_PUBLIC,
+				self::CACHE_ANON_PUBLIC_USER_PRIVATE,
+			] )
+		) {
+			$this->cachingPolicy = $policy;
+		}
 	}
 
 	/**
@@ -324,9 +330,19 @@ class WikiaResponse {
 		if ($browserTTL === false) {
 			$browserTTL = $varnishTTL;
 		}
+		$browserPolicy = self::CACHE_PUBLIC;
 
 		switch($this->cachingPolicy) {
 			case self::CACHE_PUBLIC:
+			case self::CACHE_ANON_PUBLIC_USER_PRIVATE:
+				$output = RequestContext::getMain()->getOutput();
+				if ( $this->cachingPolicy === self::CACHE_ANON_PUBLIC_USER_PRIVATE &&
+					$output->haveCacheVaryCookies()
+				) {
+					$this->setHeader( 'Cache-Control', 'private, s-maxage=0' );
+					break;
+				}
+
 				// Varnish caches for 5 seconds when Apache sends Cache-Control: public, s-maxage=0
 				// perform this logic here
 				if ( $varnishTTL === self::CACHE_DISABLED ) {
@@ -337,13 +353,14 @@ class WikiaResponse {
 				break;
 
 			case self::CACHE_PRIVATE:
-				$this->setHeader('Cache-Control', sprintf('private, s-maxage=%d', $varnishTTL));
+				$browserPolicy = self::CACHE_PRIVATE;
+				$this->setHeader( 'Cache-Control', 'private, s-maxage=0' );
 				break;
 		}
 
 		// cache on client side
 		if ($browserTTL > 0) {
-			$this->setHeader('X-Pass-Cache-Control', sprintf('%s, max-age=%d', $this->cachingPolicy, $browserTTL));
+			$this->setHeader( 'X-Pass-Cache-Control', sprintf( '%s, max-age=%d', $browserPolicy, $browserTTL ) );
 		}
 	}
 
@@ -353,10 +370,6 @@ class WikiaResponse {
 	 */
 	public function isCaching() {
 		return $this->isCaching;
-	}
-
-	public function setVaryOnCookie( $shouldVary = true ) {
-		$this->varyOnCookie = $shouldVary;
 	}
 
 	public function getHeader( $name ) {
@@ -475,11 +488,15 @@ class WikiaResponse {
 			$this->sendHeader( ( $header['name'] . ': ' . $header['value'] ), $header['replace']);
 		}
 
-		// Make sure we vary on Cookie by default (MAIN-9527)
-		$output = RequestContext::getMain()->getOutput();
-		if ( $output->getCacheVaryCookies() && $this->varyOnCookie ) {
+		// Make sure we vary on Cookie if we have a different cache between anonymous
+		// and logged-in users
+		if ( $this->isCaching() &&
+			$this->cachingPolicy === self::CACHE_ANON_PUBLIC_USER_PRIVATE
+		) {
+			$output = RequestContext::getMain()->getOutput();
 			$this->sendHeader( $output->getVaryHeader(), true );
 		}
+
 
 		if ( !empty( $this->code ) ) {
 			$msg = '';

--- a/includes/wikia/tests/WikiaResponseTest.php
+++ b/includes/wikia/tests/WikiaResponseTest.php
@@ -70,18 +70,18 @@ class WikiaResponseTest extends TestCase {
 			}
 		}
 
-		// there are two additional headers to be sent, content-type and vary
-		$headersNum = $replace ? 3 : $headersNum + 2;
+		// there is one additional header to be sent, content-type
+		$headersNum = $replace ? 2 : $headersNum + 1;
 
 		$this->object->expects( $this->exactly( $headersNum ))->method( 'sendHeader' );
 		$this->object->sendHeaders();
 	}
 
 	/**
-	 * By default we send content-type and vary headers, plus response code in this test
+	 * By default we send content-type header, plus response code in this test
 	 */
 	public function testSettingResponseCode() {
-		$this->object->expects( $this->exactly( 3 ) )->method( 'sendHeader' );
+		$this->object->expects( $this->exactly( 2 ) )->method( 'sendHeader' );
 		$this->object->setCode(200);
 		$this->object->sendHeaders();
 	}


### PR DESCRIPTION
This makes the default cache behaviour for Nirvana controllers to use
public cache for anon users and private cache for logged-in users,
rather than relying on varying on cookie. This matches the behaviour
elsewhere in MediaWiki. If the controller doesn't need to be private
for logged-in users, it can be overridden by explicitly setting the
cache as public.

The Cache-Control header sent to clients in this case will remain public
so that browser caching works as expected even for logged-in users.

