### PR TITLE
CORE-386 update php-fpm-exporter

### DIFF
--- a/docker/prod/prod.template.yaml
+++ b/docker/prod/prod.template.yaml
@@ -107,7 +107,7 @@ spec:
               cpu: 100m
               memory: 50Mi
         - name: fpm-prometheus-exporter
-          image: hipages/php-fpm_exporter:0.5.2
+          image: hipages/php-fpm_exporter:1.0.0
           ports:
             - containerPort: 9253
           resources:
@@ -277,7 +277,7 @@ spec:
               cpu: 100m
               memory: 50Mi
         - name: fpm-prometheus-exporter
-          image: hipages/php-fpm_exporter:0.5.2
+          image: hipages/php-fpm_exporter:1.0.0
           ports:
             - containerPort: 9253
           resources:

--- a/docker/sandbox/sandbox.template.yaml
+++ b/docker/sandbox/sandbox.template.yaml
@@ -106,7 +106,7 @@ spec:
               cpu: 100m
               memory: 50Mi
         - name: fpm-prometheus-exporter
-          image: hipages/php-fpm_exporter:0.5.2
+          image: hipages/php-fpm_exporter:1.0.0
           ports:
             - containerPort: 9253
           resources:


### PR DESCRIPTION
Use the latest version of `hipages/php-fpm_exporter`.