### PR TITLE
SUS-5397 - mw in k8s - nginx logs should send numbers instead of strings

### DIFF
--- a/docker/sandbox/nginx.conf
+++ b/docker/sandbox/nginx.conf
@@ -18,9 +18,9 @@ http {
       '"remote_addr": "$remote_addr", '
       '"remote_user": "$remote_user", '
       '"request": "$request", '
-      '"status": "$status", '
-      '"body_bytes_sent": "$body_bytes_sent", '
-      '"request_time": "$request_time", '
+      '"status": $status, '
+      '"body_bytes_sent": $body_bytes_sent, '
+      '"request_time": $request_time, '
       '"http_referrer": "$http_referer", '
       '"http_user_agent": "$http_user_agent" }';
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5397

@macbre @mszabo-wikia 