### PR TITLE
MAIN-13171: Fix infobox migration tool on sub-subpages

### DIFF
--- a/extensions/wikia/TemplateDraft/TemplateDraftHelper.class.php
+++ b/extensions/wikia/TemplateDraft/TemplateDraftHelper.class.php
@@ -52,7 +52,7 @@ class TemplateDraftHelper {
 	 * @throws MWException
 	 */
 	public static function getParentTitle( Title $title ) {
-		return Title::newFromText( $title->getBaseText(), NS_TEMPLATE );
+		return Title::newFromText( $title->getParentText(), NS_TEMPLATE );
 	}
 
 	/**


### PR DESCRIPTION
When a user is migrating a template draft from, for example, [Template:Infobox/Test/Draft](http://kocka.wikia.com/wiki/Template:Infobox/Test/Draft), it's expected that it migrates to the template it was created from, [Template:Infobox/Test](http://kocka.wikia.com/wiki/Template:Infobox/Test). What happens, though, is that it migrates to [Template:Infobox](http://kocka.wikia.com/wiki/Template:Infobox).

Support ticket: [#376209](https://support.wikia-inc.com/hc/en-us/requests/376209) (under number 8)
Bug ticket: [MAIN-13171](https://wikia-inc.atlassian.net/browse/MAIN-13171)