### PR TITLE
SUS-3833 | Stop using backend tools to execute scripts from within MediaWiki

### DIFF
--- a/extensions/wikia/Listusers/SpecialListusers_helper.php
+++ b/extensions/wikia/Listusers/SpecialListusers_helper.php
@@ -475,9 +475,7 @@ class ListusersData {
 	}
 
 	/**
-	 * Fills specials.events_local_users table with entries for a given wiki. This one will
-	 * replace an old Perl backend script - /usr/wikia/backend/bin/scribe/events_local_users.pl
-	 *
+	 * Fills specials.events_local_users table with entries for a given wiki.
 	 * Used by CreateNewWikiTask class
 	 *
 	 * @see SUS-3264

--- a/includes/wikia/tasks/Tasks/ImageReviewTask.class.php
+++ b/includes/wikia/tasks/Tasks/ImageReviewTask.class.php
@@ -49,9 +49,9 @@ class ImageReviewTask extends BaseTask {
 
 			if ( count( $imageData ) == 3 ) {
 				$command =
-					"/usr/wikia/backend/bin/run_maintenance --id=${wikiId} --script='wikia/deleteImageRevision.php --pageId=${imageId} --revisionId=${revisionId}'";
+					"php {$IP}/maintenance/wikia/deleteImageRevision.php --pageId=${imageId} --revisionId=${revisionId}";
 
-				$output = wfShellExec( $command, $exitStatus );
+				$output = wfShellExec( $command, $exitStatus, [ 'SERVER_ID' => $wikiId ] );
 
 				if ( $exitStatus !== 0 ) {
 					$this->error( 'article deletion error', [

--- a/maintenance/wikia/WikiFactoryVariables/migrateWikiFactoryToHttps.php
+++ b/maintenance/wikia/WikiFactoryVariables/migrateWikiFactoryToHttps.php
@@ -4,7 +4,7 @@
 * Maintenance script to manage WikiFactory variable to https
 * @usage
 * 	# this will migrate wgUploadPath for wiki with ID 119:
-*   /usr/wikia/backend/bin/run_maintenance '--script=wikia/WikiFactoryVariables/migrateWikiFactoryToHttps.php --dryRun --varName wgUploadPath' --id=119
+*   run_maintenance --script='wikia/WikiFactoryVariables/migrateWikiFactoryToHttps.php --dryRun --varName wgUploadPath' --id=119
 */
 
 ini_set( 'display_errors', 'stderr' );

--- a/maintenance/wikia/WikiFactoryVariables/migrateWikiWordmarks.php
+++ b/maintenance/wikia/WikiFactoryVariables/migrateWikiWordmarks.php
@@ -11,7 +11,7 @@
 * 	# this will migrate wordmark-image-url for wiki with ID 119:
 * 	migrateWikiWordmarks --dry-run --wiki 119 --verbose --keyName wordmark-image-url
 *   # or
-*   /usr/wikia/backend/bin/run_maintenance '--script=wikia/WikiFactoryVariables/migrateWikiWordmarks.php --dry-run --verbose --keyName wordmark-image-url' --id=119
+*   run_maintenance --script='wikia/WikiFactoryVariables/migrateWikiWordmarks.php --dry-run --verbose --keyName wordmark-image-url' --id=119
 */
 
 ini_set( 'display_errors', 'stderr' );

--- a/maintenance/wikia/WikiFactoryVariables/unescapeWordmarkText.php
+++ b/maintenance/wikia/WikiFactoryVariables/unescapeWordmarkText.php
@@ -7,7 +7,7 @@
 * 	# this will process wordmark-text for wiki with ID 119:
 * 	migrateWikiWordmarks --dry-run --wiki 119 --verbose
 *   # or
-*   /usr/wikia/backend/bin/run_maintenance '--script=wikia/WikiFactoryVariables/unescapeWordmarkText.php --dry-run' --id=119
+*   run_maintenance --script='wikia/WikiFactoryVariables/unescapeWordmarkText.php --dry-run' --id=119
 */
 
 ini_set( 'display_errors', 'stderr' );


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3833

`wfShellExec` allows to pass a set of environment variables. Let's use it to pass `SERVER_ID` and execute a script in a context of a given wiki instead of relying on `run_maintenance` Perl-backend script.

## Example

```
$ ./wiki.sh muppet
Eval for muppet...

> $out = wfShellExec( "php $IP/maintenance/update.php --quick", $retval, ['SERVER_ID' => 5915] );
wfShellExec: SERVER_ID='5915' WIKIA_TRACER_X_TRACE_ID=... WIKIA_TRACER_X_WIKIA_INTERNAL_REQUEST='mediawiki' php /home/macbre/app/maintenance/update.php --quick

> echo $out;
MediaWiki 1.19.24 Updater

Going to run database updates for plpoznan
Depending on the size of your database this may take a while!
```