### PR TITLE
SUS-4253 | Stop rewriting per-wiki ResourceLoader URLs

### DIFF
--- a/extensions/wikia/AdEngine/tests/AdEngine2ContextServiceTest.php
+++ b/extensions/wikia/AdEngine/tests/AdEngine2ContextServiceTest.php
@@ -232,7 +232,7 @@ class AdEngine2ContextServiceTest extends WikiaBaseTest {
 		$catId = WikiFactoryHub::CATEGORY_ID_LIFESTYLE;
 		$shortCat = 'shortcat';
 		// mech: using %S for hostname as RL can produce local links when $wgEnableLocalResourceLoaderLinks is set to true
-		$expectedAdEngineResourceURLFormat = '%S/__load/-/cb%3D%d%26debug%3Dfalse%26lang%3D%s%26only%3Dscripts%26skin%3Doasis/%s';
+		$expectedAdEngineResourceURLFormat = '%S/load.php?cb=%d&debug=false&lang=%s&modules=%s&only=scripts&skin=oasis&*';
 		$expectedPrebidBidderUrl = 'http://i2.john-doe.wikia-dev.com/__am/123/group/-/pr3b1d_prod_js';
 
 		$assetsManagerMock = $this->getMockBuilder( 'AssetsManager' )

--- a/includes/resourceloader/ResourceLoader.php
+++ b/includes/resourceloader/ResourceLoader.php
@@ -1209,19 +1209,6 @@ class ResourceLoader {
 		}
 	}
 
-	public function setSource( $id, $properties = null ) {
-		// Allow multiple sources to be registered in one call
-		if ( is_array( $id ) ) {
-			foreach ( $id as $key => $value ) {
-				$this->addSource( $key, $value );
-			}
-			return;
-		}
-
-		unset($this->sources[$id]);
-		$this->addSource($id,$properties);
-	}
-
 	public function rebaseModules( $modules, $source ) {
 		if ( $modules === true ) {
 			$modules = array_keys($this->moduleInfos);

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1032,12 +1032,6 @@ $wgResourceLoaderAssetsSkinMapping = [
 $wgArticleCountMethod = "any";
 
 /**
- * @name $wgEnableResourceLoaderRewrites
- * enable rewriting of Resource Loader links on nocookie domain
- */
-$wgEnableResourceLoaderRewrites = true;
-
-/**
  * Javascript minifier used by ResourceLoader
  * @var false|callback
  */

--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -1924,4 +1924,9 @@ class Wikia {
 		global $wgWikiaEnvironment;
 		return $wgWikiaEnvironment === WIKIA_ENV_PROD;
 	}
+
+	public static function isDevEnv(): bool {
+		global $wgWikiaEnvironment;
+		return $wgWikiaEnvironment === WIKIA_ENV_DEV;
+	}
 }

--- a/includes/wikia/resourceloader/ResourceLoaderHooks.class.php
+++ b/includes/wikia/resourceloader/ResourceLoaderHooks.class.php
@@ -6,6 +6,7 @@
  * @author macbre
  * @author Wladyslaw Bodzek
  */
+
 use Wikia\Logger\WikiaLogger;
 
 class ResourceLoaderHooks {
@@ -13,10 +14,6 @@ class ResourceLoaderHooks {
 	const TIMESTAMP_PRECISION = 900; // 15 minutes
 
 	static protected $resourceLoaderInstance;
-	static protected $assetsManagerGroups = array(
-//		'skins.oasis.blocking' => 'oasis_blocking',
-//		'skins.oasis.core' => 'oasis_shared_core',
-	);
 
 	/**
 	 * @static
@@ -32,101 +29,27 @@ class ResourceLoaderHooks {
 	/**
 	 * Configure Wikia-specific settings in ResourceLoader
 	 *
-	 * @static
 	 * @param ResourceLoader $resourceLoader Object to configure
-	 * @return bool true because it's a hook
+	 * @throws MWException
 	 */
 	static public function onResourceLoaderRegisterModules( ResourceLoader $resourceLoader ) {
-		self::registerSources($resourceLoader);
-		self::registerAssetsManagerGroups($resourceLoader);
-
-		return true;
-	}
-
-	static protected function registerSources( ResourceLoader $resourceLoader ) {
-		global $wgScriptPath, $wgScriptExtension, $wgMedusaHostPrefix, $wgCdnRootUrl, $wgDevelEnvironment,
-			   $wgWikiaEnvironment, $wgCityId, $wgEnableResourceLoaderRewrites;
+		global $wgCdnRootUrl;
 
 		$sources = $resourceLoader->getSources();
 
-		// staff and internal special case
-		if ( $wgCityId === null || $wgCityId === 11 ) {
-			$resourceLoader->addSource('common',$sources['local']);
-			return true;
+		// Do not use shared domain for shared assets for dev env
+		if ( Wikia::isDevEnv() ) {
+			$resourceLoader->addSource( 'common', $sources['local'] );
+			return;
 		}
 
-		// Determine the shared domain name
-		if ( Wikia::isProductionEnv() ) {
-			// Adding https here doesn't change anything, as $wgEnableResourceLoaderRewrites is enabled
-			// everywhere so this gets replaced with $wgCdnRootUrl anyway.
-			$host = 'https://' . (empty($wgMedusaHostPrefix) ? 'community.' : $wgMedusaHostPrefix) . 'wikia.com';
-		} else {
-			$host = $wgCdnRootUrl;
-		}
-
-		// Feed RL with the "common" source
-		$scriptUri = "$host{$wgScriptPath}/load{$wgScriptExtension}";
-		$sources['common'] = array(
-			'loadScript' => $scriptUri,
+		// Use shared domain name "common" source
+		$sources['common'] = [
+			'loadScript' => "$wgCdnRootUrl/__load/-/",
 			'apiScript' => $sources['local']['apiScript'],
-		);
+		];
 
-		if ( !empty( $wgEnableResourceLoaderRewrites ) ) {
-			// rewrite local source
-			$url = $sources['local']['loadScript'];
-			$url = str_replace( "/load{$wgScriptExtension}", "/__load/-/", $url );
-			$sources['local']['loadScript'] = $url;
-			// rewrite common source
-			$url = $sources['common']['loadScript'];
-			$url = str_replace( "/load{$wgScriptExtension}", "/__load/-/", $url );
-			if ( Wikia::isProductionEnv() ) {
-				$url = str_replace( $host, $wgCdnRootUrl, $url );
-			}
-			$sources['common']['loadScript'] = $url;
-		}
-
-		$resourceLoader->setSource('local',$sources['local']);
-		$resourceLoader->addSource('common',$sources['common']);
-
-		return true;
-	}
-
-	static protected function registerAssetsManagerGroups( ResourceLoader $resourceLoader ) {
-		if ( empty( self::$assetsManagerGroups ) ) {
-			return true;
-		}
-
-		$assetsConfig = new AssetsConfig();
-		foreach (self::$assetsManagerGroups as $moduleName => $groupName) {
-			$type = $assetsConfig->getGroupType($groupName);
-			$key = null;
-			switch ($type) {
-				case AssetsManager::TYPE_JS:
-					$key = 'scripts';
-					break;
-				case AssetsManager::TYPE_CSS:
-				case AssetsManager::TYPE_SCSS:
-					$key = 'styles';
-					break;
-			}
-			if ( empty( $key ) ) {
-				// todo: log error
-				continue;
-			}
-
-			$assets = $assetsConfig->resolve($groupName,false,false);
-			foreach ($assets as $k => $v) {
-				if ( !preg_match('#^(extensions|resources|skins)/#', $v) ) {
-					unset($assets[$k]);
-				}
-			}
-			$assets = array_values($assets);
-			$module = array();
-			$module[$key] = $assets;
-			$resourceLoader->register($moduleName,$module);
-		}
-
-		return true;
+		$resourceLoader->addSource( 'common', $sources['common'] );
 	}
 
 	/**
@@ -262,8 +185,9 @@ class ResourceLoaderHooks {
 		$sources = $resourceLoaderInstance->getSources();
 		$loadScript = $sources[$source]['loadScript'];
 
-		// this is triggered only when $wgEnableResourceLoaderRewrites is set
 		if ( substr($loadScript,-1) == '/' ) {
+			// shared asset loaded from shared domain
+
 			$loadQuery = $query;
 			$modules = $loadQuery['modules'];
 			unset($loadQuery['modules']);

--- a/includes/wikia/resourceloader/tests/ResourceLoaderHooksTest.php
+++ b/includes/wikia/resourceloader/tests/ResourceLoaderHooksTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class ResourceLoaderHooksTest extends TestCase {
+	use MockGlobalVariableTrait;
+
+	public function testCommonSourceIsSameAsLocalForDevEnv() {
+		$this->mockGlobalVariable( 'wgCdnRootUrl', 'https://www.example.com' );
+		$this->mockGlobalVariable( 'wgWikiaEnvironment', WIKIA_ENV_DEV );
+
+		$resourceLoader = new ResourceLoader();
+		$sources = $resourceLoader->getSources();
+
+		$this->assertEquals( $sources['local'], $sources['common'] );
+		$this->assertNotEquals( 'https://www.example.com/__load/-/', $sources['local']['loadScript'] );
+		$this->assertNotEquals( 'https://www.example.com/__load/-/', $sources['common']['loadScript'] );
+	}
+
+	/**
+	 * @dataProvider provideNonDevEnv
+	 *
+	 * @param string $env
+	 */
+	public function testCommonSourceUsesSharedDomainForNonDevEnv( string $env ) {
+		$this->mockGlobalVariable( 'wgCdnRootUrl', 'https://www.example.com' );
+		$this->mockGlobalVariable( 'wgWikiaEnvironment', $env );
+
+		$resourceLoader = new ResourceLoader();
+		$sources = $resourceLoader->getSources();
+
+		$this->assertNotEquals( 'https://www.example.com/__load/-/', $sources['local']['loadScript'] );
+		$this->assertEquals( 'https://www.example.com/__load/-/', $sources['common']['loadScript'] );
+		$this->assertEquals( $sources['local']['apiScript'], $sources['common']['apiScript'] );
+	}
+
+	protected function tearDown() {
+		parent::tearDown();
+		$this->unsetGlobals();
+	}
+
+	public function provideNonDevEnv() {
+		yield [ WIKIA_ENV_PROD ];
+		yield [ WIKIA_ENV_PREVIEW ];
+		yield [ WIKIA_ENV_SANDBOX ];
+	}
+}

--- a/includes/wikia/tests/core/MockGlobalVariableTrait.php
+++ b/includes/wikia/tests/core/MockGlobalVariableTrait.php
@@ -20,7 +20,7 @@ trait MockGlobalVariableTrait {
 	 * @param $returnValue mixed value variable should be set to
 	 */
 	protected function mockGlobalVariable( string $globalName, $returnValue ) {
-		$this->mockedGlobalVariables[$globalName] = $GLOBALS[$globalName];
+		$this->mockedGlobalVariables[$globalName] = $GLOBALS[$globalName] ?? null;
 		$this->setInGlobalScope( $globalName, $returnValue );
 	}
 

--- a/resources/mediawiki/mediawiki.js
+++ b/resources/mediawiki/mediawiki.js
@@ -971,9 +971,7 @@ var mw = ( function ( $, undefined ) {
 				);
 				request = sortQuery( request );
 
-				// Wikia - change begin - @author: wladek
-				// @see $wgEnableResourceLoaderRewrites
-//				mw.log('ResourceLoader',sourceLoadScript,moduleMap,sourceLoadScript.substr(sourceLoadScript.length-1));
+				// Wikia - change begin - @author: wladek - support for loading shared assets from nocookie.net with rewrite
 				if ( sourceLoadScript.substr(sourceLoadScript.length-1) == '/' ) {
 					var modules = request.modules;
 					delete request.modules


### PR DESCRIPTION
Stop rewriting wiki-specific ResourceLoader URLs - just use core MW load.php URLs instead. These will automatically respect `wgScriptPath` and thus avoid problems with language codes in the path.

Rewrite logic is kept for shared assets loaded from nocookie.net everywhere but in dev environment (where we already don't use a shared domain).

https://wikia-inc.atlassian.net/browse/SUS-4253