### PR TITLE
SUS-4175 | OutputPage::redirect - make the source of the redirect more obvious

### DIFF
--- a/includes/OutputPage.php
+++ b/includes/OutputPage.php
@@ -280,6 +280,9 @@ class OutputPage extends ContextSource {
 		if( $responsecode == '301' ) {
 			$this->setSquidMaxage( 1200 );
 		}
+
+		// SUS-4175 | make the source of the redirect more obvious
+		$this->getRequest()->response()->header( 'X-Redirected-By: mw-OutputPage::redirect' );
 		# end wikia change
 	}
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-4175

Having [an interwiki in `MediaWiki:Mainpage`](http://random.wikia.com/index.php?title=MediaWiki%3AMainpage&diff=4341&oldid=3698) does not make redirects debugging an easy task. Add a header indicating that it's MediaWiki that makes a redirect.

## `X-Redirected-By` response header added

```
$ curl -svo /dev/null 'http://random.wikia.com/' -x sandbox-s6:80  2>&1 | grep -E 'Redirect|Location|Serv'
* Server Apache is not blacklisted
< Server: Apache
< X-Redirected-By: mw-OutputPage::redirect
< Location: http://community.wikia.com/wiki/Special:RandomWiki
```