### PR TITLE
SUS-3561 | Fix some query pages not updating properly

### DIFF
--- a/extensions/wikia/Blogs/Blogs.php
+++ b/extensions/wikia/Blogs/Blogs.php
@@ -117,6 +117,8 @@ $wgHooks['AbortMove'][] = 'BlogsHelper::onAbortMove';
 
 $wgHooks['AfterPageHeaderButtons'][] = 'BlogsHelper::onAfterPageHeaderButtons';
 
+$wgHooks['WantedPages::getExcludedNamespaces'][] = 'BlogsHelper::onWantedPagesGetExcludedNamespaces';
+
 /**
  * load other parts
  */

--- a/extensions/wikia/Blogs/BlogsHelper.class.php
+++ b/extensions/wikia/Blogs/BlogsHelper.class.php
@@ -212,4 +212,13 @@ class BlogsHelper {
 
 		return true;
 	}
+
+	/**
+	 * SUS-3561: Exclude Blogs from Wanted Pages
+	 * @param array $namespaces
+	 */
+	public static function onWantedPagesGetExcludedNamespaces( array &$namespaces ) {
+		$namespaces[] = NS_BLOG_ARTICLE;
+		$namespaces[] = NS_BLOG_ARTICLE_TALK;
+	}
 }

--- a/extensions/wikia/Discussions/Discussions.setup.php
+++ b/extensions/wikia/Discussions/Discussions.setup.php
@@ -36,7 +36,7 @@ if ( !empty( $wgEnableDiscussions ) && empty( $wgEnableForumExt ) ) {
 
 	// IRIS-5184: Exclude outgoing links in Forum content from Special:WhatLinksHere and Special:WantedPages
 	$wgHooks['SpecialWhatLinksHere::beforeQuery'][] = 'DiscussionsHooksHelper::onSpecialWhatLinksHereBeforeQuery';
-	$wgHooks['WantedPages::getQueryInfo'][] = 'DiscussionsHooksHelper::onWantedPagesGetQueryInfo';
+	$wgHooks['WantedPages::getExcludedSourceNamespaces'][] = 'DiscussionsHooksHelper::onWantedPagesGetExcludedSourceNamespaces';
 
 	// Make sure we recognize the Forum namespaces so we can redirect them if requested
 	$wgExtensionNamespacesFiles['Discussions'] = __DIR__ . '/../Forum/Forum.namespaces.php';

--- a/extensions/wikia/Discussions/DiscussionsHooksHelper.php
+++ b/extensions/wikia/Discussions/DiscussionsHooksHelper.php
@@ -13,13 +13,12 @@ class DiscussionsHooksHelper {
 
 	/**
 	 * IRIS-5184: Exclude outgoing links in Forum content from Special:WantedPages report
-	 * @see WantedPagesPage::getQueryInfo()
+	 * @see WantedPagesPage::getExcludedSourceNamespaces()
 	 *
-	 * @param WantedPagesPage $wantedPagesPage
-	 * @param array $queryInfo
+	 * @param int[] $namespaces
 	 */
-	public static function onWantedPagesGetQueryInfo( $wantedPagesPage, array &$queryInfo ) {
-		$queryInfo['conds'][] = "pg2.page_namespace != '" . NS_WIKIA_FORUM_BOARD_THREAD . "'";
+	public static function onWantedPagesGetExcludedSourceNamespaces( array &$namespaces ) {
+		$namespaces[] = NS_WIKIA_FORUM_BOARD_THREAD;
 	}
 
 	/**

--- a/includes/QueryPage.php
+++ b/includes/QueryPage.php
@@ -298,10 +298,10 @@ abstract class QueryPage extends SpecialPage {
 		 */
 
 		if ( $res ) {
-			$num = $dbr->numRows( $res );
+			$num = 0;
 			# Fetch results
 			$vals = array();
-			while ( $res && $row = $dbr->fetchObject( $res ) ) {
+			foreach ( $res as $row ) {
 				if ( isset( $row->value ) ) {
 					if ( $this->usesTimestamps() ) {
 						$value = wfTimestamp( TS_UNIX,
@@ -313,10 +313,14 @@ abstract class QueryPage extends SpecialPage {
 					$value = 0;
 				}
 
-				$vals[] = array( 'qc_type' => $this->getName(),
-						'qc_namespace' => $row->namespace,
-						'qc_title' => $row->title,
-						'qc_value' => $value );
+				$vals[] = [
+					'qc_type' => $this->getName(),
+					'qc_namespace' => $row->namespace,
+					'qc_title' => $row->title,
+					'qc_value' => $value,
+				];
+
+				$num++;
 			}
 
 			# Save results into the querycache table on the master

--- a/includes/specials/SpecialFewestrevisions.php
+++ b/includes/specials/SpecialFewestrevisions.php
@@ -42,22 +42,22 @@ class FewestrevisionsPage extends QueryPage {
 	}
 
 	function getQueryInfo() {
-		return array (
-			'tables' => array ( 'revision', 'page' ),
-			'fields' => array ( 'page_namespace AS namespace',
-					'page_title AS title',
-					'COUNT(*) AS value',
-					'page_is_redirect AS redirect' ),
-			'conds' => array ( 'page_namespace' => MWNamespace::getContentNamespaces(),
-					'page_id = rev_page' ),
-			'options' => array ( 'HAVING' => 'COUNT(*) > 1',
-			// ^^^ This was probably here to weed out redirects.
-			// Since we mark them as such now, it might be
-			// useful to remove this. People _do_ create pages
-			// and never revise them, they aren't necessarily
-			// redirects.
-			'GROUP BY' => 'page_namespace, page_title, page_is_redirect' )
-		);
+		return [
+			'tables' => [ 'revision', 'page' ],
+			'fields' => [
+				'page_namespace AS namespace',
+				'page_title AS title',
+				'COUNT(*) AS value',
+				'page_is_redirect AS redirect',
+			],
+			'conds' => [
+				'page_namespace' => MWNamespace::getContentNamespaces(),
+				'page_id = rev_page',
+			],
+			'options' => [
+				'GROUP BY' => 'page_id',
+			],
+		];
 	}
 
 

--- a/includes/specials/SpecialMostlinked.php
+++ b/includes/specials/SpecialMostlinked.php
@@ -40,19 +40,31 @@ class MostlinkedPage extends QueryPage {
 	function isSyndicated() { return false; }
 
 	function getQueryInfo() {
-		return array (
-			'tables' => array ( 'pagelinks', 'page' ),
-			'fields' => array ( 'pl_namespace AS namespace',
-					'pl_title AS title',
-					'COUNT(*) AS value',
-					'page_namespace' ),
-			'options' => array ( 'HAVING' => 'COUNT(*) > 1',
-				'GROUP BY' => 'pl_namespace, pl_title, '.
-						'page_namespace' ),
-			'join_conds' => array ( 'page' => array ( 'LEFT JOIN',
-					array ( 'page_namespace = pl_namespace',
-						'page_title = pl_title' ) ) )
-		);
+		return [
+			'tables' => [ 'pagelinks', 'page' ],
+			'fields' => [
+				'pl_namespace AS namespace',
+				'pl_title AS title',
+				'COUNT(*) AS value',
+				'page_namespace',
+			],
+			'conds' => [
+				'page_id IS NOT NULL'
+			],
+			'options' => [
+				'HAVING' => 'COUNT(*) > 1',
+				'GROUP BY' => 'page_id',
+			],
+			'join_conds' => [
+				'page' => [
+					'LEFT JOIN',
+					[
+						'page_namespace = pl_namespace',
+						'page_title = pl_title',
+					],
+				],
+			],
+		];
 	}
 
 	/**

--- a/includes/specials/SpecialUncategorizedimages.php
+++ b/includes/specials/SpecialUncategorizedimages.php
@@ -47,17 +47,27 @@ class UncategorizedImagesPage extends ImageQueryPage {
 	}
 
 	function getQueryInfo() {
-		return array (
-			'tables' => array( 'page', 'categorylinks' ),
-			'fields' => array( 'page_namespace AS namespace',
-					'page_title AS title',
-					'page_title AS value' ),
-			'conds' => array( 'cl_from IS NULL',
-					'page_namespace' => NS_FILE,
-					'page_is_redirect' => 0 ),
-			'join_conds' => array( 'categorylinks' => array(
-					'LEFT JOIN', 'cl_from=page_id' ) )
-		);
+		return [
+			'tables' => [ 'page', 'categorylinks' ],
+			'fields' => [
+				'page_namespace AS namespace',
+				'page_title AS title',
+			],
+			'conds' => [
+				'cl_from IS NULL',
+				'page_namespace' => NS_FILE,
+				'page_is_redirect' => 0,
+			],
+			'join_conds' => [
+				'categorylinks' => [
+					'LEFT JOIN',
+					'cl_from=page_id',
+				],
+			],
+		];
 	}
 
+	function getOrderFields() {
+		return [ 'title' ];
+	}
 }

--- a/includes/specials/SpecialUnusedcategories.php
+++ b/includes/specials/SpecialUnusedcategories.php
@@ -37,16 +37,24 @@ class UnusedCategoriesPage extends QueryPage {
 	}
 
 	function getQueryInfo() {
-		return array (
-			'tables' => array ( 'page', 'categorylinks' ),
-			'fields' => array ( 'page_namespace AS namespace',
-					'page_title AS title' ),
-			'conds' => array ( 'cl_from IS NULL',
-					'page_namespace' => NS_CATEGORY,
-					'page_is_redirect' => 0 ),
-			'join_conds' => array ( 'categorylinks' => array (
-					'LEFT JOIN', 'cl_to = page_title' ) )
-		);
+		return [
+			'tables' => [ 'page', 'categorylinks' ],
+			'fields' => [
+				'page_namespace AS namespace',
+				'page_title AS title',
+			],
+			'conds' => [
+				'cl_from IS NULL',
+				'page_namespace' => NS_CATEGORY,
+				'page_is_redirect' => 0,
+			],
+			'join_conds' => [
+				'categorylinks' => [
+					'LEFT JOIN',
+					'cl_to = page_title',
+				],
+			],
+		];
 	}
 
 	/**
@@ -59,5 +67,9 @@ class UnusedCategoriesPage extends QueryPage {
 	function formatResult( $skin, $result ) {
 		$title = Title::makeTitle( NS_CATEGORY, $result->title );
 		return Linker::link( $title, htmlspecialchars( $title->getText() ) );
+	}
+
+	function getOrderFields() {
+		return [ 'title' ];
 	}
 }

--- a/includes/specials/SpecialUnusedtemplates.php
+++ b/includes/specials/SpecialUnusedtemplates.php
@@ -54,6 +54,10 @@ class UnusedtemplatesPage extends QueryPage {
 		);
 	}
 
+	function getOrderFields() {
+		return [ 'title' ];
+	}
+
 	/**
 	 * @param $skin Skin
 	 * @param $result

--- a/includes/specials/SpecialWantedpages.php
+++ b/includes/specials/SpecialWantedpages.php
@@ -39,54 +39,106 @@ class WantedPagesPage extends WantedQueryPage {
 		if ( $inc ) {
 			$parts = explode( '/', $par, 2 );
 			$this->limit = (int)$parts[0];
-			// @todo FIXME: nlinks is ignored
-			//$nlinks = isset( $parts[1] ) && $parts[1] === 'nlinks';
 			$this->offset = 0;
-		} else {
-			//$nlinks = true;
 		}
+
 		$this->setListoutput( $inc );
 		$this->shownavigation = !$inc;
 		parent::execute( $par );
 	}
 
 	function getQueryInfo() {
-		global $wgWantedPagesThreshold;
-		$count = $wgWantedPagesThreshold - 1;
-		$query = array(
-			'tables' => array(
+		$dbr = wfGetDB( DB_SLAVE );
+
+		$query = [
+			'tables' => [
 				'pagelinks',
 				'pg1' => 'page',
-				'pg2' => 'page'
-			),
-			'fields' => array(
+				'pg2' => 'page',
+			],
+			'fields' => [
 				'pl_namespace AS namespace',
 				'pl_title AS title',
-				'COUNT(*) AS value'
-			),
-			'conds' => array(
+				'pg2.page_namespace AS source_namespace'
+			],
+			'conds' => [
 				'pg1.page_namespace IS NULL',
-				"pl_namespace NOT IN ( '" . NS_USER .
-					"', '" . NS_USER_TALK . "' )",
-				"pg2.page_namespace != '" . NS_MEDIAWIKI . "'"
-			),
-			'options' => array(
-				'HAVING' => "COUNT(*) > $count",
-				'GROUP BY' => 'pl_namespace, pl_title'
-			),
-			'join_conds' => array(
-				'pg1' => array(
-					'LEFT JOIN', array(
+				'pl_namespace NOT IN (' . $dbr->makeList( $this->getExcludedNamespaces() ) . ')',
+			],
+			'options' => [],
+			'join_conds' => [
+				'pg1' => [
+					'LEFT JOIN',
+					[
 						'pg1.page_namespace = pl_namespace',
-						'pg1.page_title = pl_title'
-					)
-				),
-				'pg2' => array( 'LEFT JOIN', 'pg2.page_id = pl_from' )
-			)
-		);
+						'pg1.page_title = pl_title',
+					],
+				],
+				'pg2' => [ 'LEFT JOIN', 'pg2.page_id = pl_from' ],
+			],
+		];
 		// Replacement for the WantedPages::getSQL hook
 		Hooks::run( 'WantedPages::getQueryInfo', [ $this, &$query ] );
 
 		return $query;
+	}
+
+	function reallyDoQuery( $limit, $offset = false ) {
+		$res = parent::reallyDoQuery( false, $offset );
+
+		// SUS-3561: Group, filter and sort the results in PHP level due to abysmal query performance
+		$excludedSourceNamespaces = array_flip( $this->getExcludedSourceNamespaces() );
+		$pageGroup = [];
+
+		foreach ( $res as $row ) {
+			if ( !isset( $excludedSourceNamespaces[$row->source_namespace] ) ) {
+				$page = $row->namespace . $row->title;
+
+				if ( !isset( $pageGroup[$page] ) ) {
+					$pageGroup[$page] = $row;
+					$pageGroup[$page]->value = 0;
+				}
+
+				$pageGroup[$page]->value++;
+			}
+		}
+
+		usort( $pageGroup, function ( $x, $y ) {
+			return $y->value - $x->value;
+		} );
+
+		if ( $limit !== false ) {
+			return array_slice( $pageGroup, 0, intval( $limit ) );
+		}
+
+		return $pageGroup;
+	}
+
+	function getOrderFields() {
+		return [];
+	}
+
+	/**
+	 * List of namespaces whose pages will never show up as wanted in WantedPages
+	 * @return int[]
+	 */
+	protected function getExcludedNamespaces(): array {
+		$namespaces = [ NS_USER, NS_USER_TALK ];
+
+		Hooks::run( 'WantedPages::getExcludedNamespaces', [ &$namespaces ] );
+
+		return $namespaces;
+	}
+
+	/**
+	 * List of namespaces whose outgoing redlinks will not generate a WantedPages entry for the target page
+	 * @return int[]
+	 */
+	protected function getExcludedSourceNamespaces(): array {
+		$namespaces = [ NS_MEDIAWIKI ];
+
+		Hooks::run( 'WantedPages::getExcludedSourceNamespaces', [ &$namespaces ] );
+
+		return $namespaces;
 	}
 }

--- a/tests/fixtures/wanted_pages.yaml
+++ b/tests/fixtures/wanted_pages.yaml
@@ -1,0 +1,29 @@
+page:
+  - page_id: 1
+    page_namespace: 8
+    page_title: SomeMwPage
+    page_restrictions: ''
+    page_random: 0
+    page_latest: 1
+    page_len: 0
+  - page_id: 2
+    page_namespace: 0
+    page_title: TestPageWithRedLink
+    page_restrictions: ''
+    page_random: 0
+    page_latest: 2
+    page_len: 0
+pagelinks:
+  - pl_from: 1
+    pl_namespace: 0
+    pl_title: PageLinkedFromMwPage
+  - pl_from: 2
+    pl_namespace: 0
+    pl_title: PageLinkedFromNormalPage
+  - pl_from: 2
+    pl_namespace: 0
+    pl_title: OtherPageLinkedFromNormalPage
+  - pl_from: 2
+    pl_namespace: 2
+    pl_title: UserPageLinkedFromNormalPage
+

--- a/tests/unit/includes/specials/WantedPagesIntegrationTest.php
+++ b/tests/unit/includes/specials/WantedPagesIntegrationTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @group Integration
+ */
+class WantedPagesIntegrationTest extends WikiaDatabaseTest {
+	/** @var WantedPagesPage $wantedPagesPage */
+	private $wantedPagesPage;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->wantedPagesPage = new WantedPagesPage();
+	}
+
+	public function testQuery() {
+		$res = $this->wantedPagesPage->reallyDoQuery( 1000 );
+
+		foreach ( $res as $row ) {
+			$this->assertNotEquals( 'PageLinkedFromMwPage', $row->title, 'Page linked on MW page should not generate entry' );
+			$this->assertNotEquals( 'UserPageLinkedFromNormalPage', $row->title, 'User page linked on normal page should not generate entry' );
+		}
+
+		$this->assertCount( 2, $res );
+	}
+
+	public function testQueryWithLimit() {
+		$res = $this->wantedPagesPage->reallyDoQuery( 1 );
+
+		foreach ( $res as $row ) {
+			$this->assertNotEquals( 'PageLinkedFromMwPage', $row->title, 'Page linked on MW page should not generate entry' );
+			$this->assertNotEquals( 'UserPageLinkedFromNormalPage', $row->title, 'User page linked on normal page should not generate entry' );
+		}
+
+		$this->assertCount( 1, $res );
+	}
+
+	protected function getDataSet() {
+		return $this->createYamlDataSet( __DIR__ . '/../../../fixtures/wanted_pages.yaml' );
+	}
+}


### PR DESCRIPTION
* Move grouping, ordering and some filtering logic to PHP layer from SQL on Wanted Pages due to abysmal query performance on larger wikis
* Optimize `GROUP BY` condition for Fewest/Mostrevisions and MostLinked to make the query complete before timeout
* Fix database error on UncategorizedFiles and UnusedCategories

https://wikia-inc.atlassian.net/browse/SUS-3561