### PR TITLE
XW-3053 | Fix missing PI accent colors in horizontal group headers 

### DIFF
--- a/extensions/wikia/PortableInfobox/services/PortableInfoboxRenderService.class.php
+++ b/extensions/wikia/PortableInfobox/services/PortableInfoboxRenderService.class.php
@@ -248,6 +248,7 @@ class PortableInfoboxRenderService {
 				}
 			} elseif ( $item['type'] === 'header' ) {
 				$horizontalGroupData['header'] = $data['value'];
+				$horizontalGroupData['inlineStyles'] = $this->inlineStyles;
 			}
 		}
 

--- a/extensions/wikia/PortableInfobox/templates/PortableInfoboxHorizontalGroupContent.mustache
+++ b/extensions/wikia/PortableInfobox/templates/PortableInfoboxHorizontalGroupContent.mustache
@@ -1,5 +1,5 @@
 <table class="pi-horizontal-group{{^renderLabels}} pi-horizontal-group-no-labels{{/renderLabels}}">
-	{{#header}}<caption class="pi-header pi-secondary-font pi-secondary-background pi-item-spacing">{{{header}}}</caption>{{/header}}
+	{{#header}}<caption class="pi-header pi-secondary-font pi-secondary-background pi-item-spacing"{{#inlineStyles}} style="{{inlineStyles}}"{{/inlineStyles}}>{{{header}}}</caption>{{/header}}
 	{{#renderLabels}}
 	<thead>
 		<tr>


### PR DESCRIPTION
Accent colors doesn't apply to horizontal group headers in portable infoboxes, because inlineStyles variable isn't used in creation of horizontal groups. 

[Bug example](https://luq.wikia.com/wiki/PI_Accent)
Jira issue: [XW-3053](https://wikia-inc.atlassian.net/browse/XW-3053)