### PR TITLE
SUS-4325 | CloseWikiMaintenance should remove directories with images after tar file is created

### DIFF
--- a/extensions/wikia/WikiFactory/Close/maintenance.php
+++ b/extensions/wikia/WikiFactory/Close/maintenance.php
@@ -378,6 +378,11 @@ class CloseWikiMaintenance {
 			$this->log( "List of files in {$directory} is empty" );
 			throw new WikiaException( "List of files in {$directory} is empty" );
 		}
+
+		// SUS-4325 | CloseWikiMaintenance should remove directories with images after tar file is created
+		$this->log( "Removing '{$directory}' directory" );
+		wfRecursiveRemoveDir( $directory );
+
 		return $result;
 	}
 


### PR DESCRIPTION
Otherwise we end up with 200+ directories in `/tmp/images` on `cron-s1` and disk space alerts when a large wiki is closed and images are dumped to s3.

Or we even may end up with such directory in /tmp/images:

```
11G    ./teentitansgo
```

tar file with compressed content of this directory weights ~10 GiB. This pair consumes 50% of cron-s1 disk space...