### PR TITLE
Recirculation: discussions - allow browser cache

### DIFF
--- a/extensions/wikia/Recirculation/RecirculationController.class.php
+++ b/extensions/wikia/Recirculation/RecirculationController.class.php
@@ -52,6 +52,7 @@ class RecirculationController extends WikiaController {
 				$postObjects[] = $post->jsonSerialize();
 			}
 
+			$this->response->setCachePolicy(WikiaResponse::CACHE_PUBLIC);
 			$this->response->setTemplateEngine( WikiaResponse::TEMPLATE_ENGINE_PHP );
 			$this->response->setCacheValidity( WikiaResponse::CACHE_VERY_SHORT );
 			$this->response->setData( [


### PR DESCRIPTION
Currently, we serve response with `Vary:Cookie` header. Cookies are modified on every request. Because of that, it makes it impossible to use this asset from the browser cache. `CACHE_PUBLIC` disables `Vary:Cookie` header.

//cc @rogatty @fraszczakszymon 