### PR TITLE
SUS-3838: Save RTE parser output in cache + protect it with PoolCounter

### DIFF
--- a/extensions/wikia/RTE/RTEParsePoolWork.php
+++ b/extensions/wikia/RTE/RTEParsePoolWork.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * PoolCounter job for producing RTE parser output for a given page + revision.
+ * @see PoolWorkArticleView - regular parser output counterpart
+ */
+class RTEParsePoolWork extends PoolCounterWork {
+	/** @var RTEParserCache $parserCache */
+	private $parserCache;
+
+	/** @var EditPage $editPage */
+	private $editPage;
+
+	/** @var int $revisionId */
+	private $revisionId;
+
+	/** @var RTEParser $rteParser */
+	private $rteParser;
+
+	/** @var ParserOptions $parserOptions */
+	private $parserOptions;
+
+	/** @var ParserOutput $parserOutput */
+	private $parserOutput;
+
+	function __construct( RTEParserCache $parserCache, EditPage $editPage, ParserOptions $parserOptions ) {
+		$article = $editPage->getArticle();
+
+		$revisionId = $article->getRevIdFetched();
+		$parserCacheKey = $parserCache->getKey( $article, $parserOptions );
+
+		$poolCounterKey = "$parserCacheKey:revision:$revisionId";
+
+		parent::__construct( 'RTEParsePool', $poolCounterKey );
+
+		// Tell PoolCounter whether it can use cached results for this work
+		$this->cacheable = $article->getPage()->isParserCacheUsed( $parserOptions, $revisionId );
+
+		$this->parserCache = $parserCache;
+		$this->rteParser = new RTEParser();
+		$this->editPage = $editPage;
+		$this->revisionId = $revisionId;
+		$this->parserOptions = $parserOptions;
+	}
+
+	/**
+	 * Actually perform the work, caching it if needed.
+	 */
+	function doWork() {
+		$cacheTime = wfTimestampNow();
+
+		$this->parserOutput = $this->rteParser->parse(
+			$this->editPage->textbox1,
+			$this->editPage->getTitle(),
+			$this->parserOptions,
+			true,
+			true,
+			$this->revisionId );
+
+		if ( $this->cacheable && $this->parserOutput->isCacheable() ) {
+			// set a custom TTL (7 days instead of 14 for normal parser output)
+			$this->parserOutput->updateCacheExpiry( RTEParserCache::TTL );
+
+			$this->parserCache->save(
+				$this->parserOutput,
+				$this->editPage->getArticle(),
+				$this->parserOptions,
+				$cacheTime );
+		}
+
+		return true;
+	}
+
+	function getCachedWork() {
+		$cachedParserOutput = $this->parserCache->get( $this->editPage->getArticle(), $this->parserOptions );
+
+		if ( $cachedParserOutput instanceof ParserOutput ) {
+			$this->parserOutput = $cachedParserOutput;
+			return true;
+		}
+
+		return false;
+	}
+
+	function fallback() {
+		$dirtyParserOutput = $this->parserCache->getDirty( $this->editPage->getArticle(), $this->parserOptions );
+
+		if ( $dirtyParserOutput instanceof ParserOutput ) {
+			$this->parserOutput = $dirtyParserOutput;
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * @return ParserOutput
+	 */
+	public function getParserOutput(): ParserOutput {
+		return $this->parserOutput;
+	}
+}

--- a/extensions/wikia/RTE/RTEParsePoolWork.php
+++ b/extensions/wikia/RTE/RTEParsePoolWork.php
@@ -58,7 +58,7 @@ class RTEParsePoolWork extends PoolCounterWork {
 			$this->revisionId );
 
 		if ( $this->cacheable && $this->parserOutput->isCacheable() ) {
-			// set a custom TTL (7 days instead of 14 for normal parser output)
+			// set a custom TTL (3 days instead of 14 for normal parser output)
 			$this->parserOutput->updateCacheExpiry( RTEParserCache::TTL );
 
 			$this->parserCache->save(

--- a/extensions/wikia/RTE/RTEParserCache.php
+++ b/extensions/wikia/RTE/RTEParserCache.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * A ParserOptions-agnostic ParserCache implementation for use by RTE.
+ */
+class RTEParserCache extends ParserCache {
+	const TTL = 86400 * 7; // 7 days
+
+	public function __construct( BagOStuff $memCached ) {
+		parent::__construct( $memCached );
+	}
+
+	protected function getParserOutputKey( $article, $hash ) {
+		$articleId = $article->getID();
+
+		return wfMemcKey( 'rte-parser-cache', $articleId );
+	}
+
+	protected function getOptionsKey( $article ) {
+		$articleId = $article->getID();
+
+		return wfMemcKey( 'rte-parser-cache-pointer', $articleId );
+	}
+}

--- a/extensions/wikia/RTE/RTEParserCache.php
+++ b/extensions/wikia/RTE/RTEParserCache.php
@@ -4,7 +4,7 @@
  * A ParserOptions-agnostic ParserCache implementation for use by RTE.
  */
 class RTEParserCache extends ParserCache {
-	const TTL = 86400 * 7; // 7 days
+	const TTL = 86400 * 3; // 3 days
 
 	public function __construct( BagOStuff $memCached ) {
 		parent::__construct( $memCached );

--- a/extensions/wikia/RTE/RTE_setup.php
+++ b/extensions/wikia/RTE/RTE_setup.php
@@ -19,6 +19,8 @@ $wgAutoloadClasses['RTEMarker'] = __DIR__ . '/RTEMarker.class.php';
 $wgAutoloadClasses['RTEParser'] = __DIR__ . '/RTEParser.class.php';
 $wgAutoloadClasses['RTEReverseParser'] = __DIR__ . '/RTEReverseParser.class.php';
 $wgAutoloadClasses['RTEController'] = __DIR__ . '/RTEController.class.php';
+$wgAutoloadClasses['RTEParserCache'] = __DIR__ . '/RTEParserCache.php';
+$wgAutoloadClasses['RTEParsePoolWork'] = __DIR__ . '/RTEParsePoolWork.php';
 
 // hooks
 $wgHooks['EditPage::showEditForm:initial'][] = 'RTE::init';

--- a/includes/WikiPage.php
+++ b/includes/WikiPage.php
@@ -3175,6 +3175,9 @@ class PoolWorkArticleView extends PoolCounterWork {
 			$text = $rev->getText();
 		}
 
+		// Reduce effects of race conditions for slow parses (bug 46014)
+		$cacheTime = wfTimestampNow();
+
 		$time = - microtime( true );
 		$this->parserOutput = $wgParser->parse( $text, $this->page->getTitle(),
 			$this->parserOptions, true, true, $this->revid );
@@ -3199,7 +3202,8 @@ class PoolWorkArticleView extends PoolCounterWork {
 		}
 
 		if ( $this->cacheable && $this->parserOutput->isCacheable() ) {
-			ParserCache::singleton()->save( $this->parserOutput, $this->page, $this->parserOptions );
+			ParserCache::singleton()->save(
+				$this->parserOutput, $this->page, $this->parserOptions, $cacheTime );
 		}
 
 		// Make sure file cache is not used on uncacheable content.

--- a/includes/parser/ParserCache.php
+++ b/includes/parser/ParserCache.php
@@ -212,22 +212,19 @@ class ParserCache {
 	 * @param $parserOutput ParserOutput
 	 * @param $article Page
 	 * @param $popts ParserOptions
+	 * @param $cacheTime string Time when the cache was generated
 	 */
-	public function save( ParserOutput $parserOutput, Page $article, ParserOptions $popts ) {
-
-		Hooks::run( 'BeforeParserCacheSave', [ $parserOutput, $article ] );
-
+	public function save( ParserOutput $parserOutput, Page $article, ParserOptions $popts, $cacheTime = null ) {
 		$expire = $parserOutput->getCacheExpiry();
-
-		if( $expire > 0 ) {
-			$now = wfTimestampNow();
+		if ( $expire > 0 ) {
+			$cacheTime = $cacheTime ?: wfTimestampNow();
 
 			$optionsKey = new CacheTime;
 			$optionsKey->mUsedOptions = $parserOutput->getUsedOptions();
 			$optionsKey->updateCacheExpiry( $expire );
 
-			$optionsKey->setCacheTime( $now );
-			$parserOutput->setCacheTime( $now );
+			$optionsKey->setCacheTime( $cacheTime );
+			$parserOutput->setCacheTime( $cacheTime );
 
 			$optionsKey->setContainsOldMagic( $parserOutput->containsOldMagic() );
 


### PR DESCRIPTION
* port useful related change [r85917](https://gerrit.wikimedia.org/r/#/c/85917/) (for [T48014](https://phabricator.wikimedia.org/T48014))
* store RTE parser output in parser cache with a `ParserOptions`-agnostic key (RTE always uses same parser options)

https://wikia-inc.atlassian.net/browse/SUS-3838