### PR TITLE
Revert "SUS-2974 | increase SQL queries logging sampling to 5%"

### DIFF
--- a/includes/db/Database.php
+++ b/includes/db/Database.php
@@ -202,8 +202,8 @@ interface DatabaseType {
  */
 abstract class DatabaseBase implements DatabaseType {
 
-	// @const log 5% of queries (increased from 1% in SUS-2974)
-	const QUERY_SAMPLE_RATE = 0.05;
+	// @const log 1% of queries
+	const QUERY_SAMPLE_RATE = 0.01;
 
 	// @const log queries that took more than 15 seconds
 	const SLOW_QUERY_LOG_THRESHOLD = 15;


### PR DESCRIPTION
We want to have a longer history of SQL logs which will help us debug issue that took place during weekends. On Monday logs from Saturday are already gone.

Decrease sampling of SQL logs from MediaWiki from 5% to 1%. This will allow us to extend the retention policy for `logstash-mediawiki-sql-*` es index.