### PR TITLE
SUS-6028 | WikiFactoryLoader - do not redirect to the main domain when handling requests with X-Mw-Wiki-Id header set

### DIFF
--- a/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
+++ b/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
@@ -16,6 +16,8 @@ class WikiFactoryLoader {
 	private $parsedUrl = '';
 	/** @var string $langCode Language code given in request path, if present, without a leading slash  */
 	private $langCode = '';
+	/** @var bool $mWikiIdForced set to true if a wiki was forced via X-Mw-Wiki-Id header */
+	private $mWikiIdForced = false;
 
 	// Input variables used to identify wiki in CLI (e.g. maintenance script) context
 	private $mCityID;
@@ -76,6 +78,7 @@ class WikiFactoryLoader {
 			$this->parsedUrl = parse_url( WikiFactory::getWikiByID( $this->mCityID )->city_url );
 			$this->mServerName = $this->parsedUrl['host'];
 			$this->langCode = $this->parsedUrl['path'];
+			$this->mWikiIdForced = true;
 
 			// differ CDN caching on X-Mw-Wiki-Id request header value
 			RequestContext::getMain()->getOutput()->addVaryHeader( 'X-Mw-Wiki-Id' );
@@ -445,7 +448,7 @@ class WikiFactoryLoader {
 		$url = parse_url( $this->mCityUrl );
 
 		// check if domain from browser is different than main domain for wiki
-		$cond1 = !empty( $this->mServerName ) &&
+		$cond1 = !empty( $this->mServerName ) && $this->mWikiIdForced === false &&
 				 ( strtolower( $url['host'] ) != $this->mServerName || rtrim( $url['path'] ?? '', '/' ) !== rtrim( "/{$this->langCode}", '/' ) );
 
 		/**


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-6028

We use `X-Mw-Wiki-Id` when requesting `/proxy.php` from a single domain shared by all wikis. When this end point is requested by Celery for a wiki that uses a language path we end up in a redirects loop.

Avoid the following:

```
$ curl -v 'http://community.macbre.wikia-dev.pl/api.php?action=query&prop=revisions&meta=siteinfo&format=json' -H 'X-Mw-Wiki-Id: 5915' 2>&1 | egrep 'HTTP|Location|Surrogate|Redirect'
> GET /api.php?action=query&prop=revisions&meta=siteinfo&format=json HTTP/1.1
< HTTP/1.1 301 Moved Permanently
< X-Surrogate-Key: dev-macbre-wiki-5915 dev-macbre-wiki-5915-mediawiki
< X-Redirected-By-WF: NotPrimary
< Location: http://poznan.macbre.wikia-dev.pl/pl/pl/
```

Instead:

```
$ curl -s 'http://community.macbre.wikia-dev.pl/api.php?action=query&prop=revisions&meta=siteinfo&format=json' -H 'X-Mw-Wiki-Id: 5915'  | jq .query.general.server
"http://poznan.macbre.wikia-dev.pl"
```