### PR TITLE
getWikisUnderDomain: fix the sorting

### DIFF
--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -617,7 +617,7 @@ class WikiFactory {
 				Hooks::run( 'GetWikisUnderDomain', [ $domain, $includeRoot, &$cities ] );
 
 				// sort the wikis by their url, English wiki should come first
-				uasort( $cities, function( $a, $b ) { return strcmp( $a['city_url'], $b['city_url'] ); } );
+				usort( $cities, function( $a, $b ) { return strcmp( $a['city_url'], $b['city_url'] ); } );
 
 				return $cities;
 			}


### PR DESCRIPTION
`uasort` was preserving the keys, so in case order was changes - the result was a dict instead of an ordinary list. Which cause issues for clients trying to deserialize it.