### PR TITLE
SUS-5386 | WikiFactory::getLocalEnvURL does it now, no need to check a custom HTTP header

### DIFF
--- a/docker/sandbox/sandbox-sus2.yaml
+++ b/docker/sandbox/sandbox-sus2.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: mediawiki-sandbox
 spec:
-  replicas: 25
+  replicas: 5
   selector:
     matchLabels:
       app: mediawiki-sandbox

--- a/docker/sandbox/sandbox-sus2.yaml
+++ b/docker/sandbox/sandbox-sus2.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: mediawiki-sandbox
 spec:
-  replicas: 5
+  replicas: 25
   selector:
     matchLabels:
       app: mediawiki-sandbox

--- a/extensions/wikia/PortableInfoboxBuilder/PortableInfoboxBuilderSpecialController.class.php
+++ b/extensions/wikia/PortableInfoboxBuilder/PortableInfoboxBuilderSpecialController.class.php
@@ -8,8 +8,6 @@ class PortableInfoboxBuilderSpecialController extends WikiaSpecialPageController
 	const PAGE_NAME = 'InfoboxBuilder';
 	const PAGE_RESTRICTION = 'editinterface';
 	const INFOBOX_BUILDER_MERCURY_ROUTE = 'infobox-builder';
-	const PATH_SEPARATOR = '/';
-	const EXPLODE_LIMIT = 2;
 
 	/**
 	 * Special page constructor
@@ -36,8 +34,8 @@ class PortableInfoboxBuilderSpecialController extends WikiaSpecialPageController
 		RenderContentOnlyHelper::setRenderContentVar( true );
 		RenderContentOnlyHelper::setRenderContentLevel( RenderContentOnlyHelper::LEAVE_GLOBAL_NAV_ONLY );
 		Wikia::addAssetsToOutput( 'portable_infobox_builder_scss' );
-		$url = implode( self::PATH_SEPARATOR, [ $this->wg->server, self::INFOBOX_BUILDER_MERCURY_ROUTE, $title ] );
-		$this->response->setVal( 'iframeUrl', $url );
+		$this->response->setVal( 'iframeUrl',
+			wfExpandUrl( sprintf( '/%s/%s',self::INFOBOX_BUILDER_MERCURY_ROUTE, $title) ) );
 		$this->response->setTemplateEngine( WikiaResponse::TEMPLATE_ENGINE_MUSTACHE );
 	}
 

--- a/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
+++ b/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
@@ -617,14 +617,6 @@ class WikiFactoryLoader {
 				}
 
 				if ($key == 'wgServer') {
-					if ( !empty( $_SERVER['HTTP_X_ORIGINAL_HOST'] ) ) {
-						global $wgConf;
-
-						$stagingServer = $_SERVER['HTTP_X_ORIGINAL_HOST'];
-
-						$tValue = 'http://'.$stagingServer;
-						$wgConf->localVHosts = array_merge( $wgConf->localVHosts, [ $stagingServer ] );
-					}
 					// TODO - what about wgServer value for requests that did not go through Fastly?
 					if ( !empty( $_SERVER['HTTP_FASTLY_SSL'] ) ) {
 						$tValue = wfHttpToHttps( $tValue );


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5386

Environment variables are enough to build a proper sandbox URL, no need to handle `X-Original-Host` request header.

```
nobody@mediawiki-sandbox-6f5d84c977-bnff4:/usr/wikia/slot1/current/src$ SERVER_ID=177 php maintenance/eval.php -d 5
> echo WikiFactory::getExternalHostName()
sandbox-sus2
> echo $wgWikiaEnvironment;
sandbox
> echo WikiFactory::getLocalEnvURL('https://muppet.wikia.com')
https://muppet.sandbox-sus2.wikia.com
> echo wfExpandUrl('/Foo')
http://community.sandbox-sus2.wikia.com/Foo
> echo Title::newFromText('Foo')->getFullURL();
http://community.sandbox-sus2.wikia.com/wiki/Foo
```