### PR TITLE
Wiki Details API: return local url on devboxes/sandboxes

### DIFF
--- a/includes/wikia/services/WikiDetailsService.class.php
+++ b/includes/wikia/services/WikiDetailsService.class.php
@@ -165,7 +165,7 @@ class WikiDetailsService extends WikiService {
 			$exists = true;
 			return [
 				'title' => $wikiObj->city_title,
-				'url' => $wikiObj->city_url,
+				'url' => WikiFactory::getLocalEnvURL( $wikiObj->city_url ) . "xxxx"
 			];
 		}
 		return [];

--- a/includes/wikia/services/WikiDetailsService.class.php
+++ b/includes/wikia/services/WikiDetailsService.class.php
@@ -165,7 +165,7 @@ class WikiDetailsService extends WikiService {
 			$exists = true;
 			return [
 				'title' => $wikiObj->city_title,
-				'url' => WikiFactory::getLocalEnvURL( $wikiObj->city_url ) . "xxxx"
+				'url' => WikiFactory::getLocalEnvURL( $wikiObj->city_url ),
 			];
 		}
 		return [];


### PR DESCRIPTION
Right now responses from `http://servicesmw-s1.wikia-dev.us/api/v1/Wikis/Details?ids=1706` return production urls.
ping @Wikia/sus 