### PR TITLE
WikiFactoryLoader: Fixing redirect bug

### DIFF
--- a/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
+++ b/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
@@ -422,6 +422,12 @@ class WikiFactoryLoader {
 			header( "X-Redirected-By-WF: NotPrimary" );
 			header( 'Vary: Cookie,Accept-Encoding' );
 
+			global $wgCookiePrefix;
+			$hasAuthCookie = !empty( $_COOKIE[\Wikia\Service\User\Auth\CookieHelper::ACCESS_TOKEN_COOKIE_NAME] ) ||
+				!empty( $_COOKIE[session_name()] ) ||
+				!empty( $_COOKIE["{$wgCookiePrefix}Token"] ) ||
+				!empty( $_COOKIE["{$wgCookiePrefix}UserID"] );
+
 			if ( $hasAuthCookie ) {
 				header( 'Cache-Control: private, must-revalidate, max-age=0' );
 			} else {


### PR DESCRIPTION
Regression from https://github.com/Wikia/app/commit/812303ee73649eeeb4441d823fcf14892816b662

```
Notice: Undefined variable: hasAuthCookie in /usr/wikia/source/app/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php on line 425

Call Stack:
    0.0002     378880   1. {main}() -:0
    0.3242   15801984   2. __phpunit_run_isolated_test() -:110
    0.3289   16808496   3. PHPUnit\Framework\TestCase->run() -:57
    0.3304   16974584   4. PHPUnit\Framework\TestResult->run() /usr/wikia/source/app/lib/composer/phpunit/phpunit/src/Framework/TestCase.php:895
    0.3308   16996560   5. PHPUnit\Framework\TestCase->runBare() /usr/wikia/source/app/lib/composer/phpunit/phpunit/src/Framework/TestResult.php:698
    0.3982   17886392   6. PHPUnit\Framework\TestCase->runTest() /usr/wikia/source/app/lib/composer/phpunit/phpunit/src/Framework/TestCase.php:940
    0.3982   17887008   7. ReflectionMethod->invokeArgs() /usr/wikia/source/app/lib/composer/phpunit/phpunit/src/Framework/TestCase.php:1072
    0.3982   17887040   8. WikiFactoryLoaderIntegrationTest->testRedirectsToPrimaryDomainWhenAlternativeDomainUsed() /usr/wikia/source/app/lib/composer/phpunit/phpunit/src/Framework/TestCase.php:1072
    0.3986   17937856   9. WikiFactoryLoader->execute() /usr/wikia/source/app/extensions/wikia/WikiFactory/tests/WikiFactoryLoaderIntegrationTest.php:114
```