### PR TITLE
(PLATFORM-3759) Update interwiki URLs to the latest URL dynamically

### DIFF
--- a/extensions/wikia/HTTPSSupport/HTTPSSupport.setup.php
+++ b/extensions/wikia/HTTPSSupport/HTTPSSupport.setup.php
@@ -7,3 +7,4 @@ $wgHooks['LinkerMakeExternalLink'][] = 'HTTPSSupportHooks::onLinkerMakeExternalL
 $wgHooks['MercuryWikiVariables'][] = 'HTTPSSupportHooks::onMercuryWikiVariables';
 $wgHooks['outputMakeExternalImage'][] = 'HTTPSSupportHooks::parserUpgradeVignetteUrls';
 $wgHooks['WikiaRobotsBeforeOutput'][] = 'HTTPSSupportHooks::onRobotsBeforeOutput';
+$wgHooks['InterwikiLoadBeforeCache'][] = 'HTTPSSupportHooks::onInterwikiLoadBeforeCache';

--- a/includes/interwiki/Interwiki.php
+++ b/includes/interwiki/Interwiki.php
@@ -165,6 +165,9 @@ class Interwiki {
 
 		$row = $db->fetchRow( $db->select( 'interwiki', '*', array( 'iw_prefix' => $prefix ),
 			__METHOD__ ) );
+		// Wikia change - begin
+		Hooks::run( 'InterwikiLoadBeforeCache', [ &$row ] );
+		// Wikia change - end
 		$iw = Interwiki::loadFromArray( $row );
 		if ( $iw ) {
 			$mc = array(
@@ -340,7 +343,7 @@ class Interwiki {
 			$url = str_replace( "$1", wfUrlencode( $title ), $url );
 		}
 
-		if ( wfHttpsAllowedForURL( $url ) ) {
+		if ( strpos( $url, 'http://' ) === 0 && wfHttpsAllowedForURL( $url ) ) {
 			$url = wfProtocolUrlToRelative( $url );
 		}
 


### PR DESCRIPTION
Alternate solution to update interwiki links on the fly until we migrate all the data.

/cc @Wikia/core-platform-team 