### PR TITLE
Remove unused k8s task config

### DIFF
--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1802,16 +1802,3 @@ include_once "$IP/extensions/wikia/ListGlobalUsers/ListGlobalUsers.setup.php";
 $wgAutoloadClasses['AuditLog'] = "$IP/includes/wikia/AuditLog.class.php";
 
 $wgHooks['SetupAfterCache'][] = 'AuditLog::init';
-
-/**
- * @name $wgProcessTasksOnKubernetes
- * When enabled, tasks will be processed on kubernetes.
- * This will only work on production.
- */
-$wgProcessTasksOnKubernetes = false;
-
-/**
- * @name $wgPercentOfTasksOnKubernetes
- * Determines the percentage of wikis that send tasks to k8s.
- */
-$wgPercentOfTasksOnKubernetes = 0;

--- a/lib/Wikia/src/Tasks/AsyncTaskList.php
+++ b/lib/Wikia/src/Tasks/AsyncTaskList.php
@@ -246,16 +246,10 @@ class AsyncTaskList {
 	 * @return array
 	 */
 	protected function getExecutor() {
-		global $wgWikiaEnvironment, $wgDevDomain, $wgProcessTasksOnKubernetes;
+		global $wgWikiaEnvironment, $wgDevDomain;
 		$executor = [
 			'app' => self::EXECUTOR_APP_NAME,
 		];
-
-		// we want to use k8s on a percentage of all communities, so we need a global value for that percentage
-		$percentOfTasksOnKubernetes = \WikiFactory::getVarValueByName("wgPercentOfTasksOnKubernetes", static::DEFAULT_WIKI_ID );
-		
-		$shouldGoToKubernetes = $wgProcessTasksOnKubernetes
-			|| ( $percentOfTasksOnKubernetes && $this->wikiId % 100 < $percentOfTasksOnKubernetes );
 
 		if ( $wgWikiaEnvironment != WIKIA_ENV_PROD ) {
 			$host = wfGetEffectiveHostname();
@@ -267,9 +261,6 @@ class AsyncTaskList {
 			} elseif (in_array($wgWikiaEnvironment, [WIKIA_ENV_PREVIEW, WIKIA_ENV_VERIFY])) {
 				$executor['runner'] = ["http://community.{$wgWikiaEnvironment}.wikia.com/extensions/wikia/Tasks/proxy/proxy.php"];
 			}
-		} elseif ( $shouldGoToKubernetes ) {
-			# SUS-5562 use k8s to process task
-			$executor['runner'] = ["http://mediawiki-tasks/proxy.php"];
 		}
 
 		return $executor;


### PR DESCRIPTION
All production tasks are processed on k8s. We can remove config that was used during the migration.