### PR TITLE
SUS-4255 | use city_url to build URL in ApiService

### DIFF
--- a/includes/wikia/services/ApiService.class.php
+++ b/includes/wikia/services/ApiService.class.php
@@ -89,21 +89,14 @@ class ApiService {
 	private static function getHostByDbName( string $dbName ): string {
 		global $wgDevelEnvironment, $wgDevDomain;
 
-		/**
-		 * wgServer is generated in runtime on devboxes therefore we
-		 * can't use it to get host by db name
-		 */
-		if ( !empty( $wgDevelEnvironment ) ) {
-			$hostName = WikiFactory::DBtoUrl( $dbName );
+		$hostName = WikiFactory::DBtoUrl( $dbName );
 
+		if ( !empty( $wgDevelEnvironment ) ) {
 			if ( strpos( $hostName, 'wikia.com' ) ) {
 				$hostName = str_replace( 'wikia.com', $wgDevDomain, $hostName );
 			} else {
 				$hostName = WikiFactory::getLocalEnvURL( $hostName );
 			}
-		} else {
-			$cityId = WikiFactory::DBtoID( $dbName );
-			$hostName = WikiFactory::getVarValueByName( 'wgServer', $cityId );
 		}
 
 		return rtrim( $hostName, '/' );

--- a/includes/wikia/services/tests/ApiServiceTest.php
+++ b/includes/wikia/services/tests/ApiServiceTest.php
@@ -31,10 +31,8 @@ class ApiAccessServiceTest extends \WikiaBaseTest {
 	}
 
 	public function testLoginAsUser() {
-
-		# 2 methods and 1 var used by private method ApiService::getHostByDbName, not directly mockable
-		$this->mockStaticMethod( "WikiFactory", 'DBtoID', "1" );
-		$this->mockStaticMethod( "WikiFactory", 'getVarValueByName', "foo.wikia.com" );
+		# 1 method and 1 var used by private method ApiService::getHostByDbName, not directly mockable
+		$this->mockStaticMethod( "WikiFactory", 'DBtoUrl', "foo.wikia.com" );
 		#turn off special case url building inside getHostByDbName
 		$this->mockGlobalVariable( "wgDevelEnvironment", false );
 


### PR DESCRIPTION
Use `city_url` (`wgServer` + `wgScriptPath`) instead of `wgServer` when building request URL in `ApiService` class. This will allow us to correctly handle any language path parameters.

https://wikia-inc.atlassian.net/browse/SUS-4255