### PR TITLE
XW-5079 | Reduce usage of GlobalTitle in DesignSystemApi

### DIFF
--- a/extensions/wikia/CommunityHeader/CommunityHeaderService.class.php
+++ b/extensions/wikia/CommunityHeader/CommunityHeaderService.class.php
@@ -14,11 +14,11 @@ class CommunityHeaderService extends WikiaService {
 	private $model;
 
 	public function init() {
-		global $wgCityId, $wgLang;
+		global $wgLang;
 
 		parent::init();
 
-		$this->model = new DesignSystemCommunityHeaderModel( $wgCityId, $wgLang->getCode() );
+		$this->model = new DesignSystemCommunityHeaderModel( $wgLang->getCode() );
 	}
 
 	public function index() {

--- a/extensions/wikia/CommunityHeader/tests/NavigationTest.php
+++ b/extensions/wikia/CommunityHeader/tests/NavigationTest.php
@@ -25,11 +25,12 @@ class NavigationTest extends WikiaBaseTest {
 			$globals
 		) {
 			$globals[ 'wgServer' ] = self::DOMAIN;
+			$globals[ 'wgCityId' ] = self::WIKI_ID;
 
 			return $globals[ $variable ] ?? $GLOBALS[ $variable ] ?? false;
 		} );
 
-		$result = new Navigation( new DesignSystemCommunityHeaderModel( self::WIKI_ID, 'en' ) );
+		$result = new Navigation( new DesignSystemCommunityHeaderModel( 'en' ) );
 
 		// used `array_values` to reset keys of array
 		$this->assertEquals( $expectedExploreItems, array_values( $result->exploreItems ) );
@@ -46,11 +47,12 @@ class NavigationTest extends WikiaBaseTest {
 			$globals
 		) {
 			$globals[ 'wgServer' ] = self::DOMAIN;
+			$globals[ 'wgCityId' ] = self::WIKI_ID;
 
 			return $globals[ $variable ] ?? $GLOBALS[ $variable ] ?? false;
 		} );
 
-		$result = new Navigation( new DesignSystemCommunityHeaderModel( self::WIKI_ID, 'en' ) );
+		$result = new Navigation( new DesignSystemCommunityHeaderModel( 'en' ) );
 
 		$this->assertEquals( $expected, $result->discussLink );
 	}

--- a/includes/wikia/api/DesignSystemApiController.class.php
+++ b/includes/wikia/api/DesignSystemApiController.class.php
@@ -51,10 +51,7 @@ class DesignSystemApiController extends WikiaApiController {
 
 	public function getCommunityHeader() {
 		$params = $this->getRequestParameters();
-		$communityHeaderModel = new DesignSystemCommunityHeaderModel(
-			$params[static::PARAM_ID],
-			$params[static::PARAM_LANG]
-		);
+		$communityHeaderModel = new DesignSystemCommunityHeaderModel( $params[static::PARAM_LANG] );
 
 		$this->cors->setHeaders( $this->response );
 		$this->setResponseData( $communityHeaderModel->getData() );
@@ -97,9 +94,7 @@ class DesignSystemApiController extends WikiaApiController {
 		];
 
 		if ( $params[self::PARAM_PRODUCT] === self::PRODUCT_WIKIS ) {
-			$communityHeaderModel =
-				new DesignSystemCommunityHeaderModel( $params[static::PARAM_ID],
-					$params[static::PARAM_LANG] );
+			$communityHeaderModel = new DesignSystemCommunityHeaderModel( $params[static::PARAM_LANG] );
 
 			$responseData['community-header'] = $communityHeaderModel->getData();
 		}

--- a/includes/wikia/models/DesignSystemCommunityHeaderModel.class.php
+++ b/includes/wikia/models/DesignSystemCommunityHeaderModel.class.php
@@ -16,12 +16,14 @@ class DesignSystemCommunityHeaderModel extends WikiaModel {
 	private $discussLinkData = null;
 	private $wikiLocalNavigation = null;
 
-	public function __construct( string $cityId, string $langCode ) {
+	public function __construct( string $langCode ) {
+		global $wgCityId;
+
 		parent::__construct();
 
-		$this->productInstanceId = $cityId;
+		$this->productInstanceId = $wgCityId;
 		$this->langCode = $langCode;
-		$this->themeSettings = new ThemeSettings( $cityId );
+		$this->themeSettings = new ThemeSettings( $wgCityId );
 		$this->settings = $this->themeSettings->getSettings();
 		$this->mainPageUrl = wfProtocolUrlToRelative( Title::newMainPage()->getFullURL() );
 	}

--- a/includes/wikia/models/DesignSystemCommunityHeaderModel.class.php
+++ b/includes/wikia/models/DesignSystemCommunityHeaderModel.class.php
@@ -22,8 +22,8 @@ class DesignSystemCommunityHeaderModel extends WikiaModel {
 		$this->productInstanceId = $cityId;
 		$this->langCode = $langCode;
 		$this->themeSettings = new ThemeSettings( $cityId );
-		$this->settings = $this->themeSettings->getSettings( $cityId );
-		$this->mainPageUrl = wfProtocolUrlToRelative( GlobalTitle::newMainPage( $this->productInstanceId )->getFullURL() );
+		$this->settings = $this->themeSettings->getSettings();
+		$this->mainPageUrl = wfProtocolUrlToRelative( Title::newMainPage()->getFullURL() );
 	}
 
 	public function getData(): array {
@@ -238,7 +238,7 @@ class DesignSystemCommunityHeaderModel extends WikiaModel {
 	}
 
 	private function getFullUrl( $pageTitle, $namespace, $protocolRelative = false ) {
-		$url = GlobalTitle::newFromText( $pageTitle, NS_SPECIAL, $this->productInstanceId )->getFullURL();
+		$url = Title::newFromText( $pageTitle, $namespace)->getFullURL();
 		if ( $protocolRelative ) {
 			$url = wfProtocolUrlToRelative( $url );
 		}

--- a/includes/wikia/models/DesignSystemGlobalNavigationModel.class.php
+++ b/includes/wikia/models/DesignSystemGlobalNavigationModel.class.php
@@ -104,10 +104,17 @@ class DesignSystemGlobalNavigationModel extends WikiaModel {
 	}
 
 	private function getPageUrl( $pageTitle, $namespace, $query = '', $protocolRelative = false ) {
-		$wikiId = $this->product === static::PRODUCT_WIKIS ?
-			$this->productInstanceId :
-			WikiFactory::COMMUNITY_CENTRAL;
-		$url =  GlobalTitle::newFromText( $pageTitle, $namespace, $wikiId )->getFullURL( $query );
+		global $wgCityId;
+
+		if ( $this->product === static::PRODUCT_WIKIS && $this->$this->productInstanceId == $wgCityId) {
+			$url = Title::newFromText($pageTitle, $namespace)->getFullURL();
+		} else {
+			$wikiId = $this->product === static::PRODUCT_WIKIS ?
+				$this->productInstanceId :
+				WikiFactory::COMMUNITY_CENTRAL;
+			$url =  GlobalTitle::newFromText( $pageTitle, $namespace, $wikiId )->getFullURL( $query );
+		}
+
 		if ( $protocolRelative ) {
 			$url = wfProtocolUrlToRelative( $url );
 		}

--- a/includes/wikia/models/DesignSystemGlobalNavigationModelV2.class.php
+++ b/includes/wikia/models/DesignSystemGlobalNavigationModelV2.class.php
@@ -101,10 +101,17 @@ class DesignSystemGlobalNavigationModelV2 extends WikiaModel {
 	}
 
 	private function getPageUrl( $pageTitle, $namespace, $query = '', $protocolRelative = false ) {
-		$wikiId = $this->product === static::PRODUCT_WIKIS ?
-			$this->productInstanceId :
-			WikiFactory::COMMUNITY_CENTRAL;
-		$url =  GlobalTitle::newFromText( $pageTitle, $namespace, $wikiId )->getFullURL( $query );
+		global $wgCityId;
+
+		if ( $this->product === static::PRODUCT_WIKIS && $this->productInstanceId == $wgCityId) {
+			$url = Title::newFromText($pageTitle, $namespace)->getFullURL();
+		} else {
+			$wikiId = $this->product === static::PRODUCT_WIKIS ?
+				$this->productInstanceId :
+				WikiFactory::COMMUNITY_CENTRAL;
+			$url =  GlobalTitle::newFromText( $pageTitle, $namespace, $wikiId )->getFullURL( $query );
+		}
+
 		if ( $protocolRelative ) {
 			$url = wfProtocolUrlToRelative( $url );
 		}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/XW-5079

Caching issues on devboxes were caused by usage of GlobalTItle in DesignSystemApi. Since for wikis product we call this api in the wiki domain, we can safely use regular Title class for retrieving urls.

@Wikia/x-wing 