### PR TITLE
PLATFORM-3431: change log field name

### DIFF
--- a/extensions/3rdparty/LyricWiki/LyricFind/LyricFindTrackingService.class.php
+++ b/extensions/3rdparty/LyricWiki/LyricFind/LyricFindTrackingService.class.php
@@ -126,7 +126,7 @@ class LyricFindTrackingService extends WikiaObject {
 			'trackid' => $trackId,
 			'client_ip' => !empty( $ctx['client_ip'] ) ? $ctx['client_ip'] : '',
 			'initiator' => $callerName,
-			'timestamp' => wfTimestamp( TS_DB )
+			'call_timestamp' => wfTimestamp( TS_DB )
 		] );
 
 		return ExternalHttp::post($url, ['postData' => $data]);


### PR DESCRIPTION
`timestamp` conflicts with an existing field emitted as a number, so these string entries were dropped by elasticsearch