### PR TITLE
Simple probes for mediawiki-tasks nginx

### DIFF
--- a/docker/prod/prod.template.yaml
+++ b/docker/prod/prod.template.yaml
@@ -228,18 +228,14 @@ spec:
                 - -c
                 - sleep 3
           livenessProbe:
-            httpGet:
-              path: /health/check
+            tcpSocket:
               port: 8080
             initialDelaySeconds: 10
             timeoutSeconds: 5
-            periodSeconds: 20
           readinessProbe:
-            httpGet:
-              path: /health/check
+            tcpSocket:
               port: 8080
             timeoutSeconds: 5
-            periodSeconds: 10
           ports:
             - containerPort: 8080
           resources:


### PR DESCRIPTION
It seems that an HTTP probe going to MW is not well suited for `mediawiki-tasks` due to the long response time. We can use a simpler probe for liveness/readiness checks.