### PR TITLE
SUS-3798 | INSERT IGNORE is pure evil, remove IGNORE flag from ChangeTags class

### DIFF
--- a/includes/ChangeTags.php
+++ b/includes/ChangeTags.php
@@ -142,7 +142,8 @@ class ChangeTags {
 			);
 		}
 
-		$dbw->insert( 'change_tag', $tagsRows, __METHOD__, array( 'IGNORE' ) );
+		// SUS-3798 | Wikia change - remove an evil IGNORE flag
+		$dbw->insert( 'change_tag', $tagsRows, __METHOD__ );
 
 		return true;
 	}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3798

`change_tag` table is used to store tags for revisions. Let's remove `IGNORE` flag from `INSERT` queries, so that we will get DB errors logged.
 
Currently performed queries:

```sql
INSERT /* ChangeTags::addTags xxx */ IGNORE INTO `change_tag` (ct_tag,ct_rc_id,ct_rev_id) VALUES ('visualeditor','2680','2783');
```