### PR TITLE
(PLATFORM-3929) Enable migration notice on all remaining wikis

### DIFF
--- a/extensions/wikia/FandomComMigration/FandomComMigrationHooks.class.php
+++ b/extensions/wikia/FandomComMigration/FandomComMigrationHooks.class.php
@@ -90,17 +90,13 @@ class FandomComMigrationHooks {
 	 * @return boolean
 	 */
 	private static function isMigrationScheduled(): bool {
-		global $wgFandomComMigrationScheduled, $wgCityId, $wgServer, $wgLanguageCode;
+		global $wgFandomComMigrationScheduled, $wgWikiaOrgMigrationScheduled, $wgCityId, $wgServer, $wgLanguageCode;
 		$hubService = WikiFactoryHub::getInstance();
 
-		return !empty( $wgFandomComMigrationScheduled )
-			|| (
-				!wfHttpsEnabledForURL( $wgServer )
-				&& ( !wfHttpsAllowedForURL( $wgServer ) || $wgLanguageCode === 'en' )
-				&& !in_array( $hubService->getVerticalId( $wgCityId ), [
-					WikiFactoryHub::VERTICAL_ID_OTHER,
-					WikiFactoryHub::VERTICAL_ID_LIFESTYLE,
-				] )
+		return empty( $wgWikiaOrgMigrationScheduled ) &&
+			(
+				!empty( $wgFandomComMigrationScheduled )
+				|| !wfHttpsEnabledForURL( $wgServer )
 			);
 	}
 }

--- a/includes/wikia/VariablesBase.php
+++ b/includes/wikia/VariablesBase.php
@@ -8890,6 +8890,13 @@ $wgAllowCommunityBuilderCNWPrompt = true;
 $wgFandomComMigrationScheduled = false;
 
 /**
+ * Whether the community is scheduled to be migrated to a fandom.com domain, triggers a banner notification
+ * @see SEO-669
+ * @var bool $wgFandomComMigrationScheduled
+ */
+$wgWikiaOrgMigrationScheduled = false;
+
+/**
  * Custom messages to show on the migration banner (before and after migration).
  * @see PLATFORM-3895
  * @var string

--- a/includes/wikia/VariablesBase.php
+++ b/includes/wikia/VariablesBase.php
@@ -8890,9 +8890,8 @@ $wgAllowCommunityBuilderCNWPrompt = true;
 $wgFandomComMigrationScheduled = false;
 
 /**
- * Whether the community is scheduled to be migrated to a fandom.com domain, triggers a banner notification
- * @see SEO-669
- * @var bool $wgFandomComMigrationScheduled
+ * Whether the community is scheduled to be migrated to a wikia.org domain
+ * @var bool $wgWikiaOrgMigrationScheduled
  */
 $wgWikiaOrgMigrationScheduled = false;
 


### PR DESCRIPTION
Enable migration notice on all remaining wikis except those that may migrate to
wikia.org which will be set in WikiFactory.

/cc @Wikia/core-platform-team 