### PR TITLE
remove Java annotations from Nirvana 🐘

### DIFF
--- a/extensions/wikia/Email/Controller/BlogPostController.class.php
+++ b/extensions/wikia/Email/Controller/BlogPostController.class.php
@@ -64,10 +64,8 @@ abstract class BlogPostController extends EmailController {
 		}
 	}
 
-	/**
-	 * @template avatarLayout
-	 */
 	public function body() {
+		$this->setViewTemplate( 'avatarLayout' );
 		$this->response->setData( [
 			'salutation' => $this->getSalutation(),
 			'editorProfilePage' => $this->getCurrentProfilePage(),

--- a/extensions/wikia/Email/Controller/CategoryAddController.class.php
+++ b/extensions/wikia/Email/Controller/CategoryAddController.class.php
@@ -96,10 +96,8 @@ class CategoryAddController extends EmailController {
 		return $this->targetUser->getId() . ":sentCategoryAddEmailCount";
 	}
 
-	/**
-	 * @template avatarLayout
-	 */
 	public function body() {
+		$this->setViewTemplate( 'avatarLayout' );
 		$this->response->setData( [
 			'salutation' => $this->getSalutation(),
 			'summary' => $this->getSummary(),

--- a/extensions/wikia/Email/Controller/CommentController.class.php
+++ b/extensions/wikia/Email/Controller/CommentController.class.php
@@ -68,10 +68,8 @@ abstract class CommentController extends EmailController {
 		}
 	}
 
-	/**
-	 * @template avatarLayout
-	 */
 	public function body() {
+		$this->setViewTemplate( 'avatarLayout' );
 		$this->response->setData( [
 			'salutation' => $this->getSalutation(),
 			'editorProfilePage' => $this->getCurrentProfilePage(),

--- a/extensions/wikia/Email/Controller/DiscussionController.class.php
+++ b/extensions/wikia/Email/Controller/DiscussionController.class.php
@@ -36,10 +36,8 @@ abstract class DiscussionController extends EmailController {
 		}
 	}
 
-	/**
-	 * @template avatarLayout
-	 */
 	public function body() {
+		$this->setViewTemplate( 'avatarLayout' );
 		$this->response->setData(
 			[
 				'salutation' => $this->getSalutation(),

--- a/extensions/wikia/Email/Controller/EmailConfirmationController.class.php
+++ b/extensions/wikia/Email/Controller/EmailConfirmationController.class.php
@@ -35,10 +35,9 @@ abstract class AbstractEmailConfirmationController extends EmailController {
 		$this->assertUserHasEmail();
 	}
 
-	/**
-	 * @template registrationEmailConfirmation
-	 */
 	public function body() {
+		$this->setViewTemplate( 'registrationEmailConfirmation' );
+
 		$this->response->setData( [
 			'salutation' => $this->getSalutation(),
 			'summary' => $this->getSummary(),

--- a/extensions/wikia/Email/Controller/ForgotPasswordController.class.php
+++ b/extensions/wikia/Email/Controller/ForgotPasswordController.class.php
@@ -41,10 +41,9 @@ class ForgotPasswordController extends EmailController {
 		return $this->getMessage( 'emailext-password-subject' )->text();
 	}
 
-	/**
-	 * @template temporaryPassword
-	 */
 	public function body() {
+		$this->setViewTemplate( 'temporaryPassword' );
+
 		$this->response->setData( [
 			'salutation' => $this->getSalutation(),
 			'summary' => $this->getSummary(),

--- a/extensions/wikia/Email/Controller/ForumController.class.php
+++ b/extensions/wikia/Email/Controller/ForumController.class.php
@@ -35,10 +35,9 @@ class ForumController extends EmailController {
 		}
 	}
 
-	/**
-	 * @template avatarLayout
-	 */
 	public function body() {
+		$this->setViewTemplate( 'avatarLayout' );
+
 		$this->response->setData( [
 			'salutation' => $this->getSalutation(),
 			'editorProfilePage' => $this->getCurrentProfilePage(),

--- a/extensions/wikia/Email/Controller/FounderController.class.php
+++ b/extensions/wikia/Email/Controller/FounderController.class.php
@@ -62,10 +62,9 @@ class FounderEditController extends EmailController {
 		}
 	}
 
-	/**
-	 * @template avatarLayout
-	 */
 	public function body() {
+		$this->setViewTemplate( 'avatarLayout' );
+
 		$this->response->setData( [
 			'salutation' => $this->getSalutation(),
 			'editorProfilePage' => $this->getCurrentProfilePage(),
@@ -250,10 +249,9 @@ class FounderActiveController extends EmailController {
 		return $this->getMessage( 'emailext-founder-active-subject' )->text();
 	}
 
-	/**
-	 * @template multiAvatarLayout
-	 */
 	public function body() {
+		$this->setViewTemplate( 'multiAvatarLayout' );
+
 		$this->response->setData( [
 			'salutation' => $this->getSalutation(),
 			'summary' => $this->getSummary(),
@@ -357,10 +355,9 @@ class FounderActiveController extends EmailController {
 
 class FounderNewMemberController extends EmailController {
 
-	/**
-	 * @template avatarLayout
-	 */
 	public function body() {
+		$this->setViewTemplate( 'avatarLayout' );
+
 		$this->response->setData( [
 			'salutation' => $this->getSalutation(),
 			'editorProfilePage' => $this->getCurrentProfilePage(),
@@ -470,10 +467,9 @@ class FounderTipsController extends EmailController {
 		return $this->getMessage( 'emailext-founder-newly-created-subject', $this->wikiName )->text();
 	}
 
-	/**
-	 * @template digestLayout
-	 */
 	public function body() {
+		$this->setViewTemplate( 'digestLayout' );
+
 		$this->response->setData( [
 			'salutation' => $this->getSalutation(),
 			'summary' => $this->getMessage( 'emailext-founder-newly-created-summary', $this->wikiUrl, $this->wikiName )->parse(),
@@ -567,10 +563,9 @@ class FounderTipsThreeDaysController extends FounderTipsController {
 		return $this->getMessage( 'emailext-founder-3-days-subject', $this->wikiName )->text();
 	}
 
-	/**
-	 * @template digestLayout
-	 */
 	public function body() {
+		$this->setViewTemplate( 'digestLayout' );
+
 		$this->response->setData( [
 			'salutation' => $this->getSalutation(),
 			'summary' => $this->getMessage( 'emailext-founder-3-days-extended-summary' )->text(),
@@ -632,10 +627,9 @@ class FounderTipsTenDaysController extends FounderTipsController {
 		return $this->getMessage( 'emailext-founder-10-days-subject', $this->wikiName )->text();
 	}
 
-	/**
-	 * @template digestLayout
-	 */
 	public function body() {
+		$this->setViewTemplate( 'digestLayout' );
+
 		$this->response->setData( [
 			'salutation' => $this->getSalutation(),
 			'summary' => $this->getMessage( 'emailext-founder-10-days-summary', $this->wikiUrl, $this->wikiName )->parse(),

--- a/extensions/wikia/Email/Controller/FounderDigestController.class.php
+++ b/extensions/wikia/Email/Controller/FounderDigestController.class.php
@@ -103,10 +103,9 @@ class FounderActivityDigestController extends FounderDigestController {
 		return $this->getMessage( 'emailext-founder-activity-digest-subject', $this->wikiName )->parse();
 	}
 
-	/**
-	 * @template digestLayout
-	 */
 	public function body() {
+		$this->setViewTemplate( 'digestLayout' );
+
 		$this->response->setData( [
 			'salutation' => $this->getSalutation(),
 			'summary' => $this->getSummary(),
@@ -213,10 +212,9 @@ class FounderPageViewsDigestController extends FounderDigestController {
 		return $this->getMessage( 'emailext-founder-views-digest-subject', $this->wikiName )->parse();
 	}
 
-	/**
-	 * @template digestLayout
-	 */
 	public function body() {
+		$this->setViewTemplate( 'digestLayout' );
+
 		$this->response->setData( [
 			'salutation' => $this->getSalutation(),
 			'summary' => $this->getSummary(),

--- a/extensions/wikia/Email/Controller/GenericController.class.php
+++ b/extensions/wikia/Email/Controller/GenericController.class.php
@@ -65,10 +65,9 @@ class GenericController extends EmailController {
 		return $this->getToAddress()->address;
 	}
 
-	/**
-	 * @template genericLayout
-	 */
 	public function body() {
+		$this->setViewTemplate( 'genericLayout' );
+
 		$this->response->setData( [
 			'salutation' => $this->salutation,
 			'body' => $this->body,

--- a/extensions/wikia/Email/Controller/PasswordResetLinkController.class.php
+++ b/extensions/wikia/Email/Controller/PasswordResetLinkController.class.php
@@ -51,10 +51,8 @@ class PasswordResetLinkController extends EmailController {
 		return $this->getMessage( 'emailext-password-subject' )->text();
 	}
 
-	/**
-	 * @template passwordResetLink
-	 */
 	public function body() {
+		$this->setViewTemplate( 'passwordResetLink' );
 		$url = $this->getResetLink();
 
 		$this->response->setData( [

--- a/extensions/wikia/Email/Controller/UserNameChangeController.class.php
+++ b/extensions/wikia/Email/Controller/UserNameChangeController.class.php
@@ -37,6 +37,8 @@ class UserNameChangeController extends EmailController {
 	 * @template userNameLayout
 	 */
 	public function body() {
+		$this->setViewTemplate( 'userNameLayout' );
+
 		$this->response->setData( [
 			'salutation' => $this->getSalutation(),
 			'editorAvatarURL' => $this->getCurrentAvatarURL(),

--- a/extensions/wikia/Email/Controller/UserRightsChangedController.class.php
+++ b/extensions/wikia/Email/Controller/UserRightsChangedController.class.php
@@ -26,6 +26,8 @@ class UserRightsChangedController extends EmailController {
 	 * @template avatarLayout
 	 */
 	public function body() {
+		$this->setViewTemplate( 'avatarLayout' );
+
 		$this->response->setData( [
 			'salutation' => $this->getSalutation(),
 			'summary' => $this->getSubject(),

--- a/extensions/wikia/Email/Controller/WallMessageController.class.php
+++ b/extensions/wikia/Email/Controller/WallMessageController.class.php
@@ -79,6 +79,8 @@ abstract class WallMessageController extends EmailController {
 	 * @template avatarLayout
 	 */
 	public function body() {
+		$this->setViewTemplate( 'avatarLayout' );
+
 		$this->response->setData( [
 			'salutation' => $this->getSalutation(),
 			'summary' => $this->getSummary(),

--- a/extensions/wikia/Email/Controller/WatchedPageController.class.php
+++ b/extensions/wikia/Email/Controller/WatchedPageController.class.php
@@ -73,10 +73,8 @@ abstract class WatchedPageController extends EmailController {
 		return array_merge( $footerMessages, parent::getFooterMessages() );
 	}
 
-	/**
-	 * @template avatarLayout
-	 */
 	public function body() {
+		$this->setViewTemplate( 'avatarLayout' );
 		$contentFooterMessages = $this->getContentFooterMessages();
 
 		$this->response->setData( [

--- a/extensions/wikia/Email/Controller/WeeklyDigestController.class.php
+++ b/extensions/wikia/Email/Controller/WeeklyDigestController.class.php
@@ -39,10 +39,9 @@ class WeeklyDigestController extends EmailController {
 		return $digestData;
 	}
 
-	/**
-	 * @template weeklyDigest
-	 */
 	public function body() {
+		$this->setViewTemplate( 'weeklyDigest' );
+
 		$this->response->setData( [
 			'salutation' => $this->getSalutation(),
 			'summary' => $this->getSummary(),

--- a/extensions/wikia/Email/Controller/WelcomeController.class.php
+++ b/extensions/wikia/Email/Controller/WelcomeController.class.php
@@ -19,10 +19,9 @@ class WelcomeController extends EmailController {
 		return $this->getMessage( 'emailext-welcome-subject', $this->getCurrentUserName() )->text();
 	}
 
-	/**
-	 * @template digestLayout
-	 */
 	public function body() {
+		$this->setViewTemplate( 'digestLayout' );
+
 		$this->response->setData( [
 			'salutation' => $this->getSalutation(),
 			'summary' => $this->createSummary(),

--- a/extensions/wikia/Email/EmailController.class.php
+++ b/extensions/wikia/Email/EmailController.class.php
@@ -133,7 +133,6 @@ abstract class EmailController extends \WikiaController {
 	 * This is the main entry point for the email extension.  The template set for this
 	 * method is used for testing only, to preview the email that will be sent.
 	 *
-	 * @template emailPreview
 	 *
 	 * @throws \MWException
 	 */
@@ -142,6 +141,8 @@ abstract class EmailController extends \WikiaController {
 		if ( $this->hasErrorResponse ) {
 			return;
 		}
+
+		$this->setViewTemplate( 'emailPreview' );
 
 		try {
 			$this->assertCanEmail();
@@ -191,10 +192,9 @@ abstract class EmailController extends \WikiaController {
 
 	/**
 	 * Render the main layout file
-	 *
-	 * @template main
 	 */
 	public function main() {
+		$this->setViewTemplate( 'main' );
 		$this->response->setValues( $this->request->getParams() );
 	}
 
@@ -816,5 +816,9 @@ abstract class EmailController extends \WikiaController {
 
 		wfProfileOut( __METHOD__ );
 		return $params;
+	}
+
+	protected function setViewTemplate( string $templateName ) {
+		$this->response->getView()->setTemplatePath( self::getTemplateDir() . "/$templateName.{$this->response->getTemplateEngine()}" );
 	}
 }

--- a/extensions/wikia/Email/README.md
+++ b/extensions/wikia/Email/README.md
@@ -58,8 +58,8 @@ requests should be sufficient for almost all cases.
 
 ### Creating a New Template
 
-When defining the `body` method in the controller, give the template name via the `@template` annotation.
-This gives the name of the template, minus the directory and templating suffix.
+When defining the `body` method in the controller, give the template name by calling the `setViewTemplate` method
+in the method body with the name of the template, minus the directory and templating suffix, as argument.
 
 The `main.mustache` template is the main layout for all emails and includes the header and footer. 
 

--- a/extensions/wikia/Email/SpecialSendEmailController.class.php
+++ b/extensions/wikia/Email/SpecialSendEmailController.class.php
@@ -57,10 +57,9 @@ class SpecialSendEmailController extends \WikiaSpecialPageController {
 		$this->response->addAsset( 'special_email_admin_css' );
 	}
 
-	/**
-	 * @template specialSendEmail
-	 */
 	public function index() {
+		$this->response->getView()->setTemplatePath( __DIR__ .'/templates/specialSendEmail.mustache' );
+
 		if ( $this->wg->request->wasPosted() ) {
 			if ( $this->editTokenValidates() ) {
 				$result = $this->processForm();

--- a/extensions/wikia/FandomCreatorEmail/Controller/ContentUpdatedController.php
+++ b/extensions/wikia/FandomCreatorEmail/Controller/ContentUpdatedController.php
@@ -28,8 +28,6 @@ class ContentUpdatedController extends FandomCreatorEmailController {
 	}
 
 	/**
-	 * @template avatarLayout
-	 *
 	 * other possible keys:
 	 * 	details - additional email text
 	 * 	editorProfilePage - link to user's profile page on this community
@@ -37,6 +35,8 @@ class ContentUpdatedController extends FandomCreatorEmailController {
 	 * 	buttonLink - where buttonText goes
 	 */
 	public function body() {
+		$this->setViewTemplate( 'avatarLayout' );
+
 		$this->magicWordWrapper->wrap( function() {
 			$this->response->setData( [
 					'salutation' => $this->getSalutation(),

--- a/extensions/wikia/UserActivity/SpecialUserActivityController.class.php
+++ b/extensions/wikia/UserActivity/SpecialUserActivityController.class.php
@@ -45,10 +45,8 @@ class SpecialController extends \WikiaSpecialPageController {
 		$this->response->addAsset( 'special_user_activity_scss' );
 	}
 
-	/**
-	 * @template specialUserActivity
-	 */
 	public function index() {
+		$this->response->getView()->setTemplatePath( __DIR__ . '/templates/specialUserActivity.mustache' );
 		if ( $this->wg->User->isAnon() ) {
 			$this->getResponse()->redirect( '/' );
 			return;

--- a/includes/wikia/nirvana/WikiaView.class.php
+++ b/includes/wikia/nirvana/WikiaView.class.php
@@ -179,11 +179,6 @@ class WikiaView {
 
 		$controllerClass = $this->getClassName( $controllerClassWithNamespace );
 
-		$fromAnnotation = $this->getTemplateAnnotation( $controllerClassWithNamespace, $methodName );
-		if ( !empty( $fromAnnotation ) ) {
-			$templates[] = $fromAnnotation;
-		}
-
 		// Add variations on the controller name
 		if ( $controllerBaseName === null ) {
 			$controllerBaseName = F::app()->getBaseName( $controllerClass );
@@ -200,41 +195,6 @@ class WikiaView {
 		$controllerClassExploded = explode( '\\', $controllerClassWithNamespace );
 
 		return end( $controllerClassExploded );
-	}
-
-	/**
-	 * Extract template form "@template" annotation of a method
-	 *
-	 * @param string $controllerClass
-	 * @param string $methodName
-	 * @return mixed|null
-	 */
-	protected function getTemplateAnnotation( string $controllerClass, string $methodName ) {
-		static $annotations = [];
-		$cacheKey = $controllerClass . '-' . $methodName;
-
-		// Cache the result of this reflection code
-		if ( array_key_exists( $cacheKey, $annotations ) ) {
-			return $annotations[$cacheKey];
-		}
-
-		$template = null;
-
-		// Make sure this method exists, otherwise the call to getMethod crashes PHP
-		// so badly it can't even log that a problem occurred.
-		if ( method_exists( $controllerClass, $methodName ) ) {
-			// See if there is a @template annotation for the method we're generating a view for
-			$reflection = new ReflectionClass( $controllerClass );
-			$method = $reflection->getMethod( $methodName );
-
-			$comment = $method->getDocComment();
-			if ( preg_match( '/@template (\S+)/', $comment, $matches ) ) {
-				$template = $matches[1];
-			}
-		}
-
-		$annotations[$cacheKey] = $template;
-		return $template;
 	}
 
 	/**


### PR DESCRIPTION
Nirvana invokes reflection + regex every time a template or partial is rendered, to check for an "annotation" that'd provide the template name.

![No Java](http://beust.com/pics/no-java.png)

This is only used in very few places so it just adds needless overhead most of the time.

