### PR TITLE
CAKE-4585 | Get back to using wgTitle

### DIFF
--- a/extensions/wikia/TriviaQuizzes/js/ext.TriviaQuizzes.js
+++ b/extensions/wikia/TriviaQuizzes/js/ext.TriviaQuizzes.js
@@ -2,23 +2,26 @@ require(['jquery', 'content_types_consumption', 'wikia.trackingOptIn', 'mw'], fu
 	'use strict';
 	$(function () {
 		$('.WikiaRail').on('afterLoad.rail', function () {
-			// FIXME: For now: if they are IE11, remove the entire module until we have better support
-			if ($.browser.msie) {
-				$('#wikia-recent-activity').remove();
-			} else {
-				// https://github.com/Wikia/content-types/tree/master/consumption#usage
-				consumption.default('wikia-trivia-quizzes', {
-					environment: 'media-wiki',
-					pageType: 'Article',
-					user: {
-						id: mw.config.get('wgUserId') || 0,
-						isGDPRApproved: trackingOptIn.isOptedIn(),
-					},
-					community: {
-						dbName: mw.config.get('wgDBname') || null,
-						id: mw.config.get('wgCityId') || '0',
-					},
-				});
+			// do nothing if there's no module
+			if ($('#wikia-trivia-quizzes').length) {
+				// FIXME: For now: if they are IE11, remove the entire module until we have better support
+				if ($.browser.msie) {
+					$('#wikia-recent-activity').remove();
+				} else {
+					// https://github.com/Wikia/content-types/tree/master/consumption#usage
+					consumption.default('wikia-trivia-quizzes', {
+						environment: 'media-wiki',
+						pageType: 'Article',
+						user: {
+							id: mw.config.get('wgUserId') || 0,
+							isGDPRApproved: trackingOptIn.isOptedIn(),
+						},
+						community: {
+							dbName: mw.config.get('wgDBname') || null,
+							id: mw.config.get('wgCityId') || '0',
+						},
+					});
+				}
 			}
 		});
 	});

--- a/skins/oasis/modules/LatestActivityController.class.php
+++ b/skins/oasis/modules/LatestActivityController.class.php
@@ -6,7 +6,7 @@ class LatestActivityController extends WikiaController {
 	public function executeIndex() {
 		global $wgLang, $wgContentNamespaces, $wgMemc, $wgEnableCommunityPageExt;
 		// TODO: https://wikia-inc.atlassian.net/browse/CAKE-4746
-		global $wgEnableTriviaQuizzesExt, $wgTriviaQuizzesEnabledPages;
+		global $wgTitle, $wgEnableTriviaQuizzesExt, $wgTriviaQuizzesEnabledPages;
 
 		$mKey = wfMemcKey( 'mOasisLatestActivity' );
 		$feedData = $wgMemc->get( $mKey );
@@ -61,7 +61,7 @@ class LatestActivityController extends WikiaController {
 		$this->setVal( 'renderCommunityEntryPoint', !empty( $wgEnableCommunityPageExt ) );
 
 		// TODO: https://wikia-inc.atlassian.net/browse/CAKE-4746
-		$currentPageTitle = $this->getContext()->getTitle()->getPrefixedText();
+		$currentPageTitle = $wgTitle->getTitle()->getPrefixedText();
 		if ( $wgEnableTriviaQuizzesExt && in_array( $currentPageTitle, $wgTriviaQuizzesEnabledPages ) ) {
 			$this->setVal( 'renderTriviaQuizzes', $wgEnableTriviaQuizzesExt );
 			$this->setVal( 'moduleHeader', wfMessage('trivia-quizzes-featured-quizzes-header')->escaped() );


### PR DESCRIPTION
As discussed with @Grunny, I'm going to switch back to `wgTitle` because the context outputs community title and not page's title.