### PR TITLE
SRE-109 | Update cu_changes table in a background task

### DIFF
--- a/extensions/CheckUser/CheckUser.hooks.php
+++ b/extensions/CheckUser/CheckUser.hooks.php
@@ -64,7 +64,7 @@ class CheckUserHooks {
 		}
 
 		// SRE-109: Update the cu_changes table in a background task
-		$task = new \Wikia\Tasks\Tasks\UpdateCheckUserTask();
+		$task = \Wikia\Tasks\Tasks\UpdateCheckUserTask::newLocalTask();
 		$task->call( 'updateWithEditInfo', $rcRow );
 		$task->queue();
 

--- a/extensions/CheckUser/CheckUser.hooks.php
+++ b/extensions/CheckUser/CheckUser.hooks.php
@@ -40,10 +40,7 @@ class CheckUserHooks {
 		$actionTextTrim = substr( $actionText, 0, static::ACTION_TEXT_MAX_LENGTH );
 		$agentTrim = substr( $agent, 0, static::ACTION_TEXT_MAX_LENGTH );
 
-		$dbw = wfGetDB( DB_MASTER );
-		$cuc_id = $dbw->nextSequenceValue( 'cu_changes_cu_id_seq' );
 		$rcRow = array(
-			'cuc_id'         => $cuc_id,
 			'cuc_namespace'  => $rc_namespace,
 			'cuc_title'      => $rc_title,
 			'cuc_minor'      => $rc_minor,
@@ -65,7 +62,11 @@ class CheckUserHooks {
 		if ( isset( $rc_cur_id ) ) {
 			$rcRow['cuc_page_id'] = $rc_cur_id;
 		}
-		$dbw->insert( 'cu_changes', $rcRow, __METHOD__ );
+
+		// SRE-109: Update the cu_changes table in a background task
+		$task = new \Wikia\Tasks\Tasks\UpdateCheckUserTask();
+		$task->call( 'updateWithEditInfo', $rcRow );
+		$task->queue();
 
 		return true;
 	}

--- a/lib/Wikia/src/Tasks/Tasks/UpdateCheckUserTask.php
+++ b/lib/Wikia/src/Tasks/Tasks/UpdateCheckUserTask.php
@@ -1,0 +1,13 @@
+<?php
+namespace Wikia\Tasks\Tasks;
+
+/**
+ * SRE-109: Async task to update cu_changes table
+ */
+class UpdateCheckUserTask extends BaseTask {
+
+	public function updateWithEditInfo( array $editInfo ) {
+		$dbw = wfGetDB( DB_MASTER );
+		$dbw->insert( 'cu_changes', $editInfo, __METHOD__ );
+	}
+}

--- a/lib/composer/composer/ClassLoader.php
+++ b/lib/composer/composer/ClassLoader.php
@@ -279,7 +279,7 @@ class ClassLoader
      */
     public function setApcuPrefix($apcuPrefix)
     {
-        $this->apcuPrefix = function_exists('apcu_fetch') && ini_get('apc.enabled') ? $apcuPrefix : null;
+        $this->apcuPrefix = function_exists('apcu_fetch') && filter_var(ini_get('apc.enabled'), FILTER_VALIDATE_BOOLEAN) ? $apcuPrefix : null;
     }
 
     /**

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -3005,6 +3005,7 @@ return array(
     'Wikia\\Tasks\\Tasks\\RefreshLinksForTitleTask' => $baseDir . '/lib/Wikia/src/Tasks/Tasks/RefreshLinksForTitleTask.php',
     'Wikia\\Tasks\\Tasks\\RenameUserPagesTask' => $baseDir . '/lib/Wikia/src/Tasks/Tasks/RenameUserPagesTask.php',
     'Wikia\\Tasks\\Tasks\\SiteWideMessagesTask' => $baseDir . '/lib/Wikia/src/Tasks/Tasks/SiteWideMessagesTask.php',
+    'Wikia\\Tasks\\Tasks\\UpdateCheckUserTask' => $baseDir . '/lib/Wikia/src/Tasks/Tasks/UpdateCheckUserTask.php',
     'Wikia\\Tasks\\Tasks\\UserRegistrationTask' => $baseDir . '/lib/Wikia/src/Tasks/Tasks/UserRegistrationTask.php',
     'Wikia\\Tasks\\Tasks\\WatchlistUpdateTask' => $baseDir . '/lib/Wikia/src/Tasks/Tasks/WatchlistUpdateTask.php',
     'Wikia\\Tracer\\Uuid' => $baseDir . '/lib/Wikia/src/Tracer/Uuid.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -3519,6 +3519,7 @@ class ComposerStaticInitb367f9b4bf4d43e0d5ea402c134db26b
         'Wikia\\Tasks\\Tasks\\RefreshLinksForTitleTask' => __DIR__ . '/../../..' . '/lib/Wikia/src/Tasks/Tasks/RefreshLinksForTitleTask.php',
         'Wikia\\Tasks\\Tasks\\RenameUserPagesTask' => __DIR__ . '/../../..' . '/lib/Wikia/src/Tasks/Tasks/RenameUserPagesTask.php',
         'Wikia\\Tasks\\Tasks\\SiteWideMessagesTask' => __DIR__ . '/../../..' . '/lib/Wikia/src/Tasks/Tasks/SiteWideMessagesTask.php',
+        'Wikia\\Tasks\\Tasks\\UpdateCheckUserTask' => __DIR__ . '/../../..' . '/lib/Wikia/src/Tasks/Tasks/UpdateCheckUserTask.php',
         'Wikia\\Tasks\\Tasks\\UserRegistrationTask' => __DIR__ . '/../../..' . '/lib/Wikia/src/Tasks/Tasks/UserRegistrationTask.php',
         'Wikia\\Tasks\\Tasks\\WatchlistUpdateTask' => __DIR__ . '/../../..' . '/lib/Wikia/src/Tasks/Tasks/WatchlistUpdateTask.php',
         'Wikia\\Tracer\\Uuid' => __DIR__ . '/../../..' . '/lib/Wikia/src/Tracer/Uuid.php',


### PR DESCRIPTION
The `cu_changes` table is used by the CheckUser staff tool to log some user data after each edit—this logging should be performed asynchronously via a background task instead of the request thread.

https://wikia-inc.atlassian.net/browse/SRE-109