### PR TITLE
(PLATFORM-3724) Don't interpolate title from path for sitemap URLs

### DIFF
--- a/extensions/wikia/SitemapXml/SitemapHooks.class.php
+++ b/extensions/wikia/SitemapXml/SitemapHooks.class.php
@@ -41,6 +41,21 @@ class SitemapHooks {
 		return false;
 	}
 
+	/**
+	 * Used to abort rewriting the title URL parameter for sitemap URLs on
+	 * short URL wikis (i.e. those with an article path of /$1 rather than
+	 * /wiki/$1).
+	 *
+	 * @param  string $path
+	 * @return bool
+	 */
+	public static function onWebRequestPathInfoRouterAbort( $path ): bool {
+		if ( preg_match( '/^\/(sitemap.+\.xml[.gz]*)$/', $path ) ) {
+			return false;
+		}
+		return true;
+	}
+
 	private static function shouldCancelRedirect( $currentHost, Title $targetTitle ): bool {
 		global $wgWikiaBaseDomain, $wgFandomBaseDomain;
 

--- a/extensions/wikia/SitemapXml/SitemapXml.setup.php
+++ b/extensions/wikia/SitemapXml/SitemapXml.setup.php
@@ -51,3 +51,4 @@ $wgAutoloadClasses['SitemapXmlController'] = __DIR__ . '/SitemapXmlController.cl
 
 $wgHooks['BeforeTitleRedirect'][] = 'SitemapHooks::onBeforeTitleRedirect';
 $wgHooks['TestCanonicalRedirect'][] = 'SitemapHooks::onTestCanonicalRedirect';
+$wgHooks['WebRequestPathInfoRouterAbort'][] = 'SitemapHooks::onWebRequestPathInfoRouterAbort';

--- a/includes/WebRequest.php
+++ b/includes/WebRequest.php
@@ -106,6 +106,12 @@ class WebRequest implements Wikia\Interfaces\IRequest {
 					return $matches;
 				}
 
+				// Wikia change begin - PLATFORM-3724
+				if ( !Hooks::run( 'WebRequestPathInfoRouterAbort', [ $path ] ) ) {
+					return $matches;
+				}
+				// Wikia change end
+
 				$router = new PathRouter;
 
 				// Raw PATH_INFO style


### PR DESCRIPTION
Don't interpolate title from path for sitemap URLs as these break on short
URL wikis where the article path is /$1.

/cc @Wikia/core-platform-team 