### PR TITLE
Fix link to Google Play in emails

### DIFF
--- a/extensions/wikia/Email/MobileApplicationsLinksGenerator.class.php
+++ b/extensions/wikia/Email/MobileApplicationsLinksGenerator.class.php
@@ -18,7 +18,7 @@ class MobileApplicationsLinksGenerator {
 
 	const APPLICATION_APP_STORE_URL = 'https://itunes.apple.com/%s/app/id' . self::RELEASE_KEYWORD;
 
-	const WIKIA_GOOGLE_PLAY_URL = 'https://play.google.com/store/apps/developer?hl=%s&id=Fandom+powered+by+Wikia';
+	const WIKIA_GOOGLE_PLAY_URL = 'https://play.google.com/store/apps/developer?hl=%s&id=FANDOM+powered+by+Wikia';
 
 	const APPLICATION_GOOGLE_PLAY_URL = 'https://play.google.com/store/apps/details?hl=%s&id=' .
 	                                    self::RELEASE_KEYWORD;


### PR DESCRIPTION
https://play.google.com/store/apps/developer?hl=en&id=Fandom+powered+by+Wikia returns 404
https://play.google.com/store/apps/developer?hl=en&id=FANDOM+powered+by+Wikia works fine

@Wikia/android 