### PR TITLE
SUS-3472: Update Special:ListUsers with MW background task

### DIFF
--- a/extensions/wikia/Listusers/SpecialListusers.php
+++ b/extensions/wikia/Listusers/SpecialListusers.php
@@ -12,54 +12,60 @@ if ( !defined( 'MEDIAWIKI' ) ) {
 	exit( 1 ) ;
 }
 
-$wgExtensionCredits['specialpage'][] = array(
+$GLOBALS['wgExtensionCredits']['specialpage'][] = [
 	"name" => "Local users",
 	"description-msg" => "listusers-desc",
 	"author" => "Piotr Molski",
-	'url' => 'https://github.com/Wikia/app/tree/dev/extensions/wikia/Listusers'
-);
+	'url' => 'https://github.com/Wikia/app/tree/dev/extensions/wikia/Listusers',
+];
 
 /**
  * Messages
  */
-$wgExtensionMessagesFiles['Listusers'] = __DIR__ . '/SpecialListusers.i18n.php';
-$wgExtensionMessagesFiles['ListusersAlias'] = __DIR__ . '/SpecialListusers.alias.php';
+$GLOBALS['wgExtensionMessagesFiles']['Listusers'] = __DIR__ . '/SpecialListusers.i18n.php';
+$GLOBALS['wgExtensionMessagesFiles']['ListusersAlias'] = __DIR__ . '/SpecialListusers.alias.php';
+
+$GLOBALS['wgAutoloadClasses']['EditCountService'] = __DIR__ . '/update/EditCountService.php';
+$GLOBALS['wgAutoloadClasses']['ListUsersUpdate'] = __DIR__ . '/update/ListUsersUpdate.php';
+$GLOBALS['wgAutoloadClasses']['ListUsersEditUpdate'] = __DIR__ . '/update/ListUsersEditUpdate.php';
+$GLOBALS['wgAutoloadClasses']['UpdateListUsersTask'] = __DIR__ . '/update/UpdateListUsersTask.php';
 
 /**
  * Helpers
  */
-$wgAutoloadClasses['ListusersData']  = __DIR__ . '/SpecialListusers_helper.php';
+$GLOBALS['wgAutoloadClasses']['ListusersData']  = __DIR__ . '/SpecialListusers_helper.php';
 
 /**
  * Hooks
  */
-$wgAutoloadClasses['ListusersAjax'] = __DIR__ . '/SpecialListusers_ajax.php';
-$wgAutoloadClasses['ListusersHooks'] = __DIR__ . '/SpecialListusers_hooks.php';
+$GLOBALS['wgAutoloadClasses']['ListusersAjax'] = __DIR__ . '/SpecialListusers_ajax.php';
+$GLOBALS['wgAutoloadClasses']['ListusersHooks'] = __DIR__ . '/SpecialListusers_hooks.php';
 
-$wgHooks['SpecialPage_initList'][] = 'ListusersHooks::ActiveUsers';
-$wgAjaxExportList[] = 'ListusersAjax::axShowUsers';
-$wgAjaxExportList[] = 'ListusersAjax::axSuggestUsers';
+$GLOBALS['wgHooks']['SpecialPage_initList'][] = 'ListusersHooks::ActiveUsers';
+$GLOBALS['wgAjaxExportList'][] = 'ListusersAjax::axShowUsers';
+$GLOBALS['wgAjaxExportList'][] = 'ListusersAjax::axSuggestUsers';
 
-$wgHooks['UserRights'][] = 'ListusersHooks::updateUserRights';
+$GLOBALS['wgHooks']['UserRights'][] = 'ListusersHooks::updateUserRights';
+$GLOBALS['wgHooks']['NewRevisionFromEditComplete'][] = 'ListusersHooks::doEditUpdate';
 
 /**
  * Special pages
  */
-$wgAutoloadClasses['Listusers'] = __DIR__ . '/SpecialListusers_body.php';
-$wgAutoloadClasses['SpecialListStaff'] = __DIR__ . '/SpecialListusers_body.php';
-$wgAutoloadClasses['SpecialListVstf'] = __DIR__ . '/SpecialListusers_body.php';
-$wgAutoloadClasses['SpecialListHelpers'] = __DIR__ . '/SpecialListusers_body.php';
+$GLOBALS['wgAutoloadClasses']['Listusers'] = __DIR__ . '/SpecialListusers_body.php';
+$GLOBALS['wgAutoloadClasses']['SpecialListStaff'] = __DIR__ . '/SpecialListusers_body.php';
+$GLOBALS['wgAutoloadClasses']['SpecialListVstf'] = __DIR__ . '/SpecialListusers_body.php';
+$GLOBALS['wgAutoloadClasses']['SpecialListHelpers'] = __DIR__ . '/SpecialListusers_body.php';
 
-$wgSpecialPages['Listusers'] = 'Listusers';
-$wgSpecialPages['Liststaff'] = 'SpecialListStaff';
-$wgSpecialPages['Listvstf'] = 'SpecialListVstf';
-$wgSpecialPages['Listhelpers'] = 'SpecialListHelpers';
+$GLOBALS['wgSpecialPages']['Listusers'] = 'Listusers';
+$GLOBALS['wgSpecialPages']['Liststaff'] = 'SpecialListStaff';
+$GLOBALS['wgSpecialPages']['Listvstf'] = 'SpecialListVstf';
+$GLOBALS['wgSpecialPages']['Listhelpers'] = 'SpecialListHelpers';
 
 // Only add Listusers to Special:SpecialPages
-$wgSpecialPageGroups['Listusers'] = 'users';
+$GLOBALS['wgSpecialPageGroups']['Listusers'] = 'users';
 
 // Resources Loader module
-$wgResourceModules['ext.wikia.ListUsers'] = [
+$GLOBALS['wgResourceModules']['ext.wikia.ListUsers'] = [
 	'scripts' => [
 		'js/table.js'
 	],

--- a/extensions/wikia/Listusers/SpecialListusers_helper.php
+++ b/extensions/wikia/Listusers/SpecialListusers_helper.php
@@ -23,7 +23,6 @@ class ListusersData {
 	private $mOffset;
 	private $mOrder;
 	private $mOrderOptions;
-	private $mUseKey;
 	private $mDBh;
 
 	const TABLE = 'events_local_users';
@@ -38,12 +37,6 @@ class ListusersData {
 			'groups' 	=> array( 'all_groups %s', 'cnt_groups %s'),
 			'revcnt' 	=> array( 'edits %s' ),
 			'dtedit' 	=> array( 'editdate %s' )
-		);
-
-		$this->mUseKeyOptions = array(
-			'groups' 	=> '',
-			'revcnt' 	=> 'wiki_edits_by_user',
-			'dtedit' 	=> 'wiki_editdate_user_edits'
 		);
 	}
 
@@ -81,8 +74,6 @@ class ListusersData {
 					foreach ( $this->mOrderOptions[$orderName] as $orderStr ) {
 						$this->mOrder[] = sprintf( $orderStr, $orderDesc );
 					}
-					// disable mUseKey temporarily due to PLATFORM-1174 MAIN-4386
-					// $this->mUseKey = $this->mUseKeyOptions[$orderName];
 				}
 			}
 		}
@@ -185,13 +176,12 @@ class ListusersData {
 				$sk = $context->getSkin();
 				/* select records */
 				$oRes = $dbs->select(
-					array( self::TABLE . ( ($this->mUseKey) ? ' use key('.$this->mUseKey.')' : '' ) ),
+					array( self::TABLE ),
 					array(
 						'user_id',
 						'cnt_groups',
 						'all_groups',
 						'edits',
-						'user_is_blocked',
 						'last_revision',
 						'editdate',
 						'ifnull(last_revision, 0) as max_rev',
@@ -208,7 +198,6 @@ class ListusersData {
 
 				$data['data'] = array();
 				while ( $oRow = $dbs->fetchObject( $oRes ) ) {
-					// SUS-2772: don't do a DB query for every row
 					$oUser = User::newFromId( $oRow->user_id );
 
 					/* groups */
@@ -268,7 +257,7 @@ class ListusersData {
 						'groups_nbr' 		=> $oRow->cnt_groups,
 						'groups' 			=> $group,
 						'rev_cnt' 			=> $oRow->edits,
-						'blcked'			=> $oRow->user_is_blocked,
+						'blcked'			=> $oUser->isBlocked( true, false ),
 						'links'				=> "(" . implode( ") &#183; (", $links ) . ")",
 						'last_edit_page' 	=> null,
 						'last_edit_diff'	=> null,

--- a/extensions/wikia/Listusers/SpecialListusers_hooks.php
+++ b/extensions/wikia/Listusers/SpecialListusers_hooks.php
@@ -26,19 +26,17 @@ class ListusersHooks {
 
 
 	static public function updateUserRights( User $user ) {
-		if ( !$user->isAllowed( 'bot' ) ) {
-			$listUsersUpdate = new ListUsersUpdate();
-			$listUsersUpdate->setUserId( $user->getId() );
-			$listUsersUpdate->setUserGroups( $user->getGroups() );
+		$listUsersUpdate = new ListUsersUpdate();
+		$listUsersUpdate->setUserId( $user->getId() );
+		$listUsersUpdate->setUserGroups( $user->getGroups() );
 
-			$task = UpdateListUsersTask::newLocalTask();
-			$task->call( 'updateUserGroups', $listUsersUpdate );
-			$task->queue();
-		}
+		$task = UpdateListUsersTask::newLocalTask();
+		$task->call( 'updateUserGroups', $listUsersUpdate );
+		$task->queue();
 	}
 
 	public static function doEditUpdate( WikiPage $wikiPage, Revision $revision, $baseRevId, User $user ) {
-		if ( $user->isAnon() || $user->isAllowed( 'bot' ) ) {
+		if ( $user->isAnon() ) {
 			return;
 		}
 

--- a/extensions/wikia/Listusers/SpecialListusers_hooks.php
+++ b/extensions/wikia/Listusers/SpecialListusers_hooks.php
@@ -26,17 +26,19 @@ class ListusersHooks {
 
 
 	static public function updateUserRights( User $user ) {
-		$listUsersUpdate = new ListUsersUpdate();
-		$listUsersUpdate->setUserId( $user->getId() );
-		$listUsersUpdate->setUserGroups( $user->getGroups() );
+		if ( !$user->isAllowed( 'bot' ) ) {
+			$listUsersUpdate = new ListUsersUpdate();
+			$listUsersUpdate->setUserId( $user->getId() );
+			$listUsersUpdate->setUserGroups( $user->getGroups() );
 
-		$task = UpdateListUsersTask::newLocalTask();
-		$task->call( 'updateUserGroups', $listUsersUpdate );
-		$task->queue();
+			$task = UpdateListUsersTask::newLocalTask();
+			$task->call( 'updateUserGroups', $listUsersUpdate );
+			$task->queue();
+		}
 	}
 
 	public static function doEditUpdate( WikiPage $wikiPage, Revision $revision, $baseRevId, User $user ) {
-		if ( $user->isAnon() ) {
+		if ( $user->isAnon() || $user->isAllowed( 'bot' ) ) {
 			return;
 		}
 

--- a/extensions/wikia/Listusers/tests/UpdateListUsersTaskIntegrationTest.php
+++ b/extensions/wikia/Listusers/tests/UpdateListUsersTaskIntegrationTest.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * @group Integration
+ */
+class UpdateListUsersTaskIntegrationTest extends WikiaDatabaseTest {
+	const TEST_WIKI_ID = 1299;
+
+	const USER_ID_WITH_DATA = 1;
+	const USER_ID_WITHOUT_DATA = 2;
+
+	/** @var EditCountService|PHPUnit_Framework_MockObject_MockObject $editCountServiceMock */
+	private $editCountServiceMock;
+
+	/** @var UpdateListUsersTask $updateListUsersTask */
+	private $updateListUsersTask;
+
+	/** @var DatabaseBase $dbr */
+	private $dbr;
+
+	protected function setUp() {
+		parent::setUp();
+		require_once __DIR__ . '/../SpecialListusers.php';
+
+		$this->editCountServiceMock = $this->createMock( EditCountService::class );
+		$this->updateListUsersTask = ( new UpdateListUsersTask() )->wikiId( static::TEST_WIKI_ID );
+
+		// UserStatsService does not work with SQLite - use mock instead
+		$reflEditCountService = new ReflectionProperty( UpdateListUsersTask::class, 'editCountService' );
+		$reflEditCountService->setAccessible( true );
+		$reflEditCountService->setValue( $this->updateListUsersTask, $this->editCountServiceMock );
+
+		$this->dbr = wfGetDB( DB_SLAVE );
+	}
+
+	public function testEditUpdateInsertsNewDataForUser() {
+		$this->editCountServiceMock->expects( $this->any() )
+			->method( 'getEditCount' )
+			->with( static::USER_ID_WITHOUT_DATA )
+			->willReturn( 2500 );
+
+		$this->updateListUsersTask->updateEditInformation( [
+			'userId' => static::USER_ID_WITHOUT_DATA,
+			'userGroups' => [ 'sysop', 'bureaucrat' ],
+			'latestRevisionTimestamp' => '20171110000000',
+			'latestRevisionId' => 3
+		] );
+
+		$row = $this->selectUserRow( static::USER_ID_WITHOUT_DATA );
+
+		$this->assertEquals( 2500, $row->edits );
+		$this->assertEquals( '2017-11-10 00:00:00', $row->editdate );
+		$this->assertEquals( 3, $row->last_revision );
+
+		$this->assertEquals( 2, $row->cnt_groups );
+		$this->assertEquals( 'bureaucrat', $row->single_group );
+		$this->assertEquals( 'sysop;bureaucrat', $row->all_groups );
+	}
+
+	public function testEditUpdateUpdatesExistingDataForUser() {
+		$this->editCountServiceMock->expects( $this->any() )
+			->method( 'getEditCount' )
+			->with( static::USER_ID_WITH_DATA )
+			->willReturn( 1200 );
+
+		$this->updateListUsersTask->updateEditInformation( [
+			'userId' => static::USER_ID_WITH_DATA,
+			'userGroups' => [ 'rollback' ],
+			'latestRevisionTimestamp' => '20100101000000',
+			'latestRevisionId' => 2
+		] );
+
+		$row = $this->selectUserRow( static::USER_ID_WITH_DATA );
+
+		$this->assertEquals( 1200, $row->edits );
+		$this->assertEquals( '2010-01-01 00:00:00', $row->editdate );
+		$this->assertEquals( 2, $row->last_revision );
+
+		$this->assertEquals( 1, $row->cnt_groups );
+		$this->assertEquals( 'rollback', $row->single_group );
+		$this->assertEquals( 'rollback', $row->all_groups );
+	}
+
+	public function testGroupsUpdateInsertsNewDataForUser() {
+		$this->editCountServiceMock->expects( $this->any() )
+			->method( 'getEditCount' )
+			->with( static::USER_ID_WITHOUT_DATA )
+			->willReturn( 900 );
+
+		$this->updateListUsersTask->updateUserGroups( [
+			'userId' => static::USER_ID_WITHOUT_DATA,
+			'userGroups' => [ 'sysop', 'bureaucrat', 'chatmoderator' ],
+		] );
+
+		$row = $this->selectUserRow( static::USER_ID_WITHOUT_DATA );
+
+		$this->assertEquals( 900, $row->edits );
+		$this->assertEquals( '2011-01-01 00:00:00', $row->editdate );
+		$this->assertEquals( 3, $row->last_revision );
+
+		$this->assertEquals( 3, $row->cnt_groups );
+		$this->assertEquals( 'chatmoderator', $row->single_group );
+		$this->assertEquals( 'sysop;bureaucrat;chatmoderator', $row->all_groups );
+	}
+
+	public function testGroupsUpdateUpdatesExistingDataForUser() {
+		$this->editCountServiceMock->expects( $this->never() )
+			->method( 'getEditCount' );
+
+		$this->updateListUsersTask->updateUserGroups( [
+			'userId' => static::USER_ID_WITH_DATA,
+			'userGroups' => [ 'chatmoderator' ],
+		] );
+
+		$row = $this->selectUserRow( static::USER_ID_WITH_DATA );
+
+		$this->assertEquals( 1, $row->edits );
+		$this->assertEquals( '2009-01-01 00:00:00', $row->editdate );
+		$this->assertEquals( 1, $row->last_revision );
+
+		$this->assertEquals( 1, $row->cnt_groups );
+		$this->assertEquals( 'chatmoderator', $row->single_group );
+		$this->assertEquals( 'chatmoderator', $row->all_groups );
+	}
+
+	private function selectUserRow( int $userId ){
+		return $this->dbr->selectRow( 'events_local_users', '*', [ 'wiki_id' => static::TEST_WIKI_ID, 'user_id' => $userId ] );
+	}
+
+	protected function getDataSet() {
+		return $this->createYamlDataSet( __DIR__ . '/fixtures/update_task.yaml' );
+	}
+}

--- a/extensions/wikia/Listusers/tests/UpdateListUsersTaskIntegrationTest.php
+++ b/extensions/wikia/Listusers/tests/UpdateListUsersTaskIntegrationTest.php
@@ -22,12 +22,9 @@ class UpdateListUsersTaskIntegrationTest extends WikiaDatabaseTest {
 		require_once __DIR__ . '/../SpecialListusers.php';
 
 		$this->editCountServiceMock = $this->createMock( EditCountService::class );
-		$this->updateListUsersTask = ( new UpdateListUsersTask() )->wikiId( static::TEST_WIKI_ID );
-
-		// UserStatsService does not work with SQLite - use mock instead
-		$reflEditCountService = new ReflectionProperty( UpdateListUsersTask::class, 'editCountService' );
-		$reflEditCountService->setAccessible( true );
-		$reflEditCountService->setValue( $this->updateListUsersTask, $this->editCountServiceMock );
+		$this->updateListUsersTask =
+			( new UpdateListUsersTask( $this->editCountServiceMock ) )
+				->wikiId( static::TEST_WIKI_ID );
 
 		$this->dbr = wfGetDB( DB_SLAVE );
 	}
@@ -122,7 +119,7 @@ class UpdateListUsersTaskIntegrationTest extends WikiaDatabaseTest {
 		$this->assertEquals( 'chatmoderator', $row->all_groups );
 	}
 
-	private function selectUserRow( int $userId ){
+	private function selectUserRow( int $userId ) {
 		return $this->dbr->selectRow( 'events_local_users', '*', [ 'wiki_id' => static::TEST_WIKI_ID, 'user_id' => $userId ] );
 	}
 

--- a/extensions/wikia/Listusers/tests/fixtures/update_task.yaml
+++ b/extensions/wikia/Listusers/tests/fixtures/update_task.yaml
@@ -1,0 +1,58 @@
+user:
+  - user_id: 1
+    user_name: 'KossuthLajos'
+    user_real_name: ''
+    user_email: 'kossuth.lajos@lajoskossuth.hu'
+    user_touched: '20110101000000'
+    user_token: 'loremipsum'
+    user_email_authenticated: '20101102000000'
+    user_email_token: 'dolorsitamet'
+    user_email_token_expires: '20120301120000'
+    user_registration: '20090604060000'
+    user_editcount: 2500
+    user_birthdate:
+  - user_id: 2
+    user_name: 'FerencJozsef'
+    user_real_name: ''
+    user_email: 'ferenc.jozsef@kuk.at'
+    user_touched: '20110101000000'
+    user_token: 'loremipsum'
+    user_email_authenticated: '20101102000000'
+    user_email_token: 'dolorsitamet'
+    user_email_token_expires: '20120301120000'
+    user_registration: '20090604060000'
+    user_editcount: 2500
+    user_birthdate:
+revision:
+  - rev_id: 1
+    rev_page: 1
+    rev_text_id: 1
+    rev_comment: ''
+    rev_user: 1
+    rev_user_text: KossuthLajos
+    rev_timestamp: '20090101000000'
+  - rev_id: 2
+    rev_page: 1
+    rev_parent_id: 1
+    rev_text_id: 2
+    rev_comment: ''
+    rev_user: 1
+    rev_user_text: ''
+    rev_timestamp: '20100101000000'
+  - rev_id: 3
+    rev_page: 2
+    rev_text_id: 3
+    rev_comment: ''
+    rev_user: 2
+    rev_user_text: ''
+    rev_timestamp: '20110101000000'
+events_local_users:
+  - wiki_id: 1299
+    user_id: 1
+    edits: 1
+    editdate: '2009-01-01 00:00:00'
+    last_revision: 1
+    cnt_groups: 0
+    single_group: ''
+    all_groups: ''
+    user_is_closed: 0

--- a/extensions/wikia/Listusers/update/EditCountService.php
+++ b/extensions/wikia/Listusers/update/EditCountService.php
@@ -1,0 +1,10 @@
+<?php
+
+/**
+ * Wrapper for {@see UserStatsService} to work around incompatibilities with SQLite
+ */
+class EditCountService {
+	public function getEditCount( int $userId ): int {
+		return ( new UserStatsService( $userId ) )->getEditCountWiki();
+	}
+}

--- a/extensions/wikia/Listusers/update/ListUsersEditUpdate.php
+++ b/extensions/wikia/Listusers/update/ListUsersEditUpdate.php
@@ -1,0 +1,48 @@
+<?php
+
+class ListUsersEditUpdate extends ListUsersUpdate  {
+	use JsonDeserializerTrait;
+
+	/** @var int $latestRevisionId */
+	private $latestRevisionId;
+
+	/** @var string $latestRevisionTimestamp */
+	private $latestRevisionTimestamp;
+
+	/**
+	 * @return int
+	 */
+	public function getLatestRevisionId(): int {
+		return $this->latestRevisionId;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getLatestRevisionTimestamp(): string {
+		return $this->latestRevisionTimestamp;
+	}
+
+	/**
+	 * @param int $latestRevisionId
+	 */
+	public function setLatestRevisionId( int $latestRevisionId ) {
+		$this->latestRevisionId = $latestRevisionId;
+	}
+
+	/**
+	 * @param string $latestRevisionTimestamp
+	 */
+	public function setLatestRevisionTimestamp( string $latestRevisionTimestamp ) {
+		$this->latestRevisionTimestamp = $latestRevisionTimestamp;
+	}
+
+	public function jsonSerialize() {
+		return [
+			'userId' => $this->userId,
+			'userGroups' => $this->userGroups,
+			'latestRevisionId' => $this->latestRevisionId,
+			'latestRevisionTimestamp' => $this->latestRevisionTimestamp
+		];
+	}
+}

--- a/extensions/wikia/Listusers/update/ListUsersUpdate.php
+++ b/extensions/wikia/Listusers/update/ListUsersUpdate.php
@@ -1,0 +1,46 @@
+<?php
+
+class ListUsersUpdate implements JsonSerializable {
+	use JsonDeserializerTrait;
+
+	/** @var int $userId */
+	protected $userId;
+
+	/** @var string[] $userGroups */
+	protected $userGroups;
+
+	/**
+	 * @return int
+	 */
+	public function getUserId(): int {
+		return $this->userId;
+	}
+
+	/**
+	 * @param int $userId
+	 */
+	public function setUserId( int $userId ) {
+		$this->userId = $userId;
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public function getUserGroups(): array {
+		return $this->userGroups;
+	}
+
+	/**
+	 * @param string[] $userGroups
+	 */
+	public function setUserGroups( array $userGroups ) {
+		$this->userGroups = $userGroups;
+	}
+
+	public function jsonSerialize() {
+		return [
+			'userId' => $this->userId,
+			'userGroups' => $this->userGroups,
+		];
+	}
+}

--- a/extensions/wikia/Listusers/update/UpdateListUsersTask.php
+++ b/extensions/wikia/Listusers/update/UpdateListUsersTask.php
@@ -1,0 +1,109 @@
+<?php
+
+use Wikia\Tasks\Tasks\BaseTask;
+
+class UpdateListUsersTask extends BaseTask {
+	const EVENTS_LOCAL_USERS = 'events_local_users';
+
+	/** @var DatabaseBase $writeConnection */
+	private $writeConnection;
+
+	/** @var EditCountService $editCountService */
+	private $editCountService;
+
+	public function updateEditInformation( array $editUpdateInfo ) {
+		$editUpdate = ListUsersEditUpdate::newFromJson( $editUpdateInfo );
+		$wikiId = $this->getWikiId();
+		$userId = $editUpdate->getUserId();
+
+		$editCount = $this->editCountService->getEditCount( $userId );
+
+		$userGroups = $editUpdate->getUserGroups();
+		$groupCount = count( $userGroups );
+
+		$primaryKey = [ 'wiki_id', 'user_id' ];
+
+		$rowToInsert = [
+			'wiki_id' => $wikiId,
+			'user_id' => $userId,
+			'edits' => $editCount,
+			'editdate' => wfTimestamp( TS_DB, $editUpdate->getLatestRevisionTimestamp() ),
+			'last_revision' => $editUpdate->getLatestRevisionId(),
+			'cnt_groups' => $groupCount,
+			'single_group' => $groupCount ? $userGroups[$groupCount - 1] : '',
+			'all_groups' => implode( ';', $userGroups ),
+			'user_is_closed' => 0
+		];
+
+		$fieldsToUpdate = array_diff_key( $rowToInsert, array_flip( $primaryKey ) );
+
+		$this->writeConnection()->upsert(
+			static::EVENTS_LOCAL_USERS,
+			[ $rowToInsert ],
+			[ $primaryKey ],
+			$fieldsToUpdate,
+			__METHOD__
+		);
+	}
+
+	public function updateUserGroups( array $updateInfo ) {
+		$groupsUpdate = ListUsersUpdate::newFromJson( $updateInfo );
+
+		$wikiId = $this->getWikiId();
+		$userId = $groupsUpdate->getUserId();
+
+		$userGroups = $groupsUpdate->getUserGroups();
+		$groupCount = count( $userGroups );
+
+		$updatedFields = [
+			'cnt_groups' => $groupCount,
+			'single_group' => $groupCount ? $userGroups[$groupCount - 1] : '',
+			'all_groups' => implode( ';', $userGroups ),
+		];
+
+		// If a row already exists for this user and this wiki, a cheap UPDATE operation is sufficient
+		$this->writeConnection()->update(
+			static::EVENTS_LOCAL_USERS,
+			$updatedFields,
+			[ 'wiki_id' => $wikiId, 'user_id' => $userId ],
+			__METHOD__
+		);
+
+		// No row exists yet for this user, so create one
+		if ( !$this->writeConnection()->affectedRows() ) {
+			$dbr = wfGetDB( DB_SLAVE );
+
+			$editCount = $this->editCountService->getEditCount( $userId );
+
+			$lastEdit = $dbr->selectRow(
+				'revision',
+				[ 'max(rev_id) AS revision_id', 'max(rev_timestamp) AS timestamp' ],
+				[ 'rev_user' => $userId ],
+				__METHOD__
+			);
+
+			$row = [
+				'wiki_id' => $wikiId,
+				'user_id' => $userId,
+				'edits' => $editCount,
+				'editdate' => $lastEdit ? wfTimestamp( TS_DB, $lastEdit->timestamp ) : '',
+				'last_revision' => $lastEdit ? $lastEdit->revision_id : 0,
+				'cnt_groups' => $groupCount,
+				'single_group' => $groupCount ? $userGroups[$groupCount - 1] : '',
+				'all_groups' => implode( ';', $userGroups ),
+				'user_is_closed' => 0
+			];
+
+			$this->writeConnection()->insert( static::EVENTS_LOCAL_USERS, [ $row ], __METHOD__ );
+		}
+	}
+
+	private function writeConnection(): DatabaseBase {
+		if ( $this->writeConnection == null ) {
+			global $wgSpecialsDB;
+			$this->writeConnection = wfGetDB( DB_MASTER, [], $wgSpecialsDB );
+		}
+
+		return $this->writeConnection;
+	}
+}

--- a/extensions/wikia/Listusers/update/UpdateListUsersTask.php
+++ b/extensions/wikia/Listusers/update/UpdateListUsersTask.php
@@ -11,6 +11,10 @@ class UpdateListUsersTask extends BaseTask {
 	/** @var EditCountService $editCountService */
 	private $editCountService;
 
+	public function __construct( EditCountService $editCountService = null ) {
+		$this->editCountService = $editCountService ?? new EditCountService();
+	}
+
 	public function updateEditInformation( array $editUpdateInfo ) {
 		$editUpdate = ListUsersEditUpdate::newFromJson( $editUpdateInfo );
 		$wikiId = $this->getWikiId();

--- a/extensions/wikia/Pages/UpdatePagesTask.php
+++ b/extensions/wikia/Pages/UpdatePagesTask.php
@@ -53,14 +53,4 @@ class UpdatePagesTask extends BaseTask {
 
 		return wfGetDB( DB_MASTER, [], $wgExternalDatawareDB );
 	}
-
-	/**
-	 * Construct a new {@see UpdatePagesTask} instance that will be run in the context of the current wiki
-	 * @return UpdatePagesTask
-	 */
-	public static function newLocalTask(): UpdatePagesTask {
-		global $wgCityId;
-
-		return ( new self() )->wikiId( $wgCityId );
-	}
 }

--- a/includes/wikia/tasks/Tasks/BaseTask.class.php
+++ b/includes/wikia/tasks/Tasks/BaseTask.class.php
@@ -417,4 +417,9 @@ abstract class BaseTask {
 		return AsyncTaskList::batch( $taskLists, $priority );
 	}
 
+	public static function newLocalTask(): BaseTask {
+		global $wgCityId;
+
+		return ( new static() )->wikiId( $wgCityId );
+	}
 }

--- a/includes/wikia/tests/core/WikiaDatabaseTest.php
+++ b/includes/wikia/tests/core/WikiaDatabaseTest.php
@@ -47,6 +47,7 @@ abstract class WikiaDatabaseTest extends TestCase {
 		static::loadSchemaFile( "$IP/tests/fixtures/user.sql" );
 		static::loadSchemaFile( "$IP/tests/fixtures/user_properties.sql" );
 		static::loadSchemaFile( "$IP/tests/fixtures/dataware.sql" );
+		static::loadSchemaFile( "$IP/tests/fixtures/specials.sql" );
 
 		// destroy leaked user accounts from other tests
 		User::$idCacheByName = [];

--- a/tests/fixtures/specials.sql
+++ b/tests/fixtures/specials.sql
@@ -1,0 +1,15 @@
+CREATE TABLE `events_local_users` (
+  `wiki_id` int(8) NOT NULL,
+  `user_id` int(10) NOT NULL,
+  `edits` int(11) NOT NULL DEFAULT '0',
+  `editdate` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `last_revision` int(11) NOT NULL DEFAULT '0',
+  `cnt_groups` smallint(4) NOT NULL DEFAULT '0',
+  `single_group` varchar(255) NOT NULL DEFAULT '',
+  `all_groups` mediumtext NOT NULL,
+  `user_is_blocked` tinyint(1) DEFAULT '0',
+  `user_is_closed` tinyint(1) DEFAULT '0',
+  PRIMARY KEY (`wiki_id`,`user_id`)
+);
+
+CREATE INDEX `user_edits` ON `events_local_users` (`user_id`,`edits`,`wiki_id`);


### PR DESCRIPTION
On edit and user rights change, queue job to update `specials.events_local_users` table.

https://wikia-inc.atlassian.net/browse/SUS-3472