### PR TITLE
cake-3437 - separate function to get fandom creator variables

### DIFF
--- a/extensions/wikia/AdEngine/AdEngine2.setup.php
+++ b/extensions/wikia/AdEngine/AdEngine2.setup.php
@@ -28,6 +28,7 @@ $wgAutoloadClasses['ResourceLoaderAdEngineILCode'] = __DIR__ . '/ResourceLoaders
 // Hooks for AdEngine2
 $wgHooks['AfterInitialize'][] = 'AdEngine2Hooks::onAfterInitialize';
 $wgHooks['InstantGlobalsGetNewsAndStoriesVariables'][] = 'AdEngine2Hooks::onInstantGlobalsGetNewsAndStoriesVariables';
+$wgHooks['InstantGlobalsGetFandomCreatorVariables'][] = 'AdEngine2Hooks::onInstantGlobalsGetFandomCreatorVariables';
 $wgHooks['InstantGlobalsGetVariables'][] = 'AdEngine2Hooks::onInstantGlobalsGetVariables';
 $wgHooks['OasisSkinAssetGroups'][] = 'AdEngine2Hooks::onOasisSkinAssetGroups';
 $wgHooks['OasisSkinAssetGroupsBlocking'][] = 'AdEngine2Hooks::onOasisSkinAssetGroupsBlocking';

--- a/extensions/wikia/AdEngine/AdEngine2Hooks.class.php
+++ b/extensions/wikia/AdEngine/AdEngine2Hooks.class.php
@@ -154,6 +154,24 @@ class AdEngine2Hooks {
 		return true;
 	}
 
+	public static function onInstantGlobalsGetFandomCreatorVariables( array &$vars ) {
+		$vars[] = 'wgAdDriverBottomLeaderBoardMegaCountries';
+		$vars[] = 'wgAdDriverFVAsUapKeyValueCountries';
+		$vars[] = 'wgAdDriverFVDelayCountries';
+		$vars[] = 'wgAdDriverKikimoraPlayerTrackingCountries';
+		$vars[] = 'wgAdDriverKikimoraTrackingCountries';
+		$vars[] = 'wgAdDriverKikimoraViewabilityTrackingCountries';
+		$vars[] = 'wgAdDriverPlayAdsOnNextVideoCountries';
+		$vars[] = 'wgAdDriverPlayAdsOnNextVideoFrequency';
+		$vars[] = 'wgAdDriverPorvataMoatTrackingCountries';
+		$vars[] = 'wgAdDriverPorvataMoatTrackingSampling';
+		$vars[] = 'wgAdDriverSingleBLBSizeForUAPCountries';
+		$vars[] = 'wgAdDriverVideoMidrollCountries';
+		$vars[] = 'wgAdDriverVideoMoatTrackingCountries';
+		$vars[] = 'wgAdDriverVideoMoatTrackingSampling';
+		$vars[] = 'wgAdDriverVideoPostrollCountries';
+	}
+
 	/**
 	 * Register ad-related vars on top
 	 *

--- a/extensions/wikia/InstantGlobals/InstantGlobalsApiController.class.php
+++ b/extensions/wikia/InstantGlobals/InstantGlobalsApiController.class.php
@@ -25,7 +25,7 @@ class InstantGlobalsApiController extends WikiaController {
 	}
 
 	/**
-	 * Get news&stories variables values
+	 * Get variables values
 	 *
 	 * @return array key / value list variables
 	 */

--- a/extensions/wikia/InstantGlobals/InstantGlobalsApiController.class.php
+++ b/extensions/wikia/InstantGlobals/InstantGlobalsApiController.class.php
@@ -1,11 +1,23 @@
 <?php
 
 class InstantGlobalsApiController extends WikiaController {
+
+	const NEWS_AND_STORIES_HOOK = 'InstantGlobalsGetNewsAndStoriesVariables';
+	const FANDOM_CREATOR_HOOK = 'InstantGlobalsGetFandomCreatorVariables';
+
 	/**
 	 * @return array
 	 */
 	public function getNewsAndStoriesVariables() {
-		$instantGlobals = $this->getNewsAndStoriesVariablesValues();
+		$instantGlobals = $this->getInstantGlobals(self::NEWS_AND_STORIES_HOOK);
+
+		$this->response->setFormat( WikiaResponse::FORMAT_JSON );
+		$this->response->setCacheValidity( WikiaResponse::CACHE_VERY_SHORT );
+		$this->response->setData( $instantGlobals );
+	}
+
+	public function getFandomCreatorVariables() {
+		$instantGlobals = $this->getInstantGlobals(self::FANDOM_CREATOR_HOOK);
 
 		$this->response->setFormat( WikiaResponse::FORMAT_JSON );
 		$this->response->setCacheValidity( WikiaResponse::CACHE_VERY_SHORT );
@@ -15,13 +27,13 @@ class InstantGlobalsApiController extends WikiaController {
 	/**
 	 * Get news&stories variables values
 	 *
-	 * @return object key / value list variables
+	 * @return array key / value list variables
 	 */
-	private function getNewsAndStoriesVariablesValues() {
+	private function getInstantGlobals(string $hookName) {
 		$ret = [];
 		$variables = [];
 
-		Hooks::run( 'InstantGlobalsGetNewsAndStoriesVariables', [&$variables] );
+		Hooks::run( $hookName, [&$variables] );
 
 		foreach ( $variables as $name ) {
 			$value = WikiFactory::getVarValueByName( $name, Wikia::COMMUNITY_WIKI_ID );


### PR DESCRIPTION
@Wikia/cake @fraszczakszymon @vforge 
https://wikia-inc.atlassian.net/browse/CAKE-3437

We're integrating ads into the FC, and rather than relying on the existing n&s functionality we want to have our own function for getting these variables so they don't change for our app without explicit intent. 

I'm updating the helper function to be a bit more flexible to support both apps but the output won't change. Unfortunately this seems to only be testable in production since those variables aren't set in dev.
