### PR TITLE
PLATFORM-3862: fix domain sorting

### DIFF
--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -617,7 +617,7 @@ class WikiFactory {
 				Hooks::run( 'GetWikisUnderDomain', [ $domain, $includeRoot, &$cities ] );
 
 				// sort the wikis by their url, English wiki should come first
-				usort( $cities, function( $a, $b ) { return strcmp( $a['city_url'], $b['city_url'] ); } );
+				usort( $cities, function( $a, $b ) { return strcasecmp( $a['city_url'], $b['city_url'] ); } );
 
 				return $cities;
 			}


### PR DESCRIPTION
We want the domain root to be first, which is not the case when (for some wikis) there are uppercase letters in city_url. 