### PR TITLE
SUS-5531 | to avoid execute permission problems just execute the script via bash binary

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -81,3 +81,7 @@ If docker service fails to start run the following to diagnose the problem:
 ```sh
 sudo dockerd
 ```
+
+#### Setting up `kubectl`
+
+Follow [these instructions](https://wikia-inc.atlassian.net/wiki/spaces/OPS/pages/208011308/Kubernetes+access+for+Engineers).

--- a/docker/prod/Jenkinsfile
+++ b/docker/prod/Jenkinsfile
@@ -130,7 +130,7 @@ EOL""")
             rolloutStatus = sh(returnStatus: true, script: "kubectl --context ${k8sContext} -n ${environment} rollout status deployment/mediawiki-'${environment}'")
 
             // SUS-5531 - apply cron jobs via auto-generated YAML file
-            sh "cd app/docker/maintenance && ./cronjobs-generator.sh ${imageTag} | kubectl --context ${k8sContext} -n ${environment} apply -f -"
+            sh "cd app/docker/maintenance && bash cronjobs-generator.sh ${imageTag} | kubectl --context ${k8sContext} -n ${environment} apply -f -"
         }
     }
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5531

```
[sus-mediawiki-deploy-prod-pipeline] Running shell script
+ cd app/docker/maintenance
+ ./cronjobs-generator.sh 938129c.63ea31d
/var/lib/jenkins/workspace/sus-mediawiki-deploy-prod-pipeline@tmp/durable-9c8a50db/script.sh: line 2: ./cronjobs-generator.sh: Permission denied
+ kubectl --context kube-sjc-prod -n prod apply -f -
error: no objects passed to apply
```