### PR TITLE
SRE-109 | EditPage: do not fetch user block from master DB

### DIFF
--- a/includes/EditPage.php
+++ b/includes/EditPage.php
@@ -1171,7 +1171,8 @@ class EditPage {
 			return $status;
 		}
 
-		if ( $wgUser->isBlockedFrom( $this->mTitle, false ) ) {
+		// SRE-109: Check blocked status on a replica instead of the master
+		if ( $wgUser->isBlockedFrom( $this->mTitle, true ) ) {
 			// Auto-block user's IP if the account was "hard" blocked
 			$wgUser->spreadAnyEditBlock();
 			# Check block state against master, thus 'false'.


### PR DESCRIPTION
Follow-up to https://github.com/Wikia/app/pull/16363. As with `Title::checkUserPermissions`, we can use a replica to check user's blocked status in `EditPage` as well.

https://wikia-inc.atlassian.net/browse/SRE-109