### PR TITLE
SUS-4181 | CreateNewWiki - do not set wgDBname and wgDBcluster WikiFactory variables

### DIFF
--- a/extensions/wikia/CreateNewWiki/tasks/ConfigureCategories.php
+++ b/extensions/wikia/CreateNewWiki/tasks/ConfigureCategories.php
@@ -51,8 +51,7 @@ class ConfigureCategories extends Task {
 		return $categories;
 	}
 
-	public function setVertical( int $vertical, int $cityId, WikiFactoryHub $wikiFactoryHubInstance
-	) {
+	public function setVertical( int $vertical, int $cityId, WikiFactoryHub $wikiFactoryHubInstance ) {
 		$wikiFactoryHubInstance->setVertical( $cityId, $vertical, "CW Setup" );
 		$this->debug( implode( ":", [ __METHOD__, "Wiki added to the vertical: {$vertical}" ] ) );
 	}

--- a/extensions/wikia/CreateNewWiki/tasks/ConfigureCategories.php
+++ b/extensions/wikia/CreateNewWiki/tasks/ConfigureCategories.php
@@ -51,7 +51,8 @@ class ConfigureCategories extends Task {
 		return $categories;
 	}
 
-	public function setVertical( $vertical, $cityId, WikiFactoryHub $wikiFactoryHubInstance ) {
+	public function setVertical( int $vertical, int $cityId, WikiFactoryHub $wikiFactoryHubInstance
+	) {
 		$wikiFactoryHubInstance->setVertical( $cityId, $vertical, "CW Setup" );
 		$this->debug( implode( ":", [ __METHOD__, "Wiki added to the vertical: {$vertical}" ] ) );
 	}

--- a/extensions/wikia/CreateNewWiki/tasks/ConfigureWikiFactory.php
+++ b/extensions/wikia/CreateNewWiki/tasks/ConfigureWikiFactory.php
@@ -65,7 +65,6 @@ class ConfigureWikiFactory extends Task {
 			'wgLogo' => self::DEFAULT_WIKI_LOGO,
 			'wgUploadPath' => $imagesURL,
 			'wgUploadDirectory' => $imagesDir,
-			'wgDBname' => $dbName,
 			'wgLocalInterwiki' => $siteName,
 			'wgLanguageCode' => $language,
 			'wgServer' => rtrim( $url, "/" ),
@@ -80,8 +79,7 @@ class ConfigureWikiFactory extends Task {
 			$wikiFactoryVariables['wgMetaNamespace'] = str_replace( [ ':', ' ' ], [ '', '_' ], $siteName );
 		}
 
-		wfGetLBFactory()->sectionsByDB[$dbName] = $wikiFactoryVariables['wgDBcluster'] = \F::app()->wg->CreateDatabaseActiveCluster;
-
+		wfGetLBFactory()->sectionsByDB[$dbName] = \F::app()->wg->CreateDatabaseActiveCluster;
 
 		return $wikiFactoryVariables;
 	}

--- a/extensions/wikia/CreateNewWiki/tests/tasks/ConfigureWikiFactoryTest.php
+++ b/extensions/wikia/CreateNewWiki/tests/tasks/ConfigureWikiFactoryTest.php
@@ -114,14 +114,12 @@ class ConfigureWikiFactoryTest extends \WikiaBaseTest {
 					'wgLogo' => '$wgUploadPath/b/bc/Wiki.png',
 					'wgUploadPath' => 'https://images.wikia.com/foo/images',
 					'wgUploadDirectory' => '/images/f/foo/images',
-					'wgDBname' => 'foo',
 					'wgLocalInterwiki' => 'foo',
 					'wgLanguageCode' => 'en',
 					'wgServer' => 'https://foo.wikia.com',
 					'wgEnableSectionEdit' => true,
 					'wgOasisLoadCommonCSS' => true,
 					'wgEnablePortableInfoboxEuropaTheme' => true,
-					'wgDBcluster' => 'c7'
 				]
 			],
 			[ 'foo:', 'https://images.wikia.com/foo/images', '/images/f/foo/images', 'foo', 'en', 'https://foo.wikia.com/',
@@ -130,7 +128,6 @@ class ConfigureWikiFactoryTest extends \WikiaBaseTest {
 					'wgLogo' => '$wgUploadPath/b/bc/Wiki.png',
 					'wgUploadPath' => 'https://images.wikia.com/foo/images',
 					'wgUploadDirectory' => '/images/f/foo/images',
-					'wgDBname' => 'foo',
 					'wgLocalInterwiki' => 'foo:',
 					'wgLanguageCode' => 'en',
 					'wgServer' => 'https://foo.wikia.com',
@@ -138,7 +135,6 @@ class ConfigureWikiFactoryTest extends \WikiaBaseTest {
 					'wgOasisLoadCommonCSS' => true,
 					'wgEnablePortableInfoboxEuropaTheme' => true,
 					'wgMetaNamespace' => 'foo',
-					'wgDBcluster' => 'c7'
 				]
 			],
 			[ 'foo_bar:fizz', 'https://images.wikia.com/foo/images', '/images/f/foo/images', 'foo', 'en', 'https://foo.wikia.com/',
@@ -147,7 +143,6 @@ class ConfigureWikiFactoryTest extends \WikiaBaseTest {
 					'wgLogo' => '$wgUploadPath/b/bc/Wiki.png',
 					'wgUploadPath' => 'https://images.wikia.com/foo/images',
 					'wgUploadDirectory' => '/images/f/foo/images',
-					'wgDBname' => 'foo',
 					'wgLocalInterwiki' => 'foo_bar:fizz',
 					'wgLanguageCode' => 'en',
 					'wgServer' => 'https://foo.wikia.com',
@@ -155,7 +150,6 @@ class ConfigureWikiFactoryTest extends \WikiaBaseTest {
 					'wgOasisLoadCommonCSS' => true,
 					'wgEnablePortableInfoboxEuropaTheme' => true,
 					'wgMetaNamespace' => 'foo_barfizz',
-					'wgDBcluster' => 'c7'
 				]
 			]
 		];

--- a/extensions/wikia/WikiFactory/Hubs/WikiFactoryHub.php
+++ b/extensions/wikia/WikiFactory/Hubs/WikiFactoryHub.php
@@ -347,7 +347,7 @@ class WikiFactoryHub extends WikiaModel {
 	 * @param string    $reason      optional extra reason string for logging
 	 */
 
-	public function setVertical ( $city_id, $vertical_id, $reason) {
+	public function setVertical ( int $city_id, int $vertical_id, string $reason) {
 
 		( new WikiaSQL() )
 			->UPDATE( 'city_list' )

--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -798,29 +798,6 @@ class WikiFactory {
 						__METHOD__ );
 					break;
 
-				case "wgDBname":
-					#--- city_dbname
-					$dbw->update(
-						static::table("city_list"),
-						[ "city_dbname" => $value ],
-						[ "city_id" => $city_id ],
-						__METHOD__ );
-					break;
-
-				case "wgDBcluster":
-					/**
-					 * city_cluster
-					 *
-					 * city_cluster = null for first cluster
-					 * @todo handle deleting values of this variable
-					 */
-					$dbw->update(
-						static::table("city_list"),
-						[ "city_cluster" => $value ],
-						[ "city_id" => $city_id ],
-						__METHOD__ );
-					break;
-
 				case 'wgMetaNamespace':
 				case 'wgMetaNamespaceTalk':
 					#--- these cannot contain spaces!

--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -1848,53 +1848,6 @@ class WikiFactory {
 	}
 
 	/**
-	 * getFileCachePath
-	 *
-	 * build path to file based on id of wikia
-	 *
-	 *
-	 * @author eloy@wikia
-	 * @access public
-	 * @static
-	 *
-	 * @param integer	$city_id	identifier from city_list
-	 *
-	 * @return string: path to file or null if id is not a number
-	 */
-	static public function getFileCachePath( $city_id ) {
-		if ( is_null( $city_id ) || empty( $city_id ) ) {
-			return null;
-		}
-		wfProfileIn( __METHOD__ );
-
-		$intid = $city_id;
-		$strid = (string)$intid;
-		$path = "";
-		if ( $intid < 10 ) {
-			$path = sprintf( "%s/%d.ser", static::CACHEDIR, $intid );
-		}
-		elseif ( $intid < 100 ) {
-			$path = sprintf(
-				"%s/%s/%d.ser",
-				static::CACHEDIR,
-				substr($strid, 0, 1),
-				$intid
-			);
-		}
-		else {
-			$path = sprintf(
-				"%s/%s/%s/%d.ser",
-				static::CACHEDIR,
-				substr($strid, 0, 1),
-				substr($strid, 0, 2),
-				$intid
-			);
-		}
-		wfProfileOut( __METHOD__ );
-		return $path;
-	}
-
-	/**
 	 * setPublicStatus
 	 *
 	 * method for changing city_public value in city_list table


### PR DESCRIPTION
Values from `city_list` table row are now used instead.

https://wikia-inc.atlassian.net/browse/SUS-4181

http://pl.sus4181.sandbox-s6.wikia.com/wiki/Specjalna:Wersja has been properly created with this code.

### Cleanup

Remove `WikiFactory::getFileCachePath` method