### PR TITLE
Increase successful cron job history limit

### DIFF
--- a/docker/maintenance/cronjob-template.yaml
+++ b/docker/maintenance/cronjob-template.yaml
@@ -5,7 +5,7 @@ metadata:
   name: "mw-cj-${name}"
 spec:
   schedule: ${schedule}
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 1
   jobTemplate:
     spec:


### PR DESCRIPTION
I noticed that when `successfulJobsHistoryLimit` is set to 0 we don't have any useful logs in Kibana. I suspect the pod is deleted before the logstash picks up the logs. Let's keep a single pod per cron job to have the logs for debugging purposes.