### PR TITLE
SER-3057 | Slight refactoring Special:Search

### DIFF
--- a/includes/wikia/VariablesBase.php
+++ b/includes/wikia/VariablesBase.php
@@ -1846,12 +1846,6 @@ $wgDisableSearchUpdate = true;
 $wgDisableShowInRecirculation = false;
 
 /**
- * Set this to true to disable the full text search feature.
- * @var bool $wgDisableTextSearch
- */
-$wgDisableTextSearch = false;
-
-/**
  * Whether to enable language variant conversion for links.
  * @var bool $wgDisableTitleConversion
  */
@@ -7121,19 +7115,6 @@ $wgScriptPath = '';
  */
 $wgSearchEverythingOnlyLoggedIn = false;
 
-/**
- * Set this to a URL to forward search requests to some external location.
- * If the URL includes '$1', this will be replaced with the URL-encoded
- * search term.
- *
- * For example, to forward to Google you'd have something like:
- * $wgSearchForwardUrl = 'http://www.google.com/search?q=$1' .
- *                       '&domains=http://example.com' .
- *                       '&sitesearch=http://example.com' .
- *                       '&ie=utf-8&oe=utf-8';
- * @var string $wgSearchForwardUrl
- */
-$wgSearchForwardUrl = null;
 
 /**
  * Regexp to match word boundaries, defaults for non-CJK languages


### PR DESCRIPTION
The only significant change would be the removal of this, but as far as I understand it it's dead code.

```
// Wikia change /Begin (ADi)	
		if(($search instanceof SearchErrorReporting) && $search->getError()) {	
			$out->addWikiText( '==' . $search->getError() . '==' );	
			$out->addHTML( $search->getErrorTracker());	
			$out->addHTML( $this->powerSearchBox( $term ) );	
			wfProfileOut( __METHOD__ );	
			return;	
		}	
		// Wikia change /End (ADi)	
 		if( $wgDisableTextSearch ) {	
			if( $wgSearchForwardUrl ) {	
				$url = str_replace( '$1', urlencode( $term ), $wgSearchForwardUrl );	
				$out->redirect( $url );	
			} else {	
				$out->addHTML(	
					Xml::openElement( 'fieldset' ) .	
					Xml::element( 'legend', null, wfMsg( 'search-external' ) ) .	
					Xml::element( 'p', array( 'class' => 'mw-searchdisabled' ), wfMsg( 'searchdisabled' ) ) .	
					wfMsg( 'googlesearch',	
						htmlspecialchars( $term ),	
						htmlspecialchars( 'UTF-8' ),	
						htmlspecialchars( wfMsg( 'searchbutton' ) )	
					) .	
					Xml::closeElement( 'fieldset' )	
				);	
			}	
			wfProfileOut( __METHOD__ );	
			return;	
		}
```