### PR TITLE
SUS-5244 | Special:NewWiki shows 127.0.0.1 as founder's IP address

### DIFF
--- a/extensions/wikia/CreateNewWiki/CreateNewWikiController.class.php
+++ b/extensions/wikia/CreateNewWiki/CreateNewWikiController.class.php
@@ -280,7 +280,9 @@ class CreateNewWikiController extends WikiaController {
 		$categories = isset($params['wCategories']) ? $params['wCategories'] : array();
 		$allAges = isset($params['wAllAges']) && !empty( $params['wAllAges'] );
 
-		$task->call( 'create', $params['wName'], $params['wDomain'], $params['wLanguage'], $params['wVertical'], $categories, $allAges, time() );
+		$task->call( 'create', $params['wName'], $params['wDomain'], $params['wLanguage'],
+			$params['wVertical'], $categories, $allAges, time(),
+			$this->getContext()->getRequest()->getIP() );
 		$task_id = $task->setQueue( Wikia\Tasks\Queues\PriorityQueue::NAME )->queue();
 
 		// return ID of the created task ID, front-end code will poll its status

--- a/extensions/wikia/CreateNewWiki/CreateWikiTask.php
+++ b/extensions/wikia/CreateNewWiki/CreateWikiTask.php
@@ -78,9 +78,11 @@ class CreateWikiTask extends BaseTask {
 	 * @param string[] $categories
 	 * @param bool $allAges
 	 * @param int $timestamp when was the task scheduled
+	 * @param string $ip IP address of a user that is creating the wiki
 	 * @throws CreateWikiException an exception with status of operation set
 	 */
-	public function create( string $name, string $domain, string $language, int $vertical, array $categories, bool $allAges, int $timestamp ) {
+	public function create( string $name, string $domain, string $language, int $vertical,
+	                        array $categories, bool $allAges, int $timestamp, string $ip ) {
 		wfProfileIn( __METHOD__ );
 
 		// SUS-4838 | add an entry to creation log
@@ -93,7 +95,7 @@ class CreateWikiTask extends BaseTask {
 
 		$then = microtime( true );
 
-		$context = TaskContext::newFromUserInput( $name, $domain, $language, $vertical, $categories, $allAges, $this->getTaskId() );
+		$context = TaskContext::newFromUserInput( $name, $domain, $language, $vertical, $categories, $allAges, $this->getTaskId(), $ip );
 
 		$taskRunner = new Wikia\CreateNewWiki\Tasks\TaskRunner( $context );
 

--- a/extensions/wikia/CreateNewWiki/tasks/SetupWikiCities.php
+++ b/extensions/wikia/CreateNewWiki/tasks/SetupWikiCities.php
@@ -47,7 +47,7 @@ class SetupWikiCities extends Task {
 	}
 
 	public function addToCityList() {
-		global $wgRequest, $wgCreateDatabaseActiveCluster;
+		global $wgCreateDatabaseActiveCluster;
 		$founder = $this->taskContext->getFounder();
 
 		$insertFields = [
@@ -56,7 +56,7 @@ class SetupWikiCities extends Task {
 			'city_url' => $this->taskContext->getURL(),
 			'city_founding_user' => $founder->getId(),
 			'city_founding_email' => $founder->getEmail(),
-			'city_founding_ip_bin' => inet_pton( $wgRequest->getIP() ),
+			'city_founding_ip_bin' => inet_pton( $this->taskContext->getIP() ),
 			'city_path' => self::DEFAULT_SLOT,
 			'city_description' => $this->taskContext->getSiteName(),
 			'city_lang' => $this->taskContext->getLanguage(),

--- a/extensions/wikia/CreateNewWiki/tasks/TaskContext.php
+++ b/extensions/wikia/CreateNewWiki/tasks/TaskContext.php
@@ -54,6 +54,9 @@ class TaskContext {
 	/** @var  string ID of Celery task responsible for setting up a new wiki */
 	private $taskId;
 
+	/** @var  string IP address of a user that is creating the wiki */
+	private $ip;
+
 	/** @var  User */
 	private $founder;
 
@@ -70,7 +73,7 @@ class TaskContext {
 		}
 	}
 
-	public static function newFromUserInput( $inputWikiName, $inputDomain, $language, $vertical, $categories, $allAges, $taskId ) {
+	public static function newFromUserInput( $inputWikiName, $inputDomain, $language, $vertical, $categories, $allAges, $taskId, $ip ) {
 		global $wgCreateLanguageWikisWithPath;
 
 		return new self( [
@@ -81,6 +84,7 @@ class TaskContext {
 			'categories' => $categories,
 			'allAges' => $allAges,
 			'taskId' => $taskId,
+			'ip' => $ip,
 			'shouldCreateLanguageWikiWithPath' => $wgCreateLanguageWikisWithPath,
 		] );
 	}
@@ -157,6 +161,10 @@ class TaskContext {
 
 	public function getTaskId() {
 		return $this->taskId;
+	}
+
+	public function getIP() {
+		return $this->ip;
 	}
 
 	// wikiDBW represents CreateWiki::newWiki->dbw

--- a/extensions/wikia/CreateNewWiki/tests/CreateNewWikiControllerTest.php
+++ b/extensions/wikia/CreateNewWiki/tests/CreateNewWikiControllerTest.php
@@ -66,6 +66,7 @@ class CreateNewWikiControllerTest extends WikiaBaseTest {
 
 		$createNewWikiController->setRequest( $requestMock );
 		$createNewWikiController->setResponse( $responseMock );
+		$createNewWikiController->setContext( new RequestContext() );
 
 		$createNewWikiController->CreateWiki();
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5244

Let's pass the user's IP address to task's context.

Works fine on a devbox:

```sql
mysql@geo-db-dev-db-slave.query.consul[wikicities]>select city_id, city_dbname, INET6_NTOA(city_founding_ip_bin) from city_list order by 1 desc limit 3;
+---------+--------------+----------------------------------+
| city_id | city_dbname  | INET6_NTOA(city_founding_ip_bin) |
+---------+--------------+----------------------------------+
| 1657018 | plmacbretest | 149.6.28.163                     |
| 1657017 | nikoanntest  | 127.0.0.1                        |
| 1657016 | test12345    | 127.0.0.1                        |
+---------+--------------+----------------------------------+
3 rows in set (0.01 sec)
```