### PR TITLE
SUS-5531 | generate YAML file with cron jobs in Jenkins and apply it when making a code deploy

### DIFF
--- a/docker/prod/Jenkinsfile
+++ b/docker/prod/Jenkinsfile
@@ -130,9 +130,18 @@ EOL""")
         withDockerContainer(kubectlImage) {
             sh "kubectl --context ${k8sContext} -n ${environment} apply -f app/docker/prod/k8s.yaml"
             rolloutStatus = sh(returnStatus: true, script: "kubectl --context ${k8sContext} -n ${environment} rollout status deployment/mediawiki-'${environment}'")
+        }
+    }
 
+    stage("Apply cron jobs") {
+        dir("app") {
             // SUS-5531 - apply cron jobs via auto-generated YAML file
-            sh "cd app/docker/maintenance && bash cronjobs-generator.sh ${imageTag} | kubectl --context ${k8sContext} -n ${environment} apply -f -"
+            sh("cd docker/maintenance && bash cronjobs-generator.sh ${imageTag} > ../prod/k8s-cronjobs.yaml")
+            sh("cat docker/prod/k8s-cronjobs.yaml")
+        }
+
+        withDockerContainer(kubectlImage) {
+            sh "kubectl --context ${k8sContext} -n ${environment} apply -f app/docker/prod/k8s-cronjobs.yaml"
         }
     }
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5531

Instead of inside kubectlImage container:

```
[sus-mediawiki-deploy-prod-pipeline] Running shell script
+ cd app/docker/maintenance
+ bash cronjobs-generator.sh 00d27a0b754.a4b2b200
+ kubectl --context kube-sjc-prod -n prod apply -f -
create-cronjob-yaml.sh: line 13: ruby: command not found
create-cronjob-yaml.sh: line 23: jq: command not found
```

Tested in http://jenkins:8080/job/sus-mediawiki-deploy-prod-pipeline/110/console:

```
[sus-mediawiki-deploy-prod-pipeline] Running shell script
+ kubectl --context kube-sjc-prod -n prod apply -f app/docker/prod/k8s-cronjobs.yaml
cronjob.batch "mw-cj-cleanup-notifications-queue" configured
cronjob.batch "mw-cj-cleanup-phalanx-stats" configured
cronjob.batch "mw-cj-cleanup-upload-stash" configured
cronjob.batch "mw-cj-cleanup-wall-notifications" configured
cronjob.batch "mw-cj-cleanup-wikia-shared-talk" configured
...
```