### PR TITLE
PLATFORM-3489: fix article path for language wikis

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -312,16 +312,6 @@ try {
 }
 
 /**
- * Recalculate $wgScript and $wgArticlePath for wikis with language code path
- * component.
- * @see SUS-3851
- */
-if ( !empty( $wgScriptPath ) ) {
-       $wgScript = $wgScriptPath . $wgScript;
-       $wgArticlePath = $wgScriptPath . $wgArticlePath;
-}
-
-/**
  * In some cases $wgMemc is still null at this point. Let's initialize it.
  * @see SUS-2699
  * @var string $wgDBcluster


### PR DESCRIPTION
These lines were removed in https://github.com/Wikia/app/pull/15169 but somehow found their way back during the config refactoring