### PR TITLE
PUR-96: Fixed talkpage/reason link in Content Review module

### DIFF
--- a/extensions/wikia/ContentReview/services/ContentReviewStatusesService.class.php
+++ b/extensions/wikia/ContentReview/services/ContentReviewStatusesService.class.php
@@ -313,7 +313,7 @@ class ContentReviewStatusesService {
 	private function createRevisionTalkpageLink( \Title $title ) {
 		return \Html::element(
 			'a',
-			[ 'href' => $title->getTalkPage() ],
+			[ 'href' => $title->getTalkPage()->getLocalURL() ],
 			wfMessage( 'content-review-rejection-reason-link' )->escaped()
 		);
 	}


### PR DESCRIPTION
In the Content Review module, the rejection reason link is pointing to the talkpage incorrectly because the `Title` object passed to `Html::element` is unexpectedly converted to a string instead of its local URL.

Support ticket: [#364236](https://support.wikia-inc.com/hc/en-us/requests/364236)
Bug ticket: [PUR-96](https://wikia-inc.atlassian.net/browse/PUR-96)