### PR TITLE
SUS-4297 | video_info: drop no longer used added_at index

### DIFF
--- a/extensions/wikia/VideoHandlers/sql/video_info.sql
+++ b/extensions/wikia/VideoHandlers/sql/video_info.sql
@@ -10,5 +10,5 @@ CREATE TABLE IF NOT EXISTS `video_info` (
   `views_30day` int(10) unsigned DEFAULT '0',
   `views_total` int(10) unsigned DEFAULT '0',
   PRIMARY KEY (`video_title`),
-  KEY `added_at` (`added_at`, `duration`)
+  KEY `video_id` (`video_id`,`provider`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/includes/wikia/WikiaUpdater.php
+++ b/includes/wikia/WikiaUpdater.php
@@ -51,6 +51,7 @@ class WikiaUpdater {
 			array( 'dropIndex', 'ach_custom_badges', 'id',  $dir . 'patch-ach_custom_badges-drop-id.sql', true ), // SUS-3098
 			array( 'dropIndex', 'wall_related_pages', 'comment_id_idx',  $dir . 'patch-wall_related_pages-drop-comment_id_idx.sql', true ), // SUS-3096
 			array( 'dropIndex', 'wall_related_pages', 'page_id_idx_2',  $dir . 'patch-wall_related_pages-drop-page_id_idx_2.sql', true ), // SUS-3096
+			array( 'dropIndex', 'video_info', 'added_at',  $dir . 'patch-video_info-drop-added_at_idx.sql', true ), // SUS-4297
 
 			# functions
 			array( 'WikiaUpdater::do_page_wikia_props_update' ),

--- a/maintenance/archives/wikia/patch-video_info-drop-added_at_idx.sql
+++ b/maintenance/archives/wikia/patch-video_info-drop-added_at_idx.sql
@@ -1,0 +1,1 @@
+ALTER TABLE /*$wgDBprefix*/video_info DROP KEY added_at;


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-4297

```
macbre@cron-s1:~/app/maintenance$ SERVER_DBNAME=gates php update.php --quick --ext-only
...
Dropping added_at index from table video_info... done.
...
```

And add `video_id` index for new wikis.