### PR TITLE
Fix integration tests performance in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,10 @@ addons:
 install:
   - pecl channel-update pecl.php.net
   - pecl install uopz mustache
-before_script: phpenv config-add tests/travis/php.ini
+before_script:
+  # make sure indices are upgraded, see https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-23.html#mysqld-5-7-23-bug
+  - sudo mysql_upgrade
+  - phpenv config-add tests/travis/php.ini
 script:
   - cd tests && ./php-tests.sh
   - cd .. && composer run lint


### PR DESCRIPTION
It seems the performance regression was caused by MySQL 5.7.23 minor version bump. See https://github.com/travis-ci/travis-ci/issues/9948 for details.

Running `mysql_upgrade` after installing MySQL 5.7 in the test environment results in normal speed again. Execution time of integration tests went from 13 minutes to 36 seconds, full build now only needs 4-5 minutes instead of 17.