### PR TITLE
SRE-105 | Avoid useless "USE ... " queries in MediaWiki

### DIFF
--- a/includes/db/DatabaseMysqli.php
+++ b/includes/db/DatabaseMysqli.php
@@ -151,8 +151,13 @@ class DatabaseMysqli extends DatabaseMysqlBase {
 	 * @return bool
 	 */
 	function selectDB( $db ) {
-		$this->mDBname = $db;
-		return $this->mConn->select_db( $db );
+		// SRE-105: Only change the DB explicitly if it was actually changed
+		if ( $this->mDBname !== $db ) {
+			$this->mDBname = $db;
+			return $this->mConn->select_db( $db );
+		}
+
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
MediaWiki always issues an explicit *USE ...*  query after establishing a database connection if it was given an explicit DB name. However this is redundant because it establishes the connection with the proper DB name.

https://wikia-inc.atlassian.net/browse/SRE-105