### PR TITLE
IW-1710 publish article renames to article-tags queue

### DIFF
--- a/extensions/wikia/ArticleTagEvents/ArticleTagEvents.setup.php
+++ b/extensions/wikia/ArticleTagEvents/ArticleTagEvents.setup.php
@@ -1,0 +1,13 @@
+<?php
+
+$dir = dirname(__FILE__) . '/';
+
+/**
+ * Classes
+ */
+$wgAutoloadClasses['ArticleTagEventsProducer'] = $dir . 'ArticleTagEventsProducer.class.php';
+
+/**
+ * Hooks
+ */
+$wgHooks['SpecialMovepageAfterMove'][] = 'ArticleTagEventsProducer::onSpecialMovepageAfterMove';

--- a/extensions/wikia/ArticleTagEvents/ArticleTagEvents.setup.php
+++ b/extensions/wikia/ArticleTagEvents/ArticleTagEvents.setup.php
@@ -10,4 +10,4 @@ $wgAutoloadClasses['ArticleTagEventsProducer'] = $dir . 'ArticleTagEventsProduce
 /**
  * Hooks
  */
-$wgHooks['SpecialMovepageAfterMove'][] = 'ArticleTagEventsProducer::onSpecialMovepageAfterMove';
+$wgHooks['TitleMoveComplete'][] = 'ArticleTagEventsProducer::onTitleMoveComplete';

--- a/extensions/wikia/ArticleTagEvents/ArticleTagEventsProducer.class.php
+++ b/extensions/wikia/ArticleTagEvents/ArticleTagEventsProducer.class.php
@@ -21,10 +21,10 @@ class ArticleTagEventsProducer {
 
     /** @return \Wikia\Rabbit\ConnectionBase */
     protected static function getPublisher() {
-        global $wgArticleTagQueue;
+        global $wgArticleTagExchangeConfig;
 
         if ( !isset( self::$rabbitPublisher ) ) {
-            self::$rabbitPublisher = new ConnectionBase( $wgArticleTagQueue );
+            self::$rabbitPublisher = new ConnectionBase( $wgArticleTagExchangeConfig );
         }
 
         return self::$rabbitPublisher;

--- a/extensions/wikia/ArticleTagEvents/ArticleTagEventsProducer.class.php
+++ b/extensions/wikia/ArticleTagEvents/ArticleTagEventsProducer.class.php
@@ -8,7 +8,7 @@ class ArticleTagEventsProducer {
 
     private static $rabbitPublisher;
 
-    public static function onSpecialMovepageAfterMove( MovePageForm $form, Title $oldTitle, Title $newTitle ) {
+    public static function onTitleMoveComplete( Title $oldTitle, Title $newTitle, User $user, $pageId, $redirectId ) {
         global $wgCityId;
         $message = [
             'wikiId' => $wgCityId,

--- a/extensions/wikia/ArticleTagEvents/ArticleTagEventsProducer.class.php
+++ b/extensions/wikia/ArticleTagEvents/ArticleTagEventsProducer.class.php
@@ -1,0 +1,32 @@
+<?php
+
+use Wikia\Rabbit\ConnectionBase;
+
+class ArticleTagEventsProducer {
+
+    const RENAMED_ROUTING_KEY= 'article-changed.renamed';
+
+    private static $rabbitPublisher;
+
+    public static function onSpecialMovepageAfterMove( MovePageForm $form, Title $oldTitle, Title $newTitle ) {
+        global $wgCityId;
+        $message = [
+            'wikiId' => $wgCityId,
+            'articleId' => $newTitle->getArticleID(),
+            'articleTitle' => $newTitle->getPrefixedText()
+        ];
+
+        self::getPublisher()->publish( self::RENAMED_ROUTING_KEY, $message );
+    }
+
+    /** @return \Wikia\Rabbit\ConnectionBase */
+    protected static function getPublisher() {
+        global $wgArticleTagQueue;
+
+        if ( !isset( self::$rabbitPublisher ) ) {
+            self::$rabbitPublisher = new ConnectionBase( $wgArticleTagQueue );
+        }
+
+        return self::$rabbitPublisher;
+    }
+}

--- a/extensions/wikia/ArticleTagEvents/ArticleTagEventsProducer.class.php
+++ b/extensions/wikia/ArticleTagEvents/ArticleTagEventsProducer.class.php
@@ -13,7 +13,8 @@ class ArticleTagEventsProducer {
         $message = [
             'wikiId' => $wgCityId,
             'articleId' => $newTitle->getArticleID(),
-            'articleTitle' => $newTitle->getPrefixedText()
+            'articleTitle' => $newTitle->getPrefixedText(),
+            'relativeUrl' => $newTitle->getLocalURL(),
         ];
 
         self::getPublisher()->publish( self::RENAMED_ROUTING_KEY, $message );

--- a/extensions/wikia/ArticleTagEvents/ArticleTagEventsProducer.class.php
+++ b/extensions/wikia/ArticleTagEvents/ArticleTagEventsProducer.class.php
@@ -4,7 +4,7 @@ use Wikia\Rabbit\ConnectionBase;
 
 class ArticleTagEventsProducer {
 
-    const RENAMED_ROUTING_KEY= 'article-changed.renamed';
+    const RENAMED_ROUTING_KEY= 'article-tags.renamed';
 
     private static $rabbitPublisher;
 

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -587,6 +587,7 @@ include_once( "$IP/extensions/wikia/QuickTools/QuickTools.setup.php" );
 include_once( "$IP/extensions/wikia/TOC/TOC.setup.php" );
 include_once( "$IP/extensions/wikia/SEOTweaks/SEOTweaks.setup.php" );
 include_once( "$IP/extensions/wikia/StaticUserPages/StaticUserPages.setup.php" );
+include_once( "$IP/extensions/wikia/ArticleTagEvents/ArticleTagEvents.setup.php" );
 
 
 /**

--- a/includes/wikia/VariablesBase.php
+++ b/includes/wikia/VariablesBase.php
@@ -8935,9 +8935,9 @@ $wgEnableEditDraftSavingExt = false;
 /**
  * ArticleTags RabbitMQ configuration.
  * @see extensions/wikia/articleTagEvents
- * @var array $wgArticleTagQueue
+ * @var array $wgArticleTagExchangeConfig
  */
-$wgArticleTagQueue = [
+$wgArticleTagExchangeConfig = [
     'vhost' => 'events',
     'exchange' => 'article-tags',
 ];

--- a/includes/wikia/VariablesBase.php
+++ b/includes/wikia/VariablesBase.php
@@ -8931,3 +8931,13 @@ $wgWatchShowURL = '';
  * @var bool
  */
 $wgEnableEditDraftSavingExt = false;
+
+/**
+ * ArticleTags RabbitMQ configuration.
+ * @see extensions/wikia/articleTagEvents
+ * @var array $wgArticleTagQueue
+ */
+$wgArticleTagQueue = [
+    'vhost' => 'events',
+    'exchange' => 'article-tags',
+];


### PR DESCRIPTION
Ticket: https://wikia-inc.atlassian.net/browse/IW-1710

Publish article renames to a new article-tags exchange. This exchange will be used by discussions to keep its article tags in-sync with the latest article title.

/cc @Wikia/iwing 

relates to https://github.com/Wikia/pandora/pull/6084