### PR TITLE
SUS-4333 | do not use SELECT * FROM in WikiFactoryHub:getWikiCategories

### DIFF
--- a/extensions/wikia/Track/Track.php
+++ b/extensions/wikia/Track/Track.php
@@ -83,7 +83,7 @@ class Track {
 			'cd14' => isset( $adContext[ 'opts' ][ 'showAds' ] ) ? 'Yes' : 'No',
 			'cd15' => WikiaPageType::isCorporatePage(),
 			'cd17' => implode( ',', $hubFactory->getWikiVertical( $wgCityId ) ),
-			'cd18' => implode( ',', $hubFactory->getWikiCategories( $wgCityId ) ),
+			'cd18' => implode( ',', $hubFactory->getWikiCategoryNames( $wgCityId ) ),
 			'cd19' => WikiaPageType::getArticleType(),
 			'cd21' => $wgTitle->getArticleID(),
 			'cd25' => $wgTitle->getNamespace(),

--- a/extensions/wikia/WikiFactory/Hubs/WikiFactoryHub.php
+++ b/extensions/wikia/WikiFactory/Hubs/WikiFactoryHub.php
@@ -224,7 +224,7 @@ class WikiFactoryHub extends WikiaModel {
 
 		// query instead of lookup in AllCategories list
 		$categories = (new WikiaSQL())
-			->SELECT( "*" )
+			->SELECT( "cat_id", "cat_name", "cat_url", "cat_short", "cat_deprecated", "cat_active", "id", "city_id" )
 			->FROM( "city_cats" )
 			->JOIN ( "city_cat_mapping" )->USING( "cat_id" )
 			->WHERE( "city_id ")->EQUAL_TO( $city_id )

--- a/extensions/wikia/WikiFactory/Hubs/WikiFactoryHub.php
+++ b/extensions/wikia/WikiFactory/Hubs/WikiFactoryHub.php
@@ -224,7 +224,7 @@ class WikiFactoryHub extends WikiaModel {
 
 		// query instead of lookup in AllCategories list
 		$categories = (new WikiaSQL())
-			->SELECT( "cat_id", "cat_name", "cat_url", "cat_short", "cat_deprecated", "cat_active", "id", "city_id" )
+			->SELECT( "cat_id", "cat_short" )
 			->FROM( "city_cats" )
 			->JOIN ( "city_cat_mapping" )->USING( "cat_id" )
 			->WHERE( "city_id ")->EQUAL_TO( $city_id )
@@ -243,7 +243,7 @@ class WikiFactoryHub extends WikiaModel {
 	 *
 	 * @param Int $cityId CityId
 	 * @param Int $active Active status of categories to return
-	 * @return array Array of wiki category names
+	 * @return string[] Array of wiki category names
 	 */
 	public function getWikiCategoryNames( $cityId, $active = 1 ) {
 		$wikiCategoryNames = [];


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-4333

### Currently returned fields

```
> var_dump( (WikiFactoryHub::getInstance())->getWikiCategories(5915) )
LoadBalancer::openForeignConnection: reusing connection 1/wikicities
/usr/wikia/slot1/22490/src/maintenance/eval.php(88) : eval()'d code:1:
array(1) {
  [0] =>
  array(8) {
    'cat_id' =>
    string(1) "7"
    'cat_name' =>
    string(6) "Travel"
    'cat_url' =>
    string(32) "http://www.wikia.com/wiki/Travel"
    'cat_short' =>
    string(6) "travel"
    'cat_deprecated' =>
    string(1) "1"
    'cat_active' =>
    string(1) "1"
    'id' =>
    string(6) "771979"
    'city_id' =>
    string(4) "5915"
  }
}
```

### New query

```sql
mysql@geo-db-sharedb-slave.query.consul[wikicities]>SELECT /* WikiFactoryHub:getWikiCategories CommandLineInc - 217a3e6d-d9d0-4f45-9842-58af70707ba6 */ cat_id, cat_short   FROM city_cats    INNER JOIN city_cat_mapping    USING (cat_id)   WHERE city_id  = '5915'   AND cat_active = '1';
+--------+-----------+
| cat_id | cat_short |
+--------+-----------+
|      7 | travel    |
+--------+-----------+
1 row in set (0.00 sec)
```

* `cat_short` - used by `WikiFactoryHub::getWikiCategoryNames`
* `cat_id` - used by `SpecialWikiFactory::doWikiForm`