### PR TITLE
Update PHPUnit to 6.5.4

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2687,16 +2687,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.5.3",
+            "version": "6.5.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "882e886cc928a0abd3c61282b2a64026237d14a4"
+                "reference": "1b2f933d5775f9237369deaa2d2bfbf9d652be4c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/882e886cc928a0abd3c61282b2a64026237d14a4",
-                "reference": "882e886cc928a0abd3c61282b2a64026237d14a4",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/1b2f933d5775f9237369deaa2d2bfbf9d652be4c",
+                "reference": "1b2f933d5775f9237369deaa2d2bfbf9d652be4c",
                 "shasum": ""
             },
             "require": {
@@ -2714,7 +2714,7 @@
                 "phpunit/php-file-iterator": "^1.4.3",
                 "phpunit/php-text-template": "^1.2.1",
                 "phpunit/php-timer": "^1.0.9",
-                "phpunit/phpunit-mock-objects": "^5.0.4",
+                "phpunit/phpunit-mock-objects": "^5.0.5",
                 "sebastian/comparator": "^2.1",
                 "sebastian/diff": "^2.0",
                 "sebastian/environment": "^3.1",
@@ -2767,27 +2767,27 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-12-06T09:42:03+00:00"
+            "time": "2017-12-10T08:06:19+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "5.0.4",
+            "version": "5.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "16b50f4167e5e85e81ca8a3dd105d0a5fd32009a"
+                "reference": "283b9f4f670e3a6fd6c4ff95c51a952eb5c75933"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/16b50f4167e5e85e81ca8a3dd105d0a5fd32009a",
-                "reference": "16b50f4167e5e85e81ca8a3dd105d0a5fd32009a",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/283b9f4f670e3a6fd6c4ff95c51a952eb5c75933",
+                "reference": "283b9f4f670e3a6fd6c4ff95c51a952eb5c75933",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.5",
                 "php": "^7.0",
                 "phpunit/php-text-template": "^1.2.1",
-                "sebastian/exporter": "^3.0"
+                "sebastian/exporter": "^3.1"
             },
             "conflict": {
                 "phpunit/phpunit": "<6.0"
@@ -2826,7 +2826,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2017-12-02T05:31:19+00:00"
+            "time": "2017-12-10T08:01:53+00:00"
         },
         {
             "name": "psr/log",

--- a/lib/composer/composer/installed.json
+++ b/lib/composer/composer/installed.json
@@ -4274,67 +4274,6 @@
         ]
     },
     {
-        "name": "phpunit/phpunit-mock-objects",
-        "version": "5.0.4",
-        "version_normalized": "5.0.4.0",
-        "source": {
-            "type": "git",
-            "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-            "reference": "16b50f4167e5e85e81ca8a3dd105d0a5fd32009a"
-        },
-        "dist": {
-            "type": "zip",
-            "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/16b50f4167e5e85e81ca8a3dd105d0a5fd32009a",
-            "reference": "16b50f4167e5e85e81ca8a3dd105d0a5fd32009a",
-            "shasum": ""
-        },
-        "require": {
-            "doctrine/instantiator": "^1.0.5",
-            "php": "^7.0",
-            "phpunit/php-text-template": "^1.2.1",
-            "sebastian/exporter": "^3.0"
-        },
-        "conflict": {
-            "phpunit/phpunit": "<6.0"
-        },
-        "require-dev": {
-            "phpunit/phpunit": "^6.5"
-        },
-        "suggest": {
-            "ext-soap": "*"
-        },
-        "time": "2017-12-02T05:31:19+00:00",
-        "type": "library",
-        "extra": {
-            "branch-alias": {
-                "dev-master": "5.0.x-dev"
-            }
-        },
-        "installation-source": "dist",
-        "autoload": {
-            "classmap": [
-                "src/"
-            ]
-        },
-        "notification-url": "https://packagist.org/downloads/",
-        "license": [
-            "BSD-3-Clause"
-        ],
-        "authors": [
-            {
-                "name": "Sebastian Bergmann",
-                "email": "sebastian@phpunit.de",
-                "role": "lead"
-            }
-        ],
-        "description": "Mock Object library for PHPUnit",
-        "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
-        "keywords": [
-            "mock",
-            "xunit"
-        ]
-    },
-    {
         "name": "phpunit/php-file-iterator",
         "version": "1.4.5",
         "version_normalized": "1.4.5.0",
@@ -4665,18 +4604,79 @@
         ]
     },
     {
-        "name": "phpunit/phpunit",
-        "version": "6.5.3",
-        "version_normalized": "6.5.3.0",
+        "name": "phpunit/phpunit-mock-objects",
+        "version": "5.0.5",
+        "version_normalized": "5.0.5.0",
         "source": {
             "type": "git",
-            "url": "https://github.com/sebastianbergmann/phpunit.git",
-            "reference": "882e886cc928a0abd3c61282b2a64026237d14a4"
+            "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
+            "reference": "283b9f4f670e3a6fd6c4ff95c51a952eb5c75933"
         },
         "dist": {
             "type": "zip",
-            "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/882e886cc928a0abd3c61282b2a64026237d14a4",
-            "reference": "882e886cc928a0abd3c61282b2a64026237d14a4",
+            "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/283b9f4f670e3a6fd6c4ff95c51a952eb5c75933",
+            "reference": "283b9f4f670e3a6fd6c4ff95c51a952eb5c75933",
+            "shasum": ""
+        },
+        "require": {
+            "doctrine/instantiator": "^1.0.5",
+            "php": "^7.0",
+            "phpunit/php-text-template": "^1.2.1",
+            "sebastian/exporter": "^3.1"
+        },
+        "conflict": {
+            "phpunit/phpunit": "<6.0"
+        },
+        "require-dev": {
+            "phpunit/phpunit": "^6.5"
+        },
+        "suggest": {
+            "ext-soap": "*"
+        },
+        "time": "2017-12-10T08:01:53+00:00",
+        "type": "library",
+        "extra": {
+            "branch-alias": {
+                "dev-master": "5.0.x-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "classmap": [
+                "src/"
+            ]
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "BSD-3-Clause"
+        ],
+        "authors": [
+            {
+                "name": "Sebastian Bergmann",
+                "email": "sebastian@phpunit.de",
+                "role": "lead"
+            }
+        ],
+        "description": "Mock Object library for PHPUnit",
+        "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
+        "keywords": [
+            "mock",
+            "xunit"
+        ]
+    },
+    {
+        "name": "phpunit/phpunit",
+        "version": "6.5.4",
+        "version_normalized": "6.5.4.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/sebastianbergmann/phpunit.git",
+            "reference": "1b2f933d5775f9237369deaa2d2bfbf9d652be4c"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/1b2f933d5775f9237369deaa2d2bfbf9d652be4c",
+            "reference": "1b2f933d5775f9237369deaa2d2bfbf9d652be4c",
             "shasum": ""
         },
         "require": {
@@ -4694,7 +4694,7 @@
             "phpunit/php-file-iterator": "^1.4.3",
             "phpunit/php-text-template": "^1.2.1",
             "phpunit/php-timer": "^1.0.9",
-            "phpunit/phpunit-mock-objects": "^5.0.4",
+            "phpunit/phpunit-mock-objects": "^5.0.5",
             "sebastian/comparator": "^2.1",
             "sebastian/diff": "^2.0",
             "sebastian/environment": "^3.1",
@@ -4715,7 +4715,7 @@
             "ext-xdebug": "*",
             "phpunit/php-invoker": "^1.1"
         },
-        "time": "2017-12-06T09:42:03+00:00",
+        "time": "2017-12-10T08:06:19+00:00",
         "bin": [
             "phpunit"
         ],

--- a/lib/composer/phpunit/phpunit-mock-objects/composer.json
+++ b/lib/composer/phpunit/phpunit-mock-objects/composer.json
@@ -19,12 +19,11 @@
         "issues": "https://github.com/sebastianbergmann/phpunit-mock-objects/issues"
     },
     "prefer-stable": true,
-    "minimum-stability": "dev",
     "require": {
         "php": "^7.0",
         "phpunit/php-text-template": "^1.2.1",
         "doctrine/instantiator": "^1.0.5",
-        "sebastian/exporter": "^3.0"
+        "sebastian/exporter": "^3.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.5"

--- a/lib/composer/phpunit/phpunit-mock-objects/phpunit.xml
+++ b/lib/composer/phpunit/phpunit-mock-objects/phpunit.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.0/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.5/phpunit.xsd"
          bootstrap="tests/bootstrap.php"
          beStrictAboutCoversAnnotation="true"
          beStrictAboutOutputDuringTests="true"
-         beStrictAboutTestsThatDoNotTestAnything="true"
          beStrictAboutTodoAnnotatedTests="true"
          verbose="true">
     <testsuites>

--- a/lib/composer/phpunit/phpunit-mock-objects/src/Invocation/StaticInvocation.php
+++ b/lib/composer/phpunit/phpunit-mock-objects/src/Invocation/StaticInvocation.php
@@ -229,7 +229,7 @@ class StaticInvocation implements Invocation, SelfDescribing
             }
         }
 
-        if ($cloneable === null && \method_exists($object, 'isCloneable')) {
+        if ($cloneable === null) {
             $cloneable = $object->isCloneable();
         }
 

--- a/lib/composer/phpunit/phpunit-mock-objects/src/Matcher/AnyParameters.php
+++ b/lib/composer/phpunit/phpunit-mock-objects/src/Matcher/AnyParameters.php
@@ -9,7 +9,7 @@
  */
 namespace PHPUnit\Framework\MockObject\Matcher;
 
-use PHPUnit\Framework\MockObject\Invocation;
+use PHPUnit\Framework\MockObject\Invocation as BaseInvocation;
 
 /**
  * Invocation matcher which allows any parameters to a method.
@@ -25,11 +25,11 @@ class AnyParameters extends StatelessInvocation
     }
 
     /**
-     * @param Invocation $invocation
+     * @param BaseInvocation $invocation
      *
      * @return bool
      */
-    public function matches(Invocation $invocation)
+    public function matches(BaseInvocation $invocation)
     {
         return true;
     }

--- a/lib/composer/phpunit/phpunit-mock-objects/src/Matcher/InvokedCount.php
+++ b/lib/composer/phpunit/phpunit-mock-objects/src/Matcher/InvokedCount.php
@@ -10,7 +10,7 @@
 namespace PHPUnit\Framework\MockObject\Matcher;
 
 use PHPUnit\Framework\ExpectationFailedException;
-use PHPUnit\Framework\MockObject\Invocation;
+use PHPUnit\Framework\MockObject\Invocation as BaseInvocation;
 
 /**
  * Invocation matcher which checks if a method has been invoked a certain amount
@@ -52,11 +52,11 @@ class InvokedCount extends InvokedRecorder
     }
 
     /**
-     * @param Invocation $invocation
+     * @param BaseInvocation $invocation
      *
      * @throws ExpectationFailedException
      */
-    public function invoked(Invocation $invocation)
+    public function invoked(BaseInvocation $invocation)
     {
         parent::invoked($invocation);
 

--- a/lib/composer/phpunit/phpunit-mock-objects/src/Matcher/MethodName.php
+++ b/lib/composer/phpunit/phpunit-mock-objects/src/Matcher/MethodName.php
@@ -11,7 +11,7 @@ namespace PHPUnit\Framework\MockObject\Matcher;
 
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\Constraint\IsEqual;
-use PHPUnit\Framework\MockObject\Invocation;
+use PHPUnit\Framework\MockObject\Invocation as BaseInvocation;
 use PHPUnit\Util\InvalidArgumentHelper;
 
 /**
@@ -62,11 +62,11 @@ class MethodName extends StatelessInvocation
     }
 
     /**
-     * @param Invocation $invocation
+     * @param BaseInvocation $invocation
      *
      * @return bool
      */
-    public function matches(Invocation $invocation)
+    public function matches(BaseInvocation $invocation)
     {
         return $this->constraint->evaluate($invocation->getMethodName(), '', true);
     }

--- a/lib/composer/phpunit/phpunit-mock-objects/tests/Generator/return_type_declarations_final.phpt
+++ b/lib/composer/phpunit/phpunit-mock-objects/tests/Generator/return_type_declarations_final.phpt
@@ -44,6 +44,28 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
         $this->__phpunit_invocationMocker = clone $this->__phpunit_getInvocationMocker();
     }
 
+    public function bar(): FinalClass
+    {
+        $arguments = array();
+        $count     = func_num_args();
+
+        if ($count > 0) {
+            $_arguments = func_get_args();
+
+            for ($i = 0; $i < $count; $i++) {
+                $arguments[] = $_arguments[$i];
+            }
+        }
+
+        $result = $this->__phpunit_getInvocationMocker()->invoke(
+            new \PHPUnit\Framework\MockObject\Invocation\ObjectInvocation(
+                'Foo', 'bar', $arguments, 'FinalClass', $this, true
+            )
+        );
+
+        return $result;
+    }
+
     public function expects(\PHPUnit\Framework\MockObject\Matcher\Invocation $matcher)
     {
         return $this->__phpunit_getInvocationMocker()->expects($matcher);

--- a/lib/composer/phpunit/phpunit/ChangeLog-6.5.md
+++ b/lib/composer/phpunit/phpunit/ChangeLog-6.5.md
@@ -2,6 +2,12 @@
 
 All notable changes of the PHPUnit 6.5 release series are documented in this file using the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
+## [6.5.4] - 2017-12-10
+
+### Changed
+
+* Require version 5.0.5 of `phpunit/phpunit-mock-objects` for [phpunit-mock-objects#394](https://github.com/sebastianbergmann/phpunit-mock-objects/issues/394)
+
 ## [6.5.3] - 2017-12-06
 
 ### Fixed
@@ -30,6 +36,7 @@ All notable changes of the PHPUnit 6.5 release series are documented in this fil
 * Fixed [#2654](https://github.com/sebastianbergmann/phpunit/issues/2654): Problems with `assertJsonStringEqualsJsonString()`
 * Fixed [#2810](https://github.com/sebastianbergmann/phpunit/pull/2810): Code Coverage for PHPT tests does not work
 
+[6.5.4]: https://github.com/sebastianbergmann/phpunit/compare/6.5.3...6.5.4
 [6.5.3]: https://github.com/sebastianbergmann/phpunit/compare/6.5.2...6.5.3
 [6.5.2]: https://github.com/sebastianbergmann/phpunit/compare/6.5.1...6.5.2
 [6.5.1]: https://github.com/sebastianbergmann/phpunit/compare/6.5.0...6.5.1

--- a/lib/composer/phpunit/phpunit/composer.json
+++ b/lib/composer/phpunit/phpunit/composer.json
@@ -35,7 +35,7 @@
         "phpunit/php-file-iterator": "^1.4.3",
         "phpunit/php-text-template": "^1.2.1",
         "phpunit/php-timer": "^1.0.9",
-        "phpunit/phpunit-mock-objects": "^5.0.4",
+        "phpunit/phpunit-mock-objects": "^5.0.5",
         "sebastian/comparator": "^2.1",
         "sebastian/diff": "^2.0",
         "sebastian/environment": "^3.1",

--- a/lib/composer/phpunit/phpunit/src/Runner/Version.php
+++ b/lib/composer/phpunit/phpunit/src/Runner/Version.php
@@ -32,7 +32,7 @@ class Version
         }
 
         if (self::$version === null) {
-            $version       = new VersionId('6.5.3', \dirname(\dirname(__DIR__)));
+            $version       = new VersionId('6.5.4', \dirname(\dirname(__DIR__)));
             self::$version = $version->getVersion();
         }
 


### PR DESCRIPTION
```
$ composer update phpunit/phpunit --with-dependencies
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 0 installs, 2 updates, 0 removals
  - Updating phpunit/phpunit-mock-objects (5.0.4 => 5.0.5): Downloading (100%)
  - Updating phpunit/phpunit (6.5.3 => 6.5.4): Downloading (100%)
Writing lock file
Generating optimized autoload files
```