### PR TITLE
SUS-4497 | compressOld.php - set the flag saying that the old_text is a pseudo-URL to blobs entry

### DIFF
--- a/maintenance/storage/compressOld.php
+++ b/maintenance/storage/compressOld.php
@@ -134,10 +134,14 @@ class CompressOld extends Maintenance {
 		$isGzipped = strpos( $flags, 'gzip' ) !== false;
 		$isExternal = strpos( $flags, 'external' ) !== false;
 
-		if ( !$isExternal && $extdb !== '' ) {
+		if ( $isExternal ) {
+			# already moved to external
+			return false;
+		}
+		elseif ( !$isExternal && $extdb !== '' ) {
 			# this row is not yet kept on blobs and we want to move it there
 		}
-		else if ( $isGzipped || false !== strpos( $flags, 'object' ) ) {
+		elseif ( $isGzipped || false !== strpos( $flags, 'object' ) ) {
 			#print "Already compressed row {$row->old_id}\n";
 			return false;
 		}

--- a/maintenance/storage/compressOld.php
+++ b/maintenance/storage/compressOld.php
@@ -148,7 +148,9 @@ class CompressOld extends Maintenance {
 			}
 
 			// SUS-4497 | set the flag saying that the old_text is a pseudo-URL to blobs entry
-			$flags .= ',external';
+			if ( strpos( $flags, 'external' ) === false ) {
+				$flags .= ',external';
+			}
 		}
 
 		# Update text row

--- a/maintenance/storage/compressOld.php
+++ b/maintenance/storage/compressOld.php
@@ -103,7 +103,7 @@ class CompressOld extends Maintenance {
 
 	/** @todo document */
 	private function compressOldPages( $start = 0, $extdb = '' ) {
-		$chunksize = 50;
+		$chunksize = 500;
 		$this->output( "Starting from old_id $start...\n" );
 		$dbw = wfGetDB( DB_MASTER );
 		do {


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-4497

```sql
mysql@geo-db-dev-db-master.query.consul[zothos]>select * from text where old_id = 15;
+--------+---------------------------+---------------------+
| old_id | old_text                  | old_flags           |
+--------+---------------------------+---------------------+
|     15 | DB://blobs20141/396870054 | utf-8,gzip,external |
+--------+---------------------------+---------------------+
1 row in set (0.11 sec)
```

```
> var_dump( Revision::getRevisionText(  wfGetDB(DB_SLAVE)->selectRow('text', '*', ['old_id' => 15]) ) )
/usr/wikia/source/deploytools/18879/src/maintenance/eval.php(88) : eval()'d code:1:
string(42) "Das Passwort von $1 wurde an $2 geschickt."
```

### Before

```sql
SELECT TABLE_SCHEMA, TABLE_ROWS, DATA_LENGTH/1024/1024 as data_mb, INDEX_LENGTH/1024/1024 as index_mb FROM information_schema.TABLES WHERE TABLE_SCHEMA='zothos' AND TABLE_NAME='text';
+--------------+------------+------------+------------+
| TABLE_SCHEMA | TABLE_ROWS | data_mb    | index_mb   |
+--------------+------------+------------+------------+
| zothos       |       3010 | 8.51562500 | 0.00000000 |
+--------------+------------+------------+------------+
1 row in set (0.10 sec)

select old_flags, count(*) from text group by old_flags;
+---------------------+----------+
| old_flags           | count(*) |
+---------------------+----------+
| utf-8               |     1326 |
| utf-8,external      |     1177 |
| utf-8,gzip          |       12 |
| utf-8,gzip,external |      511 |
+---------------------+----------+
4 rows in set (0.13 sec)
```

### After

```sql
SELECT TABLE_SCHEMA, TABLE_ROWS, DATA_LENGTH/1024/1024 as data_mb, INDEX_LENGTH/1024/1024 as index_mb FROM information_schema.TABLES WHERE TABLE_SCHEMA='zothos' AND TABLE_NAME='text';
+--------------+------------+------------+------------+
| TABLE_SCHEMA | TABLE_ROWS | data_mb    | index_mb   |
+--------------+------------+------------+------------+
| zothos       |       3026 | 0.21875000 | 0.00000000 |
+--------------+------------+------------+------------+
1 row in set (0.10 sec)

select old_flags, count(*) from text group by old_flags;
+---------------------+----------+
| old_flags           | count(*) |
+---------------------+----------+
| utf-8,external,gzip |     1177 |
| utf-8,gzip,external |     1849 |
+---------------------+----------+
2 rows in set (0.14 sec)
```