### PR TITLE
SEO-669 | Show banner notification about fandom.com migration

### DIFF
--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -2456,3 +2456,10 @@ $config['feeds_and_posts_js'] = [
 		'//extensions/wikia/FeedsAndPosts/js/feedsAndPosts.js',
 	]
 ];
+
+$config['fandom_com_migration_js'] = [
+	'type' => AssetsManager::TYPE_JS,
+	'assets' => [
+		'//extensions/wikia/FandomComMigration/scripts/fandom-com-migration.js',
+	]
+];

--- a/extensions/wikia/FandomComMigration/FandomComMigration.i18n.php
+++ b/extensions/wikia/FandomComMigration/FandomComMigration.i18n.php
@@ -2,8 +2,8 @@
 $messages = array();
 
 $messages['en'] = array(
-	'fandom-com-migration-after' => 'Your community domain has been migrated to fandom.com. Find out more in <a href="https://community.wikia.com/wiki/User_blog:Brandon_Rhea/Wiki_domains_will_be_changing_from_wikia.com_to_fandom.com_in_early_2019?">this FANDOM news blog</a>.',
-	'fandom-com-migration-before' => 'We are migrating your community\'s domain to fandom.com on $1. Find out more in <a href="https://community.wikia.com/wiki/User_blog:Brandon_Rhea/Wiki_domains_will_be_changing_from_wikia.com_to_fandom.com_in_early_2019?">this FANDOM news blog</a>.',
+	'fandom-com-migration-after' => 'Attention: We have migrated your community\'s domain to fandom.com. Find out more in <a href="https://community.wikia.com/wiki/User_blog:Brandon_Rhea/Wiki_domains_will_be_changing_from_wikia.com_to_fandom.com_in_early_2019?">this FANDOM news blog</a>.',
+	'fandom-com-migration-before' => 'Attention: We are migrating your community\'s domain to fandom.com on $1. Find out more in <a href="https://community.wikia.com/wiki/User_blog:Brandon_Rhea/Wiki_domains_will_be_changing_from_wikia.com_to_fandom.com_in_early_2019?">this FANDOM news blog</a>.',
 );
 
 $messages['qqq'] = array(

--- a/extensions/wikia/FandomComMigration/FandomComMigration.i18n.php
+++ b/extensions/wikia/FandomComMigration/FandomComMigration.i18n.php
@@ -2,8 +2,8 @@
 $messages = array();
 
 $messages['en'] = array(
-	'fandom-com-migration-after' => 'Attention: We have migrated your community\'s domain to fandom.com. Find out more in <a href="https://community.wikia.com/wiki/User_blog:Brandon_Rhea/Wiki_domains_will_be_changing_from_wikia.com_to_fandom.com_in_early_2019?">this FANDOM news blog</a>.',
-	'fandom-com-migration-before' => 'Attention: We are migrating your community\'s domain to fandom.com on $1. Find out more in <a href="https://community.wikia.com/wiki/User_blog:Brandon_Rhea/Wiki_domains_will_be_changing_from_wikia.com_to_fandom.com_in_early_2019?">this FANDOM news blog</a>.',
+	'fandom-com-migration-after' => 'Attention: We have migrated your community\'s domain to fandom.com. Find out more in [http://community.wikia.com/wiki/User_blog:Brandon_Rhea/Wiki_domains_will_be_changing_from_wikia.com_to_fandom.com_in_early_2019 this FANDOM news blog].',
+	'fandom-com-migration-before' => 'Attention: We are migrating your community\'s domain to fandom.com on $1. Find out more in [http://community.wikia.com/wiki/User_blog:Brandon_Rhea/Wiki_domains_will_be_changing_from_wikia.com_to_fandom.com_in_early_2019 this FANDOM news blog].',
 );
 
 $messages['qqq'] = array(

--- a/extensions/wikia/FandomComMigration/FandomComMigration.i18n.php
+++ b/extensions/wikia/FandomComMigration/FandomComMigration.i18n.php
@@ -37,8 +37,8 @@ $messages['it'] = array(
 );
 
 $messages['ja'] = array(
-	'fandom-com-migration-after' => '注意：あなたのコミュニティのドメインはfandom.comに変更されました。詳しくは、[http://ja.community.wikia.com/wiki/%E3%83%A6%E3%83%BC%E3%82%B6%E3%83%BC%E3%83%96%E3%83%AD%E3%82%B0:Tomeito/2019%E5%B9%B4%E5%88%9D%E9%A0%AD%E3%81%ABWiki%E3%81%AE%E3%83%89%E3%83%A1%E3%82%A4%E3%83%B3%E3%81%8Cwikia.com%E3%81%8B%E3%82%89fandom.com%E3%81%AB%E5%A4%89%E6%9B%B4%E3%81%95%E3%82%8C%E3%81%BE%E3%81%99]をご覧ください。',
-	'fandom-com-migration-before' => '注意：今後数週間にかけて、あなたのコミュニティなど複数のコミュニティのドメインがfandom.comに変更されます。詳しくは、[http://ja.community.wikia.com/wiki/%E3%83%A6%E3%83%BC%E3%82%B6%E3%83%BC%E3%83%96%E3%83%AD%E3%82%B0:Tomeito/2019%E5%B9%B4%E5%88%9D%E9%A0%AD%E3%81%ABWiki%E3%81%AE%E3%83%89%E3%83%A1%E3%82%A4%E3%83%B3%E3%81%8Cwikia.com%E3%81%8B%E3%82%89fandom.com%E3%81%AB%E5%A4%89%E6%9B%B4%E3%81%95%E3%82%8C%E3%81%BE%E3%81%99]をご覧ください。',
+	'fandom-com-migration-after' => '注意：あなたのコミュニティのドメインはfandom.comに変更されました。詳しくは、[http://ja.community.wikia.com/wiki/%E3%83%A6%E3%83%BC%E3%82%B6%E3%83%BC%E3%83%96%E3%83%AD%E3%82%B0:Tomeito/fandom.com%E3%83%89%E3%83%A1%E3%82%A4%E3%83%B3%E7%A7%BB%E8%A1%8C%E3%81%AE%E3%83%86%E3%82%B9%E3%83%88%E6%96%B9%E6%B3%95%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6 FANDOMスタッフブログ]をご覧ください。',
+	'fandom-com-migration-before' => '注意：今後数週間にかけて、あなたのコミュニティなど複数のコミュニティのドメインがfandom.comに変更されます。詳しくは、[http://ja.community.wikia.com/wiki/%E3%83%A6%E3%83%BC%E3%82%B6%E3%83%BC%E3%83%96%E3%83%AD%E3%82%B0:Tomeito/fandom.com%E3%83%89%E3%83%A1%E3%82%A4%E3%83%B3%E7%A7%BB%E8%A1%8C%E3%81%AE%E3%83%86%E3%82%B9%E3%83%88%E6%96%B9%E6%B3%95%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6 FANDOMスタッフブログ]をご覧ください。',
 );
 
 $messages['nl'] = array(

--- a/extensions/wikia/FandomComMigration/FandomComMigration.i18n.php
+++ b/extensions/wikia/FandomComMigration/FandomComMigration.i18n.php
@@ -2,8 +2,8 @@
 $messages = array();
 
 $messages['en'] = array(
-	'fandom-com-migration-after' => 'Attention: We have migrated your community\'s domain to fandom.com. Find out more in [http://community.wikia.com/wiki/User_blog:Brandon_Rhea/Wiki_domains_will_be_changing_from_wikia.com_to_fandom.com_in_early_2019 this FANDOM news blog].',
-	'fandom-com-migration-before' => 'Attention: Over the next few weeks, we will be migrating several communities to fandom.com, including yours. Find out more in [http://community.wikia.com/wiki/User_blog:Brandon_Rhea/Wiki_domains_will_be_changing_from_wikia.com_to_fandom.com_in_early_2019 this FANDOM news blog].',
+	'fandom-com-migration-after' => 'Attention: We have migrated your community\'s domain to fandom.com. Find out more in [http://community.wikia.com/wiki/User_blog:Brandon_Rhea/How_we%27re_testing_the_fandom.com_domain_migration this FANDOM news blog].',
+	'fandom-com-migration-before' => 'Attention: Over the next few weeks, we will be migrating several communities to fandom.com, including yours. Find out more in [https://community.wikia.com/wiki/User_blog:Brandon_Rhea/How_we%27re_testing_the_fandom.com_domain_migration this FANDOM news blog].',
 );
 
 $messages['qqq'] = array(

--- a/extensions/wikia/FandomComMigration/FandomComMigration.i18n.php
+++ b/extensions/wikia/FandomComMigration/FandomComMigration.i18n.php
@@ -3,10 +3,10 @@ $messages = array();
 
 $messages['en'] = array(
 	'fandom-com-migration-after' => 'Attention: We have migrated your community\'s domain to fandom.com. Find out more in [http://community.wikia.com/wiki/User_blog:Brandon_Rhea/Wiki_domains_will_be_changing_from_wikia.com_to_fandom.com_in_early_2019 this FANDOM news blog].',
-	'fandom-com-migration-before' => 'Attention: We are migrating your community\'s domain to fandom.com on $1. Find out more in [http://community.wikia.com/wiki/User_blog:Brandon_Rhea/Wiki_domains_will_be_changing_from_wikia.com_to_fandom.com_in_early_2019 this FANDOM news blog].',
+	'fandom-com-migration-before' => 'Attention: Over the next few weeks, we will be migrating several communities to fandom.com, including yours. Find out more in [http://community.wikia.com/wiki/User_blog:Brandon_Rhea/Wiki_domains_will_be_changing_from_wikia.com_to_fandom.com_in_early_2019 this FANDOM news blog].',
 );
 
 $messages['qqq'] = array(
 	'fandom-com-migration-after' => 'Notification text to display after the community is migrated to fandom.com domain',
-	'fandom-com-migration-before' => 'Notification text to display before the community is migrated to fandom.com domain. $1 is the migration date.',
+	'fandom-com-migration-before' => 'Notification text to display before the community is migrated to fandom.com domain',
 );

--- a/extensions/wikia/FandomComMigration/FandomComMigration.i18n.php
+++ b/extensions/wikia/FandomComMigration/FandomComMigration.i18n.php
@@ -8,5 +8,5 @@ $messages['en'] = array(
 
 $messages['qqq'] = array(
 	'fandom-com-migration-after' => 'Notification text to display after the community is migrated to fandom.com domain',
-	'fandom-com-migration-before' => 'Notification text to display before the community is migrated to fandom.com domain',
+	'fandom-com-migration-before' => 'Notification text to display before the community is migrated to fandom.com domain. $1 is the migration date.',
 );

--- a/extensions/wikia/FandomComMigration/FandomComMigration.i18n.php
+++ b/extensions/wikia/FandomComMigration/FandomComMigration.i18n.php
@@ -1,0 +1,12 @@
+<?php
+$messages = array();
+
+$messages['en'] = array(
+	'fandom-com-migration-after' => 'Your community domain has been migrated to fandom.com. Find out more in <a href="https://community.wikia.com/wiki/User_blog:Brandon_Rhea/Wiki_domains_will_be_changing_from_wikia.com_to_fandom.com_in_early_2019?">this FANDOM news blog</a>.',
+	'fandom-com-migration-before' => 'We are migrating your community\'s domain to fandom.com on $1. Find out more in <a href="https://community.wikia.com/wiki/User_blog:Brandon_Rhea/Wiki_domains_will_be_changing_from_wikia.com_to_fandom.com_in_early_2019?">this FANDOM news blog</a>.',
+);
+
+$messages['qqq'] = array(
+	'fandom-com-migration-after' => 'Notification text to display after the community is migrated to fandom.com domain',
+	'fandom-com-migration-before' => 'Notification text to display before the community is migrated to fandom.com domain',
+);

--- a/extensions/wikia/FandomComMigration/FandomComMigration.i18n.php
+++ b/extensions/wikia/FandomComMigration/FandomComMigration.i18n.php
@@ -2,7 +2,7 @@
 $messages = array();
 
 $messages['en'] = array(
-	'fandom-com-migration-after' => 'Attention: We have migrated your community\'s domain to fandom.com. Find out more in [http://community.wikia.com/wiki/User_blog:Brandon_Rhea/How_we%27re_testing_the_fandom.com_domain_migration this FANDOM news blog].',
+	'fandom-com-migration-after' => "Attention: We have migrated your community's domain to fandom.com. Find out more in [http://community.wikia.com/wiki/User_blog:Brandon_Rhea/How_we%27re_testing_the_fandom.com_domain_migration this FANDOM news blog].",
 	'fandom-com-migration-before' => 'Attention: Over the next few weeks, we will be migrating several communities to fandom.com, including yours. Find out more in [https://community.wikia.com/wiki/User_blog:Brandon_Rhea/How_we%27re_testing_the_fandom.com_domain_migration this FANDOM news blog].',
 );
 
@@ -10,3 +10,66 @@ $messages['qqq'] = array(
 	'fandom-com-migration-after' => 'Notification text to display after the community is migrated to fandom.com domain',
 	'fandom-com-migration-before' => 'Notification text to display before the community is migrated to fandom.com domain',
 );
+
+$messages['de'] = array(
+	'fandom-com-migration-after' => 'Achtung: Wir haben die Domain deiner Community zu fandom.com geändert. Mehr Infos hierzu findest du im [http://de.community.wikia.com/wiki/Benutzer_Blog:Mira_Laime/So_testen_wir_den_Umzug_unserer_Domains_zu_fandom.com FANDOM News-Blog].',
+	'fandom-com-migration-before' => 'Achtung: In den nächsten Wochen werden wir die Domain dieser und einiger weiterer Communitys zu fandom.com ändern. Mehr Infos dazu findest du im [http://de.community.wikia.com/wiki/Benutzer_Blog:Mira_Laime/So_testen_wir_den_Umzug_unserer_Domains_zu_fandom.com FANDOM News-Blog].',
+);
+
+$messages['es'] = array(
+	'fandom-com-migration-after' => 'Atención: Hemos migrado el dominio de tu comunidad a fandom.com. Conoce más en [https://comunidad.wikia.com/wiki/Usuario_Blog:Luchofigo85/C%C3%B3mo_estamos_probando_la_migraci%C3%B3n_de_dominio_a_fandom.com esta entrada de blog].',
+	'fandom-com-migration-before' => 'Atención: Estaremos cambiando el dominio de tu comunidad a fandom.com en las próximas semanas. Conoce más en [https://comunidad.wikia.com/wiki/Usuario_Blog:Luchofigo85/C%C3%B3mo_estamos_probando_la_migraci%C3%B3n_de_dominio_a_fandom.com esta entrada de blog].',
+);
+
+$messages['fi'] = array(
+	'fandom-com-migration-after' => "Attention: We have migrated your community's domain to fandom.com. Find out more in [http://community.wikia.com/wiki/User_blog:Brandon_Rhea/How_we%27re_testing_the_fandom.com_domain_migration this FANDOM news blog].",
+	'fandom-com-migration-before' => 'Attention: Over the next few weeks, we will be migrating several communities to fandom.com, including yours. Find out more in [https://community.wikia.com/wiki/User_blog:Brandon_Rhea/How_we%27re_testing_the_fandom.com_domain_migration this FANDOM news blog].',
+);
+
+$messages['fr'] = array(
+	'fandom-com-migration-after' => "Attention : nous avons migré le domaine de votre communauté vers fandom.com. Pour en savoir plus, consultez [http://communaute.wikia.com/wiki/Blog_utilisateur:Hypsoline/Comment_nous_allons_tester_la_migration_de_domaine_vers_fandom.com ce blog d'actualités FANDOM].",
+	'fandom-com-migration-before' => "Attention : au cours des prochaines semaines, nous allons migrer plusieurs communautés, dont la vôtre, vers fandom.com. Pour en savoir plus, consultez [http://communaute.wikia.com/wiki/Blog_utilisateur:Hypsoline/Comment_nous_allons_tester_la_migration_de_domaine_vers_fandom.com ce blog d'actualités FANDOM].",
+);
+
+$messages['it'] = array(
+	'fandom-com-migration-after' => 'Attenzione: abbiamo migrato il dominio della tua comunità su fandom.com. Scopri di più leggendo [http://it.community.wikia.com/wiki/Blog_utente:Leviathan_89/Come_stiamo_testando_la_migrazione_al_dominio_fandom.com questo blog di FANDOM].',
+	'fandom-com-migration-before' => 'Attenzione: nelle prossime settimane migreremo diverse comunità sul dominio fandom.com, tra cui la tua. Scopri di più leggendo [http://it.community.wikia.com/wiki/Blog_utente:Leviathan_89/Come_stiamo_testando_la_migrazione_al_dominio_fandom.com questo blog di FANDOM].',
+);
+
+$messages['ja'] = array(
+	'fandom-com-migration-after' => '注意：あなたのコミュニティのドメインはfandom.comに変更されました。詳しくは、[http://ja.community.wikia.com/wiki/%E3%83%A6%E3%83%BC%E3%82%B6%E3%83%BC%E3%83%96%E3%83%AD%E3%82%B0:Tomeito/2019%E5%B9%B4%E5%88%9D%E9%A0%AD%E3%81%ABWiki%E3%81%AE%E3%83%89%E3%83%A1%E3%82%A4%E3%83%B3%E3%81%8Cwikia.com%E3%81%8B%E3%82%89fandom.com%E3%81%AB%E5%A4%89%E6%9B%B4%E3%81%95%E3%82%8C%E3%81%BE%E3%81%99]をご覧ください。',
+	'fandom-com-migration-before' => '注意：今後数週間にかけて、あなたのコミュニティなど複数のコミュニティのドメインがfandom.comに変更されます。詳しくは、[http://ja.community.wikia.com/wiki/%E3%83%A6%E3%83%BC%E3%82%B6%E3%83%BC%E3%83%96%E3%83%AD%E3%82%B0:Tomeito/2019%E5%B9%B4%E5%88%9D%E9%A0%AD%E3%81%ABWiki%E3%81%AE%E3%83%89%E3%83%A1%E3%82%A4%E3%83%B3%E3%81%8Cwikia.com%E3%81%8B%E3%82%89fandom.com%E3%81%AB%E5%A4%89%E6%9B%B4%E3%81%95%E3%82%8C%E3%81%BE%E3%81%99]をご覧ください。',
+);
+
+$messages['nl'] = array(
+	'fandom-com-migration-after' => 'Opgelet! We hebben het domein van jullie wiki naar fandom.com gemigreerd. Lees voor meer informatie [http://nl.community.wikia.com/wiki/Gebruikersblog:Tupka217/Zo_gaan_we_de_fandom.com_domeinmigratie_testen deze FANDOM blog].',
+	'fandom-com-migration-before' => "Opgelet! De komende weken zullen we meerdere wiki's naar fandom.com migreren. Lees voor meer informatie [http://nl.community.wikia.com/wiki/Gebruikersblog:Tupka217/Zo_gaan_we_de_fandom.com_domeinmigratie_testen deze FANDOM blog].",
+);
+
+$messages['pl'] = array(
+	'fandom-com-migration-after' => 'Uwaga: Dokonaliśmy migracji domeny waszej społeczności na fandom.com. Więcej informacji znajduje się w [[w:c:pl.c:Blog_użytkownika:Nanaki/Jak_testujemy_migrację_domeny_na_fandom.com|tym blogu]].
+',
+	'fandom-com-migration-before' => 'Uwaga: W nadchodzących tygodniach nastąpi migracja domeny waszej społeczności na fandom.com. Więcej informacji znajduje się w [[w:c:pl.c:Blog_użytkownika:Nanaki/Jak_testujemy_migrację_domeny_na_fandom.com|tym blogu]].
+',
+);
+
+$messages['pt'] = array(
+	'fandom-com-migration-after' => 'Atenção: Nós migramos o domínio da sua comunidade para fandom.com. Saiba mais [https://comunidade.wikia.com/wiki/Blog_de_usu%C3%A1rio:Matheus_Leonardo/Como_testaremos_a_migra%C3%A7%C3%A3o_para_o_dom%C3%ADnio_fandom.com neste blog de notícias do FANDOM].',
+	'fandom-com-migration-before' => 'Atenção: Durante as próximas semanas, nós estaremos migrando várias comunidades para fandom.com, incluindo a sua. Saiba mais [https://comunidade.wikia.com/wiki/Blog_de_usu%C3%A1rio:Matheus_Leonardo/Como_testaremos_a_migra%C3%A7%C3%A3o_para_o_dom%C3%ADnio_fandom.com neste blog de notícias do FANDOM].',
+);
+
+$messages['ru'] = array(
+	'fandom-com-migration-after' => 'ВНИМАНИЕ: Мы изменили домен вашего сообщества с wikia.com на fandom.com. Подробнее о переходе на домен fandom.com можно узнать в [http://ru.community.wikia.com/wiki/%D0%91%D0%BB%D0%BE%D0%B3_%D1%83%D1%87%D0%B0%D1%81%D1%82%D0%BD%D0%B8%D0%BA%D0%B0:Kuzura/%D0%A2%D0%B5%D1%81%D1%82%D0%B8%D1%80%D0%BE%D0%B2%D0%B0%D0%BD%D0%B8%D0%B5_%D0%BF%D0%B5%D1%80%D0%B5%D1%85%D0%BE%D0%B4%D0%B0_%D0%BD%D0%B0_fandom.com этом блоге].',
+	'fandom-com-migration-before' => 'ВНИМАНИЕ: В течение следующих недель мы изменим домен некоторых сообществ с wikia.com на fandom.com, включая ваше сообщество. Подробнее о переходе на домен fandom.com можно узнать в [http://ru.community.wikia.com/wiki/%D0%91%D0%BB%D0%BE%D0%B3_%D1%83%D1%87%D0%B0%D1%81%D1%82%D0%BD%D0%B8%D0%BA%D0%B0:Kuzura/%D0%A2%D0%B5%D1%81%D1%82%D0%B8%D1%80%D0%BE%D0%B2%D0%B0%D0%BD%D0%B8%D0%B5_%D0%BF%D0%B5%D1%80%D0%B5%D1%85%D0%BE%D0%B4%D0%B0_%D0%BD%D0%B0_fandom.com этом блоге].',
+);
+
+$messages['zh-hans'] = array(
+	'fandom-com-migration-after' => '提醒：我们已经将您的社区域名移动至fandom.com。请查阅[http://zh.community.wikia.com/wiki/%E7%94%A8%E6%88%B7%E5%8D%9A%E5%AE%A2:Cal-Boy/%E6%88%91%E4%BB%AC%E5%A6%82%E4%BD%95%E6%B5%8B%E8%AF%95%E7%A4%BE%E5%8C%BA%E8%BF%81%E7%A7%BB%E8%87%B3%E6%96%B0%E5%9F%9F%E5%90%8Dfandom.com 这篇文章]了解更多内容。',
+	'fandom-com-migration-before' => '提醒：在接下来的几周，我们将会把大量的社区域名移动至fandom.com，其中也包括您的社区。请查阅[http://zh.community.wikia.com/wiki/%E7%94%A8%E6%88%B7%E5%8D%9A%E5%AE%A2:Cal-Boy/%E6%88%91%E4%BB%AC%E5%A6%82%E4%BD%95%E6%B5%8B%E8%AF%95%E7%A4%BE%E5%8C%BA%E8%BF%81%E7%A7%BB%E8%87%B3%E6%96%B0%E5%9F%9F%E5%90%8Dfandom.com 这篇文章]了解更多内容。',
+);
+
+$messages['zh-hant'] = array(
+	'fandom-com-migration-after' => '提醒：我們已經將您的社區域名移動至fandom.com。請查閱[http://zh.community.wikia.com/wiki/%E7%94%A8%E6%88%B7%E5%8D%9A%E5%AE%A2:Cal-Boy/%E6%88%91%E4%BB%AC%E5%A6%82%E4%BD%95%E6%B5%8B%E8%AF%95%E7%A4%BE%E5%8C%BA%E8%BF%81%E7%A7%BB%E8%87%B3%E6%96%B0%E5%9F%9F%E5%90%8Dfandom.com?variant=zh-hant 這篇文章]了解更多内容。',
+	'fandom-com-migration-before' => '提醒：在接下來的幾周，我們將會把大量的社區域名移動至fandom.com，其中也包括您的社區。請查閱[http://zh.community.wikia.com/wiki/%E7%94%A8%E6%88%B7%E5%8D%9A%E5%AE%A2:Cal-Boy/%E6%88%91%E4%BB%AC%E5%A6%82%E4%BD%95%E6%B5%8B%E8%AF%95%E7%A4%BE%E5%8C%BA%E8%BF%81%E7%A7%BB%E8%87%B3%E6%96%B0%E5%9F%9F%E5%90%8Dfandom.com?variant=zh-hant 這篇文章]了解更多内容。',
+);
+

--- a/extensions/wikia/FandomComMigration/FandomComMigration.setup.php
+++ b/extensions/wikia/FandomComMigration/FandomComMigration.setup.php
@@ -11,6 +11,7 @@ $wgExtensionCredits['other'][] = [
 $wgAutoloadClasses['FandomComMigrationHooks'] = __DIR__ . '/FandomComMigrationHooks.class.php';
 
 $wgHooks['BeforePageDisplay'][] = 'FandomComMigrationHooks::onBeforePageDisplay';
+$wgHooks['MercuryWikiVariables'][] = 'FandomComMigrationHooks::onMercuryWikiVariables';
 $wgHooks['OasisSkinAssetGroups'][] = 'FandomComMigrationHooks::onOasisSkinAssetGroups';
 $wgHooks['WikiaSkinTopScripts'][] = 'FandomComMigrationHooks::onWikiaSkinTopScripts';
 

--- a/extensions/wikia/FandomComMigration/FandomComMigration.setup.php
+++ b/extensions/wikia/FandomComMigration/FandomComMigration.setup.php
@@ -17,7 +17,9 @@ $wgHooks['WikiaSkinTopScripts'][] = 'FandomComMigrationHooks::onWikiaSkinTopScri
 
 $wgExtensionMessagesFiles['FandomComMigration'] = __DIR__ . '/FandomComMigration.i18n.php';
 
-JSMessages::registerPackage( 'FandomComMigration', [
-	'fandom-com-migration-after',
-	'fandom-com-migration-before'
-] );
+$wgResourceModules['ext.fandomComMigration'] = [
+	'messages' => [
+		'fandom-com-migration-after',
+		'fandom-com-migration-before'
+	]
+];

--- a/extensions/wikia/FandomComMigration/FandomComMigration.setup.php
+++ b/extensions/wikia/FandomComMigration/FandomComMigration.setup.php
@@ -1,0 +1,22 @@
+<?php
+$wgExtensionCredits['other'][] = [
+	'name' => 'FandomComMigration Extension',
+	'author' => [
+		'Igor Rogatty',
+	],
+	'description' => 'Display notification about the fandom.com migration',
+	'url' => 'https://github.com/Wikia/app/tree/dev/extensions/wikia/FandomComMigration'
+];
+
+$wgAutoloadClasses['FandomComMigrationHooks'] = __DIR__ . '/FandomComMigrationHooks.class.php';
+
+$wgHooks['BeforePageDisplay'][] = 'FandomComMigrationHooks::onBeforePageDisplay';
+$wgHooks['OasisSkinAssetGroups'][] = 'FandomComMigrationHooks::onOasisSkinAssetGroups';
+$wgHooks['WikiaSkinTopScripts'][] = 'FandomComMigrationHooks::onWikiaSkinTopScripts';
+
+$wgExtensionMessagesFiles['FandomComMigration'] = __DIR__ . '/FandomComMigration.i18n.php';
+
+JSMessages::registerPackage( 'FandomComMigration', [
+	'fandom-com-migration-after',
+	'fandom-com-migration-before'
+] );

--- a/extensions/wikia/FandomComMigration/FandomComMigrationHooks.class.php
+++ b/extensions/wikia/FandomComMigration/FandomComMigrationHooks.class.php
@@ -11,16 +11,15 @@ class FandomComMigrationHooks {
 	}
 
 	public static function onMercuryWikiVariables( array &$wikiVariables ): bool {
-		global $wgFandomComMigrationDate, $wgFandomComMigrationDone;
+		global $wgFandomComMigrationScheduled, $wgFandomComMigrationDone;
 
 		// Send HTML instead of message key to avoid the issue of non-compatible i18n libs
 		if ( $wgFandomComMigrationDone ) {
 			$wikiVariables['fandomComMigrationNotificationAfter'] =
 				wfMessage( 'fandom-com-migration-after' )->parse();
-		} else if ( !empty( $wgFandomComMigrationDate ) ) {
+		} else if ( $wgFandomComMigrationScheduled ) {
 			$wikiVariables['fandomComMigrationNotificationBefore'] =
 				wfMessage( 'fandom-com-migration-before' )
-					->params( $wgFandomComMigrationDate )
 					->parse();
 		}
 
@@ -37,9 +36,9 @@ class FandomComMigrationHooks {
 
 	public static function onWikiaSkinTopScripts( &$vars, &$scripts ) {
 		if ( static::isEnabled() ) {
-			global $wgFandomComMigrationDate, $wgFandomComMigrationDone;
+			global $wgFandomComMigrationScheduled, $wgFandomComMigrationDone;
 
-			$vars['wgFandomComMigrationDate'] = $wgFandomComMigrationDate;
+			$vars['wgFandomComMigrationScheduled'] = $wgFandomComMigrationScheduled;
 			$vars['wgFandomComMigrationDone'] = $wgFandomComMigrationDone;
 		}
 
@@ -47,8 +46,8 @@ class FandomComMigrationHooks {
 	}
 
 	private static function isEnabled() {
-		global $wgFandomComMigrationDate, $wgFandomComMigrationDone;
+		global $wgFandomComMigrationScheduled, $wgFandomComMigrationDone;
 
-		return !empty( $wgFandomComMigrationDate ) || $wgFandomComMigrationDone;
+		return !empty( $wgFandomComMigrationScheduled ) || $wgFandomComMigrationDone;
 	}
 }

--- a/extensions/wikia/FandomComMigration/FandomComMigrationHooks.class.php
+++ b/extensions/wikia/FandomComMigration/FandomComMigrationHooks.class.php
@@ -1,0 +1,37 @@
+<?php
+
+class FandomComMigrationHooks {
+
+	public static function onBeforePageDisplay( OutputPage $out, Skin $skin ) {
+		if ( static::isEnabled() ) {
+			JSMessages::enqueuePackage('FandomComMigration', JSMessages::EXTERNAL);
+		}
+
+		return true;
+	}
+
+	public static function onOasisSkinAssetGroups( &$jsAssets ) {
+		if ( static::isEnabled() ) {
+			$jsAssets[] = 'fandom_com_migration_js';
+		}
+
+		return true;
+	}
+
+	public static function onWikiaSkinTopScripts( &$vars, &$scripts ) {
+		if ( static::isEnabled() ) {
+			global $wgFandomComMigrationDate, $wgFandomComMigrationDone;
+
+			$vars['wgFandomComMigrationDate'] = $wgFandomComMigrationDate;
+			$vars['wgFandomComMigrationDone'] = $wgFandomComMigrationDone;
+		}
+
+		return true;
+	}
+
+	private static function isEnabled() {
+		global $wgFandomComMigrationDate, $wgFandomComMigrationDone;
+
+		return !empty( $wgFandomComMigrationDate ) || $wgFandomComMigrationDone;
+	}
+}

--- a/extensions/wikia/FandomComMigration/FandomComMigrationHooks.class.php
+++ b/extensions/wikia/FandomComMigration/FandomComMigrationHooks.class.php
@@ -16,12 +16,12 @@ class FandomComMigrationHooks {
 		// Send HTML instead of message key to avoid the issue of non-compatible i18n libs
 		if ( $wgFandomComMigrationDone ) {
 			$wikiVariables['fandomComMigrationNotificationAfter'] =
-				wfMessage( 'fandom-com-migration-after' )->plain();
+				wfMessage( 'fandom-com-migration-after' )->parse();
 		} else if ( !empty( $wgFandomComMigrationDate ) ) {
 			$wikiVariables['fandomComMigrationNotificationBefore'] =
 				wfMessage( 'fandom-com-migration-before' )
 					->params( $wgFandomComMigrationDate )
-					->plain();
+					->parse();
 		}
 
 		return true;

--- a/extensions/wikia/FandomComMigration/FandomComMigrationHooks.class.php
+++ b/extensions/wikia/FandomComMigration/FandomComMigrationHooks.class.php
@@ -4,7 +4,7 @@ class FandomComMigrationHooks {
 
 	public static function onBeforePageDisplay( OutputPage $out, Skin $skin ) {
 		if ( static::isEnabled() ) {
-			JSMessages::enqueuePackage( 'FandomComMigration', JSMessages::EXTERNAL );
+			$out->addModules( 'ext.fandomComMigration' );
 		}
 
 		return true;

--- a/extensions/wikia/FandomComMigration/FandomComMigrationHooks.class.php
+++ b/extensions/wikia/FandomComMigration/FandomComMigrationHooks.class.php
@@ -4,7 +4,24 @@ class FandomComMigrationHooks {
 
 	public static function onBeforePageDisplay( OutputPage $out, Skin $skin ) {
 		if ( static::isEnabled() ) {
-			JSMessages::enqueuePackage('FandomComMigration', JSMessages::EXTERNAL);
+			JSMessages::enqueuePackage( 'FandomComMigration', JSMessages::EXTERNAL );
+		}
+
+		return true;
+	}
+
+	public static function onMercuryWikiVariables( array &$wikiVariables ): bool {
+		global $wgFandomComMigrationDate, $wgFandomComMigrationDone;
+
+		// Send HTML instead of message key to avoid the issue of non-compatible i18n libs
+		if ( $wgFandomComMigrationDone ) {
+			$wikiVariables['fandomComMigrationNotificationAfter'] =
+				wfMessage( 'fandom-com-migration-after' )->plain();
+		} else if ( !empty( $wgFandomComMigrationDate ) ) {
+			$wikiVariables['fandomComMigrationNotificationBefore'] =
+				wfMessage( 'fandom-com-migration-before' )
+					->params( $wgFandomComMigrationDate )
+					->plain();
 		}
 
 		return true;

--- a/extensions/wikia/FandomComMigration/crowdin.conf
+++ b/extensions/wikia/FandomComMigration/crowdin.conf
@@ -1,5 +1,5 @@
 [crowdin.project]
-projectid = "FandomComMigration"
+projectid = "fandom-com-migration"
 product_person = "bwestmoreland"
 format = "mediawiki"
 source.file = "FandomComMigration.i18n.php"

--- a/extensions/wikia/FandomComMigration/crowdin.conf
+++ b/extensions/wikia/FandomComMigration/crowdin.conf
@@ -1,0 +1,5 @@
+[crowdin.project]
+projectid = "FandomComMigration"
+product_person = "bwestmoreland"
+format = "mediawiki"
+source.file = "FandomComMigration.i18n.php"

--- a/extensions/wikia/FandomComMigration/scripts/fandom-com-migration.js
+++ b/extensions/wikia/FandomComMigration/scripts/fandom-com-migration.js
@@ -11,7 +11,7 @@ require([
 ) {
 	'use strict';
 
-	var wgFandomComMigrationDate = mw.config.get('wgFandomComMigrationDate');
+	var wgFandomComMigrationScheduled = mw.config.get('wgFandomComMigrationScheduled');
 	var wgFandomComMigrationDone = mw.config.get('wgFandomComMigrationDone');
 
 	var afterMigrationClosedStorageKey = 'fandom-com-migration-after-closed';
@@ -26,7 +26,7 @@ require([
 	}
 
 	function shouldShowBeforeMigrationNotification() {
-		return wgFandomComMigrationDate && cache.get(beforeMigrationClosedStorageKey) !== storageTrueValue;
+		return wgFandomComMigrationScheduled && cache.get(beforeMigrationClosedStorageKey) !== storageTrueValue;
 	}
 
 	function showAfterMigrationNotification() {
@@ -45,7 +45,7 @@ require([
 
 	function showBeforeMigrationNotification() {
 		var banner = new BannerNotification(
-			mw.message('fandom-com-migration-before', wgFandomComMigrationDate).parse(),
+			mw.message('fandom-com-migration-before').parse(),
 			'warn',
 			null
 		);

--- a/extensions/wikia/FandomComMigration/scripts/fandom-com-migration.js
+++ b/extensions/wikia/FandomComMigration/scripts/fandom-com-migration.js
@@ -2,14 +2,12 @@ require([
 	'jquery',
 	'mw',
 	'wikia.cache',
-	'BannerNotification',
-	'JSMessages'
+	'BannerNotification'
 ], function (
 	$,
 	mw,
 	cache,
-	BannerNotification,
-	msg
+	BannerNotification
 ) {
 	'use strict';
 
@@ -33,7 +31,7 @@ require([
 
 	function showAfterMigrationNotification() {
 		var banner = new BannerNotification(
-			msg('fandom-com-migration-after'),
+			mw.message('fandom-com-migration-after').parse(),
 			'warn',
 			null
 		);
@@ -47,7 +45,7 @@ require([
 
 	function showBeforeMigrationNotification() {
 		var banner = new BannerNotification(
-			msg('fandom-com-migration-before', wgFandomComMigrationDate),
+			mw.message('fandom-com-migration-before', wgFandomComMigrationDate).parse(),
 			'warn',
 			null
 		);

--- a/extensions/wikia/FandomComMigration/scripts/fandom-com-migration.js
+++ b/extensions/wikia/FandomComMigration/scripts/fandom-com-migration.js
@@ -18,16 +18,17 @@ require([
 
 	var afterMigrationClosedStorageKey = 'fandom-com-migration-after-closed';
 	var beforeMigrationClosedStorageKey = 'fandom-com-migration-before-closed';
+	var storageTrueValue = '1';
 
 	// Keep it for a year, it's more than enough
 	var localStorageTTL = 60 * 60 * 24 * 365;
 
 	function shouldShowAfterMigrationNotification() {
-		return wgFandomComMigrationDone && cache.get(afterMigrationClosedStorageKey) === null;
+		return wgFandomComMigrationDone && cache.get(afterMigrationClosedStorageKey) !== storageTrueValue;
 	}
 
 	function shouldShowBeforeMigrationNotification() {
-		return wgFandomComMigrationDate && cache.get(beforeMigrationClosedStorageKey) === null;
+		return wgFandomComMigrationDate && cache.get(beforeMigrationClosedStorageKey) !== storageTrueValue;
 	}
 
 	function showAfterMigrationNotification() {
@@ -38,7 +39,7 @@ require([
 		);
 
 		banner.onCloseHandler = function () {
-			cache.set(afterMigrationClosedStorageKey, true, localStorageTTL);
+			cache.set(afterMigrationClosedStorageKey, storageTrueValue, localStorageTTL);
 		}
 
 		banner.show();
@@ -52,7 +53,7 @@ require([
 		);
 
 		banner.onCloseHandler = function () {
-			cache.set(beforeMigrationClosedStorageKey, true, localStorageTTL);
+			cache.set(beforeMigrationClosedStorageKey, storageTrueValue, localStorageTTL);
 		}
 
 		banner.show();

--- a/extensions/wikia/FandomComMigration/scripts/fandom-com-migration.js
+++ b/extensions/wikia/FandomComMigration/scripts/fandom-com-migration.js
@@ -1,0 +1,68 @@
+require([
+	'jquery',
+	'mw',
+	'wikia.cache',
+	'BannerNotification',
+	'JSMessages'
+], function (
+	$,
+	mw,
+	cache,
+	BannerNotification,
+	msg
+) {
+	'use strict';
+
+	var wgFandomComMigrationDate = mw.config.get('wgFandomComMigrationDate');
+	var wgFandomComMigrationDone = mw.config.get('wgFandomComMigrationDone');
+
+	var afterMigrationClosedStorageKey = 'fandom-com-migration-after-closed';
+	var beforeMigrationClosedStorageKey = 'fandom-com-migration-before-closed';
+
+	// Keep it for a year, it's more than enough
+	var localStorageTTL = 60 * 60 * 24 * 365;
+
+	function shouldShowAfterMigrationNotification() {
+		return wgFandomComMigrationDone && cache.get(afterMigrationClosedStorageKey) === null;
+	}
+
+	function shouldShowBeforeMigrationNotification() {
+		return wgFandomComMigrationDate && cache.get(beforeMigrationClosedStorageKey) === null;
+	}
+
+	function showAfterMigrationNotification() {
+		var banner = new BannerNotification(
+			msg('fandom-com-migration-after'),
+			'warn',
+			null
+		);
+
+		banner.onCloseHandler = function () {
+			cache.set(afterMigrationClosedStorageKey, true, localStorageTTL);
+		}
+
+		banner.show();
+	}
+
+	function showBeforeMigrationNotification() {
+		var banner = new BannerNotification(
+			msg('fandom-com-migration-before', wgFandomComMigrationDate),
+			'warn',
+			null
+		);
+
+		banner.onCloseHandler = function () {
+			cache.set(beforeMigrationClosedStorageKey, true, localStorageTTL);
+		}
+
+		banner.show();
+	}
+
+	$(function () {
+		if (shouldShowAfterMigrationNotification()) {
+			showAfterMigrationNotification();
+		} else if (shouldShowBeforeMigrationNotification()) {
+			showBeforeMigrationNotification();
+		}
+	});
+});

--- a/includes/wikia/Extensions.php
+++ b/includes/wikia/Extensions.php
@@ -1758,3 +1758,5 @@ include "$IP/extensions/wikia/AutoLogin/AutoLogin.setup.php";
 if ( !empty( $wgEnableFeedsAndPostsExt ) ) {
 	include "$IP/extensions/wikia/FeedsAndPosts/FeedsAndPosts.setup.php";
 }
+
+include "$IP/extensions/wikia/FandomComMigration/FandomComMigration.setup.php";

--- a/includes/wikia/VariablesBase.php
+++ b/includes/wikia/VariablesBase.php
@@ -8885,11 +8885,11 @@ $wgDataMartOriginalCityId = 0;
 $wgAllowCommunityBuilderCNWPrompt = false;
 
 /**
- * Date of migration to a fandom.com domain, triggers a banner notification
+ * Whether the community is scheduled to be migrated to a fandom.com domain, triggers a banner notification
  * @see SEO-669
- * @var string $wgFandomComMigrationDate
+ * @var string $wgFandomComMigrationScheduled
  */
-$wgFandomComMigrationDate = null;
+$wgFandomComMigrationScheduled = false;
 
 /**
  * Whether the community was migrated to a fandom.com domain, triggers a banner notification

--- a/includes/wikia/VariablesBase.php
+++ b/includes/wikia/VariablesBase.php
@@ -8883,3 +8883,17 @@ $wgDataMartOriginalCityId = 0;
  * @see CAKE-2151
  */
 $wgAllowCommunityBuilderCNWPrompt = false;
+
+/**
+ * Date of migration to a fandom.com domain, triggers a banner notification
+ * @see SEO-669
+ * @var string $wgFandomComMigrationDate
+ */
+$wgFandomComMigrationDate = null;
+
+/**
+ * Whether the community was migrated to a fandom.com domain, triggers a banner notification
+ * @see SEO-669
+ * @var bool $wgFandomComMigrationDone
+ */
+$wgFandomComMigrationDone = false;


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SEO-669

When a wiki is chosen to be migrated to `fandom.com` domain, we'll put the migration date in the `wgFandomComMigrationDate` WikiFactory variable. When a wiki is migrated, we'll set `wgFandomComMigrationDone` to `true`. It will cause a banner notification to display before and after the migration. When user closes the notification, we'll create an entry in LocalStorage to not show it again.

@Wikia/core-platform-team 