### PR TITLE
(PLATFORM-3479) Ensure images in VE use the right protocol

### DIFF
--- a/extensions/VisualEditor/lib/ve/src/ve.utils.js
+++ b/extensions/VisualEditor/lib/ve/src/ve.utils.js
@@ -774,6 +774,19 @@ ve.resolveUrl = function ( url, base ) {
 };
 
 /**
+ * Convert a URL to use the current protocol if needed.
+ *
+ * @param {string} url URL to convert
+ * @returns {string} Converted URL
+ */
+ve.convertToCurrentProtocol = function( url ) {
+	if ( !url.startsWith( location.protocol ) ) {
+		return url.replace( /^https?:/, location.protocol );
+	}
+	return url;
+};
+
+/**
  * Get the actual inner HTML of a DOM node.
  *
  * In most browsers, .innerHTML is broken and eats newlines in `<pre>` elements, see

--- a/extensions/VisualEditor/modules/ve-mw/init/ve.init.mw.Target.js
+++ b/extensions/VisualEditor/modules/ve-mw/init/ve.init.mw.Target.js
@@ -359,17 +359,21 @@ ve.init.mw.Target.static.apiRequest = function ( data, settings ) {
  * @param {HTMLDocument} sourceDoc Document whose base URL should be used for resolution
  */
 ve.init.mw.Target.static.fixBase = function ( targetDoc, sourceDoc ) {
-	var $base;
+	var $base, baseURI;
 	if ( !targetDoc.baseURI ) {
 		$base = $( 'base', targetDoc );
 		if ( $base.length ) {
 			// Modify the existing <base> tag
-			$base.attr( 'href', ve.resolveUrl( $base.attr( 'href' ), sourceDoc ) );
+			baseURI = ve.resolveUrl( $base.attr( 'href' ), sourceDoc );
+			$base.attr( 'href', ve.convertToCurrentProtocol( baseURI ) );
 		} else {
 			// No <base> tag, add one
-			$base = $( '<base>', targetDoc ).attr( 'href', sourceDoc.baseURI );
+			$base = $( '<base>', targetDoc ).attr( 'href', ve.convertToCurrentProtocol( sourceDoc.baseURI ) );
 			$( 'head', sourceDoc ).append( $base );
 		}
+	} else if ( !targetDoc.baseURI.startsWith( location.protocol ) ) {
+		$base = $( 'base', targetDoc );
+		$base.attr( 'href', ve.convertToCurrentProtocol( $base.attr( 'href' ) ) );
 	}
 };
 


### PR DESCRIPTION
Right now, VE generates a fake HTML doc from the response from Parsoid.
Since Parsoid requests MediaWiki internally over HTTP, this doc has a
plain HTTP base URI. VE resolves relative URLs into absolute URLs using
this fake doc, which results in the URLs (including image URLs) being
HTTP even if VE is being used over HTTPS.

This fix ensures the doc used by VE always sets a base URI which uses the
right protocol for the current page request.

/cc @Wikia/core-platform-team @Wikia/sus 