### PR TITLE
SUS-5269 | Don't return ID of founder user if it's not set

### DIFF
--- a/includes/wikia/services/WikiService.class.php
+++ b/includes/wikia/services/WikiService.class.php
@@ -73,7 +73,7 @@ class WikiService extends WikiaModel {
 
 		// Get founder
 		$userIds = [];
-		if ( $includeFounder ) {
+		if ( $includeFounder && $wiki->city_founding_user ) {
 			$userIds[] = $wiki->city_founding_user;
 		}
 


### PR DESCRIPTION
Followup to https://github.com/Wikia/app/pull/15554 — old wikis do not have a founder user specified, so let's make sure we do not include invalid ID in that case.

https://wikia-inc.atlassian.net/browse/SUS-5269