### PR TITLE
(PLATFORM-3394) Add warning when a script contains plain HTTP

### DIFF
--- a/extensions/wikia/ContentReview/ContentReview.hooks.php
+++ b/extensions/wikia/ContentReview/ContentReview.hooks.php
@@ -69,13 +69,13 @@ class Hooks {
 
 	/**
 	 * Initiates a diff page Content Review controller and renders a reviewer's toolbar.
-	 * @param $diffEngine
+	 * @param \DifferenceEngine $diffEngine
 	 * @param \OutputPage $output
 	 * @return bool
 	 */
-	public function onArticleContentOnDiff( $diffEngine, \OutputPage $output ) {
+	public function onArticleContentOnDiff( \DifferenceEngine $diffEngine, \OutputPage $output ) {
 		$title = $output->getTitle();
-		$diffPage = new ContentReviewDiffPage( $title );
+		$diffPage = new ContentReviewDiffPage( $title, $diffEngine );
 
 		if ( $diffPage->shouldDisplayToolbar() ) {
 			$diffPage->addToolbarToOutput( $output );

--- a/extensions/wikia/ContentReview/ContentReviewInternal.i18n.php
+++ b/extensions/wikia/ContentReview/ContentReviewInternal.i18n.php
@@ -43,8 +43,9 @@ $messages['en'] = [
 	'content-review-diff-toolbar-title' => 'Revision review',
 	'content-review-diff-toolbar-talkpage' => 'Talk page',
 	'content-review-diff-toolbar-guidelines' => 'Reviewer guidelines',
-	'content-review-diff-toolbar-guidelines-url' => 'http://dev.wikia.com/wiki/Help:JavaScript_review_guidelines',
+	'content-review-diff-toolbar-guidelines-url' => '//dev.wikia.com/wiki/Help:JavaScript_review_guidelines',
 	'content-review-diff-hidden' => 'Since no revision of this page has been approved yet, the diff is hidden. Please review the changes based on the latest revision state below.',
+	'content-review-diff-notice-http' => 'The script contains a reference to plain "http://". Please verify this is HTTPS compliant.',
 
 	'content-review-feedback-link-text' => 'Provide feedback',
 	'content-review-edit-page-checkbox-label' => 'Automatically approve the changes',
@@ -91,6 +92,7 @@ $messages['qqq'] = [
 	'content-review-diff-toolbar-guidelines' => 'A text of a link to a page with guidelines for reviewers.',
 	'content-review-diff-toolbar-guidelines-url' => 'A URL of a page with guidelines for reviewers.',
 	'content-review-diff-hidden' => 'A message shown to a reviewer if he is reviewing a page that does not have an initial revision. In this case the regular diff view is hidden and replaced by this message to focus them on an actual content that they review.',
+	'content-review-diff-notice-http' => 'Message shown below the toolbar when a script contains a reference to a plain HTTP URL.',
 
 	'content-review-feedback-link-text' => 'Text on a link for providing feedback on script change being reviewed',
 

--- a/extensions/wikia/ContentReview/controllers/ContentReviewDiffPage.class.php
+++ b/extensions/wikia/ContentReview/controllers/ContentReviewDiffPage.class.php
@@ -14,15 +14,17 @@ class ContentReviewDiffPage extends \ContextSource {
 		$revisionId,
 		$status,
 		$title,
-		$wikiId;
+		$wikiId,
+		$diffEngine;
 
-	public function __construct( \Title $title ) {
+	public function __construct( \Title $title, \DifferenceEngine $diffEngine ) {
 		global $wgCityId;
 
 		$this->wikiId = $wgCityId;
 		$this->title = $title;
 		$this->pageId = $title->getArticleID();
 		$this->revisionId = $this->getCurrentlyReviewedRevisionId();
+		$this->diffEngine = $diffEngine;
 	}
 
 	/**
@@ -111,6 +113,7 @@ class ContentReviewDiffPage extends \ContextSource {
 			'talkpageLinkText' => $this->msg( 'content-review-diff-toolbar-talkpage' )->plain(),
 			'guidelinesUrl' => $this->msg( 'content-review-diff-toolbar-guidelines-url' )->useDatabase( false )->plain(),
 			'guidelinesLinkText' => $this->msg( 'content-review-diff-toolbar-guidelines' )->plain(),
+			'notices' => $this->getNotices(),
 		];
 
 		if ( $this->escalated ) {
@@ -139,5 +142,18 @@ class ContentReviewDiffPage extends \ContextSource {
 			$this->reviewModel = new ReviewModel();
 		}
 		return $this->reviewModel;
+	}
+
+	private function getNotices() {
+		$notices = [];
+		// Warn on references to plain HTTP
+		if ( strpos( $this->diffEngine->mNewRev->getText( \Revision::FOR_THIS_USER ), 'http://' ) !== false ) {
+			$notices[] = [
+				'text' => $this->msg( 'content-review-diff-notice-http' )->plain(),
+				'icon' => \DesignSystemHelper::renderSvg( 'wds-icons-alert', 'wds-icon' ),
+			];
+		}
+
+		return $notices;
 	}
 }

--- a/extensions/wikia/ContentReview/controllers/ContentReviewDiffPage.class.php
+++ b/extensions/wikia/ContentReview/controllers/ContentReviewDiffPage.class.php
@@ -147,7 +147,7 @@ class ContentReviewDiffPage extends \ContextSource {
 	private function getNotices() {
 		$notices = [];
 		// Warn on references to plain HTTP
-		if ( strpos( $this->diffEngine->mNewRev->getText( \Revision::FOR_THIS_USER ), 'http://' ) !== false ) {
+		if ( stripos( $this->diffEngine->mNewRev->getText( \Revision::FOR_THIS_USER ), 'http://' ) !== false ) {
 			$notices[] = [
 				'text' => $this->msg( 'content-review-diff-notice-http' )->plain(),
 				'icon' => \DesignSystemHelper::renderSvg( 'wds-icons-alert', 'wds-icon' ),

--- a/extensions/wikia/ContentReview/styles/ContentReviewDiffPage.scss
+++ b/extensions/wikia/ContentReview/styles/ContentReviewDiffPage.scss
@@ -1,11 +1,14 @@
+$content-review-color-alert: #d71035;
+$content-review-color-white: #fff;
+
 .content-review-toolbar {
 	border-bottom: 1px solid;
 	margin-bottom: 10px;
 	padding: 15px 10px;
-}
 
-.content-review-toolbar .content-review-toolbar-title {
-	margin-top: 0px;
+	.content-review-toolbar-title {
+		margin-top: 0;
+	}
 }
 
 .content-review-diff-button {
@@ -26,4 +29,23 @@
 
 .content-review-toolbar-links {
 	float: right;
+}
+
+.content-review-toolbar-notice {
+	border: 1px solid $content-review-color-alert;
+	display: flex;
+	height: 48px;
+
+	&__icon {
+		align-items: center;
+		background-color: $content-review-color-alert;
+		color: $content-review-color-white;
+		display: flex;
+		justify-content: center;
+		width: 48px;
+	}
+
+	&__text {
+		padding: 12px;
+	}
 }

--- a/extensions/wikia/ContentReview/templates/ContentReviewToolbar.mustache
+++ b/extensions/wikia/ContentReview/templates/ContentReviewToolbar.mustache
@@ -15,4 +15,12 @@
 		<a href="{{talkpageUrl}}" target="_blank" class="button secondary content-review-toolbar-link">{{talkpageLinkText}}</a>
 		<a href="{{guidelinesUrl}}" target="_blank" class="content-review-toolbar-link">{{guidelinesLinkText}}</a>
 	</div>
+	{{#notices}}
+		<div class="content-review-toolbar-notice">
+			<div class="content-review-toolbar-notice__icon">
+				{{{icon}}}
+			</div>
+			<span class="content-review-toolbar-notice__text">{{text}}</span>
+		</div>
+	{{/notices}}
 </div>


### PR DESCRIPTION
Add warning to the review page when a script contains a reference to
plain HTTP.

/cc @Wikia/core-platform-team 