### PR TITLE
More workers for mediawiki on k8s

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -4,8 +4,8 @@ We assume that you have `app` and `config` repository cloned in the same directo
 
 ```sh
 # 1. build a base image
-docker build -f base/Dockerfile -t artifactory.wikia-inc.com/sus/php-wikia-base:da4390f ./base
-docker push artifactory.wikia-inc.com/sus/php-wikia-base:da4390f
+docker build -f base/Dockerfile -t artifactory.wikia-inc.com/sus/php-wikia-base:225a68a ./base
+docker push artifactory.wikia-inc.com/sus/php-wikia-base:225a68a
 
 # 2. and then dev image
 docker build -f dev/Dockerfile -t php-wikia-dev ./dev

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -135,6 +135,6 @@ ENV WIKIA_DOCROOT=/usr/wikia/slot1/current/src
 ENV WIKIA_CONFIG_ROOT=/usr/wikia/slot1/current/config
 
 # run "sha1sum * | sha1sum" to update this value when this file (or any other in this directory) changes
-ENV WIKIA_BASE_IMAGE_HASH=da4390f
+ENV WIKIA_BASE_IMAGE_HASH=225a68a
 
 WORKDIR /usr/wikia/slot1/current/src

--- a/docker/base/Dockerfile-php
+++ b/docker/base/Dockerfile-php
@@ -1,5 +1,5 @@
 # This is a base Docker image used in prod/sandbox/preview Jenkinsfile
-FROM artifactory.wikia-inc.com/sus/php-wikia-base:da4390f
+FROM artifactory.wikia-inc.com/sus/php-wikia-base:225a68a
 
 ADD app /usr/wikia/slot1/current/src
 ADD config /usr/wikia/slot1/current/config

--- a/docker/base/php-fpm.conf
+++ b/docker/base/php-fpm.conf
@@ -1,6 +1,6 @@
 [www]
 pm = static
-pm.max_children = 5
-pm.max_requests = 2000
+pm.max_children = 20
+pm.max_requests = 1000
 pm.status_path = /status
 access.log = /dev/null

--- a/docker/base/php.ini
+++ b/docker/base/php.ini
@@ -13,7 +13,7 @@ zend.enable_gc = On
 expose_php = Off
 max_execution_time = 180
 max_input_time = 60
-memory_limit = 512M
+memory_limit = 200M
 error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 display_errors = Off
 display_startup_errors = Off
@@ -112,7 +112,7 @@ tidy.clean_output = Off
 [curl]
 [openssl]
 [opcache]
-opcache.memory_consumption=512;
+opcache.memory_consumption=200;
 opcache.interned_strings_buffer=64;
 opcache.max_accelerated_files=20000;
 opcache.validate_timestamps=0;

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,6 +1,6 @@
 # This is a Docker image for  Wikia's MediaWiki app that can be used locally by a developer.
 # Simply mount your app and config repositories clone (refer to README.md)
-FROM artifactory.wikia-inc.com/sus/php-wikia-base:da4390f
+FROM artifactory.wikia-inc.com/sus/php-wikia-base:225a68a
 
 # install dev dependencies
 

--- a/docker/prod/Jenkinsfile
+++ b/docker/prod/Jenkinsfile
@@ -347,7 +347,7 @@ node("docker-daemon-big") {
                 'DATACENTER': 'sjc',
                 'APP_VERSION': nextAppTag,
                 'CONFIG_VERSION': nextConfigTag,
-                'PODS': '150'
+                'PODS': '80'
               ])
 
               sh("""cat > docker/prod/sjc.yaml <<EOL
@@ -370,7 +370,7 @@ EOL""")
                 'DATACENTER': 'res',
                 'APP_VERSION': nextAppTag,
                 'CONFIG_VERSION': nextConfigTag,
-                'PODS': '100'
+                'PODS': '50'
               ])
 
               sh("""cat > docker/prod/res.yaml <<EOL

--- a/docker/prod/prod.template.yaml
+++ b/docker/prod/prod.template.yaml
@@ -91,16 +91,17 @@ spec:
               value: "tcp://localhost:9999"
           resources:
             limits:
-              cpu: "2500m"
-              memory: 3Gi  # 5 fpm workers x 512 MB PHP memory limit
+              cpu: 5
+              memory: 5Gi  # 20 fpm workers x 200MB PHP memory limit
             requests:
-              cpu: "1200m"
-              memory: 1.5Gi
+              cpu: 2.5
+              memory: 3Gi
         # MW log output, see K8s_LOGGING.md
         - name: logger
           image: artifactory.wikia-inc.com/sus/mediawiki-logger:latest
           resources:
             limits:
+              cpu: 100m
               memory: 200Mi
             requests:
               cpu: 100m
@@ -111,6 +112,7 @@ spec:
             - containerPort: 9253
           resources:
             limits:
+              cpu: 50m
               memory: 200Mi
             requests:
               cpu: 50m
@@ -259,11 +261,11 @@ spec:
               value: "tcp://localhost:9999"
           resources:
             limits:
-              cpu: 4
-              memory: 3Gi  # 5 fpm workers x 512 MB PHP memory limit
+              cpu: 5
+              memory: 5Gi  # 20 fpm workers x 200MB PHP memory limit
             requests:
-              cpu: 2
-              memory: 1.5Gi
+              cpu: 2.5
+              memory: 3Gi
         # MW log output, see K8s_LOGGING.md
         - name: logger
           image: artifactory.wikia-inc.com/sus/mediawiki-logger:latest

--- a/docker/sandbox/Dockerfile-debug
+++ b/docker/sandbox/Dockerfile-debug
@@ -1,5 +1,5 @@
 # This is a base Docker image used in prod/sandbox/preview Jenkinsfile
-FROM artifactory.wikia-inc.com/sus/php-wikia-base:da4390f
+FROM artifactory.wikia-inc.com/sus/php-wikia-base:225a68a
 
 # disable the opcache
 RUN sed -i 's/zend_extension=/;zend_extension=/g' /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini


### PR DESCRIPTION
This increases the number of fpm workers to 20 per pod, and decreases php memory limit to 200MB. Resources are increased accordingly.