### PR TITLE
SUS-4183 | make environments great again

### DIFF
--- a/extensions/wikia/AnalyticsEngine/AnalyticsProviderGoogleUA.php
+++ b/extensions/wikia/AnalyticsEngine/AnalyticsProviderGoogleUA.php
@@ -37,7 +37,7 @@ class AnalyticsProviderGoogleUA implements iAnalyticsProvider {
 		}
 
 		// Enable collecting stats to staging accounts on all dev and staging environments
-		if ( $wgWikiaEnvironment !== WIKIA_ENV_PROD ) {
+		if ( !Wikia::isProductionEnv() ) {
 			$vars['wgGaStaging'] = true;
 		}
 

--- a/extensions/wikia/AnalyticsEngine/AnalyticsProviderGoogleUA.php
+++ b/extensions/wikia/AnalyticsEngine/AnalyticsProviderGoogleUA.php
@@ -18,7 +18,7 @@ class AnalyticsProviderGoogleUA implements iAnalyticsProvider {
 	}
 
 	static public function onWikiaSkinTopScripts( &$vars, &$scripts, $skin ){
-		global $wgDevelEnvironment, $wgGAUserIdSalt, $wgStagingEnvironment;
+		global $wgWikiaEnvironment, $wgGAUserIdSalt;
 
 		$app = F::app();
 
@@ -37,7 +37,7 @@ class AnalyticsProviderGoogleUA implements iAnalyticsProvider {
 		}
 
 		// Enable collecting stats to staging accounts on all dev and staging environments
-		if ($wgDevelEnvironment || $wgStagingEnvironment) {
+		if ( $wgWikiaEnvironment !== WIKIA_ENV_PROD ) {
 			$vars['wgGaStaging'] = true;
 		}
 

--- a/extensions/wikia/Recirculation/RecirculationHooks.class.php
+++ b/extensions/wikia/Recirculation/RecirculationHooks.class.php
@@ -169,11 +169,9 @@ class RecirculationHooks {
 	 * @return bool
 	 */
 	private static function isProduction() {
-		global $wgDevelEnvironment, $wgStagingEnvironment, $wgWikiaEnvironment;
+		global $wgWikiaEnvironment;
 
-		return empty( $wgDevelEnvironment ) &&
-			empty( $wgStagingEnvironment ) &&
-			$wgWikiaEnvironment !== WIKIA_ENV_STAGING;
+		return $wgWikiaEnvironment === WIKIA_ENV_PROD;
 	}
 
 	/**

--- a/extensions/wikia/Recirculation/RecirculationHooks.class.php
+++ b/extensions/wikia/Recirculation/RecirculationHooks.class.php
@@ -166,15 +166,6 @@ class RecirculationHooks {
 	}
 
 	/**
-	 * @return bool
-	 */
-	private static function isProduction() {
-		global $wgWikiaEnvironment;
-
-		return $wgWikiaEnvironment === WIKIA_ENV_PROD;
-	}
-
-	/**
 	 * @param Item $metaDataFromService is actual Data returned by Liftigniter Metadata Service
 	 *
 	 * @return bool
@@ -196,7 +187,7 @@ class RecirculationHooks {
 
 		$isPrivateWiki = WikiFactory::isWikiPrivate( $wgCityId ) || $wgIsPrivateWiki;
 
-		return !self::isProduction() || $isPrivateWiki;
+		return !Wikia::isProductionEnv() || $isPrivateWiki;
 	}
 
 	/**

--- a/extensions/wikia/Track/Track.php
+++ b/extensions/wikia/Track/Track.php
@@ -97,9 +97,9 @@ class Track {
 	}
 
 	private static function getGATrackingIds() {
-		global $wgDevelEnvironment, $wgStagingEnvironment;
+		global $wgWikiaEnvironment;
 
-		$tids = [ $wgDevelEnvironment || $wgStagingEnvironment ? 'UA-32129070-2' : 'UA-32129070-1' ];
+		$tids = [ $wgWikiaEnvironment !== WIKIA_ENV_PROD ? 'UA-32129070-2' : 'UA-32129070-1' ];
 
 		return $tids;
 	}

--- a/extensions/wikia/Track/Track.php
+++ b/extensions/wikia/Track/Track.php
@@ -97,9 +97,7 @@ class Track {
 	}
 
 	private static function getGATrackingIds() {
-		global $wgWikiaEnvironment;
-
-		$tids = [ $wgWikiaEnvironment !== WIKIA_ENV_PROD ? 'UA-32129070-2' : 'UA-32129070-1' ];
+		$tids = [ !Wikia::isProductionEnv() ? 'UA-32129070-2' : 'UA-32129070-1' ];
 
 		return $tids;
 	}

--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -1143,11 +1143,11 @@ class Wikia {
 	}
 
 	static public function getEnvironmentRobotPolicy(WebRequest $request) {
-		global $wgDevelEnvironment, $wgStagingEnvironment, $wgDefaultRobotPolicy;
+		global $wgWikiaEnvironment, $wgDefaultRobotPolicy;
 
 		$policy = '';
 
-		if( !empty( $wgDevelEnvironment ) || !empty( $wgStagingEnvironment ) ) {
+		if ( $wgWikiaEnvironment !== WIKIA_ENV_PROD ) {
 			$policy = $wgDefaultRobotPolicy;
 		}
 

--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -1143,11 +1143,11 @@ class Wikia {
 	}
 
 	static public function getEnvironmentRobotPolicy(WebRequest $request) {
-		global $wgWikiaEnvironment, $wgDefaultRobotPolicy;
+		global $wgDefaultRobotPolicy;
 
 		$policy = '';
 
-		if ( $wgWikiaEnvironment !== WIKIA_ENV_PROD ) {
+		if ( !Wikia::isProductionEnv() ) {
 			$policy = $wgDefaultRobotPolicy;
 		}
 
@@ -1919,4 +1919,8 @@ class Wikia {
 		CeleryPurge::purgeBySurrogateKey( $key );
 	}
 
+	public static function isProductionEnv(): bool {
+		global $wgWikiaEnvironment;
+		return $wgWikiaEnvironment === WIKIA_ENV_PROD;
+	}
 }

--- a/includes/wikia/resourceloader/ResourceLoaderHooks.class.php
+++ b/includes/wikia/resourceloader/ResourceLoaderHooks.class.php
@@ -56,7 +56,7 @@ class ResourceLoaderHooks {
 		}
 
 		// Determine the shared domain name
-		if ( $wgWikiaEnvironment === WIKIA_ENV_PROD ) {
+		if ( Wikia::isProductionEnv() ) {
 			// Adding https here doesn't change anything, as $wgEnableResourceLoaderRewrites is enabled
 			// everywhere so this gets replaced with $wgCdnRootUrl anyway.
 			$host = 'https://' . (empty($wgMedusaHostPrefix) ? 'community.' : $wgMedusaHostPrefix) . 'wikia.com';
@@ -79,7 +79,7 @@ class ResourceLoaderHooks {
 			// rewrite common source
 			$url = $sources['common']['loadScript'];
 			$url = str_replace( "/load{$wgScriptExtension}", "/__load/-/", $url );
-			if ( $wgWikiaEnvironment === WIKIA_ENV_PROD ) {
+			if ( Wikia::isProductionEnv() ) {
 				$url = str_replace( $host, $wgCdnRootUrl, $url );
 			}
 			$sources['common']['loadScript'] = $url;

--- a/includes/wikia/resourceloader/ResourceLoaderHooks.class.php
+++ b/includes/wikia/resourceloader/ResourceLoaderHooks.class.php
@@ -45,7 +45,7 @@ class ResourceLoaderHooks {
 
 	static protected function registerSources( ResourceLoader $resourceLoader ) {
 		global $wgScriptPath, $wgScriptExtension, $wgMedusaHostPrefix, $wgCdnRootUrl, $wgDevelEnvironment,
-			   $wgStagingEnvironment, $wgCityId, $wgEnableResourceLoaderRewrites;
+			   $wgWikiaEnvironment, $wgCityId, $wgEnableResourceLoaderRewrites;
 
 		$sources = $resourceLoader->getSources();
 
@@ -56,8 +56,7 @@ class ResourceLoaderHooks {
 		}
 
 		// Determine the shared domain name
-		$isProduction = empty($wgDevelEnvironment) && empty($wgStagingEnvironment);
-		if ( $isProduction ) {
+		if ( $wgWikiaEnvironment === WIKIA_ENV_PROD ) {
 			// Adding https here doesn't change anything, as $wgEnableResourceLoaderRewrites is enabled
 			// everywhere so this gets replaced with $wgCdnRootUrl anyway.
 			$host = 'https://' . (empty($wgMedusaHostPrefix) ? 'community.' : $wgMedusaHostPrefix) . 'wikia.com';
@@ -80,7 +79,7 @@ class ResourceLoaderHooks {
 			// rewrite common source
 			$url = $sources['common']['loadScript'];
 			$url = str_replace( "/load{$wgScriptExtension}", "/__load/-/", $url );
-			if ( $isProduction ) {
+			if ( $wgWikiaEnvironment === WIKIA_ENV_PROD ) {
 				$url = str_replace( $host, $wgCdnRootUrl, $url );
 			}
 			$sources['common']['loadScript'] = $url;

--- a/includes/wikia/tests/WikiaTest.php
+++ b/includes/wikia/tests/WikiaTest.php
@@ -54,8 +54,7 @@ class WikiaTest extends WikiaBaseTest {
 	}
 
 	public function testOnSkinTemplateOutputPageBeforeExec_setsNoIndexNoFollowBecauseHeaders() {
-		$this->mockGlobalVariable('wgDevelEnvironment', false);
-		$this->mockGlobalVariable('wgStagingEnvironment', false);
+		$this->mockProdEnv();
 
 		$request = new FauxRequest();
 		$request->setHeader( 'X-Staging', 'externaltest' );
@@ -78,8 +77,7 @@ class WikiaTest extends WikiaBaseTest {
 	}
 
 	public function testOnSkinTemplateOutputPageBeforeExec_setsNoIndexNoFollowBecauseDevbox() {
-		$this->mockGlobalVariable('wgDevelEnvironment', true);
-		$this->mockGlobalVariable('wgStagingEnvironment', false);
+		$this->mockDevEnv();
 
 		$context = new RequestContext();
 		$context->setTitle( new Title() );
@@ -99,8 +97,7 @@ class WikiaTest extends WikiaBaseTest {
 	}
 
 	public function testOnSkinTemplateOutputPageBeforeExec_setsNoIndexNoFollowBecauseStaging() {
-		$this->mockGlobalVariable('wgDevelEnvironment', false);
-		$this->mockGlobalVariable('wgStagingEnvironment', true);
+		$this->mockStagingEnv();
 
 		$context = new RequestContext();
 		$context->setTitle( new Title() );
@@ -121,8 +118,7 @@ class WikiaTest extends WikiaBaseTest {
 	}
 
 	public function testOnSkinTemplateOutputPageBeforeExec_doesNotSetNoIndexNoFollow() {
-		$this->mockGlobalVariable('wgDevelEnvironment', false);
-		$this->mockGlobalVariable('wgStagingEnvironment', false);
+		$this->mockProdEnv();
 
 		$context = new RequestContext();
 		$context->setTitle( new Title() );

--- a/includes/wikia/tests/core/WikiaBaseTest.class.php
+++ b/includes/wikia/tests/core/WikiaBaseTest.class.php
@@ -439,7 +439,6 @@ abstract class WikiaBaseTest extends TestCase {
 
 	protected function mockPreviewEnv() {
 		$this->mockGlobalVariable( 'wgDevelEnvironment', false );
-		$this->mockGlobalVariable( 'wgStagingEnvironment', true );
 		$this->mockGlobalVariable( 'wgWikiaEnvironment', WIKIA_ENV_PREVIEW );
 	}
 
@@ -451,19 +450,16 @@ abstract class WikiaBaseTest extends TestCase {
 
 	protected function mockVerifyEnv() {
 		$this->mockGlobalVariable( 'wgDevelEnvironment', false );
-		$this->mockGlobalVariable( 'wgStagingEnvironment', true );
 		$this->mockGlobalVariable( 'wgWikiaEnvironment', WIKIA_ENV_VERIFY );
 	}
 
 	protected function mockStableEnv() {
 		$this->mockGlobalVariable( 'wgDevelEnvironment', false );
-		$this->mockGlobalVariable( 'wgStagingEnvironment', true );
 		$this->mockGlobalVariable( 'wgWikiaEnvironment', WIKIA_ENV_STABLE );
 	}
 
 	protected function mockSandboxEnv() {
 		$this->mockGlobalVariable( 'wgDevelEnvironment', false );
-		$this->mockGlobalVariable( 'wgStagingEnvironment', false );
 		$this->mockGlobalVariable( 'wgWikiaEnvironment', WIKIA_ENV_SANDBOX );
 		$this->getStaticMethodMock( 'WikiFactory', 'getExternalHostName' )
 			->expects( $this->any() )

--- a/lib/Wikia/src/Factory/ProviderFactory.php
+++ b/lib/Wikia/src/Factory/ProviderFactory.php
@@ -1,8 +1,8 @@
 <?php
 namespace Wikia\Factory;
 
+use Wikia\Logger\WikiaLogger;
 use Wikia\Service\Gateway\KubernetesUrlProvider;
-use Wikia\Service\Gateway\StaticUrlProvider;
 use Wikia\Service\Gateway\UrlProvider;
 use Wikia\Service\Swagger\ApiProvider;
 use Wikia\Util\Statistics\BernoulliTrial;
@@ -22,8 +22,9 @@ class ProviderFactory {
 
 	public function urlProvider(): UrlProvider {
 		if ( $this->urlProvider === null ) {
-			global $wgWikiaEnvironment, $wgWikiaDatacenter;
-			$this->urlProvider = new KubernetesUrlProvider( $wgWikiaEnvironment, $wgWikiaDatacenter );
+			global $wgRealEnvironment, $wgWikiaDatacenter;
+			$this->urlProvider = new KubernetesUrlProvider( $wgRealEnvironment, $wgWikiaDatacenter );
+			$this->urlProvider->setLogger( WikiaLogger::instance() );
 		}
 
 		return $this->urlProvider;

--- a/lib/Wikia/src/Service/Gateway/KubernetesUrlProvider.php
+++ b/lib/Wikia/src/Service/Gateway/KubernetesUrlProvider.php
@@ -3,51 +3,49 @@
 namespace Wikia\Service\Gateway;
 
 use InvalidArgumentException;
-use Wikia\Logger\WikiaLogger;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
 
-class KubernetesUrlProvider implements UrlProvider {
-	const URL_PROVIDER_WIKIA_ENVIRONMENT = 'url_provider_wikia_environment';
-	const URL_PROVIDER_DATACENTER = 'url_provider_datacenter';
-
-	const K8S_URL = "%s.%s.k8s.wikia.net/%s";
-
+class KubernetesUrlProvider implements UrlProvider, LoggerAwareInterface {
+	/** @var string $env */
 	private $env;
 
+	/** @var string $dc */
 	private $dc;
 
+	/** @var LoggerInterface $logger */
+	private $logger;
+
 	/**
-	 * @Inject({
-	 *     Wikia\Service\Gateway\KubernetesUrlProvider::URL_PROVIDER_WIKIA_ENVIRONMENT,
-	 *     Wikia\Service\Gateway\KubernetesUrlProvider::URL_PROVIDER_DATACENTER})
-	 * @param string $wikiaEnvironment
+	 * @param string $environment
 	 * @param string $dataCenter
 	 */
-	public function __construct( string $wikiaEnvironment, string $dataCenter ) {
-		switch ( $wikiaEnvironment ) {
-			case WIKIA_ENV_PROD:
-			case WIKIA_ENV_PREVIEW:
-			case WIKIA_ENV_VERIFY:
-			case WIKIA_ENV_STABLE:
-			case WIKIA_ENV_SANDBOX:
-				$this->env = WIKIA_ENV_PROD;
-				$this->dc = $dataCenter;
-				break;
-			case WIKIA_ENV_STAGING:
-				$this->env = WIKIA_ENV_STAGING;
-				$this->dc = $dataCenter;
-				break;
+	public function __construct( string $environment, string $dataCenter ) {
+		if ( !in_array( $environment, [ WIKIA_ENV_PROD, WIKIA_ENV_DEV, WIKIA_ENV_STAGING ] ) ) {
+			throw new InvalidArgumentException( "Invalid environment $environment" );
+		}
+
+		switch ( $environment ) {
 			case WIKIA_ENV_DEV:
 				$this->env = WIKIA_ENV_DEV;
 				$this->dc = "$dataCenter-dev";
 				break;
 			default:
-				throw new InvalidArgumentException( "Invalid environment $wikiaEnvironment" );
+				$this->env = $environment;
+				$this->dc = $dataCenter;
+				break;
 		}
 	}
 
 	public function getUrl( $serviceName ) {
-		$url = sprintf( static::K8S_URL, $this->env, $this->dc, $serviceName );
-		WikiaLogger::instance()->info( "Url provider", [ 'provider_url' => $url ] );
+		$url = "{$this->env}.{$this->dc}.k8s.wikia.net/$serviceName";
+
+		$this->logger->debug( "Url provider", [ 'provider_url' => $url ] );
+
 		return $url;
+	}
+
+	public function setLogger( LoggerInterface $logger ) {
+		$this->logger = $logger;
 	}
 }

--- a/lib/Wikia/tests/Service/Gateway/KubernetesUrlProviderTest.php
+++ b/lib/Wikia/tests/Service/Gateway/KubernetesUrlProviderTest.php
@@ -4,6 +4,7 @@ namespace Wikia\Service\Gateway;
 use Generator;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
 
 class KubernetesUrlProviderTest extends TestCase {
 
@@ -18,6 +19,7 @@ class KubernetesUrlProviderTest extends TestCase {
 		string $env, string $dc, string $serviceName
 	) {
 		$kubernetesUrlProvider = new KubernetesUrlProvider( $env, $dc );
+		$kubernetesUrlProvider->setLogger( new NullLogger() );
 
 		$this->assertEquals(
 			"$env.$dc.k8s.wikia.net/$serviceName",
@@ -35,31 +37,25 @@ class KubernetesUrlProviderTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider provideExoticEnvironmentDatacenterAndServiceName
+	 * @dataProvider provideExoticEnvironmentDatacenter
 	 *
 	 * @param string $env
 	 * @param string $dc
-	 * @param string $serviceName
 	 */
-	public function testFallsBackToProductionForExoticEnvironments(
-		string $env, string $dc, string $serviceName
-	) {
-		$prodEnv = WIKIA_ENV_PROD;
-		$kubernetesUrlProvider = new KubernetesUrlProvider( $env, $dc );
+	public function testThrowsExceptionForExoticEnvironments( string $env, string $dc ) {
+		$this->expectException( InvalidArgumentException::class );
+		$this->expectExceptionMessage( "Invalid environment $env" );
 
-		$this->assertEquals(
-			"$prodEnv.$dc.k8s.wikia.net/$serviceName",
-			$kubernetesUrlProvider->getUrl( $serviceName )
-		);
+		new KubernetesUrlProvider( $env, $dc );
 	}
 
-	public function provideExoticEnvironmentDatacenterAndServiceName(): Generator {
-		yield [ WIKIA_ENV_SANDBOX, WIKIA_DC_SJC, 'example' ];
-		yield [ WIKIA_ENV_SANDBOX, WIKIA_DC_SJC, 'foobar' ];
-		yield [ WIKIA_ENV_VERIFY, WIKIA_DC_SJC, 'example' ];
-		yield [ WIKIA_ENV_VERIFY, WIKIA_DC_SJC, 'foobar' ];
-		yield [ WIKIA_ENV_PREVIEW, WIKIA_DC_SJC, 'example' ];
-		yield [ WIKIA_ENV_PREVIEW, WIKIA_DC_SJC, 'foobar' ];
+	public function provideExoticEnvironmentDatacenter(): Generator {
+		yield [ WIKIA_ENV_SANDBOX, WIKIA_DC_SJC ];
+		yield [ WIKIA_ENV_SANDBOX, WIKIA_DC_SJC ];
+		yield [ WIKIA_ENV_VERIFY, WIKIA_DC_SJC ];
+		yield [ WIKIA_ENV_VERIFY, WIKIA_DC_SJC ];
+		yield [ WIKIA_ENV_PREVIEW, WIKIA_DC_SJC ];
+		yield [ WIKIA_ENV_PREVIEW, WIKIA_DC_SJC ];
 	}
 
 	/**
@@ -73,6 +69,7 @@ class KubernetesUrlProviderTest extends TestCase {
 		string $env, string $dc, string $serviceName
 	) {
 		$kubernetesUrlProvider = new KubernetesUrlProvider( $env, $dc );
+		$kubernetesUrlProvider->setLogger( new NullLogger() );
 
 		$this->assertEquals(
 			"$env.$dc-dev.k8s.wikia.net/$serviceName",
@@ -85,12 +82,5 @@ class KubernetesUrlProviderTest extends TestCase {
 		yield [ WIKIA_ENV_DEV, WIKIA_DC_SJC, 'foobar' ];
 		yield [ WIKIA_ENV_DEV, WIKIA_DC_POZ, 'example' ];
 		yield [ WIKIA_ENV_DEV, WIKIA_DC_POZ, 'foobar' ];
-	}
-
-	/**
-	 * @expectedException InvalidArgumentException
-	 */
-	public function testThrowsExceptionForInvalidEnvironment() {
-		return new KubernetesUrlProvider( 'blabla', WIKIA_DC_SJC );
 	}
 }


### PR DESCRIPTION
Get rid of `wgStagingEnvironment` and use `wgWikiaEnvironment` as the source of truth.

Tests are failing because of config dependency, but they pass locally. 🍏

https://wikia-inc.atlassian.net/browse/SUS-4183