### PR TITLE
PLATFORM-3976| handle non standard WF domains in getWikisUnderDomain()

### DIFF
--- a/includes/wikia/api/WikisApiController.class.php
+++ b/includes/wikia/api/WikisApiController.class.php
@@ -279,15 +279,14 @@ class WikisApiController extends WikiaApiController {
 	 * @responseParam array $wikis List of wikis hosted under $domain, empty if that is not a primary domain
 	 */
 	public function getWikisUnderDomain() {
-		global $wgWikiaBaseDomainRegex;
 		$domain = $this->request->getVal( 'domain' );
 		$localizeUrls = $this->request->getBool( 'localizeUrls', false );
-		if ( !preg_match( '/\.' . $wgWikiaBaseDomainRegex . '$/', $domain ) ) {
-			throw new InvalidParameterApiException( 'domain' );
-		}
-
 		$normalizedDomain = wfNormalizeHost( $domain );
 		$cityId = WikiFactory::DomainToID( $normalizedDomain );
+
+		if ( empty( $cityId ) ) {
+			throw new InvalidParameterApiException( 'domain' );
+		}
 
 		if ( !empty( $cityId ) && !WikiFactory::isLanguageWikisIndex( $cityId ) ) {
 			// there is a community at the domain root, make sure it is the primary domain

--- a/includes/wikia/api/WikisApiController.class.php
+++ b/includes/wikia/api/WikisApiController.class.php
@@ -284,10 +284,6 @@ class WikisApiController extends WikiaApiController {
 		$normalizedDomain = wfNormalizeHost( $domain );
 		$cityId = WikiFactory::DomainToID( $normalizedDomain );
 
-		if ( empty( $cityId ) ) {
-			throw new InvalidParameterApiException( 'domain' );
-		}
-
 		if ( !empty( $cityId ) && !WikiFactory::isLanguageWikisIndex( $cityId ) ) {
 			// there is a community at the domain root, make sure it is the primary domain
 			$primaryDomain = parse_url( WikiFactory::cityIDtoDomain( $cityId ), PHP_URL_HOST );

--- a/includes/wikia/api/tests/WikisApiControllerTest.php
+++ b/includes/wikia/api/tests/WikisApiControllerTest.php
@@ -445,7 +445,7 @@ class WikisApiControllerTest extends WikiaBaseTest {
 			WIKIA_ENV_PROD,
 			[],
 			[],
-			InvalidParameterApiException::class	// expected exception
+			NotFoundApiException::class	// expected exception
 		];
 		// --------- Test case ------------
 		// 10. Unknown domain


### PR DESCRIPTION
It seems that for a non-standard domains such as wowwiki.com and such call to MW API's getWikisUnderDomain() will return 400 because it assumes that all domains should have either `.wiki.com` or `.fandom.com` suffix. This should fix this.