### PR TITLE
SUS-3592 | drop ach_ranking_snapshots per-wiki table, it is now kept on wikicities

### DIFF
--- a/includes/wikia/WikiaUpdater.php
+++ b/includes/wikia/WikiaUpdater.php
@@ -86,6 +86,10 @@ class WikiaUpdater {
 			$wikia_update[] = array( 'addTable', 'city_list', $dir . 'wf/patch-create-city_list.sql', true );
 			$wikia_update[] = array( 'addTable', 'city_list', $dir . 'wf/patch-create-city_cats.sql', true );
 		}
+		else {
+			// run these updates on per-wiki databases only
+			$wikia_update[] = array( 'WikiaUpdater::do_drop_table', 'ach_ranking_snapshots' ); // SUS-3592
+		}
 
 		foreach ( $wikia_update as $update ) {
 			$updater->addExtensionUpdate( $update );


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3592

```sql
-- Query digest for "ach_ranking_snapshots" table, found 73 queries
DatabaseBase::select 100.00% [ap] db:wikicities | SELECT data FROM `ach_ranking_snapshots` WHERE wiki_id = X
```

```
macbre@dev-macbre:~/app/maintenance$ SERVER_ID=831 php update.php --quick --ext-only
...
Checking wikia ach_ranking_snapshots table...
...dropping ach_ranking_snapshots table... ok
```

But keep it on `wikicities`!

32,806 GiB to be reclaimed across all clusters and replicas (264106 tables with no data, with one exception).