### PR TITLE
(PLATFORM-3721) Make sure sitemap URLs in robots.txt are HTTPS

### DIFF
--- a/extensions/wikia/RobotsTxt/classes/WikiaRobots.class.php
+++ b/extensions/wikia/RobotsTxt/classes/WikiaRobots.class.php
@@ -161,7 +161,8 @@ class WikiaRobots {
 		       $wgSitemapXmlExposeInRobots,
 		       $wgServer,
 		       $wgScriptPath,
-		       $wgRequest;
+		       $wgRequest,
+		       $wgEnableHTTPSForAnons;
 
 		if ( !$this->accessAllowed || !empty( $wgRobotsTxtBlockedWiki ) ) {
 			// No crawling preview, verify, sandboxes, showcase, etc
@@ -171,7 +172,17 @@ class WikiaRobots {
 
 		// Sitemap
 		if ( !empty( $wgEnableSitemapXmlExt ) && !empty( $wgSitemapXmlExposeInRobots ) ) {
-			$robots->addSitemap( $wgServer . $wgScriptPath . '/sitemap-newsitemapxml-index.xml' );
+			$sitemapUrl = $wgServer . $wgScriptPath . '/sitemap-newsitemapxml-index.xml';
+			// Enforce HTTPS on wikis where it is enabled by default
+			if ( wfHttpsAllowedForURL( $sitemapUrl ) &&
+				(
+					wfHttpsEnabledForURL( $sitemapUrl ) ||
+					!empty( $wgEnableHTTPSForAnons )
+				)
+			) {
+				$sitemapUrl = wfHttpToHttps( $sitemapUrl );
+			}
+			$robots->addSitemap( $sitemapUrl );
 		}
 
 		// Block namespaces


### PR DESCRIPTION
Make sure sitemap URLs in robots.txt for language path wikis are HTTPS for
fandom.com URLs.