### PR TITLE
CORE-400 | make traefik buffer PHP response served by nginx

### DIFF
--- a/docker/sandbox/sandbox.template.yaml
+++ b/docker/sandbox/sandbox.template.yaml
@@ -167,6 +167,13 @@ metadata:
     app: mediawiki-${SANDBOX_NAME}
   annotations:
     kubernetes.io/ingress.class: traefik
+    # CORE-400 | the biggest response in nginx logs weights ~16 MB, most are under 2 MB
+    traefik.ingress.kubernetes.io/buffering: |
+      maxrequestbodybytes: 16000000
+      memrequestbodybytes: 2000000
+      maxresponsebodybytes: 16000000
+      memresponsebodybytes: 2000000
+      retryexpression: false
 spec:
   rules:
     - host: "${SANDBOX_NAME}.wikia.com"


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CORE-400

Otherwise we end up with the following response that prevent our
internal cache from caching the response:

```
< Server: nginx/1.15.6
< Vary: Accept-Encoding, Cookie
< X-Served-By: mediawiki-sandbox-s6-6d64bf77cc-k4qgg
< Transfer-Encoding: chunked
```

Apache response:

```
< Server: Apache
< Vary: Accept-Encoding,Cookie
< Content-Length: 2434
```