### PR TITLE
SUS-6163 - report when was the last time a given maintenance script has been run successfully

### DIFF
--- a/maintenance/Maintenance.php
+++ b/maintenance/Maintenance.php
@@ -130,6 +130,7 @@ abstract class Maintenance {
 	 */
 	public $noConcurrency = false;
 
+	/* @var $status MaintenanceStatus */
 	public $status = null;
 
 	/**

--- a/maintenance/doMaintenance.php
+++ b/maintenance/doMaintenance.php
@@ -160,4 +160,17 @@ try {
 	throw $e;
 }
 
+// Wikia change
+// SUS-6163 - report when was the last time a given maintenance script has been run successfully
+\Wikia\Metrics\Collector::getInstance()
+	->addGauge(
+		'mediawiki_maintenance_scripts_last_success',
+		time(),
+		[
+			'script_class' => $maintClass,
+			'env' => $wgWikiaEnvironment,
+		],
+		'Unix timestamp maintenance script last succeeded'
+	);
+
 Hooks::run( 'RestInPeace' ); // Wikia change - @author macbre


### PR DESCRIPTION
Inspired by https://www.robustperception.io/monitoring-batch-jobs-in-python

Push the UNIX timestamp of the last successful run of a given maintenance script. Use this for alerting. 

https://wikia-inc.atlassian.net/browse/SUS-6163

### Prometheus labels and metric value

```
mediawiki_mediawiki_maintenance_scripts_last_success{endpoint="main",env="sandbox",instance="10.200.124.180:8080",job="mediawiki-preview",namespace="prod",pod="mediawiki-preview-6c999658c4-qpf8m",script_class="UpdateSpecialPages",service="mediawiki-preview"}	1541418510
```

`env` and `script_class` will be reported