### PR TITLE
SUS-5825 | make nginx and Apache works similar when handling request paths

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -138,9 +138,7 @@ $wgServer = WebRequest::detectServer();
  * redirect loops when "pretty URLs" are used.
  * @var bool $wgUsePathInfo
  */
-$wgUsePathInfo = ( strpos(php_sapi_name(), 'cgi') === false ) &&
-        ( strpos(php_sapi_name(), 'apache2filter') === false ) &&
-        ( strpos(php_sapi_name(), 'isapi') === false );
+$wgUsePathInfo = ( php_sapi_name() == 'apache2handler' ) || ( php_sapi_name() == 'fpm-fcgi' ); # Wikia change - SUS-5825
 
 /**
  * Show EXIF data, on by default if available. Requires PHP's EXIF extension.


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5825

Otherwise nginx handles `/wiki/Special:RecentChanges?feed=rss&title=author` incorrectly, using `author` as a title instead of `Special:RecentChanges`.

Full path parsing to extract the title for MediaWiki logic is controlled by `wgUsePathInfo` global variable. Change the logic behind it to treat nginx+php and Apache+mod_php equally.