### PR TITLE
Remove not used /cache directory

### DIFF
--- a/cache/.htaccess
+++ b/cache/.htaccess
@@ -1,1 +1,0 @@
-Deny from all


### PR DESCRIPTION
It's empty on production as we do not use `FileCacheBase` class.