### PR TITLE
SRE-111 | Fix false negative issue in PoolWorkArticleView

### DIFF
--- a/includes/WikiPage.php
+++ b/includes/WikiPage.php
@@ -3196,7 +3196,14 @@ class PoolWorkArticleView extends PoolCounterWork {
 	 * @return bool
 	 */
 	function getCachedWork() {
-		$this->parserOutput = ParserCache::singleton()->get( $this->page, $this->parserOptions );
+		$parserCache = ParserCache::singleton();
+
+		// SRE-111: Clear out the options key from in memory cache so as not to get a false negative
+		// We lookup options key 2x, and if we got here then the first time was a miss so we have the miss cached in memory
+		// PoolCounter has notified us that the work is now done - so clear out the miss
+		$parserCache->clearOptionsKey( $this->page );
+
+		$this->parserOutput = $parserCache->get( $this->page, $this->parserOptions );
 
 		if ( $this->parserOutput === false ) {
 			wfDebug( __METHOD__ . ": parser cache miss\n" );

--- a/includes/parser/ParserCache.php
+++ b/includes/parser/ParserCache.php
@@ -10,6 +10,7 @@
  * @todo document
  */
 class ParserCache {
+	/** @var BagOStuff $mMemc */
 	private $mMemc;
 	const try116cache = false; /* Only useful $wgParserCacheExpireTime after updating to 1.17 */
 
@@ -267,5 +268,9 @@ class ParserCache {
 		} else {
 			wfDebug( "Parser output was marked as uncacheable and has not been saved.\n" );
 		}
+	}
+
+	public function clearOptionsKey( $article ) {
+		$this->mMemc->clearLocalCache( $this->getOptionsKey( $article ) );
 	}
 }


### PR DESCRIPTION
Clear out the options key from in memory cache so as not to get a false negative. We lookup options key 2x, and if we got here then the first time was a miss so we have the miss cached in memory. But PoolCounter has notified us that the work is now done - so we should clear out the miss.

https://wikia-inc.atlassian.net/browse/SRE-111