### PR TITLE
XW-3937 | do not escape edit mobile main page message

### DIFF
--- a/extensions/wikia/CuratedContent/CuratedContentHooks.class.php
+++ b/extensions/wikia/CuratedContent/CuratedContentHooks.class.php
@@ -76,7 +76,7 @@ class CuratedContentHooks {
 		if ( CuratedContentHelper::shouldDisplayToolButton() ) {
 			$contentActions['edit-mobile-main-page'] = [
 				'href' => '/main/edit?useskin=wikiamobile',
-				'text' => wfMessage( 'page-header-action-button-edit-mobile-main-page' )->escaped(),
+				'text' => wfMessage( 'page-header-action-button-edit-mobile-main-page' )->text(),
 				'id' => 'CuratedContentTool'
 			];
 		}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/XW-3937
@Wikia/x-wing

Message is escaped in the template with `htmlspecialchars` https://github.com/Wikia/app/blob/9e585479fb0bf4ad887fcf9c2bf2755c6da8b2e2/extensions/wikia/PageHeader/templates/PageHeaderController_actionButton.php#L28-L28