### PR TITLE
SUS-5838 | nginx+fpm - preserve query string when redirect-canonical.php performs a redirect

### DIFF
--- a/redirect-canonical.php
+++ b/redirect-canonical.php
@@ -95,14 +95,9 @@ function getTargetUrl() {
 		header( 'X-Redirected-By: redirect-canonical.php' );
 	}
 
-	// Preserve the query string
-	if ( isset( $_SERVER['REDIRECT_QUERY_STRING'] ) ) {
-		// Called from Apache's ErrorHandler
-		$qs = $_SERVER['REDIRECT_QUERY_STRING'];
-	} else {
-		// Called directly
-		$qs = $_SERVER['QUERY_STRING'];
-	}
+	// SUS-5838 | Preserve the query string
+	$qs = parse_url( $requestUri, PHP_URL_QUERY );
+
 	$url = wfAppendQuery( $url, $qs );
 
 	return $url;
@@ -111,5 +106,8 @@ function getTargetUrl() {
 
 // Issue the redirect
 $url = getTargetUrl();
+
 header( 'Location: ' . $url, true, 301 );
+header ('X-Served-By: '. wfHostname() );
+
 echo sprintf( 'Moved to <a href="%s">%s</a>', htmlspecialchars( $url ), htmlspecialchars( $url ) );


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5838

And emit `X-Served-By` response header:

```
$ curl -svo /dev/null 'http://muppet.dev.wikia-local.com/Gzik?action=render&cb=1234' 2>&1 | egrep '(HTTP|Location|Redirect)'
> GET /Gzik?action=render&cb=1234 HTTP/1.1
< HTTP/1.1 301 Moved Permanently
< X-Redirected-By: redirect-canonical.php
< Location: http://muppet.dev.wikia-local.com/wiki/Gzik?action=render&cb=1234
```