### PR TITLE
SRE-109 | Use proper hook for theme settings update

### DIFF
--- a/extensions/wikia/ThemeDesigner/ThemeDesignerHooks.class.php
+++ b/extensions/wikia/ThemeDesigner/ThemeDesignerHooks.class.php
@@ -3,20 +3,6 @@
 class ThemeDesignerHooks {
 
 	/**
-	 * @param $revision Revision
-	 * @return bool
-	 */
-	public static function onRevisionInsertComplete( $revision ) {
-
-		if ( $revision instanceof Revision ) {
-			$title = $revision->getTitle( true );
-			self::resetThemeBackgroundSettings( $title );
-		}
-
-		return true;
-	}
-
-	/**
 	 * @param $article WikiPage
 	 * @return bool true
 	 */
@@ -42,6 +28,8 @@ class ThemeDesignerHooks {
 		if ( self::isFavicon( $image->getTitle() ) ) {
 			Wikia::invalidateFavicon();
 		}
+
+		self::resetThemeBackgroundSettings( $image->getTitle(), false );
 
 		return true;
 	}

--- a/extensions/wikia/ThemeDesigner/ThemeDesigner_setup.php
+++ b/extensions/wikia/ThemeDesigner/ThemeDesigner_setup.php
@@ -34,7 +34,6 @@ JSMessages::registerPackage( 'ThemeDesigner', [
 
 // hooks
 $wgHooks['ArticleDeleteComplete'][] = 'ThemeDesignerHooks::onArticleDeleteComplete';
-$wgHooks['RevisionInsertComplete'][] = 'ThemeDesignerHooks::onRevisionInsertComplete';
 $wgHooks['UploadComplete'][] = 'ThemeDesignerHooks::onUploadComplete';
 $wgHooks['UploadVerification'][] = 'ThemeDesignerHooks::onUploadVerification';
 $wgHooks['PageHeaderActionButtonShouldDisplay'][] = 'SpecialThemeDesignerPreview::onPageHeaderActionButtonShouldDisplay';


### PR DESCRIPTION
Moved `ThemeDesigner `hook that invalidates settings when a new background is uploaded to a proper place—`UploadComplete` hook. Previously, the hook would fire for every edit, including non-images, and would fetch a revision from master. We only want to perform this action when one of the images managed by theme designer is updated.

https://wikia-inc.atlassian.net/browse/SRE-109