### PR TITLE
IRIS-5334 | Use critical severity when discussions creation fails

### DIFF
--- a/extensions/wikia/Discussions/api/DiscussionsActivator.class.php
+++ b/extensions/wikia/Discussions/api/DiscussionsActivator.class.php
@@ -76,7 +76,7 @@ class DiscussionsActivator {
 	}
 
 	private function logAndThrowError( Exception $e ) {
-		$this->logger->error(
+		$this->logger->critical(
 			'DISCUSSIONS Creating site caused an error',
 			[
 				'siteId' => $this->cityId,


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/IRIS-5334

We want a JIRA ticket as soon as this process fails as it requires manual intervention.