### PR TITLE
Vary on X-Mw-Wiki-Id header for LinkSuggest

### DIFF
--- a/extensions/wikia/LinkSuggest/LinkSuggest.php
+++ b/extensions/wikia/LinkSuggest/LinkSuggest.php
@@ -66,8 +66,9 @@ function getLinkSuggest() {
 
 	$out = LinkSuggest::getLinkSuggest($wgRequest);
 
-	$ar = new AjaxResponse($out);
+	$ar = new AjaxResponse( $out );
 	$ar->setCacheDuration(60 * 60);
+	$ar->setVary( implode( ",",[ "Accept-Encoding", WebRequest::MW_WIKI_ID_HEADER ] ) );
 
 	if ($wgRequest->getText('format') == 'json') {
 		$ar->setContentType('application/json; charset=utf-8');

--- a/extensions/wikia/LinkSuggest/LinkSuggest.php
+++ b/extensions/wikia/LinkSuggest/LinkSuggest.php
@@ -68,7 +68,7 @@ function getLinkSuggest() {
 
 	$ar = new AjaxResponse( $out );
 	$ar->setCacheDuration(60 * 60);
-	$ar->setVary( implode( ",",[ "Accept-Encoding", WebRequest::MW_WIKI_ID_HEADER ] ) );
+	$ar->setVary( implode( ",", [ "Accept-Encoding", WebRequest::MW_WIKI_ID_HEADER ] ) );
 
 	if ($wgRequest->getText('format') == 'json') {
 		$ar->setContentType('application/json; charset=utf-8');

--- a/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
+++ b/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
@@ -89,7 +89,7 @@ class WikiFactoryLoader {
 			$this->mWikiIdForced = true;
 
 			// differ CDN caching on X-Mw-Wiki-Id request header value
-			RequestContext::getMain()->getOutput()->addVaryHeader( 'X-Mw-Wiki-Id' );
+			RequestContext::getMain()->getOutput()->addVaryHeader( WebRequest::MW_WIKI_ID_HEADER );
 		}
 		elseif ( !empty( $server['SERVER_NAME'] ) ) {
 			// normal HTTP request

--- a/includes/WebRequest.php
+++ b/includes/WebRequest.php
@@ -1160,6 +1160,8 @@ HTML;
 		return $this->getHeader( self::MW_AUTH_OK_HEADER ) !== false;
 	}
 
+	const MW_WIKI_ID_HEADER = 'X-Mw-Wiki-Id';
+
 	/**
 	 * Get the number of seconds to have elapsed since request start,
 	 * in fractional seconds, with microsecond resolution.


### PR DESCRIPTION
The discussion service queries article titles using the LinkSuggest MW API. It makes all of those requests to community.fandom.com and differentiates the community to query using the `X-Mw-Wiki-Id` header. The problem with that approach is the LinkSuggest API doesn't include `X-Mw-Wiki-Id` in its Vary headers, so we were getting cached responses from different communities.

The fix is to update the response so that Vary header includes `X-Mw-Wiki-Id `.