### PR TITLE
MAIN-15543: Fix VE error when displaying Phalanx hit

### DIFF
--- a/resources/Resources.php
+++ b/resources/Resources.php
@@ -650,6 +650,11 @@ return array(
 				'mediawiki.cldr',
 			),
 		'targets' => array( 'desktop', 'mobile' ),
+		'messages' => array(
+			'and',
+			'comma-separator',
+			'word-separator'
+		),
 	),
 
 	'mediawiki.cldr' => array(

--- a/resources/src/mediawiki.language/mediawiki.language.js
+++ b/resources/src/mediawiki.language/mediawiki.language.js
@@ -144,8 +144,30 @@ $.extend( mw.language, {
 			return grammarForms[form][word] || word;
 		}
 		return word;
-	}
+	},
 
+	/**
+	 * Turn a list of string into a simple list using commas and 'and'.
+	 *
+	 * See Language::listToText in languages/Language.php
+	 *
+	 * @param {string[]} list
+	 * @return {string}
+	 */
+	listToText: function ( list ) {
+		var text = '',
+			i = 0;
+
+		for ( ; i < list.length; i++ ) {
+			text += list[ i ];
+			if ( list.length - 2 === i ) {
+				text += mw.msg( 'and' ) + mw.msg( 'word-separator' );
+			} else if ( list.length - 1 !== i ) {
+				text += mw.msg( 'comma-separator' );
+			}
+		}
+		return text;
+	}
 } );
 
 }( mediaWiki, jQuery ) );


### PR DESCRIPTION
When saving a page hits Phalanx, VE keeps indefinitely loading because `mw.language.listToText` function doesn't exist:
![Image](https://i.imgur.com/QdgUdgi.png)
Backports https://github.com/wikimedia/mediawiki/commit/2f0d1b81188dcbb6221f5c8a531b6bb6f50bc17d.

Support ticket: [ZD#395909](https://support.wikia-inc.com/hc/requests/395909)
Bug ticket: [MAIN-15543](https://wikia-inc.atlassian.net/browse/MAIN-15543)