### PR TITLE
SUS-6077 | CloseWikiMaintenance - move to a next wiki instead of failing the entire process

### DIFF
--- a/extensions/wikia/WikiFactory/Close/maintenance.php
+++ b/extensions/wikia/WikiFactory/Close/maintenance.php
@@ -142,7 +142,10 @@ class CloseWikiMaintenance {
 									'exception' => $ex->getMessage(),
 									'dump_size_bytes' => filesize( $source ),
 								]);
-								die( 1 );
+								unlink( $source );
+
+								// SUS-6077 | move to a next wiki instead of failing the entire process
+								continue;
 							}
 
 							$this->info( "{$source} copied to S3 Amazon" );
@@ -158,6 +161,9 @@ class CloseWikiMaintenance {
 								'city_id' => $cityid,
 							]
 						);
+
+						// SUS-6077 | move to a next wiki instead of failing the entire process
+						continue;
 					}
 				}
 			}

--- a/extensions/wikia/WikiFactory/Close/maintenance.php
+++ b/extensions/wikia/WikiFactory/Close/maintenance.php
@@ -139,7 +139,8 @@ class CloseWikiMaintenance {
 								DumpsOnDemand::putToAmazonS3( $source, !$hide, MimeMagic::singleton()->guessMimeType( $source ) );
 							} catch ( S3Exception $ex ) {
 								$this->error( "putToAmazonS3 command failed - Can't copy images to remote host. Please, fix that and rerun", [
-									'exception' => $ex->getMessage()
+									'exception' => $ex->getMessage(),
+									'dump_size_bytes' => filesize( $source ),
 								]);
 								die( 1 );
 							}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-6077

And improve logging of failed Amazon's S3 upload - report file size. We get `[EntityTooLarge] Your proposed upload exceeds the maximum allowed size` errors in logs.