### PR TITLE
HOTFIX | IRIS-5879 | Stop dumping unused `comment` column

### DIFF
--- a/extensions/wikia/Discussions/maintenance/ForumDumper.php
+++ b/extensions/wikia/Discussions/maintenance/ForumDumper.php
@@ -63,7 +63,6 @@ class ForumDumper {
 		"length",
 		"parent_id",
 		"text_flags",
-		"comment",
 		"raw_content",
 		"content",
 	];
@@ -189,7 +188,6 @@ class ForumDumper {
 					"length" => $row->rev_len,
 					"parent_id" => $row->rev_parent_id,
 					"text_flags" => $row->old_flags,
-					"comment" => $row->rev_comment,
 					"raw_content" => $plainText,
 					"content" => $parsedText,
 				] );


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/IRIS-5879
https://github.com/Wikia/app/pull/15448

Fix for:
```
ERROR 1366 (HY000) at line 1788: Incorrect string value: '\xE5\x88...\xE2...' for column 'comment' at row 1
```
We're not using this column in the migration process, anyway.