### PR TITLE
PLATFORM-3625 | Support protocol-relative external images

### DIFF
--- a/includes/parser/Parser.php
+++ b/includes/parser/Parser.php
@@ -71,7 +71,7 @@ class Parser {
 	# \p{Zs} is unicode 'separator, space' category. It covers the space 0x20
 	# as well as U+3000 is IDEOGRAPHIC SPACE for bug 19052
 	const EXT_LINK_URL_CLASS = '[^][<>"\\x00-\\x20\\x7F\p{Zs}]';
-	const EXT_IMAGE_REGEX = '/^(http:\/\/|https:\/\/)([^][<>"\\x00-\\x20\\x7F\p{Zs}]+)
+	const EXT_IMAGE_REGEX = '/^(http:\/\/|https:\/\/|\/\/)([^][<>"\\x00-\\x20\\x7F\p{Zs}]+)
 		\\/([A-Za-z0-9_.,~%\\-+&;#*?!=()@\\x80-\\xFF]+)\\.((?i)gif|png|jpg|jpeg)$/Sxu';
 
 	# State constants for the definition list colon extraction


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-3625

Support syntax like this one:
```
[{{fullurl: w:c:jump}} {{fullurl: w:c:jump:Special:FilePath/Wiki-wordmark.png}}]
```

There is also https://github.com/Wikia/app/blob/e75b3924b718941770721cf73890fc7e4b0b22c8/includes/parser/Parser_LinkHooks.php#L27 but I can't figure out where that class is being used. Possibly nowhere?

@Wikia/core-platform-team 