### PR TITLE
SUS | run NGINX validation as nginx user

### DIFF
--- a/docker/prod/Dockerfile-nginx
+++ b/docker/prod/Dockerfile-nginx
@@ -9,12 +9,12 @@ RUN chown -R nginx:nginx /etc/nginx && \
 ADD docker/prod/nginx.conf /etc/nginx/nginx.conf
 ADD docker/prod/site.conf /etc/nginx/conf.d/default.conf
 
-# validate configuration files for syntax errors
-RUN nginx -c /etc/nginx/nginx.conf -t
-
 # static mediawiki files
 ADD skins /usr/wikia/slot1/current/src/skins
 ADD resources /usr/wikia/slot1/current/src/resources
 ADD extensions /usr/wikia/slot1/current/src/extensions
 
 USER nginx
+
+# validate configuration files for syntax errors
+RUN nginx -c /etc/nginx/nginx.conf -t

--- a/docker/sandbox/Dockerfile-nginx
+++ b/docker/sandbox/Dockerfile-nginx
@@ -9,12 +9,12 @@ RUN chown -R nginx:nginx /etc/nginx && \
 ADD docker/sandbox/nginx.conf /etc/nginx/nginx.conf
 ADD docker/sandbox/site.conf /etc/nginx/conf.d/default.conf
 
-# validate configuration files for syntax errors
-RUN nginx -c /etc/nginx/nginx.conf -t
-
 # static mediawiki files
 ADD skins /usr/wikia/slot1/current/src/skins
 ADD resources /usr/wikia/slot1/current/src/resources
 ADD extensions /usr/wikia/slot1/current/src/extensions
 
 USER nginx
+
+# validate configuration files for syntax errors
+RUN nginx -c /etc/nginx/nginx.conf -t


### PR DESCRIPTION
currently it runs too early so we get permissions issues later when starting the server:
```
2018/07/13 12:01:44 [emerg] 1#1: open() "/var/run/nginx/nginx.pid" failed (13: Permission denied)
nginx: [emerg] open() "/var/run/nginx/nginx.pid" failed (13: Permission denied)
```