### PR TITLE
SRE | in proxy.php perform normal MW shutdown procedure

### DIFF
--- a/api.php
+++ b/api.php
@@ -105,13 +105,8 @@ $processor = new ApiMain( $wgRequest, $wgEnableWriteAPI );
 // Process data & print results
 $processor->execute();
 
-// Execute any deferred updates
-DeferredUpdates::doUpdates();
-
 // Log what the user did, for book-keeping purposes.
 $endtime = microtime( true );
-wfProfileOut( 'api.php' );
-wfLogProfilingData();
 
 // Log the request
 if ( $wgAPIRequestLog ) {
@@ -132,10 +127,6 @@ if ( $wgAPIRequestLog ) {
 	wfDebug( "Logged API request to $wgAPIRequestLog\n" );
 }
 
-Hooks::run( 'RestInPeace' ); // Wikia change - @author macbre
-
-// Shut down the database.  foo()->bar() syntax is not supported in PHP4: we won't ever actually
-// get here to worry about whether this should be = or =&, but the file has to parse properly.
-$lb = wfGetLBFactory();
-$lb->shutdown();
-
+// Execute common request shutdown procedure
+$mw = new MediaWiki();
+$mw->restInPeace();

--- a/extensions/wikia/Tasks/proxy/proxy.php
+++ b/extensions/wikia/Tasks/proxy/proxy.php
@@ -49,3 +49,16 @@ $response->setContentType('application/json; charset=utf-8');
 $response->sendHeaders();
 
 $response->printText();
+
+// In FastCGI world we can flush the response immediately
+if ( function_exists( 'fastcgi_finish_request' ) ) {
+	fastcgi_finish_request();
+}
+
+// Execute any deferred updates
+DeferredUpdates::doUpdates();
+
+Hooks::run( 'RestInPeace' );
+
+// Commit any pending writes on master connections
+wfGetLBFactory()->commitMasterChanges();

--- a/extensions/wikia/Tasks/proxy/proxy.php
+++ b/extensions/wikia/Tasks/proxy/proxy.php
@@ -50,15 +50,6 @@ $response->sendHeaders();
 
 $response->printText();
 
-// In FastCGI world we can flush the response immediately
-if ( function_exists( 'fastcgi_finish_request' ) ) {
-	fastcgi_finish_request();
-}
-
-// Execute any deferred updates
-DeferredUpdates::doUpdates();
-
-Hooks::run( 'RestInPeace' );
-
-// Commit any pending writes on master connections
-wfGetLBFactory()->commitMasterChanges();
+// Execute common request shutdown procedure
+$mw = new MediaWiki();
+$mw->restInPeace();

--- a/includes/DeferredUpdates.php
+++ b/includes/DeferredUpdates.php
@@ -33,14 +33,9 @@ class DeferredUpdates {
 
 	/**
 	 * Do any deferred updates and clear the list
-	 *
-	 * @param $commit String: set to 'commit' to commit after every update to
-	 *                prevent lock contention
 	 */
-	public static function doUpdates( $commit = '' ) {
+	public static function doUpdates() {
 		global $wgDeferredUpdateList;
-
-		wfProfileIn( __METHOD__ );
 
 		$updates = array_merge( $wgDeferredUpdateList, self::$updates );
 
@@ -50,21 +45,11 @@ class DeferredUpdates {
 			return;
 		}
 
-		$doCommit = $commit == 'commit';
-		if ( $doCommit ) {
-			$dbw = wfGetDB( DB_MASTER );
-		}
-
 		foreach ( $updates as $update ) {
 			$update->doUpdate();
-
-			if ( $doCommit && $dbw->trxLevel() ) {
-				$dbw->commit( __METHOD__ );
-			}
 		}
 
 		self::clearPendingUpdates();
-		wfProfileOut( __METHOD__ );
 	}
 
 	/**

--- a/includes/Wiki.php
+++ b/includes/Wiki.php
@@ -423,31 +423,43 @@ class MediaWiki {
 	/**
 	 * Cleaning up request by doing deferred updates, DB transaction, and the output
 	 */
-	public function finalCleanup() {
-		wfProfileIn( __METHOD__ );
+	private function finalCleanup() {
+		// Either all DBs should commit or none
+		ignore_user_abort( true );
+
 		// Now commit any transactions, so that unreported errors after
 		// output() don't roll back the whole DB transaction
+		// Also have ChronologyProtector take care of recording master positions
 		$factory = wfGetLBFactory();
-		$factory->commitMasterChanges();
+		$factory->shutdown();
 		// Output everything!
 		$this->context->getOutput()->output();
-		// Do any deferred jobs
-		DeferredUpdates::doUpdates( 'commit' );
-		wfProfileOut( __METHOD__ );
 	}
 
 	/**
-	 * Ends this task peacefully
+	 * Perform post-request updates such as deferred updates, profiling etc.
+	 * If possible this method will be executed only after the response has been flushed.
 	 */
 	public function restInPeace() {
+		// If using FastCGI we can flush the output now and do any further updates without blocking
+		if ( function_exists( 'fastcgi_finish_request' ) ) {
+			fastcgi_finish_request();
+		} else {
+			// Either all DBs should commit or none
+			ignore_user_abort( true );
+		}
+
+		// Do any deferred jobs
+		DeferredUpdates::doUpdates();
+
 		Hooks::run( 'RestInPeace' ); // Wikia change - @author macbre
 
 		MessageCache::logMessages();
 		wfLogProfilingData();
+
 		// Commit and close up!
 		$factory = wfGetLBFactory();
 		$factory->commitMasterChanges();
-		$factory->shutdown();
 		wfDebug( "Request ended normally\n" );
 	}
 

--- a/includes/wikia/nirvana/WikiaApp.class.php
+++ b/includes/wikia/nirvana/WikiaApp.class.php
@@ -708,22 +708,6 @@ class WikiaApp {
 
 		return self::$viewCache["P_". $controllerName . $method . $key];
 	}
-
-	/**
-	 * commit any open transactions, only if writes were done on connection and if it's a POST request
-	 */
-	public function commit(){
-		if ( $this->wg->Request->wasPosted() ) {
-			/**
-			 * @var $factory LBFactory
-			 */
-			$factory = wfGetLBFactory();
-			$factory->commitMasterChanges();  // commits only if writes were done on connection
-
-			// SUS-2757: Execute any deferred updates
-			DeferredUpdates::doUpdates( 'commit' );
-		}
-	}
 }
 
 /**

--- a/wikia.php
+++ b/wikia.php
@@ -45,9 +45,6 @@ if ( !empty( $wgEnableNirvanaAPI ) ) {
 
 	$response = $app->sendExternalRequest( null, null, null );
 
-	// commit any open transactions just in case the controller forgot to
-	$app->commit();
-
 	// if cache policy wasn't explicitly set (e.g. WikiaResponse::setCacheValidity)
 	// then force no cache to reflect api.php default behavior
 	$cacheControl = $response->getHeader( 'Cache-Control' );
@@ -81,10 +78,9 @@ if ( !empty( $wgEnableNirvanaAPI ) ) {
 
 	$response->render();
 
-	wfLogProfilingData();
-
-	Hooks::run( 'RestInPeace' );
-
+	// Execute common request shutdown procedure
+	$mw = new MediaWiki();
+	$mw->restInPeace();
 } else {
 	header( "HTTP/1.1 503 Service Unavailable", true, 503 );
 }


### PR DESCRIPTION
Ensure that the standard MW shutdown process is performed when executing background tasks—deferred updates and `RestInPeace` hook should be run, then we should commit any pending writes over our master connections.

This will be needed for example for https://github.com/Wikia/app/pull/16086