### PR TITLE
SUS-5294 | docker/sandbox/.dockerignore - remove app/node_modules directory only, keep it in the subdirectories

### DIFF
--- a/docker/sandbox/.dockerignore
+++ b/docker/sandbox/.dockerignore
@@ -14,5 +14,5 @@
 */**/README
 */**/README.md
 
-# node_modules weights over 130 MB
-*/**/node_modules/*
+# node_modules in app root weights over 130 MB
+app/node_modules


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5294

```
nobody@ef620bb858ac:/usr/wikia/slot1/current/src$ ls node_modules
ls: cannot access node_modules: No such file or directory

nobody@ef620bb858ac:/usr/wikia/slot1/current/src$ find . | grep node_modules
./skins/oasis/js/jwplayer/node_modules
./skins/oasis/js/jwplayer/node_modules/jwplayer-fandom
./skins/oasis/js/jwplayer/node_modules/jwplayer-fandom/dist
./skins/oasis/js/jwplayer/node_modules/jwplayer-fandom/dist/wikiajwplayer.js
```

This fixes the following:

```
ResourceLoaderFileModule::readScriptFiles: script file not found: "/usr/wikia/slot1/current/src/skins/oasis/js/jwplayer/node_modules/jwplayer-fandom/dist/wikiajwplayer.js"
```