### PR TITLE
SUS-5873 use array_replace to preserve proper curl options

### DIFF
--- a/lib/Wikia/src/Tasks/Tasks/ParsoidCacheUpdateTask.php
+++ b/lib/Wikia/src/Tasks/Tasks/ParsoidCacheUpdateTask.php
@@ -156,6 +156,6 @@ class ParsoidCacheUpdateTask extends BaseTask {
 			$proxyOptions[ CURLOPT_PROXY ] = $wgVisualEditorParsoidHTTPProxy;
 		}
 		
-		return array_merge( $defaultOptions, $proxyOptions, $customOptions );
+		return array_replace( $defaultOptions, $proxyOptions, $customOptions );
 	}
 }


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-5873

`ParsoidCacheUpdateTask` used incorrect CURL options due to `array_merge` changing key values. `array_replace` will preserve keys while merging arrays.