### PR TITLE
SRE-111: Don't try to acquire an exclusive lock in PoolCounterWork

### DIFF
--- a/includes/PoolCounter.php
+++ b/includes/PoolCounter.php
@@ -34,9 +34,18 @@ abstract class PoolCounter {
 	const LOCK_HELD  = -5; /* Cannot acquire another lock while you have one lock held */
 
 	/**
+	 * @var bool Whether the key is a "might wait" key
+	 */
+	private $isMightWaitKey;
+	/**
+	 * @var bool Whether this process holds a "might wait" lock key
+	 */
+	private static $acquiredMightWaitKey = 0;
+
+	/**
 	 * I want to do this task and I need to do it myself.
 	 *
-	 * @return Locked/Error
+	 * @return Status
 	 */
 	abstract function acquireForMe();
 
@@ -44,7 +53,7 @@ abstract class PoolCounter {
 	 * I want to do this task, but if anyone else does it
 	 * instead, it's also fine for me. I will read its cached data.
 	 *
-	 * @return Locked/Done/Error
+	 * @return Status
 	 */
 	abstract function acquireForAnyone();
 
@@ -53,9 +62,52 @@ abstract class PoolCounter {
 	 * Lets another one grab the lock, and returns the workers
 	 * waiting on acquireForAnyone()
 	 *
-	 * @return Released/NotLocked/Error
+	 * @return Status
 	 */
 	abstract function release();
+
+	/**
+	 * Checks that the lock request is sane.
+	 * @return Status - good for sane requests fatal for insane
+	 * @since 1.25
+	 */
+	final protected function precheckAcquire() {
+		if ( $this->isMightWaitKey ) {
+			if ( self::$acquiredMightWaitKey ) {
+				/*
+				 * The poolcounter itself is quite happy to allow you to wait
+				 * on another lock while you have a lock you waited on already
+				 * but we think that it is unlikely to be a good idea.  So we
+				 * made it an error.  If you are _really_ _really_ sure it is a
+				 * good idea then feel free to implement an unsafe flag or
+				 * something.
+				 */
+				return Status::newFatal( 'poolcounter-usage-error',
+					'You may only aquire a single non-nowait lock.' );
+			}
+		} elseif ( $this->timeout !== 0 ) {
+			return Status::newFatal( 'poolcounter-usage-error',
+				'Locks starting in nowait: must have 0 timeout.' );
+		}
+
+		return Status::newGood();
+	}
+
+	/**
+	 * Update any lock tracking information when the lock is acquired
+	 * @since 1.25
+	 */
+	final protected function onAcquire() {
+		self::$acquiredMightWaitKey |= $this->isMightWaitKey;
+	}
+
+	/**
+	 * Update any lock tracking information when the lock is released
+	 * @since 1.25
+	 */
+	final protected function onRelease() {
+		self::$acquiredMightWaitKey &= !$this->isMightWaitKey;
+	}
 
 	/**
 	 *  $key: All workers with the same key share the lock.
@@ -91,6 +143,8 @@ abstract class PoolCounter {
 		$this->workers  = $conf['workers'];
 		$this->maxqueue = $conf['maxqueue'];
 		$this->timeout  = $conf['timeout'];
+
+		$this->isMightWaitKey = !preg_match( '/^nowait:/', $this->key );
 	}
 }
 
@@ -195,6 +249,10 @@ abstract class PoolCounterWork {
 		}
 
 		switch ( $status->value ) {
+			case PoolCounter::LOCK_HELD:
+				// Better to ignore nesting pool counter limits than to fail.
+				// Assume that the outer pool limiting is reasonable enough.
+				/* no break */
 			case PoolCounter::LOCKED:
 				$result = $this->doWork();
 				$this->poolCounter->release();


### PR DESCRIPTION
Port of https://github.com/wikimedia/mediawiki-extensions-PoolCounter/commit/f01dd4a4c00e9299b504f1850ce3a0cbe2b077db and https://github.com/wikimedia/mediawiki/commit/78a654eddc10df5c64cadd2f187e889f3fd4176e.

This should prevent issues in RES where apaches try to acquire too many exclusive locks and end up degrading performance.

https://wikia-inc.atlassian.net/browse/SRE-111