### PR TITLE
Fix redir when insights subpage doesn't exist, PLATFORM-3903

### DIFF
--- a/extensions/wikia/InsightsV2/InsightsController.class.php
+++ b/extensions/wikia/InsightsV2/InsightsController.class.php
@@ -29,7 +29,10 @@ class InsightsController extends WikiaSpecialPageController {
 		if ( InsightsHelper::isInsightPage( $this->type ) ) {
 			$this->renderSubpage();
 		} elseif ( !empty( $this->type ) ) {
-			$this->response->redirect( SpecialPage::getTitleFor( 'Insights' ) );
+			$title = SpecialPage::getTitleFor( 'Insights' );
+			$targetUrl = wfExpandUrl( $title->getFullURL(), PROTO_CURRENT );
+			$this->response->redirect($targetUrl);
+
 		}
 
 		wfProfileOut( __METHOD__ );


### PR DESCRIPTION
The final redirect tries to send to a page (Special:Insights - for different languages - without /community). The redirect wasn't generated properly and browsers couldn't handle it. Generating a full url should do the trick. I still can't find a way to test it on dev. I think that there should be a more optimal way to redirect it without the final 302 redirect, but for now I don't feel confident enough it won't break anything else.