### PR TITLE
IW-1233 Create price update bot for runescape wikis

### DIFF
--- a/docker/maintenance/README.md
+++ b/docker/maintenance/README.md
@@ -241,6 +241,12 @@ Removes expired SiteWideMessages from MySQL.
 
 Warms up semantic query cache for SemanticMediaWiki's Concept pages.
 
+#### runescape-price-update-bot.yaml
+
+`maintenance/runescape-price-update-bot.yaml`
+
+Updates prices of items on runescape and oldschoolrunescape wikis using data from Jagex API
+
 #### update-special-pages.yaml
 
 `maintenance/updateSpecialPages.php`

--- a/docker/maintenance/runescape-price-update-bot.yaml
+++ b/docker/maintenance/runescape-price-update-bot.yaml
@@ -1,0 +1,6 @@
+schedule: "0 1 * * *"
+args:
+- php
+- /usr/wikia/slot1/current/src/maintenance/maintenanceTaskScheduler.php
+- --id=304,691244
+- maintenance/wikia/runescapeBot/updateGrandExchangeItemPrices.php

--- a/maintenance/wikia/runescapeBot/grandExchangeItem.class.php
+++ b/maintenance/wikia/runescapeBot/grandExchangeItem.class.php
@@ -1,0 +1,26 @@
+<?php
+
+class GrandExchangeItem {
+
+	private $timeStamp;
+	private $price;
+	private $id;
+
+	public function __construct( $timeStamp, $price, $id ) {
+		$this->timeStamp = $timeStamp;
+		$this->price = $price;
+		$this->id = $id;
+	}
+
+	public function getTimeStamp() {
+		return $this->timeStamp;
+	}
+
+	public function getPrice() {
+		return $this->price;
+	}
+
+	public function getId() {
+		return $this->id;
+	}
+}

--- a/maintenance/wikia/runescapeBot/grandExchangePageFetcher.class.php
+++ b/maintenance/wikia/runescapeBot/grandExchangePageFetcher.class.php
@@ -1,50 +1,57 @@
 <?php
 
+/**
+ * Fetches all pages which in the "Grand Exchange" with
+ * a namespace of 112
+ * Class GrandExchangePageFetcher
+ */
 class GrandExchangePageFetcher {
 
-	const GRAND_EXCHANGE_CATEGORY_NAME = "Category: Grand Exchange";
-	const EXCHANGE_NAMESPACE = 112;
+	const CATEGORY_NAME = "Grand Exchange";
+
+	const RUNESCAPE_CITY_ID = 304;
+	const OLDSCHOOL_RUNESCAPE_CITY_ID = 691244;
+
+	const RUNESCAPE_NS_FILTER = 112;
+	const OLDSCHOOL_RUNESCAPE_NS_FILTER = 114;
 
 	/**
 	 * @return array
-	 * @throws MWException
+	 * @throws Exception
 	 */
 	public function fetchAllGrandExchangePages() {
 		$pages = [];
-		$requestParams = [
-			'format' => 'json',
-			'maxlag' => 5,
-			'action' => 'query',
-			'list' => 'categorymembers',
-			'cmprop' => 'title',
-			'cmlimit' => 'max',
-			'cmtitle' => self::GRAND_EXCHANGE_CATEGORY_NAME,
-			'cmnamespace' => self::EXCHANGE_NAMESPACE,
-		];
+		$category = Category::newFromName( self::CATEGORY_NAME );
+		$namespaceFilter = $this->getNameSpaceFilter();
 
-		$hasNext = true;
-		while ( $hasNext ) {
-			$fauxRequest = new FauxRequest( $requestParams );
-			$api = new ApiMain( $fauxRequest );
-			$api->execute();
-			$jsonData = $api->getResultData();
-
-			foreach( $jsonData['query']['categorymembers'] as $page ) {
-				$pages[] = $this->stripExchangePrefix( $page['title'] );
-			}
-
-			if ( isset( $jsonData['query-continue']['categorymembers']['cmcontinue'] ) ) {
-				$requestParams['cmcontinue'] = $jsonData['query-continue']['categorymembers']['cmcontinue'];
-			} else {
-				$hasNext = false;
+		/** @var Title $page */
+		foreach ( $category->getMembers() as $page ) {
+			if ( $page->getNamespace() === $namespaceFilter ) {
+				$pages[] = $page->getText();
 			}
 		}
 
 		return $pages;
 	}
 
-	private function stripExchangePrefix( $pageTitle ) : string {
-		return preg_replace("/^Exchange:/", "", $pageTitle );
-	}
+	/**
+	 * Item pages which need updating are found in different namespaces on the runescape
+	 * and oldschoolrunescape wikis. Determine which namespace we should filter on based
+	 * on which wiki we're running
+	 * @return int
+	 * @throws Exception
+	 */
+	private function getNameSpaceFilter() {
+		global $wgCityId;
 
+		if ( (int) $wgCityId === self::RUNESCAPE_CITY_ID ) {
+			return self::RUNESCAPE_NS_FILTER;
+		}
+
+		if ( (int) $wgCityId === self::OLDSCHOOL_RUNESCAPE_CITY_ID ) {
+			return self::OLDSCHOOL_RUNESCAPE_NS_FILTER;
+		}
+
+		throw new Exception( "this should only be run on a runescape wiki!" );
+	}
 }

--- a/maintenance/wikia/runescapeBot/grandExchangePageFetcher.class.php
+++ b/maintenance/wikia/runescapeBot/grandExchangePageFetcher.class.php
@@ -1,0 +1,50 @@
+<?php
+
+class GrandExchangePageFetcher {
+
+	const GRAND_EXCHANGE_CATEGORY_NAME = "Category: Grand Exchange";
+	const EXCHANGE_NAMESPACE = 112;
+
+	/**
+	 * @return array
+	 * @throws MWException
+	 */
+	public function fetchAllGrandExchangePages() {
+		$pages = [];
+		$requestParams = [
+			'format' => 'json',
+			'maxlag' => 5,
+			'action' => 'query',
+			'list' => 'categorymembers',
+			'cmprop' => 'title',
+			'cmlimit' => 'max',
+			'cmtitle' => self::GRAND_EXCHANGE_CATEGORY_NAME,
+			'cmnamespace' => self::EXCHANGE_NAMESPACE,
+		];
+
+		$hasNext = true;
+		while ( $hasNext ) {
+			$fauxRequest = new FauxRequest( $requestParams );
+			$api = new ApiMain( $fauxRequest );
+			$api->execute();
+			$jsonData = $api->getResultData();
+
+			foreach( $jsonData['query']['categorymembers'] as $page ) {
+				$pages[] = $this->stripExchangePrefix( $page['title'] );
+			}
+
+			if ( isset( $jsonData['query-continue']['categorymembers']['cmcontinue'] ) ) {
+				$requestParams['cmcontinue'] = $jsonData['query-continue']['categorymembers']['cmcontinue'];
+			} else {
+				$hasNext = false;
+			}
+		}
+
+		return $pages;
+	}
+
+	private function stripExchangePrefix( $pageTitle ) : string {
+		return preg_replace("/^Exchange:/", "", $pageTitle );
+	}
+
+}

--- a/maintenance/wikia/runescapeBot/grandExchangePageFetcher.class.php
+++ b/maintenance/wikia/runescapeBot/grandExchangePageFetcher.class.php
@@ -3,11 +3,17 @@
 class GrandExchangePageFetcher {
 
 	const GRAND_EXCHANGE_CATEGORY_NAME = "Category: Grand Exchange";
-	const EXCHANGE_NAMESPACE = 112;
+
+	const RUNESCAPE_CITY_ID = 304;
+	const OLDSCHOOL_RUNESCAPE_CITY_ID = 691244;
+
+	const RUNESCAPE_NS_FILTER = 112;
+	const OLDSCHOOL_RUNESCAPE_NS_FILTER = 114;
 
 	/**
 	 * @return array
 	 * @throws MWException
+	 * @throws Exception
 	 */
 	public function fetchAllGrandExchangePages() {
 		$pages = [];
@@ -19,7 +25,7 @@ class GrandExchangePageFetcher {
 			'cmprop' => 'title',
 			'cmlimit' => 'max',
 			'cmtitle' => self::GRAND_EXCHANGE_CATEGORY_NAME,
-			'cmnamespace' => self::EXCHANGE_NAMESPACE,
+			'cmnamespace' => $this->getNameSpaceFilter()
 		];
 
 		$hasNext = true;
@@ -47,4 +53,24 @@ class GrandExchangePageFetcher {
 		return preg_replace("/^Exchange:/", "", $pageTitle );
 	}
 
+	/**
+	 * Item pages which need updating are found in different namespaces on the runescape
+	 * and oldschoolrunescape wikis. Determine which namespace we should filter on based
+	 * on which wiki we're running
+	 * @return int
+	 * @throws Exception
+	 */
+	private function getNameSpaceFilter() {
+		global $wgCityId;
+
+		if ( (int) $wgCityId === self::RUNESCAPE_CITY_ID ) {
+			return self::RUNESCAPE_NS_FILTER;
+		}
+
+		if ( (int) $wgCityId === self::OLDSCHOOL_RUNESCAPE_CITY_ID ) {
+			return self::OLDSCHOOL_RUNESCAPE_NS_FILTER;
+		}
+
+		throw new Exception( "this should only be run on a runescape wiki!" );
+	}
 }

--- a/maintenance/wikia/runescapeBot/grandExchangePageFetcher.class.php
+++ b/maintenance/wikia/runescapeBot/grandExchangePageFetcher.class.php
@@ -1,57 +1,50 @@
 <?php
 
-/**
- * Fetches all pages which in the "Grand Exchange" with
- * a namespace of 112
- * Class GrandExchangePageFetcher
- */
 class GrandExchangePageFetcher {
 
-	const CATEGORY_NAME = "Grand Exchange";
-
-	const RUNESCAPE_CITY_ID = 304;
-	const OLDSCHOOL_RUNESCAPE_CITY_ID = 691244;
-
-	const RUNESCAPE_NS_FILTER = 112;
-	const OLDSCHOOL_RUNESCAPE_NS_FILTER = 114;
+	const GRAND_EXCHANGE_CATEGORY_NAME = "Category: Grand Exchange";
+	const EXCHANGE_NAMESPACE = 112;
 
 	/**
 	 * @return array
-	 * @throws Exception
+	 * @throws MWException
 	 */
 	public function fetchAllGrandExchangePages() {
 		$pages = [];
-		$category = Category::newFromName( self::CATEGORY_NAME );
-		$namespaceFilter = $this->getNameSpaceFilter();
+		$requestParams = [
+			'format' => 'json',
+			'maxlag' => 5,
+			'action' => 'query',
+			'list' => 'categorymembers',
+			'cmprop' => 'title',
+			'cmlimit' => 'max',
+			'cmtitle' => self::GRAND_EXCHANGE_CATEGORY_NAME,
+			'cmnamespace' => self::EXCHANGE_NAMESPACE,
+		];
 
-		/** @var Title $page */
-		foreach ( $category->getMembers() as $page ) {
-			if ( $page->getNamespace() === $namespaceFilter ) {
-				$pages[] = $page->getText();
+		$hasNext = true;
+		while ( $hasNext ) {
+			$fauxRequest = new FauxRequest( $requestParams );
+			$api = new ApiMain( $fauxRequest );
+			$api->execute();
+			$jsonData = $api->getResultData();
+
+			foreach( $jsonData['query']['categorymembers'] as $page ) {
+				$pages[] = $this->stripExchangePrefix( $page['title'] );
+			}
+
+			if ( isset( $jsonData['query-continue']['categorymembers']['cmcontinue'] ) ) {
+				$requestParams['cmcontinue'] = $jsonData['query-continue']['categorymembers']['cmcontinue'];
+			} else {
+				$hasNext = false;
 			}
 		}
 
 		return $pages;
 	}
 
-	/**
-	 * Item pages which need updating are found in different namespaces on the runescape
-	 * and oldschoolrunescape wikis. Determine which namespace we should filter on based
-	 * on which wiki we're running
-	 * @return int
-	 * @throws Exception
-	 */
-	private function getNameSpaceFilter() {
-		global $wgCityId;
-
-		if ( (int) $wgCityId === self::RUNESCAPE_CITY_ID ) {
-			return self::RUNESCAPE_NS_FILTER;
-		}
-
-		if ( (int) $wgCityId === self::OLDSCHOOL_RUNESCAPE_CITY_ID ) {
-			return self::OLDSCHOOL_RUNESCAPE_NS_FILTER;
-		}
-
-		throw new Exception( "this should only be run on a runescape wiki!" );
+	private function stripExchangePrefix( $pageTitle ) : string {
+		return preg_replace("/^Exchange:/", "", $pageTitle );
 	}
+
 }

--- a/maintenance/wikia/runescapeBot/rawTextUpdater.class.php
+++ b/maintenance/wikia/runescapeBot/rawTextUpdater.class.php
@@ -1,0 +1,113 @@
+<?php
+
+class RawTextUpdater {
+
+	/**
+	 * @param string $rawText
+	 * @param GrandExchangeItem $grandExchangeItem
+	 * @param $tradeCount
+	 * @return string
+	 * @throws Exception
+	 */
+	public function updateModuleText(string $rawText, GrandExchangeItem $grandExchangeItem, $tradeCount ) : string {
+		$oldPrice = $this->extractPrice( $rawText );
+		$oldDate = $this->extractDate( $rawText );
+
+		$rawText = $this->replacePrice( $grandExchangeItem->getPrice(), $rawText );
+		$rawText = $this->replaceDate( $rawText );
+		$rawText = $this->replaceLastPrice( $oldPrice, $rawText );
+		$rawText = $this->replaceLastDate( $oldDate, $rawText );
+		$rawText = $this->replaceVolume( $tradeCount, $rawText );
+
+		return $rawText;
+	}
+
+	public function updateDataText(string $rawText, GrandExchangeItem $grandExchangeItem, $tradeCount ) : string {
+		if ( empty( $rawText ) ) {
+			$rawText = "return {\n}";
+		}
+
+		return $this->appendLatestPrice( $rawText, $grandExchangeItem, $tradeCount );
+	}
+
+	private function appendLatestPrice( string $rawText, GrandExchangeItem $item, $tradeCount ) {
+		if ( $tradeCount === null ) {
+			$lineToAppend = sprintf( ",\n    '%s:%s'\n}", $item->getTimeStamp(), $item->getPrice() );
+		} else {
+			$lineToAppend = sprintf( ",\n    '%s:%s:%s'\n}", $item->getTimeStamp(), $item->getPrice(), $tradeCount );
+		}
+
+		return preg_replace( "/\n}/", $lineToAppend, $rawText );
+	}
+
+	/**
+	 * @param string $rawText
+	 * @return string
+	 * @throws Exception
+	 */
+	private function extractPrice(string $rawText ) : string  {
+		return $this->extractPattern( '/price\s+= (\d+)/', $rawText );
+	}
+
+	/**
+	 * @param string $rawText
+	 * @return string
+	 * @throws Exception
+	 */
+	private function extractDate(string $rawText ) : string {
+		return $this->extractPattern( '/date\s+= \'(.*)\',/', $rawText );
+	}
+
+	/**
+	 * @param string $pattern
+	 * @param string $rawText
+	 * @return string
+	 * @throws Exception
+	 */
+	private function extractPattern(string $pattern, string $rawText ) : string {
+		$matches = [];
+		preg_match( $pattern, $rawText, $matches );
+		if ( count( $matches ) !== 2 ) {
+			throw new Exception( "Unable to extract value from text" );
+		}
+		return $matches[1];
+	}
+
+	private function replacePrice( string $replacement, string $rawText ) : string {
+		return preg_replace( '/price\s+=.*/', "price      = $replacement,", $rawText  );
+	}
+
+	private function replaceDate( string $rawText ) : string {
+		return preg_replace( '/date\s+=.*/', "date       = '~~~~~',", $rawText  );
+	}
+
+	private function replaceLastPrice( string $replacement, string $rawText ) : string {
+		return preg_replace( '/last\s+=.*/', "last       = $replacement,", $rawText  );
+	}
+
+	private function replaceLastDate( string $replacement, string $rawText ) : string {
+		return preg_replace( '/lastDate\s+=.*/', "lastDate   = '$replacement',", $rawText  );
+	}
+
+	private function replaceVolume( $replacement, string $rawText ) : string {
+		$rawText = $this->stripOldVolumeData( $rawText );
+
+		// Item doesn't have volume (aka tradecount) data. Either it fell out of the top 100 items so we aren't given
+		// trade counts for it anymore, or it was never a top 100 traded item to begin with. Either way, just return
+		// the rawText here.
+		if ( $replacement === null ) {
+			return $rawText;
+		}
+
+		return $this->appendVolumeDataAfterLastDateLine( $replacement, $rawText );
+	}
+
+	private function stripOldVolumeData( $rawText ) {
+		return preg_replace( "/\s+volume.*/", "", $rawText );
+	}
+
+	private function appendVolumeDataAfterLastDateLine( $replacement, $rawText ) {
+		$volumeString = sprintf( "    volume     = %s,\n    volumeDate = '~~~~~',", $replacement );
+		return preg_replace( "/(\s+lastDate.*)/", "$1\n" . $volumeString, $rawText );
+	}
+}

--- a/maintenance/wikia/runescapeBot/runescapeApi.class.php
+++ b/maintenance/wikia/runescapeBot/runescapeApi.class.php
@@ -1,0 +1,79 @@
+<?php
+
+class RunescapeApi {
+
+	const API_URL_TEMPLATE = "http://services.runescape.com/m=itemdb_rs/api/graph/%s.json";
+	const TOP_TRADED_ITEMS_URL = "http://services.runescape.com/m=itemdb_rs/top100.ws";
+
+	/**
+	 * @param string $itemId
+	 * @return string
+	 * @throws Exception
+	 */
+	public function getItemId( string $itemId ) : GrandExchangeItem  {
+		$response = Http::get( sprintf( self::API_URL_TEMPLATE, $itemId ), "default", [ 'noProxy' => true ] );
+
+		if ( $response === false ) {
+			throw new Exception( "Error fetching data from runescape API" );
+		}
+
+
+		$jsonResponse = json_decode( $response, true );
+		if ( json_last_error() !== JSON_ERROR_NONE || !isset( $jsonResponse['daily'] ) ) {
+			throw new Exception( "Error decoding json from runesacpe API" );
+		}
+
+		$latestTimestamp = max( array_keys( $jsonResponse['daily'] ) );
+
+		return new GrandExchangeItem(
+			$this->stripLast3Digits( $latestTimestamp ),
+			$jsonResponse['daily'][$latestTimestamp],
+			$itemId
+		);
+	}
+
+
+	/**
+	 * The original Tybot would strip the last 3 digits from the timestamp, we'll do that here as well
+	 */
+	private function stripLast3Digits( $timestamp ) {
+		return substr( $timestamp, 0, -3 );
+	}
+
+	public function getTopItems() {
+		$idToTradeCountMap = [];
+		$response = Http::get( self::TOP_TRADED_ITEMS_URL, "default", [ 'noProxy' => true ] );
+
+		if ( $response === false ) {
+			return $idToTradeCountMap;
+		}
+
+		$domDocument = HtmlHelper::createDOMDocumentFromText( $response );
+		$tableBody = $domDocument->getElementsByTagName( 'tbody' );
+		$tableRows = $tableBody->item(0)->getElementsByTagName('tr');
+		/** @var DOMElement $row */
+		foreach( $tableRows as $row ) {
+			$totalsColumn = $row->getElementsByTagName( 'td' )->item( 5 );
+			$totalsLink = $totalsColumn->getElementsByTagName( 'a' )->item( 0 );
+
+			$itemid = $this->extractIdFromTotalsLink( $totalsLink );
+			$tradeCount = $this->extractTradeCountFromTotalsLink( $totalsLink );
+			$idToTradeCountMap[$itemid] = $tradeCount;
+		}
+
+		return $idToTradeCountMap;
+	}
+
+	private function extractIdFromTotalsLink( DOMElement $totalsLink ) {
+		$match = [];
+		$urlAttr = $totalsLink->getAttribute( "href" );
+		preg_match( "/obj=(\d+)/", $urlAttr, $match );
+		return $match[1];
+	}
+
+	private function extractTradeCountFromTotalsLink(DOMElement $totalsLink  ) {
+		$match = [];
+		preg_match( "/([\d\.]+)/", $totalsLink->textContent, $match );
+		return $match[1];
+	}
+}

--- a/maintenance/wikia/runescapeBot/runescapeApi.class.php
+++ b/maintenance/wikia/runescapeBot/runescapeApi.class.php
@@ -4,29 +4,28 @@ class RunescapeApi {
 
 	const API_URL_TEMPLATE = "http://services.runescape.com/m=itemdb_rs/api/graph/%s.json";
 	const TOP_TRADED_ITEMS_URL = "http://services.runescape.com/m=itemdb_rs/top100.ws";
+	const ONE_SECOND = 1;
 
 	/**
 	 * @param string $itemId
-	 * @return string
+	 * @return GrandExchangeItem
 	 * @throws Exception
 	 */
 	public function getItemId( string $itemId ) : GrandExchangeItem  {
-		$response = Http::get( sprintf( self::API_URL_TEMPLATE, $itemId ), "default", [ 'noProxy' => true ] );
-
+		$response = $this->makeRequestAndRetryOnFailure( sprintf( self::API_URL_TEMPLATE, $itemId ) );
 		if ( $response === false ) {
 			throw new Exception( "Error fetching data from runescape API" );
 		}
 
-
 		$jsonResponse = json_decode( $response, true );
 		if ( json_last_error() !== JSON_ERROR_NONE || !isset( $jsonResponse['daily'] ) ) {
-			throw new Exception( "Error decoding json from runesacpe API" );
+			throw new Exception( "Error decoding json from runesacpe API. Last error: " . json_last_error() );
 		}
 
 		$latestTimestamp = max( array_keys( $jsonResponse['daily'] ) );
 
 		return new GrandExchangeItem(
-			$this->stripLast3Digits( $latestTimestamp ),
+			$this->convertToSeconds( $latestTimestamp ),
 			$jsonResponse['daily'][$latestTimestamp],
 			$itemId
 		);
@@ -34,15 +33,18 @@ class RunescapeApi {
 
 
 	/**
-	 * The original Tybot would strip the last 3 digits from the timestamp, we'll do that here as well
+	 * The runscape API returns epoch time in ms, we want it in seconds. Strip off the last 3 digits to do
+	 * the conversion
+	 * @param $timestamp
+	 * @return bool|string
 	 */
-	private function stripLast3Digits( $timestamp ) {
+	private function convertToSeconds( $timestamp ) {
 		return substr( $timestamp, 0, -3 );
 	}
 
 	public function getTopItems() {
 		$idToTradeCountMap = [];
-		$response = Http::get( self::TOP_TRADED_ITEMS_URL, "default", [ 'noProxy' => true ] );
+		$response = $this->makeRequestAndRetryOnFailure( self::TOP_TRADED_ITEMS_URL );
 
 		if ( $response === false ) {
 			return $idToTradeCountMap;
@@ -62,6 +64,16 @@ class RunescapeApi {
 		}
 
 		return $idToTradeCountMap;
+	}
+
+	private function makeRequestAndRetryOnFailure( string $url, int $retriesLeft = 2  ) {
+		$response = Http::get( $url, "default", [ 'noProxy' => true ] );
+		if ( $response === false && $retriesLeft !== 0 ) {
+			sleep( self::ONE_SECOND );
+			return $this->makeRequestAndRetryOnFailure( $url, $retriesLeft - 1 );
+		}
+
+		return $response;
 	}
 
 	private function extractIdFromTotalsLink( DOMElement $totalsLink ) {

--- a/maintenance/wikia/runescapeBot/runescapeApi.class.php
+++ b/maintenance/wikia/runescapeBot/runescapeApi.class.php
@@ -11,7 +11,7 @@ class RunescapeApi {
 	 * @return GrandExchangeItem
 	 * @throws Exception
 	 */
-	public function getItemId( string $itemId ) : GrandExchangeItem  {
+	public function getItemById(string $itemId ) : GrandExchangeItem  {
 		$response = $this->makeRequestAndRetryOnFailure( sprintf( self::API_URL_TEMPLATE, $itemId ) );
 		if ( $response === false ) {
 			throw new Exception( "Error fetching data from runescape API" );

--- a/maintenance/wikia/runescapeBot/runescapeBot.setup.php
+++ b/maintenance/wikia/runescapeBot/runescapeBot.setup.php
@@ -1,0 +1,6 @@
+<?php
+
+require_once __DIR__ . '/grandExchangeItem.class.php';
+require_once __DIR__ . '/runescapeApi.class.php';
+require_once __DIR__ . '/grandExchangePageFetcher.class.php';
+require_once __DIR__ . '/rawTextUpdater.class.php';

--- a/maintenance/wikia/runescapeBot/updateGrandExchangeItemPrices.php
+++ b/maintenance/wikia/runescapeBot/updateGrandExchangeItemPrices.php
@@ -180,7 +180,7 @@ class UpdateGrandExchangeItemPrices extends Maintenance {
 	private function getTimeStampForRuneScape() {
 		try {
 			return $this->runescapeApi->getItemById( $this->getFirstItemIdFromTop100Items() )->getTimeStamp();
-		} catch (Exception $e) {
+		} catch ( Exception $e ) {
 			$this->logError( "unable to fetch timestamp from runescape, using default" );
 			return time();
 		}

--- a/maintenance/wikia/runescapeBot/updateGrandExchangeItemPrices.php
+++ b/maintenance/wikia/runescapeBot/updateGrandExchangeItemPrices.php
@@ -71,7 +71,7 @@ class UpdateGrandExchangeItemPrices extends Maintenance {
 		$modulePage = $this->getWikiPageForTitle( $this->getModulePageTitle( $pageTitle ) );
 		$dataPage = $this->getWikiPageForTitle( $this->getDataPageTitle( $pageTitle ) );
 		$itemId = $this->getItemId( $modulePage->getRawText() );
-		$grandExchangeItem = $this->runescapeApi->getItemId( $itemId );
+		$grandExchangeItem = $this->runescapeApi->getItemById( $itemId );
 
 		$this->updateModulePage( $modulePage, $grandExchangeItem );
 		$this->updateDataPage( $dataPage, $grandExchangeItem );
@@ -180,7 +180,7 @@ class UpdateGrandExchangeItemPrices extends Maintenance {
 	 */
 	private function getTimeStampForRuneScape() {
 		try {
-			return $this->runescapeApi->getItemId( $this->getFirstItemIdFromTop100Items() )->getTimeStamp();
+			return $this->runescapeApi->getItemById( $this->getFirstItemIdFromTop100Items() )->getTimeStamp();
 		} catch (Exception $e) {
 			$this->logError( "unable to fetch timestamp from runescape, using default" );
 			return time();

--- a/maintenance/wikia/runescapeBot/updateGrandExchangeItemPrices.php
+++ b/maintenance/wikia/runescapeBot/updateGrandExchangeItemPrices.php
@@ -46,8 +46,7 @@ class UpdateGrandExchangeItemPrices extends Maintenance {
 
 		// "Grand Exchange" is the name of the runescape marketplace. All items that need
 		// to be updated are in the "Grand Exchange" category
-		$pages = $this->pageFetcher->fetchAllGrandExchangePages();
-		foreach ( $pages as $page) {
+		foreach ( $this->pageFetcher->fetchAllGrandExchangePages() as $page ) {
 			try {
 				$this->updatePricePagesForArticle( $page );
 			} catch	( Exception $e ) {

--- a/maintenance/wikia/runescapeBot/updateGrandExchangeItemPrices.php
+++ b/maintenance/wikia/runescapeBot/updateGrandExchangeItemPrices.php
@@ -46,7 +46,8 @@ class UpdateGrandExchangeItemPrices extends Maintenance {
 
 		// "Grand Exchange" is the name of the runescape marketplace. All items that need
 		// to be updated are in the "Grand Exchange" category
-		foreach ( $this->pageFetcher->fetchAllGrandExchangePages() as $page ) {
+		$pages = $this->pageFetcher->fetchAllGrandExchangePages();
+		foreach ( $pages as $page) {
 			try {
 				$this->updatePricePagesForArticle( $page );
 			} catch	( Exception $e ) {

--- a/maintenance/wikia/runescapeBot/updateGrandExchangeItemPrices.php
+++ b/maintenance/wikia/runescapeBot/updateGrandExchangeItemPrices.php
@@ -10,7 +10,6 @@ require_once( __DIR__ . '/runescapeBot.setup.php' );
 class UpdateGrandExchangeItemPrices extends Maintenance {
 
 	const PAUSE_TIME_IN_SECONDS = 2.5;
-	const BOT_USERNAME = "FandomBot";
 	const LOG_MESSAGE_TEMPLATE = "RUNESCAPE_BOT -- %s";
 	const MODULE_PREFIX = "Module:Exchange/";
 	const TEMPLATE_PREFIX = "Template:";
@@ -42,7 +41,7 @@ class UpdateGrandExchangeItemPrices extends Maintenance {
 	 * @throws Exception
 	 */
 	public function execute() {
-		$this->botUser = User::newFromName( self::BOT_USERNAME );
+		$this->botUser = User::newFromName( Wikia::BOT_USER );
 		$this->topItemsTradeCount = $this->runescapeApi->getTopItems();
 
 		// "Grand Exchange" is the name of the runescape marketplace. All items that need

--- a/maintenance/wikia/runescapeBot/updateGrandExchangeItemPrices.php
+++ b/maintenance/wikia/runescapeBot/updateGrandExchangeItemPrices.php
@@ -1,0 +1,261 @@
+<?php
+
+require_once( __DIR__ . '/../../Maintenance.php' );
+require_once( __DIR__ . '/runescapeBot.setup.php' );
+
+class UpdateGrandExchangeItemPrices extends Maintenance {
+
+	const PAUSE_TIME_IN_SECONDS = 2.5;
+	const BOT_USERNAME = "FandomBot";
+	const LOG_MESSAGE_TEMPLATE = "RUNESCAPE_BOT -- %s";
+	const MODULE_PREFIX = "Module:Exchange/";
+	const TEMPLATE_PREFIX = "Template:";
+	const DATA_SUFFIX = "/Data";
+	const INDEX_PAGES = [
+		"GE Common Trade Index",  "GE Discontinued Rare Index",  "GE Food Index",  "GE Herb Index",  "GE Log Index",
+		"GE Metal Index", "GE Rune Index"
+	];
+	const GRAND_EXCHANGE_PRICES_PAGE = "Module:GEPrices/data";
+
+	private $runescapeApi;
+	private $pageFetcher;
+	private $textUpdater;
+	private $allPrices = [];
+	private $botUser;
+
+	// Runescape provides the trade count for the top 100 most traded items.
+	// When updating the price for those items, we'll also update their trade count
+	private $topItemsTradeCount = [];
+
+	public function __construct() {
+		parent::__construct();
+		$this->runescapeApi = new RunescapeApi();
+		$this->pageFetcher = new GrandExchangePageFetcher();
+		$this->textUpdater = new RawTextUpdater();
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function execute() {
+		$this->botUser = User::newFromName( self::BOT_USERNAME );
+		$this->topItemsTradeCount = $this->runescapeApi->getTopItems();
+
+		$pages = $this->pageFetcher->fetchAllGrandExchangePages();
+		foreach ( $pages as $page) {
+			try {
+				$this->updatePricePagesForArticle( $page );
+			} catch	( Exception $e ) {
+				$this->logError( $e->getMessage(), [ 'page' => $page ] );
+			} finally {
+				$this->pauseExecutionMomentarily();
+			}
+		}
+
+		$this->updatePricesPage();
+		$this->updateIndexPages();
+	}
+
+	/**
+	 * @param $pageTitle
+	 * @throws MWException
+	 * @throws Exception
+	 */
+	private function updatePricePagesForArticle( $pageTitle ) {
+		$modulePage = $this->getWikiPageForTitle( $this->getModulePageTitle( $pageTitle ) );
+		$dataPage = $this->getWikiPageForTitle( $this->getDataPageTitle( $pageTitle ) );
+		$itemId = $this->getItemId( $modulePage->getRawText() );
+		$grandExchangeItem = $this->runescapeApi->getItemId( $itemId );
+
+		$this->updateModulePage( $modulePage, $grandExchangeItem );
+		$this->updateDataPage( $dataPage, $grandExchangeItem );
+
+		$this->appendPriceToAllPricesArray( $pageTitle, $grandExchangeItem->getPrice() );
+	}
+
+	private function getModulePageTitle( $pageTitle ) {
+		return self::MODULE_PREFIX . $pageTitle;
+	}
+
+	private function getDataPageTitle( $pageTitle ) {
+		return self::MODULE_PREFIX . $pageTitle . self::DATA_SUFFIX;
+	}
+
+	/**
+	 * @param WikiPage $modulePage
+	 * @param GrandExchangeItem $grandExchangeItem
+	 * @throws MWException
+	 * @throws Exception
+	 */
+	private function updateModulePage( WikiPage $modulePage, GrandExchangeItem $grandExchangeItem ) {
+		$newText = $this->textUpdater->updateModuleText(
+			$modulePage->getRawText(),
+			$grandExchangeItem,
+			$this->topItemsTradeCount[$grandExchangeItem->getId()] ?? null
+		);
+		$this->updatePageLoggingResult( $modulePage, $newText, "Updating price" );
+	}
+
+	/**
+	 * @param WikiPage $dataPage
+	 * @param GrandExchangeItem $grandExchangeItem
+	 * @throws MWException
+	 */
+	private function updateDataPage( WikiPage $dataPage, GrandExchangeItem $grandExchangeItem ) {
+		$newText = $this->textUpdater->updateDataText(
+			$dataPage->getRawText(),
+			$grandExchangeItem,
+			$this->topItemsTradeCount[$grandExchangeItem->getId()] ?? null
+		);
+		$this->updatePageLoggingResult( $dataPage, $newText, "Updating price data" );
+	}
+
+	/**
+	 * @throws MWException
+	 */
+	private function updatePricesPage() {
+		$this->appendPriceToAllPricesArray( self::BOT_USERNAME, $this->getTimeStampForRuneScape() );
+		$joinedPrices = implode ( ",\n", $this->allPrices );
+		$updateString = sprintf("return {\n%s\n}", $joinedPrices);
+		$pricesDataPage = $this->getWikiPageForTitle( self::GRAND_EXCHANGE_PRICES_PAGE );
+
+		$this->updatePageLoggingResult( $pricesDataPage, $updateString, "updating all prices" );
+	}
+
+	/**
+	 * @throws MWException
+	 */
+	private function updateIndexPages() {
+		foreach( self::INDEX_PAGES as $indexPage ) {
+			$this->purgePage( $indexPage );
+			$indexValue = $this->getIndexValuFromTemplatePage( $indexPage );
+			$timeStamp = $this->getTimeStampForRuneScape();
+			$indexDataPage = $this->getWikiPageForTitle( $this->getDataTitleForIndexPage( $indexPage ) );
+			$item = new GrandExchangeItem( $timeStamp, $indexValue, -1 );
+			$this->updateDataPage( $indexDataPage, $item );
+		}
+	}
+
+	/**
+	 * @param $pageTitle
+	 * @throws MWException
+	 */
+	private function purgePage( $pageTitle ) {
+		$this->getWikiPageForTitle( $pageTitle )->doPurge();
+	}
+
+	/**
+	 * @param $page
+	 * @return mixed
+	 * @throws MWException
+	 */
+	private function getIndexValuFromTemplatePage( $page ) {
+		$templatePage = $this->getWikiPageForTitle( $this->getTemplateTitle( $page ) );
+		return $this->extractIndexFromParsedContent( $templatePage );
+	}
+
+	private function getTemplateTitle( $pageTitle ) {
+		return self::TEMPLATE_PREFIX . $pageTitle;
+	}
+
+	private function extractIndexFromParsedContent( WikiPage $wikiPage ) {
+		$parsedContent = $wikiPage->getParserOutput( $wikiPage->makeParserOptions( $this->botUser ) )->mText;
+		$matches = [];
+		preg_match( "/^([\d\.]+)/", $parsedContent, $matches );
+		return $matches[1];
+	}
+
+	private function getTimeStampForRuneScape() {
+		try {
+			return $this->runescapeApi->getItemId( $this->getFirstItemIdFromTop100Items() )->getTimeStamp();
+		} catch (Exception $e) {
+			$this->logError( "unable to fetch timestamp from runescape, using default", null );
+			return time();
+		}
+	}
+
+	private function getDataTitleForIndexPage( $indexPage ) {
+		return self::MODULE_PREFIX . preg_replace( "/^GE /", "", $indexPage ) . self::DATA_SUFFIX;
+	}
+
+	private function getFirstItemIdFromTop100Items() {
+		return array_keys( $this->topItemsTradeCount )[0];
+	}
+
+	/**
+	 * @param $pageTitle
+	 * @return WikiPage
+	 * @throws MWException
+	 */
+	private function getWikiPageForTitle( $pageTitle ) {
+		return new WikiPage( Title::newFromText( $pageTitle ) );
+	}
+
+	/**
+	 * @param $rawText
+	 * @return mixed
+	 * @throws Exception
+	 */
+	private function getItemId( $rawText ) {
+		$matches = [];
+		preg_match( "/itemId\s*= (\d+)/", $rawText, $matches );
+		if ( count( $matches ) !== 2 ) {
+			throw new Exception( "Unable to parse id from wikipage" );
+		}
+
+		return $matches[1];
+	}
+
+	private function appendPriceToAllPricesArray(string $pageTitle, string $price ) {
+		$this->allPrices[] = $this->formatAllPricesString( $pageTitle, $price );
+	}
+
+	private function formatAllPricesString(  string $pageTitle, string $price  ) {
+		$normalizedTitle = str_replace( "_", " ", str_replace( "'", "\\'", $pageTitle ) );
+		return sprintf( "  ['%s'] = %s", $normalizedTitle, $price );
+	}
+
+	private function updatePageLoggingResult( WikiPage $page, $pageText, $summary ) {
+		$pageContext = [ "page" => $page->getTitle()->getPrefixedDBkey() ];
+		try {
+			$result = $page->doEdit( $pageText, $summary, EDIT_FORCE_BOT, false, $this->botUser );
+			if ( $result->isGood() )  {
+				$this->logInfo( "successfully updated page", $pageContext );
+			} else {
+				$this->logError( "unable to update page", $pageContext );
+			}
+		} catch ( MWException $e ) {
+			$errorContext = [ "exception" => $e ];
+			$this->logError( "error updating page", array_merge( $pageContext, $errorContext ) );
+		}
+	}
+
+	private function logError( string $errorMessage,  $context = [] ) {
+		$message = sprintf( self::LOG_MESSAGE_TEMPLATE, $errorMessage );
+		$this->output( $message . ": " . $context['page'] . "\n" );
+		Wikia\Logger\WikiaLogger::instance()->warning(
+			$message,
+			$context
+		);
+	}
+
+	private function logInfo( $infoMessage, $context = [] ) {
+		$message = sprintf( self::LOG_MESSAGE_TEMPLATE, $infoMessage );
+		$this->output( $message . ": " . $context['page'] . "\n" );
+		Wikia\Logger\WikiaLogger::instance()->info(
+			$message,
+			$context
+		);
+	}
+
+	/**
+	 * We're hitting runescape's API for every page we're updating. Rate limit ourselves to be nice about it.
+	 */
+	private function pauseExecutionMomentarily() {
+		sleep( self::PAUSE_TIME_IN_SECONDS );
+	}
+}
+
+
+$maintClass = 'UpdateGrandExchangeItemPrices';
+require_once RUN_MAINTENANCE_IF_MAIN;


### PR DESCRIPTION
Ticket: https://wikia-inc.atlassian.net/browse/IW-1233

This PR replicates a price update bot which used to exist on the runescape and oldschoolrunescape wikis. The bot queries for all items which need to be updated (those in the "Grand Exchange" category), fetches the latest price info for those items from the Jagex API (Jagex is the creator of Runescape), and updates the Module:Exchange/\<itemName\> and Module:Exchange/\<itemName\>/Data pages with the new price info. Additionally, it updates Module:GEPrices/data page (which is a list of all items and their latest prices), and a series of index pages.

It's based on the old TyBot which was an admin created and maintained bot which updates prices in the same way. After the fork on October 2nd, that bot was moved to the new wikis and removed from our wikis. This code recreates it's functionality so items on our wikis have up-to-date pricing information again.