### PR TITLE
(PLATFORM-3458) Remove blog and module namespaces from sitemaps

### DIFF
--- a/extensions/wikia/SitemapXml/SitemapXmlController.class.php
+++ b/extensions/wikia/SitemapXml/SitemapXmlController.class.php
@@ -44,6 +44,9 @@ class SitemapXmlController extends WikiaController {
 		NS_TEMPLATE,
 		NS_HELP,
 		110,
+		500, // NS_BLOG_ARTICLE
+		502, // NS_BLOG_LISTING
+		828, // NS_MODULE
 		1100,
 		1200,
 		1202,


### PR DESCRIPTION
Blogs can cause crawl errors due to some of them being set to noindex in
some cases.
    
Module pages are just Lua content, so we shouldn't submit them to Google.

/cc @Wikia/core-platform-team 