### PR TITLE
CORE-95: SemanticMediaWiki performance fix backport

### DIFF
--- a/extensions/SemanticMediaWiki/includes/storage/SQLStore/SMW_SQLStore3_Readers.php
+++ b/extensions/SemanticMediaWiki/includes/storage/SQLStore/SMW_SQLStore3_Readers.php
@@ -451,9 +451,13 @@ class SMWSQLStore3Readers {
 		$proptable = $proptables[$tableid];
 		$db = $this->store->getConnection();
 
+		// CORE-95 | performance fix backport frpm https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/3142
+		$group = false;
+
 		if ( $proptable->usesIdSubject() ) { // join with ID table to get title data
 			$from = $db->tableName( SMWSql3SmwIds::TABLE_NAME ) . " INNER JOIN " . $db->tableName( $proptable->getName() ) . " AS t1 ON t1.s_id=smw_id";
 			$select = 'smw_title, smw_namespace, smw_iw, smw_sortkey, smw_subobject';
+			$group = true;
 		} else { // no join needed, title+namespace as given in proptable
 			$from = $db->tableName( $proptable->getName() ) . " AS t1";
 			$select = 's_title AS smw_title, s_namespace AS smw_namespace, \'\' AS smw_iw, s_title AS smw_sortkey, \'\' AS smw_subobject';
@@ -476,9 +480,15 @@ class SMWSQLStore3Readers {
 			}
 		}
 
-		$res = $db->select( $from, 'DISTINCT ' . $select,
+		// CORE-95 | performance fix backport frpm https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/3142
+		$options = $this->store->getSQLOptions( $requestOptions, 'smw_sortkey' );
+		if ( $group ) {
+			$options['GROUP BY'] = 'smw_sortkey, smw_id';
+		}
+
+		$res = $db->select( $from, $select,
 		                    $where . $this->store->getSQLConditions( $requestOptions, 'smw_sortkey', 'smw_sortkey', $where !== '' ),
-		                    __METHOD__, $this->store->getSQLOptions( $requestOptions, 'smw_sortkey' ) );
+		                    __METHOD__,  $options);
 
 		$diHandler = $this->store->getDataItemHandlerForDIType( SMWDataItem::TYPE_WIKIPAGE );
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CORE-95

Cherry-picking from https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/3142 (as found by @mszabo-wikia - kudos!).

The use of `DISTINCT` makes the following query trigger `filesort` and` temporary` and causes serious performance problems on SMW database cluster. According to anemometer this query is the one with the highest median query time.

## Explain for an old query

```sql
SELECT /* SMWSQLStore3Readers::getPropertySubjects 66.249.64.63 - 1ab29fdf-071d-4bd6-9fe4-a4215604a1a8 */  DISTINCT smw_title, smw_namespace, smw_iw, smw_sortkey, smw_subobject  FROM `smw_object_ids` INNER JOIN `smw_di_blob` AS t1 ON t1.s_id=smw_id  WHERE t1.p_id='63' AND smw_iw!=':smw' AND smw_iw!=':smw-delete'  ORDER BY smw_sortkey LIMIT 13320,50

-- EXPLAIN
+----+-------------+----------------+------------+------+-----------------------+------+---------+---------------------------------------------+-------+----------+----------------------------------------------+
| id | select_type | table          | partitions | type | possible_keys         | key  | key_len | ref                                         | rows  | filtered | Extra                                        |
+----+-------------+----------------+------------+------+-----------------------+------+---------+---------------------------------------------+-------+----------+----------------------------------------------+
| 1  | SIMPLE      | smw_object_ids |            | ALL  | PRIMARY,smw_id,smw_iw |      |         |                                             | 75042 | 50.94    | Using where; Using temporary; Using filesort |
+----+-------------+----------------+------------+------+-----------------------+------+---------+---------------------------------------------+-------+----------+----------------------------------------------+
| 1  | SIMPLE      | t1             |            | ref  | s_id,p_id,s_id_2      | s_id | 8       | smw+devroniplag.smw_object_ids.smw_id,const | 1     | 100.00   | Using index; Distinct                        |
+----+-------------+----------------+------------+------+-----------------------+------+---------+---------------------------------------------+-------+----------+----------------------------------------------+
```

### Explain for a new, optimised query

```sql
SELECT smw_title, smw_namespace, smw_iw, smw_sortkey, smw_subobject  FROM `smw_object_ids` INNER JOIN `smw_di_blob` AS t1 ON t1.s_id=smw_id  WHERE t1.p_id='63' AND smw_iw!=':smw' AND smw_iw!=':smw-delete'  GROUP BY smw_sortkey, smw_id ORDER BY smw_sortkey LIMIT 13320,50;

-- EXPLAIN
+----+-------------+----------------+------------+-------+-----------------------------------+-------------+---------+---------------------------------------------+-------+----------+-------------+
| id | select_type | table          | partitions | type  | possible_keys                     | key         | key_len | ref                                         | rows  | filtered | Extra       |
+----+-------------+----------------+------------+-------+-----------------------------------+-------------+---------+---------------------------------------------+-------+----------+-------------+
|  1 | SIMPLE      | smw_object_ids | NULL       | index | PRIMARY,smw_id,smw_sortkey,smw_iw | smw_sortkey | 257     | NULL                                        | 22222 |    50.94 | Using where |
|  1 | SIMPLE      | t1             | NULL       | ref   | s_id,p_id,s_id_2                  | s_id        | 8       | smw+devroniplag.smw_object_ids.smw_id,const |     1 |   100.00 | Using index |
+----+-------------+----------------+------------+-------+-----------------------------------+-------------+---------+---------------------------------------------+-------+----------+-------------+
```

The results set is of course the same :smile: 