### PR TITLE
MAIN-12557: mw.Title: Add missing dependency on jquery.byteLength

### DIFF
--- a/resources/Resources.php
+++ b/resources/Resources.php
@@ -542,7 +542,10 @@ return array(
 	),
 	'mediawiki.Title' => array(
 		'scripts' => 'resources/mediawiki/mediawiki.Title.js',
-		'dependencies' => 'mediawiki.util',
+		'dependencies' => array(
+			'jquery.byteLength',
+			'mediawiki.util',
+		),
 	),
 	'mediawiki.Uri' => array(
 		'scripts' => 'resources/mediawiki/mediawiki.Uri.js',


### PR DESCRIPTION
Backports https://github.com/wikimedia/mediawiki/commit/dc818654ab4d5ce933ffcdb612564b66cfa88a5a. This is a Monobook-specific fix, because `jquery.byteLength` is loaded by default on Oasis.

Support ticket: [#359726](https://support.wikia-inc.com/hc/en-us/requests/359726) (under number 8)
Bug ticket: [MAIN-12557](https://wikia-inc.atlassian.net/browse/MAIN-12557)
Phabricator: [T56977](https://phabricator.wikimedia.org/T56977)