### PR TITLE
SUS-4463: Fix some block notices not rendering blocker name

### DIFF
--- a/extensions/wikia/ArticleComments/classes/ArticleCommentList.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleCommentList.class.php
@@ -462,7 +462,7 @@ class ArticleCommentList {
 		$block = $wgUser->mBlock;
 
 		list( $blockerName, $reason, $ip, $blockid, $blockTimestamp, $blockExpiry, $intended, $isGlobal ) = [
-			User::whoIs( $wgUser->blockedBy() ),
+			$wgUser->blockedBy(),
 			$wgUser->blockedFor() ? $wgUser->blockedFor() : wfMessage( 'blockednoreason' )->text(),
 			$wgRequest->getIP(),
 			$wgUser->getBlockId(),

--- a/includes/Title.php
+++ b/includes/Title.php
@@ -2118,18 +2118,12 @@ class Title {
 			// This is from OutputPage::blockedPage
 			// Copied at r23888 by werdna
 
-			$id = $user->blockedBy();
+			$name = $user->blockedBy();
 			$reason = $user->blockedFor();
 			if ( $reason == '' ) {
 				$reason = wfMsg( 'blockednoreason' );
 			}
 			$ip = $user->getRequest()->getIP();
-
-			if ( is_numeric( $id ) ) {
-				$name = User::whoIs( $id );
-			} else {
-				$name = $id;
-			}
 
 			$link = '[[' . $wgContLang->getNsText( NS_USER ) . ":{$name}|{$name}]]";
 			$blockid = $block->getId();

--- a/includes/User.php
+++ b/includes/User.php
@@ -240,11 +240,7 @@ class User implements JsonSerializable {
 	}
 
 	private static function permissionsService(): PermissionsService {
-		if ( is_null( self::$permissionsService ) ) {
-			self::$permissionsService = ServiceFactory::instance()->permissionsFactory()->permissionsService();
-		}
-
-		return self::$permissionsService;
+		return ServiceFactory::instance()->permissionsFactory()->permissionsService();
 	}
 
 	/**

--- a/includes/wikia/tests/WikiaControllerTest.php
+++ b/includes/wikia/tests/WikiaControllerTest.php
@@ -8,24 +8,6 @@ use PHPUnit\Framework\TestCase;
  */
 class WikiaControllerTest extends TestCase {
 
-	public function generatingHelpDataProvider() {
-		return array(
-			array( 'json', '{' ),
-			array( 'html', '<' )
-		);
-	}
-
-	/**
-	 * @dataProvider generatingHelpDataProvider
-	 */
-	public function testGeneratingHelp( $format, $prefix ) {
-		$response = F::app()->sendRequest( 'Test', 'help', array( 'format' => $format ), false );
-		//$response->setTemplatePath('non');
-		$this->assertInstanceOf( 'WikiaResponse', $response );
-		$this->assertNull( $response->getException() );
-		$this->assertStringStartsWith( $prefix, $response->toString() );
-	}
-
 	public function redirectingDataProvider() {
 		return array(
 			array( true ),

--- a/includes/wikia/tests/core/WikiaDatabaseTest.php
+++ b/includes/wikia/tests/core/WikiaDatabaseTest.php
@@ -47,6 +47,7 @@ abstract class WikiaDatabaseTest extends TestCase {
 
 		// destroy leaked user accounts from other tests
 		User::$idCacheByName = [];
+		\Wikia\Factory\ServiceFactory::clearState();
 	}
 
 	protected function setUp() {

--- a/tests/unit/includes/BlockIntegrationTest.php
+++ b/tests/unit/includes/BlockIntegrationTest.php
@@ -1,6 +1,9 @@
 <?php
 
-class BlockTest extends WikiaDatabaseTest {
+/**
+ * @group Integration
+ */
+class BlockIntegrationTest extends WikiaDatabaseTest {
 	const BLOCKED_USER_ONE_ID = 1;
 	const BLOCKED_USER_ONE_NAME = 'BlockedUser';
 
@@ -32,9 +35,11 @@ class BlockTest extends WikiaDatabaseTest {
 
 		$this->assertEquals( static::BLOCKING_ADMIN_ID, $block->getBlocker()->getId() );
 		$this->assertEquals( static::BLOCKING_ADMIN_NAME, $block->getBlocker()->getName() );
+		$this->assertEquals( static::BLOCKING_ADMIN_NAME, $user->blockedBy() );
 
 		$this->assertEquals( static::BLOCKED_USER_ONE_BLOCK_ID, $block->getId() );
 		$this->assertEquals( static::BLOCKED_USER_ONE_BLOCK_REASON, $block->mReason );
+		$this->assertEquals( static::BLOCKED_USER_ONE_BLOCK_REASON, $user->blockedFor() );
 		$this->assertEquals( static::BLOCKED_USER_ONE_BLOCK_TS, $block->mTimestamp );
 		$this->assertEquals( static::BLOCKED_USER_ONE_BLOCK_EXPIRY, $block->getExpiry() );
 


### PR DESCRIPTION
`User::blockedBy` returns user name, not user ID.

https://wikia-inc.atlassian.net/browse/SUS-4463