### PR TITLE
ADEN-8664 Update package-lock.json.

### DIFF
--- a/extensions/wikia/AdEngine3/package-lock.json
+++ b/extensions/wikia/AdEngine3/package-lock.json
@@ -49,8 +49,8 @@
       }
     },
     "@wikia/ad-engine": {
-      "version": "git+https://github.com/Wikia/ad-engine.git#c271d09c30697e8dc28e0aafd722298abf08de60",
-      "from": "git+https://github.com/Wikia/ad-engine.git#c271d09c30697e8dc28e0aafd722298abf08de60",
+      "version": "git+https://github.com/Wikia/ad-engine.git#3c2f2d766871dba03ec153f090730984cf592d36",
+      "from": "git+https://github.com/Wikia/ad-engine.git#v29.2.4",
       "requires": {
         "@babel/runtime-corejs2": "7.3.1",
         "blockadblock": "3.2.1",


### PR DESCRIPTION
It's a missing step from updating package.json in ADEN-8664.