### PR TITLE
Return null rather than false when we're not on an FC community

### DIFF
--- a/extensions/wikia/MercuryApi/models/MercuryApi.class.php
+++ b/extensions/wikia/MercuryApi/models/MercuryApi.class.php
@@ -223,7 +223,7 @@ class MercuryApi {
 				'siteMessage' => $this->getSiteMessage(),
 				'theme' => SassUtil::normalizeThemeColors( SassUtil::getOasisSettings() ),
 				'openGraphImageUrl' => OpenGraphImageHelper::getUrl(),
-				'fandomCreatorCommunityId' => $wgFandomCreatorCommunityId
+				'fandomCreatorCommunityId' => !empty( $wgFandomCreatorCommunityId ) ? $wgFandomCreatorCommunityId : null
 			]
 		);
 


### PR DESCRIPTION
Rather than return `false`, return `null` for `fandomCreatorCommunityId` when we're not on an FC community. Relates to: https://github.com/Wikia/app/pull/16748