### PR TITLE
SUS-6077 | refactor CloseWikiMaintenance to use Maintenance core-MediaWiki class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ services:
   - rabbitmq
 install:
   - pecl channel-update pecl.php.net
-  - pecl install uopz mustache
+  - pecl install uopz-5.0.2 mustache-0.7.4
 before_script:
   # make sure indices are upgraded, see https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-23.html#mysqld-5-7-23-bug
   - sudo mysql_upgrade

--- a/docker/prod/alerting.yaml
+++ b/docker/prod/alerting.yaml
@@ -20,3 +20,11 @@ spec:
         description: UpdateSpecialPages maintenance script did not run in the last 24 hours
         summary: UpdateSpecialPages last succeeded {{humanizeDuration $value}} ago
         graphs: https://metrics.wikia-inc.com/d/Lpjst60mk/celery-mediawiki-tasks
+    # SUS-6077 | Close wikis queue not being consumed
+    - alert: mediawiki_maintenance_scripts_CloseWikiMaintenance_last_run
+      expr: time() - max(mediawiki_mediawiki_maintenance_scripts_last_success{env="prod", script_class="CloseWikiMaintenance"}) > 86400 * 2
+      labels:
+        team: sus
+      annotations:
+        description: CloseWikiMaintenance maintenance script did not run in the last 48 hours
+        summary: CloseWikiMaintenance last succeeded {{humanizeDuration $value}} ago

--- a/extensions/wikia/WikiFactory/Close/README.md
+++ b/extensions/wikia/WikiFactory/Close/README.md
@@ -1,11 +1,7 @@
 Close
 =====
 
-This code generates backups and closes wikis marked to be closed via WikiFactory.
-
-`/extensions/wikia/WikiFactory/Close/maintenance.php` script is run every day on `cron-s1`.
-
-Logs can be found on `cron-s1` in ` /var/log/crons/closeMarkedWikis.log`.
+This code generates backups and closes wikis marked to be closed via WikiFactory. `/extensions/wikia/WikiFactory/Close/maintenance.php` script is run every day.
 
 ### SQL query
 
@@ -17,6 +13,21 @@ mysql@geo-db-sharedb-slave.query.consul[wikicities]>select count(*) from city_li
 |       80 |
 +----------+
 1 row in set (0.17 sec)
+
+--
+
+mysql@geo-db-sharedb-slave.query.consul[wikicities]>select count(*), city_additional from city_list where city_public IN (0 /* close */, -1 /* hide */) and city_flags NOT IN (0, 32 /* redirect */, 512 /* do not close */) and city_last_timestamp < now() - interval 31 day group by 2 order by 1 desc;
++----------+------------------------------------------------------------------------------------------------------------------------+
+| count(*) | city_additional                                                                                                        |
++----------+------------------------------------------------------------------------------------------------------------------------+
+|     1057 | Marked for removal by RemoveQAWikis maintenance script                                                                 
+|      739 | dead wiki                                                                                                              |
+|        4 | -                                                                                                                      |
+|        2 | Fetish wiki                                                                                                            |
+|        1 | zd#415043                                                                                                              |
+|        1 | Marked in Spam wiki review tool as SPAM by user: 36838069                                                             |
+|        1 | https://wikia.zendesk.com/agent/tickets/414900                                                                         |
+...
 ```
 
 We add ~200 wikis each day to the queue of wikis to delete. The check above **ignores QA test wikis**.

--- a/extensions/wikia/WikiFactory/Close/maintenance.php
+++ b/extensions/wikia/WikiFactory/Close/maintenance.php
@@ -113,7 +113,7 @@ class CloseWikiMaintenance extends Maintenance {
 			$folder   = WikiFactory::getVarValueByName( "wgUploadDirectory", $cityid );
 
 			if ( $this->hasOption( 'dry-run' ) ) {
-				$this->output( sprintf("Wiki #%d (%s) will be removed - %s\n",
+				$this->output( sprintf("DRY-RUN: Wiki #%d (%s) is marked to be removed - %s\n",
 					$cityid, $dbname, $row->city_additional ?: 'n/a' ) );
 				continue;
 			}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-6077

Stop using a custom maintenance script and use Maintenance class that handles monitoring out of the box.
