### PR TITLE
🐖 | Address more PHP 7.2 incompatibilities

### DIFF
--- a/extensions/3rdparty/LyricWiki/nusoap.php
+++ b/extensions/3rdparty/LyricWiki/nusoap.php
@@ -2120,7 +2120,7 @@ class soap_transport_http extends nusoap_base {
 
  				// parse elements into array
  				$digestElements = explode(', ', $digestString);
- 				while (list($key, $val) = each($digestElements)) {
+ 				foreach ( $digestElements as $val ) {
  					$tempElement = explode('=', $val);
  					$digestRequest[$tempElement[0]] = str_replace("\"", '', $tempElement[1]);
  				}

--- a/extensions/wikia/Blogs/BlogTemplate.php
+++ b/extensions/wikia/Blogs/BlogTemplate.php
@@ -1238,7 +1238,7 @@ class BlogTemplateClass {
 				$sText = $oRevision->getText();
 				$id = Parser::extractTagsAndParams( array( BLOGTPL_TAG ), $oRevision->getText(), $matches, md5( BLOGTPL_TAG . $articleId . $namespace . $page0 ) );
 				if ( !empty( $matches ) ) {
-					list ( $sKey, $aValues ) = each ( $matches );
+					$sKey = key( $matches );
 					list ( , $input, $params, ) = $matches[$sKey];
 					$input = trim( $input );
 					if ( !empty( $input ) && ( !empty( $params ) ) ) {

--- a/includes/AutoLoader.php
+++ b/includes/AutoLoader.php
@@ -986,12 +986,4 @@ class AutoLoader {
 	}
 }
 
-if ( function_exists( 'spl_autoload_register' ) ) {
-	spl_autoload_register( array( 'AutoLoader', 'autoload' ) );
-} else {
-	function __autoload( $class ) {
-		AutoLoader::autoload( $class );
-	}
-
-	ini_set( 'unserialize_callback_func', '__autoload' );
-}
+spl_autoload_register( [ 'AutoLoader', 'autoload' ] );

--- a/includes/Xml.php
+++ b/includes/Xml.php
@@ -625,8 +625,8 @@ class Xml {
 		} elseif ( is_int( $value ) || is_float( $value ) ) {
 			$s = strval($value);
 		} elseif ( is_array( $value ) && // Make sure it's not associative.
-					array_keys($value) === range( 0, count($value) - 1 ) ||
-					count($value) == 0
+				   ( array_keys($value) === range( 0, count($value) - 1 ) ||
+					count($value) == 0 )
 				) {
 			$s = '[';
 			foreach ( $value as $elt ) {

--- a/includes/wikia/api/tests/WikisApiControllerTest.php
+++ b/includes/wikia/api/tests/WikisApiControllerTest.php
@@ -55,7 +55,11 @@ class WikisApiControllerTest extends WikiaBaseTest {
 		$wikisApiController->setResponse( $response );
 		$wikisApiController->getDetails();
 
-		$actualDetailsCount = count( $response->getVal( 'items' ) );
+		$items = $response->getVal( 'items' );
+
+		$this->assertInternalType( 'object', $items );
+
+		$actualDetailsCount = count( (array) $items );
 		$this->assertLessThanOrEqual( WikisApiController::MAX_WIKIS, $actualDetailsCount );
 	}
 

--- a/includes/wikia/models/NavigationModel.class.php
+++ b/includes/wikia/models/NavigationModel.class.php
@@ -551,7 +551,7 @@ class NavigationModel extends WikiaModel {
 	private function getBiggestCategory( $index ) {
 		$limit = max( $index, 15 );
 
-		if ( $limit > count( $this->biggestCategories ) ) {
+		if ( !is_array( $this->biggestCategories ) || $limit > count( $this->biggestCategories ) ) {
 
 			$blackList = $this->wg->BiggestCategoriesBlacklist;
 


### PR DESCRIPTION
The following:
```
Deprecated: __autoload() is deprecated, use spl_autoload_register() instead in /home/travis/build/Wikia/app/includes/AutoLoader.php on line 992

PHP Warning:  count(): Parameter must be an array or an object that implements Countable in /home/travis/build/Wikia/app/includes/wikia/models/NavigationModel.class.php on line 554

PHP Warning:  count(): Parameter must be an array or an object that implements Countable in /home/travis/build/Wikia/app/includes/wikia/api/tests/WikisApiControllerTest.php on line 58

PHP Warning:  count(): Parameter must be an array or an object that implements Countable in /home/travis/build/Wikia/app/includes/Xml.php on line 629
```

And remove two stray `each()` usages from `BlogTemplateClass`and LyricWiki code.