### PR TITLE
SUS-4798 | remove old skin-related WikiFactory variables

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -276,36 +276,18 @@ require "$IP/lib/Wikia/src/Service/User/Permissions/data/PermissionsDefinesBefor
  * Apply WikiFactory settings.
  */
 try { 
-    /**
-     * Default skin, for new users and anonymous visitors. Registered users may
-     * change this to any one of the other available skins in their preferences.
-     * This has to be completely lowercase; see the "skins" directory for the
-     * list of available skins.
-     */
-    $wgDefaultSkinBeforeWF = 'oasis';
-    $wgDefaultSkin = null;
-    
     $oWiki = new WikiFactoryLoader( $_SERVER, $_ENV, $wgWikiFactoryDomains );
     $result = $oWiki->execute();
-    
+
     if ( !$result ) {
         // shouldn't we throw an exception here?
         exit( 1 );
     }
-    
+
     $wgCityId = $result;
 
     // we do not need the loader and the result in the global scope.
     unset( $oWiki, $result );
-    
-    /**
-     * WikiFactory is supposed to assign some value to $wgDefaultSkin, a
-     * per-wiki setting. If it fails and at this point $wgDefaultSkin is still
-     * null, we use the cached value from $wgDefaultSkinBeforeWF.
-     */
-    if ( is_null( $wgDefaultSkin ) ) {
-        $wgDefaultSkin = $wgDefaultSkinBeforeWF;
-    }
 } catch ( InvalidArgumentException $invalidArgumentException ) {
 	echo $invalidArgumentException->getMessage() . PHP_EOL;
 	exit( 1 );

--- a/extensions/wikia/Answers/Answers.php
+++ b/extensions/wikia/Answers/Answers.php
@@ -1,16 +1,4 @@
 <?php
-// register answers themes
-$wgSkinTheme['answers'] = array('bluebell', 'leaf', 'carnation', 'sky', 'spring', 'forest', 'moonlight', 'carbon', 'obsession', 'custom');
-$wgDefaultSkin = 'answers';
-$wgDefaultTheme = 'bluebell';
-
-// macbre: make SkinChooser works for Answers
-$wgSkinTheme['monobook'] = array();
-$wgSkipSkins[] = 'monaco';
-$wgSkipSkins[] = 'monobook';
-
-// remove answers from $wgSkipSkins
-unset($wgSkipSkins[ array_search('answers', $wgSkipSkins) ]);
 
 $wgHooks['ArticleSaveComplete'][] = 'AttributionCache::purgeArticleContribs';
 $wgHooks['TitleMoveComplete'][] = 'AttributionCache::purgeArticleContribsAfterMove';

--- a/extensions/wikia/Answers/Answers.php
+++ b/extensions/wikia/Answers/Answers.php
@@ -12,10 +12,10 @@ $wgExtensionCredits[ 'other' ][ ] = array(
 );
 
 // FIXME: Migrate require_once's to inclues for performance reasons.
-require_once( dirname(__FILE__) . "/AnswersClass.php");
-require_once( dirname(__FILE__) . "/AttributionCache.class.php");
+require_once( __DIR__ . "/AnswersClass.php");
+require_once( __DIR__ . "/AttributionCache.class.php");
 
-$wgExtensionMessagesFiles['Answers'] = dirname( __FILE__ ) . '/Answers.i18n.php';
+$wgExtensionMessagesFiles['Answers'] = __DIR__ . '/Answers.i18n.php';
 
 if(empty($wgAnswerHelperIDs)) {
 	$wgAnswerHelperIDs = array( 0 /* anonymous */, 1172427 /* Wikia User */ );
@@ -28,9 +28,9 @@ function incAnswerStats($article, $revision, $baseRevId) {
 }
 
 
-$wgAutoloadClasses['DefaultQuestion'] = dirname( __FILE__ ) . "/DefaultQuestion.php";
-$wgAutoloadClasses['PrefilledDefaultQuestion'] = dirname( __FILE__ ) . "/PrefilledDefaultQuestion.php";
-$wgAutoloadClasses['CreateQuestionPage'] = dirname( __FILE__ ) . "/SpecialCreateDefaultQuestionPage.php";
+$wgAutoloadClasses['DefaultQuestion'] = __DIR__ . "/DefaultQuestion.php";
+$wgAutoloadClasses['PrefilledDefaultQuestion'] = __DIR__ . "/PrefilledDefaultQuestion.php";
+$wgAutoloadClasses['CreateQuestionPage'] = __DIR__ . "/SpecialCreateDefaultQuestionPage.php";
 $wgSpecialPages['CreateQuestionPage'] = 'CreateQuestionPage';
 
 function fnWatchHeldPage( $user ){
@@ -217,7 +217,7 @@ function wfHoldWatchForAnon( $title ){
 	return SpecialPage::getTitleFor( 'Userlogin' )->getFullURL("type=signup");
 }
 
-$wgAutoloadClasses["CustomMovePageForm"]  = dirname( __FILE__ ) . "/CustomMoveForm.php";
+$wgAutoloadClasses["CustomMovePageForm"]  = __DIR__ . "/CustomMoveForm.php";
 $wgHooks['MovePageForm'][] = 'wfCustomMoveForm';
 function wfCustomMoveForm( &$newTitle, &$oldTitle, &$form ){
 
@@ -446,8 +446,8 @@ class CategoryWithAds extends CategoryViewer{
 	}
 }
 
-include( dirname(__FILE__) . "/HomePageList.php");
-include( dirname(__FILE__) . "/FakeAnswersMessaging.php");
+include( __DIR__ . "/HomePageList.php");
+include( __DIR__ . "/FakeAnswersMessaging.php");
 
 $wgAjaxExportList[] = 'wfAnswersGetEditPointsAjax';
 /**

--- a/extensions/wikia/Answers/AnswersClass.php
+++ b/extensions/wikia/Answers/AnswersClass.php
@@ -50,22 +50,21 @@ class Answer {
 		return $category_tag;
 	}
 
-	public function stripCategories( $content ){
+	private static function stripCategories( $content ){
 		global $wgContLang;
 		$content =  preg_replace("@\[\[" . $wgContLang->getNsText( NS_CATEGORY ) . ":[^\]]*?].*?\]@si", '', $content);
 		$content = trim( $content );
 		return $content;
 	}
 
-	public function stripImages( $content ){
+	private static function stripImages( $content ){
 		global $wgContLang;
 		$content =  preg_replace("@\[\[" . $wgContLang->getNsText( NS_IMAGE ) . ":[^\]]*?].*?\]@si", '', $content);
 		$content = trim( $content );
 		return $content;
 	}
 
-	public function stripInterlang( $content ){
-		global $wgContLang;
+	private static function stripInterlang( $content ){
 		$lang_mask = "(" . join("|", array_keys(Language::getLanguageNames())) . ")";
 		$content =  preg_replace("@\[\[" . $lang_mask . ":[^\]]*?].*?\]@si", '', $content);
 		$content = trim( $content );

--- a/extensions/wikia/SkinChooser/SkinChooser.class.php
+++ b/extensions/wikia/SkinChooser/SkinChooser.class.php
@@ -117,7 +117,7 @@ class SkinChooser {
 	 * Select proper skin and theme based on user preferences / default settings
 	 */
 	public static function onGetSkin( RequestContext $context, &$skin ) {
-		global $wgDefaultSkin, $wgDefaultTheme, $wgSkinTheme, $wgAdminSkin, $wgSkipSkins, $wgEnableAnswers;
+		global $wgDefaultSkin, $wgDefaultTheme, $wgSkinTheme, $wgAdminSkin, $wgEnableAnswers;
 
 		wfProfileIn( __METHOD__ );
 
@@ -157,8 +157,8 @@ class SkinChooser {
 			$useskin = 'oasis';
 		}
 
-		if ( !( $title instanceof Title ) || in_array( self::getUserOption( 'skin' ), $wgSkipSkins ) ) {
-			$skin = Skin::newFromKey( isset( $wgDefaultSkin ) ? $wgDefaultSkin : 'monobook' );
+		if ( !( $title instanceof Title ) ) {
+			$skin = Skin::newFromKey( $wgDefaultSkin );
 			wfProfileOut( __METHOD__ );
 			return false;
 		}

--- a/extensions/wikia/ThemeDesigner/ThemeSettings.class.php
+++ b/extensions/wikia/ThemeDesigner/ThemeSettings.class.php
@@ -44,26 +44,8 @@ class ThemeSettings {
 		$this->cityId = $cityId;
 
 		$wgSitename = WikiFactory::getVarValueByName( 'wgSitename', $cityId );
-		$wgAdminSkin = WikiFactory::getVarValueByName( 'wgAdminSkin', $cityId );
 
-		$adminSkin = explode( '-', $wgAdminSkin );
 		$themeName = 'oasis';
-
-		if ( count( $adminSkin ) == 2 ) {
-			$transition = [
-				'sky' => 'oasis',
-				'sapphire' => 'oasis',
-				'spring' => 'jade',
-				'forest' => 'jade',
-				'obsession' => 'carbon',
-				'moonlight' => 'bluesteel',
-				'beach' => 'creamsicle',
-			];
-
-			if ( isset( $transition[$adminSkin[1]] ) ) {
-				$themeName = $transition[$adminSkin[1]];
-			}
-		}
 
 		// colors
 		$this->defaultSettings = $wgOasisThemes[$themeName];

--- a/extensions/wikia/WikiaApi/WikiaApiQuerySiteinfo.php
+++ b/extensions/wikia/WikiaApi/WikiaApiQuerySiteinfo.php
@@ -15,7 +15,7 @@ if (!defined('MEDIAWIKI')) {
 
 class WikiaApiQuerySiteinfo extends ApiQuerySiteinfo {
 
-	private $variablesList = array('wgDefaultSkin','wgDefaultTheme','wgAdminSkin','wgArticlePath','wgScriptPath','wgScript','wgServer','wgLanguageCode','wgCityId','wgContentNamespaces','wgWikiaGlobalUserGroups');
+	private $variablesList = array('wgDefaultTheme','wgArticlePath','wgScriptPath','wgScript','wgServer','wgLanguageCode','wgCityId','wgContentNamespaces','wgWikiaGlobalUserGroups');
 
 	public function __construct($query, $moduleName) {
 		global $wgHooks;

--- a/includes/Skin.php
+++ b/includes/Skin.php
@@ -90,21 +90,13 @@ abstract class Skin extends ContextSource {
 	}
 
 	/**
-	 * Fetch the list of usable skins in regards to $wgSkipSkins.
+	 * Fetch the list of usable skins.
 	 * Useful for Special:Preferences and other places where you
 	 * only want to show skins users _can_ use.
 	 * @return array of strings
 	 */
 	public static function getUsableSkins() {
-		global $wgSkipSkins;
-
-		$usableSkins = self::getSkinNames();
-
-		foreach ( $wgSkipSkins as $skip ) {
-			unset( $usableSkins[$skip] );
-		}
-
-		return $usableSkins;
+		return self::getSkinNames(); // SUS-4796
 	}
 
 	/**

--- a/includes/wikia/VariablesBase.php
+++ b/includes/wikia/VariablesBase.php
@@ -7396,51 +7396,6 @@ $wgSiteStatsAsyncFactor = 1;
 $wgSkipCountForCategories = [];
 
 /**
- * Specify the name of a skin that should not be presented in the list of
- * available skins.  Use for blacklisting a skin which you do not want to
- * remove from the .../skins/ directory. NOTE: a few wikis may have local
- * override for this var, you need to modify those by hand. A SELECT on
- * city_variables will get you a list.
- * @var Array $wgSkipSkins
- */
-$wgSkipSkins = [
-    'answers',
-    'armchairgm',
-    'campfire',
-    'cars',
-    'corporate',
-    'corporatebase',
-    'corporatehome',
-    'curse',
-    'efmonaco',
-    'entertainment',
-    'food',
-    'games',
-    'gwmonobook',
-    'halo',
-    'halogamespot',
-    'health',
-    'home',
-    'law',
-    'local',
-    'lostbook',
-    'memalpha',
-    'monaco_old',
-    'monobook',
-    'music',
-    'politics',
-    'psn',
-    'quartz',
-    'restaurants',
-    'search',
-    'searchwikia',
-    'smartphone',
-    'test',
-    'uncyclopedia',
-    'wikiamobile',
-];
-
-/**
  * If slave DB lag is higher than this number of seconds, show an OBVIOUS
  * warning on some special pages.
  * @see $wgSlaveLagWarning


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-4798

Out of 41133 wikis that have `wgAdminSkin` set only one does not have theme designer customisation (and the wiki is now a redirect).

`wgDefaultSkin` is now forced to `oasis` in the code.