### PR TITLE
XW-4466: Use inline wrapper for template transclusions not at start of line

### DIFF
--- a/includes/parser/Preprocessor_DOM.php
+++ b/includes/parser/Preprocessor_DOM.php
@@ -20,6 +20,8 @@ class Preprocessor_DOM implements Preprocessor {
 
 	const CACHE_VERSION = 1;
 
+	const TEMPLATE_BLOCK_CONTEXT_PRECEDING_CHARACTER_SET = [ PHP_EOL, '}' ];
+
 	function __construct( $parser ) {
 		$this->parser = $parser;
 		$mem = ini_get( 'memory_limit' );
@@ -595,13 +597,21 @@ class Preprocessor_DOM implements Preprocessor {
 
 				# we need to add to stack only if opening brace count is enough for one of the rules
 				if ( $count >= $rule['min'] ) {
+					$precedingCharacter = $text[$i-1];
+
 					# Add it to the stack
 					$piece = array(
 						'open' => $curChar,
 						'close' => $rule['end'],
 						'count' => $count,
-						'lineStart' => ($i > 0 && $text[$i-1] == "\n"),
+						'lineStart' => ($i > 0 && $precedingCharacter == "\n"),
 					);
+
+					if ( $curChar === '{' ) {
+						$piece['isBlockContext'] =
+							$i === 0 || in_array( $precedingCharacter,
+								static::TEMPLATE_BLOCK_CONTEXT_PRECEDING_CHARACTER_SET );
+					}
 
 					$stack->push( $piece );
 					$accum =& $stack->getAccum();
@@ -686,6 +696,10 @@ class Preprocessor_DOM implements Preprocessor {
 						$attr = ' lineStart="1"';
 					} else {
 						$attr = '';
+					}
+
+					if ( !empty( $piece->isBlockContext ) ) {
+						$attr .= ' isBlockContext="1"';
 					}
 
 					# RTE (Rich Text Editor) - begin
@@ -874,7 +888,8 @@ class PPDStackElement {
 		$close,     	    // Matching closing character
 		$count,             // Number of opening characters found (number of "=" for heading)
 		$parts,             // Array of PPDPart objects describing pipe-separated parts.
-		$lineStart;         // True if the open char appeared at the start of the input line. Not set for headings.
+		$lineStart,         // True if the open char appeared at the start of the input line. Not set for headings.
+		$isBlockContext;
 
 	var $partClass = 'PPDPart';
 
@@ -1173,6 +1188,8 @@ class PPFrame_DOM implements PPFrame {
 						$newIterator = $this->virtualBracketedImplode( '{{', '|', '}}', $title, $parts );
 					} else {
 						$lineStart = $contextNode->getAttribute( 'lineStart' );
+						$isBlockContext = $contextNode->hasAttribute( 'isBlockContext' );
+
 						$params = array(
 							'title' => new PPNode_DOM( $title ),
 							'parts' => new PPNode_DOM( $parts ),
@@ -1207,7 +1224,7 @@ class PPFrame_DOM implements PPFrame {
 							];
 
 							// XW-4466: For template transclusions that are not on their own line, use an inline wrapper
-							if ( $lineStart ) {
+							if ( $isBlockContext ) {
 								$out .= Html::rawElement( 'div', $attributes, PHP_EOL . $ret['text'] );
 							} else {
 								$out .= Html::rawElement( 'span', $attributes, $ret['text'] );

--- a/includes/parser/Preprocessor_DOM.php
+++ b/includes/parser/Preprocessor_DOM.php
@@ -1198,13 +1198,20 @@ class PPFrame_DOM implements PPFrame {
 								'placeholder' => 1
 							];
 
-							$out .= Html::rawElement( 'div', [
+							$attributes = [
 								'class' => "placeholder placeholder-double-brackets",
 								'data-rte-instance' => RTE::getInstanceId(),
 								'data-rte-meta' => RTEReverseParser::encodeRTEData( $rteData ),
 								'type' => 'double-brackets',
 								'contenteditable' => 'false',
-							], PHP_EOL . $ret['text'] );
+							];
+
+							// XW-4466: For template transclusions that are not on their own line, use an inline wrapper
+							if ( $lineStart ) {
+								$out .= Html::rawElement( 'div', $attributes, PHP_EOL . $ret['text'] );
+							} else {
+								$out .= Html::rawElement( 'span', $attributes, $ret['text'] );
+							}
 						} else {
 							$out .= $ret['text'];
 						}


### PR DESCRIPTION
Assume inline context when a template transclusion is found at places other than the start of a line, and generate wrapper tag accordingly

https://wikia-inc.atlassian.net/browse/XW-4466