### PR TITLE
SUS-5842 | rewrite URLs that point to not existing PHP files

### DIFF
--- a/docker/dev/site.conf
+++ b/docker/dev/site.conf
@@ -61,7 +61,7 @@ server {
     # e.g. https://scratchpad.wikia.com/wiki/Scratchpad:Parameters_to_index.php
 
     # known MediaWiki PHP endpoints
-    location ~ ^/(api|health|index|load|extensions/wikia/Tasks/proxy/proxy|redirect-canonical|wikia|wikia-robots-txt)\.php {
+    location ~ ^/(api|health|index|load|opensearch_desc|extensions/wikia/Tasks/proxy/proxy|redirect-canonical|server|wikia|wikia-robots-txt)\.php {
         fastcgi_read_timeout 180s;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass php-wikia:9000;

--- a/docker/dev/site.conf
+++ b/docker/dev/site.conf
@@ -5,7 +5,7 @@ server {
 
     # ease debugging on rewrites defined below
     rewrite_log on;
-    error_log  /var/log/nginx/error.log notice;
+    error_log  /var/log/nginx/error.log debug;
 
     rewrite "^/health/check$" /health.php break;
     rewrite "^/proxy.php$" /extensions/wikia/Tasks/proxy/proxy.php break;
@@ -56,14 +56,12 @@ server {
         return 403;
     }
 
-    location ~ [^/]\.php(/|$) {
-        # SUS-5842 rewrite URLs that point to not existing PHP files
-        # they are highly likely wiki articles
-        # e.g. https://scratchpad.wikia.com/wiki/Scratchpad:Parameters_to_index.php
-        if ($uri !~ ^/(index).php) {
-            rewrite "^/(.*)$" /index.php?title=$1 last;
-        }
+    # SUS-5842 rewrite URLs that point to not existing PHP files
+    # they are highly likely wiki articles
+    # e.g. https://scratchpad.wikia.com/wiki/Scratchpad:Parameters_to_index.php
 
+    # known MediaWiki PHP endpoints
+    location ~ ^/(api|health|index|load|extensions/wikia/Tasks/proxy/proxy|redirect-canonical|wikia)\.php {
         fastcgi_read_timeout 180s;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass php-wikia:9000;

--- a/docker/dev/site.conf
+++ b/docker/dev/site.conf
@@ -61,7 +61,7 @@ server {
     # e.g. https://scratchpad.wikia.com/wiki/Scratchpad:Parameters_to_index.php
 
     # known MediaWiki PHP endpoints
-    location ~ ^/(api|health|index|load|extensions/wikia/Tasks/proxy/proxy|redirect-canonical|wikia)\.php {
+    location ~ ^/(api|health|index|load|extensions/wikia/Tasks/proxy/proxy|redirect-canonical|wikia|wikia-robots-txt)\.php {
         fastcgi_read_timeout 180s;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass php-wikia:9000;

--- a/docker/dev/site.conf
+++ b/docker/dev/site.conf
@@ -57,6 +57,13 @@ server {
     }
 
     location ~ [^/]\.php(/|$) {
+        # SUS-5842 rewrite URLs that point to not existing PHP files
+        # they are highly likely wiki articles
+        # e.g. https://scratchpad.wikia.com/wiki/Scratchpad:Parameters_to_index.php
+        if ($uri !~ ^/(index).php) {
+            rewrite "^/(.*)$" /index.php?title=$1 last;
+        }
+
         fastcgi_read_timeout 180s;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass php-wikia:9000;

--- a/docker/dev/site.conf
+++ b/docker/dev/site.conf
@@ -7,6 +7,9 @@ server {
     rewrite_log on;
     error_log  /var/log/nginx/error.log notice;
 
+    rewrite "^/health/check$" /health.php break;
+    rewrite "^/proxy.php$" /extensions/wikia/Tasks/proxy/proxy.php break;
+
     rewrite ^/robots.txt /wikia-robots-txt.php break;
     rewrite "^/(sitemap.+\.xml(.gz)*)$" /index.php?title=Special:Sitemap/$1&uselang=en break;
 

--- a/docker/prod/site.conf.template
+++ b/docker/prod/site.conf.template
@@ -53,7 +53,12 @@ server {
         return 403;
     }
 
-    location ~ [^/]\.php(/|$) {
+    # SUS-5842 rewrite URLs that point to not existing PHP files
+    # they are highly likely wiki articles
+    # e.g. https://scratchpad.wikia.com/wiki/Scratchpad:Parameters_to_index.php
+
+    # known MediaWiki PHP endpoints
+    location ~ ^/(api|health|index|load|extensions/wikia/Tasks/proxy/proxy|redirect-canonical|wikia|wikia-robots-txt)\.php {
         fastcgi_read_timeout ${FASTCGI_READ_TIMEOUT};
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass localhost:9000;

--- a/docker/prod/site.conf.template
+++ b/docker/prod/site.conf.template
@@ -58,7 +58,7 @@ server {
     # e.g. https://scratchpad.wikia.com/wiki/Scratchpad:Parameters_to_index.php
 
     # known MediaWiki PHP endpoints
-    location ~ ^/(api|health|index|load|extensions/wikia/Tasks/proxy/proxy|redirect-canonical|wikia|wikia-robots-txt)\.php {
+    location ~ ^/(api|health|index|load|opensearch_desc|extensions/wikia/Tasks/proxy/proxy|redirect-canonical|server|wikia|wikia-robots-txt)\.php {
         fastcgi_read_timeout ${FASTCGI_READ_TIMEOUT};
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass localhost:9000;

--- a/docker/sandbox/site.conf
+++ b/docker/sandbox/site.conf
@@ -58,7 +58,7 @@ server {
     # e.g. https://scratchpad.wikia.com/wiki/Scratchpad:Parameters_to_index.php
 
     # known MediaWiki PHP endpoints
-    location ~ ^/(api|health|index|load|extensions/wikia/Tasks/proxy/proxy|redirect-canonical|wikia|wikia-robots-txt)\.php {
+    location ~ ^/(api|health|index|load|opensearch_desc|extensions/wikia/Tasks/proxy/proxy|redirect-canonical|server|wikia|wikia-robots-txt)\.php {
         fastcgi_read_timeout 180s;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass localhost:9000;

--- a/docker/sandbox/site.conf
+++ b/docker/sandbox/site.conf
@@ -53,7 +53,12 @@ server {
         return 403;
     }
 
-    location ~ [^/]\.php(/|$) {
+    # SUS-5842 rewrite URLs that point to not existing PHP files
+    # they are highly likely wiki articles
+    # e.g. https://scratchpad.wikia.com/wiki/Scratchpad:Parameters_to_index.php
+
+    # known MediaWiki PHP endpoints
+    location ~ ^/(api|health|index|load|extensions/wikia/Tasks/proxy/proxy|redirect-canonical|wikia|wikia-robots-txt)\.php {
         fastcgi_read_timeout 180s;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass localhost:9000;

--- a/extensions/3rdparty/LyricWiki/server.php
+++ b/extensions/3rdparty/LyricWiki/server.php
@@ -84,6 +84,8 @@ if(!$SHUT_DOWN_API){
 
 wfDebug("LWSOAP: Done initializing MediaWiki.  Proceeding to SOAP-specific initialization.\n");
 
+header( 'X-Served-By: ' . wfHostname() );
+
 GLOBAL $wgUser;
 GLOBAL $server; // so that the functions can get the headers to log in.
 

--- a/server.php
+++ b/server.php
@@ -1,6 +1,6 @@
 <?php
 
 /**
- * just entry point. whole file is somwhere else
+ * just entry point. whole file is somewhere else
  */
-require_once( dirname( __FILE__ ) . "/extensions/3rdparty/LyricWiki/server.php" );
+require_once( __DIR__ . "/extensions/3rdparty/LyricWiki/server.php" );

--- a/wikia-robots-txt.php
+++ b/wikia-robots-txt.php
@@ -28,6 +28,7 @@ if ( !$output->isRedirect() || $robotsRedirect->redirectCancelled ) {
 	header( 'Content-Type: text/plain' );
 	header( 'Cache-Control: s-maxage=' . $wikiaRobots->getRobotsTxtCachePeriod() );
 	header( 'X-Pass-Cache-Control: public, max-age=' . $wikiaRobots->getRobotsTxtCachePeriod() );
+	header( 'X-Served-By: ' . wfHostname() );
 
 	echo join( PHP_EOL, $robots->getContents() ) . PHP_EOL;
 }


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5842

```
$ curl -svo /dev/null 'http://muppet.dev.wikia-local.com/threaten/popup-pomo.php' 2>&1  | egrep '(HTTP|Location|Redirect|Serve)'
> GET /threaten/popup-pomo.php HTTP/1.1
< HTTP/1.1 301 Moved Permanently
< Server: nginx/1.14.0
< X-Redirected-By: redirect-canonical.php
< Location: http://muppet.dev.wikia-local.com/wiki/Threaten/popup-pomo.php
```

And add `X-Served-By` response header to `/robots.txt` requests.