### PR TITLE
Fix articlePath variable in discussions

### DIFF
--- a/extensions/wikia/MercuryApi/models/MercuryApi.class.php
+++ b/extensions/wikia/MercuryApi/models/MercuryApi.class.php
@@ -181,7 +181,7 @@ class MercuryApi {
 
 	public function getDiscussionsWikiVariables() {
 		global $wgDefaultSkin, $wgEnableDiscussions, $wgEnableDiscussionsImageUpload, $wgDiscussionColorOverride,
-		       $wgEnableLightweightContributions, $wgEnableFeedsAndPostsExt;
+		       $wgEnableLightweightContributions, $wgEnableFeedsAndPostsExt, $wgArticlePath;
 
 		if ( !empty( $wgArticlePath ) ) {
 			$articlePath = str_replace( '$1', '', $wgArticlePath );


### PR DESCRIPTION
The global was not declared so was undefined, leading the article path to always
be `/wiki`.

/cc @rogatty 