### PR TITLE
SUS-4805 | Make wfWaitForSlaves aware of slaves in neighbouring datacenters

### DIFF
--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -3822,6 +3822,8 @@ function wfWaitForSlaves( $wiki = false ) {
 			$slaves = [];
 
 			foreach( $consul->getDataCentersForEnv( $wgWikiaEnvironment ) as $dc ) {
+				wfDebug( __METHOD__ . ": getting the list of slaves in {$dc} DC...\n" );
+
 				// get the list of IP addresses of all slave nodes from consul
 				// so that we can check all of them explicitly
 				$consul = new Wikia\Consul\Client( [

--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -3833,6 +3833,9 @@ function wfWaitForSlaves( $wiki = false ) {
 				$slaves = array_merge( $slaves, $consul->getNodesFromHostname( $slaveInfo['hostName'] ) );
 			}
 
+			// we may get duplicated entries from different DCs
+			$slaves = array_unique( $slaves );
+
 			// clone the loadbalancer and add all slaves that we've got from Consul
 			$lb = clone $lb;
 

--- a/includes/db/DatabaseMysqlBase.php
+++ b/includes/db/DatabaseMysqlBase.php
@@ -658,7 +658,7 @@ abstract class DatabaseMysqlBase extends DatabaseBase {
 
 		wfProfileIn( __METHOD__ );
 		# Commit any open transactions
-		$this->commit( __METHOD__, 'flush' );
+		$this->commit( __METHOD__ );
 
 		if ( !is_null( $this->mFakeSlaveLag ) ) {
 			$status = parent::masterPosWait( $pos, $timeout );
@@ -670,6 +670,8 @@ abstract class DatabaseMysqlBase extends DatabaseBase {
 		$encFile = $this->addQuotes( $pos->file );
 		$encPos = intval( $pos->pos );
 		$sql = "SELECT MASTER_POS_WAIT($encFile, $encPos, $timeout)";
+
+		wfDebug( sprintf( "Query %s %s %s\n", $this->getDBname(), __METHOD__, $sql ) );
 		$res = $this->doQuery( $sql );
 
 		$status = false;

--- a/lib/Wikia/src/Consul/Client.php
+++ b/lib/Wikia/src/Consul/Client.php
@@ -134,6 +134,10 @@ class Client {
 		));
 	}
 
+	static function getConsulBaseUrlForDC( string $dc ) : string {
+		return sprintf( 'http://consul.service.%s.consul:8500', $dc );
+	}
+
 	/**
 	 * Example: Wikia\Consul\Client::isConsulAddress( 'slave.db-smw.service.consul' )
 	 *

--- a/lib/Wikia/src/Consul/Client.php
+++ b/lib/Wikia/src/Consul/Client.php
@@ -22,14 +22,16 @@ class Client {
 	use Loggable;
 
 	protected $logger;
+	protected $options;
 
 	/* @var \SensioLabs\Consul\Services\Health $api */
 	protected $api;
 
-	function __construct() {
+	function __construct(array $options = []) {
 		$this->logger = WikiaLogger::instance();
+		$this->options = $options;
 
-		$consulService = new ServiceFactory( [], $this->logger );
+		$consulService = new ServiceFactory( $options, $this->logger );
 		$this->api = $consulService->get( 'health' );
 	}
 
@@ -70,7 +72,7 @@ class Client {
 	 * @return array list of IP addresses with ports ie. 127.0.0.1:1234
 	 */
 	private function getNodesFromConsulQuery( string $query ) : array {
-		$consulClient = new ConsulClient();
+		$consulClient = new ConsulClient( $this->options );
 		$resp = $consulClient->get(
 			sprintf( '/v1/query/%s/execute?passing=', $query )
 		)->json();

--- a/lib/Wikia/tests/Consul/ClientTest.php
+++ b/lib/Wikia/tests/Consul/ClientTest.php
@@ -10,6 +10,12 @@ use Wikia\Consul\Client;
  */
 class ConsulClientTest extends WikiaBaseTest {
 
+	function testGetConsulBaseUrlForDC() {
+		$this->assertEquals( 'http://consul.service.sjc.consul:8500', Client::getConsulBaseUrlForDC( 'sjc' ) );
+		$this->assertEquals( 'http://consul.service.sjc-dev.consul:8500', Client::getConsulBaseUrlForDC( 'sjc-dev' ) );
+		$this->assertEquals( 'http://consul.service.res.consul:8500', Client::getConsulBaseUrlForDC( 'res' ) );
+	}
+
 	function testIsConsulAddress() {
 		$this->assertTrue( Client::isConsulAddress( 'slave.db-smw.service.consul' ) );
 		$this->assertTrue( Client::isConsulAddress( 'master.db-a.service.consul' ) );


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-4805

### Why?

Currently `wfWaitForSlaves` queries a local Consul daemon to get the list of slaves nodes of a given database cluster.

However, we do replicate SJC writes to RES slave nodes. We should make `wfWaitForSlaves` aware of other datacenters.

### What changed?

This pull request:

* introduces `Consul/Client::getDataCentersForEnv` method that queries Consul's `/catalog` and returns list of all Wikia datacenters (either `prod` or `dev`)
* `wfWaitForSlaves` now gets the list of all datacenters for the current environment and asks for the list of slaves nodes in all of them

### Example

```
LoadBalancer::doWait: Waiting for slave #1 (10.8.36.50) to catch up...
DatabaseBase::commit: skipped [DatabaseMysqlBase::masterPosWait]
Query plpoznan DatabaseMysqlBase::masterPosWait SELECT MASTER_POS_WAIT('db-sa14_bin.001448', 248206449, 10)
LoadBalancer::doWait: Done
Connecting to 10.8.38.53 plpoznan...
LoadBalancer::doWait: Waiting for slave #2 (10.8.38.53) to catch up...
DatabaseBase::commit: skipped [DatabaseMysqlBase::masterPosWait]
Query plpoznan DatabaseMysqlBase::masterPosWait SELECT MASTER_POS_WAIT('db-sa14_bin.001448', 248206449, 10)
LoadBalancer::doWait: Done
Connecting to 10.8.38.51 plpoznan...
LoadBalancer::doWait: Waiting for slave #3 (10.8.38.51) to catch up...
DatabaseBase::commit: skipped [DatabaseMysqlBase::masterPosWait]
Query plpoznan DatabaseMysqlBase::masterPosWait SELECT MASTER_POS_WAIT('db-sa14_bin.001448', 248206449, 10)
LoadBalancer::doWait: Done
Connecting to 10.8.32.51 plpoznan...
LoadBalancer::doWait: Waiting for slave #4 (10.8.32.51) to catch up...
DatabaseBase::commit: skipped [DatabaseMysqlBase::masterPosWait]
Query plpoznan DatabaseMysqlBase::masterPosWait SELECT MASTER_POS_WAIT('db-sa14_bin.001448', 248206449, 10)
LoadBalancer::doWait: Done
Connecting to 10.12.72.62 plpoznan...
LoadBalancer::doWait: Waiting for slave #5 (10.12.72.62) to catch up...
DatabaseBase::commit: skipped [DatabaseMysqlBase::masterPosWait]
Query plpoznan DatabaseMysqlBase::masterPosWait SELECT MASTER_POS_WAIT('db-sa14_bin.001448', 248206449, 10)
LoadBalancer::doWait: Done
Connecting to 10.12.74.102 plpoznan...
LoadBalancer::doWait: Waiting for slave #6 (10.12.74.102) to catch up...
DatabaseBase::commit: skipped [DatabaseMysqlBase::masterPosWait]
Query plpoznan DatabaseMysqlBase::masterPosWait SELECT MASTER_POS_WAIT('db-sa14_bin.001448', 248206449, 10)
LoadBalancer::doWait: Done
Connecting to 10.12.60.124 plpoznan...
LoadBalancer::doWait: Waiting for slave #7 (10.12.60.124) to catch up...
DatabaseBase::commit: skipped [DatabaseMysqlBase::masterPosWait]
Query plpoznan DatabaseMysqlBase::masterPosWait SELECT MASTER_POS_WAIT('db-sa14_bin.001448', 248206449, 10)
LoadBalancer::doWait: Done
```

Calling `wfWaitForSlaves` on production now takes ~2 seconds - three HTTP requests need to be sent to neighbouring datacenters.


```php
> var_dump( (new Wikia\Consul\Client())->getDataCentersForEnv('dev') )

array(2) {
  [0] =>
  string(7) "poz-dev"
  [1] =>
  string(7) "sjc-dev"
}

> var_dump( (new Wikia\Consul\Client())->getDataCentersForEnv('prod') )

array(4) {
  [0] =>
  string(3) "poz"
  [1] =>
  string(3) "fra"
  [2] =>
  string(3) "res"
  [3] =>
  string(3) "sjc"
}
```