### PR TITLE
ADEN-7888 Check adContext.opts.incontentPlayerRail first.

### DIFF
--- a/extensions/wikia/AdEngine/js/template/porvata.js
+++ b/extensions/wikia/AdEngine/js/template/porvata.js
@@ -140,7 +140,7 @@ define('ext.wikia.adEngine.template.porvata', [
 					params.blockOutOfViewportPausing = params.fallbackBidBlockOutOfViewportPausing;
 				}
 				if (typeof params.fallbackBidEnableInContentFloating !== 'undefined') {
-					params.enableInContentFloating = params.fallbackBidEnableInContentFloating;
+					params.enableInContentFloating = adContext.opts.incontentPlayerRail || params.fallbackBidEnableInContentFloating;
 				}
 				if (typeof params.fallbackBidEnableLeaderboardFloating !== 'undefined') {
 					params.enableLeaderboardFloating = params.fallbackBidEnableLeaderboardFloating;


### PR DESCRIPTION
Incontent player flag should force outstream in rail even if bidder
has floating configured to false.