### PR TITLE
SUS-6026 | WikiFactoryLoader - make sure /proxy.php requests are handled like command line scripts

### DIFF
--- a/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
+++ b/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
@@ -48,7 +48,7 @@ class WikiFactoryLoader {
 	 * @param array $wikiFactoryDomains
 	 */
 	public function  __construct( array $server, array $environment, array $wikiFactoryDomains = [] ) {
-		global $wgDevelEnvironment, $wgExternalSharedDB, $wgWikiaBaseDomain, $wgFandomBaseDomain;
+		global $wgDevelEnvironment, $wgExternalSharedDB, $wgWikiaBaseDomain, $wgFandomBaseDomain, $wgCommandLineMode;
 
 		// initializations
 		$this->mOldServerName = false;
@@ -65,7 +65,15 @@ class WikiFactoryLoader {
 			$this->mAlwaysFromDB = 1;
 		}
 
-		$this->mCommandLine = false;
+		/**
+		 * Check if we're running in command line mode
+		 *
+		 * Set a default value of the flag below to avoid /proxy.php requests for closed wikis
+		 * to render a "this wiki is closed" web page
+		 *
+		 * @see SUS-6026
+		 */
+		$this->mCommandLine = $wgCommandLineMode;
 
 		if ( !empty( $server['HTTP_X_MW_WIKI_ID'] ) ) {
 			// SUS-5816 | a special HTTP request with wiki ID forced via request header

--- a/extensions/wikia/WikiFactory/tests/WikiFactoryLoaderIntegrationTest.php
+++ b/extensions/wikia/WikiFactory/tests/WikiFactoryLoaderIntegrationTest.php
@@ -240,6 +240,8 @@ class WikiFactoryLoaderIntegrationTest extends WikiaDatabaseTest {
 	 * @param array $server
 	 */
 	public function testRegistersClosedWikiHandlerWhenWikiIsDisabled( int $expectedCityId, array $server ) {
+		$this->mockGlobalVariable( 'wgCommandLineMode', false );
+
 		$wikiFactoryLoader = new WikiFactoryLoader( $server, [] );
 		$result = $wikiFactoryLoader->execute();
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-6026

Otherwise dump requests for closed wikis fail with "this wiki is closed" page rendered.

And we get the following error in Celery logs:

```
 response_content	     	 exceptions-WIKIA-MWException:plpolscystadionowcy/1795143: [no req]   Exception from line 1321 of /usr/wikia/slot1/current/src/includes/WebRequest.php: FauxRequest::getRequestURL() not implemented
Set $wgShowExceptionDetails = true; in LocalSettings.php to show detailed debugging information.
```