### PR TITLE
SUS-4746 | MathJax's SVG renderer always outputs black text

### DIFF
--- a/extensions/Math/Math.php
+++ b/extensions/Math/Math.php
@@ -132,6 +132,9 @@ $wgResourceModules['ext.math.mathjax'] = array(
 		// We'll let the other parts be loaded by MathJax's
 		// own module/config loader.
 	),
+	'styles' => [
+		'MathJax.css',
+	],
 	'group' => 'ext.math.mathjax',
 ) + $moduleTemplate;
 

--- a/extensions/Math/modules/MathJax.css
+++ b/extensions/Math/modules/MathJax.css
@@ -1,0 +1,7 @@
+/**
+ * SUS-4746 | MathJax's SVG renderer always outputs black text
+ */
+.MathJax_SVG > svg > g {
+    fill: currentColor;
+    stroke: currentColor;
+}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-4746

Tested on http://macbre.macbre.wikia-dev.pl/wiki/Math