### PR TITLE
IW-1736 | Add wikiId to Feeds controller response

### DIFF
--- a/extensions/wikia/FeedsAndPosts/WikiVariables.class.php
+++ b/extensions/wikia/FeedsAndPosts/WikiVariables.class.php
@@ -11,6 +11,7 @@ class WikiVariables {
 		global $wgServer, $wgDBname, $wgCityId, $wgLanguageCode, $wgEnableDiscussions;
 
 		$wikiVariables = [
+			'wikiId' => $wgCityId,
 			'basePath' => $wgServer,
 			'dbName' => $wgDBname,
 			'getStartedUrl' =>  $this->getStartedUrl(),


### PR DESCRIPTION
This PR adds the current wiki ID to the Feeds MW controller response. This spares us from having to do a separate API call just to get the wiki ID.

https://wikia-inc.atlassian.net/browse/IW-1736