### PR TITLE
words_count: store in page_props and solr

### DIFF
--- a/extensions/wikia/Search/classes/IndexService/DefaultContent.php
+++ b/extensions/wikia/Search/classes/IndexService/DefaultContent.php
@@ -50,11 +50,6 @@ class DefaultContent extends AbstractService {
 	 */
 	protected $nolang_txt = [];
 
-	private static function words_count( string $text ) : int {
-		$text = trim( strip_tags( $text ) );
-		return count( preg_split('#\s+#', $text ) );
-	}
-
 	/**
 	 * Returns the fields required to make the document searchable (specifically, wid and title and body content)
 	 *
@@ -92,7 +87,7 @@ class DefaultContent extends AbstractService {
 			$this->field( 'wikititle' ) => $sitename,
 			'page_images' => count( $response['parse']['images'] ),
 			// @see http://php.net/manual/en/function.str-word-count.php
-			'page_words' => self::words_count( strip_tags( $response['parse']['text']['*'] ) ),
+			'page_words' => \Wikia::words_count( strip_tags( $response['parse']['text']['*'] ) ),
 			'iscontent' => $service->isPageIdContent( $pageId ) ? 'true' : 'false',
 			'is_main_page' => $service->isPageIdMainPage( $pageId ) ? 'true' : 'false',
 			'indexed' => gmdate( "Y-m-d\TH:i:s\Z" )

--- a/extensions/wikia/Search/classes/IndexService/DefaultContent.php
+++ b/extensions/wikia/Search/classes/IndexService/DefaultContent.php
@@ -87,7 +87,7 @@ class DefaultContent extends AbstractService {
 			$this->field( 'wikititle' ) => $sitename,
 			'page_images' => count( $response['parse']['images'] ),
 			// @see http://php.net/manual/en/function.str-word-count.php
-			'page_words' => \Wikia::words_count( strip_tags( $response['parse']['text']['*'] ) ),
+			'page_words_i' => \Wikia::words_count( strip_tags( $response['parse']['text']['*'] ) ),
 			'iscontent' => $service->isPageIdContent( $pageId ) ? 'true' : 'false',
 			'is_main_page' => $service->isPageIdMainPage( $pageId ) ? 'true' : 'false',
 			'indexed' => gmdate( "Y-m-d\TH:i:s\Z" )

--- a/extensions/wikia/Search/classes/IndexService/DefaultContent.php
+++ b/extensions/wikia/Search/classes/IndexService/DefaultContent.php
@@ -50,6 +50,11 @@ class DefaultContent extends AbstractService {
 	 */
 	protected $nolang_txt = [];
 
+	private static function words_count( string $text ) : int {
+		$text = trim( strip_tags( $text ) );
+		return count( preg_split('#\s+#', $text ) );
+	}
+
 	/**
 	 * Returns the fields required to make the document searchable (specifically, wid and title and body content)
 	 *
@@ -86,6 +91,8 @@ class DefaultContent extends AbstractService {
 			'lang' => $service->getSimpleLanguageCode(),
 			$this->field( 'wikititle' ) => $sitename,
 			'page_images' => count( $response['parse']['images'] ),
+			// @see http://php.net/manual/en/function.str-word-count.php
+			'page_words' => self::words_count( strip_tags( $response['parse']['text']['*'] ) ),
 			'iscontent' => $service->isPageIdContent( $pageId ) ? 'true' : 'false',
 			'is_main_page' => $service->isPageIdMainPage( $pageId ) ? 'true' : 'false',
 			'indexed' => gmdate( "Y-m-d\TH:i:s\Z" )

--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -1949,4 +1949,17 @@ class Wikia {
 		}
 		return true;
 	}
+
+	/**
+	 * Removes HTML tags from a given text and counts words.
+	 *
+	 * Text is split by spaces and newlines.(
+	 *
+	 * @param string $text
+	 * @return int
+	 */
+	public static function words_count( string $text ) : int {
+		$text = trim( strip_tags( $text ) );
+		return count( preg_split('#\s+#', $text ) );
+	}
 }

--- a/includes/wikia/Wikia.php
+++ b/includes/wikia/Wikia.php
@@ -71,6 +71,9 @@ $wgHooks['BeforeUserSetEmail'][] = 'Wikia::logEmailChanges';
 $wgHooks['ShowLanguageWikisIndex'][] = 'Wikia::onClosedOrEmptyWikiDomains';
 $wgHooks['ClosedWikiHandler'][] = 'Wikia::onClosedOrEmptyWikiDomains';
 
+# Add words count statistics to page_props after each article's wikitext parsing
+$wgHooks['LinksUpdateConstructed'][] = 'Wikia::onLinksUpdateConstructed';
+
 
 use Wikia\Tracer\WikiaTracer;
 
@@ -1961,5 +1964,20 @@ class Wikia {
 	public static function words_count( string $text ) : int {
 		$text = trim( strip_tags( $text ) );
 		return count( preg_split('#\s+#', $text ) );
+	}
+
+	/**
+	 * Update words_count page property kept in page_props per-wiki table
+	 *
+	 * @param LinksUpdate $linksUpdate
+	 */
+	public static function onLinksUpdateConstructed( LinksUpdate $linksUpdate ) {
+		$parserOutput = $linksUpdate->getParserOutput();
+		$words_count = self::words_count( $parserOutput->getText() );
+
+		$parserOutput->setProperty( 'words_count', $words_count );
+
+		// keep LinksUpdate instance in sync with our updated parser output properties
+		$linksUpdate->mProperties = $parserOutput->getProperties();
 	}
 }

--- a/includes/wikia/tests/WikiaTest.php
+++ b/includes/wikia/tests/WikiaTest.php
@@ -145,4 +145,23 @@ class WikiaTest extends WikiaBaseTest {
 		);
 		$this->assertEquals( 'foo', $quickTemplate->get( 'thisquery' ) );
 	}
+
+	/**
+	 * @param string $text
+	 * @param int $expected
+	 * @dataProvider wordsCountDataProvider
+	 */
+	public function testWordsCount( $text, $expected ) {
+		$this->assertEquals( $expected, Wikia::words_count( $text ) );
+	}
+
+	public function wordsCountDataProvider() {
+		yield [ '', 1 ];
+		yield [ 'foo', 1 ];
+		yield [ ' foo ', 1 ];
+		yield [ 'foo bar', 2 ];
+		yield [ "foo\nbar", 2 ];
+		yield [ 'foo - bar', 3 ];
+		yield [ 'wcześniej nazywany również gziką', 4 ];
+	}
 }

--- a/includes/wikia/tests/WikiaTest.php
+++ b/includes/wikia/tests/WikiaTest.php
@@ -159,9 +159,9 @@ class WikiaTest extends WikiaBaseTest {
 		yield [ '', 1 ];
 		yield [ 'foo', 1 ];
 		yield [ ' foo ', 1 ];
-		yield [ 'foo bar', 2 ];
+		yield [ '<h1>foo bar</h1>', 2 ];
 		yield [ "foo\nbar", 2 ];
 		yield [ 'foo - bar', 3 ];
-		yield [ 'wcześniej nazywany również gziką', 4 ];
+		yield [ 'wcześniej <span>nazywany</span> również gziką', 4 ];
 	}
 }


### PR DESCRIPTION
Calculate words count for every wiki article (using parser output with HTML tags removed).

This value will be stored in both solr (`page_words_i` field in `main` core) and database (`page_props` table in per-wiki database).

### Example query

```sql
mysql@geo-db-dev-db-slave.query.consul[plpoznan]>select page_id, page_namespace, page_title, pp_value from page_props, page where pp_propname = 'words_count' and pp_page = page_id;
+---------+----------------+------------+----------+
| page_id | page_namespace | page_title | pp_value |
+---------+----------------+------------+----------+
|     146 |              0 | Ratusz     | 1642     |
|    1963 |              0 | Gzik       | 68       |
+---------+----------------+------------+----------+
2 rows in set (0.00 sec)
```

A null-edit is required to make this data appear in the database. `?action=purge` is not enough here.

### Force updating entries

`refreshLinks.php` maintenance script can be used to fill `page_props` with words count statistics, e.g.

```bash
SERVER_DBNAME=plpoznan php refreshLinks.php 
```

> Please note that you have to wait for a `Refreshing links table.` phase of the script.

```sql
mysql@geo-db-dev-db-slave.query.consul[plpoznan]>select page_id, page_namespace, page_title, pp_value from page_props, page where pp_propname = 'words_count' and pp_page = page_id and page_namespace = 0;
+---------+----------------+-----------------------------------------+----------+
| page_id | page_namespace | page_title                              | pp_value |
+---------+----------------+-----------------------------------------+----------+
|     146 |              0 | Ratusz                                  | 1642     |
|    1963 |              0 | Gzik                                    | 68       |
|   32700 |              0 | OgrÃ³d_Dendrologiczny                   | 54       |
|   32701 |              0 | Pomnik_PolegÅ‚ych_Harcerzy_na_Malcie    | 5        |
|   32702 |              0 | Marian_Å»elazek                         | 64       |
|   32708 |              0 | Jezioro_Kierskie                        | 140      |
|   32714 |              0 | Ulica_ks._BolesÅ‚awa_Sulka              | 4        |
|   32715 |              0 | Skwer_Romana_Ulatowskiego               | 360      |
|   32716 |              0 | Skwer_Eki_z_MaÅ‚eki                     | 360      |
|   32717 |              0 | Rondo_Åšwierczewo                       | 130      |
|   32726 |              0 | Ulica_Czerwonacka                       | 97       |
|   32727 |              0 | Ulica_Oleszycka                         | 97       |
|   32728 |              0 | Ulica_PagÃ³rkowa                        | 103      |
|   32729 |              0 | Ulica_Skowronkowa                       | 97       |
|   32730 |              0 | Ulica_WÄ…wozowa                         | 97       |
...
```