### PR TITLE
SRE-117 | Add process cache to MercuryApi templates processing

### DIFF
--- a/includes/wikia/parser/templatetypes/TemplateTypesParser.class.php
+++ b/includes/wikia/parser/templatetypes/TemplateTypesParser.class.php
@@ -1,6 +1,10 @@
 <?php
 
 class TemplateTypesParser {
+
+	/** @var TemplateClassificationService $service */
+	private static $service;
+
 	private static $cachedTemplateTitles = [ ];
 
 	/**
@@ -157,7 +161,7 @@ class TemplateTypesParser {
 		global $wgCityId;
 
 		$type = ExternalTemplateTypesProvider::getInstance()
-			->setTCS( new \TemplateClassificationService )
+			->setTCS( self::getTemplateClassificationService() )
 			->getTemplateTypeFromTitle( $wgCityId, $title );
 
 		return $type;
@@ -203,5 +207,13 @@ class TemplateTypesParser {
 		}
 
 		return self::$cachedTemplateTitles[ $templateTitle ];
+	}
+
+	private static function getTemplateClassificationService(): TemplateClassificationService {
+		if ( !self::$service ) {
+			self::$service = new TemplateClassificationService();
+		}
+
+		return self::$service;
 	}
 }

--- a/includes/wikia/parser/templatetypes/TemplateTypesParser.class.php
+++ b/includes/wikia/parser/templatetypes/TemplateTypesParser.class.php
@@ -216,4 +216,12 @@ class TemplateTypesParser {
 
 		return self::$service;
 	}
+
+	/**
+	 * Remove cached TCS instance
+	 * Used by tests
+	 */
+	public static function clearTemplateClassificationService() {
+		self::$service = null;
+	}
 }

--- a/includes/wikia/parser/templatetypes/handlers/InfoIconTemplate.class.php
+++ b/includes/wikia/parser/templatetypes/handlers/InfoIconTemplate.class.php
@@ -40,21 +40,28 @@ class InfoIconTemplate {
 	private static function getIconLink($image ) {
 		// SRE-117: Use process cache to avoid repeated expensive media queries
 		if ( !isset( self::$infoIconCache[$image] ) ) {
-			$title = Title::newFromText( $image );
+			self::$infoIconCache[$image] = self::makeIconLink( $image );
+		}
+
+		return self::$infoIconCache[$image];
+	}
+
+	private static function makeIconLink( $image ): string {
+		$title = Title::newFromText( $image );
+
+		if ( $title instanceof Title ) {
 			$file = wfFindFile( $title );
 
 			if ( $file && $file->exists() ) {
-				self::$infoIconCache[$image] = Linker::makeImageLink2(
+				return Linker::makeImageLink2(
 					$title,
 					$file,
 					[],
 					[ 'template-type' => TemplateClassificationService::TEMPLATE_INFOICON ]
 				);
-			} else {
-				self::$infoIconCache[$image] = '';
 			}
 		}
 
-		return self::$infoIconCache[$image];
+		return '';
 	}
 }

--- a/includes/wikia/parser/templatetypes/handlers/InfoIconTemplate.class.php
+++ b/includes/wikia/parser/templatetypes/handlers/InfoIconTemplate.class.php
@@ -1,5 +1,9 @@
 <?php
 class InfoIconTemplate {
+
+	/** @var string[string] Process cache map of info icon image names to rendered links */
+	private static $infoIconCache = [];
+
 	/**
 	 * @desc sanitize infoicon template content, that is remove all non-images
 	 * from it's wikitext. Then, parse them and add to stripState with
@@ -20,7 +24,7 @@ class InfoIconTemplate {
 		
 		$output = '';
 		foreach ( $images as $image ) {
-			$output .= self::makeIconLink( $image );
+			$output .= self::getIconLink( $image );
 		}
 		$stripMarker = $parser->insertStripItem( $output );
 		return $stripMarker;
@@ -33,19 +37,24 @@ class InfoIconTemplate {
 	 * @return String
 	 * @throws \MWException
 	 */
-	private static function makeIconLink( $image ) {
-		$link = '';
-		$title = Title::newFromText( $image );
-		$file = wfFindFile( $title );
-		if ( $file && $file->exists() ) {
-			$link = Linker::makeImageLink2(
-				$title,
-				$file,
-				[],
-				[ 'template-type' => TemplateClassificationService::TEMPLATE_INFOICON ]
-			);
+	private static function getIconLink($image ) {
+		// SRE-117: Use process cache to avoid repeated expensive media queries
+		if ( !isset( self::$infoIconCache[$image] ) ) {
+			$title = Title::newFromText( $image );
+			$file = wfFindFile( $title );
+
+			if ( $file && $file->exists() ) {
+				self::$infoIconCache[$image] = Linker::makeImageLink2(
+					$title,
+					$file,
+					[],
+					[ 'template-type' => TemplateClassificationService::TEMPLATE_INFOICON ]
+				);
+			} else {
+				self::$infoIconCache[$image] = '';
+			}
 		}
 
-		return $link;
+		return self::$infoIconCache[$image];
 	}
 }

--- a/includes/wikia/parser/templatetypes/tests/TemplateTypesParserTest.php
+++ b/includes/wikia/parser/templatetypes/tests/TemplateTypesParserTest.php
@@ -328,4 +328,9 @@ class TemplateTypesParserTest extends WikiaBaseTest {
 			]
 		];
 	}
+
+	protected function tearDown() {
+		parent::tearDown();
+		TemplateTypesParser::clearTemplateClassificationService();
+	}
 }


### PR DESCRIPTION
When MercuryApi is processing an article that transcludes the same template many times (e.g. an icon template used several times, like the ones in the table headers on https://fallout.wikia.com/wiki/Fallout_4_characters), it repeatedly fetches template classification data and media details for the same template. We can leverage process cache here to improve performance.

@Wikia/iwing 

https://wikia-inc.atlassian.net/browse/SRE-117