### PR TITLE
IW-1821 | Make FeedsAndPostsController::getArticleDetails check if page exists

### DIFF
--- a/extensions/wikia/FeedsAndPosts/FeedsAndPostsController.class.php
+++ b/extensions/wikia/FeedsAndPosts/FeedsAndPostsController.class.php
@@ -41,22 +41,22 @@ class FeedsAndPostsController extends WikiaApiController {
 		$articleTitle = $this->getRequiredParam( 'title' );
 
 		$title = Title::newFromText( $articleTitle );
-		$articleId = $title->getArticleID();
 
-		if ( $articleId ) {
-			$images = ArticleData::getImages( $articleId );
+		if ( $title ) {
+			$images = ArticleData::getImages( $title->getArticleID() );
 
 			$this->response->setFormat( WikiaResponse::FORMAT_JSON );
 			$this->response->setValues( [
 				'title' => $title->getText(),
+				'exists' => $title->exists(),
 				'thumbnail' => $images[0] ?? null,
 				'content_images' => count( $images ) > 1 ? array_slice( $images, 1 ) : [],
 				'snippet' => ArticleData::getTextSnippet( $title ),
 			] );
-
+			
 			return;
 		}
 
-		$this->response->setCode( WikiaResponse::RESPONSE_CODE_NOT_FOUND );
+		$this->response->setCode( WikiaResponse::RESPONSE_CODE_BAD_REQUEST );
 	}
 }

--- a/extensions/wikia/FeedsAndPosts/FeedsAndPostsController.class.php
+++ b/extensions/wikia/FeedsAndPosts/FeedsAndPostsController.class.php
@@ -67,9 +67,9 @@ class FeedsAndPostsController extends WikiaApiController {
 		$this->response->setValues( [
 			'title' => $title->getText(),
 			'exists' => $title->exists(),
-			'thumbnail' => $images[0] ?? null,
-			'content_images' => count($images) > 1 ? array_slice($images, 1) : [],
-			'snippet' => ArticleData::getTextSnippet($title),
+			'thumbnail' => null,
+			'content_images' => [],
+			'snippet' => null,
 			'relativeUrl' => '',
 		]);
 	}

--- a/extensions/wikia/FeedsAndPosts/FeedsAndPostsController.class.php
+++ b/extensions/wikia/FeedsAndPosts/FeedsAndPostsController.class.php
@@ -41,15 +41,22 @@ class FeedsAndPostsController extends WikiaApiController {
 		$articleTitle = $this->getRequiredParam( 'title' );
 
 		$title = Title::newFromText( $articleTitle );
+		$articleId = $title->getArticleID();
 
-		$images = ArticleData::getImages($title->getArticleID());
+		if ( $articleId ) {
+			$images = ArticleData::getImages( $articleId );
 
-		$this->response->setFormat(WikiaResponse::FORMAT_JSON);
-		$this->response->setValues([
-			'title' => $title->getText(),
-			'thumbnail' => $images[0] ?? null,
-			'content_images' => count($images) > 1 ? array_slice($images, 1) : [],
-			'snippet' => ArticleData::getTextSnippet($title),
-		]);
+			$this->response->setFormat( WikiaResponse::FORMAT_JSON );
+			$this->response->setValues( [
+				'title' => $title->getText(),
+				'thumbnail' => $images[0] ?? null,
+				'content_images' => count( $images ) > 1 ? array_slice( $images, 1 ) : [],
+				'snippet' => ArticleData::getTextSnippet( $title ),
+			] );
+
+			return;
+		}
+
+		$this->response->setCode( WikiaResponse::RESPONSE_CODE_NOT_FOUND );
 	}
 }

--- a/extensions/wikia/FeedsAndPosts/FeedsAndPostsController.class.php
+++ b/extensions/wikia/FeedsAndPosts/FeedsAndPostsController.class.php
@@ -58,7 +58,7 @@ class FeedsAndPostsController extends WikiaApiController {
 				'thumbnail' => $images[0] ?? null,
 				'content_images' => count( $images ) > 1 ? array_slice( $images, 1 ) : [],
 				'snippet' => ArticleData::getTextSnippet( $title ),
-        'relativeUrl' => $title->getLocalURL(),
+        			'relativeUrl' => $title->getLocalURL(),
 			] );
 
 			return;

--- a/extensions/wikia/FeedsAndPosts/FeedsAndPostsController.class.php
+++ b/extensions/wikia/FeedsAndPosts/FeedsAndPostsController.class.php
@@ -38,14 +38,20 @@ class FeedsAndPostsController extends WikiaApiController {
 	}
 
 	public function getArticleData() {
+		$this->response->setFormat( WikiaResponse::FORMAT_JSON );
+
 		$articleTitle = $this->getRequiredParam( 'title' );
 
 		$title = Title::newFromText( $articleTitle );
 
-		if ( $title ) {
+		if ( !$title ) {
+			$this->response->setCode( WikiaResponse::RESPONSE_CODE_BAD_REQUEST );
+			return;
+		}
+
+		if ( $title->exists() ) {
 			$images = ArticleData::getImages( $title->getArticleID() );
 
-			$this->response->setFormat( WikiaResponse::FORMAT_JSON );
 			$this->response->setValues( [
 				'title' => $title->getText(),
 				'exists' => $title->exists(),
@@ -53,10 +59,16 @@ class FeedsAndPostsController extends WikiaApiController {
 				'content_images' => count( $images ) > 1 ? array_slice( $images, 1 ) : [],
 				'snippet' => ArticleData::getTextSnippet( $title ),
 			] );
-			
+
 			return;
 		}
 
-		$this->response->setCode( WikiaResponse::RESPONSE_CODE_BAD_REQUEST );
+		$this->response->setValues( [
+			'title' => $title->getText(),
+			'exists' => $title->exists(),
+			'thumbnail' => null,
+			'content_images' => [],
+			'snippet' => '',
+		] );
 	}
 }


### PR DESCRIPTION
`FeedsAndPostsController::getArticleDetails` should return 404 when the requested page does not exist. This allows the tags page on feeds side to be rendered in a zero-state.

https://wikia-inc.atlassian.net/browse/IW-1821