### PR TITLE
nginx 1.14.0

### DIFF
--- a/docker/sandbox/Dockerfile-nginx
+++ b/docker/sandbox/Dockerfile-nginx
@@ -1,4 +1,4 @@
-FROM nginx:1.13
+FROM nginx:1.14.0
 
 RUN chown -R nginx:nginx /etc/nginx && \
     chown nginx:nginx /var/cache/nginx && \


### PR DESCRIPTION
Please use the latest stable release on nginx (1.14.x line) + `1.14.0` for easier bump minor updates in the future.