### PR TITLE
MAIN-13170 & MAIN-16870 | Fix links in S:Nonportableinfoboxes and S:Insights

### DIFF
--- a/extensions/wikia/InsightsV2/models/InsightsQueryPageModel.php
+++ b/extensions/wikia/InsightsV2/models/InsightsQueryPageModel.php
@@ -102,7 +102,7 @@ abstract class InsightsQueryPageModel extends InsightsModel {
 
 		while ( $row = $dbr->fetchObject( $res ) ) {
 			if ( $row->title ) {
-				$title = Title::newFromText( $row->title, $row->namespace );
+				$title = Title::makeTitle( $row->namespace, $row->title );
 
 				if ( $title instanceof Title ) {
 					$data = [

--- a/extensions/wikia/InsightsV2/models/InsightsUnconvertedInfoboxesModel.php
+++ b/extensions/wikia/InsightsV2/models/InsightsUnconvertedInfoboxesModel.php
@@ -29,7 +29,7 @@ class InsightsUnconvertedInfoboxesModel extends InsightsQueryPageModel {
 	}
 
 	public function getAction( Title $title ) {
-		$subpage = Title::newFromText( $title->getText() . "/" . wfMessage('templatedraft-subpage')->escaped() , NS_TEMPLATE );
+		$subpage = Title::makeTitle( NS_TEMPLATE, $title->getText() . "/" . wfMessage('templatedraft-subpage')->escaped() );
 
 		if ( !$subpage instanceof Title ) {
 			// something went terribly wrong, quit early

--- a/extensions/wikia/InsightsV2/specials/UnconvertedInfoboxesPage.class.php
+++ b/extensions/wikia/InsightsV2/specials/UnconvertedInfoboxesPage.class.php
@@ -115,7 +115,7 @@ class UnconvertedInfoboxesPage extends PageQueryPage {
 						$this->getName(),
 						count( $links ),
 						NS_TEMPLATE,
-						$title->getPrefixedDBkey(),
+						$title->getDBkey(),
 					];
 				}
 			}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CORE-22

Fix for an issue listed in MAIN-16870 - double namespace prefix in [Special:Nonportableinfoboxes](http://community.wikia.com/wiki/Special:Nonportableinfoboxes) and [api.php?action=query&list=querypage&qppage=Nonportableinfoboxes](http://community.wikia.com/api.php?action=query&list=querypage&qppage=Nonportableinfoboxes&format=jsonfm), which was introduced in MAIN-13170 and applies a real fix for MAIN-13170, which also affects other Special:Insights subpages ([/templateswithouttype](https://luq.wikia.com/wiki/Specjalna:Podpowiedzi/templateswithouttype), [/wantedpages](https://luq.wikia.com/wiki/Specjalna:Podpowiedzi/wantedpages) (4th link) and other ones too).

Jira issues: [MAIN-13170](https://wikia-inc.atlassian.net/projects/MAIN/issues/MAIN-13170), [MAIN-16870](https://wikia-inc.atlassian.net/projects/MAIN/issues/MAIN-16870)
Inital fix for MAIN-13170: #14955 