### PR TITLE
SUS-5523 | Kill PHP notice on Special:Community

### DIFF
--- a/extensions/wikia/CommunityPage/models/CommunityPageSpecialInsightsModel.class.php
+++ b/extensions/wikia/CommunityPage/models/CommunityPageSpecialInsightsModel.class.php
@@ -4,7 +4,6 @@ class CommunityPageSpecialInsightsModel {
 	const INSIGHTS_MODULE_ITEMS = 3;
 	const INSIGHTS_ICON = 'icon';
 	const INSIGHTS_TITLE = 'title';
-	const RANDOM_SORTING_TYPE = 'random';
 	const INSIGHTS_MODULES = [
 		'popularpages' => [
 			self::INSIGHTS_ICON => 'proof-read',
@@ -60,8 +59,7 @@ class CommunityPageSpecialInsightsModel {
 
 		$insightPages = $this->insightsService->getInsightPagesForModel(
 			$model,
-			static::INSIGHTS_MODULE_ITEMS,
-			static::RANDOM_SORTING_TYPE
+			static::INSIGHTS_MODULE_ITEMS
 		);
 
 		if ( empty( $insightPages[ 'pages' ] ) ) {

--- a/extensions/wikia/InsightsV2/helpers/InsightsSorting.php
+++ b/extensions/wikia/InsightsV2/helpers/InsightsSorting.php
@@ -40,10 +40,11 @@ class InsightsSorting {
 	/**
 	 * Overrides the default values used for sorting and pagination
 	 *
+	 * @param array $articleData
 	 * @param array $params An array of URL parameters
 	 * @return array
 	 */
-	public function getSortedData( $articleData, $params ) {
+	public function getSortedData( $articleData, array $params = []) {
 		$sortParam = $params['sort'] ?? '';
 
 		if ( $sortParam || $this->config->showPageViews() ) {

--- a/extensions/wikia/InsightsV2/services/InsightsService.class.php
+++ b/extensions/wikia/InsightsV2/services/InsightsService.class.php
@@ -2,7 +2,7 @@
 
 class InsightsService {
 
-	public function getInsightPagesForModel( InsightsModel $model, $size, $sortingType ): array {
+	public function getInsightPagesForModel( InsightsModel $model, $size ): array {
 		$insightData = ( new InsightsContext( $model ) )->fetchData();
 
 		if ( empty( $insightData ) ) {
@@ -11,37 +11,10 @@ class InsightsService {
 
 		$insightCount = count( $insightData );
 
-		if ( empty( $sortingType ) ) {
-			return [
-				'count' => $insightCount,
-				'pages' => array_slice( $insightData, 0, $size )
-			];
-		}
-
-		$sortedInsightArticleIds = ( new InsightsSorting( $model->getConfig() ) )
-			->getSortedData(
-				$insightData,
-				[ 'sort' => $sortingType ]
-			);
-
-		$articleIds = array_slice( $sortedInsightArticleIds, 0, $size );
-
 		return [
 			'count' => $insightCount,
-			'pages' => $this->getArticlesData( $insightData, $articleIds )
+			'pages' => array_slice( $insightData, 0, $size )
 		];
 	}
 
-	/**
-	 * @param array $articles all articles data
-	 * @param array $ids list of article ids we need data for
-	 * @return array
-	 */
-	private function getArticlesData( $articles, $ids ) {
-		$content = [];
-		foreach ( $ids as $id ) {
-			$content[] = $articles[$id];
-		}
-		return $content;
-	}
 }

--- a/extensions/wikia/InsightsV2/services/InsightsService.class.php
+++ b/extensions/wikia/InsightsV2/services/InsightsService.class.php
@@ -2,22 +2,6 @@
 
 class InsightsService {
 
-	/**
-	 * @param string $type type of model
-	 * @param int $size number of pages we need
-	 * @param string $sortingType define how data should be sorted (@see InsightsSorting::$sorting)
-	 * @return array
-	 */
-	public function getInsightPages( $type, $size, $sortingType ) {
-		if ( !InsightsHelper::isInsightPage( $type ) ) {
-			return [];
-		}
-
-		$model = InsightsHelper::getInsightModel( $type );
-
-		return $this->getInsightPagesForModel( $model, $size, $sortingType );
-	}
-
 	public function getInsightPagesForModel( InsightsModel $model, $size, $sortingType ): array {
 		$insightData = ( new InsightsContext( $model ) )->fetchData();
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5523

```
PHP Notice: Undefined index: random in /usr/wikia/slot1/24088/src/extensions/wikia/InsightsV2/helpers/InsightsSorting.php on line 59
```

Random sorting did not work for a while. Let's just stop sorting Insights data for Special:Community and get rid of PHP notice flood.