### PR TITLE
SER-3010 | Don't limit the number of concurrent

### DIFF
--- a/maintenance/wikia/migrateImagesToGcsForWikis.php
+++ b/maintenance/wikia/migrateImagesToGcsForWikis.php
@@ -113,7 +113,7 @@ class MigrateImagesForWikis extends Maintenance {
 
 		if ( $this->parallel > 1 ) {
 			$fullCommand =
-				"parallel \"$command --parallel={$this->parallel} --thread={}\"  --args{} :::";
+				"parallel --jobs 0 \"$command --parallel={$this->parallel} --thread={}\"  --args{} :::";
 			for ( $i = 0; $i < $this->parallel; ++ $i ) {
 				$fullCommand = $fullCommand . " {$i}";
 			}


### PR DESCRIPTION
The `parallel` param should control the number of processes, so use GNU Parallel's `--jobs 0` to never limit it.