### PR TITLE
PLATFORM-3930: Fix allinone=0 URL parameter on non-English wikis

### DIFF
--- a/extensions/wikia/AssetsManager/AssetsManager.class.php
+++ b/extensions/wikia/AssetsManager/AssetsManager.class.php
@@ -177,7 +177,6 @@ class AssetsManager {
 						// We always need to use common host for static assets since it has
 						// the information about the slot which is otherwise not available
 						// in varnish (BugId: 33905)
-//						$urls[] =  ( !empty( $local ) ) ? $this->mCommonHost . $this->getOneLocalURL( $asset ) : $this->getOneCommonURL( $asset );
 						$urls[] =  $this->getOneCommonURL( $asset );
 					}
 				}
@@ -388,27 +387,6 @@ class AssetsManager {
 	}
 
 	/**
-	 * Returns domainless URL to an asset
-	 *
-	 * @author Inez Korczyński <korczynski@gmail.com>
-	 * @return string Relative URL to one file
-	 */
-	public function getOneLocalURL(/* string */ $filePath, /* boolean */ $minify = null) {
-		global $wgScriptPath;
-		// we should never ever use Asset Manager for ONE file
-		// as it build our whole PHP stack and reads file from filesystem
-		// which cannot be cached by web server as the content is assumed
-		// to be dynamic
-		// BAC-696: added ltrim() - prevent double slash in the URL
-		$url = $wgScriptPath . '/' . ltrim( $filePath, '/' );
-		// TODO: remove it completely
-		//if ($minify !== null ? $minify : $this->mMinify) {
-		//	$url = $this->getAMLocalURL('one', $filePath);
-		//}
-		return $url;
-	}
-
-	/**
 	 * @author Inez Korczyński <korczynski@gmail.com>
 	 * @return string Full common URL to one file, uses not wiki specific host
 	 */
@@ -421,7 +399,7 @@ class AssetsManager {
 			// We always need to use common host for static assets since it has
 			// the information about the slot which is otherwise not available
 			// in varnish (BugId: 33905)
-			$url = $this->mCommonHost . $this->getOneLocalURL($filePath, $minify);
+			$url = $this->mCommonHost . '/' . ltrim( $filePath, '/' );
 		}
 
 		return $url;


### PR DESCRIPTION
The AssetsManager class contains a method that respects `$wgScriptPath` when generating URLs to assets - `getOneLocalURL`. Judging by the method's description, this behavior is absolutely intended, as it is supposed to generate a local URL to a single asset. However, the method is never used for that purpose, and it only started causing bugs after `$wgScriptPath` became something other than an empty string (that is, after the fandom.com/HTTPS migration).
This misuse, in turn, causes the `allinone=0` URL parameter (which is supposed to allow loading of every asset separately) to break on non-English wikis, while throwing a lot of 404 errors due to `$wgScriptPath`, which is only supposed to be used inside local URLs, being used in common URLs.
This pull request removes the incorrectly used method in favor of the non-broken part of the functionality it provides.

[Issue example](https://saltandsanctuary.fandom.com/ru/wiki/Special:Random?allinone=0)
Support ticket: [ZD#432990](https://support.wikia-inc.com/hc/en-us/requests/432990)
Bug ticket: [PLATFORM-3930](https://wikia-inc.atlassian.net/browse/PLATFORM-3930)