### PR TITLE
ImageSyncTask: fix a fatal [preview]

### DIFF
--- a/extensions/wikia/SwiftSync/classes/ImageSyncTask.class.php
+++ b/extensions/wikia/SwiftSync/classes/ImageSyncTask.class.php
@@ -12,11 +12,6 @@ use \Wikia\SwiftStorage;
  */
 class ImageSyncTask extends BaseTask {
 
-	public static function newLocalTask(): self {
-		global $wgCityId;
-		return ( new self() )->wikiId( $wgCityId );
-	}
-
 	/**
 	 * @param array $tasks
 	 * @throws \WikiaException


### PR DESCRIPTION
```
PHP Fatal error:  Declaration of Wikia\SwiftSync\ImageSyncTask::newLocalTask(): Wikia\SwiftSync\ImageSyncTask must be compatible with Wikia\Tasks\Tasks\Base
  Task::newLocalTask(): Wikia\Tasks\Tasks\BaseTask in /usr/wikia/slot1/21402/src/extensions/wikia/SwiftSync/classes/ImageSyncTask.class.php on line 0
```