### PR TITLE
SUS-5526 | validate NGINX configuration for syntax errors

### DIFF
--- a/docker/prod/Dockerfile-nginx
+++ b/docker/prod/Dockerfile-nginx
@@ -9,6 +9,9 @@ RUN chown -R nginx:nginx /etc/nginx && \
 ADD docker/prod/nginx.conf /etc/nginx/nginx.conf
 ADD docker/prod/site.conf /etc/nginx/conf.d/default.conf
 
+# validate configuration files for syntax errors
+RUN nginx -c /etc/nginx/nginx.conf -t
+
 # static mediawiki files
 ADD skins /usr/wikia/slot1/current/src/skins
 ADD resources /usr/wikia/slot1/current/src/resources

--- a/docker/sandbox/Dockerfile-nginx
+++ b/docker/sandbox/Dockerfile-nginx
@@ -9,6 +9,9 @@ RUN chown -R nginx:nginx /etc/nginx && \
 ADD docker/sandbox/nginx.conf /etc/nginx/nginx.conf
 ADD docker/sandbox/site.conf /etc/nginx/conf.d/default.conf
 
+# validate configuration files for syntax errors
+RUN nginx -c /etc/nginx/nginx.conf -t
+
 # static mediawiki files
 ADD skins /usr/wikia/slot1/current/src/skins
 ADD resources /usr/wikia/slot1/current/src/resources


### PR DESCRIPTION
Validate NGINX configuration for trivial syntax errors when building the image. This will validate both nginx.conf as well as site.conf which is included in it.

In case of a syntax error, the build will fail:
```
Step 5/9 : RUN nginx -c /etc/nginx/nginx.conf -t
 ---> Running in b992eb66278c
2018/07/13 10:33:37 [emerg] 6#6: unknown directive "ale" in /etc/nginx/conf.d/default.conf:1
nginx: [emerg] unknown directive "ale" in /etc/nginx/conf.d/default.conf:1
nginx: configuration file /etc/nginx/nginx.conf test failed
The command '/bin/sh -c nginx -c /etc/nginx/nginx.conf -t' returned a non-zero code: 1
```

https://wikia-inc.atlassian.net/browse/SUS-5526