### PR TITLE
fix rendering SVGs on video gallery page

### DIFF
--- a/extensions/wikia/CategoryExhibition/templates/item-media.tmpl.php
+++ b/extensions/wikia/CategoryExhibition/templates/item-media.tmpl.php
@@ -9,9 +9,9 @@
 			   title="<?= Sanitizer::encodeAttribute( $row['title'] ); ?>"
 			>
 				<? if ( $row['isVideo'] == true ): ?>
-					'<span class="thumbnail-play-icon-container">'
-					. DesignSystemHelper::renderSvg('wds-player-icon-play', 'thumbnail-play-icon')
-					. '</span>';
+					<span class="thumbnail-play-icon-container">
+						 <?= DesignSystemHelper::renderSvg('wds-player-icon-play', 'thumbnail-play-icon') ?>
+					</span>
 				<? endif; ?>
 				<img src="<?= Sanitizer::encodeAttribute( $row['img'] ); ?>"
 					 alt="<?= Sanitizer::encodeAttribute( $row['title'] ); ?>"


### PR DESCRIPTION
method invocation is rendered as string, instead of actual svg

before: http://cocktails.wikia.com/wiki/Category:Videos
after: http://cocktails.sandbox-dedicated.wikia.com/wiki/Category:Videos

@Wikia/x-wing