### PR TITLE
SUS-4198 | Respect wgScriptPath in CategoryExhibition JS

### DIFF
--- a/extensions/wikia/CategoryExhibition/js/CategoryExhibition.js
+++ b/extensions/wikia/CategoryExhibition/js/CategoryExhibition.js
@@ -60,7 +60,7 @@ var CategoryExhibition = {
 			display: UrlVars['display']
 		};
 
-		$.get(wgScript, data, function(axData){
+		$.get(mw.config.get('wgScriptPath') + mw.config.get('wgScript'), data, function(axData){
 			var goBack = clickedObj.attr('data-back');
 			var room1 = pageSection.find('div.category-gallery-room1');
 			var room2 = pageSection.find('div.category-gallery-room2');
@@ -93,4 +93,4 @@ var CategoryExhibition = {
 };
 
 //on content ready
-wgAfterContentAndJS.push(CategoryExhibition.init);
+mw.hook('wikipage.content').add(CategoryExhibition.init);


### PR DESCRIPTION
Ensure that `wgScriptPath` is correctly prepended before making an AJAX request and replace legacy `wgAfterContentAndJS` with mw hook. 

https://wikia-inc.atlassian.net/browse/SUS-4198