### PR TITLE
SUS-5508 | Remove dumps-on-demand.yaml as it should be an async task

### DIFF
--- a/docker/maintenance/dumps-on-demand.yaml
+++ b/docker/maintenance/dumps-on-demand.yaml
@@ -1,4 +1,0 @@
-schedule: "*/5"
-args:
-- php
-- /usr/wikia/slot1/current/src/extensions/wikia/WikiFactory/Dumps/maintenance/DumpsOnDemandCron.php


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5508

We will use an async task instead. For now, it will be only run on cron-s1 as always.