### PR TITLE
IW-1951 | Switch confirm email URLs to fandom.com

### DIFF
--- a/includes/User.php
+++ b/includes/User.php
@@ -3887,7 +3887,7 @@ class User implements JsonSerializable {
 		global $wgEnableNewAuthModal;
 
 		if ( $wgEnableNewAuthModal ) {
-			return WikiFactory::getLocalEnvURL( "https://www.wikia.com/confirm-email?token=$token" );
+			return WikiFactory::getLocalEnvURL( "https://www.fandom.com/confirm-email?token=$token" );
 		}
 
 		// Hack to bypass localization of 'Special:'


### PR DESCRIPTION
With most wikis migrated to fandom.com, we should switch confirm email URLs to fandom.com to spare users the step of having to log in again before they can confirm their email.
https://wikia-inc.atlassian.net/browse/IW-1951