### PR TITLE
SUS-5479 | fix sendConfirmationReminder script

### DIFF
--- a/extensions/wikia/AuthPages/maintenance/sendConfirmationReminder.php
+++ b/extensions/wikia/AuthPages/maintenance/sendConfirmationReminder.php
@@ -1,6 +1,6 @@
 <?php
 
-require __DIR__ . '/../../../maintenance/Maintenance.php';
+require __DIR__ . '/../../../../maintenance/Maintenance.php';
 
 /**
  * Maintenance script to send email confirmation reminder to users.


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5479

```
Fatal error: require(): Failed opening required 
'/extensions/wikia/AuthPages/maintenance/../../../maintenance/Maintenance.php' (include_path='.:/usr/share/php') in /extensions/wikia/AuthPages/maintenance/sendConfirmationReminder.php on line 3
```

See #15046