### PR TITLE
SRE | fix rabbit hole in tests

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,46 @@
+<?php
+
+error_reporting( E_ALL );
+ini_set( 'display_errors', 1 );
+ini_set( 'memory_limit', '256M' );
+
+// Don't include DevBoxSettings when running unit tests
+$wgRunningUnitTests = true;
+$wgDevelEnvironment = true;
+$wgCommandLineMode = true;
+
+// Evil MediaWiki bootstrap 👹
+
+$IP = __DIR__ . '/..';
+
+define( 'MEDIAWIKI', true );
+
+require_once "$IP/includes/Init.php";
+require_once "$IP/includes/AutoLoader.php";
+
+require_once "$IP/includes/Defines.php";
+
+require_once "$IP/LocalSettings.php";
+
+require_once "$IP/includes/Setup.php";
+
+// base classes for tests
+$wgAutoloadClasses['ApiIntegrationTestTrait'] = $IP . '/includes/wikia/tests/core/ApiIntegrationTestTrait.php';
+$wgAutoloadClasses['WikiaBaseTest'] = $IP . '/includes/wikia/tests/core/WikiaBaseTest.class.php';
+$wgAutoloadClasses['WikiaDatabaseTest'] = $IP . '/includes/wikia/tests/core/WikiaDatabaseTest.php';
+$wgAutoloadClasses['HttpIntegrationTest'] = "$IP/includes/wikia/tests/core/HttpIntegrationTest.php";
+$wgAutoloadClasses['WikiaMockProxy'] = $IP . '/includes/wikia/tests/core/WikiaMockProxy.class.php';
+$wgAutoloadClasses['WikiaMockProxyAction'] = $IP . '/includes/wikia/tests/core/WikiaMockProxyAction.class.php';
+$wgAutoloadClasses['WikiaMockProxyInvocation'] = $IP . '/includes/wikia/tests/core/WikiaMockProxyInvocation.class.php';
+$wgAutoloadClasses['MockGlobalVariableTrait'] = $IP . '/includes/wikia/tests/core/MockGlobalVariableTrait.php';
+
+// This is needed to properly support PHPUnit's process isolation feature
+// We are not using the official PHPUnit entry point, so we need to tell PHPUnit that it was installed via composer.
+if ( !defined( 'PHPUNIT_COMPOSER_INSTALL' ) ) {
+	define( 'PHPUNIT_COMPOSER_INSTALL', "$IP/lib/composer/autoload.php" );
+}
+
+$wgWikiFactoryCacheType = CACHE_NONE;
+$wgMemc = new EmptyBagOStuff();
+
+$wgTaskBrokerDisabled = true;

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -2,7 +2,7 @@
 <phpunit
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.5/phpunit.xsd"
-		bootstrap="run-test.php"
+		bootstrap="bootstrap.php"
 		backupGlobals="false"
 		backupStaticAttributes="false"
 		colors="true"

--- a/tests/run-test.php
+++ b/tests/run-test.php
@@ -1,48 +1,5 @@
 <?php
 
-error_reporting( E_ALL );
-ini_set( 'display_errors', 1 );
-ini_set( 'memory_limit', '256M' );
-
-// Don't include DevBoxSettings when running unit tests
-$wgRunningUnitTests = true;
-$wgDevelEnvironment = true;
-$wgCommandLineMode = true;
-
-// Evil MediaWiki bootstrap 👹
-
-$IP = __DIR__ . '/..';
-
-define( 'MEDIAWIKI', true );
-
-require_once "$IP/includes/Init.php";
-require_once "$IP/includes/AutoLoader.php";
-
-require_once "$IP/includes/Defines.php";
-
-require_once "$IP/LocalSettings.php";
-
-require_once "$IP/includes/Setup.php";
-
-// base classes for tests
-$wgAutoloadClasses['ApiIntegrationTestTrait'] = $IP . '/includes/wikia/tests/core/ApiIntegrationTestTrait.php';
-$wgAutoloadClasses['WikiaBaseTest'] = $IP . '/includes/wikia/tests/core/WikiaBaseTest.class.php';
-$wgAutoloadClasses['WikiaDatabaseTest'] = $IP . '/includes/wikia/tests/core/WikiaDatabaseTest.php';
-$wgAutoloadClasses['HttpIntegrationTest'] = "$IP/includes/wikia/tests/core/HttpIntegrationTest.php";
-$wgAutoloadClasses['WikiaMockProxy'] = $IP . '/includes/wikia/tests/core/WikiaMockProxy.class.php';
-$wgAutoloadClasses['WikiaMockProxyAction'] = $IP . '/includes/wikia/tests/core/WikiaMockProxyAction.class.php';
-$wgAutoloadClasses['WikiaMockProxyInvocation'] = $IP . '/includes/wikia/tests/core/WikiaMockProxyInvocation.class.php';
-$wgAutoloadClasses['MockGlobalVariableTrait'] = $IP . '/includes/wikia/tests/core/MockGlobalVariableTrait.php';
-
-// This is needed to properly support PHPUnit's process isolation feature
-// We are not using the official PHPUnit entry point, so we need to tell PHPUnit that it was installed via composer.
-if ( !defined( 'PHPUNIT_COMPOSER_INSTALL' ) ) {
-	define( 'PHPUNIT_COMPOSER_INSTALL', "$IP/lib/composer/autoload.php" );
-}
-
-$wgWikiFactoryCacheType = CACHE_NONE;
-$wgMemc = new EmptyBagOStuff();
-
-$wgTaskBrokerDisabled = true;
+require_once __DIR__ . '/bootstrap.php';
 
 \PHPUnit\TextUI\Command::main();


### PR DESCRIPTION
`run-test.php` contained a call to PHPUnit init code and it was also used as the PHPUnit bootstrap file. Because of this a bunch of tests would run twice if a test used process isolation. Let's separate out the bootstrap stuff into its own file to avoid that.