### PR TITLE
Log maintenance output to logstash

### DIFF
--- a/extensions/SemanticMediaWiki/maintenance/rebuildConceptCache.php
+++ b/extensions/SemanticMediaWiki/maintenance/rebuildConceptCache.php
@@ -160,8 +160,7 @@ class RebuildConceptCache extends \Maintenance {
 	 * @param string $message
 	 */
 	public function reportMessage( $message ) {
-		// Wikia change
-		\Wikia\Logger\WikiaLogger::instance()->info( $message );
+		$this->output( $message );
 	}
 
 	private function checkForRebuildState( $rebuildResult ) {

--- a/maintenance/Maintenance.php
+++ b/maintenance/Maintenance.php
@@ -112,6 +112,9 @@ abstract class Maintenance {
 	// Used by getDD() / setDB()
 	private $mDb = null;
 
+	// Wikia change
+	protected $mLogger = null;
+
 	/**
 	 * List of all the core maintenance scripts. This is added
 	 * to scripts added by extensions in $wgMaintenanceScripts
@@ -134,6 +137,9 @@ abstract class Maintenance {
 
 		$this->addDefaultParams();
 		register_shutdown_function( array( $this, 'outputChanneled' ), false );
+
+		// Wikia change
+		$this->mLogger = \Wikia\Logger\WikiaLogger::instance();
 	}
 
 	/**
@@ -319,6 +325,9 @@ abstract class Maintenance {
 	 *     function outputChanneled.
 	 */
 	protected function output( $out, $channel = null ) {
+		// Wikia change
+		$this->mLogger->info( $out );
+
 		if ( $this->mQuiet ) {
 			return;
 		}

--- a/maintenance/Maintenance.php
+++ b/maintenance/Maintenance.php
@@ -137,9 +137,6 @@ abstract class Maintenance {
 
 		$this->addDefaultParams();
 		register_shutdown_function( array( $this, 'outputChanneled' ), false );
-
-		// Wikia change
-		$this->mLogger = \Wikia\Logger\WikiaLogger::instance();
 	}
 
 	/**
@@ -325,8 +322,11 @@ abstract class Maintenance {
 	 *     function outputChanneled.
 	 */
 	protected function output( $out, $channel = null ) {
-		// Wikia change
-		$this->mLogger->info( $out );
+
+		// Wikia change: log output if possible
+		if ( $this->mLogger instanceof Wikia\Logger\WikiaLogger ) {
+			$this->mLogger->info( $out );
+		}
 
 		if ( $this->mQuiet ) {
 			return;
@@ -884,6 +884,9 @@ abstract class Maintenance {
 		}
 		# Same with these
 		$wgCommandLineMode = true;
+
+		// Wikia change
+		$this->mLogger = Wikia\Logger\WikiaLogger::instance();
 
 		/**
 		 * Wikia change - begin


### PR DESCRIPTION
When maintenance tasks are run on k8s we need to log their output to ELK. Let's add `WikiaLogger` to `Maintenance::output()` without removing the old logic so it's still possible to see the logs in the console when running script manually.