### PR TITLE
SUS-5797 add default cookie value

### DIFF
--- a/extensions/wikia/DataWarehouse/DataWarehouseEventProducer.class.php
+++ b/extensions/wikia/DataWarehouse/DataWarehouseEventProducer.class.php
@@ -30,7 +30,7 @@ class DataWarehouseEventProducer {
 				$this->mKey = self::UNDELETE_CATEGORY;
 				break;
 		}
-		$geo = json_decode( RequestContext::getMain()->getRequest()->getCookie( 'Geo', '' ) );
+		$geo = json_decode( RequestContext::getMain()->getRequest()->getCookie( 'Geo', '', '{}' ) );
 		$this->setCityId( $this->app->wg->CityId );
 		$this->setServerName( $this->app->wg->Server );
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5797

`DataWarehouseEventProducer` doesn't have geo information when invoked through a celery task. This change simply sets a default value for the cookie to avoid PHP notice logs.