### PR TITLE
SUS-3605 | Decomission statsdb database cluster - move city_used_tags to specials cluster

### DIFF
--- a/extensions/wikia/TagsReport/SpecialTagsReport_body.php
+++ b/extensions/wikia/TagsReport/SpecialTagsReport_body.php
@@ -144,13 +144,9 @@ class TagsReportPage extends SpecialPage {
 			wfMemcKey( __METHOD__, $tag ),
 			WikiaResponse::CACHE_SHORT,
 			function() use ( $tag ) {
-				global $wgCityId, $wgStatsDB, $wgStatsDBEnabled;
+				global $wgCityId, $wgSpecialsDB;
 
-				if ( empty( $wgStatsDBEnabled ) ) {
-					return [];
-				}
-
-				$dbs = wfGetDB( DB_SLAVE, [], $wgStatsDB );
+				$dbs = wfGetDB( DB_SLAVE, [], $wgSpecialsDB );
 				$res = $dbs->select(
 					self::TABLE,
 					[ ' ct_namespace', 'ct_page_id' ],
@@ -180,13 +176,9 @@ class TagsReportPage extends SpecialPage {
 	 * @throws MWException
 	 */
 	private function getGenDate() {
-		global $wgLang, $wgStatsDB, $wgCityId, $wgStatsDBEnabled;
+		global $wgLang, $wgSpecialsDB, $wgCityId;
 
-		if ( empty( $wgStatsDBEnabled ) ) {
-			return [];
-		}
-
-		$dbs = wfGetDB( DB_SLAVE, [], $wgStatsDB );
+		$dbs = wfGetDB( DB_SLAVE, [], $wgSpecialsDB );
 		$ts = $dbs->selectField(
 			self::TABLE,
 			'max(ct_timestamp) as ts',

--- a/extensions/wikia/TagsReport/api/WikiaApiTagsReport.class.php
+++ b/extensions/wikia/TagsReport/api/WikiaApiTagsReport.class.php
@@ -85,7 +85,7 @@ class WikiaApiTagsReport extends ApiQueryBase {
 	}
 
 	/**
-	 * Get connection to the stats DB slave
+	 * Get connection to the specials DB
 	 *
 	 * @return DatabaseBase
 	 */


### PR DESCRIPTION
See #14494 (missed two places where `statsdb` was still used)