### PR TITLE
PLATFORM-3878 | Avoid PHP Notice on community wiki in CLI context

### DIFF
--- a/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
+++ b/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
@@ -491,11 +491,12 @@ class WikiFactoryLoader {
 		// For api calls to community, fake the mServerName value so it matches city_url. This
 		// stops the redirects and allows the api to be used on every community domain configured
 		// in WikiFactory.
-		if ( $this->mWikiID == WikiFactory::COMMUNITY_CENTRAL &&
-			 ( strpos( $this->parsedUrl['path'], '/api.php' ) === 0 ||
-			   strpos( $this->parsedUrl['path'], '/wikia.php' ) === 0 ||
-			   strpos( $this->parsedUrl['path'], '/api/v1' ) === 0 ) ) {
-			$this->mServerName = strtolower( $url['host'] );
+		if ( $this->mWikiID == WikiFactory::COMMUNITY_CENTRAL && isset( $this->parsedUrl['path'] ) ) {
+			if ( strpos( $this->parsedUrl['path'], '/api.php' ) === 0 ||
+				 strpos( $this->parsedUrl['path'], '/wikia.php' ) === 0 ||
+				 strpos( $this->parsedUrl['path'], '/api/v1' ) === 0 ) {
+				$this->mServerName = strtolower( $url['host'] );
+			}
 		}
 		// end of PLATFORM-3878 hack
 


### PR DESCRIPTION
The workaround introduced in https://github.com/Wikia/app/pull/16604 causes PHP Notices when a CLI script is run in the context of community wiki, since `parsedUrl` is not set in such a scenario:
```
Warning: Illegal string offset 'path' in /usr/wikia/source/app/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php on line 495

Notice: Uninitialized string offset: 0 in /usr/wikia/source/app/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php on line 495
```

Let's add a check here to avoid these notices.