### PR TITLE
wgWikiFactoryRedirectForAlternateDomains fix

### DIFF
--- a/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
+++ b/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
@@ -404,7 +404,8 @@ class WikiFactoryLoader {
 		/**
 		 * check if not additional domain was used (then we redirect anyway)
 		 */
-		$cond2 = $this->mAlternativeDomainUsed && ( $url['host'] != $this->mOldServerName );
+		$cond2 = $this->mAlternativeDomainUsed && ( $url['host'] != $this->mOldServerName ) &&
+			$wgWikiFactoryRedirectForAlternateDomains;
 
 		$redirectUrl = WikiFactory::getLocalEnvURL( $this->mCityUrl );
 		$shouldUseHttps = ( $wgEnableHTTPSForAnons || !empty( $_SERVER['HTTP_FASTLY_SSL'] ) ) &&
@@ -412,7 +413,7 @@ class WikiFactoryLoader {
 			!empty( $_SERVER['HTTP_FASTLY_FF'] );	// don't redirect internal clients
 		$shouldUpgradeToHttps = $shouldUseHttps && empty( $_SERVER['HTTP_FASTLY_SSL'] );
 
-		if ( ( $cond1 || $cond2 || $shouldUpgradeToHttps ) &&  $wgWikiFactoryRedirectForAlternateDomains ) {
+		if ( $cond1 || $cond2 || $shouldUpgradeToHttps ) {
 			if ( $shouldUseHttps ) {
 				$redirectUrl = wfHttpToHttps( $redirectUrl );
 			}


### PR DESCRIPTION
`wgWikiFactoryRedirectForAlternateDomains` should not disable https and wiki domains redirects.

This is a small compromise between `wgWikiFactoryRedirectForAlternateDomains` var introduced by SUS and our need to test redirects on devboxes and sandboxes.