### PR TITLE
MAIN-17283: Fix querying for deleted revisions by user

### DIFF
--- a/includes/api/ApiQueryDeletedrevs.php
+++ b/includes/api/ApiQueryDeletedrevs.php
@@ -157,10 +157,20 @@ class ApiQueryDeletedrevs extends ApiQueryBase {
 		}
 
 		if ( !is_null( $params['user'] ) ) {
-			$this->addWhereFld( 'ar_user_text', $params['user'] );
+			$uid = User::idFromName( $params['user'] );
+			if ( empty ( $uid ) ) {
+				$this->addWhereFld( 'ar_user_text', $params['user'] );
+			} else {
+				$this->addWhereFld( 'ar_user', $uid );
+			}
 		} elseif ( !is_null( $params['excludeuser'] ) ) {
-			$this->addWhere( 'ar_user_text != ' .
-				$this->getDB()->addQuotes( $params['excludeuser'] ) );
+			$uid = User::idFromName( $params['excludeuser'] );
+			if ( empty ( $uid ) ) {
+				$this->addWhere( 'ar_user_text != ' .
+					$this->getDB()->addQuotes( $params['excludeuser'] ) );
+			} else {
+				$this->addWhere( 'ar_user != ' . $uid );
+			}
 		}
 
 		if ( !is_null( $params['continue'] ) && ( $mode == 'all' || $mode == 'revs' ) ) {


### PR DESCRIPTION
During #11511 (specifically in https://github.com/Wikia/app/commit/a3f42b9a94381745634ec9ac0b25d75dcab9ced0) the deleted revisions API module broke and can no longer list deleted revisions by a specific user. In the same commit, Special:DeletedRevisions code was changed to convert the user's username to an ID and then return deleted revisions by a user with that ID (using `ar_user`) with fallback to returning deleted revisions by a user's username in case the user could not be found (using `ar_user_text`), if I understood the code correctly:
https://github.com/Wikia/app/blob/f06df4a39302aae857d993740b366877978e1fed/includes/specials/SpecialDeletedContributions.php#L74-L80
This pull request applies the changes to Special:DeletedRevisions code to the deleted revisions API module in an attempt to fix the `druser` parameter to said module.

Support request: [ZD#407446](https://support.wikia-inc.com/hc/en-us/requests/407446)
JIRA ticket: [MAIN-17283](https://wikia-inc.atlassian.net/browse/MAIN-17283)
[Issue example.](https://dev.wikia.com/api.php?action=query&list=deletedrevs&druser=KockaAdmiralac&format=jsonfm)