### PR TITLE
SUS-4506 | File page with video not handling t URL param

### DIFF
--- a/extensions/wikia/FilePage/WikiaFilePage.php
+++ b/extensions/wikia/FilePage/WikiaFilePage.php
@@ -55,6 +55,7 @@ class WikiaFilePage extends ImagePage {
 
 		JSMessages::enqueuePackage('VideoPage', JSMessages::EXTERNAL);
 
+		/* @var $file WikiaLocalFile|OldWikiaLocalFile */
 		$file = $this->getDisplayedFile();
 
 		//If a timestamp is specified, show the archived version of the video (if it exists)
@@ -94,10 +95,10 @@ class WikiaFilePage extends ImagePage {
 
 	/**
 	 * Display info about the video below the video player: provider, views, expiration date (if any)
-	 * @param WikiaLocalFileShared $file
+	 * @param WikiaLocalFile|OldWikiaLocalFile $file
 	 * @return string
 	 */
-	public function getVideoInfoLine( WikiaLocalFile $file ) {
+	private function getVideoInfoLine( $file ) {
 		wfProfileIn( __METHOD__ );
 
 		$app = F::app();

--- a/extensions/wikia/VideoHandlers/filerepo/WikiaLocalFile.class.php
+++ b/extensions/wikia/VideoHandlers/filerepo/WikiaLocalFile.class.php
@@ -5,6 +5,11 @@
  * Works as interface, logic should go to WikiaLocalFileShared
  */
 
+/**
+ * @method string getProviderName
+ * @method string getProviderHomeUrl
+ * @method string getProviderDetailUrl
+ */
 class WikiaLocalFile extends LocalFile {
 
 	protected $oLocalFileLogic = null; // Leaf object


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-4506

Don't be so strict with type hints - prevent `Unexpected non-MediaWiki exception encountered, of type "TypeError"
TypeError: Argument 1 passed to WikiaFilePage::getVideoInfoLine() must be an instance of WikiaLocalFile, instance of OldWikiaLocalFile given`.