### PR TITLE
SUS-5284 | ignore hidden directories and files + node_modules

### DIFF
--- a/docker/sandbox/.dockerignore
+++ b/docker/sandbox/.dockerignore
@@ -1,0 +1,14 @@
+# SUS-5284 | this file instructs Docker to do not add these files to an image when ADD / COPY command is run
+
+# .git for app weights over 800 MB
+.git/
+
+# test files
+*/**/tests/*
+
+# README files
+*/**/README
+*/**/README.md
+
+# node_modules weights over 130 MB
+node_modules/

--- a/docker/sandbox/.dockerignore
+++ b/docker/sandbox/.dockerignore
@@ -1,7 +1,11 @@
 # SUS-5284 | this file instructs Docker to do not add these files to an image when ADD / COPY command is run
 
-# .git for app weights over 800 MB
-.git/
+# ignore hidden directories and files
+# (.git for app weights over 800 MB)
+*/**/.*
+
+# documentation and Docker build files
+*/**/docs/*
 
 # test files
 */**/tests/*
@@ -11,4 +15,4 @@
 */**/README.md
 
 # node_modules weights over 130 MB
-node_modules/
+*/**/node_modules/*

--- a/docker/sandbox/Jenkinsfile
+++ b/docker/sandbox/Jenkinsfile
@@ -74,6 +74,9 @@ node("docker-daemon") {
             if (!imageExists) {
                 sh("docker pull artifactory.wikia-inc.com/sus/php-wikia-base:7b76c41")
 
+                // SUS-5284 - make the image a bit smaller
+                sh("cp docker/sandbox/.dockerignore ..")
+
                 sh("docker build  . -f docker/sandbox/Dockerfile-nginx -t $nginxImage:$imageTag")
                 sh("docker build .. -f docker/sandbox/Dockerfile-php -t $mediawikiImage:$imageTag")
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5284

**The size of a sandbox image dropped from 2.52 to 1.56 GB.**

Things removed from an image:

*  `.git` and other hidden files and directories
* `node_modules` and `docs` directory
*  files in `tests` subdirectories

### Before the cleanup

```
$ docker images
REPOSITORY                                              TAG                 IMAGE ID            CREATED             SIZE
artifactory.wikia-inc.com/sus/mediawiki-sandbox-php     latest              98d11443cfaa        10 seconds ago      2.52GB
```

### After the cleanup

```
nobody@c4b691f097ab:/usr/wikia/slot1/current/src$ find . | grep '/tests/' -c
0
nobody@c4b691f097ab:/usr/wikia/slot1/current/src$ du -hs node_modules/
4.0K	node_modules/
nobody@c4b691f097ab:/usr/wikia/slot1/current/src$ find -name README | wc -l
0
nobody@c4b691f097ab:/usr/wikia/slot1/current/src$ find -name README.md | wc -l
0

nobody@9e1906a001d3:/usr/wikia/slot1/current/src$ ls -lh .git
ls: cannot access .git: No such file or directory
```

```
$ docker images 
REPOSITORY                                              TAG                 IMAGE ID            CREATED              SIZE
artifactory.wikia-inc.com/sus/mediawiki-sandbox-php     7b76c41             5840ac9813fe        About a minute ago   1.56GB
```