### PR TITLE
SUS-5476 | TorBlock - add logs for the maintenance script

### DIFF
--- a/extensions/TorBlock/TorBlock.class.php
+++ b/extensions/TorBlock/TorBlock.class.php
@@ -152,11 +152,6 @@ class TorBlock {
 
 		global $wgTorIPs, $wgMemc;
 
-		// we want to trace when the memcache entry expires and we generate new
-		if ( class_exists( 'Wikia\\Logger\\WikiaLogger' ) ) {
-			\Wikia\Logger\WikiaLogger::instance()->debug( 'TorBlock::loadExitNodes' );
-		}
-
 		// Set loading key, to prevent DoS of server.
 
 		$wgMemc->set( 'mw-tor-list-status', 'loading', 300 );

--- a/extensions/TorBlock/TorBlock.class.php
+++ b/extensions/TorBlock/TorBlock.class.php
@@ -44,6 +44,11 @@ class TorBlock {
 
 			$result[] = array('torblock-blocked', $ip);
 
+			// SUS-5525 | collect Tor blocks statistics
+			\Wikia\Logger\WikiaLogger::instance()->info( __METHOD__ . '::TorBlocked', [
+				'ip' => $ip,
+			] );
+
 			return false;
 		}
 

--- a/extensions/TorBlock/TorBlock.class.php
+++ b/extensions/TorBlock/TorBlock.class.php
@@ -161,6 +161,11 @@ class TorBlock {
 			$nodes = array_unique( array_merge( $nodes, self::loadNodesForIP( $ip ) ) );
 		}
 
+		// SUS-5476 | add logging for a cron-job
+		\Wikia\Logger\WikiaLogger::instance()->info( __METHOD__, [
+			'nodes' => count( $nodes )
+		] );
+
 		// Save to cache.
 		$wgMemc->set( 'mw-tor-exit-nodes', $nodes, 1800 ); // Store for half an hour.
 		$wgMemc->set( 'mw-tor-list-status', 'loaded', 1800 );

--- a/extensions/TorBlock/TorBlock.php
+++ b/extensions/TorBlock/TorBlock.php
@@ -54,7 +54,7 @@ $wgTorBypassPermissions = array( 'torunblocked', /*'autoconfirmed', 'proxyunbann
  * Set to false on high-load sites, and use a cron job with the included
  * maintenance script
  */
-$wgTorLoadNodes = true;
+$wgTorLoadNodes = false; // Wikia change
 
 /**
  * Actions tor users are allowed to do.


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5476

Set `$wgTorLoadNodes` to `false` which is recommended for high-load sites, and use a cron job with the included maintenance script. Better safe than sorry.

And also log blocks triggered by editing via TOR nodes. This will help us make a decision in [SUS-5525](https://wikia-inc.atlassian.net/browse/SUS-5525) to whether sunset this extension.