### PR TITLE
SUS-6267 | reduce CPU for mediawiki-prod k8s deployment

### DIFF
--- a/docker/prod/prod.template.yaml
+++ b/docker/prod/prod.template.yaml
@@ -90,10 +90,10 @@ spec:
               value: "tcp://localhost:9999"
           resources:
             limits:
-              cpu: "4"
+              cpu: "3"
               memory: 3Gi  # 5 fpm workers x 512 MB PHP memory limit
             requests:
-              cpu: "2"
+              cpu: "1.5"
               memory: 1.5Gi
         # MW log output, see K8s_LOGGING.md
         - name: logger


### PR DESCRIPTION
We want to stabilise fpm workers usage at 60%.