### PR TITLE
XW-5224 | Prevent PHP Notice: Trying to get property of non-object in WallNotifications

### DIFF
--- a/extensions/wikia/WallNotifications/WallNotificationEntity.class.php
+++ b/extensions/wikia/WallNotifications/WallNotificationEntity.class.php
@@ -98,7 +98,6 @@ class WallNotificationEntity {
 		$key = self::getMemcKey( $id );
 		$data = F::app()->wg->Memc->get( $key );
 
-		var_dump("WallNotificationEntity::getById", $data);
 		if ( empty( $data ) ) {
 			return self::createFromId( $id );
 		} else {
@@ -162,7 +161,6 @@ class WallNotificationEntity {
 			$this->threadTitleFull = $response['threadTitleFull'];
 			$this->data = (object) $response['data'];
 
-			var_dump("WallNotificationEntity::loadDataFromRevIdOnWiki", $this->data);
 			return true;
 		}
 

--- a/extensions/wikia/WallNotifications/WallNotificationEntity.class.php
+++ b/extensions/wikia/WallNotifications/WallNotificationEntity.class.php
@@ -98,6 +98,7 @@ class WallNotificationEntity {
 		$key = self::getMemcKey( $id );
 		$data = F::app()->wg->Memc->get( $key );
 
+		var_dump("WallNotificationEntity::getById", $data);
 		if ( empty( $data ) ) {
 			return self::createFromId( $id );
 		} else {
@@ -161,6 +162,7 @@ class WallNotificationEntity {
 			$this->threadTitleFull = $response['threadTitleFull'];
 			$this->data = $response['data'];
 
+			var_dump("WallNotificationEntity::loadDataFromRevIdOnWiki", $this->data);
 			return true;
 		}
 

--- a/extensions/wikia/WallNotifications/WallNotificationEntity.class.php
+++ b/extensions/wikia/WallNotifications/WallNotificationEntity.class.php
@@ -159,6 +159,8 @@ class WallNotificationEntity {
 			$this->parentTitleDbKey = $response['parentTitleDbKey'];
 			$this->msgText = $response['msgText'];
 			$this->threadTitleFull = $response['threadTitleFull'];
+			// The data property is treated in further processing as an object but HTTP response contains it in form of
+			// array, therefore casting is needed here
 			$this->data = (object) $response['data'];
 
 			return true;

--- a/extensions/wikia/WallNotifications/WallNotificationEntity.class.php
+++ b/extensions/wikia/WallNotifications/WallNotificationEntity.class.php
@@ -160,7 +160,7 @@ class WallNotificationEntity {
 			$this->parentTitleDbKey = $response['parentTitleDbKey'];
 			$this->msgText = $response['msgText'];
 			$this->threadTitleFull = $response['threadTitleFull'];
-			$this->data = $response['data'];
+			$this->data = (object) $response['data'];
 
 			var_dump("WallNotificationEntity::loadDataFromRevIdOnWiki", $this->data);
 			return true;


### PR DESCRIPTION
The WallNotificationEntity::data property is treated as an stdClass object later in the code, but when making request for data from other wiki, array is returned. Casting to object should fix `PHP Notice: Trying to get property of non-object` notices

https://wikia-inc.atlassian.net/browse/XW-5224
https://wikia-inc.atlassian.net/browse/XW-5243

@Wikia/x-wing 
@Wikia/sus 