### PR TITLE
SUS-6051 | because of The Complex Way wiki domain is passed down to nginx we need to use /redirect-canonical.php to handle these redirects

### DIFF
--- a/docker/base/base.inc
+++ b/docker/base/base.inc
@@ -14,8 +14,10 @@ rewrite ^/api/(?:v1|test)/?$ /wikia.php?controller=ApiDocs&method=index break;
 rewrite ^/api/(?:v1|test)/([^/]*)/([^/]*) /wikia.php?controller=$1Api&method=get$2 break;
 
 # SUS-5798 / SUS-5824: alternative article paths - /wiki/index.php and /w
-rewrite "^/([a-z]{2,3}(-[a-z-]{2,12})?/)?w/(.*)$" $scheme://$host/$1wiki/$3 permanent;
-rewrite "^/([a-z]{2,3}(-[a-z-]{2,12})?/)?wiki/index.php/(.*)$" $scheme://$host/$1wiki/$3 permanent;
+# SUS-6051 | because of The Complex Way wiki domain is passed down to nginx
+#            we need to use /redirect-canonical.php to handle these redirects
+rewrite "^/([a-z]{2,3}(-[a-z-]{2,12})?/)?w/(.*)$" /redirect-canonical.php break;
+rewrite "^/([a-z]{2,3}(-[a-z-]{2,12})?/)?wiki/index.php/(.*)$" /redirect-canonical.php break;
 
 # rewrites for language wiki
 rewrite "^/[a-z]{2,3}(?:-[a-z-]{2,12})?/(sitemap.+\.xml[.gz]*)$" /index.php?title=Special:Sitemap/$1&uselang=en break;

--- a/docker/prod/site.conf.template
+++ b/docker/prod/site.conf.template
@@ -16,6 +16,7 @@ server {
         # otherwise we end up with redirects to port 8080
         fastcgi_param SERVER_PORT 80;
         # use the original request host so MW can identify the specific wiki
+        # see /cookbooks/varnish4/templates/default/control_stage_deliver.vcl.erb in chef-repo
         fastcgi_param HTTP_HOST $http_x_original_host;
         fastcgi_param SERVER_NAME $http_x_original_host;
     }

--- a/docker/sandbox/site.conf
+++ b/docker/sandbox/site.conf
@@ -16,6 +16,7 @@ server {
         # otherwise we end up with redirects to port 8080
         fastcgi_param SERVER_PORT 80;
         # use the original request host so MW can identify the specific wiki
+        # see /cookbooks/varnish4/templates/default/control_stage_deliver.vcl.erb in chef-repo
         fastcgi_param HTTP_HOST $http_x_original_host;
         fastcgi_param SERVER_NAME $http_x_original_host;
     }

--- a/redirect-canonical.php
+++ b/redirect-canonical.php
@@ -29,6 +29,15 @@ require_once( dirname( __FILE__ ) . '/includes/WebStart.php' );
 function guessTitle( $path ) {
 	$path = trim( rawurldecode( $path ), '/ _' );
 
+	// SUS-6051 | /w/Foo and /wiki/index.php/Foo URLs need to be handled by PHP logic
+	// in order to use a proper wiki domain on sandboxes
+	if ( startsWith( $path, 'w/' ) ) {
+		$path = substr( $path, 2 );
+	}
+	if ( startsWith( $path, 'wiki/index.php/' ) ) {
+		$path = substr( $path, 15 );
+	}
+
 	// Hack to better recover Mercury modular home pages URLs
 	// (they have double-encoded URLs for some reason)
 	if ( startsWith( $path, 'main/' ) ) {


### PR DESCRIPTION
### The problem

Because of the way we [handle sandbox requests at the HTTP border level](https://github.com/Wikia/chef-repo/blob/bec1215779246a831dca4d1a04ca12e19d5f71b4/cookbooks/varnish4/templates/default/control_stage_deliver.vcl.erb#L52-L67) it's not trivial to build a proper redirect path from HTTP headers in nginx.

```
$ curl -v 'http://pl.gta.wikia.com/w/S:FilePath/Pt.png' -x border.service.sjc.consul:80 -H 'X-Mw-Kubernetes: 1'
*   Trying 10.8.66.62...
* Connected to border.service.sjc.consul (10.8.66.62) port 80 (#0)
> GET http://pl.gta.wikia.com/w/S:FilePath/Pt.png HTTP/1.1
> Host: pl.gta.wikia.com
> User-Agent: curl/7.47.0
> Accept: */*
> Proxy-Connection: Keep-Alive
> X-Mw-Kubernetes: 1
> 
< HTTP/1.1 301 Moved Permanently
< Content-Length: 185
< Content-Type: text/html
< Date: Wed, 17 Oct 2018 09:26:29 GMT
< Location: http://kubernetes.wikia.com/wiki/S:FilePath/Pt.png
< Server: nginx/1.14.0
< Connection: keep-alive
```

### Solution

Handle rare `/w/Foo` and `/wiki/index.php/Foo` requests via `/redirect-canonical.php` that starts MediaWiki stack and has the full knowledge about the domain we want to use (including sandbox part of the domain).

#### Local env

```
$ curl -v 'http://muppet.dev.wikia-local.com/wiki/index.php/Foo' 2>&1 | egrep 'Location|Redirect'
< X-Redirected-By: redirect-canonical.php
< Location: http://muppet.dev.wikia-local.com/wiki/Foo

$ curl -v 'http://muppet.dev.wikia-local.com/w/Foo' 2>&1 | egrep 'Location|Redirect'
< X-Redirected-By: redirect-canonical.php
< Location: http://muppet.dev.wikia-local.com/wiki/Foo
```

#### Sandbox

Before the fix:

```
$ curl -v 'http://muppet.sandbox-qa07.wikia.com/wiki/index.php/Foo' 2>&1 | egrep 'Location|Redirect'
< Location: http://sandbox-qa07.wikia.com/wiki/Foo
```

After the fix:

```
$ curl -v 'http://muppet.sandbox-qa07.wikia.com/wiki/index.php/Foo' 2>&1 | egrep 'Location|Redirect'
< Location: http://muppet.sandbox-qa07.wikia.com/wiki/Foo
< X-Redirected-By: redirect-canonical.php

-- with HTTPS url

$ curl -v 'https://muppet.sandbox-qa07.wikia.com/wiki/index.php/Foo' 2>&1 | egrep 'Location|Redirect'
< Location: https://muppet.sandbox-qa07.wikia.com/wiki/Foo
< X-Redirected-By: redirect-canonical.php
```