### PR TITLE
SUS-5393 | wVertical parameter is expected to be a numeric value

### DIFF
--- a/extensions/wikia/CreateNewWiki/CreateNewWikiController.class.php
+++ b/extensions/wikia/CreateNewWiki/CreateNewWikiController.class.php
@@ -210,11 +210,14 @@ class CreateNewWikiController extends WikiaController {
 		$params = $this->getRequest()->getArray('data');
 		$fandomCreatorCommunityId = $this->getRequest()->getVal( 'fandomCreatorCommunityId' );
 
+		// SUS-5393 | wVertical is expected to be a numeric value
+		$params['wVertical'] = (int) $params['wVertical'];
+
 		if ( empty($params) ||
 			empty($params['wName']) ||
 			empty($params['wDomain']) ||
 			empty($params['wLanguage']) ||
-			(!isset($params['wVertical']) || $params['wVertical'] === '-1'))
+			(empty($params['wVertical']) || $params['wVertical'] === -1))
 		{
 			// do nothing
 			$this->warning(__METHOD__ . ": no parameters provided" );

--- a/extensions/wikia/CreateNewWiki/js/WikiBuilder.js
+++ b/extensions/wikia/CreateNewWiki/js/WikiBuilder.js
@@ -661,6 +661,9 @@ define('ext.createNewWiki.builder', ['ext.createNewWiki.helper', 'wikia.tracker'
 						// for QA with love
 						$themWikiWrapper.find('.controls input').attr('disabled', false).addClass('enabled');
 					});
+
+					// SUS-5393 | expose task_id to Selenium tests via "data" HTML element attribute
+					$('#CreateNewWiki').attr('data-task-id', res.task_id);
 				},
 				onErrorCallback: generateAjaxErrorMsg
 			});


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5393

Prevent `Argument 4 passed to CreateWikiTask::create() must be of the type integer, string given` and fail earlier at parameters verification step.