### PR TITLE
Remove site name from title on corporate pages

### DIFF
--- a/includes/wikia/WikiaHtmlTitle.class.php
+++ b/includes/wikia/WikiaHtmlTitle.class.php
@@ -57,7 +57,10 @@ class WikiaHtmlTitle {
 	public function getAllParts() {
 		$parts = array_merge(
 			$this->parts,
-			[$this->siteName, $this->brandName]
+			// Site name on corporate pages is FANDOM so it's redundant with brand name
+			WikiaPageType::isCorporatePage() ?
+				[ $this->brandName ] :
+				[ $this->siteName, $this->brandName ]
 		);
 
 		$stringParts = array_map( function( $part ) {


### PR DESCRIPTION
Title on https://www.wikia.com/WAM is:
```
Wiki Activity Monitor (WAM) | FANDOM | FANDOM powered by Wikia
```
Let's remove the redundant `FANDOM`.

@Wikia/core-platform-team 