### PR TITLE
SUS-4766 | trim page_title when migrating comments / wall and forum entries to fit in the database column

### DIFF
--- a/extensions/wikia/ArticleComments/classes/ArticleCommentsTitle.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleCommentsTitle.class.php
@@ -10,7 +10,7 @@ class ArticleCommentsTitle {
 	 */
 	static public function normalize( string $oldTitleText ) : string {
 		// Macbre/@comment-Macbre-20170301152835/@comment-Kirkburn-20170302153001
-		return preg_replace_callback( '#/@comment-([^/]+)-(\d{14})#', function( $match ) {
+		$normalized = preg_replace_callback( '#/@comment-([^/]+)-(\d{14})#', function( $match ) {
 			// we got a user name, numeric values signal that this entry has already been mograted
 			if ( !is_numeric( $match[1] ) && !Ip::isIPAddress( $match[1] ) ) {
 				return sprintf( '/@comment-%s-%s', User::idFromName( $match[1] ), $match[2] );
@@ -19,6 +19,9 @@ class ArticleCommentsTitle {
 				return $match[0];
 			}
 		}, $oldTitleText );
+
+		// new page_title value should fit the database column
+		return substr( $normalized, 0, 255 );
 	}
 
 	/**

--- a/extensions/wikia/ArticleComments/tests/ArticleCommentTitleTest.php
+++ b/extensions/wikia/ArticleComments/tests/ArticleCommentTitleTest.php
@@ -48,6 +48,12 @@ class ArticleCommentTitleTest extends WikiaDatabaseTest {
 			'Macbre/Macbre-20170302153001',
 			'Macbre/Macbre-20170302153001',
 		];
+
+		// too long title
+		yield [
+			'FooBar/Thiś_is_ąn_important_announcement._SO_important,_in_fact,_that_if_you_don\'t_read_it_your_brain_will_explode_out_your_ears,_and_that_will_be_the_end_of_you_forever._Until_I_work_out_how_to_sustain_brains_in_glass_jars./@comment-FooBar-20111217083734',
+			'FooBar/Thiś_is_ąn_important_announcement._SO_important,_in_fact,_that_if_you_don\'t_read_it_your_brain_will_explode_out_your_ears,_and_that_will_be_the_end_of_you_forever._Until_I_work_out_how_to_sustain_brains_in_glass_jars./@comment-1234567890-20111217',
+		];
 	}
 
 	/**
@@ -57,10 +63,10 @@ class ArticleCommentTitleTest extends WikiaDatabaseTest {
 	 * @param string $expected
 	 */
 	public function testNormalize(string $oldTitleText, string $expected) {
-		$this->assertEquals(
-			$expected,
-			ArticleCommentsTitle::normalize($oldTitleText)
-		);
+		$normalizedTitle = ArticleCommentsTitle::normalize( $oldTitleText );
+
+		$this->assertLessThanOrEqual( 255, strlen( $normalizedTitle ), 'New page_title should fit the DB column' );
+		$this->assertEquals( $expected, $normalizedTitle );
 	}
 
 	protected function getDataSet() {

--- a/extensions/wikia/ArticleComments/tests/fixtures/article_comment_title.yaml
+++ b/extensions/wikia/ArticleComments/tests/fixtures/article_comment_title.yaml
@@ -38,3 +38,16 @@ user:
     user_registration: '20090604060000'
     user_editcount: 2500
     user_birthdate:
+  -
+    user_id: 1234567890
+    user_name: 'FooBar'
+    user_real_name: ''
+    user_email: 'kossuth.lajos@lajoskossuth.hu'
+    user_touched: '20110101000000'
+    user_token: 'loremipsum'
+    user_email_authenticated: '20101102000000'
+    user_email_token: 'dolorsitamet'
+    user_email_token_expires: '20120301120000'
+    user_registration: '20090604060000'
+    user_editcount: 2500
+    user_birthdate:


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-4766

Avoid issues like this one:

```sql
A database error has occurred.  Did you forget to run maintenance/update.php after upgrading?  See: https://www.mediawiki.org/wiki/Manual:Upgrading#Run_the_update_script
Query: UPDATE  `page` SET page_title = 'FooBar/This_is_an_important_announcement._SO_important,_in_fact,_that_if_you_don\'t_read_it_your_brain_will_explode_out_your_ears,_and_that_will_be_the_end_of_you_forever._Until_I_work_out_how_to_sustain_brains_in_glass_jars./@comment-1839575-20111217083734' WHERE page_id = '44433'
Function: MigrateUserNamesInTitles::execute
Error: 1406 Data too long for column 'page_title' at row 1 (geo-db-a-master.query.consul)
```

The resulting user ID can be longer than the user name and we may run out of space in `page_title` column :smile: 