### PR TITLE
SUS-5681 | force the wiki to be included in wikis search results despite having less than 50 articles

### DIFF
--- a/extensions/wikia/Search/WikiaSearchIndexerController.class.php
+++ b/extensions/wikia/Search/WikiaSearchIndexerController.class.php
@@ -69,10 +69,11 @@ class WikiaSearchIndexerController extends WikiaController
 	public function getForWiki()
 	{
 		$this->getResponse()->setFormat('json');
-		
+
 		$serviceName = 'Wikia\Search\IndexService\\' . $this->getVal( 'service' );
+		/* @var $service Wikia\Search\IndexService\CrossWikiCore|Wikia\Search\IndexService\All */
 		$service = new $serviceName();
-		
+
 		$this->response->setData( $service->getStubbedWikiResponse() );
 	}
 

--- a/extensions/wikia/Search/classes/IndexService/AbstractWikiService.php
+++ b/extensions/wikia/Search/classes/IndexService/AbstractWikiService.php
@@ -27,7 +27,7 @@ abstract class AbstractWikiService extends AbstractService {
 	 * Assumes that we are not operating on a provided page ID
 	 *
 	 * @throws \Exception
-	 * @return string
+	 * @return array
 	 */
 	public function getStubbedWikiResponse() {
 		if ( $this->currentPageId !== null ) {

--- a/extensions/wikia/Search/classes/IndexService/CrossWikiCore.php
+++ b/extensions/wikia/Search/classes/IndexService/CrossWikiCore.php
@@ -36,7 +36,8 @@ class CrossWikiCore extends AbstractWikiService {
 			$this->getCategories(),
 			$this->getVisualizationInfo(),
 			$this->getTopArticles(),
-			$this->getLicenseInformation()
+			$this->getLicenseInformation(),
+			$this->getIsPromotedWiki()
 		);
 	}
 
@@ -228,6 +229,20 @@ class CrossWikiCore extends AbstractWikiService {
 		return [
 			"commercial_use_allowed_b" => $licensedWikiService->isCommercialUseAllowedById( $this->getWikiId() ) ===
 				true
+		];
+	}
+
+	/**
+	 * Get a flag that forces a wiki to show up in wiki search results despite low number of articles
+	 *
+	 * @see SUS-5681
+	 * @return array
+	 */
+	protected function getIsPromotedWiki() {
+		global $wgForceWikiIncludeInSearch;
+
+		return [
+			"promoted_wiki_b" => !empty( $wgForceWikiIncludeInSearch )
 		];
 	}
 

--- a/extensions/wikia/Search/classes/IndexService/CrossWikiCore.php
+++ b/extensions/wikia/Search/classes/IndexService/CrossWikiCore.php
@@ -53,8 +53,6 @@ class CrossWikiCore extends AbstractWikiService {
 		$sitename = $service->getGlobal( 'Sitename' );
 		$response['id'] = $this->wikiId;
 		$response['sitename_txt'] = $sitename;
-		$sn = Utilities::field( 'sitename' );
-		$langSn = $sn == 'sitename' ? 'sitename_txt' : $sn;
 		$response['lang_s'] = $service->getLanguageCode();
 		$response['hub_s'] = $service->getHubForWikiId( $this->wikiId );
 		$response['created_dt'] = str_replace( ' ', 'T', $wiki->city_created ) . 'Z';
@@ -185,7 +183,6 @@ class CrossWikiCore extends AbstractWikiService {
 	protected function getCategories() {
 		$categories = [];
 		$dbr = wfGetDB( DB_SLAVE );
-		$sql = "SELECT cat_title FROM category WHERE cat_hidden = 0 ORDER BY cat_pages DESC";
 		$query = $dbr->select(
 			'category',
 			'cat_title',

--- a/extensions/wikia/Search/classes/QueryService/Select/Dismax/InterWiki.php
+++ b/extensions/wikia/Search/classes/QueryService/Select/Dismax/InterWiki.php
@@ -129,7 +129,11 @@ class InterWiki extends AbstractDismax {
 	 */
 	protected function getFilterQueryString() {
 		$wid = $this->getService()->getWikiId();
-		$filterQueries = [ 'articles_i:[' . $this->config->getXwikiArticleThreshold() . ' TO *]', "-id:{$wid}" ];
+		$filterQueries = [
+			// SUS-5681 | allow wikis with promoted_wiki_b fiels set to override articles threshold
+			'( articles_i:[' . $this->config->getXwikiArticleThreshold() . ' TO *] OR promoted_wiki_b:true )',
+			"-id:{$wid}"
+		];
 		if ( $this->getConfig()->getCommercialUse() ) {
 			$filterQueries[] = "-( commercial_use_allowed_b:false )";
 		}

--- a/extensions/wikia/Search/tests/IndexService/CrossWikiCoreTest.php
+++ b/extensions/wikia/Search/tests/IndexService/CrossWikiCoreTest.php
@@ -14,12 +14,12 @@ class CrossWikiCoreTest extends BaseTest
 	/**
 	 * @group Slow
 	 * @slowExecutionTime 0.09122 ms
-	 * @covers Wikia\Search\IndexService\CrossWikiCore::execute
+	 * @covers \Wikia\Search\IndexService\CrossWikiCore::execute
 	 */
 	public function testExecute() {
 		$service = $this->getMockBuilder( 'Wikia\Search\IndexService\CrossWikiCore' )
 		                ->disableOriginalConstructor()
-		                ->setMethods( [ 'getWikiBasics', 'getWikiStats', 'getWikiViews', 'getWam', 'getCategories', 'getVisualizationInfo', 'getTopArticles' , 'getLicenseInformation'] )
+		                ->setMethods( [ 'getWikiBasics', 'getWikiStats', 'getWikiViews', 'getWam', 'getCategories', 'getVisualizationInfo', 'getTopArticles' , 'getLicenseInformation', 'getIsPromotedWiki'] )
 		                ->getMock();
 
 
@@ -32,6 +32,7 @@ class CrossWikiCoreTest extends BaseTest
 		$viz = [ 'viz' => 'graph' ];
 		$articles = [ 'art' => 'vandelay' ];
 		$licence  = ['commercial_use_allowed_b'=>true];
+		$isPromoted  = ['promoted_wiki_b'=>false];
 
 		$service
 		    ->expects( $this->once() )
@@ -75,8 +76,14 @@ class CrossWikiCoreTest extends BaseTest
 			->will   ( $this->returnValue( $licence ) )
 		;
 
+		$service
+			->expects( $this->once() )
+			->method ( 'getIsPromotedWiki' )
+			->will   ( $this->returnValue( $isPromoted ) )
+		;
+
 		$this->assertEquals(
-				array_merge( $basics, $stats, $views, $wam, $cats, $viz, $articles, $licence),
+				array_merge( $basics, $stats, $views, $wam, $cats, $viz, $articles, $licence, $isPromoted),
 				$service->execute()
 		);
 	}

--- a/extensions/wikia/Search/tests/QueryService/Select/Dismax/InterWikiTest.php
+++ b/extensions/wikia/Search/tests/QueryService/Select/Dismax/InterWikiTest.php
@@ -192,7 +192,7 @@ class InterWikiTest extends Wikia\Search\Test\BaseTest {
 		$reflspell = new ReflectionMethod( 'Wikia\Search\QueryService\Select\Dismax\InterWiki', 'getFilterQueryString' );
 		$reflspell->setAccessible( true );
 		$this->assertEquals(
-				'articles_i:[50 TO *] AND -id:123',
+				'( articles_i:[50 TO *] OR promoted_wiki_b:true ) AND -id:123',
 				$reflspell->invoke( $mockSelect )
 		);
 	}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5681

Community team would like to have a feature that lets staff mark a wiki for inclusion in internal search despite having less than 50 articles.

* create a `wgForceWikiIncludeInSearch` variable in WikiFactory that will allow staff member to switch on/off the functionality of forcing the wiki to be included in wikis search results regardless the small number of articles
* use `promoted_wiki_b` field in Solr core xwiki to mark such wikis (it's a dynamic field - no Solr config change is required here)
* expose `promoted_wiki_b` value in `controller=WikiaSearchIndexer&service=CrossWikiCore` (when `wgForceWikiIncludeInSearch` is set)
* modify `InterWiki` to take `promoted_wiki_b` flag into consideration when querying cross-wiki index