### PR TITLE
SUS-5260 | compile GD with JPEG support

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -9,7 +9,7 @@ We assume that you have `app` and `config` repository cloned in the same directo
 
 ```sh
 # 1. build a base image
-docker build -f base/Dockerfile -t php-wikia-base ./base
+docker build -f base/Dockerfile -t artifactory.wikia-inc.com/sus/php-wikia-base:latest ./base
 
 # 2. and then dev image
 docker build -f dev/Dockerfile -t php-wikia-dev ./dev

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -10,7 +10,8 @@ RUN apt-get update && apt-get install -y \
     autoconf \
     automake \
     libbz2-dev \
-    libjpeg-dev \
+    libfreetype6-dev \
+    libjpeg62-turbo-dev \
     # needed by memcached
     libmemcached-dev \
     libpng-dev \
@@ -77,6 +78,8 @@ RUN wget https://github.com/Wikia/php-xhprof-extension/archive/v4.1.6.tar.gz -O 
     && rm -r /tmp/php-xhprof-extension
 
 # install PHP extensions required by MediaWiki that are provided by Docker base PHP image helper
+RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/
+
 RUN docker-php-ext-install \
     bz2 \
     gd \

--- a/docker/base/README.md
+++ b/docker/base/README.md
@@ -1,7 +1,0 @@
-base
-====
-
-```
-docker build . -t artifactory.wikia-inc.com/sus/php-wikia-base:latest
-docker push artifactory.wikia-inc.com/sus/php-wikia-base:latest
-```


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5260

```
Fixes "imagecreatefromstring(): No JPEG support in this PHP build"
```

```
gd

GD Support => enabled
GD Version => bundled (2.1.0 compatible)
FreeType Support => enabled
FreeType Linkage => with freetype
FreeType Version => 2.5.2
GIF Read Support => enabled
GIF Create Support => enabled
JPEG Support => enabled
libJPEG Version => 6b
PNG Support => enabled
libPNG Version => 1.2.50
WBMP Support => enabled
XBM Support => enabled

Directive => Local Value => Master Value
gd.jpeg_ignore_warning => 0 => 0
```