### PR TITLE
(PLATFORM-3670) Don't redirect anons for raw and render actions

### DIFF
--- a/extensions/wikia/SEOTweaks/SEOTweaksHooksHelper.class.php
+++ b/extensions/wikia/SEOTweaks/SEOTweaksHooksHelper.class.php
@@ -304,7 +304,8 @@ class SEOTweaksHooksHelper {
 		if (
 			!$user->isAnon() ||
 			!$title->isRedirect() ||
-			isset( $queryParams['redirect'] ) && $queryParams['redirect'] === 'no'
+			( isset( $queryParams['redirect'] ) && $queryParams['redirect'] === 'no' ) ||
+			in_array( $request->getVal( 'action', 'view' ), [ 'raw', 'render' ] )
 		) {
 			return true;
 		}


### PR DESCRIPTION
Wiki page redirects were changed so they redirected to the canonical URLs
for anonymous users for SEO reasons. When shared help renders the content
of the help page from Community Central, it does so using an anonymous
backend request to the page with ?action=render. As a result, help pages
that were a redirect caused errors as the ?action=render request was
redirected and broke the help page.

This is the same reason "scary includes" of templates from other wikis
likewise broke when the included tempalte was renamed, as it relied on
a request to the template with action=render on the backend.

There is no real need to redirect action=render or action=raw, so we can
exclude these from the anonymous user redirects.

/cc @Wikia/core-platform-team 