### PR TITLE
SUS-3589 | drop per-wiki sitemap_blobs table via update.php script

### DIFF
--- a/includes/wikia/WikiaUpdater.php
+++ b/includes/wikia/WikiaUpdater.php
@@ -79,6 +79,7 @@ class WikiaUpdater {
 			array( 'dropField', 'interwiki', 'iw_wikiid', $dir . 'patch-drop-wikiid.sql', true ),
 			array( 'dropField', 'cu_changes', 'cuc_user_text', $ext_dir . '/CheckUser/patch-cu_changes.sql', true ), // SUS-3080
 			array( 'WikiaUpdater::do_drop_table', 'tag_summary' ), // SUS-3066
+			array( 'WikiaUpdater::do_drop_table', 'sitemap_blobs' ), // SUS-3589
 		);
 
 		if ( $wgDBname === $wgExternalSharedDB ) {


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3589

49,145 GiB will be saved across all clusters and replicas (391326 tables, mostly empty - 0.0156 MiB taken)