### PR TITLE
PLATFORM-3485: handle full address in REQUEST_URI

### DIFF
--- a/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
+++ b/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
@@ -71,7 +71,9 @@ class WikiFactoryLoader {
 			// normal HTTP request
 			$this->mServerName = strtolower( $server['SERVER_NAME'] );
 
-			$path = parse_url( $server['REQUEST_SCHEME'] . '://' . $server['SERVER_NAME'] . $server['REQUEST_URI'], PHP_URL_PATH );
+			$fullUrl =  preg_match( "/^https?:\/\//", $server['REQUEST_URI'] ) ? $server['REQUEST_URI'] :
+				$server['REQUEST_SCHEME'] . '://' . $server['SERVER_NAME'] . $server['REQUEST_URI'];
+			$path = parse_url( $fullUrl, PHP_URL_PATH );
 
 			$slash = strpos( $path, '/', 1 ) ?: strlen( $path );
 

--- a/extensions/wikia/WikiFactory/tests/WikiFactoryLoaderIntegrationTest.php
+++ b/extensions/wikia/WikiFactory/tests/WikiFactoryLoaderIntegrationTest.php
@@ -70,6 +70,11 @@ class WikiFactoryLoaderIntegrationTest extends WikiaDatabaseTest {
 			'SERVER_NAME' => 'poznan.wikia.com',
 			'REQUEST_URI' => '/en/wiki/Thread:24',
 		] ];
+		yield [ 2, [
+			'REQUEST_SCHEME' => 'http',
+			'SERVER_NAME' => 'test1.wikia.com',
+			'REQUEST_URI' => 'http://test1.wikia.com/de/wiki/Bar',
+		] ];
 	}
 
 	/**


### PR DESCRIPTION
`ApiService::foreignCall` uses local apache as a proxy and the full address ends up in the `REQUEST_URI`