### PR TITLE
(PLATFORM-3496) Only include categories with 10+ pages in sitemaps

### DIFF
--- a/extensions/wikia/SitemapXml/SitemapXmlModel.class.php
+++ b/extensions/wikia/SitemapXml/SitemapXmlModel.class.php
@@ -60,7 +60,7 @@ class SitemapXmlModel extends WikiaModel {
 		if ( $namespaces == [ NS_CATEGORY ] ) {
 			$sql->JOIN( 'category' )->ON( 'page.page_title', 'category.cat_title')
 				->AND_( 'page.page_namespace', NS_CATEGORY );
-			$sql->AND_( 'category.cat_pages' )->GREATER_THAN( 0 );
+			$sql->AND_( 'category.cat_pages' )->GREATER_THAN( 9 );
 		}
 
 		return $sql;


### PR DESCRIPTION
Only include categories with at least 10 pages in sitemaps to try to ensure
we only include categories with some meaningful content.

/cc @Wikia/core-platform-team 