### PR TITLE
SUS-3390 | no need to explicitily insert an empty `ip` column value into page_vote table

### DIFF
--- a/extensions/wikia/Wall/VoteHelper.class.php
+++ b/extensions/wikia/Wall/VoteHelper.class.php
@@ -46,7 +46,7 @@ class VoteHelper {
 		return $out;
 	}
 
-	function addVote( $score = 1 ) {
+	function addVote() {
 		if ( $this->isVoted() ) {
 			return false;
 		}
@@ -54,10 +54,9 @@ class VoteHelper {
 
 		$values = [
 			'article_id' => $this->pageId,
-			'ip' => '',
 			'user_id' => $this->userId,
 			'time' => wfTimestampNow(),
-			'vote' => $score,
+			'vote' => 1, // TODO: SUS-3890 - remove this column
 		];
 
 		$dbr->insert(

--- a/maintenance/archives/wikia/patch-create-page_vote.sql
+++ b/maintenance/archives/wikia/patch-create-page_vote.sql
@@ -3,7 +3,6 @@ CREATE TABLE /*$wgDBprefix*/page_vote (
 	`article_id` int(8) unsigned NOT NULL,
 	`user_id` int(5) unsigned NOT NULL,
 	`vote` int(2) NOT NULL,
-	`ip` varbinary(32) DEFAULT NULL,
 	`time` datetime NOT NULL,
 	UNIQUE KEY `article_user_idx` (`article_id`, `user_id`)
 ) ENGINE=InnoDB;


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3390

All wikis now accept NULL value for `ip` column (do not create `page_vote` table with `ip` column on new wikis):

```sql
$ ./run_on_clusters.sh "select count(*) from information_schema.columns where table_name = 'page_vote' and column_name = 'ip' and is_nullable <> 'YES';" 2>/dev/null

 -- wikicities_c1
+----------+
| count(*) |
+----------+
|        0 |
+----------+

 -- wikicities_c2
+----------+
| count(*) |
+----------+
|        0 |
+----------+

 -- wikicities_c3
+----------+
| count(*) |
+----------+
|        0 |
+----------+

 -- wikicities_c4
+----------+
| count(*) |
+----------+
|        0 |
+----------+

 -- wikicities_c5
+----------+
| count(*) |
+----------+
|        0 |
+----------+

 -- wikicities_c6
+----------+
| count(*) |
+----------+
|        0 |
+----------+

 -- wikicities_c7
+----------+
| count(*) |
+----------+
|        0 |
+----------+
```

### Table schema

```sql
CREATE TABLE /*$wgDBprefix*/page_vote (
	`article_id` int(8) unsigned NOT NULL,
	`user_id` int(5) unsigned NOT NULL,
	`vote` int(2) NOT NULL,
	`ip` varbinary(32) DEFAULT NULL,
	`time` datetime NOT NULL,
	UNIQUE KEY `article_user_idx` (`article_id`, `user_id`)
) ENGINE=InnoDB;
```

### Next step

* drop `ip` column when this goes live and make `vote` column accept NULL values (forum up-votes are counted based on rows count, `vote` column is not used by SELECT queries)