### PR TITLE
(PLATFORM-3447) Don't rewrite URL for internal proxied requests

### DIFF
--- a/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
+++ b/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
@@ -403,6 +403,8 @@ class WikiFactoryLoader {
 
 			if ( $hasAuthCookie &&
 				 $_SERVER['HTTP_FASTLY_SSL'] &&
+				 // Hack until we are better able to handle internal HTTPS requests
+				 !empty( $_SERVER['HTTP_FASTLY_FF'] ) &&
 				 wfHttpsAllowedForURL( $redirectUrl )
 			) {
 				$redirectUrl = wfHttpToHttps( $redirectUrl );


### PR DESCRIPTION
This ensures internal clients that don't go through Fastly don't end up redirected
to a HTTPS URL that they can't handle due to internal cert issues.

We'll investigate alternative solutions, including internal HTTPS proxies in the
future.

/cc @Wikia/core-platform-team 