### PR TITLE
SUS-5405 | Use k8s internal ingress for calling services on Kubernetes

### DIFF
--- a/includes/wikia/VariablesBase.php
+++ b/includes/wikia/VariablesBase.php
@@ -8235,6 +8235,13 @@ $wgUseImageResize = true;
 $wgUseInstantCommons = false;
 
 /**
+ * Whether to use Kubernetes internal ingress for making requests to service dependencies on Kubernetes.
+ * This is only enabled if app itself is running on Kubernetes.
+ * @var bool $wgUseKubernetesInternalIngress
+ */
+$wgUseKubernetesInternalIngress = getenv( 'KUBERNETES_POD' );
+
+/**
  * Set this to true to make a local copy of the message cache, for use in
  * addition to memcached. The files will be put in $wgCacheDirectory.
  * @see $wgCacheDirectory

--- a/includes/wikia/VariablesBase.php
+++ b/includes/wikia/VariablesBase.php
@@ -8239,7 +8239,7 @@ $wgUseInstantCommons = false;
  * This is only enabled if app itself is running on Kubernetes.
  * @var bool $wgUseKubernetesInternalIngress
  */
-$wgUseKubernetesInternalIngress = getenv( 'KUBERNETES_POD' );
+$wgUseKubernetesInternalIngress = (bool) getenv( 'KUBERNETES_POD' );
 
 /**
  * Set this to true to make a local copy of the message cache, for use in

--- a/lib/Wikia/src/Factory/ProviderFactory.php
+++ b/lib/Wikia/src/Factory/ProviderFactory.php
@@ -26,7 +26,7 @@ class ProviderFactory {
 			global $wgRealEnvironment, $wgWikiaDatacenter, $wgUseKubernetesInternalIngress;
 
 			if ( $wgUseKubernetesInternalIngress ) {
-				$this->urlProvider = new InternalIngressUrlProvider();
+				$this->urlProvider = new InternalIngressUrlProvider( $wgRealEnvironment );
 			} else {
 				$this->urlProvider = new KubernetesUrlProvider( $wgRealEnvironment, $wgWikiaDatacenter );
 				$this->urlProvider->setLogger( WikiaLogger::instance() );

--- a/lib/Wikia/src/Factory/ProviderFactory.php
+++ b/lib/Wikia/src/Factory/ProviderFactory.php
@@ -2,6 +2,7 @@
 namespace Wikia\Factory;
 
 use Wikia\Logger\WikiaLogger;
+use Wikia\Service\Gateway\InternalIngressUrlProvider;
 use Wikia\Service\Gateway\KubernetesUrlProvider;
 use Wikia\Service\Gateway\UrlProvider;
 use Wikia\Service\Swagger\ApiProvider;
@@ -22,9 +23,14 @@ class ProviderFactory {
 
 	public function urlProvider(): UrlProvider {
 		if ( $this->urlProvider === null ) {
-			global $wgRealEnvironment, $wgWikiaDatacenter;
-			$this->urlProvider = new KubernetesUrlProvider( $wgRealEnvironment, $wgWikiaDatacenter );
-			$this->urlProvider->setLogger( WikiaLogger::instance() );
+			global $wgRealEnvironment, $wgWikiaDatacenter, $wgUseKubernetesInternalIngress;
+
+			if ( $wgUseKubernetesInternalIngress ) {
+				$this->urlProvider = new InternalIngressUrlProvider();
+			} else {
+				$this->urlProvider = new KubernetesUrlProvider( $wgRealEnvironment, $wgWikiaDatacenter );
+				$this->urlProvider->setLogger( WikiaLogger::instance() );
+			}
 		}
 
 		return $this->urlProvider;

--- a/lib/Wikia/src/Service/Gateway/InternalIngressUrlProvider.php
+++ b/lib/Wikia/src/Service/Gateway/InternalIngressUrlProvider.php
@@ -1,0 +1,9 @@
+<?php
+namespace Wikia\Service\Gateway;
+
+class InternalIngressUrlProvider implements UrlProvider {
+
+	public function getUrl( $serviceName ) {
+		return $serviceName;
+	}
+}

--- a/lib/Wikia/src/Service/Gateway/InternalIngressUrlProvider.php
+++ b/lib/Wikia/src/Service/Gateway/InternalIngressUrlProvider.php
@@ -3,7 +3,14 @@ namespace Wikia\Service\Gateway;
 
 class InternalIngressUrlProvider implements UrlProvider {
 
+	/** @var string $envName */
+	private $envName;
+
+	public function __construct( string $envName ) {
+		$this->envName = $envName;
+	}
+
 	public function getUrl( $serviceName ) {
-		return $serviceName;
+		return "$serviceName.{$this->envName}";
 	}
 }

--- a/lib/Wikia/tests/Service/Gateway/InternalIngressUrlProviderTest.php
+++ b/lib/Wikia/tests/Service/Gateway/InternalIngressUrlProviderTest.php
@@ -1,0 +1,24 @@
+<?php
+namespace Wikia\Service\Gateway;
+
+use PHPUnit\Framework\TestCase;
+
+class InternalIngressUrlProviderTest extends TestCase {
+
+	/**
+	 * @dataProvider provideEnvService
+	 *
+	 * @param string $envName
+	 * @param string $serviceName
+	 */
+	public function testGetUrl( string $envName, string $serviceName ) {
+		$provider = new InternalIngressUrlProvider( $envName );
+
+		$this->assertEquals( "$serviceName.$envName", $provider->getUrl( $serviceName ) );
+	}
+
+	public function provideEnvService() {
+		yield [ "dev", "helios" ];
+		yield [ "prod", "phalanx" ];
+	}
+}

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -2964,6 +2964,7 @@ return array(
     'Wikia\\Search\\Utilities' => $baseDir . '/extensions/wikia/Search/classes/Utilities.php',
     'Wikia\\Service\\Constants' => $baseDir . '/lib/Wikia/src/Service/Constants.php',
     'Wikia\\Service\\ForbiddenException' => $baseDir . '/lib/Wikia/src/Service/ForbiddenException.php',
+    'Wikia\\Service\\Gateway\\InternalIngressUrlProvider' => $baseDir . '/lib/Wikia/src/Service/Gateway/InternalIngressUrlProvider.php',
     'Wikia\\Service\\Gateway\\KubernetesExternalUrlProvider' => $baseDir . '/lib/Wikia/src/Service/Gateway/KubernetesExternalUrlProvider.php',
     'Wikia\\Service\\Gateway\\KubernetesUrlProvider' => $baseDir . '/lib/Wikia/src/Service/Gateway/KubernetesUrlProvider.php',
     'Wikia\\Service\\Gateway\\StaticUrlProvider' => $baseDir . '/lib/Wikia/src/Service/Gateway/StaticUrlProvider.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -3474,6 +3474,7 @@ class ComposerStaticInitb367f9b4bf4d43e0d5ea402c134db26b
         'Wikia\\Search\\Utilities' => __DIR__ . '/../../..' . '/extensions/wikia/Search/classes/Utilities.php',
         'Wikia\\Service\\Constants' => __DIR__ . '/../../..' . '/lib/Wikia/src/Service/Constants.php',
         'Wikia\\Service\\ForbiddenException' => __DIR__ . '/../../..' . '/lib/Wikia/src/Service/ForbiddenException.php',
+        'Wikia\\Service\\Gateway\\InternalIngressUrlProvider' => __DIR__ . '/../../..' . '/lib/Wikia/src/Service/Gateway/InternalIngressUrlProvider.php',
         'Wikia\\Service\\Gateway\\KubernetesExternalUrlProvider' => __DIR__ . '/../../..' . '/lib/Wikia/src/Service/Gateway/KubernetesExternalUrlProvider.php',
         'Wikia\\Service\\Gateway\\KubernetesUrlProvider' => __DIR__ . '/../../..' . '/lib/Wikia/src/Service/Gateway/KubernetesUrlProvider.php',
         'Wikia\\Service\\Gateway\\StaticUrlProvider' => __DIR__ . '/../../..' . '/lib/Wikia/src/Service/Gateway/StaticUrlProvider.php',


### PR DESCRIPTION
Avoid unnecessary roundtrip outside of K8S cluster when calling services that are themselves running on K8S.

https://wikia-inc.atlassian.net/browse/SUS-5405