### PR TITLE
SUS-825: properly route tasks on sandboxes and preview / verify

### DIFF
--- a/includes/wikia/tasks/AsyncTaskList.class.php
+++ b/includes/wikia/tasks/AsyncTaskList.class.php
@@ -252,9 +252,9 @@ class AsyncTaskList {
 			if ( $wgWikiaEnvironment == WIKIA_ENV_DEV && preg_match( '/^dev-(.*?)$/', $host ) ) {
 				$executionRunner = ["http://tasks.{$wgDevDomain}/proxy.php"];
 			} elseif ($wgWikiaEnvironment == WIKIA_ENV_SANDBOX) {
-				$executionRunner = ["http://{$host}.community.wikia.com/extensions/wikia/Tasks/proxy/proxy.php"];
+				$executionRunner = ["http://community.{$host}.wikia.com/extensions/wikia/Tasks/proxy/proxy.php"];
 			} elseif (in_array($wgWikiaEnvironment, [WIKIA_ENV_PREVIEW, WIKIA_ENV_VERIFY])) {
-				$executionRunner = ["http://{$wgWikiaEnvironment}.community.wikia.com/extensions/wikia/Tasks/proxy/proxy.php"];
+				$executionRunner = ["http://community.{$wgWikiaEnvironment}.wikia.com/extensions/wikia/Tasks/proxy/proxy.php"];
 			} else { // in other environments or when apache isn't available, ssh into this exact node to execute
 				wfDebug( __METHOD__ . " - fallback to remote_shell execution mode on {$host}!\n" );
 


### PR DESCRIPTION
```json
{"wiki_id": "177", "force": true, "context": {"titleParams": []}, "executor": {"runner": ["http://sandbox-sus1.community.wikia.com/extensions/wikia/Tasks/proxy/proxy.php"], "app": "mediawiki", "method": "http"}}
```

InvalidResponseError('Empty response',)

The runner should be http://community.sandbox-sus1.wikia.com/extensions/wikia/Tasks/proxy/proxy.php

This prevents us from testing new, user rename-related, task on sandbox / http://celery-flower.sjc.k8s.wikia.net/task/mw-0CB3BCCA-1A86-4286-950A-29009CEE8D44