### PR TITLE
SUS-4073 | remove dependency on globalimagelinks table on ext/wikia/FilePage

### DIFF
--- a/extensions/wikia/FilePage/FilePageTabbed.php
+++ b/extensions/wikia/FilePage/FilePageTabbed.php
@@ -72,8 +72,7 @@ class FilePageTabbed extends WikiaFilePage {
 		$app = F::App();
 		$out = $this->getContext()->getOutput();
 
-		$out->addHTML( $app->renderView( 'FilePageController', 'fileUsage', array('type' => 'local') ) );
-		$out->addHTML( $app->renderView( 'FilePageController', 'fileUsage', array('type' => 'global') ) );
+		$out->addHTML( $app->renderView( 'FilePageController', 'fileUsage' ) );
 
 		// Close div from about section (opened in imageContent)
 		$out->addHTML('</div>');


### PR DESCRIPTION
GlobalUsage extension was set up to use `video151` when querying `globalimagelinks` (`wgGlobalUsageDatabase` was set to `video151` site-wide). As we're sunsetting video.wikia.com, this functionality is no longer needed.

Local, per-wiki file usage still works on file pages.

https://wikia-inc.atlassian.net/browse/SUS-4073