### PR TITLE
SER-3162 | Set content type when uploading to gcs

### DIFF
--- a/includes/filerepo/backend/GcsFileBackend.php
+++ b/includes/filerepo/backend/GcsFileBackend.php
@@ -160,8 +160,14 @@ class GcsFileBackend extends FileBackendStore {
 			'sha1' => $sha1,
 		] );
 
+		// it seems that the GCS client doesn't correctly detect all mimetypes that MW support,
+		// so we have to set content-type explicitly
+		$magic = MimeMagic::singleton();
+		$contentType = $magic->guessMimeType( $params['src'], false );
+		$contentType = $magic->improveTypeFromExtension( $contentType, FsFile::extensionFromPath( $params['dst'] ) );
+
 		try {
-			$this->upload( $dst, $data, $sha1 );
+			$this->upload( $dst, $data, $sha1, $contentType );
 		}
 		catch ( Exception $e ) {
 			WikiaLogger::instance()->error( __METHOD__, [ 'exception' => $e, ] );
@@ -175,20 +181,21 @@ class GcsFileBackend extends FileBackendStore {
 		return wfBaseConvert( $sha1, 16, 36, 31 );
 	}
 
-	public function upload( string $targetName, $data, string $sha1 ) {
+	public function upload( string $targetName, $data, string $sha1, $contentType = null ) {
+		$metadata = [
+			'metadata' => [
+				'sha1' => $sha1
+			]
+		];
+
+		if ( !empty( $contentType ) ) {
+			$metadata['contentType'] = $contentType;
+		}
+
 		$this->bucket()->upload( $data, [
 			'name' => $targetName,
-			'metadata' => $this->getMetadata( $sha1 ),
+			'metadata' => $metadata
 		] );
-	}
-
-	private function getMetadata( $sha1 ) {
-		return [
-			// user metadata are nested like so: metadata.metadata
-			'metadata' => [
-				'sha1' => $sha1,
-			],
-		];
 	}
 
 	/**


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SER-3162

Since the CGS client doesn't detect all supported file types, we need to set `contentType` explicitly.