### PR TITLE
MAIN-13131: Fix scaling issue in edit preview

### DIFF
--- a/extensions/wikia/EditPreview/js/preview.js
+++ b/extensions/wikia/EditPreview/js/preview.js
@@ -117,6 +117,9 @@ define('wikia.preview', [
 					// get width of article Wrapper
 					// subtract scrollbar width to get correct width needed as reference point for scaling
 					articleWrapperWidth = $article.parent().width() - editPageOptions.scrollbarWidth;
+					// scale preview when opening modal
+					// scale preview when changing dropdown option is handled inside switchPreview function
+					scalePreview(previewTypes[currentTypeName].name);
 				}
 
 				if (currentTypeName) {
@@ -256,9 +259,6 @@ define('wikia.preview', [
 			loadPreview(previewTypes[currentTypeName].name, true);
 
 			if (window.wgOasisResponsive || window.wgOasisBreakpoints) {
-				//scale preview when opening modal
-				//scale preview when changing dropdown option is handled inside switchPreview function
-				scalePreview(previewTypes[currentTypeName].name);
 				// adding type dropdown to preview
 				if (!previewTemplate) {
 					loader({


### PR DESCRIPTION
When opening edit preview modal too fast, the edit preview could show up shrinked:
![Image](https://i.imgur.com/au1XGJP.gif)
Changes tested with [Resource Override](https://chrome.google.com/webstore/detail/resource-override/pkoacgokdfckfpndoffpifphamojphii)

Support ticket: [#376209](https://support.wikia-inc.com/hc/en-us/requests/376209) (under number 16)
Bug ticket: [MAIN-13131](https://wikia-inc.atlassian.net/browse/MAIN-13131)