### PR TITLE
allow configurable hostaname

### DIFF
--- a/extensions/wikia/Staging/Staging.setup.php
+++ b/extensions/wikia/Staging/Staging.setup.php
@@ -29,5 +29,5 @@ $wgHooks['BeforePageRedirect'][] = 'StagingHooks::onBeforePageRedirect';
  * @author macbre
  * @see PLATFORM-664
  */
-$wgCachePrefix = gethostname() . '-' . wfWikiID(); // e.g. staging-s3-muppet / sandbox-qa02-glee / ...
-$wgSharedKeyPrefix = gethostname() . '-' . $wgSharedKeyPrefix; // e.g. staging-s3-wikicities
+$wgCachePrefix = wfGetEffectiveHostname() . '-' . wfWikiID(); // e.g. staging-s3-muppet / sandbox-qa02-glee / ...
+$wgSharedKeyPrefix = wfGetEffectiveHostname() . '-' . $wgSharedKeyPrefix; // e.g. staging-s3-wikicities

--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -1247,7 +1247,7 @@ class WikiFactory {
 	public static function getExternalHostName() {
 		global $wgWikiaEnvironment;
 
-		$hostname = gethostname();
+		$hostname = wfGetEffectiveHostname();
 		if ( $wgWikiaEnvironment == WIKIA_ENV_DEV ) {
 			return mb_ereg_replace( '^dev-', '', $hostname );
 		}

--- a/includes/wikia/GlobalFunctions.php
+++ b/includes/wikia/GlobalFunctions.php
@@ -1596,3 +1596,10 @@ function wfStripProtocol( $url ) {
 	}
 	return substr( $url, $pos + 3 );
 }
+
+/**
+ * In some cases, we don't want to use the actual hostname and use a configured value.
+ */
+function wfGetEffectiveHostname() {
+	return getenv('HOSTNAME_OVERRIDE') ?: gethostname();
+}

--- a/lib/Wikia/src/Tasks/AsyncTaskList.php
+++ b/lib/Wikia/src/Tasks/AsyncTaskList.php
@@ -249,7 +249,7 @@ class AsyncTaskList {
 		];
 
 		if ( $wgWikiaEnvironment != WIKIA_ENV_PROD ) {
-			$host = gethostname();
+			$host = wfGetEffectiveHostname();
 			$executionMethod = 'http';
 
 			if ( $wgWikiaEnvironment == WIKIA_ENV_DEV && preg_match( '/^dev-(.*?)$/', $host ) ) {


### PR DESCRIPTION
We don't want to use actual hostnames when running sandboxes on k8s. This change allows us to configure a synthetic hostname in env.