### PR TITLE
PLATFORM-3575: initial HTTPS redirects cleanup

### DIFF
--- a/extensions/wikia/HTTPSSupport/HTTPSSupportHooks.class.php
+++ b/extensions/wikia/HTTPSSupport/HTTPSSupportHooks.class.php
@@ -48,7 +48,7 @@ class HTTPSSupportHooks {
 			if ( WebRequest::detectProtocol() === 'http' &&
 				self::httpsAllowed( $user, $requestURL )
 			) {
-				$output->redirect( wfHttpToHttps( $requestURL ) );
+				$output->redirectProtocol( PROTO_HTTPS );
 				if ( $user->isAnon() ) {
 					$output->enableClientCache( false );
 				}
@@ -58,7 +58,7 @@ class HTTPSSupportHooks {
 				!$request->getHeader( 'X-Wikia-WikiaAppsID' ) &&
 				!self::httpsEnabledTitle( $title )
 			) {
-				$output->redirect( wfHttpsToHttp( $requestURL ) );
+				$output->redirectProtocol( PROTO_HTTP );
 				$output->enableClientCache( false );
 			}
 		}

--- a/extensions/wikia/HTTPSSupport/HTTPSSupportHooks.class.php
+++ b/extensions/wikia/HTTPSSupport/HTTPSSupportHooks.class.php
@@ -48,7 +48,7 @@ class HTTPSSupportHooks {
 			if ( WebRequest::detectProtocol() === 'http' &&
 				self::httpsAllowed( $user, $requestURL )
 			) {
-				$output->redirectProtocol( PROTO_HTTPS );
+				$output->redirectProtocol( PROTO_HTTPS, '301' );
 				if ( $user->isAnon() ) {
 					$output->enableClientCache( false );
 				}

--- a/includes/OutputPage.php
+++ b/includes/OutputPage.php
@@ -134,6 +134,10 @@ class OutputPage extends ContextSource {
 
 	var $mRedirectCode = '';
 
+	# start wikia change
+	var $mRedirectProtocol = PROTO_CURRENT;
+	# end wikia change
+
 	var $mFeedLinksAppendQuery = null;
 
 	/**
@@ -256,6 +260,15 @@ class OutputPage extends ContextSource {
 			$this->setContext( $context );
 		}
 	}
+
+	# start wikia change
+	public function redirectProtocol( $protocol, $responsecode = '302' ) {
+		if ( $protocol === PROTO_HTTP || $protocol === PROTO_HTTPS ) {
+			$this->mRedirectProtocol = $protocol;
+			$this->mRedirectCode = $responsecode;
+		}
+	}
+	# end wikia change
 
 	/**
 	 * Redirect to $url rather than displaying the normal page
@@ -2065,9 +2078,19 @@ class OutputPage extends ContextSource {
 
 		$response = $this->getRequest()->response();
 
-		if ( $this->mRedirect != '' ) {
+		if ( $this->mRedirect != '' || $this->mRedirectProtocol != PROTO_CURRENT ) {
+			if ( $this->mRedirect == '') {
+				$this->mRedirect = $this->getRequest()->getFullRequestURL();
+			}
+
+			if ( $this->mRedirectProtocol === PROTO_HTTP ) {
+				$this->mRedirect = wfHttpsToHttp( $this->mRedirect );
+			} elseif ( $this->mRedirectProtocol === PROTO_HTTPS ) {
+				$this->mRedirect = wfHttpToHttps( $this->mRedirect );
+			}
+
 			# Standards require redirect URLs to be absolute
-			$this->mRedirect = wfExpandUrl( $this->mRedirect, PROTO_CURRENT );
+			$this->mRedirect = wfExpandUrl( $this->mRedirect, $this->mRedirectProtocol );
 
 			$redirect = $this->mRedirect;
 			$code = $this->mRedirectCode;


### PR DESCRIPTION
Introduce late HTTP <-> HTTPS redirects to allow some Wiki Factory logic to kick in before we issue 30x to a proper protocol.

ping: @Wikia/core-platform-team, @macbre 