### PR TITLE
SUS-4763 | CloseWiki maintenance script - improve logging

### DIFF
--- a/extensions/wikia/WikiFactory/Close/README.md
+++ b/extensions/wikia/WikiFactory/Close/README.md
@@ -10,7 +10,7 @@ Logs can be found on `cron-s1` in ` /var/log/crons/closeMarkedWikis.log`.
 ### SQL query
 
 ```sql
-mysql@geo-db-sharedb-slave.query.consul[wikicities]>select count(*) from city_list where city_public IN (0 /* close */, -1 /* hide */) and city_flags NOT IN (0, 32 /* redirect */) and city_dbname not like '%qatest%' and city_last_timestamp < now() - interval 30 day;
+mysql@geo-db-sharedb-slave.query.consul[wikicities]>select count(*) from city_list where city_public IN (0 /* close */, -1 /* hide */) and city_flags NOT IN (0, 32 /* redirect */, 512 /* do not close */) and city_dbname not like '%qatest%' and city_last_timestamp < now() - interval 30 day;
 +----------+
 | count(*) |
 +----------+

--- a/extensions/wikia/WikiFactory/Close/maintenance.php
+++ b/extensions/wikia/WikiFactory/Close/maintenance.php
@@ -34,14 +34,6 @@ class CloseWikiMaintenance {
 	}
 
 	/**
-	 * @param string $msg
-	 * @param array $context
-	 */
-	private function info( $msg, Array $context = [] ) {
-		\Wikia\Logger\WikiaLogger::instance()->info( $msg, $context );
-	}
-
-	/**
 	 * 1. go through all wikis which are marked for closing and check which one
 	 * 	want to have images packed.
 	 *
@@ -91,7 +83,7 @@ class CloseWikiMaintenance {
 		$dbr = WikiFactory::db( DB_SLAVE );
 		$sth = $dbr->select(
 			array( "city_list" ),
-			array( "city_id", "city_flags", "city_dbname", "city_cluster", "city_url", "city_public" ),
+			array( "city_id", "city_flags", "city_dbname", "city_cluster", "city_url", "city_public", "city_last_timestamp" ),
 			$where,
 			__METHOD__,
 			$opts
@@ -133,7 +125,8 @@ class CloseWikiMaintenance {
 				echo "{$dbname} is not unique. Check city_list and rerun script";
 				die( 1 );
 			}
-			$this->log( "city_id={$row->city_id} city_cluster={$cluster} city_url={$row->city_url} city_dbname={$dbname} city_flags={$row->city_flags} city_public={$row->city_public}" );
+
+			$this->log( "city_id={$row->city_id} city_cluster={$cluster} city_url={$row->city_url} city_dbname={$dbname} city_flags={$row->city_flags} city_public={$row->city_public} city_last_timestamp={$row->city_last_timestamp}" );
 
 			/**
 			 * request for dump on remote server (now hardcoded for Iowa)
@@ -517,7 +510,18 @@ class CloseWikiMaintenance {
 	}
 
 	private function log( string $message ) {
-		WikiaLogger::instance()->info( $message );
+		$this->info( $message );
+	}
+
+	/**
+	 * @param string $msg
+	 * @param array $context
+	 */
+	private function info( string $msg, array $context = [] ) {
+		// send logs to stdout as well
+		Wikia::log( __CLASS__, false, $msg, true, true );
+
+		\Wikia\Logger\WikiaLogger::instance()->info( $msg, $context );
 	}
 
 	private function removeDiscussions( int $cityId ) {

--- a/extensions/wikia/WikiFactory/Close/maintenance.php
+++ b/extensions/wikia/WikiFactory/Close/maintenance.php
@@ -111,21 +111,6 @@ class CloseWikiMaintenance {
 			$cluster  = $row->city_cluster;
 			$folder   = WikiFactory::getVarValueByName( "wgUploadDirectory", $cityid );
 
-			/**
-			 * safety check, if city_dbname is not unique die with message
-			 */
-			$check = $dbr->selectRow(
-				array( "city_list" ),
-				array( "count(*) as count" ),
-				array( "city_dbname" => $dbname ),
-				__METHOD__,
-				array( "GROUP BY" => "city_dbname" )
-			);
-			if( $check->count > 1 ) {
-				echo "{$dbname} is not unique. Check city_list and rerun script";
-				die( 1 );
-			}
-
 			$this->log( "city_id={$row->city_id} city_cluster={$cluster} city_url={$row->city_url} city_dbname={$dbname} city_flags={$row->city_flags} city_public={$row->city_public} city_last_timestamp={$row->city_last_timestamp}" );
 
 			/**


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-4763

Log more stuff from the script

```
macbre@cron-s1:~/app/extensions/wikia/WikiFactory/Close$ sudo -u release SERVER_ID=177 php maintenance.php --sleep=1 --limit=5
2018-05-10 07:41:48 CloseWikiMaintenance:wikia/177: start
2018-05-10 07:41:48 CloseWikiMaintenance:wikia/177: wikis to remove
2018-05-10 07:41:48 CloseWikiMaintenance:wikia/177: Wikis to remove: 5
2018-05-10 07:41:48 CloseWikiMaintenance:wikia/177: SELECT  city_id,city_flags,city_dbname,city_cluster,city_url,city_public,city_last_timestamp  FROM `city_list`  WHERE city_public IN ('0','-1')  AND (city_flags <> 0) AND (city_flags <> 32) AND (city_last_timestamp < '2018-04-10 07:41:48')  ORDER BY city_id LIMIT 5  
2018-05-10 07:41:48 CloseWikiMaintenance:wikia/177: Will start in 5 seconds...
...
```