### PR TITLE
(PLATFORM-3616) Make external links to other wikis protocol-relative

### DIFF
--- a/extensions/wikia/HTTPSSupport/HTTPSSupport.setup.php
+++ b/extensions/wikia/HTTPSSupport/HTTPSSupport.setup.php
@@ -4,6 +4,7 @@ $wgAutoloadClasses['HTTPSSupportHooks'] =  __DIR__ . '/HTTPSSupportHooks.class.p
 
 $wgHooks['AfterInitialize'][] = 'HTTPSSupportHooks::onAfterInitialize';
 $wgHooks['MercuryWikiVariables'][] = 'HTTPSSupportHooks::onMercuryWikiVariables';
-$wgHooks['outputMakeExternalImage'][] = 'HTTPSSupportHooks::parserUpgradeVignetteUrls';
 $wgHooks['SitemapPageBeforeOutput'][] = 'HTTPSSupportHooks::onSitemapRobotsPageBeforeOutput';
 $wgHooks['WikiaRobotsBeforeOutput'][] = 'HTTPSSupportHooks::onSitemapRobotsPageBeforeOutput';
+$wgHooks['outputMakeExternalImage'][] = 'HTTPSSupportHooks::parserUpgradeVignetteUrls';
+$wgHooks['LinkerMakeExternalLink'][] = 'HTTPSSupportHooks::onLinkerMakeExternalLink';

--- a/extensions/wikia/HTTPSSupport/HTTPSSupportHooks.class.php
+++ b/extensions/wikia/HTTPSSupport/HTTPSSupportHooks.class.php
@@ -91,6 +91,29 @@ class HTTPSSupportHooks {
 		return true;
 	}
 
+	public static function parserUpgradeVignetteUrls( string &$url ) {
+		if ( preg_match( self::VIGNETTE_IMAGES_HTTP_UPGRADABLE, $url ) && strpos( $url, 'http://' ) === 0 ) {
+			$url = wfHttpToHttps( $url );
+		}
+	}
+
+	/**
+	 * Make sure any "external" links to our own wikis that support HTTPS
+	 * are protocol-relative on output.
+	 *
+	 * @param  string  &$url
+	 * @param  string  &$text
+	 * @param  bool    &$link
+	 * @param  array   &$attribs
+	 * @return boolean
+	 */
+	public static function onLinkerMakeExternalLink( string &$url, string &$text, bool &$link, array &$attribs ): bool {
+		if ( wfHttpsAllowedForURL( $url ) ) {
+			$url = wfProtocolUrlToRelative( $url );
+		}
+		return true;
+	}
+
 	private static function httpsAllowed( User $user, string $url ): bool {
 		global $wgEnableHTTPSForAnons;
 		return wfHttpsAllowedForURL( $url ) &&
@@ -101,12 +124,6 @@ class HTTPSSupportHooks {
 		global $wgDBname;
 		return array_key_exists( $wgDBname, self::$httpsArticles ) &&
 			in_array( $title->getPrefixedDBKey(), self::$httpsArticles[ $wgDBname ] );
-	}
-
-	public static function parserUpgradeVignetteUrls( string &$url ) {
-		if ( preg_match( self::VIGNETTE_IMAGES_HTTP_UPGRADABLE, $url ) && strpos( $url, 'http://' ) === 0 ) {
-			$url = wfHttpToHttps( $url );
-		}
 	}
 
 	private static function redirectWithPrivateCache( string $url, WebRequest $request ) {


### PR DESCRIPTION
Make external links to other wikis protocol-relative for URLs to communities
that support HTTPS. This means we won't need users who paste URLs to other wikis
to update them.

/cc @Wikia/core-platform-team 