### PR TITLE
(PLATFORM-3746) Small fixes to sitemaps on migrated wikis

### DIFF
--- a/includes/wikia/VariablesBase.php
+++ b/includes/wikia/VariablesBase.php
@@ -1950,6 +1950,14 @@ $wgDnsBlacklistUrls = [ 'http.dnsbl.sorbs.net.' ];
 $wgDocType = '-//W3C//DTD XHTML 1.0 Transitional//EN';
 
 /**
+ * Used to set a date when migrating a wiki to a different domain to force an
+ * updated lastmod timestamp in sitemaps.
+ * @see PLATFORM-3746
+ * @var string $wgDomainChangeDate
+ */
+$wgDomainChangeDate = null;
+
+/**
  * The URL of the document type declaration.  Ignored if $wgHtml5 is true,
  * since HTML5 has no DTD, and <!DOCTYPE html> doesn't actually have a DTD part
  * to put this variable's contents in.

--- a/maintenance/wikia/HttpsMigration/migrateWikiToFandom.php
+++ b/maintenance/wikia/HttpsMigration/migrateWikiToFandom.php
@@ -91,6 +91,9 @@ class MigrateWikiToFandom extends Maintenance {
 				WikiFactory::removeVarByName( 'wgFandomComMigrationScheduled', $sourceWikiId, 'Migration to fandom.com' );
 				WikiFactory::setVarByName( 'wgFandomComMigrationDone', $sourceWikiId, true, 'Migration to fandom.com' );
 
+				// Update lastmod in sitemap timestamps
+				WikiFactory::setVarByName( 'wgDomainChangeDate', $sourceWikiId, wfTimestamp( TS_MW ), 'Migration to fandom.com' );
+
 				$this->purgeCachesForWiki( $sourceWikiId );
 			}
 


### PR DESCRIPTION
Ensure the link to the discussions sitemap uses the right base domain
for the current wiki, and ensure lastmod is updated to be either the
migration date for the wiki, or to the last edit to the article, whichever
is more recent.

I used a more generic variable name `$wgDomainChangeDate` since this
may be useful for all domain changes in the future.

/cc @Wikia/core-platform-team 