### PR TITLE
DeleteArticlesByPrefix: report that no articles were found and leave the script, just please don't die

### DIFF
--- a/maintenance/wikia/deleteArticlesByPrefix.php
+++ b/maintenance/wikia/deleteArticlesByPrefix.php
@@ -51,7 +51,7 @@ class DeleteArticlesByPrefix extends Maintenance {
 
 		if (count($pages) === 0) {
 			$this->output("No articles found!\n");
-			die();
+			return;
 		}
 
 		foreach($pages as $page) {


### PR DESCRIPTION
SUS slack channel got the following alert - https://wikia.slack.com/archives/C3E6XA2MQ/p1546413658000800

Because of Christmas / New Year' break no Selenium tests were run recently and no articles were created. As a result the maintenance script was not able to find articles to remove and was simply dying. 

Call `return` instead to be able to report correct run to Prometheus and avoid false alerts.