### PR TITLE
Avoid PHP Notice in ExternalStoreDBFetchBlobHookIntegrationTest

### DIFF
--- a/extensions/wikia/Development/tests/ExternalStoreDBFetchBlobHookIntegrationTest.php
+++ b/extensions/wikia/Development/tests/ExternalStoreDBFetchBlobHookIntegrationTest.php
@@ -16,7 +16,7 @@ class ExternalStoreDBFetchBlobHookIntegrationTest extends TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$mockApiURL = "http://{$this->getMockServerHost()}:{$this->getMockServerPort()}";
+		$mockApiURL = "http://{$this->getMockServerHost()}:{$this->getMockServerPort()}/";
 		$this->mockGlobalVariable( "wgFetchBlobApiURL", $mockApiURL );
 		$this->mockGlobalVariable( 'wgDefaultExternalStore', [] );
 	}


### PR DESCRIPTION
Add a trailing slash to the request URL to avoid the following:
```PHP Notice:  Undefined index: path in /home/travis/build/Wikia/app/includes/HttpFunctions.php on line 427
PHP Stack trace:
PHP   1. {main}() /home/travis/build/Wikia/app/tests/run-test.php:0
PHP   2. PHPUnit\TextUI\Command::main() /home/travis/build/Wikia/app/tests/run-test.php:5
PHP   3. PHPUnit\TextUI\Command->run() /home/travis/build/Wikia/app/lib/composer/phpunit/phpunit/src/TextUI/Command.php:148
PHP   4. PHPUnit\TextUI\TestRunner->doRun() /home/travis/build/Wikia/app/lib/composer/phpunit/phpunit/src/TextUI/Command.php:195
PHP   5. PHPUnit\Framework\TestSuite->run() /home/travis/build/Wikia/app/lib/composer/phpunit/phpunit/src/TextUI/TestRunner.php:546
PHP   6. PHPUnit\Framework\TestSuite->run() /home/travis/build/Wikia/app/lib/composer/phpunit/phpunit/src/Framework/TestSuite.php:755
PHP   7. PHPUnit\Framework\TestSuite->run() /home/travis/build/Wikia/app/lib/composer/phpunit/phpunit/src/Framework/TestSuite.php:755
PHP   8. ExternalStoreDBFetchBlobHookIntegrationTest->run() /home/travis/build/Wikia/app/lib/composer/phpunit/phpunit/src/Framework/TestSuite.php:755
PHP   9. PHPUnit\Framework\TestResult->run() /home/travis/build/Wikia/app/lib/composer/phpunit/phpunit/src/Framework/TestCase.php:895
PHP  10. ExternalStoreDBFetchBlobHookIntegrationTest->runBare() /home/travis/build/Wikia/app/lib/composer/phpunit/phpunit/src/Framework/TestResult.php:698
PHP  11. ExternalStoreDBFetchBlobHookIntegrationTest->runTest() /home/travis/build/Wikia/app/lib/composer/phpunit/phpunit/src/Framework/TestCase.php:940
PHP  12. ReflectionMethod->invokeArgs() /home/travis/build/Wikia/app/lib/composer/phpunit/phpunit/src/Framework/TestCase.php:1072
PHP  13. ExternalStoreDBFetchBlobHookIntegrationTest->testApiCall() /home/travis/build/Wikia/app/lib/composer/phpunit/phpunit/src/Framework/TestCase.php:1072
PHP  14. ExternalStoreDBFetchBlobHook() /home/travis/build/Wikia/app/extensions/wikia/Development/tests/ExternalStoreDBFetchBlobHookIntegrationTest.php:33
PHP  15. Http::get() /home/travis/build/Wikia/app/extensions/wikia/Development/ExternalStoreDBFetchBlobHook.php:78
PHP  16. Http::request() /home/travis/build/Wikia/app/includes/HttpFunctions.php:141
PHP  17. CurlHttpRequest->getHeaderList() /home/travis/build/Wikia/app/includes/HttpFunctions.php:89
```