### PR TITLE
hardcoding to true

### DIFF
--- a/extensions/wikia/ArticleVideo/scripts/featured-video.jwplayer.instant.js
+++ b/extensions/wikia/ArticleVideo/scripts/featured-video.jwplayer.instant.js
@@ -27,10 +27,10 @@ require([
 		return;
 	}
 
-	var inNextVideoAutoplayCountries = geo.isProperGeo(instantGlobals.wgArticleVideoNextVideoAutoplayCountries),
+	var inNextVideoAutoplayCountries = true, //geo.isProperGeo(instantGlobals.wgArticleVideoNextVideoAutoplayCountries),
 		//Fallback to the generic playlist when no recommended videos playlist is set for the wiki
 		recommendedPlaylist = videoDetails.recommendedVideoPlaylist || 'Y2RWCKuS',
-		inAutoplayCountries = geo.isProperGeo(instantGlobals.wgArticleVideoAutoplayCountries),
+		inAutoplayCountries = true, //geo.isProperGeo(instantGlobals.wgArticleVideoAutoplayCountries),
 		willAutoplay = isAutoplayEnabled() && inAutoplayCountries,
 		bidParams;
 

--- a/extensions/wikia/ArticleVideo/scripts/featured-video.jwplayer.instant.js
+++ b/extensions/wikia/ArticleVideo/scripts/featured-video.jwplayer.instant.js
@@ -1,7 +1,7 @@
 require([
 	'wikia.window',
 	'wikia.geo',
-	'wikia.instantGlobals',
+//	'wikia.instantGlobals',
 	'wikia.cookies',
 	'wikia.tracker',
 	'ext.wikia.adEngine.adContext',
@@ -13,7 +13,7 @@ require([
 ], function (
 	win,
 	geo,
-	instantGlobals,
+//	instantGlobals,
 	cookies,
 	tracker,
 	adContext,


### PR DESCRIPTION
Since this is untestable in sandbox from what I can tell, this is my attempt at fixing the autoplaying video problems.

From what I can tell a new rule to EasyList is causing the request to get instantGlobals, which is preventing these booleans from being true, so autoplay never tries to get going.

https://wikia-inc.atlassian.net/browse/XW-4612