### PR TITLE
SUS-3560 | RenameUserPagesTask - correctly handle user names with spaces

### DIFF
--- a/extensions/wikia/UserRenameTool/tests/RenameUserPagesTaskTest.php
+++ b/extensions/wikia/UserRenameTool/tests/RenameUserPagesTaskTest.php
@@ -6,8 +6,8 @@ use Wikia\Tasks\Tasks\RenameUserPagesTask;
  * @group Integration
  */
 class RenameUserPagesTaskTest extends WikiaDatabaseTest {
-	const OLD_USER_NAME = 'OldUserName';
-	const NEW_USER_NAME = 'NewUserName';
+	const OLD_USER_NAME = 'Old User Nąmę';
+	const NEW_USER_NAME = 'New User Name';
 
 	const WIKI_WITH_USER_PAGE = 177;
 	const WIKI_WITH_TALK_PAGE = 147;

--- a/extensions/wikia/UserRenameTool/tests/fixtures/expected_post_rename_state.yaml
+++ b/extensions/wikia/UserRenameTool/tests/fixtures/expected_post_rename_state.yaml
@@ -1,50 +1,50 @@
 page:
   - # moved content
     page_namespace: 2
-    page_title: NewUserName
+    page_title: New_User_Name
     page_is_redirect: 0
   -
     page_namespace: 2
-    page_title: NewUserName/User_subpage
+    page_title: New_User_Name/User_subpage
     page_is_redirect: 0
   -
     page_namespace: 3
-    page_title: NewUserName
+    page_title: New_User_Name
     page_is_redirect: 0
   -
     page_namespace: 500
-    page_title: NewUserName
+    page_title: New_User_Name
     page_is_redirect: 0
   -
     page_namespace: 500
-    page_title: NewUserName/Test_blog
+    page_title: New_User_Name/Test_blog
     page_is_redirect: 0
   -
     page_namespace: 1200
-    page_title: NewUserName
+    page_title: New_User_Name
     page_is_redirect: 0
   - # redirects from old titles
     page_namespace: 2
-    page_title: OldUserName
+    page_title: Old_User_Nąmę
     page_is_redirect: 1
   -
     page_namespace: 2
-    page_title: OldUserName/User_subpage
+    page_title: Old_User_Nąmę/User_subpage
     page_is_redirect: 1
   -
     page_namespace: 3
-    page_title: OldUserName
+    page_title: Old_User_Nąmę
     page_is_redirect: 1
   -
     page_namespace: 500
-    page_title: OldUserName
+    page_title: Old_User_Nąmę
     page_is_redirect: 1
   -
     page_namespace: 500
-    page_title: OldUserName/Test_blog
+    page_title: Old_User_Nąmę/Test_blog
     page_is_redirect: 1
   -
     page_namespace: 1200
-    page_title: OldUserName
+    page_title: Old_User_Nąmę
     page_is_redirect: 1
 

--- a/extensions/wikia/UserRenameTool/tests/fixtures/user_related_pages.yaml
+++ b/extensions/wikia/UserRenameTool/tests/fixtures/user_related_pages.yaml
@@ -2,7 +2,7 @@ page: # local page table
   - # user page
     page_id: 1
     page_namespace: 2
-    page_title: OldUserName
+    page_title: Old_User_Nąmę
     page_restrictions: ''
     page_random: 0
     page_latest: 1932
@@ -10,7 +10,7 @@ page: # local page table
   - # user page subpage
     page_id: 2
     page_namespace: 2
-    page_title: OldUserName/User_subpage
+    page_title: Old_User_Nąmę/User_subpage
     page_restrictions: ''
     page_random: 0
     page_latest: 15000
@@ -18,7 +18,7 @@ page: # local page table
   - # user talk page
     page_id: 3
     page_namespace: 3
-    page_title: OldUserName
+    page_title: Old_User_Nąmę
     page_restrictions: ''
     page_random: 0
     page_latest: 2040
@@ -26,7 +26,7 @@ page: # local page table
   - # user blog listing
     page_id: 4
     page_namespace: 500
-    page_title: OldUserName
+    page_title: Old_User_Nąmę
     page_restrictions: ''
     page_random: 0
     page_latest: 2060
@@ -34,7 +34,7 @@ page: # local page table
   - # user blog page
     page_id: 5
     page_namespace: 500
-    page_title: OldUserName/Test_blog
+    page_title: Old_User_Nąmę/Test_blog
     page_restrictions: ''
     page_random: 0
     page_latest: 4782
@@ -42,7 +42,7 @@ page: # local page table
   - # message wall
     page_id: 6
     page_namespace: 1200
-    page_title: OldUserName
+    page_title: Old_User_Nąmę
     page_restrictions: ''
     page_random: 0
     page_latest: 3600
@@ -52,32 +52,32 @@ pages: # global dataware.pages
     page_wikia_id: 177
     page_id: 8800
     page_namespace: 2
-    page_title: OldUserName
+    page_title: Old_User_Nąmę
   -
     page_wikia_id: 147
     page_id: 904
     page_namespace: 3
-    page_title: OldUserName
+    page_title: Old_User_Nąmę
   -
     page_wikia_id: 1770
     page_id: 10280
     page_namespace: 500
-    page_title: OldUserName
+    page_title: Old_User_Nąmę
   -
     page_wikia_id: 1240
     page_id: 3445
     page_namespace: 1200
-    page_title: OldUserName
+    page_title: Old_User_Nąmę
   - # main article page
     page_wikia_id: 1280
     page_id: 6512
     page_namespace: 0
-    page_title: OldUserName
+    page_title: Old_User_Nąmę
   - # talk page
     page_wikia_id: 1800
     page_id: 2871
     page_namespace: 1
-    page_title: OldUserName
+    page_title: Old_User_Nąmę
 revision: # latest revision needed for moving process
   -
     rev_id: 1932

--- a/includes/wikia/tasks/Tasks/RenameUserPagesTask.class.php
+++ b/includes/wikia/tasks/Tasks/RenameUserPagesTask.class.php
@@ -15,6 +15,19 @@ class RenameUserPagesTask extends BaseTask {
 	];
 
 	/**
+	 * Normalized user names use spaces, while article names in database
+	 * are stored with underscores instead of spaces.
+	 *
+	 * @see SUS-3560
+	 *
+	 * @param string $userName
+	 * @return string
+	 */
+	private static function normalizeUserName( string $userName ) : string {
+		return str_replace( ' ', '_', $userName );
+	}
+
+	/**
 	 * Get wikis where this user has an user page, user blog, Message Wall etc.
 	 * @param string $oldUserName
 	 * @return int[] array of wiki IDs
@@ -26,7 +39,7 @@ class RenameUserPagesTask extends BaseTask {
 
 		return $dbr->selectFieldValues( 'pages', 'page_wikia_id', [
 			'page_namespace' => static::NAMESPACES,
-			'page_title' => $oldUserName
+			'page_title' => self::normalizeUserName( $oldUserName )
 		], __METHOD__ , [ 'DISTINCT' ] );
 	}
 
@@ -38,6 +51,7 @@ class RenameUserPagesTask extends BaseTask {
 	 */
 	public function renameLocalPages( string $oldUserName, string $newUserName ) {
 		$dbr = wfGetDB( DB_SLAVE );
+		$oldUserName = self::normalizeUserName( $oldUserName );
 
 		$subPagesLikeQuery = $dbr->buildLike( "$oldUserName/", $dbr->anyString() );
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3560

User names like `Foo Bar` are stored in `wikicities.user` table with spaces. However, when database is queried for user pages across all wikis (`dataware.pages`) we need to replace spaces with underscores - as that's how MediaWiki normalises articles titles.