### PR TITLE
PlacesParserHookHandler: tag pages with <place> tag using SemanticMediaWiki "Geo" property

### DIFF
--- a/extensions/wikia/Places/PlacesParserHookHandler.class.php
+++ b/extensions/wikia/Places/PlacesParserHookHandler.class.php
@@ -84,6 +84,26 @@ class PlacesParserHookHandler {
 
 		$html = self::cleanHTML($html);
 
+		// tag pages with <place> tag using SemanticMediaWiki "Geo" property
+		global $wgEnableSemanticMediaWikiExt;
+		if ( !empty( $wgEnableSemanticMediaWikiExt ) ) {
+			$value = sprintf( "%.6f°, %.6f°", $placeModel->getLat(), $placeModel->getLon() );
+
+			// code borrowed from \SMW\SetParserFunction::parse method
+			$parserData = new \SMW\ParserData($parser->getTitle(), $parser->getOutput());
+			$subject = $parserData->getSemanticData()->getSubject();
+
+			$dataValue = \SMW\DataValueFactory::getInstance()->newDataValueByText(
+				'Geo',
+				$value,
+				false,
+				$subject
+			);
+			$parserData->addDataValue( $dataValue );
+			$parserData->pushSemanticDataToParserOutput();
+			$parserData->updateStore( true );
+		}
+
 		wfProfileOut(__METHOD__);
 		return $html;
 	}


### PR DESCRIPTION
Wikitext

```html
<place lat="52.412339" lon="16.939012" height=200 width=300 />
```

will set `Geo` SemanticMediaWiki property: 

* https://poznan.fandom.com/wiki/Specjalna:Przegl%C4%85d/Kantor_Krzy%C5%BCanowskiego
* https://poznan.fandom.com/wiki/Atrybut:Geo