### PR TITLE
SUS-5568 | disable PHP FPM access logs

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -126,6 +126,6 @@ RUN php-fpm --test
 ENV WIKIA_DOCROOT=/usr/wikia/slot1/current/src
 ENV WIKIA_CONFIG_ROOT=/usr/wikia/slot1/current/config
 
-ENV WIKIA_BASE_IMAGE_HASH=e65afb8d20b625dd17e27a672560cfe81
+ENV WIKIA_BASE_IMAGE_HASH=e65afb8d20b625dd17e27a672560cfe82
 
 WORKDIR /usr/wikia/slot1/current/src

--- a/docker/base/php-fpm.conf
+++ b/docker/base/php-fpm.conf
@@ -3,4 +3,4 @@ pm = static
 pm.max_children = 20
 pm.max_requests = 2000
 pm.status_path = /status
-access.format = "{\"appname\": \"mediawiki-fpm-access-logs\", \"memory_peak\": %M, \"cpu_total\": %C, \"method\": \"%m\", \"request\": \"%r%Q%q\", \"status\": %s}"
+access.log = /dev/null

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,6 +1,6 @@
 # This is a Docker image for  Wikia's MediaWiki app that can be used locally by a developer.
 # Simply mount your app and config repositories clone (refer to README.md)
-FROM artifactory.wikia-inc.com/sus/php-wikia-base:e65afb8d20b625dd17e27a672560cfe81
+FROM artifactory.wikia-inc.com/sus/php-wikia-base:e65afb8d20b625dd17e27a672560cfe82
 
 # install dev dependencies
 

--- a/docker/prod/Dockerfile-php
+++ b/docker/prod/Dockerfile-php
@@ -1,4 +1,4 @@
-FROM artifactory.wikia-inc.com/sus/php-wikia-base:e65afb8d20b625dd17e27a672560cfe81
+FROM artifactory.wikia-inc.com/sus/php-wikia-base:e65afb8d20b625dd17e27a672560cfe82
 
 ENV WIKIA_DATACENTER="sjc"
 ENV WIKIA_ENVIRONMENT="prod"

--- a/docker/prod/Jenkinsfile
+++ b/docker/prod/Jenkinsfile
@@ -85,7 +85,7 @@ node("docker-daemon") {
             }
 
             if (!imageExists) {
-                sh("docker pull artifactory.wikia-inc.com/sus/php-wikia-base:e65afb8d20b625dd17e27a672560cfe81")
+                sh("docker pull artifactory.wikia-inc.com/sus/php-wikia-base:e65afb8d20b625dd17e27a672560cfe82")
 
                 // SUS-5284 - make the image a bit smaller
                 sh("cp docker/.dockerignore ..")

--- a/docker/sandbox/Dockerfile-php
+++ b/docker/sandbox/Dockerfile-php
@@ -1,4 +1,4 @@
-FROM artifactory.wikia-inc.com/sus/php-wikia-base:e65afb8d20b625dd17e27a672560cfe81
+FROM artifactory.wikia-inc.com/sus/php-wikia-base:e65afb8d20b625dd17e27a672560cfe82
 
 ENV WIKIA_DATACENTER="sjc"
 ENV WIKIA_ENVIRONMENT="sandbox"

--- a/docker/sandbox/Jenkinsfile
+++ b/docker/sandbox/Jenkinsfile
@@ -82,7 +82,7 @@ node("docker-daemon") {
             }
 
             if (!imageExists) {
-                sh("docker pull artifactory.wikia-inc.com/sus/php-wikia-base:e65afb8d20b625dd17e27a672560cfe81")
+                sh("docker pull artifactory.wikia-inc.com/sus/php-wikia-base:e65afb8d20b625dd17e27a672560cfe82")
 
                 // SUS-5284 - make the image a bit smaller
                 sh("cp docker/.dockerignore ..")


### PR DESCRIPTION
These logs offer no value over NGINX access logs. Let's disable them so as not to collect redundant data.

https://wikia-inc.atlassian.net/browse/SUS-5568