### PR TITLE
SUS-3390 | page_vote - vote column can go away

### DIFF
--- a/maintenance/archives/wikia/patch-create-page_vote.sql
+++ b/maintenance/archives/wikia/patch-create-page_vote.sql
@@ -2,7 +2,6 @@
 CREATE TABLE /*$wgDBprefix*/page_vote (
 	`article_id` int(8) unsigned NOT NULL,
 	`user_id` int(5) unsigned NOT NULL,
-	`vote` int(2) DEFAULT NULL,
 	`time` datetime NOT NULL,
 	UNIQUE KEY `article_user_idx` (`article_id`, `user_id`)
 ) ENGINE=InnoDB;


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3390

SELECT queries do not use this column, INSERT queries:

```sql
INSERT /* VoteHelper::addVote xxx */  INTO `page_vote` (article_id,user_id,time) VALUES ('442001','27574631','20180228130846')
```

```sql
-- Query digest for "page_vote" table, found 4763 queries
VoteHelper::getVoteCount 50.47% [ap] db:local | SELECT count(*) as cnt FROM `page_vote` LEFT JOIN `ipblocks` ON ((user_id = ipb_user)) WHERE (ifnull(ipb_expiry, N) != X) AND (ifnull(ipb_expiry, N) < N) AND article_id = X ORDER BY time desc LIMIT N
VoteHelper::isVoted 49.34% [ap] db:local | SELECT count(*) as cnt FROM `page_vote` WHERE article_id = X AND user_id = X LIMIT N
VoteHelper::getVotersList 0.10% [ap] db:local | SELECT user_id FROM `page_vote` LEFT JOIN `ipblocks` ON ((user_id = ipb_user)) WHERE (ifnull(ipb_expiry, N) != X) AND (ifnull(ipb_expiry, N) < N) AND article_id = X ORDER BY time desc LIMIT N
DatabaseBase::sourceFile( /usr/wikia/slot1/22190/src/maintenance/archives/wikia/patch-create-page_vote.sql ) 0.02% [ap] db:zhqatestwiki1519823452682 | CREATE TABLE `page_vote` ( `article_id` int(N) unsigned NOT NULL, `user_id` int(N) unsigned NOT NULL, `vote` int(N) DEFAULT NULL, `time` datetime NOT NULL, UNIQUE KEY `article_user_idx` (`article_id`, `user_id`) ) ENGINE=InnoDB
VoteHelper::addVote 0.06% [ap] db:local | INSERT INTO `page_vote` (article_id,user_id,time) VALUES (X,X,X)
```