### PR TITLE
SUS | in WikiFactoryLoader fix domain cache

### DIFF
--- a/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
+++ b/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
@@ -360,7 +360,7 @@ class WikiFactoryLoader {
 				 * store value in cache
 				 */
 				$oMemc->set(
-					WikiFactory::getDomainKey( $this->mServerName ),
+					WikiFactory::getDomainKey( $this->mServerName . '/' . $this->langCode ),
 					$this->mDomain,
 					$this->mExpireDomainCacheTimeout
 				);


### PR DESCRIPTION
Ensure that cache is properly set for WikiFactory domains by appending the optional path component also when the cache is set, not just when its read.