### PR TITLE
Propose shorter cronjob name

### DIFF
--- a/docker/maintenance/cronjob-template.yaml
+++ b/docker/maintenance/cronjob-template.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: "mediawiki-cronjob-${name}"
+  name: "mw-cj-${name}"
 spec:
   schedule: ${schedule}
   successfulJobsHistoryLimit: 0


### PR DESCRIPTION
CronJob has a limit of 52 characters for a name
let's shorten prefix to mw-cj to allow for descriptive cronjob names