### PR TITLE
XF-100 add error handling to dumpForumData.php

### DIFF
--- a/extensions/wikia/Discussions/maintenance/dumpForumData.php
+++ b/extensions/wikia/Discussions/maintenance/dumpForumData.php
@@ -25,11 +25,12 @@ class DumpForumData extends Maintenance {
 	}
 
 	public function execute() {
-		if ( $this->hasOption( 'out' ) ) {
-			$this->fh = fopen( $this->getArg(), 'w' );
-		} else {
-			$this->fh = STDOUT;
+		$outputName = $this->hasOption( 'out' ) ? $this->getArg() : "php://stdout";
+		$this->fh = fopen( $outputName, 'w' );
+		if ( $this->fh === false ) {
+			$this->error( "Unable to open file " . $outputName, 1 );
 		}
+
 		$this->dumper = new Discussions\ForumDumper();
 
 		$this->setConnectinoEncoding();


### PR DESCRIPTION
Ticket: https://wikia-inc.atlassian.net/browse/XF-100

We've received a number of error reporter tickets with the following error:
```
PHP Warning: fwrite() expects parameter 1 to be resource, boolean given in /usr/wikia/slot1/21916/src/extensions/wikia/Discussions/maintenance/dumpForumData.php on line 79
```
The problem is that inside our `dumpForumData.php` script we're opening a file without ensuring we did so successfully. The php function we're using, `fopen` returns `false` on error and we're then passing `false` to our `fwrite` calls, rather than a file handler. This PR updates that script to add a check the file was opened successfully, failing if not.