### PR TITLE
SUS-4713 | Fix for PI galleries not working with tabber

### DIFF
--- a/extensions/wikia/PortableInfobox/services/Parser/Nodes/NodeImage.php
+++ b/extensions/wikia/PortableInfobox/services/Parser/Nodes/NodeImage.php
@@ -39,8 +39,8 @@ class NodeImage extends Node {
 		$divs = $sxml->xpath( '//div[@class=\'tabbertab\']' );
 		foreach ( $divs as $div ) {
 			if ( $wgArticleAsJson ) {
-				if ( preg_match( '/data-ref="([^"]+)"/', $div->asXML(), $out ) ) {
-					$data[] = array( 'label' => (string) $div['title'], 'title' => \ArticleAsJson::$media[$out[1]]['title'] );
+				if ( preg_match( '/data-file="([^"]+)"/', $div->asXML(), $out ) ) {
+					$data[] = array( 'label' => (string) $div['title'], 'title' => $out[1] );
 				}
 			} else {
 				if ( preg_match( '/data-(video|image)-key="([^"]+)"/', $div->asXML(), $out ) ) {


### PR DESCRIPTION
On Mercury, when the tabber is detected, it tries to extract non-existing "data-ref" parameter, which is present only when the image is a part of a gallery. This fix will use data-file attribute instead, which is tied with every image on Mercury.

Jira issue: [SUS-4713](https://wikia-inc.atlassian.net/browse/SUS-4713)