### PR TITLE
CAKE-3572: Improve Flow Atomicity, Force Checks Against Master DB, During Wiki Close

### DIFF
--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -2034,8 +2034,15 @@ class WikiFactory {
 	 * @param null $user
 	 * @return string: HTML form
 	 */
-	static public function setPublicStatus( $city_public, $city_id, $reason = "", $user = null ) {
+	static public function setPublicStatus(
+		$city_public,
+		$city_id,
+		$reason = "",
+		$user = null,
+		$shouldUseMasterDbOnCheckFlags = false
+	) {
 		global $wgWikicitiesReadOnly;
+
 		if ( ! static::isUsed() ) {
 			Wikia::log( __METHOD__, "", "WikiFactory is not used." );
 			return false;
@@ -2046,7 +2053,7 @@ class WikiFactory {
 			return false;
 		}
 
-		if ( (static::getFlags($city_id) & static::FLAG_PROTECTED) && $city_public != 1 ) {
+		if ( ( static::getFlags( $city_id, $shouldUseMasterDbOnCheckFlags ) & static::FLAG_PROTECTED ) && $city_public != 1 ) {
 			Wikia::log( __METHOD__, "", "Wiki is protected. Skipping update.");
 			return false;
 		}
@@ -2858,7 +2865,7 @@ class WikiFactory {
 	 *
 	 * @return flags
 	 */
-	static public function getFlags( $city_id ) {
+	static public function getFlags( $city_id, $shouldUseMasterDb = false ) {
 		if ( !static::isUsed() ) {
 			Wikia::log( __METHOD__, 'info', 'WikiFactory is not used.' );
 			return false;
@@ -2866,7 +2873,8 @@ class WikiFactory {
 
 		wfProfileIn( __METHOD__ );
 
-		$dbw = static::db( DB_SLAVE );
+		$dbw = ( $shouldUseMasterDb ) ? static::db( DB_MASTER ) : static::db( DB_SLAVE );
+
 		$city_flags = $dbw->selectField(
 			'city_list',
 			'city_flags',

--- a/extensions/wikia/WikiFactory/api/MarkWikiAsClosedController.class.php
+++ b/extensions/wikia/WikiFactory/api/MarkWikiAsClosedController.class.php
@@ -123,7 +123,7 @@ class MarkWikiAsClosedController extends WikiaController {
 	}
 
 	static private function isValidFandomCreatorCommunityId( $fandomCreatorCommunityId, $wikiId ) {
-		if (!is_numeric( $fandomCreatorCommunityId )) {
+		if ( !is_numeric( $fandomCreatorCommunityId ) ) {
 			return false;
 		}
 

--- a/extensions/wikia/WikiFactory/api/MarkWikiAsClosedController.class.php
+++ b/extensions/wikia/WikiFactory/api/MarkWikiAsClosedController.class.php
@@ -30,7 +30,7 @@ class MarkWikiAsClosedController extends WikiaController {
 		if ( !is_numeric( $wikiId ) || empty( $reason ) || !is_numeric( $userId ) ) {
 			// No wikiId, userId or reason given: Bad Request
 			$this->response->setCode( 400 );
-			$this->info('no wikiId or reason parameter in request' );
+			$this->info( 'no wikiId or reason parameter in request' );
 
 			return;
 		}
@@ -38,14 +38,14 @@ class MarkWikiAsClosedController extends WikiaController {
 		if ( !empty( $fandomCreatorCommunityId ) ) {
 			if ( !static::isValidFandomCreatorCommunityId( $fandomCreatorCommunityId, $wikiId )) {
 				$this->response->setCode( 400 );
-				$this->info('invalid fandomCreatorCommunityId parameter in request: ' . $fandomCreatorCommunityId );
+				$this->info( 'invalid fandomCreatorCommunityId parameter in request: ' . $fandomCreatorCommunityId );
 
 				return;
 			}
 
 			if ( !static::removeProtectionFromFandomCreatorCommunityWiki( $wikiId, $reason ) ) {
 				$this->response->setCode( 500 );
-				$this->info('could not remove protected flag on wiki with id: ' . $wikiId );
+				$this->info( 'could not remove protected flag on wiki with id: ' . $wikiId );
 
 				return;
 			}
@@ -55,7 +55,7 @@ class MarkWikiAsClosedController extends WikiaController {
 
 		if ( !static::closeWiki( $wikiId, $user, $reason ) ) {
 			$this->response->setCode( 500 );
-			$this->info('could not close wiki with id: ' . $wikiId );
+			$this->info( 'could not close wiki with id: ' . $wikiId );
 
 			return;
 		}

--- a/extensions/wikia/WikiFactory/api/MarkWikiAsClosedController.class.php
+++ b/extensions/wikia/WikiFactory/api/MarkWikiAsClosedController.class.php
@@ -110,7 +110,7 @@ class MarkWikiAsClosedController extends WikiaController {
 			true
 		);
 
-		return ($status === WikiFactory::CLOSE_ACTION);
+		return ( $status === WikiFactory::CLOSE_ACTION );
 	}
 
 	static private function removeProtectionFromFandomCreatorCommunityWiki( $wikiId, $reason ) {
@@ -129,6 +129,6 @@ class MarkWikiAsClosedController extends WikiaController {
 
 		$wikiFandomCreatorCommunityId = WikiFactory::getVarValueByName( CommunitySetup::WF_VAR_FC_COMMUNITY_ID, $wikiId );
 
-		return ($fandomCreatorCommunityId == $wikiFandomCreatorCommunityId);
+		return ( $fandomCreatorCommunityId == $wikiFandomCreatorCommunityId );
 	}
 }

--- a/extensions/wikia/WikiFactory/api/MarkWikiAsClosedController.class.php
+++ b/extensions/wikia/WikiFactory/api/MarkWikiAsClosedController.class.php
@@ -38,14 +38,22 @@ class MarkWikiAsClosedController extends WikiaController {
 		if ( !empty( $fandomCreatorCommunityId ) ) {
 			if ( !static::isValidFandomCreatorCommunityId( $fandomCreatorCommunityId, $wikiId )) {
 				$this->response->setCode( 400 );
-				$this->info( 'invalid fandomCreatorCommunityId parameter in request: ' . $fandomCreatorCommunityId );
+
+				$this->info(
+					'invalid fandomCreatorCommunityId parameter in request',
+					[ 'fandomCreatorCommunityId' => $fandomCreatorCommunityId ]
+				);
 
 				return;
 			}
 
 			if ( !static::removeProtectionFromFandomCreatorCommunityWiki( $wikiId, $reason ) ) {
 				$this->response->setCode( 500 );
-				$this->info( 'could not remove protected flag on wiki with id: ' . $wikiId );
+
+				$this->info(
+					'could not remove protected flag on wiki with id',
+					[ 'wikiId' => $wikiId ]
+				);
 
 				return;
 			}
@@ -55,7 +63,11 @@ class MarkWikiAsClosedController extends WikiaController {
 
 		if ( !static::closeWiki( $wikiId, $user, $reason ) ) {
 			$this->response->setCode( 500 );
-			$this->info( 'could not close wiki with id: ' . $wikiId );
+
+			$this->info(
+				'could not close wiki with id',
+				[ 'wikiId' => $wikiId ]
+			);
 
 			return;
 		}

--- a/extensions/wikia/WikiFactory/api/MarkWikiAsClosedController.class.php
+++ b/extensions/wikia/WikiFactory/api/MarkWikiAsClosedController.class.php
@@ -102,8 +102,15 @@ class MarkWikiAsClosedController extends WikiaController {
 	}
 
 	static private function closeWiki( $wikiId, $user, $reason ) {
-		$res = WikiFactory::setPublicStatus( WikiFactory::CLOSE_ACTION, $wikiId, $reason, $user );
-		return ($res === WikiFactory::CLOSE_ACTION);
+		$status = WikiFactory::setPublicStatus(
+			WikiFactory::CLOSE_ACTION,
+			$wikiId,
+			$reason,
+			$user,
+			true
+		);
+
+		return ($status === WikiFactory::CLOSE_ACTION);
 	}
 
 	static private function removeProtectionFromFandomCreatorCommunityWiki( $wikiId, $reason ) {

--- a/extensions/wikia/WikiFactory/api/MarkWikiAsClosedController.class.php
+++ b/extensions/wikia/WikiFactory/api/MarkWikiAsClosedController.class.php
@@ -30,32 +30,48 @@ class MarkWikiAsClosedController extends WikiaController {
 		if ( !is_numeric( $wikiId ) || empty( $reason ) || !is_numeric( $userId ) ) {
 			// No wikiId, userId or reason given: Bad Request
 			$this->response->setCode( 400 );
-			$this->info('no wikiId or reason parameter in request');
+			$this->info('no wikiId or reason parameter in request' );
 
 			return;
 		}
 
-		if ( !empty( $fandomCreatorCommunityId ) && !is_numeric( $fandomCreatorCommunityId ) ) {
-			$this->response->setCode( 400 );
-			$this->info('invalid  fandomCreatorCommunityId parameter in request');
+		if ( !empty( $fandomCreatorCommunityId ) ) {
+			if ( !static::isValidFandomCreatorCommunityId( $fandomCreatorCommunityId, $wikiId )) {
+				$this->response->setCode( 400 );
+				$this->info('invalid fandomCreatorCommunityId parameter in request: ' . $fandomCreatorCommunityId );
+
+				return;
+			}
+
+			if ( !static::removeProtectionFromFandomCreatorCommunityWiki( $wikiId, $reason ) ) {
+				$this->response->setCode( 500 );
+				$this->info('could not remove protected flag on wiki with id: ' . $wikiId );
+
+				return;
+			}
+		}
+
+		$user = User::newFromId( $userId );
+
+		if ( !static::closeWiki( $wikiId, $user, $reason ) ) {
+			$this->response->setCode( 500 );
+			$this->info('could not close wiki with id: ' . $wikiId );
 
 			return;
 		}
 
-		$user = User::newFromId($userId);
+		WikiFactory::setFlags(
+			$wikiId,
+			WikiFactory::FLAG_FREE_WIKI_URL |
+			WikiFactory::FLAG_CREATE_DB_DUMP |
+			WikiFactory::FLAG_CREATE_IMAGE_ARCHIVE,
+			false,
+			null,
+			$user
+		);
 
-		if ( static::isGoForClose($wikiId, $fandomCreatorCommunityId, $user, $reason) ) {
-			WikiFactory::setFlags( $wikiId,
-				WikiFactory::FLAG_FREE_WIKI_URL | WikiFactory::FLAG_CREATE_DB_DUMP |
-				WikiFactory::FLAG_CREATE_IMAGE_ARCHIVE, false, null,  $user );
-			WikiFactory::clearCache( $wikiId );
-			$this->response->setCode( 200 );
-
-			return;
-		}
-
-		$this->response->setCode( 500 );
-		$this->info("could not mark Wiki to be closed in MW. Wiki id: " . $wikiId);
+		WikiFactory::clearCache( $wikiId );
+		$this->response->setCode( 200 );
 
 		return;
 	}
@@ -73,27 +89,27 @@ class MarkWikiAsClosedController extends WikiaController {
 		}
 	}
 
-	static private function isGoForClose( $wikiId, $fandomCreatorCommunityId, $user, $reason ) {
-		$isGoForClose = true;
+	static private function closeWiki( $wikiId, $user, $reason ) {
+		$res = WikiFactory::setPublicStatus( WikiFactory::CLOSE_ACTION, $wikiId, $reason, $user );
+		return ($res === WikiFactory::CLOSE_ACTION);
+	}
 
-		if ( !empty( $fandomCreatorCommunityId ) ) {
-			$wikiFandomCreatorCommunityId = WikiFactory::getVarValueByName( CommunitySetup::WF_VAR_FC_COMMUNITY_ID, $wikiId );
+	static private function removeProtectionFromFandomCreatorCommunityWiki( $wikiId, $reason ) {
+		return WikiFactory::resetFlags(
+			$wikiId,
+			WikiFactory::FLAG_PROTECTED,
+			false,
+			'fandom creator community soft deletion: ' . $reason
+		);
+	}
 
-			if ( $fandomCreatorCommunityId == $wikiFandomCreatorCommunityId ) {
-				$isGoForClose = WikiFactory::resetFlags(
-					$wikiId,
-					WikiFactory::FLAG_PROTECTED,
-					false,
-					'fandom creator soft deletion: ' . $reason
-				);
-			}
+	static private function isValidFandomCreatorCommunityId( $fandomCreatorCommunityId, $wikiId ) {
+		if (!is_numeric( $fandomCreatorCommunityId )) {
+			return false;
 		}
 
-		if ( $isGoForClose ) {
-			$res = WikiFactory::setPublicStatus( WikiFactory::CLOSE_ACTION, $wikiId, $reason, $user );
-			$isGoForClose = ($res === WikiFactory::CLOSE_ACTION);
-		}
+		$wikiFandomCreatorCommunityId = WikiFactory::getVarValueByName( CommunitySetup::WF_VAR_FC_COMMUNITY_ID, $wikiId );
 
-		return $isGoForClose;
+		return ($fandomCreatorCommunityId == $wikiFandomCreatorCommunityId);
 	}
 }

--- a/extensions/wikia/WikiFactory/api/MarkWikiAsClosedController.class.php
+++ b/extensions/wikia/WikiFactory/api/MarkWikiAsClosedController.class.php
@@ -41,7 +41,7 @@ class MarkWikiAsClosedController extends WikiaController {
 
 				$this->info(
 					'invalid fandomCreatorCommunityId parameter in request',
-					[ 'fandomCreatorCommunityId' => $fandomCreatorCommunityId ]
+					[ 'fandom_creator_community_id' => $fandomCreatorCommunityId ]
 				);
 
 				return;
@@ -52,7 +52,7 @@ class MarkWikiAsClosedController extends WikiaController {
 
 				$this->info(
 					'could not remove protected flag on wiki with id',
-					[ 'wikiId' => $wikiId ]
+					[ 'wiki_id' => $wikiId ]
 				);
 
 				return;
@@ -66,7 +66,7 @@ class MarkWikiAsClosedController extends WikiaController {
 
 			$this->info(
 				'could not close wiki with id',
-				[ 'wikiId' => $wikiId ]
+				[ 'wiki_id' => $wikiId ]
 			);
 
 			return;


### PR DESCRIPTION
Make checks, flow, and related error output more atomic.
Force use of master DB, for protected flag check, when setting wiki status to closed. 

@Wikia/cake 