### PR TITLE
SUS-3528 | WikiPage::getContributors - use User::newFromId to resolve user accounts

### DIFF
--- a/includes/Action.php
+++ b/includes/Action.php
@@ -31,7 +31,7 @@ abstract class Action {
 
 	/**
 	 * Page on which we're performing the action
-	 * @var Article
+	 * @var WikiPage
 	 */
 	protected $page;
 

--- a/includes/UserArray.php
+++ b/includes/UserArray.php
@@ -67,7 +67,10 @@ class UserArrayFromResult extends UserArray {
 		if ( $row === false ) {
 			$this->current = false;
 		} else {
-			$this->current = User::newFromRow( $row );
+			// SUS-3528
+			$this->current = $row->user_id > 0
+				? User::newFromId( $row->user_id )
+				: User::newFromRow( $row );
 		}
 	}
 

--- a/includes/WikiPage.php
+++ b/includes/WikiPage.php
@@ -791,19 +791,11 @@ class WikiPage extends Page implements IDBAccessObject {
 		# @todo FIXME: This is expensive; cache this info somewhere.
 
 		$dbr = wfGetDB( DB_SLAVE );
-
-		if ( $dbr->implicitGroupby() ) {
-			$realNameField = 'user_real_name';
-		} else {
-			$realNameField = 'MIN(user_real_name) AS user_real_name';
-		}
-
-		$tables = array( 'revision', 'user' );
+		$tables = [ 'revision' ];
 
 		$fields = array(
 			'rev_user as user_id',
-			'rev_user_text AS user_name',
-			$realNameField,
+			'rev_user_text as user_name',
 			'MAX(rev_timestamp) AS timestamp',
 		);
 
@@ -820,16 +812,12 @@ class WikiPage extends Page implements IDBAccessObject {
 
 		$conds[] = "{$dbr->bitAnd( 'rev_deleted', Revision::DELETED_USER )} = 0"; // username hidden?
 
-		$jconds = array(
-			'user' => array( 'LEFT JOIN', 'rev_user = user_id' ),
-		);
-
 		$options = array(
 			'GROUP BY' => array( 'rev_user', 'rev_user_text' ),
 			'ORDER BY' => 'timestamp DESC',
 		);
 
-		$res = $dbr->select( $tables, $fields, $conds, __METHOD__, $options, $jconds );
+		$res = $dbr->select( $tables, $fields, $conds, __METHOD__, $options );
 		return new UserArrayFromResult( $res );
 	}
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3528

Avoid ` Table 'dethealchemistcode.user' doesn't exist`

## New queries

http://poznan.sandbox-s6.wikia.com/wiki/Pozna%C5%84?action=credits&uselang=en

```sql
mysql@geo-db-a-slave.query.consul[plpoznan]>SELECT  rev_user as user_id, rev_user_text as user_name, MAX(rev_timestamp) AS timestamp  FROM `revision`  WHERE rev_page = '77' AND ((rev_deleted & 4) = 0)  GROUP BY rev_user,rev_user_text ORDER BY timestamp DESC;
+----------+----------------+----------------+
| user_id  | user_name      | timestamp      |
+----------+----------------+----------------+
| 24889327 |                | 20150920195349 |
|  5897474 |                | 20141230182828 |
|  3182356 |                | 20141104103556 |
|   119245 |                | 20131013083154 |
|  5216014 |                | 20130328004753 |
|  4955712 |                | 20120409152243 |
|  2240397 |                | 20120331193520 |
|        0 | 95.108.104.100 | 20111130201427 |
|        0 | 77.255.6.241   | 20111130195341 |
+----------+----------------+----------------+
9 rows in set (0.00 sec)
```

```
+----+-------------+----------+------------+------+---------------------------------------+---------+---------+-------+------+----------+----------------------------------------------+
| id | select_type | table    | partitions | type | possible_keys                         | key     | key_len | ref   | rows | filtered | Extra                                        |
+----+-------------+----------+------------+------+---------------------------------------+---------+---------+-------+------+----------+----------------------------------------------+
|  1 | SIMPLE      | revision | NULL       | ref  | PRIMARY,page_timestamp,user_timestamp | PRIMARY | 4       | const |   53 |    84.73 | Using where; Using temporary; Using filesort |
+----+-------------+----------+------------+------+---------------------------------------+---------+---------+-------+------+----------+----------------------------------------------+
```