### PR TITLE
MAIN-16796: Fix broken links to userpages in S:Templates

### DIFF
--- a/extensions/wikia/TemplateClassification/specials/templates/TemplatesSpecialController_index.php
+++ b/extensions/wikia/TemplateClassification/specials/templates/TemplatesSpecialController_index.php
@@ -36,11 +36,7 @@
 				</a></h3>
 				<?php if ( isset( $template['revision'] ) ) : ?>
 					<?= wfMessage( 'template-classification-special-last-edit' )->rawParams(
-						Xml::element( 'a', [
-							'href' => $template['revision']['userpage']
-						],
-							$template['revision']['username']
-						),
+						$template['revision']['userpage'],
 						$template['revision']['timestamp']
 					)->escaped() ?>
 				<?php endif; ?>


### PR DESCRIPTION
In Special:Templates links to an user who made last edit to the template are broken, as `<a>` tag is already generated [here](https://github.com/Wikia/app/blob/dev/extensions/wikia/TemplateClassification/specials/TemplatesSpecialController.class.php#L231).
![](https://user-images.githubusercontent.com/14111811/42258361-9a1a88f8-7f5b-11e8-8de7-c983fbef7446.png)



Jira issue: [MAIN-16796](https://wikia-inc.atlassian.net/browse/MAIN-16796)