### PR TITLE
IRIS-6286 | Thread:xxx should never be a red link

### DIFF
--- a/extensions/wikia/Discussions/Discussions.setup.php
+++ b/extensions/wikia/Discussions/Discussions.setup.php
@@ -32,6 +32,7 @@ if ( !empty( $wgEnableDiscussions ) && empty( $wgEnableForumExt ) ) {
 	$wgAutoloadClasses['SpecialForumRedirectController'] = __DIR__ . '/controllers/SpecialForumRedirectController.class.php';
 	$wgHooks['ArticleViewHeader'][] = 'SpecialForumRedirectController::onArticleViewHeader';
 	$wgHooks['BeforePageHistory'][] = 'SpecialForumRedirectController::onBeforePageHistory';
+	$wgHooks['LinkBegin'][] = 'DiscussionsHooksHelper::onLinkBegin';
 	$wgSpecialPages['Forum'] = 'SpecialForumRedirectController';
 
 	// IRIS-5184: Exclude outgoing links in Forum content from Special:WhatLinksHere and Special:WantedPages

--- a/extensions/wikia/Discussions/DiscussionsHooksHelper.php
+++ b/extensions/wikia/Discussions/DiscussionsHooksHelper.php
@@ -29,4 +29,53 @@ class DiscussionsHooksHelper {
 		global $wgDiscussionsApiUrl;
 		$vars['wgDiscussionsApiUrl'] = $wgDiscussionsApiUrl;
 	}
+
+	/**
+	 * Changing all links to Thread:xxx to blue links
+	 * @see WallHooksHelper::onLinkBegin
+	 *
+	 * @param $skin
+	 * @param $target
+	 * @param $text
+	 * @param $customAttribs
+	 * @param $query
+	 * @param $options
+	 * @param $ret
+	 * @internal param \Title $title
+	 * @internal param bool $result
+	 *
+	 * @return true -- because it's a hook
+	 */
+	public static function onLinkBegin( $skin, $target, &$text, &$customAttribs, &$query, &$options, &$ret ) {
+		global $wgEnableWallEngine;
+		// We need this logic only when the Wall extension is disabled
+		// This method is a direct copy from WallHooksHelper::onLinkBegin
+		if ( empty( $wgEnableWallEngine ) ) {
+			return true;
+		}
+
+		if ( !( $target instanceof Title ) ) {
+			return true;
+		}
+
+		if ( self::isWallNamespace( $target->getNamespace() ) ) {
+
+			// remove "broken" assumption/override
+			$brokenKey = array_search( 'broken', $options );
+			if ( $brokenKey !== false ) {
+				unset( $options[$brokenKey] );
+			}
+
+			// make the link "blue"
+			$options[] = 'known';
+		}
+
+		return true;
+	}
+
+	private static function isWallNamespace( $ns ) {
+		global $wgWallNS;
+
+		return in_array( MWNamespace::getSubject( $ns ), $wgWallNS );
+	}
 }

--- a/extensions/wikia/Discussions/DiscussionsHooksHelper.php
+++ b/extensions/wikia/Discussions/DiscussionsHooksHelper.php
@@ -50,7 +50,7 @@ class DiscussionsHooksHelper {
 		global $wgEnableWallEngine;
 		// We need this logic only when the Wall extension is disabled
 		// This method is a direct copy from WallHooksHelper::onLinkBegin
-		if ( empty( $wgEnableWallEngine ) ) {
+		if ( !empty( $wgEnableWallEngine ) ) {
 			return true;
 		}
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/IRIS-6286

Wall hooks are run only when: https://github.com/Wikia/app/blob/5c0ee26bc7744dacff3710254b53d552cc74fb9d/includes/wikia/Extensions.php#L815

When a community is migrated to Discussions we set `$wgEnableForumExt = false` which caused `Thread:xxx` to turn into red links. Let's duplicate the logic from: https://github.com/Wikia/app/blob/a0d2913d71c4db28853ad0c14e551e2ee914703b/extensions/wikia/Wall/WallHooksHelper.class.php#L1190 to have the same behaviour on migrated communities.

@Wikia/iris 