### PR TITLE
SUS-5847: catch all Exceptions and Errors in proxy.php

### DIFF
--- a/extensions/wikia/Tasks/proxy/proxy.php
+++ b/extensions/wikia/Tasks/proxy/proxy.php
@@ -52,11 +52,19 @@ require ( $IP . '/includes/WebStart.php' );
 $request = new FauxRequest( $_POST, true );
 
 // finally, execute the task
-$runner = Wikia\Tasks\TaskRunner::newFromRequest( $request );
-$runner->run();
+try {
+	$runner = Wikia\Tasks\TaskRunner::newFromRequest( $request );
+	$runner->run();
+	$resp = $runner->format();
+} catch ( Throwable $ex ) {
+	$resp = [
+		'status' => 'failure',
+		'reason' => sprintf('%s: %s', get_class( $ex ), $ex->getMessage() ),
+	];
+}
 
 // wrap JSON response in AjaxResponse class so that we will emit consistent set of headers
-$response = new AjaxResponse( json_encode( $runner->format() ) );
+$response = new AjaxResponse( json_encode( $resp ) );
 
 $response->setContentType('application/json; charset=utf-8');
 $response->sendHeaders();

--- a/extensions/wikia/Tasks/proxy/proxy.php
+++ b/extensions/wikia/Tasks/proxy/proxy.php
@@ -66,6 +66,7 @@ try {
 // wrap JSON response in AjaxResponse class so that we will emit consistent set of headers
 $response = new AjaxResponse( json_encode( $resp ) );
 
+header('X-Served-By: ' . wfHostname() );
 $response->setContentType('application/json; charset=utf-8');
 $response->sendHeaders();
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5847

When debugging problems with celery-workers and executing MediaWiki tasks "manually" from Python console, I've found it useful to properly handled exceptions and errors thrown by tasks code. Make `proxy.php` return a proper JSON response with "failure" field. `celery-worker` will log the following:

```
[2018-10-03 09:48:40,343: ERROR/Worker-4] {"exception_type": "RemoteExecuteError", "exception": "RemoteExecuteError(u'TypeError: Argument 6 passed to Wikia\\\\Tasks\\\\TaskRunner::__construct() must be of the type float, null given, called in /usr/wikia/source/deploytools/24231/src/lib/Wikia/src/Tasks/TaskRunner.php on line 41',)", "event": "Task failed", "task_id": "ecb4a7e4-438b-430c-9efa-ac64b1708b39"}
```