### PR TITLE
SUS-6189 | /opensearch_desc.php not handled by Kubernetes on wikis with language path

### DIFF
--- a/docker/base/base.inc
+++ b/docker/base/base.inc
@@ -30,7 +30,7 @@ if ($arg_func) {
     rewrite ^(.*)$ $1?action=lyrics last;
 }
  # SUS-6154
-rewrite "^/(?:[a-z]{2,3}(?:-[a-z-]{2,12})?/)?(index|load|metrics|wikia).php(.*)" /$1.php$2 break;
+rewrite "^/(?:[a-z]{2,3}(?:-[a-z-]{2,12})?/)?(index|load|metrics|opensearch_desc|wikia).php(.*)" /$1.php$2 break;
 
 # article URL
 rewrite "^/(?:[a-z]{2,3}(?:-[a-z-]{2,12})?/)?wiki/(.*)" /index.php?title=$1 break;


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-6189

### Before the fix

```
$ curl -svo /dev/null 'http://poznan.dev.wikia-local.com/opensearch_desc.php' -L 2>&1 | egrep 'HTTP|Location'
> GET /opensearch_desc.php HTTP/1.1
< HTTP/1.1 301 Moved Permanently
< Location: http://poznan.dev.wikia-local.com/pl/opensearch_desc.php

> GET /pl/opensearch_desc.php HTTP/1.1
< HTTP/1.1 301 Moved Permanently
< Location: http://poznan.dev.wikia-local.com/pl/wiki/Pl/opensearch_desc.php

> GET /pl/wiki/Pl/opensearch_desc.php HTTP/1.1
< HTTP/1.1 404 Not Found
```

### After the fix

```
$ curl -sv 'http://poznan.dev.wikia-local.com/opensearch_desc.php' -L 2>&1 | egrep 'HTTP|Location|Redirect|Content'
> GET /opensearch_desc.php HTTP/1.1
< HTTP/1.1 301 Moved Permanently
< Content-Type: text/html; charset=UTF-8
< X-Content-Type-Options: nosniff
< X-Redirected-By-WF: NotPrimary
< Location: http://poznan.dev.wikia-local.com/pl/opensearch_desc.php

> GET /pl/opensearch_desc.php HTTP/1.1
< HTTP/1.1 200 OK
< Content-Type: application/opensearchdescription+xml
< Content-Length: 740
< X-Content-Type-Options: nosniff
```