### PR TITLE
SUS-5128 | use GoogleMaps API key in Places extension

### DIFF
--- a/extensions/Maps/Maps.php
+++ b/extensions/Maps/Maps.php
@@ -218,6 +218,9 @@ $GLOBALS['wgExtensionFunctions'][] = function() {
 		SemanticMaps::newFromMediaWikiGlobals( $GLOBALS )->initExtension();
 	}
 
+	// SUS-5128 - use Wiki specific API key that differs between environments
+	$GLOBALS['egMapsGMaps3ApiKey'] = $GLOBALS['wgGoogleMapsKey'];
+
 	return true;
 };
 

--- a/extensions/Maps/Maps_Settings.php
+++ b/extensions/Maps/Maps_Settings.php
@@ -188,7 +188,8 @@
 	// Google Maps v3
 
 		// String. Google Maps v3 API Key
-		$GLOBALS['egMapsGMaps3ApiKey'] = '';
+		// SUS-5128 - use Wiki specific API key that differs between environments
+		$GLOBALS['egMapsGMaps3ApiKey'] = $wgGoogleMapsKey;
 
 		// String. Google Maps v3 API version number
 		$GLOBALS['egMapsGMaps3ApiVersion'] = '';

--- a/extensions/Maps/Maps_Settings.php
+++ b/extensions/Maps/Maps_Settings.php
@@ -188,8 +188,7 @@
 	// Google Maps v3
 
 		// String. Google Maps v3 API Key
-		// SUS-5128 - use Wiki specific API key that differs between environments
-		$GLOBALS['egMapsGMaps3ApiKey'] = $wgGoogleMapsKey;
+		$GLOBALS['egMapsGMaps3ApiKey'] = '';
 
 		// String. Google Maps v3 API version number
 		$GLOBALS['egMapsGMaps3ApiVersion'] = '';

--- a/extensions/wikia/Places/PlacesController.class.php
+++ b/extensions/wikia/Places/PlacesController.class.php
@@ -60,11 +60,15 @@ class PlacesController extends WikiaController {
 	 * Map center can be specified
 	 */
 	public function renderMarkers() {
+		// SUS-5128 | add Google Maps API key
+		global $egMapsGMaps3ApiKey;
+
 		$this->setVal('markers', $this->prepareMarkers($this->getVal('markers')));
 		$this->setVal('center', $this->getVal('center'));
 		$this->setVal('mapId', 'places-map-' . self::$mapId++);
 		$this->setVal('height', $this->getVal('height', 500));
 		$this->setVal('options', $this->getVal('options', array()));
+		$this->setVal('googleMapsApiKey', $egMapsGMaps3ApiKey);
 	}
 
 	/**

--- a/extensions/wikia/Places/PlacesController.class.php
+++ b/extensions/wikia/Places/PlacesController.class.php
@@ -61,14 +61,14 @@ class PlacesController extends WikiaController {
 	 */
 	public function renderMarkers() {
 		// SUS-5128 | add Google Maps API key
-		global $egMapsGMaps3ApiKey;
+		global $wgGoogleMapsKey;
 
 		$this->setVal('markers', $this->prepareMarkers($this->getVal('markers')));
 		$this->setVal('center', $this->getVal('center'));
 		$this->setVal('mapId', 'places-map-' . self::$mapId++);
 		$this->setVal('height', $this->getVal('height', 500));
 		$this->setVal('options', $this->getVal('options', array()));
-		$this->setVal('googleMapsApiKey', $egMapsGMaps3ApiKey);
+		$this->setVal('googleMapsApiKey', $wgGoogleMapsKey);
 	}
 
 	/**

--- a/extensions/wikia/Places/PlacesParserHookHandler.class.php
+++ b/extensions/wikia/Places/PlacesParserHookHandler.class.php
@@ -180,10 +180,11 @@ class PlacesParserHookHandler {
 
 	/**
 	 * Get JavaScript code snippet to be loaded
+	 *
+	 * @param array $options
+	 * @return string
 	 */
 	static public function getJSSnippet(Array $options = array()) {
-		$am = AssetsManager::getInstance();
-
 		$html = JSSnippets::addToStack(
 			array( 'places_css', 'places_js' ),
 			array(),

--- a/extensions/wikia/Places/templates/Places_renderMarkers.php
+++ b/extensions/wikia/Places/templates/Places_renderMarkers.php
@@ -1,4 +1,7 @@
 <div id="<?= $mapId ?>" class="places-map" style="width:100%; height:<?= $height; ?>px"></div>
+<script>
+	wgGoogleMapsApiKey = <?= Xml::encodeJsVar( $googleMapsApiKey ) ?>;
+</script>
 <?=  JSSnippets::addToStack(
 		array( 'places_css', 'places_js' ),
 		array( '$.loadGoogleMaps' ),

--- a/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadLibrary.js
+++ b/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadLibrary.js
@@ -108,6 +108,14 @@
 				onLoaded();
 			};
 
+			// SUS-5128 | track page views where Google Maps API is loaded
+			window.Wikia.Tracker.track({
+				action: Wikia.Tracker.ACTIONS.OPEN,
+				category: 'googlemaps',
+				label: 'apiloaded',
+				trackingMethod: 'analytics'
+			});
+
 			// load GoogleMaps main JS and provide a name of the callback to be called when API is fully initialized
 			$.loadLibrary(
 				'GoogleMaps',

--- a/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadLibrary.js
+++ b/resources/wikia/libraries/jquery/loadLibrary/jquery.wikia.loadLibrary.js
@@ -82,7 +82,15 @@
 		return mw.loader.using('wikia.handlebars').done(callback);
 	};
 
-	$.loadGoogleMaps = function (callback) {
+	$.loadGoogleMaps = function (key, callback) {
+		// SUS-5128 | the key is optional
+		if (typeof key === 'function') {
+			callback = key;
+			key = undefined;
+		}
+
+		key = key || window.wgGoogleMapsApiKey;
+
 		var dfd = new jQuery.Deferred(),
 			onLoaded = function () {
 				if (typeof callback === 'function') {
@@ -104,7 +112,7 @@
 			$.loadLibrary(
 				'GoogleMaps',
 				[{
-					url: 'https://maps.googleapis.com/maps/api/js?sensor=false&callback=onGoogleMapsLoaded',
+					url: 'https://maps.googleapis.com/maps/api/js?sensor=false&callback=onGoogleMapsLoaded&key=' + (key || ''),
 					type: 'js'
 				}],
 				typeof (window.google && window.google.maps)


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5128

Avoid the following:

```
Google Maps JavaScript API warning: NoApiKeys https://developers.google.com/maps/documentation/javascript/error-messages#no-api-keys
```

Additionally, track when Google Maps API is loaded via `$.loadGoogleMaps` (uses by Places extension):

```
Wikia.Tracker: trackingevent googlemaps/open/apiloaded/ [analytics track]
```