### PR TITLE
MAIN-17238 | Fix double encoded thread titles in breadcrumb

### DIFF
--- a/extensions/wikia/Forum/ForumController.class.php
+++ b/extensions/wikia/Forum/ForumController.class.php
@@ -195,9 +195,9 @@ class ForumController extends WallBaseController {
 		if ( $this->app->wg->Title->getNamespace() == NS_WIKIA_FORUM_TOPIC_BOARD ) {
 			$indexPage = Title::newFromText( 'Forum', NS_SPECIAL );
 			$path = [ ];
-			$path[] = [ 'title' => wfMessage( 'forum-forum-title' )->escaped(), 'url' => $indexPage->getFullUrl() ];
+			$path[] = [ 'title' => wfMessage( 'forum-forum-title' )->text(), 'url' => $indexPage->getFullUrl() ];
 
-			$path[] = [ 'title' => wfMessage( 'forum-board-topics' )->escaped() ];
+			$path[] = [ 'title' => wfMessage( 'forum-board-topics' )->text() ];
 
 			$topicTitle = Title::newFromURL( $this->app->wg->Title->getText() );
 

--- a/extensions/wikia/Wall/WallBaseController.class.php
+++ b/extensions/wikia/Wall/WallBaseController.class.php
@@ -499,7 +499,7 @@ class WallBaseController extends WikiaService {
 			$wallMessage->load();
 
 			if ( $wallMessage->isWallOwner( $this->wg->User ) ) {
-				$wallName = wfMessage( 'wall-message-mywall' )->escaped();
+				$wallName = wfMessage( 'wall-message-mywall' )->text();
 			} else {
 
 				$wallOwner = $wallMessage->getWallOwner()->getName();
@@ -509,7 +509,7 @@ class WallBaseController extends WikiaService {
 
 			$wallUrl = $wallMessage->getWallUrl();
 
-			$messageTitle = htmlspecialchars( $wallMessage->getMetaTitle() );
+			$messageTitle = $wallMessage->getMetaTitle();
 			$isRemoved = $wallMessage->isRemove();
 			$isDeleted = $wallMessage->isAdminDelete();
 			$this->response->setVal( 'isRemoved', $isRemoved );


### PR DESCRIPTION
Thread titles in breadcrumb are double encoded, this fix removes unnecessary escaping and leaves handling it for the [template](https://github.com/Wikia/app/blob/dev/extensions/wikia/Wall/templates/Wall_brickHeader.php#L9). 

[Bug example](https://spolecznosc.wikia.com/wiki/Thread:50369)
Jira issue: [MAIN-17238](https://wikia-inc.atlassian.net/browse/MAIN-17238)