### PR TITLE
SUS-4544 allow rabbit publishes to fail fast

### DIFF
--- a/extensions/wikia/PhalanxII/hooks/PhalanxHooks.class.php
+++ b/extensions/wikia/PhalanxII/hooks/PhalanxHooks.class.php
@@ -6,6 +6,8 @@ use Wikia\Rabbit\ConnectionBase;
 class PhalanxHooks {
 	const ROUTING_KEY = 'onUpdate';
 
+	protected static $rabbitConnection;
+
 	/**
 	 * Add a link to central:Special:Phalanx from Special:Contributions/USERNAME
 	 * if the user has 'phalanx' permission
@@ -186,10 +188,7 @@ class PhalanxHooks {
 	}
 
 	public static function notifyPhalanxService( array $changedBlockIds ) {
-		global $wgPhalanxQueue;
-
-		$rabbitConnection = new ConnectionBase( $wgPhalanxQueue );
-		$rabbitConnection->publish( self::ROUTING_KEY, implode( ",", $changedBlockIds ) );
+		self::getRabbitConnection()->publish( self::ROUTING_KEY, implode( ",", $changedBlockIds ) );
 	}
 
 	/**
@@ -266,5 +265,16 @@ class PhalanxHooks {
 		}
 
 		return !$blockedGlobally; // If blocked globally disable listing local log
+	}
+
+	/** @return \Wikia\Rabbit\ConnectionBase */
+	protected static function getRabbitConnection() {
+		global $wgPhalanxQueue;
+
+		if ( !isset( self::$rabbitConnection ) ) {
+			self::$rabbitConnection = new ConnectionBase( $wgPhalanxQueue );
+		}
+
+		return self::$rabbitConnection;
 	}
 }

--- a/includes/wikia/rabbitmq/ConnectionBase.class.php
+++ b/includes/wikia/rabbitmq/ConnectionBase.class.php
@@ -58,7 +58,7 @@ class ConnectionBase {
 				$routingKey
 			);
 
-			$channel->wait_for_pending_acks(ACK_WAIT_TIMEOUT_SECONDS);
+			$channel->wait_for_pending_acks(self::ACK_WAIT_TIMEOUT_SECONDS);
 		} catch ( AMQPExceptionInterface $e ) {
 			WikiaLogger::instance()->error( __METHOD__, [
 				'exception' => $e,

--- a/lib/Wikia/src/Tasks/AsyncTaskList.php
+++ b/lib/Wikia/src/Tasks/AsyncTaskList.php
@@ -33,6 +33,9 @@ class AsyncTaskList {
 	/** which config to grab when figuring out the executor (on the job queue side) */
 	const EXECUTOR_APP_NAME = 'mediawiki';
 
+	/** how long we're willing to wait for publishing to finish */
+	const ACK_WAIT_TIMEOUT_SECONDS = 3;
+
 	/** @var AbstractConnection connection to message broker */
 	protected $connection;
 
@@ -276,6 +279,8 @@ class AsyncTaskList {
 	/**
 	 * put this task list into the queue
 	 *
+	 * IMPORTANT: The provided channel must be in publish confirm mode
+	 *
 	 * @param AMQPChannel $channel channel to publish messages to, if part of a batch
 	 * @param string $priority which queue to add this task list to
 	 * @return string the task list's id
@@ -329,7 +334,13 @@ class AsyncTaskList {
 			try {
 				$connection = $this->connection();
 				$channel = $connection->channel();
+				/*
+				 * Allow basic_publish to fail in case the connection is blocked by rabbit, due to insufficient resources.
+				 * https://www.rabbitmq.com/alarms.html
+				 */
+				$channel->confirm_select();
 				$channel->basic_publish( $message, '', $this->getQueue()->name() );
+				$channel->wait_for_pending_acks(self::ACK_WAIT_TIMEOUT_SECONDS);
 			} catch ( AMQPExceptionInterface $e ) {
 				$exception = $e;
 			}
@@ -437,6 +448,11 @@ class AsyncTaskList {
 		}
 
 		$channel = $connection->channel();
+		/*
+		 * Allow basic_publish to fail in case the connection is blocked by rabbit, due to insufficient resources.
+		 * https://www.rabbitmq.com/alarms.html
+		 */
+		$channel->confirm_select();
 		$exception = null;
 		$ids = [];
 
@@ -447,6 +463,7 @@ class AsyncTaskList {
 
 		try {
 			$channel->publish_batch();
+			$channel->wait_for_pending_acks(self::ACK_WAIT_TIMEOUT_SECONDS);
 		} catch ( AMQPExceptionInterface $e ) {
 			$exception = $e;
 		}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-4544

This change puts all rabbit channels in **publish confirm** mode, which allows publishes to fail when rabbit is blocking the connection, due to insufficient resources - https://www.rabbitmq.com/alarms.html.

**IMPORTANT**: Because timeout exceptions are caught, this change may cause an inconsistent state when a request is successful, but a publish fails (e. g. updating Solr, tasks, etc.). Keep this in mind while reviewing this.