### PR TITLE
MAIN-15545: Fix save button after previewing changes in Ace

### DIFF
--- a/extensions/wikia/EditPageLayout/css/core/syntaxhighlighting.scss
+++ b/extensions/wikia/EditPageLayout/css/core/syntaxhighlighting.scss
@@ -31,6 +31,7 @@
 	}
 
 	.codepage-publish-button {
+		box-sizing: border-box;
 		width: calc(100% - 22px);
 	}
 }


### PR DESCRIPTION
This happens because the change previewing modal loads uifactory resources such as [button_default.scss](https://github.com/Wikia/app/blob/dev/resources/wikia/ui_components/button/css/button_default.scss) which overrides the default styles in [buttons-wikia.scss](https://github.com/Wikia/app/blob/dev/skins/shared/styles/buttons/buttons-wikia.scss) (specifically, the `box-sizing` property):
![Image](https://i.imgur.com/TAcsFZm.gif)

Support ticket: [ZD#395909](https://support.wikia-inc.com/hc/requests/395909)
Bug ticket: [MAIN-15545](https://wikia-inc.atlassian.net/browse/MAIN-15545)