### PR TITLE
SUS-5792 | rewrite for legacy corporate pages with short article path

### DIFF
--- a/docker/dev/site.conf
+++ b/docker/dev/site.conf
@@ -63,7 +63,7 @@ server {
 
     # SUS-5792: rewrite for legacy corporate pages with short article path
     # see wgShortArticlePathWikis MediaWiki variable for the list of them
-    if ($host ~ ^(www).dev.wikia-local.com$) {
+    if ($host ~ ^(www|de|fr|pl|es|ja|ru|it).dev.wikia-local.com$) {
       rewrite ^/(.*)$ /index.php?title=$1 break;
     }
 

--- a/docker/dev/site.conf
+++ b/docker/dev/site.conf
@@ -61,5 +61,11 @@ server {
         fastcgi_param SERVER_NAME $host;
     }
 
+    # SUS-5792: rewrite for legacy corporate pages with short article path
+    # see wgShortArticlePathWikis MediaWiki variable for the list of them
+    if ($host ~ ^(www).dev.wikia-local.com$) {
+      rewrite ^/(.*)$ /index.php?title=$1 break;
+    }
+
     error_page 404 = /redirect-canonical.php;
 }

--- a/docker/prod/site.conf
+++ b/docker/prod/site.conf
@@ -64,5 +64,11 @@ server {
         fastcgi_param SERVER_NAME $http_x_original_host;
     }
 
+    # SUS-5792: rewrite for legacy corporate pages with short article path
+    # see wgShortArticlePathWikis MediaWiki variable for the list of them
+    if ($http_x_original_host ~ ^(www|de|fr|pl|es|ja|ru|it).wikia.com$) {
+      rewrite ^/(.*)$ /index.php?title=$1 break;
+    }
+
     error_page 404 = /redirect-canonical.php;
 }

--- a/docker/sandbox/site.conf
+++ b/docker/sandbox/site.conf
@@ -64,5 +64,11 @@ server {
         fastcgi_param SERVER_NAME $http_x_original_host;
     }
 
+    # SUS-5792: rewrite for legacy corporate pages with short article path
+    # see wgShortArticlePathWikis MediaWiki variable for the list of them
+    if ($http_x_original_host ~ ^(www|de|fr|pl|es|ja|ru|it).wikia.com$) {
+      rewrite ^/(.*)$ /index.php?title=$1 break;
+    }
+
     error_page 404 = /redirect-canonical.php;
 }

--- a/docker/sandbox/site.conf
+++ b/docker/sandbox/site.conf
@@ -66,7 +66,7 @@ server {
 
     # SUS-5792: rewrite for legacy corporate pages with short article path
     # see wgShortArticlePathWikis MediaWiki variable for the list of them
-    if ($http_x_original_host ~ ^(www|de|fr|pl|es|ja|ru|it).wikia.com$) {
+    if ($http_x_original_host ~ ^(www|de|fr|pl|es|ja|ru|it).sandbox[^\.]+.wikia.com$) {
       rewrite ^/(.*)$ /index.php?title=$1 break;
     }
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5792

See `$wgShortArticlePathWikis` MediaWiki variable for the list of them

### After a fix


```
$ curl -svo /dev/null 'http://www.dev.wikia-local.com/About' 2>&1 | egrep '(Location|Redirected|HTTP)'
> GET /About HTTP/1.1
< HTTP/1.1 200 OK

$ curl -svo /dev/null 'http://muppet.dev.wikia-local.com/Foo' 2>&1 | egrep '(Location|Redirected)'
< X-Redirected-By: redirect-canonical.php
< Location: http://muppet.dev.wikia-local.com/wiki/Foo
```