### PR TITLE
SUS-4580 | add ploticus binary to base Docker image

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -18,6 +18,8 @@ RUN apt-get update && apt-get install -y \
     libyaml-dev \
     locales \
     make \
+    # needed by Timeline extension
+    ploticus \
     wget \
     # needed by sass
     && apt-get -t jessie-backports install -y libsass-dev


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-4580

```
nobody@localhost:/usr/wikia/slot1/current/src$ ploticus 
usage: pl scriptfile [options] ...or...  pl -prefab prefabname [options]
ploticus 2.42-May2013 (unix).  This build can produce: PS EPS SVG SVGZ X11 PNG JPEG WBMP FreeType2 
Copyright 1998-2009 Steve Grubb, http://ploticus.sourceforge.net
```