### PR TITLE
SUS-3497 | LookupContribsCore - use events_local_users table instead of events

### DIFF
--- a/extensions/wikia/LookupContribs/SpecialLookupContribs_ajax.php
+++ b/extensions/wikia/LookupContribs/SpecialLookupContribs_ajax.php
@@ -55,10 +55,10 @@ class LookupContribsAjax {
 
 				if ( $lookupUser ) {
 					$result['sColumns'] = 'id,title,url,lastedit,edits,posts,lastpost,userrights,blocked';
-					$result['aaData'] = LookupContribsAjax::prepareLookupUserData( $activity['data'], $username );
+					$result['aaData'] = self::prepareLookupUserData( $activity['data'], $username );
 				} else {
-					$result['sColumns'] = 'id,dbname,title,url,lastedit,options';
-					$result['aaData'] = LookupContribsAjax::prepareLookupContribsData( $activity['data'] );
+					$result['sColumns'] = 'id,dbname,title,url,lastedit,options,edits';
+					$result['aaData'] = self::prepareLookupContribsData( $activity['data'] );
 				}
 			}
 		} else {
@@ -106,7 +106,9 @@ class LookupContribsAjax {
 	 *
 	 * @return array
 	 */
-	public static function prepareLookupContribsData( $activityData ) {
+	private static function prepareLookupContribsData( $activityData ) {
+		$wg = F::app()->wg;
+
 		$rows = [];
 		foreach ( $activityData as $row ) {
 			$rows[] = [
@@ -115,7 +117,8 @@ class LookupContribsAjax {
 				$row['title'], // wiki title
 				$row['url'], // wiki url
 				F::app()->wg->Lang->timeanddate( wfTimestamp( TS_MW, $row['lastedit'] ), true ), // last edited
-				'' // options
+				'', // options
+				$wg->ContLang->formatNum( $row['edits'] ),
 			];
 		}
 
@@ -129,7 +132,7 @@ class LookupContribsAjax {
 	 *
 	 * @return array
 	 */
-	public static function prepareLookupUserData( $activityData, $username ) {
+	private static function prepareLookupUserData( $activityData, $username ) {
 		$wg = F::app()->wg;
 
 		$rows = [];

--- a/extensions/wikia/LookupContribs/SpecialLookupContribs_ajax.php
+++ b/extensions/wikia/LookupContribs/SpecialLookupContribs_ajax.php
@@ -93,7 +93,10 @@ class LookupContribsAjax {
 			}
 		}
 
-		return json_encode( $result );
+		$response = new AjaxResponse( json_encode($result) );
+		$response->setContentType( 'application/json; charset=utf-8' );
+
+		return $response;
 	}
 
 	/**

--- a/extensions/wikia/LookupContribs/SpecialLookupContribs_body.php
+++ b/extensions/wikia/LookupContribs/SpecialLookupContribs_body.php
@@ -9,6 +9,8 @@ class LookupContribsPage extends SpecialPage {
 	 */
 	function  __construct() {
 		parent::__construct( "LookupContribs"  /*class*/, 'lookupcontribs' /*restriction*/ );
+
+		$this->mTitle = Title::makeTitle( NS_SPECIAL, 'LookupContribs' );
 	}
 
 	public function execute( $subpage ) {
@@ -23,7 +25,6 @@ class LookupContribsPage extends SpecialPage {
 		/**
 		 * initial output
 		 */
-		$this->mTitle = Title::makeTitle( NS_SPECIAL, 'LookupContribs' );
 		$this->mUsername = $wgRequest->getVal ( 'target', $subpage );
 		$this->mMode = $wgRequest->getVal ( 'mode' );
 		$this->mView = $wgRequest->getVal ( 'view' );

--- a/extensions/wikia/LookupContribs/SpecialLookupContribs_helper.php
+++ b/extensions/wikia/LookupContribs/SpecialLookupContribs_helper.php
@@ -146,7 +146,7 @@ class LookupContribsCore {
 	 * @throws MWException
 	 */
 	public function getUserActivity() {
-		global $wgMemc, $wgStatsDB, $wgStatsDBEnabled;
+		global $wgMemc, $wgSpecialsDB;
 
 		$memKey = $this->getUserActivityMemKey();
 		$data = $wgMemc->get( $memKey );
@@ -160,46 +160,36 @@ class LookupContribsCore {
 			'cnt' => 0
 		];
 
-		if ( empty( $wgStatsDBEnabled ) ) {
-			return $userActivity;
-		}
-
-		$dbr = wfGetDB( DB_SLAVE, 'stats', $wgStatsDB );
-		if ( is_null( $dbr ) ) {
-			return $userActivity;
-		}
+		$dbr = wfGetDB( DB_SLAVE, [], $wgSpecialsDB );
 
 		// bugId:6196
 		$excludedWikis = $this->getExclusionList();
 
 		$where = [
 			'user_id' => $this->mUserId,
-			'event_type' => [ 1, 2 ],
+			'edits > 0',
 		];
 
 		if ( !empty( $excludedWikis ) && is_array( $excludedWikis ) ) {
 			$where[] = 'wiki_id NOT IN (' . $dbr->makeList( $excludedWikis ) . ')';
 		}
 
-		$options = [
-			'GROUP BY' => 'wiki_id',
-			'ORDER BY' => 'last_edit DESC',
-		];
-
 		$res = $dbr->select(
-			'events',
+			'events_local_users',
 			[
 				'wiki_id',
-				'count(*) as edits',
-				'max(unix_timestamp(rev_timestamp)) as last_edit'
+				'edits',
+				'unix_timestamp(editdate) as last_edit'
 			],
 			$where,
 			__METHOD__,
-			$options
+			[
+				'ORDER BY' => 'editdate DESC'
+			]
 		);
 
 		$wikiaIds = [];
-		while ( $row = $dbr->fetchObject( $res ) ) {
+		foreach ( $res as $row ) {
 			$aItem = [
 				'id' => $row->wiki_id,
 				'lastedit' => $row->last_edit,
@@ -211,9 +201,6 @@ class LookupContribsCore {
 		}
 
 		$this->addWikiaInfo( $wikiaIds, $userActivity );
-
-		$dbr->freeResult( $res );
-
 		$wgMemc->set( $memKey, $userActivity, self::ACTIVITY_CACHE_TTL );
 
 		return $this->orderData( $userActivity );
@@ -243,16 +230,16 @@ class LookupContribsCore {
 	 * Clear the data cached by method getUserActivity
 	 */
 	public function clearUserActivityCache() {
-		$memKey = $this->getUserActivityMemKey();
-		F::app()->wg->Memc->delete( $memKey );
+		global $wgMemc;
+		$wgMemc->delete( $this->getUserActivityMemKey() );
 	}
 
 	private function getUserActivityMemKey() {
-		return wfSharedMemcKey( $this->mUserId, 'data' );
+		return wfSharedMemcKey( __CLASS__, $this->mUserId );
 	}
 
 	private function orderData( $userActivity ) {
-		\Wikia\Logger\WikiaLogger::instance()->info( 'SpecialLookupContribs debug', [
+		\Wikia\Logger\WikiaLogger::instance()->debug( 'SpecialLookupContribs debug', [
 			'mLimit' => $this->mLimit,
 			'mOffset' => $this->mOffset,
 			'mOrder' => $this->mOrder,
@@ -287,7 +274,7 @@ class LookupContribsCore {
 		}
 	}
 
-	function getExclusionList() {
+	private function getExclusionList() : array {
 		global $wgLookupContribsExcluded;
 
 		// Make sure there are exclusions defined
@@ -295,8 +282,7 @@ class LookupContribsCore {
 			return [];
 		}
 
-		// Start off by ignoring rows that have the undefined wiki ID of zero
-		$result = [ 0 ];
+		$result = [];
 
 		// Add any other wikis we want to exclude
 		foreach ( $wgLookupContribsExcluded as $excluded ) {

--- a/extensions/wikia/LookupContribs/SpecialLookupContribs_helper.php
+++ b/extensions/wikia/LookupContribs/SpecialLookupContribs_helper.php
@@ -182,10 +182,7 @@ class LookupContribsCore {
 				'unix_timestamp(editdate) as last_edit'
 			],
 			$where,
-			__METHOD__,
-			[
-				'ORDER BY' => 'editdate DESC'
-			]
+			__METHOD__
 		);
 
 		$wikiaIds = [];


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3497

### Old query, using `events`

```sql
mysql@geo-db-statsdb-slave.query.consul[stats]>SELECT wiki_id,count(*) as edits,max(unix_timestamp(rev_timestamp)) as last_edit FROM `events` WHERE user_id = 119245 AND event_type IN (1,2) GROUP BY wiki_id ORDER BY edits DESC limit 10;
+---------+-------+------------+
| wiki_id | edits | last_edit  |
+---------+-------+------------+
|    5915 | 13155 | 1512940039 |
| 1031256 |  1527 | 1510307622 |
|  217496 |   257 | 1495019314 |
|  492171 |   190 | 1408700730 |
|   83907 |    79 | 1277292534 |
| 1474483 |    71 | 1509726586 |
|     177 |    62 | 1509726174 |
|  203236 |    60 | 1508142143 |
|  443275 |    36 | 1348310553 |
|   41727 |    31 | 1461852249 |
+---------+-------+------------+
10 rows in set (0.02 sec)
```

### New query, using `events_local_users`

```sql
mysql@geo-db-specials-slave.query.consul[specials]>select wiki_id, edits, unix_timestamp(editdate) as last_edit from events_local_users where user_id = 119245 and edits > 0 order by edits desc limit 10;
+---------+-------+------------+
| wiki_id | edits | last_edit  |
+---------+-------+------------+
|    5915 | 13458 | 1512940039 |
| 1031256 |  1573 | 1510307622 |
|  217496 |   257 | 1495019314 |
|  492171 |   201 | 1513174032 |
| 1474483 |    73 | 1509726586 |
|     177 |    60 | 1509726174 |
|    4832 |    51 | 1251810959 |
|  203236 |    40 | 1508142143 |
|  443275 |    36 | 1513171046 |
|   41727 |    28 | 1461852249 |
+---------+-------+------------+
10 rows in set (0.00 sec)

--

mysql@geo-db-specials-slave.query.consul[specials]>explain select wiki_id, edits, unix_timestamp(editdate) as last_edit from events_local_users where user_id = 119245 and edits > 0 limit 10\G
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: events_local_users
   partitions: NULL
         type: range
possible_keys: user_edits
          key: user_edits
      key_len: 8
          ref: NULL
         rows: 86
     filtered: 100.00
        Extra: Using index condition
1 row in set, 1 warning (0.00 sec)
```

Let's skip an `ORDER BY` part and avoid filesort - sorting is performed by PHP code. 