### PR TITLE
XW-4864 | Remove UAPs only for AB test (in js)

### DIFF
--- a/extensions/wikia/AdEngine/AdEngine2ContextService.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2ContextService.class.php
@@ -19,9 +19,7 @@ class AdEngine2ContextService {
 			$pageType = $wikiaPageType->getPageType();
 			$articleId = $title->getArticleID();
 			$hasFeaturedVideo =  !empty( $wg->EnableArticleFeaturedVideo ) &&
-				( ArticleVideoContext::isFeaturedVideoEmbedded( $articleId )  ||
-				// XW-4713 | Hide UAPs on pages running the Recommended Video ABTest
-				ArticleVideoContext::isRecommendedVideoAvailable( $articleId ) );
+				ArticleVideoContext::isFeaturedVideoEmbedded( $articleId );
 			// pages with featured video on mercury have no ATF slots
 			$delayBtf = ( $skinName === 'mercury' && $hasFeaturedVideo ) ? false : $wg->AdDriverDelayBelowTheFold;
 

--- a/extensions/wikia/AdEngine/js/provider/gpt/adSizeFilter.js
+++ b/extensions/wikia/AdEngine/js/provider/gpt/adSizeFilter.js
@@ -3,8 +3,9 @@ define('ext.wikia.adEngine.provider.gpt.adSizeFilter', [
 	'ext.wikia.adEngine.bridge',
 	'wikia.document',
 	'wikia.log',
-	'wikia.window'
-], function (bridge, doc, log, win) {
+	'wikia.window',
+	'wikia.abTest'
+], function (bridge, doc, log, win, abTest) {
 	'use strict';
 
 	var logGroup = 'ext.wikia.adEngine.provider.gpt.adSizeFilter',
@@ -29,7 +30,7 @@ define('ext.wikia.adEngine.provider.gpt.adSizeFilter', [
 	function removeUAPForFeaturedVideoPages(slotName, slotSizes) {
 		var adContext = getAdContext(),
 			recommendedVideoTestName = 'RECOMMENDED_VIDEO_AB',
-			runsRecommendedVideoABTest = window.Wikia.AbTest.getGroup(recommendedVideoTestName);
+			runsRecommendedVideoABTest = abTest.getGroup(recommendedVideoTestName);
 
 		if (slotName.indexOf('TOP_LEADERBOARD') > -1 &&
 			adContext &&

--- a/extensions/wikia/AdEngine/js/provider/gpt/adSizeFilter.js
+++ b/extensions/wikia/AdEngine/js/provider/gpt/adSizeFilter.js
@@ -27,7 +27,7 @@ define('ext.wikia.adEngine.provider.gpt.adSizeFilter', [
 			win.ads.context;
 	}
 
-	function removeUAPForFeaturedVideoPages(slotName, slotSizes) {
+	function removeFanTakeoverSizes(slotName, slotSizes) {
 		var adContext = getAdContext(),
 			recommendedVideoTestName = 'RECOMMENDED_VIDEO_AB',
 			runsRecommendedVideoABTest = abTest.getGroup(recommendedVideoTestName);
@@ -66,7 +66,7 @@ define('ext.wikia.adEngine.provider.gpt.adSizeFilter', [
 
 		var context = getAdContext();
 
-		slotSizes = removeUAPForFeaturedVideoPages(slotName, slotSizes);
+		slotSizes = removeFanTakeoverSizes(slotName, slotSizes);
 
 		switch (true) {
 			case slotName.indexOf('TOP_LEADERBOARD') > -1:

--- a/extensions/wikia/AdEngine/js/provider/gpt/adSizeFilter.js
+++ b/extensions/wikia/AdEngine/js/provider/gpt/adSizeFilter.js
@@ -30,7 +30,9 @@ define('ext.wikia.adEngine.provider.gpt.adSizeFilter', [
 	function removeFanTakeoverSizes(slotName, slotSizes) {
 		var adContext = getAdContext(),
 			recommendedVideoTestName = 'RECOMMENDED_VIDEO_AB',
-			runsRecommendedVideoABTest = abTest.getGroup(recommendedVideoTestName);
+			runsRecommendedVideoABTest = abTest.getGroup(recommendedVideoTestName) && win.location.hostname.match(
+				/(dragonage|dragonball|elderscrolls|gta|memory-alpha|monsterhunter|naruto|marvelcinematicuniverse)((\.wikia\.com)|(\.wikia-dev\.pl))/g
+			);
 
 		if (slotName.indexOf('TOP_LEADERBOARD') > -1 &&
 			adContext &&

--- a/extensions/wikia/AdEngine/js/provider/gpt/adSizeFilter.js
+++ b/extensions/wikia/AdEngine/js/provider/gpt/adSizeFilter.js
@@ -27,12 +27,14 @@ define('ext.wikia.adEngine.provider.gpt.adSizeFilter', [
 	}
 
 	function removeUAPForFeaturedVideoPages(slotName, slotSizes) {
-		var adContext = getAdContext();
+		var adContext = getAdContext(),
+			recommendedVideoTestName = 'RECOMMENDED_VIDEO_AB',
+			runsRecommendedVideoABTest = window.Wikia.AbTest.getGroup(recommendedVideoTestName);
 
 		if (slotName.indexOf('TOP_LEADERBOARD') > -1 &&
 			adContext &&
 			adContext.targeting &&
-			adContext.targeting.hasFeaturedVideo
+			(adContext.targeting.hasFeaturedVideo || runsRecommendedVideoABTest)
 		) {
 			slotSizes = removeUAPFromSlotSizes(slotSizes);
 		}

--- a/extensions/wikia/AdEngine/js/spec/provider/gpt/adSizeFilter.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/provider/gpt/adSizeFilter.spec.js
@@ -54,7 +54,8 @@ describe('ext.wikia.adEngine.provider.gpt.adSizeFilter', function () {
 			mocks.bridge,
 			mocks.getDocument(),
 			mocks.log,
-			mocks.win
+			mocks.win,
+			mocks.abTest
 		);
 	}
 


### PR DESCRIPTION
@Wikia/x-wing @fraszczakszymon @Wikia/adeng 

We were previously hiding UAPs in PHP which was causing them to be hidden for all traffic on pages with Recommended Video, not only A/B test traffic.