### PR TITLE
SUS-5135 | Disable devbox import script

### DIFF
--- a/maintenance/wikia/getDatabase.php
+++ b/maintenance/wikia/getDatabase.php
@@ -9,6 +9,10 @@
  * It also imports WikiFactory variables from the production database
  */
 
+// SUS-5135 | Disable devbox import script
+echo "getDatabase.php script has been disabled due to lack of GDPR compliance. Please see SUS-5135 for details.\n";
+exit(1);
+
 putenv ("SERVER_ID=177");
 
 define('S3CMD_CONFIG', '/etc/s3cmd/amazon_ro.cfg');


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5135

It's not compatible with GDPR.

```
macbre@dev-macbre:~/app/maintenance/wikia$ php getDatabase.php -h plpoznan
getDatabase.php script has been disabled due to lack of GDPR compliance. Please see SUS-5135 for details.
```

and emit exit code 1.