### PR TITLE
(PLATFORM-3765) Use full URLs in in content links on language wikis

### DIFF
--- a/includes/Title.php
+++ b/includes/Title.php
@@ -1542,13 +1542,20 @@ class Title {
 	 * @return String the URL
 	 */
 	public function getLinkURL( $query = '', $query2 = false ) {
+		global $wgServer;
 		wfProfileIn( __METHOD__ );
 		if ( $this->isExternal() ) {
 			$ret = $this->getFullURL( $query, $query2 );
 		} elseif ( $this->getPrefixedText() === '' && $this->getFragment() !== '' ) {
 			$ret = $this->getFragmentForURL();
 		} else {
-			$ret = $this->getLocalURL( $query, $query2 ) . $this->getFragmentForURL();
+			// Wikia change begin -- always use full URLs for multiple subdomain wikis (PLATFORM-3765)
+			if ( !wfHttpsAllowedForURL( $wgServer ) ) {
+				$ret = $this->getFullURL( $query, $query2 );
+			} else {
+				$ret = $this->getLocalURL( $query, $query2 ) . $this->getFragmentForURL();
+			}
+			// Wikia change end
 		}
 		wfProfileOut( __METHOD__ );
 		return $ret;

--- a/includes/wikia/Extensions.php
+++ b/includes/wikia/Extensions.php
@@ -94,6 +94,13 @@ if ( ! empty( $wgEnableWikisApi ) ) {
 	F::app()->registerApiController( 'WikisApiController', "{$IP}/includes/wikia/api/WikisApiController.class.php" );
 }
 
+// During migration drop parser expiry on non-English wikis to 24 hours (PLATFORM-3765)
+if ( !wfHttpsAllowedForURL( $wgServer ) ||
+	( wfHttpsEnabledForURL( $wgServer ) && $wgLanguageCode !== 'en' )
+) {
+	$wgParserCacheExpireTime = 24 * 3600;
+}
+
 /*
  * Code for http://lyrics.wikia.com/
  */


### PR DESCRIPTION
Use full URLs in in content links on language wikis so that the parser
cache has valid URLs when migrating those wikis.

/cc @Wikia/core-platform-team 