### PR TITLE
PLATFORM-3491: enable HTTPS on wikis with ID greater than given threshold

### DIFF
--- a/extensions/wikia/HTTPSOptIn/HTTPSOptInHooks.class.php
+++ b/extensions/wikia/HTTPSOptIn/HTTPSOptInHooks.class.php
@@ -18,8 +18,11 @@ class HTTPSOptInHooks {
 	const WIKI_ID_THRESHOLD_WITH_HTTPS_ON = 1700000;
 
 	public static function onGetPreferences( User $user, array &$preferences ): bool {
-		global $wgServer, $wgHTTPSForLoggedInUsers;
-		if ( empty( $wgHTTPSForLoggedInUsers ) && wfHttpsAllowedForURL( $wgServer ) ) {
+		global $wgServer, $wgHTTPSForLoggedInUsers, $wgCityId;
+		if ( empty( $wgHTTPSForLoggedInUsers ) &&
+			$wgCityId <= self::WIKI_ID_THRESHOLD_WITH_HTTPS_ON &&
+			wfHttpsAllowedForURL( $wgServer )
+		) {
 			$preferences['https-opt-in'] = [
 				'type' => 'toggle',
 				'label-message' => 'https-opt-in-toggle',

--- a/extensions/wikia/HTTPSOptIn/HTTPSOptInHooks.class.php
+++ b/extensions/wikia/HTTPSOptIn/HTTPSOptInHooks.class.php
@@ -13,6 +13,8 @@ class HTTPSOptInHooks {
 		'wikia' => [ 'Community_Central:Licensing' ]
 	];
 
+	const WIKI_ID_THRESHOLD_WITH_HTTPS_ON = 10000;
+
 	public static function onGetPreferences( User $user, array &$preferences ): bool {
 		global $wgServer, $wgHTTPSForLoggedInUsers;
 		if ( empty( $wgHTTPSForLoggedInUsers ) && wfHttpsAllowedForURL( $wgServer ) ) {
@@ -69,10 +71,14 @@ class HTTPSOptInHooks {
 	}
 
 	private static function httpsAllowed( User $user, string $url ): bool {
-		global $wgHTTPSForLoggedInUsers;
+		global $wgHTTPSForLoggedInUsers, $wgCityId;
 		return wfHttpsAllowedForURL( $url ) &&
 			$user->isLoggedIn() &&
-			( !empty( $wgHTTPSForLoggedInUsers ) || $user->getGlobalPreference( 'https-opt-in', false ) );
+			(
+				!empty( $wgHTTPSForLoggedInUsers ) ||
+				$user->getGlobalPreference( 'https-opt-in', false ) ||
+				$wgCityId > self::WIKI_ID_THRESHOLD_WITH_HTTPS_ON
+			);
 	}
 
 	private static function httpsEnabledTitle( Title $title ): bool {

--- a/extensions/wikia/HTTPSOptIn/HTTPSOptInHooks.class.php
+++ b/extensions/wikia/HTTPSOptIn/HTTPSOptInHooks.class.php
@@ -13,7 +13,9 @@ class HTTPSOptInHooks {
 		'wikia' => [ 'Community_Central:Licensing' ]
 	];
 
-	const WIKI_ID_THRESHOLD_WITH_HTTPS_ON = 10000;
+	// wikis with ID greater than this threshold will get HTTPS on by default for
+	// logged-in users despite the opt-in preference
+	const WIKI_ID_THRESHOLD_WITH_HTTPS_ON = 1700000;
 
 	public static function onGetPreferences( User $user, array &$preferences ): bool {
 		global $wgServer, $wgHTTPSForLoggedInUsers;


### PR DESCRIPTION
Still final WIKI_ID is to be decided.

ping: @Wikia/core-platform-team 