### PR TITLE
PLATFORM-3482 | Remove old url format for showcase/externaltest envs

### DIFF
--- a/extensions/wikia/AdEngine/js/context/adContext.js
+++ b/extensions/wikia/AdEngine/js/context/adContext.js
@@ -159,7 +159,7 @@ define('ext.wikia.adEngine.adContext', [
 		updateAdContextBidders(context);
 		updateAdContextRabbitExperiments(context);
 
-		// showcase.*
+		// *.showcase.wikia.com
 		if (cookies.get('mock-ads') === 'NlfdjR5xC0') {
 			context.opts.showcase = true;
 		}

--- a/extensions/wikia/AdEngine/js/spec/utils/AdLogicZoneParams.spec.js
+++ b/extensions/wikia/AdEngine/js/spec/utils/AdLogicZoneParams.spec.js
@@ -106,14 +106,6 @@ describe('ext.wikia.adEngine.utils.adLogicZoneParams', function () {
 		expect(zoneParams.getHostnamePrefix()).toBe('externaltest');
 	});
 
-	it('Hostname and domain for showcase.gta.wikia.com', function () {
-		setUpLocation('showcase.gta.wikia.com');
-		var zoneParams = getModule();
-
-		expect(zoneParams.getDomain()).toBe('wikiacom');
-		expect(zoneParams.getHostnamePrefix()).toBe('showcase');
-	});
-
 	it('Hostname and domain for gta.showcase.wikia.com', function () {
 		setUpLocation('gta.showcase.wikia.com');
 		var zoneParams = getModule();

--- a/extensions/wikia/RobotsTxt/tests/RobotsIntegrationTest.php
+++ b/extensions/wikia/RobotsTxt/tests/RobotsIntegrationTest.php
@@ -6,7 +6,7 @@
  * @group SeoIntegration
  */
 class RobotsIntegrationTest extends WikiaBaseTest {
-	const SHOWCASE_ADTEST_PAGE_LINK = 'http://showcase.adtest.wikia.com/wiki/Wikia_Ad_Testing';
+	const SHOWCASE_ADTEST_PAGE_LINK = 'http://adtest.showcase.wikia.com/wiki/Wikia_Ad_Testing';
 	const ADTEST_PAGE_LINK = 'http://adtest.wikia.com/wiki/Wikia_Ad_Testing';
 	const NO_INDEX_NO_FOLLOW = '<meta name="robots" content="noindex,nofollow" />';
 	const NO_INDEX_FOLLOW = '<meta name="robots" content="noindex,follow" />';

--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -1104,7 +1104,7 @@ class Wikia {
 		$stagingHeader = $request->getHeader('X-Staging');
 
 		if( !empty($stagingHeader) ) {
-			// we've got special cases like externaltest.* and showcase.* aliases:
+			// we've got special cases like *.externaltest.wikia.com and *.showcase.wikia.com aliases:
 			// https://github.com/Wikia/wikia-vcl/blob/master/wikia.com/control-stage.vcl#L15
 			// those cases for backend look like production,
 			// therefore we don't want to base only on environment variables


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-3482

Update tests and comments after we removed the old `showcase.* / externaltest.*` format from VCL.

@Wikia/core-platform-team @Wikia/adeng 