### PR TITLE
SUS-3532 | ImageServing - add a check to prevent fatal errors

### DIFF
--- a/extensions/wikia/ImageServing/imageServing.class.php
+++ b/extensions/wikia/ImageServing/imageServing.class.php
@@ -125,10 +125,10 @@ class ImageServing {
 
 			// fetch articles metadata (try from cache)
 			foreach ( $articles as $key => $value ) {
-				$article = Article::newFromID( $key );
+				$title = Title::newFromID( $key );
 
-				if ( $article instanceof  Article ) {
-					$mcValue = $this->memc->get( $this->makeKey( $key, $article->getRevIdFetched() ) );
+				if ( $title instanceof  Title ) {
+					$mcValue = $this->memc->get( $this->makeKey( $key, $title->getLatestRevID() ) );
 
 					if ( !empty( $mcValue ) ) {
 						unset( $articles[$key] );

--- a/extensions/wikia/ImageServing/imageServing.class.php
+++ b/extensions/wikia/ImageServing/imageServing.class.php
@@ -125,11 +125,15 @@ class ImageServing {
 
 			// fetch articles metadata (try from cache)
 			foreach ( $articles as $key => $value ) {
-				$mcValue = $this->memc->get( $this->makeKey( $key, Article::newFromID( $key )->getRevIdFetched() ) );
+				$article = Article::newFromID( $key );
 
-				if ( !empty( $mcValue ) ) {
-					unset( $articles[$key] );
-					$this->addArticleToList( $mcValue );
+				if ( $article instanceof  Article ) {
+					$mcValue = $this->memc->get( $this->makeKey( $key, $article->getRevIdFetched() ) );
+
+					if ( !empty( $mcValue ) ) {
+						unset( $articles[$key] );
+						$this->addArticleToList( $mcValue );
+					}
 				}
 			}
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3532

Prevent `Error: Call to a member function getRevIdFetched() on null` for not existing articles.