### PR TITLE
SUS-1941 | Use ternary shorthand instead of null coalescing operator

### DIFF
--- a/lib/Wikia/src/Factory/PermissionsFactory.php
+++ b/lib/Wikia/src/Factory/PermissionsFactory.php
@@ -18,13 +18,13 @@ class PermissionsFactory extends AbstractFactory {
 	public function permissionsConfiguration(): PermissionsConfiguration {
 		if ( $this->permissionsConfiguration === null ) {
 			$this->permissionsConfiguration = new PermissionsConfiguration(
-					$GLOBALS['wgGroupPermissions'] ?? [],
-					$GLOBALS['wgAddGroupsLocal'] ?? [],
-					$GLOBALS['wgRemoveGroupsLocal'] ?? [],
-					$GLOBALS['wgGroupsAddToSelfLocal'] ?? [],
-					$GLOBALS['wgGroupsRemoveFromSelfLocal'] ?? [],
-					$GLOBALS['wgRestrictedAccessGroups'] ?? [],
-					$GLOBALS['wgRestrictedAccessExemptGroups'] ?? []
+					$GLOBALS['wgGroupPermissions'] ?: [],
+					$GLOBALS['wgAddGroupsLocal'] ?: [],
+					$GLOBALS['wgRemoveGroupsLocal'] ?: [],
+					$GLOBALS['wgGroupsAddToSelfLocal'] ?: [],
+					$GLOBALS['wgGroupsRemoveFromSelfLocal'] ?: [],
+					$GLOBALS['wgRestrictedAccessGroups'] ?: [],
+					$GLOBALS['wgRestrictedAccessExemptGroups'] ?: []
 				);
 		}
 


### PR DESCRIPTION
For some wikis on devobxes we get `false` instead of `null`, example: `ru.warframe`