### PR TITLE
(PLATFORM-3836) Trim trailing slashes when validating the redirect URL

### DIFF
--- a/extensions/wikia/WikiFactory/Close/SpecialCloseWiki_body.php
+++ b/extensions/wikia/WikiFactory/Close/SpecialCloseWiki_body.php
@@ -204,7 +204,7 @@ class CloseWikiPage extends SpecialPage {
 		if ( isset($this->mRedirect) && !empty($this->mRedirect) ) {
 			$this->mRedirect = preg_replace( '!^https?://!', '', $this->mRedirect );
 			Wikia::log( __METHOD__, "check domain {$this->mRedirect}" );
-			$city_id = WikiFactory::DomainToID( trim( $this->mRedirect ) );
+			$city_id = WikiFactory::DomainToID( trim( $this->mRedirect, ' /' ) );
 			if( !$city_id ) {
 				Wikia::log( __METHOD__, "domain doesn't exist" );
 				$valid = false;


### PR DESCRIPTION
When closing and redirecting a wiki, if the language path has a trailing
slash, it errors saying the wiki doesn't exist. To make this easier, let's
trim trailing slashes before validating the domain exists.

/cc @Wikia/core-platform-team 