### PR TITLE
IW-1518 | Fix saving attributes for multiple users

### DIFF
--- a/lib/Wikia/src/Service/User/Attributes/UserAttributes.php
+++ b/lib/Wikia/src/Service/User/Attributes/UserAttributes.php
@@ -22,7 +22,7 @@ class UserAttributes {
 	/** @var string[string] */
 	private $defaultAttributes;
 
-	/** @var Attribute[] $changedAttributes */
+	/** @var Attribute[][] $changedAttributes */
 	private $changedAttributes;
 
 	/**
@@ -95,32 +95,34 @@ class UserAttributes {
 
 		// SRE-97: Only set the attribute if it was not set before or the value was changed
 		if ( !isset( $this->attributes[$userId][$name] ) || $this->attributes[$userId][$name] !== $value ) {
-			$this->changedAttributes[$name] = $attribute;
+			$this->changedAttributes[$userId][$name] = $attribute;
 			$this->attributes[$userId][$name] = $attribute->getValue();
 		}
 	}
 
 	public function save( $userId ) {
-		$savedAttributes = [];
+		if ( isset( $this->changedAttributes[$userId] ) ) {
+			$savedAttributes = [];
 
-		foreach( $this->changedAttributes as $name => $attribute ) {
-			$value = $attribute->getValue();
+			foreach ( $this->changedAttributes[$userId] as $name => $attribute ) {
+				$value = $attribute->getValue();
 
-			if ( $this->isReadOnlyAttribute( $name ) ) {
-				continue;
-			}
-
-			if ( $this->attributeShouldBeSaved( $name, $value ) ) {
-				$savedAttributes[$name] = $value;
-				if ( $name == 'avatar' ) {
-					$this->logIfBadAvatarVal( $value, $userId );
+				if ( $this->isReadOnlyAttribute( $name ) ) {
+					continue;
 				}
-			} elseif ( $this->attributeShouldBeDeleted( $name, $value ) ) {
-				$this->deleteFromService( $userId, $attribute );
-			}
-		}
 
-		$this->attributeService->set( $userId, $savedAttributes );
+				if ( $this->attributeShouldBeSaved( $name, $value ) ) {
+					$savedAttributes[$name] = $value;
+					if ( $name == 'avatar' ) {
+						$this->logIfBadAvatarVal( $value, $userId );
+					}
+				} elseif ( $this->attributeShouldBeDeleted( $name, $value ) ) {
+					$this->deleteFromService( $userId, $attribute );
+				}
+			}
+
+			$this->attributeService->set( $userId, $savedAttributes );
+		}
 	}
 
 	private function isReadOnlyAttribute( $name ) {

--- a/lib/Wikia/tests/Service/User/AttributeKeyValueTest.php
+++ b/lib/Wikia/tests/Service/User/AttributeKeyValueTest.php
@@ -9,6 +9,7 @@ use Wikia\Service\PersistenceException;
 class AttributeKeyValueTest extends TestCase {
 
 	protected $userId = 1;
+	protected $otherUserId = 2;
 	protected $anonUserId = 0;
 	/** @var Attribute $testAttribute_1 */
 	protected $testAttribute_1;
@@ -37,6 +38,24 @@ class AttributeKeyValueTest extends TestCase {
 		$ret = $service->set( $this->userId, [ $this->testAttribute_1->getName() => $this->testAttribute_1->getValue()  ] );
 
 		$this->assertTrue( $ret, "the attribute was not set" );
+	}
+
+	public function testSetMultipleUsers() {
+		$this->persistenceMock->expects( $this->at( 0 ) )
+			->method( 'saveAttributes' )
+			->with( $this->userId, [ $this->testAttribute_1->getName() => $this->testAttribute_1->getValue()  ] )
+			->willReturn( true );
+		$this->persistenceMock->expects( $this->at( 1 ) )
+			->method( 'saveAttributes' )
+			->with( $this->otherUserId, [ $this->testAttribute_2->getName() => $this->testAttribute_2->getValue()  ] )
+			->willReturn( true );
+
+		$service = new AttributeService( $this->persistenceMock );
+		$firstUserResult = $service->set( $this->userId, [ $this->testAttribute_1->getName() => $this->testAttribute_1->getValue() ] );
+		$otherUserResult = $service->set( $this->otherUserId, [ $this->testAttribute_2->getName() => $this->testAttribute_2->getValue() ] );
+
+		$this->assertTrue( $firstUserResult, "the attribute was not set" );
+		$this->assertTrue( $otherUserResult, "the attribute was not set" );
 	}
 
 	/**


### PR DESCRIPTION
The UAS client stores a 2D array of attributes (user ID, name). However, a 1D array was  used to store attributes that were changed during a request, which meant that users' attributes could be mixed up in situations where attributes were changed for user(s) other than the request user. By making sure a 2D array is used in this case as well, we avoid this.

@Wikia/iwing 

https://wikia-inc.atlassian.net/browse/IW-1518