### PR TITLE
DE-3713 Removed error which can actually happen

### DIFF
--- a/extensions/wikia/Track/templates/track.mustache
+++ b/extensions/wikia/Track/templates/track.mustache
@@ -27,21 +27,6 @@
 
 			if (beacon) {
 				window.beacon_id = beacon;
-			} else {
-				// something went terribly wrong
-				try {
-					var request = new XMLHttpRequest(),
-							data = {
-								name: 'MediaWiki.track',
-								description: 'wikia_beacon_id is empty',
-								client: 'oasis'
-							};
-					request.open('POST', '{{event-logger-url}}/error', true);
-					request.setRequestHeader('Content-type', 'application/json');
-					request.send(JSON.stringify(data));
-				} catch (error) {
-					// Ignore error sending log request
-				}
 			}
 
 			window.sessionId = sessionId ? sessionId : genUID();


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/DE-3713

Removed error message about lack of beacon, since this happens for all users with cookies disabled and there's nothing we can do about it.