### PR TITLE
SUS-5793 | WebResponse - avoid large headers blowing out the nginx's FastCGI buffer

### DIFF
--- a/includes/WebResponse.php
+++ b/includes/WebResponse.php
@@ -28,7 +28,7 @@
 class WebResponse implements \Wikia\HTTP\Response {
 
 	const NO_COOKIE_PREFIX  = '';
-	const MAX_HEADER_LENGTH = 4096;
+	const MAX_HEADER_LENGTH = 2048;
 
 	/**
 	 * Output a HTTP header, wrapper for PHP's
@@ -39,6 +39,7 @@ class WebResponse implements \Wikia\HTTP\Response {
 	 */
 	public function header( $string, $replace = true, $http_response_code = null ) {
 		// PLATFORM-3070: In case of extremely long headers we should trim them to avoid problems with Fastly or other clients
+		// SUS-5793: avoid large headers blowing out the nginx's FastCGI buffer and resulting in a HTTP 500 error
 		if ( strlen( $string ) > self::MAX_HEADER_LENGTH ) {
 			$string = substr( $string, 0, self::MAX_HEADER_LENGTH );
 		}

--- a/includes/WebResponse.php
+++ b/includes/WebResponse.php
@@ -42,6 +42,10 @@ class WebResponse implements \Wikia\HTTP\Response {
 		// SUS-5793: avoid large headers blowing out the nginx's FastCGI buffer and resulting in a HTTP 500 error
 		if ( strlen( $string ) > self::MAX_HEADER_LENGTH ) {
 			$string = substr( $string, 0, self::MAX_HEADER_LENGTH );
+
+			\Wikia\Logger\WikiaLogger::instance()->warning( __METHOD__ . '- header was too long', [
+				'header_value' => substr( $string, 0, 128 )
+			] );
 		}
 
 		header( $string, $replace, $http_response_code );


### PR DESCRIPTION
… and resulting in a HTTP 500 error

https://wikia-inc.atlassian.net/browse/SUS-5793

[The Internet](https://gist.github.com/magnetikonline/11312172#determine-fastcgi-response-sizes) says:

> `fastcgi_buffer_size` is a special buffer space used to hold the first chunk of the FastCGI response, which is going to be the HTTP response headers.
>
> You shouldn't need to adjust this from the default - even if Nginx defaults to the smallest page size of 4KB (your platform will determine if 4/8k buffer) it should fit your typical HTTP header.
>
> The one exception I have seen are frameworks that push large amounts of cookie data via the `Set-Cookie` HTTP header during their user verification/login phase - blowing out the buffer and resulting in a HTTP 500 error. In those instances you will need to increase this buffer to 8k/16k/32k to fully accommodate your largest upstream HTTP header being pushed.

In our case `X-Request-Path` response header is to be blamed. Let's just trim it to 2k instead of 4k used previously. Yes, it's that long in some rare cases (see the ticket for an example).