### PR TITLE
MAIN-16926: Output &nbsp; instead of &#nbsp; in mw.text.encode

### DIFF
--- a/extensions/Scribunto/engines/LuaCommon/lualib/mw.text.lua
+++ b/extensions/Scribunto/engines/LuaCommon/lualib/mw.text.lua
@@ -32,7 +32,7 @@ local htmlencode_map = {
 	['&'] = '&amp;',
 	['"'] = '&quot;',
 	["'"] = '&#039;',
-	['\194\160'] = '&#nbsp;',
+	['\194\160'] = '&nbsp;',
 }
 local htmldecode_map = {}
 for k, v in pairs( htmlencode_map ) do

--- a/extensions/Scribunto/tests/engines/LuaCommon/TextLibraryTests.lua
+++ b/extensions/Scribunto/tests/engines/LuaCommon/TextLibraryTests.lua
@@ -50,12 +50,12 @@ local tests = {
 	},
 
 	{ name = 'encode',
-	  func = mw.text.encode, args = { '<b>foo "bar"</b> & \'baz\'' },
-	  expect = { '&lt;b&gt;foo &quot;bar&quot;&lt;/b&gt; &amp; &#039;baz&#039;' }
+	  func = mw.text.encode, args = { '<b>foo\194\160"bar"</b> & \'baz\'' },
+	  expect = { '&lt;b&gt;foo&nbsp;&quot;bar&quot;&lt;/b&gt; &amp; &#039;baz&#039;' }
 	},
 	{ name = 'encode charset',
-	  func = mw.text.encode, args = { '<b>foo "bar"</b> & \'baz\'', 'aeiou' },
-	  expect = { '<b>f&#111;&#111; "b&#97;r"</b> & \'b&#97;z\'' }
+	  func = mw.text.encode, args = { '<b>foo\194\160"bar"</b> & \'baz\'', 'aeiou' },
+	  expect = { '<b>f&#111;&#111;\194\160"b&#97;r"</b> & \'b&#97;z\'' }
 	},
 
 	{ name = 'decode',


### PR DESCRIPTION
Backported [Gerrit change 158872](https://gerrit.wikimedia.org/r/158872).

Issue discussion and example: [Dev Wiki](https://dev.wikia.com/wiki/Talk:Lua_reference_manual/Scribunto_libraries)
Phabricator ticket: [T72475](https://phabricator.wikimedia.org/T72475)
Support request: [ZD#402469](http://support.wikia-inc.com/hc/requests/402469)
Bug ticket: [MAIN-16926](https://wikia-inc.atlassian.net/browse/MAIN-16926)