### PR TITLE
SUS-5266 | explicitly add "severity" field to MediaWiki logs

### DIFF
--- a/lib/Wikia/src/Logger/LogstashFormatter.php
+++ b/lib/Wikia/src/Logger/LogstashFormatter.php
@@ -47,6 +47,10 @@ class LogstashFormatter extends \Monolog\Formatter\LogstashFormatter {
 			$message['@context'] = $record['context'];
 		}
 
+		// SUS-5266 | explicitly add severity to MediaWiki logs
+		// as those coming from containers do not have them set
+		$message['severity'] = strtolower( $record['level_name'] );
+
 		return $message;
 	}
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5266

New logs format:

```json
{"appname":"mediawiki","@timestamp":"2018-06-15T11:56:39.614323+00:00","@message":"Url provider","@fields":{"app_name":"mediawiki","app_version":"","datacenter":"poz","environment":"dev","wiki_dbname":"macbre","wiki_id":"1474483","http_url_path":"/load.php?cb=1529063769&debug=false&lang=pl&modules=ext.siteWideMessages.anon&only=scripts&skin=oasis&*","http_method":"GET","http_url_domain":"macbre.wikia-local.com","http_url":"http://macbre.wikia-local.com/load.php?cb=1529063769&debug=false&lang=pl&modules=ext.siteWideMessages.anon&only=scripts&skin=oasis&*","http_referrer":"http://macbre.wikia-local.com/wiki/Macbre_Wiki","client_ip":"192.168.16.1","span_id":"171e88ce-d602-4b3e-9449-e47b55da4176","trace_id":"176a1788-51d1-410a-bf0e-77fd19d52224"},"@context":{"provider_url":"dev.poz-dev.k8s.wikia.net/phalanx"},"severity":"debug"}
```

Monolog log levels:

```php
    protected static $levels = array(
        self::DEBUG     => 'DEBUG',
        self::INFO      => 'INFO',
        self::NOTICE    => 'NOTICE',
        self::WARNING   => 'WARNING',
        self::ERROR     => 'ERROR',
        self::CRITICAL  => 'CRITICAL',
        self::ALERT     => 'ALERT',
        self::EMERGENCY => 'EMERGENCY',
    );
```