### PR TITLE
IW-1854 | Fix "edit article" link on feeds tag page for nonexistent article

### DIFF
--- a/extensions/wikia/FeedsAndPosts/FeedsAndPostsController.class.php
+++ b/extensions/wikia/FeedsAndPosts/FeedsAndPostsController.class.php
@@ -58,7 +58,7 @@ class FeedsAndPostsController extends WikiaApiController {
 				'thumbnail' => $images[0] ?? null,
 				'content_images' => count( $images ) > 1 ? array_slice( $images, 1 ) : [],
 				'snippet' => ArticleData::getTextSnippet( $title ),
-        			'relativeUrl' => $title->getLocalURL(),
+				'relativeUrl' => $title->getLocalURL(),
 			] );
 
 			return;
@@ -70,7 +70,7 @@ class FeedsAndPostsController extends WikiaApiController {
 			'thumbnail' => null,
 			'content_images' => [],
 			'snippet' => null,
-			'relativeUrl' => '',
+			'relativeUrl' => $title->getLocalURL(),
 		]);
 	}
 }


### PR DESCRIPTION
When an article for a given tag does not exist, we should still return a valid relative URL for it. This will allow the feeds frontend to build a valid edit link to it.

https://wikia-inc.atlassian.net/browse/IW-1854