### PR TITLE
SUS-5674 | increase maxReplicas and minReplicas from production Kubernetes

### DIFF
--- a/docker/prod/prod.template.yaml
+++ b/docker/prod/prod.template.yaml
@@ -127,8 +127,8 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: mediawiki-prod
-  maxReplicas: 36
-  minReplicas: 2
+  maxReplicas: 50
+  minReplicas: 20
   metrics:
   - type: Resource
     resource:


### PR DESCRIPTION
To handle 38% of production traffic Kubernetes uses 22 pods right now. Let's increase the limits to give us some space.