### PR TITLE
SER-3189 don't use FSFile in GcsBackend

### DIFF
--- a/includes/filerepo/backend/GcsFileBackend.php
+++ b/includes/filerepo/backend/GcsFileBackend.php
@@ -164,7 +164,7 @@ class GcsFileBackend extends FileBackendStore {
 		// so we have to set content-type explicitly
 		$magic = MimeMagic::singleton();
 		$contentType = $magic->guessMimeType( $params['src'], false );
-		$contentType = $magic->improveTypeFromExtension( $contentType, FsFile::extensionFromPath( $params['dst'] ) );
+		$contentType = $magic->improveTypeFromExtension( $contentType, $this->extensionFromPath( $params['dst'] ) );
 
 		try {
 			$this->upload( $dst, $data, $sha1, $contentType );


### PR DESCRIPTION
`GcsFileBackend` has its own `extensionFromPath`. We don't have to load `FSFile`.