### PR TITLE
CORE-14: do not store namespace prefixed template names in querycache table

### DIFF
--- a/extensions/wikia/InsightsV2/specials/PagesWithoutInfobox.class.php
+++ b/extensions/wikia/InsightsV2/specials/PagesWithoutInfobox.class.php
@@ -16,6 +16,10 @@ class PagesWithoutInfobox extends PageQueryPage {
 		return true;
 	}
 
+	public function getDescription() {
+		return $this->msg( 'insights-list-subtitle-pageswithoutinfobox' )->text();
+	}
+
 	/**
 	 * A wrapper for calling the querycache table
 	 *

--- a/extensions/wikia/InsightsV2/specials/UnconvertedInfoboxesPage.class.php
+++ b/extensions/wikia/InsightsV2/specials/UnconvertedInfoboxesPage.class.php
@@ -20,6 +20,10 @@ class UnconvertedInfoboxesPage extends PageQueryPage {
 		return true;
 	}
 
+	public function getDescription() {
+		return $this->msg( 'insights-list-subtitle-nonportableinfoboxes' )->text();
+	}
+
 	/**
 	 * A wrapper for calling the querycache table
 	 *

--- a/extensions/wikia/InsightsV2/specials/UnconvertedInfoboxesPage.class.php
+++ b/extensions/wikia/InsightsV2/specials/UnconvertedInfoboxesPage.class.php
@@ -114,8 +114,8 @@ class UnconvertedInfoboxesPage extends PageQueryPage {
 					$nonportableInfoboxes[] = [
 						$this->getName(),
 						count( $links ),
-						NS_TEMPLATE,
-						$title->getPrefixedDBkey(),
+						$title->getNamespace(),
+						$title->getDBkey(),
 					];
 				}
 			}


### PR DESCRIPTION
@Wikia/core-team 

https://wikia-inc.atlassian.net/browse/CORE-14

```sql
mysql@geo-db-e-slave.query.consul[runescape]>select * from querycache where qc_namespace = 10 limit 5;
+-----------------+----------+--------------+-------------------------+
| qc_type         | qc_value | qc_namespace | qc_title                |
+-----------------+----------+--------------+-------------------------+
| AllInfoboxes    |   638495 |           10 | Til_Death_Do_Us_Part    |
| DoubleRedirects |        0 |           10 | Signatures/Degenret01   |
| Mostlinked      |      293 |           10 | Money_making            |
| Mostlinked      |      304 |           10 | Infobox_Pet             |
| Mostlinked      |      317 |           10 | Solomon's_General_Store |
+-----------------+----------+--------------+-------------------------+
5 rows in set (0.01 sec)

--

mysql@geo-db-e-slave.query.consul[runescape]>select * from querycache where qc_namespace = 10 and qc_title LIKE 'Template:%' limit 5;
+----------------------+----------+--------------+-------------------------------------+
| qc_type              | qc_value | qc_namespace | qc_title                            |
+----------------------+----------+--------------+-------------------------------------+
| Nonportableinfoboxes |        0 |           10 | Template:Achieve                    |
| Nonportableinfoboxes |        0 |           10 | Template:Disassembly/categories     |
| Nonportableinfoboxes |        0 |           10 | Template:Disassembly_items_list/doc |
| Nonportableinfoboxes |        0 |           10 | Template:Elven_worker               |
| Nonportableinfoboxes |        0 |           10 | Template:Hiscores_stats             |
+----------------------+----------+--------------+-------------------------------------+
5 rows in set (0.01 sec)
```