### PR TITLE
CORE-95 | SMWSQLStore3Readers - force an index on smw_object_ids

### DIFF
--- a/extensions/SemanticMediaWiki/includes/storage/SQLStore/SMW_SQLStore3_Readers.php
+++ b/extensions/SemanticMediaWiki/includes/storage/SQLStore/SMW_SQLStore3_Readers.php
@@ -455,7 +455,12 @@ class SMWSQLStore3Readers {
 		$group = false;
 
 		if ( $proptable->usesIdSubject() ) { // join with ID table to get title data
-			$from = $db->tableName( SMWSql3SmwIds::TABLE_NAME ) . " INNER JOIN " . $db->tableName( $proptable->getName() ) . " AS t1 ON t1.s_id=smw_id";
+			$from = $db->tableName( SMWSql3SmwIds::TABLE_NAME );
+
+			// CORE-95 | force an index on smw_object_ids, MySQL picks PRIMARY for large tables (1mm+ rows)
+			$from .= ' FORCE KEY(smw_sortkey)';
+
+			$from .= " INNER JOIN " . $db->tableName( $proptable->getName() ) . " AS t1 ON t1.s_id=smw_id";
 			$select = 'smw_title, smw_namespace, smw_iw, smw_sortkey, smw_subobject';
 			$group = true;
 		} else { // no join needed, title+namespace as given in proptable
@@ -480,7 +485,7 @@ class SMWSQLStore3Readers {
 			}
 		}
 
-		// CORE-95 | performance fix backport frpm https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/3142
+		// CORE-95 | performance fix backport from https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/3142
 		$options = $this->store->getSQLOptions( $requestOptions, 'smw_sortkey' );
 		if ( $group ) {
 			$options['GROUP BY'] = 'smw_sortkey, smw_id';


### PR DESCRIPTION
MySQL picks PRIMARY for large tables (1mm+ rows) that causes filesort + temporary combo that kills our slave nodes.

### Without "FORCE INDEX" statement:

```sql
mysql@geo-db-smw-slave.query.consul[smw+genealogy]>explain SELECT /* SMWSQLStore3Readers::getPropertySubjects 66.249.64.197 - 09618df5-d5c7-462e-9704-2f75f1156221 */  smw_title, smw_namespace, smw_iw, smw_sortkey, smw_subobject  FROM `smw_object_ids` INNER JOIN `smw_di_number` AS t1 ON t1.s_id=smw_id  WHERE t1.p_id='1408' AND smw_iw!=':smw' AND smw_iw!=':smw-delete'  GROUP BY smw_sortkey, smw_id ORDER BY smw_sortkey LIMIT 46490,20;
+----+-------------+----------------+------------+--------+-----------------------------------+---------+---------+-----------------------+--------+----------+---------------------------------+
| id | select_type | table          | partitions | type   | possible_keys                     | key     | key_len | ref                   | rows   | filtered | Extra                           |
+----+-------------+----------------+------------+--------+-----------------------------------+---------+---------+-----------------------+--------+----------+---------------------------------+
|  1 | SIMPLE      | t1             | NULL       | ref    | s_id,p_id                         | p_id    | 4       | const                 | 944045 |   100.00 | Using temporary; Using filesort |
|  1 | SIMPLE      | smw_object_ids | NULL       | eq_ref | PRIMARY,smw_id,smw_sortkey,smw_iw | PRIMARY | 4       | smw+genealogy.t1.s_id |      1 |    50.33 | Using where                     |
+----+-------------+----------------+------------+--------+-----------------------------------+---------+---------+-----------------------+--------+----------+---------------------------------+
2 rows in set, 1 warning (0.00 sec)
```

### With an index

```sql
mysql@geo-db-smw-slave.query.consul[smw+genealogy]>explain SELECT /* SMWSQLStore3Readers::getPropertySubjects 66.249.64.197 - 09618df5-d5c7-462e-9704-2f75f1156221 */  smw_title, smw_namespace, smw_iw, smw_sortkey, smw_subobject  FROM `smw_object_ids` FORCE KEY(smw_sortkey) INNER JOIN `smw_di_number` AS t1 ON t1.s_id=smw_id  WHERE t1.p_id='1408' AND smw_iw!=':smw' AND smw_iw!=':smw-delete'  GROUP BY smw_sortkey, smw_id  LIMIT 46490,20;
+----+-------------+----------------+------------+-------+--------------------+-------------+---------+-------------------------------------------+-------+----------+-------------+
| id | select_type | table          | partitions | type  | possible_keys      | key         | key_len | ref                                       | rows  | filtered | Extra       |
+----+-------------+----------------+------------+-------+--------------------+-------------+---------+-------------------------------------------+-------+----------+-------------+
|  1 | SIMPLE      | smw_object_ids | NULL       | index | smw_id,smw_sortkey | smw_sortkey | 257     | NULL                                      | 45145 |    81.00 | Using where |
|  1 | SIMPLE      | t1             | NULL       | ref   | s_id,p_id          | s_id        | 8       | smw+genealogy.smw_object_ids.smw_id,const |     1 |   100.00 | Using index |
+----+-------------+----------------+------------+-------+--------------------+-------------+---------+-------------------------------------------+-------+----------+-------------+
2 rows in set, 1 warning (0.01 sec)
```

The second step would be to alter this index to have all column that we group by:

```sql
ALTER TABLE /* CORE-95 macbre */ smw_object_ids DROP KEY `smw_sortkey`, ADD KEY `smw_sortkey` (`smw_sortkey`, `smw_id`);
```