### PR TITLE
SRE-101 | don't return hardcoded 503 for api.php/wikia.php when read-only, for real this time

### DIFF
--- a/includes/WebStart.php
+++ b/includes/WebStart.php
@@ -170,7 +170,7 @@ if ( !defined( 'MW_NO_SETUP' ) ) {
 if(wfReadOnly() && is_object($wgRequest) && $wgRequest->wasPosted()) {
 	if (
 		( strpos(strtolower($_SERVER['REQUEST_URI']), 'datacenter') === false ) &&
-		!in_array( strtolower( $_SERVER['SCRIPT_NAME'] ), [ 'api.php', 'wikia.php' ] )
+		!in_array( strtolower( $_SERVER['SCRIPT_NAME'] ), [ '/api.php', '/wikia.php' ] )
 	) {
 
 		// SUS-2627: emit a proper HTTP error code indicating that something went wrong


### PR DESCRIPTION
`$_SERVER['SCRIPT_NAME']` is `/api.php` or `/wikia.php`, not `api.php` or `wikia.php`. The existing whitelist wouldn't work correctly because of that. With this change those endpoints will be properly ignored even when the read-only flag is set.

https://wikia-inc.atlassian.net/browse/SRE-101