### PR TITLE
SUS-5454 | Use WikiaLogger in SMW's RebuildConceptCache

### DIFF
--- a/extensions/SemanticMediaWiki/maintenance/rebuildConceptCache.php
+++ b/extensions/SemanticMediaWiki/maintenance/rebuildConceptCache.php
@@ -160,7 +160,8 @@ class RebuildConceptCache extends \Maintenance {
 	 * @param string $message
 	 */
 	public function reportMessage( $message ) {
-		$this->output( $message );
+		// Wikia change
+		\Wikia\Logger\WikiaLogger::instance()->info( $message );
 	}
 
 	private function checkForRebuildState( $rebuildResult ) {


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5454

Logs from this script are printed which isn't picked up by the ELK. Let's use our logger instead.