### PR TITLE
PLATFORM-3640 | Force protocol links in emails

### DIFF
--- a/extensions/wikia/Email/EmailController.class.php
+++ b/extensions/wikia/Email/EmailController.class.php
@@ -148,7 +148,6 @@ abstract class EmailController extends \WikiaController {
 
 		// If something previously has thrown an error (likely 'init') don't continue
 		if ( $this->hasErrorResponse ) {
-			$wgForceProtocolLinks = false;
 			return;
 		}
 
@@ -187,7 +186,6 @@ abstract class EmailController extends \WikiaController {
 				$this->afterSuccess();
 			}
 		} catch ( \Exception $e ) {
-			$wgForceProtocolLinks = false;
 			$this->setErrorResponse( $e );
 			return;
 		}
@@ -217,6 +215,8 @@ abstract class EmailController extends \WikiaController {
 	 *
 	 */
 	protected function setErrorResponse( \Exception $e ) {
+		global $wgForceProtocolLinks;
+
 		if ( $e instanceof ControllerException ) {
 			$result = $e->getErrorType();
 		} else {
@@ -230,6 +230,8 @@ abstract class EmailController extends \WikiaController {
 			'result' => $result,
 			'msg' => $e->getMessage(),
 		] );
+
+		$wgForceProtocolLinks = false;
 	}
 
 	/**

--- a/extensions/wikia/Email/EmailController.class.php
+++ b/extensions/wikia/Email/EmailController.class.php
@@ -62,6 +62,12 @@ abstract class EmailController extends \WikiaController {
 
 	public function init() {
 		try {
+			global $wgForceProtocolLinks;
+
+			// Protocol relative links don't work in email clients like iOS mail app or Thunderbird
+			// They also break SendGrid's click tracking
+			$wgForceProtocolLinks = true;
+
 			$this->assertCanAccessController();
 
 			// If we're calling an internal handler, don't go through this init again
@@ -138,8 +144,11 @@ abstract class EmailController extends \WikiaController {
 	 * @throws \MWException
 	 */
 	public function handle() {
+		global $wgForceProtocolLinks;
+
 		// If something previously has thrown an error (likely 'init') don't continue
 		if ( $this->hasErrorResponse ) {
+			$wgForceProtocolLinks = false;
 			return;
 		}
 
@@ -178,6 +187,7 @@ abstract class EmailController extends \WikiaController {
 				$this->afterSuccess();
 			}
 		} catch ( \Exception $e ) {
+			$wgForceProtocolLinks = false;
 			$this->setErrorResponse( $e );
 			return;
 		}
@@ -187,6 +197,8 @@ abstract class EmailController extends \WikiaController {
 			'subject' => $subject,
 			'body' => $body['html'],
 		] );
+
+		$wgForceProtocolLinks = false;
 	}
 
 	/**

--- a/includes/wikia/GlobalFunctions.php
+++ b/includes/wikia/GlobalFunctions.php
@@ -1480,6 +1480,12 @@ function wfGetValueExcerpt( $value ) {
  * @return string
  */
 function wfProtocolUrlToRelative( $url ) {
+	global $wgForceProtocolLinks;
+
+	if ( $wgForceProtocolLinks === true ) {
+		return $url;
+	}
+
 	$pos = strpos( $url, '://' );
 	if ( $pos > 0 ) {
 		$url = substr_replace( $url, '', 0, $pos+1 );


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-3640

Protocol relative links don't work in email clients like iOS mail app or Thunderbird. They also break SendGrid's click tracking: https://sendgrid.com/docs/Classroom/Track/Clicks/click_tracking_html_best_practices.html

@Wikia/core-platform-team 