### PR TITLE
Make CentralHelpSearch URL protocol-relative when possible

### DIFF
--- a/extensions/wikia/SharedHelp/CentralHelpSearch.php
+++ b/extensions/wikia/SharedHelp/CentralHelpSearch.php
@@ -52,6 +52,9 @@ function efCreateSearchForm() {
 
 	if ( !empty( $wgHelpWikiId ) ) {
 		$helpSearchUrl = GlobalTitle::newFromText( 'Search', NS_SPECIAL, $wgHelpWikiId )->getFullURL();
+		if ( wfHttpsAllowedForURL( $helpSearchUrl ) ) {
+			$helpSearchUrl = wfProtocolUrlToRelative( $helpSearchUrl );
+		}
 	} else {
 		$helpSearchUrl = SpecialPage::getTitleFor( 'Search' )->getLocalURL();
 	}


### PR DESCRIPTION
This is a parser tag cached in the page content, so if an anon was the
one requesting the page over plain HTTP when the parsed output was last
cached for the page, it would result in logged in users getting mixed
content warnings over HTTPS on subsequent views.

/cc @Wikia/core-platform-team 