### PR TITLE
SUS-1900 revert header(500) when exception occur

### DIFF
--- a/includes/resourceloader/ResourceLoader.php
+++ b/includes/resourceloader/ResourceLoader.php
@@ -725,11 +725,6 @@ class ResourceLoader {
 			'exception' => $e
 		] );
 
-		// SUS-1900: emit a proper HTTP error code indicating that something went wrong
-		HttpStatus::header( 500 );
-		header( "X-MediaWiki-Exception: 1" );
-		header( "Content-Type: text/plain; charset=utf-8" );
-
 		if ( $wgShowExceptionDetails ) {
 			return $this->makeComment( $e->__toString() );
 		} else {


### PR DESCRIPTION
@macbre 
Proposition:
https://github.com/Wikia/app/blob/2d8e061164bd5b2db0719efe049bace0086914ff/includes/resourceloader/ResourceLoader.php#L522 should be enough to not cache exceptions