### PR TITLE
SUS-4805 | keep the list of datacenters per environment in $wgConsulDataCenters global

### DIFF
--- a/includes/wikia/VariablesBase.php
+++ b/includes/wikia/VariablesBase.php
@@ -1170,6 +1170,27 @@ $wgCompiledFiles = [];
 $wgCompressRevisions = true;
 
 /**
+ * Hardcoded list of data-centers by environment
+ *
+ * Avoid costly HTTP calls on production to Consul agents in data centers like 'poz' or 'fra'
+ *
+ * @see SUS-4805
+ *
+ * @see lib/Wikia/src/Consul/Client.php
+ * @var array $wgConsulDataCenters
+ */
+$wgConsulDataCenters = [
+	'dev' => [
+		'sjc-dev',
+		'poz-dev',
+	],
+	'prod' => [
+		'sjc',
+		'res',
+	],
+];
+
+/**
  * Slack webhook URL for JavaScript Review Tool.
  * @see extensions/wikia/ContentReview
  * @var string $wgContentReviewSlackWebhook

--- a/lib/Wikia/src/Consul/Client.php
+++ b/lib/Wikia/src/Consul/Client.php
@@ -125,13 +125,8 @@ class Client {
 	 * @return string[]
 	 */
 	function getDataCentersForEnv( string $env ) {
-		return array_values(array_filter(
-			// e.g. poz, sjc-dev, res
-			$this->catalog->datacenters()->json(),
-			function( $dc ) use ( $env ) {
-				return $env === 'dev' ? endsWith($dc, '-dev') : !endsWith($dc, '-dev');
-			}
-		));
+		global $wgConsulDataCenters;
+		return $wgConsulDataCenters[$env];
 	}
 
 	static function getConsulBaseUrlForDC( string $dc ) : string {


### PR DESCRIPTION
This will save costly cross-DC HTTP requests to Consul agents in fra and poz on production. And I wanted to avoid hard-coding ;)

```php
> var_dump( (new Wikia\Consul\Client())->getDataCentersForEnv('dev') )
/usr/wikia/source/deploytools/18879/src/maintenance/eval.php(88) : eval()'d code:1:
array(2) {
  [0] =>
  string(7) "sjc-dev"
  [1] =>
  string(7) "poz-dev"
}

> var_dump( (new Wikia\Consul\Client())->getDataCentersForEnv('prod') )
/usr/wikia/source/deploytools/18879/src/maintenance/eval.php(88) : eval()'d code:1:
array(2) {
  [0] =>
  string(3) "sjc"
  [1] =>
  string(3) "res"
}
```

Do not call `poz` and `fra` datacenters on production - there are no databases there.