### PR TITLE
SUS-5454 | Remove smw-concept-cache cron job

### DIFF
--- a/docker/maintenance/smw-concept-cache.yaml
+++ b/docker/maintenance/smw-concept-cache.yaml
@@ -1,7 +1,0 @@
-schedule: "0 8 * * *"
-args:
-- php
-- /usr/wikia/slot1/current/src/maintenance/maintenanceTaskScheduler.php
-- --params="--create"
-- --id=410,40,1318,490
-- /usr/wikia/slot1/current/src/extensions/wikia/SemanticMediaWiki/maintenance/rebuildConceptCache.php


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5454
https://github.com/Wikia/chef-repo/pull/17357

This cron job didn't work for a long time. First, the script path was wrong. Second, even when path is fixed there is this error:
```
igor@cron-s1:/usr/wikia/slot1/current/src$ SERVER_ID=410 php ./extensions/SemanticMediaWiki/maintenance/rebuildConceptCache.php --create
Unexpected non-MediaWiki exception encountered, of type "RuntimeException"
RuntimeException: A database error has occurred.  Did you forget to run maintenance/update.php after upgrading?  See: https://www.mediawiki.org/wiki/Manual:Upgrading#Run_the_update_script
Query: SELECT  page_namespace,page_title  FROM `page` FORCE INDEX (PRIMARY) WHERE page_namespace = '308'  
Function: SMW\MediaWiki\TitleLookup::selectAll
Error: 1146 Table 'smw+yugioh.page' doesn't exist (geo-db-smw-slave.query.consul)
```

Seems like no one cares about it, so let's :hocho: it.