### PR TITLE
SUS-3390 | page_vote - allow NULL values in vote column

### DIFF
--- a/maintenance/archives/wikia/patch-create-page_vote.sql
+++ b/maintenance/archives/wikia/patch-create-page_vote.sql
@@ -2,7 +2,7 @@
 CREATE TABLE /*$wgDBprefix*/page_vote (
 	`article_id` int(8) unsigned NOT NULL,
 	`user_id` int(5) unsigned NOT NULL,
-	`vote` int(2) NOT NULL,
+	`vote` int(2) DEFAULT NULL,
 	`time` datetime NOT NULL,
 	UNIQUE KEY `article_user_idx` (`article_id`, `user_id`)
 ) ENGINE=InnoDB;


### PR DESCRIPTION
See #14856 

Next steps:

* remove this column from `INSERT` queries
* remove the column from table side-wide