### PR TITLE
SUS-4504 | WikiaUpdater - no need to remove videos marked as premium

### DIFF
--- a/includes/wikia/WikiaUpdater.php
+++ b/includes/wikia/WikiaUpdater.php
@@ -78,7 +78,6 @@ class WikiaUpdater {
 			array( 'dropField', 'cu_changes', 'cuc_user_text', $ext_dir . '/CheckUser/patch-cu_changes.sql', true ), // SUS-3080
 			array( 'WikiaUpdater::do_drop_table', 'tag_summary' ), // SUS-3066
 			array( 'WikiaUpdater::do_drop_table', 'sitemap_blobs' ), // SUS-3589
-			array( 'WikiaUpdater::do_clean_video_info_table' ), // SUS-3862
 			array( 'WikiaUpdater::removeUnusedGroups' ), // SUS-4169
 			array( 'WikiaUpdater::do_drop_table', 'objectcache' ), // SUS-4171
 			array( 'WikiaUpdater::doPageVoteCleanup' ), // SUS-3390 / SUS-4252
@@ -223,16 +222,6 @@ class WikiaUpdater {
 
 		$databaseUpdater->output( "done.\n" );
 
-		wfWaitForSlaves();
-	}
-
-	public static function do_clean_video_info_table( DatabaseUpdater $databaseUpdater ) {
-		$dbw = $databaseUpdater->getDB();
-		$databaseUpdater->output( 'Removing video_info rows for premium video providers... ' );
-
-		$dbw->delete( 'video_info', [ 'premium' => 1 ], __METHOD__ );
-
-		$databaseUpdater->output( "done.\n" );
 		wfWaitForSlaves();
 	}
 


### PR DESCRIPTION
`video_info.premium` column was removed by https://wikia-inc.atlassian.net/browse/SUS-4080

Prevent `Error: 1054 Unknown column 'premium' in 'where clause'`