### PR TITLE
SUS-3742 do not check defaults zeros edits and age in AutoPromotion

### DIFF
--- a/extensions/TorBlock/TorBlock.class.php
+++ b/extensions/TorBlock/TorBlock.class.php
@@ -237,8 +237,12 @@ class TorBlock {
 			return true; // No groups to promote to anyway
 		}
 
-		$age = time() - wfTimestampOrNull( TS_UNIX, $user->getRegistration() );
 		global $wgTorAutoConfirmAge, $wgTorAutoConfirmCount;
+		if ( $wgTorAutoConfirmAge == 0 && $wgTorAutoConfirmCount == 0 && $user->isLoggedIn() ) {
+			return true;
+		}
+
+		$age = time() - wfTimestampOrNull( TS_UNIX, $user->getRegistration() );
 
 		if ($age >= $wgTorAutoConfirmAge && $user->getEditCount() >= $wgTorAutoConfirmCount) {
 			return true; // Does match requirements. Don't bother checking if we're an exit node.

--- a/includes/Autopromote.php
+++ b/includes/Autopromote.php
@@ -125,6 +125,11 @@ class Autopromote {
 
 				return $user->getEditCount() >= $cond[1];
 			case APCOND_AGE:
+				// Wikia change
+				// If age condition is 0 skip check
+				if ( $cond[1] === 0 ) {
+					return true;
+				}
 				$age = time() - wfTimestampOrNull( TS_UNIX, $user->getRegistration() );
 				return $age >= $cond[1];
 			case APCOND_AGE_FROM_EDIT:


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3742
```
$user->getEditCount()
```
Try to get value from database and if it's not there it add 0 to table.
For `first time user on wiki` it produce deadlocks on wikia_user_properties because on one page view we have many api calls simultaneously and all of them try to set 0 edits for user.

@Wikia/sus 