### PR TITLE
PLATFORM-3799 | Add $wgScriptPath to CategoryExhibition memcache keys

### DIFF
--- a/extensions/wikia/CategoryExhibition/CategoryExhibitionSection.class.php
+++ b/extensions/wikia/CategoryExhibition/CategoryExhibitionSection.class.php
@@ -219,13 +219,17 @@ abstract class CategoryExhibitionSection {
 		}
 
 		$oMemCache = F::App()->wg->memc;
-		$sKey = wfMemcKey(
+		$keyParams = [
 			'category_exhibition_category_cache_1',
 			$pageId,
-			$this->cacheHelper->getTouched( $oTitle ),
-			$wgScriptPath
-		);
+			$this->cacheHelper->getTouched( $oTitle )
+		];
 
+		if ( !empty( $wgScriptPath ) ) {
+			array_push( $keyParams, $wgScriptPath );
+		}
+
+		$sKey = wfMemcKey( ...$keyParams );
 		$cachedResult = $oMemCache->get( $sKey );
 
 		if ( !empty( $cachedResult ) ) {
@@ -262,7 +266,7 @@ abstract class CategoryExhibitionSection {
 	protected function getKey() {
 		global $wgScriptPath;
 
-		return wfMemcKey(
+		$keyParams = [
 			'category_exhibition_section_0',
 			self::CACHE_VERSION,
 			md5( $this->categoryTitle->getDBKey() ),
@@ -271,8 +275,13 @@ abstract class CategoryExhibitionSection {
 			$this->urlParams->getSortType(),
 			$this->cacheHelper->getTouched( $this->categoryTitle ),
 			// Those are mentioned separately because they modify the pagination URL
-			$this->urlParams->getSortParam(),
-			$wgScriptPath
-		);
+			$this->urlParams->getSortParam()
+		];
+
+		if ( !empty( $wgScriptPath ) ) {
+			array_push( $keyParams, $wgScriptPath );
+		}
+
+		return wfMemcKey( ...$keyParams );
 	}
 }

--- a/extensions/wikia/CategoryExhibition/CategoryExhibitionSection.class.php
+++ b/extensions/wikia/CategoryExhibition/CategoryExhibitionSection.class.php
@@ -211,6 +211,8 @@ abstract class CategoryExhibitionSection {
 	}
 
 	protected function getTemplateVarsForItem( $pageId ) {
+		global $wgScriptPath;
+
 		$oTitle = Title::newFromID( $pageId );
 		if ( !( $oTitle instanceof Title ) ) {
 			return false;
@@ -220,7 +222,8 @@ abstract class CategoryExhibitionSection {
 		$sKey = wfMemcKey(
 			'category_exhibition_category_cache_1',
 			$pageId,
-			$this->cacheHelper->getTouched( $oTitle )
+			$this->cacheHelper->getTouched( $oTitle ),
+			$wgScriptPath
 		);
 
 		$cachedResult = $oMemCache->get( $sKey );
@@ -257,6 +260,8 @@ abstract class CategoryExhibitionSection {
 	 * Caching functions.
 	 */
 	protected function getKey() {
+		global $wgScriptPath;
+
 		return wfMemcKey(
 			'category_exhibition_section_0',
 			self::CACHE_VERSION,
@@ -266,7 +271,8 @@ abstract class CategoryExhibitionSection {
 			$this->urlParams->getSortType(),
 			$this->cacheHelper->getTouched( $this->categoryTitle ),
 			// Those are mentioned separately because they modify the pagination URL
-			$this->urlParams->getSortParam()
+			$this->urlParams->getSortParam(),
+			$wgScriptPath
 		);
 	}
 }

--- a/extensions/wikia/CategoryExhibition/CategoryExhibitionSection.class.php
+++ b/extensions/wikia/CategoryExhibition/CategoryExhibitionSection.class.php
@@ -226,7 +226,7 @@ abstract class CategoryExhibitionSection {
 		];
 
 		if ( !empty( $wgScriptPath ) ) {
-			array_push( $keyParams, $wgScriptPath );
+			$keyParams[] = $wgScriptPath;
 		}
 
 		$sKey = wfMemcKey( ...$keyParams );
@@ -279,7 +279,7 @@ abstract class CategoryExhibitionSection {
 		];
 
 		if ( !empty( $wgScriptPath ) ) {
-			array_push( $keyParams, $wgScriptPath );
+			$keyParams[] = $wgScriptPath;
 		}
 
 		return wfMemcKey( ...$keyParams );

--- a/extensions/wikia/CategoryExhibition/CategoryExhibitionSectionSubcategories.class.php
+++ b/extensions/wikia/CategoryExhibition/CategoryExhibitionSectionSubcategories.class.php
@@ -27,7 +27,7 @@ class CategoryExhibitionSectionSubcategories extends CategoryExhibitionSection {
 		];
 
 		if ( !empty( $wgScriptPath ) ) {
-			array_push( $keyParams, $wgScriptPath );
+			$keyParams[] = $wgScriptPath;
 		}
 
 		$sKey = wfMemcKey( ...$keyParams );

--- a/extensions/wikia/CategoryExhibition/CategoryExhibitionSectionSubcategories.class.php
+++ b/extensions/wikia/CategoryExhibition/CategoryExhibitionSectionSubcategories.class.php
@@ -12,6 +12,8 @@ class CategoryExhibitionSectionSubcategories extends CategoryExhibitionSection {
 	}
 
 	protected function getTemplateVarsForItem( $pageId ) {
+		global $wgScriptPath;
+
 		$oTitle = Title::newFromID( $pageId );
 
 		$oMemCache = F::App()->wg->memc;
@@ -21,7 +23,8 @@ class CategoryExhibitionSectionSubcategories extends CategoryExhibitionSection {
 			$this->cacheHelper->getTouched( $oTitle ),
 			// Display/sort params are passed to the subcategory, cache separately!
 			$this->urlParams->getSortParam(),
-			self::CACHE_VERSION
+			self::CACHE_VERSION,
+			$wgScriptPath
 		);
 
 		$cachedResult = $oMemCache->get( $sKey );

--- a/extensions/wikia/CategoryExhibition/CategoryExhibitionSectionSubcategories.class.php
+++ b/extensions/wikia/CategoryExhibition/CategoryExhibitionSectionSubcategories.class.php
@@ -17,16 +17,20 @@ class CategoryExhibitionSectionSubcategories extends CategoryExhibitionSection {
 		$oTitle = Title::newFromID( $pageId );
 
 		$oMemCache = F::App()->wg->memc;
-		$sKey = wfMemcKey(
+		$keyParams = [
 			'category_exhibition_article_cache_0',
 			$pageId,
 			$this->cacheHelper->getTouched( $oTitle ),
 			// Display/sort params are passed to the subcategory, cache separately!
 			$this->urlParams->getSortParam(),
-			self::CACHE_VERSION,
-			$wgScriptPath
-		);
+			self::CACHE_VERSION
+		];
 
+		if ( !empty( $wgScriptPath ) ) {
+			array_push( $keyParams, $wgScriptPath );
+		}
+
+		$sKey = wfMemcKey( ...$keyParams );
 		$cachedResult = $oMemCache->get( $sKey );
 
 		if ( !empty( $cachedResult ) ) {


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-3799

Add `$wgScriptPath` to CategoryExhibition memcache keys so the local URLs are updated immediately after migrating communities.

Based on https://github.com/Wikia/app/commit/8779c75a31fe46785ddb13f9d4e5866e36691d62.

@Wikia/core-platform-team 