### PR TITLE
(PLATFORM-3524) More handling for downgrading anonymous users

### DIFF
--- a/extensions/wikia/HTTPSSupport/HTTPSSupport.setup.php
+++ b/extensions/wikia/HTTPSSupport/HTTPSSupport.setup.php
@@ -2,6 +2,8 @@
 
 $wgAutoloadClasses['HTTPSSupportHooks'] =  __DIR__ . '/HTTPSSupportHooks.class.php';
 
-$wgHooks['BeforeInitialize'][] = 'HTTPSSupportHooks::onBeforeInitialize';
+$wgHooks['AfterInitialize'][] = 'HTTPSSupportHooks::onAfterInitialize';
 $wgHooks['MercuryWikiVariables'][] = 'HTTPSSupportHooks::onMercuryWikiVariables';
 $wgHooks['outputMakeExternalImage'][] = 'HTTPSSupportHooks::parserUpgradeVignetteUrls';
+$wgHooks['SitemapPageBeforeOutput'][] = 'HTTPSSupportHooks::onSitemapPageBeforeOutput';
+$wgHooks['WikiaRobotsBeforeOutput'][] = 'HTTPSSupportHooks::onWikiaRobotsBeforeOutput';

--- a/extensions/wikia/SitemapXml/SpecialSitemap_body.php
+++ b/extensions/wikia/SitemapXml/SpecialSitemap_body.php
@@ -43,6 +43,9 @@ class SitemapPage extends UnlistedSpecialPage {
 
 		if ( ( $showIndex && !$forceOldSitemap ) || $forceNewSitemap ) {
 			$this->getOutput()->disable();
+			if ( !Hooks::run( 'SitemapPageBeforeOutput', [ $subpage, $this->getRequest(), $this->getUser() ] ) ) {
+				return;
+			}
 			$response = F::app()->sendRequest( 'SitemapXml', 'index', [ 'path' => $subpage ] );
 			$response->sendHeaders();
 			echo $response->getBody();

--- a/wikia-robots-txt.php
+++ b/wikia-robots-txt.php
@@ -6,6 +6,10 @@ use Wikia\RobotsTxt\WikiaRobots;
 
 require_once( __DIR__ . '/includes/WebStart.php' );
 
+if ( !Hooks::run( 'WikiaRobotsBeforeOutput', [ $wgRequest, $wgUser ] ) ) {
+	return;
+}
+
 $wikiaRobots = new WikiaRobots( new PathBuilder() );
 $robots = $wikiaRobots->configureRobotsBuilder( new RobotsTxt() );
 


### PR DESCRIPTION
Ensure app handles downgrading anonymous users to HTTP for robots.txt
and sitemaps. Also limit the cache length on anonymous downgrades of
articles for now.

/cc @Wikia/core-platform-team 
