### PR TITLE
SEO-665 | Hide file pages from robots

### DIFF
--- a/extensions/wikia/CategoryExhibition/templates/item-media.tmpl.php
+++ b/extensions/wikia/CategoryExhibition/templates/item-media.tmpl.php
@@ -7,6 +7,7 @@
 			   data-ref="<?= Sanitizer::encodeAttribute( $row['data-ref'] ); ?>"
 			   class="<?= Sanitizer::encodeAttribute( $row['class'] ); ?>"
 			   title="<?= Sanitizer::encodeAttribute( $row['title'] ); ?>"
+			   rel="nofollow"
 			>
 				<? if ( $row['isVideo'] == true ): ?>
 					<span class="thumbnail-play-icon-container">
@@ -35,7 +36,8 @@
 	<div class="title">
 		<a href="<?= Sanitizer::encodeAttribute( $row['url'] ); ?>"
 		   class="<?= Sanitizer::encodeAttribute( $row['class'] ); ?>"
-		   title="<?= Sanitizer::encodeAttribute( $row['title'] ); ?>">
+		   title="<?= Sanitizer::encodeAttribute( $row['title'] ); ?>"
+		   rel="nofollow">
 			<?= htmlspecialchars( $row['title'] ); ?>
 		</a>
 	</div>

--- a/extensions/wikia/Lightbox/templates/Lightbox_lightboxModalContent.php
+++ b/extensions/wikia/Lightbox/templates/Lightbox_lightboxModalContent.php
@@ -49,7 +49,7 @@
 			<input class="lightbox-article-input" />
 		</div>
 
-		<h1><a href="{{fileUrl}}">{{fileTitle}}</a></h1>
+		<h1><a href="{{fileUrl}}" rel="nofollow">{{fileTitle}}</a></h1>
 		<a href="{{rawImageUrl}}" class="see-full-size-link"><?= wfMsg('lightbox-header-see-full-size-image') ?></a>
 		<div class="user-details caption">
 			{{#caption}}<p>{{caption}}</p>{{/caption}}

--- a/extensions/wikia/SEOTweaks/SEOTweaksHooksHelper.class.php
+++ b/extensions/wikia/SEOTweaks/SEOTweaksHooksHelper.class.php
@@ -158,7 +158,7 @@ class SEOTweaksHooksHelper {
 
 		$ns = MWNamespace::getSubject( $title->getNamespace() );
 
-		if ( in_array( $ns, [ NS_MEDIAWIKI, NS_TEMPLATE ] ) ) {
+		if ( in_array( $ns, [ NS_FILE, NS_MEDIAWIKI, NS_TEMPLATE ] ) ) {
 			$policy = [
 				'index' => 'noindex',
 				'follow' => 'follow'

--- a/extensions/wikia/SitemapXml/SitemapXmlController.class.php
+++ b/extensions/wikia/SitemapXml/SitemapXmlController.class.php
@@ -29,7 +29,6 @@ class SitemapXmlController extends WikiaController {
 	 */
 	const SEPARATE_SITEMAPS = [
 		NS_MAIN,
-		NS_FILE,
 		NS_CATEGORY,
 	];
 

--- a/extensions/wikia/SpecialVideos/SpecialVideosSpecialController.class.php
+++ b/extensions/wikia/SpecialVideos/SpecialVideosSpecialController.class.php
@@ -37,9 +37,6 @@ class SpecialVideosSpecialController extends WikiaSpecialPageController {
 		$this->getContext()->getOutput()->setPageTitle( wfMessage( 'specialvideos-page-title' )->text() );
 		$this->getContext()->getOutput()->setHTMLTitle( wfMessage( 'specialvideos-html-title' )->text() );
 
-		// For search engines
-		$this->getContext()->getOutput()->setRobotPolicy( "index,follow" );
-
 		$helper = new SpecialVideosHelper();
 
 		// Add meta description tag to HTML source

--- a/extensions/wikia/SpecialVideos/SpecialVideosSpecialController.class.php
+++ b/extensions/wikia/SpecialVideos/SpecialVideosSpecialController.class.php
@@ -37,6 +37,9 @@ class SpecialVideosSpecialController extends WikiaSpecialPageController {
 		$this->getContext()->getOutput()->setPageTitle( wfMessage( 'specialvideos-page-title' )->text() );
 		$this->getContext()->getOutput()->setHTMLTitle( wfMessage( 'specialvideos-html-title' )->text() );
 
+		// For search engines
+		$this->getContext()->getOutput()->setRobotPolicy( "index,follow" );
+
 		$helper = new SpecialVideosHelper();
 
 		// Add meta description tag to HTML source

--- a/extensions/wikia/Thumbnails/ThumbnailVideo.class.php
+++ b/extensions/wikia/Thumbnails/ThumbnailVideo.class.php
@@ -116,6 +116,7 @@ class ThumbnailVideo extends ThumbnailImage {
 		$useRDFData = ( !empty( $options['disableRDF'] ) && $options['disableRDF'] == true ) ? false : true;
 		$linkAttribs = array(
 			'href' => $videoTitle->getLocalURL(),
+			'rel' => 'nofollow'
 		);
 
 		if ( !empty( $options['id'] ) ) {

--- a/extensions/wikia/Thumbnails/templates/Thumbnail_articleBlock.mustache
+++ b/extensions/wikia/Thumbnails/templates/Thumbnail_articleBlock.mustache
@@ -3,7 +3,7 @@
 
 	<figcaption>
 		{{#showInfoIcon}}
-			<a href="{{filePageLink}}" class="sprite info-icon"></a>
+			<a href="{{filePageLink}}" rel="nofollow" class="sprite info-icon"></a>
 		{{/showInfoIcon}}
 		{{#title}}
 			<p class="title">{{title}}</p>

--- a/extensions/wikia/Thumbnails/templates/Thumbnail_video.mustache
+++ b/extensions/wikia/Thumbnails/templates/Thumbnail_video.mustache
@@ -1,6 +1,6 @@
 <a
 	href="{{linkHref}}"
-    rel="nofollow"
+	rel="nofollow"
 	class="video video-thumbnail {{#linkClasses}}{{.}} {{/linkClasses}}"
 	{{#linkId}} id="{{id}}" {{/linkId}}
 	{{#rdf}} itemprop='video' itemscope itemtype="http://schema.org/VideoObject"{{/rdf}}

--- a/extensions/wikia/Thumbnails/templates/Thumbnail_video.mustache
+++ b/extensions/wikia/Thumbnails/templates/Thumbnail_video.mustache
@@ -1,5 +1,6 @@
 <a
 	href="{{linkHref}}"
+    rel="nofollow"
 	class="video video-thumbnail {{#linkClasses}}{{.}} {{/linkClasses}}"
 	{{#linkId}} id="{{id}}" {{/linkId}}
 	{{#rdf}} itemprop='video' itemscope itemtype="http://schema.org/VideoObject"{{/rdf}}

--- a/extensions/wikia/WikiaPhotoGallery/WikiaPhotoGallery.class.php
+++ b/extensions/wikia/WikiaPhotoGallery/WikiaPhotoGallery.class.php
@@ -989,8 +989,9 @@ class WikiaPhotoGallery extends ImageGallery {
 			$linkAttribs = array(
 				'class' => empty( $image['thumbnail'] ) ? 'image-no-lightbox' : $image['classes'],
 				'href' => $image['link'],
-				'title' => $image['linkTitle'] . ( isset( $image['bytes'] ) ? ' (' . $skin->formatSize( $image['bytes'] ) . ')':"" ),
-				'style' => "height:{$image['height']}px; width:{$image['width']}px;"
+				'rel' => 'nofollow',
+				'style' => "height:{$image['height']}px; width:{$image['width']}px;",
+				'title' => $image['linkTitle'] . ( isset( $image['bytes'] ) ? ' (' . $skin->formatSize( $image['bytes'] ) . ')':"" )
 			);
 
 			if ( !empty( $image['thumbnail'] ) ) {

--- a/extensions/wikia/WikiaPhotoGallery/WikiaPhotoGalleryHelper.class.php
+++ b/extensions/wikia/WikiaPhotoGallery/WikiaPhotoGalleryHelper.class.php
@@ -185,6 +185,7 @@ class WikiaPhotoGalleryHelper {
 		$linkAttribs = array(
 			'class' => 'image lightbox',
 			'href' => $url,
+			'rel' => 'nofollow',
 			'title' => $text,
 		);
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SEO-665

- File namespace pages are set as noindex
- File namespace pages are excluded from sitemaps
- In content links to the file namespace pages from media included in articles have `rel="nofollow"` added to them

Tests: https://github.com/Wikia/seo-tests/pull/73

@Wikia/core-platform-team 