### PR TITLE
PLATFORM-3674 | window.wgTrackID isn't always available so use inlined value instead

### DIFF
--- a/extensions/wikia/Track/Track.php
+++ b/extensions/wikia/Track/Track.php
@@ -111,7 +111,11 @@ class Track {
 			$url = Track::getURL( 'view', '', $param, false );
 			$script = ( new Wikia\Template\MustacheEngine )
 				->setPrefix( dirname( __FILE__ ) . '/templates' )
-				->setData(['url' => $url, 'event-logger-url' => $urlProvider->getUrl( 'event-logger' ) ] )
+				->setData( [
+					'event-logger-url' => $urlProvider->getUrl( 'event-logger' ),
+					'trackID' => self::getTrackID(),
+					'url' => $url
+				] )
 				->render('track.mustache');
 		}
 
@@ -177,17 +181,26 @@ class Track {
 		return F::app()->wg->request->isWikiaInternalRequest() === false;
 	}
 
+	private static function getTrackID() {
+		global $wgUser;
+
+		if ( $wgUser->isLoggedIn() ) {
+			$trackID = $wgUser->getId();
+		} else {
+			$trackID = 0;
+		}
+
+		return $trackID;
+	}
+
 	/**
 	 * @static
 	 * @param array $vars
 	 * @return bool
 	 */
 	public static function addGlobalVars( Array &$vars ) {
-		global $wgUser;
+		$vars[ 'wgTrackID' ] = self::getTrackID();
 
-		if ( $wgUser->isLoggedIn() ) {
-			$vars[ 'wgTrackID' ] = $wgUser->getId();
-		}
 		return true;
 	}
 

--- a/extensions/wikia/Track/templates/track.mustache
+++ b/extensions/wikia/Track/templates/track.mustache
@@ -50,7 +50,8 @@
 					'&pv_number_global=' + window.pvNumberGlobal;
 
 			if (optIn) {
-				trackUrl += '&u=' + window.wgTrackID;
+                {{!-- window.wgTrackID isn't available yet as this script is inlined at the top --}}
+				trackUrl += '&u=' + '{{trackID}}';
 			} else {
 				trackUrl += '&u=-1';
 			}

--- a/resources/wikia/modules/tracker.js
+++ b/resources/wikia/modules/tracker.js
@@ -143,7 +143,7 @@
 					userId = -1;
 
 			if (isOptedIn) {
-				userId = window.trackID || window.wgTrackID || 0;
+				userId = window.wgTrackID;
 			}
 
 			timeout = timeout || 3000;


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-3674

`track.mustache` is rendered at the top of the `body` while `wgTrackID` is set at the bottom. The easiest fix is to pass the user ID to the template instead of relying on a global variable.

@Wikia/core-platform-team @mszabo-wikia 