### PR TITLE
SUS-4547 | UserStatsService - properly handle cases when local edit count is zero

### DIFF
--- a/includes/wikia/services/UserStatsService.class.php
+++ b/includes/wikia/services/UserStatsService.class.php
@@ -69,7 +69,7 @@ class UserStatsService extends WikiaModel {
 		}
 
 		// update weekly edit counts on wiki
-		if ( empty( $stats['editcountThisWeek'] ) ) {
+		if ( !isset( $stats['editcountThisWeek'] ) ) {
 			$stats['editcountThisWeek'] = $this->calculateEditCountFromWeek( Title::GAID_FOR_UPDATE );
 		} elseif ( $this->updateEditCount( 'editcountThisWeek' ) ) {
 			$stats['editcountThisWeek']++;
@@ -113,6 +113,10 @@ class UserStatsService extends WikiaModel {
 				if ( !isset( $stats['editcount'] ) ) {
 					// editcount not set yet, calculate it
 					$stats['editcount'] = $this->calculateEditCountWiki( $flags );
+				}
+				else {
+					// make sure this value is an integer
+					$stats['editcount'] = (int) $stats['editcount'];
 				}
 
 				if ( $stats['editcount'] === 0 ) {
@@ -159,7 +163,7 @@ class UserStatsService extends WikiaModel {
 	 * @param int $flags bit flags with options (ie. to force DB_MASTER)
 	 * @return Int Number of edits
 	 */
-	private function calculateEditCountWiki( $flags = 0 ) {
+	private function calculateEditCountWiki( $flags = 0 ) : int {
 		if ( !$this->validateUser() ) {
 			return 0;
 		}
@@ -179,7 +183,7 @@ class UserStatsService extends WikiaModel {
 		);
 
 		$this->setUserStat( 'editcount', $editCount );
-		return $editCount;
+		return (int) $editCount;
 	}
 
 	private function updateEditCount( $propertyName ) {
@@ -305,7 +309,7 @@ class UserStatsService extends WikiaModel {
 	 * @since Nov 2013
 	 * @author Kamil Koterba
 	 *
-	 * @return String Timestamp in format YmdHis e.g. 20131107192200 or empty string
+	 * @return null|string Timestamp in format YmdHis e.g. 20131107192200 or empty string
 	 */
 	private function initFirstContributionTimestamp() {
 		$dbw = $this->getDatabase( Title::GAID_FOR_UPDATE );
@@ -324,6 +328,9 @@ class UserStatsService extends WikiaModel {
 		return $firstContributionTimestamp;
 	}
 
+	/**
+	 * @return null|string
+	 */
 	private function initLastContributionTimestamp() {
 		/* Get lastContributionTimestamp from database */
 		$dbw = $this->getDatabase( Title::GAID_FOR_UPDATE );

--- a/includes/wikia/services/UserStatsService.class.php
+++ b/includes/wikia/services/UserStatsService.class.php
@@ -61,7 +61,8 @@ class UserStatsService extends WikiaModel {
 		$stats = $this->getStats( Title::GAID_FOR_UPDATE );
 
 		// update edit counts on wiki
-		if ( empty( $stats['editcount'] ) ) {
+		if ( !isset( $stats['editcount'] ) ) {
+			// editcount not set yet, calculate it
 			$stats['editcount'] = $this->calculateEditCountWiki( Title::GAID_FOR_UPDATE );
 		} elseif ( $this->updateEditCount( 'editcount' ) ) {
 			$stats['editcount']++;
@@ -109,11 +110,12 @@ class UserStatsService extends WikiaModel {
 			function () use ( $flags ) {
 				$stats = $this->loadUserStatsFromDB();
 
-				if ( empty( $stats['editcount'] ) ) {
+				if ( !isset( $stats['editcount'] ) ) {
+					// editcount not set yet, calculate it
 					$stats['editcount'] = $this->calculateEditCountWiki( $flags );
 				}
 
-				if ( empty( $stats['editcount'] ) ) {
+				if ( $stats['editcount'] === 0 ) {
 					return [
 						'firstContributionTimestamp' => null,
 						'lastContributionTimestamp' => null,


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-4547

`empty` on value of zero does return true - use `isset` instead to leave early when edit counter is already set to zero.

We will save two `SELECT` and one `REPLACE` query on each cache miss in `getStats` method.

And always return `editcount` entry as an integer - let's be consistent with the type, ok?

### After the fix

```
> var_dump(  ( new UserStatsService( 14 ) )->getStats() )
memcached: get(wikicities:userStats:5915:14:v1.2)
Connecting to geo-db-dev-db-master.query.consul plpoznan...
Query plpoznan (DB user: wikia_maint) (4) (master): SELECT /* UserStatsService::loadUserStatsFromDB CommandLineInc - 1ceb1bd0-d260-45cc-b94a-6a0c41818ae4 */  wup_property,wup_value  FROM `wikia_user_properties`  WHERE wup_user = '14' AND wup_property IN ('editcount','editcountThisWeek','firstContributionTimestamp','lastContributionTimestamp')   
memcached: client: serializing data as it is not scalar
memcached: set wikicities:userStats:5915:14:v1.2 (STORED)
/usr/wikia/source/deploytools/18879/src/maintenance/eval.php(88) : eval()'d code:1:
array(4) {
  'firstContributionTimestamp' =>
  NULL
  'lastContributionTimestamp' =>
  NULL
  'editcount' =>
  int(0)
  'editcountThisWeek' =>
  int(0)
}



> var_dump(  ( new UserStatsService( 119245 ) )->getStats() )
memcached: get(wikicities:userStats:5915:119245:v1.2)
Connecting to geo-db-dev-db-master.query.consul plpoznan...
Query plpoznan (DB user: wikia_maint) (4) (master): SELECT /* UserStatsService::loadUserStatsFromDB CommandLineInc - 0327f661-1ecc-4d99-9eff-732121eee720 */  wup_property,wup_value  FROM `wikia_user_properties`  WHERE wup_user = '119245' AND wup_property IN ('editcount','editcountThisWeek','firstContributionTimestamp','lastContributionTimestamp')   
memcached: client: serializing data as it is not scalar
memcached: set wikicities:userStats:5915:119245:v1.2 (STORED)
/usr/wikia/source/deploytools/18879/src/maintenance/eval.php(88) : eval()'d code:1:
array(4) {
  'editcount' =>
  int(13169)
  'editcountThisWeek' =>
  string(1) "8"
  'firstContributionTimestamp' =>
  string(14) "20111016123539"
  'lastContributionTimestamp' =>
  string(14) "20180314121305"
}
```

### Before the fix

```
> var_dump(  ( new UserStatsService( 14 ) )->getStats() )
memcached: get(wikicities:userStats:5915:14:v1.2)
Connecting to geo-db-a-master.query.consul plpoznan...
Query plpoznan (DB user: wikia_maint) (1) (master): SELECT /* UserStatsService::loadUserStatsFromDB CommandLineInc - 6a36dbde-0200-4d52-94d2-58635e674d07 */  wup_property,wup_value  FROM `wikia_user_properties`  WHERE wup_user = '14' AND wup_property IN ('editcount','editcountThisWeek','firstContributionTimestamp','lastContributionTimestamp')   
LoadBalancer::getReaderIndex: Using reader #1: geo-db-a-slave.query.consul...
Connecting to geo-db-a-slave.query.consul plpoznan...
Query plpoznan (DB user: wikia_maint) (2) (slave): SELECT /* UserStatsService::calculateEditCountWiki CommandLineInc - 6a36dbde-0200-4d52-94d2-58635e674d07 */  count(*)  FROM `revision`  WHERE rev_user = '14'  LIMIT 1  
Query plpoznan (DB user: wikia_maint) (3) (slave): SELECT /* UserStatsService::calculateEditCountWiki CommandLineInc - 6a36dbde-0200-4d52-94d2-58635e674d07 */  count(*)  FROM `archive`  WHERE ar_user = '14'  LIMIT 1  
DatabaseBase::query: Writes done: REPLACE INTO `wikia_user_properties` (wup_user,wup_property,wup_value) VALUES ('14','editcount','0')
Query plpoznan (DB user: wikia_maint) (4) (master): REPLACE /* UserStatsService::setUserStat CommandLineInc - 6a36dbde-0200-4d52-94d2-58635e674d07 */ INTO `wikia_user_properties` (wup_user,wup_property,wup_value) VALUES ('14','editcount','0')
memcached: client: serializing data as it is not scalar
memcached: set wikicities:userStats:5915:14:v1.2 (STORED)
array(4) {
  ["firstContributionTimestamp"]=>
  NULL
  ["lastContributionTimestamp"]=>
  NULL
  ["editcount"]=>
  int(0)
  ["editcountThisWeek"]=>
  int(0)
}





> var_dump(  ( new UserStatsService( 119245 ) )->getStats() )
memcached: get(wikicities:userStats:5915:119245:v1.2)
Connecting to geo-db-a-master.query.consul plpoznan...
Query plpoznan (DB user: wikia_maint) (1) (master): SELECT /* UserStatsService::loadUserStatsFromDB CommandLineInc - 4e353dfc-6246-4bdd-8d6e-84d430b6e372 */  wup_property,wup_value  FROM `wikia_user_properties`  WHERE wup_user = '119245' AND wup_property IN ('editcount','editcountThisWeek','firstContributionTimestamp','lastContributionTimestamp')   
LoadBalancer::getReaderIndex: Using reader #1: geo-db-a-slave.query.consul...
Connecting to geo-db-a-slave.query.consul plpoznan...
Query plpoznan (DB user: wikia_maint) (2) (slave): SELECT /* UserStatsService::calculateEditCountFromWeek CommandLineInc - 4e353dfc-6246-4bdd-8d6e-84d430b6e372 */  count(*)  FROM `revision`  WHERE rev_user = '119245' AND (rev_timestamp >= FROM_DAYS(TO_DAYS(CURDATE()) - MOD(TO_DAYS(CURDATE()) - 1, 7)))  LIMIT 1  
Query plpoznan (DB user: wikia_maint) (3) (slave): SELECT /* UserStatsService::calculateEditCountFromWeek CommandLineInc - 4e353dfc-6246-4bdd-8d6e-84d430b6e372 */  count(*)  FROM `archive`  WHERE ar_user = '119245' AND (ar_timestamp >= FROM_DAYS(TO_DAYS(CURDATE()) - MOD(TO_DAYS(CURDATE()) - 1, 7)))  LIMIT 1  
DatabaseBase::query: Writes done: REPLACE INTO `wikia_user_properties` (wup_user,wup_property,wup_value) VALUES ('119245','editcountThisWeek','0')
Query plpoznan (DB user: wikia_maint) (4) (master): REPLACE /* UserStatsService::setUserStat CommandLineInc - 4e353dfc-6246-4bdd-8d6e-84d430b6e372 */ INTO `wikia_user_properties` (wup_user,wup_property,wup_value) VALUES ('119245','editcountThisWeek','0')
memcached: client: serializing data as it is not scalar
memcached: set wikicities:userStats:5915:119245:v1.2 (STORED)
array(4) {
  ["editcount"]=>
  string(5) "13344"
  ["firstContributionTimestamp"]=>
  string(14) "20111016123539"
  ["lastContributionTimestamp"]=>
  string(14) "20180403174342"
  ["editcountThisWeek"]=>
  int(0)
}
```

## Post-release graph

![userstatsservice_calculateeditcountwiki](https://user-images.githubusercontent.com/1929317/38553123-8c4a333e-3cbe-11e8-85e4-e3fd58693254.png) - number of SELECT queries per minute (with 5% sampling)

* `UserStatsService::setUserStat` - number of `REPLACE` **dropped by 27%** (from 1.36 mm queries a day)
* `UserStatsService::calculateEditCountWiki` - number of `SELECT` queries **dropped by 96,5%** (from 372k queries a day)