### PR TITLE
SUS-5855 | TaskRunner - send metrics to Prometheus via Pushgateway

### DIFF
--- a/lib/Wikia/src/Metrics/Collector.php
+++ b/lib/Wikia/src/Metrics/Collector.php
@@ -55,7 +55,7 @@ class Collector {
 
 	public function addCounter( string $name, array $labels, string $help ) : self {
 		$counter = $this->registry->getOrRegisterCounter(
-			self::METRICS_NAMESPACE, $name, $help, $labels );
+			self::METRICS_NAMESPACE, $name, $help, array_keys( $labels ) );
 		$counter->inc( array_values( $labels ) );
 
 		return $this;

--- a/lib/Wikia/src/Tasks/TaskRunner.php
+++ b/lib/Wikia/src/Tasks/TaskRunner.php
@@ -10,6 +10,7 @@ namespace Wikia\Tasks;
  */
 
 use Wikia\Logger\WikiaLogger;
+use Wikia\Metrics\Collector;
 
 class TaskRunner {
 	// number of seconds required before we notify flower of our job status
@@ -84,6 +85,8 @@ class TaskRunner {
 	}
 
 	function run() {
+		global $wgWikiaEnvironment;
+
 		$this->startTime = $this->endTime = microtime( true );
 		if ( $this->exception ) {
 			$this->results [] = $this->exception;
@@ -110,7 +113,12 @@ class TaskRunner {
 				}
 			}
 
-			WikiaLogger::instance()->pushContext( [ 'task_call' => get_class($task)."::{$method}"] );
+			$task_call = sprintf('%s::%s', get_class( $task ) , $method );
+			$task_delay = microtime( true ) - $this->createdAt;
+			$task_duration = microtime( true );
+
+			WikiaLogger::instance()->pushContext( [ 'task_call' => $task_call ] );
+
 			$result = $task->execute( $method, $args );
 			if ( $result instanceof \Exception ) {
 				WikiaLogger::instance()->error( 'Exception: ' . $result->getMessage(), [
@@ -118,6 +126,23 @@ class TaskRunner {
 				] );
 			}
 			WikiaLogger::instance()->popContext();
+
+			// push metrics
+			$task_duration = microtime( true ) - $task_duration;
+
+			$metrics_labels = [
+				'task_call' => $task_call,
+				'task_status' => ( $result instanceof \Exception ) ? 'failed' : 'completed',
+				'env' => $wgWikiaEnvironment
+			];
+
+			// SUS-5855
+			Collector::getInstance()
+				->addCounter('celery_tasks_total', $metrics_labels, 'Number of Celery tasks executed')
+				->addGauge('celery_tasks_duration_seconds', $task_duration, $metrics_labels, 'Time it took to execute the task')
+				->addGauge('celery_tasks_delay_seconds', $task_delay, $metrics_labels, 'How long task has waited in the queue before being executed')
+				->push('mediawiki_celery_tasks');
+
 			$this->results [] = $result;
 
 			if ( $result instanceof \Exception ) {
@@ -127,7 +152,6 @@ class TaskRunner {
 
 		$this->endTime = microtime( true );
 
-		// TODO: push tasks metrics to InfluxDB
 		WikiaLogger::instance()->info( __METHOD__ . '::completed', [
 			'took' => $this->runTime(),
 			'delay' => microtime( true ) - $this->createdAt,


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5855

In #16111 we introduced a helper class that sends metrics to Prometheus via Pushgateway.

`TaskRunner` class that is responsible for executing Celery MediaWiki tasks will report the following metrics:

* `mediawiki_celery_tasks_total` counter
* `mediawiki_celery_tasks_duration_seconds` gauge
* `mediawiki_celery_tasks_delay_seconds` gauge

### Labels

* `task_status` (either `failed` or `completed`)
* `task_call` (class name and method, e.g. `Wikia\Tasks\Tasks\MultiLookupTask::updateMultiLookup`)
* `env` (`prod` vs `preview` vs `sandbox` vs `dev`)

An example set of tags as reported by [Pushgateway](http://pushgateway-dev.poz-dev.k8s.wikia.net/):

```
env="dev" instance="" job="mediawiki_celery_tasks" task_call="Wikia\Tasks\Tasks\MultiLookupTask::updateMultiLookup" task_status="completed"
```

## An example

```php
$task = Wikia\Tasks\Tasks\HTMLCacheUpdateTask::newLocalTask(); $task->call('purge', 'imagelinks'); var_dump( $task->title( Title::newMainPage())->queue() );

$task = Wikia\Tasks\Tasks\GalleryCachePurgeTask::newLocalTask(); $task->call('purge'); var_dump( $task->title( Title::newMainPage())->queue() );
```
![sus-5855](https://user-images.githubusercontent.com/1929317/46147353-9c072700-c265-11e8-96fa-17b3684d0060.png)
