### PR TITLE
Disable file pages purging on prod - until it is fixed properly

### DIFF
--- a/extensions/wikia/FilePage/FilePageHooks.class.php
+++ b/extensions/wikia/FilePage/FilePageHooks.class.php
@@ -233,7 +233,8 @@ class FilePageHooks extends WikiaObject{
 	 * @return true -- because it's hook
 	 */
 	public static function onArticleSaveComplete( WikiPage $page ) {
-		self::clearLinkedFilesCache( $page->mTitle->getArticleID() );
+		// Temporarily commented out as this causes a lot of purge requests
+		// self::clearLinkedFilesCache( $page->mTitle->getArticleID() );
 
 		return true;
 	}


### PR DESCRIPTION
This causes a huge amount of celery purger requests, commenting out until we figure out a root cause or find a workaround.
The hook I'm commenting out is from a new SEO feature released today on prod: https://wikia-inc.atlassian.net/browse/PLATFORM-3934