### PR TITLE
SUS-4294 | video_info - do not perform INSERT IGNORE

### DIFF
--- a/extensions/wikia/VideoHandlers/videoInfo/VideoInfo.class.php
+++ b/extensions/wikia/VideoHandlers/videoInfo/VideoInfo.class.php
@@ -193,8 +193,7 @@ class VideoInfo extends WikiaModel {
 					'duration' => $this->duration,
 					'removed' => $this->removed,
 				),
-				__METHOD__,
-				'IGNORE'
+				__METHOD__
 			);
 
 			$affected = $db->affectedRows() > 0;


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-4294

```sql
INSERT IGNORE INTO `video_info` (video_title,video_id,provider,added_at,added_by,duration,hdfile,removed,featured) VALUES ('Kermit_rings_bell_at_NYSE','782ldhWOrbk','youtube','20180304033316','10637','51','1','0','0')
```

is evil.
