### PR TITLE
XW-4522 | [RTE] Prevent adding <strong class="error">...</strong> to wikitext when switching from wysiwyg to source

### DIFF
--- a/extensions/wikia/RTE/RTEReverseParser.class.php
+++ b/extensions/wikia/RTE/RTEReverseParser.class.php
@@ -513,6 +513,9 @@ class RTEReverseParser {
 					$beforeText = "\n";
 				}
 			}
+		// ignore errors displayed by extension tags
+		} elseif ( $node->nodeName === 'strong' && $node->getAttribute( 'class' ) === 'error' ) {
+			return '';
 		}
 
 		// fix for wikitext that is context-sensitive


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/XW-4522

@Wikia/x-wing 