### PR TITLE
SUS-4317 | we do not use LCStore_DB

### DIFF
--- a/includes/AutoLoader.php
+++ b/includes/AutoLoader.php
@@ -135,7 +135,6 @@ $wgAutoloadLocalClasses = array(
 	'IP' => 'includes/IP.php',
 	'LCStore_Accel' => 'includes/LocalisationCache.php',
 	'LCStore_CDB' => 'includes/LocalisationCache.php',
-	'LCStore_DB' => 'includes/LocalisationCache.php',
 	'LCStore_Null' => 'includes/LocalisationCache.php',
 	'License' => 'includes/Licenses.php',
 	'Licenses' => 'includes/Licenses.php',

--- a/includes/installer/MysqlUpdater.php
+++ b/includes/installer/MysqlUpdater.php
@@ -139,7 +139,6 @@ class MysqlUpdater extends DatabaseUpdater {
 			# array( 'addTable', 'user_properties',                   'patch-user_properties.sql' ),
 			array( 'addTable', 'log_search',                        'patch-log_search.sql' ),
 			array( 'doLogSearchPopulation' ),
-			array( 'addTable', 'l10n_cache',                        'patch-l10n_cache.sql' ),
 			array( 'addIndex', 'log_search',    'ls_field_val',     'patch-log_search-rename-index.sql' ),
 			array( 'addIndex', 'change_tag',    'change_tag_rc_tag', 'patch-change_tag-indexes.sql' ),
 			array( 'addField', 'redirect',      'rd_interwiki',     'patch-rd_interwiki.sql' ),

--- a/maintenance/Maintenance.php
+++ b/maintenance/Maintenance.php
@@ -1117,7 +1117,7 @@ abstract class Maintenance {
 	 */
 	private function lockSearchindex( &$db ) {
 		$write = []; # array( 'searchindex' ); - Wikia change, there's no searchindex per-wiki table anymore
-		$read = array( 'page', 'revision', 'text', 'interwiki', 'l10n_cache' );
+		$read = array( 'page', 'revision', 'text', 'interwiki' );
 		$db->lockTables( $read, $write, __CLASS__ . '::' . __METHOD__ );
 	}
 

--- a/maintenance/archives/patch-l10n_cache.sql
+++ b/maintenance/archives/patch-l10n_cache.sql
@@ -1,8 +1,0 @@
--- Table for storing localisation data
-CREATE TABLE /*_*/l10n_cache (
-  lc_lang varbinary(32) NOT NULL,
-  lc_key varchar(255) NOT NULL,
-  lc_value mediumblob NOT NULL
-) /*$wgDBTableOptions*/;
-CREATE INDEX /*i*/lc_lang_key ON /*_*/l10n_cache (lc_lang, lc_key);
-

--- a/maintenance/tables.sql
+++ b/maintenance/tables.sql
@@ -1172,17 +1172,6 @@ CREATE TABLE /*_*/valid_tag (
   vt_tag varchar(255) NOT NULL PRIMARY KEY
 ) /*$wgDBTableOptions*/;
 
--- Table for storing localisation data
-CREATE TABLE /*_*/l10n_cache (
-  -- Language code
-  lc_lang varbinary(32) NOT NULL,
-  -- Cache key
-  lc_key varchar(255) NOT NULL,
-  -- Value
-  lc_value mediumblob NOT NULL
-) /*$wgDBTableOptions*/;
-CREATE INDEX /*i*/lc_lang_key ON /*_*/l10n_cache (lc_lang, lc_key);
-
 -- Table for storing JSON message blobs for the resource loader
 CREATE TABLE /*_*/msg_resource (
   -- Resource name


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-4317

This change allows us to remove [`l10n_cache`](https://www.mediawiki.org/wiki/Manual:L10n_cache_table) per-wiki tables. We use `LCStore_CDB` class to handle localisation cache across all wikis.

Database storage to be reclaimed: **82,4959 GiB**