### PR TITLE
SUS-5799 | OOM errors - let's start with limits taken from production end-user facing MediaWiki template

### DIFF
--- a/docker/maintenance/cronjob-template.yaml
+++ b/docker/maintenance/cronjob-template.yaml
@@ -26,6 +26,13 @@ spec:
                 value: "${server_id}"
               - name: LOG_STDOUT_ONLY
                 value: "yes"
+            resources:
+              limits:
+                cpu: "6"
+                memory: 1200Mi
+              requests:
+                cpu: "3"
+                memory: 800Mi
             args:
 ${args}
           restartPolicy: Never


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5799

Pods that execute cron jobs do not have any memory limit sets explicitily, hence a default value of `300M` is used. It's lower than the current PHP memory limit set on production.

```
$ kubectl --context kube-sjc-prod -n prod describe pod mw-cj-send-weekly-digest-1536451560-4c6m8
Name:               mw-cj-send-weekly-digest-1536451560-4c6m8
...
Status:             Failed
...
    Limits:
      cpu:     10
      memory:  300Mi
    Requests:
      cpu:     200m
      memory:  100Mi
```

vs

```
macbre@cron-s1:~$ php -i | grep limit
memory_limit => 512M => 512M
```

For start let's use limits and requested memory from MediaWiki Kubernetes template.

I'll re-apply `mw-cj-send-weekly-digest` cronjob with a new, explicitly defined memory limits and observe the real memory usage. Then we can tweak it. Let's start from a high value and decrease it if needed.