### PR TITLE
(PLATFORM-3506) Enable HTTPS for logged in users on more wikis

### DIFF
--- a/extensions/wikia/HTTPSOptIn/HTTPSOptInHooks.class.php
+++ b/extensions/wikia/HTTPSOptIn/HTTPSOptInHooks.class.php
@@ -15,7 +15,7 @@ class HTTPSOptInHooks {
 
 	// wikis with ID greater than this threshold will get HTTPS on by default for
 	// logged-in users despite the opt-in preference
-	const WIKI_ID_THRESHOLD_WITH_HTTPS_ON = 1700000;
+	const WIKI_ID_THRESHOLD_WITH_HTTPS_ON = 1000000;
 
 	public static function onGetPreferences( User $user, array &$preferences ): bool {
 		global $wgServer, $wgHTTPSForLoggedInUsers, $wgCityId;


### PR DESCRIPTION
Enable HTTPS for logged in users by default on more wikis, lowering the
threshold to wikis with IDs greater than 1000000, which will enable it
on an additional 122,834 wikis.

/cc @Wikia/core-platform-team 