### PR TITLE
IRIS-6285 | Fix forum thread to discussions post redirects

### DIFF
--- a/extensions/wikia/ArticleComments/classes/ArticleCommentList.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleCommentList.class.php
@@ -855,7 +855,7 @@ class ArticleCommentList {
 		$ns = $title->getNamespace();
 		if (
 			!MWNamespace::isTalk( $ns ) ||
-			!in_array( $ns, $wgArticleCommentsNamespaces ) ||
+			!in_array( MWNamespace::getSubject( $ns ), $wgArticleCommentsNamespaces ) ||
 			!ArticleComment::isTitleComment( $title ) ) {
 			return true;
 		}

--- a/extensions/wikia/ArticleComments/classes/ArticleCommentList.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleCommentList.class.php
@@ -851,7 +851,12 @@ class ArticleCommentList {
 		}
 
 		// Only handle comments
-		if ( !MWNamespace::isTalk( $title->getNamespace() ) || !ArticleComment::isTitleComment( $title ) ) {
+		global $wgArticleCommentsNamespaces;
+		$ns = $title->getNamespace();
+		if (
+			!MWNamespace::isTalk( $ns ) ||
+			!in_array( $ns, $wgArticleCommentsNamespaces ) ||
+			!ArticleComment::isTitleComment( $title ) ) {
 			return true;
 		}
 

--- a/extensions/wikia/Discussions/tests/SpecialForumRedirectControllerTest.php
+++ b/extensions/wikia/Discussions/tests/SpecialForumRedirectControllerTest.php
@@ -22,7 +22,6 @@ class SpecialForumRedirectControllerTest extends WikiaDatabaseTest {
 	) {
 		$article = Article::newFromID( $articleId );
 		$redirectableForumTitle = SpecialForumRedirectController::getRedirectableForumTitle( $article );
-		var_dump($redirectableForumTitle);
 
 		$this->assertEquals( $expectedArticleId, $redirectableForumTitle->getArticleID() );
 	}

--- a/extensions/wikia/Discussions/tests/SpecialForumRedirectControllerTest.php
+++ b/extensions/wikia/Discussions/tests/SpecialForumRedirectControllerTest.php
@@ -6,32 +6,51 @@
 class SpecialForumRedirectControllerTest extends WikiaDatabaseTest {
 	const THREAD_ID = 1;
 	const REPLY_ID = 2;
+	const ARTICLE_ID = 3;
 
 	protected function setUp() {
 		parent::setUp();
 		require_once __DIR__ . '/../controllers/SpecialForumRedirectController.class.php';
 	}
 
+	protected function getDataSet()	{
+		return $this->createYamlDataSet( __DIR__ . '/fixtures/special_forum_redirect_controller.yaml' );
+	}
+
 	/**
-	 * @dataProvider provideGetRedirectableForumTitle
+	 * @dataProvider provideGetRedirectableForumTitleForForumThreadNamespace
 	 * @param int $articleId
-	 * @param int $expectedArticleId
+	 * @param int|null $expectedArticleId
 	 */
-	public function testGetRedirectableForumTitle(
-		int $articleId, int $expectedArticleId
+	public function testGetRedirectableForumTitleForForumThreadNamespace(
+		int $articleId, $expectedArticleId
 	) {
 		$article = Article::newFromID( $articleId );
+
 		$redirectableForumTitle = SpecialForumRedirectController::getRedirectableForumTitle( $article );
 
-		$this->assertEquals( $expectedArticleId, $redirectableForumTitle->getArticleID() );
+		if ( $expectedArticleId !== null ) {
+			$this->assertEquals( $expectedArticleId, $redirectableForumTitle->getArticleID() );
+		} else {
+			$this->assertEquals( null, $redirectableForumTitle );
+		}
 	}
 
-	public function provideGetRedirectableForumTitle(): Generator {
+	public function provideGetRedirectableForumTitleForForumThreadNamespace(): Generator {
 		yield [ static::THREAD_ID, static::THREAD_ID ];
 		yield [ static::REPLY_ID, static::THREAD_ID ];
+		yield [ static::ARTICLE_ID, null ];
 	}
 
-	protected function getDataSet() {
-		return $this->createYamlDataSet( __DIR__ . '/fixtures/special_forum_redirect_controller.yaml' );
+	/**
+	 * @throws MWException
+	 */
+	public function testGetRedirectableForumTitleForWallMessageNamespace() {
+		$title = Title::newFromText( 'Thread:' . static::THREAD_ID );
+		$article = Article::newFromTitle( $title, new RequestContext() );
+
+		$redirectableForumTitle = SpecialForumRedirectController::getRedirectableForumTitle( $article );
+
+		$this->assertEquals( static::THREAD_ID, $redirectableForumTitle->getArticleID() );
 	}
 }

--- a/extensions/wikia/Discussions/tests/SpecialForumRedirectControllerTest.php
+++ b/extensions/wikia/Discussions/tests/SpecialForumRedirectControllerTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @group Integration
+ */
+class SpecialForumRedirectControllerTest extends WikiaDatabaseTest {
+	const THREAD_ID = 1;
+	const REPLY_ID = 2;
+
+	protected function setUp() {
+		parent::setUp();
+		require_once __DIR__ . '/../controllers/SpecialForumRedirectController.class.php';
+	}
+
+	/**
+	 * @dataProvider provideGetRedirectableForumTitle
+	 * @param int $articleId
+	 * @param int $expectedArticleId
+	 */
+	public function testGetRedirectableForumTitle(
+		int $articleId, int $expectedArticleId
+	) {
+		$article = Article::newFromID( $articleId );
+		$redirectableForumTitle = SpecialForumRedirectController::getRedirectableForumTitle( $article );
+		var_dump($redirectableForumTitle);
+
+		$this->assertEquals( $expectedArticleId, $redirectableForumTitle->getArticleID() );
+	}
+
+	public function provideGetRedirectableForumTitle(): Generator {
+		yield [ static::THREAD_ID, static::THREAD_ID ];
+		yield [ static::REPLY_ID, static::THREAD_ID ];
+	}
+
+	protected function getDataSet() {
+		return $this->createYamlDataSet( __DIR__ . '/fixtures/special_forum_redirect_controller.yaml' );
+	}
+}

--- a/extensions/wikia/Discussions/tests/fixtures/special_forum_redirect_controller.yaml
+++ b/extensions/wikia/Discussions/tests/fixtures/special_forum_redirect_controller.yaml
@@ -13,3 +13,10 @@ page:
     page_random: 0
     page_latest: 2
     page_len: 0
+  - page_id: 3
+    page_namespace: 1
+    page_title: This_is_article
+    page_restrictions: ''
+    page_random: 0
+    page_latest: 3
+    page_len: 0

--- a/extensions/wikia/Discussions/tests/fixtures/special_forum_redirect_controller.yaml
+++ b/extensions/wikia/Discussions/tests/fixtures/special_forum_redirect_controller.yaml
@@ -1,0 +1,15 @@
+page:
+  - page_id: 1
+    page_namespace: 2001
+    page_title: This_is_forum_board/@comment-123-20160101000000
+    page_restrictions: ''
+    page_random: 0
+    page_latest: 1
+    page_len: 0
+  - page_id: 2
+    page_namespace: 2001
+    page_title: This_is_forum_board/@comment-123-20160101000000/@comment-321-20160101000001
+    page_restrictions: ''
+    page_random: 0
+    page_latest: 2
+    page_len: 0


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/IRIS-6285

Make sure all those URLs redirect to the same Discussions post (https://tardistest.wikia.com/d/p/2053744661365102344):
- https://tardistest.wikia.com/wiki/Board_Thread:News_and_Announcements/@comment-188432-20131004200402
- https://tardistest.wikia.com/wiki/Board_Thread:News_and_Announcements/@comment-188432-20131004200402/@comment-3333919-20131010202415
- https://tardistest.wikia.com/wiki/Thread:3587

cc @Wikia/iris 