### PR TITLE
SUS-5269 | Prevent FounderEmails from throwing error

### DIFF
--- a/lib/Wikia/src/Service/User/Preferences/PreferenceService.php
+++ b/lib/Wikia/src/Service/User/Preferences/PreferenceService.php
@@ -24,6 +24,9 @@ class PreferenceService {
 	/** @var UserPreferences */
 	private $defaultPreferences;
 
+	/** @var UserPreferences $anonUserPreferences */
+	private $anonUserPreferences;
+
 	/** @var string[] */
 	private $forceSavePrefs;
 
@@ -45,7 +48,7 @@ class PreferenceService {
 		$this->preferences = [];
 
 		// SUS-5236: anonymous users will always have default preferences
-		$this->preferences[0] = clone $defaultPrefs;
+		$this->anonUserPreferences = clone $defaultPrefs;
 	}
 
 	public function getPreferences( $userId ) {
@@ -221,6 +224,10 @@ class PreferenceService {
 	 * @throws \Exception
 	 */
 	private function load( $userId ) {
+
+		if ( empty( $userId ) ) {
+			return $this->anonUserPreferences;
+		}
 
 		if ( !isset( $this->preferences[$userId] ) ) {
 			try {

--- a/lib/Wikia/tests/Service/User/PreferenceServiceTest.php
+++ b/lib/Wikia/tests/Service/User/PreferenceServiceTest.php
@@ -46,6 +46,13 @@ class PreferenceServiceTest extends TestCase {
 		$this->assertEquals( 'val1', $preferences->getPreferences( 0 )->getGlobalPreference( 'pref1' ) );
 	}
 
+	public function testGetInvalidUserId() {
+		$defaultPreferences = ( new UserPreferences() )
+			->setGlobalPreference( 'pref1', 'val1' );
+		$preferences = new PreferenceService( $this->persistence, $defaultPreferences, [], [] );
+		$this->assertEquals( 'val1', $preferences->getPreferences( false )->getGlobalPreference( 'pref1' ) );
+	}
+
 	public function testGet() {
 		$this->setupServiceExpects();
 		$preferences = new PreferenceService( $this->persistence, new UserPreferences(), [], [] );


### PR DESCRIPTION
On some wikis FounderEmails tries to send email to invalid users which generates an error. Before investigating that let's prevent further such errors.

https://wikia-inc.atlassian.net/browse/SUS-5269