### PR TITLE
add missing label to mediawiki-tasks to collect metrics

### DIFF
--- a/docker/prod/prod.template.yaml
+++ b/docker/prod/prod.template.yaml
@@ -304,6 +304,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: mediawiki-tasks
+  labels:
+      app: mediawiki-tasks
 spec:
   selector:
     app: mediawiki-tasks


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5562

Add `app` label to `mediawiki-tasks` service so that it can be observed by its servicemonitor.