### PR TITLE
MAIN-13170: Link to correct page in nonportableinfoboxes

### DIFF
--- a/extensions/wikia/InsightsV2/specials/UnconvertedInfoboxesPage.class.php
+++ b/extensions/wikia/InsightsV2/specials/UnconvertedInfoboxesPage.class.php
@@ -115,7 +115,7 @@ class UnconvertedInfoboxesPage extends PageQueryPage {
 						$this->getName(),
 						count( $links ),
 						NS_TEMPLATE,
-						$title->getDBkey(),
+						$title->getPrefixedDBkey(),
 					];
 				}
 			}


### PR DESCRIPTION
When a template is named like `Template:User:A`, Special:Insights/nonportableinfoboxes will display `User:A` instead that points to that userpage. Bug example can be seen [here](http://kocka.wikia.com/wiki/Special:Insights/nonportableinfoboxes).

Support ticket: [#376209](https://support.wikia-inc.com/hc/en-us/requests/376209) (under number 8)
Bug ticket: [MAIN-13170](https://wikia-inc.atlassian.net/browse/MAIN-13170)