### PR TITLE
SUS-1529 | ipb_create_account column is no longer needed on ipblocks table

### DIFF
--- a/maintenance/tables.sql
+++ b/maintenance/tables.sql
@@ -593,9 +593,6 @@ CREATE TABLE /*_*/ipblocks (
   -- If set to 1, block applies only to logged-out users
   ipb_anon_only bool NOT NULL default 0,
 
-  -- Block prevents account creation from matching IP addresses
-  ipb_create_account bool NOT NULL default 1,
-
   -- Block triggers autoblocks
   ipb_enable_autoblock bool NOT NULL default '1',
 

--- a/tests/fixtures/BlockTest.yaml
+++ b/tests/fixtures/BlockTest.yaml
@@ -8,7 +8,6 @@ ipblocks:
     ipb_timestamp: '20110101000000'
     ipb_auto: 0
     ipb_anon_only: 0
-    ipb_create_account: 0
     ipb_expiry: 'infinity'
     ipb_range_start: ''
     ipb_range_end: ''
@@ -24,7 +23,6 @@ ipblocks:
     ipb_timestamp: '20130412050100'
     ipb_auto: 0
     ipb_anon_only: 1
-    ipb_create_account: 1
     ipb_expiry: '20360712050100' # otherwise MW will discard it as expired ;)
     ipb_range_start: ''
     ipb_range_end: ''
@@ -40,7 +38,6 @@ ipblocks:
     ipb_timestamp: '20130412050100'
     ipb_auto: 1
     ipb_anon_only: 1
-    ipb_create_account: 1
     ipb_expiry: '20360712050100' # otherwise MW will discard it as expired ;)
     ipb_range_start: ''
     ipb_range_end: ''
@@ -56,7 +53,6 @@ ipblocks:
     ipb_timestamp: '20110101000000'
     ipb_auto: 0
     ipb_anon_only: 0
-    ipb_create_account: 0
     ipb_expiry: 'infinity'
     ipb_range_start: ''
     ipb_range_end: ''
@@ -72,7 +68,6 @@ ipblocks:
     ipb_timestamp: '20110101000000'
     ipb_auto: 1
     ipb_anon_only: 0
-    ipb_create_account: 0
     ipb_expiry: '20150101000000'
     ipb_range_start: ''
     ipb_range_end: ''


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-1529

Let's stop creating `ipb_create_account` column for new wikis before we drop it on the existing ones.