### PR TITLE
SUS-5500 | add mysqldump, required by dumpStarters.php script

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -9,7 +9,8 @@ We assume that you have `app` and `config` repository cloned in the same directo
 
 ```sh
 # 1. build a base image
-docker build -f base/Dockerfile -t artifactory.wikia-inc.com/sus/php-wikia-base:27f50ce ./base
+docker build -f base/Dockerfile -t artifactory.wikia-inc.com/sus/php-wikia-base:8a16e38 ./base
+docker push artifactory.wikia-inc.com/sus/php-wikia-base:8a16e38
 
 # 2. and then dev image
 docker build -f dev/Dockerfile -t php-wikia-dev ./dev
@@ -32,26 +33,6 @@ In order to run service locally you need to configure hosts. Add below line to `
 127.0.0.1	wikia-local.com dev.wikia-local.com muppet.dev.wikia-local.com
 ```
 
-## How to push base and dev images to Wikia's repository
-
-```sh
-docker tag php-wikia-base php-wikia-base:7.0.28
-
-docker tag php-wikia-base artifactory.wikia-inc.com/sus/php-wikia-base
-docker tag php-wikia-base artifactory.wikia-inc.com/sus/php-wikia-base:7.0.28
-
-docker push artifactory.wikia-inc.com/sus/php-wikia-base
-docker push artifactory.wikia-inc.com/sus/php-wikia-base:7.0.28
-
-
-docker tag php-wikia-dev php-wikia-dev:7.0.28
-
-docker tag php-wikia-dev artifactory.wikia-inc.com/sus/php-wikia-dev
-docker tag php-wikia-dev artifactory.wikia-inc.com/sus/php-wikia-dev:7.0.28
-
-docker push artifactory.wikia-inc.com/sus/php-wikia-dev
-docker push artifactory.wikia-inc.com/sus/php-wikia-dev:7.0.28
-```
 
 ## How to set up Docker on your machine
 

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -128,6 +128,6 @@ RUN php-fpm --test
 ENV WIKIA_DOCROOT=/usr/wikia/slot1/current/src
 ENV WIKIA_CONFIG_ROOT=/usr/wikia/slot1/current/config
 
-ENV WIKIA_BASE_IMAGE_HASH=d41d8cd98f00b204e9800998ecf8427e
+ENV WIKIA_BASE_IMAGE_HASH=8a16e38
 
 WORKDIR /usr/wikia/slot1/current/src

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -128,6 +128,7 @@ RUN php-fpm --test
 ENV WIKIA_DOCROOT=/usr/wikia/slot1/current/src
 ENV WIKIA_CONFIG_ROOT=/usr/wikia/slot1/current/config
 
+# run "sha1sum Dockerfile" to update this value whenn this file changes
 ENV WIKIA_BASE_IMAGE_HASH=8a16e38
 
 WORKDIR /usr/wikia/slot1/current/src

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -31,6 +31,8 @@ RUN apt-get update && apt-get install -y \
     libicu-dev \
     # needed by php luasandbox extension
     liblua5.1-0-dev \
+    # SUS-5500 | provides mysqldump needed by dumpStarters.php script
+    default-mysql-client \
     # needed by sass, this installs libsass-3.4.3, matches with https://github.com/absalomedia/sassphp/releases/tag/0.5.10
     && apt-get install -y libsass-dev \
     # cleanup

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,6 +1,6 @@
 # This is a Docker image for  Wikia's MediaWiki app that can be used locally by a developer.
 # Simply mount your app and config repositories clone (refer to README.md)
-FROM artifactory.wikia-inc.com/sus/php-wikia-base:d41d8cd98f00b204e9800998ecf8427e
+FROM artifactory.wikia-inc.com/sus/php-wikia-base:8a16e38
 
 # install dev dependencies
 

--- a/docker/maintenance/dump-starters.yaml
+++ b/docker/maintenance/dump-starters.yaml
@@ -1,4 +1,5 @@
 schedule: "44 16 * * *"
+server_id: 80433  # www.wikia.com (where CreateWiki is enabled)
 args:
 - php
 - /usr/wikia/slot1/current/src/extensions/wikia/CreateNewWiki/maintenance/dumpStarters.php

--- a/docker/prod/Dockerfile-php
+++ b/docker/prod/Dockerfile-php
@@ -1,4 +1,4 @@
-FROM artifactory.wikia-inc.com/sus/php-wikia-base:d41d8cd98f00b204e9800998ecf8427e
+FROM artifactory.wikia-inc.com/sus/php-wikia-base:8a16e38
 
 ENV WIKIA_DATACENTER="sjc"
 ENV WIKIA_ENVIRONMENT="prod"

--- a/docker/prod/Jenkinsfile
+++ b/docker/prod/Jenkinsfile
@@ -87,7 +87,7 @@ node("docker-daemon") {
             }
 
             if (!imageExists) {
-                sh("docker pull artifactory.wikia-inc.com/sus/php-wikia-base:d41d8cd98f00b204e9800998ecf8427e")
+                sh("docker pull artifactory.wikia-inc.com/sus/php-wikia-base:8a16e38")
 
                 // SUS-5284 - make the image a bit smaller
                 sh("cp docker/.dockerignore ..")

--- a/docker/sandbox/Dockerfile-php
+++ b/docker/sandbox/Dockerfile-php
@@ -1,4 +1,4 @@
-FROM artifactory.wikia-inc.com/sus/php-wikia-base:d41d8cd98f00b204e9800998ecf8427e
+FROM artifactory.wikia-inc.com/sus/php-wikia-base:8a16e38
 
 ENV WIKIA_DATACENTER="sjc"
 ENV WIKIA_ENVIRONMENT="sandbox"

--- a/docker/sandbox/Jenkinsfile
+++ b/docker/sandbox/Jenkinsfile
@@ -82,7 +82,7 @@ node("docker-daemon") {
             }
 
             if (!imageExists) {
-                sh("docker pull artifactory.wikia-inc.com/sus/php-wikia-base:d41d8cd98f00b204e9800998ecf8427e")
+                sh("docker pull artifactory.wikia-inc.com/sus/php-wikia-base:8a16e38")
 
                 // SUS-5284 - make the image a bit smaller
                 sh("cp docker/.dockerignore ..")


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5500

```
macbre@dev-docker:~/app/docker$ docker run -it artifactory.wikia-inc.com/sus/php-wikia-base:8a16e38 bash
root@8b82bb18eee0:/usr/wikia/slot1/current/src# which mysqldump
/usr/bin/mysqldump

root@8b82bb18eee0:/usr/wikia/slot1/current/src# mysqldump -V
mysqldump  Ver 10.16 Distrib 10.1.26-MariaDB, for debian-linux-gnu (x86_64)
```

### Images

```
macbre@dev-docker:~$ docker images | head -n5
REPOSITORY                                                       TAG                                IMAGE ID            CREATED             SIZE
artifactory.wikia-inc.com/sus/php-wikia-base                     8a16e38                            245ec3ad9d5f        5 seconds ago       589MB
artifactory.wikia-inc.com/sus/php-wikia-base                     d41d8cd98f00b204e9800998ecf8427e   0a2f893f7216        5 days ago          511MB
```