### PR TITLE
Fix error on pages with syntax highlighting

### DIFF
--- a/extensions/SyntaxHighlight_GeSHi/SyntaxHighlight_GeSHi.class.php
+++ b/extensions/SyntaxHighlight_GeSHi/SyntaxHighlight_GeSHi.class.php
@@ -238,11 +238,6 @@ class SyntaxHighlight_GeSHi {
 	 * @return bool
 	 */
 	public static function viewHook( $text, $title, $output ) {
-		// SUS-1913: In production, swap 1% of GeSHi calls with Syntax Highlight experiment
-		if ( SyntaxHighlightHooks::shouldReplaceGeshi() ) {
-			return SyntaxHighlightHooks::onShowRawCssJs( $text, $title, $output );
-		}
-
 		global $wgUseSiteCss;
 		// Determine the language
 		$matches = array();


### PR DESCRIPTION
Fixes error:

    Error: Class 'SyntaxHighlightHooks' not found in extensions/
    SyntaxHighlight_GeSHi/SyntaxHighlight_GeSHi.class.php:242

Follow up to https://github.com/Wikia/app/pull/14859

/cc @TK-999 @macbre 