### PR TITLE
SUS-5820 bump php memory limit for mediawiki-tasks

### DIFF
--- a/docker/prod/prod.template.yaml
+++ b/docker/prod/prod.template.yaml
@@ -281,7 +281,7 @@ spec:
           resources:
             limits:
               cpu: 6
-              memory: 1200Mi
+              memory: 1400Mi
             requests:
               cpu: 1
               memory: 800Mi


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5820

Metrics show that the `php` container in `mediawiki-tasks` can on occasion use up almost all of its available momory, however it seems that `php-fpm` respects resource limits set by `cgroups`. The purpose of this change is to verify if this is true. If so, we may revert this PR later. If not this change should provide a safe buffer.