### PR TITLE
PLATFORM-3661: handle wikia and fandom domains on dev

### DIFF
--- a/extensions/wikia/SitemapXml/SitemapHooks.class.php
+++ b/extensions/wikia/SitemapXml/SitemapHooks.class.php
@@ -44,9 +44,9 @@ class SitemapHooks {
 	private static function shouldCancelRedirect( $currentHost, Title $targetTitle ): bool {
 		global $wgWikiaBaseDomain, $wgFandomBaseDomain;
 
-		$currentHost = WikiFactory::normalizeHost( $currentHost );
+		$currentHost = wfNormalizeHost( $currentHost );
 		$targetUrlParsed = parse_url( wfExpandUrl( $targetTitle->getFullURL(), PROTO_CURRENT ) );
-		$targetHost = WikiFactory::normalizeHost( $targetUrlParsed['host'] );
+		$targetHost = wfNormalizeHost( $targetUrlParsed['host'] );
 
 		if ( strpos( $currentHost, ".{$wgWikiaBaseDomain}" ) === false ||
 			strpos( $targetHost, ".{$wgFandomBaseDomain}" ) === false

--- a/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
+++ b/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
@@ -48,7 +48,7 @@ class WikiFactoryLoader {
 	 * @param array $wikiFactoryDomains
 	 */
 	public function  __construct( array $server, array $environment, array $wikiFactoryDomains = [] ) {
-		global $wgDevelEnvironment, $wgExternalSharedDB, $wgWikiaBaseDomain;
+		global $wgDevelEnvironment, $wgExternalSharedDB, $wgWikiaBaseDomain, $wgFandomBaseDomain;
 
 		// initializations
 		$this->mOldServerName = false;
@@ -100,37 +100,44 @@ class WikiFactoryLoader {
 			// nothing can be done at this point
 			throw new InvalidArgumentException( "Cannot tell which wiki it is (neither SERVER_NAME, SERVER_ID nor SERVER_DBNAME is defined)" );
 		}
+		if ( $wgDevelEnvironment ) {
+			global $wgWikiaDevDomain, $wgFandomDevDomain;
+			if ( endsWith( $this->mServerName, '.' . $wgWikiaDevDomain ) ) {
+				$this->mServerName = str_replace( '.' . $wgWikiaDevDomain , '.' . $wgWikiaBaseDomain, $this->mServerName );
+			} elseif ( endsWith( $this->mServerName, '.' . $wgFandomDevDomain ) ) {
+				$this->mServerName = str_replace( '.' . $wgFandomDevDomain , '.' . $wgFandomBaseDomain, $this->mServerName );
+			}
+		} else {
 
-		/**
-		 * @author Krzysztof Krzyżaniak <eloy@wikia-inc.com>
-		 *
-		 * handle additional domains, we have plenty of domains which should
-		 * redirect to <wikia>.wikia.com. They should be added to
-		 * $wgWikiFactoryDomains variable (which is simple list). When
-		 * additional domain is detected we do simple replace:
-		 *
-		 * muppets.wikia.org => muppets.wikia.com
-		 *
-		 * additionally we remove www. prefix
-		 */
+			/**
+			 * @author Krzysztof Krzyżaniak <eloy@wikia-inc.com>
+			 *
+			 * handle additional domains, we have plenty of domains which should
+			 * redirect to <wikia>.wikia.com. They should be added to
+			 * $wgWikiFactoryDomains variable (which is simple list). When
+			 * additional domain is detected we do simple replace:
+			 *
+			 * muppets.wikia.org => muppets.wikia.com
+			 *
+			 * additionally we remove www. prefix
+			 */
+			foreach ( $wikiFactoryDomains as $domain ) {
+				$tldLength = strlen( $this->mServerName ) - strlen( $domain );
 
-		foreach ( $wikiFactoryDomains as $domain ) {
-			$tldLength = strlen( $this->mServerName ) - strlen( $domain );
-
-			if ( $domain !== $wgWikiaBaseDomain && strpos( $this->mServerName, $domain ) === $tldLength ) {
-				$this->mOldServerName = $this->mServerName;
-				$this->mServerName = str_replace( $domain, $wgWikiaBaseDomain, $this->mServerName );
-				// remove extra www. prefix from domain
-				if ( $this->mServerName !== ( 'www.' . $wgWikiaBaseDomain ) ) {  // skip canonical wikia global host
-					$this->mServerName = preg_replace( "/^www\./", "", $this->mServerName );
+				if ( $domain !== $wgWikiaBaseDomain /* i nie jest fandomBaseDomain...?*/ && strpos( $this->mServerName, $domain ) === $tldLength ) {
+					$this->mOldServerName = $this->mServerName;
+					$this->mServerName = str_replace( $domain, $wgWikiaBaseDomain, $this->mServerName );
+					// remove extra www. prefix from domain
+					if ( $this->mServerName !== ( 'www.' . $wgWikiaBaseDomain ) ) {  // skip canonical wikia global host
+						$this->mServerName = preg_replace( "/^www\./", "", $this->mServerName );
+					}
+					$this->mAlternativeDomainUsed = true;
+					break;
 				}
-				$this->mAlternativeDomainUsed = true;
-				break;
 			}
 		}
 
 		WikiFactory::isUsed( true );
-
 		/**
 		 * if run via commandline always take data from database,
 		 * never from cache

--- a/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
+++ b/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
@@ -138,6 +138,7 @@ class WikiFactoryLoader {
 		}
 
 		WikiFactory::isUsed( true );
+
 		/**
 		 * if run via commandline always take data from database,
 		 * never from cache

--- a/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
+++ b/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
@@ -124,7 +124,7 @@ class WikiFactoryLoader {
 			foreach ( $wikiFactoryDomains as $domain ) {
 				$tldLength = strlen( $this->mServerName ) - strlen( $domain );
 
-				if ( $domain !== $wgWikiaBaseDomain /* i nie jest fandomBaseDomain...?*/ && strpos( $this->mServerName, $domain ) === $tldLength ) {
+				if ( $domain !== $wgWikiaBaseDomain && strpos( $this->mServerName, $domain ) === $tldLength ) {
 					$this->mOldServerName = $this->mServerName;
 					$this->mServerName = str_replace( $domain, $wgWikiaBaseDomain, $this->mServerName );
 					// remove extra www. prefix from domain

--- a/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
+++ b/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
@@ -439,7 +439,7 @@ class WikiFactoryLoader {
 		 * check if not additional domain was used (then we redirect anyway)
 		 */
 		$cond2 = $this->mAlternativeDomainUsed &&
-			( $url['host'] != WikiFactory::normalizeHost( $this->mOldServerName ) );
+			( $url['host'] != wfNormalizeHost( $this->mOldServerName ) );
 
 		$redirectUrl = WikiFactory::getLocalEnvURL( $this->mCityUrl );
 		$shouldUseHttps = ( $wgEnableHTTPSForAnons || !empty( $_SERVER['HTTP_FASTLY_SSL'] ) ) &&

--- a/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
+++ b/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
@@ -102,10 +102,10 @@ class WikiFactoryLoader {
 		}
 		if ( $wgDevelEnvironment ) {
 			global $wgWikiaDevDomain, $wgFandomDevDomain;
-			if ( endsWith( $this->mServerName, '.' . $wgWikiaDevDomain ) ) {
-				$this->mServerName = str_replace( '.' . $wgWikiaDevDomain , '.' . $wgWikiaBaseDomain, $this->mServerName );
-			} elseif ( endsWith( $this->mServerName, '.' . $wgFandomDevDomain ) ) {
-				$this->mServerName = str_replace( '.' . $wgFandomDevDomain , '.' . $wgFandomBaseDomain, $this->mServerName );
+			if ( endsWith( $this->mServerName, $wgWikiaDevDomain ) ) {
+				$this->mServerName = str_replace( $wgWikiaDevDomain , $wgWikiaBaseDomain, $this->mServerName );
+			} elseif ( endsWith( $this->mServerName, $wgFandomDevDomain ) ) {
+				$this->mServerName = str_replace( $wgFandomDevDomain , $wgFandomBaseDomain, $this->mServerName );
 			}
 		} else {
 

--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -1308,13 +1308,12 @@ class WikiFactory {
 		$baseDomain = wfGetBaseDomainForHost( $server );
 
 		$server = static::normalizeHost( $server );
-		$wikiaDomainUsed = false;
+
+		$wikiaDomainUsed = $fandomDomainUsed = false;
 		if ( endsWith( $server, ".{$wgWikiaBaseDomain}" ) ) {
 			$server = str_replace( ".{$wgWikiaBaseDomain}", '', $server );
 			$wikiaDomainUsed = true;
-
 		}
-		$fandomDomainUsed = false;
 		if ( endsWith($server, ".{$wgFandomBaseDomain}" ) ) {
 			$server = str_replace( ".{$wgFandomBaseDomain}", '', $server );
 			$fandomDomainUsed = true;

--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -575,7 +575,7 @@ class WikiFactory {
 		$dbr = static::db( DB_SLAVE );
 
 		$url = parse_url( $wgServer );
-		$server = static::normalizeHost( $url['host'] );
+		$server = wfNormalizeHost( $url['host'] );
 		$where = [
 			$dbr->makeList( [
 				'city_url ' . $dbr->buildLike( "http://{$server}/", $dbr->anyString() ),
@@ -1238,29 +1238,6 @@ class WikiFactory {
 	}
 
 	/**
-	 * "Unlocalizes" the host replaces env-specific domains with "wikia.com", for example
-	 * 'muppet.preview.wikia.com' -> 'muppet.wikia.com'
-	 *
-	 * @param $host
-	 * @return string normalized host name
-	 */
-	public static function normalizeHost( $host ) {
-		global $wgDevelEnvironment, $wgWikiaBaseDomain, $wgFandomBaseDomain, $wgWikiaDevDomain, $wgFandomDevDomain;
-		$baseDomain = wfGetBaseDomainForHost( $host );
-
-		// strip env-specific pre- and suffixes for staging environment
-		$host = preg_replace(
-			'/\.(stable|preview|verify|sandbox-[a-z0-9]+)\.' . preg_quote( $baseDomain ) . '/',
-			".{$baseDomain}",
-			$host );
-		if ( !empty( $wgDevelEnvironment ) ) {
-			$host = str_replace( ".{$wgWikiaDevDomain}", ".{$wgWikiaBaseDomain}", $host );
-			$host = str_replace( ".{$wgFandomDevDomain}", ".{$wgFandomBaseDomain}", $host );
-		}
-		return $host;
-	}
-
-	/**
 	 * getLocalEnvURL
 	 *
 	 * return URL specific to current env:
@@ -1307,7 +1284,7 @@ class WikiFactory {
 
 		$baseDomain = wfGetBaseDomainForHost( $server );
 
-		$server = static::normalizeHost( $server );
+		$server = wfNormalizeHost( $server );
 
 		$wikiaDomainUsed = $fandomDomainUsed = false;
 		if ( endsWith( $server, ".{$wgWikiaBaseDomain}" ) ) {

--- a/extensions/wikia/WikiFactory/tests/WikiFactoryTest.php
+++ b/extensions/wikia/WikiFactory/tests/WikiFactoryTest.php
@@ -243,7 +243,6 @@ class WikiFactoryTest extends WikiaBaseTest {
 		];
 	}
 
-
 	public function testRenderValueOfVariableWithoutValue() {
 		$variable = new stdClass();
 

--- a/extensions/wikia/WikiFactory/tests/WikiFactoryTest.php
+++ b/extensions/wikia/WikiFactory/tests/WikiFactoryTest.php
@@ -30,10 +30,11 @@ class WikiFactoryTest extends WikiaBaseTest {
 	}
 
 	/**
-	 * @dataProvider prepareUrlToParseDataProvider
+	 * @dataProvider normalizeHostDataProvider
 	 */
-	public function testPrepareUrlToParse( $url, $expected ) {
-		$url = WikiFactory::prepareUrlToParse( $url );
+	public function testNormalizeHost( $environment, $host, $expected ) {
+		$this->mockEnvironment( $environment );
+		$url = WikiFactory::normalizeHost( $host );
 		$this->assertEquals( $expected, $url );
 	}
 
@@ -148,6 +149,12 @@ class WikiFactoryTest extends WikiaBaseTest {
 				'expected' => 'https://muppet.' . static::MOCK_DEV_NAME . '.wikia-dev.us/wiki'
 			],
 			[
+				'env' => WIKIA_ENV_DEV,
+				'forcedEnv' => null,
+				'url' => 'https://muppet.fandom.com/wiki',
+				'expected' => 'https://muppet.' . static::MOCK_DEV_NAME . '.fandom-dev.us/wiki'
+			],
+			[
 				'env' => WIKIA_ENV_PROD,
 				'forcedEnv' => null,
 				'url' => '//www.wikia.com/wiki/test',
@@ -212,6 +219,30 @@ class WikiFactoryTest extends WikiaBaseTest {
 			]
 		];
 	}
+
+	/**
+	 * @dataProvider prepareUrlToParseDataProvider
+	 */
+	public function testPrepareUrlToParse( $url, $expected ) {
+		$url = WikiFactory::prepareUrlToParse( $url );
+		$this->assertEquals( $expected, $url );
+	}
+
+	public function normalizeHostDataProvider() {
+		return [
+			[
+				'env' => WIKIA_ENV_DEV,
+				'url' => 'http://muppet.' . static::MOCK_DEV_NAME . '.wikia-dev.us',
+				'expected' => 'http://muppet.wikia.com'
+			],
+			[
+				'env' => WIKIA_ENV_DEV,
+				'url' => 'http://muppet.' . static::MOCK_DEV_NAME . '.fandom-dev.us',
+				'expected' => 'http://muppet.fandom.com'
+			],
+		];
+	}
+
 
 	public function testRenderValueOfVariableWithoutValue() {
 		$variable = new stdClass();

--- a/extensions/wikia/WikiFactory/tests/WikiFactoryTest.php
+++ b/extensions/wikia/WikiFactory/tests/WikiFactoryTest.php
@@ -29,15 +29,6 @@ class WikiFactoryTest extends WikiaBaseTest {
 		$this->assertEquals( $expected, $url );
 	}
 
-	/**
-	 * @dataProvider normalizeHostDataProvider
-	 */
-	public function testNormalizeHost( $environment, $host, $expected ) {
-		$this->mockEnvironment( $environment );
-		$url = WikiFactory::normalizeHost( $host );
-		$this->assertEquals( $expected, $url );
-	}
-
 	public function getLocalEnvURLDataProvider() {
 		return [
 			[
@@ -226,21 +217,6 @@ class WikiFactoryTest extends WikiaBaseTest {
 	public function testPrepareUrlToParse( $url, $expected ) {
 		$url = WikiFactory::prepareUrlToParse( $url );
 		$this->assertEquals( $expected, $url );
-	}
-
-	public function normalizeHostDataProvider() {
-		return [
-			[
-				'env' => WIKIA_ENV_DEV,
-				'url' => 'http://muppet.' . static::MOCK_DEV_NAME . '.wikia-dev.us',
-				'expected' => 'http://muppet.wikia.com'
-			],
-			[
-				'env' => WIKIA_ENV_DEV,
-				'url' => 'http://muppet.' . static::MOCK_DEV_NAME . '.fandom-dev.us',
-				'expected' => 'http://muppet.fandom.com'
-			],
-		];
 	}
 
 	public function testRenderValueOfVariableWithoutValue() {

--- a/includes/OutputPage.php
+++ b/includes/OutputPage.php
@@ -2123,6 +2123,7 @@ class OutputPage extends ContextSource {
 				if ( !$this->getRequest()->wasPosted() && $current == $redirect ) {
 					$response->header( 'HTTP/1.1 508 Loop Detected' );
 					$response->header( 'X-Reason: Redirect loop detected' );
+					$response->header( 'X-Redirected-By: ' . join( ' ', $this->redirectedBy) );
 					\Wikia\Logger\WikiaLogger::instance()->error(
 						'Redirect loop detected', [
 							'currentUrl' => $current,

--- a/includes/wikia/GlobalFunctions.php
+++ b/includes/wikia/GlobalFunctions.php
@@ -1558,3 +1558,26 @@ function wfGetBaseDomainForHost( $host ) {
 
 	return $wgWikiaBaseDomain;
 }
+
+/**
+ * "Unlocalizes" the host replaces env-specific domains with "wikia.com", for example
+ * 'muppet.preview.wikia.com' -> 'muppet.wikia.com'
+ *
+ * @param $host
+ * @return string normalized host name
+ */
+function wfNormalizeHost( $host ) {
+	global $wgDevelEnvironment, $wgWikiaBaseDomain, $wgFandomBaseDomain, $wgWikiaDevDomain, $wgFandomDevDomain;
+	$baseDomain = wfGetBaseDomainForHost( $host );
+
+	// strip env-specific pre- and suffixes for staging environment
+	$host = preg_replace(
+		'/\.(stable|preview|verify|sandbox-[a-z0-9]+)\.' . preg_quote( $baseDomain ) . '/',
+		".{$baseDomain}",
+		$host );
+	if ( !empty( $wgDevelEnvironment ) ) {
+		$host = str_replace( ".{$wgWikiaDevDomain}", ".{$wgWikiaBaseDomain}", $host );
+		$host = str_replace( ".{$wgFandomDevDomain}", ".{$wgFandomBaseDomain}", $host );
+	}
+	return $host;
+}

--- a/includes/wikia/GlobalFunctions.php
+++ b/includes/wikia/GlobalFunctions.php
@@ -1503,14 +1503,15 @@ function wfHttpsToHttp( $url ) {
 }
 
 function wfHttpsAllowedForURL( $url ): bool {
-	global $wgDevDomain, $wgWikiaEnvironment, $wgDevelEnvironment;
+	global $wgWikiaDevDomain, $wgFandomDevDomain, $wgWikiaEnvironment, $wgDevelEnvironment;
 	$host = parse_url( $url, PHP_URL_HOST );
 	if ( $host === false ) {
 		return false;
 	}
 
-	if ( $wgDevelEnvironment && !empty( $wgDevDomain ) ) {
-		$server = str_replace( ".{$wgDevDomain}", '', $host );
+	if ( $wgDevelEnvironment ) {
+		$server = str_replace( ".{$wgWikiaDevDomain}", '', $host );
+		$server = str_replace( ".{$wgFandomDevDomain}", '', $server );
 	} else {
 		$baseDomain = wfGetBaseDomainForHost( $host );
 

--- a/includes/wikia/tests/UrlHelpersTest.php
+++ b/includes/wikia/tests/UrlHelpersTest.php
@@ -1,0 +1,28 @@
+<?php
+
+class UrlHelpersTest extends WikiaBaseTest {
+
+	/**
+	 * @dataProvider normalizeHostDataProvider
+	 */
+	public function testNormalizeHost( $environment, $host, $expected ) {
+		$this->mockEnvironment( $environment );
+		$url = wfNormalizeHost( $host );
+		$this->assertEquals( $expected, $url );
+	}
+
+	public function normalizeHostDataProvider() {
+		return [
+			[
+				'env' => WIKIA_ENV_DEV,
+				'url' => 'http://muppet.' . static::MOCK_DEV_NAME . '.wikia-dev.us',
+				'expected' => 'http://muppet.wikia.com'
+			],
+			[
+				'env' => WIKIA_ENV_DEV,
+				'url' => 'http://muppet.' . static::MOCK_DEV_NAME . '.fandom-dev.us',
+				'expected' => 'http://muppet.fandom.com'
+			],
+		];
+	}
+}

--- a/includes/wikia/tests/UrlHelpersTest.php
+++ b/includes/wikia/tests/UrlHelpersTest.php
@@ -20,8 +20,8 @@ class UrlHelpersTest extends WikiaBaseTest {
 			],
 			[
 				'env' => WIKIA_ENV_DEV,
-				'url' => 'http://muppet.' . static::MOCK_DEV_NAME . '.fandom-dev.us',
-				'expected' => 'http://muppet.fandom.com'
+				'url' => 'https://muppet.' . static::MOCK_DEV_NAME . '.fandom-dev.us',
+				'expected' => 'https://muppet.fandom.com'
 			],
 		];
 	}

--- a/includes/wikia/tests/core/WikiaBaseTest.class.php
+++ b/includes/wikia/tests/core/WikiaBaseTest.class.php
@@ -479,6 +479,8 @@ abstract class WikiaBaseTest extends TestCase {
 	protected function mockDevEnv() {
 		$this->mockGlobalVariable( 'wgDevelEnvironmentName', self::MOCK_DEV_NAME );
 		$this->mockGlobalVariable( 'wgDevDomain', self::MOCK_DEV_NAME . '.wikia-dev.us' );
+		$this->mockGlobalVariable( 'wgWikiaDevDomain', self::MOCK_DEV_NAME . '.wikia-dev.us' );
+		$this->mockGlobalVariable( 'wgFandomDevDomain', self::MOCK_DEV_NAME . '.fandom-dev.us' );
 		$this->getStaticMethodMock( 'WikiFactory', 'getExternalHostName' )
 			->expects( $this->any() )
 			->method( 'getExternalHostName' )

--- a/tests/travis/config/dev.php
+++ b/tests/travis/config/dev.php
@@ -42,4 +42,6 @@ $wgExternalServers['blobs'] = [[
 ]];
 
 $wgDevDomain = 'wikia.com';
+$wgWikiaDevDomain = 'wikia.com';
+$wgFandomDevDomain = 'fandom.com';
 $wgMysqlConnectionCharacterSet = 'latin1';


### PR DESCRIPTION
Distinguish between fandom and wikia domains on devboxes (to fix fandom-dev redirects and to make it more prod-like).
After this change, only wikis with `fandom.com` in the `city_url` will be available under the `fandom-dev.(pl|us)` domain. Also redirects between fandom-dev and wikia-dev will work, given a wikis has both domains configured in the `city_domains` table.