### PR TITLE
SRE-109: Disable automatic transactions for external DBs like blobs cluster

### DIFF
--- a/includes/wikia/VariablesExpansions.php
+++ b/includes/wikia/VariablesExpansions.php
@@ -347,6 +347,10 @@ $wgLBFactoryConf = [
         'blobs20132' => [ 'dbname' => 'blobs20132' ],
         'blobs20141' => [ 'dbname' => 'blobs20141' ],
     ],
+	'externalTemplateOverrides' => [
+		// SRE-109: Disable automatic transactions for external DBs like blobs cluster
+		'flags' => 0,
+	],
 ];
 
 /**


### PR DESCRIPTION
Remove automatic transactions for external DBs (our blobs cluster). It causes redundant transaction related queries to be sent for each write there.

See also https://github.com/wikimedia/operations-mediawiki-config/blob/master/wmf-config/db-codfw.php#L694

https://wikia-inc.atlassian.net/browse/SRE-109