### PR TITLE
 SUS-5694 | Use the target namespace instead of the source namespace

### DIFF
--- a/extensions/wikia/Search/classes/IndexService/Evaluation.php
+++ b/extensions/wikia/Search/classes/IndexService/Evaluation.php
@@ -7,7 +7,6 @@ use MWNamespace;
 
 class Evaluation extends AbstractService {
 	const DISABLE_BACKLINKS_COUNT_FLAG = 'disable_backlinks_count';
-	const BACKLINKS_FROM_ALL_NAMESPACES_FLAG = 'backlinks_from_all_namespaces';
 	const LANGUAGES_SUPPORTED = ['en', 'de', 'es', 'fr', 'it', 'ja', 'pl', 'pt-br', 'ru', 'zh', 'zh-tw'];
 
 	/**

--- a/extensions/wikia/Search/classes/IndexService/Evaluation.php
+++ b/extensions/wikia/Search/classes/IndexService/Evaluation.php
@@ -73,38 +73,40 @@ class Evaluation extends AbstractService {
 	 * @throws \DBUnexpectedError
 	 */
 	private function getBacklinksCount( $pageIds ) {
-		$contentNamespaces = MWNamespace::getContentNamespaces();
-
 		$service = $this->getService();
 
-		$titles = [];
+		$titlesById = [];
+		$titlesByNamespace = [];
+		$backlinks = [];
 
 		foreach ( $pageIds as $id ) {
-			$titles[ $id ] = $service->getTitleFromPageId( $id )->getPrefixedDBkey();
-		}
+			$title = $service->getTitleFromPageId( $id );
+			$dbKey = $title->getDBkey();
 
-		$where = [ 'pl_title' => array_values( $titles ) ];
+			$titlesById[ $id ] = $dbKey;
 
-		// Adding namespace to query causes db to use `pl_namespace` index and is much faster
-		if ( !in_array( self::BACKLINKS_FROM_ALL_NAMESPACES_FLAG, $this->flags ) ) {
-			$where['pl_namespace'] = $contentNamespaces;
+			// Group by namespace so the pl_namespace index can be used
+			$titlesByNamespace[ $title->getNamespace() ][] = $dbKey;
 		}
 
 		$dbr = wfGetDB( DB_SLAVE );
 
-		$dbResults = $dbr->select(
-			'pagelinks',
-			[ 'count(*) as cnt', 'pl_title' ],
-			$where,
-			__METHOD__,
-			[ 'GROUP BY' => 'pl_title' ]
-		);
+		foreach ( $titlesByNamespace as $namespace => $titles ) {
+			$dbResults = $dbr->select(
+				'pagelinks',
+				[ 'count(*) as cnt', 'pl_title' ],
+				[
+					'pl_namespace' => $namespace,
+					'pl_title' => $titles
+				],
+				__METHOD__,
+				[ 'GROUP BY' => 'pl_title' ]
+			);
 
-		$backlinks = [];
-
-		while ( ( $row = $dbResults->fetchObject() ) ) {
-			$id = array_search( $row->pl_title, $titles );
-			$backlinks[ $id ] = $row->cnt;
+			while ( ( $row = $dbResults->fetchObject() ) ) {
+				$id = array_search( $row->pl_title, $titlesById );
+				$backlinks[ $id ] = $row->cnt;
+			}
 		}
 
 		return $backlinks;


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5694

Follow up to https://github.com/Wikia/app/pull/15836

`pl_namespace` is the namespace of the target page. `pl_title` is not prefixed, colons there are a part of the title, e.g. https://harrypotter.wikia.com/wiki/Harry_Potter:_Hogwarts_Mystery is in `NS_MAIN`.

Group by target namespace so the DB uses the `pl_namespace` index.