### PR TITLE
IW-1828 | Remove double escaping from Feeds article snippet

### DIFF
--- a/extensions/wikia/FeedsAndPosts/ArticleData.class.php
+++ b/extensions/wikia/FeedsAndPosts/ArticleData.class.php
@@ -17,7 +17,7 @@ class ArticleData {
 		return $urls;
 	}
 
-	public static function getTextSnippet(Title $title) {
-		return htmlspecialchars((new ArticleService($title))->getTextSnippet(300, 350));
+	public static function getTextSnippet( Title $title ) {
+		return ( new ArticleService( $title ) )->getTextSnippet( 300, 350 );
 	}
 }


### PR DESCRIPTION
Remove double escaping from Feeds article snippet, to avoid issues with HTML entity display in snippets.

https://wikia-inc.atlassian.net/browse/IW-1828