### PR TITLE
MAIN-17303 | Fix user id in tracking script

### DIFF
--- a/extensions/wikia/Track/templates/track.mustache
+++ b/extensions/wikia/Track/templates/track.mustache
@@ -50,7 +50,7 @@
 					'&pv_number_global=' + window.pvNumberGlobal;
 
 			if (optIn) {
-				trackUrl += '&u=' + window.wgTrackID;
+				trackUrl += '&u=' + (window.trackID || window.wgTrackID || 0);
 			} else {
 				trackUrl += '&u=-1';
 			}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/MAIN-17303

`window.wgTrackID` is `undefined` for anons. Let's do the same thing as https://github.com/Wikia/app/blob/57d2dac16aef7df9eca4977d1b82a9f9e7b6fd13/resources/wikia/modules/tracker.js#L146