### PR TITLE
LORE-83, DE-3942 Add fc_community_id to the getWikis output

### DIFF
--- a/includes/wikia/api/DWDimensionApiController.class.php
+++ b/includes/wikia/api/DWDimensionApiController.class.php
@@ -134,7 +134,7 @@ class DWDimensionApiController extends WikiaApiController {
 				'created_at' => $row->created_at,
 				'deleted' => $row->deleted,
 				'is_test_wiki' => intval( in_array( $row->wiki_id, $testWikis ) ),
-				'fc_community_id' => isset( $fcCommunityIdMap[ $row->wiki_id ] ) ? $fcCommunityIdMap[ $row->wiki_id ] : null,
+				'fc_community_id' => $fcCommunityIdMap[ $row->wiki_id ] ?? null,
 			];
 		}
 		$db->freeResult( $dbResult );


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/LORE-83
https://wikia-inc.atlassian.net/browse/DE-3942

Add the Fandom Creator community id to the output of `DWDimensionApiController::getWikis`. As I understand it, this is where it needs to go in order to be imported into `dimension_wikis` in the data warehouse. See #16131 for a similar change.

I'm retaining the `string` type because that's what is currently being stored in the WikiFactory variable. More generally it's also what we use for ID references elsewhere in JSON APIs.

@Wikia/lore 