### PR TITLE
XW-4482: Hide placeholders inside template transclusions

### DIFF
--- a/extensions/wikia/RTE/css/content.scss
+++ b/extensions/wikia/RTE/css/content.scss
@@ -243,3 +243,8 @@ li .placeholder-double-brackets {
 p[data-rte-filler="true"] {
 	display: none;
 }
+
+/* XW-4482: Hide placeholders inside template transclusions */
+.placeholder-double-brackets .placeholder {
+	display: none;
+}


### PR DESCRIPTION
Placeholder puzzles that appear inside template transclusions bring no value, since they are already inside a non-contenteditable wrapper - hide them to avoid confusion.

https://wikia-inc.atlassian.net/browse/XW-4482