### PR TITLE
Do not leak StubObject from WikiFactoryLoaderIntegrationTest

### DIFF
--- a/extensions/wikia/WikiFactory/tests/WikiFactoryLoaderIntegrationTest.php
+++ b/extensions/wikia/WikiFactory/tests/WikiFactoryLoaderIntegrationTest.php
@@ -18,6 +18,9 @@ class WikiFactoryLoaderIntegrationTest extends WikiaDatabaseTest {
 		WikiFactory::isUsed( false );
 		$wgExtensionFunctions = [];
 		$this->dbName = $wgDBname;
+		
+		// WikiFactoryLoader has side effects that initialize the global content language with a StubObject
+		// In tests, we must ensure that any previous value for this global is correctly restored
 		$this->oldContentLanguage = $wgContLang;
 	}
 

--- a/extensions/wikia/WikiFactory/tests/WikiFactoryLoaderIntegrationTest.php
+++ b/extensions/wikia/WikiFactory/tests/WikiFactoryLoaderIntegrationTest.php
@@ -8,12 +8,17 @@ class WikiFactoryLoaderIntegrationTest extends WikiaDatabaseTest {
 	/** @var string $dbName */
 	private $dbName;
 
+	/** @var Language $oldContentLanguage */
+	private $oldContentLanguage;
+
 	protected function setUp() {
 		parent::setUp();
+		global $wgExtensionFunctions, $wgDBname, $wgContLang;
 
 		WikiFactory::isUsed( false );
-		$GLOBALS['wgExtensionFunctions'] = [];
-		$this->dbName = $GLOBALS['wgDBname'];
+		$wgExtensionFunctions = [];
+		$this->dbName = $wgDBname;
+		$this->oldContentLanguage = $wgContLang;
 	}
 
 	/**
@@ -381,10 +386,12 @@ class WikiFactoryLoaderIntegrationTest extends WikiaDatabaseTest {
 
 	protected function tearDown() {
 		parent::tearDown();
+		global $wgDBname, $wgContLang;
 
 		WikiFactory::isUsed( true );
 		LBFactory::destroyInstance();
-		$GLOBALS['wgDBname'] = $this->dbName;
+		$wgDBname = $this->dbName;
+		$wgContLang = $this->oldContentLanguage;
 	}
 
 	protected function getDataSet() {


### PR DESCRIPTION
`WikiFactoryLoader` internally initializes `$wgContLang` with a `StubObject` because MW LB requires `$wgContLang` to be defined in order to run, but `WikiFactoryLoader` runs very early in the request lifecycle so the variable is empty at the time. In tests, we must properly restore the value of `$wgContLang` after execution to avoid leaking the `StubObject` to other tests.