### PR TITLE
(PLATFORM-3604) Make CategoryExhibition link URLs relative

### DIFF
--- a/extensions/wikia/CategoryExhibition/CategoryExhibitionSection.class.php
+++ b/extensions/wikia/CategoryExhibition/CategoryExhibitionSection.class.php
@@ -245,7 +245,7 @@ abstract class CategoryExhibitionSection {
 			'height' => $this->thumbHeight,
 			'snippet' => $snippetText,
 			'title' => $oTitle->getText(),
-			'url' => $oTitle->getFullURL(),
+			'url' => $oTitle->getLocalURL(),
 		);
 
 		// will be purged elsewhere after edit

--- a/extensions/wikia/CategoryExhibition/CategoryExhibitionSectionMedia.class.php
+++ b/extensions/wikia/CategoryExhibition/CategoryExhibitionSectionMedia.class.php
@@ -51,10 +51,10 @@ class CategoryExhibitionSectionMedia extends CategoryExhibitionSection {
 		$linkedFiles = $this->getLinkedFiles( $itemTitle );
 		if ( !empty( $linkedFiles ) ) {
 			$linkText = $linkedFiles->getText();
-			$linkFullUrl = $linkedFiles->getFullURL();
+			$linkUrl = $linkedFiles->getLocalURL();
 		} else {
 			$linkText = '';
-			$linkFullUrl = '';
+			$linkUrl = '';
 		}
 
 		return [
@@ -62,11 +62,11 @@ class CategoryExhibitionSectionMedia extends CategoryExhibitionSection {
 			'title' => $itemTitle->getText(),
 			'key' => $itemTitle->getDBKey(),
 			'img' => (string) $imageSrc,
-			'url' => $itemTitle->getFullURL(),
+			'url' => $itemTitle->getLocalURL(),
 			'dimensions' => array( 'w' => (int) $forceWidth, 'h' => (int) $forceHeight ),
 			'class' => $elementClass,
 			'data-ref' => $itemTitle->getPrefixedURL(),
-			'targetUrl' => $linkFullUrl,
+			'targetUrl' => $linkUrl,
 			'targetText' => $linkText,
 			'isVideo' => $isVideo,
 		];

--- a/extensions/wikia/CategoryExhibition/CategoryExhibitionSectionSubcategories.class.php
+++ b/extensions/wikia/CategoryExhibition/CategoryExhibitionSectionSubcategories.class.php
@@ -49,7 +49,7 @@ class CategoryExhibitionSectionSubcategories extends CategoryExhibitionSection {
 			'id' => $pageId,
 			'title' => $oTitle->getText(),
 			// Pass the display/sort params to the subcategory:
-			'url' => $oTitle->getFullURL( [
+			'url' => $oTitle->getLocalURL( [
 				'display' => $this->urlParams->getDisplayParam(),
 				'sort' => $this->urlParams->getSortParam(),
 			] ),


### PR DESCRIPTION
Make CategoryExhibition link URLs relative to avoid any cache pollution
issues.

I can't see any reason these needed to be full URLs, so switching to relative
should be OK.

/cc @Wikia/core-platform-team 