### PR TITLE
SUS-3535 | maintenance/tables.sql - page namespaces can not be negative

### DIFF
--- a/maintenance/tables.sql
+++ b/maintenance/tables.sql
@@ -100,7 +100,8 @@ CREATE TABLE /*_*/page (
   -- A page name is broken into a namespace and a title.
   -- The namespace keys are UI-language-independent constants,
   -- defined in includes/Defines.php
-  page_namespace int NOT NULL,
+  -- SUS-3535: page namespaces can not be negative
+  page_namespace int unsigned NOT NULL,
 
   -- The rest of the title, as text.
   -- Spaces are transformed into underscores in title storage.


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3535

Make it consistent with schema of `dataware.pages` and avoid:

```
Function: UpdateDatawarePages::updateDatawarePage
Error: 1264 Out of range value for column 'page_namespace' at row 1 (geo-db-archive-master.query.consul)
```

73 wikis were affected, articles with negative `page_namespace` values were either updated to be in `NS_MAIN` or simply dropped as their content was not reachable (there was no content).