### PR TITLE
PLATFORM-3810: fix the language wikis detection in WF

### DIFF
--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -580,8 +580,8 @@ class WikiFactory {
 			function() use ($dbr, $domain) {
 				$where = [
 					$dbr->makeList( [
-						'city_url ' . $dbr->buildLike( "http://{$domain}/", $dbr->anyString() ),
-						'city_url ' . $dbr->buildLike( "https://{$domain}/", $dbr->anyString() ),
+						'city_url ' . $dbr->buildLike( "http://{$domain}/", $dbr->anyChar(), $dbr->anyString() ),
+						'city_url ' . $dbr->buildLike( "https://{$domain}/", $dbr->anyChar(), $dbr->anyString() ),
 					], LIST_OR ),
 					'city_public' => 1
 				];


### PR DESCRIPTION
we look for language wikis, so expect at least a single char in the city_url path