### PR TITLE
SUS UserProfilePage - changed sum of created and edits to only edits

### DIFF
--- a/extensions/wikia/UserProfilePageV3/models/FavoriteWikisModel.class.php
+++ b/extensions/wikia/UserProfilePageV3/models/FavoriteWikisModel.class.php
@@ -69,7 +69,7 @@ class FavoriteWikisModel extends WikiaModel {
 			'rollup_wiki_user_events',
 			[
 				'wiki_id',
-				'SUM(creates + edits) AS edits',
+				'SUM(edits) AS edits',
 			],
 			$where,
 			__METHOD__,


### PR DESCRIPTION
We discovered edits already contains creates in the event stream, so we need to remove the sum