### PR TITLE
Add context to maintenance script assertion logs

### DIFF
--- a/lib/Wikia/src/Tasks/Tasks/MaintenanceTask.php
+++ b/lib/Wikia/src/Tasks/Tasks/MaintenanceTask.php
@@ -14,11 +14,16 @@ class MaintenanceTask extends BaseTask {
 	public static function validatePath( string $script ) : bool {
 		global $IP;
 
-		$script = realpath( $IP. '/' . $script );
+		$scriptRealPath = realpath( $IP. '/' . $script );
+		$logContext = [
+			'IP' => $IP,
+			'script' => $script,
+			'scriptRealPath' => $scriptRealPath
+		];
 
-		Assert::true( file_exists( $script ), 'Provided script does not exist' );
-		Assert::true( endsWith( $script, '.php' ), '$script must end with .php' );
-		Assert::true( startsWith( $script, $IP ), 'Script path must be relative to app\'s root' );
+		Assert::true( file_exists( $scriptRealPath ), 'Provided script does not exist', $logContext );
+		Assert::true( endsWith( $scriptRealPath, '.php' ), '$script must end with .php', $logContext );
+		Assert::true( startsWith( $scriptRealPath, $IP ), 'Script path must be relative to app\'s root', $logContext );
 
 		return true;
 	}


### PR DESCRIPTION
In Kibana I see:
- `Scheduling extensions/wikia/SemanticMediaWiki/maintenance/rebuildConceptCache.php "--create"` in cron job logs
- `Provided script does not exist` in maintenance task logs

`extensions/wikia/SemanticMediaWiki/maintenance/rebuildConceptCache.php` exists so I don't know how to debug without adding more details to the logs.