### PR TITLE
SUS-4534 | fix DatabaseForumActivityServiceIntegrationTest

### DIFF
--- a/extensions/wikia/Forum/tests/DatabaseForumActivityServiceIntegrationTest.php
+++ b/extensions/wikia/Forum/tests/DatabaseForumActivityServiceIntegrationTest.php
@@ -9,6 +9,8 @@ class DatabaseForumActivityServiceIntegrationTest extends WikiaDatabaseTest {
 
 	protected function setUp() {
 		parent::setUp();
+		require_once __DIR__ . '/../Forum.setup.php';
+
 		$this->forumActivityService = new DatabaseForumActivityService();
 	}
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-4534

```
DatabaseForumActivityServiceIntegrationTest::testGetRecentlyUpdatedThreads
Error: Class 'DatabaseForumActivityService' not found
```