### PR TITLE
(PLATFORM-3765) Limit number of wikis with lower parser cache expiry

### DIFF
--- a/includes/wikia/Extensions.php
+++ b/includes/wikia/Extensions.php
@@ -95,7 +95,7 @@ if ( ! empty( $wgEnableWikisApi ) ) {
 }
 
 // During migration drop parser expiry on non-English wikis to 24 hours (PLATFORM-3765)
-if ( !wfHttpsAllowedForURL( $wgServer ) ||
+if ( ( !wfHttpsAllowedForURL( $wgServer ) && !empty( $wgFandomComMigrationScheduled ) ) ||
 	( wfHttpsEnabledForURL( $wgServer ) && $wgLanguageCode !== 'en' )
 ) {
 	$wgParserCacheExpireTime = 24 * 3600;


### PR DESCRIPTION
Limit the parser cache expiry drop to wikis scheduled for migration.