### PR TITLE
Expose fpm metrics for mediawiki-tasks

### DIFF
--- a/docker/prod/prod.template.yaml
+++ b/docker/prod/prod.template.yaml
@@ -310,7 +310,12 @@ spec:
   ports:
     - protocol: TCP
       port: 80
+      name: main
       targetPort: 8080
+    - protocol: TCP
+      port: 9253
+      name: metrics
+      targetPort: 9253
 ---
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler


### PR DESCRIPTION
Fixed service definition for `mediawiki-tasks` so that we can get FPM metrics.