### PR TITLE
Use empty when checking Fastly-SSL header

### DIFF
--- a/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
+++ b/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
@@ -402,7 +402,7 @@ class WikiFactoryLoader {
 							 !empty( $_COOKIE["{$wgCookiePrefix}UserID"] );
 
 			if ( $hasAuthCookie &&
-				 $_SERVER['HTTP_FASTLY_SSL'] &&
+				 !empty( $_SERVER['HTTP_FASTLY_SSL'] ) &&
 				 // Hack until we are better able to handle internal HTTPS requests
 				 !empty( $_SERVER['HTTP_FASTLY_FF'] ) &&
 				 wfHttpsAllowedForURL( $redirectUrl )


### PR DESCRIPTION
fixing `PHP Notice: Undefined index: HTTP_FASTLY_SSL`