### PR TITLE
IW-1504: fix the recirculation after migrating N&S to fandom.com

### DIFF
--- a/extensions/wikia/Recirculation/services/CuratedContentService.class.php
+++ b/extensions/wikia/Recirculation/services/CuratedContentService.class.php
@@ -3,7 +3,7 @@
 class CuratedContentService {
 	static protected $instance = null;
 
-	const API_BASE = 'http://fandom.wikia.com/api/recirculation_units/';
+	const API_BASE = 'https://www.fandom.com/api/recirculation_units/';
 
 	const MCACHE_VER = '1.0';
 	const MCACHE_TIME = 900; // 15 minutes

--- a/extensions/wikia/Recirculation/services/FandomDataService.class.php
+++ b/extensions/wikia/Recirculation/services/FandomDataService.class.php
@@ -1,7 +1,7 @@
 <?php
 
 class FandomDataService {
-	const API_BASE = 'http://fandom.wikia.com/wp-json/wp/v2/';
+	const API_BASE = 'https://www.fandom.com/wp-json/wp/v2/';
 
 	const MCACHE_VER = '1.0';
 	const MCACHE_TIME = 900; // 15 minutes
@@ -25,7 +25,7 @@ class FandomDataService {
 		if ( $type === 'category' || $type === 'latest' ) {
 			$this->setupCategories( $ignoreTopic );
 		} else {
-			$this->setupVerticalCategory( $vertical );
+			$this->setupVerticalCategory();
 		}
 	}
 
@@ -112,7 +112,7 @@ class FandomDataService {
 		return $posts;
 	}
 
-	private function setupVerticalCategory( $vertical ) {
+	private function setupVerticalCategory() {
 		$wikiFactoryHub = WikiFactoryHub::getInstance();
 		$vertical = $wikiFactoryHub->getWikiVertical( $this->cityId )['short'];
 


### PR DESCRIPTION
N&S is hosted on www.fandom.com. Also, because we're using `ExternalHttp` here, the request goes through Fastly, so in order to avoid a redirect, the request should use the https protocol.