### PR TITLE
SRE-116 | Redo ProtectSite with a database backend

### DIFF
--- a/extensions/wikia/ProtectSiteII/ProtectSite.i18n.php
+++ b/extensions/wikia/ProtectSiteII/ProtectSite.i18n.php
@@ -1,0 +1,14 @@
+<?php
+
+$messages = array();
+
+$messages['en'] = array(
+	'protectsite-label-prevent-users' => 'Block registered users from performing the selected actions',
+	'protectsite-label-prevent-edit' => 'Prevent page edits',
+	'protectsite-label-prevent-create' => 'Prevent page creations',
+	'protectsite-label-prevent-move' => 'Prevent page moves',
+	'protectsite-label-prevent-upload' => 'Prevent media uploads',
+	'protectsite-legend' => 'Site protection settings',
+	'protectsite-save' => 'Save settings',
+	'protectsite-update-success' => 'Settings applied successfully',
+);

--- a/extensions/wikia/ProtectSiteII/ProtectSite.i18n.php
+++ b/extensions/wikia/ProtectSiteII/ProtectSite.i18n.php
@@ -3,11 +3,14 @@
 $messages = array();
 
 $messages['en'] = array(
-	'protectsite-label-prevent-users' => 'Block registered users from performing the selected actions',
+	'protectsite-label-expiry' => 'Expires in',
+	'protectsite-label-prevent-anons-only' => 'Block only anonymous users from performing the selected actions',
+	'protectsite-label-prevent-users' => 'Block both registered and anonymous users from performing the selected actions',
 	'protectsite-label-prevent-edit' => 'Prevent page edits',
 	'protectsite-label-prevent-create' => 'Prevent page creations',
 	'protectsite-label-prevent-move' => 'Prevent page moves',
 	'protectsite-label-prevent-upload' => 'Prevent media uploads',
+	'protectsite-label-reason' => 'Reason',
 	'protectsite-legend' => 'Site protection settings',
 	'protectsite-save' => 'Save settings',
 	'protectsite-update-success' => 'Settings applied successfully',

--- a/extensions/wikia/ProtectSiteII/ProtectSite.i18n.php
+++ b/extensions/wikia/ProtectSiteII/ProtectSite.i18n.php
@@ -3,6 +3,7 @@
 $messages = array();
 
 $messages['en'] = array(
+	'action-protectsite' => 'temporarily block various site modifications',
 	'protectsite-label-expiry' => 'Expires in',
 	'protectsite-label-prevent-anons-only' => 'Block only anonymous users from performing these actions',
 	'protectsite-label-prevent-edit' => 'Prevent page edits',
@@ -14,4 +15,6 @@ $messages['en'] = array(
 	'protectsite-legend' => 'Site protection settings',
 	'protectsite-save' => 'Save settings',
 	'protectsite-update-success' => 'Settings applied successfully',
+	'right-protectsite' => 'Limit actions that can be preformed for some groups for a limited time',
+	'right-protectsite-exempt' => 'Exempt from site-wide action restrictions',
 );

--- a/extensions/wikia/ProtectSiteII/ProtectSite.i18n.php
+++ b/extensions/wikia/ProtectSiteII/ProtectSite.i18n.php
@@ -11,6 +11,7 @@ $messages['en'] = array(
 	'protectsite-label-prevent-move' => 'Prevent page moves',
 	'protectsite-label-prevent-upload' => 'Prevent media uploads',
 	'protectsite-label-reason' => 'Reason',
+	'protectsite-label-suppress-expiry' => 'Suppress expiry time from logs',
 	'protectsite-legend' => 'Site protection settings',
 	'protectsite-save' => 'Save settings',
 	'protectsite-update-success' => 'Settings applied successfully',

--- a/extensions/wikia/ProtectSiteII/ProtectSite.i18n.php
+++ b/extensions/wikia/ProtectSiteII/ProtectSite.i18n.php
@@ -4,8 +4,6 @@ $messages = array();
 
 $messages['en'] = array(
 	'protectsite-label-expiry' => 'Expires in',
-	'protectsite-label-prevent-anons-only' => 'Block only anonymous users from performing the selected actions',
-	'protectsite-label-prevent-users' => 'Block both registered and anonymous users from performing the selected actions',
 	'protectsite-label-prevent-edit' => 'Prevent page edits',
 	'protectsite-label-prevent-create' => 'Prevent page creations',
 	'protectsite-label-prevent-move' => 'Prevent page moves',

--- a/extensions/wikia/ProtectSiteII/ProtectSite.i18n.php
+++ b/extensions/wikia/ProtectSiteII/ProtectSite.i18n.php
@@ -4,6 +4,7 @@ $messages = array();
 
 $messages['en'] = array(
 	'protectsite-label-expiry' => 'Expires in',
+	'protectsite-label-prevent-anons-only' => 'Block only anonymous users from performing these actions',
 	'protectsite-label-prevent-edit' => 'Prevent page edits',
 	'protectsite-label-prevent-create' => 'Prevent page creations',
 	'protectsite-label-prevent-move' => 'Prevent page moves',

--- a/extensions/wikia/ProtectSiteII/ProtectSite.php
+++ b/extensions/wikia/ProtectSiteII/ProtectSite.php
@@ -1,0 +1,8 @@
+<?php
+
+$wgAutoloadClasses['ProtectSiteHooks'] = __DIR__ . '/ProtectSiteHooks.php';
+$wgAutoloadClasses['ProtectSiteModel'] = __DIR__ . '/ProtectSiteModel.php';
+$wgAutoloadClasses['ProtectSiteSpecialController'] = __DIR__ . '/ProtectSiteSpecialController.php';
+
+$wgSpecialPages['ProtectSite'] = 'ProtectSiteSpecialController';
+$wgSpecialPageGroups['ProtectSite'] = 'wikia';

--- a/extensions/wikia/ProtectSiteII/ProtectSite.php
+++ b/extensions/wikia/ProtectSiteII/ProtectSite.php
@@ -6,3 +6,5 @@ $wgAutoloadClasses['ProtectSiteSpecialController'] = __DIR__ . '/ProtectSiteSpec
 
 $wgSpecialPages['ProtectSite'] = 'ProtectSiteSpecialController';
 $wgSpecialPageGroups['ProtectSite'] = 'wikia';
+
+$wgHooks['getUserPermissionsErrorsExpensive'][] = '\ProtectSiteHooks::onGetUserPermissionsErrorsExpensive';

--- a/extensions/wikia/ProtectSiteII/ProtectSiteHooks.php
+++ b/extensions/wikia/ProtectSiteII/ProtectSiteHooks.php
@@ -13,12 +13,17 @@ class ProtectSiteHooks {
 
 		$settings = self::getModel()->getProtectionSettings();
 
-		if ( ProtectSiteModel::isActionFlagSet( $settings, $action ) && !$user->isAllowed( 'protectsite-exempt' ) ) {
+		if ( ProtectSiteModel::isActionFlagSet( $settings, $action ) && !self::isUserExempt( $settings, $user ) ) {
 			$result = false;
 			return false;
 		}
 
 		return true;
+	}
+
+	private static function isUserExempt( int $settings, User $user ): bool {
+		return $user->isAllowed( 'protectsite-exempt' ) ||
+			   ( $user->isLoggedIn() && ProtectSiteModel::isPreventAnonsOnlyFlagSet( $settings ) );
 	}
 
 	private static function getModel(): ProtectSiteModel {

--- a/extensions/wikia/ProtectSiteII/ProtectSiteHooks.php
+++ b/extensions/wikia/ProtectSiteII/ProtectSiteHooks.php
@@ -6,12 +6,13 @@ class ProtectSiteHooks {
 	private static $model;
 
 	public static function onGetUserPermissionsErrorsExpensive( Title $title, User $user, string $action, &$result ): bool {
+		global $wgCityId;
 
 		if ( !isset( ProtectSiteModel::PROTECT_ACTIONS[$action] ) ) {
 			return true;
 		}
 
-		$settings = self::getModel()->getProtectionSettings();
+		$settings = self::getModel()->getProtectionSettings( $wgCityId );
 
 		if ( ProtectSiteModel::isActionFlagSet( $settings, $action ) && !self::isUserExempt( $settings, $user ) ) {
 			$result = false;

--- a/extensions/wikia/ProtectSiteII/ProtectSiteHooks.php
+++ b/extensions/wikia/ProtectSiteII/ProtectSiteHooks.php
@@ -1,0 +1,35 @@
+<?php
+
+class ProtectSiteHooks {
+
+	/** @var ProtectSiteModel $model */
+	private static $model;
+
+	public static function onGetUserPermissionsErrorsExpensive( Title $title, User $user, string $action, &$result ): bool {
+
+		if ( !isset( ProtectSiteModel::PROTECT_ACTIONS[$action] ) ) {
+			return true;
+		}
+
+		$settings = self::getModel()->getProtectionSettings();
+
+		if ( ProtectSiteModel::isActionFlagSet( $settings, $action ) && self::isUserPrevented( $user, $settings ) ) {
+			$result = false;
+			return false;
+		}
+
+		return true;
+	}
+
+	private static function isUserPrevented( User $user, int $settings ): bool {
+		return $user->isAnon() || ( ProtectSiteModel::isPreventUsersFlagSet( $settings ) && !$user->isAllowed( 'protectsite-exempt' ) );
+	}
+
+	private static function getModel(): ProtectSiteModel {
+		if ( !self::$model ) {
+			self::$model = new ProtectSiteModel();
+		}
+
+		return self::$model;
+	}
+}

--- a/extensions/wikia/ProtectSiteII/ProtectSiteHooks.php
+++ b/extensions/wikia/ProtectSiteII/ProtectSiteHooks.php
@@ -13,16 +13,12 @@ class ProtectSiteHooks {
 
 		$settings = self::getModel()->getProtectionSettings();
 
-		if ( ProtectSiteModel::isActionFlagSet( $settings, $action ) && self::isUserPrevented( $user, $settings ) ) {
+		if ( ProtectSiteModel::isActionFlagSet( $settings, $action ) && !$user->isAllowed( 'protectsite-exempt' ) ) {
 			$result = false;
 			return false;
 		}
 
 		return true;
-	}
-
-	private static function isUserPrevented( User $user, int $settings ): bool {
-		return $user->isAnon() || ( ProtectSiteModel::isPreventUsersFlagSet( $settings ) && !$user->isAllowed( 'protectsite-exempt' ) );
 	}
 
 	private static function getModel(): ProtectSiteModel {

--- a/extensions/wikia/ProtectSiteII/ProtectSiteModel.php
+++ b/extensions/wikia/ProtectSiteII/ProtectSiteModel.php
@@ -9,8 +9,6 @@ class ProtectSiteModel extends WikiaModel {
 		'upload' => 8,
 	];
 
-	const PREVENT_USERS_FLAG = 512;
-
 	/** @var int $protection */
 	private $protection;
 
@@ -74,9 +72,5 @@ class ProtectSiteModel extends WikiaModel {
 
 	public static function isActionFlagSet( int $bitfield, string $action ): bool {
 		return ( $bitfield & self::PROTECT_ACTIONS[$action] ) > 0;
-	}
-
-	public static function isPreventUsersFlagSet( int $bitfield ): bool {
-		return ( $bitfield & self::PREVENT_USERS_FLAG ) > 0;
 	}
 }

--- a/extensions/wikia/ProtectSiteII/ProtectSiteModel.php
+++ b/extensions/wikia/ProtectSiteII/ProtectSiteModel.php
@@ -1,0 +1,78 @@
+<?php
+
+class ProtectSiteModel extends WikiaModel {
+
+	const PROTECT_ACTIONS = [
+		'edit' => 1,
+		'create' => 2,
+		'move' => 4,
+		'upload' => 8,
+	];
+
+	const PREVENT_USERS_FLAG = 512;
+
+	/** @var int $protection */
+	private $protection;
+
+	public function getProtectionSettings(): int {
+		if ( $this->protection === null ) {
+			global $wgCityId;
+
+			$dbr = $this->getSharedDB();
+
+			$safeNow = $dbr->addQuotes( $dbr->timestamp() );
+
+			$result = $dbr->selectField(
+				'protectsite',
+				'protection_bitfield',
+				[ 'wiki_id' => $wgCityId, "protection_expiry < $safeNow" ],
+				__METHOD__
+			);
+
+			$this->protection = intval( $result );
+		}
+
+		return $this->protection;
+	}
+
+	public function updateProtectionSettings( int $settings, int $expiry ) {
+		global $wgCityId;
+
+		$dbw = $this->getSharedDB( DB_MASTER );
+
+		$dbExpiry = $dbw->timestamp( $expiry );
+
+		$this->getSharedDB( DB_MASTER )->upsert(
+			'protectsite',
+			[
+				'wiki_id' => $wgCityId,
+				'protection_bitfield' => $settings,
+				'protection_expiry' => $dbExpiry,
+			],
+			[],
+			[
+				'protection_bitfield = VALUES(protection_bitfield)',
+				'protection_expiry = VALUES(protection_expiry)',
+			],
+			__METHOD__
+		);
+	}
+
+	public function unprotect() {
+		global $wgCityId;
+
+		$this->getSharedDB( DB_MASTER )->delete( 'protectsite', [ 'wiki_id' => $wgCityId ], __METHOD__ );
+	}
+
+	public function deleteExpiredSettings() {
+		$this->getSharedDB( DB_MASTER )->delete( 'protectsite', [ 'protection_expiry < NOW()' ], __METHOD__ );
+	}
+
+	public static function isActionFlagSet( int $bitfield, string $action ): bool {
+		return ( $bitfield & self::PROTECT_ACTIONS[$action] ) > 0;
+	}
+
+	public static function isPreventUsersFlagSet( int $bitfield ): bool {
+		return ( $bitfield & self::PREVENT_USERS_FLAG ) > 0;
+	}
+}

--- a/extensions/wikia/ProtectSiteII/ProtectSiteModel.php
+++ b/extensions/wikia/ProtectSiteII/ProtectSiteModel.php
@@ -68,6 +68,10 @@ class ProtectSiteModel extends WikiaModel {
 		$this->getSharedDB( DB_MASTER )->delete( 'protectsite', [ 'protection_expiry < NOW()' ], __METHOD__ );
 	}
 
+	public static function getValidActions(): array {
+		return array_keys( self::PROTECT_ACTIONS );
+	}
+
 	public static function isActionFlagSet( int $bitfield, string $action ): bool {
 		return ( $bitfield & self::PROTECT_ACTIONS[$action] ) > 0;
 	}

--- a/extensions/wikia/ProtectSiteII/ProtectSiteSpecialController.php
+++ b/extensions/wikia/ProtectSiteII/ProtectSiteSpecialController.php
@@ -42,6 +42,12 @@ class ProtectSiteSpecialController extends WikiaSpecialPageController {
 		];
 
 		$inputs[] = [
+			'type' => 'text',
+			'label' => $this->msg( 'protectsite-label-reason' )->escaped(),
+			'name' => 'reason',
+		];
+
+		$inputs[] = [
 			'type' => 'checkbox',
 			'label' => $this->msg( "protectsite-label-prevent-anons-only" )->escaped(),
 			'name' => 'prevent_anons_only',
@@ -52,12 +58,6 @@ class ProtectSiteSpecialController extends WikiaSpecialPageController {
 			'type' => 'checkbox',
 			'label' => $this->msg( "protectsite-label-suppress-expiry" )->escaped(),
 			'name' => 'suppress_expiry',
-		];
-
-		$inputs[] = [
-			'type' => 'text',
-			'label' => $this->msg( 'protectsite-label-reason' )->escaped(),
-			'name' => 'reason',
 		];
 
 		$inputs[] = [

--- a/extensions/wikia/ProtectSiteII/ProtectSiteSpecialController.php
+++ b/extensions/wikia/ProtectSiteII/ProtectSiteSpecialController.php
@@ -22,14 +22,12 @@ class ProtectSiteSpecialController extends WikiaSpecialPageController {
 			[
 				'type' => 'checkbox',
 				'label' => $this->msg( 'protectsite-label-prevent-users' )->escaped(),
-				'attributes' => [
-					'name' => 'prevent_users',
-					'checked' => ProtectSiteModel::isPreventUsersFlagSet( $active ) ?: null
-				],
+				'name' => 'prevent_users',
+				'checked' => ProtectSiteModel::isPreventUsersFlagSet( $active ) ?: null,
 			]
 		];
 
-		foreach ( ProtectSiteModel::PROTECT_ACTIONS as $action ) {
+		foreach ( ProtectSiteModel::getValidActions() as $action ) {
 			// For grepping - possible message keys used here:
 			// protectsite-label-prevent-edit
 			// protectsite-label-prevent-create
@@ -38,10 +36,8 @@ class ProtectSiteSpecialController extends WikiaSpecialPageController {
 			$inputs[] = [
 				'type' => 'checkbox',
 				'label' => $this->msg( "protectsite-label-prevent-$action" )->escaped(),
-				'attributes' => [
-					'name' => $action,
-					'checked' => ProtectSiteModel::isActionFlagSet( $active, $action ) ?: null,
-				],
+				'name' => $action,
+				'checked' => ProtectSiteModel::isActionFlagSet( $active, $action ) ?: null,
 			];
 		}
 
@@ -77,7 +73,7 @@ class ProtectSiteSpecialController extends WikiaSpecialPageController {
 
 		$protection = 0;
 
-		foreach ( array_keys( ProtectSiteModel::PROTECT_ACTIONS ) as $action ) {
+		foreach ( ProtectSiteModel::getValidActions() as $action ) {
 			if ( $this->request->getCheck( $action ) ) {
 				$protection |= ProtectSiteModel::PROTECT_ACTIONS[$action];
 			}

--- a/extensions/wikia/ProtectSiteII/ProtectSiteSpecialController.php
+++ b/extensions/wikia/ProtectSiteII/ProtectSiteSpecialController.php
@@ -2,6 +2,11 @@
 
 class ProtectSiteSpecialController extends WikiaSpecialPageController {
 
+	const PROTECTION_EXPIRY_VALUES = [
+		'1 hour', '2 hours', '4 hours', '8 hours', '12 hours',
+	];
+	const INVALID_EXPIRY = 'Invalid expiry time';
+
 	/** @var ProtectSiteModel $model */
 	private $model;
 
@@ -34,11 +39,20 @@ class ProtectSiteSpecialController extends WikiaSpecialPageController {
 			];
 		}
 
+		$times = [];
+
+		foreach ( self::PROTECTION_EXPIRY_VALUES as $value ) {
+			$times[] = [
+				'value' => $value,
+			];
+		}
+
 		$inputs[] = [
-			'type' => 'text',
+			'type' => 'select',
 			'label' => $this->msg( 'protectsite-label-expiry' )->escaped(),
 			'name' => 'expiry',
 			'value' => '1 hour',
+			'options' => $times,
 		];
 
 		$inputs[] = [
@@ -124,6 +138,11 @@ class ProtectSiteSpecialController extends WikiaSpecialPageController {
 
 		if ( $protection ^ ProtectSiteModel::PREVENT_ANONS_ONLY ) {
 			$expiry = $request->getVal( 'expiry', '1 hour' );
+
+			if ( !in_array( $expiry, self::PROTECTION_EXPIRY_VALUES ) ) {
+				throw new BadRequestException( self::INVALID_EXPIRY );
+			}
+
 			$expiresAt = strtotime( "+$expiry" );
 
 			$model->updateProtectionSettings( $this->wg->CityId, $protection, $expiresAt );

--- a/extensions/wikia/ProtectSiteII/ProtectSiteSpecialController.php
+++ b/extensions/wikia/ProtectSiteII/ProtectSiteSpecialController.php
@@ -51,16 +51,16 @@ class ProtectSiteSpecialController extends WikiaSpecialPageController {
 		}
 
 		$inputs[] = [
-			'type' => 'checkbox',
-			'label' => $this->msg( "protectsite-label-prevent-$action" )->escaped(),
-			'name' => 'suppress_expiry',
-		];
-
-		$inputs[] = [
 			'type' => 'text',
 			'label' => $this->msg( 'protectsite-label-expiry' )->escaped(),
 			'name' => 'expiry',
 			'value' => '1 hour',
+		];
+
+		$inputs[] = [
+			'type' => 'checkbox',
+			'label' => $this->msg( "protectsite-label-suppress-expiry" )->escaped(),
+			'name' => 'suppress_expiry',
 		];
 
 		$inputs[] = [

--- a/extensions/wikia/ProtectSiteII/ProtectSiteSpecialController.php
+++ b/extensions/wikia/ProtectSiteII/ProtectSiteSpecialController.php
@@ -136,7 +136,7 @@ class ProtectSiteSpecialController extends WikiaSpecialPageController {
 		$title = Title::makeTitle( NS_SPECIAL, 'Allpages' );
 		$log = new LogPage( 'protect' );
 
-		if ( $protection ^ ProtectSiteModel::PREVENT_ANONS_ONLY ) {
+		if ( $protection && $protection ^ ProtectSiteModel::PREVENT_ANONS_ONLY ) {
 			$expiry = $request->getVal( 'expiry', '1 hour' );
 
 			if ( !in_array( $expiry, self::PROTECTION_EXPIRY_VALUES ) ) {

--- a/extensions/wikia/ProtectSiteII/ProtectSiteSpecialController.php
+++ b/extensions/wikia/ProtectSiteII/ProtectSiteSpecialController.php
@@ -1,0 +1,105 @@
+<?php
+
+class ProtectSiteSpecialController extends WikiaSpecialPageController {
+
+	/** @var ProtectSiteModel $model */
+	private $model;
+
+	public function __construct() {
+		parent::__construct( 'ProtectSite', 'protectsite' );
+		$this->model = new ProtectSiteModel();
+	}
+
+	public function index() {
+
+		$this->setHeaders();
+		$this->checkPermissions();
+		$this->checkIfUserIsBlocked();
+
+		$active = $this->model->getProtectionSettings();
+
+		$inputs = [
+			[
+				'type' => 'checkbox',
+				'label' => $this->msg( 'protectsite-label-prevent-users' )->escaped(),
+				'attributes' => [
+					'name' => 'prevent_users',
+					'checked' => ProtectSiteModel::isPreventUsersFlagSet( $active ) ?: null
+				],
+			]
+		];
+
+		foreach ( ProtectSiteModel::PROTECT_ACTIONS as $action ) {
+			// For grepping - possible message keys used here:
+			// protectsite-label-prevent-edit
+			// protectsite-label-prevent-create
+			// protectsite-label-prevent-move
+			// protectsite-label-prevent-upload
+			$inputs[] = [
+				'type' => 'checkbox',
+				'label' => $this->msg( "protectsite-label-prevent-$action" )->escaped(),
+				'attributes' => [
+					'name' => $action,
+					'checked' => ProtectSiteModel::isActionFlagSet( $active, $action ) ?: null,
+				],
+			];
+		}
+
+		$inputs[] = [
+			'type' => 'hidden',
+			'name' => 'token',
+			'value' => $this->getUser()->getEditToken(),
+		];
+
+		$form = [
+			'method' => 'POST',
+			'action' => self::getFullUrl( 'saveProtectionSettings' ),
+			'legend' => $this->msg( 'protectsite-legend' )->escaped(),
+			'inputs' => $inputs,
+			'submits' => [
+				'attributes' => [
+					'value' => $this->msg( 'protectsite-save' )->escaped(),
+				],
+			],
+		];
+
+		$htmlForm = $this->app->renderView( WikiaStyleGuideFormController::class, 'index', [
+			'form' => $form
+		] );
+
+		$this->response->setBody( $htmlForm );
+	}
+
+	public function saveProtectionSettings() {
+		$this->response->setFormat( WikiaResponse::FORMAT_JSON );
+
+		$this->checkWriteRequest();
+
+		$protection = 0;
+
+		foreach ( array_keys( ProtectSiteModel::PROTECT_ACTIONS ) as $action ) {
+			if ( $this->request->getCheck( $action ) ) {
+				$protection |= ProtectSiteModel::PROTECT_ACTIONS[$action];
+			}
+		}
+
+		if ( $this->request->getCheck( 'prevent_users' ) ) {
+			$protection |= ProtectSiteModel::PREVENT_USERS_FLAG;
+		}
+
+		$model = new ProtectSiteModel();
+		$title = Title::makeTitle( NS_SPECIAL, 'Allpages' );
+		$log = new LogPage( 'protect' );
+
+		if ( $protection ^ ProtectSiteModel::PREVENT_USERS_FLAG ) {
+			$expiry = $this->request->getVal( 'expiry' );
+			$expiresAt = strtotime( "+$expiry" );
+
+			$model->updateProtectionSettings( $protection, $expiresAt );
+			$log->addEntry( 'protect', $title, $expiry, [], $this->getContext()->getUser() );
+		} else {
+			$model->unprotect();
+			$log->addEntry( 'unprotect', $title, '', [], $this->getContext()->getUser() );
+		}
+	}
+}

--- a/extensions/wikia/ProtectSiteII/ProtectSiteSpecialController.php
+++ b/extensions/wikia/ProtectSiteII/ProtectSiteSpecialController.php
@@ -20,22 +20,6 @@ class ProtectSiteSpecialController extends WikiaSpecialPageController {
 
 		$inputs = [];
 
-		$inputs[] = [
-			'type' => 'radio',
-			'label' => $this->msg( 'protectsite-label-prevent-anons-only' )->escaped(),
-			'name' => 'prevent_users',
-			'checked' => !ProtectSiteModel::isPreventUsersFlagSet( $active ) ?: null,
-			'value' => 0,
-		];
-
-		$inputs[] = [
-			'type' => 'radio',
-			'label' => $this->msg( 'protectsite-label-prevent-users' )->escaped(),
-			'name' => 'prevent_users',
-			'checked' => ProtectSiteModel::isPreventUsersFlagSet( $active ) ?: null,
-			'value' => 1,
-		];
-
 		foreach ( ProtectSiteModel::getValidActions() as $action ) {
 			// For grepping - possible message keys used here:
 			// protectsite-label-prevent-edit
@@ -117,17 +101,13 @@ class ProtectSiteSpecialController extends WikiaSpecialPageController {
 			}
 		}
 
-		if ( $this->request->getBool( 'prevent_users' ) ) {
-			$protection |= ProtectSiteModel::PREVENT_USERS_FLAG;
-		}
-
 		$reason = $this->request->getVal( 'reason', '' );
 
 		$model = new ProtectSiteModel();
 		$title = Title::makeTitle( NS_SPECIAL, 'Allpages' );
 		$log = new LogPage( 'protect' );
 
-		if ( $protection ^ ProtectSiteModel::PREVENT_USERS_FLAG ) {
+		if ( $protection ) {
 			$expiry = $this->request->getVal( 'expiry' );
 			$expiresAt = strtotime( "+$expiry" );
 
@@ -137,6 +117,11 @@ class ProtectSiteSpecialController extends WikiaSpecialPageController {
 			$model->unprotect();
 			$log->addEntry( 'unprotect', $title, $reason, [], $user );
 		}
+
+		$target = SpecialPage::getTitleFor( 'ProtectSite' );
+
+		$this->response->setCode( 303 );
+		$this->response->setHeader( 'Location', $target->getFullURL() );
 	}
 
 	private function getReason( string $expiry, string $reason ): string {

--- a/extensions/wikia/ProtectSiteII/ProtectSiteSpecialController.php
+++ b/extensions/wikia/ProtectSiteII/ProtectSiteSpecialController.php
@@ -122,12 +122,12 @@ class ProtectSiteSpecialController extends WikiaSpecialPageController {
 		$title = Title::makeTitle( NS_SPECIAL, 'Allpages' );
 		$log = new LogPage( 'protect' );
 
-		if ( $protection ) {
-			$expiry = $request->getVal( 'expiry' );
+		if ( $protection ^ ProtectSiteModel::PREVENT_ANONS_ONLY ) {
+			$expiry = $request->getVal( 'expiry', '1 hour' );
 			$expiresAt = strtotime( "+$expiry" );
 
 			$model->updateProtectionSettings( $this->wg->CityId, $protection, $expiresAt );
-			$log->addEntry( 'protect', $title, $this->getReason( $expiry, $reason ), [], $user);
+			$log->addEntry( 'protect', $title, $this->getReason( $expiry, $reason ), [ $expiry ], $user);
 		} else {
 			$model->unprotect( $this->wg->CityId );
 			$log->addEntry( 'unprotect', $title, $reason, [], $user );

--- a/extensions/wikia/ProtectSiteII/maintenance/purgeExpiredSiteProtections.php
+++ b/extensions/wikia/ProtectSiteII/maintenance/purgeExpiredSiteProtections.php
@@ -1,0 +1,14 @@
+<?php
+
+require_once __DIR__ . '/../../../../maintenance/Maintenance.php';
+
+class PurgeExpiredSiteProtections extends Maintenance {
+
+	public function execute() {
+		$model = new ProtectSiteModel();
+		$model->deleteExpiredSettings();
+	}
+}
+
+$maintClass = PurgeExpiredSiteProtections::class;
+require_once RUN_MAINTENANCE_IF_MAIN;

--- a/extensions/wikia/ProtectSiteII/tests/ProtectSiteHooksIntegrationTest.php
+++ b/extensions/wikia/ProtectSiteII/tests/ProtectSiteHooksIntegrationTest.php
@@ -1,0 +1,154 @@
+<?php
+
+/**
+ * @group Integration
+ */
+class ProtectSiteHooksIntegrationTest extends WikiaDatabaseTest {
+
+	const PROTECTED_WIKI_ID = 2;
+	const ANONS_ONLY_PROTECTED_WIKI_ID = 3;
+	const UNPROTECTED_WIKI_ID = 4;
+
+	/** @var Title $title */
+	private $title;
+
+	protected function setUp() {
+		parent::setUp();
+		$this->mockGlobalVariable( 'wgCityId', static::PROTECTED_WIKI_ID );
+		$this->title = new Title();
+	}
+
+	/**
+	 * @dataProvider allUserActionProvider
+	 * @param string $userName
+	 * @param string $action
+	 */
+	public function testShouldAllowEveryoneWhenNotProtected( string $userName, string $action ) {
+		$this->mockGlobalVariable( 'wgCityId', static::UNPROTECTED_WIKI_ID );
+
+		$user = User::newFromName( $userName, false );
+		$result = true;
+
+		$return = ProtectSiteHooks::onGetUserPermissionsErrorsExpensive( $this->title, $user, $action, $result );
+
+		$this->assertTrue( $result, "Action should be allowed for user: $userName" );
+		$this->assertTrue( $return, 'Hooks execution should be resumed' );
+	}
+
+	public function allUserActionProvider() {
+		foreach ( [ 'NormalUser', 'StaffUser', '8.8.8.8' ] as $userName ) {
+			foreach ( ProtectSiteModel::getValidActions() as $action ) {
+				yield "user: $userName, action: $action" => [ $userName, $action ];
+			}
+		}
+	}
+
+	/**
+	 * @dataProvider userProvider
+	 * @param string $userName
+	 */
+	public function testShouldAllowEveryoneWhenActionUnknown( string $userName ) {
+		$user = User::newFromName( $userName, false );
+		$result = true;
+
+		$return = ProtectSiteHooks::onGetUserPermissionsErrorsExpensive( $this->title, $user, 'unknown', $result );
+
+		$this->assertTrue( $result, "Action should be allowed for user: $userName" );
+		$this->assertTrue( $return, 'Hooks execution should be resumed' );
+	}
+
+	public function userProvider() {
+		yield [ 'NormalUser' ];
+		yield [ 'StaffUser' ];
+		yield [ '8.8.8.8' ];
+	}
+
+	/**
+	 * @dataProvider nonStaffUserActionProvider
+	 *
+	 * @param string $userName
+	 * @param string $action
+	 */
+	public function testShouldPreventNotStaffUsersWhenAllActionsPrevented( string $userName, string $action ) {
+		$user = User::newFromName( $userName, false );
+		$result = true;
+
+		$return = ProtectSiteHooks::onGetUserPermissionsErrorsExpensive( $this->title, $user, $action, $result );
+
+		$this->assertFalse( $result, "Action '$action' should not be allowed for user: $userName" );
+		$this->assertFalse( $return, 'Hooks execution should be stopped' );
+	}
+
+	public function nonStaffUserActionProvider() {
+		foreach ( [ 'NormalUser', '8.8.8.8' ] as $userName ) {
+			foreach ( ProtectSiteModel::getValidActions() as $action ) {
+				yield "user: $userName, action: $action" => [ $userName, $action ];
+			}
+		}
+	}
+
+	/**
+	 * @dataProvider actionProvider
+	 * @param string $action
+	 */
+	public function testShouldAllowStaffUserWhenAllActionsPrevented( string $action ) {
+		$user = User::newFromName( 'StaffUser', false );
+		$result = true;
+
+		$return = ProtectSiteHooks::onGetUserPermissionsErrorsExpensive( $this->title, $user, $action, $result );
+
+		$this->assertTrue( $result, "Action '$action' should be allowed for staff user" );
+		$this->assertTrue( $return, 'Hooks execution should be resumed' );
+	}
+
+	public function actionProvider() {
+		foreach ( ProtectSiteModel::getValidActions() as $action ) {
+			yield "action: $action" => [ $action ];
+		}
+	}
+
+	/**
+	 * @dataProvider loggedInUserActionProvider
+	 * @param string $userName
+	 * @param string $action
+	 */
+	public function testShouldAllowLoggedInUsersWhenBlockingOnlyAnons( string $userName, string $action ) {
+		$this->mockGlobalVariable( 'wgCityId', static::ANONS_ONLY_PROTECTED_WIKI_ID );
+
+		$user = User::newFromName( $userName, false );
+		$result = true;
+
+		$return = ProtectSiteHooks::onGetUserPermissionsErrorsExpensive( $this->title, $user, $action, $result );
+
+		$this->assertTrue( $result, "Action should be allowed for user: $userName" );
+		$this->assertTrue( $return, 'Hooks execution should be resumed' );
+	}
+
+	public function loggedInUserActionProvider() {
+		foreach ( [ 'NormalUser', 'StaffUser' ] as $userName ) {
+			foreach ( ProtectSiteModel::getValidActions() as $action ) {
+				yield "user: $userName, action: $action" => [ $userName, $action ];
+			}
+		}
+	}
+
+	/**
+	 * @dataProvider actionProvider
+	 * @param string $action
+	 */
+	public function testShouldPreventAnonsWhenBlockingOnlyAnons( string $action ) {
+		$this->mockGlobalVariable( 'wgCityId', static::ANONS_ONLY_PROTECTED_WIKI_ID );
+
+		$user = new User();
+		$result = true;
+
+		$return = ProtectSiteHooks::onGetUserPermissionsErrorsExpensive( $this->title, $user, $action, $result );
+
+		$this->assertFalse( $result, "Action '$action' should be prevented for anons" );
+		$this->assertFalse( $return, 'Hooks execution should be stopped' );
+	}
+
+	protected function getDataSet() {
+		return $this->createYamlDataSet( __DIR__ . '/fixtures/protect_site_shared.yaml' );
+	}
+}

--- a/extensions/wikia/ProtectSiteII/tests/ProtectSiteModelIntegrationTest.php
+++ b/extensions/wikia/ProtectSiteII/tests/ProtectSiteModelIntegrationTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @group Integration
+ */
+class ProtectSiteModelIntegrationTest extends WikiaDatabaseTest {
+
+	const EXPIRED_WIKI_ID = 2;
+	const PROTECTED_WIKI_ID = 3;
+
+	/** @var ProtectSiteModel $model */
+	private $model;
+
+	protected function setUp() {
+		parent::setUp();
+		$this->model = new ProtectSiteModel();
+	}
+
+	public function testShouldDeleteOutdatedEntries() {
+		$this->model->deleteExpiredSettings();
+
+		$this->assertEquals( 0, $this->model->getProtectionSettings( static::EXPIRED_WIKI_ID ), 'Expired settings should be deleted' );
+		$this->assertNotEquals( 0, $this->model->getProtectionSettings( static::PROTECTED_WIKI_ID ), 'Still live settings should not be deleted' );
+	}
+
+	protected function getDataSet() {
+		return $this->createYamlDataSet( __DIR__  . '/fixtures/protect_site_model.yaml' );
+	}
+}

--- a/extensions/wikia/ProtectSiteII/tests/ProtectSiteSpecialControllerIntegrationTest.php
+++ b/extensions/wikia/ProtectSiteII/tests/ProtectSiteSpecialControllerIntegrationTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * @group Integration
+ */
+class ProtectSiteSpecialControllerIntegrationTest extends WikiaDatabaseTest {
+
+	const VALID_TOKEN = 'test123';
+
+	/** @var RequestContext $requestContext */
+	private $requestContext;
+
+	/** @var ProtectSiteSpecialController $controller */
+	private $controller;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->requestContext = new RequestContext();
+		$this->controller = new ProtectSiteSpecialController();
+		$this->controller->setContext( $this->requestContext );
+		$this->controller->setResponse( new WikiaResponse( WikiaResponse::FORMAT_INVALID ) );
+	}
+
+	public function testShouldRejectGetRequest() {
+		$this->expectException( BadRequestException::class );
+		$this->createRequest( [] );
+
+		$this->controller->saveProtectionSettings();
+	}
+
+	public function testShouldRejectPostRequestWithInvalidToken() {
+		$this->expectException( BadRequestException::class );
+		$this->createRequest( [ 'token' => 'invalid' ], true );
+
+		$this->controller->saveProtectionSettings();
+	}
+
+	private function createRequestWithValidToken( array $params, bool $wasPosted = true ) {
+		$this->createRequest( $params + [ 'token' => static::VALID_TOKEN ], $wasPosted );
+	}
+
+	private function createRequest( array $params, bool $wasPosted = true ) {
+		$request = new FauxRequest( $params, $wasPosted );
+		$request->setSessionData( 'token', static::VALID_TOKEN );
+		$this->requestContext->setRequest( $request );
+	}
+
+	protected function getDataSet() {
+		return $this->createYamlDataSet( __DIR__ . '/fixtures/protect_site_model.yaml' );
+	}
+}

--- a/extensions/wikia/ProtectSiteII/tests/ProtectSiteSpecialControllerIntegrationTest.php
+++ b/extensions/wikia/ProtectSiteII/tests/ProtectSiteSpecialControllerIntegrationTest.php
@@ -5,7 +5,18 @@
  */
 class ProtectSiteSpecialControllerIntegrationTest extends WikiaDatabaseTest {
 
+	const TEST_WIKI_ID = 123;
+	const OTHER_WIKI_ID = 2;
 	const VALID_TOKEN = 'test123';
+
+	/** @var User $normalUser */
+	private $normalUser;
+
+	/** @var User $staffUser */
+	private $staffUser;
+
+	/** @var ProtectSiteModel $model */
+	private $model;
 
 	/** @var RequestContext $requestContext */
 	private $requestContext;
@@ -15,8 +26,14 @@ class ProtectSiteSpecialControllerIntegrationTest extends WikiaDatabaseTest {
 
 	protected function setUp() {
 		parent::setUp();
+		$this->mockGlobalVariable( 'wgCityId', static::TEST_WIKI_ID );
 
+		$this->normalUser = User::newFromName( 'NormalUser' );
+		$this->staffUser = User::newFromName( 'StaffUser' );
+
+		$this->model = new ProtectSiteModel();
 		$this->requestContext = new RequestContext();
+
 		$this->controller = new ProtectSiteSpecialController();
 		$this->controller->setContext( $this->requestContext );
 		$this->controller->setResponse( new WikiaResponse( WikiaResponse::FORMAT_INVALID ) );
@@ -24,29 +41,103 @@ class ProtectSiteSpecialControllerIntegrationTest extends WikiaDatabaseTest {
 
 	public function testShouldRejectGetRequest() {
 		$this->expectException( BadRequestException::class );
-		$this->createRequest( [] );
+		$this->prepareRequest( [], false );
 
-		$this->controller->saveProtectionSettings();
+		try {
+			$this->controller->saveProtectionSettings();
+		} finally {
+			$this->assertEquals( 0, $this->model->getProtectionSettings( static::TEST_WIKI_ID ), 'Settings should not have been set' );
+		}
 	}
 
 	public function testShouldRejectPostRequestWithInvalidToken() {
 		$this->expectException( BadRequestException::class );
-		$this->createRequest( [ 'token' => 'invalid' ], true );
+		$this->prepareRequest( [ 'token' => 'invalid' ] );
+
+		try {
+			$this->controller->saveProtectionSettings();
+		} finally {
+			$this->assertEquals( 0, $this->model->getProtectionSettings( static::TEST_WIKI_ID ), 'Settings should not have been set' );
+		}
+	}
+
+	public function testShouldRejectUserIfTheyHaveNoRight() {
+		$this->expectException( PermissionsError::class );
+		$this->prepareRequestWithToken( [] );
+		$this->requestContext->setUser( $this->normalUser );
+
+		try {
+			$this->controller->saveProtectionSettings();
+		} finally {
+			$this->assertEquals( 0, $this->model->getProtectionSettings( static::TEST_WIKI_ID ), 'Settings should not have been set' );
+		}
+	}
+
+	/**
+	 * @dataProvider paramsProvider
+	 *
+	 * @param array $params
+	 * @throws ForbiddenException
+	 * @throws PermissionsError
+	 */
+	public function testShouldSuccessfullySaveSettings( array $params ) {
+		$this->prepareRequestWithToken( $params );
+		$this->requestContext->setUser( $this->staffUser );
 
 		$this->controller->saveProtectionSettings();
+
+		$settings = $this->model->getProtectionSettings( static::TEST_WIKI_ID );
+
+		foreach ( ProtectSiteModel::getValidActions() as $action ) {
+			$value = ProtectSiteModel::isActionFlagSet( $settings, $action );
+			if ( isset( $params[$action] ) ) {
+				$this->assertTrue( $value, "Expected action '$action' to be blocked'" );
+			} else {
+				$this->assertFalse( $value, "Expected action '$action' to not be blocked'" );
+			}
+		}
+
+		$anonsOnly = ProtectSiteModel::isPreventAnonsOnlyFlagSet( $settings );
+
+		if ( isset( $params['prevent_anons_only'] ) ) {
+			$this->assertTrue( $anonsOnly, 'Expected anons-only flag to be set' );
+		} else {
+			$this->assertFalse( $anonsOnly, 'Expected anons-only flag to not be set' );
+		}
 	}
 
-	private function createRequestWithValidToken( array $params, bool $wasPosted = true ) {
-		$this->createRequest( $params + [ 'token' => static::VALID_TOKEN ], $wasPosted );
+	public function paramsProvider() {
+		yield [ [ 'edit' => 1, 'create' => 1 ], ];
+		yield [ [ 'edit' => 1, 'create' => 1, 'upload' => 1, 'move' => 1, ], ];
+		yield [ [ 'edit' => 1, 'create' => 1, 'upload' => 1, 'move' => 1, 'prevent_anons_only' => 1, ], ];
+		yield [ [ 'move' => 1, 'prevent_anons_only' => 1, ], ];
+		yield [ [ 'edit' => 1, 'create' => 1 ], ];
+		yield [ [ 'edit' => 1, 'create' => 1 ], ];
 	}
 
-	private function createRequest( array $params, bool $wasPosted = true ) {
+	public function testShouldRemoveProtection() {
+		$this->mockGlobalVariable( 'wgCityId', static::OTHER_WIKI_ID );
+		$this->prepareRequestWithToken( [] );
+		$this->requestContext->setUser( $this->staffUser );
+
+		$this->controller->saveProtectionSettings();
+
+		$settings = $this->model->getProtectionSettings( static::TEST_WIKI_ID );
+
+		$this->assertEquals( 0, $settings, 'Protection should be removed' );
+	}
+
+	private function prepareRequestWithToken( array $params, bool $wasPosted = true ) {
+		$this->prepareRequest( $params + [ 'token' => md5( static::VALID_TOKEN ) . EDIT_TOKEN_SUFFIX ], $wasPosted );
+	}
+
+	private function prepareRequest( array $params, bool $wasPosted = true ) {
 		$request = new FauxRequest( $params, $wasPosted );
-		$request->setSessionData( 'token', static::VALID_TOKEN );
+		$request->setSessionData( 'wsEditToken', static::VALID_TOKEN );
 		$this->requestContext->setRequest( $request );
 	}
 
 	protected function getDataSet() {
-		return $this->createYamlDataSet( __DIR__ . '/fixtures/protect_site_model.yaml' );
+		return $this->createYamlDataSet( __DIR__ . '/fixtures/protect_site_shared.yaml' );
 	}
 }

--- a/extensions/wikia/ProtectSiteII/tests/ProtectSiteSpecialControllerIntegrationTest.php
+++ b/extensions/wikia/ProtectSiteII/tests/ProtectSiteSpecialControllerIntegrationTest.php
@@ -21,6 +21,9 @@ class ProtectSiteSpecialControllerIntegrationTest extends WikiaDatabaseTest {
 	/** @var RequestContext $requestContext */
 	private $requestContext;
 
+	/** @var WikiaResponse $response */
+	private $response;
+
 	/** @var ProtectSiteSpecialController $controller */
 	private $controller;
 
@@ -33,10 +36,11 @@ class ProtectSiteSpecialControllerIntegrationTest extends WikiaDatabaseTest {
 
 		$this->model = new ProtectSiteModel();
 		$this->requestContext = new RequestContext();
+		$this->response = new WikiaResponse( WikiaResponse::FORMAT_INVALID );
 
 		$this->controller = new ProtectSiteSpecialController();
 		$this->controller->setContext( $this->requestContext );
-		$this->controller->setResponse( new WikiaResponse( WikiaResponse::FORMAT_INVALID ) );
+		$this->controller->setResponse( $this->response );
 	}
 
 	public function testShouldRejectGetRequest() {
@@ -104,6 +108,8 @@ class ProtectSiteSpecialControllerIntegrationTest extends WikiaDatabaseTest {
 		} else {
 			$this->assertFalse( $anonsOnly, 'Expected anons-only flag to not be set' );
 		}
+
+		$this->assertEquals( 303, $this->response->getCode(), 'Response should be a redirect' );
 	}
 
 	public function paramsProvider() {

--- a/extensions/wikia/ProtectSiteII/tests/fixtures/protect_site_model.yaml
+++ b/extensions/wikia/ProtectSiteII/tests/fixtures/protect_site_model.yaml
@@ -1,0 +1,7 @@
+protectsite:
+  - wiki_id: 2
+    protection_bitfield: 2
+    protection_expiry: 20180101000000
+  - wiki_id: 3
+    protection_bitfield: 2
+    protection_expiry: 20300101000000

--- a/extensions/wikia/ProtectSiteII/tests/fixtures/protect_site_shared.yaml
+++ b/extensions/wikia/ProtectSiteII/tests/fixtures/protect_site_shared.yaml
@@ -1,0 +1,37 @@
+protectsite:
+- wiki_id: 2
+  protection_bitfield: 15 # all actions prevented
+  protection_expiry: 20280101000000
+- wiki_id: 3
+  protection_bitfield: 527 # all actions prevented, only for anons
+  protection_expiry: 20280101000000
+user:
+- user_id: 1
+  user_name: 'NormalUser'
+  user_real_name: ''
+  user_email: 'kossuth.lajos@lajoskossuth.hu'
+  user_touched: '20110101000000'
+  user_token: 'loremipsum'
+  user_email_authenticated: '20101102000000'
+  user_email_token: 'dolorsitamet'
+  user_email_token_expires: '20120301120000'
+  user_registration: '20090604060000'
+  user_editcount: 2500
+  user_birthdate:
+  user_options: ''
+- user_id: 2
+  user_name: 'StaffUser'
+  user_real_name: ''
+  user_email: 'kossuth.lajos@lajoskossuth.hu'
+  user_touched: '20110101000000'
+  user_token: 'loremipsum'
+  user_email_authenticated: '20101102000000'
+  user_email_token: 'dolorsitamet'
+  user_email_token_expires: '20120301120000'
+  user_registration: '20090604060000'
+  user_editcount: 2500
+  user_birthdate:
+  user_options: ''
+user_groups:
+- ug_user: 2
+  ug_group: staff

--- a/extensions/wikia/WikiaStyleGuide/WikiaStyleGuideFormHelper.class.php
+++ b/extensions/wikia/WikiaStyleGuide/WikiaStyleGuideFormHelper.class.php
@@ -1,7 +1,16 @@
 <?php
 class WikiaStyleGuideFormHelper {
 	private static $formSupportedTopLevelAttributes = array( 'action', 'class', 'id', 'method', 'name' );
-	private static $inputSupportedTopLevelAttributes = array( 'class', 'id', 'name', 'value', 'tabindex', 'placeholder' );
+	private static $inputSupportedTopLevelAttributes = [
+		'checked',
+		'class',
+		'id',
+		'name',
+		'value',
+		'tabindex',
+		'placeholder',
+	];
+
 	private static $inputTypesToWrapWithLabel = array( 'checkbox', 'radio' );
 
 	public static function getAttributes( $target, $source, $attributes ) {

--- a/extensions/wikia/WikiaStyleGuide/templates/WikiaStyleGuideForm_index.php
+++ b/extensions/wikia/WikiaStyleGuide/templates/WikiaStyleGuideForm_index.php
@@ -76,12 +76,6 @@
 									( !empty( $input[ 'content' ] ) ? $input[ 'content' ] : '' )
 								?></button>
 							<? break; ?>
-							<? case 'submit': ?>
-								<input type="submit" <?= $inputAttributes ?>>
-							<? break; ?>
-							<? case 'checkbox': ?>
-								<input type="checkbox" <?= $inputAttributes ?>>
-								<? break; ?>
 							<? case 'custom': ?>
 								<?= $input[ 'output' ] ?>
 							<? break; ?>
@@ -106,6 +100,9 @@
 							<? case 'text': ?>
 							<? case 'url': ?>
 							<? case 'email': ?>
+							<? case 'submit': ?>
+							<? case 'checkbox': ?>
+							<? case 'radio': ?>
 								<input type="<?= $type ?>" <?= $inputAttributes ?>>
 							<? break; ?>
 							<? case 'textarea': ?>

--- a/includes/WebRequest.php
+++ b/includes/WebRequest.php
@@ -1132,11 +1132,10 @@ HTML;
 	 * (uses POST and contains a valid edit token)
 	 *
 	 * @param \User $user
-	 * @return mixed
 	 * @throws BadRequestException
 	 */
 	public function assertValidWriteRequest( \User $user ) {
-		if ( !$this->wasPosted() || !$user->matchEditToken( $this->getVal( 'token' ) ) ) {
+		if ( !$this->wasPosted() || !$user->matchEditToken( $this->getVal( 'token' ), '', $this ) ) {
 			throw new BadRequestException( 'Request must be POSTed and provide a valid edit token.' );
 		}
 	}

--- a/includes/wikia/Extensions.php
+++ b/includes/wikia/Extensions.php
@@ -1765,3 +1765,6 @@ include "$IP/extensions/wikia/FandomComMigration/FandomComMigration.setup.php";
 if ( $wgEnableFastlyInsights ) {
 	include "$IP/extensions/wikia/FastlyInsights/FastlyInsights.setup.php";
 }
+
+// SRE-116
+include "$IP/extensions/wikia/ProtectSiteII/ProtectSite.php";

--- a/includes/wikia/nirvana/WikiaSpecialPageController.class.php
+++ b/includes/wikia/nirvana/WikiaSpecialPageController.class.php
@@ -36,7 +36,7 @@
  * @method bool isListed()
  * @method bool isRestricted()
  * @method bool listed( $x = null )
- * @method Message msg()
+ * @method Message msg( ...$args )
  * @method mixed name( $x = null )
  * @method outputHeader( $summaryMessageKey = '' )
  * @method mixed restriction( $x = null )

--- a/lib/Wikia/src/Service/User/Permissions/PermissionsConfiguration.php
+++ b/lib/Wikia/src/Service/User/Permissions/PermissionsConfiguration.php
@@ -214,6 +214,7 @@ class PermissionsConfiguration {
 		'newwikislist',
 		'restricted_promote',
 		'protectsite',
+		'protectsite-exempt',
 		'stafflog',
 		'unblockable',
 		'tagsreport',

--- a/lib/Wikia/src/Service/User/Permissions/data/PermissionsDefinesBeforeWikiFactory.php
+++ b/lib/Wikia/src/Service/User/Permissions/data/PermissionsDefinesBeforeWikiFactory.php
@@ -369,3 +369,7 @@ $wgGroupPermissions['staff']['clearuserprofile'] = true;
 $wgGroupPermissions['helper']['clearuserprofile'] = true;
 
 $wgGroupPermissions['global-discussions-moderator']['block'] = true;
+
+$wgGroupPermissions['helper']['protectsite-exempt'] = true;
+$wgGroupPermissions['staff']['protectsite-exempt'] = true;
+$wgGroupPermissions['vstf']['protectsite-exempt'] = true;

--- a/maintenance/wikia/sql/wikicities-schema.sql
+++ b/maintenance/wikia/sql/wikicities-schema.sql
@@ -436,6 +436,18 @@ CREATE TABLE `phalanx` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 --
+-- Table structure for table `protectsite`
+--
+
+DROP TABLE IF EXISTS `protectsite`;
+CREATE TABLE `protectsite` (
+  `wiki_id` int(9) NOT NULL AUTO_INCREMENT,
+  `protection_bitfield` int(11) NOT NULL DEFAULT '0',
+  `protection_expiry` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`wiki_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+--
 -- Table structure for table `shared_newtalks`
 --
 
@@ -580,4 +592,4 @@ CREATE TABLE `user_properties` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 
--- Dump completed on 2018-07-13 10:12:53
+-- Dump completed on 2018-10-17 13:13:09


### PR DESCRIPTION
The current implementation of ProtectSite uses exclusively memcached as a "backend" so it will not work with multiple active datacenters. Since the extension is kind of a mess I've decided to start from scratch and rebuild it while using a database backend to store protection information.

The old extension will be removed separately, after the new one is live.

https://wikia-inc.atlassian.net/browse/SRE-116