### PR TITLE
SUS-5786 | remove hostname entry from wgTransactionContext

### DIFF
--- a/includes/wikia/transaction/Transaction.php
+++ b/includes/wikia/transaction/Transaction.php
@@ -19,7 +19,6 @@ class Transaction {
 
 	// Parameters
 	const PARAM_ENVIRONMENT = 'env';
-	const PARAM_HOSTNAME = 'hostname';
 	const PARAM_PHP_VERSION = 'php_version';
 	const PARAM_ENTRY_POINT = 'entry_point';
 	const PARAM_LOGGED_IN = 'logged_in';
@@ -71,7 +70,6 @@ class Transaction {
 				new TransactionTraceNewrelic(),
 			) );
 			$instance->set( self::PARAM_ENVIRONMENT, $wgWikiaEnvironment );
-			$instance->set( self::PARAM_HOSTNAME, wfHostname() );
 			$instance->set( self::PARAM_PHP_VERSION, explode( '-', phpversion() )[0] ); // report "5.4.17-1~precise+1" as "5.4.17"
 		}
 		return $instance;


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5786

This generates misleading differences between response from Apaches and Kubernetes cluster. And is useless for responses cached on CDN level.

## Variable after this change

```js
wgTransactionContext={"type":"page/file","env":"dev","php_version":"7.0.27","wiki":"plpoznan","entry_point":"page","namespace":6,"logged_in":false,"action":"view","skin":"oasis","parser_cache_used":true,"size_category":"simple"};
```