### PR TITLE
Wikia::setProps-save is simply polluting stdout

### DIFF
--- a/extensions/wikia/MyHome/MyHome.class.php
+++ b/extensions/wikia/MyHome/MyHome.class.php
@@ -421,13 +421,11 @@ class MyHome {
 	 * @return bool
 	 */
 	public static function savingAnRc( RecentChange $rc ): bool {
-		global $wgAchievementToAddToRc, $wgWikiaForceAIAFdebug;
+		global $wgAchievementToAddToRc;
 		wfProfileIn( __METHOD__ );
 
 		// If an achievement is spooled from earlier in the pageload, stuff it into this RecentChange.
-		Wikia::log(__METHOD__, "", "RecentChange has arrived.", $wgWikiaForceAIAFdebug);
 		if(!empty($wgAchievementToAddToRc)){
-			Wikia::log(__METHOD__, "", "RecentChange arrived. Storing achievement that we've already seen.", $wgWikiaForceAIAFdebug);
 			$additionalData = array('Badge' => $wgAchievementToAddToRc);
 			MyHome::storeInRecentChanges($rc, $additionalData);
 			unset($wgAchievementToAddToRc);

--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -890,7 +890,6 @@ class Wikia {
 					),
 					__METHOD__
 				);
-				Wikia::log( __METHOD__, "save", "id: {$page_id}, key: {$sPropName}, value: {$sPropValue}" );
 			}
 			$dbw->commit(); #--- for ajax
 		}


### PR DESCRIPTION
```
Asia ...MyHome::savingAnRc:esluxbriz/1369685: RecentChange has arrived.
Wikia::setProps-save:esluxbriz/1369685: id: 759, key: infoboxes, value: 
MyHome::savingAnRc:esluxbriz/1369685: RecentChange has arrived.
 migrated
```

Make the go away