### PR TITLE
(SEO-674) Redirect to the first category page when old params are used

### DIFF
--- a/extensions/wikia/CategoryPage3/CategoryPage3.setup.php
+++ b/extensions/wikia/CategoryPage3/CategoryPage3.setup.php
@@ -20,6 +20,7 @@ $wgAutoloadClasses['CategoryPageWithLayoutSelector'] = __DIR__ . '/CategoryPageW
 
 $wgHooks['AfterCategoriesUpdate'][] = 'CategoryPage3Hooks::onAfterCategoriesUpdate';
 $wgHooks['ArticleFromTitle'][] = 'CategoryPage3Hooks::onArticleFromTitle';
+$wgHooks['BeforeInitialize'][] = 'CategoryPage3Hooks::onBeforeInitialize';
 
 $wgResourceModules['ext.wikia.CategoryPage3.scripts'] = [
 	'localBasePath' => __DIR__,


### PR DESCRIPTION
Redirect to the first category page when old pagination query params are used.

/cc @rogatty 