### PR TITLE
SUS-6084 | increase PHP container memory limit

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -9,8 +9,8 @@ We assume that you have `app` and `config` repository cloned in the same directo
 
 ```sh
 # 1. build a base image
-docker build -f base/Dockerfile -t artifactory.wikia-inc.com/sus/php-wikia-base:372bb48 ./base
-docker push artifactory.wikia-inc.com/sus/php-wikia-base:372bb48
+docker build -f base/Dockerfile -t artifactory.wikia-inc.com/sus/php-wikia-base:da4390f ./base
+docker push artifactory.wikia-inc.com/sus/php-wikia-base:da4390f
 
 # 2. and then dev image
 docker build -f dev/Dockerfile -t php-wikia-dev ./dev

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -135,6 +135,6 @@ ENV WIKIA_DOCROOT=/usr/wikia/slot1/current/src
 ENV WIKIA_CONFIG_ROOT=/usr/wikia/slot1/current/config
 
 # run "sha1sum * | sha1sum" to update this value when this file (or any other in this directory) changes
-ENV WIKIA_BASE_IMAGE_HASH=372bb48
+ENV WIKIA_BASE_IMAGE_HASH=da4390f
 
 WORKDIR /usr/wikia/slot1/current/src

--- a/docker/base/php-fpm.conf
+++ b/docker/base/php-fpm.conf
@@ -1,6 +1,6 @@
 [www]
 pm = static
-pm.max_children = 10
+pm.max_children = 5
 pm.max_requests = 2000
 pm.status_path = /status
 access.log = /dev/null

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,6 +1,6 @@
 # This is a Docker image for  Wikia's MediaWiki app that can be used locally by a developer.
 # Simply mount your app and config repositories clone (refer to README.md)
-FROM artifactory.wikia-inc.com/sus/php-wikia-base:372bb48
+FROM artifactory.wikia-inc.com/sus/php-wikia-base:da4390f
 
 # install dev dependencies
 

--- a/docker/prod/Dockerfile-php
+++ b/docker/prod/Dockerfile-php
@@ -1,4 +1,4 @@
-FROM artifactory.wikia-inc.com/sus/php-wikia-base:372bb48
+FROM artifactory.wikia-inc.com/sus/php-wikia-base:da4390f
 
 ENV WIKIA_DATACENTER="sjc"
 ENV WIKIA_ENVIRONMENT="prod"

--- a/docker/prod/Jenkinsfile
+++ b/docker/prod/Jenkinsfile
@@ -118,7 +118,7 @@ node("docker-daemon") {
             }
 
             if (!imageExists) {
-                sh("docker pull artifactory.wikia-inc.com/sus/php-wikia-base:372bb48")
+                sh("docker pull artifactory.wikia-inc.com/sus/php-wikia-base:da4390f")
 
                 // SUS-5284 - make the image a bit smaller
                 sh("cp docker/.dockerignore ..")

--- a/docker/prod/prod.template.yaml
+++ b/docker/prod/prod.template.yaml
@@ -91,10 +91,10 @@ spec:
           resources:
             limits:
               cpu: "6"
-              memory: 1200Mi
+              memory: 3Gi  # 5 fpm workers x 512 MB PHP memory limit
             requests:
               cpu: "3"
-              memory: 800Mi
+              memory: 1.5Gi
         # MW log output, see K8s_LOGGING.md
         - name: logger
           image: artifactory.wikia-inc.com/sus/mediawiki-logger:latest
@@ -282,11 +282,11 @@ spec:
               value: "tcp://localhost:9999"
           resources:
             limits:
-              cpu: 6
-              memory: 2Gi
+              cpu: "6"
+              memory: 3Gi  # 5 fpm workers x 512 MB PHP memory limit
             requests:
-              cpu: 2
-              memory: 800Mi
+              cpu: "3"
+              memory: 1.5Gi
         # MW log output, see K8s_LOGGING.md
         - name: logger
           image: artifactory.wikia-inc.com/sus/mediawiki-logger:latest

--- a/docker/sandbox/Dockerfile-php.template
+++ b/docker/sandbox/Dockerfile-php.template
@@ -1,4 +1,4 @@
-FROM artifactory.wikia-inc.com/sus/php-wikia-base:372bb48
+FROM artifactory.wikia-inc.com/sus/php-wikia-base:da4390f
 
 ENV WIKIA_DATACENTER="${SANDBOX_DATACENTER}"
 ENV WIKIA_ENVIRONMENT="${SANDBOX_ENVIRONMENT}"

--- a/docker/sandbox/Jenkinsfile
+++ b/docker/sandbox/Jenkinsfile
@@ -102,7 +102,7 @@ node("docker-daemon") {
 			}
 
             if (!imageExists) {
-                sh("docker pull artifactory.wikia-inc.com/sus/php-wikia-base:372bb48")
+                sh("docker pull artifactory.wikia-inc.com/sus/php-wikia-base:da4390f")
 
 				// SUS-5284 - make the image a bit smaller
 				sh("cp docker/.dockerignore ..")

--- a/docker/sandbox/sandbox.template.yaml
+++ b/docker/sandbox/sandbox.template.yaml
@@ -92,10 +92,10 @@ spec:
           resources:
             limits:
               cpu: "6"
-              memory: 1200Mi
+              memory: 3Gi  # 5 fpm workers x 512 MB PHP memory limit
             requests:
               cpu: "3"
-              memory: 800Mi
+              memory: 1.5Gi
         # MW log output, see K8s_LOGGING.md
         - name: logger
           image: artifactory.wikia-inc.com/sus/mediawiki-logger:latest


### PR DESCRIPTION
When memory heavy requests are handled we usually get the following in php-fpm logs:

```
[25-Oct-2018 13:34:22] WARNING: [pool www] child 10 exited on signal 9 (SIGKILL) after 271.560674 seconds from start
```

Increase memory limits to match per-PHP process limit multiplied by the number of fpm workers. Tested with `ab` on sandbox and no HTTP 502 were reported nor SIGKILL were sent to php processes. Request less PHP workers (5 instead of 10).

## New base image

```
$ docker images | head -n2
REPOSITORY                                              TAG                  IMAGE ID            CREATED             SIZE
artifactory.wikia-inc.com/sus/php-wikia-base            da4390f              9538362443e2        17 seconds ago      596MB
```