### PR TITLE
(PLATFORM-3552) Add variable to upgrade anonymous users to HTTPS

### DIFF
--- a/extensions/wikia/HTTPSSupport/HTTPSSupportHooks.class.php
+++ b/extensions/wikia/HTTPSSupport/HTTPSSupportHooks.class.php
@@ -49,6 +49,9 @@ class HTTPSSupportHooks {
 				self::httpsAllowed( $user, $requestURL )
 			) {
 				$output->redirect( wfHttpToHttps( $requestURL ) );
+				if ( $user->isAnon() ) {
+					$output->enableClientCache( false );
+				}
 			} elseif ( WebRequest::detectProtocol() === 'https' &&
 				!self::httpsAllowed( $user, $requestURL ) &&
 				empty( $wgDisableHTTPSDowngrade ) &&
@@ -72,13 +75,7 @@ class HTTPSSupportHooks {
 	 */
 	public static function onSitemapPageBeforeOutput( string $subpage, WebRequest $request, User $user ): bool {
 		global $wgScriptPath;
-		if ( WebRequest::detectProtocol() === 'https' &&
-			!self::httpsAllowed( $user, $request->getFullRequestURL() )
-		) {
-			self::downgradeRedirectForPath( "$wgScriptPath/$subpage", $request );
-			return false;
-		}
-		return true;
+		return self::handleRedirectForPath( "$wgScriptPath/$subpage", $request, $user );
 	}
 
 	/**
@@ -89,17 +86,13 @@ class HTTPSSupportHooks {
 	 * @return boolean
 	 */
 	public static function onWikiaRobotsBeforeOutput( WebRequest $request, User $user ): bool {
-		if ( WebRequest::detectProtocol() === 'https' &&
-			!self::httpsAllowed( $user, $request->getFullRequestURL() )
-		) {
-			self::downgradeRedirectForPath( '/robots.txt', $request );
-			return false;
-		}
-		return true;
+		return self::handleRedirectForPath( '/robots.txt', $request, $user );
 	}
 
 	private static function httpsAllowed( User $user, string $url ): bool {
-		return wfHttpsAllowedForURL( $url ) && $user->isLoggedIn();
+		global $wgEnableHTTPSForAnons;
+		return wfHttpsAllowedForURL( $url ) &&
+			( !empty( $wgEnableHTTPSForAnons ) || $user->isLoggedIn() );
 	}
 
 	private static function httpsEnabledTitle( Title $title ): bool {
@@ -108,17 +101,32 @@ class HTTPSSupportHooks {
 			in_array( $title->getPrefixedDBKey(), self::$httpsArticles[ $wgDBname ] );
 	}
 
-	public static function parserUpgradeVignetteUrls ( string &$url ) {
-		if ( preg_match( self::VIGNETTE_IMAGES_HTTP_UPGRADABLE, $url ) && strpos( $url, "http://" ) === 0 ) {
+	public static function parserUpgradeVignetteUrls( string &$url ) {
+		if ( preg_match( self::VIGNETTE_IMAGES_HTTP_UPGRADABLE, $url ) && strpos( $url, 'http://' ) === 0 ) {
 			$url = wfHttpToHttps( $url );
 		}
 	}
 
-	private static function downgradeRedirectForPath( string $path, WebRequest $request ) {
-		$httpURL = wfHttpsToHttp( wfExpandUrl( $path, PROTO_HTTP ) );
+	private static function handleRedirectForPath( string $path, WebRequest $request, User $user ): bool {
+		$url = wfExpandUrl( $path, PROTO_HTTP );
+		if ( WebRequest::detectProtocol() === 'http' &&
+			self::httpsAllowed( $user, $request->getFullRequestURL() )
+		) {
+			self::redirectWithPrivateCache( wfHttpToHttps( $url ), $request );
+			return false;
+		} elseif ( WebRequest::detectProtocol() === 'https' &&
+			!self::httpsAllowed( $user, $request->getFullRequestURL() )
+		) {
+			self::redirectWithPrivateCache( wfHttpsToHttp( $url ), $request );
+			return false;
+		}
+		return true;
+	}
+
+	private static function redirectWithPrivateCache( string $url, WebRequest $request ) {
 		$response = $request->response();
-		$response->header( "Location: $httpURL", true, 302 );
-		$response->header( 'X-Redirected-By: HTTPS-Downgrade' );
+		$response->header( "Location: $url", true, 302 );
+		$response->header( 'X-Redirected-By: HTTPS-Support' );
 		$response->header( 'Cache-Control: private, must-revalidate, max-age=0' );
 	}
 }


### PR DESCRIPTION
Adds the variable `$wgEnableHTTPSForAnons` to forcibly upgrade anon requests
for initial testing. Limiting the cache of these redirects for now at least, while testing.

/cc @Wikia/core-platform-team 