### PR TITLE
IW-1129 escape wiki text in post titles

### DIFF
--- a/extensions/wikia/Email/Controller/DiscussionController.class.php
+++ b/extensions/wikia/Email/Controller/DiscussionController.class.php
@@ -80,6 +80,16 @@ abstract class DiscussionController extends EmailController {
 		return $this->wiki->city_url . 'd';
 	}
 
+	/**
+	 * Wrap the provided text in <nowiki> tags. This escapes the text preventing
+	 * it from being parsed as wikitext.
+	 * @param $text
+	 * @return string
+	 */
+	protected function wrapTextInNoWikiTags( $text ) {
+		return "<nowiki>" . $text . "</nowiki>";
+	}
+
 	protected static function getEmailSpecificFormFields() {
 		return [
 			'inputs' => [
@@ -126,7 +136,7 @@ class DiscussionReplyController extends DiscussionController {
 			return $this->getMessage(
 				'emailext-discussion-reply-with-title-subject',
 				$this->postUrl,
-				$this->threadTitle,
+				$this->wrapTextInNoWikiTags( $this->threadTitle ),
 				$this->wiki->city_url,
 				$this->wiki->city_title
 			)->parse();
@@ -234,7 +244,7 @@ class DiscussionUpvoteController extends DiscussionController {
 			return $this->getMessage(
 				self::MESSAGE_KEYS[$this->upVotes]['summary-with-title'],
 				$this->postUrl,
-				$this->postTitle,
+				$this->wrapTextInNoWikiTags( $this->postTitle ),
 				$this->wiki->city_url,
 				$this->wiki->city_title
 			);

--- a/extensions/wikia/Email/Controller/DiscussionController.class.php
+++ b/extensions/wikia/Email/Controller/DiscussionController.class.php
@@ -87,7 +87,7 @@ abstract class DiscussionController extends EmailController {
 	 * @return string
 	 */
 	protected function wrapTextInNoWikiTags( $text ) {
-		return "<nowiki>" . $text . "</nowiki>";
+		return '<nowiki>' . $text . '</nowiki>';
 	}
 
 	protected static function getEmailSpecificFormFields() {


### PR DESCRIPTION
Ticket: https://wikia-inc.atlassian.net/browse/IW-1129

Post titles are user generated content and may contain text which could be interpreted as wiki markup. This is a problem since we're interpolating that text into our i18n messages and then running them through the parser. We should escape that text so it doesn't cause unintended parsing side effects (eg, adding extra links if the text uses brackets `[]`).

cc @Wikia/iwing 