### PR TITLE
PLATFORM-3384: bugfix for css files that were deleted in the past

### DIFF
--- a/maintenance/wikia/HttpsMigration/migrateCustomCss.php
+++ b/maintenance/wikia/HttpsMigration/migrateCustomCss.php
@@ -296,12 +296,13 @@ class MigrateCustomCssToHttps extends Maintenance {
 					$editPage->summary = $this->getEditSummary();
 					$editPage->textbox1 = $updatedText;
 					$editPage->minoredit = true;
+					$editPage->starttime = wfTimestampNow();
 					$result = [];
 					$status = $editPage->internalAttemptSave( $result, /* bot */ true );
 					if ( $status->isGood() ) {
 						$this->output( "Saved updated CSS file\n" );
 					} else {
-						$this->error( "Failed to save CSS file!\n" );
+						$this->error( "Failed to save CSS file: {$status->value}!\n" );
 					}
 				}
 				return true;


### PR DESCRIPTION
A little over 1K css failed to save, because at some point they were deleted and due to lack of `starttime`, `EditPage::wasDeletedSinceLastEdit` was returning true.
Also log the reason in case css fails to save.