### PR TITLE
SUS-5475 | add YAML descriptor for extensions/wikia/WallNotifications/maintenance/cleanupNotificationsQueue.php script

### DIFF
--- a/docker/maintenance/README.md
+++ b/docker/maintenance/README.md
@@ -67,6 +67,12 @@ kubectl --context kube-sjc-prod -n prod get cronJobs | grep mw-cj
 
 ### Development Notes on Cronjobs Migration
 
+#### cleanup-notifications-queue.yaml
+
+`extensions/wikia/WallNotifications/maintenance/cleanupNotificationsQueue.php`
+
+Removes old entries from dataware.wall_notification_queue* tables
+
 #### cleanup-phalanx-stats.yaml
 
 `extensions/wikia/PhalanxII/maintenance/cleanupPhalanxStats.php`

--- a/docker/maintenance/cleanup-notifications-queue.yaml
+++ b/docker/maintenance/cleanup-notifications-queue.yaml
@@ -1,0 +1,4 @@
+schedule: "32 8 * * *"
+args:
+- php
+- /usr/wikia/slot1/current/src/extensions/wikia/WallNotifications/maintenance/cleanupNotificationsQueue.php

--- a/extensions/wikia/WallNotifications/WallNotificationsEveryone.class.php
+++ b/extensions/wikia/WallNotifications/WallNotificationsEveryone.class.php
@@ -387,7 +387,7 @@ class WallNotificationsEveryone extends WallNotifications {
 	/**
 	 * Clears notification queues and expired notifications
 	 *
-	 * Called by the maintenance.php script
+	 * Called by the cleanupNotificationsQueue.php maintenance script
 	 *
 	 * @param bool $onlyCache - clears only users' cache
 	 * @return int number of rows removed

--- a/extensions/wikia/WallNotifications/maintenance/cleanupNotificationsQueue.php
+++ b/extensions/wikia/WallNotifications/maintenance/cleanupNotificationsQueue.php
@@ -17,7 +17,7 @@ ini_set( 'include_path', dirname( __FILE__ ) . '/../../../maintenance/' );
 require_once( 'commandLine.inc' );
 
 if ( isset( $options['help'] ) ) {
-	die( "Usage: php maintenance.php [--only-cache] [--help]
+	die( "Usage: php cleanupNotificationsQueue.php [--only-cache] [--help]
 	--only-cache		clear users' cache only
 	--help			this message\n\n" );
 }


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5475

The new cronjob has been registered in Kubernetes:

```
mw-cj-cleanup-notifications-queue       16 8 * * *     False     0         8m              20m
```

This will be logged when running the script:

```
Clearing wall_notification_queue tables...
Rows removed: 12981
```