### PR TITLE
 SUS-4614 | get rid of wgEnableMemcachedBulkMode (disabled in June 2013)

### DIFF
--- a/extensions/wikia/WallNotifications/WallNotifications.class.php
+++ b/extensions/wikia/WallNotifications/WallNotifications.class.php
@@ -188,15 +188,6 @@ class WallNotifications {
 
 				$wikiList = $this->getWikiList( $userId );
 
-				// prefetch data
-				$keys = [];
-				$wno = new WallNotificationsOwner;
-				foreach ( $wikiList as $wiki ) {
-					$keys[] = $this->getKey( $userId, $wiki['id'] );
-					$keys[] = $wno->getKey( $wiki['id'], $userId );
-				}
-				$wgMemc->prefetch( $keys );
-
 				$output = [];
 				$total = 0;
 				foreach ( $wikiList as $wiki ) {
@@ -271,7 +262,6 @@ class WallNotifications {
 		} else {
 			$output = [];
 		}
-		WikiFactory::prefetchWikisById( array_keys( $val ), WikiFactory::PREFETCH_VARIABLES );
 		foreach ( $val as $wikiId => $wikiSitename ) {
 			$output[] = [
 				'id' => $wikiId,
@@ -332,7 +322,6 @@ class WallNotifications {
 			/** @var Object $row */
 			$ids[] = $row->wiki_id;
 		}
-		WikiFactory::prefetchWikisById( $ids, WikiFactory::PREFETCH_WIKI_METADATA );
 		$output = [];
 		foreach ( $ids as $id ) {
 			$output[ $id ] = WikiFactory::getWikiByID( $id )->city_title;

--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -3281,37 +3281,6 @@ class WikiFactory {
 	}
 
 	/**
-	 * Prefetch specified data for given set of wikis
-	 *
-	 * @author Władysław Bodzek <wladek@wikia-inc.com>
-	 *
-	 * @param $ids array List of wiki ids
-	 * @param $what int Flags specifying what data to prefetch
-	 */
-	static public function prefetchWikisById( $ids, $what = self::PREFETCH_DEFAULT ) {
-		global $wgMemc;
-		if ( !is_array( $ids ) ) $ids = [ $ids ];
-		$keys = [];
-		$added = [];
-		foreach ( $ids as $id ) {
-			$id = intval($id);
-
-			// don't add the same wiki twice
-			if ( !empty($added[$id]) ) continue;
-			$added[$id] = true;
-
-
-			if ( $what & static::PREFETCH_WIKI_METADATA ) {
-				$keys[] = static::getVarsKey($id);
-			}
-			if ( $what & static::PREFETCH_VARIABLES ) {
-				$keys[] = static::getWikiaCacheKey($id);
-			}
-		}
-		$wgMemc->prefetch($keys);
-	}
-
-	/**
 	 * Renders community's value of given variable
 	 *
 	 * @access public

--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -66,11 +66,6 @@ class WikiFactory {
 	// Community Central's city_id in wikicities.city_list.
 	const COMMUNITY_CENTRAL = 177;
 
-	const PREFETCH_WIKI_METADATA = 1;
-	const PREFETCH_VARIABLES = 2;
-	const PREFETCH_ALL = 255;
-	const PREFETCH_DEFAULT = self::PREFETCH_ALL;
-
 	static public $types = [
 		"integer",
 		"long",

--- a/includes/objectcache/BagOStuff.php
+++ b/includes/objectcache/BagOStuff.php
@@ -191,31 +191,6 @@ abstract class BagOStuff {
 	}
 
 	/**
-	 * Get multiple items at once
-	 *
-	 * @author Władysław Bodzek <wladek@wikia-inc.com>
-	 * @param $keys array List of keys
-	 * @return array Data associated with given keys, no data is indicated by "false"
-	 */
-	public function getMulti( $keys ) {
-		$data = array();
-		foreach ($keys as $key) {
-			$data[$key] = $this->get($key);
-		}
-		return $data;
-	}
-
-	/**
-	 * Prefetch the following keys if local cache is enabled, otherwise don't do anything
-	 *
-	 * @author Władysław Bodzek <wladek@wikia-inc.com>
-	 * @param $keys array List of keys to prefetch
-	 */
-	public function prefetch( $keys ) {
-		// noop
-	}
-
-	/**
 	 * Remove value from local cache which is associated with a given key
 	 *
 	 * @author Władysław Bodzek <wladek@wikia-inc.com>
@@ -226,5 +201,3 @@ abstract class BagOStuff {
 	}
 
 }
-
-

--- a/includes/objectcache/MemcachedPhpBagOStuff.php
+++ b/includes/objectcache/MemcachedPhpBagOStuff.php
@@ -180,64 +180,6 @@ class MemcachedPhpBagOStuff extends BagOStuff {
 	}
 
 	/**
-	 * Do a get_multi request and optionally return the data if required
-	 *
-	 * @author Władysław Bodzek <wladek@wikia-inc.com>
-	 * @param $keys array List of keys
-	 * @parma $returnData bool Return the data?
-	 * @return array
-	 */
-	protected function getMultiInternal( $keys, $returnData ) {
-		$map = array();
-		foreach ($keys as $key) {
-			$map[$this->encodeKey($key)] = $key;
-		}
-		$mappedData = $this->client->get_multi( array_keys( $map ) );
-
-		if ( !$returnData ) {
-			return true;
-		}
-
-		$data = array();
-		foreach ($mappedData as $k => $v) {
-			$data[$map[$k]] = $v;
-		}
-
-		return $data;
-	}
-
-	/**
-	 * Get multiple items at once
-	 *
-	 * @author Władysław Bodzek <wladek@wikia-inc.com>
-	 * @param $keys array List of keys
-	 * @return array Data associated with given keys, no data is indicated by "false"
-	 */
-	public function getMulti( $keys ) {
-		global $wgEnableMemcachedBulkMode;
-		if ( empty( $wgEnableMemcachedBulkMode ) ) {
-			return parent::getMulti($keys);
-		}
-
-		return $this->getMultiInternal($keys,true);
-	}
-
-	/**
-	 * Prefetch the following keys if local cache is enabled, otherwise don't do anything
-	 *
-	 * @author Władysław Bodzek <wladek@wikia-inc.com>
-	 * @param $keys array List of keys to prefetch
-	 */
-	public function prefetch( $keys ) {
-		global $wgEnableMemcachedBulkMode;
-		if ( empty( $wgEnableMemcachedBulkMode ) ) {
-			parent::prefetch($keys);
-		}
-
-		$this->getMultiInternal($keys,false);
-	}
-
-	/**
 	 * Remove value from local cache which is associated with a given key
 	 *
 	 * @author Władysław Bodzek <wladek@wikia-inc.com>
@@ -248,4 +190,3 @@ class MemcachedPhpBagOStuff extends BagOStuff {
 	}
 
 }
-

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1033,14 +1033,6 @@ $wgResourceLoaderCssMinifier = false;
  */
 $wgWikiaIsCentralWiki = false;
 
-
-/**
- * Is bulk mode in Memcached routines enabled?
- * (eg. get_multi())
- * @var boolean
- */
-$wgEnableMemcachedBulkMode = false;
-
 /**
  * WikiaSeasons flags
  */


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-4614

> This work is not complete. It has partial implementation that caused flood of warnings on production when enabled. Grouped memcached calls remain a tricky proposition as they will fail if a single key in a group is missing. Recommendation: back to drawing board.

Clean up the memcache client before we can backport https://github.com/wikimedia/mediawiki/commit/3c62077fe28778eb41bde7549fbae402c8be0ef7#diff-86946fda95cb93f7a1deb64d78e6c661