### PR TITLE
OPS-12119: X-Surrogate-Key header cleanup

### DIFF
--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -1930,7 +1930,6 @@ class Wikia {
 		}
 		$surrogateKey = implode( ' ', $surrogateKeys );
 		header( 'Surrogate-Key: ' . $surrogateKey );
-		header( 'X-Surrogate-Key: ' . $surrogateKey );
 	}
 
 	public static function surrogateKey( $args ) {


### PR DESCRIPTION
`X-Surrogate-Key` - Fastly doesn't support such header (they use `Surrogate-Key`. We want to cleanup this custom header (it's not used by our caches).