### PR TITLE
SUS-4761 | cache not set WikiFactory variables in WikiFactory::loadVariableFromDB

### DIFF
--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -2107,11 +2107,11 @@ class WikiFactory {
 		}
 
 		if ( !empty( $city_id ) ) {
-			$oRow2 = WikiaDataAccess::cache(
+			$oRow = WikiaDataAccess::cache(
 				static::getVarValueKey( $city_id, $oRow->cv_id ),
 				WikiaResponse::CACHE_STANDARD,
 				function() use ($dbr, $oRow, $city_id, $fname) {
-					return $dbr->selectRow(
+					$row = $dbr->selectRow(
 						[ "city_variables" ],
 						[
 							"cv_city_id",
@@ -2124,20 +2124,18 @@ class WikiFactory {
 						],
 						$fname
 					);
+
+					// SUS-4761 | variable is NOT set in database, still cache it
+					if ( !isset( $row->cv_variable_id ) ) {
+						$row = new stdClass();
+						$row->cv_city_id = $city_id;
+						$row->cv_variable_id = $oRow->cv_id;
+						$row->cv_value = null;
+					}
+
+					return $row;
 				}
 			);
-
-			if ( isset( $oRow2->cv_variable_id ) ) {
-
-				$oRow->cv_city_id = $oRow2->cv_city_id;
-				$oRow->cv_variable_id = $oRow2->cv_variable_id;
-				$oRow->cv_value = $oRow2->cv_value;
-			}
-			else {
-				$oRow->cv_city_id = $city_id;
-				$oRow->cv_variable_id = $oRow->cv_id;
-				$oRow->cv_value = null;
-			}
 		}
 		else {
 			$oRow->cv_city_id = null;

--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -2106,7 +2106,7 @@ class WikiFactory {
 			return null;
 		}
 
-		$oRow = WikiaDataAccess::cache(
+		$oVariableValue = WikiaDataAccess::cache(
 			static::getVarValueKey( $city_id, $oRow->cv_id ),
 			WikiaResponse::CACHE_STANDARD,
 			function() use ($dbr, $oRow, $city_id, $fname) {
@@ -2135,6 +2135,11 @@ class WikiFactory {
 				return $row;
 			}
 		);
+
+		// merge variable value with variable's metadata
+		$oRow->cv_city_id = $oVariableValue->cv_city_id;
+		$oRow->cv_variable_id = $oVariableValue->cv_variable_id;
+		$oRow->cv_value = $oVariableValue->cv_value;
 
 		wfProfileOut( __METHOD__ );
 		return $oRow;

--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -2106,42 +2106,35 @@ class WikiFactory {
 			return null;
 		}
 
-		if ( !empty( $city_id ) ) {
-			$oRow = WikiaDataAccess::cache(
-				static::getVarValueKey( $city_id, $oRow->cv_id ),
-				WikiaResponse::CACHE_STANDARD,
-				function() use ($dbr, $oRow, $city_id, $fname) {
-					$row = $dbr->selectRow(
-						[ "city_variables" ],
-						[
-							"cv_city_id",
-							"cv_variable_id",
-							"cv_value"
-						],
-						[
-							"cv_variable_id" => $oRow->cv_id,
-							"cv_city_id" => $city_id
-						],
-						$fname
-					);
+		$oRow = WikiaDataAccess::cache(
+			static::getVarValueKey( $city_id, $oRow->cv_id ),
+			WikiaResponse::CACHE_STANDARD,
+			function() use ($dbr, $oRow, $city_id, $fname) {
+				$row = $dbr->selectRow(
+					[ "city_variables" ],
+					[
+						"cv_city_id",
+						"cv_variable_id",
+						"cv_value"
+					],
+					[
+						"cv_variable_id" => $oRow->cv_id,
+						"cv_city_id" => $city_id
+					],
+					$fname
+				);
 
-					// SUS-4761 | variable is NOT set in database, still cache it
-					if ( !isset( $row->cv_variable_id ) ) {
-						$row = new stdClass();
-						$row->cv_city_id = $city_id;
-						$row->cv_variable_id = $oRow->cv_id;
-						$row->cv_value = null;
-					}
-
-					return $row;
+				// SUS-4761 | variable is NOT set in database, still cache it
+				if ( !isset( $row->cv_variable_id ) ) {
+					$row = new stdClass();
+					$row->cv_city_id = $city_id;
+					$row->cv_variable_id = $oRow->cv_id;
+					$row->cv_value = null;
 				}
-			);
-		}
-		else {
-			$oRow->cv_city_id = null;
-			$oRow->cv_variable_id = $oRow->cv_id;
-			$oRow->cv_value = null;
-		}
+
+				return $row;
+			}
+		);
 
 		wfProfileOut( __METHOD__ );
 		return $oRow;


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-4761

Set memcache entry every time we git a cache miss in `WikiFactory::loadVariableFromDB`, even if the variable is not set. This will prevent the flood of DB queries like the following one:

```sql
SELECT /* WikiFactory::loadVariableFromDB (from WikiFactoryLoader:checkPerClusterReadOnlyFlag)  - 1be9ddb1-482a-4d38-80bb-b92cbebb1e49 */  cv_city_id,cv_variable_id,cv_value  FROM `city_variables`  WHERE cv_variable_id = '1735' AND cv_city_id = '177'  LIMIT 1
```

`wgReadOnlyCluster` is only set when we need to put a given cluster in read-only mode.

The following object will be cached when the variable is not set on a given wiki (`cv_value` entry will be set to `NULL`):

```
> var_dump( $wgMemc->get('wikicities:wikifactory:variables:value:v5:5915:555') )
memcached: get(wikicities:wikifactory:variables:value:v5:5915:555)
/usr/wikia/source/deploytools/18879/src/maintenance/eval.php(88) : eval()'d code:1:
class stdClass#104 (10) {
  public $cv_id =>
  string(3) "555"
  public $cv_name =>
  string(14) "wgDefaultTheme"
  public $cv_description =>
  string(28) "Default theme for wikia skin"
  public $cv_variable_type =>
  string(6) "string"
  public $cv_variable_group =>
  string(2) "11"
  public $cv_access_level =>
  string(1) "2"
  public $cv_is_unique =>
  string(1) "0"
  public $cv_city_id =>
  string(4) "5915"
  public $cv_variable_id =>
  string(3) "555"
  public $cv_value =>
  string(15) "s:8:"sapphire";"
}
```