### PR TITLE
SUS-3279 | SunsetProvider - fallback to image table, video_info is out of sync on mediawiki119.wikia.com

### DIFF
--- a/maintenance/wikia/VideoHandlers/SunsetProvider.php
+++ b/maintenance/wikia/VideoHandlers/SunsetProvider.php
@@ -43,7 +43,9 @@ class SunsetProvider extends Maintenance {
 	 * @return ResultWrapper
 	 */
 	private function getProviderVideos( string $providerName ): ResultWrapper {
-		$videoEmbeds = $this->getDB( DB_SLAVE )->select(
+		$db = $this->getDB( DB_SLAVE );
+
+		$videoEmbeds = $db->select(
 			'video_info',
 			'video_title',
 			[
@@ -52,6 +54,24 @@ class SunsetProvider extends Maintenance {
 			],
 			__METHOD__
 		);
+
+		// fallback to image table, video_info is out of sync on mediawiki119.wikia.com
+		if ( $db->affectedRows() === 0 ) {
+			$videoEmbeds = $db->select(
+				'image',
+				'img_name AS video_title',
+				[
+					'img_minor_mime' => $providerName,
+					'img_media_type' => 'VIDEO'
+				],
+				__METHOD__
+			);
+
+			if ( $db->affectedRows() > 0 ) {
+				$this->output( sprintf( "Applied fallback to image table for %s provider",
+					$providerName ) );
+			}
+		}
 
 		return $videoEmbeds;
 	}

--- a/maintenance/wikia/VideoHandlers/SunsetProvider.php
+++ b/maintenance/wikia/VideoHandlers/SunsetProvider.php
@@ -68,7 +68,7 @@ class SunsetProvider extends Maintenance {
 			);
 
 			if ( $db->affectedRows() > 0 ) {
-				$this->output( sprintf( "Applied fallback to image table for %s provider",
+				$this->output( sprintf( "Applied fallback to image table for '%s' provider\n",
 					$providerName ) );
 			}
 		}


### PR DESCRIPTION
The script that removes videos from providers that we no longer support has some problems dealing with our test wiki. `video_info` and `image` table is out of sync there:

```sql
mysql@geo-db-f-slave.query.consul[mediawiki119cleanup4]>select count(*) from video_info where provider IN ("viddler","twitchtv","internetvideoarchive","makerstudios","iva","sevenload","southparkstudios","movieclips","crunchyroll","gametrailers","fivemin","ustream","hulu","anyclip","ooyala");
+----------+
| count(*) |
+----------+
|     2963 |
+----------+
1 row in set (0.01 sec)

mysql@geo-db-f-slave.query.consul[mediawiki119cleanup4]>select count(*) from image where img_media_type = 'VIDEO' and img_minor_mime IN ("viddler","twitchtv","internetvideoarchive","makerstudios","iva","sevenload","southparkstudios","movieclips","crunchyroll","gametrailers","fivemin","ustream","hulu","anyclip","ooyala");
+----------+
| count(*) |
+----------+
|     4897 |
+----------+
1 row in set (0.05 sec)
```

This change adds a fallback that is applied when `video_info` table query returns no rows. `image` table is then used.

```
macbre@cron-s1:~/app/maintenance/wikia$ SERVER_ID=203236 php VideoHandlers/SunsetProvider.php --provider=viddler
Applied fallback to image table for viddler provider
MyHome::savingAnRc:mediawiki119cleanup4/203236: RecentChange has arrived.
Deleted File:Lawn_mower_beer_train_gets_pulled_over video
MyHome::savingAnRc:mediawiki119cleanup4/203236: RecentChange has arrived.
```