### PR TITLE
SRE-109 | Make edit flow logic smarter

### DIFF
--- a/includes/WikiPage.php
+++ b/includes/WikiPage.php
@@ -1003,6 +1003,12 @@ class WikiPage extends Page implements IDBAccessObject {
 			$conditions['page_latest'] = $lastRevision;
 		}
 
+		// SRE-109: If the page has no previous revision (we're creating a new page)
+		// then the previous revision could not have been a redirect so there is no need to check for it
+		if ( $lastRevision === 0 ) {
+			$lastRevIsRedirect = false;
+		}
+
 		// Wikia change - begin
 		/**
 		 * PLATFORM-1311: page_latest can be set to zero only during page creation
@@ -1327,12 +1333,6 @@ class WikiPage extends Page implements IDBAccessObject {
 			$summary = self::getAutosummary( $oldtext, $text, $flags );
 		}
 
-		// <Wikia>
-		if ( is_string( $user ) ) {
-			error_log( "MOLI: " . __METHOD__ . ": invalid User : " . print_r( $user, true ) );
-			Wikia::debugBacktrace( "MOLI: invalid User:" );
-		}
-		// </Wikia>
 		$editInfo = $this->prepareTextForEdit( $text, null, $user );
 		$text = $editInfo->pst;
 		$newsize = strlen( $text );
@@ -1485,7 +1485,11 @@ class WikiPage extends Page implements IDBAccessObject {
 				'text'       => $text,
 				'user'       => $user->getId(),
 				'user_text'  => $user->getName(),
-				'timestamp'  => $now
+				'timestamp'  => $now,
+
+				// SRE-109: We're creating a page so we know that the first revision will have no parents
+				// Not setting it explicitly will cause a pointless lookup on the master database
+				'parent_id'  => 0,
 			) );
 
 			try {


### PR DESCRIPTION
* Pass an explicit `parent_id` of 0 to `Revision` when we're creating a page. Otherwise `Revision` would go looking for the parent on the master & would never find anything (since the page doesn't exist yet).
* Make `WikiPage::updateRevisionOn` eschew a `DELETE` that would try to remove entries from the redirect table if we're creating a page (since there can be no previous revisions and so no redirect table entries in that case).

https://wikia-inc.atlassian.net/browse/SRE-109