### PR TITLE
SUS-4766 | migrate comments / wall and forum entries titles to remove user name component

### DIFF
--- a/extensions/wikia/ArticleComments/ArticleComments_setup.php
+++ b/extensions/wikia/ArticleComments/ArticleComments_setup.php
@@ -37,6 +37,7 @@ $wgAutoloadClasses['ArticleCommentInit'] = __DIR__ . '/classes/ArticleCommentIni
 $wgAutoloadClasses['ArticleComment'] = __DIR__ . '/classes/ArticleComment.class.php';
 $wgAutoloadClasses['ArticleCommentList'] = __DIR__ . '/classes/ArticleCommentList.class.php';
 $wgAutoloadClasses['ArticleCommentsAjax'] = __DIR__ . '/classes/ArticleCommentsAjax.class.php';
+$wgAutoloadClasses['ArticleCommentsTitle'] = __DIR__ . '/classes/ArticleCommentsTitle.class.php';
 $wgAutoloadClasses['ArticleCommentsController'] = __DIR__ . '/modules/ArticleCommentsController.class.php';
 $wgAutoloadClasses['ArticleCommentsHooks'] = __DIR__ . '/ArticleCommentsHooks.class.php';
 

--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -977,25 +977,6 @@ class ArticleComment {
 	}
 
 	/**
-	 * Format a page_title for a comment
-	 *
-	 * e.g. Macbre/@comment-(user_ID_or_IP)-20170301152835/@comment-(user_ID_or_IP)-20171103161051
-	 *
-	 * @param Title $title
-	 * @param User $user
-	 * @param string $now
-	 * @return string
-	 */
-	static public function makeCommentTitle( Title $title, User $user, $now = null ) : string {
-		return sprintf(
-			'%s/%s%s-%s',
-			$title->getText(),
-			ARTICLECOMMENT_PREFIX,
-			$user->isLoggedIn() ? $user->getId() : $user->getName(),
-			$now ?: wfTimestampNow() );
-	}
-
-	/**
 	 * doPost -- static hook/entry for normal request post
 	 *
 	 * @param $text
@@ -1022,7 +1003,7 @@ class ArticleComment {
 		 */
 		if ( $parentId == false ) {
 			// 1st level comment
-			$commentTitle = self::makeCommentTitle( $title, $user );
+			$commentTitle = ArticleCommentsTitle::format( $title, $user );
 		} else {
 			$parentArticle = Article::newFromID( $parentId );
 			if ( empty( $parentArticle ) ) {
@@ -1051,7 +1032,8 @@ class ArticleComment {
 				return false;
 			}
 			// nested comment
-			$commentTitle = self::makeCommentTitle( $parentArticle->getTitle(), $user );
+			$commentTitle =
+				ArticleCommentsTitle::format( $parentArticle->getTitle(), $user );
 		}
 		$commentTitleText = $commentTitle;
 		$commentTitle = Title::newFromText( $commentTitle, MWNamespace::getTalk( $title->getNamespace() ) );

--- a/extensions/wikia/ArticleComments/classes/ArticleCommentsTitle.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleCommentsTitle.class.php
@@ -21,4 +21,19 @@ class ArticleCommentsTitle {
 		}, $oldTitleText );
 	}
 
+	/**
+	 * Format a page_title for a comment
+	 *
+	 * e.g. Macbre/@comment-(user_ID_or_IP)-20170301152835/@comment-(user_ID_or_IP)-20171103161051
+	 *
+	 * @param Title $title
+	 * @param User $user
+	 * @param string $now
+	 * @return string
+	 */
+	public static function format( Title $title, User $user, $now = null ): string {
+		return sprintf( '%s/%s%s-%s', $title->getText(), ARTICLECOMMENT_PREFIX,
+			$user->isLoggedIn() ? $user->getId() : $user->getName(), $now ?: wfTimestampNow() );
+	}
+
 }

--- a/extensions/wikia/ArticleComments/classes/ArticleCommentsTitle.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleCommentsTitle.class.php
@@ -1,0 +1,24 @@
+<?php
+
+class ArticleCommentsTitle {
+
+	/**
+	 * Normalizes given comments title text by removing user names and replacing them with user ID
+	 *
+	 * @param string $oldTitleText
+	 * @return string
+	 */
+	static public function normalize( string $oldTitleText ) : string {
+		// Macbre/@comment-Macbre-20170301152835/@comment-Kirkburn-20170302153001
+		return preg_replace_callback( '#/@comment-([^/]+)-(\d{14})#', function( $match ) {
+			// we got a user name, numeric values signal that this entry has already been mograted
+			if ( !is_numeric( $match[1] ) && !Ip::isIPAddress( $match[1] ) ) {
+				return sprintf( '/@comment-%s-%s', User::idFromName( $match[1] ), $match[2] );
+			}
+			else {
+				return $match[0];
+			}
+		}, $oldTitleText );
+	}
+
+}

--- a/extensions/wikia/ArticleComments/maintenance/migrateUserNamesInTitles.php
+++ b/extensions/wikia/ArticleComments/maintenance/migrateUserNamesInTitles.php
@@ -27,12 +27,6 @@ class MigrateUserNamesInTitles extends Maintenance {
 			'page',
 			['page_id', 'page_title'],
 			[
-				'page_namespace' => [
-					NS_TALK, // comments
-					501, // blog comments
-					1201, // Wall
-					2001, // Forum
-				],
 				'page_title' . $dbr->buildLike(
 					$dbr->anyString(), '/' . ARTICLECOMMENT_PREFIX, $dbr->anyString()
 				)

--- a/extensions/wikia/ArticleComments/maintenance/migrateUserNamesInTitles.php
+++ b/extensions/wikia/ArticleComments/maintenance/migrateUserNamesInTitles.php
@@ -64,6 +64,11 @@ class MigrateUserNamesInTitles extends Maintenance {
 				$updated += $dbw->affectedRows();
 
 				$this->output( "updated\n" );
+
+				// glee wiki has ~2mm rows to be processed here, do not harm the DB replication
+				if ($updated % 5000 === 0) {
+					wfWaitForSlaves();
+				}
 			}
 			else {
 				$this->output( "dry-run\n" );

--- a/extensions/wikia/ArticleComments/maintenance/migrateUserNamesInTitles.php
+++ b/extensions/wikia/ArticleComments/maintenance/migrateUserNamesInTitles.php
@@ -17,8 +17,7 @@ class MigrateUserNamesInTitles extends Maintenance {
 
 	public function execute() {
 		/**
-		 * SELECT  page_id,page_title  FROM `page`  WHERE page_namespace IN ('1','1201','2001')
-		 * AND (page_title LIKE '%/@comment-%' )
+		 * SELECT  page_id,page_title  FROM `page`  WHERE (page_title LIKE '%/@comment-%' )
 		 */
 		$dbr = $this->getDB( DB_SLAVE );
 		$dbw = $this->getDB( DB_MASTER );

--- a/extensions/wikia/ArticleComments/maintenance/migrateUserNamesInTitles.php
+++ b/extensions/wikia/ArticleComments/maintenance/migrateUserNamesInTitles.php
@@ -56,15 +56,26 @@ class MigrateUserNamesInTitles extends Maintenance {
 				continue;
 			}
 
-			$this->output( "#{$pageId}: {$oldPageTitle} -> {$newPageTitle}\n" );
+			$this->output( "#{$pageId}: {$oldPageTitle} -> {$newPageTitle} ... " );
 
 			if ($this->hasOption('do-migrate')) {
-				// TODO - migrate
-				$updated++;
+				$dbw->update(
+					'page',
+					['page_title' => $newPageTitle],
+					['page_id' => $pageId],
+					__METHOD__
+				);
+
+				$updated += $dbw->affectedRows();
+
+				$this->output( "updated\n" );
+			}
+			else {
+				$this->output( "dry-run\n" );
 			}
 		}
 
-		$this->output( "\nDone! $count rows processed.\n" );
+		$this->output( "\nDone! $count rows checked, $updated updated.\n" );
 
 		\Wikia\Logger\WikiaLogger::instance()->info(__CLASS__, [
 			'updated' => $updated,

--- a/extensions/wikia/ArticleComments/maintenance/migrateUserNamesInTitles.php
+++ b/extensions/wikia/ArticleComments/maintenance/migrateUserNamesInTitles.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Removes user name component of article comment titles and replaces it with user ID
+ *
+ * @see SUS-4766
+ * @ingroup Maintenance
+ */
+
+require_once( __DIR__ . '/../../../../maintenance/Maintenance.php' );
+
+class MigrateUserNamesInTitles extends Maintenance {
+	public function __construct() {
+		parent::__construct();
+		$this->mDescription = "Removes user name component of article comment titles and replaces it with user ID";
+		$this->addOption( 'do-migrate', 'Perform the migration', false, false );
+	}
+
+	public function execute() {
+
+		/**
+		 * SELECT  page_id,page_title  FROM `page`  WHERE page_namespace IN ('1','1201','2001')
+		 * AND (page_title LIKE '%/@comment-%' )
+		 */
+		$dbr = $this->getDB( DB_SLAVE );
+		$rows = $dbr->select(
+			'page',
+			['page_id', 'page_title'],
+			[
+				'page_namespace' => [
+					NS_TALK, // comments
+					1201, // Wall
+					2001, // Forum
+				],
+				'page_title' . $dbr->buildLike(
+					$dbr->anyString(), '/' . ARTICLECOMMENT_PREFIX, $dbr->anyString()
+				)
+			]
+		);
+		$count = $dbr->affectedRows();
+		$this->output($dbr->lastQuery() . "\n\n");
+
+		// process each title
+		foreach($rows as $row) {
+			$this->output( "{$row->page_title}\n" );
+		}
+
+		$this->output( "Done! $count rows processed.\n" );
+	}
+}
+
+$maintClass = MigrateUserNamesInTitles::class;
+require_once( RUN_MAINTENANCE_IF_MAIN );

--- a/extensions/wikia/ArticleComments/maintenance/migrateUserNamesInTitles.php
+++ b/extensions/wikia/ArticleComments/maintenance/migrateUserNamesInTitles.php
@@ -29,6 +29,7 @@ class MigrateUserNamesInTitles extends Maintenance {
 			[
 				'page_namespace' => [
 					NS_TALK, // comments
+					501, // blog comments
 					1201, // Wall
 					2001, // Forum
 				],

--- a/extensions/wikia/ArticleComments/tests/ArticleCommentTest.php
+++ b/extensions/wikia/ArticleComments/tests/ArticleCommentTest.php
@@ -85,8 +85,7 @@ class ArticleCommentTest extends WikiaBaseTest {
 		]);
 
 		$this->assertEquals(
-			$expected,
-			ArticleComment::makeCommentTitle( $title, $user, '20071201000000' )
+			$expected, ArticleCommentsTitle::format( $title, $user, '20071201000000' )
 		);
 	}
 }

--- a/extensions/wikia/ArticleComments/tests/ArticleCommentTitleTest.php
+++ b/extensions/wikia/ArticleComments/tests/ArticleCommentTitleTest.php
@@ -16,6 +16,11 @@ class ArticleCommentTitleTest extends WikiaDatabaseTest {
 			'Macbre/@comment-123-20170301152835/@comment-126761-20170302153001',
 		];
 
+		yield [
+			'Macbre/@comment-123-20170301152835/@comment-Foo-Dash-123-20170302153001',
+			'Macbre/@comment-123-20170301152835/@comment-123456-20170302153001',
+		];
+
 		// IP address
 		yield [
 			'Macbre/@comment-1.2.3.4-20170301152835/@comment-2001:978:3500:BEEF:0:0:0:1008-20170302153001',

--- a/extensions/wikia/ArticleComments/tests/ArticleCommentTitleTest.php
+++ b/extensions/wikia/ArticleComments/tests/ArticleCommentTitleTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * @group Integration
+ */
+class ArticleCommentTitleTest extends WikiaDatabaseTest {
+
+	public function provideNormalize() {
+		yield [
+			'Macbre/@comment-Macbre-20170301152835/@comment-Kirkburn-20170302153001',
+			'Macbre/@comment-119245-20170301152835/@comment-126761-20170302153001',
+		];
+
+		yield [
+			'Macbre/@comment-123-20170301152835/@comment-Kirkburn-20170302153001',
+			'Macbre/@comment-123-20170301152835/@comment-126761-20170302153001',
+		];
+
+		// IP address
+		yield [
+			'Macbre/@comment-1.2.3.4-20170301152835/@comment-2001:978:3500:BEEF:0:0:0:1008-20170302153001',
+			'Macbre/@comment-1.2.3.4-20170301152835/@comment-2001:978:3500:BEEF:0:0:0:1008-20170302153001',
+		];
+
+		yield [
+			'Macbre/@comment-1.2.3.4-20170301152835/@comment-Kirkburn-20170302153001',
+			'Macbre/@comment-1.2.3.4-20170301152835/@comment-126761-20170302153001',
+		];
+
+		// already migrated
+		yield [
+			'Macbre/@comment-123-20170301152835/@comment-456-20170302153001',
+			'Macbre/@comment-123-20170301152835/@comment-456-20170302153001',
+		];
+
+		yield [
+			'Macbre/@comment-119245-20170301152835/@comment-126761-20170302153001',
+			'Macbre/@comment-119245-20170301152835/@comment-126761-20170302153001',
+		];
+
+		// not an article comment / wall / forum
+		yield [
+			'Macbre/Macbre-20170302153001',
+			'Macbre/Macbre-20170302153001',
+		];
+	}
+
+	/**
+	 * @dataProvider provideNormalize
+	 *
+	 * @param string $oldTitleText
+	 * @param string $expected
+	 */
+	public function testNormalize(string $oldTitleText, string $expected) {
+		$this->assertEquals(
+			$expected,
+			ArticleCommentsTitle::normalize($oldTitleText)
+		);
+	}
+
+	protected function getDataSet() {
+		return $this->createYamlDataSet( __DIR__ . '/fixtures/article_comment_title.yaml' );
+	}
+}

--- a/extensions/wikia/ArticleComments/tests/fixtures/article_comment_title.yaml
+++ b/extensions/wikia/ArticleComments/tests/fixtures/article_comment_title.yaml
@@ -1,0 +1,27 @@
+user:
+  -
+    user_id: 119245
+    user_name: 'Macbre'
+    user_real_name: ''
+    user_email: 'kossuth.lajos@lajoskossuth.hu'
+    user_touched: '20110101000000'
+    user_token: 'loremipsum'
+    user_email_authenticated: '20101102000000'
+    user_email_token: 'dolorsitamet'
+    user_email_token_expires: '20120301120000'
+    user_registration: '20090604060000'
+    user_editcount: 2500
+    user_birthdate:
+  -
+    user_id: 126761
+    user_name: 'Kirkburn'
+    user_real_name: ''
+    user_email: 'kossuth.lajos@lajoskossuth.hu'
+    user_touched: '20110101000000'
+    user_token: 'loremipsum'
+    user_email_authenticated: '20101102000000'
+    user_email_token: 'dolorsitamet'
+    user_email_token_expires: '20120301120000'
+    user_registration: '20090604060000'
+    user_editcount: 2500
+    user_birthdate:

--- a/extensions/wikia/ArticleComments/tests/fixtures/article_comment_title.yaml
+++ b/extensions/wikia/ArticleComments/tests/fixtures/article_comment_title.yaml
@@ -13,6 +13,19 @@ user:
     user_editcount: 2500
     user_birthdate:
   -
+    user_id: 123456
+    user_name: 'Foo-Dash-123'
+    user_real_name: ''
+    user_email: 'kossuth.lajos@lajoskossuth.hu'
+    user_touched: '20110101000000'
+    user_token: 'loremipsum'
+    user_email_authenticated: '20101102000000'
+    user_email_token: 'dolorsitamet'
+    user_email_token_expires: '20120301120000'
+    user_registration: '20090604060000'
+    user_editcount: 2500
+    user_birthdate:
+  -
     user_id: 126761
     user_name: 'Kirkburn'
     user_real_name: ''


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-4766

```
macbre@dev-macbre:~/app/extensions/wikia/ArticleComments/maintenance$ SERVER_DBNAME=macbre php migrateUserNamesInTitles.php  --do-migrate

...

#168: Test/@comment-Ryba777-20170222114409/@comment-QATestsUser3-20170222121436 -> Test/@comment-5440664-20170222114409/@comment-5432835-20170222121436 ... updated
#158: Test/@comment-Ryba777-20170222114409/@comment-Ryba777-20170222114436 -> Test/@comment-5440664-20170222114409/@comment-5440664-20170222114436 ... updated
#186: Test/@comment-Ryba777-20170222114409/@comment-Ryba777-20170224143610 -> Test/@comment-5440664-20170222114409/@comment-5440664-20170224143610 ... updated

Done! 102 rows checked, 83 updated.
```

IP addresses are left untouched. User names are replaced with user IDs.