### PR TITLE
IW-1517 perform reupload check inside of WikiaMiniUpload::insertImage

### DIFF
--- a/extensions/wikia/WikiaMiniUpload/WikiaMiniUpload_body.php
+++ b/extensions/wikia/WikiaMiniUpload/WikiaMiniUpload_body.php
@@ -492,17 +492,12 @@ class WikiaMiniUpload {
 				}
 				if ( $title->exists() ) {
 					if ( $type == 'overwrite' ) {
-						$title = Title::newFromText($name, 6);
-						// is the target protected?
-						$permErrors = $title->getUserPermissionsErrors( 'edit', $wgUser );
-						$permErrorsUpload = $title->getUserPermissionsErrors( 'upload', $wgUser );
-						$permErrorsCreate = ( $title->exists() ? [] : $title->getUserPermissionsErrors( 'create', $wgUser ) );
-
-						if ( $permErrors || $permErrorsUpload || $permErrorsCreate ) {
+						if ( !\UploadBase::userCanReUpload( $wgUser, $name ) ) {
 							header( 'X-screen-type: error' );
 							return wfMessage( 'wmu-file-protected' )->plain();
 						}
 
+						$title = Title::newFromText( $name, 6 );
 						$file_name = new LocalFile( $title, RepoGroup::singleton()->getLocalRepo() );
 						$file_mwname = new FakeLocalFile( Title::newFromText( $mwname, NS_FILE ), RepoGroup::singleton()->getLocalRepo() );
 

--- a/extensions/wikia/WikiaMiniUpload/WikiaMiniUpload_body.php
+++ b/extensions/wikia/WikiaMiniUpload/WikiaMiniUpload_body.php
@@ -748,7 +748,6 @@ class WikiaMiniUpload {
 
 		return empty( $title->getUserPermissionsErrors( 'edit', $wgUser ) )
 			&& empty( $title->getUserPermissionsErrors( 'upload', $wgUser ) )
-			&& empty( $title->getUserPermissionsErrors( 'create', $wgUser ) )
 			&& ( $file instanceof File && UploadBase::userCanReUpload( $wgUser, $file->getName() ) );
 	}
 


### PR DESCRIPTION
Ticket: https://wikia-inc.atlassian.net/browse/IW-1517

This PR fixes a vulnerability which would allow a user to circumvent our `reupload` permission using the WMO insertImage API. This PR adds a call to `\UploadBase::userCanReUpload` which does the reupload checks for us.

Also, credit to @mszabo-wikia for identifying where we were missing that permission check and suggesting the proper fix.

cc @Wikia/iwing 