### PR TITLE
SUS-4547 | introduce LogEventsList::NO_EDIT_COUNT_CHECK flag that will make edit count to not be checked

### DIFF
--- a/includes/logging/LogEventsList.php
+++ b/includes/logging/LogEventsList.php
@@ -27,6 +27,10 @@ class LogEventsList {
 	const NO_ACTION_LINK = 1;
 	const NO_EXTRA_USER_LINKS = 2;
 
+	# SUS-4547: extra flag that will force (contribs) link to never be red and edit count to not
+	# be checked
+	const NO_EDIT_COUNT_CHECK = 4;
+
 	/**
 	 * @var Skin
 	 */
@@ -342,6 +346,7 @@ class LogEventsList {
 		$entry = DatabaseLogEntry::newFromRow( $row );
 		$formatter = LogFormatter::newFromEntry( $entry );
 		$formatter->setShowUserToolLinks( !( $this->flags & self::NO_EXTRA_USER_LINKS ) );
+		$formatter->setSkipEditsCount( $this->flags & self::NO_EDIT_COUNT_CHECK ); // SUS-4547
 
 		$action = $formatter->getActionText();
 		$comment = $formatter->getComment();

--- a/includes/logging/LogFormatter.php
+++ b/includes/logging/LogFormatter.php
@@ -484,7 +484,7 @@ class LogFormatter {
 			->title( $this->context->getTitle() );
 	}
 
-	protected function makeUserLink( User $user ) {
+	protected function makeUserLink( User $user, $toolFlags = 0 ) {
 		if ( $this->plaintext ) {
 			$element = $user->getName();
 		} else {
@@ -497,8 +497,8 @@ class LogFormatter {
 				$element .= Linker::userToolLinks(
 					$user->getId(),
 					$user->getName(),
-					true, // Red if no edits
-					0, // Flags
+					true, // redContribsWhenNoEdits
+					$toolFlags,
 					$user->getEditCount()
 				);
 			}

--- a/includes/logging/LogFormatter.php
+++ b/includes/logging/LogFormatter.php
@@ -68,6 +68,9 @@ class LogFormatter {
 	/// Whether to output user tool links
 	protected $linkFlood = false;
 
+	/// Whether to skip calculating edits count
+	protected $skipEditsCount = false;
+
 	/**
 	 * Set to true if we are constructing a message text that is going to
 	 * be included in page history or send to IRC feed. Links are replaced
@@ -126,6 +129,16 @@ class LogFormatter {
 	 */
 	public function setShowUserToolLinks( $value ) {
 		$this->linkFlood = $value;
+	}
+
+	/**
+	 * If set to true we will skip calculating user edits count and render contribs link always in
+	 * blue
+	 * @see SUS-4547
+	 * @param $value boolean
+	 */
+	public function setSkipEditsCount( $value ) {
+		$this->skipEditsCount = $value;
 	}
 
 	/**
@@ -494,12 +507,13 @@ class LogFormatter {
 			);
 
 			if ( $this->linkFlood ) {
+				# SUS-4547: do not calculate edit count when not needed (i.e. skipEditsCount is set)
 				$element .= Linker::userToolLinks(
 					$user->getId(),
 					$user->getName(),
-					true, // redContribsWhenNoEdits
+					$this->skipEditsCount ? false : true, // redContribsWhenNoEdits
 					$toolFlags,
-					$user->getEditCount()
+					$this->skipEditsCount ? null : $user->getEditCount()
 				);
 			}
 		}

--- a/includes/specials/SpecialLog.php
+++ b/includes/specials/SpecialLog.php
@@ -130,8 +130,15 @@ class SpecialLog extends SpecialPage {
 	}
 
 	private function show( FormOptions $opts, array $extraConds ) {
+		# SUS-4547: do not check edit count for each item (i.e. user) in the log
+		if ( in_array( $opts->getValue( 'type' ), $this->typeOnUser ) ) {
+			$logEventsListFlags = LogEventsList::NO_EDIT_COUNT_CHECK;
+		} else {
+			$logEventsListFlags = 0;
+		}
+
 		# Create a LogPager item to get the results and a LogEventsList item to format them...
-		$loglist = new LogEventsList( $this->getSkin(), $this->getOutput(), 0 );
+		$loglist = new LogEventsList( $this->getSkin(), $this->getOutput(), $logEventsListFlags );
 		$pager = new LogPager( $loglist, $opts->getValue( 'type' ), $opts->getValue( 'user' ),
 			$opts->getValue( 'page' ), $opts->getValue( 'pattern' ), $extraConds, $opts->getValue( 'year' ),
 			$opts->getValue( 'month' ), $opts->getValue( 'tagfilter' ) );


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-4547

This will solve `Special:Log/xxx` performance issues when a list of users is rendered and for each item we request a local edits (i.e. per-wiki edits) count.

I think we do not need a contribs link rendered red when a new user made no edits. The link itself will still be rendered, but it will always be blue.