### PR TITLE
PLATFORM-3486: use http for internal calls and set Fastly-SSL header when calling HTTPS wikis

### DIFF
--- a/includes/wikia/services/ApiService.class.php
+++ b/includes/wikia/services/ApiService.class.php
@@ -55,15 +55,21 @@ class ApiService {
 			return false;
 		}
 
+		$options = [];
+		if ( startsWith( $cityUrl, "https://" ) ) {
+			$cityUrl = wfHttpsToHttp( $cityUrl );
+			$options[ 'headers' ] = [ 'FASTLY-SSL' => 1, ];
+		}
+
+
 		// request JSON format of API response
 		$params[ 'format' ] = 'json';
 
 		$url = "{$cityUrl}/{$endpoint}?" . http_build_query( $params );
 		wfDebug( __METHOD__ . ": {$url}\n" );
 
-		$options = [];
 		if ( $setUser ) {
-			$options = self::loginAsUser();
+			$options = array_merge( $options, self::loginAsUser() );
 		}
 
 		// send request and parse response

--- a/includes/wikia/services/ApiService.class.php
+++ b/includes/wikia/services/ApiService.class.php
@@ -61,7 +61,6 @@ class ApiService {
 			$options[ 'headers' ] = [ 'FASTLY-SSL' => 1, ];
 		}
 
-
 		// request JSON format of API response
 		$params[ 'format' ] = 'json';
 

--- a/includes/wikia/services/ApiService.class.php
+++ b/includes/wikia/services/ApiService.class.php
@@ -58,7 +58,7 @@ class ApiService {
 		$options = [];
 		if ( startsWith( $cityUrl, "https://" ) ) {
 			$cityUrl = wfHttpsToHttp( $cityUrl );
-			$options[ 'headers' ] = [ 'FASTLY-SSL' => 1, ];
+			$options[ 'headers' ] = [ 'Fastly-SSL' => 1, ];
 		}
 
 		// request JSON format of API response


### PR DESCRIPTION
We should "propagate" Fastly's SSL header and always call wiki internally using HTTP

ping: @Wikia/core-platform-team 