### PR TITLE
PLATFORM-3828 | Remove Content-Security-Policy when downgrading protocol

### DIFF
--- a/extensions/wikia/HTTPSSupport/HTTPSSupport.setup.php
+++ b/extensions/wikia/HTTPSSupport/HTTPSSupport.setup.php
@@ -3,6 +3,7 @@
 $wgAutoloadClasses['HTTPSSupportHooks'] =  __DIR__ . '/HTTPSSupportHooks.class.php';
 
 $wgHooks['BeforeInitialize'][] = 'HTTPSSupportHooks::onBeforeInitialize';
+$wgHooks['BeforePageRedirect'][] = 'HTTPSSupportHooks::onBeforePageRedirect';
 $wgHooks['LinkerMakeExternalLink'][] = 'HTTPSSupportHooks::onLinkerMakeExternalLink';
 $wgHooks['MercuryWikiVariables'][] = 'HTTPSSupportHooks::onMercuryWikiVariables';
 $wgHooks['outputMakeExternalImage'][] = 'HTTPSSupportHooks::parserUpgradeVignetteUrls';

--- a/extensions/wikia/HTTPSSupport/HTTPSSupportHooks.class.php
+++ b/extensions/wikia/HTTPSSupport/HTTPSSupportHooks.class.php
@@ -67,6 +67,26 @@ class HTTPSSupportHooks {
 	}
 
 	/**
+	 * Remove Content-Security-Policy header when downgrading HTTPS to HTTP
+	 * Microsoft Edge starting from v17 misinterprets Content-Security-Policy: upgrade-insecure-requests
+	 * during redirects and falls into a loop HTTPS -> HTTP -> HTTPS -> ...
+	 *
+	 * @param $out
+	 * @param $redirect
+	 * @param $code
+	 * @param $redirectedBy
+	 */
+	public static function onBeforePageRedirect( $out, &$redirect, &$code, &$redirectedBy ) {
+		$currentUri = \WikiFactoryLoader::getCurrentRequestUri( $_SERVER, false, true );
+		$currentProtocol = parse_url( $currentUri, PHP_URL_SCHEME );
+		$targetProtocol = parse_url( $redirect, PHP_URL_SCHEME );
+
+		if ( $currentProtocol === 'https' && $targetProtocol === 'http' ) {
+			header_remove( 'Content-Security-Policy' );
+		}
+	}
+
+	/**
 	 * Handle downgrading anonymous requests for our robots.txt.
 	 *
 	 * @param  WebRequest $request

--- a/extensions/wikia/HTTPSSupport/HTTPSSupportHooks.class.php
+++ b/extensions/wikia/HTTPSSupport/HTTPSSupportHooks.class.php
@@ -77,8 +77,7 @@ class HTTPSSupportHooks {
 	 * @param $redirectedBy
 	 */
 	public static function onBeforePageRedirect( $out, &$redirect, &$code, &$redirectedBy ) {
-		$currentUri = \WikiFactoryLoader::getCurrentRequestUri( $_SERVER, false, true );
-		$currentProtocol = parse_url( $currentUri, PHP_URL_SCHEME );
+		$currentProtocol = WebRequest::detectProtocol();
 		$targetProtocol = parse_url( $redirect, PHP_URL_SCHEME );
 
 		if ( $currentProtocol === 'https' && $targetProtocol === 'http' ) {


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-3828
https://wikia-inc.atlassian.net/browse/IW-1116

Remove Content-Security-Policy header when downgrading HTTPS to HTTP.
Microsoft Edge starting from v17 misinterprets `Content-Security-Policy: upgrade-insecure-requests` during redirects and falls into a loop HTTPS -> HTTP -> HTTPS -> ...

@Wikia/core-platform-team @JamesHawking 