### PR TITLE
increase memory limit for mediawiki-tasks

### DIFF
--- a/docker/prod/prod.template.yaml
+++ b/docker/prod/prod.template.yaml
@@ -281,7 +281,7 @@ spec:
           resources:
             limits:
               cpu: 6
-              memory: 1400Mi
+              memory: 2Gi
             requests:
               cpu: 1
               memory: 800Mi


### PR DESCRIPTION
There have been more spikes in memory usage lately, and we're increasing load on `mediawiki-tasks`. Bumping memory limit to 2 gigabytes.