### PR TITLE
SRE-111 | Retry parser output key lookups varying on all options

### DIFF
--- a/includes/parser/ParserCache.php
+++ b/includes/parser/ParserCache.php
@@ -11,7 +11,7 @@
  */
 class ParserCache {
 	private $mMemc;
-	const try116cache = false; /* Only useful $wgParserCacheExpireTime after updating to 1.17 */
+	const try116cache = true; /* Only useful $wgParserCacheExpireTime after updating to 1.17 */
 
 	/**
 	 * Get an instance of this object


### PR DESCRIPTION
Based on https://github.com/Wikia/app/pull/16217 logging it seems we're missing the parser output key despite poolcounter success. Retrying the lookup with a key generated by varying on all parser options should improve hit rate here.

https://wikia-inc.atlassian.net/browse/SRE-111