### PR TITLE
fix fetching local nav

### DIFF
--- a/extensions/wikia/MercuryApi/models/MercuryApi.class.php
+++ b/extensions/wikia/MercuryApi/models/MercuryApi.class.php
@@ -323,7 +323,7 @@ class MercuryApi {
 	 * @return array
 	 */
 	private function getNavigation() {
-		$navData = $this->sendRequest( 'NavigationApi', 'getData' )->getData();
+		$navData = F::app()->sendRequest( 'NavigationApi', 'getData' )->getData();
 
 		if ( !isset( $navData['navigation']['wiki'] ) ) {
 			$localNavigation = [];


### PR DESCRIPTION
After moving code from controller to other class, fetching local navigation data failed, therefore requests to MercuryApi::getWikiVariables returned HTTP 500 status code.

@rogatty 
@Wikia/iwing 