### PR TITLE
Add second mediawiki http pool for performance comparison

### DIFF
--- a/docker/experiment/Dockerfile
+++ b/docker/experiment/Dockerfile
@@ -1,0 +1,137 @@
+# This is a base Docker image used by Wikia's MediaWiki app. It uses base PHP image provided by Docker with additional
+# production dependencies installed.
+FROM php:7.0.30-fpm-stretch
+
+# set locale as required by MediaWiki / Perl
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+# add jessie-backports repo (required to install libsass-dev package)
+RUN apt-get update && apt-get install -y \
+    autoconf \
+    automake \
+    libbz2-dev \
+    libfreetype6-dev \
+    libjpeg62-turbo-dev \
+    # needed by memcached
+    libmemcached-dev \
+    libpng-dev \
+    libxml2-dev \
+    # needed by wikidiff2
+    libthai-dev \
+    libtool \
+    libyaml-dev \
+    locales \
+    # needed by Timeline extension
+    ploticus \
+    wget \
+    # needed by php tidy extension
+    libtidy-dev \
+    # needed by php intl extension
+    libicu-dev \
+    # needed by php luasandbox extension
+    liblua5.1-0-dev \
+    # SUS-5500 | provides mysqldump needed by dumpStarters.php script
+    default-mysql-client \
+    # SUS-5807 | required by DumpsOnDemandTask
+    p7zip-full \
+    # needed by sass, this installs libsass-3.4.3, matches with https://github.com/absalomedia/sassphp/releases/tag/0.5.10
+    && apt-get install -y libsass-dev \
+    # cleanup
+    && rm -rf /var/lib/apt/lists/* \
+    #
+    # sassphp extension / @see https://github.com/absalomedia/sassphp fork
+    && cd /tmp \
+    && wget https://github.com/Wikia/sassphp/archive/0.5.10.tar.gz -O sassphp.tar.gz \
+    && mkdir -p /tmp/sassphp \
+    && tar -xf sassphp.tar.gz -C /tmp/sassphp --strip-components=1 \
+    && docker-php-ext-configure /tmp/sassphp \
+    && docker-php-ext-install /tmp/sassphp \
+    #
+    # libmustache / @see https://github.com/jbboehr/libmustache
+    && cd /tmp \
+    && wget https://github.com/Wikia/libmustache/archive/v0.4.4.tar.gz -O libmustache.tar.gz \
+    && mkdir -p /tmp/libmustache \
+    && tar -xf libmustache.tar.gz -C /tmp/libmustache --strip-components=1 \
+    && cd /tmp/libmustache \
+    && autoreconf -fiv && ./configure --without-mustache-spec \
+    && make && make install \
+    #
+    # mustache extension / @see https://github.com/jbboehr/php-mustache
+    && cd /tmp \
+    && wget https://github.com/Wikia/php-mustache/archive/v0.7.3.tar.gz -O mustache.tar.gz \
+    && mkdir -p /tmp/mustache \
+    && tar -xf mustache.tar.gz -C /tmp/mustache --strip-components=1 \
+    && docker-php-ext-configure /tmp/mustache \
+    && docker-php-ext-install /tmp/mustache \
+    #
+    # wikidiff2 extension / @see https://www.mediawiki.org/wiki/Extension:Wikidiff2#Manually
+    && cd /tmp \
+    && wget https://github.com/Wikia/wikidiff2/archive/1.4.1.tar.gz -O wikidiff2.tar.gz \
+    && mkdir -p /tmp/wikidiff2 \
+    && tar -xf wikidiff2.tar.gz -C /tmp/wikidiff2 --strip-components=1 \
+    && docker-php-ext-configure /tmp/wikidiff2 \
+    && docker-php-ext-install /tmp/wikidiff2 \
+    #
+    # tideways extension / @see https://tideways.com/
+    && cd /tmp \
+    && wget https://github.com/Wikia/php-xhprof-extension/archive/v4.1.6.tar.gz -O php-xhprof-extension.tar.gz \
+    && mkdir -p /tmp/php-xhprof-extension \
+    && tar -xf php-xhprof-extension.tar.gz -C /tmp/php-xhprof-extension --strip-components=1 \
+    && docker-php-ext-configure /tmp/php-xhprof-extension \
+    && docker-php-ext-install /tmp/php-xhprof-extension \
+    #
+    # luasandbox extension / @see https://www.mediawiki.org/wiki/LuaSandbox
+    && cd /tmp \
+    && wget https://github.com/Wikia/mediawiki-php-luasandbox/archive/3.0.1.tar.gz -O php-luasandbox-extension.tar.gz \
+    && mkdir -p /tmp/php-luasandbox-extension \
+    && tar -xf php-luasandbox-extension.tar.gz -C /tmp/php-luasandbox-extension --strip-components=1 \
+    && docker-php-ext-configure /tmp/php-luasandbox-extension \
+    && docker-php-ext-install /tmp/php-luasandbox-extension \
+    #
+    # SUS-5855 | redis pecl extension requied by Wikia\Metrics\Collector
+    && pecl install --onlyreqdeps --force redis \
+    && docker-php-ext-enable redis \
+    #
+    # install PHP extensions required by MediaWiki that are provided by Docker base PHP image helper
+    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+    && docker-php-ext-install \
+    bz2 \
+    gd \
+    mysqli \
+    opcache \
+    # simplexml: SimpleXMLElement is used by DesignSystem and PortableInfoboxBuilder extensions
+    simplexml \
+    # required by PortableInfobox
+    tidy \
+    # needed by RabbitMQ client
+    bcmath \
+    # RecentChange::notifyRC2UDP uses socket_create
+    sockets \
+    # used to read localisation cache data from CDB files
+    dba \
+    # needed by multithread scripts
+    pcntl \
+    # needed by IcuCollation class
+    intl \
+    # required by Exif.php class to render file's metdata
+    exif \
+    # remove no longer needed dependencies
+    && apt-get remove -y \
+        automake \
+        wget \
+    && apt-get autoremove -y \
+    && rm -rf /tmp/*
+
+# setup php.ini globally
+ADD ./php.ini /usr/local/etc/php/php.ini
+
+# add and validate PHP FPM configuration
+ADD ./php-fpm.conf /usr/local/etc/php-fpm.d/zz-www.conf
+RUN php-fpm --test
+
+# expose volumes for app and config repositories clones
+ENV WIKIA_DOCROOT=/usr/wikia/slot1/current/src
+ENV WIKIA_CONFIG_ROOT=/usr/wikia/slot1/current/config
+
+WORKDIR /usr/wikia/slot1/current/src

--- a/docker/experiment/Dockerfile-php
+++ b/docker/experiment/Dockerfile-php
@@ -1,0 +1,12 @@
+# This is a base Docker image used in prod/sandbox/preview Jenkinsfile
+FROM artifactory.wikia-inc.com/sus/php-wikia-base-experiment:10-workers
+
+ADD app /usr/wikia/slot1/current/src
+ADD config /usr/wikia/slot1/current/config
+
+# WIKIA_ENVIRONMENT and WIKIA_DATACENTER - needed for maintenance scripts to run, but they are not used by rebuildLocalisationCache.php
+RUN mkdir -p /usr/wikia/slot1/current/cache/messages && \
+  chmod 777 /usr/wikia/slot1/current/cache/messages && \
+  WIKIA_ENVIRONMENT=prod WIKIA_DATACENTER=sjc SERVER_ID=177 php maintenance/rebuildLocalisationCache.php --threads=16
+
+USER nobody

--- a/docker/experiment/base.inc
+++ b/docker/experiment/base.inc
@@ -1,0 +1,50 @@
+listen 8080;
+root /usr/wikia/slot1/current/src;
+
+rewrite "^/health/check$" /health.php break;
+rewrite "^/proxy.php$" /extensions/wikia/Tasks/proxy/proxy.php break;
+
+rewrite ^/robots.txt /wikia-robots-txt.php break;
+rewrite "^/(sitemap.+\.xml(.gz)*)$" /index.php?title=Special:Sitemap/$1&uselang=en break;
+
+rewrite "^/(?:[a-z]{2,3}(?:-[a-z-]{2,12})?/)?__load/[^/]*/([^/]*)/([^$].+)" /load.php?modules=$2&$1 break;
+rewrite "^/(?:[a-z]{2,3}(?:-[a-z-]{2,12})?/)?__am/(\d+)/([A-Za-z]+)/([^/]*)/(.*)" /index.php?action=ajax&rs=AssetsManagerEntryPoint&cb=$1&type=$2&params=$3&oid=$4 break;
+
+rewrite ^/api/(?:v1|test)/?$ /wikia.php?controller=ApiDocs&method=index break;
+rewrite ^/api/(?:v1|test)/([^/]*)/([^/]*) /wikia.php?controller=$1Api&method=get$2 break;
+
+# SUS-5798 / SUS-5824: alternative article paths - /wiki/index.php and /w
+# SUS-6051 | because of The Complex Way wiki domain is passed down to nginx
+#            we need to use /redirect-canonical.php to handle these redirects
+rewrite "^/([a-z]{2,3}(-[a-z-]{2,12})?/)?w/(.*)$" /redirect-canonical.php break;
+rewrite "^/([a-z]{2,3}(-[a-z-]{2,12})?/)?wiki/index.php/(.*)$" /redirect-canonical.php break;
+
+# rewrites for language wiki
+rewrite "^/[a-z]{2,3}(?:-[a-z-]{2,12})?/(sitemap.+\.xml[.gz]*)$" /index.php?title=Special:Sitemap/$1&uselang=en break;
+
+rewrite "^/(?:[a-z]{2,3}(?:-[a-z-]{2,12})?/)?api.php(.*)" /api.php$1;
+# SUS-5789 force pre-existing lyricwiki API calls to use a MediaWiki-compliant query
+# it should be the last rewrite for api.php, since "if" behaviour might be unexpected otherwise (https://www.nginx.com/resources/wiki/start/topics/depth/ifisevil/)
+# this if checks if there is a "func" query param
+if ($arg_func) {
+    rewrite ^(.*)$ $1?action=lyrics last;
+}
+ # SUS-6154
+rewrite "^/(?:[a-z]{2,3}(?:-[a-z-]{2,12})?/)?(index|load|opcache_stats|metrics|opensearch_desc|wikia).php(.*)" /$1.php$2 break;
+
+# article URL
+rewrite "^/(?:[a-z]{2,3}(?:-[a-z-]{2,12})?/)?wiki/(.*)" /index.php?title=$1 break;
+
+# rewrite for language wiki root path
+rewrite "^/(?:[a-z]{2,3}(?:-[a-z-]{2,12})?/?)?$" /index.php break;
+
+# handle cachebuster URLs and default favicon on devboxes and local machines
+rewrite "^/(?:[a-z]{2,3}(?:-[a-z-]{2,12})?/)?(__cb\d+/)?(skins|resources|extensions)/(.+)" /$2/$3 break;
+rewrite ^/favicon.ico /skins/common/images/favicon.ico break;
+
+# filter out unwanted directories
+location ~ ^/(lib|serialized|tests|mw-config|includes|cache|maintenance|languages|config) {
+    return 403;
+}
+
+error_page 404 = /redirect-canonical.php;

--- a/docker/experiment/nginx.conf
+++ b/docker/experiment/nginx.conf
@@ -1,0 +1,46 @@
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+
+    client_max_body_size 0; # disable checking of client request body size
+
+    default_type  application/octet-stream;
+    keepalive_requests 10000;
+
+    # SUS-6160 | fpm settings
+    # @see http://nginx.org/en/docs/http/ngx_http_fastcgi_module.html
+    fastcgi_connect_timeout 3s;
+    fastcgi_send_timeout 10s;
+    fastcgi_next_upstream off; # do not retry failed requests, CDN handles that for us
+
+    log_format json_combined escape=json '{ "appname": "mediawiki-nginx-access-logs", '
+      '"time_local": "$time_local", '
+      '"remote_addr": "$http_fastly_client_ip", '
+      '"remote_user": "$remote_user", '
+      '"method": "$request_method", '
+      '"request": "$request_uri", '
+      '"status": $status, '
+      '"body_bytes_sent": $body_bytes_sent, '
+      '"request_time": $request_time, '
+      '"http_host": "$http_x_original_host", '
+      '"http_referrer": "$http_referer", '
+      '"http_user_agent": "$http_user_agent" }';
+
+    access_log  /dev/stdout  json_combined;
+
+    sendfile        on;
+
+    keepalive_timeout  65;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/docker/experiment/php-fpm.conf
+++ b/docker/experiment/php-fpm.conf
@@ -1,0 +1,6 @@
+[www]
+pm = static
+pm.max_children = 10
+pm.max_requests = 1000
+pm.status_path = /status
+access.log = /dev/null

--- a/docker/experiment/php.ini
+++ b/docker/experiment/php.ini
@@ -1,0 +1,118 @@
+y2k_compliance = On
+engine = On
+short_open_tag = On
+precision = 14
+output_buffering = Off
+zlib.output_compression = Off
+implicit_flush = Off
+unserialize_callback_func =
+serialize_precision = 100
+disable_functions =
+disable_classes =
+zend.enable_gc = On
+expose_php = Off
+max_execution_time = 180
+max_input_time = 60
+memory_limit = 512M
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
+display_errors = Off
+display_startup_errors = Off
+log_errors = On
+log_errors_max_len = 0
+ignore_repeated_errors = Off
+ignore_repeated_source = Off
+report_memleaks = On
+track_errors = Off
+html_errors = On
+error_log = syslog
+variables_order = "EGPCS"
+request_order = "GP"
+register_argc_argv = On
+auto_globals_jit = On
+post_max_size = 50M
+auto_prepend_file =
+auto_append_file =
+default_mimetype = "text/html"
+default_charset = "UTF-8"
+doc_root =
+user_dir =
+enable_dl = On
+file_uploads = On
+upload_max_filesize = 10M
+max_file_uploads = 20
+allow_url_fopen = On
+allow_url_include = Off
+user_agent="php_url_routine"
+default_socket_timeout = 60
+[CLI Server]
+cli_server.color = On
+[Date]
+[filter]
+[iconv]
+[intl]
+[sqlite3]
+[Pcre]
+[Pdo]
+[Pdo_mysql]
+[Phar]
+[mail function]
+[SQL]
+[ODBC]
+[Interbase]
+[MySQLi]
+mysqli.max_persistent = -1
+mysqli.allow_persistent = On
+mysqli.max_links = -1
+mysqli.cache_size = 2000
+mysqli.default_port = 3306
+mysqli.default_socket =
+mysqli.default_host =
+mysqli.default_user =
+mysqli.default_pw =
+mysqli.reconnect = Off
+[mysqlnd]
+[PostgreSQL]
+[bcmath]
+bcmath.scale = 0
+[browscap]
+[Session]
+session.save_handler = files
+session.use_strict_mode = 0
+session.use_cookies = 1
+session.use_only_cookies = 1
+session.name = PHPSESSID
+session.auto_start = 0
+session.cookie_lifetime = 0
+session.cookie_path = /
+session.cookie_domain =
+session.cookie_httponly =
+session.serialize_handler = php
+session.gc_probability = 1
+session.gc_divisor = 1000
+session.gc_maxlifetime = 1440
+session.referer_check =
+session.cache_limiter = nocache
+session.cache_expire = 180
+session.use_trans_sid = 0
+session.hash_function = 0
+session.hash_bits_per_character = 5
+url_rewriter.tags = "a=href,area=href,frame=src,input=src,form=fakeentry"
+[Assertion]
+zend.assertions = -1
+[COM]
+[mbstring]
+[gd]
+[exif]
+[Tidy]
+tidy.clean_output = Off
+[soap]
+[sysvshm]
+[ldap]
+[mcrypt]
+[curl]
+[openssl]
+[opcache]
+opcache.memory_consumption=512;
+opcache.interned_strings_buffer=64;
+opcache.max_accelerated_files=20000;
+opcache.validate_timestamps=0;

--- a/docker/prod/Jenkinsfile
+++ b/docker/prod/Jenkinsfile
@@ -1,6 +1,7 @@
 def kubectlImage = "artifactory.wikia-inc.com/ops/k8s-deployer:0.0.15"
 def nginxImage = "artifactory.wikia-inc.com/sus/mediawiki-prod-nginx"
 def mediawikiImage = "artifactory.wikia-inc.com/sus/mediawiki-php"
+def mediawikiExperimentalImage = "artifactory.wikia-inc.com/sus/mediawiki-php-experiment"
 def loggerImage = "artifactory.wikia-inc.com/sus/mediawiki-logger"
 
 def rolloutStatusSjc = 1
@@ -301,6 +302,31 @@ node("docker-daemon-big") {
             } else {
               println("Php image tag ($imageTag) already exists")
             }
+
+            // ab performance tests
+            def experimentalImageExists = false
+            def experimentalStatus = sh(script: """
+              curl -u ${env.JENKINS_ARTIFACTORY_USERNAME}:${env.JENKINS_ARTIFACTORY_PASSWORD} \
+              -w "%{http_code}" -s -I -o /dev/null \
+              -XGET "https://artifactory.wikia-inc.com/artifactory/api/storage/dockerv2-local/sus/mediawiki-php-experiment/${imageTag}"
+            """, returnStdout: true).trim()
+
+            if (experimentalStatus == "200") {
+              experimentalImageExists = true
+            }
+
+            if (!experimentalImageExists) {
+              if (params.dry_run) {
+                println("Dry run: docker build .. -f docker/experiment/Dockerfile-php -t $mediawikiExperimentalImage:$imageTag")
+              } else {
+                // SUS-5284 - make the image a bit smaller
+                sh("cp docker/.dockerignore ..")
+                sh("docker build .. -f docker/experiment/Dockerfile-php -t $mediawikiExperimentalImage:$imageTag")
+                sh("docker push $mediawikiExperimentalImage:$imageTag")
+              }
+            } else {
+              println("Php experimental image tag ($imageTag) already exists")
+            }
           }
         }
       },
@@ -347,7 +373,8 @@ node("docker-daemon-big") {
                 'DATACENTER': 'sjc',
                 'APP_VERSION': nextAppTag,
                 'CONFIG_VERSION': nextConfigTag,
-                'PODS': '150'
+                'PODS_A': '70',
+                'PODS_B': '40',
               ])
 
               sh("""cat > docker/prod/sjc.yaml <<EOL
@@ -370,7 +397,8 @@ EOL""")
                 'DATACENTER': 'res',
                 'APP_VERSION': nextAppTag,
                 'CONFIG_VERSION': nextConfigTag,
-                'PODS': '100'
+                'PODS_A': '50',
+                'PODS_B': '25',
               ])
 
               sh("""cat > docker/prod/res.yaml <<EOL

--- a/docker/prod/prod.template.yaml
+++ b/docker/prod/prod.template.yaml
@@ -1,26 +1,28 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: mediawiki-prod
+  name: mediawiki-prod-a
   namespace: prod
   labels:
     app: mediawiki-prod
     type: mediawiki
+    pool: mediawiki-prod-a
 spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: 20%
       maxSurge: 20%
-  replicas: ${PODS}
+  replicas: ${PODS_A}
   progressDeadlineSeconds: 180
   selector:
     matchLabels:
-      app: mediawiki-prod
+      pool: mediawiki-prod-a
   template:
     metadata:
       labels:
         app: mediawiki-prod
+        pool: mediawiki-prod-a
         app_version: "${APP_VERSION}"
         config_version: "${CONFIG_VERSION}"
     spec:
@@ -96,6 +98,126 @@ spec:
             requests:
               cpu: "1200m"
               memory: 1.5Gi
+        # MW log output, see K8s_LOGGING.md
+        - name: logger
+          image: artifactory.wikia-inc.com/sus/mediawiki-logger:latest
+          resources:
+            limits:
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 50Mi
+        - name: fpm-prometheus-exporter
+          image: hipages/php-fpm_exporter:0.5.2
+          ports:
+            - containerPort: 9253
+          resources:
+            limits:
+              memory: 200Mi
+            requests:
+              cpu: 50m
+              memory: 50Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mediawiki-prod-b
+  namespace: prod
+  labels:
+    app: mediawiki-prod
+    type: mediawiki
+    pool: mediawiki-prod-b
+spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 20%
+      maxSurge: 20%
+  replicas: ${PODS_B}
+  progressDeadlineSeconds: 180
+  selector:
+    matchLabels:
+      pool: mediawiki-prod-b
+  template:
+    metadata:
+      labels:
+        app: mediawiki-prod
+        pool: mediawiki-prod-b
+        app_version: "${APP_VERSION}"
+        config_version: "${CONFIG_VERSION}"
+    spec:
+      containers:
+        - name: nginx
+          image: artifactory.wikia-inc.com/sus/mediawiki-prod-nginx:${IMAGE_TAG}
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - /bin/sh
+                - -c
+                - sleep 3
+          livenessProbe:
+            httpGet:
+              path: /health/check
+              port: 8080
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /health/check
+              port: 8080
+            timeoutSeconds: 5
+            periodSeconds: 10
+          ports:
+            - containerPort: 8080
+          resources:
+            limits:
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 50Mi
+        - name: php
+          image: artifactory.wikia-inc.com/sus/mediawiki-php-experiment:${IMAGE_TAG}
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - /bin/sh
+                - -c
+                - sleep 3
+          livenessProbe:
+            tcpSocket:
+              port: 9000
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            tcpSocket:
+              port: 9000
+            timeoutSeconds: 5
+          env:
+            # SUS-5499 | this env variable is used to set up HTTP proxy for internal MediaWiki requests
+            - name: KUBERNETES_DEPLOYMENT_NAME
+              value: mediawiki-prod
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: WIKIA_DATACENTER
+              value: "${DATACENTER}"
+            - name: WIKIA_ENVIRONMENT
+              value: prod
+            - name: LOG_SOCKET_ONLY
+              value: "yes"
+            - name: LOG_SOCKET_ADDRESS
+              value: "tcp://localhost:9999"
+          resources:
+            limits:
+              cpu: 5
+              memory: 5.5Gi  # 10 fpm workers x 512 MB PHP memory limit
+            requests:
+              cpu: 2.5
+              memory: 3Gi
         # MW log output, see K8s_LOGGING.md
         - name: logger
           image: artifactory.wikia-inc.com/sus/mediawiki-logger:latest


### PR DESCRIPTION
This adds an experimental base image with 10 fpm workers, and deploys it alongside the current configuration.