### PR TITLE
More pods for mediawiki-tasks

### DIFF
--- a/docker/prod/prod.template.yaml
+++ b/docker/prod/prod.template.yaml
@@ -341,7 +341,7 @@ spec:
     kind: Deployment
     name: mediawiki-tasks
   maxReplicas: 30
-  minReplicas: 10
+  minReplicas: 15
   metrics:
   - type: Resource
     resource:


### PR DESCRIPTION
It seems that with 5 FPM workers, `mediawki-tasks` gets congested. Let's bump the minimal number of replicas.