### PR TITLE
CORE-123 | Edit buttons for personal CSS and JS pages should never point to VisualEditor

### DIFF
--- a/extensions/wikia/EditorPreference/EditorPreference.class.php
+++ b/extensions/wikia/EditorPreference/EditorPreference.class.php
@@ -192,6 +192,7 @@ class EditorPreference {
 		return
 			$title->inNamespaces( $wgVisualEditorNamespaces ) &&
 			!$title->isRedirect() &&
+			!$title->isCssJsSubpage() &&  # CORE-123 | skip user CSS and JS pages
 			!$skin->getUser()->isBlockedFrom( $title, true );
 	}
 

--- a/extensions/wikia/EditorPreference/tests/EditorPreferencesTest.php
+++ b/extensions/wikia/EditorPreference/tests/EditorPreferencesTest.php
@@ -1,0 +1,56 @@
+<?php
+
+class EditorPreferencesTest extends WikiaBaseTest {
+
+	const NAMESPACES = [ NS_MAIN, NS_USER ];
+
+	private function getSkinMock( int $ns, string $title) : Skin {
+		$skin = Skin::newFromKey('oasis');
+
+		/* @var $title Title */
+		$title = $this->mockClassWithMethods(Title::class, [
+			'getNamespace' => $ns,
+			'inNamespaces' => in_array( $ns, self::NAMESPACES ),
+			'getText' => $title,
+			'isRedirect' => false,
+		]);
+
+		/* @var $user User */
+		$user = $this->mockClassWithMethods( User::class, [
+			'isBlockedFrom' => false,
+		]);
+
+		$context = new RequestContext();
+		$context->setTitle( $title );
+		$context->setUser( $user );
+
+		$skin->setContext($context);
+		return $skin;
+	}
+
+	/**
+	 * @param int $namespace
+	 * @param string $text
+	 * @param bool $expected
+	 * @param string $message
+	 * @dataProvider shouldShowVisualEditorLinkDataProvider
+	 */
+	public function testShouldShowVisualEditorLink( int $namespace, string $text, bool $expected, string $message ) {
+		$this->mockGlobalVariable( 'wgEnableVisualEditorExt', true );
+		$this->mockGlobalVariable( 'wgVisualEditorNamespaces', self::NAMESPACES );
+		$this->mockGlobalVariable( 'wgVisualEditorSupportedSkins', [ 'oasis' ] );
+
+		// mock the Oasis skin with a specified title
+		$skin =  self::getSkinMock( $namespace,  $text );
+
+		$this->assertEquals( $expected, EditorPreference::shouldShowVisualEditorLink( $skin ), $message );
+	}
+
+	public function shouldShowVisualEditorLinkDataProvider() {
+		yield [ NS_MAIN, 'Foo', true, 'NS_MAIN is supported by VisualEditor' ] ;
+		yield [ NS_USER, 'Foo', true, 'NS_USER is supported by VisualEditor' ] ;
+
+		yield [ NS_TEMPLATE, 'Foo', false, 'NS_TEMPLATE is not supported by VisualEditor'  ] ;
+	}
+
+}

--- a/extensions/wikia/EditorPreference/tests/EditorPreferencesTest.php
+++ b/extensions/wikia/EditorPreference/tests/EditorPreferencesTest.php
@@ -7,12 +7,15 @@ class EditorPreferencesTest extends WikiaBaseTest {
 	private function getSkinMock( int $ns, string $title) : Skin {
 		$skin = Skin::newFromKey('oasis');
 
+		$isCssJsSubpage = Title::newFromText( $title, $ns )->isCssJsSubpage();
+
 		/* @var $title Title */
 		$title = $this->mockClassWithMethods(Title::class, [
 			'getNamespace' => $ns,
 			'inNamespaces' => in_array( $ns, self::NAMESPACES ),
 			'getText' => $title,
 			'isRedirect' => false,
+			'isCssJsSubpage' => $isCssJsSubpage,
 		]);
 
 		/* @var $user User */
@@ -49,6 +52,8 @@ class EditorPreferencesTest extends WikiaBaseTest {
 	public function shouldShowVisualEditorLinkDataProvider() {
 		yield [ NS_MAIN, 'Foo', true, 'NS_MAIN is supported by VisualEditor' ] ;
 		yield [ NS_USER, 'Foo', true, 'NS_USER is supported by VisualEditor' ] ;
+		yield [ NS_USER, 'Rappy_4187/global.css ', false, 'User CSS is not editable by VisualEditor' ] ;
+		yield [ NS_USER, 'Rappy_4187/global.js ', false, 'User JS is not editable by VisualEditor' ] ;
 
 		yield [ NS_TEMPLATE, 'Foo', false, 'NS_TEMPLATE is not supported by VisualEditor'  ] ;
 	}

--- a/includes/wikia/VariablesBase.php
+++ b/includes/wikia/VariablesBase.php
@@ -8480,9 +8480,9 @@ $wgVisualEditorNoCache = false;
  * Skins integrated with VisualEditor.
  * @see extensions/VisualEditor/VisualEditor.hooks.php
  * @see extensions/wikia/EditorPreference/EditorPreference.class.php
- * @var Array $wgVisualEditorSupportedSkins
+ * @var array $wgVisualEditorSupportedSkins
  */
-$wgVisualEditorSupportedSkins = [ 'oasis', 'venus' ];
+$wgVisualEditorSupportedSkins = [ 'oasis' ];
 
 /**
  * Number of links to a page required before it is deemed "wanted".


### PR DESCRIPTION
@Wikia/core-team 

And add unit tests