### PR TITLE
SUS-5466 | Fix the active parameter in init-stat cron job

### DIFF
--- a/docker/maintenance/init-stat.yaml
+++ b/docker/maintenance/init-stat.yaml
@@ -2,6 +2,6 @@ schedule: "0 3 * * *"
 args:
 - php
 - /usr/wikia/slot1/current/src/maintenance/maintenanceTaskScheduler.php
-- --active
+- --active=1
 - --params="--noviews --active --update"
 - maintenance/initStats.php


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5466
https://github.com/Wikia/chef-repo/blob/d1d9724d801ced983b861592546d15d1f6f98818/cookbooks/cron/recipes/wiki_maintenance.rb#L72

It's supposed to be run on wikis active in the last one day. `--active` is ignored when there is no value.