### PR TITLE
XF-363 | Do not use ArticleAsJson for rendering infoboxes on Desktop

### DIFF
--- a/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php
+++ b/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php
@@ -1,7 +1,6 @@
 <?php
 
 class ArticleAsJson {
-	static $media = [ ];
 	static $heroImage = null;
 	static $mediaDetailConfig = [
 		'imageMaxWidth' => false
@@ -363,8 +362,6 @@ class ArticleAsJson {
 				$media[] = $mediaObj;
 			}
 
-			self::$media[] = $media;
-
 			if ( !empty( $media ) ) {
 				$out = self::createMarker( $media, true );
 			} else {
@@ -379,13 +376,12 @@ class ArticleAsJson {
 		return true;
 	}
 
-	public static function onExtendPortableInfoboxImageData( $data, &$ref, &$dataAttrs ) {
+	public static function onExtendPortableInfoboxImageData( $data, &$dataAttrs ) {
 		$title = Title::newFromText( $data['name'] );
 		if ( $title ) {
 			$details = self::getMediaDetailWithSizeFallback( $title, self::$mediaDetailConfig );
 			$details['context'] = $data['context'];
 			$mediaObj = self::createMediaObject( $details, $title->getText(), $data['caption'] );
-			self::$media[] = $mediaObj;
 			$dataAttrs = $mediaObj;
 
 			if ( $details['context'] == 'infobox-hero-image' && empty( self::$heroImage ) ) {
@@ -424,8 +420,6 @@ class ArticleAsJson {
 				self::$heroImage['thumbnail1by1'] = $thumbnail1by1;
 				self::$heroImage['thumbnail1by1Size'] = PortableInfoboxMobileRenderService::MOBILE_THUMBNAIL_WIDTH;
 			}
-
-			$ref = count( self::$media ) - 1;
 		}
 
 		return true;
@@ -469,8 +463,6 @@ class ArticleAsJson {
 			$media = self::createMediaObject( $details, $title->getText(), $caption, $linkHref );
 			$media['srcset'] = self::getSrcset( $media['url'], intval( $media['width'] ) );
 			$media['thumbnail'] = self::getThumbnailUrlForWidth( $media['url'], 340 );
-
-			self::$media[] = $media;
 
 			$res = self::createMarker( $media );
 
@@ -529,9 +521,6 @@ class ArticleAsJson {
 		global $wgArticleAsJson;
 
 		if ( $wgArticleAsJson && !is_null( $parser->getRevisionId() ) ) {
-			foreach ( self::$media as &$media ) {
-				self::linkifyMediaCaption( $parser, $media );
-			}
 
 			Hooks::run( 'ArticleAsJsonBeforeEncode', [ &$text ] );
 

--- a/extensions/wikia/PortableInfobox/services/Helpers/PortableInfoboxImagesHelper.php
+++ b/extensions/wikia/PortableInfobox/services/Helpers/PortableInfoboxImagesHelper.php
@@ -56,10 +56,6 @@ class PortableInfoboxImagesHelper {
 		if ( !$thumbnail || $thumbnail->isError() || !$thumbnail2x || $thumbnail2x->isError() ) {
 			return false;
 		}
-		$ref = null;
-
-		$dataAttrs = [];
-		\Hooks::run( 'PortableInfoboxRenderServiceHelper::extendImageData', [ $data, &$ref, &$dataAttrs ] );
 
 		return array_merge( $data, [
 			'height' => intval( $imgTagDimensions['height'] ),
@@ -83,8 +79,6 @@ class PortableInfoboxImagesHelper {
 			return false;
 		}
 
-		$ref = null;
-
 		$thumbnail = $file->getUrlGenerator()
 			->zoomCrop()
 			->width($width)
@@ -98,7 +92,7 @@ class PortableInfoboxImagesHelper {
 			->url();
 
 		$dataAttrs = [];
-		\Hooks::run( 'PortableInfoboxRenderServiceHelper::extendImageData', [ $data, &$ref, &$dataAttrs ] );
+		\Hooks::run( 'PortableInfoboxRenderServiceHelper::extendImageData', [ $data, &$dataAttrs ] );
 
 		return array_merge( $data, [
 			'height' => $width,
@@ -122,16 +116,14 @@ class PortableInfoboxImagesHelper {
 			return false;
 		}
 
-		$ref = null;
 		$dataAttrs = [];
-		\Hooks::run( 'PortableInfoboxRenderServiceHelper::extendImageData', [ $data, &$ref, &$dataAttrs ] );
+		\Hooks::run( 'PortableInfoboxRenderServiceHelper::extendImageData', [ $data, &$dataAttrs ] );
 
 		$thumbnail = $file->getUrlGenerator()
 			->scaleToWidth($width)
 			->url();
 
 		$thumbnail2x = $file->getUrlGenerator()
-			->zoomCrop()
 			->scaleToWidth($width * 2)
 			->url();
 

--- a/extensions/wikia/PortableInfobox/services/Helpers/PortableInfoboxImagesHelper.php
+++ b/extensions/wikia/PortableInfobox/services/Helpers/PortableInfoboxImagesHelper.php
@@ -62,15 +62,12 @@ class PortableInfoboxImagesHelper {
 		\Hooks::run( 'PortableInfoboxRenderServiceHelper::extendImageData', [ $data, &$ref, &$dataAttrs ] );
 
 		return array_merge( $data, [
-			'ref' => $ref,
 			'height' => intval( $imgTagDimensions['height'] ),
 			'width' => intval( $imgTagDimensions['width'] ),
 			'thumbnail' => $thumbnail->getUrl(),
 			'thumbnail2x' => $thumbnail2x->getUrl(),
 			'key' => urlencode( $data['key'] ?? '' ),
 			'media-type' => isset( $data['isVideo'] ) && $data['isVideo'] ? 'video' : 'image',
-			'fileName' => $dataAttrs['fileName'] ?? '',
-			'dataAttrs' => json_encode( $dataAttrs )
 		] );
 	}
 
@@ -104,7 +101,6 @@ class PortableInfoboxImagesHelper {
 		\Hooks::run( 'PortableInfoboxRenderServiceHelper::extendImageData', [ $data, &$ref, &$dataAttrs ] );
 
 		return array_merge( $data, [
-			'ref' => $ref,
 			'height' => $width,
 			'width' => $height,
 			'thumbnail' => $thumbnail,
@@ -142,7 +138,6 @@ class PortableInfoboxImagesHelper {
 			->url();
 
 		return array_merge( $data, [
-			'ref' => $ref,
 			'height' => $dataAttrs['height'],
 			'width' => $dataAttrs['width'],
 			'thumbnail' => $thumbnail,
@@ -159,6 +154,28 @@ class PortableInfoboxImagesHelper {
 	 * @return array
 	 */
 	public function extendImageCollectionData( $images ) {
+		$images = array_map(
+			function ( $image, $index ) {
+				$image['dataRef'] = $index;
+
+				return $image;
+			},
+			$images,
+			array_keys($images)
+		);
+
+		$images[0]['isFirst'] = true;
+		$images[count($images) - 1]['isLast'] = true;
+		return [
+			'images' => $images,
+		];
+	}
+
+	/**
+	 * @param array $images
+	 * @return array
+	 */
+	public function extendMobileImageCollectionData( $images ) {
 		$dataAttrs = array_map(
 			function ( $image ) {
 				return json_decode( $image['dataAttrs'] );
@@ -180,9 +197,7 @@ class PortableInfoboxImagesHelper {
 		$images[count($images) - 1]['isLast'] = true;
 		return [
 			'images' => $images,
-			'firstImage' => $images[0],
 			'dataAttrs' => json_encode( $dataAttrs ),
-			'menuControlIcon' => \DesignSystemHelper::renderSvg('wds-icons-menu-control', 'wds-icon') // TODO: clean it after premium layout released on mobile wiki and icache expired
 		];
 	}
 

--- a/extensions/wikia/PortableInfobox/services/Helpers/PortableInfoboxImagesHelper.php
+++ b/extensions/wikia/PortableInfobox/services/Helpers/PortableInfoboxImagesHelper.php
@@ -65,8 +65,6 @@ class PortableInfoboxImagesHelper {
 			'ref' => $ref,
 			'height' => intval( $imgTagDimensions['height'] ),
 			'width' => intval( $imgTagDimensions['width'] ),
-			'originalHeight' => $dataAttrs['height'] ?? '',
-			'originalWidth' => $dataAttrs['width'] ?? '',
 			'thumbnail' => $thumbnail->getUrl(),
 			'thumbnail2x' => $thumbnail2x->getUrl(),
 			'key' => urlencode( $data['key'] ?? '' ),

--- a/extensions/wikia/PortableInfobox/services/Helpers/PortableInfoboxImagesHelper.php
+++ b/extensions/wikia/PortableInfobox/services/Helpers/PortableInfoboxImagesHelper.php
@@ -105,8 +105,6 @@ class PortableInfoboxImagesHelper {
 			'width' => $height,
 			'thumbnail' => $thumbnail,
 			'thumbnail2x' => $thumbnail2x,
-			'key' => urlencode( $data['key'] ?? '' ),
-			'media-type' => isset( $data['isVideo'] ) && $data['isVideo'] ? 'video' : 'image',
 			'fileName' => $dataAttrs['fileName'] ?? '',
 			'dataAttrs' => json_encode( $dataAttrs )
 		] );
@@ -142,8 +140,6 @@ class PortableInfoboxImagesHelper {
 			'width' => $dataAttrs['width'],
 			'thumbnail' => $thumbnail,
 			'thumbnail2x' => $thumbnail2x,
-			'key' => urlencode( $data['key'] ?? '' ),
-			'media-type' => isset( $data['isVideo'] ) && $data['isVideo'] ? 'video' : 'image',
 			'fileName' => $dataAttrs['fileName'] ?? '',
 			'dataAttrs' => json_encode( $dataAttrs )
 		] );

--- a/extensions/wikia/PortableInfobox/services/Helpers/PortableInfoboxImagesHelper.php
+++ b/extensions/wikia/PortableInfobox/services/Helpers/PortableInfoboxImagesHelper.php
@@ -165,7 +165,6 @@ class PortableInfoboxImagesHelper {
 		);
 
 		$images[0]['isFirst'] = true;
-		$images[count($images) - 1]['isLast'] = true;
 		return [
 			'images' => $images,
 		];
@@ -193,8 +192,6 @@ class PortableInfoboxImagesHelper {
 			array_keys($images)
 		);
 
-		$images[0]['isFirst'] = true;
-		$images[count($images) - 1]['isLast'] = true;
 		return [
 			'images' => $images,
 			'dataAttrs' => json_encode( $dataAttrs ),

--- a/extensions/wikia/PortableInfobox/services/Parser/Nodes/NodeImage.php
+++ b/extensions/wikia/PortableInfobox/services/Parser/Nodes/NodeImage.php
@@ -33,15 +33,14 @@ class NodeImage extends Node {
 
 	public static function getTabberData( $html ) {
 		global $wgArticleAsJson;
+
 		$data = array();
 		$doc = HtmlHelper::createDOMDocumentFromText( $html );
 		$sxml = simplexml_import_dom( $doc );
 		$divs = $sxml->xpath( '//div[@class=\'tabbertab\']' );
 		foreach ( $divs as $div ) {
 			if ( $wgArticleAsJson ) {
-				if ( preg_match( '/data-ref="([^"]+)"/', $div->asXML(), $out ) ) {
-					$data[] = array( 'label' => (string) $div['title'], 'title' => \ArticleAsJson::$media[$out[1]]['title'] );
-				}
+				// TODO: fix it, it did not work on mobile
 			} else {
 				if ( preg_match( '/data-(video|image)-key="([^"]+)"/', $div->asXML(), $out ) ) {
 					$data[] = array( 'label' => (string) $div['title'], 'title' => $out[2] );

--- a/extensions/wikia/PortableInfobox/services/Parser/Nodes/NodeImage.php
+++ b/extensions/wikia/PortableInfobox/services/Parser/Nodes/NodeImage.php
@@ -34,19 +34,23 @@ class NodeImage extends Node {
 	public static function getTabberData( $html ) {
 		global $wgArticleAsJson;
 
-		$data = array();
+		$data = [];
 		$doc = HtmlHelper::createDOMDocumentFromText( $html );
 		$sxml = simplexml_import_dom( $doc );
 		$divs = $sxml->xpath( '//div[@class=\'tabbertab\']' );
 		foreach ( $divs as $div ) {
 			if ( $wgArticleAsJson ) {
-				// TODO: fix it, it did not work on mobile
+				$figures = $div->xpath( './/figure[@data-file]' );
+				if ( count( $figures ) > 0 ) {
+					$data[] = [ 'label' => (string) $div['title'], 'title' => (string) $figures[0]['data-file'] ];
+				}
 			} else {
 				if ( preg_match( '/data-(video|image)-key="([^"]+)"/', $div->asXML(), $out ) ) {
-					$data[] = array( 'label' => (string) $div['title'], 'title' => $out[2] );
+					$data[] = [ 'label' => (string) $div['title'], 'title' => $out[2] ];
 				}
 			}
 		}
+
 		return $data;
 	}
 

--- a/extensions/wikia/PortableInfobox/services/PortableInfoboxMobileRenderService.class.php
+++ b/extensions/wikia/PortableInfobox/services/PortableInfoboxMobileRenderService.class.php
@@ -102,7 +102,7 @@ class PortableInfoboxMobileRenderService extends PortableInfoboxRenderService {
 				$templateName = 'image-mobile';
 			} else {
 				// more than one image means image collection
-				$data = $helper->extendImageCollectionData( $images );
+				$data = $helper->extendMobileImageCollectionData( $images );
 				$templateName = 'image-collection-mobile';
 			}
 		}

--- a/extensions/wikia/PortableInfobox/services/PortableInfoboxMobileRenderService.class.php
+++ b/extensions/wikia/PortableInfobox/services/PortableInfoboxMobileRenderService.class.php
@@ -108,7 +108,7 @@ class PortableInfoboxMobileRenderService extends PortableInfoboxRenderService {
 		}
 
 		$data = SanitizerBuilder::createFromType( 'image' )->sanitize( $data );
-ddd($data);
+
 		return parent::render( $templateName, $data );
 	}
 

--- a/extensions/wikia/PortableInfobox/services/PortableInfoboxMobileRenderService.class.php
+++ b/extensions/wikia/PortableInfobox/services/PortableInfoboxMobileRenderService.class.php
@@ -108,7 +108,7 @@ class PortableInfoboxMobileRenderService extends PortableInfoboxRenderService {
 		}
 
 		$data = SanitizerBuilder::createFromType( 'image' )->sanitize( $data );
-
+ddd($data);
 		return parent::render( $templateName, $data );
 	}
 

--- a/extensions/wikia/PortableInfobox/templates/PortableInfoboxItemHeroMobileWikiaMobile.mustache
+++ b/extensions/wikia/PortableInfobox/templates/PortableInfoboxItemHeroMobileWikiaMobile.mustache
@@ -9,8 +9,8 @@
 	{{/title}}
 	{{#image}}
 		<img src="data:image/gif;base64,R0lGODlhAQABAIABAAAAAP///yH5BAEAAAEALAAAAAABAAEAQAICTAEAOw%3D%3D"
-			 data-src="{{thumbnail}}" class="pi-image-thumbnail lazy media article-media" alt="{{alt}}"
-			 data-image-key="{{name}}" data-image-name="{{name}}"
+			 data-src="{{thumbnail}}" class="pi-image-thumbnail lazy media article-media" alt="{{fileName}}"
+			 data-image-key="{{fileName}}" data-image-name="{{fileName}}"
 			 data-params='[{"name":"{{name}}", "full":"{{url}}"}]'/>
 	{{/image}}
 </div>

--- a/extensions/wikia/PortableInfobox/templates/PortableInfoboxItemHeroMobileWikiaMobile.mustache
+++ b/extensions/wikia/PortableInfobox/templates/PortableInfoboxItemHeroMobileWikiaMobile.mustache
@@ -10,7 +10,7 @@
 	{{#image}}
 		<img src="data:image/gif;base64,R0lGODlhAQABAIABAAAAAP///yH5BAEAAAEALAAAAAABAAEAQAICTAEAOw%3D%3D"
 			 data-src="{{thumbnail}}" class="pi-image-thumbnail lazy media article-media" alt="{{alt}}"
-			 data-image-key="{{name}}" data-image-name="{{name}}" data-ref="{{ref}}"
+			 data-image-key="{{name}}" data-image-name="{{name}}"
 			 data-params='[{"name":"{{name}}", "full":"{{url}}"}]'/>
 	{{/image}}
 </div>

--- a/extensions/wikia/PortableInfobox/templates/PortableInfoboxItemHeroMobileWikiaMobile.mustache
+++ b/extensions/wikia/PortableInfobox/templates/PortableInfoboxItemHeroMobileWikiaMobile.mustache
@@ -11,6 +11,6 @@
 		<img src="data:image/gif;base64,R0lGODlhAQABAIABAAAAAP///yH5BAEAAAEALAAAAAABAAEAQAICTAEAOw%3D%3D"
 			 data-src="{{thumbnail}}" class="pi-image-thumbnail lazy media article-media" alt="{{fileName}}"
 			 data-image-key="{{fileName}}" data-image-name="{{fileName}}"
-			 data-params='[{"name":"{{name}}", "full":"{{url}}"}]'/>
+			 data-params='[{"name":"{{fileName}}", "full":"{{url}}"}]'/>
 	{{/image}}
 </div>

--- a/extensions/wikia/PortableInfobox/templates/PortableInfoboxItemImageCollection.mustache
+++ b/extensions/wikia/PortableInfobox/templates/PortableInfoboxItemImageCollection.mustache
@@ -1,13 +1,13 @@
 <div class="pi-image-collection">
 	<ul class="pi-image-collection-tabs">
-		{{#images}}<li class="pi-tab-link pi-item-spacing {{#isFirst}}current{{/isFirst}}" data-pi-tab="pi-tab-{{ref}}">
+		{{#images}}<li class="pi-tab-link pi-item-spacing {{#isFirst}}current{{/isFirst}}" data-pi-tab="pi-tab-{{dataRef}}">
 			{{#caption}}{{{caption}}}{{/caption}}
 			{{^caption}}{{name}}{{/caption}}
 		</li>{{/images}}
 	</ul>
 
 	{{#images}}
-		<div class="pi-image-collection-tab-content {{#isFirst}}current{{/isFirst}}" id="pi-tab-{{ref}}">
+		<div class="pi-image-collection-tab-content {{#isFirst}}current{{/isFirst}}" id="pi-tab-{{dataRef}}">
 			<figure class="pi-item pi-image">
 				<a href="{{url}}" class="image image-thumbnail {{#isVideo}} video video-thumbnail small{{/isVideo}}" title="{{alt}}">
 					<img src="{{thumbnail}}" srcset="{{thumbnail}} 1x, {{thumbnail2x}} 2x" class="pi-image-thumbnail" alt="{{alt}}" width="{{{width}}}" height="{{{height}}}" data-{{media-type}}-key="{{name}}" data-{{media-type}}-name="{{name}}"/>

--- a/extensions/wikia/PortableInfobox/templates/PortableInfoboxItemImageCollectionMobileWikiaMobile.mustache
+++ b/extensions/wikia/PortableInfobox/templates/PortableInfoboxItemImageCollectionMobileWikiaMobile.mustache
@@ -1,6 +1,6 @@
 <div class="pi-item pi-hero">
 	<img src="data:image/gif;base64,R0lGODlhAQABAIABAAAAAP///yH5BAEAAAEALAAAAAABAAEAQAICTAEAOw%3D%3D"
-	     data-src="{{thumbnail}}" class="pi-image-thumbnail lazy media article-media" alt="{{alt}}"
-	     data-image-key="{{name}}" data-image-name="{{name}}" data-ref="{{ref}}"
-	     data-params='[{"name":"{{name}}", "full":"{{url}}"}]'/>
+	     data-src="{{thumbnail}}" class="pi-image-thumbnail lazy media article-media" alt="{{fileName}}"
+	     data-image-key="{{fileName}}" data-image-name="{{fileName}}"
+	     data-params='[{"name":"{{fileName}}", "full":"{{url}}"}]'/>
 </div>

--- a/extensions/wikia/PortableInfobox/templates/PortableInfoboxItemImageMobileWikiaMobile.mustache
+++ b/extensions/wikia/PortableInfobox/templates/PortableInfoboxItemImageMobileWikiaMobile.mustache
@@ -1,6 +1,6 @@
 <div class="pi-item pi-image">
 	<img src="data:image/gif;base64,R0lGODlhAQABAIABAAAAAP///yH5BAEAAAEALAAAAAABAAEAQAICTAEAOw%3D%3D"
-		 data-src="{{thumbnail}}" class="pi-image-thumbnail lazy media article-media" alt="{{alt}}"
-		 data-image-key="{{name}}" data-image-name="{{name}}" data-ref="{{ref}}"
-		 data-params='[{"name":"{{name}}", "full":"{{url}}"}]'/>
+		 data-src="{{thumbnail}}" class="pi-image-thumbnail lazy media article-media" alt="{{fileName}}"
+		 data-image-key="{{fileName}}" data-image-name="{{fileName}}"
+		 data-params='[{"name":"{{fileName}}", "full":"{{url}}"}]'/>
 </div>

--- a/extensions/wikia/PortableInfobox/tests/PortableInfoboxImagesHelperTest.php
+++ b/extensions/wikia/PortableInfobox/tests/PortableInfoboxImagesHelperTest.php
@@ -112,15 +112,12 @@ class PortableInfoboxImagesHelperTest extends WikiaBaseTest {
 	public function testCustomWidthLogic( $customWidth, $preferredWidth, $resultDimensions, $thumbnailDimensions, $thumbnail2xDimensions, $originalDimension ) {
 		$expected = [
 			'name' => 'test',
-			'ref' => null,
 			'thumbnail' => null,
 			'thumbnail2x' => null,
 			'key' => '',
 			'media-type' => 'image',
 			'width' => $resultDimensions[ 'width' ],
 			'height' => $resultDimensions[ 'height' ],
-			'fileName' => '',
-			'dataAttrs' => '[]'
 		];
 		$thumb = $this->getMockBuilder( 'ThumbnailImage' )
 			->disableOriginalConstructor()

--- a/extensions/wikia/PortableInfobox/tests/PortableInfoboxImagesHelperTest.php
+++ b/extensions/wikia/PortableInfobox/tests/PortableInfoboxImagesHelperTest.php
@@ -119,8 +119,6 @@ class PortableInfoboxImagesHelperTest extends WikiaBaseTest {
 			'media-type' => 'image',
 			'width' => $resultDimensions[ 'width' ],
 			'height' => $resultDimensions[ 'height' ],
-			'originalHeight' => '',
-			'originalWidth' => '',
 			'fileName' => '',
 			'dataAttrs' => '[]'
 		];

--- a/extensions/wikia/PortableInfobox/tests/PortableInfoboxMobileRenderServiceTest.php
+++ b/extensions/wikia/PortableInfobox/tests/PortableInfoboxMobileRenderServiceTest.php
@@ -159,7 +159,7 @@ class PortableInfoboxMobileRenderServiceTest extends WikiaBaseTest {
 									</hgroup>
 									<figure data-attrs="" data-file="">
 										<a href="http://image.jpg">
-										<img class="article-media-placeholder lazyload" src="data:image/svg+xml;charset=UTF-8,%3csvg xmlns=\'http://www.w3.org/2000/svg\' viewBox=\'-12 -12 48 48\' fill=\'%23fff\' width=\'400\' height=\'200\'%3e%3cg fill-rule=\'evenodd\'%3e%3cpath d=\'M3 4h18v8.737l-3.83-3.191a.916.916 0 0 0-1.282.108l-4.924 5.744-3.891-3.114a.92.92 0 0 0-1.146 0L3 14.626V4zm19-2H2a1 1 0 0 0-1 1v18a1 1 0 0 0 1 1h20a1 1 0 0 0 1-1V3a1 1 0 0 0-1-1z\'/%3e%3cpath d=\'M9 10c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2\'/%3e%3c/g%3e%3c/svg%3e" data-src="http://image.jpg" data-srcset="http://image.jpg, http://image2x.jpg 2x" data-sizes="auto" alt="SomeFile.jpg" width="400" height="200"/><noscript>
+										<img class="article-media-placeholder lazyload" src="data:image/svg+xml;charset=UTF-8,%3csvg xmlns=\'http://www.w3.org/2000/svg\' viewBox=\'-12 -12 48 48\' fill=\'%23fff\' width=\'400\' height=\'200\'%3e%3cg fill-rule=\'evenodd\'%3e%3cpath d=\'M3 4h18v8.737l-3.83-3.191a.916.916 0 0 0-1.282.108l-4.924 5.744-3.891-3.114a.92.92 0 0 0-1.146 0L3 14.626V4zm19-2H2a1 1 0 0 0-1 1v18a1 1 0 0 0 1 1h20a1 1 0 0 0 1-1V3a1 1 0 0 0-1-1z\'/%3e%3cpath d=\'M9 10c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2\'/%3e%3c/g%3e%3c/svg%3e" data-src="http://image.jpg" data-srcset="http://image.jpg, http://image2x.jpg 2x" data-sizes="auto" alt="" width="400" height="200"/><noscript>
 											<img src="http://image.jpg" alt="" width="400" height="200"/>
 										</noscript>
 										</a>
@@ -173,6 +173,7 @@ class PortableInfoboxMobileRenderServiceTest extends WikiaBaseTest {
 				'description' => 'Simple infobox with title, image and key-value pair',
 				'mockParams' => [
 					'extendImageData' => [
+						'url' => 'http://image.jpg',
 						'width' => '400',
 						'height' => '200',
 						'thumbnail' => 'http://image.jpg',
@@ -448,7 +449,7 @@ class PortableInfoboxMobileRenderServiceTest extends WikiaBaseTest {
 				'output' => '<aside class="portable-infobox pi-background">
 								<div class="pi-item pi-hero">
 									<img
-									src="data:image/gif;base64,R0lGODlhAQABAIABAAAAAP///yH5BAEAAAEALAAAAAABAAEAQAICTAEAOw%3D%3D" data-src="http://image.jpg" class="pi-image-thumbnail lazy media article-media" alt="someFile.jpg"  data-image-key="somefile.jpg" data-image-name="somefile.jpg" data-params=\'[{"name":"somefile.jpg", "full":"http://image.jpg"}]\' />
+									src="data:image/gif;base64,R0lGODlhAQABAIABAAAAAP///yH5BAEAAAEALAAAAAABAAEAQAICTAEAOw%3D%3D" data-src="http://image.jpg" class="pi-image-thumbnail lazy media article-media" alt="somefile.jpg"  data-image-key="somefile.jpg" data-image-name="somefile.jpg" data-params=\'[{"name":"somefile.jpg", "full":"http://image.jpg"}]\' />
 								</div>
 							</aside>',
 				'description' => 'WikiaMobile: Only image. Image is not small- should render hero.',

--- a/extensions/wikia/PortableInfobox/tests/PortableInfoboxMobileRenderServiceTest.php
+++ b/extensions/wikia/PortableInfobox/tests/PortableInfoboxMobileRenderServiceTest.php
@@ -159,8 +159,8 @@ class PortableInfoboxMobileRenderServiceTest extends WikiaBaseTest {
 									</hgroup>
 									<figure data-attrs="" data-file="">
 										<a href="http://image.jpg">
-										<img class="article-media-placeholder lazyload" src="data:image/svg+xml;charset=UTF-8,%3csvg xmlns=\'http://www.w3.org/2000/svg\' viewBox=\'-12 -12 48 48\' fill=\'%23fff\' width=\'400\' height=\'200\'%3e%3cg fill-rule=\'evenodd\'%3e%3cpath d=\'M3 4h18v8.737l-3.83-3.191a.916.916 0 0 0-1.282.108l-4.924 5.744-3.891-3.114a.92.92 0 0 0-1.146 0L3 14.626V4zm19-2H2a1 1 0 0 0-1 1v18a1 1 0 0 0 1 1h20a1 1 0 0 0 1-1V3a1 1 0 0 0-1-1z\'/%3e%3cpath d=\'M9 10c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2\'/%3e%3c/g%3e%3c/svg%3e" data-src="http://image.jpg" data-srcset="http://image.jpg, http://image2x.jpg 2x" data-sizes="auto" alt="" width="400" height="200"/><noscript>
-											<img src="http://image.jpg" alt="image alt" width="400" height="200"/>
+										<img class="article-media-placeholder lazyload" src="data:image/svg+xml;charset=UTF-8,%3csvg xmlns=\'http://www.w3.org/2000/svg\' viewBox=\'-12 -12 48 48\' fill=\'%23fff\' width=\'400\' height=\'200\'%3e%3cg fill-rule=\'evenodd\'%3e%3cpath d=\'M3 4h18v8.737l-3.83-3.191a.916.916 0 0 0-1.282.108l-4.924 5.744-3.891-3.114a.92.92 0 0 0-1.146 0L3 14.626V4zm19-2H2a1 1 0 0 0-1 1v18a1 1 0 0 0 1 1h20a1 1 0 0 0 1-1V3a1 1 0 0 0-1-1z\'/%3e%3cpath d=\'M9 10c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2\'/%3e%3c/g%3e%3c/svg%3e" data-src="http://image.jpg" data-srcset="http://image.jpg, http://image2x.jpg 2x" data-sizes="auto" alt="SomeFile.jpg" width="400" height="200"/><noscript>
+											<img src="http://image.jpg" alt="" width="400" height="200"/>
 										</noscript>
 										</a>
 									</figure>
@@ -173,7 +173,6 @@ class PortableInfoboxMobileRenderServiceTest extends WikiaBaseTest {
 				'description' => 'Simple infobox with title, image and key-value pair',
 				'mockParams' => [
 					'extendImageData' => [
-						'url' => 'http://image.jpg',
 						'width' => '400',
 						'height' => '200',
 						'thumbnail' => 'http://image.jpg',
@@ -449,7 +448,7 @@ class PortableInfoboxMobileRenderServiceTest extends WikiaBaseTest {
 				'output' => '<aside class="portable-infobox pi-background">
 								<div class="pi-item pi-hero">
 									<img
-									src="data:image/gif;base64,R0lGODlhAQABAIABAAAAAP///yH5BAEAAAEALAAAAAABAAEAQAICTAEAOw%3D%3D" data-src="http://image.jpg" class="pi-image-thumbnail lazy media article-media" alt="image alt"  data-image-key="test1" data-image-name="test1" data-params=\'[{"name":"test1", "full":"http://image.jpg"}]\' />
+									src="data:image/gif;base64,R0lGODlhAQABAIABAAAAAP///yH5BAEAAAEALAAAAAABAAEAQAICTAEAOw%3D%3D" data-src="http://image.jpg" class="pi-image-thumbnail lazy media article-media" alt="someFile.jpg"  data-image-key="somefile.jpg" data-image-name="somefile.jpg" data-params=\'[{"name":"somefile.jpg", "full":"http://image.jpg"}]\' />
 								</div>
 							</aside>',
 				'description' => 'WikiaMobile: Only image. Image is not small- should render hero.',
@@ -457,6 +456,7 @@ class PortableInfoboxMobileRenderServiceTest extends WikiaBaseTest {
 					'isMercury' => false,
 					'extendImageData' => [
 						'url' => 'http://image.jpg',
+						'fileName' => 'somefile.jpg',
 						'width' => '400',
 						'height' => '200',
 						'thumbnail' => 'http://image.jpg',
@@ -492,7 +492,7 @@ class PortableInfoboxMobileRenderServiceTest extends WikiaBaseTest {
 										<h2 class="pi-hero-title">Test <a href="example.com">Title</a></h2>
 									</hgroup>
 									<img
-									src="data:image/gif;base64,R0lGODlhAQABAIABAAAAAP///yH5BAEAAAEALAAAAAABAAEAQAICTAEAOw%3D%3D" data-src="thumbnail.jpg" class="pi-image-thumbnail lazy media article-media" alt="" data-image-key="test1" data-image-name="test1" data-params=\'[{"name":"test1", "full":"http://image.jpg"}]\'/>
+									src="data:image/gif;base64,R0lGODlhAQABAIABAAAAAP///yH5BAEAAAEALAAAAAABAAEAQAICTAEAOw%3D%3D" data-src="thumbnail.jpg" class="pi-image-thumbnail lazy media article-media" alt="somefile.jpg" data-image-key="somefile.jpg" data-image-name="somefile.jpg" data-params=\'[{"name":"somefile.jpg", "full":"http://image.jpg"}]\'/>
 								</div>
 							</aside>',
 				'description' => 'WikiaMobile: Infobox with full hero module with title with HTML tags',
@@ -500,6 +500,7 @@ class PortableInfoboxMobileRenderServiceTest extends WikiaBaseTest {
 					'isMercury' => false,
 					'extendImageData' => [
 						'url' => 'http://image.jpg',
+						'fileName' => 'somefile.jpg',
 						'width' => '400',
 						'height' => '200',
 						'thumbnail' => 'thumbnail.jpg',
@@ -529,7 +530,7 @@ class PortableInfoboxMobileRenderServiceTest extends WikiaBaseTest {
 									<figure data-attrs="" data-file="">
 										<a href="http://image.jpg">
 											<img class="article-media-placeholder lazyload" src="data:image/svg+xml;charset=UTF-8,%3csvg xmlns=\'http://www.w3.org/2000/svg\' viewBox=\'-12 -12 48 48\' fill=\'%23fff\' width=\'400\' height=\'200\'%3e%3cg fill-rule=\'evenodd\'%3e%3cpath d=\'M3 4h18v8.737l-3.83-3.191a.916.916 0 0 0-1.282.108l-4.924 5.744-3.891-3.114a.92.92 0 0 0-1.146 0L3 14.626V4zm19-2H2a1 1 0 0 0-1 1v18a1 1 0 0 0 1 1h20a1 1 0 0 0 1-1V3a1 1 0 0 0-1-1z\'/%3e%3cpath d=\'M9 10c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2\'/%3e%3c/g%3e%3c/svg%3e" data-src="http://image.jpg" data-srcset="http://image.jpg, http://image2x.jpg 2x" data-sizes="auto" alt="" width="400" height="200"/><noscript>
-												<img src="http://image.jpg" alt="image alt" width="400" height="200"/>
+												<img src="http://image.jpg" alt="" width="400" height="200"/>
 											</noscript>
 										</a>
 									</figure>

--- a/extensions/wikia/PortableInfobox/tests/PortableInfoboxMobileRenderServiceTest.php
+++ b/extensions/wikia/PortableInfobox/tests/PortableInfoboxMobileRenderServiceTest.php
@@ -173,15 +173,11 @@ class PortableInfoboxMobileRenderServiceTest extends WikiaBaseTest {
 				'description' => 'Simple infobox with title, image and key-value pair',
 				'mockParams' => [
 					'extendImageData' => [
-						'alt' => 'image alt',
 						'url' => 'http://image.jpg',
-						'name' => 'test1',
-						'key' => 'test1',
 						'width' => '400',
 						'height' => '200',
 						'thumbnail' => 'http://image.jpg',
 						'thumbnail2x' => 'http://image2x.jpg',
-						'media-type' => 'image',
 						'isVideo' => false
 					]
 				]
@@ -460,15 +456,11 @@ class PortableInfoboxMobileRenderServiceTest extends WikiaBaseTest {
 				'mockParams' => [
 					'isMercury' => false,
 					'extendImageData' => [
-						'alt' => 'image alt',
 						'url' => 'http://image.jpg',
-						'name' => 'test1',
-						'key' => 'test1',
 						'width' => '400',
 						'height' => '200',
 						'thumbnail' => 'http://image.jpg',
 						'thumbnail2x' => 'http://image2x.jpg',
-						'media-type' => 'image',
 						'isVideo' => false
 					]
 				]
@@ -508,14 +500,11 @@ class PortableInfoboxMobileRenderServiceTest extends WikiaBaseTest {
 					'isMercury' => false,
 					'extendImageData' => [
 						'url' => 'http://image.jpg',
-						'name' => 'test1',
-						'key' => 'test1',
 						'width' => '400',
 						'height' => '200',
 						'thumbnail' => 'thumbnail.jpg',
 						'thumbnail2x' => 'thumbnail2x.jpg',
 						'isVideo' => false,
-						'media-type' => 'image'
 					]
 				]
 			],
@@ -549,15 +538,11 @@ class PortableInfoboxMobileRenderServiceTest extends WikiaBaseTest {
 				'description' => 'Mercury: Only image. Image is not small- should render hero.',
 				'mockParams' => [
 					'extendImageData' => [
-						'alt' => 'image alt',
 						'url' => 'http://image.jpg',
-						'name' => 'test1',
-						'key' => 'test1',
 						'width' => '400',
 						'height' => '200',
 						'thumbnail' => 'http://image.jpg',
 						'thumbnail2x' => 'http://image2x.jpg',
-						'media-type' => 'image',
 						'isVideo' => false
 					]
 				]
@@ -601,14 +586,11 @@ class PortableInfoboxMobileRenderServiceTest extends WikiaBaseTest {
 				'mockParams' => [
 					'extendImageData' => [
 						'url' => 'http://image.jpg',
-						'name' => 'test1',
-						'key' => 'test1',
 						'width' => '400',
 						'height' => '200',
 						'thumbnail' => 'thumbnail.jpg',
 						'thumbnail2x' => 'thumbnail2x.jpg',
 						'isVideo' => false,
-						'media-type' => 'image',
 					]
 				]
 			],
@@ -705,14 +687,11 @@ class PortableInfoboxMobileRenderServiceTest extends WikiaBaseTest {
 				'mockParams' => [
 					'extendImageData' => [
 						'url' => 'http://image.jpg',
-						'name' => 'test1',
-						'key' => 'test1',
 						'width' => '400',
 						'height' => '200',
 						'thumbnail' => 'thumbnail.jpg',
 						'thumbnail2x' => 'thumbnail2x.jpg',
 						'isVideo' => false,
-						'media-type' => 'image',
 					]
 				]
 			],
@@ -809,14 +788,11 @@ class PortableInfoboxMobileRenderServiceTest extends WikiaBaseTest {
 				'mockParams' => [
 					'extendImageData' => [
 						'url' => 'http://image.jpg',
-						'name' => 'test1',
-						'key' => 'test1',
 						'width' => '200',
 						'height' => '200',
 						'thumbnail' => 'thumbnail.jpg',
 						'thumbnail2x' => 'thumbnail2x.jpg',
 						'isVideo' => false,
-						'media-type' => 'image',
 					]
 				]
 			]

--- a/extensions/wikia/PortableInfobox/tests/PortableInfoboxMobileRenderServiceTest.php
+++ b/extensions/wikia/PortableInfobox/tests/PortableInfoboxMobileRenderServiceTest.php
@@ -177,7 +177,6 @@ class PortableInfoboxMobileRenderServiceTest extends WikiaBaseTest {
 						'url' => 'http://image.jpg',
 						'name' => 'test1',
 						'key' => 'test1',
-						'ref' => 1,
 						'width' => '400',
 						'height' => '200',
 						'thumbnail' => 'http://image.jpg',
@@ -454,7 +453,7 @@ class PortableInfoboxMobileRenderServiceTest extends WikiaBaseTest {
 				'output' => '<aside class="portable-infobox pi-background">
 								<div class="pi-item pi-hero">
 									<img
-									src="data:image/gif;base64,R0lGODlhAQABAIABAAAAAP///yH5BAEAAAEALAAAAAABAAEAQAICTAEAOw%3D%3D" data-src="http://image.jpg" class="pi-image-thumbnail lazy media article-media" alt="image alt"  data-image-key="test1" data-image-name="test1" data-ref="1" data-params=\'[{"name":"test1", "full":"http://image.jpg"}]\' />
+									src="data:image/gif;base64,R0lGODlhAQABAIABAAAAAP///yH5BAEAAAEALAAAAAABAAEAQAICTAEAOw%3D%3D" data-src="http://image.jpg" class="pi-image-thumbnail lazy media article-media" alt="image alt"  data-image-key="test1" data-image-name="test1" data-params=\'[{"name":"test1", "full":"http://image.jpg"}]\' />
 								</div>
 							</aside>',
 				'description' => 'WikiaMobile: Only image. Image is not small- should render hero.',
@@ -465,7 +464,6 @@ class PortableInfoboxMobileRenderServiceTest extends WikiaBaseTest {
 						'url' => 'http://image.jpg',
 						'name' => 'test1',
 						'key' => 'test1',
-						'ref' => 1,
 						'width' => '400',
 						'height' => '200',
 						'thumbnail' => 'http://image.jpg',
@@ -502,7 +500,7 @@ class PortableInfoboxMobileRenderServiceTest extends WikiaBaseTest {
 										<h2 class="pi-hero-title">Test <a href="example.com">Title</a></h2>
 									</hgroup>
 									<img
-									src="data:image/gif;base64,R0lGODlhAQABAIABAAAAAP///yH5BAEAAAEALAAAAAABAAEAQAICTAEAOw%3D%3D" data-src="thumbnail.jpg" class="pi-image-thumbnail lazy media article-media" alt="" data-image-key="test1" data-image-name="test1" data-ref="44" data-params=\'[{"name":"test1", "full":"http://image.jpg"}]\'/>
+									src="data:image/gif;base64,R0lGODlhAQABAIABAAAAAP///yH5BAEAAAEALAAAAAABAAEAQAICTAEAOw%3D%3D" data-src="thumbnail.jpg" class="pi-image-thumbnail lazy media article-media" alt="" data-image-key="test1" data-image-name="test1" data-params=\'[{"name":"test1", "full":"http://image.jpg"}]\'/>
 								</div>
 							</aside>',
 				'description' => 'WikiaMobile: Infobox with full hero module with title with HTML tags',
@@ -512,7 +510,6 @@ class PortableInfoboxMobileRenderServiceTest extends WikiaBaseTest {
 						'url' => 'http://image.jpg',
 						'name' => 'test1',
 						'key' => 'test1',
-						'ref' => 44,
 						'width' => '400',
 						'height' => '200',
 						'thumbnail' => 'thumbnail.jpg',
@@ -556,17 +553,12 @@ class PortableInfoboxMobileRenderServiceTest extends WikiaBaseTest {
 						'url' => 'http://image.jpg',
 						'name' => 'test1',
 						'key' => 'test1',
-						'ref' => 1,
 						'width' => '400',
 						'height' => '200',
 						'thumbnail' => 'http://image.jpg',
 						'thumbnail2x' => 'http://image2x.jpg',
 						'media-type' => 'image',
-						'isVideo' => false,
-						'mercuryComponentAttrs' => json_encode( [
-								'itemContext' => 'portable-infobox',
-								'ref' => 1
-						] )
+						'isVideo' => false
 					]
 				]
 			],
@@ -611,17 +603,12 @@ class PortableInfoboxMobileRenderServiceTest extends WikiaBaseTest {
 						'url' => 'http://image.jpg',
 						'name' => 'test1',
 						'key' => 'test1',
-						'ref' => 44,
 						'width' => '400',
 						'height' => '200',
 						'thumbnail' => 'thumbnail.jpg',
 						'thumbnail2x' => 'thumbnail2x.jpg',
 						'isVideo' => false,
 						'media-type' => 'image',
-						'mercuryComponentAttrs' => json_encode( [
-							'itemContext' => 'portable-infobox',
-							'ref' => 44
-						] )
 					]
 				]
 			],
@@ -720,17 +707,12 @@ class PortableInfoboxMobileRenderServiceTest extends WikiaBaseTest {
 						'url' => 'http://image.jpg',
 						'name' => 'test1',
 						'key' => 'test1',
-						'ref' => 44,
 						'width' => '400',
 						'height' => '200',
 						'thumbnail' => 'thumbnail.jpg',
 						'thumbnail2x' => 'thumbnail2x.jpg',
 						'isVideo' => false,
 						'media-type' => 'image',
-						'mercuryComponentAttrs' => json_encode( [
-							'itemContext' => 'portable-infobox',
-							'ref' => 44
-						] )
 					]
 				]
 			],
@@ -829,17 +811,12 @@ class PortableInfoboxMobileRenderServiceTest extends WikiaBaseTest {
 						'url' => 'http://image.jpg',
 						'name' => 'test1',
 						'key' => 'test1',
-						'ref' => 44,
 						'width' => '200',
 						'height' => '200',
 						'thumbnail' => 'thumbnail.jpg',
 						'thumbnail2x' => 'thumbnail2x.jpg',
 						'isVideo' => false,
 						'media-type' => 'image',
-						'mercuryComponentAttrs' => json_encode( [
-							'itemContext' => 'portable-infobox',
-							'ref' => 44
-						] )
 					]
 				]
 			]


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/XF-363

Before, rendering gallery within portable infobox on desktop used $media array from ArticleAsJson. 
This PR breaks this unnecessary dependency. Additionally, support for tabber in portable infoboxes on mobile is fixed now.

@Wikia/x-wing 