### PR TITLE
PLATFORM-4013| Send MW logs on dev-box to ES

### DIFF
--- a/docker/base/nginx.conf
+++ b/docker/base/nginx.conf
@@ -36,7 +36,7 @@ http {
       '"http_referrer": "$http_referer", '
       '"http_user_agent": "$http_user_agent" }';
 
-    access_log  /dev/stdout  json_combined;
+    access_log  /var/log/nginx/access.log  json_combined;
 
     sendfile        on;
 

--- a/docker/devbox/Dockerfile-fluentd
+++ b/docker/devbox/Dockerfile-fluentd
@@ -8,7 +8,7 @@ USER root
 RUN apk add --no-cache --update --virtual .build-deps \
         build-base ruby-dev \
  && gem install \
-        fluent-plugin-elasticsearch \
+        fluent-plugin-elasticsearch fluent-plugin-throttle \
  && gem sources --clear-all \
  && apk del .build-deps \
  && rm -rf /home/fluent/.gem/ruby/2.5.0/cache/*.gem

--- a/docker/devbox/Dockerfile-fluentd
+++ b/docker/devbox/Dockerfile-fluentd
@@ -6,10 +6,10 @@ USER root
 # below RUN includes plugin as examples elasticsearch is not required
 # you may customize including plugins as you wish
 RUN apk add --no-cache --update --virtual .build-deps \
-        sudo build-base ruby-dev \
- && sudo gem install \
+        build-base ruby-dev \
+ && gem install \
         fluent-plugin-elasticsearch \
- && sudo gem sources --clear-all \
+ && gem sources --clear-all \
  && apk del .build-deps \
  && rm -rf /home/fluent/.gem/ruby/2.5.0/cache/*.gem
 

--- a/docker/devbox/Dockerfile-fluentd
+++ b/docker/devbox/Dockerfile-fluentd
@@ -1,0 +1,16 @@
+FROM fluent/fluentd:v1.4-onbuild
+
+# Use root account to use apk
+USER root
+
+# below RUN includes plugin as examples elasticsearch is not required
+# you may customize including plugins as you wish
+RUN apk add --no-cache --update --virtual .build-deps \
+        sudo build-base ruby-dev \
+ && sudo gem install \
+        fluent-plugin-elasticsearch \
+ && sudo gem sources --clear-all \
+ && apk del .build-deps \
+ && rm -rf /home/fluent/.gem/ruby/2.5.0/cache/*.gem
+
+USER fluent

--- a/docker/devbox/README.md
+++ b/docker/devbox/README.md
@@ -56,7 +56,8 @@ Replace `SERVER_ID` with any other city identifier.
 
 ### Logging
 
-Right now the logs are sent to console in JSON format. We may add Kibana logger later on.
+Both mediawiki and nginx logs are sent to ELK using fluentd. The are available in Kibana in the
+logstash-dev-mediawiki-* index and could e filtered by `@hostname`.
 
 ### Opcache
 

--- a/docker/devbox/README.md
+++ b/docker/devbox/README.md
@@ -32,8 +32,12 @@ You can safely purge this folder to reclaim the disk space if needed.
 	```bash
 	echo HOST_HOSTNAME=$(hostname) > app/docker/devbox/.env
 	```
-
-4. Starting mediawiki
+4 Create NGINX logs dir
+	```bash
+	mkdir nginx_logs
+	chown o+x nginx_logs
+	```
+5. Starting mediawiki
 Use docker compose in order to start the nginx&php. Use something like the `screen` command if you want it to keep 
 running the the background.
 
@@ -42,7 +46,7 @@ running the the background.
 	docker-compose up
 	```
 
-5. Stopping mediawiki
+6. Stopping mediawiki
 	Usualy the best option is to stop it with Ctrl+C and then run `docker-compose down`.
 
 ### Running eval.php

--- a/docker/devbox/README.md
+++ b/docker/devbox/README.md
@@ -32,10 +32,9 @@ You can safely purge this folder to reclaim the disk space if needed.
 	```bash
 	echo HOST_HOSTNAME=$(hostname) > app/docker/devbox/.env
 	```
-4 Create NGINX logs dir
+4. Create NGINX logs dir
 	```bash
-	mkdir nginx_logs
-	chown o+x nginx_logs
+	mkdir ~/nginx_logs && chmod 0777 ~/nginx_logs
 	```
 5. Starting mediawiki
 Use docker compose in order to start the nginx&php. Use something like the `screen` command if you want it to keep 

--- a/docker/devbox/README.md
+++ b/docker/devbox/README.md
@@ -27,7 +27,13 @@ You can safely purge this folder to reclaim the disk space if needed.
     docker run -it --rm -e "SERVER_ID=177" -e "WIKIA_DEV_DOMAIN=$WIKIA_DEV_DOMAIN" -e "WIKIA_ENVIRONMENT=$WIKIA_ENVIRONMENT" -e "WIKIA_DATACENTER=$WIKIA_DATACENTER" -e "LOG_STDOUT_ONLY=yes" -v "$HOME/app":/usr/wikia/slot1/current/src:ro -v "$HOME/config":/usr/wikia/slot1/current/config:ro -v "$HOME/cache":/usr/wikia/slot1/current/cache/messages artifactory.wikia-inc.com/platform/php-wikia-devbox:latest php maintenance/rebuildLocalisationCache.php --primary
     chmod 775 ~/cache
     ``` 
-3. Starting mediawiki
+    
+3. Create .env file with the name of the devbox (this is needed to properly set @hostname field in the logs)
+	```bash
+	echo HOST_HOSTNAME=$(hostname) > app/docker/devbox/.env
+	```
+
+4. Starting mediawiki
 Use docker compose in order to start the nginx&php. Use something like the `screen` command if you want it to keep 
 running the the background.
 
@@ -36,7 +42,7 @@ running the the background.
 	docker-compose up
 	```
 
-4. Stopping mediawiki
+5. Stopping mediawiki
 	Usualy the best option is to stop it with Ctrl+C and then run `docker-compose down`.
 
 ### Running eval.php

--- a/docker/devbox/docker-compose.yml
+++ b/docker/devbox/docker-compose.yml
@@ -13,15 +13,17 @@ services:
       - ../../../app/resources:/usr/wikia/slot1/current/src/resources:ro
       - ../../../app/extensions:/usr/wikia/slot1/current/src/extensions:ro
       - ../../../app/apple-touch-icon.png:/usr/wikia/slot1/current/src/apple-touch-icon.png:ro
+      - /tmp/nginx/logs:/var/log/nginx
     depends_on:
       - php-wikia
   logger:
-    image: artifactory.wikia-dev.us/platform/fluentd_elastic:0.0.1
-    ports:
-      - "127.0.0.1:9999:9999"
+    image: artifactory.wikia-dev.us/platform/fluentd_elastic:latest
     volumes:
       - ./fluent.conf:/fluentd/etc/config:ro
+      - /tmp/nginx/logs:/var/nginx/logs:ro
     command: "fluentd -c /fluentd/etc/config -v"
+    environment:
+      - HOST_HOSTNAME=$HOST_HOSTNAME
   php-wikia:
     image: artifactory.wikia-inc.com/platform/php-wikia-devbox:latest
     volumes:

--- a/docker/devbox/docker-compose.yml
+++ b/docker/devbox/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     image: artifactory.wikia-inc.com/platform/fluentd_elastic:latest
     volumes:
       - ./fluent.conf:/fluentd/etc/config:ro
-      - ../../../nginx_logs:/var/nginx/logs:ro
+      - ../../../nginx_logs:/var/nginx/logs
     command: "fluentd -c /fluentd/etc/config -v"
     environment:
       - HOST_HOSTNAME=$HOST_HOSTNAME

--- a/docker/devbox/docker-compose.yml
+++ b/docker/devbox/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   web:
     image: artifactory.wikia-inc.com/platform/nginx-wikia-devbox:latest
     ports:
-      - "8080:8080"
+      - "80:8080"
     volumes:
       - ../base/base.inc:/etc/nginx/conf.d/base.inc:ro
       - ./site.conf:/etc/nginx/conf.d/default.conf:ro

--- a/docker/devbox/docker-compose.yml
+++ b/docker/devbox/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   web:
     image: artifactory.wikia-inc.com/platform/nginx-wikia-devbox:latest
     ports:
-      - "80:8080"
+      - "8080:8080"
     volumes:
       - ../base/base.inc:/etc/nginx/conf.d/base.inc:ro
       - ./site.conf:/etc/nginx/conf.d/default.conf:ro
@@ -15,6 +15,13 @@ services:
       - ../../../app/apple-touch-icon.png:/usr/wikia/slot1/current/src/apple-touch-icon.png:ro
     depends_on:
       - php-wikia
+  logger:
+    image: artifactory.wikia-dev.us/platform/fluentd_elastic:0.0.1
+    ports:
+      - "127.0.0.1:9999:9999"
+    volumes:
+      - ./fluent.conf:/fluentd/etc/config:ro
+    command: "fluentd -c /fluentd/etc/config -v"
   php-wikia:
     image: artifactory.wikia-inc.com/platform/php-wikia-devbox:latest
     volumes:
@@ -28,5 +35,5 @@ services:
       - LOG_SOCKET_ONLY=yes
       - LOG_SOCKET_ADDRESS=tcp://logger:9999
       - WIKIA_FORCE_DEV_ONLY=yes
-  logger:
-    image: artifactory.wikia-inc.com/sus/mediawiki-logger:latest
+    depends_on:
+      - logger

--- a/docker/devbox/docker-compose.yml
+++ b/docker/devbox/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     depends_on:
       - php-wikia
   logger:
-    image: artifactory.wikia-dev.us/platform/fluentd_elastic:latest
+    image: artifactory.wikia-inc.com/platform/fluentd_elastic:latest
     volumes:
       - ./fluent.conf:/fluentd/etc/config:ro
       - /tmp/nginx/logs:/var/nginx/logs:ro

--- a/docker/devbox/docker-compose.yml
+++ b/docker/devbox/docker-compose.yml
@@ -13,14 +13,14 @@ services:
       - ../../../app/resources:/usr/wikia/slot1/current/src/resources:ro
       - ../../../app/extensions:/usr/wikia/slot1/current/src/extensions:ro
       - ../../../app/apple-touch-icon.png:/usr/wikia/slot1/current/src/apple-touch-icon.png:ro
-      - nginx_logs:/var/log/nginx
+      - ../../../nginx_logs:/var/log/nginx
     depends_on:
       - php-wikia
   logger:
     image: artifactory.wikia-inc.com/platform/fluentd_elastic:latest
     volumes:
       - ./fluent.conf:/fluentd/etc/config:ro
-      - nginx_logs:/var/nginx/logs:ro
+      - ../../../nginx_logs:/var/nginx/logs:ro
     command: "fluentd -c /fluentd/etc/config -v"
     environment:
       - HOST_HOSTNAME=$HOST_HOSTNAME
@@ -39,5 +39,3 @@ services:
       - WIKIA_FORCE_DEV_ONLY=yes
     depends_on:
       - logger
-volumes:
-  nginx_logs:

--- a/docker/devbox/docker-compose.yml
+++ b/docker/devbox/docker-compose.yml
@@ -13,14 +13,14 @@ services:
       - ../../../app/resources:/usr/wikia/slot1/current/src/resources:ro
       - ../../../app/extensions:/usr/wikia/slot1/current/src/extensions:ro
       - ../../../app/apple-touch-icon.png:/usr/wikia/slot1/current/src/apple-touch-icon.png:ro
-      - /tmp/nginx/logs:/var/log/nginx
+      - nginx_logs:/var/log/nginx
     depends_on:
       - php-wikia
   logger:
     image: artifactory.wikia-inc.com/platform/fluentd_elastic:latest
     volumes:
       - ./fluent.conf:/fluentd/etc/config:ro
-      - /tmp/nginx/logs:/var/nginx/logs:ro
+      - nginx_logs:/var/nginx/logs:ro
     command: "fluentd -c /fluentd/etc/config -v"
     environment:
       - HOST_HOSTNAME=$HOST_HOSTNAME
@@ -39,3 +39,5 @@ services:
       - WIKIA_FORCE_DEV_ONLY=yes
     depends_on:
       - logger
+volumes:
+  nginx_logs:

--- a/docker/devbox/fluent.conf
+++ b/docker/devbox/fluent.conf
@@ -54,7 +54,7 @@
   group_key appname
   group_bucket_period_s   60
   group_bucket_limit    3000
-  group_reset_rate_s     100
+  group_reset_rate_s      50
 </filter>
 
 <match fluent.**>

--- a/docker/devbox/fluent.conf
+++ b/docker/devbox/fluent.conf
@@ -47,6 +47,21 @@
   </record>
 </filter>
 
+<match fluent.**>
+	@type elasticsearch
+	host logs-prod.es.service.sjc.consul
+	logstash_format true
+	logstash_prefix logstash-dev-mediawiki
+	<buffer>
+		flush_thread_count 2
+		flush_interval 1s
+		chunk_limit_size 2M
+		queue_limit_length 32
+		retry_max_interval 30
+		retry_forever true
+	</buffer>
+</match>
+
 <match **>
 	@type copy
 	<store>

--- a/docker/devbox/fluent.conf
+++ b/docker/devbox/fluent.conf
@@ -14,7 +14,36 @@
 	</parse>
 </source>
 
-<match *>
+<source>
+	@type tail
+	path /var/nginx/logs/access.log
+	tag nginx.access
+	format json
+</source>
+
+<source>
+	@type tail
+	path /var/nginx/logs/error.log
+	tag nginx.error
+	format /^(?<time>[^ ]+\s[^ ]+)\s\[(?<level>[^\]]+)\]\s(?<pid>[^#]+#[^:]):\s(?<thread_id>\*\d+)(?<@message>.*)$/
+</source>
+
+<filter **>
+  @type record_transformer
+  <record>
+    @hostname "#{ENV["HOST_HOSTNAME"]}"
+    source ${tag}
+  </record>
+</filter>
+
+<filter nginx.error>
+  @type record_transformer
+  <record>
+    appname "mediawiki-nginx-error-logs"
+  </record>
+</filter>
+
+<match **>
 	@type copy
 	<store>
 		@type stdout

--- a/docker/devbox/fluent.conf
+++ b/docker/devbox/fluent.conf
@@ -12,6 +12,7 @@
 <source>
 	@type tail
 	path /var/nginx/logs/access.log
+	pos_file /var/nginx/logs/access.log.pos
 	tag nginx.access
 	format json
 </source>
@@ -19,6 +20,7 @@
 <source>
 	@type tail
 	path /var/nginx/logs/error.log
+	pos_file /var/nginx/logs/error.log.pos
 	tag nginx.error
 	format /^(?<time>[^ ]+\s[^ ]+)\s\[(?<level>[^\]]+)\]\s(?<pid>[^#]+#[^:]):\s(?<thread_id>\*\d+)\s(?<@message>.*)$/
 </source>

--- a/docker/devbox/fluent.conf
+++ b/docker/devbox/fluent.conf
@@ -1,8 +1,3 @@
-<match fluent.**>
-	# this tells fluentd to not output its log on stdout
-	@type null
-</match>
-
 <source>
   	@type tcp
   	tag mediawiki
@@ -29,11 +24,20 @@
 </source>
 
 <filter **>
-  @type record_transformer
-  <record>
-    @hostname "#{ENV["HOST_HOSTNAME"]}"
-    source ${tag}
-  </record>
+  	@type record_transformer
+  	<record>
+   		@hostname "#{ENV["HOST_HOSTNAME"]}"
+    	source ${tag}
+  	</record>
+</filter>
+
+<filter fluent.**>
+	@type record_transformer
+	<record>
+		@message ${record["message"]}
+		appname fluentd
+	</record>
+	remove_keys $['message']
 </filter>
 
 <filter nginx.error>

--- a/docker/devbox/fluent.conf
+++ b/docker/devbox/fluent.conf
@@ -25,7 +25,7 @@
 	@type tail
 	path /var/nginx/logs/error.log
 	tag nginx.error
-	format /^(?<time>[^ ]+\s[^ ]+)\s\[(?<level>[^\]]+)\]\s(?<pid>[^#]+#[^:]):\s(?<thread_id>\*\d+)(?<@message>.*)$/
+	format /^(?<time>[^ ]+\s[^ ]+)\s\[(?<level>[^\]]+)\]\s(?<pid>[^#]+#[^:]):\s(?<thread_id>\*\d+)\s(?<@message>.*)$/
 </source>
 
 <filter **>

--- a/docker/devbox/fluent.conf
+++ b/docker/devbox/fluent.conf
@@ -49,6 +49,14 @@
   </record>
 </filter>
 
+<filter **>
+  @type throttle
+  group_key appname
+  group_bucket_period_s   60
+  group_bucket_limit    3000
+  group_reset_rate_s     100
+</filter>
+
 <match fluent.**>
 	@type elasticsearch
 	host logs-prod.es.service.sjc.consul

--- a/docker/devbox/fluent.conf
+++ b/docker/devbox/fluent.conf
@@ -1,0 +1,36 @@
+<match fluent.**>
+	# this tells fluentd to not output its log on stdout
+	@type null
+</match>
+
+<source>
+  	@type tcp
+  	tag mediawiki
+  	port 9999
+  	<parse>
+		@type json
+		time_format %Y-%m-%dT%H:%M:%S.%N%z
+		time_key @timestamp
+	</parse>
+</source>
+
+<match *>
+	@type copy
+	<store>
+		@type stdout
+	</store>
+	<store>
+		@type elasticsearch
+		host logs-prod.es.service.sjc.consul
+		logstash_format true
+		logstash_prefix logstash-dev-mediawiki
+		<buffer>
+			flush_thread_count 2
+			flush_interval 5s
+			chunk_limit_size 2M
+			queue_limit_length 32
+			retry_max_interval 30
+			retry_forever true
+		</buffer>
+	</store>
+</match>


### PR DESCRIPTION
On new dev-boxes we need to send logs from docker instance
to ES. Easiest and most reliable solution was to use Fluentd
as we do for our k8s cluster.