### PR TITLE
CAKE-3572: Get Var Value Only For Community Id

### DIFF
--- a/extensions/wikia/WikiFactory/api/MarkWikiAsClosedController.class.php
+++ b/extensions/wikia/WikiFactory/api/MarkWikiAsClosedController.class.php
@@ -77,7 +77,7 @@ class MarkWikiAsClosedController extends WikiaController {
 		$isGoForClose = true;
 
 		if ( !empty( $fandomCreatorCommunityId ) ) {
-			$wikiFandomCreatorCommunityId = WikiFactory::getVarByName( CommunitySetup::WF_VAR_FC_COMMUNITY_ID, $wikiId );
+			$wikiFandomCreatorCommunityId = WikiFactory::getVarValueByName( CommunitySetup::WF_VAR_FC_COMMUNITY_ID, $wikiId );
 
 			if ( $fandomCreatorCommunityId == $wikiFandomCreatorCommunityId ) {
 				$isGoForClose = WikiFactory::resetFlags(


### PR DESCRIPTION
Changed `WikiFactory::getVarByName` to `WikiFactory::getVarValueByName`

@Wikia/cake 