### PR TITLE
Properly handle alternative domains on devboxes

### DIFF
--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -1242,7 +1242,7 @@ class WikiFactory {
 	 * @param $host
 	 * @return string normalized host name
 	 */
-	protected static function normalizeHost( $host ) {
+	public static function normalizeHost( $host ) {
 		global $wgDevDomain, $wgWikiaBaseDomain;
 		// strip env-specific pre- and suffixes for staging environment
 		$host = preg_replace(


### PR DESCRIPTION
Stripping the `www.` prefix for alternative domains is fine, as we would like to redirect `www.muppet.wikia.fr` to `muppet.wikia.com`. But as alternative domains array is also used to handle devbox/sandbox envs, it should not be done for the wikiaglobal wiki, as we would start comparing `wikia.com` with `www.wikia.com` and end up in a redirect loop.