### PR TITLE
IW-1877 | LinkSuggest: fix handling of exact match when it is a redirect

### DIFF
--- a/extensions/wikia/LinkSuggest/LinkSuggest.class.php
+++ b/extensions/wikia/LinkSuggest/LinkSuggest.class.php
@@ -251,7 +251,7 @@ class LinkSuggest {
 
 				$results = [ $row->page_id => $redirTitleFormatted ] + $results;
 
-				$redirects[$redirTitleFormatted] = $titleFormatted;
+				$redirects[$titleFormatted] = $redirTitleFormatted;
 			}
 		}
 
@@ -376,9 +376,11 @@ class LinkSuggest {
 
 	static private function formatResults($db, $res, $query, &$redirects, &$results, &$exactMatchRow, $limit) {
 		while(($row = $db->fetchObject($res)) && count($results) < $limit ) {
+			$upperCaseTitle = mb_strtoupper( $row->page_title, 'UTF-8' );
+			$upperCaseQuery = mb_strtoupper( $query, 'UTF-8' );
 
 			// SUS-846: Ensure we only have one exact match, to prevent overwriting it and losing the suggestion
-			if ( is_null( $exactMatchRow ) && strtolower( $row->page_title ) == $query ) {
+			if ( is_null( $exactMatchRow ) && $upperCaseQuery === $upperCaseTitle ) {
 				$exactMatchRow = $row;
 				continue;
 			}


### PR DESCRIPTION
Currently LinkSuggest has a bug if there's an exact match for a query—if it is all lower case, it puts items in the `redirects` map in the wrong order, and if it is not, the exact match is not detected correctly.

Example:
https://xkxd.fandom.com/index.php?action=ajax&rs=getLinkSuggest&query=can%20not%20see&format=json
returns
```
{"query":"can not see","ids":{"Can not see":136},"suggestions":["Can not see"],"redirects":{"No see":"Can not see"}}
```
which should be
```
{"query":"can not see","ids":{"Can not see":136},"suggestions":["Can not see"],"redirects":{"Can not see":"No see"}}
```

https://xkxd.fandom.com/index.php?action=ajax&rs=getLinkSuggest&query=Can%20not%20see&format=json
returns
```
{"query":"Can not see","ids":{"No see":0},"suggestions":["No see"],"redirects":{"Can not see":"No see"}}
```
which should be 
```
{"query":"Can not see","ids":{"Can not see":136},"suggestions":["No see"],"redirects":{"Can not see":"No see"}}
```

https://wikia-inc.atlassian.net/browse/IW-1877