### PR TITLE
SRE-109 | Add execution conditions for some expensive hooks

### DIFF
--- a/extensions/wikia/ImageServing/imageServingHelper.class.php
+++ b/extensions/wikia/ImageServing/imageServingHelper.class.php
@@ -14,20 +14,26 @@ class ImageServingHelper {
 	 * @return bool return true to continue hooks flow
 	 */
 	public static function onLinksUpdateComplete( $linksUpdate ) {
-		wfProfileIn(__METHOD__);
+		$title = $linksUpdate->getTitle();
+
+		// SRE-109: It is redundant to build index for file description pages and talk pages/Forum posts/Wall messages
+		if ( $title->isTalkPage() || $title->inNamespace( NS_FILE ) ) {
+			return true;
+		}
+
 		$images = $linksUpdate->getImages();
-		$articleId = $linksUpdate->getTitle()->getArticleID();
+		$articleId = $title->getArticleID();
 
 		if(count($images) === 1) {
 			$images = array_keys($images);
 			self::buildIndex( $articleId, $images);
-			wfProfileOut(__METHOD__);
+
 			return true;
 		}
 
-		$article = new Article($linksUpdate->getTitle());
+		$article = new Article( $title );
 		self::buildAndGetIndex( $article );
-		wfProfileOut(__METHOD__);
+
 		return true;
 	}
 

--- a/extensions/wikia/PortableInfobox/PortableInfoboxHooks.class.php
+++ b/extensions/wikia/PortableInfobox/PortableInfoboxHooks.class.php
@@ -68,7 +68,12 @@ class PortableInfoboxHooks {
 	 * @return bool
 	 */
 	public static function onArticleSave( Page $article, User $user, &$text, &$summary, $minor, $watchthis, $sectionanchor, &$flags, Status &$status ): bool {
-		PortableInfoboxDataService::newFromTitle( $article->getTitle() )->delete();
+		$title = $article->getTitle();
+
+		// SRE-109: This operation is redundant for file description pages and talk pages/Wall messages/Forum posts
+		if ( !$title->isTalkPage() && !$title->inNamespace( NS_FILE ) ) {
+			PortableInfoboxDataService::newFromTitle( $title )->delete();
+		}
 
 		return true;
 	}
@@ -95,7 +100,10 @@ class PortableInfoboxHooks {
 	 */
 	public static function onBacklinksPurge( Array $articles ) {
 		foreach ( $articles as $title ) {
-			PortableInfoboxDataService::newFromTitle( $title )->delete();
+			// SRE-109: This operation is redundant for file description pages and talk pages/Wall messages/Forum posts
+			if ( !$title->isTalkPage() && !$title->inNamespace( NS_FILE ) ) {
+				PortableInfoboxDataService::newFromTitle( $title )->delete();
+			}
 		}
 
 		return true;


### PR DESCRIPTION
There are some hooks (ImageServing index refresh and PortableInfobox page properties invalidation) that are run on every edit and perform expensive database writes. However, the work these hooks do is not needed in some cases, such as when the page being edited is a talk page (or derivative, like a Wall message or Forum post) or file description page. For these, these hooks can be skipped to improve performance.

https://wikia-inc.atlassian.net/browse/SRE-109