### PR TITLE
SUS-5540 | install luasandbox extension

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -29,6 +29,8 @@ RUN apt-get update && apt-get install -y \
     libtidy-dev \
     # needed by php intl extension
     libicu-dev \
+    # needed by php luasandbox extension
+    liblua5.1-0-dev \
     # needed by sass, this installs libsass-3.4.3, matches with https://github.com/absalomedia/sassphp/releases/tag/0.5.10
     && apt-get install -y libsass-dev \
     # cleanup
@@ -75,6 +77,14 @@ RUN apt-get update && apt-get install -y \
     && docker-php-ext-configure /tmp/php-xhprof-extension \
     && docker-php-ext-install /tmp/php-xhprof-extension \
     #
+    # luasandbox extension / @see https://www.mediawiki.org/wiki/LuaSandbox
+    && cd /tmp \
+    && wget https://github.com/Wikia/mediawiki-php-luasandbox/archive/3.0.1.tar.gz -O php-luasandbox-extension.tar.gz \
+    && mkdir -p /tmp/php-luasandbox-extension \
+    && tar -xf php-luasandbox-extension.tar.gz -C /tmp/php-luasandbox-extension --strip-components=1 \
+    && docker-php-ext-configure /tmp/php-luasandbox-extension \
+    && docker-php-ext-install /tmp/php-luasandbox-extension \
+    #
     # install PHP extensions required by MediaWiki that are provided by Docker base PHP image helper
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install \
@@ -112,6 +122,6 @@ ADD ./php.ini /usr/local/etc/php/php.ini
 ENV WIKIA_DOCROOT=/usr/wikia/slot1/current/src
 ENV WIKIA_CONFIG_ROOT=/usr/wikia/slot1/current/config
 
-ENV WIKIA_BASE_IMAGE_HASH=4db9245bd8b181624f2edf7401151e71
+ENV WIKIA_BASE_IMAGE_HASH=3c7539ac582b9763d929fcfb7972959e
 
 WORKDIR /usr/wikia/slot1/current/src

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,6 +1,6 @@
 # This is a Docker image for  Wikia's MediaWiki app that can be used locally by a developer.
 # Simply mount your app and config repositories clone (refer to README.md)
-FROM artifactory.wikia-inc.com/sus/php-wikia-base:27f50ce
+FROM artifactory.wikia-inc.com/sus/php-wikia-base:3c7539ac582b9763d929fcfb7972959e
 
 # install dev dependencies
 

--- a/docker/prod/Dockerfile-php
+++ b/docker/prod/Dockerfile-php
@@ -1,4 +1,4 @@
-FROM artifactory.wikia-inc.com/sus/php-wikia-base:27f50ce
+FROM artifactory.wikia-inc.com/sus/php-wikia-base:3c7539ac582b9763d929fcfb7972959e
 
 ENV WIKIA_DATACENTER="sjc"
 ENV WIKIA_ENVIRONMENT="prod"

--- a/docker/prod/Jenkinsfile
+++ b/docker/prod/Jenkinsfile
@@ -85,7 +85,7 @@ node("docker-daemon") {
             }
 
             if (!imageExists) {
-                sh("docker pull artifactory.wikia-inc.com/sus/php-wikia-base:4db9245bd8b181624f2edf7401151e71")
+                sh("docker pull artifactory.wikia-inc.com/sus/php-wikia-base:3c7539ac582b9763d929fcfb7972959e")
 
                 // SUS-5284 - make the image a bit smaller
                 sh("cp docker/.dockerignore ..")

--- a/docker/sandbox/Dockerfile-php
+++ b/docker/sandbox/Dockerfile-php
@@ -1,4 +1,4 @@
-FROM artifactory.wikia-inc.com/sus/php-wikia-base:27f50ce
+FROM artifactory.wikia-inc.com/sus/php-wikia-base:3c7539ac582b9763d929fcfb7972959e
 
 ENV WIKIA_DATACENTER="sjc"
 ENV WIKIA_ENVIRONMENT="sandbox"

--- a/docker/sandbox/Jenkinsfile
+++ b/docker/sandbox/Jenkinsfile
@@ -82,7 +82,7 @@ node("docker-daemon") {
             }
 
             if (!imageExists) {
-                sh("docker pull artifactory.wikia-inc.com/sus/php-wikia-base:4db9245bd8b181624f2edf7401151e71")
+                sh("docker pull artifactory.wikia-inc.com/sus/php-wikia-base:3c7539ac582b9763d929fcfb7972959e")
 
                 // SUS-5284 - make the image a bit smaller
                 sh("cp docker/.dockerignore ..")

--- a/includes/wikia/Extensions.php
+++ b/includes/wikia/Extensions.php
@@ -419,7 +419,14 @@ if ( defined( 'REBUILD_LOCALISATION_CACHE_IN_PROGRESS' ) || !empty($wgEnableSema
 
 if ( !empty( $wgEnableScribuntoExt ) ) {
 	include "$IP/extensions/Scribunto/Scribunto.php";
-	$wgScribuntoDefaultEngine = 'luastandalone'; # PLATFORM-1885
+	
+	// SUS-5540: use the luasandbox extension as executor if it is available
+	if ( extension_loaded( 'luasandbox' ) ) {
+		$wgScribuntoDefaultEngine = 'luasandbox';
+	} else {
+		$wgScribuntoDefaultEngine = 'luastandalone'; # PLATFORM-1885
+	}
+
 	$wgScribuntoUseGeSHi = $wgEnableSyntaxHighlightGeSHiExt;
 	$wgWysiwygDisabledNamespaces[] = NS_MODULE;
 


### PR DESCRIPTION
The currently used Lua engine spawns a child process for interpretation purposes. Because this child process is not known to the process manager, FPM reports errors, making noise in logs:
```
[16-Jul-2018 21:51:12] ALERT: oops, unknown child (11) exited with code 0. Please open a bug report (https://bugs.php.net).
```

While it is not immediately clear if this has any other ramifications apart from cryptic noise in logs, this is an excellent opportunity to replace the clumsy standalone executor with [LuaSandbox](https://www.mediawiki.org/wiki/LuaSandbox), which works with PHP 7 now.

https://wikia-inc.atlassian.net/browse/SUS-5540