### PR TITLE
(PLATFORM-3931) Fix value of wgServer during CNW post-creation task

### DIFF
--- a/lib/Wikia/src/Tasks/Tasks/CreateNewWikiTask.php
+++ b/lib/Wikia/src/Tasks/Tasks/CreateNewWikiTask.php
@@ -34,7 +34,7 @@ class CreateNewWikiTask extends BaseTask {
 	public function postCreationSetup( $params ) {
 		global $wgErrorLog, $wgServer, $wgInternalServer, $wgStatsDBEnabled;
 
-		$wgServer = rtrim( $params['url'], '/' );
+		$wgServer = \WikiFactory::cityUrlToDomain( $params['url'] );
 		$wgInternalServer = $wgServer;
 		$wgStatsDBEnabled = false;   // disable any DW queries/hooks during wiki creation
 


### PR DESCRIPTION
During the CNW post-creation task, wgServer was being overridden and ended
up including the language path. This caused URLs generated during the task
to have more than one language code in the path on non-English wikis (i.e.
/ja/ja rather than just /ja).

/cc @Wikia/core-platform-team 