### PR TITLE
MAIN-13172: Allow querying for multiple groups in subpage

### DIFF
--- a/extensions/wikia/ListGlobalUsers/SpecialListGlobalUsersController.php
+++ b/extensions/wikia/ListGlobalUsers/SpecialListGlobalUsersController.php
@@ -26,9 +26,9 @@ class SpecialListGlobalUsersController extends WikiaSpecialPageController {
 		$permissionsConfiguration = $this->permissionsService()->getConfiguration();
 		$queryGroups = $this->request->getArray( 'groups' );
 
-		// support querying for single group passed as special page /parameter
+		// support querying for multiple groups passed as special page /parameter
 		if ( !empty( $this->getPar() ) ) {
-			$queryGroups[] = $this->getPar();
+			$queryGroups = explode( ',', $this->getPar() );
 		}
 
 		$globalGroups = array_diff(


### PR DESCRIPTION
This pull request makes ListGlobalUsers replicate a functionality from ListUsers: querying for multiple groups using a subpage of the special page. For example, like [Special:ListUsers/sysop,chatmoderator](https://c.wikia.com/wiki/Special:ListUsers/sysop,chatmoderator) would list both administrators and chat moderators when visited, this pull request should make `Special:ListGlobalUsers/vstf,staff` list both VSTF and Staff when visited. Related ListUsers code:

https://github.com/Wikia/app/blob/a8da66a09e74cc7967b19843f5e43540a2cae0f2/extensions/wikia/Listusers/SpecialListusers_body.php#L86-L94

Bug ticket: [MAIN-13172](https://wikia-inc.atlassian.net/browse/MAIN-13172)
Support ticket: [ZD#376209](https://support.wikia-inc.com/hc/requests/376209) (under number 13)