### PR TITLE
SUS-3547 | SpecialRenameuser - preserve Special:UserRenameTool subpage parameter in URL and do not ask for a password when staff renames a different account

### DIFF
--- a/extensions/wikia/UserRenameTool/SpecialRenameuser_body.php
+++ b/extensions/wikia/UserRenameTool/SpecialRenameuser_body.php
@@ -58,7 +58,7 @@ class SpecialRenameuser extends SpecialPage {
 		}
 
 		if ( \RenameUserProcess::canUserChangeUsername( $requestorUser ) ) {
-			$this->renderForm( $requestorUser, $username );
+			$this->renderForm( $username );
 		} else {
 			$this->renderDisallow();
 		}
@@ -116,10 +116,9 @@ class SpecialRenameuser extends SpecialPage {
 	}
 
 	/**
-	 * @param User $requestorUser
-	 * @param User|null $oldUsername
+	 * @param string|null $oldUsername
 	 */
-	private function renderForm( User $requestorUser, $oldUsername = null ) {
+	private function renderForm( $oldUsername = null ) {
 		global $wgMaxNameChars;
 
 		$errors = [];
@@ -127,7 +126,7 @@ class SpecialRenameuser extends SpecialPage {
 		$warnings = [];
 		$showConfirm = false;
 		$showForm = true;
-		$selfRename = false;
+		$requestorUser = $this->getUser();
 		$canonicalNewUsername = '';
 		$out = $this->getOutput();
 		$request = $this->getRequest();
@@ -135,9 +134,13 @@ class SpecialRenameuser extends SpecialPage {
 		$newUsername = $requestData['newUsername'];
 		$isConfirmed = ( $requestData['isConfirmed'] === 'true' );
 
-		if ( !$oldUsername ) {
+		if ( is_null( $oldUsername ) ) {
 			$oldUsername = $requestorUser->getName();
 			$selfRename = true;
+		}
+		else {
+			// SUS-3547: staff mode, we want to rename a different user, not ourselves
+			$selfRename = $requestorUser->getName() === $oldUsername;
 		}
 
 		if ( $request->wasPosted() ) {

--- a/extensions/wikia/UserRenameTool/SpecialRenameuser_body.php
+++ b/extensions/wikia/UserRenameTool/SpecialRenameuser_body.php
@@ -66,7 +66,7 @@ class SpecialRenameuser extends SpecialPage {
 		return;
 	}
 
-	public static function validateData( array $data, User $user, bool $selfRename = true ) {
+	private static function validateData( array $data, User $user, bool $selfRename = true ) {
 		global $wgMaxNameChars;
 
 		$errorList = [];
@@ -115,6 +115,10 @@ class SpecialRenameuser extends SpecialPage {
 		return $errorList;
 	}
 
+	/**
+	 * @param User $requestorUser
+	 * @param User|null $oldUsername
+	 */
 	private function renderForm( User $requestorUser, $oldUsername = null ) {
 		global $wgMaxNameChars;
 
@@ -161,7 +165,7 @@ class SpecialRenameuser extends SpecialPage {
 		$template->set_vars( array_merge(
 			array_map( 'htmlspecialchars', $requestData ),
 			[
-				'submitUrl' => $this->getTitle()->getLocalURL(),
+				'submitUrl' => $this->getTitle($selfRename ? false : $oldUsername )->getLocalURL(),
 				'token' => $requestorUser->getEditToken(),
 				'maxUsernameLength' => $wgMaxNameChars,
 				'showForm' => $showForm,

--- a/extensions/wikia/UserRenameTool/templates/rename-form.tmpl.php
+++ b/extensions/wikia/UserRenameTool/templates/rename-form.tmpl.php
@@ -15,7 +15,7 @@
 					<label for='old-username'><?= wfMessage( 'userrenametool-old' )->inContentLanguage()->escaped(); ?></label>
 				</td>
 				<td class='mw-input'>
-					<input type="text" id="old-username" name="oldUsername" size="30" tabindex="2" disabled maxlength="<?= $maxUsernameLength; ?>" value="<?= $oldUsername; ?>"/>
+					<input id="old-username" name="oldUsername" size="30" tabindex="2" readonly maxlength="<?= $maxUsernameLength; ?>" value="<?= $oldUsername; ?>"/>
 				</td>
 			</tr>
 			<tr>

--- a/includes/User.php
+++ b/includes/User.php
@@ -3499,7 +3499,7 @@ class User implements JsonSerializable {
 	/**
 	 * Check to see if the given clear-text password is one of the accepted passwords
 	 * @param $password String: user password.
-	 * @return AuthResult: True if the given password is correct, otherwise False.
+	 * @return AuthResult
 	 */
 	public function checkPassword( $password, &$errorMessageKey = null ) {
 		$this->load();

--- a/includes/User.php
+++ b/includes/User.php
@@ -3499,7 +3499,7 @@ class User implements JsonSerializable {
 	/**
 	 * Check to see if the given clear-text password is one of the accepted passwords
 	 * @param $password String: user password.
-	 * @return Boolean: True if the given password is correct, otherwise False.
+	 * @return AuthResult: True if the given password is correct, otherwise False.
 	 */
 	public function checkPassword( $password, &$errorMessageKey = null ) {
 		$this->load();


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3547

* preserve Special:UserRenameTool subpage parameter in URL