### PR TITLE
SUS-3390 | page_vote - article and user ID + timestamp is all we need now

### DIFF
--- a/extensions/wikia/Wall/VoteHelper.class.php
+++ b/extensions/wikia/Wall/VoteHelper.class.php
@@ -55,8 +55,7 @@ class VoteHelper {
 		$values = [
 			'article_id' => $this->pageId,
 			'user_id' => $this->userId,
-			'time' => wfTimestampNow(),
-			'vote' => 1, // TODO: SUS-3890 - remove this column
+			'time' => wfTimestampNow()
 		];
 
 		$dbr->insert(


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3390

`vote` column now accepts `NULL` values, so we can skip it in `INSERT` queries.

```sql
CREATE TABLE `page_vote` (
  `article_id` int(8) unsigned NOT NULL,
  `user_id` int(5) unsigned NOT NULL,
  `vote` int(2) DEFAULT NULL,
  `time` datetime NOT NULL,
  UNIQUE KEY `article_user_idx` (`article_id`,`user_id`)
) ENGINE=InnoDB
```

Once this goes live we can drop `vote` column and announce that `page_vote` table cleanup is completed.