### PR TITLE
SUS-6166: PHP session handling broken on Kubernetes

### DIFF
--- a/includes/Wiki.php
+++ b/includes/Wiki.php
@@ -441,23 +441,13 @@ class MediaWiki {
 	 * If possible this method will be executed only after the response has been flushed.
 	 */
 	public function restInPeace() {
-		// SUS-6164 | move emitting of profiling data before fastcgi_finish_request is called
-		wfLogProfilingData();
-
-		// If using FastCGI we can flush the output now and do any further updates without blocking
-		if ( function_exists( 'fastcgi_finish_request' ) ) {
-			fastcgi_finish_request();
-		} else {
-			// Either all DBs should commit or none
-			ignore_user_abort( true );
-		}
-
 		// Do any deferred jobs
 		DeferredUpdates::doUpdates();
 
 		Hooks::run( 'RestInPeace' ); // Wikia change - @author macbre
 
 		MessageCache::logMessages();
+		wfLogProfilingData();
 
 		// Commit and close up!
 		$factory = wfGetLBFactory();


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-6166

Because we were calling` fastcgi_finish_request()` client received a response before the request fully completed on the backend side. The session data was not yet saved before the next request from the client hit the backend. The second request had the outdated session data.

This caused an issue with notifications that are handled using PHP session.

Partially revert 7900bd05fdd788930af2b9c9ee69e290e482b5d4