### PR TITLE
SUS-5829 | Improve crontabs scheduling

### DIFF
--- a/docker/maintenance/cleanup-upload-stash.yaml
+++ b/docker/maintenance/cleanup-upload-stash.yaml
@@ -1,4 +1,4 @@
-schedule: "0 14 * * *"
+schedule: "0 5 * * *"
 args:
 - php
 - /usr/wikia/slot1/current/src/maintenance/maintenanceTaskScheduler.php

--- a/docker/maintenance/update-special-pages.yaml
+++ b/docker/maintenance/update-special-pages.yaml
@@ -1,4 +1,4 @@
-schedule: "0 4 * * *"
+schedule: "0 8 * * *"
 args:
 - php
 - /usr/wikia/slot1/current/src/maintenance/maintenanceTaskScheduler.php


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5829

The current schedule for cronjobs that spawn multiple tasks across all active wikis:

```
 "0 4 * * *" # ~14k tasks scheduled - loooong consumption (~10 h) // update-special-pages
 "0 3 * * *" # ~9k tasks scheduled - consumed within 2-3 minutes // init-stats
 "0 7 * * 1" # ~21k tasks scheduled - consumed within 10 minutes // reset-weekly-user-contributions
 "0 14 * * *" # ~15k tasks scheduled - takes ~45 minutes // cleanup-upload-stash
```

The new one:

```
 "0 8 * * *" # update-special-pages
 "0 3 * * *" # init-stats
 "0 7 * * 1" # reset-weekly-user-contributions
 "0 5 * * *" # cleanup-upload-stash
```

Let's first execute rather short tasks and then (at 8 am CET) the long running (~10 hours) `update-special-pages`. 

## Avoid the following

Avoid hitting the queue with a batch of tasks at the same time.

![grafana rabbit mq queue](https://user-images.githubusercontent.com/1929317/45746222-046d5d00-bc03-11e8-8a42-fe5ad4c15854.png)
