### PR TITLE
(MAIN-13789) Quick fix for communities with custom forum namespaces

### DIFF
--- a/includes/wikia/Extensions.php
+++ b/includes/wikia/Extensions.php
@@ -94,12 +94,6 @@ switch ( $wgLanguageCode ) {
 		$wgNamespaceAliases["Forum_talk"] = 111;
 
 		break;
-            
-        default:
-                $wgExtraNamespaces[110] = 'Forum';
-                $wgExtraNamespaces[111] = 'Forum_talk';
-                break;
-
 }
 
 $wgNamespacesWithSubpages[110] = true; //Forum

--- a/includes/wikia/VariablesBase.php
+++ b/includes/wikia/VariablesBase.php
@@ -4268,7 +4268,10 @@ $wgExtraLanguageNames = [];
  *     103 => "Discussion_Aide"
  * ];
  */
-$wgExtraNamespaces = [];
+$wgExtraNamespaces = [
+	110 => 'Forum',
+	111 => 'Forum_talk',
+];
 
 /**
  * A subtitle to add to the tagline, for skins that have it.


### PR DESCRIPTION
Some older communities override wgExtraNamespaces in WikiFactory in order
to set a custom Forum: namespace ID. As such, the default forum namespace
setting for English wikis at least needs to be set before WikiFactory
overrides it. After the config changes, the more common forum namespace
ID was always getting appended to wgExtraNamespaces causing those communities
to have two forum namespaces defined, with only one taking effect.

This fixes it by moving the default back to before WikiFactory takes over
until we can consider cleaning up the situation so it's more consistent.

/cc @mixoteric 