### PR TITLE
(PLATFORM-3469) Fix parsing language path on thread ID pages

### DIFF
--- a/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
+++ b/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
@@ -71,7 +71,7 @@ class WikiFactoryLoader {
 			// normal HTTP request
 			$this->mServerName = strtolower( $server['SERVER_NAME'] );
 
-			$path = parse_url( $server['REQUEST_URI'], PHP_URL_PATH );
+			$path = parse_url( $server['REQUEST_SCHEME'] . '://' . $server['SERVER_NAME'] . $server['REQUEST_URI'], PHP_URL_PATH );
 
 			$slash = strpos( $path, '/', 1 ) ?: strlen( $path );
 

--- a/extensions/wikia/WikiFactory/tests/WikiFactoryLoaderIntegrationTest.php
+++ b/extensions/wikia/WikiFactory/tests/WikiFactoryLoaderIntegrationTest.php
@@ -28,11 +28,47 @@ class WikiFactoryLoaderIntegrationTest extends WikiaDatabaseTest {
 	}
 
 	public function provideRequestDataForExistingWikis() {
-		yield [ 1, [ 'SERVER_NAME' => 'test1.wikia.com', 'REQUEST_URI' => 'http://test1.wikia.com/wiki/Test' ] ];
-		yield [ 2, [ 'SERVER_NAME' => 'test1.wikia.com', 'REQUEST_URI' => 'http://test1.wikia.com/de/wiki/Bar' ] ];
-		yield [ 8, [ 'SERVER_NAME' => 'poznan.wikia.com', 'REQUEST_URI' => 'http://poznan.wikia.com/en/wiki/Stary_Rynek' ] ];
-		yield [ 9, [ 'SERVER_NAME' => 'poznan.wikia.com', 'REQUEST_URI' => 'http://poznan.wikia.com/wiki/Strona_główna' ] ];
-		yield [ 9, [ 'SERVER_NAME' => 'poznan.wikia.com', 'REQUEST_URI' => 'http://poznan.wikia.com/' ] ];
+		yield [ 1, [
+			'REQUEST_SCHEME' => 'http',
+			'SERVER_NAME' => 'test1.wikia.com',
+			'REQUEST_URI' => '/wiki/Test',
+		] ];
+		yield [ 2, [
+			'REQUEST_SCHEME' => 'http',
+			'SERVER_NAME' => 'test1.wikia.com',
+			'REQUEST_URI' => '/de/wiki/Bar',
+		] ];
+		yield [ 8, [
+			'REQUEST_SCHEME' => 'http',
+			'SERVER_NAME' => 'poznan.wikia.com',
+			'REQUEST_URI' => '/en/wiki/Stary_Rynek',
+		] ];
+		yield [ 9, [
+			'REQUEST_SCHEME' => 'http',
+			'SERVER_NAME' => 'poznan.wikia.com',
+			'REQUEST_URI' => '/wiki/Strona_główna',
+		] ];
+		yield [ 9, [
+			'REQUEST_SCHEME' => 'http',
+			'SERVER_NAME' => 'poznan.wikia.com',
+			'REQUEST_URI' => '/',
+		] ];
+		// Test cases for PHP bug: https://bugs.php.net/bug.php?id=71646
+		yield [ 1, [
+			'REQUEST_SCHEME' => 'http',
+			'SERVER_NAME' => 'test1.wikia.com',
+			'REQUEST_URI' => '/wiki/Thread:24',
+		] ];
+		yield [ 2, [
+			'REQUEST_SCHEME' => 'http',
+			'SERVER_NAME' => 'test1.wikia.com',
+			'REQUEST_URI' => '/de/wiki/Thread:24',
+		] ];
+		yield [ 8, [
+			'REQUEST_SCHEME' => 'http',
+			'SERVER_NAME' => 'poznan.wikia.com',
+			'REQUEST_URI' => '/en/wiki/Thread:24',
+		] ];
 	}
 
 	/**
@@ -80,13 +116,41 @@ class WikiFactoryLoaderIntegrationTest extends WikiaDatabaseTest {
 	}
 
 	public function provideRequestWithAlternativeDomain() {
-		yield [ 'http://test1.wikia.com/wiki/Foo', [ 'SERVER_NAME' => 'test1.wikicities.com', 'REQUEST_URI' => 'http://test1.wikicities.com/wiki/Foo' ] ];
-		yield [ 'http://test1.wikia.com/de/wiki/Bar', [ 'SERVER_NAME' => 'einetest.wikia.com', 'REQUEST_URI' => 'http://einetest.wikia.com/wiki/Bar' ] ];
-		yield [ 'http://test1.wikia.com/de/wiki/Bar', [ 'SERVER_NAME' => 'einetest.wikia.com', 'REQUEST_URI' => 'http://einetest.wikia.com/wiki/Bar' ] ];
-		yield [ 'http://test1.wikia.com/wiki/Test', [ 'SERVER_NAME' => 'test1.wikia.com', 'REQUEST_URI' => 'http://test1.wikia.com/en/wiki/Test' ] ];
-		yield [ 'http://poznan.wikia.com/wiki/Strona_główna', [ 'SERVER_NAME' => 'poznan.wikia.com', 'REQUEST_URI' => 'http://poznan.wikia.com/pl/wiki/Strona_główna' ] ];
-		yield [ 'http://poznan.wikia.com/', [ 'SERVER_NAME' => 'poznan.wikia.com', 'REQUEST_URI' => 'http://poznan.wikia.com/pl' ] ];
-		yield [ 'http://poznan.wikia.com/', [ 'SERVER_NAME' => 'poznan.wikia.com', 'REQUEST_URI' => 'http://poznan.wikia.com/pl/' ] ];
+		yield [ 'http://test1.wikia.com/wiki/Foo', [
+			'REQUEST_SCHEME' => 'http',
+			'SERVER_NAME' => 'test1.wikicities.com',
+			'REQUEST_URI' => '/wiki/Foo',
+		] ];
+		yield [ 'http://test1.wikia.com/de/wiki/Bar', [
+			'REQUEST_SCHEME' => 'http',
+			'SERVER_NAME' => 'einetest.wikia.com',
+			'REQUEST_URI' => '/wiki/Bar',
+		] ];
+		yield [ 'http://test1.wikia.com/de/wiki/Bar', [
+			'REQUEST_SCHEME' => 'http',
+			'SERVER_NAME' => 'einetest.wikia.com',
+			'REQUEST_URI' => '/wiki/Bar',
+		] ];
+		yield [ 'http://test1.wikia.com/wiki/Test', [
+			'REQUEST_SCHEME' => 'http',
+			'SERVER_NAME' => 'test1.wikia.com',
+			'REQUEST_URI' => '/en/wiki/Test',
+		] ];
+		yield [ 'http://poznan.wikia.com/wiki/Strona_główna', [
+			'REQUEST_SCHEME' => 'http',
+			'SERVER_NAME' => 'poznan.wikia.com',
+			'REQUEST_URI' => '/pl/wiki/Strona_główna',
+		] ];
+		yield [ 'http://poznan.wikia.com/', [
+			'REQUEST_SCHEME' => 'http',
+			'SERVER_NAME' => 'poznan.wikia.com',
+			'REQUEST_URI' => '/pl',
+		] ];
+		yield [ 'http://poznan.wikia.com/', [
+			'REQUEST_SCHEME' => 'http',
+			'SERVER_NAME' => 'poznan.wikia.com',
+			'REQUEST_URI' => '/pl/',
+		] ];
 	}
 
 	/**
@@ -109,16 +173,28 @@ class WikiFactoryLoaderIntegrationTest extends WikiaDatabaseTest {
 	}
 
 	public function provideNotExistingWikisRequests() {
-		yield [ [ 'SERVER_NAME' => 'badwiki.wikia.com', 'REQUEST_URI' => 'http://badwiki.wikia.com/wiki/Foo' ], [] ];
-		yield [ [ 'SERVER_NAME' => 'poznan.wikia.com', 'REQUEST_URI' => 'http://poznan.wikia.com/de/wiki/Posen' ], [] ];
-		yield [ [ 'SERVER_NAME' => 'zgubieni.wikia.com', 'REQUEST_URI' => 'http://zgubieni.wikia.com/en/wiki/London' ], [] ];
+		yield [ [
+			'REQUEST_SCHEME' => 'http',
+			'SERVER_NAME' => 'badwiki.wikia.com',
+			'REQUEST_URI' => '/wiki/Foo',
+		], [] ];
+		yield [ [
+			'REQUEST_SCHEME' => 'http',
+			'SERVER_NAME' => 'poznan.wikia.com',
+			'REQUEST_URI' => '/de/wiki/Posen',
+		], [] ];
+		yield [ [
+			'REQUEST_SCHEME' => 'http',
+			'SERVER_NAME' => 'zgubieni.wikia.com',
+			'REQUEST_URI' => '/en/wiki/London',
+		], [] ];
 	}
 
 	/**
 	 * @dataProvider provideWikisMarkedForClosing
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
-	 * 
+	 *
 	 * @param array $server
 	 */
 	public function testReturnsFalseAndRedirectsWhenWikiIsMarkedForClosing( array $server ) {
@@ -130,10 +206,18 @@ class WikiFactoryLoaderIntegrationTest extends WikiaDatabaseTest {
 		$this->assertFalse( $result );
 		$this->assertContains( 'X-Redirected-By-WF: MarkedForClosing', $headers );
 	}
-	
+
 	public function provideWikisMarkedForClosing() {
-		yield [ [ 'SERVER_NAME' => 'zamkniete.wikia.com', 'REQUEST_URI' => 'http://zamkniete.wikia.com/api.php' ] ];
-		yield [ [ 'SERVER_NAME' => 'spamtest.wikia.com', 'REQUEST_URI' => 'http://spamtest.wikia.com/wiki/Foo' ] ];
+		yield [ [
+			'REQUEST_SCHEME' => 'http',
+			'SERVER_NAME' => 'zamkniete.wikia.com',
+			'REQUEST_URI' => '/api.php',
+		] ];
+		yield [ [
+			'REQUEST_SCHEME' => 'http',
+			'SERVER_NAME' => 'spamtest.wikia.com',
+			'REQUEST_URI' => '/wiki/Foo',
+		] ];
 	}
 
 	/**
@@ -154,8 +238,16 @@ class WikiFactoryLoaderIntegrationTest extends WikiaDatabaseTest {
 	}
 
 	public function provideDisabledWikis() {
-		yield [ [ 'SERVER_NAME' => 'rekt.wikia.com', 'REQUEST_URI' => 'http://rekt.wikia.com/wiki/No_page' ] ];
-		yield [ [ 'SERVER_NAME' => 'dead.wikia.com', 'REQUEST_URI' => 'http://dead.wikia.com/wiki/Special:Version' ] ];
+		yield [ [
+			'REQUEST_SCHEME' => 'http',
+			'SERVER_NAME' => 'rekt.wikia.com',
+			'REQUEST_URI' => '/wiki/No_page',
+		] ];
+		yield [ [
+			'REQUEST_SCHEME' => 'http',
+			'SERVER_NAME' => 'dead.wikia.com',
+			'REQUEST_URI' => '/wiki/Special:Version',
+		] ];
 	}
 
 	/**
@@ -178,10 +270,26 @@ class WikiFactoryLoaderIntegrationTest extends WikiaDatabaseTest {
 	}
 
 	public function provideRedirectWikiRequests() {
-		yield [ [ 'SERVER_NAME' => 'redirect.wikia.com', 'REQUEST_URI' => 'http://redirect.wikia.com/wiki/Test_redirect' ] ];
-		yield [ [ 'SERVER_NAME' => 'redirect2.wikia.com', 'REQUEST_URI' => 'http://redirect2.wikia.com/wikia.php' ] ];
-		yield [ [ 'SERVER_NAME' => 'redirect.wikia.com', 'REQUEST_URI' => 'http://redirect.wikia.com/en/wiki/Test_redirect' ] ];
-		yield [ [ 'SERVER_NAME' => 'redirect2.wikia.com', 'REQUEST_URI' => 'http://redirect2.wikia.com/en/wikia.php' ] ];
+		yield [ [
+			'REQUEST_SCHEME' => 'http',
+			'SERVER_NAME' => 'redirect.wikia.com',
+			'REQUEST_URI' => '/wiki/Test_redirect',
+		] ];
+		yield [ [
+			'REQUEST_SCHEME' => 'http',
+			'SERVER_NAME' => 'redirect2.wikia.com',
+			'REQUEST_URI' => '/wikia.php',
+		] ];
+		yield [ [
+			'REQUEST_SCHEME' => 'http',
+			'SERVER_NAME' => 'redirect.wikia.com',
+			'REQUEST_URI' => '/en/wiki/Test_redirect',
+		] ];
+		yield [ [
+			'REQUEST_SCHEME' => 'http',
+			'SERVER_NAME' => 'redirect2.wikia.com',
+			'REQUEST_URI' => '/en/wikia.php',
+		] ];
 	}
 
 	/**
@@ -239,8 +347,16 @@ class WikiFactoryLoaderIntegrationTest extends WikiaDatabaseTest {
 	}
 
 	public function providePrecedence() {
-		yield 'Request info takes precedence over SERVER_ID' => [ 9, [ 'SERVER_ID' => 1 ], [ 'SERVER_NAME' => 'poznan.wikia.com', 'REQUEST_URI'	=> 'http://poznan.wikia.com/' ] ];
-		yield 'Request info takes precedence over SERVER_DBNAME' => [ 9, [ 'SERVER_DBNAME' => 'test1' ], [ 'SERVER_NAME' => 'poznan.wikia.com', 'REQUEST_URI' => 'http://poznan.wikia.com/' ] ];
+		yield 'Request info takes precedence over SERVER_ID' => [ 9, [ 'SERVER_ID' => 1 ], [
+			'REQUEST_SCHEME' => 'http',
+			'SERVER_NAME' => 'poznan.wikia.com',
+			'REQUEST_URI' => '/',
+		] ];
+		yield 'Request info takes precedence over SERVER_DBNAME' => [ 9, [ 'SERVER_DBNAME' => 'test1' ], [
+			'REQUEST_SCHEME' => 'http',
+			'SERVER_NAME' => 'poznan.wikia.com',
+			'REQUEST_URI' => '/',
+		] ];
 		yield 'SERVER_ID takes precedence over SERVER_DBNAME' => [ 1, [ 'SERVER_ID' => 1, 'SERVER_DBNAME' => 'poznan' ], [] ];
 	}
 


### PR DESCRIPTION
When accessing a thread page on a language path wiki, a redirect to
the main page of the root (non-language path) wiki occurred, i.e.
`https://some-example.wikia.com/szl/wiki/Thread:24` would redirect
to `https://some-example.wikia.com/wiki/Main_Page`.

This was caused by using PHP's `parse_url` on a relative URL to get the
URL path. Most of the time this works fine, but if the relative URL
resembles the use of a port in a URL, it fails. For example:

    > var_dump( parse_url( '/szl/wiki/Thread:Foo', PHP_URL_PATH ) );
    string(20) "/szl/wiki/Thread:Foo"

    > var_dump( parse_url( '/szl/wiki/Thread:24', PHP_URL_PATH ) );
    bool(false)

As a result, the language code in the path was not parsed and the code
behaved as if it was on the root wiki. Putting anything after the path
allows this to work as expected:

    > var_dump( parse_url( '/szl/wiki/Thread:24?', PHP_URL_PATH ) );
    string(19) "/szl/wiki/Thread:24"

Similarly, changing the URL to the thread page to add anything after the
number, i.e. `https://some-example.wikia.com/szl/wiki/Thread:24?`, would
prevent the redirect bug.

This is due to a bug in the PHP `parse_url` function when handling relative
URLs with a port-like string: https://bugs.php.net/bug.php?id=71646 In order
to work around the bug, we can simply provide a full URL to the parse_url
method, rather than the relative URL.