### PR TITLE
Platform 3901 - changing how sitemaps paginate

### DIFF
--- a/extensions/wikia/SitemapXml/SitemapXmlController.class.php
+++ b/extensions/wikia/SitemapXml/SitemapXmlController.class.php
@@ -150,14 +150,10 @@ class SitemapXmlController extends WikiaController {
 		foreach ( self::SEPARATE_SITEMAPS as $ns ) {
 			$prev = "0";
 			foreach ( $this->model->getSubSitemaps( $ns, self::URLS_PER_PAGE ) as $page ) {
-				if($prev) {
-					$url = $baseUrl . '/sitemap-newsitemapxml-NS_' . $ns . '-id-' . $page->page_id . '-'.$prev.'.xml';
-					$out .= '<sitemap><loc>' . $url . '</loc></sitemap>' . PHP_EOL;
-				}
+				$url = $baseUrl . '/sitemap-newsitemapxml-NS_' . $ns . '-id-' .$prev. '-' . $page->page_id .'.xml';
+				$out .= '<sitemap><loc>' . $url . '</loc></sitemap>' . PHP_EOL;
 				$prev = $page->page_id;
 			}
-			$url = $baseUrl . '/sitemap-newsitemapxml-NS_' . $ns . '-id-0-' . $prev . '.xml';
-			$out .= '<sitemap><loc>' . $url . '</loc></sitemap>' . PHP_EOL;
 		}
 
 		if ( $wgEnableDiscussions ) {

--- a/extensions/wikia/SitemapXml/SitemapXmlController.class.php
+++ b/extensions/wikia/SitemapXml/SitemapXmlController.class.php
@@ -170,11 +170,17 @@ class SitemapXmlController extends WikiaController {
 
 		foreach ( self::SEPARATE_SITEMAPS as $ns ) {
 			$prev = false;
-			foreach ( $this->model->getSubSitemaps( $ns, self::URLS_PER_PAGE ) as $page ) {
+			$count = 0;
+			foreach ( $this->model->getSubSitemaps( $ns, self::URLS_PER_PAGE ) as list($numberRows, $page) ) {
+				$count++;
 				if($prev) {
+					$currId = $page->page_id;
+					if($count == $numberRows) {
+						$currId += 1;
+					}
 					$url =
 						$baseUrl . '/sitemap-newsitemapxml-NS_' . $ns . '-id-' . $prev . '-' .
-						$page->page_id . '.xml';
+						$currId . '.xml';
 					$out .= '<sitemap><loc>' . $url . '</loc></sitemap>' . PHP_EOL;
 				}
 				$prev = $page->page_id;

--- a/extensions/wikia/SitemapXml/SitemapXmlController.class.php
+++ b/extensions/wikia/SitemapXml/SitemapXmlController.class.php
@@ -140,7 +140,7 @@ class SitemapXmlController extends WikiaController {
 			$limit = self::URLS_PER_PAGE;
 			$data = $this->model->getItems( $namespace, $offset, $limit );
 		}
-
+		$count = 0;
 		foreach ( $data as $item ) {
 			$encodedTitle = wfUrlencode( str_replace( ' ', '_', $item->page_title ) );
 			$lastmod = $this->getLastMod( $item->page_touched );
@@ -150,9 +150,11 @@ class SitemapXmlController extends WikiaController {
 			$out .= '<lastmod>' . $lastmod . '</lastmod>' . PHP_EOL;
 			$out .= '<priority>' . $priority . '</priority>' . PHP_EOL;
 			$out .= '</url>' . PHP_EOL;
+			$count ++;
 		}
 
 		$out .= '</urlset>' . PHP_EOL;
+		$out .= sprintf( '<!-- number of pages: %d -->' . PHP_EOL, $count );
 
 		return $out;
 	}
@@ -163,15 +165,18 @@ class SitemapXmlController extends WikiaController {
 		$out = '<?xml version="1.0" encoding="UTF-8"?>' . PHP_EOL;
 		$out .= '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . PHP_EOL;
 
+
 		$baseUrl = $this->wg->Server . $this->wg->ScriptPath;
 
 		foreach ( self::SEPARATE_SITEMAPS as $ns ) {
-			$prev = "0";
+			$prev = false;
 			foreach ( $this->model->getSubSitemaps( $ns, self::URLS_PER_PAGE ) as $page ) {
-				$url =
-					$baseUrl . '/sitemap-newsitemapxml-NS_' . $ns . '-id-' . $prev . '-' .
-					$page->page_id . '.xml';
-				$out .= '<sitemap><loc>' . $url . '</loc></sitemap>' . PHP_EOL;
+				if($prev) {
+					$url =
+						$baseUrl . '/sitemap-newsitemapxml-NS_' . $ns . '-id-' . $prev . '-' .
+						$page->page_id . '.xml';
+					$out .= '<sitemap><loc>' . $url . '</loc></sitemap>' . PHP_EOL;
+				}
 				$prev = $page->page_id;
 			}
 		}

--- a/extensions/wikia/SitemapXml/SitemapXmlModel.class.php
+++ b/extensions/wikia/SitemapXml/SitemapXmlModel.class.php
@@ -103,7 +103,7 @@ class SitemapXmlModel extends WikiaModel {
 			->FROM( 'page' )
 			->WHERE( 'page_namespace' )->EQUAL_TO( $namespace )
 			->AND_( 'page_is_redirect' )->EQUAL_TO( false )
-			->ORDER_BY('page_id');
+			->ORDER_BY( 'page_id' );
 
 		if ( $namespace === NS_CATEGORY ) {
 			$sql->JOIN( 'category' )->ON( 'page.page_title', 'category.cat_title')

--- a/extensions/wikia/SitemapXml/SitemapXmlModel.class.php
+++ b/extensions/wikia/SitemapXml/SitemapXmlModel.class.php
@@ -42,7 +42,7 @@ class SitemapXmlModel extends WikiaModel {
 							->AS_( 'rownum' )
 							->build() ) . ')' )
 				->AS_( 'db' )
-				->WHERE( 'rownum MOD ' . intval($limit)+1 )
+				->WHERE( 'rownum MOD ' . (intval($limit)+1) )
 				->EQUAL_TO( '0' )
 				->OR_( 'db.page_id = (' . $mainSQL->injectParams( $this->dbr,
 						$mainSQL->FIELD( 'max(page.page_id)' )->build() ) . ') ' );

--- a/extensions/wikia/SitemapXml/SitemapXmlModel.class.php
+++ b/extensions/wikia/SitemapXml/SitemapXmlModel.class.php
@@ -42,7 +42,7 @@ class SitemapXmlModel extends WikiaModel {
 							->AS_( 'rownum' )
 							->build() ) . ')' )
 				->AS_( 'db' )
-				->WHERE( 'rownum MOD ' . $limit )
+				->WHERE( 'rownum MOD ' . $limit+1 )
 				->EQUAL_TO( '0' )
 				->OR_( 'db.page_id = (' . $mainSQL->injectParams( $this->dbr,
 						$mainSQL->FIELD( 'max(page.page_id)' )->build() ) . ') ' );

--- a/extensions/wikia/SitemapXml/SitemapXmlModel.class.php
+++ b/extensions/wikia/SitemapXml/SitemapXmlModel.class.php
@@ -32,7 +32,7 @@ class SitemapXmlModel extends WikiaModel {
 	 */
 	public function getSubSitemaps( $namespace, $limit ) {
 		$mainSQL = $this->getQuery( $namespace );
-		echo $sql =
+		$sql =
 			( new WikiaSQL() )->SELECT()
 				->FIELD( 'page_id', 'rownum' )
 				->FROM( '(SELECT @x:=-1) AS x, (' . $mainSQL->injectParams( $this->dbr,

--- a/extensions/wikia/SitemapXml/SitemapXmlModel.class.php
+++ b/extensions/wikia/SitemapXml/SitemapXmlModel.class.php
@@ -42,7 +42,7 @@ class SitemapXmlModel extends WikiaModel {
 							->AS_( 'rownum' )
 							->build() ) . ')' )
 				->AS_( 'db' )
-				->WHERE( 'rownum MOD ' . (intval($limit)+1) )
+				->WHERE( 'rownum MOD ' . (intval($limit)+2 )
 				->EQUAL_TO( '0' )
 				->OR_( 'db.page_id = (' . $mainSQL->injectParams( $this->dbr,
 						$mainSQL->FIELD( 'max(page.page_id)' )->build() ) . ') ' );

--- a/extensions/wikia/SitemapXml/SitemapXmlModel.class.php
+++ b/extensions/wikia/SitemapXml/SitemapXmlModel.class.php
@@ -87,8 +87,9 @@ class SitemapXmlModel extends WikiaModel {
 	public function getItemsBetween( $namespace, $begin, $end ) {
 		$sql =
 			$this->getQuery( $namespace )->FIELD( 'page_namespace', 'page_title', 'page_touched' );
+		$sql = $sql->AND_( 'page_id' )->GREATER_THAN_OR_EQUAL( $begin );
 		if ( $end ) {
-			$sql = $sql->AND_( 'page_id' )->BETWEEN( $begin, $end );
+			$sql = $sql->AND_( 'page_id' )->LESS_THAN( $end );
 		}
 
 		return $sql->run( $this->dbr, function ( $result ) {

--- a/extensions/wikia/SitemapXml/SitemapXmlModel.class.php
+++ b/extensions/wikia/SitemapXml/SitemapXmlModel.class.php
@@ -36,12 +36,12 @@ class SitemapXmlModel extends WikiaModel {
 		$sql = (new WikiaSQL())
 			->SELECT()
 			->FIELD( 'page_id' , 'rownum')
-			->FROM( "(SELECT @x:=1) AS x, (".$mainSQL->injectParams($this->dbr, $this->getQuery( $namespace )
+			->FROM( '(SELECT @x:=1) AS x, ('.$mainSQL->injectParams($this->dbr, $this->getQuery( $namespace )
 					->FIELD( 'page_id' )
-					->FIELD("(@x:=@x+1)" )->AS_("rownum")->build())
-				.")")->AS_("db")
-			->WHERE("rownum MOD ".$limit)->EQUAL_TO("0")
-			->OR_("db.page_id = (".$mainSQL->injectParams($this->dbr,$mainSQL->FIELD( 'max(page.page_id)' )->build()).") ");
+					->FIELD('(@x:=@x+1)' )->AS_('rownum')->build())
+				.')')->AS_('db')
+			->WHERE('rownum MOD '.$limit)->EQUAL_TO('0')
+			->OR_('db.page_id = ('.$mainSQL->injectParams($this->dbr,$mainSQL->FIELD( 'max(page.page_id)' )->build()).') ');
 
 		return $sql->run( $this->dbr, function ( $result ) {
 			while ( $row = $result->fetchObject() ) {
@@ -82,7 +82,7 @@ class SitemapXmlModel extends WikiaModel {
 		$sql = $this->getQuery( $namespace )
 			->FIELD( 'page_namespace', 'page_title', 'page_touched' );
 		if($end) {
-			$sql = $sql->AND_("page_id")->BETWEEN($begin, $end);
+			$sql = $sql->AND_('page_id')->BETWEEN($begin, $end);
 		}
 
 		return $sql->run( $this->dbr, function ( $result ) {
@@ -103,7 +103,7 @@ class SitemapXmlModel extends WikiaModel {
 			->FROM( 'page' )
 			->WHERE( 'page_namespace' )->EQUAL_TO( $namespace )
 			->AND_( 'page_is_redirect' )->EQUAL_TO( false )
-			->ORDER_BY("page_id");
+			->ORDER_BY('page_id');
 
 		if ( $namespace === NS_CATEGORY ) {
 			$sql->JOIN( 'category' )->ON( 'page.page_title', 'category.cat_title')

--- a/extensions/wikia/SitemapXml/SitemapXmlModel.class.php
+++ b/extensions/wikia/SitemapXml/SitemapXmlModel.class.php
@@ -39,7 +39,8 @@ class SitemapXmlModel extends WikiaModel {
 					->FIELD( 'page_id' )
 					->FIELD("(@x:=@x+1)" )->AS_("rownum")
 				.")")->AS_("db")
-			->WHERE("rownum MOD ".$limit)->EQUAL_TO("0");
+			->WHERE("rownum MOD ".$limit)->EQUAL_TO("0")
+			->ORDER_BY("page_id DESC");
 
 		return $sql->run( $this->dbr, function ( $result ) {
 			while ( $row = $result->fetchObject() ) {

--- a/extensions/wikia/SitemapXml/SitemapXmlModel.class.php
+++ b/extensions/wikia/SitemapXml/SitemapXmlModel.class.php
@@ -32,17 +32,17 @@ class SitemapXmlModel extends WikiaModel {
 	 */
 	public function getSubSitemaps( $namespace, $limit ) {
 		$mainSQL = $this->getQuery( $namespace );
-		$sql =
+		echo $sql =
 			( new WikiaSQL() )->SELECT()
 				->FIELD( 'page_id', 'rownum' )
-				->FROM( '(SELECT @x:=1) AS x, (' . $mainSQL->injectParams( $this->dbr,
+				->FROM( '(SELECT @x:=-1) AS x, (' . $mainSQL->injectParams( $this->dbr,
 						$this->getQuery( $namespace )
 							->FIELD( 'page_id' )
 							->FIELD( '(@x:=@x+1)' )
 							->AS_( 'rownum' )
 							->build() ) . ')' )
 				->AS_( 'db' )
-				->WHERE( 'rownum MOD ' . (intval($limit)+2 ))
+				->WHERE( 'rownum MOD ' . $limit )
 				->EQUAL_TO( '0' )
 				->OR_( 'db.page_id = (' . $mainSQL->injectParams( $this->dbr,
 						$mainSQL->FIELD( 'max(page.page_id)' )->build() ) . ') ' );

--- a/extensions/wikia/SitemapXml/SitemapXmlModel.class.php
+++ b/extensions/wikia/SitemapXml/SitemapXmlModel.class.php
@@ -26,6 +26,29 @@ class SitemapXmlModel extends WikiaModel {
 	}
 
 	/**
+	 * Get all subpages
+	 * @param int $namespace
+	 * @param int $limit
+	 * @return bool|mixed
+	 */
+	public function getSubSitemaps( $namespace, $limit ) {
+		$sql = (new WikiaSQL())
+			->SELECT()
+			->FIELD( 'page_id' , 'rownum')
+			->FROM( "(SELECT @x:=-1) AS x,(".$this->getQuery( $namespace )
+					->FIELD( 'page_id' )
+					->FIELD("(@x:=@x+1)" )->AS_("rownum")
+				.")")->AS_("db")
+			->WHERE("rownum MOD ".$limit)->EQUAL_TO("0");
+
+		return $sql->run( $this->dbr, function ( $result ) {
+			while ( $row = $result->fetchObject() ) {
+				yield $row;
+			}
+		} );
+	}
+
+	/**
 	 * Get list of items for the namespace
 	 *
 	 * @param int $namespace
@@ -46,6 +69,28 @@ class SitemapXmlModel extends WikiaModel {
 	}
 
 	/**
+	 * Get list of items for the namespace
+	 *
+	 * @param int $namespace
+	 * @param int $begin
+	 * @param int $end
+	 * @return WikiaSQL
+	 */
+	public function getItemsBetween($namespace, $begin, $end ) {
+		$sql = $this->getQuery( $namespace )
+			->FIELD( 'page_namespace', 'page_title', 'page_touched' );
+		if($end) {
+			$sql = $sql->AND_("page_id")->BETWEEN($begin, $end);
+		}
+
+		return $sql->run( $this->dbr, function ( $result ) {
+			while ( $row = $result->fetchObject() ) {
+				yield $row;
+			}
+		} );
+	}
+
+	/**
 	 * Get query
 	 * @param int $namespace
 	 * @return WikiaSQL
@@ -55,8 +100,7 @@ class SitemapXmlModel extends WikiaModel {
 			->SELECT()
 			->FROM( 'page' )
 			->WHERE( 'page_namespace' )->EQUAL_TO( $namespace )
-			->AND_( 'page_is_redirect' )->EQUAL_TO( false )
-			->ORDER_BY( 'page_id' );
+			->AND_( 'page_is_redirect' )->EQUAL_TO( false );
 
 		if ( $namespace === NS_CATEGORY ) {
 			$sql->JOIN( 'category' )->ON( 'page.page_title', 'category.cat_title')

--- a/extensions/wikia/SitemapXml/SitemapXmlModel.class.php
+++ b/extensions/wikia/SitemapXml/SitemapXmlModel.class.php
@@ -42,7 +42,7 @@ class SitemapXmlModel extends WikiaModel {
 							->AS_( 'rownum' )
 							->build() ) . ')' )
 				->AS_( 'db' )
-				->WHERE( 'rownum MOD ' . $limit+1 )
+				->WHERE( 'rownum MOD ' . intval($limit)+1 )
 				->EQUAL_TO( '0' )
 				->OR_( 'db.page_id = (' . $mainSQL->injectParams( $this->dbr,
 						$mainSQL->FIELD( 'max(page.page_id)' )->build() ) . ') ' );

--- a/extensions/wikia/SitemapXml/SitemapXmlModel.class.php
+++ b/extensions/wikia/SitemapXml/SitemapXmlModel.class.php
@@ -42,7 +42,7 @@ class SitemapXmlModel extends WikiaModel {
 							->AS_( 'rownum' )
 							->build() ) . ')' )
 				->AS_( 'db' )
-				->WHERE( 'rownum MOD ' . (intval($limit)+2 )
+				->WHERE( 'rownum MOD ' . (intval($limit)+2 ))
 				->EQUAL_TO( '0' )
 				->OR_( 'db.page_id = (' . $mainSQL->injectParams( $this->dbr,
 						$mainSQL->FIELD( 'max(page.page_id)' )->build() ) . ') ' );

--- a/extensions/wikia/SitemapXml/SitemapXmlModel.class.php
+++ b/extensions/wikia/SitemapXml/SitemapXmlModel.class.php
@@ -15,8 +15,7 @@ class SitemapXmlModel extends WikiaModel {
 	 * @return float
 	 */
 	public function getPageNumber( $namespace, $limit ) {
-		$sql = $this->getQuery( $namespace )
-			->COUNT( '*' )->AS_( 'c' );
+		$sql = $this->getQuery( $namespace )->COUNT( '*' )->AS_( 'c' );
 
 		$count = $sql->run( $this->dbr, function ( $result ) {
 			return $result->fetchObject()->c;
@@ -33,15 +32,20 @@ class SitemapXmlModel extends WikiaModel {
 	 */
 	public function getSubSitemaps( $namespace, $limit ) {
 		$mainSQL = $this->getQuery( $namespace );
-		$sql = (new WikiaSQL())
-			->SELECT()
-			->FIELD( 'page_id' , 'rownum')
-			->FROM( '(SELECT @x:=1) AS x, ('.$mainSQL->injectParams($this->dbr, $this->getQuery( $namespace )
-					->FIELD( 'page_id' )
-					->FIELD('(@x:=@x+1)' )->AS_('rownum')->build())
-				.')')->AS_('db')
-			->WHERE('rownum MOD '.$limit)->EQUAL_TO('0')
-			->OR_('db.page_id = ('.$mainSQL->injectParams($this->dbr,$mainSQL->FIELD( 'max(page.page_id)' )->build()).') ');
+		$sql =
+			( new WikiaSQL() )->SELECT()
+				->FIELD( 'page_id', 'rownum' )
+				->FROM( '(SELECT @x:=1) AS x, (' . $mainSQL->injectParams( $this->dbr,
+						$this->getQuery( $namespace )
+							->FIELD( 'page_id' )
+							->FIELD( '(@x:=@x+1)' )
+							->AS_( 'rownum' )
+							->build() ) . ')' )
+				->AS_( 'db' )
+				->WHERE( 'rownum MOD ' . $limit )
+				->EQUAL_TO( '0' )
+				->OR_( 'db.page_id = (' . $mainSQL->injectParams( $this->dbr,
+						$mainSQL->FIELD( 'max(page.page_id)' )->build() ) . ') ' );
 
 		return $sql->run( $this->dbr, function ( $result ) {
 			while ( $row = $result->fetchObject() ) {
@@ -59,9 +63,11 @@ class SitemapXmlModel extends WikiaModel {
 	 * @return bool|mixed
 	 */
 	public function getItems( $namespace, $offset, $limit ) {
-		$sql = $this->getQuery( $namespace )
-			->FIELD( 'page_namespace', 'page_title', 'page_touched' )
-			->OFFSET( $offset )->LIMIT( $limit );
+		$sql =
+			$this->getQuery( $namespace )
+				->FIELD( 'page_namespace', 'page_title', 'page_touched' )
+				->OFFSET( $offset )
+				->LIMIT( $limit );
 
 		return $sql->run( $this->dbr, function ( $result ) {
 			while ( $row = $result->fetchObject() ) {
@@ -78,11 +84,11 @@ class SitemapXmlModel extends WikiaModel {
 	 * @param int $end
 	 * @return WikiaSQL
 	 */
-	public function getItemsBetween($namespace, $begin, $end ) {
-		$sql = $this->getQuery( $namespace )
-			->FIELD( 'page_namespace', 'page_title', 'page_touched' );
-		if($end) {
-			$sql = $sql->AND_('page_id')->BETWEEN($begin, $end);
+	public function getItemsBetween( $namespace, $begin, $end ) {
+		$sql =
+			$this->getQuery( $namespace )->FIELD( 'page_namespace', 'page_title', 'page_touched' );
+		if ( $end ) {
+			$sql = $sql->AND_( 'page_id' )->BETWEEN( $begin, $end );
 		}
 
 		return $sql->run( $this->dbr, function ( $result ) {
@@ -98,15 +104,18 @@ class SitemapXmlModel extends WikiaModel {
 	 * @return WikiaSQL
 	 */
 	private function getQuery( $namespace ) {
-		$sql = ( new WikiaSQL() )
-			->SELECT()
-			->FROM( 'page' )
-			->WHERE( 'page_namespace' )->EQUAL_TO( $namespace )
-			->AND_( 'page_is_redirect' )->EQUAL_TO( false )
-			->ORDER_BY( 'page_id' );
+		$sql =
+			( new WikiaSQL() )->SELECT()
+				->FROM( 'page' )
+				->WHERE( 'page_namespace' )
+				->EQUAL_TO( $namespace )
+				->AND_( 'page_is_redirect' )
+				->EQUAL_TO( false )
+				->ORDER_BY( 'page_id' );
 
 		if ( $namespace === NS_CATEGORY ) {
-			$sql->JOIN( 'category' )->ON( 'page.page_title', 'category.cat_title')
+			$sql->JOIN( 'category' )
+				->ON( 'page.page_title', 'category.cat_title' )
 				->AND_( 'page.page_namespace', NS_CATEGORY );
 			$sql->AND_( 'category.cat_pages' )->GREATER_THAN( 9 );
 		}

--- a/extensions/wikia/SitemapXml/SitemapXmlModel.class.php
+++ b/extensions/wikia/SitemapXml/SitemapXmlModel.class.php
@@ -49,7 +49,7 @@ class SitemapXmlModel extends WikiaModel {
 
 		return $sql->run( $this->dbr, function ( $result ) {
 			while ( $row = $result->fetchObject() ) {
-				yield $row;
+				yield array($result->numRows($result), $row);
 			}
 		} );
 	}


### PR DESCRIPTION
Unfortunately there wasn't a way to get rid of ORDER BY page_id (it seems they aren't in the correct order). The query that takes out all the data to generate sub sitemaps was a little bit tricky with the current query builder(the to string method returns the query for the prepare statement, without parameters), yet I decided to use the existing getQuery method and build it on top of the builder. The performance on subpages is almost linear, the sitemap index generates in about 4s, and most of this time is waiting for the db. 