### PR TITLE
SUS-3754 | Parser::fetchScaryTemplateMaybeFromCache - use a memcache instead of in-database cache

### DIFF
--- a/includes/installer/DatabaseUpdater.php
+++ b/includes/installer/DatabaseUpdater.php
@@ -616,20 +616,6 @@ abstract class DatabaseUpdater {
 	}
 
 	/**
-	 * Updates the timestamps in the transcache table
-	 */
-	protected function doUpdateTranscacheField() {
-		if ( $this->updateRowExists( 'convert transcache field' ) ) {
-			$this->output( "...transcache tc_time already converted.\n" );
-			return;
-		}
-
-		$this->output( "Converting tc_time from UNIX epoch to MediaWiki timestamp... " );
-		$this->applyPatch( 'patch-tc-timestamp.sql' );
-		$this->output( "done.\n" );
-	}
-
-	/**
 	 * Update CategoryLinks collation
 	 */
 	protected function doCollationUpdate() {

--- a/includes/installer/MysqlUpdater.php
+++ b/includes/installer/MysqlUpdater.php
@@ -61,7 +61,6 @@ class MysqlUpdater extends DatabaseUpdater {
 			#array( 'doUserGroupsUpdate' ),
 			array( 'addField', 'site_stats',    'ss_total_pages',   'patch-ss_total_articles.sql' ),
 			array( 'addTable', 'user_newtalk',                      'patch-usernewtalk2.sql' ),
-			array( 'addTable', 'transcache',                        'patch-transcache.sql' ),
 			array( 'addField', 'interwiki',     'iw_trans',         'patch-interwiki-trans.sql' ),
 
 			// 1.6
@@ -144,7 +143,6 @@ class MysqlUpdater extends DatabaseUpdater {
 			array( 'addIndex', 'log_search',    'ls_field_val',     'patch-log_search-rename-index.sql' ),
 			array( 'addIndex', 'change_tag',    'change_tag_rc_tag', 'patch-change_tag-indexes.sql' ),
 			array( 'addField', 'redirect',      'rd_interwiki',     'patch-rd_interwiki.sql' ),
-			array( 'doUpdateTranscacheField' ),
 			array( 'doUpdateMimeMinorField' ),
 
 			// 1.17

--- a/includes/wikia/WikiaUpdater.php
+++ b/includes/wikia/WikiaUpdater.php
@@ -70,7 +70,6 @@ class WikiaUpdater {
 			array( 'WikiaUpdater::do_drop_table', 'watchlist_old' ),
 			array( 'WikiaUpdater::do_drop_table', 'hidden' ), // SUS-2401
 			array( 'WikiaUpdater::do_clean_math_table' ),
-			array( 'WikiaUpdater::do_transcache_update' ),
 			array( 'WikiaUpdater::do_wall_history_ipv6_update' ), // SUS-2257
 			array( 'WikiaUpdater::doLoggingTableUserCleanup' ), // SUS-3222
 			array( 'WikiaUpdater::migrateRecentChangesIpData' ), // SUS-3079
@@ -147,41 +146,6 @@ class WikiaUpdater {
 			else {
 				$updater->output( "... already altered to integer.\n" );
 			}
-		}
-	}
-
-	public static function do_transcache_update( DatabaseUpdater $updater ) {
-		$db = $updater->getDB();
-		$transcache = $db->tableName( 'transcache' );
-		$res = $db->query( "SHOW COLUMNS FROM transcache" );
-		$columns = array(
-			'tc_contents' => array(
-				'old' => 'text',
-				'new' => 'blob'
-			),
-			'tc_url'      => array(
-				'old' => 'varchar(255)',
-				'new' => 'varbinary(255)'
-			)
-		);
-		$patch = array();
-		while ( $row = $db->fetchObject( $res ) ) {
-			if ( !$row ) continue;
-			$column = !empty( $columns[ $row->Field ] ) ? $columns[ $row->Field ] : '';
-
-			if ( $column && $columns[ $row->Field ]['old'] == $row->Type ) {
-				$patch[] = sprintf( "MODIFY %s %s", $row->Field, $columns[ $row->Field ]['new'] );
-			} else {
-				$updater->output( "...{$row->Field} is up-to-date.\n" );
-			}
-		}
-
-		if ( !empty( $patch ) ) {
-			$db->query( sprintf( "ALTER TABLE transcache %s", implode( ",", $patch ) ), __METHOD__ );
-			$updater->output( "... altered to binary.\n" );
-		}
-		else {
-			$updater->output( "... transcache table is up-to-date.\n" );
 		}
 	}
 

--- a/maintenance/archives/patch-tc-timestamp.sql
+++ b/maintenance/archives/patch-tc-timestamp.sql
@@ -1,4 +1,0 @@
-ALTER TABLE /*_*/transcache MODIFY tc_time binary(14);
-UPDATE /*_*/transcache SET tc_time = DATE_FORMAT(FROM_UNIXTIME(tc_time), "%Y%c%d%H%i%s");
-
-INSERT IGNORE INTO /*_*/updatelog(ul_key) VALUES ('convert transcache field');

--- a/maintenance/archives/patch-transcache.sql
+++ b/maintenance/archives/patch-transcache.sql
@@ -1,7 +1,0 @@
-CREATE TABLE /*$wgDBprefix*/transcache (
-	tc_url		varbinary(255) NOT NULL,
-	tc_contents	TEXT,
-	tc_time		binary(14) NOT NULL,
-	UNIQUE INDEX tc_url_idx(tc_url)
-) /*$wgDBTableOptions*/;
-

--- a/maintenance/tables.sql
+++ b/maintenance/tables.sql
@@ -985,19 +985,6 @@ CREATE TABLE /*_*/querycache (
 
 CREATE UNIQUE INDEX /*i*/qc_type_value_ns_title ON /*_*/querycache (qc_type,qc_value,qc_namespace,qc_title);
 
-
---
--- Cache of interwiki transclusion
---
-CREATE TABLE /*_*/transcache (
-  tc_url varbinary(255) NOT NULL,
-  tc_contents text,
-  tc_time binary(14) NOT NULL
-) /*$wgDBTableOptions*/;
-
-CREATE UNIQUE INDEX /*i*/tc_url_idx ON /*_*/transcache (tc_url);
-
-
 CREATE TABLE /*_*/logging (
   -- Log ID, for referring to this specific log entry, probably for deletion and such.
   log_id int unsigned NOT NULL PRIMARY KEY AUTO_INCREMENT,


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3754

- there was no garbage collection mechanism
- long content was causing DB errors (BLOB column was apparently too short)
- responses for the same URLs where cached separately on each wiki

```sql
mysql@geo-db-a-slave.query.consul[muppet]>select min(tc_time) from transcache;
+----------------+
| min(tc_time)   |
+----------------+
| 20061201060109 |
+----------------+
1 row in set (0.00 sec)
```