### PR TITLE
(PLATFORM-3744) Add a button to reset tracking preferences on fandom.com

### DIFF
--- a/extensions/wikia/TrackingOptIn/ResetTrackingPreferences.setup.php
+++ b/extensions/wikia/TrackingOptIn/ResetTrackingPreferences.setup.php
@@ -1,0 +1,23 @@
+<?php
+
+$GLOBALS['wgAutoloadClasses']['ResetTrackingPreferencesSpecialController'] = __DIR__ . '/ResetTrackingPreferencesSpecialController.class.php';
+$wgSpecialPages['ResetTrackingPreferences'] = 'ResetTrackingPreferencesSpecialController';
+
+$GLOBALS['wgResourceModules']['ext.wikia.trackingSettingsManager'] = [
+	'scripts' => [ 'js/ext.wikia.trackingSettingsManager.js' ],
+	'styles' => [ 'styles/ext.wikia.trackingSettingsManager.css' ],
+	'messages' => [
+		'privacy-settings-button-toggle',
+		'privacy-settings-button-toggle-fandom'
+	],
+
+	'localBasePath' => __DIR__,
+	'remoteExtPath' => 'wikia/TrackingOptIn',
+];
+
+$GLOBALS['wgResourceModules']['ext.wikia.resetTrackingSettings'] = [
+	'scripts' => [ 'js/ext.wikia.resetTrackingSettings.js' ],
+
+	'localBasePath' => __DIR__,
+	'remoteExtPath' => 'wikia/TrackingOptIn',
+];

--- a/extensions/wikia/TrackingOptIn/ResetTrackingPreferences.setup.php
+++ b/extensions/wikia/TrackingOptIn/ResetTrackingPreferences.setup.php
@@ -3,8 +3,8 @@
 $GLOBALS['wgAutoloadClasses']['ResetTrackingPreferencesSpecialController'] = __DIR__ . '/ResetTrackingPreferencesSpecialController.class.php';
 $wgSpecialPages['ResetTrackingPreferences'] = 'ResetTrackingPreferencesSpecialController';
 
-$GLOBALS['wgResourceModules']['ext.wikia.trackingSettingsManager'] = [
-	'scripts' => [ 'js/ext.wikia.trackingSettingsManager.js' ],
+$GLOBALS['wgResourceModules']['ext.wikia.resetTrackingSettingsManager'] = [
+	'scripts' => [ 'js/ext.wikia.resetTrackingSettingsManager.js' ],
 	'styles' => [ 'styles/ext.wikia.trackingSettingsManager.css' ],
 	'messages' => [
 		'privacy-settings-button-toggle',

--- a/extensions/wikia/TrackingOptIn/ResetTrackingPreferencesSpecialController.class.php
+++ b/extensions/wikia/TrackingOptIn/ResetTrackingPreferencesSpecialController.class.php
@@ -38,7 +38,7 @@ class ResetTrackingPreferencesSpecialController extends WikiaSpecialPageControll
 	private function isValidReturnToTarget( $url ) {
 		global $wgWikiaBaseDomainRegex;
 		$host = parse_url( $url, PHP_URL_HOST );
-		if ( empty( $host ) ) {
+		if ( $host === false || empty( $host ) ) {
 			return false;
 		}
 

--- a/extensions/wikia/TrackingOptIn/ResetTrackingPreferencesSpecialController.class.php
+++ b/extensions/wikia/TrackingOptIn/ResetTrackingPreferencesSpecialController.class.php
@@ -1,0 +1,30 @@
+<?php
+
+class ResetTrackingPreferencesSpecialController extends WikiaSpecialPageController {
+
+	const DEFAULT_TEMPLATE_ENGINE = \WikiaResponse::TEMPLATE_ENGINE_MUSTACHE;
+
+	public function __construct() {
+		parent::__construct( 'ResetTrackingPreferences' );
+	}
+
+	/**
+	 * Main entry point.
+	 */
+	public function index() {
+		$this->specialPage->setHeaders();
+
+		$request = $this->getRequest();
+		$output = $this->getOutput();
+
+		// CSRF protection
+		if ( $request->wasPosted()
+			&& $this->getUser()->matchEditToken( $request->getVal( 'token' ) )
+		) {
+			$output->addModules( 'ext.wikia.resetTrackingSettings' );
+		} else {
+			// Just show the button
+			$output->addModules( 'ext.wikia.trackingSettingsManager' );
+		}
+	}
+}

--- a/extensions/wikia/TrackingOptIn/ResetTrackingPreferencesSpecialController.class.php
+++ b/extensions/wikia/TrackingOptIn/ResetTrackingPreferencesSpecialController.class.php
@@ -26,7 +26,6 @@ class ResetTrackingPreferencesSpecialController extends WikiaSpecialPageControll
 			$this->setVal( 'returnToMsg', $this->msg( 'returnto', $this->defaultReturnToTarget )->parse() );
 		}
 
-		// CSRF protection
 		if ( $request->wasPosted() ) {
 			$output->addModules( 'ext.wikia.resetTrackingSettings' );
 		}

--- a/extensions/wikia/TrackingOptIn/ResetTrackingPreferencesSpecialController.class.php
+++ b/extensions/wikia/TrackingOptIn/ResetTrackingPreferencesSpecialController.class.php
@@ -34,7 +34,7 @@ class ResetTrackingPreferencesSpecialController extends WikiaSpecialPageControll
 		}
 
 		// Just show the buttons
-		$output->addModules( 'ext.wikia.trackingSettingsManager' );
+		$output->addModules( 'ext.wikia.resetTrackingSettingsManager' );
 	}
 
 	private function isValidReturnToTarget( $url ) {

--- a/extensions/wikia/TrackingOptIn/ResetTrackingPreferencesSpecialController.class.php
+++ b/extensions/wikia/TrackingOptIn/ResetTrackingPreferencesSpecialController.class.php
@@ -27,9 +27,7 @@ class ResetTrackingPreferencesSpecialController extends WikiaSpecialPageControll
 		}
 
 		// CSRF protection
-		if ( $request->wasPosted()
-			&& $this->getUser()->matchEditToken( $request->getVal( 'token' ) )
-		) {
+		if ( $request->wasPosted() ) {
 			$output->addModules( 'ext.wikia.resetTrackingSettings' );
 		}
 

--- a/extensions/wikia/TrackingOptIn/TrackingSettingsManager.i18n.php
+++ b/extensions/wikia/TrackingOptIn/TrackingSettingsManager.i18n.php
@@ -2,6 +2,7 @@
 $messages = array();
 
 $messages['en'] = array(
+	'resettrackingpreferences' => 'Reset your tracking preferences',
 	'privacy-settings-button-toggle' => 'Reset your tracking preferences on wikia.com',
 	'privacy-settings-button-toggle-fandom' => 'Reset your tracking preferences on fandom.com',
 );
@@ -11,42 +12,52 @@ $messages['qqq'] = array(
 );
 
 $messages['de'] = array(
-	'privacy-settings-button-toggle' => 'Reset your tracking preferences',
+	'privacy-settings-button-toggle' => 'Reset your tracking preferences on wikia.com',
+	'privacy-settings-button-toggle-fandom' => 'Reset your tracking preferences on fandom.com',
 );
 
 $messages['es'] = array(
-	'privacy-settings-button-toggle' => 'Reset your tracking preferences',
+	'privacy-settings-button-toggle' => 'Reset your tracking preferences on wikia.com',
+	'privacy-settings-button-toggle-fandom' => 'Reset your tracking preferences on fandom.com',
 );
 
 $messages['fr'] = array(
-	'privacy-settings-button-toggle' => 'Reset your tracking preferences',
+	'privacy-settings-button-toggle' => 'Reset your tracking preferences on wikia.com',
+	'privacy-settings-button-toggle-fandom' => 'Reset your tracking preferences on fandom.com',
 );
 
 $messages['it'] = array(
-	'privacy-settings-button-toggle' => 'Reset your tracking preferences',
+	'privacy-settings-button-toggle' => 'Reset your tracking preferences on wikia.com',
+	'privacy-settings-button-toggle-fandom' => 'Reset your tracking preferences on fandom.com',
 );
 
 $messages['ja'] = array(
-	'privacy-settings-button-toggle' => 'Reset your tracking preferences',
+	'privacy-settings-button-toggle' => 'Reset your tracking preferences on wikia.com',
+	'privacy-settings-button-toggle-fandom' => 'Reset your tracking preferences on fandom.com',
 );
 
 $messages['pl'] = array(
-	'privacy-settings-button-toggle' => 'Reset your tracking preferences',
+	'privacy-settings-button-toggle' => 'Reset your tracking preferences on wikia.com',
+	'privacy-settings-button-toggle-fandom' => 'Reset your tracking preferences on fandom.com',
 );
 
 $messages['pt'] = array(
-	'privacy-settings-button-toggle' => 'Reset your tracking preferences',
+	'privacy-settings-button-toggle' => 'Reset your tracking preferences on wikia.com',
+	'privacy-settings-button-toggle-fandom' => 'Reset your tracking preferences on fandom.com',
 );
 
 $messages['ru'] = array(
-	'privacy-settings-button-toggle' => 'Reset your tracking preferences',
+	'privacy-settings-button-toggle' => 'Reset your tracking preferences on wikia.com',
+	'privacy-settings-button-toggle-fandom' => 'Reset your tracking preferences on fandom.com',
 );
 
 $messages['zh-hans'] = array(
-	'privacy-settings-button-toggle' => 'Reset your tracking preferences',
+	'privacy-settings-button-toggle' => 'Reset your tracking preferences on wikia.com',
+	'privacy-settings-button-toggle-fandom' => 'Reset your tracking preferences on fandom.com',
 );
 
 $messages['zh-hant'] = array(
-	'privacy-settings-button-toggle' => 'Reset your tracking preferences',
+	'privacy-settings-button-toggle' => 'Reset your tracking preferences on wikia.com',
+	'privacy-settings-button-toggle-fandom' => 'Reset your tracking preferences on fandom.com',
 );
 

--- a/extensions/wikia/TrackingOptIn/TrackingSettingsManager.i18n.php
+++ b/extensions/wikia/TrackingOptIn/TrackingSettingsManager.i18n.php
@@ -2,7 +2,8 @@
 $messages = array();
 
 $messages['en'] = array(
-	'privacy-settings-button-toggle' => 'Reset your tracking preferences',
+	'privacy-settings-button-toggle' => 'Reset your tracking preferences on wikia.com',
+	'privacy-settings-button-toggle-fandom' => 'Reset your tracking preferences on fandom.com',
 );
 
 $messages['qqq'] = array(

--- a/extensions/wikia/TrackingOptIn/TrackingSettingsManager.setup.php
+++ b/extensions/wikia/TrackingOptIn/TrackingSettingsManager.setup.php
@@ -6,7 +6,10 @@ $GLOBALS['wgHooks']['OutputPageParserOutput'][] = '\TrackingSettingsManagerHooks
 $GLOBALS['wgResourceModules']['ext.wikia.trackingSettingsManager'] = [
 	'scripts' => [ 'js/ext.wikia.trackingSettingsManager.js' ],
 	'styles' => [ 'styles/ext.wikia.trackingSettingsManager.css' ],
-	'messages' => [ 'privacy-settings-button-toggle' ],
+	'messages' => [
+		'privacy-settings-button-toggle',
+		'privacy-settings-button-toggle-fandom'
+	],
 
 	'localBasePath' => __DIR__,
 	'remoteExtPath' => 'wikia/TrackingOptIn',

--- a/extensions/wikia/TrackingOptIn/js/ext.wikia.resetTrackingSettings.js
+++ b/extensions/wikia/TrackingOptIn/js/ext.wikia.resetTrackingSettings.js
@@ -8,7 +8,7 @@ require(['wikia.cmp', 'wikia.trackingOptInModal', 'mw'], function (cmp, tracking
 	}
 
 	if (document.readyState !== 'loading') {
-		createTrackingSettingsButton();
+		resetTrackingSettings();
 	} else {
 		document.addEventListener('DOMContentLoaded', resetTrackingSettings);
 	}

--- a/extensions/wikia/TrackingOptIn/js/ext.wikia.resetTrackingSettings.js
+++ b/extensions/wikia/TrackingOptIn/js/ext.wikia.resetTrackingSettings.js
@@ -1,0 +1,15 @@
+/*global require*/
+require(['wikia.cmp', 'wikia.trackingOptInModal', 'mw'], function (cmp, trackingOptInModal, mw) {
+	'use strict';
+
+	function resetTrackingSettings() {
+		cmp.reset();
+		trackingOptInModal.init({ zIndex: 9999999 }).reset();
+	}
+
+	if (document.readyState !== 'loading') {
+		createTrackingSettingsButton();
+	} else {
+		document.addEventListener('DOMContentLoaded', resetTrackingSettings);
+	}
+});

--- a/extensions/wikia/TrackingOptIn/js/ext.wikia.resetTrackingSettingsManager.js
+++ b/extensions/wikia/TrackingOptIn/js/ext.wikia.resetTrackingSettingsManager.js
@@ -1,0 +1,25 @@
+/*global require*/
+require(['wikia.cmp', 'wikia.trackingOptInModal', 'mw'], function (cmp, trackingOptInModal, mw) {
+	'use strict';
+
+	function createTrackingSettingsButton() {
+		var trackingSettingsButton = document.createElement('button');
+
+		trackingSettingsButton.classList.add('privacy-settings-button', 'wds-button');
+
+		trackingSettingsButton.textContent = mw.message('privacy-settings-button-toggle-fandom').text();
+		trackingSettingsButton.addEventListener('click', function () {
+			cmp.reset();
+			trackingOptInModal.init({ zIndex: 9999999 }).reset();
+		});
+
+		var articleContent = document.getElementById('mw-content-text');
+		articleContent.appendChild(trackingSettingsButton);
+	}
+
+	if (document.readyState !== 'loading') {
+		createTrackingSettingsButton();
+	} else {
+		document.addEventListener('DOMContentLoaded', createTrackingSettingsButton);
+	}
+});

--- a/extensions/wikia/TrackingOptIn/js/ext.wikia.trackingSettingsManager.js
+++ b/extensions/wikia/TrackingOptIn/js/ext.wikia.trackingSettingsManager.js
@@ -16,16 +16,17 @@ require(['wikia.cmp', 'wikia.trackingOptInModal', 'mw'], function (cmp, tracking
 		var articleContent = document.getElementById('mw-content-text');
 		articleContent.appendChild(trackingSettingsButton);
 
-		var trackingSettingsButtonFandom = document.createElement('button');
+		var fandomResetCookieForm = document.createElement('form');
+		fandomResetCookieForm.setAttribute('method', 'post');
+		fandomResetCookieForm.setAttribute('action','https://migration.fandom.com/wiki/Special:ResetTrackingPreferences');
 
+		var trackingSettingsButtonFandom = document.createElement('input');
+		trackingSettingsButtonFandom.setAttribute('type', 'submit');
 		trackingSettingsButtonFandom.classList.add('privacy-settings-button', 'wds-button');
+		trackingSettingsButtonFandom.value = mw.message('privacy-settings-button-toggle-fandom').text();
 
-		trackingSettingsButtonFandom.textContent = mw.message('privacy-settings-button-toggle-fandom').text();
-		trackingSettingsButtonFandom.addEventListener('click', function () {
-			// Go to migration page
-		});
-
-		articleContent.appendChild(trackingSettingsButtonFandom);
+		fandomResetCookieForm.appendChild(trackingSettingsButtonFandom);
+		articleContent.appendChild(fandomResetCookieForm);
 	}
 
 	if (document.readyState !== 'loading') {

--- a/extensions/wikia/TrackingOptIn/js/ext.wikia.trackingSettingsManager.js
+++ b/extensions/wikia/TrackingOptIn/js/ext.wikia.trackingSettingsManager.js
@@ -5,7 +5,8 @@ require(['wikia.cmp', 'wikia.trackingOptInModal', 'mw'], function (cmp, tracking
 	function createTrackingSettingsButton() {
 		var trackingSettingsButton = document.createElement('button');
 
-		trackingSettingsButton.classList.add('privacy-settings-button wds-button');
+		trackingSettingsButton.classList.add('privacy-settings-button');
+		trackingSettingsButton.classList.add('wds-button');
 
 		trackingSettingsButton.textContent = mw.message('privacy-settings-button-toggle').text();
 		trackingSettingsButton.addEventListener('click', function () {
@@ -16,17 +17,18 @@ require(['wikia.cmp', 'wikia.trackingOptInModal', 'mw'], function (cmp, tracking
 		var articleContent = document.getElementById('mw-content-text');
 		articleContent.appendChild(trackingSettingsButton);
 
-		var trackingSettingsButton = document.createElement('button');
+		var trackingSettingsButtonFandom = document.createElement('button');
 
-		trackingSettingsButton.classList.add('privacy-settings-button wds-button');
+		trackingSettingsButtonFandom.classList.add('privacy-settings-button');
+		trackingSettingsButtonFandom.classList.add('wds-button');
 
-		trackingSettingsButton.textContent = mw.message('privacy-settings-button-toggle-fandom').text();
-		trackingSettingsButton.addEventListener('click', function () {
+		trackingSettingsButtonFandom.textContent = mw.message('privacy-settings-button-toggle-fandom').text();
+		trackingSettingsButtonFandom.addEventListener('click', function () {
 			// Go to migration page
 		});
 
 		var articleContent = document.getElementById('mw-content-text');
-		articleContent.appendChild(trackingSettingsButton);
+		articleContent.appendChild(trackingSettingsButtonFandom);
 	}
 
 	if (document.readyState !== 'loading') {

--- a/extensions/wikia/TrackingOptIn/js/ext.wikia.trackingSettingsManager.js
+++ b/extensions/wikia/TrackingOptIn/js/ext.wikia.trackingSettingsManager.js
@@ -5,13 +5,24 @@ require(['wikia.cmp', 'wikia.trackingOptInModal', 'mw'], function (cmp, tracking
 	function createTrackingSettingsButton() {
 		var trackingSettingsButton = document.createElement('button');
 
-		trackingSettingsButton.id = 'privacy-settings-button';
-		trackingSettingsButton.classList.add('wds-button');
+		trackingSettingsButton.classList.add('privacy-settings-button wds-button');
 
 		trackingSettingsButton.textContent = mw.message('privacy-settings-button-toggle').text();
 		trackingSettingsButton.addEventListener('click', function () {
 			cmp.reset();
 			trackingOptInModal.init({ zIndex: 9999999 }).reset();
+		});
+
+		var articleContent = document.getElementById('mw-content-text');
+		articleContent.appendChild(trackingSettingsButton);
+
+		var trackingSettingsButton = document.createElement('button');
+
+		trackingSettingsButton.classList.add('privacy-settings-button wds-button');
+
+		trackingSettingsButton.textContent = mw.message('privacy-settings-button-toggle-fandom').text();
+		trackingSettingsButton.addEventListener('click', function () {
+			// Go to migration page
 		});
 
 		var articleContent = document.getElementById('mw-content-text');

--- a/extensions/wikia/TrackingOptIn/js/ext.wikia.trackingSettingsManager.js
+++ b/extensions/wikia/TrackingOptIn/js/ext.wikia.trackingSettingsManager.js
@@ -5,8 +5,7 @@ require(['wikia.cmp', 'wikia.trackingOptInModal', 'mw'], function (cmp, tracking
 	function createTrackingSettingsButton() {
 		var trackingSettingsButton = document.createElement('button');
 
-		trackingSettingsButton.classList.add('privacy-settings-button');
-		trackingSettingsButton.classList.add('wds-button');
+		trackingSettingsButton.classList.add('privacy-settings-button', 'wds-button');
 
 		trackingSettingsButton.textContent = mw.message('privacy-settings-button-toggle').text();
 		trackingSettingsButton.addEventListener('click', function () {
@@ -19,8 +18,7 @@ require(['wikia.cmp', 'wikia.trackingOptInModal', 'mw'], function (cmp, tracking
 
 		var trackingSettingsButtonFandom = document.createElement('button');
 
-		trackingSettingsButtonFandom.classList.add('privacy-settings-button');
-		trackingSettingsButtonFandom.classList.add('wds-button');
+		trackingSettingsButtonFandom.classList.add('privacy-settings-button', 'wds-button');
 
 		trackingSettingsButtonFandom.textContent = mw.message('privacy-settings-button-toggle-fandom').text();
 		trackingSettingsButtonFandom.addEventListener('click', function () {

--- a/extensions/wikia/TrackingOptIn/js/ext.wikia.trackingSettingsManager.js
+++ b/extensions/wikia/TrackingOptIn/js/ext.wikia.trackingSettingsManager.js
@@ -25,7 +25,6 @@ require(['wikia.cmp', 'wikia.trackingOptInModal', 'mw'], function (cmp, tracking
 			// Go to migration page
 		});
 
-		var articleContent = document.getElementById('mw-content-text');
 		articleContent.appendChild(trackingSettingsButtonFandom);
 	}
 

--- a/extensions/wikia/TrackingOptIn/styles/ext.wikia.trackingSettingsManager.css
+++ b/extensions/wikia/TrackingOptIn/styles/ext.wikia.trackingSettingsManager.css
@@ -1,4 +1,4 @@
-#privacy-settings-button {
+.privacy-settings-button {
     display: block;
     margin: 24px auto;
 }

--- a/extensions/wikia/TrackingOptIn/templates/ResetTrackingPreferencesSpecial_index.mustache
+++ b/extensions/wikia/TrackingOptIn/templates/ResetTrackingPreferencesSpecial_index.mustache
@@ -1,0 +1,1 @@
+<p id="mw-returnto">{{{returnToMsg}}}</p>

--- a/includes/wikia/Extensions.php
+++ b/includes/wikia/Extensions.php
@@ -409,7 +409,7 @@ if ( defined( 'REBUILD_LOCALISATION_CACHE_IN_PROGRESS' ) || !empty($wgEnableSema
 
 if ( !empty( $wgEnableScribuntoExt ) ) {
 	include "$IP/extensions/Scribunto/Scribunto.php";
-	
+
 	// SUS-5540: use the luasandbox extension as executor if it is available
 	if ( extension_loaded( 'luasandbox' ) ) {
 		$wgScribuntoDefaultEngine = 'luasandbox';
@@ -1727,6 +1727,10 @@ if ( !empty( $wgEnablePlaybuzzTagExt ) ) {
 
 if ( !empty( $wgEnableTrackingSettingsManager ) ) {
 	include "$IP/extensions/wikia/TrackingOptIn/TrackingSettingsManager.setup.php";
+}
+
+if ( !empty( $wgEnableResetTrackingPreferencesPage ) ) {
+	include "$IP/extensions/wikia/TrackingOptIn/ResetTrackingPreferences.setup.php";
 }
 
 include "$IP/extensions/wikia/JWPlayerTag/JWPlayerTag.setup.php";

--- a/includes/wikia/VariablesBase.php
+++ b/includes/wikia/VariablesBase.php
@@ -8876,3 +8876,9 @@ $wgFandomComMigrationScheduled = false;
  * @var bool $wgFandomComMigrationDone
  */
 $wgFandomComMigrationDone = false;
+
+/**
+ * Whether we should enable tracking cookie reset page. This is needed in transition phase
+ * when we migrate wikis from .wikia.com to .fandom.com domain.
+ */
+$wgEnableResetTrackingPreferencesPage = false;


### PR DESCRIPTION
Add a button to reset tracking preferences on fandom.com that is submitted from the
Privacy policy page.

/cc @Wikia/core-platform-team 