### PR TITLE
SUS-4742 | ChatConfig: use per-DC Consul agent instead of assuming a local one running on 127.0.0.1:8500

### DIFF
--- a/extensions/wikia/Chat2/ChatConfig.class.php
+++ b/extensions/wikia/Chat2/ChatConfig.class.php
@@ -19,7 +19,11 @@ class ChatConfig {
 			return $wgChatPrivateServerOverride;
 		}
 
-		$consul = new Wikia\Consul\Client();
+		$consul = new Wikia\Consul\Client( [
+			// SUS-4742: use per-DC Consul agent instead of assuming a local one running on 127.0.0.1:8500
+			'base_uri' => Wikia\Consul\Client::getConsulBaseUrl()
+		] );
+
 		$serverNodes = $consul->getNodes( 'chat-private', $wgWikiaEnvironment );
 
 		$index = rand( 0, count( $serverNodes ) - 1 );

--- a/lib/Wikia/src/Consul/Client.php
+++ b/lib/Wikia/src/Consul/Client.php
@@ -129,6 +129,21 @@ class Client {
 		return $wgConsulDataCenters[$env];
 	}
 
+	/**
+	 * Return Consul base URL for a current environment
+	 *
+	 * @return string
+	 */
+	static function getConsulBaseUrl() : string {
+		return sprintf( 'http://consul.service.consul:8500' );
+	}
+
+	/**
+	 * Return Consul base URL for a specific data-center
+	 *
+	 * @param string $dc
+	 * @return string
+	 */
 	static function getConsulBaseUrlForDC( string $dc ) : string {
 		return sprintf( 'http://consul.service.%s.consul:8500', $dc );
 	}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-4742

Kubernetes-powered sandbox throws the following:

```
Something went wrong when calling consul (cURL error 7: Failed to connect to 127.0.0.1 port 8500: Connection refused (see http://curl.haxx.se/libcurl/c/libcurl-errors.html)).
```