### PR TITLE
(PLATFORM-3528) Purge HTTP URLs when edits are made over HTTPS

### DIFF
--- a/extensions/wikia/PortableInfoboxBuilder/PortableInfoboxBuilderHooks.class.php
+++ b/extensions/wikia/PortableInfoboxBuilder/PortableInfoboxBuilderHooks.class.php
@@ -88,7 +88,7 @@ class PortableInfoboxBuilderHooks {
 				&& !PortableInfoboxBuilderHelper::isSubmitAction( $request )
 				&& !PortableInfoboxBuilderHelper::isForcedSourceMode( $request )
 		) {
-			$url = SpecialPage::getTitleFor( 'InfoboxBuilder', $title->getText() )->getInternalURL();
+			$url = SpecialPage::getTitleFor( 'InfoboxBuilder', $title->getText() )->getFullURL();
 			F::app()->wg->out->redirect( $url );
 			return false;
 		}

--- a/includes/Title.php
+++ b/includes/Title.php
@@ -1600,7 +1600,8 @@ class Title {
 		global $wgInternalServer, $wgServer;
 		$query = self::fixUrlQueryArgs( $query, $query2 );
 		$server = $wgInternalServer !== false ? $wgInternalServer : $wgServer;
-		$url = wfExpandUrl( $server . $this->getLocalURL( $query ), PROTO_HTTP );
+		// Ensure cache is purged over HTTP for now (PLATFORM-3528)
+		$url = wfHttpsToHttp( wfExpandUrl( $server . $this->getLocalURL( $query ), PROTO_HTTP ) );
 		Hooks::run( 'GetInternalURL', [ $this, &$url, $query ] );
 
 		return $url;

--- a/includes/actions/HistoryAction.php
+++ b/includes/actions/HistoryAction.php
@@ -98,7 +98,7 @@ class HistoryAction extends FormlessAction {
 
 		wfProfileIn( __METHOD__ );
 
-		if ( $request->getFullRequestURL() == $this->getTitle()->getInternalURL( 'action=history' ) ) {
+		if ( $request->getFullRequestURL() === $this->getTitle()->getFullURL( 'action=history' ) ) {
 			$out->setSquidMaxage( $wgSquidMaxage );
 		}
 

--- a/includes/specials/SpecialRecentchanges.php
+++ b/includes/specials/SpecialRecentchanges.php
@@ -164,11 +164,12 @@ class SpecialRecentChanges extends IncludableSpecialPage {
 
 		if ( !$this->including() ) {
 			$requestUrl = $this->getRequest()->getFullRequestURL();
-			$specialPageTitle = SpecialPage::getTitleFor('RecentChanges');
+			$specialPageTitle = SpecialPage::getTitleFor( 'RecentChanges' );
 
-			if( $requestUrl == $specialPageTitle->getInternalURL()
-				|| $requestUrl == $specialPageTitle->getInternalURL('feed=rss')
-				|| $requestUrl == $specialPageTitle->getInternalURL('feed=atom') ) {
+			if ( $requestUrl === $specialPageTitle->getFullURL()
+				|| $requestUrl === $specialPageTitle->getFullURL( 'feed=rss')
+				|| $requestUrl === $specialPageTitle->getFullURL( 'feed=atom' )
+			) {
 				$squidMaxage = $wgSquidMaxage;
 			}
 		}
@@ -198,7 +199,7 @@ class SpecialRecentChanges extends IncludableSpecialPage {
 		}
 
 		// wikia change begin
-		// bugId: 47961 Owen -- this whole query is useless IMHO as the results are not used directly 
+		// bugId: 47961 Owen -- this whole query is useless IMHO as the results are not used directly
 		// It caches links as a side effect, but the links are already cached by other wikia changes
 		/*
 		if( !$feedFormat ) {
@@ -567,7 +568,7 @@ class SpecialRecentChanges extends IncludableSpecialPage {
 			--$limit;
 		}
 		$s .= $list->endRecentChangesList();
-		
+
 		/* Wikia Change */
 		$this->getOutput()->addHTML( Xml::openElement( 'div', array( 'class' => 'rc-conntent' )) .  $s . Xml::closeElement('div') );
 		/* Wikia Change END*/
@@ -709,7 +710,7 @@ class SpecialRecentChanges extends IncludableSpecialPage {
 		$nsSelect = '';
 		/* Wikia Change */
 		Hooks::run( 'onGetNamespaceCheckbox', array(&$nsSelect, $opts['namespace'], '', 'namespace', null) );
-		
+
 		$nsLabel = Xml::label( wfMsg( 'namespace' ), 'namespace' );
 		if ( empty($nsSelect) ) {
 			$nsSelect = Html::namespaceSelector(


### PR DESCRIPTION
When a user makes an edit, MediaWiki generates a list of URLs to purge
from the CDN. If the user makes the edit over HTTPS, the URLs generated
were all HTTPS. While we separate the cache on Fastly based on the
protocol, when you purge one URL, it purges both HTTP and HTTPS.
However, if you try to purge the HTTPS version of a URL unauthenticated,
it doesn't work, but the HTTP one does. The MediaWiki purge would be
"anonymous" so the HTTPS URL purge wouldn't work at the moment.

As such, we will for now only purge HTTP URLs for article pages.

/cc @Wikia/core-platform-team 