### PR TITLE
PHPUnit 6.5.7 -> 6.5.8

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3014,16 +3014,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.5.7",
+            "version": "6.5.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "6bd77b57707c236833d2b57b968e403df060c9d9"
+                "reference": "4f21a3c6b97c42952fd5c2837bb354ec0199b97b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6bd77b57707c236833d2b57b968e403df060c9d9",
-                "reference": "6bd77b57707c236833d2b57b968e403df060c9d9",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/4f21a3c6b97c42952fd5c2837bb354ec0199b97b",
+                "reference": "4f21a3c6b97c42952fd5c2837bb354ec0199b97b",
                 "shasum": ""
             },
             "require": {
@@ -3094,7 +3094,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-02-26T07:01:09+00:00"
+            "time": "2018-04-10T11:38:34+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",

--- a/lib/composer/composer/ClassLoader.php
+++ b/lib/composer/composer/ClassLoader.php
@@ -379,9 +379,9 @@ class ClassLoader
                 $subPath = substr($subPath, 0, $lastPos);
                 $search = $subPath.'\\';
                 if (isset($this->prefixDirsPsr4[$search])) {
-                    $pathEnd = DIRECTORY_SEPARATOR . substr($logicalPathPsr4, $lastPos + 1);
                     foreach ($this->prefixDirsPsr4[$search] as $dir) {
-                        if (file_exists($file = $dir . $pathEnd)) {
+                        $length = $this->prefixLengthsPsr4[$first][$search];
+                        if (file_exists($file = $dir . DIRECTORY_SEPARATOR . substr($logicalPathPsr4, $length))) {
                             return $file;
                         }
                     }

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -2816,6 +2816,7 @@ return array(
     'Wikia\\Search\\Utilities' => $baseDir . '/extensions/wikia/Search/classes/Utilities.php',
     'Wikia\\Service\\Constants' => $baseDir . '/lib/Wikia/src/Service/Constants.php',
     'Wikia\\Service\\ForbiddenException' => $baseDir . '/lib/Wikia/src/Service/ForbiddenException.php',
+    'Wikia\\Service\\Gateway\\KubernetesExternalUrlProvider' => $baseDir . '/lib/Wikia/src/Service/Gateway/KubernetesExternalUrlProvider.php',
     'Wikia\\Service\\Gateway\\KubernetesUrlProvider' => $baseDir . '/lib/Wikia/src/Service/Gateway/KubernetesUrlProvider.php',
     'Wikia\\Service\\Gateway\\StaticUrlProvider' => $baseDir . '/lib/Wikia/src/Service/Gateway/StaticUrlProvider.php',
     'Wikia\\Service\\Gateway\\UrlProvider' => $baseDir . '/lib/Wikia/src/Service/Gateway/UrlProvider.php',

--- a/lib/composer/composer/autoload_real.php
+++ b/lib/composer/composer/autoload_real.php
@@ -24,7 +24,7 @@ class ComposerAutoloaderInitb367f9b4bf4d43e0d5ea402c134db26b
         spl_autoload_unregister(array('ComposerAutoloaderInitb367f9b4bf4d43e0d5ea402c134db26b', 'loadClassLoader'));
 
         $includePaths = require __DIR__ . '/include_paths.php';
-        $includePaths[] = get_include_path();
+        array_push($includePaths, get_include_path());
         set_include_path(implode(PATH_SEPARATOR, $includePaths));
 
         $useStaticLoader = PHP_VERSION_ID >= 50600 && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded());

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -3290,6 +3290,7 @@ class ComposerStaticInitb367f9b4bf4d43e0d5ea402c134db26b
         'Wikia\\Search\\Utilities' => __DIR__ . '/../../..' . '/extensions/wikia/Search/classes/Utilities.php',
         'Wikia\\Service\\Constants' => __DIR__ . '/../../..' . '/lib/Wikia/src/Service/Constants.php',
         'Wikia\\Service\\ForbiddenException' => __DIR__ . '/../../..' . '/lib/Wikia/src/Service/ForbiddenException.php',
+        'Wikia\\Service\\Gateway\\KubernetesExternalUrlProvider' => __DIR__ . '/../../..' . '/lib/Wikia/src/Service/Gateway/KubernetesExternalUrlProvider.php',
         'Wikia\\Service\\Gateway\\KubernetesUrlProvider' => __DIR__ . '/../../..' . '/lib/Wikia/src/Service/Gateway/KubernetesUrlProvider.php',
         'Wikia\\Service\\Gateway\\StaticUrlProvider' => __DIR__ . '/../../..' . '/lib/Wikia/src/Service/Gateway/StaticUrlProvider.php',
         'Wikia\\Service\\Gateway\\UrlProvider' => __DIR__ . '/../../..' . '/lib/Wikia/src/Service/Gateway/UrlProvider.php',

--- a/lib/composer/composer/installed.json
+++ b/lib/composer/composer/installed.json
@@ -3114,92 +3114,6 @@
         ]
     },
     {
-        "name": "phpunit/phpunit",
-        "version": "6.5.7",
-        "version_normalized": "6.5.7.0",
-        "source": {
-            "type": "git",
-            "url": "https://github.com/sebastianbergmann/phpunit.git",
-            "reference": "6bd77b57707c236833d2b57b968e403df060c9d9"
-        },
-        "dist": {
-            "type": "zip",
-            "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6bd77b57707c236833d2b57b968e403df060c9d9",
-            "reference": "6bd77b57707c236833d2b57b968e403df060c9d9",
-            "shasum": ""
-        },
-        "require": {
-            "ext-dom": "*",
-            "ext-json": "*",
-            "ext-libxml": "*",
-            "ext-mbstring": "*",
-            "ext-xml": "*",
-            "myclabs/deep-copy": "^1.6.1",
-            "phar-io/manifest": "^1.0.1",
-            "phar-io/version": "^1.0",
-            "php": "^7.0",
-            "phpspec/prophecy": "^1.7",
-            "phpunit/php-code-coverage": "^5.3",
-            "phpunit/php-file-iterator": "^1.4.3",
-            "phpunit/php-text-template": "^1.2.1",
-            "phpunit/php-timer": "^1.0.9",
-            "phpunit/phpunit-mock-objects": "^5.0.5",
-            "sebastian/comparator": "^2.1",
-            "sebastian/diff": "^2.0",
-            "sebastian/environment": "^3.1",
-            "sebastian/exporter": "^3.1",
-            "sebastian/global-state": "^2.0",
-            "sebastian/object-enumerator": "^3.0.3",
-            "sebastian/resource-operations": "^1.0",
-            "sebastian/version": "^2.0.1"
-        },
-        "conflict": {
-            "phpdocumentor/reflection-docblock": "3.0.2",
-            "phpunit/dbunit": "<3.0"
-        },
-        "require-dev": {
-            "ext-pdo": "*"
-        },
-        "suggest": {
-            "ext-xdebug": "*",
-            "phpunit/php-invoker": "^1.1"
-        },
-        "time": "2018-02-26T07:01:09+00:00",
-        "bin": [
-            "phpunit"
-        ],
-        "type": "library",
-        "extra": {
-            "branch-alias": {
-                "dev-master": "6.5.x-dev"
-            }
-        },
-        "installation-source": "dist",
-        "autoload": {
-            "classmap": [
-                "src/"
-            ]
-        },
-        "notification-url": "https://packagist.org/downloads/",
-        "license": [
-            "BSD-3-Clause"
-        ],
-        "authors": [
-            {
-                "name": "Sebastian Bergmann",
-                "email": "sebastian@phpunit.de",
-                "role": "lead"
-            }
-        ],
-        "description": "The PHP Unit Testing framework.",
-        "homepage": "https://phpunit.de/",
-        "keywords": [
-            "phpunit",
-            "testing",
-            "xunit"
-        ]
-    },
-    {
         "name": "phpunit/phpunit-mock-objects",
         "version": "5.0.5",
         "version_normalized": "5.0.5.0",
@@ -5527,6 +5441,92 @@
             "http",
             "psr",
             "psr-7"
+        ]
+    },
+    {
+        "name": "phpunit/phpunit",
+        "version": "6.5.8",
+        "version_normalized": "6.5.8.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/sebastianbergmann/phpunit.git",
+            "reference": "4f21a3c6b97c42952fd5c2837bb354ec0199b97b"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/4f21a3c6b97c42952fd5c2837bb354ec0199b97b",
+            "reference": "4f21a3c6b97c42952fd5c2837bb354ec0199b97b",
+            "shasum": ""
+        },
+        "require": {
+            "ext-dom": "*",
+            "ext-json": "*",
+            "ext-libxml": "*",
+            "ext-mbstring": "*",
+            "ext-xml": "*",
+            "myclabs/deep-copy": "^1.6.1",
+            "phar-io/manifest": "^1.0.1",
+            "phar-io/version": "^1.0",
+            "php": "^7.0",
+            "phpspec/prophecy": "^1.7",
+            "phpunit/php-code-coverage": "^5.3",
+            "phpunit/php-file-iterator": "^1.4.3",
+            "phpunit/php-text-template": "^1.2.1",
+            "phpunit/php-timer": "^1.0.9",
+            "phpunit/phpunit-mock-objects": "^5.0.5",
+            "sebastian/comparator": "^2.1",
+            "sebastian/diff": "^2.0",
+            "sebastian/environment": "^3.1",
+            "sebastian/exporter": "^3.1",
+            "sebastian/global-state": "^2.0",
+            "sebastian/object-enumerator": "^3.0.3",
+            "sebastian/resource-operations": "^1.0",
+            "sebastian/version": "^2.0.1"
+        },
+        "conflict": {
+            "phpdocumentor/reflection-docblock": "3.0.2",
+            "phpunit/dbunit": "<3.0"
+        },
+        "require-dev": {
+            "ext-pdo": "*"
+        },
+        "suggest": {
+            "ext-xdebug": "*",
+            "phpunit/php-invoker": "^1.1"
+        },
+        "time": "2018-04-10T11:38:34+00:00",
+        "bin": [
+            "phpunit"
+        ],
+        "type": "library",
+        "extra": {
+            "branch-alias": {
+                "dev-master": "6.5.x-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "classmap": [
+                "src/"
+            ]
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "BSD-3-Clause"
+        ],
+        "authors": [
+            {
+                "name": "Sebastian Bergmann",
+                "email": "sebastian@phpunit.de",
+                "role": "lead"
+            }
+        ],
+        "description": "The PHP Unit Testing framework.",
+        "homepage": "https://phpunit.de/",
+        "keywords": [
+            "phpunit",
+            "testing",
+            "xunit"
         ]
     }
 ]

--- a/lib/composer/phpunit/phpunit/.github/CONTRIBUTING.md
+++ b/lib/composer/phpunit/phpunit/.github/CONTRIBUTING.md
@@ -21,12 +21,10 @@ Due to time constraints, we are not always able to respond as quickly as we woul
 
 ## Coding Guidelines
 
-This project comes with a configuration file for [php-cs-fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) (`.php_cs`) that you can use to (re)format your sourcecode for compliance with this project's coding guidelines:
+This project comes with a configuration file and an executable for [php-cs-fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) (`.php_cs`) that you can use to (re)format your sourcecode for compliance with this project's coding guidelines:
 
 ```bash
-$ wget http://cs.sensiolabs.org/download/php-cs-fixer-v2.phar -O php-cs-fixer.phar
-
-$ php php-cs-fixer.phar fix
+$ ./build/tools/php-cs-fixer fix
 ```
 
 ## Using PHPUnit from a Git checkout

--- a/lib/composer/phpunit/phpunit/ChangeLog-6.5.md
+++ b/lib/composer/phpunit/phpunit/ChangeLog-6.5.md
@@ -2,6 +2,12 @@
 
 All notable changes of the PHPUnit 6.5 release series are documented in this file using the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
+## [6.5.8] - 2018-04-10
+
+### Fixed
+
+* Fixed [#2830](https://github.com/sebastianbergmann/phpunit/issues/2830): `@runClassInSeparateProcess` does not work for tests that use `@dataProvider`
+
 ## [6.5.7] - 2018-02-26
 
 ### Fixed
@@ -56,6 +62,7 @@ All notable changes of the PHPUnit 6.5 release series are documented in this fil
 * Fixed [#2654](https://github.com/sebastianbergmann/phpunit/issues/2654): Problems with `assertJsonStringEqualsJsonString()`
 * Fixed [#2810](https://github.com/sebastianbergmann/phpunit/pull/2810): Code Coverage for PHPT tests does not work
 
+[6.5.8]: https://github.com/sebastianbergmann/phpunit/compare/6.5.7...6.5.8
 [6.5.7]: https://github.com/sebastianbergmann/phpunit/compare/6.5.6...6.5.7
 [6.5.6]: https://github.com/sebastianbergmann/phpunit/compare/6.5.5...6.5.6
 [6.5.5]: https://github.com/sebastianbergmann/phpunit/compare/6.5.4...6.5.5

--- a/lib/composer/phpunit/phpunit/src/Framework/TestCase.php
+++ b/lib/composer/phpunit/phpunit/src/Framework/TestCase.php
@@ -875,7 +875,8 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
                 'isStrictAboutTodoAnnotatedTests'            => $isStrictAboutTodoAnnotatedTests,
                 'isStrictAboutResourceUsageDuringSmallTests' => $isStrictAboutResourceUsageDuringSmallTests,
                 'codeCoverageFilter'                         => $codeCoverageFilter,
-                'configurationFilePath'                      => $configurationFilePath
+                'configurationFilePath'                      => $configurationFilePath,
+                'name'                                       => $this->getName(false),
             ];
 
             if (!$runEntireClass) {

--- a/lib/composer/phpunit/phpunit/src/Runner/Version.php
+++ b/lib/composer/phpunit/phpunit/src/Runner/Version.php
@@ -32,7 +32,7 @@ class Version
         }
 
         if (self::$version === null) {
-            $version       = new VersionId('6.5.7', \dirname(\dirname(__DIR__)));
+            $version       = new VersionId('6.5.8', \dirname(\dirname(__DIR__)));
             self::$version = $version->getVersion();
         }
 

--- a/lib/composer/phpunit/phpunit/src/Util/PHP/Template/TestCaseClass.tpl.dist
+++ b/lib/composer/phpunit/phpunit/src/Util/PHP/Template/TestCaseClass.tpl.dist
@@ -47,7 +47,7 @@ function __phpunit_run_isolated_test()
     $result->beStrictAboutTodoAnnotatedTests({isStrictAboutTodoAnnotatedTests});
     $result->beStrictAboutResourceUsageDuringSmallTests({isStrictAboutResourceUsageDuringSmallTests});
 
-    $test = new {className}(null, unserialize('{data}'), '{dataName}');
+    $test = new {className}('{name}', unserialize('{data}'), '{dataName}');
     $test->setDependencyInput(unserialize('{dependencyInput}'));
     $test->setInIsolation(TRUE);
 

--- a/lib/composer/phpunit/phpunit/tests/Regression/GitHub/2830.phpt
+++ b/lib/composer/phpunit/phpunit/tests/Regression/GitHub/2830.phpt
@@ -1,0 +1,20 @@
+--TEST--
+GH-2830: @runClassInSeparateProcess fails for tests with a @dataProvider
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = 'Issue2830';
+$_SERVER['argv'][3] = __DIR__ . '/2830/Issue2830Test.php';
+
+require __DIR__ . '/../../bootstrap.php';
+
+PHPUnit\TextUI\Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+OK (1 test, 1 assertion)

--- a/lib/composer/phpunit/phpunit/tests/Regression/GitHub/2830/Issue2830Test.php
+++ b/lib/composer/phpunit/phpunit/tests/Regression/GitHub/2830/Issue2830Test.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @runClassInSeparateProcess
+ */
+class Issue2830Test extends PHPUnit\Framework\TestCase
+{
+    /**
+     * @dataProvider simpleDataProvider
+     */
+    public function testMethodUsesDataProvider()
+    {
+        $this->assertTrue(true);
+    }
+
+    public function simpleDataProvider()
+    {
+        return [
+            ['foo'],
+        ];
+    }
+}


### PR DESCRIPTION
```
$ composer update phpunit/phpunit
Loading composer repositories with package information
Updating dependencies (including require-dev)                
Package operations: 0 installs, 1 update, 0 removals
  - Updating phpunit/phpunit (6.5.7 => 6.5.8): Downloading (100%)         
Writing lock file
Generating optimized autoload files
```