### PR TITLE
MAIN-17184: Properly encode infobox titles in RTE infobox selection

### DIFF
--- a/extensions/wikia/RTE/js/plugins/infobox/plugin.js
+++ b/extensions/wikia/RTE/js/plugins/infobox/plugin.js
@@ -166,7 +166,7 @@ require([
 		var markup = '';
 
 		data.query.allinfoboxes.forEach(function (infoboxData) {
-			markup += '<li><a data-infobox-name="' + encodeURI(infoboxData.title) + '">' + encodeURI(infoboxData.title) + '</a></li>';
+			markup += '<li><a data-infobox-name="' + encodeURI(infoboxData.title) + '">' + mw.html.escape(infoboxData.title) + '</a></li>';
 		});
 
 		return markup;


### PR DESCRIPTION
In the infobox selection screen, infobox names are URI-encoded instead of HTML-encoded.

[Example page](http://tr.starwars.wikia.com/wiki/Darth_Bane?action=edit&useeditor=wysiwyg)
[Example image](https://cdn.discordapp.com/attachments/474995525704351744/474998744882872330/received_2109281299325991.png)
Support request: [ZD#405174](http://support.wikia-inc.com/hc/requests/405174)
JIRA ticket: [MAIN-17184](https://wikia-inc.atlassian.net/browse/MAIN-17184)