### PR TITLE
IRIS-5315 | Use mb_substr in migration scripts to prevent broken utf-8 characters

### DIFF
--- a/extensions/wikia/Discussions/api/DiscussionsActivator.class.php
+++ b/extensions/wikia/Discussions/api/DiscussionsActivator.class.php
@@ -44,7 +44,7 @@ class DiscussionsActivator {
 		return new SiteInput(
 			[
 				'id' => $this->cityId,
-				'name' => substr( $this->cityName, 0, self::SITE_NAME_MAX_LENGTH ),
+				'name' => mb_substr( $this->cityName, 0, self::SITE_NAME_MAX_LENGTH ),
 				'language_code' => $this->cityLang
 			]
 		);

--- a/extensions/wikia/Discussions/maintenance/ForumDumper.php
+++ b/extensions/wikia/Discussions/maintenance/ForumDumper.php
@@ -217,10 +217,10 @@ class ForumDumper {
 
 		// Truncate the strings if they are too big
 		if ( strlen( $parsedText ) > self::MAX_CONTENT_SIZE ) {
-			$parsedText = substr( $parsedText, 0, self::MAX_CONTENT_SIZE );
+			$parsedText = mb_substr( $parsedText, 0, self::MAX_CONTENT_SIZE );
 		}
 		if ( strlen( $rawText ) > self::MAX_CONTENT_SIZE ) {
-			$rawText = substr( $rawText, 0, self::MAX_CONTENT_SIZE );
+			$rawText = mb_substr( $rawText, 0, self::MAX_CONTENT_SIZE );
 		}
 
 		return [ $parsedText, $rawText, $title ];


### PR DESCRIPTION
## Links
https://wikia-inc.atlassian.net/browse/IRIS-5315

## Description
Prevent UTF-8 characters being cut in the middle while dumping Forum data which caused:
```
ERROR 1366 (HY000) at line 115: Incorrect string value: '\xE2\x80' for column 'raw_content' at row 1
```