### PR TITLE
Handle exceptions in Nirvana API

### DIFF
--- a/wikia.php
+++ b/wikia.php
@@ -84,15 +84,16 @@ if ( !empty( $wgEnableNirvanaAPI ) ) {
 		$response->render();
 	} catch ( WikiaHttpException $e ) {
 		http_response_code( $e->getCode() );
-		if ( $e->getCode() >= 500 ) {
+		if ( $e->getCode() >= WikiaResponse::RESPONSE_CODE_INTERNAL_SERVER_ERROR ) {
 			Wikia\Logger\WikiaLogger::instance()->error( 'Unhandled API error', [
 				'status'=> $e->getCode(),
 				'exception' => $e
 			] );
 		}
 	} catch ( Exception $e ) {
-		header( "HTTP/1.1 500 Internal Server Error", true, 500 );
+		header( "HTTP/1.1 500 Internal Server Error", true, WikiaResponse::RESPONSE_CODE_INTERNAL_SERVER_ERROR );
 		Wikia\Logger\WikiaLogger::instance()->error( 'Unhandled API error', [
+			'status' => WikiaResponse::RESPONSE_CODE_INTERNAL_SERVER_ERROR,
 			'exception' => $e
 		] );
 	}

--- a/wikia.php
+++ b/wikia.php
@@ -103,7 +103,7 @@ if ( !empty( $wgEnableNirvanaAPI ) ) {
 		echo json_encode( [
 			'status' => $e->getCode(),
 			'error' => get_class( $e ),
-			'details' => $e->getDetails()
+			'message' => $e->getMessage()
 		]);
 
 		Wikia\Logger\WikiaLogger::instance()->error( 'Unhandled API error', [

--- a/wikia.php
+++ b/wikia.php
@@ -84,6 +84,13 @@ if ( !empty( $wgEnableNirvanaAPI ) ) {
 		$response->render();
 	} catch ( WikiaHttpException $e ) {
 		http_response_code( $e->getCode() );
+		header('Content-Type: application/json; charset=utf-8');
+		echo json_encode( [
+			'status' => $e->getCode(),
+			'error' => get_class( $e ),
+			'details' => $e->getDetails()
+		]);
+
 		if ( $e->getCode() >= WikiaResponse::RESPONSE_CODE_INTERNAL_SERVER_ERROR ) {
 			Wikia\Logger\WikiaLogger::instance()->error( 'Unhandled API error', [
 				'status'=> $e->getCode(),
@@ -92,6 +99,13 @@ if ( !empty( $wgEnableNirvanaAPI ) ) {
 		}
 	} catch ( Exception $e ) {
 		header( "HTTP/1.1 500 Internal Server Error", true, WikiaResponse::RESPONSE_CODE_INTERNAL_SERVER_ERROR );
+		header('Content-Type: application/json; charset=utf-8');
+		echo json_encode( [
+			'status' => $e->getCode(),
+			'error' => get_class( $e ),
+			'details' => $e->getDetails()
+		]);
+
 		Wikia\Logger\WikiaLogger::instance()->error( 'Unhandled API error', [
 			'status' => WikiaResponse::RESPONSE_CODE_INTERNAL_SERVER_ERROR,
 			'exception' => $e


### PR DESCRIPTION
For internal requests with the `X-Wikia-Internal-Request` header,  the dispatcher rethrows exceptions instead of returning the response: https://github.com/Wikia/app/blob/1e4ea22073c29ec97beeccda86d068915366d0c5/includes/wikia/nirvana/WikiaDispatcher.class.php#L236-L240. 
Because there was no error handling in `wikia.php`, this was resulting in empty responses with 200 response status.
