### PR TITLE
(SEO-697) Prevent magic words in nav links creating links to 404s

### DIFF
--- a/includes/wikia/models/NavigationModel.class.php
+++ b/includes/wikia/models/NavigationModel.class.php
@@ -516,6 +516,8 @@ class NavigationModel extends WikiaModel {
 					$node[self::TEXT] = wfMsg( trim( $node[self::ORIGINAL], ' *' ) );
 				}
 
+				$node[self::HREF] = '#';
+
 				$fname = $this->extraWordsMap[$extraWord];
 				$data = DataProvider::$fname();
 				//http://bugs.php.net/bug.php?id=46322 count(false) == 1


### PR DESCRIPTION
/cc @Wikia/core-platform-team 