### PR TITLE
CORE-73: edit-page-ready events for Source Editor is questionable

### DIFF
--- a/extensions/wikia/EditPageLayout/js/plugins/PageControls.js
+++ b/extensions/wikia/EditPageLayout/js/plugins/PageControls.js
@@ -113,6 +113,11 @@
 				this.textarea.val('');
 			}
 
+			this.editor.track({
+				action: Wikia.Tracker.ACTIONS.SUBMIT,
+				label: 'publish'
+			});
+
 			try {
 				if (window.veTrack) {
 					veTrack({
@@ -120,11 +125,6 @@
 						isDirty: (typeof this.editor.plugins.leaveconfirm === 'undefined' || this.editor.plugins.leaveconfirm.isDirty()) ? 'yes' : 'no'
 					});
 				}
-
-				this.editor.track({
-					action: Wikia.Tracker.ACTIONS.SUBMIT,
-					label: 'publish'
-				});
 			} finally {
 				this.editor.setState(this.editor.states.SAVING);
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CORE-73

Move a call to tracker out from a try/catch block. `veTrack` looks pretty fishy and it uses `syslogReport()` function to log via Apache access logs. Do we still use it?