### PR TITLE
SUS-6262 | add Prometheus alerting for all maintenance scripts run as cron jobs

### DIFF
--- a/docker/maintenance/init-stat.yaml
+++ b/docker/maintenance/init-stat.yaml
@@ -3,5 +3,5 @@ args:
 - php
 - /usr/wikia/slot1/current/src/maintenance/maintenanceTaskScheduler.php
 - --active=1
-- --params="--noviews --active --update"
+- --params="--active --update"
 - maintenance/initStats.php

--- a/docker/prod/alerting.yaml
+++ b/docker/prod/alerting.yaml
@@ -131,7 +131,6 @@ spec:
         team: sus
       annotations:
         description: Maintenance script that re-initialises wikis statistics table was not run in the last 24 hours
-        summary: InitStats last succeeded {{humanizeDuration $value}} ago
     # CleanupPhalanxStats should be run every week
     - alert: mediawiki_maintenance_scripts_CleanupPhalanxStats_last_run
       expr: time() - max(mediawiki_mediawiki_maintenance_scripts_last_success{env="prod", script_class="CleanupPhalanxStats"}) > 86400 * 8
@@ -140,3 +139,11 @@ spec:
       annotations:
         description: Maintenance script that removes old specials.phalanx_stats entries was not run in the last 7 days
         summary: CleanupPhalanxStats last succeeded {{humanizeDuration $value}} ago
+    # LyricsWikiCrawler should be run every week
+    - alert: mediawiki_maintenance_scripts_LyricsWikiCrawler_last_run
+      expr: time() - max(mediawiki_mediawiki_maintenance_scripts_last_success{env="prod", script_class="LyricsWikiCrawler"}) > 3600 * 25
+      labels:
+        team: sus
+      annotations:
+        description: Maintenance script tht is responsible for scribing Lyrics wikia articles was not run in the last 24 hours
+        summary: LyricsWikiCrawler last succeeded {{humanizeDuration $value}} ago

--- a/docker/prod/alerting.yaml
+++ b/docker/prod/alerting.yaml
@@ -164,7 +164,7 @@ spec:
         description: Maintenance script that is responsible for scribing Lyrics wikia articles was not run in the last 24 hours
         summary: LyricsWikiCrawler last succeeded {{humanizeDuration $value}} ago
     # AutomatedDeadWikisDeletionMaintenance should be run every 24h (excluding Friday and weekends)
-    - alert: mediawiki_maintenance_scripts_LyricsWikiCrawler_last_run
+    - alert: mediawiki_maintenance_scripts_AutomatedDeadWikisDeletionMaintenance_last_run
       expr: time() - max(mediawiki_mediawiki_maintenance_scripts_last_success{env="prod", script_class="AutomatedDeadWikisDeletionMaintenance"}) > 86400 * 4
       labels:
         team: sus

--- a/docker/prod/alerting.yaml
+++ b/docker/prod/alerting.yaml
@@ -36,3 +36,91 @@ spec:
       annotations:
         description: Starter wikis XML and SQL dumps were not updated in the last 24 hours
         summary: DumpStarters last succeeded {{humanizeDuration $value}} ago
+    # CleanupCityCreationLog should be run every 24h
+    - alert: mediawiki_maintenance_scripts_CleanupCityCreationLog_last_run
+      expr: time() - max(mediawiki_mediawiki_maintenance_scripts_last_success{env="prod", script_class="CleanupCityCreationLog"}) > 3600 * 25
+      labels:
+        team: sus
+      annotations:
+        description: CleanupCityCreationLog maintenance script did not run in the last 24 hours
+        summary: CleanupCityCreationLog last succeeded {{humanizeDuration $value}} ago
+    # CleanUpWallNotifications should be run every 24h
+    - alert: mediawiki_maintenance_scripts_CleanUpWallNotifications_last_run
+      expr: time() - max(mediawiki_mediawiki_maintenance_scripts_last_success{env="prod", script_class="CleanUpWallNotifications"}) > 3600 * 25
+      labels:
+        team: sus
+      annotations:
+        description: CleanUpWallNotifications maintenance script did not run in the last 24 hours
+        summary: CleanUpWallNotifications last succeeded {{humanizeDuration $value}} ago
+    # CloseMyAccountMaintenance should be run every 24h
+    - alert: mediawiki_maintenance_scripts_CloseMyAccountMaintenance_last_run
+      expr: time() - max(mediawiki_mediawiki_maintenance_scripts_last_success{env="prod", script_class="CloseMyAccountMaintenance"}) > 3600 * 25
+      labels:
+        team: sus
+      annotations:
+        description: CloseMyAccountMaintenance maintenance script did not run in the last 24 hours
+        summary: CloseMyAccountMaintenance last succeeded {{humanizeDuration $value}} ago
+    # ContentReviewStatus should be run every 3h
+    - alert: mediawiki_maintenance_scripts_ContentReviewStatus_last_run
+      expr: time() - max(mediawiki_mediawiki_maintenance_scripts_last_success{env="prod", script_class="ContentReviewStatus"}) > 3600 * 4
+      labels:
+        team: sus
+      annotations:
+        description: "ContentReviewStatus should post a message on #js-review-tool Slack channel every three hours"
+        summary: ContentReviewStatus last succeeded {{humanizeDuration $value}} ago
+    # DeleteArticlesByPrefix should be run every 24h
+    - alert: mediawiki_maintenance_scripts_DeleteArticlesByPrefix_last_run
+      expr: time() - max(mediawiki_mediawiki_maintenance_scripts_last_success{env="prod", script_class="DeleteArticlesByPrefix"}) > 3600 * 25
+      labels:
+        team: sus
+      annotations:
+        description: DeleteArticlesByPrefix maintenance script did not run in the last 24 hours
+        summary: DeleteArticlesByPrefix last succeeded {{humanizeDuration $value}} ago
+    # FounderEmailsMaintenance should be run every 24h
+    - alert: mediawiki_maintenance_scripts_FounderEmailsMaintenance_last_run
+      expr: time() - max(mediawiki_mediawiki_maintenance_scripts_last_success{env="prod", script_class="FounderEmailsMaintenance"}) > 3600 * 25
+      labels:
+        team: sus
+      annotations:
+        description: FounderEmailsMaintenance maintenance script did not run in the last 24 hours
+        summary: FounderEmailsMaintenance last succeeded {{humanizeDuration $value}} ago
+    # MigratePhalanxUserBlocks should be run every 24h
+    - alert: mediawiki_maintenance_scripts_MigratePhalanxUserBlocks_last_run
+      expr: time() - max(mediawiki_mediawiki_maintenance_scripts_last_success{env="prod", script_class="MigratePhalanxUserBlocks"}) > 3600 * 25
+      labels:
+        team: sus
+      annotations:
+        description: MigratePhalanxUserBlocks maintenance script did not run in the last 24 hours
+        summary: MigratePhalanxUserBlocks last succeeded {{humanizeDuration $value}} ago
+    # PhraseAlerts should be run every 24h
+    - alert: mediawiki_maintenance_scripts_PhraseAlerts_last_run
+      expr: time() - max(mediawiki_mediawiki_maintenance_scripts_last_success{env="prod", script_class="PhraseAlerts"}) > 3600 * 25
+      labels:
+        team: sus
+      annotations:
+        description: Email with report about monitored phrases was not generated in the last 24 hours
+        summary: PhraseAlerts last succeeded {{humanizeDuration $value}} ago
+    # RemoveQAWikis should be run every 24h
+    - alert: mediawiki_maintenance_scripts_RemoveQAWikis_last_run
+      expr: time() - max(mediawiki_mediawiki_maintenance_scripts_last_success{env="prod", script_class="RemoveQAWikis"}) > 3600 * 25
+      labels:
+        team: sus
+      annotations:
+        description: Script that closes old QA wikis was not run in the last 24 hours
+        summary: RemoveQAWikis last succeeded {{humanizeDuration $value}} ago
+    # SendConfirmationReminder should be run every 24h
+    - alert: mediawiki_maintenance_scripts_SendConfirmationReminder_last_run
+      expr: time() - max(mediawiki_mediawiki_maintenance_scripts_last_success{env="prod", script_class="SendConfirmationReminder"}) > 3600 * 25
+      labels:
+        team: sus
+      annotations:
+        description: Maintenance script to send email confirmation reminder to users was not run in the last 24 hours
+        summary: SendConfirmationReminder last succeeded {{humanizeDuration $value}} ago
+    # UploadStashCleanup should be run every 24h
+    - alert: mediawiki_maintenance_scripts_UploadStashCleanup_last_run
+      expr: time() - max(mediawiki_mediawiki_maintenance_scripts_last_success{env="prod", script_class="UploadStashCleanup"}) > 3600 * 25
+      labels:
+        team: sus
+      annotations:
+        description: Maintenance script to that cleanups stash uploads was not run in the last 24 hours
+        summary: UploadStashCleanup last succeeded {{humanizeDuration $value}} ago

--- a/docker/prod/alerting.yaml
+++ b/docker/prod/alerting.yaml
@@ -132,3 +132,11 @@ spec:
       annotations:
         description: Maintenance script that re-initialises wikis statistics table was not run in the last 24 hours
         summary: InitStats last succeeded {{humanizeDuration $value}} ago
+    # CleanupPhalanxStats should be run every week
+    - alert: mediawiki_maintenance_scripts_CleanupPhalanxStats_last_run
+      expr: time() - max(mediawiki_mediawiki_maintenance_scripts_last_success{env="prod", script_class="CleanupPhalanxStats"}) > 86400 * 8
+      labels:
+        team: sus
+      annotations:
+        description: Maintenance script that removes old specials.phalanx_stats entries was not run in the last 7 days
+        summary: CleanupPhalanxStats last succeeded {{humanizeDuration $value}} ago

--- a/docker/prod/alerting.yaml
+++ b/docker/prod/alerting.yaml
@@ -139,6 +139,14 @@ spec:
       annotations:
         description: Maintenance script that removes old specials.phalanx_stats entries was not run in the last 7 days
         summary: CleanupPhalanxStats last succeeded {{humanizeDuration $value}} ago
+    # ResetWeeklyUserContributionsCount should be run every week
+    - alert: mediawiki_maintenance_scripts_ResetWeeklyUserContributionsCount_last_run
+      expr: time() - max(mediawiki_mediawiki_maintenance_scripts_last_success{env="prod", script_class="ResetWeeklyUserContributionsCount"}) > 86400 * 8
+      labels:
+        team: sus
+      annotations:
+        description: Maintenance script that resets users rank with most contributions was not run in the last 7 days
+        summary: ResetWeeklyUserContributionsCount last succeeded {{humanizeDuration $value}} ago
     # LyricsWikiCrawler should be run every week
     - alert: mediawiki_maintenance_scripts_LyricsWikiCrawler_last_run
       expr: time() - max(mediawiki_mediawiki_maintenance_scripts_last_success{env="prod", script_class="LyricsWikiCrawler"}) > 3600 * 25

--- a/docker/prod/alerting.yaml
+++ b/docker/prod/alerting.yaml
@@ -147,6 +147,14 @@ spec:
       annotations:
         description: Maintenance script that resets users rank with most contributions was not run in the last 7 days
         summary: ResetWeeklyUserContributionsCount last succeeded {{humanizeDuration $value}} ago
+    # sendWeeklyDigest should be run every week
+    - alert: mediawiki_maintenance_scripts_sendWeeklyDigest_last_run
+      expr: time() - max(mediawiki_mediawiki_maintenance_scripts_last_success{env="prod", script_class="sendWeeklyDigest"}) > 86400 * 8
+      labels:
+        team: sus
+      annotations:
+        description: Maintenance script that sends the weekly digest to the users found in the global_watchlist table was not run in the last 7 days
+        summary: sendWeeklyDigest last succeeded {{humanizeDuration $value}} ago
     # LyricsWikiCrawler should be run every week
     - alert: mediawiki_maintenance_scripts_LyricsWikiCrawler_last_run
       expr: time() - max(mediawiki_mediawiki_maintenance_scripts_last_success{env="prod", script_class="LyricsWikiCrawler"}) > 3600 * 25

--- a/docker/prod/alerting.yaml
+++ b/docker/prod/alerting.yaml
@@ -155,11 +155,19 @@ spec:
       annotations:
         description: Maintenance script that sends the weekly digest to the users found in the global_watchlist table was not run in the last 7 days
         summary: sendWeeklyDigest last succeeded {{humanizeDuration $value}} ago
-    # LyricsWikiCrawler should be run every week
+    # LyricsWikiCrawler should be run every 24h
     - alert: mediawiki_maintenance_scripts_LyricsWikiCrawler_last_run
       expr: time() - max(mediawiki_mediawiki_maintenance_scripts_last_success{env="prod", script_class="LyricsWikiCrawler"}) > 3600 * 25
       labels:
         team: sus
       annotations:
-        description: Maintenance script tht is responsible for scribing Lyrics wikia articles was not run in the last 24 hours
+        description: Maintenance script that is responsible for scribing Lyrics wikia articles was not run in the last 24 hours
         summary: LyricsWikiCrawler last succeeded {{humanizeDuration $value}} ago
+    # AutomatedDeadWikisDeletionMaintenance should be run every 24h (excluding Friday and weekends)
+    - alert: mediawiki_maintenance_scripts_LyricsWikiCrawler_last_run
+      expr: time() - max(mediawiki_mediawiki_maintenance_scripts_last_success{env="prod", script_class="AutomatedDeadWikisDeletionMaintenance"}) > 86400 * 4
+      labels:
+        team: sus
+      annotations:
+        description: Maintenance script that marks wikis as closed was not run in the last four days
+        summary: AutomatedDeadWikisDeletionMaintenance last succeeded {{humanizeDuration $value}} ago

--- a/docker/prod/alerting.yaml
+++ b/docker/prod/alerting.yaml
@@ -122,5 +122,13 @@ spec:
       labels:
         team: sus
       annotations:
-        description: Maintenance script to that cleanups stash uploads was not run in the last 24 hours
+        description: Maintenance script that cleanups stash uploads was not run in the last 24 hours
         summary: UploadStashCleanup last succeeded {{humanizeDuration $value}} ago
+    # InitStats should be run every 24h
+    - alert: mediawiki_maintenance_scripts_InitStats_last_run
+      expr: time() - max(mediawiki_mediawiki_maintenance_scripts_last_success{env="prod", script_class="InitStats"}) > 3600 * 25
+      labels:
+        team: sus
+      annotations:
+        description: Maintenance script that re-initialises wikis statistics table was not run in the last 24 hours
+        summary: InitStats last succeeded {{humanizeDuration $value}} ago

--- a/extensions/wikia/PhalanxII/maintenance/cleanupPhalanxStats.php
+++ b/extensions/wikia/PhalanxII/maintenance/cleanupPhalanxStats.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once __DIR__ . '/../../../../maintenance/Maintenance.php';
+
 /**
  * Script that removes specials.phalanx_stats entries that are older than 365 days
  *
@@ -8,25 +10,31 @@
  * @file
  * @ingroup Maintenance
  */
+class CleanupPhalanxStats extends Maintenance {
 
-require_once( __DIR__ . '/../../../../maintenance/commandLine.inc' );
+	function execute() {
 
-$db = wfGetDB( DB_MASTER, [], $wgSpecialsDB );
-$rows = 0;
+		global $wgSpecialsDB;
 
-do {
+		$db = wfGetDB( DB_MASTER, [], $wgSpecialsDB );
+		$rows = 0;
 
-	// delete entries older than 365 days in small batches
-	// ps_timestamp has MediaWiki-formatted timestamps, e.g. 20170101000000
-	$db->query( 'DELETE FROM phalanx_stats WHERE ps_timestamp < NOW() - INTERVAL 365 DAY LIMIT 5000', __FILE__ );
-	$affectedRows = $db->affectedRows();
+		do {
 
-	$rows +=  $affectedRows;
+			// delete entries older than 365 days in small batches
+			// ps_timestamp has MediaWiki-formatted timestamps, e.g. 20170101000000
+			$db->query( 'DELETE FROM phalanx_stats WHERE ps_timestamp < NOW() - INTERVAL 365 DAY LIMIT 5000', __METHOD__ );
+			$affectedRows = $db->affectedRows();
 
-	wfWaitForSlaves( $db->getDBname() );
+			$rows +=  $affectedRows;
 
-	echo '.';
+			wfWaitForSlaves( $db->getDBname() );
 
-} while ( $affectedRows > 0 );
+			echo '.';
 
-\Wikia\Logger\WikiaLogger::instance()->info( "Count of rows dropped from phalanx stats: $rows" );
+		} while ( $affectedRows > 0 );
+
+		// every week we remove ~150k rows
+		\Wikia\Logger\WikiaLogger::instance()->info( "Count of rows dropped from phalanx stats: $rows" );
+	}
+}

--- a/extensions/wikia/WikiFactory/DeadWikis/maintenance.php
+++ b/extensions/wikia/WikiFactory/DeadWikis/maintenance.php
@@ -17,6 +17,7 @@ use Swagger\Client\Discussion\Api\SitesApi;
 use Wikia\Factory\ServiceFactory;
 use Wikia\Logger\WikiaLogger;
 use Wikia\Service\Swagger\ApiProvider;
+use Wikia\Metrics\Collector;
 
 $optionsWithArgs = array(
 	'action',
@@ -647,6 +648,20 @@ class AutomatedDeadWikisDeletionMaintenance {
 			default:
 				$this->error("error: invalid action provided: \"{$this->action}\"",true);
 		}
+
+		// SUS-6163 - report when was the last time a given maintenance script has been run successfully
+		global $wgWikiaEnvironment;
+
+		Collector::getInstance()
+			->addGauge(
+				'mediawiki_maintenance_scripts_last_success',
+				time(),
+				[
+					'script_class' => __CLASS__,
+					'env' => $wgWikiaEnvironment,
+				],
+				'Unix timestamp maintenance script last succeeded'
+			);
 	}
 
 	static protected function adjustSettings() {


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-6262

* AutomatedDeadWikisDeletionMaintenance and CleanupPhalanxStats will now report metrics to Prometheus