### PR TITLE
(PLATFORM-3905) Convert embedded Special:FilePath URLs to Vignette URLs

### DIFF
--- a/extensions/wikia/HTTPSSupport/HTTPSSupport.setup.php
+++ b/extensions/wikia/HTTPSSupport/HTTPSSupport.setup.php
@@ -6,6 +6,7 @@ $wgHooks['BeforeInitialize'][] = 'HTTPSSupportHooks::onBeforeInitialize';
 $wgHooks['LinkerMakeExternalLink'][] = 'HTTPSSupportHooks::onLinkerMakeExternalLink';
 $wgHooks['MercuryWikiVariables'][] = 'HTTPSSupportHooks::onMercuryWikiVariables';
 $wgHooks['outputMakeExternalImage'][] = 'HTTPSSupportHooks::parserUpgradeVignetteUrls';
+$wgHooks['outputMakeExternalImage'][] = 'HTTPSSupportHooks::parserUpgradeSpecialFilePathURLs';
 $wgHooks['WikiaRobotsBeforeOutput'][] = 'HTTPSSupportHooks::onRobotsBeforeOutput';
 $wgHooks['InterwikiLoadBeforeCache'][] = 'HTTPSSupportHooks::onInterwikiLoadBeforeCache';
 $wgHooks['BeforeResourceLoaderCSSMinifier'][] = 'HTTPSSupportHooks::onBeforeResourceLoaderCSSMinifier';


### PR DESCRIPTION
This will attempt to fix plain HTTP Special:FilePath URLs in the simplest
cases by converting them to HTTPS Vignette URLs.

This will not account for non-English translations of Special:FilePath or
language path wiki URLs (which should only have ever been on HTTPS).

/cc @Wikia/core-platform-team 