### PR TITLE
SUS-5782 | introduce CleanupCityCreationLog maintenance script 

### DIFF
--- a/docker/maintenance/cleanup-city-creation-log.yaml
+++ b/docker/maintenance/cleanup-city-creation-log.yaml
@@ -1,0 +1,4 @@
+schedule: "15 8 * * *"
+args:
+- php
+- extensions/wikia/CreateNewWiki/maintenance/cleanupCityCreationLog.php

--- a/docker/maintenance/cleanup-city-creation-log.yaml
+++ b/docker/maintenance/cleanup-city-creation-log.yaml
@@ -1,4 +1,4 @@
 schedule: "15 8 * * *"
 args:
 - php
-- extensions/wikia/CreateNewWiki/maintenance/cleanupCityCreationLog.php
+- /usr/wikia/slot1/current/src/extensions/wikia/CreateNewWiki/maintenance/cleanupCityCreationLog.php

--- a/docker/maintenance/cleanup-phalanx-stats.yaml
+++ b/docker/maintenance/cleanup-phalanx-stats.yaml
@@ -1,4 +1,4 @@
 schedule: "15 9 * * 3"
 args:
 - php
-- extensions/wikia/PhalanxII/maintenance/cleanupPhalanxStats.php
+- /usr/wikia/slot1/current/src/extensions/wikia/PhalanxII/maintenance/cleanupPhalanxStats.php

--- a/docker/maintenance/send-confirmation-reminder.yaml
+++ b/docker/maintenance/send-confirmation-reminder.yaml
@@ -1,4 +1,4 @@
 schedule: "45 7 * * *"
 args:
 - php
-- extensions/wikia/AuthPages/maintenance/sendConfirmationReminder.php
+- /usr/wikia/slot1/current/src/extensions/wikia/AuthPages/maintenance/sendConfirmationReminder.php

--- a/docker/maintenance/send-weekly-digest.yaml
+++ b/docker/maintenance/send-weekly-digest.yaml
@@ -1,4 +1,4 @@
 schedule: "6 0 * * 0"
 args:
 - php
-- maintenance/wikia/cronjobs/sendWeeklyDigest.php
+- /usr/wikia/slot1/current/src/maintenance/wikia/cronjobs/sendWeeklyDigest.php

--- a/extensions/wikia/CreateNewWiki/maintenance/cleanupCityCreationLog.php
+++ b/extensions/wikia/CreateNewWiki/maintenance/cleanupCityCreationLog.php
@@ -11,12 +11,15 @@
  */
 
 require_once __DIR__ . '/../../../../maintenance/Maintenance.php';
-require_once __DIR__ . '/../CreateNewWiki_setup.php';
 
 class CleanupCityCreationLog extends Maintenance {
 
 	public function execute() {
-		global $wgExternalSharedDB;
+		global $wgExternalSharedDB, $wgAutoloadClasses;
+
+		// we need to do this here, when MediaWiki autoloader is fully set up
+		require_once __DIR__ . '/../CreateNewWiki_setup.php';
+
 		$db = wfGetDB( DB_MASTER, [], $wgExternalSharedDB );
 
 		$db->delete(

--- a/extensions/wikia/CreateNewWiki/maintenance/cleanupCityCreationLog.php
+++ b/extensions/wikia/CreateNewWiki/maintenance/cleanupCityCreationLog.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Script that removes wikicities.city_creation_log entries that are older than 30 days
+ *
+ * @see SUS-5782
+ * @see SUS-4383
+ * @author macbre
+ * @file
+ * @ingroup Maintenance
+ */
+
+require_once __DIR__ . '/../../../../maintenance/Maintenance.php';
+require_once __DIR__ . '/../CreateNewWiki_setup.php';
+
+class CleanupCityCreationLog extends Maintenance {
+
+	public function execute() {
+		global $wgExternalSharedDB;
+		$db = wfGetDB( DB_MASTER, [], $wgExternalSharedDB );
+
+		$db->delete(
+			CreateWikiTask::CREATION_LOG_TABLE,
+			[
+				'creation_started < NOW() - INTERVAL 30 DAY'
+			],
+			__METHOD__
+		);
+
+		$this->output( sprintf(
+			"Count of rows dropped from city_creation_log table: %d\n",
+			$db->affectedRows()
+		) );
+	}
+}
+
+$maintClass = CleanupCityCreationLog::class;
+require_once( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/Maintenance.php
+++ b/maintenance/Maintenance.php
@@ -113,6 +113,7 @@ abstract class Maintenance {
 	private $mDb = null;
 
 	// Wikia change
+	/* @var Wikia\Logger\WikiaLogger */
 	protected $mLogger = null;
 
 	/**


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5782

`index-digest` reports that `city_creation_log` has rows added 90 days ago, consider changing retention policy

```yaml
 "rows": 48190, 
 "data_since": "2018-06-06 11:35:17", 
 "diff_days": 90, 
 "date_column_name": "creation_started", 
 "table_size_mb": 8.03125, 
 "data_until": "2018-09-04 11:35:22", 
```

This script will periodically remove entries older than 30 days.

Tested on `cron-s1`:

```
$ SERVER_ID=177 php extensions/wikia/CreateNewWiki/maintenance/cleanupCityCreationLog.php
Count of rows dropped from city_creation_log table: 30233
```

```sql
mysql@geo-db-sharedb-slave.query.consul[wikicities]>select min(creation_started) from city_creation_log;
+-----------------------+
| min(creation_started) |
+-----------------------+
| 2018-08-06 10:58:25   |
+-----------------------+
1 row in set (0.00 sec)
```