### PR TITLE
IRIS-5315 | Use mb_strcut instead of mb_substr in Discussions

### DIFF
--- a/extensions/wikia/Discussions/api/DiscussionsActivator.class.php
+++ b/extensions/wikia/Discussions/api/DiscussionsActivator.class.php
@@ -44,7 +44,7 @@ class DiscussionsActivator {
 		return new SiteInput(
 			[
 				'id' => $this->cityId,
-				'name' => mb_substr( $this->cityName, 0, self::SITE_NAME_MAX_LENGTH ),
+				'name' => mb_strcut( $this->cityName, 0, self::SITE_NAME_MAX_LENGTH ),
 				'language_code' => $this->cityLang
 			]
 		);

--- a/extensions/wikia/Discussions/maintenance/ForumDumper.php
+++ b/extensions/wikia/Discussions/maintenance/ForumDumper.php
@@ -217,10 +217,10 @@ class ForumDumper {
 
 		// Truncate the strings if they are too big
 		if ( strlen( $parsedText ) > self::MAX_CONTENT_SIZE ) {
-			$parsedText = mb_substr( $parsedText, 0, self::MAX_CONTENT_SIZE );
+			$parsedText = mb_strcut( $parsedText, 0, self::MAX_CONTENT_SIZE );
 		}
 		if ( strlen( $rawText ) > self::MAX_CONTENT_SIZE ) {
-			$rawText = mb_substr( $rawText, 0, self::MAX_CONTENT_SIZE );
+			$rawText = mb_strcut( $rawText, 0, self::MAX_CONTENT_SIZE );
 		}
 
 		return [ $parsedText, $rawText, $title ];


### PR DESCRIPTION
## Links
* https://wikia-inc.atlassian.net/browse/IRIS-5315
* http://php.net/manual/en/function.mb-substr.php
* http://php.net/manual/en/function.mb-strcut.php

## Description
Fix:
```
ERROR 1406 (22001) at line 677: Data too long for column 'content' at row 1
```
Column limit is 65536 bytes and we were limiting it to 65520 characters. Let's use bytes instead.