### PR TITLE
PLATFORM-3646: don't report redirect loops for POST requests

### DIFF
--- a/includes/OutputPage.php
+++ b/includes/OutputPage.php
@@ -2112,7 +2112,8 @@ class OutputPage extends ContextSource {
 
 			if( Hooks::run( "BeforePageRedirect", array( $this, &$redirect, &$code, &$this->redirectedBy ) ) ) {
 				$current = WikiFactoryLoader::getCurrentRequestUri( $_SERVER, true, true );
-				if ( $current == $redirect ) {
+				// Check for the POST requests, as those are allowed to redirect to the same url (see PLATFORM-3646)
+				if ( !$this->getRequest()->wasPosted() && $current == $redirect ) {
 					$response->header( 'HTTP/1.1 508 Loop Detected' );
 					$response->header( 'X-Reason: Redirect loop detected' );
 					\Wikia\Logger\WikiaLogger::instance()->error(


### PR DESCRIPTION
POST requests are allowed to redirect to the current url