### PR TITLE
Use static number of pods for mediawiki-prod

### DIFF
--- a/docker/prod/Jenkinsfile
+++ b/docker/prod/Jenkinsfile
@@ -346,7 +346,8 @@ node("docker-daemon-big") {
                 'IMAGE_TAG': imageTag,
                 'DATACENTER': 'sjc',
                 'APP_VERSION': nextAppTag,
-                'CONFIG_VERSION': nextConfigTag
+                'CONFIG_VERSION': nextConfigTag,
+                'PODS': '150'
               ])
 
               sh("""cat > docker/prod/sjc.yaml <<EOL
@@ -368,7 +369,8 @@ EOL""")
                 'IMAGE_TAG': imageTag,
                 'DATACENTER': 'res',
                 'APP_VERSION': nextAppTag,
-                'CONFIG_VERSION': nextConfigTag
+                'CONFIG_VERSION': nextConfigTag,
+                'PODS': '100'
               ])
 
               sh("""cat > docker/prod/res.yaml <<EOL

--- a/docker/prod/prod.template.yaml
+++ b/docker/prod/prod.template.yaml
@@ -10,8 +10,9 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 0
-      maxSurge: 2
+      maxUnavailable: 20%
+      maxSurge: 20%
+  replicas: 80
   progressDeadlineSeconds: 180
   selector:
     matchLabels:
@@ -114,26 +115,6 @@ spec:
             requests:
               cpu: 50m
               memory: 50Mi
----
-apiVersion: autoscaling/v2beta1
-kind: HorizontalPodAutoscaler
-metadata:
-  name: mediawiki-prod
-  namespace: prod
-  labels:
-    app: mediawiki-prod
-spec:
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: mediawiki-prod
-  maxReplicas: 75
-  minReplicas: 20
-  metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      targetAverageUtilization: 50
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/docker/prod/prod.template.yaml
+++ b/docker/prod/prod.template.yaml
@@ -12,7 +12,7 @@ spec:
     rollingUpdate:
       maxUnavailable: 20%
       maxSurge: 20%
-  replicas: 80
+  replicas: 150
   progressDeadlineSeconds: 180
   selector:
     matchLabels:

--- a/docker/prod/prod.template.yaml
+++ b/docker/prod/prod.template.yaml
@@ -12,7 +12,7 @@ spec:
     rollingUpdate:
       maxUnavailable: 20%
       maxSurge: 20%
-  replicas: 150
+  replicas: ${PODS}
   progressDeadlineSeconds: 180
   selector:
     matchLabels:


### PR DESCRIPTION
`HorizontalPodAutoscaler` doesn't work well for our HTTP workload. Let's configure a static number of pods.