### PR TITLE
Docker | add shell helper scripts

### DIFF
--- a/docker/prod/README.md
+++ b/docker/prod/README.md
@@ -4,3 +4,7 @@ To test MW on Kubernetes you can:
 - add X-Mw-Kubernetes header to your test request (e.g. via cURL or browser extension)
 
 cURL example: `curl -svo/dev/null -H "X-Mw-Kubernetes: 1" -L http://de.god-of-war.wikia.com/wiki/God_of_War_Wiki?foo=bar`
+
+## Production shell access
+
+Use `prod_shell.sh` helper script.

--- a/docker/prod/prod_shell.sh
+++ b/docker/prod/prod_shell.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+CONTAINER=`kubectl --context kube-sjc-prod -n prod get pods --selector=app=mediawiki-prod  -o jsonpath='{.items[0].metadata.name}'`
+
+echo
+echo "Entering bash shell on ${CONTAINER} ..."
+echo "To enter MediaWiki console type: SERVER_ID=177 php maintenance/eval.php -d 5"
+echo
+
+kubectl --context kube-sjc-prod -n prod exec --container php -it $CONTAINER bash

--- a/docker/sandbox/README.md
+++ b/docker/sandbox/README.md
@@ -3,15 +3,12 @@
 Use Jenkins Pipeline. Read more on https://wikia-inc.atlassian.net/wiki/spaces/SUS/pages/378994735/Jenkins+Pipeline+-+deploy+mediawiki+to+sandbox
 
 
-## Console access to Kubernetes container
+## Sandbox shell access
 
-```sh
-$ kubectl --context kube-sjc-prod -n prod get pods | grep mediawiki-sandbox
+Use `sandbox_shell.sh` helper script:
+
 ```
-
-```sh
-$ kubectl --context kube-sjc-prod -n prod exec --container php -it mediawiki-sandbox-xxxxxx-xxxxx bash
-nobody@mediawiki-sandbox-xxxxxx-xxxxx:/usr/wikia/slot1/current/src$
+$ ./sandbox_shell.sh sandbox-sus2
 ```
 
 ## Logs

--- a/docker/sandbox/sandbox_shell.sh
+++ b/docker/sandbox/sandbox_shell.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+SANDBOX=$1
+CONTAINER=`kubectl --context kube-sjc-prod -n prod get pods --selector=app=mediawiki-$1  -o jsonpath='{.items[0].metadata.name}'`
+
+echo
+echo "Entering bash shell on ${CONTAINER} ..."
+echo "To enter MediaWiki console type: SERVER_ID=177 php maintenance/eval.php -d 5"
+echo
+
+kubectl --context kube-sjc-prod -n prod exec --container php -it $CONTAINER bash


### PR DESCRIPTION
They ease access to bash shell in PHP container for sandbox and production MediaWiki Kubernetes pods.

```
macbre@dell:~/Wikia/git/app/docker/prod$ ./prod_shell.sh 

Entering bash shell on mediawiki-prod-8778595b4-nzzwp ...
To enter MediaWiki console type: SERVER_ID=177 php maintenance/eval.php -d 5

nobody@mediawiki-prod-8778595b4-nzzwp:/usr/wikia/slot1/current/src$ SERVER_ID=177 php maintenance/eval.php -d 5
> echo $wgStyleVersion
7480017480013
```