### PR TITLE
PLATFORM-3650 | Support language path in infobox builder

### DIFF
--- a/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaInfoboxBuilderDialog.js
+++ b/extensions/VisualEditor/wikia/modules/ve/ui/dialogs/ve.ui.WikiaInfoboxBuilderDialog.js
@@ -65,7 +65,7 @@ ve.ui.WikiaInfoboxBuilderDialog.prototype.initialize = function () {
 	// Parent method
 	ve.ui.WikiaInfoboxBuilderDialog.super.prototype.initialize.call(this);
 
-	require(['wikia.loader', 'wikia.mustache', 'wikia.location'], function (loader, mustache, location) {
+	require(['wikia.loader', 'wikia.mustache', 'mw'], function (loader, mustache, mw) {
 		loader({
 			type: loader.MULTI,
 			resources: {
@@ -74,7 +74,7 @@ ve.ui.WikiaInfoboxBuilderDialog.prototype.initialize = function () {
 			}
 		}).done(function (assets) {
 			var html = mustache.render(assets.mustache[0], {
-				iframeUrl: location.origin + '/infobox-builder/',
+				iframeUrl: mw.config.get('wgServer') + mw.config.get('wgScriptPath') + '/infobox-builder/',
 				classes: 've-ui-infobox-builder'
 			});
 

--- a/extensions/wikia/PortableInfoboxBuilder/PortableInfoboxBuilderSpecialController.class.php
+++ b/extensions/wikia/PortableInfoboxBuilder/PortableInfoboxBuilderSpecialController.class.php
@@ -28,9 +28,7 @@ class PortableInfoboxBuilderSpecialController extends WikiaSpecialPageController
 	 * @throws MWException
 	 */
 	public function index() {
-		global $wgOut;
-
-		$wgOut->setHTMLTitle( wfMessage( 'portable-infobox-builder-title' )->text() );
+		$this->getOutput()->setHTMLTitle( wfMessage( 'portable-infobox-builder-title' )->text() );
 		$this->forward( __CLASS__, $this->getMethodName() );
 	}
 
@@ -55,8 +53,7 @@ class PortableInfoboxBuilderSpecialController extends WikiaSpecialPageController
 	 * @throws MWException
 	 */
 	public function sourceEditor() {
-		global $wgOut;
-		$wgOut->redirect(Title::newFromText($this->getPar(), NS_TEMPLATE)->getEditURL());
+		$this->getOutput()->redirect(Title::newFromText($this->getPar(), NS_TEMPLATE)->getEditURL());
 	}
 
 	/**

--- a/extensions/wikia/PortableInfoboxBuilder/PortableInfoboxBuilderSpecialController.class.php
+++ b/extensions/wikia/PortableInfoboxBuilder/PortableInfoboxBuilderSpecialController.class.php
@@ -18,29 +18,45 @@ class PortableInfoboxBuilderSpecialController extends WikiaSpecialPageController
 	 * @param bool $function
 	 * @param string $file
 	 * @param bool $includable
+	 * @throws WikiaException
 	 */
 	public function __construct( $name = null, $restriction = '', $listed = true, $function = false, $file = 'default', $includable = false ) {
 		parent::__construct( self::PAGE_NAME, self::PAGE_RESTRICTION, $listed, $function, $file, $includable );
 	}
 
+	/**
+	 * @throws MWException
+	 */
 	public function index() {
-		$this->wg->out->setHTMLTitle( wfMessage( 'portable-infobox-builder-title' )->text() );
+		global $wgOut;
+
+		$wgOut->setHTMLTitle( wfMessage( 'portable-infobox-builder-title' )->text() );
 		$this->forward( __CLASS__, $this->getMethodName() );
 	}
 
 	public function builder() {
+		global $wgScriptPath;
+
 		$title = $this->getPar();
 		OasisController::addHtmlClass( 'full-screen-page' );
 		RenderContentOnlyHelper::setRenderContentVar( true );
 		RenderContentOnlyHelper::setRenderContentLevel( RenderContentOnlyHelper::LEAVE_GLOBAL_NAV_ONLY );
 		Wikia::addAssetsToOutput( 'portable_infobox_builder_scss' );
-		$this->response->setVal( 'iframeUrl',
-			wfExpandUrl( sprintf( '/%s/%s',self::INFOBOX_BUILDER_MERCURY_ROUTE, $title) ) );
+		$this->response->setVal(
+			'iframeUrl',
+			wfExpandUrl(
+				sprintf( '%s/%s/%s', $wgScriptPath, self::INFOBOX_BUILDER_MERCURY_ROUTE, $title )
+			)
+		);
 		$this->response->setTemplateEngine( WikiaResponse::TEMPLATE_ENGINE_MUSTACHE );
 	}
 
+	/**
+	 * @throws MWException
+	 */
 	public function sourceEditor() {
-		$this->wg->out->redirect(Title::newFromText($this->getPar(), NS_TEMPLATE)->getEditURL());
+		global $wgOut;
+		$wgOut->redirect(Title::newFromText($this->getPar(), NS_TEMPLATE)->getEditURL());
 	}
 
 	/**

--- a/extensions/wikia/RTE/js/plugins/infobox/plugin.js
+++ b/extensions/wikia/RTE/js/plugins/infobox/plugin.js
@@ -3,13 +3,13 @@ require([
 	'wikia.window',
 	'wikia.loader',
 	'wikia.mustache',
-	'wikia.location'
+	'mw'
 ], function (
 	$,
 	window,
 	loader,
 	mustache,
-	location
+	mw
 ) {
 	var infoboxBuilderMarkup = null,
 		infoboxBuilderScripts = null,
@@ -100,7 +100,7 @@ require([
 			}
 		}).done(function (assets) {
 			infoboxBuilderMarkup = mustache.render(assets.mustache[0], {
-				iframeUrl: location.origin + '/infobox-builder/',
+				iframeUrl: mw.config.get('wgServer') + mw.config.get('wgScriptPath') + '/infobox-builder/',
 				classes: 'ck-ui-infobox-builder'
 			});
 			infoboxBuilderScripts = assets.scripts;


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-3650

Update Special:InfoboxBuilder, VE and RTE to load Infobox Builder using the language path.
Curated Content Editor paths were already updated in https://github.com/Wikia/app/pull/14889

@Wikia/core-platform-team 