### PR TITLE
SUS-5504 | simplify CleanUpWallNotifications logs

### DIFF
--- a/docker/maintenance/cleanup-wall-notifications.yaml
+++ b/docker/maintenance/cleanup-wall-notifications.yaml
@@ -1,4 +1,4 @@
-schedule: "5 8 * * 3"
+schedule: "5 8 * * *"
 args:
 - php
 - /usr/wikia/slot1/current/src/extensions/wikia/WallNotifications/maintenance/cleanupWallNotifications.php

--- a/extensions/wikia/WallNotifications/maintenance/cleanupWallNotifications.php
+++ b/extensions/wikia/WallNotifications/maintenance/cleanupWallNotifications.php
@@ -119,8 +119,6 @@ class CleanUpWallNotifications extends Maintenance {
 				$deleted = $dbw->affectedRows();
 				$affected_rows += $deleted;
 
-				$this->output( '.' );
-
 				wfWaitForSlaves( $dbw->getDBname() );
 
 			} while( $deleted > 0 );

--- a/maintenance/Maintenance.php
+++ b/maintenance/Maintenance.php
@@ -325,7 +325,7 @@ abstract class Maintenance {
 
 		// Wikia change: log output if possible
 		if ( $this->mLogger instanceof Wikia\Logger\WikiaLogger ) {
-			$this->mLogger->info( $out );
+			$this->mLogger->info( trim( $out, "\n" ) );
 		}
 
 		if ( $this->mQuiet ) {


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5504

Given the last execution logs let's run this script once a day (instead of once a week):

```
Affected 3067571 rows
```