### PR TITLE
MAIN-18410: Add mediawiki.jqueryMsg to ChatWidget's dependencies

### DIFF
--- a/extensions/wikia/Chat2/Chat_setup.php
+++ b/extensions/wikia/Chat2/Chat_setup.php
@@ -100,6 +100,7 @@ $wgResourceModules['ext.Chat2.ChatWidget'] = [
 		'chat-edit-count',
 		'chat-member-since',
 	],
+	'dependencies' => [ 'mediawiki.jqueryMsg' ],
 ];
 
 


### PR DESCRIPTION
ChatWidget code for displaying the user edit count expects the `mw.message` parser to support the `{{PLURAL:}}` keyword, otherwise issues with displaying a user's edit count arise as a result of a race condition. This code:
https://github.com/Wikia/app/blob/26af40b5f54fbf0a0618d388ac04ba8531a4a9aa/extensions/wikia/Chat2/js/ChatWidget.js#L162 along with this template:
https://github.com/Wikia/app/blob/26af40b5f54fbf0a0618d388ac04ba8531a4a9aa/extensions/wikia/Chat2/templates/widgetUserElement.mustache#L17-L18 creates issues such as this:
![Image](https://cdn.discordapp.com/attachments/246075715714416641/485113307955724299/chrome_2018-08-30_23-59-03.png)
This pull request ensures `mediawiki.jqueryMsg` module loads before the ChatWidget module by loading it as a dependency.

Bug ticket: [MAIN-18410](https://wikia-inc.atlassian.net/browse/MAIN-18410)
Support ticket: [ZD#424562](https://support.wikia-inc.com/hc/en-us/requests/424562)