### PR TITLE
Fix update schemas.sh

### DIFF
--- a/maintenance/wikia/sql/archive-schema.sql
+++ b/maintenance/wikia/sql/archive-schema.sql
@@ -1,4 +1,4 @@
--- MySQL dump 10.13  Distrib 5.6.24-72.2, for debian-linux-gnu (x86_64)
+-- MySQL dump 10.13  Distrib 5.7.18-15, for debian-linux-gnu (x86_64)
 --
 -- Host: geo-db-archive-slave.query.consul    Database: archive
 -- ------------------------------------------------------
@@ -97,4 +97,4 @@ CREATE TABLE `wikia_tasks` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 
--- Dump completed on 2018-03-15 15:22:11
+-- Dump completed on 2018-07-06 12:59:33

--- a/maintenance/wikia/sql/dataware-schema.sql
+++ b/maintenance/wikia/sql/dataware-schema.sql
@@ -4,38 +4,23 @@
 -- ------------------------------------------------------
 -- Server version	5.7.18-15-log
 
-/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
-/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
-/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
-/*!40101 SET NAMES utf8 */;
-/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
-/*!40103 SET TIME_ZONE='+00:00' */;
-/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
-/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
-/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
-/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
 
 --
 -- Table structure for table `ab_config`
 --
 
 DROP TABLE IF EXISTS `ab_config`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `ab_config` (
   `id` int(11) NOT NULL,
   `updated` datetime NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-/*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Table structure for table `ab_experiment_group_ranges`
 --
 
 DROP TABLE IF EXISTS `ab_experiment_group_ranges`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `ab_experiment_group_ranges` (
   `group_id` int(11) NOT NULL,
   `version_id` int(11) NOT NULL,
@@ -47,15 +32,12 @@ CREATE TABLE `ab_experiment_group_ranges` (
   CONSTRAINT `fk_range_group` FOREIGN KEY (`group_id`) REFERENCES `ab_experiment_groups` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `fk_range_version` FOREIGN KEY (`version_id`) REFERENCES `ab_experiment_versions` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-/*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Table structure for table `ab_experiment_groups`
 --
 
 DROP TABLE IF EXISTS `ab_experiment_groups`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `ab_experiment_groups` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL,
@@ -64,16 +46,13 @@ CREATE TABLE `ab_experiment_groups` (
   PRIMARY KEY (`id`),
   KEY `experiment_id` (`experiment_id`),
   CONSTRAINT `fk_group_experiment` FOREIGN KEY (`experiment_id`) REFERENCES `ab_experiments` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=373 DEFAULT CHARSET=latin1;
-/*!40101 SET character_set_client = @saved_cs_client */;
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 --
 -- Table structure for table `ab_experiment_versions`
 --
 
 DROP TABLE IF EXISTS `ab_experiment_versions`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `ab_experiment_versions` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `experiment_id` int(11) NOT NULL,
@@ -87,38 +66,32 @@ CREATE TABLE `ab_experiment_versions` (
   KEY `control_group_id` (`control_group_id`),
   CONSTRAINT `fk_version_control_group` FOREIGN KEY (`control_group_id`) REFERENCES `ab_experiment_groups` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
   CONSTRAINT `fk_version_experiment` FOREIGN KEY (`experiment_id`) REFERENCES `ab_experiments` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=489 DEFAULT CHARSET=latin1;
-/*!40101 SET character_set_client = @saved_cs_client */;
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 --
 -- Table structure for table `ab_experiments`
 --
 
 DROP TABLE IF EXISTS `ab_experiments`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `ab_experiments` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL,
   `description` tinyblob,
   PRIMARY KEY (`id`),
   UNIQUE KEY `name` (`name`)
-) ENGINE=InnoDB AUTO_INCREMENT=91 DEFAULT CHARSET=latin1;
-/*!40101 SET character_set_client = @saved_cs_client */;
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 --
 -- Table structure for table `blobs`
 --
 
 DROP TABLE IF EXISTS `blobs`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `blobs` (
   `blob_id` int(10) NOT NULL AUTO_INCREMENT,
   `blob_text` mediumtext NOT NULL,
   PRIMARY KEY (`blob_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=104820274 DEFAULT CHARSET=utf8
-/*!50100 PARTITION BY RANGE (blob_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8
+/* PARTITION BY RANGE (blob_id)
 (PARTITION p0 VALUES LESS THAN (10388840) ENGINE = InnoDB,
  PARTITION p1 VALUES LESS THAN (20777680) ENGINE = InnoDB,
  PARTITION p2 VALUES LESS THAN (41555360) ENGINE = InnoDB,
@@ -126,15 +99,12 @@ CREATE TABLE `blobs` (
  PARTITION p4 VALUES LESS THAN (83110720) ENGINE = InnoDB,
  PARTITION p5 VALUES LESS THAN (103888400) ENGINE = InnoDB,
  PARTITION p6 VALUES LESS THAN MAXVALUE ENGINE = InnoDB) */;
-/*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Table structure for table `chat_ban_users`
 --
 
 DROP TABLE IF EXISTS `chat_ban_users`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `chat_ban_users` (
   `cbu_wiki_id` int(10) NOT NULL DEFAULT '0',
   `cbu_user_id` int(10) NOT NULL DEFAULT '0',
@@ -145,43 +115,34 @@ CREATE TABLE `chat_ban_users` (
   UNIQUE KEY `cbu_user_id` (`cbu_wiki_id`,`cbu_user_id`),
   KEY `wiki_start_date` (`cbu_wiki_id`,`start_date`)
 ) ENGINE=InnoDB DEFAULT CHARSET=binary;
-/*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Table structure for table `chat_blocked_users`
 --
 
 DROP TABLE IF EXISTS `chat_blocked_users`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `chat_blocked_users` (
   `cbu_user_id` int(11) NOT NULL DEFAULT '0',
   `cbu_blocked_user_id` int(11) NOT NULL DEFAULT '0',
   UNIQUE KEY `cbu_user_id` (`cbu_user_id`,`cbu_blocked_user_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-/*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Table structure for table `email_types`
 --
 
 DROP TABLE IF EXISTS `email_types`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `email_types` (
   `id` tinyint(3) unsigned NOT NULL,
   `type` varchar(64) NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-/*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Table structure for table `global_watchlist`
 --
 
 DROP TABLE IF EXISTS `global_watchlist`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `global_watchlist` (
   `gwa_user_id` int(11) DEFAULT NULL,
   `gwa_city_id` int(11) DEFAULT NULL,
@@ -193,15 +154,12 @@ CREATE TABLE `global_watchlist` (
   UNIQUE KEY `wikia_user` (`gwa_city_id`,`gwa_user_id`,`gwa_namespace`,`gwa_title`),
   KEY `user_id` (`gwa_user_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-/*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Table structure for table `pages`
 --
 
 DROP TABLE IF EXISTS `pages`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `pages` (
   `page_wikia_id` int(8) unsigned NOT NULL,
   `page_id` int(8) unsigned NOT NULL,
@@ -215,15 +173,12 @@ CREATE TABLE `pages` (
   PRIMARY KEY (`page_wikia_id`,`page_id`),
   KEY `page_title_namespace_latest_idx` (`page_title`,`page_namespace`,`page_latest`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-/*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Table structure for table `user_flags`
 --
 
 DROP TABLE IF EXISTS `user_flags`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `user_flags` (
   `city_id` int(9) NOT NULL,
   `user_id` int(10) NOT NULL,
@@ -231,15 +186,12 @@ CREATE TABLE `user_flags` (
   `data` varchar(255) NOT NULL,
   PRIMARY KEY (`city_id`,`user_id`,`type`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-/*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Table structure for table `wall_notification`
 --
 
 DROP TABLE IF EXISTS `wall_notification`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `wall_notification` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `user_id` int(11) NOT NULL,
@@ -254,16 +206,13 @@ CREATE TABLE `wall_notification` (
   PRIMARY KEY (`id`),
   KEY `unique_id` (`unique_id`),
   KEY `user_wiki_unique` (`user_id`,`wiki_id`,`unique_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=363602576 DEFAULT CHARSET=latin1;
-/*!40101 SET character_set_client = @saved_cs_client */;
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 --
 -- Table structure for table `wall_notification_queue`
 --
 
 DROP TABLE IF EXISTS `wall_notification_queue`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `wall_notification_queue` (
   `wiki_id` int(10) unsigned NOT NULL,
   `entity_key` varbinary(30) NOT NULL,
@@ -272,15 +221,12 @@ CREATE TABLE `wall_notification_queue` (
   PRIMARY KEY (`wiki_id`,`page_id`),
   KEY `event_date` (`event_date`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-/*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Table structure for table `wall_notification_queue_processed`
 --
 
 DROP TABLE IF EXISTS `wall_notification_queue_processed`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `wall_notification_queue_processed` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `user_id` int(10) unsigned NOT NULL,
@@ -289,16 +235,13 @@ CREATE TABLE `wall_notification_queue_processed` (
   PRIMARY KEY (`id`),
   KEY `user_event_idx` (`user_id`,`entity_key`),
   KEY `event_date` (`event_date`)
-) ENGINE=InnoDB AUTO_INCREMENT=23978307 DEFAULT CHARSET=latin1;
-/*!40101 SET character_set_client = @saved_cs_client */;
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 --
 -- Table structure for table `wikiastaff_log`
 --
 
 DROP TABLE IF EXISTS `wikiastaff_log`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `wikiastaff_log` (
   `slog_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `slog_type` varbinary(10) NOT NULL DEFAULT '',
@@ -315,20 +258,7 @@ CREATE TABLE `wikiastaff_log` (
   `slog_city` int(11) DEFAULT NULL,
   PRIMARY KEY (`slog_id`),
   KEY `slog_time` (`slog_timestamp`)
-) ENGINE=InnoDB AUTO_INCREMENT=2064033 DEFAULT CHARSET=latin1;
-/*!40101 SET character_set_client = @saved_cs_client */;
-/*!50112 SET @disable_bulk_load = IF (@is_rocksdb_supported, 'SET SESSION rocksdb_bulk_load = @old_rocksdb_bulk_load', 'SET @dummy_rocksdb_bulk_load = 0') */;
-/*!50112 PREPARE s FROM @disable_bulk_load */;
-/*!50112 EXECUTE s */;
-/*!50112 DEALLOCATE PREPARE s */;
-/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
-/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
-/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
-/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
-/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
-/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
-/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
-/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2018-05-28 17:16:35
+-- Dump completed on 2018-07-06 12:59:33

--- a/maintenance/wikia/sql/portability_db-schema.sql
+++ b/maintenance/wikia/sql/portability_db-schema.sql
@@ -1,4 +1,4 @@
--- MySQL dump 10.13  Distrib 5.6.24-72.2, for debian-linux-gnu (x86_64)
+-- MySQL dump 10.13  Distrib 5.7.18-15, for debian-linux-gnu (x86_64)
 --
 -- Host: geo-db-archive-slave.query.consul    Database: portability_db
 -- ------------------------------------------------------
@@ -23,4 +23,4 @@ CREATE TABLE `portability_dashboard` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 
--- Dump completed on 2018-01-26  9:05:11
+-- Dump completed on 2018-07-06 12:59:34

--- a/maintenance/wikia/sql/specials-schema.sql
+++ b/maintenance/wikia/sql/specials-schema.sql
@@ -1,4 +1,4 @@
--- MySQL dump 10.13  Distrib 5.6.24-72.2, for debian-linux-gnu (x86_64)
+-- MySQL dump 10.13  Distrib 5.7.18-15, for debian-linux-gnu (x86_64)
 --
 -- Host: geo-db-specials-slave.query.consul    Database: specials
 -- ------------------------------------------------------
@@ -138,4 +138,4 @@ CREATE TABLE `script_log` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 
--- Dump completed on 2018-05-23 15:46:55
+-- Dump completed on 2018-07-06 12:59:34

--- a/maintenance/wikia/sql/statsdb-schema.sql
+++ b/maintenance/wikia/sql/statsdb-schema.sql
@@ -1,8 +1,8 @@
--- MySQL dump 10.13  Distrib 5.6.24-72.2, for debian-linux-gnu (x86_64)
+-- MySQL dump 10.13  Distrib 5.7.18-15, for debian-linux-gnu (x86_64)
 --
 -- Host: geo-db-dataware-slave.query.consul    Database: statsdb
 -- ------------------------------------------------------
--- Server version	5.6.24-72.2-log
+-- Server version	5.7.18-15-log
 
 
 --
@@ -4221,4 +4221,4 @@ CREATE TABLE `rollup_wiki_user_events` (
  PARTITION p20300101 VALUES LESS THAN ('2030-01-02') ENGINE = InnoDB) */;
 
 
--- Dump completed on 2018-03-07  9:05:27
+-- Dump completed on 2018-07-06 12:59:35

--- a/maintenance/wikia/sql/update-schemas.sh
+++ b/maintenance/wikia/sql/update-schemas.sh
@@ -6,5 +6,5 @@ do
 	echo "Updating schema of tables in $DATABASE database ..."
 
 	DB_PARAMS=`dbparams.pl --type slave --name $DATABASE`
-	mysqldump --set-gtid-purged=OFF --no-data $DB_PARAMS | grep --invert-match --regexp='^\/\*\!50717 | sed 's/AUTO_INCREMENT=[0-9]* //g' > ${DATABASE}-schema.sql
+	mysqldump --set-gtid-purged=OFF --no-data $DB_PARAMS | sed 's/\/\*\!50100/\/*/g' | grep --invert-match --regexp='^\/\*\!' | sed 's/AUTO_INCREMENT=[0-9]* //g' > ${DATABASE}-schema.sql
 done

--- a/maintenance/wikia/sql/wikicities-schema.sql
+++ b/maintenance/wikia/sql/wikicities-schema.sql
@@ -1,4 +1,4 @@
--- MySQL dump 10.13  Distrib 5.6.24-72.2, for debian-linux-gnu (x86_64)
+-- MySQL dump 10.13  Distrib 5.7.18-15, for debian-linux-gnu (x86_64)
 --
 -- Host: geo-db-sharedb-slave.query.consul    Database: wikicities
 -- ------------------------------------------------------
@@ -616,4 +616,4 @@ CREATE TABLE `wikia_tasks_log` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 
--- Dump completed on 2018-06-05 10:29:49
+-- Dump completed on 2018-07-06 12:59:35


### PR DESCRIPTION
Remove MySQL dump comments, but keep a valid SQL when partitions definition is found in dump (`dataware.blobs` example).