### PR TITLE
Remove an inline style in chat

### DIFF
--- a/extensions/wikia/Chat2/css/Chat.scss
+++ b/extensions/wikia/Chat2/css/Chat.scss
@@ -351,7 +351,7 @@ a {
 			border-color: black transparent transparent;
 			border-style: solid;
 			cursor: pointer;
-			display: none;
+			display: inline;
 			height: 0;
 			left: 3px;
 			margin: 0;

--- a/extensions/wikia/Chat2/js/views/views.js
+++ b/extensions/wikia/Chat2/js/views/views.js
@@ -536,11 +536,8 @@ var NodeChatUsers = Backbone.View.extend({
 
 	// Only show chevron in public chat if there is anyone to talk to
 	toggleChevron: function(list) {
-		var chevron = $('#Rail .public .chevron');
-		if (list.children().length > 1) {
-			chevron.show();
-		} else {
-			chevron.hide();
+		if (list.children().length =< 1) {
+			$('#Rail .public .chevron').hide();
 		}
 	},
 

--- a/extensions/wikia/Chat2/js/views/views.js
+++ b/extensions/wikia/Chat2/js/views/views.js
@@ -536,7 +536,7 @@ var NodeChatUsers = Backbone.View.extend({
 
 	// Only show chevron in public chat if there is anyone to talk to
 	toggleChevron: function(list) {
-		if (list.children().length =< 1) {
+		if (list.children().length <= 1) {
 			$('#Rail .public .chevron').hide();
 		}
 	},


### PR DESCRIPTION
This PR removes an inline style in chat so that users no longer have to use `!important` for this in their CSS.