### PR TITLE
nginx | dev-specific image with prod/sandbox directory layout

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -14,6 +14,7 @@ docker push artifactory.wikia-inc.com/sus/php-wikia-base:da4390f
 
 # 2. and then dev image
 docker build -f dev/Dockerfile -t php-wikia-dev ./dev
+docker build -f dev/Dockerfile-nginx -t nginx-wikia-dev ./dev
 
 # 3. you can now run eval.php (execute this from root directory of app repo clone)
 docker run -it --rm -h localhost -e 'SERVER_ID=165' -e 'WIKIA_ENVIRONMENT=dev' -e 'WIKIA_DATACENTER=poz' -v "$PWD":/usr/wikia/slot1/current/src -v "$PWD/../config":/usr/wikia/slot1/current/config -v "$PWD/../cache":/usr/wikia/slot1/current/cache/messages artifactory.wikia-inc.com/sus/php-wikia-dev php maintenance/eval.php

--- a/docker/base/Dockerfile-php
+++ b/docker/base/Dockerfile-php
@@ -1,3 +1,4 @@
+# This is a base Docker image used in prod/sandbox/preview Jenkinsfile
 FROM artifactory.wikia-inc.com/sus/php-wikia-base:da4390f
 
 ADD app /usr/wikia/slot1/current/src

--- a/docker/dev/Dockerfile-nginx
+++ b/docker/dev/Dockerfile-nginx
@@ -1,0 +1,10 @@
+# This is a base nginx image with Wikia's directory structure
+FROM nginx:1.15.6-alpine
+
+RUN chown -R nginx:nginx /etc/nginx && \
+    chown nginx:nginx /var/cache/nginx && \
+    chown -R nginx:nginx /var/log/nginx && \
+    mkdir /var/run/nginx && \
+    chown nginx:nginx /var/run/nginx
+
+USER nginx

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   web:
-    image: nginx:1.15.6-alpine
+    image: nginx-wikia-dev
     ports:
       - "80:8080"
     volumes:


### PR DESCRIPTION
Otherwise we end up with local docker-compose powered app throwing an error when nginx tries to create PID file in `/var/run/nginx` directory. It does not exist in a base nginx image.