### PR TITLE
CORE-399 | Use service proxy for communication within k8s

### DIFF
--- a/docker/prod/prod.template.yaml
+++ b/docker/prod/prod.template.yaml
@@ -77,6 +77,10 @@ spec:
             # SUS-5499 | this env variable is used to set up HTTP proxy for internal MediaWiki requests
             - name: KUBERNETES_DEPLOYMENT_NAME
               value: mediawiki-prod
+            - name: KUBERNETES_POD
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: KUBERNETES_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -247,6 +251,10 @@ spec:
             # SUS-5499 | this env variable is used to set up HTTP proxy for internal MediaWiki requests
             - name: KUBERNETES_DEPLOYMENT_NAME
               value: mediawiki-tasks
+            - name: KUBERNETES_POD
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: KUBERNETES_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/docker/sandbox/sandbox.template.yaml
+++ b/docker/sandbox/sandbox.template.yaml
@@ -95,11 +95,11 @@ spec:
               value: "tcp://localhost:9999"
           resources:
             limits:
-              cpu: "4"
-              memory: 3Gi  # 5 fpm workers x 512 MB PHP memory limit
+              cpu: 5
+              memory: 5Gi  # 5 fpm workers x 512 MB PHP memory limit
             requests:
-              cpu: "2"
-              memory: 1.5Gi
+              cpu: 2.5
+              memory: 3Gi
         # MW log output, see K8s_LOGGING.md
         - name: logger
           image: artifactory.wikia-inc.com/sus/mediawiki-logger:latest

--- a/docker/sandbox/sandbox.template.yaml
+++ b/docker/sandbox/sandbox.template.yaml
@@ -75,6 +75,10 @@ spec:
             # SUS-5499 | this env variable is used to set up HTTP proxy for internal MediaWiki requests
             - name: KUBERNETES_DEPLOYMENT_NAME
               value: mediawiki-${SANDBOX_NAME}
+            - name: KUBERNETES_POD
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: KUBERNETES_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/includes/wikia/VariablesExpansions.php
+++ b/includes/wikia/VariablesExpansions.php
@@ -93,13 +93,6 @@ $wgArticleCommentsNamespaces = [ NS_MAIN, 500 /* NS_BLOG_ARTICLE */ ];
 $wgArticlePath = "$wgScriptPath/wiki/$1";
 
 /**
- * Helios URL.
- * @see lib/Wikia/src/Factory/HeliosFactory.php
- * @var string $wgAuthServiceInternalUrl
- */
-$wgAuthServiceInternalUrl = "http://prod.$wgWikiaDatacenter.k8s.wikia.net/helios/";
-
-/**
  * Automatically add a usergroup to any user who matches certain conditions.
  * The format is
  *   [ '&' or '|' or '^' or '!', cond1, cond2, ... )


### PR DESCRIPTION
Mediawiki on k8s unnecessarily uses ingress addresses for communication with other k8s apps. Adding the `KUBERNETES_POD` env will properly configure the service url provider. Custom Helios prod config in unnecessary.