### PR TITLE
SUS-4084: Optimize Forum Activity module query

### DIFF
--- a/extensions/wikia/Forum/CachedForumActivityService.php
+++ b/extensions/wikia/Forum/CachedForumActivityService.php
@@ -1,0 +1,37 @@
+<?php
+
+class CachedForumActivityService implements ForumActivityService {
+	const CACHE_TTL = 86400; // 1 day
+
+	/** @var ForumActivityService $forumActivityService */
+	private $forumActivityService;
+	/** @var BagOStuff $cacheService */
+	private $cacheService;
+
+	public function __construct( ForumActivityService $forumActivityService, BagOStuff $cacheService ) {
+		$this->forumActivityService = $forumActivityService;
+		$this->cacheService = $cacheService;
+	}
+
+	public function getRecentlyUpdatedThreads(): array {
+		$key = static::getCacheKey();
+		$cachedValue = $this->cacheService->get( $key );
+
+		if ( $cachedValue !== false ) {
+			return $cachedValue;
+		}
+
+		$freshValue = $this->forumActivityService->getRecentlyUpdatedThreads();
+		$this->cacheService->set( $key, $freshValue, static::CACHE_TTL );
+
+		return $freshValue;
+	}
+
+	public static function purgeCache() {
+		WikiaDataAccess::cachePurge( static::getCacheKey() );
+	}
+
+	private static function getCacheKey(): string {
+		return wfMemcKey( 'ForumActivityService', 'getRecentlyUpdatedThreads' );
+	}
+}

--- a/extensions/wikia/Forum/DatabaseForumActivityService.php
+++ b/extensions/wikia/Forum/DatabaseForumActivityService.php
@@ -7,9 +7,17 @@ class DatabaseForumActivityService implements ForumActivityService {
 		$dbr = wfGetDB( DB_SLAVE );
 
 		$res = $dbr->select(
-			[ 'page', 'comments_index', 'thread_rev' => 'revision', 'last_comment_rev' => 'revision' ],
 			[
-				'page_id', 'page_namespace', 'page_title',
+				'page',
+				'comments_index',
+				'thread_rev' => 'revision',
+				'last_comment_page' => 'page',
+				'last_comment_rev' => 'revision'
+			],
+			[
+				'page.page_id AS page_id',
+				'page.page_namespace AS page_namespace',
+				'page.page_title AS page_title',
 				'thread_rev.rev_text_id AS thread_text_id',
 				'thread_rev.rev_user AS thread_author_id',
 				'thread_rev.rev_user_text AS thread_author_name',
@@ -19,7 +27,7 @@ class DatabaseForumActivityService implements ForumActivityService {
 				'last_comment_rev.rev_timestamp AS last_comment_timestamp'
 			],
 			[
-				'page_namespace' => NS_WIKIA_FORUM_BOARD_THREAD,
+				'page.page_namespace' => NS_WIKIA_FORUM_BOARD_THREAD,
 				'archived' => 0,
 				'deleted' => 0,
 				'removed' => 0,
@@ -34,9 +42,10 @@ class DatabaseForumActivityService implements ForumActivityService {
 				'ORDER BY' => 'last_touched DESC'
 			],
 			[
-				'comments_index' => [ 'INNER JOIN', 'page_id = comment_id' ],
-				'last_comment_rev' => [ 'INNER JOIN', 'last_comment_rev.rev_page = last_child_comment_id' ],
-				'thread_rev' => [ 'INNER JOIN', 'thread_rev.rev_id = page_latest' ],
+				'comments_index' => [ 'INNER JOIN', 'page.page_id = comment_id' ],
+				'last_comment_page' => [ 'INNER JOIN', 'last_comment_page.page_id = last_child_comment_id' ],
+				'last_comment_rev' => [ 'INNER JOIN', 'last_comment_rev.rev_id = last_comment_page.page_latest' ],
+				'thread_rev' => [ 'INNER JOIN', 'thread_rev.rev_id = page.page_latest' ],
 			]
 		);
 

--- a/extensions/wikia/Forum/DatabaseForumActivityService.php
+++ b/extensions/wikia/Forum/DatabaseForumActivityService.php
@@ -1,0 +1,97 @@
+<?php
+
+class DatabaseForumActivityService implements ForumActivityService {
+	const POST_FETCH_COUNT = 5;
+
+	public function getRecentlyUpdatedThreads(): array {
+		$dbr = wfGetDB( DB_SLAVE );
+
+		$res = $dbr->select(
+			[ 'page', 'comments_index', 'thread_rev' => 'revision', 'last_comment_rev' => 'revision' ],
+			[
+				'page_id', 'page_namespace', 'page_title',
+				'thread_rev.rev_text_id AS thread_text_id',
+				'thread_rev.rev_user AS thread_author_id',
+				'thread_rev.rev_user_text AS thread_author_name',
+				'thread_rev.rev_timestamp AS thread_modified_timestamp',
+				'last_comment_rev.rev_user AS last_comment_author_id',
+				'last_comment_rev.rev_user_text AS last_comment_author_name',
+				'last_comment_rev.rev_timestamp AS last_comment_timestamp'
+			],
+			[
+				'page_namespace' => NS_WIKIA_FORUM_BOARD_THREAD,
+				'archived' => 0,
+				'deleted' => 0,
+				'removed' => 0,
+				// only fetch threads, not replies
+				'parent_comment_id' => 0,
+				// check added so that the query planner can use proper index
+				'parent_page_id != 0'
+			],
+			__METHOD__,
+			[
+				'LIMIT' => static::POST_FETCH_COUNT,
+				'ORDER BY' => 'last_touched DESC'
+			],
+			[
+				'comments_index' => [ 'INNER JOIN', 'page_id = comment_id' ],
+				'last_comment_rev' => [ 'INNER JOIN', 'last_comment_rev.rev_page = last_child_comment_id' ],
+				'thread_rev' => [ 'INNER JOIN', 'thread_rev.rev_id = page_latest' ],
+			]
+		);
+
+		$postInfo = [];
+
+		foreach ( $res as $row ) {
+			$title = Title::newFromRow( $row );
+
+			$threadRevision = new Revision( [
+				'text_id' => $row->thread_text_id,
+				'user' => $row->thread_author_id,
+				'user_text' => $row->thread_author_name,
+				'timestamp' => $row->thread_modified_timestamp
+			] );
+			$updateRevision = new Revision( [
+				'user' => $row->last_comment_author_id,
+				'user_text' => $row->last_comment_author_name,
+				'timestamp' => $row->last_comment_timestamp
+			] );
+
+			// set comment text from already available revision
+			// this avoids redundant query when fetching Wall meta title
+			$articleComment = new ArticleComment( $title );
+			$articleComment->setRawText( $threadRevision->getRawText() );
+
+			$wallMessage = WallMessage::newFromArticleComment( $articleComment );
+
+			// SUS-4084: If the thread revision timestamp is higher than that of the last comment,
+			// then the thread was edited by the author and we should reflect that
+			if ( $threadRevision->getTimestamp() > $updateRevision->getTimestamp() ) {
+				$authorId = $threadRevision->getUser();
+				$authorName = $threadRevision->getUserText();
+				$eventTime = $threadRevision->getTimestamp();
+			} else {
+				$authorId = $updateRevision->getUser();
+				$authorName = $updateRevision->getUserText();
+				$eventTime = $updateRevision->getTimestamp();
+			}
+
+			if ( $authorId ) {
+				$authorLink = Title::makeTitle( NS_USER, $authorName );
+			} else {
+				$authorLink = SpecialPage::getTitleFor( 'Contributions', $authorName );
+			}
+
+			$postInfo[] = [
+				'authorId' => $authorId,
+				'authorName' => $authorName,
+				'authorUrl' => $authorLink->getFullURL(),
+				'threadUrl' => $wallMessage->getMessagePageUrl(),
+				'threadTitle' => $wallMessage->getMetaTitle(),
+				'timestamp' => $eventTime
+			];
+		}
+
+		return $postInfo;
+	}
+}

--- a/extensions/wikia/Forum/Forum.setup.php
+++ b/extensions/wikia/Forum/Forum.setup.php
@@ -7,7 +7,7 @@
  *
  */
 
-$wgExtensionCredits['specialpage'][] = [
+$GLOBALS['wgExtensionCredits']['specialpage'][] = [
 	'name' => 'Forum',
 	'author' => [ 'Hyun Lim', 'Kyle Florence', 'Saipetch Kongkatong', 'Tomasz Odrobny' ],
 	'url' => 'https://github.com/Wikia/app/tree/dev/extensions/wikia/Forum',
@@ -17,78 +17,82 @@ $wgExtensionCredits['specialpage'][] = [
 $dir = __DIR__ . '/';
 
 // classes
-$wgAutoloadClasses['ForumSpecialController'] =  $dir . 'ForumSpecialController.class.php' ;
-$wgAutoloadClasses['ForumHooksHelper'] =  $dir . 'ForumHooksHelper.class.php' ;
-$wgAutoloadClasses['ForumController'] =  $dir . 'ForumController.class.php' ;
-$wgAutoloadClasses['ForumNotificationPlugin'] =  $dir . 'ForumNotificationPlugin.class.php' ;
-$wgAutoloadClasses['Forum'] =  $dir . 'Forum.class.php' ;
-$wgAutoloadClasses['ForumBoard'] =  $dir . 'ForumBoard.class.php' ;
-$wgAutoloadClasses['ForumBoardInfo'] =  $dir . 'ForumBoardInfo.class.php' ;
-$wgAutoloadClasses['ForumPostInfo'] =  $dir . 'ForumPostInfo.class.php' ;
-$wgAutoloadClasses['ForumHelper'] =  $dir . 'ForumHelper.class.php' ;
-$wgAutoloadClasses['ForumExternalController'] =  $dir . 'ForumExternalController.class.php' ;
-$wgAutoloadClasses['RelatedForumDiscussionController'] =  $dir . 'RelatedForumDiscussionController.class.php' ;
-$wgAutoloadClasses['ThreadWatchlistDeleteUpdate'] = $dir . 'ThreadWatchlistDeleteUpdate.php';
+$GLOBALS['wgAutoloadClasses']['ForumSpecialController'] =  $dir . 'ForumSpecialController.class.php' ;
+$GLOBALS['wgAutoloadClasses']['ForumHooksHelper'] =  $dir . 'ForumHooksHelper.class.php' ;
+$GLOBALS['wgAutoloadClasses']['ForumController'] =  $dir . 'ForumController.class.php' ;
+$GLOBALS['wgAutoloadClasses']['ForumNotificationPlugin'] =  $dir . 'ForumNotificationPlugin.class.php' ;
+$GLOBALS['wgAutoloadClasses']['Forum'] =  $dir . 'Forum.class.php' ;
+$GLOBALS['wgAutoloadClasses']['ForumBoard'] =  $dir . 'ForumBoard.class.php' ;
+$GLOBALS['wgAutoloadClasses']['ForumBoardInfo'] =  $dir . 'ForumBoardInfo.class.php' ;
+$GLOBALS['wgAutoloadClasses']['ForumPostInfo'] =  $dir . 'ForumPostInfo.class.php' ;
+$GLOBALS['wgAutoloadClasses']['ForumHelper'] =  $dir . 'ForumHelper.class.php' ;
+$GLOBALS['wgAutoloadClasses']['ForumExternalController'] =  $dir . 'ForumExternalController.class.php' ;
+$GLOBALS['wgAutoloadClasses']['RelatedForumDiscussionController'] =  $dir . 'RelatedForumDiscussionController.class.php' ;
+$GLOBALS['wgAutoloadClasses']['ThreadWatchlistDeleteUpdate'] = $dir . 'ThreadWatchlistDeleteUpdate.php';
+
+$GLOBALS['wgAutoloadClasses']['ForumActivityService'] = __DIR__ . '/ForumActivityService.php';
+$GLOBALS['wgAutoloadClasses']['CachedForumActivityService'] = __DIR__ . '/CachedForumActivityService.php';
+$GLOBALS['wgAutoloadClasses']['DatabaseForumActivityService'] = __DIR__ . '/DatabaseForumActivityService.php';
 
 // i18n mapping
-$wgExtensionMessagesFiles['Forum'] = $dir . 'Forum.i18n.php' ;
-$wgExtensionMessagesFiles['ForumAliases'] = $dir . 'Forum.alias.php';
+$GLOBALS['wgExtensionMessagesFiles']['Forum'] = $dir . 'Forum.i18n.php' ;
+$GLOBALS['wgExtensionMessagesFiles']['ForumAliases'] = $dir . 'Forum.alias.php';
 
 // special pages
-$wgSpecialPages['Forum'] =  'ForumSpecialController';
+$GLOBALS['wgSpecialPages']['Forum'] =  'ForumSpecialController';
 
 // hooks
-$wgHooks['AfterWallWikiActivityFilter'][] = 'ForumHooksHelper::onAfterWallWikiActivityFilter';
-$wgHooks['WallContributionsLine'][] = 'ForumHooksHelper::onWallContributionsLine';
-$wgHooks['getUserPermissionsErrors'][] = 'ForumHooksHelper::getUserPermissionsErrors';
-$wgHooks['WallRecentchangesMessagePrefix'][] = 'ForumHooksHelper::onWallRecentchangesMessagePrefix';
-$wgHooks['WallThreadHeader'][] = 'ForumHooksHelper::onWallThreadHeader';
-$wgHooks['WallMessageGetWallOwnerName'][] = 'ForumHooksHelper::onWallMessageGetWallOwnerName';
+$GLOBALS['wgHooks']['AfterWallWikiActivityFilter'][] = 'ForumHooksHelper::onAfterWallWikiActivityFilter';
+$GLOBALS['wgHooks']['WallContributionsLine'][] = 'ForumHooksHelper::onWallContributionsLine';
+$GLOBALS['wgHooks']['getUserPermissionsErrors'][] = 'ForumHooksHelper::getUserPermissionsErrors';
+$GLOBALS['wgHooks']['WallRecentchangesMessagePrefix'][] = 'ForumHooksHelper::onWallRecentchangesMessagePrefix';
+$GLOBALS['wgHooks']['WallThreadHeader'][] = 'ForumHooksHelper::onWallThreadHeader';
+$GLOBALS['wgHooks']['WallMessageGetWallOwnerName'][] = 'ForumHooksHelper::onWallMessageGetWallOwnerName';
 
-$wgHooks['WallHistoryThreadHeader'][] = 'ForumHooksHelper::onWallHistoryThreadHeader';
-$wgHooks['WallHistoryHeader'][] = 'ForumHooksHelper::onWallHistoryHeader';
+$GLOBALS['wgHooks']['WallHistoryThreadHeader'][] = 'ForumHooksHelper::onWallHistoryThreadHeader';
+$GLOBALS['wgHooks']['WallHistoryHeader'][] = 'ForumHooksHelper::onWallHistoryHeader';
 
-$wgHooks['WallHeader'][] = 'ForumHooksHelper::onWallHeader';
-$wgHooks['WallNewMessage'][] = 'ForumHooksHelper::onWallNewMessage';
-$wgHooks['WallBeforeRenderThread'][] = 'ForumHooksHelper::onWallBeforeRenderThread';
-$wgHooks['AfterBuildNewMessageAndPost'][] = 'ForumHooksHelper::onAfterBuildNewMessageAndPost';
-$wgHooks['WallMessageDeleted'][] = 'ForumHooksHelper::onWallMessageDeleted';
-$wgHooks['ContributionsLineEnding'][] = 'ForumHooksHelper::onContributionsLineEnding';
-$wgHooks['OasisAddPageDeletedConfirmationMessage'][] = 'ForumHooksHelper::onOasisAddPageDeletedConfirmationMessage';
-$wgHooks['FilePageImageUsageSingleLink'][] = 'ForumHooksHelper::onFilePageImageUsageSingleLink';
-$wgHooks['AfterPageHeaderPageSubtitle'][] = 'ForumHooksHelper::onAfterPageHeaderPageSubtitle';
-$wgHooks['PageHeaderActionButtonShouldDisplay'][] = 'ForumHooksHelper::onPageHeaderActionButtonShouldDisplay';
+$GLOBALS['wgHooks']['WallHeader'][] = 'ForumHooksHelper::onWallHeader';
+$GLOBALS['wgHooks']['WallNewMessage'][] = 'ForumHooksHelper::onWallNewMessage';
+$GLOBALS['wgHooks']['WallBeforeRenderThread'][] = 'ForumHooksHelper::onWallBeforeRenderThread';
+$GLOBALS['wgHooks']['AfterBuildNewMessageAndPost'][] = 'ForumHooksHelper::onAfterBuildNewMessageAndPost';
+$GLOBALS['wgHooks']['WallMessageDeleted'][] = 'ForumHooksHelper::onWallMessageDeleted';
+$GLOBALS['wgHooks']['ContributionsLineEnding'][] = 'ForumHooksHelper::onContributionsLineEnding';
+$GLOBALS['wgHooks']['OasisAddPageDeletedConfirmationMessage'][] = 'ForumHooksHelper::onOasisAddPageDeletedConfirmationMessage';
+$GLOBALS['wgHooks']['FilePageImageUsageSingleLink'][] = 'ForumHooksHelper::onFilePageImageUsageSingleLink';
+$GLOBALS['wgHooks']['AfterPageHeaderPageSubtitle'][] = 'ForumHooksHelper::onAfterPageHeaderPageSubtitle';
+$GLOBALS['wgHooks']['PageHeaderActionButtonShouldDisplay'][] = 'ForumHooksHelper::onPageHeaderActionButtonShouldDisplay';
 
 // notification hooks
-$wgHooks['NotificationGetNotificationMessage'][] = 'ForumNotificationPlugin::onGetNotificationMessage';
+$GLOBALS['wgHooks']['NotificationGetNotificationMessage'][] = 'ForumNotificationPlugin::onGetNotificationMessage';
 
 // forum discussion on article
 // It need to be first one !!!
-array_splice( $wgHooks['OutputPageBeforeHTML'], 0, 0, 'ForumHooksHelper::onOutputPageBeforeHTML' );
+array_splice( $GLOBALS['wgHooks']['OutputPageBeforeHTML'], 0, 0, 'ForumHooksHelper::onOutputPageBeforeHTML' );
 
-$wgHooks['WallAction'][] = 'ForumHooksHelper::onWallAction';
-$wgHooks['WallBeforeStoreRelatedTopicsInDB'][] = 'ForumHooksHelper::onWallStoreRelatedTopicsInDB';
-$wgHooks['WallAfterStoreRelatedTopicsInDB'][] = 'ForumHooksHelper::onWallStoreRelatedTopicsInDB';
+$GLOBALS['wgHooks']['WallAction'][] = 'ForumHooksHelper::onWallAction';
+$GLOBALS['wgHooks']['WallBeforeStoreRelatedTopicsInDB'][] = 'ForumHooksHelper::onWallStoreRelatedTopicsInDB';
+$GLOBALS['wgHooks']['WallAfterStoreRelatedTopicsInDB'][] = 'ForumHooksHelper::onWallStoreRelatedTopicsInDB';
 
-$wgHooks['ArticleFromTitle'][] = 'ForumHooksHelper::onArticleFromTitle';
+$GLOBALS['wgHooks']['ArticleFromTitle'][] = 'ForumHooksHelper::onArticleFromTitle';
 
 // For activity module tag
-$wgHooks['ParserFirstCallInit'][] = 'ForumHooksHelper::onParserFirstCallInit';
+$GLOBALS['wgHooks']['ParserFirstCallInit'][] = 'ForumHooksHelper::onParserFirstCallInit';
 
 // Hook for topic red links
-$wgHooks['LinkBegin'][] = 'ForumHooksHelper::onLinkBegin';
+$GLOBALS['wgHooks']['LinkBegin'][] = 'ForumHooksHelper::onLinkBegin';
 
 // Fix URLs of thread pages when purging them.
-$wgHooks['TitleGetSquidURLs'][] = 'ForumHooksHelper::onTitleGetSquidURLs';
-$wgHooks['ArticleCommentGetSquidURLs'][] = 'ForumHooksHelper::onArticleCommentGetSquidURLs';
+$GLOBALS['wgHooks']['TitleGetSquidURLs'][] = 'ForumHooksHelper::onTitleGetSquidURLs';
+$GLOBALS['wgHooks']['ArticleCommentGetSquidURLs'][] = 'ForumHooksHelper::onArticleCommentGetSquidURLs';
 
 // SUS-1196: Invalidate "Forum Activity" rail module when deleting a thread via Nuke / Quick Tools
-$wgHooks['ArticleDeleteComplete'][] = 'ForumHooksHelper::onArticleDeleteComplete';
+$GLOBALS['wgHooks']['ArticleDeleteComplete'][] = 'ForumHooksHelper::onArticleDeleteComplete';
 
 // SUS-260: Prevent moving pages within, into or out of Forum namespaces
-$wgHooks['MWNamespace:isMovable'][] = 'ForumHooksHelper::onNamespaceIsMovable';
+$GLOBALS['wgHooks']['MWNamespace:isMovable'][] = 'ForumHooksHelper::onNamespaceIsMovable';
 
-$wgHooks['AfterPageHeaderButtons'][] = 'ForumHooksHelper::onAfterPageHeaderButtons';
+$GLOBALS['wgHooks']['AfterPageHeaderButtons'][] = 'ForumHooksHelper::onAfterPageHeaderButtons';
 
 include ( $dir . '/Forum.namespace.setup.php' );
 

--- a/extensions/wikia/Forum/ForumActivityService.php
+++ b/extensions/wikia/Forum/ForumActivityService.php
@@ -1,0 +1,11 @@
+<?php
+
+interface ForumActivityService {
+	/**
+	 * Returns information about the N most recently modified Forum threads.
+	 * Information includes thread URL, thread title, author data, and timestamp.
+	 *
+	 * @return array
+	 */
+	public function getRecentlyUpdatedThreads(): array;
+}

--- a/extensions/wikia/Forum/ForumController.class.php
+++ b/extensions/wikia/Forum/ForumController.class.php
@@ -281,8 +281,11 @@ class ForumController extends WallBaseController {
 	}
 
 	public function forumActivityModule() {
-		$wallHistory = new WallHistory();
-		$out = $wallHistory->getLastPosts( NS_WIKIA_FORUM_BOARD );
+		$baseForumActivityService = new DatabaseForumActivityService();
+		$forumActivityService = new CachedForumActivityService( $baseForumActivityService, $this->wg->Memc );
+
+		$out = $forumActivityService->getRecentlyUpdatedThreads();
+
 		$this->response->setVal( 'posts', $out );
 	}
 

--- a/extensions/wikia/Forum/ForumHooksHelper.class.php
+++ b/extensions/wikia/Forum/ForumHooksHelper.class.php
@@ -319,6 +319,9 @@ class ForumHooksHelper {
 					'exception' => $entryNotFoundException
 				] );
 			}
+
+			// SUS-4084: Purge Forum activity module cache here - we don't need to purge it when a Wall thread changes
+			CachedForumActivityService::purgeCache();
 		}
 		return true;
 	}
@@ -466,8 +469,7 @@ class ForumHooksHelper {
 		$pageTitle = $page->getTitle();
 
 		if ( $pageTitle->inNamespace( NS_WIKIA_FORUM_BOARD_THREAD ) ) {
-			$wallHistory = new WallHistory();
-			WikiaDataAccess::cachePurge( $wallHistory->getLastPostsMemcKey() );
+			CachedForumActivityService::purgeCache();
 
 			// SUS-2757: After the main transaction is closed, delete watchlist entries for thread
 			$threadWatchlistDeleteUpdate = new ThreadWatchlistDeleteUpdate( $pageTitle );

--- a/extensions/wikia/Forum/templates/Forum_forumActivityModule.php
+++ b/extensions/wikia/Forum/templates/Forum_forumActivityModule.php
@@ -3,21 +3,21 @@
 	<ul class="activity-items">
 		<?php foreach ( $posts as $value ): ?>
 		<li class="activity-item">
-			<?php $username = User::isIP( $value['display_username'] ) ? wfMessage( 'oasis-anon-user' )->escaped() : htmlspecialchars( $value['display_username'] ); ?>
+			<?php $displayName = $value['authorId'] ? htmlspecialchars( $value['authorName'], ENT_QUOTES ) : wfMessage( 'oasis-anon-user' )->escaped(); ?>
 
-			<a class="activity-avatar" href="<?= $value['user']->getUserPage()->getFullUrl() ?>">
-				<img class="wds-avatar" src="<?= AvatarService::getAvatarUrl( $value['user']->getName(), 30 ) ?>" data-tracking="activity-avatar" title="<?= $username ?>" />
+			<a class="activity-avatar" href="<?= Sanitizer::encodeAttribute( $value['authorUrl'] ); ?>">
+				<img class="wds-avatar" src="<?= AvatarService::getAvatarUrl( $value['authorName'], 30 ) ?>" data-tracking="activity-avatar" title="<?= $displayName ?>" />
 			</a>
 
 			<div class="activity-info">
 				<div class="page-title">
-					<a href="<?= $value['wall_message']->getMessagePageUrl( true ); ?>" title="<?= Sanitizer::encodeAttribute( $value['metatitle'] ); ?>" data-tracking="activity-title"><?= htmlspecialchars( $value['metatitle'] ); ?></a>
+					<a href="<?= Sanitizer::encodeAttribute( $value['threadUrl'] ); ?>" title="<?= Sanitizer::encodeAttribute( $value['threadTitle'] ); ?>" data-tracking="activity-title"><?= htmlspecialchars( $value['threadTitle'] ); ?></a>
 				</div>
 
 				<div class="edit-info">
-					<a class="edit-info-user" href="<?= $value['user']->getUserPage()->getFullUrl() ?>" data-tracking="activity-username">
-						<?= $username ?>
-					</a><span class="edit-info-time"> • <?= wfTimeFormatAgo( $value['event_iso'] ) ?></span>
+					<a class="edit-info-user" href="<?= Sanitizer::encodeAttribute( $value['authorUrl'] ); ?>" data-tracking="activity-username">
+						<?= $displayName ?>
+					</a><span class="edit-info-time"> • <?= wfTimeFormatAgo( $value['timestamp'] ); ?></span>
 				</div>
 			</div>
 		</li>

--- a/extensions/wikia/Forum/tests/CachedForumActivityServiceTest.php
+++ b/extensions/wikia/Forum/tests/CachedForumActivityServiceTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class CachedForumActivityServiceTest extends TestCase {
+	/** @var PHPUnit_Framework_MockObject_MockObject|BagOStuff $cacheServiceSpy */
+	private $cacheServiceSpy;
+	/** @var PHPUnit_Framework_MockObject_MockObject|ForumActivityService $forumActivityServiceMock */
+	private $forumActivityServiceMock;
+
+	/** @var ForumActivityService $cachedForumActivityService */
+	private $cachedForumActivityService;
+
+	protected function setUp() {
+		parent::setUp();
+		require_once __DIR__ . '/../Forum.setup.php';
+
+		$this->cacheServiceSpy = $this->getMockBuilder( HashBagOStuff::class )
+			->enableProxyingToOriginalMethods()
+			->getMock();
+
+		$this->forumActivityServiceMock = $this->getMockBuilder( ForumActivityService::class )
+			->getMockForAbstractClass();
+
+		$this->cachedForumActivityService =
+			new CachedForumActivityService( $this->forumActivityServiceMock, $this->cacheServiceSpy );
+	}
+
+	/**
+	 * @dataProvider provideFreshValues
+	 * @param array $freshValue
+	 */
+	public function testFreshResultFetchedOnCacheMissThenCached( array $freshValue ) {
+		$this->cacheServiceSpy->expects( $this->exactly( 2 ) )
+			->method( 'get' );
+
+		$this->cacheServiceSpy->expects( $this->once() )
+			->method( 'set' )
+			->with( $this->anything(), $this->equalTo( $freshValue ), CachedForumActivityService::CACHE_TTL );
+
+		$this->forumActivityServiceMock->expects( $this->once() )
+			->method( 'getRecentlyUpdatedThreads' )
+			->willReturn( $freshValue );
+
+		$freshResult = $this->cachedForumActivityService->getRecentlyUpdatedThreads();
+		$cachedResult = $this->cachedForumActivityService->getRecentlyUpdatedThreads();
+
+		$this->assertEquals( $freshValue, $freshResult );
+		$this->assertEquals( $freshValue, $cachedResult );
+	}
+
+	public function provideFreshValues() {
+		yield 'empty array' => [ [] ];
+		yield 'non-empty data' => [ [ 'authorId' => 0, 'authorName' => 'Foo' ] ];
+	}
+}

--- a/extensions/wikia/Forum/tests/DatabaseForumActivityServiceIntegrationTest.php
+++ b/extensions/wikia/Forum/tests/DatabaseForumActivityServiceIntegrationTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @group Integration
+ */
+class DatabaseForumActivityServiceIntegrationTest extends WikiaDatabaseTest {
+	/** @var ForumActivityService $forumActivityService */
+	private $forumActivityService;
+
+	protected function setUp() {
+		parent::setUp();
+		$this->forumActivityService = new DatabaseForumActivityService();
+	}
+
+	protected function extraSchemaFiles() {
+		yield __DIR__ . '/fixtures/comments_index.sql';
+	}
+
+	public function testGetRecentlyUpdatedThreads() {
+		$postInfo = $this->forumActivityService->getRecentlyUpdatedThreads();
+
+		$this->assertCount( 2, $postInfo );
+
+		$this->assertEquals( 0, $postInfo[0]['authorId'] );
+		$this->assertEquals( '8.8.8.8', $postInfo[0]['authorName'] );
+		$this->assertStringEndsWith(
+			'Thread:3',
+			$postInfo[0]['threadUrl']
+		);
+		$this->assertEquals( 'Lorem ipsum', $postInfo[0]['threadTitle'] );
+		$this->assertEquals( '20180211093609', $postInfo[0]['timestamp'] );
+
+		$this->assertEquals( 0, $postInfo[1]['authorId'] );
+		$this->assertEquals( '8.8.8.8', $postInfo[1]['authorName'] );
+		$this->assertStringEndsWith(
+			'Thread:2',
+			$postInfo[1]['threadUrl']
+		);
+		$this->assertEquals( 'Foo', $postInfo[1]['threadTitle'] );
+		$this->assertEquals( '20180211103609', $postInfo[1]['timestamp'] );
+
+	}
+
+	protected function getDataSet() {
+		return $this->createYamlDataSet( __DIR__ . '/fixtures/recently_updated_threads.yaml' );
+	}
+}

--- a/extensions/wikia/Forum/tests/fixtures/comments_index.sql
+++ b/extensions/wikia/Forum/tests/fixtures/comments_index.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS /*$wgDBprefix*/comments_index (
+  `parent_page_id` int(10) NOT NULL,
+  `comment_id` int(10) NOT NULL,
+  `parent_comment_id` int(10) NOT NULL DEFAULT '0',
+  `last_child_comment_id` int(10) NOT NULL DEFAULT '0',
+  `archived` tinyint(1) NOT NULL DEFAULT '0',
+  `deleted` tinyint(1) NOT NULL DEFAULT '0',
+  `removed` tinyint(1) NOT NULL DEFAULT '0',
+  `first_rev_id` int(10) NOT NULL DEFAULT '0',
+  `created_at` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `last_rev_id` int(10) NOT NULL DEFAULT '0',
+  `last_touched` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+  PRIMARY KEY (`parent_page_id`,`comment_id`)
+);
+
+CREATE INDEX `parent_page_id` ON comments_index (`parent_page_id`,`archived`,`deleted`,`removed`,`parent_comment_id`);
+CREATE INDEX `comment_id` ON comments_index (`comment_id`,`archived`,`deleted`,`removed`);
+CREATE INDEX `parent_comment_id` ON comments_index (`parent_comment_id`,`archived`,`deleted`,`removed`);
+CREATE INDEX `last_touched` ON comments_index (`last_touched`,`archived`,`deleted`,`removed`,`parent_comment_id`,`parent_page_id`);

--- a/extensions/wikia/Forum/tests/fixtures/recently_updated_threads.yaml
+++ b/extensions/wikia/Forum/tests/fixtures/recently_updated_threads.yaml
@@ -1,0 +1,121 @@
+user:
+  - user_id: 1
+    user_name: 'TestUser'
+    user_real_name: ''
+    user_email: 'kossuth.lajos@lajoskossuth.hu'
+    user_touched: '20110101000000'
+    user_token: 'loremipsum'
+    user_email_authenticated: '20101102000000'
+    user_email_token: 'dolorsitamet'
+    user_email_token_expires: '20120301120000'
+    user_registration: '20090604060000'
+    user_editcount: 2500
+    user_birthdate:
+page:
+  - page_id: 1
+    page_namespace: 1
+    page_title: Irrelevant Page
+    page_restrictions: ''
+    page_random: 0
+    page_latest: 1
+    page_len: 0
+  - page_id: 2
+    page_namespace: 2001
+    page_title: Support_Requests_-_Designing_Your_Wiki/@comment-TestUser-20180211093609
+    page_restrictions: ''
+    page_random: 0
+    page_latest: 2
+    page_len: 0
+  - page_id: 3
+    page_namespace: 2001
+    page_title: Support_Requests_-_Designing_Your_Wiki/@comment-8.8.8.8-20180211093609
+    page_restrictions: ''
+    page_random: 0
+    page_latest: 3
+    page_len: 0
+  - page_id: 4
+    page_namespace: 2001
+    page_title: Support_Requests_-_Designing_Your_Wiki/@comment-TestUser-20180211093609/@comment-8.8.8.8-20180211103609
+    page_restrictions: ''
+    page_random: 0
+    page_latest: 4
+    page_len: 0
+revision:
+  - rev_id: 1
+    rev_page: 1
+    rev_text_id: 1
+    rev_comment: ''
+    rev_user: 0
+    rev_user_text: 188.146.144.183
+    rev_timestamp: 20170311121633
+  - rev_id: 2
+    rev_page: 2
+    rev_parent_id: 0
+    rev_text_id: 2
+    rev_comment: ''
+    rev_user: 1
+    rev_user_text: ''
+    rev_timestamp: 20180211093609
+  - rev_id: 3
+    rev_page: 3
+    rev_parent_id: 0
+    rev_text_id: 3
+    rev_comment: ''
+    rev_user: 0
+    rev_user_text: 8.8.8.8
+    rev_timestamp: 20180211093609
+  - rev_id: 4
+    rev_page: 4
+    rev_parent_id: 0
+    rev_text_id: 4
+    rev_comment: ''
+    rev_user: 0
+    rev_user_text: 8.8.8.8
+    rev_timestamp: 20180211103609
+text:
+  - old_id: 1
+    old_text: Lorem ipsum
+    old_flags: ''
+  - old_id: 2
+    old_text: '<ac_metadata title="Foo"></ac_metadata>'
+    old_flags: ''
+  - old_id: 3
+    old_text: '<ac_metadata title="Lorem ipsum"></ac_metadata>'
+    old_flags: ''
+  - old_id: 4
+    old_text: Test post
+    old_flags: ''
+comments_index:
+  - parent_page_id: 999 # for test
+    comment_id: 2
+    parent_comment_id: 0
+    last_child_comment_id: 4
+    archived: 0
+    deleted: 0
+    removed: 0
+    first_rev_id: 2
+    created_at: 20180211093609
+    last_rev_id: 2
+    last_touched: 20180211103609
+  - parent_page_id: 999 # for test
+    comment_id: 3
+    parent_comment_id: 0
+    last_child_comment_id: 3
+    archived: 0
+    deleted: 0
+    removed: 0
+    first_rev_id: 3
+    created_at: 20180212093609
+    last_rev_id: 3
+    last_touched: 20180212093609
+  - parent_page_id: 999 # for test
+    comment_id: 4
+    parent_comment_id: 2
+    last_child_comment_id: 2
+    archived: 0
+    deleted: 0
+    removed: 0
+    first_rev_id: 4
+    created_at: 20180211103609
+    last_rev_id: 4
+    last_touched: 20180211103609

--- a/includes/wikia/tests/core/WikiaDatabaseTest.php
+++ b/includes/wikia/tests/core/WikiaDatabaseTest.php
@@ -61,8 +61,19 @@ abstract class WikiaDatabaseTest extends TestCase {
 
 		$this->mockGlobalVariable( 'wgMemc', new EmptyBagOStuff() );
 
+		foreach ( $this->extraSchemaFiles() as $schemaFile ) {
+			static::loadSchemaFile( $schemaFile );
+		}
+
 		// schema is ready, let DbUnit populate the DB with fixtures
 		$this->databaseSetUp();
+	}
+
+	/**
+	 * Override this in the test class to load extra schema files
+	 */
+	protected function extraSchemaFiles() {
+		return [];
 	}
 
 	/**


### PR DESCRIPTION
Optimize SQL query performance in Forum activity module.

Changes summary:
* extracted Forum specific code to Forum extension from Wall
* module now actually returns 5 entries when available, not some other number
* module now correctly detects if the thread was edited by the author, and reflects such updates
* module cache is no longer purged when a Wall thread (rather than a Forum one) is changed.

## Before the optimization
`WallHistory::getLastPosts` method would generate nested SQL query on cache miss:
```sql
SELECT `parent_page_id`,
       `post_user_id`,
       `post_user_ip_bin`,
       `is_reply`,
       `parent_comment_id`,
       `comment_id`,
       `action`,
       `event_date`,
       (SELECT `metatitle`
        FROM   `wall_history` AS `last_title`
        WHERE  `parent_comment_id` = `wall_history`.`parent_comment_id`
               AND ( `event_date`, `revision_id` ) = (SELECT Max(`event_date`),
                                                             Max(`revision_id`)
                                                      FROM   `wall_history`
                                                      WHERE
                   `action` IN ( 0, 1 )
                   AND `parent_comment_id` =
               `last_title`.`parent_comment_id`)
        LIMIT  1) AS `metatitle`,
       `reason`,
       `revision_id`
FROM   `wall_history`
       RIGHT JOIN(SELECT `parent_comment_id`,
                         Max(`event_date`)  AS `event_date`,
                         Max(`revision_id`) AS `revision_id`
                  FROM   `wall_history`
                         RIGHT JOIN(SELECT `parent_comment_id`
                                    FROM   `wall_history`
                                    WHERE  `action` = 1
                                           AND `deleted_or_removed` = 0
                                           AND `post_ns` = 2000
                                           AND `is_reply` = 0) AS
                                   `not_removed_parents`
                         USING (
                         `parent_comment_id`)
                  WHERE  `action` = 1
                         AND `deleted_or_removed` = 0
                         AND `post_ns` = 2000
                  GROUP  BY `parent_comment_id`
                  ORDER  BY `event_date` DESC
                  LIMIT  5) AS `last_new_post_date` USING (
       `parent_comment_id`, `event_date`, `revision_id`); 
```
`EXPLAIN` output:
```
+----+--------------------+--------------+------------+------+--------------------+--------------------+---------+--------------------------------------------------------------------+--------+----------+----------------------------------------------+
| id | select_type        | table        | partitions | type | possible_keys      | key                | key_len | ref                                                                | rows   | filtered | Extra                                        |
+----+--------------------+--------------+------------+------+--------------------+--------------------+---------+--------------------------------------------------------------------+--------+----------+----------------------------------------------+
|  1 | PRIMARY            | <derived4>   | NULL       | ALL  | NULL               | NULL               | NULL    | NULL                                                               |      2 |   100.00 | NULL                                         |
|  1 | PRIMARY            | wall_history | NULL       | ref  | getByParentComment | getByParentComment | 9       | last_new_post_date.parent_comment_id,last_new_post_date.event_date |      1 |   100.00 | Using where                                  |
|  4 | DERIVED            | wall_history | NULL       | ALL  | getByParentComment | NULL               | NULL    | NULL                                                               | 542702 |     0.01 | Using where; Using temporary; Using filesort |
|  4 | DERIVED            | wall_history | NULL       | ref  | getByParentComment | getByParentComment | 5       | wikia.wall_history.parent_comment_id                               |      2 |     1.69 | Using where                                  |
|  2 | DEPENDENT SUBQUERY | last_title   | NULL       | ref  | getByParentComment | getByParentComment | 5       | wikia.wall_history.parent_comment_id                               |      2 |   100.00 | Using where                                  |
|  3 | DEPENDENT SUBQUERY | wall_history | NULL       | ref  | getByParentComment | getByParentComment | 5       | wikia.last_title.parent_comment_id                                 |      2 |    20.00 | Using where                                  |
+----+--------------------+--------------+------------+------+--------------------+--------------------+---------+--------------------------------------------------------------------+--------+----------+----------------------------------------------+
6 rows in set, 3 warnings (0.00 sec)
```
Return values and execution time on `vsbattles` database:
```
+----------------+--------------+------------------+----------+-------------------+------------+--------+---------------------+------------------------------------------------------------+--------+-------------+
| parent_page_id | post_user_id | post_user_ip_bin | is_reply | parent_comment_id | comment_id | action | event_date          | metatitle                                                  | reason | revision_id |
+----------------+--------------+------------------+----------+-------------------+------------+--------+---------------------+------------------------------------------------------------+--------+-------------+
|          32586 |     32333285 | NULL             |        0 |           1376655 |    1376655 |      1 | 2018-02-12 16:15:24 | I narrowly dodge the Mami Spam (I think)                   | NULL   |     2190177 |
|          32586 |     28702329 | NULL             |        1 |           1373324 |    1376656 |      1 | 2018-02-12 16:15:24 | NOT EQUALIZED SPEED: Accelerator vs Doflamingo             | NULL   |     2190178 |
|          32586 |     30472761 | NULL             |        1 |           1373296 |    1376654 |      1 | 2018-02-12 16:15:09 | Hashirama Senju vs Sosuke Aizen                            | NULL   |     2190176 |
|           3523 |     26879614 | NULL             |        1 |            972086 |    1376653 |      1 | 2018-02-12 16:15:06 | Re:Zero Kara Hajimeru Isekai Seikatsu Discussion Thread 16 | NULL   |     2190175 |
|          32586 |     26984863 | NULL             |        1 |           1205906 |    1376651 |      1 | 2018-02-12 16:14:32 | Stabbing concepts vs Punching concepts                     | NULL   |     2190173 |
+----------------+--------------+------------------+----------+-------------------+------------+--------+---------------------+------------------------------------------------------------+--------+-------------+
5 rows in set (11.70 sec)
```

## After the optimization
A simpler query is used:
```sql
SELECT page.page_id                   AS page_id,
       page.page_namespace            AS page_namespace,
       page.page_title                AS page_title,
       thread_rev.rev_text_id         AS thread_text_id,
       thread_rev.rev_user            AS thread_author_id,
       thread_rev.rev_user_text       AS thread_author_name,
       thread_rev.rev_timestamp       AS thread_modified_timestamp,
       last_comment_rev.rev_user      AS last_comment_author_id,
       last_comment_rev.rev_user_text AS last_comment_author_name,
       last_comment_rev.rev_timestamp AS last_comment_timestamp
FROM   `page`
       INNER JOIN `comments_index`
               ON (( page.page_id = comment_id ))
       INNER JOIN `revision` `thread_rev`
               ON (( thread_rev.rev_id = page.page_latest ))
       INNER JOIN `page` `last_comment_page`
               ON (( last_comment_page.page_id = last_child_comment_id ))
       INNER JOIN `revision` `last_comment_rev`
               ON (( last_comment_rev.rev_id = last_comment_page.page_latest ))
WHERE  page.page_namespace = '2001'
       AND archived = '0'
       AND deleted = '0'
       AND removed = '0'
       AND parent_comment_id = '0'
       AND ( parent_page_id != 0 )
ORDER  BY last_touched DESC
LIMIT  5; 
```
`EXPLAIN` output:
```
+----+-------------+-------------------+------------+--------+-----------------------------------------------------+--------------+---------+------------------------------------------------+------+----------+-------------+
| id | select_type | table             | partitions | type   | possible_keys                                       | key          | key_len | ref                                            | rows | filtered | Extra       |
+----+-------------+-------------------+------------+--------+-----------------------------------------------------+--------------+---------+------------------------------------------------+------+----------+-------------+
|  1 | SIMPLE      | comments_index    | NULL       | index  | PRIMARY,comment_id,parent_comment_id,parent_page_id | last_touched | 16      | NULL                                           |   55 |     0.09 | Using where |
|  1 | SIMPLE      | page              | NULL       | eq_ref | PRIMARY,name_title,page_ns_latest_idx               | PRIMARY      | 4       | vsbattles.comments_index.comment_id            |    1 |    50.00 | Using where |
|  1 | SIMPLE      | last_comment_page | NULL       | eq_ref | PRIMARY                                             | PRIMARY      | 4       | vsbattles.comments_index.last_child_comment_id |    1 |   100.00 | NULL        |
|  1 | SIMPLE      | thread_rev        | NULL       | eq_ref | rev_id                                              | rev_id       | 4       | vsbattles.page.page_latest                     |    1 |   100.00 | NULL        |
|  1 | SIMPLE      | last_comment_rev  | NULL       | eq_ref | rev_id                                              | rev_id       | 4       | vsbattles.last_comment_page.page_latest        |    1 |   100.00 | NULL        |
+----+-------------+-------------------+------------+--------+-----------------------------------------------------+--------------+---------+------------------------------------------------+------+----------+-------------+
5 rows in set, 1 warning (0.01 sec)
```
Return values and execution time on `vsbattles` database:
```
+---------+----------------+------------------------------------------------------------+----------------+------------------+--------------------+---------------------------+------------------------+--------------------------+------------------------+
| page_id | page_namespace | page_title                                                 | thread_text_id | thread_author_id | thread_author_name | thread_modified_timestamp | last_comment_author_id | last_comment_author_name | last_comment_timestamp |
+---------+----------------+------------------------------------------------------------+----------------+------------------+--------------------+---------------------------+------------------------+--------------------------+------------------------+
| 1332021 |           2001 | General_Discussion/@comment-Veloxt1r0kore-20180130045757   |        2097255 |         31760473 |                    | 20180204053901            |               26865490 |                          | 20180212161338         |
| 1375402 |           2001 | Content_Revision/@comment-Thebluedash-20180212063148       |        2133568 |         26041742 |                    | 20180212063148            |               26984863 |                          | 20180212161256         |
| 1369182 |           2001 | Versus_Threads/@comment-The_real_cal_howard-20180210204333 |        2125118 |         27175658 |                    | 20180210204333            |               27175658 |                          | 20180212161252         |
| 1295448 |           2001 | Wiki_Management/@comment-Antvasima-20180118090303          |        2020863 |         24383490 |                    | 20180118090303            |               26474458 |                          | 20180212161239         |
| 1374761 |           2001 | Versus_Threads/@comment-Nico-v11-20180212023121            |        2134952 |         30742659 |                    | 20180212150021            |               26971556 |                          | 20180212161223         |
+---------+----------------+------------------------------------------------------------+----------------+------------------+--------------------+---------------------------+------------------------+--------------------------+------------------------+
5 rows in set (0.00 sec)
```

https://wikia-inc.atlassian.net/browse/SUS-4084