### PR TITLE
SUS-5694 | Add backlinks count to Evaluation

### DIFF
--- a/extensions/wikia/Search/WikiaSearchIndexerController.class.php
+++ b/extensions/wikia/Search/WikiaSearchIndexerController.class.php
@@ -47,9 +47,10 @@ class WikiaSearchIndexerController extends WikiaController
 
 		$serviceName = 'Wikia\Search\IndexService\\' . $this->getVal( 'service', 'DefaultContent' );
 		$ids = explode( '|', $this->getVal( 'ids', '' ) );
+		$flags = explode( '|', $this->getVal( 'flags', '' ) );
 		if ( class_exists( $serviceName ) ) {
 			/* @var Wikia\Search\IndexService\AbstractService $service */
-			$service = new $serviceName( $ids );
+			$service = new $serviceName( $ids, $flags );
 			$ids = $this->getVal( 'ids' );
 			if ( !empty( $ids ) ) {
 				$this->response->setData( $service->getResponseForPageIds() );

--- a/extensions/wikia/Search/classes/IndexService/AbstractService.php
+++ b/extensions/wikia/Search/classes/IndexService/AbstractService.php
@@ -143,6 +143,7 @@ abstract class AbstractService {
 			}
 		}
 
+		$documents = $this->processAllDocuments( $documents );
 		$result['contents'] = $documents;
 
 		return $result;
@@ -228,6 +229,16 @@ abstract class AbstractService {
 		$this->reinitialize();
 
 		return $response;
+	}
+
+	/**
+	 * Hook allowing for processing documents in batches instead of page by page
+	 *
+	 * @param array $documents
+	 * @return array
+	 */
+	protected function processAllDocuments( $documents ) {
+		return $documents;
 	}
 
 }

--- a/extensions/wikia/Search/classes/IndexService/AbstractService.php
+++ b/extensions/wikia/Search/classes/IndexService/AbstractService.php
@@ -36,6 +36,13 @@ abstract class AbstractService {
 	protected $pageIds = [];
 
 	/**
+	 * Stores flags passed in a query param
+	 *
+	 * @var array
+	 */
+	protected $flags = [];
+
+	/**
 	 * A pointer to the page ID we're currently operating on.
 	 * Allows us to interact with a specific page ID during iteration without passing it.
 	 *
@@ -54,9 +61,11 @@ abstract class AbstractService {
 	 * Allows us to instantiate a service with pageIds already set
 	 *
 	 * @param array $pageIds
+	 * @param array $flags
 	 */
-	public function __construct( array $pageIds = [] ) {
+	public function __construct( array $pageIds = [], array $flags = [] ) {
 		$this->pageIds = $pageIds;
+		$this->flags = $flags;
 	}
 
 	/**

--- a/extensions/wikia/Search/classes/IndexService/Evaluation.php
+++ b/extensions/wikia/Search/classes/IndexService/Evaluation.php
@@ -5,6 +5,7 @@ namespace Wikia\Search\IndexService;
 use Wikia\Search\Utilities;
 
 class Evaluation extends AbstractService {
+	const DISABLE_BACKLINKS_COUNT_FLAG = 'disable_backlinks_count';
 
 	/**
 	 * @return array
@@ -38,7 +39,7 @@ class Evaluation extends AbstractService {
 	 * @throws \DBUnexpectedError
 	 */
 	protected function processAllDocuments( $documents ) {
-		if ( empty( $documents ) || in_array( 'disable_backlinks_count', $this->flags ) ) {
+		if ( empty( $documents ) || in_array( self::DISABLE_BACKLINKS_COUNT_FLAG, $this->flags ) ) {
 			return $documents;
 		}
 

--- a/extensions/wikia/Search/classes/IndexService/Evaluation.php
+++ b/extensions/wikia/Search/classes/IndexService/Evaluation.php
@@ -43,13 +43,13 @@ class Evaluation extends AbstractService {
 		}
 
 		$pageIds = array_filter( array_map( function ( $document ) {
-			return $document['id'];
+			return $document['page_id']['set'];
 		}, $documents ) );
 
 		$backlinks = $this->getBacklinksCount( $pageIds );
 
 		return array_map( function ( $document ) use ( $backlinks ) {
-			$id = $document['id'];
+			$id = $document['page_id']['set'];
 
 			if ( isset( $id ) && isset( $backlinks[ $id ] ) ) {
 				$document['backlinks'] = [

--- a/extensions/wikia/Search/classes/IndexService/Evaluation.php
+++ b/extensions/wikia/Search/classes/IndexService/Evaluation.php
@@ -28,7 +28,7 @@ class Evaluation extends AbstractService {
 			'lang' => $service->getSimpleLanguageCode(),
 			'indexed' => gmdate( "Y-m-d\TH:i:s\Z" ),
 			( new Utilities )->field( 'content' ) => $text,
-			// 'backlinks' is added in processAllDocuments()
+			// 'backlinks_count' is added in processAllDocuments()
 		];
 	}
 
@@ -46,14 +46,14 @@ class Evaluation extends AbstractService {
 			return $document['page_id']['set'];
 		}, $documents ) );
 
-		$backlinks = $this->getBacklinksCount( $pageIds );
+		$backlinksCount = $this->getBacklinksCount( $pageIds );
 
-		return array_map( function ( $document ) use ( $backlinks ) {
+		return array_map( function ( $document ) use ( $backlinksCount ) {
 			$id = $document['page_id']['set'];
 
-			if ( isset( $id ) && isset( $backlinks[ $id ] ) ) {
-				$document['backlinks'] = [
-					'set' => $backlinks[ $id ]
+			if ( isset( $id ) && isset( $backlinksCount[ $id ] ) ) {
+				$document['backlinks_count'] = [
+					'set' => $backlinksCount[ $id ]
 				];
 			}
 

--- a/extensions/wikia/Search/classes/IndexService/Evaluation.php
+++ b/extensions/wikia/Search/classes/IndexService/Evaluation.php
@@ -38,7 +38,7 @@ class Evaluation extends AbstractService {
 	 * @throws \DBUnexpectedError
 	 */
 	protected function processAllDocuments( $documents ) {
-		if ( empty( $documents ) ) {
+		if ( empty( $documents ) || in_array( 'disable_backlinks_count', $this->flags ) ) {
 			return $documents;
 		}
 

--- a/extensions/wikia/Search/classes/MediaWikiService.php
+++ b/extensions/wikia/Search/classes/MediaWikiService.php
@@ -1207,7 +1207,7 @@ class MediaWikiService {
 	 *
 	 * @return \Title|null
 	 */
-	protected function getTitleFromPageId( $pageId ) {
+	public function getTitleFromPageId( $pageId ) {
 
 		if ( !isset( static::$pageIdsToTitles[$pageId] ) ) {
 			$page = $this->getPageFromPageId( $pageId );


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5694

Add `backlinks_count` field to `/wikia.php?controller=WikiaSearchIndexer&method=get&service=Evaluation`. We can't use `$this->getService()->getBacklinksCountFromPageId` because it doesn't allow batching and is too slow.

cc @cmiller-wikia 