### PR TITLE
(PLATFORM-3626) Handle protocol-relative URLs in the links whitelist

### DIFF
--- a/extensions/wikia/WikiaWhiteList/WikiaWhiteList.php
+++ b/extensions/wikia/WikiaWhiteList/WikiaWhiteList.php
@@ -55,7 +55,7 @@ function wfWhiteListParse($text) {
 		preg_match('#href\s*?=\s*?[\'"]?([^\'" ]*)[\'"]?#i', $text, $captures);
 		if ( is_array($captures) && isset($captures[1]) ) {
 			$lhref = $captures[1];
-			if (preg_match('#^\s*https?://#', $lhref)) {
+			if (preg_match('#^\s*(https?:)?//#', $lhref)) {
 				$lparsed = @parse_url($lhref);
 				#---
 				if ( empty($lparsed) || (!is_array($lparsed)) ) {


### PR DESCRIPTION
Handle protocol-relative URLs in the external links whitelist.

Backported from https://github.com/Wikia/app/pull/15869.