### PR TITLE
SUS-4310: Rollback edit transaction when external store insert fails

### DIFF
--- a/includes/WikiPage.php
+++ b/includes/WikiPage.php
@@ -1363,7 +1363,16 @@ class WikiPage extends Page implements IDBAccessObject {
 
 			if ( $changed ) {
 				$dbw->begin(__METHOD__);
-				$revisionId = $revision->insertOn( $dbw );
+
+				try {
+					$revisionId = $revision->insertOn( $dbw );
+				} catch ( DBError $error ) {
+					$dbw->rollback( __METHOD__ );
+					$status->fatal( 'databaseerror' );
+
+					wfProfileOut( __METHOD__ );
+					return $status;
+				}
 
 				# Update page
 				#
@@ -1472,7 +1481,16 @@ class WikiPage extends Page implements IDBAccessObject {
 				'user_text'  => $user->getName(),
 				'timestamp'  => $now
 			) );
-			$revisionId = $revision->insertOn( $dbw );
+
+			try {
+				$revisionId = $revision->insertOn( $dbw );
+			} catch ( DBError $error ) {
+				$dbw->rollback( __METHOD__ );
+				$status->fatal( 'databaseerror' );
+
+				wfProfileOut( __METHOD__ );
+				return $status;
+			}
 
 			# Update the page record with revision data
 			$this->updateRevisionOn( $dbw, $revision, 0 );


### PR DESCRIPTION
Avoid creating an incomplete/broken page when we cannot insert the new revision text into the external blob storage, since this situation is irrecoverable.

https://wikia-inc.atlassian.net/browse/SUS-4310