### PR TITLE
CAKE-3834 | Update resource route

### DIFF
--- a/extensions/wikia/FandomCreator/FandomCreatorApi.php
+++ b/extensions/wikia/FandomCreator/FandomCreatorApi.php
@@ -40,7 +40,7 @@ class FandomCreatorApi {
 	}
 
 	public function getSitemap( $communityId ) {
-		$response = $this->doApiRequest( "{$this->baseUrl}/communities/{$communityId}/sitemap" );
+		$response = $this->doApiRequest( "{$this->baseUrl}/communities/{$communityId}/navigation" );
 		if ( !$response->status->isOK() ) {
 			return null;
 		}


### PR DESCRIPTION
@Wikia/cake @Wikia/sus

Uses the new resource (https://github.com/Wikia/pandora/blob/master/service/content-graph/content-graph-service/src/main/java/com/wikia/services/contentgraph/resources/NavigationResource.java#L57) but retains the original structure. 

Waiting for the final migration to populate site_navigation table before merging this. 