### PR TITLE
in Indexer Evaluation service do not process empty documents

### DIFF
--- a/extensions/wikia/Search/classes/IndexService/Evaluation.php
+++ b/extensions/wikia/Search/classes/IndexService/Evaluation.php
@@ -67,6 +67,10 @@ class Evaluation extends AbstractService {
 			return $document['page_id']['set'];
 		}, $filteredDocuments );
 
+		if ( empty( $pageIds ) ) {
+			return $documents;
+		}
+
 		list( $backlinksCount, $redirects, $contents ) = $this->getAdditionalInfo( $pageIds );
 
 		return array_map( function ( $document ) use (


### PR DESCRIPTION
in indexer - when all documents are redirects there is no pageIds for loading content.
if there is no pageIds then [cond](https://github.com/Wikia/app/blob/d62acf03a09b9d9441aa95fe1fac660f9a4fde75/extensions/wikia/Search/classes/IndexService/Evaluation.php#L236]) stays empty and make query like `select rev_page, rev_text_id from revision`

@jsutterfield 
@mixoteric 