### PR TITLE
SUS-4251 | remove objectcache handling from update.php

### DIFF
--- a/includes/installer/DatabaseUpdater.php
+++ b/includes/installer/DatabaseUpdater.php
@@ -255,8 +255,6 @@ abstract class DatabaseUpdater {
 		}
 
 		if ( isset( $what['purge'] ) ) {
-			$this->purgeCache();
-
 			if ( $wgLocalisationCacheConf['manualRecache'] ) {
 				$this->rebuildLocalisationCache();
 			}
@@ -562,17 +560,6 @@ abstract class DatabaseUpdater {
 			$this->insertUpdateRow( $updateKey );
 			$this->output( "done.\n" );
 		}
-	}
-
-	/**
-	 * Purge the objectcache table
-	 */
-	protected function purgeCache() {
-		# We can't guarantee that the user will be able to use TRUNCATE,
-		# but we know that DELETE is available to us
-		$this->output( "Purging caches..." );
-		$this->db->delete( 'objectcache', '*', __METHOD__ );
-		$this->output( "done.\n" );
 	}
 
 	/**

--- a/includes/installer/MysqlUpdater.php
+++ b/includes/installer/MysqlUpdater.php
@@ -26,7 +26,6 @@ class MysqlUpdater extends DatabaseUpdater {
 			// 1.3
 			# array( 'addField', 'user',          'user_real_name',   'patch-user-realname.sql' ),
 			array( 'addTable', 'querycache',                        'patch-querycache.sql' ),
-			array( 'addTable', 'objectcache',                       'patch-objectcache.sql' ),
 			array( 'addTable', 'categorylinks',                     'patch-categorylinks.sql' ),
 			array( 'doOldLinksUpdate' ),
 			array( 'doFixAncientImagelinks' ),

--- a/maintenance/archives/patch-objectcache.sql
+++ b/maintenance/archives/patch-objectcache.sql
@@ -1,9 +1,0 @@
--- For a few generic cache operations if not using Memcached
-CREATE TABLE /*$wgDBprefix*/objectcache (
-  keyname varbinary(255) NOT NULL default '',
-  value mediumblob,
-  exptime datetime,
-  UNIQUE KEY (keyname),
-  KEY (exptime)
-
-) /*$wgDBTableOptions*/;

--- a/maintenance/update.php
+++ b/maintenance/update.php
@@ -42,7 +42,6 @@ class UpdateMediaWiki extends Maintenance {
 		$this->addOption( 'ext-only', 'Only update extension schema' );
 		$this->addOption( 'quick', 'Skip 5 second countdown before starting' );
 		$this->addOption( 'doshared', 'Also update shared tables' );
-		$this->addOption( 'nopurge', 'Do not purge the objectcache table after updates' );
 		$this->addOption( 'force', 'Override when $wgAllowSchemaUpdates disables this script' );
 	}
 
@@ -83,9 +82,7 @@ class UpdateMediaWiki extends Maintenance {
 		$shared = $this->hasOption( 'doshared' );
 
 		$updates = !$this->hasOption( 'ext-only' ) ? array( 'core', 'extensions', 'stats' ) : [ 'extensions' ];
-		if( !$this->hasOption('nopurge') ) {
-			$updates[] = 'purge';
-		}
+		$updates[] = 'purge';
 
 		$updater = DatabaseUpdater::newForDb( $db, $shared, $this );
 		$updater->doUpdates( $updates );


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-4251 / see #14788

Avoid the following:

```sql
A database query syntax error has occurred.
The last attempted database query was:
"DELETE FROM `objectcache`"
from within function "DatabaseUpdater::purgeCache".
MySQL returned error "1146: Table 'uncyclo.objectcache' doesn't exist (geo-db-a-master.query.consul)"
```