### PR TITLE
SUS-6263 | internal requests inside k8s fix

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -258,6 +258,7 @@ $wgConf->localVHosts = array_merge(
     $wgWikiFactoryDomains,
     [
         $wgWikiaBaseDomain,
+        $wgFandomBaseDomain,
         'uncyclopedia.org',
         'memory-alpha.org',
         'wowwiki.com',

--- a/includes/HttpFunctions.php
+++ b/includes/HttpFunctions.php
@@ -432,17 +432,7 @@ class MWHttpRequest {
 		// SUS-5499: Use internal host name for MW->MW requests when running on Kubernetes
 		global $wgKubernetesNamespace;
 		if ( !empty( $wgKubernetesNamespace ) && Http::isLocalURL( $this->url ) ) {
-			$originalHost = $this->parsedUrl['host'];
-			$staging = wfGetStagingEnvForUrl( $this->url ); # this method requires a full URL
-
-			if ( $staging ) {
-				# SUS-6263 | this is required by k8s internal traffic that proxies directly to a
-				# specific nginx instance instead of http-border with its own VCL logic
-				# e.g. futurama.fandom.com (remove any environment specific domain suffix)
-				$originalHost = str_replace( "{$staging}.", '', $originalHost );
-			}
-
-			$list[] = sprintf( 'X-Original-Host: %s', $originalHost );
+			$list[] = sprintf( 'X-Original-Host: %s', wfNormalizeHost( $this->parsedUrl['host'] ) );
 		}
 
 		foreach ( $this->reqHeaders as $name => $value ) {

--- a/includes/HttpFunctions.php
+++ b/includes/HttpFunctions.php
@@ -86,7 +86,7 @@ class Http {
 			$backendTime = $req->getResponseHeader('x-backend-response-time') ?: 0;
 
 			$params = [
-				'requestHeaders' => $options[ 'headers' ],
+				'requestHeaders' => $req->getHeaderList(),
 				'statusCode' => $req->getStatus(),
 				'served-by' => $req->getResponseHeader('x-served-by') ?: '',
 				'reqMethod' => $method,

--- a/includes/HttpFunctions.php
+++ b/includes/HttpFunctions.php
@@ -97,6 +97,7 @@ class Http {
 				'backendTimeMS' => intval( 1000 * $backendTime),
 			];
 			if ( !$isOk ) {
+				$params[ 'requestHeaders' ] = $options[ 'headers' ];
 				$params[ 'responseHeaders' ] = $req->getResponseHeaders();
 				$params[ 'reqStatus' ] = $status;
 				$params[ 'exception' ] = new Exception( $url, $req->getStatus() );

--- a/includes/wikia/GlobalFunctions.php
+++ b/includes/wikia/GlobalFunctions.php
@@ -1602,7 +1602,7 @@ function wfGetBaseDomainForHost( $host ) {
  * "Unlocalizes" the host replaces env-specific domains with "wikia.com", for example
  * 'muppet.preview.wikia.com' -> 'muppet.wikia.com'
  *
- * @param $host
+ * @param string $host
  * @return string normalized host name
  */
 function wfNormalizeHost( $host ) {

--- a/includes/wikia/services/ApiService.class.php
+++ b/includes/wikia/services/ApiService.class.php
@@ -65,7 +65,14 @@ class ApiService {
 
 		$staging = wfGetStagingEnvForUrl( $cityUrl );
 		if ( $staging ) {
+			# TODO: remove when we're fully migrated to k8s
 			$options[ 'headers' ][ 'X-Staging' ] = $staging;
+
+			# SUS-6263 | this is required by k8s internal traffic that proxies directly to a
+			# specific nginx instance instead of http-border with its own VCL logic
+			# e.g. futurama.fandom.com (remove any environment specific domain suffix)
+			$options[ 'headers' ][ 'X-Original-Host' ] =
+				parse_url( str_replace( "{$staging}.", '', $cityUrl ), PHP_URL_HOST );
 		}
 
 		// request JSON format of API response

--- a/includes/wikia/services/ApiService.class.php
+++ b/includes/wikia/services/ApiService.class.php
@@ -67,12 +67,6 @@ class ApiService {
 		if ( $staging ) {
 			# TODO: remove when we're fully migrated to k8s
 			$options[ 'headers' ][ 'X-Staging' ] = $staging;
-
-			# SUS-6263 | this is required by k8s internal traffic that proxies directly to a
-			# specific nginx instance instead of http-border with its own VCL logic
-			# e.g. futurama.fandom.com (remove any environment specific domain suffix)
-			$options[ 'headers' ][ 'X-Original-Host' ] =
-				parse_url( str_replace( "{$staging}.", '', $cityUrl ), PHP_URL_HOST );
 		}
 
 		// request JSON format of API response

--- a/includes/wikia/tests/DomainUtilitiesTest.php
+++ b/includes/wikia/tests/DomainUtilitiesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class HttpFunctionsTest extends WikiaBaseTest {
+class DomainUtilitiesTest extends WikiaBaseTest {
 
 	private $originallocalVHosts;
 
@@ -27,8 +27,9 @@ class HttpFunctionsTest extends WikiaBaseTest {
 	 * @param string|null $expected
 	 *
 	 * @dataProvider getHeaderListOriginalHostDataProvider
+	 * @covers MWHttpRequest::getHeaderList
 	 */
-	public function testGetHeaderListOriginalHost( $url, $expected ) {
+	public function testGetHeaderListOriginalHost( string $url, $expected ) {
 		$this->mockGlobalVariable( 'wgKubernetesNamespace', 'foo' );
 
 		$http = new MWHttpRequest( $url );
@@ -52,5 +53,26 @@ class HttpFunctionsTest extends WikiaBaseTest {
 
 		yield [ 'http://example.com/fr/wikia.php', null ] ;
 		yield [ 'http://futurama.wikia.org/fr/wikia.php', null] ;
+	}
+
+	/**
+	 * @param string $host
+	 * @param string $expected
+	 *
+	 * @dataProvider wfNormalizeHostDataProvider
+	 */
+	public function testWfNormalizeHost( string $host, string $expected ) {
+		$this->assertEquals( $expected, wfNormalizeHost( $host ) );
+	}
+
+	public function wfNormalizeHostDataProvider() {
+		yield [ 'futurama.sandbox-s6.wikia.com', 'futurama.wikia.com' ];
+		yield [ 'muppet.sandbox-qa06.wikia.com', 'muppet.wikia.com' ];
+		yield [ 'futurama.verify.wikia.com', 'futurama.wikia.com' ];
+		yield [ 'futurama.preview.wikia.com', 'futurama.wikia.com' ];
+		yield [ 'futurama.preview.fandom.com', 'futurama.fandom.com' ];
+		yield [ 'muppet.wikia.com', 'muppet.wikia.com' ];
+		yield [ 'muppet.fandom.com', 'muppet.fandom.com' ];
+		yield [ 'example.com', 'example.com' ];
 	}
 }

--- a/includes/wikia/tests/HttpFunctionsTest.php
+++ b/includes/wikia/tests/HttpFunctionsTest.php
@@ -1,0 +1,48 @@
+<?php
+
+class HttpFunctionsTest extends WikiaBaseTest {
+
+	private $originallocalVHosts;
+
+	public function setUp() {
+		parent::setUp();
+
+		global $wgConf;
+		$this->originallocalVHosts = $wgConf->localVHosts;
+		$wgConf->localVHosts = [
+			'fandom.com',
+			'wikia.com',
+		];
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+
+		global $wgConf;
+		$wgConf->localVHosts = $this->originallocalVHosts;
+	}
+
+	/**
+	 * @param string $url
+	 * @param string|null $expected
+	 *
+	 * @dataProvider getHeaderListOriginalHostDataProvider
+	 */
+	public function testGetHeaderListOriginalHost( $url, $expected ) {
+		$this->mockGlobalVariable( 'wgKubernetesNamespace', 'foo' );
+
+		$http = new MWHttpRequest( $url );
+		$headers = $http->getHeaderList();
+
+		$this->assertEquals( 'X-Original-Host: ' . $expected, $headers[0] );
+	}
+
+	public function getHeaderListOriginalHostDataProvider() {
+		yield [ 'http://futurama.sandbox-s6.fandom.com/fr/wikia.php', 'futurama.fandom.com'] ;
+		yield [ 'http://futurama.sandbox-s6.wikia.com/fr/wikia.php', 'futurama.wikia.com'] ;
+		yield [ 'http://futurama.preview.fandom.com/fr/wikia.php', 'futurama.fandom.com'] ;
+		yield [ 'http://futurama.preview.wikia.com/fr/wikia.php', 'futurama.wikia.com'] ;
+		yield [ 'http://futurama.fandom.com/fr/wikia.php', 'futurama.fandom.com'] ;
+		yield [ 'http://futurama.wikia.com/fr/wikia.php', 'futurama.wikia.com'] ;
+	}
+}

--- a/includes/wikia/tests/HttpFunctionsTest.php
+++ b/includes/wikia/tests/HttpFunctionsTest.php
@@ -34,7 +34,12 @@ class HttpFunctionsTest extends WikiaBaseTest {
 		$http = new MWHttpRequest( $url );
 		$headers = $http->getHeaderList();
 
-		$this->assertEquals( 'X-Original-Host: ' . $expected, $headers[0] );
+		if ( is_null( $expected ) ) {
+			$this->assertEquals( [], $headers );
+		}
+		else {
+			$this->assertEquals( 'X-Original-Host: ' . $expected, $headers[0] );
+		}
 	}
 
 	public function getHeaderListOriginalHostDataProvider() {
@@ -44,5 +49,8 @@ class HttpFunctionsTest extends WikiaBaseTest {
 		yield [ 'http://futurama.preview.wikia.com/fr/wikia.php', 'futurama.wikia.com'] ;
 		yield [ 'http://futurama.fandom.com/fr/wikia.php', 'futurama.fandom.com'] ;
 		yield [ 'http://futurama.wikia.com/fr/wikia.php', 'futurama.wikia.com'] ;
+
+		yield [ 'http://example.com/fr/wikia.php', null ] ;
+		yield [ 'http://futurama.wikia.org/fr/wikia.php', null] ;
 	}
 }


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-6263

`X-Original-Host` is required as we proxy "directly" to nginx when we perform internal HTTP requests within Kubernetes cluster. However, we did not add `fandom.com` to the list of internal domains, hence this request header was not set (see #15648).