### PR TITLE
SUS-3647 - revert changes for Title->getBaseText introduced in SUS-3117

### DIFF
--- a/extensions/wikia/MyHome/data/DataFeedProvider.php
+++ b/extensions/wikia/MyHome/data/DataFeedProvider.php
@@ -279,7 +279,7 @@ class DataFeedProvider {
 			$item['title'] = $parts['title'];
 			$item['url'] = $title->getLocalURL();
 		} elseif ( defined( 'NS_BLOG_ARTICLE_TALK' ) && $res['ns'] == NS_BLOG_ARTICLE_TALK && class_exists( 'ArticleComment' ) ) {
-			$subpageTitle = Title::newFromText( $title->getParentText(), NS_BLOG_ARTICLE_TALK );
+			$subpageTitle = Title::newFromText( $title->getBaseText(), NS_BLOG_ARTICLE_TALK );
 			/*
 			* Unfortunately $subpageTitle->getSubpageText() don't grab the blog article title text for subcomments.
 			* So considering blog structure reasonable way to get it, is to grab second title text part from full title text.
@@ -290,7 +290,7 @@ class DataFeedProvider {
 		} elseif ( defined( 'NS_BLOG_LISTING' ) && $res['ns'] == NS_BLOG_LISTING ) {
 			if ( $this->proxyType == self::WATCHLIST_FEED ) {
 				$item['title'] = $res['title'];
-				$item['url'] = Title::newFromText( $title->getParentText(), NS_BLOG_ARTICLE )->getLocalURL();
+				$item['url'] = Title::newFromText( $title->getBaseText(), NS_BLOG_ARTICLE )->getLocalURL();
 			}
 		} elseif (
 			!empty( $wgWallNS ) &&

--- a/extensions/wikia/TemplateDraft/TemplateDraftHelper.class.php
+++ b/extensions/wikia/TemplateDraft/TemplateDraftHelper.class.php
@@ -52,7 +52,7 @@ class TemplateDraftHelper {
 	 * @throws MWException
 	 */
 	public static function getParentTitle( Title $title ) {
-		return Title::newFromText( $title->getParentText(), NS_TEMPLATE );
+		return Title::newFromText( $title->getBaseText(), NS_TEMPLATE );
 	}
 
 	/**

--- a/extensions/wikia/Wall/WallHooksHelper.class.php
+++ b/extensions/wikia/Wall/WallHooksHelper.class.php
@@ -31,7 +31,12 @@ class WallHooksHelper {
 	static public function onUserIsBlockedFrom( User $user, $title, &$blocked, &$allowUsertalk ) {
 
 		if ( !$user->mHideName && $allowUsertalk && $title->inNamespace( NS_USER_WALL_MESSAGE  ) ) {
-			$blocked = $title->getBaseText() !== $user->getName();
+			$text = $title->getText();
+			$slashPosition = mb_strpos( $text, '/' );
+			if ( $slashPosition > 0 ) {
+				$text = mb_substr( $text, 0, $slashPosition );
+			}
+			$blocked = $text !== $user->getName();
 		}
 
 		return true;

--- a/includes/Title.php
+++ b/includes/Title.php
@@ -1297,44 +1297,22 @@ class Title {
 	}
 
 	/**
-	 * Get the base page name, i.e. the leftmost part before any slashes
+	 * Cut off the last subpage text
 	 *
 	 * @return String Base name
 	 */
 	public function getBaseText() {
-		$text = $this->getText();
 
 		if ( !MWNamespace::hasSubpages( $this->mNamespace ) ) {
-			return $text;
+			return $this->getText();
 		}
 
-		$slashPosition = mb_strpos( $text, '/' );
-
-		if ( $slashPosition === false ) {
-			return $text;
+		$parts = explode( '/', $this->getText() );
+		# Don't discard the real title if there's no subpage involved
+		if ( count( $parts ) > 1 ) {
+			unset( $parts[count( $parts ) - 1] );
 		}
-
-		return mb_substr( $text, 0, $slashPosition );
-	}
-
-	/**
-	 * Cut off the last subpage text
-	 * @return string
-	 */
-	public function getParentText() {
-		$text = $this->getText();
-
-		if ( !MWNamespace::hasSubpages( $this->mNamespace ) ) {
-			return $text;
-		}
-
-		$lastSlashPosition = mb_strrpos( $text, '/' );
-
-		if ( $lastSlashPosition === false ) {
-			return $text;
-		}
-
-		return mb_substr( $text, 0, $lastSlashPosition );
+		return implode( '/', $parts );
 	}
 
 	/**


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3647

revert changes for Title->getBaseText introduced in #14273 https://wikia-inc.atlassian.net/browse/SUS-3117
remove Title->getParentText introduced to fix missing getBaseText functionality #14295 https://wikia-inc.atlassian.net/browse/SUS-3362
correct php doc

@Wikia/sus @mszabo-wikia 