### PR TITLE
SUS-2902 | Force categorytree to use content language for error messages

### DIFF
--- a/extensions/CategoryTree/CategoryTreeFunctions.php
+++ b/extensions/CategoryTree/CategoryTreeFunctions.php
@@ -432,12 +432,12 @@ class CategoryTree {
 		if ( !$allowMissing && !$title->getArticleID() ) {
 			$html .= Html::openElement( 'span', array( 'class' => 'CategoryTreeNotice' ) );
 			if ( $parser ) {
-				$html .= $parser->recursiveTagParse( wfMsgNoTrans( 'categorytree-not-found', $category ) );
+				$html .= $parser->recursiveTagParse( wfMessage( 'categorytree-not-found', $category )->inContentLanguage()->plain() );
 			} else {
-				$html .= wfMsgExt( 'categorytree-not-found', 'parseinline', htmlspecialchars( $category ) );
+				$html .= wfMessage( 'categorytree-not-found', $category )->inContentLanguage()->parse();
 			}
 			$html .= Html::closeElement( 'span' );
-			}
+		}
 		else {
 			if ( !$hideroot ) {
 				$html .= $this->renderNode( $title, $depth, $wgCategoryTreeDynamicTag );

--- a/extensions/CategoryTree/CategoryTreePage.php
+++ b/extensions/CategoryTree/CategoryTreePage.php
@@ -16,8 +16,12 @@ if ( !defined( 'MEDIAWIKI' ) ) {
 }
 
 class CategoryTreePage extends SpecialPage {
-	var $target = '';
-	var $tree = null;
+	public $target = '';
+
+	/**
+	 * @var CategoryTree
+	 */
+	public $tree = null;
 
 	function __construct() {
 		parent::__construct( 'CategoryTree', '', true );
@@ -49,7 +53,7 @@ class CategoryTreePage extends SpecialPage {
 		if ( $par ) {
 			$this->target = $par;
 		} else {
-			$this->target = $request->getVal( 'target', wfMsg( 'rootcategory' ) );
+			$this->target = $request->getVal( 'target', $this->msg( 'rootcategory' )->text() );
 		}
 
 		$this->target = trim( $this->target );
@@ -86,13 +90,13 @@ class CategoryTreePage extends SpecialPage {
 
 			if ( $title && $title->getArticleID() ) {
 				$output->addHTML( Xml::openElement( 'div', array( 'class' => 'CategoryTreeParents' ) ) );
-				$output->addHTML( wfMsgExt( 'categorytree-parents', 'parseinline' ) );
-				$output->addHTML( wfMsg( 'colon-separator' ) );
+				$output->addHTML( $this->msg( 'categorytree-parents' )->parse() );
+				$output->addHTML( $this->msg( 'colon-separator' )->escaped() );
 
 				$parents = $this->tree->renderParents( $title );
 
 				if ( $parents == '' ) {
-					$output->addHTML( wfMsgExt( 'categorytree-no-parent-categories', 'parseinline' ) );
+					$output->addHTML( $this->msg( 'categorytree-no-parent-categories' )->parse() );
 				} else {
 					$output->addHTML( $parents );
 				}
@@ -104,7 +108,7 @@ class CategoryTreePage extends SpecialPage {
 				$output->addHTML( Xml::closeElement( 'div' ) );
 			} else {
 				$output->addHTML( Xml::openElement( 'div', array( 'class' => 'CategoryTreeNotice' ) ) );
-				$output->addHTML( wfMsgExt( 'categorytree-not-found', 'parseinline' , $this->target ) );
+				$output->addHTML( $this->msg( 'categorytree-not-found', $this->target )->parse() );
 				$output->addHTML( Xml::closeElement( 'div' ) );
 			}
 		}


### PR DESCRIPTION
Use `wfMessage()` the way it's coded in the upstream - https://phabricator.wikimedia.org/diffusion/ECTR/browse/master/includes/

https://wikia-inc.atlassian.net/browse/SUS-2902