### PR TITLE
SUS-4132 | Fix: Portable Infobox Migration tool operates on ROOTPAGENAME instead of FULLPAGENAME

### DIFF
--- a/extensions/wikia/TemplateDraft/TemplateDraftHelper.class.php
+++ b/extensions/wikia/TemplateDraft/TemplateDraftHelper.class.php
@@ -52,7 +52,7 @@ class TemplateDraftHelper {
 	 * @throws MWException
 	 */
 	public static function getParentTitle( Title $title ) {
-		return Title::newFromText( $title->getBaseText(), NS_TEMPLATE );
+		return Title::newFromText( $title->getParentText(), NS_TEMPLATE );
 	}
 
 	/**


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-4132