### PR TITLE
SRE-109 | Optimize PageStatsService

### DIFF
--- a/extensions/wikia/ArticleComments/ArticleCommentsHooks.class.php
+++ b/extensions/wikia/ArticleComments/ArticleCommentsHooks.class.php
@@ -10,7 +10,7 @@ class ArticleCommentsHooks {
 	 * @return bool
 	 */
 	public static function onAfterPageHeaderButtons( \Title $title, array &$buttons ): bool {
-		$service = PageStatsService::newFromTitle( $title );
+		$service = new PageStatsService( $title );
 		$comments = $service->getCommentsCount();
 
 		if ( ArticleCommentInit::ArticleCommentCheckTitle( $title ) ) {

--- a/extensions/wikia/PageHeader/ActionButton.class.php
+++ b/extensions/wikia/PageHeader/ActionButton.class.php
@@ -31,7 +31,7 @@ class ActionButton {
 		$this->user = $requestContext->getUser();
 		$this->request = $requestContext->getRequest();
 
-		$this->pageStatsService = PageStatsService::newFromTitle( $this->title );
+		$this->pageStatsService = new PageStatsService( $this->title );
 
 		$this->prepareActionButton();
 

--- a/extensions/wikia/PageHeader/Subtitle.class.php
+++ b/extensions/wikia/PageHeader/Subtitle.class.php
@@ -265,7 +265,7 @@ class Subtitle {
 		$namespaceText = $language->getFormattedNsText( $this->title->getNamespace() );
 		$userBlogPageText = $namespaceText . ':' . $userName;
 
-		$pageStatsService = new PageStatsService( $this->title->getArticleId() );
+		$pageStatsService = new PageStatsService( $this->title );
 		$pageCreatedDate = $language->date( $pageStatsService->getFirstRevisionTimestamp() );
 
 		return $app->renderPartial(

--- a/includes/wikia/services/tests/PageStatsServiceIntegrationTest.php
+++ b/includes/wikia/services/tests/PageStatsServiceIntegrationTest.php
@@ -8,7 +8,7 @@ class PageStatsServiceIntegrationTest extends WikiaDatabaseTest {
 	const TEST_ARTICLE_ID = 1;
 
 	public function testGetFirstRevisionTimestamp() {
-		$pageStatsService = new PageStatsService( static::TEST_ARTICLE_ID );
+		$pageStatsService = new PageStatsService( Title::newFromID( static::TEST_ARTICLE_ID ) );
 
 		$this->assertEquals( '20110101000000', $pageStatsService->getFirstRevisionTimestamp() );
 	}

--- a/skins/oasis/modules/BodyController.class.php
+++ b/skins/oasis/modules/BodyController.class.php
@@ -378,7 +378,7 @@ class BodyController extends WikiaController {
 					$talkPage = $this->wg->Title->getTalkPage();
 
 					// get number of revisions for talk page
-					$service = new PageStatsService( $this->wg->Title->getArticleID() );
+					$service = new PageStatsService( $this->wg->Title );
 					$comments = $service->getCommentsCount();
 
 					// render comments bubble


### PR DESCRIPTION
Optimize `PageStatsService` to not read from master but use the passed `Title` object properly. Previously, the class constructor worked only with article IDs, which forced a lookup from the master DB. Using `Title` objects everywhere removes dependency on master DB without risking reading stale data.

https://wikia-inc.atlassian.net/browse/SRE-109