### PR TITLE
PLATFORM-3671: fixing issues reported by mobile apps

### DIFF
--- a/includes/wikia/VariablesBase.php
+++ b/includes/wikia/VariablesBase.php
@@ -8828,3 +8828,10 @@ $wgXMLMimeTypes = [
  * @var Array $wgYoukuConfig
  */
 $wgYoukuConfig['playerColor'] = 0;
+
+/**
+ * Used for test wikis copied on prod. Top articles data should use pageviews of the original wiki.
+ * @see PLATFORM-3671
+ * @var int $wgPlatform3671DataMartCityId
+ */
+$wgPlatform3671DataMartCityId = 0;

--- a/includes/wikia/VariablesBase.php
+++ b/includes/wikia/VariablesBase.php
@@ -8832,6 +8832,6 @@ $wgYoukuConfig['playerColor'] = 0;
 /**
  * Used for test wikis copied on prod. Top articles data should use pageviews of the original wiki.
  * @see PLATFORM-3671
- * @var int $wgPlatform3671DataMartCityId
+ * @var int $wgDataMartOriginalCityId
  */
-$wgPlatform3671DataMartCityId = 0;
+$wgDataMartOriginalCityId = 0;

--- a/includes/wikia/api/ArticlesApiController.class.php
+++ b/includes/wikia/api/ArticlesApiController.class.php
@@ -136,7 +136,7 @@ class ArticlesApiController extends WikiaApiController {
 		// This DataMartService method has
 		// separate caching
 		$articles = DataMartService::getTopArticlesByPageview(
-			$this->wg->CityId,
+			!empty( $this->wg->Platform3671DataMartCityId ) ? $this->wg->Platform3671DataMartCityId : $this->wg->CityId,
 			$ids,
 			$namespaces,
 			false,

--- a/includes/wikia/api/ArticlesApiController.class.php
+++ b/includes/wikia/api/ArticlesApiController.class.php
@@ -136,7 +136,7 @@ class ArticlesApiController extends WikiaApiController {
 		// This DataMartService method has
 		// separate caching
 		$articles = DataMartService::getTopArticlesByPageview(
-			!empty( $this->wg->Platform3671DataMartCityId ) ? $this->wg->Platform3671DataMartCityId : $this->wg->CityId,
+			!empty( $this->wg->DataMartOriginalCityId ) ? $this->wg->DataMartOriginalCityId : $this->wg->CityId,
 			$ids,
 			$namespaces,
 			false,

--- a/includes/wikia/services/WikiDetailsService.class.php
+++ b/includes/wikia/services/WikiDetailsService.class.php
@@ -163,9 +163,17 @@ class WikiDetailsService extends WikiService {
 		$wikiObj = WikiFactory::getWikiByID( $id );
 		if ( $wikiObj ) {
 			$exists = true;
+
+			// convert city_url to https url for https-enabled wikis
+			$city_url = WikiFactory::getLocalEnvURL( $wikiObj->city_url );
+			$enableHTTPSForAnons = WikiFactory::getVarValueByName( 'wgEnableHTTPSForAnons', $id );
+			if ( !empty( $enableHTTPSForAnons ) && wfHttpsAllowedForURL( $city_url ) ) {
+				$city_url = wfHttpToHttps( $city_url );
+			}
+
 			return [
 				'title' => $wikiObj->city_title,
-				'url' => WikiFactory::getLocalEnvURL( $wikiObj->city_url ),
+				'url' => $city_url,
 			];
 		}
 		return [];


### PR DESCRIPTION
Fixes:
* WikiDetails should return a https url when a wiki is switched to https
* copied wiki should have top articles data - created `$wgDataMartOriginalCityId` for the workaround