### PR TITLE
SUS-6154 | fix handling of /index.php request on wikis with language path

### DIFF
--- a/docker/base/base.inc
+++ b/docker/base/base.inc
@@ -29,9 +29,8 @@ rewrite "^/(?:[a-z]{2,3}(?:-[a-z-]{2,12})?/)?api.php(.*)" /api.php$1;
 if ($arg_func) {
     rewrite ^(.*)$ $1?action=lyrics last;
 }
-
-rewrite "^/(?:[a-z]{2,3}(?:-[a-z-]{2,12})?/)?load.php(.*)" /load.php$1 break;
-rewrite "^/(?:[a-z]{2,3}(?:-[a-z-]{2,12})?/)?wikia.php(.*)" /wikia.php$1 break;
+ # SUS-6154
+rewrite "^/(?:[a-z]{2,3}(?:-[a-z-]{2,12})?/)?(index|load|metrics|wikia).php(.*)" /$1.php$2 break;
 
 # article URL
 rewrite "^/(?:[a-z]{2,3}(?:-[a-z-]{2,12})?/)?wiki/(.*)" /index.php?title=$1 break;


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-6154

## Before

```
$ curl -svo /dev/null "http://poznan.dev.wikia-local.com/pl/index.php?action=ajax&rs=getLinkSuggest&format=json&query=foo" 2>&1 | egrep 'HTTP|Location|Serve|Redir'
> GET /pl/index.php?action=ajax&rs=getLinkSuggest&format=json&query=foo HTTP/1.1
< HTTP/1.1 301 Moved Permanently
< Server: nginx/1.14.0
< X-Redirected-By: redirect-canonical.php
< Location: http://poznan.dev.wikia-local.com/pl/wiki/Pl/index.php?action=ajax&rs=getLinkSuggest&format=json&query=foo
< X-Served-By: 801df5a96304
```

## After

```
$ curl -svo /dev/null "http://poznan.dev.wikia-local.com/index.php?action=ajax&rs=getLinkSuggest&format=json&query=foo" 2>&1 | egrep 'HTTP|Location|Serve|Redir'
> GET /index.php?action=ajax&rs=getLinkSuggest&format=json&query=foo HTTP/1.1
< HTTP/1.1 200 OK
< Server: nginx/1.14.0
< X-Served-By: 801df5a96304
```