### PR TITLE
SUS-4758 | Fix Community Page performance problems

### DIFF
--- a/extensions/wikia/CommunityPage/models/CommunityPageSpecialInsightsModel.class.php
+++ b/extensions/wikia/CommunityPage/models/CommunityPageSpecialInsightsModel.class.php
@@ -50,10 +50,16 @@ class CommunityPageSpecialInsightsModel {
 	 *  - should display page views on list
 	 *  - how data should be sorted (@see InsightsSorting::$sorting)
 	 * @return array Insight Module
+	 * @throws MWException
 	 */
 	private function getInsightModule( $type, $config ) {
-		$insightPages = $this->insightsService->getInsightPages(
-			$type,
+		$model = InsightsHelper::getInsightModel( $type );
+
+		// SUS-4758: we don't need to load page view data
+		$model->getConfig()->setShowPageViews( false );
+
+		$insightPages = $this->insightsService->getInsightPagesForModel(
+			$model,
 			static::INSIGHTS_MODULE_ITEMS,
 			static::RANDOM_SORTING_TYPE
 		);

--- a/extensions/wikia/InsightsV2/helpers/InsightsConfig.php
+++ b/extensions/wikia/InsightsV2/helpers/InsightsConfig.php
@@ -60,6 +60,10 @@ class InsightsConfig {
 		}
 	}
 
+	public function setShowPageViews( bool $pageViews ) {
+		$this->pageViews = $pageViews;
+	}
+
 	public function showPageViews() {
 		return $this->pageViews;
 	}

--- a/extensions/wikia/InsightsV2/services/InsightsService.class.php
+++ b/extensions/wikia/InsightsV2/services/InsightsService.class.php
@@ -12,7 +12,13 @@ class InsightsService {
 		if ( !InsightsHelper::isInsightPage( $type ) ) {
 			return [];
 		}
+
 		$model = InsightsHelper::getInsightModel( $type );
+
+		return $this->getInsightPagesForModel( $model, $size, $sortingType );
+	}
+
+	public function getInsightPagesForModel( InsightsModel $model, $size, $sortingType ): array {
 		$insightData = ( new InsightsContext( $model ) )->fetchData();
 
 		if ( empty( $insightData ) ) {
@@ -33,11 +39,12 @@ class InsightsService {
 				$insightData,
 				[ 'sort' => $sortingType ]
 			);
-		$aritclesIds = array_slice( $sortedInsightArticleIds, 0, $size );
+
+		$articleIds = array_slice( $sortedInsightArticleIds, 0, $size );
 
 		return [
 			'count' => $insightCount,
-			'pages' => $this->getArticlesData( $insightData, $aritclesIds )
+			'pages' => $this->getArticlesData( $insightData, $articleIds )
 		];
 	}
 


### PR DESCRIPTION
Don't try to load expensive page views data for Community Page card modules, we don't need it.

As we're here: optimize [a problematic query](http://opstools-s1/anemometer/index.php?action=show_query&datasource=localhost&checksum=40F42BE62CA45FF8)

**Before**
```
+----+-------------+----------+------------+-------+----------------+----------------+---------+-----+-------+----------+--------------------------------------------------------+
| id | select_type | table    | partitions | type  | possible_keys  | key            | key_len | ref | rows  | filtered | Extra                                                  |
+----+-------------+----------+------------+-------+----------------+----------------+---------+-----+-------+----------+--------------------------------------------------------+
| 1  | SIMPLE      | revision |            | range | user_timestamp | user_timestamp | 18      |     | 26724 | 100.00   | Using index condition; Using temporary; Using filesort |
+----+-------------+----------+------------+-------+----------------+----------------+---------+-----+-------+----------+--------------------------------------------------------+
```
**After**
```
mysql@geo-db-g-slave.query.consul[mopeio]>explain select rev_user, MAX(rev_timestamp) AS latest_revision from revision WHERE rev_user <> '0'  AND rev_user IN ( '26900200', '26806340', '30691033', '31984232', '32420137' )  AND rev_user NOT IN ( '22439', '33115', '49312', '62433', '375130', '454642', '926128', '929702', '1481893', '1699056', '1724320', '1907256', '2137136', '3288694', '3504909', '3532335', '4403388', '4602158', '4663069', '5028050', '5036166', '10429353', '26120316', '27362472', '30252127', '31834486', '32769624', '32794352', '34480145' )  AND rev_timestamp > '2016-05-09' GROUP BY rev_user;
+----+-------------+----------+------------+-------+------------------------------+----------------+---------+------+------+----------+---------------------------------------+
| id | select_type | table    | partitions | type  | possible_keys                | key            | key_len | ref  | rows | filtered | Extra                                 |
+----+-------------+----------+------------+-------+------------------------------+----------------+---------+------+------+----------+---------------------------------------+
|  1 | SIMPLE      | revision | NULL       | range | rev_timestamp,user_timestamp | user_timestamp | 4       | NULL |   42 |    50.00 | Using where; Using index for group-by |
+----+-------------+----------+------------+-------+------------------------------+----------------+---------+------+------+----------+---------------------------------------+
1 row in set, 1 warning (0.00 sec)
```

https://wikia-inc.atlassian.net/browse/SUS-4758
