### PR TITLE
PLATFORM-3525: lower threshold for wiki's with HTTPS enabled by default

### DIFF
--- a/extensions/wikia/HTTPSOptIn/HTTPSOptInHooks.class.php
+++ b/extensions/wikia/HTTPSOptIn/HTTPSOptInHooks.class.php
@@ -15,7 +15,7 @@ class HTTPSOptInHooks {
 
 	// wikis with ID greater than this threshold will get HTTPS on by default for
 	// logged-in users despite the opt-in preference
-	const WIKI_ID_THRESHOLD_WITH_HTTPS_ON = 1000000;
+	const WIKI_ID_THRESHOLD_WITH_HTTPS_ON = 100000;
 
 	public static function onGetPreferences( User $user, array &$preferences ): bool {
 		global $wgServer, $wgHTTPSForLoggedInUsers, $wgCityId;


### PR DESCRIPTION
Threshold is set to IDs < 100k

ping: @Wikia/core-platform-team 