### PR TITLE
IW-1876 | [feeds] Load wiki details from a local endpoint

### DIFF
--- a/extensions/wikia/FeedsAndPosts/FeedsAndPosts.setup.php
+++ b/extensions/wikia/FeedsAndPosts/FeedsAndPosts.setup.php
@@ -14,6 +14,8 @@ $wgAutoloadClasses['Wikia\FeedsAndPosts\Thumbnails'] = $dir . 'Thumbnails.class.
 $wgAutoloadClasses['Wikia\FeedsAndPosts\ThemeSettings'] = $dir . 'ThemeSettings.class.php';
 $wgAutoloadClasses['Wikia\FeedsAndPosts\WikiVariables'] = $dir . 'WikiVariables.class.php';
 $wgAutoloadClasses['Wikia\FeedsAndPosts\ArticleData'] = $dir . 'ArticleData.class.php';
+$wgAutoloadClasses['Wikia\FeedsAndPosts\WikiDetails'] = $dir . 'WikiDetails.class.php';
+
 
 // Controllers
 $wgAutoloadClasses['FeedsAndPostsController'] = $dir . 'FeedsAndPostsController.class.php';

--- a/extensions/wikia/FeedsAndPosts/FeedsAndPostsController.class.php
+++ b/extensions/wikia/FeedsAndPosts/FeedsAndPostsController.class.php
@@ -4,6 +4,7 @@ use Wikia\FeedsAndPosts\ArticleData;
 use Wikia\FeedsAndPosts\RecentChanges;
 use Wikia\FeedsAndPosts\ThemeSettings;
 use Wikia\FeedsAndPosts\TopArticles;
+use Wikia\FeedsAndPosts\WikiDetails;
 use Wikia\FeedsAndPosts\WikiVariables;
 
 class FeedsAndPostsController extends WikiaApiController {
@@ -23,6 +24,7 @@ class FeedsAndPostsController extends WikiaApiController {
 			'topArticles' => ( new TopArticles() )->get(),
 			'theme' => ( new ThemeSettings() )->get(),
 			'wikiVariables' => ( new WikiVariables() )->get(),
+			'wikiDetails' => ( new WikiDetails() )->get(),
 		] );
 		$this->response->setFormat( WikiaResponse::FORMAT_JSON );
 	}

--- a/extensions/wikia/FeedsAndPosts/WikiDetails.class.php
+++ b/extensions/wikia/FeedsAndPosts/WikiDetails.class.php
@@ -1,0 +1,42 @@
+<?php
+namespace Wikia\FeedsAndPosts;
+
+class WikiDetails {
+	const TOP_EDITORS_COUNT = 6;
+	const AVATAR_SIZE = 52;
+
+	public function get(): array {
+		global $wgCityId;
+
+		$wikiDetailsService = new \WikiDetailsService();
+		$topUserInfo = $wikiDetailsService->getTopEditors( $wgCityId, self::TOP_EDITORS_COUNT);
+
+		$topUsers = [];
+
+		foreach ( $topUsers as $userId => $edits ) {
+			$user = \User::newFromId( $userId );
+
+			$topUsers[] = [
+				'id' => $userId,
+				'name' => $user->getName(),
+				'avatarUrl' => \AvatarService::getAvatarUrl( $user, static::AVATAR_SIZE ),
+			];
+		}
+
+		$themeSettings = new \ThemeSettings();
+
+		$topUsers = array_keys( $topUserInfo );
+		$pageCount = \SiteStats::articles();
+		$editCount = \SiteStats::edits();
+		$wordmark = $themeSettings->getWordmarkUrl();
+		$favicon = \Wikia::getFaviconFullUrl();
+
+		return [
+			'topUsers' => $topUsers,
+			'pageCount' => $pageCount,
+			'editCount' => $editCount,
+			'wordmark' => $wordmark,
+			'favicon' => $favicon,
+		];
+	}
+}

--- a/extensions/wikia/FeedsAndPosts/WikiDetails.class.php
+++ b/extensions/wikia/FeedsAndPosts/WikiDetails.class.php
@@ -13,7 +13,7 @@ class WikiDetails {
 
 		$topUsers = [];
 
-		foreach ( $topUsers as $userId => $edits ) {
+		foreach ( $topUserInfo as $userId => $edits ) {
 			$user = \User::newFromId( $userId );
 
 			$topUsers[] = [
@@ -25,7 +25,6 @@ class WikiDetails {
 
 		$themeSettings = new \ThemeSettings();
 
-		$topUsers = array_keys( $topUserInfo );
 		$pageCount = \SiteStats::articles();
 		$editCount = \SiteStats::edits();
 		$wordmark = $themeSettings->getWordmarkUrl();

--- a/extensions/wikia/FeedsAndPosts/WikiVariables.class.php
+++ b/extensions/wikia/FeedsAndPosts/WikiVariables.class.php
@@ -8,12 +8,13 @@ use WikiaDataAccess;
 
 class WikiVariables {
 	public function get() {
-		global $wgServer, $wgDBname, $wgCityId, $wgLanguageCode, $wgEnableDiscussions;
+		global $wgServer, $wgDBname, $wgCityId, $wgLanguageCode, $wgEnableDiscussions, $wgSitename;
 
 		$wikiVariables = [
 			'wikiId' => $wgCityId,
 			'basePath' => $wgServer,
 			'dbName' => $wgDBname,
+			'name' => $wgSitename,
 			'getStartedUrl' =>  $this->getStartedUrl(),
 			'wikiDescription' => ( new CommunityDataService( $wgCityId ) )->getCommunityDescription(),
 			'openGraphImageUrl' => \OpenGraphImageHelper::getUrl(),


### PR DESCRIPTION
Extend the Feeds MW controller response to include local wiki details. This allows us to include information such as the favicon in this response, which is not provided by the global API that is currently used by Feeds. This also allows us to fix the issue with robots not being excluded from top contributors.

https://wikia-inc.atlassian.net/browse/IW-1876