### PR TITLE
Fix robots on FC wikis

### DIFF
--- a/extensions/wikia/FandomCreator/FandomCreator.setup.php
+++ b/extensions/wikia/FandomCreator/FandomCreator.setup.php
@@ -12,8 +12,9 @@ spl_autoload_register( function( $class ) {
 	}
 } );
 
-// This hook is active on every wiki
+// This hooks are active on every wiki
 $wgHooks['GetWikisUnderDomain'][] = 'FandomCreator\Hooks::onGetWikisUnderDomain';
+$wgHooks['GenerateRobotsRules'][] = 'FandomCreator\Hooks::onGenerateRobotsRules';
 
 if ( !empty($wgFandomCreatorCommunityId ) ) {
 	// Part of the setup that is active on fandom creator communities
@@ -32,7 +33,6 @@ if ( !empty($wgFandomCreatorCommunityId ) ) {
 	};
 
 	$wgHooks['DesignSystemCommunityHeaderModelGetData'][] = 'FandomCreator\Hooks::onDesignSystemCommunityHeaderModelGetData';
-	$wgHooks['GenerateRobotsRules'][] = 'FandomCreator\Hooks::onGenerateRobotsRules';
 
 	$wgHooks['DesignSystemApigetAllElementsAfterExecute'][] = function( WikiaDispatchableObject $dispatchable ) {
 		$params = $dispatchable->getRequest()->getParams();

--- a/extensions/wikia/FandomCreator/FandomCreator.setup.php
+++ b/extensions/wikia/FandomCreator/FandomCreator.setup.php
@@ -12,7 +12,7 @@ spl_autoload_register( function( $class ) {
 	}
 } );
 
-// This hooks are active on every wiki
+// These hooks are active on every wiki
 $wgHooks['GetWikisUnderDomain'][] = 'FandomCreator\Hooks::onGetWikisUnderDomain';
 $wgHooks['GenerateRobotsRules'][] = 'FandomCreator\Hooks::onGenerateRobotsRules';
 

--- a/extensions/wikia/LanguageWikisIndex/LanguageWikisIndex.setup.php
+++ b/extensions/wikia/LanguageWikisIndex/LanguageWikisIndex.setup.php
@@ -9,10 +9,8 @@ $wgSpecialPages['LanguageWikisIndex'] = 'LanguageWikisIndexController';
 $wgExtensionMessagesFiles['LanguageWikisIndex'] = __DIR__ . '/LanguageWikisIndex.i18n.php';
 
 $wgExtensionFunctions[] = 'LanguageWikisIndexHooks::onExtensionFunctions';
-if ( LanguageWikisIndexHooks::isEmptyDomainWithLanguageWikis( $wgCityId ) ) {
-	$wgHooks['GenerateRobotsRules'][] = 'LanguageWikisIndexHooks::onGenerateRobotsRules';
-}
 
+$wgHooks['GenerateRobotsRules'][] = 'LanguageWikisIndexHooks::onGenerateRobotsRules';
 $wgHooks['ClosedWikiHandler'][] = 'LanguageWikisIndexHooks::onClosedWikiPage';
 $wgHooks['GetHTMLBeforeWikiaPage'][] = 'LanguageWikisIndexHooks::onGetHTMLBeforeWikiaPage';
 $wgHooks['WikiaCanonicalHref'][] = 'LanguageWikisIndexHooks::onWikiaCanonicalHref';


### PR DESCRIPTION
`GenerateRobotsRules` takes foreign city id as a param, so the hook listeners should be included on every wikis. Without this fix we're adding robots rules for domains served by Fandom Creator