### PR TITLE
Use the latest k8s-deployer

### DIFF
--- a/docker/maintenance/README.md
+++ b/docker/maintenance/README.md
@@ -43,7 +43,7 @@ In order to apply descriptor you need to map directory with YAML files to kubect
 Like so:
 
 ```sh
-docker run -v ~/app/docker/maintenance:/maintenance -it artifactory.wikia-inc.com/ops/k8s-deployer:0.0.12 ./maintenance/create-cronjob-yaml.sh one-time-job-example.yaml | kubectl --context kube-sjc-prod -n prod apply -f -
+bash create-cronjob-yaml.sh one-time-job-example.yaml <prod image label> | kubectl --context kube-sjc-prod -n prod apply -f -
 ```
 
 Or when running `kubectl` as a binary (run from app directory root):

--- a/docker/prod/Jenkinsfile
+++ b/docker/prod/Jenkinsfile
@@ -1,4 +1,4 @@
-def kubectlImage = "artifactory.wikia-inc.com/ops/k8s-deployer:0.0.14"
+def kubectlImage = "artifactory.wikia-inc.com/ops/k8s-deployer:0.0.15"
 def nginxImage = "artifactory.wikia-inc.com/sus/mediawiki-prod-nginx"
 def mediawikiImage = "artifactory.wikia-inc.com/sus/mediawiki-prod-php"
 def loggerImage = "artifactory.wikia-inc.com/sus/mediawiki-logger"

--- a/docker/sandbox/Jenkinsfile
+++ b/docker/sandbox/Jenkinsfile
@@ -6,7 +6,7 @@ def sandbox = "sandbox-sus2"
 def environment = "sandbox"
 def datacenter = "sjc"
 
-def kubectlImage = "artifactory.wikia-inc.com/ops/k8s-deployer:0.0.14"
+def kubectlImage = "artifactory.wikia-inc.com/ops/k8s-deployer:0.0.15"
 def nginxImage = "artifactory.wikia-inc.com/sus/mediawiki-sandbox-nginx"
 def mediawikiImage = "artifactory.wikia-inc.com/sus/mediawiki-sandbox-php"
 


### PR DESCRIPTION
```
Robert Jerzak [15:02]
@here if you are using (for managing k8s) one of those containers:
- `artifactory.wikia-inc.com/ops/k8s-deployer`
- `artifactory.wikia-inc.com/ops/k8s-kubectl`
please use newest version:
- k8s-deployer:0.0.15
- k8s-kubectl - just re-download latest

it’s related to consul domain change for dev env
```