### PR TITLE
CORE-389 | add language prefix to api path rewrite

### DIFF
--- a/docker/base/base.inc
+++ b/docker/base/base.inc
@@ -10,8 +10,10 @@ rewrite "^/(sitemap.+\.xml(.gz)*)$" /index.php?title=Special:Sitemap/$1&uselang=
 rewrite "^/(?:[a-z]{2,3}(?:-[a-z-]{2,12})?/)?__load/[^/]*/([^/]*)/([^$].+)" /load.php?modules=$2&$1 break;
 rewrite "^/(?:[a-z]{2,3}(?:-[a-z-]{2,12})?/)?__am/(\d+)/([A-Za-z]+)/([^/]*)/(.*)" /index.php?action=ajax&rs=AssetsManagerEntryPoint&cb=$1&type=$2&params=$3&oid=$4 break;
 
-rewrite ^/api/(?:v1|test)/?$ /wikia.php?controller=ApiDocs&method=index break;
-rewrite ^/api/(?:v1|test)/([^/]*)/([^/]*) /wikia.php?controller=$1Api&method=get$2 break;
+rewrite "^/api/(?:v1|test)/?$" /wikia.php?controller=ApiDocs&method=index break;
+rewrite "^/api/(?:v1|test)/([^/]*)/([^/]*)" /wikia.php?controller=$1Api&method=get$2 break;
+rewrite "^/[a-z]{2,3}(?:-[a-z-]{2,12})?/api/(?:v1|test)/?$" /wikia.php?controller=ApiDocs&method=index break;
+rewrite "^/[a-z]{2,3}(?:-[a-z-]{2,12})?/api/(?:v1|test)/([^/]*)/([^/]*)" /wikia.php?controller=$1Api&method=get$2 break;
 
 # SUS-5798 / SUS-5824: alternative article paths - /wiki/index.php and /w
 # SUS-6051 | because of The Complex Way wiki domain is passed down to nginx


### PR DESCRIPTION
This fixes `api/v1` for language wikis on k8s.