### PR TITLE
SUS-4181 | WikiFactoryPage - prevent a fatal

### DIFF
--- a/extensions/wikia/WikiFactory/SpecialWikiFactory_body.php
+++ b/extensions/wikia/WikiFactory/SpecialWikiFactory_body.php
@@ -86,7 +86,7 @@ class WikiFactoryPage extends SpecialPage {
 		}
 		else {
 			$subpage = ( $subpage == "/" ) ? null : $subpage;
-			$oWiki = $this->getWikiData( $subpage );
+			$oWiki = $subpage ? $this->getWikiData( $subpage ) : false;
 
 			if( !isset( $oWiki->city_id )) {
 				$this->doWikiSelector();


### PR DESCRIPTION
See #15004

`TypeError: Argument 1 passed to WikiFactory::getWikiByID() must be of the type integer, null given, called in /extensions/wikia/WikiFactory/SpecialWikiFactory_body.php on line 196 and defined in /extensions/wikia/WikiFactory/WikiFactory.php:1312`