### PR TITLE
SUS-5783 | ScribuntoHooks - emit Lua engine that was used to execute the script

### DIFF
--- a/extensions/Scribunto/common/Hooks.php
+++ b/extensions/Scribunto/common/Hooks.php
@@ -212,6 +212,7 @@ class ScribuntoHooks {
 	public static function reportLimits( $parser, &$report ) {
 		if ( Scribunto::isParserEnginePresent( $parser ) ) {
 			$engine = Scribunto::getParserEngine( $parser );
+			$report .= sprintf( "Lua engine used: %s\n", get_class( $engine ) );  // Wikia change
 			$report .= $engine->getLimitReport();
 		}
 		return true;


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5783 - ease debugging which Lua engine is used

### An example

Add the `Lua engine used` entry to the HTML comment emitted by MediaWiki parser.

```html
<!-- 
NewPP limit report
Preprocessor node count: 3/300000
Post‐expand include size: 13/2097152 bytes
Template argument size: 0/2097152 bytes
Expensive parser function count: 0/100
Lua engine used: Scribunto_LuaSandboxEngine
Lua time usage: 0.003s
Lua memory usage: 499 KB
-->
```

`Scribunto_LuaSandboxEngine` is now the way to go as we have `luasandbox` PHP extension installed on Apaches.