### PR TITLE
IW-1529 | Fix saving empty attributes

### DIFF
--- a/lib/Wikia/src/Service/User/Attributes/AttributeService.php
+++ b/lib/Wikia/src/Service/User/Attributes/AttributeService.php
@@ -34,10 +34,8 @@ class AttributeService {
 	 * @throws \Exception
 	 */
 	public function set( $userId, array $attributes ) {
-		$nonEmptyAttributes = array_filter( $attributes );
-
 		// SRE-97: No attributes to save, nothing to do
-		if ( empty( $nonEmptyAttributes ) ) {
+		if ( empty( $attributes ) ) {
 			return true;
 		}
 
@@ -47,7 +45,7 @@ class AttributeService {
 
 		try {
 			$profilerStart = $this->startProfile();
-			$ret = $this->persistenceAdapter->saveAttributes( $userId, $nonEmptyAttributes );
+			$ret = $this->persistenceAdapter->saveAttributes( $userId, $attributes );
 			$this->endProfile( AttributeService::PROFILE_EVENT, $profilerStart,
 				[ 'user_id' => intval($userId), 'method' => 'saveAttribute' ] );
 

--- a/lib/Wikia/tests/Service/User/AttributeKeyValueTest.php
+++ b/lib/Wikia/tests/Service/User/AttributeKeyValueTest.php
@@ -40,6 +40,18 @@ class AttributeKeyValueTest extends TestCase {
 		$this->assertTrue( $ret, "the attribute was not set" );
 	}
 
+	public function testSetEmptyAttributeSuccess() {
+		$this->persistenceMock->expects( $this->once() )
+			->method( 'saveAttributes' )
+			->with( $this->userId, [ $this->testAttribute_1->getName() => ''  ] )
+			->willReturn( true );
+
+		$service = new AttributeService( $this->persistenceMock );
+		$ret = $service->set( $this->userId, [ $this->testAttribute_1->getName() => ''  ] );
+
+		$this->assertTrue( $ret, "the attribute was not set" );
+	}
+
 	public function testSetMultipleUsers() {
 		$this->persistenceMock->expects( $this->at( 0 ) )
 			->method( 'saveAttributes' )


### PR DESCRIPTION
`array_filter` will filter out array values that are empty, which made it impossible to blank user profile fields and save the data. Instead of filtering out empty items, we should check if the set of attributes itself is empty.

@Wikia/iwing 

https://wikia-inc.atlassian.net/browse/IW-1529