### PR TITLE
SUS-5889 | proxy.php - clean all output before we emit a JSON response

### DIFF
--- a/extensions/wikia/Tasks/proxy/proxy.php
+++ b/extensions/wikia/Tasks/proxy/proxy.php
@@ -52,6 +52,8 @@ require ( $IP . '/includes/WebStart.php' );
 $request = new FauxRequest( $_POST, true );
 
 // finally, execute the task
+ob_start();
+
 try {
 	$runner = Wikia\Tasks\TaskRunner::newFromRequest( $request );
 	$runner->run();
@@ -62,6 +64,8 @@ try {
 		'reason' => sprintf('%s: %s', get_class( $ex ), $ex->getMessage() ),
 	];
 }
+
+ob_end_clean();
 
 // wrap JSON response in AjaxResponse class so that we will emit consistent set of headers
 $response = new AjaxResponse( json_encode( $resp ) );


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5889

Avoid the following:

```
...cu_changes table added.
...doing rc_id from 1 to 100
...doing rc_id from 100 to 199
...cu_changes table added and populated.
...cu_log already exists
{"status":"success","retval":true}
```