### PR TITLE
CORE-94 | Community Central's "Blog:Recent posts" has stopped listing posts since May 2018

### DIFF
--- a/extensions/wikia/Blogs/Blogs.php
+++ b/extensions/wikia/Blogs/Blogs.php
@@ -111,7 +111,6 @@ $wgHooks['userCan'][] = 'BlogLockdown::userCan';
 
 define ( "BLOGS_TIMESTAMP", "20081101000000" );
 define ( "BLOGS_XML_REGEX", "/\<(.*?)\>(.*?)\<\/(.*?)\>/si" );
-define ( "GROUP_CONCAT", "64000" );
 define ( "BLOGS_DEFAULT_LENGTH", "400" );
 define ( "BLOGS_HTML_PARSE", "/(<.+?>)?([^<>]*)/s" );
 define ( "BLOGS_ENTITIES_PARSE", "/&[0-9a-z]{2,8};|&#[0-9]{1,7};|&#x[0-9a-f]{1,6};/i" );


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CORE-94

Due to the way we were fetching list of blog posts IDs from a specific
category, we were unable to get all of them. This has became visible on the
biggest communities lately.

Instead of using `GROUP_CONCAT` to fetch comma separates list of IDs
(that limits returned value to 64000 characters), simply fetch all matching
blog posts IDs. This can be quite big (over 20k entries) on busy communities.
However, the list is cached in the parser cache.

@Wikia/core-team 