### PR TITLE
SUS-5391 | make Docker PHP base image a bit smaller

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -2,11 +2,13 @@
 # production dependencies installed.
 FROM php:7.0.28-fpm-jessie
 
-# add jessie-backports repo (required to install libsass-dev package)
-RUN echo 'deb http://ftp.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/backports.list
+# set locale as required by MediaWiki / Perl
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
 
-# install make (reuired by unit tests)
-RUN apt-get update && apt-get install -y \
+# add jessie-backports repo (required to install libsass-dev package)
+RUN echo 'deb http://ftp.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/backports.list \
+    && apt-get update && apt-get install -y \
     autoconf \
     automake \
     libbz2-dev \
@@ -21,7 +23,6 @@ RUN apt-get update && apt-get install -y \
     libtool \
     libyaml-dev \
     locales \
-    make \
     # needed by Timeline extension
     ploticus \
     wget \
@@ -29,60 +30,55 @@ RUN apt-get update && apt-get install -y \
     libtidy-dev \
     # needed by php intl extension
     libicu-dev \
-    # needed by sass
-    && apt-get -t jessie-backports install -y libsass-dev
-
-# set locale as required by MediaWiki / Perl
-ENV LANG C.UTF-8
-ENV LC_ALL C.UTF-8
-
-# sassphp extension / @see https://github.com/absalomedia/sassphp fork
-RUN wget https://github.com/Wikia/sassphp/archive/0.5.10.tar.gz -O sassphp.tar.gz \
+    # needed by sass, this installs libsass-3.4.3, matches with https://github.com/absalomedia/sassphp/releases/tag/0.5.10
+    && apt-get -t jessie-backports install -y libsass-dev \
+    # cleanup
+    && rm -rf /var/lib/apt/lists/* \
+    #
+    # sassphp extension / @see https://github.com/absalomedia/sassphp fork
+    && cd /tmp \
+    && wget https://github.com/Wikia/sassphp/archive/0.5.10.tar.gz -O sassphp.tar.gz \
     && mkdir -p /tmp/sassphp \
     && tar -xf sassphp.tar.gz -C /tmp/sassphp --strip-components=1 \
-    # this installs libsass-3.4.3, matches with https://github.com/absalomedia/sassphp/releases/tag/0.5.10
-    && apt-get -t jessie-backports install -y libsass-dev \
     && docker-php-ext-configure /tmp/sassphp \
     && docker-php-ext-install /tmp/sassphp \
-    && rm -r /tmp/sassphp
-
-# libmustache / @see https://github.com/jbboehr/libmustache
-RUN wget https://github.com/Wikia/libmustache/archive/v0.4.4.tar.gz -O libmustache.tar.gz \
+    #
+    # libmustache / @see https://github.com/jbboehr/libmustache
+    && cd /tmp \
+    && wget https://github.com/Wikia/libmustache/archive/v0.4.4.tar.gz -O libmustache.tar.gz \
     && mkdir -p /tmp/libmustache \
     && tar -xf libmustache.tar.gz -C /tmp/libmustache --strip-components=1 \
     && cd /tmp/libmustache \
     && autoreconf -fiv && ./configure --without-mustache-spec \
     && make && make install \
-    && rm -r /tmp/libmustache
-
-# mustache extension / @see https://github.com/jbboehr/php-mustache
-RUN wget https://github.com/Wikia/php-mustache/archive/v0.7.3.tar.gz -O mustache.tar.gz \
+    #
+    # mustache extension / @see https://github.com/jbboehr/php-mustache
+    && cd /tmp \
+    && wget https://github.com/Wikia/php-mustache/archive/v0.7.3.tar.gz -O mustache.tar.gz \
     && mkdir -p /tmp/mustache \
     && tar -xf mustache.tar.gz -C /tmp/mustache --strip-components=1 \
     && docker-php-ext-configure /tmp/mustache \
     && docker-php-ext-install /tmp/mustache \
-    && rm -r /tmp/mustache
-
-# wikidiff2 extension / @see https://www.mediawiki.org/wiki/Extension:Wikidiff2#Manually
-RUN wget https://github.com/Wikia/wikidiff2/archive/1.4.1.tar.gz -O wikidiff2.tar.gz \
+    #
+    # wikidiff2 extension / @see https://www.mediawiki.org/wiki/Extension:Wikidiff2#Manually
+    && cd /tmp \
+    && wget https://github.com/Wikia/wikidiff2/archive/1.4.1.tar.gz -O wikidiff2.tar.gz \
     && mkdir -p /tmp/wikidiff2 \
     && tar -xf wikidiff2.tar.gz -C /tmp/wikidiff2 --strip-components=1 \
     && docker-php-ext-configure /tmp/wikidiff2 \
     && docker-php-ext-install /tmp/wikidiff2 \
-    && rm -r /tmp/wikidiff2
-
-# tideways extension / @see https://tideways.com/
-RUN wget https://github.com/Wikia/php-xhprof-extension/archive/v4.1.6.tar.gz -O php-xhprof-extension.tar.gz \
+    #
+    # tideways extension / @see https://tideways.com/
+    && cd /tmp \
+    && wget https://github.com/Wikia/php-xhprof-extension/archive/v4.1.6.tar.gz -O php-xhprof-extension.tar.gz \
     && mkdir -p /tmp/php-xhprof-extension \
     && tar -xf php-xhprof-extension.tar.gz -C /tmp/php-xhprof-extension --strip-components=1 \
     && docker-php-ext-configure /tmp/php-xhprof-extension \
     && docker-php-ext-install /tmp/php-xhprof-extension \
-    && rm -r /tmp/php-xhprof-extension
-
-# install PHP extensions required by MediaWiki that are provided by Docker base PHP image helper
-RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/
-
-RUN docker-php-ext-install \
+    #
+    # install PHP extensions required by MediaWiki that are provided by Docker base PHP image helper
+    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+    && docker-php-ext-install \
     bz2 \
     gd \
     mysqli \
@@ -100,7 +96,13 @@ RUN docker-php-ext-install \
     # needed by multithread scripts
     pcntl \
     # needed by IcuCollation class
-    intl
+    intl \
+    # remove no longer needed dependencies
+    && apt-get remove -y \
+        automake \
+        wget \
+    && apt-get autoremove -y \
+    && rm -rf /tmp/*
 
 # setup php.ini globally
 ADD ./php.ini /usr/local/etc/php/php.ini

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -111,6 +111,6 @@ ADD ./php.ini /usr/local/etc/php/php.ini
 ENV WIKIA_DOCROOT=/usr/wikia/slot1/current/src
 ENV WIKIA_CONFIG_ROOT=/usr/wikia/slot1/current/config
 
-ENV WIKIA_BASE_IMAGE_HASH=d668751
+ENV WIKIA_BASE_IMAGE_HASH=f1ce193
 
 WORKDIR /usr/wikia/slot1/current/src

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -7,6 +7,8 @@ FROM artifactory.wikia-inc.com/sus/php-wikia-base:d668751
 # uopz extension / @see https://pecl.php.net/package/uopz
 # XDebug extension / @see https://pecl.php.net/package/xdebug
 # yaml extension / @see https://pecl.php.net/package/yaml / needed by db2yml.php
+#
+# these require autoconf package to be present
 RUN pecl install uopz-5.0.2 xdebug-2.6.0 yaml-2.0.2 \
     && docker-php-ext-enable uopz xdebug yaml
 

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,6 +1,6 @@
 # This is a Docker image for  Wikia's MediaWiki app that can be used locally by a developer.
 # Simply mount your app and config repositories clone (refer to README.md)
-FROM artifactory.wikia-inc.com/sus/php-wikia-base:d668751
+FROM artifactory.wikia-inc.com/sus/php-wikia-base:f1ce193
 
 # install dev dependencies
 

--- a/docker/sandbox/Dockerfile-php
+++ b/docker/sandbox/Dockerfile-php
@@ -1,4 +1,4 @@
-FROM artifactory.wikia-inc.com/sus/php-wikia-base:d668751
+FROM artifactory.wikia-inc.com/sus/php-wikia-base:f1ce193
 
 ENV WIKIA_DATACENTER="sjc"
 ENV WIKIA_ENVIRONMENT="sandbox"

--- a/docker/sandbox/Jenkinsfile
+++ b/docker/sandbox/Jenkinsfile
@@ -72,7 +72,7 @@ node("docker-daemon") {
             }
 
             if (!imageExists) {
-                sh("docker pull artifactory.wikia-inc.com/sus/php-wikia-base:d668751")
+                sh("docker pull artifactory.wikia-inc.com/sus/php-wikia-base:f1ce193")
 
                 // SUS-5284 - make the image a bit smaller
                 sh("cp docker/sandbox/.dockerignore ..")


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5391

* clean up temporary files (`apt` data, `/tmp`) and no longer needed dependencies
* run all `apt-get` and `make` commands in a single container when building Docker image

**`php-wikia-base` image is now 20% smaller**

### After

```
$ docker images | head -n3
REPOSITORY                                              TAG                 IMAGE ID            CREATED             SIZE
artifactory.wikia-inc.com/sus/php-wikia-base            f1ce193             49e7a7fe7868        11 minutes ago      513MB
php-wikia-dev                                           latest              6f9a7c7d9b8f        17 minutes ago      516MB
```

### Before

```
$ docker images | head
REPOSITORY                                              TAG                 IMAGE ID            CREATED             SIZE
php-wikia-dev                                           latest              882e8e4effb9        4 hours ago         641MB
artifactory.wikia-inc.com/sus/php-wikia-base            d668751             1c3326d9d962        4 hours ago         639MB
```