### PR TITLE
Silence PHP Warning in tests

### DIFF
--- a/tests/travis/config/dev.php
+++ b/tests/travis/config/dev.php
@@ -45,3 +45,5 @@ $wgDevDomain = 'wikia.com';
 $wgWikiaDevDomain = 'wikia.com';
 $wgFandomDevDomain = 'fandom.com';
 $wgMysqlConnectionCharacterSet = 'latin1';
+// there is no IRC server in tests
+$wgRC2UDPEnabled = false;


### PR DESCRIPTION
Avoid `Warning: socket_sendto(): Host lookup failed [-10001]: Unknown host in /home/travis/build/Wikia/app/includes/RecentChange.php on line 289`.

IRC host won't resolve in a CI context.