### PR TITLE
SUS-5287 | MWHttpRequest::proxySetup - do not use a localhost as a proxy for "local" URLs + use $wgHTTPProxy value only

### DIFF
--- a/includes/HttpFunctions.php
+++ b/includes/HttpFunctions.php
@@ -380,12 +380,11 @@ class MWHttpRequest {
 	 * (override in subclass)
 	 */
 	public function proxySetup() {
-		global $wgHTTPProxy;
-
 		if ( $this->proxy ) {
 			return;
 		}
 
+		global $wgHTTPProxy;
 		if ( $wgHTTPProxy ) {
 			$this->proxy = $wgHTTPProxy ;
 		}

--- a/includes/HttpFunctions.php
+++ b/includes/HttpFunctions.php
@@ -378,8 +378,6 @@ class MWHttpRequest {
 	/**
 	 * Take care of setting up the proxy
 	 * (override in subclass)
-	 *
-	 * @return String
 	 */
 	public function proxySetup() {
 		global $wgHTTPProxy;
@@ -388,12 +386,8 @@ class MWHttpRequest {
 			return;
 		}
 
-		if ( Http::isLocalURL( $this->url ) ) {
-			$this->proxy = 'http://localhost:80';
-		} elseif ( $wgHTTPProxy ) {
+		if ( $wgHTTPProxy ) {
 			$this->proxy = $wgHTTPProxy ;
-		} elseif ( getenv( "http_proxy" ) ) {
-			$this->proxy = getenv( "http_proxy" );
 		}
 	}
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5287

When MediaWiki is run inside a container it does not have an access to a localhost proxy as nginx is running in a different container. This commit fixes the following error when trying to perform a HTTP request to a "local" URL, i.e. in *.wikia.com domain. Instead of `localhost:80` proxy a HTTP border will be used.

Additionally, backport a MediaWiki change that simply ignores `http_proxy` environment variable. Let's stick to `$wgHTTPProxy`.

```
http-curl-error, Failed to connect to localhost port 80: Connection refused
```