### PR TITLE
SUS-4606 | catch exceptions instead of stopping the CloseWiki script

### DIFF
--- a/extensions/wikia/WikiFactory/Close/maintenance.php
+++ b/extensions/wikia/WikiFactory/Close/maintenance.php
@@ -261,7 +261,15 @@ class CloseWikiMaintenance {
 				/**
 				 * let other extensions remove entries for closed wiki
 				 */
-				Hooks::run( 'WikiFactoryDoCloseWiki', [ $row ] );
+				try {
+					Hooks::run( 'WikiFactoryDoCloseWiki', [ $row ] );
+				} catch ( Exception $ex ) {
+					// SUS-4606 | catch exceptions instead of stopping the script
+					WikiaLogger::instance()->error( 'WikiFactoryDoCloseWiki hook processing returned an error', [
+						'exception' => $ex,
+						'wiki_id' => (int) $row->city_id
+					] );
+				}
 
 				/**
 				 * there is nothing to set because row in city_list doesn't


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-4606

Prevent the following exception from stopping the entire CloseWiki process:

```
Unexpected non-MediaWiki exception encountered, of type "Swagger\Client\ApiException"
Swagger\Client\ApiException: API call to prod.sjc.k8s.wikia.net/template-classification-storage/1704782 failed: Operation timed out after 1000 milliseconds with 0 bytes received in /usr/wikia/slot1/22943/src/lib/Swagger/src/ApiClient.php:258
Stack trace:
#0 /usr/wikia/slot1/22943/src/lib/Wikia/src/Service/Swagger/ApiClient.php(36): Swagger\Client\ApiClient->callApi('/1704782', 'DELETE', Array, '', Array, NULL, '/{wiki_id}')
#1 /usr/wikia/slot1/22943/src/lib/Swagger/src/TemplateClassification/Storage/Api/TCSApi.php(269): Wikia\Service\Swagger\ApiClient->callApi('/1704782', 'DELETE', Array, '', Array, NULL, '/{wiki_id}')
#2 /usr/wikia/slot1/22943/src/lib/Swagger/src/TemplateClassification/Storage/Api/TCSApi.php(211): Swagger\Client\TemplateClassification\Storage\Api\TCSApi->deleteTemplateInformationForWikiWithHttpInfo(1704782)
#3 /usr/wikia/slot1/22943/src/includes/wikia/services/TemplateClassificationService.class.php(165): Swagger\Client\TemplateClassification\Storage\Api\TCSApi->deleteTemplateInformationForWiki(1704782)
#4 /usr/wikia/slot1/22943/src/extensions/wikia/TemplateClassification/TemplateClassification.hooks.php(56): TemplateClassificationService->deleteTemplateInformationForWiki(1704782)
#5 /usr/wikia/slot1/22943/src/includes/Hooks.php(206): Wikia\TemplateClassification\Hooks::onWikiFactoryDoCloseWiki(Object(stdClass))
#6 /usr/wikia/slot1/22943/src/extensions/wikia/WikiFactory/Close/maintenance.php(264): Hooks::run('WikiFactoryDoCl...', Array)
#7 /usr/wikia/slot1/22943/src/extensions/wikia/WikiFactory/Close/maintenance.php(548): CloseWikiMaintenance->execute()
#8 {main}
```