### PR TITLE
🐷-4760 | fix typo in 2011 memcached sessions code

### DIFF
--- a/includes/cache/MemcachedSessions.php
+++ b/includes/cache/MemcachedSessions.php
@@ -121,11 +121,10 @@ function &getMemc() {
 	global $wgSessionMemCachedServers, $wgMemc, $wgSessionMemc;
 	global $wgMemCachedPersistent, $wgMemCachedDebug;
 
-	if( !empty( $wgSessionMemCachedServers ) && is_array( $wgSessionMemCachedServers ) && class_exists( 'MemcachedClientforWiki' ) ) {
+	if( !empty( $wgSessionMemCachedServers ) && is_array( $wgSessionMemCachedServers ) ) {
 		if( !empty( $wgSessionMemc ) && is_object( $wgSessionMemc ) && $wgSessionMemc instanceof MemCachedClientforWiki ) {
 			return $wgSessionMemc;
-		}
-		else {
+		} else {
 			$wgSessionMemc = new MemCachedClientforWiki(
 				array( 'persistant' => $wgMemCachedPersistent, 'compress_threshold' => 1500 ) );
 			$wgSessionMemc->set_servers( $wgSessionMemCachedServers );
@@ -133,8 +132,7 @@ function &getMemc() {
 
 			return $wgSessionMemc;
 		}
-	}
-	else {
+	} else {
 		return $wgMemc;
 	}
 }


### PR DESCRIPTION
PHP `class_exists` check will return `false` if you query for a class name with incorrect capitalization, but it will return `true` if the class was already loaded by someone else:

```
> var_dump(class_exists( 'MemcachedClientforWiki' ));
/usr/wikia/source/app/maintenance/eval.php(88) : eval()'d code:1:
bool(false)

> var_dump(class_exists( 'MemCachedClientforWiki' ));
/usr/wikia/source/app/maintenance/eval.php(88) : eval()'d code:1:
bool(true)

> var_dump(class_exists( 'MemcachedClientforWiki' ));
/usr/wikia/source/app/maintenance/eval.php(88) : eval()'d code:1:
bool(true)
```

Because of this we started randomly falling back to `wgMemc` 50% of the time when it was using PECL client instead of old PHP client—in that case PHP client was not autoloaded so the check failed, and session was lost.

https://wikia-inc.atlassian.net/browse/SUS-4760