### PR TITLE
MAIN-18407: Fix "password too short" message

### DIFF
--- a/includes/User.php
+++ b/includes/User.php
@@ -2180,7 +2180,15 @@ class User implements JsonSerializable {
 				'userId' => $this->getId(),
 				'err'    => $heliosPasswordChange,
 			] );
-			throw new PasswordError( wfMessage( $heliosPasswordChange->errors[0]->description )->text() );
+			$description = $heliosPasswordChange->errors[0]->description;
+			$message = null;
+			if ( $description === 'passwordtooshort' ) {
+				global $wgMinimalPasswordLength;
+				$message = wfMessage( 'passwordtooshort', $wgMinimalPasswordLength );
+			} else {
+				$message = wfMessage( $description );
+			}
+			throw new PasswordError( $message->text() );
 		}
 	}
 
@@ -2199,15 +2207,7 @@ class User implements JsonSerializable {
 				'userId' => $this->getId(),
 				'err'    => $result,
 			] );
-			$description = $result->errors[0]->description;
-			$message = null;
-			if ( $description === 'passwordtooshort' ) {
-				global $wgMinimalPasswordLength;
-				$message = wfMessage( 'passwordtooshort', $wgMinimalPasswordLength );
-			} else {
-				$message = wfMessage( $description );
-			}
-			throw new PasswordError( $message->text() );
+			throw new PasswordError( wfMessage( $result->errors[0]->description )->text() );
 		}
 	}
 

--- a/includes/User.php
+++ b/includes/User.php
@@ -2199,7 +2199,15 @@ class User implements JsonSerializable {
 				'userId' => $this->getId(),
 				'err'    => $result,
 			] );
-			throw new PasswordError( wfMessage( $result->errors[0]->description )->text() );
+			$description = $result->errors[0]->description;
+			$message = null;
+			if ( $description === 'passwordtooshort' ) {
+				global $wgMinimalPasswordLength;
+				$message = wfMessage( 'passwordtooshort', $wgMinimalPasswordLength );
+			} else {
+				$message = wfMessage( $description );
+			}
+			throw new PasswordError( $message->text() );
 		}
 	}
 


### PR DESCRIPTION
The [password changing form](https://c.wikia.com/wiki/Special:ChangePassword) is showing "password must be at least $1 characters" without replacing the `$1` variable. That is because the variable is never passed to the error message, and this pull request fixes that.

Bug ticket: [MAIN-18407](https://wikia-inc.atlassian.net/browse/MAIN-18407)
Support ticket: [ZD#424553](https://support.wikia-inc.com/hc/en-us/requests/424553)