### PR TITLE
SUS-5861 add x-original-host when using local proxy

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -79,6 +79,8 @@ $wgKubernetesNamespace = getenv( 'KUBERNETES_NAMESPACE' );
 if ( !empty( $wgKubernetesDeploymentName ) ) {
 	// SUS-5499: Use internal host name for MW->MW requests when running on Kubernetes
 	$wgHTTPProxy = "$wgKubernetesDeploymentName.$wgKubernetesNamespace:80";
+	// SUS-5861 if we're proxying through the internal host, set x-original-host
+	$wgSetOriginalHostHeader = true;
 }
 else {
 	// SUS-5675 | TODO: remove when we switch fully to Kubernetes

--- a/includes/HttpFunctions.php
+++ b/includes/HttpFunctions.php
@@ -382,9 +382,13 @@ class MWHttpRequest {
 			return;
 		}
 
-		global $wgHTTPProxy;
+		global $wgHTTPProxy, $wgSetOriginalHostHeader;
 		if ( $wgHTTPProxy ) {
-			$this->proxy = $wgHTTPProxy ;
+			$this->proxy = $wgHTTPProxy;
+			if ( $wgSetOriginalHostHeader ) {
+				// SUS-5861 when we proxy to the same k8s service, we need to set x-original-host so that nginx can set the proper hostname for PHP
+				$this->setHeader( 'X-Original-Host', $this->parsedUrl['host'] );
+			}
 		}
 	}
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5861

Whenever we proxy a HTTP request locally on k8s, we need to set the proper `x-original-host` header, since nginx needs it to forward the correct host to PHP.