### PR TITLE
On special pages window.mw.user.anonymous() is loaded too late

### DIFF
--- a/extensions/wikia/AutoLogin/js/passive_autologin.js
+++ b/extensions/wikia/AutoLogin/js/passive_autologin.js
@@ -9,7 +9,7 @@ require([
 		return ua.indexOf('safari') !== -1 && ua.indexOf('chrome') === -1;
 	};
 
-	if (cookie.get('autologin_done') !== '2' && window.mw.user.anonymous() && isSafari()) {
+	if (cookie.get('autologin_done') !== '2' && !window.wgUserName && isSafari()) {
 		var iframe = window.document.createElement('iframe');
 		iframe.src = window.mw.config.get('wgPassiveAutologinUrl');
 		iframe.classList.add('auto-login-module-iframe');


### PR DESCRIPTION
Fix for:
```
Uncaught TypeError: window.mw.user.anonymous is not a function
```
happening on special pages which load scripts in a different order. Apply the same fix as in https://github.com/Wikia/app/commit/e58b000ac2ffd947cb345a091cd642aa409f3525

@Wikia/core-platform-team @mszabo-wikia 