### PR TITLE
SUS-4820 | Break dependency between mobile-wiki and old WikiaMobile comments

### DIFF
--- a/extensions/wikia/MercuryApi/MercuryApiController.class.php
+++ b/extensions/wikia/MercuryApi/MercuryApiController.class.php
@@ -103,29 +103,16 @@ class MercuryApiController extends WikiaController {
 	 */
 	public function getArticleComments() {
 		$title = $this->getTitleFromRequest();
-		$articleId = $title->getArticleId();
 
 		$page = $this->request->getInt( self::PARAM_PAGE, self::DEFAULT_PAGE );
 
-		$commentsResponse = $this->app->sendRequest(
-			'ArticleComments',
-			'WikiaMobileCommentsPage',
-			[
-				'articleID' => $articleId,
-				'page' => $page,
-				'format' => WikiaResponse::FORMAT_JSON
-			]
-		);
+		$articleCommentList = ArticleCommentList::newFromTitle( $title );
+		$commentsData = $articleCommentList->getCommentPages( false, $page );
 
-		if ( empty( $commentsResponse ) ) {
-			throw new BadRequestApiException();
-		}
-
-		$commentsData = $commentsResponse->getData();
 		$comments = $this->mercuryApi->processArticleComments( $commentsData );
 
 		$this->response->setVal( 'payload', $comments );
-		$this->response->setVal( 'pagesCount', $commentsData['pagesCount'] );
+		$this->response->setVal( 'pagesCount', $articleCommentList->getCountPages() );
 		$this->response->setVal( 'basePath', $this->wg->Server ); // remove?
 		$this->response->setFormat( WikiaResponse::FORMAT_JSON );
 	}

--- a/extensions/wikia/MercuryApi/tests/MercuryApiControllerIntegrationTest.php
+++ b/extensions/wikia/MercuryApi/tests/MercuryApiControllerIntegrationTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * @group Integration
+ */
+class MercuryApiControllerIntegrationTest extends WikiaDatabaseTest {
+
+	const PAGE_WITH_COMMENTS_ID = 1;
+	const PAGE_WITH_BROKEN_COMMENT_ID = 4;
+
+	public function testLoadArticleComments() {
+		$response = F::app()->sendExternalRequest(
+			MercuryApiController::class,
+			'getArticleComments',
+			[ 'id' => static::PAGE_WITH_COMMENTS_ID ]
+		);
+
+		$data = $response->getData();
+
+		$this->assertEquals( WikiaResponse::FORMAT_JSON, $response->getFormat() );
+		$this->assertEquals( 1, $data['pagesCount'] );
+
+		$this->assertArrayHasKey( 'TesztJózsef', $data['payload']['users'] );
+		$this->assertArrayHasKey( 'TesztBéla', $data['payload']['users'] );
+
+		$this->assertCount( 2, $data['payload']['comments'] );
+
+		$this->assertEquals( 'TesztBéla', $data['payload']['comments'][0]['userName'] );
+		$this->assertEquals( 'TesztJózsef', $data['payload']['comments'][1]['userName'] );
+
+		$this->assertEquals( 3, $data['payload']['comments'][0]['id'] );
+		$this->assertEquals( 2, $data['payload']['comments'][1]['id'] );
+	}
+
+	public function testCommentsWithMissingDataAreExcluded() {
+		$response = F::app()->sendExternalRequest(
+			MercuryApiController::class,
+			'getArticleComments',
+			[ 'id' => static::PAGE_WITH_BROKEN_COMMENT_ID ]
+		);
+
+		$data = $response->getData();
+
+		$this->assertEquals( WikiaResponse::FORMAT_JSON, $response->getFormat() );
+		$this->assertEquals( 1, $data['pagesCount'] );
+
+		$this->assertCount( 1, $data['payload']['comments'] );
+
+		foreach ( $data['payload']['comments'] as $comment ) {
+			$this->assertNotNull( $comment );
+		}
+	}
+
+	protected function getDataSet() {
+		return $this->createYamlDataSet( __DIR__  . '/fixtures/mercury_api_controller_integration.yaml');
+	}
+}

--- a/extensions/wikia/MercuryApi/tests/fixtures/mercury_api_controller_integration.yaml
+++ b/extensions/wikia/MercuryApi/tests/fixtures/mercury_api_controller_integration.yaml
@@ -1,0 +1,94 @@
+user:
+  - user_id: 1
+    user_name: 'TesztJózsef'
+    user_email: 'kossuth.lajos@lajoskossuth.hu'
+  - user_id: 2
+    user_name: 'TesztBéla'
+    user_email: 'belavagyok@bela.hu'
+page:
+  - page_id: 1
+    page_namespace: 0
+    page_title: 'Test_article'
+    page_is_redirect: 0
+    page_len: 1
+    page_latest: 0
+    page_restrictions: ''
+    page_random: 0
+  - page_id: 2
+    page_namespace: 1
+    page_title: 'Test_article/@comment-1-20170605164745'
+    page_is_redirect: 0
+    page_len: 1
+    page_latest: 1
+    page_restrictions: ''
+    page_random: 0
+  - page_id: 3
+    page_namespace: 1
+    page_title: 'Test_article/@comment-2-20180605164745'
+    page_is_redirect: 0
+    page_len: 1
+    page_latest: 3
+    page_restrictions: ''
+    page_random: 0
+  - page_id: 4
+    page_namespace: 0
+    page_title: 'Test_article_with_bad_comment'
+    page_is_redirect: 0
+    page_len: 1
+    page_latest: 0
+    page_restrictions: ''
+    page_random: 0
+  - page_id: 5
+    page_namespace: 1
+    page_title: 'Test_article_with_bad_comment/@comment-1-20120101000000'
+    page_is_redirect: 0
+    page_len: 1
+    page_latest: 0
+    page_restrictions: ''
+    page_random: 0
+  - page_id: 6
+    page_namespace: 1
+    page_title: 'Test_article_with_bad_comment/@comment-2-20180101000000'
+    page_is_redirect: 0
+    page_len: 1
+    page_latest: 4
+    page_restrictions: ''
+    page_random: 0
+revision:
+  - rev_id: 1
+    rev_page: 2
+    rev_text_id: 1
+    rev_comment: 'Test comment 1'
+    rev_user: 1
+    rev_user_text: ''
+  - rev_id: 2
+    rev_page: 3
+    rev_text_id: 2
+    rev_comment: 'Test comment 2'
+    rev_user: 2
+    rev_user_text: ''
+  - rev_id: 3
+    rev_page: 3
+    rev_text_id: 3
+    rev_comment: 'Edited comment 2'
+    rev_user: 2
+    rev_user_text: ''
+  - rev_id: 4
+    rev_page: 6
+    rev_text_id: 4
+    rev_comment: 'Test comment'
+    rev_user: 2
+    rev_user_text: ''
+text:
+  - old_id: 1
+    old_text: Lorem ipsum
+    old_flags: ''
+  - old_id: 2
+    old_text: Foo
+    old_flags: ''
+  - old_id: 3
+    old_text: Foo bar
+    old_flags: ''
+  - old_id: 4
+    old_text: baz
+    old_flags: ''


### PR DESCRIPTION
mobile-wiki relies on old WikiaMobile entry point to get article comment data, but it actually doesn't use the html templating there. Let's break this dependency by using `ArticleCommentList` instead. This approach is also more efficient as we save some database queries for every single individual comment when fetching data.

https://wikia-inc.atlassian.net/browse/SUS-4820