### PR TITLE
SUS-4773: Don't use REPLACE for updating edit counts

### DIFF
--- a/includes/wikia/WikiaUpdater.php
+++ b/includes/wikia/WikiaUpdater.php
@@ -52,6 +52,7 @@ class WikiaUpdater {
 			array( 'dropIndex', 'wall_related_pages', 'comment_id_idx',  $dir . 'patch-wall_related_pages-drop-comment_id_idx.sql', true ), // SUS-3096
 			array( 'dropIndex', 'wall_related_pages', 'page_id_idx_2',  $dir . 'patch-wall_related_pages-drop-page_id_idx_2.sql', true ), // SUS-3096
 			array( 'dropIndex', 'video_info', 'added_at',  $dir . 'patch-video_info-drop-added_at_idx.sql', true ), // SUS-4297
+			array( 'dropIndex', 'wikia_user_properties', 'wup_user', $dir . 'patch-wikia-user-properties-pk.sql', true ),
 
 			# functions
 			array( 'WikiaUpdater::do_page_wikia_props_update' ),
@@ -324,7 +325,7 @@ class WikiaUpdater {
 		$databaseUpdater->output( 'Adding default empty value to rc_user_text column... ' );
 		$databaseConnection->sourceFile( $patchDir . 'patch-rc_user_text-default.sql' );
 		$databaseUpdater->output( "done.\n" );
-		
+
 		wfWaitForSlaves();
 	}
 

--- a/includes/wikia/services/UserStatsService.class.php
+++ b/includes/wikia/services/UserStatsService.class.php
@@ -196,13 +196,15 @@ class UserStatsService extends WikiaModel {
 		// SUS-4773: In the vast majority of cases the above UPDATE will have handled setting proper edit count
 		// We only need to INSERT if this is the user's first edit on this wiki
 		if ( !$dbw->affectedRows() ) {
-			$dbw->insert(
+			$dbw->upsert(
 				'wikia_user_properties',
 				[
 					 'wup_user' => $this->userId,
 					 'wup_property' => $statName,
 					 'wup_value' => $statVal
 				 ],
+				[ [ 'wup_user', 'wup_property' ] ],
+				[ 'wup_value = wup_value + 1' ],
 				__METHOD__
 			);
 		}

--- a/includes/wikia/tests/UserStatsServiceIntegrationTest.php
+++ b/includes/wikia/tests/UserStatsServiceIntegrationTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * @group Integration
+ */
+class UserStatsServiceIntegrationTest extends WikiaDatabaseTest {
+
+	const USER_NO_EDITS_ID = 1;
+	const USER_WITH_EDITS_ID = 2;
+
+	public function testEditCountSetToOneOnFirstLocalEditOfUser() {
+		$userStatsService = new UserStatsService( static::USER_NO_EDITS_ID );
+
+		$stats = $userStatsService->getStats();
+
+		$this->assertNull( $stats['firstContributionTimestamp'] );
+		$this->assertNull( $stats['lastContributionTimestamp'] );
+		$this->assertEquals( 0, $stats['editcount'] );
+		$this->assertEquals( 0, $stats['editcountThisWeek'] );
+
+		$userStatsService->increaseEditsCount();
+
+		$stats = $userStatsService->getStats();
+
+		$this->assertEquals( 1, $stats['editcount'] );
+		$this->assertEquals( 1, $stats['editcountThisWeek'] );
+
+		$now = ( new DateTime() )->format( 'Y-m-d H:i' );
+
+		$firstContributionDate = new DateTime( $stats['firstContributionTimestamp'] );
+		$lastContributionDate = new DateTime( $stats['lastContributionTimestamp'] );
+
+		$this->assertEquals( $now, $firstContributionDate->format( 'Y-m-d H:i' ) );
+		$this->assertEquals( $now, $lastContributionDate->format( 'Y-m-d H:i' ) );
+	}
+
+	public function testEditCountIncrementedWhenUserAlreadyHasLocalEdits() {
+		$userStatsService = new UserStatsService( static::USER_WITH_EDITS_ID );
+
+		$stats = $userStatsService->getStats();
+
+		$this->assertEquals( '20110101000000', $stats['firstContributionTimestamp'] );
+		$this->assertEquals( '20180501120000', $stats['lastContributionTimestamp'] );
+		$this->assertEquals( 4, $stats['editcount'] );
+		$this->assertEquals( 3, $stats['editcountThisWeek'] );
+
+		$userStatsService->increaseEditsCount();
+
+		$stats = $userStatsService->getStats();
+
+		$this->assertEquals( 5, $stats['editcount'] );
+		$this->assertEquals( 4, $stats['editcountThisWeek'] );
+
+		$now = ( new DateTime() )->format( 'Y-m-d H:i' );
+
+		$lastContributionDate = new DateTime( $stats['lastContributionTimestamp'] );
+
+		$this->assertEquals( '20110101000000', $stats['firstContributionTimestamp'] );
+		$this->assertEquals( $now, $lastContributionDate->format( 'Y-m-d H:i' ) );
+	}
+
+	public function testEditCountNotSetForAnonUser() {
+		$userStatsService = new UserStatsService( 0 );
+
+		$stats = $userStatsService->getStats();
+
+		$this->assertNull( $stats['firstContributionTimestamp'] );
+		$this->assertNull( $stats['lastContributionTimestamp'] );
+		$this->assertEquals( 0, $stats['editcount'] );
+		$this->assertEquals( 0, $stats['editcountThisWeek'] );
+
+		$userStatsService->increaseEditsCount();
+
+		$stats = $userStatsService->getStats();
+
+		$this->assertNull( $stats['firstContributionTimestamp'] );
+		$this->assertNull( $stats['lastContributionTimestamp'] );
+		$this->assertEquals( 0, $stats['editcount'] );
+		$this->assertEquals( 0, $stats['editcountThisWeek'] );
+	}
+
+	protected function getDataSet() {
+		return $this->createYamlDataSet( __DIR__ . '/_fixtures/user_stats_service.yaml' );
+	}
+}

--- a/includes/wikia/tests/_fixtures/user_stats_service.yaml
+++ b/includes/wikia/tests/_fixtures/user_stats_service.yaml
@@ -1,0 +1,20 @@
+user:
+  - user_id: 1
+    user_name: 'UserStatsUser'
+    user_email: 'kossuth.lajos@lajoskossuth.hu'
+  - user_id: 2
+    user_name: 'UserStatsUserWithEdits'
+    user_email: 'jozsef.attila@attilajozsef.hu'
+wikia_user_properties:
+  - wup_user: 2
+    wup_property: editcount
+    wup_value: 4
+  - wup_user: 2
+    wup_property: editcountThisWeek
+    wup_value: 3
+  - wup_user: 2
+    wup_property: firstContributionTimestamp
+    wup_value: 20110101000000
+  - wup_user: 2
+    wup_property: lastContributionTimestamp
+    wup_value: 20180501120000

--- a/includes/wikia/tests/core/WikiaDatabaseTest.php
+++ b/includes/wikia/tests/core/WikiaDatabaseTest.php
@@ -45,6 +45,8 @@ abstract class WikiaDatabaseTest extends TestCase {
 		static::loadSchemaFile( "$IP/tests/fixtures/specials.sql" );
 		static::loadSchemaFile( "$IP/tests/fixtures/wikicities.sql" );
 
+		static::loadSchemaFile( "$IP/maintenance/wikia/wikia_user_properties.sql" );
+
 		// destroy leaked user accounts from other tests
 		User::$idCacheByName = [];
 		\Wikia\Factory\ServiceFactory::clearState();

--- a/maintenance/archives/wikia/patch-wikia-user-properties-pk.sql
+++ b/maintenance/archives/wikia/patch-wikia-user-properties-pk.sql
@@ -1,0 +1,12 @@
+-- set proper primary key for wikia_user_properties table
+DELETE FROM wikia_user_properties
+WHERE wup_property IS NULL;
+
+ALTER TABLE wikia_user_properties
+  MODIFY COLUMN wup_property VARBINARY(255) NOT NULL DEFAULT '';
+
+ALTER TABLE wikia_user_properties
+  ADD PRIMARY KEY (wup_user, wup_property);
+
+ALTER TABLE wikia_user_properties
+  DROP INDEX wup_user;

--- a/maintenance/wikia/wikia_user_properties.sql
+++ b/maintenance/wikia/wikia_user_properties.sql
@@ -6,11 +6,12 @@ CREATE TABLE /*$wgDBprefix*/wikia_user_properties (
   wup_user INT NOT NULL,
 
   -- Multiple key 2, name of property
-  wup_property VARBINARY(255) NULL DEFAULT NULL,
+  wup_property VARBINARY(255) NOT NULL DEFAULT '',
 
   -- Property value
-  wup_value BLOB NULL DEFAULT NULL
+  wup_value BLOB NULL DEFAULT NULL,
+
+  PRIMARY KEY (wup_user, wup_property)
 )/*$wgDBTableOptions*/;
 
-CREATE UNIQUE INDEX wup_user_property_idx ON wikia_user_properties(wup_user, wup_property);
 CREATE INDEX wup_property_idx ON wikia_user_properties(wup_property);

--- a/maintenance/wikia/wikia_user_properties.sql
+++ b/maintenance/wikia/wikia_user_properties.sql
@@ -9,8 +9,8 @@ CREATE TABLE /*$wgDBprefix*/wikia_user_properties (
   wup_property VARBINARY(255) NULL DEFAULT NULL,
 
   -- Property value
-  wup_value BLOB NULL DEFAULT NULL,
-
-  UNIQUE INDEX (wup_user, wup_property),
-  INDEX (wup_property)
+  wup_value BLOB NULL DEFAULT NULL
 )/*$wgDBTableOptions*/;
+
+CREATE UNIQUE INDEX wup_user_property_idx ON wikia_user_properties(wup_user, wup_property);
+CREATE INDEX wup_property_idx ON wikia_user_properties(wup_property);

--- a/tests/unit/ServiceTest.php
+++ b/tests/unit/ServiceTest.php
@@ -63,30 +63,6 @@ class ServiceTest extends WikiaBaseTest {
 		$this->assertTrue(empty($data));
 	}
 
-	/**
-	 * @group UsingDB
-	 */
-	function testUserStatsService() {
-		$this->markTestSkipped('This is not a unit test');
-
-		$user = User::newFromName('QATestsBot');
-
-		$service = new UserStatsService($user->getId());
-		$stats = $service->getStats();
-
-		$this->assertInternalType('int', $stats['edits']);
-		$this->assertInternalType('int', $stats['likes']);
-		$this->assertInternalType('string', $stats['date']);
-
-		// edits increase - perform fake edit
-		$edits = $stats['edits'];
-
-		$service->increaseEditsCount();
-
-		$stats = $service->getStats();
-		$this->assertEquals($edits+1, $stats['edits']);
-	}
-
 	function testCategoriesService() {
 		global $wgBiggestCategoriesBlacklist;
 


### PR DESCRIPTION
A [`REPLACE`](https://dev.mysql.com/doc/refman/5.7/en/replace.html) statement will attempt an `INSERT` then perform a `DELETE`+ `INSERT` in case of a duplicate key error:
>`REPLACE` works exactly like `INSERT`, except that if an old row in the table has the same value as a new row for a `PRIMARY KEY` or a `UNIQUE` index, the old row is deleted before the new row is inserted.

For our use case here this is suboptimal. The most common scenario is a simple `UPDATE` of already existing rows; an `INSERT` can only occur if this was the user's first edit on the given wiki. So let's optimize for that.

https://wikia-inc.atlassian.net/browse/SUS-4773