### PR TITLE
XW-4505 | CKE: Display Puzzle for empty placeholders

### DIFF
--- a/extensions/wikia/RTE/css/content.scss
+++ b/extensions/wikia/RTE/css/content.scss
@@ -114,7 +114,8 @@ img.withCaption {
 /**
  *  placeholders
  */
-img.placeholder {
+img.placeholder,
+img.empty-placeholder {
 	background-image: url(/extensions/wikia/RTE/ckeditor/skins/wikia/icons.png);/* $wgResourceBasePath */
 	background-position: 0 -1294px;
 	height: 16px !important;

--- a/extensions/wikia/RTE/js/plugins/placeholder/plugin.js
+++ b/extensions/wikia/RTE/js/plugins/placeholder/plugin.js
@@ -25,7 +25,9 @@ CKEDITOR.plugins.add('rte-placeholder',
 			// if placeholder does not have content, render green puzzle
 			placeholders.each(function (p) {
 				var $placeholder = $(placeholders.get(p));
-				console.log($placeholder);
+
+				// to check if content of placeholder is empty we need to get rid of non-width spaces (replace does not
+				// change the original string)
 				if ( $.trim($placeholder.html().replace(/[\u200B]/, '')) === '') {
 					$placeholder.html('<img class="empty-placeholder">');
 				}

--- a/extensions/wikia/RTE/js/plugins/placeholder/plugin.js
+++ b/extensions/wikia/RTE/js/plugins/placeholder/plugin.js
@@ -22,6 +22,16 @@ CKEDITOR.plugins.add('rte-placeholder',
 			// get all placeholders (template / magic words / double underscores / broken image links)
 			var placeholders = RTE.tools.getPlaceholders();
 
+			// if placeholder does not have content, render green puzzle
+			placeholders.each(function (p) {
+				var $placeholder = $(placeholders.get(p));
+				console.log($placeholder);
+				if ( $.trim($placeholder.html().replace(/[\u200B]/, '')) === '') {
+					$placeholder.html('<img class="empty-placeholder">');
+				}
+
+			});
+
 			// regenerate preview and template info
 			placeholders.removeData('preview').removeData('info');
 
@@ -103,7 +113,10 @@ CKEDITOR.plugins.add('rte-placeholder',
 
 						intro = lang.media.notExisting;
 						break;
-
+					case 'ext':
+						title = data.extName;
+						intro = lang.codedElement.intro;
+						break;
 					default:
 						title = lang.codedElement.title;
 						intro = lang.codedElement.intro;

--- a/includes/parser/Preprocessor_DOM.php
+++ b/includes/parser/Preprocessor_DOM.php
@@ -1338,7 +1338,8 @@ class PPFrame_DOM implements PPFrame {
 							'type' => 'ext',
 							'wikitext' => RTEData::get( 'wikitext', intval( $wikiTextIdx ) ),
 							'lineStart' => $contextNode->getAttribute( 'lineStart' ),
-							'placeholder' => 1
+							'placeholder' => 1,
+							'extName' => $nameNode->nodeValue
 						];
 
 						// append a zero-width space


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/XW-4505

* display puzzle
* display tag name instead of "Coded element"

@Wikia/x-wing 