### PR TITLE
MAIN-15544: Fix username in blog subtitle on blogs with slashes in page name

### DIFF
--- a/extensions/wikia/PageHeader/Subtitle.class.php
+++ b/extensions/wikia/PageHeader/Subtitle.class.php
@@ -257,7 +257,7 @@ class Subtitle {
 	private function getBlogArticleSubtitle( WikiaApp $app ) {
 		$language = RequestContext::getMain()->getLanguage();
 
-		$userName = $this->title->getBaseText();
+		$userName = $this->title->getRootText();
 		$avatar = DesignSystemHelper::renderAvatar( $userName, 30 );
 		$userPageUrl = AvatarService::getUrl( $userName );
 

--- a/includes/Title.php
+++ b/includes/Title.php
@@ -1316,6 +1316,21 @@ class Title {
 	}
 
 	/**
+	 * Cut off subpages from page text
+	 *
+	 * @return String Root name
+	 */
+	public function getRootText() {
+
+		if ( !MWNamespace::hasSubpages( $this->mNamespace ) ) {
+			return $this->getText();
+		}
+
+		$parts = explode( '/', $this->getText() );
+		return $parts[0];
+	}
+
+	/**
 	 * Get the lowest-level subpage name, i.e. the rightmost part after any slashes
 	 *
 	 * @return String Subpage name


### PR DESCRIPTION
[`Title::getBaseText()`](https://doc.wikimedia.org/mediawiki-core/master/php/classTitle.html#a8c7435293cc0cfb85a8015f4f6a75318) is used to get the author's username on blog pages. That method, however, gets the page name of the parent title and not the root title, so user blogs with slashes in their page name include parts of the blog name in their base text, which breaks blog header behavior. This pull request backports [`Title::getRootText()`](https://doc.wikimedia.org/mediawiki-core/master/php/classTitle.html#a79a8d1344f32cb2a4a356046e8b50aae) which has been [introduced in newer MediaWiki versions](https://gerrit.wikimedia.org/r/20478) and uses it in the related blog header code.

[Example of the issue](https://c.wikia.com/wiki/User_blog:EarthlingnAkumi/What_is_the_Best_Way_to_Handle_Vandals/Trolls%3F?redirect=no)
Bug ticket: [MAIN-15544](https://wikia-inc.atlassian.net/browse/MAIN-15544)
Support ticket: [ZD#395909](https://support.wikia-inc.com/hc/en-us/requests/395909) (under number 13)