### PR TITLE
PLATFORM-3484: custom JS scripts should load twitter js over https

### DIFF
--- a/maintenance/wikia/HttpsMigration/migrateCustomJs.php
+++ b/maintenance/wikia/HttpsMigration/migrateCustomJs.php
@@ -170,7 +170,7 @@ class MigrateCustomJsToHttps extends Maintenance {
 	 */
 	private function upgradeThirdPartyUrl( $url ) {
 		$knownHttpsHosts = [ 'en.wikipedia.org', 'i.imgur.com', 'upload.wikimedia.org', 'fonts.googleapis.com',
-			'commons.wikimedia.org' ];
+			'commons.wikimedia.org', 'platform.twitter.com' ];
 		$host = parse_url( $url, PHP_URL_HOST );
 		if ( in_array( $host, $knownHttpsHosts ) ) {
 			$newUrl = $this->upgradeToHttps( $url );


### PR DESCRIPTION
We're getting a lot of CSP reports about JS loading `http://platform.twitter.com/widgets.js`