### PR TITLE
(PLATFORM-3441) Add variable to enable HTTPS for all users

### DIFF
--- a/extensions/wikia/HTTPSOptIn/HTTPSOptInHooks.class.php
+++ b/extensions/wikia/HTTPSOptIn/HTTPSOptInHooks.class.php
@@ -14,8 +14,8 @@ class HTTPSOptInHooks {
 	];
 
 	public static function onGetPreferences( User $user, array &$preferences ): bool {
-		global $wgServer;
-		if ( wfHttpsAllowedForURL( $wgServer ) ) {
+		global $wgServer, $wgHTTPSForLoggedInUsers;
+		if ( empty( $wgHTTPSForLoggedInUsers ) && wfHttpsAllowedForURL( $wgServer ) ) {
 			$preferences['https-opt-in'] = [
 				'type' => 'toggle',
 				'label-message' => 'https-opt-in-toggle',
@@ -75,9 +75,10 @@ class HTTPSOptInHooks {
 	}
 
 	private static function httpsAllowed( User $user, string $url ): bool {
+		global $wgHTTPSForLoggedInUsers;
 		return wfHttpsAllowedForURL( $url ) &&
 			$user->isLoggedIn() &&
-			$user->getGlobalPreference( 'https-opt-in', false );
+			( !empty( $wgHTTPSForLoggedInUsers ) || $user->getGlobalPreference( 'https-opt-in', false ) );
 	}
 
 	private static function httpsEnabledTitle( Title $title ): bool {


### PR DESCRIPTION
Add a variable to enable HTTPS for all logged-in users. Initially, we
will enable this for a few test communities, then we will start rolling
it out in large batches.

/cc @Wikia/core-platform-team 