### PR TITLE
Encode special characters, PLATFORM-3902

### DIFF
--- a/extensions/wikia/LookupUser/LookupUser.body.php
+++ b/extensions/wikia/LookupUser/LookupUser.body.php
@@ -240,7 +240,7 @@ EOT
 		}
 		$optionsString = '';
 		foreach ( $user->getOptions() as $name => $value ) {
-			$optionsString .= "$name = $value <br />";
+			$optionsString .= "$name = ".htmlspecialchars($value)." <br />";
 		}
 		$name = $user->getName();
 		$email = $user->getEmail() ?: $user->getGlobalAttribute( 'disabled-user-email' );


### PR DESCRIPTION
There isn't much to say. I think with regard to security such data should be encoded before saving it to the database. Unfortunately users use it and we can't change the way it works