### PR TITLE
SUS-4313 | Class 'DumpsOnDemand' not found

### DIFF
--- a/extensions/wikia/WikiFactory/Dumps/DumpsOnDemand.php
+++ b/extensions/wikia/WikiFactory/Dumps/DumpsOnDemand.php
@@ -106,16 +106,6 @@ class DumpsOnDemand {
 	/**
 	 * @static
 	 * @access public
-	 * @deprecated
-	 */
-	static public function sendMail( $sDbName = null, $iCityId = null, $bHidden = false, $bClose = false ) {
-		trigger_error( sprintf( 'Using of deprecated method %s.', __METHOD__ ) , E_USER_WARNING );
-		self::queueDump( $iCityId, $bHidden, $bClose );
-	}
-
-	/**
-	 * @static
-	 * @access public
 	 */
 	static public function queueDump( $iCityId = null, $bHidden = false, $bClose = false ) {
 		global $wgCityId, $wgUser;

--- a/extensions/wikia/WikiFactory/Dumps/runBackups.php
+++ b/extensions/wikia/WikiFactory/Dumps/runBackups.php
@@ -216,7 +216,7 @@ function getDirectory( $database, $hide = false, $use_temp = false ) {
 }
 
 // SUS-4313 | make this dependency obvious
-$wgAutoloadClasses[ "DumpsOnDemand" ] = __DIR__ . '/Dumps/DumpsOnDemand.php';
+$wgAutoloadClasses[ "DumpsOnDemand" ] = __DIR__ . '/DumpsOnDemand.php';
 
 /**
  * main part

--- a/extensions/wikia/WikiFactory/Dumps/runBackups.php
+++ b/extensions/wikia/WikiFactory/Dumps/runBackups.php
@@ -26,8 +26,7 @@ require_once(__DIR__ .'/../../../../maintenance/commandLine.inc');
  */
 function runBackups( $from, $to, $full, $options ) {
 
-	global $IP, $wgWikiaLocalSettingsPath, $wgMaxShellTime,
-		$wgMaxShellFileSize, $wgDumpsDisabledWikis;
+	global $wgMaxShellTime, $wgMaxShellFileSize, $wgDumpsDisabledWikis;
 
 	$range = array();
 
@@ -215,6 +214,8 @@ function getDirectory( $database, $hide = false, $use_temp = false ) {
 
 	return $directory;
 }
+
+$wgAutoloadClasses[ "DumpsOnDemand" ] = __DIR__ . '/Dumps/DumpsOnDemand.php';
 
 /**
  * main part

--- a/extensions/wikia/WikiFactory/Dumps/runBackups.php
+++ b/extensions/wikia/WikiFactory/Dumps/runBackups.php
@@ -215,6 +215,7 @@ function getDirectory( $database, $hide = false, $use_temp = false ) {
 	return $directory;
 }
 
+// SUS-4313 | make this dependency obvious
 $wgAutoloadClasses[ "DumpsOnDemand" ] = __DIR__ . '/Dumps/DumpsOnDemand.php';
 
 /**


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-4313

Fix the following:

```
2018-03-14 15:17:05 runBackups-info:wikia/177: Running from 49200 to 49201
2018-03-14 15:17:05 doDumpBackup-info:wikia/177: 49200 esvirtualkingdom //tmp/dumps/e/es/esvirtualkingdom/esvirtualkingdom_pages_full.xml.7z
Unexpected non-MediaWiki exception encountered, of type "Error"
Error: Class 'DumpsOnDemand' not found in /usr/wikia/slot1/22426/src/extensions/wikia/WikiFactory/Dumps/runBackups.php:150
```

This is broken since `2018-02-26 07:57:12 UTC`.

Tested on `cron-s1` - works like a charm now :)

```
macbre@cron-s1:~/app/extensions/wikia/WikiFactory/Dumps/maintenance$ sudo SERVER_ID=177 php DumpsOnDemandCron.php 
INFO: Searching for dump requests to process.
INFO: Creating dumps for Wikia #1705037.
INFO: Running SERVER_ID=177 php /home/macbre/app/extensions/wikia/WikiFactory/Dumps/runBackups.php --conf /home/macbre/config/LocalSettings.php --id=1705037 --both --tmp --s3 2>&1 ...
(...)
2018-03-14 15:41:54 DumpsOnDemand::putToAmazonS3-info:wikia/177: Put '//tmp/dumps/b/be/bestelectrictanklesswaterheater/bestelectrictanklesswaterheater_pages_current.xml.7z' to Amazon S3 storage: status: 0, time: 1 sec

INFO: Dumps completed. Updating the status of the request.
Done.
```