### PR TITLE
SUS-5236 | Memoize anon user's default preferences

### DIFF
--- a/lib/Wikia/src/Service/User/Preferences/PreferenceService.php
+++ b/lib/Wikia/src/Service/User/Preferences/PreferenceService.php
@@ -43,6 +43,9 @@ class PreferenceService {
 		$this->defaultPreferences = $defaultPrefs;
 		$this->forceSavePrefs = $forceSavePrefs;
 		$this->preferences = [];
+
+		// 🐖: anonymous users will always have default preferences
+		$this->preferences[0] = clone $defaultPrefs;
 	}
 
 	public function getPreferences( $userId ) {
@@ -218,9 +221,6 @@ class PreferenceService {
 	 * @throws \Exception
 	 */
 	private function load( $userId ) {
-		if ( $userId == 0 ) {
-			return $this->applyDefaults( new UserPreferences() );
-		}
 
 		if ( !isset( $this->preferences[$userId] ) ) {
 			try {

--- a/lib/Wikia/src/Service/User/Preferences/PreferenceService.php
+++ b/lib/Wikia/src/Service/User/Preferences/PreferenceService.php
@@ -44,7 +44,7 @@ class PreferenceService {
 		$this->forceSavePrefs = $forceSavePrefs;
 		$this->preferences = [];
 
-		// 🐖: anonymous users will always have default preferences
+		// SUS-5236: anonymous users will always have default preferences
 		$this->preferences[0] = clone $defaultPrefs;
 	}
 


### PR DESCRIPTION
Profiler says this is one of the hot spots for anon page views—`User::get(Global|Local)Preference` is called quite often but we always calculate "fresh" value even though anons always have default preferences:

```
 38.40% 202.687     89 - Wikia\Service\User\Preferences\PreferenceService::load==>Wikia\Service\User\Preferences\PreferenceService::applyDefaults
```

```
 14.90% 204.746     46 - Wikia\Service\User\Preferences\PreferenceService::getPreferences==>Wikia\Service\User\Preferences\PreferenceService::load
 14.04% 193.013     43 - User::getGlobalPreference==>Wikia\Service\User\Preferences\PreferenceService::getPreferences
 14.02% 192.696     43 - User::getGlobalPreference==>Wikia\Service\User\Preferences\PreferenceService::getGlobalPreference
 13.94% 191.574     43 - Wikia\Service\User\Preferences\PreferenceService::getGlobalPreference==>Wikia\Service\User\Preferences\PreferenceService::load
```

```
10.79% 56.976   9523 - Wikia\Service\User\Preferences\PreferenceService::applyDefaults==>Wikia\Domain\User\Preferences\UserPreferences::setGlobalPreference
```

```
5.39% 28.460   9630 - Wikia\Domain\User\Preferences\UserPreferences::setGlobalPreference==>Wikia\Domain\User\Preferences\GlobalPreference::__construct
```

Let's memoize a clone of the default preference settings instead for anon user (user ID 0). On sandbox, this reduced execution time as reported by profiler (`main()`) from **~1300 ms** to **~900 ms**.
