### PR TITLE
SUS-5807 | DumpsOnDemandTask - generate 7z dumps directly in /tmp directory (without entering subdirectories)

### DIFF
--- a/extensions/wikia/WikiFactory/Close/maintenance.php
+++ b/extensions/wikia/WikiFactory/Close/maintenance.php
@@ -116,8 +116,8 @@ class CloseWikiMaintenance {
 			}
 			if( $row->city_flags & WikiFactory::FLAG_CREATE_DB_DUMP ) {
 				$script = ( $hide )
-					? "php {$IP}/extensions/wikia/WikiFactory/Dumps/runBackups.php --both --id={$cityid} --tmp --s3"
-					: "php {$IP}/extensions/wikia/WikiFactory/Dumps/runBackups.php --both --id={$cityid} --hide --tmp --s3";
+					? "php {$IP}/extensions/wikia/WikiFactory/Dumps/runBackups.php --both --id={$cityid} --s3"
+					: "php {$IP}/extensions/wikia/WikiFactory/Dumps/runBackups.php --both --id={$cityid} --hide --s3";
 
 				$this->info( "Dumping database on remote host", [
 					'script' => $script

--- a/extensions/wikia/WikiFactory/Dumps/runBackups.php
+++ b/extensions/wikia/WikiFactory/Dumps/runBackups.php
@@ -17,6 +17,7 @@
  * 	backups for city_dbname = wikicities
  *
  * This script is executed by /lib/Wikia/src/Tasks/Tasks/DumpsOnDemandTask.php
+ * and //extensions/wikia/WikiFactory/Close/maintenance.php
  */
 
 require_once(__DIR__ .'/../../../../maintenance/commandLine.inc');

--- a/extensions/wikia/WikiFactory/Dumps/runBackups.php
+++ b/extensions/wikia/WikiFactory/Dumps/runBackups.php
@@ -41,16 +41,6 @@ function runBackups( $from, $to, $full, $options ) {
 	$hide = isset( $options[ "hide" ] );
 
 	/**
-	 * store backup in the system tmp dir
-	 */
-	$use_temp = isset( $options['tmp'] );
-
-	/**
-	 * send backup to Amazon S3 and delete the local copy
-	 */
-	$s3 = isset( $options['s3'] );
-
-	/**
 	 * silly trick, if we have id defined we are defining $from & $to from it
 	 * if we have db param defined we first resolve which id is connected to this
 	 * database
@@ -111,13 +101,11 @@ function runBackups( $from, $to, $full, $options ) {
 			array( "ORDER BY" => "city_id" )
 	);
 	while( $row = $dbw->fetchObject( $sth ) ) {
-		$basedir = getDirectory( $row->city_dbname, $hide, $use_temp );
-
 		if( $full || $both ) {
-			doDumpBackup( $row, sprintf("%s/%s_pages_full.xml.7z", $basedir, $row->city_dbname ), [ '--full' ] );
+			doDumpBackup( $row, sprintf("%s/%s_pages_full.xml.7z", sys_get_temp_dir(), $row->city_dbname ), [ '--full' ] );
 		}
 		if( !$full || $both ) {
-			doDumpBackup( $row, sprintf("%s/%s_pages_current.xml.7z", $basedir, $row->city_dbname ), [ '--current' ] );
+			doDumpBackup( $row, sprintf("%s/%s_pages_current.xml.7z", sys_get_temp_dir(), $row->city_dbname ), [ '--current' ] );
 		}
 	}
 }
@@ -187,33 +175,6 @@ function doDumpBackup( $row, $path, array $args = [] ) {
 
 		exit( 2 );
 	}
-}
-
-/**
- * dump directory is created as
- *
- * <root>/<first letter>/<two first letters>/<database>
- */
-function getDirectory( $database, $hide = false, $use_temp = false ) {
-
-	$folder     = $use_temp ?  sys_get_temp_dir() : "data";
-	$subfolder  = $hide ? "dumps-hidden" : "dumps";
-	$database   = strtolower( $database );
-
-	$directory = sprintf(
-		"/%s/%s/%s/%s/%s",
-		$folder,
-		$subfolder,
-		substr( $database, 0, 1),
-		substr( $database, 0, 2),
-		$database
-	);
-	if( !is_dir( $directory ) ) {
-		Wikia::log( __METHOD__ , "dir", "create {$directory}", true, true );
-		wfMkdirParents( $directory );
-	}
-
-	return $directory;
 }
 
 // SUS-4313 | make this dependency obvious

--- a/extensions/wikia/WikiFactory/Dumps/runBackups.php
+++ b/extensions/wikia/WikiFactory/Dumps/runBackups.php
@@ -36,11 +36,6 @@ function runBackups( $from, $to, $full, $options ) {
 	$both = isset( $options[ "both" ] );
 
 	/**
-	 * store backup in another folder, not available for users
-	 */
-	$hide = isset( $options[ "hide" ] );
-
-	/**
 	 * silly trick, if we have id defined we are defining $from & $to from it
 	 * if we have db param defined we first resolve which id is connected to this
 	 * database

--- a/lib/Wikia/src/Tasks/Tasks/DumpsOnDemandTask.php
+++ b/lib/Wikia/src/Tasks/Tasks/DumpsOnDemandTask.php
@@ -29,7 +29,7 @@ class DumpsOnDemandTask extends BaseTask {
 
 		$this->info( "Creating dumps for wiki #{$wikiId}." );
 
-		$sCommand = sprintf( 'SERVER_ID=%d php %s/extensions/wikia/WikiFactory/Dumps/runBackups.php --conf %s --id=%d --both --tmp --s3 2>&1', \Wikia::COMMUNITY_WIKI_ID, $IP, $wgWikiaLocalSettingsPath, $wikiId );
+		$sCommand = sprintf( 'SERVER_ID=%d php %s/extensions/wikia/WikiFactory/Dumps/runBackups.php --conf %s --id=%d --both 2>&1', \Wikia::COMMUNITY_WIKI_ID, $IP, $wgWikiaLocalSettingsPath, $wikiId );
 		$this->info( "Running {$sCommand}" );
 
 		$sOutput = wfShellExec( $sCommand, $iStatus );

--- a/lib/Wikia/src/Tasks/Tasks/DumpsOnDemandTask.php
+++ b/lib/Wikia/src/Tasks/Tasks/DumpsOnDemandTask.php
@@ -29,7 +29,7 @@ class DumpsOnDemandTask extends BaseTask {
 
 		$this->info( "Creating dumps for wiki #{$wikiId}." );
 
-		$sCommand = sprintf( 'SERVER_ID=%d php %s/extensions/wikia/WikiFactory/Dumps/runBackups.php --conf %s --id=%d --both 2>&1', \Wikia::COMMUNITY_WIKI_ID, $IP, $wgWikiaLocalSettingsPath, $wikiId );
+		$sCommand = sprintf( 'SERVER_ID=%d php %s/extensions/wikia/WikiFactory/Dumps/runBackups.php --conf %s --id=%d --both --s3 2>&1', \Wikia::COMMUNITY_WIKI_ID, $IP, $wgWikiaLocalSettingsPath, $wikiId );
 		$this->info( "Running {$sCommand}" );
 
 		$sOutput = wfShellExec( $sCommand, $iStatus );


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5807

Otherwise we run into permission errors on Kubernetes when trying to generate files in `/tmp` sub-directories (e.g. `/tmp/dumps/a/aw/awesomegames993/awesomegames993_pages_full.xml.7z`)