### PR TITLE
SUS-926 | Pressing enter when choosing a name on Special:CreatePage/CreateBlogPage submits the (empty) page, not the dialog

### DIFF
--- a/extensions/wikia/EditPageLayout/js/plugins/PageControls.js
+++ b/extensions/wikia/EditPageLayout/js/plugins/PageControls.js
@@ -265,6 +265,9 @@
 					$('#HiddenFieldsDialog input[name="wpTitle"]').keypress(function (event) {
 						if (event.keyCode == 13) {
 							$('#ok').click();
+
+							// SUS-926 | do not submit the entire edit page
+							event.preventDefault();
 						}
 					});
 				},


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-926