### PR TITLE
SUS-5880 | more resources for mediawiki-tasks

### DIFF
--- a/docker/prod/prod.template.yaml
+++ b/docker/prod/prod.template.yaml
@@ -283,7 +283,7 @@ spec:
               cpu: 6
               memory: 2Gi
             requests:
-              cpu: 1
+              cpu: 2
               memory: 800Mi
         # MW log output, see K8s_LOGGING.md
         - name: logger
@@ -338,7 +338,7 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: mediawiki-tasks
-  maxReplicas: 20
+  maxReplicas: 30
   minReplicas: 10
   metrics:
   - type: Resource


### PR DESCRIPTION
In order to handle ~50% of tasks we need to increase the number of pods that can handle them. This PR also tweaks the `cpu` request for php so that:

1. We have more cpu initially (the request is guaranteed)
2. The autoscaler is a little slower to react (right now it's a bit too eager)