### PR TITLE
MAIN-18627: Respect wgScriptPath in the Discussions profile link.

### DIFF
--- a/extensions/wikia/UserProfilePageV3/UserIdentityBoxDiscussionInfo.class.php
+++ b/extensions/wikia/UserProfilePageV3/UserIdentityBoxDiscussionInfo.class.php
@@ -34,11 +34,11 @@ class UserIdentityBoxDiscussionInfo {
 	}
 
 	private function fetchDiscussionPostsNumber() {
-
 		$this->discussionActive = F::app()->wg->EnableDiscussions;
 		if ( $this->discussionActive ) {
+			global $wgScriptPath;
 			$this->discussionPostsCount = $this->fetchDiscussionPostsCount();
-			$this->discussionAllPostsByUserLink = "/d/u/{$this->userId}";
+			$this->discussionAllPostsByUserLink = "$wgScriptPath/d/u/{$this->userId}";
 		}
 	}
 


### PR DESCRIPTION
The link to a user's Discussions profile isn't respecting the wiki's script path, which makes it point to Discussions of the base (English) wiki (if it exists).

[Issue example](https://warframe.fandom.com/ru/wiki/User_talk:FANSG) ([discussion](https://dev.wikia.com/wiki/User_talk:FANSG#FixDiscussionsCount))
Support ticket: [ZD#432881](https://support.wikia-inc.com/hc/en-us/requests/432881)
Bug ticket: [MAIN-18627](https://wikia-inc.atlassian.net/browse/MAIN-18627)