### PR TITLE
MAIN-12541: Fix message in HotSpots module

### DIFF
--- a/skins/oasis/modules/templates/HotSpots_Index.php
+++ b/skins/oasis/modules/templates/HotSpots_Index.php
@@ -47,7 +47,10 @@ if(count($data) == 5) {
 		$hotSpotSeverity++;
 	}
 	echo '</ul>';
-} else { echo wfMsgExt('myhome-hot-spots-brandnew', array('parseinline')); } ?>
+} else {
+	echo wfMsgExt('myhome-hot-spots-feed-empty', [ 'parseinline' ]);
+}
+?>
 
 
 </section>


### PR DESCRIPTION
Apparently, `myhome-hot-spots-brandnew` message doesn't exist (anymore?) and it looks like `myhome-hot-spots-feed-empty` is what was intended here. Currently, the module looks like ![this](https://i.imgur.com/JYd6xDw.png)
when there are no hot spots on the wiki.

This is further supported by the fact [searching](https://github.com/Wikia/app/search?q=myhome-hot-spots-brandnew) for the current message yields only the currently changed line and [searching](https://github.com/Wikia/app/search?q=myhome-hot-spots-feed-empty) for the message it's being changed to yields only the definition in i18n without any use in code.

Support ticket: [#359726](https://support.wikia-inc.com/hc/en-us/requests/359726) (under number 9)
Bug ticket: [MAIN-12541](https://wikia-inc.atlassian.net/browse/MAIN-12541)