### PR TITLE
MAIN-16605: AbuseFilter examination not showing moved_to_* variables

### DIFF
--- a/extensions/AbuseFilter/AbuseFilter.class.php
+++ b/extensions/AbuseFilter/AbuseFilter.class.php
@@ -1544,8 +1544,6 @@ class AbuseFilter {
 	}
 
 	public static function getMoveVarsFromRCRow( $row ) {
-		$vars = new AbuseFilterVariableHolder;
-
 		if ( $row->rc_user ) {
 			$user = User::newFromId( $row->rc_user );
 		} else {
@@ -1553,13 +1551,12 @@ class AbuseFilter {
 			$user = User::newFromName( $userIp, false );
 		}
 
-		$params = explode( "\n", trim( $row->rc_params ) );
+		$params = array_values( DatabaseLogEntry::newFromRow( $row )->getParameters() );
 
 		$oldTitle = Title::makeTitle( $row->rc_namespace, $row->rc_title );
-		$newTitle = Title::newFromText( $params[0] );
+		$newTitle = Title::makeTitle( $params[1], $params[0] );
 
 		$vars = AbuseFilterVariableHolder::merge(
-			$vars,
 			AbuseFilter::generateUserVars( $user ),
 			AbuseFilter::generateTitleVars( $oldTitle, 'MOVED_FROM' ),
 			AbuseFilter::generateTitleVars( $newTitle, 'MOVED_TO' )

--- a/includes/logging/LogEntry.php
+++ b/includes/logging/LogEntry.php
@@ -143,8 +143,9 @@ class DatabaseLogEntry extends LogEntryBase {
 	 * @return DatabaseLogEntry
 	 */
 	public static function newFromRow( $row ) {
-		if ( is_array( $row ) && isset( $row['rc_logid'] ) ) {
-			return new RCDatabaseLogEntry( (object) $row );
+		$row = (object) $row;
+		if ( isset( $row->rc_logid ) ) {
+			return new RCDatabaseLogEntry( $row );
 		} else {
 			return new self( $row );
 		}


### PR DESCRIPTION
Backports https://github.com/wikimedia/mediawiki/commit/5c06f5f51743d3cde185d3c81b1d771e08863b14 and https://github.com/wikimedia/mediawiki-extensions-AbuseFilter/commit/6c89ccc2fe032acfe7b269543e69d78706ad1d0b

Issue example: [Examination on Community Central](https://c.wikia.com/wiki/Special:AbuseFilter/examine/3065896)
Phabricator ticket: [T54053](https://phabricator.wikimedia.org/T54053)
Support ticket: [ZD#399437](http://support.wikia-inc.com/hc/requests/399437)
JIRA ticket: [MAIN-16605](https://wikia-inc.atlassian.net/browse/MAIN-16605)

**The changes have not been tested.**