### PR TITLE
SUS-4233 | check if mobile search is still used

### DIFF
--- a/extensions/wikia/Search/WikiaSearchController.class.php
+++ b/extensions/wikia/Search/WikiaSearchController.class.php
@@ -830,6 +830,7 @@ class WikiaSearchController extends WikiaSpecialPageController {
 			$this->response->addAsset( 'extensions/wikia/Search/css/WikiaSearch.scss' );
 		}
 		if ( $skin instanceof SkinWikiaMobile ) {
+			WikiaLogger::instance()->info( 'SUS-4233 - Mobile search has been rendered' );
 			$this->overrideTemplate( 'WikiaMobileIndex' );
 		}
 


### PR DESCRIPTION
One of the mobile search templates contains a hardcoded URL. Let's check if we can remove the whole WikiaMobile specific code.

https://wikia-inc.atlassian.net/browse/SUS-4233