### PR TITLE
SRE-111 | Clear in-memory cache for the parser output as well

### DIFF
--- a/includes/parser/ParserCache.php
+++ b/includes/parser/ParserCache.php
@@ -179,6 +179,9 @@ class ParserCache {
 			return false;
 		}
 
+		// SRE-111: Clear in-memory cache for the parser output as well
+		$this->mMemc->clearLocalCache( $parserOutputKey );
+
 		$value = $this->mMemc->get( $parserOutputKey );
 		if ( self::try116cache && !$value && strpos( $value, '*' ) !== -1 ) {
 			wfDebug( "New format parser cache miss.\n" );


### PR DESCRIPTION
As we might have had a cache miss on the parser output key already on view, make sure to clear the miss before the next lookup.

https://wikia-inc.atlassian.net/browse/SRE-117