### PR TITLE
MAIN-17488 | Category Exhibition switch fixes

### DIFF
--- a/extensions/wikia/CategoryExhibition/css/CategoryExhibition.scss
+++ b/extensions/wikia/CategoryExhibition/css/CategoryExhibition.scss
@@ -16,11 +16,7 @@ $color: #000;
 
 $color-inctive-button: mix($color-page, #000, 60%);
 @if lightness($color-page) < 50 {
-	$color-inctive-button: lighten($color-inctive-button, 25%);
-}
-
-@if lightness($color-page) < 80 {
-	$color: lighten($color, 20%);
+	$color-inctive-button: mix($color-page, #fff, 60%);
 }
 
 .category-gallery-form {
@@ -28,6 +24,7 @@ $color-inctive-button: mix($color-page, #000, 60%);
 	text-align: right;
 
 	a {
+		text-decoration: none;
 		vertical-align: middle;
 	}
 


### PR DESCRIPTION
Credit to [JustLeafy](https://dev.wikia.com/wiki/User:JustLeafy) of Dev Wiki for this fix. :smiley: 

Note: fixes two visual issues in Category Exhibition:
* hovering on the switch link shows an underline
* inactive color is too dark on dark wikis