### PR TITLE
MAIN-15519: Fixed name of bot user in new wiki greetings

### DIFF
--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -466,7 +466,7 @@ class Wikia {
 			$staffUser = User::newFromName( $staffMap[$langCode][$key] );
 		} else {
 			// Fallback to robot when there is no explicit welcoming user set (unsupported language)
-			$staffUser = User::newFromName( 'Fandom' );
+			$staffUser = User::newFromName( self::USER );
 		}
 
 		$staffUser->load();


### PR DESCRIPTION
On non-top-language wikis, the user greeting founders was set to `Fandom` instead of `FANDOM`. This pull request changes it to use the `Wikia::USER` constant.

Support ticket: [#395909](https://support.wikia-inc.com/hc/en-us/requests/395909) (under number 14)
Bug ticket: [MAIN-15519](https://wikia-inc.atlassian.net/browse/MAIN-15519)
Example of the issue: [w:c:tr.kariyer:Thread:18](http://tr.kariyer.wikia.com/wiki/Thread:18)