### PR TITLE
MAIN-17280: Fix undo ban link in chat when ban message contains wikitext links

### DIFF
--- a/extensions/wikia/Chat2/js/controllers/controllers.js
+++ b/extensions/wikia/Chat2/js/controllers/controllers.js
@@ -511,7 +511,7 @@ var NodeRoomController = $.createClass(Observable, {
 					'chat-user-was-' + mode,
 					kickEvent.get('kickedUserName'),
 					kickEvent.get('moderatorName')
-				).rawParams([undoLink]).escaped()
+				).escaped().replace(/\$3/g, undoLink)
 			});
 
 			this.model.chats.add(newChatEntry);


### PR DESCRIPTION
When `chat-user-was-banned` message contains wikitext links, `mw.message` parser switches to `mediawiki.jqueryMsg`, which doesn't support raw parameters. As this does not seem to have been changed in upstream MediaWiki, simple replacing the `$3` parameter with the undo ban URL (which has already been properly escaped) should do.
This change has been tested by locally overriding the relevant JS resource.

Support request: [ZD#407456](https://support.wikia-inc.com/hc/en-us/requests/407456)
JIRA ticket: [MAIN-17280](https://wikia-inc.atlassian.net/browse/MAIN-17280)