### PR TITLE
PLATFORM-3525: fix closeWiki script to set flags properly

### DIFF
--- a/maintenance/wikia/closeWiki.php
+++ b/maintenance/wikia/closeWiki.php
@@ -34,7 +34,7 @@ class CloseWiki extends Maintenance {
 		try {
 			$res = WikiFactory::setPublicStatus( WikiFactory::CLOSE_ACTION, $wikiId, $reason );
 			
-			if ( $res ) {
+			if ( $res === WikiFactory::CLOSE_ACTION ) {
 				WikiFactory::setFlags( $wikiId, WikiFactory::FLAG_FREE_WIKI_URL | WikiFactory::FLAG_CREATE_DB_DUMP | WikiFactory::FLAG_CREATE_IMAGE_ARCHIVE );
 				WikiFactory::clearCache( $wikiId );
 			}


### PR DESCRIPTION
`setPublicStatus` returns `false` if there is an error or return desired status applied to a wiki (in this case it is `CLOSE_ACTION` which equals to `0`) and this renders modified if statement to be evaluated as false always.

ping: @Wikia/core-platform-team @Wikia/sus 