### PR TITLE
IRIS-5876 | Fix utf-8 characters in X-SMTPAPI header

### DIFF
--- a/includes/wikia/WikiaMailer.php
+++ b/includes/wikia/WikiaMailer.php
@@ -240,6 +240,7 @@ class WikiaSendgridMailer {
 			],
 		];
 
-		return json_encode( $content );
+		// Without whitespaces, wordwrap() in mimePart::encodeHeader() can break utf-8 characters
+		return json_encode( $content, JSON_PRETTY_PRINT );
 	}
 }


### PR DESCRIPTION
## Description
When working on https://wikia-inc.atlassian.net/browse/IRIS-5876 we had a few errors from SendGrid about broken UTF-8 characters, e.g.:
```
exactly four hexadecimal digits expected, at character offset 35353 (before "6b db\\u5c07 " ,"\\u...") 
```
I found that in https://github.com/Wikia/app/blob/d2b676b94079adf6aa762c017c3381adbf30d355/lib/composer/pear/mail_mime/Mail/mimePart.php#L972 we use [`wordwrap()`](http://php.net/manual/en/function.wordwrap.php) which breaks long lines using whitespaces.

`X-SMTPAPI` header is a stringified JSON that previously didn't have any whitespace. When using [`sub` field](https://sendgrid.com/docs/API_Reference/SMTP_API/building_an_smtp_email.html#-Substitution-Tags) with a long list of usernames, the usernames were cut in random places. For some users, it meant seeing a whitespace in the middle of their name, for some it wasn't delivered because the UTF-8 char was broken.

Let's use [`JSON_PRETTY_PRINT`](http://php.net/manual/en/json.constants.php#constant.json-pretty-print) to have whitespaces in JSON.

## Who might be interested
@macbre @Grunny 