### PR TITLE
XW-4872 | Don't read SVG in constructor

### DIFF
--- a/extensions/wikia/WikiaPhotoGallery/WikiaPhotoGallery.class.php
+++ b/extensions/wikia/WikiaPhotoGallery/WikiaPhotoGallery.class.php
@@ -88,9 +88,6 @@ class WikiaPhotoGallery extends ImageGallery {
 
 	function __construct() {
 		parent::__construct();
-		$this->videoPlayButton = '<span class="thumbnail-play-icon-container">'
-			. DesignSystemHelper::renderSvg('wds-player-icon-play', 'thumbnail-play-icon')
-			. '</span>';
 
 		$this->mData = array(
 			'externalImages' => array(),
@@ -141,6 +138,16 @@ class WikiaPhotoGallery extends ImageGallery {
 				)
 			)
 		);
+	}
+
+	private function getVideoPlayButton() {
+		if ( empty( $this->videoPlayButton ) ) {
+			$this->videoPlayButton = '<span class="thumbnail-play-icon-container">'
+			. DesignSystemHelper::renderSvg('wds-player-icon-play', 'thumbnail-play-icon')
+			. '</span>';
+		}
+
+		return $this->videoPlayButton;
 	}
 
 	/**
@@ -990,7 +997,7 @@ class WikiaPhotoGallery extends ImageGallery {
 				if ( $isVideo ) {
 					$thumbHtml = '';
 					$playButtonSize = ThumbnailHelper::getThumbnailSize( $image['width'] );
-					$thumbHtml .= $this->videoPlayButton;
+					$thumbHtml .= $this->getVideoPlayButton();
 					$linkAttribs['class'] .= ' video video-thumbnail ' . $playButtonSize;
 				} else {
 					$thumbHtml = '';
@@ -1483,7 +1490,7 @@ class WikiaPhotoGallery extends ImageGallery {
 					$videoHtml = $file->transform( array( 'width' => $imagesDimensions['w'] ) )->toHtml( $htmlParams );
 
 					// Get play button overlay for little video thumb
-					$videoPlayButton = $this->videoPlayButton;
+					$videoPlayButton = $this->getVideoPlayButton();
 					$navClass = 'xxsmall video-thumbnail';
 				}
 


### PR DESCRIPTION
as this class is being created when Special:Import is used
and then this happens
https://github.com/Wikia/app/blob/XW-4872/includes/Import.php#L406
that disables reading files by libxml
DesignSystem::renderSvg tries to read svg and it fails

after the change 
renderSvg will be used only when the icon is actually needed
that means this is still 'brittle' but I do not have an idea how to do it in a sane way

https://wikia-inc.atlassian.net/browse/XW-4872