### PR TITLE
SRE-92 | Disable read-only HTML error page for wikia.php POSTs

### DIFF
--- a/includes/WebStart.php
+++ b/includes/WebStart.php
@@ -170,7 +170,7 @@ if ( !defined( 'MW_NO_SETUP' ) ) {
 if(wfReadOnly() && is_object($wgRequest) && $wgRequest->wasPosted()) {
 	if (
 		( strpos(strtolower($_SERVER['SCRIPT_URL']), 'datacenter') === false ) &&
-		( strpos(strtolower($_SERVER['SCRIPT_URL']), 'api.php') === false )
+		!in_array( strtolower( $_SERVER['SCRIPT_URL'] ), [ 'api.php', 'wikia.php' ] )
 	) {
 
 		// SUS-2627: emit a proper HTTP error code indicating that something went wrong


### PR DESCRIPTION
Disable read-only HTML error page for wikia.php POSTs, like we already do for api.php.

https://wikia-inc.atlassian.net/browse/SRE-92