### PR TITLE
SRE-109 | Use User::touch instead of User::invalidateCache where appropriate

### DIFF
--- a/extensions/wikia/AchievementsII/services/AchAwardingService.class.php
+++ b/extensions/wikia/AchievementsII/services/AchAwardingService.class.php
@@ -288,8 +288,9 @@ class AchAwardingService {
 				}
 			}
 
-			//touch user when badges are given
-			$this->mUser->invalidateCache();
+			// Bust article ETags for this user, to ensure they see the updated set of badges on their profile
+			// SRE-109: Use touch() to avoid needless DB queries; it's sufficient as per r59993
+			$this->mUser->touch();
 
 			//purge the user page to update counters/ranking/badges/score, FB#2872
 			$this->mUser->getUserPage()->purgeSquid();

--- a/extensions/wikia/Blogs/BlogArticle.php
+++ b/extensions/wikia/Blogs/BlogArticle.php
@@ -609,7 +609,10 @@ class BlogArticle extends Article {
 				$oWItem = WatchedItem::fromUserTitle( $oUser, $oCommentTitle );
 				$oWItem->removeWatch();
 			}
-			$oUser->invalidateCache();
+
+			// Bust article ETags for this user, to ensure that "unwatch" links change to "watch" links
+			// SRE-109: Use touch() to avoid needless DB queries; it's sufficient as per r59993
+			$oUser->touch();
 		}
 
 		wfProfileOut( __METHOD__ );

--- a/includes/User.php
+++ b/includes/User.php
@@ -1993,7 +1993,9 @@ class User implements JsonSerializable {
 		// Wikia change - end
 
 		if ( $changed ) {
-			$this->invalidateCache();
+			// Bust article ETags for this user, to ensure they receive the message notification
+			// SRE-109: Use touch() to avoid needless DB queries; it's sufficient as per r59993
+			$this->touch();
 		}
 	}
 
@@ -2912,7 +2914,10 @@ class User implements JsonSerializable {
 	public function addWatch( $title ) {
 		$wl = WatchedItem::fromUserTitle( $this, $title );
 		$wl->addWatch();
-		$this->invalidateCache();
+
+		// Bust article ETags for this user, to ensure that "watch" links change to "unwatch" links
+		// SRE-109: Use touch() to avoid needless DB queries; it's sufficient as per r59993
+		$this->touch();
 	}
 
 	/**
@@ -2922,7 +2927,10 @@ class User implements JsonSerializable {
 	public function removeWatch( $title ) {
 		$wl = WatchedItem::fromUserTitle( $this, $title );
 		$wl->removeWatch();
-		$this->invalidateCache();
+
+		// Bust article ETags for this user, to ensure that "unwatch" links change to "watch" links
+		// SRE-109: Use touch() to avoid needless DB queries; it's sufficient as per r59993
+		$this->touch();
 	}
 
 	/**

--- a/includes/specials/SpecialEditWatchlist.php
+++ b/includes/specials/SpecialEditWatchlist.php
@@ -128,7 +128,10 @@ class SpecialEditWatchlist extends UnlistedSpecialPage {
 			$toUnwatch = array_diff( $current, $wanted );
 			$this->watchTitles( $toWatch );
 			$this->unwatchTitles( $toUnwatch );
-			$this->getUser()->invalidateCache();
+
+			// Bust article ETags for this user, to ensure that "watch" links change to "unwatch" links, and vice versa
+			// SRE-109: Use touch() to avoid needless DB queries; it's sufficient as per r59993
+			$this->getUser()->touch();
 
 			if( count( $toWatch ) > 0 || count( $toUnwatch ) > 0 ){
 				$this->successMessage = $this->msg( 'watchlistedit-raw-done' )->parse();
@@ -149,7 +152,10 @@ class SpecialEditWatchlist extends UnlistedSpecialPage {
 			}
 		} else {
 			$this->clearWatchlist();
-			$this->getUser()->invalidateCache();
+
+			// Bust article ETags for this user, to ensure that "unwatch" links change to "watch" links
+			// SRE-109: Use touch() to avoid needless DB queries; it's sufficient as per r59993
+			$this->getUser()->touch();
 
 			if( count( $current ) > 0 ){
 				$this->successMessage = $this->msg( 'watchlistedit-raw-done' )->parse();


### PR DESCRIPTION
Several times, the method `User::invalidateCache` is called in the code when it's necessary to bust article ETags for the current user to ensure they are served properly updated content (e.g. "watch this page" links should change to "unwatch this page" after the user added the page to their watchlist). However, it's sufficient to just call `User::touch` to accomplish this; `User::invalidateCache` has some expensive side effects such as forcing permissions cache recalculation, which we do not need in this context.

See also [r59993](https://www.mediawiki.org/wiki/Special:Code/MediaWiki/59993#c4885) for a relevant discussion.

https://wikia-inc.atlassian.net/browse/SRE-109