### PR TITLE
SUS | fix wall notifications issue

### DIFF
--- a/extensions/wikia/Wall/WallHelper.class.php
+++ b/extensions/wikia/Wall/WallHelper.class.php
@@ -478,17 +478,18 @@ class WallHelper {
 	/**
 	 * Create a new Wall Notification from revision info, and dispatch it to wall_notifications table.
 	 *
+	 * @param WallMessage $wallMessage
 	 * @param Revision $rev
 	 * @param int $rcType whether this is a new thread/reply (RC_NEW = 1) or edit to existing one/wall action (RC_EDIT = 2)
 	 * @param User $user
 	 */
-	public static function sendNotification( Revision $rev, int $rcType, User $user ) {
+	public static function sendNotification( WallMessage $wallMessage, Revision $rev, int $rcType, User $user ) {
 		// SUS-3281: No point in creating notification for anons
 		if ( $user->isAnon() ) {
 			return;
 		}
 
-		$notif = WallNotificationEntity::createFromRev( $rev );
+		$notif = WallNotificationEntity::newFromRevisionAndMessage( $rev, $wallMessage );
 		$wh = new WallHistory();
 
 		$wh->add( $rcType == RC_NEW ? WH_NEW : WH_EDIT, $notif, $user );

--- a/extensions/wikia/Wall/builders/WallEditBuilder.class.php
+++ b/extensions/wikia/Wall/builders/WallEditBuilder.class.php
@@ -48,7 +48,7 @@ class WallEditBuilder extends WallBuilder {
 		// Purge thread memcache and URLs for Wall/Board page etc.
 		$this->message->invalidateCache();
 
-		WallHelper::sendNotification( $comment->mLastRevision, RC_EDIT, $this->editor );
+		WallHelper::sendNotification( $this->message, $comment->mLastRevision, RC_EDIT, $this->editor );
 
 		$this->articleComment = $comment;
 		return $this;

--- a/extensions/wikia/Wall/builders/WallMessageBuilder.class.php
+++ b/extensions/wikia/Wall/builders/WallMessageBuilder.class.php
@@ -120,7 +120,12 @@ class WallMessageBuilder extends WallBuilder {
 		// Preload article ID - saves DB call
 		$this->newRevision = $rev;
 		$title->mArticleID = $rev->getPage();
-		$this->newMessage = WallMessage::newFromTitle( $title );
+
+		$articleComment = new ArticleComment( $title );
+		$articleComment->mFirstRevision = $articleComment->mLastRevision = $rev;
+		$articleComment->mFirstRevId = $articleComment->mLastRevId = $rev->getId();
+
+		$this->newMessage = WallMessage::newFromArticleComment( $articleComment );
 		return $this;
 	}
 
@@ -171,7 +176,7 @@ class WallMessageBuilder extends WallBuilder {
 	 */
 	public function notifyIfNeeded(): WallMessageBuilder {
 		if ( $this->notify ) {
-			WallHelper::sendNotification( $this->newRevision, RC_NEW, $this->messageAuthor );
+			WallHelper::sendNotification( $this->newMessage, $this->newRevision, RC_NEW, $this->messageAuthor );
 		}
 
 		return $this;


### PR DESCRIPTION
Instead of reading from slave which is susceptible to replication lag induced race conditions, pass the latest data to WallNotification when creating notification.

@macbre 