### PR TITLE
SUS-4284 | HubService::getComscoreCategoryOverride - use wgComScoreTagOverride WikiFactory variable instead of legacy WikiFactory tags

### DIFF
--- a/includes/wikia/services/HubService.class.php
+++ b/includes/wikia/services/HubService.class.php
@@ -86,21 +86,10 @@ class HubService {
 	/**
 	 * Look for a comscore_zzz tag
 	 * @param integer $cityId
-	 * @return hash of category data { id, name, url, short, deprecated, active }
+	 * @return string|null
 	 */
 	public static function getComscoreCategoryOverride( $cityId ) {
-
-		$wftags = new WikiFactoryTags( $cityId );
-		$tags = $wftags->getTags();
-		if ( is_array( $tags ) ) {
-			foreach ( $tags as $name ) {
-				if ( startsWith( $name, self::$comscore_prefix, false ) ) {
-					$catName = substr( $name, strlen( self::$comscore_prefix ) );
-					return $catName;
-				}
-			}
-		}
-		return null;
+		return WikiFactory::getVarValueByName('wgComScoreTagOverride', $cityId) ?: null;
 	}
 
 	/**


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-4284

[Values from `comscore_*` tags were migrated](https://gist.github.com/macbre/7c10460a5cb846efe321dfbf3bcae38f) to [`wgComScoreTagOverride` WikiFactory variable](https://community.wikia.com/wiki/Special:WikiFactoryReporter?varid=1829) (497 wikis were affected).

`HubService::getComscoreCategoryOverride` returns the same values.

This was the last piece of the code using `WikiFactoryTags` class - sunset PR to follow.