### PR TITLE
SEO-646 | Remove canonical from 404 and 410 pages

### DIFF
--- a/extensions/wikia/CanonicalHref/CanonicalHref.php
+++ b/extensions/wikia/CanonicalHref/CanonicalHref.php
@@ -9,27 +9,35 @@
  */
 
 $wgExtensionCredits['specialpage'][] = array(
-        'name' => 'Canonical Href',
-		'version' => '1.1',
-        'author' => array('Nick Sullivan nick at wikia-inc.com', 'Maciej Brencz', '[http://seancolombo.com Sean Colombo]'),
-        'descriptionmsg' => 'canonicalhref-desc',
-		'url' => 'https://github.com/Wikia/app/tree/dev/extensions/wikia/CanonicalHref'
+	'name' => 'Canonical Href',
+	'version' => '1.1',
+	'author' => array( 'Nick Sullivan nick at wikia-inc.com', 'Maciej Brencz', '[http://seancolombo.com Sean Colombo]' ),
+	'descriptionmsg' => 'canonicalhref-desc',
+	'url' => 'https://github.com/Wikia/app/tree/dev/extensions/wikia/CanonicalHref'
 );
 
 //i18n
 $wgExtensionMessagesFiles['CanonicalHref'] = __DIR__ . '/CanonicalHref.i18n.php';
 
 $wgHooks['BeforePageDisplay'][] = 'wfCanonicalHref';
+
 /**
  * @param OutputPage $out
  * @param Skin $skin
  * @return bool
- * @internal param $sk
+ * @throws FatalError
+ * @throws MWException
  */
 function wfCanonicalHref( OutputPage $out, Skin $skin ): bool {
-	// No canonical on pages with pagination -- they should have the link rel="next/prev" instead
-	// SUS-5546: Don't render a canonical href for the closed wiki page
-	if ( $out->getRequest()->getVal( 'page' ) || $out->getTitle()->isSpecial( 'CloseWiki' ) ) {
+	$statusCodesWithoutCanonicalHref = [ 404, 410 ];
+
+	if (
+		// No canonical on pages with pagination -- they should have the link rel="next/prev" instead
+		$out->getRequest()->getVal( 'page' ) ||
+		// SUS-5546: Don't render a canonical href for the closed wiki page
+		$out->getTitle()->isSpecial( 'CloseWiki' ) ||
+		in_array( $out->mStatusCode, $statusCodesWithoutCanonicalHref )
+	) {
 		return true;
 	}
 

--- a/includes/ImagePage.php
+++ b/includes/ImagePage.php
@@ -563,7 +563,8 @@ EOT
 			if ( !$this->getID() && $wgSend404Code ) {
 				// If there is no image, no shared image, and no description page,
 				// output a 404, to be consistent with articles.
-				$wgRequest->response()->header( 'HTTP/1.1 404 Not Found' );
+				// Wikia change - don't set the HTTP header manually
+				$wgOut->setStatusCode( 404 );
 			}
 		}
 		$wgOut->setFileVersion( $this->displayImg );


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SEO-646

I had to modify `includes/ImagePage.php` as it was setting the status code in a very ugly way and even http://php.net/manual/en/function.headers-list.php didn't show it.

@Wikia/core-platform-team 