### PR TITLE
Lower cpu request for mediawiki-tasks

### DIFF
--- a/docker/prod/prod.template.yaml
+++ b/docker/prod/prod.template.yaml
@@ -278,10 +278,10 @@ spec:
               value: "tcp://localhost:9999"
           resources:
             limits:
-              cpu: "6"
+              cpu: 4
               memory: 3Gi  # 5 fpm workers x 512 MB PHP memory limit
             requests:
-              cpu: "3"
+              cpu: 2
               memory: 1.5Gi
         # MW log output, see K8s_LOGGING.md
         - name: logger


### PR DESCRIPTION
With 5 fpm workers, `mediawiki-tasks` should have less `cpu` power to scale properly.