### PR TITLE
MAIN-18408: Fix typo in API documentation (neweditors -> firstcontributions)

### DIFF
--- a/extensions/wikia/FirstContributions/api/ApiQueryFirstContributions.php
+++ b/extensions/wikia/FirstContributions/api/ApiQueryFirstContributions.php
@@ -136,8 +136,8 @@ class ApiQueryFirstContributions extends ApiQueryBase {
 
 	public function getExamples() {
 		return [
-			'api.php?action=query&list=neweditors',
-			'api.php?action=query&list=neweditors&fcdir=newer'
+			'api.php?action=query&list=firstcontributions',
+			'api.php?action=query&list=firstcontributions&fcdir=newer'
 		];
 	}
 }


### PR DESCRIPTION
An example of the issue can be found [here](https://community.fandom.com/api.php?action=help&querymodules=firstcontributions).
Bug ticket: [MAIN-18408](https://wikia-inc.atlassian.net/browse/MAIN-18408)
Support ticket: [ZD#424540](https://support.wikia-inc.com/hc/en-us/requests/424540)