### PR TITLE
SRE-109 | Prefer reading data from replicas rather than master during edit

### DIFF
--- a/extensions/wikia/FounderEmails/events/FounderEmailsEditEvent.class.php
+++ b/extensions/wikia/FounderEmails/events/FounderEmailsEditEvent.class.php
@@ -318,23 +318,15 @@ class FounderEmailsEditEvent extends FounderEmailsEvent {
 			$wasNotificationSent = ( static::getFirstEmailSentFlag( $editor->getName() ) === '1' ) ;
 
 			if ( !$wasNotificationSent ) {
-				$userEditStatus = static::getUserEditsStatus( $editor, true );
-				/*
-					If there is at least one edit, flag that we should not send this email anymore;
-					either first email is sent out as a result of this request,
-					or there was more than 1 edit so we will never need to send it again
-				 */
-				switch ( $userEditStatus ) {
-					case self::NO_EDITS:
-						return true;
-						break;
-					case self::FIRST_EDIT:
-						$isRegisteredUserFirstEdit = true;
-						static::setFirstEmailSentFlag( $editor->getName() );
-						break;
-					case self::MULTIPLE_EDITS:
-						static::setFirstEmailSentFlag( $editor->getName() );
-				}
+				$service = new UserStatsService( $editorId );
+				$editCount = $service->getEditCountWiki();
+
+				$isRegisteredUserFirstEdit = ( $editCount === 0 );
+
+				// Flag that we should not send this email anymore;
+				// either first email is sent out as a result of this request,
+				// or there was more than 1 edit so we will never need to send it again
+				static::setFirstEmailSentFlag( $editor->getName() );
 			}
 		} else {
 			// Anon user

--- a/includes/EmailNotification.php
+++ b/includes/EmailNotification.php
@@ -185,7 +185,8 @@ class EmailNotification {
 
 	private function getWatchersToNotify( $notificationTimeoutSql ) {
 		$watchers = [];
-		$dbw = wfGetDB( DB_MASTER );
+		// SRE-109: Get the set of users to notify from the slave
+		$dbw = wfGetDB( DB_SLAVE );
 		$res = $dbw->select(
 			[ 'watchlist' ],
 			[ 'wl_user' ],

--- a/includes/LinksUpdate.php
+++ b/includes/LinksUpdate.php
@@ -47,6 +47,12 @@ class LinksUpdate {
 	/**@}}*/
 
 	/**
+	 * slave DB connection handle
+	 * @var DatabaseBase $dbForReads
+	 */
+	private $dbForReads;
+
+	/**
 	 * Constructor
 	 *
 	 * @param $title Title of the page we're updating
@@ -102,6 +108,9 @@ class LinksUpdate {
 		}
 
 		$this->mRecursive = $recursive;
+
+		// SRE-109
+		$this->dbForReads = wfGetDB( DB_SLAVE );
 
 		Hooks::run( 'LinksUpdateConstructed', [ $this ] );
 	}
@@ -322,11 +331,11 @@ class LinksUpdate {
 		}
 		$ids = array();
 
-		$res = $this->mDb->select( 'page', array( 'page_id' ),
+		$res = $this->dbForReads->select( 'page', array( 'page_id' ),
 			array(
 				'page_namespace' => $namespace,
-				'page_title IN (' . $this->mDb->makeList( $dbkeys ) . ')',
-				'page_touched < ' . $this->mDb->addQuotes( $this->mInvalidationTimestamp )
+				'page_title IN (' . $this->dbForReads->makeList( $dbkeys ) . ')',
+				'page_touched < ' . $this->dbForReads->addQuotes( $this->mInvalidationTimestamp )
 			), __METHOD__
 		);
 		foreach ( $res as $row ) {
@@ -763,7 +772,7 @@ class LinksUpdate {
 	 * @return array
 	 */
 	private function getExistingLinks() {
-		$res = $this->mDb->select( 'pagelinks', array( 'pl_namespace', 'pl_title' ),
+		$res = $this->dbForReads->select( 'pagelinks', array( 'pl_namespace', 'pl_title' ),
 			array( 'pl_from' => $this->mId ), __METHOD__, $this->mOptions );
 		$arr = array();
 		foreach ( $res as $row ) {
@@ -781,7 +790,7 @@ class LinksUpdate {
 	 * @return array
 	 */
 	private function getExistingTemplates() {
-		$res = $this->mDb->select( 'templatelinks', array( 'tl_namespace', 'tl_title' ),
+		$res = $this->dbForReads->select( 'templatelinks', array( 'tl_namespace', 'tl_title' ),
 			array( 'tl_from' => $this->mId ), __METHOD__, $this->mOptions );
 		$arr = array();
 		foreach ( $res as $row ) {
@@ -799,7 +808,7 @@ class LinksUpdate {
 	 * @return array
 	 */
 	private function getExistingImages() {
-		$res = $this->mDb->select( 'imagelinks', array( 'il_to' ),
+		$res = $this->dbForReads->select( 'imagelinks', array( 'il_to' ),
 			array( 'il_from' => $this->mId ), __METHOD__, $this->mOptions );
 		$arr = array();
 		foreach ( $res as $row ) {
@@ -814,7 +823,7 @@ class LinksUpdate {
 	 * @return array
 	 */
 	private function getExistingExternals() {
-		$res = $this->mDb->select( 'externallinks', array( 'el_to' ),
+		$res = $this->dbForReads->select( 'externallinks', array( 'el_to' ),
 			array( 'el_from' => $this->mId ), __METHOD__, $this->mOptions );
 		$arr = array();
 		foreach ( $res as $row ) {
@@ -829,7 +838,7 @@ class LinksUpdate {
 	 * @return array
 	 */
 	private function getExistingCategories() {
-		$res = $this->mDb->select( 'categorylinks', array( 'cl_to', 'cl_sortkey_prefix' ),
+		$res = $this->dbForReads->select( 'categorylinks', array( 'cl_to', 'cl_sortkey_prefix' ),
 			array( 'cl_from' => $this->mId ), __METHOD__, $this->mOptions );
 		$arr = array();
 		foreach ( $res as $row ) {
@@ -845,7 +854,7 @@ class LinksUpdate {
 	 * @return array
 	 */
 	private function getExistingInterlangs() {
-		$res = $this->mDb->select( 'langlinks', array( 'll_lang', 'll_title' ),
+		$res = $this->dbForReads->select( 'langlinks', array( 'll_lang', 'll_title' ),
 			array( 'll_from' => $this->mId ), __METHOD__, $this->mOptions );
 		$arr = array();
 		foreach ( $res as $row ) {
@@ -859,7 +868,7 @@ class LinksUpdate {
 	 * @return array (prefix => array(dbkey => 1))
 	 */
 	protected function getExistingInterwikis() {
-		$res = $this->mDb->select( 'iwlinks', array( 'iwl_prefix', 'iwl_title' ),
+		$res = $this->dbForReads->select( 'iwlinks', array( 'iwl_prefix', 'iwl_title' ),
 			array( 'iwl_from' => $this->mId ), __METHOD__, $this->mOptions );
 		$arr = array();
 		foreach ( $res as $row ) {
@@ -877,7 +886,7 @@ class LinksUpdate {
 	 * @return array
 	 */
 	private function getExistingProperties() {
-		$res = $this->mDb->select( 'page_props', array( 'pp_propname', 'pp_value' ),
+		$res = $this->dbForReads->select( 'page_props', array( 'pp_propname', 'pp_value' ),
 			array( 'pp_page' => $this->mId ), __METHOD__, $this->mOptions );
 		$arr = array();
 		foreach ( $res as $row ) {

--- a/includes/Title.php
+++ b/includes/Title.php
@@ -2117,7 +2117,8 @@ class Title {
 			$errors[] = array( 'confirmedittext' );
 		}
 
-		if ( ( $action == 'edit' || $action == 'create' ) && !$user->isBlockedFrom( $this ) ) {
+		// SRE-109: Check user block from slave instead of reading from master
+		if ( ( $action == 'edit' || $action == 'create' ) && !$user->isBlockedFrom( $this, true /* use slave */ ) ) {
 			// Don't block the user from editing their own talk page unless they've been
 			// explicitly blocked from that too.
 		} elseif( $user->isBlocked() && $user->mBlock->prevents( $action ) !== false ) {


### PR DESCRIPTION
For queries which are not sensitive to state changes made by the edit, we should use replicas rather than the master. If a replica ends up being too far behind, infrastructure will transparently remove it from the pool.

* `FounderEmailsEditEvent` would query master after each edit to determine the user's edit count. However, we're actually only interested in if this was the user's first edit, i.e. is the user's edit count 0 or not 0—we do not care about the exact edit count. For this, we can simply use `UserStatsService` instead, which avoids referred heavy calculation.
* Make `Title::checkUserBlock` read user's block status from a replica instead of the master.
* Make `LinksUpdate` read existing state from a replica instead of the master.
* Made `EmailNotification` get the list of users who are watching a given page from a replica instead of the master.

https://wikia-inc.atlassian.net/browse/SRE-109