### PR TITLE
Add fandomCreatorCommunityId to getDiscussionsWikiVariables

### DIFF
--- a/extensions/wikia/MercuryApi/models/MercuryApi.class.php
+++ b/extensions/wikia/MercuryApi/models/MercuryApi.class.php
@@ -208,7 +208,8 @@ class MercuryApi {
 
 	public function getDiscussionsWikiVariables() {
 		global $wgDefaultSkin, $wgEnableDiscussions, $wgEnableDiscussionsImageUpload, $wgDiscussionColorOverride,
-		       $wgEnableLightweightContributions, $wgEnableFeedsAndPostsExt, $wgEnableEmbeddedFeeds;
+			   $wgEnableLightweightContributions, $wgEnableFeedsAndPostsExt, $wgEnableEmbeddedFeeds,
+			   $wgFandomCreatorCommunityId;
 
 		$wikiVariables = array_merge(
 			$this->getCommonVariables(),
@@ -222,6 +223,7 @@ class MercuryApi {
 				'siteMessage' => $this->getSiteMessage(),
 				'theme' => SassUtil::normalizeThemeColors( SassUtil::getOasisSettings() ),
 				'openGraphImageUrl' => OpenGraphImageHelper::getUrl(),
+				'fandomCreatorCommunityId' => $wgFandomCreatorCommunityId
 			]
 		);
 


### PR DESCRIPTION
This PR adds the `fandomCreatorCommunityId` var to the `getDiscussionsWikiVariables` response. We use that for the article suggest resource in discussions to determine if we should contact MW or CGS to get article suggestions. See [here](https://github.com/Wikia/pandora/blob/master/service/discussion/src/main/java/com/wikia/discussionservice/services/articlesuggester/ArticleSuggester.java#L43-L50).

When we migrated the MW Gateway to use retrofit, we updated the MW API that it uses from [getWikiVariables](https://github.com/Wikia/pandora/commit/d73a9dbdfe5dba5ce9764e8ef6703a6cd6bcd693#diff-de599f82537e8a0e28803d0e0be93b39L47) to a new API [getDiscussionsWikiVariables](https://github.com/Wikia/pandora/commit/d73a9dbdfe5dba5ce9764e8ef6703a6cd6bcd693#diff-4507698e348e8ea6ba1a68b478fd252cR18). `getWikiVariables` included `fandomCreatorCommunityId`, `getDiscussionsWikiVariables` does not. This PR adds that var to the new API.

/cc @Wikia/iwing 