### PR TITLE
SUS-3754 | make long SQL queries fit the error message sent via UDP to Logstash

### DIFF
--- a/includes/db/Database.php
+++ b/includes/db/Database.php
@@ -1079,6 +1079,9 @@ abstract class DatabaseBase implements DatabaseType {
 			$sql1line = str_replace( "\n", "\\n", $sql );
 			wfLogDBError( "$fname\t{$this->mServer}\t$errno\t$error\t$sql1line\n" );
 			wfDebug( "SQL ERROR: " . $error . "\n" );
+
+			// SUS-3754 | make long SQL queries fit the error message sent via UDP to Logstash
+			$sql = substr( $sql, 0, 1024 );
 			throw new DBQueryError( $this, $error, $errno, $sql, $fname );
 		}
 	}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3754

```sql
A database error has occurred.  Did you forget to run maintenance/update.php after upgrading?  See: https://www.mediawiki.org/wiki/Manual:Upgrading#Run_the_update_script
Query: REPLACE INTO `transcache` (tc_url,tc_time,tc_contents) VALUES ('http://community.wikia.com/wiki/User:KockaAdmiralac/Wall_Archive?action=render','20180308142238','<p>Why is this thing throwing database errors.\n</p>\n<table class=\"wikitable\" style=\"width:100%; text-align:center;\">\n<caption>Archive of all threads on my Message Wall. Click on year/month names to see contents.\n</caption><tr>\n<th> Thread\n</th><th> User\n</th><th> Date\n</th></tr>\n<tr>\n<th colspan=\"3\" class=\"mw-customtoggle-collapse-2016\"> 2016\n</th></tr>\n<tr>\n<th colspan=\"3\" id=\"mw-customcollapsible-collapse-2016\" class=\"mw-customtoggle-collapse-3-2016 mw-collapsible mw-collapsed\"> March\n</th></tr>\n<tr>\n<td id=\"mw-customcollapsible-collapse-3-2016\" class=\"mw-collapsible mw-collapsed\"> <i><a href=\"http://community.wikia.com/wiki/Thread:1006976\" title=\"Thread:1006976\">Welcome to Community Central!</a></i>\n</td><td id=\"mw-customcollapsible-collapse-3-2016\" class=\"mw-collapsible mw-collapsed\"> <a href=\"http://co
Function: DatabaseMysqlBase::replace
Error: 1406 Data too long for column 'tc_contents' at row 1 (geo-db-a-master.query.consul)
```

is now logged properly to es and can be auto-reported as a Jira ticket.

![](https://engineering-blog.wikia.com/images/turning-logs-into-bug-reports/4a555154282ebf776a5ca264d13eacb5.jpg)