### PR TITLE
CORE-20 | Create an API that exposes templates parameters and articles categories

### DIFF
--- a/includes/parser/Parser.php
+++ b/includes/parser/Parser.php
@@ -3746,6 +3746,11 @@ class Parser {
 			}
 			# RTE - end
 
+			/* @var PPNode_DOM $args */
+			# wikia start
+			Hooks::run( 'ParserBraceSubstitutionForTemplate', [ $title, $args ] );
+			# wikia end
+
 			# Do infinite loop check
 			# This has to be done after redirect resolution to avoid infinite loops via redirects
 			if ( !$frame->loopCheck( $title ) ) {

--- a/includes/parser/Parser.php
+++ b/includes/parser/Parser.php
@@ -3746,11 +3746,6 @@ class Parser {
 			}
 			# RTE - end
 
-			/* @var PPNode_DOM $args */
-			# wikia start
-			Hooks::run( 'ParserBraceSubstitutionForTemplate', [ $title, $args ] );
-			# wikia end
-
 			# Do infinite loop check
 			# This has to be done after redirect resolution to avoid infinite loops via redirects
 			if ( !$frame->loopCheck( $title ) ) {

--- a/includes/parser/Preprocessor_DOM.php
+++ b/includes/parser/Preprocessor_DOM.php
@@ -1053,6 +1053,14 @@ class PPFrame_DOM implements PPFrame {
 				}
 			}
 		}
+
+		# wikia start
+		Hooks::run(
+			'PreprocessorDOMNewTemplateFrame',
+			[ $this, $title, $numberedArgs, $namedArgs ]
+		);
+		# wikia end
+
 		return new PPTemplateFrame_DOM( $this->preprocessor, $this, $numberedArgs, $namedArgs, $title );
 	}
 

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -143,6 +143,7 @@ $wgAutoloadClasses['DWDimensionApiController'] = "{$IP}/includes/wikia/api/DWDim
 $wgAutoloadClasses['DWDimensionApiControllerSQL'] = "{$IP}/includes/wikia/api/DWDimensionApiControllerSQL.class.php";
 $wgAutoloadClasses['InfoboxApiController'] = "{$IP}/includes/wikia/api/InfoboxApiController.class.php";
 $wgAutoloadClasses['TemplateClassificationApiController'] = "{$IP}/includes/wikia/api/TemplateClassificationApiController.class.php";
+$wgAutoloadClasses['TemplatesApiController'] = "{$IP}/includes/wikia/api/TemplatesApiController.class.php";
 $wgExtensionMessagesFiles['WikiaApi'] = "{$IP}/includes/wikia/api/WikiaApi.i18n.php";
 
 $wgWikiaApiControllers['DiscoverApiController'] = "{$IP}/includes/wikia/api/DiscoverApiController.class.php";

--- a/includes/wikia/api/TemplatesApiController.class.php
+++ b/includes/wikia/api/TemplatesApiController.class.php
@@ -2,12 +2,59 @@
 
 class TemplatesApiController extends WikiaApiController {
 
+	private static $TEMPLATES_BLACKLIST = [
+		'!',
+		'!!',
+	];
+	private static $templates = [];
+
+	/**
+	 * Register templates names and parameters as we parse the article
+	 *
+	 * @param PPFrame_DOM $frame
+	 * @param Title $title
+	 * @param DOMElement[] $numberedArgs
+	 * @param DOMElement[] $namedArgs
+	 * @throws \Swagger\Client\ApiException
+	 */
+	static function onPreprocessorDOMNewTemplateFrame(
+		PPFrame_DOM $frame, Title $title, array $numberedArgs, array $namedArgs
+	) {
+		global $wgCityId;
+
+		// skip blacklisted templates, e.g. ! or !!
+		if ( in_array( $title->getText(), self::$TEMPLATES_BLACKLIST ) ) {
+			return;
+		}
+
+		// skip templates without names arguments
+		if ( empty( $namedArgs ) ) {
+			return;
+		}
+
+		// collect template's parameters
+		$parameters = [];
+		foreach($namedArgs as $name => $argData) {
+			$parameters[ $name ] = $argData->textContent;
+		}
+
+		$templateClassification = new TemplateClassificationService();
+
+		self::$templates[] = [
+			'name' => $title->getText(),
+			'id' => $title->getArticleID(),
+			'type' => $templateClassification->getType( $wgCityId, $title->getArticleID() ),
+			'parameters' => $parameters,
+		];
+	}
+
 	/**
 	 * Returns metadata for all templates used on a specified article.
 	 *
 	 * CORE-20: this is an experimental API that can change in the near future
 	 *
-	 * @throws InvalidParameterApiException
+	 * @throws WikiaHttpException
+	 * @throws \Swagger\Client\ApiException
 	 */
 	public function getMetadata() {
 		$pageid = $this->getRequiredParam( 'pageid' );
@@ -17,7 +64,12 @@ class TemplatesApiController extends WikiaApiController {
 			throw new NotFoundApiException();
 		}
 
-		$templates = [];
+		// register a hook that will collect templates metadata
+		self::$templates = [];
+		Hooks::register(
+			'PreprocessorDOMNewTemplateFrame',
+			[ $this, 'onPreprocessorDOMNewTemplateFrame' ]
+		);
 
 		// parse an article to get the list of all templates
 		$parser = new Parser();
@@ -27,26 +79,9 @@ class TemplatesApiController extends WikiaApiController {
 			$title, $opts
 		);
 
-		$templatesInArticle = $out->getTemplates();
-
-		// fetch templates metadata
-		if ( array_key_exists( NS_TEMPLATE, $templatesInArticle ) ) {
-			$templateClassification = new TemplateClassificationService();
-
-			foreach ( $templatesInArticle[NS_TEMPLATE] as $templateTitle => $templateId ) {
-				$templates[] = [
-					'name' => $templateTitle,
-					'id' => $templateId,
-					'type' => $templateClassification->getType( $this->wg->CityId, $templateId )
-				];
-			}
-		}
-
-		# var_dump(__METHOD__, $out->getTemplateIds()); die;
-
 		$response = [
 			'title' => $title->getPrefixedText(),
-			'templates' => $templates,
+			'templates' => self::$templates,
 			'categories' => array_keys( $out->getCategories() )
 		];
 

--- a/includes/wikia/api/TemplatesApiController.class.php
+++ b/includes/wikia/api/TemplatesApiController.class.php
@@ -54,7 +54,6 @@ class TemplatesApiController extends WikiaApiController {
 	 * CORE-20: this is an experimental API that can change in the near future
 	 *
 	 * @throws WikiaHttpException
-	 * @throws \Swagger\Client\ApiException
 	 */
 	public function getMetadata() {
 		$pageid = $this->getRequiredParam( 'pageid' );

--- a/includes/wikia/api/TemplatesApiController.class.php
+++ b/includes/wikia/api/TemplatesApiController.class.php
@@ -1,0 +1,55 @@
+<?php
+
+class TemplatesApiController extends WikiaApiController {
+
+	/**
+	 * Returns metadata for all templates used on a specified article.
+	 *
+	 * CORE-20: this is an experimental API that can change in the near future
+	 *
+	 * @throws InvalidParameterApiException
+	 */
+	public function getMetadata() {
+		$pageid = $this->getRequiredParam( 'pageid' );
+		$title = Title::newFromID( $pageid );
+
+		if ( !$title || !$title->exists() ) {
+			throw new NotFoundApiException();
+		}
+
+		$templates = [];
+
+		// parse an article to get the list of all templates
+		$parser = new Parser();
+		$opts = ParserOptions::newFromContext( $this->getContext() );
+		$out = $parser->parse(
+			Article::newFromTitle( $title , $this->getContext())->getContent(),
+			$title, $opts
+		);
+
+		$templatesInArticle = $out->getTemplates();
+
+		// fetch templates metadata
+		if ( array_key_exists( NS_TEMPLATE, $templatesInArticle ) ) {
+			$templateClassification = new TemplateClassificationService();
+
+			foreach ( $templatesInArticle[NS_TEMPLATE] as $templateTitle => $templateId ) {
+				$templates[] = [
+					'name' => $templateTitle,
+					'id' => $templateId,
+					'type' => $templateClassification->getType( $this->wg->CityId, $templateId )
+				];
+			}
+		}
+
+		# var_dump(__METHOD__, $out->getTemplateIds()); die;
+
+		$response = [
+			'title' => $title->getPrefixedText(),
+			'templates' => $templates,
+			'categories' => array_keys( $out->getCategories() )
+		];
+
+		$this->setResponseData( $response );
+	}
+}

--- a/includes/wikia/api/TemplatesApiController.class.php
+++ b/includes/wikia/api/TemplatesApiController.class.php
@@ -54,10 +54,19 @@ class TemplatesApiController extends WikiaApiController {
 	 * CORE-20: this is an experimental API that can change in the near future
 	 *
 	 * @throws WikiaHttpException
+	 * @throws MWException
 	 */
 	public function getMetadata() {
-		$pageid = $this->getRequiredParam( 'pageid' );
-		$title = Title::newFromID( $pageid );
+		// handle both "title" and "pageid" URL parameters
+		$titleParam = $this->getVal('title');
+
+		if (!$titleParam) {
+			$pageid = $this->getRequiredParam( 'pageid' );
+			$title = Title::newFromID( $pageid );
+		}
+		else {
+			$title = Title::newFromText( $titleParam );
+		}
 
 		if ( !$title || !$title->exists() ) {
 			throw new NotFoundApiException();


### PR DESCRIPTION
@Wikia/core-team 

Introduce Nirvana API that will expose metadata of templates used by a given article. Each template that has at least one named argument provided will be listed here. Its name, type (provided by templates classification service) will be returned along with key-value set of arguments provided. Additionally, articles categories will be returned.

* https://muppet.sandbox-s6.wikia.com/api/v1/Templates/Metadata?title=Kermit_the_Frog
* https://muppet.sandbox-s6.wikia.com/api/v1/Templates/Metadata?pageid=50

## Example response

```json
{
  "title": "Elmo",
  "templates": [
    {
      "name": "Character",
      "id": 198069,
      "type": "infobox",
      "parameters": {
        "image": "Elmo-elmo-elmo.jpg",
        "performer": "[[Kevin Clash]]",
        "note": "1985-2012",
        "performer2": "[[Ryan Dillon]]",
        "note2": "2013-present",
        "more": "Casting History",
        "debut": "1979",
        "design": "[[Caroly Wilcox]]",
        "designnote": "designer/builder",
        "design2": "[[Leslee Asch]]",
        "designnote2": "designer/builder"
      }
    },
    {
      "name": "Medialink",
      "id": 189208,
      "type": "quote",
      "parameters": {
        "filename": "We_Are_All_Monsters_behind_the_scenes.jpg",
        "text": "this behind-the-scenes photo"
      }
    }
  ],
  "categories": [
    "Muppet_Characters",
    "Sesame_Street_Characters",
    "Sesame_Street_Monsters",
    "Furchester_Hotel_Characters"
  ]
}
```