### PR TITLE
SEO-652 | Block /d/g in robots.txt

### DIFF
--- a/extensions/wikia/RobotsTxt/classes/WikiaRobots.class.php
+++ b/extensions/wikia/RobotsTxt/classes/WikiaRobots.class.php
@@ -74,9 +74,10 @@ class WikiaRobots {
 	 * @var array
 	 */
 	private $blockedPaths = [
-		// User pages for discussions
+		// Discussions user pages
 		'/d/u/',
-
+		// Discussions guidelines
+		'/d/g',
 		// Fandom old URLs
 		'/fandom?p=',
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SEO-652
https://github.com/Wikia/discussions-front-end/pull/265

We don't want search crawlers to index pages like https://marvel.wikia.com/d/g

@Wikia/core-platform-team @Wikia/iris 