### PR TITLE
(PLATFORM-3877) Add a noindex robots tag to HTML API pages

### DIFF
--- a/includes/api/ApiFormatBase.php
+++ b/includes/api/ApiFormatBase.php
@@ -180,6 +180,7 @@ abstract class ApiFormatBase extends ApiBase {
 <!DOCTYPE HTML>
 <html>
 <head>
+	<meta name="robots" content="noindex,nofollow" />
 <?php if ( $this->mUnescapeAmps ) {
 ?>	<title>MediaWiki API</title>
 <?php } else {


### PR DESCRIPTION
In order to allow deeplinking in our mobile apps, api.php URLs are
explicitly allowed in robots.txt. This has lead to our HTML API docs
ending up in the search index. In order to resolve this, while
hopefully not breaking deeplinking, we can use the meta robots tag
to add "noindex,nofollow" to all the HTML API documentation pages
and see if that cleans these pages out of the index.

/cc @Wikia/core-platform-team 