### PR TITLE
MAIN-13590: Add a community-specific class to the body tag in Chat

### DIFF
--- a/extensions/wikia/Chat2/ChatController.class.php
+++ b/extensions/wikia/Chat2/ChatController.class.php
@@ -66,8 +66,7 @@ class ChatController extends WikiaController {
 		$this->pathToContribsPage = SpecialPage::getTitleFor( 'Contributions', '$1' )->getFullURL();
 
 		// Adding a community-specific class to the body tag.
-		$skin = RequestContext::getMain()->getSkin();
-		$this->bodyClasses = $skin->getBodyClassForCommunity();
+		$this->bodyClasses = Sanitizer::escapeClass( "wiki-{$this->wg->DBname}" );
 
 		// Adding chatmoderator class to the body tag.
 		if ( $wgUser->isAllowed( Chat::CHAT_MODERATOR ) ) {

--- a/extensions/wikia/Chat2/ChatController.class.php
+++ b/extensions/wikia/Chat2/ChatController.class.php
@@ -65,10 +65,14 @@ class ChatController extends WikiaController {
 		$this->pathToProfilePage = Title::makeTitle( !empty( $this->wg->EnableWallExt ) ? NS_USER_WALL : NS_USER_TALK, '$1' )->getFullURL();
 		$this->pathToContribsPage = SpecialPage::getTitleFor( 'Contributions', '$1' )->getFullURL();
 
-		$this->bodyClasses = "";
+		// Adding a community-specific class to the body tag.
+		$skin = RequestContext::getMain()->getSkin();
+		$this->bodyClasses = $skin->getBodyClassForCommunity();
+
+		// Adding chatmoderator class to the body tag.
 		if ( $wgUser->isAllowed( Chat::CHAT_MODERATOR ) ) {
 			$this->isModerator = 1;
-			$this->bodyClasses .= ' chatmoderator ';
+			$this->bodyClasses .= ' chatmoderator';
 		} else {
 			$this->isModerator = 0;
 		}
@@ -76,7 +80,7 @@ class ChatController extends WikiaController {
 		// Adding chatmoderator group for other users. CSS classes added to body tag to hide/show option in menu.
 		$userChangeableGroups = $wgUser->changeableGroups();
 		if ( in_array( Chat::CHAT_MODERATOR, $userChangeableGroups['add'] ) ) {
-			$this->bodyClasses .= ' can-give-chat-mod ';
+			$this->bodyClasses .= ' can-give-chat-mod';
 		}
 
 		// set up global js variables just for the chat page

--- a/extensions/wikia/Chat2/templates/Chat_Index.php
+++ b/extensions/wikia/Chat2/templates/Chat_Index.php
@@ -27,7 +27,7 @@
 	<?php // TODO: use js var?>
 
 </head>
-<body class="<?= $bodyClasses ?> ChatWindow">
+<body class="ChatWindow <?= $bodyClasses ?>">
 
 	<header id="ChatHeader" class="ChatHeader">
 		<h1 class="public wordmark">


### PR DESCRIPTION
Users will be able to scope local chat themes to a wiki :)

NB: I was using [getBodyClassForCommunity function](https://github.com/Wikia/app/blob/e1beb502b95a6e6527dfe63bc26735be227afafb/includes/wikia/nirvana/WikiaSkin.class.php#L338), but it seems that's unnecessary? I've removed it for now:

https://github.com/Wikia/app/commit/e1beb502b95a6e6527dfe63bc26735be227afafb