### PR TITLE
(PLATFORM-3813) Include script path when checking for redirect loops

### DIFF
--- a/includes/Wiki.php
+++ b/includes/Wiki.php
@@ -154,7 +154,7 @@ class MediaWiki {
 	 * @return void
 	 */
 	private function performRequest() {
-		global $wgServer, $wgUsePathInfo, $wgTitle;
+		global $wgServer, $wgScriptPath, $wgUsePathInfo, $wgTitle;
 
 		wfProfileIn( __METHOD__ );
 
@@ -234,7 +234,12 @@ class MediaWiki {
 				$url = $title->getFullURL( $query );
 			}
 			// Check for a redirect loop
-			if ( !preg_match( '/^' . preg_quote( $wgServer, '/' ) . '/', $url )
+			$urlScriptPath = wfGetLanguagePathFromURL( $url );
+			if (
+				(
+					!preg_match( '/^' . preg_quote( $wgServer, '/' ) . '/', $url )
+					|| ( $wgScriptPath !== $urlScriptPath )
+				)
 				&& $title->isLocal() )
 			{
 				// 301 so google et al report the target as the actual url.

--- a/includes/interwiki/Interwiki.php
+++ b/includes/interwiki/Interwiki.php
@@ -347,7 +347,7 @@ class Interwiki {
 			$url = wfProtocolUrlToRelative( $url );
 		}
 
-		return $url;
+		return WikiFactory::getLocalEnvURL( $url );
 	}
 
 	/**

--- a/includes/wikia/GlobalFunctions.php
+++ b/includes/wikia/GlobalFunctions.php
@@ -1658,3 +1658,22 @@ function wfForceBaseDomain( $url, $targetServer ) {
 	$finalUrl = http_build_url( $url, [ 'host' => $finalHost, ] );
 	return WikiFactory::getLocalEnvURL( $finalUrl );
 }
+
+function wfGetLanguagePathFromURL( string $url ): string {
+	$path = parse_url( $url, PHP_URL_PATH );
+	if ( is_null( $path ) ) {
+		return '';
+	}
+
+	$slash = strpos( $path, '/', 1 ) ?: strlen( $path );
+	if ( $slash ) {
+		$languages = Language::getLanguageNames();
+		$langCode = substr( $path, 1, $slash - 1 );
+
+		if ( isset( $languages[$langCode] ) ) {
+			return "/{$langCode}";
+		}
+	}
+
+	return '';
+}


### PR DESCRIPTION
When checking for redirect loops when handling interwiki URLs, such as parsing
https://foo.fandom.com/wiki/fr:Foo, we need to also check if the script path
matches. Previously, we only checked if the redirect target includes wgServer
which will always be true when handling interwiki redirects to language path wikis
on the same domain, leading those redirects to fail.

/cc @Wikia/core-platform-team 