### PR TITLE
Revert "CORE-95 | SMWSQLStore3Readers - force an index on smw_object_ids"

### DIFF
--- a/extensions/SemanticMediaWiki/includes/storage/SQLStore/SMW_SQLStore3_Readers.php
+++ b/extensions/SemanticMediaWiki/includes/storage/SQLStore/SMW_SQLStore3_Readers.php
@@ -455,12 +455,7 @@ class SMWSQLStore3Readers {
 		$group = false;
 
 		if ( $proptable->usesIdSubject() ) { // join with ID table to get title data
-			$from = $db->tableName( SMWSql3SmwIds::TABLE_NAME );
-
-			// CORE-95 | force an index on smw_object_ids, MySQL picks PRIMARY for large tables (1mm+ rows)
-			$from .= ' FORCE KEY(smw_sortkey)';
-
-			$from .= " INNER JOIN " . $db->tableName( $proptable->getName() ) . " AS t1 ON t1.s_id=smw_id";
+			$from = $db->tableName( SMWSql3SmwIds::TABLE_NAME ) . " INNER JOIN " . $db->tableName( $proptable->getName() ) . " AS t1 ON t1.s_id=smw_id";
 			$select = 'smw_title, smw_namespace, smw_iw, smw_sortkey, smw_subobject';
 			$group = true;
 		} else { // no join needed, title+namespace as given in proptable
@@ -485,7 +480,7 @@ class SMWSQLStore3Readers {
 			}
 		}
 
-		// CORE-95 | performance fix backport from https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/3142
+		// CORE-95 | performance fix backport frpm https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/3142
 		$options = $this->store->getSQLOptions( $requestOptions, 'smw_sortkey' );
 		if ( $group ) {
 			$options['GROUP BY'] = 'smw_sortkey, smw_id';


### PR DESCRIPTION
Reverts Wikia/app#16805, forcing an index was not the best idea.

## An example

```sql
mysql@geo-db-smw-slave.query.consul[smw+genealogy]>explain SELECT /* SMWSQLStore3Readers::getPropertySubjects 5.255.250.112 - 5fc13369-7d42-497a-b920-9719a8628d0a */  smw_title, smw_namespace, smw_iw, smw_sortkey, smw_subobject  FROM `smw_object_ids` FORCE KEY(smw_sortkey) INNER JOIN `smw_di_blob` AS t1 ON t1.s_id=smw_id  WHERE t1.p_id='437' AND smw_iw!=':smw' AND smw_iw!=':smw-delete'  GROUP BY smw_sortkey, smw_id ORDER BY smw_sortkey LIMIT 25  ;
+----+-------------+----------------+------------+------+--------------------+------+---------+-------+----------+----------+----------------------------------------------------+
| id | select_type | table          | partitions | type | possible_keys      | key  | key_len | ref   | rows     | filtered | Extra                                              |
+----+-------------+----------------+------------+------+--------------------+------+---------+-------+----------+----------+----------------------------------------------------+
|  1 | SIMPLE      | t1             | NULL       | ref  | s_id,p_id,s_id_2   | p_id | 4       | const |        2 |   100.00 | Using temporary; Using filesort                    |
|  1 | SIMPLE      | smw_object_ids | NULL       | ALL  | smw_id,smw_sortkey | NULL | NULL    | NULL  | 34551857 |     0.00 | Using where; Using join buffer (Block Nested Loop) |
+----+-------------+----------------+------------+------+--------------------+------+---------+-------+----------+----------+----------------------------------------------------+
2 rows in set, 1 warning (0.00 sec)
```