### PR TITLE
SUS-4605: Improve edit count caching

### DIFF
--- a/includes/wikia/services/UserStatsService.class.php
+++ b/includes/wikia/services/UserStatsService.class.php
@@ -61,7 +61,7 @@ class UserStatsService extends WikiaModel {
 		$stats = $this->getStats();
 
 		$this->setUserStat( 'editcount', ++$stats['editcount'] );
-		$this->setUserStat( 'editcount', ++$stats['editcountThisWeek'] );
+		$this->setUserStat( 'editcountThisWeek', ++$stats['editcountThisWeek'] );
 
 		$now = wfTimestampNow();
 


### PR DESCRIPTION
* Don't try to calculate edit count if the value is absent from database—since it's set on first edit, we'll always get 0 and just waste our time.
* Always increment and set edit count and weekly edit count values on edit
* Use current timestamp to set last contribution timestamp (and also first, if this is their first edit), instead of wasting time on an useless lookup

https://wikia-inc.atlassian.net/browse/SUS-4605