### PR TITLE
SUS-3740 - in AbuseFilter use same actionID generation method

### DIFF
--- a/extensions/AbuseFilter/AbuseFilter.class.php
+++ b/extensions/AbuseFilter/AbuseFilter.class.php
@@ -1080,10 +1080,11 @@ class AbuseFilter {
 				// Mark with a tag on recentchanges.
 				global $wgUser;
 
-				$actionID = implode( '-', array(
-						$title->getPrefixedText(), $wgUser->getName(),
-							$vars->getVar( 'ACTION' )->toString()
-					) );
+				$UserIdOrIp =
+					$wgUser->isLoggedIn()
+						? $wgUser->getId()
+						: IP::sanitizeIP( $wgUser->getRequest()->getIP() );
+				$actionID =	self::getActionId( $title, $UserIdOrIp, $vars->getVar( 'ACTION' )->toString() );
 
 				AbuseFilter::$tagsToSet[$actionID] = $parameters;
 				break;
@@ -1746,5 +1747,13 @@ class AbuseFilter {
 			array( 'af_id' => $filterID ),
 			__METHOD__
 		);
+	}
+
+	static function getActionId( Title $title, $userIdOrIp, $action ) {
+		return implode( '-', [
+			$title->getPrefixedText(),
+			$userIdOrIp,
+			$action,
+		] );
 	}
 }

--- a/extensions/AbuseFilter/AbuseFilter.hooks.php
+++ b/extensions/AbuseFilter/AbuseFilter.hooks.php
@@ -149,11 +149,8 @@ class AbuseFilterHooks {
 		);
 		$action = $recentChange->mAttribs['rc_log_type'] ?
 			$recentChange->mAttribs['rc_log_type'] : 'edit';
-		$actionID = implode( '-', [
-			$title->getPrefixedText(),
-			$recentChange->mAttribs['rc_user'] ?: $recentChange->getUserIp(),
-			$action,
-		] );
+		$userIdOrIp = $recentChange->mAttribs['rc_user'] ?: $recentChange->getUserIp();
+		$actionID = AbuseFilter::getActionId($title, $userIdOrIp, $action);
 
 		if ( !empty( AbuseFilter::$tagsToSet[$actionID] )
 			&& count( $tags = AbuseFilter::$tagsToSet[$actionID] ) )


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-3740
bug was introduced during renaming refactoring
$actionID was generated by getUsername in one place and then `rc_user_text` from recent changes was used in another place (in same request).

@Wikia/sus @mszabo-wikia 
