### PR TITLE
SUS-4749 | enable new memcache client on 50% of production requests

### DIFF
--- a/includes/DefaultSettings.php
+++ b/includes/DefaultSettings.php
@@ -1527,8 +1527,8 @@ $wgObjectCaches = array(
 			// use a new memcached-based client on sandboxes and devboxes
 			? 'MemcachedPeclBagOStuff'
 			// use an old memcache-client on production
-			// (and enable the new one on 25% of all requests)
-			: ( mt_rand(0, 100) < 25 ? 'MemcachedPeclBagOStuff' : 'MemcachedPhpBagOStuff' ),
+			// (and enable the new one on 50% of all requests)
+			: ( mt_rand(0, 100) < 50 ? 'MemcachedPeclBagOStuff' : 'MemcachedPhpBagOStuff' ),
 		'use_binary_protocol' => false, // twemproxy does not support binary protocol
 	],
 


### PR DESCRIPTION
Gradually enable a new memcache client introduced in #15226

> **Due to incompatibility of serialization of non-scalar types** between new and old client we'd need to introduce a key prefix for a new client (that's a part of this PR). In order to avoid a flood of cache misses after production deploy we need to start enabling the new client on a small fraction of production requests first.

See #15254 for a previous step