### PR TITLE
SUS-5521 | support nested subdomains in k8s

### DIFF
--- a/docker/prod/nginx.conf
+++ b/docker/prod/nginx.conf
@@ -21,7 +21,7 @@ http {
       '"status": $status, '
       '"body_bytes_sent": $body_bytes_sent, '
       '"request_time": $request_time, '
-      '"http_host": "$host", '
+      '"http_host": "$http_x_original_host", '
       '"http_referrer": "$http_referer", '
       '"http_user_agent": "$http_user_agent" }';
 

--- a/docker/prod/prod.template.yaml
+++ b/docker/prod/prod.template.yaml
@@ -60,12 +60,9 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: mediawiki-prod-ingress
-  annotations:
-    traefik.frontend.priority: "1"
-    traefik.ingress.kubernetes.io/preserve-host: "true"
 spec:
   rules:
-    - host: "*.wikia.com"
+    - host: kubernetes.wikia.com
       http:
         paths:
           - path: /

--- a/docker/prod/site.conf
+++ b/docker/prod/site.conf
@@ -45,7 +45,8 @@ server {
         # make MediaWiki think we're running on a standard port
         # otherwise we end up with redirects to port 8080
         fastcgi_param SERVER_PORT 80;
-        fastcgi_param SERVER_NAME $host;
+        fastcgi_param HTTP_HOST $http_x_original_host;
+        fastcgi_param SERVER_NAME $http_x_original_host;
     }
 
     # handle short URLs - "/Foo" instead of "/wiki/Foo"

--- a/docker/sandbox/nginx.conf
+++ b/docker/sandbox/nginx.conf
@@ -21,6 +21,7 @@ http {
       '"status": $status, '
       '"body_bytes_sent": $body_bytes_sent, '
       '"request_time": $request_time, '
+      '"http_host": "$http_x_original_host", '
       '"http_referrer": "$http_referer", '
       '"http_user_agent": "$http_user_agent" }';
 

--- a/docker/sandbox/sandbox-sus2.yaml
+++ b/docker/sandbox/sandbox-sus2.yaml
@@ -60,11 +60,9 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: mediawiki-sandbox-ingress
-  annotations:
-    traefik.frontend.priority: "2"
 spec:
   rules:
-    - host: "*.sandbox-sus2.wikia.com"
+    - host: sandbox-sus2.wikia.com
       http:
         paths:
           - path: /

--- a/docker/sandbox/sandbox.template.yaml
+++ b/docker/sandbox/sandbox.template.yaml
@@ -60,11 +60,9 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: mediawiki-sandbox-ingress
-  annotations:
-    traefik.frontend.priority: "2"
 spec:
   rules:
-    - host: "*.${SANDBOX_NAME}.wikia.com"
+    - host: "${SANDBOX_NAME}.wikia.com"
       http:
         paths:
           - path: /

--- a/docker/sandbox/site.conf
+++ b/docker/sandbox/site.conf
@@ -46,7 +46,8 @@ server {
         # otherwise we end up with redirects to port 8080
         fastcgi_param SERVER_PORT 80;
         # use the original request host so MW can identify the specific wiki
-        fastcgi_param SERVER_NAME $host;
+        fastcgi_param HTTP_HOST $http_x_original_host;
+        fastcgi_param SERVER_NAME $http_x_original_host;
     }
 
     # handle short URLs - "/Foo" instead of "/wiki/Foo"


### PR DESCRIPTION
Traefik wildcard does not support nested subdomains—let's rewrite host instead and handle it again on nginx level.

https://wikia-inc.atlassian.net/browse/SUS-5521