### PR TITLE
SUS-5467 | Run lyric wiki maintenance script on lyric wiki

### DIFF
--- a/docker/maintenance/lyricwiki-crawler.yaml
+++ b/docker/maintenance/lyricwiki-crawler.yaml
@@ -1,4 +1,5 @@
 schedule: "0 10 * * *"
+server_id: 43339
 args:
 - php
 - /usr/wikia/slot1/current/src/extensions/3rdparty/LyricWiki/maintenance/LyricsWikiCrawler.php


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5467

It doesn't do anything useful when ran on the default wiki.