### PR TITLE
CORE-111 | Wikis/Details request returns empty responses

### DIFF
--- a/includes/wikia/services/WikiDetailsService.class.php
+++ b/includes/wikia/services/WikiDetailsService.class.php
@@ -186,7 +186,7 @@ class WikiDetailsService extends WikiService {
 	 * @param int $id WikiId
 	 * @return array
 	 */
-	protected function getFromService( $id ) {
+	protected function getFromService( int $id ) {
 		$wikiStats = $this->getSiteStats( $id );
 		$topUsers = $this->getTopEditors( $id, static::DEFAULT_TOP_EDITORS_NUMBER );
 		$modelData = $this->getDetails( [ $id ] );

--- a/includes/wikia/services/WikiService.class.php
+++ b/includes/wikia/services/WikiService.class.php
@@ -925,7 +925,7 @@ class WikiService extends WikiaModel {
 				);
 
 				$cacheKey = wfSharedMemcKey( __METHOD__, self::CACHE_VERSION, $row->city_id );
-				$this->wg->Memc->set( $cacheKey, $item, WikiaResponse::CACHE_LONG /* 12h */ );
+				$this->wg->Memc->set( $cacheKey, $item, WikiaResponse::CACHE_STANDARD );
 				$results[$row->city_id] = $item;
 			}
 		}

--- a/includes/wikia/services/WikiService.class.php
+++ b/includes/wikia/services/WikiService.class.php
@@ -839,6 +839,14 @@ class WikiService extends WikiaModel {
 					$item = $this->wg->Memc->get( $cacheKey );
 
 					if ( is_array( $item ) ) {
+						// CORE-111: log cached data with missing entries
+						if ( empty( $item['lang'] ) ) {
+							\Wikia\Logger\WikiaLogger::instance()->warning( 'CORE-111', [
+								'wiki_id' => $wikiId,
+								'item_json' => json_encode($item),
+							] );
+						}
+
 						$results[$wikiId] = $item;
 					}else {
 						$notFound[] = $wikiId;

--- a/includes/wikia/services/WikiService.class.php
+++ b/includes/wikia/services/WikiService.class.php
@@ -818,30 +818,30 @@ class WikiService extends WikiaModel {
 	/**
 	 * Get details about one or more wikis
 	 *
-	 * @param array $wikiIds An array of one or more wiki ID's
+	 * @param int[] $wikiIds An array of one or more wiki ID's
 	 *
 	 * @return array A collection of results, the index is the wiki ID and each item has a name,
 	 * url, lang, hubId, headline, desc, image and flags index.
+	 *
+	 * @throws DBUnexpectedError
 	 */
-	public function getDetails( Array $wikiIds = null ) {
-		wfProfileIn(__METHOD__);
-
+	public function getDetails( Array $wikiIds ) {
 		$results = array();
 
 		if ( !empty( $wikiIds ) ) {
 			$notFound = array();
 
-			foreach ( $wikiIds as $index => $val ) {
-				$val = (int) $val;
+			foreach ( $wikiIds as $wikiId ) {
+				$wikiId = (int) $wikiId;
 
-				if ( !empty( $val ) ) {
-					$cacheKey = wfSharedMemcKey( __METHOD__, self::CACHE_VERSION, $val );
+				if ( !empty( $wikiId ) ) {
+					$cacheKey = wfSharedMemcKey( __METHOD__, self::CACHE_VERSION, $wikiId );
 					$item = $this->wg->Memc->get( $cacheKey );
 
 					if ( is_array( $item ) ) {
-						$results[$val] = $item;
+						$results[$wikiId] = $item;
 					}else {
-						$notFound[] = $val;
+						$notFound[] = $wikiId;
 					}
 				}
 			}
@@ -930,7 +930,6 @@ class WikiService extends WikiaModel {
 			}
 		}
 
-		wfProfileOut(__METHOD__);
 		return $results;
 	}
 

--- a/includes/wikia/services/WikiService.class.php
+++ b/includes/wikia/services/WikiService.class.php
@@ -840,8 +840,8 @@ class WikiService extends WikiaModel {
 
 					if ( is_array( $item ) ) {
 						// CORE-111: log cached data with missing entries
-						if ( empty( $item['lang'] ) ) {
-							\Wikia\Logger\WikiaLogger::instance()->warning( 'CORE-111', [
+						if ( empty( $item['lang'] ) || empty( $item['creation_date'] ) ) {
+							\Wikia\Logger\WikiaLogger::instance()->warning( __METHOD__ . ' - cached with missing data', [
 								'wiki_id' => $wikiId,
 								'item_json' => json_encode($item),
 							] );

--- a/includes/wikia/services/WikiService.class.php
+++ b/includes/wikia/services/WikiService.class.php
@@ -845,9 +845,13 @@ class WikiService extends WikiaModel {
 								'wiki_id' => $wikiId,
 								'item_json' => json_encode($item),
 							] );
-						}
 
-						$results[$wikiId] = $item;
+							// mark a wiki for which we have corrupted data as not found
+							$notFound[] = $wikiId;
+						}
+						else {
+							$results[$wikiId] = $item;
+						}
 					}else {
 						$notFound[] = $wikiId;
 					}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CORE-111

@Wikia/core-team 

Log entries that were cached with missing data. In such cases pretend like there was a cache miss.