### PR TITLE
SUS-3471 | we no longer use MediaWiki-based jobs dispatcher

### DIFF
--- a/includes/SiteStats.php
+++ b/includes/SiteStats.php
@@ -162,23 +162,8 @@ class SiteStats {
 	 * @return int
 	 */
 	static function jobs() {
-		if ( !isset( self::$jobs ) ) {
-			// wikia change start, eloy
-			global $wgMemc;
-			$key = wfMemcKey( 'SiteStats', 'jobs' );
-			self::$jobs = $wgMemc->get( $key );
-			if ( !self::$jobs ) {
-			// wikia change end
-				$dbr = wfGetDB( DB_SLAVE );
-				self::$jobs = $dbr->estimateRowCount( 'job' );
-				/* Zero rows still do single row read for row that doesn't exist, but people are annoyed by that */
-				if ( self::$jobs == 1 ) {
-					self::$jobs = 0;
-				}
-				$wgMemc->set( $key, self::$jobs, 3600 );
-			}
-		}
-		return self::$jobs;
+		// SUS-3471 | Wikia change - we no longer use MediaWiki-based jobs dispatcher
+		return 0;
 	}
 
 	/**


### PR DESCRIPTION
Avoid the following DB error on newly created wikis that do not have job table created anymore.

```sql
A database error has occurred.  Did you forget to run maintenance/update.php after upgrading?  See: https://www.mediawiki.org/wiki/Manual:Upgrading#Run_the_update_script
Query: EXPLAIN SELECT  *  FROM `job`
Function: DatabaseMysqlBase::estimateRowCount
Error: 1146 Table 'tassomine.job' doesn't exist (geo-db-g-slave.query.consul)
```