### PR TITLE
SUS-3390 | VoteHelper - do not insert unique_id column and use an empty string for IP address

### DIFF
--- a/extensions/wikia/Wall/VoteHelper.class.php
+++ b/extensions/wikia/Wall/VoteHelper.class.php
@@ -6,12 +6,8 @@
 class VoteHelper {
 	protected $userId;
 	protected $pageId;
-	protected $userIP = '';
 
-	function __construct( User $user = null, $pageId = 0 ) {
-		global $wgRequest;
-
-		$this->userIP = $wgRequest->getIP();
+	function __construct( User $user, $pageId = 0 ) {
 		$this->userId = $user->getId();
 		$this->pageId = $pageId;
 	}
@@ -58,9 +54,8 @@ class VoteHelper {
 
 		$values = [
 			'article_id' => $this->pageId,
-			'ip' => $this->userIP,
+			'ip' => '',
 			'user_id' => $this->userId,
-			'unique_id' => md5( $this->userIP ), // Backward compatibility
 			'time' => wfTimestampNow(),
 			'vote' => $score,
 		];

--- a/includes/wikia/WikiaUpdater.php
+++ b/includes/wikia/WikiaUpdater.php
@@ -51,7 +51,6 @@ class WikiaUpdater {
 			array( 'dropIndex', 'wall_related_pages', 'page_id_idx_2',  $dir . 'patch-wall_related_pages-drop-page_id_idx_2.sql', true ), // SUS-3096
 
 			# functions
-			array( 'WikiaUpdater::do_page_vote_unique_update' ),
 			array( 'WikiaUpdater::do_page_wikia_props_update' ),
 			array( 'WikiaUpdater::do_drop_table', 'imagetags' ),
 			array( 'WikiaUpdater::do_drop_table', 'send_queue' ),
@@ -112,19 +111,6 @@ class WikiaUpdater {
 		if ( $db->tableExists( $table ) ) {
 			$updater->output( "...dropping $table table... " );
 			$db->dropTable( $table, __METHOD__ );
-			$updater->output( "ok\n" );
-		}
-	}
-
-	public static function do_page_vote_unique_update( DatabaseUpdater $updater ) {
-		$db = $updater->getDB();
-		$dir = self::get_patch_dir();
-		$updater->output( "Checking wikia page_vote table...\n" );
-		if( $updater->getDB()->indexExists( 'page_vote', 'unique_vote' ) ) {
-			$updater->output( "...page_vote unique key already set.\n" );
-		} else {
-			$updater->output( "Making page_vote unique key... " );
-			$db->sourceFile( $dir . 'patch-page_vote_unique_vote.sql' );
 			$updater->output( "ok\n" );
 		}
 	}

--- a/includes/wikia/WikiaUpdater.php
+++ b/includes/wikia/WikiaUpdater.php
@@ -282,6 +282,10 @@ class WikiaUpdater {
 		$databaseUpdater->output( "done - {$affectedRows} rows affected\n" );
 
 		$databaseUpdater->output( 'Removing page_vote rows for non-forum pages... ' );
+
+		// so that GROUP_CONCAT below will return all values
+		$dbw->query('SET SESSION group_concat_max_len = 100000', __METHOD__);
+
 		$ids = $dbw->selectField(
 			['page_vote', 'page'],
 			'GROUP_CONCAT(DISTINCT(page_id))',

--- a/maintenance/archives/wikia/patch-create-page_vote.sql
+++ b/maintenance/archives/wikia/patch-create-page_vote.sql
@@ -5,5 +5,5 @@ CREATE TABLE /*$wgDBprefix*/page_vote (
 	`vote` int(2) NOT NULL,
 	`ip` varbinary(32) DEFAULT NULL,
 	`time` datetime NOT NULL,
-	KEY `article_user_idx` (`article_id`, `user_id`)
+	UNIQUE KEY `article_user_idx` (`article_id`, `user_id`)
 ) ENGINE=InnoDB;

--- a/maintenance/archives/wikia/patch-create-page_vote.sql
+++ b/maintenance/archives/wikia/patch-create-page_vote.sql
@@ -2,11 +2,8 @@
 CREATE TABLE /*$wgDBprefix*/page_vote (
 	`article_id` int(8) unsigned NOT NULL,
 	`user_id` int(5) unsigned NOT NULL,
-	`unique_id` varchar(32) NOT NULL DEFAULT '',
 	`vote` int(2) NOT NULL,
-	`ip` varbinary(32) NOT NULL,
+	`ip` varbinary(32) DEFAULT NULL,
 	`time` datetime NOT NULL,
-	KEY `user_id` (`user_id`,`article_id`),
-	KEY `article_id` (`article_id`),
-	KEY `unique_vote` (`unique_id`, `article_id`)
+	KEY `article_user_idx` (`article_id`, `user_id`)
 ) ENGINE=InnoDB;

--- a/maintenance/archives/wikia/patch-index-page_vote.sql
+++ b/maintenance/archives/wikia/patch-index-page_vote.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `page_vote`
+  DROP INDEX user_id,
+  DROP INDEX article_id,
+  DROP INDEX unique_vote,
+  ADD UNIQUE INDEX article_user_idx (article_id, user_id);

--- a/maintenance/archives/wikia/patch-page_vote_unique_vote.sql
+++ b/maintenance/archives/wikia/patch-page_vote_unique_vote.sql
@@ -1,4 +1,0 @@
--- Unique key in page_vote
-
-ALTER TABLE /*$wgDBprefix*/page_vote
-  ADD KEY `unique_vote` (`unique_id`, `article_id`);


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3390

Both of these columns are not used by SELECT queries, there are no constraints on them on DB level (unique keys). `ip` column can not be NULL, hence the empty string is insert for now.

### Next steps

* run an alter for the existing tables - drop `unique_id` column and redundant indices keeping `KEY article_user_idx (article_id, user_id)` only and make `ip` column accept NULL values
* stop inserting IP addresses, drop `ip` column site-wide

### Current table schema

```sql
CREATE TABLE `page_vote` (
  `article_id` int(8) unsigned NOT NULL,
  `user_id` int(5) unsigned NOT NULL,
  `vote` int(2) NOT NULL,
  `ip` varchar(32) NOT NULL,
  `time` datetime NOT NULL,
  `unique_id` varchar(32) DEFAULT NULL,
  KEY `user_id` (`user_id`,`article_id`),
  KEY `article_id` (`article_id`),
  KEY `unique_vote` (`unique_id`,`article_id`)
) ENGINE=InnoDB
```

* ip and unique_id columns will go away
* `KEY article_user_idx (article_id, user_id)` - the only index to be kept

### Data cleanup

```sql
mysql@geo-db-c-slave.query.consul[glee]>select page_namespace, count(*) from page, page_vote where page.page_id = article_id group by page_namespace;
+----------------+----------+
| page_namespace | count(*) |
+----------------+----------+
|              0 |       91 |
|            500 |       18 |
|           2001 |     4976 |
+----------------+----------+
3 rows in set (0.10 sec)

--

mysql@geo-db-c-slave.query.consul[glee]>select page_namespace, count(*) from page, page_vote where page.page_id = article_id AND user_id = 0 group by page_namespace;
+----------------+----------+
| page_namespace | count(*) |
+----------------+----------+
|              0 |       60 |
|            500 |        3 |
+----------------+----------+
2 rows in set (0.07 sec)
```

After #13765 we can remove all entries with `user_id = 0` and that refer to non-forum namespace. For glee this means that out of 53593 only 4976 will be kept.

```sql
mysql@geo-db-dev-db-slave.query.consul[glee]>select count(*) from page_vote;
+----------+
| count(*) |
+----------+
|    53425 |
+----------+
1 row in set (0.05 sec)
```

#### `update.php` run on dev...

```
Removing page_vote rows for anons... done - 43534 rows affected
Removing page_vote rows for non-forum pages... done - 303 rows affected
Adding index article_user_idx to table page_vote... done.
```

```sql
mysql@geo-db-dev-db-slave.query.consul[glee]>select count(*) from page_vote;
+----------+
| count(*) |
+----------+
|     9588 |
+----------+
1 row in set (0.01 sec)
```

```sql
-- new schema
CREATE TABLE `page_vote` (
  `article_id` int(8) unsigned NOT NULL,
  `user_id` int(5) unsigned NOT NULL,
  `unique_id` varchar(32) NOT NULL DEFAULT '',
  `vote` int(2) NOT NULL,
  `ip` varchar(32) NOT NULL,
  `time` datetime NOT NULL,
  UNIQUE KEY `article_user_idx` (`article_id`,`user_id`)
) ENGINE=InnoDB
```

### Query digest

```sql
-- Query digest for "page_vote" table, found 4593 queries
VoteHelper::isVoted 54.47% [ap] db:local | SELECT count(*) as cnt FROM `page_vote` WHERE article_id = X AND user_id = X LIMIT N
VoteHelper::getVoteCount 45.40% [ap] db:local | SELECT count(*) as cnt FROM `page_vote` LEFT JOIN `ipblocks` ON ((user_id = ipb_user)) WHERE (ifnull(ipb_expiry, N) != X) AND (ifnull(ipb_expiry, N) < N) AND article_id = X ORDER BY time desc LIMIT N
DatabaseBase::sourceFile( /usr/wikia/slot1/21991/src/maintenance/archives/wikia/patch-create-page_vote.sql ) 0.02% [ap] db:shashiipawar23 | CREATE TABLE `page_vote` ( `article_id` int(N) unsigned NOT NULL, `user_id` int(N) unsigned NOT NULL, `unique_id` varchar(N) NOT NULL DEFAULT X, `vote` int(N) NOT NULL, `ip` varbinary(N) NOT NULL, `time` datetime NOT NULL, KEY `user_id` (`user_id`,`article_id`), KEY `article_id` (`article_id`), KEY `unique_vote` (`unique_id`, `article_id`) ) ENGINE=InnoDB
VoteHelper::addVote 0.09% [ap] db:local | INSERT INTO `page_vote` (article_id,ip,user_id,unique_id,time,vote) VALUES (X,X,X,X,X,X)
VoteHelper::getVotersList 0.02% [ap] db:local | SELECT user_id FROM `page_vote` LEFT JOIN `ipblocks` ON ((user_id = ipb_user)) WHERE (ifnull(ipb_expiry, N) != X) AND (ifnull(ipb_expiry, N) < N) AND article_id = X ORDER BY time desc LIMIT N
```