### PR TITLE
SUS-4757 - make MathRenderer::getRenderer always return an instance of MathRenderer

### DIFF
--- a/extensions/Math/MathRenderer.php
+++ b/extensions/Math/MathRenderer.php
@@ -70,16 +70,17 @@ abstract class MathRenderer {
 	 * @param int $mode constant indicating rendering mode
 	 * @return MathRenderer appropriate renderer for mode
 	 */
-	public static function getRenderer( $tex, $params = array(),  $mode = MW_MATH_PNG ) {
+	public static function getRenderer( $tex, $params = array(),  $mode = MW_MATH_MATHJAX ) : MathRenderer {
 		global $wgDefaultUserOptions;
-		$validModes = array( MW_MATH_PNG, MW_MATH_SOURCE, MW_MATH_MATHJAX );
-		if ( !in_array( $mode, $validModes ) )
+		if ( !in_array( $mode, [ MW_MATH_SOURCE, MW_MATH_MATHJAX ] ) )
 			$mode = $wgDefaultUserOptions['math'];
+
 		switch ( $mode ) {
 			case MW_MATH_SOURCE:
 				$renderer = new MathSource( $tex, $params );
 				break;
 			case MW_MATH_MATHJAX:
+			default:
 				$renderer = new MathMathJax( $tex, $params );
 				break;
 		}

--- a/extensions/Math/MathRenderer.php
+++ b/extensions/Math/MathRenderer.php
@@ -80,7 +80,7 @@ abstract class MathRenderer {
 				$renderer = new MathSource( $tex, $params );
 				break;
 			case MW_MATH_MATHJAX:
-			default:
+			default: // SUS-4757 - always return a renderer instance
 				$renderer = new MathMathJax( $tex, $params );
 				break;
 		}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-4757

Fallback to `MW_MATH_MATHJAX` if we get a no longer supported value from `$wgDefaultUserOptions['math']` (which can be customized via WikiFactory). This variable was set to an invalid value on uncyclo causing a huge amount of fatal errors there.

