### PR TITLE
SUS-6170 | SharedHelp - use MediaWiki HTTP client and get rid of no longer needed handling of shared help source wiki article redirects

### DIFF
--- a/extensions/wikia/SharedHelp/SharedHelp.php
+++ b/extensions/wikia/SharedHelp/SharedHelp.php
@@ -107,8 +107,6 @@ function SharedHelpHook( OutputPage $out, string &$text ): bool {
 		} else {# If getting content from memcache failed (invalidate) then just download it via HTTP
 			$urlTemplate = $sharedServer . $sharedScript . "?title=Help:%s&action=render";
 			$articleUrl = sprintf( $urlTemplate, urlencode( $title->getDBkey() ) );
-
-			/* @var MWHttpRequest $resp */
 			$content = Http::get( $articleUrl );
 
 			if ( $content === false ) {

--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -3414,7 +3414,7 @@ class WikiFactory {
 	 * get environment-ready url from city_id
 	 * @param int $city_id	wiki id
 	 * @param boolean $master	use master or slave connection
-	 * @return url in city_list with sandbox/devbox subdomain added if needed
+	 * @return string url in city_list with sandbox/devbox subdomain added if needed
 	 */
 	static public function cityIDtoUrl( $city_id, $master = false ) {
 		if ( !static::isUsed() ) {
@@ -3432,7 +3432,7 @@ class WikiFactory {
 	 *
 	 * @param int $city_id	wiki id
 	 * @param boolean $master	use master or slave connection
-	 * @return city domain
+	 * @return string city domain
 	 */
 	static public function cityIDtoDomain( $city_id, $master = false ) {
 		$url = static::cityIDtoUrl( $city_id, $master );


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-6170

SharedHelp uses `WikiFactory::cityIDtoUrl` method to build a URL used to fetch shared help articles from Community Wiki. This method takes environment into consideration, e.g. returns community.preview.wikia.com when this code is executed on preview.

Because of the use of a custom HTTP client that forced a HTTP proxy set to localhost:80 this request was returning HTTP 302 for such requests (a redirect to "Not a valid community" page).

SharedHelp did not work on environments different than production and devboxes for quite a while.

Let's use MediaWiki's built-in HTTP client and clean up the SharedHelp code. We no longer need to handle article redirects there - API handles that for us.

