### PR TITLE
SUS-6077 | CloseWikiMaintenance - handle empty sub-buckets on DFS

### DIFF
--- a/extensions/wikia/WikiFactory/Close/maintenance.php
+++ b/extensions/wikia/WikiFactory/Close/maintenance.php
@@ -348,9 +348,6 @@ class CloseWikiMaintenance {
 		$time = Wikia::timeDuration( wfTime() - $time );
 		$this->debug( "Rsync to {$directory} from {$container} Swift storage: status: time: {$time}" );
 
-		/**
-		 * @name dumpfile
-		 */
 		$tarfile = sprintf( "/tmp/{$dbname}_images.tar" );
 		if( file_exists( $tarfile ) ) {
 			@unlink( $tarfile );
@@ -381,7 +378,10 @@ class CloseWikiMaintenance {
 		}
 		else {
 			$this->info( "List of files in {$directory} is empty" );
-			throw new WikiaException( "List of files in {$directory} is empty" );
+
+			// SUS-6077 | sub-bucket is empty, e.g. foo bucket is not empty,
+			// but bucket/<lang>  can be
+			return false;
 		}
 
 		// SUS-4325 | CloseWikiMaintenance should remove directories with images after tar file is created


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-6077

"foo" DFS bucket is not empty, but "bucket/<lang>" can be. Do not treat such cases as errors.

```
November 7th 2018, 11:18:36.537	List of files in /tmp/images/nluniversum/ is empty	 -
November 7th 2018, 11:18:36.537	WikiaException	List of files in /tmp/images/nluniversum/ is empty
November 7th 2018, 11:18:36.534	Rsyncing images from "universum/nl" Swift storage to "/tmp/images/nluniversum/"...	 -
November 7th 2018, 11:18:36.506	Dumping images on remote host
```