### PR TITLE
SUS-5660 | remove wgWikiFactoryRedirectForAlternateDomains

### DIFF
--- a/extensions/wikia/WikiFactory/tests/WikiFactoryLoaderIntegrationTest.php
+++ b/extensions/wikia/WikiFactory/tests/WikiFactoryLoaderIntegrationTest.php
@@ -111,7 +111,7 @@ class WikiFactoryLoaderIntegrationTest extends WikiaDatabaseTest {
 	public function testRedirectsToPrimaryDomainWhenAlternativeDomainUsed(
 		string $expectedRedirect, array $server
 	) {
-		$this->mockGlobalVariable( 'wgWikiFactoryRedirectForAlternateDomains', true );
+		$this->mockGlobalVariable( 'wgWikiaEnvironment', WIKIA_ENV_PROD );
 		$this->mockGlobalVariable( 'wgDevelEnvironment', false );
 
 		$wikiFactoryLoader = new WikiFactoryLoader( $server, [], [ 'wikicities.com' ] );

--- a/includes/wikia/VariablesBase.php
+++ b/includes/wikia/VariablesBase.php
@@ -8779,14 +8779,6 @@ $wgWikiFactoryDomains = [
 ];
 
 /**
- * Whether WikiFactoryLoader should serve an HTTP 301 response redirecting to the primary domain of the wiki
- * if it received a request with one of the mapped alternative domains.
- * @see $wgWikiFactoryDomains
- * @var bool $wgWikiFactoryRedirectForAlternateDomains
- */
-$wgWikiFactoryRedirectForAlternateDomains = true;
-
-/**
  * Do not allow editing articles from these namespaces with Rich Text Editor.
  * @see extensions/wikia/RTE
  * @var Array $wgWysiwygDisabledNamespaces


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5660

After the recent Platform team changes `wgWikiFactoryRedirectForAlternateDomains` is no longer needed.