### PR TITLE
PLATFORM-4015: xdebug for new devboxes

### DIFF
--- a/docker/devbox/Dockerfile
+++ b/docker/devbox/Dockerfile
@@ -7,14 +7,17 @@ FROM artifactory.wikia-inc.com/sus/php-wikia-base:da4390f
 # yaml extension / @see https://pecl.php.net/package/yaml / needed by db2yml.php
 #
 # these require autoconf package to be present
-RUN pecl install yaml-2.0.2 \
-    && docker-php-ext-enable yaml
+RUN pecl install yaml-2.0.2 xdebug-2.6.0 \
+    && docker-php-ext-enable yaml xdebug
 
 # Configure dev opcache
 ADD ./opcache.ini /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
 
 # Overwrite production php.ini settings on dev environment
 ADD ./phpdev.ini /usr/local/etc/php/conf.d/
+
+# configure xdebug
+ADD ./xdebug.ini /usr/local/etc/php/conf.d/
 
 # Mount the source and messages cache
 

--- a/docker/devbox/README.md
+++ b/docker/devbox/README.md
@@ -83,8 +83,11 @@ In a nutshell:
     ```sh
     ssh -o ServerAliveInterval=20 -R 9000:localhost:9000 dev-<devboxname>-18
     ```
-2. Enable the `Listen for debug connections` button in PhpStorm
-3. Add `XDEBUG_SESSION_START=1` query parameter to the request
+2. When mapping the paths is PhpStorm, please keep in mind that use should use `/usr/wikia/slot1/current/` as the remote 
+path instead of the path on your devbox. That is the path that sources are mounted at in the docker
+container.
+3. Enable the `Listen for debug connections` button in PhpStorm
+4. Add `XDEBUG_SESSION_START=1` query parameter to the request
 
 ### Rebuilding docker images
 

--- a/docker/devbox/README.md
+++ b/docker/devbox/README.md
@@ -75,7 +75,7 @@ nobody@2d25d207a7a7:/usr/wikia/slot1/current/src/tests$ SERVER_DBNAME=firefly ph
 ```
 ### Xdebug
 
-Xdebug extensions is enabled and configured to connect to port 9000 of the docker host. In order to use xdebug follow
+The Xdebug extension is enabled and configured to connect to port 9000 of the docker host. In order to use xdebug follow
 this article: https://wikia-inc.atlassian.net/wiki/spaces/EN/pages/35723807/Debugging+with+Xdebug+and+Charles. 
 
 In a nutshell:

--- a/docker/devbox/README.md
+++ b/docker/devbox/README.md
@@ -73,6 +73,18 @@ nobody@2d25d207a7a7:/usr/wikia/slot1/current/src$ cd tests
 nobody@2d25d207a7a7:/usr/wikia/slot1/current/src/tests$ SERVER_DBNAME=firefly php run-test.php --stderr --configuration=phpunit.xml --exclude-group Infrastructure,Integration,ExternalIntegration,ContractualResponsibilitiesValidation
 nobody@2d25d207a7a7:/usr/wikia/slot1/current/src/tests$ SERVER_DBNAME=firefly php run-test.php --stderr --configuration=phpunit.xml --group Integration
 ```
+### Xdebug
+
+Xdebug extensions is enabled and configured to connect to port 9000 of the docker host. In order to use xdebug follow
+this article: https://wikia-inc.atlassian.net/wiki/spaces/EN/pages/35723807/Debugging+with+Xdebug+and+Charles. 
+
+In a nutshell:
+1. Forward port 9000 to your laptop by running this command in the terminal:
+    ```sh
+    ssh -o ServerAliveInterval=20 -R 9000:localhost:9000 dev-<devboxname>-18
+    ```
+2. Enable the `Listen for debug connections` button in PhpStorm
+3. Add `XDEBUG_SESSION_START=1` query parameter to the request
 
 ### Rebuilding docker images
 

--- a/docker/devbox/xdebug.ini
+++ b/docker/devbox/xdebug.ini
@@ -1,0 +1,8 @@
+xdebug.default_enable=1
+xdebug.remote_enable=1
+xdebug.remote_host=172.17.0.1
+xdebug.remote_handler=dbgp
+xdebug.remote_port=9000
+xdebug.remote_autostart=1
+xdebug.remote_connect_back=0
+xdebug.idekey=“PHPSTORM”


### PR DESCRIPTION
Enable and configure xdebug. Update the readme file. 
SSHD was configured here: https://github.com/Wikia/chef-repo/pull/20397