### PR TITLE
SUS-4297 | patch video_info table

### DIFF
--- a/includes/wikia/WikiaUpdater.php
+++ b/includes/wikia/WikiaUpdater.php
@@ -38,6 +38,7 @@ class WikiaUpdater {
 			array( 'modifyField', 'recentchanges', 'rc_ip', $dir . 'patch-rc_ip-varbinary.sql', true ),
 			array( 'addField', 'recentchanges', 'rc_ip_bin',$dir . 'patch-rc_ip_bin.sql', true ), // SUS-3079
 			array( 'addField', 'video_info', 'video_id', $dir . 'patch-video_info_id.sql', true ), // SUS-4297
+			array( 'addField', 'video_info', 'provider', $dir . 'patch-video_info_provider.sql', true	), // SUS-4297
 			// SUS-805
 			array( 'dropField', 'ipblocks', 'ipb_by_text', $dir . 'patch-drop-ipb_by_text.sql', true ),
 

--- a/includes/wikia/WikiaUpdater.php
+++ b/includes/wikia/WikiaUpdater.php
@@ -37,6 +37,7 @@ class WikiaUpdater {
 			array( 'addField', 'watchlist', 'wl_wikia_addedtimestamp', $dir . 'patch-watchlist-improvements.sql', true ),
 			array( 'modifyField', 'recentchanges', 'rc_ip', $dir . 'patch-rc_ip-varbinary.sql', true ),
 			array( 'addField', 'recentchanges', 'rc_ip_bin',$dir . 'patch-rc_ip_bin.sql', true ), // SUS-3079
+			array( 'addField', 'video_info', 'video_id', $dir . 'patch-video_info_id.sql', true ), // SUS-4297
 			// SUS-805
 			array( 'dropField', 'ipblocks', 'ipb_by_text', $dir . 'patch-drop-ipb_by_text.sql', true ),
 

--- a/maintenance/archives/wikia/patch-video_info_id.sql
+++ b/maintenance/archives/wikia/patch-video_info_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE /*$wgDBprefix*/video_info
+  ADD `video_id` varchar(255) NOT NULL DEFAULT '';

--- a/maintenance/archives/wikia/patch-video_info_id.sql
+++ b/maintenance/archives/wikia/patch-video_info_id.sql
@@ -1,2 +1,2 @@
 ALTER TABLE /*$wgDBprefix*/video_info
-  ADD `video_id` varchar(255) NOT NULL DEFAULT '';
+  ADD `video_id` varchar(255) NOT NULL DEFAULT '' AFTER video_title;

--- a/maintenance/archives/wikia/patch-video_info_provider.sql
+++ b/maintenance/archives/wikia/patch-video_info_provider.sql
@@ -1,0 +1,2 @@
+ALTER TABLE /*$wgDBprefix*/video_info
+  ADD `provider` varchar(255) DEFAULT NULL AFTER video_id;


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-4297

Make the schema of `video_info` tables consistent across wikis.

```
macbre@cron-s1:~/app/maintenance$ SERVER_DBNAME=yourewaifu php update.php --quick --ext-only
MediaWiki 1.19.24 Updater
...
Adding video_id field to table video_info...done.
Adding provider field to table video_info...done.
...
Adding index video_id to table video_info... done.
```

### New schema

```sql
CREATE TABLE `video_info` (
  `video_title` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
  `added_at` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
  `added_by` int(10) unsigned NOT NULL DEFAULT '0',
  `duration` int(10) unsigned NOT NULL DEFAULT '0',
  `removed` tinyint(1) NOT NULL DEFAULT '0',
  `views_30day` int(10) unsigned DEFAULT '0',
  `views_total` int(10) unsigned DEFAULT '0',
  `video_id` varchar(255) NOT NULL DEFAULT '',
  `provider` varchar(255) DEFAULT NULL,
  PRIMARY KEY (`video_title`),
  KEY `video_id` (`video_id`,`provider`)
) ENGINE=InnoDB
```