### PR TITLE
SUS-4789 | force the value of wgEnableCategorySelectExt only when it is not set yet

### DIFF
--- a/includes/wikia/Extensions.php
+++ b/includes/wikia/Extensions.php
@@ -711,7 +711,7 @@ if( !empty( $wgEnableHAWelcomeExt ) ) {
 }
 
 // Enable CategorySelect extension for all not RTL wikis
-if (!in_array($wgLanguageCode, array('ar', 'fa', 'he', 'ps', 'yi'))) {
+if (!in_array($wgLanguageCode, array('ar', 'fa', 'he', 'ps', 'yi')) && is_null( $wgEnableCategorySelectExt) ) {
     $wgEnableCategorySelectExt = true;
 }
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-4789

Allow WikiFactory to set this variable to `false`.

### Before the fix

```
macbre@cron-s1:~$ ./city_eval.sh 3035
LBFactory_Wikia::getSectionForWiki: section c2, wiki
> var_dump($wgEnableCategorySelectExt)
bool(true)
```

### After the fix

```
macbre@cron-s1:~$ ./city_eval.sh 3035
LBFactory_Wikia::getSectionForWiki: section c2, wiki
> var_dump($wgEnableCategorySelectExt)
bool(false)
```