### PR TITLE
🐷 | Missing column

### DIFF
--- a/extensions/wikia/PhalanxII/classes/PhalanxStatsPager.class.php
+++ b/extensions/wikia/PhalanxII/classes/PhalanxStatsPager.class.php
@@ -20,6 +20,7 @@ class PhalanxStatsPager extends PhalanxPager {
 	function getQueryInfo() {
 		$query['tables'] = 'phalanx_stats';
 		$query['fields'] = [
+			'ps_blocker_id',
 			'ps_timestamp',
 			'ps_blocker_hit',
 			'ps_blocker_type',


### PR DESCRIPTION
Missing column in query was breaking per-wiki phalanx stats views.