### PR TITLE
SUS-4525 | validate an image using GD library (this is NOT a security check!)

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -10,6 +10,8 @@ RUN apt-get update && apt-get install -y \
     autoconf \
     automake \
     libbz2-dev \
+    libjpeg-dev \
+    libpng-dev \
     # needed by wikidiff2
     libthai-dev \
     libtool \
@@ -65,6 +67,7 @@ RUN wget https://github.com/Wikia/wikidiff2/archive/1.4.1.tar.gz -O wikidiff2.ta
 # install PHP extensions required by MediaWiki that are provided by Docker base PHP image helper
 RUN docker-php-ext-install \
     bz2 \
+    gd \
     mysqli \
     opcache
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-4525

This used to execute `identify` binary from ImageMagick library. Now use `getimagesize` function for basic images validation.

Plus compile and enable `gd` PHP extension in Docker container. It's already there on production / dev now.