### PR TITLE
HOTFIX | IRIS-4844 | Return meaningful error when DiscussionsActivator fails

### DIFF
--- a/extensions/wikia/Discussions/api/DiscussionsActivator.class.php
+++ b/extensions/wikia/Discussions/api/DiscussionsActivator.class.php
@@ -74,7 +74,7 @@ class DiscussionsActivator {
 		return $api;
 	}
 
-	private function logAndThrowError( Exception $e ) {
+	private function logAndThrowError( ApiException $e ) {
 		$this->logger->critical(
 			'DISCUSSIONS Creating site caused an error. Site ID: ' . $this->cityId,
 			[
@@ -82,6 +82,7 @@ class DiscussionsActivator {
 				'error' => $e->getMessage()
 			]
 		);
-		throw new ErrorPageError( 'unknown-error', 'discussions-activate-error' );
+
+		throw new WikiaException('discussions-activate-error', $e->getCode(), $e);
 	}
 }

--- a/extensions/wikia/Discussions/controllers/EnableDiscussionsController.class.php
+++ b/extensions/wikia/Discussions/controllers/EnableDiscussionsController.class.php
@@ -12,21 +12,32 @@ class EnableDiscussionsController extends \WikiaController {
 	}
 
 	public function activateDiscussions() {
-		$cityId = $this->request->getInt( self::SITE_ID );
-		if ( empty( $cityId ) ) {
-			throw new BadRequestException();
-		}
+		try {
+			$cityId = $this->request->getInt( self::SITE_ID );
+			if ( empty( $cityId ) ) {
+				throw new BadRequestException();
+			}
 
-		$wiki = WikiFactory::getWikiByID( $cityId );
-		if ( empty( $wiki ) ) {
-			throw new NotFoundException();
-		}
+			$wiki = WikiFactory::getWikiByID( $cityId );
+			if ( empty( $wiki ) ) {
+				throw new NotFoundException();
+			}
 
-		( new \DiscussionsActivator( $wiki->city_id, $wiki->city_title,
-			$wiki->city_lang ) )->activateDiscussions();
+			( new \DiscussionsActivator( $wiki->city_id, $wiki->city_title,
+				$wiki->city_lang ) )->activateDiscussions();
 
-		if ( $this->request->getBool( self::CREATE_WELCOME_POST, false ) ) {
-			( new \StaffWelcomePoster() )->postMessage( $wiki->city_id, $wiki->city_lang );
+			if ( $this->request->getBool( self::CREATE_WELCOME_POST, false ) ) {
+				( new \StaffWelcomePoster() )->postMessage( $wiki->city_id, $wiki->city_lang );
+			}
+		} catch ( WikiaBaseException $exception ) {
+			$this->response->setCode( $exception->getCode() );
+			$this->response->setVal(
+				'exception',
+				[
+					'message' => $exception->getMessage(),
+					'code' => $exception->getCode()
+				]
+			);
 		}
 	}
 
@@ -50,7 +61,7 @@ class EnableDiscussionsController extends \WikiaController {
 
 	/**
 	 * Make sure to only allow authorized POST methods.
-	 * @throws \Email\Fatal
+	 * @throws WikiaHttpException
 	 */
 	public function assertCanAccessController() {
 		if ( !$this->request->isInternal() ) {

--- a/extensions/wikia/Discussions/controllers/EnableDiscussionsController.class.php
+++ b/extensions/wikia/Discussions/controllers/EnableDiscussionsController.class.php
@@ -8,6 +8,7 @@ class EnableDiscussionsController extends \WikiaController {
 
 	public function init() {
 		$this->assertCanAccessController();
+		$this->response->setFormat( WikiaResponse::FORMAT_JSON );
 	}
 
 	public function activateDiscussions() {

--- a/extensions/wikia/Discussions/controllers/EnableDiscussionsController.class.php
+++ b/extensions/wikia/Discussions/controllers/EnableDiscussionsController.class.php
@@ -30,6 +30,8 @@ class EnableDiscussionsController extends \WikiaController {
 				( new \StaffWelcomePoster() )->postMessage( $wiki->city_id, $wiki->city_lang );
 			}
 		} catch ( WikiaBaseException $exception ) {
+			// This is normally done in WikiaDispatcher::dispatch(),
+			// but because it's an internal request, we would return 200 and only log error to ELK stack
 			$this->response->setCode( $exception->getCode() );
 			$this->response->setVal(
 				'exception',


### PR DESCRIPTION
## Links
- https://wikia-inc.atlassian.net/browse/IRIS-4844
- https://github.com/Wikia/app/pull/15422

## Description
Instead of an error page with status code 200, let's return JSON with error details and appropriate status code.